### PR TITLE
feat(acp1): provider fuzz verb (advances #262)

### DIFF
--- a/cmd/dhs/cmd_acp1_fuzz.go
+++ b/cmd/dhs/cmd_acp1_fuzz.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log/slog"
+	"time"
+
+	acp1provider "dhs/internal/acp1/provider"
+	"dhs/internal/acp1/codec"
+	"dhs/internal/provider"
+)
+
+// runACP1Fuzz implements `dhs producer acp1 fuzz [flags]`. Loads a
+// tree, spins up the standard ACP1 provider over UDP, and runs the
+// random-mutation generator against the writable objects.
+func runACP1Fuzz(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("producer acp1 fuzz", flag.ContinueOnError)
+	var (
+		treePath = fs.String("tree", "", "path to canonical tree.json (required)")
+		port     = fs.Int("port", 0, "UDP listen port (0 = plugin default)")
+		host     = fs.String("host", "0.0.0.0", "UDP listen host")
+
+		seed         = fs.Int64("seed", 0, "fuzz RNG seed (0 = time-derived)")
+		rate         = fs.Float64("rate", 1.0, "events per second")
+		duration     = fs.Duration("duration", 0, "stop after this duration (0 = until ctrl-c)")
+		slot         = fs.Int("slot", -1, "filter: only this slot (-1 = all)")
+		group        = fs.String("group", "", "filter: only this group (control / status / ...) — empty = all")
+		id           = fs.Int("id", -1, "filter: only this object id (-1 = all)")
+		includeEdges = fs.Bool("include-edges", false, "bias every 4th cycle to a min/max boundary")
+
+		logLevel  = fs.String("log-level", "info", "log level: debug / info / warn / error")
+		logFormat = fs.String("log-format", "text", "log format: text / json")
+	)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *treePath == "" {
+		return fmt.Errorf("--tree is required")
+	}
+
+	cfg := acp1provider.FuzzConfig{
+		Seed:         *seed,
+		Rate:         *rate,
+		Duration:     *duration,
+		Slot:         *slot,
+		ID:           *id,
+		IncludeEdges: *includeEdges,
+	}
+	if *group != "" {
+		g, ok := codec.ParseGroup(*group)
+		if !ok {
+			return fmt.Errorf("--group %q: unknown group name", *group)
+		}
+		cfg.Group = g
+		cfg.GroupSet = true
+	}
+
+	logger := newLogger(*logLevel, *logFormat)
+
+	factory, ok := provider.Lookup("acp1")
+	if !ok {
+		return fmt.Errorf("acp1 provider not registered")
+	}
+	tree, err := loadTree(*treePath)
+	if err != nil {
+		return fmt.Errorf("load tree: %w", err)
+	}
+
+	listenPort := *port
+	if listenPort == 0 {
+		listenPort = factory.Meta().DefaultPort
+	}
+	addr := fmt.Sprintf("%s:%d", *host, listenPort)
+
+	srv, ok := factory.New(logger, tree).(*acp1provider.Server)
+	if !ok {
+		return fmt.Errorf("acp1 fuzz: unexpected server type")
+	}
+
+	srvCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.Serve(srvCtx, addr) }()
+
+	// Give Serve a beat to bind before fuzzing kicks off — the fuzzer
+	// emits announces via broadcastAnnounce which tolerates a missing
+	// UDP socket, but in practice we want the listener active first
+	// so initial announces reach connected consumers.
+	time.Sleep(100 * time.Millisecond)
+
+	logger.Info("acp1 fuzz starting",
+		slog.String("tree", *treePath),
+		slog.String("addr", addr),
+		slog.Float64("rate", *rate),
+		slog.Duration("duration", *duration))
+
+	fuzzErr := srv.RunFuzz(srvCtx, cfg)
+
+	// Wait for serve to wind down (or already errored).
+	cancel()
+	if err := <-serveErr; err != nil && !errors.Is(err, context.Canceled) {
+		return fmt.Errorf("serve: %w", err)
+	}
+	return fuzzErr
+}

--- a/cmd/dhs/main.go
+++ b/cmd/dhs/main.go
@@ -295,8 +295,13 @@ func dispatchProducer(ctx context.Context, args []string) error {
 			return fmt.Errorf("producer %s: admin verb is acp1-only (advances #258)", proto)
 		}
 		return runACP1Admin(ctx, rest)
+	case "fuzz":
+		if proto != "acp1" {
+			return fmt.Errorf("producer %s: fuzz verb is acp1-only (advances #262)", proto)
+		}
+		return runACP1Fuzz(ctx, rest)
 	}
-	return fmt.Errorf("producer %s: unknown verb %q (expected: serve | admin)", proto, verb)
+	return fmt.Errorf("producer %s: unknown verb %q (expected: serve | admin | fuzz)", proto, verb)
 }
 
 // dispatchRegistry routes `dhs registry <proto> <verb> [args]`. The

--- a/internal/acp1/provider/fuzz.go
+++ b/internal/acp1/provider/fuzz.go
@@ -1,0 +1,290 @@
+package acp1
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"time"
+
+	"dhs/internal/acp1/codec"
+)
+
+// FuzzConfig parametrises the value-change stress generator.
+type FuzzConfig struct {
+	Seed         int64         // 0 = use time-derived seed
+	Rate         float64       // events per second; <=0 = 1.0
+	Duration     time.Duration // 0 = run until ctx is cancelled
+	Slot         int           // -1 = all slots
+	Group        codec.ObjGroup
+	GroupSet     bool
+	ID           int  // -1 = all ids
+	IncludeEdges bool // bias toward min/max/default once per cycle
+}
+
+// fuzzTarget is one writable object that the fuzzer can drive.
+type fuzzTarget struct {
+	key  objectKey
+	e    *entry
+}
+
+// RunFuzz drives random valid value-changes against the writable
+// objects in the served tree, generating broadcast announces consumers
+// can stress-test against. Reproducible per --seed; rate-limited per
+// --rate.
+//
+// Returns when ctx is cancelled or --duration elapses. Errors only
+// surface for catastrophic conditions (no eligible targets); per-tick
+// failures log and continue.
+func (s *server) RunFuzz(ctx context.Context, cfg FuzzConfig) error {
+	if cfg.Rate <= 0 {
+		cfg.Rate = 1.0
+	}
+	seed := cfg.Seed
+	if seed == 0 {
+		seed = time.Now().UnixNano()
+	}
+	//nolint:gosec // non-crypto fuzz seed is fine for value generation
+	rng := rand.New(rand.NewSource(seed))
+
+	targets := s.collectFuzzTargets(cfg)
+	if len(targets) == 0 {
+		return fmt.Errorf("acp1 fuzz: no eligible writable targets (slot=%d, group=%v, id=%d)",
+			cfg.Slot, cfg.Group, cfg.ID)
+	}
+
+	s.logger.Info("acp1 fuzz starting",
+		"seed", seed,
+		"rate", cfg.Rate,
+		"duration", cfg.Duration,
+		"targets", len(targets),
+		"include_edges", cfg.IncludeEdges)
+
+	interval := time.Duration(float64(time.Second) / cfg.Rate)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	var deadline <-chan time.Time
+	if cfg.Duration > 0 {
+		t := time.NewTimer(cfg.Duration)
+		defer t.Stop()
+		deadline = t.C
+	}
+
+	cycle := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-deadline:
+			return nil
+		case <-ticker.C:
+			s.fuzzTick(rng, targets, cfg, cycle)
+			cycle++
+		}
+	}
+}
+
+// collectFuzzTargets walks the tree once and returns every writable
+// entry matching the (slot, group, id) filter.
+func (s *server) collectFuzzTargets(cfg FuzzConfig) []fuzzTarget {
+	s.tree.mu.RLock()
+	defer s.tree.mu.RUnlock()
+	var out []fuzzTarget
+	for k, e := range s.tree.entries {
+		if cfg.Slot >= 0 && int(k.slot) != cfg.Slot {
+			continue
+		}
+		if cfg.GroupSet && k.group != cfg.Group {
+			continue
+		}
+		if cfg.ID >= 0 && int(k.id) != cfg.ID {
+			continue
+		}
+		if e.access&2 == 0 {
+			continue // not writable
+		}
+		if !fuzzableType(e.acpType) {
+			continue
+		}
+		out = append(out, fuzzTarget{key: k, e: e})
+	}
+	return out
+}
+
+// fuzzableType reports whether the fuzzer can synthesise a valid value
+// for this ACP1 type. String fuzzing is left out for now — it would
+// need a phrase pool the user supplies, and the issue's table cycles
+// "fixture phrases" which we don't have without a fixtures contract.
+// Frame / Alarm / File / Reserved are read-only or out-of-scope.
+func fuzzableType(t codec.ObjectType) bool {
+	switch t {
+	case codec.TypeInteger, codec.TypeLong, codec.TypeByte,
+		codec.TypeFloat, codec.TypeIPAddr, codec.TypeEnum:
+		return true
+	}
+	return false
+}
+
+// fuzzTick picks one target and applies a synthesised mutation.
+func (s *server) fuzzTick(rng *rand.Rand, targets []fuzzTarget, cfg FuzzConfig, cycle int) {
+	t := targets[rng.Intn(len(targets))]
+	bytes, err := s.synthesiseValue(rng, t.e, cfg.IncludeEdges, cycle)
+	if err != nil {
+		s.logger.Debug("fuzz: skip target", "key", fmt.Sprintf("%+v", t.key), "err", err.Error())
+		return
+	}
+	stored, err := s.applyMutation(t.e, codec.MethodSetValue, bytes)
+	if err != nil {
+		s.logger.Debug("fuzz: applyMutation failed",
+			"key", fmt.Sprintf("%+v", t.key), "err", err.Error())
+		return
+	}
+	ann := &codec.Message{
+		MTID:     0,
+		MType:    codec.MTypeReply,
+		MAddr:    t.key.slot,
+		MCode:    byte(codec.MethodSetValue),
+		ObjGroup: t.key.group,
+		ObjID:    t.key.id,
+		Value:    stored,
+	}
+	s.broadcastAnnounce(ann)
+}
+
+// synthesiseValue produces wire bytes for a single mutation. When
+// includeEdges is set, the synthesiser biases every 4th cycle to a
+// boundary value (min / max / default) so clamp paths get exercised.
+func (s *server) synthesiseValue(rng *rand.Rand, e *entry, includeEdges bool, cycle int) ([]byte, error) {
+	useEdge := includeEdges && cycle%4 == 0
+	switch e.acpType {
+	case codec.TypeInteger:
+		return synthInteger(rng, e, useEdge, 2), nil
+	case codec.TypeLong:
+		return synthInteger(rng, e, useEdge, 4), nil
+	case codec.TypeByte:
+		return synthInteger(rng, e, useEdge, 1), nil
+	case codec.TypeFloat:
+		return synthFloat(rng, e, useEdge), nil
+	case codec.TypeIPAddr:
+		// Random IPv4: 4 bytes, no min/max in spec metadata.
+		out := make([]byte, 4)
+		rng.Read(out)
+		return out, nil
+	case codec.TypeEnum:
+		return synthEnum(rng, e), nil
+	}
+	return nil, fmt.Errorf("acp1 fuzz: unsupported type %d", e.acpType)
+}
+
+func synthInteger(rng *rand.Rand, e *entry, useEdge bool, width int) []byte {
+	min, max := readIntBounds(e)
+	var v int64
+	switch {
+	case useEdge && rng.Intn(2) == 0:
+		v = min
+	case useEdge:
+		v = max
+	default:
+		// rng.Int63n needs span > 0
+		span := max - min + 1
+		if span <= 0 {
+			v = min
+		} else {
+			v = min + rng.Int63n(span)
+		}
+	}
+	out := make([]byte, width)
+	switch width {
+	case 1:
+		out[0] = byte(v)
+	case 2:
+		out[0] = byte(v >> 8)
+		out[1] = byte(v)
+	case 4:
+		out[0] = byte(v >> 24)
+		out[1] = byte(v >> 16)
+		out[2] = byte(v >> 8)
+		out[3] = byte(v)
+	}
+	return out
+}
+
+func synthFloat(rng *rand.Rand, e *entry, useEdge bool) []byte {
+	min, max := readFloatBounds(e)
+	var v float64
+	switch {
+	case useEdge && rng.Intn(2) == 0:
+		v = min
+	case useEdge:
+		v = max
+	default:
+		v = min + rng.Float64()*(max-min)
+	}
+	bits := math.Float32bits(float32(v))
+	return []byte{byte(bits >> 24), byte(bits >> 16), byte(bits >> 8), byte(bits)}
+}
+
+func synthEnum(rng *rand.Rand, e *entry) []byte {
+	// num_items lives on the entry indirectly via the canonical
+	// EnumMap. Fall through to a single-byte pick from [0, len-1].
+	if e.param != nil && len(e.param.EnumMap) > 0 {
+		idx := rng.Intn(len(e.param.EnumMap))
+		return []byte{byte(e.param.EnumMap[idx].Value)}
+	}
+	// No metadata: pick a random byte.
+	return []byte{byte(rng.Intn(256))}
+}
+
+func readIntBounds(e *entry) (int64, int64) {
+	min, max := int64(0), int64(0)
+	if e.param != nil {
+		switch v := e.param.Minimum.(type) {
+		case int64:
+			min = v
+		case int:
+			min = int64(v)
+		case float64:
+			min = int64(v)
+		}
+		switch v := e.param.Maximum.(type) {
+		case int64:
+			max = v
+		case int:
+			max = int64(v)
+		case float64:
+			max = int64(v)
+		}
+	}
+	if max <= min {
+		// Defensive: parameters with no declared range get a tiny one.
+		min, max = 0, 1
+	}
+	return min, max
+}
+
+func readFloatBounds(e *entry) (float64, float64) {
+	min, max := 0.0, 0.0
+	if e.param != nil {
+		switch v := e.param.Minimum.(type) {
+		case float64:
+			min = v
+		case int64:
+			min = float64(v)
+		case int:
+			min = float64(v)
+		}
+		switch v := e.param.Maximum.(type) {
+		case float64:
+			max = v
+		case int64:
+			max = float64(v)
+		case int:
+			max = float64(v)
+		}
+	}
+	if max <= min {
+		min, max = 0.0, 1.0
+	}
+	return min, max
+}

--- a/internal/acp1/provider/fuzz_test.go
+++ b/internal/acp1/provider/fuzz_test.go
@@ -1,0 +1,190 @@
+package acp1
+
+import (
+	"context"
+	"math/rand"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"dhs/internal/acp1/codec"
+)
+
+// announceCounter wraps a server's broadcast path so tests can count
+// announces without a real socket. We swap broadcastTCPAnnounce via
+// the registry; the UDP path returns early with no socket.
+func announceCounter(t *testing.T, s *server) *atomic.Int64 {
+	t.Helper()
+	var n atomic.Int64
+	reg := newTCPSessionRegistry(s.logger)
+	send := make(chan []byte, 4096)
+	reg.register("10.0.0.1", nil, send)
+	s.tcpRegistry = reg
+	go func() {
+		for range send {
+			n.Add(1)
+		}
+	}()
+	t.Cleanup(func() { close(send) })
+	return &n
+}
+
+func TestRunFuzz_NoTargets(t *testing.T) {
+	s := newTestServer(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := FuzzConfig{
+		Seed:  42,
+		Rate:  10,
+		Slot:  99, // no such slot
+		ID:    -1,
+	}
+	err := s.RunFuzz(ctx, cfg)
+	if err == nil {
+		t.Fatal("expected error for no eligible targets")
+	}
+}
+
+func TestRunFuzz_DurationStopsLoop(t *testing.T) {
+	s := newTestServer(t)
+	announceCounter(t, s)
+
+	cfg := FuzzConfig{
+		Seed:     42,
+		Rate:     50,
+		Duration: 200 * time.Millisecond,
+		Slot:     -1,
+		ID:       -1,
+	}
+	start := time.Now()
+	if err := s.RunFuzz(context.Background(), cfg); err != nil {
+		t.Fatalf("RunFuzz: %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed < 150*time.Millisecond || elapsed > 600*time.Millisecond {
+		t.Fatalf("duration not honoured: ran for %v (want ~200ms)", elapsed)
+	}
+}
+
+func TestRunFuzz_ContextCancelStopsLoop(t *testing.T) {
+	s := newTestServer(t)
+	announceCounter(t, s)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		cancel()
+	}()
+	cfg := FuzzConfig{
+		Seed: 42,
+		Rate: 50,
+		Slot: -1,
+		ID:   -1,
+	}
+	start := time.Now()
+	if err := s.RunFuzz(ctx, cfg); err != nil {
+		t.Fatalf("RunFuzz: %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed > 600*time.Millisecond {
+		t.Fatalf("ctx cancel not honoured: ran for %v", elapsed)
+	}
+}
+
+func TestRunFuzz_ProducesAnnounces(t *testing.T) {
+	s := newTestServer(t)
+	count := announceCounter(t, s)
+
+	cfg := FuzzConfig{
+		Seed:     1,
+		Rate:     100,
+		Duration: 200 * time.Millisecond,
+		Slot:     -1,
+		ID:       -1,
+	}
+	if err := s.RunFuzz(context.Background(), cfg); err != nil {
+		t.Fatalf("RunFuzz: %v", err)
+	}
+	// Allow time for the consumer goroutine to drain.
+	time.Sleep(50 * time.Millisecond)
+	if got := count.Load(); got < 5 {
+		t.Fatalf("announces emitted = %d, want at least 5 over 200ms at rate 100", got)
+	}
+}
+
+func TestRunFuzz_GroupFilter(t *testing.T) {
+	s := newTestServer(t)
+	announceCounter(t, s)
+
+	// Filter to control group only — slot 1 control 0 is writable in
+	// the test fixture; identity is read-only.
+	cfg := FuzzConfig{
+		Seed:     1,
+		Rate:     100,
+		Duration: 100 * time.Millisecond,
+		Slot:     1,
+		Group:    codec.GroupControl,
+		GroupSet: true,
+		ID:       -1,
+	}
+	if err := s.RunFuzz(context.Background(), cfg); err != nil {
+		t.Fatalf("RunFuzz: %v", err)
+	}
+}
+
+func TestRunFuzz_ReadOnlyTargetsExcluded(t *testing.T) {
+	s := newTestServer(t)
+
+	// Identity (group=1) in the test fixture is read-only. A fuzz
+	// scoped to identity should report "no eligible targets".
+	cfg := FuzzConfig{
+		Seed:  1,
+		Rate:  10,
+		Slot:  1,
+		Group: codec.GroupIdentity,
+		GroupSet: true,
+		ID:    -1,
+	}
+	err := s.RunFuzz(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected error: identity is read-only, no eligible targets")
+	}
+}
+
+func TestSynthInteger_RespectsMinMax(t *testing.T) {
+	// Synth 200 random values for a fixture entry; every one must
+	// fall within [min, max].
+	s := newTestServer(t)
+	s.tree.mu.RLock()
+	e := s.tree.entries[objectKey{slot: 1, group: codec.GroupControl, id: 0}]
+	s.tree.mu.RUnlock()
+	if e == nil {
+		t.Fatal("test fixture missing slot=1 control id=0")
+	}
+	min, max := readIntBounds(e)
+
+	for i := 0; i < 200; i++ {
+		bytes, err := s.synthesiseValue(testRand(int64(i)), e, false, i)
+		if err != nil {
+			t.Fatalf("synthesiseValue: %v", err)
+		}
+		var v int64
+		switch len(bytes) {
+		case 1:
+			v = int64(int8(bytes[0]))
+		case 2:
+			v = int64(int16(bytes[0])<<8 | int16(bytes[1]))
+		case 4:
+			v = int64(int32(bytes[0])<<24 | int32(bytes[1])<<16 | int32(bytes[2])<<8 | int32(bytes[3]))
+		}
+		if v < min || v > max {
+			t.Fatalf("synth value %d out of [%d, %d]", v, min, max)
+		}
+	}
+}
+
+// testRand provides a deterministic RNG seeded with the iteration index.
+func testRand(seed int64) *rand.Rand {
+	return rand.New(rand.NewSource(seed))
+}


### PR DESCRIPTION
## Summary

- New `dhs producer acp1 fuzz [flags]` verb that drives random valid value-changes against the writable objects in the served tree.
- `RunFuzz` method on the provider performs target collection (writable + type-fuzzable + filter match), random synthesis bounded by metadata, applyMutation + announce per tick.
- Reproducible RNG via `--seed`, rate-limited by `--rate`, time-bounded by `--duration`, scope filters via `--slot --group --id`, boundary bias via `--include-edges`.
- 7 unit tests pinning the contract.

## Flag map (matches issue spec)

| Flag | Behaviour |
| --- | --- |
| `--seed N` | reproducible (same seed → same sequence) |
| `--rate N` | events per second (default 1) |
| `--duration D` | time-bounded; default 0 = until Ctrl-C |
| `--slot N` / `--group G` / `--id N` | filter scope |
| `--include-edges` | bias every 4th cycle to a min/max boundary |

## Bounds-respect by type

| Type | Range | Wire width |
| --- | --- | --- |
| int / long / byte | uniform `[min, max]` | 2 / 4 / 1 byte BE |
| float | uniform `[min, max]` | 4 byte BE IEEE-754 |
| enum | uniform across `EnumMap` | 1 byte |
| ipaddr | uniform 4-byte | 4 byte |
| string | not in this PR (needs phrase pool) | — |

Read-only entries are filtered out at target collection. Filter that matches no writable objects fails fast with a clear error.

## Test plan

- [x] `go test ./internal/acp1/provider/... -count=1 -run "TestRunFuzz|TestSynthInteger"` — 7 cases green.
- [x] Whole-tree provider tests still green.
- [x] `go build ./...` clean.
- [x] golangci-lint clean.
- [ ] Live: `dhs producer acp1 fuzz --tree T.json --rate 100 --duration 60s` against a connected `dhs consumer acp1 watch`.

## Stacked on

PR #283 (fan-out audit). Merge order: Phase 0 (#267-#272) → #273 → #274 → #275 → #276 → #277 → #278 → #279 → #280 → #281 → #282 → #283 → this.

## Issue refs

Advances #262. Closes on the eventual PR-to-main when the ACP1 epic bundle lands together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
