### PR TITLE
feat(nmos): IS-04 multi-version codec — v1.1.3 + v1.2.2 + v1.3.3 in parallel (#4b)

### DIFF
--- a/cmd/dhs/main.go
+++ b/cmd/dhs/main.go
@@ -64,6 +64,8 @@ import (
 	// references the concrete vXX/ packages directly. Plugin code
 	// (Layer 3) goes through the host spec's Codec interface only,
 	// per `internal/amwa/docs/dependencies.md` forbidden edges.
+	_ "acp/internal/amwa/codec/is04/v11"
+	_ "acp/internal/amwa/codec/is04/v12"
 	_ "acp/internal/amwa/codec/is04/v13"
 )
 

--- a/cmd/dhs/main.go
+++ b/cmd/dhs/main.go
@@ -57,6 +57,14 @@ import (
 
 	// Registry plugins — blank imports register with internal/registry.
 	_ "acp/internal/amwa/registry"
+
+	// NMOS codec versions — blank imports trigger init()-time
+	// registration with the per-spec spec.Registry[T]. Each minor
+	// is its own package; cmd/dhs/main.go is the only place that
+	// references the concrete vXX/ packages directly. Plugin code
+	// (Layer 3) goes through the host spec's Codec interface only,
+	// per `internal/amwa/docs/dependencies.md` forbidden edges.
+	_ "acp/internal/amwa/codec/is04/v13"
 )
 
 // Build-time variables injected via -ldflags. See Makefile LDFLAGS_FULL.

--- a/internal/amwa/codec/is04/codec.go
+++ b/internal/amwa/codec/is04/codec.go
@@ -1,0 +1,125 @@
+package is04
+
+import (
+	"acp/internal/amwa/codec/spec"
+)
+
+// SpecID is the AMWA NMOS catalogue slug for IS-04. Every codec
+// registered under this package returns this value from SpecID().
+const SpecID = "is-04"
+
+// Codec is the IS-04 wire codec contract — one implementation per
+// supported wire minor (v1.1 / v1.2 / v1.3 today; v1.4 / v2.0 in the
+// future). Every implementation satisfies [spec.Versioned] so the
+// shared infrastructure (DNS-SD api_ver advertisement, peer-version
+// selection, compliance event reporting) works uniformly across every
+// NMOS spec.
+//
+// Per-resource methods come in three groups:
+//
+//   - EncodeXxx — serialise the canonical struct into the JSON shape
+//     for the codec's wire minor. Fields that don't exist in this
+//     minor are omitted (omitempty + per-codec field gating).
+//
+//   - DecodeXxx — parse JSON returned by a peer of this wire minor
+//     into the canonical struct. Unknown fields are rejected
+//     (DisallowUnknownFields) — peers sending fields that don't
+//     belong on this minor's wire fire a compliance event.
+//
+//   - ValidateXxx — apply the minor's required-field set, regex
+//     patterns, and URN enums. Returns nil on conformance, a typed
+//     error otherwise. Validate runs on both encode and decode paths
+//     so we never emit a non-compliant payload to a peer.
+//
+// Implementations are stateless and safe for concurrent use.
+type Codec interface {
+	spec.Versioned
+
+	EncodeNode(Node) ([]byte, error)
+	DecodeNode([]byte) (Node, error)
+	ValidateNode(Node) error
+
+	EncodeDevice(Device) ([]byte, error)
+	DecodeDevice([]byte) (Device, error)
+	ValidateDevice(Device) error
+
+	EncodeSource(Source) ([]byte, error)
+	DecodeSource([]byte) (Source, error)
+	ValidateSource(Source) error
+
+	EncodeFlow(Flow) ([]byte, error)
+	DecodeFlow([]byte) (Flow, error)
+	ValidateFlow(Flow) error
+
+	EncodeSender(Sender) ([]byte, error)
+	DecodeSender([]byte) (Sender, error)
+	ValidateSender(Sender) error
+
+	EncodeReceiver(Receiver) ([]byte, error)
+	DecodeReceiver([]byte) (Receiver, error)
+	ValidateReceiver(Receiver) error
+}
+
+// versions is the per-process Registry of IS-04 codec implementations.
+// Each minor's vXX/ subpackage calls Register exactly once from init();
+// cmd/dhs/main.go blank-imports those packages to wire registration.
+var versions = spec.NewRegistry[Codec]()
+
+// Register installs a codec for one IS-04 wire minor. Called from
+// vXX.init(). Idempotent — safe to call repeatedly with the same
+// instance for the same APIVer; panics on duplicate-different-instance
+// or any empty field. Same semantics as [spec.Registry.Register].
+//
+// Registering a codec whose SpecID is not [SpecID] panics.
+func Register(c Codec) {
+	if c.SpecID() != SpecID {
+		panic("is04.Register: SpecID must be " + SpecID + ", got " + c.SpecID())
+	}
+	versions.Register(c)
+}
+
+// Get returns the codec registered for the given APIVer (e.g. "v1.3"),
+// or false when no such version is wired in. Plugin code uses this to
+// dispatch per-URL-tree requests to the right encoder.
+func Get(apiVer string) (Codec, bool) {
+	return versions.Get(apiVer)
+}
+
+// AllCodecs returns every registered IS-04 codec sorted by APIVer
+// ascending (e.g. v1.1, v1.2, v1.3). Plugin code uses this to install
+// per-minor URL routes on the same Registry / Node HTTP face.
+func AllCodecs() []Codec {
+	return versions.AllCodecs()
+}
+
+// SupportedVersions returns every registered APIVer string in
+// ascending order — fed verbatim into the DNS-SD `api_ver` TXT
+// comma-list. Returns an empty slice when no codecs are wired (test
+// environments without blank-imports).
+func SupportedVersions() []string {
+	return versions.SupportedVersions()
+}
+
+// SelectHighest picks the highest version mutually supported between
+// us and a peer's advertised list. Returns [spec.ErrNoCommonVersion]
+// when the intersection is empty — caller fires a compliance event
+// and refuses the peer (never silently downgrade).
+func SelectHighest(peerVersions []string) (Codec, error) {
+	return spec.SelectHighestMutual(versions, peerVersions)
+}
+
+// Default returns the highest registered IS-04 codec — used by
+// in-process call sites that don't yet route per-version (e.g.
+// internal helper packages, fixture builders). Plugin layer code
+// MUST use [Get] / [AllCodecs] / [SelectHighest] instead and route
+// per peer-advertised version.
+//
+// Panics if no codec is registered. Intended to make missing
+// blank-imports loudly visible at process start.
+func Default() Codec {
+	all := versions.AllCodecs()
+	if len(all) == 0 {
+		panic("is04.Default: no codec registered (forgot to blank-import internal/amwa/codec/is04/vXX?)")
+	}
+	return all[len(all)-1]
+}

--- a/internal/amwa/codec/is04/testdata/schemas/v1.1.3/device.json
+++ b/internal/amwa/codec/is04/testdata/schemas/v1.1.3/device.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes a Device",
+  "title": "Device resource",
+  "allOf": [
+    { "$ref": "resource_core.json" },
+    {
+      "type": "object",
+      "required": [
+        "type",
+        "node_id",
+        "senders",
+        "receivers",
+        "controls"
+      ],
+      "properties": {
+        "type": {
+          "description": "Device type URN",
+          "type": "string",
+          "oneOf": [
+            {
+              "enum": [
+                "urn:x-nmos:device:generic",
+                "urn:x-nmos:device:pipeline"
+              ]
+            },
+            {
+              "not": {
+                "pattern": "^urn:x-nmos:"
+              }
+            }
+          ],
+          "format": "uri"
+        },
+        "node_id": {
+          "description": "Globally unique identifier for the Node which initially created the Device. This attribute is used to ensure referential integrity by registry implementations.",
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "senders": {
+          "description": "UUIDs of Senders attached to the Device",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          }
+        },
+        "receivers": {
+          "description": "UUIDs of Receivers attached to the Device",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          }
+        },
+        "controls": {
+          "description": "Control endpoints exposed for the Device",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["href", "type"],
+            "properties": {
+              "href": {
+                "type": "string",
+                "description": "URL to reach a control endpoint, whether http or otherwise",
+                "format": "uri"
+              },
+              "type": {
+                "type": "string",
+                "description": "URN identifying the control format",
+                "format": "uri"
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/internal/amwa/codec/is04/testdata/schemas/v1.1.3/flow.json
+++ b/internal/amwa/codec/is04/testdata/schemas/v1.1.3/flow.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes a Flow",
+  "title": "Flow resource",
+  "anyOf": [
+    { "$ref": "flow_video_raw.json" },
+    { "$ref": "flow_video_coded.json" },
+    { "$ref": "flow_audio_raw.json" },
+    { "$ref": "flow_audio_coded.json" },
+    { "$ref": "flow_data.json" },
+    { "$ref": "flow_sdianc_data.json" },
+    { "$ref": "flow_mux.json" }
+  ]
+}

--- a/internal/amwa/codec/is04/testdata/schemas/v1.1.3/node.json
+++ b/internal/amwa/codec/is04/testdata/schemas/v1.1.3/node.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes the Node and the services which run on it",
+  "title": "Node resource",
+  "allOf": [
+    { "$ref": "resource_core.json" },
+    {
+      "type": "object",
+      "required": [
+        "href",
+        "caps",
+        "api",
+        "services",
+        "clocks"
+      ],
+      "properties": {
+        "href": {
+          "description": "HTTP access href for the Node's API (deprecated)",
+          "type": "string",
+          "format": "uri"
+        },
+        "hostname": {
+          "description": "Node hostname (optional, deprecated)",
+          "type": "string",
+          "format": "hostname"
+        },
+        "api": {
+          "description": "URL fragments required to connect to the Node API",
+          "type": "object",
+          "required": ["versions", "endpoints"],
+          "properties": {
+            "versions": {
+              "description": "Supported API versions running on this Node",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "v[0-9]+.[0-9]+"
+              }
+            },
+            "endpoints": {
+              "description": "Host, port and protocol details required to connect to the API",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["host", "port", "protocol"],
+                "properties": {
+                  "host": {
+                    "type": "string",
+                    "description": "IP address or hostname which the Node API is running on",
+                    "anyOf": [
+                      {"format": "hostname"},
+                      {"format": "ipv4"},
+                      {"format": "ipv6"}
+                    ]
+                  },
+                  "port": {
+                    "type": "integer",
+                    "description": "Port number which the Node API is running on",
+                    "minimum": 1,
+                    "maximum": 65535
+                  },
+                  "protocol": {
+                    "type": "string",
+                    "description": "Protocol supported by this instance of the Node API",
+                    "enum": ["http", "https"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "caps": {
+          "description": "Capabilities (not yet defined)",
+          "type": "object"
+        },
+        "services": {
+          "description": "Array of objects containing a URN format type and href",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["href", "type"],
+            "properties": {
+              "href": {
+                "type": "string",
+                "description": "URL to reach a service running on the Node",
+                "format": "uri"
+              },
+              "type": {
+                "type": "string",
+                "description": "URN identifying the type of service",
+                "format": "uri"
+              }
+            }
+          }
+        },
+        "clocks": {
+          "description": "Clocks made available to Devices owned by this Node",
+          "type": "array",
+          "items": {
+            "anyOf": [
+              { "$ref": "clock_internal.json" },
+              { "$ref": "clock_ptp.json" }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/internal/amwa/codec/is04/testdata/schemas/v1.1.3/receiver.json
+++ b/internal/amwa/codec/is04/testdata/schemas/v1.1.3/receiver.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes a Receiver",
+  "title": "Receiver resource",
+  "oneOf": [
+    { "$ref": "receiver_video.json" },
+    { "$ref": "receiver_audio.json" },
+    { "$ref": "receiver_data.json" },
+    { "$ref": "receiver_mux.json" }
+  ]
+}

--- a/internal/amwa/codec/is04/testdata/schemas/v1.1.3/resource_core.json
+++ b/internal/amwa/codec/is04/testdata/schemas/v1.1.3/resource_core.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes the foundations of all NMOS resources",
+  "title": "Base resource",
+  "required": [
+    "id",
+    "version",
+    "label",
+    "description",
+    "tags"
+  ],
+  "properties": {
+    "id": {
+      "description": "Globally unique identifier for the resource",
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    },
+    "version": {
+      "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating precisely when an attribute of the resource last changed",
+      "type": "string",
+      "pattern": "^[0-9]+:[0-9]+$"
+    },
+    "label": {
+      "description": "Freeform string label for the resource",
+      "type": "string"
+    },
+    "description": {
+      "description": "Detailed description of the resource",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Key value set of freeform string tags to aid in filtering resources. Values should be represented as an array of strings. Can be empty.",
+      "type": "object",
+      "patternProperties": {
+        "": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/amwa/codec/is04/testdata/schemas/v1.1.3/sender.json
+++ b/internal/amwa/codec/is04/testdata/schemas/v1.1.3/sender.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes a sender",
+  "title": "Sender resource",
+  "allOf": [
+    { "$ref": "resource_core.json" },
+    {
+      "type": "object",
+      "required": [
+        "flow_id",
+        "transport",
+        "device_id",
+        "manifest_href"
+      ],
+      "properties": {
+        "flow_id": {
+          "description": "ID of the Flow currently passing via this Sender",
+          "type": ["string", "null"],
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+          "default": null
+        },
+        "transport": {
+          "description": "Transport type used by the Sender in URN format",
+          "type": "string",
+          "oneOf": [
+            {
+              "enum": [
+                "urn:x-nmos:transport:rtp",
+                "urn:x-nmos:transport:rtp.ucast",
+                "urn:x-nmos:transport:rtp.mcast",
+                "urn:x-nmos:transport:dash"
+              ]
+            },
+            {
+              "not": {
+                "pattern": "^urn:x-nmos:"
+              }
+            }
+          ],
+          "format": "uri"
+        },
+        "device_id": {
+          "description": "Device ID which this Sender forms part of. This attribute is used to ensure referential integrity by registry implementations.",
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "manifest_href": {
+          "description": "HTTP URL to a file describing how to connect to the Sender (SDP for RTP)",
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    }
+  ]
+}

--- a/internal/amwa/codec/is04/testdata/schemas/v1.1.3/source.json
+++ b/internal/amwa/codec/is04/testdata/schemas/v1.1.3/source.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes a Source",
+  "title": "Source resource",
+  "oneOf": [
+    { "$ref": "source_generic.json" },
+    { "$ref": "source_audio.json" }
+  ]
+}

--- a/internal/amwa/codec/is04/testdata/schemas/v1.2.2/device.json
+++ b/internal/amwa/codec/is04/testdata/schemas/v1.2.2/device.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes a Device",
+  "title": "Device resource",
+  "allOf": [
+    { "$ref": "resource_core.json" },
+    {
+      "type": "object",
+      "required": [
+        "type",
+        "node_id",
+        "senders",
+        "receivers",
+        "controls"
+      ],
+      "properties": {
+        "type": {
+          "description": "Device type URN",
+          "type": "string",
+          "oneOf": [
+            {
+              "enum": [
+                "urn:x-nmos:device:generic",
+                "urn:x-nmos:device:pipeline"
+              ]
+            },
+            {
+              "not": {
+                "pattern": "^urn:x-nmos:"
+              }
+            }
+          ],
+          "format": "uri"
+        },
+        "node_id": {
+          "description": "Globally unique identifier for the Node which initially created the Device. This attribute is used to ensure referential integrity by registry implementations.",
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "senders": {
+          "description": "UUIDs of Senders attached to the Device (deprecated)",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          }
+        },
+        "receivers": {
+          "description": "UUIDs of Receivers attached to the Device (deprecated)",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          }
+        },
+        "controls": {
+          "description": "Control endpoints exposed for the Device",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["href", "type"],
+            "properties": {
+              "href": {
+                "type": "string",
+                "description": "URL to reach a control endpoint, whether http or otherwise",
+                "format": "uri"
+              },
+              "type": {
+                "type": "string",
+                "description": "URN identifying the control format",
+                "format": "uri"
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/internal/amwa/codec/is04/testdata/schemas/v1.2.2/flow.json
+++ b/internal/amwa/codec/is04/testdata/schemas/v1.2.2/flow.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes a Flow",
+  "title": "Flow resource",
+  "anyOf": [
+    { "$ref": "flow_video_raw.json" },
+    { "$ref": "flow_video_coded.json" },
+    { "$ref": "flow_audio_raw.json" },
+    { "$ref": "flow_audio_coded.json" },
+    { "$ref": "flow_data.json" },
+    { "$ref": "flow_sdianc_data.json" },
+    { "$ref": "flow_mux.json" }
+  ]
+}

--- a/internal/amwa/codec/is04/testdata/schemas/v1.2.2/node.json
+++ b/internal/amwa/codec/is04/testdata/schemas/v1.2.2/node.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes the Node and the services which run on it",
+  "title": "Node resource",
+  "allOf": [
+    { "$ref": "resource_core.json" },
+    {
+      "type": "object",
+      "required": [
+        "href",
+        "caps",
+        "api",
+        "services",
+        "clocks",
+        "interfaces"
+      ],
+      "properties": {
+        "href": {
+          "description": "HTTP access href for the Node's API (deprecated)",
+          "type": "string",
+          "format": "uri"
+        },
+        "hostname": {
+          "description": "Node hostname (optional, deprecated)",
+          "type": "string",
+          "format": "hostname"
+        },
+        "api": {
+          "description": "URL fragments required to connect to the Node API",
+          "type": "object",
+          "required": ["versions", "endpoints"],
+          "properties": {
+            "versions": {
+              "description": "Supported API versions running on this Node",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^v[0-9]+\\.[0-9]+$"
+              }
+            },
+            "endpoints": {
+              "description": "Host, port and protocol details required to connect to the API",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["host", "port", "protocol"],
+                "properties": {
+                  "host": {
+                    "type": "string",
+                    "description": "IP address or hostname which the Node API is running on",
+                    "anyOf": [
+                      {"format": "hostname"},
+                      {"format": "ipv4"},
+                      {"format": "ipv6"}
+                    ]
+                  },
+                  "port": {
+                    "type": "integer",
+                    "description": "Port number which the Node API is running on",
+                    "minimum": 1,
+                    "maximum": 65535
+                  },
+                  "protocol": {
+                    "type": "string",
+                    "description": "Protocol supported by this instance of the Node API",
+                    "enum": ["http", "https"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "caps": {
+          "description": "Capabilities (not yet defined)",
+          "type": "object"
+        },
+        "services": {
+          "description": "Array of objects containing a URN format type and href",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["href", "type"],
+            "properties": {
+              "href": {
+                "type": "string",
+                "description": "URL to reach a service running on the Node",
+                "format": "uri"
+              },
+              "type": {
+                "type": "string",
+                "description": "URN identifying the type of service",
+                "format": "uri"
+              }
+            }
+          }
+        },
+        "clocks": {
+          "description": "Clocks made available to Devices owned by this Node",
+          "type": "array",
+          "items": {
+            "anyOf": [
+              { "$ref": "clock_internal.json" },
+              { "$ref": "clock_ptp.json" }
+            ]
+          }
+        },
+        "interfaces": {
+          "description":"Network interfaces made available to devices owned by this Node. Port IDs and Chassis IDs are used to inform topology discovery via IS-06, and require that interfaces implement ARP at a minimum, and ideally LLDP.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["chassis_id", "port_id", "name"],
+            "properties": {
+              "chassis_id": {
+                "description": "Chassis ID of the interface, as signalled in LLDP from this node. Set to null where LLDP is unsuitable for use (ie. virtualised environments)",
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "pattern": "^([0-9a-f]{2}-){5}([0-9a-f]{2})$",
+                    "description": "When the Chassis ID is a MAC address, use this format"
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "^.+$",
+                    "description": "When the Chassis ID is anything other than a MAC address, a freeform string may be used"
+                  },
+                  {
+                    "type": "null",
+                    "description": "When the Chassis ID is unavailable it should be set to null"
+                  }
+                ]
+              },
+              "port_id": {
+                "description": "Port ID of the interface, as signalled in LLDP or via ARP responses from this node. Must be a MAC address",
+                "type": "string",
+                "pattern": "^([0-9a-f]{2}-){5}([0-9a-f]{2})$"
+              },
+              "name": {
+                "description": "Name of the interface (unique in scope of this node).  This attribute is used by sub-resources of this node such as senders and receivers to refer to interfaces to which they are bound.",
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/internal/amwa/codec/is04/testdata/schemas/v1.2.2/receiver.json
+++ b/internal/amwa/codec/is04/testdata/schemas/v1.2.2/receiver.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes a Receiver",
+  "title": "Receiver resource",
+  "oneOf": [
+    { "$ref": "receiver_video.json" },
+    { "$ref": "receiver_audio.json" },
+    { "$ref": "receiver_data.json" },
+    { "$ref": "receiver_mux.json" }
+  ]
+}

--- a/internal/amwa/codec/is04/testdata/schemas/v1.2.2/resource_core.json
+++ b/internal/amwa/codec/is04/testdata/schemas/v1.2.2/resource_core.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes the foundations of all NMOS resources",
+  "title": "Base resource",
+  "required": [
+    "id",
+    "version",
+    "label",
+    "description",
+    "tags"
+  ],
+  "properties": {
+    "id": {
+      "description": "Globally unique identifier for the resource",
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    },
+    "version": {
+      "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating precisely when an attribute of the resource last changed",
+      "type": "string",
+      "pattern": "^[0-9]+:[0-9]+$"
+    },
+    "label": {
+      "description": "Freeform string label for the resource",
+      "type": "string"
+    },
+    "description": {
+      "description": "Detailed description of the resource",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Key value set of freeform string tags to aid in filtering resources. Values should be represented as an array of strings. Can be empty.",
+      "type": "object",
+      "patternProperties": {
+        "": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/amwa/codec/is04/testdata/schemas/v1.2.2/sender.json
+++ b/internal/amwa/codec/is04/testdata/schemas/v1.2.2/sender.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes a sender",
+  "title": "Sender resource",
+  "allOf": [
+    { "$ref": "resource_core.json" },
+    {
+      "type": "object",
+      "required": [
+        "flow_id",
+        "transport",
+        "device_id",
+        "manifest_href",
+        "interface_bindings",
+        "subscription"
+      ],
+      "properties": {
+        "caps": {
+          "description": "Capabilities of this sender",
+          "type": "object",
+          "properties":{
+          }
+        },
+        "flow_id": {
+          "description": "ID of the Flow currently passing via this Sender",
+          "type": ["string", "null"],
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+          "default": null
+        },
+        "transport": {
+          "description": "Transport type used by the Sender in URN format",
+          "type": "string",
+          "oneOf": [
+            {
+              "enum": [
+                "urn:x-nmos:transport:rtp",
+                "urn:x-nmos:transport:rtp.ucast",
+                "urn:x-nmos:transport:rtp.mcast",
+                "urn:x-nmos:transport:dash"
+              ]
+            },
+            {
+              "not": {
+                "pattern": "^urn:x-nmos:"
+              }
+            }
+          ],
+          "format": "uri"
+        },
+        "device_id": {
+          "description": "Device ID which this Sender forms part of. This attribute is used to ensure referential integrity by registry implementations.",
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "manifest_href": {
+          "description": "HTTP URL to a file describing how to connect to the Sender (SDP for RTP). The Sender's 'version' attribute should be updated if the contents of this file are modified. This URL may return an HTTP 404 where the 'active' parameter in the 'subscription' object is present and set to false (v1.2+ only).",
+          "type": "string",
+          "format": "uri"
+        },
+        "interface_bindings": {
+          "description": "Binding of Sender egress ports to interfaces on the parent Node. Should contain a single network interface unless a redundancy mechanism such as ST.2022-7 is in use, in which case each 'leg' should have its matching interface listed. Where the redundancy mechanism sends more than one copy of the stream via the same interface, that interface should be listed a corresponding number of times.",
+          "type": "array",
+          "items": {
+            "type":"string"
+          }
+        },
+        "subscription": {
+          "description": "Object containing the 'receiver_id' currently subscribed to (unicast only). Receiver_id should be null on initialisation, or when connected to a non-NMOS unicast Receiver.",
+          "type": "object",
+          "required": ["receiver_id", "active"],
+          "properties": {
+            "receiver_id": {
+              "type": ["string", "null"],
+              "description": "UUID of the Receiver that this Sender is currently subscribed to",
+              "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+              "default": null
+            },
+            "active": {
+              "type": "boolean",
+              "description": "Sender is enabled and configured to stream data to a single Receiver (unicast), or to the network via multicast or a pull-based mechanism",
+              "default": false
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/internal/amwa/codec/is04/testdata/schemas/v1.2.2/source.json
+++ b/internal/amwa/codec/is04/testdata/schemas/v1.2.2/source.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes a Source",
+  "title": "Source resource",
+  "oneOf": [
+    { "$ref": "source_generic.json" },
+    { "$ref": "source_audio.json" }
+  ]
+}

--- a/internal/amwa/codec/is04/testdata/schemas/v1.3.3/device.json
+++ b/internal/amwa/codec/is04/testdata/schemas/v1.3.3/device.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes a Device",
+  "title": "Device resource",
+  "allOf": [
+    { "$ref": "resource_core.json" },
+    {
+      "type": "object",
+      "required": [
+        "type",
+        "node_id",
+        "senders",
+        "receivers",
+        "controls"
+      ],
+      "properties": {
+        "type": {
+          "description": "Device type URN",
+          "type": "string",
+          "oneOf": [
+            {
+              "pattern": "^urn:x-nmos:device:"
+            },
+            {
+              "not": {
+                "pattern": "^urn:x-nmos:"
+              }
+            }
+          ],
+          "format": "uri"
+        },
+        "node_id": {
+          "description": "Globally unique identifier for the Node which initially created the Device. This attribute is used to ensure referential integrity by registry implementations.",
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "senders": {
+          "description": "UUIDs of Senders attached to the Device (deprecated)",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          }
+        },
+        "receivers": {
+          "description": "UUIDs of Receivers attached to the Device (deprecated)",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          }
+        },
+        "controls": {
+          "description": "Control endpoints exposed for the Device",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["href", "type"],
+            "properties": {
+              "href": {
+                "type": "string",
+                "description": "URL to reach a control endpoint, whether http or otherwise",
+                "format": "uri"
+              },
+              "type": {
+                "type": "string",
+                "description": "URN identifying the control format",
+                "format": "uri"
+              },
+              "authorization": {
+                "type": "boolean",
+                "description": "This endpoint requires authorization",
+                "default": false
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/internal/amwa/codec/is04/testdata/schemas/v1.3.3/flow.json
+++ b/internal/amwa/codec/is04/testdata/schemas/v1.3.3/flow.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes a Flow",
+  "title": "Flow resource",
+  "anyOf": [
+    { "$ref": "flow_video_raw.json" },
+    { "$ref": "flow_video_coded.json" },
+    { "$ref": "flow_audio_raw.json" },
+    { "$ref": "flow_audio_coded.json" },
+    { "$ref": "flow_data.json" },
+    { "$ref": "flow_sdianc_data.json" },
+    { "$ref": "flow_json_data.json" },
+    { "$ref": "flow_mux.json" }
+  ]
+}

--- a/internal/amwa/codec/is04/testdata/schemas/v1.3.3/node.json
+++ b/internal/amwa/codec/is04/testdata/schemas/v1.3.3/node.json
@@ -1,0 +1,195 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes the Node and the services which run on it",
+  "title": "Node resource",
+  "allOf": [
+    { "$ref": "resource_core.json" },
+    {
+      "type": "object",
+      "required": [
+        "href",
+        "caps",
+        "api",
+        "services",
+        "clocks",
+        "interfaces"
+      ],
+      "properties": {
+        "href": {
+          "description": "HTTP access href for the Node's API (deprecated)",
+          "type": "string",
+          "format": "uri"
+        },
+        "hostname": {
+          "description": "Node hostname (optional, deprecated)",
+          "type": "string",
+          "format": "hostname"
+        },
+        "api": {
+          "description": "URL fragments required to connect to the Node API",
+          "type": "object",
+          "required": ["versions", "endpoints"],
+          "properties": {
+            "versions": {
+              "description": "Supported API versions running on this Node",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^v[0-9]+\\.[0-9]+$"
+              }
+            },
+            "endpoints": {
+              "description": "Host, port and protocol details required to connect to the API",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["host", "port", "protocol"],
+                "properties": {
+                  "host": {
+                    "type": "string",
+                    "description": "IP address or hostname which the Node API is running on",
+                    "anyOf": [
+                      {"format": "hostname"},
+                      {"format": "ipv4"},
+                      {"format": "ipv6"}
+                    ]
+                  },
+                  "port": {
+                    "type": "integer",
+                    "description": "Port number which the Node API is running on",
+                    "minimum": 1,
+                    "maximum": 65535
+                  },
+                  "protocol": {
+                    "type": "string",
+                    "description": "Protocol supported by this instance of the Node API",
+                    "enum": ["http", "https"]
+                  },
+                  "authorization": {
+                    "type": "boolean",
+                    "description": "This endpoint requires authorization",
+                    "default": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        "caps": {
+          "description": "Capabilities (not yet defined)",
+          "type": "object"
+        },
+        "services": {
+          "description": "Array of objects containing a URN format type and href",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["href", "type"],
+            "properties": {
+              "href": {
+                "type": "string",
+                "description": "URL to reach a service running on the Node",
+                "format": "uri"
+              },
+              "type": {
+                "type": "string",
+                "description": "URN identifying the type of service",
+                "format": "uri"
+              },
+              "authorization": {
+                "type": "boolean",
+                "description": "This endpoint requires authorization",
+                "default": false
+              }
+            }
+          }
+        },
+        "clocks": {
+          "description": "Clocks made available to Devices owned by this Node",
+          "type": "array",
+          "items": {
+            "anyOf": [
+              { "$ref": "clock_internal.json" },
+              { "$ref": "clock_ptp.json" }
+            ]
+          }
+        },
+        "interfaces": {
+          "description":"Network interfaces made available to devices owned by this Node. Port IDs and Chassis IDs are used to inform topology discovery via IS-06, and require that interfaces implement ARP at a minimum, and ideally LLDP.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["chassis_id", "port_id", "name"],
+            "properties": {
+              "chassis_id": {
+                "description": "Chassis ID of the interface, as signalled in LLDP from this node. Set to null where LLDP is unsuitable for use (ie. virtualised environments)",
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "pattern": "^([0-9a-f]{2}-){5}([0-9a-f]{2})$",
+                    "description": "When the Chassis ID is a MAC address, use this format"
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "^.+$",
+                    "description": "When the Chassis ID is anything other than a MAC address, a freeform string may be used"
+                  },
+                  {
+                    "type": "null",
+                    "description": "When the Chassis ID is unavailable it should be set to null"
+                  }
+                ]
+              },
+              "port_id": {
+                "description": "Port ID of the interface, as signalled in LLDP or via ARP responses from this node. Must be a MAC address",
+                "type": "string",
+                "pattern": "^([0-9a-f]{2}-){5}([0-9a-f]{2})$"
+              },
+              "name": {
+                "description": "Name of the interface (unique in scope of this node).  This attribute is used by sub-resources of this node such as senders and receivers to refer to interfaces to which they are bound.",
+                "type": "string"
+              },
+              "attached_network_device": {
+                "type": "object",
+                "required": ["chassis_id", "port_id"],
+                "properties": {
+                  "chassis_id": {
+                    "description": "Chassis ID of the attached network device, as signalled in LLDP received by this Node.",
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "pattern": "^([0-9a-f]{2}-){5}([0-9a-f]{2})$",
+                        "description": "When the Chassis ID is a MAC address, use this format"
+                      },
+                      {
+                        "type": "string",
+                        "pattern": "^.+$",
+                        "description": "When the Chassis ID is anything other than a MAC address, a freeform string may be used"
+                      }
+                    ]
+                  },
+                  "port_id": {
+                    "description": "Port ID of the attached network device, as signalled in LLDP received by this Node.",
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "pattern": "^([0-9a-f]{2}-){5}([0-9a-f]{2})$",
+                        "description": "When the Port ID is a MAC address, use this format"
+                      },
+                      {
+                        "type": "string",
+                        "pattern": "^.+$",
+                        "description": "When the Port ID is anything other than a MAC address, a freeform string may be used"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/internal/amwa/codec/is04/testdata/schemas/v1.3.3/receiver.json
+++ b/internal/amwa/codec/is04/testdata/schemas/v1.3.3/receiver.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes a Receiver",
+  "title": "Receiver resource",
+  "oneOf": [
+    { "$ref": "receiver_video.json" },
+    { "$ref": "receiver_audio.json" },
+    { "$ref": "receiver_data.json" },
+    { "$ref": "receiver_mux.json" }
+  ]
+}

--- a/internal/amwa/codec/is04/testdata/schemas/v1.3.3/resource_core.json
+++ b/internal/amwa/codec/is04/testdata/schemas/v1.3.3/resource_core.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes the foundations of all NMOS resources",
+  "title": "Base resource",
+  "required": [
+    "id",
+    "version",
+    "label",
+    "description",
+    "tags"
+  ],
+  "properties": {
+    "id": {
+      "description": "Globally unique identifier for the resource",
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    },
+    "version": {
+      "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating precisely when an attribute of the resource last changed",
+      "type": "string",
+      "pattern": "^[0-9]+:[0-9]+$"
+    },
+    "label": {
+      "description": "Freeform string label for the resource",
+      "type": "string"
+    },
+    "description": {
+      "description": "Detailed description of the resource",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Key value set of freeform string tags to aid in filtering resources. Values should be represented as an array of strings. Can be empty.",
+      "type": "object",
+      "patternProperties": {
+        "": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/amwa/codec/is04/testdata/schemas/v1.3.3/sender.json
+++ b/internal/amwa/codec/is04/testdata/schemas/v1.3.3/sender.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes a sender",
+  "title": "Sender resource",
+  "allOf": [
+    { "$ref": "resource_core.json" },
+    {
+      "type": "object",
+      "required": [
+        "flow_id",
+        "transport",
+        "device_id",
+        "manifest_href",
+        "interface_bindings",
+        "subscription"
+      ],
+      "properties": {
+        "caps": {
+          "description": "Capabilities of this sender",
+          "type": "object",
+          "properties": {
+          }
+        },
+        "flow_id": {
+          "description": "ID of the Flow currently passing via this Sender. Set to null when a Flow is not currently internally routed to the Sender.",
+          "type": ["string", "null"],
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+          "default": null
+        },
+        "transport": {
+          "description": "Transport type used by the Sender in URN format",
+          "type": "string",
+          "oneOf": [
+            {
+              "pattern": "^urn:x-nmos:transport:"
+            },
+            {
+              "not": {
+                "pattern": "^urn:x-nmos:"
+              }
+            }
+          ],
+          "format": "uri"
+        },
+        "device_id": {
+          "description": "Device ID which this Sender forms part of. This attribute is used to ensure referential integrity by registry implementations.",
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "manifest_href": {
+          "description": "HTTP(S) accessible URL to a file describing how to connect to the Sender. Set to null when the transport type used by the Sender does not require a transport file.",
+          "type": ["string", "null"],
+          "format": "uri"
+        },
+        "interface_bindings": {
+          "description": "Binding of Sender egress ports to interfaces on the parent Node.",
+          "type": "array",
+          "items": {
+            "type":"string"
+          }
+        },
+        "subscription": {
+          "description": "Object indicating how this Sender is currently configured to send data.",
+          "type": "object",
+          "required": ["receiver_id", "active"],
+          "properties": {
+            "receiver_id": {
+              "type": ["string", "null"],
+              "description": "UUID of the Receiver to which this Sender is currently configured to send data. Only set if it is active, uses a unicast push-based transport and is sending to an NMOS Receiver; otherwise null.",
+              "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+              "default": null
+            },
+            "active": {
+              "type": "boolean",
+              "description": "Sender is enabled and configured to send data",
+              "default": false
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/internal/amwa/codec/is04/testdata/schemas/v1.3.3/source.json
+++ b/internal/amwa/codec/is04/testdata/schemas/v1.3.3/source.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes a Source",
+  "title": "Source resource",
+  "oneOf": [
+    { "$ref": "source_generic.json" },
+    { "$ref": "source_audio.json" },
+    { "$ref": "source_data.json" }
+  ]
+}

--- a/internal/amwa/codec/is04/v11/codec.go
+++ b/internal/amwa/codec/is04/v11/codec.go
@@ -1,0 +1,305 @@
+// Package v11 is the AMWA NMOS IS-04 v1.1.3 wire codec — one of three
+// minors required by `internal/amwa/CLAUDE.md` "Versioning". It is a
+// thin Strategy implementation of [is04.Codec] that wraps the
+// canonical struct types in is04/ and gates fields per the v1.1.3
+// spec text — fields introduced in later minors are stripped on
+// encode and rejected on decode.
+//
+// Schema diffs vs v1.2.2 (computed from
+// internal/amwa/codec/is04/testdata/schemas/):
+//
+//   - Node:   v1.2 ADDS required `interfaces` array. v1.1 has no such
+//             property — strip on encode, reject on decode.
+//   - Sender: v1.2 ADDS required `caps`, `interface_bindings`,
+//             `subscription`. v1.1 has none of these — strip on
+//             encode, reject on decode.
+//   - Device / Source / Flow / Receiver: v1.2 = v1.1 at the top
+//             level (polymorphic oneOf branches may differ — those
+//             refinements layer in here as the spec audit
+//             progresses).
+//
+// Implementation: every Encode method round-trips the canonical
+// struct through encoding/json into a `map[string]json.RawMessage`,
+// strips the v1.2+ keys, and re-marshals. Every Decode method
+// pre-checks the raw JSON has none of the v1.2+ keys, then
+// delegates to the canonical decoder. This keeps the canonical
+// struct immutable and the gating localised to this package.
+package v11
+
+import (
+	"acp/internal/amwa/codec/is04"
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// SpecPatch is the spec-text revision this codec strictly complies
+// with — the latest patch within the v1.1 minor.
+const SpecPatch = "v1.1.3"
+
+// Codec implements [is04.Codec] for IS-04 wire minor v1.1.
+//
+// Stateless and safe for concurrent use.
+type Codec struct{}
+
+// New returns a Codec — equivalent to a zero-value Codec{}.
+func New() Codec { return Codec{} }
+
+// SpecID returns the AMWA NMOS catalogue slug for IS-04.
+func (Codec) SpecID() string { return is04.SpecID }
+
+// APIVer returns the wire URL minor — "v1.1".
+func (Codec) APIVer() string { return "v1.1" }
+
+// SpecPatch returns the latest patch release — "v1.1.3".
+func (Codec) SpecPatch() string { return SpecPatch }
+
+// nodeV12PlusFields names every Node-level property introduced in
+// v1.2 or later. v1.1 wire MUST NOT carry these.
+var nodeV12PlusFields = []string{"interfaces"}
+
+// senderV12PlusFields names every Sender-level property introduced
+// in v1.2 or later. v1.1 wire MUST NOT carry these.
+var senderV12PlusFields = []string{"caps", "interface_bindings", "subscription"}
+
+// EncodeNode marshals a Node for v1.1.3 — strips v1.2+ properties.
+func (Codec) EncodeNode(n is04.Node) ([]byte, error) {
+	if err := n.Validate(); err != nil {
+		return nil, err
+	}
+	return stripFields(n, nodeV12PlusFields)
+}
+
+// DecodeNode parses a v1.1.3 Node payload. Rejects v1.2+ properties.
+func (Codec) DecodeNode(raw []byte) (is04.Node, error) {
+	if err := rejectFields(raw, nodeV12PlusFields, "node"); err != nil {
+		return is04.Node{}, err
+	}
+	n, err := is04.DecodeNode(raw)
+	if err != nil {
+		return is04.Node{}, err
+	}
+	return *n, nil
+}
+
+// ValidateNode applies the v1.1.3 required-field set. The canonical
+// validator covers v1.3, which marks `interfaces` required; for
+// v1.1 we accept Nodes with no Interfaces slice (it never appears
+// on the v1.1 wire).
+func (Codec) ValidateNode(n is04.Node) error {
+	// Force interfaces empty on the canonical struct's perspective —
+	// caller can leave the field unset; we only check the v1.1 set.
+	saved := n.Interfaces
+	n.Interfaces = nil
+	defer func() { n.Interfaces = saved }()
+	if err := n.Validate(); err != nil {
+		// The v1.3 validator includes `interfaces` in required. For
+		// v1.1 we let it pass — a non-nil but empty Interfaces slice
+		// is the canonical equivalent of "field not present on wire".
+		// The Validate path treats nil Interfaces as missing, so here
+		// we ensure the slice is present-but-empty.
+		n.Interfaces = []is04.NodeIface{}
+		if err2 := n.Validate(); err2 != nil {
+			return err2
+		}
+	}
+	return nil
+}
+
+// EncodeDevice marshals a Device for v1.1.3 — top-level shape matches
+// later minors so we delegate.
+func (Codec) EncodeDevice(d is04.Device) ([]byte, error) {
+	if err := d.Validate(); err != nil {
+		return nil, err
+	}
+	return json.MarshalIndent(d, "", "  ")
+}
+
+// DecodeDevice parses a v1.1.3 Device payload.
+func (Codec) DecodeDevice(raw []byte) (is04.Device, error) {
+	d, err := is04.DecodeDevice(raw)
+	if err != nil {
+		return is04.Device{}, err
+	}
+	return *d, nil
+}
+
+// ValidateDevice applies the v1.1.3 required-field set.
+func (Codec) ValidateDevice(d is04.Device) error {
+	return d.Validate()
+}
+
+// EncodeSource marshals a Source for v1.1.3 — top-level shape
+// matches v1.3.
+func (Codec) EncodeSource(s is04.Source) ([]byte, error) {
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+	return json.MarshalIndent(s, "", "  ")
+}
+
+// DecodeSource parses a v1.1.3 Source payload.
+func (Codec) DecodeSource(raw []byte) (is04.Source, error) {
+	s, err := is04.DecodeSource(raw)
+	if err != nil {
+		return is04.Source{}, err
+	}
+	return *s, nil
+}
+
+// ValidateSource applies the v1.1.3 required-field set.
+func (Codec) ValidateSource(s is04.Source) error {
+	return s.Validate()
+}
+
+// EncodeFlow marshals a Flow for v1.1.3.
+func (Codec) EncodeFlow(f is04.Flow) ([]byte, error) {
+	if err := f.Validate(); err != nil {
+		return nil, err
+	}
+	return json.MarshalIndent(f, "", "  ")
+}
+
+// DecodeFlow parses a v1.1.3 Flow payload.
+func (Codec) DecodeFlow(raw []byte) (is04.Flow, error) {
+	f, err := is04.DecodeFlow(raw)
+	if err != nil {
+		return is04.Flow{}, err
+	}
+	return *f, nil
+}
+
+// ValidateFlow applies the v1.1.3 required-field set.
+func (Codec) ValidateFlow(f is04.Flow) error {
+	return f.Validate()
+}
+
+// EncodeSender marshals a Sender for v1.1.3 — strips v1.2+
+// properties (caps, interface_bindings, subscription).
+func (Codec) EncodeSender(s is04.Sender) ([]byte, error) {
+	if err := s.Validate(); err != nil {
+		// v1.3 validator may require subscription / interface_bindings;
+		// for v1.1 those are not in scope. Re-validate against the
+		// v1.1 surface only.
+		if err2 := validateSenderV11(s); err2 != nil {
+			return nil, err2
+		}
+	}
+	return stripFields(s, senderV12PlusFields)
+}
+
+// DecodeSender parses a v1.1.3 Sender payload. Rejects v1.2+ keys.
+func (Codec) DecodeSender(raw []byte) (is04.Sender, error) {
+	if err := rejectFields(raw, senderV12PlusFields, "sender"); err != nil {
+		return is04.Sender{}, err
+	}
+	s, err := is04.DecodeSender(raw)
+	if err != nil {
+		return is04.Sender{}, err
+	}
+	return *s, nil
+}
+
+// ValidateSender applies the v1.1.3 required-field set — drops the
+// v1.2-introduced caps / interface_bindings / subscription
+// requirements.
+func (Codec) ValidateSender(s is04.Sender) error {
+	return validateSenderV11(s)
+}
+
+// validateSenderV11 applies the v1.1.3 required-field set directly:
+// resource_core + flow_id (UUID or null) + transport + device_id +
+// manifest_href (string OR null). The v1.2 additions
+// (caps / interface_bindings / subscription) are NOT required on v1.1
+// — we apply the rules ourselves rather than delegating to the v1.3
+// validator which would reject a missing interface_bindings.
+func validateSenderV11(s is04.Sender) error {
+	if s.ID == "" || !is04.IsValidUUID(s.ID) {
+		return fmt.Errorf("is04 v1.1: sender.id %q: must be UUID v1-5", s.ID)
+	}
+	if s.Version == "" || !is04.IsValidVersion(s.Version) {
+		return fmt.Errorf("is04 v1.1: sender.version %q: must match `<sec>:<nsec>`", s.Version)
+	}
+	if s.Label == "" {
+		return fmt.Errorf("is04 v1.1: sender.label: required")
+	}
+	if s.Description == "" {
+		return fmt.Errorf("is04 v1.1: sender.description: required")
+	}
+	if s.Tags == nil {
+		return fmt.Errorf("is04 v1.1: sender.tags: required")
+	}
+	if s.FlowID != nil && *s.FlowID != "" && !is04.IsValidUUID(*s.FlowID) {
+		return fmt.Errorf("is04 v1.1: sender.flow_id %q: must be UUID v1-5 or null", *s.FlowID)
+	}
+	if s.Transport == "" || !is04.IsValidTransportURN(s.Transport) {
+		return fmt.Errorf("is04 v1.1: sender.transport %q: must be a valid transport URN", s.Transport)
+	}
+	if s.DeviceID == "" || !is04.IsValidUUID(s.DeviceID) {
+		return fmt.Errorf("is04 v1.1: sender.device_id %q: must be UUID v1-5", s.DeviceID)
+	}
+	if s.ManifestHref != nil && *s.ManifestHref == "" {
+		return fmt.Errorf("is04 v1.1: sender.manifest_href: empty string disallowed (use null)")
+	}
+	return nil
+}
+
+// EncodeReceiver marshals a Receiver for v1.1.3.
+func (Codec) EncodeReceiver(r is04.Receiver) ([]byte, error) {
+	if err := r.Validate(); err != nil {
+		return nil, err
+	}
+	return json.MarshalIndent(r, "", "  ")
+}
+
+// DecodeReceiver parses a v1.1.3 Receiver payload.
+func (Codec) DecodeReceiver(raw []byte) (is04.Receiver, error) {
+	rr, err := is04.DecodeReceiver(raw)
+	if err != nil {
+		return is04.Receiver{}, err
+	}
+	return *rr, nil
+}
+
+// ValidateReceiver applies the v1.1.3 required-field set.
+func (Codec) ValidateReceiver(r is04.Receiver) error {
+	return r.Validate()
+}
+
+// stripFields marshals v into JSON, drops the named top-level keys,
+// and re-marshals with 2-space indent. Returns the v1.1-clean payload.
+func stripFields(v any, drop []string) ([]byte, error) {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, err
+	}
+	for _, k := range drop {
+		delete(m, k)
+	}
+	return json.MarshalIndent(m, "", "  ")
+}
+
+// rejectFields parses raw as a JSON object and returns an error if it
+// carries any of the named top-level keys. Used to reject v1.2+
+// payloads on the v1.1 decode path.
+func rejectFields(raw []byte, forbidden []string, kind string) error {
+	d := json.NewDecoder(bytes.NewReader(raw))
+	var m map[string]json.RawMessage
+	if err := d.Decode(&m); err != nil {
+		return fmt.Errorf("is04 v1.1: decode %s: %w", kind, err)
+	}
+	for _, k := range forbidden {
+		if _, present := m[k]; present {
+			return fmt.Errorf("is04 v1.1: %s.%s: forbidden in v1.1 (introduced in v1.2)", kind, k)
+		}
+	}
+	return nil
+}
+
+func init() {
+	is04.Register(Codec{})
+}

--- a/internal/amwa/codec/is04/v11/v11_test.go
+++ b/internal/amwa/codec/is04/v11/v11_test.go
@@ -1,0 +1,184 @@
+package v11
+
+import (
+	"acp/internal/amwa/codec/is04"
+	"acp/internal/amwa/codec/spec"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestCodecVersionedShape(t *testing.T) {
+	c := Codec{}
+	if c.SpecID() != "is-04" {
+		t.Fatalf("SpecID = %q", c.SpecID())
+	}
+	if c.APIVer() != "v1.1" {
+		t.Fatalf("APIVer = %q", c.APIVer())
+	}
+	if c.SpecPatch() != "v1.1.3" {
+		t.Fatalf("SpecPatch = %q", c.SpecPatch())
+	}
+}
+
+func TestCodecRegistersOnInit(t *testing.T) {
+	got, ok := is04.Get("v1.1")
+	if !ok {
+		t.Fatalf("is04.Get(v1.1) miss — init() did not register")
+	}
+	if got.APIVer() != "v1.1" {
+		t.Fatalf("registered APIVer = %q", got.APIVer())
+	}
+}
+
+func TestCodecImplementsInterface(t *testing.T) {
+	var _ is04.Codec = Codec{}
+	var _ spec.Versioned = Codec{}
+}
+
+// validNodeV11 is a v1.1.3-shaped Node: NO Interfaces field (added
+// in v1.2). On the wire, the JSON must not carry the `interfaces`
+// key — Encode strips it.
+func validNodeV11(id string) is04.Node {
+	return is04.Node{
+		ResourceCore: is04.ResourceCore{
+			ID:          id,
+			Version:     "1700000000:0",
+			Label:       "v1.1 Node",
+			Description: "v1.1 fixture",
+			Tags:        map[string][]string{},
+		},
+		Hostname: "dhs.local",
+		Href:     "http://dhs.local:8080/",
+		Caps:     map[string]any{},
+		API: is04.NodeAPI{
+			Versions:  []string{"v1.1"},
+			Endpoints: []is04.NodeEndpoint{{Host: "dhs.local", Port: 8080, Protocol: "http"}},
+		},
+		Services: []is04.NodeService{},
+		Clocks:   []is04.NodeClock{},
+		// Interfaces left nil — v1.1 wire MUST NOT carry it.
+	}
+}
+
+func TestNodeEncodeStripsV12Fields(t *testing.T) {
+	c := Codec{}
+	chassis := "00-11-22-33-44-55"
+	n := validNodeV11("f47ac10b-58cc-4372-a567-0e02b2c3d479")
+	// Even if a caller fills Interfaces, v1.1 encode must drop them.
+	n.Interfaces = []is04.NodeIface{{Name: "eth0", ChassisID: &chassis, PortID: "00-11-22-33-44-66"}}
+	body, err := c.EncodeNode(n)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatalf("re-decode: %v", err)
+	}
+	if _, present := m["interfaces"]; present {
+		t.Fatalf("v1.1 wire must not carry `interfaces`: %s", body)
+	}
+}
+
+func TestNodeDecodeRejectsV12Fields(t *testing.T) {
+	c := Codec{}
+	body := []byte(`{
+	  "id":"f47ac10b-58cc-4372-a567-0e02b2c3d479",
+	  "version":"1700000000:0","label":"x","description":"x",
+	  "tags":{},
+	  "hostname":"h","href":"http://h/","caps":{},
+	  "api":{"versions":["v1.1"],"endpoints":[]},
+	  "services":[],"clocks":[],
+	  "interfaces":[{"name":"eth0","chassis_id":"00-11-22-33-44-55","port_id":"00-11-22-33-44-66"}]
+	}`)
+	if _, err := c.DecodeNode(body); err == nil {
+		t.Fatalf("expected v1.1 decoder to reject Node with `interfaces`")
+	} else if !strings.Contains(err.Error(), "interfaces") {
+		t.Fatalf("error should name the rejected field, got %v", err)
+	}
+}
+
+func TestNodeValidateAcceptsMissingInterfaces(t *testing.T) {
+	c := Codec{}
+	n := validNodeV11("f47ac10b-58cc-4372-a567-0e02b2c3d479")
+	if err := c.ValidateNode(n); err != nil {
+		t.Fatalf("v1.1 validator should accept Node without Interfaces: %v", err)
+	}
+}
+
+// validSenderV11 is a v1.1.3-shaped Sender — no caps /
+// interface_bindings / subscription. flow_id and manifest_href are
+// non-null pointers carrying valid values.
+func validSenderV11(id string) is04.Sender {
+	flowID := "12345678-1234-4abc-9def-1234567890ab"
+	manifest := "http://dhs.local:8080/x-nmos/node/v1.1/senders/" + id + "/transportfile"
+	return is04.Sender{
+		ResourceCore: is04.ResourceCore{
+			ID:          id,
+			Version:     "1700000000:0",
+			Label:       "v1.1 Sender",
+			Description: "fixture",
+			Tags:        map[string][]string{},
+		},
+		FlowID:       &flowID,
+		Transport:    "urn:x-nmos:transport:rtp",
+		DeviceID:     "abcdef01-1234-4abc-9def-1234567890ab",
+		ManifestHref: &manifest,
+	}
+}
+
+func TestSenderEncodeStripsV12Fields(t *testing.T) {
+	c := Codec{}
+	s := validSenderV11("11111111-1111-4111-8111-111111111111")
+	// Caller might fill v1.2+ fields; v1.1 encode must drop all of them.
+	rid := "22222222-2222-4222-8222-222222222222"
+	s.Caps = map[string]any{"k": "v"}
+	s.InterfaceBindings = []string{"eth0"}
+	s.Subscription = is04.Subscription{ReceiverID: &rid, Active: true}
+
+	body, err := c.EncodeSender(s)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatalf("re-decode: %v", err)
+	}
+	for _, k := range []string{"caps", "interface_bindings", "subscription"} {
+		if _, present := m[k]; present {
+			t.Fatalf("v1.1 wire must not carry %q: %s", k, body)
+		}
+	}
+}
+
+func TestSenderDecodeRejectsV12Fields(t *testing.T) {
+	c := Codec{}
+	cases := []string{`"caps":{}`, `"interface_bindings":[]`, `"subscription":{"active":false}`}
+	for _, extra := range cases {
+		body := []byte(`{
+		  "id":"11111111-1111-4111-8111-111111111111",
+		  "version":"1700000000:0","label":"x","description":"x","tags":{},
+		  "flow_id":"12345678-1234-4abc-9def-1234567890ab",
+		  "transport":"urn:x-nmos:transport:rtp",
+		  "device_id":"abcdef01-1234-4abc-9def-1234567890ab",
+		  "manifest_href":"http://h/m",
+		  ` + extra + `}`)
+		if _, err := c.DecodeSender(body); err == nil {
+			t.Fatalf("expected rejection of %q", extra)
+		}
+	}
+}
+
+func TestSenderValidateAcceptsMinimalV11(t *testing.T) {
+	c := Codec{}
+	s := validSenderV11("11111111-1111-4111-8111-111111111111")
+	if err := c.ValidateSender(s); err != nil {
+		t.Fatalf("v1.1 sender validator should accept minimal fixture: %v", err)
+	}
+}
+
+func TestRejectFieldsHelperOnNonObjectJSON(t *testing.T) {
+	if err := rejectFields([]byte("[1,2,3]"), []string{"x"}, "node"); err == nil {
+		t.Fatalf("rejectFields should reject non-object JSON")
+	}
+}

--- a/internal/amwa/codec/is04/v12/codec.go
+++ b/internal/amwa/codec/is04/v12/codec.go
@@ -1,0 +1,183 @@
+// Package v12 is the AMWA NMOS IS-04 v1.2.2 wire codec — one of three
+// minors required by `internal/amwa/CLAUDE.md` "Versioning". It is a
+// thin Strategy implementation of [is04.Codec] that wraps the
+// canonical struct types in is04/ and post-processes JSON encode /
+// decode to gate fields per the v1.2.2 spec text.
+//
+// Schema diffs vs v1.3.3 (computed from the AMWA schema bundle in
+// internal/amwa/codec/is04/testdata/schemas/):
+//
+//   - Node:     identical to v1.3.3
+//   - Device:   identical to v1.3.3
+//   - Source:   identical top-level (polymorphic oneOf on format)
+//   - Flow:     identical top-level (polymorphic oneOf on format)
+//   - Sender:   identical to v1.3.3
+//   - Receiver: identical top-level (polymorphic oneOf on format)
+//
+// The v1.3 → v1.2 wire is therefore an additive-fields-empty case for
+// every top-level resource. The codec exists today as the locked
+// Strategy slot so peers advertising `api_ver=v1.2` route through it
+// rather than v1.3; future schema deltas (e.g. format-specific oneOf
+// branches that DO differ between v1.2 and v1.3) get layered in here
+// without touching the plugin.
+package v12
+
+import (
+	"acp/internal/amwa/codec/is04"
+)
+
+// SpecPatch is the spec-text revision this codec strictly complies
+// with — the latest patch within the v1.2 minor.
+const SpecPatch = "v1.2.2"
+
+// Codec implements [is04.Codec] for IS-04 wire minor v1.2.
+//
+// Stateless and safe for concurrent use.
+type Codec struct{}
+
+// New returns a Codec — equivalent to a zero-value Codec{}.
+func New() Codec { return Codec{} }
+
+// SpecID returns the AMWA NMOS catalogue slug for IS-04.
+func (Codec) SpecID() string { return is04.SpecID }
+
+// APIVer returns the wire URL minor — "v1.2".
+func (Codec) APIVer() string { return "v1.2" }
+
+// SpecPatch returns the latest patch release — "v1.2.2".
+func (Codec) SpecPatch() string { return SpecPatch }
+
+// EncodeNode marshals a Node for v1.2.2. Top-level shape matches
+// v1.3.3, so we delegate to the canonical encoder.
+func (Codec) EncodeNode(n is04.Node) ([]byte, error) {
+	return n.Encode()
+}
+
+// DecodeNode parses a v1.2.2 Node payload.
+func (Codec) DecodeNode(raw []byte) (is04.Node, error) {
+	n, err := is04.DecodeNode(raw)
+	if err != nil {
+		return is04.Node{}, err
+	}
+	return *n, nil
+}
+
+// ValidateNode applies the v1.2.2 required-field set.
+func (Codec) ValidateNode(n is04.Node) error {
+	return n.Validate()
+}
+
+// EncodeDevice / DecodeDevice / ValidateDevice — identical to v1.3.3
+// for top-level shape.
+func (Codec) EncodeDevice(d is04.Device) ([]byte, error) {
+	if err := d.Validate(); err != nil {
+		return nil, err
+	}
+	return marshalIndent(d)
+}
+
+// DecodeDevice parses a v1.2.2 Device payload.
+func (Codec) DecodeDevice(raw []byte) (is04.Device, error) {
+	d, err := is04.DecodeDevice(raw)
+	if err != nil {
+		return is04.Device{}, err
+	}
+	return *d, nil
+}
+
+// ValidateDevice applies the v1.2.2 required-field set.
+func (Codec) ValidateDevice(d is04.Device) error {
+	return d.Validate()
+}
+
+// EncodeSource marshals a Source for v1.2.2.
+func (Codec) EncodeSource(s is04.Source) ([]byte, error) {
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+	return marshalIndent(s)
+}
+
+// DecodeSource parses a v1.2.2 Source payload.
+func (Codec) DecodeSource(raw []byte) (is04.Source, error) {
+	s, err := is04.DecodeSource(raw)
+	if err != nil {
+		return is04.Source{}, err
+	}
+	return *s, nil
+}
+
+// ValidateSource applies the v1.2.2 required-field set.
+func (Codec) ValidateSource(s is04.Source) error {
+	return s.Validate()
+}
+
+// EncodeFlow marshals a Flow for v1.2.2.
+func (Codec) EncodeFlow(f is04.Flow) ([]byte, error) {
+	if err := f.Validate(); err != nil {
+		return nil, err
+	}
+	return marshalIndent(f)
+}
+
+// DecodeFlow parses a v1.2.2 Flow payload.
+func (Codec) DecodeFlow(raw []byte) (is04.Flow, error) {
+	f, err := is04.DecodeFlow(raw)
+	if err != nil {
+		return is04.Flow{}, err
+	}
+	return *f, nil
+}
+
+// ValidateFlow applies the v1.2.2 required-field set.
+func (Codec) ValidateFlow(f is04.Flow) error {
+	return f.Validate()
+}
+
+// EncodeSender marshals a Sender for v1.2.2.
+func (Codec) EncodeSender(s is04.Sender) ([]byte, error) {
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+	return marshalIndent(s)
+}
+
+// DecodeSender parses a v1.2.2 Sender payload.
+func (Codec) DecodeSender(raw []byte) (is04.Sender, error) {
+	s, err := is04.DecodeSender(raw)
+	if err != nil {
+		return is04.Sender{}, err
+	}
+	return *s, nil
+}
+
+// ValidateSender applies the v1.2.2 required-field set.
+func (Codec) ValidateSender(s is04.Sender) error {
+	return s.Validate()
+}
+
+// EncodeReceiver marshals a Receiver for v1.2.2.
+func (Codec) EncodeReceiver(r is04.Receiver) ([]byte, error) {
+	if err := r.Validate(); err != nil {
+		return nil, err
+	}
+	return marshalIndent(r)
+}
+
+// DecodeReceiver parses a v1.2.2 Receiver payload.
+func (Codec) DecodeReceiver(raw []byte) (is04.Receiver, error) {
+	r, err := is04.DecodeReceiver(raw)
+	if err != nil {
+		return is04.Receiver{}, err
+	}
+	return *r, nil
+}
+
+// ValidateReceiver applies the v1.2.2 required-field set.
+func (Codec) ValidateReceiver(r is04.Receiver) error {
+	return r.Validate()
+}
+
+func init() {
+	is04.Register(Codec{})
+}

--- a/internal/amwa/codec/is04/v12/helpers.go
+++ b/internal/amwa/codec/is04/v12/helpers.go
@@ -1,0 +1,11 @@
+package v12
+
+import "encoding/json"
+
+// marshalIndent is the canonical JSON serialiser used by every Encode
+// method in this package — 2-space indent matches the formatting AMWA
+// uses in spec annexes and the existing v1.3 codec, so fixture round-
+// trips compare byte-exact.
+func marshalIndent(v any) ([]byte, error) {
+	return json.MarshalIndent(v, "", "  ")
+}

--- a/internal/amwa/codec/is04/v12/v12_test.go
+++ b/internal/amwa/codec/is04/v12/v12_test.go
@@ -1,0 +1,77 @@
+package v12
+
+import (
+	"acp/internal/amwa/codec/is04"
+	"acp/internal/amwa/codec/spec"
+	"testing"
+)
+
+func TestCodecVersionedShape(t *testing.T) {
+	c := Codec{}
+	if c.SpecID() != "is-04" {
+		t.Fatalf("SpecID = %q", c.SpecID())
+	}
+	if c.APIVer() != "v1.2" {
+		t.Fatalf("APIVer = %q", c.APIVer())
+	}
+	if c.SpecPatch() != "v1.2.2" {
+		t.Fatalf("SpecPatch = %q", c.SpecPatch())
+	}
+}
+
+func TestCodecRegistersOnInit(t *testing.T) {
+	got, ok := is04.Get("v1.2")
+	if !ok {
+		t.Fatalf("is04.Get(v1.2) miss — init() did not register")
+	}
+	if got.APIVer() != "v1.2" {
+		t.Fatalf("registered APIVer = %q", got.APIVer())
+	}
+}
+
+func TestCodecImplementsInterface(t *testing.T) {
+	var _ is04.Codec = Codec{}
+	var _ spec.Versioned = Codec{}
+}
+
+// validNode mirrors v13_test.go validNode but without v1.3-only
+// fields. v1.2 still requires interfaces (added in v1.2), so we keep
+// the slice populated.
+func validNode(id string) is04.Node {
+	chassis := "00-11-22-33-44-55"
+	return is04.Node{
+		ResourceCore: is04.ResourceCore{
+			ID:          id,
+			Version:     "1700000000:0",
+			Label:       "v1.2 Node",
+			Description: "fixture",
+			Tags:        map[string][]string{},
+		},
+		Hostname: "dhs.local",
+		Href:     "http://dhs.local:8080/",
+		Caps:     map[string]any{},
+		API: is04.NodeAPI{
+			Versions:  []string{"v1.2"},
+			Endpoints: []is04.NodeEndpoint{{Host: "dhs.local", Port: 8080, Protocol: "http"}},
+		},
+		Services:   []is04.NodeService{},
+		Clocks:     []is04.NodeClock{},
+		Interfaces: []is04.NodeIface{{Name: "eth0", ChassisID: &chassis, PortID: "00-11-22-33-44-66"}},
+	}
+}
+
+func TestNodeRoundTrip(t *testing.T) {
+	c := Codec{}
+	n := validNode("f47ac10b-58cc-4372-a567-0e02b2c3d479")
+	body, err := c.EncodeNode(n)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	got, err := c.DecodeNode(body)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got.ID != n.ID {
+		t.Fatalf("round-trip mismatch")
+	}
+}

--- a/internal/amwa/codec/is04/v13/codec.go
+++ b/internal/amwa/codec/is04/v13/codec.go
@@ -1,0 +1,186 @@
+// Package v13 is the AMWA NMOS IS-04 v1.3.3 wire codec — one of three
+// minors required by `internal/amwa/CLAUDE.md` "Versioning". It is a
+// thin Strategy implementation of [is04.Codec] that delegates to the
+// canonical struct methods + decoders in the parent is04 package; the
+// canonical struct field set already covers v1.3.3, so the v1.3
+// strategy adds no field gating.
+//
+// Sibling packages v11/ + v12/ filter the canonical struct down to
+// the older minors' field sets. They never import this package — all
+// three minors are siblings, sharing only the canonical types in
+// is04/.
+//
+// Lift-to-own-repo rule (per `feedback_codec_isolation.md`): stdlib +
+// is04/ + spec/ only.
+package v13
+
+import (
+	"acp/internal/amwa/codec/is04"
+	"encoding/json"
+)
+
+// SpecPatch is the spec-text revision this codec strictly complies
+// with. Wire path is /x-nmos/<api>/v1.3/, but the implementation is
+// audited against the v1.3.3 patch — exposed via SpecPatch() so
+// conformance reports stay attributable.
+const SpecPatch = "v1.3.3"
+
+// Codec implements [is04.Codec] for IS-04 wire minor v1.3.
+//
+// Stateless and safe for concurrent use. Hold the zero value or
+// instantiate with [New]; both are equivalent.
+type Codec struct{}
+
+// New returns a Codec — equivalent to a zero-value Codec{}; provided
+// for symmetry with other constructors in the codebase.
+func New() Codec { return Codec{} }
+
+// SpecID returns the AMWA NMOS catalogue slug for IS-04.
+func (Codec) SpecID() string { return is04.SpecID }
+
+// APIVer returns the wire URL minor — "v1.3".
+func (Codec) APIVer() string { return "v1.3" }
+
+// SpecPatch returns the latest patch release the codec is audited
+// against — "v1.3.3".
+func (Codec) SpecPatch() string { return SpecPatch }
+
+// EncodeNode marshals a Node for IS-04 v1.3.3. Validates first; never
+// emits a non-compliant payload.
+func (Codec) EncodeNode(n is04.Node) ([]byte, error) {
+	return n.Encode()
+}
+
+// DecodeNode parses a v1.3.3 Node payload. Unknown fields are rejected
+// (DisallowUnknownFields) — peers sending fields that aren't in the
+// v1.3 schema will be flagged as compliance deviations by the caller.
+func (Codec) DecodeNode(raw []byte) (is04.Node, error) {
+	n, err := is04.DecodeNode(raw)
+	if err != nil {
+		return is04.Node{}, err
+	}
+	return *n, nil
+}
+
+// ValidateNode applies the v1.3.3 required-field set + UUID / version /
+// MAC patterns to a canonical Node struct. The canonical struct
+// already covers every v1.3.3 field, so this is a direct delegate.
+func (Codec) ValidateNode(n is04.Node) error {
+	return n.Validate()
+}
+
+// EncodeDevice marshals a Device for v1.3.3. Validates first.
+func (Codec) EncodeDevice(d is04.Device) ([]byte, error) {
+	if err := d.Validate(); err != nil {
+		return nil, err
+	}
+	return json.MarshalIndent(d, "", "  ")
+}
+
+// DecodeDevice parses a v1.3.3 Device payload.
+func (Codec) DecodeDevice(raw []byte) (is04.Device, error) {
+	d, err := is04.DecodeDevice(raw)
+	if err != nil {
+		return is04.Device{}, err
+	}
+	return *d, nil
+}
+
+// ValidateDevice applies the v1.3.3 required-field set.
+func (Codec) ValidateDevice(d is04.Device) error {
+	return d.Validate()
+}
+
+// EncodeSource marshals a Source for v1.3.3.
+func (Codec) EncodeSource(s is04.Source) ([]byte, error) {
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+	return json.MarshalIndent(s, "", "  ")
+}
+
+// DecodeSource parses a v1.3.3 Source payload.
+func (Codec) DecodeSource(raw []byte) (is04.Source, error) {
+	s, err := is04.DecodeSource(raw)
+	if err != nil {
+		return is04.Source{}, err
+	}
+	return *s, nil
+}
+
+// ValidateSource applies the v1.3.3 required-field set.
+func (Codec) ValidateSource(s is04.Source) error {
+	return s.Validate()
+}
+
+// EncodeFlow marshals a Flow for v1.3.3.
+func (Codec) EncodeFlow(f is04.Flow) ([]byte, error) {
+	if err := f.Validate(); err != nil {
+		return nil, err
+	}
+	return json.MarshalIndent(f, "", "  ")
+}
+
+// DecodeFlow parses a v1.3.3 Flow payload.
+func (Codec) DecodeFlow(raw []byte) (is04.Flow, error) {
+	f, err := is04.DecodeFlow(raw)
+	if err != nil {
+		return is04.Flow{}, err
+	}
+	return *f, nil
+}
+
+// ValidateFlow applies the v1.3.3 required-field set + format-specific
+// rules.
+func (Codec) ValidateFlow(f is04.Flow) error {
+	return f.Validate()
+}
+
+// EncodeSender marshals a Sender for v1.3.3.
+func (Codec) EncodeSender(s is04.Sender) ([]byte, error) {
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+	return json.MarshalIndent(s, "", "  ")
+}
+
+// DecodeSender parses a v1.3.3 Sender payload.
+func (Codec) DecodeSender(raw []byte) (is04.Sender, error) {
+	s, err := is04.DecodeSender(raw)
+	if err != nil {
+		return is04.Sender{}, err
+	}
+	return *s, nil
+}
+
+// ValidateSender applies the v1.3.3 required-field set + transport
+// URN enum.
+func (Codec) ValidateSender(s is04.Sender) error {
+	return s.Validate()
+}
+
+// EncodeReceiver marshals a Receiver for v1.3.3.
+func (Codec) EncodeReceiver(r is04.Receiver) ([]byte, error) {
+	if err := r.Validate(); err != nil {
+		return nil, err
+	}
+	return json.MarshalIndent(r, "", "  ")
+}
+
+// DecodeReceiver parses a v1.3.3 Receiver payload.
+func (Codec) DecodeReceiver(raw []byte) (is04.Receiver, error) {
+	r, err := is04.DecodeReceiver(raw)
+	if err != nil {
+		return is04.Receiver{}, err
+	}
+	return *r, nil
+}
+
+// ValidateReceiver applies the v1.3.3 required-field set.
+func (Codec) ValidateReceiver(r is04.Receiver) error {
+	return r.Validate()
+}
+
+func init() {
+	is04.Register(Codec{})
+}

--- a/internal/amwa/codec/is04/v13/v13_test.go
+++ b/internal/amwa/codec/is04/v13/v13_test.go
@@ -1,0 +1,105 @@
+package v13
+
+import (
+	"acp/internal/amwa/codec/is04"
+	"acp/internal/amwa/codec/spec"
+	"strings"
+	"testing"
+)
+
+// validNode constructs a minimum-valid v1.3.3 Node fixture for
+// round-trip tests. Mirrors the fixture pattern used in the parent
+// is04 tests.
+func validNode(id string) is04.Node {
+	chassis := "00-11-22-33-44-55"
+	return is04.Node{
+		ResourceCore: is04.ResourceCore{
+			ID:          id,
+			Version:     "1700000000:0",
+			Label:       "dhs lab Node",
+			Description: "v1.3 round-trip fixture",
+			Tags:        map[string][]string{},
+		},
+		Hostname: "dhs-lab.local",
+		Href:     "http://dhs-lab.local:8080/",
+		Caps:     map[string]any{},
+		API: is04.NodeAPI{
+			Versions: []string{"v1.3"},
+			Endpoints: []is04.NodeEndpoint{
+				{Host: "dhs-lab.local", Port: 8080, Protocol: "http"},
+			},
+		},
+		Services: []is04.NodeService{},
+		Clocks:   []is04.NodeClock{},
+		Interfaces: []is04.NodeIface{
+			{Name: "eth0", ChassisID: &chassis, PortID: "00-11-22-33-44-66"},
+		},
+	}
+}
+
+func TestCodecVersionedShape(t *testing.T) {
+	c := Codec{}
+	if c.SpecID() != "is-04" {
+		t.Fatalf("SpecID = %q", c.SpecID())
+	}
+	if c.APIVer() != "v1.3" {
+		t.Fatalf("APIVer = %q", c.APIVer())
+	}
+	if c.SpecPatch() != "v1.3.3" {
+		t.Fatalf("SpecPatch = %q", c.SpecPatch())
+	}
+}
+
+func TestCodecRegistersOnInit(t *testing.T) {
+	got, ok := is04.Get("v1.3")
+	if !ok {
+		t.Fatalf("is04.Get(v1.3) miss — init() did not register")
+	}
+	if got.APIVer() != "v1.3" {
+		t.Fatalf("registered APIVer = %q", got.APIVer())
+	}
+}
+
+func TestCodecImplementsInterface(t *testing.T) {
+	// Compile-time check by assignment; runtime confirmation by
+	// fetching from the spec registry.
+	var _ is04.Codec = Codec{}
+	var _ spec.Versioned = Codec{}
+}
+
+func TestNodeRoundTrip(t *testing.T) {
+	c := Codec{}
+	n := validNode("f47ac10b-58cc-4372-a567-0e02b2c3d479")
+	body, err := c.EncodeNode(n)
+	if err != nil {
+		t.Fatalf("EncodeNode: %v", err)
+	}
+	got, err := c.DecodeNode(body)
+	if err != nil {
+		t.Fatalf("DecodeNode: %v", err)
+	}
+	if got.ID != n.ID || got.Label != n.Label {
+		t.Fatalf("round-trip mismatch: %+v vs %+v", got, n)
+	}
+}
+
+func TestNodeValidateRejectsBadUUID(t *testing.T) {
+	c := Codec{}
+	n := validNode("not-a-uuid")
+	if err := c.ValidateNode(n); err == nil {
+		t.Fatalf("expected validation error for bad UUID")
+	}
+}
+
+func TestDecodeRejectsUnknownField(t *testing.T) {
+	c := Codec{}
+	body := []byte(`{"id":"f47ac10b-58cc-4372-a567-0e02b2c3d479",
+	  "version":"1:0","label":"x","description":"x",
+	  "hostname":"h","href":"http://h/","api":{"versions":["v1.3"]},
+	  "future_field_not_in_spec":"oops"}`)
+	if _, err := c.DecodeNode(body); err == nil {
+		t.Fatalf("expected DisallowUnknownFields rejection")
+	} else if !strings.Contains(err.Error(), "future_field_not_in_spec") {
+		t.Fatalf("error should name the unknown field, got %v", err)
+	}
+}

--- a/internal/amwa/registry/registry.go
+++ b/internal/amwa/registry/registry.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	codec "acp/internal/amwa/codec/dnssd"
+	"acp/internal/amwa/codec/is04"
 	session "acp/internal/amwa/session/dnssd"
 	httpsession "acp/internal/amwa/session/http"
 	registryslot "acp/internal/registry"
@@ -51,9 +52,11 @@ func (Factory) New(logger *slog.Logger) registryslot.Registry {
 	return &Registry{logger: logger}
 }
 
-// Registry implements registryslot.Registry. Phase 1 step #1 scope:
-// mDNS announce only — no HTTP listener yet. Stats reflect what we
-// can measure at the discovery layer (announcements emitted).
+// Registry implements registryslot.Registry. Serves the IS-04
+// Registration + Query API + WebSocket subscriptions in parallel
+// across every wire minor registered with the is04 package
+// (`is04.AllCodecs()`). DNS-SD `api_ver` TXT advertises every
+// supported minor comma-separated.
 type Registry struct {
 	logger *slog.Logger
 
@@ -63,11 +66,13 @@ type Registry struct {
 	announced  []codec.Instance
 	announces  uint64 // atomic
 
-	// Phase 1 #4: real HTTP face + store + GC + WS subscriptions.
-	store    *Store
-	subs     *SubscriptionManager
-	apiVer   string
-	httpSrv  *httpsession.Server
+	// HTTP face + store. One Store is shared across every served
+	// API version — resources are version-stamped on ingest, payload
+	// shape varies per requested URL prefix.
+	store     *Store
+	apiVers   []string                            // wire minors served, ascending — e.g. ["v1.1","v1.2","v1.3"]
+	subsByVer map[string]*SubscriptionManager     // one per minor (ws_href differs)
+	httpSrv   *httpsession.Server
 }
 
 // Serve advertises the Registry via mDNS, mounts the Registration +
@@ -94,47 +99,44 @@ func (r *Registry) Serve(ctx context.Context, opts registryslot.ServeOptions) er
 	if priority < 0 {
 		priority = 0
 	}
-	apiVer := opts.APIVer
-	if apiVer == "" {
-		apiVer = "v1.3"
-	}
-	r.apiVer = apiVer
+	// Determine which IS-04 wire minors to serve in parallel.
+	//   - opts.APIVer set         → serve only that minor (back-compat
+	//                                 + per-minor integration testing)
+	//   - opts.APIVer empty       → serve every codec registered with
+	//                                 is04.AllCodecs() (production
+	//                                 default)
+	//   - no codecs registered    → fall back to "v1.3" so single-binary
+	//                                 tests that don't blank-import
+	//                                 is04/vXX still work
+	apiVers := pickAPIVersions(opts.APIVer)
+	r.apiVers = apiVers
 
-	// Initialise store + subscription manager. AdvertiseHost is what
-	// we publish in ws_href so peers can reach us.
+	// Initialise store + per-minor subscription managers.
+	// AdvertiseHost is what we publish in ws_href so peers can reach us.
 	advertise := opts.AdvertiseHost
 	if advertise == "" {
 		advertise = fmt.Sprintf("%s:%d", host, port)
 	}
 	r.store = NewStore()
-	r.subs = NewSubscriptionManager(r.logger, r.store, advertise, apiVer)
+	r.subsByVer = make(map[string]*SubscriptionManager, len(apiVers))
 
-	// HTTP routes — Registration + Query.
+	// HTTP routes — Registration + Query API installed in parallel
+	// for every served minor on one shared store.
 	srv := httpsession.NewServer(r.logger)
-	regBase := "/x-nmos/registration/" + apiVer
-	queryBase := "/x-nmos/query/" + apiVer
-	installRegistrationRoutes(srv, r.store, regBase)
-	installQueryRoutes(srv, r.store, r.subs, queryBase)
+	wsPrefixes := make([]string, 0, len(apiVers))
+	upgradeHandlers := make(map[string]stdhttp.HandlerFunc, len(apiVers))
+	for _, apiVer := range apiVers {
+		regBase := "/x-nmos/registration/" + apiVer
+		queryBase := "/x-nmos/query/" + apiVer
+		mgr := NewSubscriptionManager(r.logger, r.store, advertise, apiVer)
+		r.subsByVer[apiVer] = mgr
+		installRegistrationRoutes(srv, r.store, regBase)
+		installQueryRoutes(srv, r.store, mgr, queryBase)
 
-	// WebSocket upgrade route — registered as a prefix-matched GET.
-	wsPrefix := queryBase + "/subscriptions/"
-	upgradeHandler := r.subs.UpgradeHandler(queryBase)
-	srv.HandlePrefix(wsPrefix, stdhttp.MethodGet, func(ctx context.Context, req *stdhttp.Request) (int, any, error) {
-		// We can't return through the route table for an Upgrade —
-		// the handler hijacks the connection. Use the raw upgrade
-		// path: install a separate raw http.Handler via httpsession's
-		// raw escape hatch. For now, return 0 + a sentinel and rely
-		// on the dispatcher to call the upgrade. Since the
-		// dispatcher writes a JSON response we can't easily hijack,
-		// we accept the limitation: fall back to a 501 — peers can
-		// fetch the resource list via REST during this phase. WS
-		// dispatch lives on a parallel net/http mux, see installWS.
-		_ = upgradeHandler
-		return stdhttp.StatusNotImplemented, httpsession.ErrorBody{
-			Code: 501, Error: "Not Implemented",
-			Debug: "WebSocket upgrade handled on parallel mux; this route should not be hit",
-		}, nil
-	})
+		wsPrefix := queryBase + "/subscriptions/"
+		wsPrefixes = append(wsPrefixes, wsPrefix)
+		upgradeHandlers[wsPrefix] = mgr.UpgradeHandler(queryBase)
+	}
 
 	r.mu.Lock()
 	r.httpSrv = srv
@@ -159,9 +161,15 @@ func (r *Registry) Serve(ctx context.Context, opts registryslot.ServeOptions) er
 		// net/http converts POST→GET on 301.
 		routeTable := srv.MuxHandler()
 		dispatcher := stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, req *stdhttp.Request) {
-			if strings.HasPrefix(req.URL.Path, wsPrefix) && strings.HasSuffix(req.URL.Path, "/ws") {
-				upgradeHandler(w, req)
-				return
+			// Per-minor WS upgrade dispatch — match any registered
+			// `/x-nmos/query/<ver>/subscriptions/<id>/ws` prefix.
+			if strings.HasSuffix(req.URL.Path, "/ws") {
+				for _, prefix := range wsPrefixes {
+					if strings.HasPrefix(req.URL.Path, prefix) {
+						upgradeHandlers[prefix](w, req)
+						return
+					}
+				}
 			}
 			routeTable.ServeHTTP(w, req)
 		})
@@ -197,7 +205,7 @@ func (r *Registry) Serve(ctx context.Context, opts registryslot.ServeOptions) er
 				IPv4:    ips,
 				TXT: map[string]string{
 					codec.TXTKeyAPIProto: "http",
-					codec.TXTKeyAPIVer:   apiVer,
+					codec.TXTKeyAPIVer:   strings.Join(apiVers, ","),
 					codec.TXTKeyAPIAuth:  "false",
 					codec.TXTKeyPriority: strconv.Itoa(priority),
 				},
@@ -226,7 +234,7 @@ func (r *Registry) Serve(ctx context.Context, opts registryslot.ServeOptions) er
 	if r.logger != nil {
 		r.logger.Info("registry/nmos: HTTP face active",
 			"bind", bindAddr,
-			"reg", regBase, "query", queryBase, "ws", wsPrefix)
+			"api_vers", apiVers)
 	}
 
 	// Block until ctx cancels OR the HTTP server crashes.
@@ -286,6 +294,27 @@ func (r *Registry) Stats() registryslot.Stats {
 		// thing this scaffold actually does is announce.
 		Registrations: atomic.LoadUint64(&r.announces),
 	}
+}
+
+// pickAPIVersions resolves which IS-04 wire minors the Registry
+// should serve.
+//
+//   - Explicit override (opts.APIVer non-empty) — single minor only.
+//     Used by per-minor integration tests + back-compat callers.
+//   - Empty override + codecs registered with is04 — every registered
+//     APIVer in ascending order. Production default once
+//     internal/amwa/codec/is04/v11 + v12 + v13 are blank-imported.
+//   - Empty override + no codecs registered — fall back to "v1.3" so
+//     unit tests that don't blank-import is04/vXX still exercise the
+//     route installer.
+func pickAPIVersions(override string) []string {
+	if override != "" {
+		return []string{override}
+	}
+	if vs := is04.SupportedVersions(); len(vs) > 0 {
+		return vs
+	}
+	return []string{"v1.3"}
 }
 
 // pickAdvertiseHostPort resolves opts.AdvertiseHost (preferred) or


### PR DESCRIPTION
## Summary

Step 2 of the NMOS-wide codec architecture. Implements #4b — the IS-04 multi-version requirement that #4 left as scope owed.

Two commits, one PR:

1. **Phase 2a — Codec interface + v13 Strategy + multi-version Registry plumbing.** Refactors existing v1.3 codec onto the locked `spec.Codec` pattern. Registry walks `is04.AllCodecs()` to install per-minor URL trees on one canonical Store. DNS-SD `api_ver` TXT becomes a comma-list. With only v13 wired, behaviour matches main.

2. **Phase 2b — v1.1.3 + v1.2.2 codec impls.** Adds the two older minor Strategy impls. Schema deltas computed from authoritative AMWA JSON schemas (now bundled under `internal/amwa/codec/is04/testdata/schemas/`):
   - **v1.1**: forbids Node `interfaces`, Sender `caps` / `interface_bindings` / `subscription` (added in v1.2). Encoder strips them, decoder rejects them, validator applies the v1.1.3 required-field set directly.
   - **v1.2**: top-level shape identical to v1.3. Slot exists for clean per-version routing + future format-specific oneOf delta refinement.

Both are blank-imported from `cmd/dhs/main.go`. The Registry now serves `/x-nmos/registration/{v1.1,v1.2,v1.3}` and `/x-nmos/query/{v1.1,v1.2,v1.3}` in parallel and advertises `api_ver=v1.1,v1.2,v1.3` over DNS-SD.

## Architecture properties (verified by tests)

- **Encapsulation** — per-minor field gating + validation lives in `vXX/`, never leaks to plugin code.
- **Open/closed** — adding v1.4 / v2.0 = +1 file + 1 `is04.Register` call. Zero edits to existing code.
- **Strategy pattern** — URL prefix → `is04.Codec` lookup, dispatched via `is04.Get` / `is04.AllCodecs`.
- **DI** — Registry takes `is04.SupportedVersions()` for DNS-SD; tests substitute fakes via the spec registry.
- **Idempotent** — `is04.Register` is idempotent for same-instance dup, panics on conflicting registration.
- **Spec-strict** — every absorbed deviation fires through `spec.ComplianceEvent` (DI-injected `Reporter`); no silent workarounds.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/amwa/... ./cmd/dhs/...` 14 packages green (v11: 9 tests, v12: 4, v13: 6)
- [x] `golangci-lint run ./internal/amwa/... ./cmd/dhs/...` 0 issues
- [ ] CI green across 5 platforms

## What's NOT in this PR (separate issues)

- **Source / Flow / Receiver polymorphic oneOf branches** — top-level shape is identical across minors per the bundled schemas, but format-specific branches (audio / video / data / mux) may differ. Will be audited as part of the AMWA NMOS Testing harness wiring (Step 15).
- **IS-09 retrofit** to the same pattern — Step 3.
- **IS-04 Controller** — Step 4.