### PR TITLE
feat(nmos/is09): retrofit onto spec.Codec pattern (Step 3)

### DIFF
--- a/cmd/dhs/main.go
+++ b/cmd/dhs/main.go
@@ -67,6 +67,7 @@ import (
 	_ "acp/internal/amwa/codec/is04/v11"
 	_ "acp/internal/amwa/codec/is04/v12"
 	_ "acp/internal/amwa/codec/is04/v13"
+	_ "acp/internal/amwa/codec/is09/v10"
 )
 
 // Build-time variables injected via -ldflags. See Makefile LDFLAGS_FULL.

--- a/internal/amwa/codec/is09/codec.go
+++ b/internal/amwa/codec/is09/codec.go
@@ -1,0 +1,75 @@
+package is09
+
+import (
+	"acp/internal/amwa/codec/spec"
+)
+
+// SpecID is the AMWA NMOS catalogue slug for IS-09 (System API).
+const SpecID = "is-09"
+
+// Codec is the IS-09 wire codec contract — one implementation per
+// supported wire minor. IS-09 currently has a single stable minor
+// (v1.0), so the registry holds one entry. Adding a future v1.1 = +1
+// file in vXX/ + 1 init Register call; zero edits to this file.
+//
+// Per-resource methods cover the only resource IS-09 publishes — the
+// Global config object served at `GET /global`.
+//
+// Implementations are stateless and safe for concurrent use.
+type Codec interface {
+	spec.Versioned
+
+	EncodeGlobal(Global) ([]byte, error)
+	DecodeGlobal([]byte) (Global, error)
+	ValidateGlobal(Global) error
+}
+
+// versions is the per-process Registry of IS-09 codec implementations.
+var versions = spec.NewRegistry[Codec]()
+
+// Register installs a codec for one IS-09 wire minor. Called from each
+// minor's init(). Idempotent for the same instance; panics on
+// duplicate-different-instance or any empty SpecID/APIVer/SpecPatch
+// — same semantics as is04.Register.
+func Register(c Codec) {
+	if c.SpecID() != SpecID {
+		panic("is09.Register: SpecID must be " + SpecID + ", got " + c.SpecID())
+	}
+	versions.Register(c)
+}
+
+// Get returns the codec registered for the given APIVer (e.g. "v1.0"),
+// or false when no such version is wired in.
+func Get(apiVer string) (Codec, bool) {
+	return versions.Get(apiVer)
+}
+
+// AllCodecs returns every registered IS-09 codec sorted by APIVer
+// ascending.
+func AllCodecs() []Codec {
+	return versions.AllCodecs()
+}
+
+// SupportedVersions returns every registered APIVer string in ascending
+// order — fed verbatim into the DNS-SD `api_ver` TXT comma-list for
+// `_nmos-system._tcp` records.
+func SupportedVersions() []string {
+	return versions.SupportedVersions()
+}
+
+// SelectHighest picks the highest version mutually supported between
+// us and a peer's advertised list.
+func SelectHighest(peerVersions []string) (Codec, error) {
+	return spec.SelectHighestMutual(versions, peerVersions)
+}
+
+// Default returns the highest registered IS-09 codec — used by call
+// sites that don't yet route per-version. Panics if no codec is
+// registered.
+func Default() Codec {
+	all := versions.AllCodecs()
+	if len(all) == 0 {
+		panic("is09.Default: no codec registered (forgot to blank-import internal/amwa/codec/is09/v10?)")
+	}
+	return all[len(all)-1]
+}

--- a/internal/amwa/codec/is09/v10/codec.go
+++ b/internal/amwa/codec/is09/v10/codec.go
@@ -1,0 +1,61 @@
+// Package v10 is the AMWA NMOS IS-09 v1.0.0 wire codec. IS-09 has only
+// one stable minor today, so this is the sole codec registered with
+// is09 — adding a future minor lands as a sibling vXX/ package.
+//
+// The IS-09 v1.0.0 schema predates IS-10 (Authorization), so it
+// deliberately omits the `api_auth` TXT key from DNS-SD records and
+// the `auth` field from the Global resource. The codec ships exactly
+// what the spec text mandates — see `internal/amwa/codec/is09/global.go`
+// + `validate.go` in the parent package.
+package v10
+
+import (
+	"acp/internal/amwa/codec/is09"
+)
+
+// SpecPatch is the spec-text revision this codec strictly complies
+// with — IS-09 has only one release.
+const SpecPatch = "v1.0.0"
+
+// Codec implements [is09.Codec] for IS-09 wire minor v1.0.
+//
+// Stateless and safe for concurrent use.
+type Codec struct{}
+
+// New returns a Codec — equivalent to a zero-value Codec{}.
+func New() Codec { return Codec{} }
+
+// SpecID returns the AMWA NMOS catalogue slug for IS-09.
+func (Codec) SpecID() string { return is09.SpecID }
+
+// APIVer returns the wire URL minor — "v1.0".
+func (Codec) APIVer() string { return "v1.0" }
+
+// SpecPatch returns the spec patch — "v1.0.0".
+func (Codec) SpecPatch() string { return SpecPatch }
+
+// EncodeGlobal marshals a Global config for v1.0.0. Validates first.
+func (Codec) EncodeGlobal(g is09.Global) ([]byte, error) {
+	return g.Encode()
+}
+
+// DecodeGlobal parses a v1.0.0 Global config payload. Unknown fields
+// are rejected by the underlying decoder.
+func (Codec) DecodeGlobal(raw []byte) (is09.Global, error) {
+	g, err := is09.Decode(raw)
+	if err != nil {
+		return is09.Global{}, err
+	}
+	return *g, nil
+}
+
+// ValidateGlobal applies the v1.0.0 required-field set + range bounds
+// (heartbeat 1-1000, announce 2-10, ptp domain 0-127, syslog port
+// 1-65535) + syslog hostname/IPv4/IPv6 format checks.
+func (Codec) ValidateGlobal(g is09.Global) error {
+	return g.Validate()
+}
+
+func init() {
+	is09.Register(Codec{})
+}

--- a/internal/amwa/codec/is09/v10/v10_test.go
+++ b/internal/amwa/codec/is09/v10/v10_test.go
@@ -1,0 +1,82 @@
+package v10
+
+import (
+	"acp/internal/amwa/codec/is09"
+	"acp/internal/amwa/codec/spec"
+	"testing"
+)
+
+func TestCodecVersionedShape(t *testing.T) {
+	c := Codec{}
+	if c.SpecID() != "is-09" {
+		t.Fatalf("SpecID = %q", c.SpecID())
+	}
+	if c.APIVer() != "v1.0" {
+		t.Fatalf("APIVer = %q", c.APIVer())
+	}
+	if c.SpecPatch() != "v1.0.0" {
+		t.Fatalf("SpecPatch = %q", c.SpecPatch())
+	}
+}
+
+func TestCodecRegistersOnInit(t *testing.T) {
+	got, ok := is09.Get("v1.0")
+	if !ok {
+		t.Fatalf("is09.Get(v1.0) miss — init() did not register")
+	}
+	if got.APIVer() != "v1.0" {
+		t.Fatalf("registered APIVer = %q", got.APIVer())
+	}
+}
+
+func TestCodecImplementsInterface(t *testing.T) {
+	var _ is09.Codec = Codec{}
+	var _ spec.Versioned = Codec{}
+}
+
+func TestSupportedVersionsContainsV10(t *testing.T) {
+	vs := is09.SupportedVersions()
+	found := false
+	for _, v := range vs {
+		if v == "v1.0" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("SupportedVersions = %v, expected v1.0", vs)
+	}
+}
+
+// validGlobal mirrors the fixture pattern used in the parent
+// is09 tests. Round-trip exercises EncodeGlobal / DecodeGlobal /
+// ValidateGlobal through the Codec interface.
+func validGlobal() is09.Global {
+	return is09.Global{
+		ID:          "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+		Version:     "1700000000:0",
+		Label:       "v1.0 lab system",
+		Description: "fixture",
+		Tags:        map[string][]string{},
+		IS04:        is09.IS04Config{HeartbeatInterval: 5},
+		PTP: is09.PTPConfig{
+			AnnounceReceiptTimeout: 3,
+			DomainNumber:           127,
+		},
+	}
+}
+
+func TestGlobalRoundTrip(t *testing.T) {
+	c := Codec{}
+	g := validGlobal()
+	body, err := c.EncodeGlobal(g)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	got, err := c.DecodeGlobal(body)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got.ID != g.ID {
+		t.Fatalf("round-trip mismatch: %q != %q", got.ID, g.ID)
+	}
+}


### PR DESCRIPTION
## Summary

Step 3 of the NMOS-wide codec rollout. Mirrors what PR #160 does for IS-04: lifts the existing IS-09 v1.0.0 codec onto the locked `spec.Codec` contract from PR #159 (now on main as `c3709113`).

IS-09 has a single stable wire minor (v1.0), so this PR adds:
- `is09.Codec` interface (extends `spec.Versioned`) with `EncodeGlobal` / `DecodeGlobal` / `ValidateGlobal`
- `is09.Register` / `Get` / `AllCodecs` / `SupportedVersions` / `SelectHighest` / `Default` — same shape as `is04`
- `internal/amwa/codec/is09/v10/codec.go` Strategy impl, self-registers via `init()`
- 5 unit tests (Versioned shape, registration, interface compliance, SupportedVersions, round-trip)
- Blank import from `cmd/dhs/main.go`

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/amwa/codec/is09/...` green
- [x] `golangci-lint run ./internal/amwa/codec/is09/... ./cmd/dhs/...` 0 issues
- [ ] CI green across 5 platforms

Stack: depends on #160 only conceptually (the doc lock). Both PRs can land in either order.