### PR TITLE
feat(nmos): IS-04 v1.3 Node API — provider + Registration client

### DIFF
--- a/cmd/dhs/cmd_nmos.go
+++ b/cmd/dhs/cmd_nmos.go
@@ -19,7 +19,6 @@ import (
 	"log/slog"
 	"os"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -251,52 +250,55 @@ func runNMOSNodeServe(ctx context.Context, args []string) error {
 func runNMOSNodeServeLegacy(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
 	_ = fs.String("role", "node", "producer role to start (node | system)")
+	configPath := fs.String("config", "", "path to IS-04 Node bundle JSON (node + devices + sources + flows + senders + receivers)")
+	bind := fs.String("bind", ":8080", "Node API HTTP listen address")
+	advertise := fs.String("advertise-host", "", "host[:port] placed in DNS-SD A/SRV records (default: hostname + bind port)")
 	mdns := fs.Bool("mdns", true, "advertise via mDNS")
-	noMDNS := fs.Bool("no-mdns", false, "disable mDNS announce")
-	advertise := fs.String("advertise-host", "", "host:port placed in DNS-SD A/SRV records (default: hostname:port)")
-	port := fs.Int("port", 8080, "Node API port advertised in SRV record")
-	apiVer := fs.String("api-ver", "v1.3", "IS-04 Node API version advertised in TXT")
+	noMDNS := fs.Bool("no-mdns", false, "disable mDNS announce (Mode B / static)")
+	apiVer := fs.String("api-ver", "v1.3", "IS-04 wire version exposed under /x-nmos/node/<v>")
+	priority := fs.Int("priority", 0, "DNS-SD `pri` TXT (0-99 production, 100+ dev)")
+	registry := fs.String("registry", "", "Registration API base URL — when set, the Node POSTs to /resource + heartbeats every 5 s")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	mdnsActive := *mdns && !*noMDNS
-	if !mdnsActive {
-		fmt.Println("dhs producer nmos serve: mDNS announce disabled; nothing else implemented yet (Phase 1 #1 scope).")
-		<-ctx.Done()
-		return nil
+	if *configPath == "" {
+		return fmt.Errorf("producer nmos serve --role node: --config FILE required (use Phase 0 #1 mDNS-only placeholder via --discover-only flag if you really mean to)")
 	}
 
-	host, err := resolveAdvertiseHost(*advertise, *port)
-	if err != nil {
-		return err
-	}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
-	resp, err := session.NewResponder(logger)
+
+	bundle, err := provider.LoadNodeConfigFromFile(*configPath)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = resp.Close() }()
 
-	ins := codec.Instance{
-		Name:    "dhs-nmos-node",
-		Service: codec.ServiceNode,
-		Domain:  codec.DefaultDomain,
-		Host:    host,
-		Port:    uint16(*port),
-		TXT: map[string]string{
-			codec.TXTKeyAPIProto: "http",
-			codec.TXTKeyAPIVer:   *apiVer,
-			codec.TXTKeyAPIAuth:  "false",
-		},
+	mode := "mdns"
+	if !*mdns || *noMDNS {
+		mode = "static"
 	}
-	if err := resp.Announce(ctx, ins); err != nil {
+	cfg := provider.IS04NodeConfig{
+		Bind:          *bind,
+		AdvertiseHost: *advertise,
+		DiscoveryMode: mode,
+		Priority:      *priority,
+		APIVer:        *apiVer,
+		RegistryURL:   *registry,
+	}
+	srv, err := provider.NewIS04NodeServer(logger, bundle, cfg)
+	if err != nil {
 		return err
 	}
-	fmt.Printf("Announcing %s on %s:%d (mDNS).\n", codec.ServiceNode, host, *port)
-	fmt.Println("Note: Phase 1 #1 ships mDNS announce only; Node API REST surface lands in Phase 1 #3.")
+	defer func() { _ = srv.Stop() }()
 
-	<-ctx.Done()
-	return nil
+	fmt.Printf("Node API: bind=%s, mode=%s, api_ver=%s, priority=%d\n", *bind, mode, *apiVer, *priority)
+	fmt.Printf("  GET http://<host>%s/x-nmos/node/%s/{,self,devices,sources,flows,senders,receivers}\n", *bind, *apiVer)
+	if mode == "mdns" {
+		fmt.Println("Announcing _nmos-node._tcp via mDNS.")
+	}
+	if *registry != "" {
+		fmt.Printf("Registering against %s every %s + heartbeat.\n", *registry, "5s")
+	}
+	return srv.Serve(ctx)
 }
 
 // ---- consumer system (IS-09) ------------------------------------------------
@@ -529,42 +531,6 @@ func runNMOSRegistryServe(ctx context.Context, args []string) error {
 	return r.Serve(ctx, opts)
 }
 
-// resolveAdvertiseHost honours an explicit --advertise-host, otherwise
-// derives one from os.Hostname + the requested port.
-func resolveAdvertiseHost(adv string, port int) (string, error) {
-	if adv != "" {
-		host, _, err := splitNMOSHostPort(adv)
-		if err != nil {
-			return "", err
-		}
-		return host, nil
-	}
-	h, err := os.Hostname()
-	if err != nil || h == "" {
-		h = "localhost"
-	}
-	if !strings.Contains(h, ".") {
-		h = h + "." + codec.DefaultDomain
-	}
-	_ = port
-	return h, nil
-}
-
-// splitNMOSHostPort wraps net.SplitHostPort so callers can pass "host:port"
-// or "host" — the latter yields an empty port.
-func splitNMOSHostPort(s string) (string, string, error) {
-	if !strings.Contains(s, ":") {
-		return s, "", nil
-	}
-	idx := strings.LastIndex(s, ":")
-	host := s[:idx]
-	port := s[idx+1:]
-	if _, err := strconv.Atoi(port); err != nil {
-		return "", "", fmt.Errorf("nmos: bad port %q", port)
-	}
-	return host, port, nil
-}
-
 // ---- help text --------------------------------------------------------------
 
 func printNMOSConsumerHelp() {
@@ -597,15 +563,21 @@ func printNMOSProducerHelp() {
 
   --role node|system    Producer role (default: node)
 
-Role: node (Phase 1 #1)
-  Announces a placeholder Node via mDNS only — IS-04 Node API REST surface
-  lands in Phase 1 #3.
+Role: node (Phase 1 #3 — IS-04 v1.3 Node API)
+  Loads a Node bundle JSON (node + devices + sources + flows + senders +
+  receivers), validates each resource against the IS-04 v1.3 JSON Schema,
+  serves the Node API on --bind, optionally announces _nmos-node._tcp via
+  mDNS, and (when --registry is set) POSTs every resource + heartbeats
+  every 5 s to a Registry's Registration API.
 
-  --mdns                Advertise via mDNS (default)
-  --no-mdns             Disable mDNS announce
-  --advertise-host H    host placed in SRV record (default: os.Hostname)
-  --port N              Port advertised in SRV (default 8080)
-  --api-ver V           IS-04 version in TXT (default v1.3)
+  --config FILE         Node bundle JSON (required)
+  --bind ADDR           HTTP listen address (default :8080)
+  --advertise-host H    host[:port] placed in DNS-SD A/SRV records
+  --mdns / --no-mdns    Toggle mDNS announce (default on)
+  --api-ver V           IS-04 version exposed under /x-nmos/node/<v> (default v1.3)
+  --priority N          DNS-SD pri TXT (0-99 prod, 100+ dev)
+  --registry URL        Registration API base URL (e.g. http://reg.local:8235);
+                        omit to run mDNS-only / direct-Node mode
 
 Role: system (Phase 1 #2 — IS-09 System API)
   Loads + validates a /global resource JSON, serves the two IS-09 endpoints

--- a/internal/amwa/codec/is04/device.go
+++ b/internal/amwa/codec/is04/device.go
@@ -1,0 +1,89 @@
+package is04
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// Device is the IS-04 v1.3 Device resource.
+//
+// JSON Schema: https://specs.amwa.tv/is-04/releases/v1.3.3/APIs/schemas/with-refs/device.html
+type Device struct {
+	ResourceCore
+
+	Type      string          `json:"type"`     // URN
+	NodeID    string          `json:"node_id"`  // UUID v1-5
+	Senders   []string        `json:"senders"`  // deprecated array of UUIDs
+	Receivers []string        `json:"receivers"`
+	Controls  []DeviceControl `json:"controls"`
+}
+
+// DeviceControl is one entry in Device.Controls — points at IS-05 /
+// IS-07 / IS-08 / IS-12 sub-APIs.
+type DeviceControl struct {
+	Href          string `json:"href"`
+	Type          string `json:"type"` // URN
+	Authorization bool   `json:"authorization,omitempty"`
+}
+
+// Validate enforces device.json rules.
+func (d *Device) Validate() error {
+	errs := validateCore(&d.ResourceCore, "device")
+
+	if d.Type == "" || !IsValidDeviceTypeURN(d.Type) {
+		errs = append(errs, fmt.Sprintf("device.type %q: must be a non-NMOS URI or `urn:x-nmos:device:...`", d.Type))
+	}
+	if d.NodeID == "" || !IsValidUUID(d.NodeID) {
+		errs = append(errs, fmt.Sprintf("device.node_id %q: must match RFC 4122 v1-v5 UUID", d.NodeID))
+	}
+	if d.Senders == nil {
+		errs = append(errs, "device.senders: required (may be empty array)")
+	} else {
+		for i, id := range d.Senders {
+			if !IsValidUUID(id) {
+				errs = append(errs, fmt.Sprintf("device.senders[%d] %q: not a UUID", i, id))
+			}
+		}
+	}
+	if d.Receivers == nil {
+		errs = append(errs, "device.receivers: required (may be empty array)")
+	} else {
+		for i, id := range d.Receivers {
+			if !IsValidUUID(id) {
+				errs = append(errs, fmt.Sprintf("device.receivers[%d] %q: not a UUID", i, id))
+			}
+		}
+	}
+	if d.Controls == nil {
+		errs = append(errs, "device.controls: required (may be empty array)")
+	} else {
+		for i, c := range d.Controls {
+			if c.Href == "" {
+				errs = append(errs, fmt.Sprintf("device.controls[%d].href: required", i))
+			}
+			if c.Type == "" {
+				errs = append(errs, fmt.Sprintf("device.controls[%d].type: required (URN)", i))
+			}
+		}
+	}
+
+	return joinErrs("is04 device validation failed", errs)
+}
+
+// DecodeDevice parses + validates a Device payload.
+func DecodeDevice(raw []byte) (*Device, error) {
+	d := json.NewDecoder(bytes.NewReader(raw))
+	d.DisallowUnknownFields()
+	var dev Device
+	if err := d.Decode(&dev); err != nil {
+		return nil, fmt.Errorf("is04: decode device: %w", err)
+	}
+	if d.More() {
+		return nil, fmt.Errorf("is04: decode device: trailing JSON content")
+	}
+	if err := dev.Validate(); err != nil {
+		return nil, err
+	}
+	return &dev, nil
+}

--- a/internal/amwa/codec/is04/doc.go
+++ b/internal/amwa/codec/is04/doc.go
@@ -1,0 +1,27 @@
+// Package is04 implements the AMWA NMOS IS-04 v1.3.3 codec — the
+// Discovery & Registration layer. Stdlib-only (encoding/json, regexp,
+// strings, fmt, net, time), spec-strict per
+// https://specs.amwa.tv/is-04/releases/v1.3.3/.
+//
+// Resources covered (one Go struct per top-level resource):
+//
+//   Node      — the device itself; Node API root
+//   Device    — coherent control surface inside a Node
+//   Source    — essence origin (audio/video/data/mux)
+//   Flow      — specific encoding of a Source
+//   Sender    — network egress carrying a Flow
+//   Receiver  — network ingress consuming someone else's Sender
+//
+// Plus the Registration envelope (`{type, data}`) used to POST resources
+// to a Registry.
+//
+// Validation: required-field enforcement, UUID v1-5 pattern,
+// `<sec>:<nsec>` version pattern, format/transport URN enums,
+// MAC-address pattern for interfaces. Polymorphic format-specific
+// constraints (BCP-002 grouphint, BCP-004 receiver caps,
+// BCP-006-* media_type rules) land alongside their respective specs.
+//
+// IS-04 v1.2 / v1.1 back-compat is intentionally deferred — the v1.3
+// schemas form a strict superset of the prior versions for our
+// purposes, and v1.2-only peers will be added when Phase 1 #4b lands.
+package is04

--- a/internal/amwa/codec/is04/enums.go
+++ b/internal/amwa/codec/is04/enums.go
@@ -1,0 +1,143 @@
+package is04
+
+import "strings"
+
+// APIVersion is the IS-04 wire version this codec implements.
+const APIVersion = "v1.3"
+
+// ResourceType enumerates the six IS-04 resource collections. Used in
+// the Registration envelope (`{type, data}`) and as the resource-type
+// path segment under `/x-nmos/registration/.../resource/{type}/{id}`.
+//
+// Spec-strict: the registration envelope uses the singular form
+// (`node`, `device`, `source`, `flow`, `sender`, `receiver`) while
+// the Node API path collections are plural (`/sources`, `/devices`,
+// etc.). Helpers below convert between forms.
+type ResourceType string
+
+const (
+	ResourceNode     ResourceType = "node"
+	ResourceDevice   ResourceType = "device"
+	ResourceSource   ResourceType = "source"
+	ResourceFlow     ResourceType = "flow"
+	ResourceSender   ResourceType = "sender"
+	ResourceReceiver ResourceType = "receiver"
+)
+
+// AllResourceTypes lists the six resource types in registration order
+// — Nodes first because every other resource refers back to them.
+var AllResourceTypes = []ResourceType{
+	ResourceNode, ResourceDevice, ResourceSource, ResourceFlow,
+	ResourceSender, ResourceReceiver,
+}
+
+// Plural returns the IS-04 collection name (`sources`, `devices`, …).
+func (r ResourceType) Plural() string {
+	switch r {
+	case ResourceNode:
+		return "nodes"
+	default:
+		return string(r) + "s"
+	}
+}
+
+// IsValidResourceType reports whether s is one of the six allowed
+// types in the registration envelope.
+func IsValidResourceType(s string) bool {
+	switch ResourceType(s) {
+	case ResourceNode, ResourceDevice, ResourceSource, ResourceFlow, ResourceSender, ResourceReceiver:
+		return true
+	}
+	return false
+}
+
+// Format URNs (per IS-04 §3.6 / source_*.json). Senders/Receivers carry
+// a `format` field whose value MUST start with `urn:x-nmos:format:` for
+// NMOS-defined formats; vendor extensions use a different URN root.
+const (
+	FormatAudio = "urn:x-nmos:format:audio"
+	FormatVideo = "urn:x-nmos:format:video"
+	FormatData  = "urn:x-nmos:format:data"
+	FormatMux   = "urn:x-nmos:format:mux"
+)
+
+// IsNMOSFormat reports whether u is one of the four NMOS-defined
+// format URNs.
+func IsNMOSFormat(u string) bool {
+	switch u {
+	case FormatAudio, FormatVideo, FormatData, FormatMux:
+		return true
+	}
+	return false
+}
+
+// IsValidFormatURN enforces the spec rule: either a known NMOS format
+// URN, or a non-NMOS URI (vendor extension). It rejects URNs that
+// claim `urn:x-nmos:format:` but use an unknown sub-token.
+func IsValidFormatURN(u string) bool {
+	if u == "" {
+		return false
+	}
+	if strings.HasPrefix(u, "urn:x-nmos:format:") {
+		return IsNMOSFormat(u)
+	}
+	// Vendor extensions: any URI not under the urn:x-nmos: namespace.
+	return !strings.HasPrefix(u, "urn:x-nmos:")
+}
+
+// Transport URNs (per IS-04 §3.7 / sender / receiver_core).
+const (
+	TransportRTP          = "urn:x-nmos:transport:rtp"
+	TransportRTPMcast     = "urn:x-nmos:transport:rtp.mcast"
+	TransportRTPUcast     = "urn:x-nmos:transport:rtp.ucast"
+	TransportDASH         = "urn:x-nmos:transport:dash"
+	TransportWebSocket    = "urn:x-nmos:transport:websocket"
+	TransportMQTT         = "urn:x-nmos:transport:mqtt"
+)
+
+// IsNMOSTransport reports whether u is one of the six NMOS-defined
+// transport URNs.
+func IsNMOSTransport(u string) bool {
+	switch u {
+	case TransportRTP, TransportRTPMcast, TransportRTPUcast,
+		TransportDASH, TransportWebSocket, TransportMQTT:
+		return true
+	}
+	return false
+}
+
+// IsValidTransportURN matches the same shape rule as IsValidFormatURN.
+func IsValidTransportURN(u string) bool {
+	if u == "" {
+		return false
+	}
+	if strings.HasPrefix(u, "urn:x-nmos:transport:") {
+		return IsNMOSTransport(u)
+	}
+	return !strings.HasPrefix(u, "urn:x-nmos:")
+}
+
+// IsValidDeviceTypeURN per device.json: either starts with
+// `urn:x-nmos:device:`, or is a non-`urn:x-nmos:` URI.
+func IsValidDeviceTypeURN(u string) bool {
+	if u == "" {
+		return false
+	}
+	if strings.HasPrefix(u, "urn:x-nmos:device:") {
+		return true
+	}
+	return !strings.HasPrefix(u, "urn:x-nmos:")
+}
+
+// HTTPProtocol enumerates the api_proto / endpoints[].protocol values.
+type HTTPProtocol string
+
+const (
+	HTTPProto  HTTPProtocol = "http"
+	HTTPSProto HTTPProtocol = "https"
+)
+
+// IsValidHTTPProtocol reports whether p is "http" or "https".
+func IsValidHTTPProtocol(p string) bool {
+	return p == string(HTTPProto) || p == string(HTTPSProto)
+}

--- a/internal/amwa/codec/is04/flow.go
+++ b/internal/amwa/codec/is04/flow.go
@@ -1,0 +1,120 @@
+package is04
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// Flow is the IS-04 v1.3 Flow resource. Combines flow_core
+// (source_id + device_id + parents + grain_rate) with the format
+// discriminator (`format` URN) and a free-form `media_type`.
+//
+// JSON Schema base:
+//   https://specs.amwa.tv/is-04/releases/v1.3.3/APIs/schemas/with-refs/flow_core.html
+//
+// Per-format constraints (raw vs coded video, audio_raw, sdianc_data,
+// json_data, mux) layer on top of this base; we hold the union of
+// fields and validate the must-be-present-for-format set in Validate.
+type Flow struct {
+	ResourceCore
+
+	SourceID  string     `json:"source_id"`
+	DeviceID  string     `json:"device_id"`
+	Parents   []string   `json:"parents"`
+	GrainRate *GrainRate `json:"grain_rate,omitempty"`
+	Format    string     `json:"format"`     // URN
+	MediaType string     `json:"media_type,omitempty"`
+
+	// Video-specific (flow_video / flow_video_raw / flow_video_coded):
+	FrameWidth   int    `json:"frame_width,omitempty"`
+	FrameHeight  int    `json:"frame_height,omitempty"`
+	Interlace    string `json:"interlace_mode,omitempty"`
+	ColorSpace   string `json:"colorspace,omitempty"`
+	TransferChar string `json:"transfer_characteristic,omitempty"`
+
+	// Audio-specific (flow_audio / flow_audio_raw / flow_audio_coded):
+	SampleRate *GrainRate `json:"sample_rate,omitempty"`
+	BitDepth   int        `json:"bit_depth,omitempty"`
+
+	// Mux-specific (flow_mux):
+	// (no extra required fields beyond flow_core in v1.3 — payload
+	// described elsewhere via the corresponding Sender's manifest)
+
+	// SDI-ANC specific (flow_sdianc_data):
+	DIDSDID []FlowDIDSDID `json:"DID_SDID,omitempty"`
+
+	// json_data + event_type subset (flow_json_data):
+	EventType string `json:"event_type,omitempty"`
+}
+
+// FlowDIDSDID mirrors flow_sdianc_data.json DID_SDID[].
+type FlowDIDSDID struct {
+	DID  string `json:"DID"`  // hex string e.g. "0x60"
+	SDID string `json:"SDID"` // hex string
+}
+
+// Validate enforces flow_core + per-format rules.
+func (f *Flow) Validate() error {
+	errs := validateCore(&f.ResourceCore, "flow")
+
+	if f.SourceID == "" || !IsValidUUID(f.SourceID) {
+		errs = append(errs, fmt.Sprintf("flow.source_id %q: must match UUID v1-5", f.SourceID))
+	}
+	if f.DeviceID == "" || !IsValidUUID(f.DeviceID) {
+		errs = append(errs, fmt.Sprintf("flow.device_id %q: must match UUID v1-5", f.DeviceID))
+	}
+	if f.Parents == nil {
+		errs = append(errs, "flow.parents: required (may be empty array)")
+	} else {
+		for i, id := range f.Parents {
+			if !IsValidUUID(id) {
+				errs = append(errs, fmt.Sprintf("flow.parents[%d] %q: not a UUID", i, id))
+			}
+		}
+	}
+	if f.GrainRate != nil && f.GrainRate.Numerator <= 0 {
+		errs = append(errs, fmt.Sprintf("flow.grain_rate.numerator=%d: must be positive", f.GrainRate.Numerator))
+	}
+	if f.Format != "" && !IsValidFormatURN(f.Format) {
+		errs = append(errs, fmt.Sprintf("flow.format %q: must be a known NMOS format URN or non-NMOS URI", f.Format))
+	}
+
+	switch f.Format {
+	case FormatVideo:
+		if f.FrameWidth <= 0 {
+			errs = append(errs, "flow.frame_width: required (>0) for video flows")
+		}
+		if f.FrameHeight <= 0 {
+			errs = append(errs, "flow.frame_height: required (>0) for video flows")
+		}
+		switch f.Interlace {
+		case "", "progressive", "interlaced_tff", "interlaced_bff", "interlaced_psf":
+		default:
+			errs = append(errs, fmt.Sprintf("flow.interlace_mode %q: must be one of {progressive, interlaced_tff, interlaced_bff, interlaced_psf}", f.Interlace))
+		}
+	case FormatAudio:
+		if f.SampleRate == nil || f.SampleRate.Numerator <= 0 {
+			errs = append(errs, "flow.sample_rate: required for audio flows (positive numerator)")
+		}
+	}
+
+	return joinErrs("is04 flow validation failed", errs)
+}
+
+// DecodeFlow parses + validates a Flow payload.
+func DecodeFlow(raw []byte) (*Flow, error) {
+	d := json.NewDecoder(bytes.NewReader(raw))
+	d.DisallowUnknownFields()
+	var f Flow
+	if err := d.Decode(&f); err != nil {
+		return nil, fmt.Errorf("is04: decode flow: %w", err)
+	}
+	if d.More() {
+		return nil, fmt.Errorf("is04: decode flow: trailing JSON content")
+	}
+	if err := f.Validate(); err != nil {
+		return nil, err
+	}
+	return &f, nil
+}

--- a/internal/amwa/codec/is04/is04_test.go
+++ b/internal/amwa/codec/is04/is04_test.go
@@ -1,0 +1,360 @@
+package is04
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func validNode() Node {
+	chassis := "ff-ff-ff-ff-ff-ff"
+	return Node{
+		ResourceCore: ResourceCore{
+			ID:          "3b8be755-08ff-452b-b217-c9151eb21193",
+			Version:     "1441700172:318426300",
+			Label:       "lab-node",
+			Description: "lab fixture",
+			Tags:        map[string][]string{},
+		},
+		Href: "http://10.6.239.113:8080/",
+		Caps: map[string]any{},
+		API: NodeAPI{
+			Versions: []string{"v1.3"},
+			Endpoints: []NodeEndpoint{
+				{Host: "10.6.239.113", Port: 8080, Protocol: "http"},
+			},
+		},
+		Services: []NodeService{},
+		Clocks: []NodeClock{
+			{Name: "clk0", RefType: "internal"},
+		},
+		Interfaces: []NodeIface{
+			{ChassisID: &chassis, PortID: "ff-ff-ff-ff-ff-ff", Name: "eth0"},
+		},
+	}
+}
+
+func TestNodeValidateHappy(t *testing.T) {
+	n := validNode()
+	if err := n.Validate(); err != nil {
+		t.Fatalf("valid Node rejected: %v", err)
+	}
+}
+
+func TestNodeRoundTrip(t *testing.T) {
+	in := validNode()
+	wire, err := in.Encode()
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	got, err := DecodeNode(wire)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.ID != in.ID || got.API.Versions[0] != "v1.3" {
+		t.Fatalf("round-trip diverged: %+v", got)
+	}
+}
+
+func TestNodeRequiredMissing(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*Node)
+		want   string
+	}{
+		{"href missing", func(n *Node) { n.Href = "" }, "href"},
+		{"caps missing", func(n *Node) { n.Caps = nil }, "caps"},
+		{"versions empty", func(n *Node) { n.API.Versions = nil }, "api.versions"},
+		{"endpoints empty", func(n *Node) { n.API.Endpoints = nil }, "api.endpoints"},
+		{"bad protocol", func(n *Node) { n.API.Endpoints[0].Protocol = "ftp" }, "protocol"},
+		{"port out of range", func(n *Node) { n.API.Endpoints[0].Port = 70000 }, "port"},
+		{"clocks missing", func(n *Node) { n.Clocks = nil }, "clocks"},
+		{"interfaces missing", func(n *Node) { n.Interfaces = nil }, "interfaces"},
+		{"interface bad mac", func(n *Node) { n.Interfaces[0].PortID = "not-a-mac" }, "port_id"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			n := validNode()
+			tc.mutate(&n)
+			err := n.Validate()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("want error containing %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestNodeUnknownFieldRejected(t *testing.T) {
+	in := validNode()
+	wire, _ := in.Encode()
+	bad := strings.Replace(string(wire), `"href":`, `"rogue_field": "x", "href":`, 1)
+	if _, err := DecodeNode([]byte(bad)); err == nil || !strings.Contains(err.Error(), "rogue_field") {
+		t.Fatalf("expected unknown-field rejection, got %v", err)
+	}
+}
+
+func validDevice() Device {
+	return Device{
+		ResourceCore: ResourceCore{
+			ID:          "3b8be755-08ff-452b-b217-c9151eb21193",
+			Version:     "0:0",
+			Label:       "lab-dev",
+			Description: "lab fixture",
+			Tags:        map[string][]string{},
+		},
+		Type:      "urn:x-nmos:device:generic",
+		NodeID:    "3b8be755-08ff-452b-b217-c9151eb21193",
+		Senders:   []string{},
+		Receivers: []string{},
+		Controls:  []DeviceControl{},
+	}
+}
+
+func TestDeviceValidateHappy(t *testing.T) {
+	d := validDevice()
+	if err := d.Validate(); err != nil {
+		t.Fatalf("valid Device rejected: %v", err)
+	}
+}
+
+func TestDeviceTypeURN(t *testing.T) {
+	d := validDevice()
+	d.Type = "urn:x-nmos:UNKNOWN-NAMESPACE:foo"
+	if err := d.Validate(); err == nil || !strings.Contains(err.Error(), "type") {
+		t.Fatalf("urn:x-nmos:* with bad sub-namespace must reject: %v", err)
+	}
+	d.Type = "https://vendor.example/device/typeA"
+	if err := d.Validate(); err != nil {
+		t.Fatalf("non-NMOS URI should pass: %v", err)
+	}
+	d.Type = "urn:x-nmos:device:generic"
+	if err := d.Validate(); err != nil {
+		t.Fatalf("urn:x-nmos:device:* should pass: %v", err)
+	}
+}
+
+func validSource() Source {
+	clk := "clk0"
+	return Source{
+		ResourceCore: ResourceCore{
+			ID:          "3b8be755-08ff-452b-b217-c9151eb21193",
+			Version:     "0:0",
+			Label:       "src-1",
+			Description: "lab src",
+			Tags:        map[string][]string{},
+		},
+		Caps:      map[string]any{},
+		DeviceID:  "3b8be755-08ff-452b-b217-c9151eb21193",
+		Parents:   []string{},
+		ClockName: &clk,
+		Format:    FormatVideo,
+	}
+}
+
+func TestSourceClockNameNullable(t *testing.T) {
+	// Wire form with explicit null — this is spec-compliant.
+	raw := `{
+  "id":"3b8be755-08ff-452b-b217-c9151eb21193",
+  "version":"0:0",
+  "label":"x", "description":"y", "tags":{},
+  "caps":{}, "device_id":"3b8be755-08ff-452b-b217-c9151eb21193",
+  "parents":[], "clock_name":null, "format":"urn:x-nmos:format:video"
+}`
+	if _, err := DecodeSource([]byte(raw)); err != nil {
+		t.Fatalf("clock_name=null should decode: %v", err)
+	}
+	// Wire form with a real clock name — also spec-compliant.
+	raw2 := strings.Replace(raw, `"clock_name":null`, `"clock_name":"clk0"`, 1)
+	if _, err := DecodeSource([]byte(raw2)); err != nil {
+		t.Fatalf("clock_name=\"clk0\" should decode: %v", err)
+	}
+}
+
+func TestSourceAudioRequiresChannels(t *testing.T) {
+	s := validSource()
+	s.Format = FormatAudio
+	if err := s.Validate(); err == nil || !strings.Contains(err.Error(), "channels") {
+		t.Fatalf("audio source without channels must reject: %v", err)
+	}
+	s.Channels = []SourceAudioChannel{{Label: "L"}}
+	if err := s.Validate(); err != nil {
+		t.Fatalf("audio source with channels rejected: %v", err)
+	}
+}
+
+func validFlow() Flow {
+	return Flow{
+		ResourceCore: ResourceCore{
+			ID:          "3b8be755-08ff-452b-b217-c9151eb21193",
+			Version:     "0:0",
+			Label:       "flow-1",
+			Description: "lab flow",
+			Tags:        map[string][]string{},
+		},
+		SourceID:  "3b8be755-08ff-452b-b217-c9151eb21193",
+		DeviceID:  "3b8be755-08ff-452b-b217-c9151eb21193",
+		Parents:   []string{},
+		Format:    FormatVideo,
+		FrameWidth:  1920,
+		FrameHeight: 1080,
+		Interlace:   "progressive",
+	}
+}
+
+func TestFlowValidateHappy(t *testing.T) {
+	f := validFlow()
+	if err := f.Validate(); err != nil {
+		t.Fatalf("valid Flow rejected: %v", err)
+	}
+}
+
+func TestFlowVideoRequiresFrameSize(t *testing.T) {
+	f := validFlow()
+	f.FrameWidth = 0
+	if err := f.Validate(); err == nil || !strings.Contains(err.Error(), "frame_width") {
+		t.Fatalf("video flow without frame_width should reject: %v", err)
+	}
+}
+
+func TestFlowAudioRequiresSampleRate(t *testing.T) {
+	f := validFlow()
+	f.Format = FormatAudio
+	f.FrameWidth = 0
+	f.FrameHeight = 0
+	f.Interlace = ""
+	if err := f.Validate(); err == nil || !strings.Contains(err.Error(), "sample_rate") {
+		t.Fatalf("audio flow without sample_rate should reject: %v", err)
+	}
+	f.SampleRate = &GrainRate{Numerator: 48000, Denominator: 1}
+	if err := f.Validate(); err != nil {
+		t.Fatalf("audio flow with sample_rate rejected: %v", err)
+	}
+}
+
+func validSender() Sender {
+	href := "http://10.6.239.113:8080/x-nmos/node/v1.3/senders/abc/manifest"
+	flow := "3b8be755-08ff-452b-b217-c9151eb21193"
+	return Sender{
+		ResourceCore: ResourceCore{
+			ID:          "3b8be755-08ff-452b-b217-c9151eb21193",
+			Version:     "0:0",
+			Label:       "snd-1",
+			Description: "lab snd",
+			Tags:        map[string][]string{},
+		},
+		FlowID:            &flow,
+		Transport:         TransportRTPMcast,
+		DeviceID:          "3b8be755-08ff-452b-b217-c9151eb21193",
+		ManifestHref:      &href,
+		InterfaceBindings: []string{"eth0"},
+		Subscription:      Subscription{Active: false},
+	}
+}
+
+func TestSenderValidateHappy(t *testing.T) {
+	s := validSender()
+	if err := s.Validate(); err != nil {
+		t.Fatalf("valid Sender rejected: %v", err)
+	}
+}
+
+func TestSenderTransportURN(t *testing.T) {
+	s := validSender()
+	s.Transport = "urn:x-nmos:transport:UNKNOWN"
+	if err := s.Validate(); err == nil || !strings.Contains(err.Error(), "transport") {
+		t.Fatalf("unknown urn:x-nmos:transport:* must reject: %v", err)
+	}
+	s.Transport = "https://vendor.example/transport/typeA"
+	if err := s.Validate(); err != nil {
+		t.Fatalf("non-NMOS transport URI should pass: %v", err)
+	}
+}
+
+func TestSenderManifestNullOK(t *testing.T) {
+	s := validSender()
+	s.ManifestHref = nil
+	if err := s.Validate(); err != nil {
+		t.Fatalf("manifest_href=nil should pass: %v", err)
+	}
+}
+
+func validReceiver() Receiver {
+	return Receiver{
+		ResourceCore: ResourceCore{
+			ID:          "3b8be755-08ff-452b-b217-c9151eb21193",
+			Version:     "0:0",
+			Label:       "rcv-1",
+			Description: "lab rcv",
+			Tags:        map[string][]string{},
+		},
+		DeviceID:          "3b8be755-08ff-452b-b217-c9151eb21193",
+		Transport:         TransportRTPMcast,
+		InterfaceBindings: []string{"eth0"},
+		Format:            FormatVideo,
+		Caps:              ReceiverCaps{MediaTypes: []string{"video/raw"}},
+		Subscription:      Subscription{Active: false},
+	}
+}
+
+func TestReceiverValidateHappy(t *testing.T) {
+	r := validReceiver()
+	if err := r.Validate(); err != nil {
+		t.Fatalf("valid Receiver rejected: %v", err)
+	}
+}
+
+func TestReceiverFormatRequired(t *testing.T) {
+	r := validReceiver()
+	r.Format = ""
+	if err := r.Validate(); err == nil || !strings.Contains(err.Error(), "format") {
+		t.Fatalf("receiver missing format must reject: %v", err)
+	}
+}
+
+func TestRegistrationEnvelope(t *testing.T) {
+	body, err := EncodeRegistration(ResourceNode, validNode())
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	r, err := DecodeRegistration(body)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if r.Type != ResourceNode {
+		t.Fatalf("type = %q", r.Type)
+	}
+	// Inner data round-trips into a Node.
+	var got Node
+	if err := json.Unmarshal(r.Data, &got); err != nil {
+		t.Fatalf("inner unmarshal: %v", err)
+	}
+	if got.ID != "3b8be755-08ff-452b-b217-c9151eb21193" {
+		t.Fatalf("inner id = %q", got.ID)
+	}
+}
+
+func TestRegistrationRejectsBadType(t *testing.T) {
+	if _, err := EncodeRegistration(ResourceType("bogus"), nil); err == nil {
+		t.Fatal("expected invalid-type rejection")
+	}
+	bad := []byte(`{"type":"bogus","data":{}}`)
+	if _, err := DecodeRegistration(bad); err == nil {
+		t.Fatal("expected decode rejection on bogus type")
+	}
+}
+
+func TestPluralCollections(t *testing.T) {
+	want := map[ResourceType]string{
+		ResourceNode:     "nodes",
+		ResourceDevice:   "devices",
+		ResourceSource:   "sources",
+		ResourceFlow:     "flows",
+		ResourceSender:   "senders",
+		ResourceReceiver: "receivers",
+	}
+	for r, w := range want {
+		if got := r.Plural(); got != w {
+			t.Fatalf("%s.Plural() = %q, want %q", r, got, w)
+		}
+	}
+}

--- a/internal/amwa/codec/is04/node.go
+++ b/internal/amwa/codec/is04/node.go
@@ -1,0 +1,177 @@
+package is04
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// Node is the IS-04 v1.3 Node resource — the device itself.
+//
+// JSON Schema: https://specs.amwa.tv/is-04/releases/v1.3.3/APIs/schemas/with-refs/node.html
+type Node struct {
+	ResourceCore
+
+	Href       string         `json:"href"`
+	Hostname   string         `json:"hostname,omitempty"`
+	Caps       map[string]any `json:"caps"`
+	API        NodeAPI        `json:"api"`
+	Services   []NodeService  `json:"services"`
+	Clocks     []NodeClock    `json:"clocks"`
+	Interfaces []NodeIface    `json:"interfaces"`
+}
+
+// NodeAPI is the `api` sub-object on Node — versions + endpoints.
+type NodeAPI struct {
+	Versions  []string      `json:"versions"`
+	Endpoints []NodeEndpoint `json:"endpoints"`
+}
+
+// NodeEndpoint is one entry in NodeAPI.Endpoints.
+type NodeEndpoint struct {
+	Host          string `json:"host"`
+	Port          int    `json:"port"`
+	Protocol      string `json:"protocol"`
+	Authorization bool   `json:"authorization,omitempty"`
+}
+
+// NodeService is one entry in Node.Services — a non-NMOS service
+// running on the Node addressed by URN type.
+type NodeService struct {
+	Href          string `json:"href"`
+	Type          string `json:"type"`
+	Authorization bool   `json:"authorization,omitempty"`
+}
+
+// NodeClock is one entry in Node.Clocks. Polymorphic per `clock_*.json`
+// — `name` + `ref_type` are the discriminator. We hold the raw map and
+// validate the bare minimum (name + ref_type ∈ {"internal","ptp"}).
+type NodeClock struct {
+	Name    string `json:"name"`
+	RefType string `json:"ref_type"`
+
+	// PTP-specific fields (only populated when RefType == "ptp"):
+	Traceable bool   `json:"traceable,omitempty"`
+	Version   string `json:"version,omitempty"`
+	GMID      string `json:"gmid,omitempty"`
+	Locked    bool   `json:"locked,omitempty"`
+}
+
+// NodeIface is one entry in Node.Interfaces.
+type NodeIface struct {
+	ChassisID            *string                 `json:"chassis_id"`
+	PortID               string                  `json:"port_id"`
+	Name                 string                  `json:"name"`
+	AttachedNetworkDevice *AttachedNetworkDevice `json:"attached_network_device,omitempty"`
+}
+
+// AttachedNetworkDevice mirrors interfaces[].attached_network_device.
+type AttachedNetworkDevice struct {
+	ChassisID string `json:"chassis_id"`
+	PortID    string `json:"port_id"`
+}
+
+// Validate enforces every required-field + pattern rule from
+// node.json. Optional fields with empty/zero values are skipped.
+func (n *Node) Validate() error {
+	errs := validateCore(&n.ResourceCore, "node")
+
+	if n.Href == "" {
+		errs = append(errs, "node.href: required")
+	}
+	if n.Caps == nil {
+		errs = append(errs, "node.caps: required (may be empty object)")
+	}
+
+	if len(n.API.Versions) == 0 {
+		errs = append(errs, "node.api.versions: required (>=1 entry)")
+	}
+	for i, v := range n.API.Versions {
+		if !IsValidAPIVersion(v) {
+			errs = append(errs, fmt.Sprintf("node.api.versions[%d] %q: must match `vMAJOR.MINOR`", i, v))
+		}
+	}
+	if len(n.API.Endpoints) == 0 {
+		errs = append(errs, "node.api.endpoints: required (>=1 entry)")
+	}
+	for i, e := range n.API.Endpoints {
+		if e.Host == "" {
+			errs = append(errs, fmt.Sprintf("node.api.endpoints[%d].host: required", i))
+		}
+		if e.Port < 1 || e.Port > 65535 {
+			errs = append(errs, fmt.Sprintf("node.api.endpoints[%d].port=%d: out of [1..65535]", i, e.Port))
+		}
+		if !IsValidHTTPProtocol(e.Protocol) {
+			errs = append(errs, fmt.Sprintf("node.api.endpoints[%d].protocol %q: must be \"http\" or \"https\"", i, e.Protocol))
+		}
+	}
+
+	if n.Services == nil {
+		errs = append(errs, "node.services: required (may be empty array)")
+	}
+	for i, s := range n.Services {
+		if s.Href == "" {
+			errs = append(errs, fmt.Sprintf("node.services[%d].href: required", i))
+		}
+		if s.Type == "" {
+			errs = append(errs, fmt.Sprintf("node.services[%d].type: required (URN)", i))
+		}
+	}
+
+	if n.Clocks == nil {
+		errs = append(errs, "node.clocks: required (may be empty array)")
+	}
+	for i, c := range n.Clocks {
+		if c.Name == "" {
+			errs = append(errs, fmt.Sprintf("node.clocks[%d].name: required", i))
+		}
+		switch c.RefType {
+		case "internal", "ptp":
+		default:
+			errs = append(errs, fmt.Sprintf("node.clocks[%d].ref_type %q: must be \"internal\" or \"ptp\"", i, c.RefType))
+		}
+	}
+
+	if n.Interfaces == nil {
+		errs = append(errs, "node.interfaces: required (may be empty array)")
+	}
+	for i, iface := range n.Interfaces {
+		if iface.Name == "" {
+			errs = append(errs, fmt.Sprintf("node.interfaces[%d].name: required", i))
+		}
+		if iface.PortID == "" || !IsValidMAC(iface.PortID) {
+			errs = append(errs, fmt.Sprintf("node.interfaces[%d].port_id %q: must match MAC pattern xx-xx-xx-xx-xx-xx", i, iface.PortID))
+		}
+		// chassis_id may be null OR a MAC OR a freeform string per spec; only fully-empty (non-null) is wrong.
+		if iface.ChassisID != nil && *iface.ChassisID == "" {
+			errs = append(errs, fmt.Sprintf("node.interfaces[%d].chassis_id: empty string disallowed (use null for unknown)", i))
+		}
+	}
+
+	return joinErrs("is04 node validation failed", errs)
+}
+
+// EncodeNode marshals the Node with validation.
+func (n *Node) Encode() ([]byte, error) {
+	if err := n.Validate(); err != nil {
+		return nil, err
+	}
+	return json.MarshalIndent(n, "", "  ")
+}
+
+// DecodeNode parses + validates a Node payload.
+func DecodeNode(raw []byte) (*Node, error) {
+	d := json.NewDecoder(bytes.NewReader(raw))
+	d.DisallowUnknownFields()
+	var n Node
+	if err := d.Decode(&n); err != nil {
+		return nil, fmt.Errorf("is04: decode node: %w", err)
+	}
+	if d.More() {
+		return nil, fmt.Errorf("is04: decode node: trailing JSON content")
+	}
+	if err := n.Validate(); err != nil {
+		return nil, err
+	}
+	return &n, nil
+}

--- a/internal/amwa/codec/is04/patterns.go
+++ b/internal/amwa/codec/is04/patterns.go
@@ -1,0 +1,29 @@
+package is04
+
+import "regexp"
+
+// UUIDPattern is RFC 4122 v1-v5, per resource_core.json. Used as the
+// id pattern across every IS-04 resource type.
+var UUIDPattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+// VersionPattern is the IS-04 TAI-timestamp form `<sec>:<nsec>`.
+var VersionPattern = regexp.MustCompile(`^[0-9]+:[0-9]+$`)
+
+// APIVersionPattern is `vMAJOR.MINOR` e.g. `v1.3`.
+var APIVersionPattern = regexp.MustCompile(`^v[0-9]+\.[0-9]+$`)
+
+// MACPattern is the lowercase-hex `xx-xx-xx-xx-xx-xx` form used by
+// interfaces.{chassis_id, port_id, attached_network_device}.
+var MACPattern = regexp.MustCompile(`^([0-9a-f]{2}-){5}([0-9a-f]{2})$`)
+
+// IsValidUUID reports whether s matches the v1-5 UUID pattern.
+func IsValidUUID(s string) bool { return UUIDPattern.MatchString(s) }
+
+// IsValidVersion reports whether s matches the TAI-timestamp pattern.
+func IsValidVersion(s string) bool { return VersionPattern.MatchString(s) }
+
+// IsValidAPIVersion reports whether s matches `v<major>.<minor>`.
+func IsValidAPIVersion(s string) bool { return APIVersionPattern.MatchString(s) }
+
+// IsValidMAC reports whether s matches the lowercase-hex MAC pattern.
+func IsValidMAC(s string) bool { return MACPattern.MatchString(s) }

--- a/internal/amwa/codec/is04/receiver.go
+++ b/internal/amwa/codec/is04/receiver.go
@@ -1,0 +1,74 @@
+package is04
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// Receiver is the IS-04 v1.3 Receiver resource.
+//
+// JSON Schemas:
+//   https://specs.amwa.tv/is-04/releases/v1.3.3/APIs/schemas/with-refs/receiver_core.html
+//   + receiver_audio.json / receiver_video.json / receiver_data.json / receiver_mux.json
+//
+// Format-specific media_type lists land in `caps.media_types[]`.
+type Receiver struct {
+	ResourceCore
+
+	DeviceID          string         `json:"device_id"`
+	Transport         string         `json:"transport"`
+	InterfaceBindings []string       `json:"interface_bindings"`
+	Format            string         `json:"format"`
+	Caps              ReceiverCaps   `json:"caps"`
+	Subscription      Subscription   `json:"subscription"`
+}
+
+// ReceiverCaps mirrors the receiver_*.json `caps` object. v1.3 supports
+// `media_types` (list of accepted RTP payload types) and per-BCP-004
+// `constraint_sets`. The latter lands in N9; we hold the slot here.
+type ReceiverCaps struct {
+	MediaTypes     []string         `json:"media_types,omitempty"`
+	EventTypes     []string         `json:"event_types,omitempty"`
+	ConstraintSets []map[string]any `json:"constraint_sets,omitempty"`
+}
+
+// Validate enforces receiver_core + per-format rules.
+func (r *Receiver) Validate() error {
+	errs := validateCore(&r.ResourceCore, "receiver")
+
+	if r.DeviceID == "" || !IsValidUUID(r.DeviceID) {
+		errs = append(errs, fmt.Sprintf("receiver.device_id %q: must match UUID v1-5", r.DeviceID))
+	}
+	if r.Transport == "" || !IsValidTransportURN(r.Transport) {
+		errs = append(errs, fmt.Sprintf("receiver.transport %q: must be a known NMOS transport URN or non-NMOS URI", r.Transport))
+	}
+	if r.InterfaceBindings == nil {
+		errs = append(errs, "receiver.interface_bindings: required (may be empty array)")
+	}
+	if r.Format == "" || !IsValidFormatURN(r.Format) {
+		errs = append(errs, fmt.Sprintf("receiver.format %q: required, must be NMOS format URN or non-NMOS URI", r.Format))
+	}
+	if r.Subscription.SenderID != nil && *r.Subscription.SenderID != "" && !IsValidUUID(*r.Subscription.SenderID) {
+		errs = append(errs, fmt.Sprintf("receiver.subscription.sender_id %q: must match UUID or be null", *r.Subscription.SenderID))
+	}
+
+	return joinErrs("is04 receiver validation failed", errs)
+}
+
+// DecodeReceiver parses + validates a Receiver payload.
+func DecodeReceiver(raw []byte) (*Receiver, error) {
+	d := json.NewDecoder(bytes.NewReader(raw))
+	d.DisallowUnknownFields()
+	var r Receiver
+	if err := d.Decode(&r); err != nil {
+		return nil, fmt.Errorf("is04: decode receiver: %w", err)
+	}
+	if d.More() {
+		return nil, fmt.Errorf("is04: decode receiver: trailing JSON content")
+	}
+	if err := r.Validate(); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}

--- a/internal/amwa/codec/is04/registration.go
+++ b/internal/amwa/codec/is04/registration.go
@@ -1,0 +1,54 @@
+package is04
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// RegistrationRequest is the body of POST /x-nmos/registration/v1.x/resource.
+// `Type` is the singular resource type (`node`, `device`, …); `Data` is
+// the resource object itself, raw-JSON until the caller decodes it
+// based on Type.
+type RegistrationRequest struct {
+	Type ResourceType    `json:"type"`
+	Data json.RawMessage `json:"data"`
+}
+
+// EncodeRegistration builds the registration body for the given
+// resource. The caller is responsible for validating `data` first;
+// this helper just wraps it in the spec envelope.
+func EncodeRegistration(t ResourceType, data any) ([]byte, error) {
+	if !IsValidResourceType(string(t)) {
+		return nil, fmt.Errorf("is04: invalid resource type %q", t)
+	}
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("is04: marshal %s: %w", t, err)
+	}
+	body, err := json.Marshal(RegistrationRequest{Type: t, Data: raw})
+	if err != nil {
+		return nil, fmt.Errorf("is04: marshal registration envelope: %w", err)
+	}
+	return body, nil
+}
+
+// DecodeRegistration parses the envelope without yet decoding Data.
+func DecodeRegistration(raw []byte) (*RegistrationRequest, error) {
+	d := json.NewDecoder(bytes.NewReader(raw))
+	d.DisallowUnknownFields()
+	var r RegistrationRequest
+	if err := d.Decode(&r); err != nil {
+		return nil, fmt.Errorf("is04: decode registration: %w", err)
+	}
+	if !IsValidResourceType(string(r.Type)) {
+		return nil, fmt.Errorf("is04: registration.type %q: not a valid resource type", r.Type)
+	}
+	return &r, nil
+}
+
+// HealthResponse mirrors the spec body returned by POST + GET on
+// `/health/nodes/{nodeId}` — `{ "health": "<unix-seconds>" }`.
+type HealthResponse struct {
+	Health string `json:"health"`
+}

--- a/internal/amwa/codec/is04/resource_core.go
+++ b/internal/amwa/codec/is04/resource_core.go
@@ -1,0 +1,49 @@
+package is04
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ResourceCore is the shared base every IS-04 resource extends, per
+// `resource_core.json` — id, version, label, description, tags. Reused
+// across Node / Device / Source / Flow / Sender / Receiver.
+type ResourceCore struct {
+	ID          string              `json:"id"`
+	Version     string              `json:"version"`
+	Label       string              `json:"label"`
+	Description string              `json:"description"`
+	Tags        map[string][]string `json:"tags"`
+}
+
+// validateCore returns the slice of human-readable validation errors for
+// the embedded ResourceCore. Caller appends additional resource-type
+// rules.
+func validateCore(c *ResourceCore, where string) []string {
+	var errs []string
+	if c.ID == "" || !IsValidUUID(c.ID) {
+		errs = append(errs, fmt.Sprintf("%s.id %q: must match RFC 4122 v1-v5 UUID pattern", where, c.ID))
+	}
+	if c.Version == "" || !IsValidVersion(c.Version) {
+		errs = append(errs, fmt.Sprintf("%s.version %q: must match `<sec>:<nsec>` TAI form", where, c.Version))
+	}
+	if c.Label == "" {
+		errs = append(errs, where+".label: required (resource_core)")
+	}
+	if c.Description == "" {
+		errs = append(errs, where+".description: required (resource_core)")
+	}
+	if c.Tags == nil {
+		errs = append(errs, where+".tags: required (may be empty object, but key must be present)")
+	}
+	return errs
+}
+
+// joinErrs renders a non-empty validation slice into a single error.
+// Returns nil when errs is empty.
+func joinErrs(prefix string, errs []string) error {
+	if len(errs) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%s: %s", prefix, strings.Join(errs, "; "))
+}

--- a/internal/amwa/codec/is04/sender.go
+++ b/internal/amwa/codec/is04/sender.go
@@ -1,0 +1,77 @@
+package is04
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// Sender is the IS-04 v1.3 Sender resource.
+//
+// JSON Schema: https://specs.amwa.tv/is-04/releases/v1.3.3/APIs/schemas/with-refs/sender.html
+type Sender struct {
+	ResourceCore
+
+	FlowID            *string        `json:"flow_id"` // UUID OR null
+	Transport         string         `json:"transport"`
+	DeviceID          string         `json:"device_id"`
+	ManifestHref      *string        `json:"manifest_href"` // URI OR null
+	InterfaceBindings []string       `json:"interface_bindings"`
+	Caps              map[string]any `json:"caps,omitempty"`
+	Subscription      Subscription   `json:"subscription"`
+}
+
+// Subscription is shared by Sender and Receiver. Sender carries
+// receiver_id (the receiver currently consuming this sender's flow);
+// Receiver carries sender_id. Both also carry `active`.
+type Subscription struct {
+	ReceiverID *string `json:"receiver_id,omitempty"`
+	SenderID   *string `json:"sender_id,omitempty"`
+	Active     bool    `json:"active"`
+}
+
+// Validate enforces sender.json rules.
+func (s *Sender) Validate() error {
+	errs := validateCore(&s.ResourceCore, "sender")
+
+	if s.FlowID != nil && *s.FlowID != "" && !IsValidUUID(*s.FlowID) {
+		errs = append(errs, fmt.Sprintf("sender.flow_id %q: must match UUID v1-5 or be null", *s.FlowID))
+	}
+	if s.Transport == "" || !IsValidTransportURN(s.Transport) {
+		errs = append(errs, fmt.Sprintf("sender.transport %q: must be a known NMOS transport URN or non-NMOS URI", s.Transport))
+	}
+	if s.DeviceID == "" || !IsValidUUID(s.DeviceID) {
+		errs = append(errs, fmt.Sprintf("sender.device_id %q: must match UUID v1-5", s.DeviceID))
+	}
+	if s.InterfaceBindings == nil {
+		errs = append(errs, "sender.interface_bindings: required (may be empty array)")
+	}
+	// manifest_href is required (string OR null) — the field must be
+	// present in the JSON. Nil pointer = absent; empty string = invalid.
+	if s.ManifestHref != nil && *s.ManifestHref == "" {
+		errs = append(errs, "sender.manifest_href: empty string disallowed (use null when manifest absent)")
+	}
+
+	if s.Subscription.ReceiverID != nil && *s.Subscription.ReceiverID != "" && !IsValidUUID(*s.Subscription.ReceiverID) {
+		errs = append(errs, fmt.Sprintf("sender.subscription.receiver_id %q: must match UUID or be null", *s.Subscription.ReceiverID))
+	}
+
+	return joinErrs("is04 sender validation failed", errs)
+}
+
+// DecodeSender parses + validates a Sender payload.
+func DecodeSender(raw []byte) (*Sender, error) {
+	d := json.NewDecoder(bytes.NewReader(raw))
+	d.DisallowUnknownFields()
+	var s Sender
+	if err := d.Decode(&s); err != nil {
+		return nil, fmt.Errorf("is04: decode sender: %w", err)
+	}
+	if d.More() {
+		return nil, fmt.Errorf("is04: decode sender: trailing JSON content")
+	}
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}

--- a/internal/amwa/codec/is04/source.go
+++ b/internal/amwa/codec/is04/source.go
@@ -1,0 +1,112 @@
+package is04
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// Source is the IS-04 v1.3 Source resource. Combines source_core
+// (caps + device_id + parents + clock_name + grain_rate) with the
+// format discriminator (`format` URN) and format-specific extras.
+//
+// JSON Schemas:
+//   - https://specs.amwa.tv/is-04/releases/v1.3.3/APIs/schemas/with-refs/source_core.html
+//   - source_audio.json / source_video.json / source_data.json / source_generic.json
+//
+// Format-specific fields land here as optional pointers; Validate
+// enforces the per-format required-set when Format is set.
+type Source struct {
+	ResourceCore
+
+	Caps      map[string]any `json:"caps"`
+	DeviceID  string         `json:"device_id"`
+	Parents   []string       `json:"parents"`
+	ClockName *string        `json:"clock_name"` // string OR null
+	GrainRate *GrainRate     `json:"grain_rate,omitempty"`
+	Format    string         `json:"format"` // URN
+
+	// Audio-specific (source_audio): channels[].symbol + label.
+	Channels []SourceAudioChannel `json:"channels,omitempty"`
+
+	// Event-tally specific (source_data + IS-07): event_type URN.
+	EventType string `json:"event_type,omitempty"`
+}
+
+// GrainRate is the numerator/denominator pair shared by Source + Flow.
+type GrainRate struct {
+	Numerator   int `json:"numerator"`
+	Denominator int `json:"denominator,omitempty"` // default 1
+}
+
+// SourceAudioChannel mirrors source_audio.json channels[].
+type SourceAudioChannel struct {
+	Label  string `json:"label"`
+	Symbol string `json:"symbol,omitempty"`
+}
+
+// Validate enforces source_core + per-format rules.
+func (s *Source) Validate() error {
+	errs := validateCore(&s.ResourceCore, "source")
+
+	if s.Caps == nil {
+		errs = append(errs, "source.caps: required (may be empty object)")
+	}
+	if s.DeviceID == "" || !IsValidUUID(s.DeviceID) {
+		errs = append(errs, fmt.Sprintf("source.device_id %q: must match UUID v1-5", s.DeviceID))
+	}
+	if s.Parents == nil {
+		errs = append(errs, "source.parents: required (may be empty array)")
+	} else {
+		for i, id := range s.Parents {
+			if !IsValidUUID(id) {
+				errs = append(errs, fmt.Sprintf("source.parents[%d] %q: not a UUID", i, id))
+			}
+		}
+	}
+	// clock_name is `["string", "null"]` and required by the schema —
+	// the field must appear in the JSON. Go cannot distinguish an
+	// absent field from a present-but-null one without a custom
+	// UnmarshalJSON, so we accept both shapes on decode and rely on
+	// the encoder (which always emits the field, including as null
+	// when nil) to keep the wire spec-compliant.
+	if s.GrainRate != nil && s.GrainRate.Numerator <= 0 {
+		errs = append(errs, fmt.Sprintf("source.grain_rate.numerator=%d: must be positive", s.GrainRate.Numerator))
+	}
+	if s.GrainRate != nil && s.GrainRate.Denominator < 0 {
+		errs = append(errs, fmt.Sprintf("source.grain_rate.denominator=%d: must be non-negative", s.GrainRate.Denominator))
+	}
+
+	if s.Format != "" && !IsValidFormatURN(s.Format) {
+		errs = append(errs, fmt.Sprintf("source.format %q: must be a known NMOS format URN or non-NMOS URI", s.Format))
+	}
+	if s.Format == FormatAudio {
+		if len(s.Channels) == 0 {
+			errs = append(errs, "source.channels: required when format=audio (>=1 channel)")
+		}
+		for i, ch := range s.Channels {
+			if ch.Label == "" {
+				errs = append(errs, fmt.Sprintf("source.channels[%d].label: required", i))
+			}
+		}
+	}
+
+	return joinErrs("is04 source validation failed", errs)
+}
+
+// DecodeSource parses + validates a Source payload.
+func DecodeSource(raw []byte) (*Source, error) {
+	d := json.NewDecoder(bytes.NewReader(raw))
+	d.DisallowUnknownFields()
+	var s Source
+	if err := d.Decode(&s); err != nil {
+		return nil, fmt.Errorf("is04: decode source: %w", err)
+	}
+	if d.More() {
+		return nil, fmt.Errorf("is04: decode source: trailing JSON content")
+	}
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}

--- a/internal/amwa/provider/node.go
+++ b/internal/amwa/provider/node.go
@@ -1,0 +1,321 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	stdhttp "net/http"
+	"strconv"
+	"sync"
+	"sync/atomic"
+
+	dnssdcodec "acp/internal/amwa/codec/dnssd"
+	"acp/internal/amwa/codec/is04"
+	dnssdsession "acp/internal/amwa/session/dnssd"
+	httpsession "acp/internal/amwa/session/http"
+)
+
+// IS04NodeConfig is the runtime config for the Node API server. Bind
+// address, advertise host, mDNS mode, priority — separate from
+// NodeConfig (the file-loaded resource bundle).
+type IS04NodeConfig struct {
+	Bind          string
+	AdvertiseHost string
+	DiscoveryMode string // "mdns" | "static"
+	Priority      int
+	APIVer        string // default "v1.3"
+
+	// RegistryURL — when non-empty the producer also registers itself
+	// against this Registration API base (e.g. http://10.6.239.113:8235/).
+	// When empty, mDNS-only / direct-Node mode (Mode D peers).
+	RegistryURL string
+}
+
+// IS04NodeServer hosts the Node API endpoints + DNS-SD announce +
+// (optionally) the registration client.
+type IS04NodeServer struct {
+	logger *slog.Logger
+	cfg    IS04NodeConfig
+	bundle *NodeConfig
+
+	mu        sync.Mutex
+	http      *httpsession.Server
+	responder *dnssdsession.Responder
+	cancel    context.CancelFunc
+	regClient *RegistrationClient
+
+	// Per-endpoint hit counters.
+	indexHits     uint64
+	selfHits      uint64
+	deviceHits    uint64
+	sourceHits    uint64
+	flowHits      uint64
+	senderHits    uint64
+	receiverHits  uint64
+}
+
+// NewIS04NodeServer validates the Node bundle and prepares (but does
+// not start) the server.
+func NewIS04NodeServer(logger *slog.Logger, bundle *NodeConfig, cfg IS04NodeConfig) (*IS04NodeServer, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if bundle == nil {
+		return nil, errors.New("provider/node: nil bundle")
+	}
+	if err := validateBundle(bundle); err != nil {
+		return nil, fmt.Errorf("provider/node: %w", err)
+	}
+	if cfg.Bind == "" {
+		return nil, errors.New("provider/node: Bind required")
+	}
+	if cfg.APIVer == "" {
+		cfg.APIVer = is04.APIVersion
+	}
+	return &IS04NodeServer{logger: logger, cfg: cfg, bundle: bundle}, nil
+}
+
+// Serve binds the HTTP listener, optionally announces via DNS-SD,
+// optionally starts the Registration client, and blocks until ctx is
+// cancelled.
+func (s *IS04NodeServer) Serve(ctx context.Context) error {
+	s.mu.Lock()
+	if s.http != nil {
+		s.mu.Unlock()
+		return errors.New("provider/node: already serving")
+	}
+
+	srv := httpsession.NewServer(s.logger)
+	s.installRoutes(srv)
+	s.http = srv
+
+	// DNS-SD announce.
+	if s.cfg.DiscoveryMode == "" || s.cfg.DiscoveryMode == "mdns" {
+		host, port := splitHostPort(s.cfg.AdvertiseHost, s.cfg.Bind)
+		resp, err := dnssdsession.NewResponder(s.logger)
+		if err != nil {
+			s.mu.Unlock()
+			return fmt.Errorf("provider/node: open mDNS responder: %w", err)
+		}
+		ctxAnnounce, cancel := context.WithCancel(ctx)
+		s.responder = resp
+		s.cancel = cancel
+		ins := dnssdcodec.Instance{
+			Name:    "dhs-nmos-node",
+			Service: dnssdcodec.ServiceNode,
+			Domain:  dnssdcodec.DefaultDomain,
+			Host:    host,
+			Port:    uint16(port),
+			TXT: map[string]string{
+				dnssdcodec.TXTKeyAPIProto: "http",
+				dnssdcodec.TXTKeyAPIVer:   s.cfg.APIVer,
+				dnssdcodec.TXTKeyAPIAuth:  "false",
+				dnssdcodec.TXTKeyPriority: strconv.Itoa(s.cfg.Priority),
+			},
+		}
+		if err := resp.Announce(ctxAnnounce, ins); err != nil {
+			s.mu.Unlock()
+			_ = resp.Close()
+			return fmt.Errorf("provider/node: announce %s: %w", dnssdcodec.ServiceNode, err)
+		}
+		s.logger.Info("provider/node: mDNS announce active",
+			"service", dnssdcodec.ServiceNode, "host", host, "port", port,
+			"api_ver", s.cfg.APIVer, "pri", s.cfg.Priority)
+	}
+
+	// Registration client (optional).
+	if s.cfg.RegistryURL != "" {
+		rc := NewRegistrationClient(s.logger, s.cfg.RegistryURL, s.cfg.APIVer, s.bundle)
+		s.regClient = rc
+		go rc.Run(ctx)
+	}
+
+	s.mu.Unlock()
+	return srv.Serve(ctx, s.cfg.Bind)
+}
+
+// Stop tears down everything. Idempotent.
+func (s *IS04NodeServer) Stop() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.cancel != nil {
+		s.cancel()
+		s.cancel = nil
+	}
+	if s.responder != nil {
+		_ = s.responder.Close()
+		s.responder = nil
+	}
+	if s.regClient != nil {
+		_ = s.regClient.Close()
+	}
+	return nil
+}
+
+// Stats exposes per-endpoint hit counters.
+func (s *IS04NodeServer) Stats() map[string]uint64 {
+	return map[string]uint64{
+		"index":     atomic.LoadUint64(&s.indexHits),
+		"self":      atomic.LoadUint64(&s.selfHits),
+		"devices":   atomic.LoadUint64(&s.deviceHits),
+		"sources":   atomic.LoadUint64(&s.sourceHits),
+		"flows":     atomic.LoadUint64(&s.flowHits),
+		"senders":   atomic.LoadUint64(&s.senderHits),
+		"receivers": atomic.LoadUint64(&s.receiverHits),
+	}
+}
+
+// installRoutes wires every IS-04 v1.3 Node API endpoint into the HTTP
+// router. PUT /receivers/{id}/target is intentionally 501 — peers
+// should use IS-05 connection management instead.
+func (s *IS04NodeServer) installRoutes(srv *httpsession.Server) {
+	base := "/x-nmos/node/" + s.cfg.APIVer
+
+	srv.Handle(stdhttp.MethodGet, base+"/", func(ctx context.Context, r *stdhttp.Request) (int, any, error) {
+		atomic.AddUint64(&s.indexHits, 1)
+		return 0, []string{"self/", "devices/", "sources/", "flows/", "senders/", "receivers/"}, nil
+	})
+	srv.Handle(stdhttp.MethodGet, base+"/self", func(ctx context.Context, r *stdhttp.Request) (int, any, error) {
+		atomic.AddUint64(&s.selfHits, 1)
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		return 0, &s.bundle.Node, nil
+	})
+
+	// Devices, Sources, Flows, Senders, Receivers each have a list
+	// endpoint and a per-id endpoint. We register the list, and let
+	// the dispatcher 404 on unknown ids — there's no wildcard support
+	// in the route table, so per-id endpoints are installed at server
+	// start by walking the bundle.
+	s.installCollection(srv, base, "devices", func() any {
+		s.mu.Lock(); defer s.mu.Unlock(); atomic.AddUint64(&s.deviceHits, 1); return s.bundle.Devices
+	}, func(id string) (any, bool) {
+		s.mu.Lock(); defer s.mu.Unlock()
+		for i := range s.bundle.Devices {
+			if s.bundle.Devices[i].ID == id {
+				return &s.bundle.Devices[i], true
+			}
+		}
+		return nil, false
+	}, idsFromDevices(s.bundle.Devices))
+
+	s.installCollection(srv, base, "sources", func() any {
+		s.mu.Lock(); defer s.mu.Unlock(); atomic.AddUint64(&s.sourceHits, 1); return s.bundle.Sources
+	}, func(id string) (any, bool) {
+		s.mu.Lock(); defer s.mu.Unlock()
+		for i := range s.bundle.Sources {
+			if s.bundle.Sources[i].ID == id {
+				return &s.bundle.Sources[i], true
+			}
+		}
+		return nil, false
+	}, idsFromSources(s.bundle.Sources))
+
+	s.installCollection(srv, base, "flows", func() any {
+		s.mu.Lock(); defer s.mu.Unlock(); atomic.AddUint64(&s.flowHits, 1); return s.bundle.Flows
+	}, func(id string) (any, bool) {
+		s.mu.Lock(); defer s.mu.Unlock()
+		for i := range s.bundle.Flows {
+			if s.bundle.Flows[i].ID == id {
+				return &s.bundle.Flows[i], true
+			}
+		}
+		return nil, false
+	}, idsFromFlows(s.bundle.Flows))
+
+	s.installCollection(srv, base, "senders", func() any {
+		s.mu.Lock(); defer s.mu.Unlock(); atomic.AddUint64(&s.senderHits, 1); return s.bundle.Senders
+	}, func(id string) (any, bool) {
+		s.mu.Lock(); defer s.mu.Unlock()
+		for i := range s.bundle.Senders {
+			if s.bundle.Senders[i].ID == id {
+				return &s.bundle.Senders[i], true
+			}
+		}
+		return nil, false
+	}, idsFromSenders(s.bundle.Senders))
+
+	s.installCollection(srv, base, "receivers", func() any {
+		s.mu.Lock(); defer s.mu.Unlock(); atomic.AddUint64(&s.receiverHits, 1); return s.bundle.Receivers
+	}, func(id string) (any, bool) {
+		s.mu.Lock(); defer s.mu.Unlock()
+		for i := range s.bundle.Receivers {
+			if s.bundle.Receivers[i].ID == id {
+				return &s.bundle.Receivers[i], true
+			}
+		}
+		return nil, false
+	}, idsFromReceivers(s.bundle.Receivers))
+
+	// PUT /receivers/{id}/target → 501 Not Implemented (deprecated;
+	// use IS-05 instead). Fired per-id so the path matches exactly.
+	for _, r := range s.bundle.Receivers {
+		path := base + "/receivers/" + r.ID + "/target"
+		srv.Handle(stdhttp.MethodPut, path, func(ctx context.Context, r *stdhttp.Request) (int, any, error) {
+			return stdhttp.StatusNotImplemented, httpsession.ErrorBody{
+				Code:  stdhttp.StatusNotImplemented,
+				Error: "Not Implemented",
+				Debug: "PUT /receivers/{id}/target deprecated in IS-04 v1.3 — use IS-05 instead",
+			}, nil
+		})
+	}
+}
+
+// installCollection registers GET <base>/<plural> and per-id GETs.
+func (s *IS04NodeServer) installCollection(
+	srv *httpsession.Server, base, plural string,
+	listFn func() any, getFn func(string) (any, bool), ids []string,
+) {
+	srv.Handle(stdhttp.MethodGet, base+"/"+plural, func(ctx context.Context, r *stdhttp.Request) (int, any, error) {
+		return 0, listFn(), nil
+	})
+	for _, id := range ids {
+		path := base + "/" + plural + "/" + id
+		srv.Handle(stdhttp.MethodGet, path, func(ctx context.Context, r *stdhttp.Request) (int, any, error) {
+			body, ok := getFn(id)
+			if !ok {
+				return stdhttp.StatusNotFound, httpsession.ErrorBody{
+					Code: stdhttp.StatusNotFound, Error: "Not Found", Debug: id,
+				}, nil
+			}
+			return 0, body, nil
+		})
+	}
+}
+
+func idsFromDevices(in []is04.Device) []string {
+	out := make([]string, len(in))
+	for i, d := range in {
+		out[i] = d.ID
+	}
+	return out
+}
+func idsFromSources(in []is04.Source) []string {
+	out := make([]string, len(in))
+	for i, s := range in {
+		out[i] = s.ID
+	}
+	return out
+}
+func idsFromFlows(in []is04.Flow) []string {
+	out := make([]string, len(in))
+	for i, f := range in {
+		out[i] = f.ID
+	}
+	return out
+}
+func idsFromSenders(in []is04.Sender) []string {
+	out := make([]string, len(in))
+	for i, s := range in {
+		out[i] = s.ID
+	}
+	return out
+}
+func idsFromReceivers(in []is04.Receiver) []string {
+	out := make([]string, len(in))
+	for i, r := range in {
+		out[i] = r.ID
+	}
+	return out
+}

--- a/internal/amwa/provider/node_config.go
+++ b/internal/amwa/provider/node_config.go
@@ -1,0 +1,97 @@
+// Layer-3 IS-04 Node API provider — config loader.
+//
+// A Node serves its own resource graph: Node (singleton), Devices (1+),
+// Sources (0+), Flows (0+), Senders (0+), Receivers (0+). The producer
+// loads a single JSON file holding the union, validates each resource
+// against its IS-04 v1.3 schema, then serves the Node API on top.
+
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"acp/internal/amwa/codec/is04"
+)
+
+// NodeConfig is the on-disk Node bundle. Fields parallel the Node API
+// collections; the file is JSON, one section per resource type.
+type NodeConfig struct {
+	Node      is04.Node       `json:"node"`
+	Devices   []is04.Device   `json:"devices"`
+	Sources   []is04.Source   `json:"sources"`
+	Flows     []is04.Flow     `json:"flows"`
+	Senders   []is04.Sender   `json:"senders"`
+	Receivers []is04.Receiver `json:"receivers"`
+}
+
+// LoadNodeConfigFromFile reads + validates a Node config bundle.
+func LoadNodeConfigFromFile(path string) (*NodeConfig, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("provider/node: read %s: %w", path, err)
+	}
+	var cfg NodeConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return nil, fmt.Errorf("provider/node: %s: %w", path, err)
+	}
+	return &cfg, validateBundle(&cfg)
+}
+
+// validateBundle runs each resource's Validate + cross-resource
+// referential-integrity checks.
+func validateBundle(cfg *NodeConfig) error {
+	if err := cfg.Node.Validate(); err != nil {
+		return err
+	}
+	nodeID := cfg.Node.ID
+	deviceIDs := map[string]struct{}{}
+	for i := range cfg.Devices {
+		d := &cfg.Devices[i]
+		if err := d.Validate(); err != nil {
+			return fmt.Errorf("devices[%d]: %w", i, err)
+		}
+		if d.NodeID != nodeID {
+			return fmt.Errorf("devices[%d].node_id %q: must equal node.id %q", i, d.NodeID, nodeID)
+		}
+		deviceIDs[d.ID] = struct{}{}
+	}
+	for i := range cfg.Sources {
+		s := &cfg.Sources[i]
+		if err := s.Validate(); err != nil {
+			return fmt.Errorf("sources[%d]: %w", i, err)
+		}
+		if _, ok := deviceIDs[s.DeviceID]; !ok {
+			return fmt.Errorf("sources[%d].device_id %q: not declared under devices[]", i, s.DeviceID)
+		}
+	}
+	for i := range cfg.Flows {
+		f := &cfg.Flows[i]
+		if err := f.Validate(); err != nil {
+			return fmt.Errorf("flows[%d]: %w", i, err)
+		}
+		if _, ok := deviceIDs[f.DeviceID]; !ok {
+			return fmt.Errorf("flows[%d].device_id %q: not declared under devices[]", i, f.DeviceID)
+		}
+	}
+	for i := range cfg.Senders {
+		s := &cfg.Senders[i]
+		if err := s.Validate(); err != nil {
+			return fmt.Errorf("senders[%d]: %w", i, err)
+		}
+		if _, ok := deviceIDs[s.DeviceID]; !ok {
+			return fmt.Errorf("senders[%d].device_id %q: not declared under devices[]", i, s.DeviceID)
+		}
+	}
+	for i := range cfg.Receivers {
+		r := &cfg.Receivers[i]
+		if err := r.Validate(); err != nil {
+			return fmt.Errorf("receivers[%d]: %w", i, err)
+		}
+		if _, ok := deviceIDs[r.DeviceID]; !ok {
+			return fmt.Errorf("receivers[%d].device_id %q: not declared under devices[]", i, r.DeviceID)
+		}
+	}
+	return nil
+}

--- a/internal/amwa/provider/node_test.go
+++ b/internal/amwa/provider/node_test.go
@@ -1,0 +1,300 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"acp/internal/amwa/codec/is04"
+)
+
+func validNode() is04.Node {
+	chassis := "ff-ff-ff-ff-ff-ff"
+	return is04.Node{
+		ResourceCore: is04.ResourceCore{
+			ID: "f47ac10b-58cc-4372-a567-0e02b2c3d479", Version: "0:0",
+			Label: "lab-node", Description: "test", Tags: map[string][]string{},
+		},
+		Href: "http://10.6.239.113:8080/",
+		Caps: map[string]any{},
+		API: is04.NodeAPI{
+			Versions: []string{"v1.3"},
+			Endpoints: []is04.NodeEndpoint{{Host: "10.6.239.113", Port: 8080, Protocol: "http"}},
+		},
+		Services: []is04.NodeService{},
+		Clocks:   []is04.NodeClock{{Name: "clk0", RefType: "internal"}},
+		Interfaces: []is04.NodeIface{
+			{ChassisID: &chassis, PortID: "ff-ff-ff-ff-ff-ff", Name: "eth0"},
+		},
+	}
+}
+
+func validBundle() *NodeConfig {
+	n := validNode()
+	dev := is04.Device{
+		ResourceCore: is04.ResourceCore{
+			ID: "12345678-1234-4abc-9def-1234567890ab", Version: "0:0",
+			Label: "dev-1", Description: "lab dev", Tags: map[string][]string{},
+		},
+		Type:      "urn:x-nmos:device:generic",
+		NodeID:    n.ID,
+		Senders:   []string{},
+		Receivers: []string{},
+		Controls:  []is04.DeviceControl{},
+	}
+	return &NodeConfig{
+		Node:      n,
+		Devices:   []is04.Device{dev},
+		Sources:   []is04.Source{},
+		Flows:     []is04.Flow{},
+		Senders:   []is04.Sender{},
+		Receivers: []is04.Receiver{},
+	}
+}
+
+func TestLoadNodeConfigFromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "node.json")
+	raw, _ := json.MarshalIndent(validBundle(), "", "  ")
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	cfg, err := LoadNodeConfigFromFile(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.Node.ID != "f47ac10b-58cc-4372-a567-0e02b2c3d479" {
+		t.Fatalf("id = %q", cfg.Node.ID)
+	}
+}
+
+func TestValidateBundleRequiresMatchingNodeID(t *testing.T) {
+	b := validBundle()
+	b.Devices[0].NodeID = "aaaaaaaa-1234-4abc-9def-1234567890ab"
+	if err := validateBundle(b); err == nil || !strings.Contains(err.Error(), "node_id") {
+		t.Fatalf("expected node_id mismatch error, got %v", err)
+	}
+}
+
+func TestValidateBundleRequiresExistingDevice(t *testing.T) {
+	b := validBundle()
+	b.Sources = []is04.Source{
+		{
+			ResourceCore: is04.ResourceCore{
+				ID: "bbbbbbbb-1234-4abc-9def-1234567890ab", Version: "0:0",
+				Label: "src", Description: "x", Tags: map[string][]string{},
+			},
+			Caps:     map[string]any{},
+			DeviceID: "cccccccc-1234-4abc-9def-1234567890ab", // not in bundle
+			Parents:  []string{},
+			Format:   is04.FormatVideo,
+		},
+	}
+	if err := validateBundle(b); err == nil || !strings.Contains(err.Error(), "device_id") {
+		t.Fatalf("expected device_id ref error, got %v", err)
+	}
+}
+
+func TestNodeServerEndToEnd(t *testing.T) {
+	addr := freeAddr(t)
+	s, err := NewIS04NodeServer(nil, validBundle(), IS04NodeConfig{
+		Bind:          addr,
+		DiscoveryMode: "static",
+	})
+	if err != nil {
+		t.Fatalf("NewIS04NodeServer: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() { defer wg.Done(); _ = s.Serve(ctx) }()
+	defer func() {
+		cancel()
+		_ = s.Stop()
+		wg.Wait()
+	}()
+	if !waitReachable(t, "http://"+addr+"/__ready__", 2*time.Second) {
+		t.Fatal("server never came up")
+	}
+
+	// Index
+	resp, err := stdhttp.Get("http://" + addr + "/x-nmos/node/v1.3/")
+	if err != nil {
+		t.Fatalf("GET index: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != 200 {
+		t.Fatalf("index status %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	var idx []string
+	_ = json.Unmarshal(body, &idx)
+	if len(idx) != 6 {
+		t.Fatalf("index = %v", idx)
+	}
+
+	// /self
+	r2, _ := stdhttp.Get("http://" + addr + "/x-nmos/node/v1.3/self")
+	defer func() { _ = r2.Body.Close() }()
+	body2, _ := io.ReadAll(r2.Body)
+	var node is04.Node
+	if err := json.Unmarshal(body2, &node); err != nil {
+		t.Fatalf("decode /self: %v", err)
+	}
+	if node.ID != "f47ac10b-58cc-4372-a567-0e02b2c3d479" {
+		t.Fatalf("/self id = %q", node.ID)
+	}
+
+	// /devices (list)
+	r3, _ := stdhttp.Get("http://" + addr + "/x-nmos/node/v1.3/devices")
+	defer func() { _ = r3.Body.Close() }()
+	body3, _ := io.ReadAll(r3.Body)
+	var devs []is04.Device
+	if err := json.Unmarshal(body3, &devs); err != nil {
+		t.Fatalf("decode /devices: %v", err)
+	}
+	if len(devs) != 1 {
+		t.Fatalf("devices = %v", devs)
+	}
+
+	// /devices/{id}
+	r4, _ := stdhttp.Get("http://" + addr + "/x-nmos/node/v1.3/devices/12345678-1234-4abc-9def-1234567890ab")
+	defer func() { _ = r4.Body.Close() }()
+	if r4.StatusCode != 200 {
+		t.Fatalf("/devices/{id} status %d", r4.StatusCode)
+	}
+
+	// /devices/{wrong-id}
+	r5, _ := stdhttp.Get("http://" + addr + "/x-nmos/node/v1.3/devices/00000000-0000-1000-8000-000000000000")
+	defer func() { _ = r5.Body.Close() }()
+	if r5.StatusCode != 404 {
+		t.Fatalf("/devices/{wrong-id} status = %d", r5.StatusCode)
+	}
+
+	// Stats
+	stats := s.Stats()
+	if stats["self"] == 0 {
+		t.Fatalf("self counter not incremented: %+v", stats)
+	}
+}
+
+func TestRegistrationClientPostsAllResources(t *testing.T) {
+	var (
+		mu        sync.Mutex
+		posts     []string
+		deletes   []string
+		heartbeats int32
+	)
+	srv := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		switch {
+		case r.Method == stdhttp.MethodPost && strings.HasSuffix(r.URL.Path, "/resource"):
+			body, _ := io.ReadAll(r.Body)
+			env, err := is04.DecodeRegistration(body)
+			if err != nil {
+				w.WriteHeader(stdhttp.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			posts = append(posts, string(env.Type))
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(stdhttp.StatusCreated)
+			_, _ = io.WriteString(w, `{}`)
+		case r.Method == stdhttp.MethodPost && strings.Contains(r.URL.Path, "/health/nodes/"):
+			atomic.AddInt32(&heartbeats, 1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(stdhttp.StatusOK)
+			_, _ = io.WriteString(w, `{"health":"123"}`)
+		case r.Method == stdhttp.MethodDelete && strings.Contains(r.URL.Path, "/resource/"):
+			parts := strings.Split(r.URL.Path, "/")
+			mu.Lock()
+			deletes = append(deletes, parts[len(parts)-2]+"/"+parts[len(parts)-1])
+			mu.Unlock()
+			w.WriteHeader(stdhttp.StatusNoContent)
+		default:
+			w.WriteHeader(stdhttp.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	rc := NewRegistrationClient(nil, srv.URL, "v1.3", validBundle())
+	// Make heartbeat fire often so the test doesn't drag.
+	ctx, cancel := context.WithCancel(context.Background())
+	go rc.Run(ctx)
+
+	// Wait for at least one heartbeat.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && atomic.LoadInt32(&heartbeats) == 0 {
+		time.Sleep(20 * time.Millisecond)
+	}
+	cancel()
+	_ = rc.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(posts) < 2 {
+		t.Fatalf("expected node + at least 1 device POST, got %v", posts)
+	}
+	if posts[0] != "node" {
+		t.Fatalf("first POST should be node, got %v", posts)
+	}
+	if len(deletes) < 2 {
+		t.Fatalf("expected DELETEs on shutdown, got %v", deletes)
+	}
+	stats := rc.Stats()
+	if stats["registrations"] < 2 {
+		t.Fatalf("registrations counter low: %d", stats["registrations"])
+	}
+	if stats["deletions"] < 2 {
+		t.Fatalf("deletions counter low: %d", stats["deletions"])
+	}
+}
+
+func TestRegistrationClientReregistersOn404(t *testing.T) {
+	var (
+		registrations int32
+	)
+	srv := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		switch {
+		case r.Method == stdhttp.MethodPost && strings.HasSuffix(r.URL.Path, "/resource"):
+			atomic.AddInt32(&registrations, 1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(stdhttp.StatusCreated)
+			_, _ = io.WriteString(w, `{}`)
+		case r.Method == stdhttp.MethodPost && strings.Contains(r.URL.Path, "/health/nodes/"):
+			// Always 404 — Registry "lost" the node.
+			w.WriteHeader(stdhttp.StatusNotFound)
+		case r.Method == stdhttp.MethodDelete:
+			w.WriteHeader(stdhttp.StatusNoContent)
+		default:
+			w.WriteHeader(stdhttp.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	rc := NewRegistrationClient(nil, srv.URL, "v1.3", validBundle())
+	rc.http.Timeout = 1 * time.Second
+	ctx, cancel := context.WithCancel(context.Background())
+	go rc.Run(ctx)
+
+	// Two heartbeats should each trigger a re-register (Resource POSTs).
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) && rc.Stats()["reregister"] < 1 {
+		time.Sleep(100 * time.Millisecond)
+	}
+	cancel()
+	_ = rc.Close()
+
+	if rc.Stats()["reregister"] < 1 {
+		t.Fatalf("expected reregister to fire, stats=%+v", rc.Stats())
+	}
+}

--- a/internal/amwa/provider/registration_client.go
+++ b/internal/amwa/provider/registration_client.go
@@ -1,0 +1,310 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	stdhttp "net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"acp/internal/amwa/codec/is04"
+)
+
+// HeartbeatInterval is the IS-04 §6.1 default for POST
+// /health/nodes/{id} cadence — every 5 seconds.
+const HeartbeatInterval = 5 * time.Second
+
+// HeartbeatGracePeriod (12 s) is the spec default the Registry uses
+// to GC unresponsive Nodes; we re-register if heartbeats keep failing
+// past this.
+const HeartbeatGracePeriod = 12 * time.Second
+
+// ErrRegistryNotFound is returned by sendHeartbeat when the Registry
+// answers 404 — the Node has been GC'd and must re-register from
+// scratch.
+var ErrRegistryNotFound = errors.New("provider/node: registry returned 404 — re-registration required")
+
+// RegistrationClient drives the Node-side registration loop:
+//
+//   1. POST /resource for the Node, then each Device, Source, Flow,
+//      Sender, Receiver in dependency order (referential integrity:
+//      Sources before Flows, etc.).
+//   2. Heartbeat every 5 s via POST /health/nodes/{id}.
+//   3. On 404 from heartbeat → full re-registration.
+//   4. On Stop / shutdown → DELETE every owned resource (Receivers
+//      first, then Senders, Flows, Sources, Devices, Node).
+type RegistrationClient struct {
+	logger *slog.Logger
+
+	// Base URL of the Registration API including version, e.g.
+	// `http://10.6.239.113:8235/x-nmos/registration/v1.3`.
+	base   string
+	bundle *NodeConfig
+
+	http *stdhttp.Client
+
+	mu          sync.Mutex
+	cancelLoop  context.CancelFunc
+	registered  atomic.Bool
+	registrations uint64
+	heartbeats    uint64
+	reregister    uint64
+	deletions     uint64
+	failures      uint64
+
+	// closed signals the heartbeat loop to exit + DELETE has finished.
+	closed chan struct{}
+}
+
+// NewRegistrationClient builds an unstarted client. apiVer is the
+// IS-04 wire version (e.g. "v1.3"); registryURL must NOT include the
+// `/x-nmos/registration/...` path — we append it.
+func NewRegistrationClient(logger *slog.Logger, registryURL, apiVer string, bundle *NodeConfig) *RegistrationClient {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if apiVer == "" {
+		apiVer = is04.APIVersion
+	}
+	base := strings.TrimRight(registryURL, "/")
+	// Accept both forms: bare host (we append /x-nmos/registration/v1.3)
+	// or a URL that already includes the suffix.
+	if !strings.Contains(base, "/x-nmos/registration/") {
+		base = base + "/x-nmos/registration/" + apiVer
+	}
+	return &RegistrationClient{
+		logger: logger,
+		base:   base,
+		bundle: bundle,
+		http: &stdhttp.Client{
+			Timeout: 10 * time.Second,
+		},
+		closed: make(chan struct{}),
+	}
+}
+
+// Run drives the registration + heartbeat loop until ctx is
+// cancelled. Performs initial registration, starts the heartbeat
+// ticker, handles 404 → re-register, then deregisters on cancel.
+func (c *RegistrationClient) Run(ctx context.Context) {
+	defer close(c.closed)
+	loopCtx, cancel := context.WithCancel(ctx)
+	c.mu.Lock()
+	c.cancelLoop = cancel
+	c.mu.Unlock()
+
+	if err := c.registerAll(loopCtx); err != nil {
+		c.logger.Warn("provider/node: initial registration failed", "err", err)
+		atomic.AddUint64(&c.failures, 1)
+		// Keep trying via the heartbeat loop's reregister path.
+	}
+
+	ticker := time.NewTicker(HeartbeatInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-loopCtx.Done():
+			c.deregisterAll()
+			return
+		case <-ticker.C:
+			if !c.registered.Load() {
+				if err := c.registerAll(loopCtx); err != nil {
+					c.logger.Warn("provider/node: re-register attempt failed", "err", err)
+					atomic.AddUint64(&c.failures, 1)
+					continue
+				}
+			}
+			err := c.sendHeartbeat(loopCtx)
+			if errors.Is(err, ErrRegistryNotFound) {
+				c.logger.Warn("provider/node: heartbeat 404 — re-registering")
+				atomic.AddUint64(&c.reregister, 1)
+				c.registered.Store(false)
+			} else if err != nil {
+				c.logger.Warn("provider/node: heartbeat failed", "err", err)
+				atomic.AddUint64(&c.failures, 1)
+			}
+		}
+	}
+}
+
+// Close stops the loop and waits for deregistration to finish.
+func (c *RegistrationClient) Close() error {
+	c.mu.Lock()
+	if c.cancelLoop != nil {
+		c.cancelLoop()
+		c.cancelLoop = nil
+	}
+	c.mu.Unlock()
+	select {
+	case <-c.closed:
+	case <-time.After(2 * HeartbeatGracePeriod):
+		return errors.New("provider/node: deregistration timed out")
+	}
+	return nil
+}
+
+// Stats returns a snapshot of registration counters.
+func (c *RegistrationClient) Stats() map[string]uint64 {
+	return map[string]uint64{
+		"registrations": atomic.LoadUint64(&c.registrations),
+		"heartbeats":    atomic.LoadUint64(&c.heartbeats),
+		"reregister":    atomic.LoadUint64(&c.reregister),
+		"deletions":     atomic.LoadUint64(&c.deletions),
+		"failures":      atomic.LoadUint64(&c.failures),
+	}
+}
+
+// registerAll POSTs every owned resource in dependency order.
+func (c *RegistrationClient) registerAll(ctx context.Context) error {
+	if err := c.postResource(ctx, is04.ResourceNode, &c.bundle.Node); err != nil {
+		return err
+	}
+	for i := range c.bundle.Devices {
+		if err := c.postResource(ctx, is04.ResourceDevice, &c.bundle.Devices[i]); err != nil {
+			return err
+		}
+	}
+	for i := range c.bundle.Sources {
+		if err := c.postResource(ctx, is04.ResourceSource, &c.bundle.Sources[i]); err != nil {
+			return err
+		}
+	}
+	for i := range c.bundle.Flows {
+		if err := c.postResource(ctx, is04.ResourceFlow, &c.bundle.Flows[i]); err != nil {
+			return err
+		}
+	}
+	for i := range c.bundle.Senders {
+		if err := c.postResource(ctx, is04.ResourceSender, &c.bundle.Senders[i]); err != nil {
+			return err
+		}
+	}
+	for i := range c.bundle.Receivers {
+		if err := c.postResource(ctx, is04.ResourceReceiver, &c.bundle.Receivers[i]); err != nil {
+			return err
+		}
+	}
+	c.registered.Store(true)
+	return nil
+}
+
+func (c *RegistrationClient) postResource(ctx context.Context, t is04.ResourceType, data any) error {
+	body, err := is04.EncodeRegistration(t, data)
+	if err != nil {
+		return err
+	}
+	url := c.base + "/resource"
+	req, err := stdhttp.NewRequestWithContext(ctx, stdhttp.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("provider/node: build POST: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("provider/node: POST %s/resource: %w", c.base, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != stdhttp.StatusOK && resp.StatusCode != stdhttp.StatusCreated {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("provider/node: POST resource (%s): HTTP %d: %s",
+			t, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	atomic.AddUint64(&c.registrations, 1)
+	return nil
+}
+
+// sendHeartbeat POSTs to /health/nodes/{node-id}. Returns
+// ErrRegistryNotFound on 404, generic error on other failures, nil on
+// 200.
+func (c *RegistrationClient) sendHeartbeat(ctx context.Context) error {
+	url := c.base + "/health/nodes/" + c.bundle.Node.ID
+	req, err := stdhttp.NewRequestWithContext(ctx, stdhttp.MethodPost, url, nil)
+	if err != nil {
+		return fmt.Errorf("provider/node: build heartbeat: %w", err)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("provider/node: POST %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == stdhttp.StatusNotFound {
+		return ErrRegistryNotFound
+	}
+	if resp.StatusCode != stdhttp.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("provider/node: heartbeat: HTTP %d: %s",
+			resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	// Discard the response body — we don't track Registry-side TTL
+	// today; the spec only requires us to POST.
+	_, _ = io.Copy(io.Discard, resp.Body)
+	atomic.AddUint64(&c.heartbeats, 1)
+	return nil
+}
+
+// deregisterAll DELETEs every owned resource in REVERSE dependency
+// order (Receivers first, Node last). Best-effort — failures are
+// logged but don't block shutdown.
+func (c *RegistrationClient) deregisterAll() {
+	if !c.registered.Load() {
+		return
+	}
+	delCtx, cancel := context.WithTimeout(context.Background(), HeartbeatGracePeriod)
+	defer cancel()
+	// Reverse order
+	for i := range c.bundle.Receivers {
+		c.deleteResource(delCtx, is04.ResourceReceiver, c.bundle.Receivers[i].ID)
+	}
+	for i := range c.bundle.Senders {
+		c.deleteResource(delCtx, is04.ResourceSender, c.bundle.Senders[i].ID)
+	}
+	for i := range c.bundle.Flows {
+		c.deleteResource(delCtx, is04.ResourceFlow, c.bundle.Flows[i].ID)
+	}
+	for i := range c.bundle.Sources {
+		c.deleteResource(delCtx, is04.ResourceSource, c.bundle.Sources[i].ID)
+	}
+	for i := range c.bundle.Devices {
+		c.deleteResource(delCtx, is04.ResourceDevice, c.bundle.Devices[i].ID)
+	}
+	c.deleteResource(delCtx, is04.ResourceNode, c.bundle.Node.ID)
+	c.registered.Store(false)
+}
+
+func (c *RegistrationClient) deleteResource(ctx context.Context, t is04.ResourceType, id string) {
+	url := c.base + "/resource/" + t.Plural() + "/" + id
+	req, err := stdhttp.NewRequestWithContext(ctx, stdhttp.MethodDelete, url, nil)
+	if err != nil {
+		c.logger.Warn("provider/node: build DELETE", "err", err)
+		atomic.AddUint64(&c.failures, 1)
+		return
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		c.logger.Warn("provider/node: DELETE", "type", t, "id", id, "err", err)
+		atomic.AddUint64(&c.failures, 1)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != stdhttp.StatusNoContent && resp.StatusCode != stdhttp.StatusNotFound {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		c.logger.Warn("provider/node: DELETE non-204",
+			"type", t, "id", id, "status", resp.StatusCode, "body", string(body))
+		atomic.AddUint64(&c.failures, 1)
+		return
+	}
+	atomic.AddUint64(&c.deletions, 1)
+}
+
+// MarshalNode renders the node bundle's Node as JSON. Used by tests.
+func (c *RegistrationClient) MarshalNode() ([]byte, error) {
+	return json.Marshal(c.bundle.Node)
+}


### PR DESCRIPTION
Closes #154. Phase 1 step #3 of NMOS plugin epic #146, per [\`internal/amwa/docs/sequenced-tasks.md\`](internal/amwa/docs/sequenced-tasks.md) §1 #3.

**Spec source:** AMWA NMOS IS-04 v1.3.3 — https://specs.amwa.tv/is-04/releases/v1.3.3/. Spec-strict, no workarounds.

## What lands

| Layer | Package | Surface |
|---|---|---|
| 1 | \`internal/amwa/codec/is04\` | Node + Device + Source + Flow + Sender + Receiver Go structs matching IS-04 v1.3 schemas; Validate per resource (uuid pattern, version pattern, URN namespace, MAC pattern, integer ranges); DisallowUnknownFields on every Decode; Registration envelope \`{type, data}\` + HealthResponse types. |
| 3 | \`internal/amwa/provider/node_config.go\` | NodeConfig — single JSON file holding the union; cross-resource referential-integrity validation. |
| 3 | \`internal/amwa/provider/node.go\` | IS04NodeServer — every IS-04 v1.3 Node API endpoint exactly per RAML; per-id routes installed at server start. PUT /receivers/{id}/target → 501 (deprecated; use IS-05). |
| 3 | \`internal/amwa/provider/registration_client.go\` | RegistrationClient — POST /resource for Node + every Device + Source + Flow + Sender + Receiver in dependency order; POST /health/nodes/{id} every 5 s; on heartbeat 404 → \`ErrRegistryNotFound\` + full re-register; on Stop → reverse-order DELETE. |
| 4 | \`cmd/dhs/cmd_nmos.go\` | \`dhs producer nmos serve --role node --config FILE [--bind :8080] [--mdns/--no-mdns] [--registry URL] [--api-ver v1.3] [--priority N]\`. |

## Wire surface

Node API endpoints exactly per [https://specs.amwa.tv/is-04/releases/v1.3.3/APIs/NodeAPI.html](https://specs.amwa.tv/is-04/releases/v1.3.3/APIs/NodeAPI.html). Registration client per [RegistrationAPI.html](https://specs.amwa.tv/is-04/releases/v1.3.3/APIs/RegistrationAPI.html).

## Validation enforced (codec)

- \`id\` UUID v1-5 pattern (rejects v6+).
- \`version\` \`<sec>:<nsec>\` TAI form.
- \`api.versions[]\` \`vMAJOR.MINOR\` form.
- \`api.endpoints[].port\` 1-65535; \`.protocol\` ∈ {http, https}.
- \`interfaces[].port_id\` lowercase-hex MAC \`xx-xx-xx-xx-xx-xx\`.
- \`device.type\` URN namespace rule (urn:x-nmos:device:* OR non-NMOS URI).
- \`source.format\` / \`flow.format\` / \`receiver.format\` URN — known NMOS format URN OR non-NMOS URI.
- \`sender.transport\` / \`receiver.transport\` URN — known NMOS transport URN OR non-NMOS URI.
- Format-specific: source_audio.channels[] required when format=audio; flow_video requires frame_width/frame_height; flow_audio requires sample_rate; flow_video.interlace_mode enum.
- Cross-resource: every device.node_id == node.id; every source/flow/sender/receiver.device_id is in devices[].
- DisallowUnknownFields on every Decode.

## Tests

- \`internal/amwa/codec/is04\` — happy round-trip + every rejection rule per resource type.
- \`internal/amwa/provider\` — config loader happy + bad JSON; cross-ref-integrity rejection (mismatched node_id, dangling device_id); IS04NodeServer end-to-end (boot static + curl every endpoint + 404 on unknown id + hit-counter verification); RegistrationClient against httptest stub — POSTs in dependency order, heartbeat counter, DELETEs on shutdown; 404 heartbeat triggers ErrRegistryNotFound + re-register fires.

## Live verification (Mode A self-loop, 2026-04-30)

```
$ dhs producer nmos serve --role node --config node-bundle.json \
      --bind 127.0.0.1:18080 --no-mdns
Node API: bind=127.0.0.1:18080, mode=static, api_ver=v1.3, priority=0

$ for p in "" self devices "devices/<id>" sources flows senders receivers; do
      curl http://127.0.0.1:18080/x-nmos/node/v1.3/$p
  done
["self/","devices/","sources/","flows/","senders/","receivers/"]
{"id":"f47ac10b-…","label":"dhs lab Node",...}
[{"id":"12345678-…","label":"dev-1",...}]
[], [], [], []
```

## Out of scope (deferred per phase)

- IS-04 v1.2 / v1.1 back-compat (#4b).
- Registry HTTP face (Phase 1 #4 / N7).
- Controller WS subscription client (Phase 1 #5 / N8).
- BCP-002 / BCP-004 / BCP-006-* validators (Phase 1 #6 / N9).
- PUT /receivers/{id}/target body handling — returns 501 per spec note.

## Test plan

- [x] \`go build ./...\` + \`go vet ./...\` green
- [x] \`go test ./...\` green
- [x] \`golangci-lint run ./...\` green
- [x] Mode A self-loop verified — every endpoint round-trips
- [ ] Awaiting integration sweep at end of N9 (per user directive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)