### PR TITLE
fix(emberplus/wireshark): descend universal SET wrapper in ParameterContents / NodeContents

### DIFF
--- a/internal/emberplus/wireshark/dissector_emberplus.lua
+++ b/internal/emberplus/wireshark/dissector_emberplus.lua
@@ -671,7 +671,22 @@ local ACCESS_NAMES  = { [0] = "--", [1] = "R-", [2] = "-W", [3] = "RW" }
 local CONN_OPS      = { [0] = "absolute", [1] = "connect", [2] = "disconnect" }
 local CONN_DISPS    = { [0] = "tally", [1] = "modified", [2] = "pending", [3] = "locked" }
 
+-- ParameterContents and NodeContents are BER SET OF { CTX-tagged fields }.
+-- The CTX[1] contents wrapper holds a universal SET (tag 17) as its
+-- immediate child, and the CTX-tagged identifier/value/access fields live
+-- INSIDE that SET. Without descending into the SET, peek_app_tag sees a
+-- universal constructed tag and the walk skips straight past the whole
+-- block — so identifier/value/access come back nil.
+local function step_through_set_wrapper(ba, off, endpos)
+    local c, cn, t, h, l = peek_app_tag(ba, off, endpos)
+    if c == 0 and cn == true and t == 17 and l ~= nil and l >= 0 then
+        return off + h, math.min(off + h + l, endpos)
+    end
+    return off, endpos
+end
+
 local function decode_parameter_contents(ba, off, endpos)
+    off, endpos = step_through_set_wrapper(ba, off, endpos)
     local out = {}
     local walk = off
     while walk < endpos do
@@ -692,6 +707,7 @@ local function decode_parameter_contents(ba, off, endpos)
 end
 
 local function decode_node_contents(ba, off, endpos)
+    off, endpos = step_through_set_wrapper(ba, off, endpos)
     local out = {}
     local walk = off
     while walk < endpos do


### PR DESCRIPTION
## Summary

ParameterContents and NodeContents are BER `SET OF { CTX-tagged fields }`. The CTX[1] contents wrapper contains a universal SET (tag \`0x31\`) whose members are the CTX-tagged \`identifier\` / \`description\` / \`value\` / \`access\` fields.

The dissector's \`decode_parameter_contents\` and \`decode_node_contents\` iterated from the CTX[1] inner offset directly and saw the universal SET as opaque — \`peek_app_tag\` returns class=0 tag=17, which fails the \`c == 2\` CTX check, so the walk skipped past the entire block. **Identifier / value / access all came back nil**, starving the #59 OID→identifier cache that PR #97 landed.

\`decode_matrix_connections\` already had the equivalent fix for a universal SEQUENCE wrapper (tag 16) around ConnectionCollection. Added \`step_through_set_wrapper\` and called it at the entry of both contents decoders.

## Before vs after

Against \`captures/ember59b/walk3.pcapng\` (158 frames from our consumer walking our provider on :9000):

**Before**:

\`\`\`
QParameter 1.1.1 payload=109B
QParameter 1.7.1 payload=684B
QFunction  1.6.1 payload=1002B
\`\`\`

**After**:

\`\`\`
QParameter 1.1.1 ?.?.product 'product' R- = "ACP Demo Router"
QParameter 1.7.1 ?.?.meter-L 'meter-L' R- = 0
QFunction  1.6.1 ?.?.sum 'sum'
\`\`\`

\`?.?.\` placeholders fill in as the walk reaches ancestor Nodes and the OID cache (PR #97) populates.

## Related

Unblocks the #59 identifier-chain cache that was merged in #97 — it had correct logic, just no data to cache. With this fix the chain will actually resolve on packet scroll.

## Scope

One file — \`internal/emberplus/wireshark/dissector_emberplus.lua\`, +16 / -0. No Go changes, no tests.

## Test plan

- [x] \`go build ./...\` / \`go vet ./...\` (dissector-only, CI guard)
- [x] \`golangci-lint run\` — 0 issues
- [x] Manual verification via tshark against live-captured pcap — identifier / access / value render correctly for QParameter, Parameter, QFunction, QMatrix, QNode

🤖 Generated with [Claude Code](https://claude.com/claude-code)