### PR TITLE
fix(nmos/is04): subscription field omitempty bug exposed by real-peer Cerebrum test

### DIFF
--- a/internal/amwa/codec/is04/is04_test.go
+++ b/internal/amwa/codec/is04/is04_test.go
@@ -247,7 +247,7 @@ func validSender() Sender {
 		DeviceID:          "3b8be755-08ff-452b-b217-c9151eb21193",
 		ManifestHref:      &href,
 		InterfaceBindings: []string{"eth0"},
-		Subscription:      Subscription{Active: false},
+		Subscription:      SenderSubscription{Active: false},
 	}
 }
 
@@ -292,7 +292,7 @@ func validReceiver() Receiver {
 		InterfaceBindings: []string{"eth0"},
 		Format:            FormatVideo,
 		Caps:              ReceiverCaps{MediaTypes: []string{"video/raw"}},
-		Subscription:      Subscription{Active: false},
+		Subscription:      ReceiverSubscription{Active: false},
 	}
 }
 

--- a/internal/amwa/codec/is04/receiver.go
+++ b/internal/amwa/codec/is04/receiver.go
@@ -16,12 +16,12 @@ import (
 type Receiver struct {
 	ResourceCore
 
-	DeviceID          string         `json:"device_id"`
-	Transport         string         `json:"transport"`
-	InterfaceBindings []string       `json:"interface_bindings"`
-	Format            string         `json:"format"`
-	Caps              ReceiverCaps   `json:"caps"`
-	Subscription      Subscription   `json:"subscription"`
+	DeviceID          string               `json:"device_id"`
+	Transport         string               `json:"transport"`
+	InterfaceBindings []string             `json:"interface_bindings"`
+	Format            string               `json:"format"`
+	Caps              ReceiverCaps         `json:"caps"`
+	Subscription      ReceiverSubscription `json:"subscription"`
 }
 
 // ReceiverCaps mirrors the receiver_*.json `caps` object. v1.3 supports

--- a/internal/amwa/codec/is04/sender.go
+++ b/internal/amwa/codec/is04/sender.go
@@ -12,22 +12,34 @@ import (
 type Sender struct {
 	ResourceCore
 
-	FlowID            *string        `json:"flow_id"` // UUID OR null
-	Transport         string         `json:"transport"`
-	DeviceID          string         `json:"device_id"`
-	ManifestHref      *string        `json:"manifest_href"` // URI OR null
-	InterfaceBindings []string       `json:"interface_bindings"`
-	Caps              map[string]any `json:"caps,omitempty"`
-	Subscription      Subscription   `json:"subscription"`
+	FlowID            *string            `json:"flow_id"` // UUID OR null
+	Transport         string             `json:"transport"`
+	DeviceID          string             `json:"device_id"`
+	ManifestHref      *string            `json:"manifest_href"` // URI OR null
+	InterfaceBindings []string           `json:"interface_bindings"`
+	Caps              map[string]any     `json:"caps,omitempty"`
+	Subscription      SenderSubscription `json:"subscription"`
 }
 
-// Subscription is shared by Sender and Receiver. Sender carries
-// receiver_id (the receiver currently consuming this sender's flow);
-// Receiver carries sender_id. Both also carry `active`.
-type Subscription struct {
-	ReceiverID *string `json:"receiver_id,omitempty"`
-	SenderID   *string `json:"sender_id,omitempty"`
+// SenderSubscription mirrors sender.json `subscription`. Spec
+// (sender.json §required) lists both `receiver_id` and `active` as
+// required; `receiver_id` type is `["string","null"]` so the field
+// MUST be on the wire even when null — hence no `omitempty` on the
+// pointer (Go drops a nil-pointer field tagged `omitempty` entirely).
+//
+// AMWA-approved registries (Cerebrum, etc.) silently compensate for
+// missing receiver_id, but strict IS-04 conformance requires it.
+type SenderSubscription struct {
+	ReceiverID *string `json:"receiver_id"`
 	Active     bool    `json:"active"`
+}
+
+// ReceiverSubscription mirrors receiver_*.json `subscription`. Spec
+// requires both `sender_id` and `active`; `sender_id` type is
+// `["string","null"]` so the field MUST be on the wire when null.
+type ReceiverSubscription struct {
+	SenderID *string `json:"sender_id"`
+	Active   bool    `json:"active"`
 }
 
 // Validate enforces sender.json rules.

--- a/internal/amwa/codec/is04/v11/v11_test.go
+++ b/internal/amwa/codec/is04/v11/v11_test.go
@@ -134,7 +134,7 @@ func TestSenderEncodeStripsV12Fields(t *testing.T) {
 	rid := "22222222-2222-4222-8222-222222222222"
 	s.Caps = map[string]any{"k": "v"}
 	s.InterfaceBindings = []string{"eth0"}
-	s.Subscription = is04.Subscription{ReceiverID: &rid, Active: true}
+	s.Subscription = is04.SenderSubscription{ReceiverID: &rid, Active: true}
 
 	body, err := c.EncodeSender(s)
 	if err != nil {


### PR DESCRIPTION
## Summary

**Real-peer test against EVS Cerebrum (10.100.0.5:8080) surfaced a codec bug** that loopback round-trips couldn't catch.

The shared \`is04.Subscription\` struct used \`*string + omitempty\` on both \`ReceiverID\` and \`SenderID\`. Per IS-04 v1.3 sender.json, \`receiver_id\` is **required** with type \`["string","null"]\` — the field MUST be on the wire even when null. Go's \`json.Marshal\` drops nil-pointer fields tagged \`omitempty\` entirely, so unrouted Senders went out as \`{"active":false}\` instead of \`{"receiver_id":null,"active":false}\`. Spec violation on every Sender / Receiver registration.

Cerebrum silently added the field back with null in its echo — exactly the false-positive round-trip-clean that hides codec bugs. The user pushed back: "no deviation make sure your enc/decoder is not bugged" — turned out to be ours.

## Fix

- Split \`Subscription\` into two distinct types matching the two distinct subschemas:
  - \`SenderSubscription\` — \`{receiver_id, active}\`
  - \`ReceiverSubscription\` — \`{sender_id, active}\`
- Drop \`omitempty\` on the id field so nil-pointer renders as \`null\` (spec-required).
- Update 3 test call sites.

## Verification

\`\`\`
=== dhs Node API after fix ===
"subscription": {"receiver_id":null,"active":false}      ← Sender, was {"active":false}
"subscription": {"sender_id":null,"active":false}        ← Receiver, was {"active":false}

=== Cerebrum Query API after fix ===
"subscription":{"active":false,"receiver_id":null}       ← round-trips clean
"subscription":{"active":false,"sender_id":null}         ← round-trips clean
\`\`\`

Other Cerebrum-side deviations remain (sender.version blanked, flow.sample_rate dropped, sender.subscription.active flipped) — those are NOT codec bugs on our side; our wire bytes match the spec byte-for-byte. Documenting separately as Cerebrum interop notes.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./internal/amwa/...\`
- [x] Live verification: dhs Node registered against EVS Cerebrum 10.100.0.5:8080, both Sender + Receiver subscriptions round-trip correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)