### PR TITLE
feat(acp1): Plugin.SeedFromDM (advances #252)

### DIFF
--- a/internal/acp1/consumer/seed.go
+++ b/internal/acp1/consumer/seed.go
@@ -1,0 +1,126 @@
+package acp1
+
+import (
+	"errors"
+	"fmt"
+
+	"dhs/internal/acp1/codec"
+	"dhs/internal/export"
+	"dhs/internal/protocol"
+)
+
+// SeedFromDM pre-populates the in-memory slot-tree cache from a DM-library
+// snapshot so the announce decoder has type info on the first frame —
+// no blocking walk required at Connect time.
+//
+// The seed is value-less by design (schemas don't carry live values).
+// First successful announce / GetValue / Walk on a seeded slot
+// overwrites the type entries with wire-confirmed shapes.
+//
+// Hot-swap is the caller's responsibility (watch hot-plug enrichment
+// re-seeds when GetIdentity returns a different fingerprint).
+//
+// ACPTypes is populated via best-effort mapping from protocol.ValueKind.
+// Kind is a widened type (KindInt covers Integer + Long), so the wire
+// width may be wrong for set/get round-trip until the real walk fires.
+// This is acceptable: seeded values arrive only via announces (decoded
+// from the ACP1 type byte) and the first GetValue refreshes the entry.
+func (p *Plugin) SeedFromDM(slot int, snap *export.Snapshot) error {
+	if snap == nil {
+		return errors.New("acp1: SeedFromDM: nil snapshot")
+	}
+	if len(snap.Slots) == 0 {
+		return errors.New("acp1: SeedFromDM: snapshot has no slots")
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.trees == nil {
+		return protocol.ErrNotConnected
+	}
+
+	sd := findSlot(snap, slot)
+	if sd == nil {
+		return fmt.Errorf("acp1: SeedFromDM: snapshot has no slot %d", slot)
+	}
+
+	objs := make([]protocol.Object, len(sd.Objects))
+	acpTypes := make([]codec.ObjectType, len(sd.Objects))
+	labels := map[string]map[string]int{}
+	for i, o := range sd.Objects {
+		objs[i] = o
+		objs[i].Value = protocol.Value{} // schemas are value-less
+		acpTypes[i] = kindToACPType(o.Kind, o.Meta)
+		if o.Group != "" && o.Label != "" {
+			if labels[o.Group] == nil {
+				labels[o.Group] = map[string]int{}
+			}
+			labels[o.Group][o.Label] = i
+		}
+	}
+
+	tree := &SlotTree{
+		Slot:     slot,
+		Objects:  objs,
+		ACPTypes: acpTypes,
+		Labels:   labels,
+	}
+	p.trees.Put(slot, tree)
+	return nil
+}
+
+// findSlot returns the SlotDump matching slot or nil. By convention a
+// single-slot snapshot may have Slot=0 (legacy) or Slot=N (per-slot
+// dump); we accept exact match first, single-entry fallback second.
+func findSlot(snap *export.Snapshot, slot int) *export.SlotDump {
+	for i := range snap.Slots {
+		if snap.Slots[i].Slot == slot {
+			return &snap.Slots[i]
+		}
+	}
+	if len(snap.Slots) == 1 {
+		return &snap.Slots[0]
+	}
+	return nil
+}
+
+// kindToACPType maps the widened ValueKind back to a concrete ACP1
+// ObjectType. Lossy: KindInt could come from Integer (i16) or Long
+// (i32); we default to Integer and document the limitation.
+//
+// Plugins MAY persist the original ACPType under Object.Meta["acp1_type"]
+// during walk; when present, the meta override wins.
+func kindToACPType(k protocol.ValueKind, meta map[string]any) codec.ObjectType {
+	if meta != nil {
+		if raw, ok := meta["acp1_type"]; ok {
+			switch v := raw.(type) {
+			case float64: // JSON numbers decode as float64
+				return codec.ObjectType(v)
+			case int:
+				return codec.ObjectType(v)
+			case int64:
+				return codec.ObjectType(v)
+			case codec.ObjectType:
+				return v
+			}
+		}
+	}
+	switch k {
+	case protocol.KindBool, protocol.KindEnum:
+		return codec.TypeEnum
+	case protocol.KindInt:
+		return codec.TypeInteger
+	case protocol.KindUint:
+		return codec.TypeByte
+	case protocol.KindFloat:
+		return codec.TypeFloat
+	case protocol.KindString:
+		return codec.TypeString
+	case protocol.KindIPAddr:
+		return codec.TypeIPAddr
+	case protocol.KindAlarm:
+		return codec.TypeAlarm
+	case protocol.KindFrame:
+		return codec.TypeFrame
+	}
+	return codec.ObjectType(0)
+}

--- a/internal/acp1/consumer/seed_test.go
+++ b/internal/acp1/consumer/seed_test.go
@@ -1,0 +1,172 @@
+package acp1
+
+import (
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"dhs/internal/acp1/codec"
+	"dhs/internal/export"
+	"dhs/internal/protocol"
+)
+
+func makeSeedSnapshot(slot int, objs []protocol.Object) *export.Snapshot {
+	return &export.Snapshot{
+		Device: export.DeviceInfo{IP: "10.6.239.113", Protocol: "acp1"},
+		Slots: []export.SlotDump{{
+			Slot:     slot,
+			Objects:  objs,
+			WalkedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		}},
+		CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+func TestSeedFromDM_PopulatesTreeAndLabels(t *testing.T) {
+	p := &Plugin{
+		logger: slog.Default(),
+		trees:  newSlotTreeCache(8, time.Hour),
+	}
+
+	snap := makeSeedSnapshot(1, []protocol.Object{
+		{Slot: 1, Group: "identity", ID: 0, Label: "Card Name", Kind: protocol.KindString},
+		{Slot: 1, Group: "control", ID: 5, Label: "Gain", Kind: protocol.KindFloat, Unit: "dB"},
+		{Slot: 1, Group: "status", ID: 0, Label: "Pct", Kind: protocol.KindUint, Unit: "%"},
+	})
+
+	if err := p.SeedFromDM(1, snap); err != nil {
+		t.Fatalf("SeedFromDM: %v", err)
+	}
+
+	tree, ok := p.trees.Get(1)
+	if !ok {
+		t.Fatal("slot 1 missing after seed")
+	}
+	if len(tree.Objects) != 3 {
+		t.Fatalf("Objects = %d, want 3", len(tree.Objects))
+	}
+	if len(tree.ACPTypes) != 3 {
+		t.Fatalf("ACPTypes = %d, want 3", len(tree.ACPTypes))
+	}
+	if tree.ACPTypes[0] != codec.TypeString {
+		t.Fatalf("identity ACPType = %d, want String(5)", tree.ACPTypes[0])
+	}
+	if tree.ACPTypes[1] != codec.TypeFloat {
+		t.Fatalf("control ACPType = %d, want Float(3)", tree.ACPTypes[1])
+	}
+	if tree.ACPTypes[2] != codec.TypeByte {
+		t.Fatalf("status ACPType = %d, want Byte(10)", tree.ACPTypes[2])
+	}
+	if idx := tree.Lookup("control", "Gain"); idx != 1 {
+		t.Fatalf("Lookup control/Gain = %d, want 1", idx)
+	}
+	if idx := tree.Lookup("status", "Pct"); idx != 2 {
+		t.Fatalf("Lookup status/Pct = %d, want 2", idx)
+	}
+}
+
+func TestSeedFromDM_StripsValues(t *testing.T) {
+	// Schemas are value-less: SeedFromDM must drop any values the snapshot
+	// carries (e.g. accidentally persisted from an export run).
+	p := &Plugin{
+		logger: slog.Default(),
+		trees:  newSlotTreeCache(8, time.Hour),
+	}
+
+	snap := makeSeedSnapshot(1, []protocol.Object{
+		{
+			Slot: 1, Group: "control", ID: 5, Label: "Gain",
+			Kind:  protocol.KindFloat,
+			Value: protocol.Value{Kind: protocol.KindFloat, Float: -6.0},
+		},
+	})
+	if err := p.SeedFromDM(1, snap); err != nil {
+		t.Fatalf("SeedFromDM: %v", err)
+	}
+	tree, _ := p.trees.Get(1)
+	if !tree.Objects[0].Value.IsZero() {
+		t.Fatalf("Value not stripped: %+v", tree.Objects[0].Value)
+	}
+}
+
+func TestSeedFromDM_MetaACPTypeOverridesKindMapping(t *testing.T) {
+	// Walks may persist Meta["acp1_type"] to disambiguate Integer vs
+	// Long (both widen to KindInt). SeedFromDM must honour the meta
+	// hint when present.
+	p := &Plugin{
+		logger: slog.Default(),
+		trees:  newSlotTreeCache(8, time.Hour),
+	}
+
+	snap := makeSeedSnapshot(1, []protocol.Object{
+		{Slot: 1, Group: "control", ID: 5, Label: "Counter",
+			Kind: protocol.KindInt,
+			Meta: map[string]any{"acp1_type": float64(codec.TypeLong)},
+		},
+	})
+	if err := p.SeedFromDM(1, snap); err != nil {
+		t.Fatalf("SeedFromDM: %v", err)
+	}
+	tree, _ := p.trees.Get(1)
+	if tree.ACPTypes[0] != codec.TypeLong {
+		t.Fatalf("ACPType = %d, want Long(9)", tree.ACPTypes[0])
+	}
+}
+
+func TestSeedFromDM_NotConnected(t *testing.T) {
+	p := &Plugin{logger: slog.Default()} // p.trees is nil
+	snap := makeSeedSnapshot(1, nil)
+	err := p.SeedFromDM(1, snap)
+	if !errors.Is(err, protocol.ErrNotConnected) {
+		t.Fatalf("err = %v, want ErrNotConnected", err)
+	}
+}
+
+func TestSeedFromDM_NilSnapshot(t *testing.T) {
+	p := &Plugin{
+		logger: slog.Default(),
+		trees:  newSlotTreeCache(8, time.Hour),
+	}
+	if err := p.SeedFromDM(1, nil); err == nil {
+		t.Fatal("expected error for nil snapshot")
+	}
+}
+
+func TestSeedFromDM_SlotMismatch_FallbackToSingleEntry(t *testing.T) {
+	// Single-slot snapshot with Slot=0 (legacy export) should still
+	// seed when the caller asks for slot 1.
+	p := &Plugin{
+		logger: slog.Default(),
+		trees:  newSlotTreeCache(8, time.Hour),
+	}
+	snap := makeSeedSnapshot(0, []protocol.Object{
+		{Slot: 0, Group: "control", ID: 5, Label: "Gain", Kind: protocol.KindFloat},
+	})
+	if err := p.SeedFromDM(1, snap); err != nil {
+		t.Fatalf("SeedFromDM: %v", err)
+	}
+	tree, ok := p.trees.Get(1)
+	if !ok || len(tree.Objects) != 1 {
+		t.Fatalf("seed via single-entry fallback failed: tree=%+v", tree)
+	}
+}
+
+func TestSeedFromDM_MissingSlot_MultiSlotSnapshot(t *testing.T) {
+	// Multi-slot snapshot, requested slot absent: error, not silent.
+	p := &Plugin{
+		logger: slog.Default(),
+		trees:  newSlotTreeCache(8, time.Hour),
+	}
+	snap := &export.Snapshot{
+		Device: export.DeviceInfo{IP: "x", Protocol: "acp1"},
+		Slots: []export.SlotDump{
+			{Slot: 1, Objects: []protocol.Object{{Slot: 1, ID: 1}}},
+			{Slot: 2, Objects: []protocol.Object{{Slot: 2, ID: 1}}},
+		},
+		CreatedAt: time.Now(),
+	}
+	if err := p.SeedFromDM(99, snap); err == nil {
+		t.Fatal("expected error for missing slot")
+	}
+}


### PR DESCRIPTION
## Summary

- New `Plugin.SeedFromDM(slot, snap)` method on the ACP1 consumer in `internal/acp1/consumer/seed.go`.
- Pre-populates `p.trees[slot]` from a DM-library `export.Snapshot` so the announce decoder has type info on the first frame — no blocking walk required at Connect time.
- 7 unit tests covering happy path, value-strip invariant, Meta-override of ACP type, not-connected, nil snapshot, single-entry fallback, missing-slot error.

## Why this exists

The watch verb today shows `raw(N)` and empty labels for several seconds at startup because the announce decoder has no type info until the per-slot walk completes. SeedFromDM closes the gap: with a DM-library entry on disk, the decoder sees full type + label info from the very first announce.

## ACPType reconstruction

`protocol.ValueKind` is widened (`KindInt` covers both Integer i16 and Long i32). On seed-from-disk we don't strictly know which the original wire type was. Strategy:

1. If the snapshot's Object carries `Meta["acp1_type"]` (added by walks at persist time — landing in #260), that value wins.
2. Otherwise fall back to a Kind→ACPType mapping (Integer for KindInt, Byte for KindUint, etc.).

The fallback may pick the wrong wire width for set/get round-trips on KindInt/KindUint. Acceptable degradation — the first GetValue / Walk on a seeded slot replaces the seed with wire-confirmed types.

## Hot-swap

Re-seeding on hot-swap is the caller's responsibility. Watch hot-plug enrichment (#254) detects a fingerprint change via `GetIdentity` and calls `SeedFromDM` again with the new schema.

## Test plan

- [x] `go test ./internal/acp1/consumer/... -count=1 -run TestSeedFromDM` — 7 cases green.
- [x] `go build ./...` clean.
- [x] golangci-lint clean.
- [ ] Integration test against Synapse Simulator on `feat/acp1-full`.

## Stacked on

PR #273 (GetIdentity). Merge order: Phase 0 (#267-#272) → #273 → this.

## Issue refs

Advances #252. Closes on the eventual PR-to-main when the ACP1 epic bundle lands together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
