### PR TITLE
fix(emberplus): broadcast value-change announcements to all active sessions

### DIFF
--- a/internal/emberplus/CLAUDE.md
+++ b/internal/emberplus/CLAUDE.md
@@ -93,6 +93,22 @@ in the repo.
 - `Connection` carries `target`, `sources[]`, `operation` (0=absolute set,
   1=connect, 2=disconnect), `disposition`.
 
+### Known deviations from spec (matrix subscription)
+
+§p.88 reads: "As soon as a consumer issues a GetDirectory command on a
+matrix object, it implicitly subscribes to matrix connection changes."
+Strict reading: only sessions that walked the matrix receive
+connection-change announcements. Our provider broadcasts matrix
+connection changes to **every connected session**, mirroring
+libember-cpp / TinyEmber+ / Lawo provider stacks — most viewers walk
+matrix contents from a parent node reply rather than direct
+GetDirectory(matrix), so strict subscription gating leaves crosspoint
+tallies stranded at the consumer. The same broadcast-to-all rule
+applies to plain Parameter value-change announcements (Subscribe(30)
+exists in spec for streams; no shipping provider gates plain-param
+emission on it). Stream parameters stay subscription-gated in
+`provider/streamer.go`.
+
 ## Stream values
 
 StreamEntry pushes a raw value per `streamIdentifier`. Map to the parameter

--- a/internal/emberplus/provider/invoke.go
+++ b/internal/emberplus/provider/invoke.go
@@ -267,8 +267,15 @@ func (s *server) encodeMatrixConnectionsAnnouncement(e *entry, conns []canonical
 }
 
 // broadcastMatrixConnections sends a connection-change announcement to
-// every session subscribed to the matrix OID, plus the originating session
-// so strict viewers get a direct echo.
+// every active consumer session. Spec §p.88 implicitly subscribes a
+// consumer to matrix changes on GetDirectory of that matrix, but the
+// rule is patchy across consumers — some viewers walk matrix contents
+// from a parent node reply instead of direct GetDirectory and never
+// register a subscription. Matching the broadcastParam fan-out
+// (libember/TinyEmber+ pattern), push to every connected session so
+// crosspoint changes always reach the client regardless of walking
+// style. The origin parameter stays for symmetry with the per-session
+// echo callers expect.
 func (s *server) broadcastMatrixConnections(matrixOID string, conns []canonical.MatrixConnection, origin *session) {
 	e, ok := s.tree.lookupOID(matrixOID)
 	if !ok {
@@ -277,9 +284,8 @@ func (s *server) broadcastMatrixConnections(matrixOID string, conns []canonical.
 	payload := s.encodeMatrixConnectionsAnnouncement(e, conns)
 
 	s.mu.Lock()
-	set := s.subs[matrixOID]
-	targets := make([]*session, 0, len(set)+1)
-	for sess := range set {
+	targets := make([]*session, 0, len(s.sessions))
+	for sess := range s.sessions {
 		targets = append(targets, sess)
 	}
 	s.mu.Unlock()

--- a/internal/emberplus/provider/server.go
+++ b/internal/emberplus/provider/server.go
@@ -186,8 +186,17 @@ func (s *server) unsubscribe(sess *session, oid string) {
 }
 
 // broadcastParam fans out a QualifiedParameter announcement to every
-// consumer subscribed to the given OID. Subscribers that missed the
-// send-queue high-water-mark silently drop the frame — see session.send.
+// active consumer session. The Subscribe / Unsubscribe commands in the
+// Ember+ spec gate STREAM parameter emission specifically; for plain
+// parameters every shipping provider (libember-cpp, TinyEmber+, Lawo
+// stacks) pushes value-change announcements to all connected sessions
+// regardless of explicit subscription. Most consumers (EmberViewer,
+// EmberPlusView, mc² controllers) never send Subscribe for non-stream
+// parameters and rely on this fan-out — without it they freeze on the
+// initial GetDirectory snapshot. Subscribers that missed the
+// send-queue high-water-mark silently drop the frame — see
+// session.send. Stream-parameter fan-out stays subscription-gated in
+// streamer.go.
 func (s *server) broadcastParam(oid string, p *canonical.Parameter) {
 	e, ok := s.tree.lookupOID(oid)
 	if !ok {
@@ -196,9 +205,8 @@ func (s *server) broadcastParam(oid string, p *canonical.Parameter) {
 	payload := s.encodeParamAnnouncement(e, p)
 
 	s.mu.Lock()
-	set := s.subs[oid]
-	targets := make([]*session, 0, len(set))
-	for sess := range set {
+	targets := make([]*session, 0, len(s.sessions))
+	for sess := range s.sessions {
 		targets = append(targets, sess)
 	}
 	s.mu.Unlock()


### PR DESCRIPTION
## Summary

- `broadcastParam` and `broadcastMatrixConnections` now fan out to every active consumer session, not only those that sent `Subscribe(30)` for the matching OID
- Stream parameters (`streamIdentifier` set) stay subscription-gated in `provider/streamer.go`
- Documented in `internal/emberplus/CLAUDE.md` §Matrix "Known deviations from spec"

## Why

Subscribe(30) was added to the Ember+ spec primarily for stream parameters where bandwidth opt-in matters. For plain parameters, every shipping provider stack (libember-cpp, TinyEmber+, Lawo native) broadcasts value-change announcements to all connected sessions regardless of explicit subscription. The Subscribe command for plain params is a defensive no-op that consumers send "just in case."

Pre-fix our provider was strict-per-spec and only emitted to OID-matched subscribers. Lawo VSM subscribes to intermediate node OIDs (e.g. `"1"`) rather than the parameter OIDs being announced (e.g. `"1.1"`), so value-change broadcasts from VSM-driven SetValue → no matching subscribers → EmberViewer (also connected, also walked) never received the update. Display froze on the initial GetDirectory snapshot; required a manual refresh to see new values.

## Live test 2026-04-26

| Setup | Pre-fix | Post-fix |
|---|---|---|
| VSM connected, EmberViewer connected, VSM changes `gain` | EmberViewer freezes on snapshot | EmberViewer auto-updates instantly |
| VSM changes `gain`, no other consumer | works (ack to VSM only) | works |
| Stream parameter | subscription-gated (unchanged) | subscription-gated (unchanged) |

## Spec posture

Per CLAUDE.md "Exception — when every shipping controller contradicts the spec":
- ≥2 independent in-the-field implementations (libember-cpp + Lawo) verified to broadcast to all sessions
- Spec §p.88 implicit-matrix-subscribe rule documented as known deviation in `internal/emberplus/CLAUDE.md`
- Stream subscription gate preserved (where the spec rule actually matches practice)

## Test plan

- [x] `go test ./internal/emberplus/provider/...` — green
- [x] `golangci-lint run ./internal/emberplus/...` — 0 issues (pre-commit gate)
- [x] Live: VSM Studio + EmberViewer concurrent, VSM mutates value, EmberViewer auto-updates
- [ ] Real Lawo mc² controller (parked — emulator-validated for now)

## Note

Surfaced during issue #68 verification (PR #135) — separate concern, separate PR. The two changes share a feat-branch ancestor (live VSM test) but are logically distinct: PR #135 is a codec bug, this is provider behaviour.