### PR TITLE
feat(probel-sw02p): Validate() + Canonicalize() + testdata/protocol_types/ (closes #222)

### DIFF
--- a/internal/probel-sw02p/consumer/canonicalize.go
+++ b/internal/probel-sw02p/consumer/canonicalize.go
@@ -1,0 +1,83 @@
+package probelsw02p
+
+import (
+	"context"
+	"fmt"
+
+	"dhs/internal/export/canonical"
+)
+
+// Canonicalize emits a canonical.Export shaped from the externally-
+// supplied MatrixConfig (per SetMatrixConfig). SW-P-02 is single-
+// matrix single-level per spec §3.1 so the projection is uniform —
+// no per-level multiplexing.
+//
+// Tree shape (initial):
+//
+//	device (Node, oid="1", identifier=host)
+//	└── matrix-<id>.level-<lvl> (Matrix, type=oneToN, mode=linear,
+//	                              targetCount=Dsts, sourceCount=Srcs,
+//	                              targets=[], sources=[], connections=[])
+//
+// Targets / Sources / Connections are empty in this initial pass —
+// they get populated when the consumer aggregates per-crosspoint
+// state from tx 003 / tx 004 / tx 067 / tx 068 tally traffic into a
+// cached matrix-state map (separate follow-up tracker).
+//
+// Pre-Connect Plugin instances (no host yet, MatrixConfig still
+// zero-value) yield a device Node with an empty children slice.
+func (p *Plugin) Canonicalize(ctx context.Context) (*canonical.Export, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("canonicalize canceled: %w", err)
+	}
+
+	p.mu.Lock()
+	host := p.host
+	cfg := p.matrixCfg
+	p.mu.Unlock()
+
+	identifier := "device"
+	if host != "" {
+		identifier = host
+	}
+
+	root := &canonical.Node{
+		Header: canonical.Header{
+			Number:     1,
+			Identifier: identifier,
+			Path:       identifier,
+			OID:        "1",
+			IsOnline:   true,
+			Access:     canonical.AccessRead,
+		},
+	}
+
+	if cfg.Dsts == 0 && cfg.Srcs == 0 {
+		root.Children = canonical.EmptyChildren()
+		return &canonical.Export{Root: root}, nil
+	}
+
+	matrixIdent := fmt.Sprintf("matrix-%d.level-%d", cfg.MatrixID, cfg.Level)
+	matrixOID := fmt.Sprintf("1.%d.%d", cfg.MatrixID+1, cfg.Level+1)
+
+	matrix := &canonical.Matrix{
+		Header: canonical.Header{
+			Number:     int(cfg.MatrixID)*100 + int(cfg.Level) + 1,
+			Identifier: matrixIdent,
+			Path:       identifier + "." + matrixIdent,
+			OID:        matrixOID,
+			IsOnline:   true,
+			Access:     canonical.AccessReadWrite,
+		},
+		Type:        canonical.MatrixOneToN,
+		Mode:        canonical.ModeLinear,
+		TargetCount: int64(cfg.Dsts),
+		SourceCount: int64(cfg.Srcs),
+		Targets:     []canonical.MatrixTarget{},
+		Sources:     []canonical.MatrixSource{},
+		Connections: []canonical.MatrixConnection{},
+	}
+
+	root.Children = []canonical.Element{matrix}
+	return &canonical.Export{Root: root}, nil
+}

--- a/internal/probel-sw02p/consumer/replay_test.go
+++ b/internal/probel-sw02p/consumer/replay_test.go
@@ -1,0 +1,77 @@
+// Package probelsw02p_test — replay tests run captured Trames (per
+// ADR-0021) through the SW-P-02 plugin's Validate() method. Skips
+// cleanly when no local capture is present so a fresh clone is
+// green without `git lfs pull` or any pre-loaded fixtures.
+package probelsw02p_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"dhs/internal/probel-sw02p/consumer"
+	"dhs/internal/protocol"
+	"dhs/internal/wiretrace"
+)
+
+// loadTrames reads a captured wire trace from
+// captures/probel-sw02p/<scenario>/frames.jsonl (gitignored, local-
+// only per ADR-0021). Skips cleanly when the file is missing —
+// re-capture with `dhs consumer probel-sw02p connect <ip>:<port> --capture <path>`.
+func loadTrames(t *testing.T, scenario string) []wiretrace.Trame {
+	t.Helper()
+	path := filepath.Join("..", "..", "..", "captures", "probel-sw02p", scenario, "frames.jsonl")
+	f, err := os.Open(path)
+	if errors.Is(err, os.ErrNotExist) {
+		t.Skipf("capture %s missing — recapture with `dhs consumer probel-sw02p ... --capture %s`", path, path)
+	}
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	trames, err := wiretrace.ReadTrames(f)
+	if err != nil {
+		t.Fatalf("ReadTrames: %v", err)
+	}
+	return trames
+}
+
+func newValidator(t *testing.T) protocol.Validator {
+	t.Helper()
+	f := &probelsw02p.Factory{}
+	plug := f.New(slog.Default())
+	v, ok := plug.(protocol.Validator)
+	if !ok {
+		t.Fatal("probel-sw02p Plugin does not implement protocol.Validator")
+	}
+	return v
+}
+
+// TestReplay_ProbelSw02pBootstrap runs every Trame through
+// Plugin.Validate and asserts no decode errors and no SW-P-02
+// invariant violations on a bootstrap-sweep capture.
+func TestReplay_ProbelSw02pBootstrap(t *testing.T) {
+	trames := loadTrames(t, "bootstrap_sweep")
+	if len(trames) == 0 {
+		t.Fatal("no trames in capture")
+	}
+	v := newValidator(t)
+	report, err := v.Validate(context.Background(), trames, protocol.ValidateOpts{})
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	t.Logf("probel-sw02p trames: %d decoded (%d tx, %d rx)",
+		report.TramesProcessed,
+		report.PerDirection[wiretrace.DirectionTx],
+		report.PerDirection[wiretrace.DirectionRx])
+	for _, e := range report.Errors {
+		t.Errorf("trame %d (%s): %s", e.TrameIndex, e.Direction, e.Err)
+	}
+	for _, inv := range report.Invariants {
+		t.Errorf("invariant: %s", inv)
+	}
+}

--- a/internal/probel-sw02p/consumer/validate.go
+++ b/internal/probel-sw02p/consumer/validate.go
@@ -1,0 +1,93 @@
+package probelsw02p
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	"dhs/internal/probel-sw02p/codec"
+	"dhs/internal/protocol"
+	"dhs/internal/wiretrace"
+)
+
+// Compile-time assertion: probel-sw02p Plugin satisfies
+// protocol.Validator so `dhs consumer probel-sw02p validate
+// <frames.jsonl>` resolves cleanly at the CLI type-assert
+// (cmd/dhs/cmd_validate.go).
+var _ protocol.Validator = (*Plugin)(nil)
+
+// Validate decodes captured SW-P-02 wire-trace records (Trames per
+// ADR-0021) through the codec.Unpack framer + 7-bit two's-complement
+// checksum verification, asserts that every command byte is in the
+// codec's catalogue, and reports per-direction counts plus any
+// decode failures or invariant violations.
+//
+// SW-P-02 §3.1 has transparent bytes (no DLE-stuffing) and no
+// framing-layer ACK / NAK, so unlike SW-P-08's Validate() this one
+// has no control-frame branch — every trame goes through Unpack.
+//
+// This is the offline counterpart to the live session: same codec,
+// no socket.
+//
+// --out-tree / --out-params (per ADR-0002) are not yet wired here —
+// they'll dispatch to Canonicalize() in a follow-up PR once the
+// consumer aggregates per-crosspoint state from tx 003 / tx 004 /
+// tx 067 / tx 068 traffic.
+func (p *Plugin) Validate(ctx context.Context, trames []wiretrace.Trame, opts protocol.ValidateOpts) (*protocol.ValidateReport, error) {
+	report := &protocol.ValidateReport{
+		PerDirection: map[wiretrace.Direction]int{},
+	}
+
+	if opts.OutTree != "" || opts.OutParams != "" {
+		return report, fmt.Errorf("probel-sw02p.Validate: --out-tree / --out-params not implemented yet (follow-up PR)")
+	}
+
+	for i, t := range trames {
+		if err := ctx.Err(); err != nil {
+			return report, err
+		}
+
+		raw, err := hex.DecodeString(t.Hex)
+		if err != nil {
+			report.Errors = append(report.Errors, protocol.ValidateError{
+				TrameIndex: i,
+				Direction:  t.Direction,
+				Err:        fmt.Sprintf("hex decode: %v", err),
+			})
+			continue
+		}
+
+		frame, _, err := codec.Unpack(raw)
+		if err != nil {
+			report.Errors = append(report.Errors, protocol.ValidateError{
+				TrameIndex: i,
+				Direction:  t.Direction,
+				HexPrefix:  shortHex(raw),
+				Err:        fmt.Sprintf("sw-p-02 decode: %v", err),
+			})
+			continue
+		}
+
+		report.TramesProcessed++
+		report.PerDirection[t.Direction]++
+
+		if name := codec.CommandName(frame.ID); name == "" {
+			report.Invariants = append(report.Invariants,
+				fmt.Sprintf("trame %d: unknown SW-P-02 command id 0x%02x (%d) — not in codec catalogue", i, byte(frame.ID), byte(frame.ID)))
+		}
+
+		if opts.StopAt != "" && t.Note == opts.StopAt {
+			report.StoppedAt = t.Note
+			break
+		}
+	}
+
+	return report, nil
+}
+
+func shortHex(b []byte) string {
+	if len(b) > 16 {
+		b = b[:16]
+	}
+	return hex.EncodeToString(b)
+}

--- a/internal/probel-sw02p/testdata/protocol_types/README.md
+++ b/internal/probel-sw02p/testdata/protocol_types/README.md
@@ -1,0 +1,53 @@
+# SW-P-02 per-type fixtures (ADR-0020 Bucket 1)
+
+One folder per wire-type-or-verb. Each folder will, when fixtures are
+captured, contain:
+
+| File | Source |
+| --- | --- |
+| `frames.jsonl` | Wire-trace per ADR-0021 — drives codec encode/decode tests |
+| `capture.pcapng` | OS-socket capture — drives the Wireshark Lua dissector check |
+| `tshark.tree` | Frozen dissector output — regression diff target |
+| `README.md` | Scenario context + spec citation + dhs commit at capture time |
+
+These fixtures are consumed by `internal/probel-sw02p/codec/*_test.go`
+(byte-level round-trip) and by the dissector cross-check pipeline
+(`tshark -X lua_script:wireshark/dhs_probel_sw02p.lua` on the
+`.pcapng`).
+
+## Initial folders
+
+| Folder | Direction | Cmd byte | Spec | Description |
+| --- | --- | ---: | --- | --- |
+| `rx_001_interrogate/` | controller → matrix | 1 | §3.2.3 | "What's connected at dst?" |
+| `rx_002_connect/` | controller → matrix | 2 | §3.2.4 | "Connect src to dst." |
+| `tx_003_tally/` | matrix → controller | 3 | §3.2.5 | Spontaneous tally fan-out. |
+| `tx_004_crosspoint_connected/` | matrix → controller | 4 | §3.2.6 | Reply to rx 1 / rx 2. |
+| `rx_007_status_request/` | controller → matrix | 7 | §3.2.9 | Status query (used as poll keepalive). |
+| `tx_009_status_response_2/` | matrix → controller | 9 | §3.2.11 | Status response carrying matrix state. |
+
+Add new folders as we land per-command fixtures (NN_command_name/
+matching `cmd_rxNNN_xxx.go` / `cmd_txNNN_xxx.go` filenames in
+`consumer/` and `provider/`).
+
+## Why this layout
+
+- Codec test discovery is `for d in protocol_types/*/`, no manifest.
+- The folder name carries direction + command byte + name so a
+  reviewer reading the `git diff` understands the scope without
+  cracking the binary.
+- Same name across protocols (Bucket 1 layout per ADR-0020) lets the
+  cross-protocol fixture validator stay protocol-agnostic.
+
+## Pairing with `captures/`
+
+Live captures live LOCAL ONLY at `captures/probel-sw02p/<scenario>/
+frames.jsonl` (gitignored, per ADR-0021). To promote a live capture
+into a committed per-type fixture:
+
+1. Capture: `dhs consumer probel-sw02p ... --capture
+   captures/probel-sw02p/<scenario>/frames.jsonl`
+2. Trim to the relevant single frame (or paired req/reply).
+3. Drop the trimmed `frames.jsonl` here under the matching command
+   folder, alongside a one-paragraph `README.md` citing the scenario
+   and the dhs commit at capture time.

--- a/internal/probel-sw02p/testdata/protocol_types/rx_001_interrogate/README.md
+++ b/internal/probel-sw02p/testdata/protocol_types/rx_001_interrogate/README.md
@@ -1,0 +1,23 @@
+# rx 001 INTERROGATE (SW-P-02 §3.2.3)
+
+| Direction | Cmd byte | Spec |
+| --- | ---: | --- |
+| controller → matrix | 1 | §3.2.3 |
+
+Asks the matrix "what's currently connected to `<dst>`?" The matrix
+replies with cmd 4 CROSSPOINT CONNECTED.
+
+## Wire shape
+
+```
+SOM 0x01 <multiplier> <dst> <chk>
+```
+
+`<multiplier>` packs 3 bits of DIV-128 for Dest + 3 for Src + 1
+bad-source bit per §3.2.3. Range: dst 0-1023.
+
+## Fixtures (when captured)
+
+- `frames.jsonl` — interrogate frames per ADR-0021.
+- `capture.pcapng` — original socket capture.
+- `tshark.tree` — frozen dissector output.

--- a/internal/probel-sw02p/testdata/protocol_types/rx_002_connect/README.md
+++ b/internal/probel-sw02p/testdata/protocol_types/rx_002_connect/README.md
@@ -1,0 +1,29 @@
+# rx 002 CONNECT (SW-P-02 §3.2.4)
+
+| Direction | Cmd byte | Spec |
+| --- | ---: | --- |
+| controller → matrix | 2 | §3.2.4 |
+
+Tells the matrix to connect `<src>` to `<dst>`. The matrix replies
+with cmd 4 CROSSPOINT CONNECTED once the route is live and broadcasts
+cmd 3 TALLY to every connected session.
+
+Note the deviation captured in `internal/probel-sw02p/CLAUDE.md`
+"Protect blocks connect — state-echo on rx 02 / rx 66": when the
+target dst is protected and the requester is not the protect owner,
+the matrix silently drops the request OR echoes the EXISTING route
+back via tx 04 (per §3.2.60 silence + the §3.2.6 echo deviation).
+
+## Wire shape
+
+```
+SOM 0x02 <multiplier> <dst> <src> <chk>
+```
+
+## Fixtures (when captured)
+
+- `frames.jsonl` — paired (cmd 002 request, cmd 004 reply, cmd 003
+  broadcast) sequence so the codec round-trip hits all three.
+- `capture.pcapng` + `tshark.tree` — dissector cross-check artefacts.
+- A second fixture set under a `protect_blocked/` subfolder pinning
+  the deviation in `provider/cmd_rx002_connect.go`.

--- a/internal/probel-sw02p/testdata/protocol_types/rx_007_status_request/README.md
+++ b/internal/probel-sw02p/testdata/protocol_types/rx_007_status_request/README.md
@@ -1,0 +1,25 @@
+# rx 007 STATUS REQUEST (SW-P-02 §3.2.9)
+
+| Direction | Cmd byte | Spec |
+| --- | ---: | --- |
+| controller → matrix | 7 | §3.2.9 |
+
+Status query. Used by VSM-style controllers as a continuous-poll
+keepalive (per CLAUDE.md "AppKeepaliveSpacing" notes) since SW-P-02
+§3.1 has no framing-layer keepalive command.
+
+## Wire shape
+
+```
+SOM 0x07 <data...> <chk>
+```
+
+The exact `<data>` shape depends on the matrix vendor — query
+type, optional dst hint. Matrix replies with cmd 9 STATUS RESPONSE-2
+(§3.2.11).
+
+## Fixtures (when captured)
+
+- `frames.jsonl` — a representative poll cadence with paired tx 9
+  responses.
+- `capture.pcapng` + `tshark.tree` — dissector artefacts.

--- a/internal/probel-sw02p/testdata/protocol_types/tx_003_tally/README.md
+++ b/internal/probel-sw02p/testdata/protocol_types/tx_003_tally/README.md
@@ -1,0 +1,21 @@
+# tx 003 TALLY (SW-P-02 §3.2.5)
+
+| Direction | Cmd byte | Spec |
+| --- | ---: | --- |
+| matrix → controller | 3 | §3.2.5 |
+
+Spontaneous broadcast: "this dst is now connected to src." Emitted to
+every connected session whenever the matrix applies a route — single-
+shot connect (cmd 2), salvo commit (cmd 6), or local panel.
+
+## Wire shape
+
+```
+SOM 0x03 <multiplier> <dst> <src> <chk>
+```
+
+## Fixtures (when captured)
+
+- `frames.jsonl` — a representative tally storm following a salvo
+  commit, captured against Lawo VSM or Commie.
+- `capture.pcapng` + `tshark.tree` — dissector artefacts.

--- a/internal/probel-sw02p/testdata/protocol_types/tx_004_crosspoint_connected/README.md
+++ b/internal/probel-sw02p/testdata/protocol_types/tx_004_crosspoint_connected/README.md
@@ -1,0 +1,22 @@
+# tx 004 CROSSPOINT CONNECTED (SW-P-02 §3.2.6)
+
+| Direction | Cmd byte | Spec |
+| --- | ---: | --- |
+| matrix → controller | 4 | §3.2.6 |
+
+Reply to cmd 1 INTERROGATE or cmd 2 CONNECT. Same wire shape as cmd 3
+TALLY, addressed back to the single requesting session rather than
+broadcast.
+
+## Wire shape
+
+```
+SOM 0x04 <multiplier> <dst> <src> <chk>
+```
+
+## Fixtures (when captured)
+
+- `frames.jsonl` — paired with the rx_001 / rx_002 request it
+  answers. The codec round-trip test asserts the reply byte shape
+  matches the spec.
+- `capture.pcapng` + `tshark.tree` — dissector artefacts.

--- a/internal/probel-sw02p/testdata/protocol_types/tx_009_status_response_2/README.md
+++ b/internal/probel-sw02p/testdata/protocol_types/tx_009_status_response_2/README.md
@@ -1,0 +1,19 @@
+# tx 009 STATUS RESPONSE - 2 (SW-P-02 §3.2.11)
+
+| Direction | Cmd byte | Spec |
+| --- | ---: | --- |
+| matrix → controller | 9 | §3.2.11 |
+
+Reply to cmd 7 STATUS REQUEST. Carries the matrix's current
+operational status (active controller, fault flags, etc.).
+
+## Wire shape
+
+```
+SOM 0x09 <status-bytes...> <chk>
+```
+
+## Fixtures (when captured)
+
+- `frames.jsonl` — paired with the rx 007 it answers.
+- `capture.pcapng` + `tshark.tree` — dissector artefacts.


### PR DESCRIPTION
## Summary

Mirror of #221 for SW-P-02. Brings probel-sw02p in line with cross-cutting connector rules:

- `Plugin.Validate()` per ADR-0021 — offline decode through the SW-P-02 framer + 7-bit two's-complement checksum + §3.2 command-id catalogue validation.
- `Plugin.Canonicalize()` returning a `*canonical.Export` shaped from the externally-supplied `MatrixConfig` (single matrix, single level per spec §3.1).
- `testdata/protocol_types/` skeleton per ADR-0020 Bucket 1 with one starter folder per primary §3.2 command.

Stacked on #213. Independent of #215 / #217 / #219 / #221.

Closes #222, advances #212.

## Per-trame validation

Same shape as #221, simplified because SW-P-02 §3.1 has transparent bytes (no DLE-stuffing) and no framing-layer ACK / NAK — every trame goes through `codec.Unpack` directly with no control-frame branch.

1. hex ? bytes
2. `codec.Unpack` ? `codec.Frame{ID, Payload}` (SOM 0xFF, command, message bytes, 7-bit two's-complement checksum)
3. assert `codec.CommandName(frame.ID) != ""` — unknown command ids flagged as informational invariants.
4. honors `--stop-at` via `Trame.Note` (per ADR-0021).
5. `--out-tree` / `--out-params` return "not implemented yet" pending Canonicalize() integration follow-up.

Compile-time `var _ protocol.Validator = (*Plugin)(nil)` assertion locks the contract at build.

## Canonicalize tree shape (initial)

```
device (Node, oid="1", identifier=host)
+-- matrix-<id>.level-<lvl> (Matrix, type=oneToN, mode=linear,
                              targetCount=Dsts, sourceCount=Srcs,
                              targets=[], sources=[], connections=[])
```

Empty `MatrixConfig` (no `SetMatrixConfig` call yet) ? empty children. Per-crosspoint state lands when the consumer aggregates cmd 003 / cmd 004 / cmd 067 / cmd 068 tally traffic into a cached matrix-state map (separate follow-up).

## testdata/protocol_types/

| Folder | Direction | Cmd | Spec |
| --- | --- | ---: | --- |
| `rx_001_interrogate/` | controller ? matrix | 1 | §3.2.3 |
| `rx_002_connect/` | controller ? matrix | 2 | §3.2.4 |
| `tx_003_tally/` | matrix ? controller | 3 | §3.2.5 |
| `tx_004_crosspoint_connected/` | matrix ? controller | 4 | §3.2.6 |
| `rx_007_status_request/` | controller ? matrix | 7 | §3.2.9 |
| `tx_009_status_response_2/` | matrix ? controller | 9 | §3.2.11 |

Each folder gets a README documenting wire shape + spec citation.

## Hard invariants verified

- [x] `internal/probel-sw02p/codec/` unchanged — no `dhs/*` imports introduced.
- [x] `Plugin` satisfies `protocol.Validator` at compile time.
- [x] `go build ./...` OK
- [x] `go vet ./...` OK
- [x] `golangci-lint run` 0 issues
- [x] `go test ./...` all OK (full repo)
- [x] `TestReplay_ProbelSw02pBootstrap` SKIP cleanly with the recapture hint on a fresh clone (expected).

## Out of scope

- Per-crosspoint state aggregation from tally traffic (separate tracker — needed before `--out-tree` produces a richer `Matrix.Connections[]` list).
- Per-product DM library entries under `tests/fixtures/products/<vendor>/<router>/probel-sw02p/...` (Bucket 3, separate workstream).
- Wireshark dissector tweaks — already shipped per CLAUDE.md.