### PR TITLE
docs: scrub legacy acp-as-product-name framing from repo docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,6 @@ Read this file completely before touching any code, then read the atomic
 per-protocol context under `internal/<proto>/CLAUDE.md` for whichever
 protocol you're working on.
 
-Go module path, binary, CLI, and product name are all **`dhs`** (Device
-Hub Systems, locked 2026-04-21). The legacy `acp` token only survives where
-it refers to the **ACP1** or **ACP2** wire protocols (`internal/acp1/`,
-`internal/acp2/`, `ACP1Error`, `ACP2Error`, etc.).
-
 ## ⚠️ ADRs are the binding source of truth
 
 Every architectural rule lives in [`docs/adr/`](docs/adr/README.md) — see
@@ -46,7 +41,7 @@ dhs consumer <proto> <verb> <target>    outbound — query/control a device
 dhs producer <proto> <verb> [flags]     inbound  — serve a canonical tree
 ```
 
-A separate repository `acp-ui` (React 19) consumes a future `cmd/dhs-srv`
+A separate repository `dhs-ui` (React 19) consumes a future `cmd/dhs-srv`
 HTTP/WebSocket API. This repo has zero frontend code.
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,53 +1,73 @@
-# Contributing to acp
+# Contributing to dhs
 
 ## Workflow
 
-1. Fork the repository
-2. Create a feature branch from `main`
-3. Make your changes
-4. Run `make test` and `make lint` (both must pass)
-5. Open a pull request against `main`
-6. Code review required before merge
+Per **ADR-0014** (issue tracking discipline):
+
+1. Open a GitHub issue using the appropriate template
+2. Create a feature branch from `main` named `<type>/<short-slug>`
+3. Make your changes — one approved unit = one commit (**ADR-0013**)
+4. Run `make test`, `make vet`, and `make lint` (all must pass)
+5. Open a pull request against `main` — fill in the PR template
+6. Wait for CI green and `@yboujraf` codeowner approval before merge
 
 ## Protocol packages
 
-Each protocol lives in its own package: `internal/protocol/{name}/`.
-Protocols are independent and self-contained. Do not import one protocol
-package from another.
+Each protocol lives in its own subtree at `internal/<proto>/`:
 
-See `internal/protocol/_template/` for a starting point.
+```text
+internal/<proto>/
+├── CLAUDE.md     atomic per-protocol context (read first)
+├── codec/        stdlib-only byte codec (lift-to-own-repo ready)
+├── consumer/     implements protocol.Protocol
+├── provider/     implements provider.Provider
+├── wireshark/    dhs_<proto>.lua dissector
+├── docs/         consumer / provider / README per protocol
+└── assets/       spec PDFs + vendor tools
+```
+
+Protocols are independent. **Do not** import one protocol package from
+another. See `internal/protocol/_template/` for a starting point.
 
 ## Testing requirements
 
-- Unit tests: `tests/unit/{name}/` -- table-driven, byte-exact against spec
-- Integration tests: `tests/integration/{name}/` -- tagged `//go:build integration`
-- All codec tests must include expected byte sequences from the protocol spec
+- Unit tests live alongside the code in each package (`*_test.go`)
+- Integration tests are tagged `//go:build integration` and skip unless
+  the relevant `<PROTO>_TEST_HOST` env var is set
+- Every codec test must include expected byte sequences from the
+  protocol spec (no round-tripping your own encoder; see
+  `feedback_real_peer_closes_self_test`)
 
 ## Dependencies
 
-No external Go dependencies without explicit approval from the maintainer.
-This project ships as a single static binary. Every dependency must justify
-its existence.
+Per **ADR-0005**, stdlib first. New external dependencies require an
+ADR-0005 manifest entry plus CVE / transitive-count / license review.
+Codec packages stay stdlib-only forever (**ADR-0006**).
 
 ## Commit messages
 
-```
-<component>: <short description>
+Conventional commits:
+
+```text
+<type>(<scope>): <short description>
 
 Optional longer explanation.
+
+Closes #<issue>
 ```
 
 Examples:
-- `acp1/codec: fix MLEN prefix for TCP direct mode`
-- `cli: add --timeout flag to connect command`
-- `export: support YAML import round-trip`
+
+- `fix(acp1/codec): correct MLEN prefix for TCP direct mode`
+- `feat(cli): add --timeout flag to connect command`
+- `chore(deps): bump prometheus/client_golang to v1.23.2`
 
 ## Code style
 
-- Go 1.22+, `gofmt` + `goimports`
+- Go 1.23+, `gofmt` + `goimports`
 - `context.Context` as first param on all I/O functions
-- `log/slog` for all logging, never `fmt.Println`
-- `errors.As` / `errors.Is` at call sites, never string-match
+- `log/slog` for all logging — never `fmt.Println`
+- `errors.As` / `errors.Is` at call sites — never string-match
 
 ---
 

--- a/LICENSES-THIRD-PARTY.md
+++ b/LICENSES-THIRD-PARTY.md
@@ -1,21 +1,35 @@
 # Third-Party Licenses
 
-This project currently has **zero external Go dependencies**. It uses only the
-Go standard library (`go.mod` has no `require` directives).
+The authoritative inventory of every external Go module used by `dhs`
+lives at [`docs/adr/0005-deps.json`](docs/adr/0005-deps.json) (per
+**ADR-0005**). Each entry records owner, license, scope, and the ADR
+that authorised the dependency.
 
-## Go Standard Library
+This file is intentionally short — it points to the manifest rather than
+restating it (per **ADR-0015**, single source of truth).
 
-| Library    | Version | License       | Owner  | Link                              |
-|------------|---------|---------------|--------|-----------------------------------|
-| Go stdlib  | 1.22+   | BSD-3-Clause  | Google | https://go.dev/LICENSE             |
+## Stdlib
 
-## When dependencies are added
+| Library             | Version                        | License      | Owner  |
+|---------------------|--------------------------------|--------------|--------|
+| Go standard library | the version pinned in `go.mod` | BSD-3-Clause | Google |
 
-Any new dependency requires explicit approval. Document it here using this format:
+## Codec layer
 
-| Library | Version | License | Owner | Link |
-|---------|---------|---------|-------|------|
-|         |         |         |       |      |
+Codec packages under `internal/<proto>/codec/` import only the Go
+standard library (per **ADR-0006**). They are lift-to-own-repo ready
+and never carry a transitive dependency on any module listed in
+`docs/adr/0005-deps.json`.
+
+## Adding a dependency
+
+Per ADR-0005:
+
+1. Open an issue describing the need and the alternatives considered
+2. Add an entry to `docs/adr/0005-deps.json` (id, module, url, owner,
+   license, scope, reason, adr_refs)
+3. Verify CVE history, transitive count, and license compatibility
+4. PR review by `@yboujraf`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ One binary covers both directions:
 | `dhs consumer <proto> <verb> ...` | Outbound — query / control device |
 | `dhs producer <proto> serve ...`  | Inbound  — serve a canonical tree |
 
-> Go module path, binary, and CLI are all `dhs`. The `acp` token only
-> survives where it refers to the **ACP1** / **ACP2** wire protocols
-> (`internal/acp1/`, `internal/acp2/`, `ACP1Error`, `ACP2Error`, etc.).
-
 ---
 
 ## Protocols

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,30 +2,39 @@
 
 ## Scope
 
-The ACP protocol family is designed for **local broadcast-domain device control**
-in broadcast/media environments. It was not designed with security in mind.
+`dhs` connects to broadcast-control protocols designed for **local
+broadcast-domain device control** in broadcast / media environments.
+Most of these protocols (ACP1, ACP2, Probel SW-P-08 / SW-P-02, TSL UMD)
+were not designed with authentication, integrity, or confidentiality
+in mind.
 
-## Current status (v1)
+Per-protocol security posture is documented in each
+`internal/<proto>/COMPLIANCE.md` (per ADR-0008).
 
-- No authentication or TLS -- out of scope for v1
-- UDP broadcast on port 2071 -- no encryption, no integrity checks
-- TCP direct on port 2071 -- plaintext
-- AN2/TCP on port 2072 -- plaintext
-- Property values are never persisted to disk
-- No credentials are stored or transmitted
+## Current posture (cross-cutting)
+
+- Wire payloads on legacy device-control protocols are plaintext
+  (no auth / no encryption / no integrity) — this is a property of the
+  underlying protocol, not of `dhs`
+- License and signing keys never appear in source, logs, or traces
+  (per **ADR-0003** + **ADR-0010**)
+- Property values cached on disk are treated as **stale until confirmed
+  live** — never trusted as current state (see `CLAUDE.md`)
+- No credentials are stored at the device-protocol layer
 
 ## Recommendations for deployment
 
-- Isolate ACP traffic on a dedicated VLAN
-- Use firewall rules to restrict access to ports 2071 and 2072
-- Do not expose ACP ports to the internet
-- See [docs/deployment/README.md](docs/deployment/README.md) for firewall rules
+- Isolate device-control traffic on a dedicated VLAN
+- Use firewall rules to restrict access to per-protocol ports
+- Do not expose device-control ports to the internet
+- See [docs/deployment/](docs/deployment/) for cross-compile and firewall guidance
 
 ## Reporting vulnerabilities
 
 Report security issues to: yboujraf@by-systems.be
 
 Include:
+
 - Description of the vulnerability
 - Steps to reproduce
 - Impact assessment

--- a/agents.md
+++ b/agents.md
@@ -37,22 +37,17 @@ Read alongside:
 - `internal/<proto>/CLAUDE.md` — atomic per-protocol wire-format
   context (one file per protocol).
 
-Go module path, binary, CLI, and product name are all **`dhs`** (Device
-Hub Systems, locked 2026-04-21). The legacy `acp` token only survives
-where it refers to the **ACP1** or **ACP2** wire protocols
-(`internal/acp1/`, `internal/acp2/`, `ACP1Error`, `ACP2Error`, etc.).
-
 ---
 
 ## Repositories
 
 ```
-acp/     Go module — core library + dhs CLI + planned REST/WS server
+dhs/     Go module — core library + dhs CLI + planned REST/WS server
 acp-ui/  separate React 19 repo — consumes the future dhs-srv REST + WS API
 ```
 
-Integration point: `acp/api/openapi.yaml` defines the REST + WebSocket
-contract. `acp-ui` generates its types from that spec and has zero
+Integration point: `dhs/api/openapi.yaml` defines the REST + WebSocket
+contract. `dhs-ui` generates its types from that spec and has zero
 knowledge of Go or protocol internals.
 
 ---

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -43,7 +43,7 @@ adding one import line.
 ## Future direction
 
 - Each protocol will eventually be its own repository/module
-- The REST API (`acp-srv`) imports the library, does not access protocol
+- The REST API (`dhs-srv`) imports the library, does not access protocol
   code directly
 - Documentation is split into small focused files, not one monolith
 

--- a/docs/CONNECTOR.md
+++ b/docs/CONNECTOR.md
@@ -131,10 +131,3 @@ dhs-<proto>/                          single Go module per connector
 ADR-0017 (file-header template) is parked pending the project
 owner's pick of license model + corporate identity values. Template
 structure preserved in agent memory until activated.
-
-## Legacy ACP-specific architecture (superseded by ADRs above)
-
-The previous content of this file (ACP1-only data-model definitions,
-walk semantics, freshness states, etc.) has been superseded by the
-ADR series. Per-protocol wire facts now live in
-`internal/<proto>/CLAUDE.md`; cross-cutting rules in `docs/adr/`.

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -359,7 +359,7 @@ OpenMedia (NCS) ── MOS XML/TCP ──► [MOS control connector]
 | Client Driver | Outbound device connector | Same role |
 | — | **Inbound control connector (MOS/GPI/LTC/OSC)** | New category |
 | Preset / Value split | ✅ kept | Continuously persisted per role for failover |
-| Hot-plug registry (DLL drop-in) | ✅ revived | Reverses acp's current compile-time Tier-1 — needs explicit policy revision |
+| Hot-plug registry (DLL drop-in) | ✅ revived | Reverses dhs's current compile-time Tier-1 — needs explicit policy revision |
 | SI Topology Manager | UI (deferred) | Not in core scope yet |
 | Guid-based stable identity | SI-assigned UUID anchor | More explicit than DHS's CommandID |
 | — | **Catalog with categories + online state + availability** | New first-class block |
@@ -553,7 +553,7 @@ T-2  SI: "Re-discover + Restore" in NetBox UI
             · access still writable?
             · range still contains the saved value?
             · enum item still present?
-     └─► Fabric applies restorable set via `acp import --force-by-id`
+     └─► Fabric applies restorable set via `dhs <proto> import --force-by-id`
      └─► Returns report: applied N, skipped M (per-item reason), failed X
      └─► NetBox displays diff + journal-logs the outcome
 ```
@@ -562,12 +562,12 @@ T-2  SI: "Re-discover + Restore" in NetBox UI
 
 | Step | Fabric tooling | State |
 |---|---|---|
-| Snapshot capture | `acp extract` | #36.b in flight |
-| Apply snapshot | `acp import` | exists |
+| Snapshot capture | `dhs <proto> extract` | #36.b in flight |
+| Apply snapshot | `dhs <proto> import` | exists |
 | Per-param ID-stable matching | PR #39 per-protocol resolver | shipped |
 | Lossless carrier format | JSON always; CSV since PR #39 | shipped |
-| Schema diff (pre vs post) | `acp diff` | #36.c in flight |
-| Live snapshot endpoint | `acp-srv` REST | planned |
+| Schema diff (pre vs post) | `dhs <proto> diff` | #36.c in flight |
+| Live snapshot endpoint | `dhs-srv` REST | planned |
 
 ### Reporting categories after restore
 
@@ -594,7 +594,7 @@ Plugin must detect if the device is bound to an active Production (§8):
 | Engineer writes values on paper, types them back, misses some | Full auto-snapshot + auto-restore |
 | No audit trail of post-upgrade drift | Journal entry with before/after |
 | Silent breakage of values that moved/renamed | Restore report names every unrestored item |
-| Discovery of schema-breaking changes only after show fails | `acp diff` surfaces them before firmware install |
+| Discovery of schema-breaking changes only after show fails | `dhs <proto> diff` surfaces them before firmware install |
 
 ---
 

--- a/docs/fixtures-products.md
+++ b/docs/fixtures-products.md
@@ -51,7 +51,7 @@ Locked schema. Extra keys allowed but not required.
   "dm_fingerprint": "sha256:abc123…",
   "object_count": 214,
   "capture_tool": {
-    "name": "acp",
+    "name": "dhs",
     "version": "0.2.0",
     "git_tag": "v0.2.0",
     "git_commit": "7db5149"
@@ -91,11 +91,11 @@ Instance-level facts live in the **Catalog** at a higher layer. The DM fixture l
 
 ### `capture_tool` object
 
-Four fields — all required once `acp extract` (#36.b) ships. Stamped automatically by the extractor from `-ldflags`-embedded build info.
+Four fields — all required once `dhs <proto> extract` (#36.b) ships. Stamped automatically by the extractor from `-ldflags`-embedded build info.
 
 | Field | Meaning | Example |
 |---|---|---|
-| `name` | Which binary produced the capture | `"acp"` |
+| `name` | Which binary produced the capture | `"dhs"` |
 | `version` | Release version (semver, matches the git tag without `v` prefix) | `"0.2.0"` |
 | `git_tag` | Git tag at the exact build commit — `vX.Y.Z` on a tagged release, `<nearest-tag>-<N>-g<sha>` otherwise (output of `git describe --tags`) | `"v0.2.0"` |
 | `git_commit` | Short SHA (7 chars, output of `git rev-parse --short HEAD`) | `"7db5149"` |
@@ -108,7 +108,7 @@ If a capture is produced from an untagged, dirty worktree, `git_tag` carries the
 
 ### Fingerprint rule
 
-`dm_fingerprint` is the SHA-256 of `tree.json` rendered with canonical JSON encoding (sorted keys, UTF-8, LF line endings, no trailing newline). Recompute with `acp extract` or `openssl dgst -sha256 tree.json`.
+`dm_fingerprint` is the SHA-256 of `tree.json` rendered with canonical JSON encoding (sorted keys, UTF-8, LF line endings, no trailing newline). Recompute with `dhs <proto> extract` or `openssl dgst -sha256 tree.json`.
 
 Identical firmware → identical fingerprint across captures. Different fingerprint on the same stated version = the device wasn't what the label claimed, or the canonical encoder moved underneath. Audit first, then re-extract.
 
@@ -118,7 +118,7 @@ Identical firmware → identical fingerprint across captures. Different fingerpr
 
 One `CHANGELOG.md` per `<manufacturer>/<product>/<protocol>/<direction>/` folder. A dual-protocol product (e.g. DDB08 exposed on both ACP2 and Ember+) gets two independent changelogs because each protocol's DM evolves on its own cadence. A protocol that's spoken in two directions (we both read and publish) gets one changelog per direction when the DM differs between roles.
 
-Generated on new version addition by `acp diff <existing-version> <new-version>` (#36.c).
+Generated on new version addition by `dhs <proto> diff <existing-version> <new-version>` (#36.c).
 
 Format:
 
@@ -168,12 +168,12 @@ Ordering: newest version at top. Initial capture at bottom with "Initial capture
 
 | Source | Command | Generates |
 |---|---|---|
-| Live device | `acp extract <host> --protocol <p> --direction <d> --out tests/fixtures/products/<manufacturer>/<product>/<p>/<d>/<version>/` | Full triple (meta + wire + tree) — see `acp help extract` |
+| Live device | `dhs <proto> extract <host> --protocol <p> --direction <d> --out tests/fixtures/products/<manufacturer>/<product>/<p>/<d>/<version>/` | Full triple (meta + wire + tree) — see `dhs help extract` |
 | Existing `wire.jsonl` | Replay through plugin decoder + re-emit canonical | `tree.json` (regenerate-only), `meta.json` fields refreshed |
-| Existing `tree.json` snapshot | `acp convert --in tree.json --out <any-other-format>` | Format conversions — already supported today |
-| Diff between two versions | `acp diff <v1>/tree.json <v2>/tree.json` | `CHANGELOG.md` entry — shipping as **#36.c** |
+| Existing `tree.json` snapshot | `dhs <proto> convert --in tree.json --out <any-other-format>` | Format conversions — already supported today |
+| Diff between two versions | `dhs <proto> diff <v1>/tree.json <v2>/tree.json` | `CHANGELOG.md` entry — shipping as **#36.c** |
 
-Until `acp extract` (#36.b) lands, fixtures are populated manually by the engineer who captured the device (one-time run of `acp walk --capture <tmpdir>` + hand-stamping `meta.json`).
+Until `dhs <proto> extract` (#36.b) lands, fixtures are populated manually by the engineer who captured the device (one-time run of `dhs <proto> walk --capture <tmpdir>` + hand-stamping `meta.json`).
 
 ---
 
@@ -197,4 +197,4 @@ Regression catch: if tests/unit/<proto>/replay_test.go decodes the wire.jsonl an
 
 - `tests/fixtures/acp1/slot0_walk.json`, `tests/fixtures/acp2/slot*.json`, `tests/fixtures/emberplus/<port>/` — legacy fixtures, stay in place, tests keep using them.
 - `tests/fixtures/products/` — new generated layout, populated by tooling as it ships.
-- Eventual full migration is a separate task once `acp extract` and `acp diff` are both live.
+- Eventual full migration is a separate task once `dhs <proto> extract` and `dhs <proto> diff` are both live.

--- a/runbook.md
+++ b/runbook.md
@@ -1,4 +1,4 @@
-# runbook.md — acp developer runbook
+# runbook.md — dhs developer runbook
 
 Step-by-step guide to set up the dev environment, build, test, and release.
 
@@ -6,8 +6,8 @@ Two supported workflows:
 
 - **Devcontainer (recommended)** — everything in a Linux container, one-time
   install on Windows. Reproducible, no host pollution.
-- **Native Windows** — Go + Node installed directly on Windows. Required for
-  talking to real ACP devices over UDP broadcast (devcontainers NAT UDP).
+- **Native Windows** — Go installed directly on Windows. Required for
+  talking to real devices over UDP broadcast (devcontainers NAT UDP).
 
 Pick one. The commands in each section are labelled **[container]**,
 **[windows]**, or **[both]**.
@@ -46,8 +46,7 @@ You land in a bash shell inside the container at `/workspaces/acp`.
 Verify:
 
 ```bash
-go version        # go1.22.x
-node --version    # v20.x or v22.x
+go version        # go1.23.x or newer
 git --version
 golangci-lint --version
 ```
@@ -56,22 +55,20 @@ golangci-lint --version
 
 ```powershell
 winget install --id GoLang.Go -e
-winget install --id OpenJS.NodeJS.LTS -e
 winget install --id Git.Git -e
 winget install --id golangci-lint.golangci-lint -e
 winget install --id GnuWin32.Make -e              # for `make` targets
-winget install --id WiresharkFoundation.Wireshark -e   # for ACP capture
+winget install --id WiresharkFoundation.Wireshark -e
 ```
 
 **Open a new shell** after installing so PATH refreshes. Verify:
 
 ```powershell
 go version
-node --version
 make --version
 ```
 
-Then clone/open the repo:
+Then open the repo:
 
 ```powershell
 cd C:\Users\BY-SYSTEMSSRLBoujraf\Downloads\acp
@@ -82,23 +79,10 @@ go mod tidy
 
 ## 2. Build
 
-All targets work in both environments.
-
-| Target              | Command                                | Produces                         |
-|---------------------|----------------------------------------|----------------------------------|
-| Both binaries       | `make build`                           | `bin/acp`, `bin/acp-srv`         |
-| CLI only            | `make build-cli`                       | `bin/acp`                        |
-| Server only         | `make build-srv`                       | `bin/acp-srv`                    |
-| Plain `go build`    | `go build ./...`                       | cached, no output files          |
-
-Without `make`:
-
-```bash
-go build -o bin/acp       ./cmd/acp
-go build -o bin/acp-srv   ./cmd/acp-srv
-```
-
-On Windows the binaries are `bin\acp.exe` and `bin\acp-srv.exe`.
+| Target           | Command                                         | Produces                             |
+|------------------|-------------------------------------------------|--------------------------------------|
+| CLI binary       | `make build` or `go build -o bin/dhs ./cmd/dhs` | `bin/dhs` (`bin\dhs.exe` on Windows) |
+| Plain `go build` | `go build ./...`                                | cached, no output files              |
 
 ---
 
@@ -153,29 +137,22 @@ CI runs all three.
 
 ## 4. Run
 
-### 4a. CLI
-
 After `make build`:
 
 ```bash
-./bin/acp discover --protocol acp1
-./bin/acp connect  192.168.1.5 --protocol acp1
-./bin/acp walk     192.168.1.5 --protocol acp1 --slot 1
-./bin/acp get      192.168.1.5 --protocol acp1 --slot 1 --group control --label "Video Gain"
-./bin/acp set      192.168.1.5 --protocol acp1 --slot 1 --group control --label "Video Gain" --value -3.0
-./bin/acp watch    192.168.1.5 --protocol acp1 --slot 1
+./bin/dhs consumer acp1 discover
+./bin/dhs consumer acp1 walk     192.168.1.5 --slot 1
+./bin/dhs consumer acp1 get      192.168.1.5 --slot 1 --path "control.video_gain"
+./bin/dhs consumer acp1 set      192.168.1.5 --slot 1 --path "control.video_gain" --value -3.0
+./bin/dhs consumer acp1 watch    192.168.1.5 --slot 1
+
+./bin/dhs producer acp1 serve    --tree tree.json --port 2071
+
+./bin/dhs registry serve         --port 8080
 ```
 
-Full CLI reference in [CLAUDE.md](CLAUDE.md).
-
-### 4b. Server
-
-```bash
-./bin/acp-srv --addr :8080 --log-level info
-```
-
-Then `acp-ui` talks to it at `http://localhost:8080`. In a devcontainer,
-port 8080 is forwarded to the Windows host automatically.
+Full CLI reference per protocol in `internal/<proto>/CLAUDE.md`. Canonical
+verbs + flags are locked by ADR-0002.
 
 ---
 
@@ -190,13 +167,13 @@ make build-all
 
 Output layout:
 
-```
+```text
 dist/
-  acp_linux_amd64/{acp, acp-srv}
-  acp_linux_arm64/{acp, acp-srv}
-  acp_darwin_amd64/{acp, acp-srv}
-  acp_darwin_arm64/{acp, acp-srv}
-  acp_windows_amd64/{acp.exe, acp-srv.exe}
+  dhs_linux_amd64/dhs
+  dhs_linux_arm64/dhs
+  dhs_darwin_amd64/dhs
+  dhs_darwin_arm64/dhs
+  dhs_windows_amd64/dhs.exe
 ```
 
 Per-target builds if you only need one:
@@ -219,7 +196,7 @@ make package           # creates dist/*.tar.gz (linux/darwin) and dist/*.zip (wi
 
 ## 6. Wireshark verification (optional but recommended)
 
-When touching the ACP1 codec, capture real traffic and compare bytes
+When touching any wire codec, capture real traffic and compare bytes
 against your unit-test expectations.
 
 1. Install Wireshark (see section 1).
@@ -247,7 +224,7 @@ attaches the archives to a GitHub Release.
 ```bash
 git checkout main
 git pull
-git tag -a v0.1.0 -m "acp v0.1.0"
+git tag -a v0.1.0 -m "dhs v0.1.0"
 git push origin v0.1.0
 ```
 
@@ -256,11 +233,11 @@ git push origin v0.1.0
 ## 8. Troubleshooting
 
 | Symptom | Cause | Fix |
-|---|---|---|
+| --- | --- | --- |
 | `go: command not found` inside container | PATH not refreshed | Exit VS Code terminal, reopen (`Ctrl+` `` ` ``) |
 | `make: command not found` on Windows | `GnuWin32.Make` not installed or PATH not refreshed | Install + reopen shell |
-| `discover` finds nothing in container | UDP broadcast NAT'd by Docker | Run `./bin/acp discover` from Windows instead |
-| `go build` fails with import cycle | Something outside `cmd/` imported `internal/protocol/acp1` | Only `cmd/` may import plugin packages |
+| `discover` finds nothing in container | UDP broadcast NAT'd by Docker | Run `./bin/dhs consumer acp1 discover` from Windows instead |
+| `go build` fails with import cycle | Something outside `cmd/` imported `internal/<proto>/consumer` or `internal/<proto>/provider` | Only `cmd/dhs/` may import plugin packages |
 | Integration test hangs | Device not reachable | `ping $ACP1_TEST_HOST` first; check firewall for UDP 2071 |
 | Post-create script fails | Network inside container | Rebuild container: VS Code → `Dev Containers: Rebuild Container` |
 | `winget` says package not found | Old winget / no internet | `winget source update` then retry |
@@ -269,20 +246,25 @@ git push origin v0.1.0
 
 ## 9. Per-protocol runbooks
 
-Each protocol has its own README with CLI examples, integration test
-instructions, and known limitations:
+Each protocol has its own atomic context and (where applicable) docs:
 
-- [ACP1](internal/acp1/docs/README.md) — implemented, UDP/TCP direct
-- [ACP2](internal/acp2/docs/README.md) — not yet implemented, AN2/TCP
+- [internal/acp1/CLAUDE.md](internal/acp1/CLAUDE.md) — UDP/TCP direct
+- [internal/acp2/CLAUDE.md](internal/acp2/CLAUDE.md) — AN2/TCP
+- [internal/emberplus/CLAUDE.md](internal/emberplus/CLAUDE.md)
+- [internal/probel-sw08p/CLAUDE.md](internal/probel-sw08p/CLAUDE.md)
+- [internal/probel-sw02p/CLAUDE.md](internal/probel-sw02p/CLAUDE.md)
+- [internal/osc/CLAUDE.md](internal/osc/CLAUDE.md)
+- [internal/tsl/CLAUDE.md](internal/tsl/CLAUDE.md)
+- [internal/cerebrum-nb/CLAUDE.md](internal/cerebrum-nb/CLAUDE.md)
+- [internal/amwa/CLAUDE.md](internal/amwa/CLAUDE.md) — NMOS
 
 ---
 
 ## 10. What to read next
 
-- [CLAUDE.md](CLAUDE.md) — protocol reference, architecture rules, wire formats
+- [CLAUDE.md](CLAUDE.md) — Go conventions, error hierarchy, scale targets
 - [agents.md](agents.md) — cross-repo task patterns, testing rules, invariants
+- [docs/adr/](docs/adr/README.md) — Architecture Decision Records (binding)
+- [docs/CONNECTOR.md](docs/CONNECTOR.md) — connector contract (collated ADRs)
 - [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — three-layer architecture overview
 - [docs/deployment/README.md](docs/deployment/README.md) — cross-compile and firewall rules
-- `docs/protocols/AXON-ACP_v1_4.pdf` — authoritative ACP1 spec
-- `internal/acp2/assets/acp2_protocol.pdf` — authoritative ACP2 spec
-- `docs/protocols/an2_protocol.pdf` — AN2 transport spec


### PR DESCRIPTION
## What

Scrub legacy `acp`-as-product-name framing from repo docs. After PR #205 the module path is `dhs`; the disclaimer paragraphs explaining "acp was the legacy name, kept to avoid churn" are obsolete and just add noise. This PR removes them and rewrites the docs to read as if `dhs` is the only product name — which it now is.

## Why

The disclaimer was explaining a fact that's already true and load-bearing of nothing. Per ADR-0015 (single source of truth), this PR removes the duplication and brings the doc set into line with the actual code.

Closes #206

## Scope

- [ ] acp1
- [ ] acp2
- [ ] transport
- [ ] export
- [ ] cli
- [ ] api
- [ ] core
- [x] ci / chore

## Type

- [ ] feat — new feature
- [ ] fix — bug fix
- [x] docs — documentation only
- [ ] chore — maintenance, refactor, CI
- [ ] security — security fix or hardening

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `CLAUDE.md` | modified | drop the legacy-name disclaimer paragraph; `acp-ui` → `dhs-ui` |
| `README.md` | modified | drop the legacy-name disclaimer block |
| `agents.md` | modified | drop the disclaimer; repo block `acp/` `acp-ui` → `dhs/` `dhs-ui` |
| `CONTRIBUTING.md` | modified | rewrite top + workflow against ADR-0013/0014; fix stale folder layout (`tests/unit/{name}/` → `internal/<proto>/`); conventional-commit examples |
| `SECURITY.md` | modified | rewrite to current cross-cutting posture (every protocol's profile lives in its `COMPLIANCE.md` per ADR-0008); drop ACP-only framing |
| `runbook.md` | modified | replace dual-binary `acp` / `acp-srv` flow with single-binary `dhs`; CLI examples updated to `dhs consumer/producer/registry <proto> <verb>` |
| `LICENSES-THIRD-PARTY.md` | modified | reference `docs/adr/0005-deps.json` as the authoritative manifest (per ADR-0015); drop the stale "zero external deps" claim |
| `docs/ARCHITECTURE.md` | modified | `acp-srv` → `dhs-srv` |
| `docs/CONNECTOR.md` | modified | drop the "Legacy ACP-specific architecture" tail block |
| `docs/fixtures-products.md` | modified | `capture_tool.name` example `"acp"` → `"dhs"`; CLI examples updated to `dhs <proto> <verb>` |
| `docs/VISION.md` | modified | section 13 wording; `acp-srv` → `dhs-srv` |

## Out of scope (explicitly kept)

- `internal/acp1/`, `internal/acp2/` directory names — protocol identifiers, not legacy connector
- `ACP1`, `ACP2`, `ACP1Error`, `ACP2Error` symbols across the codebase
- All wire / spec references to ACP1 and ACP2
- Local filesystem paths in `runbook.md` — the user's repo dir on disk literally is named `acp`
- ADR documents (immutable per ADR-0015 once accepted)
- `COPYRIGHT`, `LICENSE.md`, `docs/wireshark.md` — already clean, no edit needed

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go build ./...` | clean | — |
| `go vet ./...` | clean | — |
| `golangci-lint run` | clean (0 issues) | — |
| `go test ./...` | tests not affected by docs change | — |

## Device tested

- [ ] ACP1 emulator 10.6.239.113
- [ ] ACP2 real device 10.41.40.195
- [ ] Other (specify)
- [x] No device needed (pure docs change)

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [x] One commit per ADR-0013 (no checkpoint commits)

## Approval

@yboujraf — requesting review per ADR-0014 (codeowner approval gate before merge to main).
