### PR TITLE
fix(acp2-consumer): mtid pool MUST never reuse in-flight + ctx-cancellable

### DIFF
--- a/internal/acp2/consumer/compliance_events.go
+++ b/internal/acp2/consumer/compliance_events.go
@@ -133,6 +133,16 @@ const (
 	// device), we accept it + fire so the operator sees write-path
 	// coercion. Informational.
 	SetValueCoerced = "acp2_set_value_coerced"
+
+	// Spec p.4 §"Mtid": "ACP2 only uses the mtid to send a reply and
+	// does no other checks." Implies replies must carry an mtid that
+	// matches an in-flight request. When a reply arrives for a mtid
+	// the consumer is NOT currently waiting on, either:
+	//   - the peer reused a mtid we already released (peer bug), or
+	//   - our mtid pool released it too early (our bug — impossible
+	//     given defer-based release, but this catches regressions).
+	// Reply is dropped + fires. Informational.
+	OrphanReplyMtid = "acp2_orphan_reply_mtid"
 )
 
 // EventForErrStatus maps an ACP2 error status (spec p.5) to the

--- a/internal/acp2/consumer/mtid_pool_test.go
+++ b/internal/acp2/consumer/mtid_pool_test.go
@@ -1,0 +1,192 @@
+package acp2
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// newPoolTestSession builds a Session with the mtid pool ready (the
+// fields the pool exercises don't need a live TCP connection — alloc
+// /release just touch mtidPool + mtidCond + mtidMu).
+func newPoolTestSession() *Session {
+	s := &Session{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	s.mtidCond = sync.NewCond(&s.mtidMu)
+	return s
+}
+
+// TestMTIDPool_AllocateUniqueAndRelease spec p.4 §"Mtid": "ACP2 only
+// uses the mtid to send a reply and does no other checks." The
+// allocator MUST never hand out an mtid that's currently in flight.
+func TestMTIDPool_AllocateUniqueAndRelease(t *testing.T) {
+	s := newPoolTestSession()
+	ctx := context.Background()
+
+	// Allocate every mtid (1..255). Each must be unique.
+	seen := make(map[uint8]bool, 255)
+	got := make([]uint8, 0, 255)
+	for i := 0; i < 255; i++ {
+		m, err := s.allocMTID(ctx)
+		if err != nil {
+			t.Fatalf("allocMTID #%d: %v", i, err)
+		}
+		if m == 0 {
+			t.Fatalf("allocMTID returned 0 (reserved for announces)")
+		}
+		if seen[m] {
+			t.Fatalf("allocMTID returned duplicate in-flight mtid %d", m)
+		}
+		seen[m] = true
+		got = append(got, m)
+	}
+	if len(seen) != 255 {
+		t.Errorf("got %d unique mtids; want 255", len(seen))
+	}
+
+	// Release them all and verify the next alloc reuses freed slots.
+	for _, m := range got {
+		s.releaseMTID(m)
+	}
+	m2, err := s.allocMTID(ctx)
+	if err != nil {
+		t.Fatalf("alloc after full release: %v", err)
+	}
+	if m2 == 0 {
+		t.Fatal("allocMTID returned 0 after release")
+	}
+	s.releaseMTID(m2)
+}
+
+// TestMTIDPool_BlocksWhenExhausted verifies that a 256th concurrent
+// alloc blocks on mtidCond until a release. Spec p.4 says the mtid
+// space is 1..255; never wrap.
+func TestMTIDPool_BlocksWhenExhausted(t *testing.T) {
+	s := newPoolTestSession()
+	ctx := context.Background()
+
+	// Fill the pool.
+	held := make([]uint8, 0, 255)
+	for i := 0; i < 255; i++ {
+		m, err := s.allocMTID(ctx)
+		if err != nil {
+			t.Fatalf("alloc #%d: %v", i, err)
+		}
+		held = append(held, m)
+	}
+
+	// 256th call must block. Verify by racing it against a 50 ms
+	// release-trigger goroutine.
+	allocResult := make(chan uint8, 1)
+	allocErr := make(chan error, 1)
+	go func() {
+		m, err := s.allocMTID(ctx)
+		if err != nil {
+			allocErr <- err
+			return
+		}
+		allocResult <- m
+	}()
+
+	select {
+	case m := <-allocResult:
+		t.Fatalf("256th alloc returned %d immediately; expected to block", m)
+	case <-time.After(20 * time.Millisecond):
+		// Good — the 256th call is blocked.
+	}
+
+	// Release one and verify the blocked goroutine unblocks.
+	s.releaseMTID(held[42])
+
+	select {
+	case m := <-allocResult:
+		if m == 0 {
+			t.Errorf("alloc returned 0 after release")
+		}
+		// Clean up: release everything we still hold + the new one.
+		s.releaseMTID(m)
+		for i, h := range held {
+			if i == 42 {
+				continue // already released
+			}
+			s.releaseMTID(h)
+		}
+	case err := <-allocErr:
+		t.Fatalf("alloc errored after release: %v", err)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("alloc did not unblock after release")
+	}
+}
+
+// TestMTIDPool_ConcurrentAllocReleaseNeverDuplicates pounds the pool
+// with 50 goroutines each running 100 alloc/release cycles. Tracks
+// every (alloc, release) timestamp to detect any moment where two
+// goroutines hold the same mtid simultaneously.
+func TestMTIDPool_ConcurrentAllocReleaseNeverDuplicates(t *testing.T) {
+	s := newPoolTestSession()
+	ctx := context.Background()
+
+	const goroutines = 50
+	const iterations = 100
+
+	// inFlight tracks mtid -> bool atomically. Use a [256]uint32 with
+	// CAS to detect simultaneous holding.
+	var inFlight [256]uint32
+	var dupCount uint64
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				m, err := s.allocMTID(ctx)
+				if err != nil {
+					t.Errorf("alloc: %v", err)
+					return
+				}
+				if !atomic.CompareAndSwapUint32(&inFlight[m], 0, 1) {
+					atomic.AddUint64(&dupCount, 1)
+				}
+				// Hold for a short time, then release.
+				atomic.StoreUint32(&inFlight[m], 0)
+				s.releaseMTID(m)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if dupCount > 0 {
+		t.Errorf("mtid pool returned %d simultaneously-held mtids across %d goroutines x %d iterations",
+			dupCount, goroutines, iterations)
+	}
+}
+
+// TestMTIDPool_RespectsContextCancel verifies that allocMTID returns
+// ctx.Err() when the context cancels while waiting on a full pool.
+func TestMTIDPool_RespectsContextCancel(t *testing.T) {
+	s := newPoolTestSession()
+
+	// Fill the pool.
+	for i := 0; i < 255; i++ {
+		if _, err := s.allocMTID(context.Background()); err != nil {
+			t.Fatalf("fill alloc #%d: %v", i, err)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	_, err := s.allocMTID(ctx)
+	if err == nil {
+		t.Fatal("alloc on full pool with cancelled ctx returned no error")
+	}
+	if err != context.DeadlineExceeded && err != context.Canceled {
+		t.Errorf("alloc returned %v; want context.DeadlineExceeded", err)
+	}
+}

--- a/internal/acp2/consumer/session.go
+++ b/internal/acp2/consumer/session.go
@@ -538,6 +538,12 @@ func (s *Session) handleACP2Frame(f *codec.AN2Frame) {
 }
 
 // routeReply sends a message to the waiter registered for the given mtid.
+//
+// When no waiter is registered the reply is dropped and a compliance
+// event (OrphanReplyMtid) fires. This catches both peer bugs (the
+// device emitted a stale mtid) and our own pool regressions (mtid
+// released before reply arrived). Per spec p.4 §"Mtid", replies must
+// correlate to in-flight requests; an orphan reply is a wire violation.
 func (s *Session) routeReply(mtid uint8, msg *codec.ACP2Message) {
 	s.waitMu.Lock()
 	ch, ok := s.waiters[mtid]
@@ -550,16 +556,37 @@ func (s *Session) routeReply(mtid uint8, msg *codec.ACP2Message) {
 		}
 	} else {
 		s.logger.Debug("acp2: no waiter for mtid", "mtid", mtid)
+		s.note(OrphanReplyMtid)
 	}
 }
 
-// allocMTID allocates a free ACP2 mtid (1-255). Blocks if all are in use.
+// allocMTID allocates a free ACP2 mtid (1-255). Blocks when the pool
+// is exhausted until a release signals the cond, or the caller's
+// context cancels — whichever comes first.
+//
+// Spec p.4 §"Mtid": ACP2 mtid space is 1..255 with 0 reserved for
+// announces. The pool MUST never wrap (which would alias an in-flight
+// request) and MUST be cancellable so a stuck pool doesn't leak
+// goroutines on session teardown.
 func (s *Session) allocMTID(ctx context.Context) (uint8, error) {
 	s.mtidMu.Lock()
 	defer s.mtidMu.Unlock()
 
+	// Cancellation watcher: wakes the cond when ctx fires so a
+	// blocked Wait() observes the cancellation. The watcher exits
+	// when the alloc returns (ctx.Done() fires from cancel-on-defer
+	// in the caller, or via a `done` channel we close on success).
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			s.mtidCond.Broadcast()
+		case <-done:
+		}
+	}()
+
 	for {
-		// Check context first.
 		select {
 		case <-ctx.Done():
 			return 0, ctx.Err()
@@ -572,7 +599,7 @@ func (s *Session) allocMTID(ctx context.Context) (uint8, error) {
 				return uint8(i + 1), nil
 			}
 		}
-		// All mtids in use — wait for a release.
+		// All mtids in use — wait for a release or for ctx to cancel.
 		s.mtidCond.Wait()
 	}
 }


### PR DESCRIPTION
## Summary
Audit + fix of the ACP2 consumer's mtid pool per spec p.4 §"Mtid":
> ACP2 only uses the mtid to send a reply and does no other checks.

The pool MUST never hand out an in-flight mtid (else replies route to the wrong waiter and produce silent data corruption). Audit findings:

| # | Status | Note |
|---|---|---|
| 1 | ✅ PASS | `allocMTID` + `releaseMTID` correctly hold mtidMu, scan `mtidPool[i]==false`, mark in-use atomically. `defer s.releaseMTID(mtid)` in `DoACP2` keeps the mtid for the full request lifetime. |
| 2 | 🐞 BUG → FIXED | `allocMTID` was not context-cancellable. `mtidCond.Wait()` blocked indefinitely on a full pool; ctx.Done() only fired at the top of the loop, never inside Wait(). Stuck waiters would leak on session teardown. |
| 3 | ⚠ GAP → FIXED | `routeReply` silently dropped (Debug log only) replies that carried an mtid no waiter was registered for. That hides peer bugs and our own pool regressions. |

## Changes

### `internal/acp2/consumer/session.go`

**`allocMTID` cancellation** — spawn a watcher goroutine that calls `mtidCond.Broadcast()` when ctx fires so any blocked `Wait()` wakes and re-checks ctx. Watcher exits via a `done` channel closed on alloc return — no goroutine leaks on the success path.

**`routeReply` orphan detection** — when no waiter matches, fire `OrphanReplyMtid` via `s.note(...)`. Reply still dropped (no waiter to deliver to), but the event surfaces in the compliance profile.

### `internal/acp2/consumer/compliance_events.go`

New `OrphanReplyMtid` constant with spec citation. Joins the existing event catalog (next to `ReplyZeroMtid`, `AnnounceBeforeEnableEvents`, …).

## Tests (`mtid_pool_test.go`, all green)

| Test | What it pins |
|---|---|
| `TestMTIDPool_AllocateUniqueAndRelease` | Alloc all 255 mtids — every value unique and non-zero. Release + verify reuse. |
| `TestMTIDPool_BlocksWhenExhausted` | Fill pool. Verify the 256th alloc blocks (no immediate return). Release one — assert the blocked goroutine unblocks within 200 ms. |
| `TestMTIDPool_ConcurrentAllocReleaseNeverDuplicates` | 50 goroutines × 100 iterations of alloc+release with a `[256]uint32` CAS guard. Asserts `dupCount == 0`. |
| `TestMTIDPool_RespectsContextCancel` | Fill pool. Alloc with a 30 ms deadline. Assert `context.DeadlineExceeded` returns (was hanging before the cancellation fix). |

## Test plan
- [x] All four pool tests green
- [x] Full ACP2 suite green (codec / consumer / provider)
- [x] Build clean
- [ ] CI green

Closes #321. Stacks under `feat/acp2-strict-spec-closeout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
