### PR TITLE
fix(acp2-provider): omit pid=3 access on Nodes per spec property matrix

### DIFF
--- a/internal/acp2/provider/encoder.go
+++ b/internal/acp2/provider/encoder.go
@@ -35,7 +35,13 @@ func buildProperties(e *entry) ([]codec.Property, error) {
 
 	props = append(props, propInline(codec.PIDObjectType, uint8(e.objType)))
 	props = append(props, propStringData0(codec.PIDLabel, e.label))
-	props = append(props, propInline(codec.PIDAccess, e.access))
+	// pid=3 access carries 1=r, 2=w, 3=rw per spec §5.4 — Parameters only.
+	// Nodes have no access; real Neuron omits pid=3 on Nodes. Emitting
+	// pid=3 with data=0 makes Cerebrum treat the subtree as inaccessible
+	// and skip the children list (verified 2026-05-08 INPUT.SDI walk).
+	if e.access != 0 {
+		props = append(props, propInline(codec.PIDAccess, e.access))
+	}
 
 	switch e.objType {
 	case codec.ObjTypeNode:

--- a/internal/acp2/provider/encoder_test.go
+++ b/internal/acp2/provider/encoder_test.go
@@ -30,21 +30,22 @@ func buildAndDecode(t *testing.T, e *entry) []codec.Property {
 
 func TestBuildProperties_Node(t *testing.T) {
 	n := &canonical.Node{
-		Header: canonical.Header{
-			Number: 1, Identifier: "ROOT_NODE_V2", Access: canonical.AccessRead,
-		},
+		Header: canonical.Header{Number: 1, Identifier: "ROOT_NODE_V2"},
 	}
 	e := &entry{
 		objID: 1, label: n.Identifier,
-		access:   0x01,
+		access:   0,
 		objType:  codec.ObjTypeNode,
 		children: []uint32{2, 3, 4},
 		node:     n,
 	}
 	got := buildAndDecode(t, e)
 	want := map[uint8]bool{codec.PIDObjectType: true, codec.PIDLabel: true,
-		codec.PIDAccess: true, codec.PIDChildren: true}
+		codec.PIDChildren: true}
 	for _, p := range got {
+		if p.PID == codec.PIDAccess {
+			t.Errorf("Node reply must omit pid=3 access (real Neuron wire); got plen=%d data=0x%02x", p.PLen, p.VType)
+		}
 		delete(want, p.PID)
 	}
 	if len(want) > 0 {


### PR DESCRIPTION
## Summary
- Provider's `buildProperties` no longer emits pid=3 (access) on Nodes — that property only belongs on Parameters per ACP2 spec §"Property fields" matrix.
- Test `TestBuildProperties_Node` updated to assert pid=3 is absent on Node replies (was previously asserting it present, against spec).

## Spec quote (`internal/acp2/assets/acp2_protocol.docx`, §"Property fields")
| pid | Access | Dyn | Node | Preset | Enum | Number | IPv4 | String |
|-:|-|-|-|-|-|-|-|-|
| 3 | R | yes | — | Y | Y | Y | Y | Y |

The Node column for pid=3 is intentionally blank.

## Wire bytes (real-Neuron capture vs LXC producer)
INPUT.SDI obj 15522 (Node) GetObject reply:
- real Neuron `bin/neuron-fresh/raw.an2.jsonl`: dlen = 0x9c = 156 bytes
- our previous wire: 160 bytes (extra 4-byte pid=3 property header)
- our new wire: 156 bytes — byte-identical to real Neuron

## Test plan
- [x] `go test ./internal/acp2/...` — all green locally
- [x] `go build` — clean on Windows + Linux cross-compile
- [x] Cerebrum live-test against fresh device entry on `10.100.0.103:2072` — INPUT.SDI subtree expanded, all 32 CHANNEL nodes rendered (Object Browser screenshot 2026-05-08).
- [ ] CI green
- [ ] VSM Studio re-verify against `.103` (pending; previous round on `.102` continued to render fine — no regression expected).

## Risk / blast radius
- Wire frame for every Node reply is 4 bytes shorter. Spec-compliant consumers ignore the missing pid=3 (it's not required for Nodes).
- Local consumer's walker `case codec.PIDAccess` still works for Parameters.

Closes #306. First sub-PR under epic #301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
