### PR TITLE
feat(nmos/is08): codec base + v1.0.1 Strategy impl (Step 7, closes #165)

### DIFF
--- a/cmd/dhs/main.go
+++ b/cmd/dhs/main.go
@@ -70,6 +70,7 @@ import (
 	_ "acp/internal/amwa/codec/is05/v10"
 	_ "acp/internal/amwa/codec/is05/v11"
 	_ "acp/internal/amwa/codec/is07/v10"
+	_ "acp/internal/amwa/codec/is08/v10"
 	_ "acp/internal/amwa/codec/is09/v10"
 )
 

--- a/internal/amwa/codec/is08/codec.go
+++ b/internal/amwa/codec/is08/codec.go
@@ -1,0 +1,57 @@
+package is08
+
+import (
+	"acp/internal/amwa/codec/spec"
+)
+
+// SpecID is the AMWA NMOS catalogue slug for IS-08 (Audio Channel
+// Mapping).
+const SpecID = "is-08"
+
+// Codec is the IS-08 wire codec contract — one implementation per
+// supported wire minor (only v1.0 today). Each minor's vXX/
+// subpackage embeds is08/ canonical types and gates fields per its
+// spec text. Plugin code uses this interface; concrete impls are
+// wired via init() at process start.
+type Codec interface {
+	spec.Versioned
+
+	EncodeMapActive(MapActive) ([]byte, error)
+	DecodeMapActive([]byte) (MapActive, error)
+	ValidateMapActive(MapActive) error
+
+	EncodeMapActivationRequest(MapActivationRequest) ([]byte, error)
+	DecodeMapActivationRequest([]byte) (MapActivationRequest, error)
+	ValidateMapActivationRequest(MapActivationRequest) error
+
+	EncodeIO(IO) ([]byte, error)
+	DecodeIO([]byte) (IO, error)
+	ValidateIO(IO) error
+}
+
+// versions is the per-process Registry of IS-08 codec implementations.
+var versions = spec.NewRegistry[Codec]()
+
+// Register installs a codec for one IS-08 wire minor — same
+// semantics as is04.Register / is05.Register / is07.Register.
+// Idempotent for same instance; panics on conflict.
+func Register(c Codec) {
+	if c.SpecID() != SpecID {
+		panic("is08.Register: SpecID must be " + SpecID + ", got " + c.SpecID())
+	}
+	versions.Register(c)
+}
+
+// Get / AllCodecs / SupportedVersions / SelectHighest / Default —
+// same shape as the other NMOS specs.
+func Get(apiVer string) (Codec, bool)             { return versions.Get(apiVer) }
+func AllCodecs() []Codec                          { return versions.AllCodecs() }
+func SupportedVersions() []string                 { return versions.SupportedVersions() }
+func SelectHighest(peer []string) (Codec, error)  { return spec.SelectHighestMutual(versions, peer) }
+func Default() Codec {
+	all := versions.AllCodecs()
+	if len(all) == 0 {
+		panic("is08.Default: no codec registered (forgot to blank-import internal/amwa/codec/is08/vXX?)")
+	}
+	return all[len(all)-1]
+}

--- a/internal/amwa/codec/is08/doc.go
+++ b/internal/amwa/codec/is08/doc.go
@@ -1,0 +1,29 @@
+// Package is08 implements the AMWA NMOS IS-08 Audio Channel Mapping
+// codec. Stdlib-only, spec-strict per https://specs.amwa.tv/is-08/.
+//
+// Required versions per `internal/amwa/CLAUDE.md` "Versioning":
+//
+//   - v1.0 (latest patch v1.0.1) — single track. Wire layer is HTTP /
+//     JSON REST under `/x-nmos/channelmapping/v1.0/...`. No separate
+//     transport — the Node serves the Channel Mapping API; the
+//     Controller polls it and uses POST /map/activations to apply
+//     re-routes either immediately or on a TAI schedule.
+//
+// Resources covered (every schema bundled at testdata/schemas/v1.0.1):
+//
+//	IO                       — full /map/io view (inputs + outputs)
+//	InputProperties / Caps / Channels / Parent
+//	OutputProperties / Caps / Channels / SourceID
+//	MapActive / MapStaged    — current vs desired channel-routing map
+//	MapActivationRequest     — POST /map/activations body
+//	MapActivationResponse    — GET /map/activations[/{id}]
+//	Activation / ActivationResponse
+//	MapEntries               — { outputID: { channelIdxStr: MapEntry } }
+//	MapEntry                 — { input *string, channel_index *int }
+//	ErrorBody                — 4xx/5xx response shape
+//
+// This package follows the locked NMOS-wide codec pattern from
+// `internal/amwa/codec/spec/`: canonical Go structs in this package,
+// per-minor Strategy impls in vXX/. cmd/dhs/main.go blank-imports
+// each minor to wire init()-time registration.
+package is08

--- a/internal/amwa/codec/is08/is08_test.go
+++ b/internal/amwa/codec/is08/is08_test.go
@@ -1,0 +1,264 @@
+package is08
+
+import (
+	"strings"
+	"testing"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+func TestActivationModeValidity(t *testing.T) {
+	for _, m := range []ActivationMode{
+		ActivationModeImmediate,
+		ActivationModeScheduledRelative,
+		ActivationModeScheduledAbsolute,
+	} {
+		if !IsValidActivationMode(m) {
+			t.Errorf("expected %q valid", m)
+		}
+	}
+	for _, m := range []ActivationMode{"", "garbage", "activate_unknown"} {
+		if IsValidActivationMode(m) {
+			t.Errorf("expected %q invalid", m)
+		}
+	}
+}
+
+func TestValidateActivationRules(t *testing.T) {
+	cases := []struct {
+		name string
+		a    Activation
+		ok   bool
+	}{
+		{"immediate-clean", Activation{Mode: ActivationModeImmediate}, true},
+		{"immediate-with-time", Activation{Mode: ActivationModeImmediate, RequestedTime: ptr("1:0")}, false},
+		{"scheduled-rel-time", Activation{Mode: ActivationModeScheduledRelative, RequestedTime: ptr("1:0")}, true},
+		{"scheduled-abs-time", Activation{Mode: ActivationModeScheduledAbsolute, RequestedTime: ptr("1:0")}, true},
+		{"scheduled-no-time", Activation{Mode: ActivationModeScheduledRelative}, false},
+		{"scheduled-bad-tai", Activation{Mode: ActivationModeScheduledRelative, RequestedTime: ptr("not-tai")}, false},
+		{"empty-mode", Activation{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateActivation(tc.a)
+			if tc.ok && err != nil {
+				t.Fatalf("want ok, got %v", err)
+			}
+			if !tc.ok && err == nil {
+				t.Fatalf("want error")
+			}
+		})
+	}
+}
+
+func TestValidateMapEntries(t *testing.T) {
+	cases := []struct {
+		name string
+		m    MapEntries
+		ok   bool
+	}{
+		{"empty", MapEntries{}, true},
+		{"valid-routed", MapEntries{
+			"out1": {"0": MapEntry{Input: ptr("in1"), ChannelIndex: ptr(0)}},
+		}, true},
+		{"valid-unrouted", MapEntries{
+			"out1": {"0": MapEntry{}},
+		}, true},
+		{"bad-output-id", MapEntries{
+			"out 1": {"0": MapEntry{}},
+		}, false},
+		{"bad-channel-key", MapEntries{
+			"out1": {"01": MapEntry{}},
+		}, false},
+		{"bad-channel-key-negative", MapEntries{
+			"out1": {"-1": MapEntry{}},
+		}, false},
+		{"input-set-but-no-channel", MapEntries{
+			"out1": {"0": MapEntry{Input: ptr("in1")}},
+		}, false},
+		{"channel-set-but-no-input", MapEntries{
+			"out1": {"0": MapEntry{ChannelIndex: ptr(0)}},
+		}, false},
+		{"input-bad-id", MapEntries{
+			"out1": {"0": MapEntry{Input: ptr("bad id"), ChannelIndex: ptr(0)}},
+		}, false},
+		{"channel-negative", MapEntries{
+			"out1": {"0": MapEntry{Input: ptr("in1"), ChannelIndex: ptr(-1)}},
+		}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateMapEntries(tc.m)
+			if tc.ok && err != nil {
+				t.Fatalf("want ok, got %v", err)
+			}
+			if !tc.ok && err == nil {
+				t.Fatalf("want error")
+			}
+		})
+	}
+}
+
+func TestMapActiveRoundTrip(t *testing.T) {
+	in := MapActive{
+		Activation: ActivationResponse{
+			Mode:           ptrMode(ActivationModeImmediate),
+			RequestedTime:  nil,
+			ActivationTime: ptr("100:200"),
+		},
+		Map: MapEntries{
+			"out1": {
+				"0": MapEntry{Input: ptr("in1"), ChannelIndex: ptr(0)},
+				"1": MapEntry{}, // unrouted
+			},
+		},
+	}
+	body, err := EncodeMapActive(in)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	got, err := DecodeMapActive(body)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got.Map["out1"]["0"].Input == nil || *got.Map["out1"]["0"].Input != "in1" {
+		t.Fatalf("routed input mismatch: %+v", got.Map["out1"]["0"])
+	}
+	if got.Map["out1"]["1"].Input != nil {
+		t.Fatalf("unrouted entry should have nil input")
+	}
+}
+
+func TestMapActiveDecodeRejectsUnknownField(t *testing.T) {
+	body := []byte(`{"activation":{"mode":null,"requested_time":null,"activation_time":null},"map":{},"future_field":"x"}`)
+	if _, err := DecodeMapActive(body); err == nil {
+		t.Fatalf("expected DisallowUnknownFields rejection")
+	} else if !strings.Contains(err.Error(), "future_field") {
+		t.Fatalf("error should name unknown field: %v", err)
+	}
+}
+
+func TestMapActivationRequestRoundTrip(t *testing.T) {
+	in := MapActivationRequest{
+		Activation: Activation{
+			Mode:          ActivationModeScheduledAbsolute,
+			RequestedTime: ptr("1700000000:0"),
+		},
+		Action: MapEntries{
+			"out1": {"0": MapEntry{Input: ptr("in1"), ChannelIndex: ptr(0)}},
+		},
+	}
+	body, err := EncodeMapActivationRequest(in)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	got, err := DecodeMapActivationRequest(body)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got.Activation.Mode != ActivationModeScheduledAbsolute {
+		t.Fatalf("mode mismatch")
+	}
+	if *got.Activation.RequestedTime != "1700000000:0" {
+		t.Fatalf("requested_time mismatch")
+	}
+}
+
+func TestIORoundTrip(t *testing.T) {
+	in := IO{
+		Inputs: map[string]Input{
+			"in1": {
+				Properties: &InputProperties{Name: "Input 1", Description: "Mic 1"},
+				Caps:       &InputCaps{Reordering: true, BlockSize: 1},
+				Channels:   []Channel{{Label: "L"}, {Label: "R"}},
+				Parent: &InputParent{
+					ID:   ptr("1f1e1d1c-1b1a-4019-8817-161514131211"),
+					Type: ptr("source"),
+				},
+			},
+		},
+		Outputs: map[string]Output{
+			"out1": {
+				Properties: &OutputProperties{Name: "Output 1", Description: "Bus A"},
+				Caps:       &OutputCaps{RoutableInputs: []*string{ptr("in1"), nil}},
+				Channels:   []Channel{{Label: "L"}, {Label: "R"}},
+				SourceID:   ptr("2f2e2d2c-2b2a-4029-8827-262524232221"),
+			},
+		},
+	}
+	body, err := EncodeIO(in)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	got, err := DecodeIO(body)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got.Inputs["in1"].Caps.BlockSize != 1 {
+		t.Fatalf("input caps mismatch")
+	}
+	if got.Outputs["out1"].Channels[1].Label != "R" {
+		t.Fatalf("output channel mismatch")
+	}
+}
+
+func TestIORejectsBadOutputID(t *testing.T) {
+	in := IO{
+		Inputs:  map[string]Input{},
+		Outputs: map[string]Output{"out 1": {}},
+	}
+	if _, err := EncodeIO(in); err == nil {
+		t.Fatalf("expected error on bad id")
+	}
+}
+
+func TestIORequiresInputsOutputs(t *testing.T) {
+	if err := ValidateIO(IO{}); err == nil {
+		t.Fatalf("expected required inputs/outputs")
+	}
+}
+
+func TestInputCapsBlockSize(t *testing.T) {
+	if err := ValidateInputCaps(InputCaps{BlockSize: 0}); err == nil {
+		t.Fatalf("block_size 0 should fail")
+	}
+	if err := ValidateInputCaps(InputCaps{BlockSize: 1}); err != nil {
+		t.Fatalf("block_size 1 should pass: %v", err)
+	}
+}
+
+func TestOutputCapsRoutableInputs(t *testing.T) {
+	if err := ValidateOutputCaps(OutputCaps{RoutableInputs: nil}); err != nil {
+		t.Fatalf("nil routable_inputs should pass: %v", err)
+	}
+	if err := ValidateOutputCaps(OutputCaps{RoutableInputs: []*string{ptr("in 1")}}); err == nil {
+		t.Fatalf("bad id should fail")
+	}
+	if err := ValidateOutputCaps(OutputCaps{RoutableInputs: []*string{nil, ptr("in1")}}); err != nil {
+		t.Fatalf("explicit-null + valid id should pass: %v", err)
+	}
+}
+
+func TestInputParent(t *testing.T) {
+	if err := ValidateInputParent(InputParent{ID: ptr("garbage"), Type: ptr("source")}); err == nil {
+		t.Fatalf("bad uuid should fail")
+	}
+	if err := ValidateInputParent(InputParent{ID: ptr("1f1e1d1c-1b1a-4019-8817-161514131211"), Type: ptr("invalid")}); err == nil {
+		t.Fatalf("bad type should fail")
+	}
+	if err := ValidateInputParent(InputParent{}); err != nil {
+		t.Fatalf("all-null should pass: %v", err)
+	}
+}
+
+func TestActivationResponseValidity(t *testing.T) {
+	mode := ActivationModeImmediate
+	if err := ValidateActivationResponse(ActivationResponse{Mode: &mode, ActivationTime: ptr("not-tai")}); err == nil {
+		t.Fatalf("bad activation_time should fail")
+	}
+	if err := ValidateActivationResponse(ActivationResponse{}); err != nil {
+		t.Fatalf("all-null should pass: %v", err)
+	}
+}
+
+func ptrMode(m ActivationMode) *ActivationMode { return &m }

--- a/internal/amwa/codec/is08/testdata/schemas/v1.0.1/activation-response-schema.json
+++ b/internal/amwa/codec/is08/testdata/schemas/v1.0.1/activation-response-schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Parameters concerned with activation of the channel mapping",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "mode",
+    "requested_time",
+    "activation_time"
+  ],
+  "properties": {
+    "mode": {
+      "description": "Mode of activation: immediate (on message receipt), scheduled_absolute (when internal clock >= requested_time), scheduled_relative (when internal clock >= time of message receipt + requested_time), or null (no activation scheduled).",
+      "anyOf": [{
+        "type": "string",
+        "enum": [
+          "activate_immediate",
+          "activate_scheduled_absolute",
+          "activate_scheduled_relative"
+        ]
+      }, {
+        "type": "null"
+      }]
+    },
+    "requested_time": {
+      "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating time (absolute or relative) for activation requested. For an immediate activation this field will always be null.",
+      "anyOf": [{
+        "type": "string",
+        "pattern": "^[0-9]+:[0-9]+$"
+      }, {
+        "type": "null"
+      }]
+    },
+    "activation_time": {
+      "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating the absolute time the channel mapping will or did actually activate for scheduled activations, or the time activation occurred for immediate activations. For immediate activations this property will be the time the activation actually occurred in the response to the POST request.",
+      "anyOf": [{
+        "type": "string",
+        "pattern": "^[0-9]+:[0-9]+$"
+      }, {
+        "type": "null"
+      }]
+    }
+  }
+}

--- a/internal/amwa/codec/is08/testdata/schemas/v1.0.1/activation-schema.json
+++ b/internal/amwa/codec/is08/testdata/schemas/v1.0.1/activation-schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "Activation resource",
+  "description": "Parameters concerned with activation of the channel mapping",
+  "additionalProperties": false,
+  "required": [
+    "mode"
+  ],
+  "properties": {
+    "mode": {
+      "description": "Mode of activation: immediate (on message receipt), scheduled_absolute (when internal clock >= requested_time), or scheduled_relative (when internal clock >= time of message receipt + requested_time)",
+      "type": "string",
+      "enum": [
+        "activate_immediate",
+        "activate_scheduled_absolute",
+        "activate_scheduled_relative"
+      ]
+    },
+    "requested_time": {
+      "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating time (absolute or relative) for activation",
+      "anyOf": [{
+        "type": "string",
+        "pattern": "^[0-9]+:[0-9]+$"
+      }, {
+        "type": "null"
+      }]
+    }
+  }
+}

--- a/internal/amwa/codec/is08/testdata/schemas/v1.0.1/base-schema.json
+++ b/internal/amwa/codec/is08/testdata/schemas/v1.0.1/base-schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "array",
+  "description": "Describes the Channel Mapping API base resource",
+  "title": "Channel Mapping API base resource",
+  "items": {
+    "type": "string",
+    "enum": [
+      "inputs/",
+      "outputs/",
+      "map/",
+      "io/"
+    ]
+  },
+  "minItems": 4,
+  "maxItems": 4,
+  "uniqueItems": true
+}

--- a/internal/amwa/codec/is08/testdata/schemas/v1.0.1/error.json
+++ b/internal/amwa/codec/is08/testdata/schemas/v1.0.1/error.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes the standard error response which is returned with HTTP codes 400 and above",
+  "title": "Error response",
+  "required": [
+    "code",
+    "error",
+    "debug"
+  ],
+  "properties": {
+    "code": {
+      "description": "HTTP error code",
+      "type": "integer",
+      "minimum": 400,
+      "maximum": 599
+    },
+    "error": {
+      "description": "Human readable message which is suitable for user interface display, and helpful to the user",
+      "type": "string"
+    },
+    "debug": {
+      "description": "Debug information which may assist a programmer working with the API",
+      "type": ["null", "string"]
+    }
+  }
+}

--- a/internal/amwa/codec/is08/testdata/schemas/v1.0.1/input-base-schema.json
+++ b/internal/amwa/codec/is08/testdata/schemas/v1.0.1/input-base-schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "array",
+  "description": "Describes the Channel Mapping API input base resource",
+  "title": "Channel Mapping API input base resource",
+  "items": {
+    "type": "string",
+    "enum": [
+      "properties/",
+      "parent/",
+      "channels/",
+      "caps/"
+    ]
+  },
+  "minItems": 4,
+  "maxItems": 4,
+  "uniqueItems": true
+}

--- a/internal/amwa/codec/is08/testdata/schemas/v1.0.1/input-caps-response-schema.json
+++ b/internal/amwa/codec/is08/testdata/schemas/v1.0.1/input-caps-response-schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes an input's capabilities",
+  "title": "Input capabilities resource",
+  "additionalProperties": false,
+  "required":[
+    "reordering",
+    "block_size"
+  ],
+  "properties":{
+    "reordering":{
+      "type": "boolean"
+    },
+    "block_size":{
+      "type": "integer",
+      "minimum": 1
+    }
+  }
+}

--- a/internal/amwa/codec/is08/testdata/schemas/v1.0.1/input-channels-response-schema.json
+++ b/internal/amwa/codec/is08/testdata/schemas/v1.0.1/input-channels-response-schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "array",
+  "description": "List of channels in an input",
+  "title": "Input channel resource",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "required": [
+      "label"
+    ],
+    "properties": {
+      "label": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/internal/amwa/codec/is08/testdata/schemas/v1.0.1/input-parent-response-schema.json
+++ b/internal/amwa/codec/is08/testdata/schemas/v1.0.1/input-parent-response-schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "description": "Gives details of where media connected to an Input came from",
+  "title": "Input Parent Resource",
+  "required":[
+    "id",
+    "type"
+  ],
+  "properties": {
+    "id":{
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    },
+    "type":{
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum":[
+        "source",
+        "receiver",
+        null
+      ]
+    }
+  }
+}

--- a/internal/amwa/codec/is08/testdata/schemas/v1.0.1/input-properties-schema.json
+++ b/internal/amwa/codec/is08/testdata/schemas/v1.0.1/input-properties-schema.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "description": "Properties of the input",
+    "title": "Input properties resource",
+    "required":[
+      "name",
+      "description"
+    ],
+    "properties": {
+        "name":{
+            "type": "string",
+            "description": "Human readable name for the input"
+        },
+        "description":{
+            "type": "string",
+            "description": "Human readable description of the input"
+        }
+    }
+  }
+  

--- a/internal/amwa/codec/is08/testdata/schemas/v1.0.1/inputs-outputs-base-schema.json
+++ b/internal/amwa/codec/is08/testdata/schemas/v1.0.1/inputs-outputs-base-schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "array",
+  "description": "List of paths for the inputs or outputs",
+  "title": "Inputs or Outputs base resource",
+  "items": {
+    "type": "string",
+    "pattern": "^[a-zA-Z0-9\\-_]+/$"
+  },
+  "uniqueItems": true
+}

--- a/internal/amwa/codec/is08/testdata/schemas/v1.0.1/io-response-schema.json
+++ b/internal/amwa/codec/is08/testdata/schemas/v1.0.1/io-response-schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "IO Information view for entire API",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "inputs",
+    "outputs"
+  ],
+  "properties": {
+    "inputs":{
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9\\-_]+$":{
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "properties":{
+              "$ref": "input-properties-schema.json"
+            },
+            "parent":{
+              "$ref": "input-parent-response-schema.json"
+            },
+            "channels":{
+              "$ref": "input-channels-response-schema.json"
+            },
+            "caps":{
+              "$ref": "input-caps-response-schema.json"
+            }
+          }
+        }
+      }  
+    },
+    "outputs":{
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9\\-_]+$":{
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "properties":{
+              "$ref": "output-properties-schema.json"
+            },
+            "source_id":{
+              "$ref": "output-sourceid-response-schema.json"
+            },
+            "channels":{
+              "$ref": "output-channels-response-schema.json"
+            },
+            "caps":{
+              "$ref": "output-caps-response-schema.json"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/amwa/codec/is08/testdata/schemas/v1.0.1/map-activations-activation-get-response-schema.json
+++ b/internal/amwa/codec/is08/testdata/schemas/v1.0.1/map-activations-activation-get-response-schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Single activation endpoint",
+  "description": "A single pending activation",
+  "type": "object",
+  "additionalPropertes": false,
+  "required": [
+    "activation",
+    "action"
+  ],
+  "properties": {
+    "activation":{
+      "$ref": "activation-response-schema.json"
+    },
+    "action:":{
+      "$ref": "map-entries-schema.json"
+    }
+  }
+}

--- a/internal/amwa/codec/is08/testdata/schemas/v1.0.1/map-activations-get-response-schema.json
+++ b/internal/amwa/codec/is08/testdata/schemas/v1.0.1/map-activations-get-response-schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Activations endpoint",
+  "description": "List of all currently pending activations",
+  "type": "object",
+  "additionalPropertes": false,
+  "patternProperties": {
+    "^[a-zA-Z0-9\\-_]+$": {
+      "type": "object",
+      "additionalPropertes": false,
+      "required": [
+        "activation",
+        "action"
+      ],
+      "properties": {
+        "activation":{
+          "$ref": "activation-response-schema.json"
+        },
+        "action:":{
+          "$ref": "map-entries-schema.json"
+        }
+      }
+    }
+  }
+}

--- a/internal/amwa/codec/is08/testdata/schemas/v1.0.1/map-activations-post-request-schema.json
+++ b/internal/amwa/codec/is08/testdata/schemas/v1.0.1/map-activations-post-request-schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Activations endpoint",
+  "description": "Add a new activation to the activations list",
+  "type": "object",
+  "additionalPropertes": false,
+  "required": [
+    "activation",
+    "action"
+  ],
+  "properties": {
+    "activation":{
+      "$ref": "activation-schema.json"
+    },
+    "action:":{
+      "$ref": "map-entries-schema.json"
+    }
+  }
+}

--- a/internal/amwa/codec/is08/testdata/schemas/v1.0.1/map-activations-post-response-schema.json
+++ b/internal/amwa/codec/is08/testdata/schemas/v1.0.1/map-activations-post-response-schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Activations endpoint",
+  "description": "Activation response",
+  "type": "object",
+  "additionalPropertes": false,
+  "maxProperties": 1,
+  "patternProperties": {
+    "^[a-zA-Z0-9\\-_]+$": {
+      "type": "object",
+      "additionalPropertes": false,
+      "required": [
+        "activation",
+        "action"
+      ],
+      "properties": {
+        "activation":{
+          "$ref": "activation-response-schema.json"
+        },
+        "action:":{
+          "$ref": "map-entries-schema.json"
+        }
+      }
+    }
+  }
+}

--- a/internal/amwa/codec/is08/testdata/schemas/v1.0.1/map-active-output-response-schema.json
+++ b/internal/amwa/codec/is08/testdata/schemas/v1.0.1/map-active-output-response-schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes the map for one specific output",
+  "title": "Map resource",
+  "additionalProperties": false,
+  "required": [
+    "map"
+  ],
+  "properties": {
+    "activation": {
+      "$ref": "activation-response-schema.json"
+    },
+    "map":{
+      "allOf": [{
+        "$ref": "map-entries-schema.json"
+      }, {
+        "minProperties": 1,
+        "maxProperties": 1
+      }]
+    }
+  }
+}

--- a/internal/amwa/codec/is08/testdata/schemas/v1.0.1/map-active-response-schema.json
+++ b/internal/amwa/codec/is08/testdata/schemas/v1.0.1/map-active-response-schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes the map for all outputs",
+  "title": "Map resource",
+  "additionalProperties": false,
+  "required":[
+    "activation",
+    "map"
+  ],
+  "properties": {
+    "activation": {
+      "$ref": "activation-response-schema.json"
+    },
+    "map":{
+      "$ref": "map-entries-schema.json"
+    }
+  }
+}

--- a/internal/amwa/codec/is08/testdata/schemas/v1.0.1/map-base-schema.json
+++ b/internal/amwa/codec/is08/testdata/schemas/v1.0.1/map-base-schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "array",
+  "description": "Describes the Channel Mapping API map base resource",
+  "title": "Channel Mapping API map base resource",
+  "items": {
+    "type": "string",
+    "enum": [
+      "activations/",
+      "active/"
+    ]
+  },
+  "minItems": 2,
+  "maxItems": 2,
+  "uniqueItems": true
+}

--- a/internal/amwa/codec/is08/testdata/schemas/v1.0.1/map-entries-schema.json
+++ b/internal/amwa/codec/is08/testdata/schemas/v1.0.1/map-entries-schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes the map table entries",
+  "title": "Map table entries",
+  "additionalProperties": false,
+  "patternProperties": {
+    "^[a-zA-Z0-9\\-_]+$": {
+      "description": "Unique identifiers of the outputs",
+      "patternProperties":{
+        "^(0|([1-9][0-9]*))$":{
+          "description": "Indexes of channels",
+          "required":[
+            "input",
+            "channel_index"
+          ],
+          "properties": {
+            "input":{
+              "description": "Unique identifier of the input to which the channel to be routed belongs. null for unrouted.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "channel_index":{
+              "description": "Index of the input channel to be routed. null for unrouted.",
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/amwa/codec/is08/testdata/schemas/v1.0.1/output-base-schema.json
+++ b/internal/amwa/codec/is08/testdata/schemas/v1.0.1/output-base-schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "array",
+  "description": "Describes the Channel Mapping API output base resource",
+  "title": "Channel Mapping API output base resource",
+  "items": {
+    "type": "string",
+    "enum": [
+      "properties/",
+      "sourceid/",
+      "channels/",
+      "caps/"
+    ]
+  },
+  "minItems": 4,
+  "maxItems": 4,
+  "uniqueItems": true
+}

--- a/internal/amwa/codec/is08/testdata/schemas/v1.0.1/output-caps-response-schema.json
+++ b/internal/amwa/codec/is08/testdata/schemas/v1.0.1/output-caps-response-schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Describes an output's capabilities",
+  "title": "Output capabilities resource",
+  "required":[
+    "routable_inputs"
+  ],
+  "properties": {
+    "routable_inputs":{
+      "description": "List of Inputs that may be routed to this Output, including null if unrouted Output channels are allowed. This property MUST be set to null, if no such restrictions exist.",
+      "anyOf": [{
+        "type": "array",
+        "items": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^[a-zA-Z0-9\\-_]+$"
+        },
+        "uniqueItems": true
+      }, {
+        "type": "null"
+      }]
+    }
+  }
+}

--- a/internal/amwa/codec/is08/testdata/schemas/v1.0.1/output-channels-response-schema.json
+++ b/internal/amwa/codec/is08/testdata/schemas/v1.0.1/output-channels-response-schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "array",
+  "description": "List of channels in an output",
+  "title": "Output channel resource",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "required": [
+      "label"
+    ],
+    "properties": {
+      "label": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/internal/amwa/codec/is08/testdata/schemas/v1.0.1/output-properties-schema.json
+++ b/internal/amwa/codec/is08/testdata/schemas/v1.0.1/output-properties-schema.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "description": "Properties of the output",
+    "title": "Output properties resource",
+    "required":[
+      "name",
+      "description"
+    ],
+    "properties": {
+        "name":{
+            "type": "string",
+            "description": "Human readable name for the output"
+        },
+        "description":{
+            "type": "string",
+            "description": "Human readable description of the output"
+        }
+    }
+  }
+  

--- a/internal/amwa/codec/is08/testdata/schemas/v1.0.1/output-sourceid-response-schema.json
+++ b/internal/amwa/codec/is08/testdata/schemas/v1.0.1/output-sourceid-response-schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": ["string", "null"],
+  "description": "Gives an output's source ID",
+  "title": "Output source ID resource",  
+  "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+}

--- a/internal/amwa/codec/is08/types.go
+++ b/internal/amwa/codec/is08/types.go
@@ -1,0 +1,178 @@
+package is08
+
+import (
+	"regexp"
+)
+
+// ActivationMode is the discriminator on the activation sub-object —
+// one of three explicit values (no empty-string equivalent like
+// IS-05; IS-08 always names the mode).
+//
+// Spec: APIs/schemas/activation-schema.json `mode` enum.
+type ActivationMode string
+
+// Recognised activation modes per IS-08 v1.0.1.
+const (
+	ActivationModeImmediate         ActivationMode = "activate_immediate"
+	ActivationModeScheduledRelative ActivationMode = "activate_scheduled_relative"
+	ActivationModeScheduledAbsolute ActivationMode = "activate_scheduled_absolute"
+)
+
+// IsValidActivationMode is true when m is one of the three spec
+// values. Empty is rejected — IS-08 requests always name a mode.
+func IsValidActivationMode(m ActivationMode) bool {
+	switch m {
+	case ActivationModeImmediate,
+		ActivationModeScheduledRelative,
+		ActivationModeScheduledAbsolute:
+		return true
+	}
+	return false
+}
+
+// Activation is the request-side activation sub-object — `mode`
+// required + `requested_time` optional (anyOf string/null).
+// Spec: APIs/schemas/activation-schema.json.
+type Activation struct {
+	Mode          ActivationMode `json:"mode"`
+	RequestedTime *string        `json:"requested_time,omitempty"`
+}
+
+// ActivationResponse is the response-side activation block — every
+// field required and nullable. `mode` is null when no activation
+// is scheduled; `activation_time` is set by the server.
+// Spec: APIs/schemas/activation-response-schema.json.
+type ActivationResponse struct {
+	Mode           *ActivationMode `json:"mode"`
+	RequestedTime  *string         `json:"requested_time"`
+	ActivationTime *string         `json:"activation_time"`
+}
+
+// MapEntry is the per-channel route — either both fields populated
+// (routed) or both null (unrouted). Spec:
+// APIs/schemas/map-entries-schema.json.
+type MapEntry struct {
+	Input        *string `json:"input"`
+	ChannelIndex *int    `json:"channel_index"`
+}
+
+// MapEntries is the per-output channel-routing dictionary:
+//
+//	{ outputID: { "0": MapEntry, "1": MapEntry, ... } }
+//
+// Channel index keys are stringified non-negative integers.
+type MapEntries = map[string]map[string]MapEntry
+
+// MapActive is the body of GET /map/active{,/{outputID}}. The
+// activation block is response-shaped (server-populated).
+// Spec: APIs/schemas/map-active-response-schema.json.
+type MapActive struct {
+	Activation ActivationResponse `json:"activation"`
+	Map        MapEntries         `json:"map"`
+}
+
+// MapStaged is the body of GET /map/active and PATCH-style staging
+// targets — same shape as MapActive on the wire. Kept as a distinct
+// type so callers can tell the two state apart in code.
+type MapStaged = MapActive
+
+// MapActivationRequest is the body of POST /map/activations.
+// Spec: APIs/schemas/map-activations-post-request-schema.json.
+type MapActivationRequest struct {
+	Activation Activation `json:"activation"`
+	Action     MapEntries `json:"action"`
+}
+
+// MapActivationResponse is the per-activation entry on
+// GET /map/activations{,/{id}} and POST response.
+// Spec: APIs/schemas/map-activations-activation-get-response-schema.json.
+type MapActivationResponse struct {
+	ID         string             `json:"id,omitempty"`
+	Activation ActivationResponse `json:"activation"`
+	Action     MapEntries         `json:"action"`
+}
+
+// InputProperties is the body of GET /inputs/{id}/properties.
+type InputProperties struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// OutputProperties mirrors InputProperties for outputs.
+type OutputProperties = InputProperties
+
+// InputCaps is the body of GET /inputs/{id}/caps. Reordering ==
+// whether the input can be re-ordered freely; BlockSize == hardware
+// granularity.
+type InputCaps struct {
+	Reordering bool `json:"reordering"`
+	BlockSize  int  `json:"block_size"`
+}
+
+// OutputCaps is the body of GET /outputs/{id}/caps. RoutableInputs
+// is nil = unrestricted; non-nil entries with a null element ==
+// "unrouted is allowed".
+type OutputCaps struct {
+	RoutableInputs []*string `json:"routable_inputs"`
+}
+
+// InputParent is the body of GET /inputs/{id}/parent. Both fields
+// nullable; Type ∈ {"source", "receiver", null}.
+type InputParent struct {
+	ID   *string `json:"id"`
+	Type *string `json:"type"`
+}
+
+// Channel is one element of GET /inputs/{id}/channels and
+// /outputs/{id}/channels.
+type Channel struct {
+	Label string `json:"label"`
+}
+
+// Input is the inner record of IO.Inputs[id]. Every property is
+// optional on the `/map/io` aggregate view; the dedicated
+// per-property endpoints are authoritative.
+type Input struct {
+	Properties *InputProperties `json:"properties,omitempty"`
+	Parent     *InputParent     `json:"parent,omitempty"`
+	Channels   []Channel        `json:"channels,omitempty"`
+	Caps       *InputCaps       `json:"caps,omitempty"`
+}
+
+// Output is the inner record of IO.Outputs[id].
+type Output struct {
+	Properties *OutputProperties `json:"properties,omitempty"`
+	SourceID   *string           `json:"source_id,omitempty"`
+	Channels   []Channel         `json:"channels,omitempty"`
+	Caps       *OutputCaps       `json:"caps,omitempty"`
+}
+
+// IO is the body of GET /map/io — the full inputs + outputs view.
+type IO struct {
+	Inputs  map[string]Input  `json:"inputs"`
+	Outputs map[string]Output `json:"outputs"`
+}
+
+// ErrorBody is the standard 4xx/5xx response shape.
+type ErrorBody struct {
+	Code  int    `json:"code"`
+	Error string `json:"error"`
+	Debug string `json:"debug,omitempty"`
+}
+
+// idPattern matches the IS-08 input/output identifier grammar
+// (alphanumeric + hyphen + underscore).
+var idPattern = regexp.MustCompile(`^[a-zA-Z0-9\-_]+$`)
+
+// chanPattern matches the channel-index keys in MapEntries — `0` or
+// `1`-prefixed digits.
+var chanPattern = regexp.MustCompile(`^(0|[1-9][0-9]*)$`)
+
+// taiPattern matches the standard NMOS `<sec>:<nsec>` TAI form.
+var taiPattern = regexp.MustCompile(`^[0-9]+:[0-9]+$`)
+
+// uuidPattern matches the IS-04 UUID grammar reused by IS-08
+// source/parent identifiers.
+var uuidPattern = regexp.MustCompile(
+	`^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`,
+)

--- a/internal/amwa/codec/is08/v10/codec.go
+++ b/internal/amwa/codec/is08/v10/codec.go
@@ -1,0 +1,63 @@
+// Package v10 is the AMWA NMOS IS-08 v1.0.1 wire codec — the single
+// track defined by the spec today. v1.0 covers:
+//
+//   - HTTP REST endpoints under `/x-nmos/channelmapping/v1.0/...`.
+//   - Stage / activate flow on POST /map/activations.
+//   - GET /map/active, /map/staged, /map/io.
+//
+// IS-08 has not received a v1.1 release; this codec is the only
+// minor we register. The spec.Registry gracefully extends the day
+// AMWA publishes one — drop a `v11/` package and an init Register
+// call.
+package v10
+
+import (
+	"acp/internal/amwa/codec/is08"
+)
+
+// SpecPatch — the patch release the codec is audited against.
+const SpecPatch = "v1.0.1"
+
+// Codec implements [is08.Codec] for IS-08 wire minor v1.0.
+type Codec struct{}
+
+// New returns a Codec.
+func New() Codec { return Codec{} }
+
+func (Codec) SpecID() string    { return is08.SpecID }
+func (Codec) APIVer() string    { return "v1.0" }
+func (Codec) SpecPatch() string { return SpecPatch }
+
+func (Codec) EncodeMapActive(m is08.MapActive) ([]byte, error) {
+	return is08.EncodeMapActive(m)
+}
+func (Codec) DecodeMapActive(raw []byte) (is08.MapActive, error) {
+	return is08.DecodeMapActive(raw)
+}
+func (Codec) ValidateMapActive(m is08.MapActive) error {
+	return is08.ValidateMapActive(m)
+}
+
+func (Codec) EncodeMapActivationRequest(r is08.MapActivationRequest) ([]byte, error) {
+	return is08.EncodeMapActivationRequest(r)
+}
+func (Codec) DecodeMapActivationRequest(raw []byte) (is08.MapActivationRequest, error) {
+	return is08.DecodeMapActivationRequest(raw)
+}
+func (Codec) ValidateMapActivationRequest(r is08.MapActivationRequest) error {
+	return is08.ValidateMapActivationRequest(r)
+}
+
+func (Codec) EncodeIO(io is08.IO) ([]byte, error) {
+	return is08.EncodeIO(io)
+}
+func (Codec) DecodeIO(raw []byte) (is08.IO, error) {
+	return is08.DecodeIO(raw)
+}
+func (Codec) ValidateIO(io is08.IO) error {
+	return is08.ValidateIO(io)
+}
+
+func init() {
+	is08.Register(Codec{})
+}

--- a/internal/amwa/codec/is08/v10/codec_test.go
+++ b/internal/amwa/codec/is08/v10/codec_test.go
@@ -1,0 +1,48 @@
+package v10
+
+import (
+	"testing"
+
+	"acp/internal/amwa/codec/is08"
+)
+
+func TestRegistration(t *testing.T) {
+	c, ok := is08.Get("v1.0")
+	if !ok {
+		t.Fatalf("is08.Get(v1.0) not found — init() did not register?")
+	}
+	if c.SpecID() != is08.SpecID {
+		t.Fatalf("spec id %q", c.SpecID())
+	}
+	if c.APIVer() != "v1.0" {
+		t.Fatalf("api ver %q", c.APIVer())
+	}
+	if c.SpecPatch() != SpecPatch {
+		t.Fatalf("patch %q", c.SpecPatch())
+	}
+}
+
+func TestSelectHighest(t *testing.T) {
+	got, err := is08.SelectHighest([]string{"v0.9", "v1.0", "v2.0"})
+	if err != nil {
+		t.Fatalf("SelectHighest: %v", err)
+	}
+	if got.APIVer() != "v1.0" {
+		t.Fatalf("got %s", got.APIVer())
+	}
+}
+
+func TestRoundTripViaCodec(t *testing.T) {
+	c := New()
+	in := is08.MapActivationRequest{
+		Activation: is08.Activation{Mode: is08.ActivationModeImmediate},
+		Action:     is08.MapEntries{},
+	}
+	body, err := c.EncodeMapActivationRequest(in)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if _, err := c.DecodeMapActivationRequest(body); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+}

--- a/internal/amwa/codec/is08/validate.go
+++ b/internal/amwa/codec/is08/validate.go
@@ -1,0 +1,323 @@
+package is08
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// ValidateActivation enforces the request-side activation rules.
+//
+//	activate_immediate           — requested_time MUST be null/absent.
+//	activate_scheduled_relative  — requested_time MUST be set, TAI grammar.
+//	activate_scheduled_absolute  — same.
+func ValidateActivation(a Activation) error {
+	if !IsValidActivationMode(a.Mode) {
+		return fmt.Errorf("is08: activation.mode %q: invalid", a.Mode)
+	}
+	switch a.Mode {
+	case ActivationModeImmediate:
+		if a.RequestedTime != nil {
+			return fmt.Errorf("is08: activation.requested_time: must be null for activate_immediate")
+		}
+	case ActivationModeScheduledRelative, ActivationModeScheduledAbsolute:
+		if a.RequestedTime == nil || *a.RequestedTime == "" {
+			return fmt.Errorf("is08: activation.requested_time: required for %s", a.Mode)
+		}
+		if !taiPattern.MatchString(*a.RequestedTime) {
+			return fmt.Errorf("is08: activation.requested_time %q: must match `<sec>:<nsec>` TAI form",
+				*a.RequestedTime)
+		}
+	}
+	return nil
+}
+
+// ValidateActivationResponse enforces the response-side rules — every
+// field nullable + every non-null timestamp must be TAI-valid + mode
+// must be a recognised value when non-nil.
+func ValidateActivationResponse(a ActivationResponse) error {
+	if a.Mode != nil && !IsValidActivationMode(*a.Mode) {
+		return fmt.Errorf("is08: activation.mode %q: invalid", *a.Mode)
+	}
+	if a.RequestedTime != nil && *a.RequestedTime != "" && !taiPattern.MatchString(*a.RequestedTime) {
+		return fmt.Errorf("is08: activation.requested_time %q: must match `<sec>:<nsec>` TAI form",
+			*a.RequestedTime)
+	}
+	if a.ActivationTime != nil && *a.ActivationTime != "" && !taiPattern.MatchString(*a.ActivationTime) {
+		return fmt.Errorf("is08: activation.activation_time %q: must match `<sec>:<nsec>` TAI form",
+			*a.ActivationTime)
+	}
+	return nil
+}
+
+// ValidateMapEntries enforces the patternProperties rules on the
+// outer (output id) and inner (channel index string) keys + the
+// per-entry consistency invariant: input + channel_index are either
+// both nil (unrouted) or both non-nil (routed).
+func ValidateMapEntries(m MapEntries) error {
+	if m == nil {
+		return fmt.Errorf("is08: map: required (may be empty object)")
+	}
+	for outID, channels := range m {
+		if !idPattern.MatchString(outID) {
+			return fmt.Errorf("is08: map: output id %q: must match [a-zA-Z0-9-_]+", outID)
+		}
+		for ch, e := range channels {
+			if !chanPattern.MatchString(ch) {
+				return fmt.Errorf("is08: map[%s]: channel index key %q: must be a non-negative integer",
+					outID, ch)
+			}
+			if _, err := strconv.Atoi(ch); err != nil {
+				return fmt.Errorf("is08: map[%s][%s]: channel index parse: %w", outID, ch, err)
+			}
+			if (e.Input == nil) != (e.ChannelIndex == nil) {
+				return fmt.Errorf("is08: map[%s][%s]: input and channel_index must be both null or both set",
+					outID, ch)
+			}
+			if e.Input != nil && !idPattern.MatchString(*e.Input) {
+				return fmt.Errorf("is08: map[%s][%s].input %q: must match [a-zA-Z0-9-_]+",
+					outID, ch, *e.Input)
+			}
+			if e.ChannelIndex != nil && *e.ChannelIndex < 0 {
+				return fmt.Errorf("is08: map[%s][%s].channel_index %d: must be >= 0",
+					outID, ch, *e.ChannelIndex)
+			}
+		}
+	}
+	return nil
+}
+
+// ValidateMapActive validates a /map/active body — response-shaped
+// activation + map.
+func ValidateMapActive(m MapActive) error {
+	if err := ValidateActivationResponse(m.Activation); err != nil {
+		return err
+	}
+	return ValidateMapEntries(m.Map)
+}
+
+// ValidateMapActivationRequest validates a POST /map/activations body.
+func ValidateMapActivationRequest(r MapActivationRequest) error {
+	if err := ValidateActivation(r.Activation); err != nil {
+		return err
+	}
+	return ValidateMapEntries(r.Action)
+}
+
+// ValidateMapActivationResponse validates a GET /map/activations
+// response entry.
+func ValidateMapActivationResponse(r MapActivationResponse) error {
+	if err := ValidateActivationResponse(r.Activation); err != nil {
+		return err
+	}
+	return ValidateMapEntries(r.Action)
+}
+
+// ValidateInputCaps validates a /inputs/{id}/caps body.
+func ValidateInputCaps(c InputCaps) error {
+	if c.BlockSize < 1 {
+		return fmt.Errorf("is08: input.caps.block_size %d: must be >= 1", c.BlockSize)
+	}
+	return nil
+}
+
+// ValidateOutputCaps validates a /outputs/{id}/caps body. nil is OK
+// (unrestricted); non-nil entries follow the id grammar (with
+// explicit-null permitted).
+func ValidateOutputCaps(c OutputCaps) error {
+	for i, in := range c.RoutableInputs {
+		if in == nil {
+			continue // explicit-null permitted
+		}
+		if !idPattern.MatchString(*in) {
+			return fmt.Errorf("is08: output.caps.routable_inputs[%d] %q: must match [a-zA-Z0-9-_]+",
+				i, *in)
+		}
+	}
+	return nil
+}
+
+// ValidateInputParent validates a /inputs/{id}/parent body.
+func ValidateInputParent(p InputParent) error {
+	// Per spec, both id and type required (response shape) but each
+	// may be null. id pattern only when non-null.
+	if p.ID != nil && *p.ID != "" && !uuidPattern.MatchString(*p.ID) {
+		return fmt.Errorf("is08: input.parent.id %q: not a UUID", *p.ID)
+	}
+	if p.Type != nil {
+		switch *p.Type {
+		case "source", "receiver":
+		default:
+			return fmt.Errorf("is08: input.parent.type %q: must be source/receiver/null", *p.Type)
+		}
+	}
+	return nil
+}
+
+// ValidateChannels validates a /inputs/{id}/channels or
+// /outputs/{id}/channels body — minItems 1, label required.
+func ValidateChannels(cs []Channel) error {
+	if len(cs) < 1 {
+		return fmt.Errorf("is08: channels: must contain at least 1 entry")
+	}
+	for i, c := range cs {
+		if c.Label == "" {
+			return fmt.Errorf("is08: channels[%d].label: required", i)
+		}
+	}
+	return nil
+}
+
+// ValidateInputProperties / OutputProperties validate the shared
+// {name, description} body.
+func ValidateInputProperties(p InputProperties) error {
+	if p.Name == "" {
+		return fmt.Errorf("is08: input.properties.name: required")
+	}
+	if p.Description == "" {
+		return fmt.Errorf("is08: input.properties.description: required")
+	}
+	return nil
+}
+
+// ValidateIO validates a /map/io body — every embedded property
+// section is validated when present; missing sections are allowed
+// (the dedicated per-property endpoints are authoritative).
+func ValidateIO(io IO) error {
+	if io.Inputs == nil {
+		return fmt.Errorf("is08: io.inputs: required (may be empty object)")
+	}
+	if io.Outputs == nil {
+		return fmt.Errorf("is08: io.outputs: required (may be empty object)")
+	}
+	for id, in := range io.Inputs {
+		if !idPattern.MatchString(id) {
+			return fmt.Errorf("is08: io.inputs: id %q: must match [a-zA-Z0-9-_]+", id)
+		}
+		if in.Properties != nil {
+			if err := ValidateInputProperties(*in.Properties); err != nil {
+				return err
+			}
+		}
+		if in.Caps != nil {
+			if err := ValidateInputCaps(*in.Caps); err != nil {
+				return err
+			}
+		}
+		if in.Parent != nil {
+			if err := ValidateInputParent(*in.Parent); err != nil {
+				return err
+			}
+		}
+		if len(in.Channels) > 0 {
+			if err := ValidateChannels(in.Channels); err != nil {
+				return err
+			}
+		}
+	}
+	for id, out := range io.Outputs {
+		if !idPattern.MatchString(id) {
+			return fmt.Errorf("is08: io.outputs: id %q: must match [a-zA-Z0-9-_]+", id)
+		}
+		if out.Properties != nil {
+			if err := ValidateInputProperties(*out.Properties); err != nil {
+				return err
+			}
+		}
+		if out.Caps != nil {
+			if err := ValidateOutputCaps(*out.Caps); err != nil {
+				return err
+			}
+		}
+		if out.SourceID != nil && *out.SourceID != "" && !uuidPattern.MatchString(*out.SourceID) {
+			return fmt.Errorf("is08: io.outputs[%s].source_id %q: not a UUID", id, *out.SourceID)
+		}
+		if len(out.Channels) > 0 {
+			if err := ValidateChannels(out.Channels); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// EncodeMapActive marshals + validates a /map/active body.
+func EncodeMapActive(m MapActive) ([]byte, error) {
+	if err := ValidateMapActive(m); err != nil {
+		return nil, err
+	}
+	return jsonIndent(m)
+}
+
+// DecodeMapActive parses + validates a /map/active body.
+func DecodeMapActive(raw []byte) (MapActive, error) {
+	var m MapActive
+	if err := decodeStrict(raw, &m); err != nil {
+		return MapActive{}, err
+	}
+	if err := ValidateMapActive(m); err != nil {
+		return MapActive{}, err
+	}
+	return m, nil
+}
+
+// EncodeMapActivationRequest marshals + validates a POST
+// /map/activations body.
+func EncodeMapActivationRequest(r MapActivationRequest) ([]byte, error) {
+	if err := ValidateMapActivationRequest(r); err != nil {
+		return nil, err
+	}
+	return jsonIndent(r)
+}
+
+// DecodeMapActivationRequest parses + validates a POST
+// /map/activations body.
+func DecodeMapActivationRequest(raw []byte) (MapActivationRequest, error) {
+	var r MapActivationRequest
+	if err := decodeStrict(raw, &r); err != nil {
+		return MapActivationRequest{}, err
+	}
+	if err := ValidateMapActivationRequest(r); err != nil {
+		return MapActivationRequest{}, err
+	}
+	return r, nil
+}
+
+// EncodeIO marshals + validates a /map/io body.
+func EncodeIO(io IO) ([]byte, error) {
+	if err := ValidateIO(io); err != nil {
+		return nil, err
+	}
+	return jsonIndent(io)
+}
+
+// DecodeIO parses + validates a /map/io body.
+func DecodeIO(raw []byte) (IO, error) {
+	var io IO
+	if err := decodeStrict(raw, &io); err != nil {
+		return IO{}, err
+	}
+	if err := ValidateIO(io); err != nil {
+		return IO{}, err
+	}
+	return io, nil
+}
+
+// decodeStrict is the shared strict decode helper.
+func decodeStrict(raw []byte, dst any) error {
+	d := json.NewDecoder(bytes.NewReader(raw))
+	d.DisallowUnknownFields()
+	if err := d.Decode(dst); err != nil {
+		return fmt.Errorf("is08: decode %T: %w", dst, err)
+	}
+	if d.More() {
+		return fmt.Errorf("is08: decode %T: trailing JSON", dst)
+	}
+	return nil
+}
+
+// jsonIndent is the canonical pretty-printer.
+func jsonIndent(v any) ([]byte, error) {
+	return json.MarshalIndent(v, "", "  ")
+}


### PR DESCRIPTION
## Summary

- IS-08 Audio Channel Mapping codec — single track v1.0.1, follows the locked NMOS-wide pattern.
- Canonical structs (\`MapActive\` / \`MapActivationRequest\` / \`IO\` / \`MapEntries\` etc.) + per-minor Strategy impl in \`is08/v10/\`.
- 24 AMWA JSON schemas bundled at \`testdata/schemas/v1.0.1/\` for audit traceability.
- Resources covered: \`/map/io\`, \`/map/active\`, \`/map/staged\`, \`/map/activations\` (POST + GET), per-input/output \`properties/caps/channels/parent/source_id\`.
- Strict-decode with DisallowUnknownFields, identifier grammar \`[a-zA-Z0-9-_]+\`, channel-index keys must be canonical non-negative integers, TAI \`<sec>:<nsec>\` grammar on every activation timestamp, IS-04 UUID grammar on parent.id and source_id.
- Per-entry consistency invariant enforced: \`map[output][channel].input\` and \`channel_index\` must be both null (unrouted) or both set (routed) — silently inconsistent maps are rejected.
- 16 unit tests covering codec round-trip, validation paths, and rejection cases. Vet + golangci-lint clean.

Plugin layer (Node-side endpoints + Controller-side mapping diff) lands in a follow-up PR; codec is the foundation for both.

Closes #165. Refs #146.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./internal/amwa/codec/is08/...\` — all green
- [x] \`golangci-lint run ./...\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)