### PR TITLE
refactor(acp2): rename PIDAnnounceDelay to PIDEventDelay per spec §5.4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -494,8 +494,8 @@ See `feedback_amwa_strict_all_versions` in memory.
   from outside its own tree except via `cmd/dhs/` blank imports.
 - Never hardcode protocol names in generic code — use the registry.
 - Never use fixed byte offsets for ACP2 properties — use pid/plen headers.
-- Never call ACP2 pid=4 "event_delay" — it is "announce_delay".
-- Never call ACP2 type=2 "event" — it is "announce".
+- Spec name for ACP2 pid=4 is "event_delay" (acp2_protocol.docx §5.4 row 4) — match the docx exactly.
+- Spec name for ACP2 type=2 is "announce" (acp2_protocol.docx §3.2 type-field row).
 - Never use ACP2 idx=0 to mean "first preset slot" — it is ACTIVE INDEX.
 - Never write property values to disk as trusted state.
 - Never add Redis, PostgreSQL, or any external data store.

--- a/cmd/dhs/cmd_list_commands_test.go
+++ b/cmd/dhs/cmd_list_commands_test.go
@@ -83,7 +83,7 @@ func TestLookupCatalogueACPKindAddressing(t *testing.T) {
 		{"acp1", "method:0", "getValue"},
 		{"acp1", "method:5", "getObject"},
 		{"acp1", "objgroup:2", "control"},
-		{"acp2", "pid:4", "announce_delay"},
+		{"acp2", "pid:4", "event_delay"},
 		{"acp2", "acp2-func:1", "get_object"},
 		{"acp2", "obj-type:0", "node"},
 	}

--- a/internal/acp2/CLAUDE.md
+++ b/internal/acp2/CLAUDE.md
@@ -129,7 +129,7 @@ Alignment: after each property, skip `(4 - (plen % 4)) % 4` bytes.
 |   1 | object_type       | R        |  -  |                           |
 |   2 | label             | R        |  -  | 0-terminated UTF-8        |
 |   3 | access            | R        |  Y  | 1=r, 2=w, 3=rw            |
-|   4 | announce_delay    | RW       |  Y  | u32 ms (NOT "event_delay")|
+|   4 | event_delay       | RW       |  Y  | u32 ms                    |
 |   5 | number_type       | R        |  -  |                           |
 |   6 | string_max_length | R        |  -  | u16                       |
 |   7 | preset_depth      | R        |  -  | optional; valid idx list  |
@@ -189,8 +189,8 @@ Only received after `AN2 EnableProtocolEvents([2])`. AN2 slot events
 - ACP2 mtid pool: 1-255; 0 reserved for announces.
 - mtid NEVER reused while a request is in-flight.
 - EnableProtocolEvents MUST be called after every (re)connect.
-- pid=4 is "announce_delay" — NEVER call it "event_delay".
-- type=2 is "announce" — NEVER call it "event".
+- pid=4 is "event_delay" per spec §5.4 row 4.
+- type=2 is "announce" per spec §3.2 type-field row.
 - ACP2 strings are UTF-8; ACP1 strings are ASCII.
 - All multi-byte values are big-endian.
 
@@ -199,5 +199,5 @@ Only received after `AN2 EnableProtocolEvents([2])`. AN2 slot events
 - Do NOT use fixed byte offsets for property data — use pid/plen headers.
 - Do NOT skip EnableProtocolEvents before expecting announces.
 - Do NOT reuse a live mtid.
-- Do NOT call pid=4 "event_delay".
+- Spec name for pid=4 is "event_delay" — match the docx exactly.
 - Do NOT use idx=0 to mean "first preset".

--- a/internal/acp2/codec/property_codec.go
+++ b/internal/acp2/codec/property_codec.go
@@ -34,9 +34,9 @@ func propertyPadding(plen uint16) int {
 //	| 4..    | value   | plen-4| raw bytes; absent when plen == 4          |
 //	| plen.. | padding | 0-3   | (4 - (plen % 4)) % 4 zero bytes           |
 //
-// pid=4 is announce_delay — never "event_delay".
+// pid=4 is event_delay per spec §5.4 row 4.
 //
-// Spec reference: acp2_protocol.pdf §Property Header, §Property IDs
+// Spec reference: acp2_protocol.docx §Property Header, §Property IDs
 func DecodeProperties(data []byte) ([]Property, error) {
 	var props []Property
 	offset := 0

--- a/internal/acp2/codec/types.go
+++ b/internal/acp2/codec/types.go
@@ -202,7 +202,7 @@ const (
 	PIDObjectType      uint8 = 1
 	PIDLabel           uint8 = 2
 	PIDAccess          uint8 = 3
-	PIDAnnounceDelay   uint8 = 4
+	PIDEventDelay      uint8 = 4
 	PIDNumberType      uint8 = 5
 	PIDStringMaxLength uint8 = 6
 	PIDPresetDepth     uint8 = 7

--- a/internal/acp2/consumer/catalogue.go
+++ b/internal/acp2/consumer/catalogue.go
@@ -79,7 +79,7 @@ func Catalogue() []CatalogueEntry {
 		{Kind: KindPid, ID: 1, Name: "object_type", SpecRef: "ACP2 §5"},
 		{Kind: KindPid, ID: 2, Name: "label", SpecRef: "ACP2 §5", Notes: "0-terminated UTF-8"},
 		{Kind: KindPid, ID: 3, Name: "access", SpecRef: "ACP2 §5", Notes: "1=r, 2=w, 3=rw"},
-		{Kind: KindPid, ID: 4, Name: "announce_delay", SpecRef: "ACP2 §5", Notes: "u32 ms — NOT 'event_delay'"},
+		{Kind: KindPid, ID: 4, Name: "event_delay", SpecRef: "ACP2 §5.4 row 4", Notes: "u32 BE rate (ms)"},
 		{Kind: KindPid, ID: 5, Name: "number_type", SpecRef: "ACP2 §5"},
 		{Kind: KindPid, ID: 6, Name: "string_max_length", SpecRef: "ACP2 §5", Notes: "u16"},
 		{Kind: KindPid, ID: 7, Name: "preset_depth", SpecRef: "ACP2 §5", Notes: "valid idx list"},

--- a/internal/acp2/docs/consumer.md
+++ b/internal/acp2/docs/consumer.md
@@ -381,7 +381,7 @@ acp set 10.41.40.195 --protocol acp2 --slot 0 --id 15246 --value "10.41.40.195"
 - Transport: AN2 TCP, ACP2 type=2, mtid=0
 - Requires `AN2 EnableProtocolEvents([2])` on connect (automatic)
 - Announcements carry: slot, obj-id, pid, new value
-- Terminology: "announce" (not "event"), "announce_delay" (not "event_delay")
+- Terminology: spec calls type=2 "announce" (§3.2 type-field row) and pid=4 "event_delay" (§5.4 row 4) — match the docx exactly.
 
 ### Watch with disk cache
 

--- a/internal/acp2/provider/set.go
+++ b/internal/acp2/provider/set.go
@@ -35,9 +35,9 @@ func (s *server) applySet(e *entry, in *codec.Property) (codec.Property, codec.A
 		return codec.Property{}, codec.ErrNoAccess, fmt.Errorf("no write access")
 	}
 	if in.PID != codec.PIDValue {
-		// MVP only accepts writes to pid=8 (value). announce_delay
-		// (pid=4) and event_prio (pid=17) are spec-writable too but
-		// out of MVP scope.
+		// MVP only accepts writes to pid=8 (value). event_delay (pid=4)
+		// and event_priority (pid=17) are also writable per spec §5.4
+		// (RW access in property-fields matrix) but out of MVP scope.
 		return codec.Property{}, codec.ErrInvalidPID, fmt.Errorf("only pid=8 is writable in MVP")
 	}
 

--- a/internal/acp2/wireshark/dhs_acpv2.lua
+++ b/internal/acp2/wireshark/dhs_acpv2.lua
@@ -124,7 +124,7 @@ local acp2_pid_valstr = {
     [1]  = "object_type",
     [2]  = "label",
     [3]  = "access",
-    [4]  = "announce_delay",
+    [4]  = "event_delay",
     [5]  = "number_type",
     [6]  = "string_max_length",
     [7]  = "preset_depth",
@@ -388,7 +388,7 @@ local function parse_property(tvbuf, pktinfo, parent_tree, offset)
         tree:add(prop_f.access, tvbuf:range(offset + 1, 1))
 
     elseif pid_val == 4 then
-        -- announce_delay: u32 in value area
+        -- event_delay: u32 in value area
         if val_len >= 4 then
             tree:add(prop_f.delay, tvbuf:range(val_offset, 4))
         end


### PR DESCRIPTION
## Summary
Rename `codec.PIDAnnounceDelay` → `codec.PIDEventDelay` and align CLAUDE.md / docs / dissector / catalogue / tests with the spec wording.

## Why
ACP2 spec `acp2_protocol.docx` uses **"event delay"** for pid=4 in every reference:

- §"Property fields" matrix row 4 (line 1419): `4 event delay RW yes`
- §"Set property" requirement list (line 1132): `settable: event delay, value, and event priority`
- §5.4 "Property header per field" (line 1721): `event delay  4  0  8  u32 rate`

Our code + CLAUDE.md + auto-memory previously enforced the opposite rule (`pid=4 is announce_delay — NEVER call it event_delay`). That contradicts the binding spec.

Per `feedback_acp2_spec_pdfs_only` the docx is the only authority — match it exactly.

## Files changed
| File | Change |
|---|---|
| `internal/acp2/codec/types.go` | const `PIDAnnounceDelay` → `PIDEventDelay` |
| `internal/acp2/codec/property_codec.go` | doc comment |
| `internal/acp2/CLAUDE.md` | property-IDs table, key invariants, what-NOT-to-do flipped |
| `CLAUDE.md` (root) | two cross-protocol rules flipped to match spec |
| `internal/acp2/provider/set.go` | doc comment |
| `internal/acp2/consumer/catalogue.go` | `KindPid` entry name + notes |
| `internal/acp2/wireshark/dhs_acpv2.lua` | pid valstr + decoder comment |
| `internal/acp2/docs/consumer.md` | terminology line |
| `cmd/dhs/cmd_list_commands_test.go` | test expects `event_delay` |

## Test plan
- [x] `go test ./...` — full suite green (0 failures across all protocols)
- [x] `go vet` + `golangci-lint` clean (pre-commit hook)
- [x] `git grep PIDAnnounceDelay` returns 0 hits
- [ ] CI green

## Memory follow-up
The `feedback_acp2_announce_event_naming` style rule in user auto-memory mirrors the old (wrong) CLAUDE.md text. That should be rewritten in a separate user-driven memory pass — no code hook scrubs it.

Closes #317. Stacks under `feat/acp2-strict-spec-closeout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
