### PR TITLE
fix(acp2-provider): omit pid=5 (number_type) on Preset (spec: Number only)

### DIFF
--- a/internal/acp2/provider/encoder.go
+++ b/internal/acp2/provider/encoder.go
@@ -86,11 +86,15 @@ func buildProperties(e *entry) ([]codec.Property, error) {
 		props = append(props, val)
 		props = append(props, propOptions(enumOptions(e.param)))
 	case codec.ObjTypePreset:
-		// Preset child per spec §5: pid 7 preset_depth lists the N valid
-		// idx values; pids 8/9/10/11 each appear N times in the reply,
-		// once per idx. Number-style numeric fields (pid 5, 12, 13) are
-		// emitted once. For N=1 the shape degenerates to "Number + pid 7".
-		props = append(props, propInline(codec.PIDNumberType, uint8(e.numType)))
+		// Preset child per spec §"Property fields" matrix: pid 5
+		// (number_type) row is BLANK for Preset — the spec table
+		// marks pid 5 required (Y) only on the Number column. Wire
+		// vtype information for pid 8/9/10/11 still lives in each
+		// property header's data byte (set by encodeNumericProp).
+		// pid 7 preset_depth lists the N valid idx values; pids
+		// 8/9/10/11 each appear N times in the reply, once per idx.
+		// pid 12/13 stay optional (op¹). For N=1 the shape degenerates
+		// to "Number-without-pid-5 + pid 7".
 		props = append(props, propPresetDepth(e.presetDepth))
 		for i := uint32(0); i < e.presetDepth; i++ {
 			val, err := encodeValueProp(codec.PIDValue, e)

--- a/internal/acp2/provider/encoder_test.go
+++ b/internal/acp2/provider/encoder_test.go
@@ -172,6 +172,46 @@ func TestBuildProperties_String_WithMaxLen(t *testing.T) {
 	}
 }
 
+// TestBuildProperties_Preset_NoPid5 verifies pid=5 (number_type) is
+// NOT emitted on Preset replies per spec §"Property fields" matrix —
+// pid 5 column is blank for Preset (only Number marks Y on row 5).
+// Wire vtype information for pid 8/9/10/11 still rides in each
+// property header's data byte; an additional pid=5 record is wrong.
+func TestBuildProperties_Preset_NoPid5(t *testing.T) {
+	p := &canonical.Parameter{
+		Header: canonical.Header{Number: 9, Identifier: "PresetSlot",
+			Access: canonical.AccessReadWrite},
+		Type: canonical.ParamInteger, Value: int64(0),
+	}
+	e := &entry{
+		objID: 9, label: p.Identifier, access: 0x03,
+		objType: codec.ObjTypePreset, numType: codec.NumTypeU8,
+		presetDepth: 2, param: p,
+	}
+	got := buildAndDecode(t, e)
+	for _, pr := range got {
+		if pr.PID == codec.PIDNumberType {
+			t.Errorf("Preset reply must NOT carry pid=5 (number_type); spec §Property fields matrix")
+		}
+	}
+	// Sanity: pid 7 preset_depth and pid 8 value still emitted.
+	hasPresetDepth, hasValue := false, false
+	for _, pr := range got {
+		if pr.PID == codec.PIDPresetDepth {
+			hasPresetDepth = true
+		}
+		if pr.PID == codec.PIDValue {
+			hasValue = true
+		}
+	}
+	if !hasPresetDepth {
+		t.Error("Preset reply missing required pid=7 (preset_depth)")
+	}
+	if !hasValue {
+		t.Error("Preset reply missing required pid=8 (value)")
+	}
+}
+
 func TestBuildProperties_IPv4(t *testing.T) {
 	ipf := "ipv4"
 	p := &canonical.Parameter{


### PR DESCRIPTION
## Summary
Provider's `buildProperties` no longer emits pid=5 (number_type) on Preset replies — that property is required on Number only per ACP2 spec §"Property fields" matrix.

## Spec quote (`internal/acp2/assets/acp2_protocol.docx`)
| pid | name | Access | Dyn | Node | Preset | Enum | Number | IPv4 | String |
|-:|-|-|-|-|-|-|-|-|-|
| 5 | number_type | R | – | — | — | — | **Y** | — | — |

Only the Number column marks Y. Preset / Enum / IPv4 / String are blank.

## Wire effect
Preset reply is 4 bytes shorter (one fewer property header). Wire vtype information for pids 8/9/10/11 still rides in each property header's data byte (set by `encodeNumericProp`) — removing pid=5 has no decoder-side semantic effect.

## Test plan
- [x] `TestBuildProperties_Preset_NoPid5` — asserts pid=5 absent + pid 7 / pid 8 still present
- [x] All ACP2 tests green
- [x] Build clean
- [ ] CI green
- [ ] Cerebrum + VSM Studio re-walk a real Preset child object — wire shape matches real Neuron, no parser warning.

Closes #308. Stacks under `feat/acp2-strict-spec-closeout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
