### PR TITLE
feat(protocol): SessionHealth struct + HealthChecker interface (advances #248)

### DIFF
--- a/internal/protocol/health.go
+++ b/internal/protocol/health.go
@@ -1,0 +1,75 @@
+package protocol
+
+import (
+	"context"
+	"time"
+)
+
+// SessionHealth is the 3-layer protocol-agnostic health snapshot every
+// plugin can produce on demand. The bits are orthogonal: a session can
+// be Connected without being Live (device hung but TCP up) or Reachable
+// without being Connected (network OK, session dropped — reconnect).
+//
+// Layer mapping:
+//
+//   - Reachable: network path exists. Verified via ICMP / ARP / TCP SYN-ACK
+//     on demand; not constantly pinged.
+//
+//   - Connected: an active session is open. For TCP: socket ESTABLISHED
+//     and any application-level handshake (AN2 negotiated, S101
+//     keepalive, ...) complete. For UDP: the dialed remote has produced
+//     at least one reply since open.
+//
+//   - Live: the device is responding now. Set when (now - LastRx) is
+//     within StaleAfter; cleared when traffic falls silent past that
+//     window. The threshold is per-protocol (Probel 90s, TSL 5s,
+//     Ember+ 30s, ACP1 90s, ...).
+//
+// Aggregating across protocols on one device:
+//
+//	Device.IsOnline = ANY session.Live
+//
+// Each session keeps its own (Reachable, Connected, Live). UI surfaces
+// them as a per-protocol matrix on the device card; collapsing them into
+// one bool loses the diagnostic.
+type SessionHealth struct {
+	Reachable bool
+	Connected bool
+	Live      bool
+
+	// LastRx is the timestamp of the last frame received from the peer
+	// in this session. Zero if no frame has been received yet.
+	LastRx time.Time
+
+	// LastTx is the timestamp of the last frame sent to the peer in this
+	// session. Zero if nothing sent yet.
+	LastTx time.Time
+
+	// StaleAfter is the rolling window the plugin uses to decide Live:
+	// if (now - LastRx) > StaleAfter the device is judged not Live.
+	// Plugins set this to their per-protocol convention (e.g. ACP1 = 90s).
+	StaleAfter time.Duration
+}
+
+// IsLiveAt is a pure helper that recomputes Live for a given evaluation
+// time. Useful in tests and for UI render-time evaluation. Does not
+// mutate the receiver.
+func (h SessionHealth) IsLiveAt(now time.Time) bool {
+	if h.LastRx.IsZero() || h.StaleAfter <= 0 {
+		return false
+	}
+	return now.Sub(h.LastRx) <= h.StaleAfter
+}
+
+// HealthChecker is the optional interface a Protocol implementation can
+// satisfy to expose the 3-layer session health snapshot. Cross-protocol
+// callers (CLI verbs, REST API, UI) type-assert to this interface
+// rather than calling protocol-specific methods.
+//
+// Plugins MAY return early with a snapshot reflecting their best
+// current state without performing fresh probes; ctx is provided so
+// implementations that DO probe (e.g. Reachable via TCP SYN test) can
+// honour cancellation.
+type HealthChecker interface {
+	SessionHealth(ctx context.Context) SessionHealth
+}

--- a/internal/protocol/health_test.go
+++ b/internal/protocol/health_test.go
@@ -1,0 +1,96 @@
+package protocol
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSessionHealth_IsLiveAt(t *testing.T) {
+	now := time.Date(2026, 5, 5, 18, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name string
+		h    SessionHealth
+		want bool
+	}{
+		{
+			name: "fresh-rx-within-window",
+			h: SessionHealth{
+				LastRx:     now.Add(-10 * time.Second),
+				StaleAfter: 90 * time.Second,
+			},
+			want: true,
+		},
+		{
+			name: "rx-just-over-window",
+			h: SessionHealth{
+				LastRx:     now.Add(-91 * time.Second),
+				StaleAfter: 90 * time.Second,
+			},
+			want: false,
+		},
+		{
+			name: "rx-exactly-at-window-boundary",
+			h: SessionHealth{
+				LastRx:     now.Add(-90 * time.Second),
+				StaleAfter: 90 * time.Second,
+			},
+			want: true,
+		},
+		{
+			name: "no-rx-ever",
+			h: SessionHealth{
+				StaleAfter: 90 * time.Second,
+			},
+			want: false,
+		},
+		{
+			name: "zero-stale-after-treated-as-not-live",
+			h: SessionHealth{
+				LastRx:     now,
+				StaleAfter: 0,
+			},
+			want: false,
+		},
+		{
+			name: "negative-stale-after-treated-as-not-live",
+			h: SessionHealth{
+				LastRx:     now,
+				StaleAfter: -1 * time.Second,
+			},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.h.IsLiveAt(now)
+			if got != tc.want {
+				t.Fatalf("IsLiveAt = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSessionHealth_LiveDecaysOverTime(t *testing.T) {
+	t0 := time.Date(2026, 5, 5, 18, 0, 0, 0, time.UTC)
+	h := SessionHealth{
+		LastRx:     t0,
+		StaleAfter: 30 * time.Second,
+	}
+	// Within window: live.
+	if !h.IsLiveAt(t0.Add(15 * time.Second)) {
+		t.Fatal("should be live at +15s")
+	}
+	// At boundary: live.
+	if !h.IsLiveAt(t0.Add(30 * time.Second)) {
+		t.Fatal("should be live at +30s (boundary)")
+	}
+	// Past boundary: not live.
+	if h.IsLiveAt(t0.Add(31 * time.Second)) {
+		t.Fatal("should be stale at +31s")
+	}
+	// Far past boundary: still not live.
+	if h.IsLiveAt(t0.Add(10 * time.Minute)) {
+		t.Fatal("should be stale at +10m")
+	}
+}


### PR DESCRIPTION
## Summary

- New `internal/protocol/health.go` with `SessionHealth` struct (Reachable / Connected / Live + LastRx/LastTx + StaleAfter) and `HealthChecker` interface.
- `IsLiveAt(now)` helper for UI render-time evaluation without mutating state.
- 7 unit-test cases covering boundary, decay, no-rx-ever, zero/negative StaleAfter.

## Design (locked)

| Layer | Question | Source | Decay |
| --- | --- | --- | --- |
| Reachable | Network path exists? | ICMP / ARP / TCP SYN-ACK | re-test on demand |
| Connected | Active session? | TCP ESTABLISHED + handshake; UDP ever-seen-reply | instant on RST/FIN; UDP silent past transport window |
| Live | Device responding now? | rx-traffic timestamp | rolling per-protocol |

`Device.IsOnline = ANY session.Live` when a device runs multiple protocols.

## Non-goals for this PR

- No per-protocol implementations. ACP1 lands under #266; Phase 2 protocols land under their respective PRs.
- Existing `Plugin.IsOnline()` on probel-sw02p / probel-sw08p untouched — they're optional methods, not part of the Protocol interface, and the per-protocol PRs migrate them in their own commits.

## Test plan

- [x] `go test ./internal/protocol/... -count=1` — 7 cases green.
- [x] `go build ./...` clean.
- [x] golangci-lint clean.
- [ ] CI race-detector run on the umbrella PR-to-main.

## Stacked on

PR #269 (product.yaml). Merge order: #267 → #268 → #269 → this.

## Issue refs

Advances #248. Closes on the eventual PR-to-main when the foundation bundle lands together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
