### PR TITLE
refactor(acp1): split codec into internal/acp1/codec/ (closes #214)

### DIFF
--- a/internal/acp1/codec/message.go
+++ b/internal/acp1/codec/message.go
@@ -1,4 +1,4 @@
-package acp1
+package codec
 
 import (
 	"encoding/binary"

--- a/internal/acp1/codec/message_spec_test.go
+++ b/internal/acp1/codec/message_spec_test.go
@@ -1,22 +1,22 @@
 // Black-box spec-compliance tests for ACP1 message encode/decode.
 // Every byte sequence is derived from spec v1.4 pages 9-14 and 32.
 // These tests use only the exported API — no internal symbols.
-package acp1_test
+package codec_test
 
 import (
 	"bytes"
 	"testing"
 
-	"dhs/internal/acp1/consumer"
+	"dhs/internal/acp1/codec"
 )
 
 func TestSpec_EncodeGetFrameStatus(t *testing.T) {
-	m := &acp1.Message{
+	m := &codec.Message{
 		MTID:     0,
-		MType:    acp1.MTypeRequest,
+		MType:    codec.MTypeRequest,
 		MAddr:    0,
-		MCode:    byte(acp1.MethodGetValue),
-		ObjGroup: acp1.GroupFrame,
+		MCode:    byte(codec.MethodGetValue),
+		ObjGroup: codec.GroupFrame,
 		ObjID:    0,
 	}
 	want := []byte{0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x06, 0x00}
@@ -31,7 +31,7 @@ func TestSpec_EncodeGetFrameStatus(t *testing.T) {
 
 func TestSpec_DecodeRoundTrip(t *testing.T) {
 	wire := []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x05, 0x00, 0x02, 0x0A, 0xAA, 0xBB}
-	m, err := acp1.Decode(wire)
+	m, err := codec.Decode(wire)
 	if err != nil {
 		t.Fatalf("Decode: %v", err)
 	}

--- a/internal/acp1/codec/message_test.go
+++ b/internal/acp1/codec/message_test.go
@@ -1,4 +1,4 @@
-package acp1
+package codec
 
 import (
 	"bytes"

--- a/internal/acp1/codec/property.go
+++ b/internal/acp1/codec/property.go
@@ -1,4 +1,4 @@
-package acp1
+package codec
 
 import (
 	"encoding/binary"

--- a/internal/acp1/codec/property_spec_test.go
+++ b/internal/acp1/codec/property_spec_test.go
@@ -1,20 +1,20 @@
 // Black-box spec-compliance tests for ACP1 property decoders.
 // Byte sequences from spec v1.4 pages 21-27.
-package acp1_test
+package codec_test
 
 import (
 	"testing"
 
-	"dhs/internal/acp1/consumer"
+	"dhs/internal/acp1/codec"
 )
 
 func TestSpec_DecodeRoot(t *testing.T) {
 	in := []byte{0x00, 0x09, 0x01, 0x00, 0x08, 0x10, 0x04, 0x02, 0x01}
-	o, err := acp1.DecodeObject(in)
+	o, err := codec.DecodeObject(in)
 	if err != nil {
 		t.Fatalf("DecodeObject: %v", err)
 	}
-	if o.Type != acp1.TypeRoot || o.NumProps != 9 {
+	if o.Type != codec.TypeRoot || o.NumProps != 9 {
 		t.Errorf("type/numprops: %d/%d", o.Type, o.NumProps)
 	}
 	if o.NumIdentity != 8 || o.NumControl != 16 {
@@ -33,7 +33,7 @@ func TestSpec_DecodeFloat(t *testing.T) {
 		'G', 'a', 'i', 'n', 0x00,
 		'd', 'B', 0x00,
 	}
-	o, err := acp1.DecodeObject(in)
+	o, err := codec.DecodeObject(in)
 	if err != nil {
 		t.Fatalf("DecodeObject: %v", err)
 	}
@@ -48,7 +48,7 @@ func TestSpec_DecodeEnum(t *testing.T) {
 		'M', 'o', 'd', 'e', 0x00,
 		'O', 'f', 'f', ',', 'O', 'n', ',', 'A', 'u', 't', 'o', 0x00,
 	}
-	o, err := acp1.DecodeObject(in)
+	o, err := codec.DecodeObject(in)
 	if err != nil {
 		t.Fatalf("DecodeObject: %v", err)
 	}

--- a/internal/acp1/codec/property_test.go
+++ b/internal/acp1/codec/property_test.go
@@ -1,4 +1,4 @@
-package acp1
+package codec
 
 import (
 	"errors"

--- a/internal/acp1/codec/types.go
+++ b/internal/acp1/codec/types.go
@@ -1,18 +1,19 @@
-// Package acp1 implements the Axon Control Protocol v1.4 wire format and
-// plugin for the internal/protocol interface.
+// Package codec implements the ACP1 (Axon Control Protocol v1.4) wire
+// format. Stdlib-only, lift-to-own-repo ready per ADR-0006.
 //
-// Authoritative spec: assets/AXON-ACP_v1_4.pdf.
-// Cross-reference: the Axon Wireshark dissector in wireshark/dhs_acpv1.lua
-// and the C# reference driver (ByResearch.DHS.AxonACP.DeviceDriver).
+// Authoritative spec: ../assets/AXON-ACP_v1_4.pdf.
+// Cross-reference: the Axon Wireshark dissector in
+// ../wireshark/dhs_acpv1.lua and the C# reference driver
+// (ByResearch.DHS.AxonACP.DeviceDriver).
 //
 // Scope of this package:
 //   - UDP direct mode (port 2071) — current target
 //   - TCP direct mode with MLEN prefix — later
-//   - AN2 transport — out of scope for v1 (see CLAUDE.md)
+//   - AN2 transport — out of scope for v1 (see ../CLAUDE.md)
 //
-// Nothing outside cmd/ and this package's own files may import acp1. The
-// rest of the system talks to the Protocol interface only.
-package acp1
+// Imported by internal/acp1/consumer and internal/acp1/provider for the
+// Protocol / Provider interface implementations.
+package codec
 
 // Spec §"ACP Port Number" p. 7.
 const (

--- a/internal/acp1/consumer/browser.go
+++ b/internal/acp1/consumer/browser.go
@@ -7,13 +7,14 @@ import (
 
 	"dhs/internal/protocol"
 	"dhs/internal/protocol/compliance"
+	"dhs/internal/acp1/codec"
 )
 
 // walkerClient is the minimum contract the Walker needs from whatever
 // client backs it. Both the UDP Client and the TCPClient satisfy this,
 // so the Walker is transport-agnostic.
 type walkerClient interface {
-	Do(ctx context.Context, req *Message) (*Message, error)
+	Do(ctx context.Context, req *codec.Message) (*codec.Message, error)
 }
 
 // Walker walks the AxonNet object tree of one slot on one device.
@@ -63,7 +64,7 @@ type SlotTree struct {
 	// the widened ValueKind (Integer and Long both map to KindInt), so
 	// the value codec needs this side channel to pick the correct wire
 	// width at get/set time.
-	ACPTypes []ObjectType
+	ACPTypes []codec.ObjectType
 	// Labels maps group name → label string → index into Objects.
 	// Labels are unique within a group per spec p. 34. Using an index
 	// keeps Object slice the source of truth (no duplicated data).
@@ -98,11 +99,11 @@ func (w *Walker) Walk(ctx context.Context, slot int) (*SlotTree, error) {
 
 	// Step 1: read the root object to learn how many objects live in
 	// each group on this slot.
-	root, err := w.getObject(ctx, slot, GroupRoot, 0)
+	root, err := w.getObject(ctx, slot, codec.GroupRoot, 0)
 	if err != nil {
 		return nil, fmt.Errorf("walk slot %d: root: %w", slot, err)
 	}
-	if root.Type != TypeRoot {
+	if root.Type != codec.TypeRoot {
 		return nil, fmt.Errorf("walk slot %d: root is type %d, want 0", slot, root.Type)
 	}
 
@@ -111,7 +112,7 @@ func (w *Walker) Walk(ctx context.Context, slot int) (*SlotTree, error) {
 		Slot:     slot,
 		BootMode: root.BootMode,
 		Objects:  make([]protocol.Object, 0, cap),
-		ACPTypes: make([]ObjectType, 0, cap),
+		ACPTypes: make([]codec.ObjectType, 0, cap),
 		Labels:   map[string]map[string]int{},
 	}
 
@@ -119,13 +120,13 @@ func (w *Walker) Walk(ctx context.Context, slot int) (*SlotTree, error) {
 	// order the C# reference walker uses, for stable output in the CLI
 	// tree view.
 	walks := []struct {
-		group ObjGroup
+		group codec.ObjGroup
 		count uint8
 	}{
-		{GroupIdentity, root.NumIdentity},
-		{GroupControl, root.NumControl},
-		{GroupStatus, root.NumStatus},
-		{GroupAlarm, root.NumAlarm},
+		{codec.GroupIdentity, root.NumIdentity},
+		{codec.GroupControl, root.NumControl},
+		{codec.GroupStatus, root.NumStatus},
+		{codec.GroupAlarm, root.NumAlarm},
 	}
 	for _, g := range walks {
 		for id := uint8(0); id < g.count; id++ {
@@ -156,11 +157,11 @@ func (w *Walker) Walk(ctx context.Context, slot int) (*SlotTree, error) {
 // getObject is the one primitive the walker uses: send a getObject
 // request for (slot, group, id) and return the typed DecodedObject.
 // Handles both transport errors and protocol error replies.
-func (w *Walker) getObject(ctx context.Context, slot int, group ObjGroup, id uint8) (*DecodedObject, error) {
-	req := &Message{
-		MType:    MTypeRequest,
+func (w *Walker) getObject(ctx context.Context, slot int, group codec.ObjGroup, id uint8) (*codec.DecodedObject, error) {
+	req := &codec.Message{
+		MType:    codec.MTypeRequest,
 		MAddr:    byte(slot),
-		MCode:    byte(MethodGetObject),
+		MCode:    byte(codec.MethodGetObject),
 		ObjGroup: group,
 		ObjID:    id,
 	}
@@ -184,7 +185,7 @@ func (w *Walker) getObject(ctx context.Context, slot int, group ObjGroup, id uin
 		}
 		return nil, reply.ErrCode()
 	}
-	return DecodeObject(reply.Value)
+	return codec.DecodeObject(reply.Value)
 }
 
 // toProtocolObject projects one DecodedObject into the protocol-agnostic
@@ -196,7 +197,7 @@ func (w *Walker) getObject(ctx context.Context, slot int, group ObjGroup, id uin
 //   - Byte / Enum / Alarm priority → uint64
 //   - Float → float64
 //   - IPAddr → uint64 (u32 widened)
-func toProtocolObject(d *DecodedObject, slot int, group ObjGroup, id uint8) protocol.Object {
+func toProtocolObject(d *codec.DecodedObject, slot int, group codec.ObjGroup, id uint8) protocol.Object {
 	o := protocol.Object{
 		Slot:  slot,
 		Group: group.String(),
@@ -210,28 +211,28 @@ func toProtocolObject(d *DecodedObject, slot int, group ObjGroup, id uint8) prot
 		Access: d.Access,
 	}
 	switch d.Type {
-	case TypeInteger, TypeLong:
+	case codec.TypeInteger, codec.TypeLong:
 		o.Kind = protocol.KindInt
 		o.Min = d.MinInt
 		o.Max = d.MaxInt
 		o.Step = d.StepInt
 		o.Def = d.DefInt
 		o.Value = protocol.Value{Kind: protocol.KindInt, Int: d.IntVal}
-	case TypeByte:
+	case codec.TypeByte:
 		o.Kind = protocol.KindUint
 		o.Min = uint64(d.MinByte)
 		o.Max = uint64(d.MaxByte)
 		o.Step = uint64(d.StepByte)
 		o.Def = uint64(d.DefByte)
 		o.Value = protocol.Value{Kind: protocol.KindUint, Uint: uint64(d.ByteVal)}
-	case TypeFloat:
+	case codec.TypeFloat:
 		o.Kind = protocol.KindFloat
 		o.Min = d.MinFloat
 		o.Max = d.MaxFloat
 		o.Step = d.StepFloat
 		o.Def = d.DefFloat
 		o.Value = protocol.Value{Kind: protocol.KindFloat, Float: d.FloatVal}
-	case TypeIPAddr:
+	case codec.TypeIPAddr:
 		o.Kind = protocol.KindIPAddr
 		o.Min = d.MinUint
 		o.Max = d.MaxUint
@@ -244,7 +245,7 @@ func toProtocolObject(d *DecodedObject, slot int, group ObjGroup, id uint8) prot
 				byte(u >> 24), byte(u >> 16), byte(u >> 8), byte(u),
 			},
 		}
-	case TypeEnum:
+	case codec.TypeEnum:
 		o.Kind = protocol.KindEnum
 		o.EnumItems = d.EnumItems
 		o.Def = uint64(d.DefByte)
@@ -258,12 +259,12 @@ func toProtocolObject(d *DecodedObject, slot int, group ObjGroup, id uint8) prot
 			ev.Str = d.EnumItems[d.ByteVal]
 		}
 		o.Value = ev
-	case TypeString:
+	case codec.TypeString:
 		o.Kind = protocol.KindString
 		o.MaxLen = int(d.MaxLen)
 		o.SubGroupMarker = d.IsSubGroupMarker()
 		o.Value = protocol.Value{Kind: protocol.KindString, Str: d.StrValue}
-	case TypeAlarm:
+	case codec.TypeAlarm:
 		o.Kind = protocol.KindAlarm
 		o.AlarmPriority = d.Priority
 		o.AlarmTag = d.Tag
@@ -272,7 +273,7 @@ func toProtocolObject(d *DecodedObject, slot int, group ObjGroup, id uint8) prot
 		// Surface the priority byte as a Uint so the CLI has a single
 		// formatter path for "current value".
 		o.Value = protocol.Value{Kind: protocol.KindUint, Uint: uint64(d.Priority)}
-	case TypeFrame:
+	case codec.TypeFrame:
 		o.Kind = protocol.KindFrame
 		statuses := make([]protocol.SlotStatus, len(d.SlotStatus))
 		for i, s := range d.SlotStatus {

--- a/internal/acp1/consumer/browser_test.go
+++ b/internal/acp1/consumer/browser_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"dhs/internal/protocol"
+	"dhs/internal/acp1/codec"
 )
 
 // TestWalker_HappyPath runs a full slot walk against a canned sequence of
@@ -78,10 +79,10 @@ func TestWalker_HappyPath(t *testing.T) {
 	}
 
 	ft.recv = [][]byte{
-		buildReply(t, 1001, MTypeReply, byte(MethodGetObject), GroupRoot, 0, rootValue),
-		buildReply(t, 1002, MTypeReply, byte(MethodGetObject), GroupIdentity, 0, idValue),
-		buildReply(t, 1003, MTypeReply, byte(MethodGetObject), GroupControl, 0, ctrlValue),
-		buildReply(t, 1004, MTypeReply, byte(MethodGetObject), GroupStatus, 0, statValue),
+		buildReply(t, 1001, codec.MTypeReply, byte(codec.MethodGetObject), codec.GroupRoot, 0, rootValue),
+		buildReply(t, 1002, codec.MTypeReply, byte(codec.MethodGetObject), codec.GroupIdentity, 0, idValue),
+		buildReply(t, 1003, codec.MTypeReply, byte(codec.MethodGetObject), codec.GroupControl, 0, ctrlValue),
+		buildReply(t, 1004, codec.MTypeReply, byte(codec.MethodGetObject), codec.GroupStatus, 0, statValue),
 	}
 
 	w := NewWalker(c)
@@ -170,13 +171,13 @@ func TestResolve(t *testing.T) {
 
 	// 1. Label lookup with explicit group
 	g, id, err := resolve(protocol.ValueRequest{Slot: 1, Group: "control", Label: "Gain"}, tree)
-	if err != nil || g != GroupControl || id != 7 {
+	if err != nil || g != codec.GroupControl || id != 7 {
 		t.Errorf("label+group: got g=%d id=%d err=%v", g, id, err)
 	}
 
 	// 2. Label lookup without group (searches all)
 	g, id, err = resolve(protocol.ValueRequest{Slot: 1, Label: "Temp"}, tree)
-	if err != nil || g != GroupStatus || id != 3 {
+	if err != nil || g != codec.GroupStatus || id != 3 {
 		t.Errorf("label-only: got g=%d id=%d err=%v", g, id, err)
 	}
 
@@ -194,7 +195,7 @@ func TestResolve(t *testing.T) {
 
 	// 5. Group+ID fallback (no label)
 	g, id, err = resolve(protocol.ValueRequest{Slot: 1, Group: "alarm", ID: 5}, nil)
-	if err != nil || g != GroupAlarm || id != 5 {
+	if err != nil || g != codec.GroupAlarm || id != 5 {
 		t.Errorf("group+id: got g=%d id=%d err=%v", g, id, err)
 	}
 

--- a/internal/acp1/consumer/canonicalize.go
+++ b/internal/acp1/consumer/canonicalize.go
@@ -8,6 +8,7 @@ import (
 
 	"dhs/internal/export/canonical"
 	"dhs/internal/protocol"
+	"dhs/internal/acp1/codec"
 )
 
 // Canonicalize walks every cached SlotTree on this plugin and emits
@@ -135,7 +136,7 @@ func buildGroupNode(slot int, slotOID, slotPath string, groupNumber int, groupNa
 		if obj.Group != groupName {
 			continue
 		}
-		acpType := ObjectType(0)
+		acpType := codec.ObjectType(0)
 		if i < len(tree.ACPTypes) {
 			acpType = tree.ACPTypes[i]
 		}
@@ -170,7 +171,7 @@ func buildGroupNode(slot int, slotOID, slotPath string, groupNumber int, groupNa
 
 // buildParameter maps a protocol.Object to a canonical.Parameter. Spec
 // cross-refs are in per-kind switch below.
-func buildParameter(obj protocol.Object, acpType ObjectType, parentOID, parentPath string) *canonical.Parameter {
+func buildParameter(obj protocol.Object, acpType codec.ObjectType, parentOID, parentPath string) *canonical.Parameter {
 	oid := parentOID + "." + strconv.Itoa(obj.ID)
 	path := parentPath + "." + obj.Label
 	// Use Label as identifier; fall back to "#<id>" when a device
@@ -257,7 +258,7 @@ func buildParameter(obj protocol.Object, acpType ObjectType, parentOID, parentPa
 
 // kindToCanonicalType maps ValueKind + ACP1 ObjectType to the canonical
 // parameter type string (docs/protocols/elements/parameter.md).
-func kindToCanonicalType(k protocol.ValueKind, acpType ObjectType) string {
+func kindToCanonicalType(k protocol.ValueKind, acpType codec.ObjectType) string {
 	switch k {
 	case protocol.KindBool:
 		return canonical.ParamBoolean
@@ -282,7 +283,7 @@ func kindToCanonicalType(k protocol.ValueKind, acpType ObjectType) string {
 	}
 	// Fallback: File objects (acpType=TypeFile) and unknown kinds end
 	// up here. File is a named resource — surface as string.
-	if acpType == TypeFile {
+	if acpType == codec.TypeFile {
 		return canonical.ParamString
 	}
 	return canonical.ParamString

--- a/internal/acp1/consumer/canonicalize_test.go
+++ b/internal/acp1/consumer/canonicalize_test.go
@@ -7,6 +7,7 @@ import (
 
 	"dhs/internal/export/canonical"
 	"dhs/internal/protocol"
+	"dhs/internal/acp1/codec"
 )
 
 // TestCanonicalize_Empty covers the fresh-Plugin case: no Connect,
@@ -65,7 +66,7 @@ func TestCanonicalize_SlotTree(t *testing.T) {
 				EnumItems: []string{"Off", "On", "Auto"},
 				Value: protocol.Value{Kind: protocol.KindEnum, Enum: 2}},
 		},
-		ACPTypes: []ObjectType{TypeString, TypeFloat, TypeInteger, TypeEnum},
+		ACPTypes: []codec.ObjectType{codec.TypeString, codec.TypeFloat, codec.TypeInteger, codec.TypeEnum},
 	}
 
 	p := &Plugin{host: "10.6.239.113"}

--- a/internal/acp1/consumer/catalogue.go
+++ b/internal/acp1/consumer/catalogue.go
@@ -1,5 +1,7 @@
 package acp1
 
+import "dhs/internal/acp1/codec"
+
 // CommandKind groups ACP1 catalogue entries. ACP1 has no single "byte
 // command" namespace like Probel — its wire protocol mixes message
 // types (MType), method IDs (MCODE), object groups, object types, and
@@ -41,61 +43,61 @@ func (c CatalogueEntry) Address() string {
 func Catalogue() []CatalogueEntry {
 	out := []CatalogueEntry{
 		// Message types (MType field, 1 byte at header offset 5).
-		{Kind: KindMessageType, ID: uint8(MTypeAnnounce), Name: "Announce", SpecRef: "p. 8", Notes: "MTID=0; broadcast"},
-		{Kind: KindMessageType, ID: uint8(MTypeRequest), Name: "Request", SpecRef: "p. 8", Notes: "client → server"},
-		{Kind: KindMessageType, ID: uint8(MTypeReply), Name: "Reply", SpecRef: "p. 8", Notes: "server → client"},
-		{Kind: KindMessageType, ID: uint8(MTypeError), Name: "Error", SpecRef: "p. 8", Notes: "MCODE = error code"},
+		{Kind: KindMessageType, ID: uint8(codec.MTypeAnnounce), Name: "Announce", SpecRef: "p. 8", Notes: "MTID=0; broadcast"},
+		{Kind: KindMessageType, ID: uint8(codec.MTypeRequest), Name: "Request", SpecRef: "p. 8", Notes: "client → server"},
+		{Kind: KindMessageType, ID: uint8(codec.MTypeReply), Name: "Reply", SpecRef: "p. 8", Notes: "server → client"},
+		{Kind: KindMessageType, ID: uint8(codec.MTypeError), Name: "Error", SpecRef: "p. 8", Notes: "MCODE = error code"},
 
 		// Methods (MCODE byte when MType < 3). Spec §"Methods" p. 28.
-		{Kind: KindMethod, ID: uint8(MethodGetValue), Name: "getValue", SpecRef: "p. 28"},
-		{Kind: KindMethod, ID: uint8(MethodSetValue), Name: "setValue", SpecRef: "p. 28"},
-		{Kind: KindMethod, ID: uint8(MethodSetIncValue), Name: "setIncValue", SpecRef: "p. 28"},
-		{Kind: KindMethod, ID: uint8(MethodSetDecValue), Name: "setDecValue", SpecRef: "p. 28"},
-		{Kind: KindMethod, ID: uint8(MethodSetDefValue), Name: "setDefValue", SpecRef: "p. 28"},
-		{Kind: KindMethod, ID: uint8(MethodGetObject), Name: "getObject", SpecRef: "p. 28", Notes: "returns all properties in sequence"},
+		{Kind: KindMethod, ID: uint8(codec.MethodGetValue), Name: "getValue", SpecRef: "p. 28"},
+		{Kind: KindMethod, ID: uint8(codec.MethodSetValue), Name: "setValue", SpecRef: "p. 28"},
+		{Kind: KindMethod, ID: uint8(codec.MethodSetIncValue), Name: "setIncValue", SpecRef: "p. 28"},
+		{Kind: KindMethod, ID: uint8(codec.MethodSetDecValue), Name: "setDecValue", SpecRef: "p. 28"},
+		{Kind: KindMethod, ID: uint8(codec.MethodSetDefValue), Name: "setDefValue", SpecRef: "p. 28"},
+		{Kind: KindMethod, ID: uint8(codec.MethodGetObject), Name: "getObject", SpecRef: "p. 28", Notes: "returns all properties in sequence"},
 
 		// Object groups. Spec §"Object Groups" p. 17.
-		{Kind: KindObjGroup, ID: uint8(GroupRoot), Name: "root", SpecRef: "p. 17", Notes: "1 object, card counts per group"},
-		{Kind: KindObjGroup, ID: uint8(GroupIdentity), Name: "identity", SpecRef: "p. 17"},
-		{Kind: KindObjGroup, ID: uint8(GroupControl), Name: "control", SpecRef: "p. 17", Notes: "writable parameters"},
-		{Kind: KindObjGroup, ID: uint8(GroupStatus), Name: "status", SpecRef: "p. 17", Notes: "read-only"},
-		{Kind: KindObjGroup, ID: uint8(GroupAlarm), Name: "alarm", SpecRef: "p. 17"},
-		{Kind: KindObjGroup, ID: uint8(GroupFile), Name: "file", SpecRef: "p. 17", Notes: "firmware + param table"},
-		{Kind: KindObjGroup, ID: uint8(GroupFrame), Name: "frame", SpecRef: "p. 17", Notes: "rack controller only"},
+		{Kind: KindObjGroup, ID: uint8(codec.GroupRoot), Name: "root", SpecRef: "p. 17", Notes: "1 object, card counts per group"},
+		{Kind: KindObjGroup, ID: uint8(codec.GroupIdentity), Name: "identity", SpecRef: "p. 17"},
+		{Kind: KindObjGroup, ID: uint8(codec.GroupControl), Name: "control", SpecRef: "p. 17", Notes: "writable parameters"},
+		{Kind: KindObjGroup, ID: uint8(codec.GroupStatus), Name: "status", SpecRef: "p. 17", Notes: "read-only"},
+		{Kind: KindObjGroup, ID: uint8(codec.GroupAlarm), Name: "alarm", SpecRef: "p. 17"},
+		{Kind: KindObjGroup, ID: uint8(codec.GroupFile), Name: "file", SpecRef: "p. 17", Notes: "firmware + param table"},
+		{Kind: KindObjGroup, ID: uint8(codec.GroupFrame), Name: "frame", SpecRef: "p. 17", Notes: "rack controller only"},
 
 		// Object types. Spec §"Object details" p. 19 + per-type tables p. 21–27.
-		{Kind: KindObjType, ID: uint8(TypeRoot), Name: "ROOT", SpecRef: "p. 21", Notes: "9 props"},
-		{Kind: KindObjType, ID: uint8(TypeInteger), Name: "INTEGER", SpecRef: "p. 22", Notes: "10 props (i16)"},
-		{Kind: KindObjType, ID: uint8(TypeIPAddr), Name: "IPADDR", SpecRef: "p. 22", Notes: "10 props (u32)"},
-		{Kind: KindObjType, ID: uint8(TypeFloat), Name: "FLOAT", SpecRef: "p. 23", Notes: "10 props (float32)"},
-		{Kind: KindObjType, ID: uint8(TypeEnum), Name: "ENUMERATED", SpecRef: "p. 24", Notes: "8 props"},
-		{Kind: KindObjType, ID: uint8(TypeString), Name: "STRING", SpecRef: "p. 25", Notes: "6 props"},
-		{Kind: KindObjType, ID: uint8(TypeFrame), Name: "FRAME STATUS", SpecRef: "p. 25", Notes: "4 props, read-only"},
-		{Kind: KindObjType, ID: uint8(TypeAlarm), Name: "ALARM", SpecRef: "p. 26", Notes: "8 props"},
-		{Kind: KindObjType, ID: uint8(TypeFile), Name: "FILE", SpecRef: "p. 26", Notes: "5 props; engineer-mode only"},
-		{Kind: KindObjType, ID: uint8(TypeLong), Name: "LONG", SpecRef: "p. 27", Notes: "10 props (i32)"},
-		{Kind: KindObjType, ID: uint8(TypeByte), Name: "BYTE", SpecRef: "p. 27", Notes: "10 props (u8)"},
+		{Kind: KindObjType, ID: uint8(codec.TypeRoot), Name: "ROOT", SpecRef: "p. 21", Notes: "9 props"},
+		{Kind: KindObjType, ID: uint8(codec.TypeInteger), Name: "INTEGER", SpecRef: "p. 22", Notes: "10 props (i16)"},
+		{Kind: KindObjType, ID: uint8(codec.TypeIPAddr), Name: "IPADDR", SpecRef: "p. 22", Notes: "10 props (u32)"},
+		{Kind: KindObjType, ID: uint8(codec.TypeFloat), Name: "FLOAT", SpecRef: "p. 23", Notes: "10 props (float32)"},
+		{Kind: KindObjType, ID: uint8(codec.TypeEnum), Name: "ENUMERATED", SpecRef: "p. 24", Notes: "8 props"},
+		{Kind: KindObjType, ID: uint8(codec.TypeString), Name: "STRING", SpecRef: "p. 25", Notes: "6 props"},
+		{Kind: KindObjType, ID: uint8(codec.TypeFrame), Name: "FRAME STATUS", SpecRef: "p. 25", Notes: "4 props, read-only"},
+		{Kind: KindObjType, ID: uint8(codec.TypeAlarm), Name: "ALARM", SpecRef: "p. 26", Notes: "8 props"},
+		{Kind: KindObjType, ID: uint8(codec.TypeFile), Name: "FILE", SpecRef: "p. 26", Notes: "5 props; engineer-mode only"},
+		{Kind: KindObjType, ID: uint8(codec.TypeLong), Name: "LONG", SpecRef: "p. 27", Notes: "10 props (i32)"},
+		{Kind: KindObjType, ID: uint8(codec.TypeByte), Name: "BYTE", SpecRef: "p. 27", Notes: "10 props (u8)"},
 
 		// ACP transport errors (MType=3, MCODE < 16). Spec §"ACP Header" p. 11.
-		{Kind: KindXportErr, ID: uint8(TErrUndefined), Name: "undefined", SpecRef: "p. 11"},
-		{Kind: KindXportErr, ID: uint8(TErrInternalBusComm), Name: "internal-bus-comm", SpecRef: "p. 11"},
-		{Kind: KindXportErr, ID: uint8(TErrInternalBusTimeout), Name: "internal-bus-timeout", SpecRef: "p. 11"},
-		{Kind: KindXportErr, ID: uint8(TErrTransactionTimeout), Name: "transaction-timeout", SpecRef: "p. 11"},
-		{Kind: KindXportErr, ID: uint8(TErrOutOfResources), Name: "out-of-resources", SpecRef: "p. 11"},
+		{Kind: KindXportErr, ID: uint8(codec.TErrUndefined), Name: "undefined", SpecRef: "p. 11"},
+		{Kind: KindXportErr, ID: uint8(codec.TErrInternalBusComm), Name: "internal-bus-comm", SpecRef: "p. 11"},
+		{Kind: KindXportErr, ID: uint8(codec.TErrInternalBusTimeout), Name: "internal-bus-timeout", SpecRef: "p. 11"},
+		{Kind: KindXportErr, ID: uint8(codec.TErrTransactionTimeout), Name: "transaction-timeout", SpecRef: "p. 11"},
+		{Kind: KindXportErr, ID: uint8(codec.TErrOutOfResources), Name: "out-of-resources", SpecRef: "p. 11"},
 
 		// AxonNet object errors (MType=3, MCODE >= 16). Spec §"AxonNet error codes" p. 29.
-		{Kind: KindObjErr, ID: uint8(OErrGroupNoExist), Name: "object-group-not-exist", SpecRef: "p. 29"},
-		{Kind: KindObjErr, ID: uint8(OErrInstanceNoExist), Name: "object-instance-not-exist", SpecRef: "p. 29"},
-		{Kind: KindObjErr, ID: uint8(OErrPropertyNoExist), Name: "object-property-not-exist", SpecRef: "p. 29"},
-		{Kind: KindObjErr, ID: uint8(OErrNoWriteAccess), Name: "no-write-access", SpecRef: "p. 29"},
-		{Kind: KindObjErr, ID: uint8(OErrNoReadAccess), Name: "no-read-access", SpecRef: "p. 29"},
-		{Kind: KindObjErr, ID: uint8(OErrNoSetDefAccess), Name: "no-setDefault-access", SpecRef: "p. 29"},
-		{Kind: KindObjErr, ID: uint8(OErrTypeNoExist), Name: "object-type-not-exist", SpecRef: "p. 29"},
-		{Kind: KindObjErr, ID: uint8(OErrIllegalMethod), Name: "illegal-method", SpecRef: "p. 29"},
-		{Kind: KindObjErr, ID: uint8(OErrIllegalForType), Name: "illegal-method-for-type", SpecRef: "p. 29"},
-		{Kind: KindObjErr, ID: uint8(OErrFile), Name: "file-error", SpecRef: "p. 29"},
-		{Kind: KindObjErr, ID: uint8(OErrSPFConstraint), Name: "SPF-constraint-violation", SpecRef: "p. 29"},
-		{Kind: KindObjErr, ID: uint8(OErrSPFBufferFull), Name: "SPF-buffer-full", SpecRef: "p. 29", Notes: "retry"},
+		{Kind: KindObjErr, ID: uint8(codec.OErrGroupNoExist), Name: "object-group-not-exist", SpecRef: "p. 29"},
+		{Kind: KindObjErr, ID: uint8(codec.OErrInstanceNoExist), Name: "object-instance-not-exist", SpecRef: "p. 29"},
+		{Kind: KindObjErr, ID: uint8(codec.OErrPropertyNoExist), Name: "object-property-not-exist", SpecRef: "p. 29"},
+		{Kind: KindObjErr, ID: uint8(codec.OErrNoWriteAccess), Name: "no-write-access", SpecRef: "p. 29"},
+		{Kind: KindObjErr, ID: uint8(codec.OErrNoReadAccess), Name: "no-read-access", SpecRef: "p. 29"},
+		{Kind: KindObjErr, ID: uint8(codec.OErrNoSetDefAccess), Name: "no-setDefault-access", SpecRef: "p. 29"},
+		{Kind: KindObjErr, ID: uint8(codec.OErrTypeNoExist), Name: "object-type-not-exist", SpecRef: "p. 29"},
+		{Kind: KindObjErr, ID: uint8(codec.OErrIllegalMethod), Name: "illegal-method", SpecRef: "p. 29"},
+		{Kind: KindObjErr, ID: uint8(codec.OErrIllegalForType), Name: "illegal-method-for-type", SpecRef: "p. 29"},
+		{Kind: KindObjErr, ID: uint8(codec.OErrFile), Name: "file-error", SpecRef: "p. 29"},
+		{Kind: KindObjErr, ID: uint8(codec.OErrSPFConstraint), Name: "SPF-constraint-violation", SpecRef: "p. 29"},
+		{Kind: KindObjErr, ID: uint8(codec.OErrSPFBufferFull), Name: "SPF-buffer-full", SpecRef: "p. 29", Notes: "retry"},
 	}
 	return out
 }

--- a/internal/acp1/consumer/client.go
+++ b/internal/acp1/consumer/client.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"sync"
 	"time"
+	"dhs/internal/acp1/codec"
 )
 
 // Transport is the minimal send/receive contract the ACP1 client needs.
@@ -129,7 +130,7 @@ func (c *Client) Close() error {
 //   - Error-reply messages (MType=3) are returned as successful replies;
 //     the caller inspects msg.IsError() / msg.ErrCode().
 //   - Exhaustion returns ErrMaxRetries.
-func (c *Client) Do(ctx context.Context, req *Message) (*Message, error) {
+func (c *Client) Do(ctx context.Context, req *codec.Message) (*codec.Message, error) {
 	if req == nil {
 		return nil, errors.New("acp1: Do nil request")
 	}
@@ -197,7 +198,7 @@ func (c *Client) Do(ctx context.Context, req *Message) (*Message, error) {
 // ReceiveTimeout window. It sends the payload once, then drains the
 // receive pipe, discarding announcements and MTID mismatches, until
 // either the matching reply arrives or the attempt window expires.
-func (c *Client) doOneAttempt(parent context.Context, payload []byte, wantMTID uint32) (*Message, error) {
+func (c *Client) doOneAttempt(parent context.Context, payload []byte, wantMTID uint32) (*codec.Message, error) {
 	attemptCtx, cancel := context.WithTimeout(parent, c.cfg.ReceiveTimeout)
 	defer cancel()
 
@@ -206,11 +207,11 @@ func (c *Client) doOneAttempt(parent context.Context, payload []byte, wantMTID u
 	}
 
 	for {
-		raw, err := c.tr.Receive(attemptCtx, MaxPacket)
+		raw, err := c.tr.Receive(attemptCtx, codec.MaxPacket)
 		if err != nil {
 			return nil, err
 		}
-		msg, err := Decode(raw)
+		msg, err := codec.Decode(raw)
 		if err != nil {
 			c.logger.Debug("acp1 malformed reply, skipping", "err", err, "bytes", len(raw))
 			continue

--- a/internal/acp1/consumer/client_test.go
+++ b/internal/acp1/consumer/client_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"testing"
 	"time"
+	"dhs/internal/acp1/codec"
 )
 
 // fakeTransport is an in-memory Transport for deterministic client tests.
@@ -45,10 +46,10 @@ func (f *fakeTransport) Close() error {
 
 // buildReply encodes a canned reply with the requested MTID. Used to
 // hand-feed the fake transport with what a real device would return.
-func buildReply(t *testing.T, mtid uint32, mtype MType, mcode byte,
-	group ObjGroup, id byte, value []byte) []byte {
+func buildReply(t *testing.T, mtid uint32, mtype codec.MType, mcode byte,
+	group codec.ObjGroup, id byte, value []byte) []byte {
 	t.Helper()
-	m := &Message{
+	m := &codec.Message{
 		MTID:     mtid,
 		MType:    mtype,
 		MAddr:    0,
@@ -75,18 +76,18 @@ func TestClient_Do_HappyPath(t *testing.T) {
 
 	// Seed a matching reply. We don't know the MTID yet (client allocates),
 	// so we queue nothing and rebuild after we see what the client sent.
-	req := &Message{
-		MType:    MTypeRequest,
+	req := &codec.Message{
+		MType:    codec.MTypeRequest,
 		MAddr:    0,
-		MCode:    byte(MethodGetValue),
-		ObjGroup: GroupFrame,
+		MCode:    byte(codec.MethodGetValue),
+		ObjGroup: codec.GroupFrame,
 		ObjID:    0,
 	}
 
 	// Intercept: before Do runs we pre-seed recv with a placeholder; after
 	// Do encodes we patch the MTID. Simpler: pre-allocate nextMTID ourselves.
 	c.nextMTID = 41 // next allocMTID() will return 42
-	reply := buildReply(t, 42, MTypeReply, byte(MethodGetValue), GroupFrame, 0, []byte{0x02, 0x02, 0x02})
+	reply := buildReply(t, 42, codec.MTypeReply, byte(codec.MethodGetValue), codec.GroupFrame, 0, []byte{0x02, 0x02, 0x02})
 	ft.recv = [][]byte{reply}
 
 	got, err := c.Do(context.Background(), req)
@@ -96,8 +97,8 @@ func TestClient_Do_HappyPath(t *testing.T) {
 	if got.MTID != 42 {
 		t.Errorf("reply MTID: got %d, want 42", got.MTID)
 	}
-	if got.MType != MTypeReply {
-		t.Errorf("reply MType: got %d", got.MType)
+	if got.MType != codec.MTypeReply {
+		t.Errorf("reply codec.MType: got %d", got.MType)
 	}
 	if len(ft.sent) != 1 {
 		t.Errorf("sent count: got %d, want 1", len(ft.sent))
@@ -117,14 +118,14 @@ func TestClient_Do_SkipsAnnouncement(t *testing.T) {
 	c.nextMTID = 0xAA
 	// First: an announcement (MTID=0, MType=0, ObjGroup=frame) → skipped.
 	// Second: the real reply (MTID=0xAB).
-	announce := buildReply(t, 0, MTypeAnnounce, 0, GroupFrame, 0, []byte{0x02, 0x02})
-	reply := buildReply(t, 0xAB, MTypeReply, byte(MethodGetValue), GroupFrame, 0, []byte{0x03})
+	announce := buildReply(t, 0, codec.MTypeAnnounce, 0, codec.GroupFrame, 0, []byte{0x02, 0x02})
+	reply := buildReply(t, 0xAB, codec.MTypeReply, byte(codec.MethodGetValue), codec.GroupFrame, 0, []byte{0x03})
 	ft.recv = [][]byte{announce, reply}
 
-	req := &Message{
-		MType:    MTypeRequest,
-		MCode:    byte(MethodGetValue),
-		ObjGroup: GroupFrame,
+	req := &codec.Message{
+		MType:    codec.MTypeRequest,
+		MCode:    byte(codec.MethodGetValue),
+		ObjGroup: codec.GroupFrame,
 	}
 	got, err := c.Do(context.Background(), req)
 	if err != nil {
@@ -149,14 +150,14 @@ func TestClient_Do_SkipsMTIDMismatch(t *testing.T) {
 	defer func() { _ = c.Close() }()
 
 	c.nextMTID = 99
-	stale := buildReply(t, 7, MTypeReply, byte(MethodGetValue), GroupFrame, 0, []byte{0xDE})
-	real := buildReply(t, 100, MTypeReply, byte(MethodGetValue), GroupFrame, 0, []byte{0xAD})
+	stale := buildReply(t, 7, codec.MTypeReply, byte(codec.MethodGetValue), codec.GroupFrame, 0, []byte{0xDE})
+	real := buildReply(t, 100, codec.MTypeReply, byte(codec.MethodGetValue), codec.GroupFrame, 0, []byte{0xAD})
 	ft.recv = [][]byte{stale, real}
 
-	req := &Message{
-		MType:    MTypeRequest,
-		MCode:    byte(MethodGetValue),
-		ObjGroup: GroupFrame,
+	req := &codec.Message{
+		MType:    codec.MTypeRequest,
+		MCode:    byte(codec.MethodGetValue),
+		ObjGroup: codec.GroupFrame,
 	}
 	got, err := c.Do(context.Background(), req)
 	if err != nil {
@@ -182,13 +183,13 @@ func TestClient_Do_RetryOnTimeout(t *testing.T) {
 
 	c.nextMTID = 0xDEADBEE0
 	// nil = simulated timeout on the first attempt
-	reply := buildReply(t, 0xDEADBEE1, MTypeReply, byte(MethodGetValue), GroupControl, 5, []byte{0x00})
+	reply := buildReply(t, 0xDEADBEE1, codec.MTypeReply, byte(codec.MethodGetValue), codec.GroupControl, 5, []byte{0x00})
 	ft.recv = [][]byte{nil, reply}
 
-	req := &Message{
-		MType:    MTypeRequest,
-		MCode:    byte(MethodGetValue),
-		ObjGroup: GroupControl,
+	req := &codec.Message{
+		MType:    codec.MTypeRequest,
+		MCode:    byte(codec.MethodGetValue),
+		ObjGroup: codec.GroupControl,
 		ObjID:    5,
 	}
 	got, err := c.Do(context.Background(), req)
@@ -226,7 +227,7 @@ func TestClient_Do_MaxRetriesExceeded(t *testing.T) {
 	})
 	defer func() { _ = c.Close() }()
 
-	req := &Message{MType: MTypeRequest, MCode: byte(MethodGetValue), ObjGroup: GroupFrame}
+	req := &codec.Message{MType: codec.MTypeRequest, MCode: byte(codec.MethodGetValue), ObjGroup: codec.GroupFrame}
 	_, err := c.Do(context.Background(), req)
 	if !errors.Is(err, ErrMaxRetries) {
 		t.Errorf("got err=%v, want ErrMaxRetries", err)
@@ -251,7 +252,7 @@ func TestClient_Do_CtxCancelDuringBackoff(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
-	req := &Message{MType: MTypeRequest, MCode: byte(MethodGetValue), ObjGroup: GroupFrame}
+	req := &codec.Message{MType: codec.MTypeRequest, MCode: byte(codec.MethodGetValue), ObjGroup: codec.GroupFrame}
 	_, err := c.Do(ctx, req)
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("got err=%v, want DeadlineExceeded", err)
@@ -274,14 +275,14 @@ func TestClient_Do_ErrorReplyPropagates(t *testing.T) {
 	// be just the MCODE byte (spec p. 9) — no ObjGrp/ObjId.
 	errReply := []byte{
 		0x00, 0x00, 0x00, 0x0B, // MTID = 11
-		0x01,       // PVER
-		0x03,       // MType = error
+		0x01,       // codec.PVER
+		0x03,       // codec.MType = error
 		0x00,       // MAddr
 		0x13,       // MCODE = 19 (no write access)
 	}
 	ft.recv = [][]byte{errReply}
 
-	req := &Message{MType: MTypeRequest, MCode: byte(MethodSetValue), ObjGroup: GroupControl, ObjID: 7}
+	req := &codec.Message{MType: codec.MTypeRequest, MCode: byte(codec.MethodSetValue), ObjGroup: codec.GroupControl, ObjID: 7}
 	got, err := c.Do(context.Background(), req)
 	if err != nil {
 		t.Fatalf("Do: %v", err)
@@ -289,8 +290,8 @@ func TestClient_Do_ErrorReplyPropagates(t *testing.T) {
 	if !got.IsError() {
 		t.Fatal("expected IsError true")
 	}
-	oerr, ok := got.ErrCode().(ObjectErr)
-	if !ok || oerr.Code != OErrNoWriteAccess {
+	oerr, ok := got.ErrCode().(codec.ObjectErr)
+	if !ok || oerr.Code != codec.OErrNoWriteAccess {
 		t.Errorf("unexpected err code: %v", got.ErrCode())
 	}
 	if len(ft.sent) != 1 {
@@ -324,11 +325,11 @@ func TestClient_Do_Serialisation(t *testing.T) {
 	defer func() { _ = c.Close() }()
 
 	c.nextMTID = 100
-	r1 := buildReply(t, 101, MTypeReply, byte(MethodGetValue), GroupFrame, 0, []byte{0x02})
-	r2 := buildReply(t, 102, MTypeReply, byte(MethodGetValue), GroupFrame, 0, []byte{0x02})
+	r1 := buildReply(t, 101, codec.MTypeReply, byte(codec.MethodGetValue), codec.GroupFrame, 0, []byte{0x02})
+	r2 := buildReply(t, 102, codec.MTypeReply, byte(codec.MethodGetValue), codec.GroupFrame, 0, []byte{0x02})
 	ft.recv = [][]byte{r1, r2}
 
-	req := &Message{MType: MTypeRequest, MCode: byte(MethodGetValue), ObjGroup: GroupFrame}
+	req := &codec.Message{MType: codec.MTypeRequest, MCode: byte(codec.MethodGetValue), ObjGroup: codec.GroupFrame}
 	got1, err := c.Do(context.Background(), req)
 	if err != nil {
 		t.Fatalf("Do1: %v", err)

--- a/internal/acp1/consumer/discover.go
+++ b/internal/acp1/consumer/discover.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"dhs/internal/transport"
+	"dhs/internal/acp1/codec"
 )
 
 // DiscoverResult is one device seen during a discovery run.
@@ -64,7 +65,7 @@ type DiscoverConfig struct {
 // logged to stderr but do not abort passive discovery.
 func Discover(ctx context.Context, cfg DiscoverConfig) ([]DiscoverResult, error) {
 	if cfg.Port == 0 {
-		cfg.Port = DefaultPort
+		cfg.Port = codec.DefaultPort
 	}
 	if cfg.Duration == 0 {
 		cfg.Duration = 5 * time.Second
@@ -92,7 +93,7 @@ func Discover(ctx context.Context, cfg DiscoverConfig) ([]DiscoverResult, error)
 				return
 			}
 			rxCtx, cancel := context.WithTimeout(ctx, remaining)
-			raw, addr, err := listener.Receive(rxCtx, MaxPacket)
+			raw, addr, err := listener.Receive(rxCtx, codec.MaxPacket)
 			cancel()
 			if err != nil {
 				// Timeout or ctx cancel → exit loop.
@@ -104,7 +105,7 @@ func Discover(ctx context.Context, cfg DiscoverConfig) ([]DiscoverResult, error)
 			}
 			// Decode to confirm it's valid ACP1. Malformed datagrams
 			// from unrelated services on the same port are skipped.
-			msg, derr := Decode(raw)
+			msg, derr := codec.Decode(raw)
 			if derr != nil {
 				continue
 			}
@@ -128,7 +129,7 @@ func Discover(ctx context.Context, cfg DiscoverConfig) ([]DiscoverResult, error)
 			}
 			r.LastSeen = time.Now()
 			// If this is a FrameStatus reply, decode num_slots from it.
-			if msg.ObjGroup == GroupFrame && msg.ObjID == 0 && len(msg.Value) >= 1 {
+			if msg.ObjGroup == codec.GroupFrame && msg.ObjID == 0 && len(msg.Value) >= 1 {
 				r.NumSlots = int(msg.Value[0])
 			}
 			mu.Unlock()
@@ -184,13 +185,13 @@ func probeActive(port int) error {
 
 	// Build a getValue(FrameStatus, 0) request. Per spec p. 8 this is
 	// "the only broadcast message clients are allowed to invoke".
-	req := &Message{
+	req := &codec.Message{
 		MTID:     0, // broadcast marker
-		PVER:     PVER,
-		MType:    MTypeRequest,
+		PVER:     codec.PVER,
+		MType:    codec.MTypeRequest,
 		MAddr:    0,
-		MCode:    byte(MethodGetValue),
-		ObjGroup: GroupFrame,
+		MCode:    byte(codec.MethodGetValue),
+		ObjGroup: codec.GroupFrame,
 		ObjID:    0,
 	}
 	payload, err := req.Encode()

--- a/internal/acp1/consumer/listener.go
+++ b/internal/acp1/consumer/listener.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"dhs/internal/transport"
+	"dhs/internal/acp1/codec"
 )
 
 // Listener receives ACP1 announcements broadcast by rack controllers on
@@ -30,7 +31,7 @@ import (
 // wiring. The public protocol.EventFunc is wrapped around this at the
 // Plugin.Subscribe layer so higher-level code sees decoded protocol.Event
 // values with resolved labels, not raw Messages.
-type RawEventFunc func(msg *Message)
+type RawEventFunc func(msg *codec.Message)
 
 // Listener is safe for concurrent Subscribe/Unsubscribe and for one
 // Receive goroutine. Stop is idempotent.
@@ -152,7 +153,7 @@ func (l *Listener) loop(ctx context.Context) {
 			return
 		}
 
-		raw, _, err := l.conn.Receive(ctx, MaxPacket)
+		raw, _, err := l.conn.Receive(ctx, codec.MaxPacket)
 		if err != nil {
 			// Deliberate shutdown: ctx cancelled or socket closed.
 			if ctx.Err() != nil {
@@ -180,7 +181,7 @@ func (l *Listener) loop(ctx context.Context) {
 			"len", len(raw),
 			"hex", fmt.Sprintf("%x", raw))
 
-		msg, derr := Decode(raw)
+		msg, derr := codec.Decode(raw)
 		if derr != nil {
 			l.logger.Debug("acp1 listener: malformed datagram",
 				"err", derr, "bytes", len(raw))
@@ -215,7 +216,7 @@ func (l *Listener) loop(ctx context.Context) {
 // callbacks. Callbacks are invoked synchronously inside the receive
 // goroutine — subscribers must not block or the listener stops draining
 // the socket.
-func (l *Listener) dispatch(msg *Message) {
+func (l *Listener) dispatch(msg *codec.Message) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	for _, s := range l.subs {

--- a/internal/acp1/consumer/plugin.go
+++ b/internal/acp1/consumer/plugin.go
@@ -10,6 +10,7 @@ import (
 	"dhs/internal/protocol"
 	"dhs/internal/protocol/compliance"
 	"dhs/internal/transport"
+	"dhs/internal/acp1/codec"
 )
 
 // init registers the ACP1 plugin with the global protocol registry.
@@ -25,7 +26,7 @@ type Factory struct{}
 func (f *Factory) Meta() protocol.ProtocolMeta {
 	return protocol.ProtocolMeta{
 		Name:        "acp1",
-		DefaultPort: DefaultPort,
+		DefaultPort: codec.DefaultPort,
 		Description: "Axon Control Protocol v1.4 (UDP direct)",
 	}
 }
@@ -55,7 +56,7 @@ const (
 // layer. Both the UDP Client and the TCPClient satisfy it, so the rest
 // of the plugin code is transport-agnostic.
 type clientIface interface {
-	Do(ctx context.Context, req *Message) (*Message, error)
+	Do(ctx context.Context, req *codec.Message) (*codec.Message, error)
 	Close() error
 }
 
@@ -158,7 +159,7 @@ func (p *Plugin) Connect(ctx context.Context, ip string, port int) error {
 		return fmt.Errorf("acp1: already connected to %s:%d", p.host, p.port)
 	}
 	if port == 0 {
-		port = DefaultPort
+		port = codec.DefaultPort
 	}
 
 	switch p.transport {
@@ -282,11 +283,11 @@ func (p *Plugin) GetDeviceInfo(ctx context.Context) (protocol.DeviceInfo, error)
 
 	// getValue(frame, 0) at slot 0 returns [num_slots, status_array...].
 	// Spec p. 24 Frame Status Object.
-	req := &Message{
-		MType:    MTypeRequest,
+	req := &codec.Message{
+		MType:    codec.MTypeRequest,
 		MAddr:    0,
-		MCode:    byte(MethodGetValue),
-		ObjGroup: GroupFrame,
+		MCode:    byte(codec.MethodGetValue),
+		ObjGroup: codec.GroupFrame,
 		ObjID:    0,
 	}
 	reply, err := c.Do(ctx, req)
@@ -326,11 +327,11 @@ func (p *Plugin) GetSlotInfo(ctx context.Context, slot int) (protocol.SlotInfo, 
 	info := protocol.SlotInfo{Slot: slot}
 
 	// Read the rack controller's frame status for the status byte.
-	req := &Message{
-		MType:    MTypeRequest,
+	req := &codec.Message{
+		MType:    codec.MTypeRequest,
 		MAddr:    0,
-		MCode:    byte(MethodGetValue),
-		ObjGroup: GroupFrame,
+		MCode:    byte(codec.MethodGetValue),
+		ObjGroup: codec.GroupFrame,
 		ObjID:    0,
 	}
 	reply, err := c.Do(ctx, req)
@@ -411,10 +412,10 @@ func (p *Plugin) GetValue(ctx context.Context, req protocol.ValueRequest) (proto
 		return protocol.Value{}, err
 	}
 
-	m := &Message{
-		MType:    MTypeRequest,
+	m := &codec.Message{
+		MType:    codec.MTypeRequest,
 		MAddr:    byte(req.Slot),
-		MCode:    byte(MethodGetValue),
+		MCode:    byte(codec.MethodGetValue),
 		ObjGroup: group,
 		ObjID:    id,
 	}
@@ -440,17 +441,17 @@ func (p *Plugin) GetValue(ctx context.Context, req protocol.ValueRequest) (proto
 // doesn't traverse (root, frame, file). It infers the ObjectType from
 // the group alone and calls DecodeValueBytes with a synthetic empty
 // Object. Unknown groups return raw bytes.
-func decodeByGroup(group ObjGroup, raw []byte) (protocol.Value, error) {
+func decodeByGroup(group codec.ObjGroup, raw []byte) (protocol.Value, error) {
 	var synth protocol.Object
-	var t ObjectType
+	var t codec.ObjectType
 	switch group {
-	case GroupFrame:
+	case codec.GroupFrame:
 		synth.Kind = protocol.KindFrame
-		t = TypeFrame
-	case GroupRoot:
-		t = TypeRoot
-	case GroupFile:
-		t = TypeFile
+		t = codec.TypeFrame
+	case codec.GroupRoot:
+		t = codec.TypeRoot
+	case codec.GroupFile:
+		t = codec.TypeFile
 	default:
 		return protocol.Value{
 			Kind: protocol.KindRaw,
@@ -498,10 +499,10 @@ func (p *Plugin) SetValue(ctx context.Context, req protocol.ValueRequest, val pr
 		return protocol.Value{}, fmt.Errorf("acp1 set: no walked tree for slot %d, use raw bytes", req.Slot)
 	}
 
-	m := &Message{
-		MType:    MTypeRequest,
+	m := &codec.Message{
+		MType:    codec.MTypeRequest,
 		MAddr:    byte(req.Slot),
-		MCode:    byte(MethodSetValue),
+		MCode:    byte(codec.MethodSetValue),
 		ObjGroup: group,
 		ObjID:    id,
 		Value:    wireBytes,
@@ -527,7 +528,7 @@ func (p *Plugin) SetValue(ctx context.Context, req protocol.ValueRequest, val pr
 // findObject looks up an Object and its ACP1 type inside a walked tree
 // by (group, id). Returns false if the tree is nil or the object wasn't
 // walked. O(n) — acceptable for typical tree sizes under 512 objects.
-func findObject(tree *SlotTree, group ObjGroup, id byte) (protocol.Object, ObjectType, bool) {
+func findObject(tree *SlotTree, group codec.ObjGroup, id byte) (protocol.Object, codec.ObjectType, bool) {
 	if tree == nil {
 		return protocol.Object{}, 0, false
 	}
@@ -585,7 +586,7 @@ func (p *Plugin) Subscribe(req protocol.ValueRequest, fn protocol.EventFunc) err
 
 	// Wrap the user's high-level callback with a low-level RawEventFunc
 	// that decodes the value bytes using the cached tree.
-	wrapper := func(msg *Message) {
+	wrapper := func(msg *codec.Message) {
 		p.mu.Lock()
 		cache := p.trees
 		p.mu.Unlock()
@@ -638,7 +639,7 @@ func (p *Plugin) Subscribe(req protocol.ValueRequest, fn protocol.EventFunc) err
 	// filtering is applied inside the wrapper for the TCP path.
 	if tcpOK {
 		base := wrapper
-		filtered := func(msg *Message) {
+		filtered := func(msg *codec.Message) {
 			if slot >= 0 && int(msg.MAddr) != slot {
 				return
 			}
@@ -696,7 +697,7 @@ func (p *Plugin) Unsubscribe(req protocol.ValueRequest) error {
 // exists in a different group, the error message suggests where it was
 // found — a common source of confusion for users who forget which group
 // a label belongs to.
-func resolve(req protocol.ValueRequest, tree *SlotTree) (ObjGroup, byte, error) {
+func resolve(req protocol.ValueRequest, tree *SlotTree) (codec.ObjGroup, byte, error) {
 	if req.Label != "" {
 		if tree == nil {
 			return 0, 0, fmt.Errorf("%w: no walked tree for slot %d",
@@ -707,7 +708,7 @@ func resolve(req protocol.ValueRequest, tree *SlotTree) (ObjGroup, byte, error) 
 		if req.Group != "" {
 			if idx := tree.Lookup(req.Group, req.Label); idx >= 0 {
 				obj := tree.Objects[idx]
-				g, ok := ParseGroup(obj.Group)
+				g, ok := codec.ParseGroup(obj.Group)
 				if !ok {
 					return 0, 0, fmt.Errorf("acp1: bad group %q in tree", obj.Group)
 				}
@@ -718,7 +719,7 @@ func resolve(req protocol.ValueRequest, tree *SlotTree) (ObjGroup, byte, error) 
 			for _, gname := range []string{"identity", "control", "status", "alarm"} {
 				if idx := tree.Lookup(gname, req.Label); idx >= 0 {
 					obj := tree.Objects[idx]
-					g, ok := ParseGroup(obj.Group)
+					g, ok := codec.ParseGroup(obj.Group)
 					if !ok {
 						return 0, 0, fmt.Errorf("acp1: bad group %q in tree", obj.Group)
 					}
@@ -744,7 +745,7 @@ func resolve(req protocol.ValueRequest, tree *SlotTree) (ObjGroup, byte, error) 
 	}
 
 	// Address by explicit group + id — no walker needed.
-	g, ok := ParseGroup(req.Group)
+	g, ok := codec.ParseGroup(req.Group)
 	if !ok {
 		return 0, 0, fmt.Errorf("acp1: invalid group %q", req.Group)
 	}

--- a/internal/acp1/consumer/replay_test.go
+++ b/internal/acp1/consumer/replay_test.go
@@ -15,6 +15,7 @@ import (
 	"dhs/internal/acp1/consumer"
 	"dhs/internal/protocol"
 	"dhs/internal/wiretrace"
+	"dhs/internal/acp1/codec"
 )
 
 // loadTrames reads a captured wire trace from
@@ -88,21 +89,21 @@ func TestReplay_ACP1PropertyDecode(t *testing.T) {
 	trames := loadTrames(t, "slot0_walk")
 
 	var objects int
-	typeCounts := map[acp1.ObjectType]int{}
+	typeCounts := map[codec.ObjectType]int{}
 
 	for _, tr := range trames {
 		raw, err := hex.DecodeString(tr.Hex)
 		if err != nil {
 			continue
 		}
-		msg, err := acp1.Decode(raw)
+		msg, err := codec.Decode(raw)
 		if err != nil {
 			continue
 		}
-		if msg.MType != acp1.MTypeReply || msg.MCode != byte(acp1.MethodGetObject) {
+		if msg.MType != codec.MTypeReply || msg.MCode != byte(codec.MethodGetObject) {
 			continue
 		}
-		obj, err := acp1.DecodeObject(msg.Value)
+		obj, err := codec.DecodeObject(msg.Value)
 		if err != nil {
 			t.Errorf("DecodeObject(group=%d, id=%d): %v", msg.ObjGroup, msg.ObjID, err)
 			continue

--- a/internal/acp1/consumer/tcp_client.go
+++ b/internal/acp1/consumer/tcp_client.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"dhs/internal/transport"
+	"dhs/internal/acp1/codec"
 )
 
 // TCPClient is the ACP1 session layer for TCP direct mode (spec v1.4
@@ -48,7 +49,7 @@ type TCPClient struct {
 
 	// pendingMu guards pending + listeners + closed.
 	pendingMu sync.Mutex
-	pending   map[uint32]chan *Message
+	pending   map[uint32]chan *codec.Message
 	listeners []RawEventFunc
 	closed    bool
 
@@ -82,7 +83,7 @@ func NewTCPClient(conn *transport.TCPConn, logger *slog.Logger, cfg ClientConfig
 		logger:     logger,
 		cfg:        cfg,
 		nextMTID:   seed,
-		pending:    map[uint32]chan *Message{},
+		pending:    map[uint32]chan *codec.Message{},
 		readerDone: make(chan struct{}),
 	}
 	go c.readerLoop()
@@ -119,7 +120,7 @@ func (c *TCPClient) Close() error {
 // Do is the ACP1 Client contract: send a request, return the matching
 // reply. Implements the clientIface interface the Plugin uses, so it's
 // a drop-in replacement for UDP Client at the Plugin layer.
-func (c *TCPClient) Do(ctx context.Context, req *Message) (*Message, error) {
+func (c *TCPClient) Do(ctx context.Context, req *codec.Message) (*codec.Message, error) {
 	if req == nil {
 		return nil, errors.New("acp1 tcp: Do nil request")
 	}
@@ -134,7 +135,7 @@ func (c *TCPClient) Do(ctx context.Context, req *Message) (*Message, error) {
 	// sending, so a fast device can't beat us with a reply we haven't
 	// subscribed to yet.
 	req.MTID = c.allocMTID()
-	replyCh := make(chan *Message, 1)
+	replyCh := make(chan *codec.Message, 1)
 
 	c.pendingMu.Lock()
 	c.pending[req.MTID] = replyCh
@@ -219,7 +220,7 @@ func (c *TCPClient) readerLoop() {
 	for {
 		// Blocking read with no deadline — closing the socket (via
 		// Close) unblocks it with an error.
-		raw, err := c.conn.Receive(context.Background(), MaxPacket)
+		raw, err := c.conn.Receive(context.Background(), codec.MaxPacket)
 		if err != nil {
 			// Close → exit. Any other error → also exit, since a
 			// framing error on a TCP stream means we can't resync.
@@ -233,7 +234,7 @@ func (c *TCPClient) readerLoop() {
 			return
 		}
 
-		msg, derr := Decode(raw)
+		msg, derr := codec.Decode(raw)
 		if derr != nil {
 			c.logger.Debug("acp1 tcp reader: malformed frame", "err", derr, "bytes", len(raw))
 			continue

--- a/internal/acp1/consumer/validate.go
+++ b/internal/acp1/consumer/validate.go
@@ -7,6 +7,7 @@ import (
 
 	"dhs/internal/protocol"
 	"dhs/internal/wiretrace"
+	"dhs/internal/acp1/codec"
 )
 
 // Validate decodes captured ACP1 wire-trace records (Trames per ADR-0021)
@@ -44,7 +45,7 @@ func (p *Plugin) Validate(ctx context.Context, trames []wiretrace.Trame, opts pr
 			continue
 		}
 
-		msg, err := Decode(raw)
+		msg, err := codec.Decode(raw)
 		if err != nil {
 			report.Errors = append(report.Errors, protocol.ValidateError{
 				TrameIndex: i,
@@ -61,17 +62,17 @@ func (p *Plugin) Validate(ctx context.Context, trames []wiretrace.Trame, opts pr
 		// PVER must always be 1 for v1.4 devices.
 		if msg.PVER != 1 {
 			report.Invariants = append(report.Invariants,
-				fmt.Sprintf("trame %d: PVER %d, want 1", i, msg.PVER))
+				fmt.Sprintf("trame %d: codec.PVER %d, want 1", i, msg.PVER))
 		}
 
 		switch msg.MType {
-		case MTypeRequest:
+		case codec.MTypeRequest:
 			if msg.MTID == 0 {
 				report.Invariants = append(report.Invariants,
 					fmt.Sprintf("trame %d: request with MTID=0 (spec: must be non-zero)", i))
 			}
 			lastReqMTID = msg.MTID
-		case MTypeReply:
+		case codec.MTypeReply:
 			if msg.MTID != lastReqMTID {
 				report.Invariants = append(report.Invariants,
 					fmt.Sprintf("trame %d: reply MTID=%d does not match last request MTID=%d", i, msg.MTID, lastReqMTID))

--- a/internal/acp1/consumer/value_codec.go
+++ b/internal/acp1/consumer/value_codec.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"dhs/internal/protocol"
+	"dhs/internal/acp1/codec"
 )
 
 // ValueCodec encodes and decodes the "value bytes" that ACP1 getValue and
@@ -54,41 +55,41 @@ import (
 //
 // Spec reference: AXON-ACP_v1_4.pdf §"Methods" p. 28 and
 // §"Objects by Type" pp. 21–27.
-func DecodeValueBytes(obj protocol.Object, acpType ObjectType, raw []byte) (protocol.Value, error) {
+func DecodeValueBytes(obj protocol.Object, acpType codec.ObjectType, raw []byte) (protocol.Value, error) {
 	v := protocol.Value{
 		Kind: obj.Kind,
 		Raw:  append([]byte(nil), raw...),
 	}
 	switch acpType {
-	case TypeInteger:
+	case codec.TypeInteger:
 		if len(raw) < 2 {
 			return v, fmt.Errorf("acp1 decode integer: need 2 bytes, got %d", len(raw))
 		}
 		v.Int = int64(int16(binary.BigEndian.Uint16(raw)))
 		return v, nil
 
-	case TypeLong:
+	case codec.TypeLong:
 		if len(raw) < 4 {
 			return v, fmt.Errorf("acp1 decode long: need 4 bytes, got %d", len(raw))
 		}
 		v.Int = int64(int32(binary.BigEndian.Uint32(raw)))
 		return v, nil
 
-	case TypeByte:
+	case codec.TypeByte:
 		if len(raw) < 1 {
 			return v, fmt.Errorf("acp1 decode byte: need 1 byte, got %d", len(raw))
 		}
 		v.Uint = uint64(raw[0])
 		return v, nil
 
-	case TypeFloat:
+	case codec.TypeFloat:
 		if len(raw) < 4 {
 			return v, fmt.Errorf("acp1 decode float: need 4 bytes, got %d", len(raw))
 		}
 		v.Float = float64(math.Float32frombits(binary.BigEndian.Uint32(raw)))
 		return v, nil
 
-	case TypeIPAddr:
+	case codec.TypeIPAddr:
 		if len(raw) < 4 {
 			return v, fmt.Errorf("acp1 decode ipaddr: need 4 bytes, got %d", len(raw))
 		}
@@ -99,7 +100,7 @@ func DecodeValueBytes(obj protocol.Object, acpType ObjectType, raw []byte) (prot
 		}
 		return v, nil
 
-	case TypeEnum:
+	case codec.TypeEnum:
 		if len(raw) < 1 {
 			return v, fmt.Errorf("acp1 decode enum: need 1 byte, got %d", len(raw))
 		}
@@ -111,7 +112,7 @@ func DecodeValueBytes(obj protocol.Object, acpType ObjectType, raw []byte) (prot
 		}
 		return v, nil
 
-	case TypeString:
+	case codec.TypeString:
 		// Strings on the wire are NUL-terminated, but some replies omit
 		// the trailing NUL. Strip at the first NUL if present, otherwise
 		// take everything.
@@ -125,7 +126,7 @@ func DecodeValueBytes(obj protocol.Object, acpType ObjectType, raw []byte) (prot
 		v.Str = string(raw[:end])
 		return v, nil
 
-	case TypeAlarm:
+	case codec.TypeAlarm:
 		// getValue on an Alarm returns a single byte = the current
 		// priority (0 = disabled, 1..255 = enabled with that priority).
 		// Surface it as a Uint so formatValue can render it cleanly.
@@ -136,7 +137,7 @@ func DecodeValueBytes(obj protocol.Object, acpType ObjectType, raw []byte) (prot
 		v.Uint = uint64(raw[0])
 		return v, nil
 
-	case TypeFrame:
+	case codec.TypeFrame:
 		// Frame-status announcements and getValue replies both carry
 		// [num_slots, status_0, status_1, ...] per spec p. 24. Decode
 		// the byte array into the structured SlotStatus slice so
@@ -156,7 +157,7 @@ func DecodeValueBytes(obj protocol.Object, acpType ObjectType, raw []byte) (prot
 		}
 		return v, nil
 
-	case TypeRoot, TypeFile, TypeReserved:
+	case codec.TypeRoot, codec.TypeFile, codec.TypeReserved:
 		// Other compound types — leave as raw bytes.
 		v.Kind = protocol.KindRaw
 		return v, nil
@@ -189,9 +190,9 @@ func DecodeValueBytes(obj protocol.Object, acpType ObjectType, raw []byte) (prot
 //
 // Spec reference: AXON-ACP_v1_4.pdf §"Methods" p. 28 and
 // §"Objects by Type" pp. 21–27.
-func EncodeValueBytes(obj protocol.Object, acpType ObjectType, val protocol.Value) ([]byte, error) {
+func EncodeValueBytes(obj protocol.Object, acpType codec.ObjectType, val protocol.Value) ([]byte, error) {
 	switch acpType {
-	case TypeInteger:
+	case codec.TypeInteger:
 		n, err := coerceInt(val, -32768, 32767)
 		if err != nil {
 			return nil, fmt.Errorf("acp1 encode integer: %w", err)
@@ -200,7 +201,7 @@ func EncodeValueBytes(obj protocol.Object, acpType ObjectType, val protocol.Valu
 		binary.BigEndian.PutUint16(out, uint16(int16(n)))
 		return out, nil
 
-	case TypeLong:
+	case codec.TypeLong:
 		n, err := coerceInt(val, math.MinInt32, math.MaxInt32)
 		if err != nil {
 			return nil, fmt.Errorf("acp1 encode long: %w", err)
@@ -209,14 +210,14 @@ func EncodeValueBytes(obj protocol.Object, acpType ObjectType, val protocol.Valu
 		binary.BigEndian.PutUint32(out, uint32(int32(n)))
 		return out, nil
 
-	case TypeByte:
+	case codec.TypeByte:
 		n, err := coerceUint(val, 255)
 		if err != nil {
 			return nil, fmt.Errorf("acp1 encode byte: %w", err)
 		}
 		return []byte{byte(n)}, nil
 
-	case TypeFloat:
+	case codec.TypeFloat:
 		f, err := coerceFloat(val)
 		if err != nil {
 			return nil, fmt.Errorf("acp1 encode float: %w", err)
@@ -225,7 +226,7 @@ func EncodeValueBytes(obj protocol.Object, acpType ObjectType, val protocol.Valu
 		binary.BigEndian.PutUint32(out, math.Float32bits(float32(f)))
 		return out, nil
 
-	case TypeIPAddr:
+	case codec.TypeIPAddr:
 		u, err := coerceIP(val)
 		if err != nil {
 			return nil, fmt.Errorf("acp1 encode ipaddr: %w", err)
@@ -234,14 +235,14 @@ func EncodeValueBytes(obj protocol.Object, acpType ObjectType, val protocol.Valu
 		binary.BigEndian.PutUint32(out, u)
 		return out, nil
 
-	case TypeEnum:
+	case codec.TypeEnum:
 		idx, err := coerceEnum(obj.EnumItems, val)
 		if err != nil {
 			return nil, fmt.Errorf("acp1 encode enum: %w", err)
 		}
 		return []byte{idx}, nil
 
-	case TypeString:
+	case codec.TypeString:
 		s := val.Str
 		if obj.MaxLen > 0 && len(s) > obj.MaxLen {
 			return nil, fmt.Errorf("acp1 encode string: %d > max %d", len(s), obj.MaxLen)

--- a/internal/acp1/provider/demo.go
+++ b/internal/acp1/provider/demo.go
@@ -6,8 +6,7 @@ import (
 	"log/slog"
 	"math"
 	"time"
-
-	iacp1 "dhs/internal/acp1/consumer"
+	"dhs/internal/acp1/codec"
 )
 
 // RunAnnounceDemo oscillates the integer value at (slot, group, id)
@@ -28,7 +27,7 @@ func (s *server) RunAnnounceDemo(ctx context.Context, slot uint8, group, id uint
 	if interval <= 0 {
 		interval = 2 * time.Second
 	}
-	key := objectKey{slot: slot, group: iacp1.ObjGroup(group), id: id}
+	key := objectKey{slot: slot, group: codec.ObjGroup(group), id: id}
 	e, ok := s.tree.lookup(key)
 	if !ok {
 		s.logger.Warn("acp1 demo: target not found",
@@ -38,7 +37,7 @@ func (s *server) RunAnnounceDemo(ctx context.Context, slot uint8, group, id uint
 		)
 		return
 	}
-	if e.acpType != iacp1.TypeInteger {
+	if e.acpType != codec.TypeInteger {
 		s.logger.Warn("acp1 demo: target is not Integer (s16), skipping",
 			slog.Int("acp_type", int(e.acpType)),
 			slog.String("path", e.param.Path),
@@ -97,19 +96,19 @@ func (s *server) RunAnnounceDemo(ctx context.Context, slot uint8, group, id uint
 		// Route through the SAME path as a client setValue so the
 		// canonical.Parameter.Value update + reply bytes match what
 		// getValue would return after the change.
-		stored, err := s.applyMutation(e, iacp1.MethodSetValue, valBytes)
+		stored, err := s.applyMutation(e, codec.MethodSetValue, valBytes)
 		if err != nil {
 			s.logger.Warn("acp1 demo: apply failed", slog.String("err", err.Error()))
 			continue
 		}
 
-		announce := &iacp1.Message{
+		announce := &codec.Message{
 			MTID:     0,
 			PVER:     1,
-			MType:    iacp1.MTypeReply,
+			MType:    codec.MTypeReply,
 			MAddr:    slot,
-			MCode:    byte(iacp1.MethodSetValue),
-			ObjGroup: iacp1.ObjGroup(group),
+			MCode:    byte(codec.MethodSetValue),
+			ObjGroup: codec.ObjGroup(group),
 			ObjID:    id,
 			Value:    stored,
 		}

--- a/internal/acp1/provider/encoder.go
+++ b/internal/acp1/provider/encoder.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"dhs/internal/export/canonical"
-	iacp1 "dhs/internal/acp1/consumer"
+	"dhs/internal/acp1/codec"
 )
 
 // encodeObject builds the Value bytes returned by a getObject reply
@@ -42,27 +42,27 @@ func encodeObject(e *entry) ([]byte, error) {
 		return nil, fmt.Errorf("encodeObject: nil entry")
 	}
 	switch e.acpType {
-	case iacp1.TypeRoot:
+	case codec.TypeRoot:
 		return encodeRoot(e)
-	case iacp1.TypeInteger:
+	case codec.TypeInteger:
 		return encodeInteger(e)
-	case iacp1.TypeIPAddr:
+	case codec.TypeIPAddr:
 		return encodeIPAddr(e)
-	case iacp1.TypeFloat:
+	case codec.TypeFloat:
 		return encodeFloat(e)
-	case iacp1.TypeEnum:
+	case codec.TypeEnum:
 		return encodeEnum(e)
-	case iacp1.TypeString:
+	case codec.TypeString:
 		return encodeString(e)
-	case iacp1.TypeFrame:
+	case codec.TypeFrame:
 		return encodeFrame(e)
-	case iacp1.TypeAlarm:
+	case codec.TypeAlarm:
 		return encodeAlarm(e)
-	case iacp1.TypeFile:
+	case codec.TypeFile:
 		return encodeFile(e)
-	case iacp1.TypeLong:
+	case codec.TypeLong:
 		return encodeLong(e)
-	case iacp1.TypeByte:
+	case codec.TypeByte:
 		return encodeByte(e)
 	}
 	return nil, fmt.Errorf("encodeObject: unsupported ACP1 type %d", e.acpType)
@@ -106,37 +106,37 @@ func encodeValue(e *entry) ([]byte, error) {
 		return nil, fmt.Errorf("encodeValue: nil entry")
 	}
 	switch e.acpType {
-	case iacp1.TypeInteger:
+	case codec.TypeInteger:
 		v, err := asInt16(e.param.Value, "value")
 		if err != nil {
 			return nil, err
 		}
 		return writeI16(v), nil
-	case iacp1.TypeIPAddr:
+	case codec.TypeIPAddr:
 		v, err := ipv4ToUint32(e.param.Value)
 		if err != nil {
 			return nil, err
 		}
 		return writeU32(v), nil
-	case iacp1.TypeFloat:
+	case codec.TypeFloat:
 		v, err := asFloat32(e.param.Value, "value")
 		if err != nil {
 			return nil, err
 		}
 		return writeF32(v), nil
-	case iacp1.TypeEnum:
+	case codec.TypeEnum:
 		v, err := asUint8(e.param.Value, "value")
 		if err != nil {
 			return nil, err
 		}
 		return []byte{v}, nil
-	case iacp1.TypeString:
+	case codec.TypeString:
 		s, err := asString(e.param.Value, "value")
 		if err != nil {
 			return nil, err
 		}
 		return writeCStr(s), nil
-	case iacp1.TypeAlarm:
+	case codec.TypeAlarm:
 		v, err := asBool(e.param.Value, "value")
 		if err != nil {
 			return nil, err
@@ -145,25 +145,25 @@ func encodeValue(e *entry) ([]byte, error) {
 			return []byte{1}, nil
 		}
 		return []byte{0}, nil
-	case iacp1.TypeLong:
+	case codec.TypeLong:
 		v, err := asInt32(e.param.Value, "value")
 		if err != nil {
 			return nil, err
 		}
 		return writeI32(v), nil
-	case iacp1.TypeByte:
+	case codec.TypeByte:
 		v, err := asUint8(e.param.Value, "value")
 		if err != nil {
 			return nil, err
 		}
 		return []byte{v}, nil
-	case iacp1.TypeFile:
+	case codec.TypeFile:
 		v, err := asInt16(e.param.Default, "num_fragments") // File's "value" is num_fragments (see spec p.26)
 		if err != nil {
 			return nil, err
 		}
 		return writeI16(v), nil
-	case iacp1.TypeFrame:
+	case codec.TypeFrame:
 		return encodeFrameValue(e)
 	}
 	return nil, fmt.Errorf("encodeValue: unsupported ACP1 type %d", e.acpType)
@@ -237,7 +237,7 @@ func encodeInteger(e *entry) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	buf := newBuf(iacp1.TypeInteger, 10)
+	buf := newBuf(codec.TypeInteger, 10)
 	buf.u8(e.access)
 	buf.i16(value)
 	buf.i16(def)
@@ -288,7 +288,7 @@ func encodeLong(e *entry) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	buf := newBuf(iacp1.TypeLong, 10)
+	buf := newBuf(codec.TypeLong, 10)
 	buf.u8(e.access)
 	buf.i32(value)
 	buf.i32(def)
@@ -339,7 +339,7 @@ func encodeByte(e *entry) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	buf := newBuf(iacp1.TypeByte, 10)
+	buf := newBuf(codec.TypeByte, 10)
 	buf.u8(e.access)
 	buf.u8(value)
 	buf.u8(def)
@@ -390,7 +390,7 @@ func encodeFloat(e *entry) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	buf := newBuf(iacp1.TypeFloat, 10)
+	buf := newBuf(codec.TypeFloat, 10)
 	buf.u8(e.access)
 	buf.f32(value)
 	buf.f32(def)
@@ -441,7 +441,7 @@ func encodeIPAddr(e *entry) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	buf := newBuf(iacp1.TypeIPAddr, 10)
+	buf := newBuf(codec.TypeIPAddr, 10)
 	buf.u8(e.access)
 	buf.u32(value)
 	buf.u32(def)
@@ -486,7 +486,7 @@ func encodeEnum(e *entry) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	buf := newBuf(iacp1.TypeEnum, 8)
+	buf := newBuf(codec.TypeEnum, 8)
 	buf.u8(e.access)
 	buf.u8(value)
 	buf.u8(uint8(len(items)))
@@ -518,7 +518,7 @@ func encodeString(e *entry) ([]byte, error) {
 		return nil, err
 	}
 	maxLen := stringMaxLen(p)
-	buf := newBuf(iacp1.TypeString, 6)
+	buf := newBuf(codec.TypeString, 6)
 	buf.u8(e.access)
 	buf.cstr(limitString(value, int(maxLen)))
 	buf.u8(maxLen)
@@ -550,13 +550,13 @@ func encodeAlarm(e *entry) ([]byte, error) {
 	priority, tag := alarmPriorityTag(p)
 	onMsg, offMsg := alarmMessages(p)
 
-	buf := newBuf(iacp1.TypeAlarm, 8)
+	buf := newBuf(codec.TypeAlarm, 8)
 	buf.u8(e.access)
 	buf.u8(priority)
 	buf.u8(tag)
 	buf.cstr(limitLabel(p.Identifier))
-	buf.cstrWithLimit(onMsg, iacp1.MaxAlarmMsg)
-	buf.cstrWithLimit(offMsg, iacp1.MaxAlarmMsg)
+	buf.cstrWithLimit(onMsg, codec.MaxAlarmMsg)
+	buf.cstrWithLimit(offMsg, codec.MaxAlarmMsg)
 	return buf.bytes(), nil
 }
 
@@ -585,7 +585,7 @@ func encodeFile(e *entry) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	buf := newBuf(iacp1.TypeFile, 5)
+	buf := newBuf(codec.TypeFile, 5)
 	buf.u8(e.access)
 	buf.i16(frags)
 	buf.cstr(name)
@@ -612,7 +612,7 @@ func encodeFrame(e *entry) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	buf := newBuf(iacp1.TypeFrame, 4)
+	buf := newBuf(codec.TypeFrame, 4)
 	buf.u8(e.access)
 	buf.u8(uint8(len(slots)))
 	for _, s := range slots {
@@ -644,7 +644,7 @@ type objBuf struct {
 	buf []byte
 }
 
-func newBuf(typ iacp1.ObjectType, nProps uint8) *objBuf {
+func newBuf(typ codec.ObjectType, nProps uint8) *objBuf {
 	return &objBuf{buf: []byte{uint8(typ), nProps}}
 }
 
@@ -714,8 +714,8 @@ func writeCStr(s string) []byte {
 // limitLabel truncates identifiers to the spec-p.20 max (MaxLabelLen
 // excluding the NUL terminator). A real Axon device won't emit longer.
 func limitLabel(s string) string {
-	if len(s) > iacp1.MaxLabelLen {
-		return s[:iacp1.MaxLabelLen]
+	if len(s) > codec.MaxLabelLen {
+		return s[:codec.MaxLabelLen]
 	}
 	return s
 }
@@ -732,8 +732,8 @@ func unitOf(p *canonical.Parameter) string {
 		return ""
 	}
 	u := *p.Unit
-	if len(u) > iacp1.MaxUnitLen {
-		u = u[:iacp1.MaxUnitLen]
+	if len(u) > codec.MaxUnitLen {
+		u = u[:codec.MaxUnitLen]
 	}
 	return u
 }

--- a/internal/acp1/provider/encoder_test.go
+++ b/internal/acp1/provider/encoder_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"dhs/internal/export/canonical"
-	iacp1 "dhs/internal/acp1/consumer"
+	"dhs/internal/acp1/codec"
 )
 
 // TestEncodeDecodeRoundTrip asserts that every object type produced by
@@ -16,13 +16,13 @@ func TestEncodeDecodeRoundTrip(t *testing.T) {
 	tests := []struct {
 		name  string
 		entry *entry
-		check func(*testing.T, *iacp1.DecodedObject)
+		check func(*testing.T, *codec.DecodedObject)
 	}{
 		{
 			name: "integer",
 			entry: &entry{
-				acpType: iacp1.TypeInteger,
-				access:  iacp1.AccessRead | iacp1.AccessWrite,
+				acpType: codec.TypeInteger,
+				access:  codec.AccessRead | codec.AccessWrite,
 				param: param("Level", canonical.ParamInteger,
 					withValue(int64(-6)),
 					withMin(int64(-60)),
@@ -32,9 +32,9 @@ func TestEncodeDecodeRoundTrip(t *testing.T) {
 					withUnit("dB"),
 				),
 			},
-			check: func(t *testing.T, o *iacp1.DecodedObject) {
-				if o.Type != iacp1.TypeInteger {
-					t.Fatalf("type=%d want %d", o.Type, iacp1.TypeInteger)
+			check: func(t *testing.T, o *codec.DecodedObject) {
+				if o.Type != codec.TypeInteger {
+					t.Fatalf("type=%d want %d", o.Type, codec.TypeInteger)
 				}
 				if o.IntVal != -6 {
 					t.Errorf("value=%d want -6", o.IntVal)
@@ -49,7 +49,7 @@ func TestEncodeDecodeRoundTrip(t *testing.T) {
 				if o.Unit != "dB" {
 					t.Errorf("unit=%q", o.Unit)
 				}
-				if o.Access != iacp1.AccessRead|iacp1.AccessWrite {
+				if o.Access != codec.AccessRead|codec.AccessWrite {
 					t.Errorf("access=%08b", o.Access)
 				}
 			},
@@ -57,8 +57,8 @@ func TestEncodeDecodeRoundTrip(t *testing.T) {
 		{
 			name: "long",
 			entry: &entry{
-				acpType: iacp1.TypeLong,
-				access:  iacp1.AccessRead,
+				acpType: codec.TypeLong,
+				access:  codec.AccessRead,
 				param: param("Counter", canonical.ParamInteger,
 					withFormat("int32"),
 					withValue(int64(1_000_000)),
@@ -66,9 +66,9 @@ func TestEncodeDecodeRoundTrip(t *testing.T) {
 					withMax(int64(2_000_000)),
 				),
 			},
-			check: func(t *testing.T, o *iacp1.DecodedObject) {
-				if o.Type != iacp1.TypeLong {
-					t.Fatalf("type=%d want %d", o.Type, iacp1.TypeLong)
+			check: func(t *testing.T, o *codec.DecodedObject) {
+				if o.Type != codec.TypeLong {
+					t.Fatalf("type=%d want %d", o.Type, codec.TypeLong)
 				}
 				if o.IntVal != 1_000_000 || o.MinInt != 0 || o.MaxInt != 2_000_000 {
 					t.Errorf("value=%d min=%d max=%d", o.IntVal, o.MinInt, o.MaxInt)
@@ -78,8 +78,8 @@ func TestEncodeDecodeRoundTrip(t *testing.T) {
 		{
 			name: "byte",
 			entry: &entry{
-				acpType: iacp1.TypeByte,
-				access:  iacp1.AccessRead | iacp1.AccessWrite,
+				acpType: codec.TypeByte,
+				access:  codec.AccessRead | codec.AccessWrite,
 				param: param("Saturation", canonical.ParamInteger,
 					withFormat("uint8"),
 					withValue(int64(128)),
@@ -87,9 +87,9 @@ func TestEncodeDecodeRoundTrip(t *testing.T) {
 					withMax(int64(255)),
 				),
 			},
-			check: func(t *testing.T, o *iacp1.DecodedObject) {
-				if o.Type != iacp1.TypeByte {
-					t.Fatalf("type=%d want %d", o.Type, iacp1.TypeByte)
+			check: func(t *testing.T, o *codec.DecodedObject) {
+				if o.Type != codec.TypeByte {
+					t.Fatalf("type=%d want %d", o.Type, codec.TypeByte)
 				}
 				if o.ByteVal != 128 || o.MinByte != 0 || o.MaxByte != 255 {
 					t.Errorf("value=%d min=%d max=%d", o.ByteVal, o.MinByte, o.MaxByte)
@@ -99,8 +99,8 @@ func TestEncodeDecodeRoundTrip(t *testing.T) {
 		{
 			name: "float",
 			entry: &entry{
-				acpType: iacp1.TypeFloat,
-				access:  iacp1.AccessRead | iacp1.AccessWrite,
+				acpType: codec.TypeFloat,
+				access:  codec.AccessRead | codec.AccessWrite,
 				param: param("Frequency", canonical.ParamReal,
 					withValue(float64(440.0)),
 					withMin(float64(20.0)),
@@ -110,8 +110,8 @@ func TestEncodeDecodeRoundTrip(t *testing.T) {
 					withUnit("Hz"),
 				),
 			},
-			check: func(t *testing.T, o *iacp1.DecodedObject) {
-				if o.Type != iacp1.TypeFloat {
+			check: func(t *testing.T, o *codec.DecodedObject) {
+				if o.Type != codec.TypeFloat {
 					t.Fatalf("type=%d want float", o.Type)
 				}
 				if o.FloatVal < 439.99 || o.FloatVal > 440.01 {
@@ -125,15 +125,15 @@ func TestEncodeDecodeRoundTrip(t *testing.T) {
 		{
 			name: "ipaddr",
 			entry: &entry{
-				acpType: iacp1.TypeIPAddr,
-				access:  iacp1.AccessRead | iacp1.AccessWrite,
+				acpType: codec.TypeIPAddr,
+				access:  codec.AccessRead | codec.AccessWrite,
 				param: param("Gateway", canonical.ParamString,
 					withFormat("ipv4"),
 					withValue("192.168.1.1"),
 				),
 			},
-			check: func(t *testing.T, o *iacp1.DecodedObject) {
-				if o.Type != iacp1.TypeIPAddr {
+			check: func(t *testing.T, o *codec.DecodedObject) {
+				if o.Type != codec.TypeIPAddr {
 					t.Fatalf("type=%d want ipaddr", o.Type)
 				}
 				want := uint32(192)<<24 | uint32(168)<<16 | uint32(1)<<8 | uint32(1)
@@ -145,16 +145,16 @@ func TestEncodeDecodeRoundTrip(t *testing.T) {
 		{
 			name: "enum",
 			entry: &entry{
-				acpType: iacp1.TypeEnum,
-				access:  iacp1.AccessRead | iacp1.AccessWrite,
+				acpType: codec.TypeEnum,
+				access:  codec.AccessRead | codec.AccessWrite,
 				param: param("Mode", canonical.ParamEnum,
 					withValue(int64(2)),
 					withDefault(int64(0)),
 					withEnumMap("Off", "On", "Auto"),
 				),
 			},
-			check: func(t *testing.T, o *iacp1.DecodedObject) {
-				if o.Type != iacp1.TypeEnum {
+			check: func(t *testing.T, o *codec.DecodedObject) {
+				if o.Type != codec.TypeEnum {
 					t.Fatalf("type=%d want enum", o.Type)
 				}
 				if o.ByteVal != 2 || o.NumItems != 3 {
@@ -168,15 +168,15 @@ func TestEncodeDecodeRoundTrip(t *testing.T) {
 		{
 			name: "string",
 			entry: &entry{
-				acpType: iacp1.TypeString,
-				access:  iacp1.AccessRead | iacp1.AccessWrite,
+				acpType: codec.TypeString,
+				access:  codec.AccessRead | codec.AccessWrite,
 				param: param("Label", canonical.ParamString,
 					withValue("hello"),
 					withFormat("maxLen=32"),
 				),
 			},
-			check: func(t *testing.T, o *iacp1.DecodedObject) {
-				if o.Type != iacp1.TypeString {
+			check: func(t *testing.T, o *codec.DecodedObject) {
+				if o.Type != codec.TypeString {
 					t.Fatalf("type=%d want string", o.Type)
 				}
 				if o.StrValue != "hello" {
@@ -190,16 +190,16 @@ func TestEncodeDecodeRoundTrip(t *testing.T) {
 		{
 			name: "alarm",
 			entry: &entry{
-				acpType: iacp1.TypeAlarm,
-				access:  iacp1.AccessRead,
+				acpType: codec.TypeAlarm,
+				access:  codec.AccessRead,
 				param: param("OverTemp", canonical.ParamBoolean,
 					withValue(false),
 					withFormat("alarm,priority=2,tag=17"),
 					withDescription("on: Overheat / off: OK"),
 				),
 			},
-			check: func(t *testing.T, o *iacp1.DecodedObject) {
-				if o.Type != iacp1.TypeAlarm {
+			check: func(t *testing.T, o *codec.DecodedObject) {
+				if o.Type != codec.TypeAlarm {
 					t.Fatalf("type=%d want alarm", o.Type)
 				}
 				if o.Priority != 2 || o.Tag != 17 {
@@ -213,16 +213,16 @@ func TestEncodeDecodeRoundTrip(t *testing.T) {
 		{
 			name: "file",
 			entry: &entry{
-				acpType: iacp1.TypeFile,
-				access:  iacp1.AccessRead | iacp1.AccessWrite,
+				acpType: codec.TypeFile,
+				access:  codec.AccessRead | codec.AccessWrite,
 				param: param("firmware.bin", canonical.ParamString,
 					withFormat("file"),
 					withValue("firmware.bin"),
 					withDefault(int64(42)),
 				),
 			},
-			check: func(t *testing.T, o *iacp1.DecodedObject) {
-				if o.Type != iacp1.TypeFile {
+			check: func(t *testing.T, o *codec.DecodedObject) {
+				if o.Type != codec.TypeFile {
 					t.Fatalf("type=%d want file", o.Type)
 				}
 				if o.FileName != "firmware.bin" {
@@ -236,15 +236,15 @@ func TestEncodeDecodeRoundTrip(t *testing.T) {
 		{
 			name: "frame",
 			entry: &entry{
-				acpType: iacp1.TypeFrame,
-				access:  iacp1.AccessRead,
+				acpType: codec.TypeFrame,
+				access:  codec.AccessRead,
 				param: param("slotStatus", canonical.ParamOctets,
 					withFormat("frame"),
 					withValue([]any{int64(2), int64(2), int64(0), int64(3)}),
 				),
 			},
-			check: func(t *testing.T, o *iacp1.DecodedObject) {
-				if o.Type != iacp1.TypeFrame {
+			check: func(t *testing.T, o *codec.DecodedObject) {
+				if o.Type != codec.TypeFrame {
 					t.Fatalf("type=%d want frame", o.Type)
 				}
 				if o.NumSlots != 4 {
@@ -263,7 +263,7 @@ func TestEncodeDecodeRoundTrip(t *testing.T) {
 			if err != nil {
 				t.Fatalf("encode: %v", err)
 			}
-			o, err := iacp1.DecodeObject(raw)
+			o, err := codec.DecodeObject(raw)
 			if err != nil {
 				t.Fatalf("decode %q: %v", hexString(raw), err)
 			}
@@ -282,52 +282,52 @@ func TestEncodeValue(t *testing.T) {
 	}{
 		{
 			name: "int16 positive",
-			entry: &entry{acpType: iacp1.TypeInteger, param: param("v", canonical.ParamInteger, withValue(int64(300)))},
+			entry: &entry{acpType: codec.TypeInteger, param: param("v", canonical.ParamInteger, withValue(int64(300)))},
 			want: []byte{0x01, 0x2C},
 		},
 		{
 			name: "int16 negative",
-			entry: &entry{acpType: iacp1.TypeInteger, param: param("v", canonical.ParamInteger, withValue(int64(-1)))},
+			entry: &entry{acpType: codec.TypeInteger, param: param("v", canonical.ParamInteger, withValue(int64(-1)))},
 			want: []byte{0xFF, 0xFF},
 		},
 		{
 			name: "byte",
-			entry: &entry{acpType: iacp1.TypeByte, param: param("v", canonical.ParamInteger, withFormat("uint8"), withValue(int64(200)))},
+			entry: &entry{acpType: codec.TypeByte, param: param("v", canonical.ParamInteger, withFormat("uint8"), withValue(int64(200)))},
 			want: []byte{0xC8},
 		},
 		{
 			name: "long",
-			entry: &entry{acpType: iacp1.TypeLong, param: param("v", canonical.ParamInteger, withFormat("int32"), withValue(int64(1_000_000)))},
+			entry: &entry{acpType: codec.TypeLong, param: param("v", canonical.ParamInteger, withFormat("int32"), withValue(int64(1_000_000)))},
 			want: []byte{0x00, 0x0F, 0x42, 0x40},
 		},
 		{
 			name: "ipaddr",
-			entry: &entry{acpType: iacp1.TypeIPAddr, param: param("v", canonical.ParamString, withFormat("ipv4"), withValue("10.0.0.1"))},
+			entry: &entry{acpType: codec.TypeIPAddr, param: param("v", canonical.ParamString, withFormat("ipv4"), withValue("10.0.0.1"))},
 			want: []byte{0x0A, 0x00, 0x00, 0x01},
 		},
 		{
 			name: "enum",
-			entry: &entry{acpType: iacp1.TypeEnum, param: param("v", canonical.ParamEnum, withValue(int64(1)))},
+			entry: &entry{acpType: codec.TypeEnum, param: param("v", canonical.ParamEnum, withValue(int64(1)))},
 			want: []byte{0x01},
 		},
 		{
 			name: "string",
-			entry: &entry{acpType: iacp1.TypeString, param: param("v", canonical.ParamString, withValue("hi"))},
+			entry: &entry{acpType: codec.TypeString, param: param("v", canonical.ParamString, withValue("hi"))},
 			want: []byte{'h', 'i', 0},
 		},
 		{
 			name: "alarm active",
-			entry: &entry{acpType: iacp1.TypeAlarm, param: param("v", canonical.ParamBoolean, withFormat("alarm"), withValue(true))},
+			entry: &entry{acpType: codec.TypeAlarm, param: param("v", canonical.ParamBoolean, withFormat("alarm"), withValue(true))},
 			want: []byte{0x01},
 		},
 		{
 			name: "frame",
-			entry: &entry{acpType: iacp1.TypeFrame, param: param("v", canonical.ParamOctets, withFormat("frame"), withValue([]any{int64(2), int64(0), int64(2)}))},
+			entry: &entry{acpType: codec.TypeFrame, param: param("v", canonical.ParamOctets, withFormat("frame"), withValue([]any{int64(2), int64(0), int64(2)}))},
 			want: []byte{0x03, 0x02, 0x00, 0x02},
 		},
 		{
 			name:    "overflow int16",
-			entry:   &entry{acpType: iacp1.TypeInteger, param: param("v", canonical.ParamInteger, withValue(int64(40000)))},
+			entry:   &entry{acpType: codec.TypeInteger, param: param("v", canonical.ParamInteger, withValue(int64(40000)))},
 			wantErr: true,
 		},
 	}
@@ -356,21 +356,21 @@ func TestDeriveACPType(t *testing.T) {
 	cases := []struct {
 		name   string
 		p      *canonical.Parameter
-		want   iacp1.ObjectType
+		want   codec.ObjectType
 		wantOK bool
 	}{
-		{"integer default", param("x", canonical.ParamInteger), iacp1.TypeInteger, true},
-		{"integer int32", param("x", canonical.ParamInteger, withFormat("int32")), iacp1.TypeLong, true},
-		{"integer uint8", param("x", canonical.ParamInteger, withFormat("uint8")), iacp1.TypeByte, true},
+		{"integer default", param("x", canonical.ParamInteger), codec.TypeInteger, true},
+		{"integer int32", param("x", canonical.ParamInteger, withFormat("int32")), codec.TypeLong, true},
+		{"integer uint8", param("x", canonical.ParamInteger, withFormat("uint8")), codec.TypeByte, true},
 		{"integer bad", param("x", canonical.ParamInteger, withFormat("uint16")), 0, false},
-		{"real", param("x", canonical.ParamReal), iacp1.TypeFloat, true},
-		{"enum", param("x", canonical.ParamEnum), iacp1.TypeEnum, true},
-		{"string default", param("x", canonical.ParamString), iacp1.TypeString, true},
-		{"ipv4", param("x", canonical.ParamString, withFormat("ipv4")), iacp1.TypeIPAddr, true},
-		{"file", param("x", canonical.ParamString, withFormat("file")), iacp1.TypeFile, true},
-		{"alarm", param("x", canonical.ParamBoolean, withFormat("alarm")), iacp1.TypeAlarm, true},
+		{"real", param("x", canonical.ParamReal), codec.TypeFloat, true},
+		{"enum", param("x", canonical.ParamEnum), codec.TypeEnum, true},
+		{"string default", param("x", canonical.ParamString), codec.TypeString, true},
+		{"ipv4", param("x", canonical.ParamString, withFormat("ipv4")), codec.TypeIPAddr, true},
+		{"file", param("x", canonical.ParamString, withFormat("file")), codec.TypeFile, true},
+		{"alarm", param("x", canonical.ParamBoolean, withFormat("alarm")), codec.TypeAlarm, true},
 		{"boolean no hint REJECTED", param("x", canonical.ParamBoolean), 0, false},
-		{"frame", param("x", canonical.ParamOctets, withFormat("frame")), iacp1.TypeFrame, true},
+		{"frame", param("x", canonical.ParamOctets, withFormat("frame")), codec.TypeFrame, true},
 		{"octets no hint REJECTED", param("x", canonical.ParamOctets), 0, false},
 	}
 	for _, tc := range cases {

--- a/internal/acp1/provider/plugin.go
+++ b/internal/acp1/provider/plugin.go
@@ -22,12 +22,12 @@ import (
 
 	"dhs/internal/export/canonical"
 	"dhs/internal/provider"
-	iacp1 "dhs/internal/acp1/consumer"
+	"dhs/internal/acp1/codec"
 )
 
 // DefaultPort is the IANA-assigned ACP port for both UDP and TCP direct.
 // Matches the consumer plugin's default.
-const DefaultPort = iacp1.DefaultPort
+const DefaultPort = codec.DefaultPort
 
 func init() {
 	provider.Register(&Factory{})
@@ -40,7 +40,7 @@ type Factory struct{}
 func (f *Factory) Meta() provider.Meta {
 	return provider.Meta{
 		Name:        "acp1",
-		DefaultPort: DefaultPort,
+		DefaultPort: codec.DefaultPort,
 		Description: "ACP1 (AxonNet) provider — serves a canonical tree to consumers over UDP:2071",
 	}
 }

--- a/internal/acp1/provider/server.go
+++ b/internal/acp1/provider/server.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 
 	"dhs/internal/export/canonical"
-	iacp1 "dhs/internal/acp1/consumer"
+	"dhs/internal/acp1/codec"
 )
 
 // Server is the exported alias for the concrete ACP1 provider — lets
@@ -163,7 +163,7 @@ func (s *server) SetValue(_ context.Context, path string, val any) (any, error) 
 	if err != nil {
 		return nil, err
 	}
-	if _, err := s.applyMutation(e, iacp1.MethodSetValue, bytes); err != nil {
+	if _, err := s.applyMutation(e, codec.MethodSetValue, bytes); err != nil {
 		return nil, err
 	}
 	return convertStoredValue(e.param), nil
@@ -174,7 +174,7 @@ func (s *server) SetValue(_ context.Context, path string, val any) (any, error) 
 // mutating method per spec §"Announcements" p.14. Silent on send error
 // — announcements are fire-and-forget, and the consumer that made the
 // setX call already has the change confirmed via the reply.
-func (s *server) broadcastAnnounce(ann *iacp1.Message) {
+func (s *server) broadcastAnnounce(ann *codec.Message) {
 	s.mu.Lock()
 	bc := s.bcast
 	s.mu.Unlock()

--- a/internal/acp1/provider/session.go
+++ b/internal/acp1/provider/session.go
@@ -2,8 +2,7 @@ package acp1
 
 import (
 	"log/slog"
-
-	iacp1 "dhs/internal/acp1/consumer"
+	"dhs/internal/acp1/codec"
 )
 
 // handleRequest dispatches a decoded request to the right handler and
@@ -17,12 +16,12 @@ import (
 //
 // Returns (nil, nil) for messages that should be silently dropped
 // (announcements and replies from other providers, error messages).
-func (s *server) handleRequest(msg *iacp1.Message) (*iacp1.Message, *iacp1.Message) {
-	if msg.MType != iacp1.MTypeRequest {
+func (s *server) handleRequest(msg *codec.Message) (*codec.Message, *codec.Message) {
+	if msg.MType != codec.MTypeRequest {
 		return nil, nil
 	}
 
-	if msg.ObjGroup == iacp1.GroupRoot && msg.ObjID == 0 {
+	if msg.ObjGroup == codec.GroupRoot && msg.ObjID == 0 {
 		return s.handleRoot(msg), nil
 	}
 
@@ -32,31 +31,31 @@ func (s *server) handleRequest(msg *iacp1.Message) (*iacp1.Message, *iacp1.Messa
 		return errorReply(msg, groupOrInstanceMissing(s, key)), nil
 	}
 
-	method := iacp1.Method(msg.MCode)
+	method := codec.Method(msg.MCode)
 	if !methodSupported(e.acpType, method) {
-		return errorReply(msg, iacp1.OErrIllegalForType), nil
+		return errorReply(msg, codec.OErrIllegalForType), nil
 	}
 	if err := checkAccess(e.access, method); err != 0 {
 		return errorReply(msg, err), nil
 	}
 
 	switch method {
-	case iacp1.MethodGetValue:
+	case codec.MethodGetValue:
 		raw, err := encodeValue(e)
 		if err != nil {
 			s.logger.Error("getValue encode", slog.String("oid", e.param.OID), slog.String("err", err.Error()))
-			return errorReply(msg, iacp1.OErrIllegalForType), nil
+			return errorReply(msg, codec.OErrIllegalForType), nil
 		}
 		return reply(msg, raw), nil
-	case iacp1.MethodGetObject:
+	case codec.MethodGetObject:
 		raw, err := encodeObject(e)
 		if err != nil {
 			s.logger.Error("getObject encode", slog.String("oid", e.param.OID), slog.String("err", err.Error()))
-			return errorReply(msg, iacp1.OErrIllegalForType), nil
+			return errorReply(msg, codec.OErrIllegalForType), nil
 		}
 		return reply(msg, raw), nil
-	case iacp1.MethodSetValue, iacp1.MethodSetIncValue,
-		iacp1.MethodSetDecValue, iacp1.MethodSetDefValue:
+	case codec.MethodSetValue, codec.MethodSetIncValue,
+		codec.MethodSetDecValue, codec.MethodSetDefValue:
 		raw, err := s.applyMutation(e, method, msg.Value)
 		if err != nil {
 			s.logger.Warn("acp1 mutation",
@@ -64,11 +63,11 @@ func (s *server) handleRequest(msg *iacp1.Message) (*iacp1.Message, *iacp1.Messa
 				slog.String("method", methodName(method)),
 				slog.String("err", err.Error()),
 			)
-			return errorReply(msg, iacp1.OErrIllegalForType), nil
+			return errorReply(msg, codec.OErrIllegalForType), nil
 		}
 		return reply(msg, raw), announce(msg, raw)
 	}
-	return errorReply(msg, iacp1.OErrIllegalMethod), nil
+	return errorReply(msg, codec.OErrIllegalMethod), nil
 }
 
 // announce builds the unsolicited value-change announcement that every
@@ -76,10 +75,10 @@ func (s *server) handleRequest(msg *iacp1.Message) (*iacp1.Message, *iacp1.Messa
 //
 // Shape: MTID=0 (announcement marker), MType=2 (Reply), MCode=set*,
 // MAddr=slot, ObjGroup/ObjID=changed object, Value=new stored bytes.
-func announce(req *iacp1.Message, value []byte) *iacp1.Message {
-	return &iacp1.Message{
+func announce(req *codec.Message, value []byte) *codec.Message {
+	return &codec.Message{
 		MTID:     0,
-		MType:    iacp1.MTypeReply,
+		MType:    codec.MTypeReply,
 		MAddr:    req.MAddr,
 		MCode:    req.MCode,
 		ObjGroup: req.ObjGroup,
@@ -89,19 +88,19 @@ func announce(req *iacp1.Message, value []byte) *iacp1.Message {
 }
 
 // methodName is a small helper so debug logs read "setValue" not "1".
-func methodName(m iacp1.Method) string {
+func methodName(m codec.Method) string {
 	switch m {
-	case iacp1.MethodGetValue:
+	case codec.MethodGetValue:
 		return "getValue"
-	case iacp1.MethodSetValue:
+	case codec.MethodSetValue:
 		return "setValue"
-	case iacp1.MethodSetIncValue:
+	case codec.MethodSetIncValue:
 		return "setIncValue"
-	case iacp1.MethodSetDecValue:
+	case codec.MethodSetDecValue:
 		return "setDecValue"
-	case iacp1.MethodSetDefValue:
+	case codec.MethodSetDefValue:
 		return "setDefValue"
-	case iacp1.MethodGetObject:
+	case codec.MethodGetObject:
 		return "getObject"
 	}
 	return "unknown"
@@ -110,24 +109,24 @@ func methodName(m iacp1.Method) string {
 // handleRoot synthesises the Root (group=0, id=0) reply for the
 // requested slot. Real Axon cards answer Root for their own slot with
 // the per-slot object counters; we do the same from tree.slots.
-func (s *server) handleRoot(msg *iacp1.Message) *iacp1.Message {
+func (s *server) handleRoot(msg *codec.Message) *codec.Message {
 	s.tree.mu.RLock()
 	counts, ok := s.tree.slots[msg.MAddr]
 	s.tree.mu.RUnlock()
 	if !ok {
-		return errorReply(msg, iacp1.OErrInstanceNoExist)
+		return errorReply(msg, codec.OErrInstanceNoExist)
 	}
 
-	switch iacp1.Method(msg.MCode) {
-	case iacp1.MethodGetValue:
+	switch codec.Method(msg.MCode) {
+	case codec.MethodGetValue:
 		// Spec p.21: Root.getValue returns the single "boot_mode" byte.
 		// We report boot_mode=0 (normal operation). Firmware-upgrade
 		// mode (1) is out of scope for the provider.
 		return reply(msg, []byte{0})
-	case iacp1.MethodGetObject:
+	case codec.MethodGetObject:
 		return reply(msg, encodeRootObject(counts))
 	}
-	return errorReply(msg, iacp1.OErrIllegalMethod)
+	return errorReply(msg, codec.OErrIllegalMethod)
 }
 
 // encodeRootObject builds the 9-property getObject reply for the Root
@@ -135,9 +134,9 @@ func (s *server) handleRoot(msg *iacp1.Message) *iacp1.Message {
 // num_control, num_status, num_alarm, num_file.
 func encodeRootObject(c *slotCounts) []byte {
 	return []byte{
-		byte(iacp1.TypeRoot),        // object_type
+		byte(codec.TypeRoot),        // object_type
 		9,                           // num_properties
-		iacp1.AccessRead,            // access — Root is always read-only
+		codec.AccessRead,            // access — Root is always read-only
 		0,                           // boot_mode
 		c.numIdentity,               // num_identity
 		c.numControl,                // num_control
@@ -150,10 +149,10 @@ func encodeRootObject(c *slotCounts) []byte {
 // reply builds a successful reply message mirroring the request's
 // MTID, slot (MAddr), method (MCode), and object addressing. Per spec
 // the reply MUST carry the same MTID so the client can correlate.
-func reply(req *iacp1.Message, value []byte) *iacp1.Message {
-	return &iacp1.Message{
+func reply(req *codec.Message, value []byte) *codec.Message {
+	return &codec.Message{
 		MTID:     req.MTID,
-		MType:    iacp1.MTypeReply,
+		MType:    codec.MTypeReply,
 		MAddr:    req.MAddr,
 		MCode:    req.MCode,
 		ObjGroup: req.ObjGroup,
@@ -168,10 +167,10 @@ func reply(req *iacp1.Message, value []byte) *iacp1.Message {
 // Encode() writes only the MCode byte for Error messages — ObjGroup/
 // ObjID are ignored on the wire — but keeping them set helps any
 // middleware that inspects the struct.
-func errorReply(req *iacp1.Message, code iacp1.ObjectErrCode) *iacp1.Message {
-	return &iacp1.Message{
+func errorReply(req *codec.Message, code codec.ObjectErrCode) *codec.Message {
+	return &codec.Message{
 		MTID:     req.MTID,
-		MType:    iacp1.MTypeError,
+		MType:    codec.MTypeError,
 		MAddr:    req.MAddr,
 		MCode:    byte(code),
 		ObjGroup: req.ObjGroup,
@@ -182,30 +181,30 @@ func errorReply(req *iacp1.Message, code iacp1.ObjectErrCode) *iacp1.Message {
 // methodSupported implements the spec "Method Support Matrix" (CLAUDE.md
 // under §ACP1 Method Support Matrix). Ensures we emit OErrIllegalForType
 // rather than crashing on e.g. setIncValue of an Alarm.
-func methodSupported(t iacp1.ObjectType, m iacp1.Method) bool {
+func methodSupported(t codec.ObjectType, m codec.Method) bool {
 	switch t {
-	case iacp1.TypeRoot:
-		return m == iacp1.MethodGetValue || m == iacp1.MethodGetObject
-	case iacp1.TypeInteger, iacp1.TypeLong, iacp1.TypeFloat, iacp1.TypeByte, iacp1.TypeIPAddr:
+	case codec.TypeRoot:
+		return m == codec.MethodGetValue || m == codec.MethodGetObject
+	case codec.TypeInteger, codec.TypeLong, codec.TypeFloat, codec.TypeByte, codec.TypeIPAddr:
 		// Numeric-with-step types support all six methods.
 		return true
-	case iacp1.TypeEnum:
+	case codec.TypeEnum:
 		// No inc/dec on enums (no step).
 		switch m {
-		case iacp1.MethodGetValue, iacp1.MethodSetValue,
-			iacp1.MethodSetDefValue, iacp1.MethodGetObject:
+		case codec.MethodGetValue, codec.MethodSetValue,
+			codec.MethodSetDefValue, codec.MethodGetObject:
 			return true
 		}
 		return false
-	case iacp1.TypeString:
+	case codec.TypeString:
 		// No inc/dec/setDef on strings.
 		switch m {
-		case iacp1.MethodGetValue, iacp1.MethodSetValue, iacp1.MethodGetObject:
+		case codec.MethodGetValue, codec.MethodSetValue, codec.MethodGetObject:
 			return true
 		}
 		return false
-	case iacp1.TypeAlarm, iacp1.TypeFile, iacp1.TypeFrame:
-		return m == iacp1.MethodGetValue || m == iacp1.MethodGetObject
+	case codec.TypeAlarm, codec.TypeFile, codec.TypeFrame:
+		return m == codec.MethodGetValue || m == codec.MethodGetObject
 	}
 	return false
 }
@@ -213,22 +212,22 @@ func methodSupported(t iacp1.ObjectType, m iacp1.Method) bool {
 // checkAccess maps the requested method to the access bit required by
 // spec p.20 and returns 0 if the entry grants it, or the appropriate
 // OErrNo*Access code otherwise.
-func checkAccess(access uint8, m iacp1.Method) iacp1.ObjectErrCode {
+func checkAccess(access uint8, m codec.Method) codec.ObjectErrCode {
 	switch m {
-	case iacp1.MethodGetValue, iacp1.MethodGetObject:
-		if access&iacp1.AccessRead == 0 {
-			return iacp1.OErrNoReadAccess
+	case codec.MethodGetValue, codec.MethodGetObject:
+		if access&codec.AccessRead == 0 {
+			return codec.OErrNoReadAccess
 		}
-	case iacp1.MethodSetValue, iacp1.MethodSetIncValue, iacp1.MethodSetDecValue:
-		if access&iacp1.AccessWrite == 0 {
-			return iacp1.OErrNoWriteAccess
+	case codec.MethodSetValue, codec.MethodSetIncValue, codec.MethodSetDecValue:
+		if access&codec.AccessWrite == 0 {
+			return codec.OErrNoWriteAccess
 		}
-	case iacp1.MethodSetDefValue:
-		if access&iacp1.AccessSetDef == 0 {
-			return iacp1.OErrNoSetDefAccess
+	case codec.MethodSetDefValue:
+		if access&codec.AccessSetDef == 0 {
+			return codec.OErrNoSetDefAccess
 		}
 	default:
-		return iacp1.OErrIllegalMethod
+		return codec.OErrIllegalMethod
 	}
 	return 0
 }
@@ -238,15 +237,15 @@ func checkAccess(access uint8, m iacp1.Method) iacp1.ObjectErrCode {
 // group (spec code 17). Walk the flat index once looking for any entry
 // matching slot+group — cheap at the 2-3k-object scale a real frame
 // carries.
-func groupOrInstanceMissing(s *server, k objectKey) iacp1.ObjectErrCode {
+func groupOrInstanceMissing(s *server, k objectKey) codec.ObjectErrCode {
 	s.tree.mu.RLock()
 	defer s.tree.mu.RUnlock()
 	for key := range s.tree.entries {
 		if key.slot == k.slot && key.group == k.group {
-			return iacp1.OErrInstanceNoExist
+			return codec.OErrInstanceNoExist
 		}
 	}
-	return iacp1.OErrGroupNoExist
+	return codec.OErrGroupNoExist
 }
 
 // -----------------------------------------------------------------
@@ -261,7 +260,7 @@ func (s *server) handleDatagram2(data []byte, srcStr string, send func([]byte) e
 		slog.String("src", srcStr),
 		slog.Int("bytes", len(data)),
 	)
-	msg, err := iacp1.Decode(data)
+	msg, err := codec.Decode(data)
 	if err != nil {
 		s.logger.Warn("acp1 provider: decode failed",
 			slog.String("src", srcStr),

--- a/internal/acp1/provider/session_test.go
+++ b/internal/acp1/provider/session_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"dhs/internal/export/canonical"
-	iacp1 "dhs/internal/acp1/consumer"
+	"dhs/internal/acp1/codec"
 )
 
 // newTestServer builds a server with a hand-crafted tree containing two
@@ -113,17 +113,17 @@ func newTestServer(t *testing.T) *server {
 
 func TestSession_GetValue_ReadOnlyString(t *testing.T) {
 	s := newTestServer(t)
-	req := &iacp1.Message{
-		MTID: 42, MType: iacp1.MTypeRequest, MAddr: 1,
-		MCode: byte(iacp1.MethodGetValue),
-		ObjGroup: iacp1.GroupIdentity, ObjID: 0,
+	req := &codec.Message{
+		MTID: 42, MType: codec.MTypeRequest, MAddr: 1,
+		MCode: byte(codec.MethodGetValue),
+		ObjGroup: codec.GroupIdentity, ObjID: 0,
 	}
 	rep, _ := s.handleRequest(req)
 	if rep == nil {
 		t.Fatal("nil reply")
 	}
-	if rep.MType != iacp1.MTypeReply {
-		t.Fatalf("MType=%d want reply", rep.MType)
+	if rep.MType != codec.MTypeReply {
+		t.Fatalf("codec.MType=%d want reply", rep.MType)
 	}
 	if rep.MTID != 42 {
 		t.Fatalf("MTID mirror broken: got %d", rep.MTID)
@@ -137,20 +137,20 @@ func TestSession_GetValue_ReadOnlyString(t *testing.T) {
 
 func TestSession_GetObject_Integer(t *testing.T) {
 	s := newTestServer(t)
-	req := &iacp1.Message{
-		MTID: 7, MType: iacp1.MTypeRequest, MAddr: 1,
-		MCode: byte(iacp1.MethodGetObject),
-		ObjGroup: iacp1.GroupControl, ObjID: 0,
+	req := &codec.Message{
+		MTID: 7, MType: codec.MTypeRequest, MAddr: 1,
+		MCode: byte(codec.MethodGetObject),
+		ObjGroup: codec.GroupControl, ObjID: 0,
 	}
 	rep, _ := s.handleRequest(req)
-	if rep == nil || rep.MType != iacp1.MTypeReply {
+	if rep == nil || rep.MType != codec.MTypeReply {
 		t.Fatalf("bad reply: %+v", rep)
 	}
-	o, err := iacp1.DecodeObject(rep.Value)
+	o, err := codec.DecodeObject(rep.Value)
 	if err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if o.Type != iacp1.TypeInteger {
+	if o.Type != codec.TypeInteger {
 		t.Fatalf("type=%d", o.Type)
 	}
 	if o.IntVal != -6 || o.MinInt != -60 || o.MaxInt != 12 {
@@ -164,13 +164,13 @@ func TestSession_GetObject_Integer(t *testing.T) {
 func TestSession_Root_Synthesised(t *testing.T) {
 	s := newTestServer(t)
 	// getValue on Root returns boot_mode byte (0 = normal).
-	req := &iacp1.Message{
-		MTID: 1, MType: iacp1.MTypeRequest, MAddr: 1,
-		MCode: byte(iacp1.MethodGetValue),
-		ObjGroup: iacp1.GroupRoot, ObjID: 0,
+	req := &codec.Message{
+		MTID: 1, MType: codec.MTypeRequest, MAddr: 1,
+		MCode: byte(codec.MethodGetValue),
+		ObjGroup: codec.GroupRoot, ObjID: 0,
 	}
 	rep, _ := s.handleRequest(req)
-	if rep == nil || rep.MType != iacp1.MTypeReply {
+	if rep == nil || rep.MType != codec.MTypeReply {
 		t.Fatalf("bad reply: %+v", rep)
 	}
 	if len(rep.Value) != 1 || rep.Value[0] != 0 {
@@ -180,9 +180,9 @@ func TestSession_Root_Synthesised(t *testing.T) {
 	// getObject on Root returns 9 properties: type(0), numProps(9),
 	// access(1=read), boot_mode(0), numIdentity(1), numControl(1),
 	// numStatus(0), numAlarm(0), numFile(0).
-	req.MCode = byte(iacp1.MethodGetObject)
+	req.MCode = byte(codec.MethodGetObject)
 	rep, _ = s.handleRequest(req)
-	if rep == nil || rep.MType != iacp1.MTypeReply {
+	if rep == nil || rep.MType != codec.MTypeReply {
 		t.Fatalf("bad reply: %+v", rep)
 	}
 	want := []byte{0, 9, 1, 0, 1, 1, 0, 0, 0}
@@ -194,34 +194,34 @@ func TestSession_Root_Synthesised(t *testing.T) {
 func TestSession_UnknownObject_InstanceError(t *testing.T) {
 	s := newTestServer(t)
 	// control group exists, id=99 does not.
-	req := &iacp1.Message{
-		MTID: 1, MType: iacp1.MTypeRequest, MAddr: 1,
-		MCode: byte(iacp1.MethodGetValue),
-		ObjGroup: iacp1.GroupControl, ObjID: 99,
+	req := &codec.Message{
+		MTID: 1, MType: codec.MTypeRequest, MAddr: 1,
+		MCode: byte(codec.MethodGetValue),
+		ObjGroup: codec.GroupControl, ObjID: 99,
 	}
 	rep, _ := s.handleRequest(req)
-	if rep.MType != iacp1.MTypeError {
-		t.Fatalf("want error, got MType=%d", rep.MType)
+	if rep.MType != codec.MTypeError {
+		t.Fatalf("want error, got codec.MType=%d", rep.MType)
 	}
-	if rep.MCode != byte(iacp1.OErrInstanceNoExist) {
-		t.Errorf("mcode=%d want %d", rep.MCode, iacp1.OErrInstanceNoExist)
+	if rep.MCode != byte(codec.OErrInstanceNoExist) {
+		t.Errorf("mcode=%d want %d", rep.MCode, codec.OErrInstanceNoExist)
 	}
 }
 
 func TestSession_UnknownGroup_GroupError(t *testing.T) {
 	s := newTestServer(t)
 	// Alarm group has no entries on slot 1.
-	req := &iacp1.Message{
-		MTID: 1, MType: iacp1.MTypeRequest, MAddr: 1,
-		MCode: byte(iacp1.MethodGetValue),
-		ObjGroup: iacp1.GroupAlarm, ObjID: 0,
+	req := &codec.Message{
+		MTID: 1, MType: codec.MTypeRequest, MAddr: 1,
+		MCode: byte(codec.MethodGetValue),
+		ObjGroup: codec.GroupAlarm, ObjID: 0,
 	}
 	rep, _ := s.handleRequest(req)
-	if rep.MType != iacp1.MTypeError {
+	if rep.MType != codec.MTypeError {
 		t.Fatalf("want error")
 	}
-	if rep.MCode != byte(iacp1.OErrGroupNoExist) {
-		t.Errorf("mcode=%d want %d", rep.MCode, iacp1.OErrGroupNoExist)
+	if rep.MCode != byte(codec.OErrGroupNoExist) {
+		t.Errorf("mcode=%d want %d", rep.MCode, codec.OErrGroupNoExist)
 	}
 }
 
@@ -229,21 +229,21 @@ func TestSession_SetValue_RoundTrip(t *testing.T) {
 	s := newTestServer(t)
 	// Control slot-1 id=0 is Level (int16, min=-60 max=12, currently -6).
 	// Write 5, expect echo 5.
-	req := &iacp1.Message{
-		MTID: 1, MType: iacp1.MTypeRequest, MAddr: 1,
-		MCode:    byte(iacp1.MethodSetValue),
-		ObjGroup: iacp1.GroupControl, ObjID: 0,
+	req := &codec.Message{
+		MTID: 1, MType: codec.MTypeRequest, MAddr: 1,
+		MCode:    byte(codec.MethodSetValue),
+		ObjGroup: codec.GroupControl, ObjID: 0,
 		Value: []byte{0x00, 0x05},
 	}
 	rep, _ := s.handleRequest(req)
-	if rep.MType != iacp1.MTypeReply {
+	if rep.MType != codec.MTypeReply {
 		t.Fatalf("bad reply: %+v", rep)
 	}
 	if string(rep.Value) != string([]byte{0x00, 0x05}) {
 		t.Fatalf("echo bytes=%x want 0005", rep.Value)
 	}
 	// Re-read via getValue to confirm persistence.
-	req.MCode = byte(iacp1.MethodGetValue)
+	req.MCode = byte(codec.MethodGetValue)
 	req.Value = nil
 	rep, _ = s.handleRequest(req)
 	if string(rep.Value) != string([]byte{0x00, 0x05}) {
@@ -254,14 +254,14 @@ func TestSession_SetValue_RoundTrip(t *testing.T) {
 func TestSession_SetValue_ClampsToMax(t *testing.T) {
 	s := newTestServer(t)
 	// Level max=12; request 100 -> clamped to 12.
-	req := &iacp1.Message{
-		MTID: 1, MType: iacp1.MTypeRequest, MAddr: 1,
-		MCode:    byte(iacp1.MethodSetValue),
-		ObjGroup: iacp1.GroupControl, ObjID: 0,
+	req := &codec.Message{
+		MTID: 1, MType: codec.MTypeRequest, MAddr: 1,
+		MCode:    byte(codec.MethodSetValue),
+		ObjGroup: codec.GroupControl, ObjID: 0,
 		Value: []byte{0x00, 0x64}, // 100
 	}
 	rep, _ := s.handleRequest(req)
-	if rep.MType != iacp1.MTypeReply {
+	if rep.MType != codec.MTypeReply {
 		t.Fatalf("bad reply: %+v", rep)
 	}
 	if string(rep.Value) != string([]byte{0x00, 0x0C}) {
@@ -272,18 +272,18 @@ func TestSession_SetValue_ClampsToMax(t *testing.T) {
 func TestSession_SetIncDec_RespectsStepAndLimits(t *testing.T) {
 	s := newTestServer(t)
 	// Level: start at -6, step=1, min=-60, max=12.
-	req := &iacp1.Message{
-		MTID: 1, MType: iacp1.MTypeRequest, MAddr: 1,
-		MCode:    byte(iacp1.MethodSetIncValue),
-		ObjGroup: iacp1.GroupControl, ObjID: 0,
+	req := &codec.Message{
+		MTID: 1, MType: codec.MTypeRequest, MAddr: 1,
+		MCode:    byte(codec.MethodSetIncValue),
+		ObjGroup: codec.GroupControl, ObjID: 0,
 	}
 	// Inc from -6 -> -5.
 	rep, _ := s.handleRequest(req)
-	if rep.MType != iacp1.MTypeReply || string(rep.Value) != string([]byte{0xFF, 0xFB}) {
+	if rep.MType != codec.MTypeReply || string(rep.Value) != string([]byte{0xFF, 0xFB}) {
 		t.Fatalf("setInc bytes=%x want FFFB (-5)", rep.Value)
 	}
 	// Dec from -5 -> -6.
-	req.MCode = byte(iacp1.MethodSetDecValue)
+	req.MCode = byte(codec.MethodSetDecValue)
 	rep, _ = s.handleRequest(req)
 	if string(rep.Value) != string([]byte{0xFF, 0xFA}) {
 		t.Fatalf("setDec bytes=%x want FFFA (-6)", rep.Value)
@@ -294,26 +294,26 @@ func TestSession_SetDefValue_ResetsToDefault(t *testing.T) {
 	s := newTestServer(t)
 	// Level default=0.
 	// First set to 5 so we can observe the reset.
-	setReq := &iacp1.Message{
-		MTID: 1, MType: iacp1.MTypeRequest, MAddr: 1,
-		MCode:    byte(iacp1.MethodSetValue),
-		ObjGroup: iacp1.GroupControl, ObjID: 0,
+	setReq := &codec.Message{
+		MTID: 1, MType: codec.MTypeRequest, MAddr: 1,
+		MCode:    byte(codec.MethodSetValue),
+		ObjGroup: codec.GroupControl, ObjID: 0,
 		Value: []byte{0x00, 0x05},
 	}
 	if _, ann := s.handleRequest(setReq); ann == nil {
 		t.Fatal("setValue should have produced an announcement")
 	}
 
-	defReq := &iacp1.Message{
-		MTID: 2, MType: iacp1.MTypeRequest, MAddr: 1,
-		MCode:    byte(iacp1.MethodSetDefValue),
-		ObjGroup: iacp1.GroupControl, ObjID: 0,
+	defReq := &codec.Message{
+		MTID: 2, MType: codec.MTypeRequest, MAddr: 1,
+		MCode:    byte(codec.MethodSetDefValue),
+		ObjGroup: codec.GroupControl, ObjID: 0,
 	}
 	rep, ann := s.handleRequest(defReq)
-	if rep.MType != iacp1.MTypeReply || string(rep.Value) != string([]byte{0x00, 0x00}) {
+	if rep.MType != codec.MTypeReply || string(rep.Value) != string([]byte{0x00, 0x00}) {
 		t.Fatalf("setDef bytes=%x want 0000", rep.Value)
 	}
-	if ann == nil || ann.MTID != 0 || ann.MType != iacp1.MTypeReply {
+	if ann == nil || ann.MTID != 0 || ann.MType != codec.MTypeReply {
 		t.Fatalf("announce missing or wrong shape: %+v", ann)
 	}
 	if string(ann.Value) != string([]byte{0x00, 0x00}) {
@@ -324,18 +324,18 @@ func TestSession_SetDefValue_ResetsToDefault(t *testing.T) {
 func TestSession_SetValue_DeniedOnReadOnly(t *testing.T) {
 	s := newTestServer(t)
 	// Identity slot-1 group=1 id=0 is Model (read-only string).
-	req := &iacp1.Message{
-		MTID: 1, MType: iacp1.MTypeRequest, MAddr: 1,
-		MCode:    byte(iacp1.MethodSetValue),
-		ObjGroup: iacp1.GroupIdentity, ObjID: 0,
+	req := &codec.Message{
+		MTID: 1, MType: codec.MTypeRequest, MAddr: 1,
+		MCode:    byte(codec.MethodSetValue),
+		ObjGroup: codec.GroupIdentity, ObjID: 0,
 		Value: []byte("X\x00"),
 	}
 	rep, _ := s.handleRequest(req)
-	if rep.MType != iacp1.MTypeError {
+	if rep.MType != codec.MTypeError {
 		t.Fatalf("want error, got %+v", rep)
 	}
-	if rep.MCode != byte(iacp1.OErrNoWriteAccess) {
-		t.Errorf("mcode=%d want %d (NoWriteAccess)", rep.MCode, iacp1.OErrNoWriteAccess)
+	if rep.MCode != byte(codec.OErrNoWriteAccess) {
+		t.Errorf("mcode=%d want %d (NoWriteAccess)", rep.MCode, codec.OErrNoWriteAccess)
 	}
 }
 
@@ -354,41 +354,41 @@ func TestServer_SetValueAPIPath(t *testing.T) {
 func TestSession_MethodSupport_InvalidForAlarm(t *testing.T) {
 	// Alarm objects do not support setValue per the spec matrix.
 	// Verify methodSupported table directly.
-	if methodSupported(iacp1.TypeAlarm, iacp1.MethodSetValue) {
+	if methodSupported(codec.TypeAlarm, codec.MethodSetValue) {
 		t.Error("Alarm should not support setValue")
 	}
-	if methodSupported(iacp1.TypeEnum, iacp1.MethodSetIncValue) {
+	if methodSupported(codec.TypeEnum, codec.MethodSetIncValue) {
 		t.Error("Enum should not support setIncValue")
 	}
-	if !methodSupported(iacp1.TypeInteger, iacp1.MethodSetDefValue) {
+	if !methodSupported(codec.TypeInteger, codec.MethodSetDefValue) {
 		t.Error("Integer should support setDefValue")
 	}
-	if !methodSupported(iacp1.TypeFrame, iacp1.MethodGetValue) {
+	if !methodSupported(codec.TypeFrame, codec.MethodGetValue) {
 		t.Error("Frame should support getValue")
 	}
 }
 
 func TestSession_AccessCheck(t *testing.T) {
-	if checkAccess(iacp1.AccessRead, iacp1.MethodSetValue) != iacp1.OErrNoWriteAccess {
+	if checkAccess(codec.AccessRead, codec.MethodSetValue) != codec.OErrNoWriteAccess {
 		t.Error("read-only should deny write")
 	}
-	if checkAccess(iacp1.AccessWrite, iacp1.MethodGetValue) != iacp1.OErrNoReadAccess {
+	if checkAccess(codec.AccessWrite, codec.MethodGetValue) != codec.OErrNoReadAccess {
 		t.Error("write-only should deny read")
 	}
-	if checkAccess(iacp1.AccessRead|iacp1.AccessWrite, iacp1.MethodSetDefValue) != iacp1.OErrNoSetDefAccess {
+	if checkAccess(codec.AccessRead|codec.AccessWrite, codec.MethodSetDefValue) != codec.OErrNoSetDefAccess {
 		t.Error("no-setDef access should deny setDefValue")
 	}
-	if checkAccess(iacp1.AccessRead|iacp1.AccessWrite|iacp1.AccessSetDef, iacp1.MethodSetDefValue) != 0 {
+	if checkAccess(codec.AccessRead|codec.AccessWrite|codec.AccessSetDef, codec.MethodSetDefValue) != 0 {
 		t.Error("all-access should permit setDefValue")
 	}
 }
 
 func TestSession_NonRequestIgnored(t *testing.T) {
 	s := newTestServer(t)
-	for _, mt := range []iacp1.MType{iacp1.MTypeAnnounce, iacp1.MTypeReply, iacp1.MTypeError} {
-		req := &iacp1.Message{MTID: 1, MType: mt, MAddr: 1}
+	for _, mt := range []codec.MType{codec.MTypeAnnounce, codec.MTypeReply, codec.MTypeError} {
+		req := &codec.Message{MTID: 1, MType: mt, MAddr: 1}
 		if rep, _ := s.handleRequest(req); rep != nil {
-			t.Errorf("MType=%d should be dropped, got %+v", mt, rep)
+			t.Errorf("codec.MType=%d should be dropped, got %+v", mt, rep)
 		}
 	}
 }

--- a/internal/acp1/provider/set.go
+++ b/internal/acp1/provider/set.go
@@ -6,7 +6,7 @@ import (
 	"math"
 
 	"dhs/internal/export/canonical"
-	iacp1 "dhs/internal/acp1/consumer"
+	"dhs/internal/acp1/codec"
 )
 
 // applyMutation dispatches the four mutating methods (setValue,
@@ -50,24 +50,24 @@ import (
 //	| String    | len+1 | NUL-terminated bytes (setValue only)          |
 //
 // Spec reference: AXON-ACP_v1_4.pdf §"Methods" p. 28.
-func (s *server) applyMutation(e *entry, method iacp1.Method, incoming []byte) ([]byte, error) {
+func (s *server) applyMutation(e *entry, method codec.Method, incoming []byte) ([]byte, error) {
 	s.tree.mu.Lock()
 	defer s.tree.mu.Unlock()
 
 	switch e.acpType {
-	case iacp1.TypeInteger:
+	case codec.TypeInteger:
 		return s.mutateInteger(e, method, incoming)
-	case iacp1.TypeLong:
+	case codec.TypeLong:
 		return s.mutateLong(e, method, incoming)
-	case iacp1.TypeByte:
+	case codec.TypeByte:
 		return s.mutateByte(e, method, incoming)
-	case iacp1.TypeFloat:
+	case codec.TypeFloat:
 		return s.mutateFloat(e, method, incoming)
-	case iacp1.TypeIPAddr:
+	case codec.TypeIPAddr:
 		return s.mutateIPAddr(e, method, incoming)
-	case iacp1.TypeEnum:
+	case codec.TypeEnum:
 		return s.mutateEnum(e, method, incoming)
-	case iacp1.TypeString:
+	case codec.TypeString:
 		return s.mutateString(e, method, incoming)
 	}
 	return nil, fmt.Errorf("applyMutation: unsupported type %d", e.acpType)
@@ -89,7 +89,7 @@ func (s *server) applyMutation(e *entry, method iacp1.Method, incoming []byte) (
 //
 // Spec reference: AXON-ACP_v1_4.pdf §"Methods" p. 28 and
 // §"Objects by Type" p. 22.
-func (s *server) mutateInteger(e *entry, m iacp1.Method, incoming []byte) ([]byte, error) {
+func (s *server) mutateInteger(e *entry, m codec.Method, incoming []byte) ([]byte, error) {
 	p := e.param
 	cur, err := asInt16(p.Value, "value")
 	if err != nil {
@@ -102,16 +102,16 @@ func (s *server) mutateInteger(e *entry, m iacp1.Method, incoming []byte) ([]byt
 
 	var next int32 // widen so increment/decrement can overflow cleanly
 	switch m {
-	case iacp1.MethodSetValue:
+	case codec.MethodSetValue:
 		if len(incoming) < 2 {
 			return nil, fmt.Errorf("setValue integer: need 2 bytes, got %d", len(incoming))
 		}
 		next = int32(int16(binary.BigEndian.Uint16(incoming)))
-	case iacp1.MethodSetIncValue:
+	case codec.MethodSetIncValue:
 		next = int32(cur) + int32(step)
-	case iacp1.MethodSetDecValue:
+	case codec.MethodSetDecValue:
 		next = int32(cur) - int32(step)
-	case iacp1.MethodSetDefValue:
+	case codec.MethodSetDefValue:
 		next = int32(def)
 	default:
 		return nil, fmt.Errorf("unexpected method %d", m)
@@ -138,7 +138,7 @@ func (s *server) mutateInteger(e *entry, m iacp1.Method, incoming []byte) ([]byt
 //
 // Spec reference: AXON-ACP_v1_4.pdf §"Methods" p. 28 and
 // §"Objects by Type" p. 26.
-func (s *server) mutateLong(e *entry, m iacp1.Method, incoming []byte) ([]byte, error) {
+func (s *server) mutateLong(e *entry, m codec.Method, incoming []byte) ([]byte, error) {
 	p := e.param
 	cur, err := asInt32(p.Value, "value")
 	if err != nil {
@@ -151,16 +151,16 @@ func (s *server) mutateLong(e *entry, m iacp1.Method, incoming []byte) ([]byte, 
 
 	var next int64
 	switch m {
-	case iacp1.MethodSetValue:
+	case codec.MethodSetValue:
 		if len(incoming) < 4 {
 			return nil, fmt.Errorf("setValue long: need 4 bytes, got %d", len(incoming))
 		}
 		next = int64(int32(binary.BigEndian.Uint32(incoming)))
-	case iacp1.MethodSetIncValue:
+	case codec.MethodSetIncValue:
 		next = int64(cur) + int64(step)
-	case iacp1.MethodSetDecValue:
+	case codec.MethodSetDecValue:
 		next = int64(cur) - int64(step)
-	case iacp1.MethodSetDefValue:
+	case codec.MethodSetDefValue:
 		next = int64(def)
 	default:
 		return nil, fmt.Errorf("unexpected method %d", m)
@@ -187,7 +187,7 @@ func (s *server) mutateLong(e *entry, m iacp1.Method, incoming []byte) ([]byte, 
 //
 // Spec reference: AXON-ACP_v1_4.pdf §"Methods" p. 28 and
 // §"Objects by Type" p. 27.
-func (s *server) mutateByte(e *entry, m iacp1.Method, incoming []byte) ([]byte, error) {
+func (s *server) mutateByte(e *entry, m codec.Method, incoming []byte) ([]byte, error) {
 	p := e.param
 	cur, err := asUint8(p.Value, "value")
 	if err != nil {
@@ -200,16 +200,16 @@ func (s *server) mutateByte(e *entry, m iacp1.Method, incoming []byte) ([]byte, 
 
 	var next int32
 	switch m {
-	case iacp1.MethodSetValue:
+	case codec.MethodSetValue:
 		if len(incoming) < 1 {
 			return nil, fmt.Errorf("setValue byte: need 1 byte, got 0")
 		}
 		next = int32(incoming[0])
-	case iacp1.MethodSetIncValue:
+	case codec.MethodSetIncValue:
 		next = int32(cur) + int32(step)
-	case iacp1.MethodSetDecValue:
+	case codec.MethodSetDecValue:
 		next = int32(cur) - int32(step)
-	case iacp1.MethodSetDefValue:
+	case codec.MethodSetDefValue:
 		next = int32(def)
 	default:
 		return nil, fmt.Errorf("unexpected method %d", m)
@@ -236,7 +236,7 @@ func (s *server) mutateByte(e *entry, m iacp1.Method, incoming []byte) ([]byte, 
 //
 // Spec reference: AXON-ACP_v1_4.pdf §"Methods" p. 28 and
 // §"Objects by Type" p. 23.
-func (s *server) mutateFloat(e *entry, m iacp1.Method, incoming []byte) ([]byte, error) {
+func (s *server) mutateFloat(e *entry, m codec.Method, incoming []byte) ([]byte, error) {
 	p := e.param
 	cur, err := asFloat32(p.Value, "value")
 	if err != nil {
@@ -249,16 +249,16 @@ func (s *server) mutateFloat(e *entry, m iacp1.Method, incoming []byte) ([]byte,
 
 	var next float64
 	switch m {
-	case iacp1.MethodSetValue:
+	case codec.MethodSetValue:
 		if len(incoming) < 4 {
 			return nil, fmt.Errorf("setValue float: need 4 bytes, got %d", len(incoming))
 		}
 		next = float64(math.Float32frombits(binary.BigEndian.Uint32(incoming)))
-	case iacp1.MethodSetIncValue:
+	case codec.MethodSetIncValue:
 		next = float64(cur) + float64(step)
-	case iacp1.MethodSetDecValue:
+	case codec.MethodSetDecValue:
 		next = float64(cur) - float64(step)
-	case iacp1.MethodSetDefValue:
+	case codec.MethodSetDefValue:
 		next = float64(def)
 	default:
 		return nil, fmt.Errorf("unexpected method %d", m)
@@ -285,7 +285,7 @@ func (s *server) mutateFloat(e *entry, m iacp1.Method, incoming []byte) ([]byte,
 //
 // Spec reference: AXON-ACP_v1_4.pdf §"Methods" p. 28 and
 // §"Objects by Type" p. 22.
-func (s *server) mutateIPAddr(e *entry, m iacp1.Method, incoming []byte) ([]byte, error) {
+func (s *server) mutateIPAddr(e *entry, m codec.Method, incoming []byte) ([]byte, error) {
 	p := e.param
 	cur, err := ipv4ToUint32(p.Value)
 	if err != nil {
@@ -298,20 +298,20 @@ func (s *server) mutateIPAddr(e *entry, m iacp1.Method, incoming []byte) ([]byte
 
 	var next uint64 // widen so overflow maths stays clean
 	switch m {
-	case iacp1.MethodSetValue:
+	case codec.MethodSetValue:
 		if len(incoming) < 4 {
 			return nil, fmt.Errorf("setValue ipaddr: need 4 bytes, got %d", len(incoming))
 		}
 		next = uint64(binary.BigEndian.Uint32(incoming))
-	case iacp1.MethodSetIncValue:
+	case codec.MethodSetIncValue:
 		next = uint64(cur) + uint64(step)
-	case iacp1.MethodSetDecValue:
+	case codec.MethodSetDecValue:
 		if uint64(cur) < uint64(step) {
 			next = 0
 		} else {
 			next = uint64(cur) - uint64(step)
 		}
-	case iacp1.MethodSetDefValue:
+	case codec.MethodSetDefValue:
 		next = uint64(def)
 	default:
 		return nil, fmt.Errorf("unexpected method %d", m)
@@ -343,7 +343,7 @@ func (s *server) mutateIPAddr(e *entry, m iacp1.Method, incoming []byte) ([]byte
 //
 // Spec reference: AXON-ACP_v1_4.pdf §"Methods" p. 28 and
 // §"Objects by Type" p. 23.
-func (s *server) mutateEnum(e *entry, m iacp1.Method, incoming []byte) ([]byte, error) {
+func (s *server) mutateEnum(e *entry, m codec.Method, incoming []byte) ([]byte, error) {
 	p := e.param
 	items := enumItems(p)
 	if len(items) == 0 {
@@ -353,7 +353,7 @@ func (s *server) mutateEnum(e *entry, m iacp1.Method, incoming []byte) ([]byte, 
 
 	var next uint8
 	switch m {
-	case iacp1.MethodSetValue:
+	case codec.MethodSetValue:
 		if len(incoming) < 1 {
 			return nil, fmt.Errorf("setValue enum: need 1 byte, got 0")
 		}
@@ -363,7 +363,7 @@ func (s *server) mutateEnum(e *entry, m iacp1.Method, incoming []byte) ([]byte, 
 			// ACP1's closest fit is OErrIllegalForType. Caller handles.
 			return nil, fmt.Errorf("enum %q: index %d > max %d", p.Identifier, next, maxIdx)
 		}
-	case iacp1.MethodSetDefValue:
+	case codec.MethodSetDefValue:
 		def, _ := asUint8Opt(p.Default, "default", 0)
 		next = def
 		if next > maxIdx {
@@ -392,8 +392,8 @@ func (s *server) mutateEnum(e *entry, m iacp1.Method, incoming []byte) ([]byte, 
 //
 // Spec reference: AXON-ACP_v1_4.pdf §"Methods" p. 28 and
 // §"Objects by Type" p. 24.
-func (s *server) mutateString(e *entry, m iacp1.Method, incoming []byte) ([]byte, error) {
-	if m != iacp1.MethodSetValue {
+func (s *server) mutateString(e *entry, m codec.Method, incoming []byte) ([]byte, error) {
+	if m != codec.MethodSetValue {
 		return nil, fmt.Errorf("string %q: only setValue supported", e.param.Identifier)
 	}
 	// incoming is NUL-terminated on the wire. Strip the terminator if
@@ -472,43 +472,43 @@ func uint32ToDottedQuad(v uint32) string {
 // §"Objects by Type" pp. 21–27.
 func (s *server) encodeIncomingFromAny(e *entry, val any) ([]byte, error) {
 	switch e.acpType {
-	case iacp1.TypeInteger:
+	case codec.TypeInteger:
 		v, err := asInt16(val, "value")
 		if err != nil {
 			return nil, err
 		}
 		return writeI16(v), nil
-	case iacp1.TypeLong:
+	case codec.TypeLong:
 		v, err := asInt32(val, "value")
 		if err != nil {
 			return nil, err
 		}
 		return writeI32(v), nil
-	case iacp1.TypeByte:
+	case codec.TypeByte:
 		v, err := asUint8(val, "value")
 		if err != nil {
 			return nil, err
 		}
 		return []byte{v}, nil
-	case iacp1.TypeFloat:
+	case codec.TypeFloat:
 		v, err := asFloat32(val, "value")
 		if err != nil {
 			return nil, err
 		}
 		return writeF32(v), nil
-	case iacp1.TypeIPAddr:
+	case codec.TypeIPAddr:
 		v, err := ipv4ToUint32(val)
 		if err != nil {
 			return nil, err
 		}
 		return writeU32(v), nil
-	case iacp1.TypeEnum:
+	case codec.TypeEnum:
 		v, err := asUint8(val, "value")
 		if err != nil {
 			return nil, err
 		}
 		return []byte{v}, nil
-	case iacp1.TypeString:
+	case codec.TypeString:
 		v, err := asString(val, "value")
 		if err != nil {
 			return nil, err

--- a/internal/acp1/provider/tree.go
+++ b/internal/acp1/provider/tree.go
@@ -7,27 +7,27 @@ import (
 	"sync"
 
 	"dhs/internal/export/canonical"
-	iacp1 "dhs/internal/acp1/consumer"
+	"dhs/internal/acp1/codec"
 )
 
 // groupName -> ObjGroup constant. Mirrors buildSlotNode in
 // internal/protocol/acp1/canonicalize.go. Canonical uses lowercase group
 // identifiers; ACP1 wire uses the numeric group code.
-var groupByName = map[string]iacp1.ObjGroup{
-	"root":     iacp1.GroupRoot,
-	"identity": iacp1.GroupIdentity,
-	"control":  iacp1.GroupControl,
-	"status":   iacp1.GroupStatus,
-	"alarm":    iacp1.GroupAlarm,
-	"file":     iacp1.GroupFile,
-	"frame":    iacp1.GroupFrame,
+var groupByName = map[string]codec.ObjGroup{
+	"root":     codec.GroupRoot,
+	"identity": codec.GroupIdentity,
+	"control":  codec.GroupControl,
+	"status":   codec.GroupStatus,
+	"alarm":    codec.GroupAlarm,
+	"file":     codec.GroupFile,
+	"frame":    codec.GroupFrame,
 }
 
 // objectKey uniquely identifies an AxonNet object on the wire.
 // slot fits in a byte (0-31 per spec); group+id likewise.
 type objectKey struct {
 	slot  uint8
-	group iacp1.ObjGroup
+	group codec.ObjGroup
 	id    uint8
 }
 
@@ -37,7 +37,7 @@ type objectKey struct {
 type entry struct {
 	key     objectKey
 	param   *canonical.Parameter // points into the loaded canonical.Export
-	acpType iacp1.ObjectType
+	acpType codec.ObjectType
 	access  uint8 // ACP1 access bits 0/1/2
 }
 
@@ -127,23 +127,23 @@ func newTree(exp *canonical.Export) (*tree, error) {
 				t.entries[e.key] = e
 
 				switch grp {
-				case iacp1.GroupIdentity:
+				case codec.GroupIdentity:
 					if id >= counts.numIdentity {
 						counts.numIdentity = id + 1
 					}
-				case iacp1.GroupControl:
+				case codec.GroupControl:
 					if id >= counts.numControl {
 						counts.numControl = id + 1
 					}
-				case iacp1.GroupStatus:
+				case codec.GroupStatus:
 					if id >= counts.numStatus {
 						counts.numStatus = id + 1
 					}
-				case iacp1.GroupAlarm:
+				case codec.GroupAlarm:
 					if id >= counts.numAlarm {
 						counts.numAlarm = id + 1
 					}
-				case iacp1.GroupFile:
+				case codec.GroupFile:
 					if id >= counts.numFile {
 						counts.numFile = id + 1
 					}
@@ -182,7 +182,7 @@ func (t *tree) lookup(k objectKey) (*entry, bool) {
 //	boolean without "alarm" hint  -> ERROR (ACP1 has no Boolean — use
 //	                                 Enum with "Off,On" items for plain
 //	                                 booleans, Alarm for alarm objects)
-func deriveACPType(p *canonical.Parameter) (iacp1.ObjectType, error) {
+func deriveACPType(p *canonical.Parameter) (codec.ObjectType, error) {
 	// Parameter.Format is a free-form comma-separated hint carrying
 	// ACP1 type information AND other attributes (e.g. "maxLen=N" on
 	// strings, "priority=N,tag=M" on alarms). Split and scan: first
@@ -196,27 +196,27 @@ func deriveACPType(p *canonical.Parameter) (iacp1.ObjectType, error) {
 
 	switch p.Type {
 	case canonical.ParamReal:
-		return iacp1.TypeFloat, nil
+		return codec.TypeFloat, nil
 	case canonical.ParamEnum:
-		return iacp1.TypeEnum, nil
+		return codec.TypeEnum, nil
 	case canonical.ParamInteger:
 		switch typeHint {
 		case "", "int16":
-			return iacp1.TypeInteger, nil
+			return codec.TypeInteger, nil
 		case "int32", "long":
-			return iacp1.TypeLong, nil
+			return codec.TypeLong, nil
 		case "uint8", "byte":
-			return iacp1.TypeByte, nil
+			return codec.TypeByte, nil
 		}
 		return 0, fmt.Errorf("integer: unknown type hint %q (want int16|int32|uint8)", typeHint)
 	case canonical.ParamString:
 		switch typeHint {
 		case "", "string":
-			return iacp1.TypeString, nil
+			return codec.TypeString, nil
 		case "ipv4", "ipaddr":
-			return iacp1.TypeIPAddr, nil
+			return codec.TypeIPAddr, nil
 		case "file":
-			return iacp1.TypeFile, nil
+			return codec.TypeFile, nil
 		}
 		return 0, fmt.Errorf("string: unknown type hint %q (want ipv4|file or omit)", typeHint)
 	case canonical.ParamBoolean:
@@ -225,10 +225,10 @@ func deriveACPType(p *canonical.Parameter) (iacp1.ObjectType, error) {
 				"boolean has no ACP1 mapping — use enum with Off,On for plain booleans, " +
 					"or set format=\"alarm\" with description=\"on: … / off: …\" for spec-p.25 Alarm objects")
 		}
-		return iacp1.TypeAlarm, nil
+		return codec.TypeAlarm, nil
 	case canonical.ParamOctets:
 		if typeHint == "frame" {
-			return iacp1.TypeFrame, nil
+			return codec.TypeFrame, nil
 		}
 		return 0, fmt.Errorf("octets: type hint %q unsupported in ACP1 (only \"frame\" is defined)", typeHint)
 	}
@@ -297,11 +297,11 @@ func pickTypeHint(parts []string) (string, bool) {
 func deriveAccess(a string) uint8 {
 	switch a {
 	case canonical.AccessRead:
-		return iacp1.AccessRead
+		return codec.AccessRead
 	case canonical.AccessWrite:
-		return iacp1.AccessWrite | iacp1.AccessSetDef
+		return codec.AccessWrite | codec.AccessSetDef
 	case canonical.AccessReadWrite:
-		return iacp1.AccessRead | iacp1.AccessWrite | iacp1.AccessSetDef
+		return codec.AccessRead | codec.AccessWrite | codec.AccessSetDef
 	}
 	return 0
 }
@@ -339,7 +339,7 @@ func parsePath(path string) (objectKey, error) {
 	}
 	return objectKey{
 		slot:  uint8(slot1based - 1),
-		group: iacp1.ObjGroup(grpNum),
+		group: codec.ObjGroup(grpNum),
 		id:    uint8(id),
 	}, nil
 }

--- a/internal/acp1/smoke/smoke_test.go
+++ b/internal/acp1/smoke/smoke_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"dhs/internal/protocol"
+	"dhs/internal/acp1/codec"
 	"dhs/internal/acp1/consumer"
 )
 
@@ -36,7 +37,7 @@ func connectPlugin(t *testing.T) protocol.Protocol {
 	plug := f.New(slog.Default())
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	if err := plug.Connect(ctx, testHost(), acp1.DefaultPort); err != nil {
+	if err := plug.Connect(ctx, testHost(), codec.DefaultPort); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
 	t.Cleanup(func() { _ = plug.Disconnect() })


### PR DESCRIPTION
## Summary

Brings ACP1 in line with every other connector by splitting the wire codec into its own package per ADR-0006 + architecture principle 4 (codec stdlib-only, lift-to-own-repo ready).

Stacked on top of #213 — base = `feat/validate-verb-skeleton-and-acp1`. Will auto-rebase to `main` when #213 lands.

Closes #214.

## Files moved (`consumer/` ? `codec/`, `package acp1` ? `package codec`)

| File | Owns |
| --- | --- |
| `types.go` | wire constants (MType, Method, ObjGroup, ObjectType, AccessBits, error codes, header sizes) |
| `message.go` | ACP1 7-byte header Encode/Decode + TransportErr / ObjectErr |
| `property.go` | DecodedObject + DecodeObject (per-object-type decoder) |
| `message_test.go`, `property_test.go` | whitebox round-trip tests |
| `message_spec_test.go`, `property_spec_test.go` | blackbox spec-byte asserts (`package codec_test`) |

## Stays in `consumer/` (session + API layer)

`plugin`, `client`, `tcp_client`, `listener`, `browser`, `discover`, `catalogue`, `canonicalize`, `cache`, `compliance_events`, `validate`, `value_codec` (this one bridges raw codec primitives to `protocol.Value` — consumer-layer concern), and the tests for those.

## Caller updates (mechanical)

- `internal/acp1/consumer/*.go` (package acp1) — bare references prefixed with `codec.*`, `import "dhs/internal/acp1/codec"` added.
- `internal/acp1/provider/*.go` (package acp1) — same pattern; the alias import `iacp1 "dhs/internal/acp1/consumer"` dropped where it no longer carries any symbol.
- `internal/acp1/smoke/smoke_test.go` — codec import added.
- `cmd/dhs/*.go` — only consumer-side symbols (Plugin, Factory, Discover, Catalogue) referenced via `acp1.X`; no rewrite needed.

## Hard invariants verified

- [x] `internal/acp1/codec/` has zero `dhs/*` imports (production code) — only the `codec_test` package re-imports it for blackbox asserts.
- [x] No back-edge codec ? consumer (codec/ never imports `internal/acp1/consumer` or any `dhs/*` path).
- [x] `go build ./...` OK
- [x] `go vet ./...` OK
- [x] `golangci-lint run` 0 issues
- [x] `go test ./...` all OK (full repo)
- [x] `go build -tags integration ./internal/acp1/smoke/...` OK

## Out of scope

- `canonicalize.go` stays in `consumer/` — converts decoded codec values to cross-protocol Object schema (consumer-layer concern, not bytes).
- ACP1 wire spec changes (none).
- Per-type fixtures under `testdata/protocol_types/` (already present).