### PR TITLE
feat(emberplus): implement Plugin.Validate() per ADR-0021 (closes #218)

### DIFF
--- a/internal/emberplus/consumer/replay_test.go
+++ b/internal/emberplus/consumer/replay_test.go
@@ -1,0 +1,77 @@
+// Package emberplus_test — replay tests run captured Trames (per
+// ADR-0021) through the Ember+ plugin's Validate() method. Skips
+// cleanly when no local capture is present so a fresh clone is
+// green without `git lfs pull` or any pre-loaded fixtures.
+package emberplus_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"dhs/internal/emberplus/consumer"
+	"dhs/internal/protocol"
+	"dhs/internal/wiretrace"
+)
+
+// loadTrames reads a captured wire trace from
+// captures/emberplus/<scenario>/frames.jsonl (gitignored, local-only
+// per ADR-0021). Skips cleanly when the file is missing — re-capture
+// with `dhs consumer emberplus walk <ip> --capture <path>`.
+func loadTrames(t *testing.T, scenario string) []wiretrace.Trame {
+	t.Helper()
+	path := filepath.Join("..", "..", "..", "captures", "emberplus", scenario, "frames.jsonl")
+	f, err := os.Open(path)
+	if errors.Is(err, os.ErrNotExist) {
+		t.Skipf("capture %s missing — recapture with `dhs consumer emberplus walk <ip> --capture %s`", path, path)
+	}
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	trames, err := wiretrace.ReadTrames(f)
+	if err != nil {
+		t.Fatalf("ReadTrames: %v", err)
+	}
+	return trames
+}
+
+func newValidator(t *testing.T) protocol.Validator {
+	t.Helper()
+	f := &emberplus.Factory{}
+	plug := f.New(slog.Default())
+	v, ok := plug.(protocol.Validator)
+	if !ok {
+		t.Fatal("emberplus.Plugin does not implement protocol.Validator")
+	}
+	return v
+}
+
+// TestReplay_EmberplusTreeWalk runs every Trame through Plugin.Validate
+// and asserts no decode errors and no S101 / Glow invariant violations
+// on a tree-walk capture.
+func TestReplay_EmberplusTreeWalk(t *testing.T) {
+	trames := loadTrames(t, "tree_walk")
+	if len(trames) == 0 {
+		t.Fatal("no trames in capture")
+	}
+	v := newValidator(t)
+	report, err := v.Validate(context.Background(), trames, protocol.ValidateOpts{})
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	t.Logf("emberplus trames: %d decoded (%d tx, %d rx)",
+		report.TramesProcessed,
+		report.PerDirection[wiretrace.DirectionTx],
+		report.PerDirection[wiretrace.DirectionRx])
+	for _, e := range report.Errors {
+		t.Errorf("trame %d (%s): %s", e.TrameIndex, e.Direction, e.Err)
+	}
+	for _, inv := range report.Invariants {
+		t.Errorf("invariant: %s", inv)
+	}
+}

--- a/internal/emberplus/consumer/validate.go
+++ b/internal/emberplus/consumer/validate.go
@@ -1,0 +1,134 @@
+package emberplus
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	"dhs/internal/emberplus/codec/glow"
+	"dhs/internal/emberplus/codec/s101"
+	"dhs/internal/protocol"
+	"dhs/internal/wiretrace"
+)
+
+// Compile-time assertion: emberplus Plugin satisfies protocol.Validator
+// so `dhs consumer emberplus validate <frames.jsonl>` resolves cleanly
+// at the CLI type-assert (cmd/dhs/cmd_validate.go).
+var _ protocol.Validator = (*Plugin)(nil)
+
+// Validate decodes captured Ember+ wire-trace records (Trames per
+// ADR-0021) through the S101 framer + BER + Glow stack, asserts S101
+// invariants (slot=0, version=1, DTD=Glow, MPM consistency) and
+// reports per-direction counts plus any decode failures or invariant
+// violations. EmBER payloads are run through glow.DecodeRoot to
+// assert codec integrity all the way down; keep-alive frames are
+// counted but carry no payload.
+//
+// This is the offline counterpart to Walk: same codec stack, no
+// live peer.
+//
+// --out-tree / --out-params (per ADR-0002) are not yet wired here —
+// they land in a follow-up PR that integrates canonicalize.go.
+func (p *Plugin) Validate(ctx context.Context, trames []wiretrace.Trame, opts protocol.ValidateOpts) (*protocol.ValidateReport, error) {
+	report := &protocol.ValidateReport{
+		PerDirection: map[wiretrace.Direction]int{},
+	}
+
+	if opts.OutTree != "" || opts.OutParams != "" {
+		return report, fmt.Errorf("emberplus.Validate: --out-tree / --out-params not implemented yet (follow-up PR)")
+	}
+
+	for i, t := range trames {
+		if err := ctx.Err(); err != nil {
+			return report, err
+		}
+
+		raw, err := hex.DecodeString(t.Hex)
+		if err != nil {
+			report.Errors = append(report.Errors, protocol.ValidateError{
+				TrameIndex: i,
+				Direction:  t.Direction,
+				Err:        fmt.Sprintf("hex decode: %v", err),
+			})
+			continue
+		}
+
+		frame, err := s101.Decode(raw)
+		if err != nil {
+			report.Errors = append(report.Errors, protocol.ValidateError{
+				TrameIndex: i,
+				Direction:  t.Direction,
+				HexPrefix:  shortHex(raw),
+				Err:        fmt.Sprintf("s101 decode: %v", err),
+			})
+			continue
+		}
+
+		report.TramesProcessed++
+		report.PerDirection[t.Direction]++
+
+		if frame.Slot != s101.SlotDefault {
+			report.Invariants = append(report.Invariants,
+				fmt.Sprintf("trame %d: s101 slot=%d, want 0", i, frame.Slot))
+		}
+		if frame.Version != 0 && frame.Version != s101.VersionS101 {
+			report.Invariants = append(report.Invariants,
+				fmt.Sprintf("trame %d: s101 version=%d, want 1", i, frame.Version))
+		}
+
+		switch frame.MsgType {
+		case s101.MsgEmBER:
+			if frame.Command != s101.CmdEmBER {
+				report.Invariants = append(report.Invariants,
+					fmt.Sprintf("trame %d: EmBER msg with unexpected command 0x%02x", i, frame.Command))
+				continue
+			}
+			if frame.DTD != s101.DTDGlow {
+				report.Invariants = append(report.Invariants,
+					fmt.Sprintf("trame %d: EmBER msg with non-Glow DTD 0x%02x", i, frame.DTD))
+			}
+			// Mid-flight MPM packets carry partial BER; skip glow decode
+			// unless this is a single (first+last) frame.
+			if frame.Flags&s101.FlagSingle != s101.FlagSingle {
+				continue
+			}
+			if _, err := glow.DecodeRoot(frame.Payload); err != nil {
+				report.Errors = append(report.Errors, protocol.ValidateError{
+					TrameIndex: i,
+					Direction:  t.Direction,
+					HexPrefix:  shortHex(frame.Payload),
+					Err:        fmt.Sprintf("glow decode: %v", err),
+				})
+			}
+		case s101.MsgKeepAlive:
+			switch frame.Command {
+			case s101.CmdKeepAliveReq, s101.CmdKeepAliveResp:
+				// expected
+			default:
+				report.Invariants = append(report.Invariants,
+					fmt.Sprintf("trame %d: keep-alive with unknown command 0x%02x", i, frame.Command))
+			}
+			if len(frame.Payload) != 0 {
+				report.Invariants = append(report.Invariants,
+					fmt.Sprintf("trame %d: keep-alive carries unexpected payload (%d bytes)", i, len(frame.Payload)))
+			}
+		default:
+			report.Invariants = append(report.Invariants,
+				fmt.Sprintf("trame %d: unknown s101 message type 0x%02x", i, frame.MsgType))
+		}
+
+		if opts.StopAt != "" && t.Note == opts.StopAt {
+			report.StoppedAt = t.Note
+			break
+		}
+	}
+
+	return report, nil
+}
+
+func shortHex(b []byte) string {
+	if len(b) > 16 {
+		b = b[:16]
+	}
+	return hex.EncodeToString(b)
+}


### PR DESCRIPTION
## Summary

Wires the canonical `validate` verb to the Ember+ consumer plugin so `dhs consumer emberplus validate <frames.jsonl>` decodes a captured wire-trace through the S101 + BER + Glow stack offline and reports per-direction counts plus invariant violations.

Stacked on #213 (validate skeleton). Independent of #215 / #217 — emberplus already has the codec/ split.

Closes #218, advances #212.

## Per-trame validation

1. hex ? bytes
2. `s101.Decode` (CRC + escape unwrap) ? `s101.Frame`
3. assert s101 invariants:
   - `slot == 0`
   - `version == 1` (when set)
   - EmBER frames carry `CmdEmBER` (0x00) + `DTD == Glow` (0x01)
   - keep-alive frames have no payload + carry one of the two known keep-alive commands (0x01 req / 0x02 resp)
4. for SINGLE EmBER frames (`Flags & FlagSingle == FlagSingle`): run `glow.DecodeRoot(frame.Payload)` to assert the BER + Glow stack all the way down. Mid-flight MPM packets carry partial BER and are counted but not re-decoded — that's correct behaviour for the wire layer (the live session reassembles MPM before invoking the glow decoder).
5. unknown s101 message types fail the invariant.
6. honors `--stop-at` via `Trame.Note` (per ADR-0021).

`--out-tree` / `--out-params` return "not implemented yet" pending the canonicalize.go integration follow-up (same posture as acp1 / acp2).

## Files added

- `internal/emberplus/consumer/validate.go` — `Plugin.Validate()` + compile-time assertion `var _ protocol.Validator = (*Plugin)(nil)` to lock the contract at build time.
- `internal/emberplus/consumer/replay_test.go` — `TestReplay_EmberplusTreeWalk` scaffold that resolves `captures/emberplus/<scenario>/frames.jsonl` and skips cleanly with `os.IsNotExist` (per ADR-0021 storage rules — traces are local-only, gitignored).

## Hard invariants verified

- [x] `internal/emberplus/codec/` unchanged — no `dhs/*` imports introduced.
- [x] `Plugin` satisfies `protocol.Validator` at compile time.
- [x] `go build ./...` OK
- [x] `go vet ./...` OK
- [x] `golangci-lint run` 0 issues
- [x] `go test ./...` all OK (full repo)
- [x] `TestReplay_EmberplusTreeWalk` SKIP cleanly with the recapture hint on a fresh clone (expected).

## Out of scope

- Ember+ wire spec changes (none).
- `canonicalize.go` integration (separate follow-up).
- Per-product DM library entries under `tests/fixtures/products/<vendor>/<product>/emberplus/...` (Bucket 3, separate workstream).