### PR TITLE
fix(probel-sw02p): TestEmitExtendedProtectTallyDumpFanout port-collision flake (refs #232)

### DIFF
--- a/internal/probel-sw02p/provider/cmd_tally_dump_test.go
+++ b/internal/probel-sw02p/provider/cmd_tally_dump_test.go
@@ -19,23 +19,27 @@ func TestEmitExtendedProtectTallyDumpFanout(t *testing.T) {
 	srv := newServer(slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
 	defer func() { _ = srv.Stop() }()
 
+	// Pre-bind the listener so the server picks the same address with
+	// no close-and-rebind race. CI parallel runs were intermittently
+	// hitting "bind: address already in use" with the close-and-rebind
+	// pattern.
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
+	addr := ln.Addr().String()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	go func() {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		if serr := srv.Serve(ctx, ln.Addr().String()); serr != nil {
+		if serr := srv.serveListener(ctx, ln); serr != nil {
 			t.Logf("server: %v", serr)
 		}
 	}()
-	_ = ln.Close()
 
 	deadline := time.Now().Add(2 * time.Second)
 	var conn net.Conn
 	for time.Now().Before(deadline) {
-		c, derr := net.Dial("tcp", ln.Addr().String())
+		c, derr := net.Dial("tcp", addr)
 		if derr == nil {
 			conn = c
 			break

--- a/internal/probel-sw02p/provider/server.go
+++ b/internal/probel-sw02p/provider/server.go
@@ -114,6 +114,14 @@ func (s *server) Serve(ctx context.Context, addr string) error {
 	if err != nil {
 		return fmt.Errorf("probel-sw02p provider: listen %q: %w", addr, err)
 	}
+	return s.serveListener(ctx, ln)
+}
+
+// serveListener accepts client sessions on a pre-bound listener until
+// ctx is cancelled. Used by Serve once the listener is open and by
+// in-process tests that want to skip the close-then-rebind race
+// window of the addr-based path.
+func (s *server) serveListener(ctx context.Context, ln net.Listener) error {
 	s.mu.Lock()
 	s.listener = ln
 	s.mu.Unlock()
@@ -133,7 +141,7 @@ func (s *server) Serve(ctx context.Context, addr string) error {
 		s.mu.Unlock()
 	}()
 
-	err = s.acceptLoop(ctx, ln)
+	err := s.acceptLoop(ctx, ln)
 	close(s.stopped)
 	if errors.Is(err, net.ErrClosed) || errors.Is(err, context.Canceled) {
 		return nil


### PR DESCRIPTION
## Summary

Pre-existing flake observed on PR #232's rhel9 + rocky9 jobs (and earlier on other PRs intermittently). The test bound a listener on `127.0.0.1:0`, closed it to recover the address string, then asked the server to re-bind. Under parallel CI runs the OS sometimes handed the freed port to another process between `Close` and re-`Listen`, surfacing as `bind: address already in use`.

Per `feedback_test_sync_over_timeout`: fix the race, don't bump sleeps. Per `feedback_bugs_never_noise`: file + fix.

Branch base: `main`. Independent of all in-flight PRs.

Refs #232.

## Refactor

| File | Change |
| --- | --- |
| `internal/probel-sw02p/provider/server.go` | extract the accept-loop body into a new unexported `serveListener(ctx, ln)`; exported `Serve(ctx, addr)` is unchanged externally — it now binds the addr and delegates to `serveListener`. No production behaviour change |
| `internal/probel-sw02p/provider/cmd_tally_dump_test.go` | pre-bind the listener with `net.Listen("tcp", "127.0.0.1:0")` and pass it directly into `srv.serveListener`. Race window between `Close` and re-`Listen` is gone |

## Verified locally

- [x] `go build ./...` OK
- [x] `go vet ./...` OK
- [x] `golangci-lint run` 0 issues
- [x] `go test ./...` all OK (full repo)
- [x] `go test ./internal/probel-sw02p/provider/ -run TestEmitExtendedProtectTallyDumpFanout -count=10` PASS 10/10 (the flake reproduced ~1/3 runs on the prior pattern; now stable)

## Out of scope

- `TestKeepaliveAutoResponder` (probel-sw08p/consumer) is a different, also-pre-existing timing flake observed on PR #228. Separate fix tracker per memory `feedback_test_sync_over_timeout`.