### PR TITLE
refactor(wireshark): dhs_<proto> naming for all existing dissectors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ internal/
     CLAUDE.md                 atomic wire-format context
     consumer/                 package acp1 — implements protocol.Protocol
     provider/                 package acp1 — implements provider.Provider
-    wireshark/                dissector_acp1.lua
+    wireshark/                dhs_acpv1.lua
     docs/                     consumer.md / provider.md / README.md
     assets/                   spec PDFs + vendor tools (Synapse Simulator)
   acp2/

--- a/docs/references/README.md
+++ b/docs/references/README.md
@@ -20,8 +20,11 @@
 
 | Dissector            | Path                                                |
 |----------------------|-----------------------------------------------------|
-| ACP1 dissector       | [assets/dissector_acpv1.lua](../../assets/dissector_acpv1.lua) |
-| ACP2 dissector       | [assets/dissector_acp2.lua](../../assets/dissector_acp2.lua)   |
+| ACP1 dissector          | [internal/acp1/wireshark/dhs_acpv1.lua](../../internal/acp1/wireshark/dhs_acpv1.lua) |
+| ACP2 dissector          | [internal/acp2/wireshark/dhs_acpv2.lua](../../internal/acp2/wireshark/dhs_acpv2.lua) |
+| Ember+ dissector        | [internal/emberplus/wireshark/dhs_emberplus.lua](../../internal/emberplus/wireshark/dhs_emberplus.lua) |
+| OSC dissector           | [internal/osc/wireshark/dhs_osc.lua](../../internal/osc/wireshark/dhs_osc.lua) |
+| Probel SW-P-08 dissector| [internal/probel-sw08p/wireshark/dhs_probel_sw08p.lua](../../internal/probel-sw08p/wireshark/dhs_probel_sw08p.lua) |
 
 ---
 

--- a/docs/wireshark.md
+++ b/docs/wireshark.md
@@ -6,15 +6,19 @@ in Wireshark without having to decode frames by hand. Every dhs plugin
 carries a from-scratch dissector — we never delegate to Wireshark
 built-ins, so `Protocol | Info` shape stays consistent across protocols.
 
-| Protocol | Transport          | Default ports | Lua file                                  |
-|----------|--------------------|---------------|-------------------------------------------|
-| ACP1     | UDP / TCP direct   | 2071          | [`internal/acp1/assets/dissector_acpv1.lua`](../internal/acp1/assets/dissector_acpv1.lua) |
-| ACP2     | AN2 over TCP       | 2072          | [`internal/acp2/assets/dissector_acp2.lua`](../internal/acp2/assets/dissector_acp2.lua)   |
-| Ember+   | S101 over TCP      | 9000 / 9090 / 9092 | [`internal/emberplus/assets/dissector_emberplus.lua`](../internal/emberplus/assets/dissector_emberplus.lua) |
-| OSC 1.0 + 1.1 | UDP + TCP length-prefix + TCP SLIP | UDP 8000, TCP 8000 (length-prefix), TCP 8001 (SLIP) — all configurable | [`internal/osc/wireshark/dhs_osc.lua`](../internal/osc/wireshark/dhs_osc.lua) |
-| Probel SW-P-08 | TCP         | 2008          | [`internal/probel-sw08p/wireshark/dissector_probel_sw08p.lua`](../internal/probel-sw08p/wireshark/dissector_probel_sw08p.lua) |
+All files follow the `dhs_<proto>` naming convention (file / Proto /
+field-abbrev prefix) so display filters and Wireshark namespaces don't
+clash with upstream built-ins.
 
-All three target **Wireshark 4.x** (Lua 5.2+). They install the same way.
+| Protocol       | Transport                               | Default ports                         | Lua file                                                                                              | Display filter      |
+|----------------|-----------------------------------------|---------------------------------------|-------------------------------------------------------------------------------------------------------|---------------------|
+| ACP1           | UDP / TCP direct                        | 2071                                  | [`internal/acp1/wireshark/dhs_acpv1.lua`](../internal/acp1/wireshark/dhs_acpv1.lua)                   | `dhs_acpv1`         |
+| ACP2           | AN2 over TCP                            | 2072                                  | [`internal/acp2/wireshark/dhs_acpv2.lua`](../internal/acp2/wireshark/dhs_acpv2.lua)                   | `dhs_acpv2`         |
+| Ember+         | S101 over TCP                           | 9000 / 9090 / 9092                    | [`internal/emberplus/wireshark/dhs_emberplus.lua`](../internal/emberplus/wireshark/dhs_emberplus.lua) | `dhs_emberplus`     |
+| OSC 1.0 + 1.1  | UDP + TCP length-prefix + TCP SLIP      | 8000 UDP/TCP-LP, 8001 TCP-SLIP        | [`internal/osc/wireshark/dhs_osc.lua`](../internal/osc/wireshark/dhs_osc.lua)                         | `dhs_osc`           |
+| Probel SW-P-08 | TCP                                     | 2008                                  | [`internal/probel-sw08p/wireshark/dhs_probel_sw08p.lua`](../internal/probel-sw08p/wireshark/dhs_probel_sw08p.lua) | `dhs_probel_sw08p`  |
+
+All target **Wireshark 4.x** (Lua 5.2+). They install the same way.
 
 ---
 
@@ -39,16 +43,20 @@ From the repo root:
 
 ```bash
 # Linux / macOS
-cp internal/acp1/assets/dissector_acpv1.lua        "$HOME/.local/lib/wireshark/plugins/"
-cp internal/acp2/assets/dissector_acp2.lua         "$HOME/.local/lib/wireshark/plugins/"
-cp internal/emberplus/assets/dissector_emberplus.lua "$HOME/.local/lib/wireshark/plugins/"
+cp internal/acp1/wireshark/dhs_acpv1.lua              "$HOME/.local/lib/wireshark/plugins/"
+cp internal/acp2/wireshark/dhs_acpv2.lua              "$HOME/.local/lib/wireshark/plugins/"
+cp internal/emberplus/wireshark/dhs_emberplus.lua     "$HOME/.local/lib/wireshark/plugins/"
+cp internal/osc/wireshark/dhs_osc.lua                 "$HOME/.local/lib/wireshark/plugins/"
+cp internal/probel-sw08p/wireshark/dhs_probel_sw08p.lua "$HOME/.local/lib/wireshark/plugins/"
 ```
 
 ```powershell
 # Windows PowerShell
-Copy-Item internal/acp1/assets/dissector_acpv1.lua        $env:APPDATA\Wireshark\plugins\
-Copy-Item internal/acp2/assets/dissector_acp2.lua         $env:APPDATA\Wireshark\plugins\
-Copy-Item internal/emberplus/assets/dissector_emberplus.lua $env:APPDATA\Wireshark\plugins\
+Copy-Item internal/acp1/wireshark/dhs_acpv1.lua              $env:APPDATA\Wireshark\plugins\
+Copy-Item internal/acp2/wireshark/dhs_acpv2.lua              $env:APPDATA\Wireshark\plugins\
+Copy-Item internal/emberplus/wireshark/dhs_emberplus.lua     $env:APPDATA\Wireshark\plugins\
+Copy-Item internal/osc/wireshark/dhs_osc.lua                 $env:APPDATA\Wireshark\plugins\
+Copy-Item internal/probel-sw08p/wireshark/dhs_probel_sw08p.lua $env:APPDATA\Wireshark\plugins\
 ```
 
 Any `.lua` file dropped into that folder is auto-loaded on Wireshark start.
@@ -69,11 +77,13 @@ unchecked it, run the installer again and enable it.
 ## 4. Restart Wireshark
 
 Close and re-open Wireshark. On the start screen open
-**Analyze → Enabled Protocols** and verify the three protocols are listed:
+**Analyze → Enabled Protocols** and verify the dissectors are listed:
 
-- `emberplus` — Ember+ / S101 (with child `emberplus_glow` for the BER tree)
-- `acp2_msg` / `an2_acp2` — ACP2 + AN2 transport
-- `acp1` — ACP1
+- `dhs_acpv1` — ACP1
+- `dhs_acpv2` / `dhs_acpv2_an2` / `dhs_acpv2_prop` — ACP2 + AN2 transport + property sub-tree
+- `dhs_emberplus` / `dhs_emberplus_glow` — Ember+ S101 + Glow BER sub-tree
+- `dhs_osc` — OSC 1.0 + 1.1 (all three transports: UDP + TCP length-prefix + TCP SLIP)
+- `dhs_probel_sw08p` — Probel SW-P-08/88
 
 If one is missing, check **View → Reload Lua Plugins** (Ctrl-Shift-L) — the
 status bar reports Lua errors you can then copy from **View → Lua →
@@ -91,28 +101,33 @@ up the default ports automatically.
 
 ```bash
 # ACP1 (Synapse Simulator)
-./bin/acp walk 10.6.239.113 --protocol acp1 --slot 0 --capture out/acp1/
+dhs consumer acp1 walk 10.6.239.113 --slot 0 --capture out/acp1/
 
 # ACP2 (Convert Hybrid VM)
-./bin/acp walk 10.41.40.195 --protocol acp2 --slot 0 --capture out/acp2/
+dhs consumer acp2 walk 10.41.40.195 --slot 0 --capture out/acp2/
 
 # Ember+ (TinyEmberPlus, port 9092)
-./bin/acp walk localhost --protocol emberplus --port 9092 --capture out/emberplus/
+dhs consumer emberplus walk localhost:9092 --capture out/emberplus/
 ```
 
 ### Display filters
 
-| Want to see                  | Filter                        |
-|------------------------------|-------------------------------|
-| All ACP1 traffic             | `acp1`                        |
-| ACP1 errors only             | `acp1.mtype == 3`             |
-| ACP1 set method calls        | `acp1.mcode == 1`             |
-| All ACP2 traffic             | `acp2 or an2`                 |
-| ACP2 announces               | `acp2.type == 2`              |
-| ACP2 errors                  | `acp2.type == 3`              |
-| All Ember+ traffic           | `emberplus`                   |
-| Ember+ keep-alive only       | `emberplus.s101.command == 0x01 or emberplus.s101.command == 0x02` |
-| Ember+ Glow elements         | `emberplus_glow`              |
+| Want to see                  | Filter                                                    |
+|------------------------------|-----------------------------------------------------------|
+| All ACP1 traffic             | `dhs_acpv1`                                               |
+| ACP1 errors only             | `dhs_acpv1.mtype == 3`                                    |
+| ACP1 set method calls        | `dhs_acpv1.mcode == 1`                                    |
+| All ACP2 traffic             | `dhs_acpv2 or dhs_acpv2_an2`                              |
+| ACP2 announces               | `dhs_acpv2.type == 2`                                     |
+| ACP2 errors                  | `dhs_acpv2.type == 3`                                     |
+| All Ember+ traffic           | `dhs_emberplus`                                           |
+| Ember+ keep-alive only       | `dhs_emberplus.s101.command == 0x01 or dhs_emberplus.s101.command == 0x02` |
+| Ember+ Glow elements         | `dhs_emberplus_glow`                                      |
+| All OSC traffic (1.0 + 1.1)  | `dhs_osc`                                                 |
+| OSC 1.0 only                 | `dhs_osc.version == "OSC 1.0"`                            |
+| OSC 1.1 only                 | `dhs_osc.version == "OSC 1.1"`                            |
+| All Probel SW-P-08 traffic   | `dhs_probel_sw08p`                                        |
+| Probel salvo fire (cmd 121)  | `dhs_probel_sw08p.cmd == 0x79`                            |
 
 ### Non-default ports
 
@@ -120,22 +135,22 @@ Ember+ auto-detects on **any TCP port** via a heuristic that checks BoF +
 S101 header shape. No configuration needed — if your provider speaks S101
 on, say, port 12345, Wireshark will still pick it up.
 
-ACP1 / ACP2 don't have a heuristic (the wire format is less distinctive).
-For those, if your device uses a non-default port, right-click a packet →
-**Decode As…** → pick the appropriate protocol (`acp2_msg`, `acp1`) → OK.
-The rule is saved for the session; tick **Save** to make it persistent.
+For protocols without a heuristic, right-click a packet → **Decode As…** →
+pick the appropriate dissector (`dhs_acpv1`, `dhs_acpv2`, `dhs_osc`,
+`dhs_probel_sw08p`) → OK. The rule is saved for the session; tick **Save**
+to make it persistent.
 
 ---
 
-## 6. Read a capture file already recorded by `acp extract`
+## 6. Read a capture file already recorded by `dhs extract`
 
-`acp extract` emits `wire.jsonl` per run (one JSONL record per frame). That
+`dhs extract` emits `wire.jsonl` per run (one JSONL record per frame). That
 format is for offline replay in Go tests, **not** a pcap file. To inspect raw
 frames in Wireshark:
 
 1. Re-run the same CLI command with `tcpdump`/`dumpcap` open in parallel, or
 2. Use the captures stored under `bin/devices/captures/<proto>/<ip>/<slot>/`
-   when `acp walk --capture` was invoked against the device. These are pcap
+   when `dhs ... --capture` was invoked against the device. These are pcap
    sidecars (not generated automatically today — follow-up work).
 
 For fixture-driven offline inspection, the JSONL replay already gives
@@ -150,7 +165,7 @@ live debugging.
 |-----------------------------------------|----------------------------------------------------------------------------|
 | Protocol column is blank                | Confirm the port matches a registered default, or use **Decode As…**.      |
 | "Lua: Error during loading" on startup  | **View → Lua → Evaluate** to see stack trace; check Wireshark version ≥ 4. |
-| Ember+ frames show only raw bytes       | `emberplus` heuristic disabled under **Analyze → Enabled Protocols**. |
+| Ember+ frames show only raw bytes       | `dhs_emberplus` heuristic disabled under **Analyze → Enabled Protocols**.  |
 | CRC mismatch on every Ember+ frame      | Your provider uses non-standard escaping — open an issue with a pcap.      |
 | Tree recursion cut off at depth 20      | Malformed Glow tree. Grab the pcap and file a spec-deviation bug.          |
 
@@ -168,4 +183,5 @@ Plugins** (Ctrl-Shift-L). No Wireshark restart needed.
 - ACP1 spec: [`internal/acp1/assets/AXON-ACP_v1_4.pdf`](../internal/acp1/assets/AXON-ACP_v1_4.pdf)
 - ACP2 + AN2 spec: [`internal/acp2/assets/acp2_protocol.pdf`](../internal/acp2/assets/acp2_protocol.pdf) · [`internal/acp2/assets/an2_protocol.pdf`](../internal/acp2/assets/an2_protocol.pdf)
 - Ember+ spec v2.50: [`internal/emberplus/assets/Ember+ Documentation.pdf`](../internal/emberplus/assets/Ember+ Documentation.pdf)
+- Probel SW-P-08 spec: [`internal/probel-sw08p/assets/probel-sw08p/SW-P-08 Issue 30.doc`](../internal/probel-sw08p/assets/probel-sw08p/SW-P-08%20Issue%2030.doc) (via `antiword`)
 - Wire format summary: [`CLAUDE.md`](../CLAUDE.md)

--- a/internal/acp1/CLAUDE.md
+++ b/internal/acp1/CLAUDE.md
@@ -4,7 +4,7 @@ Atomic per-protocol context for the ACP1 plugin. Read the root `CLAUDE.md`
 first for cross-cutting rules; this file holds the ACP1-specific wire spec.
 
 Authoritative spec: `internal/acp1/assets/AXON-ACP_v1_4.pdf`.
-Wireshark dissector (byte-exact reference): `./wireshark/dissector_acp1.lua`.
+Wireshark dissector (byte-exact reference): `./wireshark/dhs_acpv1.lua`.
 C# reference (Mode A only): `ByResearch.DHS.AxonACP.DeviceDriver`. C# does NOT
 implement ACP2.
 
@@ -19,7 +19,7 @@ internal/acp1/
 ├── CLAUDE.md    ← this file
 ├── consumer/    package acp1 — implements protocol.Protocol
 ├── provider/    package acp1 — implements provider.Provider
-├── wireshark/   dissector_acp1.lua
+├── wireshark/   dhs_acpv1.lua
 ├── docs/        consumer.md / provider.md / README.md
 └── assets/      AXON-ACP_v1_4.pdf + Synapse Simulator vendor tool
 ```

--- a/internal/acp1/assets/README.md
+++ b/internal/acp1/assets/README.md
@@ -73,7 +73,7 @@ Requires a real ACP1 device or emulator on the same VLAN.
 ## Reference
 
 - Spec: [AXON-ACP_v1_4.pdf](AXON-ACP_v1_4.pdf)
-- Wireshark dissector: [dissector_acpv1.lua](dissector_acpv1.lua) — install per [docs/wireshark.md](../../docs/wireshark.md)
+- Wireshark dissector: [dhs_acpv1.lua](../wireshark/dhs_acpv1.lua) — install per [docs/wireshark.md](../../../docs/wireshark.md)
 - Full wire reference: [CLAUDE.md](../../CLAUDE.md) (ACP1 section)
 
 ---

--- a/internal/acp1/consumer/types.go
+++ b/internal/acp1/consumer/types.go
@@ -2,7 +2,7 @@
 // plugin for the internal/protocol interface.
 //
 // Authoritative spec: assets/AXON-ACP_v1_4.pdf.
-// Cross-reference: the Axon Wireshark dissector in assets/dissector_acpv1.lua
+// Cross-reference: the Axon Wireshark dissector in wireshark/dhs_acpv1.lua
 // and the C# reference driver (ByResearch.DHS.AxonACP.DeviceDriver).
 //
 // Scope of this package:

--- a/internal/acp1/docs/README.md
+++ b/internal/acp1/docs/README.md
@@ -10,4 +10,4 @@
 | Document | Path | Description |
 |---|---|---|
 | AXON ACP v1.4 | [AXON-ACP_v1_4.pdf](../../../internal/acp1/assets/AXON-ACP_v1_4.pdf) | Full specification |
-| Wireshark dissector | [dissector_acpv1.lua](../../../internal/acp1/assets/dissector_acpv1.lua) | Byte-exact reference |
+| Wireshark dissector | [dhs_acpv1.lua](../../../internal/acp1/wireshark/dhs_acpv1.lua) | Byte-exact reference |

--- a/internal/acp1/docs/consumer.md
+++ b/internal/acp1/docs/consumer.md
@@ -9,7 +9,7 @@ Consumer connector for ACP v1.4 (Axon Synapse protocol).
 | Document | Path | Description |
 |---|---|---|
 | Spec (authoritative) | [internal/acp1/assets/AXON-ACP_v1_4.pdf](../../../internal/acp1/assets/AXON-ACP_v1_4.pdf) | ACP v1.4 full specification |
-| Wireshark dissector | [internal/acp1/assets/dissector_acpv1.lua](../../../internal/acp1/assets/dissector_acpv1.lua) | Byte-exact reference |
+| Wireshark dissector | [internal/acp1/wireshark/dhs_acpv1.lua](../../../internal/acp1/wireshark/dhs_acpv1.lua) | Byte-exact reference |
 | C# reference driver | external (ByResearch.DHS.AxonACP.DeviceDriver) | ACP1 only, not ACP2 |
 | Protocol reference | [CLAUDE.md](../../../CLAUDE.md) — section "ACP1" | Wire format, methods, object types |
 | Testdata captures | [tests/fixtures/acp1/](../../../tests/fixtures/acp1/) | Raw JSONL captures from emulator |

--- a/internal/acp1/testdata/protocol_types/README.md
+++ b/internal/acp1/testdata/protocol_types/README.md
@@ -1,7 +1,7 @@
 # ACP1 per-type fixtures
 
 One slimmed capture + frozen tshark tree per ACP1 wire element, as defined
-by AXON-ACP v1.4. The dissector under `internal/acp1/assets/dissector_acpv1.lua`
+by AXON-ACP v1.4. The dissector under `internal/acp1/wireshark/dhs_acpv1.lua`
 is expected to render every element exactly as frozen — the CI parity test
 under `tests/unit/fixture_parity/` asserts that.
 
@@ -61,5 +61,5 @@ make fixtures-acp1
 ```
 
 Wireshark / tshark ≥ 4.x required. The dissector under
-`internal/acp1/assets/dissector_acpv1.lua` must be installed in the personal
+`internal/acp1/wireshark/dhs_acpv1.lua` must be installed in the personal
 plugins dir (see [`docs/wireshark.md`](../../../../docs/wireshark.md)).

--- a/internal/acp1/testdata/protocol_types/alarm/tshark.tree
+++ b/internal/acp1/testdata/protocol_types/alarm/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 63 bytes on wire (504 bits), 63 bytes captured (504 bits) on in
     Capture Length: 63 bytes (504 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:udp:acpv1_full]
+    [Protocols in frame: null:ip:udp:dhs_acpv1]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp1/testdata/protocol_types/byte/tshark.tree
+++ b/internal/acp1/testdata/protocol_types/byte/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 67 bytes on wire (536 bits), 67 bytes captured (536 bits) on in
     Capture Length: 67 bytes (536 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:udp:acpv1_full]
+    [Protocols in frame: null:ip:udp:dhs_acpv1]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp1/testdata/protocol_types/enumerated/tshark.tree
+++ b/internal/acp1/testdata/protocol_types/enumerated/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 68 bytes on wire (544 bits), 68 bytes captured (544 bits) on in
     Capture Length: 68 bytes (544 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:udp:acpv1_full]
+    [Protocols in frame: null:ip:udp:dhs_acpv1]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp1/testdata/protocol_types/error/tshark.tree
+++ b/internal/acp1/testdata/protocol_types/error/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 42 bytes on wire (336 bits), 42 bytes captured (336 bits) on in
     Capture Length: 42 bytes (336 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:udp:acpv1_full]
+    [Protocols in frame: null:ip:udp:dhs_acpv1]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp1/testdata/protocol_types/float/tshark.tree
+++ b/internal/acp1/testdata/protocol_types/float/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 80 bytes on wire (640 bits), 80 bytes captured (640 bits) on in
     Capture Length: 80 bytes (640 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:udp:acpv1_full]
+    [Protocols in frame: null:ip:udp:dhs_acpv1]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp1/testdata/protocol_types/frame_status/tshark.tree
+++ b/internal/acp1/testdata/protocol_types/frame_status/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 74 bytes on wire (592 bits), 74 bytes captured (592 bits) on in
     Capture Length: 74 bytes (592 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:udp:acpv1_full]
+    [Protocols in frame: null:ip:udp:dhs_acpv1]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp1/testdata/protocol_types/integer/tshark.tree
+++ b/internal/acp1/testdata/protocol_types/integer/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 72 bytes on wire (576 bits), 72 bytes captured (576 bits) on in
     Capture Length: 72 bytes (576 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:udp:acpv1_full]
+    [Protocols in frame: null:ip:udp:dhs_acpv1]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp1/testdata/protocol_types/ip_address/tshark.tree
+++ b/internal/acp1/testdata/protocol_types/ip_address/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 70 bytes on wire (560 bits), 70 bytes captured (560 bits) on in
     Capture Length: 70 bytes (560 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:udp:acpv1_full]
+    [Protocols in frame: null:ip:udp:dhs_acpv1]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp1/testdata/protocol_types/long/tshark.tree
+++ b/internal/acp1/testdata/protocol_types/long/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 81 bytes on wire (648 bits), 81 bytes captured (648 bits) on in
     Capture Length: 81 bytes (648 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:udp:acpv1_full]
+    [Protocols in frame: null:ip:udp:dhs_acpv1]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp1/testdata/protocol_types/reply/tshark.tree
+++ b/internal/acp1/testdata/protocol_types/reply/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 74 bytes on wire (592 bits), 74 bytes captured (592 bits) on in
     Capture Length: 74 bytes (592 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:udp:acpv1_full]
+    [Protocols in frame: null:ip:udp:dhs_acpv1]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp1/testdata/protocol_types/request/tshark.tree
+++ b/internal/acp1/testdata/protocol_types/request/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 42 bytes on wire (336 bits), 42 bytes captured (336 bits) on in
     Capture Length: 42 bytes (336 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:udp:acpv1_full]
+    [Protocols in frame: null:ip:udp:dhs_acpv1]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp1/testdata/protocol_types/root/tshark.tree
+++ b/internal/acp1/testdata/protocol_types/root/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 51 bytes on wire (408 bits), 51 bytes captured (408 bits) on in
     Capture Length: 51 bytes (408 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:udp:acpv1_full]
+    [Protocols in frame: null:ip:udp:dhs_acpv1]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp1/testdata/protocol_types/string/tshark.tree
+++ b/internal/acp1/testdata/protocol_types/string/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 62 bytes on wire (496 bits), 62 bytes captured (496 bits) on in
     Capture Length: 62 bytes (496 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:udp:acpv1_full]
+    [Protocols in frame: null:ip:udp:dhs_acpv1]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp1/wireshark/dhs_acpv1.lua
+++ b/internal/acp1/wireshark/dhs_acpv1.lua
@@ -98,105 +98,105 @@ local pver_valstr = {
 -- Protocol declaration
 -------------------------------------------------------------------------------
 
-local acpv1 = Proto("acpv1_full", "Axon Control Protocol V1")
+local acpv1 = Proto("dhs_acpv1", "Axon Control Protocol V1")
 
 -------------------------------------------------------------------------------
 -- ProtoFields
 -------------------------------------------------------------------------------
 
 -- TCP framing
-local f_mlen = ProtoField.uint32("acpv1.mlen", "Message Length", base.DEC)
+local f_mlen = ProtoField.uint32("dhs_acpv1.mlen", "Message Length", base.DEC)
 
 -- ACP1 header
-local f_mtid   = ProtoField.uint32("acpv1.mtid",  "Transaction ID", base.HEX)
-local f_pver   = ProtoField.uint8("acpv1.pver",   "Protocol Version", base.DEC, pver_valstr)
-local f_mtype  = ProtoField.uint8("acpv1.mtype",  "Message Type", base.DEC, mtype_valstr)
-local f_maddr  = ProtoField.uint8("acpv1.maddr",  "Slot Address", base.DEC)
+local f_mtid   = ProtoField.uint32("dhs_acpv1.mtid",  "Transaction ID", base.HEX)
+local f_pver   = ProtoField.uint8("dhs_acpv1.pver",   "Protocol Version", base.DEC, pver_valstr)
+local f_mtype  = ProtoField.uint8("dhs_acpv1.mtype",  "Message Type", base.DEC, mtype_valstr)
+local f_maddr  = ProtoField.uint8("dhs_acpv1.maddr",  "Slot Address", base.DEC)
 
 -- MDATA common
-local f_mcode  = ProtoField.uint8("acpv1.mcode",  "Method/Error Code", base.DEC)
-local f_objgrp = ProtoField.uint8("acpv1.objgrp", "Object Group", base.DEC, objgrp_valstr)
-local f_objid  = ProtoField.uint8("acpv1.objid",  "Object ID", base.DEC)
-local f_value  = ProtoField.bytes("acpv1.value",   "Value")
+local f_mcode  = ProtoField.uint8("dhs_acpv1.mcode",  "Method/Error Code", base.DEC)
+local f_objgrp = ProtoField.uint8("dhs_acpv1.objgrp", "Object Group", base.DEC, objgrp_valstr)
+local f_objid  = ProtoField.uint8("dhs_acpv1.objid",  "Object ID", base.DEC)
+local f_value  = ProtoField.bytes("dhs_acpv1.value",   "Value")
 
 -- Error fields
-local f_err_transport = ProtoField.uint8("acpv1.err_transport", "Transport Error", base.DEC, transport_error_valstr)
-local f_err_object    = ProtoField.uint8("acpv1.err_object",    "Object Error", base.DEC, object_error_valstr)
+local f_err_transport = ProtoField.uint8("dhs_acpv1.err_transport", "Transport Error", base.DEC, transport_error_valstr)
+local f_err_object    = ProtoField.uint8("dhs_acpv1.err_object",    "Object Error", base.DEC, object_error_valstr)
 
 -- Object property fields (getObject decode)
-local f_obj_type       = ProtoField.uint8("acpv1.obj.type",       "Object Type", base.DEC, objtype_valstr)
-local f_obj_numprops   = ProtoField.uint8("acpv1.obj.numprops",   "Num Properties", base.DEC)
-local f_obj_access     = ProtoField.uint8("acpv1.obj.access",     "Access", base.HEX)
-local f_obj_access_r   = ProtoField.bool("acpv1.obj.access.read",      "Read",       8, nil, 0x01)
-local f_obj_access_w   = ProtoField.bool("acpv1.obj.access.write",     "Write",      8, nil, 0x02)
-local f_obj_access_d   = ProtoField.bool("acpv1.obj.access.setdef",    "SetDefault", 8, nil, 0x04)
+local f_obj_type       = ProtoField.uint8("dhs_acpv1.obj.type",       "Object Type", base.DEC, objtype_valstr)
+local f_obj_numprops   = ProtoField.uint8("dhs_acpv1.obj.numprops",   "Num Properties", base.DEC)
+local f_obj_access     = ProtoField.uint8("dhs_acpv1.obj.access",     "Access", base.HEX)
+local f_obj_access_r   = ProtoField.bool("dhs_acpv1.obj.access.read",      "Read",       8, nil, 0x01)
+local f_obj_access_w   = ProtoField.bool("dhs_acpv1.obj.access.write",     "Write",      8, nil, 0x02)
+local f_obj_access_d   = ProtoField.bool("dhs_acpv1.obj.access.setdef",    "SetDefault", 8, nil, 0x04)
 
 -- Root
-local f_root_bootmode   = ProtoField.uint8("acpv1.obj.root.bootmode",    "Boot Mode", base.DEC)
-local f_root_numident   = ProtoField.uint8("acpv1.obj.root.numident",    "Num Identity", base.DEC)
-local f_root_numcontrol = ProtoField.uint8("acpv1.obj.root.numcontrol",  "Num Control", base.DEC)
-local f_root_numstatus  = ProtoField.uint8("acpv1.obj.root.numstatus",   "Num Status", base.DEC)
-local f_root_numalarm   = ProtoField.uint8("acpv1.obj.root.numalarm",    "Num Alarm", base.DEC)
-local f_root_numfile    = ProtoField.uint8("acpv1.obj.root.numfile",     "Num File", base.DEC)
+local f_root_bootmode   = ProtoField.uint8("dhs_acpv1.obj.root.bootmode",    "Boot Mode", base.DEC)
+local f_root_numident   = ProtoField.uint8("dhs_acpv1.obj.root.numident",    "Num Identity", base.DEC)
+local f_root_numcontrol = ProtoField.uint8("dhs_acpv1.obj.root.numcontrol",  "Num Control", base.DEC)
+local f_root_numstatus  = ProtoField.uint8("dhs_acpv1.obj.root.numstatus",   "Num Status", base.DEC)
+local f_root_numalarm   = ProtoField.uint8("dhs_acpv1.obj.root.numalarm",    "Num Alarm", base.DEC)
+local f_root_numfile    = ProtoField.uint8("dhs_acpv1.obj.root.numfile",     "Num File", base.DEC)
 
 -- Integer / Long / Byte / IPAddr / Float common numeric fields
-local f_int_value_s16   = ProtoField.int16("acpv1.obj.int.value",       "Value", base.DEC)
-local f_int_default_s16 = ProtoField.int16("acpv1.obj.int.default",     "Default Value", base.DEC)
-local f_int_step_s16    = ProtoField.int16("acpv1.obj.int.step",        "Step Size", base.DEC)
-local f_int_min_s16     = ProtoField.int16("acpv1.obj.int.min",         "Min Value", base.DEC)
-local f_int_max_s16     = ProtoField.int16("acpv1.obj.int.max",         "Max Value", base.DEC)
+local f_int_value_s16   = ProtoField.int16("dhs_acpv1.obj.int.value",       "Value", base.DEC)
+local f_int_default_s16 = ProtoField.int16("dhs_acpv1.obj.int.default",     "Default Value", base.DEC)
+local f_int_step_s16    = ProtoField.int16("dhs_acpv1.obj.int.step",        "Step Size", base.DEC)
+local f_int_min_s16     = ProtoField.int16("dhs_acpv1.obj.int.min",         "Min Value", base.DEC)
+local f_int_max_s16     = ProtoField.int16("dhs_acpv1.obj.int.max",         "Max Value", base.DEC)
 
-local f_long_value_s32   = ProtoField.int32("acpv1.obj.long.value",     "Value", base.DEC)
-local f_long_default_s32 = ProtoField.int32("acpv1.obj.long.default",   "Default Value", base.DEC)
-local f_long_step_s32    = ProtoField.int32("acpv1.obj.long.step",      "Step Size", base.DEC)
-local f_long_min_s32     = ProtoField.int32("acpv1.obj.long.min",       "Min Value", base.DEC)
-local f_long_max_s32     = ProtoField.int32("acpv1.obj.long.max",       "Max Value", base.DEC)
+local f_long_value_s32   = ProtoField.int32("dhs_acpv1.obj.long.value",     "Value", base.DEC)
+local f_long_default_s32 = ProtoField.int32("dhs_acpv1.obj.long.default",   "Default Value", base.DEC)
+local f_long_step_s32    = ProtoField.int32("dhs_acpv1.obj.long.step",      "Step Size", base.DEC)
+local f_long_min_s32     = ProtoField.int32("dhs_acpv1.obj.long.min",       "Min Value", base.DEC)
+local f_long_max_s32     = ProtoField.int32("dhs_acpv1.obj.long.max",       "Max Value", base.DEC)
 
-local f_byte_value_u8   = ProtoField.uint8("acpv1.obj.byte.value",     "Value", base.DEC)
-local f_byte_default_u8 = ProtoField.uint8("acpv1.obj.byte.default",   "Default Value", base.DEC)
-local f_byte_step_u8    = ProtoField.uint8("acpv1.obj.byte.step",      "Step Size", base.DEC)
-local f_byte_min_u8     = ProtoField.uint8("acpv1.obj.byte.min",       "Min Value", base.DEC)
-local f_byte_max_u8     = ProtoField.uint8("acpv1.obj.byte.max",       "Max Value", base.DEC)
+local f_byte_value_u8   = ProtoField.uint8("dhs_acpv1.obj.byte.value",     "Value", base.DEC)
+local f_byte_default_u8 = ProtoField.uint8("dhs_acpv1.obj.byte.default",   "Default Value", base.DEC)
+local f_byte_step_u8    = ProtoField.uint8("dhs_acpv1.obj.byte.step",      "Step Size", base.DEC)
+local f_byte_min_u8     = ProtoField.uint8("dhs_acpv1.obj.byte.min",       "Min Value", base.DEC)
+local f_byte_max_u8     = ProtoField.uint8("dhs_acpv1.obj.byte.max",       "Max Value", base.DEC)
 
-local f_ip_value_u32   = ProtoField.ipv4("acpv1.obj.ip.value",         "Value")
-local f_ip_default_u32 = ProtoField.ipv4("acpv1.obj.ip.default",       "Default Value")
-local f_ip_step_u32    = ProtoField.uint32("acpv1.obj.ip.step",        "Step Size", base.HEX)
-local f_ip_min_u32     = ProtoField.ipv4("acpv1.obj.ip.min",           "Min Value")
-local f_ip_max_u32     = ProtoField.ipv4("acpv1.obj.ip.max",           "Max Value")
+local f_ip_value_u32   = ProtoField.ipv4("dhs_acpv1.obj.ip.value",         "Value")
+local f_ip_default_u32 = ProtoField.ipv4("dhs_acpv1.obj.ip.default",       "Default Value")
+local f_ip_step_u32    = ProtoField.uint32("dhs_acpv1.obj.ip.step",        "Step Size", base.HEX)
+local f_ip_min_u32     = ProtoField.ipv4("dhs_acpv1.obj.ip.min",           "Min Value")
+local f_ip_max_u32     = ProtoField.ipv4("dhs_acpv1.obj.ip.max",           "Max Value")
 
-local f_float_value    = ProtoField.float("acpv1.obj.float.value",     "Value")
-local f_float_default  = ProtoField.float("acpv1.obj.float.default",   "Default Value")
-local f_float_step     = ProtoField.float("acpv1.obj.float.step",      "Step Size")
-local f_float_min      = ProtoField.float("acpv1.obj.float.min",       "Min Value")
-local f_float_max      = ProtoField.float("acpv1.obj.float.max",       "Max Value")
+local f_float_value    = ProtoField.float("dhs_acpv1.obj.float.value",     "Value")
+local f_float_default  = ProtoField.float("dhs_acpv1.obj.float.default",   "Default Value")
+local f_float_step     = ProtoField.float("dhs_acpv1.obj.float.step",      "Step Size")
+local f_float_min      = ProtoField.float("dhs_acpv1.obj.float.min",       "Min Value")
+local f_float_max      = ProtoField.float("dhs_acpv1.obj.float.max",       "Max Value")
 
 -- Enum
-local f_enum_value     = ProtoField.uint8("acpv1.obj.enum.value",      "Value (index)", base.DEC)
-local f_enum_numitems  = ProtoField.uint8("acpv1.obj.enum.numitems",   "Num Items", base.DEC)
-local f_enum_default   = ProtoField.uint8("acpv1.obj.enum.default",    "Default Value", base.DEC)
-local f_enum_items     = ProtoField.string("acpv1.obj.enum.items",     "Item List")
+local f_enum_value     = ProtoField.uint8("dhs_acpv1.obj.enum.value",      "Value (index)", base.DEC)
+local f_enum_numitems  = ProtoField.uint8("dhs_acpv1.obj.enum.numitems",   "Num Items", base.DEC)
+local f_enum_default   = ProtoField.uint8("dhs_acpv1.obj.enum.default",    "Default Value", base.DEC)
+local f_enum_items     = ProtoField.string("dhs_acpv1.obj.enum.items",     "Item List")
 
 -- String
-local f_str_value      = ProtoField.string("acpv1.obj.str.value",      "Value")
-local f_str_maxlen     = ProtoField.uint8("acpv1.obj.str.maxlen",      "Max Length", base.DEC)
+local f_str_value      = ProtoField.string("dhs_acpv1.obj.str.value",      "Value")
+local f_str_maxlen     = ProtoField.uint8("dhs_acpv1.obj.str.maxlen",      "Max Length", base.DEC)
 
 -- Labels and units (shared)
-local f_label          = ProtoField.string("acpv1.obj.label",          "Label")
-local f_unit           = ProtoField.string("acpv1.obj.unit",           "Unit")
+local f_label          = ProtoField.string("dhs_acpv1.obj.label",          "Label")
+local f_unit           = ProtoField.string("dhs_acpv1.obj.unit",           "Unit")
 
 -- Frame status
-local f_frame_numslots = ProtoField.uint8("acpv1.obj.frame.numslots",  "Num Slots", base.DEC)
-local f_frame_slot     = ProtoField.uint8("acpv1.obj.frame.slot",      "Slot Status", base.DEC, slot_status_valstr)
+local f_frame_numslots = ProtoField.uint8("dhs_acpv1.obj.frame.numslots",  "Num Slots", base.DEC)
+local f_frame_slot     = ProtoField.uint8("dhs_acpv1.obj.frame.slot",      "Slot Status", base.DEC, slot_status_valstr)
 
 -- Alarm
-local f_alarm_priority = ProtoField.uint8("acpv1.obj.alarm.priority",  "Priority", base.DEC)
-local f_alarm_tag      = ProtoField.uint8("acpv1.obj.alarm.tag",       "Tag", base.DEC)
-local f_alarm_on_msg   = ProtoField.string("acpv1.obj.alarm.on_msg",   "Event On Message")
-local f_alarm_off_msg  = ProtoField.string("acpv1.obj.alarm.off_msg",  "Event Off Message")
+local f_alarm_priority = ProtoField.uint8("dhs_acpv1.obj.alarm.priority",  "Priority", base.DEC)
+local f_alarm_tag      = ProtoField.uint8("dhs_acpv1.obj.alarm.tag",       "Tag", base.DEC)
+local f_alarm_on_msg   = ProtoField.string("dhs_acpv1.obj.alarm.on_msg",   "Event On Message")
+local f_alarm_off_msg  = ProtoField.string("dhs_acpv1.obj.alarm.off_msg",  "Event Off Message")
 
 -- File
-local f_file_numfrags  = ProtoField.int16("acpv1.obj.file.numfrags",   "Num Fragments", base.DEC)
-local f_file_name      = ProtoField.string("acpv1.obj.file.name",      "File Name")
+local f_file_numfrags  = ProtoField.int16("dhs_acpv1.obj.file.numfrags",   "Num Fragments", base.DEC)
+local f_file_name      = ProtoField.string("dhs_acpv1.obj.file.name",      "File Name")
 
 acpv1.fields = {
     f_mlen,

--- a/internal/acp2/CLAUDE.md
+++ b/internal/acp2/CLAUDE.md
@@ -7,7 +7,7 @@ Authoritative specs:
 - `internal/acp2/assets/acp2_protocol.pdf`
 - `internal/acp2/assets/an2_protocol.pdf` (AN2 transport)
 
-Wireshark dissector (byte-exact reference): `./wireshark/dissector_acp2.lua`.
+Wireshark dissector (byte-exact reference): `./wireshark/dhs_acpv2.lua`.
 
 Viewer under test: Lawo VSM Axon Neuron driver. Spec-strict, no workarounds.
 
@@ -20,7 +20,7 @@ internal/acp2/
 ├── CLAUDE.md    ← this file
 ├── consumer/    package acp2 — implements protocol.Protocol
 ├── provider/    package acp2 — implements provider.Provider
-├── wireshark/   dissector_acp2.lua
+├── wireshark/   dhs_acpv2.lua
 ├── docs/        consumer.md / provider.md / README.md
 └── assets/      acp2_protocol.pdf + an2_protocol.pdf + demo_device.json
 ```

--- a/internal/acp2/assets/README.md
+++ b/internal/acp2/assets/README.md
@@ -23,7 +23,7 @@ See [CLAUDE.md](../../../CLAUDE.md) for the full ACP2 wire reference.
 
 - Spec: [acp2_protocol.pdf](acp2_protocol.pdf)
 - AN2 spec: [an2_protocol.pdf](an2_protocol.pdf)
-- Wireshark dissector: [dissector_acp2.lua](dissector_acp2.lua) — install per [docs/wireshark.md](../../docs/wireshark.md)
+- Wireshark dissector: [dhs_acpv2.lua](../wireshark/dhs_acpv2.lua) — install per [docs/wireshark.md](../../../docs/wireshark.md)
 - Full wire reference: [CLAUDE.md](../../CLAUDE.md) (ACP2 section)
 
 ---

--- a/internal/acp2/consumer/codec.go
+++ b/internal/acp2/consumer/codec.go
@@ -72,7 +72,7 @@ func EncodeACP2Message(m *ACP2Message) ([]byte, error) {
 
 	case ACP2FuncGetObject:
 		// get_object: header(4) + obj-id(4) + idx(4) = 12 bytes.
-		// Confirmed by Wireshark dissector (dissector_acp2.lua lines 301-307):
+		// Confirmed by Wireshark dissector (dhs_acpv2.lua lines 301-307):
 		// obj-id at offset 4, idx at offset 8 for both request and reply.
 		buf := make([]byte, ACP2HeaderSize+8)
 		buf[0] = byte(m.Type)

--- a/internal/acp2/consumer/types.go
+++ b/internal/acp2/consumer/types.go
@@ -6,7 +6,7 @@
 // frames with proto=2.
 //
 // Authoritative spec: internal/acp2/assets/acp2_protocol.pdf.
-// Cross-reference: CLAUDE.md ACP2 section, dissector_acp2.lua.
+// Cross-reference: CLAUDE.md ACP2 section, dhs_acpv2.lua.
 package acp2
 
 import "fmt"

--- a/internal/acp2/docs/README.md
+++ b/internal/acp2/docs/README.md
@@ -11,4 +11,4 @@
 |---|---|---|
 | ACP2 Protocol | [acp2_protocol.pdf](../../../internal/acp2/assets/acp2_protocol.pdf) | Full specification |
 | AN2 Transport | [an2_protocol.pdf](../../../internal/acp2/assets/an2_protocol.pdf) | Transport layer |
-| Wireshark dissector | [dissector_acp2.lua](../../../internal/acp2/assets/dissector_acp2.lua) | Byte-exact reference |
+| Wireshark dissector | [dhs_acpv2.lua](../../../internal/acp2/wireshark/dhs_acpv2.lua) | Byte-exact reference |

--- a/internal/acp2/docs/consumer.md
+++ b/internal/acp2/docs/consumer.md
@@ -10,7 +10,7 @@ Consumer connector for ACP v2 (Axon Neuron protocol) over AN2 transport.
 |---|---|---|
 | ACP2 spec (authoritative) | [internal/acp2/assets/acp2_protocol.pdf](../../../internal/acp2/assets/acp2_protocol.pdf) | ACP v2 full specification |
 | AN2 spec (authoritative) | [internal/acp2/assets/an2_protocol.pdf](../../../internal/acp2/assets/an2_protocol.pdf) | AN2 transport specification |
-| Wireshark dissector | [internal/acp2/assets/dissector_acp2.lua](../../../internal/acp2/assets/dissector_acp2.lua) | AN2 + ACP2 byte-exact reference |
+| Wireshark dissector | [internal/acp2/wireshark/dhs_acpv2.lua](../../../internal/acp2/wireshark/dhs_acpv2.lua) | AN2 + ACP2 byte-exact reference |
 | Protocol reference | [CLAUDE.md](../../../CLAUDE.md) — section "ACP2" | Wire format, functions, properties |
 | Testdata captures | [tests/fixtures/acp2/](../../../tests/fixtures/acp2/) | Raw JSONL captures from real device |
 | Export fixtures | [tests/fixtures/exports/acp2/](../../../tests/fixtures/exports/acp2/) | JSON/YAML/CSV per slot |

--- a/internal/acp2/testdata/protocol_types/README.md
+++ b/internal/acp2/testdata/protocol_types/README.md
@@ -3,7 +3,7 @@
 One slimmed capture + frozen tshark tree per ACP2 wire element, as defined
 by `internal/acp2/assets/acp2_protocol.pdf` (object types + functions +
 error codes) and the AN2 transport spec. The dissector under
-`internal/acp2/wireshark/dissector_acp2.lua` is expected to render every
+`internal/acp2/wireshark/dhs_acpv2.lua` is expected to render every
 element exactly as frozen — the parity test under
 `internal/acp2/consumer/fixture_parity_test.go` asserts that.
 
@@ -93,5 +93,5 @@ make fixtures-acp2
 ```
 
 Wireshark / tshark ≥ 4.x required. The dissector under
-`internal/acp2/wireshark/dissector_acp2.lua` must be installed in the
+`internal/acp2/wireshark/dhs_acpv2.lua` must be installed in the
 personal plugins dir (see [`docs/wireshark.md`](../../../../docs/wireshark.md)).

--- a/internal/acp2/testdata/protocol_types/announce/tshark.tree
+++ b/internal/acp2/testdata/protocol_types/announce/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 72 bytes on wire (576 bits), 72 bytes captured (576 bits) on in
     Capture Length: 72 bytes (576 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:an2_acp2:acp2_msg]
+    [Protocols in frame: null:ip:tcp:dhs_acpv2_an2:dhs_acpv2]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp2/testdata/protocol_types/enum/tshark.tree
+++ b/internal/acp2/testdata/protocol_types/enum/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 240 bytes on wire (1920 bits), 240 bytes captured (1920 bits) o
     Capture Length: 240 bytes (1920 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:an2_acp2:acp2_msg]
+    [Protocols in frame: null:ip:tcp:dhs_acpv2_an2:dhs_acpv2]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp2/testdata/protocol_types/error_invalid_idx/tshark.tree
+++ b/internal/acp2/testdata/protocol_types/error_invalid_idx/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 68 bytes on wire (544 bits), 68 bytes captured (544 bits) on in
     Capture Length: 68 bytes (544 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:an2_acp2:acp2_msg]
+    [Protocols in frame: null:ip:tcp:dhs_acpv2_an2:dhs_acpv2]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)
@@ -115,7 +115,7 @@ Frame 2: Packet, 60 bytes on wire (480 bits), 60 bytes captured (480 bits) on in
     Capture Length: 60 bytes (480 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:an2_acp2:acp2_msg]
+    [Protocols in frame: null:ip:tcp:dhs_acpv2_an2:dhs_acpv2]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp2/testdata/protocol_types/error_invalid_obj_id/tshark.tree
+++ b/internal/acp2/testdata/protocol_types/error_invalid_obj_id/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 68 bytes on wire (544 bits), 68 bytes captured (544 bits) on in
     Capture Length: 68 bytes (544 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:an2_acp2:acp2_msg]
+    [Protocols in frame: null:ip:tcp:dhs_acpv2_an2:dhs_acpv2]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)
@@ -115,7 +115,7 @@ Frame 2: Packet, 60 bytes on wire (480 bits), 60 bytes captured (480 bits) on in
     Capture Length: 60 bytes (480 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:an2_acp2:acp2_msg]
+    [Protocols in frame: null:ip:tcp:dhs_acpv2_an2:dhs_acpv2]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp2/testdata/protocol_types/error_invalid_pid/tshark.tree
+++ b/internal/acp2/testdata/protocol_types/error_invalid_pid/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 68 bytes on wire (544 bits), 68 bytes captured (544 bits) on in
     Capture Length: 68 bytes (544 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:an2_acp2:acp2_msg]
+    [Protocols in frame: null:ip:tcp:dhs_acpv2_an2:dhs_acpv2]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)
@@ -115,7 +115,7 @@ Frame 2: Packet, 60 bytes on wire (480 bits), 60 bytes captured (480 bits) on in
     Capture Length: 60 bytes (480 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:an2_acp2:acp2_msg]
+    [Protocols in frame: null:ip:tcp:dhs_acpv2_an2:dhs_acpv2]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp2/testdata/protocol_types/error_invalid_value/tshark.tree
+++ b/internal/acp2/testdata/protocol_types/error_invalid_value/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 72 bytes on wire (576 bits), 72 bytes captured (576 bits) on in
     Capture Length: 72 bytes (576 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:an2_acp2:acp2_msg]
+    [Protocols in frame: null:ip:tcp:dhs_acpv2_an2:dhs_acpv2]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)
@@ -121,7 +121,7 @@ Frame 2: Packet, 60 bytes on wire (480 bits), 60 bytes captured (480 bits) on in
     Capture Length: 60 bytes (480 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:an2_acp2:acp2_msg]
+    [Protocols in frame: null:ip:tcp:dhs_acpv2_an2:dhs_acpv2]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp2/testdata/protocol_types/error_no_access/tshark.tree
+++ b/internal/acp2/testdata/protocol_types/error_no_access/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 72 bytes on wire (576 bits), 72 bytes captured (576 bits) on in
     Capture Length: 72 bytes (576 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:an2_acp2:acp2_msg]
+    [Protocols in frame: null:ip:tcp:dhs_acpv2_an2:dhs_acpv2]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)
@@ -121,7 +121,7 @@ Frame 2: Packet, 60 bytes on wire (480 bits), 60 bytes captured (480 bits) on in
     Capture Length: 60 bytes (480 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:an2_acp2:acp2_msg]
+    [Protocols in frame: null:ip:tcp:dhs_acpv2_an2:dhs_acpv2]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp2/testdata/protocol_types/error_protocol/tshark.tree
+++ b/internal/acp2/testdata/protocol_types/error_protocol/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 56 bytes on wire (448 bits), 56 bytes captured (448 bits) on in
     Capture Length: 56 bytes (448 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:an2_acp2:acp2_msg]
+    [Protocols in frame: null:ip:tcp:dhs_acpv2_an2:dhs_acpv2]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)
@@ -112,7 +112,7 @@ Frame 2: Packet, 60 bytes on wire (480 bits), 60 bytes captured (480 bits) on in
     Capture Length: 60 bytes (480 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:an2_acp2:acp2_msg]
+    [Protocols in frame: null:ip:tcp:dhs_acpv2_an2:dhs_acpv2]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp2/testdata/protocol_types/get_object/tshark.tree
+++ b/internal/acp2/testdata/protocol_types/get_object/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 64 bytes on wire (512 bits), 64 bytes captured (512 bits) on in
     Capture Length: 64 bytes (512 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:an2_acp2:acp2_msg]
+    [Protocols in frame: null:ip:tcp:dhs_acpv2_an2:dhs_acpv2]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)
@@ -115,7 +115,7 @@ Frame 2: Packet, 136 bytes on wire (1088 bits), 136 bytes captured (1088 bits) o
     Capture Length: 136 bytes (1088 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:an2_acp2:acp2_msg]
+    [Protocols in frame: null:ip:tcp:dhs_acpv2_an2:dhs_acpv2]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp2/testdata/protocol_types/get_property/tshark.tree
+++ b/internal/acp2/testdata/protocol_types/get_property/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 68 bytes on wire (544 bits), 68 bytes captured (544 bits) on in
     Capture Length: 68 bytes (544 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:an2_acp2:acp2_msg]
+    [Protocols in frame: null:ip:tcp:dhs_acpv2_an2:dhs_acpv2]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)
@@ -115,7 +115,7 @@ Frame 2: Packet, 72 bytes on wire (576 bits), 72 bytes captured (576 bits) on in
     Capture Length: 72 bytes (576 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:an2_acp2:acp2_msg]
+    [Protocols in frame: null:ip:tcp:dhs_acpv2_an2:dhs_acpv2]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp2/testdata/protocol_types/get_version/tshark.tree
+++ b/internal/acp2/testdata/protocol_types/get_version/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 56 bytes on wire (448 bits), 56 bytes captured (448 bits) on in
     Capture Length: 56 bytes (448 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:an2_acp2:acp2_msg]
+    [Protocols in frame: null:ip:tcp:dhs_acpv2_an2:dhs_acpv2]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)
@@ -113,7 +113,7 @@ Frame 2: Packet, 56 bytes on wire (448 bits), 56 bytes captured (448 bits) on in
     Capture Length: 56 bytes (448 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:an2_acp2:acp2_msg]
+    [Protocols in frame: null:ip:tcp:dhs_acpv2_an2:dhs_acpv2]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp2/testdata/protocol_types/ipv4/tshark.tree
+++ b/internal/acp2/testdata/protocol_types/ipv4/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 92 bytes on wire (736 bits), 92 bytes captured (736 bits) on in
     Capture Length: 92 bytes (736 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:an2_acp2:acp2_msg]
+    [Protocols in frame: null:ip:tcp:dhs_acpv2_an2:dhs_acpv2]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp2/testdata/protocol_types/node/tshark.tree
+++ b/internal/acp2/testdata/protocol_types/node/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 116 bytes on wire (928 bits), 116 bytes captured (928 bits) on 
     Capture Length: 116 bytes (928 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:an2_acp2:acp2_msg]
+    [Protocols in frame: null:ip:tcp:dhs_acpv2_an2:dhs_acpv2]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp2/testdata/protocol_types/number/tshark.tree
+++ b/internal/acp2/testdata/protocol_types/number/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 136 bytes on wire (1088 bits), 136 bytes captured (1088 bits) o
     Capture Length: 136 bytes (1088 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:an2_acp2:acp2_msg]
+    [Protocols in frame: null:ip:tcp:dhs_acpv2_an2:dhs_acpv2]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp2/testdata/protocol_types/preset/tshark.tree
+++ b/internal/acp2/testdata/protocol_types/preset/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 148 bytes on wire (1184 bits), 148 bytes captured (1184 bits) o
     Capture Length: 148 bytes (1184 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:an2_acp2:acp2_msg]
+    [Protocols in frame: null:ip:tcp:dhs_acpv2_an2:dhs_acpv2]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp2/testdata/protocol_types/set_property/tshark.tree
+++ b/internal/acp2/testdata/protocol_types/set_property/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 72 bytes on wire (576 bits), 72 bytes captured (576 bits) on in
     Capture Length: 72 bytes (576 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:an2_acp2:acp2_msg]
+    [Protocols in frame: null:ip:tcp:dhs_acpv2_an2:dhs_acpv2]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)
@@ -121,7 +121,7 @@ Frame 2: Packet, 72 bytes on wire (576 bits), 72 bytes captured (576 bits) on in
     Capture Length: 72 bytes (576 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:an2_acp2:acp2_msg]
+    [Protocols in frame: null:ip:tcp:dhs_acpv2_an2:dhs_acpv2]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp2/testdata/protocol_types/string/tshark.tree
+++ b/internal/acp2/testdata/protocol_types/string/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 116 bytes on wire (928 bits), 116 bytes captured (928 bits) on 
     Capture Length: 116 bytes (928 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:an2_acp2:acp2_msg]
+    [Protocols in frame: null:ip:tcp:dhs_acpv2_an2:dhs_acpv2]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/acp2/wireshark/dhs_acpv2.lua
+++ b/internal/acp2/wireshark/dhs_acpv2.lua
@@ -177,25 +177,25 @@ local acp2_numtype_valstr = {
 -- Protocol declarations
 -------------------------------------------------------------------------------
 
-local an2_proto  = Proto("an2_acp2", "AN2 Transport (ACP2)")
-local acp2_proto = Proto("acp2_msg", "ACP2 Protocol")
-local acp2_prop_proto = Proto("acp2_prop", "ACP2 Property")
+local an2_proto  = Proto("dhs_acpv2_an2",  "AN2 Transport (ACP2)")
+local acp2_proto = Proto("dhs_acpv2",      "ACP2 Protocol")
+local acp2_prop_proto = Proto("dhs_acpv2_prop", "ACP2 Property")
 
 -------------------------------------------------------------------------------
 -- AN2 ProtoFields
 -------------------------------------------------------------------------------
 
 local an2_f = {
-    magic = ProtoField.uint16("an2.magic",  "Magic",    base.HEX),
-    proto = ProtoField.uint8 ("an2.proto",  "Protocol", base.DEC, an2_proto_valstr),
-    slot  = ProtoField.uint8 ("an2.slot",   "Slot",     base.DEC),
-    mtid  = ProtoField.uint8 ("an2.mtid",   "MTID",     base.DEC),
-    type  = ProtoField.uint8 ("an2.type",   "Type",     base.DEC, an2_type_valstr),
-    dlen  = ProtoField.uint16("an2.dlen",   "Data Length", base.DEC),
+    magic = ProtoField.uint16("dhs_acpv2_an2.magic",  "Magic",    base.HEX),
+    proto = ProtoField.uint8 ("dhs_acpv2_an2.proto",  "Protocol", base.DEC, an2_proto_valstr),
+    slot  = ProtoField.uint8 ("dhs_acpv2_an2.slot",   "Slot",     base.DEC),
+    mtid  = ProtoField.uint8 ("dhs_acpv2_an2.mtid",   "MTID",     base.DEC),
+    type  = ProtoField.uint8 ("dhs_acpv2_an2.type",   "Type",     base.DEC, an2_type_valstr),
+    dlen  = ProtoField.uint16("dhs_acpv2_an2.dlen",   "Data Length", base.DEC),
     -- AN2 internal fields
-    func     = ProtoField.uint8 ("an2.func",     "Function",  base.DEC, an2_func_valstr),
-    version  = ProtoField.uint8 ("an2.version",  "Version",   base.DEC),
-    payload  = ProtoField.bytes ("an2.payload",  "Payload"),
+    func     = ProtoField.uint8 ("dhs_acpv2_an2.func",     "Function",  base.DEC, an2_func_valstr),
+    version  = ProtoField.uint8 ("dhs_acpv2_an2.version",  "Version",   base.DEC),
+    payload  = ProtoField.bytes ("dhs_acpv2_an2.payload",  "Payload"),
 }
 an2_proto.fields = an2_f
 
@@ -204,15 +204,15 @@ an2_proto.fields = an2_f
 -------------------------------------------------------------------------------
 
 local acp2_f = {
-    type    = ProtoField.uint8 ("acp2.type",   "Type",     base.DEC, acp2_type_valstr),
-    mtid    = ProtoField.uint8 ("acp2.mtid",   "MTID",     base.DEC),
-    func    = ProtoField.uint8 ("acp2.func",   "Function", base.DEC, acp2_func_valstr),
-    stat    = ProtoField.uint8 ("acp2.stat",   "Status",   base.DEC, acp2_error_valstr),
-    pid     = ProtoField.uint8 ("acp2.pid",    "PID",      base.DEC, acp2_pid_valstr),
-    pad     = ProtoField.uint8 ("acp2.pad",    "Padding",  base.HEX),
-    version = ProtoField.uint8 ("acp2.version","Version",  base.DEC),
-    obj_id  = ProtoField.uint32("acp2.obj_id", "Object ID",base.DEC),
-    idx     = ProtoField.uint32("acp2.idx",    "Index",    base.DEC),
+    type    = ProtoField.uint8 ("dhs_acpv2.type",   "Type",     base.DEC, acp2_type_valstr),
+    mtid    = ProtoField.uint8 ("dhs_acpv2.mtid",   "MTID",     base.DEC),
+    func    = ProtoField.uint8 ("dhs_acpv2.func",   "Function", base.DEC, acp2_func_valstr),
+    stat    = ProtoField.uint8 ("dhs_acpv2.stat",   "Status",   base.DEC, acp2_error_valstr),
+    pid     = ProtoField.uint8 ("dhs_acpv2.pid",    "PID",      base.DEC, acp2_pid_valstr),
+    pad     = ProtoField.uint8 ("dhs_acpv2.pad",    "Padding",  base.HEX),
+    version = ProtoField.uint8 ("dhs_acpv2.version","Version",  base.DEC),
+    obj_id  = ProtoField.uint32("dhs_acpv2.obj_id", "Object ID",base.DEC),
+    idx     = ProtoField.uint32("dhs_acpv2.idx",    "Index",    base.DEC),
 }
 acp2_proto.fields = acp2_f
 
@@ -221,32 +221,32 @@ acp2_proto.fields = acp2_f
 -------------------------------------------------------------------------------
 
 local prop_f = {
-    pid       = ProtoField.uint8 ("acp2.prop.pid",       "Property ID",      base.DEC, acp2_pid_valstr),
-    data_byte = ProtoField.uint8 ("acp2.prop.data",      "Data/VType",       base.DEC),
-    plen      = ProtoField.uint16("acp2.prop.plen",      "Length (plen)",    base.DEC),
-    padding   = ProtoField.bytes ("acp2.prop.padding",   "Alignment Padding"),
+    pid       = ProtoField.uint8 ("dhs_acpv2.prop.pid",       "Property ID",      base.DEC, acp2_pid_valstr),
+    data_byte = ProtoField.uint8 ("dhs_acpv2.prop.data",      "Data/VType",       base.DEC),
+    plen      = ProtoField.uint16("dhs_acpv2.prop.plen",      "Length (plen)",    base.DEC),
+    padding   = ProtoField.bytes ("dhs_acpv2.prop.padding",   "Alignment Padding"),
     -- typed value fields
-    obj_type  = ProtoField.uint8 ("acp2.prop.obj_type",  "Object Type",   base.DEC, acp2_objtype_valstr),
-    access    = ProtoField.uint8 ("acp2.prop.access",    "Access",        base.DEC, acp2_access_valstr),
-    numtype   = ProtoField.uint8 ("acp2.prop.numtype",   "Number Type",   base.DEC, acp2_numtype_valstr),
-    delay     = ProtoField.uint32("acp2.prop.delay",     "Announce Delay (ms)", base.DEC),
-    strmax    = ProtoField.uint16("acp2.prop.strmax",    "String Max Length",   base.DEC),
-    val_s32   = ProtoField.int32 ("acp2.prop.val_s32",   "Value (s32)",   base.DEC),
-    val_u32   = ProtoField.uint32("acp2.prop.val_u32",   "Value (u32)",   base.DEC),
-    val_s64   = ProtoField.int64 ("acp2.prop.val_s64",   "Value (s64)",   base.DEC),
-    val_u64   = ProtoField.uint64("acp2.prop.val_u64",   "Value (u64)",   base.DEC),
-    val_float = ProtoField.float ("acp2.prop.val_float", "Value (float)"),
-    val_ipv4  = ProtoField.ipv4  ("acp2.prop.val_ipv4",  "Value (IPv4)"),
-    val_str   = ProtoField.string("acp2.prop.val_str",   "Value (string)"),
-    child_id  = ProtoField.uint32("acp2.prop.child_id",  "Child Object ID", base.DEC),
-    opt_idx   = ProtoField.uint32("acp2.prop.opt_idx",   "Option Index",    base.DEC),
-    opt_str   = ProtoField.string("acp2.prop.opt_str",   "Option String"),
-    tag       = ProtoField.uint16("acp2.prop.tag",       "Event Tag",     base.DEC),
-    prio      = ProtoField.uint8 ("acp2.prop.prio",      "Event Priority",base.DEC),
-    state     = ProtoField.uint8 ("acp2.prop.state",     "Event State",   base.DEC),
-    parent_id = ProtoField.uint32("acp2.prop.parent_id", "Preset Parent", base.DEC),
-    depth_val = ProtoField.uint32("acp2.prop.depth_val", "Preset Index",  base.DEC),
-    raw       = ProtoField.bytes ("acp2.prop.raw",       "Raw Value"),
+    obj_type  = ProtoField.uint8 ("dhs_acpv2.prop.obj_type",  "Object Type",   base.DEC, acp2_objtype_valstr),
+    access    = ProtoField.uint8 ("dhs_acpv2.prop.access",    "Access",        base.DEC, acp2_access_valstr),
+    numtype   = ProtoField.uint8 ("dhs_acpv2.prop.numtype",   "Number Type",   base.DEC, acp2_numtype_valstr),
+    delay     = ProtoField.uint32("dhs_acpv2.prop.delay",     "Announce Delay (ms)", base.DEC),
+    strmax    = ProtoField.uint16("dhs_acpv2.prop.strmax",    "String Max Length",   base.DEC),
+    val_s32   = ProtoField.int32 ("dhs_acpv2.prop.val_s32",   "Value (s32)",   base.DEC),
+    val_u32   = ProtoField.uint32("dhs_acpv2.prop.val_u32",   "Value (u32)",   base.DEC),
+    val_s64   = ProtoField.int64 ("dhs_acpv2.prop.val_s64",   "Value (s64)",   base.DEC),
+    val_u64   = ProtoField.uint64("dhs_acpv2.prop.val_u64",   "Value (u64)",   base.DEC),
+    val_float = ProtoField.float ("dhs_acpv2.prop.val_float", "Value (float)"),
+    val_ipv4  = ProtoField.ipv4  ("dhs_acpv2.prop.val_ipv4",  "Value (IPv4)"),
+    val_str   = ProtoField.string("dhs_acpv2.prop.val_str",   "Value (string)"),
+    child_id  = ProtoField.uint32("dhs_acpv2.prop.child_id",  "Child Object ID", base.DEC),
+    opt_idx   = ProtoField.uint32("dhs_acpv2.prop.opt_idx",   "Option Index",    base.DEC),
+    opt_str   = ProtoField.string("dhs_acpv2.prop.opt_str",   "Option String"),
+    tag       = ProtoField.uint16("dhs_acpv2.prop.tag",       "Event Tag",     base.DEC),
+    prio      = ProtoField.uint8 ("dhs_acpv2.prop.prio",      "Event Priority",base.DEC),
+    state     = ProtoField.uint8 ("dhs_acpv2.prop.state",     "Event State",   base.DEC),
+    parent_id = ProtoField.uint32("dhs_acpv2.prop.parent_id", "Preset Parent", base.DEC),
+    depth_val = ProtoField.uint32("dhs_acpv2.prop.depth_val", "Preset Index",  base.DEC),
+    raw       = ProtoField.bytes ("dhs_acpv2.prop.raw",       "Raw Value"),
 }
 acp2_prop_proto.fields = prop_f
 

--- a/internal/emberplus/CLAUDE.md
+++ b/internal/emberplus/CLAUDE.md
@@ -8,7 +8,7 @@ Authoritative refs:
 - `internal/emberplus/assets/Ember+ Documentation.pdf`
 - `internal/emberplus/assets/Ember+ Formulas.pdf`
 
-Wireshark dissector: `./wireshark/dissector_emberplus.lua`.
+Wireshark dissector: `./wireshark/dhs_emberplus.lua`.
 
 Testbed emulator: `internal/emberplus/assets/smh/` (BY-RESEARCH TS emulator, port 9000/9090/9092);
 convention — targets labeled `1`, sources labeled `2`.
@@ -27,7 +27,7 @@ internal/emberplus/
 │   └── matrix/  matrix/target/source encoder helpers
 ├── consumer/    package emberplus — implements protocol.Protocol
 ├── provider/    package emberplus — implements provider.Provider
-├── wireshark/   dissector_emberplus.lua
+├── wireshark/   dhs_emberplus.lua
 ├── docs/        consumer.md / provider.md / README.md
 └── assets/      Ember+ PDFs + TinyEmberPlus/EmberPlusView tools + smh/ TS lib
 ```

--- a/internal/emberplus/assets/README.md
+++ b/internal/emberplus/assets/README.md
@@ -57,7 +57,7 @@ for the full spec.
 
 - Spec: [Ember+ Documentation.pdf](Ember%2B%20Documentation.pdf)
 - Formulas reference: [Ember+ Formulas.pdf](Ember%2B%20Formulas.pdf)
-- Wireshark dissector: [dissector_emberplus.lua](dissector_emberplus.lua) — install per [docs/wireshark.md](../../docs/wireshark.md)
+- Wireshark dissector: [dhs_emberplus.lua](../wireshark/dhs_emberplus.lua) — install per [docs/wireshark.md](../../../docs/wireshark.md)
 - Canonical schema: [internal/emberplus/docs/consumer.md](../../internal/emberplus/docs/consumer.md)
 
 ---

--- a/internal/emberplus/testdata/protocol_types/command_get_directory/tshark.tree
+++ b/internal/emberplus/testdata/protocol_types/command_get_directory/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 97 bytes on wire (776 bits), 97 bytes captured (776 bits) on in
     Capture Length: 97 bytes (776 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:emberplus]
+    [Protocols in frame: null:ip:tcp:dhs_emberplus]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/emberplus/testdata/protocol_types/command_subscribe/tshark.tree
+++ b/internal/emberplus/testdata/protocol_types/command_subscribe/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 122 bytes on wire (976 bits), 122 bytes captured (976 bits) on 
     Capture Length: 122 bytes (976 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:emberplus]
+    [Protocols in frame: null:ip:tcp:dhs_emberplus]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/emberplus/testdata/protocol_types/command_unsubscribe/tshark.tree
+++ b/internal/emberplus/testdata/protocol_types/command_unsubscribe/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 122 bytes on wire (976 bits), 122 bytes captured (976 bits) on 
     Capture Length: 122 bytes (976 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:emberplus]
+    [Protocols in frame: null:ip:tcp:dhs_emberplus]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/emberplus/testdata/protocol_types/function_invoke/tshark.tree
+++ b/internal/emberplus/testdata/protocol_types/function_invoke/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 132 bytes on wire (1056 bits), 132 bytes captured (1056 bits) o
     Capture Length: 132 bytes (1056 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:emberplus]
+    [Protocols in frame: null:ip:tcp:dhs_emberplus]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/emberplus/testdata/protocol_types/invocation_result/tshark.tree
+++ b/internal/emberplus/testdata/protocol_types/invocation_result/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 75 bytes on wire (600 bits), 75 bytes captured (600 bits) on in
     Capture Length: 75 bytes (600 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:emberplus]
+    [Protocols in frame: null:ip:tcp:dhs_emberplus]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/emberplus/testdata/protocol_types/label/tshark.tree
+++ b/internal/emberplus/testdata/protocol_types/label/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 202 bytes on wire (1616 bits), 202 bytes captured (1616 bits) o
     Capture Length: 202 bytes (1616 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:emberplus]
+    [Protocols in frame: null:ip:tcp:dhs_emberplus]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/emberplus/testdata/protocol_types/matrix/tshark.tree
+++ b/internal/emberplus/testdata/protocol_types/matrix/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 114 bytes on wire (912 bits), 114 bytes captured (912 bits) on 
     Capture Length: 114 bytes (912 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:emberplus]
+    [Protocols in frame: null:ip:tcp:dhs_emberplus]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/emberplus/testdata/protocol_types/matrix_connection/tshark.tree
+++ b/internal/emberplus/testdata/protocol_types/matrix_connection/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 114 bytes on wire (912 bits), 114 bytes captured (912 bits) on 
     Capture Length: 114 bytes (912 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:emberplus]
+    [Protocols in frame: null:ip:tcp:dhs_emberplus]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/emberplus/testdata/protocol_types/parameter/tshark.tree
+++ b/internal/emberplus/testdata/protocol_types/parameter/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 105 bytes on wire (840 bits), 105 bytes captured (840 bits) on 
     Capture Length: 105 bytes (840 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:emberplus]
+    [Protocols in frame: null:ip:tcp:dhs_emberplus]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/emberplus/testdata/protocol_types/qualified_matrix/tshark.tree
+++ b/internal/emberplus/testdata/protocol_types/qualified_matrix/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 95 bytes on wire (760 bits), 95 bytes captured (760 bits) on in
     Capture Length: 95 bytes (760 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:emberplus]
+    [Protocols in frame: null:ip:tcp:dhs_emberplus]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/emberplus/testdata/protocol_types/qualified_node/tshark.tree
+++ b/internal/emberplus/testdata/protocol_types/qualified_node/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 146 bytes on wire (1168 bits), 146 bytes captured (1168 bits) o
     Capture Length: 146 bytes (1168 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:emberplus]
+    [Protocols in frame: null:ip:tcp:dhs_emberplus]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/emberplus/testdata/protocol_types/qualified_parameter/tshark.tree
+++ b/internal/emberplus/testdata/protocol_types/qualified_parameter/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 225 bytes on wire (1800 bits), 225 bytes captured (1800 bits) o
     Capture Length: 225 bytes (1800 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:emberplus]
+    [Protocols in frame: null:ip:tcp:dhs_emberplus]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/emberplus/testdata/protocol_types/root_node/tshark.tree
+++ b/internal/emberplus/testdata/protocol_types/root_node/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 149 bytes on wire (1192 bits), 149 bytes captured (1192 bits) o
     Capture Length: 149 bytes (1192 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:emberplus]
+    [Protocols in frame: null:ip:tcp:dhs_emberplus]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/emberplus/testdata/protocol_types/stream_collection/tshark.tree
+++ b/internal/emberplus/testdata/protocol_types/stream_collection/tshark.tree
@@ -14,7 +14,7 @@ Frame 1: Packet, 136 bytes on wire (1088 bits), 136 bytes captured (1088 bits) o
     Capture Length: 136 bytes (1088 bits)
     [Frame is marked: False]
     [Frame is ignored: False]
-    [Protocols in frame: null:ip:tcp:emberplus]
+    [Protocols in frame: null:ip:tcp:dhs_emberplus]
     Character encoding: ASCII (0)
 Null/Loopback
     Family: IP (2)

--- a/internal/emberplus/wireshark/dhs_emberplus.lua
+++ b/internal/emberplus/wireshark/dhs_emberplus.lua
@@ -398,28 +398,28 @@ local contents_scope_by_app = {
 -- Protocol declarations
 -------------------------------------------------------------------------------
 
-local s101_proto = Proto("emberplus",      "Ember+ (S101)")
-local glow_proto = Proto("emberplus_glow", "Ember+ Glow BER")
+local s101_proto = Proto("dhs_emberplus",      "Ember+ (S101)")
+local glow_proto = Proto("dhs_emberplus_glow", "Ember+ Glow BER")
 
 -------------------------------------------------------------------------------
 -- ProtoFields
 -------------------------------------------------------------------------------
 
 local s101_f = {
-    bof      = ProtoField.uint8 ("emberplus.s101.bof",     "BoF",      base.HEX),
-    eof      = ProtoField.uint8 ("emberplus.s101.eof",     "EoF",      base.HEX),
-    slot     = ProtoField.uint8 ("emberplus.s101.slot",    "Slot",     base.DEC),
-    msgtype  = ProtoField.uint8 ("emberplus.s101.msgtype", "Msg Type", base.HEX, s101_msgtype_valstr),
-    command  = ProtoField.uint8 ("emberplus.s101.command", "Command",  base.HEX, s101_cmd_valstr),
-    version  = ProtoField.uint8 ("emberplus.s101.version", "Version",  base.DEC),
-    flags    = ProtoField.uint8 ("emberplus.s101.flags",   "Flags",    base.HEX, s101_flags_valstr),
-    dtd      = ProtoField.uint8 ("emberplus.s101.dtd",     "DTD Type", base.HEX, s101_dtd_valstr),
-    appblen  = ProtoField.uint8 ("emberplus.s101.applen",  "App Bytes Length", base.DEC),
-    appbytes = ProtoField.bytes ("emberplus.s101.appbytes","App Bytes"),
-    crc      = ProtoField.uint16("emberplus.s101.crc",     "CRC",      base.HEX),
-    crc_status = ProtoField.string("emberplus.s101.crc_status", "CRC Status"),
-    escaped  = ProtoField.bytes ("emberplus.s101.escaped", "Escaped Payload"),
-    unescaped= ProtoField.bytes ("emberplus.s101.unescaped","Unescaped Content"),
+    bof      = ProtoField.uint8 ("dhs_emberplus.s101.bof",     "BoF",      base.HEX),
+    eof      = ProtoField.uint8 ("dhs_emberplus.s101.eof",     "EoF",      base.HEX),
+    slot     = ProtoField.uint8 ("dhs_emberplus.s101.slot",    "Slot",     base.DEC),
+    msgtype  = ProtoField.uint8 ("dhs_emberplus.s101.msgtype", "Msg Type", base.HEX, s101_msgtype_valstr),
+    command  = ProtoField.uint8 ("dhs_emberplus.s101.command", "Command",  base.HEX, s101_cmd_valstr),
+    version  = ProtoField.uint8 ("dhs_emberplus.s101.version", "Version",  base.DEC),
+    flags    = ProtoField.uint8 ("dhs_emberplus.s101.flags",   "Flags",    base.HEX, s101_flags_valstr),
+    dtd      = ProtoField.uint8 ("dhs_emberplus.s101.dtd",     "DTD Type", base.HEX, s101_dtd_valstr),
+    appblen  = ProtoField.uint8 ("dhs_emberplus.s101.applen",  "App Bytes Length", base.DEC),
+    appbytes = ProtoField.bytes ("dhs_emberplus.s101.appbytes","App Bytes"),
+    crc      = ProtoField.uint16("dhs_emberplus.s101.crc",     "CRC",      base.HEX),
+    crc_status = ProtoField.string("dhs_emberplus.s101.crc_status", "CRC Status"),
+    escaped  = ProtoField.bytes ("dhs_emberplus.s101.escaped", "Escaped Payload"),
+    unescaped= ProtoField.bytes ("dhs_emberplus.s101.unescaped","Unescaped Content"),
 }
 s101_proto.fields = s101_f
 
@@ -428,20 +428,20 @@ s101_proto.fields = s101_f
 -- uses its own BER sub-encoding). Raw bytes are still attached separately
 -- for binary inspection.
 local glow_f = {
-    tag_class = ProtoField.uint8 ("emberplus.glow.class",    "Class",     base.DEC, ber_class_valstr),
-    tag_cons  = ProtoField.bool  ("emberplus.glow.constructed","Constructed"),
-    tag_num   = ProtoField.uint32("emberplus.glow.tag_num",  "Tag Number",base.DEC),
-    tag_name  = ProtoField.string("emberplus.glow.tag_name", "Tag Name"),
-    length    = ProtoField.uint32("emberplus.glow.length",   "Length",    base.DEC),
-    length_indef = ProtoField.bool ("emberplus.glow.length_indef", "Indefinite Length"),
-    value_int   = ProtoField.string("emberplus.glow.int",    "Value (int)"),
-    value_bool  = ProtoField.string("emberplus.glow.bool",   "Value (bool)"),
-    value_real  = ProtoField.string("emberplus.glow.real",   "Value (real)"),
-    value_utf8  = ProtoField.string("emberplus.glow.utf8",   "Value (UTF-8)"),
-    value_oid   = ProtoField.string("emberplus.glow.reloid", "Value (RELATIVE-OID)"),
-    value_null  = ProtoField.string("emberplus.glow.null",   "Value (NULL)"),
-    value_octets= ProtoField.bytes ("emberplus.glow.octets", "Value (octets)"),
-    value_raw   = ProtoField.bytes ("emberplus.glow.raw",    "Value (raw)"),
+    tag_class = ProtoField.uint8 ("dhs_emberplus.glow.class",    "Class",     base.DEC, ber_class_valstr),
+    tag_cons  = ProtoField.bool  ("dhs_emberplus.glow.constructed","Constructed"),
+    tag_num   = ProtoField.uint32("dhs_emberplus.glow.tag_num",  "Tag Number",base.DEC),
+    tag_name  = ProtoField.string("dhs_emberplus.glow.tag_name", "Tag Name"),
+    length    = ProtoField.uint32("dhs_emberplus.glow.length",   "Length",    base.DEC),
+    length_indef = ProtoField.bool ("dhs_emberplus.glow.length_indef", "Indefinite Length"),
+    value_int   = ProtoField.string("dhs_emberplus.glow.int",    "Value (int)"),
+    value_bool  = ProtoField.string("dhs_emberplus.glow.bool",   "Value (bool)"),
+    value_real  = ProtoField.string("dhs_emberplus.glow.real",   "Value (real)"),
+    value_utf8  = ProtoField.string("dhs_emberplus.glow.utf8",   "Value (UTF-8)"),
+    value_oid   = ProtoField.string("dhs_emberplus.glow.reloid", "Value (RELATIVE-OID)"),
+    value_null  = ProtoField.string("dhs_emberplus.glow.null",   "Value (NULL)"),
+    value_octets= ProtoField.bytes ("dhs_emberplus.glow.octets", "Value (octets)"),
+    value_raw   = ProtoField.bytes ("dhs_emberplus.glow.raw",    "Value (raw)"),
 }
 glow_proto.fields = glow_f
 

--- a/internal/probel-sw08p/CLAUDE.md
+++ b/internal/probel-sw08p/CLAUDE.md
@@ -218,7 +218,7 @@ See root `CLAUDE.md` "Metrics surface on the producer" section +
 ### Session 2026-04-23 closeout (post-compact)
 
 - **W2 (commit `9bf57f3`)** — Wireshark Lua dissector at
-  `wireshark/dissector_probel_sw08p.lua`. Handles §2 framing + DLE
+  `wireshark/dhs_probel_sw08p.lua`. Handles §2 framing + DLE
   stuffing, DLE ACK/NAK pseudo-frames, checksum + BTC validation with
   expert-info notes, and per-cmd decode for crosspoint interrogate /
   connect / tally / tally-dump (byte + word) / name requests + responses

--- a/internal/probel-sw08p/wireshark/dhs_probel_sw08p.lua
+++ b/internal/probel-sw08p/wireshark/dhs_probel_sw08p.lua
@@ -168,49 +168,49 @@ local protect_state_valstr = {
 -- Protocol declaration
 -------------------------------------------------------------------------------
 
-local p_probel = Proto("probel_sw08p", "Probel SW-P-08/88")
+local p_probel = Proto("dhs_probel_sw08p", "Probel SW-P-08/88")
 
 local f = {
-    som        = ProtoField.bytes  ("probel.som",        "Start-of-Message (DLE STX)"),
-    eom        = ProtoField.bytes  ("probel.eom",        "End-of-Message (DLE ETX)"),
-    data       = ProtoField.bytes  ("probel.data",       "DATA (unescaped)"),
-    raw        = ProtoField.bytes  ("probel.raw",        "Raw frame (on-wire, escaped)"),
-    cmd        = ProtoField.uint8  ("probel.cmd",        "Command",      base.HEX, cmd_name),
-    cmd_dec    = ProtoField.uint8  ("probel.cmd_dec",    "Command (dec)",base.DEC),
-    btc        = ProtoField.uint8  ("probel.btc",        "Byte Count",   base.DEC),
-    chk        = ProtoField.uint8  ("probel.chk",        "Checksum",     base.HEX),
-    chk_good   = ProtoField.bool   ("probel.chk_good",   "Checksum OK"),
-    chk_calc   = ProtoField.uint8  ("probel.chk_calc",   "Checksum (calc)", base.HEX),
-    btc_good   = ProtoField.bool   ("probel.btc_good",   "BTC OK"),
-    extended   = ProtoField.bool   ("probel.extended",   "Extended command"),
-    matrix     = ProtoField.uint8  ("probel.matrix",     "Matrix ID",    base.DEC),
-    level      = ProtoField.uint8  ("probel.level",      "Level ID",     base.DEC),
-    dst        = ProtoField.uint16 ("probel.dst",        "Destination",  base.DEC),
-    src        = ProtoField.uint16 ("probel.src",        "Source",       base.DEC),
-    first_dst  = ProtoField.uint16 ("probel.first_dst",  "First Destination",  base.DEC),
-    first_src  = ProtoField.uint16 ("probel.first_src",  "First Source",       base.DEC),
-    tally_n    = ProtoField.uint16 ("probel.tallies",    "Tallies",      base.DEC),
-    namelen    = ProtoField.uint8  ("probel.namelen",    "Name Length",  base.DEC, namelen_valstr),
-    name_count = ProtoField.uint8  ("probel.names",      "Names",        base.DEC),
-    name_item  = ProtoField.string ("probel.name",       "Name"),
-    protect    = ProtoField.uint8  ("probel.protect",    "Protect State",base.DEC, protect_state_valstr),
-    status     = ProtoField.uint8  ("probel.status",     "Status",       base.HEX),
-    salvo_grp  = ProtoField.uint16 ("probel.salvo.grp",  "Salvo Group",  base.DEC),
-    salvo_cnt  = ProtoField.uint16 ("probel.salvo.count","Salvo Elements",base.DEC),
-    payload    = ProtoField.bytes  ("probel.payload",    "Payload"),
-    ackframe   = ProtoField.bool   ("probel.ack",        "DLE ACK"),
-    nakframe   = ProtoField.bool   ("probel.nak",        "DLE NAK"),
+    som        = ProtoField.bytes  ("dhs_probel_sw08p.som",        "Start-of-Message (DLE STX)"),
+    eom        = ProtoField.bytes  ("dhs_probel_sw08p.eom",        "End-of-Message (DLE ETX)"),
+    data       = ProtoField.bytes  ("dhs_probel_sw08p.data",       "DATA (unescaped)"),
+    raw        = ProtoField.bytes  ("dhs_probel_sw08p.raw",        "Raw frame (on-wire, escaped)"),
+    cmd        = ProtoField.uint8  ("dhs_probel_sw08p.cmd",        "Command",      base.HEX, cmd_name),
+    cmd_dec    = ProtoField.uint8  ("dhs_probel_sw08p.cmd_dec",    "Command (dec)",base.DEC),
+    btc        = ProtoField.uint8  ("dhs_probel_sw08p.btc",        "Byte Count",   base.DEC),
+    chk        = ProtoField.uint8  ("dhs_probel_sw08p.chk",        "Checksum",     base.HEX),
+    chk_good   = ProtoField.bool   ("dhs_probel_sw08p.chk_good",   "Checksum OK"),
+    chk_calc   = ProtoField.uint8  ("dhs_probel_sw08p.chk_calc",   "Checksum (calc)", base.HEX),
+    btc_good   = ProtoField.bool   ("dhs_probel_sw08p.btc_good",   "BTC OK"),
+    extended   = ProtoField.bool   ("dhs_probel_sw08p.extended",   "Extended command"),
+    matrix     = ProtoField.uint8  ("dhs_probel_sw08p.matrix",     "Matrix ID",    base.DEC),
+    level      = ProtoField.uint8  ("dhs_probel_sw08p.level",      "Level ID",     base.DEC),
+    dst        = ProtoField.uint16 ("dhs_probel_sw08p.dst",        "Destination",  base.DEC),
+    src        = ProtoField.uint16 ("dhs_probel_sw08p.src",        "Source",       base.DEC),
+    first_dst  = ProtoField.uint16 ("dhs_probel_sw08p.first_dst",  "First Destination",  base.DEC),
+    first_src  = ProtoField.uint16 ("dhs_probel_sw08p.first_src",  "First Source",       base.DEC),
+    tally_n    = ProtoField.uint16 ("dhs_probel_sw08p.tallies",    "Tallies",      base.DEC),
+    namelen    = ProtoField.uint8  ("dhs_probel_sw08p.namelen",    "Name Length",  base.DEC, namelen_valstr),
+    name_count = ProtoField.uint8  ("dhs_probel_sw08p.names",      "Names",        base.DEC),
+    name_item  = ProtoField.string ("dhs_probel_sw08p.name",       "Name"),
+    protect    = ProtoField.uint8  ("dhs_probel_sw08p.protect",    "Protect State",base.DEC, protect_state_valstr),
+    status     = ProtoField.uint8  ("dhs_probel_sw08p.status",     "Status",       base.HEX),
+    salvo_grp  = ProtoField.uint16 ("dhs_probel_sw08p.salvo.grp",  "Salvo Group",  base.DEC),
+    salvo_cnt  = ProtoField.uint16 ("dhs_probel_sw08p.salvo.count","Salvo Elements",base.DEC),
+    payload    = ProtoField.bytes  ("dhs_probel_sw08p.payload",    "Payload"),
+    ackframe   = ProtoField.bool   ("dhs_probel_sw08p.ack",        "DLE ACK"),
+    nakframe   = ProtoField.bool   ("dhs_probel_sw08p.nak",        "DLE NAK"),
 }
 p_probel.fields = f
 
 -- Expert infos
-local ef_bad_chk = ProtoExpert.new("probel.bad_checksum.expert",
+local ef_bad_chk = ProtoExpert.new("dhs_probel_sw08p.bad_checksum.expert",
     "Checksum mismatch", expert.group.CHECKSUM, expert.severity.ERROR)
-local ef_bad_btc = ProtoExpert.new("probel.bad_btc.expert",
+local ef_bad_btc = ProtoExpert.new("dhs_probel_sw08p.bad_btc.expert",
     "BTC mismatch", expert.group.MALFORMED, expert.severity.ERROR)
-local ef_nak = ProtoExpert.new("probel.nak.expert",
+local ef_nak = ProtoExpert.new("dhs_probel_sw08p.nak.expert",
     "Peer NAK", expert.group.RESPONSE_CODE, expert.severity.NOTE)
-local ef_unsupported = ProtoExpert.new("probel.unsupported.expert",
+local ef_unsupported = ProtoExpert.new("dhs_probel_sw08p.unsupported.expert",
     "Unknown command byte", expert.group.PROTOCOL, expert.severity.NOTE)
 p_probel.experts = { ef_bad_chk, ef_bad_btc, ef_nak, ef_unsupported }
 

--- a/runbook.md
+++ b/runbook.md
@@ -223,15 +223,19 @@ When touching the ACP1 codec, capture real traffic and compare bytes
 against your unit-test expectations.
 
 1. Install Wireshark (see section 1).
-2. Copy the Lua dissectors from `assets/` to your Wireshark init path:
-   - Windows: `%APPDATA%\Wireshark\init.lua`
-3. Append:
-   ```lua
-   local axon_dir = "C:/Users/BY-SYSTEMSSRLBoujraf/Downloads/acp/assets/"
-   dofile(axon_dir .. "dissector_acpv1.lua")
-   dofile(axon_dir .. "dissector_acp2.lua")
-   ```
-4. Capture on your device-facing interface, filter `udp.port == 2071 || tcp.port == 2071 || tcp.port == 2072`.
+2. Copy each plugin's Lua dissector into your Wireshark personal plugins
+   directory (`%APPDATA%\Wireshark\plugins\` on Windows,
+   `~/.local/lib/wireshark/plugins/` on Linux/macOS):
+   - `internal/acp1/wireshark/dhs_acpv1.lua`
+   - `internal/acp2/wireshark/dhs_acpv2.lua`
+   - `internal/emberplus/wireshark/dhs_emberplus.lua`
+   - `internal/osc/wireshark/dhs_osc.lua`
+   - `internal/probel-sw08p/wireshark/dhs_probel_sw08p.lua`
+3. Restart Wireshark. Dissectors auto-load from the plugins directory; no
+   `init.lua` edits are needed.
+4. Capture on your device-facing interface, filter by any of the
+   `dhs_<proto>` display filters (e.g. `dhs_acpv1`, `dhs_acpv2`,
+   `dhs_emberplus`, `dhs_osc`, `dhs_probel_sw08p`).
 
 ---
 


### PR DESCRIPTION
## Summary

Renames the four pre-OSC dissectors to the \`dhs_<proto>\` naming
convention that CLAUDE.md now mandates (and that the OSC plugin already
follows). Single atomic refactor — no behaviour change.

## What changed

| Surface | Before | After |
|---|---|---|
| File  | \`dissector_acp1.lua\`         | \`dhs_acpv1.lua\`        |
| File  | \`dissector_acp2.lua\`         | \`dhs_acpv2.lua\`        |
| File  | \`dissector_emberplus.lua\`    | \`dhs_emberplus.lua\`    |
| File  | \`dissector_probel_sw08p.lua\` | \`dhs_probel_sw08p.lua\` |
| Proto | \`acpv1_full\`                 | \`dhs_acpv1\`            |
| Proto | \`an2_acp2\`                   | \`dhs_acpv2_an2\`        |
| Proto | \`acp2_msg\`                   | \`dhs_acpv2\`            |
| Proto | \`acp2_prop\`                  | \`dhs_acpv2_prop\`       |
| Proto | \`emberplus\`                  | \`dhs_emberplus\`        |
| Proto | \`emberplus_glow\`             | \`dhs_emberplus_glow\`   |
| Proto | \`probel_sw08p\`               | \`dhs_probel_sw08p\`     |

All field abbrevs swept to \`dhs_<proto>.<field>\` in the same pass so
display filters (\`dhs_acpv1\`, \`dhs_acpv2\`, \`dhs_emberplus\`,
\`dhs_osc\`, \`dhs_probel_sw08p\`) land on every frame consistently.

Frozen \`tshark.tree\` fixtures under \`internal/*/testdata/protocol_types/\`
regenerated in place — only the \`[Protocols in frame: ...]\` line
changes, which is the only field that references Proto names by their
internal identifier. Human-readable tree labels come from \`tree:add()\`
calls that stay unchanged, so fixture-parity markers continue to match.

Docs updated: \`docs/wireshark.md\`, per-protocol \`CLAUDE.md\` /
\`docs/\` / \`assets/README\`, \`runbook.md\`,
\`docs/references/README.md\`.

## Test plan

- [x] \`go build ./...\` green
- [x] \`go test ./internal/{acp1,acp2,emberplus,probel-sw08p,osc}/...\` — all pass
- [x] \`golangci-lint\` + \`go vet\` clean (pre-commit hook)
- [x] Display filters \`dhs_acpv1\`, \`dhs_acpv2\`, \`dhs_emberplus\`, \`dhs_probel_sw08p\` resolve to the renamed Protos
- [ ] Manual Wireshark reload against a live loopback capture per protocol (non-blocking — CI covers fixture parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)