### PR TITLE
feat(probel-sw08p): Validate() + Canonicalize() + testdata/protocol_types/ (closes #220)

### DIFF
--- a/internal/probel-sw08p/consumer/canonicalize.go
+++ b/internal/probel-sw08p/consumer/canonicalize.go
@@ -1,0 +1,87 @@
+package probelsw08p
+
+import (
+	"context"
+	"fmt"
+
+	"dhs/internal/export/canonical"
+)
+
+// Canonicalize emits a canonical.Export shaped from the externally-
+// supplied MatrixConfig (per SetMatrixConfig). SW-P-08 has no on-the-
+// wire matrix-discovery primitive, so the consumer relies on the
+// caller declaring matrix shape up front; this function projects that
+// declaration into the cross-protocol Matrix element shape per
+// docs/protocols/elements/matrix.md.
+//
+// Tree shape (initial):
+//
+//	device (Node, oid="1", identifier=host)
+//	└── matrix-<id>.level-<lvl> (Matrix, type=oneToN, mode=linear,
+//	                              targetCount=Dsts, sourceCount=Srcs,
+//	                              targets=[], sources=[], connections=[])
+//
+// Targets / Sources / Connections are empty in this initial pass —
+// they get populated when the consumer aggregates per-crosspoint
+// state from cmd 003 / cmd 022 / cmd 023 tally traffic into a cached
+// matrix-state map (separate follow-up tracker per
+// internal/probel-sw08p/CLAUDE.md "Matrix-centric RX/TX convention").
+//
+// Pre-Connect Plugin instances (no host yet, MatrixConfig still
+// zero-value) yield a device Node with an empty children slice.
+func (p *Plugin) Canonicalize(ctx context.Context) (*canonical.Export, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("canonicalize canceled: %w", err)
+	}
+
+	p.mu.Lock()
+	host := p.host
+	cfg := p.matrixCfg
+	p.mu.Unlock()
+
+	identifier := "device"
+	if host != "" {
+		identifier = host
+	}
+
+	root := &canonical.Node{
+		Header: canonical.Header{
+			Number:     1,
+			Identifier: identifier,
+			Path:       identifier,
+			OID:        "1",
+			IsOnline:   p.IsOnline(),
+			Access:     canonical.AccessRead,
+		},
+	}
+
+	// Empty MatrixConfig (no SetMatrixConfig call yet) → empty children.
+	if cfg.Dsts == 0 && cfg.Srcs == 0 {
+		root.Children = canonical.EmptyChildren()
+		return &canonical.Export{Root: root}, nil
+	}
+
+	matrixIdent := fmt.Sprintf("matrix-%d.level-%d", cfg.MatrixID, cfg.Level)
+	matrixOID := fmt.Sprintf("1.%d.%d", cfg.MatrixID+1, cfg.Level+1)
+
+	matrix := &canonical.Matrix{
+		Header: canonical.Header{
+			Number:     int(cfg.MatrixID)*100 + int(cfg.Level) + 1,
+			Identifier: matrixIdent,
+			Path:       identifier + "." + matrixIdent,
+			OID:        matrixOID,
+			IsOnline:   p.IsOnline(),
+			Access:     canonical.AccessReadWrite,
+		},
+		Type:        canonical.MatrixOneToN,
+		Mode:        canonical.ModeLinear,
+		TargetCount: int64(cfg.Dsts),
+		SourceCount: int64(cfg.Srcs),
+		Targets:     []canonical.MatrixTarget{},
+		Sources:     []canonical.MatrixSource{},
+		Connections: []canonical.MatrixConnection{},
+	}
+
+	root.Children = []canonical.Element{matrix}
+	return &canonical.Export{Root: root}, nil
+}

--- a/internal/probel-sw08p/consumer/replay_test.go
+++ b/internal/probel-sw08p/consumer/replay_test.go
@@ -1,0 +1,77 @@
+// Package probelsw08p_test — replay tests run captured Trames (per
+// ADR-0021) through the SW-P-08 plugin's Validate() method. Skips
+// cleanly when no local capture is present so a fresh clone is
+// green without `git lfs pull` or any pre-loaded fixtures.
+package probelsw08p_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"dhs/internal/probel-sw08p/consumer"
+	"dhs/internal/protocol"
+	"dhs/internal/wiretrace"
+)
+
+// loadTrames reads a captured wire trace from
+// captures/probel-sw08p/<scenario>/frames.jsonl (gitignored, local-
+// only per ADR-0021). Skips cleanly when the file is missing —
+// re-capture with `dhs consumer probel-sw08p connect <ip>:<port> --capture <path>`.
+func loadTrames(t *testing.T, scenario string) []wiretrace.Trame {
+	t.Helper()
+	path := filepath.Join("..", "..", "..", "captures", "probel-sw08p", scenario, "frames.jsonl")
+	f, err := os.Open(path)
+	if errors.Is(err, os.ErrNotExist) {
+		t.Skipf("capture %s missing — recapture with `dhs consumer probel-sw08p ... --capture %s`", path, path)
+	}
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	trames, err := wiretrace.ReadTrames(f)
+	if err != nil {
+		t.Fatalf("ReadTrames: %v", err)
+	}
+	return trames
+}
+
+func newValidator(t *testing.T) protocol.Validator {
+	t.Helper()
+	f := &probelsw08p.Factory{}
+	plug := f.New(slog.Default())
+	v, ok := plug.(protocol.Validator)
+	if !ok {
+		t.Fatal("probel-sw08p Plugin does not implement protocol.Validator")
+	}
+	return v
+}
+
+// TestReplay_ProbelSw08pCrosspointConnect runs every Trame through
+// Plugin.Validate and asserts no decode errors and no SW-P-08
+// invariant violations on a connect-burst capture.
+func TestReplay_ProbelSw08pCrosspointConnect(t *testing.T) {
+	trames := loadTrames(t, "crosspoint_connect")
+	if len(trames) == 0 {
+		t.Fatal("no trames in capture")
+	}
+	v := newValidator(t)
+	report, err := v.Validate(context.Background(), trames, protocol.ValidateOpts{})
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	t.Logf("probel-sw08p trames: %d decoded (%d tx, %d rx)",
+		report.TramesProcessed,
+		report.PerDirection[wiretrace.DirectionTx],
+		report.PerDirection[wiretrace.DirectionRx])
+	for _, e := range report.Errors {
+		t.Errorf("trame %d (%s): %s", e.TrameIndex, e.Direction, e.Err)
+	}
+	for _, inv := range report.Invariants {
+		t.Errorf("invariant: %s", inv)
+	}
+}

--- a/internal/probel-sw08p/consumer/validate.go
+++ b/internal/probel-sw08p/consumer/validate.go
@@ -1,0 +1,110 @@
+package probelsw08p
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/protocol"
+	"dhs/internal/wiretrace"
+)
+
+// Compile-time assertion: probel-sw08p Plugin satisfies
+// protocol.Validator so `dhs consumer probel-sw08p validate
+// <frames.jsonl>` resolves cleanly at the CLI type-assert
+// (cmd/dhs/cmd_validate.go).
+var _ protocol.Validator = (*Plugin)(nil)
+
+// Validate decodes captured SW-P-08 wire-trace records (Trames per
+// ADR-0021) through the codec.Unpack framer + checksum verification,
+// asserts that every recognised command byte is in the codec's
+// catalogue, and reports per-direction counts plus any decode
+// failures or invariant violations.
+//
+// DLE ACK / DLE NAK pseudo-frames are recognised as control trames
+// (no DATA, no checksum). NAK is not fatal — per CLAUDE.md "NAK from
+// a peer = command unsupported, NOT a fatal error" — but is recorded
+// as an informational invariant so the report surfaces unsupported-
+// command counts.
+//
+// This is the offline counterpart to the live session: same codec,
+// no socket.
+//
+// --out-tree / --out-params (per ADR-0002) are not yet wired here —
+// they'll dispatch to Canonicalize() in a follow-up PR once the
+// consumer aggregates per-crosspoint state from cmd 003 / cmd 022 /
+// cmd 023 tally traffic.
+func (p *Plugin) Validate(ctx context.Context, trames []wiretrace.Trame, opts protocol.ValidateOpts) (*protocol.ValidateReport, error) {
+	report := &protocol.ValidateReport{
+		PerDirection: map[wiretrace.Direction]int{},
+	}
+
+	if opts.OutTree != "" || opts.OutParams != "" {
+		return report, fmt.Errorf("probel-sw08p.Validate: --out-tree / --out-params not implemented yet (follow-up PR)")
+	}
+
+	for i, t := range trames {
+		if err := ctx.Err(); err != nil {
+			return report, err
+		}
+
+		raw, err := hex.DecodeString(t.Hex)
+		if err != nil {
+			report.Errors = append(report.Errors, protocol.ValidateError{
+				TrameIndex: i,
+				Direction:  t.Direction,
+				Err:        fmt.Sprintf("hex decode: %v", err),
+			})
+			continue
+		}
+
+		// Recognise DLE ACK / DLE NAK pseudo-frames before attempting
+		// Unpack — these are §2 control sequences, no SOM/DATA/CHK.
+		if codec.IsACK(raw) {
+			report.TramesProcessed++
+			report.PerDirection[t.Direction]++
+			continue
+		}
+		if codec.IsNAK(raw) {
+			report.TramesProcessed++
+			report.PerDirection[t.Direction]++
+			report.Invariants = append(report.Invariants,
+				fmt.Sprintf("trame %d: DLE NAK observed (peer rejected previous frame; per CLAUDE.md NAK = unsupported command, not fatal)", i))
+			continue
+		}
+
+		frame, _, err := codec.Unpack(raw)
+		if err != nil {
+			report.Errors = append(report.Errors, protocol.ValidateError{
+				TrameIndex: i,
+				Direction:  t.Direction,
+				HexPrefix:  shortHex(raw),
+				Err:        fmt.Sprintf("sw-p-08 decode: %v", err),
+			})
+			continue
+		}
+
+		report.TramesProcessed++
+		report.PerDirection[t.Direction]++
+
+		if name := codec.CommandName(frame.ID); name == "" {
+			report.Invariants = append(report.Invariants,
+				fmt.Sprintf("trame %d: unknown SW-P-08 command id 0x%02x (%d) — not in codec catalogue", i, byte(frame.ID), byte(frame.ID)))
+		}
+
+		if opts.StopAt != "" && t.Note == opts.StopAt {
+			report.StoppedAt = t.Note
+			break
+		}
+	}
+
+	return report, nil
+}
+
+func shortHex(b []byte) string {
+	if len(b) > 16 {
+		b = b[:16]
+	}
+	return hex.EncodeToString(b)
+}

--- a/internal/probel-sw08p/testdata/protocol_types/README.md
+++ b/internal/probel-sw08p/testdata/protocol_types/README.md
@@ -1,0 +1,52 @@
+# SW-P-08 per-type fixtures (ADR-0020 Bucket 1)
+
+One folder per wire-type-or-verb. Each folder will, when fixtures are
+captured, contain:
+
+| File | Source |
+| --- | --- |
+| `frames.jsonl` | Wire-trace per ADR-0021 — drives codec encode/decode tests |
+| `capture.pcapng` | OS-socket capture — drives the Wireshark Lua dissector check |
+| `tshark.tree` | Frozen dissector output — regression diff target |
+| `README.md` | Scenario context + spec citation + dhs commit at capture time |
+
+These fixtures are consumed by `internal/probel-sw08p/codec/*_test.go`
+(byte-level round-trip) and by the dissector cross-check pipeline
+(`tshark -X lua_script:wireshark/dhs_probel_sw08p.lua` on the
+`.pcapng`).
+
+## Initial folders
+
+| Folder | Direction | Cmd byte | Spec | Description |
+| --- | --- | ---: | --- | --- |
+| `rx_001_crosspoint_interrogate/` | controller → matrix | 1 | §3.2.1 | "What's connected at (matrix, level, dst)?" |
+| `rx_002_crosspoint_connect/` | controller → matrix | 2 | §3.2.2 | "Connect src to dst on (matrix, level)." |
+| `tx_003_crosspoint_tally/` | matrix → controller | 3 | §3.2.3 | Spontaneous "this dst is now connected to src." |
+| `tx_004_crosspoint_connected/` | matrix → controller | 4 | §3.2.4 | Reply to cmd 1 / cmd 2 — "the answer is src." |
+| `rx_007_maintenance/` | controller → matrix | 7 | §3.2.7 | Maintenance / liveness probe. |
+
+Add new folders as we land per-command fixtures (NN_command_name/
+matching `cmd_rxNNN_xxx.go` / `cmd_txNNN_xxx.go` filenames in
+`consumer/` and `provider/`).
+
+## Why this layout
+
+- Codec test discovery is `for d in protocol_types/*/`, no manifest.
+- The folder name carries direction + command byte + name so a
+  reviewer reading the `git diff` understands the scope without
+  cracking the binary.
+- Same name across protocols (Bucket 1 layout per ADR-0020) lets the
+  cross-protocol fixture validator stay protocol-agnostic.
+
+## Pairing with `captures/`
+
+Live captures live LOCAL ONLY at `captures/probel-sw08p/<scenario>/
+frames.jsonl` (gitignored, per ADR-0021). To promote a live capture
+into a committed per-type fixture:
+
+1. Capture: `dhs consumer probel-sw08p ... --capture
+   captures/probel-sw08p/<scenario>/frames.jsonl`
+2. Trim to the relevant single frame (or paired req/reply).
+3. Drop the trimmed `frames.jsonl` here under the matching command
+   folder, alongside a one-paragraph `README.md` citing the scenario
+   and the dhs commit at capture time.

--- a/internal/probel-sw08p/testdata/protocol_types/rx_001_crosspoint_interrogate/README.md
+++ b/internal/probel-sw08p/testdata/protocol_types/rx_001_crosspoint_interrogate/README.md
@@ -1,0 +1,25 @@
+# rx 001 Crosspoint Interrogate (SW-P-08 §3.2.1)
+
+| Direction | Cmd byte | Spec |
+| --- | ---: | --- |
+| controller → matrix | 1 | §3.2.1 |
+
+Asks the matrix "what's currently connected to (matrix, level, dst)?"
+The matrix replies with cmd 4 Crosspoint Connected.
+
+## Wire shape
+
+```
+DLE STX 0x01 <matrix-level> <dst-hi> <dst-lo> <btc> <chk> DLE ETX
+```
+
+`<matrix-level>` packs 4-bit matrix into the high nibble and 4-bit
+level into the low nibble (narrow form). Extended form (cmd 129)
+carries them as separate bytes.
+
+## Fixtures (when captured)
+
+- `frames.jsonl` — one or more interrogate frames per ADR-0021.
+- `capture.pcapng` — original socket capture for the Wireshark Lua
+  dissector cross-check.
+- `tshark.tree` — frozen dissector output, regression diff target.

--- a/internal/probel-sw08p/testdata/protocol_types/rx_002_crosspoint_connect/README.md
+++ b/internal/probel-sw08p/testdata/protocol_types/rx_002_crosspoint_connect/README.md
@@ -1,0 +1,26 @@
+# rx 002 Crosspoint Connect (SW-P-08 §3.2.2)
+
+| Direction | Cmd byte | Spec |
+| --- | ---: | --- |
+| controller → matrix | 2 | §3.2.2 |
+
+Tells the matrix to connect `<src>` to `<dst>` on `(matrix, level)`.
+The matrix replies with cmd 4 Crosspoint Connected once the route is
+live, AND broadcasts cmd 3 Crosspoint Tally to every connected session
+(per CLAUDE.md "Salvo commit emits cmd 04 Connected" deviation note;
+cmd 3 broadcast applies to non-salvo single-shot connects too).
+
+## Wire shape
+
+```
+DLE STX 0x02 <matrix-level> <dst-hi> <dst-lo> <src-hi> <src-lo> <btc> <chk> DLE ETX
+```
+
+Extended form (cmd 130) has separate matrix + level bytes and 14-bit
+dst / src.
+
+## Fixtures (when captured)
+
+- `frames.jsonl` — paired (cmd 002 request, cmd 004 reply, cmd 003
+  broadcast) sequence so the codec round-trip hits all three.
+- `capture.pcapng` + `tshark.tree` — dissector cross-check artefacts.

--- a/internal/probel-sw08p/testdata/protocol_types/rx_007_maintenance/README.md
+++ b/internal/probel-sw08p/testdata/protocol_types/rx_007_maintenance/README.md
@@ -1,0 +1,25 @@
+# rx 007 Maintenance (SW-P-08 §3.2.7)
+
+| Direction | Cmd byte | Spec |
+| --- | ---: | --- |
+| controller → matrix | 7 | §3.2.7 |
+
+Maintenance / liveness probe. The matrix's reply (or the framing-
+level DLE ACK alone, depending on vendor) is enough to confirm the
+session is alive.
+
+## Wire shape
+
+```
+DLE STX 0x07 <data...> <btc> <chk> DLE ETX
+```
+
+The `<data>` payload is vendor-specific (test pattern, version
+query, ping nonce). Spec leaves it open.
+
+## Fixtures (when captured)
+
+- `frames.jsonl` — at least one maintenance probe + the framing
+  ACK that follows so the codec round-trip exercises the
+  command + the §2 ACK path.
+- `capture.pcapng` + `tshark.tree` — dissector artefacts.

--- a/internal/probel-sw08p/testdata/protocol_types/tx_003_crosspoint_tally/README.md
+++ b/internal/probel-sw08p/testdata/protocol_types/tx_003_crosspoint_tally/README.md
@@ -1,0 +1,22 @@
+# tx 003 Crosspoint Tally (SW-P-08 §3.2.3)
+
+| Direction | Cmd byte | Spec |
+| --- | ---: | --- |
+| matrix → controller | 3 | §3.2.3 |
+
+Spontaneous broadcast: "this dst is now connected to src on (matrix,
+level)." Emitted to every connected session whenever the matrix
+applies a route — single-shot connect (cmd 2), salvo commit (cmd 121,
+per CLAUDE.md deviation note), or local panel.
+
+## Wire shape
+
+```
+DLE STX 0x03 <matrix-level> <dst-hi> <dst-lo> <src-hi> <src-lo> <btc> <chk> DLE ETX
+```
+
+## Fixtures (when captured)
+
+- `frames.jsonl` — a representative tally storm (e.g. the broadcast
+  fan-out following a 64-dst salvo commit).
+- `capture.pcapng` + `tshark.tree` — dissector artefacts.

--- a/internal/probel-sw08p/testdata/protocol_types/tx_004_crosspoint_connected/README.md
+++ b/internal/probel-sw08p/testdata/protocol_types/tx_004_crosspoint_connected/README.md
@@ -1,0 +1,22 @@
+# tx 004 Crosspoint Connected (SW-P-08 §3.2.4)
+
+| Direction | Cmd byte | Spec |
+| --- | ---: | --- |
+| matrix → controller | 4 | §3.2.4 |
+
+Reply to cmd 1 Crosspoint Interrogate or cmd 2 Crosspoint Connect.
+Same wire shape as cmd 3 Crosspoint Tally, but addressed back to the
+single requesting session rather than broadcast.
+
+## Wire shape
+
+```
+DLE STX 0x04 <matrix-level> <dst-hi> <dst-lo> <src-hi> <src-lo> <btc> <chk> DLE ETX
+```
+
+## Fixtures (when captured)
+
+- `frames.jsonl` — paired with the `rx_001_*` or `rx_002_*` request
+  it answers. The codec round-trip test asserts the reply byte
+  shape matches the spec.
+- `capture.pcapng` + `tshark.tree` — dissector artefacts.


### PR DESCRIPTION
## Summary

Brings probel-sw08p in line with cross-cutting connector rules:

- `Plugin.Validate()` per ADR-0021 — offline decode through the SW-P-08 framer with §2 control-frame recognition (DLE ACK / DLE NAK) and §3.2 command-id catalogue validation.
- `Plugin.Canonicalize()` returning a `*canonical.Export` shaped from the externally-supplied `MatrixConfig` — initial pass exposes the declared (matrix, level) as a Matrix element with empty `targets` / `sources` / `connections`.
- `testdata/protocol_types/` skeleton per ADR-0020 Bucket 1 with one starter folder per primary §3.2 command.

Stacked on #213. Independent of #215 / #217 / #219.

Closes #220, advances #212.

## Per-trame validation

1. hex ? bytes
2. recognise DLE ACK (0x10 0x06) and DLE NAK (0x10 0x15) as §2 control trames — counted, no `codec.Unpack`. NAK fires an informational invariant (per CLAUDE.md "NAK = unsupported command, NOT a fatal error").
3. otherwise `codec.Unpack` ? `codec.Frame{ID, Payload}` (DLE-stuffing, BTC, checksum, BOF/EOF integrity).
4. assert `codec.CommandName(frame.ID) != ""` — unknown command ids flagged as informational invariants.
5. honors `--stop-at` via `Trame.Note` (per ADR-0021).
6. `--out-tree` / `--out-params` return "not implemented yet" pending the Canonicalize() integration follow-up.

Compile-time `var _ protocol.Validator = (*Plugin)(nil)` assertion locks the contract at build.

## Canonicalize tree shape (initial)

```
device (Node, oid="1", identifier=host)
+-- matrix-<id>.level-<lvl> (Matrix, type=oneToN, mode=linear,
                              targetCount=Dsts, sourceCount=Srcs,
                              targets=[], sources=[], connections=[])
```

Empty `MatrixConfig` (no `SetMatrixConfig` call yet) ? empty children. Per-crosspoint state lands when the consumer aggregates cmd 003 / cmd 022 / cmd 023 tally traffic into a cached matrix-state map (separate follow-up).

## testdata/protocol_types/

| Folder | Direction | Cmd | Spec |
| --- | --- | ---: | --- |
| `rx_001_crosspoint_interrogate/` | controller ? matrix | 1 | §3.2.1 |
| `rx_002_crosspoint_connect/` | controller ? matrix | 2 | §3.2.2 |
| `tx_003_crosspoint_tally/` | matrix ? controller | 3 | §3.2.3 |
| `tx_004_crosspoint_connected/` | matrix ? controller | 4 | §3.2.4 |
| `rx_007_maintenance/` | controller ? matrix | 7 | §3.2.7 |

Each folder gets a README documenting wire shape + spec citation. `frames.jsonl` / `capture.pcapng` / `tshark.tree` land alongside per-command captures as they're produced.

## Hard invariants verified

- [x] `internal/probel-sw08p/codec/` unchanged — no `dhs/*` imports introduced.
- [x] `Plugin` satisfies `protocol.Validator` at compile time.
- [x] `go build ./...` OK
- [x] `go vet ./...` OK
- [x] `golangci-lint run` 0 issues
- [x] `go test ./...` all OK (full repo)
- [x] `TestReplay_ProbelSw08pCrosspointConnect` SKIP cleanly with the recapture hint on a fresh clone (expected).

## Out of scope

- Per-crosspoint state aggregation from tally traffic (separate tracker — needed before `--out-tree` produces a richer `Matrix.Connections[]` list).
- Per-product DM library entries under `tests/fixtures/products/<vendor>/<router>/probel-sw08p/...` (Bucket 3, separate workstream).
- Wireshark dissector tweaks — already shipped per CLAUDE.md `wireshark/dhs_probel_sw08p.lua`.