### PR TITLE
feat(nmos): IS-04 Controller consumer (Step 4)

### DIFF
--- a/cmd/dhs/cmd_nmos.go
+++ b/cmd/dhs/cmd_nmos.go
@@ -24,6 +24,7 @@ import (
 
 	codec "acp/internal/amwa/codec/dnssd"
 	"acp/internal/amwa/codec/is09"
+	"acp/internal/amwa/codec/spec"
 	"acp/internal/amwa/consumer"
 	"acp/internal/amwa/provider"
 	session "acp/internal/amwa/session/dnssd"
@@ -43,8 +44,10 @@ func runNMOSConsumer(ctx context.Context, args []string) error {
 		return runNMOSDiscover(ctx, rest)
 	case "system":
 		return runNMOSSystem(ctx, rest)
+	case "walk":
+		return runNMOSWalk(ctx, rest)
 	}
-	return fmt.Errorf("consumer nmos: unknown verb %q (expected: discover, system)", verb)
+	return fmt.Errorf("consumer nmos: unknown verb %q (expected: discover, system, walk)", verb)
 }
 
 // runNMOSProducer dispatches `dhs producer nmos <verb> [args]`.
@@ -614,4 +617,72 @@ announce of _nmos-register._tcp + _nmos-query._tcp.
   --gc-interval D          Heartbeat watchdog tick rate (default 1s)
   --heartbeat-timeout D    Evict Nodes that miss heartbeats this long
                            (default 12s, IS-04 §6.1)`)
+}
+
+// ---- consumer walk (IS-04 Controller) ---------------------------------------
+
+func runNMOSWalk(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("walk", flag.ContinueOnError)
+	registry := fs.String("registry", "", "Registry origin (Mode B unicast — http://host:port). When empty, --mdns or --unicast triggers DNS-SD discovery.")
+	mdns := fs.Bool("mdns", true, "discover the Registry via mDNS (Mode A); ignored if --registry is set")
+	unicast := fs.Bool("unicast", false, "discover via unicast DNS-SD (Mode B); requires --resolver")
+	resolver := fs.String("resolver", "", "unicast DNS resolver IP")
+	domain := fs.String("domain", "by-systems.arpa", "unicast DNS-SD discovery domain")
+	apiVer := fs.String("api-ver", "", "force a specific IS-04 wire minor (v1.1 / v1.2 / v1.3); empty = highest mutual")
+	timeout := fs.Duration("timeout", 5*time.Second, "DNS-SD discovery timeout")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *registry == "" && !*mdns && !*unicast {
+		return fmt.Errorf("nmos walk: pick exactly one of --registry / --mdns / --unicast")
+	}
+
+	mode := ""
+	switch {
+	case *unicast:
+		if *resolver == "" {
+			return fmt.Errorf("nmos walk --unicast: --resolver is required")
+		}
+		mode = "unicast"
+	case *mdns:
+		mode = "mdns"
+	}
+
+	rep := &spec.SliceReporter{}
+	logger := slog.Default()
+	c, err := consumer.NewController(ctx, consumer.ControllerOptions{
+		Logger:           logger,
+		Reporter:         rep,
+		RegistryURL:      *registry,
+		DiscoveryMode:    mode,
+		DiscoveryTimeout: *timeout,
+		UnicastResolver:  *resolver,
+		UnicastDomain:    *domain,
+		APIVer:           *apiVer,
+	})
+	if err != nil {
+		return fmt.Errorf("nmos walk: %w", err)
+	}
+
+	fmt.Printf("Registry %s (api_ver=%s, spec=%s)\n", c.BaseURL(), c.Codec().APIVer(), c.Codec().SpecPatch())
+
+	snap, errs := c.Walk(ctx)
+	fmt.Printf("Catalogue:\n")
+	fmt.Printf("  nodes:     %d\n", len(snap.Nodes))
+	fmt.Printf("  devices:   %d\n", len(snap.Devices))
+	fmt.Printf("  sources:   %d\n", len(snap.Sources))
+	fmt.Printf("  flows:     %d\n", len(snap.Flows))
+	fmt.Printf("  senders:   %d\n", len(snap.Senders))
+	fmt.Printf("  receivers: %d\n", len(snap.Receivers))
+	for _, e := range errs {
+		fmt.Fprintf(os.Stderr, "warn: %v\n", e)
+	}
+	if events := rep.Snapshot(); len(events) > 0 {
+		fmt.Fprintf(os.Stderr, "%d compliance event(s) fired:\n", len(events))
+		for _, ev := range events {
+			fmt.Fprintf(os.Stderr, "  [%s] %s/%s %s: %s\n",
+				ev.Severity, ev.SpecID, ev.APIVer, ev.Code, ev.Detail)
+		}
+	}
+	return nil
 }

--- a/internal/amwa/consumer/controller.go
+++ b/internal/amwa/consumer/controller.go
@@ -1,0 +1,315 @@
+package consumer
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"acp/internal/amwa/codec/dnssd"
+	"acp/internal/amwa/codec/is04"
+	"acp/internal/amwa/codec/spec"
+	"acp/internal/amwa/session/query"
+)
+
+// ControllerOptions configures the IS-04 Controller. The pattern
+// mirrors IS09FetchOptions in system.go: explicit dependency injection,
+// no globals, every knob a constructor parameter.
+type ControllerOptions struct {
+	// Logger is optional; nil = silent.
+	Logger *slog.Logger
+
+	// Reporter receives compliance events. nil = spec.NopReporter{}.
+	Reporter spec.Reporter
+
+	// One of three modes (mirrors the Registry's mode A/B/C/D
+	// deployment matrix from internal/amwa/CLAUDE.md):
+	//
+	//   RegistryURL set       — Mode B unicast: skip discovery,
+	//                            speak straight to the named host
+	//                            (e.g. http://10.6.239.113:8235).
+	//   DiscoveryMode "mdns"  — Mode A: browse _nmos-query._tcp,
+	//                            select highest-pri instance, talk
+	//                            to it.
+	//   DiscoveryMode "unicast" — Mode B via authoritative DNS:
+	//                              resolve _nmos-query._tcp at the
+	//                              named resolver / domain, pick
+	//                              highest-pri.
+	//
+	// At least one of (RegistryURL, DiscoveryMode) must be set.
+	RegistryURL   string
+	DiscoveryMode string
+
+	// Discovery knobs (used when RegistryURL is empty).
+	DiscoveryTimeout time.Duration // default 5s
+	UnicastResolver  string        // e.g. "10.100.0.1"
+	UnicastDomain    string        // e.g. "by-systems.arpa"
+
+	// APIVer constrains version selection. Empty = pick highest
+	// from is04.SupportedVersions() ∩ peer's api_ver TXT.
+	APIVer string
+}
+
+// Controller is the IS-04 Controller — high-level wrapper around the
+// Query API client + a chosen Codec. Hold one per Registry.
+//
+// Stateless after construction — every method is safe to call
+// concurrently.
+type Controller struct {
+	logger   *slog.Logger
+	reporter spec.Reporter
+	client   *query.Client
+}
+
+// NewController resolves the Registry per ControllerOptions and
+// constructs a Controller bound to the negotiated wire-version codec.
+//
+// Returns the typed [spec.ErrNoCommonVersion] when the peer's
+// `api_ver` TXT shares no minor with our registered codecs (caller
+// fires the compliance event).
+func NewController(ctx context.Context, opts ControllerOptions) (*Controller, error) {
+	rep := opts.Reporter
+	if rep == nil {
+		rep = spec.NopReporter{}
+	}
+
+	base, peerVers, err := resolveRegistry(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	codec, err := pickCodec(opts.APIVer, peerVers, rep)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := query.NewClient(base, codec)
+	if err != nil {
+		return nil, err
+	}
+	return &Controller{logger: opts.Logger, reporter: rep, client: c}, nil
+}
+
+// Codec returns the wire-version codec bound to this Controller.
+// Useful for callers that need to encode requests in the same minor
+// (e.g. POSTing a subscription).
+func (c *Controller) Codec() is04.Codec { return c.client.Codec }
+
+// BaseURL returns the Registry origin the Controller speaks to.
+func (c *Controller) BaseURL() string { return c.client.Base }
+
+// Walk fetches every catalogue collection under the Registry's Query
+// API and returns a single CatalogueSnapshot. Compliance events fire
+// for any collection that 404s (per the EVS Cerebrum behaviour
+// observed 2026-04-30 — query face surface but every catalogue
+// collection 404s).
+type CatalogueSnapshot struct {
+	APIVer    string
+	Nodes     []is04.Node
+	Devices   []is04.Device
+	Sources   []is04.Source
+	Flows     []is04.Flow
+	Senders   []is04.Sender
+	Receivers []is04.Receiver
+}
+
+// Walk fetches every catalogue collection. Errors fire compliance
+// events but do not abort the walk — callers see the partial snapshot
+// + an error per failed collection.
+func (c *Controller) Walk(ctx context.Context) (*CatalogueSnapshot, []error) {
+	snap := &CatalogueSnapshot{APIVer: c.client.Codec.APIVer()}
+	var errs []error
+
+	collect := func(name string, run func() error) {
+		if err := run(); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", name, err))
+			c.fire(spec.SeverityWarn, "nmos_query_collection_failed",
+				fmt.Sprintf("%s: %v", name, err), "")
+		}
+	}
+
+	collect("nodes", func() error {
+		v, err := c.client.ListNodes(ctx, nil)
+		snap.Nodes = v
+		return err
+	})
+	collect("devices", func() error {
+		v, err := c.client.ListDevices(ctx, nil)
+		snap.Devices = v
+		return err
+	})
+	collect("sources", func() error {
+		v, err := c.client.ListSources(ctx, nil)
+		snap.Sources = v
+		return err
+	})
+	collect("flows", func() error {
+		v, err := c.client.ListFlows(ctx, nil)
+		snap.Flows = v
+		return err
+	})
+	collect("senders", func() error {
+		v, err := c.client.ListSenders(ctx, nil)
+		snap.Senders = v
+		return err
+	})
+	collect("receivers", func() error {
+		v, err := c.client.ListReceivers(ctx, nil)
+		snap.Receivers = v
+		return err
+	})
+
+	return snap, errs
+}
+
+// fire is the DI seam to the spec.Reporter.
+func (c *Controller) fire(sev spec.Severity, code, detail, resource string) {
+	c.reporter.Report(spec.ComplianceEvent{
+		SpecID:    is04.SpecID,
+		APIVer:    c.client.Codec.APIVer(),
+		SpecPatch: c.client.Codec.SpecPatch(),
+		Code:      code,
+		Severity:  sev,
+		Detail:    detail,
+		Resource:  resource,
+		PeerHost:  trimURLScheme(c.client.Base),
+		At:        time.Now(),
+	})
+}
+
+// resolveRegistry maps ControllerOptions to a (baseURL, peerAPIVers)
+// pair. Walks Mode-B unicast first, then Mode-A mDNS. Returns an
+// explicit error when no path is configured.
+func resolveRegistry(ctx context.Context, opts ControllerOptions) (string, []string, error) {
+	if opts.RegistryURL != "" {
+		// Direct unicast — peer api_ver unknown until probe.
+		// Caller will negotiate against opts.APIVer or our supported set.
+		return strings.TrimRight(opts.RegistryURL, "/"), nil, nil
+	}
+	timeout := opts.DiscoveryTimeout
+	if timeout == 0 {
+		timeout = 5 * time.Second
+	}
+	switch strings.ToLower(opts.DiscoveryMode) {
+	case "mdns", "":
+		insts, err := DiscoverMDNS(ctx, timeout, opts.Logger)
+		if err != nil {
+			return "", nil, fmt.Errorf("nmos/controller: mDNS browse: %w", err)
+		}
+		return pickQueryInstance(insts)
+	case "unicast", "static":
+		insts, err := DiscoverUnicast(ctx, opts.UnicastResolver, opts.UnicastDomain, timeout)
+		if err != nil {
+			return "", nil, fmt.Errorf("nmos/controller: unicast browse: %w", err)
+		}
+		return pickQueryInstance(insts)
+	default:
+		return "", nil, fmt.Errorf("nmos/controller: unknown DiscoveryMode %q", opts.DiscoveryMode)
+	}
+}
+
+// pickQueryInstance filters the discovery result to `_nmos-query._tcp`
+// records, picks highest-pri (lowest pri integer wins per IS-04 §3),
+// and constructs a base URL. Returns the per-pri-tied selection in
+// definition order.
+func pickQueryInstance(insts []dnssd.Instance) (string, []string, error) {
+	var queries []dnssd.Instance
+	for _, in := range insts {
+		if in.Service == dnssd.ServiceQuery {
+			queries = append(queries, in)
+		}
+	}
+	if len(queries) == 0 {
+		return "", nil, fmt.Errorf("nmos/controller: no _nmos-query._tcp instances discovered")
+	}
+	best := queries[0]
+	bestPri := readPri(best)
+	for _, in := range queries[1:] {
+		p := readPri(in)
+		if p < bestPri {
+			best = in
+			bestPri = p
+		}
+	}
+	apiProto := best.TXT[dnssd.TXTKeyAPIProto]
+	if apiProto == "" {
+		apiProto = "http"
+	}
+	host := strings.TrimSuffix(best.Host, ".")
+	base := fmt.Sprintf("%s://%s:%d", apiProto, host, best.Port)
+	apiVers := splitAPIVerTXT(best.TXT[dnssd.TXTKeyAPIVer])
+	return base, apiVers, nil
+}
+
+// pickCodec runs the peer-version intersection rule with our
+// registered IS-04 codecs.
+func pickCodec(override string, peerVers []string, rep spec.Reporter) (is04.Codec, error) {
+	if override != "" {
+		c, ok := is04.Get(override)
+		if !ok {
+			return nil, fmt.Errorf("nmos/controller: APIVer override %q not registered", override)
+		}
+		return c, nil
+	}
+	if len(peerVers) == 0 {
+		// Direct unicast with no discovery info — assume our highest.
+		return is04.Default(), nil
+	}
+	c, err := is04.SelectHighest(peerVers)
+	if err != nil {
+		// Fire the compliance event before bubbling up.
+		rep.Report(spec.ComplianceEvent{
+			SpecID:    is04.SpecID,
+			Code:      "nmos_no_common_api_ver",
+			Severity:  spec.SeverityError,
+			Detail:    err.Error(),
+			At:        time.Now(),
+		})
+		return nil, err
+	}
+	return c, nil
+}
+
+// readPri returns the `pri` TXT integer or maxInt32 when absent /
+// malformed. Same semantics as the IS-04 §3 selection rule:
+// missing pri = lowest priority (won't be picked over a sibling).
+func readPri(in dnssd.Instance) int {
+	v := in.TXT[dnssd.TXTKeyPriority]
+	if v == "" {
+		return 1 << 30
+	}
+	n := 0
+	for _, ch := range v {
+		if ch < '0' || ch > '9' {
+			return 1 << 30
+		}
+		n = n*10 + int(ch-'0')
+	}
+	return n
+}
+
+// splitAPIVerTXT parses the comma-separated `api_ver` TXT into a list
+// of normalised version strings. Whitespace + case tolerated.
+func splitAPIVerTXT(txt string) []string {
+	if txt == "" {
+		return nil
+	}
+	parts := strings.Split(txt, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.ToLower(strings.TrimSpace(p))
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// trimURLScheme returns host:port from a base like "http://h:p".
+func trimURLScheme(u string) string {
+	if i := strings.Index(u, "://"); i >= 0 {
+		return u[i+3:]
+	}
+	return u
+}

--- a/internal/amwa/session/http/post.go
+++ b/internal/amwa/session/http/post.go
@@ -1,0 +1,63 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	stdhttp "net/http"
+	"strings"
+)
+
+// PostJSON issues a POST with a JSON body and decodes the response
+// into dst. status is the actual response status code (caller decides
+// whether 200/201 is acceptable); err is non-nil only on transport /
+// decode failure, NOT on a non-2xx response.
+//
+// dst may be nil — useful when the caller only cares about status.
+// When non-nil it must be a pointer; the body is decoded with
+// DisallowUnknownFields so spec deviations surface loudly.
+func (c *Client) PostJSON(ctx context.Context, url string, src, dst any) (int, error) {
+	body, err := json.Marshal(src)
+	if err != nil {
+		return 0, fmt.Errorf("nmos/http: marshal body: %w", err)
+	}
+	req, err := stdhttp.NewRequestWithContext(ctx, stdhttp.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return 0, fmt.Errorf("nmos/http: build POST: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("nmos/http: POST %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	max := c.MaxBody
+	if max <= 0 {
+		max = DefaultMaxBody
+	}
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, max+1))
+	if err != nil {
+		return resp.StatusCode, fmt.Errorf("nmos/http: read POST body: %w", err)
+	}
+	if int64(len(raw)) > max {
+		return resp.StatusCode, fmt.Errorf("nmos/http: POST response exceeds %d bytes", max)
+	}
+
+	if dst == nil {
+		return resp.StatusCode, nil
+	}
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return resp.StatusCode, nil
+	}
+	d := json.NewDecoder(strings.NewReader(string(raw)))
+	d.DisallowUnknownFields()
+	if err := d.Decode(dst); err != nil {
+		return resp.StatusCode, fmt.Errorf("nmos/http: decode POST response: %w", err)
+	}
+	return resp.StatusCode, nil
+}

--- a/internal/amwa/session/query/client.go
+++ b/internal/amwa/session/query/client.go
@@ -1,0 +1,162 @@
+package query
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"acp/internal/amwa/codec/is04"
+	httpsession "acp/internal/amwa/session/http"
+)
+
+// Client is the IS-04 Query API client. Hold one per Registry: it
+// caches the base URL + the negotiated wire-version codec.
+//
+// Constructor takes a Codec via DI so tests can substitute a fake.
+// Production callers usually obtain one from the Controller after
+// `is04.SelectHighest(peer.APIVersions)`.
+type Client struct {
+	HTTP   *httpsession.Client
+	Base   string     // e.g. "http://10.6.239.113:8235"
+	Codec  is04.Codec // negotiated wire version — drives URL APIVer + payload shape
+}
+
+// NewClient constructs a Client. base is the Registry origin
+// (`http(s)://host:port`, no trailing slash, no `/x-nmos/...`); codec
+// must already be selected via [is04.SelectHighest] or [is04.Get].
+//
+// Returns an error when base is empty / unparseable / already carries
+// a path; codec must be non-nil. Both checks fail fast — invalid input
+// here is a programming error.
+func NewClient(base string, codec is04.Codec) (*Client, error) {
+	if codec == nil {
+		return nil, fmt.Errorf("nmos/query: codec must not be nil")
+	}
+	u, err := url.Parse(strings.TrimRight(base, "/"))
+	if err != nil {
+		return nil, fmt.Errorf("nmos/query: parse base %q: %w", base, err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return nil, fmt.Errorf("nmos/query: base %q must be an absolute URL", base)
+	}
+	if u.Path != "" && u.Path != "/" {
+		return nil, fmt.Errorf("nmos/query: base %q must not include a path", base)
+	}
+	return &Client{
+		HTTP:  httpsession.NewClient(),
+		Base:  u.Scheme + "://" + u.Host,
+		Codec: codec,
+	}, nil
+}
+
+// urlFor returns the full URL for a Query API resource path —
+// `/x-nmos/query/<api_ver>/<rest>`.
+func (c *Client) urlFor(rest string) string {
+	rest = strings.TrimPrefix(rest, "/")
+	return c.Base + "/x-nmos/query/" + c.Codec.APIVer() + "/" + rest
+}
+
+// Index returns the top-level Query API index — the JSON array of
+// sub-resource paths a Registry exposes. Non-empty array confirms the
+// Registry's right face is reachable.
+func (c *Client) Index(ctx context.Context) ([]string, error) {
+	var out []string
+	if err := c.HTTP.GetJSON(ctx, c.urlFor("/"), &out); err != nil {
+		return nil, fmt.Errorf("nmos/query: index: %w", err)
+	}
+	return out, nil
+}
+
+// ListNodes fetches every Node currently registered. The result is
+// already decoded against the negotiated minor's schema. Caller may
+// pass a non-empty filter map to apply RQL-lite query parameters
+// (label / description / id / version equality).
+func (c *Client) ListNodes(ctx context.Context, filter map[string]string) ([]is04.Node, error) {
+	raw, err := c.fetchListRaw(ctx, "nodes", filter)
+	if err != nil {
+		return nil, err
+	}
+	return decodeList(raw, "node", c.Codec.DecodeNode)
+}
+
+// ListDevices fetches every Device.
+func (c *Client) ListDevices(ctx context.Context, filter map[string]string) ([]is04.Device, error) {
+	raw, err := c.fetchListRaw(ctx, "devices", filter)
+	if err != nil {
+		return nil, err
+	}
+	return decodeList(raw, "device", c.Codec.DecodeDevice)
+}
+
+// ListSources fetches every Source.
+func (c *Client) ListSources(ctx context.Context, filter map[string]string) ([]is04.Source, error) {
+	raw, err := c.fetchListRaw(ctx, "sources", filter)
+	if err != nil {
+		return nil, err
+	}
+	return decodeList(raw, "source", c.Codec.DecodeSource)
+}
+
+// ListFlows fetches every Flow.
+func (c *Client) ListFlows(ctx context.Context, filter map[string]string) ([]is04.Flow, error) {
+	raw, err := c.fetchListRaw(ctx, "flows", filter)
+	if err != nil {
+		return nil, err
+	}
+	return decodeList(raw, "flow", c.Codec.DecodeFlow)
+}
+
+// ListSenders fetches every Sender.
+func (c *Client) ListSenders(ctx context.Context, filter map[string]string) ([]is04.Sender, error) {
+	raw, err := c.fetchListRaw(ctx, "senders", filter)
+	if err != nil {
+		return nil, err
+	}
+	return decodeList(raw, "sender", c.Codec.DecodeSender)
+}
+
+// ListReceivers fetches every Receiver.
+func (c *Client) ListReceivers(ctx context.Context, filter map[string]string) ([]is04.Receiver, error) {
+	raw, err := c.fetchListRaw(ctx, "receivers", filter)
+	if err != nil {
+		return nil, err
+	}
+	return decodeList(raw, "receiver", c.Codec.DecodeReceiver)
+}
+
+// fetchListRaw issues GET /x-nmos/query/<api_ver>/<plural>?<filter>
+// and returns the raw JSON array. Per-resource decode happens via the
+// negotiated Codec so version-specific field gating applies.
+func (c *Client) fetchListRaw(ctx context.Context, plural string, filter map[string]string) ([]json.RawMessage, error) {
+	u := c.urlFor(plural)
+	if len(filter) > 0 {
+		q := url.Values{}
+		for k, v := range filter {
+			q.Set(k, v)
+		}
+		u += "?" + q.Encode()
+	}
+	var out []json.RawMessage
+	if err := c.HTTP.GetJSON(ctx, u, &out); err != nil {
+		return nil, fmt.Errorf("nmos/query: list %s: %w", plural, err)
+	}
+	return out, nil
+}
+
+// decodeList runs each raw element through the per-resource codec
+// decoder. Returns a partial result on the first decode error so the
+// caller can surface "X of Y resources decoded; the rest were
+// non-spec".
+func decodeList[T any](raw []json.RawMessage, kind string, decode func([]byte) (T, error)) ([]T, error) {
+	out := make([]T, 0, len(raw))
+	for i, rb := range raw {
+		v, err := decode([]byte(rb))
+		if err != nil {
+			return out, fmt.Errorf("nmos/query: decode %s[%d]: %w", kind, i, err)
+		}
+		out = append(out, v)
+	}
+	return out, nil
+}

--- a/internal/amwa/session/query/client_test.go
+++ b/internal/amwa/session/query/client_test.go
@@ -1,0 +1,105 @@
+package query
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"acp/internal/amwa/codec/is04"
+	v13 "acp/internal/amwa/codec/is04/v13"
+)
+
+func TestNewClientRejectsBadInput(t *testing.T) {
+	cases := []struct {
+		name, base string
+		codec      is04.Codec
+		wantErr    string
+	}{
+		{"nil codec", "http://h", nil, "codec must not be nil"},
+		{"empty base", "", v13.New(), "absolute URL"},
+		{"bare host", "10.0.0.1", v13.New(), "absolute URL"},
+		{"with path", "http://h/foo", v13.New(), "must not include a path"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewClient(tc.base, tc.codec)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("err = %v, want contains %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestNewClientStripsTrailingSlash(t *testing.T) {
+	c, err := NewClient("http://10.0.0.1:8235/", v13.New())
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if c.Base != "http://10.0.0.1:8235" {
+		t.Fatalf("Base = %q", c.Base)
+	}
+	if c.Codec.APIVer() != "v1.3" {
+		t.Fatalf("Codec.APIVer = %q", c.Codec.APIVer())
+	}
+}
+
+func TestIndexRoundTrip(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/x-nmos/query/v1.3/" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`["nodes/","devices/","sources/","flows/","senders/","receivers/","subscriptions/"]`))
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(srv.URL, v13.New())
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	got, err := c.Index(context.Background())
+	if err != nil {
+		t.Fatalf("Index: %v", err)
+	}
+	if len(got) != 7 {
+		t.Fatalf("got %d entries, want 7", len(got))
+	}
+}
+
+func TestListNodesAppliesLabelFilter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("label"); got != "lab" {
+			t.Errorf("filter not propagated, got label=%q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{
+		  "id":"f47ac10b-58cc-4372-a567-0e02b2c3d479",
+		  "version":"1700000000:0","label":"lab","description":"x","tags":{},
+		  "hostname":"h","href":"http://h/","caps":{},
+		  "api":{"versions":["v1.3"],"endpoints":[{"host":"h","port":80,"protocol":"http"}]},
+		  "services":[],"clocks":[],"interfaces":[]
+		}]`))
+	}))
+	defer srv.Close()
+
+	c, _ := NewClient(srv.URL, v13.New())
+	nodes, err := c.ListNodes(context.Background(), map[string]string{"label": "lab"})
+	if err != nil {
+		t.Fatalf("ListNodes: %v", err)
+	}
+	if len(nodes) != 1 || nodes[0].Label != "lab" {
+		t.Fatalf("nodes = %v", nodes)
+	}
+}
+
+func TestDecodeListSurfacesError(t *testing.T) {
+	bad := `{"id":"not-uuid","version":"x","label":"","description":"","tags":null}`
+	raw := []json.RawMessage{json.RawMessage(bad)}
+	c := v13.New()
+	if _, err := decodeList(raw, "node", c.DecodeNode); err == nil {
+		t.Fatalf("expected decode error on malformed element")
+	}
+}

--- a/internal/amwa/session/query/doc.go
+++ b/internal/amwa/session/query/doc.go
@@ -1,0 +1,19 @@
+// Package query is the IS-04 Query API client — Layer 2 session
+// helper used by the Controller plugin.
+//
+// It speaks the Query API spec (https://specs.amwa.tv/is-04/) with a
+// per-API-version base path
+// (`http(s)://<host>:<port>/x-nmos/query/<api_ver>/`). Every endpoint
+// returns canonical IS-04 resources; the package wires through to the
+// versioned [is04.Codec] for decoding so the same Client speaks every
+// supported wire minor (v1.1 / v1.2 / v1.3).
+//
+// Per the layered architecture in `internal/amwa/docs/dependencies.md`,
+// this package is allowed to import:
+//
+//   - `internal/amwa/codec/is04` — for the Codec interface
+//   - `internal/amwa/codec/spec` — for Versioned + ComplianceEvent
+//   - `internal/amwa/session/http` — typed JSON HTTP client
+//
+// It MUST NOT import any plugin layer.
+package query


### PR DESCRIPTION
## Summary

Step 4 — IS-04 Controller (consumer side). Plumbs the multi-version `is04.Codec` interface (from PR #160 → main) end-to-end: same Controller speaks v1.1, v1.2, or v1.3 depending on what the Registry advertises; never silently downgrades.

Lands:

- `internal/amwa/session/query/` — IS-04 Query API client. Codec injected via constructor; `decodeList[T]` per-resource decode through the `Codec` interface so any registered minor decodes correctly.
- `internal/amwa/session/http/post.go` — typed `PostJSON` for future IS-05 / IS-12 PATCH-style endpoints.
- `internal/amwa/consumer/controller.go` — high-level Controller. Mode-A mDNS browse + Mode-B unicast + direct `--registry` modes. `is04.SelectHighest(peer.api_ver)` per IS-04 §3 selection rule; fires `nmos_no_common_api_ver` compliance event on empty intersection. `Walk` collects all 6 catalogue collections; per-collection 404 fires `nmos_query_collection_failed` and continues (matches EVS Cerebrum behaviour observed 2026-04-30).
- `cmd/dhs/cmd_nmos.go` — `dhs consumer nmos walk` verb; flags mirror `system`. Output: per-collection counts + compliance summary.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/amwa/... ./cmd/dhs/...` 16 packages green (query: 6 new tests)
- [x] `golangci-lint run ./internal/amwa/... ./cmd/dhs/...` 0 issues
- [ ] CI green across 5 platforms

## Future on the same branch family
- WS subscription consumer (`watch` verb) — separate PR layered on this Controller
- BCP-002 / 004 validators wired through the Controller decode path — Steps 10–11