### PR TITLE
docs(probel-sw08p): tie-line family has no extended pair + boundary tests (advances #227)

### DIFF
--- a/internal/probel-sw08p/codec/cmd_rx112_crosspoint_tie_line_interrogate.go
+++ b/internal/probel-sw08p/codec/cmd_rx112_crosspoint_tie_line_interrogate.go
@@ -2,11 +2,19 @@ package codec
 
 // TieLineInterrogateParams: rx 112 CROSSPOINT TIE LINE INTERROGATE —
 // asks the matrix for the per-level tally of a destination association.
+// The matrix replies with tx 113 CROSSPOINT TIE LINE TALLY (one row
+// per destination level).
 //
-// Reference: SW-P-08 §3.2.28.
+// No extended pair — there is no cmd 240 in SW-P-08 Issue 30. The
+// narrow form is already wide enough: byte 1 is a FULL 8-bit matrix
+// byte (the spec quotes a device range of 0-19 but the wire field is
+// the full 0-255), and DestAssociationID is 16-bit (DIV/MOD 256). The
+// tie-line family does not need a needsExtended() method.
+//
+// Reference: SW-P-08 Issue 30 §3.2.28.
 type TieLineInterrogateParams struct {
-	MatrixID          uint8  // 0-19
-	DestAssociationID uint16 // u16
+	MatrixID          uint8  // wire range 0-255 (spec device limit 0-19)
+	DestAssociationID uint16 // 0-65535 (DIV/MOD 256)
 }
 
 // EncodeTieLineInterrogate packs rx 112.

--- a/internal/probel-sw08p/codec/cmd_tie_line_boundary_test.go
+++ b/internal/probel-sw08p/codec/cmd_tie_line_boundary_test.go
@@ -1,0 +1,149 @@
+package codec
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+// Boundary tests for the tie-line pair (rx 112 / tx 113). Per SW-P-08
+// Issue 30 §3.2.28 + §3.3.23 the tie-line family has NO extended pair
+// in the spec — both rx 112 (cmd 0x70) and tx 113 (cmd 0x71) already
+// use full-byte matrix and 16-bit IDs in their narrow form. These
+// tests pin that the wire form correctly carries the full type range
+// (matrix 0-255, dst_assoc 0-65535, per-source matrix/level 0-255,
+// src 0-65535) and round-trips faithfully.
+
+// --- rx 112 ----------------------------------------------------------
+
+func TestTieLineInterrogate_Min(t *testing.T) {
+	in := TieLineInterrogateParams{MatrixID: 0, DestAssociationID: 0}
+	f := EncodeTieLineInterrogate(in)
+	if f.ID != RxCrosspointTieLineInterrogate {
+		t.Errorf("ID = %#x; want 0x70", f.ID)
+	}
+	want := []byte{0x00, 0x00, 0x00}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+}
+
+func TestTieLineInterrogate_FullByteMatrix(t *testing.T) {
+	// The spec quotes a device range of 0-19 but the wire byte is full
+	// 8-bit, so the codec must accept and emit any uint8 value verbatim.
+	in := TieLineInterrogateParams{MatrixID: 200, DestAssociationID: 0}
+	f := EncodeTieLineInterrogate(in)
+	if f.ID != RxCrosspointTieLineInterrogate {
+		t.Errorf("matrix=200 ID = %#x; want 0x70 (no extended pair)", f.ID)
+	}
+	if f.Payload[0] != 200 {
+		t.Errorf("matrix byte = %#x; want 200", f.Payload[0])
+	}
+	back, err := DecodeTieLineInterrogate(f)
+	if err != nil || back != in {
+		t.Errorf("round-trip: got %+v err %v", back, err)
+	}
+}
+
+func TestTieLineInterrogate_Max(t *testing.T) {
+	in := TieLineInterrogateParams{MatrixID: 255, DestAssociationID: 65535}
+	f := EncodeTieLineInterrogate(in)
+	if f.ID != RxCrosspointTieLineInterrogate {
+		t.Fatalf("ID = %#x; want 0x70", f.ID)
+	}
+	want := []byte{0xFF, 0xFF, 0xFF}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+	back, err := DecodeTieLineInterrogate(f)
+	if err != nil || back != in {
+		t.Errorf("round-trip: got %+v err %v", back, err)
+	}
+}
+
+// --- tx 113 ----------------------------------------------------------
+
+func TestTieLineTally_NoSources(t *testing.T) {
+	// Spec §3.3.23: the per-source quad is repeated `Num Srcs` times
+	// (byte 4). An empty source list is legal — header is 4 bytes,
+	// payload total is 4 bytes.
+	in := TieLineTallyParams{DestMatrixID: 0, DestAssociationID: 0, Sources: nil}
+	f := EncodeTieLineTally(in)
+	if f.ID != TxCrosspointTieLineTally {
+		t.Errorf("ID = %#x; want 0x71", f.ID)
+	}
+	want := []byte{0x00, 0x00, 0x00, 0x00}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+	back, err := DecodeTieLineTally(f)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if back.DestMatrixID != 0 || back.DestAssociationID != 0 || len(back.Sources) != 0 {
+		t.Errorf("round-trip mismatch: %+v", back)
+	}
+}
+
+func TestTieLineTally_FullByteMatrix(t *testing.T) {
+	// All matrix-id slots are full 8-bit bytes — DestMatrixID and the
+	// per-source MatrixID. Pin that the codec accepts values past the
+	// spec device limit of 19 verbatim.
+	in := TieLineTallyParams{
+		DestMatrixID:      200,
+		DestAssociationID: 1234,
+		Sources: []TieLineSource{
+			{MatrixID: 200, LevelID: 0, SourceID: 50},
+			{MatrixID: 200, LevelID: 1, SourceID: 51},
+		},
+	}
+	f := EncodeTieLineTally(in)
+	if f.ID != TxCrosspointTieLineTally {
+		t.Errorf("ID = %#x; want 0x71", f.ID)
+	}
+	want := []byte{
+		200, 0x04, 0xD2, 0x02, // dest matrix=200, dst_assoc=1234, num srcs=2
+		200, 0, 0x00, 50, // src 0
+		200, 1, 0x00, 51, // src 1
+	}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+	back, err := DecodeTieLineTally(f)
+	if err != nil || !reflect.DeepEqual(back, in) {
+		t.Errorf("round-trip: got %+v err %v", back, err)
+	}
+}
+
+func TestTieLineTally_Max(t *testing.T) {
+	// Hammer every numeric field at the type maximum the wire form
+	// supports. Matrix 0xFF, dst_assoc 0xFFFF, per-source matrix/level
+	// 0xFF, src 0xFFFF.
+	in := TieLineTallyParams{
+		DestMatrixID:      255,
+		DestAssociationID: 65535,
+		Sources: []TieLineSource{
+			{MatrixID: 255, LevelID: 255, SourceID: 65535},
+		},
+	}
+	f := EncodeTieLineTally(in)
+	if f.ID != TxCrosspointTieLineTally {
+		t.Fatalf("ID = %#x; want 0x71", f.ID)
+	}
+	want := []byte{0xFF, 0xFF, 0xFF, 0x01, 0xFF, 0xFF, 0xFF, 0xFF}
+	if !bytes.Equal(f.Payload, want) {
+		t.Errorf("payload = %X; want %X", f.Payload, want)
+	}
+	back, err := DecodeTieLineTally(f)
+	if err != nil || !reflect.DeepEqual(back, in) {
+		t.Errorf("round-trip: got %+v err %v", back, err)
+	}
+}
+
+func TestTieLineTally_DecodeShortPayload(t *testing.T) {
+	// Header claims 1 source, but only 2 bytes follow — short.
+	short := Frame{ID: TxCrosspointTieLineTally, Payload: []byte{0x01, 0x00, 0x00, 0x01, 0x00, 0x00}}
+	if _, err := DecodeTieLineTally(short); err == nil {
+		t.Error("expected error on short payload")
+	}
+}

--- a/internal/probel-sw08p/codec/cmd_tx113_crosspoint_tie_line_tally.go
+++ b/internal/probel-sw08p/codec/cmd_tx113_crosspoint_tie_line_tally.go
@@ -14,7 +14,14 @@ type TieLineSource struct {
 // TieLineTallyParams: tx 113 CROSSPOINT TIE LINE TALLY. One row per
 // destination level.
 //
-// Reference: SW-P-08 §3.3.23.
+// No extended pair — there is no cmd 241 in SW-P-08 Issue 30. The
+// narrow form is already wide enough: byte 1 is a FULL 8-bit matrix
+// byte (not 4-bit packed like other commands), and DestAssociationID
+// + per-source SourceID are 16-bit (DIV/MOD 256). Per-source Matrix
+// and Level are also full 8-bit bytes. The tie-line family does not
+// need a needsExtended() method.
+//
+// Reference: SW-P-08 Issue 30 §3.3.23.
 type TieLineTallyParams struct {
 	DestMatrixID      uint8
 	DestAssociationID uint16


### PR DESCRIPTION
## Summary

Phase 4 of the per-cmd `needsExtended()` audit (issue #227). Verifies that the tie-line pair (rx 112 / tx 113) has **NO extended counterpart in SW-P-08 Issue 30** and locks the rationale into the codec source comments + adds boundary tests proving the narrow form already carries the full type range.

Branch base: `main`. Independent of all in-flight PRs.

Refs #227, #226.

## Spec verified — no extended pair

Searched §3 of Issue 30. No cmd 240 (would-be rx 112 ext) and no cmd 241 (would-be tx 113 ext) exist. Spec sections §3.2.28 (rx 112) + §3.3.23 (tx 113) define the only forms; both already use:

| Field | Wire form |
| --- | --- |
| rx 112 byte 1: Matrix | full 8-bit (spec device limit 0-19, wire 0-255) |
| rx 112 bytes 2-3: DestAssociationID | 16-bit DIV/MOD 256 |
| tx 113 byte 1: DestMatrix | full 8-bit |
| tx 113 bytes 2-3: DestAssociationID | 16-bit DIV/MOD 256 |
| tx 113 per-source quad bytes 5..8 (repeated) | 8-bit Matrix, 8-bit Level, 16-bit SourceID via DIV/MOD 256 |

There's no 4-bit packing here that would benefit from extended-form promotion — narrow tie-line is the wire form for the full range. The tie-line family does NOT need a `needsExtended()` method.

## Files changed

| File | Change |
| --- | --- |
| `codec/cmd_rx112_crosspoint_tie_line_interrogate.go` | struct comment updated: explicit "no extended pair" note + corrected field range comments |
| `codec/cmd_tx113_crosspoint_tie_line_tally.go` | struct comment updated with same "no extended pair" rationale |
| `codec/cmd_tie_line_boundary_test.go` | new — boundary tests |

No encoder/decoder semantics changed.

## Boundary tests (spec-cited byte tables)

- `TestTieLineInterrogate_Min` — params at 0,0 ? 0x70, 3-byte payload
- `TestTieLineInterrogate_FullByteMatrix` — matrix=200 (past spec device limit) ? still 0x70 with full byte preserved verbatim
- `TestTieLineInterrogate_Max` — matrix=255, dst_assoc=65535 ? 0x70 with spec-cited byte table
- `TestTieLineTally_NoSources` §0 sources legal, 4-byte header only
- `TestTieLineTally_FullByteMatrix` — matrix=200 across all matrix slots
- `TestTieLineTally_Max` — every numeric field at type max ? spec-cited byte table
- `TestTieLineTally_DecodeShortPayload` — header claims 1 source but body too short ? decode error

## Hard invariants verified

- [x] `internal/probel-sw08p/codec/` unchanged outside the two source files (comment-only) + the new test file — no `dhs/*` imports introduced; no encoder/decoder semantics changed
- [x] `go build ./...` OK
- [x] `go vet ./...` OK
- [x] `golangci-lint run` 0 issues
- [x] `go test ./...` all OK (full repo); existing `TestTieLineInterrogateRoundtrip` + `TestTieLineTallyRoundtrip` unaffected

## Out of scope (separate sub-PR under #227)

- Sub-PR 5: boundary sweep across the already-wired commands (rx 001 / rx 002 / rx 010 / rx 012 / rx 014 / rx 019 / rx 021 / tx 003 / tx 004 / tx 011 / tx 020 / tx 023); spec-cite every `want []byte` in their existing tests