### PR TITLE
feat(provider): ACP1 --announce-demo ticker + datagram logs

### DIFF
--- a/cmd/acp-provider/main.go
+++ b/cmd/acp-provider/main.go
@@ -20,21 +20,27 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"acp/internal/export/canonical"
 	"acp/internal/provider"
 
-	_ "acp/internal/provider/acp1"
+	acp1provider "acp/internal/provider/acp1"
 	_ "acp/internal/provider/emberplus"
 )
 
 func main() {
 	var (
-		treePath = flag.String("tree", "", "path to canonical tree.json (required)")
-		proto    = flag.String("protocol", "emberplus", "provider plugin name")
-		port     = flag.Int("port", 0, "TCP listen port (0 = plugin default)")
-		host     = flag.String("host", "0.0.0.0", "TCP listen host")
-		logLevel = flag.String("log-level", "info", "log level: debug, info, warn, error")
+		treePath      = flag.String("tree", "", "path to canonical tree.json (required)")
+		proto         = flag.String("protocol", "emberplus", "provider plugin name")
+		port          = flag.Int("port", 0, "TCP listen port (0 = plugin default)")
+		host          = flag.String("host", "0.0.0.0", "TCP listen host")
+		logLevel      = flag.String("log-level", "info", "log level: debug, info, warn, error")
+		announceDemo  = flag.Bool("announce-demo", false, "acp1: oscillate (slot,group,id) every --announce-demo-interval and broadcast announces (demonstrates device-initiated state changes)")
+		announceSlot  = flag.Int("announce-demo-slot", 1, "acp1: slot for --announce-demo target")
+		announceGroup = flag.Int("announce-demo-group", 2, "acp1: object group for --announce-demo target (2=Control)")
+		announceID    = flag.Int("announce-demo-id", 0, "acp1: object id for --announce-demo target (must be Integer type)")
+		announceEvery = flag.Duration("announce-demo-interval", 2*time.Second, "acp1: --announce-demo tick interval")
 	)
 	flag.Parse()
 
@@ -78,6 +84,25 @@ func main() {
 		cancel()
 		_ = srv.Stop()
 	}()
+
+	// Optional: spawn a device-state-change simulator. Only active when
+	// --announce-demo is set AND the loaded plugin is acp1. Ignored for
+	// Ember+ / ACP2 (each provider surfaces its own demo hooks when
+	// relevant).
+	if *announceDemo {
+		if s, ok := srv.(*acp1provider.Server); ok {
+			go s.RunAnnounceDemo(ctx,
+				uint8(*announceSlot),
+				uint8(*announceGroup),
+				uint8(*announceID),
+				*announceEvery,
+			)
+		} else {
+			logger.Warn("--announce-demo ignored: current provider is not acp1",
+				slog.String("protocol", *proto),
+			)
+		}
+	}
 
 	if err := srv.Serve(ctx, addr); err != nil && !errors.Is(err, context.Canceled) {
 		logger.Error("serve", slog.String("err", err.Error()))

--- a/internal/provider/acp1/demo.go
+++ b/internal/provider/acp1/demo.go
@@ -1,0 +1,142 @@
+package acp1
+
+import (
+	"context"
+	"encoding/binary"
+	"log/slog"
+	"math"
+	"time"
+
+	iacp1 "acp/internal/protocol/acp1"
+)
+
+// RunAnnounceDemo oscillates the integer value at (slot, group, id)
+// every `interval` ticks using a sine curve scaled to the entry's
+// declared [min, max] range and broadcasts an ACP1 value-change
+// announcement (spec §"Announcements", MTID=0, MType=2, MCode=setValue)
+// to the LAN on every tick. Exits when ctx is cancelled.
+//
+// Purpose: demonstrate that device-initiated state changes (alarms,
+// sensor readings, level meters) propagate to ACP1 subscribers exactly
+// like client-initiated setValue announces — both paths end at
+// broadcastAnnounce. Mirrors the acp2 provider's --announce-demo.
+//
+// The target must be a mutable Integer (type=1) per the ACP1 method
+// matrix; Enum/Byte/Long/Float types would need a different oscillator
+// path so we reject non-Integer up front with a warning and return.
+func (s *server) RunAnnounceDemo(ctx context.Context, slot uint8, group, id uint8, interval time.Duration) {
+	if interval <= 0 {
+		interval = 2 * time.Second
+	}
+	key := objectKey{slot: slot, group: iacp1.ObjGroup(group), id: id}
+	e, ok := s.tree.lookup(key)
+	if !ok {
+		s.logger.Warn("acp1 demo: target not found",
+			slog.Int("slot", int(slot)),
+			slog.Int("group", int(group)),
+			slog.Int("id", int(id)),
+		)
+		return
+	}
+	if e.acpType != iacp1.TypeInteger {
+		s.logger.Warn("acp1 demo: target is not Integer (s16), skipping",
+			slog.Int("acp_type", int(e.acpType)),
+			slog.String("path", e.param.Path),
+		)
+		return
+	}
+
+	minV, maxV := int16(-100), int16(100)
+	if e.param.Minimum != nil {
+		if v, ok := demoAsInt16(e.param.Minimum); ok {
+			minV = v
+		}
+	}
+	if e.param.Maximum != nil {
+		if v, ok := demoAsInt16(e.param.Maximum); ok {
+			maxV = v
+		}
+	}
+
+	t := time.NewTicker(interval)
+	defer t.Stop()
+
+	s.logger.Info("acp1 announce demo started",
+		slog.Int("slot", int(slot)),
+		slog.Int("group", int(group)),
+		slog.Int("id", int(id)),
+		slog.String("path", e.param.Path),
+		slog.Int("min", int(minV)),
+		slog.Int("max", int(maxV)),
+		slog.Duration("interval", interval),
+	)
+
+	phase := 0.0
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+		}
+		phase += math.Pi / 8 // 16 ticks per full cycle
+
+		mid := (int32(minV) + int32(maxV)) / 2
+		amp := (int32(maxV) - int32(minV)) / 2
+		v := int16(mid + int32(math.Round(float64(amp)*math.Sin(phase))))
+		if v < minV {
+			v = minV
+		}
+		if v > maxV {
+			v = maxV
+		}
+
+		// Encode as 2-byte big-endian s16 (spec §"Integer object type").
+		valBytes := make([]byte, 2)
+		binary.BigEndian.PutUint16(valBytes, uint16(v))
+
+		// Route through the SAME path as a client setValue so the
+		// canonical.Parameter.Value update + reply bytes match what
+		// getValue would return after the change.
+		stored, err := s.applyMutation(e, iacp1.MethodSetValue, valBytes)
+		if err != nil {
+			s.logger.Warn("acp1 demo: apply failed", slog.String("err", err.Error()))
+			continue
+		}
+
+		announce := &iacp1.Message{
+			MTID:     0,
+			PVER:     1,
+			MType:    iacp1.MTypeReply,
+			MAddr:    slot,
+			MCode:    byte(iacp1.MethodSetValue),
+			ObjGroup: iacp1.ObjGroup(group),
+			ObjID:    id,
+			Value:    stored,
+		}
+		s.broadcastAnnounce(announce)
+	}
+}
+
+// demoAsInt16 reads a canonical numeric constraint as int16. Returns ok=false
+// when the value is out of range or not a number.
+func demoAsInt16(v any) (int16, bool) {
+	switch x := v.(type) {
+	case int:
+		if x >= math.MinInt16 && x <= math.MaxInt16 {
+			return int16(x), true
+		}
+	case int64:
+		if x >= math.MinInt16 && x <= math.MaxInt16 {
+			return int16(x), true
+		}
+	case float64:
+		if x >= math.MinInt16 && x <= math.MaxInt16 {
+			return int16(x), true
+		}
+	case float32:
+		if x >= math.MinInt16 && x <= math.MaxInt16 {
+			return int16(x), true
+		}
+	}
+	return 0, false
+}

--- a/internal/provider/acp1/server.go
+++ b/internal/provider/acp1/server.go
@@ -12,6 +12,12 @@ import (
 	iacp1 "acp/internal/protocol/acp1"
 )
 
+// Server is the exported alias for the concrete ACP1 provider — lets
+// cmd/acp-provider reach protocol-specific helpers (e.g. RunAnnounceDemo)
+// via a type assertion without widening the cross-protocol
+// provider.Provider interface. Mirrors the pattern used in acp2.
+type Server = server
+
 // server is the concrete provider.Provider for ACP1 over UDP. One
 // datagram in -> dispatch -> one datagram out, plus broadcast announce
 // on successful mutating methods.
@@ -173,6 +179,7 @@ func (s *server) broadcastAnnounce(ann *iacp1.Message) {
 	bc := s.bcast
 	s.mu.Unlock()
 	if bc == nil {
+		s.logger.Warn("acp1 announce skipped: no broadcast socket")
 		return
 	}
 	out, err := ann.Encode()
@@ -183,10 +190,22 @@ func (s *server) broadcastAnnounce(ann *iacp1.Message) {
 		return
 	}
 	if _, err := bc.Write(out); err != nil {
-		s.logger.Debug("acp1 announce send",
+		s.logger.Warn("acp1 announce send",
 			slog.String("err", err.Error()),
+			slog.String("dst", bc.RemoteAddr().String()),
 		)
+		return
 	}
+	s.logger.Info("acp1 announce broadcast",
+		slog.Uint64("mtid", uint64(ann.MTID)),
+		slog.Int("mtype", int(ann.MType)),
+		slog.Int("mcode", int(ann.MCode)),
+		slog.Int("objgroup", int(ann.ObjGroup)),
+		slog.Int("objid", int(ann.ObjID)),
+		slog.Int("maddr", int(ann.MAddr)),
+		slog.Int("bytes", len(out)),
+		slog.String("dst", bc.RemoteAddr().String()),
+	)
 }
 
 // readLoop reads datagrams until ctx is cancelled or the conn is closed.

--- a/internal/provider/acp1/session.go
+++ b/internal/provider/acp1/session.go
@@ -257,14 +257,29 @@ func groupOrInstanceMissing(s *server, k objectKey) iacp1.ObjectErrCode {
 // happened — broadcasts the announcement via broadcastFn. Decode
 // failures are logged and dropped (no "bad-framing" reply in spec).
 func (s *server) handleDatagram2(data []byte, srcStr string, send func([]byte) error) {
+	s.logger.Info("acp1 datagram recv",
+		slog.String("src", srcStr),
+		slog.Int("bytes", len(data)),
+	)
 	msg, err := iacp1.Decode(data)
 	if err != nil {
-		s.logger.Debug("acp1 provider: decode failed",
+		s.logger.Warn("acp1 provider: decode failed",
 			slog.String("src", srcStr),
+			slog.Int("bytes", len(data)),
 			slog.String("err", err.Error()),
 		)
 		return
 	}
+	s.logger.Info("acp1 request",
+		slog.String("src", srcStr),
+		slog.Uint64("mtid", uint64(msg.MTID)),
+		slog.Int("mtype", int(msg.MType)),
+		slog.Int("mcode", int(msg.MCode)),
+		slog.Int("objgroup", int(msg.ObjGroup)),
+		slog.Int("objid", int(msg.ObjID)),
+		slog.Int("maddr", int(msg.MAddr)),
+		slog.Int("value_len", len(msg.Value)),
+	)
 	rep, ann := s.handleRequest(msg)
 	if rep == nil {
 		return


### PR DESCRIPTION
## Summary

- Adds `--announce-demo` to `cmd/acp-provider` for the ACP1 plugin: a goroutine oscillates an Integer (s16) at `(slot, group, id)` every `--announce-demo-interval` (default 2s) over its declared [min,max] and broadcasts MTID=0 MType=Reply MCode=setValue to `255.255.255.255:2071`. Mirrors the ACP2 provider's --announce-demo from PR #76.
- Exports `type Server = server` alias in the ACP1 provider package so `cmd/acp-provider` can type-assert for the demo hook.
- Upgrades broadcastAnnounce + handleDatagram2 logging to Info level (was Debug) to trace "is our announce actually leaving the socket?" and "is the viewer talking to our current provider instance?" during live validation against VSM Controller.

## Why

Demonstrate device-initiated state changes (alarms, sensor readings, meters) — the second half of the ACP1 announcement model that the reactive client-set echo path doesn't exercise on its own. Visible in VSM as a parameter that ticks on its own, and in Wireshark (with PR #80 dissector) as `ACP1 Ann slot=1 mtid=0x0 setValue control[0] value(s16)=...`.

## Test plan

- [x] `go build -o bin/acp-provider-acp1.exe ./cmd/acp-provider` passes
- [x] `go test ./internal/provider/acp1/...` passes
- [x] Lawo VSM Controller auto-discovers our provider and walks all 3 slots
- [x] Demo ticker emits MTID=0 announces every 2s visible in Wireshark
- [ ] SynapseSetUp v1.90 smoke check

Depends on PR #80 for the Wireshark dissector to render `Ann` correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)