### PR TITLE
fix(cli): standardize ACP2 verb flag taxonomy (--object alias, --direction io)

### DIFF
--- a/cmd/dhs/cmd_extract.go
+++ b/cmd/dhs/cmd_extract.go
@@ -13,6 +13,25 @@ import (
 	"time"
 )
 
+// canonicalDirection normalises the --direction flag value. Accepts
+// the canonical spellings (consumer / provider / both) plus "io" as
+// a friendlier synonym for "both" for bidirectional products like
+// ACP2 channels. Returns the canonical form on success or a wrapped
+// error on unknown values.
+//
+// Pure helper — extracted from runExtract to keep the alias logic
+// unit-testable without the full dial path.
+func canonicalDirection(d string) (string, error) {
+	if d == "io" {
+		return "both", nil
+	}
+	switch d {
+	case "consumer", "provider", "both":
+		return d, nil
+	}
+	return "", fmt.Errorf("--direction must be one of: consumer, provider, both, io (got %q)", d)
+}
+
 // runExtract drives `acp extract` (issue #47) — walks a device and
 // writes the product-fixture triple (meta + wire + tree) into the
 // output directory using the schema locked in #43.
@@ -25,7 +44,7 @@ func runExtract(ctx context.Context, args []string) error {
 	product := fs.String("product", "",
 		"product identifier as the vendor writes it (e.g. DDB08, CDV08v06). Required.")
 	direction := fs.String("direction", "",
-		"how the product speaks this protocol: consumer (we read it), provider (we expose it), or both. Required.")
+		"how the product speaks this protocol: consumer (we read it), provider (we expose it), both, or io (alias for both). Required.")
 	ver := fs.String("version", "",
 		"product / firmware version as reported by the device (e.g. 2.3). Required.")
 	versionKind := fs.String("version-kind", "firmware",
@@ -47,11 +66,11 @@ func runExtract(ctx context.Context, args []string) error {
 	if *manufacturer == "" || *product == "" || *direction == "" || *ver == "" || *outDir == "" {
 		return fmt.Errorf("--manufacturer, --product, --direction, --version, and --out are all required")
 	}
-	switch *direction {
-	case "consumer", "provider", "both":
-	default:
-		return fmt.Errorf("--direction must be one of: consumer, provider, both (got %q)", *direction)
+	canonical, err := canonicalDirection(*direction)
+	if err != nil {
+		return err
 	}
+	*direction = canonical
 
 	if cf.protocol == "emberplus" && *slot < 0 {
 		*slot = 0

--- a/cmd/dhs/cmd_get.go
+++ b/cmd/dhs/cmd_get.go
@@ -16,6 +16,7 @@ func runGet(ctx context.Context, args []string) error {
 	group := fs.String("group", "", "object group (optional when --label is unique across groups)")
 	label := fs.String("label", "", "object label (preferred over --id, requires prior walk context)")
 	id := fs.Int("id", -1, "object id within group (alternative to --label)")
+	objectAlias := fs.Int("object", -1, "alias for --id (deprecated; ACP2 callers historically wrote --object)")
 	pathFlag := fs.String("path", "", "dot-separated tree path (e.g. router.oneToN.parameters.sourceGain)")
 	idx := fs.Int("idx", 0, "ACP2 preset idx (0 = ACTIVE INDEX; default)")
 	pid := fs.Int("pid", 0, "ACP2 property id to read (0 = default pid=8 value; set to read object_type/label/access/etc.)")
@@ -30,6 +31,14 @@ func runGet(ctx context.Context, args []string) error {
 	}
 	if *slot < 0 {
 		return fmt.Errorf("--slot is required")
+	}
+	// --object is a deprecated alias for --id. Fold it in unless both
+	// were set with conflicting values.
+	if *objectAlias >= 0 {
+		if *id >= 0 && *id != *objectAlias {
+			return fmt.Errorf("--id and --object both set with different values (%d vs %d)", *id, *objectAlias)
+		}
+		*id = *objectAlias
 	}
 	if *pathFlag == "" && *label == "" && *id < 0 {
 		return fmt.Errorf("either --path, --label, or --id is required")

--- a/cmd/dhs/cmd_set.go
+++ b/cmd/dhs/cmd_set.go
@@ -17,6 +17,7 @@ func runSet(ctx context.Context, args []string) error {
 	group := fs.String("group", "", "object group name")
 	label := fs.String("label", "", "object label")
 	id := fs.Int("id", -1, "object id within group")
+	objectAlias := fs.Int("object", -1, "alias for --id (deprecated; ACP2 callers historically wrote --object)")
 	pathFlag := fs.String("path", "", "dot-separated tree path (e.g. router.oneToN.parameters.sourceGain)")
 	valueStr := fs.String("value", "", "typed value (e.g. -3.0, \"On\", \"192.168.1.5\", \"CH1\"); empty string is valid for string objects")
 	valueHex := fs.String("raw", "", "raw wire bytes as hex — escape hatch bypassing typed encoding")
@@ -45,6 +46,15 @@ func runSet(ctx context.Context, args []string) error {
 	}
 	if *slot < 0 {
 		return fmt.Errorf("--slot is required")
+	}
+	// --object is a deprecated alias for --id. If the user supplied
+	// --object and not --id, fold it in. If both are set with different
+	// values, reject — the caller's intent is ambiguous.
+	if *objectAlias >= 0 {
+		if *id >= 0 && *id != *objectAlias {
+			return fmt.Errorf("--id and --object both set with different values (%d vs %d)", *id, *objectAlias)
+		}
+		*id = *objectAlias
 	}
 	if !valueSet && !rawSet {
 		return fmt.Errorf("either --value or --raw is required")

--- a/cmd/dhs/flag_alias_test.go
+++ b/cmd/dhs/flag_alias_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestCanonicalDirection covers the alias logic per #324:
+//   - "consumer" / "provider" / "both" → identity (canonical forms)
+//   - "io" → "both" (friendlier synonym for bidirectional products)
+//   - anything else → error citing the allowed values.
+func TestCanonicalDirection(t *testing.T) {
+	cases := []struct {
+		in       string
+		want     string
+		wantErr  bool
+	}{
+		{"consumer", "consumer", false},
+		{"provider", "provider", false},
+		{"both", "both", false},
+		{"io", "both", false},
+		{"sideways", "", true},
+		{"", "", true},
+		{"IO", "", true}, // case-sensitive — "IO" is not "io"
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got, err := canonicalDirection(c.in)
+			if c.wantErr {
+				if err == nil {
+					t.Errorf("canonicalDirection(%q) = %q, want error", c.in, got)
+				}
+				if err != nil && !strings.Contains(err.Error(), "--direction must be one of") {
+					t.Errorf("canonicalDirection(%q) error = %v; want validator message", c.in, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("canonicalDirection(%q) error = %v; want nil", c.in, err)
+			}
+			if got != c.want {
+				t.Errorf("canonicalDirection(%q) = %q; want %q", c.in, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Symptoms (2026-05-08)
```
$ dhs consumer acp2 set 10.100.0.103 ... --object 3 --value test
flag provided but not defined: -object

$ dhs consumer acp2 extract 10.100.0.103 ... --direction io ...
error: --direction must be one of: consumer, provider, both (got "io")
```

Both rejections are spec-compliant but unfriendly. The `--object` term comes from the spec docx and the Wireshark dissector ("ACP2 object id"); users naturally reach for it instead of `--id`. ACP2 channels are bidirectional, so `io` reads more naturally than `both`.

## Changes
- `cmd_set.go`: `--object N` accepted as alias for `--id N`. Both set with conflicting values rejects with a clear error.
- `cmd_get.go`: same alias path.
- `cmd_extract.go`: new `canonicalDirection` helper accepting `consumer / provider / both / io`. Pure helper — extracted from `runExtract` so the alias is unit-testable without the full dial path. `io` canonicalises to `both` before the rest of the verb sees it.

## Test plan
- [x] `TestCanonicalDirection` — 7 sub-tests:
  - canonical: `consumer`, `provider`, `both` → identity
  - synonym: `io` → `both`
  - reject: `sideways`, empty string, `IO` (case-sensitive)
- [x] All `cmd/dhs` and ACP2 tests green
- [x] Build clean
- [ ] CI green
- [ ] Manual smoke: `dhs consumer acp2 set <host> --slot 1 --object 3 --value test` and `dhs consumer acp2 extract <host> ... --direction io ...` both proceed past flag parsing.

## Notes
- Canonical flag remains `--id`; `--object` is the deprecated alias kept for ergonomics.
- Future deprecation warnings can land via `--log-level debug` in a follow-up — out of scope here.

Closes #324. Stacks under `feat/acp2-strict-spec-closeout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
