### PR TITLE
feat(provider): Matrix + Function + Labels + Streams + Lock (spec-compliant)

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -418,15 +418,27 @@ No next phase until previous ships with VM integration passing.
 (branch `feat/emberplus-provider`). New tier-1 plugin directory
 `internal/provider/emberplus/` mirrors the consumer under
 `internal/protocol/emberplus/`. Binary `cmd/acp-provider`. Round-tripped
-live against EmberViewer for Node + all 7 Parameter types. Open
-follow-ups: #68 (viewer quirks), #69 (Matrix + Function extension,
-labels, parametersLocation, sum/recallSalvo functions).
+live against EmberViewer for Node + all 7 Parameter types.
+
+**Part B completion (2026-04-20):** #69 shipped on `feat/emberplus-matrix`
+(10 commits, ~1800 lines added). Adds all 4 Matrix modes (oneToN,
+oneToOne, nToN, dynamic), two-level Labels with spec-p.41 layout,
+`parametersLocation` grid (1=targets, 2=sources, 3=connections per
+spec p.37), QualifiedFunction + InvocationResult, four builtin
+functions (sum, storeSalvo/recallSalvo/listSalvos + setLock/listLocks),
+Connection Lock enforcement per spec p.89, subscribe-gated
+StreamCollection broadcast, and Parameter.formula field emission.
+12 wire-correctness landmines documented in
+`memory/project_emberplus_provider.md`. Live-smoked via EmberViewer
+1.6.2 and our own `acp invoke` / `acp walk` CLI. Open follow-ups:
+#68 (viewer REAL quirks, cross-viewer testing), #70 (formula
+expression evaluator — shared provider/consumer).
 
 ### Parked — TODO / SOW (do not start now)
 
 | item | phase | notes |
 |---|---|---|
-| Ember+ provider | ✅ MVP on PR #67; #69 for Matrix/Function |
+| Ember+ provider | ✅ MVP on PR #67; Matrix/Function/Labels/Streams/Lock on #69 branch `feat/emberplus-matrix` (ready for PR); #70 formula eval parked |
 | Bus bridge (`acp-srv --bus=none\|nats\|es\|redis-stream`) | Part C | orchestrator-level; plugins stay bus-free |
 | Probel SW-P-02 consumer+provider | later | canonical Matrix shape, no walkable tree |
 | Probel SW-P-08 Plus consumer+provider | later | canonical Matrix with level multiplex |

--- a/assets/emberplus/router_tree.json
+++ b/assets/emberplus/router_tree.json
@@ -435,6 +435,15 @@
               {"name": "salvoID", "type": "integer"}
             ],
             "result": [{"name": "success", "type": "boolean"}]
+          },
+          {
+            "number": 4, "identifier": "listSalvos", "path": "router.functions.listSalvos", "oid": "1.6.4",
+            "description": "Stored salvo IDs for a matrix (comma-separated, e.g. '1,2,5')",
+            "isOnline": true, "access": "read", "children": [],
+            "arguments": [
+              {"name": "matrixPath", "type": "string"}
+            ],
+            "result": [{"name": "ids", "type": "string"}]
           }
         ]
       }

--- a/assets/emberplus/router_tree.json
+++ b/assets/emberplus/router_tree.json
@@ -4,7 +4,7 @@
     "identifier": "router",
     "path": "router",
     "oid": "1",
-    "description": "ACP demo router — oneToN 4x4 + nToN 2x2 + 3 functions",
+    "description": "ACP demo router — spec-compliant Matrix+labels+params+functions (spec v2.50)",
     "isOnline": true,
     "access": "read",
     "children": [
@@ -17,267 +17,136 @@
         "isOnline": true,
         "access": "read",
         "children": [
-          {
-            "number": 1,
-            "identifier": "product",
-            "path": "router.identity.product",
-            "oid": "1.1.1",
-            "description": null,
-            "isOnline": true,
-            "access": "read",
-            "children": [],
-            "type": "string",
-            "value": "ACP Demo Router",
-            "default": null,
-            "minimum": null,
-            "maximum": null,
-            "step": null,
-            "unit": null,
-            "format": null,
-            "factor": null,
-            "formula": null,
-            "enumeration": null,
-            "enumMap": null,
-            "streamIdentifier": null,
-            "streamDescriptor": null,
-            "templateReference": null,
-            "schemaIdentifiers": null
-          },
-          {
-            "number": 2,
-            "identifier": "company",
-            "path": "router.identity.company",
-            "oid": "1.1.2",
-            "description": null,
-            "isOnline": true,
-            "access": "read",
-            "children": [],
-            "type": "string",
-            "value": "BY-SYSTEMS",
-            "default": null,
-            "minimum": null,
-            "maximum": null,
-            "step": null,
-            "unit": null,
-            "format": null,
-            "factor": null,
-            "formula": null,
-            "enumeration": null,
-            "enumMap": null,
-            "streamIdentifier": null,
-            "streamDescriptor": null,
-            "templateReference": null,
-            "schemaIdentifiers": null
-          }
+          {"number": 1, "identifier": "product", "path": "router.identity.product", "oid": "1.1.1", "description": null, "isOnline": true, "access": "read", "children": [], "type": "string", "value": "ACP Demo Router", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+          {"number": 2, "identifier": "company", "path": "router.identity.company", "oid": "1.1.2", "description": null, "isOnline": true, "access": "read", "children": [], "type": "string", "value": "BY-SYSTEMS", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
         ]
       },
+
       {
         "number": 2,
         "identifier": "oneToN",
         "path": "router.oneToN",
         "oid": "1.2",
-        "description": "4x4 oneToN with two-level labels",
+        "description": "4x4 oneToN linear — two label levels (Primary + Secondary)",
         "isOnline": true,
         "access": "read",
         "children": [
           {
-            "number": 1,
-            "identifier": "labels",
-            "path": "router.oneToN.labels",
-            "oid": "1.2.1",
-            "description": null,
-            "isOnline": true,
-            "access": "read",
+            "number": 1, "identifier": "labels", "path": "router.oneToN.labels", "oid": "1.2.1",
+            "description": "Label levels container (spec p.41 shape)", "isOnline": true, "access": "read",
             "children": [
               {
-                "number": 1,
-                "identifier": "targets",
-                "path": "router.oneToN.labels.targets",
-                "oid": "1.2.1.1",
-                "description": null,
-                "isOnline": true,
-                "access": "read",
+                "number": 1, "identifier": "Primary", "path": "router.oneToN.labels.Primary", "oid": "1.2.1.1",
+                "description": "Primary label level (long names)", "isOnline": true, "access": "read",
                 "children": [
-                  {"number": 0, "identifier": "t-0", "path": "router.oneToN.labels.targets.t-0", "oid": "1.2.1.1.0", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "MAIN OUT 1", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
-                  {"number": 1, "identifier": "t-1", "path": "router.oneToN.labels.targets.t-1", "oid": "1.2.1.1.1", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "MAIN OUT 2", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
-                  {"number": 2, "identifier": "t-2", "path": "router.oneToN.labels.targets.t-2", "oid": "1.2.1.1.2", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "AUX 1", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
-                  {"number": 3, "identifier": "t-3", "path": "router.oneToN.labels.targets.t-3", "oid": "1.2.1.1.3", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "AUX 2", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                  {
+                    "number": 1, "identifier": "targets", "path": "router.oneToN.labels.Primary.targets", "oid": "1.2.1.1.1",
+                    "description": null, "isOnline": true, "access": "read",
+                    "children": [
+                      {"number": 0, "identifier": "t-0", "path": "router.oneToN.labels.Primary.targets.t-0", "oid": "1.2.1.1.1.0", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "MAIN OUT 1", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                      {"number": 1, "identifier": "t-1", "path": "router.oneToN.labels.Primary.targets.t-1", "oid": "1.2.1.1.1.1", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "MAIN OUT 2", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                      {"number": 2, "identifier": "t-2", "path": "router.oneToN.labels.Primary.targets.t-2", "oid": "1.2.1.1.1.2", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "AUX 1", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                      {"number": 3, "identifier": "t-3", "path": "router.oneToN.labels.Primary.targets.t-3", "oid": "1.2.1.1.1.3", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "AUX 2", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                    ]
+                  },
+                  {
+                    "number": 2, "identifier": "sources", "path": "router.oneToN.labels.Primary.sources", "oid": "1.2.1.1.2",
+                    "description": null, "isOnline": true, "access": "read",
+                    "children": [
+                      {"number": 0, "identifier": "s-0", "path": "router.oneToN.labels.Primary.sources.s-0", "oid": "1.2.1.1.2.0", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "CAM 1", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                      {"number": 1, "identifier": "s-1", "path": "router.oneToN.labels.Primary.sources.s-1", "oid": "1.2.1.1.2.1", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "CAM 2", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                      {"number": 2, "identifier": "s-2", "path": "router.oneToN.labels.Primary.sources.s-2", "oid": "1.2.1.1.2.2", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "PLAY 1", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                      {"number": 3, "identifier": "s-3", "path": "router.oneToN.labels.Primary.sources.s-3", "oid": "1.2.1.1.2.3", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "PLAY 2", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                    ]
+                  }
                 ]
               },
               {
-                "number": 2,
-                "identifier": "sources",
-                "path": "router.oneToN.labels.sources",
-                "oid": "1.2.1.2",
-                "description": null,
-                "isOnline": true,
-                "access": "read",
+                "number": 2, "identifier": "Secondary", "path": "router.oneToN.labels.Secondary", "oid": "1.2.1.2",
+                "description": "Secondary label level (short codes)", "isOnline": true, "access": "read",
                 "children": [
-                  {"number": 0, "identifier": "s-0", "path": "router.oneToN.labels.sources.s-0", "oid": "1.2.1.2.0", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "CAM 1", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
-                  {"number": 1, "identifier": "s-1", "path": "router.oneToN.labels.sources.s-1", "oid": "1.2.1.2.1", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "CAM 2", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
-                  {"number": 2, "identifier": "s-2", "path": "router.oneToN.labels.sources.s-2", "oid": "1.2.1.2.2", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "PLAY 1", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
-                  {"number": 3, "identifier": "s-3", "path": "router.oneToN.labels.sources.s-3", "oid": "1.2.1.2.3", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "PLAY 2", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                  {
+                    "number": 1, "identifier": "targets", "path": "router.oneToN.labels.Secondary.targets", "oid": "1.2.1.2.1",
+                    "description": null, "isOnline": true, "access": "read",
+                    "children": [
+                      {"number": 0, "identifier": "t-0", "path": "router.oneToN.labels.Secondary.targets.t-0", "oid": "1.2.1.2.1.0", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "M1", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                      {"number": 1, "identifier": "t-1", "path": "router.oneToN.labels.Secondary.targets.t-1", "oid": "1.2.1.2.1.1", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "M2", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                      {"number": 2, "identifier": "t-2", "path": "router.oneToN.labels.Secondary.targets.t-2", "oid": "1.2.1.2.1.2", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "A1", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                      {"number": 3, "identifier": "t-3", "path": "router.oneToN.labels.Secondary.targets.t-3", "oid": "1.2.1.2.1.3", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "A2", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                    ]
+                  },
+                  {
+                    "number": 2, "identifier": "sources", "path": "router.oneToN.labels.Secondary.sources", "oid": "1.2.1.2.2",
+                    "description": null, "isOnline": true, "access": "read",
+                    "children": [
+                      {"number": 0, "identifier": "s-0", "path": "router.oneToN.labels.Secondary.sources.s-0", "oid": "1.2.1.2.2.0", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "C1", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                      {"number": 1, "identifier": "s-1", "path": "router.oneToN.labels.Secondary.sources.s-1", "oid": "1.2.1.2.2.1", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "C2", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                      {"number": 2, "identifier": "s-2", "path": "router.oneToN.labels.Secondary.sources.s-2", "oid": "1.2.1.2.2.2", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "P1", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                      {"number": 3, "identifier": "s-3", "path": "router.oneToN.labels.Secondary.sources.s-3", "oid": "1.2.1.2.2.3", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "P2", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                    ]
+                  }
                 ]
               }
             ]
           },
           {
-            "number": 2,
-            "identifier": "matrix",
-            "path": "router.oneToN.matrix",
-            "oid": "1.2.2",
-            "description": "4x4 oneToN linear",
-            "isOnline": true,
-            "access": "readWrite",
-            "children": [],
-            "type": "oneToN",
-            "mode": "linear",
-            "targetCount": 4,
-            "sourceCount": 4,
-            "maximumTotalConnects": null,
-            "maximumConnectsPerTarget": null,
-            "parametersLocation": null,
-            "gainParameterNumber": null,
+            "number": 2, "identifier": "matrix", "path": "router.oneToN.matrix", "oid": "1.2.2",
+            "description": "4x4 oneToN", "isOnline": true, "access": "readWrite", "children": [],
+            "type": "oneToN", "mode": "linear",
+            "targetCount": 4, "sourceCount": 4,
+            "maximumTotalConnects": null, "maximumConnectsPerTarget": null,
+            "parametersLocation": null, "gainParameterNumber": null,
             "labels": [
-              {"basePath": "1.2.1", "description": "Primary"}
+              {"basePath": "1.2.1.1", "description": "Primary"},
+              {"basePath": "1.2.1.2", "description": "Secondary"}
             ],
-            "targets": [],
-            "sources": [],
+            "targets": [], "sources": [],
             "connections": [
               {"target": 0, "sources": [0], "operation": "absolute", "disposition": "tally", "locked": false},
               {"target": 1, "sources": [1], "operation": "absolute", "disposition": "tally", "locked": false},
               {"target": 2, "sources": [2], "operation": "absolute", "disposition": "tally", "locked": false},
               {"target": 3, "sources": [3], "operation": "absolute", "disposition": "tally", "locked": false}
             ],
-            "targetLabels": null,
-            "sourceLabels": null,
-            "targetParams": null,
-            "sourceParams": null,
-            "connectionParams": null
+            "targetLabels": null, "sourceLabels": null, "targetParams": null, "sourceParams": null, "connectionParams": null
           }
         ]
       },
+
       {
         "number": 3,
-        "identifier": "nToN",
-        "path": "router.nToN",
+        "identifier": "oneToOne",
+        "path": "router.oneToOne",
         "oid": "1.3",
-        "description": "2x2 nToN with per-cell gain",
+        "description": "4x4 oneToOne linear — permutation; source exclusivity enforced",
         "isOnline": true,
         "access": "read",
         "children": [
           {
-            "number": 1,
-            "identifier": "labels",
-            "path": "router.nToN.labels",
-            "oid": "1.3.1",
-            "description": null,
-            "isOnline": true,
-            "access": "read",
+            "number": 1, "identifier": "labels", "path": "router.oneToOne.labels", "oid": "1.3.1",
+            "description": null, "isOnline": true, "access": "read",
             "children": [
               {
-                "number": 1,
-                "identifier": "targets",
-                "path": "router.nToN.labels.targets",
-                "oid": "1.3.1.1",
-                "description": null,
-                "isOnline": true,
-                "access": "read",
-                "children": [
-                  {"number": 0, "identifier": "t-0", "path": "router.nToN.labels.targets.t-0", "oid": "1.3.1.1.0", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "MIX A", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
-                  {"number": 1, "identifier": "t-1", "path": "router.nToN.labels.targets.t-1", "oid": "1.3.1.1.1", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "MIX B", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
-                ]
-              },
-              {
-                "number": 2,
-                "identifier": "sources",
-                "path": "router.nToN.labels.sources",
-                "oid": "1.3.1.2",
-                "description": null,
-                "isOnline": true,
-                "access": "read",
-                "children": [
-                  {"number": 0, "identifier": "s-0", "path": "router.nToN.labels.sources.s-0", "oid": "1.3.1.2.0", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "MIC 1", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
-                  {"number": 1, "identifier": "s-1", "path": "router.nToN.labels.sources.s-1", "oid": "1.3.1.2.1", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "MIC 2", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
-                ]
-              }
-            ]
-          },
-          {
-            "number": 2,
-            "identifier": "parameters",
-            "path": "router.nToN.parameters",
-            "oid": "1.3.2",
-            "description": "per-cell gain grid",
-            "isOnline": true,
-            "access": "read",
-            "children": [
-              {
-                "number": 0,
-                "identifier": "t-0",
-                "path": "router.nToN.parameters.t-0",
-                "oid": "1.3.2.0",
-                "description": null,
-                "isOnline": true,
-                "access": "read",
+                "number": 1, "identifier": "Primary", "path": "router.oneToOne.labels.Primary", "oid": "1.3.1.1",
+                "description": null, "isOnline": true, "access": "read",
                 "children": [
                   {
-                    "number": 0,
-                    "identifier": "s-0",
-                    "path": "router.nToN.parameters.t-0.s-0",
-                    "oid": "1.3.2.0.0",
-                    "description": null,
-                    "isOnline": true,
-                    "access": "read",
+                    "number": 1, "identifier": "targets", "path": "router.oneToOne.labels.Primary.targets", "oid": "1.3.1.1.1",
+                    "description": null, "isOnline": true, "access": "read",
                     "children": [
-                      {"number": 1, "identifier": "gain", "path": "router.nToN.parameters.t-0.s-0.gain", "oid": "1.3.2.0.0.1", "description": "Gain dB", "isOnline": true, "access": "readWrite", "children": [], "type": "real", "value": 0.0, "default": 0.0, "minimum": -60.0, "maximum": 12.0, "step": 0.5, "unit": "dB", "format": "%.1f dB", "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                      {"number": 0, "identifier": "t-0", "path": "router.oneToOne.labels.Primary.targets.t-0", "oid": "1.3.1.1.1.0", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "REC A", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                      {"number": 1, "identifier": "t-1", "path": "router.oneToOne.labels.Primary.targets.t-1", "oid": "1.3.1.1.1.1", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "REC B", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                      {"number": 2, "identifier": "t-2", "path": "router.oneToOne.labels.Primary.targets.t-2", "oid": "1.3.1.1.1.2", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "REC C", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                      {"number": 3, "identifier": "t-3", "path": "router.oneToOne.labels.Primary.targets.t-3", "oid": "1.3.1.1.1.3", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "REC D", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
                     ]
                   },
                   {
-                    "number": 1,
-                    "identifier": "s-1",
-                    "path": "router.nToN.parameters.t-0.s-1",
-                    "oid": "1.3.2.0.1",
-                    "description": null,
-                    "isOnline": true,
-                    "access": "read",
+                    "number": 2, "identifier": "sources", "path": "router.oneToOne.labels.Primary.sources", "oid": "1.3.1.1.2",
+                    "description": null, "isOnline": true, "access": "read",
                     "children": [
-                      {"number": 1, "identifier": "gain", "path": "router.nToN.parameters.t-0.s-1.gain", "oid": "1.3.2.0.1.1", "description": "Gain dB", "isOnline": true, "access": "readWrite", "children": [], "type": "real", "value": -6.0, "default": 0.0, "minimum": -60.0, "maximum": 12.0, "step": 0.5, "unit": "dB", "format": "%.1f dB", "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
-                    ]
-                  }
-                ]
-              },
-              {
-                "number": 1,
-                "identifier": "t-1",
-                "path": "router.nToN.parameters.t-1",
-                "oid": "1.3.2.1",
-                "description": null,
-                "isOnline": true,
-                "access": "read",
-                "children": [
-                  {
-                    "number": 0,
-                    "identifier": "s-0",
-                    "path": "router.nToN.parameters.t-1.s-0",
-                    "oid": "1.3.2.1.0",
-                    "description": null,
-                    "isOnline": true,
-                    "access": "read",
-                    "children": [
-                      {"number": 1, "identifier": "gain", "path": "router.nToN.parameters.t-1.s-0.gain", "oid": "1.3.2.1.0.1", "description": "Gain dB", "isOnline": true, "access": "readWrite", "children": [], "type": "real", "value": -6.0, "default": 0.0, "minimum": -60.0, "maximum": 12.0, "step": 0.5, "unit": "dB", "format": "%.1f dB", "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
-                    ]
-                  },
-                  {
-                    "number": 1,
-                    "identifier": "s-1",
-                    "path": "router.nToN.parameters.t-1.s-1",
-                    "oid": "1.3.2.1.1",
-                    "description": null,
-                    "isOnline": true,
-                    "access": "read",
-                    "children": [
-                      {"number": 1, "identifier": "gain", "path": "router.nToN.parameters.t-1.s-1.gain", "oid": "1.3.2.1.1.1", "description": "Gain dB", "isOnline": true, "access": "readWrite", "children": [], "type": "real", "value": 0.0, "default": 0.0, "minimum": -60.0, "maximum": 12.0, "step": 0.5, "unit": "dB", "format": "%.1f dB", "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                      {"number": 0, "identifier": "s-0", "path": "router.oneToOne.labels.Primary.sources.s-0", "oid": "1.3.1.1.2.0", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "SDI IN 1", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                      {"number": 1, "identifier": "s-1", "path": "router.oneToOne.labels.Primary.sources.s-1", "oid": "1.3.1.1.2.1", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "SDI IN 2", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                      {"number": 2, "identifier": "s-2", "path": "router.oneToOne.labels.Primary.sources.s-2", "oid": "1.3.1.1.2.2", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "SDI IN 3", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                      {"number": 3, "identifier": "s-3", "path": "router.oneToOne.labels.Primary.sources.s-3", "oid": "1.3.1.1.2.3", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "SDI IN 4", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
                     ]
                   }
                 ]
@@ -285,57 +154,260 @@
             ]
           },
           {
-            "number": 3,
-            "identifier": "matrix",
-            "path": "router.nToN.matrix",
-            "oid": "1.3.3",
-            "description": "2x2 nToN with per-cell gain",
-            "isOnline": true,
-            "access": "readWrite",
-            "children": [],
-            "type": "nToN",
-            "mode": "linear",
-            "targetCount": 2,
-            "sourceCount": 2,
-            "maximumTotalConnects": 4,
-            "maximumConnectsPerTarget": 2,
-            "parametersLocation": "1.3.2",
-            "gainParameterNumber": 1,
-            "labels": [
-              {"basePath": "1.3.1", "description": "Primary"}
+            "number": 2, "identifier": "matrix", "path": "router.oneToOne.matrix", "oid": "1.3.2",
+            "description": "4x4 oneToOne permutation", "isOnline": true, "access": "readWrite", "children": [],
+            "type": "oneToOne", "mode": "linear",
+            "targetCount": 4, "sourceCount": 4,
+            "maximumTotalConnects": null, "maximumConnectsPerTarget": null,
+            "parametersLocation": null, "gainParameterNumber": null,
+            "labels": [{"basePath": "1.3.1.1", "description": "Primary"}],
+            "targets": [], "sources": [],
+            "connections": [
+              {"target": 0, "sources": [3], "operation": "absolute", "disposition": "tally", "locked": false},
+              {"target": 1, "sources": [2], "operation": "absolute", "disposition": "tally", "locked": false},
+              {"target": 2, "sources": [1], "operation": "absolute", "disposition": "tally", "locked": false},
+              {"target": 3, "sources": [0], "operation": "absolute", "disposition": "tally", "locked": false}
             ],
-            "targets": [],
-            "sources": [],
+            "targetLabels": null, "sourceLabels": null, "targetParams": null, "sourceParams": null, "connectionParams": null
+          }
+        ]
+      },
+
+      {
+        "number": 4,
+        "identifier": "nToN",
+        "path": "router.nToN",
+        "oid": "1.4",
+        "description": "2x2 nToN with spec-shape parametersLocation (targets/sources/connections) + two label levels",
+        "isOnline": true,
+        "access": "read",
+        "children": [
+          {
+            "number": 1, "identifier": "labels", "path": "router.nToN.labels", "oid": "1.4.1",
+            "description": "Label levels container", "isOnline": true, "access": "read",
+            "children": [
+              {
+                "number": 1, "identifier": "Primary", "path": "router.nToN.labels.Primary", "oid": "1.4.1.1",
+                "description": null, "isOnline": true, "access": "read",
+                "children": [
+                  {
+                    "number": 1, "identifier": "targets", "path": "router.nToN.labels.Primary.targets", "oid": "1.4.1.1.1",
+                    "description": null, "isOnline": true, "access": "read",
+                    "children": [
+                      {"number": 0, "identifier": "t-0", "path": "router.nToN.labels.Primary.targets.t-0", "oid": "1.4.1.1.1.0", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "MIX A", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                      {"number": 1, "identifier": "t-1", "path": "router.nToN.labels.Primary.targets.t-1", "oid": "1.4.1.1.1.1", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "MIX B", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                    ]
+                  },
+                  {
+                    "number": 2, "identifier": "sources", "path": "router.nToN.labels.Primary.sources", "oid": "1.4.1.1.2",
+                    "description": null, "isOnline": true, "access": "read",
+                    "children": [
+                      {"number": 0, "identifier": "s-0", "path": "router.nToN.labels.Primary.sources.s-0", "oid": "1.4.1.1.2.0", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "MIC 1", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                      {"number": 1, "identifier": "s-1", "path": "router.nToN.labels.Primary.sources.s-1", "oid": "1.4.1.1.2.1", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "MIC 2", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                    ]
+                  }
+                ]
+              },
+              {
+                "number": 2, "identifier": "Secondary", "path": "router.nToN.labels.Secondary", "oid": "1.4.1.2",
+                "description": null, "isOnline": true, "access": "read",
+                "children": [
+                  {
+                    "number": 1, "identifier": "targets", "path": "router.nToN.labels.Secondary.targets", "oid": "1.4.1.2.1",
+                    "description": null, "isOnline": true, "access": "read",
+                    "children": [
+                      {"number": 0, "identifier": "t-0", "path": "router.nToN.labels.Secondary.targets.t-0", "oid": "1.4.1.2.1.0", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "MA", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                      {"number": 1, "identifier": "t-1", "path": "router.nToN.labels.Secondary.targets.t-1", "oid": "1.4.1.2.1.1", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "MB", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                    ]
+                  },
+                  {
+                    "number": 2, "identifier": "sources", "path": "router.nToN.labels.Secondary.sources", "oid": "1.4.1.2.2",
+                    "description": null, "isOnline": true, "access": "read",
+                    "children": [
+                      {"number": 0, "identifier": "s-0", "path": "router.nToN.labels.Secondary.sources.s-0", "oid": "1.4.1.2.2.0", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "M1", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                      {"number": 1, "identifier": "s-1", "path": "router.nToN.labels.Secondary.sources.s-1", "oid": "1.4.1.2.2.1", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "M2", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "number": 2, "identifier": "parameters", "path": "router.nToN.parameters", "oid": "1.4.2",
+            "description": "parametersLocation container — spec shape: 1=targets, 2=sources, 3=connections",
+            "isOnline": true, "access": "read",
+            "children": [
+              {
+                "number": 1, "identifier": "targets", "path": "router.nToN.parameters.targets", "oid": "1.4.2.1",
+                "description": "Per-target bus parameters", "isOnline": true, "access": "read",
+                "children": [
+                  {
+                    "number": 0, "identifier": "t-0", "path": "router.nToN.parameters.targets.t-0", "oid": "1.4.2.1.0",
+                    "description": null, "isOnline": true, "access": "read", "children": [
+                      {"number": 1, "identifier": "level", "path": "router.nToN.parameters.targets.t-0.level", "oid": "1.4.2.1.0.1", "description": "Bus level", "isOnline": true, "access": "readWrite", "children": [], "type": "real", "value": 0.0, "default": 0.0, "minimum": -60.0, "maximum": 12.0, "step": 0.5, "unit": "dB", "format": "%.1f dB", "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                      {"number": 2, "identifier": "mute", "path": "router.nToN.parameters.targets.t-0.mute", "oid": "1.4.2.1.0.2", "description": "Bus mute", "isOnline": true, "access": "readWrite", "children": [], "type": "boolean", "value": false, "default": false, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                    ]
+                  },
+                  {
+                    "number": 1, "identifier": "t-1", "path": "router.nToN.parameters.targets.t-1", "oid": "1.4.2.1.1",
+                    "description": null, "isOnline": true, "access": "read", "children": [
+                      {"number": 1, "identifier": "level", "path": "router.nToN.parameters.targets.t-1.level", "oid": "1.4.2.1.1.1", "description": "Bus level", "isOnline": true, "access": "readWrite", "children": [], "type": "real", "value": -3.0, "default": 0.0, "minimum": -60.0, "maximum": 12.0, "step": 0.5, "unit": "dB", "format": "%.1f dB", "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                      {"number": 2, "identifier": "mute", "path": "router.nToN.parameters.targets.t-1.mute", "oid": "1.4.2.1.1.2", "description": "Bus mute", "isOnline": true, "access": "readWrite", "children": [], "type": "boolean", "value": false, "default": false, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                    ]
+                  }
+                ]
+              },
+              {
+                "number": 2, "identifier": "sources", "path": "router.nToN.parameters.sources", "oid": "1.4.2.2",
+                "description": "Per-source input parameters", "isOnline": true, "access": "read",
+                "children": [
+                  {
+                    "number": 0, "identifier": "s-0", "path": "router.nToN.parameters.sources.s-0", "oid": "1.4.2.2.0",
+                    "description": null, "isOnline": true, "access": "read", "children": [
+                      {"number": 1, "identifier": "trim", "path": "router.nToN.parameters.sources.s-0.trim", "oid": "1.4.2.2.0.1", "description": "Input trim", "isOnline": true, "access": "readWrite", "children": [], "type": "real", "value": 0.0, "default": 0.0, "minimum": -20.0, "maximum": 20.0, "step": 0.1, "unit": "dB", "format": "%.1f dB", "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                    ]
+                  },
+                  {
+                    "number": 1, "identifier": "s-1", "path": "router.nToN.parameters.sources.s-1", "oid": "1.4.2.2.1",
+                    "description": null, "isOnline": true, "access": "read", "children": [
+                      {"number": 1, "identifier": "trim", "path": "router.nToN.parameters.sources.s-1.trim", "oid": "1.4.2.2.1.1", "description": "Input trim", "isOnline": true, "access": "readWrite", "children": [], "type": "real", "value": 2.0, "default": 0.0, "minimum": -20.0, "maximum": 20.0, "step": 0.1, "unit": "dB", "format": "%.1f dB", "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                    ]
+                  }
+                ]
+              },
+              {
+                "number": 3, "identifier": "connections", "path": "router.nToN.parameters.connections", "oid": "1.4.2.3",
+                "description": "Per-crosspoint parameters (gain)", "isOnline": true, "access": "read",
+                "children": [
+                  {
+                    "number": 0, "identifier": "t-0", "path": "router.nToN.parameters.connections.t-0", "oid": "1.4.2.3.0",
+                    "description": null, "isOnline": true, "access": "read", "children": [
+                      {
+                        "number": 0, "identifier": "s-0", "path": "router.nToN.parameters.connections.t-0.s-0", "oid": "1.4.2.3.0.0",
+                        "description": null, "isOnline": true, "access": "read", "children": [
+                          {"number": 1, "identifier": "gain", "path": "router.nToN.parameters.connections.t-0.s-0.gain", "oid": "1.4.2.3.0.0.1", "description": "Crosspoint gain", "isOnline": true, "access": "readWrite", "children": [], "type": "real", "value": 0.0, "default": 0.0, "minimum": -60.0, "maximum": 12.0, "step": 0.5, "unit": "dB", "format": "%.1f dB", "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                        ]
+                      },
+                      {
+                        "number": 1, "identifier": "s-1", "path": "router.nToN.parameters.connections.t-0.s-1", "oid": "1.4.2.3.0.1",
+                        "description": null, "isOnline": true, "access": "read", "children": [
+                          {"number": 1, "identifier": "gain", "path": "router.nToN.parameters.connections.t-0.s-1.gain", "oid": "1.4.2.3.0.1.1", "description": "Crosspoint gain", "isOnline": true, "access": "readWrite", "children": [], "type": "real", "value": -6.0, "default": 0.0, "minimum": -60.0, "maximum": 12.0, "step": 0.5, "unit": "dB", "format": "%.1f dB", "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "number": 1, "identifier": "t-1", "path": "router.nToN.parameters.connections.t-1", "oid": "1.4.2.3.1",
+                    "description": null, "isOnline": true, "access": "read", "children": [
+                      {
+                        "number": 0, "identifier": "s-0", "path": "router.nToN.parameters.connections.t-1.s-0", "oid": "1.4.2.3.1.0",
+                        "description": null, "isOnline": true, "access": "read", "children": [
+                          {"number": 1, "identifier": "gain", "path": "router.nToN.parameters.connections.t-1.s-0.gain", "oid": "1.4.2.3.1.0.1", "description": "Crosspoint gain", "isOnline": true, "access": "readWrite", "children": [], "type": "real", "value": -6.0, "default": 0.0, "minimum": -60.0, "maximum": 12.0, "step": 0.5, "unit": "dB", "format": "%.1f dB", "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                        ]
+                      },
+                      {
+                        "number": 1, "identifier": "s-1", "path": "router.nToN.parameters.connections.t-1.s-1", "oid": "1.4.2.3.1.1",
+                        "description": null, "isOnline": true, "access": "read", "children": [
+                          {"number": 1, "identifier": "gain", "path": "router.nToN.parameters.connections.t-1.s-1.gain", "oid": "1.4.2.3.1.1.1", "description": "Crosspoint gain", "isOnline": true, "access": "readWrite", "children": [], "type": "real", "value": 0.0, "default": 0.0, "minimum": -60.0, "maximum": 12.0, "step": 0.5, "unit": "dB", "format": "%.1f dB", "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "number": 3, "identifier": "matrix", "path": "router.nToN.matrix", "oid": "1.4.3",
+            "description": "2x2 nToN with per-cell gain",
+            "isOnline": true, "access": "readWrite", "children": [],
+            "type": "nToN", "mode": "linear",
+            "targetCount": 2, "sourceCount": 2,
+            "maximumTotalConnects": 4, "maximumConnectsPerTarget": 2,
+            "parametersLocation": "1.4.2", "gainParameterNumber": 1,
+            "labels": [
+              {"basePath": "1.4.1.1", "description": "Primary"},
+              {"basePath": "1.4.1.2", "description": "Secondary"}
+            ],
+            "targets": [], "sources": [],
             "connections": [
               {"target": 0, "sources": [0], "operation": "absolute", "disposition": "tally", "locked": false},
               {"target": 1, "sources": [1], "operation": "absolute", "disposition": "tally", "locked": false}
             ],
-            "targetLabels": null,
-            "sourceLabels": null,
-            "targetParams": null,
-            "sourceParams": null,
-            "connectionParams": null
+            "targetLabels": null, "sourceLabels": null, "targetParams": null, "sourceParams": null, "connectionParams": null
           }
         ]
       },
+
       {
-        "number": 4,
+        "number": 5,
+        "identifier": "dynamic",
+        "path": "router.dynamic",
+        "oid": "1.5",
+        "description": "Dynamic nToN — non-linear addressing, signal numbers sparse (10/20 targets, 30/40 sources)",
+        "isOnline": true,
+        "access": "read",
+        "children": [
+          {
+            "number": 1, "identifier": "labels", "path": "router.dynamic.labels", "oid": "1.5.1",
+            "description": null, "isOnline": true, "access": "read",
+            "children": [
+              {
+                "number": 1, "identifier": "Primary", "path": "router.dynamic.labels.Primary", "oid": "1.5.1.1",
+                "description": null, "isOnline": true, "access": "read",
+                "children": [
+                  {
+                    "number": 1, "identifier": "targets", "path": "router.dynamic.labels.Primary.targets", "oid": "1.5.1.1.1",
+                    "description": null, "isOnline": true, "access": "read",
+                    "children": [
+                      {"number": 10, "identifier": "t-10", "path": "router.dynamic.labels.Primary.targets.t-10", "oid": "1.5.1.1.1.10", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "DYN TGT A", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                      {"number": 20, "identifier": "t-20", "path": "router.dynamic.labels.Primary.targets.t-20", "oid": "1.5.1.1.1.20", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "DYN TGT B", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                    ]
+                  },
+                  {
+                    "number": 2, "identifier": "sources", "path": "router.dynamic.labels.Primary.sources", "oid": "1.5.1.1.2",
+                    "description": null, "isOnline": true, "access": "read",
+                    "children": [
+                      {"number": 30, "identifier": "s-30", "path": "router.dynamic.labels.Primary.sources.s-30", "oid": "1.5.1.1.2.30", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "DYN SRC X", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                      {"number": 40, "identifier": "s-40", "path": "router.dynamic.labels.Primary.sources.s-40", "oid": "1.5.1.1.2.40", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "DYN SRC Y", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "number": 2, "identifier": "matrix", "path": "router.dynamic.matrix", "oid": "1.5.2",
+            "description": "Dynamic nToN — explicit signal numbers",
+            "isOnline": true, "access": "readWrite", "children": [],
+            "type": "nToN", "mode": "nonLinear",
+            "targetCount": 2, "sourceCount": 2,
+            "maximumTotalConnects": 4, "maximumConnectsPerTarget": 2,
+            "parametersLocation": null, "gainParameterNumber": null,
+            "labels": [{"basePath": "1.5.1.1", "description": "Primary"}],
+            "targets": [{"number": 10}, {"number": 20}],
+            "sources": [{"number": 30}, {"number": 40}],
+            "connections": [
+              {"target": 10, "sources": [30], "operation": "absolute", "disposition": "tally", "locked": false},
+              {"target": 20, "sources": [40], "operation": "absolute", "disposition": "tally", "locked": false}
+            ],
+            "targetLabels": null, "sourceLabels": null, "targetParams": null, "sourceParams": null, "connectionParams": null
+          }
+        ]
+      },
+
+      {
+        "number": 6,
         "identifier": "functions",
         "path": "router.functions",
-        "oid": "1.4",
+        "oid": "1.6",
         "description": "Callable RPCs: sum, recallSalvo, storeSalvo",
         "isOnline": true,
         "access": "read",
         "children": [
           {
-            "number": 1,
-            "identifier": "sum",
-            "path": "router.functions.sum",
-            "oid": "1.4.1",
-            "description": "Add two integers",
-            "isOnline": true,
-            "access": "read",
-            "children": [],
+            "number": 1, "identifier": "sum", "path": "router.functions.sum", "oid": "1.6.1",
+            "description": "Add two integers", "isOnline": true, "access": "read", "children": [],
             "arguments": [
               {"name": "a", "type": "integer"},
               {"name": "b", "type": "integer"}
@@ -345,38 +417,24 @@
             ]
           },
           {
-            "number": 2,
-            "identifier": "recallSalvo",
-            "path": "router.functions.recallSalvo",
-            "oid": "1.4.2",
-            "description": "Apply saved crosspoint set to a matrix",
-            "isOnline": true,
-            "access": "read",
-            "children": [],
+            "number": 2, "identifier": "recallSalvo", "path": "router.functions.recallSalvo", "oid": "1.6.2",
+            "description": "Apply saved crosspoint set (args: matrixOID string, salvoID int)",
+            "isOnline": true, "access": "read", "children": [],
             "arguments": [
               {"name": "matrixPath", "type": "string"},
               {"name": "salvoID", "type": "integer"}
             ],
-            "result": [
-              {"name": "appliedCount", "type": "integer"}
-            ]
+            "result": [{"name": "appliedCount", "type": "integer"}]
           },
           {
-            "number": 3,
-            "identifier": "storeSalvo",
-            "path": "router.functions.storeSalvo",
-            "oid": "1.4.3",
-            "description": "Snapshot current matrix state as salvo",
-            "isOnline": true,
-            "access": "read",
-            "children": [],
+            "number": 3, "identifier": "storeSalvo", "path": "router.functions.storeSalvo", "oid": "1.6.3",
+            "description": "Snapshot matrix state as salvo (args: matrixOID, salvoID)",
+            "isOnline": true, "access": "read", "children": [],
             "arguments": [
               {"name": "matrixPath", "type": "string"},
               {"name": "salvoID", "type": "integer"}
             ],
-            "result": [
-              {"name": "success", "type": "boolean"}
-            ]
+            "result": [{"name": "success", "type": "boolean"}]
           }
         ]
       }

--- a/assets/emberplus/router_tree.json
+++ b/assets/emberplus/router_tree.json
@@ -418,7 +418,7 @@
           },
           {
             "number": 2, "identifier": "recallSalvo", "path": "router.functions.recallSalvo", "oid": "1.6.2",
-            "description": "Apply saved crosspoint set (args: matrixOID string, salvoID int)",
+            "description": "Apply saved crosspoints. matrixPath = OID '1.2.2' or dotted path 'router.oneToN.matrix'",
             "isOnline": true, "access": "read", "children": [],
             "arguments": [
               {"name": "matrixPath", "type": "string"},
@@ -428,7 +428,7 @@
           },
           {
             "number": 3, "identifier": "storeSalvo", "path": "router.functions.storeSalvo", "oid": "1.6.3",
-            "description": "Snapshot matrix state as salvo (args: matrixOID, salvoID)",
+            "description": "Snapshot matrix state. matrixPath = OID '1.4.3' or dotted path 'router.nToN.matrix'",
             "isOnline": true, "access": "read", "children": [],
             "arguments": [
               {"name": "matrixPath", "type": "string"},

--- a/assets/emberplus/router_tree.json
+++ b/assets/emberplus/router_tree.json
@@ -1,0 +1,385 @@
+{
+  "root": {
+    "number": 1,
+    "identifier": "router",
+    "path": "router",
+    "oid": "1",
+    "description": "ACP demo router — oneToN 4x4 + nToN 2x2 + 3 functions",
+    "isOnline": true,
+    "access": "read",
+    "children": [
+      {
+        "number": 1,
+        "identifier": "identity",
+        "path": "router.identity",
+        "oid": "1.1",
+        "description": null,
+        "isOnline": true,
+        "access": "read",
+        "children": [
+          {
+            "number": 1,
+            "identifier": "product",
+            "path": "router.identity.product",
+            "oid": "1.1.1",
+            "description": null,
+            "isOnline": true,
+            "access": "read",
+            "children": [],
+            "type": "string",
+            "value": "ACP Demo Router",
+            "default": null,
+            "minimum": null,
+            "maximum": null,
+            "step": null,
+            "unit": null,
+            "format": null,
+            "factor": null,
+            "formula": null,
+            "enumeration": null,
+            "enumMap": null,
+            "streamIdentifier": null,
+            "streamDescriptor": null,
+            "templateReference": null,
+            "schemaIdentifiers": null
+          },
+          {
+            "number": 2,
+            "identifier": "company",
+            "path": "router.identity.company",
+            "oid": "1.1.2",
+            "description": null,
+            "isOnline": true,
+            "access": "read",
+            "children": [],
+            "type": "string",
+            "value": "BY-SYSTEMS",
+            "default": null,
+            "minimum": null,
+            "maximum": null,
+            "step": null,
+            "unit": null,
+            "format": null,
+            "factor": null,
+            "formula": null,
+            "enumeration": null,
+            "enumMap": null,
+            "streamIdentifier": null,
+            "streamDescriptor": null,
+            "templateReference": null,
+            "schemaIdentifiers": null
+          }
+        ]
+      },
+      {
+        "number": 2,
+        "identifier": "oneToN",
+        "path": "router.oneToN",
+        "oid": "1.2",
+        "description": "4x4 oneToN with two-level labels",
+        "isOnline": true,
+        "access": "read",
+        "children": [
+          {
+            "number": 1,
+            "identifier": "labels",
+            "path": "router.oneToN.labels",
+            "oid": "1.2.1",
+            "description": null,
+            "isOnline": true,
+            "access": "read",
+            "children": [
+              {
+                "number": 1,
+                "identifier": "targets",
+                "path": "router.oneToN.labels.targets",
+                "oid": "1.2.1.1",
+                "description": null,
+                "isOnline": true,
+                "access": "read",
+                "children": [
+                  {"number": 0, "identifier": "t-0", "path": "router.oneToN.labels.targets.t-0", "oid": "1.2.1.1.0", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "MAIN OUT 1", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                  {"number": 1, "identifier": "t-1", "path": "router.oneToN.labels.targets.t-1", "oid": "1.2.1.1.1", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "MAIN OUT 2", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                  {"number": 2, "identifier": "t-2", "path": "router.oneToN.labels.targets.t-2", "oid": "1.2.1.1.2", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "AUX 1", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                  {"number": 3, "identifier": "t-3", "path": "router.oneToN.labels.targets.t-3", "oid": "1.2.1.1.3", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "AUX 2", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                ]
+              },
+              {
+                "number": 2,
+                "identifier": "sources",
+                "path": "router.oneToN.labels.sources",
+                "oid": "1.2.1.2",
+                "description": null,
+                "isOnline": true,
+                "access": "read",
+                "children": [
+                  {"number": 0, "identifier": "s-0", "path": "router.oneToN.labels.sources.s-0", "oid": "1.2.1.2.0", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "CAM 1", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                  {"number": 1, "identifier": "s-1", "path": "router.oneToN.labels.sources.s-1", "oid": "1.2.1.2.1", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "CAM 2", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                  {"number": 2, "identifier": "s-2", "path": "router.oneToN.labels.sources.s-2", "oid": "1.2.1.2.2", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "PLAY 1", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                  {"number": 3, "identifier": "s-3", "path": "router.oneToN.labels.sources.s-3", "oid": "1.2.1.2.3", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "PLAY 2", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                ]
+              }
+            ]
+          },
+          {
+            "number": 2,
+            "identifier": "matrix",
+            "path": "router.oneToN.matrix",
+            "oid": "1.2.2",
+            "description": "4x4 oneToN linear",
+            "isOnline": true,
+            "access": "readWrite",
+            "children": [],
+            "type": "oneToN",
+            "mode": "linear",
+            "targetCount": 4,
+            "sourceCount": 4,
+            "maximumTotalConnects": null,
+            "maximumConnectsPerTarget": null,
+            "parametersLocation": null,
+            "gainParameterNumber": null,
+            "labels": [
+              {"basePath": "1.2.1", "description": "Primary"}
+            ],
+            "targets": [],
+            "sources": [],
+            "connections": [
+              {"target": 0, "sources": [0], "operation": "absolute", "disposition": "tally", "locked": false},
+              {"target": 1, "sources": [1], "operation": "absolute", "disposition": "tally", "locked": false},
+              {"target": 2, "sources": [2], "operation": "absolute", "disposition": "tally", "locked": false},
+              {"target": 3, "sources": [3], "operation": "absolute", "disposition": "tally", "locked": false}
+            ],
+            "targetLabels": null,
+            "sourceLabels": null,
+            "targetParams": null,
+            "sourceParams": null,
+            "connectionParams": null
+          }
+        ]
+      },
+      {
+        "number": 3,
+        "identifier": "nToN",
+        "path": "router.nToN",
+        "oid": "1.3",
+        "description": "2x2 nToN with per-cell gain",
+        "isOnline": true,
+        "access": "read",
+        "children": [
+          {
+            "number": 1,
+            "identifier": "labels",
+            "path": "router.nToN.labels",
+            "oid": "1.3.1",
+            "description": null,
+            "isOnline": true,
+            "access": "read",
+            "children": [
+              {
+                "number": 1,
+                "identifier": "targets",
+                "path": "router.nToN.labels.targets",
+                "oid": "1.3.1.1",
+                "description": null,
+                "isOnline": true,
+                "access": "read",
+                "children": [
+                  {"number": 0, "identifier": "t-0", "path": "router.nToN.labels.targets.t-0", "oid": "1.3.1.1.0", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "MIX A", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                  {"number": 1, "identifier": "t-1", "path": "router.nToN.labels.targets.t-1", "oid": "1.3.1.1.1", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "MIX B", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                ]
+              },
+              {
+                "number": 2,
+                "identifier": "sources",
+                "path": "router.nToN.labels.sources",
+                "oid": "1.3.1.2",
+                "description": null,
+                "isOnline": true,
+                "access": "read",
+                "children": [
+                  {"number": 0, "identifier": "s-0", "path": "router.nToN.labels.sources.s-0", "oid": "1.3.1.2.0", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "MIC 1", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+                  {"number": 1, "identifier": "s-1", "path": "router.nToN.labels.sources.s-1", "oid": "1.3.1.2.1", "description": null, "isOnline": true, "access": "readWrite", "children": [], "type": "string", "value": "MIC 2", "default": null, "minimum": null, "maximum": null, "step": null, "unit": null, "format": null, "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                ]
+              }
+            ]
+          },
+          {
+            "number": 2,
+            "identifier": "parameters",
+            "path": "router.nToN.parameters",
+            "oid": "1.3.2",
+            "description": "per-cell gain grid",
+            "isOnline": true,
+            "access": "read",
+            "children": [
+              {
+                "number": 0,
+                "identifier": "t-0",
+                "path": "router.nToN.parameters.t-0",
+                "oid": "1.3.2.0",
+                "description": null,
+                "isOnline": true,
+                "access": "read",
+                "children": [
+                  {
+                    "number": 0,
+                    "identifier": "s-0",
+                    "path": "router.nToN.parameters.t-0.s-0",
+                    "oid": "1.3.2.0.0",
+                    "description": null,
+                    "isOnline": true,
+                    "access": "read",
+                    "children": [
+                      {"number": 1, "identifier": "gain", "path": "router.nToN.parameters.t-0.s-0.gain", "oid": "1.3.2.0.0.1", "description": "Gain dB", "isOnline": true, "access": "readWrite", "children": [], "type": "real", "value": 0.0, "default": 0.0, "minimum": -60.0, "maximum": 12.0, "step": 0.5, "unit": "dB", "format": "%.1f dB", "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                    ]
+                  },
+                  {
+                    "number": 1,
+                    "identifier": "s-1",
+                    "path": "router.nToN.parameters.t-0.s-1",
+                    "oid": "1.3.2.0.1",
+                    "description": null,
+                    "isOnline": true,
+                    "access": "read",
+                    "children": [
+                      {"number": 1, "identifier": "gain", "path": "router.nToN.parameters.t-0.s-1.gain", "oid": "1.3.2.0.1.1", "description": "Gain dB", "isOnline": true, "access": "readWrite", "children": [], "type": "real", "value": -6.0, "default": 0.0, "minimum": -60.0, "maximum": 12.0, "step": 0.5, "unit": "dB", "format": "%.1f dB", "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                    ]
+                  }
+                ]
+              },
+              {
+                "number": 1,
+                "identifier": "t-1",
+                "path": "router.nToN.parameters.t-1",
+                "oid": "1.3.2.1",
+                "description": null,
+                "isOnline": true,
+                "access": "read",
+                "children": [
+                  {
+                    "number": 0,
+                    "identifier": "s-0",
+                    "path": "router.nToN.parameters.t-1.s-0",
+                    "oid": "1.3.2.1.0",
+                    "description": null,
+                    "isOnline": true,
+                    "access": "read",
+                    "children": [
+                      {"number": 1, "identifier": "gain", "path": "router.nToN.parameters.t-1.s-0.gain", "oid": "1.3.2.1.0.1", "description": "Gain dB", "isOnline": true, "access": "readWrite", "children": [], "type": "real", "value": -6.0, "default": 0.0, "minimum": -60.0, "maximum": 12.0, "step": 0.5, "unit": "dB", "format": "%.1f dB", "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                    ]
+                  },
+                  {
+                    "number": 1,
+                    "identifier": "s-1",
+                    "path": "router.nToN.parameters.t-1.s-1",
+                    "oid": "1.3.2.1.1",
+                    "description": null,
+                    "isOnline": true,
+                    "access": "read",
+                    "children": [
+                      {"number": 1, "identifier": "gain", "path": "router.nToN.parameters.t-1.s-1.gain", "oid": "1.3.2.1.1.1", "description": "Gain dB", "isOnline": true, "access": "readWrite", "children": [], "type": "real", "value": 0.0, "default": 0.0, "minimum": -60.0, "maximum": 12.0, "step": 0.5, "unit": "dB", "format": "%.1f dB", "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "number": 3,
+            "identifier": "matrix",
+            "path": "router.nToN.matrix",
+            "oid": "1.3.3",
+            "description": "2x2 nToN with per-cell gain",
+            "isOnline": true,
+            "access": "readWrite",
+            "children": [],
+            "type": "nToN",
+            "mode": "linear",
+            "targetCount": 2,
+            "sourceCount": 2,
+            "maximumTotalConnects": 4,
+            "maximumConnectsPerTarget": 2,
+            "parametersLocation": "1.3.2",
+            "gainParameterNumber": 1,
+            "labels": [
+              {"basePath": "1.3.1", "description": "Primary"}
+            ],
+            "targets": [],
+            "sources": [],
+            "connections": [
+              {"target": 0, "sources": [0], "operation": "absolute", "disposition": "tally", "locked": false},
+              {"target": 1, "sources": [1], "operation": "absolute", "disposition": "tally", "locked": false}
+            ],
+            "targetLabels": null,
+            "sourceLabels": null,
+            "targetParams": null,
+            "sourceParams": null,
+            "connectionParams": null
+          }
+        ]
+      },
+      {
+        "number": 4,
+        "identifier": "functions",
+        "path": "router.functions",
+        "oid": "1.4",
+        "description": "Callable RPCs: sum, recallSalvo, storeSalvo",
+        "isOnline": true,
+        "access": "read",
+        "children": [
+          {
+            "number": 1,
+            "identifier": "sum",
+            "path": "router.functions.sum",
+            "oid": "1.4.1",
+            "description": "Add two integers",
+            "isOnline": true,
+            "access": "read",
+            "children": [],
+            "arguments": [
+              {"name": "a", "type": "integer"},
+              {"name": "b", "type": "integer"}
+            ],
+            "result": [
+              {"name": "sum", "type": "integer"}
+            ]
+          },
+          {
+            "number": 2,
+            "identifier": "recallSalvo",
+            "path": "router.functions.recallSalvo",
+            "oid": "1.4.2",
+            "description": "Apply saved crosspoint set to a matrix",
+            "isOnline": true,
+            "access": "read",
+            "children": [],
+            "arguments": [
+              {"name": "matrixPath", "type": "string"},
+              {"name": "salvoID", "type": "integer"}
+            ],
+            "result": [
+              {"name": "appliedCount", "type": "integer"}
+            ]
+          },
+          {
+            "number": 3,
+            "identifier": "storeSalvo",
+            "path": "router.functions.storeSalvo",
+            "oid": "1.4.3",
+            "description": "Snapshot current matrix state as salvo",
+            "isOnline": true,
+            "access": "read",
+            "children": [],
+            "arguments": [
+              {"name": "matrixPath", "type": "string"},
+              {"name": "salvoID", "type": "integer"}
+            ],
+            "result": [
+              {"name": "success", "type": "boolean"}
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/assets/emberplus/router_tree.json
+++ b/assets/emberplus/router_tree.json
@@ -405,8 +405,8 @@
         "isOnline": true,
         "access": "read",
         "children": [
-          {"number": 1, "identifier": "meter-L", "path": "router.streams.meter-L", "oid": "1.7.1", "description": "Left channel PPM (streamId 100)", "isOnline": true, "access": "read", "children": [], "type": "real", "value": 0.0, "default": null, "minimum": -60.0, "maximum": 0.0, "step": null, "unit": "dB", "format": "%.1f dB", "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": 100, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
-          {"number": 2, "identifier": "meter-R", "path": "router.streams.meter-R", "oid": "1.7.2", "description": "Right channel PPM (streamId 101)", "isOnline": true, "access": "read", "children": [], "type": "real", "value": 0.0, "default": null, "minimum": -60.0, "maximum": 0.0, "step": null, "unit": "dB", "format": "%.1f dB", "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": 101, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+          {"number": 1, "identifier": "meter-L", "path": "router.streams.meter-L", "oid": "1.7.1", "description": "Left channel PPM (streamId 100) — int centi-dB, factor 100", "isOnline": true, "access": "read", "children": [], "type": "integer", "value": 0, "default": 0, "minimum": -6000, "maximum": 0, "step": 1, "unit": "dB", "format": "%.2f dB", "factor": 100, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": 100, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+          {"number": 2, "identifier": "meter-R", "path": "router.streams.meter-R", "oid": "1.7.2", "description": "Right channel PPM (streamId 101) — int centi-dB, factor 100", "isOnline": true, "access": "read", "children": [], "type": "integer", "value": 0, "default": 0, "minimum": -6000, "maximum": 0, "step": 1, "unit": "dB", "format": "%.2f dB", "factor": 100, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": 101, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
         ]
       },
 

--- a/assets/emberplus/router_tree.json
+++ b/assets/emberplus/router_tree.json
@@ -406,7 +406,9 @@
         "access": "read",
         "children": [
           {"number": 1, "identifier": "meter-L", "path": "router.streams.meter-L", "oid": "1.7.1", "description": "Left channel PPM (streamId 100) — int centi-dB, factor 100", "isOnline": true, "access": "read", "children": [], "type": "integer", "value": 0, "default": 0, "minimum": -6000, "maximum": 0, "step": 1, "unit": "dB", "format": "%.2f dB", "factor": 100, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": 100, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
-          {"number": 2, "identifier": "meter-R", "path": "router.streams.meter-R", "oid": "1.7.2", "description": "Right channel PPM (streamId 101) — int centi-dB, factor 100", "isOnline": true, "access": "read", "children": [], "type": "integer", "value": 0, "default": 0, "minimum": -6000, "maximum": 0, "step": 1, "unit": "dB", "format": "%.2f dB", "factor": 100, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": 101, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+          {"number": 2, "identifier": "meter-R", "path": "router.streams.meter-R", "oid": "1.7.2", "description": "Right channel PPM (streamId 101) — int centi-dB, factor 100", "isOnline": true, "access": "read", "children": [], "type": "integer", "value": 0, "default": 0, "minimum": -6000, "maximum": 0, "step": 1, "unit": "dB", "format": "%.2f dB", "factor": 100, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": 101, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+          {"number": 3, "identifier": "meter-real", "path": "router.streams.meter-real", "oid": "1.7.3", "description": "REAL-typed PPM (streamId 102) — re-verifies EmberViewer REAL quirk #68", "isOnline": true, "access": "read", "children": [], "type": "real", "value": 0.0, "default": 0.0, "minimum": -60.0, "maximum": 0.0, "step": 0.1, "unit": "dB", "format": "%.2f dB", "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": 102, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+          {"number": 4, "identifier": "gain-with-formula", "path": "router.streams.gain-with-formula", "oid": "1.7.4", "description": "Integer gain with provider|consumer formula — 32 dB per unit on wire, display divides by 32", "isOnline": true, "access": "readWrite", "children": [], "type": "integer", "value": -1024, "default": -1024, "minimum": -4096, "maximum": 480, "step": 1, "unit": "dB", "format": "%8.2f dB", "factor": 32, "formula": "$*32\n$/32", "enumeration": null, "enumMap": null, "streamIdentifier": null, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
         ]
       },
 
@@ -458,6 +460,26 @@
               {"name": "matrixPath", "type": "string"}
             ],
             "result": [{"name": "ids", "type": "string"}]
+          },
+          {
+            "number": 5, "identifier": "setLock", "path": "router.functions.setLock", "oid": "1.6.5",
+            "description": "Lock or unlock a matrix target. Locked targets reject Connection changes (disposition=locked per spec p.89)",
+            "isOnline": true, "access": "read", "children": [],
+            "arguments": [
+              {"name": "matrixPath", "type": "string"},
+              {"name": "target", "type": "integer"},
+              {"name": "locked", "type": "boolean"}
+            ],
+            "result": [{"name": "wasLocked", "type": "boolean"}]
+          },
+          {
+            "number": 6, "identifier": "listLocks", "path": "router.functions.listLocks", "oid": "1.6.6",
+            "description": "Locked target IDs for a matrix (comma-separated)",
+            "isOnline": true, "access": "read", "children": [],
+            "arguments": [
+              {"name": "matrixPath", "type": "string"}
+            ],
+            "result": [{"name": "targets", "type": "string"}]
           }
         ]
       }

--- a/assets/emberplus/router_tree.json
+++ b/assets/emberplus/router_tree.json
@@ -397,6 +397,20 @@
       },
 
       {
+        "number": 7,
+        "identifier": "streams",
+        "path": "router.streams",
+        "oid": "1.7",
+        "description": "Live stream parameters — sine-wave meters pushed via StreamCollection",
+        "isOnline": true,
+        "access": "read",
+        "children": [
+          {"number": 1, "identifier": "meter-L", "path": "router.streams.meter-L", "oid": "1.7.1", "description": "Left channel PPM (streamId 100)", "isOnline": true, "access": "read", "children": [], "type": "real", "value": 0.0, "default": null, "minimum": -60.0, "maximum": 0.0, "step": null, "unit": "dB", "format": "%.1f dB", "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": 100, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null},
+          {"number": 2, "identifier": "meter-R", "path": "router.streams.meter-R", "oid": "1.7.2", "description": "Right channel PPM (streamId 101)", "isOnline": true, "access": "read", "children": [], "type": "real", "value": 0.0, "default": null, "minimum": -60.0, "maximum": 0.0, "step": null, "unit": "dB", "format": "%.1f dB", "factor": null, "formula": null, "enumeration": null, "enumMap": null, "streamIdentifier": 101, "streamDescriptor": null, "templateReference": null, "schemaIdentifiers": null}
+        ]
+      },
+
+      {
         "number": 6,
         "identifier": "functions",
         "path": "router.functions",

--- a/cmd/acp/cmd_invoke.go
+++ b/cmd/acp/cmd_invoke.go
@@ -50,13 +50,15 @@ func runInvoke(ctx context.Context, args []string) error {
 	}
 	defer cleanup()
 
-	opCtx, cancel := withTimeout(ctx, cf.timeout)
-	defer cancel()
-
 	// Walk to populate tree (raw ctx — no per-op deadline).
 	if _, err := plug.Walk(ctx, *slot); err != nil {
 		return fmt.Errorf("walk: %w", err)
 	}
+
+	// Start the per-op timer AFTER the walk — otherwise the walk burns
+	// through --timeout before Invoke even sends its Command frame.
+	opCtx, cancel := withTimeout(ctx, cf.timeout)
+	defer cancel()
 
 	ep, ok := plug.(*emberplus.Plugin)
 	if !ok {

--- a/internal/provider/emberplus/builtins.go
+++ b/internal/provider/emberplus/builtins.go
@@ -2,6 +2,9 @@ package emberplus
 
 import (
 	"fmt"
+	"sort"
+	"strconv"
+	"strings"
 	"sync"
 
 	"acp/internal/export/canonical"
@@ -55,6 +58,23 @@ func (s *salvoStore) recall(matrixOID string, salvoID int64) ([]canonical.Matrix
 	return conns, ok
 }
 
+// list returns the salvoIDs stored for matrixOID, ascending. Empty slice
+// if the matrix has no salvos yet.
+func (s *salvoStore) list(matrixOID string) []int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	inner, ok := s.saved[matrixOID]
+	if !ok {
+		return nil
+	}
+	ids := make([]int64, 0, len(inner))
+	for id := range inner {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
+}
+
 // setupBuiltinFunctions walks the loaded tree and registers default
 // callbacks for any canonical.Function whose identifier matches a known
 // builtin name. Order mirrors the spec-p.91 examples + the
@@ -74,6 +94,8 @@ func (s *server) setupBuiltinFunctions() {
 			s.funcs.register(oid, s.makeBuiltinRecallSalvo())
 		case "storeSalvo", "store":
 			s.funcs.register(oid, s.makeBuiltinStoreSalvo())
+		case "listSalvos", "list":
+			s.funcs.register(oid, s.makeBuiltinListSalvos())
 		}
 	})
 }
@@ -182,5 +204,34 @@ func (s *server) makeBuiltinStoreSalvo() FunctionImpl {
 		}
 		s.salvos.store(oid, salvoID, m.Connections)
 		return []any{true}, nil
+	}
+}
+
+// makeBuiltinListSalvos returns a comma-separated list of stored salvo
+// IDs for the given matrix, ascending. Args:
+//   - args[0] string matrixPath — OID or dotted identifier path
+//
+// Empty string if the matrix has no salvos yet. Returns an empty string
+// for non-matrix refs rather than an error so consumers can probe
+// cheaply without trapping exceptions.
+func (s *server) makeBuiltinListSalvos() FunctionImpl {
+	return func(args []any) ([]any, error) {
+		if len(args) < 1 {
+			return nil, fmt.Errorf("listSalvos: need (matrixPath)")
+		}
+		matrixRef, ok := args[0].(string)
+		if !ok {
+			return nil, fmt.Errorf("listSalvos: bad arg type (%T)", args[0])
+		}
+		oid, _, ok := s.resolveMatrix(matrixRef)
+		if !ok {
+			return []any{""}, nil
+		}
+		ids := s.salvos.list(oid)
+		parts := make([]string, len(ids))
+		for i, id := range ids {
+			parts[i] = strconv.FormatInt(id, 10)
+		}
+		return []any{strings.Join(parts, ",")}, nil
 	}
 }

--- a/internal/provider/emberplus/builtins.go
+++ b/internal/provider/emberplus/builtins.go
@@ -107,60 +107,80 @@ func builtinSum(args []any) ([]any, error) {
 	return []any{a + b}, nil
 }
 
+// resolveMatrix accepts either a numeric OID ("1.4.3") or a dotted
+// identifier path ("router.nToN.matrix") and returns the canonical OID
+// plus the underlying Matrix element. Returns ("", nil, false) if the
+// ref does not resolve to a Matrix — so storeSalvo/recallSalvo reject
+// attempts against label string params, nodes, or bogus OIDs rather
+// than silently keying into the salvo store.
+func (s *server) resolveMatrix(ref string) (string, *canonical.Matrix, bool) {
+	e, ok := s.tree.lookupOID(ref)
+	if !ok {
+		e, ok = s.tree.lookupPath(ref)
+	}
+	if !ok {
+		return "", nil, false
+	}
+	m, ok := e.el.(*canonical.Matrix)
+	if !ok {
+		return "", nil, false
+	}
+	return e.el.Common().OID, m, true
+}
+
 // makeBuiltinRecallSalvo binds a recall callback to this server. Args:
-//   - args[0] string matrixPath — canonical OID of the target matrix
+//   - args[0] string matrixPath — OID (e.g. "1.4.3") OR dotted identifier
+//     path (e.g. "router.nToN.matrix"); both resolve to the same matrix.
 //   - args[1] int64  salvoID
 //
 // Applies the saved crosspoint set to the matrix, broadcasts the resulting
-// connections, and returns the number of connections applied.
+// connections, and returns the number of connections applied. Returns 0
+// if the ref does not point at a Matrix or the salvo was never stored.
 func (s *server) makeBuiltinRecallSalvo() FunctionImpl {
 	return func(args []any) ([]any, error) {
 		if len(args) < 2 {
 			return nil, fmt.Errorf("recallSalvo: need (matrixPath, salvoID)")
 		}
-		matrixOID, okP := args[0].(string)
+		matrixRef, okP := args[0].(string)
 		salvoID, okS := asInt64(args[1])
 		if !okP || !okS {
 			return nil, fmt.Errorf("recallSalvo: bad arg types (%T, %T)", args[0], args[1])
 		}
-		conns, ok := s.salvos.recall(matrixOID, salvoID)
+		oid, _, ok := s.resolveMatrix(matrixRef)
 		if !ok {
 			return []any{int64(0)}, nil
 		}
-		post, err := s.applyMatrixConnections(matrixOID, conns)
+		conns, ok := s.salvos.recall(oid, salvoID)
+		if !ok {
+			return []any{int64(0)}, nil
+		}
+		post, err := s.applyMatrixConnections(oid, conns)
 		if err != nil {
 			return nil, err
 		}
-		s.broadcastMatrixConnections(matrixOID, post, nil)
+		s.broadcastMatrixConnections(oid, post, nil)
 		return []any{int64(len(post))}, nil
 	}
 }
 
-// makeBuiltinStoreSalvo binds a store callback. Args:
-//   - args[0] string matrixPath
-//   - args[1] int64  salvoID
-//
+// makeBuiltinStoreSalvo binds a store callback. Args mirror recallSalvo.
 // Snapshots the matrix's current connections under salvoID. Returns true
-// on success; false if the matrix OID is unknown.
+// on success; false if the ref does not resolve to a Matrix element.
 func (s *server) makeBuiltinStoreSalvo() FunctionImpl {
 	return func(args []any) ([]any, error) {
 		if len(args) < 2 {
 			return nil, fmt.Errorf("storeSalvo: need (matrixPath, salvoID)")
 		}
-		matrixOID, okP := args[0].(string)
+		matrixRef, okP := args[0].(string)
 		salvoID, okS := asInt64(args[1])
 		if !okP || !okS {
 			return nil, fmt.Errorf("storeSalvo: bad arg types (%T, %T)", args[0], args[1])
 		}
-		e, ok := s.tree.lookupOID(matrixOID)
+		oid, m, ok := s.resolveMatrix(matrixRef)
 		if !ok {
 			return []any{false}, nil
 		}
-		m, ok := e.el.(*canonical.Matrix)
-		if !ok {
-			return []any{false}, nil
-		}
-		s.salvos.store(matrixOID, salvoID, m.Connections)
+		s.salvos.store(oid, salvoID, m.Connections)
 		return []any{true}, nil
 	}
 }

--- a/internal/provider/emberplus/builtins.go
+++ b/internal/provider/emberplus/builtins.go
@@ -10,6 +10,59 @@ import (
 	"acp/internal/export/canonical"
 )
 
+// lockStore holds per-target locks keyed by matrixOID -> target.
+// Spec p.89: a locked target rejects connection changes and the
+// provider replies with disposition=locked + the unchanged sources.
+type lockStore struct {
+	mu     sync.Mutex
+	locked map[string]map[int64]bool
+}
+
+func newLockStore() *lockStore {
+	return &lockStore{locked: map[string]map[int64]bool{}}
+}
+
+func (l *lockStore) set(matrixOID string, target int64, on bool) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	inner, ok := l.locked[matrixOID]
+	if !ok {
+		inner = map[int64]bool{}
+		l.locked[matrixOID] = inner
+	}
+	prev := inner[target]
+	if on {
+		inner[target] = true
+	} else {
+		delete(inner, target)
+	}
+	return prev
+}
+
+func (l *lockStore) isLocked(matrixOID string, target int64) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if inner, ok := l.locked[matrixOID]; ok {
+		return inner[target]
+	}
+	return false
+}
+
+func (l *lockStore) list(matrixOID string) []int64 {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	inner, ok := l.locked[matrixOID]
+	if !ok {
+		return nil
+	}
+	out := make([]int64, 0, len(inner))
+	for t := range inner {
+		out = append(out, t)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
 // salvoStore holds matrix-connection snapshots keyed by
 // matrixOID -> salvoID -> []MatrixConnection. In-memory only — restart
 // drops every salvo. Realistic broadcast routers persist, but that is a
@@ -84,6 +137,7 @@ func (s *server) setupBuiltinFunctions() {
 		return
 	}
 	s.salvos = newSalvoStore()
+	s.locks = newLockStore()
 
 	s.walkFunctions(s.tree.root, func(e *entry, f *canonical.Function) {
 		oid := e.el.Common().OID
@@ -96,8 +150,63 @@ func (s *server) setupBuiltinFunctions() {
 			s.funcs.register(oid, s.makeBuiltinStoreSalvo())
 		case "listSalvos", "list":
 			s.funcs.register(oid, s.makeBuiltinListSalvos())
+		case "setLock", "lock":
+			s.funcs.register(oid, s.makeBuiltinSetLock())
+		case "listLocks", "locks":
+			s.funcs.register(oid, s.makeBuiltinListLocks())
 		}
 	})
+}
+
+// makeBuiltinSetLock binds a lock-toggle callback. Args:
+//   - args[0] string matrixPath — OID or dotted identifier
+//   - args[1] int64  target
+//   - args[2] bool   locked   (true = lock, false = unlock)
+//
+// Returns the previous lock state (true if target was already locked).
+// Locked targets reject Connection changes — see applyMatrixConnections.
+func (s *server) makeBuiltinSetLock() FunctionImpl {
+	return func(args []any) ([]any, error) {
+		if len(args) < 3 {
+			return nil, fmt.Errorf("setLock: need (matrixPath, target, locked)")
+		}
+		matrixRef, okP := args[0].(string)
+		target, okT := asInt64(args[1])
+		on, okL := args[2].(bool)
+		if !okP || !okT || !okL {
+			return nil, fmt.Errorf("setLock: bad arg types (%T, %T, %T)", args[0], args[1], args[2])
+		}
+		oid, _, ok := s.resolveMatrix(matrixRef)
+		if !ok {
+			return []any{false}, nil
+		}
+		prev := s.locks.set(oid, target, on)
+		return []any{prev}, nil
+	}
+}
+
+// makeBuiltinListLocks returns comma-separated locked target IDs for a
+// matrix. Empty string if no targets are locked.
+func (s *server) makeBuiltinListLocks() FunctionImpl {
+	return func(args []any) ([]any, error) {
+		if len(args) < 1 {
+			return nil, fmt.Errorf("listLocks: need (matrixPath)")
+		}
+		matrixRef, ok := args[0].(string)
+		if !ok {
+			return nil, fmt.Errorf("listLocks: bad arg type (%T)", args[0])
+		}
+		oid, _, ok := s.resolveMatrix(matrixRef)
+		if !ok {
+			return []any{""}, nil
+		}
+		targets := s.locks.list(oid)
+		parts := make([]string, len(targets))
+		for i, t := range targets {
+			parts[i] = strconv.FormatInt(t, 10)
+		}
+		return []any{strings.Join(parts, ",")}, nil
+	}
 }
 
 // walkFunctions invokes visit for every Function element reachable from el.

--- a/internal/provider/emberplus/builtins.go
+++ b/internal/provider/emberplus/builtins.go
@@ -1,0 +1,166 @@
+package emberplus
+
+import (
+	"fmt"
+	"sync"
+
+	"acp/internal/export/canonical"
+)
+
+// salvoStore holds matrix-connection snapshots keyed by
+// matrixOID -> salvoID -> []MatrixConnection. In-memory only — restart
+// drops every salvo. Realistic broadcast routers persist, but that is a
+// later concern.
+type salvoStore struct {
+	mu    sync.Mutex
+	saved map[string]map[int64][]canonical.MatrixConnection
+}
+
+func newSalvoStore() *salvoStore {
+	return &salvoStore{saved: map[string]map[int64][]canonical.MatrixConnection{}}
+}
+
+func (s *salvoStore) store(matrixOID string, salvoID int64, conns []canonical.MatrixConnection) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	inner, ok := s.saved[matrixOID]
+	if !ok {
+		inner = map[int64][]canonical.MatrixConnection{}
+		s.saved[matrixOID] = inner
+	}
+	copy := make([]canonical.MatrixConnection, len(conns))
+	for i, c := range conns {
+		src := make([]int64, len(c.Sources))
+		for j, v := range c.Sources {
+			src[j] = v
+		}
+		copy[i] = canonical.MatrixConnection{
+			Target:      c.Target,
+			Sources:     src,
+			Operation:   c.Operation,
+			Disposition: c.Disposition,
+		}
+	}
+	inner[salvoID] = copy
+}
+
+func (s *salvoStore) recall(matrixOID string, salvoID int64) ([]canonical.MatrixConnection, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	inner, ok := s.saved[matrixOID]
+	if !ok {
+		return nil, false
+	}
+	conns, ok := inner[salvoID]
+	return conns, ok
+}
+
+// setupBuiltinFunctions walks the loaded tree and registers default
+// callbacks for any canonical.Function whose identifier matches a known
+// builtin name. Order mirrors the spec-p.91 examples + the
+// broadcast-router convention (sum / recallSalvo / storeSalvo).
+func (s *server) setupBuiltinFunctions() {
+	if s.tree == nil {
+		return
+	}
+	s.salvos = newSalvoStore()
+
+	s.walkFunctions(s.tree.root, func(e *entry, f *canonical.Function) {
+		oid := e.el.Common().OID
+		switch f.Identifier {
+		case "sum", "addFunction", "add":
+			s.funcs.register(oid, builtinSum)
+		case "recallSalvo", "recall":
+			s.funcs.register(oid, s.makeBuiltinRecallSalvo())
+		case "storeSalvo", "store":
+			s.funcs.register(oid, s.makeBuiltinStoreSalvo())
+		}
+	})
+}
+
+// walkFunctions invokes visit for every Function element reachable from el.
+func (s *server) walkFunctions(el canonical.Element, visit func(*entry, *canonical.Function)) {
+	if el == nil {
+		return
+	}
+	if f, ok := el.(*canonical.Function); ok {
+		if e, found := s.tree.lookupOID(f.OID); found {
+			visit(e, f)
+		}
+	}
+	for _, child := range el.Common().Children {
+		s.walkFunctions(child, visit)
+	}
+}
+
+// builtinSum adds the first two int arguments. Returns a single int result.
+// Missing / non-int args produce success=false via the (nil, err) path.
+func builtinSum(args []any) ([]any, error) {
+	if len(args) < 2 {
+		return nil, fmt.Errorf("sum: expected 2 args, got %d", len(args))
+	}
+	a, okA := asInt64(args[0])
+	b, okB := asInt64(args[1])
+	if !okA || !okB {
+		return nil, fmt.Errorf("sum: non-integer args (%T, %T)", args[0], args[1])
+	}
+	return []any{a + b}, nil
+}
+
+// makeBuiltinRecallSalvo binds a recall callback to this server. Args:
+//   - args[0] string matrixPath — canonical OID of the target matrix
+//   - args[1] int64  salvoID
+//
+// Applies the saved crosspoint set to the matrix, broadcasts the resulting
+// connections, and returns the number of connections applied.
+func (s *server) makeBuiltinRecallSalvo() FunctionImpl {
+	return func(args []any) ([]any, error) {
+		if len(args) < 2 {
+			return nil, fmt.Errorf("recallSalvo: need (matrixPath, salvoID)")
+		}
+		matrixOID, okP := args[0].(string)
+		salvoID, okS := asInt64(args[1])
+		if !okP || !okS {
+			return nil, fmt.Errorf("recallSalvo: bad arg types (%T, %T)", args[0], args[1])
+		}
+		conns, ok := s.salvos.recall(matrixOID, salvoID)
+		if !ok {
+			return []any{int64(0)}, nil
+		}
+		post, err := s.applyMatrixConnections(matrixOID, conns)
+		if err != nil {
+			return nil, err
+		}
+		s.broadcastMatrixConnections(matrixOID, post, nil)
+		return []any{int64(len(post))}, nil
+	}
+}
+
+// makeBuiltinStoreSalvo binds a store callback. Args:
+//   - args[0] string matrixPath
+//   - args[1] int64  salvoID
+//
+// Snapshots the matrix's current connections under salvoID. Returns true
+// on success; false if the matrix OID is unknown.
+func (s *server) makeBuiltinStoreSalvo() FunctionImpl {
+	return func(args []any) ([]any, error) {
+		if len(args) < 2 {
+			return nil, fmt.Errorf("storeSalvo: need (matrixPath, salvoID)")
+		}
+		matrixOID, okP := args[0].(string)
+		salvoID, okS := asInt64(args[1])
+		if !okP || !okS {
+			return nil, fmt.Errorf("storeSalvo: bad arg types (%T, %T)", args[0], args[1])
+		}
+		e, ok := s.tree.lookupOID(matrixOID)
+		if !ok {
+			return []any{false}, nil
+		}
+		m, ok := e.el.(*canonical.Matrix)
+		if !ok {
+			return []any{false}, nil
+		}
+		s.salvos.store(matrixOID, salvoID, m.Connections)
+		return []any{true}, nil
+	}
+}

--- a/internal/provider/emberplus/encoder.go
+++ b/internal/provider/emberplus/encoder.go
@@ -171,6 +171,14 @@ func (s *server) encodeQualifiedParameter(e *entry, p *canonical.Parameter) ber.
 		kids = append(kids,
 			ber.ContextConstructed(glow.ParamContentFactor, ber.Integer(*p.Factor))) // [8]
 	}
+	// Formula [CTX 10]: "provider|consumer" split, newline-separated
+	// in spec examples (see Ember+ Formulas.pdf). Full evaluator lands
+	// in a follow-up — for now we emit the string so consumers that
+	// parse formulas themselves see it.
+	if p.Formula != nil && *p.Formula != "" {
+		kids = append(kids,
+			ber.ContextConstructed(glow.ParamContentFormula, ber.UTF8(*p.Formula))) // [10]
+	}
 	if v, ok := encodeValue(p.Type, p.Step); ok {
 		kids = append(kids,
 			ber.ContextConstructed(glow.ParamContentStep, v)) // [11]

--- a/internal/provider/emberplus/encoder.go
+++ b/internal/provider/emberplus/encoder.go
@@ -183,6 +183,10 @@ func (s *server) encodeQualifiedParameter(e *entry, p *canonical.Parameter) ber.
 		kids = append(kids,
 			ber.ContextConstructed(glow.ParamContentType, ber.Integer(tc))) // [13]
 	}
+	if p.StreamIdentifier != nil {
+		kids = append(kids,
+			ber.ContextConstructed(glow.ParamContentStreamIdentifier, ber.Integer(*p.StreamIdentifier))) // [14]
+	}
 	if len(p.EnumMap) > 0 {
 		kids = append(kids,
 			ber.ContextConstructed(glow.ParamContentEnumMap, encodeEnumMap(p.EnumMap))) // [15]

--- a/internal/provider/emberplus/encoder.go
+++ b/internal/provider/emberplus/encoder.go
@@ -75,6 +75,16 @@ func (s *server) encodeElementMinimal(e *entry) ber.TLV {
 			ber.ContextConstructed(glow.QParamPath, ber.RelOID(encodeRelativeOID(e.oidParts))),
 			ber.ContextConstructed(glow.QParamContents, contents),
 		)
+	case *canonical.Matrix:
+		return ber.AppConstructed(glow.TagQualifiedMatrix,
+			ber.ContextConstructed(0, ber.RelOID(encodeRelativeOID(e.oidParts))),
+			ber.ContextConstructed(1, contents),
+		)
+	case *canonical.Function:
+		return ber.AppConstructed(glow.TagQualifiedFunction,
+			ber.ContextConstructed(glow.QFuncPath, ber.RelOID(encodeRelativeOID(e.oidParts))),
+			ber.ContextConstructed(glow.QFuncContents, contents),
+		)
 	default:
 		return ber.AppConstructed(glow.TagQualifiedNode,
 			ber.ContextConstructed(glow.QNodePath, ber.RelOID(encodeRelativeOID(e.oidParts))),
@@ -92,6 +102,10 @@ func (s *server) encodeQualifiedElement(e *entry) (ber.TLV, error) {
 		return s.encodeQualifiedNode(e, el), nil
 	case *canonical.Parameter:
 		return s.encodeQualifiedParameter(e, el), nil
+	case *canonical.Matrix:
+		return s.encodeQualifiedMatrix(e, el)
+	case *canonical.Function:
+		return s.encodeQualifiedFunction(e, el), nil
 	default:
 		return ber.TLV{}, fmt.Errorf("encoder: element kind %q not yet implemented", e.el.Kind())
 	}

--- a/internal/provider/emberplus/function.go
+++ b/internal/provider/emberplus/function.go
@@ -1,0 +1,128 @@
+package emberplus
+
+import (
+	"acp/internal/export/canonical"
+	"acp/internal/protocol/emberplus/ber"
+	"acp/internal/protocol/emberplus/glow"
+)
+
+// encodeQualifiedFunction emits a [APPLICATION 20] QualifiedFunction. Only
+// path + contents are emitted; children are not used for demo functions.
+//
+// Spec p.91 FunctionContents SET — ascending CTX-tag order:
+//
+//	0 identifier, 1 description, 2 arguments (TupleDescription), 3 result,
+//	4 templateReference.
+func (s *server) encodeQualifiedFunction(e *entry, f *canonical.Function) ber.TLV {
+	var kids []ber.TLV
+	kids = append(kids,
+		ber.ContextConstructed(glow.FuncContentIdentifier, ber.UTF8(f.Identifier))) // [0]
+	if f.Description != nil && *f.Description != "" {
+		kids = append(kids,
+			ber.ContextConstructed(glow.FuncContentDescription, ber.UTF8(*f.Description))) // [1]
+	}
+	if len(f.Arguments) > 0 {
+		kids = append(kids,
+			ber.ContextConstructed(glow.FuncContentArguments, encodeTupleDescription(f.Arguments))) // [2]
+	}
+	if len(f.Result) > 0 {
+		kids = append(kids,
+			ber.ContextConstructed(glow.FuncContentResult, encodeTupleDescription(f.Result))) // [3]
+	}
+	contents := ber.Set(kids...)
+	return ber.AppConstructed(glow.TagQualifiedFunction,
+		ber.ContextConstructed(glow.QFuncPath, ber.RelOID(encodeRelativeOID(e.oidParts))),
+		ber.ContextConstructed(glow.QFuncContents, contents),
+	)
+}
+
+// encodeTupleDescription emits a SEQUENCE OF [0] TupleItemDescription
+// (spec p.91). Each item is [APP 21] SEQUENCE { [0] type, [1] name }.
+func encodeTupleDescription(items []canonical.TupleItem) ber.TLV {
+	out := make([]ber.TLV, 0, len(items))
+	for _, t := range items {
+		ti := encodeTupleItem(t)
+		out = append(out, ber.ContextConstructed(0, ti))
+	}
+	return ber.Sequence(out...)
+}
+
+func encodeTupleItem(t canonical.TupleItem) ber.TLV {
+	typeConst, ok := paramTypeConst(t.Type)
+	if !ok {
+		typeConst = glow.ParamTypeNull
+	}
+	fields := []ber.TLV{
+		ber.ContextConstructed(glow.TupleType, ber.Integer(typeConst)),
+	}
+	if t.Name != "" {
+		fields = append(fields,
+			ber.ContextConstructed(glow.TupleName, ber.UTF8(t.Name)))
+	}
+	return ber.AppConstructed(glow.TagTupleItemDescription, fields...)
+}
+
+// encodeInvocationResult builds a top-level Root { InvocationResult } frame.
+// Consumers receive this as the response to Command{Invoke, Invocation}.
+//
+// Spec p.92:
+//
+//	InvocationResult ::= [APPLICATION 23] SEQUENCE {
+//	  invocationId [0] Integer32,
+//	  success      [1] BOOLEAN OPTIONAL,  -- default true
+//	  result       [2] Tuple    OPTIONAL
+//	}
+func (s *server) encodeInvocationResult(invID int32, success bool, result []any) []byte {
+	fields := []ber.TLV{
+		ber.ContextConstructed(glow.InvResInvocationID, ber.Integer(int64(invID))),
+	}
+	// Spec: "True or omitted if no errors". Emit only when false.
+	if !success {
+		fields = append(fields,
+			ber.ContextConstructed(glow.InvResSuccess, ber.Boolean(false)))
+	}
+	if len(result) > 0 {
+		fields = append(fields,
+			ber.ContextConstructed(glow.InvResResult, encodeTupleValues(result)))
+	}
+	ir := ber.AppConstructed(glow.TagInvocationResult, fields...)
+	root := ber.AppConstructed(glow.TagRoot, ir)
+	return ber.EncodeTLV(root)
+}
+
+// encodeTupleValues turns a Go tuple into the wire Tuple shape
+// (SEQUENCE OF [0] Value). Each value uses its Go type to pick the BER
+// primitive — int/int64 → INTEGER, float → REAL, string → UTF8,
+// bool → BOOLEAN, []byte → OCTET STRING, nil → NULL.
+func encodeTupleValues(values []any) ber.TLV {
+	items := make([]ber.TLV, 0, len(values))
+	for _, v := range values {
+		items = append(items, ber.ContextConstructed(0, encodeTupleValue(v)))
+	}
+	return ber.Sequence(items...)
+}
+
+func encodeTupleValue(v any) ber.TLV {
+	switch t := v.(type) {
+	case nil:
+		return ber.Primitive(ber.ClassUniversal, ber.TagNull, nil)
+	case bool:
+		return ber.Boolean(t)
+	case int:
+		return ber.Integer(int64(t))
+	case int32:
+		return ber.Integer(int64(t))
+	case int64:
+		return ber.Integer(t)
+	case float32:
+		return ber.Real(float64(t))
+	case float64:
+		return ber.Real(t)
+	case string:
+		return ber.UTF8(t)
+	case []byte:
+		return ber.OctetStr(t)
+	}
+	// Fallback: NULL for unsupported types so the wire stays legal.
+	return ber.Primitive(ber.ClassUniversal, ber.TagNull, nil)
+}

--- a/internal/provider/emberplus/function_test.go
+++ b/internal/provider/emberplus/function_test.go
@@ -125,3 +125,32 @@ func TestSalvoStoreRecall(t *testing.T) {
 		t.Errorf("saved source=%d want 5 (deep-copy broken)", got[0].Sources[0])
 	}
 }
+
+// TestResolveMatrix_AcceptsOIDAndPath asserts the salvo functions accept
+// either the numeric OID or the dotted identifier path for a Matrix,
+// and reject refs that point at non-matrix elements.
+func TestResolveMatrix_AcceptsOIDAndPath(t *testing.T) {
+	m := &canonical.Matrix{Type: canonical.MatrixOneToN}
+	srv := buildMatrixTree(t, m)
+
+	cases := []struct {
+		name, ref string
+		wantOK    bool
+	}{
+		{"by OID", "1.1", true},
+		{"by dotted path", "router.mat", true},
+		{"non-matrix OID", "1", false},
+		{"non-existent OID", "9.9.9", false},
+		{"empty", "", false},
+	}
+	for _, c := range cases {
+		oid, got, ok := srv.resolveMatrix(c.ref)
+		if ok != c.wantOK {
+			t.Errorf("%s: ok=%v want %v (ref=%q)", c.name, ok, c.wantOK, c.ref)
+			continue
+		}
+		if c.wantOK && (oid != "1.1" || got != m) {
+			t.Errorf("%s: resolved to oid=%q m=%v want 1.1 / the Matrix", c.name, oid, got)
+		}
+	}
+}

--- a/internal/provider/emberplus/function_test.go
+++ b/internal/provider/emberplus/function_test.go
@@ -1,0 +1,127 @@
+package emberplus
+
+import (
+	"testing"
+
+	"acp/internal/export/canonical"
+	"acp/internal/protocol/emberplus/glow"
+)
+
+// TestRoundTrip_Function checks a Function with 2 integer args → 1 result
+// round-trips shape + tuple descriptions through the consumer decoder.
+func TestRoundTrip_Function(t *testing.T) {
+	f := &canonical.Function{
+		Header: canonical.Header{
+			Number: 1, Identifier: "sum", Path: "r.sum", OID: "1.1",
+			IsOnline: true, Access: canonical.AccessRead,
+			Children: canonical.EmptyChildren(),
+		},
+		Arguments: []canonical.TupleItem{
+			{Name: "a", Type: canonical.ParamInteger},
+			{Name: "b", Type: canonical.ParamInteger},
+		},
+		Result: []canonical.TupleItem{
+			{Name: "sum", Type: canonical.ParamInteger},
+		},
+	}
+	root := &canonical.Node{
+		Header: canonical.Header{
+			Number: 1, Identifier: "r", Path: "r", OID: "1",
+			IsOnline: true, Access: canonical.AccessRead,
+			Children: []canonical.Element{f},
+		},
+	}
+	srv := newServer(nil, &canonical.Export{Root: root})
+
+	reply, err := srv.encodeGetDirReply(srv.tree.rootEntry(), false)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	els, err := glow.DecodeRoot(reply)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(els) != 1 || els[0].Function == nil {
+		t.Fatalf("want 1 Function element, got %+v", els)
+	}
+	got := els[0].Function
+	if got.Identifier != "sum" {
+		t.Errorf("identifier=%q want sum", got.Identifier)
+	}
+	if len(got.Arguments) != 2 {
+		t.Fatalf("arguments=%d want 2", len(got.Arguments))
+	}
+	if got.Arguments[0].Name != "a" || got.Arguments[0].Type != glow.ParamTypeInteger {
+		t.Errorf("arg[0]=%+v", got.Arguments[0])
+	}
+	if len(got.Result) != 1 || got.Result[0].Name != "sum" {
+		t.Errorf("result=%+v", got.Result)
+	}
+}
+
+// TestInvocationResult checks that Root→InvocationResult decodes back with
+// the right id + tuple values (int, bool, string).
+func TestInvocationResult(t *testing.T) {
+	srv := newServer(nil, nil) // no tree — only encoder exercised
+	payload := srv.encodeInvocationResult(42, true, []any{int64(7), true, "ok"})
+
+	els, err := glow.DecodeRoot(payload)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(els) != 1 || els[0].InvocationResult == nil {
+		t.Fatalf("want 1 InvocationResult, got %+v", els)
+	}
+	r := els[0].InvocationResult
+	if r.InvocationID != 42 {
+		t.Errorf("invocationID=%d want 42", r.InvocationID)
+	}
+	if !r.Success {
+		t.Error("success=false, want true (default when omitted)")
+	}
+	if len(r.Result) != 3 {
+		t.Fatalf("result len=%d want 3", len(r.Result))
+	}
+	if v, _ := r.Result[0].(int64); v != 7 {
+		t.Errorf("result[0]=%v want 7", r.Result[0])
+	}
+	if v, _ := r.Result[1].(bool); !v {
+		t.Errorf("result[1]=%v want true", r.Result[1])
+	}
+	if v, _ := r.Result[2].(string); v != "ok" {
+		t.Errorf("result[2]=%v want ok", r.Result[2])
+	}
+}
+
+// TestBuiltinSum exercises the auto-registered builtin.
+func TestBuiltinSum(t *testing.T) {
+	got, err := builtinSum([]any{int64(3), int64(4)})
+	if err != nil {
+		t.Fatalf("sum: %v", err)
+	}
+	if len(got) != 1 || got[0] != int64(7) {
+		t.Errorf("sum got %v want [7]", got)
+	}
+
+	if _, err := builtinSum([]any{int64(1)}); err == nil {
+		t.Error("want error on missing arg")
+	}
+}
+
+// TestSalvoStoreRecall checks the salvo store preserves a deep copy so
+// later mutations to the matrix's live connections don't leak back.
+func TestSalvoStoreRecall(t *testing.T) {
+	s := newSalvoStore()
+	live := []canonical.MatrixConnection{{Target: 0, Sources: []int64{5}}}
+	s.store("1.1", 1, live)
+	// Mutate the live slice — saved copy must be independent.
+	live[0].Sources[0] = 99
+
+	got, ok := s.recall("1.1", 1)
+	if !ok {
+		t.Fatal("recall missed")
+	}
+	if got[0].Sources[0] != 5 {
+		t.Errorf("saved source=%d want 5 (deep-copy broken)", got[0].Sources[0])
+	}
+}

--- a/internal/provider/emberplus/invoke.go
+++ b/internal/provider/emberplus/invoke.go
@@ -61,15 +61,23 @@ func (s *server) invokeFunction(oid string, args []any) ([]any, bool) {
 // applyMatrixConnections mutates a Matrix element's connections per the
 // inbound Connection list and returns the resulting post-state to broadcast.
 //
-// Semantics (spec p.89 ConnectionOperation):
+// Matrix type is enforced here (spec p.88):
 //
-//	absolute (default) — for oneToN: set target's sources list to the
-//	                     incoming sources. For nToN: replace.
-//	connect           — nToN only: add sources to existing connection.
-//	disconnect        — nToN only: remove sources from existing connection.
+//	oneToN   — target has at most 1 source; same source MAY be on many targets
+//	oneToOne — target has at most 1 source; source has at most 1 target
+//	           (bijective). When a new binding steals a source, the losing
+//	           target is emitted in the returned tally so consumers redraw.
+//	nToN     — free many-to-many. connect / disconnect are additive;
+//	           absolute replaces the target's sources list.
 //
-// The returned Connection list uses disposition=tally so consumers treat it
-// as confirmed current state.
+// Operation semantics (spec p.89):
+//
+//	absolute (default) — set target's sources list to the incoming sources
+//	connect            — nToN only: add sources to existing connection
+//	disconnect         — nToN only: remove sources from existing connection
+//
+// The returned list uses disposition=tally so consumers treat it as
+// confirmed current state.
 func (s *server) applyMatrixConnections(matrixOID string, incoming []canonical.MatrixConnection) ([]canonical.MatrixConnection, error) {
 	e, ok := s.tree.lookupOID(matrixOID)
 	if !ok {
@@ -83,10 +91,52 @@ func (s *server) applyMatrixConnections(matrixOID string, incoming []canonical.M
 	s.tree.mu.Lock()
 	defer s.tree.mu.Unlock()
 
-	out := make([]canonical.MatrixConnection, 0, len(incoming))
+	// Use a map keyed by target so multiple updates to the same target in
+	// one request collapse to the final state (last-write-wins). Preserves
+	// insertion order via a parallel slice.
+	out := []canonical.MatrixConnection{}
+	touched := map[int64]int{} // target -> index into out
+	emit := func(post canonical.MatrixConnection) {
+		if idx, ok := touched[post.Target]; ok {
+			out[idx] = post
+			return
+		}
+		touched[post.Target] = len(out)
+		out = append(out, post)
+	}
+
 	for _, in := range incoming {
+		// oneToN + oneToOne both enforce target-side cardinality of 1.
+		if (m.Type == canonical.MatrixOneToN || m.Type == canonical.MatrixOneToOne) && len(in.Sources) > 1 {
+			in.Sources = in.Sources[:1]
+		}
+
 		applied := applyOneConnection(m, in)
-		out = append(out, applied)
+		emit(applied)
+
+		// oneToOne: source-side exclusivity — any other target that held
+		// one of the newly bound sources must release it. Emit the loser
+		// as a separate tally so the consumer redraws.
+		if m.Type == canonical.MatrixOneToOne {
+			for _, src := range applied.Sources {
+				for i := range m.Connections {
+					if m.Connections[i].Target == applied.Target {
+						continue
+					}
+					stripped := subtractSources(m.Connections[i].Sources, []int64{src})
+					if len(stripped) == len(m.Connections[i].Sources) {
+						continue
+					}
+					m.Connections[i].Sources = stripped
+					emit(canonical.MatrixConnection{
+						Target:      m.Connections[i].Target,
+						Sources:     append([]int64{}, stripped...),
+						Operation:   canonical.ConnOpAbsolute,
+						Disposition: canonical.ConnDispTally,
+					})
+				}
+			}
+		}
 	}
 	return out, nil
 }

--- a/internal/provider/emberplus/invoke.go
+++ b/internal/provider/emberplus/invoke.go
@@ -106,6 +106,23 @@ func (s *server) applyMatrixConnections(matrixOID string, incoming []canonical.M
 	}
 
 	for _, in := range incoming {
+		// Spec p.89: locked target rejects the change. Provider echoes
+		// the unchanged sources with disposition=locked so the consumer
+		// knows the request was seen but not applied.
+		if s.locks != nil && s.locks.isLocked(matrixOID, in.Target) {
+			var current []int64
+			if idx := findConnectionIndex(m.Connections, in.Target); idx >= 0 {
+				current = append([]int64{}, m.Connections[idx].Sources...)
+			}
+			emit(canonical.MatrixConnection{
+				Target:      in.Target,
+				Sources:     current,
+				Operation:   canonical.ConnOpAbsolute,
+				Disposition: canonical.ConnDispLocked,
+			})
+			continue
+		}
+
 		// oneToN + oneToOne both enforce target-side cardinality of 1.
 		if (m.Type == canonical.MatrixOneToN || m.Type == canonical.MatrixOneToOne) && len(in.Sources) > 1 {
 			in.Sources = in.Sources[:1]

--- a/internal/provider/emberplus/invoke.go
+++ b/internal/provider/emberplus/invoke.go
@@ -1,0 +1,216 @@
+package emberplus
+
+import (
+	"fmt"
+	"sync"
+
+	"acp/internal/export/canonical"
+	"acp/internal/protocol/emberplus/ber"
+	"acp/internal/protocol/emberplus/glow"
+)
+
+// FunctionImpl is a provider-side callback bound to a canonical Function.
+// Input args arrive as the concrete Go values the decoder emits
+// (int64 / float64 / string / bool / []byte / nil). Returning (nil, err)
+// produces an InvocationResult with success=false.
+type FunctionImpl func(args []any) ([]any, error)
+
+// functionRegistry maps function OID -> callback. Accessed under s.mu.
+type functionRegistry struct {
+	mu  sync.RWMutex
+	byOID map[string]FunctionImpl
+}
+
+func newFunctionRegistry() *functionRegistry {
+	return &functionRegistry{byOID: map[string]FunctionImpl{}}
+}
+
+func (r *functionRegistry) register(oid string, fn FunctionImpl) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.byOID[oid] = fn
+}
+
+func (r *functionRegistry) lookup(oid string) (FunctionImpl, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	fn, ok := r.byOID[oid]
+	return fn, ok
+}
+
+// invokeFunction runs the callback for the given function OID. Returns the
+// result tuple and a success flag. Missing function or callback error
+// yields (nil, false).
+func (s *server) invokeFunction(oid string, args []any) ([]any, bool) {
+	if s.funcs == nil {
+		return nil, false
+	}
+	fn, ok := s.funcs.lookup(oid)
+	if !ok {
+		s.logger.Debug("invoke: no function registered", "oid", oid)
+		return nil, false
+	}
+	result, err := fn(args)
+	if err != nil {
+		s.logger.Debug("invoke: function returned error", "oid", oid, "err", err.Error())
+		return nil, false
+	}
+	return result, true
+}
+
+// applyMatrixConnections mutates a Matrix element's connections per the
+// inbound Connection list and returns the resulting post-state to broadcast.
+//
+// Semantics (spec p.89 ConnectionOperation):
+//
+//	absolute (default) — for oneToN: set target's sources list to the
+//	                     incoming sources. For nToN: replace.
+//	connect           — nToN only: add sources to existing connection.
+//	disconnect        — nToN only: remove sources from existing connection.
+//
+// The returned Connection list uses disposition=tally so consumers treat it
+// as confirmed current state.
+func (s *server) applyMatrixConnections(matrixOID string, incoming []canonical.MatrixConnection) ([]canonical.MatrixConnection, error) {
+	e, ok := s.tree.lookupOID(matrixOID)
+	if !ok {
+		return nil, fmt.Errorf("matrix %q not found", matrixOID)
+	}
+	m, ok := e.el.(*canonical.Matrix)
+	if !ok {
+		return nil, fmt.Errorf("oid %q is %s, not matrix", matrixOID, e.el.Kind())
+	}
+
+	s.tree.mu.Lock()
+	defer s.tree.mu.Unlock()
+
+	out := make([]canonical.MatrixConnection, 0, len(incoming))
+	for _, in := range incoming {
+		applied := applyOneConnection(m, in)
+		out = append(out, applied)
+	}
+	return out, nil
+}
+
+// applyOneConnection mutates m.Connections for a single inbound change and
+// returns the post-state (disposition=tally) that should be echoed back.
+func applyOneConnection(m *canonical.Matrix, in canonical.MatrixConnection) canonical.MatrixConnection {
+	idx := findConnectionIndex(m.Connections, in.Target)
+	var sources []int64
+	switch in.Operation {
+	case canonical.ConnOpConnect:
+		if idx >= 0 {
+			sources = mergeSources(m.Connections[idx].Sources, in.Sources)
+		} else {
+			sources = append([]int64{}, in.Sources...)
+		}
+	case canonical.ConnOpDisconnect:
+		if idx >= 0 {
+			sources = subtractSources(m.Connections[idx].Sources, in.Sources)
+		}
+	default: // absolute
+		sources = append([]int64{}, in.Sources...)
+	}
+
+	post := canonical.MatrixConnection{
+		Target:      in.Target,
+		Sources:     sources,
+		Operation:   canonical.ConnOpAbsolute,
+		Disposition: canonical.ConnDispTally,
+	}
+	if idx >= 0 {
+		m.Connections[idx] = post
+	} else {
+		m.Connections = append(m.Connections, post)
+	}
+	return post
+}
+
+func findConnectionIndex(conns []canonical.MatrixConnection, target int64) int {
+	for i, c := range conns {
+		if c.Target == target {
+			return i
+		}
+	}
+	return -1
+}
+
+func mergeSources(existing, add []int64) []int64 {
+	seen := make(map[int64]struct{}, len(existing)+len(add))
+	out := make([]int64, 0, len(existing)+len(add))
+	for _, s := range existing {
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	for _, s := range add {
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
+func subtractSources(existing, remove []int64) []int64 {
+	drop := make(map[int64]struct{}, len(remove))
+	for _, s := range remove {
+		drop[s] = struct{}{}
+	}
+	out := make([]int64, 0, len(existing))
+	for _, s := range existing {
+		if _, ok := drop[s]; ok {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// encodeMatrixConnectionsAnnouncement builds a Root frame carrying a
+// QualifiedMatrix with just the path + [CTX 5] connections — the minimal
+// shape consumers accept as a live crosspoint update.
+func (s *server) encodeMatrixConnectionsAnnouncement(e *entry, conns []canonical.MatrixConnection) []byte {
+	qm := ber.AppConstructed(glow.TagQualifiedMatrix,
+		ber.ContextConstructed(0, ber.RelOID(encodeRelativeOID(e.oidParts))),
+		ber.ContextConstructed(5, encodeConnections(conns)),
+	)
+	root := ber.AppConstructed(glow.TagRoot,
+		ber.AppConstructed(glow.TagRootElementCollection,
+			ber.ContextConstructed(0, qm),
+		),
+	)
+	return ber.EncodeTLV(root)
+}
+
+// broadcastMatrixConnections sends a connection-change announcement to
+// every session subscribed to the matrix OID, plus the originating session
+// so strict viewers get a direct echo.
+func (s *server) broadcastMatrixConnections(matrixOID string, conns []canonical.MatrixConnection, origin *session) {
+	e, ok := s.tree.lookupOID(matrixOID)
+	if !ok {
+		return
+	}
+	payload := s.encodeMatrixConnectionsAnnouncement(e, conns)
+
+	s.mu.Lock()
+	set := s.subs[matrixOID]
+	targets := make([]*session, 0, len(set)+1)
+	for sess := range set {
+		targets = append(targets, sess)
+	}
+	s.mu.Unlock()
+
+	sent := map[*session]struct{}{}
+	for _, sess := range targets {
+		sess.send(payload)
+		sent[sess] = struct{}{}
+	}
+	if origin != nil {
+		if _, dup := sent[origin]; !dup {
+			origin.send(payload)
+		}
+	}
+}

--- a/internal/provider/emberplus/matrix.go
+++ b/internal/provider/emberplus/matrix.go
@@ -157,17 +157,20 @@ func encodeConnections(conns []canonical.MatrixConnection) ber.TLV {
 // encodeConnection emits one [APPLICATION 16] Connection. operation and
 // disposition are omitted when they match spec defaults (absolute/tally)
 // to match TinyEmber+ wire economy.
+//
+// sources is ALWAYS emitted — even when empty. EmberViewer (and the
+// spec's CHOICE semantics) treat an absent sources field as "unchanged"
+// rather than "disconnected"; the last-crosspoint-disconnect click
+// leaves the cell lit unless the provider sends an explicit empty
+// RelOID tally. See router oneToOne disconnect regression on #69.
 func encodeConnection(c canonical.MatrixConnection) ber.TLV {
+	parts := make([]uint32, len(c.Sources))
+	for i, v := range c.Sources {
+		parts[i] = uint32(v)
+	}
 	fields := []ber.TLV{
 		ber.ContextConstructed(glow.ConnTarget, ber.Integer(c.Target)),
-	}
-	if len(c.Sources) > 0 {
-		parts := make([]uint32, len(c.Sources))
-		for i, v := range c.Sources {
-			parts[i] = uint32(v)
-		}
-		fields = append(fields,
-			ber.ContextConstructed(glow.ConnSources, ber.RelOID(encodeRelativeOID(parts))))
+		ber.ContextConstructed(glow.ConnSources, ber.RelOID(encodeRelativeOID(parts))),
 	}
 	if op := connOperationConst(c.Operation); op != glow.ConnOpAbsolute {
 		fields = append(fields,

--- a/internal/provider/emberplus/matrix.go
+++ b/internal/provider/emberplus/matrix.go
@@ -1,0 +1,225 @@
+package emberplus
+
+import (
+	"fmt"
+
+	"acp/internal/export/canonical"
+	"acp/internal/protocol/emberplus/ber"
+	"acp/internal/protocol/emberplus/glow"
+)
+
+// encodeQualifiedMatrix emits a [APPLICATION 17] QualifiedMatrix. Contents
+// fields are emitted in ASCENDING CTX-tag order (DER requirement the
+// consumer decoder does not enforce but EmberViewer's strict path does).
+//
+// Spec p.88:
+//
+//	QualifiedMatrix ::= [APPLICATION 17] SEQUENCE {
+//	  path         [0] RELATIVE-OID,
+//	  contents     [1] MatrixContents         OPTIONAL,
+//	  children     [2] ElementCollection      OPTIONAL,
+//	  targets      [3] TargetCollection       OPTIONAL,
+//	  sources      [4] SourceCollection       OPTIONAL,
+//	  connections  [5] ConnectionCollection   OPTIONAL
+//	}
+func (s *server) encodeQualifiedMatrix(e *entry, m *canonical.Matrix) (ber.TLV, error) {
+	contents, err := encodeMatrixContents(m)
+	if err != nil {
+		return ber.TLV{}, err
+	}
+	fields := []ber.TLV{
+		ber.ContextConstructed(0, ber.RelOID(encodeRelativeOID(e.oidParts))),
+		ber.ContextConstructed(1, contents),
+	}
+	// Targets / sources are only emitted when the provider has explicit
+	// (non-linear) signal lists. For linear matrices we omit them and the
+	// consumer infers implicit [0..targetCount-1] / [0..sourceCount-1].
+	if len(m.Targets) > 0 {
+		fields = append(fields, ber.ContextConstructed(3, encodeTargets(m.Targets)))
+	}
+	if len(m.Sources) > 0 {
+		fields = append(fields, ber.ContextConstructed(4, encodeSources(m.Sources)))
+	}
+	if len(m.Connections) > 0 {
+		fields = append(fields, ber.ContextConstructed(5, encodeConnections(m.Connections)))
+	}
+	return ber.AppConstructed(glow.TagQualifiedMatrix, fields...), nil
+}
+
+// encodeMatrixContents builds the [UNIVERSAL SET] inside [CTX 1] contents.
+// Field order is ascending CTX tag; optional fields absent when the
+// canonical value is zero / nil / default (type=oneToN, mode=linear).
+func encodeMatrixContents(m *canonical.Matrix) (ber.TLV, error) {
+	var kids []ber.TLV
+	kids = append(kids,
+		ber.ContextConstructed(glow.MatContentIdentifier, ber.UTF8(m.Identifier))) // [0]
+	if m.Description != nil && *m.Description != "" {
+		kids = append(kids,
+			ber.ContextConstructed(glow.MatContentDescription, ber.UTF8(*m.Description))) // [1]
+	}
+	if tc, ok := matrixTypeConst(m.Type); ok && tc != glow.MatrixTypeOneToN {
+		kids = append(kids,
+			ber.ContextConstructed(glow.MatContentType, ber.Integer(tc))) // [2]
+	}
+	if addressingModeConst(m.Mode) == glow.MatrixAddrNonLinear {
+		kids = append(kids,
+			ber.ContextConstructed(glow.MatContentAddressingMode, ber.Integer(glow.MatrixAddrNonLinear))) // [3]
+	}
+	kids = append(kids,
+		ber.ContextConstructed(glow.MatContentTargetCount, ber.Integer(m.TargetCount))) // [4]
+	kids = append(kids,
+		ber.ContextConstructed(glow.MatContentSourceCount, ber.Integer(m.SourceCount))) // [5]
+	if m.MaximumTotalConnects != nil {
+		kids = append(kids,
+			ber.ContextConstructed(glow.MatContentMaxTotalConnects, ber.Integer(*m.MaximumTotalConnects))) // [6]
+	}
+	if m.MaximumConnectsPerTarget != nil {
+		kids = append(kids,
+			ber.ContextConstructed(glow.MatContentMaxConnectsPerTgt, ber.Integer(*m.MaximumConnectsPerTarget))) // [7]
+	}
+	if m.ParametersLocation != nil && *m.ParametersLocation != "" {
+		parts, err := parseOID(*m.ParametersLocation)
+		if err != nil {
+			return ber.TLV{}, fmt.Errorf("parametersLocation %q: %w", *m.ParametersLocation, err)
+		}
+		kids = append(kids,
+			ber.ContextConstructed(glow.MatContentParametersLocation, ber.RelOID(encodeRelativeOID(parts)))) // [8]
+	}
+	if m.GainParameterNumber != nil {
+		kids = append(kids,
+			ber.ContextConstructed(glow.MatContentGainParameterNumber, ber.Integer(*m.GainParameterNumber))) // [9]
+	}
+	if len(m.Labels) > 0 {
+		items := make([]ber.TLV, 0, len(m.Labels))
+		for _, l := range m.Labels {
+			lb, err := encodeLabel(l)
+			if err != nil {
+				return ber.TLV{}, err
+			}
+			items = append(items, ber.ContextConstructed(0, lb))
+		}
+		kids = append(kids,
+			ber.ContextConstructed(glow.MatContentLabels, ber.Sequence(items...))) // [10]
+	}
+	return ber.Set(kids...), nil
+}
+
+// encodeLabel emits one [APPLICATION 18] Label. Both fields are CTX-wrapped.
+func encodeLabel(l canonical.MatrixLabel) (ber.TLV, error) {
+	parts, err := parseOID(l.BasePath)
+	if err != nil {
+		return ber.TLV{}, fmt.Errorf("label basePath %q: %w", l.BasePath, err)
+	}
+	fields := []ber.TLV{
+		ber.ContextConstructed(glow.LabelBasePath, ber.RelOID(encodeRelativeOID(parts))),
+	}
+	if l.Description != nil && *l.Description != "" {
+		fields = append(fields,
+			ber.ContextConstructed(glow.LabelDescription, ber.UTF8(*l.Description)))
+	}
+	return ber.AppConstructed(glow.TagLabel, fields...), nil
+}
+
+// encodeTargets / encodeSources emit a TargetCollection / SourceCollection
+// ([UNIVERSAL SEQUENCE] holding [CTX 0] { [APP 14|15] Signal }). Each
+// signal carries just its number.
+func encodeTargets(targets []canonical.MatrixTarget) ber.TLV {
+	items := make([]ber.TLV, 0, len(targets))
+	for _, t := range targets {
+		sig := ber.AppConstructed(glow.TagTarget,
+			ber.ContextConstructed(glow.SignalNumber, ber.Integer(t.Number)))
+		items = append(items, ber.ContextConstructed(0, sig))
+	}
+	return ber.Sequence(items...)
+}
+
+func encodeSources(sources []canonical.MatrixSource) ber.TLV {
+	items := make([]ber.TLV, 0, len(sources))
+	for _, s := range sources {
+		sig := ber.AppConstructed(glow.TagSource,
+			ber.ContextConstructed(glow.SignalNumber, ber.Integer(s.Number)))
+		items = append(items, ber.ContextConstructed(0, sig))
+	}
+	return ber.Sequence(items...)
+}
+
+// encodeConnections emits a ConnectionCollection inside [CTX 5] of the
+// QualifiedMatrix wrapper. Each Connection is CTX[0]-wrapped per the spec
+// grammar `SEQUENCE OF [0] Connection`.
+func encodeConnections(conns []canonical.MatrixConnection) ber.TLV {
+	items := make([]ber.TLV, 0, len(conns))
+	for _, c := range conns {
+		items = append(items, ber.ContextConstructed(0, encodeConnection(c)))
+	}
+	return ber.Sequence(items...)
+}
+
+// encodeConnection emits one [APPLICATION 16] Connection. operation and
+// disposition are omitted when they match spec defaults (absolute/tally)
+// to match TinyEmber+ wire economy.
+func encodeConnection(c canonical.MatrixConnection) ber.TLV {
+	fields := []ber.TLV{
+		ber.ContextConstructed(glow.ConnTarget, ber.Integer(c.Target)),
+	}
+	if len(c.Sources) > 0 {
+		parts := make([]uint32, len(c.Sources))
+		for i, v := range c.Sources {
+			parts[i] = uint32(v)
+		}
+		fields = append(fields,
+			ber.ContextConstructed(glow.ConnSources, ber.RelOID(encodeRelativeOID(parts))))
+	}
+	if op := connOperationConst(c.Operation); op != glow.ConnOpAbsolute {
+		fields = append(fields,
+			ber.ContextConstructed(glow.ConnOperation, ber.Integer(op)))
+	}
+	if disp := connDispositionConst(c.Disposition); disp != glow.ConnDispTally {
+		fields = append(fields,
+			ber.ContextConstructed(glow.ConnDisposition, ber.Integer(disp)))
+	}
+	return ber.AppConstructed(glow.TagConnection, fields...)
+}
+
+// matrixTypeConst maps canonical type strings to the MatrixType enum.
+// Returns (_, false) for an empty / unknown string so callers can skip
+// emitting the field (default oneToN applies).
+func matrixTypeConst(t string) (int64, bool) {
+	switch t {
+	case canonical.MatrixOneToN, "":
+		return glow.MatrixTypeOneToN, true
+	case canonical.MatrixOneToOne:
+		return glow.MatrixTypeOneToOne, true
+	case canonical.MatrixNToN:
+		return glow.MatrixTypeNToN, true
+	}
+	return 0, false
+}
+
+func addressingModeConst(m string) int64 {
+	if m == canonical.ModeNonLinear {
+		return glow.MatrixAddrNonLinear
+	}
+	return glow.MatrixAddrLinear
+}
+
+func connOperationConst(op string) int64 {
+	switch op {
+	case canonical.ConnOpConnect:
+		return glow.ConnOpConnect
+	case canonical.ConnOpDisconnect:
+		return glow.ConnOpDisconnect
+	}
+	return glow.ConnOpAbsolute
+}
+
+func connDispositionConst(d string) int64 {
+	switch d {
+	case canonical.ConnDispModified:
+		return glow.ConnDispModified
+	case canonical.ConnDispPending:
+		return glow.ConnDispPending
+	case canonical.ConnDispLocked:
+		return glow.ConnDispLocked
+	}
+	return glow.ConnDispTally
+}

--- a/internal/provider/emberplus/matrix_test.go
+++ b/internal/provider/emberplus/matrix_test.go
@@ -1,0 +1,180 @@
+package emberplus
+
+import (
+	"testing"
+
+	"acp/internal/export/canonical"
+	"acp/internal/protocol/emberplus/glow"
+)
+
+// buildMatrixTree constructs a minimal tree: router(Node 1) → mat(Matrix 1.1)
+// with labels basePath + per-cell parametersLocation wired but the child
+// Nodes not populated (the Matrix element alone is what we exercise).
+func buildMatrixTree(t *testing.T, m *canonical.Matrix) *server {
+	t.Helper()
+	m.Header = canonical.Header{
+		Number: 1, Identifier: "mat", Path: "router.mat", OID: "1.1",
+		IsOnline: true, Access: canonical.AccessReadWrite,
+		Children: canonical.EmptyChildren(),
+	}
+	m.TargetCount = 4
+	m.SourceCount = 4
+	if m.Type == "" {
+		m.Type = canonical.MatrixOneToN
+	}
+	root := &canonical.Node{
+		Header: canonical.Header{
+			Number: 1, Identifier: "router", Path: "router", OID: "1",
+			IsOnline: true, Access: canonical.AccessRead,
+			Children: []canonical.Element{m},
+		},
+	}
+	srv := newServer(nil, &canonical.Export{Root: root})
+	if srv.tree == nil {
+		t.Fatal("tree failed to build")
+	}
+	return srv
+}
+
+// TestRoundTrip_Matrix_OneToN exercises a 4×4 oneToN matrix with one
+// label level + connections. The consumer decoder must recover every
+// field on the wire without error.
+func TestRoundTrip_Matrix_OneToN(t *testing.T) {
+	desc := "Primary"
+	m := &canonical.Matrix{
+		Type: canonical.MatrixOneToN,
+		Mode: canonical.ModeLinear,
+		Labels: []canonical.MatrixLabel{
+			{BasePath: "1.2", Description: &desc},
+		},
+		Connections: []canonical.MatrixConnection{
+			{Target: 0, Sources: []int64{0}, Operation: canonical.ConnOpAbsolute, Disposition: canonical.ConnDispTally},
+			{Target: 1, Sources: []int64{3}, Operation: canonical.ConnOpAbsolute, Disposition: canonical.ConnDispTally},
+		},
+	}
+	srv := buildMatrixTree(t, m)
+
+	reply, err := srv.encodeGetDirReply(srv.tree.rootEntry(), false)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	els, err := glow.DecodeRoot(reply)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(els) != 1 || els[0].Matrix == nil {
+		t.Fatalf("want 1 Matrix element, got %+v", els)
+	}
+	got := els[0].Matrix
+	if got.Identifier != "mat" {
+		t.Errorf("identifier=%q want mat", got.Identifier)
+	}
+	if got.MatrixType != glow.MatrixTypeOneToN {
+		t.Errorf("type=%d want oneToN(0)", got.MatrixType)
+	}
+	if got.TargetCount != 4 || got.SourceCount != 4 {
+		t.Errorf("counts=%d/%d want 4/4", got.TargetCount, got.SourceCount)
+	}
+	if len(got.Labels) != 1 || got.Labels[0].Description != "Primary" {
+		t.Errorf("labels=%+v", got.Labels)
+	}
+	if len(got.Connections) != 2 {
+		t.Fatalf("connections=%d want 2", len(got.Connections))
+	}
+	if got.Connections[1].Target != 1 || len(got.Connections[1].Sources) != 1 || got.Connections[1].Sources[0] != 3 {
+		t.Errorf("conn[1]=%+v want target=1 sources=[3]", got.Connections[1])
+	}
+}
+
+// TestRoundTrip_Matrix_NToN exercises nToN with parametersLocation + gain
+// number + max caps — the richest common shape.
+func TestRoundTrip_Matrix_NToN(t *testing.T) {
+	pl := "1.3.2"
+	gain := int64(1)
+	maxT := int64(8)
+	maxPT := int64(2)
+	m := &canonical.Matrix{
+		Type:                     canonical.MatrixNToN,
+		Mode:                     canonical.ModeLinear,
+		ParametersLocation:       &pl,
+		GainParameterNumber:      &gain,
+		MaximumTotalConnects:     &maxT,
+		MaximumConnectsPerTarget: &maxPT,
+	}
+	srv := buildMatrixTree(t, m)
+	reply, err := srv.encodeGetDirReply(srv.tree.rootEntry(), false)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	els, err := glow.DecodeRoot(reply)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	got := els[0].Matrix
+	if got.MatrixType != glow.MatrixTypeNToN {
+		t.Errorf("type=%d want nToN(2)", got.MatrixType)
+	}
+	if got.MaxTotalConnects != 8 || got.MaxConnectsPerTarget != 2 {
+		t.Errorf("caps=%d/%d want 8/2", got.MaxTotalConnects, got.MaxConnectsPerTarget)
+	}
+	if got.GainParameterNumber != 1 {
+		t.Errorf("gainParameterNumber=%d want 1", got.GainParameterNumber)
+	}
+	if pl, ok := got.ParametersLocation.([]int32); !ok || len(pl) != 3 {
+		t.Errorf("parametersLocation=%v want []int32{1,3,2}", got.ParametersLocation)
+	}
+}
+
+// TestApplyConnection_Absolute replaces a target's sources.
+func TestApplyConnection_Absolute(t *testing.T) {
+	m := &canonical.Matrix{
+		Type: canonical.MatrixNToN,
+		Connections: []canonical.MatrixConnection{
+			{Target: 0, Sources: []int64{0, 1}},
+		},
+	}
+	srv := buildMatrixTree(t, m)
+	post, err := srv.applyMatrixConnections("1.1", []canonical.MatrixConnection{
+		{Target: 0, Sources: []int64{2, 3}, Operation: canonical.ConnOpAbsolute},
+	})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if len(post) != 1 || len(post[0].Sources) != 2 || post[0].Sources[0] != 2 {
+		t.Errorf("post=%+v want target 0 sources [2 3]", post)
+	}
+	if post[0].Disposition != canonical.ConnDispTally {
+		t.Errorf("disposition=%q want tally", post[0].Disposition)
+	}
+}
+
+// TestApplyConnection_ConnectAndDisconnect exercises the nToN additive ops.
+func TestApplyConnection_ConnectAndDisconnect(t *testing.T) {
+	m := &canonical.Matrix{
+		Type: canonical.MatrixNToN,
+		Connections: []canonical.MatrixConnection{
+			{Target: 0, Sources: []int64{0}},
+		},
+	}
+	srv := buildMatrixTree(t, m)
+
+	post, err := srv.applyMatrixConnections("1.1", []canonical.MatrixConnection{
+		{Target: 0, Sources: []int64{1}, Operation: canonical.ConnOpConnect},
+	})
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if len(post[0].Sources) != 2 {
+		t.Fatalf("after connect want 2 sources, got %v", post[0].Sources)
+	}
+
+	post, err = srv.applyMatrixConnections("1.1", []canonical.MatrixConnection{
+		{Target: 0, Sources: []int64{0}, Operation: canonical.ConnOpDisconnect},
+	})
+	if err != nil {
+		t.Fatalf("disconnect: %v", err)
+	}
+	if len(post[0].Sources) != 1 || post[0].Sources[0] != 1 {
+		t.Errorf("after disconnect want [1], got %v", post[0].Sources)
+	}
+}

--- a/internal/provider/emberplus/matrix_test.go
+++ b/internal/provider/emberplus/matrix_test.go
@@ -148,6 +148,57 @@ func TestApplyConnection_Absolute(t *testing.T) {
 	}
 }
 
+// TestApplyConnection_OneToOne_Exclusivity asserts that reassigning a
+// source to a new target releases it from the previous target — the
+// bijection that defines oneToOne. Each apply returns a tally for the
+// loser + the winner.
+func TestApplyConnection_OneToOne_Exclusivity(t *testing.T) {
+	m := &canonical.Matrix{
+		Type: canonical.MatrixOneToOne,
+		Connections: []canonical.MatrixConnection{
+			{Target: 0, Sources: []int64{3}}, // t-0 holds s-3
+			{Target: 1, Sources: []int64{2}}, // t-1 holds s-2
+		},
+	}
+	srv := buildMatrixTree(t, m)
+	// Client sends "t-1 → s-3" — must steal s-3 from t-0.
+	post, err := srv.applyMatrixConnections("1.1", []canonical.MatrixConnection{
+		{Target: 1, Sources: []int64{3}, Operation: canonical.ConnOpAbsolute},
+	})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	byT := map[int64][]int64{}
+	for _, c := range post {
+		byT[c.Target] = c.Sources
+	}
+	if got := byT[1]; len(got) != 1 || got[0] != 3 {
+		t.Errorf("t-1 post=%v want [3]", got)
+	}
+	if _, seen := byT[0]; !seen {
+		t.Fatal("t-0 loser not emitted — consumer won't redraw")
+	}
+	if got := byT[0]; len(got) != 0 {
+		t.Errorf("t-0 post=%v want [] (source stolen)", got)
+	}
+}
+
+// TestApplyConnection_OneToN_SingleSource asserts target cardinality is
+// clamped to 1 even when the client sends extra sources.
+func TestApplyConnection_OneToN_SingleSource(t *testing.T) {
+	m := &canonical.Matrix{Type: canonical.MatrixOneToN}
+	srv := buildMatrixTree(t, m)
+	post, err := srv.applyMatrixConnections("1.1", []canonical.MatrixConnection{
+		{Target: 0, Sources: []int64{0, 1, 2}, Operation: canonical.ConnOpAbsolute},
+	})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if len(post[0].Sources) != 1 {
+		t.Errorf("oneToN target kept %d sources, want 1", len(post[0].Sources))
+	}
+}
+
 // TestApplyConnection_ConnectAndDisconnect exercises the nToN additive ops.
 func TestApplyConnection_ConnectAndDisconnect(t *testing.T) {
 	m := &canonical.Matrix{

--- a/internal/provider/emberplus/server.go
+++ b/internal/provider/emberplus/server.go
@@ -16,6 +16,8 @@ import (
 type server struct {
 	logger *slog.Logger
 	tree   *tree
+	funcs  *functionRegistry
+	salvos *salvoStore
 
 	mu       sync.Mutex
 	listener net.Listener
@@ -34,6 +36,7 @@ func newServer(logger *slog.Logger, exp *canonical.Export) *server {
 	t, err := newTree(exp)
 	s := &server{
 		logger:   logger.With(slog.String("plugin", "emberplus-provider")),
+		funcs:    newFunctionRegistry(),
 		sessions: map[*session]struct{}{},
 		subs:     map[string]map[*session]struct{}{},
 		stopped:  make(chan struct{}),
@@ -43,6 +46,7 @@ func newServer(logger *slog.Logger, exp *canonical.Export) *server {
 		s.logger.Error("tree build failed", slog.String("err", err.Error()))
 	} else {
 		s.tree = t
+		s.setupBuiltinFunctions()
 	}
 	return s
 }

--- a/internal/provider/emberplus/server.go
+++ b/internal/provider/emberplus/server.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net"
 	"sync"
+	"time"
 
 	"acp/internal/export/canonical"
 )
@@ -70,6 +71,10 @@ func (s *server) Serve(ctx context.Context, addr string) error {
 		slog.String("addr", ln.Addr().String()),
 		slog.Int("tree_size", len(s.tree.byOID)),
 	)
+
+	// Unsolicited stream fan-out — runs if the tree has any Parameters
+	// with a streamIdentifier, exits on ctx cancel or Stop().
+	go s.runStreamer(ctx, 100*time.Millisecond)
 
 	// Close listener on ctx cancel to unblock Accept.
 	go func() {

--- a/internal/provider/emberplus/server.go
+++ b/internal/provider/emberplus/server.go
@@ -19,6 +19,7 @@ type server struct {
 	tree   *tree
 	funcs  *functionRegistry
 	salvos *salvoStore
+	locks  *lockStore
 
 	mu       sync.Mutex
 	listener net.Listener

--- a/internal/provider/emberplus/session.go
+++ b/internal/provider/emberplus/session.go
@@ -170,6 +170,7 @@ func (s *session) handleEmber(payload []byte) error {
 		oid := oidFromPath(path)
 		switch cmd.Number {
 		case glow.CmdGetDirectory:
+			s.logger.Debug("get directory", slog.String("oid", oid))
 			return s.replyGetDirectory(oid)
 		case glow.CmdSubscribe:
 			s.srv.subscribe(s, oid)
@@ -231,6 +232,7 @@ func (s *session) handleInvoke(oid string, inv *glow.Invocation) {
 
 	result, ok := s.srv.invokeFunction(oid, args)
 	payload := s.srv.encodeInvocationResult(invID, ok, result)
+	s.logger.Debug("invoke reply", slog.Int("invocation_id", int(invID)), slog.Bool("success", ok), slog.Int("bytes", len(payload)))
 	s.send(payload)
 }
 
@@ -263,35 +265,50 @@ func (s *session) replyGetDirectory(oid string) error {
 // Path is built from QualifiedNode.Path / QualifiedParameter.Path if
 // present, else from chained Node.Number values for the non-qualified
 // form.
+//
+// All four container kinds (Node, Parameter, Matrix, Function) can hold
+// a child Command per spec p.86 — Function is particularly important
+// because Invoke commands arrive as QualifiedFunction(path){children:
+// [Command(Invoke)]}; if we don't descend into Function.Children the
+// Invoke gets silently dropped and the consumer times out.
 func findCommandInElements(els []glow.Element) (*glow.Command, []uint32) {
 	for _, e := range els {
 		if e.Command != nil {
 			return e.Command, nil
 		}
 		if e.Node != nil {
-			basePath := []uint32(nil)
-			if len(e.Node.Path) > 0 {
-				basePath = toUint32(e.Node.Path)
-			} else if e.Node.Number != 0 {
-				basePath = []uint32{uint32(e.Node.Number)}
-			}
+			base := nodeBasePath(e.Node)
 			if c, sub := findCommandInElements(e.Node.Children); c != nil {
-				return c, append(append([]uint32{}, basePath...), sub...)
+				return c, append(append([]uint32{}, base...), sub...)
 			}
 		}
 		if e.Parameter != nil {
-			basePath := []uint32(nil)
-			if len(e.Parameter.Path) > 0 {
-				basePath = toUint32(e.Parameter.Path)
-			} else if e.Parameter.Number != 0 {
-				basePath = []uint32{uint32(e.Parameter.Number)}
-			}
+			base := paramBasePath(e.Parameter)
 			if c, sub := findCommandInElements(e.Parameter.Children); c != nil {
-				return c, append(append([]uint32{}, basePath...), sub...)
+				return c, append(append([]uint32{}, base...), sub...)
+			}
+		}
+		if e.Function != nil {
+			base := funcBasePath(e.Function)
+			if c, sub := findCommandInElements(e.Function.Children); c != nil {
+				return c, append(append([]uint32{}, base...), sub...)
+			}
+		}
+		if e.Matrix != nil {
+			base := matrixBasePath(e.Matrix)
+			if c, sub := findCommandInElements(e.Matrix.Children); c != nil {
+				return c, append(append([]uint32{}, base...), sub...)
 			}
 		}
 	}
 	return nil, nil
+}
+
+func funcBasePath(f *glow.Function) []uint32 {
+	if len(f.Path) > 0 {
+		return toUint32(f.Path)
+	}
+	return []uint32{uint32(f.Number)}
 }
 
 // findMatrixConnectionsInElements walks the decoded tree looking for a
@@ -399,24 +416,26 @@ func findSetValueInElements(els []glow.Element) ([]uint32, any, bool) {
 	return nil, nil, false
 }
 
+// nodeBasePath / paramBasePath return the path segment an element
+// contributes when the walker concatenates nested wrappers.
+//
+// Number=0 is a LEGAL sub-identifier (e.g. label/target "t-0" sits at
+// .0 under its parent). We deliberately include it — stripping 0 broke
+// SetValue on any parameter whose number is 0. The cost of including
+// a genuinely-absent Number=0 is a path like "0" that fails lookup
+// cleanly; the cost of dropping a real .0 is a silently wrong SetValue.
 func nodeBasePath(n *glow.Node) []uint32 {
 	if len(n.Path) > 0 {
 		return toUint32(n.Path)
 	}
-	if n.Number != 0 {
-		return []uint32{uint32(n.Number)}
-	}
-	return nil
+	return []uint32{uint32(n.Number)}
 }
 
 func paramBasePath(p *glow.Parameter) []uint32 {
 	if len(p.Path) > 0 {
 		return toUint32(p.Path)
 	}
-	if p.Number != 0 {
-		return []uint32{uint32(p.Number)}
-	}
-	return nil
+	return []uint32{uint32(p.Number)}
 }
 
 func oidFromPath(parts []uint32) string {

--- a/internal/provider/emberplus/session.go
+++ b/internal/provider/emberplus/session.go
@@ -257,6 +257,27 @@ func (s *session) replyGetDirectory(oid string) error {
 		return fmt.Errorf("encode reply: %w", err)
 	}
 	s.send(payload)
+
+	// Spec p.88: "As soon as a consumer issues a GetDirectory command
+	// on a matrix object, it implicitly subscribes to matrix connection
+	// changes." Without this, salvo recalls / external crosspoint
+	// changes broadcast to nobody — cells don't update on the client.
+	//
+	// Strict reading: only the direct GetDir(path=matrix) triggers. But
+	// most consumers (EmberViewer included) read matrix contents from a
+	// parent node's reply instead of re-walking, so we also subscribe
+	// the session to any matrix child in the reply — keeps crosspoint
+	// tallies reaching the client regardless of walking style.
+	if !bareRoot {
+		if _, ok := e.el.(*canonical.Matrix); ok {
+			s.srv.subscribe(s, oid)
+		}
+		for _, child := range e.el.Common().Children {
+			if _, ok := child.(*canonical.Matrix); ok {
+				s.srv.subscribe(s, child.Common().OID)
+			}
+		}
+	}
 	return nil
 }
 

--- a/internal/provider/emberplus/session.go
+++ b/internal/provider/emberplus/session.go
@@ -147,14 +147,19 @@ func (s *session) handleFrame(f *s101.Frame) error {
 
 // handleEmber parses a Glow-encoded request and dispatches it.
 //
-// Two inbound shapes are handled:
+// Three inbound shapes are handled:
 //
-//  1. Command request — GetDirectory (32) / Subscribe (30) / Unsubscribe (31).
-//     Invoke (33) is a no-op in MVP.
+//  1. Command request — GetDirectory (32) / Subscribe (30) / Unsubscribe (31)
+//     / Invoke (33). Invoke extracts the Invocation, runs the registered
+//     function callback, and replies with InvocationResult.
 //
 //  2. SetValue request — a QualifiedParameter (or nested Node → Parameter)
 //     carrying `contents.value`. Applied via server.SetValue; the resulting
 //     announcement is broadcast to subscribers including the sender.
+//
+//  3. Matrix connection request — a QualifiedMatrix (or nested Node → Matrix)
+//     carrying [CTX 5] connections with operation=absolute|connect|disconnect.
+//     Applied to the tree and echoed back + broadcast to subscribers.
 func (s *session) handleEmber(payload []byte) error {
 	els, err := glow.DecodeRoot(payload)
 	if err != nil {
@@ -173,8 +178,21 @@ func (s *session) handleEmber(payload []byte) error {
 			s.srv.unsubscribe(s, oid)
 			return nil
 		case glow.CmdInvoke:
+			s.handleInvoke(oid, cmd.Invocation)
 			return nil
 		}
+		return nil
+	}
+
+	if path, conns, ok := findMatrixConnectionsInElements(els); ok {
+		oid := oidFromPath(path)
+		s.logger.Debug("matrix connection", slog.String("oid", oid), slog.Int("count", len(conns)))
+		post, err := s.srv.applyMatrixConnections(oid, conns)
+		if err != nil {
+			s.logger.Debug("matrix connection failed", slog.String("oid", oid), slog.String("err", err.Error()))
+			return nil
+		}
+		s.srv.broadcastMatrixConnections(oid, post, s)
 		return nil
 	}
 
@@ -197,6 +215,23 @@ func (s *session) handleEmber(payload []byte) error {
 		return nil
 	}
 	return nil
+}
+
+// handleInvoke runs the registered function callback for oid and replies
+// with an InvocationResult. A missing function or callback error yields
+// success=false with an empty result tuple (spec p.92).
+func (s *session) handleInvoke(oid string, inv *glow.Invocation) {
+	var invID int32
+	var args []any
+	if inv != nil {
+		invID = inv.InvocationID
+		args = inv.Arguments
+	}
+	s.logger.Debug("invoke", slog.String("oid", oid), slog.Int("invocation_id", int(invID)), slog.Int("argc", len(args)))
+
+	result, ok := s.srv.invokeFunction(oid, args)
+	payload := s.srv.encodeInvocationResult(invID, ok, result)
+	s.send(payload)
 }
 
 func (s *session) replyGetDirectory(oid string) error {
@@ -257,6 +292,84 @@ func findCommandInElements(els []glow.Element) (*glow.Command, []uint32) {
 		}
 	}
 	return nil, nil
+}
+
+// findMatrixConnectionsInElements walks the decoded tree looking for a
+// Matrix (or QualifiedMatrix) that carries at least one Connection entry.
+// Returns the absolute matrix path plus the connection list translated to
+// canonical form. Like the Parameter walker, it concatenates wrapping
+// Node / QualifiedNode path segments if the consumer nested the Matrix.
+func findMatrixConnectionsInElements(els []glow.Element) ([]uint32, []canonical.MatrixConnection, bool) {
+	for _, e := range els {
+		if e.Matrix != nil && len(e.Matrix.Connections) > 0 {
+			return matrixBasePath(e.Matrix), convertConnections(e.Matrix.Connections), true
+		}
+		if e.Node != nil {
+			base := nodeBasePath(e.Node)
+			if sub, conns, ok := findMatrixConnectionsInElements(e.Node.Children); ok {
+				return append(append([]uint32{}, base...), sub...), conns, true
+			}
+		}
+		if e.Matrix != nil {
+			base := matrixBasePath(e.Matrix)
+			if sub, conns, ok := findMatrixConnectionsInElements(e.Matrix.Children); ok {
+				return append(append([]uint32{}, base...), sub...), conns, true
+			}
+		}
+	}
+	return nil, nil, false
+}
+
+func matrixBasePath(m *glow.Matrix) []uint32 {
+	if len(m.Path) > 0 {
+		return toUint32(m.Path)
+	}
+	if m.Number != 0 {
+		return []uint32{uint32(m.Number)}
+	}
+	return nil
+}
+
+// convertConnections translates glow.Connection entries (wire form) to
+// canonical.MatrixConnection entries the provider state machine consumes.
+// operation / disposition enums become their string equivalents.
+func convertConnections(conns []glow.Connection) []canonical.MatrixConnection {
+	out := make([]canonical.MatrixConnection, 0, len(conns))
+	for _, c := range conns {
+		sources := make([]int64, 0, len(c.Sources))
+		for _, s := range c.Sources {
+			sources = append(sources, int64(s))
+		}
+		out = append(out, canonical.MatrixConnection{
+			Target:      int64(c.Target),
+			Sources:     sources,
+			Operation:   connOperationName(c.Operation),
+			Disposition: connDispositionName(c.Disposition),
+		})
+	}
+	return out
+}
+
+func connOperationName(op int64) string {
+	switch op {
+	case glow.ConnOpConnect:
+		return canonical.ConnOpConnect
+	case glow.ConnOpDisconnect:
+		return canonical.ConnOpDisconnect
+	}
+	return canonical.ConnOpAbsolute
+}
+
+func connDispositionName(d int64) string {
+	switch d {
+	case glow.ConnDispModified:
+		return canonical.ConnDispModified
+	case glow.ConnDispPending:
+		return canonical.ConnDispPending
+	case glow.ConnDispLocked:
+		return canonical.ConnDispLocked
+	}
+	return canonical.ConnDispTally
 }
 
 // findSetValueInElements walks the decoded tree looking for a Parameter

--- a/internal/provider/emberplus/streamer.go
+++ b/internal/provider/emberplus/streamer.go
@@ -61,16 +61,18 @@ func (s *server) collectStreams() []streamEntry {
 	return out
 }
 
-// streamTick produces one Root{StreamCollection{...}} payload with a
-// synthetic value per streamEntry. Values track a sine wave offset by
-// stream id, clamped to [min, max] — good enough to prove metering
-// consumers see the numbers move.
+// streamTick computes sine-wave values for a caller-filtered subset of
+// entries and encodes them as one Root{StreamCollection}. Returns nil
+// if the subset is empty so the caller can skip send() entirely.
 //
 // Wire shape (spec p.93):
 //
 //	Root [APP 0] → StreamCollection [APP 6] → [CTX 0] → StreamEntry [APP 5]
 //	  StreamEntry { [0] streamIdentifier Integer32, [1] streamValue Value }
 func streamTick(entries []streamEntry, t time.Time) []byte {
+	if len(entries) == 0 {
+		return nil
+	}
 	items := make([]ber.TLV, 0, len(entries))
 	phase := float64(t.UnixMilli()) / 500.0 // 2-second period
 	for _, e := range entries {
@@ -99,10 +101,15 @@ func streamTick(entries []streamEntry, t time.Time) []byte {
 	return ber.EncodeTLV(root)
 }
 
-// runStreamer fires a StreamCollection at every active session at
-// interval. Exits when ctx is cancelled or the server stops. One
-// sender covers all sessions — streams are unsolicited, not
-// subscription-based.
+// runStreamer fires StreamCollection frames every interval — but only
+// to sessions that have explicitly Subscribed to at least one stream
+// parameter. Each subscriber receives a StreamCollection containing
+// only the entries for the parameters they watch.
+//
+// This avoids broadcasting meter noise to consumers that aren't
+// interested — which matters at scale: a rack with 200 meters at 10 Hz
+// would otherwise push ~40 KB/s at every passive observer, starving
+// the link for other traffic like crosspoint tallies.
 func (s *server) runStreamer(ctx context.Context, interval time.Duration) {
 	entries := s.collectStreams()
 	if len(entries) == 0 {
@@ -122,16 +129,42 @@ func (s *server) runStreamer(ctx context.Context, interval time.Duration) {
 		case <-s.stopped:
 			return
 		case t := <-ticker.C:
-			payload := streamTick(entries, t)
-			s.mu.Lock()
-			sessions := make([]*session, 0, len(s.sessions))
-			for sess := range s.sessions {
-				sessions = append(sessions, sess)
+			s.fanoutStreams(entries, t)
+		}
+	}
+}
+
+// fanoutStreams builds a per-session StreamCollection restricted to the
+// entries that session has Subscribed to. Sessions with no relevant
+// subscriptions are skipped entirely.
+func (s *server) fanoutStreams(entries []streamEntry, t time.Time) {
+	// Snapshot sessions + their subs under the server lock, then do the
+	// (potentially slow) per-session encode + send outside it.
+	type sessFilter struct {
+		sess *session
+		want []streamEntry
+	}
+	// sess.subs is protected by server.mu — single lock covers the whole
+	// snapshot.
+	s.mu.Lock()
+	var work []sessFilter
+	for sess := range s.sessions {
+		var want []streamEntry
+		for _, e := range entries {
+			if _, ok := sess.subs[e.oid]; ok {
+				want = append(want, e)
 			}
-			s.mu.Unlock()
-			for _, sess := range sessions {
-				sess.send(payload)
-			}
+		}
+		if len(want) > 0 {
+			work = append(work, sessFilter{sess: sess, want: want})
+		}
+	}
+	s.mu.Unlock()
+
+	for _, w := range work {
+		payload := streamTick(w.want, t)
+		if payload != nil {
+			w.sess.send(payload)
 		}
 	}
 }

--- a/internal/provider/emberplus/streamer.go
+++ b/internal/provider/emberplus/streamer.go
@@ -1,0 +1,137 @@
+package emberplus
+
+import (
+	"context"
+	"log/slog"
+	"math"
+	"time"
+
+	"acp/internal/export/canonical"
+	"acp/internal/protocol/emberplus/ber"
+	"acp/internal/protocol/emberplus/glow"
+)
+
+// streamEntry holds the per-parameter state needed to emit StreamEntry
+// values each tick. Type is captured at tree-load time so the streamer
+// doesn't have to re-look-up the Parameter on every tick.
+type streamEntry struct {
+	id      int64  // stream identifier (wire-visible to consumers)
+	oid     string // source parameter OID, for debug
+	kind    string // canonical parameter type (real / integer / boolean)
+	min     float64
+	max     float64
+}
+
+// collectStreams walks the loaded tree for Parameters with a non-nil
+// StreamIdentifier. Each becomes a streamEntry the broadcaster emits
+// periodically.
+func (s *server) collectStreams() []streamEntry {
+	var out []streamEntry
+	if s.tree == nil {
+		return nil
+	}
+	var walk func(el canonical.Element)
+	walk = func(el canonical.Element) {
+		if el == nil {
+			return
+		}
+		if p, ok := el.(*canonical.Parameter); ok && p.StreamIdentifier != nil {
+			e := streamEntry{
+				id:   *p.StreamIdentifier,
+				oid:  p.OID,
+				kind: p.Type,
+			}
+			if v, ok := asFloat64(p.Minimum); ok {
+				e.min = v
+			} else {
+				e.min = -60
+			}
+			if v, ok := asFloat64(p.Maximum); ok {
+				e.max = v
+			} else {
+				e.max = 0
+			}
+			out = append(out, e)
+		}
+		for _, c := range el.Common().Children {
+			walk(c)
+		}
+	}
+	walk(s.tree.root)
+	return out
+}
+
+// streamTick produces one Root{StreamCollection{...}} payload with a
+// synthetic value per streamEntry. Values track a sine wave offset by
+// stream id, clamped to [min, max] — good enough to prove metering
+// consumers see the numbers move.
+//
+// Wire shape (spec p.93):
+//
+//	Root [APP 0] → StreamCollection [APP 6] → [CTX 0] → StreamEntry [APP 5]
+//	  StreamEntry { [0] streamIdentifier Integer32, [1] streamValue Value }
+func streamTick(entries []streamEntry, t time.Time) []byte {
+	items := make([]ber.TLV, 0, len(entries))
+	phase := float64(t.UnixMilli()) / 500.0 // 2-second period
+	for _, e := range entries {
+		amp := (e.max - e.min) / 2
+		mid := (e.max + e.min) / 2
+		raw := mid + amp*math.Sin(phase+float64(e.id))
+		var val ber.TLV
+		switch e.kind {
+		case canonical.ParamReal:
+			val = ber.Real(raw)
+		case canonical.ParamInteger:
+			val = ber.Integer(int64(math.Round(raw)))
+		case canonical.ParamBoolean:
+			val = ber.Boolean(raw > mid)
+		default:
+			val = ber.Real(raw)
+		}
+		entry := ber.AppConstructed(glow.TagStreamEntry,
+			ber.ContextConstructed(glow.StreamEntryIdentifier, ber.Integer(e.id)),
+			ber.ContextConstructed(glow.StreamEntryValue, val),
+		)
+		items = append(items, ber.ContextConstructed(0, entry))
+	}
+	coll := ber.AppConstructed(glow.TagStreamCollection, items...)
+	root := ber.AppConstructed(glow.TagRoot, coll)
+	return ber.EncodeTLV(root)
+}
+
+// runStreamer fires a StreamCollection at every active session at
+// interval. Exits when ctx is cancelled or the server stops. One
+// sender covers all sessions — streams are unsolicited, not
+// subscription-based.
+func (s *server) runStreamer(ctx context.Context, interval time.Duration) {
+	entries := s.collectStreams()
+	if len(entries) == 0 {
+		return
+	}
+	s.logger.Info("streamer started",
+		slog.Int("stream_count", len(entries)),
+		slog.Duration("interval", interval))
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.stopped:
+			return
+		case t := <-ticker.C:
+			payload := streamTick(entries, t)
+			s.mu.Lock()
+			sessions := make([]*session, 0, len(s.sessions))
+			for sess := range s.sessions {
+				sessions = append(sessions, sess)
+			}
+			s.mu.Unlock()
+			for _, sess := range sessions {
+				sess.send(payload)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #69.

Extends the Ember+ provider MVP (PR #67) into a full spec-v2.50 implementation: all 4 Matrix modes, two-level Labels, `parametersLocation` grid, Functions with Invoke dispatch, Salvo + Lock builtins, subscribe-gated Streams, and Parameter.formula emission.

Stacked on PR #67 — rebase this onto main after #67 merges.

## Summary

| Feature | Demo OID | Spec ref |
|---|---|---|
| Matrix oneToN / oneToOne / nToN / dynamic | 1.2–1.5 | p.88 |
| Two-level Labels (spec p.41 shape) | 1.2.1.*, 1.4.1.* | p.38, p.41 |
| `parametersLocation` grid (1=targets, 2=sources, 3=connections) | 1.4.2 | p.37 |
| QualifiedFunction + InvocationResult | 1.6.* | p.91–92 |
| Builtins: sum / storeSalvo / recallSalvo / listSalvos | 1.6.1–1.6.4 | — |
| Lock enforcement (disposition=locked) | 1.6.5–1.6.6 | p.89 |
| Streams (subscribe-gated StreamCollection) | 1.7.1–1.7.3 | p.93 |
| Parameter.formula field emitted | 1.7.4 | p.85 / Formulas.pdf |

## Wire-correctness landmines fixed

12 spec-compliance bugs caught during live EmberViewer + acp-cli testing. Full list in `memory/project_emberplus_provider.md`. Highlights:

- `findCommandInElements` must descend into Function.Children + Matrix.Children (was dropping every Invoke silently)
- Number=0 is a legal sub-identifier — path walker must not strip it (broke SetValue on any parameter numbered 0)
- Connection tally must always emit the `sources` field even when empty (EmberViewer interprets absent sources as "no change")
- Implicit matrix subscription on GetDirectory (spec p.88) — without this, salvo recalls broadcast to nobody
- oneToOne source exclusivity must be enforced + loser tally broadcast
- Streams must be subscribe-gated — unsolicited fan-out to every session starves the link
- Matrix.Type is semantic, not metadata — oneToN/oneToOne must clamp target to ≤1 source

## Live testing

Verified against **EmberViewer 1.6.2** and our own `acp walk` / `acp invoke`:

```
acp invoke router.functions.sum          --args 3,4         → [7]
acp invoke router.functions.storeSalvo   --args 1.4.3,1     → [true]
acp invoke router.functions.recallSalvo  --args 1.4.3,1     → [2]  ← connections applied
acp invoke router.functions.listSalvos   --args router.nToN.matrix → ["1,5"]
acp invoke router.functions.setLock      --args 1.4.3,0,true → [false] ← was-locked state
acp invoke router.functions.listLocks    --args 1.4.3       → ["0"]

EmberViewer matrix grid:
  - Primary labels (CAM 1/PLAY 1 etc.) render via right-click → Get Labels
  - oneToOne crosspoint reassignment releases previous owner (loser tally)
  - Last-source disconnect clears the cell
  - Subscribe to router.streams.meter-L → bar animates; unsubscribe → quiet
```

## EmberViewer client-side limitations noted (not provider bugs)

Tracked separately in #68:
- REAL decoder: normal values /16 factor, small values show machine-epsilon
- Matrix grid only relabels sources from labels[0], never targets
- No UI for Invoke, Lock, or stream Subscribe on Parameter
- formula [CTX 10] not shown in Contents pane

Wire is spec-literal — we've verified bytes with hex dumps against TinyEmber+ captures and cross-checked with Wireshark's decoder.

## Follow-up

- **#70** formula expression evaluator (shared provider + consumer) — demo param at router.streams.gain-with-formula (1.7.4) carries `"\$*32\n\$/32"` ready for the evaluator

## Files

- `internal/provider/emberplus/matrix.go` (NEW) — Matrix + Label + Signal + Connection encoding
- `internal/provider/emberplus/function.go` (NEW) — Function + TupleItem + InvocationResult
- `internal/provider/emberplus/invoke.go` (NEW) — Matrix apply + invoke dispatch
- `internal/provider/emberplus/builtins.go` (NEW) — salvo + lock stores + callback registration
- `internal/provider/emberplus/streamer.go` (NEW) — subscribe-gated stream fan-out
- `internal/provider/emberplus/encoder.go` (M) — Matrix/Function dispatch + Formula + streamIdentifier emission
- `internal/provider/emberplus/session.go` (M) — findCommand descent, implicit subscribe, Matrix connection dispatch, Invoke dispatch, Number=0 fix
- `internal/provider/emberplus/server.go` (M) — func registry + salvo/lock store + streamer start
- `cmd/acp/cmd_invoke.go` (M) — opCtx timer starts after Walk
- `assets/emberplus/router_tree.json` (M) — demo tree rewritten to spec-canonical shape (106 entries)

## Commits (10)

```
cdda5d6 Matrix + Function + Label + salvo MVP
b7182e7 spec-canonical labels, oneToOne exclusivity, Invoke dispatch
cc05faa salvo OID ⇄ dotted path + matrix validation
2caf465 implicit matrix subscription (spec p.88)
e375abe listSalvos function
9716d18 unsolicited StreamCollection broadcast
c211e3a demo streams integer+factor (sidestep EmberViewer REAL bug)
77fae71 subscribe-gated streams
63b9bbc Lock enforcement + Formula emission + REAL stream
f992b66 agents.md Part B completion
```

## Test plan

- [x] Unit tests green (10 cases)
- [x] Live smoke via EmberViewer 1.6.2
- [x] CLI round-trip via `acp invoke` + `acp walk`
- [x] Byte-exact verification vs TinyEmber+ captures
- [x] oneToOne exclusivity + oneToN clamping
- [x] Matrix lock enforcement
- [x] Subscribe-gated streams (no traffic to non-subscribers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)