### PR TITLE
fix(cli): acp1 watch label-cache keyed by (group, id), not id (closes #236)

### DIFF
--- a/cmd/dhs/cmd_watch.go
+++ b/cmd/dhs/cmd_watch.go
@@ -41,17 +41,21 @@ func runWatch(ctx context.Context, args []string) error {
 	defer cleanup()
 
 	// Load disk cache for instant label/unit resolution while walk runs.
-	labelCache := map[int]string{} // objID → label
-	unitCache := map[int]string{}  // objID → unit
+	// Key by watchCacheKey so ACP1 groups that re-use the same object-id
+	// space (control / status / alarm / identity / file / frame all
+	// addressable as 0..N within one slot) don't collide. (refs #236)
+	labelCache := map[string]string{}
+	unitCache := map[string]string{}
 	if treeStore != nil && *slot >= 0 {
 		if snap, lerr := treeStore.Load(host, *slot); lerr == nil && snap != nil {
 			for _, sd := range snap.Slots {
 				for _, o := range sd.Objects {
+					k := watchCacheKey(o.Group, o.ID)
 					if o.Label != "" {
-						labelCache[o.ID] = o.Label
+						labelCache[k] = o.Label
 					}
 					if o.Unit != "" {
-						unitCache[o.ID] = o.Unit
+						unitCache[k] = o.Unit
 					}
 				}
 			}
@@ -127,7 +131,7 @@ func runWatch(ctx context.Context, args []string) error {
 			label := ev.Label
 			src := "live"
 			if label == "" {
-				if cached, ok := labelCache[ev.ID]; ok {
+				if cached, ok := labelCache[watchCacheKey(ev.Group, ev.ID)]; ok {
 					label = cached
 					src = "cache"
 				}
@@ -173,7 +177,7 @@ func runWatch(ctx context.Context, args []string) error {
 
 			// Parameter event — value column.
 			valStr := formatValueInline(ev.Value)
-			if unit, ok := unitCache[ev.ID]; ok && unit != "" {
+			if unit, ok := unitCache[watchCacheKey(ev.Group, ev.ID)]; ok && unit != "" {
 				valStr += " " + unit
 			}
 			// Live description + access + freshness + changes tag.
@@ -202,4 +206,15 @@ func runWatch(ctx context.Context, args []string) error {
 			)
 		}
 	}
+}
+
+// watchCacheKey builds a stable per-(group, id) cache key for label and
+// unit lookups in the watch verb. ACP1 groups (control / status / alarm
+// / identity / file / frame) re-use the same small object-id space within
+// one slot, so a flat ID-only map collides distinct labels — e.g. slot 1
+// has both control.0=IO-Ctrl and status.0=sInp1 (refs #236). ACP2 has no
+// Group concept; the empty group reduces the key to ".N" and stays
+// unique per slot.
+func watchCacheKey(group string, id int) string {
+	return fmt.Sprintf("%s.%d", group, id)
 }

--- a/cmd/dhs/cmd_watch_test.go
+++ b/cmd/dhs/cmd_watch_test.go
@@ -1,0 +1,53 @@
+package main
+
+import "testing"
+
+// TestWatchCacheKey_DistinguishesGroupsForSharedID pins the fix for #236:
+// ACP1 groups (control / status / alarm / identity / file / frame) re-use
+// the same object-id space within one slot, so a flat ID-only cache map
+// flattens distinct labels onto the same key. The watch verb keys by
+// "<group>.<id>" so a live announce on s1.control.0 (IO-Ctrl) is no longer
+// mis-labelled with the s1.status.0 entry (sInp1) loaded from disk cache.
+func TestWatchCacheKey_DistinguishesGroupsForSharedID(t *testing.T) {
+	ctrl := watchCacheKey("control", 0)
+	stat := watchCacheKey("status", 0)
+	if ctrl == stat {
+		t.Fatalf("cache key collision: control.0 == status.0 (%q == %q)", ctrl, stat)
+	}
+
+	cache := map[string]string{
+		watchCacheKey("control", 0):  "IO-Ctrl",
+		watchCacheKey("status", 0):   "sInp1",
+		watchCacheKey("control", 3):  "#Inp_SelA",
+		watchCacheKey("status", 3):   "sInp1_WSS-Extd",
+		watchCacheKey("control", 10): "#Out-Mode",
+		watchCacheKey("status", 10):  "sInp3",
+	}
+
+	cases := []struct {
+		group string
+		id    int
+		want  string
+	}{
+		{"control", 0, "IO-Ctrl"},
+		{"status", 0, "sInp1"},
+		{"control", 3, "#Inp_SelA"},
+		{"status", 3, "sInp1_WSS-Extd"},
+		{"control", 10, "#Out-Mode"},
+		{"status", 10, "sInp3"},
+	}
+	for _, c := range cases {
+		if got := cache[watchCacheKey(c.group, c.id)]; got != c.want {
+			t.Errorf("lookup %s.%d: got %q want %q", c.group, c.id, got, c.want)
+		}
+	}
+}
+
+// TestWatchCacheKey_ACP2EmptyGroup verifies the same helper stays correct
+// for ACP2 events (no group concept; ev.Group is empty). Distinct ids
+// must yield distinct keys.
+func TestWatchCacheKey_ACP2EmptyGroup(t *testing.T) {
+	if a, b := watchCacheKey("", 1), watchCacheKey("", 2); a == b {
+		t.Fatalf("ACP2 ids collapsed: id=1 key %q == id=2 key %q", a, b)
+	}
+}


### PR DESCRIPTION
## Summary

- `cmd/dhs/cmd_watch.go` — extract `watchCacheKey(group, id)`; rewrite cache load + lookup paths to key by `<group>.<id>` instead of `<id>` alone.
- `cmd/dhs/cmd_watch_test.go` — new regression test pinning the 6-pair `(control, status)` clash from real slot-1 data, plus an ACP2 empty-group sanity case.

## Why

ACP1 groups (control / status / alarm / identity / file / frame) re-use the same small object-id space within one slot. The label / unit caches were `map[int]string{}` keyed by ID alone, so an alphabetical snapshot load made `status.0=sInp1` overwrite `control.0=IO-Ctrl`. Live announces on `s1.control.0` then printed `sInp1` instead of `IO-Ctrl` whenever the live event lacked an inline plugin-resolved label and fell through to the cache.

Spotted live on Synapse Simulator (`10.6.239.113`):
```
21:07:10  s1.control.0   sInp1   ---  cache  raw(1)   <- wrong, should be IO-Ctrl
```

After fix:
```
21:16:56  s1.control.0   IO-Ctrl  ---  live   "GPI-B" (idx 3)   <- correct
```

ACP2 has no Group concept; empty `ev.Group` reduces the key to `.N` and stays unique within a slot — no behaviour change.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` whole tree green
- [x] `go test -run TestWatchCacheKey ./cmd/dhs/` green
- [x] Live verification against Synapse Simulator: announce on `s1.control.0` prints `IO-Ctrl`

Closes #236.