### PR TITLE
fix(acp2-consumer): preserve AN2 major+minor version, log as 1.0 (closes #344)

### DIFF
--- a/internal/acp2/consumer/session.go
+++ b/internal/acp2/consumer/session.go
@@ -29,10 +29,14 @@ type Session struct {
 	port int
 
 	// AN2-level device info populated during handshake.
-	an2Version  uint8
-	numSlots    int
-	slotStatus  []protocol.SlotStatus
-	acp2Version uint8
+	// AN2 GetVersion (spec §3.3.1) returns major + minor; both
+	// preserved here so the connect log + public AN2Version() can
+	// emit the full "major.minor" — real Neuron reports 1.0.
+	an2VersionMajor uint8
+	an2VersionMinor uint8
+	numSlots        int
+	slotStatus      []protocol.SlotStatus
+	acp2Version     uint8
 
 	// mtid pool: 1-255 available, 0 reserved for announces.
 	mtidMu   sync.Mutex
@@ -145,7 +149,7 @@ func (s *Session) Connect(ctx context.Context, ip string, port int) error {
 
 	s.logger.Info("acp2: connected",
 		"host", ip, "port", port,
-		"an2_version", s.an2Version,
+		"an2_version", fmt.Sprintf("%d.%d", s.an2VersionMajor, s.an2VersionMinor),
 		"acp2_version", s.acp2Version,
 		"slots", s.numSlots)
 
@@ -166,13 +170,18 @@ func (s *Session) an2Handshake(ctx context.Context) error {
 		return fmt.Errorf("an2 GetVersion: %w", err)
 	}
 	// Reply: func_echo(u8) + major(u8) + minor(u8). Spec §3.3.1.
-	// Version is at reply[2] (minor), not reply[0].
+	// Real Neuron reports 1.0; older firmware that ships only one
+	// version byte falls back to {0, reply[0]}.
 	if len(reply) >= 3 {
-		s.an2Version = reply[2]
+		s.an2VersionMajor = reply[1]
+		s.an2VersionMinor = reply[2]
 	} else if len(reply) >= 1 {
-		s.an2Version = reply[0]
+		s.an2VersionMajor = 0
+		s.an2VersionMinor = reply[0]
 	}
-	s.logger.Debug("acp2: AN2 version", "version", s.an2Version, "raw", fmt.Sprintf("%x", reply))
+	s.logger.Debug("acp2: AN2 version", "version",
+		fmt.Sprintf("%d.%d", s.an2VersionMajor, s.an2VersionMinor),
+		"raw", fmt.Sprintf("%x", reply))
 
 	// 2. AN2 GetDeviceInfo
 	s.logger.Debug("acp2: AN2 GetDeviceInfo")
@@ -613,11 +622,12 @@ func (s *Session) NumSlots() int {
 	return s.numSlots
 }
 
-// AN2Version returns the AN2 protocol version.
-func (s *Session) AN2Version() uint8 {
+// AN2Version returns the AN2 protocol version as "major.minor"
+// per spec §3.3.1 GetVersion. Real Neuron firmware reports "1.0".
+func (s *Session) AN2Version() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.an2Version
+	return fmt.Sprintf("%d.%d", s.an2VersionMajor, s.an2VersionMinor)
 }
 
 // ACP2Version returns the ACP2 protocol version.

--- a/internal/acp2/consumer/session_version_test.go
+++ b/internal/acp2/consumer/session_version_test.go
@@ -1,0 +1,30 @@
+package acp2
+
+import "testing"
+
+// TestAN2Version_FormatsMajorMinor pins the consumer-side display +
+// public API for the AN2 GetVersion reply. Spec §3.3.1 returns
+// `func_echo + major + minor`; real Neuron emits 1.0. Before #344
+// the connect log dropped the major byte and printed only the minor
+// (e.g. an2_version=0). AN2Version() now returns "major.minor".
+func TestAN2Version_FormatsMajorMinor(t *testing.T) {
+	tests := []struct {
+		name  string
+		major uint8
+		minor uint8
+		want  string
+	}{
+		{"real-Neuron-1.0", 1, 0, "1.0"},
+		{"future-2.3", 2, 3, "2.3"},
+		{"zero-zero", 0, 0, "0.0"},
+		{"max", 0xFF, 0xFF, "255.255"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Session{an2VersionMajor: tt.major, an2VersionMinor: tt.minor}
+			if got := s.AN2Version(); got != tt.want {
+				t.Errorf("AN2Version() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The ACP2 consumer's connect log dropped the AN2 major version byte and
printed only the minor — `an2_version=0` instead of the spec-correct
`1.0`. Wire was always right; only the in-memory field width was too
narrow.

```
before: acp2: connected ... an2_version=0 acp2_version=1 slots=2
after:  acp2: connected ... an2_version=1.0 acp2_version=1 slots=2
```

## Changes

- `internal/acp2/consumer/session.go`
  - Replace `an2Version uint8` field with `an2VersionMajor` +
    `an2VersionMinor`.
  - `an2Handshake` parses spec §3.3.1 layout (`func_echo + major + minor`).
  - `AN2Version()` now returns `"major.minor"` string. Only external
    caller (consumer plugin) uses `ACP2Version()` (still uint8), so no
    other call sites need changing.
- `internal/acp2/consumer/session_version_test.go` (new)
  - `TestAN2Version_FormatsMajorMinor` pins {1,0}→"1.0", {2,3}→"2.3",
    {0,0}→"0.0", {255,255}→"255.255".

## Out of scope

Does **not** address the Cerebrum walk emptiness — that is a separate
issue tracked under #312 / #301.

## Test plan

- [x] `go build ./...` green on Windows native
- [x] `go test ./...` green; new sub-tests pass
- [x] `TestAN2Version_FormatsMajorMinor` (+ 4 sub-tests) PASS
- [ ] Manual: re-run `dhs consumer acp2 watch <host> --port 2072 --slots 0`
  with the producer up and confirm the connect line reads
  `an2_version=1.0`.

Closes #344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
