### PR TITLE
feat(import): selective --id / --path filters (mutually exclusive)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Per-type element docs with realistic samples: [docs/protocols/elements/](docs/pr
 | `acp import --file X.yaml` | Apply values from YAML file | done | done |
 | `acp import --file X.csv` | Apply values from CSV file | done | done |
 | `acp import --dry-run` | Validate without writing | done | done |
+| `acp import --id N` / `--path P` | **Selective import** — narrow apply set to specific object(s). Mutually exclusive flags; both repeat. No `--label` (labels collide thousands of times) | done | done |
 
 Export/import rules:
 - Resolver key per protocol: **Ember+ = `oid`** (numeric dotted path), **ACP1 = `group` + `id`**, **ACP2 = `id`** (globally-unique u32)

--- a/cmd/acp/cmd_import.go
+++ b/cmd/acp/cmd_import.go
@@ -4,9 +4,40 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"acp/internal/export"
 )
+
+// multiInt and multiString let --id / --label / --path repeat on the
+// command line, building up a slice for the ImportFilter.
+type multiInt []int
+
+func (m *multiInt) String() string {
+	parts := make([]string, len(*m))
+	for i, v := range *m {
+		parts[i] = strconv.Itoa(v)
+	}
+	return strings.Join(parts, ",")
+}
+
+func (m *multiInt) Set(s string) error {
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return fmt.Errorf("--id value %q is not an integer", s)
+	}
+	*m = append(*m, n)
+	return nil
+}
+
+type multiString []string
+
+func (m *multiString) String() string { return strings.Join(*m, ",") }
+func (m *multiString) Set(s string) error {
+	*m = append(*m, s)
+	return nil
+}
 
 func runImport(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("import", flag.ExitOnError)
@@ -14,13 +45,34 @@ func runImport(ctx context.Context, args []string) error {
 	file := fs.String("file", "", "snapshot file (.json, .yaml, .csv)")
 	dry := fs.Bool("dry-run", false, "validate and list would-write actions without sending")
 	slot := fs.Int("slot", -1, "apply only this slot (-1 = all slots in snapshot)")
+
+	// Selective-import filters (issue #45). --id and --path are
+	// mutually exclusive — pick one addressing scheme per invocation.
+	// Multiple values of the same flag are fine: --id 1 --id 2 targets
+	// both objects; --path "A.B" --path "C.D" targets both paths.
+	//
+	// --label is deliberately NOT offered. Labels collide across
+	// sub-trees thousands of times in Ember+ ("gain" per channel) and
+	// in ACP2 ("Present" per PSU). The only unambiguous keys are the
+	// per-protocol ID and the dotted path — --label would be a
+	// footgun.
+	var filterIDs multiInt
+	var filterPaths multiString
+	fs.Var(&filterIDs, "id",
+		"apply only this object ID. Repeat for multiple IDs. Mutually exclusive with --path.")
+	fs.Var(&filterPaths, "path",
+		"apply only objects with this dotted path (e.g. \"BOARD.Gain A\"). Repeat for multiple. Mutually exclusive with --id.")
+
 	host, rest, err := popHost(args)
 	if err != nil {
-		return fmt.Errorf("usage: acp import <host> --file SNAPSHOT [--slot N] [--dry-run]")
+		return fmt.Errorf("usage: acp import <host> --file SNAPSHOT [--slot N] [--id N ...| --path P ...] [--dry-run]")
 	}
 	_ = fs.Parse(rest)
 	if *file == "" {
 		return fmt.Errorf("--file is required")
+	}
+	if len(filterIDs) > 0 && len(filterPaths) > 0 {
+		return fmt.Errorf("--id and --path are mutually exclusive; pick one addressing scheme")
 	}
 
 	snap, err := export.LoadSnapshot(*file)
@@ -41,6 +93,15 @@ func runImport(ctx context.Context, args []string) error {
 		}
 	}
 
+	// Apply --id / --path filtering in place. Count of removed objects
+	// surfaces in the report so the operator sees exactly how many
+	// snapshot rows were excluded before Apply ran.
+	filter := &export.ImportFilter{
+		IDs:   []int(filterIDs),
+		Paths: []string(filterPaths),
+	}
+	filteredOut := export.ApplyFilter(snap, filter)
+
 	plug, cleanup, err := connect(ctx, host, cf)
 	if err != nil {
 		return err
@@ -54,12 +115,18 @@ func runImport(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	rep.Filtered = filteredOut
 
 	tag := "applied"
 	if *dry {
 		tag = "would apply"
 	}
-	fmt.Printf("%s %d, skipped %d, failed %d\n", tag, rep.Applied, rep.Skipped, rep.Failed)
+	if rep.Filtered > 0 {
+		fmt.Printf("%s %d, skipped %d, failed %d, filtered %d\n",
+			tag, rep.Applied, rep.Skipped, rep.Failed, rep.Filtered)
+	} else {
+		fmt.Printf("%s %d, skipped %d, failed %d\n", tag, rep.Applied, rep.Skipped, rep.Failed)
+	}
 	if len(rep.Failures) > 0 {
 		fmt.Println("failures:")
 		for _, f := range rep.Failures {

--- a/cmd/acp/help.go
+++ b/cmd/acp/help.go
@@ -274,7 +274,7 @@ OUT  would apply 21, skipped 38, failed 0
          …
 
 USAGE
-  acp import <host> --file SNAPSHOT [--dry-run] [flags]
+  acp import <host> --file SNAPSHOT [--slot N] [--id N ...| --path P ...] [--dry-run] [flags]
 
 DESCRIPTION
   Reads a snapshot produced by 'acp export' (json / yaml / csv — format
@@ -288,18 +288,31 @@ DESCRIPTION
   slot, id, kind, access, and path printed so you know exactly which
   rows in your edited file will be ignored.
 
-  Partial import: hand-edit the file to keep only the rows you want
-  applied — the importer acts on whatever rows survive. Selective
-  addressing via --id / --label is tracked in #36 (not yet implemented).
+  Selective addressing (issue #45): narrow the apply set to specific
+  targets with --id (object ID, per-protocol unambiguous) or --path
+  (dotted hierarchical path). Both flags repeat. They are MUTUALLY
+  EXCLUSIVE — pick one scheme per invocation. --label is deliberately
+  not offered: labels collide thousands of times across sub-trees in
+  Ember+ ("gain" per channel) and ACP2 ("Present" per PSU), so
+  label-only matching would be ambiguous.
 
 FLAGS
   --file PATH        snapshot file (json / yaml / csv)        (required)
+  --slot N           apply only this slot (-1 = all, default)
+  --id N             apply only this object ID. Repeat for multiple.
+                     Mutually exclusive with --path.
+  --path P           apply only this dotted path (e.g. "BOARD.Gain A").
+                     Repeat for multiple. Mutually exclusive with --id.
   --dry-run          validate without writing; prints skip report
 
 EXAMPLES
   acp import 10.6.239.113 --file device.json --dry-run
   acp import 10.6.239.113 --file device.json
-  acp import 10.6.239.113 --file edited.csv                     # partial setup`)
+  acp import 10.6.239.113 --file edited.csv                      # partial setup via edited file
+  acp import 10.6.239.113 --file device.json --id 47431          # one specific object
+  acp import 10.6.239.113 --file device.json --id 47431 --id 60001
+  acp import 10.6.239.113 --file tree.json --path "router.inputs.ch2.gain"
+  acp import 10.6.239.113 --file device.json --slot 1 --path "BOARD.Gain A" --dry-run`)
 }
 
 func helpDiscover() {

--- a/internal/export/filter.go
+++ b/internal/export/filter.go
@@ -1,0 +1,86 @@
+package export
+
+import (
+	"strings"
+
+	"acp/internal/protocol"
+)
+
+// ImportFilter narrows an import operation to a specific subset of
+// objects. IDs and Paths are mutually exclusive addressing schemes —
+// callers choose one per invocation and pass only that slice. Empty
+// filter means "apply to everything" (today's default).
+//
+// Within the chosen slice, entries combine additively: passing two
+// IDs or two Paths targets both objects.
+//
+// Deliberately no Labels field: labels collide across sub-trees
+// thousands of times in Ember+ (per-channel "gain") and in ACP2
+// ("Present" under each PSU). Only ID and dotted Path are
+// unambiguous. A qualified label IS a dotted path, so --label would
+// just duplicate --path.
+//
+// Comparisons are exact and case-sensitive. Paths are matched after
+// the snapshot's Path slice is joined with "." so the user can write
+// --path "BOARD.Gain A" to target a single hierarchical element.
+//
+// Enforcement of mutual exclusion lives at the CLI / API boundary;
+// Matches() tolerates both being set for defensive behaviour in tests.
+type ImportFilter struct {
+	IDs   []int
+	Paths []string
+}
+
+// Empty reports whether the filter lets everything through.
+func (f *ImportFilter) Empty() bool {
+	if f == nil {
+		return true
+	}
+	return len(f.IDs) == 0 && len(f.Paths) == 0
+}
+
+// Matches reports whether the object satisfies at least one of the
+// filter's criteria. Called per object by ApplyFilter.
+func (f *ImportFilter) Matches(o protocol.Object) bool {
+	if f.Empty() {
+		return true
+	}
+	for _, id := range f.IDs {
+		if id == o.ID {
+			return true
+		}
+	}
+	if len(f.Paths) > 0 {
+		joined := strings.Join(o.Path, ".")
+		for _, p := range f.Paths {
+			if p == joined {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ApplyFilter mutates the snapshot in place, removing every object
+// that does not match the filter, and returns the count of objects
+// removed. Empty filter leaves the snapshot untouched and returns 0.
+//
+// Per-slot ordering is preserved for the objects that survive.
+func ApplyFilter(s *Snapshot, f *ImportFilter) int {
+	if f.Empty() {
+		return 0
+	}
+	removed := 0
+	for i := range s.Slots {
+		kept := s.Slots[i].Objects[:0]
+		for _, o := range s.Slots[i].Objects {
+			if f.Matches(o) {
+				kept = append(kept, o)
+			} else {
+				removed++
+			}
+		}
+		s.Slots[i].Objects = kept
+	}
+	return removed
+}

--- a/internal/export/importer.go
+++ b/internal/export/importer.go
@@ -21,9 +21,16 @@ var (
 // ImportReport collects per-object outcomes from Apply so callers can
 // print a summary without guessing.
 type ImportReport struct {
-	Applied  int
-	Skipped  int
-	Failed   int
+	Applied int
+	Skipped int
+	Failed  int
+	// Filtered is the count of objects excluded before Apply by an
+	// ImportFilter (e.g. --id / --label / --path flags). Different
+	// from Skipped — filtered objects were never considered for apply;
+	// skipped objects were considered and rejected by policy (read-only
+	// / unknown-kind / marker). Populated by the caller after
+	// ApplyFilter runs; Apply itself does not set this field.
+	Filtered int
 	DryRun   bool
 	Failures []string
 	// Skips lists every object that the importer deliberately did not

--- a/tests/unit/export/filter_test.go
+++ b/tests/unit/export/filter_test.go
@@ -1,0 +1,168 @@
+// Selective-import filter tests (issue #45).
+//
+// Verifies ImportFilter.Matches + ApplyFilter against the three
+// sample snapshots (ACP1, ACP2, Ember+) defined in csv_lossless_test.go
+// — covers every protocol's addressing model:
+//   - ACP1: per-group unique ID, labels unique within group
+//   - ACP2: globally-unique u32 ID, labels collide across sub-nodes
+//   - Ember+: OID-based, labels collide across channels
+//
+// No device required; pure in-memory snapshot manipulation.
+package export_test
+
+import (
+	"testing"
+
+	"acp/internal/export"
+	"acp/internal/protocol"
+)
+
+// TestFilter_EmptyPassesEverything — nil filter and zero-value filter
+// both leave the snapshot untouched and report zero removed. This is
+// today's default behaviour (no flags = apply all writable).
+func TestFilter_EmptyPassesEverything(t *testing.T) {
+	cases := []struct {
+		name   string
+		filter *export.ImportFilter
+	}{
+		{"nil", nil},
+		{"zero-value", &export.ImportFilter{}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			snap := acp2Snapshot()
+			before := countObjects(snap)
+			removed := export.ApplyFilter(snap, c.filter)
+			after := countObjects(snap)
+			if removed != 0 {
+				t.Errorf("removed got %d, want 0", removed)
+			}
+			if before != after {
+				t.Errorf("object count changed: %d → %d", before, after)
+			}
+		})
+	}
+}
+
+// TestFilter_ByID — filtering by ID narrows to exactly the listed
+// objects across all 3 protocols. Verifies the ACP2 duplicate-label
+// case specifically — PSU.1/Present (id=60001) and PSU.2/Present
+// (id=60002) both have label "Present" but are addressable by ID.
+func TestFilter_ByID(t *testing.T) {
+	snap := acp2Snapshot()
+	filter := &export.ImportFilter{IDs: []int{60001}}
+	removed := export.ApplyFilter(snap, filter)
+
+	// Original ACP2 snapshot: 4 objects. Keep 1, remove 3.
+	if removed != 3 {
+		t.Errorf("removed got %d, want 3", removed)
+	}
+	if n := countObjects(snap); n != 1 {
+		t.Fatalf("objects after filter got %d, want 1", n)
+	}
+	got := snap.Slots[0].Objects[0]
+	if got.ID != 60001 || got.Label != "Present" {
+		t.Errorf("surviving object got (id=%d label=%q), want (60001, \"Present\")",
+			got.ID, got.Label)
+	}
+}
+
+// TestFilter_ByPath — filtering by dotted path works when labels
+// collide. Ember+ test snapshot has two "gain" objects under
+// different channels; path selects one unambiguously.
+func TestFilter_ByPath(t *testing.T) {
+	snap := emberplusSnapshot()
+	filter := &export.ImportFilter{Paths: []string{"router.inputs.ch2.gain"}}
+	removed := export.ApplyFilter(snap, filter)
+
+	if removed != 2 {
+		t.Errorf("removed got %d, want 2", removed)
+	}
+	if n := countObjects(snap); n != 1 {
+		t.Fatalf("objects after filter got %d, want 1", n)
+	}
+	got := snap.Slots[0].Objects[0]
+	if got.OID != "1.2.2.3" {
+		t.Errorf("surviving object got OID %q, want \"1.2.2.3\"", got.OID)
+	}
+}
+
+// TestFilter_ByMultipleIDs — two IDs via repeated --id flags.
+func TestFilter_ByMultipleIDs(t *testing.T) {
+	snap := acp2Snapshot()
+	filter := &export.ImportFilter{IDs: []int{60001, 60002}}
+	removed := export.ApplyFilter(snap, filter)
+
+	if removed != 2 {
+		t.Errorf("removed got %d, want 2", removed)
+	}
+	if n := countObjects(snap); n != 2 {
+		t.Fatalf("objects after filter got %d, want 2", n)
+	}
+}
+
+// TestFilter_ByMultiplePaths — two paths via repeated --path flags.
+func TestFilter_ByMultiplePaths(t *testing.T) {
+	snap := emberplusSnapshot()
+	filter := &export.ImportFilter{
+		Paths: []string{"router.inputs.ch1.gain", "router.inputs.ch2.gain"},
+	}
+	removed := export.ApplyFilter(snap, filter)
+
+	if removed != 1 {
+		t.Errorf("removed got %d, want 1", removed)
+	}
+	if n := countObjects(snap); n != 2 {
+		t.Fatalf("objects after filter got %d, want 2", n)
+	}
+}
+
+// TestFilter_NoMatches — filter targets IDs/paths not present; every
+// object is removed. Protects against a silent-match bug.
+func TestFilter_NoMatches(t *testing.T) {
+	snap := acp1Snapshot()
+	before := countObjects(snap)
+	filter := &export.ImportFilter{IDs: []int{99999}}
+	removed := export.ApplyFilter(snap, filter)
+
+	if removed != before {
+		t.Errorf("removed got %d, want %d (all)", removed, before)
+	}
+	if n := countObjects(snap); n != 0 {
+		t.Errorf("objects after filter got %d, want 0", n)
+	}
+}
+
+// TestFilter_MatchesHelper — verifies the Matches predicate directly,
+// without ApplyFilter. Useful for future callers (REST API) that want
+// to evaluate filter membership per object.
+func TestFilter_MatchesHelper(t *testing.T) {
+	obj := protocol.Object{
+		ID:    42,
+		Label: "Gain",
+		Path:  []string{"BOARD", "Gain"},
+		OID:   "1.1.42",
+	}
+	cases := []struct {
+		name   string
+		filter *export.ImportFilter
+		want   bool
+	}{
+		{"empty filter matches", &export.ImportFilter{}, true},
+		{"id match", &export.ImportFilter{IDs: []int{42}}, true},
+		{"id mismatch", &export.ImportFilter{IDs: []int{99}}, false},
+		{"path match", &export.ImportFilter{Paths: []string{"BOARD.Gain"}}, true},
+		{"path mismatch", &export.ImportFilter{Paths: []string{"BOARD.Mute"}}, false},
+		{"id set but path set too — both checked", &export.ImportFilter{
+			IDs: []int{99}, Paths: []string{"BOARD.Gain"},
+		}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := c.filter.Matches(obj)
+			if got != c.want {
+				t.Errorf("Matches got %v, want %v", got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Narrow an \`acp import\` to specific target objects via:

- \`--id N\` — object ID, per-protocol unambiguous. Repeat for multiple.
- \`--path P\` — dotted hierarchical path. Repeat for multiple.

**Mutually exclusive** — pick one addressing scheme per invocation. Mixing errors at parse time.

No \`--label\` flag. Labels collide thousands of times across sub-trees in Ember+ (per-channel \`gain\`) and ACP2 (per-PSU \`Present\`). A qualified label IS a dotted path, so \`--path\` covers the case without ambiguity.

## Behaviour

| Invocation | Effect |
|---|---|
| \`acp import host --file s.json\` | Apply everything writable (unchanged default) |
| \`acp import host --file s.json --id 47431\` | Apply only object 47431 |
| \`acp import host --file s.json --id 47431 --id 60001\` | Apply both |
| \`acp import host --file s.json --path "BOARD.Gain A"\` | Apply only this path |
| \`acp import host --file s.json --id 47431 --path "X.Y"\` | **Error** — mutually exclusive |

## Summary line

| Case | Output |
|---|---|
| No filter used | \`applied N, skipped M, failed X\` |
| Filter used | \`applied N, skipped M, failed X, filtered Y\` |

\`filtered\` is a new \`ImportReport.Filtered\` counter — distinct from \`skipped\` (rejected-by-policy at apply time). Filtered = "not even considered for apply because the filter excluded them".

## Files

| File | Change |
|---|---|
| \`internal/export/filter.go\` | **new** — \`ImportFilter{IDs, Paths}\` + \`ApplyFilter(snap, filter)\` returning removed count |
| \`internal/export/importer.go\` | \`ImportReport.Filtered\` field |
| \`cmd/acp/cmd_import.go\` | \`multiInt\` + \`multiString\` flag types; mutual-exclusion validated at parse |
| \`cmd/acp/help.go\` | New IN/OUT examples + flag block |
| \`README.md\` | CLI table row for selective import |
| \`tests/unit/export/filter_test.go\` | **new** — 6 tests covering all 3 protocols, duplicate-label cases for Ember+ + ACP2 |

## Test plan

- [x] \`TestFilter_EmptyPassesEverything\` — nil + zero-value filter
- [x] \`TestFilter_ByID\` — ACP2 duplicate-\`Present\` disambiguated by ID
- [x] \`TestFilter_ByPath\` — Ember+ duplicate-\`gain\` disambiguated by path
- [x] \`TestFilter_ByMultipleIDs\` — repeated \`--id\`
- [x] \`TestFilter_ByMultiplePaths\` — repeated \`--path\`
- [x] \`TestFilter_NoMatches\` — all removed when no match
- [x] \`TestFilter_MatchesHelper\` — predicate direct tests (6 sub-cases)
- [x] \`go build\` + \`go vet\` + \`go test ./...\` all green
- [x] pre-commit hook (go vet + golangci-lint) — 0 issues
- [ ] CI matrix green

## Scope exchange

See [issue comment on #45](https://github.com/by-openclaw/go-acp/issues/45#issuecomment-4276440746) for the discussion summary explaining why \`--label\` was dropped and why \`--id\` / \`--path\` became mutually exclusive.

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)