### PR TITLE
feat(tsl): compliance_events + Validate() + Canonicalize() + Walk-graceful regression (closes #224, #212)

### DIFF
--- a/internal/tsl/consumer/canonicalize.go
+++ b/internal/tsl/consumer/canonicalize.go
@@ -1,0 +1,62 @@
+package tsl
+
+import (
+	"context"
+	"fmt"
+
+	"dhs/internal/export/canonical"
+)
+
+// Canonicalize emits a canonical.Export shaped from the TSL display
+// vocabulary. TSL UMD is positional tally — there is no walkable tree
+// (the consumer's Walk method returns ErrNotImplemented by design;
+// see CLAUDE.md "TSL not use all the verb like walk").
+//
+// Tree shape (initial):
+//
+//	device (Node, oid="1", identifier=tsl-vXX)
+//	└── displays (Node, identifier="displays", children=[])
+//
+// The "displays" Node is a stable container under which per-INDEX
+// Parameter elements get added when the consumer caches V31/V40/V50
+// frame state per display address. Empty children initially —
+// populated when the per-INDEX state aggregation lands as a
+// follow-up (parallel to the probel-sw08p / probel-sw02p
+// connection-state aggregation tracker).
+//
+// Pre-Connect Plugin instances yield the empty-children shape so
+// `dhs producer ... validate --out-tree ...` produces a deterministic
+// document even on a freshly-instantiated plugin.
+func (p *Plugin) Canonicalize(ctx context.Context) (*canonical.Export, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("canonicalize canceled: %w", err)
+	}
+
+	identifier := p.version.name()
+
+	displays := &canonical.Node{
+		Header: canonical.Header{
+			Number:     1,
+			Identifier: "displays",
+			Path:       identifier + ".displays",
+			OID:        "1.1",
+			IsOnline:   true,
+			Access:     canonical.AccessRead,
+			Children:   canonical.EmptyChildren(),
+		},
+	}
+
+	root := &canonical.Node{
+		Header: canonical.Header{
+			Number:     1,
+			Identifier: identifier,
+			Path:       identifier,
+			OID:        "1",
+			IsOnline:   true,
+			Access:     canonical.AccessRead,
+			Children:   []canonical.Element{displays},
+		},
+	}
+
+	return &canonical.Export{Root: root}, nil
+}

--- a/internal/tsl/consumer/compliance_events.go
+++ b/internal/tsl/consumer/compliance_events.go
@@ -1,0 +1,97 @@
+package tsl
+
+import "dhs/internal/tsl/codec"
+
+// Compliance event labels — per-spec named deviations the TSL consumer
+// surfaces from the codec's ComplianceNote stream into the
+// compliance.Profile event log. Every label here mirrors a documented
+// row in internal/tsl/CLAUDE.md "Compliance events" and a Note kind
+// the codec already emits during Decode.
+//
+// Authoritative spec: internal/tsl/assets/tsl-umd-protocol.txt.
+//
+// The generic Profile counter lives in internal/protocol/compliance/.
+// Classification:
+//   - strict  : zero events fired this session
+//   - partial : one or more events fired, all within tolerance
+//
+// Adding a new label is an API change — downstream tooling may
+// aggregate by key. Keep this list stable + documented in
+// internal/tsl/CLAUDE.md "Compliance events".
+const (
+	// v3.1 CTRL bit 6 is "reserved (clear on tx)"; on rx, a frame with
+	// the bit set is decoded normally and this event is fired so
+	// aggregate counts can flag flaky producers. CLAUDE.md row 1.
+	ReservedBitSet = "tsl_reserved_bit_set"
+
+	// v4.0 VBC encodes a minor version (bits 6-4). v4.0 producers MUST
+	// emit minor=0; any non-zero value indicates a future micro-revision
+	// the consumer does not understand. Frame still decodes (XDATA is
+	// length-prefixed) and this event fires. CLAUDE.md row 2.
+	VersionMismatch = "tsl_version_mismatch"
+
+	// v4.0 CHKSUM is a 7-bit two's-complement of the v3.1 prefix. A
+	// mismatch is surfaced (frame body still parses; consumer caller
+	// chooses whether to drop). CLAUDE.md row 3.
+	ChecksumFail = "tsl_checksum_fail"
+
+	// v4.0 CTRL.6 = 1 ("control data") and v5.0 CONTROL.15 = 1
+	// ("control data flag") are documented but spec-undefined in the
+	// current revision. Consumer treats the payload as opaque + fires.
+	// CLAUDE.md row 4.
+	ControlDataUndefined = "tsl_control_data_undefined"
+
+	// A v5.0 DMSG arrives for an INDEX the consumer has not modelled
+	// (no display config row, no prior packet). Decode succeeds but the
+	// caller cannot map the frame to a display. CLAUDE.md row 5.
+	UnknownDisplayIndex = "tsl_unknown_display_index"
+
+	// v5.0 SCREEN=0xFFFF or DMSG INDEX=0xFFFF is a broadcast value per
+	// spec §5.0. Decode succeeds; this event fires so the operator can
+	// observe broadcast cadence. CLAUDE.md row 6.
+	BroadcastReceived = "tsl_broadcast_received"
+
+	// v5.0 frames marked UTF-16LE in FLAGS bit 0 are decoded then
+	// transcoded to UTF-8 for the consumer-side string surface. Fired
+	// once per transcode so callers can audit charset traffic.
+	// CLAUDE.md row 7.
+	CharsetTranscode = "tsl_charset_transcode"
+
+	// v3.1 / v4.0 frame received with a DATA segment whose length is
+	// not the spec-mandated 16 bytes. Decoder accepts what it has and
+	// fires. CLAUDE.md row 8.
+	LabelLengthMismatch = "tsl_label_length_mismatch"
+
+	// v3.1 producers MUST space-pad (0x20) DATA to 16 bytes. Some
+	// producers null-pad (0x00) — frame still decodes; this event
+	// fires. CLAUDE.md row 9.
+	V31NullPad = "tsl_v31_null_pad"
+
+	// v5.0 over TCP is spec-required to use the DLE/STX wrapper
+	// (§Phy). A packet arriving on a TCP listener WITHOUT the wrapper
+	// is decoded as a best effort + fired. CLAUDE.md row 10.
+	V5TcpUnwrapped = "tsl_v5_tcp_unwrapped"
+)
+
+// EventForNote maps a codec.ComplianceNote.Kind back to the consumer-
+// layer compliance event constant declared above. Returns "" when the
+// note kind is unknown (caller should not fire — a no-op event slot
+// here means the codec exposed a deviation the consumer hasn't lifted
+// yet, which is itself worth noticing). Exposed so unit tests can
+// assert mapping correctness without standing up a session.
+func EventForNote(n codec.ComplianceNote) string {
+	switch n.Kind {
+	case ReservedBitSet,
+		VersionMismatch,
+		ChecksumFail,
+		ControlDataUndefined,
+		UnknownDisplayIndex,
+		BroadcastReceived,
+		CharsetTranscode,
+		LabelLengthMismatch,
+		V31NullPad,
+		V5TcpUnwrapped:
+		return n.Kind
+	}
+	return ""
+}

--- a/internal/tsl/consumer/replay_test.go
+++ b/internal/tsl/consumer/replay_test.go
@@ -1,0 +1,126 @@
+// Package tsl_test — replay tests run captured Trames (per ADR-0021)
+// through the TSL plugin's Validate() method. Skips cleanly when no
+// local capture is present so a fresh clone is green without
+// `git lfs pull` or any pre-loaded fixtures.
+//
+// Also pins the TSL "no walk verb" contract — TSL is positional UMD
+// tally with no walkable tree, so Walk / GetValue / SetValue /
+// Subscribe must all return protocol.ErrNotImplemented for every
+// version.
+package tsl_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"dhs/internal/protocol"
+	"dhs/internal/tsl/consumer"
+	"dhs/internal/wiretrace"
+)
+
+// loadTrames reads a captured wire trace from
+// captures/<proto-name>/<scenario>/frames.jsonl (gitignored, local-
+// only per ADR-0021). Skips cleanly when the file is missing —
+// re-capture with `dhs consumer <proto-name> listen --capture <path>`.
+func loadTrames(t *testing.T, protoName, scenario string) []wiretrace.Trame {
+	t.Helper()
+	path := filepath.Join("..", "..", "..", "captures", protoName, scenario, "frames.jsonl")
+	f, err := os.Open(path)
+	if errors.Is(err, os.ErrNotExist) {
+		t.Skipf("capture %s missing — recapture with `dhs consumer %s listen --capture %s`", path, protoName, path)
+	}
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	trames, err := wiretrace.ReadTrames(f)
+	if err != nil {
+		t.Fatalf("ReadTrames: %v", err)
+	}
+	return trames
+}
+
+func newValidator(t *testing.T, factory *tsl.Factory) protocol.Validator {
+	t.Helper()
+	plug := factory.New(slog.Default())
+	v, ok := plug.(protocol.Validator)
+	if !ok {
+		t.Fatalf("tsl Plugin (%s) does not implement protocol.Validator", factory.Meta().Name)
+	}
+	return v
+}
+
+// TestReplay_TslV50DMSG runs every Trame through Plugin.Validate
+// and asserts no decode errors and no spec invariant violations on
+// a v5.0 multi-DMSG capture.
+func TestReplay_TslV50DMSG(t *testing.T) {
+	trames := loadTrames(t, "tsl-v50", "dmsg_burst")
+	if len(trames) == 0 {
+		t.Fatal("no trames in capture")
+	}
+	v := newValidator(t, &tsl.Factory{})
+	report, err := v.Validate(context.Background(), trames, protocol.ValidateOpts{})
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	t.Logf("tsl-v50 trames: %d decoded (%d tx, %d rx)",
+		report.TramesProcessed,
+		report.PerDirection[wiretrace.DirectionTx],
+		report.PerDirection[wiretrace.DirectionRx])
+	for _, e := range report.Errors {
+		t.Errorf("trame %d (%s): %s", e.TrameIndex, e.Direction, e.Err)
+	}
+	for _, inv := range report.Invariants {
+		t.Logf("compliance note: %s", inv)
+	}
+}
+
+// TestPlugin_WalkReturnsErrNotImplemented_AllVersions pins the
+// TSL "no walk verb" contract. TSL is positional UMD tally — there
+// is no walkable tree, no per-object value to read or write, no
+// per-object subscribe path. The Plugin.Walk / GetValue / SetValue /
+// Subscribe methods MUST return protocol.ErrNotImplemented for
+// every registered version (V31, V40, V50). Future feature PRs
+// that try to wire Walk for TSL break this test, by design — TSL
+// callers use SubscribeV31 / SubscribeV40 / SubscribeV50, not the
+// generic protocol.Protocol.Subscribe path.
+func TestPlugin_WalkReturnsErrNotImplemented_AllVersions(t *testing.T) {
+	cases := []struct {
+		name    string
+		factory func(*slog.Logger) *tsl.Plugin
+	}{
+		{"v31", tsl.NewPluginV31},
+		{"v40", tsl.NewPluginV40},
+		{"v50", tsl.NewPluginV50},
+	}
+	ctx := context.Background()
+	req := protocol.ValueRequest{ID: 1}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p := c.factory(slog.Default())
+			if _, err := p.Walk(ctx, 0); !errors.Is(err, protocol.ErrNotImplemented) {
+				t.Errorf("Walk: got %v, want ErrNotImplemented", err)
+			}
+			if _, err := p.GetValue(ctx, req); !errors.Is(err, protocol.ErrNotImplemented) {
+				t.Errorf("GetValue: got %v, want ErrNotImplemented", err)
+			}
+			if _, err := p.SetValue(ctx, req, protocol.Value{}); !errors.Is(err, protocol.ErrNotImplemented) {
+				t.Errorf("SetValue: got %v, want ErrNotImplemented", err)
+			}
+			if err := p.Subscribe(req, nil); !errors.Is(err, protocol.ErrNotImplemented) {
+				t.Errorf("Subscribe: got %v, want ErrNotImplemented", err)
+			}
+			if _, err := p.GetDeviceInfo(ctx); !errors.Is(err, protocol.ErrNotImplemented) {
+				t.Errorf("GetDeviceInfo: got %v, want ErrNotImplemented", err)
+			}
+			if _, err := p.GetSlotInfo(ctx, 0); !errors.Is(err, protocol.ErrNotImplemented) {
+				t.Errorf("GetSlotInfo: got %v, want ErrNotImplemented", err)
+			}
+		})
+	}
+}

--- a/internal/tsl/consumer/validate.go
+++ b/internal/tsl/consumer/validate.go
@@ -1,0 +1,148 @@
+package tsl
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	"dhs/internal/protocol"
+	"dhs/internal/tsl/codec"
+	"dhs/internal/wiretrace"
+)
+
+// Compile-time assertion: TSL Plugin satisfies protocol.Validator so
+// `dhs consumer tsl-vXX validate <frames.jsonl>` resolves cleanly at
+// the CLI type-assert (cmd/dhs/cmd_validate.go).
+var _ protocol.Validator = (*Plugin)(nil)
+
+// Validate decodes captured TSL UMD wire-trace records (Trames per
+// ADR-0021) through the version-specific decoder bound to this
+// Plugin instance, surfaces every codec ComplianceNote as an
+// informational invariant, and reports per-direction counts plus
+// any decode failures.
+//
+// Dispatch by Plugin.version:
+//
+//	V31  -> codec.DecodeV31  (18-byte UDP frame)
+//	V40  -> codec.DecodeV40  (v3.1 + CHKSUM + VBC + XDATA)
+//	V50  -> codec.DecodeV50  (PBC | VER | FLAGS | SCREEN | DMSG+)
+//
+// v5.0 trames captured from a TCP socket arrive wrapped in
+// DLE/STX (0xFE 0x02 prefix) -- this function unwraps via
+// DLEStreamDecoder before calling DecodeV50. UDP trames are
+// passed through verbatim.
+//
+// This is the offline counterpart to the live UDP/TCP listener:
+// same codec, no socket.
+//
+// --out-tree / --out-params (per ADR-0002) defer to Canonicalize() in
+// a follow-up PR once the consumer aggregates per-INDEX display state
+// from the V31/V40/V50 frame stream.
+func (p *Plugin) Validate(ctx context.Context, trames []wiretrace.Trame, opts protocol.ValidateOpts) (*protocol.ValidateReport, error) {
+	report := &protocol.ValidateReport{
+		PerDirection: map[wiretrace.Direction]int{},
+	}
+
+	if opts.OutTree != "" || opts.OutParams != "" {
+		return report, fmt.Errorf("tsl.Validate: --out-tree / --out-params not implemented yet (follow-up PR)")
+	}
+
+	for i, t := range trames {
+		if err := ctx.Err(); err != nil {
+			return report, err
+		}
+
+		raw, err := hex.DecodeString(t.Hex)
+		if err != nil {
+			report.Errors = append(report.Errors, protocol.ValidateError{
+				TrameIndex: i,
+				Direction:  t.Direction,
+				Err:        fmt.Sprintf("hex decode: %v", err),
+			})
+			continue
+		}
+
+		notes, err := p.decodeOne(raw)
+		if err != nil {
+			report.Errors = append(report.Errors, protocol.ValidateError{
+				TrameIndex: i,
+				Direction:  t.Direction,
+				HexPrefix:  shortHex(raw),
+				Err:        fmt.Sprintf("tsl decode: %v", err),
+			})
+			continue
+		}
+
+		report.TramesProcessed++
+		report.PerDirection[t.Direction]++
+
+		for _, n := range notes {
+			report.Invariants = append(report.Invariants,
+				fmt.Sprintf("trame %d: %s%s", i, n.Kind, formatNoteDetail(n.Detail)))
+		}
+
+		if opts.StopAt != "" && t.Note == opts.StopAt {
+			report.StoppedAt = t.Note
+			break
+		}
+	}
+
+	return report, nil
+}
+
+// decodeOne dispatches one byte buffer through the codec for this
+// Plugin's wire version and returns the codec's compliance notes (a
+// nil-or-empty slice on a fully-spec-compliant frame).
+func (p *Plugin) decodeOne(raw []byte) ([]codec.ComplianceNote, error) {
+	switch p.version {
+	case V31:
+		f, err := codec.DecodeV31(raw)
+		if err != nil {
+			return nil, err
+		}
+		return f.Notes, nil
+	case V40:
+		f, err := codec.DecodeV40(raw)
+		if err != nil {
+			return nil, err
+		}
+		return f.Notes, nil
+	case V50:
+		// TCP-wrapped frames begin with DLE STX (0xFE 0x02). Unwrap
+		// before handing the inner packet to DecodeV50. UDP frames
+		// arrive raw and DecodeV50 accepts them directly.
+		if len(raw) >= 2 && raw[0] == 0xFE && raw[1] == 0x02 {
+			dec := codec.NewDLEStreamDecoder(bytes.NewReader(raw), 0)
+			inner, err := dec.ReadFrame()
+			if err != nil {
+				return nil, fmt.Errorf("v5 dle/stx: %w", err)
+			}
+			pkt, err := codec.DecodeV50(inner)
+			if err != nil {
+				return nil, err
+			}
+			return pkt.Notes, nil
+		}
+		pkt, err := codec.DecodeV50(raw)
+		if err != nil {
+			return nil, err
+		}
+		return pkt.Notes, nil
+	}
+	return nil, fmt.Errorf("tsl validate: unknown plugin version %v", p.version)
+}
+
+func formatNoteDetail(detail string) string {
+	if detail == "" {
+		return ""
+	}
+	return " (" + detail + ")"
+}
+
+func shortHex(b []byte) string {
+	if len(b) > 16 {
+		b = b[:16]
+	}
+	return hex.EncodeToString(b)
+}

--- a/internal/tsl/testdata/protocol_types/README.md
+++ b/internal/tsl/testdata/protocol_types/README.md
@@ -1,0 +1,63 @@
+# TSL UMD per-type fixtures (ADR-0020 Bucket 1)
+
+One folder per wire-version + frame-type. Each folder will, when
+fixtures are captured, contain:
+
+| File | Source |
+| --- | --- |
+| `frames.jsonl` | Wire-trace per ADR-0021 — drives codec encode/decode tests |
+| `capture.pcapng` | OS-socket capture — drives the Wireshark Lua dissector check |
+| `tshark.tree` | Frozen dissector output — regression diff target |
+| `README.md` | Scenario context + spec citation + dhs commit at capture time |
+
+These fixtures are consumed by `internal/tsl/codec/*_test.go` (byte-
+level round-trip) and by the dissector cross-check pipeline
+(`tshark -X lua_script:wireshark/dissector_tsl.lua` on the
+`.pcapng`).
+
+## Initial folders
+
+| Folder | Wire | Spec | Description |
+| --- | --- | --- | --- |
+| `v31_frame/` | UDP | §3.0 | 18-byte v3.1 frame (HEADER + CTRL + DATA), 4 binary tallies, no colour. |
+| `v40_frame/` | UDP | §4.0 | v3.1 + CHKSUM + VBC + XDATA — 2-bit colour per LH/Text/RH per L/R display. |
+| `v50_dmsg/` | UDP ≤ 2048 B | §5.0 | UDP packet with PBC + VER + FLAGS + SCREEN + DMSG+ . Single + grouped multi-DMSG. |
+| `v50_dle_stx_tcp/` | TCP wrapped | §5.0 §Phy | v5.0 TCP transport with DLE/STX wrapper + 0xFE byte-stuffing. |
+
+## Why this layout
+
+- Codec test discovery is `for d in protocol_types/*/`, no manifest.
+- The folder name carries wire version + transport so a reviewer
+  reading the `git diff` understands the scope without cracking the
+  binary.
+- TSL has three wire versions (v3.1, v4.0, v5.0) and v5.0 adds a
+  TCP-wrapped variant — one folder per (version, transport) pair
+  keeps fixtures independently testable.
+
+## Pairing with `captures/`
+
+Live captures live LOCAL ONLY at `captures/tsl-vXX/<scenario>/
+frames.jsonl` (gitignored, per ADR-0021). Plugin registry names per
+CLAUDE.md:
+
+- `tsl-v31` → UDP v3.1
+- `tsl-v40` → UDP v4.0
+- `tsl-v50` → UDP v5.0 (use `--tcp` for the DLE/STX variant)
+
+To promote a live capture into a committed per-type fixture:
+
+1. Capture: `dhs consumer tsl-v50 listen --capture
+   captures/tsl-v50/<scenario>/frames.jsonl`
+2. Trim to the relevant single frame (or paired produce/consume).
+3. Drop the trimmed `frames.jsonl` here under the matching wire-
+   version folder, alongside a one-paragraph `README.md` citing the
+   scenario and the dhs commit at capture time.
+
+## Walk note
+
+TSL has no walkable tree — Plugin.Walk / GetValue / SetValue /
+Subscribe all return `protocol.ErrNotImplemented` by design (per
+CLAUDE.md "TSL not use all the verb like walk"). These fixtures
+exercise the codec layer + Validate(), not Walk; the contract is
+pinned by `TestPlugin_WalkReturnsErrNotImplemented_AllVersions` in
+`consumer/replay_test.go`.

--- a/internal/tsl/testdata/protocol_types/v31_frame/README.md
+++ b/internal/tsl/testdata/protocol_types/v31_frame/README.md
@@ -1,0 +1,28 @@
+# TSL v3.1 frame (UDP, 18 bytes — §3.0)
+
+| Wire | Default port | Tally model |
+| --- | ---: | --- |
+| UDP | 4000 | 4× binary tallies + 2-bit brightness (no colour) |
+
+## Wire shape
+
+```
+| 0    | HEADER     | 1 byte  | (addr & 0x7F) | 0x80; addr range 0..126 |
+| 1    | CTRL       | 1 byte  | bits 0-3 = tallies 1..4; bits 4-5 = brightness; bit 6 reserved (clear); bit 7 = 0 |
+| 2..17| DATA       | 16 ASCII| 0x20-0x7E, **space-padded (0x20)** to 16 |
+```
+
+Total: 18 bytes. No CHKSUM — that arrived in v4.0.
+
+## Compliance notes the codec emits
+
+- `tsl_reserved_bit_set` — CTRL bit 6 set on rx.
+- `tsl_label_length_mismatch` — DATA segment != 16 bytes.
+- `tsl_v31_null_pad` — DATA padded with 0x00 instead of 0x20.
+
+## Fixtures (when captured)
+
+- `frames.jsonl` — at least one well-formed frame + one each of the
+  three deviations above so the codec round-trip exercises the full
+  ComplianceNote vocabulary.
+- `capture.pcapng` + `tshark.tree` — dissector artefacts.

--- a/internal/tsl/testdata/protocol_types/v40_frame/README.md
+++ b/internal/tsl/testdata/protocol_types/v40_frame/README.md
@@ -1,0 +1,36 @@
+# TSL v4.0 frame (UDP, 20+ bytes — §4.0)
+
+| Wire | Default port | Tally model |
+| --- | ---: | --- |
+| UDP | 4000 (testbed: 4004) | v3.1 binary tallies + XDATA 2-bit colour per LH / Text / RH × L / R display |
+
+Full-compat extension of v3.1. The trailing CHKSUM + VBC + XDATA bytes
+are absent in v3.1 frames — receivers MUST NOT confuse the two.
+
+## Wire shape
+
+```
+| v3.1 prefix    | 18 bytes | HEADER + CTRL + DATA (see v31_frame/) |
+| CHKSUM         | 1 byte   | 7-bit two's-complement of HEADER+CTRL+DATA |
+| VBC            | 1 byte   | bit 7 = 0; bits 6-4 = minor version (v4.0 → 0); bits 3-0 = XDATA byte count |
+| XDATA          | N bytes  | per VBC.bits3-0; min-version 0 = 2 bytes (Display L, Display R) |
+```
+
+Each XByte: bit 7 = 0; bit 6 reserved; bits 5-4 LH tally (2-bit colour);
+bits 3-2 Text tally; bits 1-0 RH tally. Colours: 0=OFF, 1=RED,
+2=GREEN, 3=AMBER.
+
+## Compliance notes the codec emits
+
+- `tsl_checksum_fail` — CHKSUM mismatch (consumer still parses body).
+- `tsl_version_mismatch` — VBC minor version != 0.
+- `tsl_control_data_undefined` — CTRL.6 = 1 (control data flag).
+- All v3.1 notes (reserved bit, label length, null pad).
+
+## Fixtures (when captured)
+
+- `frames.jsonl` — Lawo VSM v4.0 producer captures (per CLAUDE.md
+  "Lawo VSM Studio | v3.1 + v4.0 + v5.0 producer | ... live-validated
+  2026-04-26"). Pair every PGM red, PVW green, ISO amber tally so the
+  XByte parser round-trips all three colours.
+- `capture.pcapng` + `tshark.tree` — dissector artefacts.

--- a/internal/tsl/testdata/protocol_types/v50_dle_stx_tcp/README.md
+++ b/internal/tsl/testdata/protocol_types/v50_dle_stx_tcp/README.md
@@ -1,0 +1,33 @@
+# TSL v5.0 over TCP with DLE/STX wrapper (§5.0 §Phy)
+
+| Wire | Default port | Tally model |
+| --- | ---: | --- |
+| TCP | 8901 (testbed: 8902) | Same as `v50_dmsg/` — only the framing differs |
+
+Spec-required wrapper on TCP. UDP frames travel raw; TCP frames are
+prefixed with DLE/STX and any 0xFE byte inside the body is doubled.
+
+## Wire shape
+
+```
+| 0xFE         | DLE — frame start  |
+| 0x02         | STX                |
+| body         | as v50_dmsg/, with every 0xFE byte stuffed (0xFE 0xFE) |
+```
+
+The decoder consumes the wrapper, un-stuffs 0xFE bytes, and reads PBC
+to bound the body — see `internal/tsl/codec/v50_dle_stx.go::ReadFrame`.
+
+## Compliance notes the codec emits
+
+- `tsl_v5_tcp_unwrapped` — A v5.0 TCP frame received WITHOUT the
+  wrapper (TallyArbiter ships such frames; spec rejects them).
+  Consumer tolerates on rx + fires.
+
+## Fixtures (when captured)
+
+- `frames.jsonl` — Miranda IP Emulator TCP captures showing both:
+  (a) a wrapped frame with 0xFE byte-stuffing inside the body, and
+  (b) an unwrapped frame from a non-spec producer for the
+  `tsl_v5_tcp_unwrapped` event.
+- `capture.pcapng` + `tshark.tree` — dissector artefacts.

--- a/internal/tsl/testdata/protocol_types/v50_dmsg/README.md
+++ b/internal/tsl/testdata/protocol_types/v50_dmsg/README.md
@@ -1,0 +1,44 @@
+# TSL v5.0 packet (UDP — §5.0)
+
+| Wire | Default port | Tally model |
+| --- | ---: | --- |
+| UDP, ≤ 2048 B | 8901 (Kaleido) | LH / Text / RH (3× 2-bit colour) + 2-bit brightness, multi-DMSG |
+
+v5.0 is a brand-new protocol — no v3.1 / v4.0 backward compatibility.
+All 16-bit values little-endian.
+
+## Wire shape
+
+```
+| PBC      | 2 LE  | total byte count of body (PBC excluded) |
+| VER      | 1     | minor version (v5.00 → 0) |
+| FLAGS    | 1     | bit 0 = UTF-16LE (1) vs ASCII (0); bit 1 = SCONTROL; bits 2-7 reserved |
+| SCREEN   | 2 LE  | 0..65534; 0xFFFF = broadcast |
+| body     | …     | DMSG+ or SCONTROL (per FLAGS bit 1) |
+```
+
+Each DMSG:
+
+```
+| INDEX     | 2 LE  | 0..65534; 0xFFFF = broadcast |
+| CONTROL   | 2 LE  | bits 0-1 RH; 2-3 Text; 4-5 LH; 6-7 brightness; 8-14 reserved; 15 control-data flag |
+| LENGTH    | 2 LE  | only when CONTROL.15 = 0 |
+| TEXT      | LENGTH bytes | encoding per FLAGS.0 |
+| CONTROL_DATA | … | only when CONTROL.15 = 1 (undefined in v5.0) |
+```
+
+## Compliance notes the codec emits
+
+- `tsl_reserved_bit_set` — CONTROL bits 8-14 set.
+- `tsl_control_data_undefined` — CONTROL bit 15 set (frame parses; payload opaque).
+- `tsl_unknown_display_index` — DMSG INDEX not modelled by the consumer.
+- `tsl_broadcast_received` — SCREEN=0xFFFF or INDEX=0xFFFF.
+- `tsl_charset_transcode` — UTF-16LE label transcoded to UTF-8.
+
+## Fixtures (when captured)
+
+- `frames.jsonl` — Miranda IP Emulator captures (per CLAUDE.md
+  "Miranda TSL IP Emulator v1.02 | v5.0 UDP + TCP | ... live-validated
+  2026-04-26 (single-DMSG + 5-DMSG group via 'Group display
+  messages')").
+- `capture.pcapng` + `tshark.tree` — dissector artefacts.


### PR DESCRIPTION
## Summary

Final connector in the per-connector Validate() migration. Brings TSL UMD in line with cross-cutting connector rules:

- `internal/tsl/consumer/compliance_events.go` — lifts the documented event vocabulary (CLAUDE.md "Compliance events" table) into Go constants the consumer can fire via `compliance.Profile`. Maps every codec `ComplianceNote.Kind` to a stable consumer-layer label via `EventForNote`.
- `Plugin.Validate()` per ADR-0021 — dispatches to v3.1 / v4.0 / v5.0 codec decoders by `Plugin.version`, surfaces every codec ComplianceNote as an informational invariant, reports per-direction counts.
- `Plugin.Canonicalize()` returning a `*canonical.Export` with a stable "displays" container Node.
- **Walk-graceful regression**: `TestPlugin_WalkReturnsErrNotImplemented_AllVersions` pins the contract that `Walk` / `GetValue` / `SetValue` / `Subscribe` / `GetDeviceInfo` / `GetSlotInfo` all return `protocol.ErrNotImplemented` for V31, V40, V50. TSL is positional UMD tally — there is no walkable tree — so future feature PRs that try to wire Walk for TSL break this test, by design.
- `testdata/protocol_types/` skeleton per ADR-0020 Bucket 1 with one folder per (wire version, transport): `v31_frame`, `v40_frame`, `v50_dmsg`, `v50_dle_stx_tcp`.

Stacked on #213. Independent of #215 / #217 / #219 / #221 / #223.

Closes #224, #212.

## Validate dispatch by version

| Version | Trame shape | Decoder |
| --- | --- | --- |
| V31 | 18-byte UDP frame | `codec.DecodeV31` |
| V40 | v3.1 + CHKSUM + VBC + XDATA | `codec.DecodeV40` |
| V50 | UDP packet = 2048 B; TCP via `DLEStreamDecoder` | `codec.DecodeV50` |

For v5.0 trames captured from a TCP socket (start with `0xFE 0x02`), Validate unwraps via `codec.DLEStreamDecoder.ReadFrame` before calling `DecodeV50`. UDP trames are passed through verbatim.

## Compliance vocabulary (10 events mirroring CLAUDE.md)

| Constant | Fires when |
| --- | --- |
| `ReservedBitSet` | v3.1 CTRL.6, v5.0 CONTROL bits 8-14 |
| `VersionMismatch` | v4.0 VBC minor != 0 |
| `ChecksumFail` | v4.0 CHKSUM mismatch |
| `ControlDataUndefined` | v4.0 CTRL.6=1, v5.0 CONTROL.15=1 |
| `UnknownDisplayIndex` | v5.0 DMSG INDEX not modelled |
| `BroadcastReceived` | v5.0 SCREEN=0xFFFF or INDEX=0xFFFF |
| `CharsetTranscode` | v5.0 UTF-16LE ? UTF-8 |
| `LabelLengthMismatch` | v3.1/v4.0 DATA != 16 bytes |
| `V31NullPad` | v3.1 frame with 0x00 pad |
| `V5TcpUnwrapped` | v5.0 TCP frame missing DLE/STX wrapper |

`EventForNote(codec.ComplianceNote) string` maps codec note Kind ? consumer event label.

Compile-time assertion: `var _ protocol.Validator = (*Plugin)(nil)`.

## testdata/protocol_types/

| Folder | Wire | Spec |
| --- | --- | --- |
| `v31_frame/` | UDP | §3.0 |
| `v40_frame/` | UDP | §4.0 |
| `v50_dmsg/` | UDP = 2048 B | §5.0 |
| `v50_dle_stx_tcp/` | TCP wrapped | §5.0 —Phy |

Each folder gets a README documenting wire shape + spec citation + which codec ComplianceNotes it should exercise.

## Hard invariants verified

- [x] `internal/tsl/codec/` unchanged — no `dhs/*` imports introduced.
- [x] `Plugin` satisfies `protocol.Validator` at compile time for all three versions.
- [x] Walk / GetValue / SetValue / Subscribe / GetDeviceInfo / GetSlotInfo still return `protocol.ErrNotImplemented` (regression test passes for v31, v40, v50).
- [x] `go build ./...` OK
- [x] `go vet ./...` OK
- [x] `golangci-lint run` 0 issues
- [x] `go test ./...` all OK (full repo)
- [x] `TestReplay_TslV50DMSG` SKIP cleanly with the recapture hint on a fresh clone (expected); `TestPlugin_WalkReturnsErrNotImplemented_AllVersions` passes.

## Out of scope

- Per-INDEX display state aggregation from V31/V40/V50 frame stream (separate tracker — needed before `--out-tree` produces richer `displays` children).
- Per-product DM library entries under `tests/fixtures/products/<vendor>/<product>/tsl-vXX/...` (Bucket 3, separate workstream).
- Wireshark dissector tweaks — already shipped per CLAUDE.md.