### PR TITLE
feat(nmos): codec base — spec.Versioned + Registry[T] + Reporter (Step 1)

### DIFF
--- a/internal/amwa/CLAUDE.md
+++ b/internal/amwa/CLAUDE.md
@@ -265,6 +265,91 @@ Enforcement: depguard golangci-lint rule + `go list -deps` audit test
 + PR review checklist. Full rules + inter-codec dependency graph + CI
 config in [`docs/dependencies.md`](docs/dependencies.md).
 
+---
+
+## Codec architecture (locked pattern — every NMOS spec)
+
+Every NMOS spec MUST implement **every stable version listed above**,
+not just the latest. To make that tractable across the whole 14-spec
+suite — and to keep the cost of supporting a future v1.4 / v2.0
+constant rather than linear — every spec follows ONE locked codec
+pattern. The shared base is in
+[`internal/amwa/codec/spec/`](codec/spec/) and is stdlib-only.
+
+### Roles per layer (Layer 1, codec)
+
+```
+internal/amwa/codec/
+  spec/                          # NMOS-wide base (Versioned interface, generic Registry[T],
+                                 # SelectHighestMutual, ComplianceEvent + Reporter)
+  is04/  is05/  is07/  is08/     # one folder per spec — canonical structs + Codec interface
+  is09/  is12/  ms0501/  ms0502/
+    codec.go                     # extends spec.Versioned with the spec's resource methods
+    {node,device,...}.go         # canonical union structs (every minor's fields, omitempty)
+    patterns.go enums.go         # shared regex / URN tables
+    v10/  v11/  v12/  v13/       # per-minor Strategy impls (~50–100 LOC each)
+      codec.go                   # implements the spec's Codec interface for ONE wire minor
+
+  bcp/                           # JSON-shape validators (no own wire — layer onto host spec)
+    bcp00201/  bcp00202/         # BCP-002-01 / 002-02
+    bcp00401/  bcp00402/         # BCP-004-01 / 002-02
+    bcp00601/  bcp00604/         # BCP-006-01 / 006-04
+    bcp00801/  bcp00802/         # BCP-008-01 / 008-02
+```
+
+### OOP principles enforced
+
+| Principle | Mechanism |
+|---|---|
+| **Encapsulation** | Per-minor field-gating + per-minor validation rules live inside each `vXX.Codec` impl. The plugin layer never sees minor-specific logic. |
+| **Open/closed** | New minor (e.g. IS-04 v1.4 when AMWA ships it) = +1 file `v14/codec.go` + 1 init-time `Register` call. Zero edits to existing files. New spec (e.g. IS-13 when stable) = +1 folder following the template. |
+| **Liskov substitution** | Any `Codec` interchangeable on the Registry store, Node API server, Controller client. Plugin code receives `is04.Codec` from `spec.Registry[is04.Codec]`. |
+| **Single responsibility** | `spec/` is contracts + cross-cutting infra only. Per-spec packages hold canonical types. `vXX/` packages hold version deltas only. Plugin layer holds business logic only. |
+| **Interface segregation** | `spec.Versioned` is three methods. Per-spec `Codec` interfaces extend it with only that spec's resource methods. No god-interface. |
+| **Dependency inversion** | Plugin code depends on `spec.Versioned` + per-spec `Codec` interface, never on `vXX/*` directly. depguard rule enforces this in CI. Concrete impls are wired in via `init()` registration; tests substitute fakes via DI. |
+
+### Idempotent registration
+
+`spec.Registry[T].Register` is safe to call repeatedly with the same
+instance under the same `(SpecID, APIVer)` key. Calling with a
+different instance under an already-registered key panics — that's a
+duplicate-init bug. Empty SpecID / APIVer / SpecPatch panic. Same
+semantics as `internal/protocol.Register`.
+
+### Cross-cutting concerns in `spec/`
+
+- **Version selection.** `spec.SelectHighestMutual` picks the highest
+  version mutually supported between us and a peer's `api_ver` TXT.
+  Returns `ErrNoCommonVersion` (typed) when intersection is empty so
+  the caller fires a compliance event — never silently downgrade.
+- **Compliance events.** `spec.ComplianceEvent` carries
+  `(SpecID, APIVer, SpecPatch, Code, Severity, Detail, Resource,
+  PeerHost, At)`. `spec.Reporter` is the DI seam codecs use to emit
+  events. Production wires a logger-backed reporter via
+  `cmd/dhs/cmd_nmos.go`; tests pass `*spec.SliceReporter` for
+  assertion. Codecs NEVER reach into a global.
+- **No silent workarounds.** Per top-level CLAUDE.md "Spec-strict,
+  no-workaround posture", every absorbed deviation MUST fire a
+  ComplianceEvent — the codec keeps decoding, but the deviation is
+  audited.
+
+### Spec-strict version coverage rule
+
+Skipping any minor listed in the [Versioning](#versioning) table is a
+**spec violation**, not a deferral. The plugin owes:
+
+- DNS-SD `api_ver` TXT advertises every supported minor
+  comma-separated.
+- Server URL trees serve every minor in parallel
+  (`/x-nmos/<api>/v1.1/`, `/v1.2/`, `/v1.3/`, …) on one canonical
+  store.
+- Highest-mutual-minor selection on every peer handshake; never
+  silently downgrade outside the intersection.
+
+WIP-at-AMWA specs (IS-13 Annotation, BCP-006-02 H.264,
+BCP-006-03 H.265, BCP-007-01 NDI) are the only legitimate "not yet"
+scope — they land when AMWA stabilises them.
+
 ## Conformance gate — AMWA NMOS Testing tool
 
 Every NMOS PR that ships an implementation chunk MUST pass the matching

--- a/internal/amwa/codec/spec/compliance.go
+++ b/internal/amwa/codec/spec/compliance.go
@@ -1,0 +1,112 @@
+package spec
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// ComplianceEvent is the cross-cutting record of a peer-side spec
+// deviation absorbed by an NMOS codec or plugin. Every NMOS spec
+// fires events through the same shape so logs, metrics, and the
+// future Grafana board look identical regardless of which spec
+// flagged the deviation.
+//
+// "Absorb-and-fire-event" is the project's no-workaround policy
+// (top-level CLAUDE.md "Spec-strict, no-workaround posture"): the
+// codec keeps decoding instead of crashing, but it does NOT silently
+// patch the deviation away. Every event is auditable.
+//
+// Fields mirror the cross-protocol compliance.Event shape from
+// internal/protocol/compliance/, with NMOS-specific identifiers
+// (SpecID + APIVer + SpecPatch) added so reports stay attributable
+// across the 14-spec suite.
+type ComplianceEvent struct {
+	SpecID    string    // e.g. "is-04"
+	APIVer    string    // e.g. "v1.3"
+	SpecPatch string    // e.g. "v1.3.3"
+	Code      string    // stable machine slug, e.g. "nmos_query_api_missing"
+	Severity  Severity  // info / warn / error
+	Detail    string    // free-form human-readable
+	Resource  string    // optional: UUID / URL of the affected resource
+	PeerHost  string    // optional: peer host:port that emitted the deviation
+	At        time.Time // when the deviation was observed
+}
+
+// Severity classifies a compliance event for log filtering.
+type Severity int
+
+const (
+	// SeverityInfo records a deviation that is harmless — a peer
+	// quirk that the spec arguably allows or that we can absorb
+	// transparently. Default for "wire shape OK but unusual".
+	SeverityInfo Severity = iota
+	// SeverityWarn records a deviation that breaks an interop
+	// expectation but does not fail the local operation — e.g.
+	// a vendor's Query API returning [] for a populated catalogue.
+	SeverityWarn
+	// SeverityError records a deviation that fails the operation —
+	// e.g. a malformed JSON body, a missing required field, or
+	// no mutually-supported version.
+	SeverityError
+)
+
+// String renders the severity for log lines. Stable wire format —
+// CI greps on these strings.
+func (s Severity) String() string {
+	switch s {
+	case SeverityInfo:
+		return "info"
+	case SeverityWarn:
+		return "warn"
+	case SeverityError:
+		return "error"
+	default:
+		return fmt.Sprintf("severity(%d)", int(s))
+	}
+}
+
+// Reporter is the dependency-injection seam codecs use to emit
+// compliance events. Plugin code passes one through the constructor;
+// codecs never reach into a global. Tests pass a [SliceReporter] that
+// records events for assertion; production passes a logger-backed
+// adapter wired via DI in cmd/dhs.
+//
+// Implementations MUST be safe for concurrent use — codecs may fire
+// events from goroutines handling distinct connections.
+type Reporter interface {
+	Report(ComplianceEvent)
+}
+
+// NopReporter discards every event. Useful as a default value when
+// a caller has not yet wired a real reporter; callers should NEVER
+// pass nil to a codec — pass NopReporter{} instead.
+type NopReporter struct{}
+
+// Report on NopReporter is a no-op.
+func (NopReporter) Report(ComplianceEvent) {}
+
+// SliceReporter records every event in an in-memory slice. Test
+// helper; codecs in production take a logger-backed Reporter
+// instead.
+type SliceReporter struct {
+	mu     sync.Mutex
+	events []ComplianceEvent
+}
+
+// Report appends the event under the internal mutex.
+func (s *SliceReporter) Report(e ComplianceEvent) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, e)
+}
+
+// Snapshot returns a copy of every event recorded so far. Safe to
+// call concurrently with Report.
+func (s *SliceReporter) Snapshot() []ComplianceEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]ComplianceEvent, len(s.events))
+	copy(out, s.events)
+	return out
+}

--- a/internal/amwa/codec/spec/doc.go
+++ b/internal/amwa/codec/spec/doc.go
@@ -1,0 +1,52 @@
+// Package spec is the NMOS-wide codec base — the cross-cutting contract
+// every AMWA NMOS specification implementation satisfies.
+//
+// NMOS is a suite of ~14 specifications (IS-04, IS-05, IS-07, IS-08,
+// IS-09, IS-12, MS-05-01, MS-05-02, plus the BCP-* JSON-shape
+// validators) that collectively define the AMWA Networked Media Open
+// Specifications stack. Every spec has multiple stable versions that
+// MUST coexist on the wire (DNS-SD `api_ver` TXT advertises every
+// supported minor; URL trees serve every minor in parallel). The
+// dhs NMOS plugin is required to implement every track listed in
+// `internal/amwa/CLAUDE.md` "Versioning" and `internal/amwa/reference.md`.
+//
+// To keep the cost of supporting every current AND future version
+// tractable, every NMOS codec follows the same pattern locked in this
+// package:
+//
+//   - One canonical Go struct per resource type (union of every
+//     minor's fields, tagged json:",omitempty"). Stored once in the
+//     spec's package (e.g. is04.Node, is05.StagedSender).
+//
+//   - One Codec interface per spec, extending [Versioned] with the
+//     spec's encode / decode / validate methods.
+//
+//   - One concrete Codec impl per minor, in vXX/ subpackages. Each
+//     impl is a thin Strategy: it gates which canonical fields appear
+//     on its wire and which validation rules apply. Adding a new
+//     minor (e.g. IS-04 v1.4 when AMWA ships it) is +1 file +
+//     1 init-time Register call — zero edits to existing code.
+//
+//   - One per-spec Registry[T] (instantiated from this package's
+//     generic helper), populated at process start by each minor's
+//     init(). Plugin code looks up codecs through the interface,
+//     never through concrete versions.
+//
+//   - Per-spec [SelectHighestMutual] consults the registry to
+//     pick the highest version mutually supported between us and a
+//     peer. Peers that advertise a version we don't implement, OR vice
+//     versa, fire a [ComplianceEvent].
+//
+// This package itself is stdlib-only (per the layer-1 codec rule
+// from `internal/amwa/CLAUDE.md`). No spec-specific knowledge leaks
+// here — only the contract.
+//
+// # Idempotence
+//
+// Every public function is referentially transparent given the same
+// input. [Registry.Register] is the one stateful operation; calling it
+// repeatedly with the same Versioned instance is a no-op. Registering
+// a different instance under the same (SpecID, APIVer) key is a
+// programming error and panics — same semantics as
+// [internal/protocol].Register.
+package spec

--- a/internal/amwa/codec/spec/registry.go
+++ b/internal/amwa/codec/spec/registry.go
@@ -1,0 +1,142 @@
+package spec
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// Registry is the per-spec map of APIVer → codec implementation. Each
+// AMWA NMOS spec package (is04, is05, is07, …) instantiates one of
+// these and exposes thin wrappers for the plugin layer to call. Each
+// minor's init() populates the registry by calling Register exactly
+// once.
+//
+// The type parameter T is the spec-specific Codec interface (which
+// itself extends [Versioned]) — e.g. is04.Codec, is05.Codec. This
+// keeps lookup type-safe: is04.Get returns is04.Codec, not a generic
+// Versioned, so callers don't need type assertions.
+//
+// All operations are safe for concurrent use. Register is the only
+// mutating op; everything else is read-only and lock-cheap (RWMutex).
+type Registry[T Versioned] struct {
+	mu       sync.RWMutex
+	specID   string         // captured from first Register call; subsequent calls must match
+	byVer    map[string]T   // APIVer → codec
+	versions []string       // APIVer list, sorted ascending semver
+}
+
+// NewRegistry constructs an empty per-spec Registry. The plugin's spec
+// package holds one of these as a package-level var; init()s in vXX/
+// subpackages populate it.
+func NewRegistry[T Versioned]() *Registry[T] {
+	return &Registry[T]{
+		byVer: map[string]T{},
+	}
+}
+
+// Register installs a codec under its (SpecID, APIVer) pair. Called
+// from each minor's init().
+//
+// Register is idempotent: calling it twice with the same instance for
+// the same key is a no-op. Calling it with a different instance under
+// an already-registered key panics — that's a programming error
+// (two minor packages claiming the same APIVer, or a typo in
+// SpecID). Same semantics as protocol.Register.
+//
+// Registering codecs for different SpecIDs in the same Registry also
+// panics — Registry is per-spec. The first Register call captures the
+// SpecID; subsequent calls must match.
+//
+// Empty SpecID, empty APIVer, or empty SpecPatch panic — these are
+// always programming errors, never legitimate runtime input.
+func (r *Registry[T]) Register(c T) {
+	specID := strings.ToLower(strings.TrimSpace(c.SpecID()))
+	apiVer := strings.ToLower(strings.TrimSpace(c.APIVer()))
+	specPatch := strings.TrimSpace(c.SpecPatch())
+	if specID == "" {
+		panic("spec.Register: empty SpecID")
+	}
+	if apiVer == "" {
+		panic(fmt.Sprintf("spec.Register: empty APIVer for SpecID %q", specID))
+	}
+	if specPatch == "" {
+		panic(fmt.Sprintf("spec.Register: empty SpecPatch for %s/%s", specID, apiVer))
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.specID == "" {
+		r.specID = specID
+	} else if r.specID != specID {
+		panic(fmt.Sprintf(
+			"spec.Register: SpecID mismatch — registry holds %q, got %q",
+			r.specID, specID,
+		))
+	}
+
+	if existing, dup := r.byVer[apiVer]; dup {
+		// Idempotent if the caller passes the exact same instance.
+		// Different instance under same key is a duplicate-init bug.
+		if any(existing) == any(c) {
+			return
+		}
+		panic(fmt.Sprintf(
+			"spec.Register: duplicate registration for %s/%s",
+			specID, apiVer,
+		))
+	}
+	r.byVer[apiVer] = c
+	r.versions = append(r.versions, apiVer)
+	sort.Strings(r.versions)
+}
+
+// Get returns the codec for an APIVer. The boolean is false when no
+// such version is registered — caller decides whether to fire a
+// compliance event or surface an error to the peer.
+//
+// APIVer comparison is case-insensitive and ignores leading/trailing
+// whitespace; everything else (including the leading "v") must match
+// exactly.
+func (r *Registry[T]) Get(apiVer string) (T, bool) {
+	key := strings.ToLower(strings.TrimSpace(apiVer))
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	c, ok := r.byVer[key]
+	return c, ok
+}
+
+// AllCodecs returns every registered codec sorted by APIVer ascending.
+// Plugin code uses this to install per-minor URL routes. The returned
+// slice is a fresh copy — safe to mutate.
+func (r *Registry[T]) AllCodecs() []T {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]T, 0, len(r.versions))
+	for _, v := range r.versions {
+		out = append(out, r.byVer[v])
+	}
+	return out
+}
+
+// SupportedVersions returns every registered APIVer string sorted
+// ascending — e.g. ["v1.1", "v1.2", "v1.3"]. The DNS-SD announcer
+// uses this to publish the `api_ver` TXT comma-list.
+func (r *Registry[T]) SupportedVersions() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]string, len(r.versions))
+	copy(out, r.versions)
+	return out
+}
+
+// SpecID returns the slug captured from the first Register call, or
+// "" if the registry is empty. Useful for compliance-event reports
+// and log lines that need to identify the spec without holding a
+// concrete codec.
+func (r *Registry[T]) SpecID() string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.specID
+}

--- a/internal/amwa/codec/spec/selector.go
+++ b/internal/amwa/codec/spec/selector.go
@@ -1,0 +1,117 @@
+package spec
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// SelectHighestMutual picks the highest APIVer mutually supported
+// between this Registry and a peer's advertised list. It implements
+// the IS-04 §3 selection rule: filter by intersection, prefer highest
+// minor — never silently downgrade outside the intersection.
+//
+// peerVersions is the comma-split set from the peer's `api_ver` TXT
+// (or the equivalent field in IS-09's `is-04` block). Whitespace and
+// case are tolerated; ordering does not matter.
+//
+// Returns ErrNoCommonVersion when the intersection is empty — the
+// caller fires a compliance event and refuses the peer.
+func SelectHighestMutual[T Versioned](r *Registry[T], peerVersions []string) (T, error) {
+	var zero T
+	if r == nil {
+		return zero, fmt.Errorf("spec.SelectHighestMutual: nil Registry")
+	}
+
+	peer := normalisePeerVersions(peerVersions)
+	mine := r.SupportedVersions()
+
+	// Sort our supported versions descending so the first match wins.
+	descending := make([]string, len(mine))
+	copy(descending, mine)
+	sort.Slice(descending, func(i, j int) bool {
+		return compareAPIVer(descending[i], descending[j]) > 0
+	})
+
+	for _, v := range descending {
+		if peer[v] {
+			c, _ := r.Get(v)
+			return c, nil
+		}
+	}
+	return zero, ErrNoCommonVersion{
+		SpecID:        r.SpecID(),
+		Mine:          mine,
+		PeerAdvertised: peerVersions,
+	}
+}
+
+// normalisePeerVersions trims whitespace + lower-cases each entry,
+// drops empties, and returns a set keyed by canonical APIVer.
+func normalisePeerVersions(in []string) map[string]bool {
+	out := map[string]bool{}
+	for _, v := range in {
+		v = strings.ToLower(strings.TrimSpace(v))
+		if v != "" {
+			out[v] = true
+		}
+	}
+	return out
+}
+
+// compareAPIVer returns -1 / 0 / +1 for semver-style major.minor APIVer
+// strings ("v1.2" < "v1.3" < "v2.0"). Strings without a leading "v"
+// or with non-numeric components compare lexicographically as a
+// fallback so we never panic on malformed input.
+func compareAPIVer(a, b string) int {
+	am, an, ok1 := splitAPIVer(a)
+	bm, bn, ok2 := splitAPIVer(b)
+	if !ok1 || !ok2 {
+		return strings.Compare(a, b)
+	}
+	if am != bm {
+		if am < bm {
+			return -1
+		}
+		return 1
+	}
+	if an != bn {
+		if an < bn {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}
+
+func splitAPIVer(v string) (major, minor int, ok bool) {
+	v = strings.TrimSpace(v)
+	v = strings.TrimPrefix(v, "v")
+	parts := strings.SplitN(v, ".", 2)
+	if len(parts) != 2 {
+		return 0, 0, false
+	}
+	maj, err1 := strconv.Atoi(parts[0])
+	min, err2 := strconv.Atoi(parts[1])
+	if err1 != nil || err2 != nil {
+		return 0, 0, false
+	}
+	return maj, min, true
+}
+
+// ErrNoCommonVersion fires when the peer's advertised version set
+// shares no entries with our registered codecs. Plugin code formats
+// it into a compliance event and refuses the peer.
+type ErrNoCommonVersion struct {
+	SpecID         string
+	Mine           []string
+	PeerAdvertised []string
+}
+
+func (e ErrNoCommonVersion) Error() string {
+	return fmt.Sprintf(
+		"%s: no mutually-supported version (we offer %v, peer advertised %v)",
+		e.SpecID, e.Mine, e.PeerAdvertised,
+	)
+}

--- a/internal/amwa/codec/spec/spec_test.go
+++ b/internal/amwa/codec/spec/spec_test.go
@@ -1,0 +1,276 @@
+package spec
+
+import (
+	"errors"
+	"reflect"
+	"sync"
+	"testing"
+)
+
+// fakeCodec is a minimal Versioned impl for testing the registry
+// without dragging an actual NMOS spec package in.
+type fakeCodec struct {
+	specID    string
+	apiVer    string
+	specPatch string
+}
+
+func (f fakeCodec) SpecID() string    { return f.specID }
+func (f fakeCodec) APIVer() string    { return f.apiVer }
+func (f fakeCodec) SpecPatch() string { return f.specPatch }
+
+func TestRegistryRegisterAndGet(t *testing.T) {
+	r := NewRegistry[fakeCodec]()
+	c11 := fakeCodec{"is-04", "v1.1", "v1.1.3"}
+	c12 := fakeCodec{"is-04", "v1.2", "v1.2.2"}
+	c13 := fakeCodec{"is-04", "v1.3", "v1.3.3"}
+	r.Register(c11)
+	r.Register(c12)
+	r.Register(c13)
+
+	if got, _ := r.Get("v1.2"); got != c12 {
+		t.Fatalf("Get v1.2 = %v, want %v", got, c12)
+	}
+	if got, ok := r.Get("v9.9"); ok {
+		t.Fatalf("Get v9.9 should miss, got %v", got)
+	}
+	if r.SpecID() != "is-04" {
+		t.Fatalf("SpecID = %q", r.SpecID())
+	}
+}
+
+func TestRegistryGetIsCaseInsensitive(t *testing.T) {
+	r := NewRegistry[fakeCodec]()
+	r.Register(fakeCodec{"is-04", "v1.3", "v1.3.3"})
+	for _, k := range []string{"v1.3", "V1.3", "  v1.3  "} {
+		if _, ok := r.Get(k); !ok {
+			t.Fatalf("Get %q should hit", k)
+		}
+	}
+}
+
+func TestRegistryRegisterIdempotentSameInstance(t *testing.T) {
+	r := NewRegistry[fakeCodec]()
+	c := fakeCodec{"is-04", "v1.3", "v1.3.3"}
+	r.Register(c)
+	r.Register(c)
+	r.Register(c)
+	if got := r.SupportedVersions(); !reflect.DeepEqual(got, []string{"v1.3"}) {
+		t.Fatalf("SupportedVersions = %v, want one entry", got)
+	}
+}
+
+func TestRegistryRegisterPanicsOnDuplicateDifferentInstance(t *testing.T) {
+	r := NewRegistry[fakeCodec]()
+	r.Register(fakeCodec{"is-04", "v1.3", "v1.3.3"})
+
+	defer func() {
+		if rec := recover(); rec == nil {
+			t.Fatalf("expected panic on duplicate registration")
+		}
+	}()
+	r.Register(fakeCodec{"is-04", "v1.3", "v1.3.4"}) // different patch
+}
+
+func TestRegistryRegisterPanicsOnSpecIDMismatch(t *testing.T) {
+	r := NewRegistry[fakeCodec]()
+	r.Register(fakeCodec{"is-04", "v1.3", "v1.3.3"})
+
+	defer func() {
+		if rec := recover(); rec == nil {
+			t.Fatalf("expected panic on SpecID mismatch")
+		}
+	}()
+	r.Register(fakeCodec{"is-05", "v1.0", "v1.0.2"})
+}
+
+func TestRegistryRegisterPanicsOnEmptyFields(t *testing.T) {
+	cases := []struct {
+		name string
+		c    fakeCodec
+	}{
+		{"empty SpecID", fakeCodec{"", "v1.3", "v1.3.3"}},
+		{"empty APIVer", fakeCodec{"is-04", "", "v1.3.3"}},
+		{"empty SpecPatch", fakeCodec{"is-04", "v1.3", ""}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewRegistry[fakeCodec]()
+			defer func() {
+				if rec := recover(); rec == nil {
+					t.Fatalf("expected panic for %s", tc.name)
+				}
+			}()
+			r.Register(tc.c)
+		})
+	}
+}
+
+func TestRegistrySupportedVersionsSortedAscending(t *testing.T) {
+	r := NewRegistry[fakeCodec]()
+	// Register out of order to verify sort.
+	r.Register(fakeCodec{"is-04", "v1.3", "v1.3.3"})
+	r.Register(fakeCodec{"is-04", "v1.1", "v1.1.3"})
+	r.Register(fakeCodec{"is-04", "v1.2", "v1.2.2"})
+	want := []string{"v1.1", "v1.2", "v1.3"}
+	if got := r.SupportedVersions(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("SupportedVersions = %v, want %v", got, want)
+	}
+}
+
+func TestRegistryAllCodecsReturnsSortedCopy(t *testing.T) {
+	r := NewRegistry[fakeCodec]()
+	r.Register(fakeCodec{"is-04", "v1.3", "v1.3.3"})
+	r.Register(fakeCodec{"is-04", "v1.1", "v1.1.3"})
+	all := r.AllCodecs()
+	if len(all) != 2 || all[0].APIVer() != "v1.1" || all[1].APIVer() != "v1.3" {
+		t.Fatalf("AllCodecs = %v", all)
+	}
+	// Mutating the returned slice must not affect the registry.
+	all[0] = fakeCodec{}
+	if got, _ := r.Get("v1.1"); got.APIVer() != "v1.1" {
+		t.Fatalf("Get v1.1 corrupted by AllCodecs caller")
+	}
+}
+
+func TestSelectHighestMutualPicksMaxIntersection(t *testing.T) {
+	r := NewRegistry[fakeCodec]()
+	r.Register(fakeCodec{"is-04", "v1.1", "v1.1.3"})
+	r.Register(fakeCodec{"is-04", "v1.2", "v1.2.2"})
+	r.Register(fakeCodec{"is-04", "v1.3", "v1.3.3"})
+
+	cases := []struct {
+		peer []string
+		want string
+	}{
+		{[]string{"v1.1", "v1.2", "v1.3"}, "v1.3"},
+		{[]string{"v1.1", "v1.2"}, "v1.2"},
+		{[]string{"v1.0", "v1.1"}, "v1.1"},
+		{[]string{"v1.3"}, "v1.3"},
+		{[]string{"V1.2  "}, "v1.2"}, // case + whitespace tolerated
+	}
+	for _, tc := range cases {
+		got, err := SelectHighestMutual(r, tc.peer)
+		if err != nil {
+			t.Fatalf("peer=%v: unexpected err %v", tc.peer, err)
+		}
+		if got.APIVer() != tc.want {
+			t.Fatalf("peer=%v: APIVer = %q, want %q", tc.peer, got.APIVer(), tc.want)
+		}
+	}
+}
+
+func TestSelectHighestMutualErrorsOnEmptyIntersection(t *testing.T) {
+	r := NewRegistry[fakeCodec]()
+	r.Register(fakeCodec{"is-04", "v1.3", "v1.3.3"})
+
+	_, err := SelectHighestMutual(r, []string{"v2.0", "v2.1"})
+	var nocommon ErrNoCommonVersion
+	if !errors.As(err, &nocommon) {
+		t.Fatalf("expected ErrNoCommonVersion, got %v", err)
+	}
+	if nocommon.SpecID != "is-04" {
+		t.Fatalf("ErrNoCommonVersion.SpecID = %q", nocommon.SpecID)
+	}
+}
+
+func TestSelectHighestMutualNilRegistry(t *testing.T) {
+	_, err := SelectHighestMutual[fakeCodec](nil, []string{"v1.0"})
+	if err == nil {
+		t.Fatalf("nil Registry should error")
+	}
+}
+
+func TestRegistryConcurrentRegisterAndRead(t *testing.T) {
+	r := NewRegistry[fakeCodec]()
+	r.Register(fakeCodec{"is-04", "v1.3", "v1.3.3"})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			// Idempotent re-register from many goroutines.
+			r.Register(fakeCodec{"is-04", "v1.3", "v1.3.3"})
+		}()
+		go func() {
+			defer wg.Done()
+			_, _ = r.Get("v1.3")
+			_ = r.SupportedVersions()
+			_ = r.AllCodecs()
+		}()
+	}
+	wg.Wait()
+	if got := r.SupportedVersions(); !reflect.DeepEqual(got, []string{"v1.3"}) {
+		t.Fatalf("SupportedVersions = %v after concurrent ops", got)
+	}
+}
+
+func TestSeverityString(t *testing.T) {
+	cases := []struct {
+		s    Severity
+		want string
+	}{
+		{SeverityInfo, "info"},
+		{SeverityWarn, "warn"},
+		{SeverityError, "error"},
+		{Severity(99), "severity(99)"},
+	}
+	for _, tc := range cases {
+		if got := tc.s.String(); got != tc.want {
+			t.Fatalf("Severity(%d) = %q, want %q", tc.s, got, tc.want)
+		}
+	}
+}
+
+func TestNopReporterDiscardsEvents(t *testing.T) {
+	var r Reporter = NopReporter{}
+	r.Report(ComplianceEvent{Code: "x"}) // must not panic
+}
+
+func TestSliceReporterRecords(t *testing.T) {
+	rep := &SliceReporter{}
+	rep.Report(ComplianceEvent{Code: "a"})
+	rep.Report(ComplianceEvent{Code: "b"})
+	snap := rep.Snapshot()
+	if len(snap) != 2 || snap[0].Code != "a" || snap[1].Code != "b" {
+		t.Fatalf("Snapshot = %v", snap)
+	}
+}
+
+func TestSliceReporterConcurrent(t *testing.T) {
+	rep := &SliceReporter{}
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rep.Report(ComplianceEvent{Code: "c"})
+		}()
+	}
+	wg.Wait()
+	if got := rep.Snapshot(); len(got) != 16 {
+		t.Fatalf("expected 16 events, got %d", len(got))
+	}
+}
+
+func TestCompareAPIVer(t *testing.T) {
+	cases := []struct {
+		a, b string
+		sign int
+	}{
+		{"v1.0", "v1.1", -1},
+		{"v1.1", "v1.0", 1},
+		{"v1.3", "v1.3", 0},
+		{"v2.0", "v1.9", 1},
+		{"v1.10", "v1.9", 1}, // numeric, not lexicographic
+		{"v1.x", "v1.y", -1}, // both invalid → lexicographic fallback
+	}
+	for _, tc := range cases {
+		got := compareAPIVer(tc.a, tc.b)
+		want := tc.sign
+		if (got < 0 && want >= 0) || (got > 0 && want <= 0) || (got == 0 && want != 0) {
+			t.Fatalf("compareAPIVer(%q,%q)=%d, want sign %d", tc.a, tc.b, got, want)
+		}
+	}
+}

--- a/internal/amwa/codec/spec/versioned.go
+++ b/internal/amwa/codec/spec/versioned.go
@@ -1,0 +1,32 @@
+package spec
+
+// Versioned is the contract every AMWA NMOS codec implementation
+// satisfies, regardless of which IS-* / MS-* / BCP-* specification it
+// codifies.
+//
+// SpecID identifies the specification in the AMWA NMOS catalogue using
+// its lower-case slug — e.g. "is-04", "is-05", "is-07", "is-08",
+// "is-09", "is-12", "ms-05-01", "ms-05-02", "bcp-002-01",
+// "bcp-004-02". One SpecID maps to many APIVer values.
+//
+// APIVer is the wire identifier — major.minor only — as it appears in
+// DNS-SD `api_ver` TXT records and in `/x-nmos/<api>/<APIVer>/...`
+// URL paths. Always written with a leading "v": "v1.0", "v1.1",
+// "v1.3". The plugin layer uses this string verbatim for URL
+// dispatch and TXT advertisement.
+//
+// SpecPatch is the spec-text revision the codec strictly complies
+// with — the latest patch within the APIVer minor. It carries three
+// components, e.g. "v1.0.2", "v1.1.3", "v1.3.3". Wire URLs do not
+// expose the patch level (the spec itself doesn't propagate it), but
+// it appears in [ComplianceEvent] reports and in conformance
+// audit logs so we can prove which spec text we're testing against.
+//
+// Implementations must be value-typed and stateless — same instance
+// safe to share across goroutines. All three returned strings are
+// const for the lifetime of the process.
+type Versioned interface {
+	SpecID() string
+	APIVer() string
+	SpecPatch() string
+}

--- a/internal/amwa/docs/dependencies.md
+++ b/internal/amwa/docs/dependencies.md
@@ -102,7 +102,32 @@ Inside Layer 1, codec sub-packages may import each other but only along
 the directed graph below. New cross-edges require an architecture
 review.
 
+The graph has THREE tiers within Layer 1:
+
+1. **`spec/`** — NMOS-wide base (`Versioned` interface, generic
+   `Registry[T]`, `SelectHighestMutual`, `ComplianceEvent + Reporter`).
+   Stdlib-only. No sibling imports. Every spec depends on it.
+2. **Per-spec packages** (`is04/`, `is05/`, …) — canonical structs +
+   per-spec `Codec` interface (extends `spec.Versioned`). May import
+   `spec/` and select sibling specs as the directed graph below allows.
+3. **Per-minor packages** (`is04/v11/`, `is05/v10/`, …) — Strategy
+   impls, one per wire minor. Import their host spec package +
+   `spec/`. Never import sibling minors (`v12/` ≠ `v11/`) or other
+   specs' minors. Blank-imported from `cmd/dhs/main.go` to wire init().
+4. **BCP validator packages** (`bcp/bcp00201/`, `bcp/bcp00401/`, …) —
+   register into their host spec at init() via
+   `<host>.RegisterValidator(...)`. Implement `bcp.Validator` (which
+   itself extends `spec.Versioned`).
+
 ```
+   ┌──────────────┐
+   │     spec     │  ◄── leaf base; no sibling imports
+   │ Versioned +  │      Versioned interface, generic Registry[T],
+   │ Registry[T] +│      SelectHighestMutual, ComplianceEvent + Reporter
+   │  Reporter    │
+   └──────┬───────┘
+          │  (every per-spec package imports spec)
+          ▼
    ┌──────────────┐         ┌──────────────┐
    │  jsonschema  │         │    dnssd     │      ◄── independent of all others
    │ (validator)  │         │ (mDNS + SRV) │
@@ -164,9 +189,21 @@ review.
 - `is09` MUST NOT import `is04` (System config is bootstrap-only).
 - `rql` MUST NOT import `is04` (it's pure filter-syntax; resource
   type-checking happens in the IS-04 layer).
-- `bcp-008-*` is NOT a separate package; it's MS-05-02 classes.
-  Likewise `bcp-002`, `bcp-004`, `bcp-006`, `bcp-007` are JSON-Schema
-  files compiled into the relevant codec, NOT separate code paths.
+- `spec/` (the NMOS-wide codec base) MUST NOT import any sibling
+  codec package. It is the leaf — every spec depends on it; it
+  depends on no spec.
+- Per-minor packages (`is04/v11/`, `is05/v10/`, …) MUST NOT be
+  imported by Layer 2 / 3 / 4. Only their host spec package may import
+  them, and only at `init()` time for `Register` calls. Plugin code
+  goes through the host spec's `Codec` interface via the
+  `spec.Registry[T]`.
+- `is04/v12/` MUST NOT import `is04/v11/` or `is04/v13/`. Per-minor
+  packages are siblings — they share the canonical structs in their
+  parent (`is04/`), not each other.
+- BCP validator packages (`bcp/bcp00201/`, `bcp/bcp00401/`, …)
+  register into their host spec via `<host>.RegisterValidator(...)` at
+  init() time and are blank-imported from `cmd/dhs/main.go`. They MUST
+  NOT be imported anywhere else.
 
 ---
 


### PR DESCRIPTION
## Summary

Step 1 of the NMOS-wide codec architecture (per user directive 2026-04-30: spec-strict, support all versions of every NMOS spec, OOP/DI/interface, cost-reduced for future versions).

Lands `internal/amwa/codec/spec/` — the cross-cutting base every IS-* / MS-* / BCP-* implementation will extend. Pure interface contracts, stdlib-only, idempotent registration, panic-on-bug semantics matching `internal/protocol/`.

## What's in this PR

- `spec.Versioned` interface — `SpecID() / APIVer() / SpecPatch()` — every NMOS codec satisfies it.
- `spec.Registry[T Versioned]` — generic per-spec map of APIVer → codec; idempotent Register, panic on duplicate-different-instance, sorted SupportedVersions, fresh-copy AllCodecs.
- `spec.SelectHighestMutual` — peer api_ver intersection rule with `ErrNoCommonVersion` typed error; never silently downgrade.
- `spec.ComplianceEvent + Reporter` — cross-cutting absorb-and-fire-event seam injected through DI; production wires logger-backed reporter, tests pass `*SliceReporter`.
- 17 unit tests covering all of the above (idempotent register, panic paths, concurrent register+read, version selection edge cases, severity rendering, reporter contracts).
- `internal/amwa/CLAUDE.md` — new "Codec architecture (locked pattern)" section + OOP principles table + spec-strict version coverage rule.
- `internal/amwa/docs/dependencies.md` — extended forbidden-edges list (`spec/` leaf rule, per-minor isolation, BCP validator package rule).

## Forward plan (this is Step 1 of ~16)

Step 2 — refactor IS-04 v1.3 + add v1.2.2 + v1.1.3 onto the locked pattern.
Step 3 — retrofit IS-09 to match.
Step 4 — IS-04 Controller (DI'd against the Codec interface).
Steps 5–9 — IS-05 / 07 / 08 / 12 / MS-05 codecs.
Steps 10–13 — BCP-002 / 004 / 006 / 008 validators.
Step 14 — Wireshark dissector.
Step 15 — AMWA NMOS Testing harness.
Then user runs the integration sweep against real Registry / Node / Controller.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/amwa/...` 100% green (10 packages)
- [x] `golangci-lint run ./internal/amwa/...` 0 issues
- [ ] CI green across 5 platforms