### PR TITLE
feat(extract): acp extract — per-product DM triple into fixture layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Per-type element docs with realistic samples: [docs/protocols/elements/](docs/pr
 | `acp import --file X.csv` | Apply values from CSV file | done | done |
 | `acp import --dry-run` | Validate without writing | done | done |
 | `acp import --id N` / `--path P` | **Selective import** — narrow apply set to specific object(s). Mutually exclusive flags; both repeat. No `--label` (labels collide thousands of times) | done | done |
+| `acp extract` | Walk a device and emit the DM fixture triple (`meta.json` + `wire.jsonl` + `tree.json`) into `tests/fixtures/products/<manufacturer>/<product>/<protocol>/<version>/`. `meta.json` carries the SHA-256 fingerprint + `capture_tool` build provenance (version + git_tag + git_commit). | done | done |
 
 Export/import rules:
 - Resolver key per protocol: **Ember+ = `oid`** (numeric dotted path), **ACP1 = `group` + `id`**, **ACP2 = `id`** (globally-unique u32)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Per-type element docs with realistic samples: [docs/protocols/elements/](docs/pr
 | `acp import --file X.csv` | Apply values from CSV file | done | done |
 | `acp import --dry-run` | Validate without writing | done | done |
 | `acp import --id N` / `--path P` | **Selective import** — narrow apply set to specific object(s). Mutually exclusive flags; both repeat. No `--label` (labels collide thousands of times) | done | done |
-| `acp extract` | Walk a device and emit the DM fixture triple (`meta.json` + `wire.jsonl` + `tree.json`) into `tests/fixtures/products/<manufacturer>/<product>/<protocol>/<version>/`. `meta.json` carries the SHA-256 fingerprint + `capture_tool` build provenance (version + git_tag + git_commit). | done | done |
+| `acp extract` | Walk a device and emit the DM fixture triple (`meta.json` + `wire.jsonl` + `tree.json`) into `tests/fixtures/products/<manufacturer>/<product>/<protocol>/<direction>/<version>/` where `<direction>` is `consumer`/`provider`/`both`. `meta.json` carries the SHA-256 fingerprint + `capture_tool` build provenance (version + git_tag + git_commit). | done | done |
 
 Export/import rules:
 - Resolver key per protocol: **Ember+ = `oid`** (numeric dotted path), **ACP1 = `group` + `id`**, **ACP2 = `id`** (globally-unique u32)

--- a/cmd/acp/buildinfo.go
+++ b/cmd/acp/buildinfo.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"runtime/debug"
+	"strings"
+)
+
+// captureToolInfo carries the four fields the meta.json capture_tool
+// object requires (issue #47, fixture schema from #43).
+type captureToolInfo struct {
+	Name      string `json:"name"`
+	Version   string `json:"version"`
+	GitTag    string `json:"git_tag"`
+	GitCommit string `json:"git_commit"`
+}
+
+// buildCaptureToolInfo assembles the struct at capture time. Reads
+// runtime/debug.BuildInfo.Settings for `vcs.revision` + `vcs.modified`
+// (populated by `go build -buildvcs=true`, default since Go 1.18).
+// A dirty worktree flags the git_tag with a "-dirty" suffix so such
+// captures are easy to refuse committing.
+func buildCaptureToolInfo() captureToolInfo {
+	info := captureToolInfo{
+		Name:    "acp",
+		Version: version,
+		GitTag:  gitTag,
+	}
+	if info.Version == "" || info.Version == "dev" {
+		info.Version = "devel"
+	}
+
+	// Prefer ldflags-injected `commit` (package-level var in main.go);
+	// fall back to runtime/debug.BuildInfo (populated by
+	// `go build -buildvcs=true`, default since Go 1.18).
+	vcsCommit := commit
+	var modified bool
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		for _, s := range bi.Settings {
+			switch s.Key {
+			case "vcs.revision":
+				if vcsCommit == "" {
+					vcsCommit = s.Value
+				}
+			case "vcs.modified":
+				modified = s.Value == "true"
+			}
+		}
+	}
+
+	switch {
+	case len(vcsCommit) >= 7:
+		info.GitCommit = vcsCommit[:7]
+	case vcsCommit != "":
+		info.GitCommit = vcsCommit
+	default:
+		info.GitCommit = "unknown"
+	}
+
+	if info.GitTag == "" {
+		if vcsCommit != "" {
+			info.GitTag = "devel-" + info.GitCommit
+		} else {
+			info.GitTag = "devel"
+		}
+	}
+
+	if modified && !strings.HasSuffix(info.GitTag, "-dirty") {
+		info.GitTag += "-dirty"
+	}
+
+	return info
+}

--- a/cmd/acp/cmd_extract.go
+++ b/cmd/acp/cmd_extract.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// runExtract drives `acp extract` (issue #47) — walks a device and
+// writes the product-fixture triple (meta + wire + tree) into the
+// output directory using the schema locked in #43.
+func runExtract(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("extract", flag.ExitOnError)
+	cf := addCommonFlags(fs)
+
+	manufacturer := fs.String("manufacturer", "",
+		"vendor display name preserving casing (e.g. Axon, Lawo). Required.")
+	product := fs.String("product", "",
+		"product identifier as the vendor writes it (e.g. DDB08, CDV08v06). Required.")
+	ver := fs.String("version", "",
+		"product / firmware version as reported by the device (e.g. 2.3). Required.")
+	versionKind := fs.String("version-kind", "firmware",
+		"firmware | software | release")
+	description := fs.String("description", "",
+		"free-text description from the device identity block (optional)")
+	notes := fs.String("notes", "",
+		"free-text notes for the engineer who captured (optional)")
+	outDir := fs.String("out", "",
+		"output directory (e.g. tests/fixtures/products/axon/DDB08/acp2/v2.3/). Required.")
+	slot := fs.Int("slot", -1, "slot to walk (Ember+ defaults to 0 if omitted)")
+
+	host, rest, err := popHost(args)
+	if err != nil {
+		return fmt.Errorf("usage: acp extract <host> --protocol P --manufacturer M --product P --version V --out DIR [--slot N]")
+	}
+	_ = fs.Parse(rest)
+
+	if *manufacturer == "" || *product == "" || *ver == "" || *outDir == "" {
+		return fmt.Errorf("--manufacturer, --product, --version, and --out are all required")
+	}
+
+	if cf.protocol == "emberplus" && *slot < 0 {
+		*slot = 0
+	}
+	if *slot < 0 {
+		return fmt.Errorf("--slot N is required (except Ember+)")
+	}
+
+	if err := os.MkdirAll(*outDir, 0o755); err != nil {
+		return fmt.Errorf("create --out dir: %w", err)
+	}
+
+	// Point capture at the out-dir so the walk's frame recorder and
+	// canonical-export writer both land there. The isDirectoryCapture
+	// heuristic treats a path without .jsonl extension as dir mode.
+	cf.capture = *outDir
+
+	plug, cleanup, err := connect(ctx, host, cf)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	// Walk raw ctx (no per-op timeout) — large devices take minutes.
+	objs, err := plug.Walk(ctx, *slot)
+	if err != nil {
+		return fmt.Errorf("walk slot %d: %w", *slot, err)
+	}
+	fmt.Printf("walked %d objects on slot %d\n", len(objs), *slot)
+
+	// writeCanonicalCapture (from cmd_walk.go) emits tree.json for
+	// every plugin type. Ember+ additionally writes glow.json; that's
+	// fine — tree.json is the fingerprint input.
+	if err := writeCanonicalCapture(ctx, *outDir, plug, cf); err != nil {
+		return fmt.Errorf("canonical capture: %w", err)
+	}
+
+	// Rename raw.<transport>.jsonl → wire.jsonl so the fixture layout
+	// matches docs/fixtures-products.md exactly (the protocol is still
+	// identifiable via meta.json). Best-effort: a missing raw file
+	// isn't fatal (recorder may have been inactive for brief walks).
+	rawPath := filepath.Join(*outDir, rawFrameFilename(cf.protocol))
+	wirePath := filepath.Join(*outDir, "wire.jsonl")
+	if err := os.Rename(rawPath, wirePath); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: rename %s → wire.jsonl: %v\n",
+			filepath.Base(rawPath), err)
+	}
+
+	treePath := filepath.Join(*outDir, "tree.json")
+	fingerprint, err := sha256File(treePath)
+	if err != nil {
+		return fmt.Errorf("fingerprint tree.json: %w", err)
+	}
+
+	meta := metaJSON{
+		Protocol:      cf.protocol,
+		Manufacturer:  *manufacturer,
+		Product:       *product,
+		Version:       *ver,
+		VersionKind:   *versionKind,
+		DiscoveredAt:  time.Now().UTC().Format(time.RFC3339),
+		Description:   *description,
+		DMFingerprint: fingerprint,
+		ObjectCount:   len(objs),
+		CaptureTool:   buildCaptureToolInfo(),
+		Notes:         *notes,
+	}
+	if err := writeMetaJSON(filepath.Join(*outDir, "meta.json"), &meta); err != nil {
+		return fmt.Errorf("write meta.json: %w", err)
+	}
+
+	fmt.Printf("extract complete: %s/{meta.json, wire.jsonl, tree.json}\n", *outDir)
+	fmt.Printf("  fingerprint: %s\n", fingerprint)
+	return nil
+}
+
+// metaJSON mirrors the locked schema in docs/fixtures-products.md.
+// Unexported on purpose — external consumers read the JSON file, not
+// the Go struct.
+type metaJSON struct {
+	Protocol      string          `json:"protocol"`
+	Manufacturer  string          `json:"manufacturer"`
+	Product       string          `json:"product"`
+	Version       string          `json:"version"`
+	VersionKind   string          `json:"version_kind"`
+	DiscoveredAt  string          `json:"discovered_at"`
+	Description   string          `json:"description,omitempty"`
+	DMFingerprint string          `json:"dm_fingerprint"`
+	ObjectCount   int             `json:"object_count"`
+	CaptureTool   captureToolInfo `json:"capture_tool"`
+	Notes         string          `json:"notes,omitempty"`
+}
+
+// sha256File streams the named file through a SHA-256 digest and
+// returns the `sha256:<hex>` form used by meta.json.dm_fingerprint.
+// Any byte-identical tree.json produces the identical fingerprint —
+// the property replay tests rely on.
+func sha256File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// writeMetaJSON emits indented JSON so the file is diff-friendly in
+// git. Keys follow the struct field order.
+func writeMetaJSON(path string, m *metaJSON) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	return enc.Encode(m)
+}

--- a/cmd/acp/cmd_extract.go
+++ b/cmd/acp/cmd_extract.go
@@ -24,6 +24,8 @@ func runExtract(ctx context.Context, args []string) error {
 		"vendor display name preserving casing (e.g. Axon, Lawo). Required.")
 	product := fs.String("product", "",
 		"product identifier as the vendor writes it (e.g. DDB08, CDV08v06). Required.")
+	direction := fs.String("direction", "",
+		"how the product speaks this protocol: consumer (we read it), provider (we expose it), or both. Required.")
 	ver := fs.String("version", "",
 		"product / firmware version as reported by the device (e.g. 2.3). Required.")
 	versionKind := fs.String("version-kind", "firmware",
@@ -38,12 +40,17 @@ func runExtract(ctx context.Context, args []string) error {
 
 	host, rest, err := popHost(args)
 	if err != nil {
-		return fmt.Errorf("usage: acp extract <host> --protocol P --manufacturer M --product P --version V --out DIR [--slot N]")
+		return fmt.Errorf("usage: acp extract <host> --protocol P --manufacturer M --product X --direction D --version V --out DIR [--slot N]")
 	}
 	_ = fs.Parse(rest)
 
-	if *manufacturer == "" || *product == "" || *ver == "" || *outDir == "" {
-		return fmt.Errorf("--manufacturer, --product, --version, and --out are all required")
+	if *manufacturer == "" || *product == "" || *direction == "" || *ver == "" || *outDir == "" {
+		return fmt.Errorf("--manufacturer, --product, --direction, --version, and --out are all required")
+	}
+	switch *direction {
+	case "consumer", "provider", "both":
+	default:
+		return fmt.Errorf("--direction must be one of: consumer, provider, both (got %q)", *direction)
 	}
 
 	if cf.protocol == "emberplus" && *slot < 0 {
@@ -103,6 +110,7 @@ func runExtract(ctx context.Context, args []string) error {
 		Protocol:      cf.protocol,
 		Manufacturer:  *manufacturer,
 		Product:       *product,
+		Direction:     *direction,
 		Version:       *ver,
 		VersionKind:   *versionKind,
 		DiscoveredAt:  time.Now().UTC().Format(time.RFC3339),
@@ -128,6 +136,7 @@ type metaJSON struct {
 	Protocol      string          `json:"protocol"`
 	Manufacturer  string          `json:"manufacturer"`
 	Product       string          `json:"product"`
+	Direction     string          `json:"direction"`
 	Version       string          `json:"version"`
 	VersionKind   string          `json:"version_kind"`
 	DiscoveredAt  string          `json:"discovered_at"`

--- a/cmd/acp/cmd_extract_test.go
+++ b/cmd/acp/cmd_extract_test.go
@@ -64,6 +64,7 @@ func TestMetaJSONRoundTrip(t *testing.T) {
 		Protocol:      "acp2",
 		Manufacturer:  "Axon",
 		Product:       "DDB08",
+		Direction:     "consumer",
 		Version:       "2.3",
 		VersionKind:   "firmware",
 		DiscoveredAt:  "2026-04-19T13:20:00Z",
@@ -97,7 +98,7 @@ func TestMetaJSONRoundTrip(t *testing.T) {
 	// Schema stability: make sure the wire JSON has the keys downstream
 	// tools depend on. Drift here breaks every replay test.
 	wantKeys := []string{
-		`"protocol"`, `"manufacturer"`, `"product"`, `"version"`,
+		`"protocol"`, `"manufacturer"`, `"product"`, `"direction"`, `"version"`,
 		`"version_kind"`, `"discovered_at"`, `"dm_fingerprint"`,
 		`"object_count"`, `"capture_tool"`, `"name"`, `"git_tag"`, `"git_commit"`,
 	}

--- a/cmd/acp/cmd_extract_test.go
+++ b/cmd/acp/cmd_extract_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSHA256File — byte-identical tree.json produces the identical
+// fingerprint. Protects the replay-test contract documented in
+// docs/fixtures-products.md.
+func TestSHA256File(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "tree.json")
+	if err := os.WriteFile(p, []byte(`{"protocol":"acp2","n":42}`), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	first, err := sha256File(p)
+	if err != nil {
+		t.Fatalf("sha256: %v", err)
+	}
+	second, err := sha256File(p)
+	if err != nil {
+		t.Fatalf("sha256 second read: %v", err)
+	}
+	if first != second {
+		t.Errorf("fingerprint non-deterministic: %q vs %q", first, second)
+	}
+	if !strings.HasPrefix(first, "sha256:") || len(first) != len("sha256:")+64 {
+		t.Errorf("fingerprint shape unexpected: %q", first)
+	}
+}
+
+// TestSHA256File_DifferentBytes — different content = different
+// fingerprint. Ensures meta.json.dm_fingerprint actually discriminates.
+func TestSHA256File_DifferentBytes(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.json")
+	b := filepath.Join(dir, "b.json")
+	if err := os.WriteFile(a, []byte(`{"v":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(b, []byte(`{"v":2}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fa, _ := sha256File(a)
+	fb, _ := sha256File(b)
+	if fa == fb {
+		t.Errorf("expected different fingerprints, both are %s", fa)
+	}
+}
+
+// TestMetaJSONRoundTrip — write + read with the locked schema. Catches
+// any field-name drift between the Go struct and the persisted JSON
+// (the docs/fixtures-products.md schema is load-bearing for every
+// replay test downstream).
+func TestMetaJSONRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "meta.json")
+	in := &metaJSON{
+		Protocol:      "acp2",
+		Manufacturer:  "Axon",
+		Product:       "DDB08",
+		Version:       "2.3",
+		VersionKind:   "firmware",
+		DiscoveredAt:  "2026-04-19T13:20:00Z",
+		Description:   "ACP2 Audio Processor card",
+		DMFingerprint: "sha256:abc",
+		ObjectCount:   214,
+		CaptureTool: captureToolInfo{
+			Name:      "acp",
+			Version:   "0.3.0",
+			GitTag:    "v0.3.0",
+			GitCommit: "7bfc8ab",
+		},
+		Notes: "smoke test",
+	}
+	if err := writeMetaJSON(p, in); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	blob, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var out metaJSON
+	if err := json.Unmarshal(blob, &out); err != nil {
+		t.Fatalf("unmarshal: %v\nbody:\n%s", err, blob)
+	}
+	if out != *in {
+		t.Errorf("round-trip diverged:\n  in:  %+v\n  out: %+v", in, out)
+	}
+
+	// Schema stability: make sure the wire JSON has the keys downstream
+	// tools depend on. Drift here breaks every replay test.
+	wantKeys := []string{
+		`"protocol"`, `"manufacturer"`, `"product"`, `"version"`,
+		`"version_kind"`, `"discovered_at"`, `"dm_fingerprint"`,
+		`"object_count"`, `"capture_tool"`, `"name"`, `"git_tag"`, `"git_commit"`,
+	}
+	for _, k := range wantKeys {
+		if !strings.Contains(string(blob), k) {
+			t.Errorf("meta.json missing expected key %s", k)
+		}
+	}
+}
+
+// TestBuildCaptureToolInfo — always returns name=acp and populates
+// GitTag / GitCommit with non-empty fallbacks even when no ldflags
+// are set. Guarantees meta.json never emits blank provenance fields.
+func TestBuildCaptureToolInfo(t *testing.T) {
+	info := buildCaptureToolInfo()
+	if info.Name != "acp" {
+		t.Errorf("Name got %q, want %q", info.Name, "acp")
+	}
+	if info.Version == "" {
+		t.Errorf("Version must not be empty")
+	}
+	if info.GitTag == "" {
+		t.Errorf("GitTag must not be empty")
+	}
+	if info.GitCommit == "" {
+		t.Errorf("GitCommit must not be empty")
+	}
+}

--- a/cmd/acp/help.go
+++ b/cmd/acp/help.go
@@ -266,15 +266,15 @@ func helpExtract() {
 	fmt.Println(`acp extract — capture a per-product DM triple into the fixture layout
 
 IN   acp extract 10.41.40.195 --protocol acp2 --slot 0 \
-       --manufacturer Axon --product DDB08 --version 2.3 \
-       --out tests/fixtures/products/axon/DDB08/acp2/v2.3/
+       --manufacturer Axon --product DDB08 --direction consumer --version 2.3 \
+       --out tests/fixtures/products/axon/DDB08/acp2/consumer/v2.3/
 OUT  walked 214 objects on slot 0
-     capture: wrote tree.json to tests/fixtures/products/axon/DDB08/acp2/v2.3/
-     extract complete: tests/fixtures/products/axon/DDB08/acp2/v2.3/{meta.json, wire.jsonl, tree.json}
+     capture: wrote tree.json to tests/fixtures/products/axon/DDB08/acp2/consumer/v2.3/
+     extract complete: tests/fixtures/products/axon/DDB08/acp2/consumer/v2.3/{meta.json, wire.jsonl, tree.json}
        fingerprint: sha256:3fa1c4e8abcd...
 
 USAGE
-  acp extract <host> --protocol P --manufacturer M --product X --version V --out DIR [--slot N] [flags]
+  acp extract <host> --protocol P --manufacturer M --product X --direction D --version V --out DIR [--slot N] [flags]
 
 DESCRIPTION
   Walks the target device (all protocols) and produces the three-file
@@ -300,6 +300,7 @@ DESCRIPTION
 FLAGS
   --manufacturer M    vendor display name (preserve casing)      (required)
   --product P         product identifier as vendor writes it     (required)
+  --direction D       consumer | provider | both                 (required)
   --version V         version as reported by the device          (required)
   --version-kind K    firmware | software | release (default firmware)
   --description S     free text from the identity block          (optional)
@@ -309,12 +310,12 @@ FLAGS
 
 EXAMPLES
   acp extract 10.6.239.113 --protocol acp1 --slot 1 \
-    --manufacturer Axon --product CDV08v06 --version 2.1 \
-    --out tests/fixtures/products/axon/CDV08v06/acp1/v2.1/
+    --manufacturer Axon --product CDV08v06 --direction consumer --version 2.1 \
+    --out tests/fixtures/products/axon/CDV08v06/acp1/consumer/v2.1/
 
   acp extract 127.0.0.1 --protocol emberplus --port 9092 \
-    --manufacturer L-S-B --product TinyEmberPlus --version 1.0 \
-    --out tests/fixtures/products/l-s-b/TinyEmberPlus/emberplus/v1.0/`)
+    --manufacturer L-S-B --product TinyEmberPlus --direction consumer --version 1.0 \
+    --out tests/fixtures/products/l-s-b/TinyEmberPlus/emberplus/consumer/v1.0/`)
 }
 
 func helpImport() {

--- a/cmd/acp/help.go
+++ b/cmd/acp/help.go
@@ -262,6 +262,61 @@ EXAMPLES
   acp export 10.6.239.113 > device.json`)
 }
 
+func helpExtract() {
+	fmt.Println(`acp extract — capture a per-product DM triple into the fixture layout
+
+IN   acp extract 10.41.40.195 --protocol acp2 --slot 0 \
+       --manufacturer Axon --product DDB08 --version 2.3 \
+       --out tests/fixtures/products/axon/DDB08/acp2/v2.3/
+OUT  walked 214 objects on slot 0
+     capture: wrote tree.json to tests/fixtures/products/axon/DDB08/acp2/v2.3/
+     extract complete: tests/fixtures/products/axon/DDB08/acp2/v2.3/{meta.json, wire.jsonl, tree.json}
+       fingerprint: sha256:3fa1c4e8abcd...
+
+USAGE
+  acp extract <host> --protocol P --manufacturer M --product X --version V --out DIR [--slot N] [flags]
+
+DESCRIPTION
+  Walks the target device (all protocols) and produces the three-file
+  DM fixture triple at --out:
+
+    meta.json    locked schema — identity, fingerprint, capture_tool
+    wire.jsonl   raw frames captured during the walk (renamed from
+                 raw.<transport>.jsonl so the fixture layout stays
+                 protocol-agnostic)
+    tree.json    canonical export (post-resolution)
+
+  capture_tool carries the name + version + git_tag + git_commit of
+  the acp binary that did the capture. git_commit comes from
+  runtime/debug.BuildInfo (default -buildvcs=true); version + git_tag
+  come from ldflags on release builds, fall back to "devel" / a
+  commit-derived string otherwise. A dirty worktree flags git_tag
+  with "-dirty" — such captures should not be committed.
+
+  dm_fingerprint is the SHA-256 of tree.json. Byte-identical firmware
+  produces identical fingerprints across captures; a drift means
+  either the firmware changed or the canonical encoder moved.
+
+FLAGS
+  --manufacturer M    vendor display name (preserve casing)      (required)
+  --product P         product identifier as vendor writes it     (required)
+  --version V         version as reported by the device          (required)
+  --version-kind K    firmware | software | release (default firmware)
+  --description S     free text from the identity block          (optional)
+  --notes S           free text for the engineer                 (optional)
+  --out DIR           destination directory                      (required)
+  --slot N            slot to walk (Ember+ defaults to 0)
+
+EXAMPLES
+  acp extract 10.6.239.113 --protocol acp1 --slot 1 \
+    --manufacturer Axon --product CDV08v06 --version 2.1 \
+    --out tests/fixtures/products/axon/CDV08v06/acp1/v2.1/
+
+  acp extract 127.0.0.1 --protocol emberplus --port 9092 \
+    --manufacturer L-S-B --product TinyEmberPlus --version 1.0 \
+    --out tests/fixtures/products/l-s-b/TinyEmberPlus/emberplus/v1.0/`)
+}
+
 func helpImport() {
 	fmt.Println(`acp import — apply values from a snapshot file
 

--- a/cmd/acp/main.go
+++ b/cmd/acp/main.go
@@ -29,10 +29,17 @@ import (
 )
 
 // Build-time variables injected via -ldflags. See Makefile LDFLAGS_FULL.
+// Consumed by buildCaptureToolInfo (cmd_extract.go) + --version flag.
+//
+//	-X main.version=0.3.0  -X main.commit=7bfc8ab  -X main.gitTag=v0.3.0
+//
+// `commit` and `gitTag` have sensible fall-backs derived from
+// runtime/debug.BuildInfo when the ldflags are absent.
 var (
 	version = "dev"
-	commit  = "unknown"
+	commit  = ""
 	date    = "unknown"
+	gitTag  = ""
 )
 
 // command is one dispatch entry. short is for the top-level index; help
@@ -55,6 +62,7 @@ var commands = []command{
 	{"watch", "subscribe to live announcements", helpWatch, runWatch},
 	{"export", "dump a walked device to json / yaml / csv", helpExport, runExport},
 	{"import", "apply values from a json snapshot file", helpImport, runImport},
+	{"extract", "capture a per-product DM triple (meta + wire + tree) into the fixture layout", helpExtract, runExtract},
 	{"convert", "translate a snapshot file between json / yaml / csv (offline)", helpConvert, runConvert},
 	{"discover", "passive + active scan for devices on the local subnet", helpDiscover, runDiscover},
 	{"matrix", "set matrix crosspoint connections (Ember+ only)", helpMatrix, runMatrix},
@@ -194,6 +202,8 @@ IN / OUT — one-line contract per command (see "acp help <cmd>" for full detail
                     OUT stream of announcements until Ctrl-C
   export            IN  acp export <host> --format json|yaml|csv --out FILE
                     OUT snapshot file (json/yaml lossless, csv flat)
+  extract           IN  acp extract <host> --protocol P --manufacturer M --product X --version V --out DIR
+                    OUT writes meta.json + wire.jsonl + tree.json; prints fingerprint
   import            IN  acp import <host> --file SNAPSHOT [--dry-run]
                     OUT applied/skipped/failed counts; dry-run prints skip table
   convert           IN  acp convert --in FILE --out FILE            (offline)

--- a/cmd/acp/main.go
+++ b/cmd/acp/main.go
@@ -202,7 +202,7 @@ IN / OUT — one-line contract per command (see "acp help <cmd>" for full detail
                     OUT stream of announcements until Ctrl-C
   export            IN  acp export <host> --format json|yaml|csv --out FILE
                     OUT snapshot file (json/yaml lossless, csv flat)
-  extract           IN  acp extract <host> --protocol P --manufacturer M --product X --version V --out DIR
+  extract           IN  acp extract <host> --protocol P --manufacturer M --product X --direction D --version V --out DIR
                     OUT writes meta.json + wire.jsonl + tree.json; prints fingerprint
   import            IN  acp import <host> --file SNAPSHOT [--dry-run]
                     OUT applied/skipped/failed counts; dry-run prints skip table

--- a/docs/fixtures-products.md
+++ b/docs/fixtures-products.md
@@ -12,14 +12,15 @@ tests/fixtures/products/
 └── <manufacturer>/                     axon | lawo | dhd | by-systems | ...
     └── <product>/                      DDB08 | CDV08v06 | mc56 | xs-core | ...
         └── <protocol>/                 acp1 | acp2 | emberplus
-            ├── CHANGELOG.md            generated on each new version add
-            └── <version>/              v2.3 | 9092 | firmware-A.B.C
-                ├── meta.json           identity, fingerprint, source tool
-                ├── wire.jsonl          raw frames (replay source)
-                └── tree.json           canonical export (replay destination)
+            └── <direction>/            consumer | provider | both
+                ├── CHANGELOG.md        generated on each new version add
+                └── <version>/          v2.3 | 9092 | firmware-A.B.C
+                    ├── meta.json       identity, fingerprint, source tool
+                    ├── wire.jsonl      raw frames (replay source)
+                    └── tree.json       canonical export (replay destination)
 ```
 
-A product folder can contain multiple protocol subfolders — one physical card sometimes exposes several interfaces (e.g. an Axon DDB08 speaking both ACP2 and Ember+). Each protocol has its own version lineage and its own `CHANGELOG.md`.
+A product folder can contain multiple protocol subfolders — one physical card sometimes exposes several interfaces (e.g. an Axon DDB08 speaking both ACP2 and Ember+). Each protocol can further split by **direction**: the same product speaks `consumer` (we read the device), `provider` (we expose a tree to external consumers), or `both` on a given protocol. Provider-side DMs usually differ from consumer-side (extra RPC / stream / write endpoints), so direction is its own segment with its own version lineage and its own `CHANGELOG.md`.
 
 ### Slug rules
 
@@ -28,6 +29,7 @@ A product folder can contain multiple protocol subfolders — one physical card 
 | `<manufacturer>` | lowercase, hyphen for spaces | Vendor slug. `axon`, `lawo`, `dhd`, `by-systems`, `calrec`. |
 | `<product>` | preserve vendor casing | Product identifier as the vendor writes it. `DDB08`, `CDV08v06`, `mc56`, `xs-core`. No spaces — replace with hyphens. |
 | `<protocol>` | lowercase | Exactly one of `acp1`, `acp2`, `emberplus`. |
+| `<direction>` | lowercase | Exactly one of `consumer`, `provider`, `both`. Use `both` only when the same DM holds in both roles — if consumer-side and provider-side differ at all, use two separate folders. |
 | `<version>` | as reported by device | ACP1/ACP2: firmware version from identity block (`v2.3`, `2.3.1`). Ember+: provider port or named release (`9092`, `lawo-v7.12`). Use what the device itself returns so lookup is deterministic. |
 
 ---
@@ -41,6 +43,7 @@ Locked schema. Extra keys allowed but not required.
   "protocol": "acp2",
   "manufacturer": "Axon",
   "product": "DDB08",
+  "direction": "consumer",
   "version": "2.3",
   "version_kind": "firmware",
   "discovered_at": "2026-04-19T13:20:00Z",
@@ -62,6 +65,7 @@ Locked schema. Extra keys allowed but not required.
 | `protocol` | yes | One of `acp1`, `acp2`, `emberplus` — matches the directory segment. |
 | `manufacturer` | yes | Vendor name, preserving vendor casing (`Axon`, `Lawo`, `DHD`). Directory segment uses the lowercase slug form. |
 | `product` | yes | Product identifier — matches the directory segment. |
+| `direction` | yes | `consumer` / `provider` / `both` — matches the directory segment. Determines how the product speaks this protocol: we read it (consumer), we expose it (provider), or both. |
 | `version` | yes | Version string — matches the directory segment. |
 | `version_kind` | yes | `firmware` for hardware devices, `software` for Ember+/soft providers, `release` for named releases. |
 | `discovered_at` | yes | UTC ISO-8601 with second precision. Timestamp of the capture run, not a DM property — included so fixtures can be audited. |
@@ -112,7 +116,7 @@ Identical firmware → identical fingerprint across captures. Different fingerpr
 
 ## `CHANGELOG.md` per product-protocol
 
-One `CHANGELOG.md` per `<manufacturer>/<product>/<protocol>/` folder. A dual-protocol product (e.g. DDB08 exposed on both ACP2 and Ember+) gets two independent changelogs because each protocol's DM evolves on its own cadence.
+One `CHANGELOG.md` per `<manufacturer>/<product>/<protocol>/<direction>/` folder. A dual-protocol product (e.g. DDB08 exposed on both ACP2 and Ember+) gets two independent changelogs because each protocol's DM evolves on its own cadence. A protocol that's spoken in two directions (we both read and publish) gets one changelog per direction when the DM differs between roles.
 
 Generated on new version addition by `acp diff <existing-version> <new-version>` (#36.c).
 
@@ -151,10 +155,11 @@ Ordering: newest version at top. Initial capture at bottom with "Initial capture
 1. **Fixtures under `products/` are generated, never hand-edited.** If a file is wrong, fix the generator and regenerate.
 2. **One product per `<manufacturer>/<product>/` folder.** Different vendor products in different folders even if similar.
 3. **One protocol per `<manufacturer>/<product>/<protocol>/` folder.** Dual-protocol products have two sibling protocol folders under the same product.
+3a. **One direction per `<protocol>/<direction>/` folder.** Use `consumer`, `provider`, or `both`. `both` only when the DM is literally identical in both roles — otherwise split.
 4. **Version folders are immutable.** New firmware = new folder. Never overwrite an existing version.
 5. **`meta.json` + `tree.json` are committed as regular blobs (not LFS).** LFS is frozen — keep files < 100 KB or store the capture locally under `bin/devices/` instead.
 6. **`wire.jsonl` is committed only if < 100 KB.** Larger wire captures stay local under `bin/devices/captures/` and are referenced in the meta.json `notes` field.
-7. **One `CHANGELOG.md` per `<product>/<protocol>/` folder.** Never per version.
+7. **One `CHANGELOG.md` per `<product>/<protocol>/<direction>/` folder.** Never per version.
 8. **When a version folder is added or removed, update the product's `CHANGELOG.md`** — if you're doing it by hand (before #36.c lands), use the format above exactly.
 
 ---
@@ -163,7 +168,7 @@ Ordering: newest version at top. Initial capture at bottom with "Initial capture
 
 | Source | Command | Generates |
 |---|---|---|
-| Live device | `acp extract <host> --protocol <p> --out tests/fixtures/products/<manufacturer>/<product>/<p>/<version>/` | Full triple (meta + wire + tree) — shipping as **#36.b** |
+| Live device | `acp extract <host> --protocol <p> --direction <d> --out tests/fixtures/products/<manufacturer>/<product>/<p>/<d>/<version>/` | Full triple (meta + wire + tree) — see `acp help extract` |
 | Existing `wire.jsonl` | Replay through plugin decoder + re-emit canonical | `tree.json` (regenerate-only), `meta.json` fields refreshed |
 | Existing `tree.json` snapshot | `acp convert --in tree.json --out <any-other-format>` | Format conversions — already supported today |
 | Diff between two versions | `acp diff <v1>/tree.json <v2>/tree.json` | `CHANGELOG.md` entry — shipping as **#36.c** |

--- a/tests/fixtures/products/README.md
+++ b/tests/fixtures/products/README.md
@@ -10,7 +10,7 @@ Per-product, per-firmware captures used by offline replay tests and by `acp diff
 
 ```
 products/
-└── <manufacturer>/<product>/<protocol>/
+└── <manufacturer>/<product>/<protocol>/<direction>/
     ├── CHANGELOG.md        generated on each new version add
     └── <version>/
         ├── meta.json       identity + fingerprint + capture_tool build info
@@ -18,7 +18,7 @@ products/
         └── tree.json       canonical export (replay destination)
 ```
 
-A product folder can hold multiple `<protocol>` subfolders — one physical card sometimes exposes several interfaces (e.g. an Axon card speaking both ACP2 and Ember+). Each protocol has its own version lineage and its own CHANGELOG.
+A product folder can hold multiple `<protocol>` subfolders — one physical card sometimes exposes several interfaces (e.g. an Axon card speaking both ACP2 and Ember+). Each protocol splits further by `<direction>`: `consumer` (we read the device), `provider` (we expose a tree to external consumers), or `both` (same DM in both roles). Each direction has its own version lineage and its own CHANGELOG.
 
 Full spec + schema: [docs/fixtures-products.md](../../../docs/fixtures-products.md).
 


### PR DESCRIPTION
## Summary

New CLI subcommand \`acp extract\` — walks a device and emits the three-file product fixture triple directly into \`tests/fixtures/products/<manufacturer>/<product>/<protocol>/<version>/\` per the layout locked in #43.

### Usage

\`\`\`
acp extract <host> --protocol P --manufacturer M --product X --version V --out DIR [--slot N]
\`\`\`

### Output

| File | Content |
|---|---|
| \`meta.json\` | Identity + SHA-256 fingerprint of tree.json + \`capture_tool\` {name, version, git_tag, git_commit} |
| \`wire.jsonl\` | Raw frames (renamed from \`raw.<transport>.jsonl\` so the fixture layout stays protocol-agnostic) |
| \`tree.json\` | Canonical export (via plugin Canonicalize) |

### Provenance — capture_tool

Four fields, all stamped automatically:

- \`name\` — always \`"acp"\`
- \`version\` — ldflags \`-X main.version\` or \`"devel"\`
- \`git_commit\` — first prefer ldflags \`-X main.commit\`; fall back to \`runtime/debug.BuildInfo.Settings["vcs.revision"]\` (populated by \`go build -buildvcs=true\`, default since Go 1.18)
- \`git_tag\` — ldflags \`-X main.gitTag\`; falls back to \`"devel-<short-sha>"\` or \`"devel"\`. **Dirty worktree → \`-dirty\` suffix** (such captures should not be committed)

### Fingerprint

\`meta.json.dm_fingerprint\` = \`sha256:<hex>\` of the \`tree.json\` bytes. Byte-identical firmware produces identical fingerprints across captures. A drift means either the firmware changed or the canonical encoder moved.

## Files

| File | Change |
|---|---|
| \`cmd/acp/cmd_extract.go\` | **new** — full subcommand, reuses \`writeCanonicalCapture\` from cmd_walk.go |
| \`cmd/acp/buildinfo.go\` | **new** — \`buildCaptureToolInfo()\` helper reading BuildInfo + ldflags |
| \`cmd/acp/cmd_extract_test.go\` | **new** — 4 tests: sha256 determinism, discrimination, meta round-trip, buildinfo non-empty |
| \`cmd/acp/main.go\` | adds \`gitTag\` build-time var; registers \`extract\` in commands table + top-help |
| \`cmd/acp/help.go\` | \`helpExtract\` with IN/OUT contract + flag block + examples |
| \`README.md\` | CLI table row |

## Test plan

- [x] \`TestSHA256File\` — deterministic + correct shape
- [x] \`TestSHA256File_DifferentBytes\` — fingerprint discriminates
- [x] \`TestMetaJSONRoundTrip\` — full schema + key audit
- [x] \`TestBuildCaptureToolInfo\` — non-empty fields always
- [x] \`go build\` + \`go vet\` + \`go test ./...\` all green
- [x] pre-commit hook (go vet + golangci-lint) — 0 issues
- [x] smoke: \`acp help extract\` renders the full page
- [ ] CI matrix green

## Out of scope (tracked separately)

- Auto-detection of product + version from the identity block → follow-up issue; manufacturer / product / version remain required flags here.
- Pushing captures into the repo (manual \`git add\` step).
- \`acp diff\` (#36.c).

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)