### PR TITLE
chore: rename Go module path acp -> dhs (legacy connector name)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,15 +22,15 @@ linters:
           deny:
             - pkg: github.com
               desc: "codec layer is stdlib-only (lift-to-own-repo ready)"
-            - pkg: acp/cmd
+            - pkg: dhs/cmd
               desc: "codec must not depend on cmd/"
-            - pkg: acp/internal/amwa/session
+            - pkg: dhs/internal/amwa/session
               desc: "codec must not depend on session/ (Layer 1 cannot import Layer 2)"
-            - pkg: acp/internal/amwa/consumer
+            - pkg: dhs/internal/amwa/consumer
               desc: "codec must not depend on consumer/ (Layer 1 cannot import Layer 3)"
-            - pkg: acp/internal/amwa/provider
+            - pkg: dhs/internal/amwa/provider
               desc: "codec must not depend on provider/ (Layer 1 cannot import Layer 3)"
-            - pkg: acp/internal/amwa/registry
+            - pkg: dhs/internal/amwa/registry
               desc: "codec must not depend on registry/ (Layer 1 cannot import Layer 3)"
 
         # Layer 2 — session may import Layer 1 codec + neutral
@@ -40,13 +40,13 @@ linters:
           files:
             - "**/internal/amwa/session/**"
           deny:
-            - pkg: acp/internal/amwa/consumer
+            - pkg: dhs/internal/amwa/consumer
               desc: "session must not import plugin layer (back-arrow)"
-            - pkg: acp/internal/amwa/provider
+            - pkg: dhs/internal/amwa/provider
               desc: "session must not import plugin layer (back-arrow)"
-            - pkg: acp/internal/amwa/registry
+            - pkg: dhs/internal/amwa/registry
               desc: "session must not import plugin layer (back-arrow)"
-            - pkg: acp/cmd
+            - pkg: dhs/cmd
               desc: "session must not import cmd/"
 
         # Layer 3 — plugins may import Layer 2 session + Layer 1 codec
@@ -59,7 +59,7 @@ linters:
             - "**/internal/amwa/provider/**"
             - "**/internal/amwa/registry/**"
           deny:
-            - pkg: acp/cmd
+            - pkg: dhs/cmd
               desc: "plugin layer must not import cmd/"
 
 issues:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,10 @@ Read this file completely before touching any code, then read the atomic
 per-protocol context under `internal/<proto>/CLAUDE.md` for whichever
 protocol you're working on.
 
-> Go module path is `acp` — that's the legacy name and stays put to avoid
-> import churn. The binary, CLI, and product name are **`dhs`** (Device Hub
-> Systems, locked 2026-04-21).
+Go module path, binary, CLI, and product name are all **`dhs`** (Device
+Hub Systems, locked 2026-04-21). The legacy `acp` token only survives where
+it refers to the **ACP1** or **ACP2** wire protocols (`internal/acp1/`,
+`internal/acp2/`, `ACP1Error`, `ACP2Error`, etc.).
 
 ---
 
@@ -247,7 +248,7 @@ explicit sign-off.
    (spec-deviation absorption), `wireshark/` (Lua only). No cross-imports
    between consumer and provider.
 4. **Library independence.** `internal/<proto>/codec/` is stdlib-only
-   and lift-to-own-repo ready. Codec never imports `acp/*`.
+   and lift-to-own-repo ready. Codec never imports `dhs/*`.
 5. **No hidden state.** No package-level mutable vars outside the
    compile-time registries; cross-cutting concerns thread through
    constructors or `context.Context`.
@@ -325,7 +326,7 @@ See [feedback_wireshark_fully_implemented] in memory.
 ## Error hierarchy
 
 ```
-ACPError (base)
+DHSError (base)
 ├── TransportError
 │   ├── ConnectionRefusedError
 │   ├── ConnectionLostError
@@ -398,7 +399,7 @@ for the same object, the announcement wins.
 - Command files per-protocol follow `cmd_rxNNN_xxx.go` / `cmd_txNNN_xxx.go`
   where NNN is the decimal command byte, zero-padded to 3 digits.
 - Codec packages under `internal/<proto>/codec/` are stdlib-only — they
-  must not import `acp/*`. They should be lift-to-own-repo ready.
+  must not import `dhs/*`. They should be lift-to-own-repo ready.
 
 ### Testing
 
@@ -480,7 +481,7 @@ See `feedback_amwa_strict_all_versions` in memory.
 - Never add Redis, PostgreSQL, or any external data store.
 - Never skip `AN2 EnableProtocolEvents` before expecting ACP2 announces.
 - Never reuse a live mtid for a new ACP2 request.
-- Never import `acp/*` from `internal/<proto>/codec/` packages.
+- Never import `dhs/*` from `internal/<proto>/codec/` packages.
 - Never assume a matrix is small — every plugin must cope with 65535×65535
   per matrix and 100 matrices per fleet; use sparse maps, stream decoders,
   and extended wire forms unconditionally.
@@ -508,8 +509,8 @@ See `feedback_amwa_strict_all_versions` in memory.
    Use `Proto("dhs_<name>", ...)` and `dhs_<name>.<field>` abbrevs throughout
    to avoid namespace clashes with Wireshark built-ins. See
    "Wireshark dissectors" above.
-6. Add `import _ "acp/internal/<name>/consumer"` and
-   `import _ "acp/internal/<name>/provider"` to `cmd/dhs/main.go`.
+6. Add `import _ "dhs/internal/<name>/consumer"` and
+   `import _ "dhs/internal/<name>/provider"` to `cmd/dhs/main.go`.
 7. Unit tests live inside the package (`internal/<name>/*/*_test.go`).
 8. Done — `dhs consumer <name> <verb>` and `dhs producer <name> serve`
    pick it up automatically via the registries.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ One binary covers both directions:
 | `dhs consumer <proto> <verb> ...` | Outbound — query / control device |
 | `dhs producer <proto> serve ...`  | Inbound  — serve a canonical tree |
 
-> Go module path is `acp` (legacy, kept to avoid import churn). Binary and
-> CLI are `dhs`.
+> Go module path, binary, and CLI are all `dhs`. The `acp` token only
+> survives where it refers to the **ACP1** / **ACP2** wire protocols
+> (`internal/acp1/`, `internal/acp2/`, `ACP1Error`, `ACP2Error`, etc.).
 
 ---
 

--- a/agents.md
+++ b/agents.md
@@ -7,8 +7,10 @@ Shared session rules for AI agents working on this project. Read alongside:
 - `internal/<proto>/CLAUDE.md` — atomic per-protocol wire-format context
   (one file per protocol).
 
-The Go module path is `acp` (legacy, kept to avoid churn). The binary,
-CLI, and product name are **`dhs`** (Device Hub Systems, locked 2026-04-21).
+Go module path, binary, CLI, and product name are all **`dhs`** (Device
+Hub Systems, locked 2026-04-21). The legacy `acp` token only survives
+where it refers to the **ACP1** or **ACP2** wire protocols
+(`internal/acp1/`, `internal/acp2/`, `ACP1Error`, `ACP2Error`, etc.).
 
 ---
 

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -13,9 +13,9 @@ import (
 	"sync"
 	"time"
 
-	"acp/internal/cerebrum-nb/codec"
-	"acp/internal/cerebrum-nb/codec/ws"
-	cerebrum "acp/internal/cerebrum-nb/consumer"
+	"dhs/internal/cerebrum-nb/codec"
+	"dhs/internal/cerebrum-nb/codec/ws"
+	cerebrum "dhs/internal/cerebrum-nb/consumer"
 )
 
 // cerebrumFlags is the common flag set for every dhs consumer cerebrum-nb

--- a/cmd/dhs/cmd_convert.go
+++ b/cmd/dhs/cmd_convert.go
@@ -14,7 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"acp/internal/export"
+	"dhs/internal/export"
 )
 
 func runConvert(_ context.Context, args []string) error {

--- a/cmd/dhs/cmd_diag.go
+++ b/cmd/dhs/cmd_diag.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	"acp/internal/acp2/consumer"
+	"dhs/internal/acp2/consumer"
 )
 
 func runDiag(ctx context.Context, args []string) error {

--- a/cmd/dhs/cmd_diff.go
+++ b/cmd/dhs/cmd_diff.go
@@ -10,8 +10,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"acp/internal/diff"
-	"acp/internal/export/canonical"
+	"dhs/internal/diff"
+	"dhs/internal/export/canonical"
 )
 
 // runDiff drives `acp diff <before> <after>` — issue #49. Compares two

--- a/cmd/dhs/cmd_discover.go
+++ b/cmd/dhs/cmd_discover.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"acp/internal/acp1/consumer"
+	"dhs/internal/acp1/consumer"
 )
 
 // runDiscover runs a one-shot LAN scan for ACP1 devices. Works only

--- a/cmd/dhs/cmd_export.go
+++ b/cmd/dhs/cmd_export.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"acp/internal/export"
-	"acp/internal/protocol"
+	"dhs/internal/export"
+	"dhs/internal/protocol"
 )
 
 // runExport walks every present slot on the device and writes the

--- a/cmd/dhs/cmd_get.go
+++ b/cmd/dhs/cmd_get.go
@@ -6,7 +6,7 @@ import (
 	"flag"
 	"fmt"
 
-	"acp/internal/protocol"
+	"dhs/internal/protocol"
 )
 
 func runGet(ctx context.Context, args []string) error {

--- a/cmd/dhs/cmd_import.go
+++ b/cmd/dhs/cmd_import.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"acp/internal/export"
+	"dhs/internal/export"
 )
 
 // multiInt and multiString let --id / --label / --path repeat on the

--- a/cmd/dhs/cmd_invoke.go
+++ b/cmd/dhs/cmd_invoke.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	emberplus "acp/internal/emberplus/consumer"
+	emberplus "dhs/internal/emberplus/consumer"
 )
 
 func runInvoke(ctx context.Context, args []string) error {

--- a/cmd/dhs/cmd_list.go
+++ b/cmd/dhs/cmd_list.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"acp/internal/protocol"
+	"dhs/internal/protocol"
 )
 
 func runListProtocols() error {

--- a/cmd/dhs/cmd_list_commands.go
+++ b/cmd/dhs/cmd_list_commands.go
@@ -8,11 +8,11 @@ import (
 	"sort"
 	"strings"
 
-	acp1 "acp/internal/acp1/consumer"
-	acp2 "acp/internal/acp2/consumer"
-	emberplus "acp/internal/emberplus/consumer"
-	codecsw02 "acp/internal/probel-sw02p/codec"
-	codecsw08 "acp/internal/probel-sw08p/codec"
+	acp1 "dhs/internal/acp1/consumer"
+	acp2 "dhs/internal/acp2/consumer"
+	emberplus "dhs/internal/emberplus/consumer"
+	codecsw02 "dhs/internal/probel-sw02p/codec"
+	codecsw08 "dhs/internal/probel-sw08p/codec"
 )
 
 // catalogueRow is the rendered shape used by `dhs list-commands` —

--- a/cmd/dhs/cmd_matrix.go
+++ b/cmd/dhs/cmd_matrix.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	emberplus "acp/internal/emberplus/consumer"
+	emberplus "dhs/internal/emberplus/consumer"
 )
 
 func runMatrix(ctx context.Context, args []string) error {

--- a/cmd/dhs/cmd_metrics.go
+++ b/cmd/dhs/cmd_metrics.go
@@ -19,7 +19,7 @@ import (
 	"os"
 	"time"
 
-	"acp/internal/metrics"
+	"dhs/internal/metrics"
 )
 
 func runMetrics(ctx context.Context, args []string) error {

--- a/cmd/dhs/cmd_nmos.go
+++ b/cmd/dhs/cmd_nmos.go
@@ -22,13 +22,13 @@ import (
 	"strings"
 	"time"
 
-	codec "acp/internal/amwa/codec/dnssd"
-	"acp/internal/amwa/codec/is09"
-	"acp/internal/amwa/codec/spec"
-	"acp/internal/amwa/consumer"
-	"acp/internal/amwa/provider"
-	session "acp/internal/amwa/session/dnssd"
-	registryslot "acp/internal/registry"
+	codec "dhs/internal/amwa/codec/dnssd"
+	"dhs/internal/amwa/codec/is09"
+	"dhs/internal/amwa/codec/spec"
+	"dhs/internal/amwa/consumer"
+	"dhs/internal/amwa/provider"
+	session "dhs/internal/amwa/session/dnssd"
+	registryslot "dhs/internal/registry"
 )
 
 // runNMOSConsumer dispatches `dhs consumer nmos <verb> [args]`.

--- a/cmd/dhs/cmd_nmos_events.go
+++ b/cmd/dhs/cmd_nmos_events.go
@@ -16,8 +16,8 @@ import (
 	"strings"
 	"time"
 
-	"acp/internal/amwa/codec/is07"
-	"acp/internal/amwa/session/events"
+	"dhs/internal/amwa/codec/is07"
+	"dhs/internal/amwa/session/events"
 )
 
 // runNMOSEventsConsumer dispatches `dhs consumer nmos events <verb>`.

--- a/cmd/dhs/cmd_osc.go
+++ b/cmd/dhs/cmd_osc.go
@@ -30,9 +30,9 @@ import (
 	"strings"
 	"time"
 
-	"acp/internal/osc/codec"
-	osccons "acp/internal/osc/consumer"
-	oscprov "acp/internal/osc/provider"
+	"dhs/internal/osc/codec"
+	osccons "dhs/internal/osc/consumer"
+	oscprov "dhs/internal/osc/provider"
 )
 
 // runOSCConsumer dispatches `dhs consumer osc-vXX <verb> [args]`.

--- a/cmd/dhs/cmd_probel.go
+++ b/cmd/dhs/cmd_probel.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"time"
 
-	"acp/internal/probel-sw08p/codec"
-	probelproto "acp/internal/probel-sw08p/consumer"
-	"acp/internal/transport"
+	"dhs/internal/probel-sw08p/codec"
+	probelproto "dhs/internal/probel-sw08p/consumer"
+	"dhs/internal/transport"
 )
 
 // runProbel dispatches `dhs consumer probel-sw08p <subcommand>` — the Probel SW-P-08

--- a/cmd/dhs/cmd_probel02p.go
+++ b/cmd/dhs/cmd_probel02p.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"time"
 
-	codec02 "acp/internal/probel-sw02p/codec"
-	probelsw02proto "acp/internal/probel-sw02p/consumer"
-	"acp/internal/transport"
+	codec02 "dhs/internal/probel-sw02p/codec"
+	probelsw02proto "dhs/internal/probel-sw02p/consumer"
+	"dhs/internal/transport"
 )
 
 // runProbelsw02p dispatches `dhs consumer probel-sw02p <subcommand>`.

--- a/cmd/dhs/cmd_probel_names.go
+++ b/cmd/dhs/cmd_probel_names.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // parseNameLen maps the --size flag (4 | 8 | 12 | 16) into the

--- a/cmd/dhs/cmd_probel_salvo.go
+++ b/cmd/dhs/cmd_probel_salvo.go
@@ -23,7 +23,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 func runProbelSalvoConnect(ctx context.Context, args []string) error {

--- a/cmd/dhs/cmd_producer.go
+++ b/cmd/dhs/cmd_producer.go
@@ -17,12 +17,12 @@ import (
 	"syscall"
 	"time"
 
-	"acp/internal/export/canonical"
-	"acp/internal/metrics"
-	"acp/internal/provider"
+	"dhs/internal/export/canonical"
+	"dhs/internal/metrics"
+	"dhs/internal/provider"
 
-	acp1provider "acp/internal/acp1/provider"
-	acp2provider "acp/internal/acp2/provider"
+	acp1provider "dhs/internal/acp1/provider"
+	acp2provider "dhs/internal/acp2/provider"
 )
 
 // metricsExposer is the optional interface provider servers implement

--- a/cmd/dhs/cmd_profile.go
+++ b/cmd/dhs/cmd_profile.go
@@ -13,11 +13,11 @@ import (
 	"fmt"
 	"sort"
 
-	"acp/internal/protocol"
-	"acp/internal/acp1/consumer"
-	"acp/internal/acp2/consumer"
-	"acp/internal/protocol/compliance"
-	emberplus "acp/internal/emberplus/consumer"
+	"dhs/internal/protocol"
+	"dhs/internal/acp1/consumer"
+	"dhs/internal/acp2/consumer"
+	"dhs/internal/protocol/compliance"
+	emberplus "dhs/internal/emberplus/consumer"
 )
 
 // pluginProfile returns the compliance profile attached to the given

--- a/cmd/dhs/cmd_set.go
+++ b/cmd/dhs/cmd_set.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	"acp/internal/protocol"
+	"dhs/internal/protocol"
 )
 
 func runSet(ctx context.Context, args []string) error {

--- a/cmd/dhs/cmd_stream.go
+++ b/cmd/dhs/cmd_stream.go
@@ -15,8 +15,8 @@ import (
 	"fmt"
 	"os"
 
-	"acp/internal/protocol"
-	emberplus "acp/internal/emberplus/consumer"
+	"dhs/internal/protocol"
+	emberplus "dhs/internal/emberplus/consumer"
 )
 
 func runStream(ctx context.Context, args []string) error {

--- a/cmd/dhs/cmd_tsl.go
+++ b/cmd/dhs/cmd_tsl.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	tslconsumer "acp/internal/tsl/consumer"
+	tslconsumer "dhs/internal/tsl/consumer"
 )
 
 // runTSLConsumer dispatches `dhs consumer <tsl-vXX> <verb> [args]`.

--- a/cmd/dhs/cmd_tsl_producer.go
+++ b/cmd/dhs/cmd_tsl_producer.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"time"
 
-	"acp/internal/tsl/codec"
-	tslprov "acp/internal/tsl/provider"
+	"dhs/internal/tsl/codec"
+	tslprov "dhs/internal/tsl/provider"
 )
 
 // runTSLProducer dispatches `dhs producer <tsl-vXX> <verb> [args]`.

--- a/cmd/dhs/cmd_walk.go
+++ b/cmd/dhs/cmd_walk.go
@@ -9,11 +9,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"acp/internal/export"
-	"acp/internal/protocol"
-	"acp/internal/acp1/consumer"
-	"acp/internal/acp2/consumer"
-	"acp/internal/emberplus/consumer"
+	"dhs/internal/export"
+	"dhs/internal/protocol"
+	"dhs/internal/acp1/consumer"
+	"dhs/internal/acp2/consumer"
+	"dhs/internal/emberplus/consumer"
 )
 
 func runWalk(ctx context.Context, args []string) error {

--- a/cmd/dhs/cmd_watch.go
+++ b/cmd/dhs/cmd_watch.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"acp/internal/protocol"
+	"dhs/internal/protocol"
 )
 
 // runWatch subscribes to live announcements and prints each event as it

--- a/cmd/dhs/common.go
+++ b/cmd/dhs/common.go
@@ -9,11 +9,11 @@ import (
 	"strings"
 	"time"
 
-	"acp/internal/logging"
-	"acp/internal/protocol"
-	"acp/internal/acp1/consumer"
-	"acp/internal/storage"
-	"acp/internal/transport"
+	"dhs/internal/logging"
+	"dhs/internal/protocol"
+	"dhs/internal/acp1/consumer"
+	"dhs/internal/storage"
+	"dhs/internal/transport"
 )
 
 // treeStore is the global file-backed tree store, initialized once.

--- a/cmd/dhs/format.go
+++ b/cmd/dhs/format.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strings"
 
-	"acp/internal/protocol"
+	"dhs/internal/protocol"
 )
 
 // sectionHeader returns the container-path string under which an

--- a/cmd/dhs/main.go
+++ b/cmd/dhs/main.go
@@ -34,29 +34,29 @@ import (
 	"os"
 	"os/signal"
 
-	"acp/internal/protocol"
+	"dhs/internal/protocol"
 
 	// Consumer plugins — blank imports register with internal/protocol.
-	_ "acp/internal/acp1/consumer"
-	_ "acp/internal/acp2/consumer"
-	_ "acp/internal/cerebrum-nb/consumer"
-	_ "acp/internal/emberplus/consumer"
-	_ "acp/internal/osc/consumer"
-	_ "acp/internal/probel-sw02p/consumer"
-	_ "acp/internal/probel-sw08p/consumer"
-	_ "acp/internal/tsl/consumer"
+	_ "dhs/internal/acp1/consumer"
+	_ "dhs/internal/acp2/consumer"
+	_ "dhs/internal/cerebrum-nb/consumer"
+	_ "dhs/internal/emberplus/consumer"
+	_ "dhs/internal/osc/consumer"
+	_ "dhs/internal/probel-sw02p/consumer"
+	_ "dhs/internal/probel-sw08p/consumer"
+	_ "dhs/internal/tsl/consumer"
 
 	// Provider plugins — blank imports register with internal/provider.
-	_ "acp/internal/acp1/provider"
-	_ "acp/internal/acp2/provider"
-	_ "acp/internal/emberplus/provider"
-	_ "acp/internal/osc/provider"
-	_ "acp/internal/probel-sw02p/provider"
-	_ "acp/internal/probel-sw08p/provider"
-	_ "acp/internal/tsl/provider"
+	_ "dhs/internal/acp1/provider"
+	_ "dhs/internal/acp2/provider"
+	_ "dhs/internal/emberplus/provider"
+	_ "dhs/internal/osc/provider"
+	_ "dhs/internal/probel-sw02p/provider"
+	_ "dhs/internal/probel-sw08p/provider"
+	_ "dhs/internal/tsl/provider"
 
 	// Registry plugins — blank imports register with internal/registry.
-	_ "acp/internal/amwa/registry"
+	_ "dhs/internal/amwa/registry"
 
 	// NMOS codec versions — blank imports trigger init()-time
 	// registration with the per-spec spec.Registry[T]. Each minor
@@ -64,29 +64,29 @@ import (
 	// references the concrete vXX/ packages directly. Plugin code
 	// (Layer 3) goes through the host spec's Codec interface only,
 	// per `internal/amwa/docs/dependencies.md` forbidden edges.
-	_ "acp/internal/amwa/codec/is04/v10"
-	_ "acp/internal/amwa/codec/is04/v11"
-	_ "acp/internal/amwa/codec/is04/v12"
-	_ "acp/internal/amwa/codec/is04/v13"
-	_ "acp/internal/amwa/codec/is05/v10"
-	_ "acp/internal/amwa/codec/is05/v11"
-	_ "acp/internal/amwa/codec/is07/v10"
-	_ "acp/internal/amwa/codec/is08/v10"
-	_ "acp/internal/amwa/codec/is09/v10"
-	_ "acp/internal/amwa/codec/is12/v10"
-	_ "acp/internal/amwa/codec/ms05/v10"
+	_ "dhs/internal/amwa/codec/is04/v10"
+	_ "dhs/internal/amwa/codec/is04/v11"
+	_ "dhs/internal/amwa/codec/is04/v12"
+	_ "dhs/internal/amwa/codec/is04/v13"
+	_ "dhs/internal/amwa/codec/is05/v10"
+	_ "dhs/internal/amwa/codec/is05/v11"
+	_ "dhs/internal/amwa/codec/is07/v10"
+	_ "dhs/internal/amwa/codec/is08/v10"
+	_ "dhs/internal/amwa/codec/is09/v10"
+	_ "dhs/internal/amwa/codec/is12/v10"
+	_ "dhs/internal/amwa/codec/ms05/v10"
 
 	// BCP validator packages — register into the shared bcp registry
 	// at init() time so the host-resource fanout in
 	// `internal/amwa/codec/bcp/Run` sees them.
-	_ "acp/internal/amwa/codec/bcp/bcp00201"
-	_ "acp/internal/amwa/codec/bcp/bcp00202"
-	_ "acp/internal/amwa/codec/bcp/bcp00401"
-	_ "acp/internal/amwa/codec/bcp/bcp00402"
-	_ "acp/internal/amwa/codec/bcp/bcp00601"
-	_ "acp/internal/amwa/codec/bcp/bcp00604"
-	_ "acp/internal/amwa/codec/bcp/bcp00801"
-	_ "acp/internal/amwa/codec/bcp/bcp00802"
+	_ "dhs/internal/amwa/codec/bcp/bcp00201"
+	_ "dhs/internal/amwa/codec/bcp/bcp00202"
+	_ "dhs/internal/amwa/codec/bcp/bcp00401"
+	_ "dhs/internal/amwa/codec/bcp/bcp00402"
+	_ "dhs/internal/amwa/codec/bcp/bcp00601"
+	_ "dhs/internal/amwa/codec/bcp/bcp00604"
+	_ "dhs/internal/amwa/codec/bcp/bcp00801"
+	_ "dhs/internal/amwa/codec/bcp/bcp00802"
 )
 
 // Build-time variables injected via -ldflags. See Makefile LDFLAGS_FULL.

--- a/cmd/dhs/route_test.go
+++ b/cmd/dhs/route_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"acp/internal/cerebrum-nb/codec"
+	"dhs/internal/cerebrum-nb/codec"
 )
 
 // TestRouteActionEncoding verifies the wire emitted by the route verb

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,8 +33,8 @@ Compile-time registration via `init()`. Each protocol package calls
 main files import the protocol packages as blank imports:
 
 ```go
-import _ "acp/internal/protocol/acp1"
-import _ "acp/internal/protocol/acp2"
+import _ "dhs/internal/protocol/acp1"
+import _ "dhs/internal/protocol/acp2"
 ```
 
 No runtime plugin loading. No external config. Adding a protocol means
@@ -51,8 +51,8 @@ adding one import line.
 
 | Binary    | Purpose                              |
 |-----------|--------------------------------------|
-| `acp`     | CLI -- direct device I/O, no server  |
-| `acp-srv` | HTTP REST + WebSocket API            |
+| `dhs`     | CLI -- direct device I/O, no server  |
+| `dhs-srv` | HTTP REST + WebSocket API            |
 
 Both share `internal/`. Neither imports the other.
 

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -398,9 +398,9 @@ From the conversation, not yet decided:
 
 ---
 
-## 13. Relationship to `acp` today
+## 13. Relationship to `dhs` today
 
-This vision is **a destination**. `acp` today is **Part A-complete**: three consumer plugins (ACP1, ACP2, Ember+) emitting canonical trees, with a compliance profile, offline CSV round-trip, and a CLI.
+This vision is **a destination**. `dhs` today is **Part A-complete**: three consumer plugins (ACP1, ACP2, Ember+) emitting canonical trees, with a compliance profile, offline CSV round-trip, and a CLI.
 
 Parts that already exist in some form:
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module acp
+module dhs
 
 go 1.23.0
 

--- a/internal/acp1/consumer/browser.go
+++ b/internal/acp1/consumer/browser.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"acp/internal/protocol"
-	"acp/internal/protocol/compliance"
+	"dhs/internal/protocol"
+	"dhs/internal/protocol/compliance"
 )
 
 // walkerClient is the minimum contract the Walker needs from whatever

--- a/internal/acp1/consumer/browser_test.go
+++ b/internal/acp1/consumer/browser_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/protocol"
+	"dhs/internal/protocol"
 )
 
 // TestWalker_HappyPath runs a full slot walk against a canned sequence of

--- a/internal/acp1/consumer/cache.go
+++ b/internal/acp1/consumer/cache.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"acp/internal/protocol"
+	"dhs/internal/protocol"
 )
 
 // slotTreeCache is a bounded LRU + TTL cache for walked SlotTree

--- a/internal/acp1/consumer/canonicalize.go
+++ b/internal/acp1/consumer/canonicalize.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	"acp/internal/export/canonical"
-	"acp/internal/protocol"
+	"dhs/internal/export/canonical"
+	"dhs/internal/protocol"
 )
 
 // Canonicalize walks every cached SlotTree on this plugin and emits

--- a/internal/acp1/consumer/canonicalize_test.go
+++ b/internal/acp1/consumer/canonicalize_test.go
@@ -5,8 +5,8 @@ import (
 	"container/list"
 	"testing"
 
-	"acp/internal/export/canonical"
-	"acp/internal/protocol"
+	"dhs/internal/export/canonical"
+	"dhs/internal/protocol"
 )
 
 // TestCanonicalize_Empty covers the fresh-Plugin case: no Connect,

--- a/internal/acp1/consumer/discover.go
+++ b/internal/acp1/consumer/discover.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 	"time"
 
-	"acp/internal/transport"
+	"dhs/internal/transport"
 )
 
 // DiscoverResult is one device seen during a discovery run.

--- a/internal/acp1/consumer/listener.go
+++ b/internal/acp1/consumer/listener.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"acp/internal/transport"
+	"dhs/internal/transport"
 )
 
 // Listener receives ACP1 announcements broadcast by rack controllers on

--- a/internal/acp1/consumer/message_spec_test.go
+++ b/internal/acp1/consumer/message_spec_test.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"testing"
 
-	"acp/internal/acp1/consumer"
+	"dhs/internal/acp1/consumer"
 )
 
 func TestSpec_EncodeGetFrameStatus(t *testing.T) {

--- a/internal/acp1/consumer/plugin.go
+++ b/internal/acp1/consumer/plugin.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
-	"acp/internal/protocol"
-	"acp/internal/protocol/compliance"
-	"acp/internal/transport"
+	"dhs/internal/protocol"
+	"dhs/internal/protocol/compliance"
+	"dhs/internal/transport"
 )
 
 // init registers the ACP1 plugin with the global protocol registry.

--- a/internal/acp1/consumer/property_spec_test.go
+++ b/internal/acp1/consumer/property_spec_test.go
@@ -5,7 +5,7 @@ package acp1_test
 import (
 	"testing"
 
-	"acp/internal/acp1/consumer"
+	"dhs/internal/acp1/consumer"
 )
 
 func TestSpec_DecodeRoot(t *testing.T) {

--- a/internal/acp1/consumer/replay_test.go
+++ b/internal/acp1/consumer/replay_test.go
@@ -12,7 +12,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"acp/internal/acp1/consumer"
+	"dhs/internal/acp1/consumer"
 )
 
 type captureRecord struct {

--- a/internal/acp1/consumer/tcp_client.go
+++ b/internal/acp1/consumer/tcp_client.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"acp/internal/transport"
+	"dhs/internal/transport"
 )
 
 // TCPClient is the ACP1 session layer for TCP direct mode (spec v1.4

--- a/internal/acp1/consumer/value_codec.go
+++ b/internal/acp1/consumer/value_codec.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"acp/internal/protocol"
+	"dhs/internal/protocol"
 )
 
 // ValueCodec encodes and decodes the "value bytes" that ACP1 getValue and

--- a/internal/acp1/provider/demo.go
+++ b/internal/acp1/provider/demo.go
@@ -7,7 +7,7 @@ import (
 	"math"
 	"time"
 
-	iacp1 "acp/internal/acp1/consumer"
+	iacp1 "dhs/internal/acp1/consumer"
 )
 
 // RunAnnounceDemo oscillates the integer value at (slot, group, id)

--- a/internal/acp1/provider/encoder.go
+++ b/internal/acp1/provider/encoder.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"strings"
 
-	"acp/internal/export/canonical"
-	iacp1 "acp/internal/acp1/consumer"
+	"dhs/internal/export/canonical"
+	iacp1 "dhs/internal/acp1/consumer"
 )
 
 // encodeObject builds the Value bytes returned by a getObject reply

--- a/internal/acp1/provider/encoder_test.go
+++ b/internal/acp1/provider/encoder_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"acp/internal/export/canonical"
-	iacp1 "acp/internal/acp1/consumer"
+	"dhs/internal/export/canonical"
+	iacp1 "dhs/internal/acp1/consumer"
 )
 
 // TestEncodeDecodeRoundTrip asserts that every object type produced by

--- a/internal/acp1/provider/plugin.go
+++ b/internal/acp1/provider/plugin.go
@@ -20,9 +20,9 @@ package acp1
 import (
 	"log/slog"
 
-	"acp/internal/export/canonical"
-	"acp/internal/provider"
-	iacp1 "acp/internal/acp1/consumer"
+	"dhs/internal/export/canonical"
+	"dhs/internal/provider"
+	iacp1 "dhs/internal/acp1/consumer"
 )
 
 // DefaultPort is the IANA-assigned ACP port for both UDP and TCP direct.

--- a/internal/acp1/provider/server.go
+++ b/internal/acp1/provider/server.go
@@ -8,8 +8,8 @@ import (
 	"net"
 	"sync"
 
-	"acp/internal/export/canonical"
-	iacp1 "acp/internal/acp1/consumer"
+	"dhs/internal/export/canonical"
+	iacp1 "dhs/internal/acp1/consumer"
 )
 
 // Server is the exported alias for the concrete ACP1 provider — lets

--- a/internal/acp1/provider/session.go
+++ b/internal/acp1/provider/session.go
@@ -3,7 +3,7 @@ package acp1
 import (
 	"log/slog"
 
-	iacp1 "acp/internal/acp1/consumer"
+	iacp1 "dhs/internal/acp1/consumer"
 )
 
 // handleRequest dispatches a decoded request to the right handler and

--- a/internal/acp1/provider/session_test.go
+++ b/internal/acp1/provider/session_test.go
@@ -6,8 +6,8 @@ import (
 	"log/slog"
 	"testing"
 
-	"acp/internal/export/canonical"
-	iacp1 "acp/internal/acp1/consumer"
+	"dhs/internal/export/canonical"
+	iacp1 "dhs/internal/acp1/consumer"
 )
 
 // newTestServer builds a server with a hand-crafted tree containing two

--- a/internal/acp1/provider/set.go
+++ b/internal/acp1/provider/set.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"math"
 
-	"acp/internal/export/canonical"
-	iacp1 "acp/internal/acp1/consumer"
+	"dhs/internal/export/canonical"
+	iacp1 "dhs/internal/acp1/consumer"
 )
 
 // applyMutation dispatches the four mutating methods (setValue,

--- a/internal/acp1/provider/tree.go
+++ b/internal/acp1/provider/tree.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"sync"
 
-	"acp/internal/export/canonical"
-	iacp1 "acp/internal/acp1/consumer"
+	"dhs/internal/export/canonical"
+	iacp1 "dhs/internal/acp1/consumer"
 )
 
 // groupName -> ObjGroup constant. Mirrors buildSlotNode in

--- a/internal/acp1/smoke/smoke_test.go
+++ b/internal/acp1/smoke/smoke_test.go
@@ -14,8 +14,8 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/protocol"
-	"acp/internal/acp1/consumer"
+	"dhs/internal/protocol"
+	"dhs/internal/acp1/consumer"
 )
 
 func testHost() string {

--- a/internal/acp2/consumer/canonicalize.go
+++ b/internal/acp2/consumer/canonicalize.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	"acp/internal/export/canonical"
-	"acp/internal/protocol"
+	"dhs/internal/export/canonical"
+	"dhs/internal/protocol"
 )
 
 // Canonicalize walks every cached WalkedTree on this plugin and emits

--- a/internal/acp2/consumer/canonicalize_test.go
+++ b/internal/acp2/consumer/canonicalize_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"acp/internal/export/canonical"
-	"acp/internal/protocol"
+	"dhs/internal/export/canonical"
+	"dhs/internal/protocol"
 )
 
 // TestCanonicalize_Empty verifies a fresh plugin emits a root device

--- a/internal/acp2/consumer/compliance_test.go
+++ b/internal/acp2/consumer/compliance_test.go
@@ -20,7 +20,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"acp/internal/acp2/consumer"
+	"dhs/internal/acp2/consumer"
 )
 
 // findACP2Error walks every frame in the capture and returns the

--- a/internal/acp2/consumer/placeholder_test.go
+++ b/internal/acp2/consumer/placeholder_test.go
@@ -9,7 +9,7 @@ import (
 	"math"
 	"testing"
 
-	"acp/internal/acp2/consumer"
+	"dhs/internal/acp2/consumer"
 )
 
 // TestAN2FrameRoundTrip verifies that an AN2 frame survives encode → decode.

--- a/internal/acp2/consumer/plugin.go
+++ b/internal/acp2/consumer/plugin.go
@@ -10,9 +10,9 @@ import (
 	"sync"
 	"time"
 
-	"acp/internal/protocol"
-	"acp/internal/protocol/compliance"
-	"acp/internal/transport"
+	"dhs/internal/protocol"
+	"dhs/internal/protocol/compliance"
+	"dhs/internal/transport"
 )
 
 // init registers the ACP2 plugin with the global protocol registry.

--- a/internal/acp2/consumer/replay_test.go
+++ b/internal/acp2/consumer/replay_test.go
@@ -13,7 +13,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"acp/internal/acp2/consumer"
+	"dhs/internal/acp2/consumer"
 )
 
 // captureRecord mirrors transport.CaptureRecord — duplicated here to

--- a/internal/acp2/consumer/session.go
+++ b/internal/acp2/consumer/session.go
@@ -9,9 +9,9 @@ import (
 	"sync"
 	"time"
 
-	"acp/internal/protocol"
-	"acp/internal/protocol/compliance"
-	"acp/internal/transport"
+	"dhs/internal/protocol"
+	"dhs/internal/protocol/compliance"
+	"dhs/internal/transport"
 )
 
 // Session manages an AN2/TCP connection to an ACP2 device. It handles:

--- a/internal/acp2/consumer/types.go
+++ b/internal/acp2/consumer/types.go
@@ -310,7 +310,7 @@ func (e *ACP2Error) Error() string {
 	return fmt.Sprintf("acp2 error (obj-id %d): %s", e.ObjID, desc)
 }
 
-func (e *ACP2Error) acpError() {} //nolint:unused // implements protocol.ACPError interface
+func (e *ACP2Error) dhsError() {} //nolint:unused // implements protocol.DHSError interface
 
 // AN2Error represents an AN2-layer error (proto=0, type=error).
 type AN2Error struct {
@@ -323,4 +323,4 @@ func (e *AN2Error) Error() string {
 	return fmt.Sprintf("an2 error (slot %d, func %d): %s", e.Slot, e.Func, e.Msg)
 }
 
-func (e *AN2Error) acpError() {} //nolint:unused // implements protocol.ACPError interface
+func (e *AN2Error) dhsError() {} //nolint:unused // implements protocol.DHSError interface

--- a/internal/acp2/consumer/walker.go
+++ b/internal/acp2/consumer/walker.go
@@ -7,7 +7,7 @@ import (
 	"log/slog"
 	"strings"
 
-	"acp/internal/protocol"
+	"dhs/internal/protocol"
 )
 
 // WalkedTree is the decoded object tree for one slot, analogous to

--- a/internal/acp2/provider/demo.go
+++ b/internal/acp2/provider/demo.go
@@ -6,7 +6,7 @@ import (
 	"math"
 	"time"
 
-	iacp2 "acp/internal/acp2/consumer"
+	iacp2 "dhs/internal/acp2/consumer"
 )
 
 // RunAnnounceDemo mutates slot=1 / obj=18 (GainFloat) every `interval`

--- a/internal/acp2/provider/encoder.go
+++ b/internal/acp2/provider/encoder.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	"acp/internal/export/canonical"
-	iacp2 "acp/internal/acp2/consumer"
+	"dhs/internal/export/canonical"
+	iacp2 "dhs/internal/acp2/consumer"
 )
 
 // buildProperties assembles the ACP2 property list a get_object reply

--- a/internal/acp2/provider/encoder_test.go
+++ b/internal/acp2/provider/encoder_test.go
@@ -4,8 +4,8 @@ import (
 	"encoding/binary"
 	"testing"
 
-	"acp/internal/export/canonical"
-	iacp2 "acp/internal/acp2/consumer"
+	"dhs/internal/export/canonical"
+	iacp2 "dhs/internal/acp2/consumer"
 )
 
 // helper — round-trips a tree through buildProperties + EncodeProperties

--- a/internal/acp2/provider/handlers.go
+++ b/internal/acp2/provider/handlers.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 
-	iacp2 "acp/internal/acp2/consumer"
+	iacp2 "dhs/internal/acp2/consumer"
 )
 
 // Version constants advertised by this provider.

--- a/internal/acp2/provider/handlers_test.go
+++ b/internal/acp2/provider/handlers_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	iacp2 "acp/internal/acp2/consumer"
+	iacp2 "dhs/internal/acp2/consumer"
 )
 
 // newTestSession builds a session bound to a net.Pipe so handshake

--- a/internal/acp2/provider/plugin.go
+++ b/internal/acp2/provider/plugin.go
@@ -15,9 +15,9 @@ package acp2
 import (
 	"log/slog"
 
-	"acp/internal/export/canonical"
-	"acp/internal/provider"
-	iacp2 "acp/internal/acp2/consumer"
+	"dhs/internal/export/canonical"
+	"dhs/internal/provider"
+	iacp2 "dhs/internal/acp2/consumer"
 )
 
 // DefaultPort is the AN2 TCP port used for ACP2 traffic.

--- a/internal/acp2/provider/server.go
+++ b/internal/acp2/provider/server.go
@@ -8,8 +8,8 @@ import (
 	"net"
 	"sync"
 
-	"acp/internal/export/canonical"
-	iacp2 "acp/internal/acp2/consumer"
+	"dhs/internal/export/canonical"
+	iacp2 "dhs/internal/acp2/consumer"
 )
 
 // Server is the exported alias for the concrete provider — lets

--- a/internal/acp2/provider/session.go
+++ b/internal/acp2/provider/session.go
@@ -7,7 +7,7 @@ import (
 	"net"
 	"sync"
 
-	iacp2 "acp/internal/acp2/consumer"
+	iacp2 "dhs/internal/acp2/consumer"
 )
 
 // session is one TCP connection. Holds the conn, a write mutex so

--- a/internal/acp2/provider/set.go
+++ b/internal/acp2/provider/set.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"math"
 
-	iacp2 "acp/internal/acp2/consumer"
+	iacp2 "dhs/internal/acp2/consumer"
 )
 
 // applySet mutates e per an incoming set_property request and returns

--- a/internal/acp2/provider/tree.go
+++ b/internal/acp2/provider/tree.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"sync"
 
-	"acp/internal/export/canonical"
-	iacp2 "acp/internal/acp2/consumer"
+	"dhs/internal/export/canonical"
+	iacp2 "dhs/internal/acp2/consumer"
 )
 
 // entry is one object in the served tree. Holds the canonical source

--- a/internal/acp2/provider/tree_test.go
+++ b/internal/acp2/provider/tree_test.go
@@ -3,8 +3,8 @@ package acp2
 import (
 	"testing"
 
-	"acp/internal/export/canonical"
-	iacp2 "acp/internal/acp2/consumer"
+	"dhs/internal/export/canonical"
+	iacp2 "dhs/internal/acp2/consumer"
 )
 
 func TestTree_FlattensAndIndexesBySlot(t *testing.T) {

--- a/internal/amwa/codec/bcp/bcp00201/validator.go
+++ b/internal/amwa/codec/bcp/bcp00201/validator.go
@@ -20,8 +20,8 @@ import (
 	"regexp"
 	"time"
 
-	"acp/internal/amwa/codec/bcp"
-	"acp/internal/amwa/codec/spec"
+	"dhs/internal/amwa/codec/bcp"
+	"dhs/internal/amwa/codec/spec"
 )
 
 const (

--- a/internal/amwa/codec/bcp/bcp00202/validator.go
+++ b/internal/amwa/codec/bcp/bcp00202/validator.go
@@ -19,8 +19,8 @@ import (
 	"regexp"
 	"time"
 
-	"acp/internal/amwa/codec/bcp"
-	"acp/internal/amwa/codec/spec"
+	"dhs/internal/amwa/codec/bcp"
+	"dhs/internal/amwa/codec/spec"
 )
 
 const (

--- a/internal/amwa/codec/bcp/bcp00401/validator.go
+++ b/internal/amwa/codec/bcp/bcp00401/validator.go
@@ -15,8 +15,8 @@ import (
 	"encoding/json"
 	"time"
 
-	"acp/internal/amwa/codec/bcp"
-	"acp/internal/amwa/codec/spec"
+	"dhs/internal/amwa/codec/bcp"
+	"dhs/internal/amwa/codec/spec"
 )
 
 const (

--- a/internal/amwa/codec/bcp/bcp00402/validator.go
+++ b/internal/amwa/codec/bcp/bcp00402/validator.go
@@ -12,8 +12,8 @@ import (
 	"encoding/json"
 	"time"
 
-	"acp/internal/amwa/codec/bcp"
-	"acp/internal/amwa/codec/spec"
+	"dhs/internal/amwa/codec/bcp"
+	"dhs/internal/amwa/codec/spec"
 )
 
 const (

--- a/internal/amwa/codec/bcp/bcp00601/validator.go
+++ b/internal/amwa/codec/bcp/bcp00601/validator.go
@@ -12,8 +12,8 @@ import (
 	"encoding/json"
 	"time"
 
-	"acp/internal/amwa/codec/bcp"
-	"acp/internal/amwa/codec/spec"
+	"dhs/internal/amwa/codec/bcp"
+	"dhs/internal/amwa/codec/spec"
 )
 
 const (

--- a/internal/amwa/codec/bcp/bcp00604/validator.go
+++ b/internal/amwa/codec/bcp/bcp00604/validator.go
@@ -12,8 +12,8 @@ import (
 	"encoding/json"
 	"time"
 
-	"acp/internal/amwa/codec/bcp"
-	"acp/internal/amwa/codec/spec"
+	"dhs/internal/amwa/codec/bcp"
+	"dhs/internal/amwa/codec/spec"
 )
 
 const (

--- a/internal/amwa/codec/bcp/bcp00801/validator.go
+++ b/internal/amwa/codec/bcp/bcp00801/validator.go
@@ -14,9 +14,9 @@ import (
 	"encoding/json"
 	"time"
 
-	"acp/internal/amwa/codec/bcp"
-	"acp/internal/amwa/codec/ms05"
-	"acp/internal/amwa/codec/spec"
+	"dhs/internal/amwa/codec/bcp"
+	"dhs/internal/amwa/codec/ms05"
+	"dhs/internal/amwa/codec/spec"
 )
 
 const (

--- a/internal/amwa/codec/bcp/bcp00802/validator.go
+++ b/internal/amwa/codec/bcp/bcp00802/validator.go
@@ -7,9 +7,9 @@ import (
 	"encoding/json"
 	"time"
 
-	"acp/internal/amwa/codec/bcp"
-	"acp/internal/amwa/codec/ms05"
-	"acp/internal/amwa/codec/spec"
+	"dhs/internal/amwa/codec/bcp"
+	"dhs/internal/amwa/codec/ms05"
+	"dhs/internal/amwa/codec/spec"
 )
 
 const (

--- a/internal/amwa/codec/bcp/bcp_test.go
+++ b/internal/amwa/codec/bcp/bcp_test.go
@@ -3,15 +3,15 @@ package bcp_test
 import (
 	"testing"
 
-	"acp/internal/amwa/codec/bcp"
-	_ "acp/internal/amwa/codec/bcp/bcp00201"
-	_ "acp/internal/amwa/codec/bcp/bcp00202"
-	_ "acp/internal/amwa/codec/bcp/bcp00401"
-	_ "acp/internal/amwa/codec/bcp/bcp00402"
-	_ "acp/internal/amwa/codec/bcp/bcp00601"
-	_ "acp/internal/amwa/codec/bcp/bcp00604"
-	_ "acp/internal/amwa/codec/bcp/bcp00801"
-	_ "acp/internal/amwa/codec/bcp/bcp00802"
+	"dhs/internal/amwa/codec/bcp"
+	_ "dhs/internal/amwa/codec/bcp/bcp00201"
+	_ "dhs/internal/amwa/codec/bcp/bcp00202"
+	_ "dhs/internal/amwa/codec/bcp/bcp00401"
+	_ "dhs/internal/amwa/codec/bcp/bcp00402"
+	_ "dhs/internal/amwa/codec/bcp/bcp00601"
+	_ "dhs/internal/amwa/codec/bcp/bcp00604"
+	_ "dhs/internal/amwa/codec/bcp/bcp00801"
+	_ "dhs/internal/amwa/codec/bcp/bcp00802"
 )
 
 func TestAllValidatorsRegistered(t *testing.T) {

--- a/internal/amwa/codec/bcp/validator.go
+++ b/internal/amwa/codec/bcp/validator.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 	"sync"
 
-	"acp/internal/amwa/codec/spec"
+	"dhs/internal/amwa/codec/spec"
 )
 
 // Kind is the NMOS resource kind a Validator targets.

--- a/internal/amwa/codec/dnssd/dns_test.go
+++ b/internal/amwa/codec/dnssd/dns_test.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"testing"
 
-	"acp/internal/amwa/codec/dnssd"
+	"dhs/internal/amwa/codec/dnssd"
 )
 
 func TestHeaderRoundTrip(t *testing.T) {

--- a/internal/amwa/codec/is04/codec.go
+++ b/internal/amwa/codec/is04/codec.go
@@ -1,7 +1,7 @@
 package is04
 
 import (
-	"acp/internal/amwa/codec/spec"
+	"dhs/internal/amwa/codec/spec"
 )
 
 // SpecID is the AMWA NMOS catalogue slug for IS-04. Every codec

--- a/internal/amwa/codec/is04/v10/codec.go
+++ b/internal/amwa/codec/is04/v10/codec.go
@@ -37,7 +37,7 @@
 package v10
 
 import (
-	"acp/internal/amwa/codec/is04"
+	"dhs/internal/amwa/codec/is04"
 	"bytes"
 	"encoding/json"
 	"fmt"

--- a/internal/amwa/codec/is04/v10/v10_test.go
+++ b/internal/amwa/codec/is04/v10/v10_test.go
@@ -1,8 +1,8 @@
 package v10
 
 import (
-	"acp/internal/amwa/codec/is04"
-	"acp/internal/amwa/codec/spec"
+	"dhs/internal/amwa/codec/is04"
+	"dhs/internal/amwa/codec/spec"
 	"encoding/json"
 	"strings"
 	"testing"

--- a/internal/amwa/codec/is04/v11/codec.go
+++ b/internal/amwa/codec/is04/v11/codec.go
@@ -27,7 +27,7 @@
 package v11
 
 import (
-	"acp/internal/amwa/codec/is04"
+	"dhs/internal/amwa/codec/is04"
 	"bytes"
 	"encoding/json"
 	"fmt"

--- a/internal/amwa/codec/is04/v11/v11_test.go
+++ b/internal/amwa/codec/is04/v11/v11_test.go
@@ -1,8 +1,8 @@
 package v11
 
 import (
-	"acp/internal/amwa/codec/is04"
-	"acp/internal/amwa/codec/spec"
+	"dhs/internal/amwa/codec/is04"
+	"dhs/internal/amwa/codec/spec"
 	"encoding/json"
 	"strings"
 	"testing"

--- a/internal/amwa/codec/is04/v12/codec.go
+++ b/internal/amwa/codec/is04/v12/codec.go
@@ -28,7 +28,7 @@
 package v12
 
 import (
-	"acp/internal/amwa/codec/is04"
+	"dhs/internal/amwa/codec/is04"
 	"bytes"
 	"encoding/json"
 	"fmt"

--- a/internal/amwa/codec/is04/v12/v12_test.go
+++ b/internal/amwa/codec/is04/v12/v12_test.go
@@ -1,8 +1,8 @@
 package v12
 
 import (
-	"acp/internal/amwa/codec/is04"
-	"acp/internal/amwa/codec/spec"
+	"dhs/internal/amwa/codec/is04"
+	"dhs/internal/amwa/codec/spec"
 	"encoding/json"
 	"strings"
 	"testing"

--- a/internal/amwa/codec/is04/v13/codec.go
+++ b/internal/amwa/codec/is04/v13/codec.go
@@ -15,7 +15,7 @@
 package v13
 
 import (
-	"acp/internal/amwa/codec/is04"
+	"dhs/internal/amwa/codec/is04"
 	"encoding/json"
 )
 

--- a/internal/amwa/codec/is04/v13/v13_test.go
+++ b/internal/amwa/codec/is04/v13/v13_test.go
@@ -1,8 +1,8 @@
 package v13
 
 import (
-	"acp/internal/amwa/codec/is04"
-	"acp/internal/amwa/codec/spec"
+	"dhs/internal/amwa/codec/is04"
+	"dhs/internal/amwa/codec/spec"
 	"strings"
 	"testing"
 )

--- a/internal/amwa/codec/is05/codec.go
+++ b/internal/amwa/codec/is05/codec.go
@@ -1,7 +1,7 @@
 package is05
 
 import (
-	"acp/internal/amwa/codec/spec"
+	"dhs/internal/amwa/codec/spec"
 )
 
 // SpecID is the AMWA NMOS catalogue slug for IS-05 (Connection

--- a/internal/amwa/codec/is05/v10/codec.go
+++ b/internal/amwa/codec/is05/v10/codec.go
@@ -12,7 +12,7 @@
 package v10
 
 import (
-	"acp/internal/amwa/codec/is05"
+	"dhs/internal/amwa/codec/is05"
 )
 
 // SpecPatch — the patch release the codec is audited against.

--- a/internal/amwa/codec/is05/v11/codec.go
+++ b/internal/amwa/codec/is05/v11/codec.go
@@ -8,7 +8,7 @@
 package v11
 
 import (
-	"acp/internal/amwa/codec/is05"
+	"dhs/internal/amwa/codec/is05"
 )
 
 // SpecPatch — the patch release the codec is audited against.

--- a/internal/amwa/codec/is07/codec.go
+++ b/internal/amwa/codec/is07/codec.go
@@ -1,7 +1,7 @@
 package is07
 
 import (
-	"acp/internal/amwa/codec/spec"
+	"dhs/internal/amwa/codec/spec"
 )
 
 // SpecID is the AMWA NMOS catalogue slug for IS-07 (Event & Tally).

--- a/internal/amwa/codec/is07/v10/codec.go
+++ b/internal/amwa/codec/is07/v10/codec.go
@@ -12,7 +12,7 @@
 package v10
 
 import (
-	"acp/internal/amwa/codec/is07"
+	"dhs/internal/amwa/codec/is07"
 )
 
 // SpecPatch — the patch release the codec is audited against.

--- a/internal/amwa/codec/is07/v10/codec_test.go
+++ b/internal/amwa/codec/is07/v10/codec_test.go
@@ -3,7 +3,7 @@ package v10
 import (
 	"testing"
 
-	"acp/internal/amwa/codec/is07"
+	"dhs/internal/amwa/codec/is07"
 )
 
 func TestRegistration(t *testing.T) {

--- a/internal/amwa/codec/is08/codec.go
+++ b/internal/amwa/codec/is08/codec.go
@@ -1,7 +1,7 @@
 package is08
 
 import (
-	"acp/internal/amwa/codec/spec"
+	"dhs/internal/amwa/codec/spec"
 )
 
 // SpecID is the AMWA NMOS catalogue slug for IS-08 (Audio Channel

--- a/internal/amwa/codec/is08/v10/codec.go
+++ b/internal/amwa/codec/is08/v10/codec.go
@@ -12,7 +12,7 @@
 package v10
 
 import (
-	"acp/internal/amwa/codec/is08"
+	"dhs/internal/amwa/codec/is08"
 )
 
 // SpecPatch — the patch release the codec is audited against.

--- a/internal/amwa/codec/is08/v10/codec_test.go
+++ b/internal/amwa/codec/is08/v10/codec_test.go
@@ -3,7 +3,7 @@ package v10
 import (
 	"testing"
 
-	"acp/internal/amwa/codec/is08"
+	"dhs/internal/amwa/codec/is08"
 )
 
 func TestRegistration(t *testing.T) {

--- a/internal/amwa/codec/is09/codec.go
+++ b/internal/amwa/codec/is09/codec.go
@@ -1,7 +1,7 @@
 package is09
 
 import (
-	"acp/internal/amwa/codec/spec"
+	"dhs/internal/amwa/codec/spec"
 )
 
 // SpecID is the AMWA NMOS catalogue slug for IS-09 (System API).

--- a/internal/amwa/codec/is09/v10/codec.go
+++ b/internal/amwa/codec/is09/v10/codec.go
@@ -10,7 +10,7 @@
 package v10
 
 import (
-	"acp/internal/amwa/codec/is09"
+	"dhs/internal/amwa/codec/is09"
 )
 
 // SpecPatch is the spec-text revision this codec strictly complies

--- a/internal/amwa/codec/is09/v10/v10_test.go
+++ b/internal/amwa/codec/is09/v10/v10_test.go
@@ -1,8 +1,8 @@
 package v10
 
 import (
-	"acp/internal/amwa/codec/is09"
-	"acp/internal/amwa/codec/spec"
+	"dhs/internal/amwa/codec/is09"
+	"dhs/internal/amwa/codec/spec"
 	"testing"
 )
 

--- a/internal/amwa/codec/is12/codec.go
+++ b/internal/amwa/codec/is12/codec.go
@@ -1,7 +1,7 @@
 package is12
 
 import (
-	"acp/internal/amwa/codec/spec"
+	"dhs/internal/amwa/codec/spec"
 )
 
 // SpecID is the AMWA NMOS catalogue slug for IS-12 (Control Protocol).

--- a/internal/amwa/codec/is12/v10/codec.go
+++ b/internal/amwa/codec/is12/v10/codec.go
@@ -3,7 +3,7 @@
 package v10
 
 import (
-	"acp/internal/amwa/codec/is12"
+	"dhs/internal/amwa/codec/is12"
 )
 
 // SpecPatch — the patch release the codec is audited against.

--- a/internal/amwa/codec/is12/v10/codec_test.go
+++ b/internal/amwa/codec/is12/v10/codec_test.go
@@ -3,7 +3,7 @@ package v10
 import (
 	"testing"
 
-	"acp/internal/amwa/codec/is12"
+	"dhs/internal/amwa/codec/is12"
 )
 
 func TestRegistration(t *testing.T) {

--- a/internal/amwa/codec/ms05/codec.go
+++ b/internal/amwa/codec/ms05/codec.go
@@ -1,7 +1,7 @@
 package ms05
 
 import (
-	"acp/internal/amwa/codec/spec"
+	"dhs/internal/amwa/codec/spec"
 )
 
 // SpecID is the AMWA NMOS catalogue slug for MS-05-02 (Control

--- a/internal/amwa/codec/ms05/v10/codec.go
+++ b/internal/amwa/codec/ms05/v10/codec.go
@@ -2,7 +2,7 @@
 // single track defined by the spec today.
 package v10
 
-import "acp/internal/amwa/codec/ms05"
+import "dhs/internal/amwa/codec/ms05"
 
 // SpecPatch — the patch release the codec is audited against.
 const SpecPatch = "v1.0.0"

--- a/internal/amwa/codec/ms05/v10/codec_test.go
+++ b/internal/amwa/codec/ms05/v10/codec_test.go
@@ -3,7 +3,7 @@ package v10
 import (
 	"testing"
 
-	"acp/internal/amwa/codec/ms05"
+	"dhs/internal/amwa/codec/ms05"
 )
 
 func TestRegistration(t *testing.T) {

--- a/internal/amwa/consumer/controller.go
+++ b/internal/amwa/consumer/controller.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"time"
 
-	"acp/internal/amwa/codec/dnssd"
-	"acp/internal/amwa/codec/is04"
-	"acp/internal/amwa/codec/spec"
-	"acp/internal/amwa/session/query"
+	"dhs/internal/amwa/codec/dnssd"
+	"dhs/internal/amwa/codec/is04"
+	"dhs/internal/amwa/codec/spec"
+	"dhs/internal/amwa/session/query"
 )
 
 // ControllerOptions configures the IS-04 Controller. The pattern

--- a/internal/amwa/consumer/system.go
+++ b/internal/amwa/consumer/system.go
@@ -28,10 +28,10 @@ import (
 	"strings"
 	"time"
 
-	dnssdcodec "acp/internal/amwa/codec/dnssd"
-	"acp/internal/amwa/codec/is09"
-	dnssdsession "acp/internal/amwa/session/dnssd"
-	httpsession "acp/internal/amwa/session/http"
+	dnssdcodec "dhs/internal/amwa/codec/dnssd"
+	"dhs/internal/amwa/codec/is09"
+	dnssdsession "dhs/internal/amwa/session/dnssd"
+	httpsession "dhs/internal/amwa/session/http"
 )
 
 // IS09FetchOptions configures a single Fetch call.

--- a/internal/amwa/consumer/system_test.go
+++ b/internal/amwa/consumer/system_test.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"testing"
 
-	dnssdcodec "acp/internal/amwa/codec/dnssd"
-	"acp/internal/amwa/codec/is09"
-	httpsession "acp/internal/amwa/session/http"
+	dnssdcodec "dhs/internal/amwa/codec/dnssd"
+	"dhs/internal/amwa/codec/is09"
+	httpsession "dhs/internal/amwa/session/http"
 )
 
 func TestSelectInstanceFiltersByProto(t *testing.T) {

--- a/internal/amwa/docs/dependencies.md
+++ b/internal/amwa/docs/dependencies.md
@@ -20,12 +20,12 @@ introduces a back-arrow.
 │  LAYER 4 — CLI                                                             │
 │  cmd/dhs/cmd_nmos.go                                                       │
 │                                                                            │
-│  Allowed:  acp/internal/amwa/consumer    (blank import + verb dispatch)     │
-│            acp/internal/amwa/provider    (blank import)                    │
-│            acp/internal/amwa/registry    (blank import)                    │
-│            acp/internal/protocol         (interface, registry lookup)       │
-│            acp/internal/provider         (interface, registry lookup)       │
-│            acp/internal/registry         (interface, registry lookup)       │
+│  Allowed:  dhs/internal/amwa/consumer    (blank import + verb dispatch)     │
+│            dhs/internal/amwa/provider    (blank import)                    │
+│            dhs/internal/amwa/registry    (blank import)                    │
+│            dhs/internal/protocol         (interface, registry lookup)       │
+│            dhs/internal/provider         (interface, registry lookup)       │
+│            dhs/internal/registry         (interface, registry lookup)       │
 │  Forbidden: anything under internal/amwa/codec/* directly                   │
 │             anything under internal/amwa/session/* directly                 │
 │             any other internal/<proto>/* (cross-protocol leak)              │
@@ -37,14 +37,14 @@ introduces a back-arrow.
 │  internal/amwa/provider/  (Node)                                           │
 │  internal/amwa/registry/  (Registry — dual-face middleware)                │
 │                                                                            │
-│  Allowed:  acp/internal/amwa/session/*                                      │
-│            acp/internal/amwa/codec/*                                        │
-│            acp/internal/protocol           (interface only)                 │
-│            acp/internal/provider           (interface only)                 │
-│            acp/internal/registry           (interface only — NEW slot)      │
-│            acp/internal/protocol/compliance                                │
-│            acp/internal/storage            (portable data dir)              │
-│            acp/internal/metrics            (connector + Prom)               │
+│  Allowed:  dhs/internal/amwa/session/*                                      │
+│            dhs/internal/amwa/codec/*                                        │
+│            dhs/internal/protocol           (interface only)                 │
+│            dhs/internal/provider           (interface only)                 │
+│            dhs/internal/registry           (interface only — NEW slot)      │
+│            dhs/internal/protocol/compliance                                │
+│            dhs/internal/storage            (portable data dir)              │
+│            dhs/internal/metrics            (connector + Prom)               │
 │  Forbidden: any other internal/<proto>/*                                    │
 │             cmd/*                                                          │
 │             cross-imports between consumer / provider / registry            │
@@ -62,11 +62,11 @@ introduces a back-arrow.
 │                                          client)                           │
 │  internal/amwa/session/bootstrap/      (IS-09 fetch on Node boot)          │
 │                                                                            │
-│  Allowed:  acp/internal/amwa/codec/*                                        │
-│            acp/internal/transport       (HTTP/WS capture)                   │
-│            acp/internal/protocol/compliance                                │
-│            acp/internal/metrics                                            │
-│  Forbidden: acp/internal/amwa/{consumer,provider,registry}                  │
+│  Allowed:  dhs/internal/amwa/codec/*                                        │
+│            dhs/internal/transport       (HTTP/WS capture)                   │
+│            dhs/internal/protocol/compliance                                │
+│            dhs/internal/metrics                                            │
+│  Forbidden: dhs/internal/amwa/{consumer,provider,registry}                  │
 │             cmd/*                                                          │
 │             any other internal/<proto>/*                                    │
 └──────────────────────────────────┬─────────────────────────────────────────┘
@@ -285,7 +285,7 @@ linters-settings:
         files:
           - "**/internal/amwa/codec/**"
         deny:
-          - pkg: "acp/"
+          - pkg: "dhs/"
             desc: "codec layer must be stdlib-only (lift-to-own-repo ready)"
           - pkg: "github.com/"
             desc: "codec layer must be stdlib-only"
@@ -295,20 +295,20 @@ linters-settings:
         files:
           - "**/internal/amwa/session/**"
         deny:
-          - pkg: "acp/internal/amwa/consumer"
+          - pkg: "dhs/internal/amwa/consumer"
             desc: "session must not import plugin layer (back-arrow)"
-          - pkg: "acp/internal/amwa/provider"
-          - pkg: "acp/internal/amwa/registry"
-          - pkg: "acp/cmd/"
+          - pkg: "dhs/internal/amwa/provider"
+          - pkg: "dhs/internal/amwa/registry"
+          - pkg: "dhs/cmd/"
 
       nmos-plugin-no-cross-plugin:
         list-mode: lax
         files:
           - "**/internal/amwa/consumer/**"
         deny:
-          - pkg: "acp/internal/amwa/provider"
+          - pkg: "dhs/internal/amwa/provider"
             desc: "consumer must not import provider (cross-plugin leak)"
-          - pkg: "acp/internal/amwa/registry"
+          - pkg: "dhs/internal/amwa/registry"
       # ... mirror rules for provider/ and registry/
 ```
 
@@ -327,14 +327,14 @@ import (
 )
 
 func TestCodecHasNoAcpImports(t *testing.T) {
-    pkg, err := build.Import("acp/internal/amwa/codec/...", "", 0)
-    // walk every codec package, fail if any import starts with "acp/"
-    // (excluding sibling acp/internal/amwa/codec/*)
+    pkg, err := build.Import("dhs/internal/amwa/codec/...", "", 0)
+    // walk every codec package, fail if any import starts with "dhs/"
+    // (excluding sibling dhs/internal/amwa/codec/*)
 }
 
 func TestSessionHasNoPluginImports(t *testing.T) {
     // walk every session package, fail if it imports
-    // acp/internal/amwa/{consumer,provider,registry}
+    // dhs/internal/amwa/{consumer,provider,registry}
 }
 
 // ... etc
@@ -366,13 +366,13 @@ without breaking the layering:
 
 | Package | Purpose | Layers allowed |
 |---|---|---|
-| `acp/internal/storage` | Portable data dir + atomic file writes | 2, 3 |
-| `acp/internal/metrics` | Connector counters + Prom registry | 2, 3 |
-| `acp/internal/transport` | HTTP/WS capture (`--capture` flag) | 2 only |
-| `acp/internal/protocol/compliance` | Compliance.Profile + event types | 2, 3 |
-| `acp/internal/protocol` | Consumer interface + registry | 3, 4 |
-| `acp/internal/provider` | Provider interface + registry | 3, 4 |
-| `acp/internal/registry` *(NEW)* | Registry interface + registry | 3, 4 |
+| `dhs/internal/storage` | Portable data dir + atomic file writes | 2, 3 |
+| `dhs/internal/metrics` | Connector counters + Prom registry | 2, 3 |
+| `dhs/internal/transport` | HTTP/WS capture (`--capture` flag) | 2 only |
+| `dhs/internal/protocol/compliance` | Compliance.Profile + event types | 2, 3 |
+| `dhs/internal/protocol` | Consumer interface + registry | 3, 4 |
+| `dhs/internal/provider` | Provider interface + registry | 3, 4 |
+| `dhs/internal/registry` *(NEW)* | Registry interface + registry | 3, 4 |
 
 ---
 

--- a/internal/amwa/provider/node.go
+++ b/internal/amwa/provider/node.go
@@ -13,10 +13,10 @@ import (
 	"sync"
 	"sync/atomic"
 
-	dnssdcodec "acp/internal/amwa/codec/dnssd"
-	"acp/internal/amwa/codec/is04"
-	dnssdsession "acp/internal/amwa/session/dnssd"
-	httpsession "acp/internal/amwa/session/http"
+	dnssdcodec "dhs/internal/amwa/codec/dnssd"
+	"dhs/internal/amwa/codec/is04"
+	dnssdsession "dhs/internal/amwa/session/dnssd"
+	httpsession "dhs/internal/amwa/session/http"
 )
 
 // encodeOne wraps a per-resource codec Encode method into a

--- a/internal/amwa/provider/node_config.go
+++ b/internal/amwa/provider/node_config.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"os"
 
-	"acp/internal/amwa/codec/is04"
+	"dhs/internal/amwa/codec/is04"
 )
 
 // NodeConfig is the on-disk Node bundle. Fields parallel the Node API

--- a/internal/amwa/provider/node_endpoints.go
+++ b/internal/amwa/provider/node_endpoints.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"acp/internal/amwa/codec/is04"
+	"dhs/internal/amwa/codec/is04"
 )
 
 // expandNodeEndpoints normalises the Node's `api.endpoints` array so

--- a/internal/amwa/provider/node_p2p_txt_test.go
+++ b/internal/amwa/provider/node_p2p_txt_test.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 	"testing"
 
-	dnssdcodec "acp/internal/amwa/codec/dnssd"
-	"acp/internal/amwa/codec/is04"
-	dnssdsession "acp/internal/amwa/session/dnssd"
+	dnssdcodec "dhs/internal/amwa/codec/dnssd"
+	"dhs/internal/amwa/codec/is04"
+	dnssdsession "dhs/internal/amwa/session/dnssd"
 )
 
 // mockResponder is a test-only [dnssdsession.Responder] that records the

--- a/internal/amwa/provider/node_test.go
+++ b/internal/amwa/provider/node_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/amwa/codec/is04"
+	"dhs/internal/amwa/codec/is04"
 	// Blank import to register the v1.3 IS-04 Codec via init() so that
 	// NewIS04NodeServer's spec.Registry lookup succeeds in unit tests.
 	// Layer 3 plugin code (which provider/ lives in) MUST NOT depend on
@@ -22,7 +22,7 @@ import (
 	// the explicit exemption: unit tests need the codec wired up to
 	// exercise the plugin end-to-end. Mirrors the pattern in
 	// internal/amwa/registry/*_test.go.
-	_ "acp/internal/amwa/codec/is04/v13"
+	_ "dhs/internal/amwa/codec/is04/v13"
 )
 
 func validNode() is04.Node {

--- a/internal/amwa/provider/registration_client.go
+++ b/internal/amwa/provider/registration_client.go
@@ -14,7 +14,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"acp/internal/amwa/codec/is04"
+	"dhs/internal/amwa/codec/is04"
 )
 
 // HeartbeatInterval is the IS-04 §6.1 default for POST

--- a/internal/amwa/provider/registry_watcher.go
+++ b/internal/amwa/provider/registry_watcher.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 	"time"
 
-	dnssdcodec "acp/internal/amwa/codec/dnssd"
-	dnssdsession "acp/internal/amwa/session/dnssd"
+	dnssdcodec "dhs/internal/amwa/codec/dnssd"
+	dnssdsession "dhs/internal/amwa/session/dnssd"
 )
 
 // RegistryCandidate is one Registry instance discovered via DNS-SD,

--- a/internal/amwa/provider/registry_watcher_test.go
+++ b/internal/amwa/provider/registry_watcher_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	dnssdcodec "acp/internal/amwa/codec/dnssd"
-	"acp/internal/amwa/codec/is04"
+	dnssdcodec "dhs/internal/amwa/codec/dnssd"
+	"dhs/internal/amwa/codec/is04"
 )
 
 func TestCandidateFromInstance(t *testing.T) {

--- a/internal/amwa/provider/system.go
+++ b/internal/amwa/provider/system.go
@@ -21,10 +21,10 @@ import (
 	"sync"
 	"sync/atomic"
 
-	dnssdcodec "acp/internal/amwa/codec/dnssd"
-	"acp/internal/amwa/codec/is09"
-	dnssdsession "acp/internal/amwa/session/dnssd"
-	httpsession "acp/internal/amwa/session/http"
+	dnssdcodec "dhs/internal/amwa/codec/dnssd"
+	"dhs/internal/amwa/codec/is09"
+	dnssdsession "dhs/internal/amwa/session/dnssd"
+	httpsession "dhs/internal/amwa/session/http"
 )
 
 // IS09Config wires the System provider together. APIVer overrides the

--- a/internal/amwa/provider/system_test.go
+++ b/internal/amwa/provider/system_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/amwa/codec/is09"
+	"dhs/internal/amwa/codec/is09"
 )
 
 func validGlobal() *is09.Global {

--- a/internal/amwa/registry/api_root.go
+++ b/internal/amwa/registry/api_root.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	stdhttp "net/http"
 
-	httpsession "acp/internal/amwa/session/http"
+	httpsession "dhs/internal/amwa/session/http"
 )
 
 // installAPIRootRoutes wires the discovery roots that AMWA IS-04-02

--- a/internal/amwa/registry/helpers.go
+++ b/internal/amwa/registry/helpers.go
@@ -3,8 +3,8 @@ package registry
 import (
 	"encoding/json"
 
-	codec "acp/internal/amwa/codec/dnssd"
-	"acp/internal/amwa/codec/is04"
+	codec "dhs/internal/amwa/codec/dnssd"
+	"dhs/internal/amwa/codec/is04"
 )
 
 // pickRegistryServices returns the DNS-SD service-type names a Registry

--- a/internal/amwa/registry/paging.go
+++ b/internal/amwa/registry/paging.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"acp/internal/amwa/codec/is04"
+	"dhs/internal/amwa/codec/is04"
 )
 
 // IS-04 §6.1.6 — Query API pagination.

--- a/internal/amwa/registry/query.go
+++ b/internal/amwa/registry/query.go
@@ -9,8 +9,8 @@ import (
 
 	stdhttp "net/http"
 
-	"acp/internal/amwa/codec/is04"
-	httpsession "acp/internal/amwa/session/http"
+	"dhs/internal/amwa/codec/is04"
+	httpsession "dhs/internal/amwa/session/http"
 )
 
 // installQueryRoutes wires the Query API endpoints onto the server.

--- a/internal/amwa/registry/registration.go
+++ b/internal/amwa/registry/registration.go
@@ -8,8 +8,8 @@ import (
 	stdhttp "net/http"
 	"strings"
 
-	"acp/internal/amwa/codec/is04"
-	httpsession "acp/internal/amwa/session/http"
+	"dhs/internal/amwa/codec/is04"
+	httpsession "dhs/internal/amwa/session/http"
 )
 
 // installRegistrationRoutes wires the Registration API endpoints onto

--- a/internal/amwa/registry/registry.go
+++ b/internal/amwa/registry/registry.go
@@ -18,11 +18,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	codec "acp/internal/amwa/codec/dnssd"
-	"acp/internal/amwa/codec/is04"
-	session "acp/internal/amwa/session/dnssd"
-	httpsession "acp/internal/amwa/session/http"
-	registryslot "acp/internal/registry"
+	codec "dhs/internal/amwa/codec/dnssd"
+	"dhs/internal/amwa/codec/is04"
+	session "dhs/internal/amwa/session/dnssd"
+	httpsession "dhs/internal/amwa/session/http"
+	registryslot "dhs/internal/registry"
 )
 
 // Plugin name registered with internal/registry/.

--- a/internal/amwa/registry/registry_advertise_test.go
+++ b/internal/amwa/registry/registry_advertise_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	codec "acp/internal/amwa/codec/dnssd"
+	codec "dhs/internal/amwa/codec/dnssd"
 )
 
 // TestPickRegistryServices_LegacyConditional pins the spec-strict rule

--- a/internal/amwa/registry/registry_http_test.go
+++ b/internal/amwa/registry/registry_http_test.go
@@ -14,8 +14,8 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/amwa/codec/is04"
-	httpsession "acp/internal/amwa/session/http"
+	"dhs/internal/amwa/codec/is04"
+	httpsession "dhs/internal/amwa/session/http"
 )
 
 // startRegistryHTTP boots only the HTTP face (no mDNS, no GC) for

--- a/internal/amwa/registry/registry_test.go
+++ b/internal/amwa/registry/registry_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	registryslot "acp/internal/registry"
+	registryslot "dhs/internal/registry"
 )
 
 func TestFactoryRegisteredViaInit(t *testing.T) {

--- a/internal/amwa/registry/store.go
+++ b/internal/amwa/registry/store.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"acp/internal/amwa/codec/is04"
+	"dhs/internal/amwa/codec/is04"
 )
 
 // ErrNotFound is returned by every getter when the resource is unknown.

--- a/internal/amwa/registry/store_test.go
+++ b/internal/amwa/registry/store_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/amwa/codec/is04"
+	"dhs/internal/amwa/codec/is04"
 )
 
 func validNode(id string) is04.Node {

--- a/internal/amwa/registry/subscriptions.go
+++ b/internal/amwa/registry/subscriptions.go
@@ -13,8 +13,8 @@ import (
 
 	stdhttp "net/http"
 
-	"acp/internal/amwa/codec/is04"
-	httpsession "acp/internal/amwa/session/http"
+	"dhs/internal/amwa/codec/is04"
+	httpsession "dhs/internal/amwa/session/http"
 )
 
 // SubscriptionRequest is the body POSTed to /subscriptions.

--- a/internal/amwa/session/dnssd/avahi_linux.go
+++ b/internal/amwa/session/dnssd/avahi_linux.go
@@ -30,7 +30,7 @@ import (
 	"strings"
 	"sync"
 
-	"acp/internal/amwa/codec/dnssd"
+	"dhs/internal/amwa/codec/dnssd"
 
 	"github.com/godbus/dbus/v5"
 )

--- a/internal/amwa/session/dnssd/interfaces.go
+++ b/internal/amwa/session/dnssd/interfaces.go
@@ -3,7 +3,7 @@ package dnssd
 import (
 	"context"
 
-	"acp/internal/amwa/codec/dnssd"
+	"dhs/internal/amwa/codec/dnssd"
 )
 
 // Browser scans the link for instances of one or more service types and

--- a/internal/amwa/session/dnssd/mdns.go
+++ b/internal/amwa/session/dnssd/mdns.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"acp/internal/amwa/codec/dnssd"
+	"dhs/internal/amwa/codec/dnssd"
 )
 
 // mDNS link-local addresses (RFC 6762 ??3). IPv6 is staged for a

--- a/internal/amwa/session/dnssd/unicast.go
+++ b/internal/amwa/session/dnssd/unicast.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"acp/internal/amwa/codec/dnssd"
+	"dhs/internal/amwa/codec/dnssd"
 )
 
 // DefaultUnicastTimeout caps a single unicast DNS-SD query.

--- a/internal/amwa/session/dnssd/unicast_test.go
+++ b/internal/amwa/session/dnssd/unicast_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/amwa/codec/dnssd"
+	"dhs/internal/amwa/codec/dnssd"
 )
 
 // runFakeDNSServer binds to a free UDP/127.0.0.1 port and replies to a

--- a/internal/amwa/session/events/events_test.go
+++ b/internal/amwa/session/events/events_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/amwa/codec/is07"
-	_ "acp/internal/amwa/codec/is07/v10"
-	"acp/internal/amwa/session/events"
+	"dhs/internal/amwa/codec/is07"
+	_ "dhs/internal/amwa/codec/is07/v10"
+	"dhs/internal/amwa/session/events"
 )
 
 const (

--- a/internal/amwa/session/events/publisher.go
+++ b/internal/amwa/session/events/publisher.go
@@ -10,8 +10,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"acp/internal/amwa/codec/is07"
-	httpsession "acp/internal/amwa/session/http"
+	"dhs/internal/amwa/codec/is07"
+	httpsession "dhs/internal/amwa/session/http"
 )
 
 // Publisher is the IS-07 WebSocket server attached to a Node. One

--- a/internal/amwa/session/events/subscriber.go
+++ b/internal/amwa/session/events/subscriber.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"acp/internal/amwa/codec/is07"
-	httpsession "acp/internal/amwa/session/http"
+	"dhs/internal/amwa/codec/is07"
+	httpsession "dhs/internal/amwa/session/http"
 )
 
 // MessageHandler receives every IS-07 sender-to-receiver wire frame

--- a/internal/amwa/session/events/subscription.go
+++ b/internal/amwa/session/events/subscription.go
@@ -6,7 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	httpsession "acp/internal/amwa/session/http"
+	httpsession "dhs/internal/amwa/session/http"
 )
 
 // subscription tracks one publisher-side connected client and its

--- a/internal/amwa/session/query/client.go
+++ b/internal/amwa/session/query/client.go
@@ -7,8 +7,8 @@ import (
 	"net/url"
 	"strings"
 
-	"acp/internal/amwa/codec/is04"
-	httpsession "acp/internal/amwa/session/http"
+	"dhs/internal/amwa/codec/is04"
+	httpsession "dhs/internal/amwa/session/http"
 )
 
 // Client is the IS-04 Query API client. Hold one per Registry: it

--- a/internal/amwa/session/query/client_test.go
+++ b/internal/amwa/session/query/client_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"acp/internal/amwa/codec/is04"
-	v13 "acp/internal/amwa/codec/is04/v13"
+	"dhs/internal/amwa/codec/is04"
+	v13 "dhs/internal/amwa/codec/is04/v13"
 )
 
 func TestNewClientRejectsBadInput(t *testing.T) {

--- a/internal/cerebrum-nb/CLAUDE.md
+++ b/internal/cerebrum-nb/CLAUDE.md
@@ -60,7 +60,7 @@ Provider deferred. Consumer-first.
 
 ### WebSocket (RFC 6455) — hand-rolled
 
-Implemented in [codec/ws/](codec/ws/). Stdlib-only, no `acp/*` imports —
+Implemented in [codec/ws/](codec/ws/). Stdlib-only, no `dhs/*` imports —
 lift-ready per `feedback_codec_isolation`.
 
 ### XML

--- a/internal/cerebrum-nb/codec/ws/doc.go
+++ b/internal/cerebrum-nb/codec/ws/doc.go
@@ -11,7 +11,7 @@
 //   - No sub-protocol negotiation.
 //
 // Lift-ready per the project's codec-isolation rule: imports stdlib
-// only and never touches `acp/*` symbols.
+// only and never touches `dhs/*` symbols.
 //
 // Spec: RFC 6455 (https://www.rfc-editor.org/rfc/rfc6455).
 package ws

--- a/internal/cerebrum-nb/consumer/integration_test.go
+++ b/internal/cerebrum-nb/consumer/integration_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/cerebrum-nb/codec"
+	"dhs/internal/cerebrum-nb/codec"
 )
 
 func liveTarget(t *testing.T) (host string, port int, user, pass string) {

--- a/internal/cerebrum-nb/consumer/plugin.go
+++ b/internal/cerebrum-nb/consumer/plugin.go
@@ -11,8 +11,8 @@ import (
 	"log/slog"
 	"sync"
 
-	"acp/internal/cerebrum-nb/codec"
-	"acp/internal/protocol"
+	"dhs/internal/cerebrum-nb/codec"
+	"dhs/internal/protocol"
 )
 
 func init() {

--- a/internal/cerebrum-nb/consumer/session.go
+++ b/internal/cerebrum-nb/consumer/session.go
@@ -14,8 +14,8 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"acp/internal/cerebrum-nb/codec"
-	"acp/internal/cerebrum-nb/codec/ws"
+	"dhs/internal/cerebrum-nb/codec"
+	"dhs/internal/cerebrum-nb/codec/ws"
 )
 
 // Session is the live WebSocket session against one Cerebrum host. It

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -16,7 +16,7 @@ import (
 	"fmt"
 	"sort"
 
-	"acp/internal/export/canonical"
+	"dhs/internal/export/canonical"
 )
 
 // Category labels — one of these per Entry. Values match the

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"acp/internal/export/canonical"
+	"dhs/internal/export/canonical"
 )
 
 // stringPtr + helpers for building synthetic elements.

--- a/internal/emberplus/CLAUDE.md
+++ b/internal/emberplus/CLAUDE.md
@@ -152,4 +152,4 @@ S101 layer. Respond to every request promptly.
 - Do NOT trust tag numbers by position — always read APPLICATION tags.
 - Do NOT assume matrix targets/sources are contiguous (holes are legal).
 - Do NOT silently swallow formula errors — route through `compliance.Profile`.
-- Do NOT import `acp/internal/*` from `codec/` subpackages (stdlib-only rule).
+- Do NOT import `dhs/internal/*` from `codec/` subpackages (stdlib-only rule).

--- a/internal/emberplus/codec/glow/decoder.go
+++ b/internal/emberplus/codec/glow/decoder.go
@@ -8,7 +8,7 @@ package glow
 import (
 	"fmt"
 
-	"acp/internal/emberplus/codec/ber"
+	"dhs/internal/emberplus/codec/ber"
 )
 
 // DecodeRoot decodes a top-level Glow payload.

--- a/internal/emberplus/codec/glow/encoder.go
+++ b/internal/emberplus/codec/glow/encoder.go
@@ -6,7 +6,7 @@
 package glow
 
 import (
-	"acp/internal/emberplus/codec/ber"
+	"dhs/internal/emberplus/codec/ber"
 )
 
 // --- Root messages ---

--- a/internal/emberplus/codec/glow/glow_test.go
+++ b/internal/emberplus/codec/glow/glow_test.go
@@ -3,7 +3,7 @@ package glow
 import (
 	"testing"
 
-	"acp/internal/emberplus/codec/ber"
+	"dhs/internal/emberplus/codec/ber"
 )
 
 func TestEncodeDecodeGetDirectory(t *testing.T) {

--- a/internal/emberplus/codec/matrix/state.go
+++ b/internal/emberplus/codec/matrix/state.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	"acp/internal/emberplus/codec/glow"
+	"dhs/internal/emberplus/codec/glow"
 )
 
 // ChangeSource attributes the most recent mutation to its origin.

--- a/internal/emberplus/codec/matrix/state_test.go
+++ b/internal/emberplus/codec/matrix/state_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"acp/internal/emberplus/codec/glow"
+	"dhs/internal/emberplus/codec/glow"
 )
 
 func TestCanConnect_OneToN(t *testing.T) {

--- a/internal/emberplus/consumer/canonicalize.go
+++ b/internal/emberplus/consumer/canonicalize.go
@@ -6,9 +6,9 @@ import (
 	"sort"
 	"strings"
 
-	"acp/internal/export/canonical"
-	"acp/internal/protocol"
-	"acp/internal/emberplus/codec/glow"
+	"dhs/internal/export/canonical"
+	"dhs/internal/protocol"
+	"dhs/internal/emberplus/codec/glow"
 )
 
 // CanonicalOptions controls which form the exporter emits for

--- a/internal/emberplus/consumer/diff.go
+++ b/internal/emberplus/consumer/diff.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"acp/internal/protocol"
-	"acp/internal/emberplus/codec/glow"
+	"dhs/internal/protocol"
+	"dhs/internal/emberplus/codec/glow"
 )
 
 // diffParameters returns the ordered list of FieldChange entries that

--- a/internal/emberplus/consumer/glow_snapshot.go
+++ b/internal/emberplus/consumer/glow_snapshot.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"sort"
 
-	"acp/internal/emberplus/codec/glow"
+	"dhs/internal/emberplus/codec/glow"
 )
 
 // GlowEntry is one row of the plugin's flat Glow tree dump.

--- a/internal/emberplus/consumer/merge.go
+++ b/internal/emberplus/consumer/merge.go
@@ -1,6 +1,6 @@
 package emberplus
 
-import "acp/internal/emberplus/codec/glow"
+import "dhs/internal/emberplus/codec/glow"
 
 // mergeAnnouncedParameter overlays the fields an announce actually
 // carried onto the previously-walked Parameter, preserving metadata

--- a/internal/emberplus/consumer/plugin.go
+++ b/internal/emberplus/consumer/plugin.go
@@ -24,11 +24,11 @@ import (
 	"sync"
 	"time"
 
-	"acp/internal/protocol"
-	"acp/internal/protocol/compliance"
-	"acp/internal/emberplus/codec/glow"
-	"acp/internal/emberplus/codec/matrix"
-	"acp/internal/transport"
+	"dhs/internal/protocol"
+	"dhs/internal/protocol/compliance"
+	"dhs/internal/emberplus/codec/glow"
+	"dhs/internal/emberplus/codec/matrix"
+	"dhs/internal/transport"
 )
 
 func init() {

--- a/internal/emberplus/consumer/reconnect.go
+++ b/internal/emberplus/consumer/reconnect.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"acp/internal/emberplus/codec/glow"
+	"dhs/internal/emberplus/codec/glow"
 )
 
 // clearTree wipes every in-RAM tree index so a post-reconnect walk

--- a/internal/emberplus/consumer/resolver.go
+++ b/internal/emberplus/consumer/resolver.go
@@ -3,7 +3,7 @@ package emberplus
 import (
 	"strconv"
 
-	"acp/internal/export/canonical"
+	"dhs/internal/export/canonical"
 )
 
 // modePointer / modeInline / modeBoth are the three values of each

--- a/internal/emberplus/consumer/resolver_test.go
+++ b/internal/emberplus/consumer/resolver_test.go
@@ -3,8 +3,8 @@ package emberplus
 import (
 	"testing"
 
-	"acp/internal/export/canonical"
-	"acp/internal/protocol/compliance"
+	"dhs/internal/export/canonical"
+	"dhs/internal/protocol/compliance"
 )
 
 // TestResolveMatrixLabels_MultiLevel exercises the N>=2 case that the

--- a/internal/emberplus/consumer/session.go
+++ b/internal/emberplus/consumer/session.go
@@ -8,10 +8,10 @@ import (
 	"sync"
 	"time"
 
-	"acp/internal/protocol/compliance"
-	"acp/internal/emberplus/codec/glow"
-	"acp/internal/emberplus/codec/s101"
-	"acp/internal/transport"
+	"dhs/internal/protocol/compliance"
+	"dhs/internal/emberplus/codec/glow"
+	"dhs/internal/emberplus/codec/s101"
+	"dhs/internal/transport"
 )
 
 // Session manages a single TCP connection to an Ember+ provider.

--- a/internal/emberplus/consumer/set_pending.go
+++ b/internal/emberplus/consumer/set_pending.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"acp/internal/protocol"
+	"dhs/internal/protocol"
 )
 
 // pendingSet captures one in-flight SetValue call waiting for the

--- a/internal/emberplus/provider/builtins.go
+++ b/internal/emberplus/provider/builtins.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"sync"
 
-	"acp/internal/export/canonical"
+	"dhs/internal/export/canonical"
 )
 
 // lockStore holds per-target locks keyed by matrixOID -> target.

--- a/internal/emberplus/provider/encoder.go
+++ b/internal/emberplus/provider/encoder.go
@@ -3,9 +3,9 @@ package emberplus
 import (
 	"fmt"
 
-	"acp/internal/export/canonical"
-	"acp/internal/emberplus/codec/ber"
-	"acp/internal/emberplus/codec/glow"
+	"dhs/internal/export/canonical"
+	"dhs/internal/emberplus/codec/ber"
+	"dhs/internal/emberplus/codec/glow"
 )
 
 // encodeGetDirReply walks the tree entry e and produces the BER payload

--- a/internal/emberplus/provider/encoder_test.go
+++ b/internal/emberplus/provider/encoder_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"acp/internal/export/canonical"
-	"acp/internal/emberplus/codec/glow"
+	"dhs/internal/export/canonical"
+	"dhs/internal/emberplus/codec/glow"
 )
 
 // TestRoundTrip_NodeWithParameter asserts the provider encoder and the

--- a/internal/emberplus/provider/function.go
+++ b/internal/emberplus/provider/function.go
@@ -1,9 +1,9 @@
 package emberplus
 
 import (
-	"acp/internal/export/canonical"
-	"acp/internal/emberplus/codec/ber"
-	"acp/internal/emberplus/codec/glow"
+	"dhs/internal/export/canonical"
+	"dhs/internal/emberplus/codec/ber"
+	"dhs/internal/emberplus/codec/glow"
 )
 
 // encodeQualifiedFunction emits a [APPLICATION 20] QualifiedFunction. Only

--- a/internal/emberplus/provider/function_test.go
+++ b/internal/emberplus/provider/function_test.go
@@ -3,8 +3,8 @@ package emberplus
 import (
 	"testing"
 
-	"acp/internal/export/canonical"
-	"acp/internal/emberplus/codec/glow"
+	"dhs/internal/export/canonical"
+	"dhs/internal/emberplus/codec/glow"
 )
 
 // TestRoundTrip_Function checks a Function with 2 integer args → 1 result

--- a/internal/emberplus/provider/invoke.go
+++ b/internal/emberplus/provider/invoke.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"sync"
 
-	"acp/internal/export/canonical"
-	"acp/internal/emberplus/codec/ber"
-	"acp/internal/emberplus/codec/glow"
+	"dhs/internal/export/canonical"
+	"dhs/internal/emberplus/codec/ber"
+	"dhs/internal/emberplus/codec/glow"
 )
 
 // FunctionImpl is a provider-side callback bound to a canonical Function.

--- a/internal/emberplus/provider/matrix.go
+++ b/internal/emberplus/provider/matrix.go
@@ -3,9 +3,9 @@ package emberplus
 import (
 	"fmt"
 
-	"acp/internal/export/canonical"
-	"acp/internal/emberplus/codec/ber"
-	"acp/internal/emberplus/codec/glow"
+	"dhs/internal/export/canonical"
+	"dhs/internal/emberplus/codec/ber"
+	"dhs/internal/emberplus/codec/glow"
 )
 
 // encodeQualifiedMatrix emits a [APPLICATION 17] QualifiedMatrix. Contents

--- a/internal/emberplus/provider/matrix_test.go
+++ b/internal/emberplus/provider/matrix_test.go
@@ -3,8 +3,8 @@ package emberplus
 import (
 	"testing"
 
-	"acp/internal/export/canonical"
-	"acp/internal/emberplus/codec/glow"
+	"dhs/internal/export/canonical"
+	"dhs/internal/emberplus/codec/glow"
 )
 
 // buildMatrixTree constructs a minimal tree: router(Node 1) → mat(Matrix 1.1)

--- a/internal/emberplus/provider/plugin.go
+++ b/internal/emberplus/provider/plugin.go
@@ -19,8 +19,8 @@ package emberplus
 import (
 	"log/slog"
 
-	"acp/internal/export/canonical"
-	"acp/internal/provider"
+	"dhs/internal/export/canonical"
+	"dhs/internal/provider"
 )
 
 // DefaultPort matches the scope of issue #66 — non-overlapping with the

--- a/internal/emberplus/provider/server.go
+++ b/internal/emberplus/provider/server.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"acp/internal/export/canonical"
+	"dhs/internal/export/canonical"
 )
 
 // server is the provider runtime. One listener, many sessions, a shared

--- a/internal/emberplus/provider/session.go
+++ b/internal/emberplus/provider/session.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"sync"
 
-	"acp/internal/export/canonical"
-	"acp/internal/emberplus/codec/glow"
-	"acp/internal/emberplus/codec/s101"
+	"dhs/internal/export/canonical"
+	"dhs/internal/emberplus/codec/glow"
+	"dhs/internal/emberplus/codec/s101"
 )
 
 // session is one live consumer connection. Single read loop; a send

--- a/internal/emberplus/provider/streamer.go
+++ b/internal/emberplus/provider/streamer.go
@@ -6,9 +6,9 @@ import (
 	"math"
 	"time"
 
-	"acp/internal/export/canonical"
-	"acp/internal/emberplus/codec/ber"
-	"acp/internal/emberplus/codec/glow"
+	"dhs/internal/export/canonical"
+	"dhs/internal/emberplus/codec/ber"
+	"dhs/internal/emberplus/codec/glow"
 )
 
 // streamEntry holds the per-parameter state needed to emit StreamEntry

--- a/internal/emberplus/provider/tree.go
+++ b/internal/emberplus/provider/tree.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"sync"
 
-	"acp/internal/export/canonical"
+	"dhs/internal/export/canonical"
 )
 
 // tree is the provider's in-memory snapshot of the served element tree.

--- a/internal/export/canonical_json.go
+++ b/internal/export/canonical_json.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io"
 
-	"acp/internal/export/canonical"
+	"dhs/internal/export/canonical"
 )
 
 // ErrNilExport is returned by WriteCanonicalJSON when the caller

--- a/internal/export/conformance_test.go
+++ b/internal/export/conformance_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	"acp/internal/export/canonical"
+	"dhs/internal/export/canonical"
 )
 
 var fencedJSON = regexp.MustCompile("(?s)```json\\s*\\n(.*?)\\n```")

--- a/internal/export/csv.go
+++ b/internal/export/csv.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"acp/internal/protocol"
+	"dhs/internal/protocol"
 )
 
 // csvHeader is the fixed column order every row follows. Adding a

--- a/internal/export/csv_lossless_test.go
+++ b/internal/export/csv_lossless_test.go
@@ -17,8 +17,8 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/export"
-	"acp/internal/protocol"
+	"dhs/internal/export"
+	"dhs/internal/protocol"
 )
 
 // dryRunMock is the minimal plugin stub Apply needs to reach its

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"time"
 
-	"acp/internal/protocol"
+	"dhs/internal/protocol"
 )
 
 // Snapshot is the top-level object every export file contains. It is

--- a/internal/export/filter.go
+++ b/internal/export/filter.go
@@ -3,7 +3,7 @@ package export
 import (
 	"strings"
 
-	"acp/internal/protocol"
+	"dhs/internal/protocol"
 )
 
 // ImportFilter narrows an import operation to a specific subset of

--- a/internal/export/filter_test.go
+++ b/internal/export/filter_test.go
@@ -13,8 +13,8 @@ package export_test
 import (
 	"testing"
 
-	"acp/internal/export"
-	"acp/internal/protocol"
+	"dhs/internal/export"
+	"dhs/internal/protocol"
 )
 
 // TestFilter_EmptyPassesEverything — nil filter and zero-value filter

--- a/internal/export/importer.go
+++ b/internal/export/importer.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"acp/internal/protocol"
+	"dhs/internal/protocol"
 )
 
 // Ensure the readers satisfy a common shape.

--- a/internal/export/json.go
+++ b/internal/export/json.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"acp/internal/protocol"
+	"dhs/internal/protocol"
 )
 
 // WriteJSON emits a Snapshot as pretty-printed JSON. Uses stdlib

--- a/internal/export/read_csv.go
+++ b/internal/export/read_csv.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"acp/internal/protocol"
+	"dhs/internal/protocol"
 )
 
 // ReadCSV parses a CSV snapshot produced by WriteCSV. Reconstructs a

--- a/internal/export/read_yaml.go
+++ b/internal/export/read_yaml.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"acp/internal/protocol"
+	"dhs/internal/protocol"
 )
 
 // ReadYAML parses a YAML snapshot produced by WriteYAML. This is NOT a

--- a/internal/export/roundtrip_test.go
+++ b/internal/export/roundtrip_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/export"
-	"acp/internal/protocol"
+	"dhs/internal/export"
+	"dhs/internal/protocol"
 )
 
 func sampleSnapshot() *export.Snapshot {

--- a/internal/export/yaml.go
+++ b/internal/export/yaml.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"strings"
 
-	"acp/internal/protocol"
+	"dhs/internal/protocol"
 )
 
 // WriteYAML emits a Snapshot as YAML. We deliberately avoid importing

--- a/internal/osc/CLAUDE.md
+++ b/internal/osc/CLAUDE.md
@@ -148,7 +148,7 @@ RFC 1055 with double-END encoding (OSC 1.1):
 
 ## What NOT to do
 
-- Do NOT import `acp/internal/*` from `internal/osc/codec/` — codec is stdlib-only.
+- Do NOT import `dhs/internal/*` from `internal/osc/codec/` — codec is stdlib-only.
 - Do NOT hardcode address semantics (`/tally/preview_on`, etc.) in the plugin. Semantic mapping lives in consumer/UI config; the plugin surfaces raw addresses + args.
 - Do NOT silently pad-align non-compliant inputs — fire `osc_alignment_violation` and accept what we can.
 - Do NOT mix 1.0 length-prefix and 1.1 SLIP on the same TCP connection — they're different framings. Registry split (`osc-v10` vs `osc-v11`) enforces this at the API level.

--- a/internal/osc/consumer/plugin.go
+++ b/internal/osc/consumer/plugin.go
@@ -20,7 +20,7 @@ import (
 	"log/slog"
 	"net"
 
-	"acp/internal/protocol"
+	"dhs/internal/protocol"
 )
 
 func init() {

--- a/internal/osc/consumer/session.go
+++ b/internal/osc/consumer/session.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	"syscall"
 
-	"acp/internal/osc/codec"
-	"acp/internal/transport"
+	"dhs/internal/osc/codec"
+	"dhs/internal/transport"
 )
 
 // PacketEvent is delivered to every subscriber whose pattern matches

--- a/internal/osc/consumer/session_test.go
+++ b/internal/osc/consumer/session_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/osc/codec"
+	"dhs/internal/osc/codec"
 )
 
 func TestUDPSession_ReceiveMessage(t *testing.T) {

--- a/internal/osc/consumer/tcp_session.go
+++ b/internal/osc/consumer/tcp_session.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"acp/internal/osc/codec"
+	"dhs/internal/osc/codec"
 )
 
 // tcpKeepalivePeriod sets SO_KEEPALIVE on accepted TCP connections.

--- a/internal/osc/integration/multi_peer_test.go
+++ b/internal/osc/integration/multi_peer_test.go
@@ -26,9 +26,9 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/osc/codec"
-	consumer "acp/internal/osc/consumer"
-	provider "acp/internal/osc/provider"
+	"dhs/internal/osc/codec"
+	consumer "dhs/internal/osc/consumer"
+	provider "dhs/internal/osc/provider"
 )
 
 func quietLogger() *slog.Logger {

--- a/internal/osc/integration/oscjs_peer_test.go
+++ b/internal/osc/integration/oscjs_peer_test.go
@@ -37,9 +37,9 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/osc/codec"
-	consumer "acp/internal/osc/consumer"
-	provider "acp/internal/osc/provider"
+	"dhs/internal/osc/codec"
+	consumer "dhs/internal/osc/consumer"
+	provider "dhs/internal/osc/provider"
 )
 
 const harnessRel = "../assets/test-harness/harness.js"

--- a/internal/osc/integration/v10_tcp_loopback_test.go
+++ b/internal/osc/integration/v10_tcp_loopback_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/osc/codec"
-	consumer "acp/internal/osc/consumer"
-	provider "acp/internal/osc/provider"
+	"dhs/internal/osc/codec"
+	consumer "dhs/internal/osc/consumer"
+	provider "dhs/internal/osc/provider"
 )
 
 // TestV10_TCP_Loopback drives a v1.0 length-prefix TCP round-trip:

--- a/internal/osc/integration/v10_udp_loopback_test.go
+++ b/internal/osc/integration/v10_udp_loopback_test.go
@@ -15,9 +15,9 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/osc/codec"
-	consumer "acp/internal/osc/consumer"
-	provider "acp/internal/osc/provider"
+	"dhs/internal/osc/codec"
+	consumer "dhs/internal/osc/consumer"
+	provider "dhs/internal/osc/provider"
 )
 
 func TestV10_UDP_Loopback_Message(t *testing.T) {

--- a/internal/osc/integration/v11_slip_loopback_test.go
+++ b/internal/osc/integration/v11_slip_loopback_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/osc/codec"
-	consumer "acp/internal/osc/consumer"
-	provider "acp/internal/osc/provider"
+	"dhs/internal/osc/codec"
+	consumer "dhs/internal/osc/consumer"
+	provider "dhs/internal/osc/provider"
 )
 
 // TestV11_SLIP_Loopback_Message drives a v1.1 TCP round-trip with SLIP

--- a/internal/osc/provider/plugin.go
+++ b/internal/osc/provider/plugin.go
@@ -13,9 +13,9 @@ import (
 	"log/slog"
 	"net"
 
-	"acp/internal/export/canonical"
-	"acp/internal/osc/codec"
-	"acp/internal/provider"
+	"dhs/internal/export/canonical"
+	"dhs/internal/osc/codec"
+	"dhs/internal/provider"
 )
 
 func init() {

--- a/internal/osc/provider/sender.go
+++ b/internal/osc/provider/sender.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"syscall"
 
-	"acp/internal/osc/codec"
-	"acp/internal/transport"
+	"dhs/internal/osc/codec"
+	"dhs/internal/transport"
 )
 
 // udpSender owns the outbound UDP socket for OSC. SO_REUSEADDR lets

--- a/internal/osc/provider/sender_test.go
+++ b/internal/osc/provider/sender_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/osc/codec"
+	"dhs/internal/osc/codec"
 )
 
 func TestUDPSender_MessageReachesListener(t *testing.T) {

--- a/internal/osc/provider/tcp_dialer.go
+++ b/internal/osc/provider/tcp_dialer.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"acp/internal/osc/codec"
+	"dhs/internal/osc/codec"
 )
 
 // DefaultTCPKeepalivePeriod is the OS-layer SO_KEEPALIVE period applied

--- a/internal/probel-sw02p/CLAUDE.md
+++ b/internal/probel-sw02p/CLAUDE.md
@@ -279,7 +279,7 @@ Next-session priority: app-layer retry policy + reconnect + keepalive.
   one file.
 - Do NOT silently work around a spec deviation — always route through
   `compliance.Profile` so the event is observable.
-- Do NOT import `acp/internal/*` from `internal/probel-sw02p/codec/` —
+- Do NOT import `dhs/internal/*` from `internal/probel-sw02p/codec/` —
   codec is stdlib-only.
 - Do NOT add DLE-stuffing logic — SW-P-02 is transparent. If you
   find yourself reaching for DLE, STX, ETX, ACK, or NAK byte escapes,

--- a/internal/probel-sw02p/consumer/cmd_connect_test.go
+++ b/internal/probel-sw02p/consumer/cmd_connect_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // TestSendConnectRoundTrip drives SendConnect through a net.Pipe pair:

--- a/internal/probel-sw02p/consumer/cmd_dual_controller_test.go
+++ b/internal/probel-sw02p/consumer/cmd_dual_controller_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // TestSendDualControllerStatusRequestRoundTrip drives SendDualController

--- a/internal/probel-sw02p/consumer/cmd_ext_connect_on_go_test.go
+++ b/internal/probel-sw02p/consumer/cmd_ext_connect_on_go_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // TestSendExtendedConnectOnGoRoundTrip drives SendExtendedConnectOnGo

--- a/internal/probel-sw02p/consumer/cmd_ext_protect_tally_dump_req_test.go
+++ b/internal/probel-sw02p/consumer/cmd_ext_protect_tally_dump_req_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // TestSendExtendedProtectTallyDumpRequestWritesFrame drives

--- a/internal/probel-sw02p/consumer/cmd_extended_test.go
+++ b/internal/probel-sw02p/consumer/cmd_extended_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // TestSendExtendedInterrogateRoundTrip drives SendExtendedInterrogate

--- a/internal/probel-sw02p/consumer/cmd_interrogate_test.go
+++ b/internal/probel-sw02p/consumer/cmd_interrogate_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // TestSendInterrogateRoundTrip drives SendInterrogate through a net.Pipe

--- a/internal/probel-sw02p/consumer/cmd_protect_device_name_test.go
+++ b/internal/probel-sw02p/consumer/cmd_protect_device_name_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // TestSendProtectDeviceNameRequestRoundTrip drives SendProtectDevice

--- a/internal/probel-sw02p/consumer/cmd_protect_test.go
+++ b/internal/probel-sw02p/consumer/cmd_protect_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // TestSubscribeExtendedProtectTally confirms a matrix-side tx 96 is

--- a/internal/probel-sw02p/consumer/cmd_router_config_test.go
+++ b/internal/probel-sw02p/consumer/cmd_router_config_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // TestSendRouterConfigRequestRoundTripResponse1 drives SendRouter

--- a/internal/probel-sw02p/consumer/cmd_rx001_interrogate.go
+++ b/internal/probel-sw02p/consumer/cmd_rx001_interrogate.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // SendInterrogate emits rx 01 INTERROGATE (§3.2.3) and waits for the

--- a/internal/probel-sw02p/consumer/cmd_rx002_connect.go
+++ b/internal/probel-sw02p/consumer/cmd_rx002_connect.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // SendConnect emits rx 02 CONNECT (§3.2.4) and waits for the matching

--- a/internal/probel-sw02p/consumer/cmd_rx005_connect_on_go.go
+++ b/internal/probel-sw02p/consumer/cmd_rx005_connect_on_go.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // SendConnectOnGo emits rx 05 CONNECT ON GO (§3.2.7) and waits for the

--- a/internal/probel-sw02p/consumer/cmd_rx006_go.go
+++ b/internal/probel-sw02p/consumer/cmd_rx006_go.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // SendGo emits rx 06 GO (§3.2.8) and waits for the matching tx 13 GO

--- a/internal/probel-sw02p/consumer/cmd_rx007_status_request.go
+++ b/internal/probel-sw02p/consumer/cmd_rx007_status_request.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // SendStatusRequest emits rx 07 STATUS REQUEST (§3.2.9) targeting the

--- a/internal/probel-sw02p/consumer/cmd_rx014_source_lock_status_request.go
+++ b/internal/probel-sw02p/consumer/cmd_rx014_source_lock_status_request.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // SendSourceLockStatusRequest emits rx 014 SOURCE LOCK STATUS REQUEST

--- a/internal/probel-sw02p/consumer/cmd_rx035_connect_on_go_group_salvo.go
+++ b/internal/probel-sw02p/consumer/cmd_rx035_connect_on_go_group_salvo.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // SendConnectOnGoGroupSalvo emits rx 35 (§3.2.36) and waits for the

--- a/internal/probel-sw02p/consumer/cmd_rx036_go_group_salvo.go
+++ b/internal/probel-sw02p/consumer/cmd_rx036_go_group_salvo.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // SendGoGroupSalvo emits rx 36 (§3.2.37) and waits for tx 38 GO DONE

--- a/internal/probel-sw02p/consumer/cmd_rx050_dual_controller_status_request.go
+++ b/internal/probel-sw02p/consumer/cmd_rx050_dual_controller_status_request.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // SendDualControllerStatusRequest emits rx 050 DUAL CONTROLLER STATUS

--- a/internal/probel-sw02p/consumer/cmd_rx065_extended_interrogate.go
+++ b/internal/probel-sw02p/consumer/cmd_rx065_extended_interrogate.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // SendExtendedInterrogate emits rx 65 Extended INTERROGATE (§3.2.47)

--- a/internal/probel-sw02p/consumer/cmd_rx066_extended_connect.go
+++ b/internal/probel-sw02p/consumer/cmd_rx066_extended_connect.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // SendExtendedConnect emits rx 66 Extended CONNECT (§3.2.48) and waits

--- a/internal/probel-sw02p/consumer/cmd_rx069_extended_connect_on_go.go
+++ b/internal/probel-sw02p/consumer/cmd_rx069_extended_connect_on_go.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // SendExtendedConnectOnGo emits rx 069 Extended CONNECT ON GO

--- a/internal/probel-sw02p/consumer/cmd_rx071_extended_connect_on_go_group_salvo.go
+++ b/internal/probel-sw02p/consumer/cmd_rx071_extended_connect_on_go_group_salvo.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // SendExtendedConnectOnGoGroupSalvo emits rx 71 (§3.2.53) and waits

--- a/internal/probel-sw02p/consumer/cmd_rx075_router_config_request.go
+++ b/internal/probel-sw02p/consumer/cmd_rx075_router_config_request.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // RouterConfigResponse captures either tx 076 RESPONSE-1 (§3.2.58)

--- a/internal/probel-sw02p/consumer/cmd_rx101_extended_protect_interrogate.go
+++ b/internal/probel-sw02p/consumer/cmd_rx101_extended_protect_interrogate.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // SendExtendedProtectInterrogate emits rx 101 Extended PROTECT

--- a/internal/probel-sw02p/consumer/cmd_rx102_extended_protect_connect.go
+++ b/internal/probel-sw02p/consumer/cmd_rx102_extended_protect_connect.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // SendExtendedProtectConnect emits rx 102 Extended PROTECT CONNECT

--- a/internal/probel-sw02p/consumer/cmd_rx103_protect_device_name_request.go
+++ b/internal/probel-sw02p/consumer/cmd_rx103_protect_device_name_request.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // SendProtectDeviceNameRequest emits rx 103 PROTECT DEVICE NAME

--- a/internal/probel-sw02p/consumer/cmd_rx104_extended_protect_disconnect.go
+++ b/internal/probel-sw02p/consumer/cmd_rx104_extended_protect_disconnect.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // SendExtendedProtectDisconnect emits rx 104 Extended PROTECT

--- a/internal/probel-sw02p/consumer/cmd_rx105_extended_protect_tally_dump_request.go
+++ b/internal/probel-sw02p/consumer/cmd_rx105_extended_protect_tally_dump_request.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // SendExtendedProtectTallyDumpRequest emits rx 105 Extended PROTECT

--- a/internal/probel-sw02p/consumer/cmd_salvo_test.go
+++ b/internal/probel-sw02p/consumer/cmd_salvo_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // TestSendConnectOnGoRoundTrip drives the consumer's SendConnectOnGo

--- a/internal/probel-sw02p/consumer/cmd_source_lock_test.go
+++ b/internal/probel-sw02p/consumer/cmd_source_lock_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // TestSendSourceLockStatusRequestRoundTrip drives SendSourceLockStatus

--- a/internal/probel-sw02p/consumer/cmd_status_test.go
+++ b/internal/probel-sw02p/consumer/cmd_status_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // TestSendStatusRequestRoundTrip drives SendStatusRequest through a

--- a/internal/probel-sw02p/consumer/cmd_tally_dump_test.go
+++ b/internal/probel-sw02p/consumer/cmd_tally_dump_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // TestSubscribeExtendedProtectTallyDump drives a tx 100 across a

--- a/internal/probel-sw02p/consumer/cmd_tx096_extended_protect_tally.go
+++ b/internal/probel-sw02p/consumer/cmd_tx096_extended_protect_tally.go
@@ -1,7 +1,7 @@
 package probelsw02p
 
 import (
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // SubscribeExtendedProtectTally registers fn as a listener for tx 96

--- a/internal/probel-sw02p/consumer/cmd_tx097_extended_protect_connected.go
+++ b/internal/probel-sw02p/consumer/cmd_tx097_extended_protect_connected.go
@@ -1,7 +1,7 @@
 package probelsw02p
 
 import (
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // SubscribeExtendedProtectConnected registers fn as a listener for

--- a/internal/probel-sw02p/consumer/cmd_tx098_extended_protect_disconnected.go
+++ b/internal/probel-sw02p/consumer/cmd_tx098_extended_protect_disconnected.go
@@ -1,7 +1,7 @@
 package probelsw02p
 
 import (
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // SubscribeExtendedProtectDisconnected registers fn as a listener for

--- a/internal/probel-sw02p/consumer/cmd_tx100_extended_protect_tally_dump.go
+++ b/internal/probel-sw02p/consumer/cmd_tx100_extended_protect_tally_dump.go
@@ -1,7 +1,7 @@
 package probelsw02p
 
 import (
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // SubscribeExtendedProtectTallyDump registers fn as a listener for

--- a/internal/probel-sw02p/consumer/keepalive.go
+++ b/internal/probel-sw02p/consumer/keepalive.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"time"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // startKeepalive spawns the background goroutine that handles two

--- a/internal/probel-sw02p/consumer/keepalive_test.go
+++ b/internal/probel-sw02p/consumer/keepalive_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // pipeClient builds a codec.Client wrapping one end of a net.Pipe and

--- a/internal/probel-sw02p/consumer/metrics_helpers.go
+++ b/internal/probel-sw02p/consumer/metrics_helpers.go
@@ -1,6 +1,6 @@
 package probelsw02p
 
-import "acp/internal/probel-sw02p/codec"
+import "dhs/internal/probel-sw02p/codec"
 
 // probelCmdFromBytes extracts the SW-P-02 command byte from a raw
 // frame's wire bytes. Returns (cmd, true) for a well-formed frame

--- a/internal/probel-sw02p/consumer/plugin.go
+++ b/internal/probel-sw02p/consumer/plugin.go
@@ -23,11 +23,11 @@ import (
 	"sync"
 	"time"
 
-	"acp/internal/metrics"
-	"acp/internal/probel-sw02p/codec"
-	"acp/internal/protocol"
-	"acp/internal/protocol/compliance"
-	"acp/internal/transport"
+	"dhs/internal/metrics"
+	"dhs/internal/probel-sw02p/codec"
+	"dhs/internal/protocol"
+	"dhs/internal/protocol/compliance"
+	"dhs/internal/transport"
 )
 
 // DefaultOnlineStaleAfter is the default "no rx traffic observed for

--- a/internal/probel-sw02p/consumer/plugin_test.go
+++ b/internal/probel-sw02p/consumer/plugin_test.go
@@ -6,7 +6,7 @@ import (
 	"log/slog"
 	"testing"
 
-	"acp/internal/protocol"
+	"dhs/internal/protocol"
 )
 
 // TestFactoryMeta verifies the registration contract: the plugin

--- a/internal/probel-sw02p/consumer/types.go
+++ b/internal/probel-sw02p/consumer/types.go
@@ -1,6 +1,6 @@
 package probelsw02p
 
-import "acp/internal/probel-sw02p/codec"
+import "dhs/internal/probel-sw02p/codec"
 
 // DefaultPort is the TCP port this plugin binds when the caller does
 // not supply one. Mirror of codec.DefaultPort so cmd/ code can import

--- a/internal/probel-sw02p/provider/cmd_connect_test.go
+++ b/internal/probel-sw02p/provider/cmd_connect_test.go
@@ -3,7 +3,7 @@ package probelsw02p
 import (
 	"testing"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // TestConnectAppliesRouteAndBroadcastsConnected locks in the rx 02 /

--- a/internal/probel-sw02p/provider/cmd_dual_controller_test.go
+++ b/internal/probel-sw02p/provider/cmd_dual_controller_test.go
@@ -3,7 +3,7 @@ package probelsw02p
 import (
 	"testing"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // TestDualControllerStatusRequestRepliesMasterHealthy locks in the

--- a/internal/probel-sw02p/provider/cmd_ext_connect_on_go_test.go
+++ b/internal/probel-sw02p/provider/cmd_ext_connect_on_go_test.go
@@ -3,7 +3,7 @@ package probelsw02p
 import (
 	"testing"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // TestExtendedConnectOnGoStagesAndAcks locks rx 069 / tx 070: one

--- a/internal/probel-sw02p/provider/cmd_ext_protect_connect_test.go
+++ b/internal/probel-sw02p/provider/cmd_ext_protect_connect_test.go
@@ -3,7 +3,7 @@ package probelsw02p
 import (
 	"testing"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // TestExtendedProtectConnectAcceptsNoneAndBroadcasts locks in the

--- a/internal/probel-sw02p/provider/cmd_ext_protect_disconnect_test.go
+++ b/internal/probel-sw02p/provider/cmd_ext_protect_disconnect_test.go
@@ -3,7 +3,7 @@ package probelsw02p
 import (
 	"testing"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // TestExtendedProtectDisconnectNoOpReturnsNone locks in the no-op

--- a/internal/probel-sw02p/provider/cmd_ext_protect_interrogate_test.go
+++ b/internal/probel-sw02p/provider/cmd_ext_protect_interrogate_test.go
@@ -3,7 +3,7 @@ package probelsw02p
 import (
 	"testing"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // TestExtendedProtectInterrogateNoEntryReportsNone locks in the

--- a/internal/probel-sw02p/provider/cmd_ext_protect_tally_dump_req_test.go
+++ b/internal/probel-sw02p/provider/cmd_ext_protect_tally_dump_req_test.go
@@ -3,7 +3,7 @@ package probelsw02p
 import (
 	"testing"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // TestTallyDumpRequestEmptyReturnsZero confirms a bare-state server

--- a/internal/probel-sw02p/provider/cmd_extended_test.go
+++ b/internal/probel-sw02p/provider/cmd_extended_test.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"testing"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // newBareTestServer returns a provider with no canonical tree —

--- a/internal/probel-sw02p/provider/cmd_interrogate_test.go
+++ b/internal/probel-sw02p/provider/cmd_interrogate_test.go
@@ -3,7 +3,7 @@ package probelsw02p
 import (
 	"testing"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // TestInterrogateRepliesWithTally locks in the rx 01 / tx 03 contract

--- a/internal/probel-sw02p/provider/cmd_protect_device_name_test.go
+++ b/internal/probel-sw02p/provider/cmd_protect_device_name_test.go
@@ -3,7 +3,7 @@ package probelsw02p
 import (
 	"testing"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // TestProtectDeviceNameRequestRepliesWithSelfName locks in the

--- a/internal/probel-sw02p/provider/cmd_protect_test.go
+++ b/internal/probel-sw02p/provider/cmd_protect_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // TestExtendedProtectEmitFanout confirms the three Emit* helpers fan

--- a/internal/probel-sw02p/provider/cmd_router_config_test.go
+++ b/internal/probel-sw02p/provider/cmd_router_config_test.go
@@ -5,8 +5,8 @@ import (
 	"log/slog"
 	"testing"
 
-	"acp/internal/export/canonical"
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/export/canonical"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // TestRouterConfigRequestDerivedFromTree drives rx 075 through the

--- a/internal/probel-sw02p/provider/cmd_rx001_interrogate.go
+++ b/internal/probel-sw02p/provider/cmd_rx001_interrogate.go
@@ -1,7 +1,7 @@
 package probelsw02p
 
 import (
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // handleInterrogate processes rx 01 INTERROGATE (§3.2.3). Controller

--- a/internal/probel-sw02p/provider/cmd_rx002_connect.go
+++ b/internal/probel-sw02p/provider/cmd_rx002_connect.go
@@ -1,7 +1,7 @@
 package probelsw02p
 
 import (
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // handleConnect processes rx 02 CONNECT (§3.2.4). Controller requests

--- a/internal/probel-sw02p/provider/cmd_rx005_connect_on_go.go
+++ b/internal/probel-sw02p/provider/cmd_rx005_connect_on_go.go
@@ -1,7 +1,7 @@
 package probelsw02p
 
 import (
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // handleConnectOnGo processes rx 05 CONNECT ON GO (§3.2.7). Each frame

--- a/internal/probel-sw02p/provider/cmd_rx006_go.go
+++ b/internal/probel-sw02p/provider/cmd_rx006_go.go
@@ -1,7 +1,7 @@
 package probelsw02p
 
 import (
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // handleGo processes rx 06 GO (§3.2.8). Drains the matrix's pending

--- a/internal/probel-sw02p/provider/cmd_rx007_status_request.go
+++ b/internal/probel-sw02p/provider/cmd_rx007_status_request.go
@@ -1,7 +1,7 @@
 package probelsw02p
 
 import (
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // handleStatusRequest processes rx 07 STATUS REQUEST (§3.2.9).

--- a/internal/probel-sw02p/provider/cmd_rx014_source_lock_status_request.go
+++ b/internal/probel-sw02p/provider/cmd_rx014_source_lock_status_request.go
@@ -1,7 +1,7 @@
 package probelsw02p
 
 import (
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // handleSourceLockStatusRequest processes rx 014 SOURCE LOCK STATUS

--- a/internal/probel-sw02p/provider/cmd_rx035_connect_on_go_group_salvo.go
+++ b/internal/probel-sw02p/provider/cmd_rx035_connect_on_go_group_salvo.go
@@ -1,7 +1,7 @@
 package probelsw02p
 
 import (
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // handleConnectOnGoGroupSalvo processes rx 35 CONNECT ON GO GROUP

--- a/internal/probel-sw02p/provider/cmd_rx036_go_group_salvo.go
+++ b/internal/probel-sw02p/provider/cmd_rx036_go_group_salvo.go
@@ -1,7 +1,7 @@
 package probelsw02p
 
 import (
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // handleGoGroupSalvo processes rx 36 GO GROUP SALVO (§3.2.37). Drains

--- a/internal/probel-sw02p/provider/cmd_rx050_dual_controller_status_request.go
+++ b/internal/probel-sw02p/provider/cmd_rx050_dual_controller_status_request.go
@@ -1,7 +1,7 @@
 package probelsw02p
 
 import (
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // handleDualControllerStatusRequest processes rx 050 DUAL CONTROLLER

--- a/internal/probel-sw02p/provider/cmd_rx065_extended_interrogate.go
+++ b/internal/probel-sw02p/provider/cmd_rx065_extended_interrogate.go
@@ -1,7 +1,7 @@
 package probelsw02p
 
 import (
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // handleExtendedInterrogate processes rx 65 Extended INTERROGATE

--- a/internal/probel-sw02p/provider/cmd_rx066_extended_connect.go
+++ b/internal/probel-sw02p/provider/cmd_rx066_extended_connect.go
@@ -1,7 +1,7 @@
 package probelsw02p
 
 import (
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // handleExtendedConnect processes rx 66 Extended CONNECT (§3.2.48).

--- a/internal/probel-sw02p/provider/cmd_rx069_extended_connect_on_go.go
+++ b/internal/probel-sw02p/provider/cmd_rx069_extended_connect_on_go.go
@@ -1,7 +1,7 @@
 package probelsw02p
 
 import (
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // handleExtendedConnectOnGo processes rx 069 Extended CONNECT ON GO

--- a/internal/probel-sw02p/provider/cmd_rx071_extended_connect_on_go_group_salvo.go
+++ b/internal/probel-sw02p/provider/cmd_rx071_extended_connect_on_go_group_salvo.go
@@ -1,7 +1,7 @@
 package probelsw02p
 
 import (
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // handleExtendedConnectOnGoGroupSalvo processes rx 71 Extended CONNECT

--- a/internal/probel-sw02p/provider/cmd_rx075_router_config_request.go
+++ b/internal/probel-sw02p/provider/cmd_rx075_router_config_request.go
@@ -1,7 +1,7 @@
 package probelsw02p
 
 import (
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // handleRouterConfigRequest processes rx 075 ROUTER CONFIGURATION

--- a/internal/probel-sw02p/provider/cmd_rx101_extended_protect_interrogate.go
+++ b/internal/probel-sw02p/provider/cmd_rx101_extended_protect_interrogate.go
@@ -1,7 +1,7 @@
 package probelsw02p
 
 import (
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // handleExtendedProtectInterrogate processes rx 101 Extended PROTECT

--- a/internal/probel-sw02p/provider/cmd_rx102_extended_protect_connect.go
+++ b/internal/probel-sw02p/provider/cmd_rx102_extended_protect_connect.go
@@ -1,7 +1,7 @@
 package probelsw02p
 
 import (
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // handleExtendedProtectConnect processes rx 102 Extended PROTECT

--- a/internal/probel-sw02p/provider/cmd_rx103_protect_device_name_request.go
+++ b/internal/probel-sw02p/provider/cmd_rx103_protect_device_name_request.go
@@ -1,7 +1,7 @@
 package probelsw02p
 
 import (
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // handleProtectDeviceNameRequest processes rx 103 PROTECT DEVICE

--- a/internal/probel-sw02p/provider/cmd_rx104_extended_protect_disconnect.go
+++ b/internal/probel-sw02p/provider/cmd_rx104_extended_protect_disconnect.go
@@ -1,7 +1,7 @@
 package probelsw02p
 
 import (
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // handleExtendedProtectDisconnect processes rx 104 Extended PROTECT

--- a/internal/probel-sw02p/provider/cmd_rx105_extended_protect_tally_dump_request.go
+++ b/internal/probel-sw02p/provider/cmd_rx105_extended_protect_tally_dump_request.go
@@ -1,7 +1,7 @@
 package probelsw02p
 
 import (
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // handleExtendedProtectTallyDumpRequest processes rx 105 Extended

--- a/internal/probel-sw02p/provider/cmd_salvo_test.go
+++ b/internal/probel-sw02p/provider/cmd_salvo_test.go
@@ -5,8 +5,8 @@ import (
 	"log/slog"
 	"testing"
 
-	"acp/internal/export/canonical"
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/export/canonical"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // newTestServer builds a minimal SW-P-02 provider against a 4×4

--- a/internal/probel-sw02p/provider/cmd_source_lock_test.go
+++ b/internal/probel-sw02p/provider/cmd_source_lock_test.go
@@ -3,7 +3,7 @@ package probelsw02p
 import (
 	"testing"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // TestSourceLockStatusRequestRepliesAllHealthy locks in the rx 014 /

--- a/internal/probel-sw02p/provider/cmd_status_test.go
+++ b/internal/probel-sw02p/provider/cmd_status_test.go
@@ -3,7 +3,7 @@ package probelsw02p
 import (
 	"testing"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // TestStatusRequestRepliesHealthyResponse2 locks in the rx 07 / tx 09

--- a/internal/probel-sw02p/provider/cmd_tally_dump_test.go
+++ b/internal/probel-sw02p/provider/cmd_tally_dump_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // TestEmitExtendedProtectTallyDumpFanout drives EmitExtendedProtect

--- a/internal/probel-sw02p/provider/cmd_tx096_extended_protect_tally.go
+++ b/internal/probel-sw02p/provider/cmd_tx096_extended_protect_tally.go
@@ -1,7 +1,7 @@
 package probelsw02p
 
 import (
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // EmitExtendedProtectTally broadcasts tx 96 Extended PROTECT TALLY

--- a/internal/probel-sw02p/provider/cmd_tx097_extended_protect_connected.go
+++ b/internal/probel-sw02p/provider/cmd_tx097_extended_protect_connected.go
@@ -1,7 +1,7 @@
 package probelsw02p
 
 import (
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // EmitExtendedProtectConnected broadcasts tx 97 Extended PROTECT

--- a/internal/probel-sw02p/provider/cmd_tx098_extended_protect_disconnected.go
+++ b/internal/probel-sw02p/provider/cmd_tx098_extended_protect_disconnected.go
@@ -1,7 +1,7 @@
 package probelsw02p
 
 import (
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // EmitExtendedProtectDisconnected broadcasts tx 98 Extended PROTECT

--- a/internal/probel-sw02p/provider/cmd_tx100_extended_protect_tally_dump.go
+++ b/internal/probel-sw02p/provider/cmd_tx100_extended_protect_tally_dump.go
@@ -3,7 +3,7 @@ package probelsw02p
 import (
 	"fmt"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // EmitExtendedProtectTallyDump broadcasts tx 100 Extended PROTECT

--- a/internal/probel-sw02p/provider/handlers.go
+++ b/internal/probel-sw02p/provider/handlers.go
@@ -3,7 +3,7 @@ package probelsw02p
 import (
 	"log/slog"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // handlerResult is what a per-command handler returns. The dispatcher

--- a/internal/probel-sw02p/provider/integration_test.go
+++ b/internal/probel-sw02p/provider/integration_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
-	consumer "acp/internal/probel-sw02p/consumer"
-	"acp/internal/probel-sw02p/codec"
-	provider "acp/internal/probel-sw02p/provider"
-	"acp/internal/export/canonical"
+	consumer "dhs/internal/probel-sw02p/consumer"
+	"dhs/internal/probel-sw02p/codec"
+	provider "dhs/internal/probel-sw02p/provider"
+	"dhs/internal/export/canonical"
 )
 
 var _ = os.Getenv

--- a/internal/probel-sw02p/provider/plugin.go
+++ b/internal/probel-sw02p/provider/plugin.go
@@ -19,9 +19,9 @@ package probelsw02p
 import (
 	"log/slog"
 
-	"acp/internal/export/canonical"
-	"acp/internal/probel-sw02p/codec"
-	"acp/internal/provider"
+	"dhs/internal/export/canonical"
+	"dhs/internal/probel-sw02p/codec"
+	"dhs/internal/provider"
 )
 
 // DefaultPort mirrors the consumer's default SW-P-02 TCP port.

--- a/internal/probel-sw02p/provider/plugin_test.go
+++ b/internal/probel-sw02p/provider/plugin_test.go
@@ -5,8 +5,8 @@ import (
 	"log/slog"
 	"testing"
 
-	"acp/internal/export/canonical"
-	"acp/internal/provider"
+	"dhs/internal/export/canonical"
+	"dhs/internal/provider"
 )
 
 // TestFactoryMeta verifies the provider registration contract.

--- a/internal/probel-sw02p/provider/salvo_connected.go
+++ b/internal/probel-sw02p/provider/salvo_connected.go
@@ -1,7 +1,7 @@
 package probelsw02p
 
 import (
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // salvoConnectedFrame builds the CONNECTED broadcast frame for a slot

--- a/internal/probel-sw02p/provider/server.go
+++ b/internal/probel-sw02p/provider/server.go
@@ -8,10 +8,10 @@ import (
 	"net"
 	"sync"
 
-	"acp/internal/export/canonical"
-	"acp/internal/metrics"
-	"acp/internal/probel-sw02p/codec"
-	"acp/internal/protocol/compliance"
+	"dhs/internal/export/canonical"
+	"dhs/internal/metrics"
+	"dhs/internal/probel-sw02p/codec"
+	"dhs/internal/protocol/compliance"
 )
 
 // Server is the exported alias for the concrete SW-P-02 provider.

--- a/internal/probel-sw02p/provider/session.go
+++ b/internal/probel-sw02p/provider/session.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // session is one connected SW-P-02 client. It owns the TCP socket,

--- a/internal/probel-sw02p/provider/tree.go
+++ b/internal/probel-sw02p/provider/tree.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"sync"
 
-	"acp/internal/export/canonical"
-	"acp/internal/probel-sw02p/codec"
+	"dhs/internal/export/canonical"
+	"dhs/internal/probel-sw02p/codec"
 )
 
 // matrixKey identifies one (matrix, level) pair within an SW-P-02

--- a/internal/probel-sw08p/CLAUDE.md
+++ b/internal/probel-sw08p/CLAUDE.md
@@ -281,5 +281,5 @@ sentinel. Fixed by switching to `map[uint16]uint16` in commit
 - Do NOT combine multiple commands in one file. One command byte = one file.
 - Do NOT silently work around a spec deviation — always route through
   `compliance.Profile` so the event is observable.
-- Do NOT import `acp/internal/*` from `internal/probel-sw08p/codec/` — codec is
+- Do NOT import `dhs/internal/*` from `internal/probel-sw08p/codec/` — codec is
   stdlib-only.

--- a/internal/probel-sw08p/consumer/cmd_rx001_crosspoint_interrogate.go
+++ b/internal/probel-sw08p/consumer/cmd_rx001_crosspoint_interrogate.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw08p/codec"
-	"acp/internal/protocol"
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/protocol"
 )
 
 // CrosspointInterrogate queries the current source routed to one

--- a/internal/probel-sw08p/consumer/cmd_rx002_crosspoint_connect.go
+++ b/internal/probel-sw08p/consumer/cmd_rx002_crosspoint_connect.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw08p/codec"
-	"acp/internal/protocol"
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/protocol"
 )
 
 // CrosspointConnect asks the matrix to route src → dst on

--- a/internal/probel-sw08p/consumer/cmd_rx007_maintenance.go
+++ b/internal/probel-sw08p/consumer/cmd_rx007_maintenance.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // Maintenance fires a rx 007 Maintenance Message. SW-P-08 does not

--- a/internal/probel-sw08p/consumer/cmd_rx008_dual_controller_status.go
+++ b/internal/probel-sw08p/consumer/cmd_rx008_dual_controller_status.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw08p/codec"
-	"acp/internal/protocol"
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/protocol"
 )
 
 // DualControllerStatus queries the 1:1 redundancy state (master vs.

--- a/internal/probel-sw08p/consumer/cmd_rx010_protect_interrogate.go
+++ b/internal/probel-sw08p/consumer/cmd_rx010_protect_interrogate.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw08p/codec"
-	"acp/internal/protocol"
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/protocol"
 )
 
 // ProtectInterrogate asks the matrix "what is the protect state of this

--- a/internal/probel-sw08p/consumer/cmd_rx012_protect_connect.go
+++ b/internal/probel-sw08p/consumer/cmd_rx012_protect_connect.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw08p/codec"
-	"acp/internal/protocol"
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/protocol"
 )
 
 // ProtectConnect requests protection on (matrix, level, dst) owned by

--- a/internal/probel-sw08p/consumer/cmd_rx014_protect_disconnect.go
+++ b/internal/probel-sw08p/consumer/cmd_rx014_protect_disconnect.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw08p/codec"
-	"acp/internal/protocol"
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/protocol"
 )
 
 // ProtectDisconnect releases the protect on (matrix, level, dst) owned

--- a/internal/probel-sw08p/consumer/cmd_rx017_protect_device_name_request.go
+++ b/internal/probel-sw08p/consumer/cmd_rx017_protect_device_name_request.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw08p/codec"
-	"acp/internal/protocol"
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/protocol"
 )
 
 // ProtectDeviceName resolves a deviceID (0-1023) to its 8-char ASCII

--- a/internal/probel-sw08p/consumer/cmd_rx019_protect_tally_dump_request.go
+++ b/internal/probel-sw08p/consumer/cmd_rx019_protect_tally_dump_request.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw08p/codec"
-	"acp/internal/protocol"
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/protocol"
 )
 
 // ProtectTallyDump requests the protect table for one (matrix, level),

--- a/internal/probel-sw08p/consumer/cmd_rx021_crosspoint_tally_dump.go
+++ b/internal/probel-sw08p/consumer/cmd_rx021_crosspoint_tally_dump.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw08p/codec"
-	"acp/internal/protocol"
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/protocol"
 )
 
 // TallyDumpResult carries the decoded reply of a CrosspointTallyDump

--- a/internal/probel-sw08p/consumer/cmd_rx029_master_protect_connect.go
+++ b/internal/probel-sw08p/consumer/cmd_rx029_master_protect_connect.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw08p/codec"
-	"acp/internal/protocol"
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/protocol"
 )
 
 // MasterProtectConnect is the override-flavoured Protect Connect used

--- a/internal/probel-sw08p/consumer/cmd_rx100_all_source_names.go
+++ b/internal/probel-sw08p/consumer/cmd_rx100_all_source_names.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw08p/codec"
-	"acp/internal/protocol"
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/protocol"
 )
 
 // AllSourceNames asks the matrix for every source name on one

--- a/internal/probel-sw08p/consumer/cmd_rx101_single_source_name.go
+++ b/internal/probel-sw08p/consumer/cmd_rx101_single_source_name.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw08p/codec"
-	"acp/internal/protocol"
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/protocol"
 )
 
 // SingleSourceName fetches one source's name. Per spec §3.3.19 Note 5,

--- a/internal/probel-sw08p/consumer/cmd_rx102_all_dest_assoc_names.go
+++ b/internal/probel-sw08p/consumer/cmd_rx102_all_dest_assoc_names.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw08p/codec"
-	"acp/internal/protocol"
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/protocol"
 )
 
 // AllDestAssocNames asks the matrix for every destination-association

--- a/internal/probel-sw08p/consumer/cmd_rx103_single_dest_assoc_name.go
+++ b/internal/probel-sw08p/consumer/cmd_rx103_single_dest_assoc_name.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw08p/codec"
-	"acp/internal/protocol"
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/protocol"
 )
 
 // SingleDestAssocName fetches one destination-association name.

--- a/internal/probel-sw08p/consumer/cmd_rx112_crosspoint_tie_line_interrogate.go
+++ b/internal/probel-sw08p/consumer/cmd_rx112_crosspoint_tie_line_interrogate.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw08p/codec"
-	"acp/internal/protocol"
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/protocol"
 )
 
 // TieLineInterrogate asks the matrix for a tie-line tally: the list

--- a/internal/probel-sw08p/consumer/cmd_rx114_all_source_assoc_names.go
+++ b/internal/probel-sw08p/consumer/cmd_rx114_all_source_assoc_names.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw08p/codec"
-	"acp/internal/protocol"
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/protocol"
 )
 
 // AllSourceAssocNames asks the matrix for every source-association

--- a/internal/probel-sw08p/consumer/cmd_rx115_single_source_assoc_name.go
+++ b/internal/probel-sw08p/consumer/cmd_rx115_single_source_assoc_name.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw08p/codec"
-	"acp/internal/protocol"
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/protocol"
 )
 
 // SingleSourceAssocName fetches one source-association name. Matrix

--- a/internal/probel-sw08p/consumer/cmd_rx117_update_name_request.go
+++ b/internal/probel-sw08p/consumer/cmd_rx117_update_name_request.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // UpdateNameRequest issues rx 117 UPDATE NAME REQUEST — a fire-and-

--- a/internal/probel-sw08p/consumer/cmd_rx120_crosspoint_connect_on_go_salvo.go
+++ b/internal/probel-sw08p/consumer/cmd_rx120_crosspoint_connect_on_go_salvo.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw08p/codec"
-	"acp/internal/protocol"
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/protocol"
 )
 
 // SalvoConnectOnGo appends one crosspoint to a salvo group. Repeat for

--- a/internal/probel-sw08p/consumer/cmd_rx121_crosspoint_go_salvo.go
+++ b/internal/probel-sw08p/consumer/cmd_rx121_crosspoint_go_salvo.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw08p/codec"
-	"acp/internal/protocol"
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/protocol"
 )
 
 // SalvoGo fires a salvo group: op=SalvoOpSet applies the stored routes,

--- a/internal/probel-sw08p/consumer/cmd_rx124_crosspoint_salvo_group_interrogate.go
+++ b/internal/probel-sw08p/consumer/cmd_rx124_crosspoint_salvo_group_interrogate.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"acp/internal/probel-sw08p/codec"
-	"acp/internal/protocol"
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/protocol"
 )
 
 // SalvoGroupInterrogate fetches one slot (ConnectIndex) of a salvo

--- a/internal/probel-sw08p/consumer/compliance_test.go
+++ b/internal/probel-sw08p/consumer/compliance_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // TestComplianceProfileNilBeforeConnect: accessing ComplianceProfile on a

--- a/internal/probel-sw08p/consumer/keepalive.go
+++ b/internal/probel-sw08p/consumer/keepalive.go
@@ -1,7 +1,7 @@
 package probelsw08p
 
 import (
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // installKeepaliveAutoResponder subscribes to the shared client's async

--- a/internal/probel-sw08p/consumer/keepalive_test.go
+++ b/internal/probel-sw08p/consumer/keepalive_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // TestKeepaliveAutoResponder: when the peer sends TxAppKeepaliveRequest

--- a/internal/probel-sw08p/consumer/metrics_helpers.go
+++ b/internal/probel-sw08p/consumer/metrics_helpers.go
@@ -1,6 +1,6 @@
 package probelsw08p
 
-import "acp/internal/probel-sw08p/codec"
+import "dhs/internal/probel-sw08p/codec"
 
 // probelCmdFromBytes extracts the SW-P-08 command byte from a raw
 // frame's wire bytes. Returns (cmd, true) for a well-formed

--- a/internal/probel-sw08p/consumer/plugin.go
+++ b/internal/probel-sw08p/consumer/plugin.go
@@ -23,11 +23,11 @@ import (
 	"sync"
 	"time"
 
-	"acp/internal/metrics"
-	"acp/internal/probel-sw08p/codec"
-	"acp/internal/protocol"
-	"acp/internal/protocol/compliance"
-	"acp/internal/transport"
+	"dhs/internal/metrics"
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/protocol"
+	"dhs/internal/protocol/compliance"
+	"dhs/internal/transport"
 )
 
 // DefaultOnlineStaleAfter is the default "no rx traffic observed for

--- a/internal/probel-sw08p/consumer/plugin_test.go
+++ b/internal/probel-sw08p/consumer/plugin_test.go
@@ -6,7 +6,7 @@ import (
 	"log/slog"
 	"testing"
 
-	"acp/internal/protocol"
+	"dhs/internal/protocol"
 )
 
 // TestFactoryMeta verifies the registration contract: the plugin

--- a/internal/probel-sw08p/consumer/types.go
+++ b/internal/probel-sw08p/consumer/types.go
@@ -1,7 +1,7 @@
 package probelsw08p
 
 import (
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // DefaultPort is the TCP port most Probel matrices expose for SW-P-08.

--- a/internal/probel-sw08p/provider/cmd_admin_test.go
+++ b/internal/probel-sw08p/provider/cmd_admin_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/probel-sw08p/codec"
-	probelproto "acp/internal/probel-sw08p/consumer"
+	"dhs/internal/probel-sw08p/codec"
+	probelproto "dhs/internal/probel-sw08p/consumer"
 )
 
 // TestMaintenanceClearProtectsUnit exercises the rx 007 ClearProtects

--- a/internal/probel-sw08p/provider/cmd_crosspoint_test.go
+++ b/internal/probel-sw08p/provider/cmd_crosspoint_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/probel-sw08p/codec"
-	"acp/internal/export/canonical"
-	probelproto "acp/internal/probel-sw08p/consumer"
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/export/canonical"
+	probelproto "dhs/internal/probel-sw08p/consumer"
 )
 
 // TestCrosspointInterrogateLoopback exercises the full rx 001 → tx 003

--- a/internal/probel-sw08p/provider/cmd_names_test.go
+++ b/internal/probel-sw08p/provider/cmd_names_test.go
@@ -3,7 +3,7 @@ package probelsw08p
 import (
 	"testing"
 
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // TestHandleAllSourceNames: loopback dispatch returns a tx 106 with

--- a/internal/probel-sw08p/provider/cmd_protect_test.go
+++ b/internal/probel-sw08p/provider/cmd_protect_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/probel-sw08p/codec"
-	probelproto "acp/internal/probel-sw08p/consumer"
+	"dhs/internal/probel-sw08p/codec"
+	probelproto "dhs/internal/probel-sw08p/consumer"
 )
 
 // TestProtectRoundTripLoopback exercises the full protect life-cycle

--- a/internal/probel-sw08p/provider/cmd_rx001_crosspoint_interrogate.go
+++ b/internal/probel-sw08p/provider/cmd_rx001_crosspoint_interrogate.go
@@ -1,7 +1,7 @@
 package probelsw08p
 
 import (
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // handleCrosspointInterrogate decodes the incoming interrogate, looks

--- a/internal/probel-sw08p/provider/cmd_rx002_crosspoint_connect.go
+++ b/internal/probel-sw08p/provider/cmd_rx002_crosspoint_connect.go
@@ -1,7 +1,7 @@
 package probelsw08p
 
 import (
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // handleCrosspointConnect decodes the connect request, records the

--- a/internal/probel-sw08p/provider/cmd_rx007_maintenance.go
+++ b/internal/probel-sw08p/provider/cmd_rx007_maintenance.go
@@ -3,7 +3,7 @@ package probelsw08p
 import (
 	"log/slog"
 
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // handleMaintenance decodes the function byte and logs it; ClearProtects

--- a/internal/probel-sw08p/provider/cmd_rx008_dual_controller_status.go
+++ b/internal/probel-sw08p/provider/cmd_rx008_dual_controller_status.go
@@ -1,7 +1,7 @@
 package probelsw08p
 
 import (
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // handleDualControllerStatus reports the redundancy state of this

--- a/internal/probel-sw08p/provider/cmd_rx010_protect_interrogate.go
+++ b/internal/probel-sw08p/provider/cmd_rx010_protect_interrogate.go
@@ -1,7 +1,7 @@
 package probelsw08p
 
 import (
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // handleProtectInterrogate replies with the current protect state of

--- a/internal/probel-sw08p/provider/cmd_rx012_protect_connect.go
+++ b/internal/probel-sw08p/provider/cmd_rx012_protect_connect.go
@@ -1,7 +1,7 @@
 package probelsw08p
 
 import (
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // handleProtectConnect installs a Probel-class protect on (matrix,

--- a/internal/probel-sw08p/provider/cmd_rx014_protect_disconnect.go
+++ b/internal/probel-sw08p/provider/cmd_rx014_protect_disconnect.go
@@ -1,7 +1,7 @@
 package probelsw08p
 
 import (
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // handleProtectDisconnect releases the protect iff the caller owns it.

--- a/internal/probel-sw08p/provider/cmd_rx017_protect_device_name.go
+++ b/internal/probel-sw08p/provider/cmd_rx017_protect_device_name.go
@@ -1,7 +1,7 @@
 package probelsw08p
 
 import (
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // handleProtectDeviceNameRequest resolves the device-id to a name via

--- a/internal/probel-sw08p/provider/cmd_rx019_protect_tally_dump.go
+++ b/internal/probel-sw08p/provider/cmd_rx019_protect_tally_dump.go
@@ -1,7 +1,7 @@
 package probelsw08p
 
 import (
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // handleProtectTallyDumpRequest dumps the protect table starting at

--- a/internal/probel-sw08p/provider/cmd_rx021_crosspoint_tally_dump.go
+++ b/internal/probel-sw08p/provider/cmd_rx021_crosspoint_tally_dump.go
@@ -1,7 +1,7 @@
 package probelsw08p
 
 import (
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // Per-frame tally caps. SW-P-08 soft-caps DATA at 128 bytes (§2), so:

--- a/internal/probel-sw08p/provider/cmd_rx029_master_protect_connect.go
+++ b/internal/probel-sw08p/provider/cmd_rx029_master_protect_connect.go
@@ -1,7 +1,7 @@
 package probelsw08p
 
 import (
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // handleMasterProtectConnect is Protect Connect with override=true —

--- a/internal/probel-sw08p/provider/cmd_rx100_all_source_names.go
+++ b/internal/probel-sw08p/provider/cmd_rx100_all_source_names.go
@@ -1,7 +1,7 @@
 package probelsw08p
 
 import (
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // handleAllSourceNames: rx 100 → tx 106.  Builds one tx 106 frame from

--- a/internal/probel-sw08p/provider/cmd_rx101_single_source_name.go
+++ b/internal/probel-sw08p/provider/cmd_rx101_single_source_name.go
@@ -1,7 +1,7 @@
 package probelsw08p
 
 import (
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // handleSingleSourceName: rx 101 → tx 106 with NumNames=1.

--- a/internal/probel-sw08p/provider/cmd_rx102_all_dest_assoc_names.go
+++ b/internal/probel-sw08p/provider/cmd_rx102_all_dest_assoc_names.go
@@ -1,7 +1,7 @@
 package probelsw08p
 
 import (
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // handleAllDestAssocNames: rx 102 → tx 107.

--- a/internal/probel-sw08p/provider/cmd_rx103_single_dest_assoc_name.go
+++ b/internal/probel-sw08p/provider/cmd_rx103_single_dest_assoc_name.go
@@ -1,7 +1,7 @@
 package probelsw08p
 
 import (
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // handleSingleDestAssocName: rx 103 → tx 107 with NumNames=1.

--- a/internal/probel-sw08p/provider/cmd_rx112_crosspoint_tie_line_interrogate.go
+++ b/internal/probel-sw08p/provider/cmd_rx112_crosspoint_tie_line_interrogate.go
@@ -1,7 +1,7 @@
 package probelsw08p
 
 import (
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // handleTieLineInterrogate: rx 112 → tx 113.

--- a/internal/probel-sw08p/provider/cmd_rx114_all_source_assoc_names.go
+++ b/internal/probel-sw08p/provider/cmd_rx114_all_source_assoc_names.go
@@ -1,7 +1,7 @@
 package probelsw08p
 
 import (
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // handleAllSourceAssocNames: rx 114 → tx 116. Reuses the sources

--- a/internal/probel-sw08p/provider/cmd_rx115_single_source_assoc_name.go
+++ b/internal/probel-sw08p/provider/cmd_rx115_single_source_assoc_name.go
@@ -1,7 +1,7 @@
 package probelsw08p
 
 import (
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // handleSingleSourceAssocName: rx 115 → tx 116 with NumNames=1.

--- a/internal/probel-sw08p/provider/cmd_rx117_update_name_request.go
+++ b/internal/probel-sw08p/provider/cmd_rx117_update_name_request.go
@@ -3,7 +3,7 @@ package probelsw08p
 import (
 	"log/slog"
 
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // handleUpdateNameRequest: rx 117 — fire-and-forget label push.

--- a/internal/probel-sw08p/provider/cmd_rx120_crosspoint_connect_on_go_salvo.go
+++ b/internal/probel-sw08p/provider/cmd_rx120_crosspoint_connect_on_go_salvo.go
@@ -1,7 +1,7 @@
 package probelsw08p
 
 import (
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // handleSalvoConnectOnGo: rx 120 → tx 122. Appends the crosspoint to

--- a/internal/probel-sw08p/provider/cmd_rx121_crosspoint_go_salvo.go
+++ b/internal/probel-sw08p/provider/cmd_rx121_crosspoint_go_salvo.go
@@ -1,7 +1,7 @@
 package probelsw08p
 
 import (
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // handleSalvoGo: rx 121 → tx 123 (+ spontaneous tx 004 per applied slot on Set).

--- a/internal/probel-sw08p/provider/cmd_rx124_crosspoint_salvo_group_interrogate.go
+++ b/internal/probel-sw08p/provider/cmd_rx124_crosspoint_salvo_group_interrogate.go
@@ -1,7 +1,7 @@
 package probelsw08p
 
 import (
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // handleSalvoGroupInterrogate: rx 124 → tx 125. Returns one salvo slot

--- a/internal/probel-sw08p/provider/cmd_salvo_test.go
+++ b/internal/probel-sw08p/provider/cmd_salvo_test.go
@@ -3,7 +3,7 @@ package probelsw08p
 import (
 	"testing"
 
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // TestSalvoBuildFireInterrogate exercises the full salvo lifecycle on

--- a/internal/probel-sw08p/provider/cmd_tie_line_test.go
+++ b/internal/probel-sw08p/provider/cmd_tie_line_test.go
@@ -3,7 +3,7 @@ package probelsw08p
 import (
 	"testing"
 
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // TestHandleTieLineInterrogateEmpty: unrouted dst yields NumSrcs=0.

--- a/internal/probel-sw08p/provider/cmd_update_name_test.go
+++ b/internal/probel-sw08p/provider/cmd_update_name_test.go
@@ -3,7 +3,7 @@ package probelsw08p
 import (
 	"testing"
 
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // TestHandleUpdateNameSource: rx 117 with NameType=Source overwrites

--- a/internal/probel-sw08p/provider/compliance_test.go
+++ b/internal/probel-sw08p/provider/compliance_test.go
@@ -5,8 +5,8 @@ import (
 	"log/slog"
 	"testing"
 
-	"acp/internal/probel-sw08p/codec"
-	"acp/internal/export/canonical"
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/export/canonical"
 )
 
 // newComplianceServer builds a minimal provider against a 4×4 single-level

--- a/internal/probel-sw08p/provider/handlers.go
+++ b/internal/probel-sw08p/provider/handlers.go
@@ -1,7 +1,7 @@
 package probelsw08p
 
 import (
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // handlerResult is what a per-command handler returns:

--- a/internal/probel-sw08p/provider/integration_test.go
+++ b/internal/probel-sw08p/provider/integration_test.go
@@ -16,9 +16,9 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/export/canonical"
-	"acp/internal/probel-sw08p/codec"
-	cons "acp/internal/probel-sw08p/consumer"
+	"dhs/internal/export/canonical"
+	"dhs/internal/probel-sw08p/codec"
+	cons "dhs/internal/probel-sw08p/consumer"
 )
 
 // emptyExport is the smallest tree the provider accepts — enough to

--- a/internal/probel-sw08p/provider/keepalive.go
+++ b/internal/probel-sw08p/provider/keepalive.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"time"
 
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // DefaultKeepaliveInterval matches the TS emulator's heartbeat cadence.

--- a/internal/probel-sw08p/provider/keepalive_test.go
+++ b/internal/probel-sw08p/provider/keepalive_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/probel-sw08p/codec"
-	"acp/internal/export/canonical"
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/export/canonical"
 )
 
 // TestKeepaliveSchedulerSendsPings: with a short interval, the server

--- a/internal/probel-sw08p/provider/plugin.go
+++ b/internal/probel-sw08p/provider/plugin.go
@@ -18,9 +18,9 @@ package probelsw08p
 import (
 	"log/slog"
 
-	"acp/internal/probel-sw08p/codec"
-	"acp/internal/export/canonical"
-	"acp/internal/provider"
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/export/canonical"
+	"dhs/internal/provider"
 )
 
 // DefaultPort mirrors the consumer's default Probel TCP port.

--- a/internal/probel-sw08p/provider/server.go
+++ b/internal/probel-sw08p/provider/server.go
@@ -9,10 +9,10 @@ import (
 	"sync"
 	"time"
 
-	"acp/internal/export/canonical"
-	"acp/internal/metrics"
-	"acp/internal/probel-sw08p/codec"
-	"acp/internal/protocol/compliance"
+	"dhs/internal/export/canonical"
+	"dhs/internal/metrics"
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/protocol/compliance"
 )
 
 // Server is the exported alias for the concrete Probel provider. Mirrors

--- a/internal/probel-sw08p/provider/server_test.go
+++ b/internal/probel-sw08p/provider/server_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/probel-sw08p/codec"
-	"acp/internal/export/canonical"
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/export/canonical"
 )
 
 // TestTreeParsesDemoMatrix loads the demo fixture and verifies both

--- a/internal/probel-sw08p/provider/session.go
+++ b/internal/probel-sw08p/provider/session.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"acp/internal/probel-sw08p/codec"
+	"dhs/internal/probel-sw08p/codec"
 )
 
 // session is one connected SW-P-08 client (typically a controller).

--- a/internal/probel-sw08p/provider/tree.go
+++ b/internal/probel-sw08p/provider/tree.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"sync"
 
-	"acp/internal/export/canonical"
+	"dhs/internal/export/canonical"
 )
 
 // matrixKey identifies one (matrix, level) pair within a Probel tree.

--- a/internal/protocol/_template/plugin.go
+++ b/internal/protocol/_template/plugin.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"log/slog"
 
-	"acp/internal/protocol"
+	"dhs/internal/protocol"
 )
 
 // Register this plugin on import.

--- a/internal/protocol/errors.go
+++ b/internal/protocol/errors.go
@@ -34,12 +34,12 @@ var ErrWriteCoerced = errors.New("protocol: write accepted but value coerced")
 // access denied). Tree's value stays unchanged.
 var ErrWriteRejected = errors.New("protocol: write rejected by provider")
 
-// ACPError is the root of all protocol-family errors. Both transport-layer
+// DHSError is the root of all protocol-family errors. Both transport-layer
 // and object-layer failures implement this, so call sites can do one
 // errors.As check.
-type ACPError interface {
+type DHSError interface {
 	error
-	acpError() // tag method
+	dhsError() // tag method
 }
 
 // TransportError is returned for socket, framing, and timeout failures —
@@ -58,7 +58,7 @@ func (e *TransportError) Error() string {
 }
 
 func (e *TransportError) Unwrap() error { return e.Err }
-func (e *TransportError) acpError()     {}
+func (e *TransportError) dhsError()     {}
 
 // ValidationError is raised client-side before a request hits the wire
 // (out-of-range value, wrong type for the object, string too long, unknown
@@ -71,4 +71,4 @@ type ValidationError struct {
 func (e *ValidationError) Error() string {
 	return fmt.Sprintf("validation: %s: %s", e.Field, e.Reason)
 }
-func (e *ValidationError) acpError() {}
+func (e *ValidationError) dhsError() {}

--- a/internal/provider/iface.go
+++ b/internal/provider/iface.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	"log/slog"
 
-	"acp/internal/export/canonical"
+	"dhs/internal/export/canonical"
 )
 
 // Provider is the runtime contract: start serving on an address, stop cleanly.

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"testing"
 
-	"acp/internal/registry"
+	"dhs/internal/registry"
 )
 
 type stubFactory struct {

--- a/internal/scenario/runner.go
+++ b/internal/scenario/runner.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"acp/internal/acp2/consumer"
+	"dhs/internal/acp2/consumer"
 )
 
 // Run dispatches the scenario to the right per-protocol runner and

--- a/internal/scenario/scenario_test.go
+++ b/internal/scenario/scenario_test.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"acp/internal/scenario"
+	"dhs/internal/scenario"
 )
 
 // TestScenarios discovers every committed scenario under

--- a/internal/storage/tree_store.go
+++ b/internal/storage/tree_store.go
@@ -16,8 +16,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"acp/internal/export"
-	"acp/internal/protocol"
+	"dhs/internal/export"
+	"dhs/internal/protocol"
 )
 
 // TreeStore manages cached tree files on disk.

--- a/internal/storage/tree_store_test.go
+++ b/internal/storage/tree_store_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"acp/internal/protocol"
+	"dhs/internal/protocol"
 )
 
 func TestTreeStore_SaveLoad(t *testing.T) {

--- a/internal/tsl/CLAUDE.md
+++ b/internal/tsl/CLAUDE.md
@@ -158,7 +158,7 @@ Never silently absorb a deviation — fire the relevant compliance event.
 
 ## What NOT to do
 
-- Do NOT import `acp/internal/*` from `internal/tsl/codec/` — codec is stdlib-only.
+- Do NOT import `dhs/internal/*` from `internal/tsl/codec/` — codec is stdlib-only.
 - Do NOT hardcode tally-position semantics (`lh=preview` etc.) in the
   plugin. The plugin surfaces raw positional tallies; semantic mapping
   lives in the consumer UI / config layer.

--- a/internal/tsl/consumer/plugin.go
+++ b/internal/tsl/consumer/plugin.go
@@ -19,7 +19,7 @@ import (
 	"log/slog"
 	"net"
 
-	"acp/internal/protocol"
+	"dhs/internal/protocol"
 )
 
 func init() {

--- a/internal/tsl/consumer/session.go
+++ b/internal/tsl/consumer/session.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	"syscall"
 
-	"acp/internal/transport"
-	"acp/internal/tsl/codec"
+	"dhs/internal/transport"
+	"dhs/internal/tsl/codec"
 )
 
 // FrameV31Event is delivered to registered v3.1 handlers.

--- a/internal/tsl/consumer/session_test.go
+++ b/internal/tsl/consumer/session_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/tsl/codec"
+	"dhs/internal/tsl/codec"
 )
 
 func TestUDPSession_V31ReceiveAndDispatch(t *testing.T) {

--- a/internal/tsl/consumer/tcp_session.go
+++ b/internal/tsl/consumer/tcp_session.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"acp/internal/tsl/codec"
+	"dhs/internal/tsl/codec"
 )
 
 // tcpKeepalivePeriod sets SO_KEEPALIVE on accepted TCP connections.

--- a/internal/tsl/integration/v31_loopback_test.go
+++ b/internal/tsl/integration/v31_loopback_test.go
@@ -16,9 +16,9 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/tsl/codec"
-	consumer "acp/internal/tsl/consumer"
-	provider "acp/internal/tsl/provider"
+	"dhs/internal/tsl/codec"
+	consumer "dhs/internal/tsl/consumer"
+	provider "dhs/internal/tsl/provider"
 )
 
 func TestV31_Loopback(t *testing.T) {

--- a/internal/tsl/integration/v31_multiinstance_test.go
+++ b/internal/tsl/integration/v31_multiinstance_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/tsl/codec"
-	consumer "acp/internal/tsl/consumer"
-	provider "acp/internal/tsl/provider"
+	"dhs/internal/tsl/codec"
+	consumer "dhs/internal/tsl/consumer"
+	provider "dhs/internal/tsl/provider"
 )
 
 // TestV31_MultiInstance_SamePort verifies the SO_REUSEADDR multi-listener

--- a/internal/tsl/integration/v40_loopback_test.go
+++ b/internal/tsl/integration/v40_loopback_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/tsl/codec"
-	consumer "acp/internal/tsl/consumer"
-	provider "acp/internal/tsl/provider"
+	"dhs/internal/tsl/codec"
+	consumer "dhs/internal/tsl/consumer"
+	provider "dhs/internal/tsl/provider"
 )
 
 // TestV40_Loopback drives a full v4.0 round-trip (v3.1 block + CHKSUM +

--- a/internal/tsl/integration/v50_loopback_test.go
+++ b/internal/tsl/integration/v50_loopback_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/tsl/codec"
-	consumer "acp/internal/tsl/consumer"
-	provider "acp/internal/tsl/provider"
+	"dhs/internal/tsl/codec"
+	consumer "dhs/internal/tsl/consumer"
+	provider "dhs/internal/tsl/provider"
 )
 
 // TestV50_UDPLoopback_ASCII drives a single-DMSG ASCII v5.0 packet via

--- a/internal/tsl/provider/plugin.go
+++ b/internal/tsl/provider/plugin.go
@@ -12,9 +12,9 @@ import (
 	"log/slog"
 	"net"
 
-	"acp/internal/export/canonical"
-	"acp/internal/provider"
-	"acp/internal/tsl/codec"
+	"dhs/internal/export/canonical"
+	"dhs/internal/provider"
+	"dhs/internal/tsl/codec"
 )
 
 func init() {

--- a/internal/tsl/provider/sender.go
+++ b/internal/tsl/provider/sender.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"syscall"
 
-	"acp/internal/transport"
-	"acp/internal/tsl/codec"
+	"dhs/internal/transport"
+	"dhs/internal/tsl/codec"
 )
 
 // udpSender is shared across versions. It owns a single outbound UDP

--- a/internal/tsl/provider/sender_test.go
+++ b/internal/tsl/provider/sender_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"acp/internal/tsl/codec"
+	"dhs/internal/tsl/codec"
 )
 
 func TestUDPSender_V31SendReachesListener(t *testing.T) {

--- a/internal/tsl/provider/tcp_dialer.go
+++ b/internal/tsl/provider/tcp_dialer.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"acp/internal/tsl/codec"
+	"dhs/internal/tsl/codec"
 )
 
 // DefaultTCPKeepalivePeriod is the OS-layer SO_KEEPALIVE period applied

--- a/tools/gen-probel-tree/main.go
+++ b/tools/gen-probel-tree/main.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"time"
 
-	"acp/internal/export/canonical"
+	"dhs/internal/export/canonical"
 )
 
 func main() {


### PR DESCRIPTION
## What

Rename the Go module path from `acp` to `dhs` (Device Hub Systems) — the last surface still using the legacy connector name.

## Why

`acp` was the original ACP1-only product name. The product is now `dhs` (locked 2026-04-21) and the binary, CLI, and registry names already match. Every `import "acp/..."` was a daily reminder of the old branding and confused new contributors who landed on docs that said "Go module path is `acp` (legacy)". Per ADR-0015 the rename is one atomic change with no behaviour change.

Closes #204

## Scope

- [ ] acp1
- [ ] acp2
- [ ] transport
- [ ] export
- [ ] cli
- [ ] api
- [ ] core
- [x] ci / chore

## Type

- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] docs — documentation only
- [x] chore — maintenance, refactor, CI
- [ ] security — security fix or hardening

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `go.mod` | modified | `module acp` → `module dhs` |
| `.golangci.yml` | modified | depguard rules `pkg: acp/...` → `pkg: dhs/...` (8 lines) |
| `internal/protocol/errors.go` | modified | `ACPError` interface → `DHSError`; tag method `acpError()` → `dhsError()` |
| `internal/acp2/consumer/types.go` | modified | tag-method rename on `ACP2Error` + `AN2Error` |
| `internal/cerebrum-nb/codec/ws/doc.go` | modified | package comment `acp/*` → `dhs/*` |
| `cmd/dhs/`, `internal/{acp1,acp2,amwa,cerebrum-nb,diff,emberplus,export,osc,probel-sw02p,probel-sw08p,protocol,provider,registry,scenario,storage,tsl}/`, `tools/gen-probel-tree/` | modified | every `import "acp/..."` → `import "dhs/..."` (~365 lines, 384 .go files) |
| `README.md`, `agents.md`, `CLAUDE.md` | modified | legacy-name disclaimers replaced with explicit "acp survives only for ACP1/ACP2 wire protocols" rule |
| `docs/ARCHITECTURE.md` | modified | binary table `acp` / `acp-srv` → `dhs` / `dhs-srv` |
| `docs/VISION.md` | modified | section 13 "Relationship to `acp` today" → "Relationship to `dhs` today" |
| `internal/<proto>/CLAUDE.md` (cerebrum-nb, emberplus, osc, probel-sw02p, probel-sw08p, tsl) | modified | "Codec must not import `acp/*`" → "`dhs/*`" |
| `internal/amwa/docs/dependencies.md` | modified | layer / depguard examples |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go build ./...` | clean | — |
| `go vet ./...` | clean | — |
| `golangci-lint run` | clean (0 issues) | — |
| `go test ./...` | all packages OK | 0 |

## Device tested

- [ ] ACP1 emulator 10.6.239.113
- [ ] ACP2 real device 10.41.40.195
- [ ] Other (specify)
- [x] No device needed (pure rename — no behaviour change)

## Out of scope (explicitly kept)

- `internal/acp1/`, `internal/acp2/` directory names — these are protocol identifiers, not the legacy connector
- `ACP1`, `ACP2` symbols across the codebase
- `ACP1Error`, `ACP2Error` per-protocol error subclasses
- All wire / spec references to ACP1 and ACP2

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [x] One commit per ADR-0013 (no checkpoint commits)
- [ ] Integration tested on VM before PR (not applicable — pure rename, unit + lint coverage sufficient per @yboujraf judgement)

## Approval

@yboujraf — requesting review per ADR-0014 (codeowner approval gate before merge to main).
