### PR TITLE
feat(nmos/is12): codec base + v1.0.1 Strategy impl (Step 8, refs #166)

### DIFF
--- a/cmd/dhs/main.go
+++ b/cmd/dhs/main.go
@@ -72,6 +72,7 @@ import (
 	_ "acp/internal/amwa/codec/is07/v10"
 	_ "acp/internal/amwa/codec/is08/v10"
 	_ "acp/internal/amwa/codec/is09/v10"
+	_ "acp/internal/amwa/codec/is12/v10"
 )
 
 // Build-time variables injected via -ldflags. See Makefile LDFLAGS_FULL.

--- a/internal/amwa/codec/is12/codec.go
+++ b/internal/amwa/codec/is12/codec.go
@@ -1,0 +1,39 @@
+package is12
+
+import (
+	"acp/internal/amwa/codec/spec"
+)
+
+// SpecID is the AMWA NMOS catalogue slug for IS-12 (Control Protocol).
+const SpecID = "is-12"
+
+// Codec is the IS-12 wire codec contract — one implementation per
+// supported wire minor (only v1.0 today).
+type Codec interface {
+	spec.Versioned
+
+	Encode(Message) ([]byte, error)
+	Decode([]byte) (Message, error)
+}
+
+var versions = spec.NewRegistry[Codec]()
+
+// Register installs a codec for one IS-12 wire minor.
+func Register(c Codec) {
+	if c.SpecID() != SpecID {
+		panic("is12.Register: SpecID must be " + SpecID + ", got " + c.SpecID())
+	}
+	versions.Register(c)
+}
+
+func Get(apiVer string) (Codec, bool)             { return versions.Get(apiVer) }
+func AllCodecs() []Codec                          { return versions.AllCodecs() }
+func SupportedVersions() []string                 { return versions.SupportedVersions() }
+func SelectHighest(peer []string) (Codec, error)  { return spec.SelectHighestMutual(versions, peer) }
+func Default() Codec {
+	all := versions.AllCodecs()
+	if len(all) == 0 {
+		panic("is12.Default: no codec registered (forgot to blank-import internal/amwa/codec/is12/vXX?)")
+	}
+	return all[len(all)-1]
+}

--- a/internal/amwa/codec/is12/doc.go
+++ b/internal/amwa/codec/is12/doc.go
@@ -1,0 +1,29 @@
+// Package is12 implements the AMWA NMOS IS-12 Control Protocol
+// codec. Stdlib-only, spec-strict per https://specs.amwa.tv/is-12/.
+//
+// Required versions per `internal/amwa/CLAUDE.md` "Versioning":
+//
+//   - v1.0 (latest patch v1.0.1) — single track. Wire layer is JSON
+//     over WebSocket. The Node serves the IS-12 endpoint at the path
+//     advertised in the IS-04 Device controls array
+//     (`urn:x-nmos:control:ncp/v1.0`); the Controller dials it and
+//     marshals MS-05-02 commands / notifications.
+//
+// Wire envelopes (six messageType discriminators):
+//
+//	0  Command               — controller -> node (method invocation)
+//	1  CommandResponse       — node -> controller (paired by handle)
+//	2  Notification          — node -> controller (subscribed events)
+//	3  Subscription          — controller -> node (oid list)
+//	4  SubscriptionResponse  — node -> controller (accepted oids)
+//	5  Error                 — node -> controller (envelope-level)
+//
+// MS-05-02 datatype + class marshalling lives in the
+// `internal/amwa/codec/ms05/` package (Step 9). is12 is the
+// transport envelope only.
+//
+// This package follows the locked NMOS-wide codec pattern from
+// `internal/amwa/codec/spec/`: canonical Go structs in this package,
+// per-minor Strategy impls in vXX/. cmd/dhs/main.go blank-imports
+// each minor to wire init()-time registration.
+package is12

--- a/internal/amwa/codec/is12/is12_test.go
+++ b/internal/amwa/codec/is12/is12_test.go
@@ -1,0 +1,264 @@
+package is12
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestMessageTypeString(t *testing.T) {
+	cases := map[MessageType]string{
+		MessageTypeCommand:              "Command",
+		MessageTypeCommandResponse:      "CommandResponse",
+		MessageTypeNotification:         "Notification",
+		MessageTypeSubscription:         "Subscription",
+		MessageTypeSubscriptionResponse: "SubscriptionResponse",
+		MessageTypeError:                "Error",
+		MessageType(99):                 "",
+	}
+	for m, want := range cases {
+		if got := m.String(); got != want {
+			t.Errorf("(%d).String() = %q, want %q", int(m), got, want)
+		}
+	}
+}
+
+func TestCommandRoundTrip(t *testing.T) {
+	in := CommandMessage{
+		Commands: []Command{
+			{
+				Handle:    1,
+				OID:       1,
+				MethodID:  MethodID{Level: 1, Index: 5},
+				Arguments: json.RawMessage(`{"propertyId":{"level":1,"index":3}}`),
+			},
+		},
+	}
+	body, err := Encode(in)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	out, err := Decode(body)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	got := out.(CommandMessage)
+	if got.Kind() != MessageTypeCommand {
+		t.Fatalf("kind mismatch")
+	}
+	if got.Commands[0].Handle != 1 {
+		t.Fatalf("handle mismatch")
+	}
+}
+
+func TestCommandResponseRoundTrip(t *testing.T) {
+	in := CommandResponseMessage{
+		Responses: []CommandResponseEntry{
+			{
+				Handle: 1,
+				Result: MethodResult{
+					Status: NcMethodStatusOK,
+					Value:  json.RawMessage(`42`),
+				},
+			},
+		},
+	}
+	body, err := Encode(in)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	out, err := Decode(body)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	got := out.(CommandResponseMessage)
+	if got.Responses[0].Result.Status != 200 {
+		t.Fatalf("status mismatch")
+	}
+}
+
+func TestNotificationRoundTrip(t *testing.T) {
+	idx := 0
+	in := NotificationMessage{
+		Notifications: []Notification{
+			{
+				OID:     1,
+				EventID: EventID{Level: 1, Index: 1},
+				EventData: PropertyChangedEventData{
+					PropertyID:        PropertyID{Level: 1, Index: 3},
+					ChangeType:        0,
+					Value:             json.RawMessage(`"hello"`),
+					SequenceItemIndex: &idx,
+				},
+			},
+		},
+	}
+	body, err := Encode(in)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	out, err := Decode(body)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	got := out.(NotificationMessage)
+	if got.Notifications[0].EventData.SequenceItemIndex == nil ||
+		*got.Notifications[0].EventData.SequenceItemIndex != 0 {
+		t.Fatalf("sequence_item_index mismatch")
+	}
+}
+
+func TestSubscriptionRoundTrip(t *testing.T) {
+	in := SubscriptionMessage{Subscriptions: []int{1, 2, 3}}
+	body, err := Encode(in)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	out, err := Decode(body)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	got := out.(SubscriptionMessage)
+	if len(got.Subscriptions) != 3 {
+		t.Fatalf("subs length mismatch")
+	}
+}
+
+func TestSubscriptionResponseRoundTrip(t *testing.T) {
+	in := SubscriptionResponseMessage{Subscriptions: []int{1, 2}}
+	body, err := Encode(in)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	out, err := Decode(body)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	got := out.(SubscriptionResponseMessage)
+	if got.Kind() != MessageTypeSubscriptionResponse {
+		t.Fatalf("kind mismatch")
+	}
+	if len(got.Subscriptions) != 2 {
+		t.Fatalf("subs length mismatch")
+	}
+}
+
+func TestErrorRoundTrip(t *testing.T) {
+	in := ErrorMessage{Status: 500, ErrorMessage: "boom"}
+	body, err := Encode(in)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	out, err := Decode(body)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	got := out.(ErrorMessage)
+	if got.ErrorMessage != "boom" {
+		t.Fatalf("error message mismatch")
+	}
+}
+
+func TestErrorRequiresMessage(t *testing.T) {
+	in := ErrorMessage{Status: 500}
+	if _, err := Encode(in); err == nil {
+		t.Fatalf("expected required errorMessage")
+	}
+}
+
+func TestDecodeUnknownMessageType(t *testing.T) {
+	body := []byte(`{"messageType":99}`)
+	if _, err := Decode(body); err == nil {
+		t.Fatalf("expected unknown messageType error")
+	}
+}
+
+func TestDecodeMissingMessageType(t *testing.T) {
+	body := []byte(`{}`)
+	if _, err := Decode(body); err == nil {
+		t.Fatalf("expected error on missing messageType")
+	}
+}
+
+func TestDecodeRejectsUnknownField(t *testing.T) {
+	body := []byte(`{"messageType":3,"subscriptions":[],"future_field":42}`)
+	if _, err := Decode(body); err == nil {
+		t.Fatalf("expected DisallowUnknownFields rejection")
+	} else if !strings.Contains(err.Error(), "future_field") {
+		t.Fatalf("error should name unknown field: %v", err)
+	}
+}
+
+func TestCommandHandleRange(t *testing.T) {
+	cases := []struct {
+		name   string
+		handle int
+		ok     bool
+	}{
+		{"too-low", 0, false},
+		{"too-high", 70000, false},
+		{"low", 1, true},
+		{"high", 65535, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := CommandMessage{
+				Commands: []Command{
+					{Handle: tc.handle, OID: 1, MethodID: MethodID{Level: 1, Index: 1}},
+				},
+			}
+			_, err := Encode(in)
+			if tc.ok && err != nil {
+				t.Fatalf("want ok, got %v", err)
+			}
+			if !tc.ok && err == nil {
+				t.Fatalf("want error")
+			}
+		})
+	}
+}
+
+func TestMethodIDValidation(t *testing.T) {
+	in := CommandMessage{
+		Commands: []Command{
+			{Handle: 1, OID: 1, MethodID: MethodID{Level: 0, Index: 1}},
+		},
+	}
+	if _, err := Encode(in); err == nil {
+		t.Fatalf("level 0 should fail")
+	}
+	in.Commands[0].MethodID = MethodID{Level: 1, Index: 0}
+	if _, err := Encode(in); err == nil {
+		t.Fatalf("index 0 should fail")
+	}
+}
+
+func TestCommandRequiresArray(t *testing.T) {
+	in := CommandMessage{}
+	if _, err := Encode(in); err == nil {
+		t.Fatalf("nil commands should fail")
+	}
+}
+
+func TestEncodeNormalisesDiscriminator(t *testing.T) {
+	in := CommandMessage{
+		MessageType: 99, // wrong on input
+		Commands: []Command{
+			{Handle: 1, OID: 1, MethodID: MethodID{Level: 1, Index: 1}},
+		},
+	}
+	body, err := Encode(in)
+	if err == nil {
+		t.Fatalf("expected validate to reject mismatched messageType")
+	}
+	_ = body
+	// With correct (or zero) discriminator, encode normalises to canonical.
+	in.MessageType = 0
+	body, err = Encode(in)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if !strings.Contains(string(body), `"messageType": 0`) {
+		t.Fatalf("encoded body missing canonical messageType: %s", string(body))
+	}
+}

--- a/internal/amwa/codec/is12/messages.go
+++ b/internal/amwa/codec/is12/messages.go
@@ -1,0 +1,154 @@
+package is12
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// Message is the closed sum-type for every IS-12 wire frame. The
+// Kind() method returns the integer discriminator.
+type Message interface {
+	Kind() MessageType
+	validate() error
+}
+
+var (
+	_ Message = CommandMessage{}
+	_ Message = CommandResponseMessage{}
+	_ Message = NotificationMessage{}
+	_ Message = SubscriptionMessage{}
+	_ Message = SubscriptionResponseMessage{}
+	_ Message = ErrorMessage{}
+)
+
+func (CommandMessage) Kind() MessageType              { return MessageTypeCommand }
+func (CommandResponseMessage) Kind() MessageType      { return MessageTypeCommandResponse }
+func (NotificationMessage) Kind() MessageType         { return MessageTypeNotification }
+func (SubscriptionMessage) Kind() MessageType         { return MessageTypeSubscription }
+func (SubscriptionResponseMessage) Kind() MessageType { return MessageTypeSubscriptionResponse }
+func (ErrorMessage) Kind() MessageType                { return MessageTypeError }
+
+// envelope is the minimum-peek struct used by Decode to switch on
+// messageType.
+type envelope struct {
+	MessageType MessageType `json:"messageType"`
+}
+
+// Decode parses any IS-12 wire frame and returns a typed Message.
+// Strict-decode rejects unknown fields per dhs convention.
+func Decode(raw []byte) (Message, error) {
+	var env envelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return nil, fmt.Errorf("is12: peek messageType: %w", err)
+	}
+	if !IsValidMessageType(env.MessageType) {
+		return nil, fmt.Errorf("is12: messageType %d: unknown", env.MessageType)
+	}
+	switch env.MessageType {
+	case MessageTypeCommand:
+		var m CommandMessage
+		if err := decodeStrict(raw, &m); err != nil {
+			return nil, err
+		}
+		if err := m.validate(); err != nil {
+			return nil, err
+		}
+		return m, nil
+	case MessageTypeCommandResponse:
+		var m CommandResponseMessage
+		if err := decodeStrict(raw, &m); err != nil {
+			return nil, err
+		}
+		if err := m.validate(); err != nil {
+			return nil, err
+		}
+		return m, nil
+	case MessageTypeNotification:
+		var m NotificationMessage
+		if err := decodeStrict(raw, &m); err != nil {
+			return nil, err
+		}
+		if err := m.validate(); err != nil {
+			return nil, err
+		}
+		return m, nil
+	case MessageTypeSubscription:
+		var m SubscriptionMessage
+		if err := decodeStrict(raw, &m); err != nil {
+			return nil, err
+		}
+		if err := m.validate(); err != nil {
+			return nil, err
+		}
+		return m, nil
+	case MessageTypeSubscriptionResponse:
+		var m SubscriptionResponseMessage
+		if err := decodeStrict(raw, &m); err != nil {
+			return nil, err
+		}
+		if err := m.validate(); err != nil {
+			return nil, err
+		}
+		return m, nil
+	case MessageTypeError:
+		var m ErrorMessage
+		if err := decodeStrict(raw, &m); err != nil {
+			return nil, err
+		}
+		if err := m.validate(); err != nil {
+			return nil, err
+		}
+		return m, nil
+	}
+	return nil, fmt.Errorf("is12: messageType %d: dispatch fall-through", env.MessageType)
+}
+
+// Encode marshals any Message variant. The discriminator field is
+// normalised to the canonical literal before marshalling so callers
+// cannot accidentally ship a frame with the wrong `messageType`.
+func Encode(m Message) ([]byte, error) {
+	if m == nil {
+		return nil, fmt.Errorf("is12: encode: nil")
+	}
+	if err := m.validate(); err != nil {
+		return nil, err
+	}
+	switch v := m.(type) {
+	case CommandMessage:
+		v.MessageType = MessageTypeCommand
+		return jsonIndent(v)
+	case CommandResponseMessage:
+		v.MessageType = MessageTypeCommandResponse
+		return jsonIndent(v)
+	case NotificationMessage:
+		v.MessageType = MessageTypeNotification
+		return jsonIndent(v)
+	case SubscriptionMessage:
+		v.MessageType = MessageTypeSubscription
+		return jsonIndent(v)
+	case SubscriptionResponseMessage:
+		v.MessageType = MessageTypeSubscriptionResponse
+		return jsonIndent(v)
+	case ErrorMessage:
+		v.MessageType = MessageTypeError
+		return jsonIndent(v)
+	}
+	return nil, fmt.Errorf("is12: encode: unsupported variant %T", m)
+}
+
+func decodeStrict(raw []byte, dst any) error {
+	d := json.NewDecoder(bytes.NewReader(raw))
+	d.DisallowUnknownFields()
+	if err := d.Decode(dst); err != nil {
+		return fmt.Errorf("is12: decode %T: %w", dst, err)
+	}
+	if d.More() {
+		return fmt.Errorf("is12: decode %T: trailing JSON", dst)
+	}
+	return nil
+}
+
+func jsonIndent(v any) ([]byte, error) {
+	return json.MarshalIndent(v, "", "  ")
+}

--- a/internal/amwa/codec/is12/testdata/schemas/v1.0.1/base-message.json
+++ b/internal/amwa/codec/is12/testdata/schemas/v1.0.1/base-message.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Base protocol message structure",
+  "title": "Base protocol message",
+  "required": [
+    "messageType"
+  ],
+  "properties": {
+    "messageType": {
+      "description": "Protocol message type",
+      "type": "integer",
+      "enum": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ]
+    }
+  }
+}

--- a/internal/amwa/codec/is12/testdata/schemas/v1.0.1/command-message.json
+++ b/internal/amwa/codec/is12/testdata/schemas/v1.0.1/command-message.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Command protocol message structure",
+  "title": "Command protocol message",
+  "allOf": [
+    {
+      "$ref": "base-message.json"
+    },
+    {
+      "type": "object",
+      "required": [
+        "commands",
+        "messageType"
+      ],
+      "properties": {
+        "commands": {
+          "description": "Commands being transmited in this transaction",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "handle",
+              "oid",
+              "methodId"
+            ],
+            "properties": {
+              "handle": {
+                "type": "integer",
+                "description": "Integer value used for pairing with the response",
+                "minimum": 1,
+                "maximum": 65535
+              },
+              "oid": {
+                "type": "integer",
+                "description": "Object id containing the method",
+                "minimum": 1
+              },
+              "methodId": {
+                "type": "object",
+                "description": "ID structure for the target method",
+                "required": [
+                  "level",
+                  "index"
+                ],
+                "properties": {
+                  "level": {
+                    "type": "integer",
+                    "description": "Level component of the method ID",
+                    "minimum": 1
+                  },
+                  "index": {
+                    "type": "integer",
+                    "description": "Index component of the method ID",
+                    "minimum": 1
+                  }
+                }
+              },
+              "arguments": {
+                "type": "object",
+                "description": "Method arguments"
+              }
+            }
+          }
+        },
+        "messageType": {
+          "description": "Protocol message type",
+          "type": "integer",
+          "enum": [
+            0
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/internal/amwa/codec/is12/testdata/schemas/v1.0.1/command-response-message.json
+++ b/internal/amwa/codec/is12/testdata/schemas/v1.0.1/command-response-message.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Command response protocol message structure",
+  "title": "Command response protocol message",
+  "allOf": [
+    {
+      "$ref": "base-message.json"
+    },
+    {
+      "type": "object",
+      "required": [
+        "responses",
+        "messageType"
+      ],
+      "properties": {
+        "responses": {
+          "description": "Responses being transmited in this transaction",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "handle",
+              "result"
+            ],
+            "properties": {
+              "handle": {
+                "type": "integer",
+                "description": "Integer value used for pairing with the command",
+                "minimum": 1,
+                "maximum": 65535
+              },
+              "result": {
+                "type": "object",
+                "description": "Response result",
+                "required": [
+                  "status"
+                ],
+                "properties": {
+                  "status": {
+                    "type": "integer",
+                    "description": "Status of the command response. Must include the numeric values for NcMethodStatus or other types which inherit from it. 200 must be returned if the command was successful",
+                    "minimum": 0,
+                    "maximum": 65535
+                  },
+                  "value": {
+                    "type": ["string", "number", "object", "array", "boolean", "null" ],
+                    "description": "Method return value as described in the MS-05-02 Type definition or in a private Type definition"
+                  },
+                  "errorMessage": {
+                    "description": "Error message associated with the failure of the command (optional)",
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "messageType": {
+          "description": "Protocol message type",
+          "type": "integer",
+          "enum": [
+            1
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/internal/amwa/codec/is12/testdata/schemas/v1.0.1/error-message.json
+++ b/internal/amwa/codec/is12/testdata/schemas/v1.0.1/error-message.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Error protocol message structure - used by devices to return general error messages for example when incoming messages do not have messageType, handles or contain invalid JSON",
+  "title": "Error protocol message",
+  "allOf": [
+    {
+      "$ref": "base-message.json"
+    },
+    {
+      "type": "object",
+      "required": [
+        "status",
+        "errorMessage",
+        "messageType"
+      ],
+      "properties": {
+        "status": {
+          "type": "integer",
+          "description": "Status of the message response. Must include the numeric values for NcMethodStatus or other types which inherit from it.",
+          "minimum": 0,
+          "maximum": 65535
+        },
+        "errorMessage": {
+          "description": "Error details associated with the failure",
+          "type": "string"
+        },
+        "messageType": {
+          "description": "Protocol message type",
+          "type": "integer",
+          "enum": [
+            5
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/internal/amwa/codec/is12/testdata/schemas/v1.0.1/event-data.json
+++ b/internal/amwa/codec/is12/testdata/schemas/v1.0.1/event-data.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Event data structure",
+  "title": "Event data",
+  "oneOf": [
+    {
+      "$ref": "property-changed-event-data.json"
+    }
+  ]
+}

--- a/internal/amwa/codec/is12/testdata/schemas/v1.0.1/notification-message.json
+++ b/internal/amwa/codec/is12/testdata/schemas/v1.0.1/notification-message.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Notification protocol message structure",
+  "title": "Notification protocol message",
+  "allOf": [
+    {
+      "$ref": "base-message.json"
+    },
+    {
+      "type": "object",
+      "required": [
+        "notifications",
+        "messageType"
+      ],
+      "properties": {
+        "notifications": {
+          "description": "Notifications being transmited in this transaction",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "oid",
+              "eventId",
+              "eventData"
+            ],
+            "properties": {
+              "oid": {
+                "type": "integer",
+                "description": "Emitter object id",
+                "minimum": 1
+              },
+              "eventId": {
+                "type": "object",
+                "description": "Event ID structure",
+                "required": [
+                  "level",
+                  "index"
+                ],
+                "properties": {
+                  "level": {
+                    "type": "integer",
+                    "description": "Level component of the event ID",
+                    "minimum": 1
+                  },
+                  "index": {
+                    "type": "integer",
+                    "description": "Index component of the event ID",
+                    "minimum": 1
+                  }
+                }
+              },
+              "eventData": {
+                "$ref": "event-data.json"
+              }
+            }
+          }
+        },
+        "messageType": {
+          "description": "Protocol message type",
+          "type": "integer",
+          "enum": [
+            2
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/internal/amwa/codec/is12/testdata/schemas/v1.0.1/property-changed-event-data.json
+++ b/internal/amwa/codec/is12/testdata/schemas/v1.0.1/property-changed-event-data.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Property changed event data structure",
+  "title": "Property changed event data",
+  "properties": {
+    "propertyId": {
+      "type": "object",
+      "description": "Property ID structure",
+      "required": [
+        "level",
+        "index"
+      ],
+      "properties": {
+        "level": {
+          "type": "integer",
+          "description": "Level component of the property ID",
+          "minimum": 1
+        },
+        "index": {
+          "type": "integer",
+          "description": "Index component of the property ID",
+          "minimum": 1
+        }
+      }
+    },
+    "changeType": {
+      "type": "integer",
+      "description": "Event change type numeric value. Must include the numeric values for NcPropertyChangeType",
+      "minimum": 0,
+      "maximum": 65535
+    },
+    "value": {
+      "type": [
+        "string",
+        "number",
+        "object",
+        "array",
+        "boolean",
+        "null"
+      ],
+      "description": "Property value as described in the MS-05-02 Class definition or in a private Class definition"
+    },
+    "sequenceItemIndex": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "description": "Index of sequence item if the property is a sequence"
+    }
+  },
+  "required": [
+    "propertyId",
+    "changeType",
+    "value",
+    "sequenceItemIndex"
+  ]
+}

--- a/internal/amwa/codec/is12/testdata/schemas/v1.0.1/subscription-message.json
+++ b/internal/amwa/codec/is12/testdata/schemas/v1.0.1/subscription-message.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Subscription protocol message structure",
+  "title": "Subscription protocol message",
+  "allOf": [
+    {
+      "$ref": "base-message.json"
+    },
+    {
+      "type": "object",
+      "required": [
+        "subscriptions",
+        "messageType"
+      ],
+      "properties": {
+        "subscriptions": {
+          "description": "Array of OIDs desired for subscription",
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        },
+        "messageType": {
+          "description": "Protocol message type",
+          "type": "integer",
+          "enum": [
+            3
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/internal/amwa/codec/is12/testdata/schemas/v1.0.1/subscription-response-message.json
+++ b/internal/amwa/codec/is12/testdata/schemas/v1.0.1/subscription-response-message.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Subscription response protocol message structure",
+  "title": "Subscription response protocol message",
+  "allOf": [
+    {
+      "$ref": "base-message.json"
+    },
+    {
+      "type": "object",
+      "required": [
+        "subscriptions",
+        "messageType"
+      ],
+      "properties": {
+        "subscriptions": {
+          "description": "Array of OIDs which have successfully been added to the subscription list.",
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        },
+        "messageType": {
+          "description": "Protocol message type",
+          "type": "integer",
+          "enum": [
+            4
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/internal/amwa/codec/is12/types.go
+++ b/internal/amwa/codec/is12/types.go
@@ -1,0 +1,151 @@
+package is12
+
+import (
+	"encoding/json"
+)
+
+// MessageType is the integer discriminator on every IS-12 frame.
+// Spec: APIs/schemas/base-message.json `messageType` enum.
+type MessageType int
+
+// Recognised IS-12 message types per v1.0.1 §5.
+const (
+	MessageTypeCommand              MessageType = 0
+	MessageTypeCommandResponse      MessageType = 1
+	MessageTypeNotification         MessageType = 2
+	MessageTypeSubscription         MessageType = 3
+	MessageTypeSubscriptionResponse MessageType = 4
+	MessageTypeError                MessageType = 5
+)
+
+// IsValidMessageType is true for the six recognised values.
+func IsValidMessageType(m MessageType) bool {
+	return m >= MessageTypeCommand && m <= MessageTypeError
+}
+
+// String returns the human label for diagnostic logs / Info columns.
+// Empty for unrecognised values.
+func (m MessageType) String() string {
+	switch m {
+	case MessageTypeCommand:
+		return "Command"
+	case MessageTypeCommandResponse:
+		return "CommandResponse"
+	case MessageTypeNotification:
+		return "Notification"
+	case MessageTypeSubscription:
+		return "Subscription"
+	case MessageTypeSubscriptionResponse:
+		return "SubscriptionResponse"
+	case MessageTypeError:
+		return "Error"
+	}
+	return ""
+}
+
+// MS-05-02 NcMethodStatus baseline values referenced by the wire
+// codec — full enum lives in the ms05 package. We pin the success
+// value here so transports can short-circuit `result.status == 200`
+// without a cross-package import.
+const NcMethodStatusOK = 200
+
+// MethodID is the {level, index} identifier used to address methods
+// + properties + events on an MS-05-02 class. Both components are
+// 1-based.
+type MethodID struct {
+	Level int `json:"level"`
+	Index int `json:"index"`
+}
+
+// PropertyID is structurally identical to MethodID — separate type
+// to keep call sites self-documenting.
+type PropertyID = MethodID
+
+// EventID is structurally identical to MethodID.
+type EventID = MethodID
+
+// Command is one entry in a Command message's `commands` array.
+type Command struct {
+	Handle    int             `json:"handle"`
+	OID       int             `json:"oid"`
+	MethodID  MethodID        `json:"methodId"`
+	Arguments json.RawMessage `json:"arguments,omitempty"`
+}
+
+// MethodResult is the shape of `responses[*].result` on
+// CommandResponse messages. Status is an MS-05-02 NcMethodStatus
+// (200 for success); Value is the typed return value as raw JSON
+// (callers unmarshal per the called method's return type); ErrorMessage
+// is the optional human-readable error string.
+type MethodResult struct {
+	Status       int             `json:"status"`
+	Value        json.RawMessage `json:"value,omitempty"`
+	ErrorMessage string          `json:"errorMessage,omitempty"`
+}
+
+// CommandResponseEntry is one entry in a CommandResponse message's
+// `responses` array.
+type CommandResponseEntry struct {
+	Handle int          `json:"handle"`
+	Result MethodResult `json:"result"`
+}
+
+// Notification is one entry in a Notification message's
+// `notifications` array.
+type Notification struct {
+	OID       int       `json:"oid"`
+	EventID   EventID   `json:"eventId"`
+	EventData EventData `json:"eventData"`
+}
+
+// EventData is the union body carried in Notification.eventData. The
+// only standardised variant in v1.0.1 is property-changed; the
+// `oneOf` schema means future sub-types layer in transparently.
+type EventData = PropertyChangedEventData
+
+// PropertyChangedEventData carries a property update event from the
+// Node to a subscribed Controller. SequenceItemIndex is non-null
+// only for sequence-typed properties.
+type PropertyChangedEventData struct {
+	PropertyID        PropertyID      `json:"propertyId"`
+	ChangeType        int             `json:"changeType"`
+	Value             json.RawMessage `json:"value"`
+	SequenceItemIndex *int            `json:"sequenceItemIndex"`
+}
+
+// CommandMessage is the body of a messageType=0 frame.
+type CommandMessage struct {
+	MessageType MessageType `json:"messageType"`
+	Commands    []Command   `json:"commands"`
+}
+
+// CommandResponseMessage is the body of a messageType=1 frame.
+type CommandResponseMessage struct {
+	MessageType MessageType            `json:"messageType"`
+	Responses   []CommandResponseEntry `json:"responses"`
+}
+
+// NotificationMessage is the body of a messageType=2 frame.
+type NotificationMessage struct {
+	MessageType   MessageType    `json:"messageType"`
+	Notifications []Notification `json:"notifications"`
+}
+
+// SubscriptionMessage is the body of a messageType=3 frame.
+type SubscriptionMessage struct {
+	MessageType   MessageType `json:"messageType"`
+	Subscriptions []int       `json:"subscriptions"`
+}
+
+// SubscriptionResponseMessage is the body of a messageType=4 frame.
+type SubscriptionResponseMessage struct {
+	MessageType   MessageType `json:"messageType"`
+	Subscriptions []int       `json:"subscriptions"`
+}
+
+// ErrorMessage is the body of a messageType=5 frame.
+type ErrorMessage struct {
+	MessageType  MessageType `json:"messageType"`
+	Status       int         `json:"status"`
+	ErrorMessage string      `json:"errorMessage"`
+}

--- a/internal/amwa/codec/is12/v10/codec.go
+++ b/internal/amwa/codec/is12/v10/codec.go
@@ -1,0 +1,27 @@
+// Package v10 is the AMWA NMOS IS-12 v1.0.1 wire codec — the single
+// track defined by the spec today.
+package v10
+
+import (
+	"acp/internal/amwa/codec/is12"
+)
+
+// SpecPatch — the patch release the codec is audited against.
+const SpecPatch = "v1.0.1"
+
+// Codec implements [is12.Codec] for IS-12 wire minor v1.0.
+type Codec struct{}
+
+// New returns a Codec.
+func New() Codec { return Codec{} }
+
+func (Codec) SpecID() string    { return is12.SpecID }
+func (Codec) APIVer() string    { return "v1.0" }
+func (Codec) SpecPatch() string { return SpecPatch }
+
+func (Codec) Encode(m is12.Message) ([]byte, error)    { return is12.Encode(m) }
+func (Codec) Decode(raw []byte) (is12.Message, error)  { return is12.Decode(raw) }
+
+func init() {
+	is12.Register(Codec{})
+}

--- a/internal/amwa/codec/is12/v10/codec_test.go
+++ b/internal/amwa/codec/is12/v10/codec_test.go
@@ -1,0 +1,45 @@
+package v10
+
+import (
+	"testing"
+
+	"acp/internal/amwa/codec/is12"
+)
+
+func TestRegistration(t *testing.T) {
+	c, ok := is12.Get("v1.0")
+	if !ok {
+		t.Fatalf("is12.Get(v1.0) not found")
+	}
+	if c.SpecID() != is12.SpecID {
+		t.Fatalf("spec id %q", c.SpecID())
+	}
+	if c.APIVer() != "v1.0" {
+		t.Fatalf("api ver %q", c.APIVer())
+	}
+	if c.SpecPatch() != SpecPatch {
+		t.Fatalf("patch %q", c.SpecPatch())
+	}
+}
+
+func TestSelectHighest(t *testing.T) {
+	got, err := is12.SelectHighest([]string{"v0.9", "v1.0"})
+	if err != nil {
+		t.Fatalf("SelectHighest: %v", err)
+	}
+	if got.APIVer() != "v1.0" {
+		t.Fatalf("got %s", got.APIVer())
+	}
+}
+
+func TestRoundTripViaCodec(t *testing.T) {
+	c := New()
+	in := is12.SubscriptionMessage{Subscriptions: []int{1, 2}}
+	body, err := c.Encode(in)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if _, err := c.Decode(body); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+}

--- a/internal/amwa/codec/is12/validate.go
+++ b/internal/amwa/codec/is12/validate.go
@@ -1,0 +1,139 @@
+package is12
+
+import (
+	"fmt"
+)
+
+func validateMethodID(m MethodID) error {
+	if m.Level < 1 {
+		return fmt.Errorf("is12: methodId.level %d: must be >= 1", m.Level)
+	}
+	if m.Index < 1 {
+		return fmt.Errorf("is12: methodId.index %d: must be >= 1", m.Index)
+	}
+	return nil
+}
+
+func validateHandle(h int) error {
+	if h < 1 || h > 65535 {
+		return fmt.Errorf("is12: handle %d: must be in [1, 65535]", h)
+	}
+	return nil
+}
+
+func validateOID(o int) error {
+	if o < 1 {
+		return fmt.Errorf("is12: oid %d: must be >= 1", o)
+	}
+	return nil
+}
+
+func validateStatus(s int) error {
+	if s < 0 || s > 65535 {
+		return fmt.Errorf("is12: status %d: must be in [0, 65535]", s)
+	}
+	return nil
+}
+
+func (m CommandMessage) validate() error {
+	if m.MessageType != 0 && m.MessageType != MessageTypeCommand {
+		return fmt.Errorf("is12: command.messageType %d: must be %d",
+			m.MessageType, MessageTypeCommand)
+	}
+	if m.Commands == nil {
+		return fmt.Errorf("is12: command.commands: required (may be empty array)")
+	}
+	for i, c := range m.Commands {
+		if err := validateHandle(c.Handle); err != nil {
+			return fmt.Errorf("is12: command.commands[%d]: %w", i, err)
+		}
+		if err := validateOID(c.OID); err != nil {
+			return fmt.Errorf("is12: command.commands[%d]: %w", i, err)
+		}
+		if err := validateMethodID(c.MethodID); err != nil {
+			return fmt.Errorf("is12: command.commands[%d]: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func (m CommandResponseMessage) validate() error {
+	if m.MessageType != 0 && m.MessageType != MessageTypeCommandResponse {
+		return fmt.Errorf("is12: response.messageType %d: must be %d",
+			m.MessageType, MessageTypeCommandResponse)
+	}
+	if m.Responses == nil {
+		return fmt.Errorf("is12: response.responses: required (may be empty array)")
+	}
+	for i, r := range m.Responses {
+		if err := validateHandle(r.Handle); err != nil {
+			return fmt.Errorf("is12: response.responses[%d]: %w", i, err)
+		}
+		if err := validateStatus(r.Result.Status); err != nil {
+			return fmt.Errorf("is12: response.responses[%d].result: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func (m NotificationMessage) validate() error {
+	if m.MessageType != 0 && m.MessageType != MessageTypeNotification {
+		return fmt.Errorf("is12: notification.messageType %d: must be %d",
+			m.MessageType, MessageTypeNotification)
+	}
+	if m.Notifications == nil {
+		return fmt.Errorf("is12: notification.notifications: required (may be empty array)")
+	}
+	for i, n := range m.Notifications {
+		if err := validateOID(n.OID); err != nil {
+			return fmt.Errorf("is12: notification.notifications[%d]: %w", i, err)
+		}
+		if err := validateMethodID(n.EventID); err != nil {
+			return fmt.Errorf("is12: notification.notifications[%d].eventId: %w", i, err)
+		}
+		if err := validateMethodID(n.EventData.PropertyID); err != nil {
+			return fmt.Errorf("is12: notification.notifications[%d].eventData.propertyId: %w", i, err)
+		}
+		if n.EventData.ChangeType < 0 || n.EventData.ChangeType > 65535 {
+			return fmt.Errorf("is12: notification.notifications[%d].eventData.changeType %d: must be in [0, 65535]",
+				i, n.EventData.ChangeType)
+		}
+	}
+	return nil
+}
+
+func (m SubscriptionMessage) validate() error {
+	if m.MessageType != 0 && m.MessageType != MessageTypeSubscription {
+		return fmt.Errorf("is12: subscription.messageType %d: must be %d",
+			m.MessageType, MessageTypeSubscription)
+	}
+	if m.Subscriptions == nil {
+		return fmt.Errorf("is12: subscription.subscriptions: required (may be empty array)")
+	}
+	return nil
+}
+
+func (m SubscriptionResponseMessage) validate() error {
+	if m.MessageType != 0 && m.MessageType != MessageTypeSubscriptionResponse {
+		return fmt.Errorf("is12: subscription_response.messageType %d: must be %d",
+			m.MessageType, MessageTypeSubscriptionResponse)
+	}
+	if m.Subscriptions == nil {
+		return fmt.Errorf("is12: subscription_response.subscriptions: required (may be empty array)")
+	}
+	return nil
+}
+
+func (m ErrorMessage) validate() error {
+	if m.MessageType != 0 && m.MessageType != MessageTypeError {
+		return fmt.Errorf("is12: error.messageType %d: must be %d",
+			m.MessageType, MessageTypeError)
+	}
+	if err := validateStatus(m.Status); err != nil {
+		return err
+	}
+	if m.ErrorMessage == "" {
+		return fmt.Errorf("is12: error.errorMessage: required")
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- IS-12 Control Protocol codec — single track v1.0.1, follows the locked NMOS-wide pattern.
- Six wire envelopes covered via integer messageType discriminator (0-5): Command, CommandResponse, Notification, Subscription, SubscriptionResponse, Error.
- 9 AMWA JSON schemas bundled at \`testdata/schemas/v1.0.1/\` for audit traceability.
- Sum-type Message interface with Kind() dispatcher; Decode peeks messageType; Encode normalises canonical discriminator before marshalling.
- MS-05-02 model marshalling lives in \`internal/amwa/codec/ms05/\` (Step 9, next PR). is12 is the transport envelope only.
- Strict-decode with DisallowUnknownFields, handle ∈ [1, 65535], oid >= 1, methodId/eventId components >= 1, status ∈ [0, 65535] enforced.
- 17 unit tests covering each envelope round-trip, polymorphic dispatch, and validation paths. Vet + golangci-lint clean.

WS server + client + CLI verbs land in a follow-up PR. Refs #166.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./internal/amwa/codec/is12/...\` — green
- [x] \`golangci-lint run ./...\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)