### PR TITLE
feat(protocol): SlotInfo extended with State enum + LiveAt + IsOnline (advances #249)

### DIFF
--- a/internal/protocol/slot_state_test.go
+++ b/internal/protocol/slot_state_test.go
@@ -1,0 +1,78 @@
+package protocol
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSlotStatus_State_Mapping(t *testing.T) {
+	cases := []struct {
+		status SlotStatus
+		want   SlotState
+	}{
+		{SlotNoCard, SlotStateNoCard},
+		{SlotPowerUp, SlotStatePowerup},
+		{SlotPresent, SlotStatePresent},
+		{SlotError, SlotStateError},
+		{SlotRemoved, SlotStateRemoved},
+		{SlotBootMode, SlotStateBoot},
+		{SlotStatus(99), SlotStateNoCard}, // unknown defaults to no_card
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.want), func(t *testing.T) {
+			got := tc.status.State()
+			if got != tc.want {
+				t.Fatalf("State() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSlotInfo_IsOnline_TruthTable(t *testing.T) {
+	// Online is derived: State == present && Live.
+	now := time.Now()
+
+	cases := []struct {
+		name   string
+		state  SlotState
+		live   bool
+		want   bool
+	}{
+		{"present-and-live", SlotStatePresent, true, true},
+		{"present-but-not-live", SlotStatePresent, false, false},
+		{"error-and-live", SlotStateError, true, false},
+		{"error-and-not-live", SlotStateError, false, false},
+		{"no_card-and-live", SlotStateNoCard, true, false},
+		{"no_card-and-not-live", SlotStateNoCard, false, false},
+		{"powerup-and-live", SlotStatePowerup, true, false},
+		{"boot-and-live", SlotStateBoot, true, false},
+		{"removed-and-live", SlotStateRemoved, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			info := SlotInfo{
+				Slot:     1,
+				State:    tc.state,
+				LiveAt:   now,
+				IsOnline: tc.state == SlotStatePresent && tc.live,
+			}
+			if info.IsOnline != tc.want {
+				t.Fatalf("IsOnline = %v, want %v (state=%s live=%v)",
+					info.IsOnline, tc.want, tc.state, tc.live)
+			}
+		})
+	}
+}
+
+func TestSlotState_DistinctFromString(t *testing.T) {
+	// Confirm the locked names — "powerup" not "power_up", "boot" not
+	// "boot_mode" — are exposed in the new SlotState type. The wire-level
+	// SlotStatus.String() retains the legacy names for round-trip
+	// fidelity with on-disk snapshots.
+	if string(SlotStatePowerup) != "powerup" {
+		t.Fatalf("SlotStatePowerup = %q, want powerup", SlotStatePowerup)
+	}
+	if string(SlotStateBoot) != "boot" {
+		t.Fatalf("SlotStateBoot = %q, want boot", SlotStateBoot)
+	}
+}

--- a/internal/protocol/types.go
+++ b/internal/protocol/types.go
@@ -97,10 +97,69 @@ func (s SlotStatus) String() string {
 	}
 }
 
+// SlotState is the semantic 6-value slot-state enum, distinct from the
+// wire-level SlotStatus byte. UI surfaces and per-slot logic use this
+// type so the diagnostic ("error" vs "removed" vs "no_card") survives;
+// collapsing them all into Online=false loses the information.
+//
+// Values map 1:1 to SlotStatus (use .State() to convert) but the names
+// follow the locked vocabulary from the design doc — "powerup" not
+// "power_up", "boot" not "boot_mode".
+type SlotState string
+
+const (
+	SlotStateNoCard  SlotState = "no_card"  // physically empty
+	SlotStatePowerup SlotState = "powerup"  // card inserted, power ramping
+	SlotStateBoot    SlotState = "boot"     // firmware booting
+	SlotStatePresent SlotState = "present"  // card up, normal operation
+	SlotStateError   SlotState = "error"    // card present, fault flagged
+	SlotStateRemoved SlotState = "removed"  // hot-removed, transient before no_card
+)
+
+// State returns the semantic SlotState for a wire-level SlotStatus. Unknown
+// values map to "no_card" (the safest default for a missing/unrecognised
+// slot).
+func (s SlotStatus) State() SlotState {
+	switch s {
+	case SlotNoCard:
+		return SlotStateNoCard
+	case SlotPowerUp:
+		return SlotStatePowerup
+	case SlotPresent:
+		return SlotStatePresent
+	case SlotError:
+		return SlotStateError
+	case SlotRemoved:
+		return SlotStateRemoved
+	case SlotBootMode:
+		return SlotStateBoot
+	}
+	return SlotStateNoCard
+}
+
 // SlotInfo describes a single card slot within a device frame.
 type SlotInfo struct {
 	Slot   int
 	Status SlotStatus
+
+	// State is the semantic enum (no_card / powerup / present / error /
+	// removed / boot). Plugins MAY populate this alongside Status; the
+	// canonical conversion is Status.State(). Callers should prefer
+	// State for UI / per-slot logic; Status remains the wire-level
+	// numeric for round-trip fidelity.
+	State SlotState
+
+	// LiveAt is the timestamp of the last announce or reply that
+	// mentioned this slot. Zero if never seen. Used by hot-plug
+	// enrichment + watch decoders to decide whether the slot is still
+	// being talked about.
+	LiveAt time.Time
+
+	// IsOnline is the derived "this slot is usable right now" bool —
+	// true exactly when State == SlotStatePresent AND the device's
+	// session is Live (see SessionHealth). Plugins compute it on
+	// SlotInfo construction; consumers read it directly.
+	IsOnline bool
 
 	// Identity is the decoded mandatory identity objects (label, description,
 	// serial, etc.) populated after Walk. May be empty before walk.


### PR DESCRIPTION
## Summary

- New `SlotState` string-typed enum (no_card / powerup / present / error / removed / boot) on `internal/protocol/types.go`, distinct from the wire-level `SlotStatus uint8`.
- `SlotStatus.State()` converter — 1:1 mapping plus a safe default for unknown values.
- `SlotInfo` grows three optional fields: `State SlotState`, `LiveAt time.Time`, `IsOnline bool` (derived: `State == present && Device.Live`).
- 17 test cases covering the conversion table and the `IsOnline` truth table.

## Why a string-typed enum

The existing `SlotStatus uint8` is the wire byte (ACP1 spec p.24). The new `SlotState` is the *semantic* enum used by UI / per-slot logic. Names follow the locked vocabulary — `"powerup"` not `"power_up"`, `"boot"` not `"boot_mode"` — so the strings match what every cross-protocol component renders.

## Per-protocol migration

This PR adds the contract only. Each plugin populates `SlotInfo.State`, `LiveAt`, and `IsOnline` in its own per-protocol PR:
- ACP1: Phase 1 #259 (slot state machine).
- Phase 2 protocols: their respective sub-issues.

`Status SlotStatus` stays for round-trip fidelity with on-disk snapshots.

## Test plan

- [x] `go test ./internal/protocol/... -count=1` — 17 cases green.
- [x] `go build ./...` clean.
- [x] golangci-lint clean.
- [ ] CI race-detector run on the umbrella PR-to-main.

## Stacked on

PR #270 (SessionHealth). Merge order: #267 → #268 → #269 → #270 → this.

## Issue refs

Advances #249. Closes on the eventual PR-to-main when the foundation bundle lands together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
