### PR TITLE
fix(acp2-codec): get_property request body = obj-id + idx only per spec

### DIFF
--- a/internal/acp2/codec/codec.go
+++ b/internal/acp2/codec/codec.go
@@ -84,18 +84,27 @@ func EncodeACP2Message(m *ACP2Message) ([]byte, error) {
 		return buf, nil
 
 	case ACP2FuncGetProperty:
-		// get_property request: header + obj-id(4) + idx(4) + property header(4)
-		buf := make([]byte, ACP2HeaderSize+8+4)
+		// get_property request per spec §"Get property" Request
+		// (acp2_protocol.docx line 990-1020): body = obj-id(u32 BE) +
+		// idx(u32 BE). The requested pid is carried in the ACP2
+		// header byte 3 — there is NO trailing property header in
+		// the request body.
+		//
+		//	| Offset | Field  | Width  | Notes                          |
+		//	|--------|--------|--------|--------------------------------|
+		//	| 0      | type   | u8     | 0 = request                    |
+		//	| 1      | mtid   | u8     | 1..255                         |
+		//	| 2      | func   | u8     | 2 = get_property               |
+		//	| 3      | pid    | u8     | property id requested          |
+		//	| 4-7    | obj-id | u32 BE | target object id               |
+		//	| 8-11   | idx    | u32 BE | preset idx (0 = ACTIVE INDEX)  |
+		buf := make([]byte, ACP2HeaderSize+8)
 		buf[0] = byte(m.Type)
 		buf[1] = m.MTID
 		buf[2] = byte(m.Func)
 		buf[3] = m.PID
 		binary.BigEndian.PutUint32(buf[4:8], m.ObjID)
 		binary.BigEndian.PutUint32(buf[8:12], m.Idx)
-		// Property header for the requested pid: pid, 0, plen=4
-		buf[12] = m.PID
-		buf[13] = 0
-		binary.BigEndian.PutUint16(buf[14:16], 4)
 		return buf, nil
 
 	case ACP2FuncSetProperty:

--- a/internal/acp2/codec/codec_test.go
+++ b/internal/acp2/codec/codec_test.go
@@ -147,13 +147,23 @@ func TestEncodeDecodeACP2Message_GetProperty(t *testing.T) {
 		t.Fatalf("Encode: %v", err)
 	}
 
-	// Should be header(4) + obj-id(4) + idx(4) + prop-header(4) = 16
-	if len(data) != 16 {
-		t.Fatalf("expected 16 bytes, got %d", len(data))
+	// Per spec §"Get property" Request (acp2_protocol.docx line 990-1020):
+	// body = obj-id (u32 BE) + idx (u32 BE). The pid is carried in ACP2
+	// header byte 3; there is NO trailing property header. Total = 12 bytes.
+	if len(data) != 12 {
+		t.Fatalf("expected 12 bytes (4 hdr + 4 obj-id + 4 idx) per spec; got %d", len(data))
 	}
 
-	// Verify the property header in the request.
-	if data[12] != PIDValue {
-		t.Errorf("prop pid: got %d, want %d", data[12], PIDValue)
+	// Verify pid in header byte 3.
+	if data[3] != PIDValue {
+		t.Errorf("ACP2 header byte 3 (pid): got %d, want %d", data[3], PIDValue)
+	}
+	// Verify obj-id at bytes 4-7.
+	if got := binary.BigEndian.Uint32(data[4:8]); got != 100 {
+		t.Errorf("obj-id: got %d, want 100", got)
+	}
+	// Verify idx at bytes 8-11.
+	if got := binary.BigEndian.Uint32(data[8:12]); got != 0 {
+		t.Errorf("idx: got %d, want 0", got)
 	}
 }


### PR DESCRIPTION
## Summary
Consumer's `EncodeACP2Message` for `ACP2FuncGetProperty` now produces a 12-byte ACP2 payload (4 hdr + 4 obj-id + 4 idx) per spec, instead of the previous 16 bytes that included a redundant property header.

## Spec quote (`internal/acp2/assets/acp2_protocol.docx` §"Get property" Request, line 990-1020)
| Offset | Field | Width | Notes |
|---|---|---|---|
| 0 | type | u8 | 0 = request |
| 1 | mtid | u8 | 1..255 |
| 2 | func | u8 | 2 = get_property |
| 3 | pid | u8 | property id requested |
| 4-7 | obj-id | u32 BE | target object |
| 8-11 | idx | u32 BE | preset idx (0 = ACTIVE INDEX) |

The requested pid is carried in ACP2 header byte 3; there is NO trailing property header in the body.

## Wire effect
| Before | After |
|---|---|
| 16 bytes (4 hdr + 4 obj-id + 4 idx + 4 prop hdr) | 12 bytes (4 hdr + 4 obj-id + 4 idx) |

## Provider compatibility
`handleACP2` in `internal/acp2/provider/handlers.go` reads obj-id + idx from `msg.Body[0:8]` and ignores any trailing bytes — compatible with both the old (16-byte) and the new (12-byte) form. **No provider change required.**

## Test plan
- [x] `TestEncodeDecodeACP2Message_GetProperty` — updated to assert 12-byte payload, pid in header byte 3, obj-id at bytes 4-7, idx at bytes 8-11.
- [x] All ACP2 tests green
- [x] Build clean
- [ ] CI green
- [ ] Wire verify against real Neuron / Cerebrum once integration round runs.

Closes #314. Stacks under `feat/acp2-strict-spec-closeout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
