### PR TITLE
feat(nmos/is07): codec base + v1.0.1 Strategy impl (Step 6, refs #164)

### DIFF
--- a/cmd/dhs/main.go
+++ b/cmd/dhs/main.go
@@ -69,6 +69,7 @@ import (
 	_ "acp/internal/amwa/codec/is04/v13"
 	_ "acp/internal/amwa/codec/is05/v10"
 	_ "acp/internal/amwa/codec/is05/v11"
+	_ "acp/internal/amwa/codec/is07/v10"
 	_ "acp/internal/amwa/codec/is09/v10"
 )
 

--- a/internal/amwa/codec/is07/codec.go
+++ b/internal/amwa/codec/is07/codec.go
@@ -1,0 +1,50 @@
+package is07
+
+import (
+	"acp/internal/amwa/codec/spec"
+)
+
+// SpecID is the AMWA NMOS catalogue slug for IS-07 (Event & Tally).
+const SpecID = "is-07"
+
+// Codec is the IS-07 wire codec contract — one implementation per
+// supported wire minor (only v1.0 today). Each minor's vXX/
+// subpackage embeds is07/ canonical types and gates fields per its
+// spec text. Plugin code uses this interface; concrete impls are
+// wired via init() at process start.
+type Codec interface {
+	spec.Versioned
+
+	EncodeMessage(Message) ([]byte, error)
+	DecodeMessage([]byte) (Message, error)
+
+	EncodeCommand(Command) ([]byte, error)
+	DecodeCommand([]byte) (Command, error)
+}
+
+// versions is the per-process Registry of IS-07 codec implementations.
+var versions = spec.NewRegistry[Codec]()
+
+// Register installs a codec for one IS-07 wire minor — same
+// semantics as is04.Register / is05.Register / is09.Register.
+// Idempotent for same instance; panics on conflict.
+func Register(c Codec) {
+	if c.SpecID() != SpecID {
+		panic("is07.Register: SpecID must be " + SpecID + ", got " + c.SpecID())
+	}
+	versions.Register(c)
+}
+
+// Get / AllCodecs / SupportedVersions / SelectHighest / Default —
+// same shape as is04 / is05 / is09.
+func Get(apiVer string) (Codec, bool)             { return versions.Get(apiVer) }
+func AllCodecs() []Codec                          { return versions.AllCodecs() }
+func SupportedVersions() []string                 { return versions.SupportedVersions() }
+func SelectHighest(peer []string) (Codec, error)  { return spec.SelectHighestMutual(versions, peer) }
+func Default() Codec {
+	all := versions.AllCodecs()
+	if len(all) == 0 {
+		panic("is07.Default: no codec registered (forgot to blank-import internal/amwa/codec/is07/vXX?)")
+	}
+	return all[len(all)-1]
+}

--- a/internal/amwa/codec/is07/doc.go
+++ b/internal/amwa/codec/is07/doc.go
@@ -1,0 +1,35 @@
+// Package is07 implements the AMWA NMOS IS-07 Event & Tally codec.
+// Stdlib-only, spec-strict per https://specs.amwa.tv/is-07/.
+//
+// Required versions per `internal/amwa/CLAUDE.md` "Versioning":
+//
+//   - v1.0 (latest patch v1.0.1) — single track. Wire layer is JSON
+//     over WebSocket OR MQTT. The Node serves the Events API
+//     (`/x-nmos/events/v1.0/...`) over HTTP and the WebSocket / MQTT
+//     transport in parallel; transport selection is signalled in the
+//     IS-04 Sender's `transport` URN and IS-05
+//     `connection_uri` / `broker_*` parameters.
+//
+// Wire envelopes (sender → receiver):
+//
+//	state              — EventBoolean / EventNumber / EventString / EventObject
+//	health             — heartbeat response
+//	reboot / shutdown  — controlled shutdown notifications
+//	connection_status  — MQTT-only Will/announce message
+//
+// Wire envelopes (receiver → sender):
+//
+//	health        — heartbeat probe
+//	subscription  — subscribe to source_id list
+//
+// Type descriptors (REST `/sources/{id}/type`):
+//
+//	type_boolean / type_number / type_string  — base types
+//	type_boolean_enum / type_number_enum
+//	  / type_string_enum                       — enumerated variants
+//
+// This package follows the locked NMOS-wide codec pattern from
+// `internal/amwa/codec/spec/`: canonical Go structs in this package,
+// per-minor Strategy impls in vXX/. cmd/dhs/main.go blank-imports
+// each minor to wire init()-time registration.
+package is07

--- a/internal/amwa/codec/is07/is07_test.go
+++ b/internal/amwa/codec/is07/is07_test.go
@@ -1,0 +1,421 @@
+package is07
+
+import (
+	"strings"
+	"testing"
+)
+
+const (
+	srcUUID  = "1f1e1d1c-1b1a-4019-8817-161514131211"
+	flowUUID = "2f2e2d2c-2b2a-4029-8827-262524232221"
+)
+
+func validIdentity() Identity { return Identity{SourceID: srcUUID} }
+func validTiming() Timing     { return Timing{CreationTimestamp: "100:200"} }
+
+func TestCategoryOf(t *testing.T) {
+	cases := map[string]EventCategory{
+		"boolean":             EventCategoryBoolean,
+		"boolean/tally":       EventCategoryBoolean,
+		"boolean/tally/red":   EventCategoryBoolean,
+		"number":              EventCategoryNumber,
+		"number/temperature":  EventCategoryNumber,
+		"string":              EventCategoryString,
+		"object":              EventCategoryObject,
+		"unknown":             "",
+		"":                    "",
+		"boolean//double":     "",
+		"number/space here":   "",
+	}
+	for ev, want := range cases {
+		if got := CategoryOf(ev); got != want {
+			t.Errorf("CategoryOf(%q) = %q, want %q", ev, got, want)
+		}
+	}
+}
+
+func TestEventBooleanRoundTrip(t *testing.T) {
+	in := EventBoolean{
+		EventCommon: EventCommon{
+			Identity:  validIdentity(),
+			Timing:    validTiming(),
+			EventType: "boolean/tally",
+		},
+		Payload: PayloadBoolean{Value: true},
+	}
+	body, err := EncodeMessage(in)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	out, err := DecodeMessage(body)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	got, ok := out.(EventBoolean)
+	if !ok {
+		t.Fatalf("decoded into %T, want EventBoolean", out)
+	}
+	if got.Payload.Value != true {
+		t.Fatalf("payload mismatch")
+	}
+	if got.MessageType != MessageTypeState {
+		t.Fatalf("message_type %q, want state", got.MessageType)
+	}
+}
+
+func TestEventNumberRoundTrip(t *testing.T) {
+	in := EventNumber{
+		EventCommon: EventCommon{
+			Identity:  validIdentity(),
+			Timing:    validTiming(),
+			EventType: "number/temperature",
+		},
+		Payload: Number{Value: 273, Scale: 100},
+	}
+	body, err := EncodeMessage(in)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	out, err := DecodeMessage(body)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	got := out.(EventNumber)
+	if got.Payload.Value != 273 || got.Payload.Scale != 100 {
+		t.Fatalf("payload mismatch: %+v", got.Payload)
+	}
+}
+
+func TestEventStringRoundTrip(t *testing.T) {
+	in := EventString{
+		EventCommon: EventCommon{
+			Identity:  Identity{SourceID: srcUUID, FlowID: flowUUID},
+			Timing:    validTiming(),
+			EventType: "string/level/db",
+		},
+		Payload: PayloadString{Value: "+0dB"},
+	}
+	body, err := EncodeMessage(in)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	out, err := DecodeMessage(body)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	got := out.(EventString)
+	if got.Payload.Value != "+0dB" {
+		t.Fatalf("payload mismatch")
+	}
+	if got.Identity.FlowID != flowUUID {
+		t.Fatalf("flow_id mismatch")
+	}
+}
+
+func TestEventObjectRoundTrip(t *testing.T) {
+	in := EventObject{
+		EventCommon: EventCommon{
+			Identity:  validIdentity(),
+			Timing:    validTiming(),
+			EventType: "object/coords",
+		},
+		Payload: PayloadObject{"x": 1.0, "y": 2.0},
+	}
+	body, err := EncodeMessage(in)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	out, err := DecodeMessage(body)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	got := out.(EventObject)
+	if got.Payload["x"] != 1.0 {
+		t.Fatalf("payload mismatch: %+v", got.Payload)
+	}
+}
+
+func TestMessageHealthRoundTrip(t *testing.T) {
+	in := MessageHealth{
+		Timing: Timing{CreationTimestamp: "10:20", OriginTimestamp: "9:0"},
+	}
+	body, err := EncodeMessage(in)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	out, err := DecodeMessage(body)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	got := out.(MessageHealth)
+	if got.Timing.OriginTimestamp != "9:0" {
+		t.Fatalf("origin_timestamp mismatch")
+	}
+}
+
+func TestMessageHealthRequiresOrigin(t *testing.T) {
+	in := MessageHealth{Timing: Timing{CreationTimestamp: "10:20"}}
+	if _, err := EncodeMessage(in); err == nil {
+		t.Fatalf("expected error: missing origin_timestamp")
+	}
+}
+
+func TestMessageShutdownRebootRoundTrip(t *testing.T) {
+	for _, mt := range []MessageType{MessageTypeReboot, MessageTypeShutdown} {
+		in := MessageShutdownReboot{
+			MessageType: mt,
+			Identity:    validIdentity(),
+			Timing:      validTiming(),
+		}
+		body, err := EncodeMessage(in)
+		if err != nil {
+			t.Fatalf("Encode %s: %v", mt, err)
+		}
+		out, err := DecodeMessage(body)
+		if err != nil {
+			t.Fatalf("Decode %s: %v", mt, err)
+		}
+		got := out.(MessageShutdownReboot)
+		if got.MessageType != mt {
+			t.Fatalf("message_type mismatch: got %q want %q", got.MessageType, mt)
+		}
+	}
+}
+
+func TestMessageShutdownRebootRejectsBlankMessageType(t *testing.T) {
+	in := MessageShutdownReboot{
+		Identity: validIdentity(),
+		Timing:   validTiming(),
+	}
+	if _, err := EncodeMessage(in); err == nil {
+		t.Fatalf("expected error on blank message_type")
+	}
+}
+
+func TestMessageConnectionStatusRoundTrip(t *testing.T) {
+	in := MessageConnectionStatus{Active: true}
+	body, err := EncodeMessage(in)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	out, err := DecodeMessage(body)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	got := out.(MessageConnectionStatus)
+	if !got.Active {
+		t.Fatalf("active mismatch")
+	}
+}
+
+func TestDecodeMessageUnknownType(t *testing.T) {
+	body := []byte(`{"message_type":"unrecognised"}`)
+	if _, err := DecodeMessage(body); err == nil {
+		t.Fatalf("expected error on unknown message_type")
+	} else if !strings.Contains(err.Error(), "unrecognised") {
+		t.Fatalf("error should name discriminator: %v", err)
+	}
+}
+
+func TestDecodeMessageMissingType(t *testing.T) {
+	body := []byte(`{}`)
+	if _, err := DecodeMessage(body); err == nil {
+		t.Fatalf("expected error on missing message_type")
+	}
+}
+
+func TestDecodeMessageRejectsUnknownField(t *testing.T) {
+	body := []byte(`{"message_type":"health","timing":{"creation_timestamp":"1:2","origin_timestamp":"1:1"},"future_field":42}`)
+	if _, err := DecodeMessage(body); err == nil {
+		t.Fatalf("expected DisallowUnknownFields rejection")
+	} else if !strings.Contains(err.Error(), "future_field") {
+		t.Fatalf("error should name unknown field: %v", err)
+	}
+}
+
+func TestEventTypeMustMatchPrefix(t *testing.T) {
+	in := EventBoolean{
+		EventCommon: EventCommon{
+			Identity:  validIdentity(),
+			Timing:    validTiming(),
+			EventType: "string/wrong",
+		},
+	}
+	if _, err := EncodeMessage(in); err == nil {
+		t.Fatalf("expected error on category mismatch")
+	}
+}
+
+func TestIdentityRequiresUUID(t *testing.T) {
+	in := EventBoolean{
+		EventCommon: EventCommon{
+			Identity:  Identity{SourceID: "not-a-uuid"},
+			Timing:    validTiming(),
+			EventType: "boolean",
+		},
+	}
+	if _, err := EncodeMessage(in); err == nil {
+		t.Fatalf("expected UUID validation")
+	}
+}
+
+func TestTimingRequiresCreation(t *testing.T) {
+	in := EventBoolean{
+		EventCommon: EventCommon{
+			Identity:  validIdentity(),
+			EventType: "boolean",
+		},
+	}
+	if _, err := EncodeMessage(in); err == nil {
+		t.Fatalf("expected creation_timestamp validation")
+	}
+}
+
+func TestTimingRejectsBadTAI(t *testing.T) {
+	in := EventBoolean{
+		EventCommon: EventCommon{
+			Identity:  validIdentity(),
+			Timing:    Timing{CreationTimestamp: "not-tai"},
+			EventType: "boolean",
+		},
+	}
+	if _, err := EncodeMessage(in); err == nil {
+		t.Fatalf("expected TAI grammar validation")
+	}
+}
+
+func TestCommandHealthRoundTrip(t *testing.T) {
+	in := CommandHealth{Timestamp: "12:34"}
+	body, err := EncodeCommand(in)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	out, err := DecodeCommand(body)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	got := out.(CommandHealth)
+	if got.Command != CommandTypeHealth {
+		t.Fatalf("command discriminator missing")
+	}
+	if got.Timestamp != "12:34" {
+		t.Fatalf("timestamp mismatch")
+	}
+}
+
+func TestCommandSubscriptionRoundTrip(t *testing.T) {
+	in := CommandSubscription{Sources: []string{srcUUID, flowUUID}}
+	body, err := EncodeCommand(in)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	out, err := DecodeCommand(body)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	got := out.(CommandSubscription)
+	if len(got.Sources) != 2 {
+		t.Fatalf("sources length mismatch")
+	}
+}
+
+func TestCommandSubscriptionRejectsDuplicates(t *testing.T) {
+	in := CommandSubscription{Sources: []string{srcUUID, srcUUID}}
+	if _, err := EncodeCommand(in); err == nil {
+		t.Fatalf("expected dup rejection")
+	}
+}
+
+func TestCommandSubscriptionAcceptsEmpty(t *testing.T) {
+	in := CommandSubscription{Sources: []string{}}
+	if _, err := EncodeCommand(in); err != nil {
+		t.Fatalf("empty array should be valid: %v", err)
+	}
+}
+
+func TestCommandSubscriptionRequiresSources(t *testing.T) {
+	in := CommandSubscription{}
+	if _, err := EncodeCommand(in); err == nil {
+		t.Fatalf("expected required sources")
+	}
+}
+
+func TestDecodeCommandUnknownType(t *testing.T) {
+	body := []byte(`{"command":"reset"}`)
+	if _, err := DecodeCommand(body); err == nil {
+		t.Fatalf("expected error on unknown command")
+	}
+}
+
+func TestEventBooleanKind(t *testing.T) {
+	if (EventBoolean{}).Kind() != MessageTypeState {
+		t.Fatal("EventBoolean.Kind() should be state")
+	}
+	if (CommandHealth{}).Kind() != CommandTypeHealth {
+		t.Fatal("CommandHealth.Kind() should be health")
+	}
+}
+
+func TestEventNumberRejectsBadScale(t *testing.T) {
+	in := EventNumber{
+		EventCommon: EventCommon{
+			Identity:  validIdentity(),
+			Timing:    validTiming(),
+			EventType: "number",
+		},
+		Payload: Number{Value: 0, Scale: 0},
+	}
+	// scale=0 is OK (omitempty default)
+	if _, err := EncodeMessage(in); err != nil {
+		t.Fatalf("scale=0 should be valid: %v", err)
+	}
+	in.Payload.Scale = -1
+	if _, err := EncodeMessage(in); err == nil {
+		t.Fatalf("scale<1 should be rejected")
+	}
+}
+
+func TestValidateTypeBoolean(t *testing.T) {
+	if err := ValidateTypeBoolean(TypeBoolean{Type: TypeBaseNameBoolean}); err != nil {
+		t.Fatalf("valid: %v", err)
+	}
+	if err := ValidateTypeBoolean(TypeBoolean{Type: "string"}); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestValidateTypeBooleanEnum(t *testing.T) {
+	good := TypeBooleanEnum{
+		Type: TypeBaseNameBoolean,
+		Values: []EnumValueBoolean{
+			{Value: false, Label: "off", Description: "Inactive"},
+			{Value: true, Label: "on", Description: "Active"},
+		},
+	}
+	if err := ValidateTypeBooleanEnum(good); err != nil {
+		t.Fatalf("valid: %v", err)
+	}
+	if err := ValidateTypeBooleanEnum(TypeBooleanEnum{Type: TypeBaseNameBoolean}); err == nil {
+		t.Fatalf("empty values should error")
+	}
+}
+
+func TestValidateTypeNumber(t *testing.T) {
+	good := TypeNumber{Type: TypeBaseNameNumber, Min: Number{Value: 0}, Max: Number{Value: 100}, Unit: "celsius"}
+	if err := ValidateTypeNumber(good); err != nil {
+		t.Fatalf("valid: %v", err)
+	}
+}
+
+func TestValidateTypeStringEnum(t *testing.T) {
+	good := TypeStringEnum{
+		Type: TypeBaseNameString,
+		Values: []EnumValueString{
+			{Value: "off", Label: "off", Description: "Off"},
+			{Value: "on", Label: "on", Description: "On"},
+		},
+	}
+	if err := ValidateTypeStringEnum(good); err != nil {
+		t.Fatalf("valid: %v", err)
+	}
+}

--- a/internal/amwa/codec/is07/messages.go
+++ b/internal/amwa/codec/is07/messages.go
@@ -1,0 +1,351 @@
+package is07
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// Message is the closed sum-type for every sender → receiver
+// envelope. Implementations: EventBoolean / EventNumber / EventString
+// / EventObject / MessageHealth / MessageShutdownReboot /
+// MessageConnectionStatus.
+//
+// Kind returns the discriminator that selects the variant on the
+// wire — the same string that appears in the `message_type` field.
+type Message interface {
+	Kind() MessageType
+	validate() error
+}
+
+// EventCommon holds the fields shared by every state-change event
+// (event_core.json) — embedded by all four event payload variants.
+type EventCommon struct {
+	MessageType MessageType `json:"message_type"`
+	Identity    Identity    `json:"identity"`
+	Timing      Timing      `json:"timing"`
+	EventType   string      `json:"event_type"`
+}
+
+// EventBoolean carries a `boolean(/<sub>)*` event_type payload.
+// Spec: APIs/schemas/event_boolean.json.
+type EventBoolean struct {
+	EventCommon
+	Payload PayloadBoolean `json:"payload"`
+}
+
+// EventNumber carries a `number(/<sub>)*` event_type payload.
+// Spec: APIs/schemas/event_number.json.
+type EventNumber struct {
+	EventCommon
+	Payload Number `json:"payload"`
+}
+
+// EventString carries a `string(/<sub>)*` event_type payload.
+// Spec: APIs/schemas/event_string.json.
+type EventString struct {
+	EventCommon
+	Payload PayloadString `json:"payload"`
+}
+
+// EventObject carries an `object(/<sub>)*` event_type payload.
+// Spec: APIs/schemas/event_object.json.
+type EventObject struct {
+	EventCommon
+	Payload PayloadObject `json:"payload"`
+}
+
+// MessageHealth is the heartbeat response. Spec:
+// APIs/schemas/message_health.json.
+type MessageHealth struct {
+	MessageType MessageType `json:"message_type"`
+	Timing      Timing      `json:"timing"`
+}
+
+// MessageShutdownReboot covers both `reboot` and `shutdown`
+// envelopes. Spec: APIs/schemas/message_shutdown_reboot.json.
+type MessageShutdownReboot struct {
+	MessageType MessageType `json:"message_type"`
+	Identity    Identity    `json:"identity"`
+	Timing      Timing      `json:"timing"`
+}
+
+// MessageConnectionStatus is the MQTT-only Will/announce envelope
+// indicating the client's connection state to the broker. Spec:
+// APIs/schemas/message_connection_status.json.
+type MessageConnectionStatus struct {
+	MessageType MessageType `json:"message_type"`
+	Active      bool        `json:"active"`
+}
+
+// Compile-time interface assertions.
+var (
+	_ Message = EventBoolean{}
+	_ Message = EventNumber{}
+	_ Message = EventString{}
+	_ Message = EventObject{}
+	_ Message = MessageHealth{}
+	_ Message = MessageShutdownReboot{}
+	_ Message = MessageConnectionStatus{}
+)
+
+// Kind getters — required by the Message interface. We return the
+// spec literal even when the receiver was constructed with a blank
+// field, so encoders can rely on it for the wire form.
+func (e EventBoolean) Kind() MessageType            { return MessageTypeState }
+func (e EventNumber) Kind() MessageType             { return MessageTypeState }
+func (e EventString) Kind() MessageType             { return MessageTypeState }
+func (e EventObject) Kind() MessageType             { return MessageTypeState }
+func (m MessageHealth) Kind() MessageType           { return MessageTypeHealth }
+func (m MessageShutdownReboot) Kind() MessageType   { return m.MessageType }
+func (m MessageConnectionStatus) Kind() MessageType { return MessageTypeConnectionStatus }
+
+// Command is the closed sum-type for every receiver → sender
+// envelope. Implementations: CommandHealth / CommandSubscription.
+type Command interface {
+	Kind() CommandType
+	validate() error
+}
+
+// CommandHealth probes the sender. Spec:
+// APIs/schemas/command_health.json.
+type CommandHealth struct {
+	Command   CommandType `json:"command"`
+	Timestamp string      `json:"timestamp"`
+}
+
+// CommandSubscription subscribes the receiver to the listed source
+// IDs. Spec: APIs/schemas/command_subscription.json. Per spec
+// `sources` MUST be unique; the encoder rejects duplicates.
+type CommandSubscription struct {
+	Command CommandType `json:"command"`
+	Sources []string    `json:"sources"`
+}
+
+// Compile-time interface assertions.
+var (
+	_ Command = CommandHealth{}
+	_ Command = CommandSubscription{}
+)
+
+// Kind getters — required by the Command interface.
+func (c CommandHealth) Kind() CommandType       { return CommandTypeHealth }
+func (c CommandSubscription) Kind() CommandType { return CommandTypeSubscription }
+
+// envelope is the minimal peek-ahead struct used by DecodeMessage
+// and DecodeCommand to decide which concrete variant to unmarshal
+// into.
+type envelope struct {
+	MessageType MessageType `json:"message_type"`
+	Command     CommandType `json:"command"`
+}
+
+// DecodeMessage parses any sender → receiver wire frame, switching
+// on `message_type`. For state events it further switches on the
+// `event_type` prefix to pick the boolean / number / string / object
+// variant. Returns a typed error for unknown discriminators so
+// callers can fire a compliance event without string-matching.
+func DecodeMessage(raw []byte) (Message, error) {
+	var env envelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return nil, fmt.Errorf("is07: peek message_type: %w", err)
+	}
+	switch env.MessageType {
+	case MessageTypeState:
+		return decodeStateEvent(raw)
+	case MessageTypeHealth:
+		var m MessageHealth
+		if err := decodeStrict(raw, &m); err != nil {
+			return nil, err
+		}
+		if err := m.validate(); err != nil {
+			return nil, err
+		}
+		return m, nil
+	case MessageTypeReboot, MessageTypeShutdown:
+		var m MessageShutdownReboot
+		if err := decodeStrict(raw, &m); err != nil {
+			return nil, err
+		}
+		if err := m.validate(); err != nil {
+			return nil, err
+		}
+		return m, nil
+	case MessageTypeConnectionStatus:
+		var m MessageConnectionStatus
+		if err := decodeStrict(raw, &m); err != nil {
+			return nil, err
+		}
+		if err := m.validate(); err != nil {
+			return nil, err
+		}
+		return m, nil
+	case "":
+		return nil, fmt.Errorf("is07: message_type: required")
+	}
+	return nil, fmt.Errorf("is07: message_type %q: unknown", env.MessageType)
+}
+
+// decodeStateEvent inspects event_type to pick the correct payload
+// variant. Strict-decode rejects unknown fields per dhs convention.
+func decodeStateEvent(raw []byte) (Message, error) {
+	var head struct {
+		EventType string `json:"event_type"`
+	}
+	if err := json.Unmarshal(raw, &head); err != nil {
+		return nil, fmt.Errorf("is07: peek event_type: %w", err)
+	}
+	switch CategoryOf(head.EventType) {
+	case EventCategoryBoolean:
+		var e EventBoolean
+		if err := decodeStrict(raw, &e); err != nil {
+			return nil, err
+		}
+		if err := e.validate(); err != nil {
+			return nil, err
+		}
+		return e, nil
+	case EventCategoryNumber:
+		var e EventNumber
+		if err := decodeStrict(raw, &e); err != nil {
+			return nil, err
+		}
+		if err := e.validate(); err != nil {
+			return nil, err
+		}
+		return e, nil
+	case EventCategoryString:
+		var e EventString
+		if err := decodeStrict(raw, &e); err != nil {
+			return nil, err
+		}
+		if err := e.validate(); err != nil {
+			return nil, err
+		}
+		return e, nil
+	case EventCategoryObject:
+		var e EventObject
+		if err := decodeStrict(raw, &e); err != nil {
+			return nil, err
+		}
+		if err := e.validate(); err != nil {
+			return nil, err
+		}
+		return e, nil
+	}
+	return nil, fmt.Errorf("is07: event_type %q: must start with boolean/number/string/object", head.EventType)
+}
+
+// DecodeCommand parses any receiver → sender wire frame, switching
+// on `command`.
+func DecodeCommand(raw []byte) (Command, error) {
+	var env envelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return nil, fmt.Errorf("is07: peek command: %w", err)
+	}
+	switch env.Command {
+	case CommandTypeHealth:
+		var c CommandHealth
+		if err := decodeStrict(raw, &c); err != nil {
+			return nil, err
+		}
+		if err := c.validate(); err != nil {
+			return nil, err
+		}
+		return c, nil
+	case CommandTypeSubscription:
+		var c CommandSubscription
+		if err := decodeStrict(raw, &c); err != nil {
+			return nil, err
+		}
+		if err := c.validate(); err != nil {
+			return nil, err
+		}
+		return c, nil
+	case "":
+		return nil, fmt.Errorf("is07: command: required")
+	}
+	return nil, fmt.Errorf("is07: command %q: unknown", env.Command)
+}
+
+// EncodeMessage marshals any Message variant. The discriminator
+// fields are normalised (filled with the canonical literal) before
+// marshalling so callers cannot accidentally ship a frame with a
+// blank `message_type`.
+func EncodeMessage(m Message) ([]byte, error) {
+	if m == nil {
+		return nil, fmt.Errorf("is07: encode message: nil")
+	}
+	if err := m.validate(); err != nil {
+		return nil, err
+	}
+	return marshalNormalised(m)
+}
+
+// EncodeCommand marshals any Command variant.
+func EncodeCommand(c Command) ([]byte, error) {
+	if c == nil {
+		return nil, fmt.Errorf("is07: encode command: nil")
+	}
+	if err := c.validate(); err != nil {
+		return nil, err
+	}
+	return marshalNormalised(c)
+}
+
+// marshalNormalised injects the canonical discriminator value into
+// the in-memory struct before marshalling. We deliberately don't
+// mutate the caller's struct — callers may keep state across many
+// encodes.
+func marshalNormalised(v any) ([]byte, error) {
+	switch x := v.(type) {
+	case EventBoolean:
+		x.MessageType = MessageTypeState
+		return jsonMarshalIndent(x)
+	case EventNumber:
+		x.MessageType = MessageTypeState
+		return jsonMarshalIndent(x)
+	case EventString:
+		x.MessageType = MessageTypeState
+		return jsonMarshalIndent(x)
+	case EventObject:
+		x.MessageType = MessageTypeState
+		return jsonMarshalIndent(x)
+	case MessageHealth:
+		x.MessageType = MessageTypeHealth
+		return jsonMarshalIndent(x)
+	case MessageShutdownReboot:
+		// `reboot` and `shutdown` are both legal — caller's intent
+		// stays. validate() above already rejected unknown values.
+		return jsonMarshalIndent(x)
+	case MessageConnectionStatus:
+		x.MessageType = MessageTypeConnectionStatus
+		return jsonMarshalIndent(x)
+	case CommandHealth:
+		x.Command = CommandTypeHealth
+		return jsonMarshalIndent(x)
+	case CommandSubscription:
+		x.Command = CommandTypeSubscription
+		return jsonMarshalIndent(x)
+	}
+	return nil, fmt.Errorf("is07: encode: unsupported variant %T", v)
+}
+
+// decodeStrict is shared strict JSON decode helper — rejects unknown
+// fields and trailing content for every IS-07 wire variant.
+func decodeStrict(raw []byte, dst any) error {
+	d := json.NewDecoder(bytes.NewReader(raw))
+	d.DisallowUnknownFields()
+	if err := d.Decode(dst); err != nil {
+		return fmt.Errorf("is07: decode %T: %w", dst, err)
+	}
+	if d.More() {
+		return fmt.Errorf("is07: decode %T: trailing JSON", dst)
+	}
+	return nil
+}
+
+// jsonMarshalIndent is the canonical pretty-printer.
+func jsonMarshalIndent(v any) ([]byte, error) {
+	return json.MarshalIndent(v, "", "  ")
+}

--- a/internal/amwa/codec/is07/testdata/schemas/v1.0.1/base.json
+++ b/internal/amwa/codec/is07/testdata/schemas/v1.0.1/base.json
@@ -1,0 +1,16 @@
+{
+  "$id": "https://www.amwa.tv/event_and_tally/base.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "array",
+  "description": "Describes the Events API base resource",
+  "title": "Events API base resource",
+  "items": {
+    "type": "string",
+    "enum": [
+      "sources/"
+    ],
+    "minItems": 1,
+    "maxItems": 1,
+    "uniqueItems": true
+  }
+}

--- a/internal/amwa/codec/is07/testdata/schemas/v1.0.1/command.json
+++ b/internal/amwa/codec/is07/testdata/schemas/v1.0.1/command.json
@@ -1,0 +1,12 @@
+{
+  "$id": "https://www.amwa.tv/event_and_tally/command.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Allowed commands (communication from the receiver to the sender)",
+  "title": "Command",
+  "oneOf": [{
+    "$ref": "command_health.json"
+  }, {
+    "$ref": "command_subscription.json"
+  }]
+}

--- a/internal/amwa/codec/is07/testdata/schemas/v1.0.1/command_health.json
+++ b/internal/amwa/codec/is07/testdata/schemas/v1.0.1/command_health.json
@@ -1,0 +1,23 @@
+{
+  "$id": "https://www.amwa.tv/event_and_tally/command_health.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Command that initiates a health message to be generated in order to check the state of the connection and the sender",
+  "title": "Health command",
+  "required": [
+    "command",
+    "timestamp"
+  ],
+  "properties": {
+    "command": {
+      "description": "A fixed string showing this is a health command",
+      "type": "string",
+      "pattern": "^health$"
+    },
+    "timestamp": {
+      "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating the time the command was issued",
+      "type": "string",
+      "pattern": "^[0-9]+:[0-9]+$"
+    }
+  }
+}

--- a/internal/amwa/codec/is07/testdata/schemas/v1.0.1/command_subscription.json
+++ b/internal/amwa/codec/is07/testdata/schemas/v1.0.1/command_subscription.json
@@ -1,0 +1,29 @@
+{
+  "$id": "https://www.amwa.tv/event_and_tally/command_subscription.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Command that subscribes the receiver to receive the state change messages for the specified sources",
+  "title": "Subscription command",
+  "required": [
+    "command",
+    "sources"
+  ],
+  "properties": {
+    "command": {
+      "description": "A fixed string showing this is a subscription command",
+      "type": "string",
+      "pattern": "^subscription$"
+    },
+    "sources": {
+      "type": "array",
+      "description": "A list of Event & Tally sources to subscribe to",
+      "items": {
+        "description": "IDs of the Event & Tally compatible sources",
+        "type": "string",
+        "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+      },
+      "minItems": 0,
+      "uniqueItems": true
+    }
+  }
+}

--- a/internal/amwa/codec/is07/testdata/schemas/v1.0.1/error.json
+++ b/internal/amwa/codec/is07/testdata/schemas/v1.0.1/error.json
@@ -1,0 +1,28 @@
+{
+  "$id": "https://www.amwa.tv/event_and_tally/error.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes the standard error response which is returned with HTTP codes 400 and above",
+  "title": "Error response",
+  "required": [
+    "code",
+    "error",
+    "debug"
+  ],
+  "properties": {
+    "code": {
+      "description": "HTTP error code",
+      "type": "integer",
+      "minimum": 400,
+      "maximum": 599
+    },
+    "error": {
+      "description": "Human readable message which is suitable for user interface display, and helpful to the user",
+      "type": "string"
+    },
+    "debug": {
+      "description": "Debug information which may assist a programmer working with the API",
+      "type": ["null", "string"]
+    }
+  }
+}

--- a/internal/amwa/codec/is07/testdata/schemas/v1.0.1/event.json
+++ b/internal/amwa/codec/is07/testdata/schemas/v1.0.1/event.json
@@ -1,0 +1,16 @@
+{
+  "$id": "https://www.amwa.tv/event_and_tally/event.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Message that gets sent out when the source state changes",
+  "title": "State change event",
+  "oneOf": [{
+    "$ref": "event_boolean.json"
+  }, {
+    "$ref": "event_number.json"
+  }, {
+    "$ref": "event_string.json"
+  }, {
+    "$ref": "event_object.json"
+  }]
+}

--- a/internal/amwa/codec/is07/testdata/schemas/v1.0.1/event_boolean.json
+++ b/internal/amwa/codec/is07/testdata/schemas/v1.0.1/event_boolean.json
@@ -1,0 +1,37 @@
+{
+  "$id": "https://www.amwa.tv/event_and_tally/event_boolean.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes an event with boolean payload",
+  "title": "Boolean event",
+  "allOf": [
+    { "$ref": "event_core.json" },
+    {
+      "type": "object",
+      "required": [
+        "event_type",
+        "payload"
+      ],
+      "properties": {
+        "event_type": {
+          "description": "Event type",
+          "type": "string",
+          "pattern": "^boolean(\\/[^\\s\\/]+)*$"
+        },
+        "payload": {
+          "description": "Boolean payload",
+          "type": "object",
+          "required": [
+            "value"
+          ],
+          "properties": {
+            "value": {
+              "description": "Boolean value",
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/internal/amwa/codec/is07/testdata/schemas/v1.0.1/event_core.json
+++ b/internal/amwa/codec/is07/testdata/schemas/v1.0.1/event_core.json
@@ -1,0 +1,64 @@
+{
+  "$id": "https://www.amwa.tv/event_and_tally/event_core.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Message that gets sent out when the source state changes",
+  "title": "State change event",
+  "required": [
+    "identity",
+    "timing",
+    "event_type",
+    "payload",
+    "message_type"
+  ],
+  "properties": {
+    "message_type": {
+      "description": "A fixed string showing this is a state message",
+      "type": "string",
+      "pattern": "^state$"
+    },
+    "identity": {
+      "description": "Object describing event identity",
+      "type": "object",
+      "required": [
+        "source_id"
+      ],
+      "properties": {
+        "source_id": {
+          "description": "ID of the source that holds the state that has changed",
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "flow_id": {
+          "description": "ID of the flow carrying the message",
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        }
+      }
+    },
+    "timing": {
+      "description": "Object describing event timing",
+      "type": "object",
+      "required": [
+        "creation_timestamp"
+      ],
+      "properties": {
+        "creation_timestamp": {
+          "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating when the message was created",
+          "type": "string",
+          "pattern": "^[0-9]+:[0-9]+$"
+        },
+        "origin_timestamp": {
+          "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating when the message that triggered this message (if any) was created",
+          "type": "string",
+          "pattern": "^[0-9]+:[0-9]+$"
+        },
+        "action_timestamp": {
+          "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating when the state change described in the event took or will take place",
+          "type": "string",
+          "pattern": "^[0-9]+:[0-9]+$"
+        }
+      }
+    }
+  }
+}

--- a/internal/amwa/codec/is07/testdata/schemas/v1.0.1/event_number.json
+++ b/internal/amwa/codec/is07/testdata/schemas/v1.0.1/event_number.json
@@ -1,0 +1,25 @@
+{
+  "$id": "https://www.amwa.tv/event_and_tally/event_number.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes an event with Number payload",
+  "title": "Number event",
+  "allOf": [
+    { "$ref": "event_core.json" },
+    {
+      "type": "object",
+      "required": [
+        "event_type",
+        "payload"
+      ],
+      "properties": {
+        "event_type": {
+          "description": "Event type",
+          "type": "string",
+          "pattern": "^number(\\/[^\\s\\/]+)*$"
+        },
+        "payload": { "$ref": "number.json" }
+      }
+    }
+  ]
+}

--- a/internal/amwa/codec/is07/testdata/schemas/v1.0.1/event_object.json
+++ b/internal/amwa/codec/is07/testdata/schemas/v1.0.1/event_object.json
@@ -1,0 +1,28 @@
+{
+  "$id": "https://www.amwa.tv/event_and_tally/event_object.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes an event with object payload",
+  "title": "Object event",
+  "allOf": [
+    { "$ref": "event_core.json" },
+    {
+      "type": "object",
+      "required": [
+        "event_type",
+        "payload"
+      ],
+      "properties": {
+        "event_type": {
+          "description": "Event type",
+          "type": "string",
+          "pattern": "^object(\\/[^\\s\\/]+)*$"
+        },
+        "payload": {
+          "description": "Object payload",
+          "type": "object"
+        }
+      }
+    }
+  ]
+}

--- a/internal/amwa/codec/is07/testdata/schemas/v1.0.1/event_string.json
+++ b/internal/amwa/codec/is07/testdata/schemas/v1.0.1/event_string.json
@@ -1,0 +1,37 @@
+{
+  "$id": "https://www.amwa.tv/event_and_tally/event_string.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes an event with string payload",
+  "title": "String event",
+  "allOf": [
+    { "$ref": "event_core.json" },
+    {
+      "type": "object",
+      "required": [
+        "event_type",
+        "payload"
+      ],
+      "properties": {
+        "event_type": {
+          "description": "Event type",
+          "type": "string",
+          "pattern": "^string(\\/[^\\s\\/]+)*$"
+        },
+        "payload": {
+          "description": "String payload",
+          "type": "object",
+          "required": [
+            "value"
+          ],
+          "properties": {
+            "value": {
+              "description": "String value",
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/internal/amwa/codec/is07/testdata/schemas/v1.0.1/message.json
+++ b/internal/amwa/codec/is07/testdata/schemas/v1.0.1/message.json
@@ -1,0 +1,16 @@
+{
+  "$id": "https://www.amwa.tv/event_and_tally/message.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Allowed messages (communication from the sender to the receiver)",
+  "title": "Message",
+  "oneOf": [{
+    "$ref": "event.json"
+  }, {
+    "$ref": "message_connection_status.json"
+  }, {
+    "$ref": "message_health.json"
+  }, {
+    "$ref": "message_shutdown_reboot.json"
+  }]
+}

--- a/internal/amwa/codec/is07/testdata/schemas/v1.0.1/message_connection_status.json
+++ b/internal/amwa/codec/is07/testdata/schemas/v1.0.1/message_connection_status.json
@@ -1,0 +1,21 @@
+{
+  "$id": "https://www.amwa.tv/event_and_tally/message_connection_status.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Message that indicates the status of the connection between the MQTT client and the broker. The topic used is connection specific and has to be specified in the connection_status_broker_topic parameter of the MQTT IS-05 transport parameters object. The client should publish this message with the RETAIN flag set, after opening the connection to the broker and before closing the connection normally. The client should also configure a retained Will Message indicating it is disconnected.",
+  "title": "Connection status message",
+  "required": [
+    "message_type",
+    "active"
+  ],
+  "properties": {
+    "message_type": {
+      "description": "A fixed string showing this is a connection status message",
+      "type": "string",
+      "pattern": "^connection_status$"
+    },
+    "active": {
+      "description": "A boolean value showing whether the MQTT client is connected to the broker.",
+      "type": "boolean"
+  }
+}

--- a/internal/amwa/codec/is07/testdata/schemas/v1.0.1/message_health.json
+++ b/internal/amwa/codec/is07/testdata/schemas/v1.0.1/message_health.json
@@ -1,0 +1,38 @@
+{
+  "$id": "https://www.amwa.tv/event_and_tally/message_health.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Message that gets sent out as the response to a health (heartbeat) command",
+  "title": "Health message",
+  "required": [
+    "timing",
+    "message_type"
+  ],
+  "properties": {
+    "message_type": {
+      "description": "A fixed string showing this is a health message",
+      "type": "string",
+      "pattern": "^health$"
+    },
+    "timing": {
+      "description": "Object describing event timing",
+      "type": "object",
+      "required": [
+        "creation_timestamp",
+        "origin_timestamp"
+      ],
+      "properties": {
+        "creation_timestamp": {
+          "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating when the message was created",
+          "type": "string",
+          "pattern": "^[0-9]+:[0-9]+$"
+        },
+        "origin_timestamp": {
+          "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) copied from the incoming health command",
+          "type": "string",
+          "pattern": "^[0-9]+:[0-9]+$"
+        }
+      }
+    }
+  }
+}

--- a/internal/amwa/codec/is07/testdata/schemas/v1.0.1/message_shutdown_reboot.json
+++ b/internal/amwa/codec/is07/testdata/schemas/v1.0.1/message_shutdown_reboot.json
@@ -1,0 +1,52 @@
+{
+  "$id": "https://www.amwa.tv/event_and_tally/message_shutdown_reboot.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Message that gets sent out when the device start a shutdown or reboot process",
+  "title": "Shutdown and reboot message",
+  "required": [
+    "identity",
+    "timing",
+    "message_type"
+  ],
+  "properties": {
+    "message_type": {
+      "description": "A fixed string showing this is a reboot or a shutdown message",
+      "type": "string",
+      "pattern": "^reboot|shutdown$"
+    },
+    "identity": {
+      "description": "Object describing event identity",
+      "type": "object",
+      "required": [
+        "source_id"
+      ],
+      "properties": {
+        "source_id": {
+          "description": "ID of the source which identifies the emitter of the event",
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "flow_id": {
+          "description": "ID of the flow carrying the message",
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        }
+      }
+    },
+    "timing": {
+      "description": "Object describing event timing",
+      "type": "object",
+      "required": [
+        "creation_timestamp"
+      ],
+      "properties": {
+        "creation_timestamp": {
+          "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating when the message was created",
+          "type": "string",
+          "pattern": "^[0-9]+:[0-9]+$"
+        }
+      }
+    }
+  }
+}

--- a/internal/amwa/codec/is07/testdata/schemas/v1.0.1/number.json
+++ b/internal/amwa/codec/is07/testdata/schemas/v1.0.1/number.json
@@ -1,0 +1,20 @@
+{
+  "$id": "https://www.amwa.tv/event_and_tally/number.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Number",
+  "type": "object",
+  "required": [
+    "value"
+  ],
+  "properties": {
+    "value": {
+      "description": "Number value",
+      "type": "number"
+    },
+    "scale": {
+      "description": "Denominator for rational number representation (default = 1)",
+      "type": "integer",
+      "minimum": 1
+    }
+  }
+}

--- a/internal/amwa/codec/is07/testdata/schemas/v1.0.1/receiver_transport_params_ext.json
+++ b/internal/amwa/codec/is07/testdata/schemas/v1.0.1/receiver_transport_params_ext.json
@@ -1,0 +1,25 @@
+{
+  "$id": "https://www.amwa.tv/event_and_tally/receiver_transport_params_ext.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Describes external Receiver transport parameters defined for IS-07 NMOS Event & Tally specification. The constraints in this schema are minimum constraints, but may be further constrained at the constraints endpoint.",
+  "title": "External Receiver Transport Parameters",
+  "type": "object",
+  "properties": {
+    "ext_is_07_rest_api_url": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "the URL for the Events API resource for the associated source",
+      "format": "uri"
+    },
+    "ext_is_07_source_id": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "ID of the related source",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    }
+  }
+}

--- a/internal/amwa/codec/is07/testdata/schemas/v1.0.1/sender_transport_params_ext.json
+++ b/internal/amwa/codec/is07/testdata/schemas/v1.0.1/sender_transport_params_ext.json
@@ -1,0 +1,19 @@
+{
+  "$id": "https://www.amwa.tv/event_and_tally/sender_transport_params_ext.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Describes external Sender transport parameters defined for IS-07 NMOS Event & Tally specification. The constraints in this schema are minimum constraints, but may be further constrained at the constraints endpoint.",
+  "title": "External Sender Transport Parameters",
+  "type": "object",
+  "properties": {
+    "ext_is_07_rest_api_url": {
+      "type": "string",
+      "description": "the URL for the Events API resource for the associated source",
+      "format": "uri"
+    },
+    "ext_is_07_source_id": {
+      "type": "string",
+      "description": "ID of the related source",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    }
+  }
+}

--- a/internal/amwa/codec/is07/testdata/schemas/v1.0.1/source.json
+++ b/internal/amwa/codec/is07/testdata/schemas/v1.0.1/source.json
@@ -1,0 +1,17 @@
+{
+  "$id": "https://www.amwa.tv/event_and_tally/source.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "array",
+  "description": "Describes the Event & Tally source",
+  "title": "Event & Tally source",
+  "items": {
+    "type": "string",
+    "enum": [
+      "type/",
+      "state/"
+    ],
+    "minItems": 2,
+    "maxItems": 2,
+    "uniqueItems": true
+  }
+}

--- a/internal/amwa/codec/is07/testdata/schemas/v1.0.1/sources.json
+++ b/internal/amwa/codec/is07/testdata/schemas/v1.0.1/sources.json
@@ -1,0 +1,14 @@
+{
+  "$id": "https://www.amwa.tv/event_and_tally/sources.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "array",
+  "description": "A list of Event & Tally Source resources",
+  "title": "Collection of Event & Tally Sources",
+  "items": {
+    "description": "IDs of the Event & Tally compatible sources",
+    "type": "string",
+    "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\\/$"
+  },
+  "minItems": 0,
+  "uniqueItems": true
+}

--- a/internal/amwa/codec/is07/testdata/schemas/v1.0.1/type.json
+++ b/internal/amwa/codec/is07/testdata/schemas/v1.0.1/type.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://www.amwa.tv/event_and_tally/type.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Type definition",
+  "title": "Type definition",
+  "oneOf": [
+    { "$ref": "type_boolean.json" },
+    { "$ref": "type_boolean_enum.json" },
+    { "$ref": "type_number.json" },
+    { "$ref": "type_number_enum.json" },
+    { "$ref": "type_string.json" },
+    { "$ref": "type_string_enum.json" }
+  ]
+}

--- a/internal/amwa/codec/is07/testdata/schemas/v1.0.1/type_boolean.json
+++ b/internal/amwa/codec/is07/testdata/schemas/v1.0.1/type_boolean.json
@@ -1,0 +1,20 @@
+{
+  "$id": "https://www.amwa.tv/event_and_tally/type_boolean.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Type definition for the boolean type",
+  "title": "Boolean Type",
+  "additionalProperties": false,
+  "required": [
+    "type"
+  ],
+  "properties": {
+    "type": {
+      "description": "Base type name",
+      "type": "string",
+      "enum": [
+        "boolean"
+      ]
+    }
+  }
+}

--- a/internal/amwa/codec/is07/testdata/schemas/v1.0.1/type_boolean_enum.json
+++ b/internal/amwa/codec/is07/testdata/schemas/v1.0.1/type_boolean_enum.json
@@ -1,0 +1,48 @@
+{
+  "$id": "https://www.amwa.tv/event_and_tally/type_boolean_enum.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Type definition for the boolean enum type",
+  "title": "Boolean Enum Type",
+  "additionalProperties": false,
+  "required": [
+    "type",
+    "values"
+  ],
+  "properties": {
+    "type": {
+      "description": "Base type name",
+      "type": "string",
+      "enum": [
+        "boolean"
+      ]
+    },
+    "values": {
+      "description": "List of allowed values",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "title": "Enum Element",
+        "required": [
+          "value",
+          "label",
+          "description"
+        ],
+        "properties": {
+          "value": {
+            "description": "Enum value",
+            "type": "boolean"
+          },
+          "label": {
+            "description": "Enum label",
+            "type": "string"
+          },
+          "description": {
+            "description": "Enum description",
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/amwa/codec/is07/testdata/schemas/v1.0.1/type_number.json
+++ b/internal/amwa/codec/is07/testdata/schemas/v1.0.1/type_number.json
@@ -1,0 +1,34 @@
+{
+  "$id": "https://www.amwa.tv/event_and_tally/type_number.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Type definition for the number type",
+  "title": "Number Type",
+  "additionalProperties": false,
+  "required": [
+    "type",
+    "min",
+    "max"
+  ],
+  "properties": {
+    "type": {
+      "description": "Base type name",
+      "type": "string",
+      "enum": [
+        "number"
+      ]
+    },
+    "scale": {
+      "description": "Denominator typically used for rational numbers in the event payload",
+      "type": "integer",
+      "minimum": 1
+    },
+    "min": { "$ref": "number.json" },
+    "max": { "$ref": "number.json" },
+    "step": { "$ref": "number.json" },
+    "unit": {
+      "description": "Unit of measure",
+      "type": "string"
+    }
+  }
+}

--- a/internal/amwa/codec/is07/testdata/schemas/v1.0.1/type_number_enum.json
+++ b/internal/amwa/codec/is07/testdata/schemas/v1.0.1/type_number_enum.json
@@ -1,0 +1,48 @@
+{
+  "$id": "https://www.amwa.tv/event_and_tally/type_number_enum.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Type definition for the number enum type",
+  "title": "Number Enum Type",
+  "additionalProperties": false,
+  "required": [
+    "type",
+    "values"
+  ],
+  "properties": {
+    "type": {
+      "description": "Base type name",
+      "type": "string",
+      "enum": [
+        "number"
+      ]
+    },
+    "values": {
+      "description": "List of allowed values",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "title": "Enum Element",
+        "required": [
+          "value",
+          "label",
+          "description"
+        ],
+        "properties": {
+          "value": {
+            "description": "Enum value",
+            "type": "number"
+          },
+          "label": {
+            "description": "Enum label",
+            "type": "string"
+          },
+          "description": {
+            "description": "Enum description",
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/amwa/codec/is07/testdata/schemas/v1.0.1/type_string.json
+++ b/internal/amwa/codec/is07/testdata/schemas/v1.0.1/type_string.json
@@ -1,0 +1,34 @@
+{
+  "$id": "https://www.amwa.tv/event_and_tally/type_string.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Type definition for the string type",
+  "title": "String Type",
+  "additionalProperties": false,
+  "required": [
+    "type"
+  ],
+  "properties": {
+    "type": {
+      "description": "Base type name",
+      "type": "string",
+      "enum": [
+        "string"
+      ]
+    },
+    "min_length": {
+      "description": "Minimum string length",
+      "type": "integer",
+      "minimum": 0
+    },
+    "max_length": {
+      "description": "Maximum string length",
+      "type": "integer",
+      "minimum": 1
+    },
+    "pattern": {
+      "description": "Regular expression constraining the value",
+      "type": "string"
+    }
+  }
+}

--- a/internal/amwa/codec/is07/testdata/schemas/v1.0.1/type_string_enum.json
+++ b/internal/amwa/codec/is07/testdata/schemas/v1.0.1/type_string_enum.json
@@ -1,0 +1,48 @@
+{
+  "$id": "https://www.amwa.tv/event_and_tally/type_string_enum.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Type definition for the string enum type",
+  "title": "String Enum Type",
+  "additionalProperties": false,
+  "required": [
+    "type",
+    "values"
+  ],
+  "properties": {
+    "type": {
+      "description": "Base type name",
+      "type": "string",
+      "enum": [
+        "string"
+      ]
+    },
+    "values": {
+      "description": "List of allowed values",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "title": "Enum Element",
+        "required": [
+          "value",
+          "label",
+          "description"
+        ],
+        "properties": {
+          "value": {
+            "description": "Enum value",
+            "type": "string"
+          },
+          "label": {
+            "description": "Enum label",
+            "type": "string"
+          },
+          "description": {
+            "description": "Enum description",
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/amwa/codec/is07/types.go
+++ b/internal/amwa/codec/is07/types.go
@@ -1,0 +1,203 @@
+package is07
+
+import (
+	"regexp"
+)
+
+// MessageType is the discriminator on the sender → receiver envelope.
+// Spec: APIs/schemas/{event_core,message_health,message_shutdown_reboot,
+// message_connection_status}.json `message_type` field.
+type MessageType string
+
+// Recognised message types per IS-07 v1.0.1 §2.
+const (
+	MessageTypeState            MessageType = "state"
+	MessageTypeHealth           MessageType = "health"
+	MessageTypeReboot           MessageType = "reboot"
+	MessageTypeShutdown         MessageType = "shutdown"
+	MessageTypeConnectionStatus MessageType = "connection_status"
+)
+
+// CommandType is the discriminator on the receiver → sender envelope.
+// Spec: APIs/schemas/{command_health,command_subscription}.json
+// `command` field.
+type CommandType string
+
+// Recognised command types per IS-07 v1.0.1 §2.
+const (
+	CommandTypeHealth       CommandType = "health"
+	CommandTypeSubscription CommandType = "subscription"
+)
+
+// EventCategory is the top-level prefix on event_type strings.
+// Spec: APIs/schemas/event_*.json `event_type` pattern.
+type EventCategory string
+
+// Recognised event-type prefixes.
+const (
+	EventCategoryBoolean EventCategory = "boolean"
+	EventCategoryNumber  EventCategory = "number"
+	EventCategoryString  EventCategory = "string"
+	EventCategoryObject  EventCategory = "object"
+)
+
+// Identity is the per-event identity sub-object. `source_id` is
+// always required; `flow_id` is optional and identifies the IS-04
+// flow carrying the message when one is configured.
+type Identity struct {
+	SourceID string `json:"source_id"`
+	FlowID   string `json:"flow_id,omitempty"`
+}
+
+// Timing is the per-event timing sub-object. All timestamps are TAI
+// `<seconds>:<nanoseconds>` strings. `creation_timestamp` is
+// mandatory; `origin_timestamp` and `action_timestamp` are optional.
+type Timing struct {
+	CreationTimestamp string `json:"creation_timestamp"`
+	OriginTimestamp  string `json:"origin_timestamp,omitempty"`
+	ActionTimestamp  string `json:"action_timestamp,omitempty"`
+}
+
+// Number is the rational-number payload used by event_number and
+// type_number. `Scale` defaults to 1; final value is Value/Scale.
+type Number struct {
+	Value float64 `json:"value"`
+	Scale int     `json:"scale,omitempty"`
+}
+
+// PayloadBoolean is the payload of an event_boolean.
+type PayloadBoolean struct {
+	Value bool `json:"value"`
+}
+
+// PayloadString is the payload of an event_string.
+type PayloadString struct {
+	Value string `json:"value"`
+}
+
+// PayloadObject is the payload of an event_object — opaque object
+// allowed by spec.
+type PayloadObject = map[string]any
+
+// Source is the resource at `/sources/{id}` — the spec mandates
+// exactly the two-element array `["type/", "state/"]`.
+type Source []string
+
+// SourcesIndex is the resource at `/sources` — array of source-id
+// folders.
+type SourcesIndex []string
+
+// EnumValueBoolean is one entry of a type_boolean_enum.values array.
+type EnumValueBoolean struct {
+	Value       bool   `json:"value"`
+	Label       string `json:"label"`
+	Description string `json:"description"`
+}
+
+// EnumValueNumber is one entry of a type_number_enum.values array.
+type EnumValueNumber struct {
+	Value       Number `json:"value"`
+	Label       string `json:"label"`
+	Description string `json:"description"`
+}
+
+// EnumValueString is one entry of a type_string_enum.values array.
+type EnumValueString struct {
+	Value       string `json:"value"`
+	Label       string `json:"label"`
+	Description string `json:"description"`
+}
+
+// TypeBaseName is the base type discriminator on every type_*
+// descriptor (spec: APIs/schemas/type_*.json `type` enum).
+type TypeBaseName string
+
+// Recognised base type names per IS-07 v1.0.1.
+const (
+	TypeBaseNameBoolean TypeBaseName = "boolean"
+	TypeBaseNameNumber  TypeBaseName = "number"
+	TypeBaseNameString  TypeBaseName = "string"
+)
+
+// TypeBoolean is the type descriptor for a boolean source.
+type TypeBoolean struct {
+	Type TypeBaseName `json:"type"`
+}
+
+// TypeBooleanEnum is the type descriptor for a boolean-enum source.
+type TypeBooleanEnum struct {
+	Type   TypeBaseName       `json:"type"`
+	Values []EnumValueBoolean `json:"values"`
+}
+
+// TypeNumber is the type descriptor for a numeric source. `Min` /
+// `Max` are mandatory; `Step` and `Unit` are optional.
+type TypeNumber struct {
+	Type  TypeBaseName `json:"type"`
+	Min   Number       `json:"min"`
+	Max   Number       `json:"max"`
+	Scale int          `json:"scale,omitempty"`
+	Step  *Number      `json:"step,omitempty"`
+	Unit  string       `json:"unit,omitempty"`
+}
+
+// TypeNumberEnum is the type descriptor for a numeric-enum source.
+type TypeNumberEnum struct {
+	Type   TypeBaseName      `json:"type"`
+	Values []EnumValueNumber `json:"values"`
+}
+
+// TypeString is the type descriptor for a string source.
+type TypeString struct {
+	Type      TypeBaseName `json:"type"`
+	MinLength *int         `json:"min_length,omitempty"`
+	MaxLength *int         `json:"max_length,omitempty"`
+	Pattern   string       `json:"pattern,omitempty"`
+}
+
+// TypeStringEnum is the type descriptor for a string-enum source.
+type TypeStringEnum struct {
+	Type   TypeBaseName      `json:"type"`
+	Values []EnumValueString `json:"values"`
+}
+
+// ErrorBody is the standard 4xx/5xx response body per IS-07 §5.
+type ErrorBody struct {
+	Code  int    `json:"code"`
+	Error string `json:"error"`
+	Debug string `json:"debug,omitempty"`
+}
+
+// uuidPattern matches the IS-04 UUID grammar reused by IS-07.
+var uuidPattern = regexp.MustCompile(
+	`^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`,
+)
+
+// taiPattern matches `<sec>:<nsec>` per IS-04 / IS-05 / IS-07.
+var taiPattern = regexp.MustCompile(`^[0-9]+:[0-9]+$`)
+
+// eventTypeBoolean / eventTypeNumber / eventTypeString /
+// eventTypeObject match the per-prefix event_type pattern from each
+// event_*.json schema.
+var (
+	eventTypeBoolean = regexp.MustCompile(`^boolean(/[^\s/]+)*$`)
+	eventTypeNumber  = regexp.MustCompile(`^number(/[^\s/]+)*$`)
+	eventTypeString  = regexp.MustCompile(`^string(/[^\s/]+)*$`)
+	eventTypeObject  = regexp.MustCompile(`^object(/[^\s/]+)*$`)
+)
+
+// CategoryOf returns the prefix of an event_type string, or empty if
+// it does not match any recognised category.
+func CategoryOf(eventType string) EventCategory {
+	switch {
+	case eventTypeBoolean.MatchString(eventType):
+		return EventCategoryBoolean
+	case eventTypeNumber.MatchString(eventType):
+		return EventCategoryNumber
+	case eventTypeString.MatchString(eventType):
+		return EventCategoryString
+	case eventTypeObject.MatchString(eventType):
+		return EventCategoryObject
+	}
+	return ""
+}

--- a/internal/amwa/codec/is07/v10/codec.go
+++ b/internal/amwa/codec/is07/v10/codec.go
@@ -1,0 +1,46 @@
+// Package v10 is the AMWA NMOS IS-07 v1.0.1 wire codec — the
+// single track defined by the spec today. v1.0 covers:
+//
+//   - WebSocket transport (state, health, reboot, shutdown).
+//   - MQTT transport (adds connection_status).
+//   - HTTP REST endpoints under `/x-nmos/events/v1.0/...`.
+//
+// IS-07 has not received a v1.1 release; this codec is the only
+// minor we register. The spec.Registry gracefully extends the day
+// AMWA publishes one — drop a `v11/` package and an init Register
+// call.
+package v10
+
+import (
+	"acp/internal/amwa/codec/is07"
+)
+
+// SpecPatch — the patch release the codec is audited against.
+const SpecPatch = "v1.0.1"
+
+// Codec implements [is07.Codec] for IS-07 wire minor v1.0.
+type Codec struct{}
+
+// New returns a Codec.
+func New() Codec { return Codec{} }
+
+func (Codec) SpecID() string    { return is07.SpecID }
+func (Codec) APIVer() string    { return "v1.0" }
+func (Codec) SpecPatch() string { return SpecPatch }
+
+func (Codec) EncodeMessage(m is07.Message) ([]byte, error) {
+	return is07.EncodeMessage(m)
+}
+func (Codec) DecodeMessage(raw []byte) (is07.Message, error) {
+	return is07.DecodeMessage(raw)
+}
+func (Codec) EncodeCommand(c is07.Command) ([]byte, error) {
+	return is07.EncodeCommand(c)
+}
+func (Codec) DecodeCommand(raw []byte) (is07.Command, error) {
+	return is07.DecodeCommand(raw)
+}
+
+func init() {
+	is07.Register(Codec{})
+}

--- a/internal/amwa/codec/is07/v10/codec_test.go
+++ b/internal/amwa/codec/is07/v10/codec_test.go
@@ -1,0 +1,68 @@
+package v10
+
+import (
+	"testing"
+
+	"acp/internal/amwa/codec/is07"
+)
+
+func TestRegistration(t *testing.T) {
+	c, ok := is07.Get("v1.0")
+	if !ok {
+		t.Fatalf("is07.Get(v1.0) not found — init() did not register?")
+	}
+	if c.SpecID() != is07.SpecID {
+		t.Fatalf("spec id %q, want %q", c.SpecID(), is07.SpecID)
+	}
+	if c.APIVer() != "v1.0" {
+		t.Fatalf("api ver %q, want v1.0", c.APIVer())
+	}
+	if c.SpecPatch() != SpecPatch {
+		t.Fatalf("patch %q, want %q", c.SpecPatch(), SpecPatch)
+	}
+}
+
+func TestRoundTripViaCodec(t *testing.T) {
+	c := New()
+	in := is07.MessageHealth{
+		Timing: is07.Timing{
+			CreationTimestamp: "10:20",
+			OriginTimestamp:   "9:0",
+		},
+	}
+	body, err := c.EncodeMessage(in)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	out, err := c.DecodeMessage(body)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if _, ok := out.(is07.MessageHealth); !ok {
+		t.Fatalf("decoded into %T, want MessageHealth", out)
+	}
+}
+
+func TestSelectHighest(t *testing.T) {
+	got, err := is07.SelectHighest([]string{"v0.9", "v1.0", "v2.0"})
+	if err != nil {
+		t.Fatalf("SelectHighest: %v", err)
+	}
+	if got.APIVer() != "v1.0" {
+		t.Fatalf("expected v1.0 (only registered minor), got %s", got.APIVer())
+	}
+}
+
+func TestSupportedVersions(t *testing.T) {
+	versions := is07.SupportedVersions()
+	if len(versions) == 0 {
+		t.Fatalf("no versions registered")
+	}
+	want := "v1.0"
+	for _, v := range versions {
+		if v == want {
+			return
+		}
+	}
+	t.Fatalf("v1.0 missing from %v", versions)
+}

--- a/internal/amwa/codec/is07/validate.go
+++ b/internal/amwa/codec/is07/validate.go
@@ -1,0 +1,260 @@
+package is07
+
+import (
+	"fmt"
+)
+
+// validateIdentity enforces source_id presence + UUID grammar +
+// optional flow_id grammar.
+func validateIdentity(i Identity) error {
+	if i.SourceID == "" {
+		return fmt.Errorf("is07: identity.source_id: required")
+	}
+	if !uuidPattern.MatchString(i.SourceID) {
+		return fmt.Errorf("is07: identity.source_id %q: not a UUID", i.SourceID)
+	}
+	if i.FlowID != "" && !uuidPattern.MatchString(i.FlowID) {
+		return fmt.Errorf("is07: identity.flow_id %q: not a UUID", i.FlowID)
+	}
+	return nil
+}
+
+// validateTiming enforces creation_timestamp presence + optional TAI
+// grammar on every timestamp field.
+func validateTiming(t Timing, requireOrigin bool) error {
+	if t.CreationTimestamp == "" {
+		return fmt.Errorf("is07: timing.creation_timestamp: required")
+	}
+	if !taiPattern.MatchString(t.CreationTimestamp) {
+		return fmt.Errorf("is07: timing.creation_timestamp %q: must match `<sec>:<nsec>` TAI form",
+			t.CreationTimestamp)
+	}
+	if requireOrigin {
+		if t.OriginTimestamp == "" {
+			return fmt.Errorf("is07: timing.origin_timestamp: required")
+		}
+	}
+	if t.OriginTimestamp != "" && !taiPattern.MatchString(t.OriginTimestamp) {
+		return fmt.Errorf("is07: timing.origin_timestamp %q: must match `<sec>:<nsec>` TAI form",
+			t.OriginTimestamp)
+	}
+	if t.ActionTimestamp != "" && !taiPattern.MatchString(t.ActionTimestamp) {
+		return fmt.Errorf("is07: timing.action_timestamp %q: must match `<sec>:<nsec>` TAI form",
+			t.ActionTimestamp)
+	}
+	return nil
+}
+
+// validateEventCommon enforces the shared event_core fields, with
+// the per-category event_type prefix supplied by the caller.
+func validateEventCommon(c EventCommon, want EventCategory) error {
+	if c.MessageType != "" && c.MessageType != MessageTypeState {
+		return fmt.Errorf("is07: event message_type %q: must be %q",
+			c.MessageType, MessageTypeState)
+	}
+	if err := validateIdentity(c.Identity); err != nil {
+		return err
+	}
+	if err := validateTiming(c.Timing, false); err != nil {
+		return err
+	}
+	if c.EventType == "" {
+		return fmt.Errorf("is07: event_type: required")
+	}
+	if got := CategoryOf(c.EventType); got != want {
+		return fmt.Errorf("is07: event_type %q: expected category %q, got %q",
+			c.EventType, want, got)
+	}
+	return nil
+}
+
+func (e EventBoolean) validate() error {
+	return validateEventCommon(e.EventCommon, EventCategoryBoolean)
+}
+
+func (e EventNumber) validate() error {
+	if err := validateEventCommon(e.EventCommon, EventCategoryNumber); err != nil {
+		return err
+	}
+	if e.Payload.Scale != 0 && e.Payload.Scale < 1 {
+		return fmt.Errorf("is07: event_number.payload.scale %d: must be >= 1", e.Payload.Scale)
+	}
+	return nil
+}
+
+func (e EventString) validate() error {
+	return validateEventCommon(e.EventCommon, EventCategoryString)
+}
+
+func (e EventObject) validate() error {
+	if err := validateEventCommon(e.EventCommon, EventCategoryObject); err != nil {
+		return err
+	}
+	if e.Payload == nil {
+		return fmt.Errorf("is07: event_object.payload: required (may be empty object)")
+	}
+	return nil
+}
+
+func (m MessageHealth) validate() error {
+	if m.MessageType != "" && m.MessageType != MessageTypeHealth {
+		return fmt.Errorf("is07: health.message_type %q: must be %q",
+			m.MessageType, MessageTypeHealth)
+	}
+	return validateTiming(m.Timing, true)
+}
+
+// (note: MessageType is the struct's JSON-bearing field, NOT the
+// Kind() interface method.)
+
+func (m MessageShutdownReboot) validate() error {
+	if m.MessageType != MessageTypeReboot && m.MessageType != MessageTypeShutdown {
+		return fmt.Errorf("is07: shutdown_reboot.message_type %q: must be reboot or shutdown",
+			m.MessageType)
+	}
+	if err := validateIdentity(m.Identity); err != nil {
+		return err
+	}
+	return validateTiming(m.Timing, false)
+}
+
+func (m MessageConnectionStatus) validate() error {
+	if m.MessageType != "" && m.MessageType != MessageTypeConnectionStatus {
+		return fmt.Errorf("is07: connection_status.message_type %q: must be %q",
+			m.MessageType, MessageTypeConnectionStatus)
+	}
+	return nil
+}
+
+func (c CommandHealth) validate() error {
+	if c.Command != "" && c.Command != CommandTypeHealth {
+		return fmt.Errorf("is07: command_health.command %q: must be %q",
+			c.Command, CommandTypeHealth)
+	}
+	if c.Timestamp == "" {
+		return fmt.Errorf("is07: command_health.timestamp: required")
+	}
+	if !taiPattern.MatchString(c.Timestamp) {
+		return fmt.Errorf("is07: command_health.timestamp %q: must match `<sec>:<nsec>` TAI form",
+			c.Timestamp)
+	}
+	return nil
+}
+
+func (c CommandSubscription) validate() error {
+	if c.Command != "" && c.Command != CommandTypeSubscription {
+		return fmt.Errorf("is07: command_subscription.command %q: must be %q",
+			c.Command, CommandTypeSubscription)
+	}
+	if c.Sources == nil {
+		return fmt.Errorf("is07: command_subscription.sources: required (may be empty array)")
+	}
+	seen := make(map[string]struct{}, len(c.Sources))
+	for i, s := range c.Sources {
+		if !uuidPattern.MatchString(s) {
+			return fmt.Errorf("is07: command_subscription.sources[%d] %q: not a UUID", i, s)
+		}
+		if _, dup := seen[s]; dup {
+			return fmt.Errorf("is07: command_subscription.sources[%d] %q: duplicate", i, s)
+		}
+		seen[s] = struct{}{}
+	}
+	return nil
+}
+
+// ValidateTypeBoolean enforces the type_boolean shape.
+func ValidateTypeBoolean(t TypeBoolean) error {
+	if t.Type != TypeBaseNameBoolean {
+		return fmt.Errorf("is07: type_boolean.type %q: must be %q", t.Type, TypeBaseNameBoolean)
+	}
+	return nil
+}
+
+// ValidateTypeBooleanEnum enforces the type_boolean_enum shape.
+func ValidateTypeBooleanEnum(t TypeBooleanEnum) error {
+	if t.Type != TypeBaseNameBoolean {
+		return fmt.Errorf("is07: type_boolean_enum.type %q: must be %q", t.Type, TypeBaseNameBoolean)
+	}
+	if len(t.Values) == 0 {
+		return fmt.Errorf("is07: type_boolean_enum.values: required (must be non-empty)")
+	}
+	for i, v := range t.Values {
+		if v.Label == "" {
+			return fmt.Errorf("is07: type_boolean_enum.values[%d].label: required", i)
+		}
+		if v.Description == "" {
+			return fmt.Errorf("is07: type_boolean_enum.values[%d].description: required", i)
+		}
+	}
+	return nil
+}
+
+// ValidateTypeNumber enforces the type_number shape — Min/Max
+// required, optional Step / Unit / Scale all > 0.
+func ValidateTypeNumber(t TypeNumber) error {
+	if t.Type != TypeBaseNameNumber {
+		return fmt.Errorf("is07: type_number.type %q: must be %q", t.Type, TypeBaseNameNumber)
+	}
+	if t.Scale != 0 && t.Scale < 1 {
+		return fmt.Errorf("is07: type_number.scale %d: must be >= 1", t.Scale)
+	}
+	if t.Min.Scale != 0 && t.Min.Scale < 1 {
+		return fmt.Errorf("is07: type_number.min.scale %d: must be >= 1", t.Min.Scale)
+	}
+	if t.Max.Scale != 0 && t.Max.Scale < 1 {
+		return fmt.Errorf("is07: type_number.max.scale %d: must be >= 1", t.Max.Scale)
+	}
+	return nil
+}
+
+// ValidateTypeNumberEnum enforces the type_number_enum shape.
+func ValidateTypeNumberEnum(t TypeNumberEnum) error {
+	if t.Type != TypeBaseNameNumber {
+		return fmt.Errorf("is07: type_number_enum.type %q: must be %q", t.Type, TypeBaseNameNumber)
+	}
+	if len(t.Values) == 0 {
+		return fmt.Errorf("is07: type_number_enum.values: required (must be non-empty)")
+	}
+	for i, v := range t.Values {
+		if v.Label == "" {
+			return fmt.Errorf("is07: type_number_enum.values[%d].label: required", i)
+		}
+		if v.Description == "" {
+			return fmt.Errorf("is07: type_number_enum.values[%d].description: required", i)
+		}
+	}
+	return nil
+}
+
+// ValidateTypeString enforces the type_string shape.
+func ValidateTypeString(t TypeString) error {
+	if t.Type != TypeBaseNameString {
+		return fmt.Errorf("is07: type_string.type %q: must be %q", t.Type, TypeBaseNameString)
+	}
+	if t.MinLength != nil && *t.MinLength < 0 {
+		return fmt.Errorf("is07: type_string.min_length %d: must be >= 0", *t.MinLength)
+	}
+	if t.MaxLength != nil && *t.MaxLength < 1 {
+		return fmt.Errorf("is07: type_string.max_length %d: must be >= 1", *t.MaxLength)
+	}
+	return nil
+}
+
+// ValidateTypeStringEnum enforces the type_string_enum shape.
+func ValidateTypeStringEnum(t TypeStringEnum) error {
+	if t.Type != TypeBaseNameString {
+		return fmt.Errorf("is07: type_string_enum.type %q: must be %q", t.Type, TypeBaseNameString)
+	}
+	if len(t.Values) == 0 {
+		return fmt.Errorf("is07: type_string_enum.values: required (must be non-empty)")
+	}
+	for i, v := range t.Values {
+		if v.Label == "" {
+			return fmt.Errorf("is07: type_string_enum.values[%d].label: required", i)
+		}
+		if v.Description == "" {
+			return fmt.Errorf("is07: type_string_enum.values[%d].description: required", i)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- IS-07 Event & Tally codec — single track v1.0.1, follows the locked NMOS-wide pattern from `internal/amwa/codec/spec/`.
- Canonical structs (`is07.Message` / `is07.Command` sum types) + per-minor Strategy impl in `is07/v10/`. Future v1.1 = +1 file.
- 27 AMWA JSON schemas bundled at `internal/amwa/codec/is07/testdata/schemas/v1.0.1/` for audit traceability.
- All wire envelopes covered: state events (boolean/number/string/object payload variants), health, reboot/shutdown, MQTT connection_status; receiver-to-sender command_health and command_subscription with UUID + duplicate validation.
- Type descriptors (REST `/sources/{id}/type`) for boolean/number/string base + enum forms.
- Strict-decode with `DisallowUnknownFields`, TAI grammar, IS-04 UUID grammar, event_type / payload category cross-check.
- 33 unit tests covering codec round-trip, polymorphic dispatch, and validation rejection paths. Vet + golangci-lint clean.

WS server (Node-side publisher), WS subscriber (Controller-side consumer), and the optional MQTT bridge land in a follow-up PR that closes #164.

Refs #146 #164.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/amwa/codec/is07/...`
- [x] `golangci-lint run ./internal/amwa/codec/is07/... ./cmd/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)