### PR TITLE
docs: per-protocol pages + README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # acp
 
-Go toolset to discover, connect, monitor, and control Axon devices that
-speak the ACP protocol family (ACP1, ACP2, and future protocols).
+Go toolset to discover, connect, monitor, and control devices that
+speak the ACP protocol family (ACP1, ACP2, and future Ember+).
 
 Two binaries share one internal library:
 
@@ -14,110 +14,137 @@ Two binaries share one internal library:
 
 ---
 
-## Status
+## Protocols
 
-Early implementation. See [CLAUDE.md](CLAUDE.md) for the full protocol
-reference and architecture. The spec documents live in [assets/](assets/)
-(PDFs + Wireshark dissectors).
+Each protocol has a dedicated connector page with transport, firewall rules,
+identity, object types, discovery, get/set, subscriptions, export, capture,
+and CLI examples.
 
-| Component                    | Status        |
-|------------------------------|---------------|
-| Protocol core + registry     | landed        |
-| UDP transport (SO_REUSEADDR) | landed        |
-| TCP direct transport         | landed        |
-| ACP1 codec (all 11 types)    | landed        |
-| ACP1 walker + cache (LRU+TTL)| landed        |
-| ACP1 announcement listener   | landed        |
-| ACP1 plugin (Protocol iface) | landed        |
-| CLI: info / walk / walk --all| landed        |
-| CLI: get / set / watch       | landed        |
-| CLI: export (json/yaml/csv)  | landed        |
-| CLI: import (json)           | landed        |
-| CLI: discover (passive+active)| landed       |
-| CLI: list-protocols / help   | landed        |
-| ACP1 AN2 transport           | not started   |
-| ACP2                         | not started   |
-| `acp-srv` HTTP/WS API        | not started   |
-| Persistence (devices.yaml)   | not started   |
-
-Out of scope for v1: AN2 transport (ACP1 AN2 and ACP2), ACP1 methods 6–9,
-file-object firmware reprogramming, authentication, multi-user sessions.
-See `agents.md` for the full exclusion list.
+| Protocol | Transport | Port | Status | Documentation |
+|---|---|---|---|---|
+| ACP1 | UDP / TCP direct | 2071 | done | [docs/protocols/acp1.md](docs/protocols/acp1.md) |
+| ACP2 | AN2/TCP | 2072 | done | [docs/protocols/acp2.md](docs/protocols/acp2.md) |
+| Ember+ | S101/TCP | 9000 | planned | — |
 
 ---
 
-## Protocols
+## 2. CLI — export / import
 
-| Protocol | Transport                       | Port        | Status         |
-|----------|---------------------------------|-------------|----------------|
-| ACP1     | UDP direct                      | 2071        | in progress    |
-| ACP1     | TCP direct / AN2 TCP            | 2071 / 2072 | not started    |
-| ACP2     | AN2 TCP                         | 2072        | not started    |
+| Command | Description | ACP1 | ACP2 |
+|---|---|---|---|
+| `acp export --format json` | Hierarchical tree + values to JSON | done | done |
+| `acp export --format yaml` | Hierarchical tree + values to YAML | done | done |
+| `acp export --format csv` | Flat rows, path in group column | done | done |
+| `acp import --file X.json` | Apply values from JSON file | done | done |
+| `acp import --file X.yaml` | Apply values from YAML file | done | done |
+| `acp import --file X.csv` | Apply values from CSV file | done | done |
+| `acp import --dry-run` | Validate without writing | done | done |
+
+Export/import rules:
+- Object ID is the primary key (unambiguous)
+- Read-only objects are skipped on import
+- Values in export are live (from walk)
+- Round-trip: export → edit → import works for all 3 formats
+- Hierarchical tree format: identity > Card name > {id, kind, value}
+
+---
+
+## 3. CLI — commands
+
+| Command | Description | Example |
+|---|---|---|
+| `info` | Device info + slot status | `acp info 10.41.40.195 --protocol acp2` |
+| `walk` | Enumerate all objects on a slot | `acp walk 10.41.40.195 --protocol acp2 --slot 0` |
+| `get` | Read one value by ID or label | `acp get 10.41.40.195 --protocol acp2 --slot 0 --id 15239` |
+| `set` | Write one value by ID or label | `acp set 10.41.40.195 --protocol acp2 --slot 0 --id 15239 --value "OK"` |
+| `watch` | Live announcements (Ctrl-C to stop) | `acp watch 10.41.40.195 --protocol acp2 --slot 0` |
+| `export` | Dump tree + values to file | `acp export 10.41.40.195 --format yaml --out device.yaml` |
+| `import` | Apply values from file | `acp import 10.41.40.195 --file device.yaml --dry-run` |
+| `discover` | LAN device discovery (ACP1 only) | `acp discover` |
+| `diag` | Protocol diagnostic probes (ACP2) | `acp diag 10.41.40.195 --protocol acp2` |
+| `list-protocols` | Show registered protocols | `acp list-protocols` |
+| `help` | Per-command help | `acp help walk` |
+
+### Filtering
+
+| Flag | Description | Example |
+|---|---|---|
+| `--path` | Subtree prefix filter | `--path BOARD`, `--path PSU/1` |
+| `--filter` | Text search on output | `--filter Temperature` |
+| `--path + --filter` | Combine both | `--path PSU --filter Temperature` |
+
+### Global flags
+
+| Flag | Description | Default |
+|---|---|---|
+| `--protocol` | Protocol plugin | `acp1` |
+| `--port` | Override default port | auto |
+| `--timeout` | Per-operation timeout | `30s` |
+| `--log-level` | trace/debug/info/warn/error/critical | `info` |
+| `--verbose` | Shortcut for `--log-level debug` | false |
+| `--capture` | Write raw traffic to JSONL file | — |
+| `--transport` | ACP1: `udp` or `tcp` | `udp` |
+
+---
+
+## Architecture
+
+See [docs/CONNECTOR.md](docs/CONNECTOR.md) for the full connector architecture,
+data model library, Ember+ terminology, and provider mode design.
+
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the three-layer system overview.
+
+See [CLAUDE.md](CLAUDE.md) for the complete protocol reference (ACP1 + ACP2 wire format).
 
 ---
 
 ## Getting started
 
-- **Developers**: read [runbook.md](runbook.md) — devcontainer setup, build,
-  test, integration test, cross-compile, emulator workflow.
-- **Agents (Claude, Copilot, etc.)**: read [CLAUDE.md](CLAUDE.md) first,
-  then [agents.md](agents.md) for task patterns.
-- **Protocol deep-dive**: read the PDFs in [assets/](assets/). Spec is
-  authoritative; the C# reference driver (external) is secondary.
+```bash
+# Build
+make build                    # → bin/acp, bin/acp-srv
+
+# Setup pre-commit hooks
+make setup
+
+# Test
+make test                     # unit tests
+make lint                     # golangci-lint
+
+# Run
+bin/acp info 10.6.239.113
+bin/acp walk 10.6.239.113 --slot 0
+bin/acp walk 10.41.40.195 --protocol acp2 --slot 0 --path BOARD
+
+# Integration tests (need device access)
+ACP1_TEST_HOST=10.6.239.113 make test-integration-acp1
+ACP2_TEST_HOST=10.41.40.195 make test-integration-acp2
+```
 
 ---
 
 ## Repository layout
 
 ```
-cmd/
-  acp/                  CLI entrypoint
-  acp-srv/              HTTP + WebSocket server entrypoint
+cmd/acp/              CLI (14 files, split by command)
+cmd/acp-srv/          HTTP + WebSocket server (planned)
 internal/
-  protocol/             IProtocol interface, registry, shared types
-    acp1/               ACP1 plugin (UDP / TCP direct / AN2)
-    acp2/               ACP2 plugin (AN2 only)
-    _template/          Starting point for new protocols
-  transport/            UDP / TCP / AN2 framer primitives
-  device/               Protocol-agnostic Device model + file-backed registry
-  validator/            Value-vs-object constraint checks
-  export/               JSON / CSV / YAML export + import
-  storage/              OS-aware config + devices files
-  logging/              slog handler, Loki-format JSON
-api/
-  server.go             net/http router
-  handlers/             REST handlers
-  ws/                   WebSocket hub + protocol-announce bridge
-  openapi.yaml          OpenAPI 3.1 source of truth
-tests/
-  unit/                 Table-driven byte-exact codec tests
-  integration/          Real-device tests (//go:build integration)
-assets/                 Protocol spec PDFs + Wireshark dissectors
-.devcontainer/          VS Code Dev Container config
+  protocol/           IProtocol interface, registry, shared types
+    acp1/             ACP1 plugin (UDP/TCP, codec, walker, cache)
+    acp2/             ACP2 plugin (AN2/TCP, codec, walker, cache)
+    _template/        Starting point for new protocols
+  transport/          UDP/TCP/AN2 framer, traffic capture
+  export/             JSON/YAML/CSV export + import
+  storage/            File-backed tree store
+  logging/            Structured logging (slog, Loki-compatible)
+assets/
+  acp1/               ACP1 spec PDF + Wireshark dissector
+  acp2/               ACP2 spec PDF + Wireshark dissector
+testdata/             Raw captures + export fixtures
+tests/unit/           Table-driven + replay tests
+tests/integration/    Real-device tests (build tag)
+docs/                 Architecture, connector design, references
 ```
-
----
-
-## Documentation
-
-| File                                                        | Audience        | Purpose                                       |
-|-------------------------------------------------------------|-----------------|-----------------------------------------------|
-| [README.md](README.md)                                      | everyone        | What this project is                          |
-| [runbook.md](runbook.md)                                    | developers      | How to build, test, run, release              |
-| [CLAUDE.md](CLAUDE.md)                                      | AI agents, devs | Protocol reference + architecture rules       |
-| [agents.md](agents.md)                                      | AI agents       | Shared cross-repo instructions                |
-| [LICENSE.md](LICENSE.md)                                     | everyone        | License terms                                 |
-| [COPYRIGHT](COPYRIGHT)                                      | everyone        | Copyright notice                              |
-| [LICENSES-THIRD-PARTY.md](LICENSES-THIRD-PARTY.md)         | everyone        | Third-party dependency licenses               |
-| [CONTRIBUTING.md](CONTRIBUTING.md)                          | contributors    | Contribution guidelines                       |
-| [CHANGELOG.md](CHANGELOG.md)                               | everyone        | Version history                               |
-| [SECURITY.md](SECURITY.md)                                  | everyone        | Security policy + vulnerability reporting     |
-| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)               | developers      | Three-layer architecture overview             |
-| [docs/protocols/acp1/README.md](docs/protocols/acp1/README.md) | developers  | ACP1 protocol runbook                         |
-| [docs/protocols/acp2/README.md](docs/protocols/acp2/README.md) | developers  | ACP2 protocol placeholder                     |
-| [docs/references/README.md](docs/references/README.md)     | developers      | External protocol references                  |
-| [docs/deployment/README.md](docs/deployment/README.md)     | ops             | Cross-compile + firewall rules                |
-| [docs/examples/](docs/examples/)                            | developers      | Example export files (JSON, YAML, CSV)        |
 
 ---
 

--- a/docs/protocols/acp1.md
+++ b/docs/protocols/acp1.md
@@ -1,0 +1,212 @@
+# ACP1 Connector
+
+Consumer connector for ACP v1.4 (Axon Synapse protocol).
+
+---
+
+## References
+
+| Document | Path | Description |
+|---|---|---|
+| Spec (authoritative) | [assets/acp1/AXON-ACP_v1_4.pdf](../../assets/acp1/AXON-ACP_v1_4.pdf) | ACP v1.4 full specification |
+| Wireshark dissector | [assets/acp1/dissector_acpv1.lua](../../assets/acp1/dissector_acpv1.lua) | Byte-exact reference |
+| C# reference driver | external (ByResearch.DHS.AxonACP.DeviceDriver) | ACP1 only, not ACP2 |
+| Protocol reference | [CLAUDE.md](../../CLAUDE.md) — section "ACP1" | Wire format, methods, object types |
+| Testdata captures | [testdata/acp1/](../../testdata/acp1/) | Raw JSONL captures from emulator |
+| Export fixtures | [testdata/exports/acp1/](../../testdata/exports/acp1/) | JSON/YAML/CSV per slot |
+| Source code | [internal/protocol/acp1/](../../internal/protocol/acp1/) | Plugin implementation |
+| Unit tests | [tests/unit/acp1/](../../tests/unit/acp1/) | Replay + spec tests |
+
+---
+
+## Transport
+
+| Mode | Transport | Port | Description |
+|---|---|---|---|
+| Mode A | UDP direct | 2071 | Default. No length prefix. Each datagram = one message |
+| Mode B | TCP direct | 2071 | MLEN (u32 BE) prefix before every message. Added in v1.4 |
+| Mode C | AN2/TCP | 2072 | AN2 frame wraps ACP1 payload. AN2 dlen handles framing |
+
+### Firewall rules
+
+```
+UDP 2071  inbound + outbound    (Mode A — default)
+TCP 2071  outbound              (Mode B — TCP direct)
+TCP 2072  outbound              (Mode C — AN2)
+UDP 2071  inbound broadcast     (announcements + discovery)
+```
+
+### CLI transport selection
+
+```
+acp info 10.6.239.113                              # UDP (default)
+acp info 10.6.239.113 --transport tcp              # TCP direct
+```
+
+---
+
+## Identity
+
+Read from `getObject(group=identity, id=0)` on any slot.
+
+| Field | Group | ID | Label | Type |
+|---|---|---|---|---|
+| Card name | identity | 0 | Card name | string |
+| Firmware | identity | 3 | Software rev | string |
+| Serial number | identity | 6 | Serial number | string |
+| Hardware rev | identity | 4 | Hardware rev | string |
+| Product code | identity | 5 | Product code | string |
+| Card ID | identity | 7 | Card ID | string |
+
+---
+
+## Object Groups
+
+| ID | Group | Description | Objects |
+|---|---|---|---|
+| 0 | root | Card counts per group | 1 (boot mode + counts) |
+| 1 | identity | Label, description, serial, sw/hw rev | 8 |
+| 2 | control | Writable parameters | variable |
+| 3 | status | Read-only status values | variable |
+| 4 | alarm | Alarm objects with priority + tag | variable |
+| 5 | file | Firmware + param table | variable |
+| 6 | frame | Slot status array (slot 0 only) | 1 |
+
+---
+
+## Object Types
+
+| ID | Type | Properties | Value field |
+|---|---|---|---|
+| 0 | Root | 9 | boot_mode (byte) |
+| 1 | Integer | 10 | int16 |
+| 2 | IP Address | 10 | uint32 (4 bytes) |
+| 3 | Float | 10 | float32 (IEEE 754) |
+| 4 | Enumerated | 8 | byte index into item list |
+| 5 | String | 6 | null-terminated ASCII |
+| 6 | Frame Status | 4 | slot status array |
+| 7 | Alarm | 8 | priority byte |
+| 8 | File | 5 | fragment count |
+| 9 | Long | 10 | int32 |
+| 10 | Byte | 10 | uint8 |
+
+---
+
+## Discovery (Walk)
+
+Walk = `getObject` per object in each group. Root object provides counts.
+
+```
+1. getObject(root, 0)        → num_identity, num_control, num_status, num_alarm
+2. getObject(identity, 0..N) → label, type, value, constraints
+3. getObject(control, 0..N)
+4. getObject(status, 0..N)
+5. getObject(alarm, 0..N)
+```
+
+Typical slot 0 (rack controller): ~60 objects, < 1 second.
+
+### Data model save
+
+After walk: saved to `devices/{ip}/slot_{n}.json` (hierarchical format,
+values stripped). Used for instant label resolution on next startup.
+
+---
+
+## Get / Set
+
+| Method | ID | Direction | Description |
+|---|---|---|---|
+| getValue | 0 | request → reply | Read current value |
+| setValue | 1 | request → reply | Write value, returns confirmed |
+| setIncValue | 2 | request → reply | Increment, returns new value |
+| setDecValue | 3 | request → reply | Decrement, returns new value |
+| setDefValue | 4 | request → reply | Reset to default, returns default |
+| getObject | 5 | request → reply | All properties in sequence |
+
+### CLI examples
+
+```
+acp get 10.6.239.113 --slot 0 --id 4 --group control       # by ID
+acp get 10.6.239.113 --slot 0 --label "Broadcasts"          # by label
+acp set 10.6.239.113 --slot 0 --label "Broadcasts" --value "On"
+acp set 10.6.239.113 --slot 0 --id 4 --group control --value "Off"
+```
+
+---
+
+## Subscriptions (Announcements)
+
+- Transport: UDP broadcast, MTID=0
+- Requires `Broadcasts` param = `On` on rack controller (slot 0, control group)
+- If `Broadcasts` = `Off`, no value-change announcements from the device
+- Announcements carry: slot, group, object ID, new value
+
+### CLI
+
+```
+acp watch 10.6.239.113 --slot 0
+acp watch 10.6.239.113 --filter Temperature
+```
+
+---
+
+## Export / Import
+
+Hierarchical tree format matching the group structure:
+
+```yaml
+identity:
+  Card name:
+    id: 0
+    kind: string
+    access: R--
+    value: RRS18
+  Serial number:
+    id: 6
+    kind: string
+    access: R--
+    value: "001633"
+control:
+  Broadcasts:
+    id: 4
+    kind: enum
+    access: RW-
+    enum_items: [Off, On]
+    value_name: "On"
+```
+
+### CLI
+
+```
+acp export 10.6.239.113 --slot 0 --format yaml --out slot0.yaml
+acp export 10.6.239.113 --slot 0 --format json --out slot0.json
+acp export 10.6.239.113 --slot 0 --format csv  --out slot0.csv
+acp import 10.6.239.113 --file slot0.yaml --dry-run
+acp import 10.6.239.113 --file slot0.yaml              # apply
+```
+
+---
+
+## Raw Capture
+
+```
+acp walk 10.6.239.113 --slot 0 --capture slot0_walk.jsonl
+acp watch 10.6.239.113 --capture watch.jsonl
+```
+
+Format: JSONL, one line per wire message:
+```json
+{"ts":"2026-04-16T20:57:56Z","proto":"acp1","dir":"tx","hex":"39d29002010100050000","len":10}
+{"ts":"2026-04-16T20:57:56Z","proto":"acp1","dir":"rx","hex":"39d2900201020005000000090100080e1f0620","len":19}
+```
+
+Used for: unit test replay, protocol analysis, debugging.
+
+---
+
+## Test Device
+
+| Device | IP | Protocol | Notes |
+|---|---|---|---|
+| Synapse Simulator | 10.6.239.113 | ACP1/UDP | Emulator, 31 slots, 4 present |

--- a/docs/protocols/acp2.md
+++ b/docs/protocols/acp2.md
@@ -1,0 +1,297 @@
+# ACP2 Connector
+
+Consumer connector for ACP v2 (Axon Neuron protocol) over AN2 transport.
+
+---
+
+## References
+
+| Document | Path | Description |
+|---|---|---|
+| ACP2 spec (authoritative) | [assets/acp2/acp2_protocol.pdf](../../assets/acp2/acp2_protocol.pdf) | ACP v2 full specification |
+| AN2 spec (authoritative) | [assets/acp2/an2_protocol.pdf](../../assets/acp2/an2_protocol.pdf) | AN2 transport specification |
+| Wireshark dissector | [assets/acp2/dissector_acp2.lua](../../assets/acp2/dissector_acp2.lua) | AN2 + ACP2 byte-exact reference |
+| Protocol reference | [CLAUDE.md](../../CLAUDE.md) — section "ACP2" | Wire format, functions, properties |
+| Testdata captures | [testdata/acp2/](../../testdata/acp2/) | Raw JSONL captures from real device |
+| Export fixtures | [testdata/exports/acp2/](../../testdata/exports/acp2/) | JSON/YAML/CSV per slot |
+| Source code | [internal/protocol/acp2/](../../internal/protocol/acp2/) | Plugin implementation |
+| Unit tests | [tests/unit/acp2/](../../tests/unit/acp2/) | Replay + spec tests |
+
+---
+
+## Transport
+
+ACP2 runs **exclusively over AN2/TCP**. No direct UDP or TCP variant.
+
+| Layer | Protocol | Port | Description |
+|---|---|---|---|
+| Transport | TCP | 2072 | Single TCP connection per device |
+| Framing | AN2 | — | Magic 0xC635, proto/slot/mtid/type/dlen header |
+| Application | ACP2 | — | Carried inside AN2 data frames (proto=2) |
+
+### AN2 initialization sequence
+
+```
+connect TCP :2072
+→ AN2 GetVersion       (proto=0)
+→ AN2 GetDeviceInfo    (proto=0)  → slot count
+→ AN2 GetSlotInfo(n)   (proto=0)  → per slot
+→ AN2 EnableProtocolEvents([2])   ← REQUIRED for ACP2 announces
+→ ACP2 GetVersion      (proto=2)
+→ ACP2 GetObject(slot, root)      → walk from root
+```
+
+### Firewall rules
+
+```
+TCP 2072  outbound    (AN2/TCP — single connection, multiplexes all slots)
+```
+
+### Key transport facts
+
+- Single TCP connection handles ALL slots (AN2 frame header slot field)
+- AN2 mtid is SEPARATE from ACP2 mtid
+- Multiple consumers connect simultaneously (us, Cerebrum, third-party)
+- Per-slot lifecycle is LOGICAL (subscribe/unsubscribe), not PHYSICAL (TCP stays open)
+
+---
+
+## Identity
+
+Identity fields vary by slot role:
+
+### CTRL (slot 0) — Neuron controller
+
+| Field | Path | ID | Label | Type |
+|---|---|---|---|---|
+| Card name | BOARD | 2 | Card Name | string |
+| Firmware | BOARD | 13673 | Product Version | string |
+| Serial number | BOARD | 8 | Serial Number | string |
+| Hardware rev | BOARD | 6 | Hardware Version | string |
+| Product code | BOARD | 7 | Product Code | string |
+| Card ID | BOARD | 9 | Card ID | string |
+
+Note: Serial Number belongs to the Neuron controller, not individual device cards.
+
+### Device (slot 1+) — processing card
+
+| Field | Path | ID | Label | Type |
+|---|---|---|---|---|
+| Card name | IDENTITY | 2 | Card Name | string |
+| Firmware | IDENTITY | 13673 | Product Version | string |
+| Description | IDENTITY | 4 | Card Description | string |
+| Serial number | — | — | Not available | — |
+
+---
+
+## Object Types
+
+| ID | Type | Description |
+|---|---|---|
+| 0 | node | Container — has children (pid 14). No scalar value |
+| 1 | preset | Preset child — value repeated per idx |
+| 2 | enum | Enumerated value (arbitrary u32 wire indices) |
+| 3 | number | Typed numeric (S8/S16/S32/S64/U8/U16/U32/U64/float) |
+| 4 | ipv4 | IP address (4 bytes) |
+| 5 | string | UTF-8 null-terminated string |
+
+### Number types (pid 5)
+
+| ID | Type | Wire size |
+|---|---|---|
+| 0 | S8 | u32 |
+| 1 | S16 | u32 |
+| 2 | S32 | u32 |
+| 3 | S64 | u64 |
+| 4 | U8 | u32 |
+| 5 | U16 | u32 |
+| 6 | U32 | u32 |
+| 7 | U64 | u64 |
+| 8 | float | u32 (IEEE 754) |
+
+---
+
+## Tree Structure
+
+ACP2 has a hierarchical object tree. Typical slot 0 (CONVERT Hybrid):
+
+```
+ROOT_NODE_V2
+├── BOARD (identity, versions, config)
+├── IO BOARD (SDI I/O)
+├── PSU
+│   ├── Fan Control
+│   ├── 1 (Present, Status, Type, Fan Health 1-4)
+│   ├── 2 (Present, Status, Type, Fan Health 1-4)
+│   └── BOARD (Power, Temperature)
+├── TEMPERATURE (USP, ZYNQ)
+├── MANAGEMENT PORT (IP config, routes)
+├── QSFP 1-4 (optical transceivers)
+├── SFP 1-4 (optical transceivers)
+└── SMARC (compute module)
+```
+
+- Slot 0: ~214 objects (~2 seconds walk)
+- Slot 1: ~44k objects (~11 minutes walk)
+
+---
+
+## Discovery (Walk)
+
+Walk = DFS from root via `get_object` + pid=14 (children).
+
+```
+1. get_object(obj_id=1)           → root node, children=[BOARD, IO BOARD, PSU, ...]
+2. get_object(obj_id=15237)       → BOARD, children=[Card Name, Card ID, ...]
+3. get_object(obj_id=2)           → Card Name, leaf (no children)
+4. ... recursively for all children
+```
+
+Root obj-id: 1 on real devices, 0 on some firmware. Walker tries both.
+
+### Streaming walk
+
+Objects are printed as they're discovered (essential for slot 1 with 44k objects).
+No waiting for full tree completion.
+
+### Data model save
+
+After walk: saved to `devices/{ip}/slot_{n}.json` (hierarchical format,
+values stripped). Used for instant label resolution on next startup.
+
+---
+
+## Get / Set
+
+| Function | ID | Direction | Description |
+|---|---|---|---|
+| get_version | 0 | request → reply | ACP2 protocol version |
+| get_object | 1 | request → reply | All properties for obj-id |
+| get_property | 2 | request → reply | Single property for (obj-id, pid) |
+| set_property | 3 | request → reply | Set + returns confirmed property |
+
+### Enum resolution
+
+ACP2 enum wire indices are **arbitrary u32** (not 0-based). Resolved via
+options map (pid=15):
+
+```
+wire 16 = "NA", wire 17 = "OK", wire 18 = "Error"
+```
+
+Set by label uses O(1) reverse map lookup: `"OK" → wire 17`.
+
+### CLI examples
+
+```
+acp get 10.41.40.195 --protocol acp2 --slot 0 --id 15239
+acp get 10.41.40.195 --protocol acp2 --slot 0 --label "Card Name"
+acp set 10.41.40.195 --protocol acp2 --slot 0 --id 21127 --value "Full Speed"
+acp set 10.41.40.195 --protocol acp2 --slot 0 --id 15246 --value "10.41.40.195"
+```
+
+---
+
+## Subscriptions (Announcements)
+
+- Transport: AN2 TCP, ACP2 type=2, mtid=0
+- Requires `AN2 EnableProtocolEvents([2])` on connect (automatic)
+- Announcements carry: slot, obj-id, pid, new value
+- Terminology: "announce" (not "event"), "announce_delay" (not "event_delay")
+
+### Watch with disk cache
+
+```
+acp watch 10.41.40.195 --protocol acp2 --slot 0
+```
+
+Flow:
+1. Load labels + units from disk cache → instant display
+2. Subscribe → announcements arrive with `[cache]` labels
+3. Background walk → populates plugin tree
+4. Walk done → switch to `[live]` (decoded values + enum labels)
+
+Output:
+```
+loaded 190 labels from cache
+17:01:04  s0  15212  Temperature  [live]  20 C
+17:01:06  s0  47397  Power Rx 1   [live]  0.99 mW
+17:01:10  s0  15219  Fan Speed    [live]  10 %
+```
+
+---
+
+## Export / Import
+
+Hierarchical tree format matching the device tree:
+
+```yaml
+BOARD:
+  Card Name:
+    id: 2
+    kind: string
+    access: R--
+    value: SHPRM1
+PSU:
+  Fan Control:
+    id: 21127
+    kind: enum
+    access: RW-
+    enum_items: [Automatic, Full Speed]
+    value_name: Automatic
+  1:
+    Present:
+      id: 15239
+      kind: enum
+      access: R--
+      value_name: OK
+```
+
+### CLI
+
+```
+acp export 10.41.40.195 --protocol acp2 --slot 0 --format yaml --out slot0.yaml
+acp export 10.41.40.195 --protocol acp2 --slot 0 --format json --out slot0.json
+acp export 10.41.40.195 --protocol acp2 --slot 0 --format csv  --out slot0.csv
+acp export 10.41.40.195 --protocol acp2 --slot 0 --path BOARD --format yaml
+acp import 10.41.40.195 --protocol acp2 --file slot0.yaml --dry-run
+acp import 10.41.40.195 --protocol acp2 --file slot0.yaml
+```
+
+---
+
+## Raw Capture
+
+```
+acp walk 10.41.40.195 --protocol acp2 --slot 0 --capture slot0_walk.jsonl
+acp watch 10.41.40.195 --protocol acp2 --capture watch.jsonl
+```
+
+Format: JSONL, one line per AN2 frame:
+```json
+{"ts":"2026-04-16T20:55:07Z","proto":"acp2","dir":"tx","hex":"c63500000100000100","len":9}
+{"ts":"2026-04-16T20:55:07Z","proto":"acp2","dir":"rx","hex":"c635000001010003000001","len":11}
+```
+
+---
+
+## Error Codes
+
+| Status | Error | Description |
+|---|---|---|
+| 0 | protocol error | Bad type/func/packet |
+| 1 | invalid obj-id | Object does not exist |
+| 2 | invalid idx | Preset index out of range |
+| 3 | invalid pid | Property does not exist for this object |
+| 4 | no access | Read-only, set attempted |
+| 5 | invalid value | Enum/preset out of options |
+
+---
+
+## Test Device
+
+| Device | IP | Protocol | Notes |
+|---|---|---|---|
+| Axon CONVERT Hybrid | 10.41.40.195 | ACP2/AN2/TCP | Real device, fw 5.3.5, 2 slots |
+| Slot 0 (SHPRM1) | — | — | Neuron controller, 214 objects |
+| Slot 1 (CONVERT) | — | — | Processing card, 44k+ objects |

--- a/docs/protocols/use-cases.md
+++ b/docs/protocols/use-cases.md
@@ -1,0 +1,316 @@
+# Use Cases — Sequence Diagrams
+
+Protocol-agnostic flows. Applies to ACP1, ACP2, and future Ember+.
+
+---
+
+## 1. Connect + Discover (first time, no library)
+
+```
+  CLI/API            Connector           Device            Library (disk)
+    |                   |                  |                    |
+    |-- connect ------->|                  |                    |
+    |                   |-- TCP/UDP ------>|                    |
+    |                   |<--- connected ---|                    |
+    |                   |                  |                    |
+    |                   |-- get_info ----->|                    |
+    |                   |<--- slots=2 -----|                    |
+    |                   |                  |                    |
+    |                   |-- get_identity ->|                    |
+    |                   |<-- SHPRM1/5.3.5 -|                    |
+    |                   |                  |                    |
+    |                   |-- lookup ------->|----------------->  |
+    |                   |                  |  NOT FOUND         |
+    |                   |                  |<-----------------  |
+    |                   |                  |                    |
+    |                   |== FULL WALK ====>|                    |
+    |                   |  get_object(1)   |                    |
+    |                   |  get_object(2)   |                    |
+    |                   |  ...             |                    |
+    |                   |  get_object(N)   |                    |
+    |                   |<== all objects ==|                    |
+    |                   |                  |                    |
+    |                   |-- save DM ------>|----------------->  |
+    |                   |                  |  SHPRM1_5.3.5.json |
+    |                   |                  |<-----------------  |
+    |                   |                  |                    |
+    |<-- ready (N obj) -|                  |                    |
+    |                   |                  |                    |
+```
+
+---
+
+## 2. Connect + Load from Library (instant)
+
+```
+  CLI/API            Connector           Device            Library (disk)
+    |                   |                  |                    |
+    |-- connect ------->|                  |                    |
+    |                   |-- TCP/UDP ------>|                    |
+    |                   |<--- connected ---|                    |
+    |                   |                  |                    |
+    |                   |-- get_identity ->|                    |
+    |                   |<-- SHPRM1/5.3.5 -|                    |
+    |                   |                  |                    |
+    |                   |-- lookup ------->|----------------->  |
+    |                   |                  |  FOUND             |
+    |                   |                  |  load DM from disk |
+    |                   |<----------------|<-----------------  |
+    |                   |                  |                    |
+    |<-- ready (instant)|                  |                    |
+    |                   |                  |                    |
+    |   NO WALK NEEDED  |                  |                    |
+    |                   |                  |                    |
+```
+
+---
+
+## 3. Get Value by ID
+
+```
+  CLI/API            Connector           Device
+    |                   |                  |
+    |-- get(slot=0,     |                  |
+    |    id=15239) ---->|                  |
+    |                   |                  |
+    |                   |-- get_object --->|
+    |                   |    (id=15239)    |
+    |                   |                  |
+    |                   |<-- reply --------|
+    |                   |    value="OK"    |
+    |                   |    kind=enum     |
+    |                   |                  |
+    |<-- value="OK" ----|                  |
+    |    kind=enum      |                  |
+    |    id=15239       |                  |
+    |                   |                  |
+```
+
+---
+
+## 4. Set Value by ID (ACK + Announcement)
+
+```
+  CLI/API            Connector           Device           Other consumers
+    |                   |                  |                    |
+    |-- set(slot=0,     |                  |                    |
+    |    id=21127,      |                  |                    |
+    |    "Full Speed")->|                  |                    |
+    |                   |                  |                    |
+    |                   |-- reverse map -->|                    |
+    |                   |  "Full Speed"    |                    |
+    |                   |   → wire idx 19  |                    |
+    |                   |                  |                    |
+    |                   |-- set_property ->|                    |
+    |                   |    (id=21127,    |                    |
+    |                   |     val=19)      |                    |
+    |                   |                  |                    |
+    |                   |<-- ACK ---------|                    |
+    |                   |    confirmed=19  |                    |
+    |                   |                  |                    |
+    |<-- confirmed -----|                  |                    |
+    |    "Full Speed"   |                  |                    |
+    |                   |                  |                    |
+    |                   |                  |-- announce ------->|
+    |                   |<-- announce -----|    (id=21127,      |
+    |                   |    (id=21127,    |     val=19)        |
+    |                   |     val=19)      |                    |
+    |                   |                  |                    |
+    |   (watch sees     |                  |                    |
+    |    the change)    |                  |                    |
+    |                   |                  |                    |
+```
+
+---
+
+## 5. Watch (Subscribe + Announcements)
+
+```
+  CLI/API            Connector           Device            Library (disk)
+    |                   |                  |                    |
+    |-- watch(slot=0)-->|                  |                    |
+    |                   |                  |                    |
+    |                   |-- load cache --->|----------------->  |
+    |                   |                  |  labels + units    |
+    |                   |<----------------|<-----------------  |
+    |                   |                  |                    |
+    |                   |-- subscribe ---->|                    |
+    |                   |   (all objects)  |                    |
+    |                   |                  |                    |
+    |                   |     BACKGROUND:  |                    |
+    |                   |== full walk ====>|                    |
+    |                   |                  |                    |
+    |                   |<-- announce -----|                    |
+    |<-- [cache] -------|  id=15212        |                    |
+    |    Temperature=20C|  (label from     |                    |
+    |                   |   disk cache)    |                    |
+    |                   |                  |                    |
+    |                   |<-- announce -----|                    |
+    |<-- [cache] -------|  id=47397        |                    |
+    |    Power Rx=0.99mW|                  |                    |
+    |                   |                  |                    |
+    |                   |<== walk done ====|                    |
+    |                   |  (plugin tree    |                    |
+    |                   |   populated)     |                    |
+    |                   |                  |                    |
+    |                   |-- save DM ------>|----------------->  |
+    |                   |                  |                    |
+    |                   |<-- announce -----|                    |
+    |<-- [live] --------|  id=15212        |                    |
+    |    Temperature=21C|  (label + decode |                    |
+    |                   |   from walk tree)|                    |
+    |                   |                  |                    |
+    |   ... continues until Ctrl-C ...     |                    |
+    |                   |                  |                    |
+```
+
+---
+
+## 6. Export
+
+```
+  CLI/API            Connector           Device            File (disk)
+    |                   |                  |                    |
+    |-- export(slot=0,  |                  |                    |
+    |    format=yaml)-->|                  |                    |
+    |                   |                  |                    |
+    |                   |== full walk ====>|                    |
+    |                   |  (DM + values)   |                    |
+    |                   |<== all objects ==|                    |
+    |                   |                  |                    |
+    |                   |-- save DM ------>|                    |
+    |                   |  (cache, no val) |                    |
+    |                   |                  |                    |
+    |-- apply --path -->|                  |                    |
+    |   apply --filter  |                  |                    |
+    |   (filter objects)|                  |                    |
+    |                   |                  |                    |
+    |-- write YAML ---->|-----------------|----------------->  |
+    |                   |                  |  slot0.yaml        |
+    |                   |                  |  (tree + values)   |
+    |                   |                  |                    |
+    |<-- done (N obj) --|                  |                    |
+    |                   |                  |                    |
+```
+
+---
+
+## 7. Import (dry-run + apply)
+
+```
+  CLI/API            Connector           Device            File (disk)
+    |                   |                  |                    |
+    |-- import -------->|                  |                    |
+    |   (file=slot0.yaml|                  |                    |
+    |    dry-run=true)  |                  |                    |
+    |                   |                  |                    |
+    |                   |<-- read file ----|<-----------------  |
+    |                   |   parse objects  |  slot0.yaml        |
+    |                   |                  |                    |
+    |                   |-- walk slot ---->|                    |
+    |                   |  (fresh tree     |                    |
+    |                   |   for metadata)  |                    |
+    |                   |<== tree =========|                    |
+    |                   |                  |                    |
+    |   FOR EACH OBJECT:|                  |                    |
+    |                   |                  |                    |
+    |   R-- (read-only)?|  → skip          |                    |
+    |   RW- (writable)? |  → would apply   |                    |
+    |                   |                  |                    |
+    |<-- dry-run report-|                  |                    |
+    |    45 would apply |                  |                    |
+    |    154 skipped    |                  |                    |
+    |    0 failed       |                  |                    |
+    |                   |                  |                    |
+    |                   |                  |                    |
+    |== APPLY (not dry-run): ==============|                    |
+    |                   |                  |                    |
+    |   FOR EACH RW-:   |                  |                    |
+    |                   |-- set_property ->|                    |
+    |                   |    (by obj ID)   |                    |
+    |                   |<-- ACK ---------|                    |
+    |                   |                  |                    |
+    |<-- applied 45 ----|                  |                    |
+    |                   |                  |                    |
+```
+
+---
+
+## 8. Browse (search DM + live values)
+
+```
+  CLI/API            Connector           Device            Library (disk)
+    |                   |                  |                    |
+    |-- browse -------->|                  |                    |
+    |   (--filter Temp  |                  |                    |
+    |    --slot 0)      |                  |                    |
+    |                   |                  |                    |
+    |                   |-- load DM ------>|----------------->  |
+    |                   |                  |  SHPRM1_5.3.5.json |
+    |                   |<----------------|<-----------------  |
+    |                   |                  |                    |
+    |                   |-- search DM ---->|                    |
+    |                   |  filter="Temp"   |                    |
+    |                   |  matches:        |                    |
+    |                   |   15212 PSU/1    |                    |
+    |                   |   15220 PSU/2    |                    |
+    |                   |   15529 PSU/BOARD|                    |
+    |                   |                  |                    |
+    |                   |-- get(15212) --->|                    |
+    |                   |<-- 20 C --------|                    |
+    |                   |-- get(15220) --->|                    |
+    |                   |<-- 20 C --------|                    |
+    |                   |-- get(15529) --->|                    |
+    |                   |<-- 0 C ---------|                    |
+    |                   |                  |                    |
+    |<-- results -------|                  |                    |
+    |  15212 PSU/1/Temp  20 C              |                    |
+    |  15220 PSU/2/Temp  20 C              |                    |
+    |  15529 PSU/B/Temp  0 C               |                    |
+    |                   |                  |                    |
+```
+
+---
+
+## 9. Startup with Stale Cache
+
+```
+  CLI/API            Connector           Device            Library (disk)
+    |                   |                  |                    |
+    |-- connect ------->|                  |                    |
+    |                   |-- TCP/UDP ------>|                    |
+    |                   |<--- connected ---|                    |
+    |                   |                  |                    |
+    |                   |-- load cache --->|----------------->  |
+    |                   |                  |  DM + stale values |
+    |                   |<----------------|<-----------------  |
+    |                   |                  |                    |
+    |<-- all objects ----|                  |                    |
+    |    [stale]        |                  |                    |
+    |                   |                  |                    |
+    |                   |-- subscribe ---->|                    |
+    |                   | (client view     |                    |
+    |                   |  objects first)  |                    |
+    |                   |                  |                    |
+    |                   |<-- announce -----|                    |
+    |<-- id=15212 ------|  [stale] → [live]|                    |
+    |    Temperature=20C|                  |                    |
+    |                   |                  |                    |
+    |                   |<-- announce -----|                    |
+    |<-- id=15219 ------|  [stale] → [live]|                    |
+    |    Fan Speed=10%  |                  |                    |
+    |                   |                  |                    |
+    |   SUBSCRIBED OBJECTS NOW [live]       |                    |
+    |                   |                  |                    |
+    |                   |     BACKGROUND:  |                    |
+    |                   |== walk rest ====>|                    |
+    |                   |  (non-subscribed |                    |
+    |                   |   objects)       |                    |
+    |                   |                  |                    |
+    |                   |<== walk done ====|                    |
+    |<-- all [live] ----|                  |                    |
+    |                   |                  |                    |
+    |                   |-- save cache --->|----------------->  |
+    |                   |                  |  DM + fresh values |
+    |                   |                  |                    |
+```


### PR DESCRIPTION
## What

Dedicated documentation page per protocol + streamlined README.

## Why

One page per protocol with everything: transport, firewall, identity, tree, get/set, subscribe, export, capture, test device. README links to them instead of inline comparison tables.

## Scope

- [x] docs

## Type

- [x] docs — documentation only

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `docs/protocols/acp1.md` | new | Full ACP1 connector reference |
| `docs/protocols/acp2.md` | new | Full ACP2 connector reference |
| `README.md` | modified | Protocol table links to pages |

## Approval

@yboujraf — requesting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)