### PR TITLE
docs(emberplus/codec): byte-table doc-comments on all wire codecs (part 3 of #78)

### DIFF
--- a/internal/emberplus/codec/ber/length.go
+++ b/internal/emberplus/codec/ber/length.go
@@ -3,6 +3,21 @@ package ber
 // EncodeLength writes a BER length to bytes.
 //   - Short form (0-127): single octet
 //   - Long form (128+): 0x80|n followed by n octets big-endian
+//
+// First length octet layout (X.690 §8.1.3):
+//
+//	| Bit(s) | Field           | Width | Notes                                |
+//	|--------|-----------------|-------|--------------------------------------|
+//	|   7    | form            |   1   | 0=short, 1=long                      |
+//	|  6..0  | length or count |   7   | short: L itself (0..127);            |
+//	|        |                 |       | long: number of following octets (N) |
+//	|  1..N  | length octets   |   N   | long-form big-endian length value    |
+//
+// A single 0x80 first octet signals indefinite-length encoding (the
+// value ends with an EOC 0x00 0x00 sentinel — used by constructed
+// constructions that stream children).
+//
+// Spec reference: ITU-T X.690 §8.1.3 (Length octets).
 func EncodeLength(length int) []byte {
 	if length < 0 {
 		// Indefinite length: 0x80
@@ -29,6 +44,17 @@ func EncodeLength(length int) []byte {
 
 // DecodeLength reads a BER length from buf, returning length and bytes consumed.
 // Returns -1 for indefinite length.
+//
+// Inverse of EncodeLength — dispatches on bit 7 of the first octet:
+//
+//	| First octet | Form              | Result                              |
+//	|-------------|-------------------|-------------------------------------|
+//	| 0x00..0x7F  | short definite    | length = first octet (0..127)       |
+//	| 0x80        | indefinite        | length = -1 (EOC-terminated value)  |
+//	| 0x81..0x84  | long definite (N) | next N octets = big-endian length   |
+//	| >= 0x85     | rejected          | errLengthTooLong (cap at 4 octets)  |
+//
+// Spec reference: ITU-T X.690 §8.1.3 (Length octets).
 func DecodeLength(buf []byte) (int, int, error) {
 	if len(buf) == 0 {
 		return 0, 0, errTruncated

--- a/internal/emberplus/codec/ber/tag.go
+++ b/internal/emberplus/codec/ber/tag.go
@@ -55,6 +55,20 @@ type Tag struct {
 }
 
 // EncodeTag writes a BER tag to bytes.
+//
+// First identifier octet layout (X.690 §8.1.2):
+//
+//	| Bit(s) | Field       | Width | Notes                                   |
+//	|--------|-------------|-------|-----------------------------------------|
+//	|  7..6  | class       |   2   | 00=UNIV, 01=APP, 10=CTX, 11=PRIV        |
+//	|   5    | constructed |   1   | 0=primitive, 1=constructed              |
+//	|  4..0  | tag number  |   5   | short form (0..30); 31 = long-form flag |
+//
+// When the tag number is >= 31 the low 5 bits are set to 0x1F and the
+// real number follows as base-128 octets (MSB first, continuation bit 7
+// set on every octet except the last).
+//
+// Spec reference: ITU-T X.690 §8.1.2 (Identifier octets).
 func EncodeTag(t Tag) []byte {
 	first := byte(t.Class) << 6
 	if t.Constructed {
@@ -73,6 +87,19 @@ func EncodeTag(t Tag) []byte {
 }
 
 // DecodeTag reads a BER tag from buf, returning the tag and bytes consumed.
+//
+// Inverse of EncodeTag — parses the first identifier octet:
+//
+//	| Bit(s) | Field       | Width | Notes                                   |
+//	|--------|-------------|-------|-----------------------------------------|
+//	|  7..6  | class       |   2   | 00=UNIV, 01=APP, 10=CTX, 11=PRIV        |
+//	|   5    | constructed |   1   | 0=primitive, 1=constructed              |
+//	|  4..0  | tag number  |   5   | short form or 0x1F sentinel = long form |
+//
+// When the sentinel is seen, decodeBase128 reads the continuation-bit
+// chain that carries the real tag number.
+//
+// Spec reference: ITU-T X.690 §8.1.2 (Identifier octets).
 func DecodeTag(buf []byte) (Tag, int, error) {
 	if len(buf) == 0 {
 		return Tag{}, 0, errTruncated

--- a/internal/emberplus/codec/ber/tlv.go
+++ b/internal/emberplus/codec/ber/tlv.go
@@ -8,6 +8,18 @@ type TLV struct {
 }
 
 // EncodeTLV encodes a TLV element to bytes.
+//
+// Every BER TLV is the concatenation of three fields:
+//
+//	| Tag | Field   | Encoding                | Notes                      |
+//	|-----|---------|-------------------------|----------------------------|
+//	|  T  | tag     | EncodeTag               | 1+ octets, class+form+num  |
+//	|  L  | length  | EncodeLength            | 1+ octets, short or long   |
+//	|  V  | value   | raw / recursive(TLV...) | primitive: t.Value bytes;  |
+//	|     |         |                         | constructed: concatenated  |
+//	|     |         |                         | EncodeTLV(child) bodies    |
+//
+// Spec reference: ITU-T X.690 §8.1.1 (General rules for BER).
 func EncodeTLV(t TLV) []byte {
 	tag := EncodeTag(t.Tag)
 
@@ -36,6 +48,18 @@ func EncodeTLV(t TLV) []byte {
 
 // DecodeTLV reads one TLV element from buf. Returns the TLV and total
 // bytes consumed (tag + length + value).
+//
+// Layout parsed (inverse of EncodeTLV):
+//
+//	| Tag | Field   | Encoding     | Notes                                |
+//	|-----|---------|--------------|--------------------------------------|
+//	|  T  | tag     | DecodeTag    | identifier octets (1+)               |
+//	|  L  | length  | DecodeLength | length octets (1+); -1 = indefinite  |
+//	|  V  | value   | L bytes      | primitive: raw; constructed: TLVs    |
+//	|     |         |              | until L reached OR EOC 0x00 0x00     |
+//	|     |         |              | sentinel for indefinite length       |
+//
+// Spec reference: ITU-T X.690 §8.1.1 (General rules for BER).
 func DecodeTLV(buf []byte) (TLV, int, error) {
 	if len(buf) == 0 {
 		return TLV{}, 0, errTruncated

--- a/internal/emberplus/codec/ber/value.go
+++ b/internal/emberplus/codec/ber/value.go
@@ -8,6 +8,14 @@ import (
 // --- Encode value types ---
 
 // EncodeBoolean returns BER BOOLEAN value bytes.
+//
+//	| Offset | Field | Width | Notes                                  |
+//	|--------|-------|-------|----------------------------------------|
+//	|   0    | flag  |   1   | 0x00 = FALSE; any non-zero = TRUE      |
+//	|        |       |       | (this encoder emits 0xFF for TRUE as   |
+//	|        |       |       | DER §11.1 mandates)                    |
+//
+// Spec reference: ITU-T X.690 §8.2 (Encoding of a boolean value).
 func EncodeBoolean(v bool) []byte {
 	if v {
 		return []byte{0xFF}
@@ -17,6 +25,18 @@ func EncodeBoolean(v bool) []byte {
 
 // EncodeInteger returns BER INTEGER value bytes (two's complement, big-endian).
 // Uses minimum number of octets.
+//
+//	| Offset | Field    | Width | Notes                                     |
+//	|--------|----------|-------|-------------------------------------------|
+//	|   0    | MSB      |   1   | sign-significant byte; two's-complement   |
+//	|  1..N  | low bytes|  N-1  | big-endian remaining payload              |
+//
+// Shortest form rule (X.690 §8.3.2): the first nine bits must not all be
+// the same — the codec prepends 0x00 for positive values whose top bit
+// would otherwise flip the sign, and prepends 0xFF for negative values
+// whose top bit would be cleared.
+//
+// Spec reference: ITU-T X.690 §8.3 (Encoding of an integer value).
 func EncodeInteger(v int64) []byte {
 	if v == 0 {
 		return []byte{0x00}
@@ -60,6 +80,16 @@ func EncodeInteger(v int64) []byte {
 // Such that  value = (-1)^S * mantissa * 2^exponent.
 //
 // Special values: zero → empty; ±∞ → 0x40 / 0x41; NaN → 0x42.
+//
+//	| Offset | Field        | Width | Notes                                    |
+//	|--------|--------------|-------|------------------------------------------|
+//	|   0    | first octet  |   1   | bit7=1 binary; bit6 sign; 5-4 base;      |
+//	|        |              |       | 3-2 scale; 1-0 exponent length code      |
+//	|   1    | exp-len ext  | 0/1   | only when bits 1-0 = 11 (long form)      |
+//	|  1..E  | exponent     |   E   | two's-complement, big-endian             |
+//	| E+1..N | mantissa     |   M   | unsigned, big-endian, LSB-trimmed        |
+//
+// Spec reference: ITU-T X.690 §8.5 (Encoding of a real value).
 func EncodeReal(v float64) []byte {
 	if v == 0 {
 		return nil
@@ -161,11 +191,23 @@ func encodeUnsignedInt(v uint64) []byte {
 }
 
 // EncodeUTF8String returns BER UTF8String value bytes (raw UTF-8).
+//
+//	| Offset | Field   | Width | Notes                            |
+//	|--------|---------|-------|----------------------------------|
+//	|  0..N  | UTF-8   |   N   | raw UTF-8 code units (no BOM)    |
+//
+// Spec reference: ITU-T X.690 §8.21 / X.680 §41 (RestrictedString).
 func EncodeUTF8String(s string) []byte {
 	return []byte(s)
 }
 
 // EncodeOctetString returns BER OCTET STRING value bytes.
+//
+//	| Offset | Field  | Width | Notes                                    |
+//	|--------|--------|-------|------------------------------------------|
+//	|  0..N  | octets |   N   | raw opaque bytes, copied to new buffer   |
+//
+// Spec reference: ITU-T X.690 §8.7 (Encoding of an octetstring value).
 func EncodeOctetString(b []byte) []byte {
 	out := make([]byte, len(b))
 	copy(out, b)
@@ -175,6 +217,12 @@ func EncodeOctetString(b []byte) []byte {
 // --- Decode value types ---
 
 // DecodeBoolean reads a BER BOOLEAN from value bytes.
+//
+//	| Offset | Field | Width | Notes                                |
+//	|--------|-------|-------|--------------------------------------|
+//	|   0    | flag  |   1   | 0x00 = false, anything else = true   |
+//
+// Spec reference: ITU-T X.690 §8.2 (Encoding of a boolean value).
 func DecodeBoolean(data []byte) (bool, error) {
 	if len(data) != 1 {
 		return false, errTruncated
@@ -183,6 +231,16 @@ func DecodeBoolean(data []byte) (bool, error) {
 }
 
 // DecodeInteger reads a BER INTEGER from value bytes (two's complement).
+//
+//	| Offset | Field    | Width | Notes                                     |
+//	|--------|----------|-------|-------------------------------------------|
+//	|   0    | MSB      |   1   | sign bit in bit 7; drives 64-bit sign-pad |
+//	|  1..N  | low bytes|  N-1  | big-endian remainder                      |
+//
+// Rejects encodings longer than 8 octets (errOverflow); the Glow subset
+// never emits INTEGER wider than int64 in practice.
+//
+// Spec reference: ITU-T X.690 §8.3 (Encoding of an integer value).
 func DecodeInteger(data []byte) (int64, error) {
 	if len(data) == 0 {
 		return 0, errTruncated
@@ -207,6 +265,21 @@ func DecodeInteger(data []byte) (int64, error) {
 // DecodeReal reads an ITU-T X.690 §8.5 BER REAL from value bytes.
 // Supports the binary form (base 2, base 8, base 16) with scale 0 —
 // which covers every REAL shape Glow actually emits.
+//
+// Value-octets layout (binary form, first octet bit 7 = 1):
+//
+//	| Offset | Field        | Width | Notes                                    |
+//	|--------|--------------|-------|------------------------------------------|
+//	|   0    | first octet  |   1   | sign/base/scale/exp-len code             |
+//	|   1    | exp-len ext  | 0/1   | present iff bits 1-0 of first = 11       |
+//	|  1..E  | exponent     |   E   | signed two's-complement, big-endian      |
+//	| E+1..N | mantissa     |   M   | unsigned, big-endian                     |
+//
+// Special first-octet sentinels (§8.5.9): 0x40=+∞, 0x41=-∞, 0x42=NaN,
+// empty = 0. Decimal form (bit 7 = 0) is not emitted by Glow and is
+// rejected here.
+//
+// Spec reference: ITU-T X.690 §8.5 (Encoding of a real value).
 func DecodeReal(data []byte) (float64, error) {
 	if len(data) == 0 {
 		return 0.0, nil
@@ -293,6 +366,12 @@ func DecodeReal(data []byte) (float64, error) {
 }
 
 // DecodeUTF8String reads a BER UTF8String from value bytes.
+//
+//	| Offset | Field | Width | Notes                            |
+//	|--------|-------|-------|----------------------------------|
+//	|  0..N  | UTF-8 |   N   | raw UTF-8 code units (no BOM)    |
+//
+// Spec reference: ITU-T X.690 §8.21 / X.680 §41 (RestrictedString).
 func DecodeUTF8String(data []byte) string {
 	return string(data)
 }

--- a/internal/emberplus/codec/glow/decoder.go
+++ b/internal/emberplus/codec/glow/decoder.go
@@ -18,6 +18,15 @@ import (
 // APPLICATION[6], or InvocationResult APPLICATION[23]. Real-world
 // providers also emit bare RootElementCollection without the [APP 0]
 // wrapper, so we flatten both shapes here.
+//
+//	| Context Tag | Field                   | Type         | Notes             |
+//	|-------------|-------------------------|--------------|-------------------|
+//	| APP[0]      | Root (optional wrapper) | CHOICE       | TagRoot           |
+//	| APP[11]     | RootElementCollection   | SEQUENCE OF  | TagRootElementColl|
+//	| APP[6]      | StreamCollection        | SEQUENCE OF  | StreamEntry       |
+//	| APP[23]     | InvocationResult        | SEQUENCE     | see decodeInv...  |
+//
+// Spec reference: Ember+ Documentation.pdf §Root p. 93.
 func DecodeRoot(data []byte) ([]Element, error) {
 	tlvs, err := ber.DecodeAll(data)
 	if err != nil {
@@ -134,6 +143,15 @@ func decodeElement(tlv ber.TLV) (*Element, error) {
 
 // --- Node / QualifiedNode (spec p.87) ---
 
+// decodeNode parses a relative-form Node APPLICATION[3].
+//
+//	| Context Tag | Field     | Type         | Notes                   |
+//	|-------------|-----------|--------------|-------------------------|
+//	|   [0]       | number    | INTEGER      | NodeNumber              |
+//	|   [1]       | contents  | NodeContents | SET via decodeNodeCont. |
+//	|   [2]       | children  | ElementColl. | nested Elements         |
+//
+// Spec reference: Ember+ Documentation.pdf §Node p. 87.
 func decodeNode(tlv ber.TLV) (*Element, error) {
 	n := &Node{}
 	for _, child := range tlv.Children {
@@ -152,6 +170,15 @@ func decodeNode(tlv ber.TLV) (*Element, error) {
 	return &Element{Node: n}, nil
 }
 
+// decodeQualifiedNode parses a QualifiedNode APPLICATION[10].
+//
+//	| Context Tag | Field     | Type         | Notes                   |
+//	|-------------|-----------|--------------|-------------------------|
+//	|   [0]       | path      | RELATIVE-OID | QNodePath               |
+//	|   [1]       | contents  | NodeContents | SET via decodeNodeCont. |
+//	|   [2]       | children  | ElementColl. | nested Elements         |
+//
+// Spec reference: Ember+ Documentation.pdf §QualifiedNode p. 87.
 func decodeQualifiedNode(tlv ber.TLV) (*Element, error) {
 	n := &Node{}
 	for _, child := range tlv.Children {
@@ -199,6 +226,15 @@ func decodeNodeContents(n *Node, tlv ber.TLV) {
 
 // --- Parameter / QualifiedParameter (spec p.85) ---
 
+// decodeParameter parses a relative-form Parameter APPLICATION[1].
+//
+//	| Context Tag | Field    | Type             | Notes                |
+//	|-------------|----------|------------------|----------------------|
+//	|   [0]       | number   | INTEGER          | ParamNumber          |
+//	|   [1]       | contents | ParameterContents| SET — see below      |
+//	|   [2]       | children | ElementColl.     | nested Elements      |
+//
+// Spec reference: Ember+ Documentation.pdf §Parameter p. 85.
 func decodeParameter(tlv ber.TLV) (*Element, error) {
 	p := &Parameter{}
 	for _, child := range tlv.Children {
@@ -217,6 +253,15 @@ func decodeParameter(tlv ber.TLV) (*Element, error) {
 	return &Element{Parameter: p}, nil
 }
 
+// decodeQualifiedParameter parses a QualifiedParameter APPLICATION[9].
+//
+//	| Context Tag | Field    | Type             | Notes                |
+//	|-------------|----------|------------------|----------------------|
+//	|   [0]       | path     | RELATIVE-OID     | QParamPath           |
+//	|   [1]       | contents | ParameterContents| SET — see below      |
+//	|   [2]       | children | ElementColl.     | nested Elements      |
+//
+// Spec reference: Ember+ Documentation.pdf §QualifiedParameter p. 85.
 func decodeQualifiedParameter(tlv ber.TLV) (*Element, error) {
 	p := &Parameter{}
 	for _, child := range tlv.Children {
@@ -239,6 +284,30 @@ func decodeQualifiedParameter(tlv ber.TLV) (*Element, error) {
 }
 
 // decodeParamContents covers all 18 optional ParameterContents fields.
+//
+//	| Context Tag | Field              | Type          | Notes                |
+//	|-------------|--------------------|---------------|----------------------|
+//	|   [0]       | identifier         | EmberString   | required             |
+//	|   [1]       | description        | EmberString   | optional             |
+//	|   [2]       | value              | Value CHOICE  | int/real/str/bool/oct|
+//	|   [3]       | minimum            | Value CHOICE  | optional             |
+//	|   [4]       | maximum            | Value CHOICE  | optional             |
+//	|   [5]       | access             | INTEGER       | ro/rw/wo             |
+//	|   [6]       | format             | EmberString   | printf-style         |
+//	|   [7]       | enumeration        | EmberString   | \n-separated         |
+//	|   [8]       | factor             | INTEGER       | display scaling      |
+//	|   [9]       | isOnline           | BOOLEAN       |                      |
+//	|   [10]      | formula            | EmberString   | see Formulas.pdf     |
+//	|   [11]      | step               | Value CHOICE  |                      |
+//	|   [12]      | default            | Value CHOICE  |                      |
+//	|   [13]      | type               | ParameterType | 1..7                 |
+//	|   [14]      | streamIdentifier   | INTEGER       |                      |
+//	|   [15]      | enumMap            | StringInt.Coll| APP[8]               |
+//	|   [16]      | streamDescriptor   | StreamDesc.   | APP[12]              |
+//	|   [17]      | schemaIdentifiers  | EmberString   | \n-separated         |
+//	|   [18]      | templateReference  | RELATIVE-OID  |                      |
+//
+// Spec reference: Ember+ Documentation.pdf §ParameterContents p. 85-86.
 func decodeParamContents(p *Parameter, tlv ber.TLV) {
 	for _, child := range unwrapSet(tlv) {
 		if child.Tag.Class != ber.ClassContext {
@@ -289,6 +358,18 @@ func decodeParamContents(p *Parameter, tlv ber.TLV) {
 
 // --- Matrix / QualifiedMatrix (spec p.88) ---
 
+// decodeMatrix parses a relative-form Matrix APPLICATION[13].
+//
+//	| Context Tag | Field       | Type            | Notes                 |
+//	|-------------|-------------|-----------------|-----------------------|
+//	|   [0]       | number      | INTEGER         | MatrixNumber          |
+//	|   [1]       | contents    | MatrixContents  | SET — see below       |
+//	|   [2]       | children    | ElementColl.    | nested Elements       |
+//	|   [3]       | targets     | TargetColl.     | [APP 14] signals      |
+//	|   [4]       | sources     | SourceColl.     | [APP 15] signals      |
+//	|   [5]       | connections | ConnectionColl. | SEQUENCE OF Connection|
+//
+// Spec reference: Ember+ Documentation.pdf §Matrix p. 88.
 func decodeMatrix(tlv ber.TLV) (*Element, error) {
 	m := &Matrix{}
 	for _, child := range tlv.Children {
@@ -313,6 +394,18 @@ func decodeMatrix(tlv ber.TLV) (*Element, error) {
 	return &Element{Matrix: m}, nil
 }
 
+// decodeQualifiedMatrix parses a QualifiedMatrix APPLICATION[17].
+//
+//	| Context Tag | Field       | Type            | Notes                 |
+//	|-------------|-------------|-----------------|-----------------------|
+//	|   [0]       | path        | RELATIVE-OID    | matrix OID            |
+//	|   [1]       | contents    | MatrixContents  | SET                   |
+//	|   [2]       | children    | ElementColl.    | nested Elements       |
+//	|   [3]       | targets     | TargetColl.     |                       |
+//	|   [4]       | sources     | SourceColl.     |                       |
+//	|   [5]       | connections | ConnectionColl. | SEQUENCE OF Connection|
+//
+// Spec reference: Ember+ Documentation.pdf §QualifiedMatrix p. 88.
 func decodeQualifiedMatrix(tlv ber.TLV) (*Element, error) {
 	m := &Matrix{}
 	for _, child := range tlv.Children {
@@ -341,6 +434,24 @@ func decodeQualifiedMatrix(tlv ber.TLV) (*Element, error) {
 }
 
 // decodeMatrixContents covers all 12 MatrixContents CTX fields.
+//
+//	| Context Tag | Field                    | Type         | Notes            |
+//	|-------------|--------------------------|--------------|------------------|
+//	|   [0]       | identifier               | EmberString  |                  |
+//	|   [1]       | description              | EmberString  |                  |
+//	|   [2]       | type                     | MatrixType   | 0=oneToN default |
+//	|   [3]       | addressingMode           | AddressMode  | 0=linear default |
+//	|   [4]       | targetCount              | INTEGER      | required         |
+//	|   [5]       | sourceCount              | INTEGER      | required         |
+//	|   [6]       | maximumTotalConnects     | INTEGER      |                  |
+//	|   [7]       | maximumConnectsPerTarget | INTEGER      |                  |
+//	|   [8]       | parametersLocation       | CHOICE       | RelOID or INTEGER|
+//	|   [9]       | gainParameterNumber      | INTEGER      |                  |
+//	|   [10]      | labels                   | LabelColl.   | [APP 18]         |
+//	|   [11]      | schemaIdentifiers        | EmberString  |                  |
+//	|   [12]      | templateReference        | RELATIVE-OID |                  |
+//
+// Spec reference: Ember+ Documentation.pdf §MatrixContents p. 88.
 func decodeMatrixContents(m *Matrix, tlv ber.TLV) {
 	for _, child := range unwrapSet(tlv) {
 		if child.Tag.Class != ber.ClassContext {
@@ -469,6 +580,17 @@ func decodeSignalCollection(tlv ber.TLV) []int32 {
 
 // --- Connections (spec p.89) ---
 
+// decodeConnectionCollection walks a ConnectionCollection and returns every
+// Connection APPLICATION[16] found inside.
+//
+//	| Context Tag | Field       | Type         | Notes                   |
+//	|-------------|-------------|--------------|-------------------------|
+//	|   [0]       | target      | INTEGER      | target number           |
+//	|   [1]       | sources     | RELATIVE-OID | concatenated source nums|
+//	|   [2]       | operation   | INTEGER      | 0=absolute default      |
+//	|   [3]       | disposition | INTEGER      | 0=tally default         |
+//
+// Spec reference: Ember+ Documentation.pdf §Connection p. 89.
 func decodeConnectionCollection(tlv ber.TLV) []Connection {
 	var out []Connection
 	for _, container := range flattenForApp(tlv, TagConnection) {
@@ -498,6 +620,15 @@ func decodeConnectionCollection(tlv ber.TLV) []Connection {
 
 // --- Function / QualifiedFunction (spec p.91) ---
 
+// decodeFunction parses a relative-form Function APPLICATION[19].
+//
+//	| Context Tag | Field    | Type            | Notes           |
+//	|-------------|----------|-----------------|-----------------|
+//	|   [0]       | number   | INTEGER         | FuncNumber      |
+//	|   [1]       | contents | FunctionContents| SET             |
+//	|   [2]       | children | ElementColl.    | nested Elements |
+//
+// Spec reference: Ember+ Documentation.pdf §Function p. 91.
 func decodeFunction(tlv ber.TLV) (*Element, error) {
 	f := &Function{}
 	for _, child := range tlv.Children {
@@ -516,6 +647,15 @@ func decodeFunction(tlv ber.TLV) (*Element, error) {
 	return &Element{Function: f}, nil
 }
 
+// decodeQualifiedFunction parses a QualifiedFunction APPLICATION[20].
+//
+//	| Context Tag | Field    | Type            | Notes           |
+//	|-------------|----------|-----------------|-----------------|
+//	|   [0]       | path     | RELATIVE-OID    | QFuncPath       |
+//	|   [1]       | contents | FunctionContents| SET             |
+//	|   [2]       | children | ElementColl.    | nested Elements |
+//
+// Spec reference: Ember+ Documentation.pdf §QualifiedFunction p. 91.
 func decodeQualifiedFunction(tlv ber.TLV) (*Element, error) {
 	f := &Function{}
 	for _, child := range tlv.Children {
@@ -537,6 +677,17 @@ func decodeQualifiedFunction(tlv ber.TLV) (*Element, error) {
 	return &Element{Function: f}, nil
 }
 
+// decodeFuncContents fills Function contents fields per spec p.91.
+//
+//	| Context Tag | Field             | Type             | Notes            |
+//	|-------------|-------------------|------------------|------------------|
+//	|   [0]       | identifier        | EmberString      | required         |
+//	|   [1]       | description       | EmberString      | optional         |
+//	|   [2]       | arguments         | TupleDescription | SEQUENCE OF item |
+//	|   [3]       | result            | TupleDescription |                  |
+//	|   [4]       | templateReference | RELATIVE-OID     |                  |
+//
+// Spec reference: Ember+ Documentation.pdf §FunctionContents p. 91.
 func decodeFuncContents(f *Function, tlv ber.TLV) {
 	for _, child := range unwrapSet(tlv) {
 		if child.Tag.Class != ber.ClassContext {
@@ -559,6 +710,16 @@ func decodeFuncContents(f *Function, tlv ber.TLV) {
 
 // --- Command (spec p.86) ---
 
+// decodeCommand parses a Command APPLICATION[2].
+//
+//	| Context Tag | Field        | Type       | Notes                      |
+//	|-------------|--------------|------------|----------------------------|
+//	|   [0]       | number       | INTEGER    | 30 Sub/31 Unsub/32 GetDir  |
+//	|             |              |            | 33 Invoke                  |
+//	|   [1]       | dirFieldMask | INTEGER    | GetDirectory only          |
+//	|   [2]       | invocation   | Invocation | Invoke only (APP[22])      |
+//
+// Spec reference: Ember+ Documentation.pdf §Command p. 86.
 func decodeCommand(tlv ber.TLV) (*Element, error) {
 	c := &Command{}
 	for _, child := range tlv.Children {
@@ -579,6 +740,13 @@ func decodeCommand(tlv ber.TLV) (*Element, error) {
 
 // decodeInvocation handles Invocation APPLICATION[22] (spec p.91). The CTX[2]
 // option slot may wrap the APP tag, or emit fields directly — both accepted.
+//
+//	| Context Tag | Field        | Type         | Notes                 |
+//	|-------------|--------------|--------------|-----------------------|
+//	|   [0]       | invocationId | INTEGER      | echoed in result      |
+//	|   [1]       | arguments    | Tuple        | SEQUENCE OF [0] Value |
+//
+// Spec reference: Ember+ Documentation.pdf §Invocation p. 91.
 func decodeInvocation(tlv ber.TLV) *Invocation {
 	inv := &Invocation{}
 	children := tlv.Children
@@ -604,6 +772,14 @@ func decodeInvocation(tlv ber.TLV) *Invocation {
 
 // decodeInvocationResult handles APPLICATION[23] (spec p.92).
 // success defaults to true when the field is omitted.
+//
+//	| Context Tag | Field        | Type    | Notes                       |
+//	|-------------|--------------|---------|-----------------------------|
+//	|   [0]       | invocationId | INTEGER | echoes Invocation [0]       |
+//	|   [1]       | success      | BOOLEAN | optional, default true      |
+//	|   [2]       | result       | Tuple   | SEQUENCE OF [0] Value       |
+//
+// Spec reference: Ember+ Documentation.pdf §InvocationResult p. 92.
 func decodeInvocationResult(tlv ber.TLV) (*Element, error) {
 	r := &InvocationResult{Success: true}
 	for _, child := range tlv.Children {
@@ -665,6 +841,15 @@ func decodeTupleDescription(tlv ber.TLV) []TupleItem {
 
 // --- StreamEntry / StreamCollection (spec p.93) ---
 
+// decodeStreamCollection walks StreamCollection APPLICATION[6] and returns
+// every StreamEntry APPLICATION[5] found.
+//
+//	| Context Tag | Field            | Type         | Notes              |
+//	|-------------|------------------|--------------|--------------------|
+//	|   [0]       | streamIdentifier | INTEGER      | maps to Parameter  |
+//	|   [1]       | value            | Value CHOICE | current stream val |
+//
+// Spec reference: Ember+ Documentation.pdf §StreamCollection p. 93.
 func decodeStreamCollection(tlv ber.TLV) []StreamEntry {
 	var out []StreamEntry
 	for _, container := range flattenForApp(tlv, TagStreamEntry) {
@@ -719,6 +904,16 @@ func decodeStreamDescription(tlv ber.TLV) *StreamDescription {
 
 // --- Template / QualifiedTemplate (spec p.84) ---
 
+// decodeTemplate parses Template APPLICATION[24] (relative) or
+// QualifiedTemplate APPLICATION[25] (absolute) per the qualified flag.
+//
+//	| Context Tag | Field       | Type             | Notes                 |
+//	|-------------|-------------|------------------|-----------------------|
+//	|   [0]       | number/path | INTEGER / RelOID | chosen by qualified   |
+//	|   [1]       | element     | CHOICE           | Param/Node/Matrix/Func|
+//	|   [2]       | description | EmberString      | optional              |
+//
+// Spec reference: Ember+ Documentation.pdf §Template p. 84.
 func decodeTemplate(tlv ber.TLV, qualified bool) (*Element, error) {
 	t := &Template{Qualified: qualified}
 	for _, child := range tlv.Children {

--- a/internal/emberplus/codec/glow/encoder.go
+++ b/internal/emberplus/codec/glow/encoder.go
@@ -31,6 +31,16 @@ func wrapRoot(child ber.TLV) ber.TLV {
 // Sparse(-2, Glow 2.50+). All is the most common consumer choice — it
 // asks the provider to return every property. Older providers
 // (TinyEmber+ DTD 2.31) ignore the field; strict providers require it.
+//
+// Wire shape (inside the Root + RootElementCollection + CTX[0] wrapper):
+//
+//	| Context Tag | Field        | Type      | Notes                        |
+//	|-------------|--------------|-----------|------------------------------|
+//	| APP[2]      | Command      | SEQUENCE  | glow.TagCommand              |
+//	|  ├─ [0]     | number       | INTEGER   | 32 = GetDirectory            |
+//	|  └─ [1]     | dirFieldMask | INTEGER   | -1 = DirFieldMaskAll         |
+//
+// Spec reference: Ember+ Documentation.pdf §Command p. 86.
 func EncodeGetDirectory() []byte {
 	cmd := ber.AppConstructed(TagCommand,
 		ber.ContextConstructed(CmdCtxNumber, ber.Integer(CmdGetDirectory)),
@@ -42,6 +52,16 @@ func EncodeGetDirectory() []byte {
 // EncodeGetDirectoryFor builds a GetDirectory for a specific node path.
 // Pattern: QualifiedNode(path) → children → ElementCollection → Context(0) → Command(32)
 // dirFieldMask=All (-1) per spec p.31.
+//
+//	| Context Tag | Field             | Type         | Notes                |
+//	|-------------|-------------------|--------------|----------------------|
+//	| APP[10]     | QualifiedNode     | SEQUENCE     | glow.TagQualifiedNode|
+//	|  ├─ [0]     | path              | RELATIVE-OID | target node OID      |
+//	|  └─ [2]     | children          | ElementColl. | wrapped Command(32)  |
+//	|      └─[0]  | child             | CTX wrapper  | nests the Command    |
+//	|       APP[2]| Command           | SEQUENCE     | as in GetDirectory   |
+//
+// Spec reference: Ember+ Documentation.pdf §QualifiedNode p. 87, Command p. 86.
 func EncodeGetDirectoryFor(path []int32) []byte {
 	cmd := ber.AppConstructed(TagCommand,
 		ber.ContextConstructed(CmdCtxNumber, ber.Integer(CmdGetDirectory)),
@@ -62,6 +82,15 @@ func EncodeGetDirectoryFor(path []int32) []byte {
 
 // EncodeSetValue builds a set-value for a parameter.
 // Pattern: QualifiedParameter(path) → contents(SET(value))
+//
+//	| Context Tag | Field       | Type         | Notes                       |
+//	|-------------|-------------|--------------|-----------------------------|
+//	| APP[9]      | QualParam   | SEQUENCE     | glow.TagQualifiedParameter  |
+//	|  ├─ [0]     | path        | RELATIVE-OID | parameter OID               |
+//	|  └─ [1]     | contents    | SET          | wraps [2] value             |
+//	|      └─[2]  | value       | Value CHOICE | int/real/str/bool/octets    |
+//
+// Spec reference: Ember+ Documentation.pdf §QualifiedParameter p. 85.
 func EncodeSetValue(path []int32, value interface{}) []byte {
 	valTLV := encodeAnyValue(value)
 	param := ber.AppConstructed(TagQualifiedParameter,
@@ -75,6 +104,16 @@ func EncodeSetValue(path []int32, value interface{}) []byte {
 
 // EncodeSubscribe builds a Subscribe command for a parameter path.
 // Pattern: QualifiedParameter(path) → children → ElementCollection → Context(0) → Command(30)
+//
+//	| Context Tag | Field      | Type         | Notes                       |
+//	|-------------|------------|--------------|-----------------------------|
+//	| APP[9]      | QualParam  | SEQUENCE     | glow.TagQualifiedParameter  |
+//	|  ├─ [0]     | path       | RELATIVE-OID | parameter OID               |
+//	|  └─ [2]     | children   | ElementColl. | wraps the Command           |
+//	|      └─[0]  | child      | CTX wrapper  | nests the Command           |
+//	|       APP[2]| Command    | SEQUENCE     | number [0] = 30 Subscribe   |
+//
+// Spec reference: Ember+ Documentation.pdf §Command Subscribe p. 86.
 func EncodeSubscribe(path []int32) []byte {
 	cmd := ber.AppConstructed(TagCommand,
 		ber.ContextConstructed(CmdCtxNumber, ber.Integer(CmdSubscribe)),
@@ -91,6 +130,17 @@ func EncodeSubscribe(path []int32) []byte {
 }
 
 // EncodeUnsubscribe builds an Unsubscribe command for a parameter path.
+//
+// Same layout as EncodeSubscribe with Command.number [0] = 31 Unsubscribe:
+//
+//	| Context Tag | Field      | Type         | Notes                      |
+//	|-------------|------------|--------------|----------------------------|
+//	| APP[9]      | QualParam  | SEQUENCE     | glow.TagQualifiedParameter |
+//	|  ├─ [0]     | path       | RELATIVE-OID | parameter OID              |
+//	|  └─ [2]     | children   | ElementColl. | wraps the Command          |
+//	|       APP[2]| Command    | SEQUENCE     | number [0] = 31 Unsubscribe|
+//
+// Spec reference: Ember+ Documentation.pdf §Command Unsubscribe p. 86.
 func EncodeUnsubscribe(path []int32) []byte {
 	cmd := ber.AppConstructed(TagCommand,
 		ber.ContextConstructed(CmdCtxNumber, ber.Integer(CmdUnsubscribe)),
@@ -111,6 +161,19 @@ func EncodeUnsubscribe(path []int32) []byte {
 // EncodeMatrixConnect builds a matrix connection command.
 // Pattern: QualifiedMatrix(path) → connections(SEQUENCE(Context(0)(Connection)))
 // Spec p42: Connection inside ConnectionCollection.
+//
+//	| Context Tag | Field        | Type         | Notes                        |
+//	|-------------|--------------|--------------|------------------------------|
+//	| APP[17]     | QualMatrix   | SEQUENCE     | glow.TagQualifiedMatrix      |
+//	|  ├─ [0]     | path         | RELATIVE-OID | matrix OID                   |
+//	|  └─ [5]     | connections  | SEQUENCE OF  | ConnectionCollection         |
+//	|      └─[0]  | item         | CTX wrapper  | per-connection               |
+//	|       APP[16]| Connection  | SEQUENCE     | glow.TagConnection           |
+//	|        ├─[0]| target       | INTEGER      | target number                |
+//	|        ├─[1]| sources      | RELATIVE-OID | concatenated source numbers  |
+//	|        └─[2]| operation    | INTEGER      | 0=absolute, 1=connect, 2=disc|
+//
+// Spec reference: Ember+ Documentation.pdf §Matrix Connection p. 89, §Connection p. 42.
 func EncodeMatrixConnect(matrixPath []int32, target int32, sources []int32, operation int64) []byte {
 	conn := ber.AppConstructed(TagConnection,
 		ber.ContextConstructed(ConnTarget, ber.Integer(int64(target))),
@@ -131,6 +194,15 @@ func EncodeMatrixConnect(matrixPath []int32, target int32, sources []int32, oper
 // EncodeMatrixGetDirectory builds a GetDirectory on a matrix to fetch connections.
 // Spec p42: "As soon as a consumer issues a GetDirectory on a matrix, it implicitly
 // subscribes to matrix connection changes."
+//
+//	| Context Tag | Field      | Type         | Notes                       |
+//	|-------------|------------|--------------|-----------------------------|
+//	| APP[17]     | QualMatrix | SEQUENCE     | glow.TagQualifiedMatrix     |
+//	|  ├─ [0]     | path       | RELATIVE-OID | matrix OID                  |
+//	|  └─ [2]     | children   | ElementColl. | wraps the Command           |
+//	|       APP[2]| Command    | SEQUENCE     | number [0] = 32 GetDirectory|
+//
+// Spec reference: Ember+ Documentation.pdf §Matrix GetDirectory p. 42.
 func EncodeMatrixGetDirectory(matrixPath []int32) []byte {
 	cmd := ber.AppConstructed(TagCommand,
 		ber.ContextConstructed(CmdCtxNumber, ber.Integer(CmdGetDirectory)),
@@ -151,6 +223,19 @@ func EncodeMatrixGetDirectory(matrixPath []int32) []byte {
 // EncodeInvoke builds a function invocation message.
 // Pattern: QualifiedFunction(path) → children → ElementCollection → Context(0) → Command(33) → Invocation
 // Spec p50: Command(33) contains Invocation at Context(2).
+//
+//	| Context Tag | Field         | Type         | Notes                      |
+//	|-------------|---------------|--------------|----------------------------|
+//	| APP[20]     | QualFunction  | SEQUENCE     | glow.TagQualifiedFunction  |
+//	|  ├─ [0]     | path          | RELATIVE-OID | function OID               |
+//	|  └─ [2]     | children      | ElementColl. | wraps the Command          |
+//	|       APP[2]| Command       | SEQUENCE     |                            |
+//	|        ├─[0]| number        | INTEGER      | 33 = Invoke                |
+//	|        └─[2]| invocation    | Invocation   | APP[22]                    |
+//	|         ├─[0]|invocationId  | INTEGER      | echoed in result           |
+//	|         └─[1]|arguments     | SEQUENCE OF  | each arg wrapped in CTX[0] |
+//
+// Spec reference: Ember+ Documentation.pdf §Function Invoke p. 50, §Invocation p. 91.
 func EncodeInvoke(funcPath []int32, invocationID int32, args []interface{}) []byte {
 	// Each argument wrapped in Context(0) per Dufour ContentParameter.Encode(0, writer).
 	var argTLVs []ber.TLV

--- a/internal/emberplus/codec/matrix/state.go
+++ b/internal/emberplus/codec/matrix/state.go
@@ -66,6 +66,19 @@ type State struct {
 
 // NewStateFromGlow builds a fresh State from a decoded Glow Matrix. Call
 // once per walk; replace wholesale when MatrixContents changes.
+//
+// Fields mirrored from the decoded glow.Matrix Context-tagged SET:
+//
+//	| Context Tag | Field                    | Type         | Notes         |
+//	|-------------|--------------------------|--------------|---------------|
+//	|   [2]       | type                     | MatrixType   | 1-to-N / N-N  |
+//	|   [3]       | addressingMode           | AddressMode  | linear default|
+//	|   [4]       | targetCount              | INTEGER      |               |
+//	|   [5]       | sourceCount              | INTEGER      |               |
+//	|   [6]       | maximumTotalConnects     | INTEGER      | nToN cap      |
+//	|   [7]       | maximumConnectsPerTarget | INTEGER      | nToN cap      |
+//
+// Spec reference: Ember+ Documentation.pdf §MatrixContents pp. 88-89.
 func NewStateFromGlow(m *glow.Matrix) *State {
 	s := &State{
 		Type:                 m.MatrixType,
@@ -92,6 +105,17 @@ func NewStateFromGlow(m *glow.Matrix) *State {
 // ApplyConnection merges an incoming announcement into the state. source
 // == ChangeAnnounce updates the tally; anything else records the request
 // as sent. Respects ConnectionOperation semantics (spec p.89).
+//
+// Fields consumed from the decoded glow.Connection (APPLICATION[16]):
+//
+//	| Context Tag | Field       | Type         | Semantics                 |
+//	|-------------|-------------|--------------|---------------------------|
+//	|   [0]       | target      | INTEGER      | target number             |
+//	|   [1]       | sources     | RELATIVE-OID | source-number list        |
+//	|   [2]       | operation   | INTEGER      | 0=absolute/1=conn/2=disc. |
+//	|   [3]       | disposition | INTEGER      | 0=tally/1=mod/2=pend/3=lck|
+//
+// Spec reference: Ember+ Documentation.pdf §Connection p. 89.
 func (s *State) ApplyConnection(c glow.Connection, source ChangeSource) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/emberplus/codec/s101/frame.go
+++ b/internal/emberplus/codec/s101/frame.go
@@ -63,6 +63,31 @@ type Frame struct {
 }
 
 // Encode builds an S101 wire frame: BOF + header + escaped payload + CRC + EOF.
+//
+// Wire layout (EmBER frame before BOF/escape/CRC/EOF wrapping):
+//
+//	| Offset | Field           | Width | Notes                                   |
+//	|--------|-----------------|-------|-----------------------------------------|
+//	|   0    | BOF             |   1   | 0xFE start-of-frame (wrapper, post-esc) |
+//	|   1    | slot            |   1   | always 0x00                             |
+//	|   2    | message type    |   1   | 0x0E MsgEmBER                           |
+//	|   3    | command         |   1   | 0x00 EmBER / 0x01 KA req / 0x02 KA resp |
+//	|   4    | version         |   1   | 0x01 S101 version                       |
+//	|   5    | flags           |   1   | 0xC0 Single / 0x80 First / 0x40 Last    |
+//	|   6    | DTD             |   1   | 0x01 Glow                               |
+//	|   7    | appBytesLen     |   1   | 0x02 (length of following DTD version)  |
+//	|   8    | DTD minor ver   |   1   | 0x1F (=31)                              |
+//	|   9    | DTD major ver   |   1   | 0x02 (=2)                               |
+//	|  10..  | BER payload     |   N   | Glow TLV tree                           |
+//	|  N+10  | CRC-CCITT16     |   2   | little-endian, over unescaped content   |
+//	|  N+12  | EOF             |   1   | 0xFF end-of-frame (wrapper, post-esc)   |
+//
+// Keep-alive frames compress to a 4-byte content [slot, msgType=0x0E, cmd,
+// version] plus CRC; no flags/DTD/payload. After header assembly the whole
+// unescaped buffer is byte-escaped (0xFD prefix, XOR 0x20) for any byte
+// >= 0xF8, then wrapped with BOF/EOF markers.
+//
+// Spec reference: Ember+ Documentation.pdf §S101 Framing p. 94.
 func Encode(f *Frame) []byte {
 	var raw []byte
 
@@ -106,6 +131,24 @@ func Encode(f *Frame) []byte {
 }
 
 // Decode parses an S101 frame from wire bytes (including BOF/EOF).
+//
+// Inverse of Encode — strips BOF/EOF, unescapes 0xFD sequences, verifies the
+// little-endian CRC-CCITT16 trailer, then reads the header fields:
+//
+//	| Offset | Field         | Width | Notes                               |
+//	|--------|---------------|-------|-------------------------------------|
+//	|   0    | slot          |   1   | 0x00                                |
+//	|   1    | message type  |   1   | 0x0E (MsgEmBER)                     |
+//	|   2    | command       |   1   | 0x00 EmBER / 0x01 KA req / 0x02 resp|
+//	|   3    | version       |   1   | 0x01                                |
+//	|   4    | flags         |   1   | only on EmBER frames                |
+//	|   5    | DTD           |   1   | 0x01 Glow                           |
+//	|   6    | appBytesLen   |   1   | 0x02                                |
+//	|   7    | DTD minor ver |   1   | 31                                  |
+//	|   8    | DTD major ver |   1   | 2                                   |
+//	|   9..  | payload       |   N   | BER Glow TLVs                       |
+//
+// Spec reference: Ember+ Documentation.pdf §S101 Framing p. 94.
 func Decode(data []byte) (*Frame, error) {
 	if len(data) < 2 || data[0] != BOF || data[len(data)-1] != EOF {
 		return nil, ErrBadFrame

--- a/internal/emberplus/codec/s101/reader.go
+++ b/internal/emberplus/codec/s101/reader.go
@@ -27,6 +27,19 @@ func (r *Reader) SetTap(fn func([]byte)) {
 
 // ReadFrame reads the next complete S101 frame from the stream.
 // Blocks until a complete BOF...EOF sequence is received.
+//
+// Framing scan (byte-by-byte, pre-decode):
+//
+//	| Offset | Field      | Width | Notes                                    |
+//	|--------|------------|-------|------------------------------------------|
+//	|   0    | BOF        |   1   | 0xFE; bytes before this are discarded    |
+//	|  1..N  | content    |   N   | escaped inner bytes (0xFD XOR-0x20)      |
+//	|  N+1   | EOF        |   1   | 0xFF; terminates the frame               |
+//
+// The collected buffer (BOF..EOF inclusive) is handed to the optional tap
+// and then to Decode for unescape/CRC-check/header-parse.
+//
+// Spec reference: Ember+ Documentation.pdf §S101 Framing p. 94.
 func (r *Reader) ReadFrame() (*Frame, error) {
 	// Scan for BOF.
 	for {

--- a/internal/emberplus/codec/s101/writer.go
+++ b/internal/emberplus/codec/s101/writer.go
@@ -25,6 +25,17 @@ func (w *Writer) SetTap(fn func([]byte)) {
 }
 
 // WriteFrame encodes and writes an S101 frame to the stream.
+//
+// Produces the wire shape of frame.Encode:
+//
+//	| Offset | Field       | Width | Notes                                  |
+//	|--------|-------------|-------|----------------------------------------|
+//	|   0    | BOF         |   1   | 0xFE                                   |
+//	|   1..  | header+data |   N   | slot+msgType+cmd+ver (+flags+DTD+body) |
+//	|  N+1   | CRC16       |   2   | little-endian CCITT                    |
+//	|  N+3   | EOF         |   1   | 0xFF                                   |
+//
+// Spec reference: Ember+ Documentation.pdf §S101 Framing p. 94.
 func (w *Writer) WriteFrame(f *Frame) error {
 	data := Encode(f)
 	if w.tap != nil {

--- a/internal/emberplus/provider/encoder.go
+++ b/internal/emberplus/provider/encoder.go
@@ -24,6 +24,17 @@ import (
 //
 // isRoot and isOnline are intentionally omitted: TinyEmber+ does not
 // emit them, and EmberViewer treats extra content as schema deviation.
+//
+// Envelope the reply always emits:
+//
+//	| Context Tag | Field                 | Type         | Notes          |
+//	|-------------|-----------------------|--------------|----------------|
+//	| APP[0]      | Root                  | CHOICE       | TagRoot        |
+//	|  └ APP[11]  | RootElementCollection | SEQUENCE OF  | one per child  |
+//	|     └─[0]   | child wrapper         | CTX wrapper  | per-element    |
+//	|       APP[X]| QualifiedX            | SEQUENCE     | X=9/10/17/20   |
+//
+// Spec reference: Ember+ Documentation.pdf §Root + RootElementCollection p. 93.
 func (s *server) encodeGetDirReply(e *entry, bareRoot bool) ([]byte, error) {
 	hdr := e.el.Common()
 
@@ -55,6 +66,20 @@ func (s *server) encodeGetDirReply(e *entry, bareRoot bool) ([]byte, error) {
 // encodeElementMinimal emits a qualified element with just the identifier
 // (and description if present) — the shape TinyEmber+ uses for the
 // initial root reply.
+//
+// Always-present slots (within the chosen APP tag):
+//
+//	| Context Tag | Field       | Type         | Notes                      |
+//	|-------------|-------------|--------------|----------------------------|
+//	|   [0]       | path        | RELATIVE-OID | absolute OID               |
+//	|   [1]       | contents    | SET          | identifier + description   |
+//	|     └─[0]   | identifier  | EmberString  | always present             |
+//	|     └─[1]   | description | EmberString  | when non-empty             |
+//
+// APP tag chosen by element kind: Parameter=9, Matrix=17, Function=20,
+// Node=10 (default).
+//
+// Spec reference: Ember+ Documentation.pdf §QualifiedX contents pp. 85-91.
 func (s *server) encodeElementMinimal(e *entry) ber.TLV {
 	hdr := e.el.Common()
 	var setChildren []ber.TLV
@@ -111,6 +136,17 @@ func (s *server) encodeQualifiedElement(e *entry) (ber.TLV, error) {
 	}
 }
 
+// encodeQualifiedNode emits a QualifiedNode APPLICATION[10] with only the
+// fields TinyEmber+ tolerates on per-child walk replies.
+//
+//	| Context Tag | Field       | Type         | Notes                  |
+//	|-------------|-------------|--------------|------------------------|
+//	|   [0]       | path        | RELATIVE-OID | absolute OID           |
+//	|   [1]       | contents    | NodeContents | SET of identifier +... |
+//	|     └─[0]   | identifier  | EmberString  |                        |
+//	|     └─[1]   | description | EmberString  | optional               |
+//
+// Spec reference: Ember+ Documentation.pdf §QualifiedNode p. 87.
 func (s *server) encodeQualifiedNode(e *entry, n *canonical.Node) ber.TLV {
 	// Minimal NodeContents — identifier + optional description. Matches
 	// TinyEmber+'s shape; strict viewers reject isRoot/isOnline padding
@@ -128,6 +164,30 @@ func (s *server) encodeQualifiedNode(e *entry, n *canonical.Node) ber.TLV {
 	)
 }
 
+// encodeQualifiedParameter emits a QualifiedParameter APPLICATION[9] with
+// every defined ParameterContents field in ascending CTX-tag order (DER).
+//
+//	| Context Tag | Field             | Type         | Notes              |
+//	|-------------|-------------------|--------------|--------------------|
+//	|   [0]       | path              | RELATIVE-OID | absolute OID       |
+//	|   [1]       | contents          | SET          | fields in order:   |
+//	|     ├─[0]   | identifier        | EmberString  |                    |
+//	|     ├─[1]   | description       | EmberString  | optional           |
+//	|     ├─[2]   | value             | Value CHOICE | optional           |
+//	|     ├─[3]   | minimum           | Value CHOICE | optional           |
+//	|     ├─[4]   | maximum           | Value CHOICE | optional           |
+//	|     ├─[5]   | access            | INTEGER      |                    |
+//	|     ├─[6]   | format            | EmberString  | printf-style       |
+//	|     ├─[7]   | enumeration       | EmberString  | \n-separated       |
+//	|     ├─[8]   | factor            | INTEGER      | skipped if 0 or 1  |
+//	|     ├─[10]  | formula           | EmberString  | see Formulas.pdf   |
+//	|     ├─[11]  | step              | Value CHOICE | optional           |
+//	|     ├─[12]  | default           | Value CHOICE | optional           |
+//	|     ├─[13]  | type              | ParameterType| 1..7 if mapped     |
+//	|     ├─[14]  | streamIdentifier  | INTEGER      | optional           |
+//	|     └─[15]  | enumMap           | StringIntColl| APP[8]             |
+//
+// Spec reference: Ember+ Documentation.pdf §ParameterContents p. 85.
 func (s *server) encodeQualifiedParameter(e *entry, p *canonical.Parameter) ber.TLV {
 	// ParameterContents SET — fields in ASCENDING context tag order
 	// (DER requirement + EmberViewer enforces it). Spec p.85:
@@ -227,6 +287,17 @@ func encodeEnumMap(entries []canonical.EnumEntry) ber.TLV {
 // encodeParamAnnouncement produces a value-change announcement — same
 // shape as a walk reply for a single QualifiedParameter, so consumers
 // with a subscribe-only path treat it as an update.
+//
+// Envelope layout:
+//
+//	| Context Tag | Field              | Type           | Notes         |
+//	|-------------|--------------------|----------------|---------------|
+//	| APP[0]      | Root               | CHOICE         | TagRoot       |
+//	|  └ APP[11]  | RootElementColl    | SEQUENCE OF    | one child     |
+//	|     └─[0]   | child wrapper      | CTX wrapper    | single        |
+//	|       APP[9]| QualifiedParameter | SEQUENCE       | full contents |
+//
+// Spec reference: Ember+ Documentation.pdf §Root + RootElementCollection p. 93.
 func (s *server) encodeParamAnnouncement(e *entry, p *canonical.Parameter) []byte {
 	qp := s.encodeQualifiedParameter(e, p)
 	root := ber.AppConstructed(glow.TagRoot,

--- a/internal/emberplus/provider/function.go
+++ b/internal/emberplus/provider/function.go
@@ -38,6 +38,16 @@ func (s *server) encodeQualifiedFunction(e *entry, f *canonical.Function) ber.TL
 
 // encodeTupleDescription emits a SEQUENCE OF [0] TupleItemDescription
 // (spec p.91). Each item is [APP 21] SEQUENCE { [0] type, [1] name }.
+//
+//	| Context Tag | Field | Type        | Notes                             |
+//	|-------------|-------|-------------|-----------------------------------|
+//	|   SEQUENCE  | list  | SEQUENCE OF | one wrapper per item              |
+//	|     └─[0]   | item  | CTX wrapper |                                   |
+//	|      APP[21]| Tuple | SEQUENCE    | TagTupleItemDescription           |
+//	|       ├─[0] | type  | ParameterType| INTEGER 1..7                     |
+//	|       └─[1] | name  | EmberString | optional                          |
+//
+// Spec reference: Ember+ Documentation.pdf §TupleItemDescription p. 91.
 func encodeTupleDescription(items []canonical.TupleItem) ber.TLV {
 	out := make([]ber.TLV, 0, len(items))
 	for _, t := range items {
@@ -94,6 +104,13 @@ func (s *server) encodeInvocationResult(invID int32, success bool, result []any)
 // (SEQUENCE OF [0] Value). Each value uses its Go type to pick the BER
 // primitive — int/int64 → INTEGER, float → REAL, string → UTF8,
 // bool → BOOLEAN, []byte → OCTET STRING, nil → NULL.
+//
+//	| Context Tag | Field | Type         | Notes                          |
+//	|-------------|-------|--------------|--------------------------------|
+//	|   SEQUENCE  | tuple | SEQUENCE OF  | per spec `Tuple ::= SEQ OF [0]`|
+//	|     └─[0]   | value | Value CHOICE | UNIVERSAL primitive per type   |
+//
+// Spec reference: Ember+ Documentation.pdf §Tuple p. 92.
 func encodeTupleValues(values []any) ber.TLV {
 	items := make([]ber.TLV, 0, len(values))
 	for _, v := range values {

--- a/internal/emberplus/provider/matrix.go
+++ b/internal/emberplus/provider/matrix.go
@@ -49,6 +49,22 @@ func (s *server) encodeQualifiedMatrix(e *entry, m *canonical.Matrix) (ber.TLV, 
 // encodeMatrixContents builds the [UNIVERSAL SET] inside [CTX 1] contents.
 // Field order is ascending CTX tag; optional fields absent when the
 // canonical value is zero / nil / default (type=oneToN, mode=linear).
+//
+//	| Context Tag | Field                    | Type         | Notes         |
+//	|-------------|--------------------------|--------------|---------------|
+//	|   [0]       | identifier               | EmberString  | required      |
+//	|   [1]       | description              | EmberString  | optional      |
+//	|   [2]       | type                     | MatrixType   | skip if oneToN|
+//	|   [3]       | addressingMode           | AddressMode  | skip if linear|
+//	|   [4]       | targetCount              | INTEGER      | required      |
+//	|   [5]       | sourceCount              | INTEGER      | required      |
+//	|   [6]       | maximumTotalConnects     | INTEGER      | optional      |
+//	|   [7]       | maximumConnectsPerTarget | INTEGER      | optional      |
+//	|   [8]       | parametersLocation       | RELATIVE-OID | optional      |
+//	|   [9]       | gainParameterNumber      | INTEGER      | optional      |
+//	|   [10]      | labels                   | SEQUENCE OF  | Label APP[18] |
+//
+// Spec reference: Ember+ Documentation.pdf §MatrixContents p. 88.
 func encodeMatrixContents(m *canonical.Matrix) (ber.TLV, error) {
 	var kids []ber.TLV
 	kids = append(kids,
@@ -105,6 +121,13 @@ func encodeMatrixContents(m *canonical.Matrix) (ber.TLV, error) {
 }
 
 // encodeLabel emits one [APPLICATION 18] Label. Both fields are CTX-wrapped.
+//
+//	| Context Tag | Field       | Type         | Notes                |
+//	|-------------|-------------|--------------|----------------------|
+//	|   [0]       | basePath    | RELATIVE-OID | path of label param  |
+//	|   [1]       | description | EmberString  | optional             |
+//
+// Spec reference: Ember+ Documentation.pdf §Label p. 89.
 func encodeLabel(l canonical.MatrixLabel) (ber.TLV, error) {
 	parts, err := parseOID(l.BasePath)
 	if err != nil {
@@ -123,6 +146,15 @@ func encodeLabel(l canonical.MatrixLabel) (ber.TLV, error) {
 // encodeTargets / encodeSources emit a TargetCollection / SourceCollection
 // ([UNIVERSAL SEQUENCE] holding [CTX 0] { [APP 14|15] Signal }). Each
 // signal carries just its number.
+//
+//	| Context Tag | Field      | Type        | Notes                         |
+//	|-------------|------------|-------------|-------------------------------|
+//	|   SEQUENCE  | collection | SEQUENCE OF | per-signal items              |
+//	|     └─[0]   | item       | CTX wrapper | per the spec grammar          |
+//	|      APP[14]| Target     | SEQUENCE    | APP[15] for Source            |
+//	|       └─[0] | number     | INTEGER     | SignalNumber                  |
+//
+// Spec reference: Ember+ Documentation.pdf §Target/Source p. 89.
 func encodeTargets(targets []canonical.MatrixTarget) ber.TLV {
 	items := make([]ber.TLV, 0, len(targets))
 	for _, t := range targets {
@@ -146,6 +178,14 @@ func encodeSources(sources []canonical.MatrixSource) ber.TLV {
 // encodeConnections emits a ConnectionCollection inside [CTX 5] of the
 // QualifiedMatrix wrapper. Each Connection is CTX[0]-wrapped per the spec
 // grammar `SEQUENCE OF [0] Connection`.
+//
+//	| Context Tag | Field       | Type        | Notes                        |
+//	|-------------|-------------|-------------|------------------------------|
+//	|   SEQUENCE  | collection  | SEQUENCE OF | per spec grammar             |
+//	|     └─[0]   | item        | CTX wrapper | one per Connection           |
+//	|      APP[16]| Connection  | SEQUENCE    | see encodeConnection         |
+//
+// Spec reference: Ember+ Documentation.pdf §ConnectionCollection p. 89.
 func encodeConnections(conns []canonical.MatrixConnection) ber.TLV {
 	items := make([]ber.TLV, 0, len(conns))
 	for _, c := range conns {
@@ -163,6 +203,15 @@ func encodeConnections(conns []canonical.MatrixConnection) ber.TLV {
 // rather than "disconnected"; the last-crosspoint-disconnect click
 // leaves the cell lit unless the provider sends an explicit empty
 // RelOID tally. See router oneToOne disconnect regression on #69.
+//
+//	| Context Tag | Field       | Type         | Notes                     |
+//	|-------------|-------------|--------------|---------------------------|
+//	|   [0]       | target      | INTEGER      | target number             |
+//	|   [1]       | sources     | RELATIVE-OID | always emitted (empty OK) |
+//	|   [2]       | operation   | INTEGER      | skip if absolute (default)|
+//	|   [3]       | disposition | INTEGER      | skip if tally (default)   |
+//
+// Spec reference: Ember+ Documentation.pdf §Connection p. 89.
 func encodeConnection(c canonical.MatrixConnection) ber.TLV {
 	parts := make([]uint32, len(c.Sources))
 	for i, v := range c.Sources {


### PR DESCRIPTION
Part 3 of #78 — Ember+ slice. Completes the three-part retrofit (ACP1 #93, ACP2 #94, Ember+ here).

Closes #78.

## Summary

Retrofit markdown byte-/tag-layout tables on every Ember+ wire-codec function. **No functional change.**

## Scope

54 functions across 13 files:

| Package | Functions |
|---|---:|
| `codec/s101/` | 4 (frame/reader/writer) |
| `codec/ber/` | 14 (tag/length/tlv/value × enc/dec) |
| `codec/glow/encoder.go` | 7 (GetDir, SetValue, Subscribe, etc.) |
| `codec/glow/decoder.go` | 15 (per-container decoders) |
| `codec/matrix/state.go` | 2 |
| `provider/encoder.go` | 5 |
| `provider/matrix.go` | 5 |
| `provider/function.go` | 2 |

## Column style — chosen per function concern

- S101 framing + BER value encoders → `| Offset | Field | Width | Notes |`
- BER tag / length first octets → `| Bit(s) | Field | Width | Notes |`
- Glow context-tagged containers → `| Context Tag | Field | Type | Notes |`

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run` — 0 issues
- [x] `go test -count=1 ./internal/emberplus/...` green (ber / glow / matrix / s101 / consumer / provider)

🤖 Generated with [Claude Code](https://claude.com/claude-code)