### PR TITLE
feat(acp1): provider admin CLI surface (advances #258)

### DIFF
--- a/cmd/dhs/cmd_acp1_admin.go
+++ b/cmd/dhs/cmd_acp1_admin.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+
+	acp1provider "dhs/internal/acp1/provider"
+)
+
+// runACP1Admin handles `dhs producer acp1 admin <verb> [flags]`. The
+// concrete verb dispatches to the right helper which assembles the
+// AdminRequest map and calls into the running provider's admin RPC.
+//
+// Discovery: the CLI reads $TMPDIR/dhs-acp1-<name>.json (default name
+// "dhs-acp1") to find the admin TCP loopback address.
+func runACP1Admin(ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		printACP1AdminHelp()
+		return nil
+	}
+	verb := args[0]
+	rest := args[1:]
+
+	switch verb {
+	case "ping":
+		return acp1AdminPing(ctx, rest)
+	case "slot":
+		return acp1AdminSlot(ctx, rest)
+	case "value":
+		return acp1AdminValue(ctx, rest)
+	case "reload":
+		return acp1AdminReload(ctx, rest)
+	case "help", "-h", "--help":
+		printACP1AdminHelp()
+		return nil
+	}
+	return fmt.Errorf("dhs producer acp1 admin: unknown verb %q", verb)
+}
+
+func printACP1AdminHelp() {
+	fmt.Println(`usage: dhs producer acp1 admin <verb> [flags]
+
+verbs:
+  ping                            liveness probe; returns slot count
+  slot load   --slot N --card P   load a DM-library schema into slot N (#260)
+  slot unload --slot N            unload slot N (#260)
+  slot state  --slot N --state S  jump slot N to state (no_card/powerup/boot/present/error/removed)
+  value set   --path P --value V  set object value (path = "1.<slot+1>.<group>.<id>")
+  value get   --slot N --group G --id I
+                                  read object value
+  reload                          reload tree from disk (#259)
+
+common flags:
+  --name NAME    instance name to address (default "dhs-acp1")`)
+}
+
+func adminClient(name string) (*acp1provider.AdminClient, error) {
+	if name == "" {
+		name = "dhs-acp1"
+	}
+	return acp1provider.NewAdminClient(name)
+}
+
+func adminCall(ctx context.Context, name, verb string, args map[string]any) (*acp1provider.AdminResponse, error) {
+	c, err := adminClient(name)
+	if err != nil {
+		return nil, fmt.Errorf("admin: locate provider %q: %w", name, err)
+	}
+	return c.Call(ctx, &acp1provider.AdminRequest{Verb: verb, Args: args})
+}
+
+func printAdminResp(resp *acp1provider.AdminResponse) error {
+	if resp.Status != "ok" {
+		return fmt.Errorf("admin: %s", resp.Message)
+	}
+	if len(resp.Result) == 0 {
+		fmt.Println("ok")
+		return nil
+	}
+	out, err := json.MarshalIndent(resp.Result, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(out))
+	return nil
+}
+
+func acp1AdminPing(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("admin ping", flag.ExitOnError)
+	name := fs.String("name", "dhs-acp1", "provider instance name")
+	_ = fs.Parse(args)
+	resp, err := adminCall(ctx, *name, "ping", nil)
+	if err != nil {
+		return err
+	}
+	return printAdminResp(resp)
+}
+
+func acp1AdminSlot(ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("dhs producer acp1 admin slot: missing sub-verb (load / unload / state)")
+	}
+	sub := args[0]
+	rest := args[1:]
+	fs := flag.NewFlagSet("admin slot "+sub, flag.ExitOnError)
+	name := fs.String("name", "dhs-acp1", "provider instance name")
+	slot := fs.Int("slot", -1, "slot number")
+	switch sub {
+	case "load":
+		card := fs.String("card", "", "DM-library card path: vendor/product/model-rev/proto")
+		_ = fs.Parse(rest)
+		if *slot < 0 || *card == "" {
+			return fmt.Errorf("admin slot load: --slot and --card are required")
+		}
+		resp, err := adminCall(ctx, *name, "slot.load", map[string]any{
+			"slot": *slot,
+			"card": *card,
+		})
+		if err != nil {
+			return err
+		}
+		return printAdminResp(resp)
+	case "unload":
+		_ = fs.Parse(rest)
+		if *slot < 0 {
+			return fmt.Errorf("admin slot unload: --slot is required")
+		}
+		resp, err := adminCall(ctx, *name, "slot.unload", map[string]any{"slot": *slot})
+		if err != nil {
+			return err
+		}
+		return printAdminResp(resp)
+	case "state":
+		state := fs.String("state", "", "target state: no_card / powerup / boot / present / error / removed")
+		_ = fs.Parse(rest)
+		if *slot < 0 || *state == "" {
+			return fmt.Errorf("admin slot state: --slot and --state are required")
+		}
+		resp, err := adminCall(ctx, *name, "slot.state", map[string]any{
+			"slot":  *slot,
+			"state": *state,
+		})
+		if err != nil {
+			return err
+		}
+		return printAdminResp(resp)
+	}
+	return fmt.Errorf("admin slot: unknown sub-verb %q (load / unload / state)", sub)
+}
+
+func acp1AdminValue(ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("dhs producer acp1 admin value: missing sub-verb (set / get)")
+	}
+	sub := args[0]
+	rest := args[1:]
+	fs := flag.NewFlagSet("admin value "+sub, flag.ExitOnError)
+	name := fs.String("name", "dhs-acp1", "provider instance name")
+	switch sub {
+	case "set":
+		path := fs.String("path", "", `object path "1.<slot+1>.<group>.<id>"`)
+		valStr := fs.String("value", "", "new value (parsed as int if numeric, else string)")
+		_ = fs.Parse(rest)
+		if *path == "" || *valStr == "" {
+			return fmt.Errorf("admin value set: --path and --value are required")
+		}
+		var v any
+		if n, err := strconv.ParseInt(*valStr, 10, 64); err == nil {
+			v = n
+		} else {
+			v = *valStr
+		}
+		resp, err := adminCall(ctx, *name, "value.set", map[string]any{
+			"path":  *path,
+			"value": v,
+		})
+		if err != nil {
+			return err
+		}
+		return printAdminResp(resp)
+	case "get":
+		slot := fs.Int("slot", -1, "slot number")
+		group := fs.Int("group", -1, "object group (0..6)")
+		id := fs.Int("id", -1, "object id (0..255)")
+		_ = fs.Parse(rest)
+		if *slot < 0 || *group < 0 || *id < 0 {
+			return fmt.Errorf("admin value get: --slot --group --id all required")
+		}
+		resp, err := adminCall(ctx, *name, "value.get", map[string]any{
+			"slot":  *slot,
+			"group": *group,
+			"id":    *id,
+		})
+		if err != nil {
+			return err
+		}
+		return printAdminResp(resp)
+	}
+	return fmt.Errorf("admin value: unknown sub-verb %q (set / get)", sub)
+}
+
+func acp1AdminReload(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("admin reload", flag.ExitOnError)
+	name := fs.String("name", "dhs-acp1", "provider instance name")
+	_ = fs.Parse(args)
+	resp, err := adminCall(ctx, *name, "reload", nil)
+	if err != nil {
+		return err
+	}
+	return printAdminResp(resp)
+}
+
+// Silence unused-import warnings if the test build is partial.
+var _ = os.Getenv

--- a/cmd/dhs/cmd_producer.go
+++ b/cmd/dhs/cmd_producer.go
@@ -53,6 +53,7 @@ func runProducer(ctx context.Context, protoName string, args []string) error {
 		transport     = fs.String("transport", "udp", "acp1 only: udp (Mode A), tcp (Mode B), an2 (Mode C, port 2072), or all (every transport). Other protocols ignore this flag.")
 		tcpPort       = fs.Int("tcp-port", 0, "acp1 only: TCP listen port for --transport tcp/all (0 = same as --port)")
 		an2Port       = fs.Int("an2-port", 2072, "acp1 only: AN2/TCP listen port for --transport an2/all")
+		adminName     = fs.String("name", "dhs-acp1", "acp1 only: instance name for admin RPC discovery file")
 	)
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -181,6 +182,17 @@ func runProducer(ctx context.Context, protoName string, args []string) error {
 		if !ok {
 			return fmt.Errorf("acp1 producer: wrong server type %T", srv)
 		}
+
+		// Admin RPC always runs alongside the wire transports so the
+		// `dhs producer acp1 admin <verb>` CLI can talk to this
+		// instance (#258).
+		go func() {
+			if err := acp1Srv.ServeAdmin(srvCtx, *adminName); err != nil &&
+				!errors.Is(err, context.Canceled) {
+				logger.Warn("acp1 admin server stopped",
+					slog.String("err", err.Error()))
+			}
+		}()
 		switch *transport {
 		case "udp":
 			if err := acp1Srv.Serve(srvCtx, addr); err != nil && !errors.Is(err, context.Canceled) {

--- a/cmd/dhs/main.go
+++ b/cmd/dhs/main.go
@@ -290,8 +290,13 @@ func dispatchProducer(ctx context.Context, args []string) error {
 	switch verb {
 	case "serve":
 		return runProducer(ctx, proto, rest)
+	case "admin":
+		if proto != "acp1" {
+			return fmt.Errorf("producer %s: admin verb is acp1-only (advances #258)", proto)
+		}
+		return runACP1Admin(ctx, rest)
 	}
-	return fmt.Errorf("producer %s: unknown verb %q (expected: serve)", proto, verb)
+	return fmt.Errorf("producer %s: unknown verb %q (expected: serve | admin)", proto, verb)
 }
 
 // dispatchRegistry routes `dhs registry <proto> <verb> [args]`. The

--- a/internal/acp1/provider/admin.go
+++ b/internal/acp1/provider/admin.go
@@ -1,0 +1,306 @@
+package acp1
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// AdminRequest is one JSON command from a CLI client. Verbs map 1:1 to
+// the issue's `dhs producer acp1 admin <verb> ...` surface. The Args map
+// carries verb-specific parameters.
+type AdminRequest struct {
+	Verb string         `json:"verb"`
+	Args map[string]any `json:"args,omitempty"`
+}
+
+// AdminResponse is the reply envelope. Status is "ok" or "error";
+// when "error", Message carries the diagnostic. Result is verb-specific
+// success payload (e.g. value-get returns {"value": ...}).
+type AdminResponse struct {
+	Status  string         `json:"status"`
+	Message string         `json:"message,omitempty"`
+	Result  map[string]any `json:"result,omitempty"`
+}
+
+// AdminDiscovery is the file written by the running provider so the
+// admin CLI can find the listening port without hard-coding it.
+type AdminDiscovery struct {
+	Name      string    `json:"name"`
+	Addr      string    `json:"addr"`
+	StartedAt time.Time `json:"started_at"`
+	PID       int       `json:"pid"`
+}
+
+// adminMaxFrame caps one length-prefixed JSON request to 64 KiB.
+// Bigger payloads fall outside the admin surface (slot load with a
+// massive DM schema goes through the DM library, not the wire).
+const adminMaxFrame = 64 * 1024
+
+// ServeAdmin runs the admin RPC server. It listens on TCP loopback at a
+// kernel-assigned port and writes a discovery file at
+// $TMPDIR/dhs-acp1-<name>.json so the matching CLI can find it.
+//
+// Returns when ctx is cancelled. The discovery file is removed on exit.
+func (s *server) ServeAdmin(ctx context.Context, name string) error {
+	if name == "" {
+		name = "dhs-acp1"
+	}
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		return fmt.Errorf("acp1 admin: listen: %w", err)
+	}
+	addr := ln.Addr().String()
+
+	disc := AdminDiscovery{
+		Name:      name,
+		Addr:      addr,
+		StartedAt: time.Now().UTC(),
+		PID:       os.Getpid(),
+	}
+	discPath := AdminDiscoveryPath(name)
+	if err := writeAdminDiscovery(discPath, &disc); err != nil {
+		_ = ln.Close()
+		return fmt.Errorf("acp1 admin: discovery file: %w", err)
+	}
+	defer func() { _ = os.Remove(discPath) }()
+
+	s.logger.Info("acp1 admin listening",
+		slog.String("name", name),
+		slog.String("addr", addr),
+		slog.String("discovery", discPath))
+
+	go func() {
+		<-ctx.Done()
+		_ = ln.Close()
+	}()
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if isClosed(err) || errors.Is(ctx.Err(), context.Canceled) {
+				return nil
+			}
+			s.logger.Warn("acp1 admin accept", slog.String("err", err.Error()))
+			continue
+		}
+		go s.handleAdminConn(ctx, conn)
+	}
+}
+
+// AdminDiscoveryPath returns the platform-specific discovery file path
+// for the named instance. Exported so the admin CLI can locate the
+// running provider.
+func AdminDiscoveryPath(name string) string {
+	return filepath.Join(os.TempDir(), fmt.Sprintf("dhs-acp1-%s.json", sanitiseName(name)))
+}
+
+func writeAdminDiscovery(path string, d *AdminDiscovery) error {
+	raw, err := json.MarshalIndent(d, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, raw, 0o600); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// ReadAdminDiscovery is used by the admin CLI client to find a running
+// provider's address.
+func ReadAdminDiscovery(name string) (*AdminDiscovery, error) {
+	raw, err := os.ReadFile(AdminDiscoveryPath(name))
+	if err != nil {
+		return nil, err
+	}
+	var d AdminDiscovery
+	if err := json.Unmarshal(raw, &d); err != nil {
+		return nil, fmt.Errorf("admin discovery decode: %w", err)
+	}
+	return &d, nil
+}
+
+// handleAdminConn serves one admin client connection: read a single
+// length-prefixed JSON request, dispatch via handleAdminRequest, write
+// the reply, close. Keep-alive isn't needed — admin calls are rare.
+func (s *server) handleAdminConn(ctx context.Context, conn net.Conn) {
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+
+	var lenBuf [4]byte
+	if _, err := io.ReadFull(conn, lenBuf[:]); err != nil {
+		return
+	}
+	mlen := binary.BigEndian.Uint32(lenBuf[:])
+	if mlen == 0 || mlen > adminMaxFrame {
+		s.writeAdminErr(conn, fmt.Errorf("frame size %d out of range", mlen))
+		return
+	}
+	body := make([]byte, mlen)
+	if _, err := io.ReadFull(conn, body); err != nil {
+		return
+	}
+
+	var req AdminRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		s.writeAdminErr(conn, fmt.Errorf("decode: %w", err))
+		return
+	}
+	resp := s.handleAdminRequest(ctx, &req)
+	s.writeAdminResp(conn, resp)
+}
+
+// writeAdminResp emits a length-prefixed JSON reply.
+func (s *server) writeAdminResp(conn net.Conn, resp *AdminResponse) {
+	raw, err := json.Marshal(resp)
+	if err != nil {
+		raw, _ = json.Marshal(&AdminResponse{Status: "error", Message: err.Error()})
+	}
+	var lenBuf [4]byte
+	binary.BigEndian.PutUint32(lenBuf[:], uint32(len(raw)))
+	_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	_, _ = conn.Write(lenBuf[:])
+	_, _ = conn.Write(raw)
+}
+
+func (s *server) writeAdminErr(conn net.Conn, err error) {
+	s.writeAdminResp(conn, &AdminResponse{Status: "error", Message: err.Error()})
+}
+
+// AdminClient is the in-process side of the admin RPC. The CLI uses
+// this; tests use it too. One round-trip per call.
+type AdminClient struct {
+	addr string
+}
+
+// NewAdminClient resolves a discovery file and returns a client.
+func NewAdminClient(name string) (*AdminClient, error) {
+	d, err := ReadAdminDiscovery(name)
+	if err != nil {
+		return nil, err
+	}
+	return &AdminClient{addr: d.Addr}, nil
+}
+
+// Call sends one request and returns the response. Error reflects
+// transport failures; AdminResponse.Status carries application-level
+// outcome.
+func (c *AdminClient) Call(ctx context.Context, req *AdminRequest) (*AdminResponse, error) {
+	conn, err := net.DialTimeout("tcp4", c.addr, 5*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("admin dial: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	if dl, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(dl)
+	} else {
+		_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	var lenBuf [4]byte
+	binary.BigEndian.PutUint32(lenBuf[:], uint32(len(body)))
+	if _, err := conn.Write(lenBuf[:]); err != nil {
+		return nil, fmt.Errorf("admin write: %w", err)
+	}
+	if _, err := conn.Write(body); err != nil {
+		return nil, fmt.Errorf("admin write body: %w", err)
+	}
+
+	if _, err := io.ReadFull(conn, lenBuf[:]); err != nil {
+		return nil, fmt.Errorf("admin read len: %w", err)
+	}
+	rlen := binary.BigEndian.Uint32(lenBuf[:])
+	if rlen > adminMaxFrame {
+		return nil, fmt.Errorf("admin reply size %d > max %d", rlen, adminMaxFrame)
+	}
+	respBody := make([]byte, rlen)
+	if _, err := io.ReadFull(conn, respBody); err != nil {
+		return nil, fmt.Errorf("admin read body: %w", err)
+	}
+	var resp AdminResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("admin decode: %w", err)
+	}
+	return &resp, nil
+}
+
+// sanitiseName trims a free-text instance name into a filesystem-safe
+// component. Falls back to "dhs-acp1" if nothing usable remains.
+func sanitiseName(name string) string {
+	var b []byte
+	for _, c := range []byte(name) {
+		switch {
+		case c >= 'A' && c <= 'Z',
+			c >= 'a' && c <= 'z',
+			c >= '0' && c <= '9',
+			c == '.', c == '_', c == '-':
+			b = append(b, c)
+		}
+	}
+	if len(b) == 0 {
+		return "dhs-acp1"
+	}
+	return string(b)
+}
+
+// adminHandlers is the registry of verb -> handler functions. Single
+// global so tests + tree-load reload share the same set.
+type adminHandler func(ctx context.Context, s *server, args map[string]any) (*AdminResponse, error)
+
+var adminHandlers = map[string]adminHandler{}
+var adminHandlersMu sync.RWMutex
+
+func registerAdminHandler(verb string, h adminHandler) {
+	adminHandlersMu.Lock()
+	adminHandlers[verb] = h
+	adminHandlersMu.Unlock()
+}
+
+func lookupAdminHandler(verb string) (adminHandler, bool) {
+	adminHandlersMu.RLock()
+	defer adminHandlersMu.RUnlock()
+	h, ok := adminHandlers[verb]
+	return h, ok
+}
+
+// handleAdminRequest dispatches one decoded request to the right
+// handler. Returns a non-nil AdminResponse for every request.
+func (s *server) handleAdminRequest(ctx context.Context, req *AdminRequest) *AdminResponse {
+	h, ok := lookupAdminHandler(req.Verb)
+	if !ok {
+		return &AdminResponse{
+			Status:  "error",
+			Message: fmt.Sprintf("unknown verb %q", req.Verb),
+		}
+	}
+	resp, err := h(ctx, s, req.Args)
+	if err != nil {
+		return &AdminResponse{Status: "error", Message: err.Error()}
+	}
+	if resp == nil {
+		return &AdminResponse{Status: "ok"}
+	}
+	if resp.Status == "" {
+		resp.Status = "ok"
+	}
+	return resp
+}

--- a/internal/acp1/provider/admin_handlers.go
+++ b/internal/acp1/provider/admin_handlers.go
@@ -1,0 +1,183 @@
+package acp1
+
+import (
+	"context"
+	"fmt"
+
+	"dhs/internal/acp1/codec"
+)
+
+func init() {
+	registerAdminHandler("ping", handlePing)
+	registerAdminHandler("slot.load", handleSlotLoad)
+	registerAdminHandler("slot.unload", handleSlotUnload)
+	registerAdminHandler("slot.state", handleSlotState)
+	registerAdminHandler("value.set", handleValueSet)
+	registerAdminHandler("value.get", handleValueGet)
+	registerAdminHandler("reload", handleReload)
+}
+
+// handlePing is a liveness probe. Used by tests + the CLI's `admin
+// ping` to confirm a running provider before issuing real verbs.
+func handlePing(_ context.Context, s *server, _ map[string]any) (*AdminResponse, error) {
+	return &AdminResponse{
+		Status: "ok",
+		Result: map[string]any{
+			"slots": s.tree.numSlots(),
+		},
+	}, nil
+}
+
+// handleSlotLoad is reserved for the DM-library loader (#260). For now
+// it returns a clear "not implemented yet" diagnostic so the verb is
+// reachable from the CLI but the actual schema-load wiring waits.
+func handleSlotLoad(_ context.Context, _ *server, _ map[string]any) (*AdminResponse, error) {
+	return &AdminResponse{
+		Status:  "error",
+		Message: "slot.load: DM-library loader lands in #260; verb is plumbed but not yet wired",
+	}, nil
+}
+
+// handleSlotUnload mirrors handleSlotLoad — full implementation lands
+// in #260 alongside the loader.
+func handleSlotUnload(_ context.Context, _ *server, _ map[string]any) (*AdminResponse, error) {
+	return &AdminResponse{
+		Status:  "error",
+		Message: "slot.unload: DM-library loader lands in #260",
+	}, nil
+}
+
+// handleSlotState mutates the rack-controller's frame-status array for
+// one slot. The full state-machine cascade (no_card → powerup → boot
+// → present with realistic timings) lands in #259; this handler does
+// the immediate-jump variant per the issue's `slot state * → error`
+// shortcut.
+func handleSlotState(_ context.Context, s *server, args map[string]any) (*AdminResponse, error) {
+	slot, err := readIntArg(args, "slot")
+	if err != nil {
+		return nil, err
+	}
+	stateStr, err := readStringArg(args, "state")
+	if err != nil {
+		return nil, err
+	}
+	state, err := parseSlotStatus(stateStr)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.setSlotStatus(uint8(slot), state); err != nil {
+		return nil, err
+	}
+	return &AdminResponse{
+		Result: map[string]any{
+			"slot":  slot,
+			"state": stateStr,
+		},
+	}, nil
+}
+
+// handleValueSet drives a SetValue through the API path. The path
+// format mirrors the existing s.SetValue contract:
+// "1.<slot+1>.<group_num>.<id>".
+func handleValueSet(ctx context.Context, s *server, args map[string]any) (*AdminResponse, error) {
+	path, err := readStringArg(args, "path")
+	if err != nil {
+		return nil, err
+	}
+	value, ok := args["value"]
+	if !ok {
+		return nil, fmt.Errorf("value.set: missing arg %q", "value")
+	}
+	got, err := s.SetValue(ctx, path, value)
+	if err != nil {
+		return nil, err
+	}
+	return &AdminResponse{
+		Result: map[string]any{
+			"path":  path,
+			"value": got,
+		},
+	}, nil
+}
+
+// handleValueGet reads one object value through the wire dispatcher.
+// Synthesises a getValue request and returns the decoded value bytes
+// as base64-equivalent (raw bytes) so callers can post-process.
+func handleValueGet(_ context.Context, s *server, args map[string]any) (*AdminResponse, error) {
+	slot, err := readIntArg(args, "slot")
+	if err != nil {
+		return nil, err
+	}
+	groupNum, err := readIntArg(args, "group")
+	if err != nil {
+		return nil, err
+	}
+	id, err := readIntArg(args, "id")
+	if err != nil {
+		return nil, err
+	}
+
+	req := &codec.Message{
+		MType:    codec.MTypeRequest,
+		MAddr:    uint8(slot),
+		MCode:    byte(codec.MethodGetValue),
+		ObjGroup: codec.ObjGroup(groupNum),
+		ObjID:    uint8(id),
+	}
+	rep, _ := s.handleRequest(req)
+	if rep == nil {
+		return nil, fmt.Errorf("value.get: no reply (object missing or method unsupported)")
+	}
+	if rep.IsError() {
+		return nil, rep.ErrCode()
+	}
+	return &AdminResponse{
+		Result: map[string]any{
+			"slot":  slot,
+			"group": groupNum,
+			"id":    id,
+			"raw":   rep.Value,
+		},
+	}, nil
+}
+
+// handleReload re-reads the served tree from disk. Implemented as a
+// stub for now — the file path is not stored on the server. Wiring
+// happens alongside #259 when the producer CLI passes its --tree path
+// down for hot-reload.
+func handleReload(_ context.Context, _ *server, _ map[string]any) (*AdminResponse, error) {
+	return &AdminResponse{
+		Status:  "error",
+		Message: "reload: tree-path bookkeeping lands alongside #259",
+	}, nil
+}
+
+// ---- helpers -----------------------------------------------------------
+
+func readIntArg(args map[string]any, key string) (int, error) {
+	raw, ok := args[key]
+	if !ok {
+		return 0, fmt.Errorf("missing arg %q", key)
+	}
+	switch v := raw.(type) {
+	case int:
+		return v, nil
+	case int64:
+		return int(v), nil
+	case float64:
+		return int(v), nil
+	}
+	return 0, fmt.Errorf("arg %q: want number, got %T", key, raw)
+}
+
+func readStringArg(args map[string]any, key string) (string, error) {
+	raw, ok := args[key]
+	if !ok {
+		return "", fmt.Errorf("missing arg %q", key)
+	}
+	s, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("arg %q: want string, got %T", key, raw)
+	}
+	return s, nil
+}

--- a/internal/acp1/provider/admin_slot.go
+++ b/internal/acp1/provider/admin_slot.go
@@ -1,0 +1,85 @@
+package acp1
+
+import (
+	"fmt"
+
+	"dhs/internal/acp1/codec"
+)
+
+// parseSlotStatus translates an admin-supplied state string into the
+// numeric SlotStatus byte. Names follow the SlotState semantic vocabulary
+// from #249 — "powerup" not "power_up", "boot" not "boot_mode" — so the
+// admin CLI matches what watch / health renders.
+func parseSlotStatus(s string) (uint8, error) {
+	switch s {
+	case "no_card":
+		return 0, nil
+	case "powerup":
+		return 1, nil
+	case "present":
+		return 2, nil
+	case "error":
+		return 3, nil
+	case "removed":
+		return 4, nil
+	case "boot":
+		return 5, nil
+	}
+	return 0, fmt.Errorf("unknown slot state %q (use no_card / powerup / boot / present / error / removed)", s)
+}
+
+// setSlotStatus mutates the rack-controller's frame-status array for one
+// slot and broadcasts an announce so subscribed consumers see the
+// transition. Bypasses the normal SetValue path because frame-status is
+// read-only over the wire — admin-driven mutation is intentional.
+func (s *server) setSlotStatus(slot uint8, state uint8) error {
+	if state > 5 {
+		return fmt.Errorf("slot state %d out of range 0..5", state)
+	}
+	frameKey := objectKey{slot: 0, group: codec.GroupFrame, id: 0}
+
+	s.tree.mu.Lock()
+	e, ok := s.tree.entries[frameKey]
+	if !ok || e.param == nil {
+		s.tree.mu.Unlock()
+		return fmt.Errorf("frame-status object (slot=0, group=frame, id=0) absent in tree")
+	}
+
+	statuses, ok := e.param.Value.([]any)
+	if !ok {
+		s.tree.mu.Unlock()
+		return fmt.Errorf("frame-status value is %T, want []any", e.param.Value)
+	}
+	if int(slot) >= len(statuses) {
+		s.tree.mu.Unlock()
+		return fmt.Errorf("slot %d out of range (frame-status has %d slots)", slot, len(statuses))
+	}
+	statuses[slot] = int64(state)
+	e.param.Value = statuses
+	s.tree.mu.Unlock()
+
+	// Build a frame-status announce body: [num_slots, status_0, ...].
+	body := make([]byte, 1+len(statuses))
+	body[0] = byte(len(statuses))
+	for i, st := range statuses {
+		switch v := st.(type) {
+		case int64:
+			body[1+i] = byte(v)
+		case int:
+			body[1+i] = byte(v)
+		case float64:
+			body[1+i] = byte(v)
+		}
+	}
+	ann := &codec.Message{
+		MTID:     0,
+		MType:    codec.MTypeAnnounce,
+		MAddr:    0,
+		MCode:    0,
+		ObjGroup: codec.GroupFrame,
+		ObjID:    0,
+		Value:    body,
+	}
+	s.broadcastAnnounce(ann)
+	return nil
+}

--- a/internal/acp1/provider/admin_test.go
+++ b/internal/acp1/provider/admin_test.go
@@ -1,0 +1,198 @@
+package acp1
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// startAdminServer launches s.ServeAdmin under a unique name and
+// returns the client + cancel func.
+func startAdminServer(t *testing.T, s *server, name string) *AdminClient {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- s.ServeAdmin(ctx, name)
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	var c *AdminClient
+	for time.Now().Before(deadline) {
+		client, err := NewAdminClient(name)
+		if err == nil {
+			c = client
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if c == nil {
+		cancel()
+		t.Fatalf("admin server did not become reachable")
+	}
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Errorf("admin server did not return within 2s of cancel")
+		}
+	})
+	return c
+}
+
+func TestAdminPing(t *testing.T) {
+	s := newTestServer(t)
+	c := startAdminServer(t, s, "test-ping")
+
+	resp, err := c.Call(context.Background(), &AdminRequest{Verb: "ping"})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if resp.Status != "ok" {
+		t.Fatalf("status = %q, want ok (msg=%s)", resp.Status, resp.Message)
+	}
+	if resp.Result == nil {
+		t.Fatalf("result missing")
+	}
+	slots, ok := resp.Result["slots"].(float64)
+	if !ok || slots <= 0 {
+		t.Fatalf("slots = %v, want positive number", resp.Result["slots"])
+	}
+}
+
+func TestAdminUnknownVerb(t *testing.T) {
+	s := newTestServer(t)
+	c := startAdminServer(t, s, "test-unknown")
+
+	resp, err := c.Call(context.Background(), &AdminRequest{Verb: "wat"})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if resp.Status != "error" {
+		t.Fatalf("status = %q, want error", resp.Status)
+	}
+}
+
+func TestAdminValueGet(t *testing.T) {
+	s := newTestServer(t)
+	c := startAdminServer(t, s, "test-value-get")
+
+	// slot=1 group=1 (identity) id=0 returns the Card Label string.
+	resp, err := c.Call(context.Background(), &AdminRequest{
+		Verb: "value.get",
+		Args: map[string]any{"slot": 1, "group": 1, "id": 0},
+	})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if resp.Status != "ok" {
+		t.Fatalf("status = %q (msg=%s)", resp.Status, resp.Message)
+	}
+}
+
+func TestAdminValueSet(t *testing.T) {
+	s := newTestServer(t)
+	c := startAdminServer(t, s, "test-value-set")
+
+	resp, err := c.Call(context.Background(), &AdminRequest{
+		Verb: "value.set",
+		Args: map[string]any{"path": "1.2.2.0", "value": int64(7)},
+	})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if resp.Status != "ok" {
+		t.Fatalf("status = %q (msg=%s)", resp.Status, resp.Message)
+	}
+}
+
+func TestAdminSlotState(t *testing.T) {
+	s := newTestServer(t)
+	c := startAdminServer(t, s, "test-slot-state")
+
+	resp, err := c.Call(context.Background(), &AdminRequest{
+		Verb: "slot.state",
+		Args: map[string]any{"slot": 1, "state": "error"},
+	})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if resp.Status != "ok" {
+		t.Fatalf("status = %q (msg=%s)", resp.Status, resp.Message)
+	}
+}
+
+func TestAdminSlotState_UnknownState(t *testing.T) {
+	s := newTestServer(t)
+	c := startAdminServer(t, s, "test-slot-bad")
+
+	resp, err := c.Call(context.Background(), &AdminRequest{
+		Verb: "slot.state",
+		Args: map[string]any{"slot": 1, "state": "wat"},
+	})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if resp.Status != "error" {
+		t.Fatalf("status = %q, want error for unknown state", resp.Status)
+	}
+}
+
+func TestAdminSlotLoad_NotImplemented(t *testing.T) {
+	s := newTestServer(t)
+	c := startAdminServer(t, s, "test-slot-load")
+
+	resp, err := c.Call(context.Background(), &AdminRequest{
+		Verb: "slot.load",
+		Args: map[string]any{"slot": 1, "card": "axon/synapse/RRS18-1601/acp1"},
+	})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if resp.Status != "error" {
+		t.Fatalf("status = %q, want error (#260 not yet wired)", resp.Status)
+	}
+}
+
+func TestAdminMultiInstance_DistinctDiscoveryFiles(t *testing.T) {
+	s1 := newTestServer(t)
+	s2 := newTestServer(t)
+	c1 := startAdminServer(t, s1, "rackA")
+	c2 := startAdminServer(t, s2, "rackB")
+
+	if c1.addr == c2.addr {
+		t.Fatalf("two instances share addr %q — discovery file collision", c1.addr)
+	}
+
+	r1, err := c1.Call(context.Background(), &AdminRequest{Verb: "ping"})
+	if err != nil || r1.Status != "ok" {
+		t.Fatalf("rackA ping: %v / %+v", err, r1)
+	}
+	r2, err := c2.Call(context.Background(), &AdminRequest{Verb: "ping"})
+	if err != nil || r2.Status != "ok" {
+		t.Fatalf("rackB ping: %v / %+v", err, r2)
+	}
+}
+
+func TestSanitiseName(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"dhs-acp1", "dhs-acp1"},
+		{"rack A", "rackA"},
+		{"slash/danger", "slashdanger"},
+		{"empty:::", "empty"},
+		{":::", "dhs-acp1"},
+		{"valid.name_v2", "valid.name_v2"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := sanitiseName(tc.in); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Local admin RPC over TCP loopback with a discovery file at `$TMPDIR/dhs-acp1-<name>.json`. Multi-instance via `--name`; cross-platform (no Unix-socket/named-pipe build-tag dance).
- Wire format: length-prefixed JSON request + response, 64 KiB cap.
- Server runs as a goroutine alongside `Serve` / `ServeTCP` / `ServeAN2` inside `dhs producer acp1 serve`.
- New CLI dispatch: `dhs producer acp1 admin <verb>` reads the discovery file and round-trips over TCP.
- 8 unit + integration tests.

## Verb surface

| Verb | Status |
| --- | --- |
| `ping` | implemented (liveness + slot count) |
| `slot.state` | implemented (direct mutation; emits frame-status announce) |
| `value.set` | implemented (routes through `s.SetValue`) |
| `value.get` | implemented (synthesises wire getValue + handleRequest) |
| `slot.load` | stub — reserved for #260 (DM-library loader) |
| `slot.unload` | stub — reserved for #260 |
| `reload` | stub — reserved for #259 (tree-path bookkeeping) |

The stubs return clear `not yet wired` errors so the CLI can still call them; the framework lands here, the wiring lands in the named follow-up issues.

## CLI shape

```
dhs producer acp1 serve --tree T.json --transport all --name rackA
dhs producer acp1 admin  ping --name rackA
dhs producer acp1 admin  slot state  --slot 1 --state error --name rackA
dhs producer acp1 admin  value set   --path 1.2.2.0 --value 5 --name rackA
dhs producer acp1 admin  value get   --slot 1 --group 1 --id 0 --name rackA
```

## Test plan

- [x] `go test ./internal/acp1/provider/... -count=1` — green (8 admin + all existing).
- [x] `go test ./...` — every package green.
- [x] `go build ./...` clean.
- [x] golangci-lint clean.
- [ ] Live test: drive admin verbs against a running provider on the integration rig.

## Stacked on

PR #279 (Broadcasts gate). Merge order: Phase 0 (#267-#272) → #273 → #274 → #275 → #276 → #277 → #278 → #279 → this.

## Issue refs

Advances #258. Closes on the eventual PR-to-main when the ACP1 epic bundle lands together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
