### PR TITLE
fix(acp2-cli): watch persists tree types so announces decode immediately

### DIFF
--- a/cmd/dhs/cmd_watch.go
+++ b/cmd/dhs/cmd_watch.go
@@ -78,6 +78,13 @@ func runWatch(ctx context.Context, args []string) error {
 	// Key by watchCacheKey so ACP1 groups that re-use the same object-id
 	// space (control / status / alarm / identity / file / frame all
 	// addressable as 0..N within one slot) don't collide. (refs #236)
+	//
+	// Per #323 the same loaded snapshot is also fed back into the
+	// plugin via the optional TreeSeeder interface (currently
+	// implemented by ACP2). That populates the plugin's per-slot
+	// WalkedTree cache from disk so Subscribe-fed announces can
+	// decode types + labels immediately — no waiting on the
+	// background walk to fill in.
 	labelCache := map[string]string{}
 	unitCache := map[string]string{}
 	if treeStore != nil && *slot >= 0 {
@@ -91,6 +98,15 @@ func runWatch(ctx context.Context, args []string) error {
 					if o.Unit != "" {
 						unitCache[k] = o.Unit
 					}
+				}
+				// Seed the plugin's in-memory tree cache from disk.
+				// Only the plugins that implement TreeSeeder benefit;
+				// others ignore the call (interface assertion is
+				// optional).
+				if seeder, ok := plug.(interface {
+					SeedTreeFromCachedObjects(slot int, objs []protocol.Object)
+				}); ok && sd.Slot == *slot {
+					seeder.SeedTreeFromCachedObjects(sd.Slot, sd.Objects)
 				}
 			}
 			if len(labelCache) > 0 {

--- a/internal/acp2/consumer/plugin.go
+++ b/internal/acp2/consumer/plugin.go
@@ -66,6 +66,117 @@ type Plugin struct {
 	profile *compliance.Profile
 }
 
+// SeedTreeFromCachedObjects rebuilds an in-memory WalkedTree from a
+// previously-walked + persisted snapshot and inserts it into the
+// per-slot tree cache. After this returns, the next Subscribe-fed
+// announce can decode types and labels immediately — no need to wait
+// for a fresh Walk to populate the cache.
+//
+// Used by the watch CLI on startup (cmd_watch.go #323): load the disk
+// snapshot, hand it to the plugin, then Subscribe. Without this, the
+// first set of announces render as `raw(N)` until the background walk
+// finishes (sometimes 30+ s on a 50 000-object Neuron tree).
+//
+// The snapshot's objects MUST carry acp2.objType + acp2.numType in
+// Meta (set by walker.go on a normal walk). Objects without those
+// keys are kept in the tree for label resolution but their value
+// decoding falls back to KindRaw — same as today.
+func (p *Plugin) SeedTreeFromCachedObjects(slot int, objs []protocol.Object) {
+	p.mu.Lock()
+	if p.trees == nil {
+		p.trees = newWalkedTreeCache(32, 10*time.Minute)
+	}
+	cache := p.trees
+	p.mu.Unlock()
+
+	tree := &WalkedTree{
+		Slot:        slot,
+		Objects:     make([]protocol.Object, 0, len(objs)),
+		ObjTypes:    make([]codec.ACP2ObjType, 0, len(objs)),
+		NumTypes:    make([]codec.NumberType, 0, len(objs)),
+		OptionsMaps: make([]map[uint32]string, 0, len(objs)),
+		Labels:      make(map[string]int, len(objs)),
+	}
+	for i, o := range objs {
+		// Fill ObjType / NumType from Meta. Default to ObjTypeNode /
+		// NumTypeS32 when absent — Nodes don't decode values, and
+		// the Subscribe path falls back to vtype-from-wire when
+		// ObjType is unset.
+		var ot codec.ACP2ObjType
+		var nt codec.NumberType
+		if o.Meta != nil {
+			if v, ok := o.Meta["acp2.objType"]; ok {
+				ot = codec.ACP2ObjType(metaToUint8(v))
+			}
+			if v, ok := o.Meta["acp2.numType"]; ok {
+				nt = codec.NumberType(metaToUint8(v))
+			}
+		}
+		var optMap map[uint32]string
+		if o.Meta != nil {
+			if v, ok := o.Meta["acp2.optionsMap"]; ok {
+				optMap = decodeStringlyOptionsMap(v)
+			}
+		}
+		tree.Objects = append(tree.Objects, o)
+		tree.ObjTypes = append(tree.ObjTypes, ot)
+		tree.NumTypes = append(tree.NumTypes, nt)
+		tree.OptionsMaps = append(tree.OptionsMaps, optMap)
+		if o.Label != "" {
+			tree.Labels[o.Label] = i
+		}
+	}
+	cache.Put(slot, tree)
+}
+
+// metaToUint8 coerces a Meta value into uint8. Tolerates the
+// JSON-decoded float64 that arrives when a snapshot round-trips
+// through encoding/json plus the in-memory uint8 the live walker
+// stashes. Returns 0 on unrecognised types.
+func metaToUint8(v any) uint8 {
+	switch x := v.(type) {
+	case uint8:
+		return x
+	case int:
+		return uint8(x)
+	case int64:
+		return uint8(x)
+	case float64:
+		return uint8(x)
+	}
+	return 0
+}
+
+// decodeStringlyOptionsMap turns a JSON-decoded `map[string]any`
+// (where keys are stringified u32 indices and values are labels)
+// back into the in-memory `map[uint32]string` shape WalkedTree
+// expects. Tolerates the live-walker shape (already correct) too.
+func decodeStringlyOptionsMap(v any) map[uint32]string {
+	switch x := v.(type) {
+	case map[uint32]string:
+		return x
+	case map[string]string:
+		out := make(map[uint32]string, len(x))
+		for k, lbl := range x {
+			var idx uint32
+			_, _ = fmt.Sscanf(k, "%d", &idx)
+			out[idx] = lbl
+		}
+		return out
+	case map[string]any:
+		out := make(map[uint32]string, len(x))
+		for k, lbl := range x {
+			var idx uint32
+			_, _ = fmt.Sscanf(k, "%d", &idx)
+			if s, ok := lbl.(string); ok {
+				out[idx] = s
+			}
+		}
+		return out
+	}
+	return nil
+}
+
 // ComplianceProfile returns the session-scoped compliance profile.
 // Returns nil if Connect hasn't been called yet. Safe to call from
 // any goroutine.

--- a/internal/acp2/consumer/seed_tree_test.go
+++ b/internal/acp2/consumer/seed_tree_test.go
@@ -1,0 +1,146 @@
+package acp2
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"dhs/internal/acp2/codec"
+	"dhs/internal/protocol"
+)
+
+// TestSeedTreeFromCachedObjects pins the disk-cache fast-path for
+// watch (#323): a Plugin instance that hasn't done a live Walk should
+// still serve a populated WalkedTree out of trees.Get(slot) after the
+// CLI calls SeedTreeFromCachedObjects with the disk snapshot.
+//
+// The walker stashes acp2.objType / acp2.numType / acp2.optionsMap in
+// obj.Meta on a normal walk; those keys round-trip through the disk
+// JSON cache. SeedTreeFromCachedObjects reads them back to rebuild
+// the parallel ObjTypes / NumTypes / OptionsMaps slices Subscribe
+// needs to decode announces.
+func TestSeedTreeFromCachedObjects(t *testing.T) {
+	p := &Plugin{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	// Build snapshot-shaped objects: live-walker shape (uint8 in Meta).
+	objs := []protocol.Object{
+		{
+			Slot: 1, ID: 5, Label: "Volume",
+			Meta: map[string]any{
+				"acp2.objType": uint8(codec.ObjTypeNumber),
+				"acp2.numType": uint8(codec.NumTypeS32),
+			},
+		},
+		{
+			Slot: 1, ID: 6, Label: "Mute",
+			Meta: map[string]any{
+				"acp2.objType":    uint8(codec.ObjTypeEnum),
+				"acp2.numType":    uint8(codec.NumTypePreset),
+				"acp2.optionsMap": map[string]string{"0": "Off", "1": "On"},
+			},
+		},
+	}
+
+	p.SeedTreeFromCachedObjects(1, objs)
+
+	tree, ok := p.trees.Get(1)
+	if !ok || tree == nil {
+		t.Fatal("trees.Get(1) returned no tree after seed")
+	}
+	if len(tree.Objects) != 2 {
+		t.Fatalf("Objects len=%d want 2", len(tree.Objects))
+	}
+	if tree.ObjTypes[0] != codec.ObjTypeNumber {
+		t.Errorf("ObjTypes[0]=%v want Number", tree.ObjTypes[0])
+	}
+	if tree.NumTypes[0] != codec.NumTypeS32 {
+		t.Errorf("NumTypes[0]=%v want S32", tree.NumTypes[0])
+	}
+	if tree.ObjTypes[1] != codec.ObjTypeEnum {
+		t.Errorf("ObjTypes[1]=%v want Enum", tree.ObjTypes[1])
+	}
+	if tree.OptionsMaps[1] == nil {
+		t.Fatal("OptionsMaps[1] is nil; expected {0:Off, 1:On}")
+	}
+	if tree.OptionsMaps[1][0] != "Off" || tree.OptionsMaps[1][1] != "On" {
+		t.Errorf("OptionsMaps[1]=%v want {0:Off, 1:On}", tree.OptionsMaps[1])
+	}
+	if tree.Labels["Volume"] != 0 {
+		t.Errorf("Labels[Volume]=%d want 0", tree.Labels["Volume"])
+	}
+}
+
+// TestSeedTreeFromCachedObjects_JSONRoundTrip simulates the disk
+// reload path: Meta values arrive as JSON-decoded `float64` (numbers)
+// and `map[string]any` (nested map). SeedTreeFromCachedObjects must
+// coerce both shapes back into typed values.
+func TestSeedTreeFromCachedObjects_JSONRoundTrip(t *testing.T) {
+	p := &Plugin{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	objs := []protocol.Object{
+		{
+			Slot: 1, ID: 5, Label: "Vol",
+			Meta: map[string]any{
+				// JSON unmarshal into any → float64.
+				"acp2.objType": float64(codec.ObjTypeNumber),
+				"acp2.numType": float64(codec.NumTypeS32),
+			},
+		},
+		{
+			Slot: 1, ID: 6, Label: "Mode",
+			Meta: map[string]any{
+				"acp2.objType": float64(codec.ObjTypeEnum),
+				"acp2.numType": float64(codec.NumTypePreset),
+				// JSON-decoded options map: map[string]any with string values.
+				"acp2.optionsMap": map[string]any{"42": "A", "99": "Z"},
+			},
+		},
+	}
+	p.SeedTreeFromCachedObjects(1, objs)
+	tree, _ := p.trees.Get(1)
+	if tree == nil {
+		t.Fatal("no tree after seed (json round-trip)")
+	}
+	if tree.ObjTypes[0] != codec.ObjTypeNumber {
+		t.Errorf("ObjTypes[0]=%v want Number (float64 coercion failed)", tree.ObjTypes[0])
+	}
+	if tree.NumTypes[0] != codec.NumTypeS32 {
+		t.Errorf("NumTypes[0]=%v want S32", tree.NumTypes[0])
+	}
+	if tree.OptionsMaps[1] == nil {
+		t.Fatal("OptionsMaps[1] nil after JSON-shaped seed")
+	}
+	if tree.OptionsMaps[1][42] != "A" || tree.OptionsMaps[1][99] != "Z" {
+		t.Errorf("OptionsMaps[1]=%v want {42:A, 99:Z}", tree.OptionsMaps[1])
+	}
+}
+
+// TestSeedTreeFromCachedObjects_TimingFastPath asserts the seed
+// path doesn't take longer than the implicit Walk would on a 50k
+// tree. This is a smoke test: 5 000 objects must seed in under 50 ms
+// on a typical workstation; cache.Put is O(1) and our parallel
+// slice fills are O(n).
+func TestSeedTreeFromCachedObjects_TimingFastPath(t *testing.T) {
+	p := &Plugin{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	objs := make([]protocol.Object, 5000)
+	for i := range objs {
+		objs[i] = protocol.Object{
+			Slot: 1, ID: i + 1, Label: "x",
+			Meta: map[string]any{
+				"acp2.objType": uint8(codec.ObjTypeNumber),
+				"acp2.numType": uint8(codec.NumTypeS32),
+			},
+		}
+	}
+	start := time.Now()
+	p.SeedTreeFromCachedObjects(1, objs)
+	elapsed := time.Since(start)
+	if elapsed > 50*time.Millisecond {
+		t.Errorf("seed took %v; want < 50 ms (background walk would take seconds)", elapsed)
+	}
+	tree, _ := p.trees.Get(1)
+	if tree == nil || len(tree.Objects) != 5000 {
+		t.Errorf("expected 5000 seeded objects; got tree=%v", tree)
+	}
+}

--- a/internal/acp2/consumer/walker.go
+++ b/internal/acp2/consumer/walker.go
@@ -231,6 +231,29 @@ func (w *Walker) parseObjectProperties(props []codec.Property, slot int, objID u
 		}
 	}
 
+	// Stash the ACP2 object type and number type in Meta so a watch
+	// session resuming from disk cache can decode announces without
+	// waiting for a full re-walk. (#323)
+	if objType != codec.ObjTypeNode {
+		setMeta(&obj, "acp2.objType", uint8(objType))
+		setMeta(&obj, "acp2.numType", uint8(numType))
+	}
+	if optionsMap != nil {
+		// Persist as map[string]string (JSON-friendly stringly idx → label)
+		// so the snapshot round-trips through encoding/json.
+		stringly := make(map[string]string, len(optionsMap))
+		for idx, lbl := range optionsMap {
+			stringly[fmt.Sprintf("%d", idx)] = lbl
+		}
+		setMeta(&obj, "acp2.optionsMap", stringly)
+	}
+
+	// Suppress the original block-end so the rest of parseObjectProperties
+	// (value decode, label resolution, path building) continues. The
+	// substituted block above runs after the per-pid switch closes.
+	{
+	}
+
 	// Second pass: decode value now that options map is available.
 	if valueProp != nil {
 		w.decodeValue(valueProp, objType, numType, &obj, optionsMap)
@@ -406,4 +429,16 @@ func numberTypeToKind(nt codec.NumberType) protocol.ValueKind {
 	default:
 		return protocol.KindRaw
 	}
+}
+
+// setMeta writes a key/value into obj.Meta, lazily allocating the map.
+// Used by the walker to stash protocol-specific decoded values that
+// don't fit the fixed Object fields (e.g. acp2.objType / acp2.numType
+// / acp2.optionsMap — read by the cache reload path so a watch session
+// can decode announces without waiting for a re-walk).
+func setMeta(obj *protocol.Object, key string, value any) {
+	if obj.Meta == nil {
+		obj.Meta = make(map[string]any)
+	}
+	obj.Meta[key] = value
 }


### PR DESCRIPTION
## Symptom (2026-05-08)
A freshly-started `dhs consumer acp2 watch 10.100.0.103 --port 2072 --slot 1` rendered every announce as
```
01:05:29  s1..3                                                    ---  live  raw(7)
```
— empty group / path / label and raw bytes — for tens of seconds. The disk cache had everything (`loaded 39018 labels from cache`), but only the **label** column was hydrated; the value-decoder still waited for the in-memory `WalkedTree` from a live walk.

## Root cause
`internal/acp2/consumer/plugin.go::Subscribe` needs `(objType, numType)` to decode an announce property. Both come from the in-memory `WalkedTree` cache, which today is populated only by a live `Walk()`. The watch CLI loaded the disk snapshot but never fed it back into the plugin → `Subscribe` returned `KindRaw` (`raw(N)`) until the background walk caught up.

## Fix (4 changes)

### 1. `walker.go::parseObjectProperties` stashes wire types into Meta
```
acp2.objType    → uint8(codec.ACP2ObjType)
acp2.numType    → uint8(codec.NumberType)
acp2.optionsMap → map[string]string (idx-as-string → label)
```
Persisted via the existing JSON tag on `protocol.Object.Meta`.

### 2. New `setMeta` helper
Lazy-allocates `obj.Meta` so callers don't have to nil-check.

### 3. `Plugin.SeedTreeFromCachedObjects(slot, objs)`
- Builds a `WalkedTree` from the snapshot's Objects.
- Populates the parallel `ObjTypes` / `NumTypes` / `OptionsMaps` slices from each object's Meta.
- Tolerates **two** Meta shapes:
  - **Live walker**: `uint8` / `map[uint32]string`
  - **Disk reload (post-JSON)**: `float64` / `map[string]any` / `map[string]string`
- Inserts into `p.trees` so the next Subscribe-fed announce decodes immediately.

### 4. `cmd/dhs/cmd_watch.go` calls the seeder after disk load
Uses an interface assertion so protocols that don't implement the seeder yet (ACP1 / Ember+ / Probel) ignore the call. No API break.

## Tests (`internal/acp2/consumer/seed_tree_test.go`)
- `TestSeedTreeFromCachedObjects` — live-walker Meta shape (`uint8` + `map[string]string`) round-trips into a populated `WalkedTree` with `ObjTypes`/`NumTypes`/`OptionsMaps`/`Labels` filled.
- `TestSeedTreeFromCachedObjects_JSONRoundTrip` — post-JSON Meta shape (`float64` + `map[string]any`) coerces back to typed values via `metaToUint8` / `decodeStringlyOptionsMap`.
- `TestSeedTreeFromCachedObjects_TimingFastPath` — 5 000 objects seed in < 50 ms (vs seconds-to-minutes for a live walk).

## Behaviour matrix

| Scenario | Before | After |
|---|---|---|
| watch start with primed cache | label resolves instantly; values render `raw(N)` until BG walk completes (10–60 s) | label + value resolve instantly; first announce decodes typed |
| watch start with empty cache | `raw(N)` until BG walk completes | unchanged (no cache to seed from; BG walk fills it) |
| ACP1 / Ember+ / Probel watch | unchanged | unchanged (seeder is interface-assertion-gated) |

## Coordination
Conflicts with #315 (PR #332) on the `setMeta` helper — that PR also defines it. Whichever lands first leaves a duplicate-symbol diff for the other; one-line resolution.

Closes #323. Stacks under `feat/acp2-strict-spec-closeout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
