### PR TITLE
fix(acp2-provider): pid=7 (preset_depth) idx values from canonical Format

### DIFF
--- a/internal/acp2/provider/encoder.go
+++ b/internal/acp2/provider/encoder.go
@@ -91,7 +91,7 @@ func buildProperties(e *entry) ([]codec.Property, error) {
 		// once per idx. Number-style numeric fields (pid 5, 12, 13) are
 		// emitted once. For N=1 the shape degenerates to "Number + pid 7".
 		props = append(props, propInline(codec.PIDNumberType, uint8(e.numType)))
-		props = append(props, propPresetDepth(e.presetDepth))
+		props = append(props, propPresetDepth(e.presetDepth, e.presetIdxList))
 		for i := uint32(0); i < e.presetDepth; i++ {
 			val, err := encodeValueProp(codec.PIDValue, e)
 			if err != nil {
@@ -242,24 +242,39 @@ func propChildren(ids []uint32) codec.Property {
 	}
 }
 
-// propPresetDepth builds the pid=7 (preset_depth) property per spec §5
-// "Preset depth". Body is a u32[] big-endian list of valid preset idx
-// values — consumers then know how many times pids 8/9/10/11 repeat in
-// the same get_object reply (once per idx listed here).
+// propPresetDepth builds the pid=7 (preset_depth) property per spec
+// §"Preset depth". Body is a u32[] big-endian list of valid preset
+// idx values — consumers then know how many times pids 8/9/10/11
+// repeat in the same get_object reply (once per idx listed here).
 //
 //	| Offset    | Field   | Width    | Notes                              |
 //	|-----------|---------|----------|------------------------------------|
 //	| 0         | pid     | u8       | 7 = preset_depth                   |
 //	| 1         | data    | u8       | 0                                  |
 //	| 2-3       | plen    | u16 BE   | 4 + 4*depth                        |
-//	| 4 + 4*i   | idx_i   | u32 BE   | valid preset idx value, 0..depth-1 |
+//	| 4 + 4*i   | idx_i   | u32 BE   | valid preset idx value             |
 //
-// Spec reference: acp2_protocol.pdf §5 Preset depth,
-// internal/acp2/CLAUDE.md "Preset depth".
-func propPresetDepth(depth uint32) codec.Property {
+// Spec idx values are arbitrary u32 — the docx example
+// (acp2_protocol.docx §"Preset depth", line 2613-2632) uses
+// non-contiguous {100, 200}. When idxList is supplied (from
+// canonical Format hint `idx=A,B,C`) we emit those bytes verbatim.
+// When idxList is empty/short we fall back to contiguous
+// 0..depth-1 — historical behaviour for fixtures lacking the hint.
+//
+// Spec reference: acp2_protocol.docx §"Preset depth".
+func propPresetDepth(depth uint32, idxList []uint32) codec.Property {
+	// Use the canonical-supplied idx list when its length matches
+	// presetDepth; otherwise fall back to 0..depth-1.
+	useIdx := uint32(len(idxList)) == depth
 	data := make([]byte, 4*depth)
 	for i := uint32(0); i < depth; i++ {
-		binary.BigEndian.PutUint32(data[i*4:], i)
+		var v uint32
+		if useIdx {
+			v = idxList[i]
+		} else {
+			v = i
+		}
+		binary.BigEndian.PutUint32(data[i*4:], v)
 	}
 	return codec.Property{
 		PID:   codec.PIDPresetDepth,

--- a/internal/acp2/provider/preset_idx_test.go
+++ b/internal/acp2/provider/preset_idx_test.go
@@ -1,0 +1,134 @@
+package acp2
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"dhs/internal/acp2/codec"
+	"dhs/internal/export/canonical"
+)
+
+// TestPresetIdx_SpecExampleNonContiguous covers the spec example from
+// acp2_protocol.docx §"Preset depth" (line 2613-2632):
+//
+//	property pid 7: preset depth 2
+//	property pid data plen idx0 idx1
+//	u8 u8 u16 u32 u32
+//	7 0 12 100 200
+//
+// Encoder must emit the canonical idx values verbatim — not the
+// hardcoded contiguous 0..depth-1 fallback.
+func TestPresetIdx_SpecExampleNonContiguous(t *testing.T) {
+	fmtHint := "depth=2,idx=100|200"
+	p := &canonical.Parameter{
+		Header: canonical.Header{Number: 9, Identifier: "Slot",
+			Access: canonical.AccessReadWrite},
+		Type: canonical.ParamInteger, Value: int64(0),
+		Format: &fmtHint,
+	}
+	e := &entry{
+		objID: 9, label: p.Identifier, access: 0x03,
+		objType: codec.ObjTypePreset, numType: codec.NumTypeU8,
+		presetDepth:   2,
+		presetIdxList: presetIdxHint(p),
+		param:         p,
+	}
+	if len(e.presetIdxList) != 2 || e.presetIdxList[0] != 100 || e.presetIdxList[1] != 200 {
+		t.Fatalf("presetIdxHint returned %v; want [100, 200]", e.presetIdxList)
+	}
+
+	got := buildAndDecode(t, e)
+	var pd codec.Property
+	for _, pr := range got {
+		if pr.PID == codec.PIDPresetDepth {
+			pd = pr
+			break
+		}
+	}
+	if pd.PID != codec.PIDPresetDepth {
+		t.Fatal("reply missing pid=7 (preset_depth)")
+	}
+	if pd.PLen != 12 {
+		t.Errorf("pid=7 plen=%d want 12 (4 hdr + 2*4 idx)", pd.PLen)
+	}
+	if len(pd.Data) != 8 {
+		t.Fatalf("pid=7 body len=%d want 8 (2 u32 idx)", len(pd.Data))
+	}
+	got0 := binary.BigEndian.Uint32(pd.Data[0:4])
+	got1 := binary.BigEndian.Uint32(pd.Data[4:8])
+	if got0 != 100 || got1 != 200 {
+		t.Errorf("pid=7 idx values=[%d, %d]; want [100, 200] (spec docx line 2613-2632)", got0, got1)
+	}
+}
+
+// TestPresetIdx_FallbackContiguousWhenHintAbsent verifies the
+// historical contiguous 0..depth-1 fallback when the canonical
+// fixture omits the `idx=...` hint.
+func TestPresetIdx_FallbackContiguousWhenHintAbsent(t *testing.T) {
+	fmtHint := "depth=3"
+	p := &canonical.Parameter{
+		Header: canonical.Header{Number: 9, Identifier: "Slot",
+			Access: canonical.AccessReadWrite},
+		Type: canonical.ParamInteger, Value: int64(0),
+		Format: &fmtHint,
+	}
+	e := &entry{
+		objID: 9, label: p.Identifier, access: 0x03,
+		objType: codec.ObjTypePreset, numType: codec.NumTypeU8,
+		presetDepth:   3,
+		presetIdxList: presetIdxHint(p), // expected: nil
+		param:         p,
+	}
+	if e.presetIdxList != nil {
+		t.Errorf("presetIdxHint(%q)=%v; want nil (no idx= hint)", fmtHint, e.presetIdxList)
+	}
+	got := buildAndDecode(t, e)
+	var pd codec.Property
+	for _, pr := range got {
+		if pr.PID == codec.PIDPresetDepth {
+			pd = pr
+			break
+		}
+	}
+	for i := uint32(0); i < 3; i++ {
+		got := binary.BigEndian.Uint32(pd.Data[i*4 : i*4+4])
+		if got != i {
+			t.Errorf("idx[%d]=%d want %d (contiguous fallback)", i, got, i)
+		}
+	}
+}
+
+// TestPresetIdx_IgnoresMismatchedListLength asserts that a Format
+// hint specifying fewer idx values than depth declares falls back to
+// contiguous indices (defensive — protects against malformed fixtures).
+func TestPresetIdx_IgnoresMismatchedListLength(t *testing.T) {
+	fmtHint := "depth=4,idx=100|200" // length mismatch
+	p := &canonical.Parameter{
+		Header: canonical.Header{Number: 9, Identifier: "Slot",
+			Access: canonical.AccessReadWrite},
+		Type: canonical.ParamInteger, Value: int64(0),
+		Format: &fmtHint,
+	}
+	e := &entry{
+		objID: 9, label: p.Identifier, access: 0x03,
+		objType: codec.ObjTypePreset, numType: codec.NumTypeU8,
+		presetDepth:   4,
+		presetIdxList: presetIdxHint(p), // [100, 200] but depth=4
+		param:         p,
+	}
+	got := buildAndDecode(t, e)
+	var pd codec.Property
+	for _, pr := range got {
+		if pr.PID == codec.PIDPresetDepth {
+			pd = pr
+			break
+		}
+	}
+	// Mismatch → fallback to 0..3 (NOT [100, 200, 0, 0]).
+	for i := uint32(0); i < 4; i++ {
+		got := binary.BigEndian.Uint32(pd.Data[i*4 : i*4+4])
+		if got != i {
+			t.Errorf("idx[%d]=%d want %d (length mismatch should fall back)", i, got, i)
+		}
+	}
+}

--- a/internal/acp2/provider/tree.go
+++ b/internal/acp2/provider/tree.go
@@ -31,6 +31,14 @@ type entry struct {
 	// the bare "preset" token. Used to emit pid 7 and to size the
 	// per-idx repetition of pids 8/9/10/11 in get_object replies.
 	presetDepth uint32
+
+	// presetIdxList holds the explicit u32 idx values for pid 7
+	// (preset_depth) when the canonical fixture supplies them via
+	// `idx=A,B,C` in Format. Spec example (acp2_protocol.docx
+	// §"Preset depth", line 2613-2632) uses non-contiguous values
+	// like {100, 200}. When this slice is empty, the encoder falls
+	// back to contiguous 0..presetDepth-1 — the historical behaviour.
+	presetIdxList []uint32
 }
 
 // tree is the obj-id indexed snapshot the provider serves. ACP2 obj-ids
@@ -159,7 +167,8 @@ func flatten(slot uint8, parent uint32, el canonical.Element, index map[uint32]*
 			objType:     objType,
 			numType:     numType,
 			param:       x,
-			presetDepth: presetDepthHint(x),
+			presetDepth:   presetDepthHint(x),
+			presetIdxList: presetIdxHint(x),
 		}
 		if objType == codec.ObjTypePreset && e.presetDepth == 0 {
 			// Spec §5 requires at least one idx in pid 7 for preset children.
@@ -385,6 +394,42 @@ func presetDepthHint(p *canonical.Parameter) uint32 {
 		}
 	}
 	return 0
+}
+
+// presetIdxHint extracts the "idx=A|B|C" attribute from
+// Parameter.Format, returning the parsed u32 values. Used by the
+// encoder to emit pid 7 (preset_depth) with the spec-allowed
+// non-contiguous idx list (e.g. {100, 200} per acp2_protocol.docx
+// §"Preset depth" line 2613-2632) instead of synthesising contiguous
+// 0..N-1.
+//
+// The pipe `|` separates idx values rather than comma, because comma
+// is the existing top-level separator between Format hints
+// (`depth=2,maxLen=16,idx=100|200`). Returns nil when the hint is
+// absent or unparseable; callers fall back to contiguous indices.
+func presetIdxHint(p *canonical.Parameter) []uint32 {
+	for _, kv := range formatParts(p.Format) {
+		if !strings.HasPrefix(kv, "idx=") {
+			continue
+		}
+		raw := strings.TrimPrefix(kv, "idx=")
+		parts := strings.Split(raw, "|")
+		out := make([]uint32, 0, len(parts))
+		for _, p := range parts {
+			p = strings.TrimSpace(p)
+			if p == "" {
+				continue
+			}
+			var n uint32
+			if _, err := fmt.Sscanf(p, "%d", &n); err == nil {
+				out = append(out, n)
+			}
+		}
+		if len(out) > 0 {
+			return out
+		}
+	}
+	return nil
 }
 
 // maxLenHint extracts the "maxLen=N" attribute from Parameter.Format,


### PR DESCRIPTION
## Summary
Provider's `propPresetDepth` now emits the canonical-supplied idx values for pid=7 instead of hardcoding contiguous `0..depth-1`. Strict ACP2-only — no canonical schema change.

## Spec quote (`acp2_protocol.docx` §"Preset depth", line 2613-2632)
```
property pid 7: preset depth 2
property pid data plen idx0 idx1
u8 u8 u16 u32 u32
7 0 12 100 200
```
Idx values are arbitrary u32 chosen by the device (here `{100, 200}`), not array positions.

## Mechanism (no schema change)
Existing convention: the provider parses hints from `Parameter.Format` (`"depth=N,maxLen=M"`). Extending with a new token `idx=A|B|C` (pipe-separated values; comma is already the token separator at the Format layer):
```
"depth=2,idx=100|200"  → presetDepth=2, presetIdxList=[100, 200]
"depth=3"              → presetDepth=3, presetIdxList=nil  (legacy)
```

`entry` struct gains `presetIdxList []uint32`. `propPresetDepth(depth, idxList)` emits the supplied list when its length matches `depth`; falls back to `0..depth-1` otherwise (defensive — never emits garbage zero-padded ids on length mismatch).

## Test plan
- [x] `TestPresetIdx_SpecExampleNonContiguous` — `depth=2, idx=100|200` emits pid=7 plen=12 with idx0=100, idx1=200; byte-identical to the spec example.
- [x] `TestPresetIdx_FallbackContiguousWhenHintAbsent` — `depth=3` with no `idx=` hint emits 0/1/2 (legacy fallback).
- [x] `TestPresetIdx_IgnoresMismatchedListLength` — `depth=4, idx=100|200` (length mismatch) falls back to 0/1/2/3.
- [x] All ACP2 tests green
- [x] Build clean
- [ ] CI green

Closes #311. Stacks under `feat/acp2-strict-spec-closeout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
