### PR TITLE
fix(acp2-provider): error reply body MUST be empty per spec §Error

### DIFF
--- a/internal/acp2/provider/handlers.go
+++ b/internal/acp2/provider/handlers.go
@@ -374,19 +374,31 @@ func (s *session) replyACP2(slot uint8, msg *codec.ACP2Message) {
 	}
 }
 
-// errorACP2 builds an ACP2 error reply per spec §"Error Codes". The
-// func field of an error message holds the stat byte (not a function
-// ID); codec.go picks this back up in ToACP2Error.
+// errorACP2 builds an ACP2 error reply per spec §"Error". The error
+// message is exactly the 4-byte ACP2 header — NO body.
+//
+//	| Offset | Field | Width | Notes                                 |
+//	|--------|-------|-------|---------------------------------------|
+//	| 0      | type  | u8    | 3 = error                             |
+//	| 1      | mtid  | u8    | matches the request mtid              |
+//	| 2      | stat  | u8    | error status (§3.1: 0..5)             |
+//	| 3      | pid   | u8    | 0                                     |
+//
+// The func slot carries the stat byte for error messages; the codec
+// picks this back up in ToACP2Error. ObjID is preserved on the
+// in-memory message struct purely for caller-side diagnostics — it
+// is NOT serialised onto the wire.
+//
+// Spec reference: acp2_protocol.docx §"Error" (line 1207-1250) — the
+// error table lists only type/mtid/stat/pid; no body row.
 func errorACP2(req *codec.ACP2Message, stat codec.ACP2ErrStatus) *codec.ACP2Message {
-	body := make([]byte, 4)
-	binaryBigEndianU32(body, req.ObjID)
 	return &codec.ACP2Message{
 		Type:  codec.ACP2TypeError,
 		MTID:  req.MTID,
 		Func:  codec.ACP2Func(stat),
 		PID:   0,
 		ObjID: req.ObjID,
-		Body:  body,
+		Body:  nil,
 	}
 }
 

--- a/internal/acp2/provider/handlers_test.go
+++ b/internal/acp2/provider/handlers_test.go
@@ -217,6 +217,67 @@ func TestAN2Handshake_EnableProtocolEvents(t *testing.T) {
 	}
 }
 
+// TestACP2Error_NoBody verifies the error reply is exactly the 4-byte
+// ACP2 header per spec §"Error" (line 1207-1250 of acp2_protocol.docx).
+// The error table lists only type/mtid/stat/pid; no body row.
+//
+// Request:  ACP2 get_object for obj-id 999 (not in tree).
+// Expected reply (AN2 frame payload, total = 4 bytes):
+//
+//	| byte 0 | byte 1 | byte 2     | byte 3 |
+//	| type=3 | mtid=N | stat=1     | pid=0  |
+func TestACP2Error_NoBody(t *testing.T) {
+	sess, peer := newTestSession(t)
+	defer func() { _ = sess.conn.Close() }()
+	defer func() { _ = peer.Close() }()
+
+	// Build an ACP2 GetObject request for an obj-id that's not in the
+	// tree (slot 1 was initialised empty by newTestSession).
+	getObj := &codec.ACP2Message{
+		Type:  codec.ACP2TypeRequest,
+		MTID:  42,
+		Func:  codec.ACP2FuncGetObject,
+		PID:   0,
+		ObjID: 999,
+		Idx:   0,
+	}
+	body, err := codec.EncodeACP2Message(getObj)
+	if err != nil {
+		t.Fatalf("encode acp2 request: %v", err)
+	}
+	req := &codec.AN2Frame{
+		Proto:   codec.AN2ProtoACP2,
+		Slot:    1,
+		MTID:    0, // AN2 mtid for data frames
+		Type:    codec.AN2TypeData,
+		Payload: body,
+	}
+	rep := roundtrip(t, sess, peer, req)
+
+	if rep.Proto != codec.AN2ProtoACP2 {
+		t.Fatalf("reply proto=%v want ACP2", rep.Proto)
+	}
+	if rep.Type != codec.AN2TypeData {
+		t.Fatalf("reply AN2 type=%v want data(4)", rep.Type)
+	}
+	if len(rep.Payload) != 4 {
+		t.Fatalf("error reply payload len=%d want 4 (spec §Error: header only, no body); got %x",
+			len(rep.Payload), rep.Payload)
+	}
+	if rep.Payload[0] != byte(codec.ACP2TypeError) {
+		t.Errorf("byte 0 (type)=%d want %d (error)", rep.Payload[0], codec.ACP2TypeError)
+	}
+	if rep.Payload[1] != 42 {
+		t.Errorf("byte 1 (mtid)=%d want 42 (matches request)", rep.Payload[1])
+	}
+	if rep.Payload[2] != byte(codec.ErrInvalidObjID) {
+		t.Errorf("byte 2 (stat)=%d want %d (invalid_obj_id)", rep.Payload[2], codec.ErrInvalidObjID)
+	}
+	if rep.Payload[3] != 0 {
+		t.Errorf("byte 3 (pid)=%d want 0", rep.Payload[3])
+	}
+}
+
 func bytesEq(a, b []byte) bool {
 	if len(a) != len(b) {
 		return false


### PR DESCRIPTION
## Summary
Provider's `errorACP2` helper now returns a message with `Body: nil`. ACP2 error replies are exactly the 4-byte ACP2 header on the wire, per spec §"Error" (line 1207-1250 of `acp2_protocol.docx`).

## Spec quote
The §"Error" table lists only the four header bytes:
```
type    error    see 3.2
mtid    x
stat    error status (see 3.1)
pid     0
```
No body row.

## Wire effect
| Before | After |
|---|---|
| AN2 dlen = 8 (4 ACP2 hdr + 4 obj-id body) | AN2 dlen = 4 (ACP2 hdr only) |
| Total frame 16 B | Total frame 12 B |

`ObjID` is preserved on the in-memory `*codec.ACP2Message` struct purely for caller-side diagnostics — it is NOT serialised onto the wire.

## Test plan
- [x] New `TestACP2Error_NoBody` — sends ACP2 GetObject for obj-id 999 (not in tree), asserts AN2 payload is exactly 4 bytes with type=3, mtid matching, stat=invalid_obj_id, pid=0.
- [x] All ACP2 tests green
- [x] Build clean
- [ ] CI green
- [ ] Cerebrum + VSM Studio: error replies (e.g. on a Set against an invalid obj-id) decode correctly without trailing bytes.

## Sister change
Consumer-side strict decoder (stop reading obj-id from error body) tracked in #316.

Closes #313. Stacks under `feat/acp2-strict-spec-closeout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
