### PR TITLE
fix(acp2-provider): emit pid=4 (event_delay) on every Parameter type

### DIFF
--- a/internal/acp2/provider/encoder.go
+++ b/internal/acp2/provider/encoder.go
@@ -11,31 +11,44 @@ import (
 )
 
 // buildProperties assembles the ACP2 property list a get_object reply
-// must carry for one entry. Per spec §"Property IDs" the ordering is
-// not strictly required but consumers generally expect:
+// must carry for one entry. Per spec §"Property fields" the order is
+// by ascending pid. Required pids per object type (§"Property fields"
+// matrix):
 //
 //	pid=1  object_type (all)
 //	pid=2  label        (all)
-//	pid=3  access       (all)
-//	pid=5  number_type  (Number, Enum)
+//	pid=3  access       (Parameters only — not Node)
+//	pid=4  event_delay  (Parameters only — not Node)
+//	pid=5  number_type  (Number only)
 //	pid=6  string_max_length (String)
-//	pid=8  value        (Number, Enum, IPv4, String)
-//	pid=9  default_value (Number)
-//	pid=10 min_value    (Number)
-//	pid=11 max_value    (Number)
-//	pid=12 step_size    (Number)
-//	pid=13 unit         (Number)
-//	pid=14 children     (Node)
-//	pid=15 options      (Enum)
+//	pid=7  preset_depth (Preset)
+//	pid=8  value        (Parameters)
+//	pid=9  default_value (Number, Enum, Preset)
+//	pid=10 min_value    (Number, Enum, Preset)
+//	pid=11 max_value    (Number, Enum, Preset)
+//	pid=12 step_size    (Number; optional Preset)
+//	pid=13 unit         (Number; optional Preset)
+//	pid=14 children     (Node only)
+//	pid=15 options      (Enum only)
 //
-// We emit in this order. The codec's EncodeProperties takes care of
-// the per-property alignment.
+// We emit in ascending pid order. The codec's EncodeProperties takes
+// care of the per-property alignment.
 func buildProperties(e *entry) ([]codec.Property, error) {
-	props := make([]codec.Property, 0, 8)
+	props := make([]codec.Property, 0, 10)
 
 	props = append(props, propInline(codec.PIDObjectType, uint8(e.objType)))
 	props = append(props, propStringData0(codec.PIDLabel, e.label))
 	props = append(props, propInline(codec.PIDAccess, e.access))
+	// pid 4 event_delay per spec §5.4 row 4 — required (Y) on every
+	// Parameter row of the property-fields matrix (Preset/Enum/Number/
+	// IPv4/String) and absent on the Node row. Wire shape:
+	//   data=0, plen=8, body=u32 BE rate (announce delay in milliseconds).
+	// Default 0 ms ("no delay"); a future canonical-schema field can
+	// override this per object. Spec name is "event delay" — the
+	// PIDAnnounceDelay constant is renamed to PIDEventDelay in #317.
+	if e.objType != codec.ObjTypeNode {
+		props = append(props, propEventDelay(0))
+	}
 
 	switch e.objType {
 	case codec.ObjTypeNode:
@@ -190,6 +203,32 @@ func propInline(pid uint8, val uint8) codec.Property {
 		VType: val, // the "data" byte carries the value itself
 		PLen:  4,   // header only; no body
 		Data:  nil,
+	}
+}
+
+// propEventDelay builds the pid=4 (event_delay) property per spec
+// §5.4 row 4. Carries the per-object announce-rate (in milliseconds)
+// that the device applies before emitting an announce when the value
+// changes. Required on every Parameter type (Preset/Enum/Number/IPv4/
+// String); absent on Node.
+//
+//	| Offset | Field   | Width  | Notes                                  |
+//	|--------|---------|--------|----------------------------------------|
+//	| 0      | pid     | u8     | 4 = event_delay                        |
+//	| 1      | data    | u8     | 0 per spec §5.4                        |
+//	| 2-3    | plen    | u16 BE | 8 (header 4 + body 4)                  |
+//	| 4-7    | rate    | u32 BE | announce delay in milliseconds         |
+//
+// Spec reference: acp2_protocol.docx §5.4 "Property header per field"
+// row "event delay".
+func propEventDelay(rateMs uint32) codec.Property {
+	body := make([]byte, 4)
+	binary.BigEndian.PutUint32(body, rateMs)
+	return codec.Property{
+		PID:   codec.PIDAnnounceDelay,
+		VType: 0,
+		PLen:  8,
+		Data:  body,
 	}
 }
 

--- a/internal/acp2/provider/encoder.go
+++ b/internal/acp2/provider/encoder.go
@@ -11,28 +11,40 @@ import (
 )
 
 // buildProperties assembles the ACP2 property list a get_object reply
-// must carry for one entry. Per spec §"Property fields" the order is
-// by ascending pid. Required pids per object type (§"Property fields"
-// matrix):
+// must carry for one entry, in ascending pid order. The codec's
+// EncodeProperties takes care of the per-property alignment.
 //
-//	pid=1  object_type (all)
-//	pid=2  label        (all)
-//	pid=3  access       (Parameters only — not Node)
-//	pid=4  event_delay  (Parameters only — not Node)
-//	pid=5  number_type  (Number only)
-//	pid=6  string_max_length (String)
-//	pid=7  preset_depth (Preset)
-//	pid=8  value        (Parameters)
-//	pid=9  default_value (Number, Enum, Preset)
-//	pid=10 min_value    (Number, Enum, Preset)
-//	pid=11 max_value    (Number, Enum, Preset)
-//	pid=12 step_size    (Number; optional Preset)
-//	pid=13 unit         (Number; optional Preset)
-//	pid=14 children     (Node only)
-//	pid=15 options      (Enum only)
+// Authoritative spec reference: ACP2 §5.1 Property fields per object
+// type (acp2_protocol.docx). The shaded cells in the spec docx encode
+// applicability as: ✓ = required, op¹ = optional, — = does not apply.
+// The full matrix below is verbatim from the docx and is the source
+// of truth for what every per-type case must emit.
 //
-// We emit in ascending pid order. The codec's EncodeProperties takes
-// care of the per-property alignment.
+//	| pid | name              | Acc  | Dyn | Node | Pres | Enum | Num  | IPv4 | Str  |
+//	|-----|-------------------|------|-----|------|------|------|------|------|------|
+//	|  1  | object type       | R    |  -  |  ✓   |  ✓   |  ✓   |  ✓   |  ✓   |  ✓   |
+//	|  2  | label             | R    |  -  |  ✓   |  ✓   |  ✓   |  ✓   |  ✓   |  ✓   |
+//	|  3  | access            | R    | yes |  —   |  ✓   |  ✓   |  ✓   |  ✓   |  ✓   |
+//	|  4  | event delay       | RW   | yes |  —   |  ✓   |  ✓   |  ✓   |  ✓   |  ✓   |
+//	|  5  | number type       | R    |  -  |  —   |  —   |  —   |  ✓   |  —   |  —   |
+//	|  6  | string max length | R    |  -  |  —   |  —   |  —   |  —   |  —   |  ✓   |
+//	|  7  | preset depth      | R    |  -  |  —   |  —   | op¹  | op¹  | op¹  | op¹  |
+//	|  8  | value[depth]      | R/RW | yes |  —   |  ✓   |  ✓   |  ✓   |  ✓   |  ✓   |
+//	|  9  | default value     | R    |  -  |  —   |  ✓   |  ✓   |  ✓   |  ✓   |  ✓   |
+//	| 10  | min value         | R    | yes |  —   |  —   |  —   |  ✓   |  —   |  —   |
+//	| 11  | max value         | R    | yes |  —   |  —   |  —   |  ✓   |  —   |  —   |
+//	| 12  | step size         | R    |  -  |  —   |  —   |  —   | op¹  |  —   |  —   |
+//	| 13  | unit              | R    |  -  |  —   |  —   |  —   | op¹  |  —   |  —   |
+//	| 14  | children          | R    |  -  |  ✓   |  —   |  —   |  —   |  —   |  —   |
+//	| 15  | options           | R    |  -  |  —   |  ✓   |  ✓   |  —   |  —   |  —   |
+//	| 16  | event tag         | R    |  -  |  —   | op¹  | op¹  | op¹  | op¹  | op¹  |
+//	| 17  | event priority    | RW   | yes |  —   | op¹  | op¹  | op¹  | op¹  | op¹  |
+//	| 18  | event state       | R    | yes |  —   | op¹  | op¹  | op¹  | op¹  | op¹  |
+//	| 19  | event message     | R    |  -  |  —   | op¹  | op¹  | op¹  | op¹  | op¹  |
+//	| 20  | preset parent     | R    |  -  |  —   |  —   | op¹  | op¹  | op¹  | op¹  |
+//
+// Decoded by reading the §5.1 cell shading directly out of the docx
+// XML (any deviation from this table = bug in this function).
 func buildProperties(e *entry) ([]codec.Property, error) {
 	props := make([]codec.Property, 0, 10)
 

--- a/internal/acp2/provider/encoder_test.go
+++ b/internal/acp2/provider/encoder_test.go
@@ -85,6 +85,7 @@ func TestBuildProperties_NumberS32(t *testing.T) {
 		seen[got[i].PID] = got[i]
 	}
 	for _, pid := range []uint8{codec.PIDObjectType, codec.PIDLabel, codec.PIDAccess,
+		codec.PIDAnnounceDelay,
 		codec.PIDNumberType, codec.PIDValue, codec.PIDDefaultValue,
 		codec.PIDMinValue, codec.PIDMaxValue, codec.PIDStepSize, codec.PIDUnit} {
 		if _, ok := seen[pid]; !ok {
@@ -170,6 +171,111 @@ func TestBuildProperties_String_WithMaxLen(t *testing.T) {
 	if s := codec.PropertyString(&val); s != "Input-A" {
 		t.Errorf("string value=%q want Input-A", s)
 	}
+}
+
+// TestBuildProperties_EventDelay verifies pid=4 (event_delay) per spec
+// §5.4 row 4. Required on every Parameter type, absent on Node.
+//
+// Wire: pid=4, data=0, plen=8, body=u32 BE rate (ms).
+func TestBuildProperties_EventDelay(t *testing.T) {
+	t.Run("Number_has_pid4", func(t *testing.T) {
+		p := &canonical.Parameter{
+			Header: canonical.Header{Number: 5, Identifier: "Level",
+				Access: canonical.AccessReadWrite},
+			Type: canonical.ParamInteger, Value: int64(0),
+		}
+		e := &entry{
+			objID: 5, label: p.Identifier, access: 0x03,
+			objType: codec.ObjTypeNumber, numType: codec.NumTypeS32,
+			param: p,
+		}
+		got := buildAndDecode(t, e)
+		assertEventDelayPresent(t, got, "Number")
+	})
+	t.Run("Enum_has_pid4", func(t *testing.T) {
+		p := &canonical.Parameter{
+			Header: canonical.Header{Number: 6, Identifier: "Mute",
+				Access: canonical.AccessReadWrite},
+			Type:    canonical.ParamEnum, Value: int64(0),
+			EnumMap: []canonical.EnumEntry{{Key: "Off", Value: 0}, {Key: "On", Value: 1}},
+		}
+		e := &entry{
+			objID: 6, label: p.Identifier, access: 0x03,
+			objType: codec.ObjTypeEnum, numType: codec.NumTypeU32,
+			param: p,
+		}
+		got := buildAndDecode(t, e)
+		assertEventDelayPresent(t, got, "Enum")
+	})
+	t.Run("String_has_pid4", func(t *testing.T) {
+		p := &canonical.Parameter{
+			Header: canonical.Header{Number: 7, Identifier: "Label",
+				Access: canonical.AccessReadWrite},
+			Type: canonical.ParamString, Value: "x",
+		}
+		e := &entry{
+			objID: 7, label: p.Identifier, access: 0x03,
+			objType: codec.ObjTypeString, numType: codec.NumTypeString,
+			param: p,
+		}
+		got := buildAndDecode(t, e)
+		assertEventDelayPresent(t, got, "String")
+	})
+	t.Run("IPv4_has_pid4", func(t *testing.T) {
+		ipf := "ipv4"
+		p := &canonical.Parameter{
+			Header: canonical.Header{Number: 8, Identifier: "GW",
+				Access: canonical.AccessReadWrite},
+			Type: canonical.ParamString, Value: "0.0.0.0", Format: &ipf,
+		}
+		e := &entry{
+			objID: 8, label: p.Identifier, access: 0x03,
+			objType: codec.ObjTypeIPv4, numType: codec.NumTypeIPv4,
+			param: p,
+		}
+		got := buildAndDecode(t, e)
+		assertEventDelayPresent(t, got, "IPv4")
+	})
+	t.Run("Node_has_no_pid4", func(t *testing.T) {
+		n := &canonical.Node{Header: canonical.Header{Number: 1, Identifier: "ROOT",
+			Access: canonical.AccessRead}}
+		e := &entry{
+			objID: 1, label: n.Identifier, access: 0x01,
+			objType: codec.ObjTypeNode, children: []uint32{2}, node: n,
+		}
+		got := buildAndDecode(t, e)
+		for _, p := range got {
+			if p.PID == codec.PIDAnnounceDelay {
+				t.Errorf("Node reply must not carry pid=4 (got plen=%d)", p.PLen)
+			}
+		}
+	})
+}
+
+// assertEventDelayPresent verifies the spec wire shape of pid=4:
+// data=0, plen=8, body=u32 BE rate.
+func assertEventDelayPresent(t *testing.T, props []codec.Property, kind string) {
+	t.Helper()
+	for _, p := range props {
+		if p.PID != codec.PIDAnnounceDelay {
+			continue
+		}
+		if p.VType != 0 {
+			t.Errorf("%s pid=4 data byte=%d want 0 (spec §5.4)", kind, p.VType)
+		}
+		if p.PLen != 8 {
+			t.Errorf("%s pid=4 plen=%d want 8 (spec §5.4)", kind, p.PLen)
+		}
+		if len(p.Data) != 4 {
+			t.Fatalf("%s pid=4 body len=%d want 4", kind, len(p.Data))
+		}
+		rate := binary.BigEndian.Uint32(p.Data[0:4])
+		if rate != 0 {
+			t.Errorf("%s pid=4 default rate=%d want 0", kind, rate)
+		}
+		return
+	}
+	t.Errorf("%s reply missing required pid=4 (event_delay)", kind)
 }
 
 func TestBuildProperties_IPv4(t *testing.T) {


### PR DESCRIPTION
## Summary
- Provider's `buildProperties` now emits **pid=4 (event_delay)** on every Parameter type per ACP2 spec §"Property fields" matrix.
- New `propEventDelay` helper builds the spec-shaped property: data=0, plen=8, body=u32 BE rate (ms).
- Default rate is 0 ms ("no delay") until the canonical schema gains a per-object EventDelay field.
- Node objects continue to omit pid=4 (spec: blank in matrix).

## Spec quote (`internal/acp2/assets/acp2_protocol.docx`)
§"Property fields" matrix row 4:
| pid | name | Access | Dyn | Node | Preset | Enum | Number | IPv4 | String |
|-:|-|-|-|-|-|-|-|-|-|
| 4 | event_delay | RW | yes | — | Y | Y | Y | Y | Y |

§5.4 "Property header per field" row "event delay":
```
event delay  4  0  8  u32 rate
```

## Wire shape

```
| Offset | Field | Width  | Notes                               |
|--------|-------|--------|-------------------------------------|
| 0      | pid   | u8     | 4 = event_delay                     |
| 1      | data  | u8     | 0 per spec §5.4                     |
| 2-3    | plen  | u16 BE | 8                                   |
| 4-7    | rate  | u32 BE | announce delay in milliseconds      |
```

## Test plan
- [x] `TestBuildProperties_EventDelay` — five sub-tests:
  - `Number_has_pid4`, `Enum_has_pid4`, `String_has_pid4`, `IPv4_has_pid4`: assert pid=4 present, plen=8, data=0, rate=0
  - `Node_has_no_pid4`: assert pid=4 absent
- [x] `TestBuildProperties_NumberS32` updated to expect pid=4 alongside other required Number pids
- [x] Full `go test ./internal/acp2/...` green
- [x] `go build` clean
- [ ] CI green
- [ ] Cerebrum + VSM Studio re-walk against fresh device entry on `.103` — both controllers continue to render every Parameter (spec-required field added, no removal).

## Naming note
ACP2 spec §5.4 row 4 + §"Set property" line 1132 + §5.4 property-header table line 1721 all call this property **"event delay"**. The Go constant is currently `codec.PIDAnnounceDelay`; the rename to `PIDEventDelay` is tracked in #317 to keep this PR focused on the wire change.

## Risk / blast radius
- Wire frame for every Parameter reply is 12 bytes longer (pid=4 header 4 + body 4 + 0 padding = 8, plus position adjustment). Matches real Neuron's wire shape on the same property.
- Consumer walker `walker.go` does NOT yet have a case for `PIDAnnounceDelay`. The decoded property is silently dropped. That is tracked in #315 (walker decodes pid 4/7/18/20). After #315 lands, round-trip preserves the field.

Closes #307. Stacks on top of #325 indirectly via `feat/acp2-strict-spec-closeout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
