### PR TITLE
feat(wireshark): ACP1 + ACP2 dissector Info column — richer details

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ Each protocol has a dedicated connector page with transport, firewall rules,
 identity, object types, discovery, get/set, subscriptions, export, capture,
 and CLI examples.
 
-| Protocol | Transport | Port | Status | Documentation |
-|---|---|---|---|---|
-| ACP1 | UDP / TCP direct | 2071 | done, canonical-aligned | [docs/protocols/acp1/consumer.md](docs/protocols/acp1/consumer.md) |
-| ACP2 | AN2/TCP | 2072 | done, canonical alignment pending (#32) | [docs/protocols/acp2/consumer.md](docs/protocols/acp2/consumer.md) |
-| Ember+ | S101/TCP | 9000-9092 | consumer done (resolver + multi-level labels) | [docs/protocols/emberplus/consumer.md](docs/protocols/emberplus/consumer.md) |
-| Probel SW-P-02 | TCP | — | planned (audit YELLOW) | [memory: project_probel_extensions.md] |
-| Probel SW-P-08+ | TCP | — | planned (audit YELLOW) | [memory: project_probel_extensions.md] |
-| TSL UMD v3.1/v4/v5 | UDP push | — | planned (audit GREEN) | [memory: project_tsl_extensions.md] |
+| Protocol | Transport | Port | Consumer | Provider | Documentation |
+|---|---|---|---|---|---|
+| ACP1 | UDP / TCP direct | 2071 | done, canonical-aligned | ✅ merged (#74), SynapseSetUp + Lawo VSM Controller validated, `--announce-demo` ticker (#81) | [docs/protocols/acp1/consumer.md](docs/protocols/acp1/consumer.md) |
+| ACP2 | AN2/TCP | 2072 | done, canonical alignment pending (#32) | 🟡 PR #76, 5/6 object types Lawo-VSM-validated; Enum (pid 15) parked in #79 pending Cerebrum | [docs/protocols/acp2/consumer.md](docs/protocols/acp2/consumer.md) |
+| Ember+ | S101/TCP | 9000-9092 | consumer done (resolver + multi-level labels) | ✅ merged (#67 + #72) | [docs/protocols/emberplus/consumer.md](docs/protocols/emberplus/consumer.md) |
+| Probel SW-P-02 | TCP | — | planned (audit YELLOW) | — | [memory: project_probel_extensions.md] |
+| Probel SW-P-08+ | TCP | 2008 | 🟡 PR #77 in progress (rx/tx codec through Step 2e) | planned | [memory: project_probel_extensions.md] |
+| TSL UMD v3.1/v4/v5 | UDP push | — | planned (audit GREEN) | — | [memory: project_tsl_extensions.md] |
 
 Canonical JSON schema shared across all protocols: [docs/protocols/schema.md](docs/protocols/schema.md).
 Per-type element docs with realistic samples: [docs/protocols/elements/](docs/protocols/elements/).
@@ -222,6 +222,21 @@ All three protocols ship Lua dissectors under `assets/`. Install once (copy
 into your Wireshark personal plugins directory) and live captures from
 `acp walk` / `acp watch` / `acp extract` are auto-decoded. Full install +
 filter guide: [docs/wireshark.md](docs/wireshark.md).
+
+**Info column content (PR #80, 2026-04-21):** ACP1 and ACP2 Info columns
+now carry short type / mtid / dotted OID path / typed value inline, so
+you can scroll through a capture without expanding every tree:
+
+```
+ACP1 Req slot=1 mtid=0x4A2F setValue control.3 value(s16)=-30
+ACP1 Ann slot=1 mtid=0x0   setValue control.0 value(s16)=-10
+AN2 > ACP2 Rep mtid=116 SetProperty 0.3 pid=value value(string)="ACP2-Frame"
+AN2 > ACP2 Evt mtid=0   Announce    pid=value 1.18 value(float)=-35.3
+```
+
+Announce detection uses MTID=0 per spec "Announcements" — MType=2+MTID=0
+is labelled `Ann`, not `Rep`. Per-value type tagging (s8/s16/s32/s64/u8/u16/u32/u64/float/enum/ipv4/string)
+matches the declared object category derived from the ACP2 vtype byte.
 
 ---
 

--- a/agents.md
+++ b/agents.md
@@ -465,13 +465,34 @@ match the Ember+ provider tier.
 Both PRs pending external viewer validation (user sourcing Probel-free
 ACP1 + ACP2 clients). No merge until confirmed.
 
+**Part B completion (2026-04-20, late session):**
+
+- **#74 ACP1 provider MERGED to main.** Validated against real **Axon
+  SynapseSetUp v1.90** — full walk (Root/Identity/Control/Status/Alarm),
+  setValue on string/int/float/ipv4/enum/byte/long, setDec on float +
+  int with spec-correct Level-max=12 clamping, value-change broadcasts.
+  10/11 operator-mode ACP1 types exercised; File type (type 8) is
+  engineer-mode only on real Synapse and is covered by unit tests.
+
+- **#76 ACP2 provider** — viewer-validation in flight against **Lawo
+  VSM Axon Neuron driver** (port 2072). Multiple spec-strict fixes
+  landed on `feat/acp2-provider` after decoding Lawo parser-failure
+  hex dumps against spec §5.4 "Property header per field" table.
+  Memory `project_acp2_provider.md` now documents **14 wire-correctness
+  landmines** (up from 3), covering GetSlotInfo slot-header placement
+  (spec §3.3.3), GetDeviceInfo slot-count semantics (§3.3.2),
+  inline-data encoding for pid 1/3/5, data=0 for pid 2 (label) / pid 13
+  (unit), pid 6 u16+pad body (not u32), **72-byte fixed enum options**
+  (pid 15 spec §5.4), and enum value vtype=9 (preset/enum, not u32).
+  Not yet viewer-green — more frames to decode.
+
 ### Parked — TODO / SOW (do not start now)
 
 | item | phase | notes |
 |---|---|---|
 | Ember+ provider | ✅ merged main (#67 + #72); #70 formula eval parked |
-| ACP1 provider | ✅ PR #74 pending external-client validation |
-| ACP2 provider | ✅ PR #76 pending external-client validation |
+| ACP1 provider | ✅ merged main (#74, SynapseSetUp-validated) |
+| ACP2 provider | 🟡 PR #76, Lawo VSM validation active — no merge until all frames parse |
 | Probel SW-P-08 consumer | **Part B → Part C bridge** | **#77 opened** — matrix/level encoded as Node hierarchy (same shape as ACP slot). TS ref at `assets/probel/smh-probelsw08p/` with both matrix emulator (main-server) and controller emulator (main-client). Commie.exe + .dat for cross-vendor |
 | Wire codec doc retrofit (byte-tables + range comments) | tracked | **#78 opened** — apply the TS doc convention (`feedback_command_docstyle.md`) to ACP1/ACP2/Ember+ codecs |
 | Probel SW-P-02 consumer+provider | later | subset of SW-P-08; after SW-P-08 ships |

--- a/agents.md
+++ b/agents.md
@@ -474,25 +474,50 @@ ACP1 + ACP2 clients). No merge until confirmed.
   10/11 operator-mode ACP1 types exercised; File type (type 8) is
   engineer-mode only on real Synapse and is covered by unit tests.
 
-- **#76 ACP2 provider** — viewer-validation in flight against **Lawo
-  VSM Axon Neuron driver** (port 2072). Multiple spec-strict fixes
-  landed on `feat/acp2-provider` after decoding Lawo parser-failure
-  hex dumps against spec §5.4 "Property header per field" table.
-  Memory `project_acp2_provider.md` now documents **14 wire-correctness
-  landmines** (up from 3), covering GetSlotInfo slot-header placement
-  (spec §3.3.3), GetDeviceInfo slot-count semantics (§3.3.2),
-  inline-data encoding for pid 1/3/5, data=0 for pid 2 (label) / pid 13
-  (unit), pid 6 u16+pad body (not u32), **72-byte fixed enum options**
-  (pid 15 spec §5.4), and enum value vtype=9 (preset/enum, not u32).
-  Not yet viewer-green — more frames to decode.
+- **#76 ACP2 provider** — **5/6 types Lawo-VSM-validated** on
+  2026-04-20/21. Node / Number (all 9 subtypes) / IPv4 / String+maxLen /
+  subscribe / client-set echo / device-initiated announces (via
+  `--announce-demo`) all parse clean. Memory
+  `project_acp2_provider.md` now documents **16 wire-correctness
+  landmines** — incl. announce header byte 2 = stat=0 (NOT pid), Enum
+  MUST NOT emit pid 9 (depth-indexed only), GetSlotInfo slot-header
+  placement (§3.3.3), GetDeviceInfo slot-count semantics (§3.3.2),
+  inline-data for pid 1/3/5, data=0 for pid 2/13, pid 6 u16+pad body,
+  72-byte fixed enum options (§5.4), enum value vtype=9. Only **Enum
+  (pid 15 options inner 72-byte layout)** unresolved, parked behind
+  **issue #79** pending Cerebrum controller capture. PR #76 merge-
+  conflict with main after #74 + #81 touched `cmd/acp-provider/main.go`
+  — needs rebase.
+
+- **#80 Wireshark dissector Info enrichment** — ACP1 + ACP2 Info
+  column now carries short type (Req/Rep/Evt/Err/Ann), mtid, dotted
+  OID path (control.3 / 1.18), typed value (value(s8)=-40,
+  value(float)=-35.3, value(string)="Input-A", value(enum)=0).
+  ACP1 Ann label driven by MTID=0 per spec "Announcements".
+  Landmine: Wireshark's Proto.dissector FFI drops Lua multi-return —
+  use module-local side channels (pattern:
+  `feedback_wireshark_lua_quirks.md`). Partial resolution of issues
+  #57 and #58 (remaining polish: per-session label cache,
+  min/max/unit on getObject Info, ACP1 frame-status Info decode).
+
+- **#81 ACP1 --announce-demo ticker** — Symmetric to ACP2's demo.
+  `cmd/acp-provider --announce-demo --announce-demo-slot 1
+  --announce-demo-group 2 --announce-demo-id 0
+  --announce-demo-interval 2s` oscillates an Integer (s16) over its
+  declared [min,max] and broadcasts MTID=0 MType=Reply MCode=setValue
+  to 255.255.255.255:2071 every 2s. Plus Info-level diagnostic logs
+  on every inbound datagram + announce broadcast (fixed the "am I
+  actually emitting?" debugging problem). Lawo VSM Controller
+  auto-discovers + walks + receives announces end-to-end.
 
 ### Parked — TODO / SOW (do not start now)
 
 | item | phase | notes |
 |---|---|---|
 | Ember+ provider | ✅ merged main (#67 + #72); #70 formula eval parked |
-| ACP1 provider | ✅ merged main (#74, SynapseSetUp-validated) |
-| ACP2 provider | 🟡 PR #76, Lawo VSM validation active — no merge until all frames parse |
+| ACP1 provider | ✅ merged main (#74, SynapseSetUp + Lawo VSM Controller validated); #81 adds --announce-demo |
+| ACP2 provider | 🟡 PR #76, 5/6 types Lawo-validated, merge-conflict with main needs rebase; Enum parked in #79 pending Cerebrum |
+| Wireshark dissectors | 🟡 PR #80 Info column enrichment — dotted OID + type-tagged values + MTID=0 Ann label |
 | Probel SW-P-08 consumer | **Part B → Part C bridge** | **#77 opened** — matrix/level encoded as Node hierarchy (same shape as ACP slot). TS ref at `assets/probel/smh-probelsw08p/` with both matrix emulator (main-server) and controller emulator (main-client). Commie.exe + .dat for cross-vendor |
 | Wire codec doc retrofit (byte-tables + range comments) | tracked | **#78 opened** — apply the TS doc convention (`feedback_command_docstyle.md`) to ACP1/ACP2/Ember+ codecs |
 | Probel SW-P-02 consumer+provider | later | subset of SW-P-08; after SW-P-08 ships |

--- a/assets/acp1/dissector_acpv1.lua
+++ b/assets/acp1/dissector_acpv1.lua
@@ -454,23 +454,32 @@ end
 -------------------------------------------------------------------------------
 -- acp1_value_preview returns a compact decoded-value string for the
 -- Info column when we're looking at a getValue reply / setValue request
--- without type context. Heuristic: length-based — 1 byte = u8, 2 bytes
--- = s16, 4 bytes = u32 or float. Longer runs show as hex + possible
--- ASCII. Always prints as "value=..." so the Info column reads cleanly.
+-- without type context. The ACP1 protocol doesn't carry a type byte
+-- with the value (unlike ACP2's vtype in the property header), so the
+-- type is derived from the OBJECT definition — which requires prior
+-- getObject context we don't have here. We do a length-based guess:
+--   1 byte  -> u8  (byte/enum)
+--   2 bytes -> s16 (integer)
+--   4 bytes -> s32 (long) + hex (covers u32/float/ipaddr ambiguity)
+--   varies  -> string (if printable) or raw byte count
+-- The "/0x..." hex on 4-byte values lets the reader recognise float or
+-- ipaddr patterns without the dissector having to pick a type.
 -------------------------------------------------------------------------------
 local function acp1_value_preview(tvbuf, offset, datalen)
     if datalen <= 0 then return "" end
     if datalen == 1 then
-        return "value=" .. tvbuf:range(offset, 1):uint()
+        return "value(u8)=" .. tvbuf:range(offset, 1):uint()
     elseif datalen == 2 then
-        return "value=" .. tvbuf:range(offset, 2):int()
+        return "value(s16)=" .. tvbuf:range(offset, 2):int()
     elseif datalen == 4 then
         local u = tvbuf:range(offset, 4):uint()
-        return string.format("value=%d/0x%X", u, u)
-    elseif datalen <= 16 then
+        local s = tvbuf:range(offset, 4):int()
+        return string.format("value(s32/u32)=%d/0x%X", s, u)
+    elseif datalen <= 32 then
         local s = tvbuf:range(offset, datalen):string()
-        if s:match("^[%w%s%._%-/:]*$") and #s > 0 then
-            return "value=\"" .. s:gsub("\0", "") .. "\""
+        local printable = s:match("^[%w%s%._%-/:%+%(%)]*$") and #s > 0
+        if printable then
+            return "value(string)=\"" .. s:gsub("\0", "") .. "\""
         end
         return "value=" .. datalen .. "B"
     end
@@ -568,12 +577,23 @@ local function dissect_acpv1_message(tvbuf, pktinfo, root)
             local label_str = nil
             if value_len > 0 then
                 if mcode_val == 5 and (mtype_val == 2 or mtype_val == 0) then
-                    -- getObject reply or announce: full property decode, capture label
+                    -- getObject reply or announce: full property decode.
+                    -- The first byte of the object payload is obj_type
+                    -- (spec Property Layouts table) — expose it in the
+                    -- Info column so you can see "type=integer" /
+                    -- "type=enum" / "type=string" at a glance without
+                    -- expanding the tree. decode_getobject_value reads
+                    -- the full property list and returns the label.
+                    local obj_type = tvbuf:range(mdata_offset + 3, 1):uint()
+                    local type_name = objtype_valstr[obj_type] or ("type=" .. obj_type)
+                    table.insert(info_parts, "type=" .. type_name)
                     label_str = decode_getobject_value(tvbuf, tree, mdata_offset + 3, value_len)
                 else
-                    -- setValue/getValue/setInc/setDec/setDef: we don't know the
-                    -- object type without context (would need to have seen the
-                    -- getObject reply first). Show a compact value preview.
+                    -- setValue/getValue/setInc/setDec/setDef: we don't
+                    -- know the object type without state (prior
+                    -- getObject reply). Length-based heuristic in
+                    -- acp1_value_preview tags with best-guess type
+                    -- ("value(u8)=", "value(s16)=", "value(s32/u32)=").
                     tree:add(f_value, tvbuf:range(mdata_offset + 3, value_len))
                     local preview = acp1_value_preview(tvbuf, mdata_offset + 3, value_len)
                     if preview ~= "" then

--- a/assets/acp1/dissector_acpv1.lua
+++ b/assets/acp1/dissector_acpv1.lua
@@ -510,21 +510,33 @@ local function dissect_acpv1_message(tvbuf, pktinfo, root)
     tree:add(f_mtype, tvbuf:range(5, 1))
     tree:add(f_maddr, tvbuf:range(6, 1))
 
-    -- Short type names: Ann/Req/Rep/Err (concise, matches ACP2 dissector style)
-    local mtype_short = { [0] = "Ann", [1] = "Req", [2] = "Rep", [3] = "Err" }
-    local mtype_str = mtype_short[mtype_val] or ("T" .. mtype_val)
+    -- MTID=0 is the authoritative announcement discriminator per spec
+    -- "Announcements" — a broadcast value-change carries MType=2 (Reply)
+    -- AND MTID=0 to tell subscribers "this was not solicited by you",
+    -- while a regular solicited reply has MTID>0 matching the request.
+    -- Label by MTID first so MType=2+MTID=0 shows "Ann" (not "Rep").
     local is_announce = (mtid_val == 0)
+    local mtype_short = { [0] = "Ann", [1] = "Req", [2] = "Rep", [3] = "Err" }
+    local mtype_str
+    if is_announce then
+        mtype_str = "Ann"
+    else
+        mtype_str = mtype_short[mtype_val] or ("T" .. mtype_val)
+    end
 
     -- MDATA starts at offset 7
     local mdata_offset = 7
     local mdata_len = pktlen - mdata_offset
 
     -- Build info incrementally so every packet gets the common prefix:
-    -- "ACP1 <type> slot=N [mtid=...]"
-    local info_parts = { "ACP1", mtype_str, "slot=" .. maddr_val }
-    if not is_announce then
-        table.insert(info_parts, string.format("mtid=0x%X", mtid_val))
-    end
+    -- "ACP1 <type> slot=N mtid=0x..."
+    -- Always show mtid — for announces it's the discriminator (mtid=0)
+    -- and useful for debugging; for req/reply it pairs them.
+    local info_parts = {
+        "ACP1", mtype_str,
+        "slot=" .. maddr_val,
+        string.format("mtid=0x%X", mtid_val),
+    }
 
     if mdata_len <= 0 then
         table.insert(info_parts, "(no mdata)")

--- a/assets/acp1/dissector_acpv1.lua
+++ b/assets/acp1/dissector_acpv1.lua
@@ -452,6 +452,32 @@ local function decode_getobject_value(tvbuf, tree, offset, datalen)
 end
 
 -------------------------------------------------------------------------------
+-- acp1_value_preview returns a compact decoded-value string for the
+-- Info column when we're looking at a getValue reply / setValue request
+-- without type context. Heuristic: length-based — 1 byte = u8, 2 bytes
+-- = s16, 4 bytes = u32 or float. Longer runs show as hex + possible
+-- ASCII. Always prints as "value=..." so the Info column reads cleanly.
+-------------------------------------------------------------------------------
+local function acp1_value_preview(tvbuf, offset, datalen)
+    if datalen <= 0 then return "" end
+    if datalen == 1 then
+        return "value=" .. tvbuf:range(offset, 1):uint()
+    elseif datalen == 2 then
+        return "value=" .. tvbuf:range(offset, 2):int()
+    elseif datalen == 4 then
+        local u = tvbuf:range(offset, 4):uint()
+        return string.format("value=%d/0x%X", u, u)
+    elseif datalen <= 16 then
+        local s = tvbuf:range(offset, datalen):string()
+        if s:match("^[%w%s%._%-/:]*$") and #s > 0 then
+            return "value=\"" .. s:gsub("\0", "") .. "\""
+        end
+        return "value=" .. datalen .. "B"
+    end
+    return "value=" .. datalen .. "B"
+end
+
+-------------------------------------------------------------------------------
 -- Core ACP1 dissection (shared by UDP and TCP paths)
 -- tvbuf: starts at MTID (no MLEN prefix)
 -- Returns bytes consumed
@@ -475,42 +501,42 @@ local function dissect_acpv1_message(tvbuf, pktinfo, root)
     tree:add(f_mtype, tvbuf:range(5, 1))
     tree:add(f_maddr, tvbuf:range(6, 1))
 
-    local mtype_str = mtype_valstr[mtype_val] or "Unknown"
-    local info_parts = {}
-
-    -- Check for announcement (MTID = 0)
+    -- Short type names: Ann/Req/Rep/Err (concise, matches ACP2 dissector style)
+    local mtype_short = { [0] = "Ann", [1] = "Req", [2] = "Rep", [3] = "Err" }
+    local mtype_str = mtype_short[mtype_val] or ("T" .. mtype_val)
     local is_announce = (mtid_val == 0)
 
     -- MDATA starts at offset 7
     local mdata_offset = 7
     local mdata_len = pktlen - mdata_offset
 
+    -- Build info incrementally so every packet gets the common prefix:
+    -- "ACP1 <type> slot=N [mtid=...]"
+    local info_parts = { "ACP1", mtype_str, "slot=" .. maddr_val }
+    if not is_announce then
+        table.insert(info_parts, string.format("mtid=0x%X", mtid_val))
+    end
+
     if mdata_len <= 0 then
-        -- Header only, no MDATA
-        if is_announce then
-            table.insert(info_parts, "ACP1 Announce (empty)")
-        else
-            table.insert(info_parts, string.format("ACP1 %s slot=%d (no data)", mtype_str, maddr_val))
-        end
-        pktinfo.cols.info:set(table.concat(info_parts))
+        table.insert(info_parts, "(no mdata)")
+        pktinfo.cols.info:set(table.concat(info_parts, " "))
         return pktlen
     end
 
     local mcode_val = tvbuf:range(mdata_offset, 1):uint()
 
     if mtype_val == 3 then
-        -- Error reply
+        -- Error reply: MCODE is the error code
+        local err_str
         if mcode_val < 16 then
             tree:add(f_err_transport, tvbuf:range(mdata_offset, 1))
-            local err_str = transport_error_valstr[mcode_val] or "Unknown transport error"
-            table.insert(info_parts, string.format("ACP1 Error slot=%d: %s (code=%d)",
-                maddr_val, err_str, mcode_val))
+            err_str = transport_error_valstr[mcode_val] or "Unknown transport error"
         else
             tree:add(f_err_object, tvbuf:range(mdata_offset, 1))
-            local err_str = object_error_valstr[mcode_val] or "Unknown object error"
-            table.insert(info_parts, string.format("ACP1 Error slot=%d: %s (code=%d)",
-                maddr_val, err_str, mcode_val))
+            err_str = object_error_valstr[mcode_val] or "Unknown object error"
         end
+        table.insert(info_parts, string.format("%s(code=%d)", err_str, mcode_val))
+
         -- Error may have ObjGrp/ObjId after MCODE
         if mdata_len >= 3 then
             local grp = tvbuf:range(mdata_offset + 1, 1):uint()
@@ -518,7 +544,7 @@ local function dissect_acpv1_message(tvbuf, pktinfo, root)
             tree:add(f_objgrp, tvbuf:range(mdata_offset + 1, 1))
             tree:add(f_objid,  tvbuf:range(mdata_offset + 2, 1))
             local grp_str = objgrp_valstr[grp] or tostring(grp)
-            info_parts[1] = info_parts[1] .. string.format(" %s[%d]", grp_str, oid)
+            table.insert(info_parts, string.format("%s[%d]", grp_str, oid))
         end
         if mdata_len > 3 then
             tree:add(f_value, tvbuf:range(mdata_offset + 3, mdata_len - 3))
@@ -527,6 +553,7 @@ local function dissect_acpv1_message(tvbuf, pktinfo, root)
         -- Non-error: MCODE is method ID
         tree:add(f_mcode, tvbuf:range(mdata_offset, 1))
         local method_str = mcode_method_valstr[mcode_val] or string.format("method(%d)", mcode_val)
+        table.insert(info_parts, method_str)
 
         if mdata_len >= 3 then
             local grp = tvbuf:range(mdata_offset + 1, 1):uint()
@@ -535,53 +562,36 @@ local function dissect_acpv1_message(tvbuf, pktinfo, root)
             tree:add(f_objid,  tvbuf:range(mdata_offset + 2, 1))
 
             local grp_str = objgrp_valstr[grp] or tostring(grp)
-            local label_str = nil
-            local value_len = mdata_len - 3
+            table.insert(info_parts, string.format("%s[%d]", grp_str, oid))
 
+            local value_len = mdata_len - 3
+            local label_str = nil
             if value_len > 0 then
-                -- Decode value bytes
                 if mcode_val == 5 and (mtype_val == 2 or mtype_val == 0) then
-                    -- getObject reply or announce: full property decode
+                    -- getObject reply or announce: full property decode, capture label
                     label_str = decode_getobject_value(tvbuf, tree, mdata_offset + 3, value_len)
                 else
-                    -- Other methods: show raw value
+                    -- setValue/getValue/setInc/setDec/setDef: we don't know the
+                    -- object type without context (would need to have seen the
+                    -- getObject reply first). Show a compact value preview.
                     tree:add(f_value, tvbuf:range(mdata_offset + 3, value_len))
+                    local preview = acp1_value_preview(tvbuf, mdata_offset + 3, value_len)
+                    if preview ~= "" then
+                        table.insert(info_parts, preview)
+                    end
                 end
-            end
-
-            if is_announce then
-                if mcode_val == 0 then
-                    -- Status/card-event announcement
-                    table.insert(info_parts, string.format("ACP1 Announce slot=%d %s[%d]",
-                        maddr_val, grp_str, oid))
-                else
-                    -- Value-change echo
-                    table.insert(info_parts, string.format("ACP1 Announce %s slot=%d %s[%d]",
-                        method_str, maddr_val, grp_str, oid))
-                end
-            else
-                table.insert(info_parts, string.format("ACP1 %s %s slot=%d %s[%d]",
-                    mtype_str, method_str, maddr_val, grp_str, oid))
             end
 
             if label_str and label_str ~= "" then
-                info_parts[1] = info_parts[1] .. " " .. label_str
-            end
-        else
-            -- Only MCODE, no ObjGrp/ObjId
-            if is_announce then
-                table.insert(info_parts, string.format("ACP1 Announce %s slot=%d",
-                    method_str, maddr_val))
-            else
-                table.insert(info_parts, string.format("ACP1 %s %s slot=%d",
-                    mtype_str, method_str, maddr_val))
+                table.insert(info_parts, string.format("\"%s\"", label_str))
             end
         end
     end
 
-    pktinfo.cols.info:set(table.concat(info_parts))
+    pktinfo.cols.info:set(table.concat(info_parts, " "))
     return pktlen
 end
+
 
 -------------------------------------------------------------------------------
 -- UDP dissector (Mode A) — each datagram is one ACP1 message

--- a/assets/acp1/dissector_acpv1.lua
+++ b/assets/acp1/dissector_acpv1.lua
@@ -565,7 +565,11 @@ local function dissect_acpv1_message(tvbuf, pktinfo, root)
             tree:add(f_objgrp, tvbuf:range(mdata_offset + 1, 1))
             tree:add(f_objid,  tvbuf:range(mdata_offset + 2, 1))
             local grp_str = objgrp_valstr[grp] or tostring(grp)
-            table.insert(info_parts, string.format("%s[%d]", grp_str, oid))
+            -- Path notation: group.id per issue #57 — dotted OID form
+            -- (control.3 instead of control[3]). Slot is already shown
+            -- by the "slot=N" token earlier in the Info line, no need
+            -- to repeat it in the path.
+            table.insert(info_parts, string.format("%s.%d", grp_str, oid))
         end
         if mdata_len > 3 then
             tree:add(f_value, tvbuf:range(mdata_offset + 3, mdata_len - 3))
@@ -583,7 +587,11 @@ local function dissect_acpv1_message(tvbuf, pktinfo, root)
             tree:add(f_objid,  tvbuf:range(mdata_offset + 2, 1))
 
             local grp_str = objgrp_valstr[grp] or tostring(grp)
-            table.insert(info_parts, string.format("%s[%d]", grp_str, oid))
+            -- Path notation: group.id per issue #57 — dotted OID form
+            -- (control.3 instead of control[3]). Slot is already shown
+            -- by the "slot=N" token earlier in the Info line, no need
+            -- to repeat it in the path.
+            table.insert(info_parts, string.format("%s.%d", grp_str, oid))
 
             local value_len = mdata_len - 3
             local label_str = nil

--- a/assets/acp2/dissector_acp2.lua
+++ b/assets/acp2/dissector_acp2.lua
@@ -23,6 +23,12 @@ local AN2_MAGIC   = 0xC635
 -- read by the AN2 dissector right after the nested call.
 local acp2_last_info = ""
 
+-- Slot lives in the AN2 frame header, not the ACP2 payload. AN2 writes
+-- it here before invoking acp2_proto.dissector so the ACP2 side can
+-- build dotted paths like "0.5.value" (slot.obj_id.pid) per issue #58
+-- — matches the Ember+ OID-dotted Info column style.
+local acp2_current_slot = 0
+
 -------------------------------------------------------------------------------
 -- Value-string tables
 -------------------------------------------------------------------------------
@@ -659,7 +665,8 @@ function acp2_proto.dissector(tvbuf, pktinfo, root)
                 local idx    = tvbuf:range(8, 4):uint()
                 tree:add(acp2_f.obj_id, tvbuf:range(4, 4))
                 tree:add(acp2_f.idx,    tvbuf:range(8, 4))
-                table.insert(info_parts, "obj=" .. obj_id)
+                -- Dotted slot.obj path per issue #58 (match Ember+ OID style).
+                table.insert(info_parts, string.format("%d.%d", acp2_current_slot, obj_id))
                 if idx ~= 0 then
                     table.insert(info_parts, "idx=" .. idx)
                 end
@@ -677,7 +684,8 @@ function acp2_proto.dissector(tvbuf, pktinfo, root)
                 local idx    = tvbuf:range(8, 4):uint()
                 tree:add(acp2_f.obj_id, tvbuf:range(4, 4))
                 tree:add(acp2_f.idx,    tvbuf:range(8, 4))
-                table.insert(info_parts, "obj=" .. obj_id)
+                -- Dotted slot.obj path per issue #58 (match Ember+ OID style).
+                table.insert(info_parts, string.format("%d.%d", acp2_current_slot, obj_id))
                 table.insert(info_parts, "pid=" .. pid_name)
                 if idx ~= 0 then
                     table.insert(info_parts, "idx=" .. idx)
@@ -698,7 +706,8 @@ function acp2_proto.dissector(tvbuf, pktinfo, root)
                 local idx    = tvbuf:range(8, 4):uint()
                 tree:add(acp2_f.obj_id, tvbuf:range(4, 4))
                 tree:add(acp2_f.idx,    tvbuf:range(8, 4))
-                table.insert(info_parts, "obj=" .. obj_id)
+                -- Dotted slot.obj path per issue #58 (match Ember+ OID style).
+                table.insert(info_parts, string.format("%d.%d", acp2_current_slot, obj_id))
                 table.insert(info_parts, "pid=" .. pid_name)
                 if idx ~= 0 then
                     table.insert(info_parts, "idx=" .. idx)
@@ -724,7 +733,7 @@ function acp2_proto.dissector(tvbuf, pktinfo, root)
             local idx    = tvbuf:range(8, 4):uint()
             tree:add(acp2_f.obj_id, tvbuf:range(4, 4))
             tree:add(acp2_f.idx,    tvbuf:range(8, 4))
-            table.insert(info_parts, "obj=" .. obj_id)
+            table.insert(info_parts, string.format("%d.%d", acp2_current_slot, obj_id))
             if idx ~= 0 then
                 table.insert(info_parts, "idx=" .. idx)
             end
@@ -747,7 +756,7 @@ function acp2_proto.dissector(tvbuf, pktinfo, root)
             tree:add(acp2_f.obj_id, tvbuf:range(4, 4))
             tree:add(acp2_f.idx,    tvbuf:range(8, 4))
             local obj_id = tvbuf:range(4, 4):uint()
-            table.insert(info_parts, "obj=" .. obj_id)
+            table.insert(info_parts, string.format("%d.%d", acp2_current_slot, obj_id))
         end
     end
 
@@ -874,18 +883,21 @@ local function dissect_one_an2(tvbuf, pktinfo, root, offset)
         -- ACP2 data frame: hand off to ACP2 dissector. We read the
         -- composed info text from the module-local side-channel
         -- `acp2_last_info`, because Wireshark's Proto.dissector wrapper
-        -- drops multi-return values when called via Lua.
+        -- drops multi-return values when called via Lua. Slot is
+        -- forwarded the same way so ACP2 can build dotted paths.
         acp2_last_info = ""
+        acp2_current_slot = slot_val
         local payload_tvb = tvbuf:range(offset + AN2_HDR_LEN, dlen):tvb()
         acp2_proto.dissector(payload_tvb, pktinfo, an2_tree)
-        info_str = "AN2 > ACP2 " .. acp2_last_info .. " " .. slot_str
+        info_str = "AN2 > ACP2 " .. acp2_last_info
 
     elseif proto_val == 2 and dlen > 0 then
         -- ACP2 non-data frame (req/reply/event/error at AN2 level)
         acp2_last_info = ""
+        acp2_current_slot = slot_val
         local payload_tvb = tvbuf:range(offset + AN2_HDR_LEN, dlen):tvb()
         acp2_proto.dissector(payload_tvb, pktinfo, an2_tree)
-        info_str = "AN2 " .. type_str .. " > ACP2 " .. acp2_last_info .. " " .. slot_str
+        info_str = "AN2 " .. type_str .. " > ACP2 " .. acp2_last_info
 
     elseif proto_val == 0 and dlen > 0 then
         -- AN2 internal protocol

--- a/assets/acp2/dissector_acp2.lua
+++ b/assets/acp2/dissector_acp2.lua
@@ -494,6 +494,81 @@ end
 -------------------------------------------------------------------------------
 -- ACP2 dissector (called for AN2 proto=2, type=4 data frames)
 -------------------------------------------------------------------------------
+-- Peek the value bytes of the first property at `offset` in tvbuf and
+-- return a short text summary for the Info column: `value=42`,
+-- `value="ACP2-Frame"`, `value=10.4.210.100`, etc. Returns "" when
+-- nothing meaningful can be extracted.
+local function summarize_first_prop(tvbuf, offset)
+    local remaining = tvbuf:reported_length_remaining(offset)
+    if remaining < 4 then return "" end
+    local pid = tvbuf:range(offset, 1):uint()
+    local data = tvbuf:range(offset + 1, 1):uint()
+    local plen = tvbuf:range(offset + 2, 2):uint()
+    if plen < 4 then return "" end
+    local vlen = plen - 4
+    if vlen < 0 then vlen = 0 end
+    local voff = offset + 4
+
+    -- inline-in-data pids (value rides the header's data byte itself)
+    if pid == 1 then
+        local t = acp2_objtype_valstr[data] or ("type=" .. data)
+        return "type=" .. t
+    elseif pid == 3 then
+        return "access=" .. data
+    elseif pid == 5 then
+        local t = acp2_numtype_valstr[data] or ("nt=" .. data)
+        return "numtype=" .. t
+    elseif pid == 15 then
+        return "options=" .. data
+    end
+
+    if vlen == 0 then return "" end
+
+    if pid == 2 or pid == 13 or pid == 19 then
+        -- label / unit / event_messages = NUL-terminated UTF-8
+        local strlen = vlen
+        for i = 0, vlen - 1 do
+            if tvbuf:range(voff + i, 1):uint() == 0 then strlen = i; break end
+        end
+        if strlen == 0 then return "" end
+        return "\"" .. tvbuf:range(voff, strlen):string() .. "\""
+    elseif pid == 6 then
+        if vlen >= 2 then
+            return "maxlen=" .. tvbuf:range(voff, 2):uint()
+        end
+    elseif pid == 14 then
+        -- children array
+        local n = math.floor(vlen / 4)
+        return n .. " children"
+    elseif pid >= 8 and pid <= 12 then
+        -- value / default / min / max / step — decode by vtype in data byte
+        local vtype = data
+        if vtype <= 2 then
+            return "value=" .. tvbuf:range(voff, 4):int()
+        elseif vtype == 3 and vlen >= 8 then
+            return "value=" .. tvbuf:range(voff, 8):int64()
+        elseif vtype >= 4 and vtype <= 6 then
+            return "value=" .. tvbuf:range(voff, 4):uint()
+        elseif vtype == 7 and vlen >= 8 then
+            return "value=" .. tvbuf:range(voff, 8):uint64()
+        elseif vtype == 8 then
+            return string.format("value=%g", tvbuf:range(voff, 4):float())
+        elseif vtype == 9 then
+            return "enum=" .. tvbuf:range(voff, 4):uint()
+        elseif vtype == 10 then
+            return "ipv4=" .. tvbuf:range(voff, 4):ipv4()
+        elseif vtype == 11 then
+            local strlen = vlen
+            for i = 0, vlen - 1 do
+                if tvbuf:range(voff + i, 1):uint() == 0 then strlen = i; break end
+            end
+            if strlen == 0 then return "value=\"\"" end
+            return "value=\"" .. tvbuf:range(voff, strlen):string() .. "\""
+        end
+    end
+    return ""
+end
+
 function acp2_proto.dissector(tvbuf, pktinfo, root)
     local pktlen = tvbuf:reported_length_remaining()
     if pktlen < 4 then return 0 end
@@ -508,14 +583,16 @@ function acp2_proto.dissector(tvbuf, pktinfo, root)
     tree:add(acp2_f.type, tvbuf:range(0, 1))
     tree:add(acp2_f.mtid, tvbuf:range(1, 1))
 
-    local type_str = acp2_type_valstr[type_val] or "Unknown"
+    local type_short = { [0]="Req", [1]="Rep", [2]="Evt", [3]="Err" }
+    local type_str = type_short[type_val] or ("T" .. type_val)
     local info_parts = {}
+    table.insert(info_parts, type_str)
+    table.insert(info_parts, "mtid=" .. mtid_val)
 
     if type_val == 0 or type_val == 1 then
         -- Request or Reply
         tree:add(acp2_f.func, tvbuf:range(2, 1))
         local func_str = acp2_func_valstr[byte2] or ("func=" .. byte2)
-        table.insert(info_parts, type_str)
         table.insert(info_parts, func_str)
 
         if byte2 == 0 then
@@ -552,11 +629,13 @@ function acp2_proto.dissector(tvbuf, pktinfo, root)
                 tree:add(acp2_f.obj_id, tvbuf:range(4, 4))
                 tree:add(acp2_f.idx,    tvbuf:range(8, 4))
                 table.insert(info_parts, "obj=" .. obj_id)
-                table.insert(info_parts, pid_name)
+                table.insert(info_parts, "pid=" .. pid_name)
                 if idx ~= 0 then
                     table.insert(info_parts, "idx=" .. idx)
                 end
                 if type_val == 1 and pktlen > 12 then
+                    local vs = summarize_first_prop(tvbuf, 12)
+                    if vs ~= "" then table.insert(info_parts, vs) end
                     parse_properties(tvbuf, pktinfo, tree, 12)
                 end
             end
@@ -571,11 +650,13 @@ function acp2_proto.dissector(tvbuf, pktinfo, root)
                 tree:add(acp2_f.obj_id, tvbuf:range(4, 4))
                 tree:add(acp2_f.idx,    tvbuf:range(8, 4))
                 table.insert(info_parts, "obj=" .. obj_id)
-                table.insert(info_parts, pid_name)
+                table.insert(info_parts, "pid=" .. pid_name)
                 if idx ~= 0 then
                     table.insert(info_parts, "idx=" .. idx)
                 end
                 if pktlen > 12 then
+                    local vs = summarize_first_prop(tvbuf, 12)
+                    if vs ~= "" then table.insert(info_parts, vs) end
                     parse_properties(tvbuf, pktinfo, tree, 12)
                 end
             end
@@ -587,7 +668,7 @@ function acp2_proto.dissector(tvbuf, pktinfo, root)
         tree:add(acp2_f.pid, tvbuf:range(3, 1))
         local pid_name = acp2_pid_valstr[byte3] or ("pid=" .. byte3)
         table.insert(info_parts, "Announce")
-        table.insert(info_parts, pid_name)
+        table.insert(info_parts, "pid=" .. pid_name)
 
         if pktlen >= 12 then
             local obj_id = tvbuf:range(4, 4):uint()
@@ -599,6 +680,8 @@ function acp2_proto.dissector(tvbuf, pktinfo, root)
                 table.insert(info_parts, "idx=" .. idx)
             end
             if pktlen > 12 then
+                local vs = summarize_first_prop(tvbuf, 12)
+                if vs ~= "" then table.insert(info_parts, vs) end
                 parse_properties(tvbuf, pktinfo, tree, 12)
             end
         end

--- a/assets/acp2/dissector_acp2.lua
+++ b/assets/acp2/dissector_acp2.lua
@@ -16,6 +16,13 @@
 local AN2_HDR_LEN = 8
 local AN2_MAGIC   = 0xC635
 
+-- Side-channel from the ACP2 dissector back to its AN2 caller.
+-- Wireshark's Proto:dissector wrapper drops multi-return values, so we
+-- can't rely on `local consumed, info = acp2_proto.dissector(...)`.
+-- Module-local string set by acp2_proto.dissector on every invocation,
+-- read by the AN2 dissector right after the nested call.
+local acp2_last_info = ""
+
 -------------------------------------------------------------------------------
 -- Value-string tables
 -------------------------------------------------------------------------------
@@ -702,7 +709,12 @@ function acp2_proto.dissector(tvbuf, pktinfo, root)
         end
     end
 
-    return pktlen, table.concat(info_parts, " ")
+    -- Write composed info text to the module-local side-channel so the
+    -- AN2 caller can render it into pktinfo.cols.info. Multi-return here
+    -- is unreliable because Wireshark's Proto.dissector wrapper drops
+    -- extra values.
+    acp2_last_info = table.concat(info_parts, " ")
+    return pktlen
 end
 
 -------------------------------------------------------------------------------
@@ -817,18 +829,21 @@ local function dissect_one_an2(tvbuf, pktinfo, root, offset)
     local info_str = ""
 
     if proto_val == 2 and type_val == 4 and dlen > 0 then
-        -- ACP2 data frame: hand off to ACP2 dissector
+        -- ACP2 data frame: hand off to ACP2 dissector. We read the
+        -- composed info text from the module-local side-channel
+        -- `acp2_last_info`, because Wireshark's Proto.dissector wrapper
+        -- drops multi-return values when called via Lua.
+        acp2_last_info = ""
         local payload_tvb = tvbuf:range(offset + AN2_HDR_LEN, dlen):tvb()
-        local consumed, acp2_info = acp2_proto.dissector(payload_tvb, pktinfo, an2_tree)
-        info_str = "AN2 > ACP2 " .. (acp2_info or "")
-        info_str = info_str .. " " .. slot_str
+        acp2_proto.dissector(payload_tvb, pktinfo, an2_tree)
+        info_str = "AN2 > ACP2 " .. acp2_last_info .. " " .. slot_str
 
     elseif proto_val == 2 and dlen > 0 then
         -- ACP2 non-data frame (req/reply/event/error at AN2 level)
+        acp2_last_info = ""
         local payload_tvb = tvbuf:range(offset + AN2_HDR_LEN, dlen):tvb()
-        local consumed, acp2_info = acp2_proto.dissector(payload_tvb, pktinfo, an2_tree)
-        info_str = "AN2 " .. type_str .. " > ACP2 " .. (acp2_info or "")
-        info_str = info_str .. " " .. slot_str
+        acp2_proto.dissector(payload_tvb, pktinfo, an2_tree)
+        info_str = "AN2 " .. type_str .. " > ACP2 " .. acp2_last_info .. " " .. slot_str
 
     elseif proto_val == 0 and dlen > 0 then
         -- AN2 internal protocol

--- a/assets/acp2/dissector_acp2.lua
+++ b/assets/acp2/dissector_acp2.lua
@@ -586,29 +586,33 @@ local function summarize_first_prop(tvbuf, offset)
         local n = math.floor(vlen / 4)
         return n .. " children"
     elseif pid >= 8 and pid <= 12 then
-        -- value / default / min / max / step — decode by vtype in data byte
+        -- value / default / min / max / step — decode by vtype in data
+        -- byte. Tag each summary with the declared type so the Info
+        -- column reads e.g. `value(s8)=-40`, `value(float)=-35.3073`,
+        -- `value(string)="Input-A"` — no guessing needed.
         local vtype = data
+        local t = acp2_numtype_valstr[vtype] or ("vtype=" .. vtype)
         if vtype <= 2 then
-            return "value=" .. tvbuf:range(voff, 4):int()
+            return string.format("value(%s)=%d", t, tvbuf:range(voff, 4):int())
         elseif vtype == 3 and vlen >= 8 then
-            return "value=" .. tvbuf:range(voff, 8):int64()
+            return string.format("value(s64)=%s", tostring(tvbuf:range(voff, 8):int64()))
         elseif vtype >= 4 and vtype <= 6 then
-            return "value=" .. tvbuf:range(voff, 4):uint()
+            return string.format("value(%s)=%d", t, tvbuf:range(voff, 4):uint())
         elseif vtype == 7 and vlen >= 8 then
-            return "value=" .. tvbuf:range(voff, 8):uint64()
+            return string.format("value(u64)=%s", tostring(tvbuf:range(voff, 8):uint64()))
         elseif vtype == 8 then
-            return string.format("value=%g", tvbuf:range(voff, 4):float())
+            return string.format("value(float)=%g", tvbuf:range(voff, 4):float())
         elseif vtype == 9 then
-            return "enum=" .. tvbuf:range(voff, 4):uint()
+            return string.format("value(enum)=%d", tvbuf:range(voff, 4):uint())
         elseif vtype == 10 then
-            return "ipv4=" .. tvbuf:range(voff, 4):ipv4()
+            return "value(ipv4)=" .. tostring(tvbuf:range(voff, 4):ipv4())
         elseif vtype == 11 then
             local strlen = vlen
             for i = 0, vlen - 1 do
                 if tvbuf:range(voff + i, 1):uint() == 0 then strlen = i; break end
             end
-            if strlen == 0 then return "value=\"\"" end
-            return "value=\"" .. tvbuf:range(voff, strlen):string() .. "\""
+            if strlen == 0 then return "value(string)=\"\"" end
+            return string.format("value(string)=\"%s\"", tvbuf:range(voff, strlen):string())
         end
     end
     return ""

--- a/assets/acp2/dissector_acp2.lua
+++ b/assets/acp2/dissector_acp2.lua
@@ -355,10 +355,33 @@ local function parse_property(tvbuf, pktinfo, parent_tree, offset)
 
     elseif pid_val >= 8 and pid_val <= 12 then
         -- value, default_value, min_value, max_value, step_size
-        -- vtype is in data byte
+        -- vtype is in data byte. Derive the containing object type from
+        -- vtype (spec §5.2.2 "Property value type") so the property tree
+        -- shows both the object category (Number/Enum/IPv4/String) and
+        -- the numeric subtype: e.g. "[Number.float]" instead of just
+        -- "[float]". This matters for announces, which only carry pid 8
+        -- and never pid 1 (object_type) — otherwise a consumer has to
+        -- remember per-obj context across frames to know what kind of
+        -- object just changed.
         local vtype = data_val
         local vtype_name = acp2_numtype_valstr[vtype] or ("vtype=" .. vtype)
-        tree:append_text(" [" .. vtype_name .. "]")
+        local obj_cat
+        if vtype <= 8 then
+            obj_cat = "Number"         -- s8/s16/s32/s64/u8/u16/u32/u64/float
+        elseif vtype == 9 then
+            obj_cat = "Enum/Preset"    -- u32 index
+        elseif vtype == 10 then
+            obj_cat = "IPv4"           -- 4 bytes
+        elseif vtype == 11 then
+            obj_cat = "String"         -- NUL-terminated UTF-8
+        else
+            obj_cat = "Unknown"
+        end
+        tree:append_text(" [" .. obj_cat .. "." .. vtype_name .. "]")
+        -- Expose the derived object category as a discrete field so
+        -- users can filter and the Detail panel shows it on its own row.
+        tree:add(prop_f.obj_type, tvbuf:range(offset + 1, 1))
+            :set_text("Object Category (derived): " .. obj_cat)
         if val_len > 0 then
             parse_numeric_value(tvbuf, tree, val_offset, vtype, val_len)
         end

--- a/assets/acp2/dissector_acp2.lua
+++ b/assets/acp2/dissector_acp2.lua
@@ -220,33 +220,46 @@ end
 local function parse_numeric_value(tvbuf, tree, offset, vtype, remaining)
     if remaining < 4 then return end
 
+    -- Spec §5.4 "Property value wire sizes":
+    --   s8/s16/s32 all stored as 4-byte signed (sign-extended)
+    --   u8/u16/u32 all stored as 4-byte unsigned (zero-extended)
+    --   s64/u64    stored as 8 bytes
+    --   float      stored as 4 bytes
+    -- The Wireshark ProtoField types are fixed at declaration, so we
+    -- always read 4/8 bytes and override the displayed label via
+    -- set_text() to reflect the DECLARED type (s8/s16/s32/u8/...) —
+    -- matches the "[Number.sX]" annotation in the property header.
+    local type_label = acp2_numtype_valstr[vtype] or ("vtype=" .. vtype)
+
     if vtype >= 0 and vtype <= 2 then
-        -- s8, s16, s32 all stored as s32
+        local v = tvbuf:range(offset, 4):int()
         tree:add(prop_f.val_s32, tvbuf:range(offset, 4))
+            :set_text(string.format("Value (%s): %d", type_label, v))
     elseif vtype == 3 then
-        -- s64
         if remaining >= 8 then
             tree:add(prop_f.val_s64, tvbuf:range(offset, 8))
+                :set_text("Value (s64): " .. tostring(tvbuf:range(offset, 8):int64()))
         end
     elseif vtype >= 4 and vtype <= 6 then
-        -- u8, u16, u32 all stored as u32
+        local v = tvbuf:range(offset, 4):uint()
         tree:add(prop_f.val_u32, tvbuf:range(offset, 4))
+            :set_text(string.format("Value (%s): %d", type_label, v))
     elseif vtype == 7 then
-        -- u64
         if remaining >= 8 then
             tree:add(prop_f.val_u64, tvbuf:range(offset, 8))
+                :set_text("Value (u64): " .. tostring(tvbuf:range(offset, 8):uint64()))
         end
     elseif vtype == 8 then
-        -- float stored as 4 bytes
+        local v = tvbuf:range(offset, 4):float()
         tree:add(prop_f.val_float, tvbuf:range(offset, 4))
+            :set_text(string.format("Value (float): %g", v))
     elseif vtype == 9 then
-        -- preset/enum stored as u32
+        local v = tvbuf:range(offset, 4):uint()
         tree:add(prop_f.val_u32, tvbuf:range(offset, 4))
+            :set_text(string.format("Value (enum/preset index): %d", v))
     elseif vtype == 10 then
-        -- ipv4
         tree:add(prop_f.val_ipv4, tvbuf:range(offset, 4))
     elseif vtype == 11 then
-        -- string: null-terminated
         local str_bytes = tvbuf:range(offset, remaining):bytes()
         local str_len = remaining
         for i = 0, remaining - 1 do
@@ -256,7 +269,9 @@ local function parse_numeric_value(tvbuf, tree, offset, vtype, remaining)
             end
         end
         if str_len > 0 then
+            local s = tvbuf:range(offset, str_len):string()
             tree:add(prop_f.val_str, tvbuf:range(offset, str_len))
+                :set_text(string.format("Value (string): \"%s\"", s))
         end
     end
 end

--- a/internal/probel/cmd_crosspoint_connect.go
+++ b/internal/probel/cmd_crosspoint_connect.go
@@ -1,0 +1,199 @@
+package probel
+
+// --- rx 002 / rx 130 : Crosspoint Connect Message --------------------------
+
+// CrosspointConnectParams is the request to route source S to destination D on
+// (matrix M, level L). The router replies with tx 004 (general) or 0x84
+// (extended) carrying the same fields once the route is confirmed.
+//
+// Reference: TS rx/002/params.ts CrossPointConnectMessageCommandParams.
+type CrosspointConnectParams struct {
+	MatrixID      uint8
+	LevelID       uint8
+	DestinationID uint16
+	SourceID      uint16
+}
+
+func (p CrosspointConnectParams) needsExtended() bool {
+	return p.DestinationID > 895 || p.SourceID > 1023 ||
+		p.MatrixID > 15 || p.LevelID > 15
+}
+
+// EncodeCrosspointConnect builds the CROSSPOINT CONNECT request frame.
+//
+// General form (CommandID 0x02 — 4 data bytes):
+//
+//	| Byte | Field          | Notes                                     |
+//	|------|----------------|-------------------------------------------|
+//	|  1   | Matrix / Level | bits[4-7] = Matrix, bits[0-3] = Level     |
+//	|  2   | Multiplier     | bits[4-6] = Dest DIV 128                  |
+//	|      |                | bits[0-2] = Source DIV 128                |
+//	|  3   | Dest (low 7b)  | Destination MOD 128                       |
+//	|  4   | Src  (low 7b)  | Source MOD 128                            |
+//
+// Extended form (CommandID 0x82 — 6 data bytes):
+//
+//	| Byte | Field           | Notes                                    |
+//	|------|-----------------|------------------------------------------|
+//	|  1   | Matrix          | full 8-bit                               |
+//	|  2   | Level           | full 8-bit                               |
+//	|  3   | Dest multiplier | Destination DIV 256                      |
+//	|  4   | Dest (low 8b)   | Destination MOD 256                      |
+//	|  5   | Src  multiplier | Source DIV 256                           |
+//	|  6   | Src  (low 8b)   | Source MOD 256                           |
+//
+// Spec: SW-P-88 §5.5. Reference: TS rx/002/command.ts.
+func EncodeCrosspointConnect(p CrosspointConnectParams) Frame {
+	if p.needsExtended() {
+		return Frame{
+			ID: RxCrosspointConnectExt,
+			Payload: []byte{
+				p.MatrixID,
+				p.LevelID,
+				byte(p.DestinationID / 256),
+				byte(p.DestinationID % 256),
+				byte(p.SourceID / 256),
+				byte(p.SourceID % 256),
+			},
+		}
+	}
+	return Frame{
+		ID: RxCrosspointConnect,
+		Payload: []byte{
+			(p.MatrixID << 4) | (p.LevelID & 0x0F),
+			byte(((p.DestinationID/128)<<4)&0x70) | byte((p.SourceID/128)&0x0F),
+			byte(p.DestinationID % 128),
+			byte(p.SourceID % 128),
+		},
+	}
+}
+
+// DecodeCrosspointConnect parses a general 0x02 or extended 0x82 payload.
+func DecodeCrosspointConnect(f Frame) (CrosspointConnectParams, error) {
+	switch f.ID {
+	case RxCrosspointConnect:
+		if len(f.Payload) < 4 {
+			return CrosspointConnectParams{}, ErrShortPayload
+		}
+		return CrosspointConnectParams{
+			MatrixID:      f.Payload[0] >> 4,
+			LevelID:       f.Payload[0] & 0x0F,
+			DestinationID: (uint16(f.Payload[1]>>4) & 0x07) * 128 + uint16(f.Payload[2]),
+			SourceID:      (uint16(f.Payload[1]) & 0x07) * 128 + uint16(f.Payload[3]),
+		}, nil
+	case RxCrosspointConnectExt:
+		if len(f.Payload) < 6 {
+			return CrosspointConnectParams{}, ErrShortPayload
+		}
+		return CrosspointConnectParams{
+			MatrixID:      f.Payload[0],
+			LevelID:       f.Payload[1],
+			DestinationID: uint16(f.Payload[2])*256 + uint16(f.Payload[3]),
+			SourceID:      uint16(f.Payload[4])*256 + uint16(f.Payload[5]),
+		}, nil
+	default:
+		return CrosspointConnectParams{}, ErrWrongCommand
+	}
+}
+
+// --- tx 004 / tx 132 : Crosspoint Connected Message ------------------------
+
+// CrosspointConnectedParams is the router's broadcast-style confirmation that
+// (matrix M, level L, dest D) is now sourced by S. Emitted on ALL connected
+// ports after a CONNECT request succeeds — not addressed to a single peer.
+//
+// Reference: TS tx/004/params.ts CrossPointConnectedMessageCommandParams.
+// Wire layout identical to tx 003 (Crosspoint Tally); only the CommandID
+// byte differs.
+type CrosspointConnectedParams struct {
+	MatrixID      uint8
+	LevelID       uint8
+	DestinationID uint16
+	SourceID      uint16
+	Status        uint8 // extended only; reserved, 0
+}
+
+func (p CrosspointConnectedParams) needsExtended() bool {
+	return p.DestinationID > 895 || p.SourceID > 1023 ||
+		p.MatrixID > 15 || p.LevelID > 15
+}
+
+// EncodeCrosspointConnected builds the CROSSPOINT CONNECTED broadcast frame.
+//
+// General form (CommandID 0x04 — 4 data bytes) — identical layout to tx 003:
+//
+//	| Byte | Field          | Notes                                     |
+//	|------|----------------|-------------------------------------------|
+//	|  1   | Matrix / Level | bits[4-7] = Matrix, bits[0-3] = Level     |
+//	|  2   | Multiplier     | bits[4-6] = Dest DIV 128                  |
+//	|      |                | bits[0-2] = Source DIV 128                |
+//	|  3   | Dest (low 7b)  | Destination MOD 128                       |
+//	|  4   | Src  (low 7b)  | Source MOD 128                            |
+//
+// Extended form (CommandID 0x84 — 7 data bytes) — identical to tx 131:
+//
+//	| Byte | Field           | Notes                                    |
+//	|------|-----------------|------------------------------------------|
+//	|  1   | Matrix          | full 8-bit                               |
+//	|  2   | Level           | full 8-bit                               |
+//	|  3   | Dest multiplier | Destination DIV 256                      |
+//	|  4   | Dest (low 8b)   | Destination MOD 256                      |
+//	|  5   | Src  multiplier | Source DIV 256                           |
+//	|  6   | Src  (low 8b)   | Source MOD 256                           |
+//	|  7   | Status          | reserved, 0                              |
+//
+// Spec: SW-P-88 §5.6. Reference: TS tx/004/command.ts.
+func EncodeCrosspointConnected(p CrosspointConnectedParams) Frame {
+	if p.needsExtended() {
+		return Frame{
+			ID: TxCrosspointConnectedExt,
+			Payload: []byte{
+				p.MatrixID,
+				p.LevelID,
+				byte(p.DestinationID / 256),
+				byte(p.DestinationID % 256),
+				byte(p.SourceID / 256),
+				byte(p.SourceID % 256),
+				p.Status,
+			},
+		}
+	}
+	return Frame{
+		ID: TxCrosspointConnected,
+		Payload: []byte{
+			(p.MatrixID << 4) | (p.LevelID & 0x0F),
+			byte(((p.DestinationID/128)<<4)&0x70) | byte((p.SourceID/128)&0x0F),
+			byte(p.DestinationID % 128),
+			byte(p.SourceID % 128),
+		},
+	}
+}
+
+// DecodeCrosspointConnected parses a general 0x04 or extended 0x84 payload.
+func DecodeCrosspointConnected(f Frame) (CrosspointConnectedParams, error) {
+	switch f.ID {
+	case TxCrosspointConnected:
+		if len(f.Payload) < 4 {
+			return CrosspointConnectedParams{}, ErrShortPayload
+		}
+		return CrosspointConnectedParams{
+			MatrixID:      f.Payload[0] >> 4,
+			LevelID:       f.Payload[0] & 0x0F,
+			DestinationID: (uint16(f.Payload[1]>>4) & 0x07) * 128 + uint16(f.Payload[2]),
+			SourceID:      (uint16(f.Payload[1]) & 0x07) * 128 + uint16(f.Payload[3]),
+		}, nil
+	case TxCrosspointConnectedExt:
+		if len(f.Payload) < 7 {
+			return CrosspointConnectedParams{}, ErrShortPayload
+		}
+		return CrosspointConnectedParams{
+			MatrixID:      f.Payload[0],
+			LevelID:       f.Payload[1],
+			DestinationID: uint16(f.Payload[2])*256 + uint16(f.Payload[3]),
+			SourceID:      uint16(f.Payload[4])*256 + uint16(f.Payload[5]),
+			Status:        f.Payload[6],
+		}, nil
+	default:
+		return CrosspointConnectedParams{}, ErrWrongCommand
+	}
+}

--- a/internal/probel/cmd_crosspoint_connect_test.go
+++ b/internal/probel/cmd_crosspoint_connect_test.go
@@ -1,0 +1,97 @@
+package probel
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+func TestCrosspointConnect_General(t *testing.T) {
+	p := CrosspointConnectParams{MatrixID: 1, LevelID: 2, DestinationID: 500, SourceID: 600}
+	f := EncodeCrosspointConnect(p)
+	if f.ID != RxCrosspointConnect {
+		t.Errorf("ID got %#x want 0x02", f.ID)
+	}
+	// Same layout as tx 003: multiplier 0x34, dest%128=0x74, src%128=0x58
+	want := []byte{0x12, 0x34, 0x74, 0x58}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("Payload got %X want %X", f.Payload, want)
+	}
+	got, err := DecodeCrosspointConnect(f)
+	if err != nil || got != p {
+		t.Errorf("round-trip: got %+v err %v want %+v", got, err, p)
+	}
+}
+
+func TestCrosspointConnect_Extended(t *testing.T) {
+	p := CrosspointConnectParams{MatrixID: 16, LevelID: 2, DestinationID: 1000, SourceID: 2000}
+	f := EncodeCrosspointConnect(p)
+	if f.ID != RxCrosspointConnectExt {
+		t.Errorf("ID got %#x want 0x82", f.ID)
+	}
+	want := []byte{16, 2, 0x03, 0xE8, 0x07, 0xD0}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("Payload got %X want %X", f.Payload, want)
+	}
+	got, err := DecodeCrosspointConnect(f)
+	if err != nil || got != p {
+		t.Errorf("round-trip extended: got %+v err %v want %+v", got, err, p)
+	}
+}
+
+func TestCrosspointConnect_FramerRoundTrip(t *testing.T) {
+	p := CrosspointConnectParams{MatrixID: 3, LevelID: 4, DestinationID: 10, SourceID: 20}
+	wire := Pack(EncodeCrosspointConnect(p))
+	back, _, err := Unpack(wire)
+	if err != nil {
+		t.Fatalf("Unpack: %v", err)
+	}
+	got, err := DecodeCrosspointConnect(back)
+	if err != nil || got != p {
+		t.Errorf("got %+v err %v want %+v", got, err, p)
+	}
+}
+
+func TestCrosspointConnected_General(t *testing.T) {
+	// Matches tx 003 layout on wire; only ID differs.
+	p := CrosspointConnectedParams{MatrixID: 1, LevelID: 2, DestinationID: 500, SourceID: 600}
+	f := EncodeCrosspointConnected(p)
+	if f.ID != TxCrosspointConnected {
+		t.Errorf("ID got %#x want 0x04", f.ID)
+	}
+	want := []byte{0x12, 0x34, 0x74, 0x58}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("Payload got %X want %X", f.Payload, want)
+	}
+	got, err := DecodeCrosspointConnected(f)
+	if err != nil || got != p {
+		t.Errorf("round-trip: got %+v err %v want %+v", got, err, p)
+	}
+}
+
+func TestCrosspointConnected_Extended(t *testing.T) {
+	p := CrosspointConnectedParams{
+		MatrixID: 30, LevelID: 4, DestinationID: 1200, SourceID: 2000,
+	}
+	f := EncodeCrosspointConnected(p)
+	if f.ID != TxCrosspointConnectedExt {
+		t.Errorf("ID got %#x want 0x84", f.ID)
+	}
+	want := []byte{30, 4, 0x04, 0xB0, 0x07, 0xD0, 0x00}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("Payload got %X want %X", f.Payload, want)
+	}
+	got, err := DecodeCrosspointConnected(f)
+	if err != nil || got != p {
+		t.Errorf("round-trip extended: got %+v err %v want %+v", got, err, p)
+	}
+}
+
+func TestCrosspointConnect_DecodeErrors(t *testing.T) {
+	if _, err := DecodeCrosspointConnect(Frame{ID: RxCrosspointConnect, Payload: []byte{0x01, 0x02}}); !errors.Is(err, ErrShortPayload) {
+		t.Errorf("short: got %v", err)
+	}
+	if _, err := DecodeCrosspointConnected(Frame{ID: RxCrosspointConnect}); !errors.Is(err, ErrWrongCommand) {
+		t.Errorf("wrong: got %v", err)
+	}
+}

--- a/internal/probel/cmd_crosspoint_interrogate.go
+++ b/internal/probel/cmd_crosspoint_interrogate.go
@@ -1,0 +1,209 @@
+package probel
+
+import "errors"
+
+// Errors shared by per-command codecs. Kept in the same file pattern as TS
+// (each command file surfaces just the errors it can produce).
+var (
+	ErrShortPayload = errors.New("probel: frame payload too short for this command")
+	ErrWrongCommand = errors.New("probel: frame command ID does not match the expected command")
+)
+
+// --- rx 001 / rx 129 : Crosspoint Interrogate Message -----------------------
+
+// CrosspointInterrogateParams carries the inputs for a crosspoint interrogate
+// request (rx 001 general or rx 129/0x81 extended).  The encoder picks general
+// vs. extended automatically based on the field ranges.
+//
+// Reference: TS params.ts CrossPointInterrogateMessageCommandParams.
+type CrosspointInterrogateParams struct {
+	MatrixID      uint8  // 0-15 for general, 0-255 for extended
+	LevelID       uint8  // 0-15 for general, 0-255 for extended
+	DestinationID uint16 // 0-895 for general, 0-65535 for extended
+}
+
+// needsExtendedCrosspointInterrogate returns true when any param exceeds the
+// ranges encodable in the general (3-byte) form, forcing the extended (4-byte)
+// encoding with CommandID 0x81.
+//
+// Mirror of TS CrossPointInterrogateMessageCommand.isExtended — 895 DIV 128 < 7
+// means the 3-bit multiplier slot still fits.
+func (p CrosspointInterrogateParams) needsExtended() bool {
+	return p.DestinationID > 895 || p.MatrixID > 15 || p.LevelID > 15
+}
+
+// EncodeCrosspointInterrogate builds a Frame for the CROSSPOINT INTERROGATE
+// message (request tally for one destination).
+//
+// General form (CommandID 0x01 — 3 data bytes):
+//
+//	| Byte | Field           | Notes                                    |
+//	|------|-----------------|------------------------------------------|
+//	|  1   | Matrix / Level  | bits[4-7] = Matrix, bits[0-3] = Level    |
+//	|  2   | Multiplier      | bits[4-6] = Dest DIV 128 (3 bits)        |
+//	|      |                 | bits[0-2] = Source DIV 128 (here = 0)    |
+//	|  3   | Dest (low 7b)   | Destination MOD 128                      |
+//
+// Extended form (CommandID 0x81 — 4 data bytes):
+//
+//	| Byte | Field           | Notes                                    |
+//	|------|-----------------|------------------------------------------|
+//	|  1   | Matrix          | full 8-bit                               |
+//	|  2   | Level           | full 8-bit                               |
+//	|  3   | Dest multiplier | Destination DIV 256                      |
+//	|  4   | Dest (low 8b)   | Destination MOD 256                      |
+//
+// Spec: SW-P-88 §5.3.  Reference: TS rx/001/command.ts buildDataNormal /
+// buildDataExtended.
+func EncodeCrosspointInterrogate(p CrosspointInterrogateParams) Frame {
+	if p.needsExtended() {
+		return Frame{
+			ID: RxCrosspointInterrogateExt,
+			Payload: []byte{
+				p.MatrixID,
+				p.LevelID,
+				byte(p.DestinationID / 256),
+				byte(p.DestinationID % 256),
+			},
+		}
+	}
+	return Frame{
+		ID: RxCrosspointInterrogate,
+		Payload: []byte{
+			(p.MatrixID << 4) | (p.LevelID & 0x0F),
+			byte(((p.DestinationID / 128) << 4) & 0x70),
+			byte(p.DestinationID % 128),
+		},
+	}
+}
+
+// DecodeCrosspointInterrogate parses the payload of a CROSSPOINT INTERROGATE
+// frame (general 0x01 or extended 0x81) back into its params.
+func DecodeCrosspointInterrogate(f Frame) (CrosspointInterrogateParams, error) {
+	switch f.ID {
+	case RxCrosspointInterrogate:
+		if len(f.Payload) < 3 {
+			return CrosspointInterrogateParams{}, ErrShortPayload
+		}
+		return CrosspointInterrogateParams{
+			MatrixID:      f.Payload[0] >> 4,
+			LevelID:       f.Payload[0] & 0x0F,
+			DestinationID: (uint16(f.Payload[1]>>4) & 0x07) * 128 + uint16(f.Payload[2]),
+		}, nil
+	case RxCrosspointInterrogateExt:
+		if len(f.Payload) < 4 {
+			return CrosspointInterrogateParams{}, ErrShortPayload
+		}
+		return CrosspointInterrogateParams{
+			MatrixID:      f.Payload[0],
+			LevelID:       f.Payload[1],
+			DestinationID: uint16(f.Payload[2])*256 + uint16(f.Payload[3]),
+		}, nil
+	default:
+		return CrosspointInterrogateParams{}, ErrWrongCommand
+	}
+}
+
+// --- tx 003 / tx 131 : Crosspoint Tally Message ----------------------------
+
+// CrosspointTallyParams carries the router's reply to a CROSSPOINT INTERROGATE
+// request: "destination D on matrix M level L is currently sourced by S".
+// Reference: TS tx/003/params.ts CrossPointTallyMessageCommandParams.
+type CrosspointTallyParams struct {
+	MatrixID      uint8
+	LevelID       uint8
+	DestinationID uint16
+	SourceID      uint16
+	Status        uint8 // extended only; "for future use", 0 in current spec
+}
+
+// needsExtendedCrosspointTally returns true when any param exceeds the ranges
+// encodable in the general (4-byte) form.
+//
+// Mirror of TS CrossPointTallyMessageCommand.isExtended.
+func (p CrosspointTallyParams) needsExtended() bool {
+	return p.DestinationID > 895 || p.SourceID > 1023 ||
+		p.MatrixID > 15 || p.LevelID > 15
+}
+
+// EncodeCrosspointTally builds a Frame for the CROSSPOINT TALLY reply.
+//
+// General form (CommandID 0x03 — 4 data bytes):
+//
+//	| Byte | Field          | Notes                                     |
+//	|------|----------------|-------------------------------------------|
+//	|  1   | Matrix / Level | bits[4-7] = Matrix, bits[0-3] = Level     |
+//	|  2   | Multiplier     | bits[4-6] = Dest DIV 128                  |
+//	|      |                | bits[0-2] = Source DIV 128                |
+//	|  3   | Dest (low 7b)  | Destination MOD 128                       |
+//	|  4   | Src  (low 7b)  | Source MOD 128                            |
+//
+// Extended form (CommandID 0x83 — 7 data bytes):
+//
+//	| Byte | Field           | Notes                                    |
+//	|------|-----------------|------------------------------------------|
+//	|  1   | Matrix          | full 8-bit                               |
+//	|  2   | Level           | full 8-bit                               |
+//	|  3   | Dest multiplier | Destination DIV 256                      |
+//	|  4   | Dest (low 8b)   | Destination MOD 256                      |
+//	|  5   | Src  multiplier | Source DIV 256                           |
+//	|  6   | Src  (low 8b)   | Source MOD 256                           |
+//	|  7   | Status          | reserved, 0                              |
+//
+// Spec: SW-P-88 §5.4.  Reference: TS tx/003/command.ts buildDataNormal /
+// buildDataExtended.
+func EncodeCrosspointTally(p CrosspointTallyParams) Frame {
+	if p.needsExtended() {
+		return Frame{
+			ID: TxCrosspointTallyExt,
+			Payload: []byte{
+				p.MatrixID,
+				p.LevelID,
+				byte(p.DestinationID / 256),
+				byte(p.DestinationID % 256),
+				byte(p.SourceID / 256),
+				byte(p.SourceID % 256),
+				p.Status,
+			},
+		}
+	}
+	return Frame{
+		ID: TxCrosspointTally,
+		Payload: []byte{
+			(p.MatrixID << 4) | (p.LevelID & 0x0F),
+			byte(((p.DestinationID/128)<<4)&0x70) | byte((p.SourceID/128)&0x0F),
+			byte(p.DestinationID % 128),
+			byte(p.SourceID % 128),
+		},
+	}
+}
+
+// DecodeCrosspointTally parses the payload of a CROSSPOINT TALLY frame
+// (general 0x03 or extended 0x83).
+func DecodeCrosspointTally(f Frame) (CrosspointTallyParams, error) {
+	switch f.ID {
+	case TxCrosspointTally:
+		if len(f.Payload) < 4 {
+			return CrosspointTallyParams{}, ErrShortPayload
+		}
+		return CrosspointTallyParams{
+			MatrixID:      f.Payload[0] >> 4,
+			LevelID:       f.Payload[0] & 0x0F,
+			DestinationID: (uint16(f.Payload[1]>>4) & 0x07) * 128 + uint16(f.Payload[2]),
+			SourceID:      (uint16(f.Payload[1]) & 0x07) * 128 + uint16(f.Payload[3]),
+		}, nil
+	case TxCrosspointTallyExt:
+		if len(f.Payload) < 7 {
+			return CrosspointTallyParams{}, ErrShortPayload
+		}
+		return CrosspointTallyParams{
+			MatrixID:      f.Payload[0],
+			LevelID:       f.Payload[1],
+			DestinationID: uint16(f.Payload[2])*256 + uint16(f.Payload[3]),
+			SourceID:      uint16(f.Payload[4])*256 + uint16(f.Payload[5]),
+			Status:        f.Payload[6],
+		}, nil
+	default:
+		return CrosspointTallyParams{}, ErrWrongCommand
+	}
+}

--- a/internal/probel/cmd_crosspoint_interrogate_test.go
+++ b/internal/probel/cmd_crosspoint_interrogate_test.go
@@ -1,0 +1,149 @@
+package probel
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+func TestCrosspointInterrogate_General(t *testing.T) {
+	p := CrosspointInterrogateParams{MatrixID: 1, LevelID: 2, DestinationID: 500}
+	f := EncodeCrosspointInterrogate(p)
+
+	if f.ID != RxCrosspointInterrogate {
+		t.Errorf("ID got %#x want %#x (general)", f.ID, RxCrosspointInterrogate)
+	}
+	// byte 1 = matrix<<4 | level = 0x12
+	// dest 500 = 3*128 + 116, so multiplier byte = (3<<4)&0x70 = 0x30; src=0
+	// dest%128 = 116 = 0x74
+	want := []byte{0x12, 0x30, 0x74}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("Payload got %X want %X", f.Payload, want)
+	}
+
+	got, err := DecodeCrosspointInterrogate(f)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got != p {
+		t.Errorf("round-trip: got %+v want %+v", got, p)
+	}
+}
+
+func TestCrosspointInterrogate_Extended_ByDest(t *testing.T) {
+	p := CrosspointInterrogateParams{MatrixID: 0, LevelID: 0, DestinationID: 1000}
+	f := EncodeCrosspointInterrogate(p)
+	if f.ID != RxCrosspointInterrogateExt {
+		t.Errorf("ID got %#x want %#x", f.ID, RxCrosspointInterrogateExt)
+	}
+	// 1000 = 3*256 + 232
+	want := []byte{0x00, 0x00, 0x03, 0xE8}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("Payload got %X want %X", f.Payload, want)
+	}
+	got, err := DecodeCrosspointInterrogate(f)
+	if err != nil || got != p {
+		t.Errorf("round-trip: got %+v err %v want %+v", got, err, p)
+	}
+}
+
+func TestCrosspointInterrogate_ExtendedByMatrix(t *testing.T) {
+	p := CrosspointInterrogateParams{MatrixID: 20, LevelID: 3, DestinationID: 5}
+	f := EncodeCrosspointInterrogate(p)
+	if f.ID != RxCrosspointInterrogateExt {
+		t.Errorf("matrix>15 should trigger extended: got %#x", f.ID)
+	}
+	got, _ := DecodeCrosspointInterrogate(f)
+	if got != p {
+		t.Errorf("round-trip: got %+v want %+v", got, p)
+	}
+}
+
+func TestCrosspointInterrogate_FramerRoundTrip(t *testing.T) {
+	p := CrosspointInterrogateParams{MatrixID: 5, LevelID: 7, DestinationID: 200}
+	f := EncodeCrosspointInterrogate(p)
+	wire := Pack(f)
+	// Decoded from the wire → Params round-trip via framer.
+	back, n, err := Unpack(wire)
+	if err != nil {
+		t.Fatalf("Unpack: %v", err)
+	}
+	if n != len(wire) {
+		t.Errorf("n=%d len(wire)=%d", n, len(wire))
+	}
+	got, err := DecodeCrosspointInterrogate(back)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got != p {
+		t.Errorf("round-trip via framer: got %+v want %+v", got, p)
+	}
+}
+
+func TestCrosspointInterrogate_DecodeErrors(t *testing.T) {
+	_, err := DecodeCrosspointInterrogate(Frame{ID: TxCrosspointTally})
+	if !errors.Is(err, ErrWrongCommand) {
+		t.Errorf("wrong command: got %v want ErrWrongCommand", err)
+	}
+	_, err = DecodeCrosspointInterrogate(Frame{ID: RxCrosspointInterrogate, Payload: []byte{0x01}})
+	if !errors.Is(err, ErrShortPayload) {
+		t.Errorf("short general: got %v want ErrShortPayload", err)
+	}
+	_, err = DecodeCrosspointInterrogate(Frame{ID: RxCrosspointInterrogateExt, Payload: []byte{0x01, 0x02, 0x03}})
+	if !errors.Is(err, ErrShortPayload) {
+		t.Errorf("short extended: got %v want ErrShortPayload", err)
+	}
+}
+
+func TestCrosspointTally_General(t *testing.T) {
+	p := CrosspointTallyParams{MatrixID: 1, LevelID: 2, DestinationID: 500, SourceID: 600}
+	f := EncodeCrosspointTally(p)
+	if f.ID != TxCrosspointTally {
+		t.Errorf("ID got %#x want general 0x03", f.ID)
+	}
+	// matrix/level = 0x12
+	// multiplier: dest=500/128=3 → bits 4-6 = 0x30 ; src=600/128=4 → bits 0-2 = 0x04
+	//            combined = 0x34
+	// dest%128 = 116 = 0x74 ; src%128 = 600-4*128=88 = 0x58
+	want := []byte{0x12, 0x34, 0x74, 0x58}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("Payload got %X want %X", f.Payload, want)
+	}
+	got, err := DecodeCrosspointTally(f)
+	if err != nil || got != p {
+		t.Errorf("round-trip general: got %+v err %v want %+v", got, err, p)
+	}
+}
+
+func TestCrosspointTally_Extended(t *testing.T) {
+	p := CrosspointTallyParams{
+		MatrixID: 30, LevelID: 4, DestinationID: 1200, SourceID: 2000, Status: 0,
+	}
+	f := EncodeCrosspointTally(p)
+	if f.ID != TxCrosspointTallyExt {
+		t.Errorf("ID got %#x want extended 0x83", f.ID)
+	}
+	// 1200 = 4*256 + 176 → 04 B0
+	// 2000 = 7*256 + 208 → 07 D0
+	want := []byte{30, 4, 0x04, 0xB0, 0x07, 0xD0, 0x00}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("Payload got %X want %X", f.Payload, want)
+	}
+	got, err := DecodeCrosspointTally(f)
+	if err != nil || got != p {
+		t.Errorf("round-trip extended: got %+v err %v want %+v", got, err, p)
+	}
+}
+
+func TestCrosspointTally_FramerRoundTrip(t *testing.T) {
+	p := CrosspointTallyParams{MatrixID: 2, LevelID: 1, DestinationID: 42, SourceID: 7}
+	wire := Pack(EncodeCrosspointTally(p))
+	back, _, err := Unpack(wire)
+	if err != nil {
+		t.Fatalf("Unpack: %v", err)
+	}
+	got, err := DecodeCrosspointTally(back)
+	if err != nil || got != p {
+		t.Errorf("round-trip via framer: got %+v err %v want %+v", got, err, p)
+	}
+}

--- a/internal/probel/cmd_crosspoint_tally_dump.go
+++ b/internal/probel/cmd_crosspoint_tally_dump.go
@@ -1,0 +1,256 @@
+package probel
+
+// --- rx 021 / rx 149 : Crosspoint Tally Dump Request ------------------------
+
+// CrosspointTallyDumpRequestParams asks the controller to dump the full tally
+// table for one (matrix, level) pair. Reply arrives as one or more tx 022
+// (byte form) and/or tx 023 (word form) messages depending on destination
+// count and matrix size.
+//
+// Reference: TS rx/021/params.ts CrossPointTallyDumpRequestMessageCommandParams.
+type CrosspointTallyDumpRequestParams struct {
+	MatrixID uint8 // 0-15 general, 0-255 extended
+	LevelID  uint8 // 0-15 general, 0-255 extended
+}
+
+func (p CrosspointTallyDumpRequestParams) needsExtended() bool {
+	return p.MatrixID > 15 || p.LevelID > 15
+}
+
+// EncodeCrosspointTallyDumpRequest builds the CROSSPOINT TALLY DUMP REQUEST.
+//
+// General form (CommandID 0x15 — 1-byte payload):
+//
+//	| Byte | Field          | Notes                                     |
+//	|------|----------------|-------------------------------------------|
+//	|  1   | Matrix / Level | bits[4-7] = Matrix, bits[0-3] = Level     |
+//
+// Extended form (CommandID 0x95 — 2-byte payload):
+//
+//	| Byte | Field          | Notes                                     |
+//	|------|----------------|-------------------------------------------|
+//	|  1   | Matrix         | full 8-bit                                |
+//	|  2   | Level          | full 8-bit                                |
+//
+// Spec: SW-P-88 §5.22. Reference: TS rx/021/command.ts.
+func EncodeCrosspointTallyDumpRequest(p CrosspointTallyDumpRequestParams) Frame {
+	if p.needsExtended() {
+		return Frame{
+			ID:      RxCrosspointTallyDumpRequestExt,
+			Payload: []byte{p.MatrixID, p.LevelID},
+		}
+	}
+	return Frame{
+		ID:      RxCrosspointTallyDumpRequest,
+		Payload: []byte{(p.MatrixID << 4) | (p.LevelID & 0x0F)},
+	}
+}
+
+// DecodeCrosspointTallyDumpRequest parses the general (0x15) or extended
+// (0x95) request payload.
+func DecodeCrosspointTallyDumpRequest(f Frame) (CrosspointTallyDumpRequestParams, error) {
+	switch f.ID {
+	case RxCrosspointTallyDumpRequest:
+		if len(f.Payload) < 1 {
+			return CrosspointTallyDumpRequestParams{}, ErrShortPayload
+		}
+		return CrosspointTallyDumpRequestParams{
+			MatrixID: f.Payload[0] >> 4,
+			LevelID:  f.Payload[0] & 0x0F,
+		}, nil
+	case RxCrosspointTallyDumpRequestExt:
+		if len(f.Payload) < 2 {
+			return CrosspointTallyDumpRequestParams{}, ErrShortPayload
+		}
+		return CrosspointTallyDumpRequestParams{
+			MatrixID: f.Payload[0],
+			LevelID:  f.Payload[1],
+		}, nil
+	default:
+		return CrosspointTallyDumpRequestParams{}, ErrWrongCommand
+	}
+}
+
+// --- tx 022 : Crosspoint Tally Dump (Byte) ---------------------------------
+
+// CrosspointTallyDumpByteParams is the compact 1-byte-per-ID dump used when
+// destination AND source IDs both fit in 7 bits (≤ 191 per Probel spec; the
+// TS emulator notes "max 191"). SourceIDs[i] is the source currently routed to
+// destination FirstDestinationID+i.
+//
+// Reference: TS tx/022/params.ts CrossPointTallyDumpByteCommandParams.
+// SW-P-08 caps one frame at 133 bytes, so callers dumping > ~128 destinations
+// must split into multiple frames (each with its own FirstDestinationID).
+type CrosspointTallyDumpByteParams struct {
+	MatrixID           uint8
+	LevelID            uint8
+	FirstDestinationID uint8
+	SourceIDs          []uint8
+}
+
+// EncodeCrosspointTallyDumpByte builds one TX 022 frame. Caller is
+// responsible for chunking a large tally table into multiple calls.
+//
+// General form (CommandID 0x16 — 3 + N payload bytes, N = len(SourceIDs)):
+//
+//	| Byte | Field               | Notes                                  |
+//	|------|---------------------|----------------------------------------|
+//	|  1   | Matrix / Level      | bits[4-7] = Matrix, bits[0-3] = Level  |
+//	|  2   | Tallies returned    | N = len(SourceIDs), max 191            |
+//	|  3   | First destination   | (u8)                                   |
+//	|  4..N+3 | Source IDs       | one byte per destination, ascending    |
+//
+// Spec: SW-P-88 §5.23. Reference: TS tx/022/command.ts buildDataNormal.
+func EncodeCrosspointTallyDumpByte(p CrosspointTallyDumpByteParams) Frame {
+	out := make([]byte, 0, 3+len(p.SourceIDs))
+	out = append(out,
+		(p.MatrixID<<4)|(p.LevelID&0x0F),
+		byte(len(p.SourceIDs)),
+		p.FirstDestinationID,
+	)
+	out = append(out, p.SourceIDs...)
+	return Frame{ID: TxCrosspointTallyDumpByte, Payload: out}
+}
+
+// DecodeCrosspointTallyDumpByte parses a TX 022 payload.
+func DecodeCrosspointTallyDumpByte(f Frame) (CrosspointTallyDumpByteParams, error) {
+	if f.ID != TxCrosspointTallyDumpByte {
+		return CrosspointTallyDumpByteParams{}, ErrWrongCommand
+	}
+	if len(f.Payload) < 3 {
+		return CrosspointTallyDumpByteParams{}, ErrShortPayload
+	}
+	tallies := int(f.Payload[1])
+	if len(f.Payload) < 3+tallies {
+		return CrosspointTallyDumpByteParams{}, ErrShortPayload
+	}
+	src := make([]uint8, tallies)
+	copy(src, f.Payload[3:3+tallies])
+	return CrosspointTallyDumpByteParams{
+		MatrixID:           f.Payload[0] >> 4,
+		LevelID:            f.Payload[0] & 0x0F,
+		FirstDestinationID: f.Payload[2],
+		SourceIDs:          src,
+	}, nil
+}
+
+// --- tx 023 / tx 151 : Crosspoint Tally Dump (Word) ------------------------
+
+// CrosspointTallyDumpWordParams carries the wide-address tally dump
+// (destinations and sources addressed with u16). SourceIDs[i] is the source
+// routed to destination FirstDestinationID+i.
+//
+// Reference: TS tx/023/params.ts CrossPointTallyDumpWordCommandParams.
+type CrosspointTallyDumpWordParams struct {
+	MatrixID           uint8
+	LevelID            uint8
+	FirstDestinationID uint16
+	SourceIDs          []uint16
+}
+
+func (p CrosspointTallyDumpWordParams) needsExtended() bool {
+	return p.MatrixID > 15 || p.LevelID > 15 || p.FirstDestinationID > 895
+}
+
+// EncodeCrosspointTallyDumpWord builds one TX 023 / TX 151 frame.
+//
+// General form (CommandID 0x17 — 4 + 2N payload bytes, N = len(SourceIDs)):
+//
+//	| Byte | Field                | Notes                                 |
+//	|------|----------------------|---------------------------------------|
+//	|  1   | Matrix / Level       | bits[4-7] = Matrix, bits[0-3] = Level |
+//	|  2   | Tallies returned     | N = len(SourceIDs), max 64            |
+//	|  3   | 1st Dest multiplier  | FirstDestinationID DIV 256            |
+//	|  4   | 1st Dest number      | FirstDestinationID MOD 256            |
+//	|  5,7,... | Src multiplier   | SourceIDs[i] DIV 256                  |
+//	|  6,8,... | Src number       | SourceIDs[i] MOD 256                  |
+//
+// Extended form (CommandID 0x97 — 5 + 2N payload bytes):
+//
+//	| Byte | Field                | Notes                                 |
+//	|------|----------------------|---------------------------------------|
+//	|  1   | Matrix               | full 8-bit                            |
+//	|  2   | Level                | full 8-bit                            |
+//	|  3   | Tallies returned     | N = len(SourceIDs), max 64            |
+//	|  4   | 1st Dest multiplier  | FirstDestinationID DIV 256            |
+//	|  5   | 1st Dest number      | FirstDestinationID MOD 256            |
+//	|  6,8,... | Src multiplier   | SourceIDs[i] DIV 256                  |
+//	|  7,9,... | Src number       | SourceIDs[i] MOD 256                  |
+//
+// Spec: SW-P-88 §5.24. Reference: TS tx/023/command.ts.
+func EncodeCrosspointTallyDumpWord(p CrosspointTallyDumpWordParams) Frame {
+	n := len(p.SourceIDs)
+	if p.needsExtended() {
+		out := make([]byte, 0, 5+2*n)
+		out = append(out,
+			p.MatrixID,
+			p.LevelID,
+			byte(n),
+			byte(p.FirstDestinationID/256),
+			byte(p.FirstDestinationID%256),
+		)
+		for _, s := range p.SourceIDs {
+			out = append(out, byte(s/256), byte(s%256))
+		}
+		return Frame{ID: TxCrosspointTallyDumpWordExt, Payload: out}
+	}
+	out := make([]byte, 0, 4+2*n)
+	out = append(out,
+		(p.MatrixID<<4)|(p.LevelID&0x0F),
+		byte(n),
+		byte(p.FirstDestinationID/256),
+		byte(p.FirstDestinationID%256),
+	)
+	for _, s := range p.SourceIDs {
+		out = append(out, byte(s/256), byte(s%256))
+	}
+	return Frame{ID: TxCrosspointTallyDumpWord, Payload: out}
+}
+
+// DecodeCrosspointTallyDumpWord parses a TX 023 (general) or TX 151
+// (extended) payload.
+func DecodeCrosspointTallyDumpWord(f Frame) (CrosspointTallyDumpWordParams, error) {
+	var (
+		matrix, level byte
+		headerLen     int
+		tallies       int
+		firstDest     uint16
+	)
+	switch f.ID {
+	case TxCrosspointTallyDumpWord:
+		if len(f.Payload) < 4 {
+			return CrosspointTallyDumpWordParams{}, ErrShortPayload
+		}
+		matrix = f.Payload[0] >> 4
+		level = f.Payload[0] & 0x0F
+		tallies = int(f.Payload[1])
+		firstDest = uint16(f.Payload[2])*256 + uint16(f.Payload[3])
+		headerLen = 4
+	case TxCrosspointTallyDumpWordExt:
+		if len(f.Payload) < 5 {
+			return CrosspointTallyDumpWordParams{}, ErrShortPayload
+		}
+		matrix = f.Payload[0]
+		level = f.Payload[1]
+		tallies = int(f.Payload[2])
+		firstDest = uint16(f.Payload[3])*256 + uint16(f.Payload[4])
+		headerLen = 5
+	default:
+		return CrosspointTallyDumpWordParams{}, ErrWrongCommand
+	}
+	if len(f.Payload) < headerLen+2*tallies {
+		return CrosspointTallyDumpWordParams{}, ErrShortPayload
+	}
+	src := make([]uint16, tallies)
+	for i := 0; i < tallies; i++ {
+		hi := uint16(f.Payload[headerLen+2*i])
+		lo := uint16(f.Payload[headerLen+2*i+1])
+		src[i] = hi*256 + lo
+	}
+	return CrosspointTallyDumpWordParams{
+		MatrixID:           matrix,
+		LevelID:            level,
+		FirstDestinationID: firstDest,
+		SourceIDs:          src,
+	}, nil
+}

--- a/internal/probel/cmd_crosspoint_tally_dump_test.go
+++ b/internal/probel/cmd_crosspoint_tally_dump_test.go
@@ -1,0 +1,146 @@
+package probel
+
+import (
+	"bytes"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestTallyDumpRequest_General(t *testing.T) {
+	p := CrosspointTallyDumpRequestParams{MatrixID: 1, LevelID: 2}
+	f := EncodeCrosspointTallyDumpRequest(p)
+	if f.ID != RxCrosspointTallyDumpRequest {
+		t.Errorf("ID got %#x", f.ID)
+	}
+	if !bytes.Equal(f.Payload, []byte{0x12}) {
+		t.Errorf("Payload got %X", f.Payload)
+	}
+	got, err := DecodeCrosspointTallyDumpRequest(f)
+	if err != nil || got != p {
+		t.Errorf("round-trip: got %+v err %v", got, err)
+	}
+}
+
+func TestTallyDumpRequest_Extended(t *testing.T) {
+	p := CrosspointTallyDumpRequestParams{MatrixID: 200, LevelID: 30}
+	f := EncodeCrosspointTallyDumpRequest(p)
+	if f.ID != RxCrosspointTallyDumpRequestExt {
+		t.Errorf("ID got %#x", f.ID)
+	}
+	if !bytes.Equal(f.Payload, []byte{200, 30}) {
+		t.Errorf("Payload got %X", f.Payload)
+	}
+	got, err := DecodeCrosspointTallyDumpRequest(f)
+	if err != nil || got != p {
+		t.Errorf("round-trip: got %+v err %v", got, err)
+	}
+}
+
+func TestTallyDumpByte_RoundTrip(t *testing.T) {
+	p := CrosspointTallyDumpByteParams{
+		MatrixID:           2,
+		LevelID:            3,
+		FirstDestinationID: 10,
+		SourceIDs:          []uint8{100, 101, 102, 103},
+	}
+	f := EncodeCrosspointTallyDumpByte(p)
+	if f.ID != TxCrosspointTallyDumpByte {
+		t.Errorf("ID got %#x", f.ID)
+	}
+	// matrix/level = 0x23, tallies=4, firstDest=10, then 100,101,102,103
+	want := []byte{0x23, 0x04, 0x0A, 100, 101, 102, 103}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("Payload got %X want %X", f.Payload, want)
+	}
+	got, err := DecodeCrosspointTallyDumpByte(f)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got.MatrixID != p.MatrixID || got.LevelID != p.LevelID ||
+		got.FirstDestinationID != p.FirstDestinationID ||
+		!reflect.DeepEqual(got.SourceIDs, p.SourceIDs) {
+		t.Errorf("round-trip: got %+v want %+v", got, p)
+	}
+}
+
+func TestTallyDumpByte_Framer(t *testing.T) {
+	p := CrosspointTallyDumpByteParams{
+		MatrixID: 0, LevelID: 0, FirstDestinationID: 0,
+		SourceIDs: []uint8{1, 2, 3, 4, 5},
+	}
+	wire := Pack(EncodeCrosspointTallyDumpByte(p))
+	back, _, err := Unpack(wire)
+	if err != nil {
+		t.Fatalf("Unpack: %v", err)
+	}
+	got, err := DecodeCrosspointTallyDumpByte(back)
+	if err != nil || !reflect.DeepEqual(got.SourceIDs, p.SourceIDs) {
+		t.Errorf("framer round-trip got %+v err %v", got, err)
+	}
+}
+
+func TestTallyDumpWord_General(t *testing.T) {
+	p := CrosspointTallyDumpWordParams{
+		MatrixID:           1,
+		LevelID:            2,
+		FirstDestinationID: 500,
+		SourceIDs:          []uint16{1000, 1500},
+	}
+	f := EncodeCrosspointTallyDumpWord(p)
+	if f.ID != TxCrosspointTallyDumpWord {
+		t.Errorf("ID got %#x", f.ID)
+	}
+	// 500 = 01F4 (01 F4); 1000 = 03 E8; 1500 = 05 DC
+	want := []byte{0x12, 0x02, 0x01, 0xF4, 0x03, 0xE8, 0x05, 0xDC}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("Payload got %X want %X", f.Payload, want)
+	}
+	got, err := DecodeCrosspointTallyDumpWord(f)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got.MatrixID != p.MatrixID || got.FirstDestinationID != p.FirstDestinationID ||
+		!reflect.DeepEqual(got.SourceIDs, p.SourceIDs) {
+		t.Errorf("round-trip: got %+v want %+v", got, p)
+	}
+}
+
+func TestTallyDumpWord_Extended(t *testing.T) {
+	p := CrosspointTallyDumpWordParams{
+		MatrixID:           30,
+		LevelID:            4,
+		FirstDestinationID: 1000,
+		SourceIDs:          []uint16{50000, 65535},
+	}
+	f := EncodeCrosspointTallyDumpWord(p)
+	if f.ID != TxCrosspointTallyDumpWordExt {
+		t.Errorf("ID got %#x", f.ID)
+	}
+	// matrix=30, level=4, tallies=2, dest=03 E8, src0=C3 50, src1=FF FF
+	want := []byte{30, 4, 2, 0x03, 0xE8, 0xC3, 0x50, 0xFF, 0xFF}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("Payload got %X want %X", f.Payload, want)
+	}
+	got, err := DecodeCrosspointTallyDumpWord(f)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got.MatrixID != p.MatrixID || !reflect.DeepEqual(got.SourceIDs, p.SourceIDs) {
+		t.Errorf("round-trip: got %+v want %+v", got, p)
+	}
+}
+
+func TestTallyDump_DecodeErrors(t *testing.T) {
+	if _, err := DecodeCrosspointTallyDumpByte(Frame{ID: TxCrosspointTally}); !errors.Is(err, ErrWrongCommand) {
+		t.Errorf("byte wrong: %v", err)
+	}
+	// Tallies claims 3 but only 2 bytes follow
+	short := Frame{ID: TxCrosspointTallyDumpByte, Payload: []byte{0x23, 0x03, 0x00, 1, 2}}
+	if _, err := DecodeCrosspointTallyDumpByte(short); !errors.Is(err, ErrShortPayload) {
+		t.Errorf("byte short: %v", err)
+	}
+	if _, err := DecodeCrosspointTallyDumpWord(Frame{ID: TxCrosspointTally}); !errors.Is(err, ErrWrongCommand) {
+		t.Errorf("word wrong: %v", err)
+	}
+}

--- a/internal/probel/cmd_dual_controller_status.go
+++ b/internal/probel/cmd_dual_controller_status.go
@@ -1,0 +1,90 @@
+package probel
+
+// --- rx 008 : Dual Controller Status Request -------------------------------
+
+// EncodeDualControllerStatusRequest builds the empty-payload request.
+//
+// General form (CommandID 0x08 — 1-byte DATA = ID only):
+//
+//	| Byte | Field | Notes              |
+//	|------|-------|--------------------|
+//	|  (none) | — | no payload bytes   |
+//
+// The controller replies with tx 009 (DualControllerStatusResponse).
+// Spec: SW-P-88 §5.9. Reference: TS rx/008/command.ts.
+func EncodeDualControllerStatusRequest() Frame {
+	return Frame{ID: RxDualControllerStatusRequest}
+}
+
+// DecodeDualControllerStatusRequest validates an incoming empty-payload
+// request. Returns ErrWrongCommand if the command ID does not match.
+func DecodeDualControllerStatusRequest(f Frame) error {
+	if f.ID != RxDualControllerStatusRequest {
+		return ErrWrongCommand
+	}
+	return nil
+}
+
+// --- tx 009 : Dual Controller Status Response ------------------------------
+
+// DualControllerStatusParams describes the active/idle controller state in
+// a dual-controller system (1:1 redundancy).
+//
+// Reference: TS tx/009/options.ts DualControllerStatusResponseMessageCommandOptions.
+type DualControllerStatusParams struct {
+	// SlaveActive is true when the SLAVE controller is the active one.
+	// Byte 1 bit 0: 0 = MASTER active, 1 = SLAVE active.
+	SlaveActive bool
+	// Active is the ACTIVE flag of the queried controller. Bit 1 of byte 1.
+	// Semantics per spec: 0 = Inactive, 1 = Active.
+	Active bool
+	// IdleControllerFaulty reports whether the idle peer is missing/faulty.
+	// Byte 2: 0 = OK, 1 = missing/faulty.
+	IdleControllerFaulty bool
+}
+
+// EncodeDualControllerStatusResponse builds the tx 009 reply.
+//
+// General form (CommandID 0x09 — 2-byte payload):
+//
+//	| Byte | Field      | Notes                                           |
+//	|------|------------|-------------------------------------------------|
+//	|  1   | Status     | bit[0] = SlaveActive (0=MASTER, 1=SLAVE)        |
+//	|      |            | bit[1] = Active     (0=Inactive, 1=Active)      |
+//	|      |            | bits[2-7] reserved, 0                           |
+//	|  2   | Idle Card  | 0 = idle controller OK, 1 = missing/faulty      |
+//
+// Spec: SW-P-88 §5.9. Reference: TS tx/009/command.ts buildDataNormal.
+func EncodeDualControllerStatusResponse(p DualControllerStatusParams) Frame {
+	var status byte
+	if p.SlaveActive {
+		status |= 0x01
+	}
+	if p.Active {
+		status |= 0x02
+	}
+	var idle byte
+	if p.IdleControllerFaulty {
+		idle = 1
+	}
+	return Frame{
+		ID:      TxDualControllerStatusResponse,
+		Payload: []byte{status, idle},
+	}
+}
+
+// DecodeDualControllerStatusResponse parses the 2-byte tx 009 payload.
+func DecodeDualControllerStatusResponse(f Frame) (DualControllerStatusParams, error) {
+	if f.ID != TxDualControllerStatusResponse {
+		return DualControllerStatusParams{}, ErrWrongCommand
+	}
+	if len(f.Payload) < 2 {
+		return DualControllerStatusParams{}, ErrShortPayload
+	}
+	status := f.Payload[0]
+	return DualControllerStatusParams{
+		SlaveActive:          status&0x01 != 0,
+		Active:               status&0x02 != 0,
+		IdleControllerFaulty: f.Payload[1] != 0,
+	}, nil
+}

--- a/internal/probel/cmd_maintenance.go
+++ b/internal/probel/cmd_maintenance.go
@@ -1,0 +1,86 @@
+package probel
+
+// --- rx 007 : Maintenance Message ------------------------------------------
+
+// MaintenanceFunction selects the controller-side action requested by
+// rx 007. Spec: SW-P-88 §5.8 "Maintenance Message". Reference: TS
+// rx/007/options.ts MaintenanceFunction enum.
+type MaintenanceFunction uint8
+
+const (
+	// MaintHardReset forces the controller to completely reset, as if power
+	// had just been applied (watchdog-style hardware reset).
+	MaintHardReset MaintenanceFunction = 0x00
+	// MaintSoftReset forces a software-only reset (re-init after database
+	// download or main-loop restart). Hardware may not be re-initialised.
+	MaintSoftReset MaintenanceFunction = 0x01
+	// MaintClearProtects clears crosspoint protects on (matrix, level),
+	// ignoring ownership. Acts as a "MASTER protect override".
+	// MatrixID=0xFF → clear that level on ALL matrices; LevelID=0xFF → clear
+	// ALL levels on that matrix; both 0xFF → clear everything.
+	MaintClearProtects MaintenanceFunction = 0x02
+	// MaintDatabaseTransfer (dual-processor controllers only) forces the
+	// database to be transferred from ACTIVE to IDLE. No further bytes.
+	MaintDatabaseTransfer MaintenanceFunction = 0x04
+)
+
+// MaintenanceParams carries the optional matrix/level fields that only
+// appear when Function == MaintClearProtects.
+//
+// Reference: TS rx/007/params.ts MaintenanceMessageCommandParams.
+type MaintenanceParams struct {
+	Function MaintenanceFunction
+	MatrixID uint8 // 0-19 or 0xFF = "all matrices" — only used for ClearProtects
+	LevelID  uint8 // 0-15 or 0xFF = "all levels"   — only used for ClearProtects
+}
+
+// EncodeMaintenance builds the MAINTENANCE MESSAGE request. Payload size is
+// variable and depends on the selected function:
+//
+// General form (2-byte DATA including ID) — any function except ClearProtects:
+//
+//	| Byte | Field                | Notes                                |
+//	|------|----------------------|--------------------------------------|
+//	|  1   | Maintenance function | 0x00/0x01/0x04 (ClearProtects uses ext form) |
+//
+// ClearProtects extended form (4-byte DATA including ID):
+//
+//	| Byte | Field                | Notes                                |
+//	|------|----------------------|--------------------------------------|
+//	|  1   | Function = 0x02      | MaintClearProtects                   |
+//	|  2   | Matrix number        | 0-19 or 0xFF                         |
+//	|  3   | Level number         | 0-15 or 0xFF                         |
+//
+// Spec: SW-P-88 §5.8. Reference: TS rx/007/command.ts.
+func EncodeMaintenance(p MaintenanceParams) Frame {
+	if p.Function == MaintClearProtects {
+		return Frame{
+			ID:      RxMaintenance,
+			Payload: []byte{byte(p.Function), p.MatrixID, p.LevelID},
+		}
+	}
+	return Frame{
+		ID:      RxMaintenance,
+		Payload: []byte{byte(p.Function)},
+	}
+}
+
+// DecodeMaintenance parses a MAINTENANCE MESSAGE. Any function except
+// ClearProtects leaves MatrixID and LevelID set to zero.
+func DecodeMaintenance(f Frame) (MaintenanceParams, error) {
+	if f.ID != RxMaintenance {
+		return MaintenanceParams{}, ErrWrongCommand
+	}
+	if len(f.Payload) < 1 {
+		return MaintenanceParams{}, ErrShortPayload
+	}
+	p := MaintenanceParams{Function: MaintenanceFunction(f.Payload[0])}
+	if p.Function == MaintClearProtects {
+		if len(f.Payload) < 3 {
+			return MaintenanceParams{}, ErrShortPayload
+		}
+		p.MatrixID = f.Payload[1]
+		p.LevelID = f.Payload[2]
+	}
+	return p, nil
+}

--- a/internal/probel/cmd_maintenance_test.go
+++ b/internal/probel/cmd_maintenance_test.go
@@ -1,0 +1,113 @@
+package probel
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+func TestMaintenance_HardReset(t *testing.T) {
+	f := EncodeMaintenance(MaintenanceParams{Function: MaintHardReset})
+	if f.ID != RxMaintenance {
+		t.Errorf("ID got %#x", f.ID)
+	}
+	if !bytes.Equal(f.Payload, []byte{0x00}) {
+		t.Errorf("Payload got %X want 00", f.Payload)
+	}
+	got, err := DecodeMaintenance(f)
+	if err != nil || got.Function != MaintHardReset {
+		t.Errorf("round-trip: got %+v err %v", got, err)
+	}
+}
+
+func TestMaintenance_SoftReset(t *testing.T) {
+	f := EncodeMaintenance(MaintenanceParams{Function: MaintSoftReset})
+	if !bytes.Equal(f.Payload, []byte{0x01}) {
+		t.Errorf("Payload got %X want 01", f.Payload)
+	}
+	got, _ := DecodeMaintenance(f)
+	if got.Function != MaintSoftReset {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func TestMaintenance_ClearProtects(t *testing.T) {
+	p := MaintenanceParams{Function: MaintClearProtects, MatrixID: 3, LevelID: 0xFF}
+	f := EncodeMaintenance(p)
+	want := []byte{0x02, 0x03, 0xFF}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("Payload got %X want %X", f.Payload, want)
+	}
+	got, err := DecodeMaintenance(f)
+	if err != nil || got != p {
+		t.Errorf("round-trip: got %+v err %v want %+v", got, err, p)
+	}
+}
+
+func TestMaintenance_DecodeErrors(t *testing.T) {
+	_, err := DecodeMaintenance(Frame{ID: RxCrosspointConnect, Payload: []byte{0x01}})
+	if !errors.Is(err, ErrWrongCommand) {
+		t.Errorf("wrong: got %v", err)
+	}
+	_, err = DecodeMaintenance(Frame{ID: RxMaintenance, Payload: nil})
+	if !errors.Is(err, ErrShortPayload) {
+		t.Errorf("empty: got %v", err)
+	}
+	_, err = DecodeMaintenance(Frame{ID: RxMaintenance, Payload: []byte{0x02}}) // ClearProtects needs 3 bytes
+	if !errors.Is(err, ErrShortPayload) {
+		t.Errorf("short clear-protects: got %v", err)
+	}
+}
+
+func TestDualControllerStatus_Request(t *testing.T) {
+	f := EncodeDualControllerStatusRequest()
+	if f.ID != RxDualControllerStatusRequest {
+		t.Errorf("ID got %#x", f.ID)
+	}
+	if len(f.Payload) != 0 {
+		t.Errorf("payload should be empty, got %X", f.Payload)
+	}
+	if err := DecodeDualControllerStatusRequest(f); err != nil {
+		t.Errorf("decode: %v", err)
+	}
+	if err := DecodeDualControllerStatusRequest(Frame{ID: TxCrosspointTally}); !errors.Is(err, ErrWrongCommand) {
+		t.Errorf("wrong id: %v", err)
+	}
+}
+
+func TestDualControllerStatus_Response(t *testing.T) {
+	cases := []struct {
+		name string
+		in   DualControllerStatusParams
+		want []byte
+	}{
+		{"master active ok", DualControllerStatusParams{SlaveActive: false, Active: true}, []byte{0x02, 0x00}},
+		{"slave active ok", DualControllerStatusParams{SlaveActive: true, Active: true}, []byte{0x03, 0x00}},
+		{"master inactive idle faulty", DualControllerStatusParams{IdleControllerFaulty: true}, []byte{0x00, 0x01}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := EncodeDualControllerStatusResponse(tc.in)
+			if !bytes.Equal(f.Payload, tc.want) {
+				t.Errorf("Payload got %X want %X", f.Payload, tc.want)
+			}
+			got, err := DecodeDualControllerStatusResponse(f)
+			if err != nil || got != tc.in {
+				t.Errorf("round-trip: got %+v err %v want %+v", got, err, tc.in)
+			}
+		})
+	}
+}
+
+func TestMaintenance_FramerRoundTrip(t *testing.T) {
+	p := MaintenanceParams{Function: MaintClearProtects, MatrixID: 0xFF, LevelID: 0xFF}
+	wire := Pack(EncodeMaintenance(p))
+	back, _, err := Unpack(wire)
+	if err != nil {
+		t.Fatalf("Unpack: %v", err)
+	}
+	got, err := DecodeMaintenance(back)
+	if err != nil || got != p {
+		t.Errorf("got %+v err %v want %+v", got, err, p)
+	}
+}

--- a/internal/probel/cmd_master_protect_connect.go
+++ b/internal/probel/cmd_master_protect_connect.go
@@ -1,0 +1,61 @@
+package probel
+
+// --- rx 029 : Master Protect Connect ---------------------------------------
+
+// MasterProtectConnectParams is a PROTECT CONNECT variant issued by a remote
+// device that claims MASTER-panel privilege: it overrides any existing
+// protection set by another panel. The router replies with a regular tx 013
+// PROTECT CONNECTED broadcast.
+//
+// General (and only) form; no extended variant. Reference: TS rx/029/command.ts.
+type MasterProtectConnectParams struct {
+	MatrixID      uint8
+	LevelID       uint8
+	DestinationID uint16
+	DeviceID      uint16
+}
+
+// EncodeMasterProtectConnect builds the MASTER PROTECT CONNECT request.
+//
+// General form (CommandID 0x1D — 6 data bytes; uses extended-style addressing
+// even in the only form — matrix/level are full u8, dest/device are u16):
+//
+//	| Byte | Field           | Notes                                   |
+//	|------|-----------------|-----------------------------------------|
+//	|  1   | Matrix          | full 8-bit                              |
+//	|  2   | Level           | full 8-bit                              |
+//	|  3   | Dest multiplier | Destination DIV 256                     |
+//	|  4   | Dest (low 8b)   | Destination MOD 256                     |
+//	|  5   | Dev  multiplier | Device DIV 256                          |
+//	|  6   | Dev  (low 8b)   | Device MOD 256                          |
+//
+// Spec: SW-P-88 §5.31. Reference: TS rx/029/command.ts.
+func EncodeMasterProtectConnect(p MasterProtectConnectParams) Frame {
+	return Frame{
+		ID: RxMasterProtectConnect,
+		Payload: []byte{
+			p.MatrixID,
+			p.LevelID,
+			byte(p.DestinationID / 256),
+			byte(p.DestinationID % 256),
+			byte(p.DeviceID / 256),
+			byte(p.DeviceID % 256),
+		},
+	}
+}
+
+// DecodeMasterProtectConnect parses the request payload.
+func DecodeMasterProtectConnect(f Frame) (MasterProtectConnectParams, error) {
+	if f.ID != RxMasterProtectConnect {
+		return MasterProtectConnectParams{}, ErrWrongCommand
+	}
+	if len(f.Payload) < 6 {
+		return MasterProtectConnectParams{}, ErrShortPayload
+	}
+	return MasterProtectConnectParams{
+		MatrixID:      f.Payload[0],
+		LevelID:       f.Payload[1],
+		DestinationID: uint16(f.Payload[2])*256 + uint16(f.Payload[3]),
+		DeviceID:      uint16(f.Payload[4])*256 + uint16(f.Payload[5]),
+	}, nil
+}

--- a/internal/probel/cmd_protect_connect.go
+++ b/internal/probel/cmd_protect_connect.go
@@ -1,0 +1,135 @@
+package probel
+
+// --- rx 012 / rx 140 : Protect Connect --------------------------------------
+
+// ProtectConnectParams requests protection of (matrix, level, destination) on
+// behalf of the given deviceID (the panel/device that will own the protect).
+// The router replies with tx 013 Protect Connected broadcast on success.
+//
+// Reference: TS rx/012/params.ts ProtectConnectMessageCommandParams.
+type ProtectConnectParams struct {
+	MatrixID      uint8
+	LevelID       uint8
+	DestinationID uint16
+	DeviceID      uint16
+}
+
+func (p ProtectConnectParams) needsExtended() bool {
+	return p.MatrixID > 15 || p.LevelID > 15 || p.DestinationID > 895
+}
+
+// EncodeProtectConnect builds the PROTECT CONNECT request.
+//
+// General form (CommandID 0x0C — 4 data bytes):
+//
+//	| Byte | Field           | Notes                                   |
+//	|------|-----------------|-----------------------------------------|
+//	|  1   | Matrix / Level  | bits[4-7] = Matrix, bits[0-3] = Level   |
+//	|  2   | Multiplier      | bits[4-6] = Dest DIV 128                |
+//	|      |                 | bits[0-2] = Device DIV 128              |
+//	|  3   | Dest (low 7b)   | Destination MOD 128                     |
+//	|  4   | Device (low 7b) | Device MOD 128                          |
+//
+// Extended form (CommandID 0x8C — 6 data bytes):
+//
+//	| Byte | Field           | Notes                                   |
+//	|------|-----------------|-----------------------------------------|
+//	|  1   | Matrix          | full 8-bit                              |
+//	|  2   | Level           | full 8-bit                              |
+//	|  3   | Dest multiplier | Destination DIV 256                     |
+//	|  4   | Dest (low 8b)   | Destination MOD 256                     |
+//	|  5   | Dev  multiplier | Device DIV 256                          |
+//	|  6   | Dev  (low 8b)   | Device MOD 256                          |
+//
+// Spec: SW-P-88 §5.15. Reference: TS rx/012/command.ts.
+func EncodeProtectConnect(p ProtectConnectParams) Frame {
+	if p.needsExtended() {
+		return Frame{
+			ID: RxProtectConnectExt,
+			Payload: []byte{
+				p.MatrixID,
+				p.LevelID,
+				byte(p.DestinationID / 256),
+				byte(p.DestinationID % 256),
+				byte(p.DeviceID / 256),
+				byte(p.DeviceID % 256),
+			},
+		}
+	}
+	return Frame{
+		ID: RxProtectConnect,
+		Payload: []byte{
+			(p.MatrixID << 4) | (p.LevelID & 0x0F),
+			byte(((p.DestinationID/128)<<4)&0x70) | byte((p.DeviceID/128)&0x07),
+			byte(p.DestinationID % 128),
+			byte(p.DeviceID % 128),
+		},
+	}
+}
+
+// DecodeProtectConnect parses a PROTECT CONNECT payload.
+func DecodeProtectConnect(f Frame) (ProtectConnectParams, error) {
+	switch f.ID {
+	case RxProtectConnect:
+		if len(f.Payload) < 4 {
+			return ProtectConnectParams{}, ErrShortPayload
+		}
+		return ProtectConnectParams{
+			MatrixID:      f.Payload[0] >> 4,
+			LevelID:       f.Payload[0] & 0x0F,
+			DestinationID: (uint16(f.Payload[1]>>4) & 0x07) * 128 + uint16(f.Payload[2]),
+			DeviceID:      (uint16(f.Payload[1]) & 0x07) * 128 + uint16(f.Payload[3]),
+		}, nil
+	case RxProtectConnectExt:
+		if len(f.Payload) < 6 {
+			return ProtectConnectParams{}, ErrShortPayload
+		}
+		return ProtectConnectParams{
+			MatrixID:      f.Payload[0],
+			LevelID:       f.Payload[1],
+			DestinationID: uint16(f.Payload[2])*256 + uint16(f.Payload[3]),
+			DeviceID:      uint16(f.Payload[4])*256 + uint16(f.Payload[5]),
+		}, nil
+	default:
+		return ProtectConnectParams{}, ErrWrongCommand
+	}
+}
+
+// --- tx 013 / tx 141 : Protect Connected -----------------------------------
+
+// ProtectConnectedParams reports protect-data state change — emitted by the
+// router on all ports after a successful PROTECT CONNECT (or to signal a
+// failed attempt, in which case State reflects the current unchanged state).
+//
+// Wire layout identical to tx 011 Protect Tally; only CommandID differs.
+// Reference: TS tx/013/params.ts + options.ts (merged).
+type ProtectConnectedParams = ProtectTallyParams
+
+// EncodeProtectConnected builds the PROTECT CONNECTED broadcast reply.
+// Layout byte-for-byte the same as tx 011; see EncodeProtectTally. The only
+// difference is the CommandID (0x0D vs 0x0B).
+//
+// Spec: SW-P-88 §5.16. Reference: TS tx/013/command.ts.
+func EncodeProtectConnected(p ProtectConnectedParams) Frame {
+	f := EncodeProtectTally(p)
+	if f.ID == TxProtectTallyExt {
+		f.ID = TxProtectConnectedExt
+	} else {
+		f.ID = TxProtectConnected
+	}
+	return f
+}
+
+// DecodeProtectConnected parses a PROTECT CONNECTED payload.
+func DecodeProtectConnected(f Frame) (ProtectConnectedParams, error) {
+	// Re-use tally decoder but validate command ID ourselves.
+	switch f.ID {
+	case TxProtectConnected:
+		f.ID = TxProtectTally
+	case TxProtectConnectedExt:
+		f.ID = TxProtectTallyExt
+	default:
+		return ProtectConnectedParams{}, ErrWrongCommand
+	}
+	return DecodeProtectTally(f)
+}

--- a/internal/probel/cmd_protect_device_name.go
+++ b/internal/probel/cmd_protect_device_name.go
@@ -1,0 +1,104 @@
+package probel
+
+import "strings"
+
+// --- rx 017 : Protect Device Name Request ----------------------------------
+
+// ProtectDeviceNameRequestParams queries the 8-character ASCII device name
+// that currently holds a given deviceID in the controller's protect device
+// table. This is used by a Probel device to resolve an OEM device, or vice
+// versa.
+//
+// General form only (no extended variant). Reference: TS rx/017/params.ts.
+type ProtectDeviceNameRequestParams struct {
+	DeviceID uint16 // 0-1023
+}
+
+// EncodeProtectDeviceNameRequest builds the PROTECT DEVICE NAME REQUEST.
+//
+// General form (CommandID 0x11 — 2 data bytes):
+//
+//	| Byte | Field           | Notes                                   |
+//	|------|-----------------|-----------------------------------------|
+//	|  1   | Multiplier      | bit[7]   = 0                            |
+//	|      |                 | bits[4-6]= 0                            |
+//	|      |                 | bit[3]   = 0                            |
+//	|      |                 | bits[0-2]= Device DIV 128               |
+//	|  2   | Device (low 7b) | Device MOD 128                          |
+//
+// Spec: SW-P-88 §5.21. Reference: TS rx/017/command.ts.
+func EncodeProtectDeviceNameRequest(p ProtectDeviceNameRequestParams) Frame {
+	return Frame{
+		ID: RxProtectDeviceNameRequest,
+		Payload: []byte{
+			byte((p.DeviceID / 128) & 0x07),
+			byte(p.DeviceID % 128),
+		},
+	}
+}
+
+// DecodeProtectDeviceNameRequest parses the request payload.
+func DecodeProtectDeviceNameRequest(f Frame) (ProtectDeviceNameRequestParams, error) {
+	if f.ID != RxProtectDeviceNameRequest {
+		return ProtectDeviceNameRequestParams{}, ErrWrongCommand
+	}
+	if len(f.Payload) < 2 {
+		return ProtectDeviceNameRequestParams{}, ErrShortPayload
+	}
+	return ProtectDeviceNameRequestParams{
+		DeviceID: (uint16(f.Payload[0]) & 0x07) * 128 + uint16(f.Payload[1]),
+	}, nil
+}
+
+// --- tx 018 : Protect Device Name Response ---------------------------------
+
+// ProtectDeviceNameResponseParams answers rx 017 with the 8-character ASCII
+// device name. Names shorter than 8 chars are left-padded with spaces on the
+// wire (matching TS rx/018 behaviour); the decoder trims trailing spaces.
+//
+// Reference: TS tx/018/params.ts ProtectDeviceNameResponseCommandParams.
+type ProtectDeviceNameResponseParams struct {
+	DeviceID   uint16 // 0-1023
+	DeviceName string // ≤ 8 chars, left-padded with ' ' on wire
+}
+
+// EncodeProtectDeviceNameResponse builds the PROTECT DEVICE NAME RESPONSE.
+//
+// General form (CommandID 0x12 — 10 data bytes):
+//
+//	| Byte  | Field           | Notes                                  |
+//	|-------|-----------------|----------------------------------------|
+//	|  1    | Multiplier      | bits[0-2] = Device DIV 128             |
+//	|  2    | Device (low 7b) | Device MOD 128                         |
+//	|  3..10| Name (8 bytes)  | ASCII, left-padded with SPACE (0x20)   |
+//
+// Spec: SW-P-88 §5.21. Reference: TS tx/018/command.ts.
+func EncodeProtectDeviceNameResponse(p ProtectDeviceNameResponseParams) Frame {
+	name := p.DeviceName
+	if len(name) > 8 {
+		name = name[:8]
+	}
+	padded := strings.Repeat(" ", 8-len(name)) + name
+	out := make([]byte, 0, 10)
+	out = append(out,
+		byte((p.DeviceID/128)&0x07),
+		byte(p.DeviceID%128),
+	)
+	out = append(out, padded...)
+	return Frame{ID: TxProtectDeviceNameResponse, Payload: out}
+}
+
+// DecodeProtectDeviceNameResponse parses the response payload and trims the
+// space-padding from DeviceName.
+func DecodeProtectDeviceNameResponse(f Frame) (ProtectDeviceNameResponseParams, error) {
+	if f.ID != TxProtectDeviceNameResponse {
+		return ProtectDeviceNameResponseParams{}, ErrWrongCommand
+	}
+	if len(f.Payload) < 10 {
+		return ProtectDeviceNameResponseParams{}, ErrShortPayload
+	}
+	return ProtectDeviceNameResponseParams{
+		DeviceID:   (uint16(f.Payload[0]) & 0x07) * 128 + uint16(f.Payload[1]),
+		DeviceName: strings.TrimLeft(string(f.Payload[2:10]), " "),
+	}, nil
+}

--- a/internal/probel/cmd_protect_disconnect.go
+++ b/internal/probel/cmd_protect_disconnect.go
@@ -1,0 +1,90 @@
+package probel
+
+// --- rx 014 / rx 142 : Protect Disconnect ----------------------------------
+
+// ProtectDisconnectParams clears protection set by the given deviceID on
+// (matrix, level, destination). The router replies with tx 015 Protect
+// Disconnected.
+//
+// Wire layout is byte-for-byte identical to rx 012 Protect Connect — only the
+// CommandID differs (0x0E vs 0x0C; extended 0x8E vs 0x8C). We alias the
+// params and encoder through the connect implementation to keep behaviour
+// in sync.
+//
+// Reference: TS rx/014/params.ts ProtectDisConnectMessageCommandParams.
+type ProtectDisconnectParams = ProtectConnectParams
+
+// EncodeProtectDisconnect builds the PROTECT DIS-CONNECT request.
+//
+// General form (CommandID 0x0E — 4 data bytes, same layout as rx 012):
+//
+//	| Byte | Field           | Notes                                   |
+//	|------|-----------------|-----------------------------------------|
+//	|  1   | Matrix / Level  | bits[4-7] = Matrix, bits[0-3] = Level   |
+//	|  2   | Multiplier      | bits[4-6] = Dest DIV 128                |
+//	|      |                 | bits[0-2] = Device DIV 128              |
+//	|  3   | Dest (low 7b)   | Destination MOD 128                     |
+//	|  4   | Device (low 7b) | Device MOD 128                          |
+//
+// Extended form (CommandID 0x8E — 6 data bytes, same layout as rx 140).
+//
+// Spec: SW-P-88 §5.17. Reference: TS rx/014/command.ts.
+func EncodeProtectDisconnect(p ProtectDisconnectParams) Frame {
+	f := EncodeProtectConnect(p)
+	if f.ID == RxProtectConnectExt {
+		f.ID = RxProtectDisconnectExt
+	} else {
+		f.ID = RxProtectDisconnect
+	}
+	return f
+}
+
+// DecodeProtectDisconnect parses a PROTECT DIS-CONNECT payload.
+func DecodeProtectDisconnect(f Frame) (ProtectDisconnectParams, error) {
+	switch f.ID {
+	case RxProtectDisconnect:
+		f.ID = RxProtectConnect
+	case RxProtectDisconnectExt:
+		f.ID = RxProtectConnectExt
+	default:
+		return ProtectDisconnectParams{}, ErrWrongCommand
+	}
+	return DecodeProtectConnect(f)
+}
+
+// --- tx 015 / tx 143 : Protect Disconnected --------------------------------
+
+// ProtectDisconnectedParams broadcasts the protect-data change after a
+// PROTECT DIS-CONNECT. State should be ProtectNone on success; on failure
+// State reflects the unchanged current state.
+//
+// Wire layout identical to tx 011 / tx 013; CommandID 0x0F (ext 0x8F).
+// Reference: TS tx/015/params.ts.
+type ProtectDisconnectedParams = ProtectTallyParams
+
+// EncodeProtectDisconnected builds the PROTECT DIS-CONNECTED broadcast.
+// Same layout as tx 011 (Protect Tally); see EncodeProtectTally doc table.
+//
+// Spec: SW-P-88 §5.18. Reference: TS tx/015/command.ts.
+func EncodeProtectDisconnected(p ProtectDisconnectedParams) Frame {
+	f := EncodeProtectTally(p)
+	if f.ID == TxProtectTallyExt {
+		f.ID = TxProtectDisconnectedExt
+	} else {
+		f.ID = TxProtectDisconnected
+	}
+	return f
+}
+
+// DecodeProtectDisconnected parses a PROTECT DIS-CONNECTED payload.
+func DecodeProtectDisconnected(f Frame) (ProtectDisconnectedParams, error) {
+	switch f.ID {
+	case TxProtectDisconnected:
+		f.ID = TxProtectTally
+	case TxProtectDisconnectedExt:
+		f.ID = TxProtectTallyExt
+	default:
+		return ProtectDisconnectedParams{}, ErrWrongCommand
+	}
+	return DecodeProtectTally(f)
+}

--- a/internal/probel/cmd_protect_interrogate.go
+++ b/internal/probel/cmd_protect_interrogate.go
@@ -1,0 +1,209 @@
+package probel
+
+// ProtectState is the 4-value enum carried in tx 011 / 013 / 015 / 020 byte 3
+// (or byte 3 of the header for tx 020 items) to describe a destination's
+// protect disposition. Defined in SW-P-88 §3.2.5.
+//
+// | Value | Meaning                                             |
+// |-------|-----------------------------------------------------|
+// |   0   | Not Protected                                       |
+// |   1   | Pro-Bel Protected                                   |
+// |   2   | Pro-Bel override Protected (cannot be altered rem.) |
+// |   3   | OEM Protected                                       |
+type ProtectState uint8
+
+const (
+	ProtectNone        ProtectState = 0
+	ProtectProbel      ProtectState = 1
+	ProtectProbelOver  ProtectState = 2
+	ProtectOEM         ProtectState = 3
+)
+
+// --- rx 010 / rx 138 : Protect Interrogate ---------------------------------
+
+// ProtectInterrogateParams asks "what is the protect state of destination D
+// on (matrix M, level L)?" — DeviceID scopes the query in general form (it
+// becomes part of the multiplier byte; 3-bit encoding limits to 0-1023).
+//
+// Reference: TS rx/010/params.ts ProtectInterrogateMessageCommandParams.
+type ProtectInterrogateParams struct {
+	MatrixID      uint8
+	LevelID       uint8
+	DestinationID uint16
+	DeviceID      uint16 // only encoded in general form multiplier; 0 is a sensible default
+}
+
+func (p ProtectInterrogateParams) needsExtended() bool {
+	return p.MatrixID > 15 || p.LevelID > 15 || p.DestinationID > 895
+}
+
+// EncodeProtectInterrogate builds the PROTECT INTERROGATE request.
+//
+// General form (CommandID 0x0A — 3 data bytes):
+//
+//	| Byte | Field          | Notes                                   |
+//	|------|----------------|-----------------------------------------|
+//	|  1   | Matrix / Level | bits[4-7] = Matrix, bits[0-3] = Level   |
+//	|  2   | Multiplier     | bits[4-6] = Dest DIV 128                |
+//	|      |                | bits[0-2] = Device DIV 128              |
+//	|  3   | Dest (low 7b)  | Destination MOD 128                     |
+//
+// Extended form (CommandID 0x8A — 4 data bytes; device is NOT carried):
+//
+//	| Byte | Field           | Notes                                  |
+//	|------|-----------------|----------------------------------------|
+//	|  1   | Matrix          | full 8-bit                             |
+//	|  2   | Level           | full 8-bit                             |
+//	|  3   | Dest multiplier | Destination DIV 256                    |
+//	|  4   | Dest (low 8b)   | Destination MOD 256                    |
+//
+// Spec: SW-P-88 §5.13. Reference: TS rx/010/command.ts.
+func EncodeProtectInterrogate(p ProtectInterrogateParams) Frame {
+	if p.needsExtended() {
+		return Frame{
+			ID: RxProtectInterrogateExt,
+			Payload: []byte{
+				p.MatrixID,
+				p.LevelID,
+				byte(p.DestinationID / 256),
+				byte(p.DestinationID % 256),
+			},
+		}
+	}
+	return Frame{
+		ID: RxProtectInterrogate,
+		Payload: []byte{
+			(p.MatrixID << 4) | (p.LevelID & 0x0F),
+			byte(((p.DestinationID/128)<<4)&0x70) | byte((p.DeviceID/128)&0x07),
+			byte(p.DestinationID % 128),
+		},
+	}
+}
+
+// DecodeProtectInterrogate parses a PROTECT INTERROGATE payload.
+func DecodeProtectInterrogate(f Frame) (ProtectInterrogateParams, error) {
+	switch f.ID {
+	case RxProtectInterrogate:
+		if len(f.Payload) < 3 {
+			return ProtectInterrogateParams{}, ErrShortPayload
+		}
+		return ProtectInterrogateParams{
+			MatrixID:      f.Payload[0] >> 4,
+			LevelID:       f.Payload[0] & 0x0F,
+			DestinationID: (uint16(f.Payload[1]>>4) & 0x07) * 128 + uint16(f.Payload[2]),
+			DeviceID:      (uint16(f.Payload[1]) & 0x07) * 128,
+		}, nil
+	case RxProtectInterrogateExt:
+		if len(f.Payload) < 4 {
+			return ProtectInterrogateParams{}, ErrShortPayload
+		}
+		return ProtectInterrogateParams{
+			MatrixID:      f.Payload[0],
+			LevelID:       f.Payload[1],
+			DestinationID: uint16(f.Payload[2])*256 + uint16(f.Payload[3]),
+		}, nil
+	default:
+		return ProtectInterrogateParams{}, ErrWrongCommand
+	}
+}
+
+// --- tx 011 / tx 139 : Protect Tally ---------------------------------------
+
+// ProtectTallyParams reports the protect state of one destination, with the
+// owning deviceID (whose name can be fetched via rx 017 / tx 018).
+//
+// Reference: TS tx/011/params.ts + options.ts (merged into one struct here).
+type ProtectTallyParams struct {
+	MatrixID      uint8
+	LevelID       uint8
+	DestinationID uint16
+	DeviceID      uint16
+	State         ProtectState
+}
+
+func (p ProtectTallyParams) needsExtended() bool {
+	return p.MatrixID > 15 || p.LevelID > 15 || p.DestinationID > 895 || p.DeviceID > 1023
+}
+
+// EncodeProtectTally builds the PROTECT TALLY reply.
+//
+// General form (CommandID 0x0B — 5 data bytes):
+//
+//	| Byte | Field          | Notes                                     |
+//	|------|----------------|-------------------------------------------|
+//	|  1   | Matrix / Level | bits[4-7] = Matrix, bits[0-3] = Level     |
+//	|  2   | Protect        | ProtectState (0-3)                        |
+//	|  3   | Multiplier     | bits[4-6] = Dest DIV 128                  |
+//	|      |                | bits[0-2] = Device DIV 128                |
+//	|  4   | Dest (low 7b)  | Destination MOD 128                       |
+//	|  5   | Device (low 7b)| Device MOD 128                            |
+//
+// Extended form (CommandID 0x8B — 7 data bytes):
+//
+//	| Byte | Field           | Notes                                    |
+//	|------|-----------------|------------------------------------------|
+//	|  1   | Matrix          | full 8-bit                               |
+//	|  2   | Level           | full 8-bit                               |
+//	|  3   | Protect         | ProtectState (0-3)                       |
+//	|  4   | Dest multiplier | Destination DIV 256                      |
+//	|  5   | Dest (low 8b)   | Destination MOD 256                      |
+//	|  6   | Dev  multiplier | Device DIV 256                           |
+//	|  7   | Dev  (low 8b)   | Device MOD 256                           |
+//
+// Spec: SW-P-88 §5.14. Reference: TS tx/011/command.ts.
+func EncodeProtectTally(p ProtectTallyParams) Frame {
+	if p.needsExtended() {
+		return Frame{
+			ID: TxProtectTallyExt,
+			Payload: []byte{
+				p.MatrixID,
+				p.LevelID,
+				byte(p.State),
+				byte(p.DestinationID / 256),
+				byte(p.DestinationID % 256),
+				byte(p.DeviceID / 256),
+				byte(p.DeviceID % 256),
+			},
+		}
+	}
+	return Frame{
+		ID: TxProtectTally,
+		Payload: []byte{
+			(p.MatrixID << 4) | (p.LevelID & 0x0F),
+			byte(p.State),
+			byte(((p.DestinationID/128)<<4)&0x70) | byte((p.DeviceID/128)&0x07),
+			byte(p.DestinationID % 128),
+			byte(p.DeviceID % 128),
+		},
+	}
+}
+
+// DecodeProtectTally parses a PROTECT TALLY payload.
+func DecodeProtectTally(f Frame) (ProtectTallyParams, error) {
+	switch f.ID {
+	case TxProtectTally:
+		if len(f.Payload) < 5 {
+			return ProtectTallyParams{}, ErrShortPayload
+		}
+		return ProtectTallyParams{
+			MatrixID:      f.Payload[0] >> 4,
+			LevelID:       f.Payload[0] & 0x0F,
+			State:         ProtectState(f.Payload[1]),
+			DestinationID: (uint16(f.Payload[2]>>4) & 0x07) * 128 + uint16(f.Payload[3]),
+			DeviceID:      (uint16(f.Payload[2]) & 0x07) * 128 + uint16(f.Payload[4]),
+		}, nil
+	case TxProtectTallyExt:
+		if len(f.Payload) < 7 {
+			return ProtectTallyParams{}, ErrShortPayload
+		}
+		return ProtectTallyParams{
+			MatrixID:      f.Payload[0],
+			LevelID:       f.Payload[1],
+			State:         ProtectState(f.Payload[2]),
+			DestinationID: uint16(f.Payload[3])*256 + uint16(f.Payload[4]),
+			DeviceID:      uint16(f.Payload[5])*256 + uint16(f.Payload[6]),
+		}, nil
+	default:
+		return ProtectTallyParams{}, ErrWrongCommand
+	}
+}

--- a/internal/probel/cmd_protect_tally_dump.go
+++ b/internal/probel/cmd_protect_tally_dump.go
@@ -1,0 +1,236 @@
+package probel
+
+// --- rx 019 / rx 147 : Protect Tally Dump Request --------------------------
+
+// ProtectTallyDumpRequestParams asks for a bulk dump of protect information
+// for (matrix, level), starting at FirstDestinationID. Unlike rx 001 or rx
+// 010, this request uses a FULL u16 destination in BOTH general and extended
+// forms (no multiplier/mod128 split). Only matrix/level differ in encoding.
+//
+// Reference: TS rx/019/params.ts ProtectTallyDumpRequestMessageCommandParams.
+type ProtectTallyDumpRequestParams struct {
+	MatrixID      uint8
+	LevelID       uint8
+	DestinationID uint16
+}
+
+func (p ProtectTallyDumpRequestParams) needsExtended() bool {
+	return p.MatrixID > 15 || p.LevelID > 15 || p.DestinationID > 895
+}
+
+// EncodeProtectTallyDumpRequest builds the PROTECT TALLY DUMP REQUEST.
+//
+// General form (CommandID 0x13 — 3 data bytes):
+//
+//	| Byte | Field           | Notes                                   |
+//	|------|-----------------|-----------------------------------------|
+//	|  1   | Matrix / Level  | bits[4-7] = Matrix, bits[0-3] = Level   |
+//	|  2   | Dest multiplier | Destination DIV 256                     |
+//	|  3   | Dest (low 8b)   | Destination MOD 256                     |
+//
+// Extended form (CommandID 0x93 — 4 data bytes):
+//
+//	| Byte | Field           | Notes                                   |
+//	|------|-----------------|-----------------------------------------|
+//	|  1   | Matrix          | full 8-bit                              |
+//	|  2   | Level           | full 8-bit                              |
+//	|  3   | Dest multiplier | Destination DIV 256                     |
+//	|  4   | Dest (low 8b)   | Destination MOD 256                     |
+//
+// Spec: SW-P-88 §5.19. Reference: TS rx/019/command.ts.
+func EncodeProtectTallyDumpRequest(p ProtectTallyDumpRequestParams) Frame {
+	if p.needsExtended() {
+		return Frame{
+			ID: RxProtectTallyDumpRequestExt,
+			Payload: []byte{
+				p.MatrixID,
+				p.LevelID,
+				byte(p.DestinationID / 256),
+				byte(p.DestinationID % 256),
+			},
+		}
+	}
+	return Frame{
+		ID: RxProtectTallyDumpRequest,
+		Payload: []byte{
+			(p.MatrixID << 4) | (p.LevelID & 0x0F),
+			byte(p.DestinationID / 256),
+			byte(p.DestinationID % 256),
+		},
+	}
+}
+
+// DecodeProtectTallyDumpRequest parses the request payload.
+func DecodeProtectTallyDumpRequest(f Frame) (ProtectTallyDumpRequestParams, error) {
+	switch f.ID {
+	case RxProtectTallyDumpRequest:
+		if len(f.Payload) < 3 {
+			return ProtectTallyDumpRequestParams{}, ErrShortPayload
+		}
+		return ProtectTallyDumpRequestParams{
+			MatrixID:      f.Payload[0] >> 4,
+			LevelID:       f.Payload[0] & 0x0F,
+			DestinationID: uint16(f.Payload[1])*256 + uint16(f.Payload[2]),
+		}, nil
+	case RxProtectTallyDumpRequestExt:
+		if len(f.Payload) < 4 {
+			return ProtectTallyDumpRequestParams{}, ErrShortPayload
+		}
+		return ProtectTallyDumpRequestParams{
+			MatrixID:      f.Payload[0],
+			LevelID:       f.Payload[1],
+			DestinationID: uint16(f.Payload[2])*256 + uint16(f.Payload[3]),
+		}, nil
+	default:
+		return ProtectTallyDumpRequestParams{}, ErrWrongCommand
+	}
+}
+
+// --- tx 020 / tx 148 : Protect Tally Dump ----------------------------------
+
+// ProtectTallyItem is one (state, deviceID) pair in a protect tally dump,
+// associated with consecutive destination numbers starting at the frame's
+// FirstDestinationID. State occupies bits 12-14 of a u16; device bits 0-9.
+type ProtectTallyItem struct {
+	State    ProtectState
+	DeviceID uint16 // 0-1023
+}
+
+// ProtectTallyDumpParams carries a run of protect items starting at
+// FirstDestinationID. Caller chunks at the 133-byte frame limit.
+//
+// Reference: TS tx/020/params.ts ProtectTallyDumpCommandParams.
+type ProtectTallyDumpParams struct {
+	MatrixID           uint8
+	LevelID            uint8
+	FirstDestinationID uint16
+	Items              []ProtectTallyItem
+}
+
+func (p ProtectTallyDumpParams) needsExtended() bool {
+	return p.MatrixID > 15 || p.LevelID > 15 || p.FirstDestinationID > 895
+}
+
+// packItem packs one item as a 16-bit big-endian value:
+//
+//	bit[15]     = 0
+//	bits[12-14] = protect state
+//	bits[10-11] = 0
+//	bits[0-9]   = device id
+func packItem(it ProtectTallyItem) (byte, byte) {
+	hi := byte((uint16(it.State)&0x07)<<4) | byte((it.DeviceID/256)&0x03)
+	lo := byte(it.DeviceID % 256)
+	return hi, lo
+}
+
+func unpackItem(hi, lo byte) ProtectTallyItem {
+	return ProtectTallyItem{
+		State:    ProtectState((hi >> 4) & 0x07),
+		DeviceID: (uint16(hi) & 0x03) * 256 + uint16(lo),
+	}
+}
+
+// EncodeProtectTallyDump builds ONE PROTECT TALLY DUMP frame. Callers must
+// chunk large runs across multiple frames (SW-P-08 caps a frame at 133 bytes).
+//
+// General form (CommandID 0x14 — 4 + 2N payload bytes, N = len(Items)):
+//
+//	| Byte | Field            | Notes                                  |
+//	|------|------------------|----------------------------------------|
+//	|  1   | Matrix / Level   | bits[4-7] = Matrix, bits[0-3] = Level  |
+//	|  2   | Num protect      | N = len(Items), max 64                 |
+//	|  3   | 1st Dest mult    | FirstDestinationID DIV 256             |
+//	|  4   | 1st Dest num     | FirstDestinationID MOD 256             |
+//	|  5,7,…| Device/protect hi| packed byte 1 (see packItem)           |
+//	|  6,8,…| Device/protect lo| packed byte 2                          |
+//
+// Extended form (CommandID 0x94 — 5 + 2N payload bytes):
+//
+//	| Byte | Field            | Notes                                  |
+//	|------|------------------|----------------------------------------|
+//	|  1   | Matrix           | full 8-bit                             |
+//	|  2   | Level            | full 8-bit                             |
+//	|  3   | Num protect      | N = len(Items), max 64                 |
+//	|  4   | 1st Dest mult    | FirstDestinationID DIV 256             |
+//	|  5   | 1st Dest num     | FirstDestinationID MOD 256             |
+//	|  6,8,…| Device/protect hi|                                        |
+//	|  7,9,…| Device/protect lo|                                        |
+//
+// Spec: SW-P-88 §5.20. Reference: TS tx/020/command.ts.
+func EncodeProtectTallyDump(p ProtectTallyDumpParams) Frame {
+	n := len(p.Items)
+	if p.needsExtended() {
+		out := make([]byte, 0, 5+2*n)
+		out = append(out,
+			p.MatrixID,
+			p.LevelID,
+			byte(n),
+			byte(p.FirstDestinationID/256),
+			byte(p.FirstDestinationID%256),
+		)
+		for _, it := range p.Items {
+			hi, lo := packItem(it)
+			out = append(out, hi, lo)
+		}
+		return Frame{ID: TxProtectTallyDumpExt, Payload: out}
+	}
+	out := make([]byte, 0, 4+2*n)
+	out = append(out,
+		(p.MatrixID<<4)|(p.LevelID&0x0F),
+		byte(n),
+		byte(p.FirstDestinationID/256),
+		byte(p.FirstDestinationID%256),
+	)
+	for _, it := range p.Items {
+		hi, lo := packItem(it)
+		out = append(out, hi, lo)
+	}
+	return Frame{ID: TxProtectTallyDump, Payload: out}
+}
+
+// DecodeProtectTallyDump parses a PROTECT TALLY DUMP payload.
+func DecodeProtectTallyDump(f Frame) (ProtectTallyDumpParams, error) {
+	var (
+		matrix, level byte
+		count         int
+		firstDest     uint16
+		headerLen     int
+	)
+	switch f.ID {
+	case TxProtectTallyDump:
+		if len(f.Payload) < 4 {
+			return ProtectTallyDumpParams{}, ErrShortPayload
+		}
+		matrix = f.Payload[0] >> 4
+		level = f.Payload[0] & 0x0F
+		count = int(f.Payload[1])
+		firstDest = uint16(f.Payload[2])*256 + uint16(f.Payload[3])
+		headerLen = 4
+	case TxProtectTallyDumpExt:
+		if len(f.Payload) < 5 {
+			return ProtectTallyDumpParams{}, ErrShortPayload
+		}
+		matrix = f.Payload[0]
+		level = f.Payload[1]
+		count = int(f.Payload[2])
+		firstDest = uint16(f.Payload[3])*256 + uint16(f.Payload[4])
+		headerLen = 5
+	default:
+		return ProtectTallyDumpParams{}, ErrWrongCommand
+	}
+	if len(f.Payload) < headerLen+2*count {
+		return ProtectTallyDumpParams{}, ErrShortPayload
+	}
+	items := make([]ProtectTallyItem, count)
+	for i := 0; i < count; i++ {
+		hi := f.Payload[headerLen+2*i]
+		lo := f.Payload[headerLen+2*i+1]
+		items[i] = unpackItem(hi, lo)
+	}
+	return ProtectTallyDumpParams{
+		MatrixID:           matrix,
+		LevelID:            level,
+		FirstDestinationID: firstDest,
+		Items:              items,
+	}, nil
+}

--- a/internal/probel/cmd_protect_test.go
+++ b/internal/probel/cmd_protect_test.go
@@ -1,0 +1,265 @@
+package probel
+
+import (
+	"bytes"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestProtectInterrogate_General(t *testing.T) {
+	p := ProtectInterrogateParams{MatrixID: 1, LevelID: 2, DestinationID: 500, DeviceID: 400}
+	f := EncodeProtectInterrogate(p)
+	if f.ID != RxProtectInterrogate {
+		t.Errorf("ID got %#x", f.ID)
+	}
+	// matrix/level=0x12, dest=500 → dest/128=3 in bits4-6=0x30; dev=400/128=3 in bits0-2=0x03
+	// dest%128=116=0x74
+	want := []byte{0x12, 0x33, 0x74}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("Payload got %X want %X", f.Payload, want)
+	}
+	got, err := DecodeProtectInterrogate(f)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	// In general form DeviceID is encoded only as /128 → decoded value is 3*128=384
+	if got.MatrixID != p.MatrixID || got.LevelID != p.LevelID || got.DestinationID != p.DestinationID {
+		t.Errorf("round-trip: got %+v want %+v", got, p)
+	}
+}
+
+func TestProtectInterrogate_Extended(t *testing.T) {
+	p := ProtectInterrogateParams{MatrixID: 30, LevelID: 2, DestinationID: 1000}
+	f := EncodeProtectInterrogate(p)
+	if f.ID != RxProtectInterrogateExt {
+		t.Errorf("ID got %#x", f.ID)
+	}
+	want := []byte{30, 2, 0x03, 0xE8}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("Payload got %X", f.Payload)
+	}
+	got, _ := DecodeProtectInterrogate(f)
+	if got.MatrixID != p.MatrixID || got.DestinationID != p.DestinationID {
+		t.Errorf("round-trip: got %+v want %+v", got, p)
+	}
+}
+
+func TestProtectTally_RoundTrip(t *testing.T) {
+	p := ProtectTallyParams{
+		MatrixID:      1,
+		LevelID:       2,
+		DestinationID: 500,
+		DeviceID:      600,
+		State:         ProtectProbel,
+	}
+	f := EncodeProtectTally(p)
+	if f.ID != TxProtectTally {
+		t.Errorf("ID got %#x", f.ID)
+	}
+	// matrix/level=0x12, state=1, multiplier=0x34, dest%128=0x74, dev%128=0x58
+	want := []byte{0x12, 0x01, 0x34, 0x74, 0x58}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("Payload got %X want %X", f.Payload, want)
+	}
+	got, err := DecodeProtectTally(f)
+	if err != nil || got != p {
+		t.Errorf("round-trip: got %+v err %v want %+v", got, err, p)
+	}
+}
+
+func TestProtectTally_Extended(t *testing.T) {
+	p := ProtectTallyParams{
+		MatrixID:      30,
+		LevelID:       4,
+		DestinationID: 1000,
+		DeviceID:      2000,
+		State:         ProtectOEM,
+	}
+	f := EncodeProtectTally(p)
+	if f.ID != TxProtectTallyExt {
+		t.Errorf("ID got %#x want ext 0x8B", f.ID)
+	}
+	// matrix=30, level=4, state=3, dest=03 E8, dev=07 D0
+	want := []byte{30, 4, 3, 0x03, 0xE8, 0x07, 0xD0}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("Payload got %X", f.Payload)
+	}
+	got, _ := DecodeProtectTally(f)
+	if got != p {
+		t.Errorf("round-trip ext: got %+v want %+v", got, p)
+	}
+}
+
+func TestProtectConnect_RoundTrip(t *testing.T) {
+	p := ProtectConnectParams{MatrixID: 1, LevelID: 2, DestinationID: 500, DeviceID: 600}
+	f := EncodeProtectConnect(p)
+	if f.ID != RxProtectConnect {
+		t.Errorf("ID got %#x", f.ID)
+	}
+	want := []byte{0x12, 0x34, 0x74, 0x58}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("Payload got %X", f.Payload)
+	}
+	got, _ := DecodeProtectConnect(f)
+	if got != p {
+		t.Errorf("got %+v want %+v", got, p)
+	}
+}
+
+func TestProtectConnected_RoundTrip(t *testing.T) {
+	p := ProtectConnectedParams{
+		MatrixID: 1, LevelID: 2, DestinationID: 500, DeviceID: 600, State: ProtectProbelOver,
+	}
+	f := EncodeProtectConnected(p)
+	if f.ID != TxProtectConnected {
+		t.Errorf("ID got %#x want 0x0D", f.ID)
+	}
+	// Same body as Tally with CommandID 0x0D
+	got, err := DecodeProtectConnected(f)
+	if err != nil || got != p {
+		t.Errorf("round-trip: got %+v err %v want %+v", got, err, p)
+	}
+}
+
+func TestProtectDisconnect_RoundTrip(t *testing.T) {
+	p := ProtectDisconnectParams{MatrixID: 2, LevelID: 1, DestinationID: 100, DeviceID: 200}
+	f := EncodeProtectDisconnect(p)
+	if f.ID != RxProtectDisconnect {
+		t.Errorf("ID got %#x want 0x0E", f.ID)
+	}
+	got, _ := DecodeProtectDisconnect(f)
+	if got != p {
+		t.Errorf("got %+v want %+v", got, p)
+	}
+}
+
+func TestProtectDisconnected_Ext(t *testing.T) {
+	p := ProtectDisconnectedParams{
+		MatrixID: 20, LevelID: 4, DestinationID: 1000, DeviceID: 500, State: ProtectNone,
+	}
+	f := EncodeProtectDisconnected(p)
+	if f.ID != TxProtectDisconnectedExt {
+		t.Errorf("ID got %#x want 0x8F", f.ID)
+	}
+	got, err := DecodeProtectDisconnected(f)
+	if err != nil || got != p {
+		t.Errorf("round-trip: got %+v err %v want %+v", got, err, p)
+	}
+}
+
+func TestProtectDeviceNameRequest(t *testing.T) {
+	f := EncodeProtectDeviceNameRequest(ProtectDeviceNameRequestParams{DeviceID: 300})
+	if f.ID != RxProtectDeviceNameRequest {
+		t.Errorf("ID got %#x", f.ID)
+	}
+	// 300/128=2, 300%128=44=0x2C
+	want := []byte{0x02, 0x2C}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("Payload got %X want %X", f.Payload, want)
+	}
+	got, err := DecodeProtectDeviceNameRequest(f)
+	if err != nil || got.DeviceID != 300 {
+		t.Errorf("round-trip: got %+v err %v", got, err)
+	}
+}
+
+func TestProtectDeviceNameResponse(t *testing.T) {
+	p := ProtectDeviceNameResponseParams{DeviceID: 300, DeviceName: "PANEL01"}
+	f := EncodeProtectDeviceNameResponse(p)
+	if f.ID != TxProtectDeviceNameResponse {
+		t.Errorf("ID got %#x", f.ID)
+	}
+	// 10 bytes: 02 2C + " PANEL01" (space-padded to 8)
+	want := []byte{0x02, 0x2C, ' ', 'P', 'A', 'N', 'E', 'L', '0', '1'}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("Payload got %X want %X", f.Payload, want)
+	}
+	got, err := DecodeProtectDeviceNameResponse(f)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got.DeviceID != p.DeviceID || got.DeviceName != p.DeviceName {
+		t.Errorf("round-trip: got %+v want %+v", got, p)
+	}
+}
+
+func TestProtectTallyDumpRequest(t *testing.T) {
+	p := ProtectTallyDumpRequestParams{MatrixID: 1, LevelID: 2, DestinationID: 500}
+	f := EncodeProtectTallyDumpRequest(p)
+	if f.ID != RxProtectTallyDumpRequest {
+		t.Errorf("ID got %#x", f.ID)
+	}
+	// matrix/level=0x12, dest=01 F4
+	want := []byte{0x12, 0x01, 0xF4}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("Payload got %X", f.Payload)
+	}
+	got, _ := DecodeProtectTallyDumpRequest(f)
+	if got != p {
+		t.Errorf("got %+v want %+v", got, p)
+	}
+}
+
+func TestProtectTallyDump_RoundTrip(t *testing.T) {
+	p := ProtectTallyDumpParams{
+		MatrixID:           1,
+		LevelID:            2,
+		FirstDestinationID: 100,
+		Items: []ProtectTallyItem{
+			{State: ProtectProbel, DeviceID: 50},
+			{State: ProtectOEM, DeviceID: 500},
+			{State: ProtectNone, DeviceID: 0},
+		},
+	}
+	f := EncodeProtectTallyDump(p)
+	if f.ID != TxProtectTallyDump {
+		t.Errorf("ID got %#x", f.ID)
+	}
+	// matrix/level=0x12, count=3, dest=00 64
+	// item0: hi = (1<<4)|(50/256=0) = 0x10, lo = 50
+	// item1: hi = (3<<4)|(500/256=1) = 0x31, lo = 500%256 = 244 = 0xF4
+	// item2: hi = 0, lo = 0
+	want := []byte{0x12, 0x03, 0x00, 0x64, 0x10, 50, 0x31, 0xF4, 0x00, 0x00}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("Payload got %X want %X", f.Payload, want)
+	}
+	got, err := DecodeProtectTallyDump(f)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got.MatrixID != p.MatrixID || !reflect.DeepEqual(got.Items, p.Items) {
+		t.Errorf("round-trip: got %+v want %+v", got, p)
+	}
+}
+
+func TestMasterProtectConnect(t *testing.T) {
+	p := MasterProtectConnectParams{MatrixID: 2, LevelID: 3, DestinationID: 400, DeviceID: 500}
+	f := EncodeMasterProtectConnect(p)
+	if f.ID != RxMasterProtectConnect {
+		t.Errorf("ID got %#x want 0x1D", f.ID)
+	}
+	want := []byte{2, 3, 0x01, 0x90, 0x01, 0xF4}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("Payload got %X", f.Payload)
+	}
+	got, err := DecodeMasterProtectConnect(f)
+	if err != nil || got != p {
+		t.Errorf("round-trip: got %+v err %v want %+v", got, err, p)
+	}
+}
+
+func TestProtect_DecodeErrors(t *testing.T) {
+	if _, err := DecodeProtectInterrogate(Frame{ID: TxCrosspointTally}); !errors.Is(err, ErrWrongCommand) {
+		t.Errorf("interrogate: %v", err)
+	}
+	if _, err := DecodeProtectTally(Frame{ID: TxProtectTally, Payload: []byte{1, 2}}); !errors.Is(err, ErrShortPayload) {
+		t.Errorf("tally short: %v", err)
+	}
+	if _, err := DecodeProtectConnect(Frame{ID: RxMaintenance}); !errors.Is(err, ErrWrongCommand) {
+		t.Errorf("connect wrong: %v", err)
+	}
+	if _, err := DecodeProtectDisconnect(Frame{ID: RxProtectConnect}); !errors.Is(err, ErrWrongCommand) {
+		t.Errorf("disconnect must reject RxProtectConnect: %v", err)
+	}
+}

--- a/internal/probel/framer.go
+++ b/internal/probel/framer.go
@@ -1,0 +1,197 @@
+package probel
+
+import (
+	"errors"
+	"io"
+)
+
+// Frame is one logical SW-P-08 command as it rides the wire, post-decode
+// (i.e. after DLE-unstuffing). ID is DATA[0]; Payload is DATA[1:].
+type Frame struct {
+	ID      CommandID
+	Payload []byte // zero or more bytes following the command byte
+}
+
+// Errors surfaced by the framer. Users distinguish them with errors.Is.
+var (
+	ErrBadSOM      = errors.New("probel: bad start-of-message (expected DLE STX)")
+	ErrTruncated   = errors.New("probel: truncated frame (no DLE ETX seen)")
+	ErrBadBTC      = errors.New("probel: byte-count mismatch")
+	ErrBadChecksum = errors.New("probel: checksum mismatch")
+	ErrEmptyFrame  = errors.New("probel: frame has no command byte")
+)
+
+// Checksum8 returns the 8-bit two's-complement checksum over b, i.e.
+// (~sum + 1) & 0xFF. Applied by SW-P-08 over (DATA || BTC) pre-escape.
+//
+// Reference: TS BufferUtility.calculateChecksum8
+// (assets/probel/smh-probelsw08p/src/common/utility/buffer.utility.ts line 152).
+func Checksum8(b []byte) byte {
+	var s uint32
+	for _, x := range b {
+		s += uint32(x)
+	}
+	return byte((^s + 1) & 0xFF)
+}
+
+// escapeDLE returns a copy of src with every DLE byte (0x10) doubled.
+// Applied to DATA, BTC and CHK during Pack; NOT applied to SOM/EOM markers.
+func escapeDLE(src []byte) []byte {
+	n := 0
+	for _, b := range src {
+		if b == DLE {
+			n++
+		}
+	}
+	if n == 0 {
+		out := make([]byte, len(src))
+		copy(out, src)
+		return out
+	}
+	out := make([]byte, 0, len(src)+n)
+	for _, b := range src {
+		out = append(out, b)
+		if b == DLE {
+			out = append(out, DLE)
+		}
+	}
+	return out
+}
+
+// Pack builds a complete framed SW-P-08 message from an unescaped Frame.
+//
+// | Section | Bytes                 | Notes                                       |
+// |---------|-----------------------|---------------------------------------------|
+// | SOM     | DLE STX               | literal, never escaped                      |
+// | DATA    | ID + Payload, escaped | DLE (0x10) doubled                          |
+// | BTC     | 1 byte, escaped       | byte count of pre-escape DATA               |
+// | CHK     | 1 byte, escaped       | 2's-complement of (pre-escape DATA ++ BTC)  |
+// | EOM     | DLE ETX               | literal, never escaped                      |
+//
+// Spec: SW-P-88 §3.4. Reference: TS command.base.ts::packAndBuildDataBuffer.
+func Pack(f Frame) []byte {
+	data := make([]byte, 1+len(f.Payload))
+	data[0] = byte(f.ID)
+	copy(data[1:], f.Payload)
+
+	btc := byte(len(data))
+	chkIn := make([]byte, 0, len(data)+1)
+	chkIn = append(chkIn, data...)
+	chkIn = append(chkIn, btc)
+	chk := Checksum8(chkIn)
+
+	escData := escapeDLE(data)
+	escBTC := escapeDLE([]byte{btc})
+	escCHK := escapeDLE([]byte{chk})
+
+	out := make([]byte, 0, 2+len(escData)+len(escBTC)+len(escCHK)+2)
+	out = append(out, DLE, STX)
+	out = append(out, escData...)
+	out = append(out, escBTC...)
+	out = append(out, escCHK...)
+	out = append(out, DLE, ETX)
+	return out
+}
+
+// PackACK returns the 2-byte positive-acknowledge sequence DLE ACK (0x10 0x06).
+// Controllers and matrices emit this immediately after every correctly-framed
+// frame they accept (SW-P-88 §3.5).
+func PackACK() []byte { return []byte{DLE, ACK} }
+
+// PackNAK returns the 2-byte negative-acknowledge sequence DLE NAK (0x10 0x15).
+// Peers emit this on bad BTC, bad checksum, or malformed framing.
+func PackNAK() []byte { return []byte{DLE, NAK} }
+
+// unescapeDLE reverses escapeDLE: every doubled DLE collapses to a single DLE.
+// Assumes no unpaired DLE in src (the framer guarantees this by terminating at
+// the DLE ETX boundary before reaching here).
+func unescapeDLE(src []byte) []byte {
+	out := make([]byte, 0, len(src))
+	i := 0
+	for i < len(src) {
+		if src[i] == DLE && i+1 < len(src) && src[i+1] == DLE {
+			out = append(out, DLE)
+			i += 2
+			continue
+		}
+		out = append(out, src[i])
+		i++
+	}
+	return out
+}
+
+// Unpack parses one complete SW-P-08 frame from buf[start:], verifying SOM,
+// BTC, checksum and EOM. Returns the decoded Frame and n, the number of bytes
+// consumed from buf. If buf does not begin with DLE STX, ErrBadSOM is returned.
+// If EOM is never seen, ErrTruncated.
+//
+// Callers driving this from a socket stream should accumulate bytes until
+// Unpack succeeds; partial buffers return io.ErrUnexpectedEOF.
+func Unpack(buf []byte) (Frame, int, error) {
+	if len(buf) < 2 {
+		return Frame{}, 0, io.ErrUnexpectedEOF
+	}
+	if buf[0] != DLE || buf[1] != STX {
+		return Frame{}, 0, ErrBadSOM
+	}
+
+	// Scan for DLE ETX, skipping doubled DLE pairs inside DATA/BTC/CHK.
+	eom := -1
+	i := 2
+	for i < len(buf) {
+		if buf[i] != DLE {
+			i++
+			continue
+		}
+		if i+1 >= len(buf) {
+			return Frame{}, 0, io.ErrUnexpectedEOF
+		}
+		switch buf[i+1] {
+		case DLE:
+			i += 2 // escaped data byte
+		case ETX:
+			eom = i
+			i = len(buf) // break
+		default:
+			return Frame{}, 0, ErrTruncated // stray DLE X
+		}
+	}
+	if eom < 0 {
+		return Frame{}, 0, io.ErrUnexpectedEOF
+	}
+
+	body := unescapeDLE(buf[2:eom])
+	if len(body) < 3 {
+		return Frame{}, 0, ErrEmptyFrame // need at least ID + BTC + CHK
+	}
+	data := body[:len(body)-2]
+	btc := body[len(body)-2]
+	chk := body[len(body)-1]
+
+	if int(btc) != len(data) {
+		return Frame{}, 0, ErrBadBTC
+	}
+
+	chkIn := make([]byte, 0, len(data)+1)
+	chkIn = append(chkIn, data...)
+	chkIn = append(chkIn, btc)
+	if Checksum8(chkIn) != chk {
+		return Frame{}, 0, ErrBadChecksum
+	}
+
+	if len(data) == 0 {
+		return Frame{}, 0, ErrEmptyFrame
+	}
+
+	f := Frame{
+		ID:      CommandID(data[0]),
+		Payload: append([]byte(nil), data[1:]...),
+	}
+	return f, eom + 2, nil // consume through DLE ETX
+}
+
+// IsACK reports whether buf begins with the 2-byte positive-acknowledge (DLE ACK).
+func IsACK(buf []byte) bool { return len(buf) >= 2 && buf[0] == DLE && buf[1] == ACK }
+
+// IsNAK reports whether buf begins with the 2-byte negative-acknowledge (DLE NAK).
+func IsNAK(buf []byte) bool { return len(buf) >= 2 && buf[0] == DLE && buf[1] == NAK }

--- a/internal/probel/framer_test.go
+++ b/internal/probel/framer_test.go
@@ -1,0 +1,231 @@
+package probel
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+)
+
+func TestChecksum8(t *testing.T) {
+	// Reference values computed from TS BufferUtility.calculateChecksum8.
+	// sum([0x01, 0x02, 0x03]) = 6 → (~6+1) & 0xFF = 0xFA.
+	if got, want := Checksum8([]byte{0x01, 0x02, 0x03}), byte(0xFA); got != want {
+		t.Errorf("Checksum8 basic: got %#x want %#x", got, want)
+	}
+	// Empty buffer → (~0+1) & 0xFF = 0.
+	if got := Checksum8(nil); got != 0 {
+		t.Errorf("Checksum8 empty: got %#x want 0", got)
+	}
+	// sum = 0x100 → (~0+1)&0xFF = 0.
+	if got := Checksum8([]byte{0xFF, 0x01}); got != 0 {
+		t.Errorf("Checksum8 wrap: got %#x want 0", got)
+	}
+}
+
+func TestPackRoundTrip(t *testing.T) {
+	cases := []struct {
+		name    string
+		frame   Frame
+		wantHex []byte // whole wire output, hand-computed
+	}{
+		{
+			name:  "no payload",
+			frame: Frame{ID: RxMaintenance}, // id=0x07, btc=1, chk = ~(7+1)+1 = 0xF8
+			wantHex: []byte{
+				0x10, 0x02, // SOM
+				0x07,       // DATA
+				0x01,       // BTC
+				0xF8,       // CHK
+				0x10, 0x03, // EOM
+			},
+		},
+		{
+			name: "3-byte payload, no DLE",
+			frame: Frame{
+				ID:      RxCrosspointInterrogate, // 0x01
+				Payload: []byte{0x10 + 1, 0x00, 0x02},
+			},
+			// data = 01 11 00 02, btc=4, sum=01+11+00+02+04=0x18, chk=0xE8.
+			// DATA has no 0x10 byte → no escaping.
+			wantHex: []byte{
+				0x10, 0x02,
+				0x01, 0x11, 0x00, 0x02,
+				0x04,
+				0xE8,
+				0x10, 0x03,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Pack(tc.frame)
+			if !bytes.Equal(got, tc.wantHex) {
+				t.Fatalf("wire mismatch\n got %X\nwant %X", got, tc.wantHex)
+			}
+			f, n, err := Unpack(got)
+			if err != nil {
+				t.Fatalf("Unpack after Pack: %v", err)
+			}
+			if n != len(got) {
+				t.Errorf("Unpack n = %d want %d", n, len(got))
+			}
+			if f.ID != tc.frame.ID {
+				t.Errorf("ID mismatch: got %#x want %#x", f.ID, tc.frame.ID)
+			}
+			if !bytes.Equal(f.Payload, tc.frame.Payload) {
+				t.Errorf("Payload mismatch: got %X want %X", f.Payload, tc.frame.Payload)
+			}
+		})
+	}
+}
+
+func TestPackEscapesDLEInData(t *testing.T) {
+	// Payload contains a literal DLE (0x10) — must be doubled in DATA.
+	f := Frame{ID: RxCrosspointConnect, Payload: []byte{0x10, 0xAA}}
+	out := Pack(f)
+
+	// data = 02 10 AA, btc=3, chkIn = 02 10 AA 03 = 0xBF, chk = ~0xBF+1 = 0x41.
+	// DATA on wire: 02 10 10 AA (DLE doubled). BTC=3, CHK=0x41. Neither BTC
+	// nor CHK equals DLE so they appear once each.
+	want := []byte{
+		0x10, 0x02,
+		0x02, 0x10, 0x10, 0xAA,
+		0x03,
+		0x41,
+		0x10, 0x03,
+	}
+	if !bytes.Equal(out, want) {
+		t.Fatalf("wire mismatch\n got %X\nwant %X", out, want)
+	}
+
+	// Round-trip decodes the single embedded DLE, not two.
+	got, _, err := Unpack(out)
+	if err != nil {
+		t.Fatalf("Unpack: %v", err)
+	}
+	if !bytes.Equal(got.Payload, []byte{0x10, 0xAA}) {
+		t.Errorf("payload round-trip: got %X want 10 AA", got.Payload)
+	}
+}
+
+func TestPackEscapesDLEInBTC(t *testing.T) {
+	// Craft a payload whose DATA is exactly 0x10 bytes, giving BTC = 0x10
+	// (= DLE).  BTC itself must be DLE-doubled on the wire.
+	payload := make([]byte, 0x10-1) // + 1-byte ID = 0x10 total DATA
+	f := Frame{ID: RxMaintenance, Payload: payload}
+	out := Pack(f)
+
+	// Expect ... 10 10 [chk] 10 03 (BTC escaped).
+	// Find the byte sequence: after DATA we must see DLE DLE (escaped BTC).
+	btcIdx := 2 + 0x10 // SOM(2) + DATA(0x10, no 0x10 in content since id=0x07 and zeros)
+	if btcIdx+1 >= len(out) || out[btcIdx] != DLE || out[btcIdx+1] != DLE {
+		t.Fatalf("BTC not escaped: out=%X", out)
+	}
+
+	// Round-trip.
+	got, _, err := Unpack(out)
+	if err != nil {
+		t.Fatalf("Unpack: %v", err)
+	}
+	if got.ID != RxMaintenance || len(got.Payload) != len(payload) {
+		t.Errorf("round-trip failure: id=%#x len=%d want id=%#x len=%d",
+			got.ID, len(got.Payload), RxMaintenance, len(payload))
+	}
+}
+
+func TestPackEscapesDLEInCHK(t *testing.T) {
+	// Find a payload whose checksum equals 0x10.  Checksum over (DATA || BTC):
+	// pick ID=0x01, payload = [0xEF], DATA = 01 EF, BTC=2, chkIn = 01 EF 02
+	// sum=0xF2, chk = ~0xF2+1 = 0x0E. Tweak: payload=[0xED] → sum=01+ED+02 = 0xF0 → chk=0x10.
+	f := Frame{ID: 0x01, Payload: []byte{0xED}}
+	out := Pack(f)
+	// DATA 01 ED (no 0x10). BTC=2 (no escape). CHK=0x10 → escaped as 10 10.
+	want := []byte{
+		0x10, 0x02,
+		0x01, 0xED,
+		0x02,
+		0x10, 0x10,
+		0x10, 0x03,
+	}
+	if !bytes.Equal(out, want) {
+		t.Fatalf("CHK escape\n got %X\nwant %X", out, want)
+	}
+	if _, _, err := Unpack(out); err != nil {
+		t.Errorf("Unpack escaped-CHK frame: %v", err)
+	}
+}
+
+func TestUnpackErrors(t *testing.T) {
+	t.Run("bad SOM", func(t *testing.T) {
+		_, _, err := Unpack([]byte{0xAA, 0xBB, 0x10, 0x03})
+		if !errors.Is(err, ErrBadSOM) {
+			t.Errorf("got %v want ErrBadSOM", err)
+		}
+	})
+	t.Run("truncated", func(t *testing.T) {
+		_, _, err := Unpack([]byte{0x10, 0x02, 0x01, 0x01, 0xFE})
+		if !errors.Is(err, io.ErrUnexpectedEOF) {
+			t.Errorf("got %v want ErrUnexpectedEOF", err)
+		}
+	})
+	t.Run("bad BTC", func(t *testing.T) {
+		bad := []byte{
+			0x10, 0x02,
+			0x07,       // DATA (1 byte)
+			0x05,       // BTC claims 5 → mismatch with actual 1
+			Checksum8([]byte{0x07, 0x05}),
+			0x10, 0x03,
+		}
+		_, _, err := Unpack(bad)
+		if !errors.Is(err, ErrBadBTC) {
+			t.Errorf("got %v want ErrBadBTC", err)
+		}
+	})
+	t.Run("bad checksum", func(t *testing.T) {
+		bad := []byte{
+			0x10, 0x02,
+			0x07,
+			0x01,
+			0x00, // wrong checksum
+			0x10, 0x03,
+		}
+		_, _, err := Unpack(bad)
+		if !errors.Is(err, ErrBadChecksum) {
+			t.Errorf("got %v want ErrBadChecksum", err)
+		}
+	})
+}
+
+func TestAckNak(t *testing.T) {
+	if !bytes.Equal(PackACK(), []byte{0x10, 0x06}) {
+		t.Errorf("PackACK = %X", PackACK())
+	}
+	if !bytes.Equal(PackNAK(), []byte{0x10, 0x15}) {
+		t.Errorf("PackNAK = %X", PackNAK())
+	}
+	if !IsACK([]byte{0x10, 0x06}) {
+		t.Error("IsACK(DLE ACK) = false")
+	}
+	if IsACK([]byte{0x10, 0x03}) {
+		t.Error("IsACK(DLE ETX) = true")
+	}
+	if !IsNAK([]byte{0x10, 0x15}) {
+		t.Error("IsNAK(DLE NAK) = false")
+	}
+	if IsNAK(nil) {
+		t.Error("IsNAK(nil) = true")
+	}
+}
+
+func TestCommandIDIsExtended(t *testing.T) {
+	if RxCrosspointInterrogate.IsExtended() {
+		t.Error("0x01 should not be extended")
+	}
+	if !RxCrosspointInterrogateExt.IsExtended() {
+		t.Error("0x81 should be extended")
+	}
+	if !TxCrosspointTallyExt.IsExtended() {
+		t.Error("0x83 should be extended")
+	}
+}

--- a/internal/probel/types.go
+++ b/internal/probel/types.go
@@ -1,0 +1,123 @@
+// Package probel implements the Probel SW-P-08 wire protocol (framer + codec).
+//
+// Spec: Probel SW-P-88 Issue 3 (assets/probel/probel-sw08p/SW-P-88 Issue 3.pdf).
+// Reference implementation: assets/probel/smh-probelsw08p/ (TypeScript, full matrix
+// emulator + controller emulator). Every command carries a byte-layout doc-comment
+// matching the TS per-command style.
+//
+// This package is consumer-agnostic and provider-agnostic: it only knows bytes.
+// Consumer wrapper lives at internal/protocol/probel/.
+// Provider wrapper lives at internal/provider/probel/.
+package probel
+
+// Control symbols from ASCII control set (SW-P-88 §3.2).
+//
+// | Symbol | Byte | Meaning                                              |
+// |--------|------|------------------------------------------------------|
+// | DLE    | 0x10 | Data Link Escape — frame delimiter and escape char   |
+// | STX    | 0x02 | Start of Text (paired with DLE = SOM)                |
+// | ETX    | 0x03 | End of Text   (paired with DLE = EOM)                |
+// | ACK    | 0x06 | Positive acknowledge (paired with DLE)               |
+// | NAK    | 0x15 | Negative acknowledge (paired with DLE)               |
+const (
+	DLE byte = 0x10
+	STX byte = 0x02
+	ETX byte = 0x03
+	ACK byte = 0x06
+	NAK byte = 0x15
+)
+
+// CommandID is a single Probel SW-P-08 command byte (rx or tx, general or extended).
+// General rx+tx codes are < 128 (0x00–0x7F). Extended codes are >= 128 (0x80–0xFF).
+type CommandID byte
+
+// RX general command IDs (controller → matrix). Source: SW-P-88 §5 and TS
+// assets/probel/smh-probelsw08p/src/command/command-contract.ts RX_GENERAL.
+const (
+	RxCrosspointInterrogate          CommandID = 0x01 // 001 dest status request
+	RxCrosspointConnect              CommandID = 0x02 // 002 connect (route)
+	RxMaintenance                    CommandID = 0x07 // 007 keepalive
+	RxDualControllerStatusRequest    CommandID = 0x08 // 008 dual-ctl status req
+	RxProtectInterrogate             CommandID = 0x0A // 010 protect status req
+	RxProtectConnect                 CommandID = 0x0C // 012 protect on
+	RxProtectDisconnect              CommandID = 0x0E // 014 protect off
+	RxProtectDeviceNameRequest       CommandID = 0x11 // 017 owner name req
+	RxProtectTallyDumpRequest        CommandID = 0x13 // 019 protect dump req
+	RxCrosspointTallyDumpRequest     CommandID = 0x15 // 021 tally dump req
+	RxMasterProtectConnect           CommandID = 0x1D // 029 master protect
+	RxAllSourceNamesRequest          CommandID = 0x64 // 100 names all srcs
+	RxSingleSourceNameRequest        CommandID = 0x65 // 101 name single src
+	RxAllDestNamesRequest            CommandID = 0x66 // 102 names all dsts
+	RxSingleDestNameRequest          CommandID = 0x67 // 103 name single dst
+	RxCrosspointTieLineInterrogate   CommandID = 0x70 // 112 tie-line status
+	RxAllSourceAssocNamesRequest     CommandID = 0x72 // 114 assoc all srcs
+	RxSingleSourceAssocNameRequest   CommandID = 0x73 // 115 assoc single src
+	RxUpdateNameRequest              CommandID = 0x75 // 117 rename notify
+	RxCrosspointConnectOnGoSalvo     CommandID = 0x78 // 120 salvo build
+	RxCrosspointGoSalvo              CommandID = 0x79 // 121 salvo fire
+	RxCrosspointSalvoGroupInterrogate CommandID = 0x7C // 124 salvo query
+)
+
+// RX extended command IDs (controller → matrix, wide addressing). Addresses above
+// the general-command range flip the MSB: general ID | 0x80 = extended ID.
+const (
+	RxCrosspointInterrogateExt       CommandID = 0x81
+	RxCrosspointConnectExt           CommandID = 0x82
+	RxProtectInterrogateExt          CommandID = 0x8A
+	RxProtectConnectExt              CommandID = 0x8C
+	RxProtectDisconnectExt           CommandID = 0x8E
+	RxProtectTallyDumpRequestExt     CommandID = 0x93
+	RxCrosspointTallyDumpRequestExt  CommandID = 0x95
+	RxAllSourceNamesRequestExt       CommandID = 0xE4
+	RxSingleSourceNameRequestExt     CommandID = 0xE5
+	RxAllDestNamesRequestExt         CommandID = 0xE6
+	RxSingleDestNameRequestExt       CommandID = 0xE7
+	RxCrosspointConnectOnGoSalvoExt  CommandID = 0xF8
+	RxCrosspointSalvoGroupInterrogateExt CommandID = 0xFC
+)
+
+// TX general command IDs (matrix → controller). Source: SW-P-88 §5 and TS
+// assets/probel/smh-probelsw08p/src/command/command-contract.ts TX_GENERAL.
+const (
+	TxCrosspointTally              CommandID = 0x03 // 003 async tally
+	TxCrosspointConnected          CommandID = 0x04 // 004 connect ack
+	TxDualControllerStatusResponse CommandID = 0x09 // 009
+	TxProtectTally                 CommandID = 0x0B // 011
+	TxProtectConnected             CommandID = 0x0D // 013
+	TxProtectDisconnected          CommandID = 0x0F // 015
+	TxProtectDeviceNameResponse    CommandID = 0x12 // 018
+	TxProtectTallyDump             CommandID = 0x14 // 020
+	TxCrosspointTallyDumpByte      CommandID = 0x16 // 022
+	TxCrosspointTallyDumpWord      CommandID = 0x17 // 023
+	TxSourceNamesResponse          CommandID = 0x6A // 106
+	TxDestAssocNamesResponse       CommandID = 0x6B // 107
+	TxCrosspointTieLineTally       CommandID = 0x71 // 113
+	TxSourceAssocNamesResponse     CommandID = 0x74 // 116
+	TxSalvoConnectOnGoAck          CommandID = 0x7A // 122
+	TxSalvoGoDoneAck               CommandID = 0x7B // 123
+	TxSalvoGroupTally              CommandID = 0x7D // 125
+)
+
+// TX extended command IDs (matrix → controller, wide addressing).
+const (
+	TxCrosspointTallyExt         CommandID = 0x83
+	TxCrosspointConnectedExt     CommandID = 0x84
+	TxProtectTallyExt            CommandID = 0x8B
+	TxProtectConnectedExt        CommandID = 0x8D
+	TxProtectDisconnectedExt     CommandID = 0x8F
+	TxProtectTallyDumpExt        CommandID = 0x94
+	TxCrosspointTallyDumpWordExt CommandID = 0x97
+	TxSourceNamesResponseExt     CommandID = 0xEA
+	TxDestAssocNamesResponseExt  CommandID = 0xEB
+	TxSalvoConnectOnGoAckExt     CommandID = 0xFA
+	TxSalvoGroupTallyExt         CommandID = 0xFD
+)
+
+// IsExtended reports whether a command ID is in the extended range (bit 7 set).
+// Extended commands use wider address fields than their general counterparts.
+func (id CommandID) IsExtended() bool { return id&0x80 != 0 }
+
+// DefaultPort is the IANA-unregistered TCP port commonly used by Probel SW-P-08
+// matrices when exposed over TCP ("IP Stream" mode in Commie / SMH). Serial mode
+// is the original transport and carries no port.
+const DefaultPort = 2008


### PR DESCRIPTION
## Summary

- ACP2 dissector: decode first property (vtype-aware) into Info line so SetProperty / GetProperty-reply / Announce show the value inline. Short type names (Req/Rep/Evt/Err) + mtid=N for correlation.
- ACP1 dissector: short type names (Ann/Req/Rep/Err) + mtid=0xN on non-announce frames; new length-based value preview for getValue/setValue; getObject label quoted.

## Before / After

**ACP2 SetProperty reply**
- Before: `AN2 > ACP2  slot=0`
- After: `AN2 > ACP2 Rep mtid=116 SetProperty obj=3 pid=value value="ACP2-Frame" slot=0`

**ACP1 setValue request**
- Before: `ACP1 Request setValue slot=1 control[5]`
- After: `ACP1 Req slot=1 mtid=0x4A2F setValue control[5] value=-600`

## Test plan

- [x] Lua syntax verified via tshark load (parses to Proto registration)
- [x] Wireshark reload (Ctrl+Shift+L) picks up new Info without restart
- [ ] Visual: capture ACP2 walk on :2072 → confirm `Rep mtid=N GetObject obj=...`
- [ ] Visual: capture ACP1 walk on :2071 → confirm `Req slot=N mtid=0x... method group[id]`
- [ ] Visual: announce-demo stream → confirm `Evt mtid=0 Announce pid=value obj=18 value=...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)