### PR TITLE
fix(probel-sw08p): keepalive responder pre-registered before reader goroutine (closes #234)

### DIFF
--- a/internal/probel-sw08p/codec/client.go
+++ b/internal/probel-sw08p/codec/client.go
@@ -224,6 +224,16 @@ type ClientConfig struct {
 	// OnNoACK fires when a reply frame arrives before the peer's ACK.
 	// Spec deviation per SW-P-08 §2; frame accepted regardless.
 	OnNoACK func()
+
+	// OnEvent is an async-event listener installed BEFORE the reader
+	// goroutine starts, so frames arriving immediately after Dial
+	// returns are not lost to a Subscribe-vs-readLoop race. The Client
+	// pointer is the same one Dial returns; callers typically use it
+	// to write a reply (e.g. keepalive auto-response) without going
+	// through a captured-by-closure variable that may still be unset
+	// when the reader fires. Subscribe remains the right surface for
+	// listeners attached after the session is established.
+	OnEvent func(c *Client, f Frame)
 }
 
 // Dial opens a TCP connection to addr (host:port) and starts the reader
@@ -302,7 +312,7 @@ func newClient(conn net.Conn, logger *slog.Logger, cfg ClientConfig) *Client {
 	if max <= 0 {
 		max = DefaultMaxAttempts
 	}
-	return &Client{
+	c := &Client{
 		logger:      logger,
 		conn:        conn,
 		readerDone:  make(chan struct{}),
@@ -317,6 +327,14 @@ func newClient(conn net.Conn, logger *slog.Logger, cfg ClientConfig) *Client {
 		onRetry:     cfg.OnRetry,
 		onNoACK:     cfg.OnNoACK,
 	}
+	// Pre-register OnEvent BEFORE Dial spawns the reader goroutine, so
+	// the very first inbound frame can never lose to a post-Dial
+	// Subscribe (refs #234).
+	if cfg.OnEvent != nil {
+		onEv := cfg.OnEvent
+		c.readers = append(c.readers, func(f Frame) { onEv(c, f) })
+	}
+	return c
 }
 
 // Close stops the reader goroutine and releases the socket. Safe to

--- a/internal/probel-sw08p/codec/client_test.go
+++ b/internal/probel-sw08p/codec/client_test.go
@@ -115,3 +115,58 @@ func TestClientCloseWakesPending(t *testing.T) {
 	}
 	_ = client.Close()
 }
+
+// TestClientOnEventFiresBeforeSubscribe proves that ClientConfig.OnEvent is
+// wired in before the reader goroutine starts: a frame already on the wire
+// when Dial returns is delivered to OnEvent without a separate Subscribe
+// call. Pinned regression for #234 (keepalive Subscribe vs reader race).
+func TestClientOnEventFiresBeforeSubscribe(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	// Server side: accept + immediately write a keepalive ping. The
+	// ping is on the wire before the client's reader goroutine starts.
+	go func() {
+		c, aerr := ln.Accept()
+		if aerr != nil {
+			return
+		}
+		defer func() { _ = c.Close() }()
+		_, _ = c.Write(Pack(EncodeKeepaliveRequest()))
+		// Hold the socket open so the client's reader can drain it.
+		time.Sleep(2 * time.Second)
+	}()
+
+	got := make(chan Frame, 1)
+	disable := false
+	cfg := ClientConfig{
+		WireHexLog: &disable,
+		OnEvent: func(c *Client, f Frame) {
+			select {
+			case got <- f:
+			default:
+			}
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cli, err := Dial(ctx, ln.Addr().String(), logger, cfg)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer func() { _ = cli.Close() }()
+
+	select {
+	case f := <-got:
+		if f.ID != TxAppKeepaliveRequest {
+			t.Fatalf("OnEvent got cmd %02x; want %02x", f.ID, TxAppKeepaliveRequest)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnEvent never fired for pre-Dial wire frame")
+	}
+}

--- a/internal/probel-sw08p/consumer/keepalive.go
+++ b/internal/probel-sw08p/consumer/keepalive.go
@@ -4,20 +4,23 @@ import (
 	"dhs/internal/probel-sw08p/codec"
 )
 
-// installKeepaliveAutoResponder subscribes to the shared client's async
-// event stream and auto-replies to any TxAppKeepaliveRequest (0x11) with
-// an RxAppKeepaliveResponse (0x22). Kept as a passive listener — the
-// response goes out via client.Write (bypass-retry, like the reader's
-// own ACK/NAK emission), so it does not collide with any in-flight
-// Send's pending waiter.
+// keepaliveAutoResponder returns a codec.ClientConfig.OnEvent listener
+// that auto-replies to any TxAppKeepaliveRequest (0x11) with an
+// RxAppKeepaliveResponse (0x22). Wired through ClientConfig.OnEvent so
+// the listener is registered BEFORE the reader goroutine starts —
+// guarantees the very first inbound keepalive is never lost to a
+// post-Dial Subscribe race (refs #234).
 //
-// Rationale: the TS matrix emulator pings controllers every ~30 s; a
-// controller that never responds is dropped. Auto-response keeps the
-// session alive without bothering application code.
+// The response goes out via Client.Write (bypass-retry, like the
+// reader's own ACK/NAK emission), so it does not collide with any
+// in-flight Send's pending waiter.
 //
-// Reference: TS internal/probel-sw08p/assets/smh-probelsw08p/src/command/application-keep-alive/.
-func (p *Plugin) installKeepaliveAutoResponder(cli *codec.Client) {
-	cli.Subscribe(func(f codec.Frame) {
+// Rationale: matrices (e.g. real SW-P-08 controllers and the in-tree
+// reference emulator) ping controllers every ~30 s; a controller that
+// never responds is dropped. Auto-response keeps the session alive
+// without bothering application code.
+func (p *Plugin) keepaliveAutoResponder() func(*codec.Client, codec.Frame) {
+	return func(cli *codec.Client, f codec.Frame) {
 		if f.ID != codec.TxAppKeepaliveRequest {
 			return
 		}
@@ -28,5 +31,5 @@ func (p *Plugin) installKeepaliveAutoResponder(cli *codec.Client) {
 			p.logger.Warn("probel keepalive response write failed",
 				"err", err.Error())
 		}
-	})
+	}
 }

--- a/internal/probel-sw08p/consumer/plugin.go
+++ b/internal/probel-sw08p/consumer/plugin.go
@@ -224,6 +224,7 @@ func (p *Plugin) Connect(ctx context.Context, ip string, port int) error {
 				met.ObserveRx(len(b))
 			}
 		},
+		OnEvent: p.keepaliveAutoResponder(),
 	}
 	if p.recorder != nil {
 		rec := p.recorder
@@ -247,7 +248,6 @@ func (p *Plugin) Connect(ctx context.Context, ip string, port int) error {
 	p.port = port
 	p.profile = prof
 	p.metricsConn = met
-	p.installKeepaliveAutoResponder(cli)
 	p.logger.Info("probel connected",
 		slog.String("host", ip),
 		slog.Int("port", port),


### PR DESCRIPTION
## Summary

- `codec.ClientConfig` gains `OnEvent func(*Client, Frame)`; `newClient` pre-registers it in `c.readers` BEFORE `go c.readLoop()` spawns. No race window between reader-goroutine startup and post-Dial `Subscribe`.
- `Plugin.Connect` wires the keepalive responder via `cfg.OnEvent` instead of post-Dial `Subscribe`. `installKeepaliveAutoResponder` becomes `keepaliveAutoResponder()` returning the closure.
- New regression `TestClientOnEventFiresBeforeSubscribe` (codec) pins the contract: a frame already on the wire when Dial returns is delivered to OnEvent without any post-Dial Subscribe.
- Existing `Subscribe` API unchanged — still used by codec/provider tests where ordering is deterministic.

## Why

`TestKeepaliveAutoResponder` flaked on macos-latest (PR #228 CI). Root cause was the consumer-side mirror of the race already documented in `feedback_test_sync_over_timeout.md`: `Dial` spawned the reader before `installKeepaliveAutoResponder` could `Subscribe`; if the peer wrote a keepalive ping in that window, the reader fanned out to zero listeners and the frame was silently dropped.

Per `feedback_test_sync_over_timeout` and `feedback_no_timeout_in_code`: do not bump the deadline, register the listener BEFORE the reader can fire.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` whole tree green
- [x] `go test -count=500 -run TestKeepaliveAutoResponder ./internal/probel-sw08p/consumer` 500/500 green on Windows
- [x] `go test -count=200 -run TestClientOnEventFiresBeforeSubscribe|TestKeepaliveAutoResponder ./internal/probel-sw08p/...` green
- [ ] CI exercises `-race` on ubuntu / macos / windows / rhel9 / rocky9

Closes #234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)