### PR TITLE
feat(acp1): validate --out-tree wired (advances #264)

### DIFF
--- a/internal/acp1/consumer/validate.go
+++ b/internal/acp1/consumer/validate.go
@@ -46,6 +46,11 @@ func (p *Plugin) Validate(ctx context.Context, trames []wiretrace.Trame, opts pr
 		id    uint8
 	}
 	objects := map[objKey]protocol.Object{}
+	// frameStatuses captures the latest decoded frame-status reply
+	// (slot 0, group=frame, id=0) so the replay tree can stamp each
+	// SlotDump with the per-slot status it had at capture time —
+	// matching what GetSlotInfo populates on a live walk.
+	var frameStatuses []protocol.SlotStatus
 
 	var lastReqMTID uint32
 	for i, t := range trames {
@@ -100,9 +105,30 @@ func (p *Plugin) Validate(ctx context.Context, trames []wiretrace.Trame, opts pr
 			// regardless and just discard the result if --out-tree is
 			// off, but the decode is non-trivial — gate it.
 			if opts.OutTree != "" && msg.MCode == byte(codec.MethodGetObject) {
+				// Skip root probes: the live walker reads root only for
+				// per-group counts (browser.go) and never emits it as
+				// an Object. The replay tree must match.
+				if msg.ObjGroup == codec.GroupRoot {
+					break
+				}
 				if d, derr := codec.DecodeObject(msg.Value); derr == nil {
 					obj := toProtocolObject(d, int(msg.MAddr), msg.ObjGroup, msg.ObjID)
 					objects[objKey{int(msg.MAddr), msg.ObjGroup, msg.ObjID}] = obj
+				}
+			}
+			// Capture frame-status getValue replies so the replay tree
+			// can stamp each SlotDump.Status. Format per spec p.24:
+			// MDATA = [num_slots, status_0, status_1, ...].
+			if opts.OutTree != "" &&
+				msg.MCode == byte(codec.MethodGetValue) &&
+				msg.ObjGroup == codec.GroupFrame && msg.ObjID == 0 &&
+				len(msg.Value) >= 1 {
+				num := int(msg.Value[0])
+				if num > 0 && len(msg.Value) >= 1+num {
+					frameStatuses = make([]protocol.SlotStatus, num)
+					for i := 0; i < num; i++ {
+						frameStatuses[i] = protocol.SlotStatus(msg.Value[1+i])
+					}
 				}
 			}
 		}
@@ -114,7 +140,7 @@ func (p *Plugin) Validate(ctx context.Context, trames []wiretrace.Trame, opts pr
 	}
 
 	if opts.OutTree != "" {
-		if err := writeReplayTree(opts.OutTree, objects); err != nil {
+		if err := writeReplayTree(opts.OutTree, objects, frameStatuses); err != nil {
 			return report, fmt.Errorf("write out-tree: %w", err)
 		}
 	}
@@ -126,7 +152,11 @@ func (p *Plugin) Validate(ctx context.Context, trames []wiretrace.Trame, opts pr
 // JSON. The format matches what `dhs consumer acp1 export --format json`
 // produces from a live walk so capture/replay round-trips compare with
 // byte-equality (after timestamp normalisation).
-func writeReplayTree[K comparable](path string, objects map[K]protocol.Object) error {
+//
+// frameStatuses is the per-slot status array captured from the
+// getValue(slot=0, group=frame, id=0) reply, used to stamp each
+// SlotDump.Status (matches what live GetSlotInfo populates).
+func writeReplayTree[K comparable](path string, objects map[K]protocol.Object, frameStatuses []protocol.SlotStatus) error {
 	bySlot := map[int][]protocol.Object{}
 	for _, o := range objects {
 		bySlot[o.Slot] = append(bySlot[o.Slot], o)
@@ -153,11 +183,15 @@ func writeReplayTree[K comparable](path string, objects map[K]protocol.Object) e
 			}
 			return objs[i].ID < objs[j].ID
 		})
-		snap.Slots = append(snap.Slots, export.SlotDump{
+		dump := export.SlotDump{
 			Slot:     s,
 			WalkedAt: now,
 			Objects:  objs,
-		})
+		}
+		if s >= 0 && s < len(frameStatuses) {
+			dump.Status = frameStatuses[s].String()
+		}
+		snap.Slots = append(snap.Slots, dump)
 	}
 	f, err := os.Create(path)
 	if err != nil {

--- a/internal/acp1/consumer/validate.go
+++ b/internal/acp1/consumer/validate.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"os"
+	"sort"
+	"time"
 
+	"dhs/internal/export"
 	"dhs/internal/protocol"
 	"dhs/internal/wiretrace"
 	"dhs/internal/acp1/codec"
@@ -17,17 +21,31 @@ import (
 //
 // This is the offline counterpart to Walk: same codec, no live peer.
 //
-// `--out-tree` and `--out-params` (per ADR-0002) are not yet wired
-// here — Validate returns a clear error rather than silently ignoring
-// them. They land in a follow-up PR that integrates canonicalize.go.
+// When --out-tree is set, every successful getObject reply is converted
+// via toProtocolObject and accumulated into a per-slot map. After the
+// scan completes, the map is rendered as an export.Snapshot and written
+// to disk. The result is byte-equivalent (modulo timestamp + generator)
+// to the snapshot a live Walk would produce against the same device,
+// so capture / replay round-trips can be asserted in CI.
+//
+// --out-params remains a follow-up.
 func (p *Plugin) Validate(ctx context.Context, trames []wiretrace.Trame, opts protocol.ValidateOpts) (*protocol.ValidateReport, error) {
 	report := &protocol.ValidateReport{
 		PerDirection: map[wiretrace.Direction]int{},
 	}
 
-	if opts.OutTree != "" || opts.OutParams != "" {
-		return report, fmt.Errorf("acp1.Validate: --out-tree / --out-params not implemented yet (follow-up PR)")
+	if opts.OutParams != "" {
+		return report, fmt.Errorf("acp1.Validate: --out-params not implemented yet (follow-up PR)")
 	}
+
+	// Per-(slot, group, id) latest decoded object — getObject replies
+	// can repeat (e.g. the consumer re-walked); the latest wins.
+	type objKey struct {
+		slot  int
+		group codec.ObjGroup
+		id    uint8
+	}
+	objects := map[objKey]protocol.Object{}
 
 	var lastReqMTID uint32
 	for i, t := range trames {
@@ -77,6 +95,16 @@ func (p *Plugin) Validate(ctx context.Context, trames []wiretrace.Trame, opts pr
 				report.Invariants = append(report.Invariants,
 					fmt.Sprintf("trame %d: reply MTID=%d does not match last request MTID=%d", i, msg.MTID, lastReqMTID))
 			}
+			// Capture getObject replies into the per-slot tree map
+			// when --out-tree is requested. We can decode every reply
+			// regardless and just discard the result if --out-tree is
+			// off, but the decode is non-trivial — gate it.
+			if opts.OutTree != "" && msg.MCode == byte(codec.MethodGetObject) {
+				if d, derr := codec.DecodeObject(msg.Value); derr == nil {
+					obj := toProtocolObject(d, int(msg.MAddr), msg.ObjGroup, msg.ObjID)
+					objects[objKey{int(msg.MAddr), msg.ObjGroup, msg.ObjID}] = obj
+				}
+			}
 		}
 
 		if opts.StopAt != "" && t.Note == opts.StopAt {
@@ -85,7 +113,58 @@ func (p *Plugin) Validate(ctx context.Context, trames []wiretrace.Trame, opts pr
 		}
 	}
 
+	if opts.OutTree != "" {
+		if err := writeReplayTree(opts.OutTree, objects); err != nil {
+			return report, fmt.Errorf("write out-tree: %w", err)
+		}
+	}
+
 	return report, nil
+}
+
+// writeReplayTree emits the captured-getObject map as an export.Snapshot
+// JSON. The format matches what `dhs consumer acp1 export --format json`
+// produces from a live walk so capture/replay round-trips compare with
+// byte-equality (after timestamp normalisation).
+func writeReplayTree[K comparable](path string, objects map[K]protocol.Object) error {
+	bySlot := map[int][]protocol.Object{}
+	for _, o := range objects {
+		bySlot[o.Slot] = append(bySlot[o.Slot], o)
+	}
+	slots := make([]int, 0, len(bySlot))
+	for s := range bySlot {
+		slots = append(slots, s)
+	}
+	sort.Ints(slots)
+	now := time.Now().UTC()
+	snap := &export.Snapshot{
+		Generator: "dhs validate --out-tree (acp1)",
+		CreatedAt: now,
+		Device: export.DeviceInfo{
+			Protocol: "acp1",
+			NumSlots: len(slots),
+		},
+	}
+	for _, s := range slots {
+		objs := bySlot[s]
+		sort.SliceStable(objs, func(i, j int) bool {
+			if objs[i].Group != objs[j].Group {
+				return objs[i].Group < objs[j].Group
+			}
+			return objs[i].ID < objs[j].ID
+		})
+		snap.Slots = append(snap.Slots, export.SlotDump{
+			Slot:     s,
+			WalkedAt: now,
+			Objects:  objs,
+		})
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	return export.WriteJSON(f, snap)
 }
 
 func shortHex(b []byte) string {

--- a/internal/acp1/consumer/validate_out_tree_test.go
+++ b/internal/acp1/consumer/validate_out_tree_test.go
@@ -1,0 +1,219 @@
+package acp1
+
+import (
+	"context"
+	"encoding/hex"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"dhs/internal/export"
+	"dhs/internal/protocol"
+	"dhs/internal/wiretrace"
+	"dhs/internal/acp1/codec"
+)
+
+// buildGetObjectTrame constructs one Trame holding a getObject reply.
+// Helper for test fixtures -- no live wire activity.
+func buildGetObjectTrame(t *testing.T, mtid uint32, slot uint8, group codec.ObjGroup, id uint8, value []byte) wiretrace.Trame {
+	t.Helper()
+	m := &codec.Message{
+		MTID:     mtid,
+		MType:    codec.MTypeReply,
+		MAddr:    slot,
+		MCode:    byte(codec.MethodGetObject),
+		ObjGroup: group,
+		ObjID:    id,
+		Value:    value,
+	}
+	raw, err := m.Encode()
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	return wiretrace.Trame{
+		Direction: wiretrace.DirectionRx,
+		Hex:       hex.EncodeToString(raw),
+	}
+}
+
+func newPluginForOutTree(t *testing.T) *Plugin {
+	t.Helper()
+	f := &Factory{}
+	plug := f.New(slog.Default()).(*Plugin)
+	return plug
+}
+
+func TestValidateOutTree_WritesSnapshot(t *testing.T) {
+	p := newPluginForOutTree(t)
+
+	// Identity[0]: String "DEMO".
+	idValue := []byte{
+		0x05, 0x06, 0x01,
+		'D', 'E', 'M', 'O', 0x00,
+		0x10,
+		'C', 'a', 'r', 'd', 0x00,
+	}
+	// Control[0]: Float gain -6.0.
+	ctrlValue := []byte{
+		0x03, 0x0A, 0x03,
+		0xC0, 0xC0, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x3F, 0x80, 0x00, 0x00,
+		0xC2, 0xA0, 0x00, 0x00,
+		0x41, 0xA0, 0x00, 0x00,
+		'G', 'a', 'i', 'n', 0x00,
+		'd', 'B', 0x00,
+	}
+
+	// Need one matching request per reply for MTID invariant; provide
+	// a request before each reply.
+	requestFor := func(mtid uint32, slot uint8, group codec.ObjGroup, id uint8) wiretrace.Trame {
+		req := &codec.Message{
+			MTID: mtid, MType: codec.MTypeRequest, MAddr: slot,
+			MCode: byte(codec.MethodGetObject), ObjGroup: group, ObjID: id,
+		}
+		raw, _ := req.Encode()
+		return wiretrace.Trame{Direction: wiretrace.DirectionTx, Hex: hex.EncodeToString(raw)}
+	}
+
+	trames := []wiretrace.Trame{
+		requestFor(1, 1, codec.GroupIdentity, 0),
+		buildGetObjectTrame(t, 1, 1, codec.GroupIdentity, 0, idValue),
+		requestFor(2, 1, codec.GroupControl, 0),
+		buildGetObjectTrame(t, 2, 1, codec.GroupControl, 0, ctrlValue),
+	}
+
+	out := filepath.Join(t.TempDir(), "tree.json")
+	report, err := p.Validate(context.Background(), trames, protocol.ValidateOpts{
+		OutTree: out,
+	})
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if report.TramesProcessed != 4 {
+		t.Fatalf("trames processed = %d, want 4", report.TramesProcessed)
+	}
+
+	// Read back the snapshot and verify shape.
+	f, err := os.Open(out)
+	if err != nil {
+		t.Fatalf("open out-tree: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	snap, err := export.ReadJSON(f)
+	if err != nil {
+		t.Fatalf("ReadJSON: %v", err)
+	}
+	if snap.Device.Protocol != "acp1" {
+		t.Fatalf("protocol = %q, want acp1", snap.Device.Protocol)
+	}
+	if len(snap.Slots) != 1 {
+		t.Fatalf("slots = %d, want 1", len(snap.Slots))
+	}
+	if len(snap.Slots[0].Objects) != 2 {
+		t.Fatalf("objects = %d, want 2", len(snap.Slots[0].Objects))
+	}
+	// Order by group (alphabetical) then ID per the writer's
+	// deterministic sort: control < identity.
+	got := snap.Slots[0].Objects
+	if got[0].Group != "control" || got[0].Label != "Gain" {
+		t.Errorf("control object: %+v", got[0])
+	}
+	if got[1].Group != "identity" || got[1].Label != "Card" {
+		t.Errorf("identity object: %+v", got[1])
+	}
+}
+
+func TestValidateOutTree_LatestReplyWins(t *testing.T) {
+	p := newPluginForOutTree(t)
+
+	idV1 := []byte{
+		0x05, 0x06, 0x01,
+		'V', '1', 0x00,
+		0x10,
+		'C', 'a', 'r', 'd', 0x00,
+	}
+	idV2 := []byte{
+		0x05, 0x06, 0x01,
+		'V', '2', 0x00,
+		0x10,
+		'C', 'a', 'r', 'd', 0x00,
+	}
+	requestFor := func(mtid uint32, slot uint8, group codec.ObjGroup, id uint8) wiretrace.Trame {
+		req := &codec.Message{
+			MTID: mtid, MType: codec.MTypeRequest, MAddr: slot,
+			MCode: byte(codec.MethodGetObject), ObjGroup: group, ObjID: id,
+		}
+		raw, _ := req.Encode()
+		return wiretrace.Trame{Direction: wiretrace.DirectionTx, Hex: hex.EncodeToString(raw)}
+	}
+	trames := []wiretrace.Trame{
+		requestFor(1, 1, codec.GroupIdentity, 0),
+		buildGetObjectTrame(t, 1, 1, codec.GroupIdentity, 0, idV1),
+		requestFor(2, 1, codec.GroupIdentity, 0),
+		buildGetObjectTrame(t, 2, 1, codec.GroupIdentity, 0, idV2),
+	}
+	out := filepath.Join(t.TempDir(), "tree.json")
+	if _, err := p.Validate(context.Background(), trames, protocol.ValidateOpts{OutTree: out}); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	f, err := os.Open(out)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	snap, err := export.ReadJSON(f)
+	if err != nil {
+		t.Fatalf("ReadJSON: %v", err)
+	}
+	if got := snap.Slots[0].Objects[0].Value.Str; got != "V2" {
+		t.Fatalf("latest-reply-wins broken: got %q, want V2", got)
+	}
+}
+
+func TestValidateOutTree_NoGetObjectInputProducesEmptySnapshot(t *testing.T) {
+	p := newPluginForOutTree(t)
+
+	// Only getValue replies -- out-tree path should still work and emit
+	// an empty Snapshot.
+	req := &codec.Message{
+		MTID: 1, MType: codec.MTypeRequest, MAddr: 1,
+		MCode: byte(codec.MethodGetValue), ObjGroup: codec.GroupIdentity, ObjID: 0,
+	}
+	rep := &codec.Message{
+		MTID: 1, MType: codec.MTypeReply, MAddr: 1,
+		MCode: byte(codec.MethodGetValue), ObjGroup: codec.GroupIdentity, ObjID: 0,
+		Value: []byte("DEMO\x00"),
+	}
+	reqRaw, _ := req.Encode()
+	repRaw, _ := rep.Encode()
+	trames := []wiretrace.Trame{
+		{Direction: wiretrace.DirectionTx, Hex: hex.EncodeToString(reqRaw)},
+		{Direction: wiretrace.DirectionRx, Hex: hex.EncodeToString(repRaw)},
+	}
+	out := filepath.Join(t.TempDir(), "tree.json")
+	if _, err := p.Validate(context.Background(), trames, protocol.ValidateOpts{OutTree: out}); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	f, err := os.Open(out)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	snap, err := export.ReadJSON(f)
+	if err != nil {
+		t.Fatalf("ReadJSON: %v", err)
+	}
+	if len(snap.Slots) != 0 {
+		t.Fatalf("expected empty slots for getValue-only capture, got %d", len(snap.Slots))
+	}
+}
+
+func TestValidateOutTree_OutParamsStillRejected(t *testing.T) {
+	p := newPluginForOutTree(t)
+	_, err := p.Validate(context.Background(), nil, protocol.ValidateOpts{OutParams: "x.csv"})
+	if err == nil {
+		t.Fatal("--out-params should still error")
+	}
+}


### PR DESCRIPTION
## Summary

- `dhs consumer acp1 validate <frames.jsonl> --out-tree <out.json>` now emits a canonical Snapshot built from every getObject reply in the capture. Previously the flag returned "not implemented yet"; this PR wires it.
- Implementation tracks per-(slot, group, id) the latest decoded getObject reply, then renders as `export.Snapshot` with deterministic group/id ordering.
- 4 unit tests covering happy path, latest-reply-wins on duplicate keys, getValue-only capture produces empty Snapshot, and `--out-params` still errors.

## Round-trip property

```
captures/acp1/X/frames.jsonl
   == validate --out-tree ==>
out/X.tree.json

dhs consumer acp1 walk 10.6.239.113 --slot 1 --out live.tree.json
captures/acp1/Y/frames.jsonl  (same walk, captured)
   == validate --out-tree ==>
out/Y.tree.json

assert byte-equal(live.tree.json, out/Y.tree.json) modulo timestamps
```

This is the integration-gate "capture / replay round-trip" check from the ACP1 epic. Live verification waits on the integration rig.

## What's still deferred

`--out-params` (canonical params dump) remains "not implemented" — separate scope, smaller PR after this one is reviewed.

## Test plan

- [x] `go test ./internal/acp1/consumer/... -count=1 -run TestValidateOutTree` — 4 cases green.
- [x] `go build ./...` clean.
- [x] golangci-lint clean.
- [ ] Live: walk Synapse Simulator with `--capture`, then `validate --out-tree` on the JSONL, diff against the live tree.

## Stacked on

PR #285 (VIP bind). Merge order: Phase 0 (#267-#272) → #273 → ... → #284 → #285 → this.

## Issue refs

Advances #264 (sub of #243). Closes on the eventual PR-to-main when the ACP1 epic bundle lands together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
