### PR TITLE
feat(acp1): provider DM-library loader (advances #260)

### DIFF
--- a/cmd/dhs/cmd_producer.go
+++ b/cmd/dhs/cmd_producer.go
@@ -17,6 +17,7 @@ import (
 	"syscall"
 	"time"
 
+	"dhs/internal/dmlib"
 	"dhs/internal/export/canonical"
 	"dhs/internal/metrics"
 	"dhs/internal/provider"
@@ -55,6 +56,7 @@ func runProducer(ctx context.Context, protoName string, args []string) error {
 		an2Port       = fs.Int("an2-port", 2072, "acp1 only: AN2/TCP listen port for --transport an2/all")
 		adminName     = fs.String("name", "dhs-acp1", "acp1 only: instance name for admin RPC discovery file")
 		insertTiming  = fs.String("insert-timing", "real", "acp1 only: cascade timing for slot insert (real / fast)")
+		dmLibraryRoot = fs.String("dm-library", "", "acp1 only: DM library root for admin slot.load (#260)")
 	)
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -191,6 +193,12 @@ func runProducer(ctx context.Context, protoName string, args []string) error {
 			return err
 		}
 		acp1Srv.SetInsertTiming(timing)
+
+		// DM library: --dm-library points at tests/fixtures/products/
+		// so the admin slot.load verb (#260) can resolve cards.
+		if *dmLibraryRoot != "" {
+			acp1Srv.SetDMLibrary(dmlib.New(*dmLibraryRoot))
+		}
 
 		// Admin RPC always runs alongside the wire transports so the
 		// `dhs producer acp1 admin <verb>` CLI can talk to this

--- a/internal/acp1/provider/admin_handlers.go
+++ b/internal/acp1/provider/admin_handlers.go
@@ -57,22 +57,39 @@ func handlePing(_ context.Context, s *server, _ map[string]any) (*AdminResponse,
 	}, nil
 }
 
-// handleSlotLoad is reserved for the DM-library loader (#260). For now
-// it returns a clear "not implemented yet" diagnostic so the verb is
-// reachable from the CLI but the actual schema-load wiring waits.
-func handleSlotLoad(_ context.Context, _ *server, _ map[string]any) (*AdminResponse, error) {
+// handleSlotLoad models a hot-plug insert by resolving a DM-library
+// card and driving CascadeInsert. The resolver must be attached via
+// SetDMLibrary on the server (the producer CLI passes --dm-library).
+func handleSlotLoad(ctx context.Context, s *server, args map[string]any) (*AdminResponse, error) {
+	slot, err := readIntArg(args, "slot")
+	if err != nil {
+		return nil, err
+	}
+	card, err := readStringArg(args, "card")
+	if err != nil {
+		return nil, err
+	}
+	if err := s.SlotLoad(ctx, uint8(slot), card); err != nil {
+		return nil, err
+	}
 	return &AdminResponse{
-		Status:  "error",
-		Message: "slot.load: DM-library loader lands in #260; verb is plumbed but not yet wired",
+		Result: map[string]any{
+			"slot":    slot,
+			"card":    card,
+			"started": true,
+		},
 	}, nil
 }
 
-// handleSlotUnload mirrors handleSlotLoad — full implementation lands
-// in #260 alongside the loader.
-func handleSlotUnload(_ context.Context, _ *server, _ map[string]any) (*AdminResponse, error) {
+// handleSlotUnload models a hot-extract.
+func handleSlotUnload(_ context.Context, s *server, args map[string]any) (*AdminResponse, error) {
+	slot, err := readIntArg(args, "slot")
+	if err != nil {
+		return nil, err
+	}
+	s.SlotUnload(uint8(slot))
 	return &AdminResponse{
-		Status:  "error",
-		Message: "slot.unload: DM-library loader lands in #260",
+		Result: map[string]any{"slot": slot, "extracted": true},
 	}, nil
 }
 

--- a/internal/acp1/provider/dm_loader.go
+++ b/internal/acp1/provider/dm_loader.go
@@ -1,0 +1,91 @@
+package acp1
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"dhs/internal/dmlib"
+)
+
+// SetDMLibrary attaches a DM-library resolver. The resolver drives the
+// admin `slot.load` verb: callers ask for a card by
+// vendor/product/model-rev/proto path, the resolver locates the schema
+// on disk, and the provider models a hot-plug insert ending in
+// "present".
+//
+// Schema-into-tree replacement is intentionally out of scope for #260:
+// the served tree from --tree stays the source of truth for object
+// values; slot.load only drives the cascade so consumers see the
+// transition. The follow-up converter (canonical export <-> []protocol.
+// Object) lands separately when integration tests prove a need.
+func (s *server) SetDMLibrary(r dmlib.Resolver) {
+	s.mu.Lock()
+	s.dmLibrary = r
+	s.mu.Unlock()
+}
+
+// SlotLoad models a hot-plug insert: resolve the named card via the
+// DM library, then drive CascadeInsert so the slot transitions
+// no_card -> powerup -> boot -> present with realistic timings.
+//
+// Returns ErrNoDMLibrary when no resolver has been attached.
+// Returns dmlib.ErrNotFound when the path does not resolve.
+func (s *server) SlotLoad(ctx context.Context, slot uint8, cardPath string) error {
+	s.mu.Lock()
+	r := s.dmLibrary
+	s.mu.Unlock()
+	if r == nil {
+		return ErrNoDMLibrary
+	}
+	fp, err := parseCardPath(cardPath)
+	if err != nil {
+		return err
+	}
+	if _, err := r.Resolve(fp); err != nil {
+		return fmt.Errorf("dmlib resolve %s: %w", cardPath, err)
+	}
+	s.CascadeInsert(ctx, slot)
+	return nil
+}
+
+// SlotUnload models a hot-extract.
+func (s *server) SlotUnload(slot uint8) {
+	s.CascadeExtract(slot)
+}
+
+// ErrNoDMLibrary is returned when slot.load is called without a
+// resolver attached.
+var ErrNoDMLibrary = errors.New("acp1 provider: DM library not configured (use --dm-library on serve)")
+
+// parseCardPath parses "vendor/product/model-rev/proto" into a
+// Fingerprint. Examples:
+//
+//	axon/synapse/RRS18-1601/acp1
+//	lawo/vsm/CARD-1.0/acp2
+//
+// model-rev splits on the last "-" so "RRS18-1601" yields
+// (Model="RRS18", SwRev="1601") and "GIO-12-2000" yields
+// (Model="GIO-12", SwRev="2000").
+func parseCardPath(s string) (dmlib.Fingerprint, error) {
+	parts := strings.Split(s, "/")
+	if len(parts) != 4 {
+		return dmlib.Fingerprint{}, fmt.Errorf("card path %q: expected 4 components vendor/product/model-rev/proto", s)
+	}
+	vendor, product, modelRev, proto := parts[0], parts[1], parts[2], parts[3]
+	if vendor == "" || product == "" || modelRev == "" || proto == "" {
+		return dmlib.Fingerprint{}, fmt.Errorf("card path %q: empty component", s)
+	}
+	idx := strings.LastIndex(modelRev, "-")
+	if idx <= 0 || idx == len(modelRev)-1 {
+		return dmlib.Fingerprint{}, fmt.Errorf("card path %q: model-rev component %q must be <model>-<rev>", s, modelRev)
+	}
+	return dmlib.Fingerprint{
+		Vendor:  vendor,
+		Product: product,
+		Model:   modelRev[:idx],
+		SwRev:   modelRev[idx+1:],
+		Proto:   proto,
+	}, nil
+}

--- a/internal/acp1/provider/dm_loader_test.go
+++ b/internal/acp1/provider/dm_loader_test.go
@@ -1,0 +1,159 @@
+package acp1
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"dhs/internal/dmlib"
+	"dhs/internal/export"
+	"dhs/internal/protocol"
+)
+
+func TestParseCardPath(t *testing.T) {
+	cases := []struct {
+		in   string
+		want dmlib.Fingerprint
+		err  bool
+	}{
+		{
+			in: "axon/synapse/RRS18-1601/acp1",
+			want: dmlib.Fingerprint{
+				Vendor: "axon", Product: "synapse",
+				Model: "RRS18", SwRev: "1601", Proto: "acp1",
+			},
+		},
+		{
+			// Hyphenated model: split on the LAST '-'.
+			in: "lawo/vsm/GIO-12-2000/acp2",
+			want: dmlib.Fingerprint{
+				Vendor: "lawo", Product: "vsm",
+				Model: "GIO-12", SwRev: "2000", Proto: "acp2",
+			},
+		},
+		{in: "too/few/parts", err: true},
+		{in: "too/many/parts/here/now", err: true},
+		{in: "axon//RRS18-1601/acp1", err: true},
+		{in: "axon/synapse/RRS18/acp1", err: true},   // no rev separator
+		{in: "axon/synapse/-1601/acp1", err: true},   // empty model
+		{in: "axon/synapse/RRS18-/acp1", err: true},  // empty rev
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := parseCardPath(tc.in)
+			if tc.err {
+				if err == nil {
+					t.Fatalf("expected error for %q", tc.in)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("got %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+// fakeDMResolver satisfies dmlib.Resolver with canned answers.
+type fakeDMResolver struct {
+	resolveErr error
+	calledFP   dmlib.Fingerprint
+}
+
+func (r *fakeDMResolver) Resolve(fp dmlib.Fingerprint) (*dmlib.Schema, error) {
+	r.calledFP = fp
+	if r.resolveErr != nil {
+		return nil, r.resolveErr
+	}
+	return &dmlib.Schema{
+		Fingerprint: fp,
+		Slots: map[int]*export.Snapshot{
+			1: {Slots: []export.SlotDump{{Slot: 1, Objects: []protocol.Object{}}}},
+		},
+	}, nil
+}
+func (r *fakeDMResolver) LookupAlternate(fp dmlib.Fingerprint) ([]dmlib.Fingerprint, error) {
+	return nil, nil
+}
+func (r *fakeDMResolver) Persist(s *dmlib.Schema) error      { return nil }
+func (r *fakeDMResolver) Diff(p, c *dmlib.Schema) dmlib.Diff { return dmlib.Diff{} }
+
+func TestSlotLoad_NoResolverConfigured(t *testing.T) {
+	s := newTestServer(t)
+	err := s.SlotLoad(context.Background(), 1, "axon/synapse/RRS18-1601/acp1")
+	if !errors.Is(err, ErrNoDMLibrary) {
+		t.Fatalf("err = %v, want ErrNoDMLibrary", err)
+	}
+}
+
+func TestSlotLoad_BadCardPath(t *testing.T) {
+	s := newTestServer(t)
+	s.SetDMLibrary(&fakeDMResolver{})
+	err := s.SlotLoad(context.Background(), 1, "totally bogus")
+	if err == nil {
+		t.Fatal("expected error for bad path")
+	}
+}
+
+func TestSlotLoad_ResolverMiss(t *testing.T) {
+	s := newTestServer(t)
+	s.SetDMLibrary(&fakeDMResolver{resolveErr: dmlib.ErrNotFound})
+	err := s.SlotLoad(context.Background(), 1, "axon/synapse/RRS18-1601/acp1")
+	if !errors.Is(err, dmlib.ErrNotFound) {
+		t.Fatalf("err = %v, want dmlib.ErrNotFound", err)
+	}
+}
+
+func TestSlotLoad_DrivesCascade(t *testing.T) {
+	s := newTestServer(t)
+	s.SetInsertTiming(InsertTimingFast)
+	s.SetDMLibrary(&fakeDMResolver{})
+	if err := s.setSlotStatus(1, 0); err != nil {
+		t.Fatalf("reset slot: %v", err)
+	}
+
+	if err := s.SlotLoad(context.Background(), 1, "axon/synapse/RRS18-1601/acp1"); err != nil {
+		t.Fatalf("SlotLoad: %v", err)
+	}
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if readSlotStatus(t, s, 1) == 2 /* present */ {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("cascade did not reach present after SlotLoad: state = %d", readSlotStatus(t, s, 1))
+}
+
+func TestSlotUnload_DrivesExtract(t *testing.T) {
+	s := newTestServer(t)
+	// fixture starts slot 1 at present.
+	s.SlotUnload(1)
+	if got := readSlotStatus(t, s, 1); got != 0 {
+		t.Fatalf("after SlotUnload: state = %d, want no_card (0)", got)
+	}
+}
+
+func TestSlotLoad_PassesFingerprintToResolver(t *testing.T) {
+	s := newTestServer(t)
+	r := &fakeDMResolver{}
+	s.SetDMLibrary(r)
+
+	const path = "axon/synapse/RRS18-1601/acp1"
+	if err := s.SlotLoad(context.Background(), 1, path); err != nil {
+		t.Fatalf("SlotLoad: %v", err)
+	}
+	want := dmlib.Fingerprint{
+		Vendor: "axon", Product: "synapse",
+		Model: "RRS18", SwRev: "1601", Proto: "acp1",
+	}
+	if r.calledFP != want {
+		t.Fatalf("resolver called with %+v, want %+v", r.calledFP, want)
+	}
+}

--- a/internal/acp1/provider/server.go
+++ b/internal/acp1/provider/server.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"sync"
 
+	"dhs/internal/dmlib"
 	"dhs/internal/export/canonical"
 	"dhs/internal/acp1/codec"
 )
@@ -55,6 +56,10 @@ type server struct {
 	// Initialised by newServer with InsertTimingReal; the producer CLI
 	// can override via --insert-timing.
 	slotMachine *slotStateMachine
+
+	// dmLibrary, when non-nil, drives slot.load via the DM-library
+	// resolver. Set via SetDMLibrary at startup.
+	dmLibrary dmlib.Resolver
 }
 
 // SetInsertTiming switches the cascade timing for new transitions.


### PR DESCRIPTION
## Summary

- `server.SlotLoad(ctx, slot, cardPath)` resolves a DM-library entry via the configured `dmlib.Resolver` and drives `CascadeInsert` (#259).
- `server.SlotUnload(slot)` drives `CascadeExtract`.
- `admin slot.load` / `slot.unload` verbs now route through these methods (they were stubs).
- Producer CLI: `--dm-library <path>` configures the resolver.
- 8 unit tests covering parse-path edge cases, no-resolver error, bad path, resolver miss, cascade drive, extract drive, fingerprint hand-off.

## Card path syntax

```
vendor/product/model-rev/proto
```

| Path | Vendor | Product | Model | SwRev | Proto |
| --- | --- | --- | --- | --- | --- |
| `axon/synapse/RRS18-1601/acp1` | axon | synapse | RRS18 | 1601 | acp1 |
| `lawo/vsm/GIO-12-2000/acp2` | lawo | vsm | GIO-12 | 2000 | acp2 |

The model-rev split uses the LAST hyphen so hyphenated models survive.

## What's deliberately NOT in this PR

Schema-into-tree replacement. The served `--tree` stays the source of truth for object values; `slot.load` only models the hot-plug cascade so consumers see the transition.

The canonical `<-> []protocol.Object` converter that would actually swap tree contents is a follow-up. Integration tests against Synapse Setup / VSM Studio / Cerebrum will tell us whether the cascade alone is sufficient or whether we need the converter.

## Test plan

- [x] `go test ./internal/acp1/provider/... -count=1 -run "TestParseCardPath|TestSlotLoad|TestSlotUnload"` — 8 cases green.
- [x] `go build ./...` clean.
- [x] golangci-lint clean.
- [ ] Live test: `dhs producer acp1 serve --dm-library tests/fixtures/products/` + `dhs producer acp1 admin slot load --slot 1 --card axon/synapse/RRS18-1601/acp1`.

## Stacked on

PR #281 (slot state machine). Merge order: Phase 0 (#267-#272) → #273 → #274 → #275 → #276 → #277 → #278 → #279 → #280 → #281 → this.

## Issue refs

Advances #260. Closes on the eventual PR-to-main when the ACP1 epic bundle lands together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
