### PR TITLE
fix(acp2-provider): applySetEnum validates against EnumMap.Value, not positional length (closes #346)

### DIFF
--- a/internal/acp2/provider/set.go
+++ b/internal/acp2/provider/set.go
@@ -4,7 +4,9 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+
 	"dhs/internal/acp2/codec"
+	"dhs/internal/export/canonical"
 )
 
 // applySet mutates e per an incoming set_property request and returns
@@ -124,8 +126,8 @@ func (s *server) applySetNumber(e *entry, in *codec.Property) (codec.Property, c
 	return codec.Property{}, codec.ErrInvalidValue, fmt.Errorf("number_type %d not writable", nt)
 }
 
-// applySetEnum validates the incoming index against the entry's options
-// and persists it as int64 in canonical.Parameter.Value.
+// applySetEnum validates the incoming wire idx against the entry's
+// EnumMap and persists it as int64 in canonical.Parameter.Value.
 //
 // Incoming / reply body:
 //
@@ -134,20 +136,57 @@ func (s *server) applySetNumber(e *entry, in *codec.Property) (codec.Property, c
 //	| 0      | pid   | u8     | 8 = value                                 |
 //	| 1      | vtype | u8     | reply uses NumTypeU32 (6)                 |
 //	| 2-3    | plen  | u16 BE | 8                                         |
-//	| 4-7    | idx   | u32 BE | option index; >= len(options) -> Invalid  |
+//	| 4-7    | idx   | u32 BE | option wire id; not in EnumMap -> Invalid |
 //
-// Spec reference: acp2_protocol.pdf §5.2.2 enum value
+// Real Neuron enums use sparse u32 wire ids (e.g. 641 "Main",
+// 786 "Automatic"); the option's wire idx is stored in EnumMap.Value.
+// The gate validates against the set of wire ids, NOT positional
+// 0..N-1 (which would reject every valid Set when EnumMap is sparse).
+//
+// When the canonical lacks an EnumMap (legacy comma/newline
+// Enumeration string), accept the positional 0..N-1 range as a
+// fallback so legacy fixtures keep round-tripping.
+//
+// Spec reference: acp2_protocol.pdf §4.3.4 set property + §5.2.2 enum value
 func (s *server) applySetEnum(e *entry, in *codec.Property) (codec.Property, codec.ACP2ErrStatus, error) {
 	if len(in.Data) < 4 {
 		return codec.Property{}, codec.ErrInvalidValue, fmt.Errorf("enum needs u32")
 	}
 	idx := binary.BigEndian.Uint32(in.Data[0:4])
-	opts := enumOptions(e.param)
-	if int(idx) >= len(opts) {
-		return codec.Property{}, codec.ErrInvalidValue, fmt.Errorf("enum index %d >= %d", idx, len(opts))
+	if !enumIdxValid(e.param, idx) {
+		return codec.Property{}, codec.ErrInvalidValue,
+			fmt.Errorf("enum idx %d not in EnumMap", idx)
 	}
 	e.param.Value = int64(idx)
 	return numericProp(codec.PIDValue, codec.NumTypeU32, u32Data(idx)), 0, nil
+}
+
+// enumIdxValid returns true when idx matches one of the wire ids
+// declared on the canonical's EnumMap, or — if the canonical has no
+// EnumMap — falls back to positional bounds against the legacy
+// Enumeration string.
+func enumIdxValid(p *canonical.Parameter, idx uint32) bool {
+	if len(p.EnumMap) > 0 {
+		for _, e := range p.EnumMap {
+			if uint32(e.Value) == idx {
+				return true
+			}
+		}
+		return false
+	}
+	// Legacy fallback: no EnumMap, count newline/comma-separated labels
+	// in the Enumeration string and accept idx in [0, N).
+	if p.Enumeration != nil && *p.Enumeration != "" {
+		raw := *p.Enumeration
+		n := 1
+		for _, c := range raw {
+			if c == '\n' || c == ',' {
+				n++
+			}
+		}
+		return int(idx) < n
+	}
+	return false
 }
 
 // applySetIPv4 decodes four packed octets and stores them as a dotted-quad

--- a/internal/acp2/provider/set_enum_test.go
+++ b/internal/acp2/provider/set_enum_test.go
@@ -1,0 +1,104 @@
+package acp2
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"dhs/internal/acp2/codec"
+	"dhs/internal/export/canonical"
+)
+
+// TestApplySetEnum_SparseEnumMap pins #346: applySetEnum must validate
+// the incoming wire idx against the sparse u32 ids declared in
+// canonical.EnumMap.Value, not the positional 0..N-1 length. Real
+// Neuron enums use ids like 786 "Automatic" / 791 "Full Speed";
+// rejecting them as "out of bounds" when len(EnumMap)==2 freezes the
+// VSM UI on every Set.
+func TestApplySetEnum_SparseEnumMap(t *testing.T) {
+	param := &canonical.Parameter{
+		Header: canonical.Header{Number: 21127, Identifier: "Fan Control",
+			Access: canonical.AccessReadWrite},
+		Type:  canonical.ParamEnum,
+		Value: int64(786),
+		EnumMap: []canonical.EnumEntry{
+			{Key: "Automatic", Value: 786},
+			{Key: "Full Speed", Value: 791},
+		},
+	}
+	e := &entry{
+		objID: 21127, label: param.Identifier, access: 0x03,
+		objType: codec.ObjTypeEnum, numType: codec.NumTypeU32,
+		param: param,
+	}
+	srv := &server{}
+
+	tests := []struct {
+		name    string
+		idx     uint32
+		wantErr codec.ACP2ErrStatus
+	}{
+		{"sparse_786_Automatic_accept", 786, 0},
+		{"sparse_791_FullSpeed_accept", 791, 0},
+		{"out_of_set_999_reject", 999, codec.ErrInvalidValue},
+		{"positional_0_reject_when_sparse", 0, codec.ErrInvalidValue},
+		{"positional_1_reject_when_sparse", 1, codec.ErrInvalidValue},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := make([]byte, 4)
+			binary.BigEndian.PutUint32(data, tt.idx)
+			in := &codec.Property{PID: codec.PIDValue,
+				VType: uint8(codec.NumTypeU32), PLen: 8, Data: data}
+			_, status, _ := srv.applySetEnum(e, in)
+			if status != tt.wantErr {
+				t.Errorf("idx=%d status=%d want=%d", tt.idx, status, tt.wantErr)
+			}
+			if tt.wantErr == 0 && param.Value != int64(tt.idx) {
+				t.Errorf("param.Value=%v want %d", param.Value, tt.idx)
+			}
+		})
+	}
+}
+
+// TestApplySetEnum_LegacyEnumeration covers the fallback path: when
+// canonical lacks an EnumMap (older fixtures with a comma/newline
+// Enumeration string only), accept idx in [0, N) where N is the
+// label count. Keeps legacy fixtures round-tripping.
+func TestApplySetEnum_LegacyEnumeration(t *testing.T) {
+	enum := "Off,On,Auto"
+	param := &canonical.Parameter{
+		Header: canonical.Header{Number: 1, Identifier: "Mode",
+			Access: canonical.AccessReadWrite},
+		Type:        canonical.ParamEnum,
+		Value:       int64(1),
+		Enumeration: &enum,
+	}
+	e := &entry{
+		objID: 1, label: param.Identifier, access: 0x03,
+		objType: codec.ObjTypeEnum, numType: codec.NumTypeU32,
+		param: param,
+	}
+	srv := &server{}
+
+	tests := []struct {
+		name    string
+		idx     uint32
+		wantErr codec.ACP2ErrStatus
+	}{
+		{"legacy_0_accept", 0, 0},
+		{"legacy_2_accept", 2, 0},
+		{"legacy_3_reject", 3, codec.ErrInvalidValue},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := make([]byte, 4)
+			binary.BigEndian.PutUint32(data, tt.idx)
+			in := &codec.Property{PID: codec.PIDValue,
+				VType: uint8(codec.NumTypeU32), PLen: 8, Data: data}
+			_, status, _ := srv.applySetEnum(e, in)
+			if status != tt.wantErr {
+				t.Errorf("idx=%d status=%d want=%d", tt.idx, status, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`applySetEnum` rejected every valid Set on enums whose canonical
`EnumMap` uses sparse u32 wire ids — gate was `idx >= len(opts)`
(positional 0..N-1) instead of `idx in {EnumMap[i].Value}`.

Symptom: VSM "select Full Speed" → producer replies `stat=5
InvalidValue` ("enum index 791 >= 2") → no Announce → UI freezes.
Read path (encoder pid=15, walker pid=8) was already fixed for
sparse ids; only the write path was missed.

## Changes

- `internal/acp2/provider/set.go`
  - New `enumIdxValid(p, idx)` helper: iterates `EnumMap` and
    accepts iff one entry has `Value == idx`.
  - Legacy fallback for canonical fixtures lacking an `EnumMap`
    (newline/comma-separated `Enumeration` only): accept idx in
    `[0, N)` so old fixtures keep round-tripping.
  - `applySetEnum` calls the helper instead of the positional gate.
- `internal/acp2/provider/set_enum_test.go` (new)
  - `TestApplySetEnum_SparseEnumMap`: `{Automatic:786, Full Speed:791}`
    accepts 786 + 791; rejects 999 + positional 0 + positional 1.
  - `TestApplySetEnum_LegacyEnumeration`: legacy `"Off,On,Auto"`
    accepts 0 + 2, rejects 3.

## Spec reference

ACP2 spec acp2_protocol.docx §4.3.4 set property + §5.2.2 enum value
+ §5.4 pid 15 (option's wire idx is the u32 in the option record).

## Test plan

- [x] `go build ./...` green on Windows native
- [x] `go test ./...` green; new sub-tests PASS
- [x] `TestApplySetEnum_SparseEnumMap` (5 sub-tests) PASS
- [x] `TestApplySetEnum_LegacyEnumeration` (3 sub-tests) PASS
- [ ] Manual: VSM Studio Set on enum (e.g. Fan Control "Full Speed")
  → producer replies confirmed value 791, fans out Announce,
  next GetObject reports pid=8 value=791.

Closes #346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
