### PR TITLE
feat(cli): add --path flag for subtree walk and export

### DIFF
--- a/cmd/acp/cmd_export.go
+++ b/cmd/acp/cmd_export.go
@@ -24,6 +24,7 @@ func runExport(ctx context.Context, args []string) error {
 	format := fs.String("format", "", "output format: json | yaml | csv (default: json or from --out extension)")
 	out := fs.String("out", "", "output file path (default: stdout)")
 	slot := fs.Int("slot", -1, "export only this slot (-1 = all present slots)")
+	pathFlag := fs.String("path", "", "filter objects by path prefix (e.g. BOARD, PSU/1)")
 	host, rest, err := popHost(args)
 	if err != nil {
 		return fmt.Errorf("usage: acp export <host> [--format F] [--out FILE]")
@@ -88,6 +89,11 @@ func runExport(ctx context.Context, args []string) error {
 		if werr != nil {
 			fmt.Fprintf(os.Stderr, "warning: slot %d walk failed: %v\n", s, werr)
 			continue
+		}
+		// Apply --path filter if set.
+		if *pathFlag != "" {
+			pathSegs := strings.Split(*pathFlag, "/")
+			objs = filterByPath(objs, pathSegs)
 		}
 		snap.Slots = append(snap.Slots, export.SlotDump{
 			Slot:     s,

--- a/cmd/acp/cmd_walk.go
+++ b/cmd/acp/cmd_walk.go
@@ -16,6 +16,7 @@ func runWalk(ctx context.Context, args []string) error {
 	slot := fs.Int("slot", -1, "slot number (omit or pass -1 with --all to walk every present slot)")
 	all := fs.Bool("all", false, "walk every present slot on the device")
 	filter := fs.String("filter", "", "case-insensitive filter on output lines (like findstr /i or grep -i)")
+	pathFlag := fs.String("path", "", "filter objects by path prefix (e.g. BOARD, PSU/1)")
 	host, rest, err := popHost(args)
 	if err != nil {
 		return fmt.Errorf("usage: acp walk <host> (--slot N | --all)")
@@ -23,6 +24,12 @@ func runWalk(ctx context.Context, args []string) error {
 	_ = fs.Parse(rest)
 	if !*all && *slot < 0 {
 		return fmt.Errorf("--slot N or --all is required")
+	}
+
+	// Parse --path into segments for prefix matching.
+	var pathSegs []string
+	if *pathFlag != "" {
+		pathSegs = strings.Split(*pathFlag, "/")
 	}
 
 	plug, cleanup, err := connect(ctx, host, cf)
@@ -41,6 +48,9 @@ func runWalk(ctx context.Context, args []string) error {
 		p.SetWalkProgress(func(count int, obj *protocol.Object) {
 			if obj.Kind == protocol.KindRaw && obj.Label == "" {
 				return // skip node containers
+			}
+			if !matchPathPrefix(obj.Path, pathSegs) {
+				return
 			}
 			valStr := walkValueColumn(*obj)
 			rngStr := walkRangeColumn(*obj)
@@ -92,6 +102,7 @@ func runWalk(ctx context.Context, args []string) error {
 				fmt.Printf("\nslot %d — walk error: %v\n", s, werr)
 				continue
 			}
+			objs = filterByPath(objs, pathSegs)
 			if !streaming {
 				printSlotTree(s, objs, *filter)
 			} else {
@@ -107,6 +118,7 @@ func runWalk(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	objs = filterByPath(objs, pathSegs)
 	if !streaming {
 		printSlotTree(*slot, objs, *filter)
 	} else {

--- a/cmd/acp/format.go
+++ b/cmd/acp/format.go
@@ -493,3 +493,48 @@ func findObjectByLabel(plug protocol.Protocol, slot int, group, label string) *p
 	}
 	return nil
 }
+
+// matchPathPrefix returns true if the object's Path contains the given
+// prefix segments. The match skips ROOT_NODE_V2 (path[0] for ACP2).
+// An empty prefix matches everything.
+//
+// Examples:
+//
+//	matchPathPrefix(["ROOT_NODE_V2","BOARD","Card Name"], ["BOARD"])       → true
+//	matchPathPrefix(["ROOT_NODE_V2","PSU","1","Present"], ["PSU","1"])     → true
+//	matchPathPrefix(["ROOT_NODE_V2","PSU","1","Present"], ["BOARD"])       → false
+//	matchPathPrefix(["identity"], ["identity"])                            → true (ACP1)
+func matchPathPrefix(objPath, prefix []string) bool {
+	if len(prefix) == 0 {
+		return true
+	}
+	// For ACP2: skip ROOT_NODE_V2 (path[0]) when matching.
+	// For ACP1: path has 1 element (group name), match directly.
+	p := objPath
+	if len(p) > 1 && strings.EqualFold(p[0], "ROOT_NODE_V2") {
+		p = p[1:]
+	}
+	if len(p) < len(prefix) {
+		return false
+	}
+	for i, seg := range prefix {
+		if !strings.EqualFold(p[i], seg) {
+			return false
+		}
+	}
+	return true
+}
+
+// filterByPath returns only objects whose path matches the given prefix.
+func filterByPath(objs []protocol.Object, prefix []string) []protocol.Object {
+	if len(prefix) == 0 {
+		return objs
+	}
+	var out []protocol.Object
+	for _, o := range objs {
+		if matchPathPrefix(o.Path, prefix) {
+			out = append(out, o)
+		}
+	}
+	return out
+}

--- a/cmd/acp/help.go
+++ b/cmd/acp/help.go
@@ -44,14 +44,17 @@ DESCRIPTION
 
 FLAGS
   --slot N           slot number (required)
+  --all              walk every present slot
+  --path PATH        filter by tree path prefix (e.g. BOARD, PSU/1)
   --filter TEXT      case-insensitive filter on output lines (like findstr /i or grep -i)
 
 EXAMPLES
-  acp walk 10.6.239.113 --slot 0        # rack controller
-  acp walk 10.6.239.113 --slot 1        # first card
-  acp walk 10.6.239.113 --slot 1 --verbose
-  acp walk 10.41.40.195 --protocol acp2 --slot 0 --filter enum
-  acp walk 10.41.40.195 --protocol acp2 --slot 0 --filter "Fan Health"`)
+  acp walk 10.6.239.113 --slot 0                                       # rack controller
+  acp walk 10.6.239.113 --slot 1                                       # first card
+  acp walk 10.41.40.195 --protocol acp2 --slot 0 --path BOARD          # only BOARD subtree
+  acp walk 10.41.40.195 --protocol acp2 --slot 0 --path PSU/1          # only PSU unit 1
+  acp walk 10.41.40.195 --protocol acp2 --slot 0 --path PSU --filter Temperature  # combine
+  acp walk 10.41.40.195 --protocol acp2 --slot 0 --filter QSFP         # text search all`)
 }
 
 func helpGet() {
@@ -202,11 +205,15 @@ DESCRIPTION
 FLAGS
   --format F         json | yaml | csv   (default: json or from extension)
   --out FILE         output file path    (default: stdout)
+  --slot N           export only this slot (-1 = all present)
+  --path PATH        filter by tree path prefix (e.g. BOARD, PSU/1)
 
 EXAMPLES
   acp export 10.6.239.113 --format json --out device.json
   acp export 10.6.239.113 --format yaml --out device.yaml
   acp export 10.6.239.113 --format csv  --out device.csv
+  acp export 10.41.40.195 --protocol acp2 --slot 0 --path BOARD --format yaml   # subtree only
+  acp export 10.41.40.195 --protocol acp2 --slot 0 --path PSU/1 --format csv    # single PSU unit
   acp export 10.6.239.113 > device.json`)
 }
 


### PR DESCRIPTION
## What

Add `--path` flag to walk and export commands for tree path prefix filtering.

## Why

Slot 1 has 44k+ objects. Users need to focus on specific subtrees (BOARD, PSU/1) without scrolling through thousands of lines.

Closes #9

## Scope

- [x] cli

## Type

- [x] feat — new feature

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `cmd/acp/cmd_walk.go` | modified | Add --path flag, filter streaming + non-streaming |
| `cmd/acp/cmd_export.go` | modified | Add --path flag, filter snapshot before writing |
| `cmd/acp/format.go` | modified | Add matchPathPrefix + filterByPath helpers |
| `cmd/acp/help.go` | modified | Update walk + export help with --path examples |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go vet ./...` | clean | — |
| `golangci-lint run` | clean | — |

## Device tested

- [x] ACP2 real device 10.41.40.195
  - `--path BOARD` → 27 objects
  - `--path PSU/1` → 14 objects
  - `--path PSU --filter Temperature` → 5 objects
  - `help walk` → examples shown

## Checklist

- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean (pre-commit hook)
- [x] No new external dependencies
- [x] Integration tested on VM before PR

## Approval

@yboujraf — requesting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)