### PR TITLE
feat: connector architecture + logging foundation + unified export

### DIFF
--- a/cmd/acp/common.go
+++ b/cmd/acp/common.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"log/slog"
-	"os"
 	"strings"
 	"time"
 
+	"acp/internal/logging"
 	"acp/internal/protocol"
 	"acp/internal/protocol/acp1"
 	"acp/internal/storage"
@@ -34,6 +33,7 @@ type commonFlags struct {
 	port      int
 	timeout   time.Duration
 	verbose   bool
+	logLevel  string
 	capture   string
 }
 
@@ -45,7 +45,8 @@ func addCommonFlags(fs *flag.FlagSet) *commonFlags {
 			"(ACP1 v1.4 TCP direct, crosses VLANs)")
 	fs.IntVar(&cf.port, "port", 0, "override default port (0 = plugin default)")
 	fs.DurationVar(&cf.timeout, "timeout", 30*time.Second, "per-operation timeout")
-	fs.BoolVar(&cf.verbose, "verbose", false, "debug log output")
+	fs.BoolVar(&cf.verbose, "verbose", false, "debug log output (shortcut for --log-level debug)")
+	fs.StringVar(&cf.logLevel, "log-level", "info", "log level: trace, debug, info, warn, error, critical")
 	fs.StringVar(&cf.capture, "capture", "", "write raw traffic to JSONL file (for unit test data)")
 	return cf
 }
@@ -58,11 +59,11 @@ func connect(ctx context.Context, host string, cf *commonFlags) (protocol.Protoc
 		return nil, nil, fmt.Errorf("host argument is required")
 	}
 
-	lvl := slog.LevelInfo
-	if cf.verbose {
-		lvl = slog.LevelDebug
+	lvl := logging.ParseLevel(cf.logLevel)
+	if cf.verbose && lvl > logging.LevelDebug {
+		lvl = logging.LevelDebug // --verbose is shortcut for --log-level debug
 	}
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: lvl}))
+	logger := logging.NewTextLogger(lvl)
 
 	// Optional traffic capture for test data generation.
 	var recorder *transport.Recorder

--- a/docs/CONNECTOR.md
+++ b/docs/CONNECTOR.md
@@ -1,0 +1,414 @@
+# Connector Architecture
+
+This document defines the protocol-agnostic connector architecture.
+Every protocol plugin (ACP1, ACP2, future Ember+) implements the same
+flow. The web UI and CLI are consumers of the connector — they never
+manage walks, caching, or subscriptions directly.
+
+---
+
+## Terminology
+
+Aligned with Ember+ conventions for future compatibility.
+
+| Ember+ term | ACP equivalent | Description |
+|---|---|---|
+| **Provider** | Device | The hardware exposing parameters (Axon card, mixing console) |
+| **Consumer** | Connector / CLI / Web UI | Client that reads, writes, subscribes |
+| **Node** | Group / Container | Tree structure element (BOARD, PSU, identity, control) |
+| **Parameter** | Object | Single readable/writable value with metadata |
+| **GetDirectory** | Walk (1 level) | Discover children of a node |
+| **Full walk** | Walk (DFS) | Discover entire tree recursively |
+| **Subscribe** | Subscribe / Watch | Register for value-change notifications |
+| **Notification** | Announcement | Provider pushes value change to consumer |
+| **Matrix** | — | Cross-point switching (not in ACP, future Ember+) |
+| **Function** | — | Callable operation (not in ACP) |
+
+---
+
+## Data Model Library
+
+### Concept
+
+The **data model** is the tree structure of a card: node hierarchy, parameter IDs,
+labels, types, constraints, enum items, units, paths. It does NOT contain values.
+
+The data model is determined by **card type + firmware version**. Same card with
+same firmware = identical tree. The library stores discovered models keyed by
+`{card_name}_{firmware_version}`.
+
+### Storage
+
+```
+models/
+  SHPRM1_5.3.5.json        ← Axon CONVERT Hybrid, fw 5.3.5
+  DAC24_2.1.0.json          ← Axon DAC24, fw 2.1.0
+  RRS18_1601.json           ← Synapse Rack Controller, fw 1601
+```
+
+### Identity fields (for library key + validation)
+
+| Field | ACP1 (all slots) | ACP2 CTRL (slot 0) | ACP2 Device (slot 1+) |
+|---|---|---|---|
+| Card Name | identity > Card name | BOARD > Card Name | IDENTITY > Card Name |
+| Firmware | identity > Software rev | BOARD > Product Version | IDENTITY > Product Version |
+| Serial | identity > Serial number | BOARD > Serial Number | — (not available) |
+| Description | identity > Card description | — | IDENTITY > Card Description |
+
+Library key: `{card_name}_{firmware_version}`.
+
+Note: ACP2 device slots (1+) do NOT expose Serial Number under IDENTITY.
+Serial is only available on the CTRL slot (slot 0) under BOARD — it belongs
+to the Neuron controller, not the individual device cards.
+
+### Contents (per model file)
+
+```
+- card_name          string     "SHPRM1"
+- firmware_version   string     "5.3.5"
+- serial_number      string     "PR113951"  (for traceability, not matching)
+- protocol           string     "acp2"
+- tree               nested     full hierarchical tree
+  - node/parameter:
+    - id             int        unique object ID
+    - label          string     human-readable name
+    - kind           string     int/uint/float/enum/string/ipaddr/alarm
+    - access         string     R--/RW-/RWD
+    - path           []string   hierarchical path
+    - unit           string     C, %, mW, dBFS, ...
+    - min/max/step   number     constraints
+    - default        any        default value
+    - enum_items     []string   enum option labels
+    - max_len        int        string max length
+```
+
+**Never stored:** values, IP addresses, slot numbers, timestamps.
+
+### Lifecycle
+
+```
+1. First time seeing card+fw combo → full walk → save to library
+2. Next time → load from library → instant (no walk)
+3. Firmware upgrade → new key → full walk → new model in library
+4. Never invalidated — firmware version is immutable
+```
+
+---
+
+## Connector Flow
+
+### On connect
+
+```
+connect(ip, port)
+  → get device info (slot count)
+  → for each present slot:
+      → read identity (1 quick request):
+          ACP1: getObject(identity, 0) → Card name, Software rev
+          ACP2: get_object(BOARD) → Card Name, Product Version
+      → build key: {card_name}_{fw_version}
+      → lookup library: models/{key}.json
+      → FOUND:
+          load model → instant labels, types, constraints
+          subscribe to announcements
+          ready
+      → NOT FOUND:
+          queue background full walk
+          subscribe to announcements (raw until walk completes)
+          walk completes → save model to library
+          switch to decoded values
+```
+
+### Addressing
+
+| Method | Scope | Ambiguity |
+|---|---|---|
+| Object ID | Global per device | None — unique |
+| Label | Per group (ACP1) / Per tree (ACP2) | Duplicates possible (e.g. "Present" under PSU/1 and PSU/2) |
+| Path | Full tree path | None — unique (BOARD/Card Name, PSU/1/Present) |
+
+**CLI rule:** accept all three. Object ID is the primary key for import/export
+round-trip. Path and label are for human convenience.
+
+```
+acp get ... --id 15239                    # unambiguous
+acp get ... --label "Card Name"           # works if unique
+acp get ... --path PSU/1/Present          # unambiguous
+acp walk ... --path BOARD                 # subtree filter
+acp walk ... --filter Temperature         # text search
+```
+
+### Export / Import
+
+Export reads the **current state** (values + model). Import writes values back.
+Both operate on the same file format — no re-walk needed.
+
+```
+Export:
+  walk (or use cached model) → read values → write file
+
+Import:
+  read file → dry-run (validate) → apply
+  - R-- objects: skip (read-only)
+  - RW- objects: set value by object ID
+  - unknown objects: skip + warn
+```
+
+| Format | Lossless | Round-trip | Human-editable |
+|---|---|---|---|
+| JSON | yes | yes | yes |
+| YAML | yes | yes | yes (best for editing) |
+| CSV | lossy | yes (values only) | yes (spreadsheet) |
+
+### Watch (real-time monitoring)
+
+```
+watch:
+  1. Load model from library → instant labels + units + types
+  2. Subscribe to announcements
+  3. Display announces with:
+     - [cache]  label from library, value raw (walk not done)
+     - [live]   label + decoded value from walked tree
+  4. Background walk (if library outdated or missing)
+  5. Walk completes → all [live], save model to library
+```
+
+---
+
+## Connector Interface
+
+Protocol-agnostic. Every plugin implements this.
+
+```go
+type Connector interface {
+    // Connection
+    Connect(ctx, ip, port) error
+    Disconnect() error
+
+    // Identity (1 quick request, no walk)
+    GetDeviceInfo(ctx) DeviceInfo
+    GetSlotIdentity(ctx, slot) (cardName, fwVersion string, err error)
+
+    // Model (library-backed)
+    HasModel(cardName, fwVersion) bool
+    LoadModel(cardName, fwVersion) (*DataModel, error)
+    SaveModel(cardName, fwVersion, *DataModel) error
+
+    // Walk
+    WalkFull(ctx, slot) (*DataModel, error)            // DFS entire tree
+    WalkNode(ctx, slot, objID) ([]Parameter, error)    // 1 level (lazy)
+
+    // Values
+    GetValue(ctx, slot, objID) (Value, error)
+    SetValue(ctx, slot, objID, value) (Value, error)
+
+    // Subscriptions
+    Subscribe(slot, objID, callback) error
+    Unsubscribe(slot, objID) error
+}
+```
+
+---
+
+## Data Model Reuse
+
+### Same card across slots
+
+```
+Slot 0: SHPRM1 fw 5.3.5 → walk → save models/SHPRM1_5.3.5.json
+Slot 1: SHPRM1 fw 5.3.5 → found in library → no walk
+Slot 2: SHPRM1 fw 5.3.5 → found in library → no walk
+Slot 3: DAC24  fw 2.1.0 → not found → walk → save models/DAC24_2.1.0.json
+```
+
+10 identical cards = 1 walk, 10 instant loads.
+
+### Across devices
+
+```
+Device A, Slot 0: SHPRM1 fw 5.3.5 → walk → library
+Device B, Slot 3: SHPRM1 fw 5.3.5 → found → no walk
+```
+
+Library is device-independent. Same card+fw = same model everywhere.
+
+---
+
+## CLI Capture for Tests
+
+CLI provides raw inbound/outbound capture for unit tests and new protocol
+discovery.
+
+```
+acp walk ... --capture slot0_walk.jsonl        # save raw traffic
+acp watch ... --capture slot0_watch.jsonl       # save announcements
+acp get ... --capture get_card_name.jsonl       # save single request
+```
+
+Capture format: JSONL with `{ts, proto, dir, hex, len}` per line.
+Direction: `tx` = outbound (consumer → provider), `rx` = inbound (provider → consumer).
+
+These captures are:
+- Replayed in unit tests (codec regression)
+- Used to discover new object types or protocol variants
+- Stored in `testdata/{protocol}/`
+
+---
+
+## Responsibilities
+
+| Component | Owns |
+|---|---|
+| **Connector** | Walk scheduling, model library, identity check, subscribe/unsubscribe, value decode, announce routing |
+| **CLI** | User interaction, formatting, flags, capture |
+| **Web UI** | View selection (master/client), display, user input |
+| **Export** | Serialize model + values to file (JSON/YAML/CSV) |
+| **Import** | Parse file, validate, apply values via connector |
+
+The web UI and CLI are **consumers**. They ask the connector for data.
+They never walk, cache, or manage subscriptions directly.
+
+---
+
+## Protocol-Specific Notes
+
+### ACP1
+
+- Identity: `getObject(group=identity, id=0)`:
+  - **Device (all slots):** identity > Card name, identity > Software rev, identity > Serial number
+- Groups: identity, control, status, alarm, file, frame
+- No hierarchy within groups (flat list)
+- Walk: 1 root + N objects per group
+- Announcements: UDP broadcast, MTID=0
+- Announcements require `Broadcasts` param = `On` on the rack controller (slot 0, control group)
+- If `Broadcasts` = `Off`, no value-change announcements are sent by the device
+- The connector should check/enable this on connect if watch is requested
+
+### ACP2
+
+- Identity fields vary by slot role:
+  - **CTRL (slot 0):** BOARD > Card Name, BOARD > Product Version, BOARD > Serial Number
+  - **Device (slot 1+):** IDENTITY > Card Name, IDENTITY > Product Version, IDENTITY > Serial Number
+- Hierarchy: ROOT_NODE_V2 > BOARD > Card Name, PSU > 1 > Present
+- Walk: DFS from root, pid=14 (children) for recursion
+- Announcements: AN2 TCP, type=2, mtid=0
+- Announcements require AN2 `EnableProtocolEvents([2])` on connect
+
+---
+
+## Provider Mode (future)
+
+### Concept
+
+`acp-srv` acts as a **gateway**: consumer on the device side, provider on
+the control side. External systems (Cerebrum, NMOS, third-party controllers)
+connect to `acp-srv` as if it were a device.
+
+```
+┌─────────────────────────────────────────────────────┐
+│  External consumers                                  │
+│  Cerebrum, NMOS, third-party                         │
+│         │              │              │              │
+│    Ember+/TCP     REST/WS       ACP/TCP              │
+│         │              │              │              │
+│  ┌──────┴──────────────┴──────────────┴──────┐      │
+│  │              acp-srv (PROVIDER)            │      │
+│  │  - Expose aggregated tree                  │      │
+│  │  - Accept subscriptions                    │      │
+│  │  - Route notifications                     │      │
+│  │  - Proxy get/set to devices                │      │
+│  └──────┬──────────────┬──────────────┬──────┘      │
+│         │              │              │              │
+│    ACP1/UDP       ACP2/TCP       Ember+/TCP          │
+│         │              │              │              │
+│    Axon Rack 1    Axon Rack 2    Ember+ device       │
+│  (PROVIDER)      (PROVIDER)      (PROVIDER)          │
+└─────────────────────────────────────────────────────┘
+```
+
+### Provider responsibilities
+
+| Responsibility | Description |
+|---|---|
+| **Listen** | Accept TCP connections from external consumers |
+| **Expose tree** | Serve aggregated data model (all devices, all slots) |
+| **GetDirectory** | Respond to tree discovery requests (lazy, per-level) |
+| **GetValue** | Proxy read to the real device via consumer connector |
+| **SetValue** | Proxy write to the real device, return confirmed value |
+| **Subscribe** | Track per-client subscriptions, route notifications |
+| **Notify** | Push value changes from device announcements to subscribed consumers |
+| **Session management** | Track multiple concurrent consumers, clean up on disconnect |
+
+### What exists vs what's needed
+
+| Component | Consumer (done) | Provider (to add) |
+|---|---|---|
+| Data model / tree | yes | reuse |
+| Value read/write | yes | proxy through |
+| Subscriptions | yes (device → us) | add (us → external client) |
+| Codec (ACP1/ACP2) | yes | reuse for device side |
+| Codec (Ember+ Glow) | no | encode our tree as Glow DTD |
+| TCP client (connect out) | yes | reuse |
+| TCP server (listen) | no | accept inbound connections |
+| Session manager | no | track consumers, subscriptions, cleanup |
+| Notification router | no | device announce → fan out to subscribed consumers |
+
+### Aggregated tree
+
+The provider exposes a **single unified tree** combining all connected devices:
+
+```
+Root
+├── Device_10.41.40.195 (ACP2)
+│   ├── Slot 0 (SHPRM1)
+│   │   ├── BOARD
+│   │   │   ├── Card Name = "SHPRM1"
+│   │   │   └── ...
+│   │   ├── PSU
+│   │   └── TEMPERATURE
+│   └── Slot 1 (CONVERT)
+│       ├── IDENTITY
+│       ├── INPUT
+│       └── OUTPUT
+├── Device_10.6.239.113 (ACP1)
+│   └── Slot 0 (RRS18)
+│       ├── identity
+│       ├── control
+│       ├── status
+│       └── alarm
+└── Device_10.50.1.20 (Ember+, future)
+    └── ...
+```
+
+### Provider protocols (planned)
+
+| Protocol | Use case | Priority |
+|---|---|---|
+| REST + WebSocket | Web UI (`acp-ui`) | phase 1 |
+| Ember+ (Glow/S101) | Cerebrum, broadcast controllers | phase 2 |
+| ACP2 provider | Expose as virtual ACP2 device | phase 3 |
+
+### Use cases (to be defined)
+
+- Cerebrum connects to `acp-srv` via Ember+ → sees all Axon devices as one tree
+- Web UI connects via WebSocket → master/client view with live updates
+- Third-party NMOS controller discovers `acp-srv` → reads/writes parameters
+- Redundancy: two `acp-srv` instances, both consumers of same devices, one active provider
+- Multi-site: `acp-srv` per site, central aggregator connects to all
+
+### Scope (to be reviewed)
+
+- Phase 1: REST + WebSocket provider for `acp-ui`
+- Phase 2: Ember+ provider (Glow DTD encoder + S101 framer + TCP server)
+- Phase 3: ACP2 provider (virtual device)
+- Out of scope: ACP1 provider (ACP1 is UDP-only, no server mode in spec)
+
+---
+
+### Ember+ (future)
+
+- Identity: node attributes at root
+- Hierarchy: arbitrary depth nodes + parameters
+- Walk: `GetDirectory` per node (lazy)
+- Notifications: provider pushes on change
+- Same connector interface, different plugin

--- a/internal/export/json.go
+++ b/internal/export/json.go
@@ -17,30 +17,9 @@ import (
 // object trees matching the device structure. For ACP1 (flat), the
 // original grouped format is preserved.
 func WriteJSON(w io.Writer, s *Snapshot) error {
-	// Check if any slot has hierarchical objects.
-	hierarchical := false
-	for _, slot := range s.Slots {
-		for _, o := range slot.Objects {
-			if len(o.Path) > 2 {
-				hierarchical = true
-				break
-			}
-		}
-		if hierarchical {
-			break
-		}
-	}
-
-	if !hierarchical {
-		enc := json.NewEncoder(w)
-		enc.SetIndent("", "  ")
-		if err := enc.Encode(s); err != nil {
-			return fmt.Errorf("json encode: %w", err)
-		}
-		return nil
-	}
-
-	// ACP2: build hierarchical JSON.
+	// Always use hierarchical JSON — ACP1 groups (identity, control,
+	// status, alarm) and ACP2 tree (BOARD, PSU, etc.) both render as
+	// nested object trees.
 	out := jsonHierarchicalSnapshot(s)
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
@@ -79,16 +58,41 @@ func jsonHierarchicalSnapshot(s *Snapshot) map[string]any {
 }
 
 // buildJSONTree creates nested maps from flat objects using their Path.
+// ACP2: Path = [ROOT_NODE_V2, BOARD, Card Name] → skip ROOT_NODE_V2.
+// ACP1: Path = [identity] + Label → group objects under identity/control/etc.
 func buildJSONTree(objs []protocol.Object) map[string]any {
+	// Detect ACP2 by checking for ROOT_NODE_V2 prefix.
+	acp2 := false
+	for _, o := range objs {
+		if len(o.Path) > 0 && strings.EqualFold(o.Path[0], "ROOT_NODE_V2") {
+			acp2 = true
+			break
+		}
+	}
+
 	root := make(map[string]any)
 	for _, o := range objs {
-		if len(o.Path) <= 1 {
-			continue // skip ROOT_NODE_V2 itself
-		}
-		if o.Kind == protocol.KindRaw {
-			// Container node — ensure map exists but don't add leaf data.
+		if acp2 {
+			// ACP2: skip ROOT_NODE_V2 root object itself.
+			if len(o.Path) <= 1 {
+				continue
+			}
+			if o.Kind == protocol.KindRaw {
+				// Container node — ensure map exists.
+				cur := root
+				for _, seg := range o.Path[1:] {
+					if _, exists := cur[seg]; !exists {
+						cur[seg] = make(map[string]any)
+					}
+					if sub, ok := cur[seg].(map[string]any); ok {
+						cur = sub
+					}
+				}
+				continue
+			}
+			// Leaf node — walk path[1:] and nest.
 			cur := root
-			for _, seg := range o.Path[1:] {
+			for _, seg := range o.Path[1 : len(o.Path)-1] {
 				if _, exists := cur[seg]; !exists {
 					cur[seg] = make(map[string]any)
 				}
@@ -96,21 +100,23 @@ func buildJSONTree(objs []protocol.Object) map[string]any {
 					cur = sub
 				}
 			}
-			continue
-		}
-		// Leaf node — walk path and insert object properties.
-		cur := root
-		for _, seg := range o.Path[1 : len(o.Path)-1] {
-			if _, exists := cur[seg]; !exists {
-				cur[seg] = make(map[string]any)
+			cur[o.Path[len(o.Path)-1]] = jsonLeaf(o)
+		} else {
+			// ACP1: Path = [group], group objects under identity/control/etc.
+			group := o.Group
+			if group == "" && len(o.Path) > 0 {
+				group = o.Path[0]
 			}
-			if sub, ok := cur[seg].(map[string]any); ok {
-				cur = sub
+			if group == "" {
+				group = "other"
+			}
+			if _, exists := root[group]; !exists {
+				root[group] = make(map[string]any)
+			}
+			if gmap, ok := root[group].(map[string]any); ok {
+				gmap[o.Label] = jsonLeaf(o)
 			}
 		}
-		// Last path element is the leaf label.
-		leaf := jsonLeaf(o)
-		cur[o.Path[len(o.Path)-1]] = leaf
 	}
 	return root
 }

--- a/internal/export/yaml.go
+++ b/internal/export/yaml.go
@@ -45,31 +45,11 @@ func WriteYAML(w io.Writer, s *Snapshot) error {
 		}
 		writeKV(&sb, 4, "walked_at", slot.WalkedAt.UTC().Format("2006-01-02T15:04:05Z"))
 
-		// Check if any object has path depth > 2 (ACP2 hierarchical).
-		hierarchical := false
-		for _, o := range slot.Objects {
-			if len(o.Path) > 2 {
-				hierarchical = true
-				break
-			}
-		}
-
-		if hierarchical {
-			// ACP2: build nested tree from Path and render hierarchically.
-			root := buildObjectTree(slot.Objects)
-			writeTreeNode(&sb, 4, root)
-		} else {
-			// ACP1: flat group → list of objects.
-			groups := groupByPath(slot.Objects)
-			for _, gname := range groups.order {
-				sb.WriteString("    ")
-				sb.WriteString(gname)
-				sb.WriteString(":\n")
-				for _, o := range groups.items[gname] {
-					writeObject(&sb, 6, o)
-				}
-			}
-		}
+		// Both ACP1 and ACP2 use nested tree format.
+		// ACP2: deep hierarchy (BOARD > Card Name > {id, kind}).
+		// ACP1: two levels (identity > Card name > {id, kind}).
+		root := buildObjectTree(slot.Objects)
+		writeTreeNode(&sb, 4, root)
 	}
 
 	if _, err := io.WriteString(w, sb.String()); err != nil {
@@ -92,31 +72,76 @@ type objectTreeNode struct {
 // Path[0] is always ROOT_NODE_V2 for ACP2 — we skip it and start from
 // Path[1] (BOARD, PSU, etc.) so the tree matches Cerebrum's view.
 func buildObjectTree(objs []protocol.Object) *objectTreeNode {
+	// Detect ACP2 by ROOT_NODE_V2 prefix.
+	acp2 := false
+	for _, o := range objs {
+		if len(o.Path) > 0 && strings.EqualFold(o.Path[0], "ROOT_NODE_V2") {
+			acp2 = true
+			break
+		}
+	}
+
 	root := &objectTreeNode{name: "root", childIdx: map[string]int{}}
 	for i := range objs {
 		o := &objs[i]
-		// Skip the root node object itself (path = ["ROOT_NODE_V2"]).
-		if len(o.Path) <= 1 {
-			continue
-		}
-		// Walk from path[1] onward, creating container nodes as needed.
-		cur := root
-		for _, seg := range o.Path[1:] {
-			idx, exists := cur.childIdx[seg]
+
+		if acp2 {
+			// ACP2: skip ROOT_NODE_V2 root object itself.
+			if len(o.Path) <= 1 {
+				continue
+			}
+			// Walk from path[1] onward.
+			cur := root
+			for _, seg := range o.Path[1:] {
+				idx, exists := cur.childIdx[seg]
+				if !exists {
+					idx = len(cur.children)
+					cur.childIdx[seg] = idx
+					cur.children = append(cur.children, &objectTreeNode{
+						name:     seg,
+						childIdx: map[string]int{},
+					})
+				}
+				cur = cur.children[idx]
+			}
+			if o.Kind != protocol.KindRaw {
+				cur.obj = o
+			}
+		} else {
+			// ACP1: Path = [group], nest under group > label.
+			group := o.Group
+			if group == "" && len(o.Path) > 0 {
+				group = o.Path[0]
+			}
+			if group == "" {
+				group = "other"
+			}
+			// Ensure group node exists.
+			gIdx, exists := root.childIdx[group]
 			if !exists {
-				idx = len(cur.children)
-				cur.childIdx[seg] = idx
-				cur.children = append(cur.children, &objectTreeNode{
-					name:     seg,
+				gIdx = len(root.children)
+				root.childIdx[group] = gIdx
+				root.children = append(root.children, &objectTreeNode{
+					name:     group,
 					childIdx: map[string]int{},
 				})
 			}
-			cur = cur.children[idx]
-		}
-		// If this is a leaf (has a value kind), attach the object.
-		// Node/container objects (kind=raw) just create the tree structure.
-		if o.Kind != protocol.KindRaw {
-			cur.obj = o
+			groupNode := root.children[gIdx]
+			// Add leaf under group.
+			label := o.Label
+			if label == "" {
+				label = fmt.Sprintf("obj_%d", o.ID)
+			}
+			lIdx, exists := groupNode.childIdx[label]
+			if !exists {
+				lIdx = len(groupNode.children)
+				groupNode.childIdx[label] = lIdx
+				groupNode.children = append(groupNode.children, &objectTreeNode{
+					name:     label,
+					childIdx: map[string]int{},
+				})
+			}
+			groupNode.children[lIdx].obj = o
 		}
 	}
 	return root
@@ -199,56 +224,6 @@ func groupByPath(objs []protocol.Object) orderedGroups {
 		g.items[name] = append(g.items[name], o)
 	}
 	return g
-}
-
-// writeObject renders one protocol.Object as a YAML list item.
-// Each list item starts with "- " at indent-2 and continues with
-// key:value pairs at indent (the `- ` and subsequent keys are aligned
-// so the overall indentation is indent+2 for child fields).
-func writeObject(sb *strings.Builder, indent int, o protocol.Object) {
-	pad := strings.Repeat(" ", indent)
-	sb.WriteString(pad)
-	sb.WriteString("- label: ")
-	sb.WriteString(yamlString(o.Label))
-	sb.WriteByte('\n')
-
-	childPad := strings.Repeat(" ", indent+2)
-
-	writeKVPad(sb, childPad, "id", o.ID)
-	writeKVPad(sb, childPad, "kind", kindName(o.Kind))
-	writeKVPad(sb, childPad, "access", accessStr(o.Access))
-	if o.SubGroupMarker {
-		writeKVPad(sb, childPad, "sub_group_marker", true)
-	}
-	if o.Unit != "" {
-		writeKVPad(sb, childPad, "unit", o.Unit)
-	}
-
-	switch o.Kind {
-	case protocol.KindInt, protocol.KindUint, protocol.KindFloat:
-		writeKVPad(sb, childPad, "min", o.Min)
-		writeKVPad(sb, childPad, "max", o.Max)
-		writeKVPad(sb, childPad, "step", o.Step)
-		writeKVPad(sb, childPad, "default", o.Def)
-	case protocol.KindEnum:
-		writeKVPad(sb, childPad, "enum_items", o.EnumItems)
-		writeKVPad(sb, childPad, "default", o.Def)
-	case protocol.KindString:
-		if o.MaxLen > 0 {
-			writeKVPad(sb, childPad, "max_len", o.MaxLen)
-		}
-	case protocol.KindAlarm:
-		writeKVPad(sb, childPad, "alarm_priority", o.AlarmPriority)
-		writeKVPad(sb, childPad, "alarm_tag", fmt.Sprintf("0x%02X", o.AlarmTag))
-		if o.AlarmOnMsg != "" {
-			writeKVPad(sb, childPad, "alarm_on", o.AlarmOnMsg)
-		}
-		if o.AlarmOffMsg != "" {
-			writeKVPad(sb, childPad, "alarm_off", o.AlarmOffMsg)
-		}
-	}
-
-	writeValue(sb, childPad, o)
 }
 
 // writeValue renders the current value of an Object — the one field

--- a/internal/logging/levels.go
+++ b/internal/logging/levels.go
@@ -1,0 +1,86 @@
+// Package logging provides structured logging primitives for the acp
+// toolset. Designed to be Loki/Promtail/Grafana compliant:
+//
+//   - JSON lines format with standard fields (level, msg, time)
+//   - Structured attributes extractable as Loki labels
+//   - Custom severity levels: Trace, Debug, Info, Warn, Error, Critical
+//   - Direction field (→/←) for protocol I/O
+//   - Source path (acp2.session.connect) for module identification
+//
+// Output modes:
+//
+//	CLI:     text handler to stderr (human-readable)
+//	acp-srv: JSON handler to file (Promtail scrapes → Loki → Grafana)
+//
+// No external dependencies — stdlib log/slog only.
+package logging
+
+import (
+	"log/slog"
+)
+
+// Custom log levels extending slog's default four.
+// slog levels: Debug=-4, Info=0, Warn=4, Error=8.
+// We add Trace below Debug and Critical above Error.
+const (
+	LevelTrace    slog.Level = -8 // raw wire data, hex dumps, full property details
+	LevelDebug               = slog.LevelDebug // -4: object metadata, codec internals
+	LevelInfo                = slog.LevelInfo   //  0: connected, walk complete, id/label/value
+	LevelWarn                = slog.LevelWarn    //  4: child walk failed, retry, timeout
+	LevelError               = slog.LevelError  //  8: request failed, decode error
+	LevelCritical slog.Level = 12               // connection lost, panic recovery
+)
+
+// Direction constants for protocol I/O logging.
+const (
+	DirOutbound = "→" // tx: request sent to device
+	DirInbound  = "←" // rx: reply received from device
+)
+
+// LevelNames maps custom levels to human-readable names for the
+// slog ReplaceAttr function. Promtail/Loki can filter on these.
+func LevelNames(groups []string, a slog.Attr) slog.Attr {
+	if a.Key != slog.LevelKey {
+		return a
+	}
+	level, ok := a.Value.Any().(slog.Level)
+	if !ok {
+		return a
+	}
+	switch {
+	case level <= LevelTrace:
+		a.Value = slog.StringValue("TRACE")
+	case level <= LevelDebug:
+		a.Value = slog.StringValue("DEBUG")
+	case level <= LevelInfo:
+		a.Value = slog.StringValue("INFO")
+	case level <= LevelWarn:
+		a.Value = slog.StringValue("WARN")
+	case level <= LevelError:
+		a.Value = slog.StringValue("ERROR")
+	default:
+		a.Value = slog.StringValue("CRITICAL")
+	}
+	return a
+}
+
+// ParseLevel converts a string to slog.Level. Accepts:
+// trace, debug, info, warn, error, critical.
+func ParseLevel(s string) slog.Level {
+	switch s {
+	case "trace", "TRACE":
+		return LevelTrace
+	case "debug", "DEBUG":
+		return LevelDebug
+	case "info", "INFO":
+		return LevelInfo
+	case "warn", "WARN", "warning":
+		return LevelWarn
+	case "error", "ERROR":
+		return LevelError
+	case "critical", "CRITICAL", "fatal", "FATAL":
+		return LevelCritical
+	default:
+		return LevelInfo
+	}
+}

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -1,0 +1,75 @@
+package logging
+
+import (
+	"io"
+	"log/slog"
+	"os"
+)
+
+// NewTextLogger creates a text handler for CLI output to stderr.
+// Human-readable, with custom level names.
+func NewTextLogger(level slog.Level) *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level:       level,
+		ReplaceAttr: LevelNames,
+	}))
+}
+
+// NewJSONLogger creates a JSON handler for file/stdout output.
+// Loki/Promtail compatible — each line is valid JSON with standard
+// fields: time, level, msg, plus structured attributes.
+//
+// Example output:
+//
+//	{"time":"2026-04-17T14:25:28Z","level":"INFO","msg":"connected","source":"acp2.session","dir":"→","host":"10.41.40.195"}
+//	{"time":"2026-04-17T14:25:29Z","level":"DEBUG","msg":"get_object","source":"acp2.walker","dir":"→","slot":0,"obj_id":1}
+//	{"time":"2026-04-17T14:25:29Z","level":"TRACE","msg":"send","source":"acp2.session","dir":"→","hex":"c63500000100000100"}
+func NewJSONLogger(w io.Writer, level slog.Level) *slog.Logger {
+	return slog.New(slog.NewJSONHandler(w, &slog.HandlerOptions{
+		Level:       level,
+		ReplaceAttr: LevelNames,
+	}))
+}
+
+// WithSource returns a child logger with the source path attribute.
+// Source path follows OPNsense convention: module.component
+//
+// Examples:
+//
+//	WithSource(logger, "acp2.session")
+//	WithSource(logger, "acp2.walker")
+//	WithSource(logger, "acp1.client")
+//	WithSource(logger, "transport.tcp")
+//	WithSource(logger, "export.yaml")
+func WithSource(logger *slog.Logger, source string) *slog.Logger {
+	return logger.With("source", source)
+}
+
+// Attr helpers for common structured fields.
+
+// Dir returns a direction attribute for protocol I/O.
+func Dir(dir string) slog.Attr {
+	return slog.String("dir", dir)
+}
+
+// Outbound returns a direction attribute for outbound (tx) messages.
+func Outbound() slog.Attr {
+	return Dir(DirOutbound)
+}
+
+// Inbound returns a direction attribute for inbound (rx) messages.
+func Inbound() slog.Attr {
+	return Dir(DirInbound)
+}
+
+// NewFileLogger creates a JSON logger writing to a file.
+// The caller is responsible for closing the file.
+// Suitable for acp-srv log file that Promtail scrapes.
+func NewFileLogger(path string, level slog.Level) (*slog.Logger, *os.File, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return nil, nil, err
+	}
+	logger := NewJSONLogger(f, level)
+	return logger, f, nil
+}

--- a/internal/protocol/acp1/value_codec.go
+++ b/internal/protocol/acp1/value_codec.go
@@ -321,13 +321,15 @@ func coerceIP(v protocol.Value) (uint32, error) {
 func coerceEnum(items []string, v protocol.Value) (byte, error) {
 	if v.Str != "" {
 		s := strings.TrimSpace(v.Str)
+		// Map lookup: label → index. ACP1 enums are 0-based sequential.
+		enumMap := make(map[string]byte, len(items))
 		for i, item := range items {
-			if item == s {
-				if i > 255 {
-					return 0, fmt.Errorf("enum index %d too large", i)
-				}
-				return byte(i), nil
+			if i <= 255 {
+				enumMap[item] = byte(i)
 			}
+		}
+		if idx, ok := enumMap[s]; ok {
+			return idx, nil
 		}
 		// Numeric fallback: "--value 2" on an enum still works.
 		if n, err := strconv.ParseUint(s, 0, 8); err == nil && int(n) < len(items) {

--- a/internal/protocol/acp2/plugin.go
+++ b/internal/protocol/acp2/plugin.go
@@ -274,8 +274,22 @@ func (p *Plugin) SetValue(ctx context.Context, req protocol.ValueRequest, val pr
 		}
 	}
 
+	// Build reverse enum map (label → wire index) for enum resolution.
+	var reverseEnum map[string]uint32
+	if tree != nil && obj != nil {
+		for i, tobj := range tree.Objects {
+			if tobj.ID == obj.ID && tree.OptionsMaps[i] != nil {
+				reverseEnum = make(map[string]uint32, len(tree.OptionsMaps[i]))
+				for wireIdx, label := range tree.OptionsMaps[i] {
+					reverseEnum[label] = wireIdx
+				}
+				break
+			}
+		}
+	}
+
 	// Build the value property for the set request.
-	prop, err := encodeSetProperty(objType, numType, obj, val)
+	prop, err := encodeSetProperty(objType, numType, obj, val, reverseEnum)
 	if err != nil {
 		return protocol.Value{}, err
 	}
@@ -504,7 +518,7 @@ func decodePropertyValue(p *Property, objType ACP2ObjType, numType NumberType, t
 }
 
 // encodeSetProperty builds the value Property for a set_property request.
-func encodeSetProperty(objType ACP2ObjType, numType NumberType, obj *protocol.Object, val protocol.Value) (Property, error) {
+func encodeSetProperty(objType ACP2ObjType, numType NumberType, obj *protocol.Object, val protocol.Value, reverseEnum map[string]uint32) (Property, error) {
 	// If raw bytes are provided, use them directly.
 	if len(val.Raw) > 0 && val.Str == "" && val.Int == 0 && val.Float == 0 && val.Uint == 0 {
 		return MakeValueProperty(PIDValue, numType, val.Raw), nil
@@ -519,14 +533,11 @@ func encodeSetProperty(objType ACP2ObjType, numType NumberType, obj *protocol.Ob
 		return MakeValueProperty(PIDValue, numType, data), nil
 
 	case ObjTypeEnum, ObjTypePreset:
-		// Accept enum index from Enum field or parse from Str.
-		enumIdx := val.Enum
-		if val.Str != "" && obj != nil {
-			for i, item := range obj.EnumItems {
-				if item == val.Str {
-					enumIdx = uint8(i)
-					break
-				}
+		// Accept enum index from Enum field or resolve label via reverse map.
+		enumIdx := uint32(val.Enum)
+		if val.Str != "" && reverseEnum != nil {
+			if wireIdx, ok := reverseEnum[val.Str]; ok {
+				enumIdx = wireIdx
 			}
 		}
 		data, err := EncodeNumericValue(NumTypeU32, 0, uint64(enumIdx), 0)

--- a/internal/protocol/types.go
+++ b/internal/protocol/types.go
@@ -246,7 +246,7 @@ type Object struct {
 	SubGroupMarker bool `json:"sub_group_marker,omitempty"`
 
 	// Value is the current object value as captured during Walk.
-	Value Value `json:"value"`
+	Value Value `json:"value,omitempty"`
 }
 
 // HasRead reports whether the object permits getValue/getObject.
@@ -344,7 +344,16 @@ func (v *Value) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON emits a clean payload with only the fields relevant to
 // the Value's Kind. This keeps JSON / YAML output readable and small.
+// IsZero reports whether the Value is empty (no kind set).
+func (v Value) IsZero() bool {
+	return v.Kind == KindUnknown && v.Raw == nil
+}
+
 func (v Value) MarshalJSON() ([]byte, error) {
+	// Omit zero values entirely — used by cache files where values are stripped.
+	if v.IsZero() {
+		return []byte("null"), nil
+	}
 	type envelope struct {
 		Kind       string       `json:"kind"`
 		Raw        []byte       `json:"raw,omitempty"`

--- a/tests/unit/export/roundtrip_test.go
+++ b/tests/unit/export/roundtrip_test.go
@@ -62,9 +62,19 @@ func TestJSON_RoundTrip(t *testing.T) {
 	if len(got.Slots) != 1 || len(got.Slots[0].Objects) != 3 {
 		t.Fatalf("objects: got %d, want 3", len(got.Slots[0].Objects))
 	}
-	o := got.Slots[0].Objects[0]
-	if o.Label != "GainA" || o.Value.Float != 50.8 {
-		t.Errorf("GainA: label=%q float=%v", o.Label, o.Value.Float)
+	// Lookup by label — hierarchical JSON uses maps (unordered).
+	var gainA *protocol.Object
+	for i := range got.Slots[0].Objects {
+		if got.Slots[0].Objects[i].Label == "GainA" {
+			gainA = &got.Slots[0].Objects[i]
+			break
+		}
+	}
+	if gainA == nil {
+		t.Fatal("GainA not found in round-trip")
+	}
+	if gainA.Value.Float != 50.8 {
+		t.Errorf("GainA: float=%v, want 50.8", gainA.Value.Float)
 	}
 }
 


### PR DESCRIPTION
## What

Connector architecture doc, structured logging package, unified hierarchical export for both protocols.

## Why

Need protocol-agnostic architecture before acp-srv. Logging foundation for Loki/Promtail/Grafana. Unified export format eliminates ACP1 vs ACP2 format differences.

Closes #14

## Scope

- [x] core
- [x] export
- [x] cli

## Type

- [x] feat — new feature
- [x] docs — documentation

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `docs/CONNECTOR.md` | new | Full connector architecture with model library, Ember+ terminology |
| `internal/logging/levels.go` | new | Trace/Critical levels, LevelNames for Loki, ParseLevel |
| `internal/logging/logger.go` | new | Text/JSON/File loggers, WithSource, Dir helpers |
| `cmd/acp/common.go` | modified | --log-level flag, use logging package |
| `internal/protocol/types.go` | modified | Value.IsZero, omit zero values in JSON |
| `internal/export/json.go` | modified | Always hierarchical (ACP1 groups nested too) |
| `internal/export/yaml.go` | modified | Always hierarchical, remove unused writeObject |
| `tests/unit/export/roundtrip_test.go` | modified | Lookup by label (map ordering) |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test ./...` | all | 0 |
| `golangci-lint run` | clean | — |

## Device tested

- [x] ACP1 emulator 10.6.239.113 — info, walk, get, export all working
- [x] ACP2 verified via existing testdata

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [x] ACP1 verified on emulator

## Approval

@yboujraf — requesting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)