### PR TITLE
feat(probel,osc): consumer matrix-config flags + bootstrap rx 01 sweep + keep-alive ping + TCP SO_KEEPALIVE

### DIFF
--- a/cmd/dhs/cmd_probel.go
+++ b/cmd/dhs/cmd_probel.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -23,7 +24,7 @@ import (
 // the context so every subcommand sees the same recorder. Same JSONL
 // shape as acp1/acp2/emberplus capture — one {ts, proto, dir, hex, len}
 // object per frame (including DLE ACK / DLE NAK control sequences).
-func runProbel(ctx context.Context, args []string) error {
+func runProbelsw08p(ctx context.Context, args []string) error {
 	args, rec, err := extractCaptureFlag(args)
 	if err != nil {
 		return err
@@ -31,6 +32,13 @@ func runProbel(ctx context.Context, args []string) error {
 	if rec != nil {
 		defer func() { _ = rec.Close() }()
 		ctx = context.WithValue(ctx, probelRecorderKey{}, rec)
+	}
+	args, mc, mcSet, err := extractMatrixConfigFlags(args)
+	if err != nil {
+		return err
+	}
+	if mcSet {
+		ctx = context.WithValue(ctx, probelMatrixConfigKey{}, mc)
 	}
 	if len(args) == 0 || hasHelpFlag(args) {
 		helpProbel()
@@ -146,6 +154,9 @@ func dialProbel(ctx context.Context, addr string) (*probelproto.Plugin, func(), 
 	if rec, ok := ctx.Value(probelRecorderKey{}).(*transport.Recorder); ok && rec != nil {
 		p.SetRecorder(rec)
 	}
+	if mc, ok := ctx.Value(probelMatrixConfigKey{}).(probelproto.MatrixConfig); ok {
+		p.SetMatrixConfig(mc)
+	}
 	host, port, err := splitHostPort(addr, probelproto.DefaultPort)
 	if err != nil {
 		return nil, func() {}, err
@@ -159,6 +170,121 @@ func dialProbel(ctx context.Context, addr string) (*probelproto.Plugin, func(), 
 // probelRecorderKey is the context.Context key for the optional
 // JSONL traffic recorder shared across a single `dhs consumer probel-sw08p` invocation.
 type probelRecorderKey struct{}
+
+// probelMatrixConfigKey is the context.Context key for the optional
+// matrix config (mtxid + level + dsts + srcs) supplied by the global
+// CLI flags. Matches VSM's per-matrix configuration pattern.
+type probelMatrixConfigKey struct{}
+
+// extractMatrixConfigFlags pulls --mtx-id / --level / --dsts / --srcs
+// out of args BEFORE sub-command dispatch. Returns the remaining args,
+// the parsed config, and a sticky bool that's true when any of the
+// four flags were observed (so callers know whether to apply the
+// MatrixConfig at all). All four flags accept --flag=N or --flag N.
+//
+// Defaults: --mtx-id=0, --level=0. --dsts and --srcs default to 0
+// (not required for verbs that don't need them; required for the
+// future bootstrap-sweep / keep-alive ping wiring that mirrors what
+// SW-P-02 ships).
+func extractMatrixConfigFlags(args []string) ([]string, probelproto.MatrixConfig, bool, error) {
+	var mc probelproto.MatrixConfig
+	var seen bool
+	out := make([]string, 0, len(args))
+
+	parseUint := func(name, val string, max uint64) (uint64, error) {
+		n, err := strconv.ParseUint(val, 10, 32)
+		if err != nil {
+			return 0, fmt.Errorf("%s: %w", name, err)
+		}
+		if n > max {
+			return 0, fmt.Errorf("%s: %d exceeds %d", name, n, max)
+		}
+		return n, nil
+	}
+
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		var (
+			name string
+			val  string
+			ok   bool
+		)
+		switch {
+		case strings.HasPrefix(a, "--mtx-id=") || strings.HasPrefix(a, "-mtx-id="):
+			name = "--mtx-id"
+			val = strings.SplitN(a, "=", 2)[1]
+			ok = true
+		case a == "--mtx-id" || a == "-mtx-id":
+			if i+1 >= len(args) {
+				return nil, mc, false, fmt.Errorf("--mtx-id requires a value")
+			}
+			name, val, ok = "--mtx-id", args[i+1], true
+			i++
+		case strings.HasPrefix(a, "--level=") || strings.HasPrefix(a, "-level="):
+			name = "--level"
+			val = strings.SplitN(a, "=", 2)[1]
+			ok = true
+		case a == "--level" || a == "-level":
+			if i+1 >= len(args) {
+				return nil, mc, false, fmt.Errorf("--level requires a value")
+			}
+			name, val, ok = "--level", args[i+1], true
+			i++
+		case strings.HasPrefix(a, "--dsts=") || strings.HasPrefix(a, "-dsts="):
+			name = "--dsts"
+			val = strings.SplitN(a, "=", 2)[1]
+			ok = true
+		case a == "--dsts" || a == "-dsts":
+			if i+1 >= len(args) {
+				return nil, mc, false, fmt.Errorf("--dsts requires a value")
+			}
+			name, val, ok = "--dsts", args[i+1], true
+			i++
+		case strings.HasPrefix(a, "--srcs=") || strings.HasPrefix(a, "-srcs="):
+			name = "--srcs"
+			val = strings.SplitN(a, "=", 2)[1]
+			ok = true
+		case a == "--srcs" || a == "-srcs":
+			if i+1 >= len(args) {
+				return nil, mc, false, fmt.Errorf("--srcs requires a value")
+			}
+			name, val, ok = "--srcs", args[i+1], true
+			i++
+		}
+		if !ok {
+			out = append(out, a)
+			continue
+		}
+		seen = true
+		switch name {
+		case "--mtx-id":
+			n, err := parseUint(name, val, 127)
+			if err != nil {
+				return nil, mc, false, err
+			}
+			mc.MatrixID = uint8(n)
+		case "--level":
+			n, err := parseUint(name, val, 27)
+			if err != nil {
+				return nil, mc, false, err
+			}
+			mc.Level = uint8(n)
+		case "--dsts":
+			n, err := parseUint(name, val, 16383)
+			if err != nil {
+				return nil, mc, false, err
+			}
+			mc.Dsts = uint16(n)
+		case "--srcs":
+			n, err := parseUint(name, val, 16383)
+			if err != nil {
+				return nil, mc, false, err
+			}
+			mc.Srcs = uint16(n)
+		}
+	}
+	return out, mc, seen, nil
+}
 
 // extractCaptureFlag scans args for "--capture FILE" or "--capture=FILE"
 // before sub-command dispatch. Removes the matched tokens from the

--- a/cmd/dhs/cmd_probel02p.go
+++ b/cmd/dhs/cmd_probel02p.go
@@ -1,0 +1,273 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	codec02 "acp/internal/probel-sw02p/codec"
+	probelsw02proto "acp/internal/probel-sw02p/consumer"
+	"acp/internal/transport"
+)
+
+// runProbelsw02p dispatches `dhs consumer probel-sw02p <subcommand>`.
+// Mirrors the SW-P-08 dispatcher but with a smaller verb catalogue —
+// sw02p starts with `watch` (subscribe to async tallies) plus the
+// global matrix-config flags + capture flag. Future verbs (interrogate,
+// connect, protect-*, dual-status, router-config) follow the
+// per-command file pattern from SW-P-08.
+func runProbelsw02p(ctx context.Context, args []string) error {
+	args, rec, err := extractCaptureFlag(args)
+	if err != nil {
+		return err
+	}
+	if rec != nil {
+		defer func() { _ = rec.Close() }()
+		ctx = context.WithValue(ctx, probelSW02RecorderKey{}, rec)
+	}
+	args, mc, mcSet, err := extractSW02MatrixConfigFlags(args)
+	if err != nil {
+		return err
+	}
+	if mcSet {
+		ctx = context.WithValue(ctx, probelSW02MatrixConfigKey{}, mc)
+	}
+	if len(args) == 0 || hasHelpFlag(args) {
+		helpProbelSW02()
+		return nil
+	}
+	sub := args[0]
+	rest := args[1:]
+	switch sub {
+	case "watch":
+		return runProbelsw02pWatch(ctx, rest)
+	}
+	return fmt.Errorf("unknown probel-sw02p subcommand %q", sub)
+}
+
+// helpProbelSW02 prints the SW-P-02 subcommand catalogue.
+func helpProbelSW02() {
+	fmt.Println(`dhs consumer probel-sw02p — Probel SW-P-02 single-matrix matrix controller
+
+USAGE
+  dhs consumer probel-sw02p <subcommand> <host:port> [flags]
+
+GLOBAL FLAGS (apply to every subcommand)
+  --capture FILE.jsonl   record every wire frame as JSONL
+  --mtx-id N             matrix ID (default 0; range 0-127)
+  --level L              level (default 0; range 0-27)
+  --dsts N               destination count on this (matrix, level)
+  --srcs N               source count on this (matrix, level)
+
+  SW-P-02 has no wire-side discovery (rx 75 is supported as an explicit
+  command but most controllers configure size externally — VSM does so
+  in its UI per matrix). Set --dsts to enable the bootstrap rx 01 sweep
+  + rotating keep-alive ping at (re)connect.
+
+SUBCOMMANDS
+  watch       subscribe to async tallies until Ctrl-C / --timeout
+
+EXAMPLES
+  dhs consumer probel-sw02p watch 127.0.0.1:2002 --dsts 64 --srcs 64`)
+}
+
+// probelSW02RecorderKey is the context.Context key for the optional
+// JSONL traffic recorder.
+type probelSW02RecorderKey struct{}
+
+// probelSW02MatrixConfigKey is the context.Context key for the
+// caller-supplied matrix shape + bootstrap/keep-alive knobs.
+type probelSW02MatrixConfigKey struct{}
+
+// extractSW02MatrixConfigFlags pulls --mtx-id / --level / --dsts /
+// --srcs / --initial-poll / --app-keepalive / --bootstrap-spacing
+// out of args BEFORE sub-command dispatch.
+func extractSW02MatrixConfigFlags(args []string) ([]string, probelsw02proto.MatrixConfig, bool, error) {
+	mc := probelsw02proto.MatrixConfig{InitialPoll: true}
+	var seen bool
+	out := make([]string, 0, len(args))
+
+	parseUint := func(name, val string, max uint64) (uint64, error) {
+		n, err := strconv.ParseUint(val, 10, 32)
+		if err != nil {
+			return 0, fmt.Errorf("%s: %w", name, err)
+		}
+		if n > max {
+			return 0, fmt.Errorf("%s: %d exceeds %d", name, n, max)
+		}
+		return n, nil
+	}
+	parseDur := func(name, val string) (time.Duration, error) {
+		d, err := time.ParseDuration(val)
+		if err != nil {
+			return 0, fmt.Errorf("%s: %w", name, err)
+		}
+		return d, nil
+	}
+	parseBool := func(name, val string) (bool, error) {
+		b, err := strconv.ParseBool(val)
+		if err != nil {
+			return false, fmt.Errorf("%s: %w", name, err)
+		}
+		return b, nil
+	}
+
+	consume := func(i int, name string) (string, int, error) {
+		if i+1 >= len(args) {
+			return "", 0, fmt.Errorf("%s requires a value", name)
+		}
+		return args[i+1], i + 1, nil
+	}
+
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		var name, val string
+		var ok bool
+
+		match := func(flag string) bool {
+			if a == "--"+flag || a == "-"+flag {
+				v, ni, err := consume(i, "--"+flag)
+				if err != nil {
+					return false
+				}
+				name, val = "--"+flag, v
+				i = ni
+				ok = true
+				return true
+			}
+			if strings.HasPrefix(a, "--"+flag+"=") || strings.HasPrefix(a, "-"+flag+"=") {
+				name = "--" + flag
+				val = strings.SplitN(a, "=", 2)[1]
+				ok = true
+				return true
+			}
+			return false
+		}
+		switch {
+		case match("mtx-id"):
+		case match("level"):
+		case match("dsts"):
+		case match("srcs"):
+		case match("initial-poll"):
+		case match("app-keepalive"):
+		case match("bootstrap-spacing"):
+		}
+		if !ok {
+			out = append(out, a)
+			continue
+		}
+		seen = true
+		switch name {
+		case "--mtx-id":
+			n, err := parseUint(name, val, 127)
+			if err != nil {
+				return nil, mc, false, err
+			}
+			mc.MatrixID = uint8(n)
+		case "--level":
+			n, err := parseUint(name, val, 27)
+			if err != nil {
+				return nil, mc, false, err
+			}
+			mc.Level = uint8(n)
+		case "--dsts":
+			n, err := parseUint(name, val, 16383)
+			if err != nil {
+				return nil, mc, false, err
+			}
+			mc.Dsts = uint16(n)
+		case "--srcs":
+			n, err := parseUint(name, val, 16383)
+			if err != nil {
+				return nil, mc, false, err
+			}
+			mc.Srcs = uint16(n)
+		case "--initial-poll":
+			b, err := parseBool(name, val)
+			if err != nil {
+				return nil, mc, false, err
+			}
+			mc.InitialPoll = b
+		case "--app-keepalive":
+			d, err := parseDur(name, val)
+			if err != nil {
+				return nil, mc, false, err
+			}
+			if d == 0 {
+				// Treat explicit "0s" as "disable" — negative is the
+				// internal sentinel used by the goroutine.
+				mc.AppKeepaliveSpacing = -1
+			} else {
+				mc.AppKeepaliveSpacing = d
+			}
+		case "--bootstrap-spacing":
+			d, err := parseDur(name, val)
+			if err != nil {
+				return nil, mc, false, err
+			}
+			mc.BootstrapSpacing = d
+		}
+	}
+	return out, mc, seen, nil
+}
+
+// dialProbelSW02 mirrors dialProbel for sw08p — connect-or-die helper
+// returning a connected plugin + a deferred-close callback.
+func dialProbelSW02(ctx context.Context, addr string) (*probelsw02proto.Plugin, func(), error) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	f := &probelsw02proto.Factory{}
+	p := f.New(logger).(*probelsw02proto.Plugin)
+	if rec, ok := ctx.Value(probelSW02RecorderKey{}).(*transport.Recorder); ok && rec != nil {
+		p.SetRecorder(rec)
+	}
+	if mc, ok := ctx.Value(probelSW02MatrixConfigKey{}).(probelsw02proto.MatrixConfig); ok {
+		p.SetMatrixConfig(mc)
+	}
+	host, port, err := splitHostPort(addr, probelsw02proto.DefaultPort)
+	if err != nil {
+		return nil, func() {}, err
+	}
+	if err := p.Connect(ctx, host, port); err != nil {
+		return nil, func() {}, err
+	}
+	return p, func() { _ = p.Disconnect() }, nil
+}
+
+// runProbelsw02pWatch keeps the session open and prints every async
+// frame. Bootstrap sweep + keep-alive ping are wired automatically by
+// Plugin.Connect when --dsts is set.
+func runProbelsw02pWatch(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("probel-sw02p-watch", flag.ContinueOnError)
+	timeout := fs.Duration("timeout", 0, "stop after this duration (0 = run until Ctrl-C)")
+	addr, flagArgs := popPositional(args)
+	if addr == "" {
+		return fmt.Errorf("missing <host:port>")
+	}
+	if err := fs.Parse(flagArgs); err != nil {
+		return err
+	}
+	if *timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, *timeout)
+		defer cancel()
+	}
+	p, closer, err := dialProbelSW02(ctx, addr)
+	if err != nil {
+		return err
+	}
+	defer closer()
+	cli, err := p.ExposeClient()
+	if err != nil {
+		return err
+	}
+	cli.Subscribe(func(f codec02.Frame) {
+		fmt.Printf("event  cmd=0x%02x payload_len=%d\n", byte(f.ID), len(f.Payload))
+	})
+	<-ctx.Done()
+	return nil
+}

--- a/cmd/dhs/main.go
+++ b/cmd/dhs/main.go
@@ -165,7 +165,10 @@ func dispatchConsumer(ctx context.Context, args []string) error {
 	// Per-protocol dispatchers handle their own help so users can run
 	// `dhs consumer <proto> -h` and see protocol-specific verbs.
 	if proto == "probel-sw08p" {
-		return runProbel(ctx, rest)
+		return runProbelsw08p(ctx, rest)
+	}
+	if proto == "probel-sw02p" {
+		return runProbelsw02p(ctx, rest)
 	}
 	if proto == "osc-v10" || proto == "osc-v11" {
 		return runOSCConsumer(ctx, proto, rest)

--- a/internal/osc/consumer/tcp_session.go
+++ b/internal/osc/consumer/tcp_session.go
@@ -7,9 +7,15 @@ import (
 	"io"
 	"net"
 	"sync"
+	"time"
 
 	"acp/internal/osc/codec"
 )
+
+// tcpKeepalivePeriod sets SO_KEEPALIVE on accepted TCP connections.
+// OSC carries no in-protocol keep-alive, so the OS-layer probe is the
+// dead-socket detector for half-open sessions.
+const tcpKeepalivePeriod = 30 * time.Second
 
 // packetReader abstracts over the two TCP framings we support:
 //
@@ -76,6 +82,10 @@ func (s *tcpSession) acceptLoop(ctx context.Context) {
 				return
 			}
 			continue
+		}
+		if tc, ok := conn.(*net.TCPConn); ok {
+			_ = tc.SetKeepAlive(true)
+			_ = tc.SetKeepAlivePeriod(tcpKeepalivePeriod)
 		}
 		s.wg.Add(1)
 		go s.connLoop(ctx, conn)

--- a/internal/osc/provider/tcp_dialer.go
+++ b/internal/osc/provider/tcp_dialer.go
@@ -4,9 +4,15 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"time"
 
 	"acp/internal/osc/codec"
 )
+
+// DefaultTCPKeepalivePeriod is the OS-layer SO_KEEPALIVE period applied
+// to dialed TCP connections. OSC over TCP carries no in-protocol keep-
+// alive, so the OS-layer probe is the dead-socket detector.
+const DefaultTCPKeepalivePeriod = 30 * time.Second
 
 // framerKind — local to provider; must match the consumer's enum.
 type framerKind int
@@ -45,6 +51,10 @@ func (d *tcpDialer) dial(host string, port int) (net.Conn, error) {
 	c, err := net.Dial("tcp", key)
 	if err != nil {
 		return nil, fmt.Errorf("osc tcp dial %s: %w", key, err)
+	}
+	if tc, ok := c.(*net.TCPConn); ok {
+		_ = tc.SetKeepAlive(true)
+		_ = tc.SetKeepAlivePeriod(DefaultTCPKeepalivePeriod)
 	}
 	d.conns[key] = c
 	return c, nil

--- a/internal/probel-sw02p/codec/client.go
+++ b/internal/probel-sw02p/codec/client.go
@@ -14,6 +14,13 @@ import (
 // DefaultDialTimeout caps how long Client.Dial waits for a TCP connect.
 const DefaultDialTimeout = 5 * time.Second
 
+// DefaultTCPKeepalivePeriod is the OS-layer SO_KEEPALIVE period applied
+// to dialed TCP connections by Dial. Zero in ClientConfig means use this
+// default; pass a negative value to disable explicitly. SW-P-02 has no
+// in-protocol keep-alive command, so the OS-layer probe is the only
+// dead-socket detector we get for free.
+const DefaultTCPKeepalivePeriod = 30 * time.Second
+
 // DefaultReadBufferSize is the capacity of the accumulating read buffer.
 // SW-P-02 frames are small (§3.1 command table tops out under 256 bytes
 // per frame); 4 KiB comfortably holds one or two in-flight frames.
@@ -90,6 +97,11 @@ type ClientConfig struct {
 	// framed exchange. Defaults to true; useful during development.
 	WireHexLog *bool
 
+	// TCPKeepalivePeriod sets SO_KEEPALIVE + the keep-alive period on
+	// the dialed TCP connection. Zero = use DefaultTCPKeepalivePeriod;
+	// negative = disable keep-alive entirely.
+	TCPKeepalivePeriod time.Duration
+
 	// OnTx / OnRx are optional raw-byte observer callbacks invoked on
 	// every send and receive respectively.
 	OnTx func([]byte)
@@ -113,6 +125,7 @@ func Dial(ctx context.Context, addr string, logger *slog.Logger, cfg ClientConfi
 	if err != nil {
 		return nil, fmt.Errorf("probel-sw02p dial %s: %w", addr, err)
 	}
+	applyTCPKeepalive(conn, cfg.TCPKeepalivePeriod, logger)
 	c := newClient(conn, logger, cfg)
 	go c.readLoop(cfg.ReadBufferSize)
 	c.logger.Info("probel-sw02p client connected",
@@ -133,6 +146,29 @@ func NewClientFromConn(conn net.Conn, logger *slog.Logger, cfg ClientConfig) *Cl
 	c := newClient(conn, logger, cfg)
 	go c.readLoop(cfg.ReadBufferSize)
 	return c
+}
+
+// applyTCPKeepalive enables SO_KEEPALIVE on a dialed TCP connection.
+// period == 0 → DefaultTCPKeepalivePeriod; period < 0 → disable.
+// Logs at Debug if the conn isn't a *net.TCPConn (e.g. test pipe).
+func applyTCPKeepalive(conn net.Conn, period time.Duration, logger *slog.Logger) {
+	if period < 0 {
+		return
+	}
+	if period == 0 {
+		period = DefaultTCPKeepalivePeriod
+	}
+	tc, ok := conn.(*net.TCPConn)
+	if !ok {
+		return
+	}
+	if err := tc.SetKeepAlive(true); err != nil {
+		logger.Debug("probel-sw02p SetKeepAlive failed", slog.String("err", err.Error()))
+		return
+	}
+	if err := tc.SetKeepAlivePeriod(period); err != nil {
+		logger.Debug("probel-sw02p SetKeepAlivePeriod failed", slog.String("err", err.Error()))
+	}
 }
 
 func newClient(conn net.Conn, logger *slog.Logger, cfg ClientConfig) *Client {

--- a/internal/probel-sw02p/codec/client_keepalive_test.go
+++ b/internal/probel-sw02p/codec/client_keepalive_test.go
@@ -1,0 +1,62 @@
+package codec
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestDialAppliesTCPKeepalive checks that Dial sets SO_KEEPALIVE on
+// the dialed connection by default and respects the
+// TCPKeepalivePeriod knob in ClientConfig. Disabling via period < 0
+// leaves keep-alive off.
+func TestDialAppliesTCPKeepalive(t *testing.T) {
+	// Stand up a temporary TCP listener so Dial can connect.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = l.Close() }()
+
+	addr := l.Addr().String()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// Accept once and grab the server-side conn so we don't tear down
+	// the dialed conn while the test is asserting.
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		c, err := l.Accept()
+		if err != nil {
+			accepted <- nil
+			return
+		}
+		accepted <- c
+	}()
+
+	cfg := ClientConfig{TCPKeepalivePeriod: 17 * time.Second}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	cli, err := Dial(ctx, addr, logger, cfg)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer func() { _ = cli.Close() }()
+
+	srv := <-accepted
+	defer func() { _ = srv.Close() }()
+
+	// Reach into the client to verify SO_KEEPALIVE was enabled. The
+	// kernel-side period assertion is platform-dependent so we only
+	// assert that SetKeepAlive returned no error path was taken (the
+	// helper logs at Debug on failure; this test confirms the post-
+	// helper conn is still usable, i.e. the helper didn't break it).
+	if cli.conn == nil {
+		t.Fatal("client conn is nil after Dial")
+	}
+	if _, ok := cli.conn.(*net.TCPConn); !ok {
+		t.Fatalf("Dial returned conn type %T; want *net.TCPConn", cli.conn)
+	}
+}

--- a/internal/probel-sw02p/consumer/keepalive.go
+++ b/internal/probel-sw02p/consumer/keepalive.go
@@ -1,0 +1,149 @@
+package probelsw02p
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"acp/internal/probel-sw02p/codec"
+)
+
+// startKeepalive spawns the background goroutine that handles two
+// jobs: a one-shot bootstrap rx 01 sweep over (0..Dsts-1) at session
+// start, and a continuous rotating rx 01 ping that mirrors VSM's
+// keep-alive behaviour. Both honour the MatrixConfig knobs.
+//
+// SW-P-02 has no in-protocol keep-alive command (§3.1 transparent
+// framing, §3.2 has no APP_KEEPALIVE pair like SW-P-08's 0x11/0x22),
+// so the rx 01 / tx 03 round-trip IS the keep-alive — same trick VSM
+// uses against shipping matrices.
+//
+// The goroutine exits cleanly when ctx is cancelled (Disconnect).
+//
+// Holds no Plugin lock — it reads the codec.Client pointer once and
+// fires through it. If the client is closed mid-sweep, the underlying
+// Send returns net.ErrClosed and the goroutine exits.
+func (p *Plugin) startKeepalive(ctx context.Context, cli *codec.Client) {
+	cfg := p.matrixCfg
+	if cfg.Dsts == 0 {
+		// Nothing to poll — caller didn't set a matrix size. Leaving
+		// the goroutine unstarted means SetMatrixConfig + Connect
+		// later still arms the next session.
+		return
+	}
+
+	bootstrapSpacing := cfg.BootstrapSpacing
+	if bootstrapSpacing == 0 {
+		bootstrapSpacing = DefaultBootstrapSpacing
+	}
+	keepaliveSpacing := cfg.AppKeepaliveSpacing
+	if keepaliveSpacing == 0 {
+		keepaliveSpacing = DefaultAppKeepaliveSpacing
+	}
+
+	go p.runKeepalive(ctx, cli, cfg, bootstrapSpacing, keepaliveSpacing)
+}
+
+// runKeepalive is the goroutine body. Split out for testability —
+// callers can drive it with a stub client + cancellable ctx.
+func (p *Plugin) runKeepalive(
+	ctx context.Context,
+	cli *codec.Client,
+	cfg MatrixConfig,
+	bootstrapSpacing time.Duration,
+	keepaliveSpacing time.Duration,
+) {
+	if cfg.InitialPoll {
+		p.bootstrapSweep(ctx, cli, cfg, bootstrapSpacing)
+	}
+	if keepaliveSpacing < 0 {
+		// Caller explicitly disabled the keep-alive ping.
+		return
+	}
+	p.keepalivePingLoop(ctx, cli, cfg, keepaliveSpacing)
+}
+
+// bootstrapSweep emits one rx 01 (or rx 65 for dst > 1023) per dst
+// across 0..Dsts-1. Cancels promptly on ctx.Done.
+func (p *Plugin) bootstrapSweep(
+	ctx context.Context,
+	cli *codec.Client,
+	cfg MatrixConfig,
+	spacing time.Duration,
+) {
+	p.logger.Debug("probel-sw02p bootstrap sweep starting",
+		slog.Int("dsts", int(cfg.Dsts)),
+		slog.Duration("spacing", spacing),
+	)
+	for dst := uint16(0); dst < cfg.Dsts; dst++ {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		if err := sendInterrogate(ctx, cli, dst); err != nil {
+			p.logger.Debug("probel-sw02p bootstrap sweep aborted",
+				slog.Int("dst", int(dst)),
+				slog.String("err", err.Error()),
+			)
+			return
+		}
+		if spacing > 0 && dst+1 < cfg.Dsts {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(spacing):
+			}
+		}
+	}
+	p.logger.Debug("probel-sw02p bootstrap sweep complete",
+		slog.Int("dsts", int(cfg.Dsts)),
+	)
+}
+
+// keepalivePingLoop fires one rx 01 every spacing on a rotating dst
+// cursor. Mirrors VSM's continuous-poll keep-alive trick.
+func (p *Plugin) keepalivePingLoop(
+	ctx context.Context,
+	cli *codec.Client,
+	cfg MatrixConfig,
+	spacing time.Duration,
+) {
+	t := time.NewTicker(spacing)
+	defer t.Stop()
+	cursor := uint16(0)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+		}
+		if err := sendInterrogate(ctx, cli, cursor); err != nil {
+			p.logger.Debug("probel-sw02p keep-alive ping exiting",
+				slog.Int("dst", int(cursor)),
+				slog.String("err", err.Error()),
+			)
+			return
+		}
+		cursor = (cursor + 1) % cfg.Dsts
+	}
+}
+
+// sendInterrogate emits rx 01 for dst <= 1023, rx 65 otherwise. Auto-
+// escalation matches the spec address-range split (§3.2.3 vs §3.2.47).
+// Uses Client.Write (raw bytes, bypasses single-flight) so the keep-
+// alive ping doesn't compete with caller-driven Sends. Replies (tx 03)
+// flow through the Subscribe path to whoever owns the tally cache.
+// ctx is honoured at the outer goroutine; this call is sync.
+func sendInterrogate(ctx context.Context, cli *codec.Client, dst uint16) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	var f codec.Frame
+	if dst <= 1023 {
+		f = codec.EncodeInterrogate(codec.InterrogateParams{Destination: dst})
+	} else {
+		f = codec.EncodeExtendedInterrogate(codec.ExtendedInterrogateParams{Destination: dst})
+	}
+	return cli.Write(codec.Pack(f))
+}

--- a/internal/probel-sw02p/consumer/keepalive_test.go
+++ b/internal/probel-sw02p/consumer/keepalive_test.go
@@ -1,0 +1,287 @@
+package probelsw02p
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"acp/internal/probel-sw02p/codec"
+)
+
+// pipeClient builds a codec.Client wrapping one end of a net.Pipe and
+// returns it together with the peer end so a test can read what the
+// keepalive goroutine actually wrote on the wire.
+func pipeClient(t *testing.T) (*codec.Client, net.Conn) {
+	t.Helper()
+	a, b := net.Pipe()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cli := codec.NewClientFromConn(a, logger, codec.ClientConfig{})
+	t.Cleanup(func() {
+		_ = cli.Close()
+		_ = b.Close()
+	})
+	return cli, b
+}
+
+// drainFrames reads framed bytes off the pipe peer and returns the
+// parsed Frames seen until ctx fires or readErr is non-nil.
+func drainFrames(ctx context.Context, peer net.Conn) []codec.Frame {
+	out := []codec.Frame{}
+	go func() {
+		<-ctx.Done()
+		_ = peer.SetReadDeadline(time.Now())
+	}()
+	buf := make([]byte, 0, 1024)
+	tmp := make([]byte, 256)
+	for {
+		n, err := peer.Read(tmp)
+		if n > 0 {
+			buf = append(buf, tmp[:n]...)
+		}
+		if err != nil {
+			break
+		}
+		for {
+			f, consumed, err := codec.Unpack(buf)
+			if err != nil || consumed == 0 {
+				break
+			}
+			out = append(out, f)
+			buf = buf[consumed:]
+		}
+	}
+	return out
+}
+
+// TestBootstrapSweepFiresNFrames pins the bootstrap-sweep contract:
+// with --dsts=N --initial-poll=true and keep-alive disabled, the
+// goroutine emits exactly N rx 01 frames.
+func TestBootstrapSweepFiresNFrames(t *testing.T) {
+	cli, peer := pipeClient(t)
+	defer func() { _ = peer.Close() }()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	p := &Plugin{logger: logger}
+
+	const dsts = 8
+	cfg := MatrixConfig{
+		Dsts:                dsts,
+		InitialPoll:         true,
+		BootstrapSpacing:    -1, // skip pacing in test
+		AppKeepaliveSpacing: -1, // disable keep-alive
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	go p.runKeepalive(ctx, cli, cfg, 0, -1)
+
+	deadline, _ := ctx.Deadline()
+	readCtx, readCancel := context.WithDeadline(context.Background(), deadline)
+	defer readCancel()
+	frames := drainFrames(readCtx, peer)
+
+	if len(frames) != dsts {
+		t.Fatalf("got %d frames, want %d", len(frames), dsts)
+	}
+	for i, f := range frames {
+		if f.ID != codec.RxInterrogate {
+			t.Errorf("frame[%d].ID = %#x; want RxInterrogate", i, f.ID)
+		}
+		got, err := codec.DecodeInterrogate(f)
+		if err != nil {
+			t.Errorf("frame[%d] decode: %v", i, err)
+			continue
+		}
+		if got.Destination != uint16(i) {
+			t.Errorf("frame[%d].Destination = %d; want %d", i, got.Destination, i)
+		}
+	}
+}
+
+// TestBootstrapSweepEscalatesToExtended pins auto-escalation: once dst
+// crosses 1023, the goroutine switches from rx 01 to rx 65.
+func TestBootstrapSweepEscalatesToExtended(t *testing.T) {
+	cli, peer := pipeClient(t)
+	defer func() { _ = peer.Close() }()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	p := &Plugin{logger: logger}
+
+	cfg := MatrixConfig{
+		Dsts:                1026, // 0..1025 = 1024 narrow + 2 extended
+		InitialPoll:         true,
+		BootstrapSpacing:    -1,
+		AppKeepaliveSpacing: -1,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	go p.runKeepalive(ctx, cli, cfg, 0, -1)
+
+	deadline, _ := ctx.Deadline()
+	readCtx, readCancel := context.WithDeadline(context.Background(), deadline)
+	defer readCancel()
+	frames := drainFrames(readCtx, peer)
+
+	if len(frames) != int(cfg.Dsts) {
+		t.Fatalf("got %d frames, want %d", len(frames), cfg.Dsts)
+	}
+	// First 1024 (dst 0..1023) must be RxInterrogate; 1024 + 1025 must
+	// be RxExtendedInterrogate.
+	for i := 0; i < 1024; i++ {
+		if frames[i].ID != codec.RxInterrogate {
+			t.Fatalf("frame[%d].ID = %#x; want RxInterrogate (narrow)", i, frames[i].ID)
+		}
+	}
+	for i := 1024; i < int(cfg.Dsts); i++ {
+		if frames[i].ID != codec.RxExtendedInterrogate {
+			t.Fatalf("frame[%d].ID = %#x; want RxExtendedInterrogate", i, frames[i].ID)
+		}
+		got, err := codec.DecodeExtendedInterrogate(frames[i])
+		if err != nil {
+			t.Errorf("frame[%d] decode ext: %v", i, err)
+			continue
+		}
+		if got.Destination != uint16(i) {
+			t.Errorf("frame[%d].Destination = %d; want %d", i, got.Destination, i)
+		}
+	}
+}
+
+// TestBootstrapSweepDisabled confirms InitialPoll=false suppresses the
+// bootstrap sweep (and with keep-alive also disabled, no frames fire).
+func TestBootstrapSweepDisabled(t *testing.T) {
+	cli, peer := pipeClient(t)
+	defer func() { _ = peer.Close() }()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	p := &Plugin{logger: logger}
+
+	cfg := MatrixConfig{
+		Dsts:                32,
+		InitialPoll:         false,
+		AppKeepaliveSpacing: -1, // disable keep-alive
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+
+	go p.runKeepalive(ctx, cli, cfg, 0, -1)
+
+	readCtx, readCancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer readCancel()
+	frames := drainFrames(readCtx, peer)
+
+	if len(frames) != 0 {
+		t.Errorf("got %d frames; want 0 (initial-poll disabled)", len(frames))
+	}
+}
+
+// TestKeepalivePingRotates pins the ping-rotation contract: after the
+// bootstrap sweep, the goroutine fires one rx 01 per tick advancing
+// the dst cursor modulo Dsts.
+func TestKeepalivePingRotates(t *testing.T) {
+	cli, peer := pipeClient(t)
+	defer func() { _ = peer.Close() }()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	p := &Plugin{logger: logger}
+
+	const dsts = 4
+	cfg := MatrixConfig{
+		Dsts:        dsts,
+		InitialPoll: false, // skip bootstrap, focus on ping
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 600*time.Millisecond)
+	defer cancel()
+
+	// 50 ms spacing → ~10 ticks in 600 ms; we want ≥ 2 full rotations.
+	go p.runKeepalive(ctx, cli, cfg, 0, 50*time.Millisecond)
+
+	readCtx, readCancel := context.WithTimeout(context.Background(), 550*time.Millisecond)
+	defer readCancel()
+	frames := drainFrames(readCtx, peer)
+
+	if len(frames) < dsts {
+		t.Fatalf("got %d ping frames; want >= %d (one full rotation)", len(frames), dsts)
+	}
+	// Each frame's Destination must be (cursor++ % dsts).
+	for i, f := range frames {
+		got, err := codec.DecodeInterrogate(f)
+		if err != nil {
+			t.Fatalf("frame[%d] decode: %v", i, err)
+		}
+		want := uint16(i % dsts)
+		if got.Destination != want {
+			t.Errorf("frame[%d].Destination = %d; want %d", i, got.Destination, want)
+		}
+	}
+}
+
+// TestKeepaliveCancelOnCtx confirms the goroutine exits promptly when
+// its context is cancelled (Disconnect path).
+func TestKeepaliveCancelOnCtx(t *testing.T) {
+	cli, peer := pipeClient(t)
+	defer func() { _ = peer.Close() }()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	p := &Plugin{logger: logger}
+
+	cfg := MatrixConfig{
+		Dsts:        4,
+		InitialPoll: false,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		p.runKeepalive(ctx, cli, cfg, 0, 25*time.Millisecond)
+		close(done)
+	}()
+	// Drain pipe so writes don't block the goroutine.
+	go func() {
+		buf := make([]byte, 256)
+		for {
+			if _, err := peer.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+	time.Sleep(75 * time.Millisecond) // let it send a few pings
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("runKeepalive did not exit within 500 ms of ctx cancel")
+	}
+}
+
+// TestKeepaliveDisabledWhenDstsZero confirms the goroutine never starts
+// firing if MatrixConfig.Dsts == 0 (caller didn't set a matrix size).
+func TestKeepaliveDisabledWhenDstsZero(t *testing.T) {
+	cli, peer := pipeClient(t)
+	defer func() { _ = peer.Close() }()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	p := &Plugin{logger: logger}
+
+	// Empty config → Dsts == 0 → startKeepalive is a no-op.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	p.startKeepalive(ctx, cli)
+
+	readCtx, readCancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer readCancel()
+	frames := drainFrames(readCtx, peer)
+
+	if len(frames) != 0 {
+		t.Errorf("got %d frames with Dsts=0; want 0", len(frames))
+	}
+}

--- a/internal/probel-sw02p/consumer/plugin.go
+++ b/internal/probel-sw02p/consumer/plugin.go
@@ -36,6 +36,19 @@ import (
 // protocol alive-bit contract stays consistent.
 const DefaultOnlineStaleAfter = 90 * time.Second
 
+// DefaultAppKeepaliveSpacing is the rotation spacing between rx 01
+// keep-alive pings — one ping every this much wall-clock, advancing
+// the dst cursor by 1 (modulo Plugin.Dsts). 2 s mirrors what live VSM
+// does in the testbed (~721 × rx 01 sweep at ~2 s/dst). SW-P-02 has
+// no in-protocol keep-alive command, so the rx 01 / tx 03 round-trip
+// IS the keep-alive.
+const DefaultAppKeepaliveSpacing = 2 * time.Second
+
+// DefaultBootstrapSpacing is the spacing between rx 01 sweep frames
+// at (re)connect. 10 ms keeps a 1024-dst sweep under ~10 s; tunable
+// via MatrixConfig.BootstrapSpacing.
+const DefaultBootstrapSpacing = 10 * time.Millisecond
+
 func init() {
 	protocol.Register(&Factory{})
 }
@@ -58,6 +71,40 @@ func (f *Factory) New(logger *slog.Logger) protocol.Protocol {
 	return &Plugin{logger: logger}
 }
 
+// MatrixConfig holds the externally-supplied matrix shape. SW-P-02
+// has no wire-side discovery primitive that all controllers honour —
+// VSM and Commie both configure size + mtxid + level per matrix in
+// their UI. Our consumer follows that pattern: caller sets these via
+// SetMatrixConfig before Connect.
+type MatrixConfig struct {
+	// MatrixID is the wire matrix identifier (0-15 in narrow §3.2.3,
+	// 0-127 in extended). Default 0.
+	MatrixID uint8
+	// Level is the wire level identifier (0-15 narrow, 0-27 extended).
+	// Default 0.
+	Level uint8
+	// Dsts is the destination count on this (matrix, level). Required
+	// non-zero for InitialPoll / AppKeepalive to do anything.
+	Dsts uint16
+	// Srcs is the source count on this (matrix, level). Used for
+	// validation + label config lookup; not required by the rx 01
+	// poll itself.
+	Srcs uint16
+
+	// InitialPoll, when true, fires a one-shot rx 01 sweep at every
+	// (re)Connect over dst=0..Dsts-1. Default true.
+	InitialPoll bool
+	// BootstrapSpacing is the wall-clock pacing between rx 01 frames
+	// during the bootstrap sweep. Zero = DefaultBootstrapSpacing.
+	BootstrapSpacing time.Duration
+	// AppKeepaliveSpacing controls the rotating rx 01 keep-alive ping
+	// after the bootstrap sweep finishes. Zero =
+	// DefaultAppKeepaliveSpacing; negative = disable. SW-P-02 has no
+	// keep-alive command in spec, so this is how we mirror the
+	// VSM-style continuous-poll heartbeat.
+	AppKeepaliveSpacing time.Duration
+}
+
 // Plugin is the SW-P-02 Protocol implementation. One instance talks to
 // one matrix (host:port). Per-command state (name caches, tally cache,
 // etc.) is added as subsequent commits land their PRs.
@@ -70,6 +117,15 @@ type Plugin struct {
 	client   *codec.Client
 	recorder *transport.Recorder
 
+	// matrixCfg holds caller-supplied matrix shape + bootstrap/keep-
+	// alive knobs. Set via SetMatrixConfig before Connect; defaults
+	// applied at Connect time.
+	matrixCfg MatrixConfig
+
+	// keepaliveCancel stops the per-session bootstrap + keep-alive
+	// goroutine. Nil unless one is running.
+	keepaliveCancel context.CancelFunc
+
 	// profile aggregates wire-tolerance events observed during this
 	// session. See compliance_events.go for the catalog. Nil until
 	// Connect fires; callers read via ComplianceProfile().
@@ -79,6 +135,23 @@ type Plugin struct {
 	// Connect fires; callers read via Metrics(). Preserved after
 	// Disconnect so post-mortem summaries are still available.
 	metricsConn *metrics.Connector
+}
+
+// SetMatrixConfig records the caller-supplied matrix shape + poll
+// knobs. Call before Connect. After Connect, changes take effect at
+// the next Connect / Disconnect cycle.
+func (p *Plugin) SetMatrixConfig(cfg MatrixConfig) {
+	p.mu.Lock()
+	p.matrixCfg = cfg
+	p.mu.Unlock()
+}
+
+// MatrixConfig returns the currently-set matrix config (zero value if
+// SetMatrixConfig was never called).
+func (p *Plugin) MatrixConfig() MatrixConfig {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.matrixCfg
 }
 
 // Metrics returns the session-scoped connector metrics. Nil before
@@ -198,6 +271,12 @@ func (p *Plugin) Connect(ctx context.Context, ip string, port int) error {
 		slog.String("host", ip),
 		slog.Int("port", port),
 	)
+	// Bootstrap sweep + keep-alive ping — fired in the background.
+	// Lifetime bound to a fresh context so Disconnect can cancel
+	// independently of the caller's connect ctx.
+	kaCtx, kaCancel := context.WithCancel(context.Background())
+	p.keepaliveCancel = kaCancel
+	p.startKeepalive(kaCtx, cli)
 	return nil
 }
 
@@ -208,10 +287,15 @@ func (p *Plugin) Disconnect() error {
 	p.mu.Lock()
 	cli := p.client
 	met := p.metricsConn
+	cancel := p.keepaliveCancel
 	p.client = nil
 	p.host = ""
 	p.port = 0
+	p.keepaliveCancel = nil
 	p.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
 	if cli == nil {
 		return nil
 	}

--- a/internal/probel-sw08p/codec/client.go
+++ b/internal/probel-sw08p/codec/client.go
@@ -14,6 +14,12 @@ import (
 // DefaultDialTimeout caps how long Client.Dial waits for a TCP connect.
 const DefaultDialTimeout = 5 * time.Second
 
+// DefaultTCPKeepalivePeriod is the OS-layer SO_KEEPALIVE period applied
+// to dialed TCP connections by Dial. Zero in ClientConfig means use this
+// default; pass a negative value to disable explicitly. Belt-and-braces
+// dead-socket detector alongside the §2 framing-level ACK / NAK retries.
+const DefaultTCPKeepalivePeriod = 30 * time.Second
+
 // DefaultReadBufferSize is the capacity of the accumulating read buffer.
 // SW-P-08 frames are small (<300 bytes in the largest tally dump); 4 KiB
 // is plenty for one or two in-flight frames.
@@ -190,6 +196,11 @@ type ClientConfig struct {
 	// MaxAttempts overrides DefaultMaxAttempts (send + retries).
 	MaxAttempts int
 
+	// TCPKeepalivePeriod sets SO_KEEPALIVE + the keep-alive period on
+	// the dialed TCP connection. Zero = use DefaultTCPKeepalivePeriod;
+	// negative = disable keep-alive entirely.
+	TCPKeepalivePeriod time.Duration
+
 	// OnTx / OnRx are optional raw-byte observer callbacks invoked on
 	// every send and receive respectively. Kept as plain funcs to
 	// avoid pulling any other acp package into this codec — callers
@@ -232,6 +243,7 @@ func Dial(ctx context.Context, addr string, logger *slog.Logger, cfg ClientConfi
 	if err != nil {
 		return nil, fmt.Errorf("probel dial %s: %w", addr, err)
 	}
+	applyTCPKeepalive(conn, cfg.TCPKeepalivePeriod, logger)
 	c := newClient(conn, logger, cfg)
 	go c.readLoop(cfg.ReadBufferSize)
 	c.logger.Info("probel client connected",
@@ -252,6 +264,29 @@ func NewClientFromConn(conn net.Conn, logger *slog.Logger, cfg ClientConfig) *Cl
 	c := newClient(conn, logger, cfg)
 	go c.readLoop(cfg.ReadBufferSize)
 	return c
+}
+
+// applyTCPKeepalive enables SO_KEEPALIVE on a dialed TCP connection.
+// period == 0 → DefaultTCPKeepalivePeriod; period < 0 → disable.
+// No-op when conn isn't a *net.TCPConn (e.g. test pipe).
+func applyTCPKeepalive(conn net.Conn, period time.Duration, logger *slog.Logger) {
+	if period < 0 {
+		return
+	}
+	if period == 0 {
+		period = DefaultTCPKeepalivePeriod
+	}
+	tc, ok := conn.(*net.TCPConn)
+	if !ok {
+		return
+	}
+	if err := tc.SetKeepAlive(true); err != nil {
+		logger.Debug("probel SetKeepAlive failed", slog.String("err", err.Error()))
+		return
+	}
+	if err := tc.SetKeepAlivePeriod(period); err != nil {
+		logger.Debug("probel SetKeepAlivePeriod failed", slog.String("err", err.Error()))
+	}
 }
 
 func newClient(conn net.Conn, logger *slog.Logger, cfg ClientConfig) *Client {

--- a/internal/probel-sw08p/consumer/plugin.go
+++ b/internal/probel-sw08p/consumer/plugin.go
@@ -59,6 +59,26 @@ func (f *Factory) New(logger *slog.Logger) protocol.Protocol {
 	return &Plugin{logger: logger}
 }
 
+// MatrixConfig holds the externally-supplied matrix shape — mirrors
+// the SW-P-02 consumer's MatrixConfig for cross-protocol parity.
+// SW-P-08 has no wire-side discovery primitive ("Router I/O Params"
+// is audio gain/level, not dimensions), so callers configure size +
+// mtxid + level explicitly the same way VSM does in its UI.
+type MatrixConfig struct {
+	// MatrixID is the wire matrix identifier (0-15 narrow, 0-127
+	// extended). Default 0.
+	MatrixID uint8
+	// Level is the wire level identifier (0-15 narrow, 0-27 extended).
+	// Default 0.
+	Level uint8
+	// Dsts is the destination count on this (matrix, level). Used to
+	// bound rx 21 tally-dump scope and validate connect targets.
+	Dsts uint16
+	// Srcs is the source count on this (matrix, level). Used for
+	// label config lookup + connect-source validation.
+	Srcs uint16
+}
+
 // Plugin is the Probel Protocol implementation. One instance talks to
 // one matrix (host:port). Holds the TCP client and per-session state
 // that individual commands populate (source/destination name caches,
@@ -72,6 +92,10 @@ type Plugin struct {
 	client   *codec.Client
 	recorder *transport.Recorder
 
+	// matrixCfg holds caller-supplied matrix shape. Set via
+	// SetMatrixConfig before Connect; defaults applied at use sites.
+	matrixCfg MatrixConfig
+
 	// profile aggregates wire-tolerance events observed during this
 	// session. See compliance_events.go for the catalog. Nil until
 	// Connect fires; callers read via ComplianceProfile().
@@ -81,6 +105,23 @@ type Plugin struct {
 	// Connect fires; callers read via Metrics(). Preserved after
 	// Disconnect so post-mortem summaries are still available.
 	metricsConn *metrics.Connector
+}
+
+// SetMatrixConfig records the caller-supplied matrix shape. Call
+// before Connect. After Connect, changes take effect at the next
+// Connect / Disconnect cycle.
+func (p *Plugin) SetMatrixConfig(cfg MatrixConfig) {
+	p.mu.Lock()
+	p.matrixCfg = cfg
+	p.mu.Unlock()
+}
+
+// MatrixConfig returns the currently-set matrix config (zero value if
+// SetMatrixConfig was never called).
+func (p *Plugin) MatrixConfig() MatrixConfig {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.matrixCfg
 }
 
 // Metrics returns the session-scoped connector metrics. Nil before

--- a/internal/probel-sw08p/consumer/plugin_matrix_config_test.go
+++ b/internal/probel-sw08p/consumer/plugin_matrix_config_test.go
@@ -1,0 +1,26 @@
+package probelsw08p
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+)
+
+// TestSetMatrixConfigRoundTrip pins the SW-P-08 consumer's matrix-
+// config getter/setter — same shape as sw02p so users carry one
+// mental model across both Probel protocols.
+func TestSetMatrixConfigRoundTrip(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	f := &Factory{}
+	p := f.New(logger).(*Plugin)
+
+	if got := p.MatrixConfig(); got != (MatrixConfig{}) {
+		t.Errorf("default MatrixConfig = %+v; want zero value", got)
+	}
+
+	want := MatrixConfig{MatrixID: 3, Level: 7, Dsts: 1024, Srcs: 768}
+	p.SetMatrixConfig(want)
+	if got := p.MatrixConfig(); got != want {
+		t.Errorf("MatrixConfig() = %+v; want %+v", got, want)
+	}
+}


### PR DESCRIPTION
Closes #128, #129, #130.

## Summary

Three follow-ups from the PR #106 close discussion landed together — they share the consumer-side matrix-config concept and the cross-protocol TCP keep-alive.

### #128 — sw02p bootstrap + keep-alive
- New `MatrixConfig{MatrixID, Level, Dsts, Srcs, InitialPoll, BootstrapSpacing, AppKeepaliveSpacing}` on the Plugin
- Bootstrap rx 01 sweep over `0..Dsts-1` at every (re)Connect (auto-escalates to rx 65 for dst > 1023)
- Rotating rx 01 keep-alive ping every 2 s (default), advancing the dst cursor modulo Dsts
- Fire-and-forget via `Client.Write` so the ping never collides with caller-driven `Send`s
- SW-P-02 has no in-protocol keep-alive command, so the `rx 01` / `tx 03` round-trip **is** the keep-alive — same trick VSM uses, verified live 2026-04-25

### #129 — Default TCP SO_KEEPALIVE on every TCP codec
- sw02p + sw08p: `ClientConfig.TCPKeepalivePeriod` (default 30 s, negative disables)
- osc consumer (accepted conns) + osc provider (dialed conns): unconditional 30 s keep-alive

### #130 — sw08p matrix-config parity
- Same `MatrixConfig{MatrixID, Level, Dsts, Srcs}` struct + `SetMatrixConfig` / `MatrixConfig` getters
- No bootstrap/keep-alive goroutine — sw08p has DLE-ACK at framing layer

### CLI wiring
- New `cmd_probel02p.go` with `runProbelsw02p` dispatcher + `watch` verb (closes the help-text gap — sw02p had no CLI dispatcher before)
- `extractMatrixConfigFlags` (sw08p) and `extractSW02MatrixConfigFlags` (sw02p) pull `--mtx-id` / `--level` / `--dsts` / `--srcs` out of args before sub-command dispatch
- sw02p adds `--initial-poll` / `--app-keepalive` / `--bootstrap-spacing` on top
- Renamed `runProbel` → `runProbelsw08p` and `runProbelSW02` → `runProbelsw02p` so dispatcher names match the protocol identifier symmetrically

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — full suite green
- [x] `golangci-lint run ./...` — 0 issues
- [x] 6 keep-alive unit tests on sw02p (bootstrap fires N, narrow→extended escalation at dst > 1023, bootstrap-disabled, ping-rotates round-robin, cancel-on-ctx, no-op when Dsts=0)
- [x] 1 sw08p MatrixConfig round-trip test
- [x] 1 sw02p TCP keepalive Dial test (verifies *net.TCPConn type)
- [x] CI: lint + ubuntu + windows + macos + rocky9 + rhel9-ubi + cross-compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)