### PR TITLE
feat(probel-sw08p): wire names-family extended-form + boundary tests (advances #227)

### DIFF
--- a/internal/probel-sw08p/codec/cmd_names_extended_test.go
+++ b/internal/probel-sw08p/codec/cmd_names_extended_test.go
@@ -1,0 +1,257 @@
+package codec
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+// Boundary tests for the names family: rx 100/101/102/103 + tx 106/107
+// + their extended counterparts (rx 228/229/230/231 + tx 234/235).
+//
+// Form-selection rule (per SW-P-08 §3.1.2):
+//   - rx 100 / rx 101 / tx 106 / tx 107  : matrix > 15 OR level > 15 → ext
+//   - rx 102 / rx 103                    : matrix > 15               → ext
+//
+// SourceID (rx 101 / tx 106) and DestAssociationID (rx 103 / tx 107)
+// are 16-bit in BOTH narrow and extended forms, so they do not promote
+// on their own.
+
+// --- rx 100 / rx 228 -------------------------------------------------
+
+func TestAllSourceNamesRequest_NarrowMin(t *testing.T) {
+	in := AllSourceNamesRequestParams{MatrixID: 0, LevelID: 0, NameLength: NameLen4}
+	f := EncodeAllSourceNamesRequest(in)
+	if f.ID != RxAllSourceNamesRequest {
+		t.Errorf("min-narrow ID = %#x; want 0x64 (general)", f.ID)
+	}
+	want := []byte{0x00, 0x00}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+	roundtripAllSrcNames(t, f, in, "narrow-min")
+}
+
+func TestAllSourceNamesRequest_NarrowMax(t *testing.T) {
+	in := AllSourceNamesRequestParams{MatrixID: 15, LevelID: 15, NameLength: NameLen12}
+	f := EncodeAllSourceNamesRequest(in)
+	if f.ID != RxAllSourceNamesRequest {
+		t.Errorf("max-narrow ID = %#x; want 0x64 (general, no promotion)", f.ID)
+	}
+	want := []byte{0xFF, 0x02} // matrix(15)<<4|level(15) = 0xFF; NameLen12 = 0x02
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+	roundtripAllSrcNames(t, f, in, "narrow-max")
+}
+
+func TestAllSourceNamesRequest_PromoteOnMatrix(t *testing.T) {
+	in := AllSourceNamesRequestParams{MatrixID: 16, LevelID: 0, NameLength: NameLen8}
+	f := EncodeAllSourceNamesRequest(in)
+	if f.ID != RxAllSourceNamesRequestExt {
+		t.Errorf("matrix=16 ID = %#x; want 0xE4 (extended)", f.ID)
+	}
+	want := []byte{16, 0, 0x01}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+	roundtripAllSrcNames(t, f, in, "promote-matrix")
+}
+
+func TestAllSourceNamesRequest_PromoteOnLevel(t *testing.T) {
+	in := AllSourceNamesRequestParams{MatrixID: 0, LevelID: 16, NameLength: NameLen4}
+	f := EncodeAllSourceNamesRequest(in)
+	if f.ID != RxAllSourceNamesRequestExt {
+		t.Errorf("level=16 ID = %#x; want 0xE4", f.ID)
+	}
+	roundtripAllSrcNames(t, f, in, "promote-level")
+}
+
+func TestAllSourceNamesRequest_ExtendedMax(t *testing.T) {
+	in := AllSourceNamesRequestParams{MatrixID: 255, LevelID: 255, NameLength: NameLen12}
+	f := EncodeAllSourceNamesRequest(in)
+	if f.ID != RxAllSourceNamesRequestExt {
+		t.Errorf("max-ext ID = %#x; want 0xE4", f.ID)
+	}
+	want := []byte{0xFF, 0xFF, 0x02}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+	roundtripAllSrcNames(t, f, in, "extended-max")
+}
+
+// --- rx 101 / rx 229 -------------------------------------------------
+
+func TestSingleSourceNameRequest_NarrowMaxStillNarrow(t *testing.T) {
+	// SourceID is 16-bit in narrow form already — never triggers ext.
+	in := SingleSourceNameRequestParams{MatrixID: 15, LevelID: 15, NameLength: NameLen8, SourceID: 65535}
+	f := EncodeSingleSourceNameRequest(in)
+	if f.ID != RxSingleSourceNameRequest {
+		t.Errorf("ID = %#x; want 0x65 (narrow accepts SourceID up to 65535)", f.ID)
+	}
+	want := []byte{0xFF, 0x01, 0xFF, 0xFF}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+}
+
+func TestSingleSourceNameRequest_PromoteOnMatrix(t *testing.T) {
+	in := SingleSourceNameRequestParams{MatrixID: 16, LevelID: 0, NameLength: NameLen4, SourceID: 100}
+	f := EncodeSingleSourceNameRequest(in)
+	if f.ID != RxSingleSourceNameRequestExt {
+		t.Errorf("matrix=16 ID = %#x; want 0xE5", f.ID)
+	}
+	want := []byte{16, 0, 0x00, 0x00, 100}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+	back, err := DecodeSingleSourceNameRequest(f)
+	if err != nil || !reflect.DeepEqual(back, in) {
+		t.Errorf("round-trip: got %+v err %v want %+v", back, err, in)
+	}
+}
+
+func TestSingleSourceNameRequest_ExtendedMax(t *testing.T) {
+	in := SingleSourceNameRequestParams{MatrixID: 255, LevelID: 255, NameLength: NameLen12, SourceID: 65535}
+	f := EncodeSingleSourceNameRequest(in)
+	if f.ID != RxSingleSourceNameRequestExt {
+		t.Fatalf("ID = %#x; want 0xE5", f.ID)
+	}
+	want := []byte{0xFF, 0xFF, 0x02, 0xFF, 0xFF}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+}
+
+// --- rx 102 / rx 230 -------------------------------------------------
+
+func TestAllDestAssocNamesRequest_NarrowMaxStillNarrow(t *testing.T) {
+	in := AllDestAssocNamesRequestParams{MatrixID: 15, NameLength: NameLen12}
+	f := EncodeAllDestAssocNamesRequest(in)
+	if f.ID != RxAllDestNamesRequest {
+		t.Errorf("matrix=15 ID = %#x; want 0x66", f.ID)
+	}
+	want := []byte{0x0F, 0x02} // matrix is bits 0-3 only in narrow; bits 4-7 unused
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+}
+
+func TestAllDestAssocNamesRequest_PromoteOnMatrix(t *testing.T) {
+	in := AllDestAssocNamesRequestParams{MatrixID: 16, NameLength: NameLen4}
+	f := EncodeAllDestAssocNamesRequest(in)
+	if f.ID != RxAllDestNamesRequestExt {
+		t.Errorf("matrix=16 ID = %#x; want 0xE6", f.ID)
+	}
+	want := []byte{16, 0x00}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+	back, err := DecodeAllDestAssocNamesRequest(f)
+	if err != nil || back != in {
+		t.Errorf("round-trip: got %+v err %v", back, err)
+	}
+}
+
+// --- rx 103 / rx 231 -------------------------------------------------
+
+func TestSingleDestAssocNameRequest_NarrowMaxStillNarrow(t *testing.T) {
+	// AssocID 16-bit in narrow — never triggers ext.
+	in := SingleDestAssocNameRequestParams{MatrixID: 15, NameLength: NameLen8, DestAssociationID: 65535}
+	f := EncodeSingleDestAssocNameRequest(in)
+	if f.ID != RxSingleDestNameRequest {
+		t.Errorf("ID = %#x; want 0x67 (narrow accepts AssocID up to 65535)", f.ID)
+	}
+	want := []byte{0x0F, 0x01, 0xFF, 0xFF}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+}
+
+func TestSingleDestAssocNameRequest_PromoteOnMatrix(t *testing.T) {
+	in := SingleDestAssocNameRequestParams{MatrixID: 16, NameLength: NameLen4, DestAssociationID: 1234}
+	f := EncodeSingleDestAssocNameRequest(in)
+	if f.ID != RxSingleDestNameRequestExt {
+		t.Errorf("matrix=16 ID = %#x; want 0xE7", f.ID)
+	}
+	want := []byte{16, 0x00, 0x04, 0xD2} // 1234 = 4*256 + 210 (0xD2)
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+	back, err := DecodeSingleDestAssocNameRequest(f)
+	if err != nil || back != in {
+		t.Errorf("round-trip: got %+v err %v", back, err)
+	}
+}
+
+// --- tx 106 / tx 234 -------------------------------------------------
+
+func TestSourceNamesResponse_PromoteOnMatrix(t *testing.T) {
+	in := SourceNamesResponseParams{
+		MatrixID: 16, LevelID: 0, NameLength: NameLen4,
+		FirstSourceID: 0,
+		Names:         []string{"A", "B"},
+	}
+	f := EncodeSourceNamesResponse(in)
+	if f.ID != TxSourceNamesResponseExt {
+		t.Errorf("matrix=16 ID = %#x; want 0xEA", f.ID)
+	}
+	// Payload prefix: matrix(16), level(0), namelen(0=4-char), firstsrc/256, firstsrc%256, count=2,
+	// then 2 × 4-char names "A   " "B   ".
+	if len(f.Payload) != 6+2*4 {
+		t.Fatalf("ext payload len = %d; want %d", len(f.Payload), 6+2*4)
+	}
+	if f.Payload[0] != 16 || f.Payload[1] != 0 {
+		t.Errorf("matrix/level prefix = %X / %X; want 10 / 00", f.Payload[0], f.Payload[1])
+	}
+	back, err := DecodeSourceNamesResponse(f)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if back.MatrixID != 16 || back.LevelID != 0 || len(back.Names) != 2 {
+		t.Errorf("round-trip mismatch: %+v", back)
+	}
+}
+
+func TestSourceNamesResponse_NarrowMaxStillNarrow(t *testing.T) {
+	in := SourceNamesResponseParams{MatrixID: 15, LevelID: 15, NameLength: NameLen8, FirstSourceID: 0, Names: []string{"X"}}
+	f := EncodeSourceNamesResponse(in)
+	if f.ID != TxSourceNamesResponse {
+		t.Errorf("ID = %#x; want 0x6A", f.ID)
+	}
+}
+
+// --- tx 107 / tx 235 -------------------------------------------------
+
+func TestDestAssocNamesResponse_PromoteOnMatrix(t *testing.T) {
+	in := DestAssocNamesResponseParams{
+		MatrixID: 16, LevelID: 0, NameLength: NameLen4,
+		FirstDestAssociationID: 0,
+		Names:                  []string{"D"},
+	}
+	f := EncodeDestAssocNamesResponse(in)
+	if f.ID != TxDestAssocNamesResponseExt {
+		t.Errorf("matrix=16 ID = %#x; want 0xEB", f.ID)
+	}
+	back, err := DecodeDestAssocNamesResponse(f)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if back.MatrixID != 16 || back.LevelID != 0 || len(back.Names) != 1 {
+		t.Errorf("round-trip mismatch: %+v", back)
+	}
+}
+
+// --- helper ----------------------------------------------------------
+
+func roundtripAllSrcNames(t *testing.T, f Frame, want AllSourceNamesRequestParams, label string) {
+	t.Helper()
+	got, err := DecodeAllSourceNamesRequest(f)
+	if err != nil {
+		t.Errorf("%s: decode: %v", label, err)
+		return
+	}
+	if got != want {
+		t.Errorf("%s: round-trip got %+v want %+v", label, got, want)
+	}
+}

--- a/internal/probel-sw08p/codec/cmd_rx100_all_source_names_request.go
+++ b/internal/probel-sw08p/codec/cmd_rx100_all_source_names_request.go
@@ -1,25 +1,53 @@
 package codec
 
-// AllSourceNamesRequestParams carries the inputs for rx 100 ALL SOURCE
-// NAMES REQUEST: controller asks the matrix for the names of every
-// source on one (matrix, level), in the given name-length format.
+// AllSourceNamesRequestParams carries the inputs for rx 100 / rx 228
+// ALL SOURCE NAMES REQUEST: controller asks the matrix for the names
+// of every source on one (matrix, level), in the given name-length
+// format. The encoder picks general (cmd 100, narrow) or extended
+// (cmd 228, wide) form per the SW-P-08 §3.4.10 ranges — same logical
+// struct, two wire forms.
 //
-// Reference: SW-P-08 §3.2.18.
+// Reference: SW-P-08 Issue 30 §3.2.18 (general) + §3.4.10 (extended).
 type AllSourceNamesRequestParams struct {
-	MatrixID   uint8 // 0-15
-	LevelID    uint8 // 0-15
+	MatrixID   uint8 // narrow: 0-15 (4 bits); extended: 0-255 (full byte)
+	LevelID    uint8 // narrow: 0-15 (4 bits); extended: 0-255 (full byte)
 	NameLength NameLength
 }
 
-// EncodeAllSourceNamesRequest packs rx 100 ALL SOURCE NAMES REQUEST.
+// needsExtended fires when matrix or level exceeds the narrow form's
+// 4-bit packing in byte 1 (§3.1.2).
+func (p AllSourceNamesRequestParams) needsExtended() bool {
+	return p.MatrixID > 15 || p.LevelID > 15
+}
+
+// EncodeAllSourceNamesRequest packs cmd 100 (general, 2-byte) or
+// cmd 228 (extended, 3-byte) per the addressing range of the params.
 //
-// | Byte | Field          | Notes                                       |
-// |------|----------------|---------------------------------------------|
-// |  1   | Matrix / Level | bits[4-7] = Matrix, bits[0-3] = Level (§3.1.2) |
-// |  2   | Name Length    | 0=4-char, 1=8-char, 2=12-char (§3.1.18)        |
+// General form (CommandID 0x64 — 2 data bytes, §3.2.18):
 //
-// Spec: SW-P-08 §3.2.18.
+//	| Byte | Field          | Notes                                       |
+//	|------|----------------|---------------------------------------------|
+//	|  1   | Matrix / Level | bits[4-7] = Matrix, bits[0-3] = Level (§3.1.2) |
+//	|  2   | Name Length    | 0=4-char, 1=8-char, 2=12-char (§3.1.18)        |
+//
+// Extended form (CommandID 0xE4 — 3 data bytes, §3.4.10):
+//
+//	| Byte | Field          | Notes                                       |
+//	|------|----------------|---------------------------------------------|
+//	|  1   | Matrix         | full 8-bit                                   |
+//	|  2   | Level          | full 8-bit                                   |
+//	|  3   | Name Length    | 0=4-char, 1=8-char, 2=12-char                |
 func EncodeAllSourceNamesRequest(p AllSourceNamesRequestParams) Frame {
+	if p.needsExtended() {
+		return Frame{
+			ID: RxAllSourceNamesRequestExt,
+			Payload: []byte{
+				p.MatrixID,
+				p.LevelID,
+				byte(p.NameLength),
+			},
+		}
+	}
 	return Frame{
 		ID: RxAllSourceNamesRequest,
 		Payload: []byte{
@@ -29,18 +57,34 @@ func EncodeAllSourceNamesRequest(p AllSourceNamesRequestParams) Frame {
 	}
 }
 
-// DecodeAllSourceNamesRequest parses an rx 100 ALL SOURCE NAMES REQUEST.
+// DecodeAllSourceNamesRequest parses cmd 100 (general 2-byte) or
+// cmd 228 (extended 3-byte) into the same logical struct.
 func DecodeAllSourceNamesRequest(f Frame) (AllSourceNamesRequestParams, error) {
-	if f.ID != RxAllSourceNamesRequest {
+	switch f.ID {
+	case RxAllSourceNamesRequest:
+		if len(f.Payload) < 2 {
+			return AllSourceNamesRequestParams{}, ErrShortPayload
+		}
+		m, l := decodeMatrixLevel(f.Payload[0])
+		n := NameLength(f.Payload[1])
+		if err := validateNameLength(n); err != nil {
+			return AllSourceNamesRequestParams{}, err
+		}
+		return AllSourceNamesRequestParams{MatrixID: m, LevelID: l, NameLength: n}, nil
+	case RxAllSourceNamesRequestExt:
+		if len(f.Payload) < 3 {
+			return AllSourceNamesRequestParams{}, ErrShortPayload
+		}
+		n := NameLength(f.Payload[2])
+		if err := validateNameLength(n); err != nil {
+			return AllSourceNamesRequestParams{}, err
+		}
+		return AllSourceNamesRequestParams{
+			MatrixID:   f.Payload[0],
+			LevelID:    f.Payload[1],
+			NameLength: n,
+		}, nil
+	default:
 		return AllSourceNamesRequestParams{}, ErrWrongCommand
 	}
-	if len(f.Payload) < 2 {
-		return AllSourceNamesRequestParams{}, ErrShortPayload
-	}
-	m, l := decodeMatrixLevel(f.Payload[0])
-	n := NameLength(f.Payload[1])
-	if err := validateNameLength(n); err != nil {
-		return AllSourceNamesRequestParams{}, err
-	}
-	return AllSourceNamesRequestParams{MatrixID: m, LevelID: l, NameLength: n}, nil
 }

--- a/internal/probel-sw08p/codec/cmd_rx101_single_source_name_request.go
+++ b/internal/probel-sw08p/codec/cmd_rx101_single_source_name_request.go
@@ -1,28 +1,60 @@
 package codec
 
-// SingleSourceNameRequestParams: rx 101 — fetch exactly one source's
-// name.  Matrix uses the full Matrix/Level byte; SourceID is u16 split
-// into a DIV/MOD 256 pair on the wire.
+// SingleSourceNameRequestParams: rx 101 / rx 229 — fetch exactly one
+// source's name.  The narrow form already carries SourceID as a 16-bit
+// DIV/MOD 256 split, so SourceID alone never triggers extended; the
+// promotion fires only on Matrix > 15 or Level > 15 (§3.1.2's 4-bit
+// packing).
 //
-// Reference: SW-P-08 §3.2.19.
+// Reference: SW-P-08 Issue 30 §3.2.19 (general) + §3.4.11 (extended).
 type SingleSourceNameRequestParams struct {
-	MatrixID   uint8 // 0-15
-	LevelID    uint8 // 0-15
+	MatrixID   uint8
+	LevelID    uint8
 	NameLength NameLength
-	SourceID   uint16 // 0-65535
+	SourceID   uint16 // 0-65535 in BOTH forms
 }
 
-// EncodeSingleSourceNameRequest packs rx 101 SINGLE SOURCE NAME REQUEST.
+// needsExtended fires when matrix or level exceeds the narrow form's
+// 4-bit packing in byte 1 (§3.1.2). SourceID is 16-bit in both forms,
+// so it does not promote on its own.
+func (p SingleSourceNameRequestParams) needsExtended() bool {
+	return p.MatrixID > 15 || p.LevelID > 15
+}
+
+// EncodeSingleSourceNameRequest packs cmd 101 (general, 4-byte) or
+// cmd 229 (extended, 5-byte) per the addressing range of the params.
 //
-// | Byte | Field          | Notes                                       |
-// |------|----------------|---------------------------------------------|
-// |  1   | Matrix / Level | bits[4-7] = Matrix, bits[0-3] = Level          |
-// |  2   | Name Length    | 0=4, 1=8, 2=12                                 |
-// |  3   | Src mult       | SourceID DIV 256                               |
-// |  4   | Src num        | SourceID MOD 256                               |
+// General form (CommandID 0x65 — 4 data bytes, §3.2.19):
 //
-// Spec: SW-P-08 §3.2.19.
+//	| Byte | Field          | Notes                                       |
+//	|------|----------------|---------------------------------------------|
+//	|  1   | Matrix / Level | bits[4-7] = Matrix, bits[0-3] = Level          |
+//	|  2   | Name Length    | 0=4, 1=8, 2=12                                 |
+//	|  3   | Src mult       | SourceID DIV 256                               |
+//	|  4   | Src num        | SourceID MOD 256                               |
+//
+// Extended form (CommandID 0xE5 — 5 data bytes, §3.4.11):
+//
+//	| Byte | Field          | Notes                                       |
+//	|------|----------------|---------------------------------------------|
+//	|  1   | Matrix         | full 8-bit                                   |
+//	|  2   | Level          | full 8-bit                                   |
+//	|  3   | Name Length    | 0=4, 1=8, 2=12                              |
+//	|  4   | Src mult       | SourceID DIV 256                            |
+//	|  5   | Src num        | SourceID MOD 256                            |
 func EncodeSingleSourceNameRequest(p SingleSourceNameRequestParams) Frame {
+	if p.needsExtended() {
+		return Frame{
+			ID: RxSingleSourceNameRequestExt,
+			Payload: []byte{
+				p.MatrixID,
+				p.LevelID,
+				byte(p.NameLength),
+				byte(p.SourceID / 256),
+				byte(p.SourceID % 256),
+			},
+		}
+	}
 	return Frame{
 		ID: RxSingleSourceNameRequest,
 		Payload: []byte{
@@ -34,23 +66,40 @@ func EncodeSingleSourceNameRequest(p SingleSourceNameRequestParams) Frame {
 	}
 }
 
-// DecodeSingleSourceNameRequest parses rx 101.
+// DecodeSingleSourceNameRequest parses cmd 101 (general 4-byte) or
+// cmd 229 (extended 5-byte) into the same logical struct.
 func DecodeSingleSourceNameRequest(f Frame) (SingleSourceNameRequestParams, error) {
-	if f.ID != RxSingleSourceNameRequest {
+	switch f.ID {
+	case RxSingleSourceNameRequest:
+		if len(f.Payload) < 4 {
+			return SingleSourceNameRequestParams{}, ErrShortPayload
+		}
+		m, l := decodeMatrixLevel(f.Payload[0])
+		n := NameLength(f.Payload[1])
+		if err := validateNameLength(n); err != nil {
+			return SingleSourceNameRequestParams{}, err
+		}
+		return SingleSourceNameRequestParams{
+			MatrixID:   m,
+			LevelID:    l,
+			NameLength: n,
+			SourceID:   uint16(f.Payload[2])*256 + uint16(f.Payload[3]),
+		}, nil
+	case RxSingleSourceNameRequestExt:
+		if len(f.Payload) < 5 {
+			return SingleSourceNameRequestParams{}, ErrShortPayload
+		}
+		n := NameLength(f.Payload[2])
+		if err := validateNameLength(n); err != nil {
+			return SingleSourceNameRequestParams{}, err
+		}
+		return SingleSourceNameRequestParams{
+			MatrixID:   f.Payload[0],
+			LevelID:    f.Payload[1],
+			NameLength: n,
+			SourceID:   uint16(f.Payload[3])*256 + uint16(f.Payload[4]),
+		}, nil
+	default:
 		return SingleSourceNameRequestParams{}, ErrWrongCommand
 	}
-	if len(f.Payload) < 4 {
-		return SingleSourceNameRequestParams{}, ErrShortPayload
-	}
-	m, l := decodeMatrixLevel(f.Payload[0])
-	n := NameLength(f.Payload[1])
-	if err := validateNameLength(n); err != nil {
-		return SingleSourceNameRequestParams{}, err
-	}
-	return SingleSourceNameRequestParams{
-		MatrixID:   m,
-		LevelID:    l,
-		NameLength: n,
-		SourceID:   uint16(f.Payload[2])*256 + uint16(f.Payload[3]),
-	}, nil
 }

--- a/internal/probel-sw08p/codec/cmd_rx102_all_dest_assoc_names_request.go
+++ b/internal/probel-sw08p/codec/cmd_rx102_all_dest_assoc_names_request.go
@@ -1,44 +1,81 @@
 package codec
 
-// AllDestAssocNamesRequestParams: rx 102 — fetch every destination-
-// association name on a given matrix. Unlike rx 100, this command's
-// byte 1 encodes matrix only (bits 0-3); level has no meaning here.
+// AllDestAssocNamesRequestParams: rx 102 / rx 230 — fetch every
+// destination-association name on a given matrix. The narrow form
+// packs Matrix into bits 0-3 of byte 1 (§3.2.20); extended uses a full
+// 8-bit byte. There is no Level in either form — dest-assoc is matrix-
+// scoped, not matrix+level scoped.
 //
-// Reference: SW-P-08 §3.2.20.
+// Reference: SW-P-08 Issue 30 §3.2.20 (general) + §3.4.12 (extended).
 type AllDestAssocNamesRequestParams struct {
-	MatrixID   uint8 // 0-15 (bits 0-3)
+	MatrixID   uint8 // narrow: 0-15 (bits 0-3); extended: 0-255 (full byte)
 	NameLength NameLength
 }
 
-// EncodeAllDestAssocNamesRequest packs rx 102.
+// needsExtended fires when matrix exceeds the narrow form's 4-bit
+// packing in byte 1 (§3.2.20: bits 0-3 used; bits 4-7 unused).
+func (p AllDestAssocNamesRequestParams) needsExtended() bool {
+	return p.MatrixID > 15
+}
+
+// EncodeAllDestAssocNamesRequest packs cmd 102 (general, 2-byte) or
+// cmd 230 (extended, 2-byte but full 8-bit matrix).
 //
-// | Byte | Field        | Notes                                     |
-// |------|--------------|-------------------------------------------|
-// |  1   | Matrix       | bits[0-3] = Matrix; bits[4-7] unused         |
-// |  2   | Name Length  | 0=4, 1=8, 2=12                               |
+// General form (CommandID 0x66 — 2 data bytes, §3.2.20):
 //
-// Spec: SW-P-08 §3.2.20.
+//	| Byte | Field        | Notes                                     |
+//	|------|--------------|-------------------------------------------|
+//	|  1   | Matrix       | bits[0-3] = Matrix; bits[4-7] unused         |
+//	|  2   | Name Length  | 0=4, 1=8, 2=12                               |
+//
+// Extended form (CommandID 0xE6 — 2 data bytes, §3.4.12):
+//
+//	| Byte | Field        | Notes                                     |
+//	|------|--------------|-------------------------------------------|
+//	|  1   | Matrix       | full 8-bit                                |
+//	|  2   | Name Length  | 0=4, 1=8, 2=12                            |
 func EncodeAllDestAssocNamesRequest(p AllDestAssocNamesRequestParams) Frame {
+	if p.needsExtended() {
+		return Frame{
+			ID:      RxAllDestNamesRequestExt,
+			Payload: []byte{p.MatrixID, byte(p.NameLength)},
+		}
+	}
 	return Frame{
 		ID:      RxAllDestNamesRequest,
 		Payload: []byte{p.MatrixID & 0x0F, byte(p.NameLength)},
 	}
 }
 
-// DecodeAllDestAssocNamesRequest parses rx 102.
+// DecodeAllDestAssocNamesRequest parses cmd 102 (general 2-byte) or
+// cmd 230 (extended 2-byte) into the same logical struct.
 func DecodeAllDestAssocNamesRequest(f Frame) (AllDestAssocNamesRequestParams, error) {
-	if f.ID != RxAllDestNamesRequest {
+	switch f.ID {
+	case RxAllDestNamesRequest:
+		if len(f.Payload) < 2 {
+			return AllDestAssocNamesRequestParams{}, ErrShortPayload
+		}
+		n := NameLength(f.Payload[1])
+		if err := validateNameLength(n); err != nil {
+			return AllDestAssocNamesRequestParams{}, err
+		}
+		return AllDestAssocNamesRequestParams{
+			MatrixID:   f.Payload[0] & 0x0F,
+			NameLength: n,
+		}, nil
+	case RxAllDestNamesRequestExt:
+		if len(f.Payload) < 2 {
+			return AllDestAssocNamesRequestParams{}, ErrShortPayload
+		}
+		n := NameLength(f.Payload[1])
+		if err := validateNameLength(n); err != nil {
+			return AllDestAssocNamesRequestParams{}, err
+		}
+		return AllDestAssocNamesRequestParams{
+			MatrixID:   f.Payload[0],
+			NameLength: n,
+		}, nil
+	default:
 		return AllDestAssocNamesRequestParams{}, ErrWrongCommand
 	}
-	if len(f.Payload) < 2 {
-		return AllDestAssocNamesRequestParams{}, ErrShortPayload
-	}
-	n := NameLength(f.Payload[1])
-	if err := validateNameLength(n); err != nil {
-		return AllDestAssocNamesRequestParams{}, err
-	}
-	return AllDestAssocNamesRequestParams{
-		MatrixID:   f.Payload[0] & 0x0F,
-		NameLength: n,
-	}, nil
 }

--- a/internal/probel-sw08p/codec/cmd_rx103_single_dest_assoc_name_request.go
+++ b/internal/probel-sw08p/codec/cmd_rx103_single_dest_assoc_name_request.go
@@ -1,27 +1,55 @@
 package codec
 
-// SingleDestAssocNameRequestParams: rx 103 — fetch one destination-
-// association name. Byte 1 is matrix-only (bits 0-3); assoc id is u16
-// split DIV/MOD 256.
+// SingleDestAssocNameRequestParams: rx 103 / rx 231 — fetch one
+// destination-association name. Like rx 102, byte 1 is matrix-only;
+// AssocID is u16 split DIV/MOD 256 in BOTH forms, so AssocID never
+// triggers extended on its own.
 //
-// Reference: SW-P-08 §3.2.21.
+// Reference: SW-P-08 Issue 30 §3.2.21 (general) + §3.4.13 (extended).
 type SingleDestAssocNameRequestParams struct {
 	MatrixID          uint8
 	NameLength        NameLength
 	DestAssociationID uint16
 }
 
-// EncodeSingleDestAssocNameRequest packs rx 103.
+// needsExtended fires when matrix exceeds the narrow form's 4-bit
+// packing in byte 1 (§3.2.21).
+func (p SingleDestAssocNameRequestParams) needsExtended() bool {
+	return p.MatrixID > 15
+}
+
+// EncodeSingleDestAssocNameRequest packs cmd 103 (general, 4-byte) or
+// cmd 231 (extended, 4-byte but full 8-bit matrix).
 //
-// | Byte | Field        | Notes                                     |
-// |------|--------------|-------------------------------------------|
-// |  1   | Matrix       | bits[0-3] = Matrix                           |
-// |  2   | Name Length  | 0=4, 1=8, 2=12                               |
-// |  3   | Dest assoc mult | AssocID DIV 256                            |
-// |  4   | Dest assoc num  | AssocID MOD 256                            |
+// General form (CommandID 0x67 — 4 data bytes, §3.2.21):
 //
-// Spec: SW-P-08 §3.2.21.
+//	| Byte | Field            | Notes                                     |
+//	|------|------------------|-------------------------------------------|
+//	|  1   | Matrix           | bits[0-3] = Matrix                           |
+//	|  2   | Name Length      | 0=4, 1=8, 2=12                               |
+//	|  3   | Dest assoc mult  | AssocID DIV 256                              |
+//	|  4   | Dest assoc num   | AssocID MOD 256                              |
+//
+// Extended form (CommandID 0xE7 — 4 data bytes, §3.4.13):
+//
+//	| Byte | Field            | Notes                                     |
+//	|------|------------------|-------------------------------------------|
+//	|  1   | Matrix           | full 8-bit                                |
+//	|  2   | Name Length      | 0=4, 1=8, 2=12                            |
+//	|  3   | Dest assoc mult  | AssocID DIV 256                           |
+//	|  4   | Dest assoc num   | AssocID MOD 256                           |
 func EncodeSingleDestAssocNameRequest(p SingleDestAssocNameRequestParams) Frame {
+	if p.needsExtended() {
+		return Frame{
+			ID: RxSingleDestNameRequestExt,
+			Payload: []byte{
+				p.MatrixID,
+				byte(p.NameLength),
+				byte(p.DestAssociationID / 256),
+				byte(p.DestAssociationID % 256),
+			},
+		}
+	}
 	return Frame{
 		ID: RxSingleDestNameRequest,
 		Payload: []byte{
@@ -33,21 +61,37 @@ func EncodeSingleDestAssocNameRequest(p SingleDestAssocNameRequestParams) Frame 
 	}
 }
 
-// DecodeSingleDestAssocNameRequest parses rx 103.
+// DecodeSingleDestAssocNameRequest parses cmd 103 (general 4-byte) or
+// cmd 231 (extended 4-byte) into the same logical struct.
 func DecodeSingleDestAssocNameRequest(f Frame) (SingleDestAssocNameRequestParams, error) {
-	if f.ID != RxSingleDestNameRequest {
+	switch f.ID {
+	case RxSingleDestNameRequest:
+		if len(f.Payload) < 4 {
+			return SingleDestAssocNameRequestParams{}, ErrShortPayload
+		}
+		n := NameLength(f.Payload[1])
+		if err := validateNameLength(n); err != nil {
+			return SingleDestAssocNameRequestParams{}, err
+		}
+		return SingleDestAssocNameRequestParams{
+			MatrixID:          f.Payload[0] & 0x0F,
+			NameLength:        n,
+			DestAssociationID: uint16(f.Payload[2])*256 + uint16(f.Payload[3]),
+		}, nil
+	case RxSingleDestNameRequestExt:
+		if len(f.Payload) < 4 {
+			return SingleDestAssocNameRequestParams{}, ErrShortPayload
+		}
+		n := NameLength(f.Payload[1])
+		if err := validateNameLength(n); err != nil {
+			return SingleDestAssocNameRequestParams{}, err
+		}
+		return SingleDestAssocNameRequestParams{
+			MatrixID:          f.Payload[0],
+			NameLength:        n,
+			DestAssociationID: uint16(f.Payload[2])*256 + uint16(f.Payload[3]),
+		}, nil
+	default:
 		return SingleDestAssocNameRequestParams{}, ErrWrongCommand
 	}
-	if len(f.Payload) < 4 {
-		return SingleDestAssocNameRequestParams{}, ErrShortPayload
-	}
-	n := NameLength(f.Payload[1])
-	if err := validateNameLength(n); err != nil {
-		return SingleDestAssocNameRequestParams{}, err
-	}
-	return SingleDestAssocNameRequestParams{
-		MatrixID:          f.Payload[0] & 0x0F,
-		NameLength:        n,
-		DestAssociationID: uint16(f.Payload[2])*256 + uint16(f.Payload[3]),
-	}, nil
 }

--- a/internal/probel-sw08p/codec/cmd_tx106_source_names_response.go
+++ b/internal/probel-sw08p/codec/cmd_tx106_source_names_response.go
@@ -2,15 +2,16 @@ package codec
 
 import "fmt"
 
-// SourceNamesResponseParams: tx 106 — one frame of source names, as
-// issued by the matrix in reply to rx 100 or rx 101. Large name tables
-// require multiple frames; callers paginate with successive FirstSourceID.
+// SourceNamesResponseParams: tx 106 / tx 234 — one frame of source
+// names, as issued by the matrix in reply to rx 100/101 (or
+// rx 228/229). Large name tables require multiple frames; callers
+// paginate with successive FirstSourceID.
 //
-// Names is a slice of the source labels in wire order; each entry is at
-// most NameLength.Bytes() chars. Longer strings are truncated; shorter
-// strings are right-padded with spaces.
+// Names is a slice of the source labels in wire order; each entry is
+// at most NameLength.Bytes() chars. Longer strings are truncated;
+// shorter strings are right-padded with spaces.
 //
-// Reference: SW-P-08 §3.3.19.
+// Reference: SW-P-08 Issue 30 §3.3.19 (general) + §3.5.10 (extended).
 type SourceNamesResponseParams struct {
 	MatrixID      uint8
 	LevelID       uint8
@@ -19,70 +20,138 @@ type SourceNamesResponseParams struct {
 	Names         []string
 }
 
-// EncodeSourceNamesResponse packs tx 106 SOURCE NAMES RESPONSE.
+// needsExtended mirrors the request-side rule (§3.1.2 4-bit packing):
+// matrix > 15 OR level > 15 promotes to extended. FirstSourceID is
+// 16-bit in BOTH forms, so it does not promote on its own.
+func (p SourceNamesResponseParams) needsExtended() bool {
+	return p.MatrixID > 15 || p.LevelID > 15
+}
+
+// EncodeSourceNamesResponse packs cmd 106 (general) or cmd 234
+// (extended) per the addressing range of the params.
 //
-// | Byte     | Field               | Notes                                  |
-// |----------|---------------------|----------------------------------------|
-// |  1       | Matrix / Level      | bits[4-7] = Matrix, bits[0-3] = Level     |
-// |  2       | Name Length         | 0=4, 1=8, 2=12                            |
-// |  3       | 1st Src mult        | FirstSourceID DIV 256                     |
-// |  4       | 1st Src num         | FirstSourceID MOD 256                     |
-// |  5       | Num of names        | Names count to follow                     |
-// |  6+      | N × Name (fixed)    | NameLength.Bytes() bytes each, ASCII      |
+// General form (CommandID 0x6A — §3.3.19):
 //
-// Caps (spec §3.3.19): "max 32 × 4-char, 16 × 8-char, or 10 × 12-char
-// names" per frame. Extras are silently dropped — callers paginate.
+//	| Byte     | Field               | Notes                                  |
+//	|----------|---------------------|----------------------------------------|
+//	|  1       | Matrix / Level      | bits[4-7] = Matrix, bits[0-3] = Level     |
+//	|  2       | Name Length         | 0=4, 1=8, 2=12                            |
+//	|  3       | 1st Src mult        | FirstSourceID DIV 256                     |
+//	|  4       | 1st Src num         | FirstSourceID MOD 256                     |
+//	|  5       | Num of names        | Names count to follow                     |
+//	|  6+      | N × Name (fixed)    | NameLength.Bytes() bytes each             |
 //
-// Spec: SW-P-08 §3.3.19.
+// Extended form (CommandID 0xEA — §3.5.10):
+//
+//	| Byte     | Field               | Notes                                  |
+//	|----------|---------------------|----------------------------------------|
+//	|  1       | Matrix              | full 8-bit                             |
+//	|  2       | Level               | full 8-bit                             |
+//	|  3       | Name Length         | 0=4, 1=8, 2=12                         |
+//	|  4       | 1st Src mult        | FirstSourceID DIV 256                  |
+//	|  5       | 1st Src num         | FirstSourceID MOD 256                  |
+//	|  6       | Num of names        | Names count to follow                  |
+//	|  7+      | N × Name (fixed)    | NameLength.Bytes() bytes each          |
+//
+// Caps (spec §3.3.19 / §3.5.10): "max 32 × 4-char, 16 × 8-char, or
+// 10 × 12-char names" per frame. Extras are silently dropped — callers
+// paginate via FirstSourceID.
 func EncodeSourceNamesResponse(p SourceNamesResponseParams) Frame {
 	width := p.NameLength.Bytes()
-	cap := p.NameLength.MaxNamesPerMessage()
+	maxN := p.NameLength.MaxNamesPerMessage()
 	n := len(p.Names)
-	if n > cap {
-		n = cap
+	if n > maxN {
+		n = maxN
+	}
+	if p.needsExtended() {
+		payload := make([]byte, 0, 6+n*width)
+		payload = append(payload,
+			p.MatrixID,
+			p.LevelID,
+			byte(p.NameLength),
+			byte(p.FirstSourceID/256),
+			byte(p.FirstSourceID%256),
+			byte(n),
+		)
+		for i := 0; i < n; i++ {
+			payload = append(payload, packName(p.Names[i], width)...)
+		}
+		return Frame{ID: TxSourceNamesResponseExt, Payload: payload}
 	}
 	payload := make([]byte, 0, 5+n*width)
-	payload = append(payload, encodeMatrixLevel(p.MatrixID, p.LevelID))
-	payload = append(payload, byte(p.NameLength))
-	payload = append(payload, byte(p.FirstSourceID/256))
-	payload = append(payload, byte(p.FirstSourceID%256))
-	payload = append(payload, byte(n))
+	payload = append(payload,
+		encodeMatrixLevel(p.MatrixID, p.LevelID),
+		byte(p.NameLength),
+		byte(p.FirstSourceID/256),
+		byte(p.FirstSourceID%256),
+		byte(n),
+	)
 	for i := 0; i < n; i++ {
 		payload = append(payload, packName(p.Names[i], width)...)
 	}
 	return Frame{ID: TxSourceNamesResponse, Payload: payload}
 }
 
-// DecodeSourceNamesResponse parses tx 106.
+// DecodeSourceNamesResponse parses tx 106 (general) or tx 234
+// (extended) into the same logical struct.
 func DecodeSourceNamesResponse(f Frame) (SourceNamesResponseParams, error) {
-	if f.ID != TxSourceNamesResponse {
+	switch f.ID {
+	case TxSourceNamesResponse:
+		if len(f.Payload) < 5 {
+			return SourceNamesResponseParams{}, ErrShortPayload
+		}
+		m, l := decodeMatrixLevel(f.Payload[0])
+		n := NameLength(f.Payload[1])
+		if err := validateNameLength(n); err != nil {
+			return SourceNamesResponseParams{}, err
+		}
+		first := uint16(f.Payload[2])*256 + uint16(f.Payload[3])
+		count := int(f.Payload[4])
+		width := n.Bytes()
+		if len(f.Payload) < 5+count*width {
+			return SourceNamesResponseParams{}, fmt.Errorf("probel: tx 106 needs %d bytes, got %d",
+				5+count*width, len(f.Payload))
+		}
+		names := make([]string, count)
+		for i := 0; i < count; i++ {
+			off := 5 + i*width
+			names[i] = unpackName(f.Payload[off : off+width])
+		}
+		return SourceNamesResponseParams{
+			MatrixID:      m,
+			LevelID:       l,
+			NameLength:    n,
+			FirstSourceID: first,
+			Names:         names,
+		}, nil
+	case TxSourceNamesResponseExt:
+		if len(f.Payload) < 6 {
+			return SourceNamesResponseParams{}, ErrShortPayload
+		}
+		n := NameLength(f.Payload[2])
+		if err := validateNameLength(n); err != nil {
+			return SourceNamesResponseParams{}, err
+		}
+		first := uint16(f.Payload[3])*256 + uint16(f.Payload[4])
+		count := int(f.Payload[5])
+		width := n.Bytes()
+		if len(f.Payload) < 6+count*width {
+			return SourceNamesResponseParams{}, fmt.Errorf("probel: tx 234 needs %d bytes, got %d",
+				6+count*width, len(f.Payload))
+		}
+		names := make([]string, count)
+		for i := 0; i < count; i++ {
+			off := 6 + i*width
+			names[i] = unpackName(f.Payload[off : off+width])
+		}
+		return SourceNamesResponseParams{
+			MatrixID:      f.Payload[0],
+			LevelID:       f.Payload[1],
+			NameLength:    n,
+			FirstSourceID: first,
+			Names:         names,
+		}, nil
+	default:
 		return SourceNamesResponseParams{}, ErrWrongCommand
 	}
-	if len(f.Payload) < 5 {
-		return SourceNamesResponseParams{}, ErrShortPayload
-	}
-	m, l := decodeMatrixLevel(f.Payload[0])
-	n := NameLength(f.Payload[1])
-	if err := validateNameLength(n); err != nil {
-		return SourceNamesResponseParams{}, err
-	}
-	first := uint16(f.Payload[2])*256 + uint16(f.Payload[3])
-	count := int(f.Payload[4])
-	width := n.Bytes()
-	if len(f.Payload) < 5+count*width {
-		return SourceNamesResponseParams{}, fmt.Errorf("probel: tx 106 needs %d bytes, got %d",
-			5+count*width, len(f.Payload))
-	}
-	names := make([]string, count)
-	for i := 0; i < count; i++ {
-		off := 5 + i*width
-		names[i] = unpackName(f.Payload[off : off+width])
-	}
-	return SourceNamesResponseParams{
-		MatrixID:      m,
-		LevelID:       l,
-		NameLength:    n,
-		FirstSourceID: first,
-		Names:         names,
-	}, nil
 }

--- a/internal/probel-sw08p/codec/cmd_tx107_dest_assoc_names_response.go
+++ b/internal/probel-sw08p/codec/cmd_tx107_dest_assoc_names_response.go
@@ -2,80 +2,149 @@ package codec
 
 import "fmt"
 
-// DestAssocNamesResponseParams: tx 107 — matrix's reply to rx 102 or
-// rx 103. Byte 1 is Matrix/Level per §3.1.2 (yes, asymmetric with the
-// request — the response carries a level slot, the request doesn't).
+// DestAssocNamesResponseParams: tx 107 / tx 235 — matrix's reply to
+// rx 102/103 (or rx 230/231). Byte 1 is Matrix/Level per §3.1.2 (yes,
+// asymmetric with the request — the response carries a level slot,
+// the request doesn't). Both narrow and extended responses include
+// the level field; the request side just doesn't.
 //
-// Reference: SW-P-08 §3.3.20.
+// Reference: SW-P-08 Issue 30 §3.3.20 (general) + §3.5.11 (extended).
 type DestAssocNamesResponseParams struct {
-	MatrixID              uint8
-	LevelID               uint8
-	NameLength            NameLength
+	MatrixID               uint8
+	LevelID                uint8
+	NameLength             NameLength
 	FirstDestAssociationID uint16
-	Names                 []string
+	Names                  []string
 }
 
-// EncodeDestAssocNamesResponse packs tx 107.
+// needsExtended mirrors the request-side rule: matrix > 15 OR level >
+// 15 promotes to extended. FirstDestAssociationID is 16-bit in BOTH
+// forms, so it does not promote on its own.
+func (p DestAssocNamesResponseParams) needsExtended() bool {
+	return p.MatrixID > 15 || p.LevelID > 15
+}
+
+// EncodeDestAssocNamesResponse packs cmd 107 (general) or cmd 235
+// (extended) per the addressing range of the params.
 //
-// | Byte     | Field            | Notes                                    |
-// |----------|------------------|------------------------------------------|
-// |  1       | Matrix / Level   | bits[4-7] Matrix, bits[0-3] Level (§3.1.2) |
-// |  2       | Name Length      | 0=4, 1=8, 2=12                              |
-// |  3       | 1st Dest mult    | FirstDestAssociationID DIV 256              |
-// |  4       | 1st Dest num     | FirstDestAssociationID MOD 256              |
-// |  5       | Num of names     | Names count to follow                       |
-// |  6+      | N × Name (fixed) | NameLength.Bytes() bytes each, ASCII        |
+// General form (CommandID 0x6B — §3.3.20):
 //
-// Spec: SW-P-08 §3.3.20.
+//	| Byte     | Field            | Notes                                    |
+//	|----------|------------------|------------------------------------------|
+//	|  1       | Matrix / Level   | bits[4-7] Matrix, bits[0-3] Level (§3.1.2) |
+//	|  2       | Name Length      | 0=4, 1=8, 2=12                              |
+//	|  3       | 1st Dest mult    | FirstDestAssociationID DIV 256              |
+//	|  4       | 1st Dest num     | FirstDestAssociationID MOD 256              |
+//	|  5       | Num of names     | Names count to follow                       |
+//	|  6+      | N × Name (fixed) | NameLength.Bytes() bytes each               |
+//
+// Extended form (CommandID 0xEB — §3.5.11):
+//
+//	| Byte     | Field            | Notes                                    |
+//	|----------|------------------|------------------------------------------|
+//	|  1       | Matrix           | full 8-bit                               |
+//	|  2       | Level            | full 8-bit                               |
+//	|  3       | Name Length      | 0=4, 1=8, 2=12                           |
+//	|  4       | 1st Dest mult    | FirstDestAssociationID DIV 256           |
+//	|  5       | 1st Dest num     | FirstDestAssociationID MOD 256           |
+//	|  6       | Num of names     | Names count to follow                    |
+//	|  7+      | N × Name (fixed) | NameLength.Bytes() bytes each            |
 func EncodeDestAssocNamesResponse(p DestAssocNamesResponseParams) Frame {
 	width := p.NameLength.Bytes()
-	cap := p.NameLength.MaxNamesPerMessage()
+	maxN := p.NameLength.MaxNamesPerMessage()
 	n := len(p.Names)
-	if n > cap {
-		n = cap
+	if n > maxN {
+		n = maxN
+	}
+	if p.needsExtended() {
+		payload := make([]byte, 0, 6+n*width)
+		payload = append(payload,
+			p.MatrixID,
+			p.LevelID,
+			byte(p.NameLength),
+			byte(p.FirstDestAssociationID/256),
+			byte(p.FirstDestAssociationID%256),
+			byte(n),
+		)
+		for i := 0; i < n; i++ {
+			payload = append(payload, packName(p.Names[i], width)...)
+		}
+		return Frame{ID: TxDestAssocNamesResponseExt, Payload: payload}
 	}
 	payload := make([]byte, 0, 5+n*width)
-	payload = append(payload, encodeMatrixLevel(p.MatrixID, p.LevelID))
-	payload = append(payload, byte(p.NameLength))
-	payload = append(payload, byte(p.FirstDestAssociationID/256))
-	payload = append(payload, byte(p.FirstDestAssociationID%256))
-	payload = append(payload, byte(n))
+	payload = append(payload,
+		encodeMatrixLevel(p.MatrixID, p.LevelID),
+		byte(p.NameLength),
+		byte(p.FirstDestAssociationID/256),
+		byte(p.FirstDestAssociationID%256),
+		byte(n),
+	)
 	for i := 0; i < n; i++ {
 		payload = append(payload, packName(p.Names[i], width)...)
 	}
 	return Frame{ID: TxDestAssocNamesResponse, Payload: payload}
 }
 
-// DecodeDestAssocNamesResponse parses tx 107.
+// DecodeDestAssocNamesResponse parses tx 107 (general) or tx 235
+// (extended) into the same logical struct.
 func DecodeDestAssocNamesResponse(f Frame) (DestAssocNamesResponseParams, error) {
-	if f.ID != TxDestAssocNamesResponse {
+	switch f.ID {
+	case TxDestAssocNamesResponse:
+		if len(f.Payload) < 5 {
+			return DestAssocNamesResponseParams{}, ErrShortPayload
+		}
+		m, l := decodeMatrixLevel(f.Payload[0])
+		n := NameLength(f.Payload[1])
+		if err := validateNameLength(n); err != nil {
+			return DestAssocNamesResponseParams{}, err
+		}
+		first := uint16(f.Payload[2])*256 + uint16(f.Payload[3])
+		count := int(f.Payload[4])
+		width := n.Bytes()
+		if len(f.Payload) < 5+count*width {
+			return DestAssocNamesResponseParams{}, fmt.Errorf("probel: tx 107 needs %d bytes, got %d",
+				5+count*width, len(f.Payload))
+		}
+		names := make([]string, count)
+		for i := 0; i < count; i++ {
+			off := 5 + i*width
+			names[i] = unpackName(f.Payload[off : off+width])
+		}
+		return DestAssocNamesResponseParams{
+			MatrixID:               m,
+			LevelID:                l,
+			NameLength:             n,
+			FirstDestAssociationID: first,
+			Names:                  names,
+		}, nil
+	case TxDestAssocNamesResponseExt:
+		if len(f.Payload) < 6 {
+			return DestAssocNamesResponseParams{}, ErrShortPayload
+		}
+		n := NameLength(f.Payload[2])
+		if err := validateNameLength(n); err != nil {
+			return DestAssocNamesResponseParams{}, err
+		}
+		first := uint16(f.Payload[3])*256 + uint16(f.Payload[4])
+		count := int(f.Payload[5])
+		width := n.Bytes()
+		if len(f.Payload) < 6+count*width {
+			return DestAssocNamesResponseParams{}, fmt.Errorf("probel: tx 235 needs %d bytes, got %d",
+				6+count*width, len(f.Payload))
+		}
+		names := make([]string, count)
+		for i := 0; i < count; i++ {
+			off := 6 + i*width
+			names[i] = unpackName(f.Payload[off : off+width])
+		}
+		return DestAssocNamesResponseParams{
+			MatrixID:               f.Payload[0],
+			LevelID:                f.Payload[1],
+			NameLength:             n,
+			FirstDestAssociationID: first,
+			Names:                  names,
+		}, nil
+	default:
 		return DestAssocNamesResponseParams{}, ErrWrongCommand
 	}
-	if len(f.Payload) < 5 {
-		return DestAssocNamesResponseParams{}, ErrShortPayload
-	}
-	m, l := decodeMatrixLevel(f.Payload[0])
-	n := NameLength(f.Payload[1])
-	if err := validateNameLength(n); err != nil {
-		return DestAssocNamesResponseParams{}, err
-	}
-	first := uint16(f.Payload[2])*256 + uint16(f.Payload[3])
-	count := int(f.Payload[4])
-	width := n.Bytes()
-	if len(f.Payload) < 5+count*width {
-		return DestAssocNamesResponseParams{}, fmt.Errorf("probel: tx 107 needs %d bytes, got %d",
-			5+count*width, len(f.Payload))
-	}
-	names := make([]string, count)
-	for i := 0; i < count; i++ {
-		off := 5 + i*width
-		names[i] = unpackName(f.Payload[off : off+width])
-	}
-	return DestAssocNamesResponseParams{
-		MatrixID:              m,
-		LevelID:               l,
-		NameLength:            n,
-		FirstDestAssociationID: first,
-		Names:                 names,
-	}, nil
 }


### PR DESCRIPTION
## Summary

Phase 2 of the per-cmd `needsExtended()` audit (issue #227). Closes the silent-truncation hazard for the names family — same bug class fixed for salvo in #228, applied to source names + dest-association names.

Branch base: `main`. Independent of all in-flight PRs.

Refs #227, #226.

## Spec basis

SW-P-08 Issue 30:

- §3.2.18-§3.2.21 + §3.3.19-§3.3.20 (general)
- §3.4.10-§3.4.13 + §3.5.10-§3.5.11 (extended)

## Form-selection rules (per §3.1.2 narrow ranges)

| Cmd pair | Trigger |
| --- | --- |
| rx 100 / 228, rx 101 / 229, tx 106 / 234, tx 107 / 235 | matrix > 15 OR level > 15 |
| rx 102 / 230, rx 103 / 231 | matrix > 15 |

`SourceID` (rx 101 / tx 106) and `DestAssociationID` (rx 103 / tx 107) are 16-bit (DIV/MOD 256 split) in BOTH forms — they do NOT promote on their own. Only the matrix/level packing differs between forms.

## Files changed

| File | Change |
| --- | --- |
| `codec/cmd_rx100_all_source_names_request.go` | encoder branches 0x64 (2-byte) / 0xE4 (3-byte) |
| `codec/cmd_rx101_single_source_name_request.go` | encoder branches 0x65 (4-byte) / 0xE5 (5-byte) |
| `codec/cmd_rx102_all_dest_assoc_names_request.go` | encoder branches 0x66 (matrix bits 0-3) / 0xE6 (full 8-bit matrix); same 2-byte payload |
| `codec/cmd_rx103_single_dest_assoc_name_request.go` | encoder branches 0x67 / 0xE7; same 4-byte payload |
| `codec/cmd_tx106_source_names_response.go` | encoder branches 0x6A (5-byte header) / 0xEA (6-byte header — adds full level byte) |
| `codec/cmd_tx107_dest_assoc_names_response.go` | encoder branches 0x6B / 0xEB |
| `codec/cmd_names_extended_test.go` | new — boundary tests |

The 6 already-declared extended IDs in `codec/types.go` (0xE4-0xE7, 0xEA, 0xEB) are now wired in the encoder.

## Boundary tests (spec-cited byte tables)

- `TestAllSourceNamesRequest_*` — NarrowMin / NarrowMax / PromoteOnMatrix / PromoteOnLevel / ExtendedMax
- `TestSingleSourceNameRequest_NarrowMaxStillNarrow` — SourceID=65535 in narrow form; pins that source ID does not promote
- `TestSingleSourceNameRequest_PromoteOnMatrix / ExtendedMax`
- `TestAllDestAssocNamesRequest_NarrowMaxStillNarrow / PromoteOnMatrix`
- `TestSingleDestAssocNameRequest_NarrowMaxStillNarrow` — AssocID=65535 in narrow form
- `TestSingleDestAssocNameRequest_PromoteOnMatrix`
- `TestSourceNamesResponse_PromoteOnMatrix / NarrowMaxStillNarrow`
- `TestDestAssocNamesResponse_PromoteOnMatrix`

## Hard invariants verified

- [x] `internal/probel-sw08p/codec/` unchanged outside the six names files + the new test file — no `dhs/*` imports introduced
- [x] `needsExtended()` cited to spec ceilings on each command
- [x] `go build ./...` OK
- [x] `go vet ./...` OK
- [x] `golangci-lint run` 0 issues
- [x] `go test ./...` all OK (full repo)

## Out of scope (separate sub-PRs under #227)

- Sub-PR 3: tx 022 Crosspoint Tally Dump (byte) + extended 0x96
- Sub-PR 4: tx 113 Crosspoint Tie-Line Tally — verify ext pair in spec
- Sub-PR 5: boundary-test sweep across the 11 already-wired commands; spec-cite every `want []byte` in their existing tests
- rx 114 / rx 115 (source-association names) — verify and wire if §3.4 lists ext pairs