### PR TITLE
feat(acp2-provider): filter disabled objects per spec §Requirements

### DIFF
--- a/internal/acp2/provider/disabled_test.go
+++ b/internal/acp2/provider/disabled_test.go
@@ -1,0 +1,117 @@
+package acp2
+
+import (
+	"testing"
+
+	"dhs/internal/export/canonical"
+)
+
+// TestDisabledFilter_LeafSkipped pins spec acp2_protocol.docx
+// §"Requirements" line 320: "Disabled parts of the menu are not
+// visible to clients (not shown as children, options, etc)."
+//
+// A canonical Parameter with `disabled` in its Format hint MUST NOT
+// appear in the per-slot obj-id index, MUST NOT be listed in its
+// parent's pid=14 children, and MUST NOT be reachable via lookup.
+func TestDisabledFilter_LeafSkipped(t *testing.T) {
+	disabledFmt := "u32,disabled"
+	enabledFmt := "u32"
+	root := &canonical.Node{
+		Header: canonical.Header{
+			Number: 1, Identifier: "ROOT_NODE_V2",
+			Children: []canonical.Element{
+				&canonical.Parameter{
+					Header: canonical.Header{Number: 100, Identifier: "Visible"},
+					Type:   canonical.ParamInteger, Value: int64(0),
+					Format: &enabledFmt,
+				},
+				&canonical.Parameter{
+					Header: canonical.Header{Number: 200, Identifier: "Hidden"},
+					Type:   canonical.ParamInteger, Value: int64(0),
+					Format: &disabledFmt,
+				},
+			},
+		},
+	}
+	slot := &canonical.Node{
+		Header: canonical.Header{
+			Number: 1, Identifier: "slot-1",
+			Children: []canonical.Element{root},
+		},
+	}
+	device := &canonical.Node{
+		Header: canonical.Header{
+			Number: 1, Identifier: "device",
+			Children: []canonical.Element{slot},
+		},
+	}
+	exp := &canonical.Export{Root: device}
+
+	tr, err := newTree(exp)
+	if err != nil {
+		t.Fatalf("newTree: %v", err)
+	}
+
+	// The disabled obj-id MUST NOT be indexed.
+	if _, ok := tr.lookup(1, 200); ok {
+		t.Errorf("obj-id 200 (disabled) is indexed; spec §Requirements says it must be invisible")
+	}
+	// The visible peer is still indexed.
+	if _, ok := tr.lookup(1, 100); !ok {
+		t.Errorf("obj-id 100 (enabled) missing from index")
+	}
+	// Root's children list excludes the disabled obj-id.
+	rootEntry, _ := tr.lookup(1, 1)
+	if rootEntry == nil {
+		t.Fatal("root not indexed")
+	}
+	for _, kid := range rootEntry.children {
+		if kid == 200 {
+			t.Errorf("root.children = %v; obj-id 200 (disabled) MUST be filtered out", rootEntry.children)
+		}
+	}
+	if len(rootEntry.children) != 1 || rootEntry.children[0] != 100 {
+		t.Errorf("root.children = %v; want [100] (only the enabled child)", rootEntry.children)
+	}
+}
+
+// TestDisabledFilter_BareTokenShortCircuits verifies a Parameter
+// whose Format is just "disabled" never reaches deriveACP2Type —
+// the disabled flag check fires first, so a malformed token list
+// doesn't get rejected by the unknown-type validator.
+func TestDisabledFilter_BareTokenShortCircuits(t *testing.T) {
+	fmt := "disabled"
+	root := &canonical.Node{
+		Header: canonical.Header{
+			Number: 1, Identifier: "ROOT_NODE_V2",
+			Children: []canonical.Element{
+				&canonical.Parameter{
+					Header: canonical.Header{Number: 50, Identifier: "Stub"},
+					Type:   canonical.ParamInteger, Value: int64(0),
+					Format: &fmt,
+				},
+			},
+		},
+	}
+	slot := &canonical.Node{
+		Header: canonical.Header{
+			Number: 1, Identifier: "slot-1",
+			Children: []canonical.Element{root},
+		},
+	}
+	device := &canonical.Node{
+		Header: canonical.Header{
+			Number: 1, Identifier: "device",
+			Children: []canonical.Element{slot},
+		},
+	}
+	exp := &canonical.Export{Root: device}
+
+	tr, err := newTree(exp)
+	if err != nil {
+		t.Fatalf("newTree: %v (disabled-only Format must short-circuit before type-derive)", err)
+	}
+	if _, ok := tr.lookup(1, 50); ok {
+		t.Error("disabled-only Parameter is indexed; should be skipped")
+	}
+}

--- a/internal/acp2/provider/tree.go
+++ b/internal/acp2/provider/tree.go
@@ -119,9 +119,20 @@ func newTree(exp *canonical.Export) (*tree, error) {
 // obj-id index. Assigns entries with their canonical Number as obj-id;
 // each entry's `children` list is filled with the obj-ids of its
 // direct children (sufficient to serve pid=14 without re-walking).
+//
+// Per spec acp2_protocol.docx §"Requirements" line 320-332: "Disabled
+// parts of the menu are not visible to clients (not shown as children,
+// options, etc)." Entries whose canonical Format carries a `disabled`
+// token are skipped: never indexed, never appear in any pid=14
+// children list, never reachable via get_object.
 func flatten(slot uint8, parent uint32, el canonical.Element, index map[uint32]*entry) error {
 	switch x := el.(type) {
 	case *canonical.Node:
+		// Nodes use Format only on Parameters, not on the Node header,
+		// so disabled-via-Format applies to leaves; Node-level
+		// disabled is out of canonical schema today and would need a
+		// separate field. Honour the same rule when a future schema
+		// extension adds it.
 		id := uint32(x.Number)
 		e := &entry{
 			objID:   id,
@@ -138,6 +149,12 @@ func flatten(slot uint8, parent uint32, el canonical.Element, index map[uint32]*
 			if err != nil {
 				return err
 			}
+			// Skip disabled children: drop from pid=14 list AND
+			// skip recursive flatten so the obj-id is never
+			// indexed.
+			if isDisabledElement(c) {
+				continue
+			}
 			e.children = append(e.children, childID)
 			if err := flatten(slot, id, c, index); err != nil {
 				return err
@@ -145,6 +162,11 @@ func flatten(slot uint8, parent uint32, el canonical.Element, index map[uint32]*
 		}
 		return nil
 	case *canonical.Parameter:
+		// Belt-and-braces: even if the parent forgets to filter,
+		// a disabled leaf still doesn't land in the index.
+		if isDisabledParameter(x) {
+			return nil
+		}
 		id := uint32(x.Number)
 		objType, numType, err := deriveACP2Type(x)
 		if err != nil {
@@ -171,6 +193,29 @@ func flatten(slot uint8, parent uint32, el canonical.Element, index map[uint32]*
 		return nil
 	}
 	return nil
+}
+
+// isDisabledElement returns true when the element should be hidden
+// from clients per spec §"Requirements" disabled-menu rule. Today
+// only Parameter entries can carry the `disabled` Format hint;
+// Nodes always pass through.
+func isDisabledElement(el canonical.Element) bool {
+	if p, ok := el.(*canonical.Parameter); ok {
+		return isDisabledParameter(p)
+	}
+	return false
+}
+
+// isDisabledParameter checks for the `disabled` bare token in
+// Parameter.Format. Same convention as the type discriminator
+// (`preset`, `ipv4`) — a flag without a value.
+func isDisabledParameter(p *canonical.Parameter) bool {
+	for _, kv := range formatParts(p.Format) {
+		if kv == "disabled" {
+			return true
+		}
+	}
+	return false
 }
 
 // elementID returns the Header.Number of any canonical element.


### PR DESCRIPTION
## Summary
Provider's `flatten` now skips canonical Parameters carrying a `disabled` token in their Format hint, per ACP2 spec §"Requirements" line 320-332:
> Disabled parts of the menu are not visible to clients (not shown as children, options, etc).

Strict ACP2-only — no cross-protocol canonical schema change. Same Format-hint convention as `preset` / `ipv4` / `disabled`.

## Behaviour
A disabled Parameter:
- ❌ never appears in the per-slot obj-id index
- ❌ never appears in its parent's pid=14 children list
- ❌ can't be reached via `get_object` (returns `invalid_obj_id`)

The check fires at two layers (belt-and-braces):
1. **Parent-side** in the Node branch — disabled children are dropped from the pid=14 list and not recursed into.
2. **Leaf-side** in the Parameter branch — even a forgotten parent filter doesn't index a disabled Parameter.

## Test plan
- [x] `TestDisabledFilter_LeafSkipped` — tree with two siblings (enabled + disabled). Asserts disabled obj-id absent from index AND from root's pid=14 children. Enabled sibling unaffected.
- [x] `TestDisabledFilter_BareTokenShortCircuits` — Parameter whose Format is just `"disabled"` (no type token) skips before `deriveACP2Type` runs. Validates the short-circuit ordering.
- [x] All ACP2 tests green
- [x] Build clean
- [ ] CI green

## Notes
Today only Parameters carry Format. A future canonical-schema extension can grow a Node-level disabled bit using the same `isDisabledElement` switch — already coded for the future.

Closes #319. Stacks under `feat/acp2-strict-spec-closeout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
