### PR TITLE
fix(emberplus): BER REAL ecosystem mantissa bias + S101 BoF resync

### DIFF
--- a/internal/emberplus/CLAUDE.md
+++ b/internal/emberplus/CLAUDE.md
@@ -117,7 +117,19 @@ S101 layer. Respond to every request promptly.
 - Connection-snapshot diff needs to honor `disposition=modified` (partial).
 - `formula` evaluation (#70) is **parked** — consumer ignores formulas and
   surfaces raw values. Do not lazily implement — requires full Formulas PDF.
-- Viewer quirks (#68) around matrix reflection are **parked**.
+- BER REAL mantissa convention (#68 fix 2026-04-26): every Ember+ stack
+  (libember, EmberViewer, Lawo VSM) reads `N` as a normalised fraction with
+  binary point implicit after the leading 1 bit, not as the literal X.690
+  §8.5.7 unsigned integer. `EncodeReal` + `DecodeReal` in `codec/ber/value.go`
+  bias the wire exponent by `bits.Len64(N)-1` to match. Pinned by
+  `TestReal_EcosystemBytes` (50.0 → `80 05 19`, 100.0 → `80 06 19`,
+  0.1 → `80 fc 0c cc cc cc cc cc cd`). Verified live against EmberViewer
+  v2.40.0.35 + Lawo VSM Studio.
+- S101 reader resyncs on a second BOF mid-frame (`codec/s101/reader.go`).
+  Spec mandates 0xFE escape-stuffing; Lawo VSM-as-consumer emits a 15-byte
+  non-S101 preamble before its first real frame on every reconnect, and
+  resyncing on the second BOF drops the junk rather than failing CRC over
+  the concatenation.
 
 ## What NOT to do
 

--- a/internal/emberplus/codec/ber/ber_test.go
+++ b/internal/emberplus/codec/ber/ber_test.go
@@ -141,6 +141,44 @@ func TestReal_RoundTrip(t *testing.T) {
 	}
 }
 
+// TestReal_EcosystemBytes pins the wire bytes against the
+// fractional-mantissa reading (libember / EmberViewer / Lawo VSM).
+// Issue #68: prior to 2026-04-26 the encoder emitted N-as-integer per
+// the literal X.690 §8.5.7 reading; every shipping Ember+ viewer
+// instead reads N as a normalised fraction with binary point implicit
+// after the leading 1 bit, so 50.0 displayed as 3.125, 100.0 as 6.25,
+// and 0.1 as 4.44E-17. The encoder now biases the wire exponent by
+// (bitlen(N)-1) so the wire bytes match what every other Ember+ stack
+// produces. Verified live against EmberViewer v2.40.0.35 + VSM Studio
+// (host 10.6.239.160) on 2026-04-26.
+func TestReal_EcosystemBytes(t *testing.T) {
+	cases := []struct {
+		value float64
+		want  []byte
+	}{
+		{50.0, []byte{0x80, 0x05, 0x19}},
+		{100.0, []byte{0x80, 0x06, 0x19}},
+		{1.0, []byte{0x80, 0x00, 0x01}},
+		{2.0, []byte{0x80, 0x01, 0x01}},
+		{16.0, []byte{0x80, 0x04, 0x01}},
+		{0.1, []byte{0x80, 0xfc, 0x0c, 0xcc, 0xcc, 0xcc, 0xcc, 0xcc, 0xcd}},
+	}
+	for _, tc := range cases {
+		got := EncodeReal(tc.value)
+		if len(got) != len(tc.want) {
+			t.Errorf("EncodeReal(%v) length = %d, want %d (got % x, want % x)",
+				tc.value, len(got), len(tc.want), got, tc.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Errorf("EncodeReal(%v) = % x, want % x", tc.value, got, tc.want)
+				break
+			}
+		}
+	}
+}
+
 func TestTLV_PrimitiveRoundTrip(t *testing.T) {
 	orig := Integer(42)
 	data := EncodeTLV(orig)

--- a/internal/emberplus/codec/ber/value.go
+++ b/internal/emberplus/codec/ber/value.go
@@ -3,6 +3,7 @@ package ber
 import (
 	"encoding/binary"
 	"math"
+	"math/bits"
 )
 
 // --- Encode value types ---
@@ -104,10 +105,10 @@ func EncodeReal(v float64) []byte {
 		return []byte{0x41}
 	}
 
-	bits := math.Float64bits(v)
-	sign := byte((bits >> 63) & 1)
-	expRaw := int((bits >> 52) & 0x7FF)
-	frac := bits & ((1 << 52) - 1)
+	fbits := math.Float64bits(v)
+	sign := byte((fbits >> 63) & 1)
+	expRaw := int((fbits >> 52) & 0x7FF)
+	frac := fbits & ((1 << 52) - 1)
 
 	var mantissa uint64
 	var exponent int
@@ -127,6 +128,21 @@ func EncodeReal(v float64) []byte {
 		mantissa >>= 1
 		exponent++
 	}
+
+	// X.690 §8.5.6 reads the mantissa N as an unsigned integer:
+	//   value = N × 2^F × B^E
+	// libember-cpp / libember-slim and every Ember+ viewer in the wild
+	// (EmberViewer, EmberPlusView, Lawo VSM) instead read N as a
+	// normalised fraction with the binary point implicit after the
+	// leading 1 bit:
+	//   value = (N / 2^(bitlen(N)-1)) × B^E × 2^F
+	// Two interpretations of the same X.690 clauses; the ecosystem
+	// reading is universal in practice. Bias the wire exponent by
+	// (bitlen(N)-1) so viewers display the value our caller passed in.
+	// Verified live 2026-04-26 against EmberViewer v2.40.0.35 + Lawo
+	// VSM Studio (issue #68): without this bias, 50.0 displays as
+	// 3.125, 100.0 as 6.25, etc.
+	exponent += bits.Len64(mantissa) - 1
 
 	// Exponent as two's-complement minimum-octet signed integer.
 	expBytes := encodeSignedInt(int64(exponent))
@@ -359,7 +375,16 @@ func DecodeReal(data []byte) (float64, error) {
 		for _, b := range mantBytes {
 			mant = (mant << 8) | uint64(b)
 		}
-		v := sign * float64(mant) * math.Pow(2.0, float64(int(exp)*baseFactor+scale))
+		// Mirror the EncodeReal bias: ecosystem readers (libember,
+		// EmberViewer, Lawo VSM) interpret the mantissa N as a normalised
+		// fraction with the implicit binary point after the leading 1
+		// bit. Subtract (bitlen(N)-1) from the wire exponent so this
+		// decoder matches what those peers produce.
+		shift := 0
+		if mant != 0 {
+			shift = bits.Len64(mant) - 1
+		}
+		v := sign * float64(mant) * math.Pow(2.0, float64(int(exp)*baseFactor+scale-shift))
 		return v, nil
 	}
 	return 0, errInvalidReal

--- a/internal/emberplus/codec/s101/reader.go
+++ b/internal/emberplus/codec/s101/reader.go
@@ -53,13 +53,25 @@ func (r *Reader) ReadFrame() (*Frame, error) {
 		// Discard bytes outside frames.
 	}
 
-	// Collect bytes until EOF.
+	// Collect bytes until EOF. A literal 0xFE inside a frame is a spec
+	// violation — S101 §p.94 mandates 0xFE escape-stuffing as 0xFD 0xDE,
+	// so a properly-encoded payload byte never appears here as a raw
+	// 0xFE. Lawo VSM-as-consumer emits a 15-byte non-S101 preamble
+	// (e.g. fe d9 5c 80 30 80 7f 20 02 31 00 00 00 00 00) before its
+	// first real EmBER frame on every reconnect; resyncing on a second
+	// raw 0xFE drops the junk preamble and recovers the real frame
+	// instead of failing CRC over the concatenation.
 	var buf []byte
 	buf = append(buf, BOF)
 	for {
 		b, err := r.r.ReadByte()
 		if err != nil {
 			return nil, fmt.Errorf("s101 read: %w", err)
+		}
+		if b == BOF {
+			buf = buf[:0]
+			buf = append(buf, BOF)
+			continue
 		}
 		buf = append(buf, b)
 		if b == EOF {

--- a/internal/emberplus/wireshark/dhs_emberplus.lua
+++ b/internal/emberplus/wireshark/dhs_emberplus.lua
@@ -609,6 +609,24 @@ end
 
 -- BER REAL decoder (Ember+ uses binary encoding only for this field).
 -- Returns a Lua number or nil.
+--
+-- X.690 §8.5.7 reads the mantissa N as an unsigned integer with
+-- value = N × 2^F × B^E. Every Ember+ stack in the wild
+-- (libember, EmberViewer, EmberPlusView, Lawo VSM) instead reads N
+-- as a normalised fraction with binary point implicit after the
+-- leading 1 bit, so the wire exponent is biased by bitlen(N)-1.
+-- This dissector mirrors the ecosystem reading; otherwise it shows
+-- 50.0 as 3.125, 100.0 as 6.25, etc. See issue #68 (2026-04-26).
+local function bitlen64(n)
+    if n == 0 then return 0 end
+    local b = 0
+    while n > 0 do
+        b = b + 1
+        n = math.floor(n / 2)
+    end
+    return b
+end
+
 local function decode_ber_real(ba, off, len)
     if len == 0 then return 0.0 end
     local first = ba:get_index(off)
@@ -637,7 +655,8 @@ local function decode_ber_real(ba, off, len)
     local mant_len   = (off + len) - mant_start
     if mant_len < 0 then return nil end
     local mant = decode_ber_uint(ba, mant_start, mant_len)
-    return sign * mant * (2 ^ scale) * (base ^ exp)
+    local shift = mant > 0 and (bitlen64(mant) - 1) or 0
+    return sign * mant * (2 ^ scale) * (base ^ exp) / (2 ^ shift)
 end
 
 -- Decode RELATIVE-OID: sequence of base-128 subidentifiers, high bit = "more".
@@ -1583,12 +1602,20 @@ local function find_next_frame(tvbuf, offset)
     if offset >= pktlen then return nil end
 
     local start = offset
-    -- find EoF, skipping escape sequences.
+    -- find EoF, skipping escape sequences. A literal 0xFE inside a
+    -- frame is a spec violation (S101 mandates 0xFE escape-stuffing as
+    -- 0xFD 0xDE) but Lawo VSM-as-consumer emits a 15-byte non-S101
+    -- preamble before its first real frame on every reconnect. Resync
+    -- on the second BoF so we report CRC over the right bytes instead
+    -- of failing CRC over preamble + real frame concatenated.
     local i = offset + 1
     while i < pktlen do
         local b = tvbuf:range(i, 1):uint()
         if b == S101_ESC then
             i = i + 2
+        elseif b == S101_BOF then
+            start = i
+            i = i + 1
         elseif b == S101_EOF then
             return start, i
         else
@@ -1679,14 +1706,22 @@ local function heuristic(tvbuf, pktinfo, root)
     if len < 6 then return false end
     if tvbuf:range(0, 1):uint() ~= S101_BOF then return false end
 
-    -- Bounded EoF scan, skipping escape sequences.
+    -- Bounded EoF scan, skipping escape sequences. Resync on a second
+    -- BoF mid-stream — Lawo VSM-as-consumer emits a 15-byte non-S101
+    -- preamble before its first real frame; without resync the
+    -- heuristic mis-validates against the preamble bytes and never
+    -- claims the stream.
     local scan_limit = math.min(len, 4096)
+    local bof_at = 1
     local eof_at
     local i = 1
     while i < scan_limit do
         local b = tvbuf:range(i, 1):uint()
         if b == S101_ESC then
             i = i + 2
+        elseif b == S101_BOF then
+            bof_at = i + 1
+            i = i + 1
         elseif b == S101_EOF then
             eof_at = i
             break
@@ -1697,7 +1732,7 @@ local function heuristic(tvbuf, pktinfo, root)
     if not eof_at then return false end
 
     -- Validate S101 header after unescape.
-    local unesc = unescape_s101(tvbuf, 1, eof_at)
+    local unesc = unescape_s101(tvbuf, bof_at, eof_at)
     if unesc:len() < 6 then return false end
     local msg_type = unesc:get_index(1)
     local command  = unesc:get_index(2)


### PR DESCRIPTION
## Summary

- BER REAL encoder + decoder + dissector now bias the wire exponent by `bits.Len64(N)-1` so values match every Ember+ stack in the wild (libember, EmberViewer, EmberPlusView, Lawo VSM)
- S101 reader + Wireshark dissector resync on a literal `0xFE` mid-frame to drop Lawo VSM-as-consumer's 15-byte non-S101 preamble
- New `TestReal_EcosystemBytes` pins the wire bytes for 50 / 100 / 0.1 / 1 / 2 / 16 against the fractional-mantissa interpretation

## Root cause (#68)

X.690 §8.5.7 specifies binary REAL as `value = N × 2^F × B^E` with `N` as the unsigned mantissa integer. Every Ember+ stack in production reads `N` as a normalised fraction with binary point implicit after the leading 1 bit:

```
value = sign × (N / 2^(bitlen(N)-1)) × B^E × 2^F
```

Round-trip via our own encoder + decoder hid the bug for a year — both sides used the literal X.690 reading and agreed. Live verification 2026-04-26 against EmberViewer v2.40.0.35 + Lawo VSM Studio (10.6.239.160) showed both consumers display identical wrong values:

| Tree | Pre-fix bytes | EmberViewer | VSM | Post-fix bytes | Both post |
|---|---|---:|---:|---|---:|
| 50.0 | `80 01 19` | 3.125 | 3.13 | `80 05 19` | 50.00 |
| 100.0 | `80 02 19` | 6.25 | 6.25 | `80 06 19` | 100.00 |
| 0.1 | `80 c9 0c cc cc cc cc cc cd` | 4.44E-17 | 0.00 | `80 fc 0c cc cc cc cc cc cd` | 0.10 |

Single-bit mantissa cases (1.0, 2.0, 16.0) are unchanged — bit-length minus one is zero so the bias is a no-op.

## Bonus fix — S101 BoF resync

Lawo VSM-as-consumer emits a 15-byte non-S101 preamble before its first real frame on every reconnect (e.g. `fe d9 5c 80 30 80 7f 20 02 31 00 00 00 00 00`). The S101 reader and our Wireshark dissector now resync on a second BoF mid-frame, dropping the junk rather than failing CRC over the concatenation. Spec-compliant peers escape-stuff every `0xFE` as `0xFD 0xDE` so the resync code path is unreachable for them.

## Test plan

- [x] `go test ./internal/emberplus/...` — green (codec/ber, codec/glow, codec/matrix, codec/s101, consumer, provider)
- [x] Live: VSM Studio + EmberViewer v2.40.0.35 both walk `dhs producer emberplus serve` and display 50.00 / 100.00 / 0.10 byte-exact
- [x] `golangci-lint run ./internal/emberplus/...` — 0 issues (pre-commit gate)
- [ ] Reload `dhs_emberplus.lua` in Wireshark and confirm the S101 frames decode without CRC mismatch and REAL fields render correct values

## Posture

Per CLAUDE.md "Exception — when every shipping controller contradicts the spec":
- ≥2 independent in-the-field implementations (libember + Lawo) verified to use the ecosystem reading
- X.690 §8.5.6 finds textual support for both readings; ecosystem reading is the de-facto standard
- `TestReal_EcosystemBytes` pins the bytes; round-trip stays as secondary check
- Decision documented in `internal/emberplus/CLAUDE.md` "Quirks / landmines" + memory `reference_emberplus_ber_real`

Closes #68