### PR TITLE
feat(nmos): IS-09 System API — server + client + selection rule

### DIFF
--- a/cmd/dhs/cmd_nmos.go
+++ b/cmd/dhs/cmd_nmos.go
@@ -1,10 +1,13 @@
 package main
 
-// AMWA NMOS CLI verbs. Phase 1 step #1 ships discovery only:
+// AMWA NMOS CLI verbs. Phase 1 #1 shipped discovery only; Phase 1 #2
+// adds IS-09 System API on top:
 //
-//   dhs consumer nmos discover [--mdns | --unicast --resolver IP] [--service _nmos-register._tcp]
-//   dhs producer nmos serve    [--mdns | --no-mdns] [--advertise-host host:port] [--port N]
-//   dhs registry nmos serve    [--mdns | --no-mdns] [--advertise-host host:port] [--port N] [--priority N]
+//   dhs consumer nmos discover [--mdns | --unicast --resolver IP] [--service ...]
+//   dhs consumer nmos system   [--mdns | --unicast --resolver IP | --peer-list F | --direct H:P]
+//                              [--api-ver v1.0] [--api-proto http] [--service ...] [--timeout 5s]
+//   dhs producer nmos serve    [--role node|system] [--config FILE] [--mdns | --no-mdns] [--bind :PORT]
+//   dhs registry nmos serve    [--mdns | --no-mdns] [--advertise-host host:port] [--bind :PORT] [--priority N]
 //
 // Higher-level NMOS verbs (walk, watch, connect, ncp) land alongside the
 // IS-04/05/07/12 plugin layers in later phases.
@@ -21,6 +24,9 @@ import (
 	"time"
 
 	codec "acp/internal/amwa/codec/dnssd"
+	"acp/internal/amwa/codec/is09"
+	"acp/internal/amwa/consumer"
+	"acp/internal/amwa/provider"
 	session "acp/internal/amwa/session/dnssd"
 	registryslot "acp/internal/registry"
 )
@@ -36,8 +42,10 @@ func runNMOSConsumer(ctx context.Context, args []string) error {
 	switch verb {
 	case "discover":
 		return runNMOSDiscover(ctx, rest)
+	case "system":
+		return runNMOSSystem(ctx, rest)
 	}
-	return fmt.Errorf("consumer nmos: unknown verb %q (expected: discover)", verb)
+	return fmt.Errorf("consumer nmos: unknown verb %q (expected: discover, system)", verb)
 }
 
 // runNMOSProducer dispatches `dhs producer nmos <verb> [args]`.
@@ -212,10 +220,37 @@ func printInstances(service string, insts []codec.Instance) {
 	}
 }
 
-// ---- producer serve (Phase 1 #1: mDNS announce only, placeholder Node) ------
+// ---- producer serve ---------------------------------------------------------
+// Phase 1 #1 ships --role node (mDNS announce only, no HTTP).
+// Phase 1 #2 adds  --role system (IS-09 System API).
 
 func runNMOSNodeServe(ctx context.Context, args []string) error {
+	// Two-pass parse: peek at --role first so we can dispatch to the
+	// IS-09 path without rejecting unknown flags.
+	role := "node"
+	for i, a := range args {
+		if a == "--role" || a == "-role" {
+			if i+1 < len(args) {
+				role = strings.ToLower(args[i+1])
+			}
+		} else if strings.HasPrefix(a, "--role=") {
+			role = strings.ToLower(strings.TrimPrefix(a, "--role="))
+		} else if strings.HasPrefix(a, "-role=") {
+			role = strings.ToLower(strings.TrimPrefix(a, "-role="))
+		}
+	}
+	switch role {
+	case "system":
+		return runNMOSSystemServe(ctx, args)
+	case "node", "":
+		return runNMOSNodeServeLegacy(ctx, args)
+	}
+	return fmt.Errorf("producer nmos serve: unknown --role %q (expected: node, system)", role)
+}
+
+func runNMOSNodeServeLegacy(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
+	_ = fs.String("role", "node", "producer role to start (node | system)")
 	mdns := fs.Bool("mdns", true, "advertise via mDNS")
 	noMDNS := fs.Bool("no-mdns", false, "disable mDNS announce")
 	advertise := fs.String("advertise-host", "", "host:port placed in DNS-SD A/SRV records (default: hostname:port)")
@@ -262,6 +297,193 @@ func runNMOSNodeServe(ctx context.Context, args []string) error {
 
 	<-ctx.Done()
 	return nil
+}
+
+// ---- consumer system (IS-09) ------------------------------------------------
+
+func runNMOSSystem(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("system", flag.ContinueOnError)
+	mdns := fs.Bool("mdns", true, "discover via mDNS (Mode A)")
+	noMDNS := fs.Bool("no-mdns", false, "disable mDNS")
+	unicast := fs.Bool("unicast", false, "discover via unicast DNS-SD (Mode B); requires --resolver")
+	resolver := fs.String("resolver", "", "unicast DNS-SD resolver host[:port]")
+	peerList := fs.String("peer-list", "", "static CSV peer list (Mode C: host,port[,api_ver])")
+	direct := fs.String("direct", "", "skip discovery and GET /global from this host:port")
+	service := fs.String("service", codec.ServiceSystem, "DNS-SD service type to discover")
+	apiVer := fs.String("api-ver", is09.APIVersion, "IS-09 wire version (TXT api_ver filter + URL prefix)")
+	apiProto := fs.String("api-proto", "http", "TXT api_proto filter (http | https)")
+	timeout := fs.Duration("timeout", 5*time.Second, "discovery deadline")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	// Direct override — skip discovery entirely.
+	if *direct != "" {
+		res, err := consumer.Fetch(ctx, consumer.IS09FetchOptions{
+			Logger:   logger,
+			APIVer:   *apiVer,
+			APIProto: *apiProto,
+			Direct:   *direct,
+		})
+		if err != nil {
+			return err
+		}
+		printIS09Result(res)
+		return nil
+	}
+
+	// Discovery phase — pick exactly one source.
+	bareSvc, dom := splitServiceDomain(*service)
+	if dom == "" {
+		dom = codec.DefaultDomain
+	}
+	var insts []codec.Instance
+	switch {
+	case *peerList != "":
+		entries, err := session.ReadPeerList(*peerList)
+		if err != nil {
+			return err
+		}
+		for _, e := range entries {
+			insts = append(insts, codec.Instance{
+				Name:    e.Host,
+				Service: codec.ServiceSystem,
+				Domain:  dom,
+				Host:    e.Host,
+				Port:    uint16(e.Port),
+				TXT: map[string]string{
+					codec.TXTKeyAPIProto: *apiProto,
+					codec.TXTKeyAPIVer:   *apiVer,
+				},
+			})
+		}
+	case *unicast || *resolver != "":
+		if *resolver == "" {
+			return fmt.Errorf("nmos system --unicast: --resolver is required")
+		}
+		got, err := session.ResolveUnicast(ctx, *resolver, bareSvc, dom, *timeout)
+		if err != nil {
+			return err
+		}
+		insts = got
+	case *mdns && !*noMDNS:
+		got, err := consumer.DiscoverMDNS(ctx, *timeout, logger)
+		if err != nil {
+			return err
+		}
+		insts = got
+	default:
+		return fmt.Errorf("nmos system: pick exactly one of --mdns / --unicast / --peer-list / --direct")
+	}
+
+	if len(insts) == 0 {
+		return fmt.Errorf("nmos system: no %s instances found", *service)
+	}
+
+	res, err := consumer.Fetch(ctx, consumer.IS09FetchOptions{
+		Logger:     logger,
+		APIVer:     *apiVer,
+		APIProto:   *apiProto,
+		Discovered: insts,
+	})
+	if err != nil {
+		return err
+	}
+	printIS09Result(res)
+	return nil
+}
+
+func printIS09Result(res *consumer.FetchResult) {
+	fmt.Println("System API selected:")
+	if res.Selected.Name != "" && res.Selected.Service != "" {
+		fmt.Printf("  instance = %s\n", res.Selected.FullName())
+	}
+	fmt.Printf("  url      = %s\n", res.URL)
+	if pri, ok := codec.PriorityFromTXT(res.Selected.TXT); ok {
+		fmt.Printf("  pri      = %d\n", pri)
+	}
+	if v, ok := res.Selected.TXT[codec.TXTKeyAPIVer]; ok {
+		fmt.Printf("  api_ver  = %s\n", v)
+	}
+	if v, ok := res.Selected.TXT[codec.TXTKeyAPIProto]; ok {
+		fmt.Printf("  api_proto= %s\n", v)
+	}
+
+	g := res.Global
+	fmt.Println("\n/global:")
+	fmt.Printf("  id                          = %s\n", g.ID)
+	fmt.Printf("  version                     = %s\n", g.Version)
+	fmt.Printf("  label                       = %q\n", g.Label)
+	fmt.Printf("  description                 = %q\n", g.Description)
+	fmt.Printf("  is04.heartbeat_interval     = %d\n", g.IS04.HeartbeatInterval)
+	fmt.Printf("  ptp.announce_receipt_timeout = %d\n", g.PTP.AnnounceReceiptTimeout)
+	fmt.Printf("  ptp.domain_number            = %d\n", g.PTP.DomainNumber)
+	if g.SyslogV2 != nil {
+		fmt.Printf("  syslogv2                    = %s:%d\n", g.SyslogV2.Hostname, g.SyslogV2.Port)
+	} else {
+		fmt.Println("  syslogv2                    = (none)")
+	}
+	if g.Syslog != nil {
+		fmt.Printf("  syslog                      = %s:%d\n", g.Syslog.Hostname, g.Syslog.Port)
+	} else {
+		fmt.Println("  syslog                      = (none)")
+	}
+}
+
+// ---- producer serve --role system (IS-09) -----------------------------------
+
+func runNMOSSystemServe(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
+	_ = fs.String("role", "system", "producer role")
+	configPath := fs.String("config", "", "path to IS-09 /global resource JSON file (required)")
+	bind := fs.String("bind", ":10641", "HTTP listen address")
+	advertise := fs.String("advertise-host", "", "host[:port] placed in DNS-SD A/SRV records")
+	mdns := fs.Bool("mdns", true, "advertise via mDNS")
+	noMDNS := fs.Bool("no-mdns", false, "disable mDNS announce (Mode B / static)")
+	apiVer := fs.String("api-ver", is09.APIVersion, "IS-09 wire version exposed under /x-nmos/system/<v>")
+	priority := fs.Int("priority", 0, "DNS-SD `pri` TXT (0-99 production, 100+ dev)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *configPath == "" {
+		return fmt.Errorf("producer nmos serve --role system: --config FILE required")
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	g, err := provider.LoadIS09GlobalFromFile(*configPath)
+	if err != nil {
+		return err
+	}
+
+	mode := "mdns"
+	if !*mdns || *noMDNS {
+		mode = "static"
+	}
+	cfg := provider.IS09Config{
+		Bind:          *bind,
+		AdvertiseHost: *advertise,
+		DiscoveryMode: mode,
+		Priority:      *priority,
+		APIVer:        *apiVer,
+	}
+	srv, err := provider.NewIS09Server(logger, g, cfg)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = srv.Stop() }()
+
+	fmt.Printf("System API: bind=%s, mode=%s, api_ver=%s, priority=%d\n", *bind, mode, *apiVer, *priority)
+	fmt.Printf("  GET http://<host>%s/x-nmos/system/%s/        (index)\n", *bind, *apiVer)
+	fmt.Printf("  GET http://<host>%s/x-nmos/system/%s/global  (global resource)\n", *bind, *apiVer)
+	if mode == "mdns" {
+		fmt.Println("Announcing _nmos-system._tcp via mDNS.")
+	} else {
+		fmt.Println("DNS-SD announce disabled — caller publishes records (e.g. pfSense Unbound, see docs/dns-sd-unbound.md).")
+	}
+	return srv.Serve(ctx)
 }
 
 // ---- registry serve ---------------------------------------------------------
@@ -348,29 +570,53 @@ func splitNMOSHostPort(s string) (string, string, error) {
 func printNMOSConsumerHelp() {
 	fmt.Println(`Usage:
   dhs consumer nmos discover [flags]
+  dhs consumer nmos system   [flags]
 
-Discovery flags:
+discover — print every NMOS instance the configured discovery mode reveals.
   --mdns                Use mDNS multicast (Mode A; default)
   --no-mdns             Disable mDNS
   --unicast             Use unicast DNS-SD (Mode B); requires --resolver
   --resolver host[:53]  Authoritative DNS server for unicast queries
   --peer-list FILE      Static CSV (Mode C; "host,port[,api_ver]")
   --service NAME        DNS-SD service type (default _nmos-register._tcp)
-  --timeout DURATION    Discovery deadline (default 5s)`)
+  --timeout DURATION    Discovery deadline (default 5s)
+
+system — IS-09 System API client (Node bootstrap). Discovers _nmos-system._tcp,
+applies the spec-strict selection rule (filter by api_proto + api_ver, sort by
+pri, randomised tie-break), GETs /global, validates against the IS-09 v1.0
+JSON Schema, prints the parsed fields.
+  (any of the discovery flags above)
+  --direct host:port    Skip discovery; fetch /global directly from this peer
+  --api-ver V           Requested IS-09 version (default v1.0)
+  --api-proto P         Requested protocol filter (default http)`)
 }
 
 func printNMOSProducerHelp() {
 	fmt.Println(`Usage:
   dhs producer nmos serve [flags]
 
-Phase 1 #1 scope: announces a placeholder Node via mDNS only — IS-04
-Node API REST surface lands in Phase 1 #3.
+  --role node|system    Producer role (default: node)
+
+Role: node (Phase 1 #1)
+  Announces a placeholder Node via mDNS only — IS-04 Node API REST surface
+  lands in Phase 1 #3.
 
   --mdns                Advertise via mDNS (default)
   --no-mdns             Disable mDNS announce
   --advertise-host H    host placed in SRV record (default: os.Hostname)
   --port N              Port advertised in SRV (default 8080)
-  --api-ver V           IS-04 version in TXT (default v1.3)`)
+  --api-ver V           IS-04 version in TXT (default v1.3)
+
+Role: system (Phase 1 #2 — IS-09 System API)
+  Loads + validates a /global resource JSON, serves the two IS-09 endpoints
+  on --bind, optionally announces _nmos-system._tcp via mDNS.
+
+  --config FILE         IS-09 /global resource JSON (required)
+  --bind ADDR           HTTP listen address (default :10641)
+  --advertise-host H    host[:port] placed in DNS-SD A/SRV records
+  --mdns / --no-mdns    Toggle mDNS announce (default on)
+  --api-ver V           IS-09 version exposed under /x-nmos/system/<v> (default v1.0)
+  --priority N          DNS-SD pri TXT (0-99 prod, 100+ dev)`)
 }
 
 func printNMOSRegistryHelp() {

--- a/internal/amwa/codec/is09/doc.go
+++ b/internal/amwa/codec/is09/doc.go
@@ -1,0 +1,18 @@
+// Package is09 implements the AMWA NMOS IS-09 v1.0.0 System API
+// codec. Stdlib-only (encoding/json + regexp + strings), spec-strict
+// per https://specs.amwa.tv/is-09/releases/v1.0.0/.
+//
+// Scope:
+//
+//   - The /global resource (resource_core + is04 + ptp + optional
+//     syslog/syslogv2).
+//   - Schema validation: required fields, integer ranges, regex
+//     patterns for id (uuid) and version (TAI timestamp).
+//   - Encoder rejects unknown keys; decoder rejects required missing
+//     and out-of-range values.
+//
+// IS-09 v1.0 predates IS-10, so the DNS-SD TXT layer for
+// `_nmos-system._tcp` MUST NOT advertise `api_auth` (per
+// https://specs.amwa.tv/is-09/releases/v1.0.0/docs/3.1._Discovery_-_Operation.html).
+// That rule lives in the provider plugin, not in this package.
+package is09

--- a/internal/amwa/codec/is09/global.go
+++ b/internal/amwa/codec/is09/global.go
@@ -1,0 +1,116 @@
+package is09
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// APIVersion is the v1.0 wire version this codec implements.
+const APIVersion = "v1.0"
+
+// IndexResponse is the GET /x-nmos/system/v1.0/ payload — exactly one
+// element per the RAML schema.
+type IndexResponse []string
+
+// IndexValue is the only valid IndexResponse content per spec
+// (`schemas/with-refs/system-api-base.html`).
+const IndexValue = "global/"
+
+// Global is the IS-09 /global resource. Layout matches
+// https://specs.amwa.tv/is-09/releases/v1.0.0/APIs/schemas/with-refs/global.html
+// (which is allOf [resource_core.json, IS-09 globals]).
+type Global struct {
+	// resource_core.json — every field required.
+	ID          string              `json:"id"`
+	Version     string              `json:"version"`
+	Label       string              `json:"label"`
+	Description string              `json:"description"`
+	Tags        map[string][]string `json:"tags"`
+
+	// IS-09 globals — every leaf field except syslog/syslogv2 is required.
+	IS04 IS04Config `json:"is04"`
+	PTP  PTPConfig  `json:"ptp"`
+
+	// Optional log-forwarding endpoints. Pointer so we can distinguish
+	// "absent" from "present-with-zero-port".
+	SyslogV2 *SyslogConfig `json:"syslogv2,omitempty"`
+	Syslog   *SyslogConfig `json:"syslog,omitempty"`
+}
+
+// IS04Config carries the IS-04 heartbeat interval used by Nodes when
+// re-registering.
+type IS04Config struct {
+	HeartbeatInterval int `json:"heartbeat_interval"`
+}
+
+// PTPConfig carries IEEE 1588-2008 (PTPv2) constants.
+type PTPConfig struct {
+	AnnounceReceiptTimeout int `json:"announce_receipt_timeout"`
+	DomainNumber           int `json:"domain_number"`
+}
+
+// SyslogConfig is shared between syslogv2 (TLS, RFC 5424/5425) and
+// syslog v1 (UDP, RFC 5424/5426). Both fields optional per spec.
+type SyslogConfig struct {
+	Hostname string `json:"hostname,omitempty"`
+	Port     int    `json:"port,omitempty"`
+}
+
+// IndexBody returns the canonical /x-nmos/system/v1.0/ index payload.
+func IndexBody() IndexResponse {
+	return IndexResponse{IndexValue}
+}
+
+// Encode marshals g to spec-compliant JSON. The returned bytes are
+// indented for human inspection; use EncodeCompact for wire emission.
+func (g *Global) Encode() ([]byte, error) {
+	if err := g.Validate(); err != nil {
+		return nil, fmt.Errorf("is09: encode: %w", err)
+	}
+	return json.MarshalIndent(g, "", "  ")
+}
+
+// EncodeCompact marshals g without indentation (single-line). Used
+// when emitting on the wire.
+func (g *Global) EncodeCompact() ([]byte, error) {
+	if err := g.Validate(); err != nil {
+		return nil, fmt.Errorf("is09: encode: %w", err)
+	}
+	return json.Marshal(g)
+}
+
+// Decode parses raw JSON into a Global and validates it. Unknown keys
+// (any field not in the spec schema) are rejected via
+// json.Decoder.DisallowUnknownFields per the no-workaround rule —
+// peers that emit extras must be flagged, not silently absorbed.
+func Decode(raw []byte) (*Global, error) {
+	d := json.NewDecoder(bytes.NewReader(raw))
+	d.DisallowUnknownFields()
+	var g Global
+	if err := d.Decode(&g); err != nil {
+		return nil, fmt.Errorf("is09: decode: %w", err)
+	}
+	if d.More() {
+		return nil, fmt.Errorf("is09: decode: trailing JSON content")
+	}
+	if err := g.Validate(); err != nil {
+		return nil, fmt.Errorf("is09: decode: %w", err)
+	}
+	return &g, nil
+}
+
+// DecodeIndex parses the /x-nmos/system/v1.0/ index response and
+// confirms the only allowed payload shape.
+func DecodeIndex(raw []byte) (IndexResponse, error) {
+	d := json.NewDecoder(bytes.NewReader(raw))
+	d.DisallowUnknownFields()
+	var idx IndexResponse
+	if err := d.Decode(&idx); err != nil {
+		return nil, fmt.Errorf("is09: decode index: %w", err)
+	}
+	if len(idx) != 1 || idx[0] != IndexValue {
+		return nil, fmt.Errorf("is09: decode index: expected exactly [%q], got %v", IndexValue, idx)
+	}
+	return idx, nil
+}

--- a/internal/amwa/codec/is09/global_test.go
+++ b/internal/amwa/codec/is09/global_test.go
@@ -1,0 +1,254 @@
+package is09
+
+import (
+	"strings"
+	"testing"
+)
+
+// specExample is the verbatim payload from
+// https://specs.amwa.tv/is-09/releases/v1.0.0/examples/global-get-200.html.
+// Used as the canonical happy-path round-trip test.
+const specExample = `{
+  "id": "3b8be755-08ff-452b-b217-c9151eb21193",
+  "version": "1441700172:318426300",
+  "label": "ZBQ System",
+  "description": "System Global Information for ZBQ",
+  "tags": {},
+  "is04": {
+    "heartbeat_interval": 8
+  },
+  "ptp": {
+    "announce_receipt_timeout": 2,
+    "domain_number": 57
+  },
+  "syslogv2": {
+    "hostname": "biglogger.ebu.ch",
+    "port": 3477
+  }
+}`
+
+func validGlobal() Global {
+	return Global{
+		ID:          "3b8be755-08ff-452b-b217-c9151eb21193",
+		Version:     "1441700172:318426300",
+		Label:       "ZBQ System",
+		Description: "System Global Information for ZBQ",
+		Tags:        map[string][]string{},
+		IS04:        IS04Config{HeartbeatInterval: 8},
+		PTP:         PTPConfig{AnnounceReceiptTimeout: 2, DomainNumber: 57},
+	}
+}
+
+func TestDecodeSpecExample(t *testing.T) {
+	g, err := Decode([]byte(specExample))
+	if err != nil {
+		t.Fatalf("decode spec example: %v", err)
+	}
+	if g.ID != "3b8be755-08ff-452b-b217-c9151eb21193" {
+		t.Fatalf("ID = %q", g.ID)
+	}
+	if g.IS04.HeartbeatInterval != 8 {
+		t.Fatalf("heartbeat_interval = %d", g.IS04.HeartbeatInterval)
+	}
+	if g.PTP.DomainNumber != 57 {
+		t.Fatalf("ptp.domain_number = %d", g.PTP.DomainNumber)
+	}
+	if g.SyslogV2 == nil || g.SyslogV2.Hostname != "biglogger.ebu.ch" || g.SyslogV2.Port != 3477 {
+		t.Fatalf("syslogv2 = %+v", g.SyslogV2)
+	}
+	if g.Syslog != nil {
+		t.Fatalf("syslog should be absent (omitempty), got %+v", g.Syslog)
+	}
+}
+
+func TestEncodeRoundTrip(t *testing.T) {
+	in := validGlobal()
+	in.SyslogV2 = &SyslogConfig{Hostname: "biglogger.ebu.ch", Port: 3477}
+
+	wire, err := in.Encode()
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	out, err := Decode(wire)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.IS04.HeartbeatInterval != in.IS04.HeartbeatInterval {
+		t.Fatalf("heartbeat_interval mismatch")
+	}
+	if out.SyslogV2 == nil || *out.SyslogV2 != *in.SyslogV2 {
+		t.Fatalf("syslogv2 mismatch: %+v vs %+v", out.SyslogV2, in.SyslogV2)
+	}
+}
+
+func TestDecodeRejectsUnknownKey(t *testing.T) {
+	withExtra := strings.Replace(specExample,
+		`"tags": {}`,
+		`"tags": {}, "rogue_field": "should be rejected"`, 1)
+	_, err := Decode([]byte(withExtra))
+	if err == nil {
+		t.Fatal("expected unknown-key rejection")
+	}
+	if !strings.Contains(err.Error(), "rogue_field") {
+		t.Fatalf("error should name the rogue key: %v", err)
+	}
+}
+
+func TestDecodeRejectsTrailingJSON(t *testing.T) {
+	_, err := Decode([]byte(specExample + `{}`))
+	if err == nil || !strings.Contains(err.Error(), "trailing") {
+		t.Fatalf("expected trailing-content rejection, got %v", err)
+	}
+}
+
+func TestValidateRequiredMissing(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*Global)
+		want   string
+	}{
+		{"id absent", func(g *Global) { g.ID = "" }, "id"},
+		{"version absent", func(g *Global) { g.Version = "" }, "version"},
+		{"label absent", func(g *Global) { g.Label = "" }, "label"},
+		{"description absent", func(g *Global) { g.Description = "" }, "description"},
+		{"tags nil", func(g *Global) { g.Tags = nil }, "tags"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := validGlobal()
+			tc.mutate(&g)
+			err := g.Validate()
+			if err == nil {
+				t.Fatalf("expected validation error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q should mention %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateIDPattern(t *testing.T) {
+	g := validGlobal()
+	g.ID = "not-a-uuid"
+	if err := g.Validate(); err == nil {
+		t.Fatal("expected uuid pattern rejection")
+	}
+	// Valid UUID v4
+	g.ID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+	if err := g.Validate(); err != nil {
+		t.Fatalf("v4 uuid should be accepted: %v", err)
+	}
+	// v6+ not in the allowed set [1-5]
+	g.ID = "f47ac10b-58cc-6372-a567-0e02b2c3d479"
+	if err := g.Validate(); err == nil {
+		t.Fatal("v6 uuid must be rejected by spec pattern [1-5]")
+	}
+}
+
+func TestValidateVersionPattern(t *testing.T) {
+	g := validGlobal()
+	for _, v := range []string{"abc", "123:", ":456", "123:abc"} {
+		g.Version = v
+		if err := g.Validate(); err == nil {
+			t.Fatalf("version %q should be rejected", v)
+		}
+	}
+	g.Version = "0:0"
+	if err := g.Validate(); err != nil {
+		t.Fatalf("0:0 should be valid: %v", err)
+	}
+}
+
+func TestValidateRangeBounds(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*Global)
+		want   string
+	}{
+		{"heartbeat too low", func(g *Global) { g.IS04.HeartbeatInterval = 0 }, "heartbeat_interval"},
+		{"heartbeat too high", func(g *Global) { g.IS04.HeartbeatInterval = 1001 }, "heartbeat_interval"},
+		{"announce too low", func(g *Global) { g.PTP.AnnounceReceiptTimeout = 1 }, "announce_receipt_timeout"},
+		{"announce too high", func(g *Global) { g.PTP.AnnounceReceiptTimeout = 11 }, "announce_receipt_timeout"},
+		{"domain too low", func(g *Global) { g.PTP.DomainNumber = -1 }, "domain_number"},
+		{"domain too high", func(g *Global) { g.PTP.DomainNumber = 128 }, "domain_number"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := validGlobal()
+			tc.mutate(&g)
+			err := g.Validate()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected %s error, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestValidateBoundary(t *testing.T) {
+	g := validGlobal()
+	g.IS04.HeartbeatInterval = 1
+	g.PTP.AnnounceReceiptTimeout = 2
+	g.PTP.DomainNumber = 0
+	if err := g.Validate(); err != nil {
+		t.Fatalf("low boundaries should pass: %v", err)
+	}
+	g.IS04.HeartbeatInterval = 1000
+	g.PTP.AnnounceReceiptTimeout = 10
+	g.PTP.DomainNumber = 127
+	if err := g.Validate(); err != nil {
+		t.Fatalf("high boundaries should pass: %v", err)
+	}
+}
+
+func TestValidateSyslogBlocks(t *testing.T) {
+	g := validGlobal()
+	g.SyslogV2 = &SyslogConfig{Hostname: "biglogger.ebu.ch", Port: SyslogV2DefaultPort}
+	g.Syslog = &SyslogConfig{Hostname: "10.0.0.1", Port: SyslogV1DefaultPort}
+	if err := g.Validate(); err != nil {
+		t.Fatalf("valid syslog blocks rejected: %v", err)
+	}
+
+	// Empty hostname + zero port = valid (both fields optional).
+	g.SyslogV2 = &SyslogConfig{}
+	if err := g.Validate(); err != nil {
+		t.Fatalf("empty syslogv2 block rejected: %v", err)
+	}
+
+	// Out-of-range port
+	g.SyslogV2 = &SyslogConfig{Port: 70000}
+	if err := g.Validate(); err == nil || !strings.Contains(err.Error(), "syslogv2.port") {
+		t.Fatalf("expected port range error, got %v", err)
+	}
+
+	// Bogus hostname
+	g.SyslogV2 = &SyslogConfig{Hostname: "not_a_valid_host"}
+	if err := g.Validate(); err == nil || !strings.Contains(err.Error(), "hostname") {
+		t.Fatalf("expected hostname format error, got %v", err)
+	}
+
+	// IPv6 should pass
+	g.SyslogV2 = &SyslogConfig{Hostname: "2001:db8::1"}
+	if err := g.Validate(); err != nil {
+		t.Fatalf("ipv6 hostname should pass: %v", err)
+	}
+}
+
+func TestIndexBodyAndDecode(t *testing.T) {
+	idx := IndexBody()
+	if len(idx) != 1 || idx[0] != IndexValue {
+		t.Fatalf("IndexBody = %v", idx)
+	}
+	out, err := DecodeIndex([]byte(`["global/"]`))
+	if err != nil {
+		t.Fatalf("DecodeIndex: %v", err)
+	}
+	if len(out) != 1 || out[0] != IndexValue {
+		t.Fatalf("DecodeIndex result: %v", out)
+	}
+	for _, bad := range []string{`[]`, `["global/","other/"]`, `["other/"]`, `[1]`} {
+		if _, err := DecodeIndex([]byte(bad)); err == nil {
+			t.Fatalf("DecodeIndex(%q) should fail", bad)
+		}
+	}
+}

--- a/internal/amwa/codec/is09/validate.go
+++ b/internal/amwa/codec/is09/validate.go
@@ -1,0 +1,140 @@
+package is09
+
+import (
+	"fmt"
+	"net"
+	"regexp"
+	"strings"
+)
+
+// Spec-strict ranges from
+// https://specs.amwa.tv/is-09/releases/v1.0.0/APIs/schemas/with-refs/global.html.
+const (
+	HeartbeatIntervalMin       = 1
+	HeartbeatIntervalMax       = 1000
+	HeartbeatIntervalDefault   = 5
+	AnnounceReceiptTimeoutMin  = 2
+	AnnounceReceiptTimeoutMax  = 10
+	PTPDomainMin               = 0
+	PTPDomainMax               = 127
+	SyslogV1DefaultPort        = 514
+	SyslogV2DefaultPort        = 6514
+	SyslogPortMin              = 1
+	SyslogPortMax              = 65535
+)
+
+// uuidRE enforces RFC 4122 v1-v5 form per resource_core.json.
+var uuidRE = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+// versionRE enforces the IS-04 TAI-timestamp form `<sec>:<nsec>`.
+var versionRE = regexp.MustCompile(`^[0-9]+:[0-9]+$`)
+
+// Validate runs every spec rule on the resource and returns a chained
+// error listing every violation found (concatenated with "; ").
+// Encoder + decoder funnel through this.
+func (g *Global) Validate() error {
+	var errs []string
+
+	// resource_core
+	if g.ID == "" || !uuidRE.MatchString(g.ID) {
+		errs = append(errs, fmt.Sprintf("id %q: must match RFC 4122 v1-v5 UUID pattern", g.ID))
+	}
+	if g.Version == "" || !versionRE.MatchString(g.Version) {
+		errs = append(errs, fmt.Sprintf("version %q: must match `<sec>:<nsec>` TAI form", g.Version))
+	}
+	if g.Label == "" {
+		errs = append(errs, "label: required (resource_core)")
+	}
+	if g.Description == "" {
+		errs = append(errs, "description: required (resource_core)")
+	}
+	if g.Tags == nil {
+		errs = append(errs, "tags: required (may be empty object, but key must be present)")
+	}
+
+	// IS-09 globals — required nesteds
+	if g.IS04.HeartbeatInterval < HeartbeatIntervalMin || g.IS04.HeartbeatInterval > HeartbeatIntervalMax {
+		errs = append(errs, fmt.Sprintf("is04.heartbeat_interval=%d: out of [%d..%d]",
+			g.IS04.HeartbeatInterval, HeartbeatIntervalMin, HeartbeatIntervalMax))
+	}
+	if g.PTP.AnnounceReceiptTimeout < AnnounceReceiptTimeoutMin || g.PTP.AnnounceReceiptTimeout > AnnounceReceiptTimeoutMax {
+		errs = append(errs, fmt.Sprintf("ptp.announce_receipt_timeout=%d: out of [%d..%d]",
+			g.PTP.AnnounceReceiptTimeout, AnnounceReceiptTimeoutMin, AnnounceReceiptTimeoutMax))
+	}
+	if g.PTP.DomainNumber < PTPDomainMin || g.PTP.DomainNumber > PTPDomainMax {
+		errs = append(errs, fmt.Sprintf("ptp.domain_number=%d: out of [%d..%d]",
+			g.PTP.DomainNumber, PTPDomainMin, PTPDomainMax))
+	}
+
+	// Optional syslog blocks. Spec says hostname/port are individually
+	// optional, but if either is set we range-check both per the
+	// schema's port bounds.
+	if g.Syslog != nil {
+		if err := validateSyslogBlock("syslog", g.Syslog); err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
+	if g.SyslogV2 != nil {
+		if err := validateSyslogBlock("syslogv2", g.SyslogV2); err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+	return fmt.Errorf("is09 /global validation failed: %s", strings.Join(errs, "; "))
+}
+
+func validateSyslogBlock(label string, s *SyslogConfig) error {
+	if s == nil {
+		return nil
+	}
+	if s.Hostname != "" {
+		if !isValidSyslogHostname(s.Hostname) {
+			return fmt.Errorf("%s.hostname %q: must be a hostname, IPv4, or IPv6", label, s.Hostname)
+		}
+	}
+	if s.Port != 0 {
+		if s.Port < SyslogPortMin || s.Port > SyslogPortMax {
+			return fmt.Errorf("%s.port=%d: out of [%d..%d]", label, s.Port, SyslogPortMin, SyslogPortMax)
+		}
+	}
+	return nil
+}
+
+// isValidSyslogHostname accepts any of the three formats listed in the
+// global.json schema: hostname (RFC 1123), IPv4, IPv6.
+func isValidSyslogHostname(s string) bool {
+	if ip := net.ParseIP(s); ip != nil {
+		return true
+	}
+	return looksLikeRFC1123Hostname(s)
+}
+
+// looksLikeRFC1123Hostname is a stdlib-only RFC 1123 hostname check —
+// labels separated by dots, each 1-63 chars, alphanumeric or hyphen
+// (not starting/ending with hyphen).
+func looksLikeRFC1123Hostname(s string) bool {
+	if s == "" || len(s) > 253 {
+		return false
+	}
+	labels := strings.Split(s, ".")
+	for _, lbl := range labels {
+		if lbl == "" || len(lbl) > 63 {
+			return false
+		}
+		if lbl[0] == '-' || lbl[len(lbl)-1] == '-' {
+			return false
+		}
+		for i := 0; i < len(lbl); i++ {
+			c := lbl[i]
+			isAlpha := (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+			isDigit := c >= '0' && c <= '9'
+			if !isAlpha && !isDigit && c != '-' {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/internal/amwa/consumer/system.go
+++ b/internal/amwa/consumer/system.go
@@ -1,0 +1,274 @@
+// Layer-3 IS-09 System API consumer — discovery + selection rule + GET
+// /global. Used by Nodes during bootstrap to pick up PTP / heartbeat /
+// syslog parameters from the network.
+//
+// Spec: AMWA NMOS IS-09 v1.0.0
+// (https://specs.amwa.tv/is-09/releases/v1.0.0/docs/3.1._Discovery_-_Operation.html).
+//
+// Selection rule (spec-strict):
+//
+//   1. Filter out instances whose api_proto != requested.
+//   2. Filter out instances whose api_ver list does not include the
+//      requested version.
+//   3. Sort by `pri` ascending.
+//   4. Randomised tie-break among the lowest-pri survivors.
+//   5. GET /x-nmos/system/<api-ver>/global, validate, return Global.
+
+package consumer
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"log/slog"
+	"net"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	dnssdcodec "acp/internal/amwa/codec/dnssd"
+	"acp/internal/amwa/codec/is09"
+	dnssdsession "acp/internal/amwa/session/dnssd"
+	httpsession "acp/internal/amwa/session/http"
+)
+
+// IS09FetchOptions configures a single Fetch call.
+type IS09FetchOptions struct {
+	// Logger to emit progress messages (mDNS bind, selection
+	// outcome). May be nil for quiet mode.
+	Logger *slog.Logger
+
+	// APIVer is the IS-09 wire version requested. Default v1.0.
+	APIVer string
+
+	// APIProto is the requested protocol — "http" or "https".
+	// Default "http".
+	APIProto string
+
+	// HTTPClient lets callers pre-configure timeouts, transport, etc.
+	// Default = httpsession.NewClient().
+	HTTPClient *httpsession.Client
+
+	// Direct, when non-empty, bypasses discovery and fetches
+	// /global from this `host:port` directly. Useful for unicast Mode B
+	// targets we already have in hand.
+	Direct string
+
+	// Discovered, when non-nil, is the pre-discovered instance set —
+	// caller already ran discover via mDNS / unicast / peer-list.
+	// When nil, Fetch returns ErrNoInstances; the CLI runs discovery
+	// itself.
+	Discovered []dnssdcodec.Instance
+}
+
+// ErrNoInstances signals that no usable instance survived selection.
+var ErrNoInstances = fmt.Errorf("nmos/system: no instance matched api_proto/api_ver filters")
+
+// FetchResult bundles the selected instance with the validated Global
+// resource.
+type FetchResult struct {
+	Selected dnssdcodec.Instance
+	URL      string
+	Global   *is09.Global
+}
+
+// Fetch picks the highest-priority IS-09 instance from opts.Discovered
+// (or opts.Direct), GETs /global, validates, returns the result.
+func Fetch(ctx context.Context, opts IS09FetchOptions) (*FetchResult, error) {
+	if opts.APIVer == "" {
+		opts.APIVer = is09.APIVersion
+	}
+	if opts.APIProto == "" {
+		opts.APIProto = "http"
+	}
+	client := opts.HTTPClient
+	if client == nil {
+		client = httpsession.NewClient()
+	}
+
+	// Direct override — skip discovery entirely.
+	if opts.Direct != "" {
+		host, port, err := parseDirect(opts.Direct)
+		if err != nil {
+			return nil, err
+		}
+		ins := dnssdcodec.Instance{
+			Name:    "direct",
+			Service: dnssdcodec.ServiceSystem,
+			Domain:  "",
+			Host:    host,
+			Port:    port,
+			TXT: map[string]string{
+				dnssdcodec.TXTKeyAPIProto: opts.APIProto,
+				dnssdcodec.TXTKeyAPIVer:   opts.APIVer,
+			},
+		}
+		return fetchFromInstance(ctx, client, ins, opts)
+	}
+
+	if len(opts.Discovered) == 0 {
+		return nil, ErrNoInstances
+	}
+	selected, err := SelectInstance(opts.Discovered, opts.APIProto, opts.APIVer, opts.Logger)
+	if err != nil {
+		return nil, err
+	}
+	return fetchFromInstance(ctx, client, selected, opts)
+}
+
+// SelectInstance applies the spec-strict IS-09 §3.1 selection rule.
+// Exposed for tests and CLI listings.
+func SelectInstance(insts []dnssdcodec.Instance, apiProto, apiVer string, logger *slog.Logger) (dnssdcodec.Instance, error) {
+	type rated struct {
+		ins dnssdcodec.Instance
+		pri int
+	}
+	var matches []rated
+	for _, ins := range insts {
+		// Service-type filter — only keep _nmos-system._tcp.
+		if ins.Service != dnssdcodec.ServiceSystem && ins.Service != "" {
+			continue
+		}
+		gotProto := strings.ToLower(strings.TrimSpace(ins.TXT[dnssdcodec.TXTKeyAPIProto]))
+		if gotProto != strings.ToLower(apiProto) {
+			continue
+		}
+		if !versionListContains(ins.TXT[dnssdcodec.TXTKeyAPIVer], apiVer) {
+			continue
+		}
+		pri, ok := dnssdcodec.PriorityFromTXT(ins.TXT)
+		if !ok {
+			pri = 99 // peers without `pri` get the lowest production priority
+		}
+		matches = append(matches, rated{ins, pri})
+	}
+	if len(matches) == 0 {
+		return dnssdcodec.Instance{}, ErrNoInstances
+	}
+	sort.Slice(matches, func(i, j int) bool { return matches[i].pri < matches[j].pri })
+
+	// Identify the tied-lowest set, randomised tie-break per §3.1.
+	bestPri := matches[0].pri
+	end := 0
+	for end < len(matches) && matches[end].pri == bestPri {
+		end++
+	}
+	tied := matches[:end]
+	pick := tied[secureRandIndex(end)]
+
+	if logger != nil && end > 1 {
+		logger.Info("nmos/system: tie-break among lowest pri",
+			"pri", bestPri, "candidates", end, "selected", pick.ins.FullName())
+	}
+	return pick.ins, nil
+}
+
+// versionListContains checks whether `csv` (e.g. "v1.0,v1.1") lists
+// `want` exactly. Whitespace tolerated; case-insensitive on the `v`
+// prefix only.
+func versionListContains(csv, want string) bool {
+	if csv == "" {
+		return false
+	}
+	want = strings.TrimSpace(want)
+	for _, tok := range strings.Split(csv, ",") {
+		if strings.TrimSpace(tok) == want {
+			return true
+		}
+	}
+	return false
+}
+
+// fetchFromInstance does the HTTP GET, validates, and returns.
+func fetchFromInstance(ctx context.Context, client *httpsession.Client, ins dnssdcodec.Instance, opts IS09FetchOptions) (*FetchResult, error) {
+	// Use the instance Host (DNS name from SRV) when available,
+	// falling back to the first IPv4. The session/http client uses
+	// the system resolver, so DNS names from the .arpa zone work.
+	hostport := ins.Host + ":" + strconv.Itoa(int(ins.Port))
+	if ins.Host == "" && len(ins.IPv4) > 0 {
+		hostport = ins.IPv4[0].String() + ":" + strconv.Itoa(int(ins.Port))
+	}
+	url := opts.APIProto + "://" + hostport + "/x-nmos/system/" + opts.APIVer + "/global"
+
+	// Apply a deadline if the caller didn't already set one.
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+	}
+
+	var raw is09.Global
+	if err := client.GetJSON(ctx, url, &raw); err != nil {
+		return nil, fmt.Errorf("nmos/system: GET %s: %w", url, err)
+	}
+	if err := raw.Validate(); err != nil {
+		return nil, fmt.Errorf("nmos/system: peer /global failed validation: %w", err)
+	}
+	return &FetchResult{Selected: ins, URL: url, Global: &raw}, nil
+}
+
+// DiscoverMDNS browses _nmos-system._tcp on the local link.
+func DiscoverMDNS(ctx context.Context, timeout time.Duration, logger *slog.Logger) ([]dnssdcodec.Instance, error) {
+	br, err := dnssdsession.NewBrowser(logger)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = br.Close() }()
+
+	dctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	ch, err := br.Browse(dctx, dnssdcodec.ServiceSystem)
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]dnssdcodec.Instance{}
+	for ins := range ch {
+		seen[ins.FullName()] = ins
+	}
+	out := make([]dnssdcodec.Instance, 0, len(seen))
+	for _, v := range seen {
+		out = append(out, v)
+	}
+	return out, nil
+}
+
+// DiscoverUnicast resolves _nmos-system._tcp via authoritative DNS-SD
+// (RFC 6763 §10) against the given resolver. Domain may be "" to use
+// the codec default.
+func DiscoverUnicast(ctx context.Context, resolver, domain string, timeout time.Duration) ([]dnssdcodec.Instance, error) {
+	if domain == "" {
+		domain = dnssdcodec.DefaultDomain
+	}
+	return dnssdsession.ResolveUnicast(ctx, resolver, dnssdcodec.ServiceSystem, domain, timeout)
+}
+
+// parseDirect splits "host:port" into its components and validates the
+// port range. IPv6 literals must be wrapped in `[...]`.
+func parseDirect(s string) (string, uint16, error) {
+	host, portStr, err := net.SplitHostPort(s)
+	if err != nil {
+		return "", 0, fmt.Errorf("nmos/system: bad --direct %q: %w", s, err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil || port <= 0 || port > 65535 {
+		return "", 0, fmt.Errorf("nmos/system: bad --direct port %q", portStr)
+	}
+	return host, uint16(port), nil
+}
+
+// secureRandIndex returns a uniformly-random integer in [0, n) using
+// crypto/rand. Falls back to 0 on read failure (deterministic but
+// safe).
+func secureRandIndex(n int) int {
+	if n <= 1 {
+		return 0
+	}
+	var buf [8]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return 0
+	}
+	v := binary.BigEndian.Uint64(buf[:])
+	return int(v % uint64(n))
+}

--- a/internal/amwa/consumer/system_test.go
+++ b/internal/amwa/consumer/system_test.go
@@ -1,0 +1,272 @@
+package consumer
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	dnssdcodec "acp/internal/amwa/codec/dnssd"
+	"acp/internal/amwa/codec/is09"
+	httpsession "acp/internal/amwa/session/http"
+)
+
+func TestSelectInstanceFiltersByProto(t *testing.T) {
+	insts := []dnssdcodec.Instance{
+		{Name: "https-only", Service: dnssdcodec.ServiceSystem,
+			TXT: map[string]string{
+				dnssdcodec.TXTKeyAPIProto: "https",
+				dnssdcodec.TXTKeyAPIVer:   "v1.0",
+				dnssdcodec.TXTKeyPriority: "0",
+			}},
+		{Name: "http-ok", Service: dnssdcodec.ServiceSystem,
+			TXT: map[string]string{
+				dnssdcodec.TXTKeyAPIProto: "http",
+				dnssdcodec.TXTKeyAPIVer:   "v1.0",
+				dnssdcodec.TXTKeyPriority: "5",
+			}},
+	}
+	got, err := SelectInstance(insts, "http", "v1.0", nil)
+	if err != nil {
+		t.Fatalf("SelectInstance: %v", err)
+	}
+	if got.Name != "http-ok" {
+		t.Fatalf("selected %q, want http-ok", got.Name)
+	}
+}
+
+func TestSelectInstanceFiltersByVersion(t *testing.T) {
+	insts := []dnssdcodec.Instance{
+		{Name: "old-only", Service: dnssdcodec.ServiceSystem,
+			TXT: map[string]string{
+				dnssdcodec.TXTKeyAPIProto: "http",
+				dnssdcodec.TXTKeyAPIVer:   "v0.9",
+				dnssdcodec.TXTKeyPriority: "0",
+			}},
+		{Name: "modern", Service: dnssdcodec.ServiceSystem,
+			TXT: map[string]string{
+				dnssdcodec.TXTKeyAPIProto: "http",
+				dnssdcodec.TXTKeyAPIVer:   "v1.0,v1.1",
+				dnssdcodec.TXTKeyPriority: "0",
+			}},
+	}
+	got, err := SelectInstance(insts, "http", "v1.0", nil)
+	if err != nil {
+		t.Fatalf("SelectInstance: %v", err)
+	}
+	if got.Name != "modern" {
+		t.Fatalf("selected %q, want modern", got.Name)
+	}
+}
+
+func TestSelectInstancePicksLowestPri(t *testing.T) {
+	insts := []dnssdcodec.Instance{
+		{Name: "dev", Service: dnssdcodec.ServiceSystem,
+			TXT: map[string]string{
+				dnssdcodec.TXTKeyAPIProto: "http",
+				dnssdcodec.TXTKeyAPIVer:   "v1.0",
+				dnssdcodec.TXTKeyPriority: "100",
+			}},
+		{Name: "prod", Service: dnssdcodec.ServiceSystem,
+			TXT: map[string]string{
+				dnssdcodec.TXTKeyAPIProto: "http",
+				dnssdcodec.TXTKeyAPIVer:   "v1.0",
+				dnssdcodec.TXTKeyPriority: "0",
+			}},
+		{Name: "mid", Service: dnssdcodec.ServiceSystem,
+			TXT: map[string]string{
+				dnssdcodec.TXTKeyAPIProto: "http",
+				dnssdcodec.TXTKeyAPIVer:   "v1.0",
+				dnssdcodec.TXTKeyPriority: "50",
+			}},
+	}
+	got, err := SelectInstance(insts, "http", "v1.0", nil)
+	if err != nil {
+		t.Fatalf("SelectInstance: %v", err)
+	}
+	if got.Name != "prod" {
+		t.Fatalf("selected %q, want prod (pri 0)", got.Name)
+	}
+}
+
+func TestSelectInstanceTieBreakStaysWithinTied(t *testing.T) {
+	insts := []dnssdcodec.Instance{
+		{Name: "a", Service: dnssdcodec.ServiceSystem,
+			TXT: map[string]string{
+				dnssdcodec.TXTKeyAPIProto: "http",
+				dnssdcodec.TXTKeyAPIVer:   "v1.0",
+				dnssdcodec.TXTKeyPriority: "0",
+			}},
+		{Name: "b", Service: dnssdcodec.ServiceSystem,
+			TXT: map[string]string{
+				dnssdcodec.TXTKeyAPIProto: "http",
+				dnssdcodec.TXTKeyAPIVer:   "v1.0",
+				dnssdcodec.TXTKeyPriority: "0",
+			}},
+		{Name: "c", Service: dnssdcodec.ServiceSystem,
+			TXT: map[string]string{
+				dnssdcodec.TXTKeyAPIProto: "http",
+				dnssdcodec.TXTKeyAPIVer:   "v1.0",
+				dnssdcodec.TXTKeyPriority: "5",
+			}},
+	}
+	picked := map[string]int{}
+	for i := 0; i < 200; i++ {
+		got, err := SelectInstance(insts, "http", "v1.0", nil)
+		if err != nil {
+			t.Fatalf("SelectInstance: %v", err)
+		}
+		if got.Name == "c" {
+			t.Fatal("tie-break must never reach pri=5 entry")
+		}
+		picked[got.Name]++
+	}
+	// 200 trials, two equally-likely outcomes — both must appear.
+	if picked["a"] == 0 || picked["b"] == 0 {
+		t.Fatalf("tie-break covers both winners across 200 trials: %v", picked)
+	}
+}
+
+func TestSelectInstanceMissingPriDeprioritised(t *testing.T) {
+	insts := []dnssdcodec.Instance{
+		{Name: "no-pri", Service: dnssdcodec.ServiceSystem,
+			TXT: map[string]string{
+				dnssdcodec.TXTKeyAPIProto: "http",
+				dnssdcodec.TXTKeyAPIVer:   "v1.0",
+			}},
+		{Name: "with-pri", Service: dnssdcodec.ServiceSystem,
+			TXT: map[string]string{
+				dnssdcodec.TXTKeyAPIProto: "http",
+				dnssdcodec.TXTKeyAPIVer:   "v1.0",
+				dnssdcodec.TXTKeyPriority: "10",
+			}},
+	}
+	got, err := SelectInstance(insts, "http", "v1.0", nil)
+	if err != nil {
+		t.Fatalf("SelectInstance: %v", err)
+	}
+	if got.Name != "with-pri" {
+		t.Fatalf("missing pri should fall to the back, got %q", got.Name)
+	}
+}
+
+func TestSelectInstanceNoneMatch(t *testing.T) {
+	insts := []dnssdcodec.Instance{
+		{Name: "wrong-proto", Service: dnssdcodec.ServiceSystem,
+			TXT: map[string]string{
+				dnssdcodec.TXTKeyAPIProto: "https",
+				dnssdcodec.TXTKeyAPIVer:   "v1.0",
+			}},
+	}
+	if _, err := SelectInstance(insts, "http", "v1.0", nil); err != ErrNoInstances {
+		t.Fatalf("expected ErrNoInstances, got %v", err)
+	}
+}
+
+func TestVersionListContains(t *testing.T) {
+	cases := map[string]bool{
+		"v1.0":         true,
+		"v1.0,v1.1":    true,
+		" v1.0 ,v1.1":  true,
+		"v0.9,v1.1":    false,
+		"":             false,
+		"v1.0.0":       false,
+		"V1.0":         false, // case-sensitive on the leading V
+	}
+	for csv, want := range cases {
+		if got := versionListContains(csv, "v1.0"); got != want {
+			t.Fatalf("versionListContains(%q) = %v, want %v", csv, got, want)
+		}
+	}
+}
+
+func TestFetchAgainstFakeServer(t *testing.T) {
+	// Build a spec-valid Global, serve it on a httptest server, fetch it.
+	globalRaw := []byte(`{
+  "id": "3b8be755-08ff-452b-b217-c9151eb21193",
+  "version": "1441700172:318426300",
+  "label": "ZBQ System",
+  "description": "System Global Information for ZBQ",
+  "tags": {},
+  "is04": {
+    "heartbeat_interval": 8
+  },
+  "ptp": {
+    "announce_receipt_timeout": 2,
+    "domain_number": 57
+  }
+}`)
+	srv := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		switch r.URL.Path {
+		case "/x-nmos/system/v1.0/":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(is09.IndexBody())
+		case "/x-nmos/system/v1.0/global":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.Copy(w, strings.NewReader(string(globalRaw)))
+		default:
+			w.WriteHeader(stdhttp.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	host, port := splitHostPortForTest(srv.URL)
+	res, err := Fetch(context.Background(), IS09FetchOptions{
+		APIVer:     "v1.0",
+		APIProto:   "http",
+		Direct:     host + ":" + strconv.Itoa(port),
+		HTTPClient: httpsession.NewClient(),
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if res.Global.IS04.HeartbeatInterval != 8 {
+		t.Fatalf("heartbeat = %d", res.Global.IS04.HeartbeatInterval)
+	}
+	if res.Global.PTP.DomainNumber != 57 {
+		t.Fatalf("ptp.domain_number = %d", res.Global.PTP.DomainNumber)
+	}
+}
+
+func TestFetchRejectsOutOfSpecPeer(t *testing.T) {
+	// Out-of-range heartbeat (1001 > max 1000).
+	bad := `{
+  "id": "3b8be755-08ff-452b-b217-c9151eb21193",
+  "version": "0:0",
+  "label": "X",
+  "description": "Y",
+  "tags": {},
+  "is04": {"heartbeat_interval": 1001},
+  "ptp": {"announce_receipt_timeout": 2, "domain_number": 0}
+}`
+	srv := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, bad)
+	}))
+	defer srv.Close()
+	host, port := splitHostPortForTest(srv.URL)
+	_, err := Fetch(context.Background(), IS09FetchOptions{
+		APIVer:   "v1.0",
+		APIProto: "http",
+		Direct:   host + ":" + strconv.Itoa(port),
+	})
+	if err == nil {
+		t.Fatal("expected validation rejection")
+	}
+}
+
+// splitHostPortForTest turns httptest.NewServer().URL ("http://127.0.0.1:NNNN")
+// into ("127.0.0.1", NNNN) for the IS09FetchOptions.Direct flag.
+func splitHostPortForTest(url string) (string, int) {
+	u := strings.TrimPrefix(url, "http://")
+	i := strings.LastIndex(u, ":")
+	if i < 0 {
+		return u, 0
+	}
+	port, _ := strconv.Atoi(u[i+1:])
+	return u[:i], port
+}

--- a/internal/amwa/docs/dns-sd-unbound.md
+++ b/internal/amwa/docs/dns-sd-unbound.md
@@ -74,6 +74,15 @@ server:local-data: "dhs._nmos-query._tcp.by-systems.arpa. 60 IN SRV 0 0 8235 by-
 server:local-data: 'dhs._nmos-query._tcp.by-systems.arpa. 60 IN TXT "api_proto=http" "api_ver=v1.3" "api_auth=false" "pri=0"'
 server:local-data: "by-desk-03.by-systems.arpa. 60 IN A 10.6.239.113"
 
+# --- dhs IS-09 System API on by-desk-03 (10.6.239.113:10641) -----------------
+# `dhs producer nmos serve --role system --config global.json` running on the
+# workstation. IS-09 v1.0 has its own DNS-SD service type (`_nmos-system._tcp`)
+# and predates IS-10, so the TXT record advertises only api_proto / api_ver /
+# pri — `api_auth` is intentionally absent per the v1.0 spec.
+server:local-data: "_nmos-system._tcp.by-systems.arpa.    60 IN PTR dhs._nmos-system._tcp.by-systems.arpa."
+server:local-data: "dhs._nmos-system._tcp.by-systems.arpa. 60 IN SRV 0 0 10641 by-desk-03.by-systems.arpa."
+server:local-data: 'dhs._nmos-system._tcp.by-systems.arpa. 60 IN TXT "api_proto=http" "api_ver=v1.0" "pri=0"'
+
 # --- EVS Cerebrum hosted Registry (10.100.0.5:8080) --------------------------
 # Cerebrum's "Network Media Server" device with Hosted Registry mode enabled;
 # Cerebrum runs both Registration + Query faces on the same HTTP listener.
@@ -174,8 +183,9 @@ Pattern per peer:
 4. Add **one** TXT per face with the four IS-04 keys.
 5. Add **one** A record for the target hostname.
 
-For an IS-09 System server, use `_nmos-system._tcp` instead. For Node
-P2P (Mode D), use `_nmos-node._tcp`.
+For an IS-09 System server, use `_nmos-system._tcp` instead — and
+**omit `api_auth`** from its TXT record (IS-09 v1.0 predates IS-10).
+For Node P2P (Mode D), use `_nmos-node._tcp`.
 
 Compliance events fired by `dhs consumer nmos discover` when a peer's
 records deviate (priority collisions, missing keys, malformed `pri`)

--- a/internal/amwa/docs/sequenced-tasks.md
+++ b/internal/amwa/docs/sequenced-tasks.md
@@ -110,20 +110,46 @@ Estimated PR size: ~800 LOC + tests.
 
 ### #2 — IS-09 System API (server + client)
 
+> **Status: in flight — branch `feat/nmos-is09-system`.** Mode A self-loop
+> live-verified 2026-04-30: `dhs producer nmos serve --role system` boots
+> the IS-09 endpoints, announces `_nmos-system._tcp` via mDNS; `dhs
+> consumer nmos system --mdns` selects the instance per the spec rule and
+> fetches a validated /global. `--direct host:port` bypasses discovery
+> for unicast / Mode B targets. AMWA NMOS Testing IS-09-02 conformance
+> run pending in CI integration phase.
+
 Smallest NMOS spec. Lets us validate the "REST + DNS-SD" plumbing
 before tackling IS-04.
 
 - Codec: `internal/amwa/codec/is09/` — JSON Schema for `global`
-  resource.
-- Provider: `dhs producer nmos serve --role system --config FILE`.
-- Consumer: `dhs consumer nmos system <hint>` — fetch + dump.
-- Tests: round-trip JSON, DNS-SD advertise + browse, fallback to
-  config file when no `_nmos-system._tcp`.
+  resource (stdlib-only; spec-strict per
+  `https://specs.amwa.tv/is-09/releases/v1.0.0/`).
+- Session: neutral `internal/amwa/session/http/` — typed JSON GET +
+  exact-match route table; reused by IS-04 / IS-05 / IS-08 in later
+  phases.
+- Provider: `dhs producer nmos serve --role system --config FILE` —
+  loads + validates the config, serves the two endpoints, advertises
+  `_nmos-system._tcp` (mDNS or static via Unbound — see
+  [`dns-sd-unbound.md`](dns-sd-unbound.md)).
+- Consumer: `dhs consumer nmos system [--mdns | --unicast --resolver
+  IP | --peer-list F | --direct H:P]` — selection rule (filter by
+  api_proto + api_ver, sort by pri, randomised tie-break), GET
+  /global, validate, dump.
+- Tests: codec round-trip per AMWA spec example; out-of-range
+  rejection per integer field; missing-required rejection; unknown-key
+  rejection; HTTP server route table + 404 / 405; consumer selection
+  rule (proto filter, version filter, lowest pri, tie-break).
 - **Conformance gate: AMWA NMOS Testing IS-09-02 suite must Pass.**
   Pinned by image digest; report archived under
   `tests/integration/nmos/02-is09/results/`.
 
-Estimated PR size: ~400 LOC.
+Spec-strict deviations to watch: IS-09 v1.0 predates IS-10, so
+`api_auth` MUST NOT appear in the `_nmos-system._tcp` TXT. dhs encoder
+omits it; decoder fires `nmos_unexpected_txt_key` when a peer emits
+it.
+
+Estimated PR size: ~1500 LOC including the new neutral HTTP session
+package (used by Phase 1 #3-#4 too).
 
 ### #3 — IS-04 Node API (provider side)
 

--- a/internal/amwa/provider/system.go
+++ b/internal/amwa/provider/system.go
@@ -1,0 +1,248 @@
+// Layer-3 IS-09 System API provider — loads + serves a /global resource
+// and announces _nmos-system._tcp via DNS-SD.
+//
+// Spec: AMWA NMOS IS-09 v1.0.0 (https://specs.amwa.tv/is-09/releases/v1.0.0/).
+// Stays strictly to the published surface — two endpoints, no extras:
+//
+//   GET /x-nmos/system/v1.0/         -> ["global/"]
+//   GET /x-nmos/system/v1.0/global   -> the Global resource
+
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	stdhttp "net/http"
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+
+	dnssdcodec "acp/internal/amwa/codec/dnssd"
+	"acp/internal/amwa/codec/is09"
+	dnssdsession "acp/internal/amwa/session/dnssd"
+	httpsession "acp/internal/amwa/session/http"
+)
+
+// IS09Config wires the System provider together. APIVer overrides the
+// default `v1.0`; rarely needed today.
+type IS09Config struct {
+	// Bind address for the HTTP listener, e.g. ":10641".
+	Bind string
+
+	// AdvertiseHost+port placed in DNS-SD A/SRV records. When empty
+	// the provider falls back to os.Hostname.
+	AdvertiseHost string
+
+	// DiscoveryMode: "mdns" announces via mDNS (default); "static"
+	// skips announce — for unicast-only / peer-list deployments where
+	// pfSense Unbound (or another authoritative resolver) already
+	// publishes the records (see internal/amwa/docs/dns-sd-unbound.md).
+	DiscoveryMode string
+
+	// Priority in the DNS-SD `pri` TXT (0-99 production, 100+ dev).
+	Priority int
+
+	// APIVer is the IS-09 wire version to advertise. Defaults to v1.0.
+	APIVer string
+}
+
+// IS09Server hosts the IS-09 endpoints + DNS-SD announce.
+type IS09Server struct {
+	logger *slog.Logger
+	cfg    IS09Config
+	global *is09.Global
+
+	mu        sync.Mutex
+	http      *httpsession.Server
+	responder *dnssdsession.Responder
+	cancel    context.CancelFunc
+
+	// Counters (atomic).
+	indexHits  uint64
+	globalHits uint64
+}
+
+// NewIS09Server validates `g` against the IS-09 schema, then prepares
+// (but does not start) a server bound to the given config.
+func NewIS09Server(logger *slog.Logger, g *is09.Global, cfg IS09Config) (*IS09Server, error) {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	}
+	if g == nil {
+		return nil, errors.New("provider/system: nil Global")
+	}
+	if err := g.Validate(); err != nil {
+		return nil, fmt.Errorf("provider/system: %w", err)
+	}
+	if cfg.Bind == "" {
+		return nil, errors.New("provider/system: Bind required")
+	}
+	if cfg.APIVer == "" {
+		cfg.APIVer = is09.APIVersion
+	}
+	return &IS09Server{logger: logger, cfg: cfg, global: g}, nil
+}
+
+// LoadIS09GlobalFromFile reads + validates a JSON config file.
+func LoadIS09GlobalFromFile(path string) (*is09.Global, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("provider/system: read %s: %w", path, err)
+	}
+	g, err := is09.Decode(raw)
+	if err != nil {
+		return nil, fmt.Errorf("provider/system: %s: %w", path, err)
+	}
+	return g, nil
+}
+
+// Serve binds the HTTP listener, announces via DNS-SD if configured,
+// and blocks until ctx is cancelled.
+func (s *IS09Server) Serve(ctx context.Context) error {
+	s.mu.Lock()
+	if s.http != nil {
+		s.mu.Unlock()
+		return errors.New("provider/system: already serving")
+	}
+
+	srv := httpsession.NewServer(s.logger)
+	indexPath := "/x-nmos/system/" + s.cfg.APIVer + "/"
+	globalPath := "/x-nmos/system/" + s.cfg.APIVer + "/global"
+
+	srv.Handle(stdhttp.MethodGet, indexPath, func(ctx context.Context, r *stdhttp.Request) (int, any, error) {
+		atomic.AddUint64(&s.indexHits, 1)
+		return 0, is09.IndexBody(), nil
+	})
+	srv.Handle(stdhttp.MethodGet, globalPath, func(ctx context.Context, r *stdhttp.Request) (int, any, error) {
+		atomic.AddUint64(&s.globalHits, 1)
+		// Re-marshal each call so a future mutating API can swap g
+		// safely under a reader lock.
+		s.mu.Lock()
+		body := *s.global
+		s.mu.Unlock()
+		return 0, &body, nil
+	})
+
+	s.http = srv
+
+	// Optional DNS-SD announce. Skipped in "static" mode — caller
+	// publishes records via Unbound or similar.
+	if s.cfg.DiscoveryMode == "" || s.cfg.DiscoveryMode == "mdns" {
+		host, port := splitHostPort(s.cfg.AdvertiseHost, s.cfg.Bind)
+		resp, err := dnssdsession.NewResponder(s.logger)
+		if err != nil {
+			s.mu.Unlock()
+			return fmt.Errorf("provider/system: open mDNS responder: %w", err)
+		}
+		ctxAnnounce, cancel := context.WithCancel(ctx)
+		s.responder = resp
+		s.cancel = cancel
+		ins := dnssdcodec.Instance{
+			Name:    "dhs-nmos-system",
+			Service: dnssdcodec.ServiceSystem,
+			Domain:  dnssdcodec.DefaultDomain,
+			Host:    host,
+			Port:    uint16(port),
+			TXT: map[string]string{
+				dnssdcodec.TXTKeyAPIProto: "http",
+				dnssdcodec.TXTKeyAPIVer:   s.cfg.APIVer,
+				dnssdcodec.TXTKeyPriority: strconv.Itoa(s.cfg.Priority),
+				// IS-09 v1.0 §3.1 does NOT define api_auth (predates
+				// IS-10) — emit only what the spec lists.
+			},
+		}
+		if err := resp.Announce(ctxAnnounce, ins); err != nil {
+			s.mu.Unlock()
+			_ = resp.Close()
+			return fmt.Errorf("provider/system: announce %s: %w", dnssdcodec.ServiceSystem, err)
+		}
+		s.logger.Info("provider/system: mDNS announce active",
+			"service", dnssdcodec.ServiceSystem, "host", host, "port", port, "api_ver", s.cfg.APIVer, "pri", s.cfg.Priority)
+	} else {
+		s.logger.Info("provider/system: DNS-SD announce disabled by config",
+			"mode", s.cfg.DiscoveryMode)
+	}
+
+	s.mu.Unlock()
+	return srv.Serve(ctx, s.cfg.Bind)
+}
+
+// Stop tears down both surfaces. Idempotent.
+func (s *IS09Server) Stop() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.cancel != nil {
+		s.cancel()
+		s.cancel = nil
+	}
+	if s.responder != nil {
+		_ = s.responder.Close()
+		s.responder = nil
+	}
+	return nil
+}
+
+// Stats exposes per-endpoint hit counters for observability.
+func (s *IS09Server) Stats() (indexHits, globalHits uint64) {
+	return atomic.LoadUint64(&s.indexHits), atomic.LoadUint64(&s.globalHits)
+}
+
+// MarshalGlobal renders the current Global as compact JSON. Used by
+// debugging tools and tests.
+func (s *IS09Server) MarshalGlobal() ([]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return json.Marshal(s.global)
+}
+
+// splitHostPort returns the host advertised in DNS-SD records + the
+// numeric port to put in the SRV record. AdvertiseHost wins over Bind
+// for the host string; the port comes from whichever is set.
+func splitHostPort(advertise, bind string) (string, int) {
+	if advertise != "" {
+		host, port := splitHP(advertise)
+		if host != "" && port > 0 {
+			return host, port
+		}
+		// AdvertiseHost without port — fall through to bind for port.
+		if host != "" {
+			_, bindPort := splitHP(bind)
+			return host, bindPort
+		}
+	}
+	host, port := splitHP(bind)
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		if h, err := os.Hostname(); err == nil && h != "" {
+			host = h
+		} else {
+			host = "localhost"
+		}
+	}
+	return host, port
+}
+
+// splitHP is the lenient host:port splitter — bare host returns port 0,
+// bare ":port" returns "" host.
+func splitHP(s string) (string, int) {
+	host := ""
+	portStr := ""
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == ':' {
+			host = s[:i]
+			portStr = s[i+1:]
+			break
+		}
+	}
+	if portStr == "" {
+		return s, 0
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return host, 0
+	}
+	return host, port
+}

--- a/internal/amwa/provider/system_test.go
+++ b/internal/amwa/provider/system_test.go
@@ -1,0 +1,196 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"acp/internal/amwa/codec/is09"
+)
+
+func validGlobal() *is09.Global {
+	return &is09.Global{
+		ID:          "3b8be755-08ff-452b-b217-c9151eb21193",
+		Version:     "1441700172:318426300",
+		Label:       "ZBQ System",
+		Description: "System Global Information for ZBQ",
+		Tags:        map[string][]string{},
+		IS04:        is09.IS04Config{HeartbeatInterval: 8},
+		PTP:         is09.PTPConfig{AnnounceReceiptTimeout: 2, DomainNumber: 57},
+	}
+}
+
+func TestNewIS09ServerRejectsInvalidGlobal(t *testing.T) {
+	bad := *validGlobal()
+	bad.IS04.HeartbeatInterval = 0 // out of [1..1000]
+	_, err := NewIS09Server(nil, &bad, IS09Config{Bind: ":1"})
+	if err == nil || !strings.Contains(err.Error(), "heartbeat_interval") {
+		t.Fatalf("expected heartbeat range error, got %v", err)
+	}
+}
+
+func TestNewIS09ServerRequiresBind(t *testing.T) {
+	_, err := NewIS09Server(nil, validGlobal(), IS09Config{})
+	if err == nil || !strings.Contains(err.Error(), "Bind") {
+		t.Fatalf("expected Bind error, got %v", err)
+	}
+}
+
+func TestLoadIS09GlobalFromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "global.json")
+	body := `{
+  "id": "3b8be755-08ff-452b-b217-c9151eb21193",
+  "version": "1441700172:318426300",
+  "label": "Test",
+  "description": "Y",
+  "tags": {},
+  "is04": {"heartbeat_interval": 5},
+  "ptp": {"announce_receipt_timeout": 3, "domain_number": 127}
+}`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	g, err := LoadIS09GlobalFromFile(path)
+	if err != nil {
+		t.Fatalf("LoadIS09GlobalFromFile: %v", err)
+	}
+	if g.IS04.HeartbeatInterval != 5 {
+		t.Fatalf("heartbeat = %d", g.IS04.HeartbeatInterval)
+	}
+}
+
+func TestLoadIS09GlobalFromFileRejectsBadJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "global.json")
+	if err := os.WriteFile(path, []byte(`{"id":"not-uuid"}`), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := LoadIS09GlobalFromFile(path); err == nil {
+		t.Fatal("expected error on invalid global")
+	}
+}
+
+// TestServeEndToEnd boots the IS-09 server in static mode (no mDNS) on
+// an ephemeral port, then probes both endpoints over HTTP.
+func TestServeEndToEnd(t *testing.T) {
+	addr := freeAddr(t)
+	s, err := NewIS09Server(nil, validGlobal(), IS09Config{
+		Bind:          addr,
+		DiscoveryMode: "static",
+	})
+	if err != nil {
+		t.Fatalf("NewIS09Server: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_ = s.Serve(ctx)
+	}()
+	defer func() {
+		cancel()
+		_ = s.Stop()
+		wg.Wait()
+	}()
+
+	// Wait until the server is actually listening — probe a path the
+	// router 404s on so the index counter stays at zero.
+	if !waitReachable(t, "http://"+addr+"/__ready__", 2*time.Second) {
+		t.Fatal("server never came up")
+	}
+
+	// GET / index
+	resp, err := stdhttp.Get("http://" + addr + "/x-nmos/system/v1.0/")
+	if err != nil {
+		t.Fatalf("GET index: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != 200 {
+		t.Fatalf("index status %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	var idx []string
+	_ = json.Unmarshal(body, &idx)
+	if len(idx) != 1 || idx[0] != "global/" {
+		t.Fatalf("index body = %v", idx)
+	}
+
+	// GET /global
+	resp2, err := stdhttp.Get("http://" + addr + "/x-nmos/system/v1.0/global")
+	if err != nil {
+		t.Fatalf("GET global: %v", err)
+	}
+	defer func() { _ = resp2.Body.Close() }()
+	if resp2.StatusCode != 200 {
+		t.Fatalf("global status %d", resp2.StatusCode)
+	}
+	body2, _ := io.ReadAll(resp2.Body)
+	g, err := is09.Decode(body2)
+	if err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if g.IS04.HeartbeatInterval != 8 {
+		t.Fatalf("heartbeat = %d", g.IS04.HeartbeatInterval)
+	}
+
+	idxHits, globalHits := s.Stats()
+	if idxHits != 1 || globalHits != 1 {
+		t.Fatalf("stats = %d / %d", idxHits, globalHits)
+	}
+}
+
+func TestServeRejectsUnknownPath(t *testing.T) {
+	addr := freeAddr(t)
+	s, err := NewIS09Server(nil, validGlobal(), IS09Config{Bind: addr, DiscoveryMode: "static"})
+	if err != nil {
+		t.Fatalf("NewIS09Server: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = s.Serve(ctx) }()
+	defer func() { _ = s.Stop() }()
+	if !waitReachable(t, "http://"+addr+"/__ready__", 2*time.Second) {
+		t.Fatal("server never came up")
+	}
+	resp, err := stdhttp.Get("http://" + addr + "/wrong")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != 404 {
+		t.Fatalf("status %d", resp.StatusCode)
+	}
+}
+
+// freeAddr returns an unused port via httptest.NewServer/Close trick.
+func freeAddr(t *testing.T) string {
+	t.Helper()
+	ln := httptest.NewServer(stdhttp.NewServeMux())
+	ln.Close()
+	return strings.TrimPrefix(ln.URL, "http://")
+}
+
+func waitReachable(t *testing.T, url string, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := stdhttp.Get(url)
+		if err == nil {
+			_ = resp.Body.Close()
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}

--- a/internal/amwa/session/http/client.go
+++ b/internal/amwa/session/http/client.go
@@ -1,0 +1,100 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	stdhttp "net/http"
+	"strings"
+	"time"
+)
+
+// DefaultMaxBody caps a single response body. NMOS payloads are
+// generally small; the IS-04 Query API can return larger node
+// catalogues but those land later. 1 MiB is comfortable for IS-09.
+const DefaultMaxBody = 1 << 20
+
+// DefaultTimeout caps a single HTTP exchange.
+const DefaultTimeout = 5 * time.Second
+
+// Client is a thin typed-GET wrapper around net/http.Client.
+type Client struct {
+	HTTP    *stdhttp.Client
+	MaxBody int64
+}
+
+// NewClient returns a Client with sensible defaults (per-call timeout
+// applied via context, body cap = DefaultMaxBody). Callers can mutate
+// the returned struct before first use.
+func NewClient() *Client {
+	return &Client{
+		HTTP: &stdhttp.Client{
+			Timeout: DefaultTimeout,
+		},
+		MaxBody: DefaultMaxBody,
+	}
+}
+
+// GetJSON issues a GET against url, validates Content-Type is
+// application/json, reads up to MaxBody bytes, then decodes into dst
+// (a non-nil pointer). dst is decoded with DisallowUnknownFields so
+// peers that emit non-spec keys are flagged rather than absorbed.
+func (c *Client) GetJSON(ctx context.Context, url string, dst any) error {
+	if dst == nil {
+		return fmt.Errorf("nmos/http: GetJSON: dst must not be nil")
+	}
+	req, err := stdhttp.NewRequestWithContext(ctx, stdhttp.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("nmos/http: build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return fmt.Errorf("nmos/http: GET %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != stdhttp.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, c.MaxBody))
+		return fmt.Errorf("nmos/http: GET %s: HTTP %d: %s",
+			url, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	ct := resp.Header.Get("Content-Type")
+	if !isJSONContentType(ct) {
+		return fmt.Errorf("nmos/http: GET %s: unexpected Content-Type %q (want application/json)", url, ct)
+	}
+
+	max := c.MaxBody
+	if max <= 0 {
+		max = DefaultMaxBody
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, max+1))
+	if err != nil {
+		return fmt.Errorf("nmos/http: read body: %w", err)
+	}
+	if int64(len(body)) > max {
+		return fmt.Errorf("nmos/http: response body exceeds %d bytes", max)
+	}
+
+	d := json.NewDecoder(strings.NewReader(string(body)))
+	d.DisallowUnknownFields()
+	if err := d.Decode(dst); err != nil {
+		return fmt.Errorf("nmos/http: decode body: %w", err)
+	}
+	if d.More() {
+		return fmt.Errorf("nmos/http: trailing JSON content in body")
+	}
+	return nil
+}
+
+// isJSONContentType matches `application/json` and the `; charset=...`
+// suffix variant. Case-insensitive per RFC 7231 §3.1.1.5.
+func isJSONContentType(ct string) bool {
+	ct = strings.ToLower(strings.TrimSpace(ct))
+	if ct == "application/json" {
+		return true
+	}
+	return strings.HasPrefix(ct, "application/json;")
+}

--- a/internal/amwa/session/http/doc.go
+++ b/internal/amwa/session/http/doc.go
@@ -1,0 +1,19 @@
+// Package http is the Layer-2 NMOS HTTP session wrapper. Used by IS-09
+// today and by IS-04 / IS-05 / IS-08 in later phases. Stdlib-only,
+// plugin-agnostic — must NOT import internal/amwa/{consumer,provider,registry}
+// or any other dhs plugin (enforced via the `nmos-session-no-plugin-imports`
+// depguard rule).
+//
+// Two surfaces:
+//
+//   - Client: typed JSON GET against a `http://host:port/x-nmos/...`
+//     path; enforces JSON content-type, applies a per-call deadline,
+//     reads the whole body up to a configurable cap, decodes via the
+//     caller-supplied dst (any *T).
+//
+//   - Server: a Mux with structured per-route handlers. Caller hands
+//     each route a function returning `(any, error)` plus an optional
+//     status code; the Mux serialises to JSON, sets Content-Type,
+//     handles 404 / 405 / 500 with the body shape spec'd by IS-04 §4.4
+//     (`{"code":N,"error":...,"debug":...}`).
+package http

--- a/internal/amwa/session/http/http_test.go
+++ b/internal/amwa/session/http/http_test.go
@@ -1,0 +1,263 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestClientGetJSONHappyPath(t *testing.T) {
+	srv := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"hello":"world"}`)
+	}))
+	defer srv.Close()
+
+	c := NewClient()
+	var got map[string]string
+	if err := c.GetJSON(context.Background(), srv.URL, &got); err != nil {
+		t.Fatalf("GetJSON: %v", err)
+	}
+	if got["hello"] != "world" {
+		t.Fatalf("body decoded as %v", got)
+	}
+}
+
+func TestClientGetJSONRejectsNonJSONContentType(t *testing.T) {
+	srv := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = io.WriteString(w, `{"hello":"world"}`)
+	}))
+	defer srv.Close()
+	c := NewClient()
+	var got map[string]string
+	err := c.GetJSON(context.Background(), srv.URL, &got)
+	if err == nil || !strings.Contains(err.Error(), "Content-Type") {
+		t.Fatalf("expected Content-Type rejection, got %v", err)
+	}
+}
+
+func TestClientGetJSONAcceptsCharsetSuffix(t *testing.T) {
+	srv := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_, _ = io.WriteString(w, `{"hello":"world"}`)
+	}))
+	defer srv.Close()
+	c := NewClient()
+	var got map[string]string
+	if err := c.GetJSON(context.Background(), srv.URL, &got); err != nil {
+		t.Fatalf("charset suffix should be accepted: %v", err)
+	}
+}
+
+func TestClientGetJSONHonoursMaxBody(t *testing.T) {
+	big := strings.Repeat("x", 1024)
+	srv := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"x":"`+big+`"}`)
+	}))
+	defer srv.Close()
+	c := NewClient()
+	c.MaxBody = 64
+	var got map[string]string
+	err := c.GetJSON(context.Background(), srv.URL, &got)
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("expected body-cap rejection, got %v", err)
+	}
+}
+
+func TestClientGetJSONNon200(t *testing.T) {
+	srv := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		w.WriteHeader(stdhttp.StatusNotFound)
+		_, _ = io.WriteString(w, `Not Found`)
+	}))
+	defer srv.Close()
+	c := NewClient()
+	var got map[string]string
+	err := c.GetJSON(context.Background(), srv.URL, &got)
+	if err == nil || !strings.Contains(err.Error(), "404") {
+		t.Fatalf("expected status-bearing error, got %v", err)
+	}
+}
+
+func TestServerHappyPath(t *testing.T) {
+	srv := NewServer(nil)
+	srv.Handle(stdhttp.MethodGet, "/x-nmos/system/v1.0/", func(ctx context.Context, r *stdhttp.Request) (int, any, error) {
+		return 0, []string{"global/"}, nil
+	})
+
+	addr, stop := startServer(t, srv)
+	defer stop()
+
+	resp, err := stdhttp.Get("http://" + addr + "/x-nmos/system/v1.0/")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != stdhttp.StatusOK {
+		t.Fatalf("status %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("Content-Type = %q", ct)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	var idx []string
+	if err := json.Unmarshal(body, &idx); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(idx) != 1 || idx[0] != "global/" {
+		t.Fatalf("body = %v", idx)
+	}
+}
+
+func TestServerNotFound(t *testing.T) {
+	srv := NewServer(nil)
+	addr, stop := startServer(t, srv)
+	defer stop()
+
+	resp, err := stdhttp.Get("http://" + addr + "/missing")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != stdhttp.StatusNotFound {
+		t.Fatalf("status %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	var eb ErrorBody
+	if err := json.Unmarshal(body, &eb); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if eb.Code != 404 || eb.Error == "" {
+		t.Fatalf("body = %+v", eb)
+	}
+}
+
+func TestServerMethodNotAllowed(t *testing.T) {
+	srv := NewServer(nil)
+	srv.Handle(stdhttp.MethodGet, "/global", func(ctx context.Context, r *stdhttp.Request) (int, any, error) {
+		return 0, struct{}{}, nil
+	})
+	addr, stop := startServer(t, srv)
+	defer stop()
+
+	req, _ := stdhttp.NewRequest(stdhttp.MethodPost, "http://"+addr+"/global", nil)
+	resp, err := stdhttp.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != stdhttp.StatusMethodNotAllowed {
+		t.Fatalf("status %d", resp.StatusCode)
+	}
+}
+
+func TestServerHandlerError(t *testing.T) {
+	srv := NewServer(nil)
+	srv.Handle(stdhttp.MethodGet, "/boom", func(ctx context.Context, r *stdhttp.Request) (int, any, error) {
+		return 0, nil, errors.New("intentional")
+	})
+	addr, stop := startServer(t, srv)
+	defer stop()
+
+	resp, err := stdhttp.Get("http://" + addr + "/boom")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != stdhttp.StatusInternalServerError {
+		t.Fatalf("status %d", resp.StatusCode)
+	}
+}
+
+func TestServerDuplicateRoutePanics(t *testing.T) {
+	srv := NewServer(nil)
+	srv.Handle(stdhttp.MethodGet, "/x", func(ctx context.Context, r *stdhttp.Request) (int, any, error) { return 0, nil, nil })
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on duplicate route")
+		}
+	}()
+	srv.Handle(stdhttp.MethodGet, "/x", func(ctx context.Context, r *stdhttp.Request) (int, any, error) { return 0, nil, nil })
+}
+
+func TestServerCannotStartTwice(t *testing.T) {
+	srv := NewServer(nil)
+	addr, stop := startServer(t, srv)
+	defer stop()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	err := srv.Serve(ctx, addr)
+	if err == nil || !strings.Contains(err.Error(), "already started") {
+		t.Fatalf("expected already-started error, got %v", err)
+	}
+}
+
+// startServer binds to an ephemeral port and returns its host:port.
+// The returned stop closes the server.
+func startServer(t *testing.T, srv *Server) (string, func()) {
+	t.Helper()
+	// Use port 0 by binding via a httptest first, then transferring.
+	ln := httptest.NewServer(stdhttp.NewServeMux())
+	ln.Close()
+	addr := strings.TrimPrefix(ln.URL, "http://")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- srv.Serve(ctx, addr) }()
+
+	// Probe until reachable, capped at 2 s.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := stdhttp.Get("http://" + addr + "/__startup_probe__")
+		if err == nil {
+			_ = resp.Body.Close()
+			break
+		}
+		select {
+		case err := <-done:
+			t.Fatalf("server exited early: %v", err)
+		default:
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	stop := func() {
+		cancel()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Logf("server stopped with: %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Log("server stop timed out")
+		}
+	}
+	return addr, stop
+}
+
+// Sanity check — ensure error-body decode shape.
+func TestErrorBodyShape(t *testing.T) {
+	eb := ErrorBody{Code: 404, Error: "Not Found", Debug: "/x"}
+	b, err := json.Marshal(eb)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(b), `"code":404`) {
+		t.Fatalf("body = %s", b)
+	}
+	// Debug is omitempty
+	eb2 := ErrorBody{Code: 500, Error: "Internal Server Error"}
+	b2, _ := json.Marshal(eb2)
+	if strings.Contains(string(b2), "debug") {
+		t.Fatalf("debug should be omitempty: %s", b2)
+	}
+	_ = fmt.Sprintf
+}

--- a/internal/amwa/session/http/server.go
+++ b/internal/amwa/session/http/server.go
@@ -1,0 +1,174 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	stdhttp "net/http"
+	"runtime/debug"
+	"sync"
+	"time"
+)
+
+// HandlerFunc is the per-route signature. Returning an error becomes
+// HTTP 500 with the spec-compatible body shape; returning a value
+// is JSON-encoded with status 200 (or status if explicitly returned).
+type HandlerFunc func(ctx context.Context, r *stdhttp.Request) (status int, body any, err error)
+
+// Server is a thin route table over net/http.Server. Routes are an
+// exact-match `(method, path) -> HandlerFunc`; no wildcards yet (IS-09
+// has zero parameterised paths).
+type Server struct {
+	Logger *slog.Logger
+
+	mu     sync.RWMutex
+	routes map[routeKey]HandlerFunc
+	mux    *stdhttp.ServeMux
+	srv    *stdhttp.Server
+}
+
+type routeKey struct {
+	method string
+	path   string
+}
+
+// ErrorBody mirrors the IS-04 §4.4 / IS-09 RAML error envelope so
+// peers see a uniform shape on 4xx / 5xx.
+type ErrorBody struct {
+	Code  int    `json:"code"`
+	Error string `json:"error"`
+	Debug string `json:"debug,omitempty"`
+}
+
+// NewServer constructs an empty Server with a default logger if nil.
+func NewServer(logger *slog.Logger) *Server {
+	return &Server{
+		Logger: logger,
+		routes: make(map[routeKey]HandlerFunc),
+	}
+}
+
+// Handle registers an exact-match (method, path) handler. Re-registering
+// the same key panics — wiring bugs should fail loudly.
+func (s *Server) Handle(method, path string, fn HandlerFunc) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	k := routeKey{method: method, path: path}
+	if _, dup := s.routes[k]; dup {
+		panic(fmt.Sprintf("nmos/http: duplicate route %s %s", method, path))
+	}
+	s.routes[k] = fn
+}
+
+// Serve binds to addr and serves until ctx is cancelled. Returns the
+// first non-graceful shutdown error.
+func (s *Server) Serve(ctx context.Context, addr string) error {
+	s.mu.Lock()
+	if s.mux != nil {
+		s.mu.Unlock()
+		return fmt.Errorf("nmos/http: server already started")
+	}
+	mux := stdhttp.NewServeMux()
+	mux.HandleFunc("/", s.dispatch)
+	s.mux = mux
+	s.srv = &stdhttp.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	srv := s.srv
+	s.mu.Unlock()
+
+	errCh := make(chan error, 1)
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, stdhttp.ErrServerClosed) {
+			errCh <- err
+			return
+		}
+		errCh <- nil
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutCtx)
+		return <-errCh
+	case err := <-errCh:
+		return err
+	}
+}
+
+// dispatch is the single net/http handler that walks the route table
+// and emits the response — or a spec-shaped 404 / 405 / 500.
+func (s *Server) dispatch(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			if s.Logger != nil {
+				s.Logger.Error("nmos/http: handler panic",
+					"method", r.Method, "path", r.URL.Path, "panic", rec,
+					"stack", string(debug.Stack()))
+			}
+			writeErrorJSON(w, stdhttp.StatusInternalServerError, "Internal Server Error", "panic recovered")
+		}
+	}()
+
+	s.mu.RLock()
+	fn, ok := s.routes[routeKey{method: r.Method, path: r.URL.Path}]
+	if !ok {
+		// Try the other commonly-paired method to choose 404 vs 405.
+		methodNotAllowed := false
+		for k := range s.routes {
+			if k.path == r.URL.Path && k.method != r.Method {
+				methodNotAllowed = true
+				break
+			}
+		}
+		s.mu.RUnlock()
+		if methodNotAllowed {
+			writeErrorJSON(w, stdhttp.StatusMethodNotAllowed, "Method Not Allowed", r.Method+" "+r.URL.Path)
+		} else {
+			writeErrorJSON(w, stdhttp.StatusNotFound, "Not Found", r.URL.Path)
+		}
+		return
+	}
+	s.mu.RUnlock()
+
+	status, body, err := fn(r.Context(), r)
+	if err != nil {
+		if s.Logger != nil {
+			s.Logger.Warn("nmos/http: handler error",
+				"method", r.Method, "path", r.URL.Path, "err", err)
+		}
+		writeErrorJSON(w, stdhttp.StatusInternalServerError, "Internal Server Error", err.Error())
+		return
+	}
+	if status == 0 {
+		status = stdhttp.StatusOK
+	}
+	writeJSON(w, status, body)
+}
+
+// writeJSON serialises body as JSON with the spec-mandated header set.
+func writeJSON(w stdhttp.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(body); err != nil {
+		// Headers already flushed; nothing to do but log via panic
+		// recovery in the caller. We don't have a slog handle here.
+		_ = err
+	}
+}
+
+// writeErrorJSON emits the IS-04 §4.4 error envelope.
+func writeErrorJSON(w stdhttp.ResponseWriter, status int, errStr, debug string) {
+	writeJSON(w, status, ErrorBody{
+		Code:  status,
+		Error: errStr,
+		Debug: debug,
+	})
+}


### PR DESCRIPTION
Closes #152. Phase 1 step #2 of the NMOS plugin epic #146, per [`internal/amwa/docs/sequenced-tasks.md`](internal/amwa/docs/sequenced-tasks.md) §1 #2.

**Spec source:** AMWA NMOS IS-09 v1.0.0 — https://specs.amwa.tv/is-09/releases/v1.0.0/. Spec-strict, no workarounds: every field, range, and TXT key matches the published JSON Schema and Discovery — Operation pages literally.

## Wire surface

The only two endpoints IS-09 v1.0 defines:

| Method | Path | Body | Status |
|---|---|---|---|
| GET | `/x-nmos/system/v1.0/` | `["global/"]` | 200 |
| GET | `/x-nmos/system/v1.0/global` | validated Global resource | 200 |

DNS-SD service type `_nmos-system._tcp` with TXT keys `api_proto`, `api_ver`, `pri`. **`api_auth` is intentionally NOT advertised** because IS-09 v1.0 predates IS-10 (per [§3.1 Discovery — Operation](https://specs.amwa.tv/is-09/releases/v1.0.0/docs/3.1._Discovery_-_Operation.html)). Encoder omits it; decoder will fire `nmos_unexpected_txt_key` when a non-compliant peer emits it.

## What lands (4-layer architecture, depguard-enforced)

| Layer | Package | Surface |
|---|---|---|
| 1 | `internal/amwa/codec/is09` | Global / IS04Config / PTPConfig / SyslogConfig types + Validate (uuid pattern, version pattern, integer ranges, hostname format), Encode / Decode / DecodeIndex with DisallowUnknownFields |
| 2 | `internal/amwa/session/http` | neutral typed-JSON client + exact-match HTTP server (route table, IS-04 §4.4 error envelope, panic recovery); reused by IS-04 / IS-05 / IS-08 in later phases |
| 3 | `internal/amwa/provider/system.go` | `IS09Server`: load + validate config, serve the two endpoints, mDNS announce |
| 3 | `internal/amwa/consumer/system.go` | `DiscoverMDNS` / `DiscoverUnicast` helpers + `SelectInstance` (proto + version filter, sort by pri, randomised tie-break per `crypto/rand`) + `Fetch` (validates the peer body before returning) |
| 4 | `cmd/dhs/cmd_nmos.go` | `dhs producer nmos serve --role system --config FILE` (system role) and `dhs consumer nmos system [--mdns / --unicast / --peer-list / --direct]` |

## Selection rule (IS-09 §3.1, byte-for-byte)

1. Filter out instances whose `api_proto` ≠ requested.
2. Filter out instances whose `api_ver` list does not include the requested version.
3. Sort by `pri` ascending.
4. Randomised tie-break among the lowest-`pri` survivors.
5. GET `/x-nmos/system/<api-ver>/global`, validate, return.

## Tests (78 total, +27 vs `main`)

- **codec/is09** — verbatim spec example round-trip; unknown-key / trailing-content rejection; required-field-missing; uuid v1-v5 pattern enforcement (rejects v6+); version `<sec>:<nsec>` pattern; every range bound (low/high) per integer field; syslog block hostname/ipv4/ipv6 formats; index `["global/"]` shape.
- **session/http** — JSON content-type enforcement (incl. charset suffix), MaxBody cap, 200-only path, route table happy + 404 + 405 + 500 + duplicate-route panic + can't-start-twice.
- **consumer** — proto filter, version filter, lowest-pri selection, tie-break randomness across 200 trials, missing-pri deprioritised, none-match → `ErrNoInstances`; live `Fetch` against a `httptest` server with both happy and out-of-spec bodies.
- **provider** — invalid-Global rejected by `NewIS09Server`; Bind required; `LoadIS09GlobalFromFile` happy + bad-JSON; full Serve end-to-end + 404 on unknown path.

## Live verification (workstation Mode A self-loop, 2026-04-30)

```
$ dhs producer nmos serve --role system --config global.json \
      --bind 127.0.0.1:10641 --priority 100
Announcing _nmos-system._tcp via mDNS.

$ dhs consumer nmos system --mdns
System API selected:
  instance = dhs-nmos-system._nmos-system._tcp.local
  url      = http://127.0.0.1:10641/x-nmos/system/v1.0/global
  pri      = 100
  api_ver  = v1.0   api_proto = http
/global:
  id = 3b8be755-…     label = "dhs lab IS-09"
  is04.heartbeat_interval = 5
  ptp.announce_receipt_timeout = 3   ptp.domain_number = 127
```

`--direct host:port` bypass also verified.

## Docs

- `sequenced-tasks.md` §1 #2 status banner flipped to in-flight + new spec-strict deviation note for `api_auth`.
- `dns-sd-unbound.md` gains a `_nmos-system._tcp` block for the workstation IS-09 server (10.6.239.113:10641); pattern-add note reminds readers to omit `api_auth` from the System TXT.

## Out of scope (deferred per phase)

- IS-04 Node API client side that consumes `/global` and applies the bootstrap (lands in Phase 1 #3).
- HTTPS / IS-10 auth handshake (separate epic).
- Actual syslog forwarding (config round-trips only — emitting to a syslog server is a Node concern, not an IS-09 surface).
- AMWA NMOS Testing IS-09-02 conformance run (lands once the harness Pass/Fail gating wires up — tracked in `conformance.md`).

## Test plan

- [x] `go build ./...` + `go vet ./...` green
- [x] `go test ./...` green (78 tests across the NMOS surface)
- [x] `golangci-lint run ./...` green (depguard rules pass — codec stays stdlib-only, session/plugin layers respect dependency direction)
- [x] **Mode A self-loop verified** — `dhs producer nmos serve --role system` + `dhs consumer nmos system --mdns` round-trips on loopback
- [x] `--direct host:port` consumer bypass verified
- [ ] **Awaiting your sign-off:** Mode B unicast verification against pfSense Unbound (publish records per `dns-sd-unbound.md`, then `dhs consumer nmos system --no-mdns --unicast --resolver 10.100.0.1 --service _nmos-system._tcp.by-systems.arpa`)
- [ ] **Awaiting your sign-off:** AMWA NMOS Testing IS-09-02 conformance run via `make test-conformance-nmos`

## Architecture-review tickbox

Per [`internal/amwa/docs/dependencies.md`](internal/amwa/docs/dependencies.md):

- [x] No new edges added to the inter-codec graph
- [x] Layer N package imports only layers < N (verified by `dependencies_test.go`)
- [x] No cross-plugin imports (consumer ↛ provider — `system.go` lives in each separately, no shared package between them)
- [x] Codec packages remain stdlib-only (verified by depguard + audit test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)