### PR TITLE
docs(acp1/codec): byte-table doc-comments on all wire codecs (part 1 of #78)

### DIFF
--- a/internal/acp1/consumer/message.go
+++ b/internal/acp1/consumer/message.go
@@ -63,6 +63,22 @@ var ErrBadPVer = errors.New("acp1: unsupported PVER (expected 1)")
 //   - For MType < 3: MDATA = [MCODE, ObjGroup, ObjID, Value...]
 //   - For MType = 3: MDATA = [MCode] only (caller supplies the error code
 //     via MCode and leaves Value nil)
+//
+// Output wire layout (≤ 141 bytes total):
+//
+//	| Offset | Field    | Width | Notes                                      |
+//	|--------|----------|-------|--------------------------------------------|
+//	|   0    | MTID     |   4   | u32 big-endian; 0 = announcement           |
+//	|   4    | PVER     |   1   | 1 (ACP1 v1.4); forced if caller passes 0   |
+//	|   5    | MTYPE    |   1   | 0=announce, 1=request, 2=reply, 3=error    |
+//	|   6    | MADDR    |   1   | slot 0..31 (0 = rack controller)           |
+//	|   7    | MCODE    |   1   | method id (MTYPE<3) or error code (MTYPE=3)|
+//	|   8    | ObjGroup |   1   | present only when MTYPE < 3                |
+//	|   9    | ObjID    |   1   | present only when MTYPE < 3                |
+//	|  10..  | Value    |  ≤131 | method args / return value (MTYPE < 3)     |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"ACP Header" p. 9 and
+// §"AxonNet - ACP mapping" p. 32.
 func (m *Message) Encode() ([]byte, error) {
 	if m == nil {
 		return nil, errors.New("acp1: Encode nil message")
@@ -120,6 +136,22 @@ func (m *Message) Encode() ([]byte, error) {
 
 // Decode parses one ACP1 datagram. Safe for garbled input — every length
 // check is explicit and every return path sets a non-nil error on failure.
+//
+// Input wire layout (minimum 8 bytes, maximum 141 bytes):
+//
+//	| Offset | Field    | Width | Notes                                      |
+//	|--------|----------|-------|--------------------------------------------|
+//	|   0    | MTID     |   4   | u32 big-endian; 0 = announcement           |
+//	|   4    | PVER     |   1   | must be 1; otherwise ErrBadPVer            |
+//	|   5    | MTYPE    |   1   | 0..3; otherwise "invalid MType"            |
+//	|   6    | MADDR    |   1   | slot id (0..31)                            |
+//	|   7    | MCODE    |   1   | always present (method id or error code)   |
+//	|   8    | ObjGroup |   1   | required for MTYPE<3; optional on error    |
+//	|   9    | ObjID    |   1   | required for MTYPE<3; optional on error    |
+//	|  10..  | Value    |  ≤131 | present only for MTYPE < 3                 |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"ACP Header" p. 9 and
+// §"AxonNet - ACP mapping" p. 32.
 func Decode(buf []byte) (*Message, error) {
 	if len(buf) < HeaderSize+1 {
 		// Smallest valid ACP1 datagram: 7-byte header + 1-byte MDATA (an

--- a/internal/acp1/consumer/property.go
+++ b/internal/acp1/consumer/property.go
@@ -97,6 +97,19 @@ var ErrBadProperty = errors.New("acp1: property decode out of bounds")
 //
 // Defensive: every read is bounds-checked. A truncated or malformed reply
 // returns ErrBadProperty with an offset/length context.
+//
+// Common prefix (all object types):
+//
+//	| Byte | Field       | Notes                                          |
+//	|------|-------------|------------------------------------------------|
+//	|  0   | object_type |  0=Root, 1=Integer, 2=IPAddr, 3=Float, 4=Enum  |
+//	|      |             |  5=String, 6=Frame, 7=Alarm, 8=File, 9=Long,   |
+//	|      |             |  10=Byte, 11=Reserved                          |
+//	|  1   | num_props   | number of properties following                 |
+//	| 2..  | (type-specific fields — see per-type decoders) |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Property Object Type" p. 19 and
+// §"Objects by Type" pp. 21–27.
 func DecodeObject(value []byte) (*DecodedObject, error) {
 	r := &reader{buf: value}
 
@@ -154,6 +167,20 @@ func DecodeObject(value []byte) (*DecodedObject, error) {
 //	pid 6  num_status    byte
 //	pid 7  num_alarm     byte
 //	pid 8  num_file      byte
+//
+// Wire layout after the common prefix (7 bytes):
+//
+//	| Byte | Field         | Width | Notes                                |
+//	|------|---------------|-------|--------------------------------------|
+//	|  0   | access        |   1   | bit0=r, bit1=w, bit2=setDef          |
+//	|  1   | boot_mode     |   1   | Root's "value" property              |
+//	|  2   | num_identity  |   1   | count of Identity objects            |
+//	|  3   | num_control   |   1   | count of Control objects             |
+//	|  4   | num_status    |   1   | count of Status objects              |
+//	|  5   | num_alarm     |   1   | count of Alarm objects               |
+//	|  6   | num_file      |   1   | count of File objects                |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Objects by Type" p. 21.
 func decodeRoot(o *DecodedObject, r *reader) (*DecodedObject, error) {
 	var err error
 	if o.Access, err = r.u8(); err != nil {
@@ -184,6 +211,21 @@ func decodeRoot(o *DecodedObject, r *reader) (*DecodedObject, error) {
 //
 //	access, value(int16), default(int16), step(int16), min(int16),
 //	max(int16), label(string), unit(string)
+//
+// Wire layout after the common prefix:
+//
+//	| Byte   | Field   | Width | Notes                                   |
+//	|--------|---------|-------|-----------------------------------------|
+//	|  0     | access  |   1   | bit0=r, bit1=w, bit2=setDef             |
+//	|  1..2  | value   |   2   | int16 big-endian                        |
+//	|  3..4  | default |   2   | int16 big-endian                        |
+//	|  5..6  | step    |   2   | int16 big-endian                        |
+//	|  7..8  | min     |   2   | int16 big-endian                        |
+//	|  9..10 | max     |   2   | int16 big-endian                        |
+//	| 11..   | label   |  ≤17  | NUL-terminated ASCII (max 16 + \0)      |
+//	|  ...   | unit    |  ≤5   | NUL-terminated ASCII (max 4 + \0); opt. |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Objects by Type" p. 22.
 func decodeInteger(o *DecodedObject, r *reader) (*DecodedObject, error) {
 	var err error
 	if o.Access, err = r.u8(); err != nil {
@@ -219,6 +261,21 @@ func decodeInteger(o *DecodedObject, r *reader) (*DecodedObject, error) {
 
 // decodeIPAddr — Spec p. 22. Layout identical to Integer but all numeric
 // properties are uint32 (big-endian, MSB first).
+//
+// Wire layout after the common prefix:
+//
+//	| Byte    | Field   | Width | Notes                                  |
+//	|---------|---------|-------|----------------------------------------|
+//	|  0      | access  |   1   | bit0=r, bit1=w, bit2=setDef            |
+//	|  1..4   | value   |   4   | uint32 big-endian (4 octets a.b.c.d)   |
+//	|  5..8   | default |   4   | uint32 big-endian                      |
+//	|  9..12  | step    |   4   | uint32 big-endian                      |
+//	| 13..16  | min     |   4   | uint32 big-endian                      |
+//	| 17..20  | max     |   4   | uint32 big-endian                      |
+//	| 21..    | label   |  ≤17  | NUL-terminated ASCII                   |
+//	|  ...    | unit    |  ≤5   | NUL-terminated ASCII; optional         |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Objects by Type" p. 22.
 func decodeIPAddr(o *DecodedObject, r *reader) (*DecodedObject, error) {
 	var err error
 	if o.Access, err = r.u8(); err != nil {
@@ -249,6 +306,21 @@ func decodeIPAddr(o *DecodedObject, r *reader) (*DecodedObject, error) {
 }
 
 // decodeFloat — Spec p. 23. IEEE-754 single-precision, MSB first.
+//
+// Wire layout after the common prefix:
+//
+//	| Byte    | Field   | Width | Notes                                  |
+//	|---------|---------|-------|----------------------------------------|
+//	|  0      | access  |   1   | bit0=r, bit1=w, bit2=setDef            |
+//	|  1..4   | value   |   4   | IEEE-754 float32 big-endian            |
+//	|  5..8   | default |   4   | IEEE-754 float32 big-endian            |
+//	|  9..12  | step    |   4   | IEEE-754 float32 big-endian            |
+//	| 13..16  | min     |   4   | IEEE-754 float32 big-endian            |
+//	| 17..20  | max     |   4   | IEEE-754 float32 big-endian            |
+//	| 21..    | label   |  ≤17  | NUL-terminated ASCII                   |
+//	|  ...    | unit    |  ≤5   | NUL-terminated ASCII; optional         |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Objects by Type" p. 23.
 func decodeFloat(o *DecodedObject, r *reader) (*DecodedObject, error) {
 	var err error
 	if o.Access, err = r.u8(); err != nil {
@@ -281,6 +353,20 @@ func decodeFloat(o *DecodedObject, r *reader) (*DecodedObject, error) {
 // decodeEnum — Spec p. 23. Value is a 1-byte index into a comma-delimited
 // NUL-terminated item list. The item list is the last field and may be
 // empty. Label precedes the item list.
+//
+// Wire layout after the common prefix:
+//
+//	| Byte | Field      | Width | Notes                                     |
+//	|------|------------|-------|-------------------------------------------|
+//	|  0   | access     |   1   | bit0=r, bit1=w, bit2=setDef               |
+//	|  1   | value      |   1   | u8 index into item_list                   |
+//	|  2   | num_items  |   1   | number of items declared                  |
+//	|  3   | default    |   1   | u8 index                                  |
+//	|  4.. | label      |  ≤17  | NUL-terminated ASCII                      |
+//	|  ... | item_list  |   ?   | comma-delimited NUL-terminated, e.g.      |
+//	|      |            |       | "Off,On,Auto\0"; may be empty             |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Objects by Type" p. 23.
 func decodeEnum(o *DecodedObject, r *reader) (*DecodedObject, error) {
 	var err error
 	if o.Access, err = r.u8(); err != nil {
@@ -341,6 +427,17 @@ func splitEnumItems(raw string, n int) []string {
 // decodeString — Spec p. 24. Value(string[MaxLen]) + MaxLen(byte) + Label.
 // Order on the wire: Value, then MaxLen, then Label. The spec puts MaxLen
 // AFTER the value, not before — verified against the C# reference parser.
+//
+// Wire layout after the common prefix:
+//
+//	| Byte | Field    | Width | Notes                                       |
+//	|------|----------|-------|---------------------------------------------|
+//	|  0   | access   |   1   | bit0=r, bit1=w, bit2=setDef                 |
+//	|  1.. | value    |   ?   | NUL-terminated ASCII, bounded by max_len+\0 |
+//	|  ... | max_len  |   1   | u8; declared buffer size (bytes)            |
+//	|  ... | label    |  ≤17  | NUL-terminated ASCII; optional on wire      |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Objects by Type" p. 24.
 func decodeString(o *DecodedObject, r *reader) (*DecodedObject, error) {
 	var err error
 	if o.Access, err = r.u8(); err != nil {
@@ -360,6 +457,19 @@ func decodeString(o *DecodedObject, r *reader) (*DecodedObject, error) {
 
 // decodeFrame — Spec p. 24. Frame Status Object (type=6, 4 props).
 // Access byte then NumOfSlots + SlotStatus array packed into one field.
+//
+// Wire layout after the common prefix:
+//
+//	| Byte      | Field         | Width | Notes                           |
+//	|-----------|---------------|-------|---------------------------------|
+//	|  0        | access        |   1   | read-only (bit0 set, 1)         |
+//	|  1        | num_slots     |   1   | u8; number of cards in frame    |
+//	|  2..n+1   | slot_status[] |   n   | one u8 per slot:                |
+//	|           |               |       |  0=no-card, 1=powerup,          |
+//	|           |               |       |  2=present, 3=error,            |
+//	|           |               |       |  4=removed, 5=boot              |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Objects by Type" p. 24.
 func decodeFrame(o *DecodedObject, r *reader) (*DecodedObject, error) {
 	var err error
 	if o.Access, err = r.u8(); err != nil {
@@ -382,6 +492,19 @@ func decodeFrame(o *DecodedObject, r *reader) (*DecodedObject, error) {
 // decodeAlarm — Spec p. 25. 8 properties (since rev 1.2 added Event Off):
 //
 //	access, priority, tag, label, event_on_msg, event_off_msg
+//
+// Wire layout after the common prefix:
+//
+//	| Byte | Field         | Width | Notes                                |
+//	|------|---------------|-------|--------------------------------------|
+//	|  0   | access        |   1   | bit0=r, bit1=w, bit2=setDef          |
+//	|  1   | priority      |   1   | u8; 0 = alarm disabled               |
+//	|  2   | tag           |   1   | u8; device-assigned identifier       |
+//	|  3.. | label         |  ≤17  | NUL-terminated ASCII (max 16 + \0)   |
+//	|  ... | event_on_msg  |  ≤33  | NUL-terminated ASCII (max 32 + \0)   |
+//	|  ... | event_off_msg |  ≤33  | NUL-terminated ASCII; optional       |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Objects by Type" p. 25.
 func decodeAlarm(o *DecodedObject, r *reader) (*DecodedObject, error) {
 	var err error
 	if o.Access, err = r.u8(); err != nil {
@@ -407,6 +530,19 @@ func decodeAlarm(o *DecodedObject, r *reader) (*DecodedObject, error) {
 
 // decodeFile — Spec p. 26. File Object (type=8, 5 props). The Fragment
 // property is not returned by getObject per the spec note on p. 26.
+//
+// Wire layout after the common prefix:
+//
+//	| Byte   | Field         | Width | Notes                              |
+//	|--------|---------------|-------|------------------------------------|
+//	|  0     | access        |   1   | bit0=r, bit1=w, bit2=setDef        |
+//	|  1..2  | num_fragments |   2   | int16 big-endian                   |
+//	|  3..   | file_name     |  ≤17  | NUL-terminated ASCII (max 16 + \0) |
+//
+// Note: Fragment property is engineer-mode only and never returned by
+// getObject on real Synapse firmware.
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Objects by Type" p. 26.
 func decodeFile(o *DecodedObject, r *reader) (*DecodedObject, error) {
 	var err error
 	if o.Access, err = r.u8(); err != nil {
@@ -424,6 +560,21 @@ func decodeFile(o *DecodedObject, r *reader) (*DecodedObject, error) {
 }
 
 // decodeLong — Spec p. 26. Layout identical to Integer but int32 values.
+//
+// Wire layout after the common prefix:
+//
+//	| Byte    | Field   | Width | Notes                                  |
+//	|---------|---------|-------|----------------------------------------|
+//	|  0      | access  |   1   | bit0=r, bit1=w, bit2=setDef            |
+//	|  1..4   | value   |   4   | int32 big-endian                       |
+//	|  5..8   | default |   4   | int32 big-endian                       |
+//	|  9..12  | step    |   4   | int32 big-endian                       |
+//	| 13..16  | min     |   4   | int32 big-endian                       |
+//	| 17..20  | max     |   4   | int32 big-endian                       |
+//	| 21..    | label   |  ≤17  | NUL-terminated ASCII                   |
+//	|  ...    | unit    |  ≤5   | NUL-terminated ASCII; optional         |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Objects by Type" p. 26.
 func decodeLong(o *DecodedObject, r *reader) (*DecodedObject, error) {
 	var err error
 	if o.Access, err = r.u8(); err != nil {
@@ -454,6 +605,21 @@ func decodeLong(o *DecodedObject, r *reader) (*DecodedObject, error) {
 }
 
 // decodeByte — Spec p. 27. Layout identical to Integer but u8 values.
+//
+// Wire layout after the common prefix:
+//
+//	| Byte | Field   | Width | Notes                                     |
+//	|------|---------|-------|-------------------------------------------|
+//	|  0   | access  |   1   | bit0=r, bit1=w, bit2=setDef               |
+//	|  1   | value   |   1   | u8                                        |
+//	|  2   | default |   1   | u8                                        |
+//	|  3   | step    |   1   | u8                                        |
+//	|  4   | min     |   1   | u8                                        |
+//	|  5   | max     |   1   | u8                                        |
+//	|  6.. | label   |  ≤17  | NUL-terminated ASCII                      |
+//	|  ... | unit    |  ≤5   | NUL-terminated ASCII; optional            |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Objects by Type" p. 27.
 func decodeByte(o *DecodedObject, r *reader) (*DecodedObject, error) {
 	var err error
 	if o.Access, err = r.u8(); err != nil {

--- a/internal/acp1/consumer/value_codec.go
+++ b/internal/acp1/consumer/value_codec.go
@@ -36,6 +36,24 @@ import (
 // The fine-grained ACP1 type is passed in explicitly because the widened
 // protocol.ValueKind cannot distinguish Integer (int16) from Long (int32)
 // — both surface as KindInt to the rest of the system.
+//
+// Per-type raw-value layout (no type/num_props prefix — scoped by object):
+//
+//	| ACP1 type | Width | Wire layout                                    |
+//	|-----------|-------|------------------------------------------------|
+//	| Integer   |   2   | int16 big-endian                               |
+//	| Long      |   4   | int32 big-endian                               |
+//	| Byte      |   1   | u8                                             |
+//	| Float     |   4   | IEEE-754 float32 big-endian                    |
+//	| IPAddr    |   4   | uint32 big-endian (4 octets a.b.c.d)           |
+//	| Enum      |   1   | u8 index into item list                        |
+//	| String    |   ?   | NUL-terminated ASCII; terminator optional      |
+//	| Alarm     |   1   | u8 priority (0 = disabled)                     |
+//	| Frame     |  1+N  | u8 num_slots then N × u8 slot_status           |
+//	| Root/File |   ?   | raw bytes pass-through                         |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Methods" p. 28 and
+// §"Objects by Type" pp. 21–27.
 func DecodeValueBytes(obj protocol.Object, acpType ObjectType, raw []byte) (protocol.Value, error) {
 	v := protocol.Value{
 		Kind: obj.Kind,
@@ -156,6 +174,21 @@ func DecodeValueBytes(obj protocol.Object, acpType ObjectType, raw []byte) (prot
 // This is the inverse of DecodeValueBytes with a forgiving input policy:
 // Value.Str takes precedence when present so CLI users can type
 // `--value "On"` or `--value "192.168.1.5"` regardless of object kind.
+//
+// Per-type raw-value layout produced on the wire:
+//
+//	| ACP1 type | Width  | Wire layout                                   |
+//	|-----------|--------|-----------------------------------------------|
+//	| Integer   |   2    | int16 big-endian; range [-32768..32767]       |
+//	| Long      |   4    | int32 big-endian; range [MinInt32..MaxInt32]  |
+//	| Byte      |   1    | u8; range [0..255]                            |
+//	| Float     |   4    | IEEE-754 float32 big-endian                   |
+//	| IPAddr    |   4    | uint32 big-endian (4 octets a.b.c.d)          |
+//	| Enum      |   1    | u8 index (validated against item list)        |
+//	| String    | len+1  | bytes + NUL terminator; bounded by MaxLen     |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Methods" p. 28 and
+// §"Objects by Type" pp. 21–27.
 func EncodeValueBytes(obj protocol.Object, acpType ObjectType, val protocol.Value) ([]byte, error) {
 	switch acpType {
 	case TypeInteger:

--- a/internal/acp1/provider/encoder.go
+++ b/internal/acp1/provider/encoder.go
@@ -24,6 +24,19 @@ import (
 // Errors returned when a canonical value is out of spec range for its
 // ACP1 type (e.g. int16 value 40000) so the provider never emits
 // malformed bytes. Never silently clamps.
+//
+// Common prefix (all object types):
+//
+//	| Byte | Field       | Notes                                          |
+//	|------|-------------|------------------------------------------------|
+//	|  0   | object_type |  0=Root, 1=Integer, 2=IPAddr, 3=Float, 4=Enum  |
+//	|      |             |  5=String, 6=Frame, 7=Alarm, 8=File, 9=Long,   |
+//	|      |             |  10=Byte                                       |
+//	|  1   | num_props   | number of properties emitted                   |
+//	| 2..  | (type-specific fields — see per-type encoders) |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Methods" p. 28 and
+// §"Objects by Type" pp. 21–27.
 func encodeObject(e *entry) ([]byte, error) {
 	if e == nil || e.param == nil {
 		return nil, fmt.Errorf("encodeObject: nil entry")
@@ -70,6 +83,24 @@ func encodeObject(e *entry) ([]byte, error) {
 //	File       -> num_fragments (i16)
 //	Long       -> value (i32)
 //	Byte       -> value (u8)
+//
+// Per-type raw-value layout on the wire:
+//
+//	| ACP1 type | Width | Wire layout                                   |
+//	|-----------|-------|-----------------------------------------------|
+//	| Integer   |   2   | int16 big-endian                              |
+//	| IPAddr    |   4   | uint32 big-endian (4 octets a.b.c.d)          |
+//	| Float     |   4   | IEEE-754 float32 big-endian                   |
+//	| Enum      |   1   | u8 index into item list                       |
+//	| String    | len+1 | bytes + NUL terminator                        |
+//	| Alarm     |   1   | u8 (0 = idle, 1 = active)                     |
+//	| Long      |   4   | int32 big-endian                              |
+//	| Byte      |   1   | u8                                            |
+//	| File      |   2   | int16 big-endian num_fragments                |
+//	| Frame     |  1+N  | u8 num_slots + N × u8 slot_status             |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Methods" p. 28 and
+// §"Objects by Type" pp. 21–27.
 func encodeValue(e *entry) ([]byte, error) {
 	if e == nil || e.param == nil {
 		return nil, fmt.Errorf("encodeValue: nil entry")
@@ -140,6 +171,24 @@ func encodeValue(e *entry) ([]byte, error) {
 
 // encodeRoot — spec p.21. Root has 9 properties; object_type(0) and
 // num_props(9) are part of the header.
+//
+// Wire layout after the common prefix (7 bytes):
+//
+//	| Byte | Field         | Width | Notes                                |
+//	|------|---------------|-------|--------------------------------------|
+//	|  0   | access        |   1   | bit0=r, bit1=w, bit2=setDef          |
+//	|  1   | boot_mode     |   1   | Root's "value" property              |
+//	|  2   | num_identity  |   1   | count of Identity objects            |
+//	|  3   | num_control   |   1   | count of Control objects             |
+//	|  4   | num_status    |   1   | count of Status objects              |
+//	|  5   | num_alarm     |   1   | count of Alarm objects               |
+//	|  6   | num_file      |   1   | count of File objects                |
+//
+// Note: Root objects are synthesised by session.go from tree.slots and
+// never stored in the canonical tree; this function is a stub that
+// returns an error so callers route through the session layer.
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Objects by Type" p. 21.
 func encodeRoot(e *entry) ([]byte, error) {
 	// Root props: access, boot_mode, num_identity, num_control,
 	// num_status, num_alarm, num_file. The canonical tree doesn't store
@@ -149,6 +198,23 @@ func encodeRoot(e *entry) ([]byte, error) {
 	return nil, fmt.Errorf("encodeRoot: Root objects are synthesised by session.go, not stored as tree entries")
 }
 
+// encodeInteger — inverse of consumer's decodeInteger. Integer Object
+// (type=1, 10 props).
+//
+// Wire layout after the common prefix:
+//
+//	| Byte   | Field   | Width | Notes                                   |
+//	|--------|---------|-------|-----------------------------------------|
+//	|  0     | access  |   1   | bit0=r, bit1=w, bit2=setDef             |
+//	|  1..2  | value   |   2   | int16 big-endian                        |
+//	|  3..4  | default |   2   | int16 big-endian                        |
+//	|  5..6  | step    |   2   | int16 big-endian                        |
+//	|  7..8  | min     |   2   | int16 big-endian                        |
+//	|  9..10 | max     |   2   | int16 big-endian                        |
+//	| 11..   | label   |  ≤17  | NUL-terminated ASCII (max 16 + \0)      |
+//	|  ...   | unit    |  ≤5   | NUL-terminated ASCII (max 4 + \0)       |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Objects by Type" p. 22.
 func encodeInteger(e *entry) ([]byte, error) {
 	p := e.param
 	value, err := asInt16(p.Value, "value")
@@ -183,6 +249,23 @@ func encodeInteger(e *entry) ([]byte, error) {
 	return buf.bytes(), nil
 }
 
+// encodeLong — inverse of consumer's decodeLong. Long Object (type=9,
+// 10 props). Same layout as Integer but int32 numerics.
+//
+// Wire layout after the common prefix:
+//
+//	| Byte    | Field   | Width | Notes                                  |
+//	|---------|---------|-------|----------------------------------------|
+//	|  0      | access  |   1   | bit0=r, bit1=w, bit2=setDef            |
+//	|  1..4   | value   |   4   | int32 big-endian                       |
+//	|  5..8   | default |   4   | int32 big-endian                       |
+//	|  9..12  | step    |   4   | int32 big-endian                       |
+//	| 13..16  | min     |   4   | int32 big-endian                       |
+//	| 17..20  | max     |   4   | int32 big-endian                       |
+//	| 21..    | label   |  ≤17  | NUL-terminated ASCII                   |
+//	|  ...    | unit    |  ≤5   | NUL-terminated ASCII                   |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Objects by Type" p. 26.
 func encodeLong(e *entry) ([]byte, error) {
 	p := e.param
 	value, err := asInt32(p.Value, "value")
@@ -217,6 +300,23 @@ func encodeLong(e *entry) ([]byte, error) {
 	return buf.bytes(), nil
 }
 
+// encodeByte — inverse of consumer's decodeByte. Byte Object (type=10,
+// 10 props). Same layout as Integer but u8 numerics.
+//
+// Wire layout after the common prefix:
+//
+//	| Byte | Field   | Width | Notes                                     |
+//	|------|---------|-------|-------------------------------------------|
+//	|  0   | access  |   1   | bit0=r, bit1=w, bit2=setDef               |
+//	|  1   | value   |   1   | u8                                        |
+//	|  2   | default |   1   | u8                                        |
+//	|  3   | step    |   1   | u8                                        |
+//	|  4   | min     |   1   | u8                                        |
+//	|  5   | max     |   1   | u8                                        |
+//	|  6.. | label   |  ≤17  | NUL-terminated ASCII                      |
+//	|  ... | unit    |  ≤5   | NUL-terminated ASCII                      |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Objects by Type" p. 27.
 func encodeByte(e *entry) ([]byte, error) {
 	p := e.param
 	value, err := asUint8(p.Value, "value")
@@ -251,6 +351,23 @@ func encodeByte(e *entry) ([]byte, error) {
 	return buf.bytes(), nil
 }
 
+// encodeFloat — inverse of consumer's decodeFloat. Float Object (type=3,
+// 10 props).
+//
+// Wire layout after the common prefix:
+//
+//	| Byte    | Field   | Width | Notes                                  |
+//	|---------|---------|-------|----------------------------------------|
+//	|  0      | access  |   1   | bit0=r, bit1=w, bit2=setDef            |
+//	|  1..4   | value   |   4   | IEEE-754 float32 big-endian            |
+//	|  5..8   | default |   4   | IEEE-754 float32 big-endian            |
+//	|  9..12  | step    |   4   | IEEE-754 float32 big-endian            |
+//	| 13..16  | min     |   4   | IEEE-754 float32 big-endian            |
+//	| 17..20  | max     |   4   | IEEE-754 float32 big-endian            |
+//	| 21..    | label   |  ≤17  | NUL-terminated ASCII                   |
+//	|  ...    | unit    |  ≤5   | NUL-terminated ASCII                   |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Objects by Type" p. 23.
 func encodeFloat(e *entry) ([]byte, error) {
 	p := e.param
 	value, err := asFloat32(p.Value, "value")
@@ -285,6 +402,23 @@ func encodeFloat(e *entry) ([]byte, error) {
 	return buf.bytes(), nil
 }
 
+// encodeIPAddr — inverse of consumer's decodeIPAddr. IPAddr Object
+// (type=2, 10 props). Same layout as Integer but uint32 numerics.
+//
+// Wire layout after the common prefix:
+//
+//	| Byte    | Field   | Width | Notes                                  |
+//	|---------|---------|-------|----------------------------------------|
+//	|  0      | access  |   1   | bit0=r, bit1=w, bit2=setDef            |
+//	|  1..4   | value   |   4   | uint32 big-endian (4 octets a.b.c.d)   |
+//	|  5..8   | default |   4   | uint32 big-endian                      |
+//	|  9..12  | step    |   4   | uint32 big-endian                      |
+//	| 13..16  | min     |   4   | uint32 big-endian                      |
+//	| 17..20  | max     |   4   | uint32 big-endian                      |
+//	| 21..    | label   |  ≤17  | NUL-terminated ASCII                   |
+//	|  ...    | unit    |  ≤5   | NUL-terminated ASCII                   |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Objects by Type" p. 22.
 func encodeIPAddr(e *entry) ([]byte, error) {
 	p := e.param
 	value, err := ipv4ToUint32(p.Value)
@@ -319,6 +453,22 @@ func encodeIPAddr(e *entry) ([]byte, error) {
 	return buf.bytes(), nil
 }
 
+// encodeEnum — inverse of consumer's decodeEnum. Enum Object (type=4,
+// 8 props).
+//
+// Wire layout after the common prefix:
+//
+//	| Byte | Field      | Width | Notes                                     |
+//	|------|------------|-------|-------------------------------------------|
+//	|  0   | access     |   1   | bit0=r, bit1=w, bit2=setDef               |
+//	|  1   | value      |   1   | u8 index into item_list                   |
+//	|  2   | num_items  |   1   | number of items emitted                   |
+//	|  3   | default    |   1   | u8 index                                  |
+//	|  4.. | label      |  ≤17  | NUL-terminated ASCII                      |
+//	|  ... | item_list  |   ?   | comma-delimited NUL-terminated, e.g.      |
+//	|      |            |       | "Off,On,Auto\0"                           |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Objects by Type" p. 23.
 func encodeEnum(e *entry) ([]byte, error) {
 	p := e.param
 	value, err := asUint8(p.Value, "value")
@@ -348,6 +498,19 @@ func encodeEnum(e *entry) ([]byte, error) {
 	return buf.bytes(), nil
 }
 
+// encodeString — inverse of consumer's decodeString. String Object
+// (type=5, 6 props). Order on the wire: Value, then MaxLen, then Label.
+//
+// Wire layout after the common prefix:
+//
+//	| Byte | Field    | Width | Notes                                       |
+//	|------|----------|-------|---------------------------------------------|
+//	|  0   | access   |   1   | bit0=r, bit1=w, bit2=setDef                 |
+//	|  1.. | value    |   ?   | NUL-terminated ASCII, bounded by max_len+\0 |
+//	|  ... | max_len  |   1   | u8; declared buffer size (bytes)            |
+//	|  ... | label    |  ≤17  | NUL-terminated ASCII                        |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Objects by Type" p. 24.
 func encodeString(e *entry) ([]byte, error) {
 	p := e.param
 	value, err := asString(p.Value, "value")
@@ -363,6 +526,21 @@ func encodeString(e *entry) ([]byte, error) {
 	return buf.bytes(), nil
 }
 
+// encodeAlarm — inverse of consumer's decodeAlarm. Alarm Object (type=7,
+// 8 props).
+//
+// Wire layout after the common prefix:
+//
+//	| Byte | Field         | Width | Notes                                |
+//	|------|---------------|-------|--------------------------------------|
+//	|  0   | access        |   1   | bit0=r, bit1=w, bit2=setDef          |
+//	|  1   | priority      |   1   | u8; 0 = alarm disabled               |
+//	|  2   | tag           |   1   | u8; device-assigned identifier       |
+//	|  3.. | label         |  ≤17  | NUL-terminated ASCII (max 16 + \0)   |
+//	|  ... | event_on_msg  |  ≤33  | NUL-terminated ASCII (max 32 + \0)   |
+//	|  ... | event_off_msg |  ≤33  | NUL-terminated ASCII (max 32 + \0)   |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Objects by Type" p. 25.
 func encodeAlarm(e *entry) ([]byte, error) {
 	p := e.param
 	// priority/tag live as inline property fields of a real Axon alarm
@@ -382,6 +560,18 @@ func encodeAlarm(e *entry) ([]byte, error) {
 	return buf.bytes(), nil
 }
 
+// encodeFile — inverse of consumer's decodeFile. File Object (type=8,
+// 5 props). Fragment property is engineer-mode only and NOT emitted.
+//
+// Wire layout after the common prefix:
+//
+//	| Byte   | Field         | Width | Notes                              |
+//	|--------|---------------|-------|------------------------------------|
+//	|  0     | access        |   1   | bit0=r, bit1=w, bit2=setDef        |
+//	|  1..2  | num_fragments |   2   | int16 big-endian                   |
+//	|  3..   | file_name     |  ≤17  | NUL-terminated ASCII (max 16 + \0) |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Objects by Type" p. 26.
 func encodeFile(e *entry) ([]byte, error) {
 	p := e.param
 	// Canonical carries the file name in Value; num_fragments in Default
@@ -402,6 +592,21 @@ func encodeFile(e *entry) ([]byte, error) {
 	return buf.bytes(), nil
 }
 
+// encodeFrame — inverse of consumer's decodeFrame. Frame Status Object
+// (type=6, 4 props, read-only; rack-controller only).
+//
+// Wire layout after the common prefix:
+//
+//	| Byte      | Field         | Width | Notes                           |
+//	|-----------|---------------|-------|---------------------------------|
+//	|  0        | access        |   1   | read-only (bit0 set, 1)         |
+//	|  1        | num_slots     |   1   | u8; number of cards in frame    |
+//	|  2..n+1   | slot_status[] |   n   | one u8 per slot:                |
+//	|           |               |       |  0=no-card, 1=powerup,          |
+//	|           |               |       |  2=present, 3=error,            |
+//	|           |               |       |  4=removed, 5=boot              |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Objects by Type" p. 24.
 func encodeFrame(e *entry) ([]byte, error) {
 	slots, err := frameSlotStatuses(e.param)
 	if err != nil {

--- a/internal/acp1/provider/set.go
+++ b/internal/acp1/provider/set.go
@@ -27,6 +27,29 @@ import (
 // are what getValue would return *after* the change. The ACP1 spec
 // requires the reply to carry the confirmed-stored value, not the
 // requested one.
+//
+// Incoming / outgoing value-bytes layout by method + type:
+//
+//	| Method        | Incoming bytes        | Outgoing (reply/announce)     |
+//	|---------------|-----------------------|-------------------------------|
+//	| setValue      | raw value bytes       | confirmed stored value bytes  |
+//	| setIncValue   | (none)                | post-increment value bytes    |
+//	| setDecValue   | (none)                | post-decrement value bytes    |
+//	| setDefValue   | (none)                | default value bytes           |
+//
+// Per-type width (both incoming and outgoing):
+//
+//	| ACP1 type | Width | Wire layout                                   |
+//	|-----------|-------|-----------------------------------------------|
+//	| Integer   |   2   | int16 big-endian                              |
+//	| Long      |   4   | int32 big-endian                              |
+//	| Byte      |   1   | u8                                            |
+//	| Float     |   4   | IEEE-754 float32 big-endian                   |
+//	| IPAddr    |   4   | uint32 big-endian                             |
+//	| Enum      |   1   | u8 index (setValue + setDefValue only)        |
+//	| String    | len+1 | NUL-terminated bytes (setValue only)          |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Methods" p. 28.
 func (s *server) applyMutation(e *entry, method iacp1.Method, incoming []byte) ([]byte, error) {
 	s.tree.mu.Lock()
 	defer s.tree.mu.Unlock()
@@ -52,6 +75,20 @@ func (s *server) applyMutation(e *entry, method iacp1.Method, incoming []byte) (
 
 // ----------------------------------------------------------------- Integer
 
+// mutateInteger applies one of the four mutating methods to an Integer
+// object (type=1) and returns the post-state value bytes.
+//
+// Incoming / outgoing layout:
+//
+//	| Method        | Incoming bytes | Outgoing (2 bytes)                |
+//	|---------------|----------------|-----------------------------------|
+//	| setValue      | 2 (int16 BE)   | int16 BE clamped to [min,max]     |
+//	| setIncValue   | (none)         | int16 BE of (value + step)        |
+//	| setDecValue   | (none)         | int16 BE of (value - step)        |
+//	| setDefValue   | (none)         | int16 BE of default               |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Methods" p. 28 and
+// §"Objects by Type" p. 22.
 func (s *server) mutateInteger(e *entry, m iacp1.Method, incoming []byte) ([]byte, error) {
 	p := e.param
 	cur, err := asInt16(p.Value, "value")
@@ -87,6 +124,20 @@ func (s *server) mutateInteger(e *entry, m iacp1.Method, incoming []byte) ([]byt
 
 // ----------------------------------------------------------------- Long
 
+// mutateLong applies one of the four mutating methods to a Long object
+// (type=9) and returns the post-state value bytes.
+//
+// Incoming / outgoing layout:
+//
+//	| Method        | Incoming bytes | Outgoing (4 bytes)                |
+//	|---------------|----------------|-----------------------------------|
+//	| setValue      | 4 (int32 BE)   | int32 BE clamped to [min,max]     |
+//	| setIncValue   | (none)         | int32 BE of (value + step)        |
+//	| setDecValue   | (none)         | int32 BE of (value - step)        |
+//	| setDefValue   | (none)         | int32 BE of default               |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Methods" p. 28 and
+// §"Objects by Type" p. 26.
 func (s *server) mutateLong(e *entry, m iacp1.Method, incoming []byte) ([]byte, error) {
 	p := e.param
 	cur, err := asInt32(p.Value, "value")
@@ -122,6 +173,20 @@ func (s *server) mutateLong(e *entry, m iacp1.Method, incoming []byte) ([]byte, 
 
 // ----------------------------------------------------------------- Byte
 
+// mutateByte applies one of the four mutating methods to a Byte object
+// (type=10) and returns the post-state value bytes.
+//
+// Incoming / outgoing layout:
+//
+//	| Method        | Incoming bytes | Outgoing (1 byte)                 |
+//	|---------------|----------------|-----------------------------------|
+//	| setValue      | 1 (u8)         | u8 clamped to [min,max]           |
+//	| setIncValue   | (none)         | u8 of (value + step)              |
+//	| setDecValue   | (none)         | u8 of (value - step)              |
+//	| setDefValue   | (none)         | u8 of default                     |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Methods" p. 28 and
+// §"Objects by Type" p. 27.
 func (s *server) mutateByte(e *entry, m iacp1.Method, incoming []byte) ([]byte, error) {
 	p := e.param
 	cur, err := asUint8(p.Value, "value")
@@ -157,6 +222,20 @@ func (s *server) mutateByte(e *entry, m iacp1.Method, incoming []byte) ([]byte, 
 
 // ----------------------------------------------------------------- Float
 
+// mutateFloat applies one of the four mutating methods to a Float object
+// (type=3) and returns the post-state value bytes.
+//
+// Incoming / outgoing layout:
+//
+//	| Method        | Incoming bytes | Outgoing (4 bytes)                |
+//	|---------------|----------------|-----------------------------------|
+//	| setValue      | 4 (f32 BE)     | f32 BE clamped to [min,max]       |
+//	| setIncValue   | (none)         | f32 BE of (value + step)          |
+//	| setDecValue   | (none)         | f32 BE of (value - step)          |
+//	| setDefValue   | (none)         | f32 BE of default                 |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Methods" p. 28 and
+// §"Objects by Type" p. 23.
 func (s *server) mutateFloat(e *entry, m iacp1.Method, incoming []byte) ([]byte, error) {
 	p := e.param
 	cur, err := asFloat32(p.Value, "value")
@@ -192,6 +271,20 @@ func (s *server) mutateFloat(e *entry, m iacp1.Method, incoming []byte) ([]byte,
 
 // ----------------------------------------------------------------- IPAddr
 
+// mutateIPAddr applies one of the four mutating methods to an IPAddr
+// object (type=2) and returns the post-state value bytes.
+//
+// Incoming / outgoing layout:
+//
+//	| Method        | Incoming bytes | Outgoing (4 bytes)                |
+//	|---------------|----------------|-----------------------------------|
+//	| setValue      | 4 (u32 BE)     | u32 BE clamped to [min,max]       |
+//	| setIncValue   | (none)         | u32 BE of (value + step)          |
+//	| setDecValue   | (none)         | u32 BE of (value - step); floors 0|
+//	| setDefValue   | (none)         | u32 BE of default                 |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Methods" p. 28 and
+// §"Objects by Type" p. 22.
 func (s *server) mutateIPAddr(e *entry, m iacp1.Method, incoming []byte) ([]byte, error) {
 	p := e.param
 	cur, err := ipv4ToUint32(p.Value)
@@ -237,6 +330,19 @@ func (s *server) mutateIPAddr(e *entry, m iacp1.Method, incoming []byte) ([]byte
 
 // ----------------------------------------------------------------- Enum
 
+// mutateEnum applies setValue or setDefValue to an Enum object (type=4)
+// and returns the post-state value bytes. setIncValue / setDecValue are
+// not supported for enums per spec §"Method support matrix".
+//
+// Incoming / outgoing layout:
+//
+//	| Method        | Incoming bytes | Outgoing (1 byte)                 |
+//	|---------------|----------------|-----------------------------------|
+//	| setValue      | 1 (u8 index)   | u8 echo (validated ≤ num_items-1) |
+//	| setDefValue   | (none)         | u8 default (0 if default invalid) |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Methods" p. 28 and
+// §"Objects by Type" p. 23.
 func (s *server) mutateEnum(e *entry, m iacp1.Method, incoming []byte) ([]byte, error) {
 	p := e.param
 	items := enumItems(p)
@@ -273,6 +379,19 @@ func (s *server) mutateEnum(e *entry, m iacp1.Method, incoming []byte) ([]byte, 
 
 // ----------------------------------------------------------------- String
 
+// mutateString applies setValue to a String object (type=5) and returns
+// the post-state value bytes. Only setValue is supported per spec
+// §"Method support matrix".
+//
+// Incoming / outgoing layout:
+//
+//	| Method        | Incoming bytes          | Outgoing                 |
+//	|---------------|-------------------------|--------------------------|
+//	| setValue      | NUL-terminated (len+1)  | NUL-terminated (len+1);  |
+//	|               | truncated to max_len    | confirmed stored string  |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Methods" p. 28 and
+// §"Objects by Type" p. 24.
 func (s *server) mutateString(e *entry, m iacp1.Method, incoming []byte) ([]byte, error) {
 	if m != iacp1.MethodSetValue {
 		return nil, fmt.Errorf("string %q: only setValue supported", e.param.Identifier)
@@ -336,6 +455,21 @@ func uint32ToDottedQuad(v uint32) string {
 //
 // Used by server.SetValue (API-driven writes) to route through the same
 // mutation pipeline as the wire handlers.
+//
+// Per-type outgoing wire layout (setValue bytes):
+//
+//	| ACP1 type | Width  | Wire layout                                  |
+//	|-----------|--------|----------------------------------------------|
+//	| Integer   |   2    | int16 big-endian                             |
+//	| Long      |   4    | int32 big-endian                             |
+//	| Byte      |   1    | u8                                           |
+//	| Float     |   4    | IEEE-754 float32 big-endian                  |
+//	| IPAddr    |   4    | uint32 big-endian (from dotted-quad)         |
+//	| Enum      |   1    | u8 index                                     |
+//	| String    | len+1  | bytes + NUL terminator                       |
+//
+// Spec reference: AXON-ACP_v1_4.pdf §"Methods" p. 28 and
+// §"Objects by Type" pp. 21–27.
 func (s *server) encodeIncomingFromAny(e *entry, val any) ([]byte, error) {
 	switch e.acpType {
 	case iacp1.TypeInteger:


### PR DESCRIPTION
Part 1 of #78 — ACP1 slice. ACP2 and Ember+ follow in separate PRs.

## Summary

Retrofit markdown byte-layout tables on every ACP1 wire-codec function, matching the convention already in place for Probel SW-P-08 (`internal/probel-sw08p/codec/`). **No functional change.**

## Scope

38 functions across 5 files:

| File | Functions |
|---|---:|
| `internal/acp1/consumer/message.go` | 2 |
| `internal/acp1/consumer/property.go` | 12 |
| `internal/acp1/consumer/value_codec.go` | 2 |
| `internal/acp1/provider/encoder.go` | 13 |
| `internal/acp1/provider/set.go` | 9 |

Each table cites `AXON-ACP_v1_4.pdf` section + page so the codec is self-documenting against the spec.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run` — 0 issues
- [x] `go test -count=1 ./internal/acp1/...` green (both consumer + provider)

🤖 Generated with [Claude Code](https://claude.com/claude-code)