### PR TITLE
feat(cli): list-commands + help-cmd across all 5 protocols

### DIFF
--- a/cmd/dhs/cmd_list_commands.go
+++ b/cmd/dhs/cmd_list_commands.go
@@ -1,0 +1,407 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	acp1 "acp/internal/acp1/consumer"
+	acp2 "acp/internal/acp2/consumer"
+	emberplus "acp/internal/emberplus/consumer"
+	codecsw02 "acp/internal/probel-sw02p/codec"
+	codecsw08 "acp/internal/probel-sw08p/codec"
+)
+
+// catalogueRow is the rendered shape used by `dhs list-commands` —
+// flat columns common across all protocols. Per-protocol catalogues
+// (which differ in their native shape) are projected into this row
+// type by the per-protocol adapter functions below.
+type catalogueRow struct {
+	Address     string `json:"address"`
+	Name        string `json:"name"`
+	Direction   string `json:"direction,omitempty"`
+	SpecRef     string `json:"spec_ref,omitempty"`
+	PayloadHint string `json:"payload_hint,omitempty"`
+	Notes       string `json:"notes,omitempty"`
+	Supported   bool   `json:"supported"`
+}
+
+// runListCommands implements `dhs list-commands <proto> [--format=table|json|md]`.
+// Sourced from each protocol's static catalogue exporter (no live device).
+func runListCommands(args []string) error {
+	if len(args) == 0 || hasHelpFlag(args) {
+		printListCommandsHelp(os.Stdout)
+		return nil
+	}
+	proto := args[0]
+	rest := args[1:]
+	format := "table"
+	for i := 0; i < len(rest); i++ {
+		switch {
+		case rest[i] == "--format" || rest[i] == "-format":
+			if i+1 >= len(rest) {
+				return fmt.Errorf("--format requires a value (table|json|md)")
+			}
+			format = rest[i+1]
+			i++
+		case strings.HasPrefix(rest[i], "--format=") || strings.HasPrefix(rest[i], "-format="):
+			format = strings.SplitN(rest[i], "=", 2)[1]
+		}
+	}
+	rows, err := catalogueRowsForProto(proto)
+	if err != nil {
+		return err
+	}
+	switch format {
+	case "table", "":
+		return renderCatalogueTable(os.Stdout, proto, rows)
+	case "json":
+		return renderCatalogueJSON(os.Stdout, proto, rows)
+	case "md", "markdown":
+		return renderCatalogueMarkdown(os.Stdout, proto, rows)
+	}
+	return fmt.Errorf("--format: unknown value %q (want table|json|md)", format)
+}
+
+// runHelpCmd implements `dhs help-cmd <proto> <address>` printing one
+// catalogue entry's full detail.
+func runHelpCmd(args []string) error {
+	if len(args) < 2 || hasHelpFlag(args) {
+		printHelpCmdHelp(os.Stdout)
+		return nil
+	}
+	proto := args[0]
+	addr := args[1]
+	row, ok, err := lookupCatalogueForProto(proto, addr)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("help-cmd %s: address %q not in catalogue (try `dhs list-commands %s`)", proto, addr, proto)
+	}
+	return renderCatalogueRowDetail(os.Stdout, proto, addr, row)
+}
+
+func catalogueRowsForProto(proto string) ([]catalogueRow, error) {
+	switch proto {
+	case "probel-sw02p":
+		return sw02pRows(), nil
+	case "probel-sw08p":
+		return sw08pRows(), nil
+	case "acp1":
+		return acp1Rows(), nil
+	case "acp2":
+		return acp2Rows(), nil
+	case "emberplus":
+		return emberplusRows(), nil
+	}
+	return nil, fmt.Errorf("list-commands: unknown protocol %q (acp1 | acp2 | emberplus | probel-sw02p | probel-sw08p)", proto)
+}
+
+func lookupCatalogueForProto(proto, addr string) (catalogueRow, bool, error) {
+	switch proto {
+	case "probel-sw02p":
+		id, ok := parseProbelByte(addr)
+		if !ok {
+			return catalogueRow{}, false, fmt.Errorf("probel-sw02p: %q is not a byte (try 0x.. or decimal)", addr)
+		}
+		spec, ok := codecsw02.CommandByID(codecsw02.CommandID(id))
+		if !ok {
+			return catalogueRow{}, false, nil
+		}
+		return sw02pRowFromSpec(spec), true, nil
+	case "probel-sw08p":
+		id, ok := parseProbelByte(addr)
+		if !ok {
+			return catalogueRow{}, false, fmt.Errorf("probel-sw08p: %q is not a byte (try 0x.. or decimal)", addr)
+		}
+		spec, ok := codecsw08.CommandByID(codecsw08.CommandID(id))
+		if !ok {
+			return catalogueRow{}, false, nil
+		}
+		return sw08pRowFromSpec(spec), true, nil
+	case "acp1":
+		entry, ok := acp1.LookupCatalogue(addr)
+		if !ok {
+			return catalogueRow{}, false, nil
+		}
+		return acp1RowFromEntry(entry), true, nil
+	case "acp2":
+		entry, ok := acp2.LookupCatalogue(addr)
+		if !ok {
+			return catalogueRow{}, false, nil
+		}
+		return acp2RowFromEntry(entry), true, nil
+	case "emberplus":
+		entry, ok := emberplus.LookupCatalogue(addr)
+		if !ok {
+			return catalogueRow{}, false, nil
+		}
+		return emberplusRowFromEntry(entry), true, nil
+	}
+	return catalogueRow{}, false, fmt.Errorf("help-cmd: unknown protocol %q", proto)
+}
+
+func sw02pRows() []catalogueRow {
+	cmds := codecsw02.Commands()
+	out := make([]catalogueRow, 0, len(cmds))
+	for _, c := range cmds {
+		out = append(out, sw02pRowFromSpec(c))
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Address < out[j].Address })
+	return out
+}
+
+func sw02pRowFromSpec(c codecsw02.CommandSpec) catalogueRow {
+	return catalogueRow{
+		Address:     fmt.Sprintf("0x%02x (%d)", uint8(c.ID), uint8(c.ID)),
+		Name:        c.Name,
+		Direction:   string(c.Direction),
+		SpecRef:     "SW-P-02 " + c.SpecRef,
+		PayloadHint: c.Payload,
+		Notes:       c.Notes,
+		Supported:   c.Supported,
+	}
+}
+
+func sw08pRows() []catalogueRow {
+	cmds := codecsw08.Commands()
+	out := make([]catalogueRow, 0, len(cmds))
+	for _, c := range cmds {
+		out = append(out, sw08pRowFromSpec(c))
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Address < out[j].Address })
+	return out
+}
+
+func sw08pRowFromSpec(c codecsw08.CommandSpec) catalogueRow {
+	return catalogueRow{
+		Address:     fmt.Sprintf("0x%02x (%d)", uint8(c.ID), uint8(c.ID)),
+		Name:        c.Name,
+		Direction:   string(c.Direction),
+		SpecRef:     "SW-P-08 " + c.SpecRef,
+		PayloadHint: c.Payload,
+		Notes:       c.Notes,
+		Supported:   c.Supported,
+	}
+}
+
+func acp1Rows() []catalogueRow {
+	entries := acp1.Catalogue()
+	out := make([]catalogueRow, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, acp1RowFromEntry(e))
+	}
+	return out
+}
+
+func acp1RowFromEntry(e acp1.CatalogueEntry) catalogueRow {
+	return catalogueRow{
+		Address:   e.Address(),
+		Name:      e.Name,
+		SpecRef:   "ACP1 " + e.SpecRef,
+		Notes:     e.Notes,
+		Supported: true,
+	}
+}
+
+func acp2Rows() []catalogueRow {
+	entries := acp2.Catalogue()
+	out := make([]catalogueRow, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, acp2RowFromEntry(e))
+	}
+	return out
+}
+
+func acp2RowFromEntry(e acp2.CatalogueEntry) catalogueRow {
+	return catalogueRow{
+		Address:   e.Address(),
+		Name:      e.Name,
+		SpecRef:   e.SpecRef,
+		Notes:     e.Notes,
+		Supported: true,
+	}
+}
+
+func emberplusRows() []catalogueRow {
+	entries := emberplus.Catalogue()
+	out := make([]catalogueRow, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, emberplusRowFromEntry(e))
+	}
+	return out
+}
+
+func emberplusRowFromEntry(e emberplus.CatalogueEntry) catalogueRow {
+	return catalogueRow{
+		Address:   e.Address(),
+		Name:      e.Name,
+		SpecRef:   e.SpecRef,
+		Notes:     e.Notes,
+		Supported: true,
+	}
+}
+
+// parseProbelByte accepts hex (0x..) or decimal, returns the uint8.
+func parseProbelByte(s string) (uint8, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, false
+	}
+	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
+		var n uint16
+		for _, c := range s[2:] {
+			var d uint16
+			switch {
+			case c >= '0' && c <= '9':
+				d = uint16(c - '0')
+			case c >= 'a' && c <= 'f':
+				d = uint16(c-'a') + 10
+			case c >= 'A' && c <= 'F':
+				d = uint16(c-'A') + 10
+			default:
+				return 0, false
+			}
+			n = n*16 + d
+			if n > 255 {
+				return 0, false
+			}
+		}
+		return uint8(n), true
+	}
+	var n uint16
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+		n = n*10 + uint16(c-'0')
+		if n > 255 {
+			return 0, false
+		}
+	}
+	return uint8(n), true
+}
+
+func renderCatalogueTable(w io.Writer, proto string, rows []catalogueRow) error {
+	_, _ = fmt.Fprintf(w, "# %s — %d catalogue entries\n\n", proto, len(rows))
+	maxAddr := 7
+	maxName := 4
+	maxDir := 3
+	for _, r := range rows {
+		if len(r.Address) > maxAddr {
+			maxAddr = len(r.Address)
+		}
+		if len(r.Name) > maxName {
+			maxName = len(r.Name)
+		}
+		if len(r.Direction) > maxDir {
+			maxDir = len(r.Direction)
+		}
+	}
+	header := fmt.Sprintf("%-*s  %-*s  %-*s  %s\n", maxAddr, "address", maxName, "name", maxDir, "dir", "spec / notes")
+	_, _ = fmt.Fprint(w, header)
+	_, _ = fmt.Fprint(w, strings.Repeat("-", len(header)-1)+"\n")
+	for _, r := range rows {
+		notes := r.SpecRef
+		if r.PayloadHint != "" {
+			notes = notes + " · " + r.PayloadHint
+		}
+		if r.Notes != "" {
+			notes = notes + " · " + r.Notes
+		}
+		_, _ = fmt.Fprintf(w, "%-*s  %-*s  %-*s  %s\n", maxAddr, r.Address, maxName, r.Name, maxDir, r.Direction, notes)
+	}
+	return nil
+}
+
+func renderCatalogueJSON(w io.Writer, proto string, rows []catalogueRow) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(map[string]interface{}{
+		"protocol": proto,
+		"count":    len(rows),
+		"entries":  rows,
+	})
+}
+
+func renderCatalogueMarkdown(w io.Writer, proto string, rows []catalogueRow) error {
+	_, _ = fmt.Fprintf(w, "# %s — %d catalogue entries\n\n", proto, len(rows))
+	_, _ = fmt.Fprintln(w, "| Address | Name | Dir | Spec | Payload | Notes |")
+	_, _ = fmt.Fprintln(w, "|---|---|---|---|---|---|")
+	for _, r := range rows {
+		_, _ = fmt.Fprintf(w, "| `%s` | %s | %s | %s | %s | %s |\n",
+			r.Address, r.Name, r.Direction, r.SpecRef, r.PayloadHint, r.Notes)
+	}
+	return nil
+}
+
+func renderCatalogueRowDetail(w io.Writer, proto, addr string, r catalogueRow) error {
+	_, _ = fmt.Fprintf(w, "%s · %s\n", proto, addr)
+	_, _ = fmt.Fprintln(w, strings.Repeat("=", 60))
+	_, _ = fmt.Fprintf(w, "Name:       %s\n", r.Name)
+	if r.Direction != "" {
+		_, _ = fmt.Fprintf(w, "Direction:  %s\n", r.Direction)
+	}
+	if r.SpecRef != "" {
+		_, _ = fmt.Fprintf(w, "Spec:       %s\n", r.SpecRef)
+	}
+	if r.PayloadHint != "" {
+		_, _ = fmt.Fprintf(w, "Payload:    %s\n", r.PayloadHint)
+	}
+	if r.Notes != "" {
+		_, _ = fmt.Fprintf(w, "Notes:      %s\n", r.Notes)
+	}
+	_, _ = fmt.Fprintf(w, "Supported:  %t\n", r.Supported)
+	return nil
+}
+
+func printListCommandsHelp(w io.Writer) {
+	_, _ = fmt.Fprintln(w, `dhs list-commands — enumerate the static command catalogue for a protocol
+
+USAGE
+  dhs list-commands <proto> [--format=table|json|md]
+
+PROTOCOLS
+  acp1           message-types, methods, object groups, object types, error codes
+  acp2           message-types, funcs, object types, property IDs, number types, error stat codes
+  emberplus      Glow element kinds + Command verbs (Parameter, Node, Function, Matrix, …)
+  probel-sw02p   wire byte commands (rx/tx)
+  probel-sw08p   wire byte commands (rx/tx)
+
+EXAMPLES
+  dhs list-commands probel-sw02p
+  dhs list-commands acp2 --format=json
+  dhs list-commands emberplus --format=md
+
+PAIRED VERB
+  dhs help-cmd <proto> <address>   drill into one entry`)
+}
+
+func printHelpCmdHelp(w io.Writer) {
+	_, _ = fmt.Fprintln(w, `dhs help-cmd — print full detail for one catalogue entry
+
+USAGE
+  dhs help-cmd <proto> <address>
+
+ADDRESS FORMAT (per protocol)
+  probel-sw02p / -sw08p   byte: 0x02, 0xFF, or decimal 2 / 255
+  acp1                    <kind>:<id>  (kinds: msgtype, method, objgroup, objtype, xport-err, obj-err)
+  acp2                    <kind>:<id>  (kinds: an2-type, an2-func, acp2-type, acp2-func, obj-type, pid, number-type, err-stat)
+  emberplus               <kind>:<name>  (kind:Parameter, cmd:GetDirectory)
+                          OR  numeric OID path  (1.2.4.1.0.2)
+                          OR  dotted label path (root.foo.bar)
+
+EXAMPLES
+  dhs help-cmd probel-sw02p 0x02
+  dhs help-cmd acp1 method:0
+  dhs help-cmd acp2 pid:4
+  dhs help-cmd emberplus kind:Parameter
+  dhs help-cmd emberplus 1.2.4.1.0.2
+
+PAIRED VERB
+  dhs list-commands <proto>   show every entry`)
+}

--- a/cmd/dhs/cmd_list_commands_test.go
+++ b/cmd/dhs/cmd_list_commands_test.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestCatalogueRowsForProtoCoversAllProtocols pins that every
+// registered protocol returns a non-empty catalogue. New protocols
+// are required to extend the dispatcher (or this test fails).
+func TestCatalogueRowsForProtoCoversAllProtocols(t *testing.T) {
+	for _, p := range []string{"acp1", "acp2", "emberplus", "probel-sw02p", "probel-sw08p"} {
+		t.Run(p, func(t *testing.T) {
+			rows, err := catalogueRowsForProto(p)
+			if err != nil {
+				t.Fatalf("catalogueRowsForProto(%q): %v", p, err)
+			}
+			if len(rows) == 0 {
+				t.Fatalf("catalogueRowsForProto(%q): empty", p)
+			}
+			for i, r := range rows {
+				if r.Address == "" {
+					t.Errorf("rows[%d].Address empty", i)
+				}
+				if r.Name == "" {
+					t.Errorf("rows[%d].Name empty", i)
+				}
+			}
+		})
+	}
+}
+
+// TestCatalogueRowsForProtoUnknown rejects unknown protocols with a
+// helpful error message.
+func TestCatalogueRowsForProtoUnknown(t *testing.T) {
+	_, err := catalogueRowsForProto("not-a-protocol")
+	if err == nil {
+		t.Fatal("expected error for unknown protocol; got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown protocol") {
+		t.Errorf("error missing 'unknown protocol': %v", err)
+	}
+}
+
+// TestLookupCatalogueProbelByByte exercises the probel-sw02p / -sw08p
+// byte-address path (decimal + hex).
+func TestLookupCatalogueProbelByByte(t *testing.T) {
+	cases := []struct {
+		proto, addr string
+		wantPrefix  string // expected Name prefix
+	}{
+		{"probel-sw02p", "0x02", "connect"},
+		{"probel-sw02p", "2", "connect"},
+		{"probel-sw02p", "0x01", "interrogate"},
+		{"probel-sw08p", "0x02", "rx 002 Crosspoint Connect"},
+		{"probel-sw08p", "120", "rx 120 Crosspoint Connect-On-Go Salvo"},
+	}
+	for _, c := range cases {
+		t.Run(c.proto+"/"+c.addr, func(t *testing.T) {
+			row, ok, err := lookupCatalogueForProto(c.proto, c.addr)
+			if err != nil {
+				t.Fatalf("lookup(%q, %q): %v", c.proto, c.addr, err)
+			}
+			if !ok {
+				t.Fatalf("lookup(%q, %q): not found", c.proto, c.addr)
+			}
+			if !strings.HasPrefix(row.Name, c.wantPrefix) {
+				t.Errorf("Name = %q; want prefix %q", row.Name, c.wantPrefix)
+			}
+		})
+	}
+}
+
+// TestLookupCatalogueACPKindAddressing exercises the ACP1 / ACP2
+// kind:id address shape.
+func TestLookupCatalogueACPKindAddressing(t *testing.T) {
+	cases := []struct {
+		proto, addr string
+		wantName    string
+	}{
+		{"acp1", "method:0", "getValue"},
+		{"acp1", "method:5", "getObject"},
+		{"acp1", "objgroup:2", "control"},
+		{"acp2", "pid:4", "announce_delay"},
+		{"acp2", "acp2-func:1", "get_object"},
+		{"acp2", "obj-type:0", "node"},
+	}
+	for _, c := range cases {
+		t.Run(c.proto+"/"+c.addr, func(t *testing.T) {
+			row, ok, err := lookupCatalogueForProto(c.proto, c.addr)
+			if err != nil {
+				t.Fatalf("lookup: %v", err)
+			}
+			if !ok {
+				t.Fatalf("lookup: not found")
+			}
+			if row.Name != c.wantName {
+				t.Errorf("Name = %q; want %q", row.Name, c.wantName)
+			}
+		})
+	}
+}
+
+// TestLookupCatalogueEmberplusPaths checks all three Ember+ address
+// forms: kind:Name, OID path, dotted label path.
+func TestLookupCatalogueEmberplusPaths(t *testing.T) {
+	cases := []struct {
+		addr     string
+		wantName string
+	}{
+		{"kind:Parameter", "Parameter"},
+		{"cmd:GetDirectory", "GetDirectory"},
+		{"1.2.4.1.0.2", "1.2.4.1.0.2"},
+		{"root.foo.bar", "root.foo.bar"},
+	}
+	for _, c := range cases {
+		t.Run(c.addr, func(t *testing.T) {
+			row, ok, err := lookupCatalogueForProto("emberplus", c.addr)
+			if err != nil {
+				t.Fatalf("lookup: %v", err)
+			}
+			if !ok {
+				t.Fatalf("lookup: not found")
+			}
+			if row.Name != c.wantName {
+				t.Errorf("Name = %q; want %q", row.Name, c.wantName)
+			}
+		})
+	}
+}
+
+// TestLookupCatalogueMissingByte returns ok=false for a byte that
+// isn't in the codec's catalogue (e.g. unsupported sw02p byte).
+func TestLookupCatalogueMissingByte(t *testing.T) {
+	_, ok, err := lookupCatalogueForProto("probel-sw02p", "0x80")
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if ok {
+		t.Errorf("byte 0x80 should not be in the sw02p catalogue (yet)")
+	}
+}
+
+// TestRenderCatalogueJSONIsValid pins that --format=json output
+// parses back as the expected envelope.
+func TestRenderCatalogueJSONIsValid(t *testing.T) {
+	rows, err := catalogueRowsForProto("probel-sw02p")
+	if err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := renderCatalogueJSON(&buf, "probel-sw02p", rows); err != nil {
+		t.Fatalf("renderJSON: %v", err)
+	}
+	var got struct {
+		Protocol string         `json:"protocol"`
+		Count    int            `json:"count"`
+		Entries  []catalogueRow `json:"entries"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, buf.String())
+	}
+	if got.Protocol != "probel-sw02p" {
+		t.Errorf("Protocol = %q; want probel-sw02p", got.Protocol)
+	}
+	if got.Count != len(rows) {
+		t.Errorf("Count = %d; want %d", got.Count, len(rows))
+	}
+	if len(got.Entries) != len(rows) {
+		t.Errorf("Entries len = %d; want %d", len(got.Entries), len(rows))
+	}
+}
+
+// TestParseProbelByte covers hex/decimal accept + reject.
+func TestParseProbelByte(t *testing.T) {
+	cases := []struct {
+		in       string
+		want     uint8
+		wantOk   bool
+	}{
+		{"0", 0, true},
+		{"255", 255, true},
+		{"0x00", 0, true},
+		{"0xFF", 255, true},
+		{"0xff", 255, true},
+		{"256", 0, false},
+		{"abc", 0, false},
+		{"", 0, false},
+		{"0x100", 0, false},
+	}
+	for _, c := range cases {
+		got, ok := parseProbelByte(c.in)
+		if ok != c.wantOk || got != c.want {
+			t.Errorf("parseProbelByte(%q) = (%d, %t); want (%d, %t)", c.in, got, ok, c.want, c.wantOk)
+		}
+	}
+}

--- a/cmd/dhs/main.go
+++ b/cmd/dhs/main.go
@@ -120,6 +120,18 @@ func main() {
 			os.Exit(1)
 		}
 		return
+	case "list-commands":
+		if err := runListCommands(args[1:]); err != nil {
+			fmt.Fprintln(os.Stderr, "error:", err)
+			os.Exit(1)
+		}
+		return
+	case "help-cmd":
+		if err := runHelpCmd(args[1:]); err != nil {
+			fmt.Fprintln(os.Stderr, "error:", err)
+			os.Exit(1)
+		}
+		return
 	case "consumer":
 		if err := dispatchConsumer(ctx, args[1:]); err != nil {
 			fmt.Fprintln(os.Stderr, "error:", err)

--- a/internal/acp1/consumer/catalogue.go
+++ b/internal/acp1/consumer/catalogue.go
@@ -1,0 +1,167 @@
+package acp1
+
+// CommandKind groups ACP1 catalogue entries. ACP1 has no single "byte
+// command" namespace like Probel — its wire protocol mixes message
+// types (MType), method IDs (MCODE), object groups, object types, and
+// error codes. The CLI catalogue surfaces all four as parallel kinds
+// addressable as `<kind>:<id>` (e.g. `method:0`, `objgroup:2`).
+type CommandKind string
+
+const (
+	KindMessageType CommandKind = "msgtype"
+	KindMethod      CommandKind = "method"
+	KindObjGroup    CommandKind = "objgroup"
+	KindObjType     CommandKind = "objtype"
+	KindXportErr    CommandKind = "xport-err"
+	KindObjErr      CommandKind = "obj-err"
+)
+
+// CatalogueEntry is the structured row used by the CLI catalogue
+// renderers (`dhs list-commands acp1`, `dhs help-cmd acp1 <addr>`).
+type CatalogueEntry struct {
+	Kind    CommandKind
+	ID      uint8
+	Name    string
+	SpecRef string
+	Notes   string
+}
+
+// Address returns the canonical "<kind>:<id>" string used by
+// `dhs help-cmd acp1 <addr>`.
+func (c CatalogueEntry) Address() string {
+	return string(c.Kind) + ":" + uint8ToDec(c.ID)
+}
+
+// Catalogue returns every ACP1 catalogue entry the consumer knows.
+// Order: MType → Methods → Object groups → Object types → ACP errors
+// → AxonNet errors. Used by the CLI catalogue helpers.
+//
+// Source of truth: AXON-ACP_v1_4.pdf, mirrored from the const blocks
+// in this package's types.go.
+func Catalogue() []CatalogueEntry {
+	out := []CatalogueEntry{
+		// Message types (MType field, 1 byte at header offset 5).
+		{Kind: KindMessageType, ID: uint8(MTypeAnnounce), Name: "Announce", SpecRef: "p. 8", Notes: "MTID=0; broadcast"},
+		{Kind: KindMessageType, ID: uint8(MTypeRequest), Name: "Request", SpecRef: "p. 8", Notes: "client → server"},
+		{Kind: KindMessageType, ID: uint8(MTypeReply), Name: "Reply", SpecRef: "p. 8", Notes: "server → client"},
+		{Kind: KindMessageType, ID: uint8(MTypeError), Name: "Error", SpecRef: "p. 8", Notes: "MCODE = error code"},
+
+		// Methods (MCODE byte when MType < 3). Spec §"Methods" p. 28.
+		{Kind: KindMethod, ID: uint8(MethodGetValue), Name: "getValue", SpecRef: "p. 28"},
+		{Kind: KindMethod, ID: uint8(MethodSetValue), Name: "setValue", SpecRef: "p. 28"},
+		{Kind: KindMethod, ID: uint8(MethodSetIncValue), Name: "setIncValue", SpecRef: "p. 28"},
+		{Kind: KindMethod, ID: uint8(MethodSetDecValue), Name: "setDecValue", SpecRef: "p. 28"},
+		{Kind: KindMethod, ID: uint8(MethodSetDefValue), Name: "setDefValue", SpecRef: "p. 28"},
+		{Kind: KindMethod, ID: uint8(MethodGetObject), Name: "getObject", SpecRef: "p. 28", Notes: "returns all properties in sequence"},
+
+		// Object groups. Spec §"Object Groups" p. 17.
+		{Kind: KindObjGroup, ID: uint8(GroupRoot), Name: "root", SpecRef: "p. 17", Notes: "1 object, card counts per group"},
+		{Kind: KindObjGroup, ID: uint8(GroupIdentity), Name: "identity", SpecRef: "p. 17"},
+		{Kind: KindObjGroup, ID: uint8(GroupControl), Name: "control", SpecRef: "p. 17", Notes: "writable parameters"},
+		{Kind: KindObjGroup, ID: uint8(GroupStatus), Name: "status", SpecRef: "p. 17", Notes: "read-only"},
+		{Kind: KindObjGroup, ID: uint8(GroupAlarm), Name: "alarm", SpecRef: "p. 17"},
+		{Kind: KindObjGroup, ID: uint8(GroupFile), Name: "file", SpecRef: "p. 17", Notes: "firmware + param table"},
+		{Kind: KindObjGroup, ID: uint8(GroupFrame), Name: "frame", SpecRef: "p. 17", Notes: "rack controller only"},
+
+		// Object types. Spec §"Object details" p. 19 + per-type tables p. 21–27.
+		{Kind: KindObjType, ID: uint8(TypeRoot), Name: "ROOT", SpecRef: "p. 21", Notes: "9 props"},
+		{Kind: KindObjType, ID: uint8(TypeInteger), Name: "INTEGER", SpecRef: "p. 22", Notes: "10 props (i16)"},
+		{Kind: KindObjType, ID: uint8(TypeIPAddr), Name: "IPADDR", SpecRef: "p. 22", Notes: "10 props (u32)"},
+		{Kind: KindObjType, ID: uint8(TypeFloat), Name: "FLOAT", SpecRef: "p. 23", Notes: "10 props (float32)"},
+		{Kind: KindObjType, ID: uint8(TypeEnum), Name: "ENUMERATED", SpecRef: "p. 24", Notes: "8 props"},
+		{Kind: KindObjType, ID: uint8(TypeString), Name: "STRING", SpecRef: "p. 25", Notes: "6 props"},
+		{Kind: KindObjType, ID: uint8(TypeFrame), Name: "FRAME STATUS", SpecRef: "p. 25", Notes: "4 props, read-only"},
+		{Kind: KindObjType, ID: uint8(TypeAlarm), Name: "ALARM", SpecRef: "p. 26", Notes: "8 props"},
+		{Kind: KindObjType, ID: uint8(TypeFile), Name: "FILE", SpecRef: "p. 26", Notes: "5 props; engineer-mode only"},
+		{Kind: KindObjType, ID: uint8(TypeLong), Name: "LONG", SpecRef: "p. 27", Notes: "10 props (i32)"},
+		{Kind: KindObjType, ID: uint8(TypeByte), Name: "BYTE", SpecRef: "p. 27", Notes: "10 props (u8)"},
+
+		// ACP transport errors (MType=3, MCODE < 16). Spec §"ACP Header" p. 11.
+		{Kind: KindXportErr, ID: uint8(TErrUndefined), Name: "undefined", SpecRef: "p. 11"},
+		{Kind: KindXportErr, ID: uint8(TErrInternalBusComm), Name: "internal-bus-comm", SpecRef: "p. 11"},
+		{Kind: KindXportErr, ID: uint8(TErrInternalBusTimeout), Name: "internal-bus-timeout", SpecRef: "p. 11"},
+		{Kind: KindXportErr, ID: uint8(TErrTransactionTimeout), Name: "transaction-timeout", SpecRef: "p. 11"},
+		{Kind: KindXportErr, ID: uint8(TErrOutOfResources), Name: "out-of-resources", SpecRef: "p. 11"},
+
+		// AxonNet object errors (MType=3, MCODE >= 16). Spec §"AxonNet error codes" p. 29.
+		{Kind: KindObjErr, ID: uint8(OErrGroupNoExist), Name: "object-group-not-exist", SpecRef: "p. 29"},
+		{Kind: KindObjErr, ID: uint8(OErrInstanceNoExist), Name: "object-instance-not-exist", SpecRef: "p. 29"},
+		{Kind: KindObjErr, ID: uint8(OErrPropertyNoExist), Name: "object-property-not-exist", SpecRef: "p. 29"},
+		{Kind: KindObjErr, ID: uint8(OErrNoWriteAccess), Name: "no-write-access", SpecRef: "p. 29"},
+		{Kind: KindObjErr, ID: uint8(OErrNoReadAccess), Name: "no-read-access", SpecRef: "p. 29"},
+		{Kind: KindObjErr, ID: uint8(OErrNoSetDefAccess), Name: "no-setDefault-access", SpecRef: "p. 29"},
+		{Kind: KindObjErr, ID: uint8(OErrTypeNoExist), Name: "object-type-not-exist", SpecRef: "p. 29"},
+		{Kind: KindObjErr, ID: uint8(OErrIllegalMethod), Name: "illegal-method", SpecRef: "p. 29"},
+		{Kind: KindObjErr, ID: uint8(OErrIllegalForType), Name: "illegal-method-for-type", SpecRef: "p. 29"},
+		{Kind: KindObjErr, ID: uint8(OErrFile), Name: "file-error", SpecRef: "p. 29"},
+		{Kind: KindObjErr, ID: uint8(OErrSPFConstraint), Name: "SPF-constraint-violation", SpecRef: "p. 29"},
+		{Kind: KindObjErr, ID: uint8(OErrSPFBufferFull), Name: "SPF-buffer-full", SpecRef: "p. 29", Notes: "retry"},
+	}
+	return out
+}
+
+// LookupCatalogue returns the entry matching `<kind>:<id>` (e.g.
+// "method:0"). Returns false if either the kind is unknown or the id
+// isn't in this codec's catalogue.
+func LookupCatalogue(addr string) (CatalogueEntry, bool) {
+	kind, id, ok := splitAddress(addr)
+	if !ok {
+		return CatalogueEntry{}, false
+	}
+	for _, e := range Catalogue() {
+		if e.Kind == kind && e.ID == id {
+			return e, true
+		}
+	}
+	return CatalogueEntry{}, false
+}
+
+// splitAddress parses "<kind>:<id>" into its components.
+func splitAddress(s string) (CommandKind, uint8, bool) {
+	for i := 0; i < len(s); i++ {
+		if s[i] == ':' {
+			k := CommandKind(s[:i])
+			rest := s[i+1:]
+			n, err := decToUint8(rest)
+			if err {
+				return "", 0, false
+			}
+			return k, n, true
+		}
+	}
+	return "", 0, false
+}
+
+// uint8ToDec / decToUint8 are tiny stdlib-free converters used by the
+// catalogue helpers — keeps consumer/types.go independent of strconv
+// imports it doesn't already pull in.
+func uint8ToDec(n uint8) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [3]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0') + n%10
+		n /= 10
+	}
+	return string(buf[i:])
+}
+
+func decToUint8(s string) (uint8, bool) {
+	if s == "" || len(s) > 3 {
+		return 0, true
+	}
+	var n uint16
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0, true
+		}
+		n = n*10 + uint16(c-'0')
+		if n > 255 {
+			return 0, true
+		}
+	}
+	return uint8(n), false
+}

--- a/internal/acp2/consumer/catalogue.go
+++ b/internal/acp2/consumer/catalogue.go
@@ -1,0 +1,181 @@
+package acp2
+
+// CommandKind groups ACP2 catalogue entries. ACP2 mixes AN2 transport
+// constants (frame type, internal func IDs) with ACP2 application
+// constants (message type, function IDs, object types, property IDs,
+// error stat codes, number types). The CLI catalogue surfaces all
+// kinds in parallel addressable as `<kind>:<id>`.
+type CommandKind string
+
+const (
+	KindAN2Type     CommandKind = "an2-type"     // AN2 frame type field (request/reply/event/error/data)
+	KindAN2Func     CommandKind = "an2-func"     // AN2 internal func ID (proto=0)
+	KindACP2Type    CommandKind = "acp2-type"    // ACP2 message type byte
+	KindACP2Func    CommandKind = "acp2-func"    // ACP2 application func ID
+	KindObjType     CommandKind = "obj-type"     // ACP2 object type
+	KindPid         CommandKind = "pid"          // ACP2 property ID
+	KindNumberType  CommandKind = "number-type"  // ACP2 numeric vtype
+	KindErrStat     CommandKind = "err-stat"     // ACP2 error stat code
+)
+
+// CatalogueEntry is the structured row used by the CLI catalogue
+// renderers (`dhs list-commands acp2`, `dhs help-cmd acp2 <addr>`).
+type CatalogueEntry struct {
+	Kind    CommandKind
+	ID      uint8
+	Name    string
+	SpecRef string
+	Notes   string
+}
+
+// Address returns the canonical "<kind>:<id>" string used by
+// `dhs help-cmd acp2 <addr>`.
+func (c CatalogueEntry) Address() string {
+	return string(c.Kind) + ":" + uint8ToDec(c.ID)
+}
+
+// Catalogue returns every ACP2 catalogue entry the consumer knows.
+// Source of truth: acp2_protocol.pdf + an2_protocol.pdf, mirrored
+// from the const blocks in this package's types.go and from
+// internal/acp2/CLAUDE.md.
+func Catalogue() []CatalogueEntry {
+	return []CatalogueEntry{
+		// AN2 frame types
+		{Kind: KindAN2Type, ID: uint8(AN2TypeRequest), Name: "request", SpecRef: "AN2"},
+		{Kind: KindAN2Type, ID: uint8(AN2TypeReply), Name: "reply", SpecRef: "AN2"},
+		{Kind: KindAN2Type, ID: uint8(AN2TypeEvent), Name: "event", SpecRef: "AN2"},
+		{Kind: KindAN2Type, ID: uint8(AN2TypeError), Name: "error", SpecRef: "AN2"},
+		{Kind: KindAN2Type, ID: uint8(AN2TypeData), Name: "data", SpecRef: "AN2", Notes: "ACP1/ACP2 messages travel in data frames"},
+
+		// AN2 internal funcs (proto=0)
+		{Kind: KindAN2Func, ID: AN2FuncGetVersion, Name: "GetVersion", SpecRef: "AN2 §4"},
+		{Kind: KindAN2Func, ID: AN2FuncGetDeviceInfo, Name: "GetDeviceInfo", SpecRef: "AN2 §4"},
+		{Kind: KindAN2Func, ID: AN2FuncGetSlotInfo, Name: "GetSlotInfo", SpecRef: "AN2 §4"},
+		{Kind: KindAN2Func, ID: AN2FuncEnableProtocolEvents, Name: "EnableProtocolEvents", SpecRef: "AN2 §4", Notes: "REQUIRED for ACP2 announces"},
+
+		// ACP2 message types
+		{Kind: KindACP2Type, ID: uint8(ACP2TypeRequest), Name: "request", SpecRef: "ACP2 §1"},
+		{Kind: KindACP2Type, ID: uint8(ACP2TypeReply), Name: "reply", SpecRef: "ACP2 §1"},
+		{Kind: KindACP2Type, ID: uint8(ACP2TypeAnnounce), Name: "announce", SpecRef: "ACP2 §1", Notes: "NOT 'event'"},
+		{Kind: KindACP2Type, ID: uint8(ACP2TypeError), Name: "error", SpecRef: "ACP2 §1"},
+
+		// ACP2 application funcs
+		{Kind: KindACP2Func, ID: uint8(ACP2FuncGetVersion), Name: "get_version", SpecRef: "ACP2 §3"},
+		{Kind: KindACP2Func, ID: uint8(ACP2FuncGetObject), Name: "get_object", SpecRef: "ACP2 §3", Notes: "all property headers for obj-id"},
+		{Kind: KindACP2Func, ID: uint8(ACP2FuncGetProperty), Name: "get_property", SpecRef: "ACP2 §3"},
+		{Kind: KindACP2Func, ID: uint8(ACP2FuncSetProperty), Name: "set_property", SpecRef: "ACP2 §3"},
+
+		// Object types
+		{Kind: KindObjType, ID: 0, Name: "node", SpecRef: "ACP2 §4", Notes: "container; children via pid 14"},
+		{Kind: KindObjType, ID: 1, Name: "preset", SpecRef: "ACP2 §4", Notes: "value repeated per idx"},
+		{Kind: KindObjType, ID: 2, Name: "enum", SpecRef: "ACP2 §4"},
+		{Kind: KindObjType, ID: 3, Name: "number", SpecRef: "ACP2 §4"},
+		{Kind: KindObjType, ID: 4, Name: "ipv4", SpecRef: "ACP2 §4"},
+		{Kind: KindObjType, ID: 5, Name: "string", SpecRef: "ACP2 §4", Notes: "UTF-8"},
+
+		// Property IDs
+		{Kind: KindPid, ID: 1, Name: "object_type", SpecRef: "ACP2 §5"},
+		{Kind: KindPid, ID: 2, Name: "label", SpecRef: "ACP2 §5", Notes: "0-terminated UTF-8"},
+		{Kind: KindPid, ID: 3, Name: "access", SpecRef: "ACP2 §5", Notes: "1=r, 2=w, 3=rw"},
+		{Kind: KindPid, ID: 4, Name: "announce_delay", SpecRef: "ACP2 §5", Notes: "u32 ms — NOT 'event_delay'"},
+		{Kind: KindPid, ID: 5, Name: "number_type", SpecRef: "ACP2 §5"},
+		{Kind: KindPid, ID: 6, Name: "string_max_length", SpecRef: "ACP2 §5", Notes: "u16"},
+		{Kind: KindPid, ID: 7, Name: "preset_depth", SpecRef: "ACP2 §5", Notes: "valid idx list"},
+		{Kind: KindPid, ID: 8, Name: "value", SpecRef: "ACP2 §5", Notes: "repeated per preset idx"},
+		{Kind: KindPid, ID: 9, Name: "default_value", SpecRef: "ACP2 §5", Notes: "repeated per preset idx"},
+		{Kind: KindPid, ID: 10, Name: "min_value", SpecRef: "ACP2 §5", Notes: "repeated per preset idx"},
+		{Kind: KindPid, ID: 11, Name: "max_value", SpecRef: "ACP2 §5", Notes: "repeated per preset idx"},
+		{Kind: KindPid, ID: 12, Name: "step_size", SpecRef: "ACP2 §5", Notes: "optional"},
+		{Kind: KindPid, ID: 13, Name: "unit", SpecRef: "ACP2 §5", Notes: "optional, 0-terminated"},
+		{Kind: KindPid, ID: 14, Name: "children", SpecRef: "ACP2 §5", Notes: "u32[] child obj-ids"},
+		{Kind: KindPid, ID: 15, Name: "options", SpecRef: "ACP2 §5", Notes: "enum: 72 bytes per option"},
+		{Kind: KindPid, ID: 16, Name: "event_tag", SpecRef: "ACP2 §5", Notes: "optional, u16"},
+		{Kind: KindPid, ID: 17, Name: "event_prio", SpecRef: "ACP2 §5", Notes: "optional"},
+		{Kind: KindPid, ID: 18, Name: "event_state", SpecRef: "ACP2 §5", Notes: "optional"},
+		{Kind: KindPid, ID: 19, Name: "event_messages", SpecRef: "ACP2 §5", Notes: "optional, two strings"},
+		{Kind: KindPid, ID: 20, Name: "preset_parent", SpecRef: "ACP2 §5", Notes: "optional, u32"},
+
+		// Number types
+		{Kind: KindNumberType, ID: 0, Name: "S8", SpecRef: "ACP2 §6"},
+		{Kind: KindNumberType, ID: 1, Name: "S16", SpecRef: "ACP2 §6"},
+		{Kind: KindNumberType, ID: 2, Name: "S32", SpecRef: "ACP2 §6"},
+		{Kind: KindNumberType, ID: 3, Name: "S64", SpecRef: "ACP2 §6"},
+		{Kind: KindNumberType, ID: 4, Name: "U8", SpecRef: "ACP2 §6"},
+		{Kind: KindNumberType, ID: 5, Name: "U16", SpecRef: "ACP2 §6"},
+		{Kind: KindNumberType, ID: 6, Name: "U32", SpecRef: "ACP2 §6"},
+		{Kind: KindNumberType, ID: 7, Name: "U64", SpecRef: "ACP2 §6"},
+		{Kind: KindNumberType, ID: 8, Name: "float", SpecRef: "ACP2 §6"},
+		{Kind: KindNumberType, ID: 9, Name: "preset/enum", SpecRef: "ACP2 §6"},
+		{Kind: KindNumberType, ID: 10, Name: "ipv4", SpecRef: "ACP2 §6"},
+		{Kind: KindNumberType, ID: 11, Name: "string", SpecRef: "ACP2 §6"},
+
+		// Error stat codes (ACP2 type=3)
+		{Kind: KindErrStat, ID: 0, Name: "protocol-error", SpecRef: "ACP2 §7", Notes: "bad type/func/packet"},
+		{Kind: KindErrStat, ID: 1, Name: "invalid-obj-id", SpecRef: "ACP2 §7"},
+		{Kind: KindErrStat, ID: 2, Name: "invalid-idx", SpecRef: "ACP2 §7"},
+		{Kind: KindErrStat, ID: 3, Name: "invalid-pid", SpecRef: "ACP2 §7", Notes: "or object lacks this property"},
+		{Kind: KindErrStat, ID: 4, Name: "no-access", SpecRef: "ACP2 §7", Notes: "read-only, set attempted"},
+		{Kind: KindErrStat, ID: 5, Name: "invalid-value", SpecRef: "ACP2 §7", Notes: "enum/preset out of options, etc."},
+	}
+}
+
+// LookupCatalogue returns the entry matching `<kind>:<id>` (e.g.
+// "pid:4", "acp2-func:1"). Returns false if either the kind is
+// unknown or the id isn't in this codec's catalogue.
+func LookupCatalogue(addr string) (CatalogueEntry, bool) {
+	kind, id, ok := splitAddress(addr)
+	if !ok {
+		return CatalogueEntry{}, false
+	}
+	for _, e := range Catalogue() {
+		if e.Kind == kind && e.ID == id {
+			return e, true
+		}
+	}
+	return CatalogueEntry{}, false
+}
+
+func splitAddress(s string) (CommandKind, uint8, bool) {
+	for i := 0; i < len(s); i++ {
+		if s[i] == ':' {
+			k := CommandKind(s[:i])
+			n, err := decToUint8(s[i+1:])
+			if err {
+				return "", 0, false
+			}
+			return k, n, true
+		}
+	}
+	return "", 0, false
+}
+
+func uint8ToDec(n uint8) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [3]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0') + n%10
+		n /= 10
+	}
+	return string(buf[i:])
+}
+
+func decToUint8(s string) (uint8, bool) {
+	if s == "" || len(s) > 3 {
+		return 0, true
+	}
+	var n uint16
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0, true
+		}
+		n = n*10 + uint16(c-'0')
+		if n > 255 {
+			return 0, true
+		}
+	}
+	return uint8(n), false
+}

--- a/internal/emberplus/consumer/catalogue.go
+++ b/internal/emberplus/consumer/catalogue.go
@@ -1,0 +1,155 @@
+package emberplus
+
+import "strings"
+
+// CommandKind groups Ember+ catalogue entries. Unlike byte-cmd
+// protocols (Probel, ACP1/2), Ember+ Glow uses BER CHOICE-of-tag —
+// there's no "command byte 7" to look up. Instead the protocol model
+// surfaces as Glow element kinds + Command verbs + path addressing.
+//
+// `dhs help-cmd emberplus <addr>` accepts either a `<kind>:<name>`
+// shape (e.g. `kind:Parameter`, `cmd:GetDirectory`) OR a numeric OID
+// path (`1.2.4.1.0.2`) OR a dotted label path (`root.foo.bar`).
+type CommandKind string
+
+const (
+	KindElement CommandKind = "kind"  // Glow element kind (Parameter, Node, …)
+	KindCommand CommandKind = "cmd"   // Glow Command verb (GetDirectory, Subscribe, …)
+	KindOID     CommandKind = "oid"   // numeric OID path (e.g. 1.2.4.1.0.2)
+	KindPath    CommandKind = "path"  // dotted-label path (e.g. root.foo.bar)
+)
+
+// CatalogueEntry is the structured row used by the CLI catalogue
+// renderers (`dhs list-commands emberplus`, `dhs help-cmd emberplus
+// <addr>`).
+type CatalogueEntry struct {
+	Kind    CommandKind
+	Name    string
+	SpecRef string
+	Notes   string
+}
+
+// Address returns the canonical "<kind>:<name>" string used by
+// `dhs help-cmd emberplus <addr>`. For OID and Path kinds the user
+// passes the path directly without a `kind:` prefix.
+func (c CatalogueEntry) Address() string {
+	return string(c.Kind) + ":" + c.Name
+}
+
+// Catalogue returns every Ember+ catalogue entry the consumer knows
+// at the protocol-model level — Glow element kinds plus the Command
+// verbs. OID paths and dotted-label paths address INSTANCES inside a
+// connected device's tree, not protocol-model entries; they're
+// resolvable via `dhs help-cmd emberplus <path>` against a captured
+// tree.json file (out of scope for this static catalogue).
+//
+// Source of truth: Ember+ Documentation.pdf §Glow + ASN.1 schema in
+// internal/emberplus/codec/glow/tags.go.
+func Catalogue() []CatalogueEntry {
+	return []CatalogueEntry{
+		// Glow element kinds (top-level CHOICE alternatives in the Glow tree)
+		{Kind: KindElement, Name: "Parameter", SpecRef: "Glow §3.2.1", Notes: "leaf with typed value (int / real / string / boolean / octets / enum)"},
+		{Kind: KindElement, Name: "QualifiedParameter", SpecRef: "Glow §3.2.2", Notes: "Parameter addressed by full OID path"},
+		{Kind: KindElement, Name: "Node", SpecRef: "Glow §3.2.3", Notes: "container with children"},
+		{Kind: KindElement, Name: "QualifiedNode", SpecRef: "Glow §3.2.4", Notes: "Node addressed by full OID path"},
+		{Kind: KindElement, Name: "Function", SpecRef: "Glow §3.2.5", Notes: "RPC-callable; arguments + result"},
+		{Kind: KindElement, Name: "QualifiedFunction", SpecRef: "Glow §3.2.6", Notes: "Function addressed by full OID path"},
+		{Kind: KindElement, Name: "Matrix", SpecRef: "Glow §3.2.7", Notes: "src/dst routing matrix; sub-elements: Sources / Targets / Connections / Labels / Parameters"},
+		{Kind: KindElement, Name: "QualifiedMatrix", SpecRef: "Glow §3.2.8", Notes: "Matrix addressed by full OID path"},
+		{Kind: KindElement, Name: "StreamCollection", SpecRef: "Glow §3.3.1", Notes: "stream entries (audio meters, telemetry)"},
+		{Kind: KindElement, Name: "StreamEntry", SpecRef: "Glow §3.3.2", Notes: "single stream payload referencing a Parameter by OID"},
+		{Kind: KindElement, Name: "Template", SpecRef: "Glow §3.4", Notes: "shared sub-tree referenced by multiple Nodes"},
+		{Kind: KindElement, Name: "QualifiedTemplate", SpecRef: "Glow §3.4", Notes: "Template addressed by full OID path"},
+		{Kind: KindElement, Name: "Invocation", SpecRef: "Glow §3.2.5", Notes: "Function call descriptor + argument tuple"},
+		{Kind: KindElement, Name: "InvocationResult", SpecRef: "Glow §3.2.5", Notes: "Function call return value"},
+		{Kind: KindElement, Name: "ElementCollection", SpecRef: "Glow §3.1", Notes: "ordered list of any Glow element"},
+
+		// Glow Command verbs (subscribe / getDirectory / invoke)
+		{Kind: KindCommand, Name: "GetDirectory", SpecRef: "Glow §3.5", Notes: "1 — request a node's children (depth-1)"},
+		{Kind: KindCommand, Name: "Subscribe", SpecRef: "Glow §3.5", Notes: "30 — register for parameter value-change events"},
+		{Kind: KindCommand, Name: "Unsubscribe", SpecRef: "Glow §3.5", Notes: "31 — unregister"},
+		{Kind: KindCommand, Name: "Invoke", SpecRef: "Glow §3.5", Notes: "33 — call a Function with an Invocation"},
+	}
+}
+
+// LookupCatalogue returns the entry matching `<addr>`. Accepted
+// shapes:
+//
+//	kind:Parameter         → static Glow element kind entry
+//	cmd:GetDirectory       → static Glow Command verb entry
+//	1.2.4.1.0.2            → numeric OID path (synthetic entry)
+//	root.foo.bar           → dotted label path (synthetic entry)
+//
+// Path-based addresses return a synthetic CatalogueEntry pointing the
+// user at the live-tree query path; resolving them to actual Glow
+// elements requires a connected device or a captured tree.json.
+func LookupCatalogue(addr string) (CatalogueEntry, bool) {
+	if i := strings.IndexByte(addr, ':'); i >= 0 {
+		k := CommandKind(addr[:i])
+		name := addr[i+1:]
+		for _, e := range Catalogue() {
+			if e.Kind == k && e.Name == name {
+				return e, true
+			}
+		}
+		return CatalogueEntry{}, false
+	}
+	// No `kind:` prefix → infer from shape. All-digits-and-dots = OID.
+	if isOIDPath(addr) {
+		return CatalogueEntry{
+			Kind: KindOID, Name: addr,
+			SpecRef: "Glow §3 — OID-path addressing",
+			Notes:   "live-tree address; resolve via `dhs consumer emberplus walk` or a captured tree.json",
+		}, true
+	}
+	if isDottedPath(addr) {
+		return CatalogueEntry{
+			Kind: KindPath, Name: addr,
+			SpecRef: "canonical-schema dotted path",
+			Notes:   "live-tree address; resolve via `dhs consumer emberplus walk` or a captured tree.json",
+		}, true
+	}
+	return CatalogueEntry{}, false
+}
+
+// isOIDPath reports whether s contains only ASCII digits and dots.
+func isOIDPath(s string) bool {
+	if s == "" {
+		return false
+	}
+	hadDigit := false
+	for _, c := range s {
+		switch {
+		case c >= '0' && c <= '9':
+			hadDigit = true
+		case c == '.':
+			// allowed
+		default:
+			return false
+		}
+	}
+	return hadDigit
+}
+
+// isDottedPath reports whether s looks like a canonical dotted label
+// path (alphanumeric segments + underscore / hyphen, separated by
+// dots; at least one dot to disambiguate from a single identifier).
+func isDottedPath(s string) bool {
+	if s == "" {
+		return false
+	}
+	hasDot := false
+	for _, c := range s {
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c >= '0' && c <= '9':
+		case c == '_' || c == '-':
+		case c == '.':
+			hasDot = true
+		default:
+			return false
+		}
+	}
+	return hasDot
+}

--- a/internal/probel-sw02p/codec/catalogue.go
+++ b/internal/probel-sw02p/codec/catalogue.go
@@ -1,0 +1,82 @@
+package codec
+
+// CommandDirection captures whether a command travels controller →
+// matrix (Rx) or matrix → controller (Tx). Used by the CLI catalogue
+// renderers (`dhs list-commands`, `dhs help-cmd`).
+type CommandDirection string
+
+const (
+	DirRx CommandDirection = "rx"
+	DirTx CommandDirection = "tx"
+)
+
+// CommandSpec is the structured metadata used by the CLI catalogue
+// helpers. Stdlib-only so the codec stays lift-ready.
+type CommandSpec struct {
+	ID         CommandID        // wire byte
+	Name       string           // snake_case identifier (matches CommandName)
+	Direction  CommandDirection // rx (controller → matrix) or tx (matrix → controller)
+	SpecRef    string           // SW-P-02 Issue 26 section, e.g. "§3.2.4"
+	Payload    string           // "fixed N bytes" / "variable" / "zero" — hint, not a schema
+	Notes      string           // free-form (extended-form, owner-only auth, etc.)
+	Supported  bool             // true if this codec implements the command
+}
+
+// Commands returns the full SW-P-02 command catalogue this codec
+// supports — every byte covered by a cmd_rxNNN_*.go / cmd_txNNN_*.go
+// file. Order: command-byte ascending. Used by `dhs list-commands
+// probel-sw02p` and `dhs help-cmd probel-sw02p NN`.
+func Commands() []CommandSpec {
+	return []CommandSpec{
+		{ID: RxInterrogate, Name: "interrogate", Direction: DirRx, SpecRef: "§3.2.3", Payload: "fixed 2 bytes", Supported: true},
+		{ID: RxConnect, Name: "connect", Direction: DirRx, SpecRef: "§3.2.4", Payload: "fixed 3 bytes", Supported: true},
+		{ID: TxTally, Name: "tally", Direction: DirTx, SpecRef: "§3.2.5", Payload: "fixed 3 bytes", Supported: true},
+		{ID: TxCrosspointConnected, Name: "crosspoint_connected", Direction: DirTx, SpecRef: "§3.2.6", Payload: "fixed 3 bytes", Notes: "broadcast on all ports", Supported: true},
+		{ID: RxConnectOnGo, Name: "connect_on_go", Direction: DirRx, SpecRef: "§3.2.7", Payload: "fixed 3 bytes", Notes: "salvo build", Supported: true},
+		{ID: RxGo, Name: "go", Direction: DirRx, SpecRef: "§3.2.8", Payload: "fixed 1 byte", Notes: "salvo commit", Supported: true},
+		{ID: RxStatusRequest, Name: "status_request", Direction: DirRx, SpecRef: "§3.2.9", Payload: "zero", Supported: true},
+		{ID: TxStatusResponse2, Name: "status_response_2", Direction: DirTx, SpecRef: "§3.2.11", Payload: "fixed 6 bytes", Supported: true},
+		{ID: TxConnectOnGoAck, Name: "connect_on_go_ack", Direction: DirTx, SpecRef: "§3.2.14", Payload: "fixed 3 bytes", Supported: true},
+		{ID: TxGoDoneAck, Name: "go_done_ack", Direction: DirTx, SpecRef: "§3.2.15", Payload: "fixed 1 byte", Supported: true},
+		{ID: RxSourceLockStatusRequest, Name: "source_lock_status_request", Direction: DirRx, SpecRef: "§3.2.16", Payload: "zero", Supported: true},
+		{ID: TxSourceLockStatusResponse, Name: "source_lock_status_response", Direction: DirTx, SpecRef: "§3.2.17", Payload: "variable", Notes: "var-len", Supported: true},
+		{ID: RxConnectOnGoGroupSalvo, Name: "connect_on_go_group_salvo", Direction: DirRx, SpecRef: "§3.2.36", Payload: "fixed 4 bytes", Notes: "group salvo build", Supported: true},
+		{ID: TxConnectOnGoGroupSalvoAck, Name: "connect_on_go_group_salvo_ack", Direction: DirTx, SpecRef: "§3.2.37", Payload: "fixed 4 bytes", Supported: true},
+		{ID: RxGoGroupSalvo, Name: "go_group_salvo", Direction: DirRx, SpecRef: "§3.2.38", Payload: "fixed 2 bytes", Notes: "group salvo commit", Supported: true},
+		{ID: TxGoDoneGroupSalvoAck, Name: "go_done_group_salvo_ack", Direction: DirTx, SpecRef: "§3.2.39", Payload: "fixed 2 bytes", Supported: true},
+		{ID: RxDualControllerStatusRequest, Name: "dual_controller_status_request", Direction: DirRx, SpecRef: "§3.2.45", Payload: "zero", Supported: true},
+		{ID: TxDualControllerStatusResponse, Name: "dual_controller_status_response", Direction: DirTx, SpecRef: "§3.2.46", Payload: "fixed 2 bytes", Supported: true},
+		{ID: RxExtendedInterrogate, Name: "extended_interrogate", Direction: DirRx, SpecRef: "§3.2.47", Payload: "fixed 2 bytes", Notes: "extended addressing (dst 0-16383)", Supported: true},
+		{ID: RxExtendedConnect, Name: "extended_connect", Direction: DirRx, SpecRef: "§3.2.48", Payload: "fixed 4 bytes", Notes: "extended addressing", Supported: true},
+		{ID: TxExtendedTally, Name: "extended_tally", Direction: DirTx, SpecRef: "§3.2.49", Payload: "fixed 4 bytes", Supported: true},
+		{ID: TxExtendedConnected, Name: "extended_connected", Direction: DirTx, SpecRef: "§3.2.50", Payload: "fixed 4 bytes", Supported: true},
+		{ID: RxExtendedConnectOnGo, Name: "extended_connect_on_go", Direction: DirRx, SpecRef: "§3.2.51", Payload: "fixed 4 bytes", Supported: true},
+		{ID: TxExtendedConnectOnGoAck, Name: "extended_connect_on_go_ack", Direction: DirTx, SpecRef: "§3.2.52", Payload: "fixed 4 bytes", Supported: true},
+		{ID: RxExtendedConnectOnGoGroupSalvo, Name: "extended_connect_on_go_group_salvo", Direction: DirRx, SpecRef: "§3.2.53", Payload: "fixed 5 bytes", Supported: true},
+		{ID: TxExtendedConnectOnGoGroupSalvoAck, Name: "extended_connect_on_go_group_salvo_ack", Direction: DirTx, SpecRef: "§3.2.54", Payload: "fixed 5 bytes", Supported: true},
+		{ID: RxRouterConfigRequest, Name: "router_config_request", Direction: DirRx, SpecRef: "§3.2.57", Payload: "zero", Supported: true},
+		{ID: TxRouterConfigResponse1, Name: "router_config_response_1", Direction: DirTx, SpecRef: "§3.2.58", Payload: "variable", Notes: "var-len, level map + per-level dst/src counts", Supported: true},
+		{ID: TxRouterConfigResponse2, Name: "router_config_response_2", Direction: DirTx, SpecRef: "§3.2.59", Payload: "variable", Notes: "var-len, sparse level layout", Supported: true},
+		{ID: TxExtendedProtectTally, Name: "extended_protect_tally", Direction: DirTx, SpecRef: "§3.2.60", Payload: "fixed 4 bytes", Supported: true},
+		{ID: TxExtendedProtectConnected, Name: "extended_protect_connected", Direction: DirTx, SpecRef: "§3.2.61", Payload: "fixed 4 bytes", Supported: true},
+		{ID: TxExtendedProtectDisconnected, Name: "extended_protect_disconnected", Direction: DirTx, SpecRef: "§3.2.62", Payload: "fixed 4 bytes", Supported: true},
+		{ID: TxProtectDeviceNameResponse, Name: "protect_device_name_response", Direction: DirTx, SpecRef: "§3.2.63", Payload: "fixed 10 bytes", Supported: true},
+		{ID: TxExtendedProtectTallyDump, Name: "extended_protect_tally_dump", Direction: DirTx, SpecRef: "§3.2.64", Payload: "variable", Notes: "var-len", Supported: true},
+		{ID: RxExtendedProtectInterrogate, Name: "extended_protect_interrogate", Direction: DirRx, SpecRef: "§3.2.65", Payload: "fixed 2 bytes", Supported: true},
+		{ID: RxExtendedProtectConnect, Name: "extended_protect_connect", Direction: DirRx, SpecRef: "§3.2.66", Payload: "fixed 4 bytes", Notes: "owner-only auth", Supported: true},
+		{ID: RxProtectDeviceNameRequest, Name: "protect_device_name_request", Direction: DirRx, SpecRef: "§3.2.67", Payload: "fixed 2 bytes", Supported: true},
+		{ID: RxExtendedProtectDisconnect, Name: "extended_protect_disconnect", Direction: DirRx, SpecRef: "§3.2.68", Payload: "fixed 4 bytes", Notes: "owner-only auth", Supported: true},
+		{ID: RxExtendedProtectTallyDumpRequest, Name: "extended_protect_tally_dump_request", Direction: DirRx, SpecRef: "§3.2.69", Payload: "fixed 2 bytes", Supported: true},
+	}
+}
+
+// CommandByID looks up a single CommandSpec by wire byte. Returns
+// false when the byte isn't in this codec's catalogue.
+func CommandByID(id CommandID) (CommandSpec, bool) {
+	for _, c := range Commands() {
+		if c.ID == id {
+			return c, true
+		}
+	}
+	return CommandSpec{}, false
+}

--- a/internal/probel-sw08p/codec/catalogue.go
+++ b/internal/probel-sw08p/codec/catalogue.go
@@ -1,0 +1,98 @@
+package codec
+
+// CommandDirection captures whether a command travels controller →
+// matrix (Rx), matrix → controller (Tx), or both (one byte means
+// different things by direction). Used by the CLI catalogue
+// renderers (`dhs list-commands`, `dhs help-cmd`).
+type CommandDirection string
+
+const (
+	DirRx   CommandDirection = "rx"
+	DirTx   CommandDirection = "tx"
+	DirBoth CommandDirection = "both"
+)
+
+// CommandSpec is the structured metadata used by the CLI catalogue
+// helpers. Stdlib-only so the codec stays lift-ready.
+type CommandSpec struct {
+	ID         CommandID
+	Name       string           // matches CommandName output verbatim
+	Direction  CommandDirection // rx / tx / both (0x11 is rx 17 OR tx 17)
+	SpecRef    string           // SW-P-08 Issue 30 section reference
+	Payload    string           // "fixed N bytes" / "variable" / "zero"
+	Notes      string
+	Supported  bool
+}
+
+// Commands returns the full SW-P-08 command catalogue this codec
+// supports. Used by `dhs list-commands probel-sw08p` and
+// `dhs help-cmd probel-sw08p NN`.
+func Commands() []CommandSpec {
+	return []CommandSpec{
+		// RX general
+		{ID: RxCrosspointInterrogate, Name: "rx 001 Crosspoint Interrogate", Direction: DirRx, SpecRef: "§3.2.1", Payload: "fixed 4 bytes", Supported: true},
+		{ID: RxCrosspointConnect, Name: "rx 002 Crosspoint Connect", Direction: DirRx, SpecRef: "§3.2.2", Payload: "fixed 6 bytes", Supported: true},
+		{ID: TxCrosspointTally, Name: "tx 003 Crosspoint Tally", Direction: DirTx, SpecRef: "§3.2.3", Payload: "fixed 6 bytes", Supported: true},
+		{ID: TxCrosspointConnected, Name: "tx 004 Crosspoint Connected", Direction: DirTx, SpecRef: "§3.2.4", Payload: "fixed 6 bytes", Supported: true},
+		{ID: RxMaintenance, Name: "rx 007 Maintenance", Direction: DirRx, SpecRef: "§3.2.7", Payload: "fixed 1 byte", Supported: true},
+		{ID: RxDualControllerStatusRequest, Name: "rx 008 Dual Controller Status Request", Direction: DirRx, SpecRef: "§3.2.8", Payload: "zero", Supported: true},
+		{ID: TxDualControllerStatusResponse, Name: "tx 009 Dual Controller Status Response", Direction: DirTx, SpecRef: "§3.2.9", Payload: "fixed 2 bytes", Supported: true},
+		{ID: RxProtectInterrogate, Name: "rx 010 Protect Interrogate", Direction: DirRx, SpecRef: "§3.2.10", Payload: "fixed 4 bytes", Supported: true},
+		{ID: TxProtectTally, Name: "tx 011 Protect Tally", Direction: DirTx, SpecRef: "§3.2.11", Payload: "fixed 4 bytes", Supported: true},
+		{ID: RxProtectConnect, Name: "rx 012 Protect Connect", Direction: DirRx, SpecRef: "§3.2.12", Payload: "fixed 6 bytes", Supported: true},
+		{ID: TxProtectConnected, Name: "tx 013 Protect Connected", Direction: DirTx, SpecRef: "§3.2.13", Payload: "fixed 6 bytes", Supported: true},
+		{ID: RxProtectDisconnect, Name: "rx 014 Protect Disconnect", Direction: DirRx, SpecRef: "§3.2.14", Payload: "fixed 4 bytes", Supported: true},
+		{ID: TxProtectDisconnected, Name: "tx 015 Protect Disconnected", Direction: DirTx, SpecRef: "§3.2.15", Payload: "fixed 4 bytes", Supported: true},
+		{ID: RxProtectDeviceNameRequest, Name: "rx 017 Protect Device Name Req / tx 017 App Keepalive Req", Direction: DirBoth, SpecRef: "§3.2.17 (rx) / §3.2.17 (tx)", Payload: "zero (tx) / fixed 2 bytes (rx)", Notes: "byte 0x11 overloaded by direction", Supported: true},
+		{ID: TxProtectDeviceNameResponse, Name: "tx 018 Protect Device Name Response", Direction: DirTx, SpecRef: "§3.2.18", Payload: "variable", Notes: "var-len device name", Supported: true},
+		{ID: RxProtectTallyDumpRequest, Name: "rx 019 Protect Tally Dump Request", Direction: DirRx, SpecRef: "§3.2.19", Payload: "fixed 2 bytes", Supported: true},
+		{ID: TxProtectTallyDump, Name: "tx 020 Protect Tally Dump", Direction: DirTx, SpecRef: "§3.2.20", Payload: "variable", Notes: "var-len, streamed", Supported: true},
+		{ID: RxCrosspointTallyDumpRequest, Name: "rx 021 Crosspoint Tally Dump Request", Direction: DirRx, SpecRef: "§3.2.21", Payload: "fixed 2 bytes", Supported: true},
+		{ID: TxCrosspointTallyDumpByte, Name: "tx 022 Crosspoint Tally Dump (byte)", Direction: DirTx, SpecRef: "§3.2.22", Payload: "variable", Notes: "var-len byte form", Supported: true},
+		{ID: TxCrosspointTallyDumpWord, Name: "tx 023 Crosspoint Tally Dump (word)", Direction: DirTx, SpecRef: "§3.2.23", Payload: "variable", Notes: "var-len word form", Supported: true},
+		{ID: RxMasterProtectConnect, Name: "rx 029 Master Protect Connect", Direction: DirRx, SpecRef: "§3.2.29", Payload: "fixed 6 bytes", Supported: true},
+		{ID: RxAppKeepaliveResponse, Name: "rx 034 App Keepalive Response", Direction: DirRx, SpecRef: "§3.2.34", Payload: "zero", Supported: true},
+		{ID: RxAllSourceNamesRequest, Name: "rx 100 All Source Names Request", Direction: DirRx, SpecRef: "§3.2.100", Payload: "fixed 2 bytes", Supported: true},
+		{ID: RxSingleSourceNameRequest, Name: "rx 101 Single Source Name Request", Direction: DirRx, SpecRef: "§3.2.101", Payload: "fixed 4 bytes", Supported: true},
+		{ID: RxAllDestNamesRequest, Name: "rx 102 All Dest Assoc Names Request", Direction: DirRx, SpecRef: "§3.2.102", Payload: "fixed 2 bytes", Supported: true},
+		{ID: RxSingleDestNameRequest, Name: "rx 103 Single Dest Assoc Name Request", Direction: DirRx, SpecRef: "§3.2.103", Payload: "fixed 4 bytes", Supported: true},
+		{ID: TxSourceNamesResponse, Name: "tx 106 Source Names Response", Direction: DirTx, SpecRef: "§3.2.106", Payload: "variable", Notes: "var-len", Supported: true},
+		{ID: TxDestAssocNamesResponse, Name: "tx 107 Dest Assoc Names Response", Direction: DirTx, SpecRef: "§3.2.107", Payload: "variable", Supported: true},
+		{ID: RxCrosspointTieLineInterrogate, Name: "rx 112 Crosspoint Tie-Line Interrogate", Direction: DirRx, SpecRef: "§3.2.112", Payload: "fixed 4 bytes", Supported: true},
+		{ID: TxCrosspointTieLineTally, Name: "tx 113 Crosspoint Tie-Line Tally", Direction: DirTx, SpecRef: "§3.2.113", Payload: "fixed 6 bytes", Supported: true},
+		{ID: RxAllSourceAssocNamesRequest, Name: "rx 114 All Source Assoc Names Request", Direction: DirRx, SpecRef: "§3.2.114", Payload: "fixed 2 bytes", Supported: true},
+		{ID: RxSingleSourceAssocNameRequest, Name: "rx 115 Single Source Assoc Name Request", Direction: DirRx, SpecRef: "§3.2.115", Payload: "fixed 4 bytes", Supported: true},
+		{ID: TxSourceAssocNamesResponse, Name: "tx 116 Source Assoc Names Response", Direction: DirTx, SpecRef: "§3.2.116", Payload: "variable", Supported: true},
+		{ID: RxUpdateNameRequest, Name: "rx 117 Update Name Request", Direction: DirRx, SpecRef: "§3.2.117", Payload: "variable", Supported: true},
+		{ID: RxCrosspointConnectOnGoSalvo, Name: "rx 120 Crosspoint Connect-On-Go Salvo", Direction: DirRx, SpecRef: "§3.2.120", Payload: "variable", Notes: "salvo build (var-len)", Supported: true},
+		{ID: RxCrosspointGoSalvo, Name: "rx 121 Crosspoint Go Salvo", Direction: DirRx, SpecRef: "§3.2.121", Payload: "fixed 2 bytes", Notes: "salvo commit", Supported: true},
+		{ID: TxSalvoConnectOnGoAck, Name: "tx 122 Salvo Connect-On-Go Ack", Direction: DirTx, SpecRef: "§3.2.122", Payload: "fixed 2 bytes", Supported: true},
+		{ID: RxCrosspointSalvoGroupInterrogate, Name: "rx 124 Crosspoint Salvo Group Interrogate", Direction: DirRx, SpecRef: "§3.2.124", Payload: "fixed 2 bytes", Supported: true},
+
+		// RX/TX extended
+		{ID: RxCrosspointInterrogateExt, Name: "rx 129 Crosspoint Interrogate (ext)", Direction: DirRx, SpecRef: "§3.4.1", Payload: "fixed 6 bytes", Notes: "extended addressing", Supported: true},
+		{ID: RxCrosspointConnectExt, Name: "rx 130 Crosspoint Connect (ext)", Direction: DirRx, SpecRef: "§3.4.2", Payload: "fixed 8 bytes", Notes: "extended addressing", Supported: true},
+		{ID: RxProtectInterrogateExt, Name: "rx 138 Protect Interrogate (ext)", Direction: DirRx, SpecRef: "§3.4.10", Payload: "fixed 6 bytes", Supported: true},
+		{ID: RxProtectConnectExt, Name: "rx 140 Protect Connect (ext)", Direction: DirRx, SpecRef: "§3.4.12", Payload: "fixed 8 bytes", Supported: true},
+		{ID: RxProtectDisconnectExt, Name: "rx 142 Protect Disconnect (ext)", Direction: DirRx, SpecRef: "§3.4.14", Payload: "fixed 6 bytes", Supported: true},
+		{ID: RxProtectTallyDumpRequestExt, Name: "rx 147 Protect Tally Dump Request (ext)", Direction: DirRx, SpecRef: "§3.4.19", Payload: "fixed 4 bytes", Supported: true},
+		{ID: RxCrosspointTallyDumpRequestExt, Name: "rx 149 Crosspoint Tally Dump Request (ext)", Direction: DirRx, SpecRef: "§3.4.21", Payload: "fixed 4 bytes", Supported: true},
+		{ID: RxAllSourceNamesRequestExt, Name: "rx 228 All Source Names Request (ext)", Direction: DirRx, SpecRef: "§3.4.100", Payload: "fixed 4 bytes", Supported: true},
+		{ID: RxSingleSourceNameRequestExt, Name: "rx 229 Single Source Name Request (ext)", Direction: DirRx, SpecRef: "§3.4.101", Payload: "fixed 6 bytes", Supported: true},
+		{ID: RxAllDestNamesRequestExt, Name: "rx 230 All Dest Assoc Names Request (ext)", Direction: DirRx, SpecRef: "§3.4.102", Payload: "fixed 4 bytes", Supported: true},
+		{ID: RxSingleDestNameRequestExt, Name: "rx 231 Single Dest Assoc Name Request (ext)", Direction: DirRx, SpecRef: "§3.4.103", Payload: "fixed 6 bytes", Supported: true},
+		{ID: RxCrosspointConnectOnGoSalvoExt, Name: "rx 248 Crosspoint Connect-On-Go Salvo (ext)", Direction: DirRx, SpecRef: "§3.4.120", Payload: "variable", Supported: true},
+		{ID: RxCrosspointSalvoGroupInterrogateExt, Name: "rx 252 Crosspoint Salvo Group Interrogate (ext)", Direction: DirRx, SpecRef: "§3.4.124", Payload: "fixed 4 bytes", Supported: true},
+	}
+}
+
+// CommandByID looks up a single CommandSpec by wire byte. Returns
+// false when the byte isn't in this codec's catalogue.
+func CommandByID(id CommandID) (CommandSpec, bool) {
+	for _, c := range Commands() {
+		if c.ID == id {
+			return c, true
+		}
+	}
+	return CommandSpec{}, false
+}


### PR DESCRIPTION
Closes #108. Closes #109. Closes #110. Closes #111. Closes #112.
Closes #113. Closes #114. Closes #115. Closes #116. Closes #117.

## Summary

Two new top-level CLI verbs that surface each protocol's static command catalogue and per-entry detail:

```
dhs list-commands <proto> [--format=table|json|md]
dhs help-cmd      <proto> <address>
```

Per-protocol catalogue exporters live next to the codec / consumer package they describe (one source of truth per protocol):

| Protocol | Catalogue file | Entries | Address shape |
|---|---|---:|---|
| probel-sw02p | `internal/probel-sw02p/codec/catalogue.go` | 39 | byte (`0x02` or `2`) |
| probel-sw08p | `internal/probel-sw08p/codec/catalogue.go` | 51 | byte |
| acp1 | `internal/acp1/consumer/catalogue.go` | 45 | `<kind>:<id>` (msgtype, method, objgroup, objtype, xport-err, obj-err) |
| acp2 | `internal/acp2/consumer/catalogue.go` | 61 | `<kind>:<id>` (an2-type, an2-func, acp2-type, acp2-func, obj-type, pid, number-type, err-stat) |
| emberplus | `internal/emberplus/consumer/catalogue.go` | 19 | `kind:Parameter` / `cmd:GetDirectory` / OID `1.2.4.1.0.2` / dotted `root.foo.bar` |

Probel codecs expose `CommandSpec{ID, Name, Direction, SpecRef, Payload, Notes, Supported}` + `Commands()` + `CommandByID()`. ACP1 / ACP2 expose `CatalogueEntry{Kind, ID, Name, SpecRef, Notes}` + `Catalogue()` + `LookupCatalogue()` under their consumer package. Ember+ exposes the same shape with `Kind ∈ {kind, cmd, oid, path}`; OID paths and dotted-label paths are recognised by shape and return synthetic entries pointing at live-tree query commands.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — full suite green
- [x] `golangci-lint run ./...` — 0 issues
- [x] 7 unit tests in `cmd/dhs/cmd_list_commands_test.go` covering: every protocol's catalogue shape; byte parsing (hex + decimal + reject); kind:id addressing; emberplus path resolution (kind / cmd / OID / dotted); JSON envelope shape; unknown-protocol rejection
- [x] Smoke-tested live: `list-commands` for all 5 protocols + `help-cmd` for byte / kind:id / OID-path forms

## Sample output

```
$ dhs list-commands probel-sw02p
# probel-sw02p — 39 catalogue entries

address     name                 dir  spec / notes
0x01 (1)    interrogate          rx   SW-P-02 §3.2.3 · fixed 2 bytes
0x02 (2)    connect              rx   SW-P-02 §3.2.4 · fixed 3 bytes
...

$ dhs help-cmd probel-sw02p 0x02
probel-sw02p · 0x02
============================================================
Name:       connect
Direction:  rx
Spec:       SW-P-02 §3.2.4
Payload:    fixed 3 bytes
Supported:  true

$ dhs help-cmd emberplus 1.2.4.1.0.2
emberplus · 1.2.4.1.0.2
============================================================
Name:       1.2.4.1.0.2
Spec:       Glow §3 — OID-path addressing
Notes:      live-tree address; resolve via ` + "`dhs consumer emberplus walk`" + ` or a captured tree.json
Supported:  true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)