### PR TITLE
fix(acp2-codec): error decoder MUST NOT read body per spec §Error

### DIFF
--- a/internal/acp2/codec/codec.go
+++ b/internal/acp2/codec/codec.go
@@ -141,8 +141,11 @@ func EncodeACP2Message(m *ACP2Message) ([]byte, error) {
 //	| 3      | pid    | u8    | pid / padding / version number            |
 //
 // Body parsing rules:
-//   - type=3 error: first 4 body bytes (if present) decode as obj-id u32 BE.
-//     func byte is reinterpreted as ACP2ErrStatus via ToACP2Error.
+//   - type=3 error: per spec §"Error" the message is exactly the
+//     4-byte ACP2 header; no body. The func byte is reinterpreted as
+//     ACP2ErrStatus via ToACP2Error. Any trailing bytes are stashed
+//     in m.Body so a caller / compliance check can flag the
+//     deviation, but ObjID is NEVER populated from them.
 //   - reply + func=get_version: header only; pid holds the version byte.
 //   - reply / announce (funcs 1-3): body layout
 //     [0..3]   obj-id  u32 BE
@@ -169,11 +172,17 @@ func DecodeACP2Message(data []byte) (*ACP2Message, error) {
 	m.Body = make([]byte, len(body))
 	copy(m.Body, body)
 
-	// For error messages, extract obj-id from body if present.
+	// For error messages, the spec (§"Error", line 1207-1250 of
+	// acp2_protocol.docx) defines the message as exactly the 4-byte
+	// ACP2 header — NO body. Do not synthesise ObjID from any
+	// trailing bytes; doing so silently masks producer bugs in
+	// shipping peers and prevents detection of spec-non-compliant
+	// wire shapes.
 	if m.Type == ACP2TypeError {
-		if len(body) >= 4 {
-			m.ObjID = binary.BigEndian.Uint32(body[0:4])
-		}
+		// Trailing bytes (if any) remain in m.Body for caller-side
+		// compliance checks to inspect. ObjID stays 0 — clients
+		// needing to correlate the error with a specific request use
+		// the mtid, not a body-derived obj-id.
 		return m, nil
 	}
 

--- a/internal/acp2/codec/codec_test.go
+++ b/internal/acp2/codec/codec_test.go
@@ -93,16 +93,15 @@ func TestDecodeACP2Message_Reply(t *testing.T) {
 }
 
 func TestDecodeACP2Message_Error(t *testing.T) {
-	// Simulate an error reply: type=3, mtid=2, stat=1 (invalid obj-id), pid=0
-	// Body: obj-id = 99
-	body := make([]byte, 4)
-	binary.BigEndian.PutUint32(body, 99)
-	data := append([]byte{
-		byte(ACP2TypeError), // type
-		2,                    // mtid
-		byte(ErrInvalidObjID), // stat
-		0,                    // pid
-	}, body...)
+	// Per spec §"Error" (line 1207-1250): error message is exactly the
+	// 4-byte ACP2 header. No body. Decoder must NOT synthesise ObjID
+	// from any trailing bytes.
+	data := []byte{
+		byte(ACP2TypeError),    // type
+		2,                       // mtid
+		byte(ErrInvalidObjID),   // stat (in func slot)
+		0,                       // pid
+	}
 
 	msg, err := DecodeACP2Message(data)
 	if err != nil {
@@ -114,13 +113,41 @@ func TestDecodeACP2Message_Error(t *testing.T) {
 	if ACP2ErrStatus(msg.Func) != ErrInvalidObjID {
 		t.Errorf("stat: got %d, want %d", msg.Func, ErrInvalidObjID)
 	}
-	if msg.ObjID != 99 {
-		t.Errorf("obj-id: got %d, want 99", msg.ObjID)
+	if msg.ObjID != 0 {
+		t.Errorf("obj-id=%d want 0 (spec: error has no body)", msg.ObjID)
 	}
 
 	acp2Err := msg.ToACP2Error()
 	if acp2Err == nil {
 		t.Fatal("expected non-nil error")
+	}
+}
+
+// TestDecodeACP2Message_Error_TolerantOfTrailingBytes verifies that a
+// non-compliant peer that emits an error with a body (e.g. trailing
+// obj-id) does not crash the decoder, and that ObjID remains 0
+// (never synthesised from those bytes — they may be garbage).
+func TestDecodeACP2Message_Error_TolerantOfTrailingBytes(t *testing.T) {
+	body := make([]byte, 4)
+	binary.BigEndian.PutUint32(body, 99) // bogus trailing obj-id
+	data := append([]byte{
+		byte(ACP2TypeError),
+		3,
+		byte(ErrInvalidObjID),
+		0,
+	}, body...)
+
+	msg, err := DecodeACP2Message(data)
+	if err != nil {
+		t.Fatalf("Decode: %v (decoder must tolerate trailing bytes)", err)
+	}
+	if msg.ObjID != 0 {
+		t.Errorf("obj-id=%d want 0 (decoder MUST NOT synthesise obj-id "+
+			"from trailing bytes per spec §Error)", msg.ObjID)
+	}
+	if len(msg.Body) != 4 {
+		t.Errorf("Body len=%d want 4 (trailing bytes preserved for "+
+			"caller-side compliance inspection)", len(msg.Body))
 	}
 }
 

--- a/internal/acp2/consumer/placeholder_test.go
+++ b/internal/acp2/consumer/placeholder_test.go
@@ -91,12 +91,12 @@ func TestACP2MessageHeader(t *testing.T) {
 	}
 }
 
-// TestACP2ErrorDecode verifies error reply decoding.
+// TestACP2ErrorDecode verifies error reply decoding per spec §"Error":
+// the message is exactly the 4-byte ACP2 header, no body. ObjID is
+// NOT populated from any trailing bytes — clients correlate via mtid.
 func TestACP2ErrorDecode(t *testing.T) {
-	// Build: type=3, mtid=2, stat=4 (no access), pid=0, body: obj-id=50
-	body := make([]byte, 4)
-	binary.BigEndian.PutUint32(body, 50)
-	data := append([]byte{3, 2, 4, 0}, body...)
+	// Spec-compliant 4-byte error: type=3, mtid=2, stat=4, pid=0.
+	data := []byte{3, 2, 4, 0}
 
 	msg, err := codec.DecodeACP2Message(data)
 	if err != nil {
@@ -105,8 +105,8 @@ func TestACP2ErrorDecode(t *testing.T) {
 	if msg.Type != codec.ACP2TypeError {
 		t.Errorf("type: got %d, want 3", msg.Type)
 	}
-	if msg.ObjID != 50 {
-		t.Errorf("obj-id: got %d, want 50", msg.ObjID)
+	if msg.ObjID != 0 {
+		t.Errorf("obj-id=%d want 0 (spec: error has no body)", msg.ObjID)
 	}
 
 	acp2Err := msg.ToACP2Error()


### PR DESCRIPTION
## Summary
`DecodeACP2Message` no longer synthesises `m.ObjID` from trailing bytes on error messages. Per ACP2 spec §"Error" (line 1207-1250 of `acp2_protocol.docx`), an error message is exactly the 4-byte ACP2 header — no body. Clients correlate the error with a request via mtid, not via a body-derived obj-id.

## Spec quote
The §"Error" table lists only the four header bytes:
```
type    error    see 3.2
mtid    x
stat    error status (see 3.1)
pid     0
```
No body row.

## Behaviour change
| Input | Before | After |
|---|---|---|
| 4-byte spec error `{3, 2, 1, 0}` | `ObjID = 0` (no body to read) | `ObjID = 0` (unchanged) |
| 8-byte non-compliant `{3, 2, 1, 0, 0, 0, 0, 99}` | `ObjID = 99` (synthesised) | `ObjID = 0` (decoder refuses to invent it; trailing bytes preserved in `m.Body` for caller-side compliance inspection) |

Mtid (in `m.MTID`) is the spec-defined correlation key.

## Test plan
- [x] `TestDecodeACP2Message_Error` — spec-compliant 4-byte error decodes correctly with `ObjID=0`.
- [x] `TestDecodeACP2Message_Error_TolerantOfTrailingBytes` — bogus trailing 4-byte body is preserved in `Body` but `ObjID` stays 0.
- [x] `TestACP2ErrorDecode` (consumer) — updated to spec shape.
- [x] All ACP2 tests green
- [x] Build clean
- [ ] CI green

## Sister change
- #313 / PR #330 (provider drops error reply body) is the companion producer-side fix. Together they restore strict spec compliance on both ends.

Closes #316. Stacks under `feat/acp2-strict-spec-closeout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
