### PR TITLE
feat(acp1): Plugin.SessionHealth implementation (advances #266)

### DIFF
--- a/cmd/dhs/cmd_diff.go
+++ b/cmd/dhs/cmd_diff.go
@@ -20,6 +20,10 @@ import (
 // prepended to the named CHANGELOG.md (creating it if absent).
 func runDiff(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("diff", flag.ExitOnError)
+	// --protocol is injected by the consumer dispatcher but diff is
+	// offline (operates on canonical tree.json files directly). Accept
+	// and ignore so `dhs consumer acp1 diff` works.
+	_ = fs.String("protocol", "", "(ignored; diff is offline)")
 	format := fs.String("format", "text", "output format: text | changelog")
 	version := fs.String("version", "", "version label for changelog entry (e.g. 2.4)")
 	date := fs.String("date", "", "date for changelog entry (YYYY-MM-DD). Default: today UTC.")

--- a/cmd/dhs/cmd_watch_hotplug.go
+++ b/cmd/dhs/cmd_watch_hotplug.go
@@ -75,7 +75,16 @@ func (h *hotPlugEnricher) observe(ctx context.Context, plug protocol.Protocol, t
 		prev, ok := h.prev[slot]
 		h.prev[slot] = cur
 		if !ok {
-			continue // first sight; record without acting
+			// First sight: if the slot is already present (controller
+			// boot finished before our watch started), enrich now —
+			// there's no boot→present transition to catch later.
+			// Synthesise the transition as no_card → cur so the
+			// downstream switch routes it correctly.
+			if cur == protocol.SlotPresent {
+				transitioned = append(transitioned, slot)
+				h.handleTransition(ctx, plug, ts, slot, protocol.SlotNoCard, cur)
+			}
+			continue
 		}
 		if prev == cur {
 			continue
@@ -93,8 +102,14 @@ func (h *hotPlugEnricher) handleTransition(ctx context.Context, plug protocol.Pr
 	tag := fmt.Sprintf("s%-2d %s -> %s", slot, prev.State(), cur.State())
 
 	switch {
-	case prev == protocol.SlotBootMode && cur == protocol.SlotPresent:
-		// Boot → present: trigger identity + seed (+ optional walk).
+	case cur == protocol.SlotPresent && prev != protocol.SlotPresent:
+		// Any path landing on present triggers enrichment. The
+		// canonical path is boot → present (real hardware always
+		// passes through boot); simulator and post-controller-boot
+		// shortcuts (no_card / powerup / removed / error → present)
+		// land here too. Identity probe is idempotent: re-running it
+		// on a card we've seen before just confirms or refreshes the
+		// fingerprint.
 		fp, seedRows, err := h.enrich(ctx, plug, slot)
 		if err != nil {
 			_, _ = fmt.Fprintf(h.out,"%s  hot-plug  %s  enrichment-failed: %v\n", tsStr, tag, err)

--- a/cmd/dhs/cmd_watch_hotplug.go
+++ b/cmd/dhs/cmd_watch_hotplug.go
@@ -34,7 +34,8 @@ import (
 type hotPlugEnricher struct {
 	mu             sync.Mutex
 	prev           map[int]protocol.SlotStatus
-	resolver       dmlib.Resolver // nil ⇒ no DM-library lookups
+	prevFP         map[int]protocol.CardIdentity // last-seen fingerprint per slot
+	resolver       dmlib.Resolver                // nil ⇒ no DM-library lookups
 	autoWalkOnPlug bool
 	out            io.Writer
 }
@@ -53,6 +54,7 @@ func newHotPlugEnricher(resolver dmlib.Resolver, autoWalkOnPlug bool, out io.Wri
 	}
 	return &hotPlugEnricher{
 		prev:           map[int]protocol.SlotStatus{},
+		prevFP:         map[int]protocol.CardIdentity{},
 		resolver:       resolver,
 		autoWalkOnPlug: autoWalkOnPlug,
 		out:            out,
@@ -110,14 +112,17 @@ func (h *hotPlugEnricher) handleTransition(ctx context.Context, plug protocol.Pr
 		// land here too. Identity probe is idempotent: re-running it
 		// on a card we've seen before just confirms or refreshes the
 		// fingerprint.
-		fp, seedRows, err := h.enrich(ctx, plug, slot)
+		swapTag, fp, seedRows, err := h.enrich(ctx, plug, slot)
 		if err != nil {
 			_, _ = fmt.Fprintf(h.out,"%s  hot-plug  %s  enrichment-failed: %v\n", tsStr, tag, err)
 			return
 		}
-		_, _ = fmt.Fprintf(h.out,"%s  hot-plug  %s  %s  %s\n", tsStr, tag, fp, seedRows)
-	case cur == protocol.SlotRemoved, prev == protocol.SlotRemoved && cur == protocol.SlotNoCard:
-		// Hot-removal cascade: keep emitting rows, no re-seed.
+		_, _ = fmt.Fprintf(h.out,"%s  hot-plug  %s  %s %s  %s\n", tsStr, tag, swapTag, fp, seedRows)
+	case cur == protocol.SlotRemoved, prev == protocol.SlotRemoved && cur == protocol.SlotNoCard, cur == protocol.SlotNoCard:
+		// Hot-removal cascade: keep emitting rows, no re-seed. Drop
+		// the cached fingerprint so a re-plug starts fresh
+		// ("discovered") rather than silently assuming continuity.
+		delete(h.prevFP, slot)
 		_, _ = fmt.Fprintf(h.out,"%s  hot-plug  %s\n", tsStr, tag)
 	case cur == protocol.SlotError:
 		_, _ = fmt.Fprintf(h.out,"%s  hot-plug  %s  card faulted\n", tsStr, tag)
@@ -129,24 +134,35 @@ func (h *hotPlugEnricher) handleTransition(ctx context.Context, plug protocol.Pr
 }
 
 // enrich runs the identity probe, DM-library lookup, plugin seed, and
-// (optionally) one-shot walk for a freshly-present slot. Returns a
-// short fingerprint string for the row and a seed-result tag.
-func (h *hotPlugEnricher) enrich(ctx context.Context, plug protocol.Protocol, slot int) (string, string, error) {
+// (optionally) one-shot walk for a freshly-present slot. Returns:
+//
+//	swapTag    diagnostic prefix: discovered / re-confirmed /
+//	           fw-upgrade / fw-downgrade / card-swap
+//	fp         current fingerprint MODEL@REV
+//	seedRows   seed-result tag (seeded(N objs) / no-resolver /
+//	           no-DM-entry / no-Seeder / schema-empty)
+func (h *hotPlugEnricher) enrich(ctx context.Context, plug protocol.Protocol, slot int) (string, string, string, error) {
 	idr, ok := plug.(protocol.Identifier)
 	if !ok {
-		return "(no Identifier)", "skipped", nil
+		return "discovered", "(no Identifier)", "skipped", nil
 	}
 	id, err := idr.GetIdentity(ctx, slot)
 	if err != nil {
 		if errors.Is(err, protocol.ErrIdentityUnresolved) {
-			return "id-unresolved", "no-DM-entry", nil
+			return "discovered", "id-unresolved", "no-DM-entry", nil
 		}
-		return "", "", fmt.Errorf("identity: %w", err)
+		return "", "", "", fmt.Errorf("identity: %w", err)
 	}
 	fp := fmt.Sprintf("%s@%s", id.Model, id.SwRev)
 
+	// Compare against the per-slot cached fingerprint to classify the
+	// transition. Caller (observe) holds h.mu so direct map access is
+	// safe.
+	swapTag := classifyFingerprintShift(h.prevFP[slot], id, h.prevFP)
+	h.prevFP[slot] = id
+
 	if h.resolver == nil {
-		return fp, "no-resolver", nil
+		return swapTag, fp, "no-resolver", nil
 	}
 	schema, rerr := h.resolver.Resolve(dmlib.Fingerprint{
 		Model: id.Model,
@@ -155,14 +171,14 @@ func (h *hotPlugEnricher) enrich(ctx context.Context, plug protocol.Protocol, sl
 	})
 	if rerr != nil {
 		if errors.Is(rerr, dmlib.ErrNotFound) {
-			return fp, "no-DM-entry", nil
+			return swapTag, fp, "no-DM-entry", nil
 		}
-		return fp, "", fmt.Errorf("dmlib.Resolve: %w", rerr)
+		return swapTag, fp, "", fmt.Errorf("dmlib.Resolve: %w", rerr)
 	}
 
 	seeder, ok := plug.(seederIface)
 	if !ok {
-		return fp, "no-Seeder", nil
+		return swapTag, fp, "no-Seeder", nil
 	}
 	snap, snapOK := schema.Slots[slot]
 	if !snapOK {
@@ -175,10 +191,10 @@ func (h *hotPlugEnricher) enrich(ctx context.Context, plug protocol.Protocol, sl
 		}
 	}
 	if !snapOK {
-		return fp, "schema-empty", nil
+		return swapTag, fp, "schema-empty", nil
 	}
 	if err := seeder.SeedFromDM(slot, snap); err != nil {
-		return fp, "", fmt.Errorf("seed: %w", err)
+		return swapTag, fp, "", fmt.Errorf("seed: %w", err)
 	}
 	objCount := 0
 	for _, sd := range snap.Slots {
@@ -196,5 +212,34 @@ func (h *hotPlugEnricher) enrich(ctx context.Context, plug protocol.Protocol, sl
 			_, _ = fmt.Fprintf(h.out,"         hot-plug s%-2d  walk=ok(%d)\n", slot, len(objs))
 		}()
 	}
-	return fp, tag, nil
+	return swapTag, fp, tag, nil
+}
+
+// classifyFingerprintShift compares the previous and current per-slot
+// fingerprint and returns the diagnostic prefix the row should carry.
+// prevFP is the entire enricher cache; we only need the per-slot prior
+// here, but passing the map keeps the signature open for future cross-
+// slot logic (e.g. card moved between slots).
+//
+// Outcomes:
+//
+//	discovered      no prior fingerprint cached
+//	re-confirmed    same Model + same SwRev (HwRev variation ignored)
+//	fw-upgrade      same Model, current SwRev > prior (lex compare)
+//	fw-downgrade    same Model, current SwRev < prior
+//	card-swap       different Model
+func classifyFingerprintShift(prev, cur protocol.CardIdentity, _ map[int]protocol.CardIdentity) string {
+	if prev.Model == "" {
+		return "discovered"
+	}
+	if prev.Model != cur.Model {
+		return fmt.Sprintf("card-swap %s@%s →", prev.Model, prev.SwRev)
+	}
+	if prev.SwRev == cur.SwRev {
+		return "re-confirmed"
+	}
+	if cur.SwRev > prev.SwRev {
+		return fmt.Sprintf("fw-upgrade %s %s →", prev.Model, prev.SwRev)
+	}
+	return fmt.Sprintf("fw-downgrade %s %s →", prev.Model, prev.SwRev)
 }

--- a/cmd/dhs/cmd_watch_hotplug_test.go
+++ b/cmd/dhs/cmd_watch_hotplug_test.go
@@ -105,19 +105,48 @@ func makeSchema(slot, nObjs int) *dmlib.Schema {
 	}
 }
 
-// firstFrameStatus seeds prev[]; subsequent calls drive transitions.
-func TestHotPlugEnricher_FirstSightDoesNothing(t *testing.T) {
+// firstFrameStatus seeds prev[]. Slots already present at first sight
+// are enriched immediately (controller booted before the watch started;
+// no boot→present transition will arrive). Slots in any non-present
+// state at first sight are recorded silently.
+func TestHotPlugEnricher_FirstSight_NonPresentSlotsRecordedSilently(t *testing.T) {
 	var buf bytes.Buffer
 	enr := newHotPlugEnricher(nil, false, &buf)
 	plug := &fakePlugin{}
 
+	// First-sight: slot 0 = no_card → no action.
 	transitioned := enr.observe(context.Background(), plug, time.Now(),
-		[]protocol.SlotStatus{protocol.SlotPresent, protocol.SlotNoCard})
+		[]protocol.SlotStatus{protocol.SlotNoCard})
 	if len(transitioned) != 0 {
-		t.Fatalf("first sight returned transitioned=%v, want []", transitioned)
+		t.Fatalf("first sight no_card returned transitioned=%v, want []", transitioned)
 	}
 	if buf.Len() != 0 {
-		t.Fatalf("first sight emitted output: %q", buf.String())
+		t.Fatalf("first sight no_card emitted output: %q", buf.String())
+	}
+}
+
+func TestHotPlugEnricher_FirstSight_PresentSlotEnriches(t *testing.T) {
+	// When the watch verb starts AFTER the controller has booted, the
+	// first frame-status announce shows slots already present.  We
+	// must enrich them on first sight — there will be no boot→present
+	// transition arriving later.
+	var buf bytes.Buffer
+	enr := newHotPlugEnricher(nil, false, &buf)
+	plug := &fakePlugin{
+		identity: protocol.CardIdentity{Model: "RRS18", SwRev: "1601"},
+	}
+
+	transitioned := enr.observe(context.Background(), plug, time.Now(),
+		[]protocol.SlotStatus{protocol.SlotPresent})
+	if len(transitioned) != 1 || transitioned[0] != 0 {
+		t.Fatalf("first sight present returned transitioned=%v, want [0]", transitioned)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "no_card -> present") {
+		t.Fatalf("missing synthesised transition row: %q", out)
+	}
+	if !strings.Contains(out, "RRS18@1601") {
+		t.Fatalf("missing identity probe result: %q", out)
 	}
 }
 
@@ -229,21 +258,68 @@ func TestHotPlugEnricher_AutoWalkOnPlug(t *testing.T) {
 }
 
 func TestHotPlugEnricher_HotRemove_NoReseed(t *testing.T) {
+	// First-sight-present triggers enrichment (one SeedFromDM call).
+	// The remove cascade after it must NOT add further seed calls —
+	// that's what this test pins.
 	var buf bytes.Buffer
 	enr := newHotPlugEnricher(&fakeResolver{schema: makeSchema(1, 1)}, false, &buf)
 	plug := &fakePlugin{identity: protocol.CardIdentity{Model: "RRS18", SwRev: "1601"}}
 
 	t0 := time.Now()
 	enr.observe(context.Background(), plug, t0, []protocol.SlotStatus{protocol.SlotPresent})
+	seedAfterFirstSight := plug.seedCalls
+	if seedAfterFirstSight != 1 {
+		t.Fatalf("first-sight present should enrich once; seedCalls = %d", seedAfterFirstSight)
+	}
+
 	enr.observe(context.Background(), plug, t0, []protocol.SlotStatus{protocol.SlotRemoved})
 	enr.observe(context.Background(), plug, t0, []protocol.SlotStatus{protocol.SlotNoCard})
 
-	if plug.seedCalls != 0 {
-		t.Fatalf("SeedFromDM called %d times during hot-remove cascade; want 0", plug.seedCalls)
+	if plug.seedCalls != seedAfterFirstSight {
+		t.Fatalf("hot-remove cascade should not re-seed; seedCalls = %d, want %d",
+			plug.seedCalls, seedAfterFirstSight)
 	}
 	out := buf.String()
 	if !strings.Contains(out, "present -> removed") || !strings.Contains(out, "removed -> no_card") {
 		t.Fatalf("missing transitions in output: %q", out)
+	}
+}
+
+// TestHotPlugEnricher_AnyPathToPresent_TriggersEnrichment pins the
+// widened trigger introduced after the simulator showed shortcut
+// transitions: powerup→present and removed→present can both happen
+// without going through boot. Real hardware always passes through
+// boot (so the canonical path stays exercised), but the simulator and
+// post-controller-boot first-sight cases must enrich too.
+func TestHotPlugEnricher_AnyPathToPresent_TriggersEnrichment(t *testing.T) {
+	cases := []struct {
+		name string
+		prev protocol.SlotStatus
+	}{
+		{"boot-to-present", protocol.SlotBootMode},
+		{"powerup-to-present", protocol.SlotPowerUp},
+		{"removed-to-present", protocol.SlotRemoved},
+		{"error-to-present", protocol.SlotError},
+		{"no_card-to-present", protocol.SlotNoCard},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			enr := newHotPlugEnricher(&fakeResolver{schema: makeSchema(0, 1)}, false, &buf)
+			plug := &fakePlugin{identity: protocol.CardIdentity{Model: "RRS18", SwRev: "1601"}}
+
+			t0 := time.Now()
+			enr.observe(context.Background(), plug, t0, []protocol.SlotStatus{tc.prev})
+			before := plug.seedCalls
+			enr.observe(context.Background(), plug, t0, []protocol.SlotStatus{protocol.SlotPresent})
+			if plug.seedCalls <= before {
+				t.Fatalf("%s did not trigger enrichment; seedCalls before=%d after=%d",
+					tc.name, before, plug.seedCalls)
+			}
+			if !strings.Contains(buf.String(), "RRS18@1601") {
+				t.Fatalf("%s missing fingerprint in output: %q", tc.name, buf.String())
+			}
+		})
 	}
 }
 

--- a/cmd/dhs/cmd_watch_hotplug_test.go
+++ b/cmd/dhs/cmd_watch_hotplug_test.go
@@ -285,6 +285,103 @@ func TestHotPlugEnricher_HotRemove_NoReseed(t *testing.T) {
 	}
 }
 
+func TestClassifyFingerprintShift(t *testing.T) {
+	cases := []struct {
+		name string
+		prev protocol.CardIdentity
+		cur  protocol.CardIdentity
+		want string
+	}{
+		{"first-sight", protocol.CardIdentity{}, protocol.CardIdentity{Model: "RRS18", SwRev: "1601"}, "discovered"},
+		{"re-confirmed-same", protocol.CardIdentity{Model: "RRS18", SwRev: "1601"}, protocol.CardIdentity{Model: "RRS18", SwRev: "1601"}, "re-confirmed"},
+		{"fw-upgrade", protocol.CardIdentity{Model: "RRS18", SwRev: "1601"}, protocol.CardIdentity{Model: "RRS18", SwRev: "1602"}, "fw-upgrade RRS18 1601 →"},
+		{"fw-downgrade", protocol.CardIdentity{Model: "RRS18", SwRev: "1602"}, protocol.CardIdentity{Model: "RRS18", SwRev: "1601"}, "fw-downgrade RRS18 1602 →"},
+		{"card-swap", protocol.CardIdentity{Model: "RRS18", SwRev: "1601"}, protocol.CardIdentity{Model: "GJA840", SwRev: "0101"}, "card-swap RRS18@1601 →"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyFingerprintShift(tc.prev, tc.cur, nil)
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHotPlugEnricher_FingerprintShifts_LiveDiagnostic(t *testing.T) {
+	// Drive a real card-swap sequence and confirm the diagnostic row
+	// classifies it correctly.
+	var buf bytes.Buffer
+	enr := newHotPlugEnricher(&fakeResolver{schema: makeSchema(0, 1)}, false, &buf)
+	plug := &fakePlugin{
+		identity: protocol.CardIdentity{Model: "RRS18", SwRev: "1601"},
+	}
+
+	// 1) Initial discovery.
+	t0 := time.Now()
+	enr.observe(context.Background(), plug, t0, []protocol.SlotStatus{protocol.SlotPresent})
+	if !strings.Contains(buf.String(), "discovered RRS18@1601") {
+		t.Fatalf("missing 'discovered' for initial; output: %q", buf.String())
+	}
+	buf.Reset()
+
+	// 2) Same card re-confirmed: cycle through boot then back to present.
+	enr.observe(context.Background(), plug, t0, []protocol.SlotStatus{protocol.SlotBootMode})
+	enr.observe(context.Background(), plug, t0, []protocol.SlotStatus{protocol.SlotPresent})
+	if !strings.Contains(buf.String(), "re-confirmed RRS18@1601") {
+		t.Fatalf("missing 're-confirmed'; output: %q", buf.String())
+	}
+	buf.Reset()
+
+	// 3) Firmware upgrade: same model, higher sw_rev.
+	plug.identity = protocol.CardIdentity{Model: "RRS18", SwRev: "1602"}
+	enr.observe(context.Background(), plug, t0, []protocol.SlotStatus{protocol.SlotBootMode})
+	enr.observe(context.Background(), plug, t0, []protocol.SlotStatus{protocol.SlotPresent})
+	if !strings.Contains(buf.String(), "fw-upgrade RRS18 1601") {
+		t.Fatalf("missing 'fw-upgrade'; output: %q", buf.String())
+	}
+	buf.Reset()
+
+	// 4) Firmware downgrade.
+	plug.identity = protocol.CardIdentity{Model: "RRS18", SwRev: "1500"}
+	enr.observe(context.Background(), plug, t0, []protocol.SlotStatus{protocol.SlotBootMode})
+	enr.observe(context.Background(), plug, t0, []protocol.SlotStatus{protocol.SlotPresent})
+	if !strings.Contains(buf.String(), "fw-downgrade RRS18 1602") {
+		t.Fatalf("missing 'fw-downgrade'; output: %q", buf.String())
+	}
+	buf.Reset()
+
+	// 5) Card swap to a different model.
+	plug.identity = protocol.CardIdentity{Model: "GJA840", SwRev: "0101"}
+	enr.observe(context.Background(), plug, t0, []protocol.SlotStatus{protocol.SlotBootMode})
+	enr.observe(context.Background(), plug, t0, []protocol.SlotStatus{protocol.SlotPresent})
+	if !strings.Contains(buf.String(), "card-swap RRS18@1500") {
+		t.Fatalf("missing 'card-swap'; output: %q", buf.String())
+	}
+}
+
+func TestHotPlugEnricher_NoCard_DropsCachedFingerprint(t *testing.T) {
+	// After the slot goes empty (no_card), the next time it hits
+	// present we should classify as 'discovered' even if the same
+	// physical card is re-inserted — we cannot assume continuity.
+	var buf bytes.Buffer
+	enr := newHotPlugEnricher(&fakeResolver{schema: makeSchema(0, 1)}, false, &buf)
+	plug := &fakePlugin{identity: protocol.CardIdentity{Model: "RRS18", SwRev: "1601"}}
+
+	t0 := time.Now()
+	enr.observe(context.Background(), plug, t0, []protocol.SlotStatus{protocol.SlotPresent})
+	enr.observe(context.Background(), plug, t0, []protocol.SlotStatus{protocol.SlotRemoved})
+	enr.observe(context.Background(), plug, t0, []protocol.SlotStatus{protocol.SlotNoCard})
+	buf.Reset()
+	enr.observe(context.Background(), plug, t0, []protocol.SlotStatus{protocol.SlotPresent})
+	if strings.Contains(buf.String(), "re-confirmed") {
+		t.Fatalf("re-plug after no_card should NOT be re-confirmed; output: %q", buf.String())
+	}
+	if !strings.Contains(buf.String(), "discovered") {
+		t.Fatalf("re-plug after no_card should classify as 'discovered'; output: %q", buf.String())
+	}
+}
+
 // TestHotPlugEnricher_AnyPathToPresent_TriggersEnrichment pins the
 // widened trigger introduced after the simulator showed shortcut
 // transitions: powerup→present and removed→present can both happen

--- a/internal/acp1/consumer/plugin.go
+++ b/internal/acp1/consumer/plugin.go
@@ -104,6 +104,11 @@ type Plugin struct {
 	// session. See compliance_events.go for the catalog. Nil until
 	// Connect fires; callers read via ComplianceProfile().
 	profile *compliance.Profile
+
+	// tsSink tracks the most-recent rx/tx wire timestamps so
+	// SessionHealth() can compute Live without blocking. Nil until
+	// Connect fires.
+	tsSink *timestampSink
 }
 
 // ComplianceProfile returns the session-scoped compliance profile.
@@ -179,6 +184,9 @@ func (p *Plugin) Connect(ctx context.Context, ip string, port int) error {
 	p.trees = newSlotTreeCache(cfg.MaxSize, cfg.TTL)
 	p.subHandles = map[subKey]SubHandle{}
 	p.profile = &compliance.Profile{}
+	if p.tsSink == nil {
+		p.tsSink = &timestampSink{}
+	}
 	p.walker = NewWalker(p.client)
 	p.walker.SetProfile(p.profile)
 	p.logger.Info("acp1 connected",
@@ -199,6 +207,12 @@ func (p *Plugin) connectUDP(ctx context.Context, ip string, port int) error {
 	if p.recorder != nil {
 		tr = p.recorder.WrapTransport(conn, "acp1")
 	}
+	// Wrap with timestamp tap so SessionHealth (#266) sees rx/tx
+	// activity without each call needing to probe the wire.
+	if p.tsSink == nil {
+		p.tsSink = &timestampSink{}
+	}
+	tr = &timestampingTransport{inner: tr, sink: p.tsSink}
 	p.client = NewClient(tr, p.logger, ClientConfig{})
 
 	if l, lerr := NewListener(p.logger, port); lerr != nil {

--- a/internal/acp1/consumer/session_health.go
+++ b/internal/acp1/consumer/session_health.go
@@ -1,0 +1,138 @@
+package acp1
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"time"
+
+	"dhs/internal/protocol"
+)
+
+// acp1StaleAfter is the rolling-window threshold past which the device
+// is judged not Live. Per spec p.20 + design discussion: 90 seconds
+// matches the slow announce cadence Synapse rack controllers use.
+const acp1StaleAfter = 90 * time.Second
+
+// timestampSink stores the most recent rx/tx wall-clock timestamps as
+// UnixNano values. Lock-free reads via atomic.Int64; writers update
+// once per wire event.
+type timestampSink struct {
+	lastRxNS atomic.Int64
+	lastTxNS atomic.Int64
+}
+
+// recordRx must be called from the transport read path.
+func (t *timestampSink) recordRx() { t.lastRxNS.Store(time.Now().UnixNano()) }
+
+// recordTx must be called from the transport write path.
+func (t *timestampSink) recordTx() { t.lastTxNS.Store(time.Now().UnixNano()) }
+
+func (t *timestampSink) lastRx() time.Time {
+	ns := t.lastRxNS.Load()
+	if ns == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, ns)
+}
+
+func (t *timestampSink) lastTx() time.Time {
+	ns := t.lastTxNS.Load()
+	if ns == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, ns)
+}
+
+// timestampingTransport wraps a Transport and updates a timestampSink on
+// every Send/Receive. Cheap (one atomic store per wire event).
+type timestampingTransport struct {
+	inner interface {
+		Send(ctx context.Context, payload []byte) error
+		Receive(ctx context.Context, maxSize int) ([]byte, error)
+		Close() error
+	}
+	sink *timestampSink
+}
+
+func (t *timestampingTransport) Send(ctx context.Context, payload []byte) error {
+	t.sink.recordTx()
+	return t.inner.Send(ctx, payload)
+}
+
+func (t *timestampingTransport) Receive(ctx context.Context, maxSize int) ([]byte, error) {
+	data, err := t.inner.Receive(ctx, maxSize)
+	if err == nil && len(data) > 0 {
+		t.sink.recordRx()
+	}
+	return data, err
+}
+
+func (t *timestampingTransport) Close() error { return t.inner.Close() }
+
+// SessionHealth implements the cross-protocol HealthChecker (#248).
+// Maps the 3 layers (Reachable / Connected / Live) onto ACP1's
+// transport mix per the design table.
+func (p *Plugin) SessionHealth(ctx context.Context) protocol.SessionHealth {
+	p.mu.Lock()
+	c := p.client
+	host := p.host
+	port := p.port
+	tk := p.transport
+	sink := p.tsSink
+	p.mu.Unlock()
+
+	out := protocol.SessionHealth{
+		StaleAfter: acp1StaleAfter,
+	}
+	if sink != nil {
+		out.LastRx = sink.lastRx()
+		out.LastTx = sink.lastTx()
+	}
+	out.Connected = c != nil
+	out.Live = !out.LastRx.IsZero() && time.Since(out.LastRx) <= acp1StaleAfter
+
+	// Reachable: do a quick on-demand probe. For both UDP and TCP we
+	// dial TCP to host:port — it's the cheapest cross-platform check
+	// that doesn't require ICMP privileges. Honour the caller's ctx
+	// deadline; default 500ms cap so SessionHealth never blocks for
+	// long.
+	if host != "" && port > 0 {
+		out.Reachable = probeReachable(ctx, host, port)
+	}
+	_ = tk
+	return out
+}
+
+func probeReachable(ctx context.Context, host string, port int) bool {
+	d := net.Dialer{Timeout: 500 * time.Millisecond}
+	if dl, ok := ctx.Deadline(); ok {
+		if time.Until(dl) < d.Timeout {
+			d.Timeout = time.Until(dl)
+			if d.Timeout <= 0 {
+				return false
+			}
+		}
+	}
+	addr := net.JoinHostPort(host, itoaPort(port))
+	conn, err := d.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+func itoaPort(p int) string {
+	if p == 0 {
+		return "0"
+	}
+	var buf [10]byte
+	i := len(buf)
+	for p > 0 {
+		i--
+		buf[i] = byte('0' + p%10)
+		p /= 10
+	}
+	return string(buf[i:])
+}

--- a/internal/acp1/consumer/session_health_test.go
+++ b/internal/acp1/consumer/session_health_test.go
@@ -1,0 +1,172 @@
+package acp1
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"dhs/internal/protocol"
+)
+
+func TestPlugin_SatisfiesHealthChecker(t *testing.T) {
+	var _ protocol.HealthChecker = (*Plugin)(nil)
+}
+
+func TestSessionHealth_DefaultsWhenNotConnected(t *testing.T) {
+	p := &Plugin{logger: slog.Default()}
+
+	// Use a context with a sub-millisecond deadline to fail-fast on
+	// the Reachable probe (no host, no port set anyway).
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	h := p.SessionHealth(ctx)
+	if h.Reachable {
+		t.Errorf("Reachable = true on disconnected plugin")
+	}
+	if h.Connected {
+		t.Errorf("Connected = true on disconnected plugin")
+	}
+	if h.Live {
+		t.Errorf("Live = true on disconnected plugin")
+	}
+	if !h.LastRx.IsZero() || !h.LastTx.IsZero() {
+		t.Errorf("Timestamps non-zero on disconnected plugin: rx=%v tx=%v", h.LastRx, h.LastTx)
+	}
+	if h.StaleAfter != acp1StaleAfter {
+		t.Errorf("StaleAfter = %v, want %v", h.StaleAfter, acp1StaleAfter)
+	}
+}
+
+func TestSessionHealth_LiveAfterRecentRx(t *testing.T) {
+	p := &Plugin{
+		logger: slog.Default(),
+		tsSink: &timestampSink{},
+	}
+	p.tsSink.recordRx()
+	p.tsSink.recordTx()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	h := p.SessionHealth(ctx)
+	if !h.Live {
+		t.Errorf("Live = false despite fresh rx; LastRx=%v", h.LastRx)
+	}
+	if h.LastRx.IsZero() {
+		t.Errorf("LastRx zero after recordRx()")
+	}
+	if h.LastTx.IsZero() {
+		t.Errorf("LastTx zero after recordTx()")
+	}
+}
+
+func TestSessionHealth_StaleAfterWindow(t *testing.T) {
+	p := &Plugin{
+		logger: slog.Default(),
+		tsSink: &timestampSink{},
+	}
+	// Forge a stale rx timestamp 100s ago > 90s threshold.
+	p.tsSink.lastRxNS.Store(time.Now().Add(-100 * time.Second).UnixNano())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	h := p.SessionHealth(ctx)
+	if h.Live {
+		t.Errorf("Live = true despite stale rx (100s ago)")
+	}
+	if h.LastRx.IsZero() {
+		t.Errorf("LastRx zero")
+	}
+}
+
+func TestTimestampSink_Atomic(t *testing.T) {
+	// Multiple goroutines hammer recordRx; final state is non-zero.
+	s := &timestampSink{}
+	done := make(chan struct{})
+	for i := 0; i < 8; i++ {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			for j := 0; j < 100; j++ {
+				s.recordRx()
+				s.recordTx()
+			}
+		}()
+	}
+	for i := 0; i < 8; i++ {
+		<-done
+	}
+	if s.lastRx().IsZero() || s.lastTx().IsZero() {
+		t.Fatal("timestamps zero after concurrent updates")
+	}
+}
+
+func TestTimestampingTransport_TapsBothDirections(t *testing.T) {
+	sink := &timestampSink{}
+	stub := &stubTimestampInner{rxData: []byte{0x01, 0x02}}
+	wrapped := &timestampingTransport{inner: stub, sink: sink}
+
+	if err := wrapped.Send(context.Background(), []byte{0xAA}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if sink.lastTx().IsZero() {
+		t.Fatal("lastTx not updated by Send")
+	}
+
+	got, err := wrapped.Receive(context.Background(), 16)
+	if err != nil {
+		t.Fatalf("Receive: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("rx data = %v", got)
+	}
+	if sink.lastRx().IsZero() {
+		t.Fatal("lastRx not updated by Receive")
+	}
+}
+
+type stubTimestampInner struct {
+	rxData []byte
+	served bool
+}
+
+func (s *stubTimestampInner) Send(_ context.Context, _ []byte) error { return nil }
+func (s *stubTimestampInner) Receive(_ context.Context, _ int) ([]byte, error) {
+	if s.served {
+		return nil, context.DeadlineExceeded
+	}
+	s.served = true
+	return s.rxData, nil
+}
+func (s *stubTimestampInner) Close() error { return nil }
+
+func TestProbeReachable_NoListener(t *testing.T) {
+	// Pick a definitely-closed port: bind+release then probe.
+	// This is racy in theory; in practice an ephemeral port immediately
+	// after release is closed.
+	const closedPort = 1 // privileged + unlikely to listen
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if probeReachable(ctx, "127.0.0.1", closedPort) {
+		t.Fatalf("probe returned reachable for closed port")
+	}
+}
+
+func TestItoaPort(t *testing.T) {
+	cases := []struct {
+		in   int
+		want string
+	}{
+		{0, "0"},
+		{1, "1"},
+		{2071, "2071"},
+		{65535, "65535"},
+	}
+	for _, tc := range cases {
+		if got := itoaPort(tc.in); got != tc.want {
+			t.Errorf("itoaPort(%d) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/dmlib/dm_diff_demo_test.go
+++ b/internal/dmlib/dm_diff_demo_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 
 	"dhs/internal/dmlib"
@@ -63,21 +64,35 @@ func TestDM_Diff_LiveCapture(t *testing.T) {
 				snap.Slots[i].Objects[j].Slot = 1
 			}
 		}
+		// Parse "MODEL@REV" so the dmlib.Diff (Model, Proto) gate can
+		// reject cross-model pairs as Mismatch. Diff is only valid
+		// between firmware revisions of the same product.
+		// fmt.Sscanf does NOT support POSIX character classes in Go;
+		// using strings.SplitN keeps the parse unambiguous.
+		parts := strings.SplitN(c.label, "@", 2)
+		if len(parts) != 2 {
+			t.Fatalf("bad label %q", c.label)
+		}
 		loaded[c.label] = &dmlib.Schema{
+			Fingerprint: dmlib.Fingerprint{
+				Model: parts[0],
+				SwRev: parts[1],
+				Proto: "acp1",
+			},
 			Slots: map[int]*export.Snapshot{1: snap},
 		}
 	}
 
 	r := dmlib.New(t.TempDir())
 
-	// Two interesting comparisons.
+	// Same-model firmware diffs (the only meaningful case). The
+	// simulator only has the 2GS110 family with two firmware revs;
+	// other models have a single rev each so no diff to run.
 	demo := []struct {
 		title       string
 		before, aft string
 	}{
 		{"firmware bump 2GS110: 2728 -> 2929", "2GS110@2728", "2GS110@2929"},
-		{"cross-model: RRS18 -> 2GS110", "RRS18@1601", "2GS110@2728"},
-		{"cross-model: 2HF110 -> GED130", "2HF110@4326", "GED130@2522"},
 	}
 	for _, d := range demo {
 		t.Run(d.title, func(t *testing.T) {
@@ -87,6 +102,9 @@ func TestDM_Diff_LiveCapture(t *testing.T) {
 				t.Skipf("schema missing: before=%v after=%v", ok1, ok2)
 			}
 			diff := r.Diff(before, after)
+			if diff.Mismatch {
+				t.Fatalf("%s: dmlib.Diff reports Mismatch — Models differ", d.title)
+			}
 			fmt.Printf("\n=== %s ===\n", d.title)
 			fmt.Printf("AddedSlots:   %v\n", diff.AddedSlots)
 			fmt.Printf("RemovedSlots: %v\n", diff.RemovedSlots)
@@ -110,6 +128,22 @@ func TestDM_Diff_LiveCapture(t *testing.T) {
 			}
 		})
 	}
+
+	// Negative case: cross-model diff must report Mismatch, not pretend
+	// to compute a delta.
+	t.Run("cross-model rejected as Mismatch", func(t *testing.T) {
+		rrs, ok1 := loaded["RRS18@1601"]
+		gjA, ok2 := loaded["2GS110@2728"]
+		if !ok1 || !ok2 {
+			t.Skip("schema missing")
+		}
+		diff := r.Diff(rrs, gjA)
+		if !diff.Mismatch {
+			t.Fatalf("cross-model diff did not flag Mismatch; got %+v", diff)
+		}
+		fmt.Println("\n=== cross-model: RRS18 -> 2GS110 ===")
+		fmt.Println("Mismatch=true (rejected: Models differ)")
+	})
 }
 
 func firstN(xs []string, n int) []string {

--- a/internal/dmlib/dm_diff_demo_test.go
+++ b/internal/dmlib/dm_diff_demo_test.go
@@ -1,0 +1,120 @@
+package dmlib_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"dhs/internal/dmlib"
+	"dhs/internal/export"
+)
+
+// TestDM_Diff_LiveCapture demonstrates dmlib.Diff against the schemas
+// extracted from the simulator's nine unique cards. Surfaces per-slot
+// Added/Removed/Changed object labels for every cross-pair.
+//
+// Run with `go test ./internal/dmlib/... -v -run TestDM_Diff_LiveCapture`.
+// Skips unless the captured fixtures exist (i.e. only meaningful after
+// the integration extraction has run).
+func TestDM_Diff_LiveCapture(t *testing.T) {
+	root := filepath.Join("..", "..", "tests", "fixtures", "products", "axon", "synapse")
+	if _, err := os.Stat(root); err != nil {
+		t.Skipf("fixtures absent: %v", err)
+	}
+
+	type card struct {
+		dir   string
+		slot  int
+		label string
+	}
+	cards := []card{
+		{"RRS18-1601", 0, "RRS18@1601"},
+		{"2GS110-2728", 1, "2GS110@2728"},
+		{"2GS110-2929", 5, "2GS110@2929"},
+		{"2HF110-4326", 2, "2HF110@4326"},
+		{"GED130-2522", 3, "GED130@2522"},
+		{"SDB20-0806", 9, "SDB20@0806"},
+		{"HPD130-2120", 13, "HPD130@2120"},
+		{"GJA840-0101", 16, "GJA840@0101"},
+		{"HRB990-1010", 19, "HRB990@1010"},
+	}
+	loaded := map[string]*dmlib.Schema{}
+	for _, c := range cards {
+		path := filepath.Join(root, c.dir, "acp1", fmt.Sprintf("slot_%d.json", c.slot))
+		f, err := os.Open(path)
+		if err != nil {
+			t.Logf("skip %s: %v", c.label, err)
+			continue
+		}
+		snap, err := export.ReadJSON(f)
+		_ = f.Close()
+		if err != nil {
+			t.Fatalf("%s: %v", c.label, err)
+		}
+		// Normalise to slot 1: both the map key AND every Object.Slot
+		// field. Without this the per-object diff sees Slot=N on one
+		// side and Slot=M on the other and reports every object as
+		// changed even when the schema is identical.
+		for i := range snap.Slots {
+			snap.Slots[i].Slot = 1
+			for j := range snap.Slots[i].Objects {
+				snap.Slots[i].Objects[j].Slot = 1
+			}
+		}
+		loaded[c.label] = &dmlib.Schema{
+			Slots: map[int]*export.Snapshot{1: snap},
+		}
+	}
+
+	r := dmlib.New(t.TempDir())
+
+	// Two interesting comparisons.
+	demo := []struct {
+		title       string
+		before, aft string
+	}{
+		{"firmware bump 2GS110: 2728 -> 2929", "2GS110@2728", "2GS110@2929"},
+		{"cross-model: RRS18 -> 2GS110", "RRS18@1601", "2GS110@2728"},
+		{"cross-model: 2HF110 -> GED130", "2HF110@4326", "GED130@2522"},
+	}
+	for _, d := range demo {
+		t.Run(d.title, func(t *testing.T) {
+			before, ok1 := loaded[d.before]
+			after, ok2 := loaded[d.aft]
+			if !ok1 || !ok2 {
+				t.Skipf("schema missing: before=%v after=%v", ok1, ok2)
+			}
+			diff := r.Diff(before, after)
+			fmt.Printf("\n=== %s ===\n", d.title)
+			fmt.Printf("AddedSlots:   %v\n", diff.AddedSlots)
+			fmt.Printf("RemovedSlots: %v\n", diff.RemovedSlots)
+			slots := make([]int, 0, len(diff.PerSlot))
+			for s := range diff.PerSlot {
+				slots = append(slots, s)
+			}
+			sort.Ints(slots)
+			for _, s := range slots {
+				sd := diff.PerSlot[s]
+				fmt.Printf("Slot %d: +%d / -%d / ~%d\n", s, len(sd.Added), len(sd.Removed), len(sd.Changed))
+				if len(sd.Added) > 0 {
+					fmt.Printf("  added (%d, first 5): %v\n", len(sd.Added), firstN(sd.Added, 5))
+				}
+				if len(sd.Removed) > 0 {
+					fmt.Printf("  removed (%d, first 5): %v\n", len(sd.Removed), firstN(sd.Removed, 5))
+				}
+				if len(sd.Changed) > 0 {
+					fmt.Printf("  changed (%d, first 5): %v\n", len(sd.Changed), firstN(sd.Changed, 5))
+				}
+			}
+		})
+	}
+}
+
+func firstN(xs []string, n int) []string {
+	if len(xs) <= n {
+		return xs
+	}
+	return xs[:n]
+}

--- a/internal/dmlib/dmlib.go
+++ b/internal/dmlib/dmlib.go
@@ -74,7 +74,10 @@ type Schema struct {
 	SupportedProtocols []string
 }
 
-// Diff is the per-slot delta between two Schemas of the same Fingerprint.
+// Diff is the per-slot delta between two Schemas of the SAME (Model,
+// Proto) — i.e. two firmware revisions of one product. Diffing across
+// models is conceptually meaningless and Diff returns an empty result
+// (Mismatch=true) for that case.
 type Diff struct {
 	AddedSlots   []int
 	RemovedSlots []int
@@ -82,6 +85,11 @@ type Diff struct {
 	// PerSlot holds the object-level diff for slots present in both
 	// snapshots. Keyed by slot number.
 	PerSlot map[int]SlotDiff
+
+	// Mismatch is set when the two schemas don't share (Model, Proto).
+	// Callers must check this before consuming PerSlot — a Mismatch
+	// diff is empty by design, not because the schemas are identical.
+	Mismatch bool
 }
 
 // SlotDiff is the object-level delta for one slot.
@@ -264,7 +272,12 @@ func (r *fileResolver) Diff(prev, cur *Schema) Diff {
 	if prev == nil || cur == nil {
 		return d
 	}
-	if prev.Fingerprint != cur.Fingerprint {
+	// Diff is semantically valid only between two firmware revisions of
+	// the same product. (Model, Proto) must match; SwRev / HwRev may
+	// differ — that's the whole point.
+	if prev.Fingerprint.Model != cur.Fingerprint.Model ||
+		prev.Fingerprint.Proto != cur.Fingerprint.Proto {
+		d.Mismatch = true
 		return d
 	}
 	for slot := range cur.Slots {

--- a/internal/dmlib/dmlib_test.go
+++ b/internal/dmlib/dmlib_test.go
@@ -300,6 +300,72 @@ func TestDiff_AddedRemovedSlots(t *testing.T) {
 	}
 }
 
+func TestDiff_ModelMismatch_FlagsAndReturnsEmpty(t *testing.T) {
+	prev := &Schema{
+		Fingerprint: Fingerprint{Model: "RRS18", SwRev: "1601", Proto: "acp1"},
+		Slots: map[int]*export.Snapshot{
+			1: makeSnapshot("RRS18", []protocol.Object{{Slot: 1, ID: 1, Label: "A"}}),
+		},
+	}
+	cur := &Schema{
+		Fingerprint: Fingerprint{Model: "GJA840", SwRev: "0101", Proto: "acp1"},
+		Slots: map[int]*export.Snapshot{
+			1: makeSnapshot("GJA840", []protocol.Object{{Slot: 1, ID: 1, Label: "B"}}),
+		},
+	}
+	r := New(t.TempDir())
+	d := r.Diff(prev, cur)
+	if !d.Mismatch {
+		t.Fatal("Diff across different Models should flag Mismatch")
+	}
+	if len(d.AddedSlots) != 0 || len(d.RemovedSlots) != 0 || len(d.PerSlot) != 0 {
+		t.Fatalf("Mismatch diff should be empty; got %+v", d)
+	}
+}
+
+func TestDiff_SameModel_DifferentSwRev_OK(t *testing.T) {
+	// Firmware bump: same model, different sw_rev. Diff should run.
+	prev := &Schema{
+		Fingerprint: Fingerprint{Model: "RRS18", SwRev: "1601", Proto: "acp1"},
+		Slots: map[int]*export.Snapshot{
+			1: makeSnapshot("RRS18", []protocol.Object{{Slot: 1, ID: 1, Label: "A"}}),
+		},
+	}
+	cur := &Schema{
+		Fingerprint: Fingerprint{Model: "RRS18", SwRev: "1602", Proto: "acp1"},
+		Slots: map[int]*export.Snapshot{
+			1: makeSnapshot("RRS18", []protocol.Object{
+				{Slot: 1, ID: 1, Label: "A"},
+				{Slot: 1, ID: 2, Label: "NewControl"},
+			}),
+		},
+	}
+	r := New(t.TempDir())
+	d := r.Diff(prev, cur)
+	if d.Mismatch {
+		t.Fatal("same-Model different-SwRev diff should not flag Mismatch")
+	}
+	if len(d.PerSlot[1].Added) != 1 || d.PerSlot[1].Added[0] != "NewControl" {
+		t.Fatalf("expected 1 added (NewControl); got %+v", d.PerSlot[1])
+	}
+}
+
+func TestDiff_ProtoMismatch_FlagsAndReturnsEmpty(t *testing.T) {
+	prev := &Schema{
+		Fingerprint: Fingerprint{Model: "RRS18", SwRev: "1601", Proto: "acp1"},
+		Slots:       map[int]*export.Snapshot{1: makeSnapshot("X", nil)},
+	}
+	cur := &Schema{
+		Fingerprint: Fingerprint{Model: "RRS18", SwRev: "1601", Proto: "acp2"},
+		Slots:       map[int]*export.Snapshot{1: makeSnapshot("X", nil)},
+	}
+	r := New(t.TempDir())
+	d := r.Diff(prev, cur)
+	if !d.Mismatch {
+		t.Fatal("Diff across different Protos should flag Mismatch")
+	}
+}
+
 func TestPersist_RejectsUnsafeFingerprint(t *testing.T) {
 	r := New(t.TempDir())
 	s := &Schema{

--- a/tests/fixtures/products/axon/synapse/2GS110-2728/acp1/slot_1.json
+++ b/tests/fixtures/products/axon/synapse/2GS110-2728/acp1/slot_1.json
@@ -1,0 +1,3846 @@
+{
+  "created_at": "2026-05-05T10:21:44Z",
+  "device": {
+    "ip": "10.6.239.113",
+    "port": 2071,
+    "protocol": "acp1",
+    "protocol_version": 1,
+    "num_slots": 31
+  },
+  "generator": "acp dev",
+  "slots": [
+    {
+      "objects": {
+        "alarm": {
+          "Announcements": {
+            "access": "RW-",
+            "id": 0,
+            "kind": "alarm",
+            "value": 1
+          },
+          "Input_A": {
+            "access": "RW-",
+            "id": 1,
+            "kind": "alarm",
+            "value": 1
+          },
+          "Input_B": {
+            "access": "RW-",
+            "id": 2,
+            "kind": "alarm",
+            "value": 1
+          },
+          "Ref-Status": {
+            "access": "RW-",
+            "id": 3,
+            "kind": "alarm",
+            "value": 0
+          }
+        },
+        "control": {
+          "  AUDIO PROC AMP": {
+            "access": "RW-",
+            "id": 109,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "  DOWN CONV": {
+            "access": "RW-",
+            "id": 29,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "  EMBEDDER": {
+            "access": "RW-",
+            "id": 115,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "  GPI MODE": {
+            "access": "RW-",
+            "id": 184,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "  INSERTER": {
+            "access": "RW-",
+            "id": 61,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "  TRANSPARENT": {
+            "access": "RW-",
+            "id": 46,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "  VIDEO PROC": {
+            "access": "RW-",
+            "id": 90,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          " NETWORK": {
+            "access": "RW-",
+            "id": 191,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "#Audio_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 113,
+            "kind": "int",
+            "max": 10000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#CC_Ena_A": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 78,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#CC_Ena_B": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 89,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#CVBS-Frmt": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Auto",
+              "PAL-M",
+              "PAL-N",
+              "NTSC-M",
+              "NTSC-4.43",
+              "NTSC-J",
+              "SECAM",
+              "PAL-60",
+              "PAL-BGHID"
+            ],
+            "id": 5,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "NTSC-4.43"
+          },
+          "#Dn_ArcA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Anamorphic",
+              "CenterCut",
+              "LBox-16:9",
+              "LBox-14:9",
+              "Variable",
+              "Anam-702"
+            ],
+            "id": 33,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Anamorphic"
+          },
+          "#Dn_ArcB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Anamorphic",
+              "CenterCut",
+              "LBox-16:9",
+              "LBox-14:9",
+              "Variable",
+              "Anam-702"
+            ],
+            "id": 41,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Anamorphic"
+          },
+          "#Dn_ColorConvA": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Off",
+              "709to601"
+            ],
+            "id": 37,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "709to601"
+          },
+          "#Dn_ColorConvB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "709to601"
+            ],
+            "id": 45,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#Dn_H-EnhA": {
+            "access": "RW-",
+            "default": 0,
+            "id": 36,
+            "kind": "int",
+            "max": 100,
+            "min": 0,
+            "step": 1,
+            "value": 0
+          },
+          "#Dn_H-EnhB": {
+            "access": "RW-",
+            "default": 0,
+            "id": 44,
+            "kind": "int",
+            "max": 100,
+            "min": 0,
+            "step": 1,
+            "value": 0
+          },
+          "#Dn_H-ScaleA": {
+            "access": "RW-",
+            "default": 100,
+            "id": 34,
+            "kind": "float",
+            "max": 200,
+            "min": 50,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "#Dn_H-ScaleB": {
+            "access": "RW-",
+            "default": 100,
+            "id": 42,
+            "kind": "float",
+            "max": 200,
+            "min": 50,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "#Dn_V-ScaleA": {
+            "access": "RW-",
+            "default": 100,
+            "id": 35,
+            "kind": "float",
+            "max": 200,
+            "min": 50,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "#Dn_V-ScaleB": {
+            "access": "RW-",
+            "default": 100,
+            "id": 43,
+            "kind": "float",
+            "max": 200,
+            "min": 50,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "#EmbA1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 152,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbA1_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 117,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbA1_Inp_Ch": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 118,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ch_1"
+          },
+          "#EmbA1_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 153,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbA2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 154,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbA2_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 119,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbA2_Inp_Ch": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 120,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Ch_2"
+          },
+          "#EmbA2_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 155,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbA3_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 156,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbA3_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 121,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbA3_Inp_Ch": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 122,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ch_3"
+          },
+          "#EmbA3_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 157,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbA4_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 158,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbA4_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 123,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbA4_Inp_Ch": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 124,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Ch_4"
+          },
+          "#EmbA4_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 159,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbA_Grp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Group1",
+              "Group2",
+              "Group3",
+              "Group4",
+              "Off"
+            ],
+            "id": 116,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Group1"
+          },
+          "#EmbB1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 160,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbB1_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 126,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbB1_Inp_Ch": {
+            "access": "RW-",
+            "default": 4,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 127,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "Ch_5"
+          },
+          "#EmbB1_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 161,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbB2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 162,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbB2_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 128,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbB2_Inp_Ch": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 129,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Ch_6"
+          },
+          "#EmbB2_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 163,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbB3_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 164,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbB3_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 130,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbB3_Inp_Ch": {
+            "access": "RW-",
+            "default": 6,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 131,
+            "kind": "enum",
+            "value": 6,
+            "value_name": "Ch_7"
+          },
+          "#EmbB3_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 165,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbB4_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 166,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbB4_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 132,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbB4_Inp_Ch": {
+            "access": "RW-",
+            "default": 7,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 133,
+            "kind": "enum",
+            "value": 7,
+            "value_name": "Ch_8"
+          },
+          "#EmbB4_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 167,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbB_Grp": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Group1",
+              "Group2",
+              "Group3",
+              "Group4",
+              "Off"
+            ],
+            "id": 125,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Group2"
+          },
+          "#EmbC1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 168,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbC1_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 135,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbC1_Inp_Ch": {
+            "access": "RW-",
+            "default": 8,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 136,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "Ch_9"
+          },
+          "#EmbC1_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 169,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbC2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 170,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbC2_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 137,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbC2_Inp_Ch": {
+            "access": "RW-",
+            "default": 9,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 138,
+            "kind": "enum",
+            "value": 9,
+            "value_name": "Ch_10"
+          },
+          "#EmbC2_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 171,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbC3_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 172,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbC3_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 139,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbC3_Inp_Ch": {
+            "access": "RW-",
+            "default": 10,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 140,
+            "kind": "enum",
+            "value": 10,
+            "value_name": "Ch_11"
+          },
+          "#EmbC3_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 173,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbC4_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 174,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbC4_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 141,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbC4_Inp_Ch": {
+            "access": "RW-",
+            "default": 11,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 142,
+            "kind": "enum",
+            "value": 11,
+            "value_name": "Ch_12"
+          },
+          "#EmbC4_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 175,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbC_Grp": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Group1",
+              "Group2",
+              "Group3",
+              "Group4",
+              "Off"
+            ],
+            "id": 134,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Group3"
+          },
+          "#EmbD1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 176,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbD1_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 144,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbD1_Inp_Ch": {
+            "access": "RW-",
+            "default": 12,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 145,
+            "kind": "enum",
+            "value": 12,
+            "value_name": "Ch_13"
+          },
+          "#EmbD1_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 177,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbD2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 178,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbD2_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 146,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbD2_Inp_Ch": {
+            "access": "RW-",
+            "default": 13,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 147,
+            "kind": "enum",
+            "value": 13,
+            "value_name": "Ch_14"
+          },
+          "#EmbD2_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 179,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbD3_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 180,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbD3_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 148,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbD3_Inp_Ch": {
+            "access": "RW-",
+            "default": 14,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 149,
+            "kind": "enum",
+            "value": 14,
+            "value_name": "Ch_15"
+          },
+          "#EmbD3_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 181,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbD4_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 182,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbD4_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 150,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbD4_Inp_Ch": {
+            "access": "RW-",
+            "default": 15,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 151,
+            "kind": "enum",
+            "value": 15,
+            "value_name": "Ch_16"
+          },
+          "#EmbD4_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 183,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbD_Grp": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Group1",
+              "Group2",
+              "Group3",
+              "Group4",
+              "Off"
+            ],
+            "id": 143,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Group4"
+          },
+          "#F_delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 7,
+            "kind": "uint",
+            "max": 250,
+            "min": 0,
+            "step": 1,
+            "unit": "F",
+            "value": 0
+          },
+          "#Freeze_A": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 11,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#Freeze_B": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 12,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#H_delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 9,
+            "kind": "int",
+            "max": 5124,
+            "min": 0,
+            "step": 1,
+            "unit": "px",
+            "value": 0
+          },
+          "#Inp_SelA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI-1",
+              "SDI-2",
+              "Analog",
+              "Zoneplate",
+              "Colorbar"
+            ],
+            "id": 3,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "Colorbar"
+          },
+          "#Inp_SelB": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "SDI-1",
+              "SDI-2",
+              "Analog",
+              "Zoneplate",
+              "Colorbar"
+            ],
+            "id": 4,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "SDI-2"
+          },
+          "#LowPassFilt_A": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "H_Only",
+              "V_Only",
+              "H_And_V",
+              "H2_Only",
+              "H2_And_V"
+            ],
+            "id": 13,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#LowPassFilt_B": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "H_Only",
+              "V_Only",
+              "H_And_V",
+              "H2_Only",
+              "H2_And_V"
+            ],
+            "id": 14,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#Out-Frmt": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1080i60",
+              "1080i50",
+              "1080p30",
+              "1080p25",
+              "1080p24",
+              "1080p24sf",
+              "720p60",
+              "720p50",
+              "720p24",
+              "SD525",
+              "SD625",
+              "1080p60",
+              "1080p50"
+            ],
+            "id": 6,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1080i60"
+          },
+          "#Out-Mode": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Straight",
+              "Crossed",
+              "A Only",
+              "B Only",
+              "Sum"
+            ],
+            "id": 10,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "A Only"
+          },
+          "#S2016-DataA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "AFD0",
+              "AFD1",
+              "AFD2",
+              "AFD3",
+              "AFD4",
+              "AFD5",
+              "AFD6",
+              "AFD7",
+              "AFD8",
+              "AFD9",
+              "AFD10",
+              "AFD11",
+              "AFD12",
+              "AFD13",
+              "AFD14",
+              "AFD15"
+            ],
+            "id": 77,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "AFD0"
+          },
+          "#S2016-DataB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "AFD0",
+              "AFD1",
+              "AFD2",
+              "AFD3",
+              "AFD4",
+              "AFD5",
+              "AFD6",
+              "AFD7",
+              "AFD8",
+              "AFD9",
+              "AFD10",
+              "AFD11",
+              "AFD12",
+              "AFD13",
+              "AFD14",
+              "AFD15"
+            ],
+            "id": 88,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "AFD0"
+          },
+          "#S2016-InsertA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 76,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#S2016-InsertB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 87,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#Tr_ArcA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Anamorphic",
+              "Variable"
+            ],
+            "id": 50,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Anamorphic"
+          },
+          "#Tr_ArcB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Anamorphic",
+              "Variable"
+            ],
+            "id": 57,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Anamorphic"
+          },
+          "#Tr_H-EnhA": {
+            "access": "RW-",
+            "default": 0,
+            "id": 53,
+            "kind": "int",
+            "max": 100,
+            "min": 0,
+            "step": 1,
+            "value": 0
+          },
+          "#Tr_H-EnhB": {
+            "access": "RW-",
+            "default": 0,
+            "id": 60,
+            "kind": "int",
+            "max": 100,
+            "min": 0,
+            "step": 1,
+            "value": 0
+          },
+          "#Tr_H-ScaleA": {
+            "access": "RW-",
+            "default": 100,
+            "id": 51,
+            "kind": "float",
+            "max": 200,
+            "min": 50,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "#Tr_H-ScaleB": {
+            "access": "RW-",
+            "default": 100,
+            "id": 58,
+            "kind": "float",
+            "max": 200,
+            "min": 50,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "#Tr_V-ScaleA": {
+            "access": "RW-",
+            "default": 100,
+            "id": 52,
+            "kind": "float",
+            "max": 200,
+            "min": 50,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "#Tr_V-ScaleB": {
+            "access": "RW-",
+            "default": 100,
+            "id": 59,
+            "kind": "float",
+            "max": 200,
+            "min": 50,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "#VANC_Trans": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 15,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#VANC_Trans_Ln0": {
+            "access": "RW-",
+            "default": 7,
+            "id": 16,
+            "kind": "int",
+            "max": 41,
+            "min": 7,
+            "step": 1,
+            "unit": "ln",
+            "value": 9
+          },
+          "#VANC_Trans_Ln1": {
+            "access": "RW-",
+            "default": 7,
+            "id": 17,
+            "kind": "int",
+            "max": 41,
+            "min": 7,
+            "step": 1,
+            "unit": "ln",
+            "value": 7
+          },
+          "#VANC_Trans_Ln2": {
+            "access": "RW-",
+            "default": 7,
+            "id": 18,
+            "kind": "int",
+            "max": 41,
+            "min": 7,
+            "step": 1,
+            "unit": "ln",
+            "value": 7
+          },
+          "#VANC_Trans_Ln3": {
+            "access": "RW-",
+            "default": 7,
+            "id": 19,
+            "kind": "int",
+            "max": 41,
+            "min": 7,
+            "step": 1,
+            "unit": "ln",
+            "value": 7
+          },
+          "#VANC_Trans_Ln4": {
+            "access": "RW-",
+            "default": 7,
+            "id": 20,
+            "kind": "int",
+            "max": 41,
+            "min": 7,
+            "step": 1,
+            "unit": "ln",
+            "value": 7
+          },
+          "#VANC_Trans_Ln5": {
+            "access": "RW-",
+            "default": 7,
+            "id": 21,
+            "kind": "int",
+            "max": 41,
+            "min": 7,
+            "step": 1,
+            "unit": "ln",
+            "value": 7
+          },
+          "#VI-DataA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "4:3_0",
+              "4:3_1",
+              "4:3_2",
+              "4:3_3",
+              "4:3_4",
+              "4:3_5",
+              "4:3_6",
+              "4:3_7",
+              "16:9_0",
+              "16:9_1",
+              "16:9_2",
+              "16:9_3",
+              "16:9_4",
+              "16:9_5",
+              "16:9_6",
+              "16:9_7"
+            ],
+            "id": 72,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "4:3_0"
+          },
+          "#VI-DataB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "4:3_0",
+              "4:3_1",
+              "4:3_2",
+              "4:3_3",
+              "4:3_4",
+              "4:3_5",
+              "4:3_6",
+              "4:3_7",
+              "16:9_0",
+              "16:9_1",
+              "16:9_2",
+              "16:9_3",
+              "16:9_4",
+              "16:9_5",
+              "16:9_6",
+              "16:9_7"
+            ],
+            "id": 83,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "4:3_0"
+          },
+          "#VI-InsertA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 71,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#VI-InsertB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 82,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#V_delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 8,
+            "kind": "int",
+            "max": 1125,
+            "min": 0,
+            "step": 1,
+            "unit": "ln",
+            "value": 0
+          },
+          "#WSS-ExtndA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "4:3_0",
+              "4:3_1",
+              "4:3_2",
+              "4:3_3",
+              "4:3_4",
+              "4:3_5",
+              "4:3_6",
+              "4:3_7",
+              "16:9_0",
+              "16:9_1",
+              "16:9_2",
+              "16:9_3",
+              "16:9_4",
+              "16:9_5",
+              "16:9_6",
+              "16:9_7"
+            ],
+            "id": 75,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "4:3_0"
+          },
+          "#WSS-ExtndB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "4:3_0",
+              "4:3_1",
+              "4:3_2",
+              "4:3_3",
+              "4:3_4",
+              "4:3_5",
+              "4:3_6",
+              "4:3_7",
+              "16:9_0",
+              "16:9_1",
+              "16:9_2",
+              "16:9_3",
+              "16:9_4",
+              "16:9_5",
+              "16:9_6",
+              "16:9_7"
+            ],
+            "id": 86,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "4:3_0"
+          },
+          "#WSS-InsertA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Standard",
+              "Extended"
+            ],
+            "id": 73,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#WSS-InsertB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Standard",
+              "Extended"
+            ],
+            "id": 84,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#WSS-StndA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1_vid",
+              "2_vid",
+              "3_vid",
+              "4_vid",
+              "5_vid",
+              "6_vid",
+              "7_vid",
+              "8_vid",
+              "1_flm",
+              "2_flm",
+              "3_flm",
+              "4_flm",
+              "5_flm",
+              "6_flm",
+              "7_flm",
+              "8_flm"
+            ],
+            "id": 74,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1_vid"
+          },
+          "#WSS-StndB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1_vid",
+              "2_vid",
+              "3_vid",
+              "4_vid",
+              "5_vid",
+              "6_vid",
+              "7_vid",
+              "8_vid",
+              "1_flm",
+              "2_flm",
+              "3_flm",
+              "4_flm",
+              "5_flm",
+              "6_flm",
+              "7_flm",
+              "8_flm"
+            ],
+            "id": 85,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1_vid"
+          },
+          "Audio-Bus-IO": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1234",
+              "1324"
+            ],
+            "id": 114,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1234"
+          },
+          "Audio_Ctrl": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Manual",
+              "GPI",
+              "GPI-A",
+              "GPI-B",
+              "GPI-C"
+            ],
+            "id": 110,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Manual"
+          },
+          "Audio_Prst_Act": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 111,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Audio_Prst_Edit": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 112,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "B-BlackA": {
+            "access": "RW-",
+            "default": 0,
+            "id": 102,
+            "kind": "int",
+            "max": 127,
+            "min": -128,
+            "step": 1,
+            "unit": "bit",
+            "value": 0
+          },
+          "B-BlackB": {
+            "access": "RW-",
+            "default": 0,
+            "id": 107,
+            "kind": "int",
+            "max": 127,
+            "min": -128,
+            "step": 1,
+            "unit": "bit",
+            "value": 0
+          },
+          "B-GainA": {
+            "access": "RW-",
+            "default": 100,
+            "id": 94,
+            "kind": "float",
+            "max": 150,
+            "min": 0,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "B-GainB": {
+            "access": "RW-",
+            "default": 100,
+            "id": 98,
+            "kind": "float",
+            "max": 150,
+            "min": 0,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "BlackA": {
+            "access": "RW-",
+            "default": 0,
+            "id": 99,
+            "kind": "int",
+            "max": 127,
+            "min": -128,
+            "step": 1,
+            "unit": "bit",
+            "value": 0
+          },
+          "BlackB": {
+            "access": "RW-",
+            "default": 0,
+            "id": 103,
+            "kind": "int",
+            "max": 127,
+            "min": -128,
+            "step": 1,
+            "unit": "bit",
+            "value": 0
+          },
+          "CVBS-Hue": {
+            "access": "RW-",
+            "default": 0,
+            "id": 108,
+            "kind": "int",
+            "max": 90,
+            "min": -90,
+            "step": 1,
+            "value": 0
+          },
+          "Delay-Status": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 22,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "Dn_CtrlA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Manual",
+              "GPI",
+              "S2016",
+              "GPI-A",
+              "GPI-B",
+              "GPI-C"
+            ],
+            "id": 30,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Manual"
+          },
+          "Dn_CtrlB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Manual",
+              "GPI",
+              "S2016",
+              "GPI-A",
+              "GPI-B",
+              "GPI-C"
+            ],
+            "id": 38,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Manual"
+          },
+          "Dn_Prst_ActA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 31,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Dn_Prst_ActB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 39,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Dn_Prst_EditA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 32,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Dn_Prst_EditB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 40,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "G-BlackA": {
+            "access": "RW-",
+            "default": 0,
+            "id": 101,
+            "kind": "int",
+            "max": 127,
+            "min": -128,
+            "step": 1,
+            "unit": "bit",
+            "value": 0
+          },
+          "G-BlackB": {
+            "access": "RW-",
+            "default": 0,
+            "id": 105,
+            "kind": "int",
+            "max": 127,
+            "min": -128,
+            "step": 1,
+            "unit": "bit",
+            "value": 0
+          },
+          "G-GainA": {
+            "access": "RW-",
+            "default": 100,
+            "id": 93,
+            "kind": "float",
+            "max": 150,
+            "min": 0,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "G-GainB": {
+            "access": "RW-",
+            "default": 100,
+            "id": 97,
+            "kind": "float",
+            "max": 150,
+            "min": 0,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "GPI-Ctrl": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Latch",
+              "nonLatch"
+            ],
+            "id": 185,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Latch"
+          },
+          "GPI_1": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "Off",
+              "GPI A",
+              "GPI B",
+              "GPI C",
+              "Take A",
+              "Take B",
+              "Take C",
+              "GPI Prio A",
+              "GPI Prio B",
+              "GPI Prio C"
+            ],
+            "id": 186,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Take B"
+          },
+          "GPI_2": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "Off",
+              "GPI A",
+              "GPI B",
+              "GPI C",
+              "Take A",
+              "Take B",
+              "Take C",
+              "GPI Prio A",
+              "GPI Prio B",
+              "GPI Prio C"
+            ],
+            "id": 187,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Take B"
+          },
+          "GPI_3": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "Off",
+              "GPI A",
+              "GPI B",
+              "GPI C",
+              "Take A",
+              "Take B",
+              "Take C",
+              "GPI Prio A",
+              "GPI Prio B",
+              "GPI Prio C"
+            ],
+            "id": 188,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Take B"
+          },
+          "GPI_4": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "Off",
+              "GPI A",
+              "GPI B",
+              "GPI C",
+              "Take A",
+              "Take B",
+              "Take C",
+              "GPI Prio A",
+              "GPI Prio B",
+              "GPI Prio C"
+            ],
+            "id": 189,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Take B"
+          },
+          "GPI_5": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "GPI A",
+              "GPI B",
+              "GPI C",
+              "Take A",
+              "Take B",
+              "Take C",
+              "GPI Prio A",
+              "GPI Prio B",
+              "GPI Prio C"
+            ],
+            "id": 190,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "GainA": {
+            "access": "RW-",
+            "default": 100,
+            "id": 91,
+            "kind": "float",
+            "max": 150,
+            "min": 0,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "GainB": {
+            "access": "RW-",
+            "default": 100,
+            "id": 95,
+            "kind": "float",
+            "max": 150,
+            "min": 0,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "IO-Ctrl": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Manual",
+              "GPI",
+              "GPI-A",
+              "GPI-B",
+              "GPI-C"
+            ],
+            "id": 0,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Manual"
+          },
+          "IO-Prst_Act": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8"
+            ],
+            "id": 1,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "5"
+          },
+          "IO-Prst_Edit": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8"
+            ],
+            "id": 2,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "IP_Conf0": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Manual",
+              "DHCP"
+            ],
+            "id": 192,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "DHCP"
+          },
+          "Input_Loss_A": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Freeze",
+              "Colorbar",
+              "Zoneplate",
+              "Black",
+              "Grey",
+              "Green"
+            ],
+            "id": 27,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Freeze"
+          },
+          "Input_Loss_B": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Freeze",
+              "Colorbar",
+              "Zoneplate",
+              "Black",
+              "Grey",
+              "Green"
+            ],
+            "id": 28,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Freeze"
+          },
+          "Ins_CtrlA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Manual",
+              "GPI",
+              "S2016",
+              "SD-AR",
+              "GPI-A",
+              "GPI-B",
+              "GPI-C"
+            ],
+            "id": 68,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Manual"
+          },
+          "Ins_CtrlB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Manual",
+              "GPI",
+              "S2016",
+              "SD-AR",
+              "GPI-A",
+              "GPI-B",
+              "GPI-C"
+            ],
+            "id": 79,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Manual"
+          },
+          "Ins_Prst_ActA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 69,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Ins_Prst_ActB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 80,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Ins_Prst_EditA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 70,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Ins_Prst_EditB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 81,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Lock-Mode": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Ref1",
+              "Ref2",
+              "Input",
+              "Freerun",
+              "RefAuto"
+            ],
+            "id": 23,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ref1"
+          },
+          "NetwPrefix0": {
+            "access": "RW-",
+            "default": 0,
+            "id": 196,
+            "kind": "int",
+            "max": 30,
+            "min": 0,
+            "step": 1,
+            "unit": "bit",
+            "value": 0
+          },
+          "Output_Map_A": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Level A",
+              "Level B"
+            ],
+            "id": 106,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Level A"
+          },
+          "PatternSpeed": {
+            "access": "RW-",
+            "default": 1,
+            "id": 26,
+            "kind": "uint",
+            "max": 15,
+            "min": 0,
+            "step": 1,
+            "value": 1
+          },
+          "PrstEditView": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Follow Active",
+              "Independent"
+            ],
+            "id": 25,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Follow Active"
+          },
+          "R-BlackA": {
+            "access": "RW-",
+            "default": 0,
+            "id": 100,
+            "kind": "int",
+            "max": 127,
+            "min": -128,
+            "step": 1,
+            "unit": "bit",
+            "value": 0
+          },
+          "R-BlackB": {
+            "access": "RW-",
+            "default": 0,
+            "id": 104,
+            "kind": "int",
+            "max": 127,
+            "min": -128,
+            "step": 1,
+            "unit": "bit",
+            "value": 0
+          },
+          "R-GainA": {
+            "access": "RW-",
+            "default": 100,
+            "id": 92,
+            "kind": "float",
+            "max": 150,
+            "min": 0,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "R-GainB": {
+            "access": "RW-",
+            "default": 100,
+            "id": 96,
+            "kind": "float",
+            "max": 150,
+            "min": 0,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "Ref-Type": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Bi-Level",
+              "Tri-Level"
+            ],
+            "id": 24,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Bi-Level"
+          },
+          "Timecode_ins": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 62,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "On"
+          },
+          "Tr_CtrlA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Manual",
+              "GPI",
+              "S2016",
+              "SD-AR",
+              "GPI-A",
+              "GPI-B",
+              "GPI-C"
+            ],
+            "id": 47,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Manual"
+          },
+          "Tr_CtrlB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Manual",
+              "GPI",
+              "S2016",
+              "SD-AR",
+              "GPI-A",
+              "GPI-B",
+              "GPI-C"
+            ],
+            "id": 54,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Manual"
+          },
+          "Tr_Prst_ActA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 48,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Tr_Prst_ActB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 55,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Tr_Prst_EditA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 49,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Tr_Prst_EditB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 56,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "VITC_Ln_525": {
+            "access": "RW-",
+            "default": 10,
+            "id": 66,
+            "kind": "int",
+            "max": 20,
+            "min": 10,
+            "step": 1,
+            "value": 10
+          },
+          "VITC_Ln_625": {
+            "access": "RW-",
+            "default": 19,
+            "id": 65,
+            "kind": "int",
+            "max": 22,
+            "min": 7,
+            "step": 1,
+            "value": 19
+          },
+          "VITC_Ln_Ctrl": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Manual",
+              "ATC_DBB"
+            ],
+            "id": 64,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Manual"
+          },
+          "VITC_Ln_Dup": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 67,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "VITC_Ln_In": {
+            "access": "RW-",
+            "default": 19,
+            "id": 63,
+            "kind": "int",
+            "max": 22,
+            "min": 7,
+            "step": 1,
+            "unit": "ln",
+            "value": 19
+          },
+          "mGW0": {
+            "access": "RW-",
+            "id": 195,
+            "kind": "ipaddr",
+            "value": "0.0.0.0"
+          },
+          "mIP0": {
+            "access": "RW-",
+            "id": 193,
+            "kind": "ipaddr",
+            "value": "0.0.0.0"
+          },
+          "mNM0": {
+            "access": "RW-",
+            "id": 194,
+            "kind": "ipaddr",
+            "value": "0.0.0.0"
+          }
+        },
+        "identity": {
+          "3G": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 11,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "ARC": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 13,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Audio Shuffler": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 12,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "CVBS In": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 19,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Card ID": {
+            "access": "R--",
+            "id": 7,
+            "kind": "string",
+            "max_len": 16,
+            "value": "71ef060a00000001"
+          },
+          "Card description": {
+            "access": "R--",
+            "id": 2,
+            "kind": "string",
+            "max_len": 16,
+            "value": "2GS110-2728.html"
+          },
+          "Card name": {
+            "access": "R--",
+            "id": 0,
+            "kind": "string",
+            "max_len": 8,
+            "value": "2GS110"
+          },
+          "Cross": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 16,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Down": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 15,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Features": {
+            "access": "R--",
+            "id": 9,
+            "kind": "string",
+            "max_len": 8,
+            "value": "400F3CB7"
+          },
+          "Frame Delay": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 18,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "HD": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 10,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Hardware rev": {
+            "access": "R--",
+            "id": 4,
+            "kind": "string",
+            "max_len": 4,
+            "value": "0100"
+          },
+          "Key": {
+            "access": "RW-",
+            "id": 8,
+            "kind": "string",
+            "max_len": 15,
+            "value": "ZH43-ZXQFG-64JK"
+          },
+          "Product code": {
+            "access": "R--",
+            "id": 5,
+            "kind": "string",
+            "max_len": 10,
+            "value": "9490590010"
+          },
+          "SDI In 2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 20,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Serial number": {
+            "access": "R--",
+            "id": 6,
+            "kind": "string",
+            "max_len": 16,
+            "value": "PR000158"
+          },
+          "Side Curtains": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 17,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Software rev": {
+            "access": "R--",
+            "id": 3,
+            "kind": "string",
+            "max_len": 4,
+            "value": "2728"
+          },
+          "TWINS": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 21,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Up": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 14,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "User label": {
+            "access": "RW-",
+            "id": 1,
+            "kind": "string",
+            "max_len": 16,
+            "value": "Full HD format c"
+          }
+        },
+        "status": {
+          "  NET STATUS": {
+            "access": "R--",
+            "id": 29,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "CC_Det_A": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok"
+            ],
+            "id": 27,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "CC_Det_B": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok"
+            ],
+            "id": 28,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "FunctionA": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "Up",
+              "Down",
+              "Cross",
+              "Trans",
+              "NA",
+              "TestPattern"
+            ],
+            "id": 16,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Up"
+          },
+          "FunctionB": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "Up",
+              "Down",
+              "Cross",
+              "Trans",
+              "NA",
+              "TestPattern"
+            ],
+            "id": 17,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Up"
+          },
+          "GPI": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "____",
+              "1___",
+              "_2__",
+              "12__",
+              "__3_",
+              "1_3_",
+              "_23_",
+              "123_",
+              "___4",
+              "1__4",
+              "_2_4",
+              "12_4",
+              "__34",
+              "1_34",
+              "_234",
+              "1234"
+            ],
+            "id": 19,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "____"
+          },
+          "GPIA": {
+            "access": "R--",
+            "default": 0,
+            "id": 20,
+            "kind": "uint",
+            "max": 255,
+            "min": 0,
+            "step": 1,
+            "value": 0
+          },
+          "GPIB": {
+            "access": "R--",
+            "default": 0,
+            "id": 21,
+            "kind": "uint",
+            "max": 255,
+            "min": 0,
+            "step": 1,
+            "value": 0
+          },
+          "GPIC": {
+            "access": "R--",
+            "default": 0,
+            "id": 22,
+            "kind": "uint",
+            "max": 255,
+            "min": 0,
+            "step": 1,
+            "value": 0
+          },
+          "GW0": {
+            "access": "R--",
+            "id": 34,
+            "kind": "ipaddr",
+            "value": "0.0.0.0"
+          },
+          "IODelayA": {
+            "access": "R--",
+            "default": 0,
+            "id": 14,
+            "kind": "int",
+            "max": 15000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "IODelayB": {
+            "access": "R--",
+            "default": 0,
+            "id": 15,
+            "kind": "int",
+            "max": 15000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "IP0": {
+            "access": "R--",
+            "id": 32,
+            "kind": "ipaddr",
+            "value": "0.0.0.0"
+          },
+          "IP_Addr0": {
+            "access": "R--",
+            "default": 1,
+            "enum_items": [
+              "Manual",
+              "DHCP Asking",
+              "DHCP Leased",
+              "DHCP Infin"
+            ],
+            "id": 30,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "DHCP Asking"
+          },
+          "MAC0": {
+            "access": "R--",
+            "id": 31,
+            "kind": "string",
+            "max_len": 17,
+            "value": "00:03:41:10:00:31"
+          },
+          "NM0": {
+            "access": "R--",
+            "id": 33,
+            "kind": "ipaddr",
+            "value": "0.0.0.0"
+          },
+          "OP47-Det-A": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok"
+            ],
+            "id": 23,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "OP47-Det-B": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok"
+            ],
+            "id": 24,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Ref": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Present"
+            ],
+            "id": 18,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "WST-Det-A": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok"
+            ],
+            "id": 25,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "WST-Det-B": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok"
+            ],
+            "id": 26,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "sInp1": {
+            "access": "R--",
+            "default": 15,
+            "enum_items": [
+              "1080i60",
+              "1080i50",
+              "1080p30",
+              "1080p25",
+              "1080p24",
+              "1080p24sf",
+              "720p60",
+              "720p50",
+              "720p30",
+              "720p25",
+              "720p24",
+              "SD525",
+              "SD625",
+              "1080p60",
+              "1080p50",
+              "NA"
+            ],
+            "id": 0,
+            "kind": "enum",
+            "value": 15,
+            "value_name": "NA"
+          },
+          "sInp1_VI": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "4:3_0",
+              "4:3_1",
+              "4:3_2",
+              "4:3_3",
+              "4:3_4",
+              "4:3_5",
+              "4:3_6",
+              "4:3_7",
+              "16:9_0",
+              "16:9_1",
+              "16:9_2",
+              "16:9_3",
+              "16:9_4",
+              "16:9_5",
+              "16:9_6",
+              "16:9_7",
+              "NA"
+            ],
+            "id": 1,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInp1_WSS-Extd": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "4:3_0",
+              "4:3_1",
+              "4:3_2",
+              "4:3_3",
+              "4:3_4",
+              "4:3_5",
+              "4:3_6",
+              "4:3_7",
+              "16:9_0",
+              "16:9_1",
+              "16:9_2",
+              "16:9_3",
+              "16:9_4",
+              "16:9_5",
+              "16:9_6",
+              "16:9_7",
+              "NA"
+            ],
+            "id": 3,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInp1_WSS-Stnd": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "1_vid",
+              "2_vid",
+              "3_vid",
+              "4_vid",
+              "5_vid",
+              "6_vid",
+              "7_vid",
+              "8_vid",
+              "1_flm",
+              "2_flm",
+              "3_flm",
+              "4_flm",
+              "5_flm",
+              "6_flm",
+              "7_flm",
+              "8_flm",
+              "NA"
+            ],
+            "id": 2,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInp1_s2016": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "AFD0",
+              "AFD1",
+              "AFD2",
+              "AFD3",
+              "AFD4",
+              "AFD5",
+              "AFD6",
+              "AFD7",
+              "AFD8",
+              "AFD9",
+              "AFD10",
+              "AFD11",
+              "AFD12",
+              "AFD13",
+              "AFD14",
+              "AFD15",
+              "NA"
+            ],
+            "id": 4,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInp2": {
+            "access": "R--",
+            "default": 15,
+            "enum_items": [
+              "1080i60",
+              "1080i50",
+              "1080p30",
+              "1080p25",
+              "1080p24",
+              "1080p24sf",
+              "720p60",
+              "720p50",
+              "720p30",
+              "720p25",
+              "720p24",
+              "SD525",
+              "SD625",
+              "1080p60",
+              "1080p50",
+              "NA"
+            ],
+            "id": 5,
+            "kind": "enum",
+            "value": 15,
+            "value_name": "NA"
+          },
+          "sInp2_VI": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "4:3_0",
+              "4:3_1",
+              "4:3_2",
+              "4:3_3",
+              "4:3_4",
+              "4:3_5",
+              "4:3_6",
+              "4:3_7",
+              "16:9_0",
+              "16:9_1",
+              "16:9_2",
+              "16:9_3",
+              "16:9_4",
+              "16:9_5",
+              "16:9_6",
+              "16:9_7",
+              "NA"
+            ],
+            "id": 6,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInp2_WSS-Extd": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "4:3_0",
+              "4:3_1",
+              "4:3_2",
+              "4:3_3",
+              "4:3_4",
+              "4:3_5",
+              "4:3_6",
+              "4:3_7",
+              "16:9_0",
+              "16:9_1",
+              "16:9_2",
+              "16:9_3",
+              "16:9_4",
+              "16:9_5",
+              "16:9_6",
+              "16:9_7",
+              "NA"
+            ],
+            "id": 8,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInp2_WSS-Stnd": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "1_vid",
+              "2_vid",
+              "3_vid",
+              "4_vid",
+              "5_vid",
+              "6_vid",
+              "7_vid",
+              "8_vid",
+              "1_flm",
+              "2_flm",
+              "3_flm",
+              "4_flm",
+              "5_flm",
+              "6_flm",
+              "7_flm",
+              "8_flm",
+              "NA"
+            ],
+            "id": 7,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInp2_s2016": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "AFD0",
+              "AFD1",
+              "AFD2",
+              "AFD3",
+              "AFD4",
+              "AFD5",
+              "AFD6",
+              "AFD7",
+              "AFD8",
+              "AFD9",
+              "AFD10",
+              "AFD11",
+              "AFD12",
+              "AFD13",
+              "AFD14",
+              "AFD15",
+              "NA"
+            ],
+            "id": 9,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInp3": {
+            "access": "R--",
+            "default": 15,
+            "enum_items": [
+              "1080i60",
+              "1080i50",
+              "1080p30",
+              "1080p25",
+              "1080p24",
+              "1080p24sf",
+              "720p60",
+              "720p50",
+              "720p30",
+              "720p25",
+              "720p24",
+              "SD525",
+              "SD625",
+              "1080p60",
+              "1080p50",
+              "NA"
+            ],
+            "id": 10,
+            "kind": "enum",
+            "value": 15,
+            "value_name": "NA"
+          },
+          "sInp3_WSS-Extd": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "4:3_0",
+              "4:3_1",
+              "4:3_2",
+              "4:3_3",
+              "4:3_4",
+              "4:3_5",
+              "4:3_6",
+              "4:3_7",
+              "16:9_0",
+              "16:9_1",
+              "16:9_2",
+              "16:9_3",
+              "16:9_4",
+              "16:9_5",
+              "16:9_6",
+              "16:9_7",
+              "NA"
+            ],
+            "id": 12,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInp3_WSS-Stnd": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "1_vid",
+              "2_vid",
+              "3_vid",
+              "4_vid",
+              "5_vid",
+              "6_vid",
+              "7_vid",
+              "8_vid",
+              "1_flm",
+              "2_flm",
+              "3_flm",
+              "4_flm",
+              "5_flm",
+              "6_flm",
+              "7_flm",
+              "8_flm",
+              "NA"
+            ],
+            "id": 11,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInpCVBS": {
+            "access": "R--",
+            "default": 9,
+            "enum_items": [
+              "NTSC-J",
+              "NTSC-M",
+              "NTSC-4.43",
+              "PAL-BGHID",
+              "PAL-N",
+              "PAL-M",
+              "PAL-60",
+              "SECAM",
+              "SECAM-525",
+              "NA"
+            ],
+            "id": 13,
+            "kind": "enum",
+            "value": 9,
+            "value_name": "NA"
+          }
+        }
+      },
+      "slot": 1,
+      "status": "present",
+      "walked_at": "2026-05-05T10:21:44Z"
+    }
+  ]
+}

--- a/tests/fixtures/products/axon/synapse/2GS110-2929/acp1/slot_5.json
+++ b/tests/fixtures/products/axon/synapse/2GS110-2929/acp1/slot_5.json
@@ -1,0 +1,3848 @@
+{
+  "created_at": "2026-05-05T10:21:44Z",
+  "device": {
+    "ip": "10.6.239.113",
+    "port": 2071,
+    "protocol": "acp1",
+    "protocol_version": 1,
+    "num_slots": 31
+  },
+  "generator": "acp dev",
+  "slots": [
+    {
+      "objects": {
+        "alarm": {
+          "Announcements": {
+            "access": "RW-",
+            "id": 0,
+            "kind": "alarm",
+            "value": 1
+          },
+          "Input_A": {
+            "access": "RW-",
+            "id": 1,
+            "kind": "alarm",
+            "value": 1
+          },
+          "Input_B": {
+            "access": "RW-",
+            "id": 2,
+            "kind": "alarm",
+            "value": 1
+          },
+          "Ref-Status": {
+            "access": "RW-",
+            "id": 3,
+            "kind": "alarm",
+            "value": 0
+          }
+        },
+        "control": {
+          "  AUDIO PROC AMP": {
+            "access": "RW-",
+            "id": 109,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "  DOWN CONV": {
+            "access": "RW-",
+            "id": 29,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "  EMBEDDER": {
+            "access": "RW-",
+            "id": 115,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "  GPI MODE": {
+            "access": "RW-",
+            "id": 184,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "  INSERTER": {
+            "access": "RW-",
+            "id": 61,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "  TRANSPARENT": {
+            "access": "RW-",
+            "id": 46,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "  VIDEO PROC": {
+            "access": "RW-",
+            "id": 90,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          " NETWORK": {
+            "access": "RW-",
+            "id": 191,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "#Audio_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 113,
+            "kind": "int",
+            "max": 10000,
+            "min": -10000,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#CC_Ena_A": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 78,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#CC_Ena_B": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 89,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#CVBS-Frmt": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Auto",
+              "PAL-M",
+              "PAL-N",
+              "NTSC-M",
+              "NTSC-4.43",
+              "NTSC-J",
+              "SECAM",
+              "PAL-60",
+              "PAL-BGHID"
+            ],
+            "id": 5,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Auto"
+          },
+          "#Dn_ArcA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Anamorphic",
+              "CenterCut",
+              "LBox-16:9",
+              "LBox-14:9",
+              "Variable",
+              "Anam-702"
+            ],
+            "id": 33,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Anamorphic"
+          },
+          "#Dn_ArcB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Anamorphic",
+              "CenterCut",
+              "LBox-16:9",
+              "LBox-14:9",
+              "Variable",
+              "Anam-702"
+            ],
+            "id": 41,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Anamorphic"
+          },
+          "#Dn_ColorConvA": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Off",
+              "709to601"
+            ],
+            "id": 37,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "709to601"
+          },
+          "#Dn_ColorConvB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "709to601"
+            ],
+            "id": 45,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#Dn_H-EnhA": {
+            "access": "RW-",
+            "default": 0,
+            "id": 36,
+            "kind": "int",
+            "max": 100,
+            "min": 0,
+            "step": 1,
+            "value": 0
+          },
+          "#Dn_H-EnhB": {
+            "access": "RW-",
+            "default": 0,
+            "id": 44,
+            "kind": "int",
+            "max": 100,
+            "min": 0,
+            "step": 1,
+            "value": 0
+          },
+          "#Dn_H-ScaleA": {
+            "access": "RW-",
+            "default": 100,
+            "id": 34,
+            "kind": "float",
+            "max": 200,
+            "min": 50,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "#Dn_H-ScaleB": {
+            "access": "RW-",
+            "default": 100,
+            "id": 42,
+            "kind": "float",
+            "max": 200,
+            "min": 50,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "#Dn_V-ScaleA": {
+            "access": "RW-",
+            "default": 100,
+            "id": 35,
+            "kind": "float",
+            "max": 200,
+            "min": 50,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "#Dn_V-ScaleB": {
+            "access": "RW-",
+            "default": 100,
+            "id": 43,
+            "kind": "float",
+            "max": 200,
+            "min": 50,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "#EmbA1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 152,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbA1_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 117,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbA1_Inp_Ch": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 118,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ch_1"
+          },
+          "#EmbA1_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 153,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbA2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 154,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbA2_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 119,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbA2_Inp_Ch": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 120,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Ch_2"
+          },
+          "#EmbA2_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 155,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbA3_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 156,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbA3_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 121,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbA3_Inp_Ch": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 122,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ch_3"
+          },
+          "#EmbA3_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 157,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbA4_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 158,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbA4_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 123,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbA4_Inp_Ch": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 124,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Ch_4"
+          },
+          "#EmbA4_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 159,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbA_Grp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Group1",
+              "Group2",
+              "Group3",
+              "Group4",
+              "Off"
+            ],
+            "id": 116,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Group1"
+          },
+          "#EmbB1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 160,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbB1_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 126,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbB1_Inp_Ch": {
+            "access": "RW-",
+            "default": 4,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 127,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "Ch_5"
+          },
+          "#EmbB1_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 161,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbB2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 162,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbB2_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 128,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbB2_Inp_Ch": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 129,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Ch_6"
+          },
+          "#EmbB2_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 163,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbB3_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 164,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbB3_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 130,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbB3_Inp_Ch": {
+            "access": "RW-",
+            "default": 6,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 131,
+            "kind": "enum",
+            "value": 6,
+            "value_name": "Ch_7"
+          },
+          "#EmbB3_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 165,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbB4_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 166,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbB4_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 132,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbB4_Inp_Ch": {
+            "access": "RW-",
+            "default": 7,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 133,
+            "kind": "enum",
+            "value": 7,
+            "value_name": "Ch_8"
+          },
+          "#EmbB4_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 167,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbB_Grp": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Group1",
+              "Group2",
+              "Group3",
+              "Group4",
+              "Off"
+            ],
+            "id": 125,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Group2"
+          },
+          "#EmbC1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 168,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbC1_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 135,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbC1_Inp_Ch": {
+            "access": "RW-",
+            "default": 8,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 136,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "Ch_9"
+          },
+          "#EmbC1_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 169,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbC2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 170,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbC2_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 137,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbC2_Inp_Ch": {
+            "access": "RW-",
+            "default": 9,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 138,
+            "kind": "enum",
+            "value": 9,
+            "value_name": "Ch_10"
+          },
+          "#EmbC2_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 171,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbC3_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 172,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbC3_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 139,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbC3_Inp_Ch": {
+            "access": "RW-",
+            "default": 10,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 140,
+            "kind": "enum",
+            "value": 10,
+            "value_name": "Ch_11"
+          },
+          "#EmbC3_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 173,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbC4_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 174,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbC4_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 141,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbC4_Inp_Ch": {
+            "access": "RW-",
+            "default": 11,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 142,
+            "kind": "enum",
+            "value": 11,
+            "value_name": "Ch_12"
+          },
+          "#EmbC4_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 175,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbC_Grp": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Group1",
+              "Group2",
+              "Group3",
+              "Group4",
+              "Off"
+            ],
+            "id": 134,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Group3"
+          },
+          "#EmbD1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 176,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbD1_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 144,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbD1_Inp_Ch": {
+            "access": "RW-",
+            "default": 12,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 145,
+            "kind": "enum",
+            "value": 12,
+            "value_name": "Ch_13"
+          },
+          "#EmbD1_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 177,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbD2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 178,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbD2_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 146,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbD2_Inp_Ch": {
+            "access": "RW-",
+            "default": 13,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 147,
+            "kind": "enum",
+            "value": 13,
+            "value_name": "Ch_14"
+          },
+          "#EmbD2_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 179,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbD3_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 180,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbD3_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 148,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbD3_Inp_Ch": {
+            "access": "RW-",
+            "default": 14,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 149,
+            "kind": "enum",
+            "value": 14,
+            "value_name": "Ch_15"
+          },
+          "#EmbD3_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 181,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbD4_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 182,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbD4_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 150,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbD4_Inp_Ch": {
+            "access": "RW-",
+            "default": 15,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 151,
+            "kind": "enum",
+            "value": 15,
+            "value_name": "Ch_16"
+          },
+          "#EmbD4_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 183,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbD_Grp": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Group1",
+              "Group2",
+              "Group3",
+              "Group4",
+              "Off"
+            ],
+            "id": 143,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Group4"
+          },
+          "#F_delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 7,
+            "kind": "uint",
+            "max": 250,
+            "min": 0,
+            "step": 1,
+            "unit": "F",
+            "value": 0
+          },
+          "#Freeze_A": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 11,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#Freeze_B": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 12,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#H_delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 9,
+            "kind": "int",
+            "max": 5124,
+            "min": 0,
+            "step": 1,
+            "unit": "px",
+            "value": 0
+          },
+          "#Inp_SelA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI-1",
+              "SDI-2",
+              "Analog",
+              "Zoneplate",
+              "Colorbar"
+            ],
+            "id": 3,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI-1"
+          },
+          "#Inp_SelB": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "SDI-1",
+              "SDI-2",
+              "Analog",
+              "Zoneplate",
+              "Colorbar"
+            ],
+            "id": 4,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "SDI-2"
+          },
+          "#LowPassFilt_A": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "H_Only",
+              "V_Only",
+              "H_And_V",
+              "H2_Only",
+              "H2_And_V"
+            ],
+            "id": 13,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#LowPassFilt_B": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "H_Only",
+              "V_Only",
+              "H_And_V",
+              "H2_Only",
+              "H2_And_V"
+            ],
+            "id": 14,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#Out-Frmt": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1080i60",
+              "1080i50",
+              "1080p30",
+              "1080p25",
+              "1080p24",
+              "1080p24sf",
+              "720p60",
+              "720p50",
+              "720p24",
+              "SD525",
+              "SD625",
+              "1080p60",
+              "1080p50"
+            ],
+            "id": 6,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1080i60"
+          },
+          "#Out-Mode": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Straight",
+              "Crossed",
+              "A Only",
+              "B Only",
+              "Sum"
+            ],
+            "id": 10,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Straight"
+          },
+          "#S2016-DataA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "AFD0",
+              "AFD1",
+              "AFD2",
+              "AFD3",
+              "AFD4",
+              "AFD5",
+              "AFD6",
+              "AFD7",
+              "AFD8",
+              "AFD9",
+              "AFD10",
+              "AFD11",
+              "AFD12",
+              "AFD13",
+              "AFD14",
+              "AFD15"
+            ],
+            "id": 77,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "AFD0"
+          },
+          "#S2016-DataB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "AFD0",
+              "AFD1",
+              "AFD2",
+              "AFD3",
+              "AFD4",
+              "AFD5",
+              "AFD6",
+              "AFD7",
+              "AFD8",
+              "AFD9",
+              "AFD10",
+              "AFD11",
+              "AFD12",
+              "AFD13",
+              "AFD14",
+              "AFD15"
+            ],
+            "id": 88,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "AFD0"
+          },
+          "#S2016-InsertA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 76,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#S2016-InsertB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 87,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#Tr_ArcA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Anamorphic",
+              "Variable"
+            ],
+            "id": 50,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Anamorphic"
+          },
+          "#Tr_ArcB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Anamorphic",
+              "Variable"
+            ],
+            "id": 57,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Anamorphic"
+          },
+          "#Tr_H-EnhA": {
+            "access": "RW-",
+            "default": 0,
+            "id": 53,
+            "kind": "int",
+            "max": 100,
+            "min": 0,
+            "step": 1,
+            "value": 0
+          },
+          "#Tr_H-EnhB": {
+            "access": "RW-",
+            "default": 0,
+            "id": 60,
+            "kind": "int",
+            "max": 100,
+            "min": 0,
+            "step": 1,
+            "value": 0
+          },
+          "#Tr_H-ScaleA": {
+            "access": "RW-",
+            "default": 100,
+            "id": 51,
+            "kind": "float",
+            "max": 200,
+            "min": 50,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "#Tr_H-ScaleB": {
+            "access": "RW-",
+            "default": 100,
+            "id": 58,
+            "kind": "float",
+            "max": 200,
+            "min": 50,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "#Tr_V-ScaleA": {
+            "access": "RW-",
+            "default": 100,
+            "id": 52,
+            "kind": "float",
+            "max": 200,
+            "min": 50,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "#Tr_V-ScaleB": {
+            "access": "RW-",
+            "default": 100,
+            "id": 59,
+            "kind": "float",
+            "max": 200,
+            "min": 50,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "#VANC_Trans": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 15,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#VANC_Trans_Ln0": {
+            "access": "RW-",
+            "default": 7,
+            "id": 16,
+            "kind": "int",
+            "max": 41,
+            "min": 7,
+            "step": 1,
+            "unit": "ln",
+            "value": 7
+          },
+          "#VANC_Trans_Ln1": {
+            "access": "RW-",
+            "default": 7,
+            "id": 17,
+            "kind": "int",
+            "max": 41,
+            "min": 7,
+            "step": 1,
+            "unit": "ln",
+            "value": 7
+          },
+          "#VANC_Trans_Ln2": {
+            "access": "RW-",
+            "default": 7,
+            "id": 18,
+            "kind": "int",
+            "max": 41,
+            "min": 7,
+            "step": 1,
+            "unit": "ln",
+            "value": 7
+          },
+          "#VANC_Trans_Ln3": {
+            "access": "RW-",
+            "default": 7,
+            "id": 19,
+            "kind": "int",
+            "max": 41,
+            "min": 7,
+            "step": 1,
+            "unit": "ln",
+            "value": 7
+          },
+          "#VANC_Trans_Ln4": {
+            "access": "RW-",
+            "default": 7,
+            "id": 20,
+            "kind": "int",
+            "max": 41,
+            "min": 7,
+            "step": 1,
+            "unit": "ln",
+            "value": 7
+          },
+          "#VANC_Trans_Ln5": {
+            "access": "RW-",
+            "default": 7,
+            "id": 21,
+            "kind": "int",
+            "max": 41,
+            "min": 7,
+            "step": 1,
+            "unit": "ln",
+            "value": 7
+          },
+          "#VI-DataA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "4:3_0",
+              "4:3_1",
+              "4:3_2",
+              "4:3_3",
+              "4:3_4",
+              "4:3_5",
+              "4:3_6",
+              "4:3_7",
+              "16:9_0",
+              "16:9_1",
+              "16:9_2",
+              "16:9_3",
+              "16:9_4",
+              "16:9_5",
+              "16:9_6",
+              "16:9_7"
+            ],
+            "id": 72,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "4:3_0"
+          },
+          "#VI-DataB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "4:3_0",
+              "4:3_1",
+              "4:3_2",
+              "4:3_3",
+              "4:3_4",
+              "4:3_5",
+              "4:3_6",
+              "4:3_7",
+              "16:9_0",
+              "16:9_1",
+              "16:9_2",
+              "16:9_3",
+              "16:9_4",
+              "16:9_5",
+              "16:9_6",
+              "16:9_7"
+            ],
+            "id": 83,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "4:3_0"
+          },
+          "#VI-InsertA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 71,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#VI-InsertB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 82,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#V_delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 8,
+            "kind": "int",
+            "max": 1125,
+            "min": 0,
+            "step": 1,
+            "unit": "ln",
+            "value": 0
+          },
+          "#WSS-ExtndA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "4:3_0",
+              "4:3_1",
+              "4:3_2",
+              "4:3_3",
+              "4:3_4",
+              "4:3_5",
+              "4:3_6",
+              "4:3_7",
+              "16:9_0",
+              "16:9_1",
+              "16:9_2",
+              "16:9_3",
+              "16:9_4",
+              "16:9_5",
+              "16:9_6",
+              "16:9_7"
+            ],
+            "id": 75,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "4:3_0"
+          },
+          "#WSS-ExtndB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "4:3_0",
+              "4:3_1",
+              "4:3_2",
+              "4:3_3",
+              "4:3_4",
+              "4:3_5",
+              "4:3_6",
+              "4:3_7",
+              "16:9_0",
+              "16:9_1",
+              "16:9_2",
+              "16:9_3",
+              "16:9_4",
+              "16:9_5",
+              "16:9_6",
+              "16:9_7"
+            ],
+            "id": 86,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "4:3_0"
+          },
+          "#WSS-InsertA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Standard",
+              "Extended"
+            ],
+            "id": 73,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#WSS-InsertB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Standard",
+              "Extended"
+            ],
+            "id": 84,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#WSS-StndA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1_vid",
+              "2_vid",
+              "3_vid",
+              "4_vid",
+              "5_vid",
+              "6_vid",
+              "7_vid",
+              "8_vid",
+              "1_flm",
+              "2_flm",
+              "3_flm",
+              "4_flm",
+              "5_flm",
+              "6_flm",
+              "7_flm",
+              "8_flm"
+            ],
+            "id": 74,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1_vid"
+          },
+          "#WSS-StndB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1_vid",
+              "2_vid",
+              "3_vid",
+              "4_vid",
+              "5_vid",
+              "6_vid",
+              "7_vid",
+              "8_vid",
+              "1_flm",
+              "2_flm",
+              "3_flm",
+              "4_flm",
+              "5_flm",
+              "6_flm",
+              "7_flm",
+              "8_flm"
+            ],
+            "id": 85,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1_vid"
+          },
+          "Audio-Bus-IO": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1234",
+              "1324"
+            ],
+            "id": 114,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1234"
+          },
+          "Audio_Ctrl": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Manual",
+              "GPI",
+              "GPI-A",
+              "GPI-B",
+              "GPI-C"
+            ],
+            "id": 110,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Manual"
+          },
+          "Audio_Prst_Act": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 111,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Audio_Prst_Edit": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 112,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "B-BlackA": {
+            "access": "RW-",
+            "default": 0,
+            "id": 102,
+            "kind": "int",
+            "max": 127,
+            "min": -128,
+            "step": 1,
+            "unit": "bit",
+            "value": 0
+          },
+          "B-BlackB": {
+            "access": "RW-",
+            "default": 0,
+            "id": 107,
+            "kind": "int",
+            "max": 127,
+            "min": -128,
+            "step": 1,
+            "unit": "bit",
+            "value": 0
+          },
+          "B-GainA": {
+            "access": "RW-",
+            "default": 100,
+            "id": 94,
+            "kind": "float",
+            "max": 150,
+            "min": 0,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "B-GainB": {
+            "access": "RW-",
+            "default": 100,
+            "id": 98,
+            "kind": "float",
+            "max": 150,
+            "min": 0,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "BlackA": {
+            "access": "RW-",
+            "default": 0,
+            "id": 99,
+            "kind": "int",
+            "max": 127,
+            "min": -128,
+            "step": 1,
+            "unit": "bit",
+            "value": 0
+          },
+          "BlackB": {
+            "access": "RW-",
+            "default": 0,
+            "id": 103,
+            "kind": "int",
+            "max": 127,
+            "min": -128,
+            "step": 1,
+            "unit": "bit",
+            "value": 0
+          },
+          "CVBS-Hue": {
+            "access": "RW-",
+            "default": 0,
+            "id": 108,
+            "kind": "int",
+            "max": 90,
+            "min": -90,
+            "step": 1,
+            "value": 0
+          },
+          "Delay-Status": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 22,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "Dn_CtrlA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Manual",
+              "GPI",
+              "S2016",
+              "GPI-A",
+              "GPI-B",
+              "GPI-C"
+            ],
+            "id": 30,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Manual"
+          },
+          "Dn_CtrlB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Manual",
+              "GPI",
+              "S2016",
+              "GPI-A",
+              "GPI-B",
+              "GPI-C"
+            ],
+            "id": 38,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Manual"
+          },
+          "Dn_Prst_ActA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 31,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Dn_Prst_ActB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 39,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Dn_Prst_EditA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 32,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Dn_Prst_EditB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 40,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "G-BlackA": {
+            "access": "RW-",
+            "default": 0,
+            "id": 101,
+            "kind": "int",
+            "max": 127,
+            "min": -128,
+            "step": 1,
+            "unit": "bit",
+            "value": 0
+          },
+          "G-BlackB": {
+            "access": "RW-",
+            "default": 0,
+            "id": 106,
+            "kind": "int",
+            "max": 127,
+            "min": -128,
+            "step": 1,
+            "unit": "bit",
+            "value": 0
+          },
+          "G-GainA": {
+            "access": "RW-",
+            "default": 100,
+            "id": 93,
+            "kind": "float",
+            "max": 150,
+            "min": 0,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "G-GainB": {
+            "access": "RW-",
+            "default": 100,
+            "id": 97,
+            "kind": "float",
+            "max": 150,
+            "min": 0,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "GPI-Ctrl": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Latch",
+              "nonLatch"
+            ],
+            "id": 185,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Latch"
+          },
+          "GPI_1": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "Off",
+              "GPI A",
+              "GPI B",
+              "GPI C",
+              "Take A",
+              "Take B",
+              "Take C",
+              "GPI Prio A",
+              "GPI Prio B",
+              "GPI Prio C"
+            ],
+            "id": 186,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Take B"
+          },
+          "GPI_2": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "Off",
+              "GPI A",
+              "GPI B",
+              "GPI C",
+              "Take A",
+              "Take B",
+              "Take C",
+              "GPI Prio A",
+              "GPI Prio B",
+              "GPI Prio C"
+            ],
+            "id": 187,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Take B"
+          },
+          "GPI_3": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "Off",
+              "GPI A",
+              "GPI B",
+              "GPI C",
+              "Take A",
+              "Take B",
+              "Take C",
+              "GPI Prio A",
+              "GPI Prio B",
+              "GPI Prio C"
+            ],
+            "id": 188,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Take B"
+          },
+          "GPI_4": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "Off",
+              "GPI A",
+              "GPI B",
+              "GPI C",
+              "Take A",
+              "Take B",
+              "Take C",
+              "GPI Prio A",
+              "GPI Prio B",
+              "GPI Prio C"
+            ],
+            "id": 189,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Take B"
+          },
+          "GPI_5": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "GPI A",
+              "GPI B",
+              "GPI C",
+              "Take A",
+              "Take B",
+              "Take C",
+              "GPI Prio A",
+              "GPI Prio B",
+              "GPI Prio C"
+            ],
+            "id": 190,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "GainA": {
+            "access": "RW-",
+            "default": 100,
+            "id": 91,
+            "kind": "float",
+            "max": 150,
+            "min": 0,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "GainB": {
+            "access": "RW-",
+            "default": 100,
+            "id": 95,
+            "kind": "float",
+            "max": 150,
+            "min": 0,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "IO-Ctrl": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Manual",
+              "GPI",
+              "GPI-A",
+              "GPI-B",
+              "GPI-C"
+            ],
+            "id": 0,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Manual"
+          },
+          "IO-Prst_Act": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8"
+            ],
+            "id": 1,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "IO-Prst_Edit": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8"
+            ],
+            "id": 2,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "IP_Conf0": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Manual",
+              "DHCP"
+            ],
+            "id": 192,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "DHCP"
+          },
+          "Input_Loss_A": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Freeze",
+              "Colorbar",
+              "Zoneplate",
+              "Black",
+              "Grey",
+              "Green"
+            ],
+            "id": 27,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Freeze"
+          },
+          "Input_Loss_B": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Freeze",
+              "Colorbar",
+              "Zoneplate",
+              "Black",
+              "Grey",
+              "Green"
+            ],
+            "id": 28,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Freeze"
+          },
+          "Ins_CtrlA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Manual",
+              "GPI",
+              "S2016",
+              "SD-AR",
+              "GPI-A",
+              "GPI-B",
+              "GPI-C"
+            ],
+            "id": 68,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Manual"
+          },
+          "Ins_CtrlB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Manual",
+              "GPI",
+              "S2016",
+              "SD-AR",
+              "GPI-A",
+              "GPI-B",
+              "GPI-C"
+            ],
+            "id": 79,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Manual"
+          },
+          "Ins_Prst_ActA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 69,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Ins_Prst_ActB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 80,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Ins_Prst_EditA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 70,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Ins_Prst_EditB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 81,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Lock-Mode": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Ref1",
+              "Ref2",
+              "Input",
+              "Freerun",
+              "RefAuto"
+            ],
+            "id": 23,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ref1"
+          },
+          "NetwPrefix0": {
+            "access": "RW-",
+            "default": 0,
+            "id": 196,
+            "kind": "int",
+            "max": 30,
+            "min": 0,
+            "step": 1,
+            "unit": "bit",
+            "value": 0
+          },
+          "Output_Map_A": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Level A",
+              "Level B"
+            ],
+            "id": 104,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Level A"
+          },
+          "PatternSpeed": {
+            "access": "RW-",
+            "default": 1,
+            "id": 26,
+            "kind": "uint",
+            "max": 15,
+            "min": 0,
+            "step": 1,
+            "value": 1
+          },
+          "PrstEditView": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Follow Active",
+              "Independent"
+            ],
+            "id": 25,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Follow Active"
+          },
+          "R-BlackA": {
+            "access": "RW-",
+            "default": 0,
+            "id": 100,
+            "kind": "int",
+            "max": 127,
+            "min": -128,
+            "step": 1,
+            "unit": "bit",
+            "value": 0
+          },
+          "R-BlackB": {
+            "access": "RW-",
+            "default": 0,
+            "id": 105,
+            "kind": "int",
+            "max": 127,
+            "min": -128,
+            "step": 1,
+            "unit": "bit",
+            "value": 0
+          },
+          "R-GainA": {
+            "access": "RW-",
+            "default": 100,
+            "id": 92,
+            "kind": "float",
+            "max": 150,
+            "min": 0,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "R-GainB": {
+            "access": "RW-",
+            "default": 100,
+            "id": 96,
+            "kind": "float",
+            "max": 150,
+            "min": 0,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "Ref-Type": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Bi-Level",
+              "Tri-Level"
+            ],
+            "id": 24,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Bi-Level"
+          },
+          "Timecode_ins": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On",
+              "Copy 1=\u003e2",
+              "Copy 2=\u003e1"
+            ],
+            "id": 62,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "Tr_CtrlA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Manual",
+              "GPI",
+              "S2016",
+              "SD-AR",
+              "GPI-A",
+              "GPI-B",
+              "GPI-C"
+            ],
+            "id": 47,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Manual"
+          },
+          "Tr_CtrlB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Manual",
+              "GPI",
+              "S2016",
+              "SD-AR",
+              "GPI-A",
+              "GPI-B",
+              "GPI-C"
+            ],
+            "id": 54,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Manual"
+          },
+          "Tr_Prst_ActA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 48,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Tr_Prst_ActB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 55,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Tr_Prst_EditA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 49,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Tr_Prst_EditB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 56,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "VITC_Ln_525": {
+            "access": "RW-",
+            "default": 10,
+            "id": 66,
+            "kind": "int",
+            "max": 20,
+            "min": 10,
+            "step": 1,
+            "value": 10
+          },
+          "VITC_Ln_625": {
+            "access": "RW-",
+            "default": 19,
+            "id": 65,
+            "kind": "int",
+            "max": 22,
+            "min": 7,
+            "step": 1,
+            "value": 19
+          },
+          "VITC_Ln_Ctrl": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Manual",
+              "ATC_DBB"
+            ],
+            "id": 64,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Manual"
+          },
+          "VITC_Ln_Dup": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 67,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "VITC_Ln_In": {
+            "access": "RW-",
+            "default": 19,
+            "id": 63,
+            "kind": "int",
+            "max": 22,
+            "min": 7,
+            "step": 1,
+            "unit": "ln",
+            "value": 19
+          },
+          "mGW0": {
+            "access": "RW-",
+            "id": 195,
+            "kind": "ipaddr",
+            "value": "0.0.0.0"
+          },
+          "mIP0": {
+            "access": "RW-",
+            "id": 193,
+            "kind": "ipaddr",
+            "value": "0.0.0.0"
+          },
+          "mNM0": {
+            "access": "RW-",
+            "id": 194,
+            "kind": "ipaddr",
+            "value": "0.0.0.0"
+          }
+        },
+        "identity": {
+          "3G": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 11,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "ARC": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 13,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Audio Shuffler": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 12,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "CVBS In": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 19,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Card ID": {
+            "access": "R--",
+            "id": 7,
+            "kind": "string",
+            "max_len": 16,
+            "value": "71ef060a0000001f"
+          },
+          "Card description": {
+            "access": "R--",
+            "id": 2,
+            "kind": "string",
+            "max_len": 16,
+            "value": "2GS110-2929.html"
+          },
+          "Card name": {
+            "access": "R--",
+            "id": 0,
+            "kind": "string",
+            "max_len": 8,
+            "value": "2GS110"
+          },
+          "Cross": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 16,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Down": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 15,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Features": {
+            "access": "R--",
+            "id": 9,
+            "kind": "string",
+            "max_len": 8,
+            "value": "400F3CB7"
+          },
+          "Frame Delay": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 18,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "HD": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 10,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Hardware rev": {
+            "access": "R--",
+            "id": 4,
+            "kind": "string",
+            "max_len": 4,
+            "value": "0200"
+          },
+          "Key": {
+            "access": "RW-",
+            "id": 8,
+            "kind": "string",
+            "max_len": 15,
+            "value": "EAYE-4GC82-HNTF"
+          },
+          "Product code": {
+            "access": "R--",
+            "id": 5,
+            "kind": "string",
+            "max_len": 10,
+            "value": "9490590010"
+          },
+          "SDI In 2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 20,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Serial number": {
+            "access": "R--",
+            "id": 6,
+            "kind": "string",
+            "max_len": 16,
+            "value": "PR013274"
+          },
+          "Side Curtains": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 17,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Software rev": {
+            "access": "R--",
+            "id": 3,
+            "kind": "string",
+            "max_len": 4,
+            "value": "2929"
+          },
+          "TWINS": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 21,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Up": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 14,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "User label": {
+            "access": "RW-",
+            "id": 1,
+            "kind": "string",
+            "max_len": 16,
+            "value": "Full HD format c"
+          }
+        },
+        "status": {
+          "  NET STATUS": {
+            "access": "R--",
+            "id": 29,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "CC_Det_A": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok"
+            ],
+            "id": 27,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "CC_Det_B": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok"
+            ],
+            "id": 28,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "FunctionA": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "Up",
+              "Down",
+              "Cross",
+              "Trans",
+              "NA",
+              "TestPattern"
+            ],
+            "id": 16,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Up"
+          },
+          "FunctionB": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "Up",
+              "Down",
+              "Cross",
+              "Trans",
+              "NA",
+              "TestPattern"
+            ],
+            "id": 17,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Up"
+          },
+          "GPI": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "____",
+              "1___",
+              "_2__",
+              "12__",
+              "__3_",
+              "1_3_",
+              "_23_",
+              "123_",
+              "___4",
+              "1__4",
+              "_2_4",
+              "12_4",
+              "__34",
+              "1_34",
+              "_234",
+              "1234"
+            ],
+            "id": 19,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "____"
+          },
+          "GPIA": {
+            "access": "R--",
+            "default": 0,
+            "id": 20,
+            "kind": "uint",
+            "max": 255,
+            "min": 0,
+            "step": 1,
+            "value": 0
+          },
+          "GPIB": {
+            "access": "R--",
+            "default": 0,
+            "id": 21,
+            "kind": "uint",
+            "max": 255,
+            "min": 0,
+            "step": 1,
+            "value": 0
+          },
+          "GPIC": {
+            "access": "R--",
+            "default": 0,
+            "id": 22,
+            "kind": "uint",
+            "max": 255,
+            "min": 0,
+            "step": 1,
+            "value": 0
+          },
+          "GW0": {
+            "access": "R--",
+            "id": 34,
+            "kind": "ipaddr",
+            "value": "0.0.0.0"
+          },
+          "IODelayA": {
+            "access": "R--",
+            "default": 0,
+            "id": 14,
+            "kind": "int",
+            "max": 15000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "IODelayB": {
+            "access": "R--",
+            "default": 0,
+            "id": 15,
+            "kind": "int",
+            "max": 15000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "IP0": {
+            "access": "R--",
+            "id": 32,
+            "kind": "ipaddr",
+            "value": "0.0.0.0"
+          },
+          "IP_Addr0": {
+            "access": "R--",
+            "default": 1,
+            "enum_items": [
+              "Manual",
+              "DHCP Asking",
+              "DHCP Leased",
+              "DHCP Infin"
+            ],
+            "id": 30,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "DHCP Asking"
+          },
+          "MAC0": {
+            "access": "R--",
+            "id": 31,
+            "kind": "string",
+            "max_len": 17,
+            "value": "00:03:41:10:0f:e3"
+          },
+          "NM0": {
+            "access": "R--",
+            "id": 33,
+            "kind": "ipaddr",
+            "value": "0.0.0.0"
+          },
+          "OP47-Det-A": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok"
+            ],
+            "id": 23,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "OP47-Det-B": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok"
+            ],
+            "id": 24,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Ref": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Present"
+            ],
+            "id": 18,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "WST-Det-A": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok"
+            ],
+            "id": 25,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "WST-Det-B": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok"
+            ],
+            "id": 26,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "sInp1": {
+            "access": "R--",
+            "default": 15,
+            "enum_items": [
+              "1080i60",
+              "1080i50",
+              "1080p30",
+              "1080p25",
+              "1080p24",
+              "1080p24sf",
+              "720p60",
+              "720p50",
+              "720p30",
+              "720p25",
+              "720p24",
+              "SD525",
+              "SD625",
+              "1080p60",
+              "1080p50",
+              "NA"
+            ],
+            "id": 0,
+            "kind": "enum",
+            "value": 15,
+            "value_name": "NA"
+          },
+          "sInp1_VI": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "4:3_0",
+              "4:3_1",
+              "4:3_2",
+              "4:3_3",
+              "4:3_4",
+              "4:3_5",
+              "4:3_6",
+              "4:3_7",
+              "16:9_0",
+              "16:9_1",
+              "16:9_2",
+              "16:9_3",
+              "16:9_4",
+              "16:9_5",
+              "16:9_6",
+              "16:9_7",
+              "NA"
+            ],
+            "id": 1,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInp1_WSS-Extd": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "4:3_0",
+              "4:3_1",
+              "4:3_2",
+              "4:3_3",
+              "4:3_4",
+              "4:3_5",
+              "4:3_6",
+              "4:3_7",
+              "16:9_0",
+              "16:9_1",
+              "16:9_2",
+              "16:9_3",
+              "16:9_4",
+              "16:9_5",
+              "16:9_6",
+              "16:9_7",
+              "NA"
+            ],
+            "id": 3,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInp1_WSS-Stnd": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "1_vid",
+              "2_vid",
+              "3_vid",
+              "4_vid",
+              "5_vid",
+              "6_vid",
+              "7_vid",
+              "8_vid",
+              "1_flm",
+              "2_flm",
+              "3_flm",
+              "4_flm",
+              "5_flm",
+              "6_flm",
+              "7_flm",
+              "8_flm",
+              "NA"
+            ],
+            "id": 2,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInp1_s2016": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "AFD0",
+              "AFD1",
+              "AFD2",
+              "AFD3",
+              "AFD4",
+              "AFD5",
+              "AFD6",
+              "AFD7",
+              "AFD8",
+              "AFD9",
+              "AFD10",
+              "AFD11",
+              "AFD12",
+              "AFD13",
+              "AFD14",
+              "AFD15",
+              "NA"
+            ],
+            "id": 4,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInp2": {
+            "access": "R--",
+            "default": 15,
+            "enum_items": [
+              "1080i60",
+              "1080i50",
+              "1080p30",
+              "1080p25",
+              "1080p24",
+              "1080p24sf",
+              "720p60",
+              "720p50",
+              "720p30",
+              "720p25",
+              "720p24",
+              "SD525",
+              "SD625",
+              "1080p60",
+              "1080p50",
+              "NA"
+            ],
+            "id": 5,
+            "kind": "enum",
+            "value": 15,
+            "value_name": "NA"
+          },
+          "sInp2_VI": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "4:3_0",
+              "4:3_1",
+              "4:3_2",
+              "4:3_3",
+              "4:3_4",
+              "4:3_5",
+              "4:3_6",
+              "4:3_7",
+              "16:9_0",
+              "16:9_1",
+              "16:9_2",
+              "16:9_3",
+              "16:9_4",
+              "16:9_5",
+              "16:9_6",
+              "16:9_7",
+              "NA"
+            ],
+            "id": 6,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInp2_WSS-Extd": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "4:3_0",
+              "4:3_1",
+              "4:3_2",
+              "4:3_3",
+              "4:3_4",
+              "4:3_5",
+              "4:3_6",
+              "4:3_7",
+              "16:9_0",
+              "16:9_1",
+              "16:9_2",
+              "16:9_3",
+              "16:9_4",
+              "16:9_5",
+              "16:9_6",
+              "16:9_7",
+              "NA"
+            ],
+            "id": 8,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInp2_WSS-Stnd": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "1_vid",
+              "2_vid",
+              "3_vid",
+              "4_vid",
+              "5_vid",
+              "6_vid",
+              "7_vid",
+              "8_vid",
+              "1_flm",
+              "2_flm",
+              "3_flm",
+              "4_flm",
+              "5_flm",
+              "6_flm",
+              "7_flm",
+              "8_flm",
+              "NA"
+            ],
+            "id": 7,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInp2_s2016": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "AFD0",
+              "AFD1",
+              "AFD2",
+              "AFD3",
+              "AFD4",
+              "AFD5",
+              "AFD6",
+              "AFD7",
+              "AFD8",
+              "AFD9",
+              "AFD10",
+              "AFD11",
+              "AFD12",
+              "AFD13",
+              "AFD14",
+              "AFD15",
+              "NA"
+            ],
+            "id": 9,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInp3": {
+            "access": "R--",
+            "default": 15,
+            "enum_items": [
+              "1080i60",
+              "1080i50",
+              "1080p30",
+              "1080p25",
+              "1080p24",
+              "1080p24sf",
+              "720p60",
+              "720p50",
+              "720p30",
+              "720p25",
+              "720p24",
+              "SD525",
+              "SD625",
+              "1080p60",
+              "1080p50",
+              "NA"
+            ],
+            "id": 10,
+            "kind": "enum",
+            "value": 15,
+            "value_name": "NA"
+          },
+          "sInp3_WSS-Extd": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "4:3_0",
+              "4:3_1",
+              "4:3_2",
+              "4:3_3",
+              "4:3_4",
+              "4:3_5",
+              "4:3_6",
+              "4:3_7",
+              "16:9_0",
+              "16:9_1",
+              "16:9_2",
+              "16:9_3",
+              "16:9_4",
+              "16:9_5",
+              "16:9_6",
+              "16:9_7",
+              "NA"
+            ],
+            "id": 12,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInp3_WSS-Stnd": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "1_vid",
+              "2_vid",
+              "3_vid",
+              "4_vid",
+              "5_vid",
+              "6_vid",
+              "7_vid",
+              "8_vid",
+              "1_flm",
+              "2_flm",
+              "3_flm",
+              "4_flm",
+              "5_flm",
+              "6_flm",
+              "7_flm",
+              "8_flm",
+              "NA"
+            ],
+            "id": 11,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInpCVBS": {
+            "access": "R--",
+            "default": 9,
+            "enum_items": [
+              "NTSC-J",
+              "NTSC-M",
+              "NTSC-4.43",
+              "PAL-BGHID",
+              "PAL-N",
+              "PAL-M",
+              "PAL-60",
+              "SECAM",
+              "SECAM-525",
+              "NA"
+            ],
+            "id": 13,
+            "kind": "enum",
+            "value": 9,
+            "value_name": "NA"
+          }
+        }
+      },
+      "slot": 5,
+      "status": "present",
+      "walked_at": "2026-05-05T10:21:45Z"
+    }
+  ]
+}

--- a/tests/fixtures/products/axon/synapse/2HF110-4326/acp1/slot_2.json
+++ b/tests/fixtures/products/axon/synapse/2HF110-4326/acp1/slot_2.json
@@ -1,0 +1,3416 @@
+{
+  "created_at": "2026-05-05T10:21:44Z",
+  "device": {
+    "ip": "10.6.239.113",
+    "port": 2071,
+    "protocol": "acp1",
+    "protocol_version": 1,
+    "num_slots": 31
+  },
+  "generator": "acp dev",
+  "slots": [
+    {
+      "objects": {
+        "alarm": {
+          "Active_Out_A": {
+            "access": "RW-",
+            "id": 4,
+            "kind": "alarm",
+            "value": 1
+          },
+          "Active_Out_B": {
+            "access": "RW-",
+            "id": 5,
+            "kind": "alarm",
+            "value": 1
+          },
+          "Announcements": {
+            "access": "RW-",
+            "id": 0,
+            "kind": "alarm",
+            "value": 1
+          },
+          "Input_A": {
+            "access": "RW-",
+            "id": 1,
+            "kind": "alarm",
+            "value": 1
+          },
+          "Input_B": {
+            "access": "RW-",
+            "id": 2,
+            "kind": "alarm",
+            "value": 1
+          },
+          "Ref-Status": {
+            "access": "RW-",
+            "id": 3,
+            "kind": "alarm",
+            "value": 0
+          }
+        },
+        "control": {
+          "  AUDIO PROC AMP": {
+            "access": "RW-",
+            "id": 76,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "  EMBEDDER": {
+            "access": "RW-",
+            "id": 82,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "  GPI MODE": {
+            "access": "RW-",
+            "id": 153,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "  INSERTER": {
+            "access": "RW-",
+            "id": 25,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "  VIDEO PROC": {
+            "access": "RW-",
+            "id": 56,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          " NETWORK": {
+            "access": "RW-",
+            "id": 160,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "#Audio_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 81,
+            "kind": "int",
+            "max": 10000,
+            "min": -10000,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#CVBS-Frmt": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Auto",
+              "PAL-M",
+              "PAL-N",
+              "NTSC-M",
+              "NTSC-4.43",
+              "NTSC-J",
+              "SECAM",
+              "PAL-60",
+              "PAL-BGHID"
+            ],
+            "id": 5,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Auto"
+          },
+          "#Emb-AB-Mode": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Overwrite",
+              "Append"
+            ],
+            "id": 83,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Overwrite"
+          },
+          "#Emb-CD-Mode": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Overwrite",
+              "Append"
+            ],
+            "id": 102,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Overwrite"
+          },
+          "#EmbA1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 121,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbA1_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 85,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbA1_Inp_Ch": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 86,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ch_1"
+          },
+          "#EmbA1_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 122,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbA2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 123,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbA2_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 87,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbA2_Inp_Ch": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 88,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Ch_2"
+          },
+          "#EmbA2_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 124,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbA3_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 125,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbA3_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 89,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbA3_Inp_Ch": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 90,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ch_3"
+          },
+          "#EmbA3_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 126,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbA4_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 127,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbA4_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 91,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbA4_Inp_Ch": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 92,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Ch_4"
+          },
+          "#EmbA4_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 128,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbA_Grp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Group1",
+              "Group2",
+              "Group3",
+              "Group4",
+              "Off"
+            ],
+            "id": 84,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Group1"
+          },
+          "#EmbB1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 129,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbB1_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 94,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbB1_Inp_Ch": {
+            "access": "RW-",
+            "default": 4,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 95,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "Ch_5"
+          },
+          "#EmbB1_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 130,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbB2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 131,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbB2_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 96,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbB2_Inp_Ch": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 97,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Ch_6"
+          },
+          "#EmbB2_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 132,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbB3_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 133,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbB3_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 98,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbB3_Inp_Ch": {
+            "access": "RW-",
+            "default": 6,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 99,
+            "kind": "enum",
+            "value": 6,
+            "value_name": "Ch_7"
+          },
+          "#EmbB3_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 134,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbB4_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 135,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbB4_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 100,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbB4_Inp_Ch": {
+            "access": "RW-",
+            "default": 7,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 101,
+            "kind": "enum",
+            "value": 7,
+            "value_name": "Ch_8"
+          },
+          "#EmbB4_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 136,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbB_Grp": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Group1",
+              "Group2",
+              "Group3",
+              "Group4",
+              "Off"
+            ],
+            "id": 93,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Group2"
+          },
+          "#EmbC1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 137,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbC1_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 104,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbC1_Inp_Ch": {
+            "access": "RW-",
+            "default": 8,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 105,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "Ch_9"
+          },
+          "#EmbC1_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 138,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbC2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 139,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbC2_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 106,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbC2_Inp_Ch": {
+            "access": "RW-",
+            "default": 9,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 107,
+            "kind": "enum",
+            "value": 9,
+            "value_name": "Ch_10"
+          },
+          "#EmbC2_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 140,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbC3_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 141,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbC3_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 108,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbC3_Inp_Ch": {
+            "access": "RW-",
+            "default": 10,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 109,
+            "kind": "enum",
+            "value": 10,
+            "value_name": "Ch_11"
+          },
+          "#EmbC3_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 142,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbC4_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 143,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbC4_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 110,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbC4_Inp_Ch": {
+            "access": "RW-",
+            "default": 11,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 111,
+            "kind": "enum",
+            "value": 11,
+            "value_name": "Ch_12"
+          },
+          "#EmbC4_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 144,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbC_Grp": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Group1",
+              "Group2",
+              "Group3",
+              "Group4",
+              "Off"
+            ],
+            "id": 103,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Group3"
+          },
+          "#EmbD1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 145,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbD1_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 113,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbD1_Inp_Ch": {
+            "access": "RW-",
+            "default": 12,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 114,
+            "kind": "enum",
+            "value": 12,
+            "value_name": "Ch_13"
+          },
+          "#EmbD1_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 146,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbD2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 147,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbD2_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 115,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbD2_Inp_Ch": {
+            "access": "RW-",
+            "default": 13,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 116,
+            "kind": "enum",
+            "value": 13,
+            "value_name": "Ch_14"
+          },
+          "#EmbD2_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 148,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbD3_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 149,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbD3_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 117,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbD3_Inp_Ch": {
+            "access": "RW-",
+            "default": 14,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 118,
+            "kind": "enum",
+            "value": 14,
+            "value_name": "Ch_15"
+          },
+          "#EmbD3_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 150,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbD4_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 151,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#EmbD4_Inp": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Demb-SDI1",
+              "Demb-SDI2",
+              "Demb-Input",
+              "ADD-ON"
+            ],
+            "id": 119,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#EmbD4_Inp_Ch": {
+            "access": "RW-",
+            "default": 15,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 120,
+            "kind": "enum",
+            "value": 15,
+            "value_name": "Ch_16"
+          },
+          "#EmbD4_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 152,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "#EmbD_Grp": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Group1",
+              "Group2",
+              "Group3",
+              "Group4",
+              "Off"
+            ],
+            "id": 112,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Group4"
+          },
+          "#F_delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 9,
+            "kind": "uint",
+            "max": 250,
+            "min": 0,
+            "step": 1,
+            "unit": "F",
+            "value": 0
+          },
+          "#Freeze_A": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 12,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#Freeze_B": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 13,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#H_delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 11,
+            "kind": "int",
+            "max": 5124,
+            "min": 0,
+            "step": 1,
+            "unit": "px",
+            "value": 0
+          },
+          "#Inp_SelA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI-1",
+              "SDI-2",
+              "Analog",
+              "Zoneplate",
+              "Colorbar"
+            ],
+            "id": 3,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI-1"
+          },
+          "#Inp_SelB": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "SDI-1",
+              "SDI-2",
+              "Analog",
+              "Zoneplate",
+              "Colorbar"
+            ],
+            "id": 4,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "SDI-2"
+          },
+          "#OSD-StyleA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Transp",
+              "Masked",
+              "Blink-Transp",
+              "Blink-Masked"
+            ],
+            "id": 42,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#OSD-StyleB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Transp",
+              "Masked",
+              "Blink-Transp",
+              "Blink-Masked"
+            ],
+            "id": 54,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#OSD-TextA": {
+            "access": "RW-",
+            "id": 43,
+            "kind": "string",
+            "max_len": 10,
+            "value": "empty string"
+          },
+          "#OSD-TextB": {
+            "access": "RW-",
+            "id": 55,
+            "kind": "string",
+            "max_len": 10,
+            "value": "empty string"
+          },
+          "#Out-Frmt": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1080i60",
+              "1080i50",
+              "1080p30",
+              "1080p25",
+              "1080p24",
+              "1080p24sf",
+              "720p60",
+              "720p50",
+              "720p24",
+              "SD525",
+              "SD625",
+              "1080p60",
+              "1080p50",
+              "AutoA",
+              "AutoB"
+            ],
+            "id": 6,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1080i60"
+          },
+          "#Out-Mode": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Straight",
+              "Crossed",
+              "A Only",
+              "B Only"
+            ],
+            "id": 7,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Straight"
+          },
+          "#S2016-DataA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "AFD0",
+              "AFD1",
+              "AFD2",
+              "AFD3",
+              "AFD4",
+              "AFD5",
+              "AFD6",
+              "AFD7",
+              "AFD8",
+              "AFD9",
+              "AFD10",
+              "AFD11",
+              "AFD12",
+              "AFD13",
+              "AFD14",
+              "AFD15"
+            ],
+            "id": 41,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "AFD0"
+          },
+          "#S2016-DataB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "AFD0",
+              "AFD1",
+              "AFD2",
+              "AFD3",
+              "AFD4",
+              "AFD5",
+              "AFD6",
+              "AFD7",
+              "AFD8",
+              "AFD9",
+              "AFD10",
+              "AFD11",
+              "AFD12",
+              "AFD13",
+              "AFD14",
+              "AFD15"
+            ],
+            "id": 53,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "AFD0"
+          },
+          "#S2016-InsertA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 40,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#S2016-InsertB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 52,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#Switch-Back": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "On",
+              "Off",
+              "Once"
+            ],
+            "id": 8,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "On"
+          },
+          "#VI-DataA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "4:3_0",
+              "4:3_1",
+              "4:3_2",
+              "4:3_3",
+              "4:3_4",
+              "4:3_5",
+              "4:3_6",
+              "4:3_7",
+              "16:9_0",
+              "16:9_1",
+              "16:9_2",
+              "16:9_3",
+              "16:9_4",
+              "16:9_5",
+              "16:9_6",
+              "16:9_7"
+            ],
+            "id": 36,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "4:3_0"
+          },
+          "#VI-DataB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "4:3_0",
+              "4:3_1",
+              "4:3_2",
+              "4:3_3",
+              "4:3_4",
+              "4:3_5",
+              "4:3_6",
+              "4:3_7",
+              "16:9_0",
+              "16:9_1",
+              "16:9_2",
+              "16:9_3",
+              "16:9_4",
+              "16:9_5",
+              "16:9_6",
+              "16:9_7"
+            ],
+            "id": 48,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "4:3_0"
+          },
+          "#VI-InsertA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 35,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#VI-InsertB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 47,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#V_delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 10,
+            "kind": "int",
+            "max": 1125,
+            "min": 0,
+            "step": 1,
+            "unit": "ln",
+            "value": 0
+          },
+          "#WSS-ExtndA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "4:3_0",
+              "4:3_1",
+              "4:3_2",
+              "4:3_3",
+              "4:3_4",
+              "4:3_5",
+              "4:3_6",
+              "4:3_7",
+              "16:9_0",
+              "16:9_1",
+              "16:9_2",
+              "16:9_3",
+              "16:9_4",
+              "16:9_5",
+              "16:9_6",
+              "16:9_7"
+            ],
+            "id": 39,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "4:3_0"
+          },
+          "#WSS-ExtndB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "4:3_0",
+              "4:3_1",
+              "4:3_2",
+              "4:3_3",
+              "4:3_4",
+              "4:3_5",
+              "4:3_6",
+              "4:3_7",
+              "16:9_0",
+              "16:9_1",
+              "16:9_2",
+              "16:9_3",
+              "16:9_4",
+              "16:9_5",
+              "16:9_6",
+              "16:9_7"
+            ],
+            "id": 51,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "4:3_0"
+          },
+          "#WSS-InsertA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Standard",
+              "Extended"
+            ],
+            "id": 37,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#WSS-InsertB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Standard",
+              "Extended"
+            ],
+            "id": 49,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#WSS-StndA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1_vid",
+              "2_vid",
+              "3_vid",
+              "4_vid",
+              "5_vid",
+              "6_vid",
+              "7_vid",
+              "8_vid",
+              "1_flm",
+              "2_flm",
+              "3_flm",
+              "4_flm",
+              "5_flm",
+              "6_flm",
+              "7_flm",
+              "8_flm"
+            ],
+            "id": 38,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1_vid"
+          },
+          "#WSS-StndB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1_vid",
+              "2_vid",
+              "3_vid",
+              "4_vid",
+              "5_vid",
+              "6_vid",
+              "7_vid",
+              "8_vid",
+              "1_flm",
+              "2_flm",
+              "3_flm",
+              "4_flm",
+              "5_flm",
+              "6_flm",
+              "7_flm",
+              "8_flm"
+            ],
+            "id": 50,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1_vid"
+          },
+          "ANC_BlankA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "H_Only",
+              "V_Only",
+              "H_And_V"
+            ],
+            "id": 18,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "ANC_BlankB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "H_Only",
+              "V_Only",
+              "H_And_V"
+            ],
+            "id": 19,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "Audio-Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Align"
+            ],
+            "id": 77,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "Audio_Ctrl": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Manual",
+              "GPI",
+              "GPI-A",
+              "GPI-B",
+              "GPI-C"
+            ],
+            "id": 78,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Manual"
+          },
+          "Audio_Prst_Act": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 79,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Audio_Prst_Edit": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 80,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "B-BlackA": {
+            "access": "RW-",
+            "default": 0,
+            "id": 70,
+            "kind": "int",
+            "max": 127,
+            "min": -128,
+            "step": 1,
+            "unit": "bit",
+            "value": 0
+          },
+          "B-BlackB": {
+            "access": "RW-",
+            "default": 0,
+            "id": 74,
+            "kind": "int",
+            "max": 127,
+            "min": -128,
+            "step": 1,
+            "unit": "bit",
+            "value": 0
+          },
+          "B-GainA": {
+            "access": "RW-",
+            "default": 100,
+            "id": 62,
+            "kind": "float",
+            "max": 150,
+            "min": 0,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "B-GainB": {
+            "access": "RW-",
+            "default": 100,
+            "id": 66,
+            "kind": "float",
+            "max": 150,
+            "min": 0,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "BlackA": {
+            "access": "RW-",
+            "default": 0,
+            "id": 67,
+            "kind": "int",
+            "max": 127,
+            "min": -128,
+            "step": 1,
+            "unit": "bit",
+            "value": 0
+          },
+          "BlackB": {
+            "access": "RW-",
+            "default": 0,
+            "id": 71,
+            "kind": "int",
+            "max": 127,
+            "min": -128,
+            "step": 1,
+            "unit": "bit",
+            "value": 0
+          },
+          "C-Gain": {
+            "access": "RW-",
+            "default": 100,
+            "id": 58,
+            "kind": "float",
+            "max": 150,
+            "min": 50,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "CVBS-Hue": {
+            "access": "RW-",
+            "default": 0,
+            "id": 75,
+            "kind": "int",
+            "max": 90,
+            "min": -90,
+            "step": 1,
+            "value": 0
+          },
+          "Delay-Status": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 14,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "Freeze_Mode": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Field",
+              "Frame"
+            ],
+            "id": 20,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Field"
+          },
+          "G-BlackA": {
+            "access": "RW-",
+            "default": 0,
+            "id": 69,
+            "kind": "int",
+            "max": 127,
+            "min": -128,
+            "step": 1,
+            "unit": "bit",
+            "value": 0
+          },
+          "G-BlackB": {
+            "access": "RW-",
+            "default": 0,
+            "id": 73,
+            "kind": "int",
+            "max": 127,
+            "min": -128,
+            "step": 1,
+            "unit": "bit",
+            "value": 0
+          },
+          "G-GainA": {
+            "access": "RW-",
+            "default": 100,
+            "id": 61,
+            "kind": "float",
+            "max": 150,
+            "min": 0,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "G-GainB": {
+            "access": "RW-",
+            "default": 100,
+            "id": 65,
+            "kind": "float",
+            "max": 150,
+            "min": 0,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "GPI-Ctrl": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Latch",
+              "nonLatch"
+            ],
+            "id": 154,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Latch"
+          },
+          "GPI_1": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "Off",
+              "GPI A",
+              "GPI B",
+              "GPI C",
+              "Take A",
+              "Take B",
+              "Take C",
+              "GPI Prio A",
+              "GPI Prio B",
+              "GPI Prio C"
+            ],
+            "id": 155,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Take B"
+          },
+          "GPI_2": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "Off",
+              "GPI A",
+              "GPI B",
+              "GPI C",
+              "Take A",
+              "Take B",
+              "Take C",
+              "GPI Prio A",
+              "GPI Prio B",
+              "GPI Prio C"
+            ],
+            "id": 156,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Take B"
+          },
+          "GPI_3": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "Off",
+              "GPI A",
+              "GPI B",
+              "GPI C",
+              "Take A",
+              "Take B",
+              "Take C",
+              "GPI Prio A",
+              "GPI Prio B",
+              "GPI Prio C"
+            ],
+            "id": 157,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Take B"
+          },
+          "GPI_4": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "Off",
+              "GPI A",
+              "GPI B",
+              "GPI C",
+              "Take A",
+              "Take B",
+              "Take C",
+              "GPI Prio A",
+              "GPI Prio B",
+              "GPI Prio C"
+            ],
+            "id": 158,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Take B"
+          },
+          "GPI_5": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "GPI A",
+              "GPI B",
+              "GPI C",
+              "Take A",
+              "Take B",
+              "Take C",
+              "GPI Prio A",
+              "GPI Prio B",
+              "GPI Prio C"
+            ],
+            "id": 159,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "GainA": {
+            "access": "RW-",
+            "default": 100,
+            "id": 59,
+            "kind": "float",
+            "max": 150,
+            "min": 0,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "GainB": {
+            "access": "RW-",
+            "default": 100,
+            "id": 63,
+            "kind": "float",
+            "max": 150,
+            "min": 0,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "IO-Ctrl": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Manual",
+              "GPI",
+              "GPI-A",
+              "GPI-B",
+              "GPI-C",
+              "SDI1-Format",
+              "SDI2-Format"
+            ],
+            "id": 0,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Manual"
+          },
+          "IO-Prst_Act": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 1,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "IO-Prst_Edit": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 2,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "IP_Conf0": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Manual",
+              "DHCP"
+            ],
+            "id": 161,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "DHCP"
+          },
+          "Input_Loss_A": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Freeze",
+              "Colorbar",
+              "Zoneplate",
+              "Black",
+              "Grey",
+              "Green",
+              "Freeze 1 sec",
+              "Freeze 5 sec",
+              "Backup-B"
+            ],
+            "id": 23,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Freeze"
+          },
+          "Input_Loss_B": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Freeze",
+              "Colorbar",
+              "Zoneplate",
+              "Black",
+              "Grey",
+              "Green",
+              "Freeze 1 sec",
+              "Freeze 5 sec",
+              "Backup-A"
+            ],
+            "id": 24,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Freeze"
+          },
+          "Ins_CtrlA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Manual",
+              "GPI",
+              "S2016",
+              "SD-AR",
+              "GPI-A",
+              "GPI-B",
+              "GPI-C"
+            ],
+            "id": 32,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Manual"
+          },
+          "Ins_CtrlB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Manual",
+              "GPI",
+              "S2016",
+              "SD-AR",
+              "GPI-A",
+              "GPI-B",
+              "GPI-C"
+            ],
+            "id": 44,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Manual"
+          },
+          "Ins_Prst_ActA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 33,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Ins_Prst_ActB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 45,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Ins_Prst_EditA": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 34,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Ins_Prst_EditB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16"
+            ],
+            "id": 46,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Lock-Mode": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Ref1",
+              "Ref2",
+              "Input",
+              "Freerun",
+              "RefAuto"
+            ],
+            "id": 15,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ref1"
+          },
+          "NetwPrefix0": {
+            "access": "RW-",
+            "default": 0,
+            "id": 165,
+            "kind": "int",
+            "max": 30,
+            "min": 0,
+            "step": 1,
+            "unit": "bit",
+            "value": 0
+          },
+          "P60-P50_Sync": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "One Frame",
+              "Two Frames"
+            ],
+            "id": 17,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "One Frame"
+          },
+          "PatternSpeed": {
+            "access": "RW-",
+            "default": 1,
+            "id": 22,
+            "kind": "uint",
+            "max": 15,
+            "min": 0,
+            "step": 1,
+            "value": 1
+          },
+          "PrstEditView": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Follow Active",
+              "Independent"
+            ],
+            "id": 21,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Follow Active"
+          },
+          "R-BlackA": {
+            "access": "RW-",
+            "default": 0,
+            "id": 68,
+            "kind": "int",
+            "max": 127,
+            "min": -128,
+            "step": 1,
+            "unit": "bit",
+            "value": 0
+          },
+          "R-BlackB": {
+            "access": "RW-",
+            "default": 0,
+            "id": 72,
+            "kind": "int",
+            "max": 127,
+            "min": -128,
+            "step": 1,
+            "unit": "bit",
+            "value": 0
+          },
+          "R-GainA": {
+            "access": "RW-",
+            "default": 100,
+            "id": 60,
+            "kind": "float",
+            "max": 150,
+            "min": 0,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "R-GainB": {
+            "access": "RW-",
+            "default": 100,
+            "id": 64,
+            "kind": "float",
+            "max": 150,
+            "min": 0,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "Ref-Type": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Bi-Level",
+              "Tri-Level"
+            ],
+            "id": 16,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Bi-Level"
+          },
+          "Timecode_ins": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Off",
+              "On",
+              "Copy 1=\u003e2",
+              "Copy 2=\u003e1"
+            ],
+            "id": 26,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "On"
+          },
+          "VITC_Ln_525": {
+            "access": "RW-",
+            "default": 10,
+            "id": 30,
+            "kind": "int",
+            "max": 20,
+            "min": 10,
+            "step": 1,
+            "value": 10
+          },
+          "VITC_Ln_625": {
+            "access": "RW-",
+            "default": 19,
+            "id": 29,
+            "kind": "int",
+            "max": 22,
+            "min": 7,
+            "step": 1,
+            "value": 19
+          },
+          "VITC_Ln_Ctrl": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Manual",
+              "ATC_DBB"
+            ],
+            "id": 28,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Manual"
+          },
+          "VITC_Ln_Dup": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 31,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "VITC_Ln_In": {
+            "access": "RW-",
+            "default": 19,
+            "id": 27,
+            "kind": "int",
+            "max": 22,
+            "min": 7,
+            "step": 1,
+            "unit": "ln",
+            "value": 19
+          },
+          "Y_Gain": {
+            "access": "RW-",
+            "default": 100,
+            "id": 57,
+            "kind": "float",
+            "max": 200,
+            "min": 0,
+            "step": 1,
+            "unit": "%",
+            "value": 100
+          },
+          "mGW0": {
+            "access": "RW-",
+            "id": 164,
+            "kind": "ipaddr",
+            "value": "0.0.0.0"
+          },
+          "mIP0": {
+            "access": "RW-",
+            "id": 162,
+            "kind": "ipaddr",
+            "value": "0.0.0.0"
+          },
+          "mNM0": {
+            "access": "RW-",
+            "id": 163,
+            "kind": "ipaddr",
+            "value": "0.0.0.0"
+          }
+        },
+        "identity": {
+          "3G": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 11,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "ARC": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 13,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Audio Shuffler": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 12,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "CVBS In": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 19,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Card ID": {
+            "access": "R--",
+            "id": 7,
+            "kind": "string",
+            "max_len": 16,
+            "value": "71ef060a00000002"
+          },
+          "Card description": {
+            "access": "R--",
+            "id": 2,
+            "kind": "string",
+            "max_len": 16,
+            "value": "2HF110-4326.html"
+          },
+          "Card name": {
+            "access": "R--",
+            "id": 0,
+            "kind": "string",
+            "max_len": 8,
+            "value": "2HF110"
+          },
+          "Cross": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 16,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Down": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 15,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Features": {
+            "access": "R--",
+            "id": 9,
+            "kind": "string",
+            "max_len": 8,
+            "value": "400F7C15"
+          },
+          "Frame Delay": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 18,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "HD": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 10,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Hardware rev": {
+            "access": "R--",
+            "id": 4,
+            "kind": "string",
+            "max_len": 4,
+            "value": "0200"
+          },
+          "Key": {
+            "access": "RW-",
+            "id": 8,
+            "kind": "string",
+            "max_len": 15,
+            "value": "774W-A8X8Q-VF3P"
+          },
+          "Product code": {
+            "access": "R--",
+            "id": 5,
+            "kind": "string",
+            "max_len": 10,
+            "value": "9490590010"
+          },
+          "SDI In 2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 20,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Serial number": {
+            "access": "R--",
+            "id": 6,
+            "kind": "string",
+            "max_len": 16,
+            "value": "PR013274"
+          },
+          "Side Curtains": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 17,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Software rev": {
+            "access": "R--",
+            "id": 3,
+            "kind": "string",
+            "max_len": 4,
+            "value": "4326"
+          },
+          "TWINS": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 21,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Up": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 14,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "User label": {
+            "access": "RW-",
+            "id": 1,
+            "kind": "string",
+            "max_len": 16,
+            "value": "Full HD format c"
+          }
+        },
+        "status": {
+          "  NET STATUS": {
+            "access": "R--",
+            "id": 31,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "ActiveA": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "SDI-1",
+              "SDI-2",
+              "Analog"
+            ],
+            "id": 0,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI-1"
+          },
+          "ActiveB": {
+            "access": "R--",
+            "default": 1,
+            "enum_items": [
+              "SDI-1",
+              "SDI-2",
+              "Analog"
+            ],
+            "id": 1,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "SDI-2"
+          },
+          "FunctionA": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "Up",
+              "Down",
+              "Cross",
+              "Trans",
+              "NA",
+              "TestPattern"
+            ],
+            "id": 24,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Up"
+          },
+          "FunctionB": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "Up",
+              "Down",
+              "Cross",
+              "Trans",
+              "NA",
+              "TestPattern"
+            ],
+            "id": 25,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Up"
+          },
+          "GPI": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "____",
+              "1___",
+              "_2__",
+              "12__",
+              "__3_",
+              "1_3_",
+              "_23_",
+              "123_",
+              "___4",
+              "1__4",
+              "_2_4",
+              "12_4",
+              "__34",
+              "1_34",
+              "_234",
+              "1234"
+            ],
+            "id": 27,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "____"
+          },
+          "GPIA": {
+            "access": "R--",
+            "default": 0,
+            "id": 28,
+            "kind": "uint",
+            "max": 255,
+            "min": 0,
+            "step": 1,
+            "value": 0
+          },
+          "GPIB": {
+            "access": "R--",
+            "default": 0,
+            "id": 29,
+            "kind": "uint",
+            "max": 255,
+            "min": 0,
+            "step": 1,
+            "value": 0
+          },
+          "GPIC": {
+            "access": "R--",
+            "default": 0,
+            "id": 30,
+            "kind": "uint",
+            "max": 255,
+            "min": 0,
+            "step": 1,
+            "value": 0
+          },
+          "GW0": {
+            "access": "R--",
+            "id": 36,
+            "kind": "ipaddr",
+            "value": "0.0.0.0"
+          },
+          "IODelayA": {
+            "access": "R--",
+            "default": 0,
+            "id": 16,
+            "kind": "int",
+            "max": 15000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "IODelayB": {
+            "access": "R--",
+            "default": 0,
+            "id": 20,
+            "kind": "int",
+            "max": 15000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "IP0": {
+            "access": "R--",
+            "id": 34,
+            "kind": "ipaddr",
+            "value": "0.0.0.0"
+          },
+          "IP_Addr0": {
+            "access": "R--",
+            "default": 1,
+            "enum_items": [
+              "Manual",
+              "DHCP Asking",
+              "DHCP Leased",
+              "DHCP Infin"
+            ],
+            "id": 32,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "DHCP Asking"
+          },
+          "MAC0": {
+            "access": "R--",
+            "id": 33,
+            "kind": "string",
+            "max_len": 17,
+            "value": "00:03:41:10:0f:e3"
+          },
+          "NM0": {
+            "access": "R--",
+            "id": 35,
+            "kind": "ipaddr",
+            "value": "0.0.0.0"
+          },
+          "Ref": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Present"
+            ],
+            "id": 26,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "SwitchLnA": {
+            "access": "R--",
+            "default": 0,
+            "id": 17,
+            "kind": "int",
+            "max": 1125,
+            "min": 0,
+            "step": 1,
+            "value": 0
+          },
+          "SwitchLnB": {
+            "access": "R--",
+            "default": 0,
+            "id": 21,
+            "kind": "int",
+            "max": 1125,
+            "min": 0,
+            "step": 1,
+            "value": 0
+          },
+          "SwitchLn_LenA": {
+            "access": "R--",
+            "default": 0,
+            "id": 18,
+            "kind": "int",
+            "max": 10000,
+            "min": 0,
+            "step": 1,
+            "unit": "px",
+            "value": 0
+          },
+          "SwitchLn_LenB": {
+            "access": "R--",
+            "default": 0,
+            "id": 22,
+            "kind": "int",
+            "max": 10000,
+            "min": 0,
+            "step": 1,
+            "unit": "px",
+            "value": 0
+          },
+          "SwitchLn_PosA": {
+            "access": "R--",
+            "default": 0,
+            "id": 19,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "px",
+            "value": 0
+          },
+          "SwitchLn_PosB": {
+            "access": "R--",
+            "default": 0,
+            "id": 23,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "px",
+            "value": 0
+          },
+          "sInp1": {
+            "access": "R--",
+            "default": 15,
+            "enum_items": [
+              "1080i60",
+              "1080i50",
+              "1080p30",
+              "1080p25",
+              "1080p24",
+              "1080p24sf",
+              "720p60",
+              "720p50",
+              "720p30",
+              "720p25",
+              "720p24",
+              "SD525",
+              "SD625",
+              "1080p60",
+              "1080p50",
+              "NA"
+            ],
+            "id": 2,
+            "kind": "enum",
+            "value": 15,
+            "value_name": "NA"
+          },
+          "sInp1_VI": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "4:3_0",
+              "4:3_1",
+              "4:3_2",
+              "4:3_3",
+              "4:3_4",
+              "4:3_5",
+              "4:3_6",
+              "4:3_7",
+              "16:9_0",
+              "16:9_1",
+              "16:9_2",
+              "16:9_3",
+              "16:9_4",
+              "16:9_5",
+              "16:9_6",
+              "16:9_7",
+              "NA"
+            ],
+            "id": 3,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInp1_WSS-Extd": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "4:3_0",
+              "4:3_1",
+              "4:3_2",
+              "4:3_3",
+              "4:3_4",
+              "4:3_5",
+              "4:3_6",
+              "4:3_7",
+              "16:9_0",
+              "16:9_1",
+              "16:9_2",
+              "16:9_3",
+              "16:9_4",
+              "16:9_5",
+              "16:9_6",
+              "16:9_7",
+              "NA"
+            ],
+            "id": 5,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInp1_WSS-Stnd": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "1_vid",
+              "2_vid",
+              "3_vid",
+              "4_vid",
+              "5_vid",
+              "6_vid",
+              "7_vid",
+              "8_vid",
+              "1_flm",
+              "2_flm",
+              "3_flm",
+              "4_flm",
+              "5_flm",
+              "6_flm",
+              "7_flm",
+              "8_flm",
+              "NA"
+            ],
+            "id": 4,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInp1_s2016": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "AFD0",
+              "AFD1",
+              "AFD2",
+              "AFD3",
+              "AFD4",
+              "AFD5",
+              "AFD6",
+              "AFD7",
+              "AFD8",
+              "AFD9",
+              "AFD10",
+              "AFD11",
+              "AFD12",
+              "AFD13",
+              "AFD14",
+              "AFD15",
+              "NA"
+            ],
+            "id": 6,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInp2": {
+            "access": "R--",
+            "default": 15,
+            "enum_items": [
+              "1080i60",
+              "1080i50",
+              "1080p30",
+              "1080p25",
+              "1080p24",
+              "1080p24sf",
+              "720p60",
+              "720p50",
+              "720p30",
+              "720p25",
+              "720p24",
+              "SD525",
+              "SD625",
+              "1080p60",
+              "1080p50",
+              "NA"
+            ],
+            "id": 7,
+            "kind": "enum",
+            "value": 15,
+            "value_name": "NA"
+          },
+          "sInp2_VI": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "4:3_0",
+              "4:3_1",
+              "4:3_2",
+              "4:3_3",
+              "4:3_4",
+              "4:3_5",
+              "4:3_6",
+              "4:3_7",
+              "16:9_0",
+              "16:9_1",
+              "16:9_2",
+              "16:9_3",
+              "16:9_4",
+              "16:9_5",
+              "16:9_6",
+              "16:9_7",
+              "NA"
+            ],
+            "id": 8,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInp2_WSS-Extd": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "4:3_0",
+              "4:3_1",
+              "4:3_2",
+              "4:3_3",
+              "4:3_4",
+              "4:3_5",
+              "4:3_6",
+              "4:3_7",
+              "16:9_0",
+              "16:9_1",
+              "16:9_2",
+              "16:9_3",
+              "16:9_4",
+              "16:9_5",
+              "16:9_6",
+              "16:9_7",
+              "NA"
+            ],
+            "id": 10,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInp2_WSS-Stnd": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "1_vid",
+              "2_vid",
+              "3_vid",
+              "4_vid",
+              "5_vid",
+              "6_vid",
+              "7_vid",
+              "8_vid",
+              "1_flm",
+              "2_flm",
+              "3_flm",
+              "4_flm",
+              "5_flm",
+              "6_flm",
+              "7_flm",
+              "8_flm",
+              "NA"
+            ],
+            "id": 9,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInp2_s2016": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "AFD0",
+              "AFD1",
+              "AFD2",
+              "AFD3",
+              "AFD4",
+              "AFD5",
+              "AFD6",
+              "AFD7",
+              "AFD8",
+              "AFD9",
+              "AFD10",
+              "AFD11",
+              "AFD12",
+              "AFD13",
+              "AFD14",
+              "AFD15",
+              "NA"
+            ],
+            "id": 11,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInp3": {
+            "access": "R--",
+            "default": 15,
+            "enum_items": [
+              "1080i60",
+              "1080i50",
+              "1080p30",
+              "1080p25",
+              "1080p24",
+              "1080p24sf",
+              "720p60",
+              "720p50",
+              "720p30",
+              "720p25",
+              "720p24",
+              "SD525",
+              "SD625",
+              "1080p60",
+              "1080p50",
+              "NA"
+            ],
+            "id": 12,
+            "kind": "enum",
+            "value": 15,
+            "value_name": "NA"
+          },
+          "sInp3_WSS-Extd": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "4:3_0",
+              "4:3_1",
+              "4:3_2",
+              "4:3_3",
+              "4:3_4",
+              "4:3_5",
+              "4:3_6",
+              "4:3_7",
+              "16:9_0",
+              "16:9_1",
+              "16:9_2",
+              "16:9_3",
+              "16:9_4",
+              "16:9_5",
+              "16:9_6",
+              "16:9_7",
+              "NA"
+            ],
+            "id": 14,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInp3_WSS-Stnd": {
+            "access": "R--",
+            "default": 16,
+            "enum_items": [
+              "1_vid",
+              "2_vid",
+              "3_vid",
+              "4_vid",
+              "5_vid",
+              "6_vid",
+              "7_vid",
+              "8_vid",
+              "1_flm",
+              "2_flm",
+              "3_flm",
+              "4_flm",
+              "5_flm",
+              "6_flm",
+              "7_flm",
+              "8_flm",
+              "NA"
+            ],
+            "id": 13,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "NA"
+          },
+          "sInpCVBS": {
+            "access": "R--",
+            "default": 9,
+            "enum_items": [
+              "NTSC-J",
+              "NTSC-M",
+              "NTSC-4.43",
+              "PAL-BGHID",
+              "PAL-N",
+              "PAL-M",
+              "PAL-60",
+              "SECAM",
+              "SECAM-525",
+              "NA"
+            ],
+            "id": 15,
+            "kind": "enum",
+            "value": 9,
+            "value_name": "NA"
+          }
+        }
+      },
+      "slot": 2,
+      "status": "present",
+      "walked_at": "2026-05-05T10:21:44Z"
+    }
+  ]
+}

--- a/tests/fixtures/products/axon/synapse/GED130-2522/acp1/slot_3.json
+++ b/tests/fixtures/products/axon/synapse/GED130-2522/acp1/slot_3.json
@@ -1,0 +1,6191 @@
+{
+  "created_at": "2026-05-05T10:21:44Z",
+  "device": {
+    "ip": "10.6.239.113",
+    "port": 2071,
+    "protocol": "acp1",
+    "protocol_version": 1,
+    "num_slots": 31
+  },
+  "generator": "acp dev",
+  "slots": [
+    {
+      "objects": {
+        "alarm": {
+          "Announcements": {
+            "access": "RW-",
+            "id": 0,
+            "kind": "alarm",
+            "value": 1
+          },
+          "CRC-Status1": {
+            "access": "RW-",
+            "id": 3,
+            "kind": "alarm",
+            "value": 0
+          },
+          "CRC-Status2": {
+            "access": "RW-",
+            "id": 4,
+            "kind": "alarm",
+            "value": 0
+          },
+          "DolbyLoss-Status": {
+            "access": "RW-",
+            "id": 7,
+            "kind": "alarm",
+            "value": 0
+          },
+          "Input1": {
+            "access": "RW-",
+            "id": 1,
+            "kind": "alarm",
+            "value": 0
+          },
+          "Input2": {
+            "access": "RW-",
+            "id": 2,
+            "kind": "alarm",
+            "value": 0
+          },
+          "Lock-Status": {
+            "access": "RW-",
+            "id": 6,
+            "kind": "alarm",
+            "value": 0
+          },
+          "Ref-Status": {
+            "access": "RW-",
+            "id": 5,
+            "kind": "alarm",
+            "value": 0
+          }
+        },
+        "control": {
+          "   EMB AUDIO OUT": {
+            "access": "R--",
+            "id": 99,
+            "kind": "string",
+            "value": ""
+          },
+          "  DELAY": {
+            "access": "R--",
+            "id": 8,
+            "kind": "string",
+            "value": ""
+          },
+          "  DOLBY DECODER": {
+            "access": "R--",
+            "id": 30,
+            "kind": "string",
+            "value": ""
+          },
+          "  DOLBY ENCODER": {
+            "access": "R--",
+            "id": 37,
+            "kind": "string",
+            "value": ""
+          },
+          "  METADATA": {
+            "access": "R--",
+            "id": 195,
+            "kind": "string",
+            "value": ""
+          },
+          "  S2020": {
+            "access": "R--",
+            "id": 187,
+            "kind": "string",
+            "value": ""
+          },
+          " METADATA PROG": {
+            "access": "R--",
+            "id": 213,
+            "kind": "string",
+            "value": ""
+          },
+          "#AC3Copyright": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "No",
+              "Yes",
+              "Ext_Meta"
+            ],
+            "id": 230,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ext_Meta"
+          },
+          "#AC3Datarate": {
+            "access": "RW-",
+            "default": 19,
+            "enum_items": [
+              "32",
+              "40",
+              "48",
+              "56",
+              "64",
+              "80",
+              "96",
+              "112",
+              "128",
+              "160",
+              "192",
+              "224",
+              "256",
+              "320",
+              "384",
+              "448",
+              "512",
+              "576",
+              "640",
+              "Ext_Meta"
+            ],
+            "id": 218,
+            "kind": "enum",
+            "value": 19,
+            "value_name": "Ext_Meta"
+          },
+          "#AC3OrigBitstr": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "No",
+              "Yes",
+              "Ext_Meta"
+            ],
+            "id": 236,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ext_Meta"
+          },
+          "#ADConvType": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Standard",
+              "HDCD",
+              "Ext_Meta"
+            ],
+            "id": 243,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ext_Meta"
+          },
+          "#AudioProdInfo": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "Ext_Meta"
+            ],
+            "id": 231,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ext_Meta"
+          },
+          "#Bckup2DecOut": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "Ch01/02",
+              "Ch03/04",
+              "Ch05/06",
+              "Ch07/08",
+              "All",
+              "None"
+            ],
+            "id": 36,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "None"
+          },
+          "#Bitstrm": {
+            "access": "RW-",
+            "default": 8,
+            "enum_items": [
+              "Complete",
+              "M\u0026E",
+              "Visual",
+              "Hearing",
+              "Dialogue",
+              "Commentary",
+              "Emergency",
+              "VO_Karaoke",
+              "Ext_Meta"
+            ],
+            "id": 219,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "Ext_Meta"
+          },
+          "#CenterMixLvl": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "-3.0dB",
+              "-4.5dB",
+              "-6.0dB",
+              "Ext_Meta"
+            ],
+            "id": 221,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Ext_Meta"
+          },
+          "#Ch_Mode": {
+            "access": "RW-",
+            "default": 7,
+            "enum_items": [
+              "1/0(C)",
+              "2/0(L-R)",
+              "3/0(L-C-R)",
+              "2/1(L-R-S)",
+              "3/1(L-C-R-S)",
+              "2/2(L-R-Ls-Rs)",
+              "3/2(L-C-R-Ls-Rs)",
+              "Ext_Meta"
+            ],
+            "id": 220,
+            "kind": "enum",
+            "value": 7,
+            "value_name": "Ext_Meta"
+          },
+          "#DC_filter": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "Ext_Meta"
+            ],
+            "id": 244,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ext_Meta"
+          },
+          "#D_HeadPhone": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Not Indic.",
+              "Not_Headph",
+              "Headph",
+              "Ext_Meta"
+            ],
+            "id": 242,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Ext_Meta"
+          },
+          "#D_Srnd": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Not Indic.",
+              "Not_Srnd",
+              "Srnd",
+              "Ext_Meta"
+            ],
+            "id": 223,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Ext_Meta"
+          },
+          "#Dialogue_Lev": {
+            "access": "RW-",
+            "default": -27,
+            "id": 226,
+            "kind": "int",
+            "max": -1,
+            "min": -31,
+            "step": 1,
+            "unit": "dB",
+            "value": -27
+          },
+          "#Dialogue_Src": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Ext_Meta",
+              "Int_Meta"
+            ],
+            "id": 225,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ext_Meta"
+          },
+          "#Dolby_Srnd EX": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Not Indic.",
+              "Not_Srnd",
+              "Srnd",
+              "Ext_Meta"
+            ],
+            "id": 241,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Ext_Meta"
+          },
+          "#ELossBckupCh": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Ch01/02",
+              "Ch03/04",
+              "Ch05/06",
+              "Ch07/08",
+              "Ch09/10",
+              "Ch11/12",
+              "Ch13/14",
+              "Ch15/16"
+            ],
+            "id": 34,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ch01/02"
+          },
+          "#ELossBckupDelay": {
+            "access": "RW-",
+            "default": 169,
+            "id": 35,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 169
+          },
+          "#ELossBckupSrc": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32"
+            ],
+            "id": 33,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#Emb-A1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 101,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ch_1"
+          },
+          "#Emb-A2": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 103,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Ch_2"
+          },
+          "#Emb-A3": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 105,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ch_3"
+          },
+          "#Emb-A4": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 107,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Ch_4"
+          },
+          "#Emb-B1": {
+            "access": "RW-",
+            "default": 4,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 109,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "Ch_5"
+          },
+          "#Emb-B2": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 111,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Ch_6"
+          },
+          "#Emb-B3": {
+            "access": "RW-",
+            "default": 6,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 113,
+            "kind": "enum",
+            "value": 6,
+            "value_name": "Ch_7"
+          },
+          "#Emb-B4": {
+            "access": "RW-",
+            "default": 7,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 115,
+            "kind": "enum",
+            "value": 7,
+            "value_name": "Ch_8"
+          },
+          "#Emb-C1": {
+            "access": "RW-",
+            "default": 8,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 117,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "Ch_9"
+          },
+          "#Emb-C2": {
+            "access": "RW-",
+            "default": 9,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 119,
+            "kind": "enum",
+            "value": 9,
+            "value_name": "Ch_10"
+          },
+          "#Emb-C3": {
+            "access": "RW-",
+            "default": 10,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 121,
+            "kind": "enum",
+            "value": 10,
+            "value_name": "Ch_11"
+          },
+          "#Emb-C4": {
+            "access": "RW-",
+            "default": 11,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 123,
+            "kind": "enum",
+            "value": 11,
+            "value_name": "Ch_12"
+          },
+          "#Emb-D1": {
+            "access": "RW-",
+            "default": 12,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 125,
+            "kind": "enum",
+            "value": 12,
+            "value_name": "Ch_13"
+          },
+          "#Emb-D2": {
+            "access": "RW-",
+            "default": 13,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 127,
+            "kind": "enum",
+            "value": 13,
+            "value_name": "Ch_14"
+          },
+          "#Emb-D3": {
+            "access": "RW-",
+            "default": 14,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 129,
+            "kind": "enum",
+            "value": 14,
+            "value_name": "Ch_15"
+          },
+          "#Emb-D4": {
+            "access": "RW-",
+            "default": 15,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 131,
+            "kind": "enum",
+            "value": 15,
+            "value_name": "Ch_16"
+          },
+          "#Emb-Mode": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Off",
+              "Append",
+              "Overwrite"
+            ],
+            "id": 94,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Overwrite"
+          },
+          "#EmbA1_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 164,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbA2_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 165,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbA3_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 166,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbA4_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 167,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbB1_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 168,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbB2_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 169,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbB3_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 170,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbB4_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 171,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbC1_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 172,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbC2_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 173,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbC3_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 174,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbC4_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 175,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbD1_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 176,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbD2_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 177,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbD3_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 178,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbD4_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 179,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#Emb_A_Sel": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Group1",
+              "Group2",
+              "Group3",
+              "Group4",
+              "Off"
+            ],
+            "id": 95,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Group1"
+          },
+          "#Emb_B_Sel": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Group1",
+              "Group2",
+              "Group3",
+              "Group4",
+              "Off"
+            ],
+            "id": 96,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Group2"
+          },
+          "#Emb_C_Sel": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Group1",
+              "Group2",
+              "Group3",
+              "Group4",
+              "Off"
+            ],
+            "id": 97,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Group3"
+          },
+          "#Emb_D_Sel": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Group1",
+              "Group2",
+              "Group3",
+              "Group4",
+              "Off"
+            ],
+            "id": 98,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Group4"
+          },
+          "#Enc_MD_Src": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "Local",
+              "ShufflerOut"
+            ],
+            "id": 54,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#Enc_config": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "2",
+              "2+2",
+              "2+2+2",
+              "2+2+2+2",
+              "5.1",
+              "5.1+2",
+              "5.1+2+PL.0",
+              "5.1+2+PL.1",
+              "TC",
+              "2orTC",
+              "2+2orTC",
+              "5.1orTC",
+              "7.1DD+",
+              "7.1upDD+"
+            ],
+            "id": 55,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "5.1+2"
+          },
+          "#EncoderIn01": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 39,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ch_1"
+          },
+          "#EncoderIn02": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 41,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Ch_2"
+          },
+          "#EncoderIn03": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 43,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ch_3"
+          },
+          "#EncoderIn04": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 45,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Ch_4"
+          },
+          "#EncoderIn05": {
+            "access": "RW-",
+            "default": 4,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 47,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "Ch_5"
+          },
+          "#EncoderIn06": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 51,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Ch_6"
+          },
+          "#EncoderIn07": {
+            "access": "RW-",
+            "default": 6,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 49,
+            "kind": "enum",
+            "value": 6,
+            "value_name": "Ch_7"
+          },
+          "#EncoderIn08": {
+            "access": "RW-",
+            "default": 7,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 53,
+            "kind": "enum",
+            "value": 7,
+            "value_name": "Ch_8"
+          },
+          "#FrameRate": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "23.98",
+              "24",
+              "25",
+              "29.97",
+              "30",
+              "Ext_Meta"
+            ],
+            "id": 208,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Ext_Meta"
+          },
+          "#Insert_Ass_Ch": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "None",
+              "Ch01/02",
+              "Ch03/04",
+              "Ch05/06",
+              "Ch07/08",
+              "Ch09/10",
+              "Ch11/12",
+              "Ch13/14",
+              "Ch15/16"
+            ],
+            "id": 194,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "None"
+          },
+          "#LFE": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "Ext_Meta"
+            ],
+            "id": 224,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ext_Meta"
+          },
+          "#LFE_Filter": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "Ext_Meta"
+            ],
+            "id": 235,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ext_Meta"
+          },
+          "#LanguageCode": {
+            "access": "RW-",
+            "default": 0,
+            "id": 229,
+            "kind": "uint",
+            "max": 127,
+            "min": 0,
+            "step": 1,
+            "value": 0
+          },
+          "#Language_Src": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Ext_Meta",
+              "Int_Meta"
+            ],
+            "id": 228,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ext_Meta"
+          },
+          "#Line": {
+            "access": "RW-",
+            "default": 6,
+            "enum_items": [
+              "None",
+              "FilmStandard",
+              "FilmLight",
+              "MusicStandard",
+              "MusicLight",
+              "Speech",
+              "Ext_Meta"
+            ],
+            "id": 250,
+            "kind": "enum",
+            "value": 6,
+            "value_name": "Ext_Meta"
+          },
+          "#Lo/Ro_C_Dwnmx": {
+            "access": "RW-",
+            "default": 8,
+            "enum_items": [
+              "+3.0dB",
+              "+1.5dB",
+              "0.0dB",
+              "-1.5dB",
+              "-3.0dB",
+              "-4.5dB",
+              "-6.0dB",
+              "-999dB",
+              "Ext_Meta"
+            ],
+            "id": 239,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "Ext_Meta"
+          },
+          "#Lo/Ro_S_Dwnmx": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "-1.5dB",
+              "-3.0dB",
+              "-4.5dB",
+              "-6.0dB",
+              "-999dB",
+              "Ext_Meta"
+            ],
+            "id": 240,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Ext_Meta"
+          },
+          "#LocalOut_MD_Src": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "Local",
+              "ShufflerOut"
+            ],
+            "id": 196,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#Lowpass_Filter": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "Ext_Meta"
+            ],
+            "id": 245,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ext_Meta"
+          },
+          "#Lt/Rt_C_Dwnmx": {
+            "access": "RW-",
+            "default": 8,
+            "enum_items": [
+              "+3.0dB",
+              "+1.5dB",
+              "0.0dB",
+              "-1.5dB",
+              "-3.0dB",
+              "-4.5dB",
+              "-6.0dB",
+              "-999dB",
+              "Ext_Meta"
+            ],
+            "id": 238,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "Ext_Meta"
+          },
+          "#Lt/Rt_S_Dwnmx": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "-1.5dB",
+              "-3.0dB",
+              "-4.5dB",
+              "-6.0dB",
+              "-999dB",
+              "Ext_Meta"
+            ],
+            "id": 227,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Ext_Meta"
+          },
+          "#MD_Preset_Name": {
+            "access": "RW-",
+            "id": 206,
+            "kind": "string",
+            "max_len": 16,
+            "value": "empty string"
+          },
+          "#MD_Prog_1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E",
+              "F",
+              "G",
+              "H",
+              "Ext"
+            ],
+            "id": 209,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "A"
+          },
+          "#MD_Prog_2": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E",
+              "F",
+              "G",
+              "H",
+              "Ext"
+            ],
+            "id": 210,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "B"
+          },
+          "#MD_Prog_3": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E",
+              "F",
+              "G",
+              "H",
+              "Ext"
+            ],
+            "id": 211,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "C"
+          },
+          "#MD_Prog_4": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E",
+              "F",
+              "G",
+              "H",
+              "Ext"
+            ],
+            "id": 212,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "D"
+          },
+          "#MD_Prog_Type": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "1 Ch",
+              "2 Ch",
+              "4 Ch",
+              "5.1 Ch"
+            ],
+            "id": 215,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "5.1 Ch"
+          },
+          "#Pref_Dwnmx": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Not Indic.",
+              "Lt/Rt",
+              "Lo/Ro",
+              "Ext_Meta"
+            ],
+            "id": 237,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Ext_Meta"
+          },
+          "#Preset_Name": {
+            "access": "RW-",
+            "id": 28,
+            "kind": "string",
+            "max_len": 16,
+            "value": ""
+          },
+          "#ProdMixLvl": {
+            "access": "RW-",
+            "default": 80,
+            "id": 233,
+            "kind": "int",
+            "max": 111,
+            "min": 80,
+            "step": 1,
+            "unit": "dB",
+            "value": 80
+          },
+          "#ProdMixLvl_Src": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Ext_Meta",
+              "Int_Meta"
+            ],
+            "id": 232,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ext_Meta"
+          },
+          "#ProdRoomType": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Not Indic.",
+              "Large",
+              "Small",
+              "Ext_Meta"
+            ],
+            "id": 234,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Ext_Meta"
+          },
+          "#ProgramConfig": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "7.1",
+              "5.1+2",
+              "5.1",
+              "4x2",
+              "3x2",
+              "2+2",
+              "Ext_Meta"
+            ],
+            "id": 207,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "5.1+2"
+          },
+          "#ProgramText": {
+            "access": "RW-",
+            "id": 217,
+            "kind": "string",
+            "max_len": 12,
+            "value": "empty string"
+          },
+          "#ProgramText_Src": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Ext_Meta",
+              "Int_Meta"
+            ],
+            "id": 216,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ext_Meta"
+          },
+          "#RFPreEmph": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "Ext_Meta"
+            ],
+            "id": 248,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ext_Meta"
+          },
+          "#RfMode": {
+            "access": "RW-",
+            "default": 6,
+            "enum_items": [
+              "None",
+              "FilmStandard",
+              "FilmLight",
+              "MusicStandard",
+              "MusicLight",
+              "Speech",
+              "Ext_Meta"
+            ],
+            "id": 249,
+            "kind": "enum",
+            "value": 6,
+            "value_name": "Ext_Meta"
+          },
+          "#S2020-Emb": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Overwrite"
+            ],
+            "id": 190,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#S2020Emb_MD_Src": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "Local",
+              "ShufflerOut"
+            ],
+            "id": 191,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#Shuffler_MD_Src": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "Local"
+            ],
+            "id": 197,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-A1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 100,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-A2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 102,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-A3": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 104,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-A4": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 106,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-B1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 108,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-B2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 110,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-B3": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 112,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-B4": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 114,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-C1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 116,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-C2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 118,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-C3": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 120,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-C4": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 122,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-D1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 124,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-D2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 126,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-D3": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 128,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-D4": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 130,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEncoder01": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 38,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "DecoderOut"
+          },
+          "#SourceEncoder02": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 40,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "DecoderOut"
+          },
+          "#SourceEncoder03": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 42,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "DecoderOut"
+          },
+          "#SourceEncoder04": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 44,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "DecoderOut"
+          },
+          "#SourceEncoder05": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 46,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "DecoderOut"
+          },
+          "#SourceEncoder06": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 50,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "DecoderOut"
+          },
+          "#SourceEncoder07": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 48,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "DecoderOut"
+          },
+          "#SourceEncoder08": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 52,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "DecoderOut"
+          },
+          "#SrndMixLvl": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "-3.0dB",
+              "-6.0dB",
+              "-999dB",
+              "Ext_Meta"
+            ],
+            "id": 222,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Ext_Meta"
+          },
+          "#Srnd_3dB_Atten": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "Ext_Meta"
+            ],
+            "id": 247,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ext_Meta"
+          },
+          "#Srnd_Ph_Shift": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "Ext_Meta"
+            ],
+            "id": 246,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ext_Meta"
+          },
+          "AD": {
+            "access": "RW-",
+            "default": 16,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 83,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "Off"
+          },
+          "AD-Loss": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Off",
+              "1/2-\u003e3/4",
+              "3/4-\u003e1/2",
+              "Mute-1/2",
+              "Mute-3/4"
+            ],
+            "id": 77,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "1/2-\u003e3/4"
+          },
+          "ADControl": {
+            "access": "RW-",
+            "default": 16,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 85,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "Off"
+          },
+          "ADControl_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 92,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "ADProg1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 79,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ch_1"
+          },
+          "ADProg1_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 89,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "ADProg1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 86,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "ADProg2": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 81,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Ch_2"
+          },
+          "ADProg2_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 90,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "ADProg2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 87,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "AD_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 91,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "AD_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 88,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "AUDIODESCRIPTION": {
+            "access": "R--",
+            "id": 76,
+            "kind": "string",
+            "value": ""
+          },
+          "Active-Preset": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14"
+            ],
+            "id": 26,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Audio-Phase": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Off",
+              "Align"
+            ],
+            "id": 183,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Align"
+          },
+          "AudioStatusBits": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Transparent",
+              "Overwrite"
+            ],
+            "id": 184,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Transparent"
+          },
+          "Control": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Manual",
+              "GPI",
+              "LossDetect",
+              "GPI+LossDetect"
+            ],
+            "id": 17,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Manual"
+          },
+          "DecoderIn": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Ch01/02",
+              "Ch03/04",
+              "Ch05/06",
+              "Ch07/08",
+              "Ch09/10",
+              "Ch11/12",
+              "Ch13/14",
+              "Ch15/16"
+            ],
+            "id": 32,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Ch03/04"
+          },
+          "Delay-Bypass": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 9,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "Delay-Status": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 15,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "Delay-mode_1": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Time",
+              "Fr-Ln-Px"
+            ],
+            "id": 10,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Fr-Ln-Px"
+          },
+          "Detect": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Preset 1",
+              "Preset 2",
+              "Preset 3",
+              "Preset 4",
+              "Preset 5",
+              "Preset 6",
+              "Preset 7",
+              "S2020-SDID",
+              "ProgramConfig",
+              "Previous"
+            ],
+            "id": 22,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "Detect_2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Preset 1",
+              "Preset 2",
+              "Preset 3",
+              "Preset 4",
+              "Preset 5",
+              "Preset 6",
+              "Preset 7",
+              "S2020-SDID",
+              "ProgramConfig"
+            ],
+            "id": 25,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "EMBEDDING": {
+            "access": "RW-",
+            "id": 93,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "Edit-Preset": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14"
+            ],
+            "id": 27,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "EmbA1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 132,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbA1_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 148,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbA2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 133,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbA2_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 149,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbA3_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 134,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbA3_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 150,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbA4_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 135,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbA4_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 151,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbB1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 136,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbB1_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 152,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbB2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 137,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbB2_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 153,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbB3_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 138,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbB3_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 154,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbB4_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 139,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbB4_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 155,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbC1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 140,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbC1_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 156,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbC2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 141,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbC2_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 157,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbC3_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 142,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbC3_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 158,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbC4_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 143,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbC4_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 159,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbD1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 144,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbD1_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 160,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbD2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 145,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbD2_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 161,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbD3_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 146,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbD3_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 162,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbD4_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 147,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbD4_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 163,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "Enc1_DDPlus_Man": {
+            "access": "RW-",
+            "default": 256,
+            "id": 64,
+            "kind": "int",
+            "max": 1532,
+            "min": 32,
+            "step": 1,
+            "unit": "kbps",
+            "value": 256
+          },
+          "Enc1_DD_Man": {
+            "access": "RW-",
+            "default": 384,
+            "id": 60,
+            "kind": "int",
+            "max": 640,
+            "min": 32,
+            "step": 1,
+            "unit": "kbps",
+            "value": 384
+          },
+          "Enc1_mode": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "DDPlus_Man",
+              "DDPlus_Auto192 ",
+              "DDPlus_Auto200",
+              "DDPlus_Auto224",
+              "DDPlus_Auto256",
+              "DD_Man",
+              "DD_Auto384",
+              "DD_Auto448"
+            ],
+            "id": 56,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "DDPlus_Man"
+          },
+          "Enc2_DDPlus_Man": {
+            "access": "RW-",
+            "default": 256,
+            "id": 65,
+            "kind": "int",
+            "max": 1532,
+            "min": 32,
+            "step": 1,
+            "unit": "kbps",
+            "value": 256
+          },
+          "Enc2_DD_Man": {
+            "access": "RW-",
+            "default": 384,
+            "id": 61,
+            "kind": "int",
+            "max": 640,
+            "min": 32,
+            "step": 1,
+            "unit": "kbps",
+            "value": 384
+          },
+          "Enc2_mode": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "DDPlus_Man",
+              "DDPlus_Auto192 ",
+              "DDPlus_Auto200",
+              "DDPlus_Auto224",
+              "DDPlus_Auto256",
+              "DD_Man",
+              "DD_Auto384",
+              "DD_Auto448"
+            ],
+            "id": 57,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "DDPlus_Man"
+          },
+          "Enc3_DDPlus_Man": {
+            "access": "RW-",
+            "default": 256,
+            "id": 66,
+            "kind": "int",
+            "max": 1532,
+            "min": 32,
+            "step": 1,
+            "unit": "kbps",
+            "value": 256
+          },
+          "Enc3_DD_Man": {
+            "access": "RW-",
+            "default": 384,
+            "id": 62,
+            "kind": "int",
+            "max": 640,
+            "min": 32,
+            "step": 1,
+            "unit": "kbps",
+            "value": 384
+          },
+          "Enc3_mode": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "DDPlus_Man",
+              "DDPlus_Auto192 ",
+              "DDPlus_Auto200",
+              "DDPlus_Auto224",
+              "DDPlus_Auto256",
+              "DD_Man",
+              "DD_Auto384",
+              "DD_Auto448"
+            ],
+            "id": 58,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "DDPlus_Man"
+          },
+          "Enc4_DDPlus_Man": {
+            "access": "RW-",
+            "default": 256,
+            "id": 67,
+            "kind": "int",
+            "max": 1532,
+            "min": 32,
+            "step": 1,
+            "unit": "kbps",
+            "value": 256
+          },
+          "Enc4_DD_Man": {
+            "access": "RW-",
+            "default": 384,
+            "id": 63,
+            "kind": "int",
+            "max": 640,
+            "min": 32,
+            "step": 1,
+            "unit": "kbps",
+            "value": 384
+          },
+          "Enc4_mode": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "DDPlus_Man",
+              "DDPlus_Auto192 ",
+              "DDPlus_Auto200",
+              "DDPlus_Auto224",
+              "DDPlus_Auto256",
+              "DD_Man",
+              "DD_Auto384",
+              "DD_Auto448"
+            ],
+            "id": 59,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "DDPlus_Man"
+          },
+          "Ext-Mode": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "GPIO",
+              "Metadata"
+            ],
+            "id": 19,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "GPIO"
+          },
+          "Extract_Ass_Ch": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Auto",
+              "None",
+              "Ch01/02",
+              "Ch03/04",
+              "Ch05/06",
+              "Ch07/08",
+              "Ch09/10",
+              "Ch11/12",
+              "Ch13/14",
+              "Ch15/16"
+            ],
+            "id": 189,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Auto"
+          },
+          "Extract_Line": {
+            "access": "RW-",
+            "default": 0,
+            "id": 188,
+            "kind": "int",
+            "max": 1125,
+            "min": 0,
+            "step": 1,
+            "unit": "ln",
+            "value": 0
+          },
+          "F-Delay_1": {
+            "access": "RW-",
+            "default": 12,
+            "id": 12,
+            "kind": "uint",
+            "max": 250,
+            "min": 0,
+            "step": 1,
+            "unit": "F",
+            "value": 12
+          },
+          "Fade-Time": {
+            "access": "RW-",
+            "default": 500,
+            "id": 182,
+            "kind": "int",
+            "max": 10000,
+            "min": 1,
+            "step": 1,
+            "unit": "ms",
+            "value": 500
+          },
+          "GPI-Ctrl": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Latch",
+              "nonLatch",
+              "BCD"
+            ],
+            "id": 18,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Latch"
+          },
+          "H-Delay_1": {
+            "access": "RW-",
+            "default": 0,
+            "id": 14,
+            "kind": "int",
+            "max": 4124,
+            "min": 0,
+            "step": 1,
+            "unit": "px",
+            "value": 0
+          },
+          "Input-Select": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI-1",
+              "SDI-2",
+              "Auto"
+            ],
+            "id": 1,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "SDI-2"
+          },
+          "Insert_Line": {
+            "access": "RW-",
+            "default": 9,
+            "id": 192,
+            "kind": "int",
+            "max": 1125,
+            "min": 1,
+            "step": 1,
+            "unit": "ln",
+            "value": 9
+          },
+          "Insert_Method": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Method B"
+            ],
+            "id": 193,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Method B"
+          },
+          "Lock-Mode": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI1",
+              "SDI2",
+              "Ref1",
+              "Ref2",
+              "Auto-SDI"
+            ],
+            "id": 3,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI1"
+          },
+          "Loss": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Preset 1",
+              "Preset 2",
+              "Preset 3",
+              "Preset 4",
+              "Preset 5",
+              "Preset 6",
+              "Preset 7"
+            ],
+            "id": 21,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "LossDetect": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "DolbyE",
+              "S2020-SDI",
+              "MD-LocalIn"
+            ],
+            "id": 20,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "DolbyE"
+          },
+          "LossDetect_2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "DolbyE",
+              "S2020-SDI",
+              "MD-LocalIn"
+            ],
+            "id": 23,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "Loss_2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Preset 1",
+              "Preset 2",
+              "Preset 3",
+              "Preset 4",
+              "Preset 5",
+              "Preset 6",
+              "Preset 7"
+            ],
+            "id": 24,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "MD-Control": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Manual",
+              "GPI",
+              "LossDetect",
+              "GPI+LossDetect"
+            ],
+            "id": 198,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Manual"
+          },
+          "MD-LossDetect": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "Local"
+            ],
+            "id": 199,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "MD-LossDetect_2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "SDI",
+              "DecoderOut",
+              "Local"
+            ],
+            "id": 202,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "MD_Prog_Set": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E",
+              "F",
+              "G",
+              "H"
+            ],
+            "id": 214,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "A"
+          },
+          "MD_Status_Pgm": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8"
+            ],
+            "id": 252,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "MD_Status_Src": {
+            "access": "RW-",
+            "default": 4,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "Local",
+              "ShufflerOut",
+              "Off"
+            ],
+            "id": 251,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "Off"
+          },
+          "MISC": {
+            "access": "RW-",
+            "id": 180,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "MetaDet": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "MDPreset 1",
+              "MDPreset 2",
+              "MDPreset 3",
+              "MDPreset 4",
+              "MDPreset 5",
+              "MDPreset 6",
+              "MDPreset 7",
+              "S2020-SDID",
+              "ProgramConfig",
+              "Previous"
+            ],
+            "id": 201,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "MetaDet_2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "MDPreset 1",
+              "MDPreset 2",
+              "MDPreset 3",
+              "MDPreset 4",
+              "MDPreset 5",
+              "MDPreset 6",
+              "MDPreset 7",
+              "S2020-SDID",
+              "ProgramConfig",
+              "Previous"
+            ],
+            "id": 204,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "MetaLoss": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "MDPreset 1",
+              "MDPreset 2",
+              "MDPreset 3",
+              "MDPreset 4",
+              "MDPreset 5",
+              "MDPreset 6",
+              "MDPreset 7"
+            ],
+            "id": 200,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "MetaLoss_2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "MDPreset 1",
+              "MDPreset 2",
+              "MDPreset 3",
+              "MDPreset 4",
+              "MDPreset 5",
+              "MDPreset 6",
+              "MDPreset 7"
+            ],
+            "id": 203,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "Metadata_Preset": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14"
+            ],
+            "id": 205,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "NonPCM-Bypass": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 181,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "On"
+          },
+          "Out-Frmt": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Auto",
+              "1080p60",
+              "1080p50",
+              "1080i60",
+              "1080i50",
+              "1080p30",
+              "1080p25",
+              "1080p24",
+              "720p60",
+              "720p50",
+              "SD625",
+              "SD525"
+            ],
+            "id": 4,
+            "kind": "enum",
+            "value": 6,
+            "value_name": "1080p25"
+          },
+          "PL Center_mix": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "+3.0dB",
+              "+1.5dB",
+              "0.0dB",
+              "-1.5dB",
+              "-3.0dB",
+              "-4.5dB",
+              "-6.0dB",
+              "-999dB"
+            ],
+            "id": 72,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "0.0dB"
+          },
+          "PL Dialnorm": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 71,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "On"
+          },
+          "PL Downmix_Type": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Auto",
+              "Lt/Rt",
+              "Lo/Ro",
+              "PLII"
+            ],
+            "id": 70,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "PLII"
+          },
+          "PL LFE_En": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Disabled",
+              "Auto",
+              "Enabled"
+            ],
+            "id": 74,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Disabled"
+          },
+          "PL LFE_MixLevel": {
+            "access": "RW-",
+            "default": 7,
+            "id": 75,
+            "kind": "int",
+            "max": 10,
+            "min": -21,
+            "step": 1,
+            "unit": "dB",
+            "value": 7
+          },
+          "PL MD_Src": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "MD_Enc1",
+              "Int_Meta"
+            ],
+            "id": 69,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Int_Meta"
+          },
+          "PL Surround_mix": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "+3.0dB",
+              "+1.5dB",
+              "0.0dB",
+              "-1.5dB",
+              "-3.0dB",
+              "-4.5dB",
+              "-6.0dB",
+              "-999dB"
+            ],
+            "id": 73,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "-1.5dB"
+          },
+          "PRESET": {
+            "access": "RW-",
+            "id": 16,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "PROLOGIC CONTROL": {
+            "access": "R--",
+            "id": 68,
+            "kind": "string",
+            "value": ""
+          },
+          "Phaser-Status": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 7,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "Phaser1-Offset": {
+            "access": "RW-",
+            "default": 0,
+            "id": 5,
+            "kind": "int",
+            "max": 4124,
+            "min": 0,
+            "step": 1,
+            "unit": "px",
+            "value": 1
+          },
+          "Phaser2-Offset": {
+            "access": "RW-",
+            "default": 0,
+            "id": 6,
+            "kind": "int",
+            "max": 4124,
+            "min": 0,
+            "step": 1,
+            "unit": "px",
+            "value": 0
+          },
+          "PrstEditView": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Follow Active",
+              "Independent"
+            ],
+            "id": 29,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Follow Active"
+          },
+          "RestartCAT561": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "No Reset",
+              "Reset"
+            ],
+            "id": 253,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "No Reset"
+          },
+          "Silence-Level": {
+            "access": "RW-",
+            "default": -60,
+            "id": 185,
+            "kind": "float",
+            "max": -20,
+            "min": -100,
+            "step": 1,
+            "unit": "dBFS",
+            "value": -60
+          },
+          "Silence-Time": {
+            "access": "RW-",
+            "default": 10,
+            "id": 186,
+            "kind": "uint",
+            "max": 255,
+            "min": 1,
+            "step": 1,
+            "unit": "s",
+            "value": 10
+          },
+          "SourceAD": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "Addon01/16",
+              "Addon17/32"
+            ],
+            "id": 82,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "SourceADControl": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "Addon01/16",
+              "Addon17/32"
+            ],
+            "id": 84,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "SourceADProg1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "Addon01/16",
+              "Addon17/32"
+            ],
+            "id": 78,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "SourceADProg2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "Addon01/16",
+              "Addon17/32"
+            ],
+            "id": 80,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "SourceDecoder": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32"
+            ],
+            "id": 31,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "Switch-Back": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 2,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "Time-Delay_1": {
+            "access": "RW-",
+            "default": 480,
+            "id": 11,
+            "kind": "float",
+            "max": 10000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 480
+          },
+          "V-Delay_1": {
+            "access": "RW-",
+            "default": 0,
+            "id": 13,
+            "kind": "int",
+            "max": 1124,
+            "min": 0,
+            "step": 1,
+            "unit": "ln",
+            "value": 0
+          },
+          "VIDEO": {
+            "access": "RW-",
+            "id": 0,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          }
+        },
+        "identity": {
+          "3G - Capable": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 16,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "AudioDescription": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 19,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Card ID": {
+            "access": "R--",
+            "id": 7,
+            "kind": "string",
+            "max_len": 16,
+            "value": "71ef060a0000001f"
+          },
+          "Card description": {
+            "access": "R--",
+            "id": 2,
+            "kind": "string",
+            "max_len": 16,
+            "value": "GED130-2522.html"
+          },
+          "Card name": {
+            "access": "R--",
+            "id": 0,
+            "kind": "string",
+            "max_len": 8,
+            "value": "GED130"
+          },
+          "Card-Status": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Unknown",
+              "Programming",
+              "Card Failed",
+              "Operational"
+            ],
+            "id": 10,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Operational"
+          },
+          "DM-D HW Rev": {
+            "access": "R--",
+            "id": 13,
+            "kind": "string",
+            "max_len": 16,
+            "value": "22"
+          },
+          "DM-D Name": {
+            "access": "R--",
+            "id": 11,
+            "kind": "string",
+            "max_len": 16,
+            "value": "CAT561 EPD"
+          },
+          "DM-D SW Rev": {
+            "access": "R--",
+            "id": 12,
+            "kind": "string",
+            "max_len": 16,
+            "value": "2407"
+          },
+          "DM-D Serial": {
+            "access": "R--",
+            "id": 14,
+            "kind": "string",
+            "max_len": 16,
+            "value": "501904"
+          },
+          "Decoder": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 17,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Encoder": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 18,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Features": {
+            "access": "R--",
+            "id": 9,
+            "kind": "string",
+            "max_len": 8,
+            "value": "0008FE5B"
+          },
+          "HD - Capable": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 15,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Hardware rev": {
+            "access": "R--",
+            "id": 4,
+            "kind": "string",
+            "max_len": 4,
+            "value": "0300"
+          },
+          "Key": {
+            "access": "RW-",
+            "id": 8,
+            "kind": "string",
+            "max_len": 15,
+            "value": "empty string"
+          },
+          "Product code": {
+            "access": "R--",
+            "id": 5,
+            "kind": "string",
+            "max_len": 10,
+            "value": "9490600011"
+          },
+          "Serial number": {
+            "access": "R--",
+            "id": 6,
+            "kind": "string",
+            "max_len": 16,
+            "value": "PR011621"
+          },
+          "Software rev": {
+            "access": "R--",
+            "id": 3,
+            "kind": "string",
+            "max_len": 4,
+            "value": "2522"
+          },
+          "User label": {
+            "access": "RW-",
+            "id": 1,
+            "kind": "string",
+            "max_len": 16,
+            "value": "3G/HD/SD Dolby"
+          }
+        },
+        "status": {
+          "AD-Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 64,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "ADControl-Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Error"
+            ],
+            "id": 65,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "ADProg1-Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 62,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "ADProg2-Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 63,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "ANC-Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Error"
+            ],
+            "id": 21,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "ATC-Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Present",
+              "Error"
+            ],
+            "id": 20,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Active-Out1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "SDI1",
+              "SDI2"
+            ],
+            "id": 16,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI1"
+          },
+          "Active-Out2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "SDI1",
+              "SDI2"
+            ],
+            "id": 17,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI1"
+          },
+          "AddOnFrmtIn01/02": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 46,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn03/04": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 47,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn05/06": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 48,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn07/08": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 49,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn09/10": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 50,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn11/12": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 51,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn13/14": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 52,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn15/16": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 53,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn17/18": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 54,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn19/20": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 55,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn21/22": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 56,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn23/24": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 57,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn25/26": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 58,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn27/28": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 59,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn29/30": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 60,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn31/32": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 61,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "CRC-Stat_1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "OK",
+              "CRC Error"
+            ],
+            "id": 6,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "OK"
+          },
+          "CRC-Stat_2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "OK",
+              "CRC Error"
+            ],
+            "id": 7,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "OK"
+          },
+          "DM-D_Status": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Error"
+            ],
+            "id": 132,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "DM-D_Type": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "CAT561 Dec",
+              "CAT561 Enc",
+              "CAT561 Comp",
+              "CAT561 EPD"
+            ],
+            "id": 131,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "DecInFrmt01/02": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 24,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "DecLatency": {
+            "access": "R--",
+            "default": 0,
+            "id": 25,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "DecMetaProg": {
+            "access": "R--",
+            "default": 11,
+            "enum_items": [
+              "5.1+2",
+              "5.1+1+1",
+              "4+4",
+              "4x2",
+              "8x1",
+              "5.1",
+              "3x2",
+              "4",
+              "2+2",
+              "7.1",
+              "Other",
+              "NA"
+            ],
+            "id": 94,
+            "kind": "enum",
+            "value": 11,
+            "value_name": "NA"
+          },
+          "DecMetaStat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Error"
+            ],
+            "id": 93,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtIn01/02": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 30,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtIn03/04": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 31,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtIn05/06": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 32,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtIn07/08": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 33,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtIn09/10": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 34,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtIn11/12": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 35,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtIn13/14": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 36,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtIn15/16": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 37,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutA1/2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 82,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutA3/4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 83,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutB1/2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 84,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutB3/4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 85,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutC1/2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 86,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutC3/4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 87,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutD1/2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 88,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutD3/4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 89,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbSOF-EIn01/02": {
+            "access": "R--",
+            "default": 0,
+            "id": 38,
+            "kind": "int",
+            "max": 1125,
+            "min": 0,
+            "step": 1,
+            "unit": "ln",
+            "value": 0
+          },
+          "EmbSOF-EIn03/04": {
+            "access": "R--",
+            "default": 0,
+            "id": 39,
+            "kind": "int",
+            "max": 1125,
+            "min": 0,
+            "step": 1,
+            "unit": "ln",
+            "value": 0
+          },
+          "EmbSOF-EIn05/06": {
+            "access": "R--",
+            "default": 0,
+            "id": 40,
+            "kind": "int",
+            "max": 1125,
+            "min": 0,
+            "step": 1,
+            "unit": "ln",
+            "value": 0
+          },
+          "EmbSOF-EIn07/08": {
+            "access": "R--",
+            "default": 0,
+            "id": 41,
+            "kind": "int",
+            "max": 1125,
+            "min": 0,
+            "step": 1,
+            "unit": "ln",
+            "value": 0
+          },
+          "EmbSOF-EIn09/10": {
+            "access": "R--",
+            "default": 0,
+            "id": 42,
+            "kind": "int",
+            "max": 1125,
+            "min": 0,
+            "step": 1,
+            "unit": "ln",
+            "value": 0
+          },
+          "EmbSOF-EIn11/12": {
+            "access": "R--",
+            "default": 0,
+            "id": 43,
+            "kind": "int",
+            "max": 1125,
+            "min": 0,
+            "step": 1,
+            "unit": "ln",
+            "value": 0
+          },
+          "EmbSOF-EIn13/14": {
+            "access": "R--",
+            "default": 0,
+            "id": 44,
+            "kind": "int",
+            "max": 1125,
+            "min": 0,
+            "step": 1,
+            "unit": "ln",
+            "value": 0
+          },
+          "EmbSOF-EIn15/16": {
+            "access": "R--",
+            "default": 0,
+            "id": 45,
+            "kind": "int",
+            "max": 1125,
+            "min": 0,
+            "step": 1,
+            "unit": "ln",
+            "value": 0
+          },
+          "EmbStatOutA1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 66,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutA2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 67,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutA3": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 68,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutA4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 69,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutB1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 70,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutB2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 71,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutB3": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 72,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutB4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 73,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutC1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 74,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutC2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 75,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutC3": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 76,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutC4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 77,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutD1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 78,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutD2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 79,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutD3": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 80,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutD4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 81,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Enc1Latency": {
+            "access": "R--",
+            "default": 0,
+            "id": 26,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "Enc2Latency": {
+            "access": "R--",
+            "default": 0,
+            "id": 27,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "Enc3Latency": {
+            "access": "R--",
+            "default": 0,
+            "id": 28,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "Enc4Latency": {
+            "access": "R--",
+            "default": 0,
+            "id": 29,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "FPGA-Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "OK",
+              "Error"
+            ],
+            "id": 130,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "OK"
+          },
+          "GPI": {
+            "access": "R--",
+            "default": 1,
+            "id": 19,
+            "kind": "int",
+            "max": 7,
+            "min": 0,
+            "step": 1,
+            "value": 1
+          },
+          "Grp-Ins": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Error"
+            ],
+            "id": 23,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "GrpInUse": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "____",
+              "1___",
+              "_2__",
+              "12__",
+              "__3_",
+              "1_3_",
+              "_23_",
+              "123_",
+              "___4",
+              "1__4",
+              "_2_4",
+              "12_4",
+              "__34",
+              "1_34",
+              "_234",
+              "1234"
+            ],
+            "id": 22,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "____"
+          },
+          "IO-Delay_1": {
+            "access": "R--",
+            "default": 0,
+            "id": 18,
+            "kind": "float",
+            "max": 10000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "LocMetaProg": {
+            "access": "R--",
+            "default": 11,
+            "enum_items": [
+              "5.1+2",
+              "5.1+1+1",
+              "4+4",
+              "4x2",
+              "8x1",
+              "5.1",
+              "3x2",
+              "4",
+              "2+2",
+              "7.1",
+              "Other",
+              "NA"
+            ],
+            "id": 96,
+            "kind": "enum",
+            "value": 11,
+            "value_name": "NA"
+          },
+          "LocMetaStat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Error"
+            ],
+            "id": 95,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Locked-To": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "Not Locked",
+              "Ref",
+              "SDI1",
+              "SDI2"
+            ],
+            "id": 15,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Not Locked"
+          },
+          "MD AC3Copyright": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "No",
+              "Yes",
+              "NA"
+            ],
+            "id": 112,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD AC3Datarate": {
+            "access": "R--",
+            "default": 0,
+            "id": 100,
+            "kind": "int",
+            "max": 640,
+            "min": 0,
+            "step": 1,
+            "unit": "kbps",
+            "value": 0
+          },
+          "MD AC3OrigBitstr": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "No",
+              "Yes",
+              "NA"
+            ],
+            "id": 113,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD ADConvType": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "Standard",
+              "HDCD",
+              "NA"
+            ],
+            "id": 121,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD AudioProdInfo": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "NA"
+            ],
+            "id": 109,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD Bitstream": {
+            "access": "R--",
+            "default": 8,
+            "enum_items": [
+              "Complete",
+              "M\u0026E",
+              "Visual",
+              "Hearing",
+              "Dialogue",
+              "Commentary",
+              "Emergency",
+              "VO_Karaoke",
+              "NA"
+            ],
+            "id": 101,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "NA"
+          },
+          "MD CenterMixLvl": {
+            "access": "R--",
+            "default": 3,
+            "enum_items": [
+              "-3.0dB",
+              "-4.5dB",
+              "-6.0dB",
+              "NA"
+            ],
+            "id": 103,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "NA"
+          },
+          "MD ChannelMode": {
+            "access": "R--",
+            "default": 7,
+            "enum_items": [
+              "1/0(C)",
+              "2/0(L-R)",
+              "3/0(L-C-R)",
+              "2/1(L-R-S)",
+              "3/1(L-C-R-S)",
+              "2/2(L-R-Ls-Rs)",
+              "3/2(L-C-R-Ls-Rs)",
+              "NA"
+            ],
+            "id": 102,
+            "kind": "enum",
+            "value": 7,
+            "value_name": "NA"
+          },
+          "MD DC Filter": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "NA"
+            ],
+            "id": 122,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD D_HeadPhone": {
+            "access": "R--",
+            "default": 4,
+            "enum_items": [
+              "Not Indic.",
+              "Not_Headph",
+              "Headph",
+              "Rsvd",
+              "NA"
+            ],
+            "id": 120,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "NA"
+          },
+          "MD D_Surnd": {
+            "access": "R--",
+            "default": 4,
+            "enum_items": [
+              "Not Indic.",
+              "Not_Srnd",
+              "Srnd",
+              "Rsvd",
+              "NA"
+            ],
+            "id": 105,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "NA"
+          },
+          "MD D_Surnd EX": {
+            "access": "R--",
+            "default": 4,
+            "enum_items": [
+              "Not Indic.",
+              "Not_Srnd",
+              "Srnd",
+              "Rsvd",
+              "NA"
+            ],
+            "id": 119,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "NA"
+          },
+          "MD Dialog Lvl": {
+            "access": "R--",
+            "default": 0,
+            "id": 107,
+            "kind": "int",
+            "max": 0,
+            "min": -31,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "MD FrameRate": {
+            "access": "R--",
+            "default": 5,
+            "enum_items": [
+              "23.98",
+              "24",
+              "25",
+              "29.97",
+              "30",
+              "NA"
+            ],
+            "id": 98,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "NA"
+          },
+          "MD LFE": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "NA"
+            ],
+            "id": 106,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD LFE Filter": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "NA"
+            ],
+            "id": 124,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD LanguageCode": {
+            "access": "R--",
+            "default": 0,
+            "id": 108,
+            "kind": "uint",
+            "max": 127,
+            "min": 0,
+            "step": 1,
+            "value": 0
+          },
+          "MD Line Mode": {
+            "access": "R--",
+            "default": 7,
+            "enum_items": [
+              "None",
+              "FilmStandard",
+              "FilmLight",
+              "MusicStandard",
+              "MusicLight",
+              "Speech",
+              "Rsvd",
+              "NA"
+            ],
+            "id": 129,
+            "kind": "enum",
+            "value": 7,
+            "value_name": "NA"
+          },
+          "MD Lo/RoCDwnmx": {
+            "access": "R--",
+            "default": 8,
+            "enum_items": [
+              "+3.0dB",
+              "+1.5dB",
+              "0.0dB",
+              "-1.5dB",
+              "-3.0dB",
+              "-4.5dB",
+              "-6.0dB",
+              "-999dB",
+              "NA"
+            ],
+            "id": 117,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "NA"
+          },
+          "MD Lo/RoSDwnmx": {
+            "access": "R--",
+            "default": 8,
+            "enum_items": [
+              "+3.0dB",
+              "+1.5dB",
+              "0.0dB",
+              "-1.5dB",
+              "-3.0dB",
+              "-4.5dB",
+              "-6.0dB",
+              "-999dB",
+              "NA"
+            ],
+            "id": 118,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "NA"
+          },
+          "MD Lowpass Fil": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "NA"
+            ],
+            "id": 123,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD Lt/RtCDwnmx": {
+            "access": "R--",
+            "default": 8,
+            "enum_items": [
+              "+3.0dB",
+              "+1.5dB",
+              "0.0dB",
+              "-1.5dB",
+              "-3.0dB",
+              "-4.5dB",
+              "-6.0dB",
+              "-999dB",
+              "NA"
+            ],
+            "id": 115,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "NA"
+          },
+          "MD Lt/RtSDwnmx": {
+            "access": "R--",
+            "default": 8,
+            "enum_items": [
+              "+3.0dB",
+              "+1.5dB",
+              "0.0dB",
+              "-1.5dB",
+              "-3.0dB",
+              "-4.5dB",
+              "-6.0dB",
+              "-999dB",
+              "NA"
+            ],
+            "id": 116,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "NA"
+          },
+          "MD Pref. Dwnmx": {
+            "access": "R--",
+            "default": 4,
+            "enum_items": [
+              "Not Indic.",
+              "Lt/Rt",
+              "Lo/Ro",
+              "Rsvd",
+              "NA"
+            ],
+            "id": 114,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "NA"
+          },
+          "MD Prgm Config": {
+            "access": "R--",
+            "default": 12,
+            "enum_items": [
+              "5.1+2",
+              "5.1+1+1",
+              "4+4",
+              "4x2",
+              "8x1",
+              "5.1",
+              "3x2",
+              "4",
+              "2+2",
+              "7.1",
+              "Rsvd",
+              "Other",
+              "NA"
+            ],
+            "id": 97,
+            "kind": "enum",
+            "value": 12,
+            "value_name": "NA"
+          },
+          "MD ProdMixLvl": {
+            "access": "R--",
+            "default": 0,
+            "id": 110,
+            "kind": "int",
+            "max": 111,
+            "min": 0,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "MD ProdRoomType": {
+            "access": "R--",
+            "default": 4,
+            "enum_items": [
+              "Not Indic.",
+              "Large",
+              "Small",
+              "Rsvd",
+              "NA"
+            ],
+            "id": 111,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "NA"
+          },
+          "MD ProgramText": {
+            "access": "R--",
+            "id": 99,
+            "kind": "string",
+            "max_len": 12,
+            "value": ""
+          },
+          "MD RF Mode": {
+            "access": "R--",
+            "default": 7,
+            "enum_items": [
+              "None",
+              "FilmStandard",
+              "FilmLight",
+              "MusicStandard",
+              "MusicLight",
+              "Speech",
+              "Rsvd",
+              "NA"
+            ],
+            "id": 128,
+            "kind": "enum",
+            "value": 7,
+            "value_name": "NA"
+          },
+          "MD RFPreEmph": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "NA"
+            ],
+            "id": 127,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD SrndMixLvl": {
+            "access": "R--",
+            "default": 3,
+            "enum_items": [
+              "-3.0dB",
+              "-6.0dB",
+              "-999dB",
+              "NA"
+            ],
+            "id": 104,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "NA"
+          },
+          "MD Sur Phshift": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "NA"
+            ],
+            "id": 125,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD Sur3dB Att": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "NA"
+            ],
+            "id": 126,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "Phaser1_H_Pos": {
+            "access": "R--",
+            "default": 0,
+            "id": 9,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "px",
+            "value": 0
+          },
+          "Phaser1_Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Safe",
+              "Warning",
+              "Critical"
+            ],
+            "id": 11,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Phaser2_H_Pos": {
+            "access": "R--",
+            "default": 0,
+            "id": 10,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "px",
+            "value": 0
+          },
+          "Phaser2_Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Safe",
+              "Warning",
+              "Critical"
+            ],
+            "id": 12,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Ref-Format": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "NTSC/480i",
+              "PAL/576i",
+              "480p",
+              "576p",
+              "720p",
+              "1080i",
+              "1080p"
+            ],
+            "id": 8,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "S2020-Src_Ass_Ch": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "None",
+              "Ch01/02",
+              "Ch03/04",
+              "Ch05/06",
+              "Ch07/08",
+              "Ch09/10",
+              "Ch11/12",
+              "Ch13/14",
+              "Ch15/16"
+            ],
+            "id": 91,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "SDI-Freq_1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "1:1",
+              "1:1.001"
+            ],
+            "id": 4,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "SDI-Freq_2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "1:1",
+              "1:1.001"
+            ],
+            "id": 5,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "SDI-Input_1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "1080p60",
+              "1080p50",
+              "1080p30",
+              "1080p25",
+              "1080p24",
+              "1080i50",
+              "1080i60",
+              "720p60",
+              "720p50",
+              "SD625",
+              "SD525"
+            ],
+            "id": 0,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "SDI-Input_2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "1080p60",
+              "1080p50",
+              "1080p30",
+              "1080p25",
+              "1080p24",
+              "1080i50",
+              "1080i60",
+              "720p60",
+              "720p50",
+              "SD625",
+              "SD525"
+            ],
+            "id": 1,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "SDI-Map_1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Level A",
+              "Level B"
+            ],
+            "id": 2,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "SDI-Map_2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Level A",
+              "Level B"
+            ],
+            "id": 3,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "SDI1-Ref_Offset": {
+            "access": "R--",
+            "default": 0,
+            "id": 13,
+            "kind": "float",
+            "max": 40000,
+            "min": 0,
+            "step": 1,
+            "unit": "us",
+            "value": 0
+          },
+          "SDI2-Ref_Offset": {
+            "access": "R--",
+            "default": 0,
+            "id": 14,
+            "kind": "float",
+            "max": 40000,
+            "min": 0,
+            "step": 1,
+            "unit": "us",
+            "value": 0
+          },
+          "SDIS2020Prog": {
+            "access": "R--",
+            "default": 11,
+            "enum_items": [
+              "5.1+2",
+              "5.1+1+1",
+              "4+4",
+              "4x2",
+              "8x1",
+              "5.1",
+              "3x2",
+              "4",
+              "2+2",
+              "7.1",
+              "Other",
+              "NA"
+            ],
+            "id": 92,
+            "kind": "enum",
+            "value": 11,
+            "value_name": "NA"
+          },
+          "SDIS2020Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Error"
+            ],
+            "id": 90,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          }
+        }
+      },
+      "slot": 3,
+      "status": "present",
+      "walked_at": "2026-05-05T10:21:44Z"
+    }
+  ]
+}

--- a/tests/fixtures/products/axon/synapse/GJA840-0101/acp1/slot_16.json
+++ b/tests/fixtures/products/axon/synapse/GJA840-0101/acp1/slot_16.json
@@ -1,0 +1,5625 @@
+{
+  "created_at": "2026-05-05T10:21:45Z",
+  "device": {
+    "ip": "10.6.239.113",
+    "port": 2071,
+    "protocol": "acp1",
+    "protocol_version": 1,
+    "num_slots": 31
+  },
+  "generator": "acp dev",
+  "slots": [
+    {
+      "objects": {
+        "alarm": {
+          "Announcements": {
+            "access": "RW-",
+            "id": 0,
+            "kind": "alarm",
+            "value": 1
+          },
+          "CRC-Status1": {
+            "access": "RW-",
+            "id": 2,
+            "kind": "alarm",
+            "value": 0
+          },
+          "Input1": {
+            "access": "RW-",
+            "id": 1,
+            "kind": "alarm",
+            "value": 0
+          },
+          "Lock-Status": {
+            "access": "RW-",
+            "id": 4,
+            "kind": "alarm",
+            "value": 0
+          },
+          "Ref-Status": {
+            "access": "RW-",
+            "id": 3,
+            "kind": "alarm",
+            "value": 0
+          }
+        },
+        "control": {
+          "   EMB AUDIO OUT": {
+            "access": "R--",
+            "id": 117,
+            "kind": "string",
+            "value": ""
+          },
+          "  METADATA": {
+            "access": "R--",
+            "id": 205,
+            "kind": "string",
+            "value": ""
+          },
+          "#ClrProcHistory": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Clear"
+            ],
+            "id": 110,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#Emb-A1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 119,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ch_1"
+          },
+          "#Emb-A2": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 121,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Ch_2"
+          },
+          "#Emb-A3": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 123,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ch_3"
+          },
+          "#Emb-A4": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 125,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Ch_4"
+          },
+          "#Emb-B1": {
+            "access": "RW-",
+            "default": 4,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 127,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "Ch_5"
+          },
+          "#Emb-B2": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 129,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Ch_6"
+          },
+          "#Emb-B3": {
+            "access": "RW-",
+            "default": 6,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 131,
+            "kind": "enum",
+            "value": 6,
+            "value_name": "Ch_7"
+          },
+          "#Emb-B4": {
+            "access": "RW-",
+            "default": 7,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 133,
+            "kind": "enum",
+            "value": 7,
+            "value_name": "Ch_8"
+          },
+          "#Emb-C1": {
+            "access": "RW-",
+            "default": 8,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 135,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "Ch_9"
+          },
+          "#Emb-C2": {
+            "access": "RW-",
+            "default": 9,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 137,
+            "kind": "enum",
+            "value": 9,
+            "value_name": "Ch_10"
+          },
+          "#Emb-C3": {
+            "access": "RW-",
+            "default": 10,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 139,
+            "kind": "enum",
+            "value": 10,
+            "value_name": "Ch_11"
+          },
+          "#Emb-C4": {
+            "access": "RW-",
+            "default": 11,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 141,
+            "kind": "enum",
+            "value": 11,
+            "value_name": "Ch_12"
+          },
+          "#Emb-D1": {
+            "access": "RW-",
+            "default": 12,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 143,
+            "kind": "enum",
+            "value": 12,
+            "value_name": "Ch_13"
+          },
+          "#Emb-D2": {
+            "access": "RW-",
+            "default": 13,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 145,
+            "kind": "enum",
+            "value": 13,
+            "value_name": "Ch_14"
+          },
+          "#Emb-D3": {
+            "access": "RW-",
+            "default": 14,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 147,
+            "kind": "enum",
+            "value": 14,
+            "value_name": "Ch_15"
+          },
+          "#Emb-D4": {
+            "access": "RW-",
+            "default": 15,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 149,
+            "kind": "enum",
+            "value": 15,
+            "value_name": "Ch_16"
+          },
+          "#Emb-Mode": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Off",
+              "Append",
+              "Overwrite"
+            ],
+            "id": 116,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Overwrite"
+          },
+          "#EmbA1_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 182,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbA2_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 183,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbA3_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 184,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbA4_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 185,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbB1_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 186,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbB2_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 187,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbB3_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 188,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbB4_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 189,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbC1_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 190,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbC2_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 191,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbC3_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 192,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbC4_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 193,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbD1_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 194,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbD2_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 195,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbD3_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 196,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbD4_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 197,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#Emb_A_Sel": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Group1",
+              "Group2",
+              "Group3",
+              "Group4",
+              "Off"
+            ],
+            "id": 112,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Group1"
+          },
+          "#Emb_B_Sel": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Group1",
+              "Group2",
+              "Group3",
+              "Group4",
+              "Off"
+            ],
+            "id": 113,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Group2"
+          },
+          "#Emb_C_Sel": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Group1",
+              "Group2",
+              "Group3",
+              "Group4",
+              "Off"
+            ],
+            "id": 114,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Group3"
+          },
+          "#Emb_D_Sel": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Group1",
+              "Group2",
+              "Group3",
+              "Group4",
+              "Off"
+            ],
+            "id": 115,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Group4"
+          },
+          "#Insert_Ass_Ch": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "None",
+              "Ch01/02",
+              "Ch03/04",
+              "Ch05/06",
+              "Ch07/08",
+              "Ch09/10",
+              "Ch11/12",
+              "Ch13/14",
+              "Ch15/16"
+            ],
+            "id": 212,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "None"
+          },
+          "#Preset_Name": {
+            "access": "RW-",
+            "id": 22,
+            "kind": "string",
+            "max_len": 16,
+            "value": ""
+          },
+          "#ProgramJ1_01": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E",
+              "F",
+              "G",
+              "H",
+              "I",
+              "J",
+              "K",
+              "L",
+              "M",
+              "N",
+              "O",
+              "P"
+            ],
+            "id": 61,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "A"
+          },
+          "#ProgramJ1_02": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E",
+              "F",
+              "G",
+              "H",
+              "I",
+              "J",
+              "K",
+              "L",
+              "M",
+              "N",
+              "O",
+              "P"
+            ],
+            "id": 62,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "A"
+          },
+          "#ProgramJ1_03": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E",
+              "F",
+              "G",
+              "H",
+              "I",
+              "J",
+              "K",
+              "L",
+              "M",
+              "N",
+              "O",
+              "P"
+            ],
+            "id": 63,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "A"
+          },
+          "#ProgramJ1_04": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E",
+              "F",
+              "G",
+              "H",
+              "I",
+              "J",
+              "K",
+              "L",
+              "M",
+              "N",
+              "O",
+              "P"
+            ],
+            "id": 64,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "A"
+          },
+          "#ProgramJ1_05": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E",
+              "F",
+              "G",
+              "H",
+              "I",
+              "J",
+              "K",
+              "L",
+              "M",
+              "N",
+              "O",
+              "P"
+            ],
+            "id": 65,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "A"
+          },
+          "#ProgramJ1_06": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E",
+              "F",
+              "G",
+              "H",
+              "I",
+              "J",
+              "K",
+              "L",
+              "M",
+              "N",
+              "O",
+              "P"
+            ],
+            "id": 66,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "A"
+          },
+          "#ProgramJ1_07": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E",
+              "F",
+              "G",
+              "H",
+              "I",
+              "J",
+              "K",
+              "L",
+              "M",
+              "N",
+              "O",
+              "P"
+            ],
+            "id": 67,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "A"
+          },
+          "#ProgramJ1_08": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E",
+              "F",
+              "G",
+              "H",
+              "I",
+              "J",
+              "K",
+              "L",
+              "M",
+              "N",
+              "O",
+              "P"
+            ],
+            "id": 68,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "A"
+          },
+          "#ProgramJ2_01": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E",
+              "F",
+              "G",
+              "H",
+              "I",
+              "J",
+              "K",
+              "L",
+              "M",
+              "N",
+              "O",
+              "P"
+            ],
+            "id": 75,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "A"
+          },
+          "#ProgramJ2_02": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E",
+              "F",
+              "G",
+              "H",
+              "I",
+              "J",
+              "K",
+              "L",
+              "M",
+              "N",
+              "O",
+              "P"
+            ],
+            "id": 76,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "A"
+          },
+          "#ProgramJ2_03": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E",
+              "F",
+              "G",
+              "H",
+              "I",
+              "J",
+              "K",
+              "L",
+              "M",
+              "N",
+              "O",
+              "P"
+            ],
+            "id": 77,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "A"
+          },
+          "#ProgramJ2_04": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E",
+              "F",
+              "G",
+              "H",
+              "I",
+              "J",
+              "K",
+              "L",
+              "M",
+              "N",
+              "O",
+              "P"
+            ],
+            "id": 78,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "A"
+          },
+          "#ProgramJ2_05": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E",
+              "F",
+              "G",
+              "H",
+              "I",
+              "J",
+              "K",
+              "L",
+              "M",
+              "N",
+              "O",
+              "P"
+            ],
+            "id": 79,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "A"
+          },
+          "#ProgramJ2_06": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E",
+              "F",
+              "G",
+              "H",
+              "I",
+              "J",
+              "K",
+              "L",
+              "M",
+              "N",
+              "O",
+              "P"
+            ],
+            "id": 80,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "A"
+          },
+          "#ProgramJ2_07": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E",
+              "F",
+              "G",
+              "H",
+              "I",
+              "J",
+              "K",
+              "L",
+              "M",
+              "N",
+              "O",
+              "P"
+            ],
+            "id": 81,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "A"
+          },
+          "#ProgramJ2_08": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E",
+              "F",
+              "G",
+              "H",
+              "I",
+              "J",
+              "K",
+              "L",
+              "M",
+              "N",
+              "O",
+              "P"
+            ],
+            "id": 82,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "A"
+          },
+          "#S2020-Emb": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Overwrite"
+            ],
+            "id": 208,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#S2020Emb_MD_Src": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Local",
+              "ShufflerOut"
+            ],
+            "id": 209,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-A1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32",
+              "J1Out",
+              "J2Out"
+            ],
+            "id": 118,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-A2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32",
+              "J1Out",
+              "J2Out"
+            ],
+            "id": 120,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-A3": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32",
+              "J1Out",
+              "J2Out"
+            ],
+            "id": 122,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-A4": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32",
+              "J1Out",
+              "J2Out"
+            ],
+            "id": 124,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-B1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32",
+              "J1Out",
+              "J2Out"
+            ],
+            "id": 126,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-B2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32",
+              "J1Out",
+              "J2Out"
+            ],
+            "id": 128,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-B3": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32",
+              "J1Out",
+              "J2Out"
+            ],
+            "id": 130,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-B4": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32",
+              "J1Out",
+              "J2Out"
+            ],
+            "id": 132,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-C1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32",
+              "J1Out",
+              "J2Out"
+            ],
+            "id": 134,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-C2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32",
+              "J1Out",
+              "J2Out"
+            ],
+            "id": 136,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-C3": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32",
+              "J1Out",
+              "J2Out"
+            ],
+            "id": 138,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-C4": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32",
+              "J1Out",
+              "J2Out"
+            ],
+            "id": 140,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-D1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32",
+              "J1Out",
+              "J2Out"
+            ],
+            "id": 142,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-D2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32",
+              "J1Out",
+              "J2Out"
+            ],
+            "id": 144,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-D3": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32",
+              "J1Out",
+              "J2Out"
+            ],
+            "id": 146,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-D4": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32",
+              "J1Out",
+              "J2Out"
+            ],
+            "id": 148,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#Source_lmJ1Ch01": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32"
+            ],
+            "id": 23,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#Source_lmJ1Ch02": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32"
+            ],
+            "id": 25,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#Source_lmJ1Ch03": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32"
+            ],
+            "id": 27,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#Source_lmJ1Ch04": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32"
+            ],
+            "id": 29,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#Source_lmJ1Ch05": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32"
+            ],
+            "id": 31,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#Source_lmJ1Ch06": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32"
+            ],
+            "id": 33,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#Source_lmJ1Ch07": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32"
+            ],
+            "id": 35,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#Source_lmJ1Ch08": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32"
+            ],
+            "id": 37,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#Source_lmJ2Ch01": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32"
+            ],
+            "id": 39,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#Source_lmJ2Ch02": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32"
+            ],
+            "id": 41,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#Source_lmJ2Ch03": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32"
+            ],
+            "id": 43,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#Source_lmJ2Ch04": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32"
+            ],
+            "id": 45,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#Source_lmJ2Ch05": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32"
+            ],
+            "id": 47,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#Source_lmJ2Ch06": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32"
+            ],
+            "id": 49,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#Source_lmJ2Ch07": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32"
+            ],
+            "id": 51,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#Source_lmJ2Ch08": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32"
+            ],
+            "id": 53,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#comp_bypass": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 101,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "On"
+          },
+          "#comp_processing": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Live",
+              "Speech",
+              "Pop",
+              "Uni",
+              "Classic"
+            ],
+            "id": 105,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Live"
+          },
+          "#comp_range": {
+            "access": "RW-",
+            "default": 15,
+            "id": 104,
+            "kind": "int",
+            "max": 20,
+            "min": 0,
+            "step": 1,
+            "unit": "dB",
+            "value": 15
+          },
+          "#comp_ratio": {
+            "access": "RW-",
+            "default": 1,
+            "id": 103,
+            "kind": "float",
+            "max": 4,
+            "min": 1,
+            "step": 1,
+            "value": 1
+          },
+          "#comp_ref_lvl": {
+            "access": "RW-",
+            "default": -24,
+            "id": 102,
+            "kind": "int",
+            "max": 0,
+            "min": -40,
+            "step": 1,
+            "unit": "dBFS",
+            "value": -24
+          },
+          "#exp_bypass": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 97,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "On"
+          },
+          "#exp_range": {
+            "access": "RW-",
+            "default": 10,
+            "id": 99,
+            "kind": "int",
+            "max": 21,
+            "min": 0,
+            "step": 1,
+            "unit": "dB",
+            "value": 10
+          },
+          "#exp_release": {
+            "access": "RW-",
+            "default": 4,
+            "id": 100,
+            "kind": "uint",
+            "max": 9,
+            "min": 0,
+            "step": 1,
+            "value": 4
+          },
+          "#exp_threshold": {
+            "access": "RW-",
+            "default": -60,
+            "id": 98,
+            "kind": "int",
+            "max": -20,
+            "min": -60,
+            "step": 1,
+            "unit": "dBFS",
+            "value": -60
+          },
+          "#lmJ1_Ch01": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 24,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ch_1"
+          },
+          "#lmJ1_Ch02": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 26,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Ch_2"
+          },
+          "#lmJ1_Ch03": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 28,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ch_3"
+          },
+          "#lmJ1_Ch04": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 30,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Ch_4"
+          },
+          "#lmJ1_Ch05": {
+            "access": "RW-",
+            "default": 4,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 32,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "Ch_5"
+          },
+          "#lmJ1_Ch06": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 34,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Ch_6"
+          },
+          "#lmJ1_Ch07": {
+            "access": "RW-",
+            "default": 6,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 36,
+            "kind": "enum",
+            "value": 6,
+            "value_name": "Ch_7"
+          },
+          "#lmJ1_Ch08": {
+            "access": "RW-",
+            "default": 7,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 38,
+            "kind": "enum",
+            "value": 7,
+            "value_name": "Ch_8"
+          },
+          "#lmJ1_control": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "ITU-BS.1770-1 (A/85:2011)",
+              "ITU-BS.1770-2",
+              "ITU-BS.1770-3",
+              "EBU R 128"
+            ],
+            "id": 55,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "ITU-BS.1770-1 (A/85:2011)"
+          },
+          "#lmJ1_linking_01": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Mono",
+              "Stereo"
+            ],
+            "id": 57,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Stereo"
+          },
+          "#lmJ1_linking_02": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Mono",
+              "Stereo"
+            ],
+            "id": 58,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Stereo"
+          },
+          "#lmJ1_linking_03": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Mono",
+              "Stereo"
+            ],
+            "id": 59,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Stereo"
+          },
+          "#lmJ1_linking_04": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Mono",
+              "Stereo"
+            ],
+            "id": 60,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Stereo"
+          },
+          "#lmJ2_Ch01": {
+            "access": "RW-",
+            "default": 8,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 40,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "Ch_9"
+          },
+          "#lmJ2_Ch02": {
+            "access": "RW-",
+            "default": 9,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 42,
+            "kind": "enum",
+            "value": 9,
+            "value_name": "Ch_10"
+          },
+          "#lmJ2_Ch03": {
+            "access": "RW-",
+            "default": 10,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 44,
+            "kind": "enum",
+            "value": 10,
+            "value_name": "Ch_11"
+          },
+          "#lmJ2_Ch04": {
+            "access": "RW-",
+            "default": 11,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 46,
+            "kind": "enum",
+            "value": 11,
+            "value_name": "Ch_12"
+          },
+          "#lmJ2_Ch05": {
+            "access": "RW-",
+            "default": 12,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 48,
+            "kind": "enum",
+            "value": 12,
+            "value_name": "Ch_13"
+          },
+          "#lmJ2_Ch06": {
+            "access": "RW-",
+            "default": 13,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 50,
+            "kind": "enum",
+            "value": 13,
+            "value_name": "Ch_14"
+          },
+          "#lmJ2_Ch07": {
+            "access": "RW-",
+            "default": 14,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 52,
+            "kind": "enum",
+            "value": 14,
+            "value_name": "Ch_15"
+          },
+          "#lmJ2_Ch08": {
+            "access": "RW-",
+            "default": 15,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 54,
+            "kind": "enum",
+            "value": 15,
+            "value_name": "Ch_16"
+          },
+          "#lmJ2_control": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "ITU-BS.1770-1 (A/85:2011)",
+              "ITU-BS.1770-2",
+              "ITU-BS.1770-3",
+              "EBU R 128"
+            ],
+            "id": 69,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "ITU-BS.1770-1 (A/85:2011)"
+          },
+          "#lmJ2_linking_01": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Mono",
+              "Stereo"
+            ],
+            "id": 71,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Stereo"
+          },
+          "#lmJ2_linking_02": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Mono",
+              "Stereo"
+            ],
+            "id": 72,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Stereo"
+          },
+          "#lmJ2_linking_03": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Mono",
+              "Stereo"
+            ],
+            "id": 73,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Stereo"
+          },
+          "#lmJ2_linking_04": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Mono",
+              "Stereo"
+            ],
+            "id": 74,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Stereo"
+          },
+          "#lm_J1_Bypass": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 56,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#lm_J2_Bypass": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 70,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#lm_agc_max_gain": {
+            "access": "RW-",
+            "default": 20,
+            "id": 90,
+            "kind": "int",
+            "max": 20,
+            "min": 0,
+            "step": 1,
+            "unit": "dB",
+            "value": 20
+          },
+          "#lm_agc_recovery": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Normal",
+              "Fast"
+            ],
+            "id": 106,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Normal"
+          },
+          "#lm_agc_time": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "10s",
+              "20s",
+              "40s",
+              "1min",
+              "2min",
+              "5min",
+              "10min"
+            ],
+            "id": 89,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "20s"
+          },
+          "#lm_below_thres": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "release",
+              "hold"
+            ],
+            "id": 109,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "release"
+          },
+          "#lm_freeze_lvl": {
+            "access": "RW-",
+            "default": -50,
+            "id": 91,
+            "kind": "int",
+            "max": 0,
+            "min": -70,
+            "step": 1,
+            "unit": "dBFS",
+            "value": -50
+          },
+          "#lm_init_gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 107,
+            "kind": "float",
+            "max": 15,
+            "min": -40,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#lm_input_gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 86,
+            "kind": "float",
+            "max": 20,
+            "min": -20,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "#lm_leveler_en": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 87,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#lm_limiter_en": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 94,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#lm_max_tpl": {
+            "access": "RW-",
+            "default": 0,
+            "id": 95,
+            "kind": "float",
+            "max": 0,
+            "min": -20,
+            "step": 1,
+            "unit": "dBTP",
+            "value": 0
+          },
+          "#lm_proc_thres": {
+            "access": "RW-",
+            "default": -70,
+            "id": 108,
+            "kind": "int",
+            "max": 0,
+            "min": -70,
+            "step": 1,
+            "unit": "dBFS",
+            "value": -70
+          },
+          "#lm_processing": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Live",
+              "Speech",
+              "Pop",
+              "Uni",
+              "Classic"
+            ],
+            "id": 96,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Live"
+          },
+          "#lm_program_name": {
+            "access": "RW-",
+            "id": 85,
+            "kind": "string",
+            "max_len": 16,
+            "value": "empty string"
+          },
+          "#lm_target_level": {
+            "access": "RW-",
+            "default": -24,
+            "id": 88,
+            "kind": "int",
+            "max": 0,
+            "min": -40,
+            "step": 1,
+            "unit": "LKFS",
+            "value": -24
+          },
+          "#lm_trp_max_gain": {
+            "access": "RW-",
+            "default": 15,
+            "id": 92,
+            "kind": "int",
+            "max": 20,
+            "min": 0,
+            "step": 1,
+            "unit": "dB",
+            "value": 15
+          },
+          "#lm_trp_response": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "soft",
+              "mid",
+              "hard"
+            ],
+            "id": 93,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "soft"
+          },
+          "Active-Preset": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7"
+            ],
+            "id": 19,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Audio-Phase": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Off",
+              "Align"
+            ],
+            "id": 201,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Align"
+          },
+          "AudioStatusBits": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Transparent",
+              "Overwrite"
+            ],
+            "id": 202,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Transparent"
+          },
+          "Control": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Manual",
+              "GPI"
+            ],
+            "id": 16,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Manual"
+          },
+          "Delay-Bypass": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 8,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "Delay-Status": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 14,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "Delay-mode_1": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Time",
+              "Fr-Ln-Px"
+            ],
+            "id": 9,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Fr-Ln-Px"
+          },
+          "EMBEDDING": {
+            "access": "RW-",
+            "id": 111,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "Edit-Preset": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7"
+            ],
+            "id": 20,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "EmbA1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 150,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbA1_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 166,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbA2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 151,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbA2_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 167,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbA3_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 152,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbA3_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 168,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbA4_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 153,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbA4_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 169,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbB1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 154,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbB1_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 170,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbB2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 155,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbB2_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 171,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbB3_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 156,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbB3_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 172,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbB4_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 157,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbB4_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 173,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbC1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 158,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbC1_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 174,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbC2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 159,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbC2_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 175,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbC3_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 160,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbC3_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 176,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbC4_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 161,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbC4_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 177,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbD1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 162,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbD1_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 178,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbD2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 163,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbD2_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 179,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbD3_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 164,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbD3_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 180,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbD4_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 165,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbD4_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 181,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "Ext-Mode": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "GPIO",
+              "Metadata"
+            ],
+            "id": 18,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "GPIO"
+          },
+          "Extract_Ass_Ch": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Auto",
+              "None",
+              "Ch01/02",
+              "Ch03/04",
+              "Ch05/06",
+              "Ch07/08",
+              "Ch09/10",
+              "Ch11/12",
+              "Ch13/14",
+              "Ch15/16"
+            ],
+            "id": 207,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "None"
+          },
+          "Extract_Line": {
+            "access": "RW-",
+            "default": 0,
+            "id": 206,
+            "kind": "int",
+            "max": 1125,
+            "min": 0,
+            "step": 1,
+            "unit": "ln",
+            "value": 0
+          },
+          "F-Delay_1": {
+            "access": "RW-",
+            "default": 1,
+            "id": 11,
+            "kind": "uint",
+            "max": 250,
+            "min": 0,
+            "step": 1,
+            "unit": "F",
+            "value": 1
+          },
+          "Fade-Time": {
+            "access": "RW-",
+            "default": 500,
+            "id": 200,
+            "kind": "int",
+            "max": 10000,
+            "min": 100,
+            "step": 1,
+            "unit": "ms",
+            "value": 500
+          },
+          "GPI-Ctrl": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Latch",
+              "nonLatch",
+              "BCD"
+            ],
+            "id": 17,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Latch"
+          },
+          "H-Delay_1": {
+            "access": "RW-",
+            "default": 0,
+            "id": 13,
+            "kind": "int",
+            "max": 4124,
+            "min": 0,
+            "step": 1,
+            "unit": "px",
+            "value": 0
+          },
+          "Input-Select": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI-1",
+              "SDI-2",
+              "Auto"
+            ],
+            "id": 1,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI-1"
+          },
+          "Insert_Line": {
+            "access": "RW-",
+            "default": 9,
+            "id": 210,
+            "kind": "int",
+            "max": 1125,
+            "min": 1,
+            "step": 1,
+            "unit": "ln",
+            "value": 9
+          },
+          "Insert_Method": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Method B"
+            ],
+            "id": 211,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Method B"
+          },
+          "LOUDNESS PROGRAM": {
+            "access": "R--",
+            "id": 83,
+            "kind": "string",
+            "value": ""
+          },
+          "Lock-Mode": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI1",
+              "SDI2",
+              "Ref1",
+              "Ref2",
+              "Auto-SDI"
+            ],
+            "id": 3,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI1"
+          },
+          "MD_Status_Pgm": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8"
+            ],
+            "id": 214,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "MD_Status_Src": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "SDI",
+              "Local"
+            ],
+            "id": 213,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "MISC": {
+            "access": "RW-",
+            "id": 198,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "NonPCM-Bypass": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 199,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "On"
+          },
+          "Out-Frmt": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Auto",
+              "1080p60",
+              "1080p50",
+              "1080i60",
+              "1080i50",
+              "1080p30",
+              "1080p25",
+              "1080p24",
+              "720p60",
+              "720p50",
+              "SD625",
+              "SD525"
+            ],
+            "id": 4,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Auto"
+          },
+          "PRESET": {
+            "access": "RW-",
+            "id": 15,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "Phaser-Status": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 7,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "Phaser1-Offset": {
+            "access": "RW-",
+            "default": 0,
+            "id": 5,
+            "kind": "int",
+            "max": 4124,
+            "min": 0,
+            "step": 1,
+            "unit": "px",
+            "value": 0
+          },
+          "Phaser2-Offset": {
+            "access": "RW-",
+            "default": 0,
+            "id": 6,
+            "kind": "int",
+            "max": 4124,
+            "min": 0,
+            "step": 1,
+            "unit": "px",
+            "value": 0
+          },
+          "PrstEditView": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Follow Active",
+              "Independent"
+            ],
+            "id": 21,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Follow Active"
+          },
+          "Silence-Level": {
+            "access": "RW-",
+            "default": -60,
+            "id": 203,
+            "kind": "float",
+            "max": -20,
+            "min": -100,
+            "step": 1,
+            "unit": "dBFS",
+            "value": -60
+          },
+          "Silence-Time": {
+            "access": "RW-",
+            "default": 10,
+            "id": 204,
+            "kind": "uint",
+            "max": 255,
+            "min": 1,
+            "step": 1,
+            "unit": "s",
+            "value": 10
+          },
+          "Switch-Back": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 2,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "Time-Delay_1": {
+            "access": "RW-",
+            "default": 40,
+            "id": 10,
+            "kind": "float",
+            "max": 10000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 40
+          },
+          "V-Delay_1": {
+            "access": "RW-",
+            "default": 0,
+            "id": 12,
+            "kind": "int",
+            "max": 1124,
+            "min": 0,
+            "step": 1,
+            "unit": "ln",
+            "value": 0
+          },
+          "VIDEO": {
+            "access": "RW-",
+            "id": 0,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "lm_program": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E",
+              "F",
+              "G",
+              "H",
+              "I",
+              "J",
+              "K",
+              "L",
+              "M",
+              "N",
+              "O",
+              "P"
+            ],
+            "id": 84,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "A"
+          }
+        },
+        "identity": {
+          "3G - Capable": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 19,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Card ID": {
+            "access": "R--",
+            "id": 7,
+            "kind": "string",
+            "max_len": 16,
+            "value": "71ef060a0000001f"
+          },
+          "Card description": {
+            "access": "R--",
+            "id": 2,
+            "kind": "string",
+            "max_len": 16,
+            "value": "GJA840-0101.html"
+          },
+          "Card name": {
+            "access": "R--",
+            "id": 0,
+            "kind": "string",
+            "max_len": 8,
+            "value": "GJA840"
+          },
+          "Card-Status": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Unknown",
+              "Programming",
+              "Card Failed",
+              "Operational"
+            ],
+            "id": 10,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Operational"
+          },
+          "DM-D HW Rev": {
+            "access": "R--",
+            "id": 13,
+            "kind": "string",
+            "max_len": 16,
+            "value": "0102"
+          },
+          "DM-D ID": {
+            "access": "R--",
+            "id": 16,
+            "kind": "string",
+            "max_len": 16,
+            "value": "70D4B23C0005D"
+          },
+          "DM-D Name": {
+            "access": "R--",
+            "id": 12,
+            "kind": "string",
+            "max_len": 16,
+            "value": "AXD469"
+          },
+          "DM-D Pr.code": {
+            "access": "R--",
+            "id": 15,
+            "kind": "string",
+            "max_len": 10,
+            "value": "94603300"
+          },
+          "DM-D SW Rev": {
+            "access": "R--",
+            "id": 17,
+            "kind": "string",
+            "max_len": 16,
+            "value": "0.7"
+          },
+          "DM-D Serial": {
+            "access": "R--",
+            "id": 14,
+            "kind": "string",
+            "max_len": 16,
+            "value": "PR014548"
+          },
+          "Engine J1 4x2.0": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 20,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Engine J1 5.1+2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 21,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Engine J2 4x2.0": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 22,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Engine J2 5.1+2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 23,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Features": {
+            "access": "R--",
+            "id": 9,
+            "kind": "string",
+            "max_len": 8,
+            "value": "00082AF3"
+          },
+          "HD - Capable": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 18,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Hardware rev": {
+            "access": "R--",
+            "id": 4,
+            "kind": "string",
+            "max_len": 4,
+            "value": "0300"
+          },
+          "Junger License": {
+            "access": "R--",
+            "id": 11,
+            "kind": "string",
+            "max_len": 19,
+            "value": "empty string"
+          },
+          "Key": {
+            "access": "RW-",
+            "id": 8,
+            "kind": "string",
+            "max_len": 15,
+            "value": "empty string"
+          },
+          "Product code": {
+            "access": "R--",
+            "id": 5,
+            "kind": "string",
+            "max_len": 10,
+            "value": "9490600011"
+          },
+          "Serial number": {
+            "access": "R--",
+            "id": 6,
+            "kind": "string",
+            "max_len": 16,
+            "value": "PR011608"
+          },
+          "Software rev": {
+            "access": "R--",
+            "id": 3,
+            "kind": "string",
+            "max_len": 4,
+            "value": "0101"
+          },
+          "User label": {
+            "access": "RW-",
+            "id": 1,
+            "kind": "string",
+            "max_len": 16,
+            "value": "Emb Loudness"
+          }
+        },
+        "status": {
+          "ANC-Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Error"
+            ],
+            "id": 20,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "ATC-Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Present",
+              "Error"
+            ],
+            "id": 19,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Active-Out1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "SDI1",
+              "SDI2"
+            ],
+            "id": 16,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI1"
+          },
+          "ActiveProgJ1_1": {
+            "access": "R--",
+            "id": 47,
+            "kind": "string",
+            "max_len": 16,
+            "value": "LoudnessLimiterA"
+          },
+          "ActiveProgJ1_2": {
+            "access": "R--",
+            "id": 48,
+            "kind": "string",
+            "max_len": 16,
+            "value": "LFE_Program"
+          },
+          "ActiveProgJ1_3": {
+            "access": "R--",
+            "id": 49,
+            "kind": "string",
+            "max_len": 16,
+            "value": "NewsLiveC"
+          },
+          "ActiveProgJ1_4": {
+            "access": "R--",
+            "id": 50,
+            "kind": "string",
+            "max_len": 16,
+            "value": ""
+          },
+          "ActiveProgJ1_5": {
+            "access": "R--",
+            "id": 51,
+            "kind": "string",
+            "max_len": 16,
+            "value": "LoudnessLimiterA"
+          },
+          "ActiveProgJ1_6": {
+            "access": "R--",
+            "id": 52,
+            "kind": "string",
+            "max_len": 16,
+            "value": ""
+          },
+          "ActiveProgJ1_7": {
+            "access": "R--",
+            "id": 53,
+            "kind": "string",
+            "max_len": 16,
+            "value": "LoudnessLimiterA"
+          },
+          "ActiveProgJ1_8": {
+            "access": "R--",
+            "id": 54,
+            "kind": "string",
+            "max_len": 16,
+            "value": ""
+          },
+          "ActiveProgJ2_1": {
+            "access": "R--",
+            "id": 55,
+            "kind": "string",
+            "max_len": 16,
+            "value": "LoudnessLimiterA"
+          },
+          "ActiveProgJ2_2": {
+            "access": "R--",
+            "id": 56,
+            "kind": "string",
+            "max_len": 16,
+            "value": ""
+          },
+          "ActiveProgJ2_3": {
+            "access": "R--",
+            "id": 57,
+            "kind": "string",
+            "max_len": 16,
+            "value": "LoudnessLimiterA"
+          },
+          "ActiveProgJ2_4": {
+            "access": "R--",
+            "id": 58,
+            "kind": "string",
+            "max_len": 16,
+            "value": ""
+          },
+          "ActiveProgJ2_5": {
+            "access": "R--",
+            "id": 59,
+            "kind": "string",
+            "max_len": 16,
+            "value": "LoudnessLimiterA"
+          },
+          "ActiveProgJ2_6": {
+            "access": "R--",
+            "id": 60,
+            "kind": "string",
+            "max_len": 16,
+            "value": ""
+          },
+          "ActiveProgJ2_7": {
+            "access": "R--",
+            "id": 61,
+            "kind": "string",
+            "max_len": 16,
+            "value": "LoudnessLimiterA"
+          },
+          "ActiveProgJ2_8": {
+            "access": "R--",
+            "id": 62,
+            "kind": "string",
+            "max_len": 16,
+            "value": ""
+          },
+          "AddOnFrmtIn01/02": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 31,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn03/04": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 32,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn05/06": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 33,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn07/08": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 34,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn09/10": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 35,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn11/12": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 36,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn13/14": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 37,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn15/16": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 38,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn17/18": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 39,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn19/20": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 40,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn21/22": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 41,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn23/24": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 42,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn25/26": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 43,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn27/28": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 44,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn29/30": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 45,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn31/32": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 46,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "CRC-Stat_1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "OK",
+              "CRC Error"
+            ],
+            "id": 6,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "OK"
+          },
+          "CRC-Stat_2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "OK",
+              "CRC Error"
+            ],
+            "id": 7,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "OK"
+          },
+          "DM-D_Status": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Error"
+            ],
+            "id": 126,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "DM-D_Type": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "AXD469"
+            ],
+            "id": 127,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtIn01/02": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 23,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtIn03/04": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 24,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtIn05/06": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 25,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtIn07/08": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 26,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtIn09/10": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 27,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtIn11/12": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 28,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtIn13/14": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 29,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtIn15/16": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 30,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutA1/2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 79,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutA3/4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 80,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutB1/2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 81,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutB3/4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 82,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutC1/2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 83,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutC3/4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 84,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutD1/2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 85,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutD3/4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 86,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutA1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 63,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutA2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 64,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutA3": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 65,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutA4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 66,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutB1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 67,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutB2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 68,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutB3": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 69,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutB4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 70,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutC1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 71,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutC2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 72,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutC3": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 73,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutC4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 74,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutD1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 75,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutD2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 76,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutD3": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 77,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutD4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 78,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "FPGA-Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "OK",
+              "Error"
+            ],
+            "id": 125,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "OK"
+          },
+          "GPI": {
+            "access": "R--",
+            "default": 1,
+            "id": 18,
+            "kind": "int",
+            "max": 7,
+            "min": 0,
+            "step": 1,
+            "value": 1
+          },
+          "Grp-Ins": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Error"
+            ],
+            "id": 22,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "GrpInUse": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "____",
+              "1___",
+              "_2__",
+              "12__",
+              "__3_",
+              "1_3_",
+              "_23_",
+              "123_",
+              "___4",
+              "1__4",
+              "_2_4",
+              "12_4",
+              "__34",
+              "1_34",
+              "_234",
+              "1234"
+            ],
+            "id": 21,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "____"
+          },
+          "IO-Delay_1": {
+            "access": "R--",
+            "default": 0,
+            "id": 17,
+            "kind": "float",
+            "max": 10000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "LocMetaProg": {
+            "access": "R--",
+            "default": 11,
+            "enum_items": [
+              "5.1+2",
+              "5.1+1+1",
+              "4+4",
+              "4x2",
+              "8x1",
+              "5.1",
+              "3x2",
+              "4",
+              "2+2",
+              "7.1",
+              "Other",
+              "NA"
+            ],
+            "id": 91,
+            "kind": "enum",
+            "value": 11,
+            "value_name": "NA"
+          },
+          "LocMetaStat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Error"
+            ],
+            "id": 90,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Locked-To": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "Not Locked",
+              "Ref",
+              "SDI1",
+              "SDI2"
+            ],
+            "id": 15,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Not Locked"
+          },
+          "MD AC3Copyright": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "No",
+              "Yes",
+              "NA"
+            ],
+            "id": 107,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD AC3Datarate": {
+            "access": "R--",
+            "default": 0,
+            "id": 95,
+            "kind": "int",
+            "max": 640,
+            "min": 0,
+            "step": 1,
+            "unit": "kbps",
+            "value": 0
+          },
+          "MD AC3OrigBitstr": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "No",
+              "Yes",
+              "NA"
+            ],
+            "id": 108,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD ADConvType": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "Standard",
+              "HDCD",
+              "NA"
+            ],
+            "id": 116,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD AudioProdInfo": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "NA"
+            ],
+            "id": 104,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD Bitstream": {
+            "access": "R--",
+            "default": 8,
+            "enum_items": [
+              "Complete",
+              "M\u0026E",
+              "Visual",
+              "Hearing",
+              "Dialogue",
+              "Commentary",
+              "Emergency",
+              "VO_Karaoke",
+              "NA"
+            ],
+            "id": 96,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "NA"
+          },
+          "MD CenterMixLvl": {
+            "access": "R--",
+            "default": 3,
+            "enum_items": [
+              "-3.0dB",
+              "-4.5dB",
+              "-6.0dB",
+              "NA"
+            ],
+            "id": 98,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "NA"
+          },
+          "MD ChannelMode": {
+            "access": "R--",
+            "default": 7,
+            "enum_items": [
+              "1/0(C)",
+              "2/0(L-R)",
+              "3/0(L-C-R)",
+              "2/1(L-R-S)",
+              "3/1(L-C-R-S)",
+              "2/2(L-R-Ls-Rs)",
+              "3/2(L-C-R-Ls-Rs)",
+              "NA"
+            ],
+            "id": 97,
+            "kind": "enum",
+            "value": 7,
+            "value_name": "NA"
+          },
+          "MD DC Filter": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "NA"
+            ],
+            "id": 117,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD D_HeadPhone": {
+            "access": "R--",
+            "default": 4,
+            "enum_items": [
+              "Not Indic.",
+              "Not_Headph",
+              "Headph",
+              "Rsvd",
+              "NA"
+            ],
+            "id": 115,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "NA"
+          },
+          "MD D_Surnd": {
+            "access": "R--",
+            "default": 4,
+            "enum_items": [
+              "Not Indic.",
+              "Not_Srnd",
+              "Srnd",
+              "Rsvd",
+              "NA"
+            ],
+            "id": 100,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "NA"
+          },
+          "MD D_Surnd EX": {
+            "access": "R--",
+            "default": 4,
+            "enum_items": [
+              "Not Indic.",
+              "Not_Srnd",
+              "Srnd",
+              "Rsvd",
+              "NA"
+            ],
+            "id": 114,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "NA"
+          },
+          "MD Dialog Lvl": {
+            "access": "R--",
+            "default": 0,
+            "id": 102,
+            "kind": "int",
+            "max": 0,
+            "min": -31,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "MD FrameRate": {
+            "access": "R--",
+            "default": 5,
+            "enum_items": [
+              "23.98",
+              "24",
+              "25",
+              "29.97",
+              "30",
+              "NA"
+            ],
+            "id": 93,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "NA"
+          },
+          "MD LFE": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "NA"
+            ],
+            "id": 101,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD LFE Filter": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "NA"
+            ],
+            "id": 119,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD LanguageCode": {
+            "access": "R--",
+            "default": 0,
+            "id": 103,
+            "kind": "uint",
+            "max": 127,
+            "min": 0,
+            "step": 1,
+            "value": 0
+          },
+          "MD Line Mode": {
+            "access": "R--",
+            "default": 7,
+            "enum_items": [
+              "None",
+              "FilmStandard",
+              "FilmLight",
+              "MusicStandard",
+              "MusicLight",
+              "Speech",
+              "Rsvd",
+              "NA"
+            ],
+            "id": 124,
+            "kind": "enum",
+            "value": 7,
+            "value_name": "NA"
+          },
+          "MD Lo/RoCDwnmx": {
+            "access": "R--",
+            "default": 8,
+            "enum_items": [
+              "+3.0dB",
+              "+1.5dB",
+              "0.0dB",
+              "-1.5dB",
+              "-3.0dB",
+              "-4.5dB",
+              "-6.0dB",
+              "-999dB",
+              "NA"
+            ],
+            "id": 112,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "NA"
+          },
+          "MD Lo/RoSDwnmx": {
+            "access": "R--",
+            "default": 8,
+            "enum_items": [
+              "+3.0dB",
+              "+1.5dB",
+              "0.0dB",
+              "-1.5dB",
+              "-3.0dB",
+              "-4.5dB",
+              "-6.0dB",
+              "-999dB",
+              "NA"
+            ],
+            "id": 113,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "NA"
+          },
+          "MD Lowpass Fil": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "NA"
+            ],
+            "id": 118,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD Lt/RtCDwnmx": {
+            "access": "R--",
+            "default": 8,
+            "enum_items": [
+              "+3.0dB",
+              "+1.5dB",
+              "0.0dB",
+              "-1.5dB",
+              "-3.0dB",
+              "-4.5dB",
+              "-6.0dB",
+              "-999dB",
+              "NA"
+            ],
+            "id": 110,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "NA"
+          },
+          "MD Lt/RtSDwnmx": {
+            "access": "R--",
+            "default": 8,
+            "enum_items": [
+              "+3.0dB",
+              "+1.5dB",
+              "0.0dB",
+              "-1.5dB",
+              "-3.0dB",
+              "-4.5dB",
+              "-6.0dB",
+              "-999dB",
+              "NA"
+            ],
+            "id": 111,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "NA"
+          },
+          "MD Pref. Dwnmx": {
+            "access": "R--",
+            "default": 4,
+            "enum_items": [
+              "Not Indic.",
+              "Lt/Rt",
+              "Lo/Ro",
+              "Rsvd",
+              "NA"
+            ],
+            "id": 109,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "NA"
+          },
+          "MD Prgm Config": {
+            "access": "R--",
+            "default": 12,
+            "enum_items": [
+              "5.1+2",
+              "5.1+1+1",
+              "4+4",
+              "4x2",
+              "8x1",
+              "5.1",
+              "3x2",
+              "4",
+              "2+2",
+              "7.1",
+              "Rsvd",
+              "Other",
+              "NA"
+            ],
+            "id": 92,
+            "kind": "enum",
+            "value": 12,
+            "value_name": "NA"
+          },
+          "MD ProdMixLvl": {
+            "access": "R--",
+            "default": 0,
+            "id": 105,
+            "kind": "int",
+            "max": 111,
+            "min": 0,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "MD ProdRoomType": {
+            "access": "R--",
+            "default": 4,
+            "enum_items": [
+              "Not Indic.",
+              "Large",
+              "Small",
+              "Rsvd",
+              "NA"
+            ],
+            "id": 106,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "NA"
+          },
+          "MD ProgramText": {
+            "access": "R--",
+            "id": 94,
+            "kind": "string",
+            "max_len": 12,
+            "value": ""
+          },
+          "MD RF Mode": {
+            "access": "R--",
+            "default": 7,
+            "enum_items": [
+              "None",
+              "FilmStandard",
+              "FilmLight",
+              "MusicStandard",
+              "MusicLight",
+              "Speech",
+              "Rsvd",
+              "NA"
+            ],
+            "id": 123,
+            "kind": "enum",
+            "value": 7,
+            "value_name": "NA"
+          },
+          "MD RFPreEmph": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "NA"
+            ],
+            "id": 122,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD SrndMixLvl": {
+            "access": "R--",
+            "default": 3,
+            "enum_items": [
+              "-3.0dB",
+              "-6.0dB",
+              "-999dB",
+              "NA"
+            ],
+            "id": 99,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "NA"
+          },
+          "MD Sur Phshift": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "NA"
+            ],
+            "id": 120,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD Sur3dB Att": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "NA"
+            ],
+            "id": 121,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "Mode_J1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "Bypass",
+              "5.1+2",
+              "4x2.0"
+            ],
+            "id": 128,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Bypass"
+          },
+          "Mode_J2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "Bypass",
+              "5.1+2",
+              "4x2.0"
+            ],
+            "id": 129,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Bypass"
+          },
+          "Phaser1_H_Pos": {
+            "access": "R--",
+            "default": 0,
+            "id": 9,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "px",
+            "value": 0
+          },
+          "Phaser1_Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Safe",
+              "Warning",
+              "Critical"
+            ],
+            "id": 11,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Phaser2_H_Pos": {
+            "access": "R--",
+            "default": 0,
+            "id": 10,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "px",
+            "value": 0
+          },
+          "Phaser2_Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Safe",
+              "Warning",
+              "Critical"
+            ],
+            "id": 12,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Ref-Format": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "NTSC/480i",
+              "PAL/576i",
+              "480p",
+              "576p",
+              "720p",
+              "1080i",
+              "1080p"
+            ],
+            "id": 8,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "S2020-Src_Ass_Ch": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "None",
+              "Ch01/02",
+              "Ch03/04",
+              "Ch05/06",
+              "Ch07/08",
+              "Ch09/10",
+              "Ch11/12",
+              "Ch13/14",
+              "Ch15/16"
+            ],
+            "id": 88,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "SDI-Freq_1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "1:1",
+              "1:1.001"
+            ],
+            "id": 4,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "SDI-Freq_2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "1:1",
+              "1:1.001"
+            ],
+            "id": 5,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "SDI-Input_1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "1080p60",
+              "1080p50",
+              "1080p30",
+              "1080p25",
+              "1080p24",
+              "1080i50",
+              "1080i60",
+              "720p60",
+              "720p50",
+              "SD625",
+              "SD525"
+            ],
+            "id": 0,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "SDI-Input_2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "1080p60",
+              "1080p50",
+              "1080p30",
+              "1080p25",
+              "1080p24",
+              "1080i50",
+              "1080i60",
+              "720p60",
+              "720p50",
+              "SD625",
+              "SD525"
+            ],
+            "id": 1,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "SDI-Map_1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Level A",
+              "Level B"
+            ],
+            "id": 2,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "SDI-Map_2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Level A",
+              "Level B"
+            ],
+            "id": 3,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "SDI1-Ref_Offset": {
+            "access": "R--",
+            "default": 0,
+            "id": 13,
+            "kind": "float",
+            "max": 40000,
+            "min": 0,
+            "step": 1,
+            "unit": "us",
+            "value": 0
+          },
+          "SDI2-Ref_Offset": {
+            "access": "R--",
+            "default": 0,
+            "id": 14,
+            "kind": "float",
+            "max": 40000,
+            "min": 0,
+            "step": 1,
+            "unit": "us",
+            "value": 0
+          },
+          "SDIS2020Prog": {
+            "access": "R--",
+            "default": 11,
+            "enum_items": [
+              "5.1+2",
+              "5.1+1+1",
+              "4+4",
+              "4x2",
+              "8x1",
+              "5.1",
+              "3x2",
+              "4",
+              "2+2",
+              "7.1",
+              "Other",
+              "NA"
+            ],
+            "id": 89,
+            "kind": "enum",
+            "value": 11,
+            "value_name": "NA"
+          },
+          "SDIS2020Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Error"
+            ],
+            "id": 87,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          }
+        }
+      },
+      "slot": 16,
+      "status": "present",
+      "walked_at": "2026-05-05T10:21:45Z"
+    }
+  ]
+}

--- a/tests/fixtures/products/axon/synapse/HPD130-2120/acp1/slot_13.json
+++ b/tests/fixtures/products/axon/synapse/HPD130-2120/acp1/slot_13.json
@@ -1,0 +1,5984 @@
+{
+  "created_at": "2026-05-05T10:21:45Z",
+  "device": {
+    "ip": "10.6.239.113",
+    "port": 2071,
+    "protocol": "acp1",
+    "protocol_version": 1,
+    "num_slots": 31
+  },
+  "generator": "acp dev",
+  "slots": [
+    {
+      "objects": {
+        "alarm": {
+          "Announcements": {
+            "access": "RW-",
+            "id": 0,
+            "kind": "alarm",
+            "value": 1
+          },
+          "CRC-Status1": {
+            "access": "RW-",
+            "id": 3,
+            "kind": "alarm",
+            "value": 0
+          },
+          "CRC-Status2": {
+            "access": "RW-",
+            "id": 4,
+            "kind": "alarm",
+            "value": 0
+          },
+          "Input1": {
+            "access": "RW-",
+            "id": 1,
+            "kind": "alarm",
+            "value": 0
+          },
+          "Input2": {
+            "access": "RW-",
+            "id": 2,
+            "kind": "alarm",
+            "value": 0
+          },
+          "Lock-Status": {
+            "access": "RW-",
+            "id": 6,
+            "kind": "alarm",
+            "value": 0
+          },
+          "Ref-Status": {
+            "access": "RW-",
+            "id": 5,
+            "kind": "alarm",
+            "value": 0
+          }
+        },
+        "control": {
+          "   EMB AUDIO OUT": {
+            "access": "R--",
+            "id": 92,
+            "kind": "string",
+            "value": ""
+          },
+          "  DELAY": {
+            "access": "R--",
+            "id": 8,
+            "kind": "string",
+            "value": ""
+          },
+          "  DOLBY ENCODER": {
+            "access": "R--",
+            "id": 30,
+            "kind": "string",
+            "value": ""
+          },
+          "  METADATA": {
+            "access": "R--",
+            "id": 188,
+            "kind": "string",
+            "value": ""
+          },
+          "  S2020": {
+            "access": "R--",
+            "id": 180,
+            "kind": "string",
+            "value": ""
+          },
+          " METADATA PROG": {
+            "access": "R--",
+            "id": 206,
+            "kind": "string",
+            "value": ""
+          },
+          "#AC3Copyright": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "No",
+              "Yes",
+              "Ext_Meta"
+            ],
+            "id": 223,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ext_Meta"
+          },
+          "#AC3Datarate": {
+            "access": "RW-",
+            "default": 19,
+            "enum_items": [
+              "32",
+              "40",
+              "48",
+              "56",
+              "64",
+              "80",
+              "96",
+              "112",
+              "128",
+              "160",
+              "192",
+              "224",
+              "256",
+              "320",
+              "384",
+              "448",
+              "512",
+              "576",
+              "640",
+              "Ext_Meta"
+            ],
+            "id": 211,
+            "kind": "enum",
+            "value": 19,
+            "value_name": "Ext_Meta"
+          },
+          "#AC3OrigBitstr": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "No",
+              "Yes",
+              "Ext_Meta"
+            ],
+            "id": 229,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ext_Meta"
+          },
+          "#ADConvType": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Standard",
+              "HDCD",
+              "Ext_Meta"
+            ],
+            "id": 236,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ext_Meta"
+          },
+          "#AudioProdInfo": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "Ext_Meta"
+            ],
+            "id": 224,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ext_Meta"
+          },
+          "#Bitstrm": {
+            "access": "RW-",
+            "default": 8,
+            "enum_items": [
+              "Complete",
+              "M\u0026E",
+              "Visual",
+              "Hearing",
+              "Dialogue",
+              "Commentary",
+              "Emergency",
+              "VO_Karaoke",
+              "Ext_Meta"
+            ],
+            "id": 212,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "Ext_Meta"
+          },
+          "#CenterMixLvl": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "-3.0dB",
+              "-4.5dB",
+              "-6.0dB",
+              "Ext_Meta"
+            ],
+            "id": 214,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Ext_Meta"
+          },
+          "#Ch_Mode": {
+            "access": "RW-",
+            "default": 7,
+            "enum_items": [
+              "1/0(C)",
+              "2/0(L-R)",
+              "3/0(L-C-R)",
+              "2/1(L-R-S)",
+              "3/1(L-C-R-S)",
+              "2/2(L-R-Ls-Rs)",
+              "3/2(L-C-R-Ls-Rs)",
+              "Ext_Meta"
+            ],
+            "id": 213,
+            "kind": "enum",
+            "value": 7,
+            "value_name": "Ext_Meta"
+          },
+          "#DC_filter": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "Ext_Meta"
+            ],
+            "id": 237,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ext_Meta"
+          },
+          "#D_HeadPhone": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Not Indic.",
+              "Not_Headph",
+              "Headph",
+              "Ext_Meta"
+            ],
+            "id": 235,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Ext_Meta"
+          },
+          "#D_Srnd": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Not Indic.",
+              "Not_Srnd",
+              "Srnd",
+              "Ext_Meta"
+            ],
+            "id": 216,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Ext_Meta"
+          },
+          "#Dialogue_Lev": {
+            "access": "RW-",
+            "default": -27,
+            "id": 219,
+            "kind": "int",
+            "max": -1,
+            "min": -31,
+            "step": 1,
+            "unit": "dB",
+            "value": -27
+          },
+          "#Dialogue_Src": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Ext_Meta",
+              "Int_Meta"
+            ],
+            "id": 218,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ext_Meta"
+          },
+          "#Dolby_Srnd EX": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Not Indic.",
+              "Not_Srnd",
+              "Srnd",
+              "Ext_Meta"
+            ],
+            "id": 234,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Ext_Meta"
+          },
+          "#Emb-A1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 94,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ch_1"
+          },
+          "#Emb-A2": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 96,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Ch_2"
+          },
+          "#Emb-A3": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 98,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ch_3"
+          },
+          "#Emb-A4": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 100,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Ch_4"
+          },
+          "#Emb-B1": {
+            "access": "RW-",
+            "default": 4,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 102,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "Ch_5"
+          },
+          "#Emb-B2": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 104,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Ch_6"
+          },
+          "#Emb-B3": {
+            "access": "RW-",
+            "default": 6,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 106,
+            "kind": "enum",
+            "value": 6,
+            "value_name": "Ch_7"
+          },
+          "#Emb-B4": {
+            "access": "RW-",
+            "default": 7,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 108,
+            "kind": "enum",
+            "value": 7,
+            "value_name": "Ch_8"
+          },
+          "#Emb-C1": {
+            "access": "RW-",
+            "default": 8,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 110,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "Ch_9"
+          },
+          "#Emb-C2": {
+            "access": "RW-",
+            "default": 9,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 112,
+            "kind": "enum",
+            "value": 9,
+            "value_name": "Ch_10"
+          },
+          "#Emb-C3": {
+            "access": "RW-",
+            "default": 10,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 114,
+            "kind": "enum",
+            "value": 10,
+            "value_name": "Ch_11"
+          },
+          "#Emb-C4": {
+            "access": "RW-",
+            "default": 11,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 116,
+            "kind": "enum",
+            "value": 11,
+            "value_name": "Ch_12"
+          },
+          "#Emb-D1": {
+            "access": "RW-",
+            "default": 12,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 118,
+            "kind": "enum",
+            "value": 12,
+            "value_name": "Ch_13"
+          },
+          "#Emb-D2": {
+            "access": "RW-",
+            "default": 13,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 120,
+            "kind": "enum",
+            "value": 13,
+            "value_name": "Ch_14"
+          },
+          "#Emb-D3": {
+            "access": "RW-",
+            "default": 14,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 122,
+            "kind": "enum",
+            "value": 14,
+            "value_name": "Ch_15"
+          },
+          "#Emb-D4": {
+            "access": "RW-",
+            "default": 15,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 124,
+            "kind": "enum",
+            "value": 15,
+            "value_name": "Ch_16"
+          },
+          "#Emb-Mode": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Off",
+              "Append",
+              "Overwrite"
+            ],
+            "id": 87,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Overwrite"
+          },
+          "#EmbA1_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 157,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbA2_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 158,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbA3_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 159,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbA4_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 160,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbB1_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 161,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbB2_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 162,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbB3_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 163,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbB4_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 164,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbC1_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 165,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbC2_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 166,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbC3_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 167,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbC4_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 168,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbD1_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 169,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbD2_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 170,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbD3_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 171,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbD4_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 172,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#Emb_A_Sel": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Group1",
+              "Group2",
+              "Group3",
+              "Group4",
+              "Off"
+            ],
+            "id": 88,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Group1"
+          },
+          "#Emb_B_Sel": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Group1",
+              "Group2",
+              "Group3",
+              "Group4",
+              "Off"
+            ],
+            "id": 89,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Group2"
+          },
+          "#Emb_C_Sel": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Group1",
+              "Group2",
+              "Group3",
+              "Group4",
+              "Off"
+            ],
+            "id": 90,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Group3"
+          },
+          "#Emb_D_Sel": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Group1",
+              "Group2",
+              "Group3",
+              "Group4",
+              "Off"
+            ],
+            "id": 91,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Group4"
+          },
+          "#Enc_MD_Src": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Local",
+              "ShufflerOut"
+            ],
+            "id": 47,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#Enc_config": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "2",
+              "2+2",
+              "2+2+2",
+              "2+2+2+2",
+              "5.1",
+              "5.1+2",
+              "5.1+2+PL.0",
+              "5.1+2+PL.1",
+              "TC",
+              "2orTC",
+              "2+2orTC",
+              "5.1orTC"
+            ],
+            "id": 48,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "5.1+2"
+          },
+          "#EncoderIn01": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 32,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ch_1"
+          },
+          "#EncoderIn02": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 34,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Ch_2"
+          },
+          "#EncoderIn03": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 36,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ch_3"
+          },
+          "#EncoderIn04": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 38,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Ch_4"
+          },
+          "#EncoderIn05": {
+            "access": "RW-",
+            "default": 4,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 40,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "Ch_5"
+          },
+          "#EncoderIn06": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 44,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Ch_6"
+          },
+          "#EncoderIn07": {
+            "access": "RW-",
+            "default": 6,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 42,
+            "kind": "enum",
+            "value": 6,
+            "value_name": "Ch_7"
+          },
+          "#EncoderIn08": {
+            "access": "RW-",
+            "default": 7,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 46,
+            "kind": "enum",
+            "value": 7,
+            "value_name": "Ch_8"
+          },
+          "#FrameRate": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "23.98",
+              "24",
+              "25",
+              "29.97",
+              "30",
+              "Ext_Meta"
+            ],
+            "id": 201,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Ext_Meta"
+          },
+          "#Insert_Ass_Ch": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "None",
+              "Ch01/02",
+              "Ch03/04",
+              "Ch05/06",
+              "Ch07/08",
+              "Ch09/10",
+              "Ch11/12",
+              "Ch13/14",
+              "Ch15/16"
+            ],
+            "id": 187,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "None"
+          },
+          "#LFE": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "Ext_Meta"
+            ],
+            "id": 217,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ext_Meta"
+          },
+          "#LFE_Filter": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "Ext_Meta"
+            ],
+            "id": 228,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ext_Meta"
+          },
+          "#LanguageCode": {
+            "access": "RW-",
+            "default": 0,
+            "id": 222,
+            "kind": "uint",
+            "max": 127,
+            "min": 0,
+            "step": 1,
+            "value": 0
+          },
+          "#Language_Src": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Ext_Meta",
+              "Int_Meta"
+            ],
+            "id": 221,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ext_Meta"
+          },
+          "#Line": {
+            "access": "RW-",
+            "default": 6,
+            "enum_items": [
+              "None",
+              "FilmStandard",
+              "FilmLight",
+              "MusicStandard",
+              "MusicLight",
+              "Speech",
+              "Ext_Meta"
+            ],
+            "id": 243,
+            "kind": "enum",
+            "value": 6,
+            "value_name": "Ext_Meta"
+          },
+          "#Lo/Ro_C_Dwnmx": {
+            "access": "RW-",
+            "default": 8,
+            "enum_items": [
+              "+3.0dB",
+              "+1.5dB",
+              "0.0dB",
+              "-1.5dB",
+              "-3.0dB",
+              "-4.5dB",
+              "-6.0dB",
+              "-999dB",
+              "Ext_Meta"
+            ],
+            "id": 232,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "Ext_Meta"
+          },
+          "#Lo/Ro_S_Dwnmx": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "-1.5dB",
+              "-3.0dB",
+              "-4.5dB",
+              "-6.0dB",
+              "-999dB",
+              "Ext_Meta"
+            ],
+            "id": 233,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Ext_Meta"
+          },
+          "#LocalOut_MD_Src": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Local",
+              "ShufflerOut"
+            ],
+            "id": 189,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#Lowpass_Filter": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "Ext_Meta"
+            ],
+            "id": 238,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ext_Meta"
+          },
+          "#Lt/Rt_C_Dwnmx": {
+            "access": "RW-",
+            "default": 8,
+            "enum_items": [
+              "+3.0dB",
+              "+1.5dB",
+              "0.0dB",
+              "-1.5dB",
+              "-3.0dB",
+              "-4.5dB",
+              "-6.0dB",
+              "-999dB",
+              "Ext_Meta"
+            ],
+            "id": 231,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "Ext_Meta"
+          },
+          "#Lt/Rt_S_Dwnmx": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "-1.5dB",
+              "-3.0dB",
+              "-4.5dB",
+              "-6.0dB",
+              "-999dB",
+              "Ext_Meta"
+            ],
+            "id": 220,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Ext_Meta"
+          },
+          "#MD_Preset_Name": {
+            "access": "RW-",
+            "id": 199,
+            "kind": "string",
+            "max_len": 16,
+            "value": "empty string"
+          },
+          "#MD_Prog_1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E",
+              "F",
+              "G",
+              "H",
+              "Ext"
+            ],
+            "id": 202,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "A"
+          },
+          "#MD_Prog_2": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E",
+              "F",
+              "G",
+              "H",
+              "Ext"
+            ],
+            "id": 203,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "B"
+          },
+          "#MD_Prog_3": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E",
+              "F",
+              "G",
+              "H",
+              "Ext"
+            ],
+            "id": 204,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "C"
+          },
+          "#MD_Prog_4": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E",
+              "F",
+              "G",
+              "H",
+              "Ext"
+            ],
+            "id": 205,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "D"
+          },
+          "#MD_Prog_Type": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "1 Ch",
+              "2 Ch",
+              "4 Ch",
+              "5.1 Ch"
+            ],
+            "id": 208,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "5.1 Ch"
+          },
+          "#Pref_Dwnmx": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Not Indic.",
+              "Lt/Rt",
+              "Lo/Ro",
+              "Ext_Meta"
+            ],
+            "id": 230,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Ext_Meta"
+          },
+          "#Preset_Name": {
+            "access": "RW-",
+            "id": 28,
+            "kind": "string",
+            "max_len": 16,
+            "value": ""
+          },
+          "#ProdMixLvl": {
+            "access": "RW-",
+            "default": 80,
+            "id": 226,
+            "kind": "int",
+            "max": 111,
+            "min": 80,
+            "step": 1,
+            "unit": "dB",
+            "value": 80
+          },
+          "#ProdMixLvl_Src": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Ext_Meta",
+              "Int_Meta"
+            ],
+            "id": 225,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ext_Meta"
+          },
+          "#ProdRoomType": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Not Indic.",
+              "Large",
+              "Small",
+              "Ext_Meta"
+            ],
+            "id": 227,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Ext_Meta"
+          },
+          "#ProgramConfig": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "7.1",
+              "5.1+2",
+              "5.1",
+              "4x2",
+              "3x2",
+              "2+2",
+              "Ext_Meta"
+            ],
+            "id": 200,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "5.1+2"
+          },
+          "#ProgramText": {
+            "access": "RW-",
+            "id": 210,
+            "kind": "string",
+            "max_len": 12,
+            "value": "empty string"
+          },
+          "#ProgramText_Src": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Ext_Meta",
+              "Int_Meta"
+            ],
+            "id": 209,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ext_Meta"
+          },
+          "#RFPreEmph": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "Ext_Meta"
+            ],
+            "id": 241,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ext_Meta"
+          },
+          "#RfMode": {
+            "access": "RW-",
+            "default": 6,
+            "enum_items": [
+              "None",
+              "FilmStandard",
+              "FilmLight",
+              "MusicStandard",
+              "MusicLight",
+              "Speech",
+              "Ext_Meta"
+            ],
+            "id": 242,
+            "kind": "enum",
+            "value": 6,
+            "value_name": "Ext_Meta"
+          },
+          "#S2020-Emb": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Overwrite"
+            ],
+            "id": 183,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#S2020Emb_MD_Src": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Local",
+              "ShufflerOut"
+            ],
+            "id": 184,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#Shuffler_MD_Src": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Local"
+            ],
+            "id": 190,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-A1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 93,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-A2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 95,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-A3": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 97,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-A4": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 99,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-B1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 101,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-B2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 103,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-B3": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 105,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-B4": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 107,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-C1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 109,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-C2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 111,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-C3": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 113,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-C4": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 115,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-D1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 117,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-D2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 119,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-D3": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 121,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEmb-D4": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "EncoderOut",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 123,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "#SourceEncoder01": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 31,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Addon01/16"
+          },
+          "#SourceEncoder02": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 33,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Addon01/16"
+          },
+          "#SourceEncoder03": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 35,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Addon01/16"
+          },
+          "#SourceEncoder04": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 37,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Addon01/16"
+          },
+          "#SourceEncoder05": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 39,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Addon01/16"
+          },
+          "#SourceEncoder06": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 43,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Addon01/16"
+          },
+          "#SourceEncoder07": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 41,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Addon01/16"
+          },
+          "#SourceEncoder08": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "SDI",
+              "Addon01/16",
+              "Addon17/32",
+              "AudioDescrOut"
+            ],
+            "id": 45,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Addon01/16"
+          },
+          "#SrndMixLvl": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "-3.0dB",
+              "-6.0dB",
+              "-999dB",
+              "Ext_Meta"
+            ],
+            "id": 215,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Ext_Meta"
+          },
+          "#Srnd_3dB_Atten": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "Ext_Meta"
+            ],
+            "id": 240,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ext_Meta"
+          },
+          "#Srnd_Ph_Shift": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "Ext_Meta"
+            ],
+            "id": 239,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ext_Meta"
+          },
+          "AD": {
+            "access": "RW-",
+            "default": 16,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 76,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "Off"
+          },
+          "AD-Loss": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Off",
+              "1/2-\u003e3/4",
+              "3/4-\u003e1/2",
+              "Mute-1/2",
+              "Mute-3/4"
+            ],
+            "id": 70,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "1/2-\u003e3/4"
+          },
+          "ADControl": {
+            "access": "RW-",
+            "default": 16,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 78,
+            "kind": "enum",
+            "value": 16,
+            "value_name": "Off"
+          },
+          "ADControl_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 85,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "ADProg1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 72,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ch_1"
+          },
+          "ADProg1_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 82,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "ADProg1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 79,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "ADProg2": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 74,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Ch_2"
+          },
+          "ADProg2_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 83,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "ADProg2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 80,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "AD_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 84,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "AD_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 81,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "AUDIODESCRIPTION": {
+            "access": "R--",
+            "id": 69,
+            "kind": "string",
+            "value": ""
+          },
+          "Active-Preset": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14"
+            ],
+            "id": 26,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Audio-Phase": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Off",
+              "Align"
+            ],
+            "id": 176,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Align"
+          },
+          "AudioStatusBits": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Transparent",
+              "Overwrite"
+            ],
+            "id": 177,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Transparent"
+          },
+          "Control": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Manual",
+              "GPI",
+              "LossDetect",
+              "GPI+LossDetect"
+            ],
+            "id": 17,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Manual"
+          },
+          "Delay-Bypass": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 9,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "Delay-Status": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 15,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "Delay-mode_1": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Time",
+              "Fr-Ln-Px"
+            ],
+            "id": 10,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Fr-Ln-Px"
+          },
+          "Detect": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Preset 1",
+              "Preset 2",
+              "Preset 3",
+              "Preset 4",
+              "Preset 5",
+              "Preset 6",
+              "Preset 7",
+              "S2020-SDID",
+              "ProgramConfig",
+              "Previous"
+            ],
+            "id": 22,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "Detect_2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Preset 1",
+              "Preset 2",
+              "Preset 3",
+              "Preset 4",
+              "Preset 5",
+              "Preset 6",
+              "Preset 7",
+              "S2020-SDID",
+              "ProgramConfig"
+            ],
+            "id": 25,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "EMBEDDING": {
+            "access": "RW-",
+            "id": 86,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "Edit-Preset": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14"
+            ],
+            "id": 27,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "EmbA1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 125,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbA1_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 141,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbA2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 126,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbA2_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 142,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbA3_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 127,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbA3_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 143,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbA4_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 128,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbA4_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 144,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbB1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 129,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbB1_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 145,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbB2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 130,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbB2_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 146,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbB3_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 131,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbB3_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 147,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbB4_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 132,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbB4_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 148,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbC1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 133,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbC1_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 149,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbC2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 134,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbC2_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 150,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbC3_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 135,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbC3_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 151,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbC4_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 136,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbC4_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 152,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbD1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 137,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbD1_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 153,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbD2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 138,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbD2_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 154,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbD3_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 139,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbD3_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 155,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbD4_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 140,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbD4_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 156,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "Enc1_DDPlus_Man": {
+            "access": "RW-",
+            "default": 256,
+            "id": 57,
+            "kind": "int",
+            "max": 1532,
+            "min": 32,
+            "step": 1,
+            "unit": "kbps",
+            "value": 256
+          },
+          "Enc1_DD_Man": {
+            "access": "RW-",
+            "default": 384,
+            "id": 53,
+            "kind": "int",
+            "max": 640,
+            "min": 32,
+            "step": 1,
+            "unit": "kbps",
+            "value": 384
+          },
+          "Enc1_mode": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "DDPlus_Man",
+              "DDPlus_Auto192 ",
+              "DDPlus_Auto200",
+              "DDPlus_Auto224",
+              "DDPlus_Auto256",
+              "DD_Man",
+              "DD_Auto384",
+              "DD_Auto448"
+            ],
+            "id": 49,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "DDPlus_Man"
+          },
+          "Enc2_DDPlus_Man": {
+            "access": "RW-",
+            "default": 256,
+            "id": 58,
+            "kind": "int",
+            "max": 1532,
+            "min": 32,
+            "step": 1,
+            "unit": "kbps",
+            "value": 256
+          },
+          "Enc2_DD_Man": {
+            "access": "RW-",
+            "default": 384,
+            "id": 54,
+            "kind": "int",
+            "max": 640,
+            "min": 32,
+            "step": 1,
+            "unit": "kbps",
+            "value": 384
+          },
+          "Enc2_mode": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "DDPlus_Man",
+              "DDPlus_Auto192 ",
+              "DDPlus_Auto200",
+              "DDPlus_Auto224",
+              "DDPlus_Auto256",
+              "DD_Man",
+              "DD_Auto384",
+              "DD_Auto448"
+            ],
+            "id": 50,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "DDPlus_Man"
+          },
+          "Enc3_DDPlus_Man": {
+            "access": "RW-",
+            "default": 256,
+            "id": 59,
+            "kind": "int",
+            "max": 1532,
+            "min": 32,
+            "step": 1,
+            "unit": "kbps",
+            "value": 256
+          },
+          "Enc3_DD_Man": {
+            "access": "RW-",
+            "default": 384,
+            "id": 55,
+            "kind": "int",
+            "max": 640,
+            "min": 32,
+            "step": 1,
+            "unit": "kbps",
+            "value": 384
+          },
+          "Enc3_mode": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "DDPlus_Man",
+              "DDPlus_Auto192 ",
+              "DDPlus_Auto200",
+              "DDPlus_Auto224",
+              "DDPlus_Auto256",
+              "DD_Man",
+              "DD_Auto384",
+              "DD_Auto448"
+            ],
+            "id": 51,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "DDPlus_Man"
+          },
+          "Enc4_DDPlus_Man": {
+            "access": "RW-",
+            "default": 256,
+            "id": 60,
+            "kind": "int",
+            "max": 1532,
+            "min": 32,
+            "step": 1,
+            "unit": "kbps",
+            "value": 256
+          },
+          "Enc4_DD_Man": {
+            "access": "RW-",
+            "default": 384,
+            "id": 56,
+            "kind": "int",
+            "max": 640,
+            "min": 32,
+            "step": 1,
+            "unit": "kbps",
+            "value": 384
+          },
+          "Enc4_mode": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "DDPlus_Man",
+              "DDPlus_Auto192 ",
+              "DDPlus_Auto200",
+              "DDPlus_Auto224",
+              "DDPlus_Auto256",
+              "DD_Man",
+              "DD_Auto384",
+              "DD_Auto448"
+            ],
+            "id": 52,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "DDPlus_Man"
+          },
+          "Ext-Mode": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "GPIO",
+              "Metadata"
+            ],
+            "id": 19,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "GPIO"
+          },
+          "Extract_Ass_Ch": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Auto",
+              "None",
+              "Ch01/02",
+              "Ch03/04",
+              "Ch05/06",
+              "Ch07/08",
+              "Ch09/10",
+              "Ch11/12",
+              "Ch13/14",
+              "Ch15/16"
+            ],
+            "id": 182,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "None"
+          },
+          "Extract_Line": {
+            "access": "RW-",
+            "default": 0,
+            "id": 181,
+            "kind": "int",
+            "max": 1125,
+            "min": 0,
+            "step": 1,
+            "unit": "ln",
+            "value": 0
+          },
+          "F-Delay_1": {
+            "access": "RW-",
+            "default": 12,
+            "id": 12,
+            "kind": "uint",
+            "max": 250,
+            "min": 0,
+            "step": 1,
+            "unit": "F",
+            "value": 12
+          },
+          "Fade-Time": {
+            "access": "RW-",
+            "default": 500,
+            "id": 175,
+            "kind": "int",
+            "max": 10000,
+            "min": 100,
+            "step": 1,
+            "unit": "ms",
+            "value": 500
+          },
+          "GPI-Ctrl": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Latch",
+              "nonLatch",
+              "BCD"
+            ],
+            "id": 18,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Latch"
+          },
+          "H-Delay_1": {
+            "access": "RW-",
+            "default": 0,
+            "id": 14,
+            "kind": "int",
+            "max": 4124,
+            "min": 0,
+            "step": 1,
+            "unit": "px",
+            "value": 0
+          },
+          "Input-Select": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI-1",
+              "SDI-2",
+              "Auto"
+            ],
+            "id": 1,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "SDI-2"
+          },
+          "Insert_Line": {
+            "access": "RW-",
+            "default": 9,
+            "id": 185,
+            "kind": "int",
+            "max": 1125,
+            "min": 1,
+            "step": 1,
+            "unit": "ln",
+            "value": 9
+          },
+          "Insert_Method": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Method B"
+            ],
+            "id": 186,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Method B"
+          },
+          "Lock-Mode": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI1",
+              "SDI2",
+              "Ref1",
+              "Ref2",
+              "Auto-SDI"
+            ],
+            "id": 3,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI1"
+          },
+          "Loss": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Preset 1",
+              "Preset 2",
+              "Preset 3",
+              "Preset 4",
+              "Preset 5",
+              "Preset 6",
+              "Preset 7"
+            ],
+            "id": 21,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "LossDetect": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "S2020-SDI",
+              "MD-LocalIn"
+            ],
+            "id": 20,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "S2020-SDI"
+          },
+          "LossDetect_2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "S2020-SDI",
+              "MD-LocalIn"
+            ],
+            "id": 23,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "Loss_2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Preset 1",
+              "Preset 2",
+              "Preset 3",
+              "Preset 4",
+              "Preset 5",
+              "Preset 6",
+              "Preset 7"
+            ],
+            "id": 24,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "MD-Control": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Manual",
+              "GPI",
+              "LossDetect",
+              "GPI+LossDetect"
+            ],
+            "id": 191,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Manual"
+          },
+          "MD-LossDetect": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "Local"
+            ],
+            "id": 192,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "MD-LossDetect_2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "SDI",
+              "Local"
+            ],
+            "id": 195,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "MD_Prog_Set": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "E",
+              "F",
+              "G",
+              "H"
+            ],
+            "id": 207,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "A"
+          },
+          "MD_Status_Pgm": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8"
+            ],
+            "id": 245,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "MD_Status_Src": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "SDI",
+              "Local",
+              "ShufflerOut",
+              "Off"
+            ],
+            "id": 244,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Off"
+          },
+          "MISC": {
+            "access": "RW-",
+            "id": 173,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "MetaDet": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "MDPreset 1",
+              "MDPreset 2",
+              "MDPreset 3",
+              "MDPreset 4",
+              "MDPreset 5",
+              "MDPreset 6",
+              "MDPreset 7",
+              "S2020-SDID",
+              "ProgramConfig",
+              "Previous"
+            ],
+            "id": 194,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "MetaDet_2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "MDPreset 1",
+              "MDPreset 2",
+              "MDPreset 3",
+              "MDPreset 4",
+              "MDPreset 5",
+              "MDPreset 6",
+              "MDPreset 7",
+              "S2020-SDID",
+              "ProgramConfig",
+              "Previous"
+            ],
+            "id": 197,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "MetaLoss": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "MDPreset 1",
+              "MDPreset 2",
+              "MDPreset 3",
+              "MDPreset 4",
+              "MDPreset 5",
+              "MDPreset 6",
+              "MDPreset 7"
+            ],
+            "id": 193,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "MetaLoss_2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "MDPreset 1",
+              "MDPreset 2",
+              "MDPreset 3",
+              "MDPreset 4",
+              "MDPreset 5",
+              "MDPreset 6",
+              "MDPreset 7"
+            ],
+            "id": 196,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "Metadata_Preset": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14"
+            ],
+            "id": 198,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "NonPCM-Bypass": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 174,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "On"
+          },
+          "Out-Frmt": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Auto",
+              "1080i60",
+              "1080i50",
+              "1080p30",
+              "1080p25",
+              "1080p24",
+              "720p60",
+              "720p50",
+              "SD625",
+              "SD525"
+            ],
+            "id": 4,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Auto"
+          },
+          "PL Center_mix": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "+3.0dB",
+              "+1.5dB",
+              "0.0dB",
+              "-1.5dB",
+              "-3.0dB",
+              "-4.5dB",
+              "-6.0dB",
+              "-999dB"
+            ],
+            "id": 65,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "0.0dB"
+          },
+          "PL Dialnorm": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 64,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "On"
+          },
+          "PL Downmix_Type": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Auto",
+              "Lt/Rt",
+              "Lo/Ro",
+              "PLII"
+            ],
+            "id": 63,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "PLII"
+          },
+          "PL LFE_En": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Disabled",
+              "Auto",
+              "Enabled"
+            ],
+            "id": 67,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Disabled"
+          },
+          "PL LFE_MixLevel": {
+            "access": "RW-",
+            "default": 7,
+            "id": 68,
+            "kind": "int",
+            "max": 10,
+            "min": -21,
+            "step": 1,
+            "unit": "dB",
+            "value": 7
+          },
+          "PL MD_Src": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "MD_Enc1",
+              "Int_Meta"
+            ],
+            "id": 62,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Int_Meta"
+          },
+          "PL Surround_mix": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "+3.0dB",
+              "+1.5dB",
+              "0.0dB",
+              "-1.5dB",
+              "-3.0dB",
+              "-4.5dB",
+              "-6.0dB",
+              "-999dB"
+            ],
+            "id": 66,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "-1.5dB"
+          },
+          "PRESET": {
+            "access": "RW-",
+            "id": 16,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "PROLOGIC CONTROL": {
+            "access": "R--",
+            "id": 61,
+            "kind": "string",
+            "value": ""
+          },
+          "Phaser-Status": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 7,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "Phaser1-Offset": {
+            "access": "RW-",
+            "default": 0,
+            "id": 5,
+            "kind": "int",
+            "max": 4124,
+            "min": 0,
+            "step": 1,
+            "unit": "px",
+            "value": 0
+          },
+          "Phaser2-Offset": {
+            "access": "RW-",
+            "default": 0,
+            "id": 6,
+            "kind": "int",
+            "max": 4124,
+            "min": 0,
+            "step": 1,
+            "unit": "px",
+            "value": 0
+          },
+          "PrstEditView": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Follow Active",
+              "Independent"
+            ],
+            "id": 29,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Follow Active"
+          },
+          "RestartCAT561": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "No Reset",
+              "Reset"
+            ],
+            "id": 246,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "No Reset"
+          },
+          "Silence-Level": {
+            "access": "RW-",
+            "default": -60,
+            "id": 178,
+            "kind": "float",
+            "max": -20,
+            "min": -100,
+            "step": 1,
+            "unit": "dBFS",
+            "value": -60
+          },
+          "Silence-Time": {
+            "access": "RW-",
+            "default": 10,
+            "id": 179,
+            "kind": "uint",
+            "max": 255,
+            "min": 1,
+            "step": 1,
+            "unit": "s",
+            "value": 10
+          },
+          "SourceAD": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "Addon01/16",
+              "Addon17/32"
+            ],
+            "id": 75,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "SourceADControl": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "Addon01/16",
+              "Addon17/32"
+            ],
+            "id": 77,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "SourceADProg1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "Addon01/16",
+              "Addon17/32"
+            ],
+            "id": 71,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "SourceADProg2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI",
+              "DecoderOut",
+              "Addon01/16",
+              "Addon17/32"
+            ],
+            "id": 73,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI"
+          },
+          "Switch-Back": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 2,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "On"
+          },
+          "Time-Delay_1": {
+            "access": "RW-",
+            "default": 480,
+            "id": 11,
+            "kind": "float",
+            "max": 10000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 480
+          },
+          "V-Delay_1": {
+            "access": "RW-",
+            "default": 0,
+            "id": 13,
+            "kind": "int",
+            "max": 1124,
+            "min": 0,
+            "step": 1,
+            "unit": "ln",
+            "value": 0
+          },
+          "VIDEO": {
+            "access": "RW-",
+            "id": 0,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          }
+        },
+        "identity": {
+          "3G - Capable": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 16,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Audio Description": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 19,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Card ID": {
+            "access": "R--",
+            "id": 7,
+            "kind": "string",
+            "max_len": 16,
+            "value": "71ef060a0000001f"
+          },
+          "Card description": {
+            "access": "R--",
+            "id": 2,
+            "kind": "string",
+            "max_len": 16,
+            "value": "HPD130-2120.html"
+          },
+          "Card name": {
+            "access": "R--",
+            "id": 0,
+            "kind": "string",
+            "max_len": 8,
+            "value": "HPD130"
+          },
+          "Card-Status": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Unknown",
+              "Programming",
+              "Card Failed",
+              "Operational"
+            ],
+            "id": 10,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Operational"
+          },
+          "DM-D HW Rev": {
+            "access": "R--",
+            "id": 13,
+            "kind": "string",
+            "max_len": 16,
+            "value": "22"
+          },
+          "DM-D Name": {
+            "access": "R--",
+            "id": 11,
+            "kind": "string",
+            "max_len": 16,
+            "value": "CAT561 EPD"
+          },
+          "DM-D SW Rev": {
+            "access": "R--",
+            "id": 12,
+            "kind": "string",
+            "max_len": 16,
+            "value": "2407"
+          },
+          "DM-D Serial": {
+            "access": "R--",
+            "id": 14,
+            "kind": "string",
+            "max_len": 16,
+            "value": "500589"
+          },
+          "Decoder": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 17,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Encoder": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 18,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Features": {
+            "access": "R--",
+            "id": 9,
+            "kind": "string",
+            "max_len": 8,
+            "value": "0008BE59"
+          },
+          "HD - Capable": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 15,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Hardware rev": {
+            "access": "R--",
+            "id": 4,
+            "kind": "string",
+            "max_len": 4,
+            "value": "0300"
+          },
+          "Key": {
+            "access": "RW-",
+            "id": 8,
+            "kind": "string",
+            "max_len": 15,
+            "value": "empty string"
+          },
+          "Product code": {
+            "access": "R--",
+            "id": 5,
+            "kind": "string",
+            "max_len": 10,
+            "value": "9490600011"
+          },
+          "Serial number": {
+            "access": "R--",
+            "id": 6,
+            "kind": "string",
+            "max_len": 16,
+            "value": "PR011617"
+          },
+          "Software rev": {
+            "access": "R--",
+            "id": 3,
+            "kind": "string",
+            "max_len": 4,
+            "value": "2120"
+          },
+          "User label": {
+            "access": "RW-",
+            "id": 1,
+            "kind": "string",
+            "max_len": 16,
+            "value": "3G/HD/SD Dolby"
+          }
+        },
+        "status": {
+          "AD-Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 62,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "ADControl-Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Error"
+            ],
+            "id": 63,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "ADProg1-Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 60,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "ADProg2-Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 61,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "ANC-Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Error"
+            ],
+            "id": 21,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "ATC-Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Present",
+              "Error"
+            ],
+            "id": 20,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Active-Out1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "SDI1",
+              "SDI2"
+            ],
+            "id": 16,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI1"
+          },
+          "Active-Out2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "SDI1",
+              "SDI2"
+            ],
+            "id": 17,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI1"
+          },
+          "AddOnFrmtIn01/02": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 44,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn03/04": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 45,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn05/06": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 46,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn07/08": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 47,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn09/10": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 48,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn11/12": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 49,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn13/14": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 50,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn15/16": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 51,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn17/18": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 52,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn19/20": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 53,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn21/22": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 54,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn23/24": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 55,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn25/26": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 56,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn27/28": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 57,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn29/30": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 58,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtIn31/32": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 59,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "CRC-Stat_1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "OK",
+              "CRC Error"
+            ],
+            "id": 6,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "OK"
+          },
+          "CRC-Stat_2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "OK",
+              "CRC Error"
+            ],
+            "id": 7,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "OK"
+          },
+          "DM-D_Status": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Error"
+            ],
+            "id": 128,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "DM-D_Type": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "CAT561 Dec",
+              "CAT561 Enc",
+              "CAT561 Comp",
+              "CAT561 EPD"
+            ],
+            "id": 127,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtIn01/02": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 28,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtIn03/04": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 29,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtIn05/06": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 30,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtIn07/08": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 31,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtIn09/10": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 32,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtIn11/12": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 33,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtIn13/14": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 34,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtIn15/16": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 35,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutA1/2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 80,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutA3/4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 81,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutB1/2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 82,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutB3/4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 83,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutC1/2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 84,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutC3/4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 85,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutD1/2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 86,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutD3/4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 87,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbSOF-EIn01/02": {
+            "access": "R--",
+            "default": 0,
+            "id": 36,
+            "kind": "int",
+            "max": 1125,
+            "min": 0,
+            "step": 1,
+            "unit": "ln",
+            "value": 0
+          },
+          "EmbSOF-EIn03/04": {
+            "access": "R--",
+            "default": 0,
+            "id": 37,
+            "kind": "int",
+            "max": 1125,
+            "min": 0,
+            "step": 1,
+            "unit": "ln",
+            "value": 0
+          },
+          "EmbSOF-EIn05/06": {
+            "access": "R--",
+            "default": 0,
+            "id": 38,
+            "kind": "int",
+            "max": 1125,
+            "min": 0,
+            "step": 1,
+            "unit": "ln",
+            "value": 0
+          },
+          "EmbSOF-EIn07/08": {
+            "access": "R--",
+            "default": 0,
+            "id": 39,
+            "kind": "int",
+            "max": 1125,
+            "min": 0,
+            "step": 1,
+            "unit": "ln",
+            "value": 0
+          },
+          "EmbSOF-EIn09/10": {
+            "access": "R--",
+            "default": 0,
+            "id": 40,
+            "kind": "int",
+            "max": 1125,
+            "min": 0,
+            "step": 1,
+            "unit": "ln",
+            "value": 0
+          },
+          "EmbSOF-EIn11/12": {
+            "access": "R--",
+            "default": 0,
+            "id": 41,
+            "kind": "int",
+            "max": 1125,
+            "min": 0,
+            "step": 1,
+            "unit": "ln",
+            "value": 0
+          },
+          "EmbSOF-EIn13/14": {
+            "access": "R--",
+            "default": 0,
+            "id": 42,
+            "kind": "int",
+            "max": 1125,
+            "min": 0,
+            "step": 1,
+            "unit": "ln",
+            "value": 0
+          },
+          "EmbSOF-EIn15/16": {
+            "access": "R--",
+            "default": 0,
+            "id": 43,
+            "kind": "int",
+            "max": 1125,
+            "min": 0,
+            "step": 1,
+            "unit": "ln",
+            "value": 0
+          },
+          "EmbStatOutA1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 64,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutA2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 65,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutA3": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 66,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutA4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 67,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutB1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 68,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutB2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 69,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutB3": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 70,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutB4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 71,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutC1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 72,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutC2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 73,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutC3": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 74,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutC4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 75,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutD1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 76,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutD2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 77,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutD3": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 78,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutD4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 79,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Enc1Latency": {
+            "access": "R--",
+            "default": 0,
+            "id": 24,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "Enc2Latency": {
+            "access": "R--",
+            "default": 0,
+            "id": 25,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "Enc3Latency": {
+            "access": "R--",
+            "default": 0,
+            "id": 26,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "Enc4Latency": {
+            "access": "R--",
+            "default": 0,
+            "id": 27,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "FPGA-Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "OK",
+              "Error"
+            ],
+            "id": 126,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "OK"
+          },
+          "GPI": {
+            "access": "R--",
+            "default": 1,
+            "id": 19,
+            "kind": "int",
+            "max": 7,
+            "min": 0,
+            "step": 1,
+            "value": 1
+          },
+          "Grp-Ins": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Error"
+            ],
+            "id": 23,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "GrpInUse": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "____",
+              "1___",
+              "_2__",
+              "12__",
+              "__3_",
+              "1_3_",
+              "_23_",
+              "123_",
+              "___4",
+              "1__4",
+              "_2_4",
+              "12_4",
+              "__34",
+              "1_34",
+              "_234",
+              "1234"
+            ],
+            "id": 22,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "____"
+          },
+          "IO-Delay_1": {
+            "access": "R--",
+            "default": 0,
+            "id": 18,
+            "kind": "float",
+            "max": 10000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "LocMetaProg": {
+            "access": "R--",
+            "default": 11,
+            "enum_items": [
+              "5.1+2",
+              "5.1+1+1",
+              "4+4",
+              "4x2",
+              "8x1",
+              "5.1",
+              "3x2",
+              "4",
+              "2+2",
+              "7.1",
+              "Other",
+              "NA"
+            ],
+            "id": 92,
+            "kind": "enum",
+            "value": 11,
+            "value_name": "NA"
+          },
+          "LocMetaStat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Error"
+            ],
+            "id": 91,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Locked-To": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "Not Locked",
+              "Ref",
+              "SDI1",
+              "SDI2"
+            ],
+            "id": 15,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Not Locked"
+          },
+          "MD AC3Copyright": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "No",
+              "Yes",
+              "NA"
+            ],
+            "id": 108,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD AC3Datarate": {
+            "access": "R--",
+            "default": 0,
+            "id": 96,
+            "kind": "int",
+            "max": 640,
+            "min": 0,
+            "step": 1,
+            "unit": "kbps",
+            "value": 0
+          },
+          "MD AC3OrigBitstr": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "No",
+              "Yes",
+              "NA"
+            ],
+            "id": 109,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD ADConvType": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "Standard",
+              "HDCD",
+              "NA"
+            ],
+            "id": 117,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD AudioProdInfo": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "NA"
+            ],
+            "id": 105,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD Bitstream": {
+            "access": "R--",
+            "default": 8,
+            "enum_items": [
+              "Complete",
+              "M\u0026E",
+              "Visual",
+              "Hearing",
+              "Dialogue",
+              "Commentary",
+              "Emergency",
+              "VO_Karaoke",
+              "NA"
+            ],
+            "id": 97,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "NA"
+          },
+          "MD CenterMixLvl": {
+            "access": "R--",
+            "default": 3,
+            "enum_items": [
+              "-3.0dB",
+              "-4.5dB",
+              "-6.0dB",
+              "NA"
+            ],
+            "id": 99,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "NA"
+          },
+          "MD ChannelMode": {
+            "access": "R--",
+            "default": 7,
+            "enum_items": [
+              "1/0(C)",
+              "2/0(L-R)",
+              "3/0(L-C-R)",
+              "2/1(L-R-S)",
+              "3/1(L-C-R-S)",
+              "2/2(L-R-Ls-Rs)",
+              "3/2(L-C-R-Ls-Rs)",
+              "NA"
+            ],
+            "id": 98,
+            "kind": "enum",
+            "value": 7,
+            "value_name": "NA"
+          },
+          "MD DC Filter": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "NA"
+            ],
+            "id": 118,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD D_HeadPhone": {
+            "access": "R--",
+            "default": 4,
+            "enum_items": [
+              "Not Indic.",
+              "Not_Headph",
+              "Headph",
+              "Rsvd",
+              "NA"
+            ],
+            "id": 116,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "NA"
+          },
+          "MD D_Surnd": {
+            "access": "R--",
+            "default": 4,
+            "enum_items": [
+              "Not Indic.",
+              "Not_Srnd",
+              "Srnd",
+              "Rsvd",
+              "NA"
+            ],
+            "id": 101,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "NA"
+          },
+          "MD D_Surnd EX": {
+            "access": "R--",
+            "default": 4,
+            "enum_items": [
+              "Not Indic.",
+              "Not_Srnd",
+              "Srnd",
+              "Rsvd",
+              "NA"
+            ],
+            "id": 115,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "NA"
+          },
+          "MD Dialog Lvl": {
+            "access": "R--",
+            "default": 0,
+            "id": 103,
+            "kind": "int",
+            "max": 0,
+            "min": -31,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "MD FrameRate": {
+            "access": "R--",
+            "default": 5,
+            "enum_items": [
+              "23.98",
+              "24",
+              "25",
+              "29.97",
+              "30",
+              "NA"
+            ],
+            "id": 94,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "NA"
+          },
+          "MD LFE": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "NA"
+            ],
+            "id": 102,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD LFE Filter": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "NA"
+            ],
+            "id": 120,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD LanguageCode": {
+            "access": "R--",
+            "default": 0,
+            "id": 104,
+            "kind": "uint",
+            "max": 127,
+            "min": 0,
+            "step": 1,
+            "value": 0
+          },
+          "MD Line Mode": {
+            "access": "R--",
+            "default": 7,
+            "enum_items": [
+              "None",
+              "FilmStandard",
+              "FilmLight",
+              "MusicStandard",
+              "MusicLight",
+              "Speech",
+              "Rsvd",
+              "NA"
+            ],
+            "id": 125,
+            "kind": "enum",
+            "value": 7,
+            "value_name": "NA"
+          },
+          "MD Lo/RoCDwnmx": {
+            "access": "R--",
+            "default": 8,
+            "enum_items": [
+              "+3.0dB",
+              "+1.5dB",
+              "0.0dB",
+              "-1.5dB",
+              "-3.0dB",
+              "-4.5dB",
+              "-6.0dB",
+              "-999dB",
+              "NA"
+            ],
+            "id": 113,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "NA"
+          },
+          "MD Lo/RoSDwnmx": {
+            "access": "R--",
+            "default": 8,
+            "enum_items": [
+              "+3.0dB",
+              "+1.5dB",
+              "0.0dB",
+              "-1.5dB",
+              "-3.0dB",
+              "-4.5dB",
+              "-6.0dB",
+              "-999dB",
+              "NA"
+            ],
+            "id": 114,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "NA"
+          },
+          "MD Lowpass Fil": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "NA"
+            ],
+            "id": 119,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD Lt/RtCDwnmx": {
+            "access": "R--",
+            "default": 8,
+            "enum_items": [
+              "+3.0dB",
+              "+1.5dB",
+              "0.0dB",
+              "-1.5dB",
+              "-3.0dB",
+              "-4.5dB",
+              "-6.0dB",
+              "-999dB",
+              "NA"
+            ],
+            "id": 111,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "NA"
+          },
+          "MD Lt/RtSDwnmx": {
+            "access": "R--",
+            "default": 8,
+            "enum_items": [
+              "+3.0dB",
+              "+1.5dB",
+              "0.0dB",
+              "-1.5dB",
+              "-3.0dB",
+              "-4.5dB",
+              "-6.0dB",
+              "-999dB",
+              "NA"
+            ],
+            "id": 112,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "NA"
+          },
+          "MD Pref. Dwnmx": {
+            "access": "R--",
+            "default": 4,
+            "enum_items": [
+              "Not Indic.",
+              "Lt/Rt",
+              "Lo/Ro",
+              "Rsvd",
+              "NA"
+            ],
+            "id": 110,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "NA"
+          },
+          "MD Prgm Config": {
+            "access": "R--",
+            "default": 12,
+            "enum_items": [
+              "5.1+2",
+              "5.1+1+1",
+              "4+4",
+              "4x2",
+              "8x1",
+              "5.1",
+              "3x2",
+              "4",
+              "2+2",
+              "7.1",
+              "Rsvd",
+              "Other",
+              "NA"
+            ],
+            "id": 93,
+            "kind": "enum",
+            "value": 12,
+            "value_name": "NA"
+          },
+          "MD ProdMixLvl": {
+            "access": "R--",
+            "default": 0,
+            "id": 106,
+            "kind": "int",
+            "max": 111,
+            "min": 0,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "MD ProdRoomType": {
+            "access": "R--",
+            "default": 4,
+            "enum_items": [
+              "Not Indic.",
+              "Large",
+              "Small",
+              "Rsvd",
+              "NA"
+            ],
+            "id": 107,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "NA"
+          },
+          "MD ProgramText": {
+            "access": "R--",
+            "id": 95,
+            "kind": "string",
+            "max_len": 12,
+            "value": ""
+          },
+          "MD RF Mode": {
+            "access": "R--",
+            "default": 7,
+            "enum_items": [
+              "None",
+              "FilmStandard",
+              "FilmLight",
+              "MusicStandard",
+              "MusicLight",
+              "Speech",
+              "Rsvd",
+              "NA"
+            ],
+            "id": 124,
+            "kind": "enum",
+            "value": 7,
+            "value_name": "NA"
+          },
+          "MD RFPreEmph": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "NA"
+            ],
+            "id": 123,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD SrndMixLvl": {
+            "access": "R--",
+            "default": 3,
+            "enum_items": [
+              "-3.0dB",
+              "-6.0dB",
+              "-999dB",
+              "NA"
+            ],
+            "id": 100,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "NA"
+          },
+          "MD Sur Phshift": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "NA"
+            ],
+            "id": 121,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "MD Sur3dB Att": {
+            "access": "R--",
+            "default": 2,
+            "enum_items": [
+              "Disabled",
+              "Enabled",
+              "NA"
+            ],
+            "id": 122,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "NA"
+          },
+          "Phaser1_H_Pos": {
+            "access": "R--",
+            "default": 0,
+            "id": 9,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "px",
+            "value": 0
+          },
+          "Phaser1_Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Safe",
+              "Warning",
+              "Critical"
+            ],
+            "id": 11,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Phaser2_H_Pos": {
+            "access": "R--",
+            "default": 0,
+            "id": 10,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "px",
+            "value": 0
+          },
+          "Phaser2_Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Safe",
+              "Warning",
+              "Critical"
+            ],
+            "id": 12,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Ref-Format": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "NTSC/480i",
+              "PAL/576i",
+              "480p",
+              "576p",
+              "720p",
+              "1080i",
+              "1080p"
+            ],
+            "id": 8,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "S2020-Src_Ass_Ch": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "None",
+              "Ch01/02",
+              "Ch03/04",
+              "Ch05/06",
+              "Ch07/08",
+              "Ch09/10",
+              "Ch11/12",
+              "Ch13/14",
+              "Ch15/16"
+            ],
+            "id": 89,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "SDI-Freq_1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "1:1",
+              "1:1.001"
+            ],
+            "id": 4,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "SDI-Freq_2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "1:1",
+              "1:1.001"
+            ],
+            "id": 5,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "SDI-Input_1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "1080p60",
+              "1080p50",
+              "1080p30",
+              "1080p25",
+              "1080p24",
+              "1080i50",
+              "1080i60",
+              "720p60",
+              "720p50",
+              "SD625",
+              "SD525"
+            ],
+            "id": 0,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "SDI-Input_2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "1080p60",
+              "1080p50",
+              "1080p30",
+              "1080p25",
+              "1080p24",
+              "1080i50",
+              "1080i60",
+              "720p60",
+              "720p50",
+              "SD625",
+              "SD525"
+            ],
+            "id": 1,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "SDI-Map_1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Level A",
+              "Level B"
+            ],
+            "id": 2,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "SDI-Map_2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Level A",
+              "Level B"
+            ],
+            "id": 3,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "SDI1-Ref_Offset": {
+            "access": "R--",
+            "default": 0,
+            "id": 13,
+            "kind": "float",
+            "max": 40000,
+            "min": 0,
+            "step": 1,
+            "unit": "us",
+            "value": 0
+          },
+          "SDI2-Ref_Offset": {
+            "access": "R--",
+            "default": 0,
+            "id": 14,
+            "kind": "float",
+            "max": 40000,
+            "min": 0,
+            "step": 1,
+            "unit": "us",
+            "value": 0
+          },
+          "SDIS2020Prog": {
+            "access": "R--",
+            "default": 11,
+            "enum_items": [
+              "5.1+2",
+              "5.1+1+1",
+              "4+4",
+              "4x2",
+              "8x1",
+              "5.1",
+              "3x2",
+              "4",
+              "2+2",
+              "7.1",
+              "Other",
+              "NA"
+            ],
+            "id": 90,
+            "kind": "enum",
+            "value": 11,
+            "value_name": "NA"
+          },
+          "SDIS2020Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Error"
+            ],
+            "id": 88,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          }
+        }
+      },
+      "slot": 13,
+      "status": "present",
+      "walked_at": "2026-05-05T10:21:45Z"
+    }
+  ]
+}

--- a/tests/fixtures/products/axon/synapse/HRB990-1010/acp1/slot_19.json
+++ b/tests/fixtures/products/axon/synapse/HRB990-1010/acp1/slot_19.json
@@ -1,0 +1,4898 @@
+{
+  "created_at": "2026-05-05T10:21:45Z",
+  "device": {
+    "ip": "10.6.239.113",
+    "port": 2071,
+    "protocol": "acp1",
+    "protocol_version": 1,
+    "num_slots": 31
+  },
+  "generator": "acp dev",
+  "slots": [
+    {
+      "objects": {
+        "alarm": {
+          "Announcements": {
+            "access": "RW-",
+            "id": 0,
+            "kind": "alarm",
+            "value": 1
+          },
+          "CRC-Status1": {
+            "access": "RW-",
+            "id": 3,
+            "kind": "alarm",
+            "value": 0
+          },
+          "CRC-Status2": {
+            "access": "RW-",
+            "id": 4,
+            "kind": "alarm",
+            "value": 0
+          },
+          "Input1": {
+            "access": "RW-",
+            "id": 1,
+            "kind": "alarm",
+            "value": 0
+          },
+          "Input2": {
+            "access": "RW-",
+            "id": 2,
+            "kind": "alarm",
+            "value": 0
+          },
+          "Lock-Status": {
+            "access": "RW-",
+            "id": 6,
+            "kind": "alarm",
+            "value": 0
+          },
+          "Ref-Status": {
+            "access": "RW-",
+            "id": 5,
+            "kind": "alarm",
+            "value": 0
+          },
+          "Silence_LocInA1": {
+            "access": "RW-",
+            "id": 7,
+            "kind": "alarm",
+            "value": 0
+          },
+          "Silence_LocInA2": {
+            "access": "RW-",
+            "id": 8,
+            "kind": "alarm",
+            "value": 0
+          },
+          "Silence_LocInA3": {
+            "access": "RW-",
+            "id": 9,
+            "kind": "alarm",
+            "value": 0
+          },
+          "Silence_LocInA4": {
+            "access": "RW-",
+            "id": 10,
+            "kind": "alarm",
+            "value": 0
+          },
+          "Silence_LocInA5": {
+            "access": "RW-",
+            "id": 11,
+            "kind": "alarm",
+            "value": 0
+          },
+          "Silence_LocInA6": {
+            "access": "RW-",
+            "id": 12,
+            "kind": "alarm",
+            "value": 0
+          },
+          "Silence_LocInA7": {
+            "access": "RW-",
+            "id": 13,
+            "kind": "alarm",
+            "value": 0
+          },
+          "Silence_LocInA8": {
+            "access": "RW-",
+            "id": 14,
+            "kind": "alarm",
+            "value": 0
+          }
+        },
+        "control": {
+          "   DE-EMBEDDING": {
+            "access": "RW-",
+            "id": 28,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "  DELAY": {
+            "access": "R--",
+            "id": 8,
+            "kind": "string",
+            "value": ""
+          },
+          "  METADATA": {
+            "access": "R--",
+            "id": 191,
+            "kind": "string",
+            "value": ""
+          },
+          "#AddonOutA1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 162,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ch_1"
+          },
+          "#AddonOutA2": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 164,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Ch_2"
+          },
+          "#AddonOutA3": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 166,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ch_3"
+          },
+          "#AddonOutA4": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 168,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Ch_4"
+          },
+          "#AddonOutC1": {
+            "access": "RW-",
+            "default": 4,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 170,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "Ch_5"
+          },
+          "#AddonOutC2": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 172,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Ch_6"
+          },
+          "#AddonOutC3": {
+            "access": "RW-",
+            "default": 6,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 174,
+            "kind": "enum",
+            "value": 6,
+            "value_name": "Ch_7"
+          },
+          "#AddonOutC4": {
+            "access": "RW-",
+            "default": 7,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 176,
+            "kind": "enum",
+            "value": 7,
+            "value_name": "Ch_8"
+          },
+          "#Emb-A1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 40,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ch_1"
+          },
+          "#Emb-A2": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 42,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Ch_2"
+          },
+          "#Emb-A3": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 44,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ch_3"
+          },
+          "#Emb-A4": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 46,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Ch_4"
+          },
+          "#Emb-AB-Mode": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Off",
+              "Append",
+              "Overwrite"
+            ],
+            "id": 32,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Overwrite"
+          },
+          "#Emb-B1": {
+            "access": "RW-",
+            "default": 4,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 48,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "Ch_5"
+          },
+          "#Emb-B2": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 50,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Ch_6"
+          },
+          "#Emb-B3": {
+            "access": "RW-",
+            "default": 6,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 52,
+            "kind": "enum",
+            "value": 6,
+            "value_name": "Ch_7"
+          },
+          "#Emb-B4": {
+            "access": "RW-",
+            "default": 7,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 54,
+            "kind": "enum",
+            "value": 7,
+            "value_name": "Ch_8"
+          },
+          "#Emb-C1": {
+            "access": "RW-",
+            "default": 8,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 56,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "Ch_9"
+          },
+          "#Emb-C2": {
+            "access": "RW-",
+            "default": 9,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 58,
+            "kind": "enum",
+            "value": 9,
+            "value_name": "Ch_10"
+          },
+          "#Emb-C3": {
+            "access": "RW-",
+            "default": 10,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 60,
+            "kind": "enum",
+            "value": 10,
+            "value_name": "Ch_11"
+          },
+          "#Emb-C4": {
+            "access": "RW-",
+            "default": 11,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 62,
+            "kind": "enum",
+            "value": 11,
+            "value_name": "Ch_12"
+          },
+          "#Emb-CD-Mode": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Off",
+              "Append",
+              "Overwrite"
+            ],
+            "id": 33,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Overwrite"
+          },
+          "#Emb-D1": {
+            "access": "RW-",
+            "default": 12,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 64,
+            "kind": "enum",
+            "value": 12,
+            "value_name": "Ch_13"
+          },
+          "#Emb-D2": {
+            "access": "RW-",
+            "default": 13,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 66,
+            "kind": "enum",
+            "value": 13,
+            "value_name": "Ch_14"
+          },
+          "#Emb-D3": {
+            "access": "RW-",
+            "default": 14,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 68,
+            "kind": "enum",
+            "value": 14,
+            "value_name": "Ch_15"
+          },
+          "#Emb-D4": {
+            "access": "RW-",
+            "default": 15,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 70,
+            "kind": "enum",
+            "value": 15,
+            "value_name": "Ch_16"
+          },
+          "#EmbA1_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 103,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbA2_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 104,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbA3_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 105,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbA4_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 106,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbB1_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 107,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbB2_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 108,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbB3_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 109,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbB4_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 110,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbC1_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 111,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbC2_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 112,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbC3_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 113,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbC4_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 114,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbD1_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 115,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbD2_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 116,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbD3_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 117,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#EmbD4_Delay": {
+            "access": "RW-",
+            "default": 0,
+            "id": 118,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#Emb_A_Sel": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Group1",
+              "Group2",
+              "Group3",
+              "Group4",
+              "Off"
+            ],
+            "id": 34,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Group1"
+          },
+          "#Emb_B_Sel": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Group1",
+              "Group2",
+              "Group3",
+              "Group4",
+              "Off"
+            ],
+            "id": 35,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Group2"
+          },
+          "#Emb_C_Sel": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Group1",
+              "Group2",
+              "Group3",
+              "Group4",
+              "Off"
+            ],
+            "id": 36,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Group3"
+          },
+          "#Emb_D_Sel": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Group1",
+              "Group2",
+              "Group3",
+              "Group4",
+              "Off"
+            ],
+            "id": 37,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Group4"
+          },
+          "#Insert_Ass_Ch": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "None",
+              "Ch01/02",
+              "Ch03/04",
+              "Ch05/06",
+              "Ch07/08",
+              "Ch09/10",
+              "Ch11/12",
+              "Ch13/14",
+              "Ch15/16"
+            ],
+            "id": 199,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "None"
+          },
+          "#LocDelayOutB1": {
+            "access": "RW-",
+            "default": 0,
+            "id": 152,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#LocDelayOutB2": {
+            "access": "RW-",
+            "default": 0,
+            "id": 153,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#LocDelayOutB3": {
+            "access": "RW-",
+            "default": 0,
+            "id": 154,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#LocDelayOutB4": {
+            "access": "RW-",
+            "default": 0,
+            "id": 155,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#LocDelayOutB5": {
+            "access": "RW-",
+            "default": 0,
+            "id": 156,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#LocDelayOutB6": {
+            "access": "RW-",
+            "default": 0,
+            "id": 157,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#LocDelayOutB7": {
+            "access": "RW-",
+            "default": 0,
+            "id": 158,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#LocDelayOutB8": {
+            "access": "RW-",
+            "default": 0,
+            "id": 159,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "#LocOutB1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 121,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ch_1"
+          },
+          "#LocOutB2": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 123,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Ch_2"
+          },
+          "#LocOutB3": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 125,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ch_3"
+          },
+          "#LocOutB4": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 127,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Ch_4"
+          },
+          "#LocOutB5": {
+            "access": "RW-",
+            "default": 4,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 129,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "Ch_5"
+          },
+          "#LocOutB6": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 131,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Ch_6"
+          },
+          "#LocOutB7": {
+            "access": "RW-",
+            "default": 6,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 133,
+            "kind": "enum",
+            "value": 6,
+            "value_name": "Ch_7"
+          },
+          "#LocOutB8": {
+            "access": "RW-",
+            "default": 7,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16",
+              "Off"
+            ],
+            "id": 135,
+            "kind": "enum",
+            "value": 7,
+            "value_name": "Ch_8"
+          },
+          "#Preset_Name": {
+            "access": "RW-",
+            "id": 27,
+            "kind": "string",
+            "max_len": 16,
+            "value": "1"
+          },
+          "#Rail1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Pre-Delay1",
+              "Post-Delay1"
+            ],
+            "id": 29,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Pre-Delay1"
+          },
+          "#Rail2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Pre-Delay2",
+              "Post-Delay2"
+            ],
+            "id": 30,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Pre-Delay2"
+          },
+          "#S2020-Emb-AB": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Overwrite"
+            ],
+            "id": 195,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#S2020-Emb-CD": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Overwrite"
+            ],
+            "id": 196,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "#SourceAddonA1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 161,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceAddonA2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 163,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceAddonA3": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 165,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceAddonA4": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 167,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceAddonC1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 169,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceAddonC2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 171,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceAddonC3": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 173,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceAddonC4": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 175,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceEmb-A1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 39,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceEmb-A2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 41,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceEmb-A3": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 43,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceEmb-A4": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 45,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceEmb-B1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 47,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceEmb-B2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 49,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceEmb-B3": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 51,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceEmb-B4": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 53,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceEmb-C1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 55,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceEmb-C2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 57,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceEmb-C3": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 59,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceEmb-C4": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 61,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceEmb-D1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 63,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceEmb-D2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 65,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceEmb-D3": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 67,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceEmb-D4": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 69,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceLocB1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 120,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceLocB2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 122,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceLocB3": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 124,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceLocB4": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 126,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceLocB5": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 128,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceLocB6": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 130,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceLocB7": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 132,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "#SourceLocB8": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "LocalA",
+              "AddOnB",
+              "AddOnD"
+            ],
+            "id": 134,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "0dBFS-In": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "+24dBu",
+              "+18dBu",
+              "+15dBu",
+              "+12dBu"
+            ],
+            "id": 182,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "+24dBu"
+          },
+          "0dBFS-Out": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "+24dBu",
+              "+18dBu",
+              "+15dBu",
+              "+12dBu"
+            ],
+            "id": 183,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "+24dBu"
+          },
+          "ADDON AUDIO OUT": {
+            "access": "RW-",
+            "id": 160,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "AUDIO IN": {
+            "access": "RW-",
+            "id": 38,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "Active-Preset": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7"
+            ],
+            "id": 21,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "Addon-IO-Mode": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "O-I-O-I",
+              "I-I-O-O",
+              "O-O-I-I"
+            ],
+            "id": 184,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "O-I-O-I"
+          },
+          "Audio-Phase": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Off",
+              "Align"
+            ],
+            "id": 187,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Align"
+          },
+          "AudioStatusBits": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Transparent",
+              "Overwrite"
+            ],
+            "id": 188,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Transparent"
+          },
+          "Control": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Manual",
+              "GPI",
+              "GPI+LossDetect"
+            ],
+            "id": 18,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Manual"
+          },
+          "Delay-Bypass": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 9,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "On"
+          },
+          "Delay-Status": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 16,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "On"
+          },
+          "Detect": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Preset 1",
+              "Preset 2",
+              "Preset 3",
+              "Preset 4",
+              "Preset 5",
+              "Preset 6",
+              "Preset 7",
+              "S2020-SDID",
+              "ProgramConfig",
+              "Previous"
+            ],
+            "id": 25,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "EMBEDDING": {
+            "access": "RW-",
+            "id": 31,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "Edit-Preset": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7"
+            ],
+            "id": 22,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "1"
+          },
+          "EmbA1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 71,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbA1_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 87,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbA2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 72,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbA2_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 88,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbA3_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 73,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbA3_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 89,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbA4_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 74,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbA4_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 90,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbB1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 75,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbB1_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 91,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbB2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 76,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbB2_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 92,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbB3_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 77,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbB3_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 93,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbB4_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 78,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbB4_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 94,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbC1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 79,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbC1_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 95,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbC2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 80,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbC2_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 96,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbC3_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 81,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbC3_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 97,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbC4_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 82,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbC4_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 98,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbD1_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 83,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbD1_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 99,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbD2_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 84,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbD2_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 100,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbD3_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 85,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbD3_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 101,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "EmbD4_Gain": {
+            "access": "RW-",
+            "default": 0,
+            "id": 86,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "EmbD4_Phase": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 102,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "Ext-Mode": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "GPIO",
+              "Metadata"
+            ],
+            "id": 20,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "GPIO"
+          },
+          "Extract_Ass_Ch": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "None",
+              "Ch01/02",
+              "Ch03/04",
+              "Ch05/06",
+              "Ch07/08",
+              "Ch09/10",
+              "Ch11/12",
+              "Ch13/14",
+              "Ch15/16",
+              "NA",
+              "Auto"
+            ],
+            "id": 194,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "None"
+          },
+          "Extract_Line": {
+            "access": "RW-",
+            "default": 0,
+            "id": 193,
+            "kind": "int",
+            "max": 1125,
+            "min": 0,
+            "step": 1,
+            "unit": "ln",
+            "value": 0
+          },
+          "F-Delay_1": {
+            "access": "RW-",
+            "default": 0,
+            "id": 10,
+            "kind": "uint",
+            "max": 125,
+            "min": 0,
+            "step": 1,
+            "unit": "F",
+            "value": 0
+          },
+          "F-Delay_2": {
+            "access": "RW-",
+            "default": 0,
+            "id": 13,
+            "kind": "uint",
+            "max": 125,
+            "min": 0,
+            "step": 1,
+            "unit": "F",
+            "value": 0
+          },
+          "Fade-Time": {
+            "access": "RW-",
+            "default": 500,
+            "id": 186,
+            "kind": "int",
+            "max": 10000,
+            "min": 100,
+            "step": 1,
+            "unit": "ms",
+            "value": 500
+          },
+          "GPI-Ctrl": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Latch",
+              "nonLatch"
+            ],
+            "id": 19,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Latch"
+          },
+          "H-Delay_1": {
+            "access": "RW-",
+            "default": 0,
+            "id": 12,
+            "kind": "int",
+            "max": 4124,
+            "min": 0,
+            "step": 1,
+            "unit": "px",
+            "value": 0
+          },
+          "H-Delay_2": {
+            "access": "RW-",
+            "default": 0,
+            "id": 15,
+            "kind": "int",
+            "max": 4124,
+            "min": 0,
+            "step": 1,
+            "unit": "px",
+            "value": 0
+          },
+          "Input-Select": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI-1",
+              "SDI-2",
+              "Auto",
+              "TWINS"
+            ],
+            "id": 1,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "TWINS"
+          },
+          "Insert_Line": {
+            "access": "RW-",
+            "default": 9,
+            "id": 197,
+            "kind": "int",
+            "max": 1125,
+            "min": 1,
+            "step": 1,
+            "unit": "ln",
+            "value": 9
+          },
+          "Insert_Method": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Method B"
+            ],
+            "id": 198,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Method B"
+          },
+          "LOCAL AUDIO OUT": {
+            "access": "RW-",
+            "id": 119,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "LocGainOutB1": {
+            "access": "RW-",
+            "default": 0,
+            "id": 136,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "LocGainOutB2": {
+            "access": "RW-",
+            "default": 0,
+            "id": 137,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "LocGainOutB3": {
+            "access": "RW-",
+            "default": 0,
+            "id": 138,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "LocGainOutB4": {
+            "access": "RW-",
+            "default": 0,
+            "id": 139,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "LocGainOutB5": {
+            "access": "RW-",
+            "default": 0,
+            "id": 140,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "LocGainOutB6": {
+            "access": "RW-",
+            "default": 0,
+            "id": 141,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "LocGainOutB7": {
+            "access": "RW-",
+            "default": 0,
+            "id": 142,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "LocGainOutB8": {
+            "access": "RW-",
+            "default": 0,
+            "id": 143,
+            "kind": "float",
+            "max": 12,
+            "min": -144,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "LocPhaseOutB1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 144,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "LocPhaseOutB2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 145,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "LocPhaseOutB3": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 146,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "LocPhaseOutB4": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 147,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "LocPhaseOutB5": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 148,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "LocPhaseOutB6": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 149,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "LocPhaseOutB7": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 150,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "LocPhaseOutB8": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 151,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "Lock-Mode": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "SDI1",
+              "SDI2",
+              "Ref1",
+              "Ref2",
+              "Auto-SDI"
+            ],
+            "id": 3,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI1"
+          },
+          "Loss": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "Preset 1",
+              "Preset 2",
+              "Preset 3",
+              "Preset 4",
+              "Preset 5",
+              "Preset 6",
+              "Preset 7"
+            ],
+            "id": 24,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "LossDetect": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "S2020-Rail1",
+              "S2020-Rail2",
+              "MD-LocalIn"
+            ],
+            "id": 23,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "S2020-Rail1"
+          },
+          "MISC": {
+            "access": "RW-",
+            "id": 177,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "NonPCM-Bypass": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 185,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "On"
+          },
+          "Out-Frmt": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Auto",
+              "1080p60",
+              "1080p50",
+              "1080i60",
+              "1080i50",
+              "1080p30",
+              "1080p25",
+              "1080p24",
+              "720p60",
+              "720p50",
+              "SD625",
+              "SD525"
+            ],
+            "id": 4,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Auto"
+          },
+          "PRESET": {
+            "access": "RW-",
+            "id": 17,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          },
+          "Phaser-Status": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 7,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "Phaser1-Offset": {
+            "access": "RW-",
+            "default": 0,
+            "id": 5,
+            "kind": "int",
+            "max": 4124,
+            "min": 0,
+            "step": 1,
+            "unit": "px",
+            "value": 5
+          },
+          "Phaser2-Offset": {
+            "access": "RW-",
+            "default": 0,
+            "id": 6,
+            "kind": "int",
+            "max": 4124,
+            "min": 0,
+            "step": 1,
+            "unit": "px",
+            "value": 0
+          },
+          "PrstEditView": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Follow Active",
+              "Independent"
+            ],
+            "id": 26,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Follow Active"
+          },
+          "S2020-Source": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Rail1",
+              "Rail2",
+              "Local"
+            ],
+            "id": 192,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Rail1"
+          },
+          "SRC_AES-A1/2": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Transparent",
+              "On",
+              "Auto"
+            ],
+            "id": 178,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "On"
+          },
+          "SRC_AES-A3/4": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Transparent",
+              "On",
+              "Auto"
+            ],
+            "id": 179,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "On"
+          },
+          "SRC_AES-A5/6": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Transparent",
+              "On",
+              "Auto"
+            ],
+            "id": 180,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "On"
+          },
+          "SRC_AES-A7/8": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Transparent",
+              "On",
+              "Auto"
+            ],
+            "id": 181,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "On"
+          },
+          "Silence-Level": {
+            "access": "RW-",
+            "default": -60,
+            "id": 190,
+            "kind": "float",
+            "max": -20,
+            "min": -100,
+            "step": 1,
+            "unit": "dBFS",
+            "value": -60
+          },
+          "Silence-Time": {
+            "access": "RW-",
+            "default": 10,
+            "id": 189,
+            "kind": "uint",
+            "max": 60,
+            "min": 1,
+            "step": 1,
+            "unit": "s",
+            "value": 10
+          },
+          "Switch-Back": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 2,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "V-Delay_1": {
+            "access": "RW-",
+            "default": 0,
+            "id": 11,
+            "kind": "int",
+            "max": 1124,
+            "min": 0,
+            "step": 1,
+            "unit": "ln",
+            "value": 0
+          },
+          "V-Delay_2": {
+            "access": "RW-",
+            "default": 0,
+            "id": 14,
+            "kind": "int",
+            "max": 1124,
+            "min": 0,
+            "step": 1,
+            "unit": "ln",
+            "value": 1
+          },
+          "VIDEO": {
+            "access": "RW-",
+            "id": 0,
+            "kind": "string",
+            "max_len": 1,
+            "value": ""
+          }
+        },
+        "identity": {
+          "3G - Capable": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 19,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Card ID": {
+            "access": "R--",
+            "id": 7,
+            "kind": "string",
+            "max_len": 16,
+            "value": "71ef060a0000001f"
+          },
+          "Card description": {
+            "access": "R--",
+            "id": 2,
+            "kind": "string",
+            "max_len": 16,
+            "value": "HRB990-1010.html"
+          },
+          "Card name": {
+            "access": "R--",
+            "id": 0,
+            "kind": "string",
+            "max_len": 8,
+            "value": "HRB990"
+          },
+          "DM-A GEG-AI": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 23,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "DM-A GEG-DI": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 24,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "DM-A HW Rev": {
+            "access": "R--",
+            "id": 11,
+            "kind": "string",
+            "max_len": 16,
+            "value": "0100"
+          },
+          "DM-A Name": {
+            "access": "R--",
+            "id": 10,
+            "kind": "string",
+            "max_len": 16,
+            "value": "GEG-DI"
+          },
+          "DM-A Pr.code": {
+            "access": "R--",
+            "id": 12,
+            "kind": "string",
+            "max_len": 10,
+            "value": "9490640010"
+          },
+          "DM-A Serial": {
+            "access": "R--",
+            "id": 13,
+            "kind": "string",
+            "max_len": 16,
+            "value": "PR000028"
+          },
+          "DM-A Support": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 21,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "DM-B GEG-AO": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 25,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "DM-B GEG-DO": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 26,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "DM-B HW Rev": {
+            "access": "R--",
+            "id": 15,
+            "kind": "string",
+            "max_len": 16,
+            "value": "0100"
+          },
+          "DM-B Name": {
+            "access": "R--",
+            "id": 14,
+            "kind": "string",
+            "max_len": 16,
+            "value": "GEG-DO"
+          },
+          "DM-B Pr.code": {
+            "access": "R--",
+            "id": 16,
+            "kind": "string",
+            "max_len": 10,
+            "value": "9490610010"
+          },
+          "DM-B Serial": {
+            "access": "R--",
+            "id": 17,
+            "kind": "string",
+            "max_len": 16,
+            "value": "007"
+          },
+          "DM-B Support": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 22,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Dual Video Input": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 20,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Features": {
+            "access": "R--",
+            "id": 9,
+            "kind": "string",
+            "max_len": 8,
+            "value": "00A33E39"
+          },
+          "HD - Capable": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Option",
+              "OK"
+            ],
+            "id": 18,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Option"
+          },
+          "Hardware rev": {
+            "access": "R--",
+            "id": 4,
+            "kind": "string",
+            "max_len": 4,
+            "value": "0300"
+          },
+          "Key": {
+            "access": "RW-",
+            "id": 8,
+            "kind": "string",
+            "max_len": 15,
+            "value": "empty string"
+          },
+          "Product code": {
+            "access": "R--",
+            "id": 5,
+            "kind": "string",
+            "max_len": 10,
+            "value": "9490600011"
+          },
+          "Serial number": {
+            "access": "R--",
+            "id": 6,
+            "kind": "string",
+            "max_len": 16,
+            "value": "PR011617"
+          },
+          "Software rev": {
+            "access": "R--",
+            "id": 3,
+            "kind": "string",
+            "max_len": 4,
+            "value": "1010"
+          },
+          "User label": {
+            "access": "RW-",
+            "id": 1,
+            "kind": "string",
+            "max_len": 16,
+            "value": "3G/HD/SD Re-Emb"
+          }
+        },
+        "status": {
+          "ANC-Rl1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Error"
+            ],
+            "id": 23,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "ANC-Rl2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Error"
+            ],
+            "id": 24,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "ATC-Stat_AB": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Present",
+              "Error"
+            ],
+            "id": 21,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "ATC-Stat_CD": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Present",
+              "Error"
+            ],
+            "id": 22,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Active-Out1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "SDI1",
+              "SDI2"
+            ],
+            "id": 16,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI1"
+          },
+          "Active-Out2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "SDI1",
+              "SDI2"
+            ],
+            "id": 17,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "SDI1"
+          },
+          "AddOnFrmtInB1/2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 41,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtInB3/4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 42,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtInD1/2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 43,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtInD3/4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 44,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtOutA1/2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 81,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtOutA3/4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 82,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtOutC1/2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 83,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "AddOnFrmtOutC3/4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 84,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "CRC-Stat_1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "OK",
+              "CRC Error"
+            ],
+            "id": 6,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "OK"
+          },
+          "CRC-Stat_2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "OK",
+              "CRC Error"
+            ],
+            "id": 7,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "OK"
+          },
+          "DM-A_Status": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Error"
+            ],
+            "id": 94,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "DM-A_Type": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Digital Input",
+              "Digital Output",
+              "Analog Input",
+              "Analog Output"
+            ],
+            "id": 93,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "DM-B_Status": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Error"
+            ],
+            "id": 96,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "DM-B_Type": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Digital Input",
+              "Digital Output",
+              "Analog Input",
+              "Analog Output"
+            ],
+            "id": 95,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutA1/2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 61,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutA3/4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 62,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutB1/2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 63,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutB3/4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 64,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutC1/2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 65,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutC3/4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 66,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutD1/2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 67,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbFrmtOutD3/4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 68,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutA1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 45,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutA2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 46,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutA3": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 47,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutA4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 48,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutB1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 49,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutB2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 50,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutB3": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 51,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutB4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 52,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutC1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 53,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutC2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 54,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutC3": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 55,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutC4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 56,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutD1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 57,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutD2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 58,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutD3": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 59,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EmbStatOutD4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 60,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "FPGA-Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "OK",
+              "Error"
+            ],
+            "id": 92,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "OK"
+          },
+          "GPI": {
+            "access": "R--",
+            "default": 0,
+            "id": 20,
+            "kind": "int",
+            "max": 7,
+            "min": 0,
+            "step": 1,
+            "value": 0
+          },
+          "Grp-Ins_AB": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "Ok",
+              "Error"
+            ],
+            "id": 27,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ok"
+          },
+          "Grp-Ins_CD": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "Ok",
+              "Error"
+            ],
+            "id": 28,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ok"
+          },
+          "GrpInUse_AB": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "____",
+              "1___",
+              "_2__",
+              "12__",
+              "__3_",
+              "1_3_",
+              "_23_",
+              "123_",
+              "___4",
+              "1__4",
+              "_2_4",
+              "12_4",
+              "__34",
+              "1_34",
+              "_234",
+              "1234"
+            ],
+            "id": 25,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "____"
+          },
+          "GrpInUse_CD": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "____",
+              "1___",
+              "_2__",
+              "12__",
+              "__3_",
+              "1_3_",
+              "_23_",
+              "123_",
+              "___4",
+              "1__4",
+              "_2_4",
+              "12_4",
+              "__34",
+              "1_34",
+              "_234",
+              "1234"
+            ],
+            "id": 26,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "____"
+          },
+          "IO-Delay_1": {
+            "access": "R--",
+            "default": 0,
+            "id": 18,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "IO-Delay_2": {
+            "access": "R--",
+            "default": 0,
+            "id": 19,
+            "kind": "float",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "ms",
+            "value": 0
+          },
+          "LocFrmtInA1/2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 37,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "LocFrmtInA3/4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 38,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "LocFrmtInA5/6": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 39,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "LocFrmtInA7/8": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 40,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "LocFrmtOutB1/2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 77,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "LocFrmtOutB3/4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 78,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "LocFrmtOutB5/6": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 79,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "LocFrmtOutB7/8": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "PCM",
+              "Null",
+              "AC-3",
+              "TimeStmp",
+              "MPEG-1",
+              "MPEG-2",
+              "SMPTE-KLV",
+              "Dolby E",
+              "Caption data",
+              "UserDef",
+              "Rsvd",
+              "Enh AC-3"
+            ],
+            "id": 80,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "LocMetaProg": {
+            "access": "R--",
+            "default": 11,
+            "enum_items": [
+              "5.1+2",
+              "5.1+1+1",
+              "4+4",
+              "4x2",
+              "8x1",
+              "5.1",
+              "3x2",
+              "4",
+              "2+2",
+              "7.1",
+              "Other",
+              "NA"
+            ],
+            "id": 91,
+            "kind": "enum",
+            "value": 11,
+            "value_name": "NA"
+          },
+          "LocMetaStat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Error"
+            ],
+            "id": 90,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "LocStatInA1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 29,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "LocStatInA2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 30,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "LocStatInA3": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 31,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "LocStatInA4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 32,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "LocStatInA5": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 33,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "LocStatInA6": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 34,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "LocStatInA7": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 35,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "LocStatInA8": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 36,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "LocStatOutB1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 69,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "LocStatOutB2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 70,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "LocStatOutB3": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 71,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "LocStatOutB4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 72,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "LocStatOutB5": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 73,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "LocStatOutB6": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 74,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "LocStatOutB7": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 75,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "LocStatOutB8": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Clipped",
+              "Silence"
+            ],
+            "id": 76,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Locked-To": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "Not Locked",
+              "Ref",
+              "SDI1",
+              "SDI2"
+            ],
+            "id": 15,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Not Locked"
+          },
+          "Phaser1_H_Pos": {
+            "access": "R--",
+            "default": 0,
+            "id": 9,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "px",
+            "value": 0
+          },
+          "Phaser1_Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Safe",
+              "Warning",
+              "Critical"
+            ],
+            "id": 11,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Phaser2_H_Pos": {
+            "access": "R--",
+            "default": 0,
+            "id": 10,
+            "kind": "int",
+            "max": 5000,
+            "min": 0,
+            "step": 1,
+            "unit": "px",
+            "value": 0
+          },
+          "Phaser2_Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Safe",
+              "Warning",
+              "Critical"
+            ],
+            "id": 12,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Rail1S2020Prog": {
+            "access": "R--",
+            "default": 11,
+            "enum_items": [
+              "5.1+2",
+              "5.1+1+1",
+              "4+4",
+              "4x2",
+              "8x1",
+              "5.1",
+              "3x2",
+              "4",
+              "2+2",
+              "7.1",
+              "Other",
+              "NA"
+            ],
+            "id": 86,
+            "kind": "enum",
+            "value": 11,
+            "value_name": "NA"
+          },
+          "Rail1S2020Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Error"
+            ],
+            "id": 85,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Rail2S2020Prog": {
+            "access": "R--",
+            "default": 11,
+            "enum_items": [
+              "5.1+2",
+              "5.1+1+1",
+              "4+4",
+              "4x2",
+              "8x1",
+              "5.1",
+              "3x2",
+              "4",
+              "2+2",
+              "7.1",
+              "Other",
+              "NA"
+            ],
+            "id": 88,
+            "kind": "enum",
+            "value": 11,
+            "value_name": "NA"
+          },
+          "Rail2S2020Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok",
+              "Error"
+            ],
+            "id": 87,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Ref-Format": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "NTSC/480i",
+              "PAL/576i",
+              "480p",
+              "576p",
+              "720p",
+              "1080i",
+              "1080p"
+            ],
+            "id": 8,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "S2020-Src_Ass_Ch": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "None",
+              "Ch01/02",
+              "Ch03/04",
+              "Ch05/06",
+              "Ch07/08",
+              "Ch09/10",
+              "Ch11/12",
+              "Ch13/14",
+              "Ch15/16"
+            ],
+            "id": 89,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "SDI-Freq_1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "1:1",
+              "1:1.001"
+            ],
+            "id": 4,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "SDI-Freq_2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "1:1",
+              "1:1.001"
+            ],
+            "id": 5,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "SDI-Input_1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "1080p60",
+              "1080p50",
+              "1080p30",
+              "1080p25",
+              "1080p24",
+              "1080i50",
+              "1080i60",
+              "1035i60",
+              "720p60",
+              "720p50",
+              "720p30",
+              "720p25",
+              "SD625",
+              "SD525"
+            ],
+            "id": 0,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "SDI-Input_2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "1080p60",
+              "1080p50",
+              "1080p30",
+              "1080p25",
+              "1080p24",
+              "1080i50",
+              "1080i60",
+              "1035i60",
+              "720p60",
+              "720p50",
+              "720p30",
+              "720p25",
+              "SD625",
+              "SD525"
+            ],
+            "id": 1,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "SDI-Map_1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Level A",
+              "Level B"
+            ],
+            "id": 2,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "SDI-Map_2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Level A",
+              "Level B"
+            ],
+            "id": 3,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "SDI1-Ref_Offset": {
+            "access": "R--",
+            "default": 0,
+            "id": 13,
+            "kind": "float",
+            "max": 40000,
+            "min": 0,
+            "step": 1,
+            "unit": "us",
+            "value": 0
+          },
+          "SDI2-Ref_Offset": {
+            "access": "R--",
+            "default": 0,
+            "id": 14,
+            "kind": "float",
+            "max": 40000,
+            "min": 0,
+            "step": 1,
+            "unit": "us",
+            "value": 0
+          }
+        }
+      },
+      "slot": 19,
+      "status": "present",
+      "walked_at": "2026-05-05T10:21:45Z"
+    }
+  ]
+}

--- a/tests/fixtures/products/axon/synapse/RRS18-1601/acp1/slot_0.json
+++ b/tests/fixtures/products/axon/synapse/RRS18-1601/acp1/slot_0.json
@@ -1,0 +1,507 @@
+{
+  "created_at": "2026-05-05T10:21:44Z",
+  "device": {
+    "ip": "10.6.239.113",
+    "port": 2071,
+    "protocol": "acp1",
+    "protocol_version": 1,
+    "num_slots": 31
+  },
+  "generator": "acp dev",
+  "slots": [
+    {
+      "objects": {
+        "alarm": {
+          "Announcements": {
+            "access": "RW-",
+            "id": 0,
+            "kind": "alarm",
+            "value": 1
+          },
+          "Card-Presence": {
+            "access": "RW-",
+            "id": 5,
+            "kind": "alarm",
+            "value": 0
+          },
+          "PSU_B": {
+            "access": "RW-",
+            "id": 2,
+            "kind": "alarm",
+            "value": 0
+          },
+          "PSU_T": {
+            "access": "RW-",
+            "id": 1,
+            "kind": "alarm",
+            "value": 0
+          },
+          "Ref_Backup": {
+            "access": "RW-",
+            "id": 4,
+            "kind": "alarm",
+            "value": 0
+          },
+          "Temperature": {
+            "access": "RW-",
+            "id": 3,
+            "kind": "alarm",
+            "value": 0
+          }
+        },
+        "control": {
+          "Broadcasts": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 4,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "On"
+          },
+          "ErrorThreshold": {
+            "access": "RW-",
+            "default": 10,
+            "id": 8,
+            "kind": "uint",
+            "max": 255,
+            "min": 0,
+            "step": 1,
+            "value": 10
+          },
+          "FW": {
+            "access": "RW-",
+            "id": 6,
+            "kind": "ipaddr",
+            "value": "0.0.0.0"
+          },
+          "Forwarding": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 5,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "IP_Conf": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Manual",
+              "DHCP"
+            ],
+            "id": 0,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "DHCP"
+          },
+          "NetwPrefix": {
+            "access": "RW-",
+            "default": 0,
+            "id": 7,
+            "kind": "uint",
+            "max": 32,
+            "min": 0,
+            "step": 1,
+            "unit": "bits",
+            "value": 0
+          },
+          "Redund_Pwr_Test": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 9,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "TD_0": {
+            "access": "RW-",
+            "id": 11,
+            "kind": "ipaddr",
+            "value": "0.0.0.0"
+          },
+          "TD_1": {
+            "access": "RW-",
+            "id": 13,
+            "kind": "ipaddr",
+            "value": "0.0.0.0"
+          },
+          "Trap-Dest_0": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 10,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "Trap-Dest_1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Off",
+              "On"
+            ],
+            "id": 12,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Off"
+          },
+          "mGW": {
+            "access": "RW-",
+            "id": 3,
+            "kind": "ipaddr",
+            "value": "0.0.0.0"
+          },
+          "mIP": {
+            "access": "RW-",
+            "id": 1,
+            "kind": "ipaddr",
+            "value": "0.0.0.0"
+          },
+          "mNM": {
+            "access": "RW-",
+            "id": 2,
+            "kind": "ipaddr",
+            "value": "0.0.0.0"
+          }
+        },
+        "identity": {
+          "Card ID": {
+            "access": "R--",
+            "id": 7,
+            "kind": "string",
+            "max_len": 16,
+            "value": "71ef060a00000000"
+          },
+          "Card description": {
+            "access": "R--",
+            "id": 2,
+            "kind": "string",
+            "max_len": 32,
+            "value": "Virtual Rack Controller"
+          },
+          "Card name": {
+            "access": "R--",
+            "id": 0,
+            "kind": "string",
+            "max_len": 8,
+            "value": "RRS18"
+          },
+          "Hardware rev": {
+            "access": "R--",
+            "id": 4,
+            "kind": "string",
+            "max_len": 4,
+            "value": "0100"
+          },
+          "Product code": {
+            "access": "R--",
+            "id": 5,
+            "kind": "string",
+            "max_len": 10,
+            "value": "9410070001"
+          },
+          "Serial number": {
+            "access": "R--",
+            "id": 6,
+            "kind": "string",
+            "max_len": 6,
+            "value": "001633"
+          },
+          "Software rev": {
+            "access": "R--",
+            "id": 3,
+            "kind": "string",
+            "max_len": 4,
+            "value": "1601"
+          },
+          "User label": {
+            "access": "RW-",
+            "id": 1,
+            "kind": "string",
+            "max_len": 16,
+            "value": "Synapse Simulator"
+          }
+        },
+        "status": {
+          "GW": {
+            "access": "R--",
+            "id": 3,
+            "kind": "ipaddr",
+            "value": "0.0.0.0"
+          },
+          "IP": {
+            "access": "R--",
+            "id": 1,
+            "kind": "ipaddr",
+            "value": "0.0.0.0"
+          },
+          "IP_Addr": {
+            "access": "R--",
+            "default": 1,
+            "enum_items": [
+              "Manual",
+              "DHCP-Asking",
+              "DHCP-Leased",
+              "DHCP-Infin."
+            ],
+            "id": 0,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "DHCP-Asking"
+          },
+          "MIB_S0": {
+            "access": "R--",
+            "id": 12,
+            "kind": "string",
+            "max_len": 11,
+            "value": "RRS18v16   "
+          },
+          "MIB_S1": {
+            "access": "R--",
+            "id": 13,
+            "kind": "string",
+            "max_len": 11,
+            "value": "CDV08v06   "
+          },
+          "MIB_S10": {
+            "access": "R--",
+            "id": 22,
+            "kind": "string",
+            "max_len": 11,
+            "value": "SAM08v07   "
+          },
+          "MIB_S11": {
+            "access": "R--",
+            "id": 23,
+            "kind": "string",
+            "max_len": 11,
+            "value": "DAC24v04   "
+          },
+          "MIB_S12": {
+            "access": "R--",
+            "id": 24,
+            "kind": "string",
+            "max_len": 11,
+            "value": "AAD08v02   "
+          },
+          "MIB_S13": {
+            "access": "R--",
+            "id": 25,
+            "kind": "string",
+            "max_len": 11,
+            "value": "AAD08v04   "
+          },
+          "MIB_S14": {
+            "access": "R--",
+            "id": 26,
+            "kind": "string",
+            "max_len": 11,
+            "value": "empty"
+          },
+          "MIB_S15": {
+            "access": "R--",
+            "id": 27,
+            "kind": "string",
+            "max_len": 11,
+            "value": "empty"
+          },
+          "MIB_S16": {
+            "access": "R--",
+            "id": 28,
+            "kind": "string",
+            "max_len": 11,
+            "value": "empty"
+          },
+          "MIB_S17": {
+            "access": "R--",
+            "id": 29,
+            "kind": "string",
+            "max_len": 11,
+            "value": "empty"
+          },
+          "MIB_S18": {
+            "access": "R--",
+            "id": 30,
+            "kind": "string",
+            "max_len": 11,
+            "value": "HQW09v22   "
+          },
+          "MIB_S2": {
+            "access": "R--",
+            "id": 14,
+            "kind": "string",
+            "max_len": 11,
+            "value": "ASV10v12   "
+          },
+          "MIB_S3": {
+            "access": "R--",
+            "id": 15,
+            "kind": "string",
+            "max_len": 11,
+            "value": "ADC24v07   "
+          },
+          "MIB_S4": {
+            "access": "R--",
+            "id": 16,
+            "kind": "string",
+            "max_len": 11,
+            "value": "ADC24v07   "
+          },
+          "MIB_S5": {
+            "access": "R--",
+            "id": 17,
+            "kind": "string",
+            "max_len": 11,
+            "value": "ASM10v03   "
+          },
+          "MIB_S6": {
+            "access": "R--",
+            "id": 18,
+            "kind": "string",
+            "max_len": 11,
+            "value": "ADC24v07   "
+          },
+          "MIB_S7": {
+            "access": "R--",
+            "id": 19,
+            "kind": "string",
+            "max_len": 11,
+            "value": "ADC24v07   "
+          },
+          "MIB_S8": {
+            "access": "R--",
+            "id": 20,
+            "kind": "string",
+            "max_len": 11,
+            "value": "SDR08v05   "
+          },
+          "MIB_S9": {
+            "access": "R--",
+            "id": 21,
+            "kind": "string",
+            "max_len": 11,
+            "value": "SIM21v04   "
+          },
+          "NM": {
+            "access": "R--",
+            "id": 2,
+            "kind": "ipaddr",
+            "value": "0.0.0.0"
+          },
+          "PSU_Bottom": {
+            "access": "R--",
+            "default": 1,
+            "enum_items": [
+              "NA",
+              "OK"
+            ],
+            "id": 5,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "OK"
+          },
+          "PSU_Top": {
+            "access": "R--",
+            "default": 1,
+            "enum_items": [
+              "NA",
+              "OK"
+            ],
+            "id": 4,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "OK"
+          },
+          "Redund_Ref_Pwr": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "OK"
+            ],
+            "id": 11,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Rx_Packet_Loss": {
+            "access": "R--",
+            "default": 0,
+            "id": 10,
+            "kind": "int",
+            "max": 32767,
+            "min": 0,
+            "step": 1,
+            "value": 0
+          },
+          "SPF_Progress": {
+            "access": "R--",
+            "default": 0,
+            "id": 8,
+            "kind": "float",
+            "max": 100,
+            "min": 0,
+            "step": 1,
+            "unit": "%",
+            "value": 0
+          },
+          "SPF_Status": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "Idle",
+              "Busy",
+              "Done",
+              "Error"
+            ],
+            "id": 9,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Idle"
+          },
+          "Temp_Left": {
+            "access": "R--",
+            "default": 24,
+            "id": 6,
+            "kind": "int",
+            "max": 127,
+            "min": -128,
+            "step": 1,
+            "unit": "deg.C",
+            "value": 24
+          },
+          "Temp_Right": {
+            "access": "R--",
+            "default": 27,
+            "id": 7,
+            "kind": "int",
+            "max": 127,
+            "min": -128,
+            "step": 1,
+            "unit": "deg.C",
+            "value": 27
+          }
+        }
+      },
+      "slot": 0,
+      "status": "present",
+      "walked_at": "2026-05-05T10:21:44Z"
+    }
+  ]
+}

--- a/tests/fixtures/products/axon/synapse/SDB20-0806/acp1/slot_9.json
+++ b/tests/fixtures/products/axon/synapse/SDB20-0806/acp1/slot_9.json
@@ -1,0 +1,778 @@
+{
+  "created_at": "2026-05-05T10:21:45Z",
+  "device": {
+    "ip": "10.6.239.113",
+    "port": 2071,
+    "protocol": "acp1",
+    "protocol_version": 1,
+    "num_slots": 31
+  },
+  "generator": "acp dev",
+  "slots": [
+    {
+      "objects": {
+        "alarm": {
+          "ANC-Status": {
+            "access": "RW-",
+            "id": 3,
+            "kind": "alarm",
+            "value": 0
+          },
+          "Announcements": {
+            "access": "RW-",
+            "id": 0,
+            "kind": "alarm",
+            "value": 1
+          },
+          "EDH-Status": {
+            "access": "RW-",
+            "id": 2,
+            "kind": "alarm",
+            "value": 0
+          },
+          "Input": {
+            "access": "RW-",
+            "id": 1,
+            "kind": "alarm",
+            "value": 0
+          }
+        },
+        "control": {
+          "AddOn_A1": {
+            "access": "RW-",
+            "default": 4,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 4,
+            "kind": "enum",
+            "value": 4,
+            "value_name": "Ch_5"
+          },
+          "AddOn_A2": {
+            "access": "RW-",
+            "default": 5,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 5,
+            "kind": "enum",
+            "value": 5,
+            "value_name": "Ch_6"
+          },
+          "AddOn_A3": {
+            "access": "RW-",
+            "default": 6,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 6,
+            "kind": "enum",
+            "value": 6,
+            "value_name": "Ch_7"
+          },
+          "AddOn_A4": {
+            "access": "RW-",
+            "default": 7,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 7,
+            "kind": "enum",
+            "value": 7,
+            "value_name": "Ch_8"
+          },
+          "AddOn_B1": {
+            "access": "RW-",
+            "default": 8,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 8,
+            "kind": "enum",
+            "value": 8,
+            "value_name": "Ch_9"
+          },
+          "AddOn_B2": {
+            "access": "RW-",
+            "default": 9,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 9,
+            "kind": "enum",
+            "value": 9,
+            "value_name": "Ch_10"
+          },
+          "AddOn_B3": {
+            "access": "RW-",
+            "default": 10,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 10,
+            "kind": "enum",
+            "value": 10,
+            "value_name": "Ch_11"
+          },
+          "AddOn_B4": {
+            "access": "RW-",
+            "default": 11,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 11,
+            "kind": "enum",
+            "value": 11,
+            "value_name": "Ch_12"
+          },
+          "EDH-Det": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Active-P",
+              "Full-F"
+            ],
+            "id": 22,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Active-P"
+          },
+          "Gain-Ch_1": {
+            "access": "RW-",
+            "default": 0,
+            "id": 12,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "Gain-Ch_2": {
+            "access": "RW-",
+            "default": 0,
+            "id": 13,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "Gain-Ch_3": {
+            "access": "RW-",
+            "default": 0,
+            "id": 14,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "Gain-Ch_4": {
+            "access": "RW-",
+            "default": 0,
+            "id": 15,
+            "kind": "float",
+            "max": 12,
+            "min": -999,
+            "step": 1,
+            "unit": "dB",
+            "value": 0
+          },
+          "Out_1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 0,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ch_1"
+          },
+          "Out_1/2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Stereo",
+              "Mono"
+            ],
+            "id": 20,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Stereo"
+          },
+          "Out_2": {
+            "access": "RW-",
+            "default": 1,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 1,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "Ch_2"
+          },
+          "Out_3": {
+            "access": "RW-",
+            "default": 2,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 2,
+            "kind": "enum",
+            "value": 2,
+            "value_name": "Ch_3"
+          },
+          "Out_3/4": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "Stereo",
+              "Mono"
+            ],
+            "id": 21,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Stereo"
+          },
+          "Out_4": {
+            "access": "RW-",
+            "default": 3,
+            "enum_items": [
+              "Ch_1",
+              "Ch_2",
+              "Ch_3",
+              "Ch_4",
+              "Ch_5",
+              "Ch_6",
+              "Ch_7",
+              "Ch_8",
+              "Ch_9",
+              "Ch_10",
+              "Ch_11",
+              "Ch_12",
+              "Ch_13",
+              "Ch_14",
+              "Ch_15",
+              "Ch_16"
+            ],
+            "id": 3,
+            "kind": "enum",
+            "value": 3,
+            "value_name": "Ch_4"
+          },
+          "Phase-Ch_1": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 16,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "Phase-Ch_2": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 17,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "Phase-Ch_3": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 18,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          },
+          "Phase-Ch_4": {
+            "access": "RW-",
+            "default": 0,
+            "enum_items": [
+              "0 deg",
+              "180 deg"
+            ],
+            "id": 19,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "0 deg"
+          }
+        },
+        "identity": {
+          "Card ID": {
+            "access": "R--",
+            "id": 7,
+            "kind": "string",
+            "max_len": 16,
+            "value": "71ef060a00000009"
+          },
+          "Card description": {
+            "access": "R--",
+            "id": 2,
+            "kind": "string",
+            "max_len": 32,
+            "value": "SDB20-0806.html"
+          },
+          "Card name": {
+            "access": "R--",
+            "id": 0,
+            "kind": "string",
+            "max_len": 8,
+            "value": "SDB20"
+          },
+          "Hardware rev": {
+            "access": "R--",
+            "id": 4,
+            "kind": "string",
+            "max_len": 4,
+            "value": "0101"
+          },
+          "Product code": {
+            "access": "R--",
+            "id": 5,
+            "kind": "string",
+            "max_len": 10,
+            "value": "9460020001"
+          },
+          "Serial number": {
+            "access": "R--",
+            "id": 6,
+            "kind": "string",
+            "max_len": 6,
+            "value": "000604"
+          },
+          "Software rev": {
+            "access": "R--",
+            "id": 3,
+            "kind": "string",
+            "max_len": 4,
+            "value": "0806"
+          },
+          "User label": {
+            "access": "RW-",
+            "id": 1,
+            "kind": "string",
+            "max_len": 16,
+            "value": "Audio De-embedder"
+          }
+        },
+        "status": {
+          "ANC-Stat": {
+            "access": "R--",
+            "default": 1,
+            "enum_items": [
+              "NA",
+              "NA",
+              "Ok",
+              "Error"
+            ],
+            "id": 14,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "NA"
+          },
+          "Audio-Ch_1": {
+            "access": "R--",
+            "default": 1,
+            "enum_items": [
+              "NA",
+              "NA",
+              "Ok",
+              "Clipped"
+            ],
+            "id": 2,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "NA"
+          },
+          "Audio-Ch_2": {
+            "access": "R--",
+            "default": 1,
+            "enum_items": [
+              "NA",
+              "NA",
+              "Ok",
+              "Clipped"
+            ],
+            "id": 3,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "NA"
+          },
+          "Audio-Ch_3": {
+            "access": "R--",
+            "default": 1,
+            "enum_items": [
+              "NA",
+              "NA",
+              "Ok",
+              "Clipped"
+            ],
+            "id": 4,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "NA"
+          },
+          "Audio-Ch_4": {
+            "access": "R--",
+            "default": 1,
+            "enum_items": [
+              "NA",
+              "NA",
+              "Ok",
+              "Clipped"
+            ],
+            "id": 5,
+            "kind": "enum",
+            "value": 1,
+            "value_name": "NA"
+          },
+          "Audio_A1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok"
+            ],
+            "id": 6,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Audio_A2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok"
+            ],
+            "id": 7,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Audio_A3": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok"
+            ],
+            "id": 8,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Audio_A4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok"
+            ],
+            "id": 9,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Audio_B1": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok"
+            ],
+            "id": 10,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Audio_B2": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok"
+            ],
+            "id": 11,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Audio_B3": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok"
+            ],
+            "id": 12,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "Audio_B4": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Ok"
+            ],
+            "id": 13,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          },
+          "EDH-Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "Ok",
+              "UES",
+              "EDA",
+              "EDH"
+            ],
+            "id": 15,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ok"
+          },
+          "FPGA-Stat": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "Ok",
+              "Error"
+            ],
+            "id": 16,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "Ok"
+          },
+          "GrpInUse": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "____",
+              "1___",
+              "_2__",
+              "12__",
+              "__3_",
+              "1_3_",
+              "_23_",
+              "123_",
+              "___4",
+              "1__4",
+              "_2_4",
+              "12_4",
+              "__34",
+              "1_34",
+              "_234",
+              "1234"
+            ],
+            "id": 1,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "____"
+          },
+          "SDI-Input": {
+            "access": "R--",
+            "default": 0,
+            "enum_items": [
+              "NA",
+              "Present"
+            ],
+            "id": 0,
+            "kind": "enum",
+            "value": 0,
+            "value_name": "NA"
+          }
+        }
+      },
+      "slot": 9,
+      "status": "present",
+      "walked_at": "2026-05-05T10:21:45Z"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Last Phase 1 piece. Wires `Plugin.SessionHealth(ctx)` on the ACP1 consumer per the design table from #248.

| Layer | Source |
| --- | --- |
| Reachable | on-demand TCP SYN test to the saved host:port (500ms cap) |
| Connected | `p.client != nil` after `Connect` |
| Live | `time.Since(lastRx) <= 90s` |

`StaleAfter = 90s` matches the Synapse rack-controller announce cadence.

## Implementation

- `timestampSink` holds `lastRxNS` / `lastTxNS` as `atomic.Int64` (wall-clock UnixNano). Lock-free reads via `atomic.Load`; one atomic store per wire event.
- `timestampingTransport` wraps the inner `Transport` at Connect time and updates the sink on every `Send` / `Receive`.
- `probeReachable` does a single TCP dial with a 500ms cap (or the caller's ctx deadline, whichever is shorter) — cheap, cross-platform, no ICMP privileges needed.

## TCP timestamp limitation

Today the timestamp tap only wraps the UDP path. `TCPClient` holds `*TCPConn` directly (same pattern as the existing recorder limitation). When `TCPClient` migrates to the `Transport` interface, the tap applies uniformly. Out of scope for this PR.

## Test plan

- [x] `go test ./internal/acp1/consumer/... -count=1` — green (8 new + all existing).
- [x] Whole-repo smoke: `go test ./... -count=1` clean.
- [x] `go build ./...` clean.
- [x] golangci-lint clean.
- [ ] Live: `dhs consumer acp1 health 10.6.239.113 --watch` against Synapse Simulator; pull cable; verify Reachable / Connected / Live flips at expected boundaries.

## Stacked on

PR #287 (capture parity audit). Merge order: Phase 0 (#267-#272) → #273 → ... → #286 → #287 → this. **This is the last Phase 1 sub-PR.**

## Issue refs

Advances #266. Closes on the eventual PR-to-main when the ACP1 epic bundle lands together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
