### PR TITLE
feat(scenario): declarative error-path test harness

### DIFF
--- a/internal/scenario/runner.go
+++ b/internal/scenario/runner.go
@@ -1,0 +1,155 @@
+package scenario
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"acp/internal/protocol/acp2"
+)
+
+// Run dispatches the scenario to the right per-protocol runner and
+// asserts the scenario's expectations. Call as a sub-test:
+//
+//	t.Run(scenarioName, func(t *testing.T) { scenario.Run(t, s) })
+//
+// Any mismatch is reported with t.Errorf or t.Fatalf as appropriate.
+func Run(t *testing.T, s *Scenario) {
+	t.Helper()
+	switch s.Protocol {
+	case "acp2":
+		runACP2(t, s)
+	case "acp1":
+		t.Skipf("acp1 scenario runner not implemented yet (scenario %q)", s.Name)
+	case "emberplus":
+		t.Skipf("emberplus scenario runner not implemented yet (scenario %q)", s.Name)
+	default:
+		t.Fatalf("unknown protocol %q in scenario %q", s.Protocol, s.Name)
+	}
+}
+
+// captureRecord mirrors the on-wire jsonl record shape the CLI's
+// --capture recorder emits. One line per frame; `hex` holds the raw
+// transport bytes.
+type captureRecord struct {
+	Timestamp string `json:"ts"`
+	Protocol  string `json:"proto,omitempty"`
+	Direction string `json:"dir"`
+	Hex       string `json:"hex"`
+	Length    int    `json:"len,omitempty"`
+}
+
+// readCapture opens the resolved wire.jsonl path (or legacy raw.*
+// filenames) and returns every line as a parsed captureRecord. Skips
+// a fixture file that's still a Git LFS pointer rather than failing
+// hard — CI without git-lfs installed runs successfully.
+func readCapture(t *testing.T, wirePath string) []captureRecord {
+	t.Helper()
+	f, err := os.Open(wirePath)
+	if err != nil {
+		t.Fatalf("open wire file %s: %v", wirePath, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var recs []captureRecord
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 1024*1024), 16*1024*1024)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) > 0 && line[0] != '{' {
+			t.Skipf("wire file %s is a Git LFS pointer, not real content — skipping", wirePath)
+		}
+		var r captureRecord
+		if err := json.Unmarshal(line, &r); err != nil {
+			t.Fatalf("unmarshal line in %s: %v", wirePath, err)
+		}
+		recs = append(recs, r)
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan %s: %v", wirePath, err)
+	}
+	return recs
+}
+
+// runACP2 is the protocol-specific runner. Walks inbound frames,
+// decodes the first ACP2 error reply, asserts the status code + the
+// compliance-event label derived via acp2.EventForErrStatus.
+func runACP2(t *testing.T, s *Scenario) {
+	t.Helper()
+	wirePath, err := s.ResolveWirePath()
+	if err != nil {
+		t.Fatalf("scenario %q: %v", s.Name, err)
+	}
+	recs := readCapture(t, wirePath)
+
+	var errMsg *acp2.ACP2Message
+	var errStat acp2.ACP2ErrStatus
+
+	for _, r := range recs {
+		if r.Direction != "rx" {
+			continue
+		}
+		raw, err := hex.DecodeString(r.Hex)
+		if err != nil {
+			t.Fatalf("scenario %q: hex decode: %v", s.Name, err)
+		}
+		frame, err := acp2.ReadAN2Frame(bytes.NewReader(raw))
+		if err != nil {
+			continue
+		}
+		if frame.Proto != acp2.AN2ProtoACP2 || frame.Type != acp2.AN2TypeData {
+			continue
+		}
+		msg, err := acp2.DecodeACP2Message(frame.Payload)
+		if err != nil {
+			continue
+		}
+		if msg.Type == acp2.ACP2TypeError {
+			errMsg = msg
+			errStat = acp2.ACP2ErrStatus(msg.Func)
+			break
+		}
+	}
+
+	if len(s.ExpectEvents) > 0 || s.ExpectErrorClass != "" || s.ExpectErrorStatus != nil {
+		if errMsg == nil {
+			t.Fatalf("scenario %q: expected an ACP2 error reply, none found in %s",
+				s.Name, wirePath)
+		}
+	}
+
+	// Assert expected compliance events.
+	for _, wantEvent := range s.ExpectEvents {
+		got := acp2.EventForErrStatus(errStat)
+		if got != wantEvent {
+			t.Errorf("scenario %q: EventForErrStatus(%d) = %q, want %q",
+				s.Name, errStat, got, wantEvent)
+		}
+	}
+
+	// Assert expected error class + status (optional).
+	if s.ExpectErrorClass != "" {
+		err := errMsg.ToACP2Error()
+		typeName := fmt.Sprintf("%T", err)
+		// Accept either the fully-qualified type "*acp2.ACP2Error" or
+		// the short form "ACP2Error" for ergonomic scenario files.
+		short := typeName[strings.LastIndex(typeName, ".")+1:]
+		short = strings.TrimPrefix(short, "*")
+		if s.ExpectErrorClass != short && s.ExpectErrorClass != typeName {
+			t.Errorf("scenario %q: error class got %q, want %q",
+				s.Name, short, s.ExpectErrorClass)
+		}
+	}
+	if s.ExpectErrorStatus != nil {
+		want := acp2.ACP2ErrStatus(*s.ExpectErrorStatus)
+		if errStat != want {
+			t.Errorf("scenario %q: error status got %d, want %d",
+				s.Name, errStat, want)
+		}
+	}
+}

--- a/internal/scenario/scenario.go
+++ b/internal/scenario/scenario.go
@@ -1,0 +1,110 @@
+// Package scenario defines a declarative format for error-path
+// regression tests (#51) and the harness that runs them. A scenario
+// is a JSON file describing:
+//
+//   - a committed wire capture to replay,
+//   - the compliance-event labels that must appear while replaying,
+//   - optionally, an error class + numeric status the decoder must
+//     emit for the first error reply in the capture.
+//
+// The harness is consumed by tests/unit/scenario/scenario_test.go,
+// which walks tests/scenarios/** and runs every file it finds. New
+// scenarios are added by dropping a JSON file in place — no Go code
+// changes required.
+package scenario
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Scenario is the parsed JSON shape. ExpectErrorStatus is a pointer
+// so the scenario author can omit it when no error status is expected
+// (vs. the separate meaning of "expect status 0").
+type Scenario struct {
+	Name              string   `json:"name"`
+	Protocol          string   `json:"protocol"`
+	WireFile          string   `json:"wire_file"`
+	ExpectEvents      []string `json:"expect_events,omitempty"`
+	ExpectErrorClass  string   `json:"expect_error_class,omitempty"`
+	ExpectErrorStatus *int     `json:"expect_error_status,omitempty"`
+
+	// SourcePath is set by Load() to the absolute path of the
+	// scenario file; used to resolve WireFile relative to the
+	// scenario's own directory when needed.
+	SourcePath string `json:"-"`
+}
+
+// Load reads and parses a scenario file. The parsed Scenario's
+// SourcePath is set to the absolute path so the runner can resolve
+// relative WireFile references correctly regardless of cwd.
+func Load(path string) (*Scenario, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var s Scenario
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("abs %s: %w", path, err)
+	}
+	s.SourcePath = abs
+	return &s, nil
+}
+
+// Discover walks a directory recursively and returns every *.json
+// file found, sorted for deterministic ordering. Used by the test
+// harness to enumerate every committed scenario.
+func Discover(dir string) ([]string, error) {
+	var out []string
+	err := filepath.Walk(dir, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if filepath.Ext(p) == ".json" && filepath.Base(p) != "README.json" {
+			out = append(out, p)
+		}
+		return nil
+	})
+	return out, err
+}
+
+// ResolveWirePath returns the absolute path to the scenario's
+// referenced wire.jsonl. The JSON file's WireFile may be:
+//   - absolute — used as-is
+//   - relative to the scenario file's dir — resolved against SourcePath
+//   - relative to the repo root (starts with "tests/") — resolved
+//     against the repo root (walks up from SourcePath to find the
+//     nearest go.mod)
+func (s *Scenario) ResolveWirePath() (string, error) {
+	if filepath.IsAbs(s.WireFile) {
+		return s.WireFile, nil
+	}
+	// Try: relative to scenario directory
+	dir := filepath.Dir(s.SourcePath)
+	candidate := filepath.Join(dir, s.WireFile)
+	if _, err := os.Stat(candidate); err == nil {
+		return candidate, nil
+	}
+	// Try: walk up to find go.mod (repo root) and resolve from there
+	root := dir
+	for {
+		if _, err := os.Stat(filepath.Join(root, "go.mod")); err == nil {
+			return filepath.Join(root, s.WireFile), nil
+		}
+		parent := filepath.Dir(root)
+		if parent == root {
+			break
+		}
+		root = parent
+	}
+	return "", fmt.Errorf("cannot resolve wire_file %q (tried scenario-dir and repo root)", s.WireFile)
+}

--- a/tests/scenarios/README.md
+++ b/tests/scenarios/README.md
@@ -1,0 +1,58 @@
+# Scenario test catalogue
+
+Declarative error / edge-case replay tests. Each `.json` file describes one scenario; the harness at `tests/unit/scenario/` runs every file automatically.
+
+Full package docs: [`internal/scenario/`](../../internal/scenario/).
+
+## Layout
+
+```
+tests/scenarios/
+├── README.md
+├── <protocol>/
+│   └── <scenario>.json
+```
+
+## Scenario file shape
+
+```json
+{
+  "name": "human-readable one-liner, used as sub-test name",
+  "protocol": "acp2",
+  "wire_file": "tests/fixtures/acp2/err_no_access.jsonl",
+  "expect_events": ["acp2_access_denied_received"],
+  "expect_error_class": "ACP2Error",
+  "expect_error_status": 4
+}
+```
+
+### Fields
+
+| Field | Required | Meaning |
+|---|---|---|
+| `name` | yes | Human-readable description. Used as the Go sub-test name so it shows up in `go test -v` output. |
+| `protocol` | yes | One of `acp1`, `acp2`, `emberplus`. Selects the per-protocol runner. |
+| `wire_file` | yes | Path to a committed `*.jsonl` capture. Resolved against the scenario file's directory first, then against the repo root. |
+| `expect_events` | no | List of compliance-event labels the runner must observe for the first error reply in the capture. Empty = no event assertion. |
+| `expect_error_class` | no | Expected Go error type name (`ACP2Error`, `ACP1ObjectError`, …). Matched against the short form (no `*` prefix, no package). |
+| `expect_error_status` | no | Expected numeric status / error code. For ACP2 = `stat`; for ACP1 = `MCODE`; for Ember+ = error sub-container. |
+
+## Status today
+
+- **acp2** — 2 scenarios cover the error-reply path (`err_no_access`, `err_invalid_obj`).
+- **acp1** — runner stub; scenarios pending (need ACP1 error captures).
+- **emberplus** — runner stub; scenarios pending.
+
+## Adding a scenario
+
+1. Capture the wire with `acp extract` or `acp walk --capture` against a real device exhibiting the edge case.
+2. Commit the capture under `tests/fixtures/<proto>/` (only if < 100 KB — LFS is frozen).
+3. Drop a new `<name>.json` in `tests/scenarios/<proto>/` referencing the capture.
+4. Run `go test ./tests/unit/scenario/` — the new scenario runs as a sub-test on every `go test ./...`.
+
+No Go code changes required.
+
+## Out of scope today
+
+- **Timeout / disconnect** scenarios — need an active transport mock (not replay). Tracked as a follow-up.
+- **Scenario generator** that captures from live device + stamps the JSON. Separate issue.

--- a/tests/scenarios/acp2/err_invalid_obj.json
+++ b/tests/scenarios/acp2/err_invalid_obj.json
@@ -1,0 +1,8 @@
+{
+  "name": "acp2 error: get on unknown obj-id",
+  "protocol": "acp2",
+  "wire_file": "tests/fixtures/acp2/err_invalid_obj.jsonl",
+  "expect_events": ["acp2_invalid_object_received"],
+  "expect_error_class": "ACP2Error",
+  "expect_error_status": 1
+}

--- a/tests/scenarios/acp2/err_no_access.json
+++ b/tests/scenarios/acp2/err_no_access.json
@@ -1,0 +1,8 @@
+{
+  "name": "acp2 error: set on read-only parameter",
+  "protocol": "acp2",
+  "wire_file": "tests/fixtures/acp2/err_no_access.jsonl",
+  "expect_events": ["acp2_access_denied_received"],
+  "expect_error_class": "ACP2Error",
+  "expect_error_status": 4
+}

--- a/tests/unit/scenario/scenario_test.go
+++ b/tests/unit/scenario/scenario_test.go
@@ -1,0 +1,42 @@
+// Scenario discovery test — walks tests/scenarios/** and runs every
+// .json file through the declarative harness. Each scenario appears
+// as its own sub-test in `go test -v` output.
+//
+// Add a new scenario = drop a .json in tests/scenarios/<proto>/. No
+// test-code changes required.
+package scenario_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"acp/internal/scenario"
+)
+
+// TestScenarios discovers every committed scenario under
+// tests/scenarios/ and runs it. Failures are per-scenario — one green
+// line per passing scenario, one red line per failing one.
+func TestScenarios(t *testing.T) {
+	root := filepath.Join("..", "..", "scenarios")
+	paths, err := scenario.Discover(root)
+	if err != nil {
+		t.Fatalf("discover %s: %v", root, err)
+	}
+	if len(paths) == 0 {
+		t.Fatalf("no scenarios found under %s — check the layout docs", root)
+	}
+
+	for _, p := range paths {
+		p := p
+		s, err := scenario.Load(p)
+		if err != nil {
+			t.Run(filepath.Base(p), func(t *testing.T) {
+				t.Fatalf("load %s: %v", p, err)
+			})
+			continue
+		}
+		t.Run(s.Name, func(t *testing.T) {
+			scenario.Run(t, s)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

New test-only package \`internal/scenario/\` + committed scenario catalogue under \`tests/scenarios/\`. Each scenario is a JSON file; the harness walks the tree and runs each as a Go sub-test. Drop a new JSON file to add a scenario — no Go code changes.

Formalises the pattern already used by \`tests/unit/acp2/compliance_test.go\` into a reusable, declarative framework.

## Scenario shape

\`\`\`json
{
  "name": "acp2 error: set on read-only parameter",
  "protocol": "acp2",
  "wire_file": "tests/fixtures/acp2/err_no_access.jsonl",
  "expect_events": ["acp2_access_denied_received"],
  "expect_error_class": "ACP2Error",
  "expect_error_status": 4
}
\`\`\`

## Runtime

\`\`\`
$ go test -v ./tests/unit/scenario/
=== RUN   TestScenarios
=== RUN   TestScenarios/acp2_error:_get_on_unknown_obj-id
=== RUN   TestScenarios/acp2_error:_set_on_read-only_parameter
--- PASS: TestScenarios (0.03s)
    --- PASS: TestScenarios/acp2_error:_get_on_unknown_obj-id (0.01s)
    --- PASS: TestScenarios/acp2_error:_set_on_read-only_parameter (0.01s)
\`\`\`

One sub-test per scenario file. Failures show the scenario name.

## MVP scope

| Protocol | State |
|---|---|
| ACP2 | ✅ runner implemented + 2 committed scenarios |
| ACP1 | stub — \`t.Skip\` until fixtures captured |
| Ember+ | stub — \`t.Skip\` until fixtures captured |

Replay-only. Timeout / disconnect simulation (active transport mock) = separate follow-up.

## Files

| File | Change |
|---|---|
| \`internal/scenario/scenario.go\` | **new** — \`Scenario\`, \`Load\`, \`Discover\`, \`ResolveWirePath\` (handles scenario-dir-relative + repo-root-relative paths) |
| \`internal/scenario/runner.go\` | **new** — \`Run(t, s)\` dispatcher + \`runACP2\` |
| \`tests/unit/scenario/scenario_test.go\` | **new** — walks \`tests/scenarios/\` + runs every file |
| \`tests/scenarios/README.md\` | **new** — format spec + add-a-scenario workflow |
| \`tests/scenarios/acp2/err_no_access.json\` | **new** — stat=4 ACP2 error (access denied) |
| \`tests/scenarios/acp2/err_invalid_obj.json\` | **new** — stat=1 ACP2 error (invalid obj-id) |

## Relationship to existing tests

\`tests/unit/acp2/compliance_test.go\` stays (tests the pure \`EventForErrStatus\` helper, independently of wire). The per-fixture test functions in that file (\`TestCompliance_ErrNoAccess\`, \`TestCompliance_ErrInvalidObj\`) are now redundant with the scenario harness — planned to retire after one release of dual coverage to validate the harness is equivalent.

## Test plan

- [x] Both ACP2 scenarios pass as sub-tests
- [x] \`go build\` + \`go vet\` + \`go test ./...\` all green
- [x] Pre-commit hook — 0 issues
- [x] Discovery test: with zero scenarios, fails loudly (tested manually; fall-through is safe)
- [ ] CI matrix green

## Out of scope

- Timeout / disconnect via transport mock → follow-up issue
- ACP1 + Ember+ runners → land when fixtures are captured
- Scenario generator CLI → separate issue
- YAML scenario format → unnecessary complexity, JSON stays

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)