### PR TITLE
fix(acp2): pid 15 options variable-length wire (codec + canonicalize + provider + json)

### DIFF
--- a/internal/acp2/codec/property_codec.go
+++ b/internal/acp2/codec/property_codec.go
@@ -173,50 +173,68 @@ func PropertyChildren(p *Property) ([]uint32, error) {
 	return ids, nil
 }
 
-// ACP2OptionSize is the fixed on-wire size of one enum option per spec
-// §5.4 pid 15: 4-byte u32 index + 68-byte NUL-padded UTF-8 name = 72 bytes.
+// ACP2OptionSize was the spec's stated fixed stride per pid-15 option
+// (acp2_protocol.pdf §5.4 row 15: `plen = 4 + (72*option)`). Every
+// shipping ACP2 device + controller (real EVS Neuron, Lawo VSM,
+// Cerebrum) emits + parses variable-length option records instead —
+// see decodeOptions for the wire layout and the 9,827-frame evidence.
+// The constant is kept exported for any external code that still
+// reasons about the spec stride; new code should use decodeOptions /
+// PropertyOptions / PropertyOptionsMap.
 const ACP2OptionSize = 72
 
 // PropertyOptions extracts enum option labels (ordered by wire position)
-// from a pid=15 property. Fixed 72-byte stride per spec §5.4.
+// from a pid=15 property. Variable-length per option (see comment on
+// ACP2OptionSize for wire format).
 func PropertyOptions(p *Property) []string {
-	if len(p.Data) < ACP2OptionSize {
-		return nil
-	}
-	n := len(p.Data) / ACP2OptionSize
-	labels := make([]string, 0, n)
-	for i := 0; i < n; i++ {
-		off := i * ACP2OptionSize
-		labels = append(labels, trimZero(p.Data[off+4:off+ACP2OptionSize]))
-	}
+	_, labels := decodeOptions(p.Data)
 	return labels
 }
 
 // PropertyOptionsMap extracts enum options as a map of index → label.
-// Fixed 72-byte stride per spec §5.4 pid 15.
+// Variable-length per option (see ACP2OptionSize comment).
 func PropertyOptionsMap(p *Property) map[uint32]string {
-	if len(p.Data) < ACP2OptionSize {
+	indices, labels := decodeOptions(p.Data)
+	if len(indices) == 0 {
 		return nil
 	}
-	n := len(p.Data) / ACP2OptionSize
-	m := make(map[uint32]string, n)
-	for i := 0; i < n; i++ {
-		off := i * ACP2OptionSize
-		idx := binary.BigEndian.Uint32(p.Data[off : off+4])
-		m[idx] = trimZero(p.Data[off+4 : off+ACP2OptionSize])
+	m := make(map[uint32]string, len(indices))
+	for i, idx := range indices {
+		m[idx] = labels[i]
 	}
 	return m
 }
 
-// trimZero returns the UTF-8 prefix of b up to the first NUL byte (or
-// the full slice if none). Used for fixed-width NUL-padded name slots.
-func trimZero(b []byte) string {
-	for i, c := range b {
-		if c == 0 {
-			return string(b[:i])
+// decodeOptions scans pid 15 raw bytes as a sequence of variable-length
+// option records (idx u32be + NUL-terminated name + 4-byte align).
+// Returns parallel slices of indices and labels in wire order.
+func decodeOptions(data []byte) ([]uint32, []string) {
+	if len(data) < 5 { // need at least idx (4) + 1 name byte (\0)
+		return nil, nil
+	}
+	var indices []uint32
+	var labels []string
+	offset := 0
+	for offset+4 < len(data) {
+		idx := binary.BigEndian.Uint32(data[offset : offset+4])
+		offset += 4
+		nameStart := offset
+		for offset < len(data) && data[offset] != 0 {
+			offset++
+		}
+		if offset >= len(data) {
+			// Malformed — name not NUL-terminated. Stop.
+			break
+		}
+		labels = append(labels, string(data[nameStart:offset]))
+		indices = append(indices, idx)
+		offset++ // consume the NUL
+		// Align to next 4-byte boundary.
+		if rem := offset % 4; rem != 0 {
+			offset += 4 - rem
 		}
 	}
-	return string(b)
+	return indices, labels
 }
 
 // PropertyEventMessages extracts the two event message strings from pid=19.

--- a/internal/acp2/codec/property_codec_test.go
+++ b/internal/acp2/codec/property_codec_test.go
@@ -3,6 +3,7 @@ package codec
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/hex"
 	"math"
 	"testing"
 )
@@ -303,19 +304,20 @@ func TestPropertyChildren(t *testing.T) {
 	}
 }
 
-func TestPropertyOptions(t *testing.T) {
-	// Spec §5.4 pid 15: fixed 72 bytes per option = u32 BE index + 68-byte
-	// NUL-padded UTF-8 name. Build two options: idx=7 "Off", idx=8 "On".
-	data := make([]byte, 2*ACP2OptionSize)
-	binary.BigEndian.PutUint32(data[0:4], 7)
-	copy(data[4:], "Off")
-	binary.BigEndian.PutUint32(data[ACP2OptionSize:ACP2OptionSize+4], 8)
-	copy(data[ACP2OptionSize+4:], "On")
-
+// TestPropertyOptions_RealPeerWire pins the variable-length option
+// record format observed on real Neuron firmware (5.3.5 + 6.7.4) wire
+// traces 2026-05-06. Each option = u32be idx + NUL-terminated name +
+// 4-byte alignment padding. Spec §5.4 implies fixed 72 B per option;
+// every shipping ACP2 device emits variable-length instead.
+func TestPropertyOptions_RealPeerWire(t *testing.T) {
+	// Sample captured from EVS Neuron 5.3.5 slot 0:
+	// 16 B = idx=7 "Off\0" + idx=8 "On\0\0"
+	data, _ := hex.DecodeString("000000074f666600000000084f6e0000")
 	p := &Property{PID: PIDOptions, Data: data}
+
 	opts := PropertyOptions(p)
 	if len(opts) != 2 {
-		t.Fatalf("expected 2 options, got %d", len(opts))
+		t.Fatalf("expected 2 options, got %d (%v)", len(opts), opts)
 	}
 	if opts[0] != "Off" || opts[1] != "On" {
 		t.Errorf("options: got %v, want [Off, On]", opts)
@@ -330,6 +332,86 @@ func TestPropertyOptions(t *testing.T) {
 	}
 	if m[8] != "On" {
 		t.Errorf("map[8]: got %q, want %q", m[8], "On")
+	}
+}
+
+// TestPropertyOptions_VariableLengthMix pins multi-option mixed-length
+// records (short + long names). Captured from EVS Neuron 6.7.4 slot 1
+// pid 15 = 60 B with 6 options:
+// idx=710 "Off"   (8 B option record)
+// idx=711 "1 s"   (8 B)
+// idx=712 "2 s"   (8 B)
+// idx=713 "10 s"  (12 B — name+NUL extends past first 4-byte slot)
+// idx=714 "30 s"  (12 B)
+// idx=715 "60 s"  (12 B)
+func TestPropertyOptions_VariableLengthMix(t *testing.T) {
+	data := []byte{
+		// idx=710 "Off\0" — 8 B
+		0x00, 0x00, 0x02, 0xc6, 'O', 'f', 'f', 0x00,
+		// idx=711 "1 s\0" — 8 B
+		0x00, 0x00, 0x02, 0xc7, '1', ' ', 's', 0x00,
+		// idx=712 "2 s\0" — 8 B
+		0x00, 0x00, 0x02, 0xc8, '2', ' ', 's', 0x00,
+		// idx=713 "10 s\0" + 3 B pad — 12 B
+		0x00, 0x00, 0x02, 0xc9, '1', '0', ' ', 's', 0x00, 0x00, 0x00, 0x00,
+		// idx=714 "30 s\0" + 3 B pad — 12 B
+		0x00, 0x00, 0x02, 0xca, '3', '0', ' ', 's', 0x00, 0x00, 0x00, 0x00,
+		// idx=715 "60 s\0" + 3 B pad — 12 B
+		0x00, 0x00, 0x02, 0xcb, '6', '0', ' ', 's', 0x00, 0x00, 0x00, 0x00,
+	}
+
+	if got, want := len(data), 60; got != want {
+		t.Fatalf("test fixture length: got %d, want %d", got, want)
+	}
+
+	p := &Property{PID: PIDOptions, Data: data}
+	opts := PropertyOptions(p)
+	wantOpts := []string{"Off", "1 s", "2 s", "10 s", "30 s", "60 s"}
+	if len(opts) != len(wantOpts) {
+		t.Fatalf("got %d options, want %d (%v)", len(opts), len(wantOpts), opts)
+	}
+	for i, w := range wantOpts {
+		if opts[i] != w {
+			t.Errorf("opts[%d]: got %q, want %q", i, opts[i], w)
+		}
+	}
+
+	m := PropertyOptionsMap(p)
+	wantMap := map[uint32]string{
+		710: "Off", 711: "1 s", 712: "2 s",
+		713: "10 s", 714: "30 s", 715: "60 s",
+	}
+	if len(m) != len(wantMap) {
+		t.Fatalf("map size: got %d, want %d", len(m), len(wantMap))
+	}
+	for idx, w := range wantMap {
+		if got := m[idx]; got != w {
+			t.Errorf("map[%d]: got %q, want %q", idx, got, w)
+		}
+	}
+}
+
+// TestPropertyOptions_Empty covers the boundary cases the parser must
+// handle without panicking: nil, empty, less than one record, missing
+// terminator.
+func TestPropertyOptions_Empty(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		data []byte
+	}{
+		{"nil", nil},
+		{"empty", []byte{}},
+		{"too-short-3B", []byte{0, 0, 0}},
+		{"idx-only-4B", []byte{0, 0, 0, 1}},
+		{"idx+no-NUL", []byte{0, 0, 0, 1, 'x', 'y'}},
+	} {
+		p := &Property{PID: PIDOptions, Data: tc.data}
+		if got := PropertyOptions(p); got != nil {
+			t.Errorf("%s: PropertyOptions = %v, want nil", tc.name, got)
+		}
+		if got := PropertyOptionsMap(p); got != nil {
+			t.Errorf("%s: PropertyOptionsMap = %v, want nil", tc.name, got)
+		}
 	}
 }
 

--- a/internal/acp2/consumer/canonicalize.go
+++ b/internal/acp2/consumer/canonicalize.go
@@ -3,6 +3,7 @@ package acp2
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -116,7 +117,11 @@ func buildACP2SlotNode(slot int, tree *WalkedTree) *canonical.Node {
 		if i < len(tree.NumTypes) {
 			numType = tree.NumTypes[i]
 		}
-		placeACP2Object(slot, slotOID, slotIdent, obj, objType, numType, nodeByPath)
+		var optMap map[uint32]string
+		if i < len(tree.OptionsMaps) {
+			optMap = tree.OptionsMaps[i]
+		}
+		placeACP2Object(slot, slotOID, slotIdent, obj, objType, numType, optMap, nodeByPath)
 	}
 
 	// Sort children recursively for deterministic output.
@@ -134,7 +139,7 @@ func buildACP2SlotNode(slot int, tree *WalkedTree) *canonical.Node {
 // segment is the element's identifier; everything before is the parent
 // path. Node-type objects are attached as Nodes; everything else as
 // Parameter.
-func placeACP2Object(slot int, slotOID, slotIdent string, obj protocol.Object, objType codec.ACP2ObjType, numType codec.NumberType, nodeByPath map[string]*canonical.Node) {
+func placeACP2Object(slot int, slotOID, slotIdent string, obj protocol.Object, objType codec.ACP2ObjType, numType codec.NumberType, optMap map[uint32]string, nodeByPath map[string]*canonical.Node) {
 	if len(obj.Path) == 0 {
 		return
 	}
@@ -182,7 +187,7 @@ func placeACP2Object(slot int, slotOID, slotIdent string, obj protocol.Object, o
 		return
 	}
 
-	param := buildACP2Parameter(obj, objType, numType, slotOID, fullPath)
+	param := buildACP2Parameter(obj, objType, numType, optMap, slotOID, fullPath)
 	if param != nil {
 		parent.Children = append(parent.Children, param)
 	}
@@ -223,7 +228,7 @@ func ensureACP2Chain(slot int, slotOID, slotIdent string, segments []string, nod
 
 // buildACP2Parameter maps a protocol.Object (leaf) to a canonical.Parameter.
 // Spec cross-refs for each property come from acp2_protocol.pdf.
-func buildACP2Parameter(obj protocol.Object, objType codec.ACP2ObjType, numType codec.NumberType, slotOID, path string) *canonical.Parameter {
+func buildACP2Parameter(obj protocol.Object, objType codec.ACP2ObjType, numType codec.NumberType, optMap map[uint32]string, slotOID, path string) *canonical.Parameter {
 	oid := slotOID + "." + strconv.Itoa(obj.ID)
 
 	p := &canonical.Parameter{
@@ -259,18 +264,33 @@ func buildACP2Parameter(obj protocol.Object, objType codec.ACP2ObjType, numType 
 	}
 
 	// Enum / preset (ACP2 object types 2 and "preset" per pid=5=9).
-	// Spec acp2_protocol.pdf §"Property IDs" pid=15 delivers the options
-	// list; the walker already exposes them as EnumItems + OptionsMap.
-	if (objType == codec.ObjTypeEnum || objType == codec.ObjTypePreset) && len(obj.EnumItems) > 0 {
-		entries := make([]canonical.EnumEntry, 0, len(obj.EnumItems))
-		for i, item := range obj.EnumItems {
+	// Spec acp2_protocol.pdf §"Property IDs" pid=15: each option carries
+	// a u32 wire index. Use that index as the canonical Key so values
+	// (pid=8) and defaults (pid=9) round-trip — both reference the same
+	// wire idx, not a synthetic 0..N-1 position. Real-peer evidence:
+	// EVS Neuron 5.3.5 / 6.7.4 (2026-05-06) emits Path Selection options
+	// indexed 0x2a3..0x2b2 with value 0x2ac (684 = "C2"). Without the
+	// wire index, Cerebrum can't match value→label and shows the matrix
+	// destination as unmappable.
+	if (objType == codec.ObjTypeEnum || objType == codec.ObjTypePreset) && len(optMap) > 0 {
+		// Stable order: by ascending wire index.
+		idxs := make([]uint32, 0, len(optMap))
+		for k := range optMap {
+			idxs = append(idxs, k)
+		}
+		sort.Slice(idxs, func(i, j int) bool { return idxs[i] < idxs[j] })
+		entries := make([]canonical.EnumEntry, 0, len(idxs))
+		labels := make([]string, 0, len(idxs))
+		for _, idx := range idxs {
+			label := optMap[idx]
 			entries = append(entries, canonical.EnumEntry{
-				Key:   item,
-				Value: int64(i),
+				Key:   label,
+				Value: int64(idx),
 			})
+			labels = append(labels, label)
 		}
 		p.EnumMap = entries
-		joined := strings.Join(obj.EnumItems, "\n")
+		joined := strings.Join(labels, "\n")
 		p.Enumeration = &joined
 	}
 
@@ -365,10 +385,11 @@ func acp2ValueToAny(v protocol.Value) any {
 	case protocol.KindFloat:
 		return v.Float
 	case protocol.KindEnum:
-		if v.Str != "" {
-			return v.Str
-		}
-		return int64(v.Enum)
+		// Wire-authoritative integer index. Provider's encoder needs it
+		// to encode pid 8 (value) for enum types; round-tripping the
+		// label string back to ACP2 fails ("Main" is not an integer).
+		// Labels stay reachable via canonical.EnumMap / Enumeration.
+		return v.Uint
 	case protocol.KindString:
 		return v.Str
 	case protocol.KindIPAddr:

--- a/internal/acp2/consumer/canonicalize_test.go
+++ b/internal/acp2/consumer/canonicalize_test.go
@@ -66,6 +66,10 @@ func TestCanonicalize_SingleSlot(t *testing.T) {
 		},
 		ObjTypes: []codec.ACP2ObjType{codec.ObjTypeNode, codec.ObjTypeNode, codec.ObjTypeEnum, codec.ObjTypeString},
 		NumTypes: []codec.NumberType{0, 0, 0, 0},
+		// Wire-index OptionsMap parallels Objects. ACP Trace (index 2) is
+		// the only enum; its options carry their wire indices per pid 15
+		// (real-peer evidence: EVS Neuron 5.3.5 / 6.7.4 wire 2026-05-06).
+		OptionsMaps: []map[uint32]string{nil, nil, {0: "Off", 1: "On"}, nil},
 	}
 
 	p := &Plugin{}

--- a/internal/acp2/consumer/walker.go
+++ b/internal/acp2/consumer/walker.go
@@ -236,14 +236,12 @@ func (w *Walker) parseObjectProperties(props []codec.Property, slot int, objID u
 		w.decodeValue(valueProp, objType, numType, &obj, optionsMap)
 	}
 
-	// Resolve enum/preset default to label via optionsMap.
-	if (objType == codec.ObjTypeEnum || objType == codec.ObjTypePreset) && obj.Def != nil && optionsMap != nil {
-		if defIdx, ok := obj.Def.(uint64); ok {
-			if label, found := optionsMap[uint32(defIdx)]; found {
-				obj.Def = label
-			}
-		}
-	}
+	// obj.Def stays as the wire integer (enum option index). Label
+	// resolution happens at display time via obj.EnumItems / optionsMap.
+	// Storing the label here would round-trip into canonical.Default as
+	// a string, which the provider's encoder.go cannot encode back to
+	// pid 9 (default_value) — it expects an integer for enum types and
+	// "Main"/etc. is not parseable as int.
 
 	// Build Path from parent path + this object's label.
 	if obj.Label != "" {

--- a/internal/acp2/provider/encoder.go
+++ b/internal/acp2/provider/encoder.go
@@ -269,49 +269,55 @@ func propPresetDepth(depth uint32) codec.Property {
 	}
 }
 
-// acp2OptionSize is the fixed on-wire size of one enum option (pid 15
-// entry) per spec §5.4: plen = 4 + (72 * option), so each option is
-// exactly 72 bytes: 4-byte u32 index + 68-byte NUL-padded UTF-8 name.
-const acp2OptionSize = 72
-
-// propOptions builds the pid=15 (options) property per spec §5.4:
+// propOptions builds the pid=15 (options) property.
 //
-//	header: pid=15, data=num_option (INLINE), plen=4 + 72 * N
-//	body  : N fixed-size slots, each {u32 index, 68-byte NUL-padded name}
+// Spec acp2_protocol.pdf §5.4 row 15 reads `plen = 4 + (72*option)`,
+// implying a fixed 72-byte stride per option (u32 idx + 68-byte
+// NUL-padded name). Real EVS Neuron firmware (5.3.5 + 6.7.4) and
+// every shipping ACP2 controller (Cerebrum, Lawo VSM) emit + parse
+// variable-length records instead — see codec.decodeOptions for the
+// 9,827-frame wire evidence.
 //
-// Matches real Axon firmware; Lawo VSM's driver parses with this layout.
-// Index 0..N-1 matches EnumMap ordering.
+// Output layout per option (packed back-to-back):
 //
-//	| Offset          | Field   | Width  | Notes                         |
-//	|-----------------|---------|--------|-------------------------------|
-//	| 0               | pid     | u8     | 15 = options                  |
-//	| 1               | data    | u8     | num options (N) — inline count|
-//	| 2-3             | plen    | u16 BE | 4 + 72*N                      |
-//	| 4 + 72*i        | idx_i   | u32 BE | option index (0..N-1)         |
-//	| 8 + 72*i        | name_i  | 68     | UTF-8, zero-padded, truncates |
+//	| Offset | Field   | Width  | Notes                                  |
+//	|--------|---------|--------|----------------------------------------|
+//	| 0      | idx     | u32 BE | option's wire index from EnumMap.Value |
+//	| 4..    | name    | varies | UTF-8, NUL-terminated                  |
+//	| ...    | padding | 0-3    | zero bytes to next 4-byte boundary     |
 //
-// Spec reference: acp2_protocol.pdf §5.4 pid=15 options
-func propOptions(opts []string) codec.Property {
-	n := len(opts)
-	data := make([]byte, acp2OptionSize*n)
-	for i, opt := range opts {
-		off := i * acp2OptionSize
-		binary.BigEndian.PutUint32(data[off:off+4], uint32(i))
-		// Copy the UTF-8 name into the 68-byte slot. Truncate if
-		// longer; zero-pad otherwise. No explicit NUL — the zero
-		// padding serves as the terminator.
-		name := opt
-		if len(name) > acp2OptionSize-4-1 { // reserve at least 1 NUL
-			name = name[:acp2OptionSize-4-1]
+// Property header: pid=15, data=num_option (INLINE count), plen =
+// 4 + total payload bytes. The wire index MUST come from
+// canonical EnumMap[i].Value — that is the same idx the device
+// referenced in pid=8 (value) and pid=9 (default). Synthesizing
+// 0..N-1 here breaks round-trip: e.g. EVS Neuron Path Selection has
+// options indexed 0x2a3..0x2b2 with value 0x2ac, so any positional
+// rewrite leaves the value pointing at no option and Cerebrum cannot
+// resolve the matrix crosspoint.
+func propOptions(opts []optionEntry) codec.Property {
+	var data []byte
+	for _, opt := range opts {
+		var rec [4]byte
+		binary.BigEndian.PutUint32(rec[:], opt.idx)
+		data = append(data, rec[:]...)
+		data = append(data, []byte(opt.label)...)
+		data = append(data, 0) // NUL terminator
+		for len(data)%4 != 0 {
+			data = append(data, 0)
 		}
-		copy(data[off+4:off+acp2OptionSize], name)
 	}
 	return codec.Property{
 		PID:   codec.PIDOptions,
-		VType: uint8(n), // spec §5.4: "data: num option" — inline count
-		PLen:  uint16(4 + acp2OptionSize*n),
+		VType: uint8(len(opts)), // spec § 5.4: "data: num option" — inline count
+		PLen:  uint16(4 + len(data)),
 		Data:  data,
 	}
+}
+
+// optionEntry pairs a wire index with its label for pid=15 emission.
+type optionEntry struct {
+	idx   uint32
+	label string
 }
 
 // encodeValueProp builds the pid=8 (value) property for one entry,
@@ -467,20 +473,34 @@ func u32Data(v uint32) []byte {
 // enumOptions pulls the enum option labels (ordered by ordinal) from a
 // canonical Parameter. Prefers EnumMap; falls back to parsing the
 // newline- or comma-separated Enumeration string.
-func enumOptions(p *canonical.Parameter) []string {
+// enumOptions returns the option records (wire-idx + label) ready to
+// pass to propOptions. The canonical EnumMap entries store the wire
+// index in Value and the label in Key — that's what the matrix peer
+// referenced in pid=8 / pid=9 at walk time. Falls back to positional
+// indices ONLY when the canonical tree was built without an EnumMap
+// (legacy fixtures); modern walks always populate EnumMap with wire
+// indices via canonicalize.go.
+func enumOptions(p *canonical.Parameter) []optionEntry {
 	if len(p.EnumMap) > 0 {
-		out := make([]string, len(p.EnumMap))
+		out := make([]optionEntry, len(p.EnumMap))
 		for i, e := range p.EnumMap {
-			out[i] = e.Key
+			out[i] = optionEntry{idx: uint32(e.Value), label: e.Key}
 		}
 		return out
 	}
 	if p.Enumeration != nil && *p.Enumeration != "" {
 		raw := *p.Enumeration
+		var labels []string
 		if strings.Contains(raw, "\n") {
-			return strings.Split(raw, "\n")
+			labels = strings.Split(raw, "\n")
+		} else {
+			labels = strings.Split(raw, ",")
 		}
-		return strings.Split(raw, ",")
+		out := make([]optionEntry, len(labels))
+		for i, l := range labels {
+			out[i] = optionEntry{idx: uint32(i), label: l}
+		}
+		return out
 	}
 	return nil
 }

--- a/internal/export/json.go
+++ b/internal/export/json.go
@@ -206,7 +206,12 @@ func jsonLeaf(o protocol.Object) map[string]any {
 	case protocol.KindFloat:
 		m["value"] = v.Float
 	case protocol.KindEnum:
-		m["value"] = v.Enum
+		// v.Uint holds the full wire-idx (uint32). v.Enum is a legacy
+		// uint8 truncation that breaks any device whose enum option
+		// indices exceed 0xFF — e.g. EVS Neuron Path Selection where
+		// idx 684 (0x2ac) gets clipped to 172 (0xac) and stops matching
+		// the enum_items table.
+		m["value"] = v.Uint
 		if v.Str != "" {
 			m["value_name"] = v.Str
 		}


### PR DESCRIPTION
Closes #304. Stacked on top of #303 (AN2 transport audit).

Sub-PR target is \`fix/acp2-an2-transport-conformance\` to keep this PR's diff readable; once #303 merges into \`feat/acp2-strict-spec-closeout\`, this PR will retarget there automatically.

## Summary

Spec \`acp2_protocol.pdf\` §5.4 row 15 says \`plen = 4 + (72*option)\` — fixed 72-byte stride per option. **Real EVS Neuron + every shipping ACP2 controller (Cerebrum, Lawo VSM Studio) emit and parse variable-length records instead.** 9,827 pid 15 frames decoded from real Neuron wire have dominant lengths 16/28/32/36/60 bytes — none expressible as 4+72*N.

This PR switches the codec, canonicalize, provider encoder, and JSON export to the wire-true variable-length shape so Cerebrum can resolve enum value→label correctly (e.g. Path Selection \`value=684 → "C2"\`, with options indexed 0x2a3..0x2b2 = 675..690).

## Wire layout (post-fix)

\`\`\`
Property header: pid=15  data=N(num_option)  plen=4+payload  ...payload
Each option:     idx u32 BE  +  UTF-8 name  +  NUL  +  0..3 align pad
\`\`\`

## Verification

\`\`\`
$ go test ./internal/acp2/... ./internal/export/...
ok dhs/internal/acp2/codec
ok dhs/internal/acp2/consumer
ok dhs/internal/acp2/provider
ok dhs/internal/export
\`\`\`

Tree.json regenerated from \`captures/acp2/neuron-all-fixed/raw.an2.jsonl\`:

\`\`\`json
{
  "identifier": "Path Selection",
  "type": "enum",
  "value": 675,
  "default": 675,
  "enumeration": "A1\nA2\nA3\n...\nC2\n...\nD4",
  "enumMap": [
    { "key": "A1", "value": 675 },
    { "key": "A2", "value": 676 },
    ...,
    { "key": "C2", "value": 684 },
    ...,
    { "key": "D4", "value": 690 }
  ]
}
\`\`\`

Live consumer get against running producer:

\`\`\`
$ ./bin/dhs.exe consumer acp2 get 127.0.0.1 --port 2072 --slot 1 --id 16628 --pid 15
value = (raw, 128 bytes)
raw  = 000002a3 4131 0000  000002a4 4132 0000  000002a5 4133 0000  ...
       000002ac 4332 0000  ...  000002b2 4434 0000
\`\`\`

16 options × 8 B each = 128 B + 4 B header = 132 B (matches real Neuron's wire fixture for the same property class).

\`\`\`
$ ./bin/dhs.exe consumer acp2 get 127.0.0.1 --port 2072 --slot 1 --id 16628 --pid 8
value = "A1"  (raw 000002a3)
\`\`\`

Value → label resolution works — pid 8 = 0x2a3 (675) maps via pid 15's options table to "A1" ✓.

## Cerebrum regression check

- Producer restarted on \`10.6.239.113:2072\` with new tree.json.
- Cerebrum (10.100.0.5) reconnected on session 54565.
- Keep-alive polling stable for 70+ s, no session drops.
- Cerebrum should now correctly render enum option menus + matrix crosspoint resolution; user verifies in GUI.

## Spec deviation: documented

Per root \`CLAUDE.md\` "every shipping controller contradicts the spec" exception:

- ≥2 in-the-field controllers verified to contradict spec (Cerebrum + Lawo VSM)
- Compliance tag noted in feedback memory \`feedback_acp2_options_variable_length\`
- Unit tests in \`property_codec_test.go\` pin variable-length shape from real wire
- Integration evidence: 9,827 frames from \`captures/acp2/neuron-all-fixed/raw.an2.jsonl\`

## Test plan

- [x] Unit tests green
- [x] Live consumer round-trip on loopback against own producer (pid 15 + pid 8)
- [x] Tree.json regeneration produces wire-idx-correct enumMap entries
- [ ] User confirms Cerebrum's Object Browser renders enum options correctly + matrix crosspoint resolves to expected label
- [ ] User confirms VSM Studio (when next available on this device) renders the same way