### PR TITLE
feat(acp1): provider VIP-aware broadcast source (advances #263)

### DIFF
--- a/cmd/dhs/cmd_producer.go
+++ b/cmd/dhs/cmd_producer.go
@@ -41,7 +41,8 @@ func runProducer(ctx context.Context, protoName string, args []string) error {
 	var (
 		treePath      = fs.String("tree", "", "path to canonical tree.json (required)")
 		port          = fs.Int("port", 0, "TCP listen port (0 = plugin default)")
-		host          = fs.String("host", "0.0.0.0", "TCP listen host")
+		host          = fs.String("host", "0.0.0.0", "TCP/UDP listen host (alias: --bind)")
+		bind          = fs.String("bind", "", "alternate spelling of --host. e.g. --bind 10.6.239.200 binds the listener AND pins the broadcast source IP to the VIP, so multi-instance emulators on the same machine appear as distinct From: addresses to consumers (#263).")
 		logLevel      = fs.String("log-level", "info", "log level: debug, info, warn, error")
 		logFormat     = fs.String("log-format", "text", "log format: text | json (json for Loki/Promtail)")
 		announceDemo  = fs.Bool("announce-demo", false, "oscillate a target value every --announce-demo-interval and broadcast announces (acp1/acp2 only)")
@@ -63,6 +64,11 @@ func runProducer(ctx context.Context, protoName string, args []string) error {
 	}
 	if *treePath == "" {
 		return fmt.Errorf("--tree is required")
+	}
+	// --bind is the canonical name in the design discussion (#263);
+	// --host stays for backwards-compat. When both are set, --bind wins.
+	if *bind != "" {
+		*host = *bind
 	}
 
 	logger := newLogger(*logLevel, *logFormat)

--- a/internal/acp1/provider/server.go
+++ b/internal/acp1/provider/server.go
@@ -105,8 +105,19 @@ func (s *server) Serve(ctx context.Context, addr string) error {
 	// Dial a second socket to the limited broadcast address. Go stdlib
 	// auto-sets SO_BROADCAST on dialed sockets with broadcast peers,
 	// which is the portable path across Windows / Linux / macOS.
+	//
+	// VIP-aware source selection (#263): when --bind <ip> selects a
+	// specific local address, we pin the broadcast dial's LocalAddr
+	// to it so the kernel routes via the matching iface and consumers
+	// see the right `From:` per emulator. Without this, multiple
+	// emulators on different VIPs would share whichever IP the kernel
+	// picks for the route, collapsing the per-emulator distinction.
 	bcastAddr := &net.UDPAddr{IP: net.IPv4bcast, Port: udpAddr.Port}
-	bconn, bErr := net.DialUDP("udp4", nil, bcastAddr)
+	var localAddr *net.UDPAddr
+	if udpAddr.IP != nil && !udpAddr.IP.IsUnspecified() {
+		localAddr = &net.UDPAddr{IP: udpAddr.IP, Port: 0}
+	}
+	bconn, bErr := net.DialUDP("udp4", localAddr, bcastAddr)
 	// Best-effort: if the OS rejects the broadcast dial (no route, no
 	// iface up) we log and continue without announcements.
 	if bErr != nil {

--- a/internal/acp1/provider/vip_bind_test.go
+++ b/internal/acp1/provider/vip_bind_test.go
@@ -1,0 +1,123 @@
+package acp1
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+)
+
+// startServerOnAddr launches s.Serve on the given addr and returns
+// when the listener is reachable.
+func startServerOnAddr(t *testing.T, s *server, addr string) context.CancelFunc {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- s.Serve(ctx, addr)
+	}()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		c, err := net.DialTimeout("udp4", addr, 50*time.Millisecond)
+		if err == nil {
+			_ = c.Close()
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Errorf("server did not return within 2s")
+		}
+	})
+	return cancel
+}
+
+// TestVIPBind_LoopbackBroadcastSourcePinned verifies the broadcast
+// socket's LocalAddr matches the listener's bind IP. We bind to
+// 127.0.0.1 (a real loopback IP, distinct from 0.0.0.0) and check
+// that s.bcast.LocalAddr() reflects 127.0.0.1.
+//
+// The "real" VIP scenario (multiple non-loopback IPs on different
+// ifaces) is exercised in integration tests on the LXC rig — unit
+// tests can only assert the bind logic here.
+func TestVIPBind_LoopbackBroadcastSourcePinned(t *testing.T) {
+	s := newTestServer(t)
+
+	// Pick a kernel-assigned port to avoid collisions when tests run
+	// in parallel.
+	probe, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatalf("probe listen: %v", err)
+	}
+	port := probe.LocalAddr().(*net.UDPAddr).Port
+	_ = probe.Close()
+
+	addr := net.JoinHostPort("127.0.0.1", itoa(port))
+	startServerOnAddr(t, s, addr)
+	time.Sleep(100 * time.Millisecond)
+
+	s.mu.Lock()
+	bc := s.bcast
+	s.mu.Unlock()
+	if bc == nil {
+		// Some systems refuse the broadcast dial from a loopback IP
+		// (no route for 255.255.255.255). That's documented behaviour;
+		// skip rather than fail.
+		t.Skip("loopback broadcast dial unsupported on this host — skip")
+	}
+	local := bc.LocalAddr().(*net.UDPAddr)
+	if !local.IP.Equal(net.IPv4(127, 0, 0, 1)) {
+		t.Fatalf("broadcast LocalAddr = %v, want 127.0.0.1", local.IP)
+	}
+}
+
+func TestVIPBind_UnspecifiedHostLeavesKernelChoice(t *testing.T) {
+	// When --bind is not set (or = 0.0.0.0), we deliberately do NOT
+	// pin the broadcast source so the kernel's default-route logic
+	// applies (preserves legacy behaviour).
+	s := newTestServer(t)
+
+	probe, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4zero})
+	if err != nil {
+		t.Fatalf("probe listen: %v", err)
+	}
+	port := probe.LocalAddr().(*net.UDPAddr).Port
+	_ = probe.Close()
+
+	addr := net.JoinHostPort("0.0.0.0", itoa(port))
+	startServerOnAddr(t, s, addr)
+	time.Sleep(100 * time.Millisecond)
+
+	s.mu.Lock()
+	bc := s.bcast
+	s.mu.Unlock()
+	if bc == nil {
+		t.Skip("broadcast dial unsupported on this host — skip")
+	}
+	local := bc.LocalAddr().(*net.UDPAddr)
+	// With unspecified bind, the kernel chooses; we can't predict
+	// which IP. Just ensure the broadcast socket exists and has a
+	// concrete (not zero) source after dial.
+	if local.IP.IsUnspecified() {
+		t.Fatalf("broadcast source = unspecified, kernel should have picked something")
+	}
+}
+
+// itoa is a tiny stdlib-free integer-to-string helper for ports.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [10]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}


### PR DESCRIPTION
## Summary

- Pin the broadcast socket's `LocalAddr` to the listener's bind IP when `--bind <ip>` is set. Multi-instance emulators on different VIPs now appear as distinct `From:` addresses to consumers.
- New `--bind` alias for `--host` on `dhs producer acp1 serve`. Both spellings work; `--bind` is the canonical name from the design discussion.
- Default `--bind 0.0.0.0` leaves the broadcast `LocalAddr` nil so legacy behaviour (kernel picks source) is preserved.
- 2 unit tests pin the LocalAddr behaviour on loopback.

## Why this matters

```
host A: --bind 10.6.239.200 --tree rack-A.json
host A: --bind 10.6.239.201 --tree rack-B.json
```

Two emulators, same machine, two VIPs. Without source-IP pinning, both broadcasts source from whichever IP the kernel default-routes — consumer sees `From: 10.6.239.X` for both, can't tell them apart. With this PR, each broadcast carries the bind IP, and `dhs consumer acp1 discover` lists both as distinct origins.

## Multi-VIP integration

The real multi-VIP scenario needs multiple non-loopback IPs configured on different ifaces. The LXC rig already provides this; CI cannot. Unit tests assert the bind logic on loopback (which is the only thing we can portably test); integration tests on the LXC rig verify the cross-iface case.

## Test plan

- [x] `go test ./internal/acp1/provider/... -count=1 -run TestVIPBind` — 2 cases green.
- [x] `go build ./...` clean.
- [x] golangci-lint clean.
- [ ] Live: two emulator instances on `10.6.239.200` and `.201`, `dhs consumer acp1 discover` lists both.

## Stacked on

PR #284 (fuzz verb). Merge order: Phase 0 (#267-#272) → #273 → #274 → #275 → #276 → #277 → #278 → #279 → #280 → #281 → #282 → #283 → #284 → this.

## Issue refs

Advances #263. Closes on the eventual PR-to-main when the ACP1 epic bundle lands together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
