### PR TITLE
fix(emberplus/provider): matrix Connect/Disconnect semantics on oneToN/oneToOne

### DIFF
--- a/internal/emberplus/provider/invoke.go
+++ b/internal/emberplus/provider/invoke.go
@@ -123,9 +123,23 @@ func (s *server) applyMatrixConnections(matrixOID string, incoming []canonical.M
 			continue
 		}
 
-		// oneToN + oneToOne both enforce target-side cardinality of 1.
-		if (m.Type == canonical.MatrixOneToN || m.Type == canonical.MatrixOneToOne) && len(in.Sources) > 1 {
-			in.Sources = in.Sources[:1]
+		// oneToN + oneToOne enforce target-side cardinality of 1 BOTH on
+		// the incoming list and against any pre-existing connection.
+		// EmberViewer (and most Ember+ clients) send Operation=Connect
+		// on user clicks; Connect performs a union via applyOneConnection,
+		// which for these matrix types would leave the target holding
+		// (oldSrc + newSrc) = 2 sources — violating the invariant.
+		// Disconnect would leave the target unrouted, also a violation.
+		// Coerce both to Absolute so the target's single source is
+		// replaced, matching spec p.33 and what the user expects from
+		// a mouse click ("route src X to tgt Y").
+		if m.Type == canonical.MatrixOneToN || m.Type == canonical.MatrixOneToOne {
+			if len(in.Sources) > 1 {
+				in.Sources = in.Sources[:1]
+			}
+			if in.Operation == canonical.ConnOpConnect || in.Operation == canonical.ConnOpDisconnect {
+				in.Operation = canonical.ConnOpAbsolute
+			}
 		}
 
 		applied := applyOneConnection(m, in)

--- a/internal/emberplus/provider/matrix_test.go
+++ b/internal/emberplus/provider/matrix_test.go
@@ -199,6 +199,89 @@ func TestApplyConnection_OneToN_SingleSource(t *testing.T) {
 	}
 }
 
+// TestApplyConnection_OneToN_ConnectOp_Replaces: EmberViewer (and most
+// Ember+ clients) send Operation=Connect on user clicks. For a oneToN
+// matrix, Connect MUST replace the target's single source — not union.
+// Without the coercion, mergeSources([0], [2]) = [0, 2] and the target
+// ends up with 2 sources, violating the oneToN invariant.
+func TestApplyConnection_OneToN_ConnectOp_Replaces(t *testing.T) {
+	m := &canonical.Matrix{
+		Type: canonical.MatrixOneToN,
+		Connections: []canonical.MatrixConnection{
+			{Target: 0, Sources: []int64{0}}, // t-0 currently ← s-0
+		},
+	}
+	srv := buildMatrixTree(t, m)
+	post, err := srv.applyMatrixConnections("1.1", []canonical.MatrixConnection{
+		{Target: 0, Sources: []int64{2}, Operation: canonical.ConnOpConnect},
+	})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if len(post[0].Sources) != 1 {
+		t.Fatalf("oneToN + Connect must keep exactly 1 source, got %v", post[0].Sources)
+	}
+	if post[0].Sources[0] != 2 {
+		t.Errorf("oneToN + Connect must replace, got src=%d want 2", post[0].Sources[0])
+	}
+}
+
+// TestApplyConnection_OneToOne_ConnectOp_ReplacesAndSteals: on a user
+// click, Operation=Connect against a oneToOne matrix must replace the
+// target's source AND strip the newly-bound source from any other
+// target that held it (source-exclusivity / loser tally).
+func TestApplyConnection_OneToOne_ConnectOp_ReplacesAndSteals(t *testing.T) {
+	m := &canonical.Matrix{
+		Type: canonical.MatrixOneToOne,
+		Connections: []canonical.MatrixConnection{
+			{Target: 0, Sources: []int64{0}}, // t-0 ← s-0
+			{Target: 1, Sources: []int64{1}}, // t-1 ← s-1
+		},
+	}
+	srv := buildMatrixTree(t, m)
+	// User routes s-0 onto t-1 via EmberViewer → Operation=Connect.
+	post, err := srv.applyMatrixConnections("1.1", []canonical.MatrixConnection{
+		{Target: 1, Sources: []int64{0}, Operation: canonical.ConnOpConnect},
+	})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	byT := map[int64][]int64{}
+	for _, c := range post {
+		byT[c.Target] = c.Sources
+	}
+	if got := byT[1]; len(got) != 1 || got[0] != 0 {
+		t.Errorf("t-1 post=%v want [0] (Connect replaces, keeps exactly 1 src)", got)
+	}
+	if _, seen := byT[0]; !seen {
+		t.Fatal("t-0 loser tally not emitted — consumer won't redraw")
+	}
+	if got := byT[0]; len(got) != 0 {
+		t.Errorf("t-0 post=%v want [] (s-0 stolen by t-1)", got)
+	}
+}
+
+// TestApplyConnection_NToN_ConnectOp_Unions confirms nToN is NOT
+// coerced — Connect on nToN still unions (many-to-many is the point).
+func TestApplyConnection_NToN_ConnectOp_Unions(t *testing.T) {
+	m := &canonical.Matrix{
+		Type: canonical.MatrixNToN,
+		Connections: []canonical.MatrixConnection{
+			{Target: 0, Sources: []int64{0}},
+		},
+	}
+	srv := buildMatrixTree(t, m)
+	post, err := srv.applyMatrixConnections("1.1", []canonical.MatrixConnection{
+		{Target: 0, Sources: []int64{1}, Operation: canonical.ConnOpConnect},
+	})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if len(post[0].Sources) != 2 {
+		t.Fatalf("nToN + Connect must union, got %v want [0 1]", post[0].Sources)
+	}
+}
+
 // TestApplyConnection_ConnectAndDisconnect exercises the nToN additive ops.
 func TestApplyConnection_ConnectAndDisconnect(t *testing.T) {
 	m := &canonical.Matrix{


### PR DESCRIPTION
## Summary

Ember+ clients (EmberViewer, Lawo VSM, TinyEmber+) send `Operation=Connect` on user clicks. Against a oneToN or oneToOne matrix whose target already has a source, the provider's \`applyOneConnection\` did a union — leaving the target with 2 sources, violating spec p. 33 target-cardinality-of-1.

**Symptom** (reproduced live with EmberPlusView on \`router_tree.json\`): clicking a new src on an already-bound oneToN / oneToOne target left the old src in place. For oneToOne the source-exclusivity "steal" also failed, because the loser tally pass ran after the target had already accumulated 2 sources.

**Fix**: coerce \`Connect\` and \`Disconnect\` to \`Absolute\` for oneToN + oneToOne before calling \`applyOneConnection\`. nToN keeps Connect/Disconnect/Absolute semantics for many-to-many routing.

## Semantics table (matches user's stated rules)

| Type | Connect on unbound tgt | Connect on bound tgt | Source-exclusivity |
|---|---|---|---|
| oneToN | src → tgt | **replaces** old src | none (src can feed many tgts) |
| oneToOne | src → tgt; strip src from any other tgt | **replaces** old src; strip src from other tgt (loser tally) | yes (src has at most 1 tgt) |
| nToN | add src to tgt | **unions** (add) | none |

## Tests

3 new regression tests that drive \`Operation=Connect\` against each matrix type:

- \`TestApplyConnection_OneToN_ConnectOp_Replaces\` — Connect replaces instead of unioning
- \`TestApplyConnection_OneToOne_ConnectOp_ReplacesAndSteals\` — Connect replaces + loser tally still fires
- \`TestApplyConnection_NToN_ConnectOp_Unions\` — confirms nToN still unions (many-to-many is the point)

Existing Absolute-op tests (\`OneToN_SingleSource\`, \`OneToOne_Exclusivity\`, \`ConnectAndDisconnect\`) still green.

## Why the suite didn't catch this before

The pre-existing \`TestApplyConnection_*\` tests drove \`Operation=Absolute\` only. EmberViewer uses \`Connect\` on user clicks, so nothing in CI exercised the mergeSources path for oneToN/oneToOne.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`golangci-lint run\` — 0 issues
- [x] \`go test -count=1 -run TestApplyConnection ./internal/emberplus/provider/...\` — all green
- [x] Live verification: EmberPlusView 1.6.2 on \`127.0.0.1:9000\` against \`router_tree.json\` — user confirmed all three matrix types now behave per spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)