### PR TITLE
feat(acp1): provider slot state machine + realistic timings (advances #259)

### DIFF
--- a/cmd/dhs/cmd_producer.go
+++ b/cmd/dhs/cmd_producer.go
@@ -54,6 +54,7 @@ func runProducer(ctx context.Context, protoName string, args []string) error {
 		tcpPort       = fs.Int("tcp-port", 0, "acp1 only: TCP listen port for --transport tcp/all (0 = same as --port)")
 		an2Port       = fs.Int("an2-port", 2072, "acp1 only: AN2/TCP listen port for --transport an2/all")
 		adminName     = fs.String("name", "dhs-acp1", "acp1 only: instance name for admin RPC discovery file")
+		insertTiming  = fs.String("insert-timing", "real", "acp1 only: cascade timing for slot insert (real / fast)")
 	)
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -182,6 +183,14 @@ func runProducer(ctx context.Context, protoName string, args []string) error {
 		if !ok {
 			return fmt.Errorf("acp1 producer: wrong server type %T", srv)
 		}
+
+		// Slot state-machine timing: --insert-timing real (default) or
+		// fast (50ms per phase, for CI integration tests).
+		timing, err := acp1provider.ParseInsertTiming(*insertTiming)
+		if err != nil {
+			return err
+		}
+		acp1Srv.SetInsertTiming(timing)
 
 		// Admin RPC always runs alongside the wire transports so the
 		// `dhs producer acp1 admin <verb>` CLI can talk to this

--- a/internal/acp1/provider/admin_handlers.go
+++ b/internal/acp1/provider/admin_handlers.go
@@ -12,9 +12,38 @@ func init() {
 	registerAdminHandler("slot.load", handleSlotLoad)
 	registerAdminHandler("slot.unload", handleSlotUnload)
 	registerAdminHandler("slot.state", handleSlotState)
+	registerAdminHandler("slot.insert", handleSlotInsert)
+	registerAdminHandler("slot.extract", handleSlotExtract)
 	registerAdminHandler("value.set", handleValueSet)
 	registerAdminHandler("value.get", handleValueGet)
 	registerAdminHandler("reload", handleReload)
+}
+
+// handleSlotInsert kicks off the no_card -> powerup -> boot -> present
+// cascade. Returns immediately; the cascade runs in the background
+// using the configured InsertTiming. Pre-empts any in-flight cascade.
+func handleSlotInsert(ctx context.Context, s *server, args map[string]any) (*AdminResponse, error) {
+	slot, err := readIntArg(args, "slot")
+	if err != nil {
+		return nil, err
+	}
+	s.CascadeInsert(ctx, uint8(slot))
+	return &AdminResponse{
+		Result: map[string]any{"slot": slot, "started": true},
+	}, nil
+}
+
+// handleSlotExtract drives present -> removed -> no_card immediately.
+// Pre-empts any in-flight insert cascade.
+func handleSlotExtract(_ context.Context, s *server, args map[string]any) (*AdminResponse, error) {
+	slot, err := readIntArg(args, "slot")
+	if err != nil {
+		return nil, err
+	}
+	s.CascadeExtract(uint8(slot))
+	return &AdminResponse{
+		Result: map[string]any{"slot": slot, "extracted": true},
+	}, nil
 }
 
 // handlePing is a liveness probe. Used by tests + the CLI's `admin

--- a/internal/acp1/provider/server.go
+++ b/internal/acp1/provider/server.go
@@ -50,6 +50,19 @@ type server struct {
 	// UDP / TCP broadcast paths are also wrapped in AN2 frames and
 	// fanned to AN2 sessions that have called EnableProtocolEvents.
 	an2Registry *an2SessionRegistry
+
+	// slotMachine tracks pending insert/extract cascades per slot.
+	// Initialised by newServer with InsertTimingReal; the producer CLI
+	// can override via --insert-timing.
+	slotMachine *slotStateMachine
+}
+
+// SetInsertTiming switches the cascade timing for new transitions.
+// Existing in-flight cascades keep their starting timing.
+func (s *server) SetInsertTiming(t InsertTiming) {
+	if s.slotMachine != nil {
+		s.slotMachine.SetTiming(t)
+	}
 }
 
 func newServer(logger *slog.Logger, exp *canonical.Export) *server {
@@ -57,8 +70,9 @@ func newServer(logger *slog.Logger, exp *canonical.Export) *server {
 		logger = slog.Default()
 	}
 	s := &server{
-		logger:  logger,
-		stopped: make(chan struct{}),
+		logger:      logger,
+		stopped:     make(chan struct{}),
+		slotMachine: newSlotStateMachine(InsertTimingReal),
 	}
 	t, err := newTree(exp)
 	if err != nil {

--- a/internal/acp1/provider/slot_state_machine.go
+++ b/internal/acp1/provider/slot_state_machine.go
@@ -1,0 +1,190 @@
+package acp1
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// InsertTiming selects the durations the slot state machine uses for
+// the no_card -> powerup -> boot -> present cascade.
+type InsertTiming int
+
+const (
+	// InsertTimingReal uses spec-typical durations (1-3s per phase) so
+	// the emulator visually matches a real Synapse hot-plug.
+	InsertTimingReal InsertTiming = iota
+
+	// InsertTimingFast uses 50ms per phase so CI integration tests
+	// finish quickly without losing the cascade structure.
+	InsertTimingFast
+)
+
+func (t InsertTiming) String() string {
+	switch t {
+	case InsertTimingReal:
+		return "real"
+	case InsertTimingFast:
+		return "fast"
+	}
+	return fmt.Sprintf("timing(%d)", t)
+}
+
+// ParseInsertTiming translates the producer CLI flag value.
+func ParseInsertTiming(s string) (InsertTiming, error) {
+	switch s {
+	case "", "real":
+		return InsertTimingReal, nil
+	case "fast":
+		return InsertTimingFast, nil
+	}
+	return InsertTimingReal, fmt.Errorf("unknown --insert-timing %q (use real / fast)", s)
+}
+
+func (t InsertTiming) powerupDuration() time.Duration {
+	if t == InsertTimingFast {
+		return 50 * time.Millisecond
+	}
+	return 1500 * time.Millisecond
+}
+
+func (t InsertTiming) bootDuration() time.Duration {
+	if t == InsertTimingFast {
+		return 50 * time.Millisecond
+	}
+	return 2500 * time.Millisecond
+}
+
+// slotStateMachine tracks per-slot pending transitions. Methods are
+// safe for concurrent calls. Cancelling a slot's cascade stops any
+// pending timer before it fires the next transition.
+type slotStateMachine struct {
+	mu      sync.Mutex
+	pending map[uint8]context.CancelFunc
+	timing  InsertTiming
+}
+
+func newSlotStateMachine(timing InsertTiming) *slotStateMachine {
+	return &slotStateMachine{
+		pending: map[uint8]context.CancelFunc{},
+		timing:  timing,
+	}
+}
+
+// SetTiming updates the cascade timing. Pending cascades continue with
+// the timing they started with; new cascades use the new timing.
+func (m *slotStateMachine) SetTiming(t InsertTiming) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.timing = t
+}
+
+// cancelPending stops any in-flight cascade for slot. Safe to call
+// when nothing is pending.
+func (m *slotStateMachine) cancelPending(slot uint8) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if cancel, ok := m.pending[slot]; ok {
+		cancel()
+		delete(m.pending, slot)
+	}
+}
+
+// trackCascade registers a cancel func for the given slot. Replaces
+// any existing pending cascade.
+func (m *slotStateMachine) trackCascade(slot uint8, cancel context.CancelFunc) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if prev, ok := m.pending[slot]; ok {
+		prev() // pre-empt any pending cascade for this slot
+	}
+	m.pending[slot] = cancel
+}
+
+func (m *slotStateMachine) clearCascade(slot uint8) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.pending, slot)
+}
+
+// CascadeInsert drives the no_card -> powerup -> boot -> present
+// transition for one slot. Each phase emits a frame-status announce
+// via setSlotStatus before the timer for the next phase fires.
+//
+// Pre-empts any in-flight cascade for the same slot.
+//
+// Returns immediately; the cascade runs on a background goroutine and
+// completes after powerupDuration + bootDuration, OR aborts early if
+// the parent context cancels (server stop, slot.extract during
+// cascade, etc.).
+func (s *server) CascadeInsert(parent context.Context, slot uint8) {
+	machine := s.slotMachine
+	if machine == nil {
+		return
+	}
+	machine.cancelPending(slot)
+
+	ctx, cancel := context.WithCancel(parent)
+	machine.trackCascade(slot, cancel)
+
+	timing := func() InsertTiming {
+		machine.mu.Lock()
+		defer machine.mu.Unlock()
+		return machine.timing
+	}()
+
+	go func() {
+		defer machine.clearCascade(slot)
+
+		// Phase 1: no_card -> powerup (immediate).
+		if err := s.setSlotStatus(slot, 1 /* powerup */); err != nil {
+			s.logger.Warn("cascade powerup failed", "slot", slot, "err", err)
+			return
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(timing.powerupDuration()):
+		}
+
+		// Phase 2: powerup -> boot.
+		if err := s.setSlotStatus(slot, 5 /* boot */); err != nil {
+			s.logger.Warn("cascade boot failed", "slot", slot, "err", err)
+			return
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(timing.bootDuration()):
+		}
+
+		// Phase 3: boot -> present.
+		if err := s.setSlotStatus(slot, 2 /* present */); err != nil {
+			s.logger.Warn("cascade present failed", "slot", slot, "err", err)
+			return
+		}
+	}()
+}
+
+// CascadeExtract drives the present -> removed -> no_card extraction.
+// Both transitions fire immediately; spec p.20 has no required dwell
+// time between them.
+//
+// Pre-empts any in-flight insert cascade for the same slot — pulling
+// a card out mid-boot is a real-world scenario.
+func (s *server) CascadeExtract(slot uint8) {
+	machine := s.slotMachine
+	if machine != nil {
+		machine.cancelPending(slot)
+	}
+	if err := s.setSlotStatus(slot, 4 /* removed */); err != nil {
+		s.logger.Warn("cascade removed failed", "slot", slot, "err", err)
+		return
+	}
+	if err := s.setSlotStatus(slot, 0 /* no_card */); err != nil {
+		s.logger.Warn("cascade no_card failed", "slot", slot, "err", err)
+	}
+}

--- a/internal/acp1/provider/slot_state_machine_test.go
+++ b/internal/acp1/provider/slot_state_machine_test.go
@@ -1,0 +1,213 @@
+package acp1
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"dhs/internal/acp1/codec"
+)
+
+// readSlotStatus extracts the current numeric status byte for a slot
+// from the rack-controller frame-status object.
+func readSlotStatus(t *testing.T, s *server, slot uint8) uint8 {
+	t.Helper()
+	s.tree.mu.RLock()
+	defer s.tree.mu.RUnlock()
+	e := s.tree.entries[objectKey{slot: 0, group: codec.GroupFrame, id: 0}]
+	if e == nil || e.param == nil {
+		t.Fatalf("frame-status object absent")
+	}
+	statuses, ok := e.param.Value.([]any)
+	if !ok || int(slot) >= len(statuses) {
+		t.Fatalf("frame-status shape unexpected: %T (slot %d, len %d)", e.param.Value, slot, len(statuses))
+	}
+	switch v := statuses[slot].(type) {
+	case int64:
+		return uint8(v)
+	case int:
+		return uint8(v)
+	case float64:
+		return uint8(v)
+	}
+	t.Fatalf("status type %T", statuses[slot])
+	return 0
+}
+
+func TestParseInsertTiming(t *testing.T) {
+	cases := []struct {
+		in   string
+		want InsertTiming
+		err  bool
+	}{
+		{"", InsertTimingReal, false},
+		{"real", InsertTimingReal, false},
+		{"fast", InsertTimingFast, false},
+		{"slow", 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := ParseInsertTiming(tc.in)
+			if tc.err {
+				if err == nil {
+					t.Fatalf("expected error for %q", tc.in)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestInsertTiming_Durations(t *testing.T) {
+	if InsertTimingFast.powerupDuration() >= time.Second {
+		t.Fatalf("fast powerup too slow: %v", InsertTimingFast.powerupDuration())
+	}
+	if InsertTimingFast.bootDuration() >= time.Second {
+		t.Fatalf("fast boot too slow: %v", InsertTimingFast.bootDuration())
+	}
+	if InsertTimingReal.powerupDuration() < time.Second {
+		t.Fatalf("real powerup too fast: %v", InsertTimingReal.powerupDuration())
+	}
+	if InsertTimingReal.bootDuration() < time.Second {
+		t.Fatalf("real boot too fast: %v", InsertTimingReal.bootDuration())
+	}
+}
+
+func TestCascadeInsert_Fast_ReachesPresent(t *testing.T) {
+	s := newTestServer(t)
+	s.SetInsertTiming(InsertTimingFast)
+
+	// Initial: slot 1 starts as 2 (present, per fixture). Reset to no_card.
+	if err := s.setSlotStatus(1, 0); err != nil {
+		t.Fatalf("reset slot: %v", err)
+	}
+
+	s.CascadeInsert(context.Background(), 1)
+
+	// Wait up to 500ms (fast = ~100ms total).
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if readSlotStatus(t, s, 1) == 2 /* present */ {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("cascade did not reach present: final state = %d", readSlotStatus(t, s, 1))
+}
+
+func TestCascadeInsert_PassesThroughEachPhase(t *testing.T) {
+	s := newTestServer(t)
+	s.SetInsertTiming(InsertTimingFast)
+	if err := s.setSlotStatus(1, 0); err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+
+	// Capture the sequence by polling with high frequency.
+	seen := map[uint8]bool{}
+	stop := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(2 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				seen[readSlotStatus(t, s, 1)] = true
+			}
+		}
+	}()
+
+	s.CascadeInsert(context.Background(), 1)
+	time.Sleep(300 * time.Millisecond)
+	close(stop)
+
+	// We expect to have observed at least powerup (1) and boot (5) and
+	// present (2). Initial no_card (0) may also be present depending on
+	// race but is not required.
+	if !seen[1] {
+		t.Errorf("never observed powerup state")
+	}
+	if !seen[5] {
+		t.Errorf("never observed boot state")
+	}
+	if !seen[2] {
+		t.Errorf("never observed present state")
+	}
+}
+
+func TestCascadeInsert_Cancellation(t *testing.T) {
+	s := newTestServer(t)
+	s.SetInsertTiming(InsertTimingReal) // slow enough to cancel mid-flight
+	if err := s.setSlotStatus(1, 0); err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s.CascadeInsert(ctx, 1)
+
+	// Let it advance to powerup (immediate) and start the powerup timer.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	// Wait past where boot should have fired (~1500ms). Status should
+	// stay at powerup (1) since the cancel pre-empted the timer.
+	time.Sleep(1800 * time.Millisecond)
+	if got := readSlotStatus(t, s, 1); got >= 5 {
+		t.Fatalf("cascade continued past cancel: state = %d", got)
+	}
+}
+
+func TestCascadeExtract_Immediate(t *testing.T) {
+	s := newTestServer(t)
+	// fixture starts slot 1 at present (2).
+	s.CascadeExtract(1)
+
+	// Both transitions happen synchronously inside CascadeExtract.
+	if got := readSlotStatus(t, s, 1); got != 0 {
+		t.Fatalf("after extract: state = %d, want no_card (0)", got)
+	}
+}
+
+func TestCascadeInsert_PreemptsExistingCascade(t *testing.T) {
+	s := newTestServer(t)
+	s.SetInsertTiming(InsertTimingReal)
+	if err := s.setSlotStatus(1, 0); err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+
+	// Start one cascade.
+	s.CascadeInsert(context.Background(), 1)
+	// Wait for powerup phase.
+	time.Sleep(50 * time.Millisecond)
+
+	// Switch to fast and re-trigger.
+	s.SetInsertTiming(InsertTimingFast)
+	s.CascadeInsert(context.Background(), 1)
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if readSlotStatus(t, s, 1) == 2 /* present */ {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("preempted cascade did not reach present: state = %d", readSlotStatus(t, s, 1))
+}
+
+func TestSlotStateMachine_TimingMutation(t *testing.T) {
+	m := newSlotStateMachine(InsertTimingReal)
+	if m.timing != InsertTimingReal {
+		t.Fatalf("default timing = %v, want real", m.timing)
+	}
+	m.SetTiming(InsertTimingFast)
+	if m.timing != InsertTimingFast {
+		t.Fatalf("after SetTiming(fast) = %v", m.timing)
+	}
+}


### PR DESCRIPTION
## Summary

- New `slotStateMachine` on the ACP1 provider tracks per-slot cancellable cascades.
- `CascadeInsert` drives `no_card -> powerup -> boot -> present`, emitting a frame-status announce at each phase.
- `CascadeExtract` drives `present -> removed -> no_card` immediately.
- Two timing modes: `InsertTimingReal` (1500ms powerup + 2500ms boot, spec-typical) and `InsertTimingFast` (50ms per phase, CI-friendly).
- New admin verbs: `slot.insert --slot N` (kicks off the cascade) and `slot.extract --slot N` (immediate).
- Producer CLI: `--insert-timing real|fast` (default `real`) plumbs to `SetInsertTiming` on the server.
- 9 unit tests covering parse, durations, full-cascade reaches present, per-phase observation, cancellation, immediate extract, pre-emption, timing mutation.

## State machine (per spec p.20)

```text
no_card  -> powerup : immediate (admin slot.insert)
powerup  -> boot    : after powerupDuration (real=1500ms / fast=50ms)
boot     -> present : after bootDuration   (real=2500ms / fast=50ms)
present  -> removed : immediate (admin slot.extract)
removed  -> no_card : immediate (admin slot.extract follow-up)
*        -> error   : immediate (admin slot.state --state error, lands in #258)
```

Cancellation:
- Server stop cancels parent context — pending timers drain.
- New `slot.insert` for the same slot pre-empts the in-flight cascade.
- `slot.extract` mid-cascade pre-empts the insert cascade.

## Why two timings

Real timings make the emulator visually match a Synapse hot-plug for live testing. Fast mode cuts the cascade to ~100ms total so the `feat/acp1-full` integration suite can drive `slot.insert` repeatedly without burning seconds on every test.

## Test plan

- [x] `go test ./internal/acp1/provider/... -count=1 -run "TestCascade|TestParseInsertTiming|TestInsertTiming|TestSlotStateMachine"` — 9 cases green.
- [x] `go build ./...` clean.
- [x] golangci-lint clean.
- [ ] Live test: drive `admin slot.insert` over the wire and watch the cascade in `dhs consumer acp1 watch`.

## Stacked on

PR #280 (admin CLI). Merge order: Phase 0 (#267-#272) → #273 → #274 → #275 → #276 → #277 → #278 → #279 → #280 → this.

## Issue refs

Advances #259. Closes on the eventual PR-to-main when the ACP1 epic bundle lands together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
