### PR TITLE
feat(acp1): Plugin.GetIdentity (advances #251)

### DIFF
--- a/internal/acp1/consumer/compliance_events.go
+++ b/internal/acp1/consumer/compliance_events.go
@@ -95,4 +95,11 @@ const (
 	// (coerced / clamped), we accept it but fire this so the
 	// operator sees write-path coercion. Informational.
 	SetValueCoerced = "acp1_set_value_coerced"
+
+	// Spec p.20 ("Identity Object Group"): Card Label (id 0) is
+	// mandatory on every slot. When GetIdentity probes id 0 and the
+	// device returns a transport or object error, we fire this and
+	// return protocol.ErrIdentityUnresolved so the DM-library lookup
+	// falls through to walk-only. Informational.
+	IdentityNAK = "acp1_identity_nak"
 )

--- a/internal/acp1/consumer/identity.go
+++ b/internal/acp1/consumer/identity.go
@@ -1,0 +1,106 @@
+package acp1
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"dhs/internal/acp1/codec"
+	"dhs/internal/protocol"
+)
+
+// GetIdentity probes the ACP1 identity group (group=1) for the (Model,
+// SwRev, HwRev) triple. Per spec p.20 the identity group has 8 fixed
+// IDs; we read three:
+//
+//	id 0  Card Label             -> Model    (hard-required)
+//	id 3  Card Software Revision -> SwRev    (soft-required)
+//	id 4  Card Hardware Revision -> HwRev    (metadata only)
+//
+// Three deterministic getObject calls. NAK on the Card Label probe
+// fires the IdentityNAK compliance event and returns
+// protocol.ErrIdentityUnresolved. NAKs on SwRev / HwRev leave those
+// fields empty but do not fail — partial fingerprints are still useful
+// for DM-library partial-match lookup.
+//
+// Vendor strings come straight off the wire. Persistence callers must
+// run them through internal/identity sanitisers before disk write.
+func (p *Plugin) GetIdentity(ctx context.Context, slot int) (protocol.CardIdentity, error) {
+	p.mu.Lock()
+	c := p.client
+	profile := p.profile
+	p.mu.Unlock()
+	if c == nil {
+		return protocol.CardIdentity{}, protocol.ErrNotConnected
+	}
+
+	model, err := identityField(ctx, c, slot, 0)
+	if err != nil {
+		if profile != nil {
+			profile.Note(IdentityNAK)
+		}
+		return protocol.CardIdentity{}, fmt.Errorf("%w: card label: %v", protocol.ErrIdentityUnresolved, err)
+	}
+
+	// SwRev + HwRev are best-effort. Empty on miss; the DM-library
+	// resolver decides whether to keep looking with a partial key.
+	swrev, _ := identityField(ctx, c, slot, 3)
+	hwrev, _ := identityField(ctx, c, slot, 4)
+
+	return protocol.CardIdentity{
+		Model: model,
+		SwRev: swrev,
+		HwRev: hwrev,
+	}, nil
+}
+
+// identityField issues one getObject for (group=identity, id) and
+// extracts the value as a string regardless of underlying ACP1 type.
+// Strings carry through verbatim; numerics format as decimal; floats
+// use the shortest-round-trip representation.
+func identityField(ctx context.Context, c clientIface, slot int, id byte) (string, error) {
+	req := &codec.Message{
+		MType:    codec.MTypeRequest,
+		MAddr:    byte(slot),
+		MCode:    byte(codec.MethodGetObject),
+		ObjGroup: codec.GroupIdentity,
+		ObjID:    id,
+	}
+	reply, err := c.Do(ctx, req)
+	if err != nil {
+		return "", err
+	}
+	if reply.IsError() {
+		return "", reply.ErrCode()
+	}
+	d, err := codec.DecodeObject(reply.Value)
+	if err != nil {
+		return "", fmt.Errorf("decode identity: %w", err)
+	}
+	return identityValueAsString(d), nil
+}
+
+// identityValueAsString renders the "value" field of a DecodedObject as
+// a Go string regardless of the underlying ACP1 object type. Identity
+// objects are conventionally Strings, but real cards have shipped
+// Software Revision as Integer or Long; the helper covers all numeric
+// types so a non-string identity field still produces a usable
+// fingerprint component.
+func identityValueAsString(d *codec.DecodedObject) string {
+	if d == nil {
+		return ""
+	}
+	switch d.Type {
+	case codec.TypeString:
+		return d.StrValue
+	case codec.TypeInteger, codec.TypeLong:
+		return strconv.FormatInt(d.IntVal, 10)
+	case codec.TypeByte, codec.TypeEnum:
+		return strconv.FormatUint(uint64(d.ByteVal), 10)
+	case codec.TypeIPAddr:
+		return strconv.FormatUint(d.UintVal, 10)
+	case codec.TypeFloat:
+		return strconv.FormatFloat(d.FloatVal, 'f', -1, 64)
+	}
+	return ""
+}

--- a/internal/acp1/consumer/identity_test.go
+++ b/internal/acp1/consumer/identity_test.go
@@ -1,0 +1,168 @@
+package acp1
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"dhs/internal/acp1/codec"
+	"dhs/internal/protocol"
+	"dhs/internal/protocol/compliance"
+)
+
+// stringObject builds the wire bytes for a String identity object
+// (type=5, num_props=6) with the given value+label.
+func stringObject(value, label string) []byte {
+	v := []byte(value)
+	l := []byte(label)
+	v = append(v, 0x00) // NUL-terminate value
+	l = append(l, 0x00) // NUL-terminate label
+	out := []byte{
+		0x05,                  // type = String
+		0x06,                  // num_props
+		0x01,                  // access (read)
+	}
+	out = append(out, v...)
+	out = append(out, byte(len(value))) // max_len
+	out = append(out, l...)
+	return out
+}
+
+// integerObject builds the wire bytes for an Integer identity object
+// (type=1, num_props=10) with a given i16 value. min/max/default/step
+// are zero — sufficient for identity purposes.
+func integerObject(value int16, label string) []byte {
+	out := []byte{
+		0x01,                                  // type = Integer
+		0x0A,                                  // num_props
+		0x01,                                  // access (read)
+		byte(uint16(value) >> 8), byte(value), // value (i16 BE)
+		0x00, 0x00, // default
+		0x00, 0x01, // step (1)
+		0x00, 0x00, // min
+		0xFF, 0xFF, // max
+	}
+	l := append([]byte(label), 0x00)
+	out = append(out, l...)
+	out = append(out, 0x00) // unit (empty + NUL)
+	return out
+}
+
+// newPluginWithClient builds a Plugin wired to a fake client transport.
+// Mirrors the live Connect flow's bookkeeping just enough that
+// GetIdentity / GetValue work in unit tests.
+func newPluginWithClient(t *testing.T) (*Plugin, *fakeTransport, uint32) {
+	t.Helper()
+	ft := &fakeTransport{}
+	c := NewClient(ft, nil, ClientConfig{
+		MaxRetries:     2,
+		ReceiveTimeout: 50 * time.Millisecond,
+	})
+	c.nextMTID = 1000
+	p := &Plugin{
+		logger:  slog.Default(),
+		client:  c,
+		profile: &compliance.Profile{},
+	}
+	return p, ft, 1000
+}
+
+func TestGetIdentity_HappyPath(t *testing.T) {
+	p, ft, mtid := newPluginWithClient(t)
+
+	// Three replies in order: id=0 (Card Label), id=3 (Software Rev), id=4 (Hardware Rev).
+	ft.recv = [][]byte{
+		buildReply(t, mtid+1, codec.MTypeReply, byte(codec.MethodGetObject),
+			codec.GroupIdentity, 0, stringObject("RRS18", "Card Label")),
+		buildReply(t, mtid+2, codec.MTypeReply, byte(codec.MethodGetObject),
+			codec.GroupIdentity, 3, integerObject(1601, "SwRev")),
+		buildReply(t, mtid+3, codec.MTypeReply, byte(codec.MethodGetObject),
+			codec.GroupIdentity, 4, integerObject(100, "HwRev")),
+	}
+
+	id, err := p.GetIdentity(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("GetIdentity: %v", err)
+	}
+	if id.Model != "RRS18" {
+		t.Fatalf("Model = %q, want RRS18", id.Model)
+	}
+	if id.SwRev != "1601" {
+		t.Fatalf("SwRev = %q, want 1601", id.SwRev)
+	}
+	if id.HwRev != "100" {
+		t.Fatalf("HwRev = %q, want 100", id.HwRev)
+	}
+	if got := p.profile.Snapshot()[IdentityNAK]; got != 0 {
+		t.Fatalf("IdentityNAK fired %d times, want 0", got)
+	}
+}
+
+func TestGetIdentity_CardLabelNAK_FiresComplianceEvent(t *testing.T) {
+	p, ft, mtid := newPluginWithClient(t)
+
+	// First reply (id=0) is an error; the probe should bail with
+	// ErrIdentityUnresolved and fire the IdentityNAK compliance event.
+	errReply := buildReply(t, mtid+1, codec.MTypeError, 17 /* object instance not exist */,
+		codec.GroupIdentity, 0, nil)
+	ft.recv = [][]byte{errReply}
+
+	_, err := p.GetIdentity(context.Background(), 1)
+	if !errors.Is(err, protocol.ErrIdentityUnresolved) {
+		t.Fatalf("err = %v, want ErrIdentityUnresolved", err)
+	}
+	if got := p.profile.Snapshot()[IdentityNAK]; got != 1 {
+		t.Fatalf("IdentityNAK fired %d times, want 1", got)
+	}
+}
+
+func TestGetIdentity_PartialIdentity_OnSwRevNAK(t *testing.T) {
+	p, ft, mtid := newPluginWithClient(t)
+
+	// id=0 OK, id=3 NAK, id=4 OK. The probe should NOT fail —
+	// partial fingerprints are allowed; SwRev empty.
+	ft.recv = [][]byte{
+		buildReply(t, mtid+1, codec.MTypeReply, byte(codec.MethodGetObject),
+			codec.GroupIdentity, 0, stringObject("RRS18", "Card Label")),
+		buildReply(t, mtid+2, codec.MTypeError, 17,
+			codec.GroupIdentity, 3, nil),
+		buildReply(t, mtid+3, codec.MTypeReply, byte(codec.MethodGetObject),
+			codec.GroupIdentity, 4, integerObject(100, "HwRev")),
+	}
+
+	id, err := p.GetIdentity(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("GetIdentity: %v", err)
+	}
+	if id.Model != "RRS18" || id.SwRev != "" || id.HwRev != "100" {
+		t.Fatalf("partial identity wrong: %+v", id)
+	}
+	// Soft-NAK must NOT trip the IdentityNAK compliance event.
+	if got := p.profile.Snapshot()[IdentityNAK]; got != 0 {
+		t.Fatalf("IdentityNAK fired %d times, want 0", got)
+	}
+}
+
+func TestGetIdentity_NotConnected(t *testing.T) {
+	p := &Plugin{logger: slog.Default()}
+	_, err := p.GetIdentity(context.Background(), 1)
+	if !errors.Is(err, protocol.ErrNotConnected) {
+		t.Fatalf("err = %v, want ErrNotConnected", err)
+	}
+}
+
+func TestCardIdentity_IsZero(t *testing.T) {
+	if !(protocol.CardIdentity{}).IsZero() {
+		t.Fatal("zero value should be zero")
+	}
+	if (protocol.CardIdentity{Model: "RRS18"}).IsZero() {
+		t.Fatal("non-zero Model should not be zero")
+	}
+}
+
+func TestPlugin_SatisfiesIdentifier(t *testing.T) {
+	// Compile-time assertion that *Plugin satisfies protocol.Identifier.
+	var _ protocol.Identifier = (*Plugin)(nil)
+}

--- a/internal/protocol/identity.go
+++ b/internal/protocol/identity.go
@@ -1,0 +1,36 @@
+package protocol
+
+import (
+	"context"
+	"errors"
+)
+
+// CardIdentity is the protocol-agnostic fingerprint that drives DM-library
+// lookup. Plugins fill this from a deterministic identity probe (ACP1
+// fixed-pid getObject at group=1) or a runtime alias-scan (ACP2 label
+// matching). Vendor strings are returned raw from the wire; persistence
+// callers run them through internal/identity sanitisers before disk write.
+type CardIdentity struct {
+	Model string // hard-required for DM-library lookup
+	SwRev string // strict lookup; partial-match fallback when empty
+	HwRev string // metadata only — not in lookup key today
+}
+
+// IsZero reports whether the identity carries no useful fields.
+func (c CardIdentity) IsZero() bool {
+	return c.Model == "" && c.SwRev == "" && c.HwRev == ""
+}
+
+// Identifier is the optional contract a Protocol implementation may
+// satisfy to expose per-slot identity information. Cross-protocol
+// callers (DM-library seed flow, watch hot-plug enrichment) type-assert
+// to this interface.
+type Identifier interface {
+	GetIdentity(ctx context.Context, slot int) (CardIdentity, error)
+}
+
+// ErrIdentityUnresolved is returned by GetIdentity when the device did
+// not provide enough information to fingerprint the card. Plugins fire
+// a per-protocol compliance event before returning this error so the
+// session profile reflects the failure.
+var ErrIdentityUnresolved = errors.New("protocol: card identity unresolved")


### PR DESCRIPTION
## Summary

- New cross-protocol `protocol.Identifier` interface in `internal/protocol/identity.go` with `CardIdentity` struct (Model / SwRev / HwRev) and `ErrIdentityUnresolved` sentinel.
- ACP1 `Plugin.GetIdentity(ctx, slot)` impl in `internal/acp1/consumer/identity.go` — three deterministic getObject calls at group=1 ids 0/3/4 per spec p.20.
- New `acp1_identity_nak` compliance event fired on Card Label NAK.
- `identityValueAsString` covers every ACP1 numeric type so a non-string identity field still produces a fingerprint component.
- 6 unit tests covering happy path, hard NAK + compliance event, soft NAK partial fingerprint, not-connected, IsZero, compile-time interface assertion.

## Spec mapping

| ACP1 ID | Field | CardIdentity | Required |
| ---: | --- | --- | :-: |
| 0 | Card Label | Model | hard |
| 3 | Software Rev | SwRev | soft |
| 4 | Hardware Rev | HwRev | metadata |

Hard-required = NAK fires compliance event and returns `ErrIdentityUnresolved`. Soft-required = NAK leaves the field empty so DM-library partial-match still has a chance.

## Cross-protocol contract

```go
type Identifier interface {
    GetIdentity(ctx context.Context, slot int) (CardIdentity, error)
}
```

The `Plugin.SeedFromDM` flow (#252) and watch hot-plug enrichment (#254) type-assert `plug.(protocol.Identifier)`. Phase 2 protocols satisfy the same interface — ACP2 with alias-scan, others with their wire-specific probes.

## Test plan

- [x] `go test ./internal/acp1/consumer/... ./internal/protocol/... -count=1` — green (4 new + 2 protocol-level + existing).
- [x] `go build ./...` clean.
- [x] golangci-lint clean.
- [ ] Integration test against Synapse Simulator on `feat/acp1-full`.

## Stacked on

PR #272 (health verb). Merge order: #267 → #268 → #269 → #270 → #271 → #272 → this. **First Phase 1 piece.**

## Issue refs

Advances #251. Closes on the eventual PR-to-main when the ACP1 epic bundle lands together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
