### PR TITLE
feat(provider): Ember+ provider plugin — MVP serve tree.json on :9010 (#66)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,17 +8,26 @@ This is the single authoritative context for Claude Code working in this reposit
 ## Project Purpose
 
 A Go toolset to connect to, monitor, and control devices that speak the **ACP family
-of protocols** over UDP or TCP (via AN2 transport). Two binaries share one internal
+of protocols** over UDP or TCP (via AN2 transport). Three binaries share one internal
 library:
 
 ```
-cmd/acp          CLI — direct device I/O, no server
-cmd/acp-srv      HTTP REST + WebSocket API (consumed by acp-ui)
+cmd/acp          CLI — direct device I/O, no server (consumer side)
+cmd/acp-srv      HTTP REST + WebSocket API (consumed by acp-ui) — planned
+cmd/acp-provider Provider server — serves a canonical tree.json to consumers over wire (#66)
 internal/        core library — imported only by cmd/
 ```
 
 A separate repository `acp-ui` (React 19) consumes `cmd/acp-srv`.
 This repo has zero frontend code.
+
+**Two plugin tiers**, both Tier-1 compile-time registries:
+- `internal/protocol/` — consumer (connect to a device, walk, get, set, subscribe)
+- `internal/provider/` — provider (listen, serve a tree, broadcast on value change)
+
+Ember+ has both: the consumer plugin at `internal/protocol/emberplus/` and the
+provider plugin at `internal/provider/emberplus/`. ACP1 / ACP2 providers are
+future work.
 
 ---
 
@@ -802,7 +811,17 @@ announcement wins (more recent).
 3. Implement ProtocolFactory.Meta() — name, default port
 4. Add: func init() { protocol.Register(&Factory{}) }
 5. Add import _ "acp/internal/protocol/{name}" in cmd/acp/main.go
-6. Add import _ "acp/internal/protocol/{name}" in cmd/acp-srv/main.go
+6. Add import _ "acp/internal/protocol/{name}" in cmd/acp-srv/main.go (when the server lands)
+
+## Adding a New Provider
+
+Mirror the consumer pattern, but under `internal/provider/`:
+
+1. Create `internal/provider/{name}/`
+2. Implement the `provider.Provider` interface (Serve, Stop, SetValue)
+3. Expose a `Factory` + `func init() { provider.Register(&Factory{}) }`
+4. Add `import _ "acp/internal/provider/{name}"` to `cmd/acp-provider/main.go`
+5. Writes unit tests in `internal/provider/{name}/*_test.go` (no external dirs)
 7. Write unit tests in tests/unit/{name}/
 8. Done — CLI, API, UI pick it up automatically
 ```

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ DIST_DIR     ?= dist
 PKG          := ./...
 CMD_ACP      := ./cmd/acp
 CMD_SRV      := ./cmd/acp-srv
+CMD_PROVIDER := ./cmd/acp-provider
 
 # Version injected into binaries via -ldflags. Uses git tag if available,
 # otherwise "dev".
@@ -43,16 +44,22 @@ all: build
 
 # ---------------------------------------------------------------- Build
 
-.PHONY: build build-cli build-srv
-build: build-cli build-srv
+.PHONY: build build-cli build-srv build-provider
+build: build-cli build-provider
 
 build-cli:
 	@mkdir -p $(BIN_DIR)
 	$(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS_FULL)" -o $(BIN_DIR)/acp$(EXE) $(CMD_ACP)
 
+# build-srv is kept here as a scaffold target — cmd/acp-srv is planned
+# (see CLAUDE.md) but not yet implemented; do not add to `build`.
 build-srv:
 	@mkdir -p $(BIN_DIR)
 	$(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS_FULL)" -o $(BIN_DIR)/acp-srv$(EXE) $(CMD_SRV)
+
+build-provider:
+	@mkdir -p $(BIN_DIR)
+	$(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS_FULL)" -o $(BIN_DIR)/acp-provider$(EXE) $(CMD_PROVIDER)
 
 # ---------------------------------------------------------------- Cross-compile
 
@@ -66,9 +73,9 @@ build-all: build-linux-amd64 build-linux-arm64 \
 define _xbuild
 	@mkdir -p $(DIST_DIR)/acp_$(1)_$(2)
 	GOOS=$(1) GOARCH=$(2) $(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS_FULL)" \
-		-o $(DIST_DIR)/acp_$(1)_$(2)/acp$(3)     $(CMD_ACP)
+		-o $(DIST_DIR)/acp_$(1)_$(2)/acp$(3)          $(CMD_ACP)
 	GOOS=$(1) GOARCH=$(2) $(GO) build $(GOFLAGS) -ldflags "$(LDFLAGS_FULL)" \
-		-o $(DIST_DIR)/acp_$(1)_$(2)/acp-srv$(3) $(CMD_SRV)
+		-o $(DIST_DIR)/acp_$(1)_$(2)/acp-provider$(3) $(CMD_PROVIDER)
 endef
 
 build-linux-amd64:

--- a/agents.md
+++ b/agents.md
@@ -414,11 +414,19 @@ Replay tests under tests/unit/emberplus/:
 Order: **Ember+ consumer → Ember+ provider → bus / extra protocols**.
 No next phase until previous ships with VM integration passing.
 
+**Part B update (2026-04-20):** Ember+ provider MVP opened on PR #67
+(branch `feat/emberplus-provider`). New tier-1 plugin directory
+`internal/provider/emberplus/` mirrors the consumer under
+`internal/protocol/emberplus/`. Binary `cmd/acp-provider`. Round-tripped
+live against EmberViewer for Node + all 7 Parameter types. Open
+follow-ups: #68 (viewer quirks), #69 (Matrix + Function extension,
+labels, parametersLocation, sum/recallSalvo functions).
+
 ### Parked — TODO / SOW (do not start now)
 
 | item | phase | notes |
 |---|---|---|
-| Ember+ provider | Part B | after consumer closed |
+| Ember+ provider | ✅ MVP on PR #67; #69 for Matrix/Function |
 | Bus bridge (`acp-srv --bus=none\|nats\|es\|redis-stream`) | Part C | orchestrator-level; plugins stay bus-free |
 | Probel SW-P-02 consumer+provider | later | canonical Matrix shape, no walkable tree |
 | Probel SW-P-08 Plus consumer+provider | later | canonical Matrix with level multiplex |

--- a/cmd/acp-provider/main.go
+++ b/cmd/acp-provider/main.go
@@ -1,0 +1,112 @@
+// Command acp-provider runs an Ember+ (or future protocol) provider
+// server. Loads a canonical tree.json and serves it to consumers.
+//
+// Usage:
+//
+//	acp-provider --tree <file.json> [--protocol emberplus] [--port 9010]
+//
+// The binary is thin: parse flags, read the tree, resolve the provider
+// plugin, Serve, wait for SIGINT. Plugin registration happens in
+// init() of each imported provider package.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"acp/internal/export/canonical"
+	"acp/internal/provider"
+
+	_ "acp/internal/provider/emberplus"
+)
+
+func main() {
+	var (
+		treePath = flag.String("tree", "", "path to canonical tree.json (required)")
+		proto    = flag.String("protocol", "emberplus", "provider plugin name")
+		port     = flag.Int("port", 0, "TCP listen port (0 = plugin default)")
+		host     = flag.String("host", "0.0.0.0", "TCP listen host")
+		logLevel = flag.String("log-level", "info", "log level: debug, info, warn, error")
+	)
+	flag.Parse()
+
+	if *treePath == "" {
+		fmt.Fprintln(os.Stderr, "error: --tree is required")
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	logger := newLogger(*logLevel)
+
+	factory, ok := provider.Lookup(*proto)
+	if !ok {
+		fmt.Fprintf(os.Stderr, "error: unknown provider %q. available: %v\n", *proto, provider.List())
+		os.Exit(2)
+	}
+
+	tree, err := loadTree(*treePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: load tree: %v\n", err)
+		os.Exit(1)
+	}
+
+	listenPort := *port
+	if listenPort == 0 {
+		listenPort = factory.Meta().DefaultPort
+	}
+	addr := fmt.Sprintf("%s:%d", *host, listenPort)
+
+	srv := factory.New(logger, tree)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Graceful shutdown on SIGINT / SIGTERM.
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigs
+		logger.Info("shutdown signal received")
+		cancel()
+		_ = srv.Stop()
+	}()
+
+	if err := srv.Serve(ctx, addr); err != nil && !errors.Is(err, context.Canceled) {
+		logger.Error("serve", slog.String("err", err.Error()))
+		os.Exit(1)
+	}
+}
+
+func loadTree(path string) (*canonical.Export, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var exp canonical.Export
+	if err := json.Unmarshal(data, &exp); err != nil {
+		return nil, fmt.Errorf("parse canonical: %w", err)
+	}
+	return &exp, nil
+}
+
+func newLogger(level string) *slog.Logger {
+	var lvl slog.Level
+	switch level {
+	case "debug":
+		lvl = slog.LevelDebug
+	case "warn":
+		lvl = slog.LevelWarn
+	case "error":
+		lvl = slog.LevelError
+	default:
+		lvl = slog.LevelInfo
+	}
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: lvl}))
+}

--- a/internal/protocol/emberplus/ber/value.go
+++ b/internal/protocol/emberplus/ber/value.go
@@ -50,31 +50,114 @@ func EncodeInteger(v int64) []byte {
 
 // EncodeReal returns BER REAL value bytes for an IEEE 754 double.
 // Uses binary encoding (X.690 8.5.6): first octet 0x80 + 8-byte double.
+// EncodeReal encodes a float64 as ITU-T X.690 §8.5 BER REAL in binary
+// form (base 2, scaling factor 0). The on-wire shape is:
+//
+//	first byte   : 1 S BB FF EE  (S=sign, BB=base, FF=scale, EE=exponent length)
+//	exponent     : two's-complement signed integer, EE+1 octets (or long form)
+//	mantissa     : unsigned big-endian integer, normalised (trailing zero bits trimmed)
+//
+// Such that  value = (-1)^S * mantissa * 2^exponent.
+//
+// Special values: zero → empty; ±∞ → 0x40 / 0x41; NaN → 0x42.
 func EncodeReal(v float64) []byte {
 	if v == 0 {
-		return nil // zero-length content = 0.0
+		return nil
+	}
+	if math.IsNaN(v) {
+		return []byte{0x42}
 	}
 	if math.IsInf(v, 1) {
-		return []byte{0x40} // PLUS-INFINITY
+		return []byte{0x40}
 	}
 	if math.IsInf(v, -1) {
-		return []byte{0x41} // MINUS-INFINITY
+		return []byte{0x41}
 	}
 
-	// Binary encoding, base 2, positive exponent format.
-	// Simplest correct encoding: store as raw IEEE 754 double.
-	var buf [9]byte
-	buf[0] = 0x80 // binary encoding, sign+, base 2, exponent length 2
 	bits := math.Float64bits(v)
+	sign := byte((bits >> 63) & 1)
+	expRaw := int((bits >> 52) & 0x7FF)
+	frac := bits & ((1 << 52) - 1)
 
-	// Handle negative.
-	if v < 0 {
-		buf[0] |= 0x40 // sign bit
-		bits = math.Float64bits(-v)
+	var mantissa uint64
+	var exponent int
+	if expRaw == 0 {
+		// Subnormal: no implicit leading 1.
+		mantissa = frac
+		exponent = -1022 - 52
+	} else {
+		// Normal: add implicit leading 1.
+		mantissa = frac | (1 << 52)
+		exponent = expRaw - 1023 - 52
 	}
 
-	binary.BigEndian.PutUint64(buf[1:], bits)
-	return buf[:]
+	// Normalise: drop trailing zero bits (BER REAL mantissa must be odd
+	// unless zero, per X.690 §8.5.7.3 — the normalised form).
+	for mantissa != 0 && mantissa&1 == 0 {
+		mantissa >>= 1
+		exponent++
+	}
+
+	// Exponent as two's-complement minimum-octet signed integer.
+	expBytes := encodeSignedInt(int64(exponent))
+	// Mantissa as unsigned big-endian minimum-octet integer.
+	mantBytes := encodeUnsignedInt(mantissa)
+
+	// First byte layout: bit 7 always 1 (binary), bit 6 sign, bits 5-4
+	// base (00 = base 2), bits 3-2 scale (00), bits 1-0 exponent-length
+	// encoding: 00=1 octet, 01=2 octets, 10=3 octets, 11=long form with
+	// extra length octet following.
+	first := byte(0x80) | (sign << 6)
+	out := make([]byte, 0, 1+len(expBytes)+len(mantBytes)+1)
+	switch len(expBytes) {
+	case 1:
+		first |= 0x00
+		out = append(out, first)
+	case 2:
+		first |= 0x01
+		out = append(out, first)
+	case 3:
+		first |= 0x02
+		out = append(out, first)
+	default:
+		first |= 0x03
+		out = append(out, first, byte(len(expBytes)))
+	}
+	out = append(out, expBytes...)
+	out = append(out, mantBytes...)
+	return out
+}
+
+// encodeSignedInt returns the minimum-octet two's-complement big-endian
+// representation of v. Shared helper for BER REAL exponent encoding.
+func encodeSignedInt(v int64) []byte {
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], uint64(v))
+
+	// Trim redundant leading 0x00 / 0xFF bytes while preserving sign.
+	start := 0
+	for start < 7 {
+		next := start + 1
+		if (buf[start] == 0x00 && buf[next]&0x80 == 0) ||
+			(buf[start] == 0xFF && buf[next]&0x80 != 0) {
+			start = next
+			continue
+		}
+		break
+	}
+	return buf[start:]
+}
+
+// encodeUnsignedInt returns the minimum-octet big-endian representation
+// of v, treated as unsigned. Shared helper for BER REAL mantissa.
+func encodeUnsignedInt(v uint64) []byte {
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], v)
+	start := 0
+	for start < 7 && buf[start] == 0 {
+		start++
+	}
+	return buf[start:]
 }
 
 // EncodeUTF8String returns BER UTF8String value bytes (raw UTF-8).
@@ -121,36 +204,91 @@ func DecodeInteger(data []byte) (int64, error) {
 	return int64(binary.BigEndian.Uint64(buf[:])), nil
 }
 
-// DecodeReal reads a BER REAL from value bytes.
+// DecodeReal reads an ITU-T X.690 §8.5 BER REAL from value bytes.
+// Supports the binary form (base 2, base 8, base 16) with scale 0 —
+// which covers every REAL shape Glow actually emits.
 func DecodeReal(data []byte) (float64, error) {
 	if len(data) == 0 {
-		return 0.0, nil // zero-length = 0.0
+		return 0.0, nil
 	}
 
 	first := data[0]
 
-	// Special values.
+	// Special values (§8.5.9).
 	if first == 0x40 {
 		return math.Inf(1), nil
 	}
 	if first == 0x41 {
 		return math.Inf(-1), nil
 	}
-
-	// Binary encoding.
-	if first&0x80 != 0 {
-		negative := first&0x40 != 0
-		if len(data) < 9 {
-			return 0, errInvalidReal
-		}
-		bits := binary.BigEndian.Uint64(data[1:9])
-		v := math.Float64frombits(bits)
-		if negative {
-			v = -v
-		}
-		return v, nil
+	if first == 0x42 {
+		return math.NaN(), nil
 	}
 
+	// Decimal form (bit 7 = 0, bit 6 = 0) — not emitted by Glow, reject.
+	if first&0xC0 == 0x00 {
+		return 0, errInvalidReal
+	}
+
+	// Binary form: bit 7 = 1.
+	if first&0x80 != 0 {
+		sign := 1.0
+		if first&0x40 != 0 {
+			sign = -1.0
+		}
+		// Base: bits 5-4. 00=2, 01=8, 10=16.
+		var baseFactor int
+		switch (first >> 4) & 0x03 {
+		case 0:
+			baseFactor = 1 // exponent bits are powers of 2
+		case 1:
+			baseFactor = 3 // × 2^3 = base 8
+		case 2:
+			baseFactor = 4 // × 2^4 = base 16
+		default:
+			return 0, errInvalidReal
+		}
+		// Scaling factor: bits 3-2. Added to mantissa.
+		scale := int((first >> 2) & 0x03)
+		// Exponent length: bits 1-0.
+		var expLen int
+		var expStart int
+		switch first & 0x03 {
+		case 0:
+			expLen = 1
+			expStart = 1
+		case 1:
+			expLen = 2
+			expStart = 1
+		case 2:
+			expLen = 3
+			expStart = 1
+		default:
+			if len(data) < 2 {
+				return 0, errInvalidReal
+			}
+			expLen = int(data[1])
+			expStart = 2
+		}
+		if expLen == 0 || expStart+expLen > len(data) {
+			return 0, errInvalidReal
+		}
+		exp, err := DecodeInteger(data[expStart : expStart+expLen])
+		if err != nil {
+			return 0, err
+		}
+		// Mantissa — remaining bytes, unsigned big-endian.
+		mantBytes := data[expStart+expLen:]
+		if len(mantBytes) == 0 {
+			return 0, errInvalidReal
+		}
+		var mant uint64
+		for _, b := range mantBytes {
+			mant = (mant << 8) | uint64(b)
+		}
+		v := sign * float64(mant) * math.Pow(2.0, float64(int(exp)*baseFactor+scale))
+		return v, nil
+	}
 	return 0, errInvalidReal
 }
 

--- a/internal/provider/emberplus/encoder.go
+++ b/internal/provider/emberplus/encoder.go
@@ -9,47 +9,78 @@ import (
 )
 
 // encodeGetDirReply walks the tree entry e and produces the BER payload
-// for a GetDirectory reply. The shape is:
+// for a GetDirectory reply.
 //
-//	Root → RootElementCollection → Context[0] → QualifiedNode(path) →
-//	  children → ElementCollection →
-//	    Context[0] → QualifiedNode | QualifiedParameter | QualifiedMatrix | QualifiedFunction
-//	    Context[0] → (next sibling)
-//	    ...
+// Spec pattern (observed from TinyEmber+ frame 6 + 10):
 //
-// Always emits qualified forms so consumers walking by path resolve each
-// child independently — the lax "bare Node with number only" form is
-// valid wire but upsets strict providers' walkers; provider should
-// always emit the strict-safe shape.
-func (s *server) encodeGetDirReply(e *entry) ([]byte, error) {
+//  1. GetDirectory at root level (bare Command, empty path)
+//     → return the tree's top-level element alone (identifier only)
+//
+//  2. GetDirectory on a specific path P (Command nested in QualifiedNode(P))
+//     → return each direct child of P as a FLAT QualifiedElement with
+//       absolute path at the RootElementCollection level (NOT nested
+//       inside a wrapper). Minimal contents — strict viewers reject
+//       anything beyond identifier (+description where set).
+//
+// isRoot and isOnline are intentionally omitted: TinyEmber+ does not
+// emit them, and EmberViewer treats extra content as schema deviation.
+func (s *server) encodeGetDirReply(e *entry, bareRoot bool) ([]byte, error) {
 	hdr := e.el.Common()
 
-	// Build the children collection as [0]-wrapped qualified elements.
-	kids := make([]ber.TLV, 0, len(hdr.Children))
-	for _, child := range hdr.Children {
-		centry := s.tree.byOID[child.Common().OID]
-		if centry == nil {
-			return nil, fmt.Errorf("encoder: missing index for %q", child.Common().OID)
+	var items []ber.TLV
+	if bareRoot {
+		// Just the queried element itself, identifier only.
+		items = append(items, ber.ContextConstructed(0, s.encodeElementMinimal(e)))
+	} else {
+		// Flat list of direct children, each as a qualified element.
+		for _, child := range hdr.Children {
+			centry := s.tree.byOID[child.Common().OID]
+			if centry == nil {
+				return nil, fmt.Errorf("encoder: missing index for %q", child.Common().OID)
+			}
+			tlv, err := s.encodeQualifiedElement(centry)
+			if err != nil {
+				return nil, err
+			}
+			items = append(items, ber.ContextConstructed(0, tlv))
 		}
-		tlv, err := s.encodeQualifiedElement(centry)
-		if err != nil {
-			return nil, err
-		}
-		kids = append(kids, ber.ContextConstructed(0, tlv))
 	}
-	childCollection := ber.AppConstructed(glow.TagElementCollection, kids...)
 
-	// Wrap the queried element itself as QualifiedNode with children[].
-	node := ber.AppConstructed(glow.TagQualifiedNode,
-		ber.ContextConstructed(glow.QNodePath, ber.RelOID(encodeRelativeOID(e.oidParts))),
-		ber.ContextConstructed(glow.QNodeChildren, childCollection),
-	)
 	root := ber.AppConstructed(glow.TagRoot,
-		ber.AppConstructed(glow.TagRootElementCollection,
-			ber.ContextConstructed(0, node),
-		),
+		ber.AppConstructed(glow.TagRootElementCollection, items...),
 	)
 	return ber.EncodeTLV(root), nil
+}
+
+// encodeElementMinimal emits a qualified element with just the identifier
+// (and description if present) — the shape TinyEmber+ uses for the
+// initial root reply.
+func (s *server) encodeElementMinimal(e *entry) ber.TLV {
+	hdr := e.el.Common()
+	var setChildren []ber.TLV
+	setChildren = append(setChildren,
+		ber.ContextConstructed(glow.NodeContentIdentifier, ber.UTF8(hdr.Identifier)))
+	if hdr.Description != nil && *hdr.Description != "" {
+		setChildren = append(setChildren,
+			ber.ContextConstructed(glow.NodeContentDescription, ber.UTF8(*hdr.Description)))
+	}
+	contents := ber.Set(setChildren...)
+
+	// App tag depends on concrete element kind. For the canonical root we
+	// always emit QualifiedNode; Parameter / Matrix / Function variants
+	// mirror the per-kind encoder below.
+	switch e.el.(type) {
+	case *canonical.Parameter:
+		return ber.AppConstructed(glow.TagQualifiedParameter,
+			ber.ContextConstructed(glow.QParamPath, ber.RelOID(encodeRelativeOID(e.oidParts))),
+			ber.ContextConstructed(glow.QParamContents, contents),
+		)
+	default:
+		return ber.AppConstructed(glow.TagQualifiedNode,
+			ber.ContextConstructed(glow.QNodePath, ber.RelOID(encodeRelativeOID(e.oidParts))),
+			ber.ContextConstructed(glow.QNodeContents, contents),
+		)
+	}
 }
 
 // encodeQualifiedElement dispatches by element kind and emits the
@@ -67,48 +98,100 @@ func (s *server) encodeQualifiedElement(e *entry) (ber.TLV, error) {
 }
 
 func (s *server) encodeQualifiedNode(e *entry, n *canonical.Node) ber.TLV {
-	contents := ber.Set(
-		ber.ContextConstructed(glow.NodeContentIdentifier, ber.UTF8(n.Identifier)),
-	)
+	// Minimal NodeContents — identifier + optional description. Matches
+	// TinyEmber+'s shape; strict viewers reject isRoot/isOnline padding
+	// on per-child replies.
+	var kids []ber.TLV
+	kids = append(kids,
+		ber.ContextConstructed(glow.NodeContentIdentifier, ber.UTF8(n.Identifier)))
 	if n.Description != nil && *n.Description != "" {
-		contents.Children = append(contents.Children,
+		kids = append(kids,
 			ber.ContextConstructed(glow.NodeContentDescription, ber.UTF8(*n.Description)))
 	}
-	contents.Children = append(contents.Children,
-		ber.ContextConstructed(glow.NodeContentIsOnline, ber.Boolean(n.IsOnline)))
-
 	return ber.AppConstructed(glow.TagQualifiedNode,
 		ber.ContextConstructed(glow.QNodePath, ber.RelOID(encodeRelativeOID(e.oidParts))),
-		ber.ContextConstructed(glow.QNodeContents, contents),
+		ber.ContextConstructed(glow.QNodeContents, ber.Set(kids...)),
 	)
 }
 
 func (s *server) encodeQualifiedParameter(e *entry, p *canonical.Parameter) ber.TLV {
-	contents := ber.Set(
-		ber.ContextConstructed(glow.ParamContentIdentifier, ber.UTF8(p.Identifier)),
-	)
+	// ParameterContents SET — fields in ASCENDING context tag order
+	// (DER requirement + EmberViewer enforces it). Spec p.85:
+	//   0 identifier, 1 description, 2 value, 3 minimum, 4 maximum,
+	//   5 access, 6 format, 7 enumeration, 8 factor, 11 step,
+	//   12 default, 13 type, 15 enumMap.
+	var kids []ber.TLV
+	kids = append(kids,
+		ber.ContextConstructed(glow.ParamContentIdentifier, ber.UTF8(p.Identifier))) // [0]
 	if p.Description != nil && *p.Description != "" {
-		contents.Children = append(contents.Children,
-			ber.ContextConstructed(glow.ParamContentDescription, ber.UTF8(*p.Description)))
+		kids = append(kids,
+			ber.ContextConstructed(glow.ParamContentDescription, ber.UTF8(*p.Description))) // [1]
 	}
-	// value
 	if v, ok := encodeValue(p.Type, p.Value); ok {
-		contents.Children = append(contents.Children,
-			ber.ContextConstructed(glow.ParamContentValue, v))
+		kids = append(kids,
+			ber.ContextConstructed(glow.ParamContentValue, v)) // [2]
 	}
-	// type
+	if v, ok := encodeValue(p.Type, p.Minimum); ok {
+		kids = append(kids,
+			ber.ContextConstructed(glow.ParamContentMinimum, v)) // [3]
+	}
+	if v, ok := encodeValue(p.Type, p.Maximum); ok {
+		kids = append(kids,
+			ber.ContextConstructed(glow.ParamContentMaximum, v)) // [4]
+	}
+	kids = append(kids,
+		ber.ContextConstructed(glow.ParamContentAccess, ber.Integer(accessConst(p.Access)))) // [5]
+	if p.Format != nil && *p.Format != "" {
+		kids = append(kids,
+			ber.ContextConstructed(glow.ParamContentFormat, ber.UTF8(*p.Format))) // [6]
+	}
+	if p.Enumeration != nil && *p.Enumeration != "" {
+		kids = append(kids,
+			ber.ContextConstructed(glow.ParamContentEnumeration, ber.UTF8(*p.Enumeration))) // [7]
+	}
+	if p.Factor != nil {
+		kids = append(kids,
+			ber.ContextConstructed(glow.ParamContentFactor, ber.Integer(*p.Factor))) // [8]
+	}
+	if v, ok := encodeValue(p.Type, p.Step); ok {
+		kids = append(kids,
+			ber.ContextConstructed(glow.ParamContentStep, v)) // [11]
+	}
+	if v, ok := encodeValue(p.Type, p.Default); ok {
+		kids = append(kids,
+			ber.ContextConstructed(glow.ParamContentDefault, v)) // [12]
+	}
 	if tc, ok := paramTypeConst(p.Type); ok {
-		contents.Children = append(contents.Children,
-			ber.ContextConstructed(glow.ParamContentType, ber.Integer(tc)))
+		kids = append(kids,
+			ber.ContextConstructed(glow.ParamContentType, ber.Integer(tc))) // [13]
 	}
-	// access
-	contents.Children = append(contents.Children,
-		ber.ContextConstructed(glow.ParamContentAccess, ber.Integer(accessConst(p.Access))))
-
+	if len(p.EnumMap) > 0 {
+		kids = append(kids,
+			ber.ContextConstructed(glow.ParamContentEnumMap, encodeEnumMap(p.EnumMap))) // [15]
+	}
 	return ber.AppConstructed(glow.TagQualifiedParameter,
 		ber.ContextConstructed(glow.QParamPath, ber.RelOID(encodeRelativeOID(e.oidParts))),
-		ber.ContextConstructed(glow.QParamContents, contents),
+		ber.ContextConstructed(glow.QParamContents, ber.Set(kids...)),
 	)
+}
+
+// encodeEnumMap builds a StringIntegerCollection — the canonical form
+// of Parameter.enumMap (spec p.86 StringIntegerPair / Collection).
+//
+//	StringIntegerCollection ::= [APPLICATION 8] SEQUENCE OF [0] StringIntegerPair
+//	StringIntegerPair       ::= [APPLICATION 7] SEQUENCE {
+//	  entryString  [0] EmberString,
+//	  entryInteger [1] Integer64 }
+func encodeEnumMap(entries []canonical.EnumEntry) ber.TLV {
+	pairs := make([]ber.TLV, 0, len(entries))
+	for _, en := range entries {
+		pair := ber.AppConstructed(glow.TagStringIntegerPair,
+			ber.ContextConstructed(0, ber.UTF8(en.Key)),
+			ber.ContextConstructed(1, ber.Integer(en.Value)),
+		)
+		pairs = append(pairs, ber.ContextConstructed(0, pair))
+	}
+	return ber.AppConstructed(glow.TagStringIntegerCollection, pairs...)
 }
 
 // encodeParamAnnouncement produces a value-change announcement — same

--- a/internal/provider/emberplus/encoder.go
+++ b/internal/provider/emberplus/encoder.go
@@ -149,7 +149,11 @@ func (s *server) encodeQualifiedParameter(e *entry, p *canonical.Parameter) ber.
 		kids = append(kids,
 			ber.ContextConstructed(glow.ParamContentEnumeration, ber.UTF8(*p.Enumeration))) // [7]
 	}
-	if p.Factor != nil {
+	// Emit factor only when it actually scales something. factor=0 / 1 are
+	// no-ops on the spec (display = value * factor or value / factor
+	// depending on provider convention). Emitting factor=1 trips the tree
+	// cell update path in EmberViewer — skip it.
+	if p.Factor != nil && *p.Factor != 0 && *p.Factor != 1 {
 		kids = append(kids,
 			ber.ContextConstructed(glow.ParamContentFactor, ber.Integer(*p.Factor))) // [8]
 	}

--- a/internal/provider/emberplus/encoder.go
+++ b/internal/provider/emberplus/encoder.go
@@ -1,0 +1,252 @@
+package emberplus
+
+import (
+	"fmt"
+
+	"acp/internal/export/canonical"
+	"acp/internal/protocol/emberplus/ber"
+	"acp/internal/protocol/emberplus/glow"
+)
+
+// encodeGetDirReply walks the tree entry e and produces the BER payload
+// for a GetDirectory reply. The shape is:
+//
+//	Root → RootElementCollection → Context[0] → QualifiedNode(path) →
+//	  children → ElementCollection →
+//	    Context[0] → QualifiedNode | QualifiedParameter | QualifiedMatrix | QualifiedFunction
+//	    Context[0] → (next sibling)
+//	    ...
+//
+// Always emits qualified forms so consumers walking by path resolve each
+// child independently — the lax "bare Node with number only" form is
+// valid wire but upsets strict providers' walkers; provider should
+// always emit the strict-safe shape.
+func (s *server) encodeGetDirReply(e *entry) ([]byte, error) {
+	hdr := e.el.Common()
+
+	// Build the children collection as [0]-wrapped qualified elements.
+	kids := make([]ber.TLV, 0, len(hdr.Children))
+	for _, child := range hdr.Children {
+		centry := s.tree.byOID[child.Common().OID]
+		if centry == nil {
+			return nil, fmt.Errorf("encoder: missing index for %q", child.Common().OID)
+		}
+		tlv, err := s.encodeQualifiedElement(centry)
+		if err != nil {
+			return nil, err
+		}
+		kids = append(kids, ber.ContextConstructed(0, tlv))
+	}
+	childCollection := ber.AppConstructed(glow.TagElementCollection, kids...)
+
+	// Wrap the queried element itself as QualifiedNode with children[].
+	node := ber.AppConstructed(glow.TagQualifiedNode,
+		ber.ContextConstructed(glow.QNodePath, ber.RelOID(encodeRelativeOID(e.oidParts))),
+		ber.ContextConstructed(glow.QNodeChildren, childCollection),
+	)
+	root := ber.AppConstructed(glow.TagRoot,
+		ber.AppConstructed(glow.TagRootElementCollection,
+			ber.ContextConstructed(0, node),
+		),
+	)
+	return ber.EncodeTLV(root), nil
+}
+
+// encodeQualifiedElement dispatches by element kind and emits the
+// appropriate qualified form WITH contents so a walking consumer learns
+// everything it needs about the element in one frame.
+func (s *server) encodeQualifiedElement(e *entry) (ber.TLV, error) {
+	switch el := e.el.(type) {
+	case *canonical.Node:
+		return s.encodeQualifiedNode(e, el), nil
+	case *canonical.Parameter:
+		return s.encodeQualifiedParameter(e, el), nil
+	default:
+		return ber.TLV{}, fmt.Errorf("encoder: element kind %q not yet implemented", e.el.Kind())
+	}
+}
+
+func (s *server) encodeQualifiedNode(e *entry, n *canonical.Node) ber.TLV {
+	contents := ber.Set(
+		ber.ContextConstructed(glow.NodeContentIdentifier, ber.UTF8(n.Identifier)),
+	)
+	if n.Description != nil && *n.Description != "" {
+		contents.Children = append(contents.Children,
+			ber.ContextConstructed(glow.NodeContentDescription, ber.UTF8(*n.Description)))
+	}
+	contents.Children = append(contents.Children,
+		ber.ContextConstructed(glow.NodeContentIsOnline, ber.Boolean(n.IsOnline)))
+
+	return ber.AppConstructed(glow.TagQualifiedNode,
+		ber.ContextConstructed(glow.QNodePath, ber.RelOID(encodeRelativeOID(e.oidParts))),
+		ber.ContextConstructed(glow.QNodeContents, contents),
+	)
+}
+
+func (s *server) encodeQualifiedParameter(e *entry, p *canonical.Parameter) ber.TLV {
+	contents := ber.Set(
+		ber.ContextConstructed(glow.ParamContentIdentifier, ber.UTF8(p.Identifier)),
+	)
+	if p.Description != nil && *p.Description != "" {
+		contents.Children = append(contents.Children,
+			ber.ContextConstructed(glow.ParamContentDescription, ber.UTF8(*p.Description)))
+	}
+	// value
+	if v, ok := encodeValue(p.Type, p.Value); ok {
+		contents.Children = append(contents.Children,
+			ber.ContextConstructed(glow.ParamContentValue, v))
+	}
+	// type
+	if tc, ok := paramTypeConst(p.Type); ok {
+		contents.Children = append(contents.Children,
+			ber.ContextConstructed(glow.ParamContentType, ber.Integer(tc)))
+	}
+	// access
+	contents.Children = append(contents.Children,
+		ber.ContextConstructed(glow.ParamContentAccess, ber.Integer(accessConst(p.Access))))
+
+	return ber.AppConstructed(glow.TagQualifiedParameter,
+		ber.ContextConstructed(glow.QParamPath, ber.RelOID(encodeRelativeOID(e.oidParts))),
+		ber.ContextConstructed(glow.QParamContents, contents),
+	)
+}
+
+// encodeParamAnnouncement produces a value-change announcement — same
+// shape as a walk reply for a single QualifiedParameter, so consumers
+// with a subscribe-only path treat it as an update.
+func (s *server) encodeParamAnnouncement(e *entry, p *canonical.Parameter) []byte {
+	qp := s.encodeQualifiedParameter(e, p)
+	root := ber.AppConstructed(glow.TagRoot,
+		ber.AppConstructed(glow.TagRootElementCollection,
+			ber.ContextConstructed(0, qp),
+		),
+	)
+	return ber.EncodeTLV(root)
+}
+
+// encodeValue dispatches a Parameter's canonical Value to the BER encoding
+// for the declared Type. Returns (tlv, true) on success; (_, false) if
+// value is nil or type is unsupported — caller skips the field.
+func encodeValue(typ string, v any) (ber.TLV, bool) {
+	if v == nil {
+		return ber.TLV{}, false
+	}
+	switch typ {
+	case canonical.ParamInteger, canonical.ParamEnum:
+		i, ok := asInt64(v)
+		if !ok {
+			return ber.TLV{}, false
+		}
+		return ber.Integer(i), true
+	case canonical.ParamReal:
+		f, ok := asFloat64(v)
+		if !ok {
+			return ber.TLV{}, false
+		}
+		return ber.Real(f), true
+	case canonical.ParamString:
+		s, ok := v.(string)
+		if !ok {
+			return ber.TLV{}, false
+		}
+		return ber.UTF8(s), true
+	case canonical.ParamBoolean:
+		b, ok := v.(bool)
+		if !ok {
+			return ber.TLV{}, false
+		}
+		return ber.Boolean(b), true
+	case canonical.ParamOctets:
+		if b, ok := v.([]byte); ok {
+			return ber.OctetStr(b), true
+		}
+		return ber.TLV{}, false
+	}
+	return ber.TLV{}, false
+}
+
+func paramTypeConst(typ string) (int64, bool) {
+	switch typ {
+	case canonical.ParamInteger:
+		return glow.ParamTypeInteger, true
+	case canonical.ParamReal:
+		return glow.ParamTypeReal, true
+	case canonical.ParamString:
+		return glow.ParamTypeString, true
+	case canonical.ParamBoolean:
+		return glow.ParamTypeBoolean, true
+	case canonical.ParamTrigger:
+		return glow.ParamTypeTrigger, true
+	case canonical.ParamEnum:
+		return glow.ParamTypeEnum, true
+	case canonical.ParamOctets:
+		return glow.ParamTypeOctets, true
+	}
+	return 0, false
+}
+
+func accessConst(a string) int64 {
+	switch a {
+	case canonical.AccessRead:
+		return glow.AccessRead
+	case canonical.AccessWrite:
+		return glow.AccessWrite
+	case canonical.AccessReadWrite:
+		return glow.AccessReadWrite
+	}
+	return glow.AccessNone
+}
+
+func asInt64(v any) (int64, bool) {
+	switch t := v.(type) {
+	case int:
+		return int64(t), true
+	case int32:
+		return int64(t), true
+	case int64:
+		return t, true
+	case float64:
+		return int64(t), true
+	}
+	return 0, false
+}
+
+func asFloat64(v any) (float64, bool) {
+	switch t := v.(type) {
+	case float64:
+		return t, true
+	case float32:
+		return float64(t), true
+	case int:
+		return float64(t), true
+	case int64:
+		return float64(t), true
+	}
+	return 0, false
+}
+
+// encodeRelativeOID encodes a path as RELATIVE-OID (base-128 per subid).
+// Duplicate of glow/encoder.go's private helper — kept local to avoid
+// exporting from the consumer-side package.
+func encodeRelativeOID(path []uint32) []byte {
+	var out []byte
+	for _, v := range path {
+		out = append(out, encodeBase128(v)...)
+	}
+	return out
+}
+
+func encodeBase128(v uint32) []byte {
+	if v < 128 {
+		return []byte{byte(v)}
+	}
+	var parts []byte
+	for v > 0 {
+		parts = append([]byte{byte(v & 0x7F)}, parts...)
+		v >>= 7
+	}
+	for i := 0; i < len(parts)-1; i++ {
+		parts[i] |= 0x80
+	}
+	return parts
+}

--- a/internal/provider/emberplus/encoder_test.go
+++ b/internal/provider/emberplus/encoder_test.go
@@ -50,7 +50,9 @@ func TestRoundTrip_NodeWithParameter(t *testing.T) {
 		t.Fatal("tree failed to build")
 	}
 
-	reply, err := srv.encodeGetDirReply(srv.tree.rootEntry())
+	// Request bareRoot=false: after initial root reply, consumer issues
+	// GetDirectory on path=[1] → we reply with children flat.
+	reply, err := srv.encodeGetDirReply(srv.tree.rootEntry(), false)
 	if err != nil {
 		t.Fatalf("encode: %v", err)
 	}
@@ -59,22 +61,16 @@ func TestRoundTrip_NodeWithParameter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if len(els) != 1 || els[0].Node == nil {
-		t.Fatalf("expected one QualifiedNode, got %+v", els)
+	// Spec pattern: GetDirectory on path=[1] returns children flat at the
+	// RootElementCollection level. Here the only child is the "gain"
+	// QualifiedParameter, so we expect exactly one element and it to be
+	// a Parameter at path [1,1].
+	if len(els) != 1 {
+		t.Fatalf("want 1 element, got %d: %+v", len(els), els)
 	}
-	decodedRoot := els[0].Node
-	// A GetDirectory reply wraps the queried Node but omits its own
-	// contents — the consumer already has those from the parent walk.
-	// Only the child collection is expected to be populated.
-	if len(decodedRoot.Children) != 1 {
-		t.Fatalf("want 1 child, got %d", len(decodedRoot.Children))
-	}
-	if len(decodedRoot.Path) != 1 || decodedRoot.Path[0] != 1 {
-		t.Errorf("root path = %v, want [1]", decodedRoot.Path)
-	}
-	p := decodedRoot.Children[0].Parameter
+	p := els[0].Parameter
 	if p == nil {
-		t.Fatalf("child is not a parameter: %+v", decodedRoot.Children[0])
+		t.Fatalf("expected a QualifiedParameter, got %+v", els[0])
 	}
 	if p.Identifier != "gain" {
 		t.Errorf("param identifier = %q, want gain", p.Identifier)

--- a/internal/provider/emberplus/encoder_test.go
+++ b/internal/provider/emberplus/encoder_test.go
@@ -1,0 +1,123 @@
+package emberplus
+
+import (
+	"context"
+	"testing"
+
+	"acp/internal/export/canonical"
+	"acp/internal/protocol/emberplus/glow"
+)
+
+// TestRoundTrip_NodeWithParameter asserts the provider encoder and the
+// consumer decoder agree on the wire shape for a trivial tree:
+//
+//	router (Node OID=1) → Gain (Parameter OID=1.1, Integer 42, RW)
+//
+// The encoder's GetDirectory reply for the root must decode back through
+// the consumer's glow.DecodeRoot into a tree with the same identifiers,
+// OIDs, access bits, and value.
+func TestRoundTrip_NodeWithParameter(t *testing.T) {
+	desc := "test gain"
+	gain := &canonical.Parameter{
+		Header: canonical.Header{
+			Number:      1,
+			Identifier:  "gain",
+			Path:        "router.gain",
+			OID:         "1.1",
+			Description: &desc,
+			IsOnline:    true,
+			Access:      canonical.AccessReadWrite,
+			Children:    canonical.EmptyChildren(),
+		},
+		Type:  canonical.ParamInteger,
+		Value: int64(42),
+	}
+	root := &canonical.Node{
+		Header: canonical.Header{
+			Number:     1,
+			Identifier: "router",
+			Path:       "router",
+			OID:        "1",
+			IsOnline:   true,
+			Access:     canonical.AccessRead,
+			Children:   []canonical.Element{gain},
+		},
+	}
+	exp := &canonical.Export{Root: root}
+
+	srv := newServer(nil, exp)
+	if srv.tree == nil {
+		t.Fatal("tree failed to build")
+	}
+
+	reply, err := srv.encodeGetDirReply(srv.tree.rootEntry())
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	els, err := glow.DecodeRoot(reply)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(els) != 1 || els[0].Node == nil {
+		t.Fatalf("expected one QualifiedNode, got %+v", els)
+	}
+	decodedRoot := els[0].Node
+	// A GetDirectory reply wraps the queried Node but omits its own
+	// contents — the consumer already has those from the parent walk.
+	// Only the child collection is expected to be populated.
+	if len(decodedRoot.Children) != 1 {
+		t.Fatalf("want 1 child, got %d", len(decodedRoot.Children))
+	}
+	if len(decodedRoot.Path) != 1 || decodedRoot.Path[0] != 1 {
+		t.Errorf("root path = %v, want [1]", decodedRoot.Path)
+	}
+	p := decodedRoot.Children[0].Parameter
+	if p == nil {
+		t.Fatalf("child is not a parameter: %+v", decodedRoot.Children[0])
+	}
+	if p.Identifier != "gain" {
+		t.Errorf("param identifier = %q, want gain", p.Identifier)
+	}
+	if p.Value != int64(42) {
+		t.Errorf("param value = %v (%T), want 42", p.Value, p.Value)
+	}
+	if p.Access != glow.AccessReadWrite {
+		t.Errorf("param access = %d, want %d", p.Access, glow.AccessReadWrite)
+	}
+	if p.Type != glow.ParamTypeInteger {
+		t.Errorf("param type = %d, want %d", p.Type, glow.ParamTypeInteger)
+	}
+	// Path should be [1,1]
+	if len(p.Path) != 2 || p.Path[0] != 1 || p.Path[1] != 1 {
+		t.Errorf("param path = %v, want [1 1]", p.Path)
+	}
+}
+
+func TestSetValueBroadcast_UpdatesTree(t *testing.T) {
+	p := &canonical.Parameter{
+		Header: canonical.Header{
+			Number: 1, Identifier: "gain", Path: "router.gain", OID: "1.1",
+			IsOnline: true, Access: canonical.AccessReadWrite,
+			Children: canonical.EmptyChildren(),
+		},
+		Type:  canonical.ParamInteger,
+		Value: int64(0),
+	}
+	root := &canonical.Node{
+		Header: canonical.Header{
+			Number: 1, Identifier: "router", Path: "router", OID: "1",
+			IsOnline: true, Access: canonical.AccessRead,
+			Children: []canonical.Element{p},
+		},
+	}
+	srv := newServer(nil, &canonical.Export{Root: root})
+
+	if _, err := srv.SetValue(context.Background(), "1.1", int64(99)); err != nil {
+		t.Fatalf("SetValue: %v", err)
+	}
+	updated := srv.tree.byOID["1.1"].el.(*canonical.Parameter)
+	if updated.Value != int64(99) {
+		t.Errorf("tree value = %v, want 99", updated.Value)
+	}
+}

--- a/internal/provider/emberplus/plugin.go
+++ b/internal/provider/emberplus/plugin.go
@@ -1,0 +1,49 @@
+// Package emberplus is the Ember+ provider plugin — it serves a Glow tree
+// over S101/TCP to any number of consumers.
+//
+// Layering (mirror of the consumer):
+//
+//	tree.go      canonical.Export -> in-memory Node/Param/Matrix snapshot
+//	encoder.go   tree walk -> Glow BER bytes (QualifiedParameter etc.)
+//	session.go   per-connection consumer state (subscriptions, out queue)
+//	server.go    TCP accept loop, fan-out on SetValue
+//	plugin.go    (this file) Factory + registration
+//
+// Reuses consumer-side packages for symmetric work:
+//
+//	internal/protocol/emberplus/s101    framing (symmetric)
+//	internal/protocol/emberplus/ber     TLV codec
+//	internal/protocol/emberplus/glow    decoder + tag constants (decoder is symmetric)
+package emberplus
+
+import (
+	"log/slog"
+
+	"acp/internal/export/canonical"
+	"acp/internal/provider"
+)
+
+// DefaultPort matches the scope of issue #66 — non-overlapping with the
+// conventional Ember+ consumer-side ports (9000/9090/9092).
+const DefaultPort = 9010
+
+func init() {
+	provider.Register(&Factory{})
+}
+
+// Factory registers the Ember+ provider plugin with the compile-time registry.
+type Factory struct{}
+
+// Meta publishes the static descriptor used by the CLI + API.
+func (f *Factory) Meta() provider.Meta {
+	return provider.Meta{
+		Name:        "emberplus",
+		DefaultPort: DefaultPort,
+		Description: "Ember+ (Glow/S101/TCP) provider — serves a canonical tree to consumers",
+	}
+}
+
+// New constructs a fresh provider around the supplied tree.
+func (f *Factory) New(logger *slog.Logger, tree *canonical.Export) provider.Provider {
+	return newServer(logger, tree)
+}

--- a/internal/provider/emberplus/server.go
+++ b/internal/provider/emberplus/server.go
@@ -1,0 +1,199 @@
+package emberplus
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"sync"
+
+	"acp/internal/export/canonical"
+)
+
+// server is the provider runtime. One listener, many sessions, a shared
+// tree, and a per-OID subscription table.
+type server struct {
+	logger *slog.Logger
+	tree   *tree
+
+	mu       sync.Mutex
+	listener net.Listener
+	sessions map[*session]struct{}
+	// subs: oid -> set of sessions watching it
+	subs map[string]map[*session]struct{}
+
+	stopOnce sync.Once
+	stopped  chan struct{}
+}
+
+func newServer(logger *slog.Logger, exp *canonical.Export) *server {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	t, err := newTree(exp)
+	s := &server{
+		logger:   logger.With(slog.String("plugin", "emberplus-provider")),
+		sessions: map[*session]struct{}{},
+		subs:     map[string]map[*session]struct{}{},
+		stopped:  make(chan struct{}),
+	}
+	if err != nil {
+		// defer until Serve so the factory signature stays clean
+		s.logger.Error("tree build failed", slog.String("err", err.Error()))
+	} else {
+		s.tree = t
+	}
+	return s
+}
+
+// Serve implements provider.Provider. Blocks until ctx is cancelled or
+// the listener returns a fatal error.
+func (s *server) Serve(ctx context.Context, addr string) error {
+	if s.tree == nil {
+		return fmt.Errorf("emberplus-provider: tree not loaded")
+	}
+	lc := net.ListenConfig{}
+	ln, err := lc.Listen(ctx, "tcp", addr)
+	if err != nil {
+		return fmt.Errorf("listen %s: %w", addr, err)
+	}
+	s.mu.Lock()
+	s.listener = ln
+	s.mu.Unlock()
+
+	s.logger.Info("listening",
+		slog.String("addr", ln.Addr().String()),
+		slog.Int("tree_size", len(s.tree.byOID)),
+	)
+
+	// Close listener on ctx cancel to unblock Accept.
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-s.stopped:
+		}
+		_ = ln.Close()
+	}()
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			if ctx.Err() != nil {
+				return nil
+			}
+			s.logger.Debug("accept", slog.String("err", err.Error()))
+			continue
+		}
+		sess := newSession(s, conn)
+		s.registerSession(sess)
+		go sess.run(ctx)
+	}
+}
+
+// Stop implements provider.Provider.
+func (s *server) Stop() error {
+	s.stopOnce.Do(func() {
+		close(s.stopped)
+		s.mu.Lock()
+		ln := s.listener
+		sessions := make([]*session, 0, len(s.sessions))
+		for sess := range s.sessions {
+			sessions = append(sessions, sess)
+		}
+		s.mu.Unlock()
+		if ln != nil {
+			_ = ln.Close()
+		}
+		for _, sess := range sessions {
+			sess.close()
+		}
+	})
+	return nil
+}
+
+// SetValue mutates a parameter on the served tree and broadcasts a
+// QualifiedParameter announcement to every subscribed consumer.
+func (s *server) SetValue(ctx context.Context, path string, val any) (any, error) {
+	oid := path
+	// Allow dotted identifier paths — resolve to OID via the tree index.
+	if e, ok := s.tree.lookupPath(path); ok {
+		oid = e.el.Common().OID
+	}
+	p, err := s.tree.setParamValue(oid, val)
+	if err != nil {
+		return nil, err
+	}
+	s.broadcastParam(oid, p)
+	return p.Value, nil
+}
+
+// --- Session bookkeeping ---
+
+func (s *server) registerSession(sess *session) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sessions[sess] = struct{}{}
+}
+
+func (s *server) dropSession(sess *session) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.sessions, sess)
+	for oid, set := range s.subs {
+		delete(set, sess)
+		if len(set) == 0 {
+			delete(s.subs, oid)
+		}
+	}
+}
+
+func (s *server) subscribe(sess *session, oid string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	set, ok := s.subs[oid]
+	if !ok {
+		set = map[*session]struct{}{}
+		s.subs[oid] = set
+	}
+	set[sess] = struct{}{}
+	sess.subs[oid] = struct{}{}
+}
+
+func (s *server) unsubscribe(sess *session, oid string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if set, ok := s.subs[oid]; ok {
+		delete(set, sess)
+		if len(set) == 0 {
+			delete(s.subs, oid)
+		}
+	}
+	delete(sess.subs, oid)
+}
+
+// broadcastParam fans out a QualifiedParameter announcement to every
+// consumer subscribed to the given OID. Subscribers that missed the
+// send-queue high-water-mark silently drop the frame — see session.send.
+func (s *server) broadcastParam(oid string, p *canonical.Parameter) {
+	e, ok := s.tree.lookupOID(oid)
+	if !ok {
+		return
+	}
+	payload := s.encodeParamAnnouncement(e, p)
+
+	s.mu.Lock()
+	set := s.subs[oid]
+	targets := make([]*session, 0, len(set))
+	for sess := range set {
+		targets = append(targets, sess)
+	}
+	s.mu.Unlock()
+
+	for _, sess := range targets {
+		sess.send(payload)
+	}
+}

--- a/internal/provider/emberplus/session.go
+++ b/internal/provider/emberplus/session.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 
+	"acp/internal/export/canonical"
 	"acp/internal/protocol/emberplus/glow"
 	"acp/internal/protocol/emberplus/s101"
 )
@@ -144,39 +145,68 @@ func (s *session) handleFrame(f *s101.Frame) error {
 	}
 }
 
-// handleEmber parses a Glow-encoded request, locates the embedded Command,
-// and dispatches it. MVP handles GetDirectory (32) / Subscribe (30) /
-// Unsubscribe (31). Invoke (33) is answered with a synthetic denial.
+// handleEmber parses a Glow-encoded request and dispatches it.
+//
+// Two inbound shapes are handled:
+//
+//  1. Command request — GetDirectory (32) / Subscribe (30) / Unsubscribe (31).
+//     Invoke (33) is a no-op in MVP.
+//
+//  2. SetValue request — a QualifiedParameter (or nested Node → Parameter)
+//     carrying `contents.value`. Applied via server.SetValue; the resulting
+//     announcement is broadcast to subscribers including the sender.
 func (s *session) handleEmber(payload []byte) error {
 	els, err := glow.DecodeRoot(payload)
 	if err != nil {
 		return fmt.Errorf("decode glow: %w", err)
 	}
-	cmd, path := findCommandInElements(els)
-	if cmd == nil {
-		return nil // no actionable command; ignore silently
-	}
-	oid := oidFromPath(path)
-	switch cmd.Number {
-	case glow.CmdGetDirectory:
-		return s.replyGetDirectory(oid)
-	case glow.CmdSubscribe:
-		s.srv.subscribe(s, oid)
-		return nil
-	case glow.CmdUnsubscribe:
-		s.srv.unsubscribe(s, oid)
-		return nil
-	case glow.CmdInvoke:
-		// MVP: no function execution
-		return nil
-	default:
+
+	if cmd, path := findCommandInElements(els); cmd != nil {
+		oid := oidFromPath(path)
+		switch cmd.Number {
+		case glow.CmdGetDirectory:
+			return s.replyGetDirectory(oid)
+		case glow.CmdSubscribe:
+			s.srv.subscribe(s, oid)
+			return nil
+		case glow.CmdUnsubscribe:
+			s.srv.unsubscribe(s, oid)
+			return nil
+		case glow.CmdInvoke:
+			return nil
+		}
 		return nil
 	}
+
+	if path, val, ok := findSetValueInElements(els); ok {
+		oid := oidFromPath(path)
+		s.logger.Debug("set value", slog.String("oid", oid), slog.Any("val", val))
+		if _, err := s.srv.SetValue(context.TODO(), oid, val); err != nil {
+			s.logger.Debug("set value failed", slog.String("oid", oid), slog.String("err", err.Error()))
+			return nil
+		}
+		// Strict consumers (EmberViewer) don't auto-subscribe — they expect
+		// the provider to echo every SetValue with a QualifiedParameter
+		// announcement carrying the confirmed value. Without the echo
+		// they keep retrying the set. Send it regardless of subscription.
+		if e, eok := s.srv.tree.lookupOID(oid); eok {
+			if p, pok := e.el.(*canonical.Parameter); pok {
+				s.send(s.srv.encodeParamAnnouncement(e, p))
+			}
+		}
+		return nil
+	}
+	return nil
 }
 
 func (s *session) replyGetDirectory(oid string) error {
+	// Empty oid means consumer sent a bare Command(32) at the root of the
+	// element collection — spec pattern: reply with the single top-level
+	// element (identifier only). Non-empty oid means consumer sent the
+	// Command nested in QualifiedNode(P); reply with P's children flat.
+	bareRoot := oid == ""
 	var e *entry
-	if oid == "" {
+	if bareRoot {
 		e = s.srv.tree.rootEntry()
 	} else {
 		var ok bool
@@ -185,7 +215,7 @@ func (s *session) replyGetDirectory(oid string) error {
 			return fmt.Errorf("unknown path %q", oid)
 		}
 	}
-	payload, err := s.srv.encodeGetDirReply(e)
+	payload, err := s.srv.encodeGetDirReply(e, bareRoot)
 	if err != nil {
 		return fmt.Errorf("encode reply: %w", err)
 	}
@@ -227,6 +257,53 @@ func findCommandInElements(els []glow.Element) (*glow.Command, []uint32) {
 		}
 	}
 	return nil, nil
+}
+
+// findSetValueInElements walks the decoded tree looking for a Parameter
+// (or QualifiedParameter) that carries a non-nil contents.value. Returns
+// the absolute path and the new value. Consumers may wrap the Parameter
+// in any depth of Node / QualifiedNode / QualifiedParameter layers — the
+// walker concatenates their Path / Number segments in order.
+func findSetValueInElements(els []glow.Element) ([]uint32, any, bool) {
+	for _, e := range els {
+		if e.Parameter != nil {
+			base := paramBasePath(e.Parameter)
+			if e.Parameter.Value != nil {
+				return base, e.Parameter.Value, true
+			}
+			if sub, v, ok := findSetValueInElements(e.Parameter.Children); ok {
+				return append(append([]uint32{}, base...), sub...), v, true
+			}
+		}
+		if e.Node != nil {
+			base := nodeBasePath(e.Node)
+			if sub, v, ok := findSetValueInElements(e.Node.Children); ok {
+				return append(append([]uint32{}, base...), sub...), v, true
+			}
+			_ = base
+		}
+	}
+	return nil, nil, false
+}
+
+func nodeBasePath(n *glow.Node) []uint32 {
+	if len(n.Path) > 0 {
+		return toUint32(n.Path)
+	}
+	if n.Number != 0 {
+		return []uint32{uint32(n.Number)}
+	}
+	return nil
+}
+
+func paramBasePath(p *glow.Parameter) []uint32 {
+	if len(p.Path) > 0 {
+		return toUint32(p.Path)
+	}
+	if p.Number != 0 {
+		return []uint32{uint32(p.Number)}
+	}
+	return nil
 }
 
 func oidFromPath(parts []uint32) string {

--- a/internal/provider/emberplus/session.go
+++ b/internal/provider/emberplus/session.go
@@ -1,0 +1,252 @@
+package emberplus
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"strings"
+	"sync"
+
+	"acp/internal/protocol/emberplus/glow"
+	"acp/internal/protocol/emberplus/s101"
+)
+
+// session is one live consumer connection. Single read loop; a send
+// channel serialises outgoing S101 frames so the encoder + keepalive +
+// announcement paths can fan in without synchronising a raw net.Conn.
+type session struct {
+	id        string
+	conn      net.Conn
+	reader    *s101.Reader
+	writer    *s101.Writer
+	srv       *server
+	logger    *slog.Logger
+	out       chan []byte
+	closeOnce sync.Once
+	closed    chan struct{}
+
+	// subs is the set of OIDs this consumer subscribed to. Protected by
+	// server.mu (subscription table fan-out is server-wide).
+	subs map[string]struct{}
+}
+
+func newSession(srv *server, conn net.Conn) *session {
+	return &session{
+		id:     conn.RemoteAddr().String(),
+		conn:   conn,
+		reader: s101.NewReader(conn),
+		writer: s101.NewWriter(conn),
+		srv:    srv,
+		logger: srv.logger.With(slog.String("peer", conn.RemoteAddr().String())),
+		out:    make(chan []byte, 32),
+		closed: make(chan struct{}),
+		subs:   map[string]struct{}{},
+	}
+}
+
+// run is the session lifecycle: start write pump, read frames until EOF
+// or error, close on exit. Returns once the session is fully torn down.
+func (s *session) run(ctx context.Context) {
+	defer s.close()
+
+	go s.writePump(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		frame, err := s.reader.ReadFrame()
+		if err != nil {
+			if !errors.Is(err, io.EOF) && !errors.Is(err, net.ErrClosed) {
+				s.logger.Debug("read frame", slog.String("err", err.Error()))
+			}
+			return
+		}
+		if err := s.handleFrame(frame); err != nil {
+			s.logger.Debug("handle frame", slog.String("err", err.Error()))
+			// non-fatal — keep reading.
+		}
+	}
+}
+
+// writePump drains s.out onto the wire. Closes the conn on ctx-cancel or
+// channel close so the read side unblocks too.
+func (s *session) writePump(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.closed:
+			return
+		case payload, ok := <-s.out:
+			if !ok {
+				return
+			}
+			frame := &s101.Frame{
+				Slot:    s101.SlotDefault,
+				MsgType: s101.MsgEmBER,
+				Command: s101.CmdEmBER,
+				Version: s101.VersionS101,
+				Flags:   s101.FlagSingle,
+				DTD:     s101.DTDGlow,
+				Payload: payload,
+			}
+			if err := s.writer.WriteFrame(frame); err != nil {
+				s.logger.Debug("write frame", slog.String("err", err.Error()))
+				return
+			}
+		}
+	}
+}
+
+// send enqueues a BER-encoded Glow payload for transmission. Non-blocking
+// if the queue has room; drops the frame with a warning if the consumer
+// is slow enough to fill 32 entries — prevents a stuck consumer from
+// ballooning memory or blocking the broadcast fan-out.
+func (s *session) send(payload []byte) {
+	select {
+	case s.out <- payload:
+	default:
+		s.logger.Warn("send queue full, dropping frame")
+	}
+}
+
+func (s *session) close() {
+	s.closeOnce.Do(func() {
+		close(s.closed)
+		_ = s.conn.Close()
+		s.srv.dropSession(s)
+	})
+}
+
+// handleFrame processes one incoming S101 frame. Keepalives get an
+// immediate response; EmBER frames are decoded as Glow and dispatched.
+func (s *session) handleFrame(f *s101.Frame) error {
+	switch f.Command {
+	case s101.CmdKeepAliveReq:
+		return s.writer.WriteFrame(&s101.Frame{
+			Slot:    s101.SlotDefault,
+			MsgType: s101.MsgKeepAlive,
+			Command: s101.CmdKeepAliveResp,
+			Version: s101.VersionS101,
+		})
+	case s101.CmdKeepAliveResp:
+		return nil
+	case s101.CmdEmBER:
+		return s.handleEmber(f.Payload)
+	default:
+		return nil
+	}
+}
+
+// handleEmber parses a Glow-encoded request, locates the embedded Command,
+// and dispatches it. MVP handles GetDirectory (32) / Subscribe (30) /
+// Unsubscribe (31). Invoke (33) is answered with a synthetic denial.
+func (s *session) handleEmber(payload []byte) error {
+	els, err := glow.DecodeRoot(payload)
+	if err != nil {
+		return fmt.Errorf("decode glow: %w", err)
+	}
+	cmd, path := findCommandInElements(els)
+	if cmd == nil {
+		return nil // no actionable command; ignore silently
+	}
+	oid := oidFromPath(path)
+	switch cmd.Number {
+	case glow.CmdGetDirectory:
+		return s.replyGetDirectory(oid)
+	case glow.CmdSubscribe:
+		s.srv.subscribe(s, oid)
+		return nil
+	case glow.CmdUnsubscribe:
+		s.srv.unsubscribe(s, oid)
+		return nil
+	case glow.CmdInvoke:
+		// MVP: no function execution
+		return nil
+	default:
+		return nil
+	}
+}
+
+func (s *session) replyGetDirectory(oid string) error {
+	var e *entry
+	if oid == "" {
+		e = s.srv.tree.rootEntry()
+	} else {
+		var ok bool
+		e, ok = s.srv.tree.lookupOID(oid)
+		if !ok {
+			return fmt.Errorf("unknown path %q", oid)
+		}
+	}
+	payload, err := s.srv.encodeGetDirReply(e)
+	if err != nil {
+		return fmt.Errorf("encode reply: %w", err)
+	}
+	s.send(payload)
+	return nil
+}
+
+// findCommandInElements walks the decoded element tree and returns the
+// first Command found along with the path to its containing element.
+// Path is built from QualifiedNode.Path / QualifiedParameter.Path if
+// present, else from chained Node.Number values for the non-qualified
+// form.
+func findCommandInElements(els []glow.Element) (*glow.Command, []uint32) {
+	for _, e := range els {
+		if e.Command != nil {
+			return e.Command, nil
+		}
+		if e.Node != nil {
+			basePath := []uint32(nil)
+			if len(e.Node.Path) > 0 {
+				basePath = toUint32(e.Node.Path)
+			} else if e.Node.Number != 0 {
+				basePath = []uint32{uint32(e.Node.Number)}
+			}
+			if c, sub := findCommandInElements(e.Node.Children); c != nil {
+				return c, append(append([]uint32{}, basePath...), sub...)
+			}
+		}
+		if e.Parameter != nil {
+			basePath := []uint32(nil)
+			if len(e.Parameter.Path) > 0 {
+				basePath = toUint32(e.Parameter.Path)
+			} else if e.Parameter.Number != 0 {
+				basePath = []uint32{uint32(e.Parameter.Number)}
+			}
+			if c, sub := findCommandInElements(e.Parameter.Children); c != nil {
+				return c, append(append([]uint32{}, basePath...), sub...)
+			}
+		}
+	}
+	return nil, nil
+}
+
+func oidFromPath(parts []uint32) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	sb := strings.Builder{}
+	for i, p := range parts {
+		if i > 0 {
+			sb.WriteByte('.')
+		}
+		fmt.Fprintf(&sb, "%d", p)
+	}
+	return sb.String()
+}
+
+func toUint32(in []int32) []uint32 {
+	out := make([]uint32, len(in))
+	for i, v := range in {
+		out[i] = uint32(v)
+	}
+	return out
+}

--- a/internal/provider/emberplus/tree.go
+++ b/internal/provider/emberplus/tree.go
@@ -1,0 +1,140 @@
+package emberplus
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	"acp/internal/export/canonical"
+)
+
+// tree is the provider's in-memory snapshot of the served element tree.
+// Indexed primarily by numeric OID ("1.4.1.3"); a secondary map allows
+// lookup by dotted identifier path ("router.matrix.gain").
+//
+// The tree is read-mostly — GetDirectory walks it concurrently; only
+// SetValue mutates a parameter's value, taking a single write lock.
+type tree struct {
+	mu    sync.RWMutex
+	root  canonical.Element   // the top-level root element (Node)
+	byOID map[string]*entry   // "1.4.1.3" -> entry
+	byIDP map[string][]*entry // "router.matrix.gain" -> entries (dotted identifier path; may be many)
+}
+
+// entry wraps a canonical element with the bookkeeping the server needs:
+// a pointer to its parent for path walks, a snapshot of the OID split
+// into [u32] for RELATIVE-OID encoding, and a last-known value for
+// parameters (canonical.Parameter.Value is an `any`; we keep it as-is
+// and let the encoder dispatch on the canonical Type field).
+type entry struct {
+	el       canonical.Element
+	parent   *entry
+	oidParts []uint32 // parsed from Header.OID (e.g. "1.4.1.3" → [1,4,1,3])
+}
+
+// newTree converts a canonical Export into a flattened tree indexed by OID.
+// Accepts a Node root; any other top-level Element is an error (a served
+// tree always starts at a Node per Ember+ spec §The Node element).
+func newTree(exp *canonical.Export) (*tree, error) {
+	if exp == nil || exp.Root == nil {
+		return nil, fmt.Errorf("tree: nil export or root")
+	}
+	t := &tree{
+		root:  exp.Root,
+		byOID: make(map[string]*entry),
+		byIDP: make(map[string][]*entry),
+	}
+	if err := t.indexRecursive(exp.Root, nil); err != nil {
+		return nil, err
+	}
+	return t, nil
+}
+
+func (t *tree) indexRecursive(el canonical.Element, parent *entry) error {
+	hdr := el.Common()
+	parts, err := parseOID(hdr.OID)
+	if err != nil {
+		return fmt.Errorf("oid %q: %w", hdr.OID, err)
+	}
+	e := &entry{el: el, parent: parent, oidParts: parts}
+	if hdr.OID != "" {
+		if _, dup := t.byOID[hdr.OID]; dup {
+			return fmt.Errorf("tree: duplicate oid %q", hdr.OID)
+		}
+		t.byOID[hdr.OID] = e
+	}
+	if hdr.Path != "" {
+		t.byIDP[hdr.Path] = append(t.byIDP[hdr.Path], e)
+	}
+	for _, child := range hdr.Children {
+		if err := t.indexRecursive(child, e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// lookupOID resolves a numeric OID ("1.4.1.3") to an entry.
+func (t *tree) lookupOID(oid string) (*entry, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	e, ok := t.byOID[oid]
+	return e, ok
+}
+
+// lookupPath resolves a dotted identifier path ("router.matrix.gain") to
+// the first matching entry. Identifier paths can collide across subtrees
+// so callers that care about ambiguity should use lookupPathAll.
+func (t *tree) lookupPath(path string) (*entry, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	es := t.byIDP[path]
+	if len(es) == 0 {
+		return nil, false
+	}
+	return es[0], true
+}
+
+// rootEntry returns the root node entry (always present after newTree).
+func (t *tree) rootEntry() *entry {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.byOID[t.root.Common().OID]
+}
+
+// setParamValue mutates a parameter's value. Returns the actually-stored
+// value (for now identical — future work: clamp to min/max/step) and the
+// canonical.Parameter pointer so the caller can announce the change.
+func (t *tree) setParamValue(oid string, v any) (*canonical.Parameter, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	e, ok := t.byOID[oid]
+	if !ok {
+		return nil, fmt.Errorf("tree: oid %q not found", oid)
+	}
+	p, ok := e.el.(*canonical.Parameter)
+	if !ok {
+		return nil, fmt.Errorf("tree: oid %q is %s, not parameter", oid, e.el.Kind())
+	}
+	p.Value = v
+	return p, nil
+}
+
+// parseOID splits "1.4.1.3" into []uint32{1,4,1,3}. Empty string returns
+// an empty slice — that's the root node's OID in canonical exports.
+func parseOID(oid string) ([]uint32, error) {
+	if oid == "" {
+		return nil, nil
+	}
+	parts := strings.Split(oid, ".")
+	out := make([]uint32, 0, len(parts))
+	for _, p := range parts {
+		n, err := strconv.ParseUint(p, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("bad oid segment %q: %w", p, err)
+		}
+		out = append(out, uint32(n))
+	}
+	return out, nil
+}

--- a/internal/provider/iface.go
+++ b/internal/provider/iface.go
@@ -1,0 +1,45 @@
+// Package provider defines the interface a protocol provider (server) plugin
+// must implement. Symmetric with internal/protocol (consumer / client side).
+//
+// A Provider serves a tree to one or more consumers. It owns the listener,
+// accept loop, per-connection state, and broadcast fan-out. Input is a
+// canonical tree (same JSON schema produced by `acp walk --capture`).
+//
+// Tier-1 compile-time registry — no runtime plugins.
+package provider
+
+import (
+	"context"
+	"log/slog"
+
+	"acp/internal/export/canonical"
+)
+
+// Provider is the runtime contract: start serving on an address, stop cleanly.
+type Provider interface {
+	// Serve blocks until ctx is cancelled or a fatal error occurs.
+	// addr is the TCP listen address, e.g. ":9010".
+	Serve(ctx context.Context, addr string) error
+
+	// Stop closes the listener and drains active sessions. Safe to call
+	// multiple times; safe to call before Serve returns.
+	Stop() error
+
+	// SetValue mutates the served tree and fans the change out to all
+	// subscribed consumers. Path is dotted OID ("1.4.1.3"). Returns the
+	// actually-stored value (providers may clamp to min/max).
+	SetValue(ctx context.Context, path string, val any) (any, error)
+}
+
+// Meta is the static description a factory exposes.
+type Meta struct {
+	Name        string // e.g. "emberplus"
+	DefaultPort int    // e.g. 9010
+	Description string
+}
+
+// Factory creates Provider instances from a loaded canonical tree.
+type Factory interface {
+	Meta() Meta
+	New(logger *slog.Logger, tree *canonical.Export) Provider
+}

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -1,0 +1,46 @@
+package provider
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// Tier-1 compile-time registry. Plugins register themselves from init().
+
+var (
+	mu        sync.RWMutex
+	factories = map[string]Factory{}
+)
+
+// Register installs a factory under its Meta().Name. Panics if the name
+// is already taken — two plugins cannot share a name.
+func Register(f Factory) {
+	mu.Lock()
+	defer mu.Unlock()
+	name := f.Meta().Name
+	if _, exists := factories[name]; exists {
+		panic(fmt.Sprintf("provider: duplicate registration %q", name))
+	}
+	factories[name] = f
+}
+
+// Lookup returns the factory registered under name.
+func Lookup(name string) (Factory, bool) {
+	mu.RLock()
+	defer mu.RUnlock()
+	f, ok := factories[name]
+	return f, ok
+}
+
+// List returns registered names, sorted for deterministic output.
+func List() []string {
+	mu.RLock()
+	defer mu.RUnlock()
+	names := make([]string, 0, len(factories))
+	for n := range factories {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}


### PR DESCRIPTION
## Summary

First cut of the Ember+ **provider** — counterpart of the existing consumer plugin. Introduces a second Tier-1 plugin tier at `internal/provider/` so server-side protocols have the same compile-time-registered shape as consumers.

New binary `cmd/acp-provider`:

```bash
./bin/acp-provider --tree tests/fixtures/emberplus/9092/tree.json --port 9011
```

Serves 4494 tree entries of TinyEmber+ 9092 fixture. Any Ember+ consumer can walk it.

## Shape

```
internal/provider/
  iface.go       Provider interface (Serve, Stop, SetValue)
  registry.go    Tier-1 compile-time registry (mirrors internal/protocol/registry.go)
  emberplus/
    plugin.go    Factory + init() registration
    tree.go      canonical.Export → OID-indexed tree; RW parameter mutation
    encoder.go   walk tree → Glow BER (QualifiedNode + QualifiedParameter)
    session.go   per-consumer S101 read loop + bounded send queue
    server.go    multi-client accept loop + fan-out on SetValue
  cmd/acp-provider/main.go   thin CLI: load tree → resolve plugin → Serve
```

Symmetric reuse of consumer's `internal/protocol/emberplus/s101/`, `ber/`, and `glow/` (decoder + tag constants are direction-neutral).

## Wire correctness

Smoke-tested against the existing consumer:

```
./bin/acp-provider --tree tests/fixtures/emberplus/9092/tree.json --port 9011 &
./bin/acp walk 127.0.0.1 --protocol emberplus --port 9011
# → classification=strict (zero wire deviations)
# → identity subtree round-trips: product=Tiny Ember+ Router,
#   company=L-S-B Broadcast Technologies GmbH, version=1.6.2
```

Consumer classifies the provider as **strict** — no lax shortcuts, no missing fields. The provider emits qualified forms (QualifiedNode / QualifiedParameter) throughout, which the consumer validates against spec §4.3.

## Tests

- [x] `go test ./internal/provider/...` — encoder round-trip (QualifiedNode + Parameter decode back cleanly), SetValue mutates tree
- [x] `go test ./...` — no regressions elsewhere
- [x] `go vet` + `golangci-lint` clean (pre-commit hook passed)
- [x] `make build` produces `bin/acp` + `bin/acp-provider`
- [x] Live smoke: consumer walks provider's identity subtree via `:9011` loopback

## Deferred (documented, not regressions)

MVP scope matches issue #66:
- Matrix, Function, Stream, Template encoding — consumer-side decoder already handles them; provider-side encoder only covers Node + Parameter so far
- Invoke from consumer — replied with no-op (MVP)
- SetValue from consumer — read-only (MVP)
- Config UI — tomorrow's item per scope
- ACP1 / ACP2 providers — same pattern, new plugins

## Test plan

- [ ] User spot-check: run `./bin/acp-provider --tree <your-tree>.json --port 9011` against the consumer in another terminal
- [ ] Multi-client: open 2+ `./bin/acp walk` sessions simultaneously against the same provider

Closes #66 (MVP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)