### PR TITLE
fix(probel-sw08p): tally-dump byte→word→ext-word promotion ladder + boundary tests (advances #227)

### DIFF
--- a/internal/probel-sw08p/codec/cmd_names_extended_test.go
+++ b/internal/probel-sw08p/codec/cmd_names_extended_test.go
@@ -1,0 +1,257 @@
+package codec
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+// Boundary tests for the names family: rx 100/101/102/103 + tx 106/107
+// + their extended counterparts (rx 228/229/230/231 + tx 234/235).
+//
+// Form-selection rule (per SW-P-08 §3.1.2):
+//   - rx 100 / rx 101 / tx 106 / tx 107  : matrix > 15 OR level > 15 → ext
+//   - rx 102 / rx 103                    : matrix > 15               → ext
+//
+// SourceID (rx 101 / tx 106) and DestAssociationID (rx 103 / tx 107)
+// are 16-bit in BOTH narrow and extended forms, so they do not promote
+// on their own.
+
+// --- rx 100 / rx 228 -------------------------------------------------
+
+func TestAllSourceNamesRequest_NarrowMin(t *testing.T) {
+	in := AllSourceNamesRequestParams{MatrixID: 0, LevelID: 0, NameLength: NameLen4}
+	f := EncodeAllSourceNamesRequest(in)
+	if f.ID != RxAllSourceNamesRequest {
+		t.Errorf("min-narrow ID = %#x; want 0x64 (general)", f.ID)
+	}
+	want := []byte{0x00, 0x00}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+	roundtripAllSrcNames(t, f, in, "narrow-min")
+}
+
+func TestAllSourceNamesRequest_NarrowMax(t *testing.T) {
+	in := AllSourceNamesRequestParams{MatrixID: 15, LevelID: 15, NameLength: NameLen12}
+	f := EncodeAllSourceNamesRequest(in)
+	if f.ID != RxAllSourceNamesRequest {
+		t.Errorf("max-narrow ID = %#x; want 0x64 (general, no promotion)", f.ID)
+	}
+	want := []byte{0xFF, 0x02} // matrix(15)<<4|level(15) = 0xFF; NameLen12 = 0x02
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+	roundtripAllSrcNames(t, f, in, "narrow-max")
+}
+
+func TestAllSourceNamesRequest_PromoteOnMatrix(t *testing.T) {
+	in := AllSourceNamesRequestParams{MatrixID: 16, LevelID: 0, NameLength: NameLen8}
+	f := EncodeAllSourceNamesRequest(in)
+	if f.ID != RxAllSourceNamesRequestExt {
+		t.Errorf("matrix=16 ID = %#x; want 0xE4 (extended)", f.ID)
+	}
+	want := []byte{16, 0, 0x01}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+	roundtripAllSrcNames(t, f, in, "promote-matrix")
+}
+
+func TestAllSourceNamesRequest_PromoteOnLevel(t *testing.T) {
+	in := AllSourceNamesRequestParams{MatrixID: 0, LevelID: 16, NameLength: NameLen4}
+	f := EncodeAllSourceNamesRequest(in)
+	if f.ID != RxAllSourceNamesRequestExt {
+		t.Errorf("level=16 ID = %#x; want 0xE4", f.ID)
+	}
+	roundtripAllSrcNames(t, f, in, "promote-level")
+}
+
+func TestAllSourceNamesRequest_ExtendedMax(t *testing.T) {
+	in := AllSourceNamesRequestParams{MatrixID: 255, LevelID: 255, NameLength: NameLen12}
+	f := EncodeAllSourceNamesRequest(in)
+	if f.ID != RxAllSourceNamesRequestExt {
+		t.Errorf("max-ext ID = %#x; want 0xE4", f.ID)
+	}
+	want := []byte{0xFF, 0xFF, 0x02}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+	roundtripAllSrcNames(t, f, in, "extended-max")
+}
+
+// --- rx 101 / rx 229 -------------------------------------------------
+
+func TestSingleSourceNameRequest_NarrowMaxStillNarrow(t *testing.T) {
+	// SourceID is 16-bit in narrow form already — never triggers ext.
+	in := SingleSourceNameRequestParams{MatrixID: 15, LevelID: 15, NameLength: NameLen8, SourceID: 65535}
+	f := EncodeSingleSourceNameRequest(in)
+	if f.ID != RxSingleSourceNameRequest {
+		t.Errorf("ID = %#x; want 0x65 (narrow accepts SourceID up to 65535)", f.ID)
+	}
+	want := []byte{0xFF, 0x01, 0xFF, 0xFF}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+}
+
+func TestSingleSourceNameRequest_PromoteOnMatrix(t *testing.T) {
+	in := SingleSourceNameRequestParams{MatrixID: 16, LevelID: 0, NameLength: NameLen4, SourceID: 100}
+	f := EncodeSingleSourceNameRequest(in)
+	if f.ID != RxSingleSourceNameRequestExt {
+		t.Errorf("matrix=16 ID = %#x; want 0xE5", f.ID)
+	}
+	want := []byte{16, 0, 0x00, 0x00, 100}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+	back, err := DecodeSingleSourceNameRequest(f)
+	if err != nil || !reflect.DeepEqual(back, in) {
+		t.Errorf("round-trip: got %+v err %v want %+v", back, err, in)
+	}
+}
+
+func TestSingleSourceNameRequest_ExtendedMax(t *testing.T) {
+	in := SingleSourceNameRequestParams{MatrixID: 255, LevelID: 255, NameLength: NameLen12, SourceID: 65535}
+	f := EncodeSingleSourceNameRequest(in)
+	if f.ID != RxSingleSourceNameRequestExt {
+		t.Fatalf("ID = %#x; want 0xE5", f.ID)
+	}
+	want := []byte{0xFF, 0xFF, 0x02, 0xFF, 0xFF}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+}
+
+// --- rx 102 / rx 230 -------------------------------------------------
+
+func TestAllDestAssocNamesRequest_NarrowMaxStillNarrow(t *testing.T) {
+	in := AllDestAssocNamesRequestParams{MatrixID: 15, NameLength: NameLen12}
+	f := EncodeAllDestAssocNamesRequest(in)
+	if f.ID != RxAllDestNamesRequest {
+		t.Errorf("matrix=15 ID = %#x; want 0x66", f.ID)
+	}
+	want := []byte{0x0F, 0x02} // matrix is bits 0-3 only in narrow; bits 4-7 unused
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+}
+
+func TestAllDestAssocNamesRequest_PromoteOnMatrix(t *testing.T) {
+	in := AllDestAssocNamesRequestParams{MatrixID: 16, NameLength: NameLen4}
+	f := EncodeAllDestAssocNamesRequest(in)
+	if f.ID != RxAllDestNamesRequestExt {
+		t.Errorf("matrix=16 ID = %#x; want 0xE6", f.ID)
+	}
+	want := []byte{16, 0x00}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+	back, err := DecodeAllDestAssocNamesRequest(f)
+	if err != nil || back != in {
+		t.Errorf("round-trip: got %+v err %v", back, err)
+	}
+}
+
+// --- rx 103 / rx 231 -------------------------------------------------
+
+func TestSingleDestAssocNameRequest_NarrowMaxStillNarrow(t *testing.T) {
+	// AssocID 16-bit in narrow — never triggers ext.
+	in := SingleDestAssocNameRequestParams{MatrixID: 15, NameLength: NameLen8, DestAssociationID: 65535}
+	f := EncodeSingleDestAssocNameRequest(in)
+	if f.ID != RxSingleDestNameRequest {
+		t.Errorf("ID = %#x; want 0x67 (narrow accepts AssocID up to 65535)", f.ID)
+	}
+	want := []byte{0x0F, 0x01, 0xFF, 0xFF}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+}
+
+func TestSingleDestAssocNameRequest_PromoteOnMatrix(t *testing.T) {
+	in := SingleDestAssocNameRequestParams{MatrixID: 16, NameLength: NameLen4, DestAssociationID: 1234}
+	f := EncodeSingleDestAssocNameRequest(in)
+	if f.ID != RxSingleDestNameRequestExt {
+		t.Errorf("matrix=16 ID = %#x; want 0xE7", f.ID)
+	}
+	want := []byte{16, 0x00, 0x04, 0xD2} // 1234 = 4*256 + 210 (0xD2)
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+	back, err := DecodeSingleDestAssocNameRequest(f)
+	if err != nil || back != in {
+		t.Errorf("round-trip: got %+v err %v", back, err)
+	}
+}
+
+// --- tx 106 / tx 234 -------------------------------------------------
+
+func TestSourceNamesResponse_PromoteOnMatrix(t *testing.T) {
+	in := SourceNamesResponseParams{
+		MatrixID: 16, LevelID: 0, NameLength: NameLen4,
+		FirstSourceID: 0,
+		Names:         []string{"A", "B"},
+	}
+	f := EncodeSourceNamesResponse(in)
+	if f.ID != TxSourceNamesResponseExt {
+		t.Errorf("matrix=16 ID = %#x; want 0xEA", f.ID)
+	}
+	// Payload prefix: matrix(16), level(0), namelen(0=4-char), firstsrc/256, firstsrc%256, count=2,
+	// then 2 × 4-char names "A   " "B   ".
+	if len(f.Payload) != 6+2*4 {
+		t.Fatalf("ext payload len = %d; want %d", len(f.Payload), 6+2*4)
+	}
+	if f.Payload[0] != 16 || f.Payload[1] != 0 {
+		t.Errorf("matrix/level prefix = %X / %X; want 10 / 00", f.Payload[0], f.Payload[1])
+	}
+	back, err := DecodeSourceNamesResponse(f)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if back.MatrixID != 16 || back.LevelID != 0 || len(back.Names) != 2 {
+		t.Errorf("round-trip mismatch: %+v", back)
+	}
+}
+
+func TestSourceNamesResponse_NarrowMaxStillNarrow(t *testing.T) {
+	in := SourceNamesResponseParams{MatrixID: 15, LevelID: 15, NameLength: NameLen8, FirstSourceID: 0, Names: []string{"X"}}
+	f := EncodeSourceNamesResponse(in)
+	if f.ID != TxSourceNamesResponse {
+		t.Errorf("ID = %#x; want 0x6A", f.ID)
+	}
+}
+
+// --- tx 107 / tx 235 -------------------------------------------------
+
+func TestDestAssocNamesResponse_PromoteOnMatrix(t *testing.T) {
+	in := DestAssocNamesResponseParams{
+		MatrixID: 16, LevelID: 0, NameLength: NameLen4,
+		FirstDestAssociationID: 0,
+		Names:                  []string{"D"},
+	}
+	f := EncodeDestAssocNamesResponse(in)
+	if f.ID != TxDestAssocNamesResponseExt {
+		t.Errorf("matrix=16 ID = %#x; want 0xEB", f.ID)
+	}
+	back, err := DecodeDestAssocNamesResponse(f)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if back.MatrixID != 16 || back.LevelID != 0 || len(back.Names) != 1 {
+		t.Errorf("round-trip mismatch: %+v", back)
+	}
+}
+
+// --- helper ----------------------------------------------------------
+
+func roundtripAllSrcNames(t *testing.T, f Frame, want AllSourceNamesRequestParams, label string) {
+	t.Helper()
+	got, err := DecodeAllSourceNamesRequest(f)
+	if err != nil {
+		t.Errorf("%s: decode: %v", label, err)
+		return
+	}
+	if got != want {
+		t.Errorf("%s: round-trip got %+v want %+v", label, got, want)
+	}
+}

--- a/internal/probel-sw08p/codec/cmd_rx100_all_source_names_request.go
+++ b/internal/probel-sw08p/codec/cmd_rx100_all_source_names_request.go
@@ -1,25 +1,53 @@
 package codec
 
-// AllSourceNamesRequestParams carries the inputs for rx 100 ALL SOURCE
-// NAMES REQUEST: controller asks the matrix for the names of every
-// source on one (matrix, level), in the given name-length format.
+// AllSourceNamesRequestParams carries the inputs for rx 100 / rx 228
+// ALL SOURCE NAMES REQUEST: controller asks the matrix for the names
+// of every source on one (matrix, level), in the given name-length
+// format. The encoder picks general (cmd 100, narrow) or extended
+// (cmd 228, wide) form per the SW-P-08 §3.4.10 ranges — same logical
+// struct, two wire forms.
 //
-// Reference: SW-P-08 §3.2.18.
+// Reference: SW-P-08 Issue 30 §3.2.18 (general) + §3.4.10 (extended).
 type AllSourceNamesRequestParams struct {
-	MatrixID   uint8 // 0-15
-	LevelID    uint8 // 0-15
+	MatrixID   uint8 // narrow: 0-15 (4 bits); extended: 0-255 (full byte)
+	LevelID    uint8 // narrow: 0-15 (4 bits); extended: 0-255 (full byte)
 	NameLength NameLength
 }
 
-// EncodeAllSourceNamesRequest packs rx 100 ALL SOURCE NAMES REQUEST.
+// needsExtended fires when matrix or level exceeds the narrow form's
+// 4-bit packing in byte 1 (§3.1.2).
+func (p AllSourceNamesRequestParams) needsExtended() bool {
+	return p.MatrixID > 15 || p.LevelID > 15
+}
+
+// EncodeAllSourceNamesRequest packs cmd 100 (general, 2-byte) or
+// cmd 228 (extended, 3-byte) per the addressing range of the params.
 //
-// | Byte | Field          | Notes                                       |
-// |------|----------------|---------------------------------------------|
-// |  1   | Matrix / Level | bits[4-7] = Matrix, bits[0-3] = Level (§3.1.2) |
-// |  2   | Name Length    | 0=4-char, 1=8-char, 2=12-char (§3.1.18)        |
+// General form (CommandID 0x64 — 2 data bytes, §3.2.18):
 //
-// Spec: SW-P-08 §3.2.18.
+//	| Byte | Field          | Notes                                       |
+//	|------|----------------|---------------------------------------------|
+//	|  1   | Matrix / Level | bits[4-7] = Matrix, bits[0-3] = Level (§3.1.2) |
+//	|  2   | Name Length    | 0=4-char, 1=8-char, 2=12-char (§3.1.18)        |
+//
+// Extended form (CommandID 0xE4 — 3 data bytes, §3.4.10):
+//
+//	| Byte | Field          | Notes                                       |
+//	|------|----------------|---------------------------------------------|
+//	|  1   | Matrix         | full 8-bit                                   |
+//	|  2   | Level          | full 8-bit                                   |
+//	|  3   | Name Length    | 0=4-char, 1=8-char, 2=12-char                |
 func EncodeAllSourceNamesRequest(p AllSourceNamesRequestParams) Frame {
+	if p.needsExtended() {
+		return Frame{
+			ID: RxAllSourceNamesRequestExt,
+			Payload: []byte{
+				p.MatrixID,
+				p.LevelID,
+				byte(p.NameLength),
+			},
+		}
+	}
 	return Frame{
 		ID: RxAllSourceNamesRequest,
 		Payload: []byte{
@@ -29,18 +57,34 @@ func EncodeAllSourceNamesRequest(p AllSourceNamesRequestParams) Frame {
 	}
 }
 
-// DecodeAllSourceNamesRequest parses an rx 100 ALL SOURCE NAMES REQUEST.
+// DecodeAllSourceNamesRequest parses cmd 100 (general 2-byte) or
+// cmd 228 (extended 3-byte) into the same logical struct.
 func DecodeAllSourceNamesRequest(f Frame) (AllSourceNamesRequestParams, error) {
-	if f.ID != RxAllSourceNamesRequest {
+	switch f.ID {
+	case RxAllSourceNamesRequest:
+		if len(f.Payload) < 2 {
+			return AllSourceNamesRequestParams{}, ErrShortPayload
+		}
+		m, l := decodeMatrixLevel(f.Payload[0])
+		n := NameLength(f.Payload[1])
+		if err := validateNameLength(n); err != nil {
+			return AllSourceNamesRequestParams{}, err
+		}
+		return AllSourceNamesRequestParams{MatrixID: m, LevelID: l, NameLength: n}, nil
+	case RxAllSourceNamesRequestExt:
+		if len(f.Payload) < 3 {
+			return AllSourceNamesRequestParams{}, ErrShortPayload
+		}
+		n := NameLength(f.Payload[2])
+		if err := validateNameLength(n); err != nil {
+			return AllSourceNamesRequestParams{}, err
+		}
+		return AllSourceNamesRequestParams{
+			MatrixID:   f.Payload[0],
+			LevelID:    f.Payload[1],
+			NameLength: n,
+		}, nil
+	default:
 		return AllSourceNamesRequestParams{}, ErrWrongCommand
 	}
-	if len(f.Payload) < 2 {
-		return AllSourceNamesRequestParams{}, ErrShortPayload
-	}
-	m, l := decodeMatrixLevel(f.Payload[0])
-	n := NameLength(f.Payload[1])
-	if err := validateNameLength(n); err != nil {
-		return AllSourceNamesRequestParams{}, err
-	}
-	return AllSourceNamesRequestParams{MatrixID: m, LevelID: l, NameLength: n}, nil
 }

--- a/internal/probel-sw08p/codec/cmd_rx101_single_source_name_request.go
+++ b/internal/probel-sw08p/codec/cmd_rx101_single_source_name_request.go
@@ -1,28 +1,60 @@
 package codec
 
-// SingleSourceNameRequestParams: rx 101 — fetch exactly one source's
-// name.  Matrix uses the full Matrix/Level byte; SourceID is u16 split
-// into a DIV/MOD 256 pair on the wire.
+// SingleSourceNameRequestParams: rx 101 / rx 229 — fetch exactly one
+// source's name.  The narrow form already carries SourceID as a 16-bit
+// DIV/MOD 256 split, so SourceID alone never triggers extended; the
+// promotion fires only on Matrix > 15 or Level > 15 (§3.1.2's 4-bit
+// packing).
 //
-// Reference: SW-P-08 §3.2.19.
+// Reference: SW-P-08 Issue 30 §3.2.19 (general) + §3.4.11 (extended).
 type SingleSourceNameRequestParams struct {
-	MatrixID   uint8 // 0-15
-	LevelID    uint8 // 0-15
+	MatrixID   uint8
+	LevelID    uint8
 	NameLength NameLength
-	SourceID   uint16 // 0-65535
+	SourceID   uint16 // 0-65535 in BOTH forms
 }
 
-// EncodeSingleSourceNameRequest packs rx 101 SINGLE SOURCE NAME REQUEST.
+// needsExtended fires when matrix or level exceeds the narrow form's
+// 4-bit packing in byte 1 (§3.1.2). SourceID is 16-bit in both forms,
+// so it does not promote on its own.
+func (p SingleSourceNameRequestParams) needsExtended() bool {
+	return p.MatrixID > 15 || p.LevelID > 15
+}
+
+// EncodeSingleSourceNameRequest packs cmd 101 (general, 4-byte) or
+// cmd 229 (extended, 5-byte) per the addressing range of the params.
 //
-// | Byte | Field          | Notes                                       |
-// |------|----------------|---------------------------------------------|
-// |  1   | Matrix / Level | bits[4-7] = Matrix, bits[0-3] = Level          |
-// |  2   | Name Length    | 0=4, 1=8, 2=12                                 |
-// |  3   | Src mult       | SourceID DIV 256                               |
-// |  4   | Src num        | SourceID MOD 256                               |
+// General form (CommandID 0x65 — 4 data bytes, §3.2.19):
 //
-// Spec: SW-P-08 §3.2.19.
+//	| Byte | Field          | Notes                                       |
+//	|------|----------------|---------------------------------------------|
+//	|  1   | Matrix / Level | bits[4-7] = Matrix, bits[0-3] = Level          |
+//	|  2   | Name Length    | 0=4, 1=8, 2=12                                 |
+//	|  3   | Src mult       | SourceID DIV 256                               |
+//	|  4   | Src num        | SourceID MOD 256                               |
+//
+// Extended form (CommandID 0xE5 — 5 data bytes, §3.4.11):
+//
+//	| Byte | Field          | Notes                                       |
+//	|------|----------------|---------------------------------------------|
+//	|  1   | Matrix         | full 8-bit                                   |
+//	|  2   | Level          | full 8-bit                                   |
+//	|  3   | Name Length    | 0=4, 1=8, 2=12                              |
+//	|  4   | Src mult       | SourceID DIV 256                            |
+//	|  5   | Src num        | SourceID MOD 256                            |
 func EncodeSingleSourceNameRequest(p SingleSourceNameRequestParams) Frame {
+	if p.needsExtended() {
+		return Frame{
+			ID: RxSingleSourceNameRequestExt,
+			Payload: []byte{
+				p.MatrixID,
+				p.LevelID,
+				byte(p.NameLength),
+				byte(p.SourceID / 256),
+				byte(p.SourceID % 256),
+			},
+		}
+	}
 	return Frame{
 		ID: RxSingleSourceNameRequest,
 		Payload: []byte{
@@ -34,23 +66,40 @@ func EncodeSingleSourceNameRequest(p SingleSourceNameRequestParams) Frame {
 	}
 }
 
-// DecodeSingleSourceNameRequest parses rx 101.
+// DecodeSingleSourceNameRequest parses cmd 101 (general 4-byte) or
+// cmd 229 (extended 5-byte) into the same logical struct.
 func DecodeSingleSourceNameRequest(f Frame) (SingleSourceNameRequestParams, error) {
-	if f.ID != RxSingleSourceNameRequest {
+	switch f.ID {
+	case RxSingleSourceNameRequest:
+		if len(f.Payload) < 4 {
+			return SingleSourceNameRequestParams{}, ErrShortPayload
+		}
+		m, l := decodeMatrixLevel(f.Payload[0])
+		n := NameLength(f.Payload[1])
+		if err := validateNameLength(n); err != nil {
+			return SingleSourceNameRequestParams{}, err
+		}
+		return SingleSourceNameRequestParams{
+			MatrixID:   m,
+			LevelID:    l,
+			NameLength: n,
+			SourceID:   uint16(f.Payload[2])*256 + uint16(f.Payload[3]),
+		}, nil
+	case RxSingleSourceNameRequestExt:
+		if len(f.Payload) < 5 {
+			return SingleSourceNameRequestParams{}, ErrShortPayload
+		}
+		n := NameLength(f.Payload[2])
+		if err := validateNameLength(n); err != nil {
+			return SingleSourceNameRequestParams{}, err
+		}
+		return SingleSourceNameRequestParams{
+			MatrixID:   f.Payload[0],
+			LevelID:    f.Payload[1],
+			NameLength: n,
+			SourceID:   uint16(f.Payload[3])*256 + uint16(f.Payload[4]),
+		}, nil
+	default:
 		return SingleSourceNameRequestParams{}, ErrWrongCommand
 	}
-	if len(f.Payload) < 4 {
-		return SingleSourceNameRequestParams{}, ErrShortPayload
-	}
-	m, l := decodeMatrixLevel(f.Payload[0])
-	n := NameLength(f.Payload[1])
-	if err := validateNameLength(n); err != nil {
-		return SingleSourceNameRequestParams{}, err
-	}
-	return SingleSourceNameRequestParams{
-		MatrixID:   m,
-		LevelID:    l,
-		NameLength: n,
-		SourceID:   uint16(f.Payload[2])*256 + uint16(f.Payload[3]),
-	}, nil
 }

--- a/internal/probel-sw08p/codec/cmd_rx102_all_dest_assoc_names_request.go
+++ b/internal/probel-sw08p/codec/cmd_rx102_all_dest_assoc_names_request.go
@@ -1,44 +1,81 @@
 package codec
 
-// AllDestAssocNamesRequestParams: rx 102 — fetch every destination-
-// association name on a given matrix. Unlike rx 100, this command's
-// byte 1 encodes matrix only (bits 0-3); level has no meaning here.
+// AllDestAssocNamesRequestParams: rx 102 / rx 230 — fetch every
+// destination-association name on a given matrix. The narrow form
+// packs Matrix into bits 0-3 of byte 1 (§3.2.20); extended uses a full
+// 8-bit byte. There is no Level in either form — dest-assoc is matrix-
+// scoped, not matrix+level scoped.
 //
-// Reference: SW-P-08 §3.2.20.
+// Reference: SW-P-08 Issue 30 §3.2.20 (general) + §3.4.12 (extended).
 type AllDestAssocNamesRequestParams struct {
-	MatrixID   uint8 // 0-15 (bits 0-3)
+	MatrixID   uint8 // narrow: 0-15 (bits 0-3); extended: 0-255 (full byte)
 	NameLength NameLength
 }
 
-// EncodeAllDestAssocNamesRequest packs rx 102.
+// needsExtended fires when matrix exceeds the narrow form's 4-bit
+// packing in byte 1 (§3.2.20: bits 0-3 used; bits 4-7 unused).
+func (p AllDestAssocNamesRequestParams) needsExtended() bool {
+	return p.MatrixID > 15
+}
+
+// EncodeAllDestAssocNamesRequest packs cmd 102 (general, 2-byte) or
+// cmd 230 (extended, 2-byte but full 8-bit matrix).
 //
-// | Byte | Field        | Notes                                     |
-// |------|--------------|-------------------------------------------|
-// |  1   | Matrix       | bits[0-3] = Matrix; bits[4-7] unused         |
-// |  2   | Name Length  | 0=4, 1=8, 2=12                               |
+// General form (CommandID 0x66 — 2 data bytes, §3.2.20):
 //
-// Spec: SW-P-08 §3.2.20.
+//	| Byte | Field        | Notes                                     |
+//	|------|--------------|-------------------------------------------|
+//	|  1   | Matrix       | bits[0-3] = Matrix; bits[4-7] unused         |
+//	|  2   | Name Length  | 0=4, 1=8, 2=12                               |
+//
+// Extended form (CommandID 0xE6 — 2 data bytes, §3.4.12):
+//
+//	| Byte | Field        | Notes                                     |
+//	|------|--------------|-------------------------------------------|
+//	|  1   | Matrix       | full 8-bit                                |
+//	|  2   | Name Length  | 0=4, 1=8, 2=12                            |
 func EncodeAllDestAssocNamesRequest(p AllDestAssocNamesRequestParams) Frame {
+	if p.needsExtended() {
+		return Frame{
+			ID:      RxAllDestNamesRequestExt,
+			Payload: []byte{p.MatrixID, byte(p.NameLength)},
+		}
+	}
 	return Frame{
 		ID:      RxAllDestNamesRequest,
 		Payload: []byte{p.MatrixID & 0x0F, byte(p.NameLength)},
 	}
 }
 
-// DecodeAllDestAssocNamesRequest parses rx 102.
+// DecodeAllDestAssocNamesRequest parses cmd 102 (general 2-byte) or
+// cmd 230 (extended 2-byte) into the same logical struct.
 func DecodeAllDestAssocNamesRequest(f Frame) (AllDestAssocNamesRequestParams, error) {
-	if f.ID != RxAllDestNamesRequest {
+	switch f.ID {
+	case RxAllDestNamesRequest:
+		if len(f.Payload) < 2 {
+			return AllDestAssocNamesRequestParams{}, ErrShortPayload
+		}
+		n := NameLength(f.Payload[1])
+		if err := validateNameLength(n); err != nil {
+			return AllDestAssocNamesRequestParams{}, err
+		}
+		return AllDestAssocNamesRequestParams{
+			MatrixID:   f.Payload[0] & 0x0F,
+			NameLength: n,
+		}, nil
+	case RxAllDestNamesRequestExt:
+		if len(f.Payload) < 2 {
+			return AllDestAssocNamesRequestParams{}, ErrShortPayload
+		}
+		n := NameLength(f.Payload[1])
+		if err := validateNameLength(n); err != nil {
+			return AllDestAssocNamesRequestParams{}, err
+		}
+		return AllDestAssocNamesRequestParams{
+			MatrixID:   f.Payload[0],
+			NameLength: n,
+		}, nil
+	default:
 		return AllDestAssocNamesRequestParams{}, ErrWrongCommand
 	}
-	if len(f.Payload) < 2 {
-		return AllDestAssocNamesRequestParams{}, ErrShortPayload
-	}
-	n := NameLength(f.Payload[1])
-	if err := validateNameLength(n); err != nil {
-		return AllDestAssocNamesRequestParams{}, err
-	}
-	return AllDestAssocNamesRequestParams{
-		MatrixID:   f.Payload[0] & 0x0F,
-		NameLength: n,
-	}, nil
 }

--- a/internal/probel-sw08p/codec/cmd_rx103_single_dest_assoc_name_request.go
+++ b/internal/probel-sw08p/codec/cmd_rx103_single_dest_assoc_name_request.go
@@ -1,27 +1,55 @@
 package codec
 
-// SingleDestAssocNameRequestParams: rx 103 — fetch one destination-
-// association name. Byte 1 is matrix-only (bits 0-3); assoc id is u16
-// split DIV/MOD 256.
+// SingleDestAssocNameRequestParams: rx 103 / rx 231 — fetch one
+// destination-association name. Like rx 102, byte 1 is matrix-only;
+// AssocID is u16 split DIV/MOD 256 in BOTH forms, so AssocID never
+// triggers extended on its own.
 //
-// Reference: SW-P-08 §3.2.21.
+// Reference: SW-P-08 Issue 30 §3.2.21 (general) + §3.4.13 (extended).
 type SingleDestAssocNameRequestParams struct {
 	MatrixID          uint8
 	NameLength        NameLength
 	DestAssociationID uint16
 }
 
-// EncodeSingleDestAssocNameRequest packs rx 103.
+// needsExtended fires when matrix exceeds the narrow form's 4-bit
+// packing in byte 1 (§3.2.21).
+func (p SingleDestAssocNameRequestParams) needsExtended() bool {
+	return p.MatrixID > 15
+}
+
+// EncodeSingleDestAssocNameRequest packs cmd 103 (general, 4-byte) or
+// cmd 231 (extended, 4-byte but full 8-bit matrix).
 //
-// | Byte | Field        | Notes                                     |
-// |------|--------------|-------------------------------------------|
-// |  1   | Matrix       | bits[0-3] = Matrix                           |
-// |  2   | Name Length  | 0=4, 1=8, 2=12                               |
-// |  3   | Dest assoc mult | AssocID DIV 256                            |
-// |  4   | Dest assoc num  | AssocID MOD 256                            |
+// General form (CommandID 0x67 — 4 data bytes, §3.2.21):
 //
-// Spec: SW-P-08 §3.2.21.
+//	| Byte | Field            | Notes                                     |
+//	|------|------------------|-------------------------------------------|
+//	|  1   | Matrix           | bits[0-3] = Matrix                           |
+//	|  2   | Name Length      | 0=4, 1=8, 2=12                               |
+//	|  3   | Dest assoc mult  | AssocID DIV 256                              |
+//	|  4   | Dest assoc num   | AssocID MOD 256                              |
+//
+// Extended form (CommandID 0xE7 — 4 data bytes, §3.4.13):
+//
+//	| Byte | Field            | Notes                                     |
+//	|------|------------------|-------------------------------------------|
+//	|  1   | Matrix           | full 8-bit                                |
+//	|  2   | Name Length      | 0=4, 1=8, 2=12                            |
+//	|  3   | Dest assoc mult  | AssocID DIV 256                           |
+//	|  4   | Dest assoc num   | AssocID MOD 256                           |
 func EncodeSingleDestAssocNameRequest(p SingleDestAssocNameRequestParams) Frame {
+	if p.needsExtended() {
+		return Frame{
+			ID: RxSingleDestNameRequestExt,
+			Payload: []byte{
+				p.MatrixID,
+				byte(p.NameLength),
+				byte(p.DestAssociationID / 256),
+				byte(p.DestAssociationID % 256),
+			},
+		}
+	}
 	return Frame{
 		ID: RxSingleDestNameRequest,
 		Payload: []byte{
@@ -33,21 +61,37 @@ func EncodeSingleDestAssocNameRequest(p SingleDestAssocNameRequestParams) Frame 
 	}
 }
 
-// DecodeSingleDestAssocNameRequest parses rx 103.
+// DecodeSingleDestAssocNameRequest parses cmd 103 (general 4-byte) or
+// cmd 231 (extended 4-byte) into the same logical struct.
 func DecodeSingleDestAssocNameRequest(f Frame) (SingleDestAssocNameRequestParams, error) {
-	if f.ID != RxSingleDestNameRequest {
+	switch f.ID {
+	case RxSingleDestNameRequest:
+		if len(f.Payload) < 4 {
+			return SingleDestAssocNameRequestParams{}, ErrShortPayload
+		}
+		n := NameLength(f.Payload[1])
+		if err := validateNameLength(n); err != nil {
+			return SingleDestAssocNameRequestParams{}, err
+		}
+		return SingleDestAssocNameRequestParams{
+			MatrixID:          f.Payload[0] & 0x0F,
+			NameLength:        n,
+			DestAssociationID: uint16(f.Payload[2])*256 + uint16(f.Payload[3]),
+		}, nil
+	case RxSingleDestNameRequestExt:
+		if len(f.Payload) < 4 {
+			return SingleDestAssocNameRequestParams{}, ErrShortPayload
+		}
+		n := NameLength(f.Payload[1])
+		if err := validateNameLength(n); err != nil {
+			return SingleDestAssocNameRequestParams{}, err
+		}
+		return SingleDestAssocNameRequestParams{
+			MatrixID:          f.Payload[0],
+			NameLength:        n,
+			DestAssociationID: uint16(f.Payload[2])*256 + uint16(f.Payload[3]),
+		}, nil
+	default:
 		return SingleDestAssocNameRequestParams{}, ErrWrongCommand
 	}
-	if len(f.Payload) < 4 {
-		return SingleDestAssocNameRequestParams{}, ErrShortPayload
-	}
-	n := NameLength(f.Payload[1])
-	if err := validateNameLength(n); err != nil {
-		return SingleDestAssocNameRequestParams{}, err
-	}
-	return SingleDestAssocNameRequestParams{
-		MatrixID:          f.Payload[0] & 0x0F,
-		NameLength:        n,
-		DestAssociationID: uint16(f.Payload[2])*256 + uint16(f.Payload[3]),
-	}, nil
 }

--- a/internal/probel-sw08p/codec/cmd_tally_dump_extended_test.go
+++ b/internal/probel-sw08p/codec/cmd_tally_dump_extended_test.go
@@ -1,0 +1,185 @@
+package codec
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+// Boundary tests for the Crosspoint Tally Dump form-selection ladder:
+// cmd 22 (narrow byte) → cmd 23 (narrow word) → cmd 151 (extended word).
+// Spec basis: SW-P-08 Issue 30 §3.3.10 (cmd 22 byte) + §3.3.11 (cmd 23
+// word) + §3.5.7 (cmd 151 ext word).
+//
+// There is NO extended-byte form in the spec — when ANY of the byte-
+// form's narrow ceilings is exceeded the encoder promotes to the word
+// form, which itself promotes to the extended word form when matrix
+// or level exceeds the 4-bit narrow packing.
+
+// --- byte-form ceilings (cmd 22 narrow) -----------------------------
+
+func TestTallyDumpByte_NarrowMin(t *testing.T) {
+	in := CrosspointTallyDumpByteParams{
+		MatrixID: 0, LevelID: 0,
+		FirstDestinationID: 0,
+		SourceIDs:          []uint8{0, 0, 0},
+	}
+	f := EncodeCrosspointTallyDumpByte(in)
+	if f.ID != TxCrosspointTallyDumpByte {
+		t.Errorf("min ID = %#x; want 0x16 (narrow byte)", f.ID)
+	}
+	want := []byte{0x00, 0x03, 0x00, 0x00, 0x00, 0x00}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+}
+
+func TestTallyDumpByte_NarrowMax(t *testing.T) {
+	// Spec §3.3.10 ceiling: matrix=15, level=15, firstdst=191, src=191.
+	in := CrosspointTallyDumpByteParams{
+		MatrixID: 15, LevelID: 15,
+		FirstDestinationID: 191,
+		SourceIDs:          []uint8{191, 0, 191},
+	}
+	f := EncodeCrosspointTallyDumpByte(in)
+	if f.ID != TxCrosspointTallyDumpByte {
+		t.Errorf("max-narrow ID = %#x; want 0x16 (still narrow byte)", f.ID)
+	}
+	want := []byte{0xFF, 0x03, 0xBF, 0xBF, 0x00, 0xBF}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+}
+
+// --- byte → word promotion -------------------------------------------
+
+func TestTallyDumpByte_PromoteOnDst(t *testing.T) {
+	in := CrosspointTallyDumpByteParams{
+		MatrixID: 0, LevelID: 0,
+		FirstDestinationID: 192, // > 191 → must promote
+		SourceIDs:          []uint8{0, 0},
+	}
+	f := EncodeCrosspointTallyDumpByte(in)
+	if f.ID != TxCrosspointTallyDumpWord {
+		t.Errorf("firstdst=192 ID = %#x; want 0x17 (promoted to narrow word; byte form caps at 191)", f.ID)
+	}
+	// Word narrow form: matrix/level=0x00, tallies=02, dst_hi=00, dst_lo=192, src0_hi=00, src0_lo=00, src1_hi=00, src1_lo=00
+	want := []byte{0x00, 0x02, 0x00, 0xC0, 0x00, 0x00, 0x00, 0x00}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+}
+
+func TestTallyDumpByte_PromoteOnSrc(t *testing.T) {
+	in := CrosspointTallyDumpByteParams{
+		MatrixID: 0, LevelID: 0,
+		FirstDestinationID: 0,
+		SourceIDs:          []uint8{50, 200, 100}, // 200 > 191 → must promote
+	}
+	f := EncodeCrosspointTallyDumpByte(in)
+	if f.ID != TxCrosspointTallyDumpWord {
+		t.Errorf("src=200 ID = %#x; want 0x17 (promoted; byte form caps at 191)", f.ID)
+	}
+	// Verify the payload has each source as 2 bytes.
+	if len(f.Payload) != 4+2*3 {
+		t.Errorf("word payload len = %d; want %d", len(f.Payload), 4+2*3)
+	}
+}
+
+func TestTallyDumpByte_PromoteOnMatrix(t *testing.T) {
+	in := CrosspointTallyDumpByteParams{
+		MatrixID: 16, LevelID: 0,
+		FirstDestinationID: 0,
+		SourceIDs:          []uint8{1, 2},
+	}
+	f := EncodeCrosspointTallyDumpByte(in)
+	if f.ID != TxCrosspointTallyDumpWordExt {
+		t.Errorf("matrix=16 ID = %#x; want 0x97 (byte form promotes through narrow-word into extended-word)", f.ID)
+	}
+}
+
+func TestTallyDumpByte_PromoteOnLevel(t *testing.T) {
+	in := CrosspointTallyDumpByteParams{
+		MatrixID: 0, LevelID: 16,
+		FirstDestinationID: 0,
+		SourceIDs:          []uint8{1},
+	}
+	f := EncodeCrosspointTallyDumpByte(in)
+	if f.ID != TxCrosspointTallyDumpWordExt {
+		t.Errorf("level=16 ID = %#x; want 0x97", f.ID)
+	}
+}
+
+// --- word-form boundary tests ----------------------------------------
+
+func TestTallyDumpWord_NarrowMaxStillNarrow(t *testing.T) {
+	// Per spec §3.3.11 narrow word DOES support 0-65535 dst/src — only
+	// matrix/level packing differs from extended. Verify dst=65535 +
+	// src=65535 stays in narrow word.
+	in := CrosspointTallyDumpWordParams{
+		MatrixID: 15, LevelID: 15,
+		FirstDestinationID: 65535,
+		SourceIDs:          []uint16{65535, 0, 65535},
+	}
+	f := EncodeCrosspointTallyDumpWord(in)
+	if f.ID != TxCrosspointTallyDumpWord {
+		t.Errorf("max-narrow word ID = %#x; want 0x17 (matrix/level fit in narrow nibble; dst/src can be 0-65535)", f.ID)
+	}
+	want := []byte{0xFF, 0x03, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0xFF, 0xFF}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+}
+
+func TestTallyDumpWord_PromoteOnMatrix(t *testing.T) {
+	in := CrosspointTallyDumpWordParams{
+		MatrixID: 16, LevelID: 0,
+		FirstDestinationID: 100,
+		SourceIDs:          []uint16{200, 300},
+	}
+	f := EncodeCrosspointTallyDumpWord(in)
+	if f.ID != TxCrosspointTallyDumpWordExt {
+		t.Errorf("matrix=16 ID = %#x; want 0x97 (extended)", f.ID)
+	}
+	want := []byte{16, 0, 0x02, 0x00, 0x64, 0x00, 0xC8, 0x01, 0x2C}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+}
+
+func TestTallyDumpWord_ExtendedMax(t *testing.T) {
+	in := CrosspointTallyDumpWordParams{
+		MatrixID: 255, LevelID: 255,
+		FirstDestinationID: 65535,
+		SourceIDs:          []uint16{65535},
+	}
+	f := EncodeCrosspointTallyDumpWord(in)
+	if f.ID != TxCrosspointTallyDumpWordExt {
+		t.Fatalf("ID = %#x; want 0x97", f.ID)
+	}
+	want := []byte{0xFF, 0xFF, 0x01, 0xFF, 0xFF, 0xFF, 0xFF}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+}
+
+// --- byte form decode + word-form-on-decode round-trip ---------------
+
+func TestTallyDumpByte_DecodeRoundTrip(t *testing.T) {
+	in := CrosspointTallyDumpByteParams{
+		MatrixID: 5, LevelID: 3,
+		FirstDestinationID: 100,
+		SourceIDs:          []uint8{10, 20, 30, 40},
+	}
+	f := EncodeCrosspointTallyDumpByte(in)
+	if f.ID != TxCrosspointTallyDumpByte {
+		t.Fatalf("expected narrow byte form")
+	}
+	got, err := DecodeCrosspointTallyDumpByte(f)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !reflect.DeepEqual(got, in) {
+		t.Errorf("round-trip: got %+v want %+v", got, in)
+	}
+}

--- a/internal/probel-sw08p/codec/cmd_tx022_crosspoint_tally_dump_byte.go
+++ b/internal/probel-sw08p/codec/cmd_tx022_crosspoint_tally_dump_byte.go
@@ -1,13 +1,24 @@
 package codec
 
-// CrosspointTallyDumpByteParams is the compact 1-byte-per-ID dump used when
-// destination AND source IDs both fit in 7 bits (≤ 191 per Probel spec).
-// SourceIDs[i] is the source currently routed to destination
-// FirstDestinationID+i.
+// CrosspointTallyDumpByteParams is the compact 1-byte-per-ID dump used
+// when the (matrix, level) and every dst/src ID fit in the spec's
+// narrow byte-form limits. SourceIDs[i] is the source currently routed
+// to destination FirstDestinationID+i.
 //
-// Reference: TS tx/022/params.ts CrossPointTallyDumpByteCommandParams.
-// SW-P-08 caps one frame at 133 bytes, so callers dumping > ~128 destinations
-// must split into multiple frames (each with its own FirstDestinationID).
+// Spec narrow-byte ranges (SW-P-08 Issue 30 §3.3.10):
+//   - matrix:               0-15  (4-bit packing in byte 1)
+//   - level:                0-15  (4-bit packing in byte 1)
+//   - FirstDestinationID:   0-191
+//   - any SourceIDs[i]:     0-191
+//
+// When ANY of those ceilings is exceeded the encoder auto-promotes to
+// the word form (cmd 23) — and the word form itself promotes to the
+// extended word form (cmd 151) when matrix or level exceeds the narrow
+// 4-bit packing. There is no separate extended-byte form in the spec.
+//
+// Per-frame tally count is bounded by the §2 128-byte DATA cap; large
+// dumps split into multiple frames each with its own
+// FirstDestinationID.
 type CrosspointTallyDumpByteParams struct {
 	MatrixID           uint8
 	LevelID            uint8
@@ -15,20 +26,56 @@ type CrosspointTallyDumpByteParams struct {
 	SourceIDs          []uint8
 }
 
-// EncodeCrosspointTallyDumpByte builds one TX 022 frame. Caller is
-// responsible for chunking a large tally table into multiple calls.
+// needsWordPromote returns true when any field exceeds the narrow
+// byte-form's spec-defined limits (§3.3.10). The encoder then routes
+// the frame through the word codec, which itself picks narrow-word
+// (cmd 23) vs extended-word (cmd 151) based on matrix/level.
 //
-// General form (CommandID 0x16 — 3 + N payload bytes, N = len(SourceIDs)):
+// SourceID > 255 is structurally impossible (uint8 caps at 255); the
+// 192..255 range is wire-encodable but spec-disallowed for byte form,
+// so we promote to word.
+func (p CrosspointTallyDumpByteParams) needsWordPromote() bool {
+	if p.MatrixID > 15 || p.LevelID > 15 || p.FirstDestinationID > 191 {
+		return true
+	}
+	for _, s := range p.SourceIDs {
+		if s > 191 {
+			return true
+		}
+	}
+	return false
+}
+
+// EncodeCrosspointTallyDumpByte builds one cmd 22 frame, OR auto-
+// promotes to the word form (cmd 23 / cmd 151 per word-form rules)
+// when the params exceed byte-form limits per §3.3.10. Caller is
+// responsible for chunking a large tally table across multiple calls
+// (per ADR §2 128-byte DATA cap).
+//
+// Narrow byte form (CommandID 0x16 — 3 + N payload bytes, N = len(SourceIDs)):
 //
 //	| Byte    | Field               | Notes                               |
 //	|---------|---------------------|-------------------------------------|
-//	|  1      | Matrix / Level      | bits[4-7] = Matrix, bits[0-3] = Level|
-//	|  2      | Tallies returned    | N = len(SourceIDs), max 191         |
-//	|  3      | First destination   | (u8)                                |
-//	|  4..N+3 | Source IDs          | one byte per destination, ascending |
+//	|  1      | Matrix / Level      | bits[4-7] = Matrix, bits[0-3] = Level |
+//	|  2      | Tallies returned    | N = len(SourceIDs)                  |
+//	|  3      | First destination   | u8, range 0-191 per spec            |
+//	|  4..N+3 | Source IDs          | one byte per destination, 0-191     |
 //
-// Spec: SW-P-08 §3.3.23. Reference: TS tx/022/command.ts buildDataNormal.
+// Spec: SW-P-08 Issue 30 §3.3.10 "This message assumes a maximum
+// destination/source number of 191."
 func EncodeCrosspointTallyDumpByte(p CrosspointTallyDumpByteParams) Frame {
+	if p.needsWordPromote() {
+		srcWord := make([]uint16, len(p.SourceIDs))
+		for i, s := range p.SourceIDs {
+			srcWord[i] = uint16(s)
+		}
+		return EncodeCrosspointTallyDumpWord(CrosspointTallyDumpWordParams{
+			MatrixID:           p.MatrixID,
+			LevelID:            p.LevelID,
+			FirstDestinationID: uint16(p.FirstDestinationID),
+			SourceIDs:          srcWord,
+		})
+	}
 	out := make([]byte, 0, 3+len(p.SourceIDs))
 	out = append(out,
 		(p.MatrixID<<4)|(p.LevelID&0x0F),
@@ -39,7 +86,9 @@ func EncodeCrosspointTallyDumpByte(p CrosspointTallyDumpByteParams) Frame {
 	return Frame{ID: TxCrosspointTallyDumpByte, Payload: out}
 }
 
-// DecodeCrosspointTallyDumpByte parses a TX 022 payload.
+// DecodeCrosspointTallyDumpByte parses a cmd 22 payload. Use
+// DecodeCrosspointTallyDumpWord for cmd 23 (narrow word) or cmd 151
+// (extended word) frames.
 func DecodeCrosspointTallyDumpByte(f Frame) (CrosspointTallyDumpByteParams, error) {
 	if f.ID != TxCrosspointTallyDumpByte {
 		return CrosspointTallyDumpByteParams{}, ErrWrongCommand

--- a/internal/probel-sw08p/codec/cmd_tx023_crosspoint_tally_dump_word.go
+++ b/internal/probel-sw08p/codec/cmd_tx023_crosspoint_tally_dump_word.go
@@ -12,8 +12,13 @@ type CrosspointTallyDumpWordParams struct {
 	SourceIDs          []uint16
 }
 
+// needsExtended fires only on matrix/level overflow. Per SW-P-08 Issue
+// 30 §3.3.11 (narrow word, cmd 23) and §3.5.7 (extended word, cmd 151),
+// BOTH forms support FirstDestinationID and any SourceID in the full
+// 0-65535 range via the DIV/MOD 256 split — only the matrix/level
+// packing differs (4-bit nibble vs full 8-bit byte).
 func (p CrosspointTallyDumpWordParams) needsExtended() bool {
-	return p.MatrixID > 15 || p.LevelID > 15 || p.FirstDestinationID > 895
+	return p.MatrixID > 15 || p.LevelID > 15
 }
 
 // EncodeCrosspointTallyDumpWord builds one TX 023 / TX 151 frame.

--- a/internal/probel-sw08p/codec/cmd_tx106_source_names_response.go
+++ b/internal/probel-sw08p/codec/cmd_tx106_source_names_response.go
@@ -2,15 +2,16 @@ package codec
 
 import "fmt"
 
-// SourceNamesResponseParams: tx 106 — one frame of source names, as
-// issued by the matrix in reply to rx 100 or rx 101. Large name tables
-// require multiple frames; callers paginate with successive FirstSourceID.
+// SourceNamesResponseParams: tx 106 / tx 234 — one frame of source
+// names, as issued by the matrix in reply to rx 100/101 (or
+// rx 228/229). Large name tables require multiple frames; callers
+// paginate with successive FirstSourceID.
 //
-// Names is a slice of the source labels in wire order; each entry is at
-// most NameLength.Bytes() chars. Longer strings are truncated; shorter
-// strings are right-padded with spaces.
+// Names is a slice of the source labels in wire order; each entry is
+// at most NameLength.Bytes() chars. Longer strings are truncated;
+// shorter strings are right-padded with spaces.
 //
-// Reference: SW-P-08 §3.3.19.
+// Reference: SW-P-08 Issue 30 §3.3.19 (general) + §3.5.10 (extended).
 type SourceNamesResponseParams struct {
 	MatrixID      uint8
 	LevelID       uint8
@@ -19,70 +20,138 @@ type SourceNamesResponseParams struct {
 	Names         []string
 }
 
-// EncodeSourceNamesResponse packs tx 106 SOURCE NAMES RESPONSE.
+// needsExtended mirrors the request-side rule (§3.1.2 4-bit packing):
+// matrix > 15 OR level > 15 promotes to extended. FirstSourceID is
+// 16-bit in BOTH forms, so it does not promote on its own.
+func (p SourceNamesResponseParams) needsExtended() bool {
+	return p.MatrixID > 15 || p.LevelID > 15
+}
+
+// EncodeSourceNamesResponse packs cmd 106 (general) or cmd 234
+// (extended) per the addressing range of the params.
 //
-// | Byte     | Field               | Notes                                  |
-// |----------|---------------------|----------------------------------------|
-// |  1       | Matrix / Level      | bits[4-7] = Matrix, bits[0-3] = Level     |
-// |  2       | Name Length         | 0=4, 1=8, 2=12                            |
-// |  3       | 1st Src mult        | FirstSourceID DIV 256                     |
-// |  4       | 1st Src num         | FirstSourceID MOD 256                     |
-// |  5       | Num of names        | Names count to follow                     |
-// |  6+      | N × Name (fixed)    | NameLength.Bytes() bytes each, ASCII      |
+// General form (CommandID 0x6A — §3.3.19):
 //
-// Caps (spec §3.3.19): "max 32 × 4-char, 16 × 8-char, or 10 × 12-char
-// names" per frame. Extras are silently dropped — callers paginate.
+//	| Byte     | Field               | Notes                                  |
+//	|----------|---------------------|----------------------------------------|
+//	|  1       | Matrix / Level      | bits[4-7] = Matrix, bits[0-3] = Level     |
+//	|  2       | Name Length         | 0=4, 1=8, 2=12                            |
+//	|  3       | 1st Src mult        | FirstSourceID DIV 256                     |
+//	|  4       | 1st Src num         | FirstSourceID MOD 256                     |
+//	|  5       | Num of names        | Names count to follow                     |
+//	|  6+      | N × Name (fixed)    | NameLength.Bytes() bytes each             |
 //
-// Spec: SW-P-08 §3.3.19.
+// Extended form (CommandID 0xEA — §3.5.10):
+//
+//	| Byte     | Field               | Notes                                  |
+//	|----------|---------------------|----------------------------------------|
+//	|  1       | Matrix              | full 8-bit                             |
+//	|  2       | Level               | full 8-bit                             |
+//	|  3       | Name Length         | 0=4, 1=8, 2=12                         |
+//	|  4       | 1st Src mult        | FirstSourceID DIV 256                  |
+//	|  5       | 1st Src num         | FirstSourceID MOD 256                  |
+//	|  6       | Num of names        | Names count to follow                  |
+//	|  7+      | N × Name (fixed)    | NameLength.Bytes() bytes each          |
+//
+// Caps (spec §3.3.19 / §3.5.10): "max 32 × 4-char, 16 × 8-char, or
+// 10 × 12-char names" per frame. Extras are silently dropped — callers
+// paginate via FirstSourceID.
 func EncodeSourceNamesResponse(p SourceNamesResponseParams) Frame {
 	width := p.NameLength.Bytes()
-	cap := p.NameLength.MaxNamesPerMessage()
+	maxN := p.NameLength.MaxNamesPerMessage()
 	n := len(p.Names)
-	if n > cap {
-		n = cap
+	if n > maxN {
+		n = maxN
+	}
+	if p.needsExtended() {
+		payload := make([]byte, 0, 6+n*width)
+		payload = append(payload,
+			p.MatrixID,
+			p.LevelID,
+			byte(p.NameLength),
+			byte(p.FirstSourceID/256),
+			byte(p.FirstSourceID%256),
+			byte(n),
+		)
+		for i := 0; i < n; i++ {
+			payload = append(payload, packName(p.Names[i], width)...)
+		}
+		return Frame{ID: TxSourceNamesResponseExt, Payload: payload}
 	}
 	payload := make([]byte, 0, 5+n*width)
-	payload = append(payload, encodeMatrixLevel(p.MatrixID, p.LevelID))
-	payload = append(payload, byte(p.NameLength))
-	payload = append(payload, byte(p.FirstSourceID/256))
-	payload = append(payload, byte(p.FirstSourceID%256))
-	payload = append(payload, byte(n))
+	payload = append(payload,
+		encodeMatrixLevel(p.MatrixID, p.LevelID),
+		byte(p.NameLength),
+		byte(p.FirstSourceID/256),
+		byte(p.FirstSourceID%256),
+		byte(n),
+	)
 	for i := 0; i < n; i++ {
 		payload = append(payload, packName(p.Names[i], width)...)
 	}
 	return Frame{ID: TxSourceNamesResponse, Payload: payload}
 }
 
-// DecodeSourceNamesResponse parses tx 106.
+// DecodeSourceNamesResponse parses tx 106 (general) or tx 234
+// (extended) into the same logical struct.
 func DecodeSourceNamesResponse(f Frame) (SourceNamesResponseParams, error) {
-	if f.ID != TxSourceNamesResponse {
+	switch f.ID {
+	case TxSourceNamesResponse:
+		if len(f.Payload) < 5 {
+			return SourceNamesResponseParams{}, ErrShortPayload
+		}
+		m, l := decodeMatrixLevel(f.Payload[0])
+		n := NameLength(f.Payload[1])
+		if err := validateNameLength(n); err != nil {
+			return SourceNamesResponseParams{}, err
+		}
+		first := uint16(f.Payload[2])*256 + uint16(f.Payload[3])
+		count := int(f.Payload[4])
+		width := n.Bytes()
+		if len(f.Payload) < 5+count*width {
+			return SourceNamesResponseParams{}, fmt.Errorf("probel: tx 106 needs %d bytes, got %d",
+				5+count*width, len(f.Payload))
+		}
+		names := make([]string, count)
+		for i := 0; i < count; i++ {
+			off := 5 + i*width
+			names[i] = unpackName(f.Payload[off : off+width])
+		}
+		return SourceNamesResponseParams{
+			MatrixID:      m,
+			LevelID:       l,
+			NameLength:    n,
+			FirstSourceID: first,
+			Names:         names,
+		}, nil
+	case TxSourceNamesResponseExt:
+		if len(f.Payload) < 6 {
+			return SourceNamesResponseParams{}, ErrShortPayload
+		}
+		n := NameLength(f.Payload[2])
+		if err := validateNameLength(n); err != nil {
+			return SourceNamesResponseParams{}, err
+		}
+		first := uint16(f.Payload[3])*256 + uint16(f.Payload[4])
+		count := int(f.Payload[5])
+		width := n.Bytes()
+		if len(f.Payload) < 6+count*width {
+			return SourceNamesResponseParams{}, fmt.Errorf("probel: tx 234 needs %d bytes, got %d",
+				6+count*width, len(f.Payload))
+		}
+		names := make([]string, count)
+		for i := 0; i < count; i++ {
+			off := 6 + i*width
+			names[i] = unpackName(f.Payload[off : off+width])
+		}
+		return SourceNamesResponseParams{
+			MatrixID:      f.Payload[0],
+			LevelID:       f.Payload[1],
+			NameLength:    n,
+			FirstSourceID: first,
+			Names:         names,
+		}, nil
+	default:
 		return SourceNamesResponseParams{}, ErrWrongCommand
 	}
-	if len(f.Payload) < 5 {
-		return SourceNamesResponseParams{}, ErrShortPayload
-	}
-	m, l := decodeMatrixLevel(f.Payload[0])
-	n := NameLength(f.Payload[1])
-	if err := validateNameLength(n); err != nil {
-		return SourceNamesResponseParams{}, err
-	}
-	first := uint16(f.Payload[2])*256 + uint16(f.Payload[3])
-	count := int(f.Payload[4])
-	width := n.Bytes()
-	if len(f.Payload) < 5+count*width {
-		return SourceNamesResponseParams{}, fmt.Errorf("probel: tx 106 needs %d bytes, got %d",
-			5+count*width, len(f.Payload))
-	}
-	names := make([]string, count)
-	for i := 0; i < count; i++ {
-		off := 5 + i*width
-		names[i] = unpackName(f.Payload[off : off+width])
-	}
-	return SourceNamesResponseParams{
-		MatrixID:      m,
-		LevelID:       l,
-		NameLength:    n,
-		FirstSourceID: first,
-		Names:         names,
-	}, nil
 }

--- a/internal/probel-sw08p/codec/cmd_tx107_dest_assoc_names_response.go
+++ b/internal/probel-sw08p/codec/cmd_tx107_dest_assoc_names_response.go
@@ -2,80 +2,149 @@ package codec
 
 import "fmt"
 
-// DestAssocNamesResponseParams: tx 107 — matrix's reply to rx 102 or
-// rx 103. Byte 1 is Matrix/Level per §3.1.2 (yes, asymmetric with the
-// request — the response carries a level slot, the request doesn't).
+// DestAssocNamesResponseParams: tx 107 / tx 235 — matrix's reply to
+// rx 102/103 (or rx 230/231). Byte 1 is Matrix/Level per §3.1.2 (yes,
+// asymmetric with the request — the response carries a level slot,
+// the request doesn't). Both narrow and extended responses include
+// the level field; the request side just doesn't.
 //
-// Reference: SW-P-08 §3.3.20.
+// Reference: SW-P-08 Issue 30 §3.3.20 (general) + §3.5.11 (extended).
 type DestAssocNamesResponseParams struct {
-	MatrixID              uint8
-	LevelID               uint8
-	NameLength            NameLength
+	MatrixID               uint8
+	LevelID                uint8
+	NameLength             NameLength
 	FirstDestAssociationID uint16
-	Names                 []string
+	Names                  []string
 }
 
-// EncodeDestAssocNamesResponse packs tx 107.
+// needsExtended mirrors the request-side rule: matrix > 15 OR level >
+// 15 promotes to extended. FirstDestAssociationID is 16-bit in BOTH
+// forms, so it does not promote on its own.
+func (p DestAssocNamesResponseParams) needsExtended() bool {
+	return p.MatrixID > 15 || p.LevelID > 15
+}
+
+// EncodeDestAssocNamesResponse packs cmd 107 (general) or cmd 235
+// (extended) per the addressing range of the params.
 //
-// | Byte     | Field            | Notes                                    |
-// |----------|------------------|------------------------------------------|
-// |  1       | Matrix / Level   | bits[4-7] Matrix, bits[0-3] Level (§3.1.2) |
-// |  2       | Name Length      | 0=4, 1=8, 2=12                              |
-// |  3       | 1st Dest mult    | FirstDestAssociationID DIV 256              |
-// |  4       | 1st Dest num     | FirstDestAssociationID MOD 256              |
-// |  5       | Num of names     | Names count to follow                       |
-// |  6+      | N × Name (fixed) | NameLength.Bytes() bytes each, ASCII        |
+// General form (CommandID 0x6B — §3.3.20):
 //
-// Spec: SW-P-08 §3.3.20.
+//	| Byte     | Field            | Notes                                    |
+//	|----------|------------------|------------------------------------------|
+//	|  1       | Matrix / Level   | bits[4-7] Matrix, bits[0-3] Level (§3.1.2) |
+//	|  2       | Name Length      | 0=4, 1=8, 2=12                              |
+//	|  3       | 1st Dest mult    | FirstDestAssociationID DIV 256              |
+//	|  4       | 1st Dest num     | FirstDestAssociationID MOD 256              |
+//	|  5       | Num of names     | Names count to follow                       |
+//	|  6+      | N × Name (fixed) | NameLength.Bytes() bytes each               |
+//
+// Extended form (CommandID 0xEB — §3.5.11):
+//
+//	| Byte     | Field            | Notes                                    |
+//	|----------|------------------|------------------------------------------|
+//	|  1       | Matrix           | full 8-bit                               |
+//	|  2       | Level            | full 8-bit                               |
+//	|  3       | Name Length      | 0=4, 1=8, 2=12                           |
+//	|  4       | 1st Dest mult    | FirstDestAssociationID DIV 256           |
+//	|  5       | 1st Dest num     | FirstDestAssociationID MOD 256           |
+//	|  6       | Num of names     | Names count to follow                    |
+//	|  7+      | N × Name (fixed) | NameLength.Bytes() bytes each            |
 func EncodeDestAssocNamesResponse(p DestAssocNamesResponseParams) Frame {
 	width := p.NameLength.Bytes()
-	cap := p.NameLength.MaxNamesPerMessage()
+	maxN := p.NameLength.MaxNamesPerMessage()
 	n := len(p.Names)
-	if n > cap {
-		n = cap
+	if n > maxN {
+		n = maxN
+	}
+	if p.needsExtended() {
+		payload := make([]byte, 0, 6+n*width)
+		payload = append(payload,
+			p.MatrixID,
+			p.LevelID,
+			byte(p.NameLength),
+			byte(p.FirstDestAssociationID/256),
+			byte(p.FirstDestAssociationID%256),
+			byte(n),
+		)
+		for i := 0; i < n; i++ {
+			payload = append(payload, packName(p.Names[i], width)...)
+		}
+		return Frame{ID: TxDestAssocNamesResponseExt, Payload: payload}
 	}
 	payload := make([]byte, 0, 5+n*width)
-	payload = append(payload, encodeMatrixLevel(p.MatrixID, p.LevelID))
-	payload = append(payload, byte(p.NameLength))
-	payload = append(payload, byte(p.FirstDestAssociationID/256))
-	payload = append(payload, byte(p.FirstDestAssociationID%256))
-	payload = append(payload, byte(n))
+	payload = append(payload,
+		encodeMatrixLevel(p.MatrixID, p.LevelID),
+		byte(p.NameLength),
+		byte(p.FirstDestAssociationID/256),
+		byte(p.FirstDestAssociationID%256),
+		byte(n),
+	)
 	for i := 0; i < n; i++ {
 		payload = append(payload, packName(p.Names[i], width)...)
 	}
 	return Frame{ID: TxDestAssocNamesResponse, Payload: payload}
 }
 
-// DecodeDestAssocNamesResponse parses tx 107.
+// DecodeDestAssocNamesResponse parses tx 107 (general) or tx 235
+// (extended) into the same logical struct.
 func DecodeDestAssocNamesResponse(f Frame) (DestAssocNamesResponseParams, error) {
-	if f.ID != TxDestAssocNamesResponse {
+	switch f.ID {
+	case TxDestAssocNamesResponse:
+		if len(f.Payload) < 5 {
+			return DestAssocNamesResponseParams{}, ErrShortPayload
+		}
+		m, l := decodeMatrixLevel(f.Payload[0])
+		n := NameLength(f.Payload[1])
+		if err := validateNameLength(n); err != nil {
+			return DestAssocNamesResponseParams{}, err
+		}
+		first := uint16(f.Payload[2])*256 + uint16(f.Payload[3])
+		count := int(f.Payload[4])
+		width := n.Bytes()
+		if len(f.Payload) < 5+count*width {
+			return DestAssocNamesResponseParams{}, fmt.Errorf("probel: tx 107 needs %d bytes, got %d",
+				5+count*width, len(f.Payload))
+		}
+		names := make([]string, count)
+		for i := 0; i < count; i++ {
+			off := 5 + i*width
+			names[i] = unpackName(f.Payload[off : off+width])
+		}
+		return DestAssocNamesResponseParams{
+			MatrixID:               m,
+			LevelID:                l,
+			NameLength:             n,
+			FirstDestAssociationID: first,
+			Names:                  names,
+		}, nil
+	case TxDestAssocNamesResponseExt:
+		if len(f.Payload) < 6 {
+			return DestAssocNamesResponseParams{}, ErrShortPayload
+		}
+		n := NameLength(f.Payload[2])
+		if err := validateNameLength(n); err != nil {
+			return DestAssocNamesResponseParams{}, err
+		}
+		first := uint16(f.Payload[3])*256 + uint16(f.Payload[4])
+		count := int(f.Payload[5])
+		width := n.Bytes()
+		if len(f.Payload) < 6+count*width {
+			return DestAssocNamesResponseParams{}, fmt.Errorf("probel: tx 235 needs %d bytes, got %d",
+				6+count*width, len(f.Payload))
+		}
+		names := make([]string, count)
+		for i := 0; i < count; i++ {
+			off := 6 + i*width
+			names[i] = unpackName(f.Payload[off : off+width])
+		}
+		return DestAssocNamesResponseParams{
+			MatrixID:               f.Payload[0],
+			LevelID:                f.Payload[1],
+			NameLength:             n,
+			FirstDestAssociationID: first,
+			Names:                  names,
+		}, nil
+	default:
 		return DestAssocNamesResponseParams{}, ErrWrongCommand
 	}
-	if len(f.Payload) < 5 {
-		return DestAssocNamesResponseParams{}, ErrShortPayload
-	}
-	m, l := decodeMatrixLevel(f.Payload[0])
-	n := NameLength(f.Payload[1])
-	if err := validateNameLength(n); err != nil {
-		return DestAssocNamesResponseParams{}, err
-	}
-	first := uint16(f.Payload[2])*256 + uint16(f.Payload[3])
-	count := int(f.Payload[4])
-	width := n.Bytes()
-	if len(f.Payload) < 5+count*width {
-		return DestAssocNamesResponseParams{}, fmt.Errorf("probel: tx 107 needs %d bytes, got %d",
-			5+count*width, len(f.Payload))
-	}
-	names := make([]string, count)
-	for i := 0; i < count; i++ {
-		off := 5 + i*width
-		names[i] = unpackName(f.Payload[off : off+width])
-	}
-	return DestAssocNamesResponseParams{
-		MatrixID:              m,
-		LevelID:               l,
-		NameLength:            n,
-		FirstDestAssociationID: first,
-		Names:                 names,
-	}, nil
 }


### PR DESCRIPTION
## Summary

Phase 3 of the per-cmd `needsExtended()` audit (issue #227). Two fixes to the Crosspoint Tally Dump form-selection per spec §3.3.10 (cmd 22 narrow byte) + §3.3.11 (cmd 23 narrow word) + §3.5.7 (cmd 151 ext word):

**1. tx 022 (narrow byte) was hardcoded.** Silently truncated `mtx > 15` / `lvl > 15` / `firstdst > 191` / `src > 191` via 4-bit packing or u8 range. Now auto-promotes to the **word form** (cmd 23) when ANY field exceeds the byte-form's spec ceiling. The word form itself promotes to the extended word form (cmd 151) via the existing word-codec branch — so the full **byte ? narrow word ? extended word** ladder is covered by a single `EncodeCrosspointTallyDumpByte` call.

**2. tx 023 (narrow word) had a bug.** A spurious `FirstDestinationID > 895` clause in `needsExtended()` didn't match spec. Per §3.3.11 the narrow word form supports the FULL 0-65535 range for `FirstDestinationID` and any `SourceID` via the DIV/MOD 256 split — ONLY the matrix/level packing differs between narrow word and extended word. Rule simplified to `MatrixID > 15 || LevelID > 15`.

**Important spec note**: the SW-P-08 spec defines NO extended-byte form (no cmd 150). The tracker #227 erroneously listed "extended 0x96" — that ID isn't declared in `codec/types.go` and isn't defined in the spec. The correct fix for byte form is auto-promotion to word, not adding a new ID.

Branch base: `main`. Independent of all in-flight PRs.

Refs #227, #226.

## Form-selection ladder (verified against spec)

| Trigger | Resulting wire form | Cmd ID |
| --- | --- | --- |
| matrix = 15 AND level = 15 AND firstdst = 191 AND all srcs = 191 | narrow byte | `0x16` (cmd 22) |
| matrix = 15 AND level = 15 AND (firstdst > 191 OR any src > 191) | narrow word | `0x17` (cmd 23) |
| matrix > 15 OR level > 15 (any dst/src range) | extended word | `0x97` (cmd 151) |

## Files changed

| File | Change |
| --- | --- |
| `codec/cmd_tx022_crosspoint_tally_dump_byte.go` | new `needsWordPromote()` + auto-promote branch routing through the word encoder |
| `codec/cmd_tx023_crosspoint_tally_dump_word.go` | `needsExtended()` rule simplified per spec §3.3.11; spurious `>895` dropped |
| `codec/cmd_tally_dump_extended_test.go` | new — boundary tests |

## Boundary tests (spec-cited byte tables)

- `TestTallyDumpByte_NarrowMin` — params at 0,0,0,[0,0,0] ? 0x16, 6-byte payload
- `TestTallyDumpByte_NarrowMax` — mtx=15, lvl=15, firstdst=191, srcs=[191,0,191] ? 0x16
- `TestTallyDumpByte_PromoteOnDst` — firstdst=192 ? 0x17 (narrow word)
- `TestTallyDumpByte_PromoteOnSrc` — src=200 in mid-array ? 0x17
- `TestTallyDumpByte_PromoteOnMatrix` — mtx=16 ? 0x97 (extended word, via byte?word?ext chain)
- `TestTallyDumpByte_PromoteOnLevel` — lvl=16 ? 0x97
- `TestTallyDumpWord_NarrowMaxStillNarrow` — mtx=15, lvl=15, dst=65535, srcs=[65535,0,65535] ? 0x17 (the spurious `>895` fix lock)
- `TestTallyDumpWord_PromoteOnMatrix` — mtx=16 ? 0x97 with spec-cited byte table
- `TestTallyDumpWord_ExtendedMax` — mtx=255, lvl=255, dst=65535, src=65535 ? 0x97
- `TestTallyDumpByte_DecodeRoundTrip` — verifies the byte decoder's round-trip

## Hard invariants verified

- [x] `internal/probel-sw08p/codec/` unchanged outside the two source files + the new test file — no `dhs/*` imports introduced
- [x] `needsExtended()` / `needsWordPromote()` cited to spec sections
- [x] `go build ./...` OK
- [x] `go vet ./...` OK
- [x] `golangci-lint run` 0 issues
- [x] `go test ./...` all OK (full repo); existing `TestTallyDumpByte_RoundTrip`, `TestTallyDumpByte_Framer`, `TestTallyDumpWord_General`, `TestTallyDumpWord_Extended` pass with the new rules

## Out of scope (separate sub-PRs under #227)

- Sub-PR 4: tx 113 Crosspoint Tie-Line Tally — verify ext pair in spec
- Sub-PR 5: boundary sweep across already-wired commands; spec-cite every `want []byte` in their existing tests