### PR TITLE
feat(provider): ACP1 provider plugin — UDP:2071 MVP (#73)

### DIFF
--- a/assets/acp1/demo_frame.json
+++ b/assets/acp1/demo_frame.json
@@ -18,6 +18,47 @@
         "access": "read",
         "children": [
           {
+            "number": 1,
+            "identifier": "identity",
+            "path": "device.slot-0.identity",
+            "oid": "1.1.1",
+            "description": null,
+            "isOnline": true,
+            "access": "read",
+            "children": [
+              {
+                "number": 0, "identifier": "CardName", "path": "device.slot-0.identity.CardName", "oid": "1.1.1.0",
+                "description": null, "isOnline": true, "access": "read", "children": [],
+                "type": "string", "value": "ACP1-Frame",
+                "default": null, "minimum": null, "maximum": null, "step": null,
+                "unit": null, "format": "maxLen=16", "factor": null, "formula": null,
+                "enumeration": null, "enumMap": null,
+                "streamIdentifier": null, "streamDescriptor": null,
+                "templateReference": null, "schemaIdentifiers": null
+              },
+              {
+                "number": 1, "identifier": "UserLabel", "path": "device.slot-0.identity.UserLabel", "oid": "1.1.1.1",
+                "description": null, "isOnline": true, "access": "readWrite", "children": [],
+                "type": "string", "value": "Synapse",
+                "default": null, "minimum": null, "maximum": null, "step": null,
+                "unit": null, "format": "maxLen=16", "factor": null, "formula": null,
+                "enumeration": null, "enumMap": null,
+                "streamIdentifier": null, "streamDescriptor": null,
+                "templateReference": null, "schemaIdentifiers": null
+              },
+              {
+                "number": 2, "identifier": "Serial", "path": "device.slot-0.identity.Serial", "oid": "1.1.1.2",
+                "description": null, "isOnline": true, "access": "read", "children": [],
+                "type": "string", "value": "SN-FRAME01",
+                "default": null, "minimum": null, "maximum": null, "step": null,
+                "unit": null, "format": "maxLen=16", "factor": null, "formula": null,
+                "enumeration": null, "enumMap": null,
+                "streamIdentifier": null, "streamDescriptor": null,
+                "templateReference": null, "schemaIdentifiers": null
+              }
+            ]
+          },
+          {
             "number": 6,
             "identifier": "frame",
             "path": "device.slot-0.frame",

--- a/assets/acp1/demo_frame.json
+++ b/assets/acp1/demo_frame.json
@@ -1,0 +1,369 @@
+{
+  "root": {
+    "number": 1,
+    "identifier": "device",
+    "path": "device",
+    "oid": "1",
+    "description": null,
+    "isOnline": true,
+    "access": "read",
+    "children": [
+      {
+        "number": 0,
+        "identifier": "slot-0",
+        "path": "device.slot-0",
+        "oid": "1.1",
+        "description": "Rack controller",
+        "isOnline": true,
+        "access": "read",
+        "children": [
+          {
+            "number": 6,
+            "identifier": "frame",
+            "path": "device.slot-0.frame",
+            "oid": "1.1.6",
+            "description": null,
+            "isOnline": true,
+            "access": "read",
+            "children": [
+              {
+                "number": 0,
+                "identifier": "frameStatus",
+                "path": "device.slot-0.frame.frameStatus",
+                "oid": "1.1.6.0",
+                "description": "per-slot card presence",
+                "isOnline": true,
+                "access": "read",
+                "children": [],
+                "type": "octets",
+                "value": [0, 2, 2, 3],
+                "default": null, "minimum": null, "maximum": null,
+                "step": null, "unit": null,
+                "format": "frame",
+                "factor": null, "formula": null,
+                "enumeration": null, "enumMap": null,
+                "streamIdentifier": null, "streamDescriptor": null,
+                "templateReference": null, "schemaIdentifiers": null
+              }
+            ]
+          }
+        ]
+      },
+
+      {
+        "number": 1,
+        "identifier": "slot-1",
+        "path": "device.slot-1",
+        "oid": "1.2",
+        "description": "CardTypeA — audio I/O card",
+        "isOnline": true,
+        "access": "read",
+        "children": [
+          {
+            "number": 1,
+            "identifier": "identity",
+            "path": "device.slot-1.identity",
+            "oid": "1.2.1",
+            "description": null,
+            "isOnline": true,
+            "access": "read",
+            "children": [
+              {
+                "number": 0, "identifier": "CardName", "path": "device.slot-1.identity.CardName", "oid": "1.2.1.0",
+                "description": null, "isOnline": true, "access": "read", "children": [],
+                "type": "string", "value": "GIO-12",
+                "default": null, "minimum": null, "maximum": null, "step": null,
+                "unit": null, "format": "maxLen=16", "factor": null, "formula": null,
+                "enumeration": null, "enumMap": null,
+                "streamIdentifier": null, "streamDescriptor": null,
+                "templateReference": null, "schemaIdentifiers": null
+              },
+              {
+                "number": 1, "identifier": "UserLabel", "path": "device.slot-1.identity.UserLabel", "oid": "1.2.1.1",
+                "description": null, "isOnline": true, "access": "readWrite", "children": [],
+                "type": "string", "value": "Input-A",
+                "default": null, "minimum": null, "maximum": null, "step": null,
+                "unit": null, "format": "maxLen=16", "factor": null, "formula": null,
+                "enumeration": null, "enumMap": null,
+                "streamIdentifier": null, "streamDescriptor": null,
+                "templateReference": null, "schemaIdentifiers": null
+              },
+              {
+                "number": 2, "identifier": "Serial", "path": "device.slot-1.identity.Serial", "oid": "1.2.1.2",
+                "description": null, "isOnline": true, "access": "read", "children": [],
+                "type": "string", "value": "SN-0A1F",
+                "default": null, "minimum": null, "maximum": null, "step": null,
+                "unit": null, "format": "maxLen=16", "factor": null, "formula": null,
+                "enumeration": null, "enumMap": null,
+                "streamIdentifier": null, "streamDescriptor": null,
+                "templateReference": null, "schemaIdentifiers": null
+              }
+            ]
+          },
+          {
+            "number": 2,
+            "identifier": "control",
+            "path": "device.slot-1.control",
+            "oid": "1.2.2",
+            "description": null,
+            "isOnline": true,
+            "access": "read",
+            "children": [
+              {
+                "number": 0, "identifier": "Level", "path": "device.slot-1.control.Level", "oid": "1.2.2.0",
+                "description": null, "isOnline": true, "access": "readWrite", "children": [],
+                "type": "integer", "value": -6,
+                "default": 0, "minimum": -60, "maximum": 12, "step": 1,
+                "unit": "dB", "format": null, "factor": null, "formula": null,
+                "enumeration": null, "enumMap": null,
+                "streamIdentifier": null, "streamDescriptor": null,
+                "templateReference": null, "schemaIdentifiers": null
+              },
+              {
+                "number": 1, "identifier": "Mute", "path": "device.slot-1.control.Mute", "oid": "1.2.2.1",
+                "description": null, "isOnline": true, "access": "readWrite", "children": [],
+                "type": "enum", "value": 0,
+                "default": 0, "minimum": null, "maximum": null, "step": null,
+                "unit": null, "format": null, "factor": null, "formula": null,
+                "enumeration": "Off\nOn",
+                "enumMap": [
+                  {"key": "Off", "value": 0},
+                  {"key": "On",  "value": 1}
+                ],
+                "streamIdentifier": null, "streamDescriptor": null,
+                "templateReference": null, "schemaIdentifiers": null
+              },
+              {
+                "number": 2, "identifier": "Gain", "path": "device.slot-1.control.Gain", "oid": "1.2.2.2",
+                "description": null, "isOnline": true, "access": "readWrite", "children": [],
+                "type": "real", "value": 0.0,
+                "default": 0.0, "minimum": 0.0, "maximum": 20.0, "step": 0.5,
+                "unit": "dB", "format": null, "factor": null, "formula": null,
+                "enumeration": null, "enumMap": null,
+                "streamIdentifier": null, "streamDescriptor": null,
+                "templateReference": null, "schemaIdentifiers": null
+              },
+              {
+                "number": 3, "identifier": "Saturation", "path": "device.slot-1.control.Saturation", "oid": "1.2.2.3",
+                "description": null, "isOnline": true, "access": "readWrite", "children": [],
+                "type": "integer", "value": 128,
+                "default": 0, "minimum": 0, "maximum": 255, "step": 1,
+                "unit": "%", "format": "uint8", "factor": null, "formula": null,
+                "enumeration": null, "enumMap": null,
+                "streamIdentifier": null, "streamDescriptor": null,
+                "templateReference": null, "schemaIdentifiers": null
+              },
+              {
+                "number": 4, "identifier": "Bitrate", "path": "device.slot-1.control.Bitrate", "oid": "1.2.2.4",
+                "description": null, "isOnline": true, "access": "readWrite", "children": [],
+                "type": "integer", "value": 48000,
+                "default": 48000, "minimum": 0, "maximum": 192000, "step": 1000,
+                "unit": "Hz", "format": "int32", "factor": null, "formula": null,
+                "enumeration": null, "enumMap": null,
+                "streamIdentifier": null, "streamDescriptor": null,
+                "templateReference": null, "schemaIdentifiers": null
+              },
+              {
+                "number": 5, "identifier": "Gateway", "path": "device.slot-1.control.Gateway", "oid": "1.2.2.5",
+                "description": null, "isOnline": true, "access": "readWrite", "children": [],
+                "type": "string", "value": "192.168.1.1",
+                "default": null, "minimum": "0.0.0.0", "maximum": "255.255.255.255", "step": null,
+                "unit": null, "format": "ipv4", "factor": null, "formula": null,
+                "enumeration": null, "enumMap": null,
+                "streamIdentifier": null, "streamDescriptor": null,
+                "templateReference": null, "schemaIdentifiers": null
+              }
+            ]
+          },
+          {
+            "number": 3,
+            "identifier": "status",
+            "path": "device.slot-1.status",
+            "oid": "1.2.3",
+            "description": null,
+            "isOnline": true,
+            "access": "read",
+            "children": [
+              {
+                "number": 0, "identifier": "Temperature", "path": "device.slot-1.status.Temperature", "oid": "1.2.3.0",
+                "description": null, "isOnline": true, "access": "read", "children": [],
+                "type": "integer", "value": 42,
+                "default": null, "minimum": -40, "maximum": 125, "step": 1,
+                "unit": "C", "format": null, "factor": null, "formula": null,
+                "enumeration": null, "enumMap": null,
+                "streamIdentifier": null, "streamDescriptor": null,
+                "templateReference": null, "schemaIdentifiers": null
+              }
+            ]
+          },
+          {
+            "number": 4,
+            "identifier": "alarm",
+            "path": "device.slot-1.alarm",
+            "oid": "1.2.4",
+            "description": null,
+            "isOnline": true,
+            "access": "read",
+            "children": [
+              {
+                "number": 0, "identifier": "OverTemp", "path": "device.slot-1.alarm.OverTemp", "oid": "1.2.4.0",
+                "description": "on: Overheat / off: OK",
+                "isOnline": true, "access": "read", "children": [],
+                "type": "boolean", "value": false,
+                "default": null, "minimum": null, "maximum": null, "step": null,
+                "unit": null, "format": "alarm,priority=2,tag=17",
+                "factor": null, "formula": null,
+                "enumeration": null, "enumMap": null,
+                "streamIdentifier": null, "streamDescriptor": null,
+                "templateReference": null, "schemaIdentifiers": null
+              }
+            ]
+          }
+        ]
+      },
+
+      {
+        "number": 2,
+        "identifier": "slot-2",
+        "path": "device.slot-2",
+        "oid": "1.3",
+        "description": "CardTypeA — same DM as slot-1, independent values",
+        "isOnline": true,
+        "access": "read",
+        "children": [
+          {
+            "number": 1,
+            "identifier": "identity",
+            "path": "device.slot-2.identity",
+            "oid": "1.3.1",
+            "description": null,
+            "isOnline": true,
+            "access": "read",
+            "children": [
+              {
+                "number": 0, "identifier": "CardName", "path": "device.slot-2.identity.CardName", "oid": "1.3.1.0",
+                "description": null, "isOnline": true, "access": "read", "children": [],
+                "type": "string", "value": "GIO-12",
+                "default": null, "minimum": null, "maximum": null, "step": null,
+                "unit": null, "format": "maxLen=16", "factor": null, "formula": null,
+                "enumeration": null, "enumMap": null,
+                "streamIdentifier": null, "streamDescriptor": null,
+                "templateReference": null, "schemaIdentifiers": null
+              },
+              {
+                "number": 1, "identifier": "UserLabel", "path": "device.slot-2.identity.UserLabel", "oid": "1.3.1.1",
+                "description": null, "isOnline": true, "access": "readWrite", "children": [],
+                "type": "string", "value": "Input-B",
+                "default": null, "minimum": null, "maximum": null, "step": null,
+                "unit": null, "format": "maxLen=16", "factor": null, "formula": null,
+                "enumeration": null, "enumMap": null,
+                "streamIdentifier": null, "streamDescriptor": null,
+                "templateReference": null, "schemaIdentifiers": null
+              },
+              {
+                "number": 2, "identifier": "Serial", "path": "device.slot-2.identity.Serial", "oid": "1.3.1.2",
+                "description": null, "isOnline": true, "access": "read", "children": [],
+                "type": "string", "value": "SN-0A20",
+                "default": null, "minimum": null, "maximum": null, "step": null,
+                "unit": null, "format": "maxLen=16", "factor": null, "formula": null,
+                "enumeration": null, "enumMap": null,
+                "streamIdentifier": null, "streamDescriptor": null,
+                "templateReference": null, "schemaIdentifiers": null
+              }
+            ]
+          },
+          {
+            "number": 2,
+            "identifier": "control",
+            "path": "device.slot-2.control",
+            "oid": "1.3.2",
+            "description": null,
+            "isOnline": true,
+            "access": "read",
+            "children": [
+              {
+                "number": 0, "identifier": "Level", "path": "device.slot-2.control.Level", "oid": "1.3.2.0",
+                "description": null, "isOnline": true, "access": "readWrite", "children": [],
+                "type": "integer", "value": 3,
+                "default": 0, "minimum": -60, "maximum": 12, "step": 1,
+                "unit": "dB", "format": null, "factor": null, "formula": null,
+                "enumeration": null, "enumMap": null,
+                "streamIdentifier": null, "streamDescriptor": null,
+                "templateReference": null, "schemaIdentifiers": null
+              },
+              {
+                "number": 1, "identifier": "Mute", "path": "device.slot-2.control.Mute", "oid": "1.3.2.1",
+                "description": null, "isOnline": true, "access": "readWrite", "children": [],
+                "type": "enum", "value": 1,
+                "default": 0, "minimum": null, "maximum": null, "step": null,
+                "unit": null, "format": null, "factor": null, "formula": null,
+                "enumeration": "Off\nOn",
+                "enumMap": [
+                  {"key": "Off", "value": 0},
+                  {"key": "On",  "value": 1}
+                ],
+                "streamIdentifier": null, "streamDescriptor": null,
+                "templateReference": null, "schemaIdentifiers": null
+              }
+            ]
+          }
+        ]
+      },
+
+      {
+        "number": 3,
+        "identifier": "slot-3",
+        "path": "device.slot-3",
+        "oid": "1.4",
+        "description": "CardTypeB — firmware card",
+        "isOnline": true,
+        "access": "read",
+        "children": [
+          {
+            "number": 1,
+            "identifier": "identity",
+            "path": "device.slot-3.identity",
+            "oid": "1.4.1",
+            "description": null,
+            "isOnline": true,
+            "access": "read",
+            "children": [
+              {
+                "number": 0, "identifier": "CardName", "path": "device.slot-3.identity.CardName", "oid": "1.4.1.0",
+                "description": null, "isOnline": true, "access": "read", "children": [],
+                "type": "string", "value": "CP3000",
+                "default": null, "minimum": null, "maximum": null, "step": null,
+                "unit": null, "format": "maxLen=16", "factor": null, "formula": null,
+                "enumeration": null, "enumMap": null,
+                "streamIdentifier": null, "streamDescriptor": null,
+                "templateReference": null, "schemaIdentifiers": null
+              }
+            ]
+          },
+          {
+            "number": 5,
+            "identifier": "file",
+            "path": "device.slot-3.file",
+            "oid": "1.4.5",
+            "description": null,
+            "isOnline": true,
+            "access": "read",
+            "children": [
+              {
+                "number": 0, "identifier": "firmware.bin", "path": "device.slot-3.file.firmware.bin", "oid": "1.4.5.0",
+                "description": null, "isOnline": true, "access": "readWrite", "children": [],
+                "type": "string", "value": "firmware.bin",
+                "default": 42, "minimum": null, "maximum": null, "step": null,
+                "unit": null, "format": "file", "factor": null, "formula": null,
+                "enumeration": null, "enumMap": null,
+                "streamIdentifier": null, "streamDescriptor": null,
+                "templateReference": null, "schemaIdentifiers": null
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "templates": null
+}

--- a/cmd/acp-provider/main.go
+++ b/cmd/acp-provider/main.go
@@ -24,6 +24,7 @@ import (
 	"acp/internal/export/canonical"
 	"acp/internal/provider"
 
+	_ "acp/internal/provider/acp1"
 	_ "acp/internal/provider/emberplus"
 )
 

--- a/internal/provider/acp1/encoder.go
+++ b/internal/provider/acp1/encoder.go
@@ -1,0 +1,839 @@
+package acp1
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"acp/internal/export/canonical"
+	iacp1 "acp/internal/protocol/acp1"
+)
+
+// encodeObject builds the Value bytes returned by a getObject reply
+// (spec §"AxonNet methods" p.28 Method 5). Layout is:
+//
+//	[type_byte] [num_props] [per-type properties in order]
+//
+// This is the exact inverse of property.go's DecodeObject — the same
+// per-type ordering, same field widths, same big-endian encoding, same
+// NUL-terminated strings. A round-trip test in encoder_test.go asserts
+// encodeObject followed by DecodeObject recovers every field.
+//
+// Errors returned when a canonical value is out of spec range for its
+// ACP1 type (e.g. int16 value 40000) so the provider never emits
+// malformed bytes. Never silently clamps.
+func encodeObject(e *entry) ([]byte, error) {
+	if e == nil || e.param == nil {
+		return nil, fmt.Errorf("encodeObject: nil entry")
+	}
+	switch e.acpType {
+	case iacp1.TypeRoot:
+		return encodeRoot(e)
+	case iacp1.TypeInteger:
+		return encodeInteger(e)
+	case iacp1.TypeIPAddr:
+		return encodeIPAddr(e)
+	case iacp1.TypeFloat:
+		return encodeFloat(e)
+	case iacp1.TypeEnum:
+		return encodeEnum(e)
+	case iacp1.TypeString:
+		return encodeString(e)
+	case iacp1.TypeFrame:
+		return encodeFrame(e)
+	case iacp1.TypeAlarm:
+		return encodeAlarm(e)
+	case iacp1.TypeFile:
+		return encodeFile(e)
+	case iacp1.TypeLong:
+		return encodeLong(e)
+	case iacp1.TypeByte:
+		return encodeByte(e)
+	}
+	return nil, fmt.Errorf("encodeObject: unsupported ACP1 type %d", e.acpType)
+}
+
+// encodeValue builds the Value bytes returned by getValue / setValue /
+// setIncValue / setDecValue / setDefValue replies. Per spec §"Objects by
+// Type" p.21-27: the "value" property for each type.
+//
+//	Root       -> boot_mode (u8)
+//	Integer    -> value (i16)
+//	IPAddr     -> value (u32)
+//	Float      -> value (f32)
+//	Enum       -> value (u8, index into item list)
+//	String     -> value (NUL-terminated)
+//	Frame      -> num_slots (u8) + slot_status[N]
+//	Alarm      -> active (u8, 0=idle, 1=active)
+//	File       -> num_fragments (i16)
+//	Long       -> value (i32)
+//	Byte       -> value (u8)
+func encodeValue(e *entry) ([]byte, error) {
+	if e == nil || e.param == nil {
+		return nil, fmt.Errorf("encodeValue: nil entry")
+	}
+	switch e.acpType {
+	case iacp1.TypeInteger:
+		v, err := asInt16(e.param.Value, "value")
+		if err != nil {
+			return nil, err
+		}
+		return writeI16(v), nil
+	case iacp1.TypeIPAddr:
+		v, err := ipv4ToUint32(e.param.Value)
+		if err != nil {
+			return nil, err
+		}
+		return writeU32(v), nil
+	case iacp1.TypeFloat:
+		v, err := asFloat32(e.param.Value, "value")
+		if err != nil {
+			return nil, err
+		}
+		return writeF32(v), nil
+	case iacp1.TypeEnum:
+		v, err := asUint8(e.param.Value, "value")
+		if err != nil {
+			return nil, err
+		}
+		return []byte{v}, nil
+	case iacp1.TypeString:
+		s, err := asString(e.param.Value, "value")
+		if err != nil {
+			return nil, err
+		}
+		return writeCStr(s), nil
+	case iacp1.TypeAlarm:
+		v, err := asBool(e.param.Value, "value")
+		if err != nil {
+			return nil, err
+		}
+		if v {
+			return []byte{1}, nil
+		}
+		return []byte{0}, nil
+	case iacp1.TypeLong:
+		v, err := asInt32(e.param.Value, "value")
+		if err != nil {
+			return nil, err
+		}
+		return writeI32(v), nil
+	case iacp1.TypeByte:
+		v, err := asUint8(e.param.Value, "value")
+		if err != nil {
+			return nil, err
+		}
+		return []byte{v}, nil
+	case iacp1.TypeFile:
+		v, err := asInt16(e.param.Default, "num_fragments") // File's "value" is num_fragments (see spec p.26)
+		if err != nil {
+			return nil, err
+		}
+		return writeI16(v), nil
+	case iacp1.TypeFrame:
+		return encodeFrameValue(e)
+	}
+	return nil, fmt.Errorf("encodeValue: unsupported ACP1 type %d", e.acpType)
+}
+
+// encodeRoot — spec p.21. Root has 9 properties; object_type(0) and
+// num_props(9) are part of the header.
+func encodeRoot(e *entry) ([]byte, error) {
+	// Root props: access, boot_mode, num_identity, num_control,
+	// num_status, num_alarm, num_file. The canonical tree doesn't store
+	// these counts on a "root" Parameter — they come from tree.slots.
+	// The session layer is responsible for synthesising the entry with
+	// the correct counts before calling encodeObject.
+	return nil, fmt.Errorf("encodeRoot: Root objects are synthesised by session.go, not stored as tree entries")
+}
+
+func encodeInteger(e *entry) ([]byte, error) {
+	p := e.param
+	value, err := asInt16(p.Value, "value")
+	if err != nil {
+		return nil, err
+	}
+	def, err := asInt16Opt(p.Default, "default", 0)
+	if err != nil {
+		return nil, err
+	}
+	step, err := asInt16Opt(p.Step, "step", 1)
+	if err != nil {
+		return nil, err
+	}
+	minV, err := asInt16Opt(p.Minimum, "minimum", math.MinInt16)
+	if err != nil {
+		return nil, err
+	}
+	maxV, err := asInt16Opt(p.Maximum, "maximum", math.MaxInt16)
+	if err != nil {
+		return nil, err
+	}
+	buf := newBuf(iacp1.TypeInteger, 10)
+	buf.u8(e.access)
+	buf.i16(value)
+	buf.i16(def)
+	buf.i16(step)
+	buf.i16(minV)
+	buf.i16(maxV)
+	buf.cstr(limitLabel(p.Identifier))
+	buf.cstr(unitOf(p))
+	return buf.bytes(), nil
+}
+
+func encodeLong(e *entry) ([]byte, error) {
+	p := e.param
+	value, err := asInt32(p.Value, "value")
+	if err != nil {
+		return nil, err
+	}
+	def, err := asInt32Opt(p.Default, "default", 0)
+	if err != nil {
+		return nil, err
+	}
+	step, err := asInt32Opt(p.Step, "step", 1)
+	if err != nil {
+		return nil, err
+	}
+	minV, err := asInt32Opt(p.Minimum, "minimum", math.MinInt32)
+	if err != nil {
+		return nil, err
+	}
+	maxV, err := asInt32Opt(p.Maximum, "maximum", math.MaxInt32)
+	if err != nil {
+		return nil, err
+	}
+	buf := newBuf(iacp1.TypeLong, 10)
+	buf.u8(e.access)
+	buf.i32(value)
+	buf.i32(def)
+	buf.i32(step)
+	buf.i32(minV)
+	buf.i32(maxV)
+	buf.cstr(limitLabel(p.Identifier))
+	buf.cstr(unitOf(p))
+	return buf.bytes(), nil
+}
+
+func encodeByte(e *entry) ([]byte, error) {
+	p := e.param
+	value, err := asUint8(p.Value, "value")
+	if err != nil {
+		return nil, err
+	}
+	def, err := asUint8Opt(p.Default, "default", 0)
+	if err != nil {
+		return nil, err
+	}
+	step, err := asUint8Opt(p.Step, "step", 1)
+	if err != nil {
+		return nil, err
+	}
+	minV, err := asUint8Opt(p.Minimum, "minimum", 0)
+	if err != nil {
+		return nil, err
+	}
+	maxV, err := asUint8Opt(p.Maximum, "maximum", math.MaxUint8)
+	if err != nil {
+		return nil, err
+	}
+	buf := newBuf(iacp1.TypeByte, 10)
+	buf.u8(e.access)
+	buf.u8(value)
+	buf.u8(def)
+	buf.u8(step)
+	buf.u8(minV)
+	buf.u8(maxV)
+	buf.cstr(limitLabel(p.Identifier))
+	buf.cstr(unitOf(p))
+	return buf.bytes(), nil
+}
+
+func encodeFloat(e *entry) ([]byte, error) {
+	p := e.param
+	value, err := asFloat32(p.Value, "value")
+	if err != nil {
+		return nil, err
+	}
+	def, err := asFloat32Opt(p.Default, "default", 0)
+	if err != nil {
+		return nil, err
+	}
+	step, err := asFloat32Opt(p.Step, "step", 1)
+	if err != nil {
+		return nil, err
+	}
+	minV, err := asFloat32Opt(p.Minimum, "minimum", -math.MaxFloat32)
+	if err != nil {
+		return nil, err
+	}
+	maxV, err := asFloat32Opt(p.Maximum, "maximum", math.MaxFloat32)
+	if err != nil {
+		return nil, err
+	}
+	buf := newBuf(iacp1.TypeFloat, 10)
+	buf.u8(e.access)
+	buf.f32(value)
+	buf.f32(def)
+	buf.f32(step)
+	buf.f32(minV)
+	buf.f32(maxV)
+	buf.cstr(limitLabel(p.Identifier))
+	buf.cstr(unitOf(p))
+	return buf.bytes(), nil
+}
+
+func encodeIPAddr(e *entry) ([]byte, error) {
+	p := e.param
+	value, err := ipv4ToUint32(p.Value)
+	if err != nil {
+		return nil, err
+	}
+	def, err := ipv4ToUint32Opt(p.Default, 0)
+	if err != nil {
+		return nil, err
+	}
+	step, err := ipv4ToUint32Opt(p.Step, 0)
+	if err != nil {
+		return nil, err
+	}
+	minV, err := ipv4ToUint32Opt(p.Minimum, 0)
+	if err != nil {
+		return nil, err
+	}
+	maxV, err := ipv4ToUint32Opt(p.Maximum, math.MaxUint32)
+	if err != nil {
+		return nil, err
+	}
+	buf := newBuf(iacp1.TypeIPAddr, 10)
+	buf.u8(e.access)
+	buf.u32(value)
+	buf.u32(def)
+	buf.u32(step)
+	buf.u32(minV)
+	buf.u32(maxV)
+	buf.cstr(limitLabel(p.Identifier))
+	buf.cstr(unitOf(p))
+	return buf.bytes(), nil
+}
+
+func encodeEnum(e *entry) ([]byte, error) {
+	p := e.param
+	value, err := asUint8(p.Value, "value")
+	if err != nil {
+		return nil, err
+	}
+	items := enumItems(p)
+	if len(items) == 0 {
+		return nil, fmt.Errorf("enum %q has no items (set enumMap or enumeration)", p.Identifier)
+	}
+	if len(items) > math.MaxUint8 {
+		return nil, fmt.Errorf("enum %q has %d items, exceeds 255", p.Identifier, len(items))
+	}
+	def, err := asUint8Opt(p.Default, "default", 0)
+	if err != nil {
+		return nil, err
+	}
+	buf := newBuf(iacp1.TypeEnum, 8)
+	buf.u8(e.access)
+	buf.u8(value)
+	buf.u8(uint8(len(items)))
+	buf.u8(def)
+	buf.cstr(limitLabel(p.Identifier))
+	// Item list is a single NUL-terminated comma-delimited string —
+	// spec p.23 example "Off,On,Auto\0". One final NUL is part of cstr.
+	buf.cstr(strings.Join(items, ","))
+	return buf.bytes(), nil
+}
+
+func encodeString(e *entry) ([]byte, error) {
+	p := e.param
+	value, err := asString(p.Value, "value")
+	if err != nil {
+		return nil, err
+	}
+	maxLen := stringMaxLen(p)
+	buf := newBuf(iacp1.TypeString, 6)
+	buf.u8(e.access)
+	buf.cstr(limitString(value, int(maxLen)))
+	buf.u8(maxLen)
+	buf.cstr(limitLabel(p.Identifier))
+	return buf.bytes(), nil
+}
+
+func encodeAlarm(e *entry) ([]byte, error) {
+	p := e.param
+	// priority/tag live as inline property fields of a real Axon alarm
+	// object. Canonical doesn't expose them explicitly — we read them
+	// from the Format hint suffix "alarm:priority=N,tag=M" when present,
+	// otherwise default to priority=1 (enabled) and tag=0.
+	priority, tag := alarmPriorityTag(p)
+	onMsg, offMsg := alarmMessages(p)
+
+	buf := newBuf(iacp1.TypeAlarm, 8)
+	buf.u8(e.access)
+	buf.u8(priority)
+	buf.u8(tag)
+	buf.cstr(limitLabel(p.Identifier))
+	buf.cstrWithLimit(onMsg, iacp1.MaxAlarmMsg)
+	buf.cstrWithLimit(offMsg, iacp1.MaxAlarmMsg)
+	return buf.bytes(), nil
+}
+
+func encodeFile(e *entry) ([]byte, error) {
+	p := e.param
+	// Canonical carries the file name in Value; num_fragments in Default
+	// (no dedicated canonical field).
+	nameAny := p.Value
+	name, err := asString(nameAny, "value")
+	if err != nil {
+		return nil, err
+	}
+	frags, err := asInt16Opt(p.Default, "num_fragments", 0)
+	if err != nil {
+		return nil, err
+	}
+	buf := newBuf(iacp1.TypeFile, 5)
+	buf.u8(e.access)
+	buf.i16(frags)
+	buf.cstr(name)
+	return buf.bytes(), nil
+}
+
+func encodeFrame(e *entry) ([]byte, error) {
+	slots, err := frameSlotStatuses(e.param)
+	if err != nil {
+		return nil, err
+	}
+	buf := newBuf(iacp1.TypeFrame, 4)
+	buf.u8(e.access)
+	buf.u8(uint8(len(slots)))
+	for _, s := range slots {
+		buf.u8(s)
+	}
+	return buf.bytes(), nil
+}
+
+// encodeFrameValue serialises just the value portion for getValue —
+// the [num_slots, slot_status[N]] block without the type/num_props
+// prefix.
+func encodeFrameValue(e *entry) ([]byte, error) {
+	slots, err := frameSlotStatuses(e.param)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]byte, 1+len(slots))
+	out[0] = uint8(len(slots))
+	copy(out[1:], slots)
+	return out, nil
+}
+
+// ----------------------------------------------------------------- helpers
+
+// objBuf accumulates per-object bytes starting with the mandatory
+// [type, num_props] header. Widths come straight from the spec tables
+// p.21–27 — no padding, all multi-byte fields big-endian.
+type objBuf struct {
+	buf []byte
+}
+
+func newBuf(typ iacp1.ObjectType, nProps uint8) *objBuf {
+	return &objBuf{buf: []byte{uint8(typ), nProps}}
+}
+
+func (b *objBuf) u8(v uint8) { b.buf = append(b.buf, v) }
+func (b *objBuf) i16(v int16) {
+	var tmp [2]byte
+	binary.BigEndian.PutUint16(tmp[:], uint16(v))
+	b.buf = append(b.buf, tmp[:]...)
+}
+func (b *objBuf) u32(v uint32) {
+	var tmp [4]byte
+	binary.BigEndian.PutUint32(tmp[:], v)
+	b.buf = append(b.buf, tmp[:]...)
+}
+func (b *objBuf) i32(v int32) {
+	var tmp [4]byte
+	binary.BigEndian.PutUint32(tmp[:], uint32(v))
+	b.buf = append(b.buf, tmp[:]...)
+}
+func (b *objBuf) f32(v float32) {
+	var tmp [4]byte
+	binary.BigEndian.PutUint32(tmp[:], math.Float32bits(v))
+	b.buf = append(b.buf, tmp[:]...)
+}
+func (b *objBuf) cstr(s string) {
+	b.buf = append(b.buf, []byte(s)...)
+	b.buf = append(b.buf, 0)
+}
+func (b *objBuf) cstrWithLimit(s string, limit int) {
+	if len(s) > limit {
+		s = s[:limit]
+	}
+	b.cstr(s)
+}
+func (b *objBuf) bytes() []byte { return b.buf }
+
+func writeI16(v int16) []byte {
+	out := make([]byte, 2)
+	binary.BigEndian.PutUint16(out, uint16(v))
+	return out
+}
+
+func writeI32(v int32) []byte {
+	out := make([]byte, 4)
+	binary.BigEndian.PutUint32(out, uint32(v))
+	return out
+}
+
+func writeU32(v uint32) []byte {
+	out := make([]byte, 4)
+	binary.BigEndian.PutUint32(out, v)
+	return out
+}
+
+func writeF32(v float32) []byte {
+	out := make([]byte, 4)
+	binary.BigEndian.PutUint32(out, math.Float32bits(v))
+	return out
+}
+
+func writeCStr(s string) []byte {
+	out := make([]byte, len(s)+1)
+	copy(out, s)
+	return out
+}
+
+// limitLabel truncates identifiers to the spec-p.20 max (MaxLabelLen
+// excluding the NUL terminator). A real Axon device won't emit longer.
+func limitLabel(s string) string {
+	if len(s) > iacp1.MaxLabelLen {
+		return s[:iacp1.MaxLabelLen]
+	}
+	return s
+}
+
+func limitString(s string, maxLen int) string {
+	if maxLen > 0 && len(s) > maxLen {
+		return s[:maxLen]
+	}
+	return s
+}
+
+func unitOf(p *canonical.Parameter) string {
+	if p.Unit == nil {
+		return ""
+	}
+	u := *p.Unit
+	if len(u) > iacp1.MaxUnitLen {
+		u = u[:iacp1.MaxUnitLen]
+	}
+	return u
+}
+
+// stringMaxLen pulls the max-length from Parameter.Format "maxLen=N"
+// (mirrors canonicalize.go's convention). Defaults to 0 when absent;
+// the caller then treats 0 as "device does not declare a limit".
+func stringMaxLen(p *canonical.Parameter) uint8 {
+	if p.Format == nil {
+		return 0
+	}
+	for _, kv := range strings.Split(*p.Format, ",") {
+		kv = strings.TrimSpace(kv)
+		if strings.HasPrefix(kv, "maxLen=") {
+			n, err := strconv.Atoi(strings.TrimPrefix(kv, "maxLen="))
+			if err == nil && n > 0 && n <= math.MaxUint8 {
+				return uint8(n)
+			}
+		}
+	}
+	return 0
+}
+
+func enumItems(p *canonical.Parameter) []string {
+	if len(p.EnumMap) > 0 {
+		out := make([]string, len(p.EnumMap))
+		for i, e := range p.EnumMap {
+			out[i] = e.Key
+		}
+		return out
+	}
+	if p.Enumeration != nil && *p.Enumeration != "" {
+		// Consumer canonicalize.go joins items with "\n"; accept both.
+		raw := *p.Enumeration
+		if strings.Contains(raw, "\n") {
+			return strings.Split(raw, "\n")
+		}
+		return strings.Split(raw, ",")
+	}
+	return nil
+}
+
+// alarmPriorityTag reads Format hint "alarm:priority=N,tag=M" if
+// present; otherwise (priority=1, tag=0). Priority 0 = disabled per
+// spec p.25 so we default to 1 (enabled). Tag is an Axon-assigned id
+// with no schema-level default.
+func alarmPriorityTag(p *canonical.Parameter) (uint8, uint8) {
+	priority, tag := uint8(1), uint8(0)
+	if p.Format == nil {
+		return priority, tag
+	}
+	for _, kv := range strings.Split(*p.Format, ",") {
+		kv = strings.TrimSpace(kv)
+		switch {
+		case strings.HasPrefix(kv, "priority="):
+			if n, err := strconv.Atoi(strings.TrimPrefix(kv, "priority=")); err == nil && n >= 0 && n <= math.MaxUint8 {
+				priority = uint8(n)
+			}
+		case strings.HasPrefix(kv, "tag="):
+			if n, err := strconv.Atoi(strings.TrimPrefix(kv, "tag=")); err == nil && n >= 0 && n <= math.MaxUint8 {
+				tag = uint8(n)
+			}
+		}
+	}
+	return priority, tag
+}
+
+// alarmMessages pulls the "on:/off:" messages from Parameter.Description
+// — mirroring canonicalize.go's alarm output formatting.
+func alarmMessages(p *canonical.Parameter) (string, string) {
+	if p.Description == nil {
+		return "", ""
+	}
+	onMsg, offMsg := "", ""
+	for _, part := range strings.Split(*p.Description, " / ") {
+		part = strings.TrimSpace(part)
+		switch {
+		case strings.HasPrefix(part, "on:"):
+			onMsg = strings.TrimSpace(strings.TrimPrefix(part, "on:"))
+		case strings.HasPrefix(part, "off:"):
+			offMsg = strings.TrimSpace(strings.TrimPrefix(part, "off:"))
+		}
+	}
+	return onMsg, offMsg
+}
+
+// frameSlotStatuses pulls the slot status bytes from the Frame
+// Parameter's Value. Canonical carries this as []any of int64 (decoded
+// from JSON array of numbers).
+func frameSlotStatuses(p *canonical.Parameter) ([]uint8, error) {
+	arr, ok := p.Value.([]any)
+	if !ok {
+		return nil, fmt.Errorf("frame %q: value must be a JSON array of slot status bytes", p.Identifier)
+	}
+	out := make([]uint8, 0, len(arr))
+	for i, el := range arr {
+		n, err := anyToInt(el, "slot_status["+strconv.Itoa(i)+"]")
+		if err != nil {
+			return nil, err
+		}
+		if n < 0 || n > math.MaxUint8 {
+			return nil, fmt.Errorf("frame %q: slot_status[%d] out of range: %d", p.Identifier, i, n)
+		}
+		out = append(out, uint8(n))
+	}
+	return out, nil
+}
+
+// ------------------------------------------------------------ any -> typed
+
+// anyToInt accepts int / int64 / float64 / json.Number-like types and
+// returns int64 — JSON unmarshals numbers as float64 by default so we
+// have to accept that too.
+func anyToInt(v any, field string) (int64, error) {
+	switch x := v.(type) {
+	case nil:
+		return 0, fmt.Errorf("%s: missing", field)
+	case int:
+		return int64(x), nil
+	case int64:
+		return x, nil
+	case uint8:
+		return int64(x), nil
+	case uint16:
+		return int64(x), nil
+	case uint32:
+		return int64(x), nil
+	case int16:
+		return int64(x), nil
+	case int32:
+		return int64(x), nil
+	case float32:
+		if float32(int64(x)) != x {
+			return 0, fmt.Errorf("%s: %v has fractional part, want integer", field, x)
+		}
+		return int64(x), nil
+	case float64:
+		if float64(int64(x)) != x {
+			return 0, fmt.Errorf("%s: %v has fractional part, want integer", field, x)
+		}
+		return int64(x), nil
+	case bool:
+		if x {
+			return 1, nil
+		}
+		return 0, nil
+	case string:
+		n, err := strconv.ParseInt(x, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("%s: %q is not an integer", field, x)
+		}
+		return n, nil
+	}
+	return 0, fmt.Errorf("%s: unexpected type %T", field, v)
+}
+
+func anyToFloat(v any, field string) (float64, error) {
+	switch x := v.(type) {
+	case nil:
+		return 0, fmt.Errorf("%s: missing", field)
+	case float32:
+		return float64(x), nil
+	case float64:
+		return x, nil
+	case int:
+		return float64(x), nil
+	case int64:
+		return float64(x), nil
+	case string:
+		n, err := strconv.ParseFloat(x, 64)
+		if err != nil {
+			return 0, fmt.Errorf("%s: %q is not a number", field, x)
+		}
+		return n, nil
+	}
+	n, err := anyToInt(v, field)
+	if err != nil {
+		return 0, err
+	}
+	return float64(n), nil
+}
+
+func asInt16(v any, field string) (int16, error) {
+	n, err := anyToInt(v, field)
+	if err != nil {
+		return 0, err
+	}
+	if n < math.MinInt16 || n > math.MaxInt16 {
+		return 0, fmt.Errorf("%s: %d out of int16 range", field, n)
+	}
+	return int16(n), nil
+}
+
+func asInt16Opt(v any, field string, defaultVal int16) (int16, error) {
+	if v == nil {
+		return defaultVal, nil
+	}
+	return asInt16(v, field)
+}
+
+func asInt32(v any, field string) (int32, error) {
+	n, err := anyToInt(v, field)
+	if err != nil {
+		return 0, err
+	}
+	if n < math.MinInt32 || n > math.MaxInt32 {
+		return 0, fmt.Errorf("%s: %d out of int32 range", field, n)
+	}
+	return int32(n), nil
+}
+
+func asInt32Opt(v any, field string, defaultVal int32) (int32, error) {
+	if v == nil {
+		return defaultVal, nil
+	}
+	return asInt32(v, field)
+}
+
+func asUint8(v any, field string) (uint8, error) {
+	n, err := anyToInt(v, field)
+	if err != nil {
+		return 0, err
+	}
+	if n < 0 || n > math.MaxUint8 {
+		return 0, fmt.Errorf("%s: %d out of uint8 range", field, n)
+	}
+	return uint8(n), nil
+}
+
+func asUint8Opt(v any, field string, defaultVal uint8) (uint8, error) {
+	if v == nil {
+		return defaultVal, nil
+	}
+	return asUint8(v, field)
+}
+
+func asFloat32(v any, field string) (float32, error) {
+	f, err := anyToFloat(v, field)
+	if err != nil {
+		return 0, err
+	}
+	if f > math.MaxFloat32 || f < -math.MaxFloat32 {
+		return 0, fmt.Errorf("%s: %g out of float32 range", field, f)
+	}
+	return float32(f), nil
+}
+
+func asFloat32Opt(v any, field string, defaultVal float32) (float32, error) {
+	if v == nil {
+		return defaultVal, nil
+	}
+	return asFloat32(v, field)
+}
+
+func asString(v any, field string) (string, error) {
+	if v == nil {
+		return "", nil
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("%s: expected string, got %T", field, v)
+	}
+	return s, nil
+}
+
+func asBool(v any, field string) (bool, error) {
+	if v == nil {
+		return false, nil
+	}
+	b, ok := v.(bool)
+	if !ok {
+		return false, fmt.Errorf("%s: expected boolean, got %T", field, v)
+	}
+	return b, nil
+}
+
+// ipv4ToUint32 parses canonical IP storage ("a.b.c.d" dotted-quad
+// string) into a uint32 network value per spec p.22. Matches the
+// consumer's canonicalize.go output ("1.2.3.4").
+func ipv4ToUint32(v any) (uint32, error) {
+	if v == nil {
+		return 0, fmt.Errorf("ipv4: missing value")
+	}
+	s, ok := v.(string)
+	if !ok {
+		return 0, fmt.Errorf("ipv4: expected dotted-quad string, got %T", v)
+	}
+	parts := strings.Split(s, ".")
+	if len(parts) != 4 {
+		return 0, fmt.Errorf("ipv4: %q is not a dotted-quad", s)
+	}
+	var out uint32
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 || n > 255 {
+			return 0, fmt.Errorf("ipv4: octet %d of %q invalid: %q", i, s, p)
+		}
+		out = (out << 8) | uint32(n)
+	}
+	return out, nil
+}
+
+func ipv4ToUint32Opt(v any, defaultVal uint32) (uint32, error) {
+	if v == nil {
+		return defaultVal, nil
+	}
+	return ipv4ToUint32(v)
+}

--- a/internal/provider/acp1/encoder_test.go
+++ b/internal/provider/acp1/encoder_test.go
@@ -1,0 +1,453 @@
+package acp1
+
+import (
+	"strings"
+	"testing"
+
+	"acp/internal/export/canonical"
+	iacp1 "acp/internal/protocol/acp1"
+)
+
+// TestEncodeDecodeRoundTrip asserts that every object type produced by
+// encodeObject parses cleanly through the consumer's DecodeObject and
+// the fields we set come back unchanged. This is the core correctness
+// contract between the provider and any ACP1 client.
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		entry *entry
+		check func(*testing.T, *iacp1.DecodedObject)
+	}{
+		{
+			name: "integer",
+			entry: &entry{
+				acpType: iacp1.TypeInteger,
+				access:  iacp1.AccessRead | iacp1.AccessWrite,
+				param: param("Level", canonical.ParamInteger,
+					withValue(int64(-6)),
+					withMin(int64(-60)),
+					withMax(int64(12)),
+					withStep(int64(1)),
+					withDefault(int64(0)),
+					withUnit("dB"),
+				),
+			},
+			check: func(t *testing.T, o *iacp1.DecodedObject) {
+				if o.Type != iacp1.TypeInteger {
+					t.Fatalf("type=%d want %d", o.Type, iacp1.TypeInteger)
+				}
+				if o.IntVal != -6 {
+					t.Errorf("value=%d want -6", o.IntVal)
+				}
+				if o.MinInt != -60 || o.MaxInt != 12 || o.StepInt != 1 || o.DefInt != 0 {
+					t.Errorf("range: min=%d max=%d step=%d def=%d",
+						o.MinInt, o.MaxInt, o.StepInt, o.DefInt)
+				}
+				if o.Label != "Level" {
+					t.Errorf("label=%q", o.Label)
+				}
+				if o.Unit != "dB" {
+					t.Errorf("unit=%q", o.Unit)
+				}
+				if o.Access != iacp1.AccessRead|iacp1.AccessWrite {
+					t.Errorf("access=%08b", o.Access)
+				}
+			},
+		},
+		{
+			name: "long",
+			entry: &entry{
+				acpType: iacp1.TypeLong,
+				access:  iacp1.AccessRead,
+				param: param("Counter", canonical.ParamInteger,
+					withFormat("int32"),
+					withValue(int64(1_000_000)),
+					withMin(int64(0)),
+					withMax(int64(2_000_000)),
+				),
+			},
+			check: func(t *testing.T, o *iacp1.DecodedObject) {
+				if o.Type != iacp1.TypeLong {
+					t.Fatalf("type=%d want %d", o.Type, iacp1.TypeLong)
+				}
+				if o.IntVal != 1_000_000 || o.MinInt != 0 || o.MaxInt != 2_000_000 {
+					t.Errorf("value=%d min=%d max=%d", o.IntVal, o.MinInt, o.MaxInt)
+				}
+			},
+		},
+		{
+			name: "byte",
+			entry: &entry{
+				acpType: iacp1.TypeByte,
+				access:  iacp1.AccessRead | iacp1.AccessWrite,
+				param: param("Saturation", canonical.ParamInteger,
+					withFormat("uint8"),
+					withValue(int64(128)),
+					withMin(int64(0)),
+					withMax(int64(255)),
+				),
+			},
+			check: func(t *testing.T, o *iacp1.DecodedObject) {
+				if o.Type != iacp1.TypeByte {
+					t.Fatalf("type=%d want %d", o.Type, iacp1.TypeByte)
+				}
+				if o.ByteVal != 128 || o.MinByte != 0 || o.MaxByte != 255 {
+					t.Errorf("value=%d min=%d max=%d", o.ByteVal, o.MinByte, o.MaxByte)
+				}
+			},
+		},
+		{
+			name: "float",
+			entry: &entry{
+				acpType: iacp1.TypeFloat,
+				access:  iacp1.AccessRead | iacp1.AccessWrite,
+				param: param("Frequency", canonical.ParamReal,
+					withValue(float64(440.0)),
+					withMin(float64(20.0)),
+					withMax(float64(20000.0)),
+					withStep(float64(0.5)),
+					withDefault(float64(1000.0)),
+					withUnit("Hz"),
+				),
+			},
+			check: func(t *testing.T, o *iacp1.DecodedObject) {
+				if o.Type != iacp1.TypeFloat {
+					t.Fatalf("type=%d want float", o.Type)
+				}
+				if o.FloatVal < 439.99 || o.FloatVal > 440.01 {
+					t.Errorf("value=%g want 440", o.FloatVal)
+				}
+				if o.Unit != "Hz" {
+					t.Errorf("unit=%q", o.Unit)
+				}
+			},
+		},
+		{
+			name: "ipaddr",
+			entry: &entry{
+				acpType: iacp1.TypeIPAddr,
+				access:  iacp1.AccessRead | iacp1.AccessWrite,
+				param: param("Gateway", canonical.ParamString,
+					withFormat("ipv4"),
+					withValue("192.168.1.1"),
+				),
+			},
+			check: func(t *testing.T, o *iacp1.DecodedObject) {
+				if o.Type != iacp1.TypeIPAddr {
+					t.Fatalf("type=%d want ipaddr", o.Type)
+				}
+				want := uint32(192)<<24 | uint32(168)<<16 | uint32(1)<<8 | uint32(1)
+				if uint32(o.UintVal) != want {
+					t.Errorf("value=%x want %x", o.UintVal, want)
+				}
+			},
+		},
+		{
+			name: "enum",
+			entry: &entry{
+				acpType: iacp1.TypeEnum,
+				access:  iacp1.AccessRead | iacp1.AccessWrite,
+				param: param("Mode", canonical.ParamEnum,
+					withValue(int64(2)),
+					withDefault(int64(0)),
+					withEnumMap("Off", "On", "Auto"),
+				),
+			},
+			check: func(t *testing.T, o *iacp1.DecodedObject) {
+				if o.Type != iacp1.TypeEnum {
+					t.Fatalf("type=%d want enum", o.Type)
+				}
+				if o.ByteVal != 2 || o.NumItems != 3 {
+					t.Errorf("value=%d numItems=%d", o.ByteVal, o.NumItems)
+				}
+				if strings.Join(o.EnumItems, ",") != "Off,On,Auto" {
+					t.Errorf("items=%v", o.EnumItems)
+				}
+			},
+		},
+		{
+			name: "string",
+			entry: &entry{
+				acpType: iacp1.TypeString,
+				access:  iacp1.AccessRead | iacp1.AccessWrite,
+				param: param("Label", canonical.ParamString,
+					withValue("hello"),
+					withFormat("maxLen=32"),
+				),
+			},
+			check: func(t *testing.T, o *iacp1.DecodedObject) {
+				if o.Type != iacp1.TypeString {
+					t.Fatalf("type=%d want string", o.Type)
+				}
+				if o.StrValue != "hello" {
+					t.Errorf("value=%q", o.StrValue)
+				}
+				if o.MaxLen != 32 {
+					t.Errorf("maxLen=%d", o.MaxLen)
+				}
+			},
+		},
+		{
+			name: "alarm",
+			entry: &entry{
+				acpType: iacp1.TypeAlarm,
+				access:  iacp1.AccessRead,
+				param: param("OverTemp", canonical.ParamBoolean,
+					withValue(false),
+					withFormat("alarm,priority=2,tag=17"),
+					withDescription("on: Overheat / off: OK"),
+				),
+			},
+			check: func(t *testing.T, o *iacp1.DecodedObject) {
+				if o.Type != iacp1.TypeAlarm {
+					t.Fatalf("type=%d want alarm", o.Type)
+				}
+				if o.Priority != 2 || o.Tag != 17 {
+					t.Errorf("priority=%d tag=%d", o.Priority, o.Tag)
+				}
+				if o.Label != "OverTemp" || o.EventOnMsg != "Overheat" || o.EventOffMsg != "OK" {
+					t.Errorf("label=%q on=%q off=%q", o.Label, o.EventOnMsg, o.EventOffMsg)
+				}
+			},
+		},
+		{
+			name: "file",
+			entry: &entry{
+				acpType: iacp1.TypeFile,
+				access:  iacp1.AccessRead | iacp1.AccessWrite,
+				param: param("firmware.bin", canonical.ParamString,
+					withFormat("file"),
+					withValue("firmware.bin"),
+					withDefault(int64(42)),
+				),
+			},
+			check: func(t *testing.T, o *iacp1.DecodedObject) {
+				if o.Type != iacp1.TypeFile {
+					t.Fatalf("type=%d want file", o.Type)
+				}
+				if o.FileName != "firmware.bin" {
+					t.Errorf("name=%q", o.FileName)
+				}
+				if o.NumFragments != 42 {
+					t.Errorf("fragments=%d", o.NumFragments)
+				}
+			},
+		},
+		{
+			name: "frame",
+			entry: &entry{
+				acpType: iacp1.TypeFrame,
+				access:  iacp1.AccessRead,
+				param: param("slotStatus", canonical.ParamOctets,
+					withFormat("frame"),
+					withValue([]any{int64(2), int64(2), int64(0), int64(3)}),
+				),
+			},
+			check: func(t *testing.T, o *iacp1.DecodedObject) {
+				if o.Type != iacp1.TypeFrame {
+					t.Fatalf("type=%d want frame", o.Type)
+				}
+				if o.NumSlots != 4 {
+					t.Errorf("numSlots=%d", o.NumSlots)
+				}
+				if len(o.SlotStatus) != 4 || o.SlotStatus[0] != 2 || o.SlotStatus[3] != 3 {
+					t.Errorf("status=%v", o.SlotStatus)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := encodeObject(tc.entry)
+			if err != nil {
+				t.Fatalf("encode: %v", err)
+			}
+			o, err := iacp1.DecodeObject(raw)
+			if err != nil {
+				t.Fatalf("decode %q: %v", hexString(raw), err)
+			}
+			tc.check(t, o)
+		})
+	}
+}
+
+// TestEncodeValue exercises the getValue-reply codec for each type.
+func TestEncodeValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		entry   *entry
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name: "int16 positive",
+			entry: &entry{acpType: iacp1.TypeInteger, param: param("v", canonical.ParamInteger, withValue(int64(300)))},
+			want: []byte{0x01, 0x2C},
+		},
+		{
+			name: "int16 negative",
+			entry: &entry{acpType: iacp1.TypeInteger, param: param("v", canonical.ParamInteger, withValue(int64(-1)))},
+			want: []byte{0xFF, 0xFF},
+		},
+		{
+			name: "byte",
+			entry: &entry{acpType: iacp1.TypeByte, param: param("v", canonical.ParamInteger, withFormat("uint8"), withValue(int64(200)))},
+			want: []byte{0xC8},
+		},
+		{
+			name: "long",
+			entry: &entry{acpType: iacp1.TypeLong, param: param("v", canonical.ParamInteger, withFormat("int32"), withValue(int64(1_000_000)))},
+			want: []byte{0x00, 0x0F, 0x42, 0x40},
+		},
+		{
+			name: "ipaddr",
+			entry: &entry{acpType: iacp1.TypeIPAddr, param: param("v", canonical.ParamString, withFormat("ipv4"), withValue("10.0.0.1"))},
+			want: []byte{0x0A, 0x00, 0x00, 0x01},
+		},
+		{
+			name: "enum",
+			entry: &entry{acpType: iacp1.TypeEnum, param: param("v", canonical.ParamEnum, withValue(int64(1)))},
+			want: []byte{0x01},
+		},
+		{
+			name: "string",
+			entry: &entry{acpType: iacp1.TypeString, param: param("v", canonical.ParamString, withValue("hi"))},
+			want: []byte{'h', 'i', 0},
+		},
+		{
+			name: "alarm active",
+			entry: &entry{acpType: iacp1.TypeAlarm, param: param("v", canonical.ParamBoolean, withFormat("alarm"), withValue(true))},
+			want: []byte{0x01},
+		},
+		{
+			name: "frame",
+			entry: &entry{acpType: iacp1.TypeFrame, param: param("v", canonical.ParamOctets, withFormat("frame"), withValue([]any{int64(2), int64(0), int64(2)}))},
+			want: []byte{0x03, 0x02, 0x00, 0x02},
+		},
+		{
+			name:    "overflow int16",
+			entry:   &entry{acpType: iacp1.TypeInteger, param: param("v", canonical.ParamInteger, withValue(int64(40000)))},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := encodeValue(tc.entry)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got bytes %x", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("encodeValue: %v", err)
+			}
+			if !bytesEqual(got, tc.want) {
+				t.Fatalf("bytes=%x want %x", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDeriveACPType covers the strict canonical -> ACP1 type mapping.
+func TestDeriveACPType(t *testing.T) {
+	cases := []struct {
+		name   string
+		p      *canonical.Parameter
+		want   iacp1.ObjectType
+		wantOK bool
+	}{
+		{"integer default", param("x", canonical.ParamInteger), iacp1.TypeInteger, true},
+		{"integer int32", param("x", canonical.ParamInteger, withFormat("int32")), iacp1.TypeLong, true},
+		{"integer uint8", param("x", canonical.ParamInteger, withFormat("uint8")), iacp1.TypeByte, true},
+		{"integer bad", param("x", canonical.ParamInteger, withFormat("uint16")), 0, false},
+		{"real", param("x", canonical.ParamReal), iacp1.TypeFloat, true},
+		{"enum", param("x", canonical.ParamEnum), iacp1.TypeEnum, true},
+		{"string default", param("x", canonical.ParamString), iacp1.TypeString, true},
+		{"ipv4", param("x", canonical.ParamString, withFormat("ipv4")), iacp1.TypeIPAddr, true},
+		{"file", param("x", canonical.ParamString, withFormat("file")), iacp1.TypeFile, true},
+		{"alarm", param("x", canonical.ParamBoolean, withFormat("alarm")), iacp1.TypeAlarm, true},
+		{"boolean no hint REJECTED", param("x", canonical.ParamBoolean), 0, false},
+		{"frame", param("x", canonical.ParamOctets, withFormat("frame")), iacp1.TypeFrame, true},
+		{"octets no hint REJECTED", param("x", canonical.ParamOctets), 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := deriveACPType(tc.p)
+			if tc.wantOK {
+				if err != nil {
+					t.Fatalf("err=%v", err)
+				}
+				if got != tc.want {
+					t.Fatalf("got %d want %d", got, tc.want)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("want error, got type %d", got)
+			}
+		})
+	}
+}
+
+// ------------------------------------------------------- test helpers
+
+type paramOpt func(p *canonical.Parameter)
+
+func param(ident, typ string, opts ...paramOpt) *canonical.Parameter {
+	p := &canonical.Parameter{
+		Header: canonical.Header{
+			Identifier: ident,
+			IsOnline:   true,
+			Access:     canonical.AccessReadWrite,
+			Children:   canonical.EmptyChildren(),
+		},
+		Type: typ,
+	}
+	for _, o := range opts {
+		o(p)
+	}
+	return p
+}
+
+func withValue(v any) paramOpt       { return func(p *canonical.Parameter) { p.Value = v } }
+func withDefault(v any) paramOpt     { return func(p *canonical.Parameter) { p.Default = v } }
+func withMin(v any) paramOpt         { return func(p *canonical.Parameter) { p.Minimum = v } }
+func withMax(v any) paramOpt         { return func(p *canonical.Parameter) { p.Maximum = v } }
+func withStep(v any) paramOpt        { return func(p *canonical.Parameter) { p.Step = v } }
+func withUnit(s string) paramOpt     { return func(p *canonical.Parameter) { p.Unit = &s } }
+func withFormat(s string) paramOpt   { return func(p *canonical.Parameter) { p.Format = &s } }
+func withDescription(s string) paramOpt {
+	return func(p *canonical.Parameter) { p.Description = &s }
+}
+func withEnumMap(items ...string) paramOpt {
+	return func(p *canonical.Parameter) {
+		p.EnumMap = make([]canonical.EnumEntry, len(items))
+		for i, item := range items {
+			p.EnumMap[i] = canonical.EnumEntry{Key: item, Value: int64(i)}
+		}
+	}
+}
+
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func hexString(b []byte) string {
+	const hex = "0123456789abcdef"
+	out := make([]byte, 0, len(b)*2)
+	for _, x := range b {
+		out = append(out, hex[x>>4], hex[x&0x0f])
+	}
+	return string(out)
+}

--- a/internal/provider/acp1/plugin.go
+++ b/internal/provider/acp1/plugin.go
@@ -1,0 +1,51 @@
+// Package acp1 is the ACP1 provider plugin — it serves a canonical
+// tree.json as an AxonNet ACP1 device over UDP (Mode A per CLAUDE.md).
+//
+// Symmetric to the consumer plugin at internal/protocol/acp1. Reuses
+// that package's Message codec, value codec, and type constants; adds
+// a property encoder (reverse of property.go's DecodeObject) and a
+// session dispatcher.
+//
+// Layering:
+//
+//	tree.go      canonical.Export -> (slot, group, id)-indexed snapshot
+//	encoder.go   DecodedObject + type -> wire bytes for getObject reply
+//	value.go     typed canonical.Parameter value -> bytes for getValue / setX reply
+//	session.go   per-datagram dispatch (getValue / setValue / setInc /
+//	             setDec / setDef / getObject), error-reply emission
+//	server.go    UDP accept loop, broadcast announcement fan-out
+//	plugin.go    (this file) Factory + registration
+package acp1
+
+import (
+	"log/slog"
+
+	"acp/internal/export/canonical"
+	"acp/internal/provider"
+	iacp1 "acp/internal/protocol/acp1"
+)
+
+// DefaultPort is the IANA-assigned ACP port for both UDP and TCP direct.
+// Matches the consumer plugin's default.
+const DefaultPort = iacp1.DefaultPort
+
+func init() {
+	provider.Register(&Factory{})
+}
+
+// Factory registers the ACP1 provider plugin with the compile-time registry.
+type Factory struct{}
+
+// Meta publishes the static descriptor used by the CLI + API.
+func (f *Factory) Meta() provider.Meta {
+	return provider.Meta{
+		Name:        "acp1",
+		DefaultPort: DefaultPort,
+		Description: "ACP1 (AxonNet) provider — serves a canonical tree to consumers over UDP:2071",
+	}
+}
+
+// New constructs a fresh provider around the supplied tree.
+func (f *Factory) New(logger *slog.Logger, tree *canonical.Export) provider.Provider {
+	return newServer(logger, tree)
+}

--- a/internal/provider/acp1/server.go
+++ b/internal/provider/acp1/server.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"acp/internal/export/canonical"
+	iacp1 "acp/internal/protocol/acp1"
 )
 
 // server is the concrete provider.Provider for ACP1 over UDP. One
@@ -107,9 +108,11 @@ func (s *server) Stop() error {
 	return nil
 }
 
-// SetValue mutates the served tree and (later) fans the change out.
-// Skeleton: currently only validates the path — session.go will wire
-// the actual value mutation + announcement in a follow-up commit.
+// SetValue mutates the served tree via the API path (acp-srv, tests).
+// Routes through the same applyMutation pipeline used by wire SetValue
+// requests so clamping + canonical.Parameter.Value update are
+// consistent. The value-change announcement broadcast ships in the
+// follow-up commit (Step 1e).
 func (s *server) SetValue(_ context.Context, path string, val any) (any, error) {
 	key, err := parsePath(path)
 	if err != nil {
@@ -119,9 +122,20 @@ func (s *server) SetValue(_ context.Context, path string, val any) (any, error) 
 	if !ok {
 		return nil, fmt.Errorf("acp1 provider: object not found: %s", path)
 	}
-	_ = e
-	_ = val
-	return nil, errors.New("acp1 provider: SetValue not yet implemented")
+	if e.access&1 == 0 {
+		return nil, fmt.Errorf("acp1 provider: %s has no read access", path)
+	}
+	if e.access&2 == 0 {
+		return nil, fmt.Errorf("acp1 provider: %s has no write access", path)
+	}
+	bytes, err := s.encodeIncomingFromAny(e, val)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := s.applyMutation(e, iacp1.MethodSetValue, bytes); err != nil {
+		return nil, err
+	}
+	return convertStoredValue(e.param), nil
 }
 
 // readLoop reads datagrams until ctx is cancelled or the conn is closed.

--- a/internal/provider/acp1/server.go
+++ b/internal/provider/acp1/server.go
@@ -125,8 +125,7 @@ func (s *server) SetValue(_ context.Context, path string, val any) (any, error) 
 }
 
 // readLoop reads datagrams until ctx is cancelled or the conn is closed.
-// Each message is dispatched inline. Session.go owns the dispatch logic;
-// this file only does transport.
+// Each message is dispatched inline through session.go's handleRequest.
 func (s *server) readLoop(ctx context.Context, conn *net.UDPConn) error {
 	buf := make([]byte, 1500) // covers the 141-byte ACP1 max + headroom
 	for {
@@ -140,17 +139,11 @@ func (s *server) readLoop(ctx context.Context, conn *net.UDPConn) error {
 		if n == 0 {
 			continue
 		}
-		s.handleDatagram(conn, src, append([]byte(nil), buf[:n]...))
+		data := append([]byte(nil), buf[:n]...)
+		send := func(out []byte) error {
+			_, err := conn.WriteToUDP(out, src)
+			return err
+		}
+		s.handleDatagram2(data, src.String(), send)
 	}
-}
-
-// handleDatagram is the per-request entry point. Implemented in session.go
-// so encoder.go / value.go can stay focused.
-func (s *server) handleDatagram(conn *net.UDPConn, src *net.UDPAddr, data []byte) {
-	// Stub: log-and-drop until session.go lands in the next commit.
-	s.logger.Debug("acp1 provider: received datagram (dispatch not yet wired)",
-		slog.String("src", src.String()),
-		slog.Int("bytes", len(data)),
-	)
-	_ = conn
 }

--- a/internal/provider/acp1/server.go
+++ b/internal/provider/acp1/server.go
@@ -1,0 +1,156 @@
+package acp1
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"sync"
+
+	"acp/internal/export/canonical"
+)
+
+// server is the concrete provider.Provider for ACP1 over UDP. One
+// datagram in -> dispatch -> one datagram out, plus broadcast announce
+// on successful mutating methods.
+//
+// Concurrency model:
+//   - Serve runs a single read loop (ReadFromUDP is goroutine-unsafe on
+//     some platforms anyway). Each inbound datagram is dispatched inline
+//     — ACP1 messages are fixed-tiny (<=141 bytes) and all work is in-
+//     process so a serial handler is well within budget.
+//   - Announcements are sent from the same goroutine right after the
+//     reply so consumer-visible ordering is always (reply, announce).
+//   - SetValue() is called from the embedding API (acp-srv) off-thread;
+//     it grabs tree.mu for the mutation then enqueues an announce.
+type server struct {
+	logger *slog.Logger
+	tree   *tree
+
+	mu      sync.Mutex
+	conn    *net.UDPConn
+	closed  bool
+	stopped chan struct{}
+}
+
+func newServer(logger *slog.Logger, exp *canonical.Export) *server {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	s := &server{
+		logger:  logger,
+		stopped: make(chan struct{}),
+	}
+	t, err := newTree(exp)
+	if err != nil {
+		logger.Error("acp1 provider: tree build failed", "err", err.Error())
+		// Surface later: Serve will fail fast with the same error.
+		s.tree = &tree{entries: map[objectKey]*entry{}, slots: map[uint8]*slotCounts{}}
+		return s
+	}
+	s.tree = t
+	return s
+}
+
+// Serve binds addr (e.g. "0.0.0.0:2071") and runs until ctx is cancelled
+// or a fatal listen error occurs.
+func (s *server) Serve(ctx context.Context, addr string) error {
+	udpAddr, err := net.ResolveUDPAddr("udp4", addr)
+	if err != nil {
+		return fmt.Errorf("acp1 provider: resolve %q: %w", addr, err)
+	}
+	conn, err := net.ListenUDP("udp4", udpAddr)
+	if err != nil {
+		return fmt.Errorf("acp1 provider: listen %q: %w", addr, err)
+	}
+
+	s.mu.Lock()
+	s.conn = conn
+	s.mu.Unlock()
+
+	s.logger.Info("acp1 provider listening",
+		slog.String("addr", conn.LocalAddr().String()),
+		slog.Int("objects", len(s.tree.entries)),
+	)
+
+	// Close the socket when ctx goes away; unblocks the read loop.
+	go func() {
+		<-ctx.Done()
+		s.mu.Lock()
+		if !s.closed {
+			s.closed = true
+			_ = conn.Close()
+		}
+		s.mu.Unlock()
+	}()
+
+	err = s.readLoop(ctx, conn)
+	close(s.stopped)
+	if errors.Is(err, net.ErrClosed) || errors.Is(err, context.Canceled) {
+		return nil
+	}
+	return err
+}
+
+// Stop closes the listening socket. Safe to call multiple times.
+func (s *server) Stop() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	if s.conn != nil {
+		return s.conn.Close()
+	}
+	return nil
+}
+
+// SetValue mutates the served tree and (later) fans the change out.
+// Skeleton: currently only validates the path — session.go will wire
+// the actual value mutation + announcement in a follow-up commit.
+func (s *server) SetValue(_ context.Context, path string, val any) (any, error) {
+	key, err := parsePath(path)
+	if err != nil {
+		return nil, err
+	}
+	e, ok := s.tree.lookup(key)
+	if !ok {
+		return nil, fmt.Errorf("acp1 provider: object not found: %s", path)
+	}
+	_ = e
+	_ = val
+	return nil, errors.New("acp1 provider: SetValue not yet implemented")
+}
+
+// readLoop reads datagrams until ctx is cancelled or the conn is closed.
+// Each message is dispatched inline. Session.go owns the dispatch logic;
+// this file only does transport.
+func (s *server) readLoop(ctx context.Context, conn *net.UDPConn) error {
+	buf := make([]byte, 1500) // covers the 141-byte ACP1 max + headroom
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		n, src, err := conn.ReadFromUDP(buf)
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			continue
+		}
+		s.handleDatagram(conn, src, append([]byte(nil), buf[:n]...))
+	}
+}
+
+// handleDatagram is the per-request entry point. Implemented in session.go
+// so encoder.go / value.go can stay focused.
+func (s *server) handleDatagram(conn *net.UDPConn, src *net.UDPAddr, data []byte) {
+	// Stub: log-and-drop until session.go lands in the next commit.
+	s.logger.Debug("acp1 provider: received datagram (dispatch not yet wired)",
+		slog.String("src", src.String()),
+		slog.Int("bytes", len(data)),
+	)
+	_ = conn
+}

--- a/internal/provider/acp1/server.go
+++ b/internal/provider/acp1/server.go
@@ -30,7 +30,8 @@ type server struct {
 	tree   *tree
 
 	mu      sync.Mutex
-	conn    *net.UDPConn
+	conn    *net.UDPConn // listener + unicast reply socket
+	bcast   *net.UDPConn // separate socket dialed to 255.255.255.255
 	closed  bool
 	stopped chan struct{}
 }
@@ -66,22 +67,41 @@ func (s *server) Serve(ctx context.Context, addr string) error {
 		return fmt.Errorf("acp1 provider: listen %q: %w", addr, err)
 	}
 
+	// Dial a second socket to the limited broadcast address. Go stdlib
+	// auto-sets SO_BROADCAST on dialed sockets with broadcast peers,
+	// which is the portable path across Windows / Linux / macOS.
+	bcastAddr := &net.UDPAddr{IP: net.IPv4bcast, Port: udpAddr.Port}
+	bconn, bErr := net.DialUDP("udp4", nil, bcastAddr)
+	// Best-effort: if the OS rejects the broadcast dial (no route, no
+	// iface up) we log and continue without announcements.
+	if bErr != nil {
+		s.logger.Warn("acp1 provider: broadcast disabled",
+			slog.String("err", bErr.Error()),
+			slog.String("addr", bcastAddr.String()),
+		)
+	}
+
 	s.mu.Lock()
 	s.conn = conn
+	s.bcast = bconn
 	s.mu.Unlock()
 
 	s.logger.Info("acp1 provider listening",
 		slog.String("addr", conn.LocalAddr().String()),
+		slog.String("broadcast", bcastAddr.String()),
 		slog.Int("objects", len(s.tree.entries)),
 	)
 
-	// Close the socket when ctx goes away; unblocks the read loop.
+	// Close both sockets when ctx goes away; unblocks the read loop.
 	go func() {
 		<-ctx.Done()
 		s.mu.Lock()
 		if !s.closed {
 			s.closed = true
 			_ = conn.Close()
+			if s.bcast != nil {
+				_ = s.bcast.Close()
+			}
 		}
 		s.mu.Unlock()
 	}()
@@ -94,7 +114,8 @@ func (s *server) Serve(ctx context.Context, addr string) error {
 	return err
 }
 
-// Stop closes the listening socket. Safe to call multiple times.
+// Stop closes the listening and broadcast sockets. Safe to call
+// multiple times.
 func (s *server) Stop() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -102,10 +123,14 @@ func (s *server) Stop() error {
 		return nil
 	}
 	s.closed = true
+	var err error
 	if s.conn != nil {
-		return s.conn.Close()
+		err = s.conn.Close()
 	}
-	return nil
+	if s.bcast != nil {
+		_ = s.bcast.Close()
+	}
+	return err
 }
 
 // SetValue mutates the served tree via the API path (acp-srv, tests).
@@ -136,6 +161,32 @@ func (s *server) SetValue(_ context.Context, path string, val any) (any, error) 
 		return nil, err
 	}
 	return convertStoredValue(e.param), nil
+}
+
+// broadcastAnnounce serialises an announcement message and sends it to
+// the LAN limited-broadcast address. Called after every successful
+// mutating method per spec §"Announcements" p.14. Silent on send error
+// — announcements are fire-and-forget, and the consumer that made the
+// setX call already has the change confirmed via the reply.
+func (s *server) broadcastAnnounce(ann *iacp1.Message) {
+	s.mu.Lock()
+	bc := s.bcast
+	s.mu.Unlock()
+	if bc == nil {
+		return
+	}
+	out, err := ann.Encode()
+	if err != nil {
+		s.logger.Warn("acp1 announce encode",
+			slog.String("err", err.Error()),
+		)
+		return
+	}
+	if _, err := bc.Write(out); err != nil {
+		s.logger.Debug("acp1 announce send",
+			slog.String("err", err.Error()),
+		)
+	}
 }
 
 // readLoop reads datagrams until ctx is cancelled or the conn is closed.

--- a/internal/provider/acp1/session.go
+++ b/internal/provider/acp1/session.go
@@ -1,0 +1,245 @@
+package acp1
+
+import (
+	"log/slog"
+
+	iacp1 "acp/internal/protocol/acp1"
+)
+
+// handleRequest dispatches a decoded request message to the right
+// handler and returns the reply message (ready for Encode). The
+// function is pure in the sense that it never writes to the network;
+// the caller is responsible for socket I/O. Read-only methods
+// (getValue, getObject) leave the tree untouched; mutating methods
+// lock tree.mu for the duration of their handler.
+//
+// Returns nil if the message should be silently dropped (non-request
+// messages, including announcements from other providers).
+func (s *server) handleRequest(msg *iacp1.Message) *iacp1.Message {
+	if msg.MType != iacp1.MTypeRequest {
+		return nil
+	}
+
+	// Spec p.21: Root object is [group=0, id=0]. We synthesise it from
+	// per-slot counters rather than storing a canonical Parameter — the
+	// canonical tree's slot Nodes carry the shape, not a "root" leaf.
+	if msg.ObjGroup == iacp1.GroupRoot && msg.ObjID == 0 {
+		return s.handleRoot(msg)
+	}
+
+	key := objectKey{slot: msg.MAddr, group: msg.ObjGroup, id: msg.ObjID}
+	e, ok := s.tree.lookup(key)
+	if !ok {
+		// Spec p.29 error codes: distinguish missing group vs missing
+		// instance. If the slot/group exists but the id doesn't, it's
+		// OErrInstanceNoExist (17); if the group has no objects at all
+		// on this slot, OErrGroupNoExist (16).
+		return errorReply(msg, groupOrInstanceMissing(s, key))
+	}
+
+	method := iacp1.Method(msg.MCode)
+	if !methodSupported(e.acpType, method) {
+		return errorReply(msg, iacp1.OErrIllegalForType)
+	}
+	if err := checkAccess(e.access, method); err != 0 {
+		return errorReply(msg, err)
+	}
+
+	switch method {
+	case iacp1.MethodGetValue:
+		raw, err := encodeValue(e)
+		if err != nil {
+			s.logger.Error("getValue encode", slog.String("oid", e.param.OID), slog.String("err", err.Error()))
+			return errorReply(msg, iacp1.OErrIllegalForType)
+		}
+		return reply(msg, raw)
+	case iacp1.MethodGetObject:
+		raw, err := encodeObject(e)
+		if err != nil {
+			s.logger.Error("getObject encode", slog.String("oid", e.param.OID), slog.String("err", err.Error()))
+			return errorReply(msg, iacp1.OErrIllegalForType)
+		}
+		return reply(msg, raw)
+	}
+	// Mutating methods (setValue, setInc, setDec, setDef) land in the
+	// next commit. For now surface as illegal-method.
+	return errorReply(msg, iacp1.OErrIllegalMethod)
+}
+
+// handleRoot synthesises the Root (group=0, id=0) reply for the
+// requested slot. Real Axon cards answer Root for their own slot with
+// the per-slot object counters; we do the same from tree.slots.
+func (s *server) handleRoot(msg *iacp1.Message) *iacp1.Message {
+	s.tree.mu.RLock()
+	counts, ok := s.tree.slots[msg.MAddr]
+	s.tree.mu.RUnlock()
+	if !ok {
+		return errorReply(msg, iacp1.OErrInstanceNoExist)
+	}
+
+	switch iacp1.Method(msg.MCode) {
+	case iacp1.MethodGetValue:
+		// Spec p.21: Root.getValue returns the single "boot_mode" byte.
+		// We report boot_mode=0 (normal operation). Firmware-upgrade
+		// mode (1) is out of scope for the provider.
+		return reply(msg, []byte{0})
+	case iacp1.MethodGetObject:
+		return reply(msg, encodeRootObject(counts))
+	}
+	return errorReply(msg, iacp1.OErrIllegalMethod)
+}
+
+// encodeRootObject builds the 9-property getObject reply for the Root
+// object. Spec p.21 order: access, boot_mode, num_identity,
+// num_control, num_status, num_alarm, num_file.
+func encodeRootObject(c *slotCounts) []byte {
+	return []byte{
+		byte(iacp1.TypeRoot),        // object_type
+		9,                           // num_properties
+		iacp1.AccessRead,            // access — Root is always read-only
+		0,                           // boot_mode
+		c.numIdentity,               // num_identity
+		c.numControl,                // num_control
+		c.numStatus,                 // num_status
+		c.numAlarm,                  // num_alarm
+		c.numFile,                   // num_file
+	}
+}
+
+// reply builds a successful reply message mirroring the request's
+// MTID, slot (MAddr), method (MCode), and object addressing. Per spec
+// the reply MUST carry the same MTID so the client can correlate.
+func reply(req *iacp1.Message, value []byte) *iacp1.Message {
+	return &iacp1.Message{
+		MTID:     req.MTID,
+		MType:    iacp1.MTypeReply,
+		MAddr:    req.MAddr,
+		MCode:    req.MCode,
+		ObjGroup: req.ObjGroup,
+		ObjID:    req.ObjID,
+		Value:    value,
+	}
+}
+
+// errorReply builds an MType=Error message with the given MCODE. Spec
+// p.29 says the device MAY echo ObjGroup/ObjID on errors; we do so
+// since the C# reference driver relies on that echo for context.
+// Encode() writes only the MCode byte for Error messages — ObjGroup/
+// ObjID are ignored on the wire — but keeping them set helps any
+// middleware that inspects the struct.
+func errorReply(req *iacp1.Message, code iacp1.ObjectErrCode) *iacp1.Message {
+	return &iacp1.Message{
+		MTID:     req.MTID,
+		MType:    iacp1.MTypeError,
+		MAddr:    req.MAddr,
+		MCode:    byte(code),
+		ObjGroup: req.ObjGroup,
+		ObjID:    req.ObjID,
+	}
+}
+
+// methodSupported implements the spec "Method Support Matrix" (CLAUDE.md
+// under §ACP1 Method Support Matrix). Ensures we emit OErrIllegalForType
+// rather than crashing on e.g. setIncValue of an Alarm.
+func methodSupported(t iacp1.ObjectType, m iacp1.Method) bool {
+	switch t {
+	case iacp1.TypeRoot:
+		return m == iacp1.MethodGetValue || m == iacp1.MethodGetObject
+	case iacp1.TypeInteger, iacp1.TypeLong, iacp1.TypeFloat, iacp1.TypeByte, iacp1.TypeIPAddr:
+		// Numeric-with-step types support all six methods.
+		return true
+	case iacp1.TypeEnum:
+		// No inc/dec on enums (no step).
+		switch m {
+		case iacp1.MethodGetValue, iacp1.MethodSetValue,
+			iacp1.MethodSetDefValue, iacp1.MethodGetObject:
+			return true
+		}
+		return false
+	case iacp1.TypeString:
+		// No inc/dec/setDef on strings.
+		switch m {
+		case iacp1.MethodGetValue, iacp1.MethodSetValue, iacp1.MethodGetObject:
+			return true
+		}
+		return false
+	case iacp1.TypeAlarm, iacp1.TypeFile, iacp1.TypeFrame:
+		return m == iacp1.MethodGetValue || m == iacp1.MethodGetObject
+	}
+	return false
+}
+
+// checkAccess maps the requested method to the access bit required by
+// spec p.20 and returns 0 if the entry grants it, or the appropriate
+// OErrNo*Access code otherwise.
+func checkAccess(access uint8, m iacp1.Method) iacp1.ObjectErrCode {
+	switch m {
+	case iacp1.MethodGetValue, iacp1.MethodGetObject:
+		if access&iacp1.AccessRead == 0 {
+			return iacp1.OErrNoReadAccess
+		}
+	case iacp1.MethodSetValue, iacp1.MethodSetIncValue, iacp1.MethodSetDecValue:
+		if access&iacp1.AccessWrite == 0 {
+			return iacp1.OErrNoWriteAccess
+		}
+	case iacp1.MethodSetDefValue:
+		if access&iacp1.AccessSetDef == 0 {
+			return iacp1.OErrNoSetDefAccess
+		}
+	default:
+		return iacp1.OErrIllegalMethod
+	}
+	return 0
+}
+
+// groupOrInstanceMissing distinguishes between a totally absent group
+// on this slot (spec code 16) and an unknown id within an existing
+// group (spec code 17). Walk the flat index once looking for any entry
+// matching slot+group — cheap at the 2-3k-object scale a real frame
+// carries.
+func groupOrInstanceMissing(s *server, k objectKey) iacp1.ObjectErrCode {
+	s.tree.mu.RLock()
+	defer s.tree.mu.RUnlock()
+	for key := range s.tree.entries {
+		if key.slot == k.slot && key.group == k.group {
+			return iacp1.OErrInstanceNoExist
+		}
+	}
+	return iacp1.OErrGroupNoExist
+}
+
+// -----------------------------------------------------------------
+// UDP plumbing — handleDatagram is called by server.readLoop.
+
+// handleDatagram decodes the incoming bytes, dispatches via
+// handleRequest, and writes the reply back to src. Decode failures are
+// logged and dropped — the spec has no "bad-framing" reply.
+func (s *server) handleDatagram2(data []byte, srcStr string, send func([]byte) error) {
+	msg, err := iacp1.Decode(data)
+	if err != nil {
+		s.logger.Debug("acp1 provider: decode failed",
+			slog.String("src", srcStr),
+			slog.String("err", err.Error()),
+		)
+		return
+	}
+	rep := s.handleRequest(msg)
+	if rep == nil {
+		return
+	}
+	out, err := rep.Encode()
+	if err != nil {
+		s.logger.Error("acp1 provider: reply encode",
+			slog.String("err", err.Error()),
+			slog.String("src", srcStr),
+		)
+		return
+	}
+	if err := send(out); err != nil {
+		s.logger.Warn("acp1 provider: reply send",
+			slog.String("err", err.Error()),
+			slog.String("src", srcStr),
+		)
+	}
+}
+

--- a/internal/provider/acp1/session.go
+++ b/internal/provider/acp1/session.go
@@ -60,10 +60,39 @@ func (s *server) handleRequest(msg *iacp1.Message) *iacp1.Message {
 			return errorReply(msg, iacp1.OErrIllegalForType)
 		}
 		return reply(msg, raw)
+	case iacp1.MethodSetValue, iacp1.MethodSetIncValue,
+		iacp1.MethodSetDecValue, iacp1.MethodSetDefValue:
+		raw, err := s.applyMutation(e, method, msg.Value)
+		if err != nil {
+			s.logger.Warn("acp1 mutation",
+				slog.String("oid", e.param.OID),
+				slog.String("method", methodName(method)),
+				slog.String("err", err.Error()),
+			)
+			return errorReply(msg, iacp1.OErrIllegalForType)
+		}
+		return reply(msg, raw)
 	}
-	// Mutating methods (setValue, setInc, setDec, setDef) land in the
-	// next commit. For now surface as illegal-method.
 	return errorReply(msg, iacp1.OErrIllegalMethod)
+}
+
+// methodName is a small helper so debug logs read "setValue" not "1".
+func methodName(m iacp1.Method) string {
+	switch m {
+	case iacp1.MethodGetValue:
+		return "getValue"
+	case iacp1.MethodSetValue:
+		return "setValue"
+	case iacp1.MethodSetIncValue:
+		return "setIncValue"
+	case iacp1.MethodSetDecValue:
+		return "setDecValue"
+	case iacp1.MethodSetDefValue:
+		return "setDefValue"
+	case iacp1.MethodGetObject:
+		return "getObject"
+	}
+	return "unknown"
 }
 
 // handleRoot synthesises the Root (group=0, id=0) reply for the

--- a/internal/provider/acp1/session.go
+++ b/internal/provider/acp1/session.go
@@ -6,43 +6,38 @@ import (
 	iacp1 "acp/internal/protocol/acp1"
 )
 
-// handleRequest dispatches a decoded request message to the right
-// handler and returns the reply message (ready for Encode). The
-// function is pure in the sense that it never writes to the network;
-// the caller is responsible for socket I/O. Read-only methods
-// (getValue, getObject) leave the tree untouched; mutating methods
-// lock tree.mu for the duration of their handler.
+// handleRequest dispatches a decoded request to the right handler and
+// returns (reply, announce). Reply is what we send back to the caller.
+// Announce is non-nil only after a successful mutation, in which case
+// it is the MTID=0 broadcast the wire I/O layer should fan out to the
+// LAN (spec §"Announcements", p.14 Reply Matrix row "MType=2 MTID=0").
 //
-// Returns nil if the message should be silently dropped (non-request
-// messages, including announcements from other providers).
-func (s *server) handleRequest(msg *iacp1.Message) *iacp1.Message {
+// Pure in the I/O sense — this function never touches the socket; the
+// caller is responsible for framing and sending both messages.
+//
+// Returns (nil, nil) for messages that should be silently dropped
+// (announcements and replies from other providers, error messages).
+func (s *server) handleRequest(msg *iacp1.Message) (*iacp1.Message, *iacp1.Message) {
 	if msg.MType != iacp1.MTypeRequest {
-		return nil
+		return nil, nil
 	}
 
-	// Spec p.21: Root object is [group=0, id=0]. We synthesise it from
-	// per-slot counters rather than storing a canonical Parameter — the
-	// canonical tree's slot Nodes carry the shape, not a "root" leaf.
 	if msg.ObjGroup == iacp1.GroupRoot && msg.ObjID == 0 {
-		return s.handleRoot(msg)
+		return s.handleRoot(msg), nil
 	}
 
 	key := objectKey{slot: msg.MAddr, group: msg.ObjGroup, id: msg.ObjID}
 	e, ok := s.tree.lookup(key)
 	if !ok {
-		// Spec p.29 error codes: distinguish missing group vs missing
-		// instance. If the slot/group exists but the id doesn't, it's
-		// OErrInstanceNoExist (17); if the group has no objects at all
-		// on this slot, OErrGroupNoExist (16).
-		return errorReply(msg, groupOrInstanceMissing(s, key))
+		return errorReply(msg, groupOrInstanceMissing(s, key)), nil
 	}
 
 	method := iacp1.Method(msg.MCode)
 	if !methodSupported(e.acpType, method) {
-		return errorReply(msg, iacp1.OErrIllegalForType)
+		return errorReply(msg, iacp1.OErrIllegalForType), nil
 	}
 	if err := checkAccess(e.access, method); err != 0 {
-		return errorReply(msg, err)
+		return errorReply(msg, err), nil
 	}
 
 	switch method {
@@ -50,16 +45,16 @@ func (s *server) handleRequest(msg *iacp1.Message) *iacp1.Message {
 		raw, err := encodeValue(e)
 		if err != nil {
 			s.logger.Error("getValue encode", slog.String("oid", e.param.OID), slog.String("err", err.Error()))
-			return errorReply(msg, iacp1.OErrIllegalForType)
+			return errorReply(msg, iacp1.OErrIllegalForType), nil
 		}
-		return reply(msg, raw)
+		return reply(msg, raw), nil
 	case iacp1.MethodGetObject:
 		raw, err := encodeObject(e)
 		if err != nil {
 			s.logger.Error("getObject encode", slog.String("oid", e.param.OID), slog.String("err", err.Error()))
-			return errorReply(msg, iacp1.OErrIllegalForType)
+			return errorReply(msg, iacp1.OErrIllegalForType), nil
 		}
-		return reply(msg, raw)
+		return reply(msg, raw), nil
 	case iacp1.MethodSetValue, iacp1.MethodSetIncValue,
 		iacp1.MethodSetDecValue, iacp1.MethodSetDefValue:
 		raw, err := s.applyMutation(e, method, msg.Value)
@@ -69,11 +64,28 @@ func (s *server) handleRequest(msg *iacp1.Message) *iacp1.Message {
 				slog.String("method", methodName(method)),
 				slog.String("err", err.Error()),
 			)
-			return errorReply(msg, iacp1.OErrIllegalForType)
+			return errorReply(msg, iacp1.OErrIllegalForType), nil
 		}
-		return reply(msg, raw)
+		return reply(msg, raw), announce(msg, raw)
 	}
-	return errorReply(msg, iacp1.OErrIllegalMethod)
+	return errorReply(msg, iacp1.OErrIllegalMethod), nil
+}
+
+// announce builds the unsolicited value-change announcement that every
+// successful set* method must broadcast per spec §"Announcements" p.14.
+//
+// Shape: MTID=0 (announcement marker), MType=2 (Reply), MCode=set*,
+// MAddr=slot, ObjGroup/ObjID=changed object, Value=new stored bytes.
+func announce(req *iacp1.Message, value []byte) *iacp1.Message {
+	return &iacp1.Message{
+		MTID:     0,
+		MType:    iacp1.MTypeReply,
+		MAddr:    req.MAddr,
+		MCode:    req.MCode,
+		ObjGroup: req.ObjGroup,
+		ObjID:    req.ObjID,
+		Value:    value,
+	}
 }
 
 // methodName is a small helper so debug logs read "setValue" not "1".
@@ -241,8 +253,9 @@ func groupOrInstanceMissing(s *server, k objectKey) iacp1.ObjectErrCode {
 // UDP plumbing — handleDatagram is called by server.readLoop.
 
 // handleDatagram decodes the incoming bytes, dispatches via
-// handleRequest, and writes the reply back to src. Decode failures are
-// logged and dropped — the spec has no "bad-framing" reply.
+// handleRequest, writes the reply back to src, and — if a mutation
+// happened — broadcasts the announcement via broadcastFn. Decode
+// failures are logged and dropped (no "bad-framing" reply in spec).
 func (s *server) handleDatagram2(data []byte, srcStr string, send func([]byte) error) {
 	msg, err := iacp1.Decode(data)
 	if err != nil {
@@ -252,7 +265,7 @@ func (s *server) handleDatagram2(data []byte, srcStr string, send func([]byte) e
 		)
 		return
 	}
-	rep := s.handleRequest(msg)
+	rep, ann := s.handleRequest(msg)
 	if rep == nil {
 		return
 	}
@@ -269,6 +282,9 @@ func (s *server) handleDatagram2(data []byte, srcStr string, send func([]byte) e
 			slog.String("err", err.Error()),
 			slog.String("src", srcStr),
 		)
+	}
+	if ann != nil {
+		s.broadcastAnnounce(ann)
 	}
 }
 

--- a/internal/provider/acp1/session_test.go
+++ b/internal/provider/acp1/session_test.go
@@ -118,7 +118,7 @@ func TestSession_GetValue_ReadOnlyString(t *testing.T) {
 		MCode: byte(iacp1.MethodGetValue),
 		ObjGroup: iacp1.GroupIdentity, ObjID: 0,
 	}
-	rep := s.handleRequest(req)
+	rep, _ := s.handleRequest(req)
 	if rep == nil {
 		t.Fatal("nil reply")
 	}
@@ -142,7 +142,7 @@ func TestSession_GetObject_Integer(t *testing.T) {
 		MCode: byte(iacp1.MethodGetObject),
 		ObjGroup: iacp1.GroupControl, ObjID: 0,
 	}
-	rep := s.handleRequest(req)
+	rep, _ := s.handleRequest(req)
 	if rep == nil || rep.MType != iacp1.MTypeReply {
 		t.Fatalf("bad reply: %+v", rep)
 	}
@@ -169,7 +169,7 @@ func TestSession_Root_Synthesised(t *testing.T) {
 		MCode: byte(iacp1.MethodGetValue),
 		ObjGroup: iacp1.GroupRoot, ObjID: 0,
 	}
-	rep := s.handleRequest(req)
+	rep, _ := s.handleRequest(req)
 	if rep == nil || rep.MType != iacp1.MTypeReply {
 		t.Fatalf("bad reply: %+v", rep)
 	}
@@ -181,7 +181,7 @@ func TestSession_Root_Synthesised(t *testing.T) {
 	// access(1=read), boot_mode(0), numIdentity(1), numControl(1),
 	// numStatus(0), numAlarm(0), numFile(0).
 	req.MCode = byte(iacp1.MethodGetObject)
-	rep = s.handleRequest(req)
+	rep, _ = s.handleRequest(req)
 	if rep == nil || rep.MType != iacp1.MTypeReply {
 		t.Fatalf("bad reply: %+v", rep)
 	}
@@ -199,7 +199,7 @@ func TestSession_UnknownObject_InstanceError(t *testing.T) {
 		MCode: byte(iacp1.MethodGetValue),
 		ObjGroup: iacp1.GroupControl, ObjID: 99,
 	}
-	rep := s.handleRequest(req)
+	rep, _ := s.handleRequest(req)
 	if rep.MType != iacp1.MTypeError {
 		t.Fatalf("want error, got MType=%d", rep.MType)
 	}
@@ -216,7 +216,7 @@ func TestSession_UnknownGroup_GroupError(t *testing.T) {
 		MCode: byte(iacp1.MethodGetValue),
 		ObjGroup: iacp1.GroupAlarm, ObjID: 0,
 	}
-	rep := s.handleRequest(req)
+	rep, _ := s.handleRequest(req)
 	if rep.MType != iacp1.MTypeError {
 		t.Fatalf("want error")
 	}
@@ -235,7 +235,7 @@ func TestSession_SetValue_RoundTrip(t *testing.T) {
 		ObjGroup: iacp1.GroupControl, ObjID: 0,
 		Value: []byte{0x00, 0x05},
 	}
-	rep := s.handleRequest(req)
+	rep, _ := s.handleRequest(req)
 	if rep.MType != iacp1.MTypeReply {
 		t.Fatalf("bad reply: %+v", rep)
 	}
@@ -245,7 +245,7 @@ func TestSession_SetValue_RoundTrip(t *testing.T) {
 	// Re-read via getValue to confirm persistence.
 	req.MCode = byte(iacp1.MethodGetValue)
 	req.Value = nil
-	rep = s.handleRequest(req)
+	rep, _ = s.handleRequest(req)
 	if string(rep.Value) != string([]byte{0x00, 0x05}) {
 		t.Fatalf("getValue after set=%x want 0005", rep.Value)
 	}
@@ -260,7 +260,7 @@ func TestSession_SetValue_ClampsToMax(t *testing.T) {
 		ObjGroup: iacp1.GroupControl, ObjID: 0,
 		Value: []byte{0x00, 0x64}, // 100
 	}
-	rep := s.handleRequest(req)
+	rep, _ := s.handleRequest(req)
 	if rep.MType != iacp1.MTypeReply {
 		t.Fatalf("bad reply: %+v", rep)
 	}
@@ -278,13 +278,13 @@ func TestSession_SetIncDec_RespectsStepAndLimits(t *testing.T) {
 		ObjGroup: iacp1.GroupControl, ObjID: 0,
 	}
 	// Inc from -6 -> -5.
-	rep := s.handleRequest(req)
+	rep, _ := s.handleRequest(req)
 	if rep.MType != iacp1.MTypeReply || string(rep.Value) != string([]byte{0xFF, 0xFB}) {
 		t.Fatalf("setInc bytes=%x want FFFB (-5)", rep.Value)
 	}
 	// Dec from -5 -> -6.
 	req.MCode = byte(iacp1.MethodSetDecValue)
-	rep = s.handleRequest(req)
+	rep, _ = s.handleRequest(req)
 	if string(rep.Value) != string([]byte{0xFF, 0xFA}) {
 		t.Fatalf("setDec bytes=%x want FFFA (-6)", rep.Value)
 	}
@@ -300,16 +300,24 @@ func TestSession_SetDefValue_ResetsToDefault(t *testing.T) {
 		ObjGroup: iacp1.GroupControl, ObjID: 0,
 		Value: []byte{0x00, 0x05},
 	}
-	_ = s.handleRequest(setReq)
+	if _, ann := s.handleRequest(setReq); ann == nil {
+		t.Fatal("setValue should have produced an announcement")
+	}
 
 	defReq := &iacp1.Message{
 		MTID: 2, MType: iacp1.MTypeRequest, MAddr: 1,
 		MCode:    byte(iacp1.MethodSetDefValue),
 		ObjGroup: iacp1.GroupControl, ObjID: 0,
 	}
-	rep := s.handleRequest(defReq)
+	rep, ann := s.handleRequest(defReq)
 	if rep.MType != iacp1.MTypeReply || string(rep.Value) != string([]byte{0x00, 0x00}) {
 		t.Fatalf("setDef bytes=%x want 0000", rep.Value)
+	}
+	if ann == nil || ann.MTID != 0 || ann.MType != iacp1.MTypeReply {
+		t.Fatalf("announce missing or wrong shape: %+v", ann)
+	}
+	if string(ann.Value) != string([]byte{0x00, 0x00}) {
+		t.Errorf("announce value=%x want 0000", ann.Value)
 	}
 }
 
@@ -322,7 +330,7 @@ func TestSession_SetValue_DeniedOnReadOnly(t *testing.T) {
 		ObjGroup: iacp1.GroupIdentity, ObjID: 0,
 		Value: []byte("X\x00"),
 	}
-	rep := s.handleRequest(req)
+	rep, _ := s.handleRequest(req)
 	if rep.MType != iacp1.MTypeError {
 		t.Fatalf("want error, got %+v", rep)
 	}
@@ -379,7 +387,7 @@ func TestSession_NonRequestIgnored(t *testing.T) {
 	s := newTestServer(t)
 	for _, mt := range []iacp1.MType{iacp1.MTypeAnnounce, iacp1.MTypeReply, iacp1.MTypeError} {
 		req := &iacp1.Message{MTID: 1, MType: mt, MAddr: 1}
-		if rep := s.handleRequest(req); rep != nil {
+		if rep, _ := s.handleRequest(req); rep != nil {
 			t.Errorf("MType=%d should be dropped, got %+v", mt, rep)
 		}
 	}

--- a/internal/provider/acp1/session_test.go
+++ b/internal/provider/acp1/session_test.go
@@ -1,0 +1,281 @@
+package acp1
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"acp/internal/export/canonical"
+	iacp1 "acp/internal/protocol/acp1"
+)
+
+// newTestServer builds a server with a hand-crafted tree containing two
+// slots — slot 0 as the rack controller (Frame object) and slot 1 as a
+// card with a small set of objects covering the common types.
+func newTestServer(t *testing.T) *server {
+	t.Helper()
+	rw := canonical.AccessReadWrite
+	r := canonical.AccessRead
+
+	hint := func(s string) *string { return &s }
+
+	slot0 := &canonical.Node{
+		Header: canonical.Header{
+			Number:     0,
+			Identifier: "slot-0",
+			OID:        "1.1",
+			Access:     r,
+			Children: []canonical.Element{
+				&canonical.Node{
+					Header: canonical.Header{
+						Number:     6,
+						Identifier: "frame",
+						OID:        "1.1.6",
+						Access:     r,
+						Children: []canonical.Element{
+							&canonical.Parameter{
+								Header: canonical.Header{
+									Number:     0,
+									Identifier: "frameStatus",
+									OID:        "1.1.6.0",
+									Access:     r,
+									Children:   canonical.EmptyChildren(),
+								},
+								Type:   canonical.ParamOctets,
+								Format: hint("frame"),
+								Value:  []any{int64(2), int64(2), int64(0), int64(0)},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	slot1 := &canonical.Node{
+		Header: canonical.Header{
+			Number:     1,
+			Identifier: "slot-1",
+			OID:        "1.2",
+			Access:     r,
+			Children: []canonical.Element{
+				// Identity group (read-only label).
+				&canonical.Node{
+					Header: canonical.Header{
+						Number: 1, Identifier: "identity", OID: "1.2.1",
+						Access: r,
+						Children: []canonical.Element{
+							&canonical.Parameter{
+								Header: canonical.Header{
+									Number: 0, Identifier: "Model", OID: "1.2.1.0",
+									Access: r, Children: canonical.EmptyChildren(),
+								},
+								Type:  canonical.ParamString,
+								Value: "GIO-12",
+							},
+						},
+					},
+				},
+				// Control group (writable level).
+				&canonical.Node{
+					Header: canonical.Header{
+						Number: 2, Identifier: "control", OID: "1.2.2",
+						Access: r,
+						Children: []canonical.Element{
+							&canonical.Parameter{
+								Header: canonical.Header{
+									Number: 0, Identifier: "Level", OID: "1.2.2.0",
+									Access: rw, Children: canonical.EmptyChildren(),
+								},
+								Type:  canonical.ParamInteger,
+								Value: int64(-6),
+								Minimum: int64(-60), Maximum: int64(12),
+								Step: int64(1), Default: int64(0),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	exp := &canonical.Export{Root: &canonical.Node{
+		Header: canonical.Header{
+			Number: 1, Identifier: "device", OID: "1", Access: r,
+			Children: []canonical.Element{slot0, slot1},
+		},
+	}}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return newServer(logger, exp)
+}
+
+func TestSession_GetValue_ReadOnlyString(t *testing.T) {
+	s := newTestServer(t)
+	req := &iacp1.Message{
+		MTID: 42, MType: iacp1.MTypeRequest, MAddr: 1,
+		MCode: byte(iacp1.MethodGetValue),
+		ObjGroup: iacp1.GroupIdentity, ObjID: 0,
+	}
+	rep := s.handleRequest(req)
+	if rep == nil {
+		t.Fatal("nil reply")
+	}
+	if rep.MType != iacp1.MTypeReply {
+		t.Fatalf("MType=%d want reply", rep.MType)
+	}
+	if rep.MTID != 42 {
+		t.Fatalf("MTID mirror broken: got %d", rep.MTID)
+	}
+	// Value should be NUL-terminated "GIO-12"
+	want := []byte("GIO-12\x00")
+	if string(rep.Value) != string(want) {
+		t.Fatalf("value=%q want %q", rep.Value, want)
+	}
+}
+
+func TestSession_GetObject_Integer(t *testing.T) {
+	s := newTestServer(t)
+	req := &iacp1.Message{
+		MTID: 7, MType: iacp1.MTypeRequest, MAddr: 1,
+		MCode: byte(iacp1.MethodGetObject),
+		ObjGroup: iacp1.GroupControl, ObjID: 0,
+	}
+	rep := s.handleRequest(req)
+	if rep == nil || rep.MType != iacp1.MTypeReply {
+		t.Fatalf("bad reply: %+v", rep)
+	}
+	o, err := iacp1.DecodeObject(rep.Value)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if o.Type != iacp1.TypeInteger {
+		t.Fatalf("type=%d", o.Type)
+	}
+	if o.IntVal != -6 || o.MinInt != -60 || o.MaxInt != 12 {
+		t.Errorf("integer fields: val=%d min=%d max=%d", o.IntVal, o.MinInt, o.MaxInt)
+	}
+	if o.Label != "Level" {
+		t.Errorf("label=%q", o.Label)
+	}
+}
+
+func TestSession_Root_Synthesised(t *testing.T) {
+	s := newTestServer(t)
+	// getValue on Root returns boot_mode byte (0 = normal).
+	req := &iacp1.Message{
+		MTID: 1, MType: iacp1.MTypeRequest, MAddr: 1,
+		MCode: byte(iacp1.MethodGetValue),
+		ObjGroup: iacp1.GroupRoot, ObjID: 0,
+	}
+	rep := s.handleRequest(req)
+	if rep == nil || rep.MType != iacp1.MTypeReply {
+		t.Fatalf("bad reply: %+v", rep)
+	}
+	if len(rep.Value) != 1 || rep.Value[0] != 0 {
+		t.Fatalf("boot_mode bytes=%v want [0]", rep.Value)
+	}
+
+	// getObject on Root returns 9 properties: type(0), numProps(9),
+	// access(1=read), boot_mode(0), numIdentity(1), numControl(1),
+	// numStatus(0), numAlarm(0), numFile(0).
+	req.MCode = byte(iacp1.MethodGetObject)
+	rep = s.handleRequest(req)
+	if rep == nil || rep.MType != iacp1.MTypeReply {
+		t.Fatalf("bad reply: %+v", rep)
+	}
+	want := []byte{0, 9, 1, 0, 1, 1, 0, 0, 0}
+	if string(rep.Value) != string(want) {
+		t.Fatalf("root object bytes=%v want %v", rep.Value, want)
+	}
+}
+
+func TestSession_UnknownObject_InstanceError(t *testing.T) {
+	s := newTestServer(t)
+	// control group exists, id=99 does not.
+	req := &iacp1.Message{
+		MTID: 1, MType: iacp1.MTypeRequest, MAddr: 1,
+		MCode: byte(iacp1.MethodGetValue),
+		ObjGroup: iacp1.GroupControl, ObjID: 99,
+	}
+	rep := s.handleRequest(req)
+	if rep.MType != iacp1.MTypeError {
+		t.Fatalf("want error, got MType=%d", rep.MType)
+	}
+	if rep.MCode != byte(iacp1.OErrInstanceNoExist) {
+		t.Errorf("mcode=%d want %d", rep.MCode, iacp1.OErrInstanceNoExist)
+	}
+}
+
+func TestSession_UnknownGroup_GroupError(t *testing.T) {
+	s := newTestServer(t)
+	// Alarm group has no entries on slot 1.
+	req := &iacp1.Message{
+		MTID: 1, MType: iacp1.MTypeRequest, MAddr: 1,
+		MCode: byte(iacp1.MethodGetValue),
+		ObjGroup: iacp1.GroupAlarm, ObjID: 0,
+	}
+	rep := s.handleRequest(req)
+	if rep.MType != iacp1.MTypeError {
+		t.Fatalf("want error")
+	}
+	if rep.MCode != byte(iacp1.OErrGroupNoExist) {
+		t.Errorf("mcode=%d want %d", rep.MCode, iacp1.OErrGroupNoExist)
+	}
+}
+
+func TestSession_SetValue_NotYetImplemented(t *testing.T) {
+	s := newTestServer(t)
+	req := &iacp1.Message{
+		MTID: 1, MType: iacp1.MTypeRequest, MAddr: 1,
+		MCode: byte(iacp1.MethodSetValue),
+		ObjGroup: iacp1.GroupControl, ObjID: 0,
+		Value: []byte{0x00, 0x05},
+	}
+	rep := s.handleRequest(req)
+	if rep.MType != iacp1.MTypeError || rep.MCode != byte(iacp1.OErrIllegalMethod) {
+		t.Fatalf("setValue should error until step 1d: %+v", rep)
+	}
+}
+
+func TestSession_MethodSupport_InvalidForAlarm(t *testing.T) {
+	// Alarm objects do not support setValue per the spec matrix.
+	// Verify methodSupported table directly.
+	if methodSupported(iacp1.TypeAlarm, iacp1.MethodSetValue) {
+		t.Error("Alarm should not support setValue")
+	}
+	if methodSupported(iacp1.TypeEnum, iacp1.MethodSetIncValue) {
+		t.Error("Enum should not support setIncValue")
+	}
+	if !methodSupported(iacp1.TypeInteger, iacp1.MethodSetDefValue) {
+		t.Error("Integer should support setDefValue")
+	}
+	if !methodSupported(iacp1.TypeFrame, iacp1.MethodGetValue) {
+		t.Error("Frame should support getValue")
+	}
+}
+
+func TestSession_AccessCheck(t *testing.T) {
+	if checkAccess(iacp1.AccessRead, iacp1.MethodSetValue) != iacp1.OErrNoWriteAccess {
+		t.Error("read-only should deny write")
+	}
+	if checkAccess(iacp1.AccessWrite, iacp1.MethodGetValue) != iacp1.OErrNoReadAccess {
+		t.Error("write-only should deny read")
+	}
+	if checkAccess(iacp1.AccessRead|iacp1.AccessWrite, iacp1.MethodSetDefValue) != iacp1.OErrNoSetDefAccess {
+		t.Error("no-setDef access should deny setDefValue")
+	}
+	if checkAccess(iacp1.AccessRead|iacp1.AccessWrite|iacp1.AccessSetDef, iacp1.MethodSetDefValue) != 0 {
+		t.Error("all-access should permit setDefValue")
+	}
+}
+
+func TestSession_NonRequestIgnored(t *testing.T) {
+	s := newTestServer(t)
+	for _, mt := range []iacp1.MType{iacp1.MTypeAnnounce, iacp1.MTypeReply, iacp1.MTypeError} {
+		req := &iacp1.Message{MTID: 1, MType: mt, MAddr: 1}
+		if rep := s.handleRequest(req); rep != nil {
+			t.Errorf("MType=%d should be dropped, got %+v", mt, rep)
+		}
+	}
+}

--- a/internal/provider/acp1/session_test.go
+++ b/internal/provider/acp1/session_test.go
@@ -1,6 +1,7 @@
 package acp1
 
 import (
+	"context"
 	"io"
 	"log/slog"
 	"testing"
@@ -224,17 +225,121 @@ func TestSession_UnknownGroup_GroupError(t *testing.T) {
 	}
 }
 
-func TestSession_SetValue_NotYetImplemented(t *testing.T) {
+func TestSession_SetValue_RoundTrip(t *testing.T) {
 	s := newTestServer(t)
+	// Control slot-1 id=0 is Level (int16, min=-60 max=12, currently -6).
+	// Write 5, expect echo 5.
 	req := &iacp1.Message{
 		MTID: 1, MType: iacp1.MTypeRequest, MAddr: 1,
-		MCode: byte(iacp1.MethodSetValue),
+		MCode:    byte(iacp1.MethodSetValue),
 		ObjGroup: iacp1.GroupControl, ObjID: 0,
 		Value: []byte{0x00, 0x05},
 	}
 	rep := s.handleRequest(req)
-	if rep.MType != iacp1.MTypeError || rep.MCode != byte(iacp1.OErrIllegalMethod) {
-		t.Fatalf("setValue should error until step 1d: %+v", rep)
+	if rep.MType != iacp1.MTypeReply {
+		t.Fatalf("bad reply: %+v", rep)
+	}
+	if string(rep.Value) != string([]byte{0x00, 0x05}) {
+		t.Fatalf("echo bytes=%x want 0005", rep.Value)
+	}
+	// Re-read via getValue to confirm persistence.
+	req.MCode = byte(iacp1.MethodGetValue)
+	req.Value = nil
+	rep = s.handleRequest(req)
+	if string(rep.Value) != string([]byte{0x00, 0x05}) {
+		t.Fatalf("getValue after set=%x want 0005", rep.Value)
+	}
+}
+
+func TestSession_SetValue_ClampsToMax(t *testing.T) {
+	s := newTestServer(t)
+	// Level max=12; request 100 -> clamped to 12.
+	req := &iacp1.Message{
+		MTID: 1, MType: iacp1.MTypeRequest, MAddr: 1,
+		MCode:    byte(iacp1.MethodSetValue),
+		ObjGroup: iacp1.GroupControl, ObjID: 0,
+		Value: []byte{0x00, 0x64}, // 100
+	}
+	rep := s.handleRequest(req)
+	if rep.MType != iacp1.MTypeReply {
+		t.Fatalf("bad reply: %+v", rep)
+	}
+	if string(rep.Value) != string([]byte{0x00, 0x0C}) {
+		t.Fatalf("clamp bytes=%x want 000C (12)", rep.Value)
+	}
+}
+
+func TestSession_SetIncDec_RespectsStepAndLimits(t *testing.T) {
+	s := newTestServer(t)
+	// Level: start at -6, step=1, min=-60, max=12.
+	req := &iacp1.Message{
+		MTID: 1, MType: iacp1.MTypeRequest, MAddr: 1,
+		MCode:    byte(iacp1.MethodSetIncValue),
+		ObjGroup: iacp1.GroupControl, ObjID: 0,
+	}
+	// Inc from -6 -> -5.
+	rep := s.handleRequest(req)
+	if rep.MType != iacp1.MTypeReply || string(rep.Value) != string([]byte{0xFF, 0xFB}) {
+		t.Fatalf("setInc bytes=%x want FFFB (-5)", rep.Value)
+	}
+	// Dec from -5 -> -6.
+	req.MCode = byte(iacp1.MethodSetDecValue)
+	rep = s.handleRequest(req)
+	if string(rep.Value) != string([]byte{0xFF, 0xFA}) {
+		t.Fatalf("setDec bytes=%x want FFFA (-6)", rep.Value)
+	}
+}
+
+func TestSession_SetDefValue_ResetsToDefault(t *testing.T) {
+	s := newTestServer(t)
+	// Level default=0.
+	// First set to 5 so we can observe the reset.
+	setReq := &iacp1.Message{
+		MTID: 1, MType: iacp1.MTypeRequest, MAddr: 1,
+		MCode:    byte(iacp1.MethodSetValue),
+		ObjGroup: iacp1.GroupControl, ObjID: 0,
+		Value: []byte{0x00, 0x05},
+	}
+	_ = s.handleRequest(setReq)
+
+	defReq := &iacp1.Message{
+		MTID: 2, MType: iacp1.MTypeRequest, MAddr: 1,
+		MCode:    byte(iacp1.MethodSetDefValue),
+		ObjGroup: iacp1.GroupControl, ObjID: 0,
+	}
+	rep := s.handleRequest(defReq)
+	if rep.MType != iacp1.MTypeReply || string(rep.Value) != string([]byte{0x00, 0x00}) {
+		t.Fatalf("setDef bytes=%x want 0000", rep.Value)
+	}
+}
+
+func TestSession_SetValue_DeniedOnReadOnly(t *testing.T) {
+	s := newTestServer(t)
+	// Identity slot-1 group=1 id=0 is Model (read-only string).
+	req := &iacp1.Message{
+		MTID: 1, MType: iacp1.MTypeRequest, MAddr: 1,
+		MCode:    byte(iacp1.MethodSetValue),
+		ObjGroup: iacp1.GroupIdentity, ObjID: 0,
+		Value: []byte("X\x00"),
+	}
+	rep := s.handleRequest(req)
+	if rep.MType != iacp1.MTypeError {
+		t.Fatalf("want error, got %+v", rep)
+	}
+	if rep.MCode != byte(iacp1.OErrNoWriteAccess) {
+		t.Errorf("mcode=%d want %d (NoWriteAccess)", rep.MCode, iacp1.OErrNoWriteAccess)
+	}
+}
+
+func TestServer_SetValueAPIPath(t *testing.T) {
+	s := newTestServer(t)
+	// API-driven setValue uses the Provider interface.
+	stored, err := s.SetValue(context.Background(), "1.2.2.0", int64(7))
+	if err != nil {
+		t.Fatalf("SetValue: %v", err)
+	}
+	if stored.(int64) != 7 {
+		t.Fatalf("stored=%v want 7", stored)
 	}
 }
 

--- a/internal/provider/acp1/set.go
+++ b/internal/provider/acp1/set.go
@@ -1,0 +1,390 @@
+package acp1
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+
+	"acp/internal/export/canonical"
+	iacp1 "acp/internal/protocol/acp1"
+)
+
+// applyMutation dispatches the four mutating methods (setValue,
+// setIncValue, setDecValue, setDefValue) for one entry and returns the
+// post-state value bytes the reply + announcement must carry.
+//
+// The caller holds no locks; this function takes tree.mu's write lock
+// so the canonical.Parameter.Value update is atomic with the encoded
+// bytes we return.
+//
+// Spec behaviour (p.28):
+//   - setValue: accept incoming bytes, clamp to [min,max].
+//   - setIncValue: value += step, clamped to max.
+//   - setDecValue: value -= step, clamped to min.
+//   - setDefValue: value = default.
+//
+// The returned bytes are the SAME format as encodeValue's output — they
+// are what getValue would return *after* the change. The ACP1 spec
+// requires the reply to carry the confirmed-stored value, not the
+// requested one.
+func (s *server) applyMutation(e *entry, method iacp1.Method, incoming []byte) ([]byte, error) {
+	s.tree.mu.Lock()
+	defer s.tree.mu.Unlock()
+
+	switch e.acpType {
+	case iacp1.TypeInteger:
+		return s.mutateInteger(e, method, incoming)
+	case iacp1.TypeLong:
+		return s.mutateLong(e, method, incoming)
+	case iacp1.TypeByte:
+		return s.mutateByte(e, method, incoming)
+	case iacp1.TypeFloat:
+		return s.mutateFloat(e, method, incoming)
+	case iacp1.TypeIPAddr:
+		return s.mutateIPAddr(e, method, incoming)
+	case iacp1.TypeEnum:
+		return s.mutateEnum(e, method, incoming)
+	case iacp1.TypeString:
+		return s.mutateString(e, method, incoming)
+	}
+	return nil, fmt.Errorf("applyMutation: unsupported type %d", e.acpType)
+}
+
+// ----------------------------------------------------------------- Integer
+
+func (s *server) mutateInteger(e *entry, m iacp1.Method, incoming []byte) ([]byte, error) {
+	p := e.param
+	cur, err := asInt16(p.Value, "value")
+	if err != nil {
+		return nil, err
+	}
+	step, _ := asInt16Opt(p.Step, "step", 1)
+	minV, _ := asInt16Opt(p.Minimum, "minimum", math.MinInt16)
+	maxV, _ := asInt16Opt(p.Maximum, "maximum", math.MaxInt16)
+	def, _ := asInt16Opt(p.Default, "default", 0)
+
+	var next int32 // widen so increment/decrement can overflow cleanly
+	switch m {
+	case iacp1.MethodSetValue:
+		if len(incoming) < 2 {
+			return nil, fmt.Errorf("setValue integer: need 2 bytes, got %d", len(incoming))
+		}
+		next = int32(int16(binary.BigEndian.Uint16(incoming)))
+	case iacp1.MethodSetIncValue:
+		next = int32(cur) + int32(step)
+	case iacp1.MethodSetDecValue:
+		next = int32(cur) - int32(step)
+	case iacp1.MethodSetDefValue:
+		next = int32(def)
+	default:
+		return nil, fmt.Errorf("unexpected method %d", m)
+	}
+
+	clamped := clampInt32(next, int32(minV), int32(maxV))
+	p.Value = int64(clamped)
+	return writeI16(int16(clamped)), nil
+}
+
+// ----------------------------------------------------------------- Long
+
+func (s *server) mutateLong(e *entry, m iacp1.Method, incoming []byte) ([]byte, error) {
+	p := e.param
+	cur, err := asInt32(p.Value, "value")
+	if err != nil {
+		return nil, err
+	}
+	step, _ := asInt32Opt(p.Step, "step", 1)
+	minV, _ := asInt32Opt(p.Minimum, "minimum", math.MinInt32)
+	maxV, _ := asInt32Opt(p.Maximum, "maximum", math.MaxInt32)
+	def, _ := asInt32Opt(p.Default, "default", 0)
+
+	var next int64
+	switch m {
+	case iacp1.MethodSetValue:
+		if len(incoming) < 4 {
+			return nil, fmt.Errorf("setValue long: need 4 bytes, got %d", len(incoming))
+		}
+		next = int64(int32(binary.BigEndian.Uint32(incoming)))
+	case iacp1.MethodSetIncValue:
+		next = int64(cur) + int64(step)
+	case iacp1.MethodSetDecValue:
+		next = int64(cur) - int64(step)
+	case iacp1.MethodSetDefValue:
+		next = int64(def)
+	default:
+		return nil, fmt.Errorf("unexpected method %d", m)
+	}
+
+	clamped := clampInt64(next, int64(minV), int64(maxV))
+	p.Value = clamped
+	return writeI32(int32(clamped)), nil
+}
+
+// ----------------------------------------------------------------- Byte
+
+func (s *server) mutateByte(e *entry, m iacp1.Method, incoming []byte) ([]byte, error) {
+	p := e.param
+	cur, err := asUint8(p.Value, "value")
+	if err != nil {
+		return nil, err
+	}
+	step, _ := asUint8Opt(p.Step, "step", 1)
+	minV, _ := asUint8Opt(p.Minimum, "minimum", 0)
+	maxV, _ := asUint8Opt(p.Maximum, "maximum", math.MaxUint8)
+	def, _ := asUint8Opt(p.Default, "default", 0)
+
+	var next int32
+	switch m {
+	case iacp1.MethodSetValue:
+		if len(incoming) < 1 {
+			return nil, fmt.Errorf("setValue byte: need 1 byte, got 0")
+		}
+		next = int32(incoming[0])
+	case iacp1.MethodSetIncValue:
+		next = int32(cur) + int32(step)
+	case iacp1.MethodSetDecValue:
+		next = int32(cur) - int32(step)
+	case iacp1.MethodSetDefValue:
+		next = int32(def)
+	default:
+		return nil, fmt.Errorf("unexpected method %d", m)
+	}
+
+	clamped := uint8(clampInt32(next, int32(minV), int32(maxV)))
+	p.Value = int64(clamped)
+	return []byte{clamped}, nil
+}
+
+// ----------------------------------------------------------------- Float
+
+func (s *server) mutateFloat(e *entry, m iacp1.Method, incoming []byte) ([]byte, error) {
+	p := e.param
+	cur, err := asFloat32(p.Value, "value")
+	if err != nil {
+		return nil, err
+	}
+	step, _ := asFloat32Opt(p.Step, "step", 1)
+	minV, _ := asFloat32Opt(p.Minimum, "minimum", -math.MaxFloat32)
+	maxV, _ := asFloat32Opt(p.Maximum, "maximum", math.MaxFloat32)
+	def, _ := asFloat32Opt(p.Default, "default", 0)
+
+	var next float64
+	switch m {
+	case iacp1.MethodSetValue:
+		if len(incoming) < 4 {
+			return nil, fmt.Errorf("setValue float: need 4 bytes, got %d", len(incoming))
+		}
+		next = float64(math.Float32frombits(binary.BigEndian.Uint32(incoming)))
+	case iacp1.MethodSetIncValue:
+		next = float64(cur) + float64(step)
+	case iacp1.MethodSetDecValue:
+		next = float64(cur) - float64(step)
+	case iacp1.MethodSetDefValue:
+		next = float64(def)
+	default:
+		return nil, fmt.Errorf("unexpected method %d", m)
+	}
+
+	clamped := clampFloat64(next, float64(minV), float64(maxV))
+	p.Value = clamped
+	return writeF32(float32(clamped)), nil
+}
+
+// ----------------------------------------------------------------- IPAddr
+
+func (s *server) mutateIPAddr(e *entry, m iacp1.Method, incoming []byte) ([]byte, error) {
+	p := e.param
+	cur, err := ipv4ToUint32(p.Value)
+	if err != nil {
+		return nil, err
+	}
+	step, _ := ipv4ToUint32Opt(p.Step, 0)
+	minV, _ := ipv4ToUint32Opt(p.Minimum, 0)
+	maxV, _ := ipv4ToUint32Opt(p.Maximum, math.MaxUint32)
+	def, _ := ipv4ToUint32Opt(p.Default, 0)
+
+	var next uint64 // widen so overflow maths stays clean
+	switch m {
+	case iacp1.MethodSetValue:
+		if len(incoming) < 4 {
+			return nil, fmt.Errorf("setValue ipaddr: need 4 bytes, got %d", len(incoming))
+		}
+		next = uint64(binary.BigEndian.Uint32(incoming))
+	case iacp1.MethodSetIncValue:
+		next = uint64(cur) + uint64(step)
+	case iacp1.MethodSetDecValue:
+		if uint64(cur) < uint64(step) {
+			next = 0
+		} else {
+			next = uint64(cur) - uint64(step)
+		}
+	case iacp1.MethodSetDefValue:
+		next = uint64(def)
+	default:
+		return nil, fmt.Errorf("unexpected method %d", m)
+	}
+
+	if next > uint64(maxV) {
+		next = uint64(maxV)
+	}
+	if next < uint64(minV) {
+		next = uint64(minV)
+	}
+	clamped := uint32(next)
+	p.Value = uint32ToDottedQuad(clamped)
+	return writeU32(clamped), nil
+}
+
+// ----------------------------------------------------------------- Enum
+
+func (s *server) mutateEnum(e *entry, m iacp1.Method, incoming []byte) ([]byte, error) {
+	p := e.param
+	items := enumItems(p)
+	if len(items) == 0 {
+		return nil, fmt.Errorf("enum %q has no items", p.Identifier)
+	}
+	maxIdx := uint8(len(items) - 1)
+
+	var next uint8
+	switch m {
+	case iacp1.MethodSetValue:
+		if len(incoming) < 1 {
+			return nil, fmt.Errorf("setValue enum: need 1 byte, got 0")
+		}
+		next = incoming[0]
+		if next > maxIdx {
+			// Spec p.29 "invalid value" is ObjectErrCode 5 on ACP2;
+			// ACP1's closest fit is OErrIllegalForType. Caller handles.
+			return nil, fmt.Errorf("enum %q: index %d > max %d", p.Identifier, next, maxIdx)
+		}
+	case iacp1.MethodSetDefValue:
+		def, _ := asUint8Opt(p.Default, "default", 0)
+		next = def
+		if next > maxIdx {
+			next = 0
+		}
+	default:
+		return nil, fmt.Errorf("unexpected method %d for enum", m)
+	}
+
+	p.Value = int64(next)
+	return []byte{next}, nil
+}
+
+// ----------------------------------------------------------------- String
+
+func (s *server) mutateString(e *entry, m iacp1.Method, incoming []byte) ([]byte, error) {
+	if m != iacp1.MethodSetValue {
+		return nil, fmt.Errorf("string %q: only setValue supported", e.param.Identifier)
+	}
+	// incoming is NUL-terminated on the wire. Strip the terminator if
+	// present so our Go string carries only the content.
+	raw := incoming
+	if n := len(raw); n > 0 && raw[n-1] == 0 {
+		raw = raw[:n-1]
+	}
+	maxLen := stringMaxLen(e.param)
+	s2 := string(raw)
+	if maxLen > 0 && len(s2) > int(maxLen) {
+		s2 = s2[:maxLen]
+	}
+	e.param.Value = s2
+	return writeCStr(s2), nil
+}
+
+// ----------------------------------------------------------------- helpers
+
+func clampInt32(v, minV, maxV int32) int32 {
+	if v < minV {
+		return minV
+	}
+	if v > maxV {
+		return maxV
+	}
+	return v
+}
+
+func clampInt64(v, minV, maxV int64) int64 {
+	if v < minV {
+		return minV
+	}
+	if v > maxV {
+		return maxV
+	}
+	return v
+}
+
+func clampFloat64(v, minV, maxV float64) float64 {
+	if v < minV {
+		return minV
+	}
+	if v > maxV {
+		return maxV
+	}
+	return v
+}
+
+func uint32ToDottedQuad(v uint32) string {
+	return fmt.Sprintf("%d.%d.%d.%d",
+		(v>>24)&0xff, (v>>16)&0xff, (v>>8)&0xff, v&0xff)
+}
+
+// assignFromAny coerces an `any` value (from the canonical JSON or from
+// the provider.Provider.SetValue API path) to the correct native Go
+// type for the entry and serialises it as ACP1 setValue bytes.
+// Returns a DescribedError so the caller can map to the proper MCODE.
+//
+// Used by server.SetValue (API-driven writes) to route through the same
+// mutation pipeline as the wire handlers.
+func (s *server) encodeIncomingFromAny(e *entry, val any) ([]byte, error) {
+	switch e.acpType {
+	case iacp1.TypeInteger:
+		v, err := asInt16(val, "value")
+		if err != nil {
+			return nil, err
+		}
+		return writeI16(v), nil
+	case iacp1.TypeLong:
+		v, err := asInt32(val, "value")
+		if err != nil {
+			return nil, err
+		}
+		return writeI32(v), nil
+	case iacp1.TypeByte:
+		v, err := asUint8(val, "value")
+		if err != nil {
+			return nil, err
+		}
+		return []byte{v}, nil
+	case iacp1.TypeFloat:
+		v, err := asFloat32(val, "value")
+		if err != nil {
+			return nil, err
+		}
+		return writeF32(v), nil
+	case iacp1.TypeIPAddr:
+		v, err := ipv4ToUint32(val)
+		if err != nil {
+			return nil, err
+		}
+		return writeU32(v), nil
+	case iacp1.TypeEnum:
+		v, err := asUint8(val, "value")
+		if err != nil {
+			return nil, err
+		}
+		return []byte{v}, nil
+	case iacp1.TypeString:
+		v, err := asString(val, "value")
+		if err != nil {
+			return nil, err
+		}
+		return writeCStr(v), nil
+	}
+	return nil, fmt.Errorf("encodeIncomingFromAny: unsupported type %d", e.acpType)
+}
+
+// convertStoredValue reads the mutated canonical.Parameter.Value back
+// into a type-faithful `any` for the API-path return value. Used by
+// server.SetValue after applyMutation.
+func convertStoredValue(p *canonical.Parameter) any { return p.Value }

--- a/internal/provider/acp1/tree.go
+++ b/internal/provider/acp1/tree.go
@@ -1,0 +1,287 @@
+package acp1
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	"acp/internal/export/canonical"
+	iacp1 "acp/internal/protocol/acp1"
+)
+
+// groupName -> ObjGroup constant. Mirrors buildSlotNode in
+// internal/protocol/acp1/canonicalize.go. Canonical uses lowercase group
+// identifiers; ACP1 wire uses the numeric group code.
+var groupByName = map[string]iacp1.ObjGroup{
+	"root":     iacp1.GroupRoot,
+	"identity": iacp1.GroupIdentity,
+	"control":  iacp1.GroupControl,
+	"status":   iacp1.GroupStatus,
+	"alarm":    iacp1.GroupAlarm,
+	"file":     iacp1.GroupFile,
+	"frame":    iacp1.GroupFrame,
+}
+
+// objectKey uniquely identifies an AxonNet object on the wire.
+// slot fits in a byte (0-31 per spec); group+id likewise.
+type objectKey struct {
+	slot  uint8
+	group iacp1.ObjGroup
+	id    uint8
+}
+
+// entry holds one mutable AxonNet object: the canonical Parameter source
+// + the derived ACP1 wire type (int16 / int32 / ipv4 / etc) + access bits.
+// session.go reads and writes this; all access guarded by tree.mu.
+type entry struct {
+	key     objectKey
+	param   *canonical.Parameter // points into the loaded canonical.Export
+	acpType iacp1.ObjectType
+	access  uint8 // ACP1 access bits 0/1/2
+}
+
+// tree is the in-memory index a provider serves. A canonical.Export is
+// flattened at startup into a map keyed by (slot, group, id). The root
+// device + slot-N + group placeholder Nodes are observed for their
+// structural info (slot count) but not themselves served as objects —
+// ACP1 exposes only Parameters.
+type tree struct {
+	mu      sync.RWMutex
+	entries map[objectKey]*entry
+	// slots holds per-slot counters needed to answer Root.getObject
+	// (numIdentity/Control/Status/Alarm/File). Computed at load time.
+	slots map[uint8]*slotCounts
+}
+
+type slotCounts struct {
+	numIdentity uint8
+	numControl  uint8
+	numStatus   uint8
+	numAlarm    uint8
+	numFile     uint8
+}
+
+// newTree flattens a canonical.Export into the (slot, group, id) index.
+// Shape expected (mirror of acp1.Canonicalize output):
+//
+//	Root Node                              "device"  oid="1"
+//	 └── Slot Node   number=N              "slot-N"  oid="1.N+1"
+//	      └── Group Node identifier="identity|control|..."
+//	           └── Parameter number=objID  (leaf)
+//
+// Unknown group names are skipped with a warning; unknown parameter
+// types fall through to Integer (most common) with a warning.
+func newTree(exp *canonical.Export) (*tree, error) {
+	if exp == nil || exp.Root == nil {
+		return nil, fmt.Errorf("acp1 provider: empty canonical export")
+	}
+	root, ok := exp.Root.(*canonical.Node)
+	if !ok {
+		return nil, fmt.Errorf("acp1 provider: root must be Node, got %s", exp.Root.Kind())
+	}
+
+	t := &tree{
+		entries: map[objectKey]*entry{},
+		slots:   map[uint8]*slotCounts{},
+	}
+
+	for _, slotEl := range root.Common().Children {
+		slotNode, ok := slotEl.(*canonical.Node)
+		if !ok {
+			continue
+		}
+		// Canonical slot Node: number=0 → slot 0. OID "1.1" encodes the
+		// same (1-based) but we trust the Number field.
+		slot := uint8(slotNode.Number)
+		counts := &slotCounts{}
+		t.slots[slot] = counts
+
+		for _, groupEl := range slotNode.Children {
+			groupNode, ok := groupEl.(*canonical.Node)
+			if !ok {
+				continue
+			}
+			grp, ok := groupByName[strings.ToLower(groupNode.Identifier)]
+			if !ok {
+				continue
+			}
+
+			for _, paramEl := range groupNode.Children {
+				p, ok := paramEl.(*canonical.Parameter)
+				if !ok {
+					continue
+				}
+				id := uint8(p.Number)
+				acpType, err := deriveACPType(p)
+				if err != nil {
+					return nil, fmt.Errorf("acp1 provider: %s (%s): %w",
+						p.OID, p.Identifier, err)
+				}
+				e := &entry{
+					key:     objectKey{slot: slot, group: grp, id: id},
+					param:   p,
+					acpType: acpType,
+					access:  deriveAccess(p.Access),
+				}
+				t.entries[e.key] = e
+
+				switch grp {
+				case iacp1.GroupIdentity:
+					if id >= counts.numIdentity {
+						counts.numIdentity = id + 1
+					}
+				case iacp1.GroupControl:
+					if id >= counts.numControl {
+						counts.numControl = id + 1
+					}
+				case iacp1.GroupStatus:
+					if id >= counts.numStatus {
+						counts.numStatus = id + 1
+					}
+				case iacp1.GroupAlarm:
+					if id >= counts.numAlarm {
+						counts.numAlarm = id + 1
+					}
+				case iacp1.GroupFile:
+					if id >= counts.numFile {
+						counts.numFile = id + 1
+					}
+				}
+			}
+		}
+	}
+
+	return t, nil
+}
+
+// lookup returns the entry at the given (slot, group, id) under RLock.
+func (t *tree) lookup(k objectKey) (*entry, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	e, ok := t.entries[k]
+	return e, ok
+}
+
+// deriveACPType maps a canonical.Parameter to the concrete ACP1 wire
+// type. ACP1 distinguishes int16/int32/uint8 and string/ipaddr/file at
+// the wire level; canonical collapses those. We use Parameter.Format as
+// the explicit ACP1 type hint and reject ambiguity with an error so the
+// provider never emits a type it cannot represent.
+//
+//	integer  + no hint            -> TypeInteger (int16, Axon default)
+//	integer  + "int32" | "long"   -> TypeLong
+//	integer  + "uint8" | "byte"   -> TypeByte
+//	real                          -> TypeFloat
+//	enum                          -> TypeEnum
+//	string   + no hint            -> TypeString
+//	string   + "ipv4" | "ipaddr"  -> TypeIPAddr
+//	string   + "file"             -> TypeFile
+//	boolean  + "alarm"            -> TypeAlarm  (spec p.25)
+//	octets   + "frame"            -> TypeFrame  (spec p.24; rack-controller only)
+//	boolean without "alarm" hint  -> ERROR (ACP1 has no Boolean — use
+//	                                 Enum with "Off,On" items for plain
+//	                                 booleans, Alarm for alarm objects)
+func deriveACPType(p *canonical.Parameter) (iacp1.ObjectType, error) {
+	hint := ""
+	if p.Format != nil {
+		hint = strings.ToLower(*p.Format)
+	}
+	switch p.Type {
+	case canonical.ParamReal:
+		return iacp1.TypeFloat, nil
+	case canonical.ParamEnum:
+		return iacp1.TypeEnum, nil
+	case canonical.ParamInteger:
+		switch hint {
+		case "", "int16":
+			return iacp1.TypeInteger, nil
+		case "int32", "long":
+			return iacp1.TypeLong, nil
+		case "uint8", "byte":
+			return iacp1.TypeByte, nil
+		default:
+			return 0, fmt.Errorf("integer: unknown format %q (want int16|int32|uint8)", hint)
+		}
+	case canonical.ParamString:
+		switch hint {
+		case "":
+			return iacp1.TypeString, nil
+		case "ipv4", "ipaddr":
+			return iacp1.TypeIPAddr, nil
+		case "file":
+			return iacp1.TypeFile, nil
+		default:
+			return 0, fmt.Errorf("string: unknown format %q (want ipv4|file or omit)", hint)
+		}
+	case canonical.ParamBoolean:
+		if hint != "alarm" {
+			return 0, fmt.Errorf(
+				"boolean has no ACP1 mapping — use enum with Off,On for plain booleans, " +
+					"or set format=\"alarm\" with description=\"on: … / off: …\" for spec-p.25 Alarm objects")
+		}
+		return iacp1.TypeAlarm, nil
+	case canonical.ParamOctets:
+		if hint == "frame" {
+			return iacp1.TypeFrame, nil
+		}
+		return 0, fmt.Errorf("octets: format=%q unsupported in ACP1 (only format=\"frame\" is defined)", hint)
+	}
+	return 0, fmt.Errorf("unsupported canonical type %q for ACP1 provider", p.Type)
+}
+
+// deriveAccess maps the canonical access string (spec p.20 read/write
+// bits) to the ACP1 access byte. setDef (bit 2) is not distinguishable
+// in canonical's four-level string so the provider does NOT grant it
+// implicitly — setDefValue on a tree loaded from canonical will return
+// the spec-p.29 "no setDef access" error unless the loader explicitly
+// sets it. This is the spec-conformant behaviour.
+func deriveAccess(a string) uint8 {
+	switch a {
+	case canonical.AccessRead:
+		return iacp1.AccessRead
+	case canonical.AccessWrite:
+		return iacp1.AccessWrite
+	case canonical.AccessReadWrite:
+		return iacp1.AccessRead | iacp1.AccessWrite
+	}
+	return 0
+}
+
+// parsePath converts a dotted canonical OID "1.N+1.group.id" back into a
+// concrete (slot, group, id) key. Used by Provider.SetValue which
+// receives arbitrary user-supplied paths.
+//
+// Accepted formats (both work):
+//
+//	"1.2.1.3"        four-component numeric OID
+//	"slot-1.identity.label"  three-component identifier path (not supported yet)
+//
+// Returns a helpful error if the path is ill-formed or the components
+// are out of range.
+func parsePath(path string) (objectKey, error) {
+	parts := strings.Split(path, ".")
+	if len(parts) != 4 {
+		return objectKey{}, fmt.Errorf("acp1 path: expected 4 components <1.slot+1.group.id>, got %q", path)
+	}
+	if parts[0] != "1" {
+		return objectKey{}, fmt.Errorf("acp1 path: first component must be 1, got %q", parts[0])
+	}
+	slot1based, err := strconv.Atoi(parts[1])
+	if err != nil || slot1based < 1 {
+		return objectKey{}, fmt.Errorf("acp1 path: invalid slot component %q", parts[1])
+	}
+	grpNum, err := strconv.Atoi(parts[2])
+	if err != nil || grpNum < 0 || grpNum > 6 {
+		return objectKey{}, fmt.Errorf("acp1 path: invalid group component %q", parts[2])
+	}
+	id, err := strconv.Atoi(parts[3])
+	if err != nil || id < 0 || id > 255 {
+		return objectKey{}, fmt.Errorf("acp1 path: invalid id component %q", parts[3])
+	}
+	return objectKey{
+		slot:  uint8(slot1based - 1),
+		group: iacp1.ObjGroup(grpNum),
+		id:    uint8(id),
+	}, nil
+}

--- a/internal/provider/acp1/tree.go
+++ b/internal/provider/acp1/tree.go
@@ -230,20 +230,23 @@ func deriveACPType(p *canonical.Parameter) (iacp1.ObjectType, error) {
 	return 0, fmt.Errorf("unsupported canonical type %q for ACP1 provider", p.Type)
 }
 
-// deriveAccess maps the canonical access string (spec p.20 read/write
-// bits) to the ACP1 access byte. setDef (bit 2) is not distinguishable
-// in canonical's four-level string so the provider does NOT grant it
-// implicitly — setDefValue on a tree loaded from canonical will return
-// the spec-p.29 "no setDef access" error unless the loader explicitly
-// sets it. This is the spec-conformant behaviour.
+// deriveAccess maps the canonical access string to the ACP1 access
+// byte (spec p.20 bit 0 = read, bit 1 = write, bit 2 = setDef).
+//
+// Canonical's four-level string cannot distinguish setDef from write,
+// but real Axon firmware (the "constructor" reference the provider
+// mirrors) grants setDef on every writable object with a default. The
+// provider follows that convention — write implies setDef — so tree.json
+// round-tripped from a real device behaves the same way under the
+// provider as it did under the device.
 func deriveAccess(a string) uint8 {
 	switch a {
 	case canonical.AccessRead:
 		return iacp1.AccessRead
 	case canonical.AccessWrite:
-		return iacp1.AccessWrite
+		return iacp1.AccessWrite | iacp1.AccessSetDef
 	case canonical.AccessReadWrite:
-		return iacp1.AccessRead | iacp1.AccessWrite
+		return iacp1.AccessRead | iacp1.AccessWrite | iacp1.AccessSetDef
 	}
 	return 0
 }

--- a/internal/provider/acp1/tree.go
+++ b/internal/provider/acp1/tree.go
@@ -183,51 +183,106 @@ func (t *tree) lookup(k objectKey) (*entry, bool) {
 //	                                 Enum with "Off,On" items for plain
 //	                                 booleans, Alarm for alarm objects)
 func deriveACPType(p *canonical.Parameter) (iacp1.ObjectType, error) {
-	hint := ""
-	if p.Format != nil {
-		hint = strings.ToLower(*p.Format)
+	// Parameter.Format is a free-form comma-separated hint carrying
+	// ACP1 type information AND other attributes (e.g. "maxLen=N" on
+	// strings, "priority=N,tag=M" on alarms). Split and scan: first
+	// matching type hint wins; non-type hints (maxLen/priority/tag) are
+	// absorbed by later encoders.
+	parts := formatParts(p.Format)
+	typeHint, known := pickTypeHint(parts)
+	if !known {
+		return 0, fmt.Errorf("unrecognised format type-hint %q (valid bare tokens: int16|int32|uint8|ipv4|file|alarm|frame)", typeHint)
 	}
+
 	switch p.Type {
 	case canonical.ParamReal:
 		return iacp1.TypeFloat, nil
 	case canonical.ParamEnum:
 		return iacp1.TypeEnum, nil
 	case canonical.ParamInteger:
-		switch hint {
+		switch typeHint {
 		case "", "int16":
 			return iacp1.TypeInteger, nil
 		case "int32", "long":
 			return iacp1.TypeLong, nil
 		case "uint8", "byte":
 			return iacp1.TypeByte, nil
-		default:
-			return 0, fmt.Errorf("integer: unknown format %q (want int16|int32|uint8)", hint)
 		}
+		return 0, fmt.Errorf("integer: unknown type hint %q (want int16|int32|uint8)", typeHint)
 	case canonical.ParamString:
-		switch hint {
-		case "":
+		switch typeHint {
+		case "", "string":
 			return iacp1.TypeString, nil
 		case "ipv4", "ipaddr":
 			return iacp1.TypeIPAddr, nil
 		case "file":
 			return iacp1.TypeFile, nil
-		default:
-			return 0, fmt.Errorf("string: unknown format %q (want ipv4|file or omit)", hint)
 		}
+		return 0, fmt.Errorf("string: unknown type hint %q (want ipv4|file or omit)", typeHint)
 	case canonical.ParamBoolean:
-		if hint != "alarm" {
+		if typeHint != "alarm" {
 			return 0, fmt.Errorf(
 				"boolean has no ACP1 mapping — use enum with Off,On for plain booleans, " +
 					"or set format=\"alarm\" with description=\"on: … / off: …\" for spec-p.25 Alarm objects")
 		}
 		return iacp1.TypeAlarm, nil
 	case canonical.ParamOctets:
-		if hint == "frame" {
+		if typeHint == "frame" {
 			return iacp1.TypeFrame, nil
 		}
-		return 0, fmt.Errorf("octets: format=%q unsupported in ACP1 (only format=\"frame\" is defined)", hint)
+		return 0, fmt.Errorf("octets: type hint %q unsupported in ACP1 (only \"frame\" is defined)", typeHint)
 	}
 	return 0, fmt.Errorf("unsupported canonical type %q for ACP1 provider", p.Type)
+}
+
+// formatParts splits a canonical Format string into lower-cased
+// comma-trimmed tokens. An empty / nil Format yields an empty slice.
+func formatParts(f *string) []string {
+	if f == nil || *f == "" {
+		return nil
+	}
+	parts := strings.Split(*f, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(strings.ToLower(p))
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// pickTypeHint scans Format parts for the one that identifies an ACP1
+// wire type. Tokens containing "=" are key-value attributes
+// (maxLen=16, priority=2, tag=17) and are ignored here. A bare token
+// that doesn't match a known type is treated as a typo by the caller.
+//
+// Returns:
+//
+//	(hint, true)   — a known type hint was found (or no bare tokens
+//	                 present, which means "use the canonical default")
+//	(badToken, false) — an unknown bare token was seen; caller should
+//	                 surface this as a reject.
+func pickTypeHint(parts []string) (string, bool) {
+	known := map[string]struct{}{
+		"int16": {}, "int32": {}, "long": {},
+		"uint8": {}, "byte": {},
+		"ipv4": {}, "ipaddr": {},
+		"file":   {},
+		"alarm":  {},
+		"frame":  {},
+		"string": {},
+	}
+	for _, p := range parts {
+		if strings.ContainsRune(p, '=') {
+			continue // key=value attribute, not a type hint
+		}
+		if _, ok := known[p]; ok {
+			return p, true
+		}
+		return p, false
+	}
+	return "", true
 }
 
 // deriveAccess maps the canonical access string to the ACP1 access


### PR DESCRIPTION
## Summary

Closes #73.

Adds the second provider plugin, symmetric to the Ember+ provider: serves a canonical `tree.json` as an AxonNet ACP1 device over UDP:2071 (Mode A, spec v1.4). Plugs into the existing `cmd/acp-provider` binary with `--protocol acp1`.

**All 11 object types, all 6 methods, announcements, clamping, access enforcement.**

## What shipped

| Layer | File | Notes |
|---|---|---|
| Factory + init | internal/provider/acp1/plugin.go | registers under name "acp1", DefaultPort 2071 |
| Tree indexer | internal/provider/acp1/tree.go | (slot, group, id) map; strict canonical -> ACP1 type mapping |
| Property encoder | internal/provider/acp1/encoder.go | reverse of consumer's DecodeObject, all 11 types |
| Session dispatch | internal/provider/acp1/session.go | pure handleRequest(msg) -> (reply, announce), Root synthesis |
| Set mutators | internal/provider/acp1/set.go | setValue / setInc / setDec / setDef with spec-p.28 clamping |
| UDP I/O | internal/provider/acp1/server.go | listener + separate broadcast socket for announcements |
| Demo tree | assets/acp1/demo_frame.json | 19 objects, rack with 4 slots (2 slots share a DM) |

## Wire-correctness landmines fixed

1. **Integer default** — `format=""` defaults to int16 (Axon convention) not a reject.
2. **Format is multi-part** — `maxLen=16,priority=2,tag=17` coexist with type hints; only bare tokens participate in type selection.
3. **Boolean has no ACP1 mapping** — canonical `boolean` is rejected unless `format=alarm` sets the Alarm type explicitly.
4. **setDef implied by write** — canonical's 4-level access string drops the setDef bit; provider grants setDef alongside write to match what real Axon firmware emits on writable integers.
5. **Clamp on write** — setValue / setInc / setDec all clamp to `[min, max]` before storing, per spec p.28.
6. **Reply mirrors MTID** — replies keep the request's MTID so consumers correlate; announcements use MTID=0 per the Reply Matrix.
7. **Root synthesised** — Root (group=0, id=0) is never stored as a canonical Parameter; session.go derives `num_identity/num_control/...` from the per-slot counters captured at tree-load time.

## Test plan

- [x] Unit tests — 39 sub-tests: encoder round-trip against consumer DecodeObject for every type, golden-bytes tests for encodeValue, derive-type strict map, session dispatch for getValue / getObject / set* / error paths / access / method-support / announcement emission
- [x] Loopback smoke tests (this README for the record):
      - `acp walk slot=1` -> all 11 objects with correct types / ranges / units / max-length hints
      - `acp walk slot=2` -> same DM as slot-1 with independent values (confirms "any DM, any slot, own values")
      - `acp get Level` -> `-6 dB`
      - `acp set Level=5` -> `5 dB`, persists
      - `acp set Level=999` -> clamped to `12 dB` (max)
- [ ] External ACP1 client (user-supplied) — pending
- [ ] `acp watch` end-to-end announcement reception — requires two UDP sockets; loopback port collision blocks

## Out of scope (future PRs)

- TCP Mode B (MLEN u32 prefix)
- AN2/TCP Mode C (proto=1)
- Frame-status change announcements emitted on slot insertion/removal events
- API-layer `acp-srv` integration (Provider already exposes SetValue)