### PR TITLE
fix(acp2-consumer): walker decodes pid=4/7/18/20 (currently silently dropped)

### DIFF
--- a/internal/acp2/consumer/walker.go
+++ b/internal/acp2/consumer/walker.go
@@ -228,6 +228,39 @@ func (w *Walker) parseObjectProperties(props []codec.Property, slot int, objID u
 
 		case codec.PIDEventMessages:
 			obj.AlarmOnMsg, obj.AlarmOffMsg = codec.PropertyEventMessages(p)
+
+		case codec.PIDAnnounceDelay:
+			// pid 4 event_delay per spec §5.4 row 4: data=0, plen=8,
+			// body=u32 BE rate (announce delay in milliseconds).
+			if v, err := codec.PropertyU32(p); err == nil {
+				setMeta(&obj, "acp2.announceDelay", uint64(v))
+			}
+
+		case codec.PIDPresetDepth:
+			// pid 7 preset_depth per spec §5.4 row 7: data=0,
+			// plen=4+4*depth, body=u32 BE idx values list. Decode
+			// every idx for round-trip; consumers needing the list
+			// use Meta["acp2.presetIdxList"].
+			if len(p.Data)%4 == 0 && len(p.Data) > 0 {
+				idx := make([]uint32, 0, len(p.Data)/4)
+				for off := 0; off+4 <= len(p.Data); off += 4 {
+					idx = append(idx, beU32(p.Data[off:off+4]))
+				}
+				setMeta(&obj, "acp2.presetIdxList", idx)
+			}
+
+		case codec.PIDEventState:
+			// pid 18 event_state per spec §5.4 row 18: inline
+			// state byte in the property header's data slot,
+			// plen=4 (no body).
+			setMeta(&obj, "acp2.eventState", p.VType)
+
+		case codec.PIDPresetParent:
+			// pid 20 preset_parent per spec §5.4 row 20: data=0,
+			// plen=8, body=u32 BE parent obj-id.
+			if v, err := codec.PropertyU32(p); err == nil {
+				setMeta(&obj, "acp2.presetParent", uint64(v))
+			}
 		}
 	}
 
@@ -389,6 +422,23 @@ func (w *Walker) decodeConstraint(p *codec.Property, objType codec.ACP2ObjType, 
 }
 
 // numberTypeToKind maps an ACP2 NumberType to a protocol.ValueKind.
+// setMeta writes a key/value into obj.Meta, lazily allocating the map.
+// Used by the walker to stash protocol-specific decoded values that
+// don't fit the fixed Object fields (e.g. acp2.announceDelay,
+// acp2.presetIdxList — see protocol.Object docstring).
+func setMeta(obj *protocol.Object, key string, value any) {
+	if obj.Meta == nil {
+		obj.Meta = make(map[string]any)
+	}
+	obj.Meta[key] = value
+}
+
+// beU32 reads a big-endian uint32 from a byte slice. Local to this
+// package to avoid importing encoding/binary at every call site.
+func beU32(b []byte) uint32 {
+	return binary.BigEndian.Uint32(b)
+}
+
 func numberTypeToKind(nt codec.NumberType) protocol.ValueKind {
 	switch nt {
 	case codec.NumTypeS8, codec.NumTypeS16, codec.NumTypeS32, codec.NumTypeS64:

--- a/internal/acp2/consumer/walker_pids_test.go
+++ b/internal/acp2/consumer/walker_pids_test.go
@@ -1,0 +1,99 @@
+package acp2
+
+import (
+	"encoding/binary"
+	"io"
+	"log/slog"
+	"testing"
+
+	"dhs/internal/acp2/codec"
+)
+
+// TestWalker_DecodesPid4_AnnounceDelay covers spec §5.4 row 4: pid=4
+// data=0, plen=8, body=u32 BE rate (announce delay in milliseconds).
+// The walker must stash the decoded value into Meta["acp2.announceDelay"].
+func TestWalker_DecodesPid4_AnnounceDelay(t *testing.T) {
+	w := &Walker{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	body := make([]byte, 4)
+	binary.BigEndian.PutUint32(body, 1500)
+	props := []codec.Property{
+		{PID: codec.PIDObjectType, VType: uint8(codec.ObjTypeNumber), PLen: 4},
+		{PID: codec.PIDLabel, VType: 0, PLen: 4 + 5, Data: []byte("Foo\x00")},
+		{PID: codec.PIDAnnounceDelay, VType: 0, PLen: 8, Data: body},
+	}
+	obj, _, _, _, _ := w.parseObjectProperties(props, 1, 5, nil)
+	v, ok := obj.Meta["acp2.announceDelay"]
+	if !ok {
+		t.Fatal("walker did not stash acp2.announceDelay in Meta")
+	}
+	if got, _ := v.(uint64); got != 1500 {
+		t.Errorf("acp2.announceDelay=%v want 1500", v)
+	}
+}
+
+// TestWalker_DecodesPid7_PresetDepth covers spec §5.4 row 7: pid=7
+// data=0, plen=4+4*depth, body = u32 BE list of valid idx values.
+// Walker stashes the list into Meta["acp2.presetIdxList"].
+func TestWalker_DecodesPid7_PresetDepth(t *testing.T) {
+	w := &Walker{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	// Two idx values: 100, 200 — matches the spec example at line 2613-2632.
+	body := make([]byte, 8)
+	binary.BigEndian.PutUint32(body[0:4], 100)
+	binary.BigEndian.PutUint32(body[4:8], 200)
+	props := []codec.Property{
+		{PID: codec.PIDObjectType, VType: uint8(codec.ObjTypePreset), PLen: 4},
+		{PID: codec.PIDLabel, VType: 0, PLen: 4 + 5, Data: []byte("Bar\x00")},
+		{PID: codec.PIDPresetDepth, VType: 0, PLen: 12, Data: body},
+	}
+	obj, _, _, _, _ := w.parseObjectProperties(props, 1, 6, nil)
+	v, ok := obj.Meta["acp2.presetIdxList"]
+	if !ok {
+		t.Fatal("walker did not stash acp2.presetIdxList in Meta")
+	}
+	idxList, _ := v.([]uint32)
+	if len(idxList) != 2 || idxList[0] != 100 || idxList[1] != 200 {
+		t.Errorf("acp2.presetIdxList=%v want [100, 200]", idxList)
+	}
+}
+
+// TestWalker_DecodesPid18_EventState covers spec §5.4 row 18: pid=18
+// inline state byte in the property header's data slot, plen=4.
+// Walker stashes the state into Meta["acp2.eventState"].
+func TestWalker_DecodesPid18_EventState(t *testing.T) {
+	w := &Walker{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	props := []codec.Property{
+		{PID: codec.PIDObjectType, VType: uint8(codec.ObjTypeEnum), PLen: 4},
+		{PID: codec.PIDLabel, VType: 0, PLen: 4 + 5, Data: []byte("Baz\x00")},
+		{PID: codec.PIDEventState, VType: 7, PLen: 4},
+	}
+	obj, _, _, _, _ := w.parseObjectProperties(props, 1, 7, nil)
+	v, ok := obj.Meta["acp2.eventState"]
+	if !ok {
+		t.Fatal("walker did not stash acp2.eventState in Meta")
+	}
+	if got, _ := v.(uint8); got != 7 {
+		t.Errorf("acp2.eventState=%v want 7", v)
+	}
+}
+
+// TestWalker_DecodesPid20_PresetParent covers spec §5.4 row 20: pid=20
+// data=0, plen=8, body=u32 BE parent obj-id. Walker stashes into
+// Meta["acp2.presetParent"].
+func TestWalker_DecodesPid20_PresetParent(t *testing.T) {
+	w := &Walker{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	body := make([]byte, 4)
+	binary.BigEndian.PutUint32(body, 12345)
+	props := []codec.Property{
+		{PID: codec.PIDObjectType, VType: uint8(codec.ObjTypePreset), PLen: 4},
+		{PID: codec.PIDLabel, VType: 0, PLen: 4 + 5, Data: []byte("Qux\x00")},
+		{PID: codec.PIDPresetParent, VType: 0, PLen: 8, Data: body},
+	}
+	obj, _, _, _, _ := w.parseObjectProperties(props, 1, 8, nil)
+	v, ok := obj.Meta["acp2.presetParent"]
+	if !ok {
+		t.Fatal("walker did not stash acp2.presetParent in Meta")
+	}
+	if got, _ := v.(uint64); got != 12345 {
+		t.Errorf("acp2.presetParent=%v want 12345", v)
+	}
+}


### PR DESCRIPTION
## Summary
Consumer's `walker.go` now decodes four spec-defined property ids it previously silently dropped:

| pid | name | wire shape | Meta key |
|---:|---|---|---|
| 4 | event_delay | data=0, plen=8, body=u32 BE rate (ms) | `acp2.announceDelay` (uint64) |
| 7 | preset_depth | data=0, plen=4+4*depth, body=u32 BE idx list | `acp2.presetIdxList` ([]uint32) |
| 18 | event_state | inline state byte in property header data slot, plen=4 | `acp2.eventState` (uint8) |
| 20 | preset_parent | data=0, plen=8, body=u32 BE parent obj-id | `acp2.presetParent` (uint64) |

The decoded values land on `protocol.Object.Meta` under protocol-namespaced keys, keeping the cross-protocol Object struct unchanged. ACP2 clients introspect `Meta` when they need these fields.

## Spec quote (`internal/acp2/assets/acp2_protocol.docx` §"Property header per field")
```
event delay   4   0   8           u32 rate
preset depth  7   0   4+4*depth   idx0, idx, ..
event state   18  state  4
preset parent 20  0   8           u32 parent id
```

## Helpers
- `setMeta(obj, key, value)` — lazy-allocates `obj.Meta` map.
- `beU32(b)` — local big-endian u32 reader, avoids `binary.BigEndian.Uint32` at every call site.

## Test plan
- [x] `TestWalker_DecodesPid4_AnnounceDelay` — rate=1500 ms round-trip
- [x] `TestWalker_DecodesPid7_PresetDepth` — idx list `{100, 200}` matches spec example line 2613-2632
- [x] `TestWalker_DecodesPid18_EventState` — inline state byte = 7
- [x] `TestWalker_DecodesPid20_PresetParent` — parent obj-id = 12345
- [x] All ACP2 tests green
- [ ] CI green
- [ ] Round-trip test once #307 (provider emits pid=4) lands → consumer round-trip preserves the field.

## Sister change
- #307 (provider emits pid=4 event_delay)
- #311 (provider pid=7 idx values from canonical) — deferred pending canonical schema decision

Closes #315. Stacks under `feat/acp2-strict-spec-closeout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
