### PR TITLE
feat(cli): acp1 watch emits per-slot frame-status delta (closes #239)

### DIFF
--- a/cmd/dhs/cmd_watch.go
+++ b/cmd/dhs/cmd_watch.go
@@ -122,6 +122,12 @@ func runWatch(ctx context.Context, args []string) error {
 	fmt.Printf("%-8s  %-18s  %-30s  %-20s  %-3s  %-7s  value\n",
 		"time", "oid", "path", "label", "acc", "fr")
 	fmt.Println(strings.Repeat("-", 117))
+
+	// prevFrame remembers the last frame-status slice so we can emit
+	// per-slot deltas instead of dumping the full 31-slot strip on every
+	// announce. Kept slot-list-empty until the first frame event arrives.
+	var prevFrame []protocol.SlotStatus
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -175,6 +181,45 @@ func runWatch(ctx context.Context, args []string) error {
 				continue
 			}
 
+			// Frame-status announce — emit per-slot deltas instead of
+			// dumping the full 31-slot strip every time. First event of
+			// the session prints a baseline; subsequent events with no
+			// change are suppressed entirely. (refs #239)
+			if ev.Value.Kind == protocol.KindFrame {
+				cur := ev.Value.SlotStatus
+				ts := ev.Timestamp.Format("15:04:05")
+				fr := ev.Freshness
+				if fr == "" {
+					fr = src
+				}
+				if prevFrame == nil {
+					fmt.Printf("%s  %-18s  %-30s  %-20s  %-3s  %-7s  %s\n",
+						ts,
+						truncate(oid, 18),
+						truncate(ev.Path, 30),
+						truncate(label, 20),
+						accessStr(ev.Access),
+						fr,
+						"baseline "+formatFrameStatus(cur),
+					)
+				} else {
+					for _, c := range frameStatusDelta(prevFrame, cur) {
+						fmt.Printf("%s  %-18s  %-30s  %-20s  %-3s  %-7s  %s\n",
+							ts,
+							truncate(oid, 18),
+							truncate(ev.Path, 30),
+							truncate(label, 20),
+							accessStr(ev.Access),
+							fr,
+							c,
+						)
+					}
+					// Silent on no-change re-broadcasts.
+				}
+				prevFrame = append(prevFrame[:0], cur...)
+				continue
+			}
+
 			// Parameter event — value column.
 			valStr := formatValueInline(ev.Value)
 			if unit, ok := unitCache[watchCacheKey(ev.Group, ev.ID)]; ok && unit != "" {
@@ -206,6 +251,36 @@ func runWatch(ctx context.Context, args []string) error {
 			)
 		}
 	}
+}
+
+// frameStatusDelta returns one human-readable transition line per slot
+// where prev[i] != cur[i]. The caller is expected to emit a baseline
+// line for the first observation (when prev is nil/empty); this helper
+// returns no entries in that case so the caller can branch cleanly.
+// Length mismatches between prev and cur are tolerated by treating the
+// missing positions as SlotNoCard. (refs #239)
+func frameStatusDelta(prev, cur []protocol.SlotStatus) []string {
+	if len(prev) == 0 {
+		return nil
+	}
+	n := len(cur)
+	if len(prev) > n {
+		n = len(prev)
+	}
+	var out []string
+	for i := 0; i < n; i++ {
+		var oldS, newS protocol.SlotStatus
+		if i < len(prev) {
+			oldS = prev[i]
+		}
+		if i < len(cur) {
+			newS = cur[i]
+		}
+		if oldS != newS {
+			out = append(out, fmt.Sprintf("slot %d: %s -> %s", i, oldS, newS))
+		}
+	}
+	return out
 }
 
 // watchCacheKey builds a stable per-(group, id) cache key for label and

--- a/cmd/dhs/cmd_watch_test.go
+++ b/cmd/dhs/cmd_watch_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"dhs/internal/protocol"
+)
 
 // TestWatchCacheKey_DistinguishesGroupsForSharedID pins the fix for #236:
 // ACP1 groups (control / status / alarm / identity / file / frame) re-use
@@ -49,5 +53,84 @@ func TestWatchCacheKey_DistinguishesGroupsForSharedID(t *testing.T) {
 func TestWatchCacheKey_ACP2EmptyGroup(t *testing.T) {
 	if a, b := watchCacheKey("", 1), watchCacheKey("", 2); a == b {
 		t.Fatalf("ACP2 ids collapsed: id=1 key %q == id=2 key %q", a, b)
+	}
+}
+
+// TestFrameStatusDelta_BaselineThenSingleChange covers the common watch
+// flow: first event seeds the baseline (no transitions emitted, caller
+// prints baseline), second event with one slot delta emits one line.
+func TestFrameStatusDelta_BaselineThenSingleChange(t *testing.T) {
+	// Helper using the protocol's SlotStatus constants directly.
+	P := protocol.SlotPresent
+	N := protocol.SlotNoCard
+	U := protocol.SlotPowerUp
+
+	// First call: prev nil → no transitions returned (baseline path).
+	if got := frameStatusDelta(nil, []protocol.SlotStatus{P, N, N, P}); len(got) != 0 {
+		t.Errorf("baseline: got %d transitions, want 0: %v", len(got), got)
+	}
+
+	// Single slot transition: slot 2 N → U.
+	got := frameStatusDelta(
+		[]protocol.SlotStatus{P, N, N, P},
+		[]protocol.SlotStatus{P, N, U, P},
+	)
+	if len(got) != 1 {
+		t.Fatalf("got %d transitions, want 1: %v", len(got), got)
+	}
+	if got[0] != "slot 2: no_card -> power_up" {
+		t.Errorf("got %q, want %q", got[0], "slot 2: no_card -> power_up")
+	}
+}
+
+// TestFrameStatusDelta_NoChange covers re-broadcast suppression: same
+// strip in/out yields zero transitions so watch prints nothing.
+func TestFrameStatusDelta_NoChange(t *testing.T) {
+	strip := []protocol.SlotStatus{
+		protocol.SlotPresent, protocol.SlotPresent, protocol.SlotNoCard,
+	}
+	if got := frameStatusDelta(strip, strip); len(got) != 0 {
+		t.Errorf("idempotent re-broadcast emitted %d transitions: %v", len(got), got)
+	}
+}
+
+// TestFrameStatusDelta_FullCycle replays the live 6-state cycle the user
+// observed on slot 19 (no_card → power_up → error → removed → boot →
+// present) to lock the slot-only diff output.
+func TestFrameStatusDelta_FullCycle(t *testing.T) {
+	mkStrip := func(slot19 protocol.SlotStatus) []protocol.SlotStatus {
+		s := make([]protocol.SlotStatus, 31)
+		s[0] = protocol.SlotPresent
+		s[1] = protocol.SlotPresent
+		s[19] = slot19
+		return s
+	}
+	steps := []struct {
+		from, to protocol.SlotStatus
+		want     string
+	}{
+		{protocol.SlotNoCard, protocol.SlotPowerUp, "slot 19: no_card -> power_up"},
+		{protocol.SlotPowerUp, protocol.SlotError, "slot 19: power_up -> error"},
+		{protocol.SlotError, protocol.SlotRemoved, "slot 19: error -> removed"},
+		{protocol.SlotRemoved, protocol.SlotBootMode, "slot 19: removed -> boot_mode"},
+		{protocol.SlotBootMode, protocol.SlotPresent, "slot 19: boot_mode -> present"},
+	}
+	for _, st := range steps {
+		out := frameStatusDelta(mkStrip(st.from), mkStrip(st.to))
+		if len(out) != 1 || out[0] != st.want {
+			t.Errorf("step %s -> %s: got %v want [%q]", st.from, st.to, out, st.want)
+		}
+	}
+}
+
+// TestFrameStatusDelta_LengthMismatch verifies short/long slice handling:
+// a frame whose slot count grew gets the new positions reported as
+// no_card -> X transitions.
+func TestFrameStatusDelta_LengthMismatch(t *testing.T) {
+	prev := []protocol.SlotStatus{protocol.SlotPresent}
+	cur := []protocol.SlotStatus{protocol.SlotPresent, protocol.SlotPresent}
+	got := frameStatusDelta(prev, cur)
+	if len(got) != 1 || got[0] != "slot 1: no_card -> present" {
+		t.Errorf("length-grow: got %v want [\"slot 1: no_card -> present\"]", got)
 	}
 }


### PR DESCRIPTION
## Summary

- `cmd/dhs/cmd_watch.go` — extract `frameStatusDelta(prev, cur)` helper; watch loop tracks `prevFrame` and branches on `KindFrame` events to emit per-slot transitions instead of dumping the full 31-slot strip on every announce.
- `cmd/dhs/cmd_watch_test.go` — pin the diff with 4 cases: baseline, no-change re-broadcast, full 6-state cycle on slot 19 (no_card → power_up → error → removed → boot → present), and length mismatch.

## Why

During live testing against the Synapse Simulator, the operator had to scan the full 31-slot strip and present-only bracket digest column-by-column to figure out which slot actually changed. After this change a single transition prints as one tight line:

Before:
```
20:45:44  s0.frame.0  frame: PPPP.....P...P..P..U........... [..., 19=power_up]
20:45:45  s0.frame.0  frame: PPPP.....P...P..P..E........... [..., 19=error]
```

After:
```
20:45:41  s0.frame.0  baseline frame: PPPP.....P...P..P..........  [...]
20:45:44  s0.frame.0  slot 19: no_card -> power_up
20:45:45  s0.frame.0  slot 19: power_up -> error
```

`info` / `walk` / `export` paths still call `formatFrameStatus` so the full-digest view stays available where it makes sense.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` whole tree green
- [x] `go test -run "TestFrameStatusDelta|TestWatchCacheKey" ./cmd/dhs/` 5/5 pass
- [x] Live smoke against Synapse Simulator (no slot changes during the window so no frame events fired; pure-additive refactor — non-frame events render identically to before).

Closes #239.