### PR TITLE
fix(acp2-provider): always emit pid=6 (string_max_length) on String objects

### DIFF
--- a/internal/acp2/provider/encoder.go
+++ b/internal/acp2/provider/encoder.go
@@ -10,6 +10,13 @@ import (
 	"dhs/internal/acp2/codec"
 )
 
+// stringMaxLengthDefault is the spec-stated upper bound for ACP2
+// string objects (§"Requirements" line 173: "A string type should
+// support strings up to 256 bytes, configurable in menu"). Used as
+// the pid=6 (string_max_length) value when the canonical fixture
+// omits an explicit hint.
+const stringMaxLengthDefault = 256
+
 // buildProperties assembles the ACP2 property list a get_object reply
 // must carry for one entry. Per spec §"Property IDs" the ordering is
 // not strictly required but consumers generally expect:
@@ -135,9 +142,16 @@ func buildProperties(e *entry) ([]codec.Property, error) {
 		}
 		props = append(props, val)
 	case codec.ObjTypeString:
-		if ml := maxLenHint(e.param); ml > 0 {
-			props = append(props, propU16Pad(codec.PIDStringMaxLength, uint16(ml)))
+		// pid 6 string_max_length is required (Y) on String per spec
+		// §"Property fields" matrix. Spec §"Requirements" line 173:
+		// "A string type should support strings up to 256 bytes,
+		// configurable in menu." When canonical lacks an explicit
+		// maxLen hint, fall back to 256 — the spec-stated maximum.
+		ml := maxLenHint(e.param)
+		if ml <= 0 {
+			ml = stringMaxLengthDefault
 		}
+		props = append(props, propU16Pad(codec.PIDStringMaxLength, uint16(ml)))
 		val, err := encodeValueProp(codec.PIDValue, e)
 		if err != nil {
 			return nil, err

--- a/internal/acp2/provider/encoder_test.go
+++ b/internal/acp2/provider/encoder_test.go
@@ -172,6 +172,46 @@ func TestBuildProperties_String_WithMaxLen(t *testing.T) {
 	}
 }
 
+// TestBuildProperties_String_NoCanonicalMaxLen verifies pid=6
+// (string_max_length) is always emitted on String replies per spec
+// §"Property fields" matrix (Y on String row). When canonical lacks
+// an explicit maxLen hint, encoder falls back to the spec-stated
+// 256-byte default (§"Requirements" line 173).
+func TestBuildProperties_String_NoCanonicalMaxLen(t *testing.T) {
+	p := &canonical.Parameter{
+		Header: canonical.Header{Number: 7, Identifier: "Label",
+			Access: canonical.AccessReadWrite},
+		Type: canonical.ParamString, Value: "x",
+	}
+	e := &entry{
+		objID: 7, label: p.Identifier, access: 0x03,
+		objType: codec.ObjTypeString, numType: codec.NumTypeString, param: p,
+	}
+	got := buildAndDecode(t, e)
+	var maxLen codec.Property
+	found := false
+	for _, pr := range got {
+		if pr.PID == codec.PIDStringMaxLength {
+			maxLen = pr
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("String reply missing required pid=6 (string_max_length) when canonical hint absent")
+	}
+	if maxLen.PLen != 6 {
+		t.Errorf("pid=6 plen=%d want 6 (spec §5.4 row 6)", maxLen.PLen)
+	}
+	if len(maxLen.Data) < 2 {
+		t.Fatalf("pid=6 body len=%d want >=2", len(maxLen.Data))
+	}
+	got16 := binary.BigEndian.Uint16(maxLen.Data[0:2])
+	if got16 != 256 {
+		t.Errorf("pid=6 default value=%d want 256 (spec §Requirements line 173)", got16)
+	}
+}
+
 func TestBuildProperties_IPv4(t *testing.T) {
 	ipf := "ipv4"
 	p := &canonical.Parameter{


### PR DESCRIPTION
## Summary
Provider's `buildProperties` now always emits **pid=6 (string_max_length)** on every String reply per ACP2 spec §"Property fields" matrix (Y on String row). Previously skipped when `maxLenHint(canonical) == 0`.

When canonical lacks an explicit hint, falls back to **256 bytes** per spec §"Requirements" line 173:
> A string type should support strings up to a 256 bytes, configurable in menu.

Wire shape (§5.4 row 6): `data=0, plen=6, body=u16 BE len + u16 pad`.

## Test plan
- [x] `TestBuildProperties_String_NoCanonicalMaxLen` — asserts pid=6 present with default value 256 when canonical hint absent
- [x] `TestBuildProperties_String_WithMaxLen` (existing) — continues to pass with canonical-supplied value (16)
- [x] All ACP2 tests green
- [x] Build clean
- [ ] CI green
- [ ] Cerebrum + VSM Studio re-walk: every String value (e.g. `IDENTITY > User Label 1`, `MANAGEMENT PORT > DNS Domain`, etc.) carries pid=6 — no parser warnings.

## Risk / blast radius
Wire frame for every String reply gains a single 8-byte property record (header 4 + body 2 + pad 2). Consumer walker already handles pid 6 (`PIDStringMaxLength` case in `walker.go:185`).

Closes #309. Stacks under `feat/acp2-strict-spec-closeout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
