### PR TITLE
feat(dmlib): product.yaml metadata + identity_probe (advances #246)

### DIFF
--- a/internal/dmlib/dmlib.go
+++ b/internal/dmlib/dmlib.go
@@ -47,7 +47,7 @@ type Fingerprint struct {
 }
 
 // Schema is one resolved product entry: per-slot tree snapshots for one
-// (Model, SwRev, Proto) tuple.
+// (Model, SwRev, Proto) tuple plus optional cross-protocol metadata.
 type Schema struct {
 	Fingerprint Fingerprint
 
@@ -55,6 +55,23 @@ type Schema struct {
 	// frames (Synapse) every slot has its own snapshot. For single-slot
 	// devices the map has one entry, conventionally slot 1.
 	Slots map[int]*export.Snapshot
+
+	// Product is the cross-protocol product metadata loaded from
+	// product.yaml at the model-rev directory root. Optional — schemas
+	// without product.yaml resolve cleanly with Product zero-valued.
+	Product ProductMeta
+
+	// Identity holds the per-protocol identity-probe configuration
+	// loaded from product.yaml. Optional.
+	Identity IdentityProbe
+
+	// Walk records when/by-what-tool the schema was captured.
+	// Optional.
+	Walk WalkMetadata
+
+	// SupportedProtocols lists every protocol with a sibling proto dir
+	// at the model-rev root. Loaded from product.yaml.
+	SupportedProtocols []string
 }
 
 // Diff is the per-slot delta between two Schemas of the same Fingerprint.
@@ -132,7 +149,22 @@ func (r *fileResolver) Resolve(fp Fingerprint) (*Schema, error) {
 	if len(slots) == 0 {
 		return nil, ErrNotFound
 	}
-	return &Schema{Fingerprint: fp, Slots: slots}, nil
+	s := &Schema{Fingerprint: fp, Slots: slots}
+
+	// Load product.yaml from the model-rev root if present. Absence is
+	// fine — schemas may exist without cross-protocol metadata.
+	pyPath, perr := r.productYAMLPath(fp)
+	if perr == nil {
+		if pm, ip, wm, sp, lerr := LoadProductYAML(pyPath); lerr == nil {
+			s.Product = *pm
+			s.Identity = *ip
+			s.Walk = *wm
+			s.SupportedProtocols = sp
+		} else if !os.IsNotExist(unwrapPathErr(lerr)) {
+			return nil, lerr
+		}
+	}
+	return s, nil
 }
 
 // LookupAlternate scans the same vendor/product/model dir for sibling
@@ -184,7 +216,9 @@ func (r *fileResolver) LookupAlternate(fp Fingerprint) ([]Fingerprint, error) {
 	return out, nil
 }
 
-// Persist writes every slot's snapshot atomically.
+// Persist writes every slot's snapshot atomically and, when the schema
+// carries cross-protocol metadata, writes product.yaml at the model-rev
+// root.
 func (r *fileResolver) Persist(s *Schema) error {
 	if s == nil {
 		return ErrInvalid
@@ -204,6 +238,18 @@ func (r *fileResolver) Persist(s *Schema) error {
 			continue
 		}
 		if err := writeSlot(dir, slot, snap); err != nil {
+			return err
+		}
+	}
+
+	// Save product.yaml if the schema carries metadata. The Product
+	// struct's Model + SwRev are the trigger; both must be non-empty.
+	if s.Product.Model != "" && s.Product.SwRev != "" {
+		pyPath, perr := r.productYAMLPath(s.Fingerprint)
+		if perr != nil {
+			return perr
+		}
+		if err := SaveProductYAML(pyPath, &s.Product, &s.Identity, &s.Walk, s.SupportedProtocols); err != nil {
 			return err
 		}
 	}
@@ -258,6 +304,39 @@ func (r *fileResolver) productDir(fp Fingerprint) (string, error) {
 		return "", fmt.Errorf("dmlib: product: %w", err)
 	}
 	return filepath.Join(r.root, v, p), nil
+}
+
+// productYAMLPath returns <root>/<vendor>/<product>/<model>-<sw_rev>/product.yaml.
+func (r *fileResolver) productYAMLPath(fp Fingerprint) (string, error) {
+	pd, err := r.productDir(fp)
+	if err != nil {
+		return "", err
+	}
+	m, err := identity.PathSegment(fp.Model)
+	if err != nil {
+		return "", fmt.Errorf("dmlib: model: %w", err)
+	}
+	sw, err := identity.PathSegment(fp.SwRev)
+	if err != nil {
+		return "", fmt.Errorf("dmlib: sw_rev: %w", err)
+	}
+	return filepath.Join(pd, m+"-"+sw, "product.yaml"), nil
+}
+
+// unwrapPathErr peels wrapping layers to find an os.PathError that
+// carries the actual not-exist signal. Used in Resolve to distinguish
+// "metadata absent" from real I/O failures.
+func unwrapPathErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	for {
+		inner := errors.Unwrap(err)
+		if inner == nil {
+			return err
+		}
+		err = inner
+	}
 }
 
 // protoDir returns <root>/<vendor>/<product>/<model>-<sw_rev>/<proto>/.

--- a/internal/dmlib/product_yaml.go
+++ b/internal/dmlib/product_yaml.go
@@ -1,0 +1,147 @@
+package dmlib
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"dhs/internal/identity"
+)
+
+// ProductMeta is the cross-protocol metadata for one product entry. It
+// lives in product.yaml at the root of every model-rev directory:
+// <root>/<vendor>/<product>/<model>-<sw_rev>/product.yaml.
+type ProductMeta struct {
+	Vendor      string `json:"vendor"`
+	Product     string `json:"product"`
+	Model       string `json:"model"`
+	SwRev       string `json:"sw_rev"`
+	HwRev       string `json:"hw_rev,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// IdentityProbe holds the per-protocol identity-probe configuration.
+// ACP1 is documentation-only (deterministic fixed-pid lookup at group=1).
+// ACP2 caches the alias-scan result so future encounters skip the scan.
+// Future protocols slot in alongside.
+type IdentityProbe struct {
+	ACP1 *IdentityProbeACP1 `json:"acp1,omitempty"`
+	ACP2 *IdentityProbeACP2 `json:"acp2,omitempty"`
+}
+
+// IdentityProbeACP1 documents the deterministic ACP1 identity probe.
+// The fields are fixed by spec p.20; this section is informational.
+type IdentityProbeACP1 struct {
+	Group int           `json:"group"`
+	Pids  IdentityPids  `json:"pids"`
+}
+
+// IdentityProbeACP2 caches the runtime-resolved ACP2 identity PIDs and
+// the labels the alias-scan saw at first encounter. Empty on first
+// encounter; populated after the alias-scan completes.
+type IdentityProbeACP2 struct {
+	Pids         IdentityPids    `json:"pids"`
+	AliasesSeen  IdentityAliases `json:"aliases_seen"`
+}
+
+// IdentityPids is the (Model, SwRev, HwRev) PID triple a plugin uses to
+// fetch identity. ACP1 PIDs are bytes (0..255); ACP2 PIDs are u32.
+type IdentityPids struct {
+	Model int `json:"model"`
+	SwRev int `json:"sw_rev"`
+	HwRev int `json:"hw_rev,omitempty"`
+}
+
+// IdentityAliases is the labels the ACP2 alias-scan matched on first
+// encounter. Persisted for diagnostics.
+type IdentityAliases struct {
+	Model string `json:"model"`
+	SwRev string `json:"sw_rev"`
+	HwRev string `json:"hw_rev,omitempty"`
+}
+
+// WalkMetadata records when and by what tool the schema was captured.
+// All fields optional.
+type WalkMetadata struct {
+	WalkedAt   time.Time `json:"walked_at,omitempty"`
+	WalkedBy   string    `json:"walked_by,omitempty"`
+	Controller string    `json:"controller,omitempty"`
+	Notes      string    `json:"notes,omitempty"`
+}
+
+// productYAML is the on-disk envelope for product.yaml. The file is
+// encoded as JSON (which is valid YAML 1.2) so we round-trip cleanly
+// without depending on a third-party YAML library.
+type productYAML struct {
+	Product            ProductMeta   `json:"product"`
+	SupportedProtocols []string      `json:"supported_protocols,omitempty"`
+	IdentityProbe      IdentityProbe `json:"identity_probe,omitempty"`
+	WalkMetadata       WalkMetadata  `json:"walk_metadata,omitempty"`
+}
+
+// LoadProductYAML reads product.yaml from disk. Returns os.ErrNotExist
+// (wrapped) if the file is absent so callers can treat that as "no
+// metadata yet" rather than a hard failure.
+func LoadProductYAML(path string) (*ProductMeta, *IdentityProbe, *WalkMetadata, []string, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("dmlib: read %s: %w", path, err)
+	}
+	var py productYAML
+	if err := json.Unmarshal(raw, &py); err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("dmlib: decode %s: %w", path, err)
+	}
+	if py.Product.Model == "" || py.Product.SwRev == "" {
+		return nil, nil, nil, nil, fmt.Errorf("dmlib: %s: missing model or sw_rev", path)
+	}
+	return &py.Product, &py.IdentityProbe, &py.WalkMetadata, py.SupportedProtocols, nil
+}
+
+// SaveProductYAML writes product.yaml atomically. Vendor strings flow
+// through identity.YAMLValue so untrusted wire content never reaches
+// disk verbatim.
+func SaveProductYAML(path string, m *ProductMeta, ip *IdentityProbe, wm *WalkMetadata, supported []string) error {
+	if m == nil || m.Model == "" || m.SwRev == "" {
+		return fmt.Errorf("dmlib: SaveProductYAML: missing model or sw_rev")
+	}
+	clean := *m
+	clean.Vendor = identity.YAMLValue(m.Vendor)
+	clean.Product = identity.YAMLValue(m.Product)
+	clean.Model = identity.YAMLValue(m.Model)
+	clean.SwRev = identity.YAMLValue(m.SwRev)
+	clean.HwRev = identity.YAMLValue(m.HwRev)
+	clean.Description = identity.YAMLValue(m.Description)
+
+	py := productYAML{
+		Product:            clean,
+		SupportedProtocols: supported,
+	}
+	if ip != nil {
+		py.IdentityProbe = *ip
+	}
+	if wm != nil {
+		py.WalkMetadata = *wm
+	}
+
+	raw, err := json.MarshalIndent(py, "", "  ")
+	if err != nil {
+		return fmt.Errorf("dmlib: encode %s: %w", path, err)
+	}
+	raw = append(raw, '\n')
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("dmlib: mkdir %s: %w", filepath.Dir(path), err)
+	}
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, raw, 0o644); err != nil {
+		return fmt.Errorf("dmlib: write %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("dmlib: rename %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/dmlib/product_yaml_test.go
+++ b/internal/dmlib/product_yaml_test.go
@@ -1,0 +1,216 @@
+package dmlib
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"dhs/internal/export"
+	"dhs/internal/protocol"
+)
+
+func TestProductYAML_Roundtrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "product.yaml")
+
+	pm := &ProductMeta{
+		Vendor:      "Axon",
+		Product:     "Synapse",
+		Model:       "RRS18",
+		SwRev:       "1601",
+		HwRev:       "0100",
+		Description: "Reference reception card",
+	}
+	ip := &IdentityProbe{
+		ACP1: &IdentityProbeACP1{
+			Group: 1,
+			Pids:  IdentityPids{Model: 0, SwRev: 3, HwRev: 4},
+		},
+		ACP2: &IdentityProbeACP2{
+			Pids:        IdentityPids{Model: 1234, SwRev: 1235, HwRev: 1236},
+			AliasesSeen: IdentityAliases{Model: "Card Type", SwRev: "Software Version", HwRev: "Hardware Revision"},
+		},
+	}
+	wm := &WalkMetadata{
+		WalkedAt:   time.Date(2026, 4, 22, 10, 30, 15, 0, time.UTC),
+		WalkedBy:   "dhs/0.7.0",
+		Controller: "Synapse Setup 4.2",
+		Notes:      "RRS18 reception card",
+	}
+	supported := []string{"acp1", "acp2"}
+
+	if err := SaveProductYAML(path, pm, ip, wm, supported); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, gotIP, gotWM, gotSP, err := LoadProductYAML(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if *got != *pm {
+		t.Fatalf("ProductMeta roundtrip diverged:\n got %+v\nwant %+v", *got, *pm)
+	}
+	if gotIP.ACP1.Group != 1 || gotIP.ACP1.Pids.Model != 0 {
+		t.Fatalf("ACP1 probe diverged: %+v", gotIP.ACP1)
+	}
+	if gotIP.ACP2.Pids.Model != 1234 || gotIP.ACP2.AliasesSeen.Model != "Card Type" {
+		t.Fatalf("ACP2 probe diverged: %+v", gotIP.ACP2)
+	}
+	if !gotWM.WalkedAt.Equal(wm.WalkedAt) {
+		t.Fatalf("WalkedAt diverged: got %v, want %v", gotWM.WalkedAt, wm.WalkedAt)
+	}
+	if len(gotSP) != 2 || gotSP[0] != "acp1" {
+		t.Fatalf("supported_protocols diverged: %v", gotSP)
+	}
+}
+
+func TestProductYAML_PartialOptional(t *testing.T) {
+	// Only mandatory fields populated; everything else zero-valued.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "product.yaml")
+
+	pm := &ProductMeta{Model: "RRS18", SwRev: "1601"}
+	if err := SaveProductYAML(path, pm, nil, nil, nil); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, gotIP, gotWM, gotSP, err := LoadProductYAML(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.Model != "RRS18" || got.SwRev != "1601" {
+		t.Fatalf("ProductMeta lost: %+v", *got)
+	}
+	if gotIP.ACP1 != nil || gotIP.ACP2 != nil {
+		t.Fatal("identity_probe should be empty")
+	}
+	if !gotWM.WalkedAt.IsZero() || gotWM.WalkedBy != "" {
+		t.Fatalf("walk_metadata should be empty: %+v", *gotWM)
+	}
+	if len(gotSP) != 0 {
+		t.Fatalf("supported_protocols should be empty: %v", gotSP)
+	}
+}
+
+func TestProductYAML_RejectsMissingModel(t *testing.T) {
+	if err := SaveProductYAML(filepath.Join(t.TempDir(), "p.yaml"), &ProductMeta{SwRev: "1601"}, nil, nil, nil); err == nil {
+		t.Fatal("Save accepted missing Model")
+	}
+	if err := SaveProductYAML(filepath.Join(t.TempDir(), "p.yaml"), &ProductMeta{Model: "RRS18"}, nil, nil, nil); err == nil {
+		t.Fatal("Save accepted missing SwRev")
+	}
+}
+
+func TestProductYAML_VendorSanitised(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "product.yaml")
+
+	pm := &ProductMeta{
+		Vendor:  "Axon\r\nFW=evil",
+		Product: "Synapse",
+		Model:   "RRS18",
+		SwRev:   "1601",
+	}
+	if err := SaveProductYAML(path, pm, nil, nil, nil); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, _, _, _, err := LoadProductYAML(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// CRLF collapsed to space by identity.YAMLValue.
+	if got.Vendor != "Axon FW=evil" {
+		t.Fatalf("vendor not sanitised: %q", got.Vendor)
+	}
+}
+
+func TestProductYAML_AbsentFile(t *testing.T) {
+	_, _, _, _, err := LoadProductYAML(filepath.Join(t.TempDir(), "nope.yaml"))
+	if err == nil {
+		t.Fatal("Load returned nil error for missing file")
+	}
+	if !os.IsNotExist(unwrapPathErr(err)) {
+		t.Fatalf("err = %v, want os.ErrNotExist underneath", err)
+	}
+}
+
+func TestResolve_LoadsProductMetadata(t *testing.T) {
+	root := t.TempDir()
+	r := New(root)
+
+	// Build a schema with full metadata.
+	s := &Schema{
+		Fingerprint: Fingerprint{
+			Vendor: "axon", Product: "synapse",
+			Model: "RRS18", SwRev: "1601", Proto: "acp1",
+		},
+		Slots: map[int]*export.Snapshot{
+			1: makeSnapshot("RRS18", []protocol.Object{
+				{Slot: 1, Group: "control", ID: 0, Label: "Card Name", Kind: protocol.KindString},
+			}),
+		},
+		Product: ProductMeta{
+			Vendor: "Axon", Product: "Synapse",
+			Model: "RRS18", SwRev: "1601", HwRev: "0100",
+			Description: "Reception card",
+		},
+		Identity: IdentityProbe{
+			ACP1: &IdentityProbeACP1{Group: 1, Pids: IdentityPids{Model: 0, SwRev: 3, HwRev: 4}},
+		},
+		Walk: WalkMetadata{
+			WalkedBy:   "dhs/0.7.0",
+			Controller: "Synapse Setup",
+		},
+		SupportedProtocols: []string{"acp1"},
+	}
+	if err := r.Persist(s); err != nil {
+		t.Fatalf("Persist: %v", err)
+	}
+
+	got, err := r.Resolve(s.Fingerprint)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got.Product.Vendor != "Axon" {
+		t.Fatalf("Product.Vendor = %q, want Axon", got.Product.Vendor)
+	}
+	if got.Identity.ACP1 == nil || got.Identity.ACP1.Group != 1 {
+		t.Fatalf("Identity.ACP1 = %+v, want group=1", got.Identity.ACP1)
+	}
+	if got.Walk.WalkedBy != "dhs/0.7.0" {
+		t.Fatalf("Walk.WalkedBy = %q", got.Walk.WalkedBy)
+	}
+	if len(got.SupportedProtocols) != 1 || got.SupportedProtocols[0] != "acp1" {
+		t.Fatalf("SupportedProtocols = %v", got.SupportedProtocols)
+	}
+}
+
+func TestResolve_MissingProductYAML_StillResolves(t *testing.T) {
+	// Schema without product.yaml should still resolve cleanly.
+	r := New(fixture(t))
+	got, err := r.Resolve(Fingerprint{
+		Vendor: "axon", Product: "synapse",
+		Model: "RRS18", SwRev: "1601", Proto: "acp1",
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got.Product.Model != "" {
+		t.Fatalf("Product should be zero-valued when product.yaml absent: %+v", got.Product)
+	}
+	if len(got.Slots) != 1 {
+		t.Fatalf("slots = %d, want 1", len(got.Slots))
+	}
+}
+
+func TestUnwrapPathErr_Identity(t *testing.T) {
+	if unwrapPathErr(nil) != nil {
+		t.Fatal("nil should unwrap to nil")
+	}
+	base := errors.New("plain")
+	if unwrapPathErr(base) != base {
+		t.Fatal("non-wrapped should return as-is")
+	}
+}


### PR DESCRIPTION
## Summary

- New `internal/dmlib/product_yaml.go` with `ProductMeta`, `IdentityProbe` (per-protocol), `WalkMetadata` types and `LoadProductYAML` / `SaveProductYAML` round-trippable helpers.
- `Schema` extended with optional `Product` / `Identity` / `Walk` / `SupportedProtocols` fields. `Resolve` auto-loads product.yaml when present (absence is fine); `Persist` saves when metadata is populated.
- 8 new tests covering full round-trip, partial/optional, missing-mandatory rejection, vendor sanitisation, absent-file behaviour, Resolve + Persist metadata integration, and unwrap helper.

## Encoding decision

Per ADR-0006 (codec stdlib-only), no third-party YAML lib. The on-disk file uses JSON syntax, which is valid YAML 1.2 — `encoding/json` round-trips cleanly, the file keeps `.yaml` extension for readability, and humans can still edit it by hand. Plain YAML tools also read it.

## Sanitiser integration

Every string field on `ProductMeta` flows through `identity.YAMLValue` before persistence, so wire-supplied strings (CRLF, control chars, NUL padding) never land on disk verbatim. Test `TestProductYAML_VendorSanitised` pins this.

## Test plan

- [x] `go test ./internal/dmlib/... -count=1` — 20 cases green (12 from #245 + 8 new).
- [x] `go build ./...` clean.
- [x] golangci-lint clean (pre-commit hook).
- [ ] CI race-detector run on the umbrella PR-to-main.

## Stacked on

PR #268 (DM library resolver). Merge order: #267 (sanitiser) → #268 (resolver) → this.

## Issue refs

Advances #246. Closes on the eventual PR-to-main when the foundation bundle lands together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
