### PR TITLE
feat(acp1): provider Broadcasts gate (advances #257)

### DIFF
--- a/internal/acp1/provider/an2_server.go
+++ b/internal/acp1/provider/an2_server.go
@@ -218,21 +218,9 @@ func (s *server) handleAN2ACP1Frame(f *an2.AN2Frame, sess *an2Session) {
 		}
 	}
 	if ann != nil {
-		body, err := ann.Encode()
-		if err == nil {
-			out := &an2.AN2Frame{
-				Proto:   an2.AN2ProtoACP1,
-				Slot:    f.Slot,
-				MTID:    0,
-				Type:    an2.AN2TypeData,
-				Payload: body,
-			}
-			if b, err := an2.EncodeAN2Frame(out); err == nil {
-				if s.an2Registry != nil {
-					s.an2Registry.broadcastACP1(b)
-				}
-			}
-		}
+		// Route through broadcastAnnounce for the Broadcasts gate
+		// (#257) plus the UDP+TCP bridges.
+		s.broadcastAnnounce(ann)
 	}
 }
 

--- a/internal/acp1/provider/broadcasts_gate_test.go
+++ b/internal/acp1/provider/broadcasts_gate_test.go
@@ -1,0 +1,157 @@
+package acp1
+
+import (
+	"testing"
+
+	"dhs/internal/acp1/codec"
+	"dhs/internal/export/canonical"
+)
+
+func TestBroadcastsEnabled_NoGateObject_PermissiveDefault(t *testing.T) {
+	s := newTestServer(t)
+	if !s.tree.broadcastsEnabled() {
+		t.Fatal("default tree without (slot=0, control, id=4) should report enabled=true")
+	}
+}
+
+func TestBroadcastsEnabled_EnumOn(t *testing.T) {
+	tr := &tree{
+		entries: map[objectKey]*entry{
+			{slot: 0, group: codec.GroupControl, id: 4}: {
+				key:     objectKey{slot: 0, group: codec.GroupControl, id: 4},
+				acpType: codec.TypeEnum,
+				access:  3,
+				param: &canonical.Parameter{
+					Type: "enum",
+					EnumMap: []canonical.EnumEntry{
+						{Key: "Off", Value: 0},
+						{Key: "On", Value: 1},
+					},
+					Value: int64(1),
+				},
+			},
+		},
+		slots: map[uint8]*slotCounts{},
+	}
+	if !tr.broadcastsEnabled() {
+		t.Fatal("enum value=1 (On) should report enabled=true")
+	}
+}
+
+func TestBroadcastsEnabled_EnumOff(t *testing.T) {
+	tr := &tree{
+		entries: map[objectKey]*entry{
+			{slot: 0, group: codec.GroupControl, id: 4}: {
+				param: &canonical.Parameter{
+					Type: "enum",
+					EnumMap: []canonical.EnumEntry{
+						{Key: "Off", Value: 0},
+						{Key: "On", Value: 1},
+					},
+					Value: int64(0),
+				},
+			},
+		},
+	}
+	if tr.broadcastsEnabled() {
+		t.Fatal("enum value=0 (Off) should report enabled=false")
+	}
+}
+
+func TestBroadcastsEnabled_BareNumeric(t *testing.T) {
+	cases := []struct {
+		name string
+		v    any
+		want bool
+	}{
+		{"int64-zero", int64(0), false},
+		{"int64-one", int64(1), true},
+		{"uint64-zero", uint64(0), false},
+		{"uint64-one", uint64(1), true},
+		{"int-zero", int(0), false},
+		{"int-one", int(1), true},
+		{"float64-zero", float64(0), false},
+		{"float64-one", float64(1), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := &tree{
+				entries: map[objectKey]*entry{
+					{slot: 0, group: codec.GroupControl, id: 4}: {
+						param: &canonical.Parameter{Value: tc.v},
+					},
+				},
+			}
+			if got := tr.broadcastsEnabled(); got != tc.want {
+				t.Fatalf("broadcastsEnabled() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBroadcastsEnabled_NilParam(t *testing.T) {
+	tr := &tree{
+		entries: map[objectKey]*entry{
+			{slot: 0, group: codec.GroupControl, id: 4}: {
+				key:     objectKey{slot: 0, group: codec.GroupControl, id: 4},
+				acpType: codec.TypeEnum,
+				access:  3,
+				// param: nil
+			},
+		},
+	}
+	if !tr.broadcastsEnabled() {
+		t.Fatal("nil param should fall back to permissive default")
+	}
+}
+
+func TestBroadcastAnnounce_GatedSilently_WhenOff(t *testing.T) {
+	// Build a tree that has the gate object set to Off, then verify
+	// broadcastAnnounce produces no output to TCP fan-out (no panic on
+	// nil bcast / no exception).
+	s := newTestServer(t)
+	s.tree.entries[objectKey{slot: 0, group: codec.GroupControl, id: 4}] = &entry{
+		param: &canonical.Parameter{Value: int64(0)},
+	}
+
+	reg := newTCPSessionRegistry(s.logger)
+	send := make(chan []byte, 4)
+	reg.register("10.0.0.1", nil, send)
+	s.tcpRegistry = reg
+
+	ann := &codec.Message{
+		MTID: 0, MType: codec.MTypeReply, MAddr: 1,
+		MCode: byte(codec.MethodSetValue),
+		ObjGroup: codec.GroupControl, ObjID: 0,
+		Value: []byte{0x00, 0x05},
+	}
+	s.broadcastAnnounce(ann)
+
+	if len(send) != 0 {
+		t.Fatalf("Broadcasts=Off should suppress fan-out: got %d items in send queue", len(send))
+	}
+}
+
+func TestBroadcastAnnounce_FlowsThroughWhenOn(t *testing.T) {
+	s := newTestServer(t)
+	s.tree.entries[objectKey{slot: 0, group: codec.GroupControl, id: 4}] = &entry{
+		param: &canonical.Parameter{Value: int64(1)}, // On
+	}
+
+	reg := newTCPSessionRegistry(s.logger)
+	send := make(chan []byte, 4)
+	reg.register("10.0.0.1", nil, send)
+	s.tcpRegistry = reg
+
+	ann := &codec.Message{
+		MTID: 0, MType: codec.MTypeReply, MAddr: 1,
+		MCode: byte(codec.MethodSetValue),
+		ObjGroup: codec.GroupControl, ObjID: 0,
+		Value: []byte{0x00, 0x05},
+	}
+	s.broadcastAnnounce(ann)
+
+	if len(send) != 1 {
+		t.Fatalf("Broadcasts=On should fan-out to TCP session: got %d items, want 1", len(send))
+	}
+}

--- a/internal/acp1/provider/server.go
+++ b/internal/acp1/provider/server.go
@@ -184,12 +184,17 @@ func (s *server) SetValue(_ context.Context, path string, val any) (any, error) 
 // mutating method per spec §"Announcements" p.14. Silent on send error
 // — announcements are fire-and-forget, and the consumer that made the
 // setX call already has the change confirmed via the reply.
+//
+// Gated by the Broadcasts field (slot 0 / control / id 4): when the
+// served tree has Broadcasts=Off, every spontaneous announce is
+// suppressed. Replies to active requests stay on regardless — only
+// this path is gated. (#257)
 func (s *server) broadcastAnnounce(ann *codec.Message) {
-	s.mu.Lock()
-	bc := s.bcast
-	s.mu.Unlock()
-	if bc == nil {
-		s.logger.Warn("acp1 announce skipped: no broadcast socket")
+	if !s.tree.broadcastsEnabled() {
+		s.logger.Debug("acp1 announce gated by Broadcasts=Off",
+			slog.Int("objgroup", int(ann.ObjGroup)),
+			slog.Int("objid", int(ann.ObjID)),
+		)
 		return
 	}
 	out, err := ann.Encode()
@@ -199,9 +204,18 @@ func (s *server) broadcastAnnounce(ann *codec.Message) {
 		)
 		return
 	}
-	// Bridge: also fan-out to every live TCP and AN2 session.
+	// Fan-out to every live TCP and AN2 session. Standalone TCP/AN2
+	// providers (no UDP listener) still announce here.
 	s.broadcastTCPAnnounce(out)
 	s.broadcastAN2Announce(out)
+
+	s.mu.Lock()
+	bc := s.bcast
+	s.mu.Unlock()
+	if bc == nil {
+		// No UDP listener — TCP / AN2 fan-out already done above.
+		return
+	}
 	if _, err := bc.Write(out); err != nil {
 		s.logger.Warn("acp1 announce send",
 			slog.String("err", err.Error()),

--- a/internal/acp1/provider/tcp_server.go
+++ b/internal/acp1/provider/tcp_server.go
@@ -157,11 +157,11 @@ func (s *server) serveTCPSession(ctx context.Context, conn *net.TCPConn, ip stri
 			}
 		}
 		if ann != nil {
-			b, err := ann.Encode()
-			if err == nil {
-				// Fan-out: every active session including this one.
-				reg.broadcast(b)
-			}
+			// Route through broadcastAnnounce so the Broadcasts gate
+			// (#257) and UDP+AN2 bridges all apply uniformly. Slow
+			// consumers in the local TCP registry don't block the
+			// announce path — drop-on-full per session.
+			s.broadcastAnnounce(ann)
 		}
 	}
 

--- a/internal/acp1/provider/tree.go
+++ b/internal/acp1/provider/tree.go
@@ -54,6 +54,60 @@ type tree struct {
 	slots map[uint8]*slotCounts
 }
 
+// broadcastsEnabled implements the ACP1 Broadcasts gate per spec p.20:
+// slot 0 / control / id 4 is an enum that controls whether the device
+// emits spontaneous announces. When the field is absent (older trees
+// without the gate object), the default is permissive (true) so legacy
+// behaviour is preserved.
+//
+// The check is deliberately tolerant of enum encoding: any non-zero
+// value-byte counts as "On" since the spec convention is items=["Off","On"]
+// (index 0 = Off, index 1 = On). If the served tree carries a richer
+// enum map with a labelled "On" entry, the lookup honours that too.
+func (t *tree) broadcastsEnabled() bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	e, ok := t.entries[objectKey{slot: 0, group: codec.GroupControl, id: 4}]
+	if !ok {
+		return true // gate object not defined — permissive default
+	}
+	if e.param == nil {
+		return true
+	}
+	// Enum map case: the labelled "On" entry's index is authoritative.
+	if len(e.param.EnumMap) > 0 {
+		var idx uint8
+		switch v := e.param.Value.(type) {
+		case int64:
+			idx = uint8(v)
+		case uint64:
+			idx = uint8(v)
+		case int:
+			idx = uint8(v)
+		case float64:
+			idx = uint8(v)
+		}
+		for _, item := range e.param.EnumMap {
+			if int64(idx) == item.Value {
+				return strings.EqualFold(item.Key, "On")
+			}
+		}
+		return false
+	}
+	// Bare numeric value with no map: convention 0=Off, anything else=On.
+	switch v := e.param.Value.(type) {
+	case int64:
+		return v != 0
+	case uint64:
+		return v != 0
+	case int:
+		return v != 0
+	case float64:
+		return v != 0
+	}
+	return true
+}
+
 // numSlots returns the highest slot number that carries any entry,
 // plus one (giving the count). Used by AN2 GetDeviceInfo replies.
 func (t *tree) numSlots() int {


### PR DESCRIPTION
## Summary

- New `tree.broadcastsEnabled()` method consults `(slot=0, group=control, id=4)` per spec p.20. The served tree value IS the gate; no shadow flag.
- `broadcastAnnounce` checks the gate before fan-out and bails silently on Off. Replies to active requests stay on regardless — only spontaneous announces are gated.
- Centralised: `handleAN2ACP1Frame` and `serveTCPSession` previously fanned announces directly to their session registries, bypassing the gate + UDP broadcast. Both now route through `broadcastAnnounce`.
- `broadcastAnnounce` no longer requires a UDP socket: standalone TCP/AN2 providers (no UDP listener) emit through the bridge fan-outs without warning.
- 13 unit tests covering no-gate permissive default, enum On/Off, bare-numeric truth table, nil-param fallback, end-to-end gated/flowing broadcasts.

## Resolution order for the gate value

| Tree state at (slot=0, control, id=4) | Result |
| --- | --- |
| Entry absent | `enabled=true` (permissive default) |
| Enum with `EnumMap` | label match: `"On"` (case-insensitive) ⇒ true |
| Bare numeric | `0` ⇒ false; anything else ⇒ true |
| Nil `param` | `enabled=true` |

Legacy trees without the gate object keep their current behaviour. Trees that explicitly set `Off` get full silence. Trees that flip mid-stream resume immediately on the next `Set`.

## Why centralise the announce path

Three paths previously bypassed `broadcastAnnounce`:

1. UDP wire (already went through it) ✓
2. TCP wire (`serveTCPSession`) — fanned to TCP registry directly ✗
3. AN2 wire (`handleAN2ACP1Frame`) — fanned to AN2 registry directly ✗

After this PR all three share one entry point that:
- Honours the Broadcasts gate
- Sends UDP limited-broadcast (when configured)
- Bridges to TCP and AN2 sessions

So a Set arriving on AN2 reaches both UDP and TCP consumers, all subject to the same gate.

## Test plan

- [x] `go test ./internal/acp1/provider/... -count=1` — green (13 new + all existing).
- [x] `go build ./...` clean.
- [x] golangci-lint clean.
- [ ] Live test: flip Broadcasts via admin CLI (#258) and verify silence on consumer side.

## Stacked on

PR #278 (AN2/TCP listener). Merge order: Phase 0 (#267-#272) → #273 → #274 → #275 → #276 → #277 → #278 → this.

## Issue refs

Advances #257. Closes on the eventual PR-to-main when the ACP1 epic bundle lands together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
