### PR TITLE
feat(acp2-consumer): identity-keyed DM cache + hot-load on watch start (closes #353)

### DIFF
--- a/cmd/dhs/cmd_walk.go
+++ b/cmd/dhs/cmd_walk.go
@@ -113,12 +113,11 @@ func runWalk(ctx context.Context, args []string) error {
 				fmt.Printf("\nslot %d — walk error: %v\n", s, werr)
 				continue
 			}
-			// Save walked tree to disk for instant label resolution next time.
-			if treeStore != nil {
-				if serr := treeStore.Save(host, cf.protocol, s, objs); serr != nil {
-					fmt.Fprintf(os.Stderr, "warning: cache save slot %d: %v\n", s, serr)
-				}
-			}
+			// Persist walked tree. ACP2 -> identity-keyed MasterView at
+			// .cache/dm/<identity>.json; ACP1/Ember+ -> IP-keyed
+			// .cache/devices/<ip>/slot_<n>.json. See saveSlotCache.
+			prober, _ := plug.(identityProber)
+			saveSlotCache(ctx, prober, host, cf.protocol, s, objs)
 			objs = filterByPath(objs, pathSegs)
 			if !streaming {
 				printSlotTree(s, objs, *filter)
@@ -135,12 +134,11 @@ func runWalk(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	// Save walked tree to disk for instant label resolution next time.
-	if treeStore != nil {
-		if serr := treeStore.Save(host, cf.protocol, *slot, objs); serr != nil {
-			fmt.Fprintf(os.Stderr, "warning: cache save slot %d: %v\n", *slot, serr)
-		}
-	}
+	// Persist walked tree. ACP2 -> identity-keyed MasterView at
+	// .cache/dm/<identity>.json; ACP1/Ember+ -> IP-keyed
+	// .cache/devices/<ip>/slot_<n>.json. See saveSlotCache.
+	prober, _ := plug.(identityProber)
+	saveSlotCache(ctx, prober, host, cf.protocol, *slot, objs)
 	objs = filterByPath(objs, pathSegs)
 	if !streaming {
 		printSlotTree(*slot, objs, *filter)

--- a/cmd/dhs/cmd_watch.go
+++ b/cmd/dhs/cmd_watch.go
@@ -77,13 +77,21 @@ func runWatch(ctx context.Context, args []string) error {
 	}
 	defer cleanup()
 
-	// Load disk cache for instant label/unit resolution while walk runs.
-	// Key by watchCacheKey so ACP1 groups that re-use the same object-id
-	// space (control / status / alarm / identity / file / frame all
-	// addressable as 0..N within one slot) don't collide. (refs #236)
+	// Load IP-keyed disk cache for instant label/unit resolution while
+	// walk runs. Key by watchCacheKey so ACP1 groups that re-use the
+	// same object-id space (control / status / alarm / identity / file
+	// / frame all addressable as 0..N within one slot) don't collide
+	// (refs #236).
+	//
+	// ACP2 deliberately skips this path — its DM cache is identity-
+	// keyed at .cache/dm/<identity>.json (DHS 2016 MasterView model,
+	// #353/#355) and is loaded into the plugin's WalkedTree directly
+	// in the block below. Letting the IP-keyed loader run for ACP2
+	// would emit a misleading "loaded N labels from cache" line backed
+	// by stale per-IP files even when the identity cache is current.
 	labelCache := map[string]string{}
 	unitCache := map[string]string{}
-	if treeStore != nil && *slot >= 0 {
+	if cf.protocol != "acp2" && treeStore != nil && *slot >= 0 {
 		if snap, lerr := treeStore.Load(host, *slot); lerr == nil && snap != nil {
 			for _, sd := range snap.Slots {
 				for _, o := range sd.Objects {
@@ -439,31 +447,56 @@ func runWalkScope(ctx context.Context, plug protocol.Protocol, host, proto strin
 	}
 }
 
+// identityProber is the optional contract a Protocol plugin satisfies
+// to participate in identity-keyed MasterView caching. ACP2 implements
+// it via Plugin.IdentityProbe (Card Name + Hardware Version on slot 0).
+// ACP1 / Ember+ do not — they fall back to IP-keyed storage.
+type identityProber interface {
+	IdentityProbe(ctx context.Context) (string, error)
+}
+
 func walkSlotAndCache(ctx context.Context, plug protocol.Protocol, host, proto string, slot int) {
 	objs, werr := plug.Walk(ctx, slot)
 	if werr != nil {
 		fmt.Fprintf(os.Stderr, "warning: walk slot %d failed: %v\n", slot, werr)
 		return
 	}
-	if treeStore != nil {
-		if serr := treeStore.Save(host, proto, slot, objs); serr != nil {
-			fmt.Fprintf(os.Stderr, "warning: cache save slot %d: %v\n", slot, serr)
-		}
+	prober, _ := plug.(identityProber)
+	saveSlotCache(ctx, prober, host, proto, slot, objs)
+}
+
+// saveSlotCache routes a walked slot to the right on-disk cache.
+//
+// ACP2 has a stable device identity probe (Card Name + Hardware Version
+// on slot 0), so its cache is keyed by identity and lives in one
+// multi-slot file at .cache/dm/<identity>.json — DHS 2016 MasterView
+// model. Walking any slot of the frame accumulates into the same file.
+// IP-keyed cache is NOT written for ACP2 (#353, #355).
+//
+// Other protocols (ACP1, Ember+) keep the legacy IP-keyed layout at
+// .cache/devices/<ip>/slot_<n>.json — those plugins have no identity
+// probe contract today.
+func saveSlotCache(ctx context.Context, prober identityProber, host, proto string, slot int, objs []protocol.Object) {
+	if treeStore == nil {
+		return
 	}
-	// Identity-keyed DM cache (#353): for ACP2 also save under
-	// <CardName>@<HardwareVersion> so the next watch session against
-	// any IP for the same card/firmware can hot-load the DM and skip
-	// the cold-start label gap. ACP1 keeps IP-only caching.
-	if proto == "acp2" && treeStore != nil {
-		if probe, ok := plug.(interface {
-			IdentityProbe(context.Context) (string, error)
-		}); ok {
-			if identity, perr := probe.IdentityProbe(ctx); perr == nil && identity != "" {
-				if serr := saveIdentityCache(treeStore, plug, ctx, identity, host, proto, slot, objs); serr != nil {
-					fmt.Fprintf(os.Stderr, "warning: identity cache save: %v\n", serr)
-				}
-			}
+	if proto == "acp2" {
+		if prober == nil {
+			fmt.Fprintf(os.Stderr, "warning: acp2 plugin missing IdentityProbe; slot %d not cached\n", slot)
+			return
 		}
+		identity, perr := prober.IdentityProbe(ctx)
+		if perr != nil || identity == "" {
+			fmt.Fprintf(os.Stderr, "warning: identity probe failed; slot %d not cached: %v\n", slot, perr)
+			return
+		}
+		if serr := saveIdentityCache(treeStore, identity, host, proto, slot, objs); serr != nil {
+			fmt.Fprintf(os.Stderr, "warning: identity cache save: %v\n", serr)
+		}
+		return
+	}
+	if serr := treeStore.Save(host, proto, slot, objs); serr != nil {
+		fmt.Fprintf(os.Stderr, "warning: cache save slot %d: %v\n", slot, serr)
 	}
 }
 
@@ -471,7 +504,7 @@ func walkSlotAndCache(ctx context.Context, plug protocol.Protocol, host, proto s
 // merges the just-walked slot into it, and saves the result. So
 // successive walks of slot 0 then slot 1 build up a single
 // multi-slot cache file keyed by device identity.
-func saveIdentityCache(store *storage.TreeStore, plug protocol.Protocol, ctx context.Context, identity, host, proto string, slot int, objs []protocol.Object) error {
+func saveIdentityCache(store *storage.TreeStore, identity, host, proto string, slot int, objs []protocol.Object) error {
 	existing, _ := store.LoadByIdentity(identity)
 	now := time.Now().UTC()
 	if existing == nil {

--- a/cmd/dhs/cmd_watch.go
+++ b/cmd/dhs/cmd_watch.go
@@ -7,9 +7,12 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"dhs/internal/dmlib"
+	"dhs/internal/export"
 	"dhs/internal/protocol"
+	"dhs/internal/storage"
 )
 
 // runWatch subscribes to live announcements and prints each event as it
@@ -95,6 +98,36 @@ func runWatch(ctx context.Context, args []string) error {
 			}
 			if len(labelCache) > 0 {
 				fmt.Fprintf(os.Stderr, "loaded %d labels from cache\n", len(labelCache))
+			}
+		}
+	}
+
+	// Identity-keyed DM cache hot-load (#353): probe device identity
+	// (Card Name + Hardware Version on slot 0, sub-second), look up
+	// the persisted DM by identity, and seed the plugin's in-memory
+	// tree BEFORE Subscribe fires. The announce decoder then resolves
+	// types + enum labels from frame 1 — eliminates the cold-start
+	// "idx N" gap on slot 1 watches where the fresh walk takes 30-60s.
+	//
+	// ACP2-only — other plugins keep the IP-keyed cache today.
+	if cf.protocol == "acp2" && treeStore != nil {
+		if probe, hot := plug.(interface {
+			IdentityProbe(context.Context) (string, error)
+			SeedTreeFromCachedObjects(slot int, objs []protocol.Object)
+		}); hot {
+			identity, perr := probe.IdentityProbe(ctx)
+			if perr == nil && identity != "" {
+				if snap, lerr := treeStore.LoadByIdentity(identity); lerr == nil && snap != nil {
+					seeded := 0
+					for _, sd := range snap.Slots {
+						probe.SeedTreeFromCachedObjects(sd.Slot, sd.Objects)
+						seeded += len(sd.Objects)
+					}
+					if seeded > 0 {
+						fmt.Fprintf(os.Stderr, "DM cache hit %q — seeded %d objects across %d slot(s)\n",
+							identity, seeded, len(snap.Slots))
+					}
+				}
 			}
 		}
 	}
@@ -417,4 +450,56 @@ func walkSlotAndCache(ctx context.Context, plug protocol.Protocol, host, proto s
 			fmt.Fprintf(os.Stderr, "warning: cache save slot %d: %v\n", slot, serr)
 		}
 	}
+	// Identity-keyed DM cache (#353): for ACP2 also save under
+	// <CardName>@<HardwareVersion> so the next watch session against
+	// any IP for the same card/firmware can hot-load the DM and skip
+	// the cold-start label gap. ACP1 keeps IP-only caching.
+	if proto == "acp2" && treeStore != nil {
+		if probe, ok := plug.(interface {
+			IdentityProbe(context.Context) (string, error)
+		}); ok {
+			if identity, perr := probe.IdentityProbe(ctx); perr == nil && identity != "" {
+				if serr := saveIdentityCache(treeStore, plug, ctx, identity, host, proto, slot, objs); serr != nil {
+					fmt.Fprintf(os.Stderr, "warning: identity cache save: %v\n", serr)
+				}
+			}
+		}
+	}
+}
+
+// saveIdentityCache loads the existing identity-keyed DM (if any),
+// merges the just-walked slot into it, and saves the result. So
+// successive walks of slot 0 then slot 1 build up a single
+// multi-slot cache file keyed by device identity.
+func saveIdentityCache(store *storage.TreeStore, plug protocol.Protocol, ctx context.Context, identity, host, proto string, slot int, objs []protocol.Object) error {
+	existing, _ := store.LoadByIdentity(identity)
+	now := time.Now().UTC()
+	if existing == nil {
+		existing = &export.Snapshot{
+			Device:    export.DeviceInfo{IP: host, Protocol: proto},
+			Generator: "dhs dm-cache",
+			CreatedAt: now,
+		}
+	}
+	// Replace or append this slot's dump.
+	updated := false
+	for i := range existing.Slots {
+		if existing.Slots[i].Slot == slot {
+			existing.Slots[i] = export.SlotDump{
+				Slot:     slot,
+				WalkedAt: now,
+				Objects:  objs,
+			}
+			updated = true
+			break
+		}
+	}
+	if !updated {
+		existing.Slots = append(existing.Slots, export.SlotDump{
+			Slot:     slot,
+			WalkedAt: now,
+			Objects:  objs,
+		})
+	}
+	return store.SaveByIdentity(identity, existing)
 }

--- a/cmd/dhs/cmd_watch.go
+++ b/cmd/dhs/cmd_watch.go
@@ -107,8 +107,19 @@ func runWatch(ctx context.Context, args []string) error {
 		}()
 	}
 
+	// Slot filter for the announce subscription. When the user invoked
+	// --slots N (a single slot) we propagate it to req.Slot so the
+	// subscription drops announces from any other slot. With --slot N
+	// the flag already sets *slot directly. Multi-slot --slots 1,3,7
+	// leaves the filter at -1 (no filter) — ValueRequest.Slot is a
+	// single int, so multi-slot filtering would need a Subscribe API
+	// extension; until then the user sees all slots.
+	slotFilter := *slot
+	if slotFilter < 0 && walkScope.mode == walkList && len(walkScope.slots) == 1 {
+		slotFilter = walkScope.slots[0]
+	}
 	req := protocol.ValueRequest{
-		Slot:  *slot,
+		Slot:  slotFilter,
 		Group: *group,
 		Label: *label,
 		ID:    *id,

--- a/cmd/dhs/cmd_watch_cache_test.go
+++ b/cmd/dhs/cmd_watch_cache_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"dhs/internal/protocol"
+	"dhs/internal/storage"
+)
+
+// fakeProber satisfies identityProber for the ACP2 routing tests.
+type fakeProber struct {
+	identity string
+	err      error
+	calls    int
+}
+
+func (f *fakeProber) IdentityProbe(_ context.Context) (string, error) {
+	f.calls++
+	return f.identity, f.err
+}
+
+// withTempStore swaps the package-level treeStore for one rooted at a
+// fresh tempdir, and restores the original on cleanup.
+func withTempStore(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	prev := treeStore
+	treeStore = storage.NewTreeStore(root)
+	t.Cleanup(func() { treeStore = prev })
+	return root
+}
+
+func makeObjs() []protocol.Object {
+	return []protocol.Object{
+		{Slot: 1, ID: 70232, Label: "Backup Input"},
+	}
+}
+
+// TestSaveSlotCache_ACP2_WritesIdentityKeyedOnly pins the #355 contract:
+// the ACP2 cache lives in .cache/dm/<identity>.json (DHS 2016 MasterView
+// model). The legacy IP-keyed file at .cache/devices/<ip>/slot_<n>.json
+// must NOT be created for ACP2 — even though TreeStore.Save still
+// supports it for ACP1 / Ember+.
+func TestSaveSlotCache_ACP2_WritesIdentityKeyedOnly(t *testing.T) {
+	root := withTempStore(t)
+	prober := &fakeProber{identity: "SHPRM1@0.7"}
+
+	saveSlotCache(context.Background(), prober, "10.100.0.103", "acp2", 1, makeObjs())
+
+	dmPath := filepath.Join(root, "dm", "SHPRM1@0.7.json")
+	if _, err := os.Stat(dmPath); err != nil {
+		t.Fatalf("identity-keyed file missing: %v", err)
+	}
+	ipPath := filepath.Join(root, "devices", "10.100.0.103", "slot_1.json")
+	if _, err := os.Stat(ipPath); !os.IsNotExist(err) {
+		t.Errorf("IP-keyed file MUST NOT exist for acp2, got err=%v", err)
+	}
+	if prober.calls != 1 {
+		t.Errorf("identity probe call count: got %d want 1", prober.calls)
+	}
+}
+
+// TestSaveSlotCache_ACP2_NilProber_NoFile guards against silent fall-
+// through if a future plugin variant forgets to implement IdentityProbe.
+// For ACP2 with a nil prober, no file should be created (warn-only).
+func TestSaveSlotCache_ACP2_NilProber_NoFile(t *testing.T) {
+	root := withTempStore(t)
+
+	saveSlotCache(context.Background(), nil, "10.100.0.103", "acp2", 1, makeObjs())
+
+	dmDir := filepath.Join(root, "dm")
+	if _, err := os.Stat(dmDir); !os.IsNotExist(err) {
+		t.Errorf("dm dir MUST NOT exist when prober is nil, err=%v", err)
+	}
+	ipPath := filepath.Join(root, "devices", "10.100.0.103", "slot_1.json")
+	if _, err := os.Stat(ipPath); !os.IsNotExist(err) {
+		t.Errorf("IP-keyed file MUST NOT exist for acp2 fallback, err=%v", err)
+	}
+}
+
+// TestSaveSlotCache_ACP2_EmptyIdentity_NoFile covers the case where the
+// probe runs but returns "" (e.g. device offline / Card Name label
+// missing). We refuse to write under an empty identity — there is no
+// safe filename for it.
+func TestSaveSlotCache_ACP2_EmptyIdentity_NoFile(t *testing.T) {
+	root := withTempStore(t)
+	prober := &fakeProber{identity: ""}
+
+	saveSlotCache(context.Background(), prober, "10.100.0.103", "acp2", 1, makeObjs())
+
+	if _, err := os.Stat(filepath.Join(root, "dm")); !os.IsNotExist(err) {
+		t.Errorf("dm dir MUST NOT be created on empty identity, err=%v", err)
+	}
+}
+
+// TestSaveSlotCache_NonACP2_WritesIPKeyed verifies the ACP1 / Ember+
+// path is preserved: no identity probe used, IP-keyed file written.
+func TestSaveSlotCache_NonACP2_WritesIPKeyed(t *testing.T) {
+	root := withTempStore(t)
+
+	saveSlotCache(context.Background(), nil, "10.6.239.113", "acp1", 0, makeObjs())
+
+	ipPath := filepath.Join(root, "devices", "10.6.239.113", "slot_0.json")
+	if _, err := os.Stat(ipPath); err != nil {
+		t.Fatalf("IP-keyed file missing for acp1: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "dm")); !os.IsNotExist(err) {
+		t.Errorf("dm dir MUST NOT exist for non-acp2 protocols, err=%v", err)
+	}
+}
+
+// TestSaveSlotCache_ACP2_MultiSlotMerge pins the multi-slot merge
+// contract: walking slot 0 then slot 1 of the same device produces a
+// SINGLE identity-keyed file containing both slots, not two separate
+// files. This is how a frame with N populated slots accumulates into
+// one MasterView.
+func TestSaveSlotCache_ACP2_MultiSlotMerge(t *testing.T) {
+	root := withTempStore(t)
+	prober := &fakeProber{identity: "SHPRM1@0.7"}
+	ctx := context.Background()
+
+	slot0 := []protocol.Object{{Slot: 0, ID: 1, Label: "BOARD"}}
+	slot1 := []protocol.Object{{Slot: 1, ID: 70232, Label: "Backup Input"}}
+
+	saveSlotCache(ctx, prober, "10.41.40.4", "acp2", 0, slot0)
+	saveSlotCache(ctx, prober, "10.41.40.4", "acp2", 1, slot1)
+
+	snap, err := treeStore.LoadByIdentity("SHPRM1@0.7")
+	if err != nil || snap == nil {
+		t.Fatalf("LoadByIdentity: snap=%v err=%v", snap, err)
+	}
+	if len(snap.Slots) != 2 {
+		t.Fatalf("merged file should hold 2 slots, got %d", len(snap.Slots))
+	}
+	gotSlots := map[int]bool{}
+	for _, sd := range snap.Slots {
+		gotSlots[sd.Slot] = true
+	}
+	if !gotSlots[0] || !gotSlots[1] {
+		t.Errorf("merged file missing slot(s): %v", gotSlots)
+	}
+
+	// Sanity: no per-slot files appeared on the IP-keyed path.
+	if _, err := os.Stat(filepath.Join(root, "devices")); !os.IsNotExist(err) {
+		t.Errorf("devices/ dir MUST NOT exist for acp2, err=%v", err)
+	}
+}

--- a/internal/acp2/codec/property_codec.go
+++ b/internal/acp2/codec/property_codec.go
@@ -173,50 +173,73 @@ func PropertyChildren(p *Property) ([]uint32, error) {
 	return ids, nil
 }
 
-// ACP2OptionSize is the fixed on-wire size of one enum option per spec
-// §5.4 pid 15: 4-byte u32 index + 68-byte NUL-padded UTF-8 name = 72 bytes.
+// ACP2OptionSize is the spec-literal stride per option per
+// acp2_protocol.docx §5.4 row 15: 4-byte u32 idx + 68-byte NUL-padded
+// UTF-8 name = 72 bytes. No production controller emits this layout —
+// real Axon firmware uses variable-length records (verified against
+// 9,827 pid 15 frames captured 2026-05-06 + obj 17671/21127 captured
+// 2026-05-09). Constant retained for fixture/golden inspection only.
 const ACP2OptionSize = 72
 
-// PropertyOptions extracts enum option labels (ordered by wire position)
-// from a pid=15 property. Fixed 72-byte stride per spec §5.4.
+// PropertyOptions extracts enum option labels (ordered by wire
+// position) from a pid=15 property using the variable-length per-
+// option layout that every shipping ACP2 controller implements:
+//
+//	record: u32 BE idx + NUL-terminated UTF-8 name + 0-3 byte align.
+//
+// Spec deviation tolerated; see compliance event
+// `acp2_options_variable_length_per_device_convention`.
 func PropertyOptions(p *Property) []string {
-	if len(p.Data) < ACP2OptionSize {
+	if len(p.Data) < 4 {
 		return nil
 	}
-	n := len(p.Data) / ACP2OptionSize
-	labels := make([]string, 0, n)
-	for i := 0; i < n; i++ {
-		off := i * ACP2OptionSize
-		labels = append(labels, trimZero(p.Data[off+4:off+ACP2OptionSize]))
-	}
-	return labels
-}
-
-// PropertyOptionsMap extracts enum options as a map of index → label.
-// Fixed 72-byte stride per spec §5.4 pid 15.
-func PropertyOptionsMap(p *Property) map[uint32]string {
-	if len(p.Data) < ACP2OptionSize {
-		return nil
-	}
-	n := len(p.Data) / ACP2OptionSize
-	m := make(map[uint32]string, n)
-	for i := 0; i < n; i++ {
-		off := i * ACP2OptionSize
-		idx := binary.BigEndian.Uint32(p.Data[off : off+4])
-		m[idx] = trimZero(p.Data[off+4 : off+ACP2OptionSize])
-	}
-	return m
-}
-
-// trimZero returns the UTF-8 prefix of b up to the first NUL byte (or
-// the full slice if none). Used for fixed-width NUL-padded name slots.
-func trimZero(b []byte) string {
-	for i, c := range b {
-		if c == 0 {
-			return string(b[:i])
+	out := make([]string, 0, 4)
+	pos := 0
+	for pos+4 <= len(p.Data) {
+		strStart := pos + 4
+		end := strStart
+		for end < len(p.Data) && p.Data[end] != 0 {
+			end++
+		}
+		out = append(out, string(p.Data[strStart:end]))
+		pos = end
+		if pos < len(p.Data) && p.Data[pos] == 0 {
+			pos++
+		}
+		recUsed := pos - (strStart - 4)
+		if pad := (4 - (recUsed % 4)) % 4; pad > 0 {
+			pos += pad
 		}
 	}
-	return string(b)
+	return out
+}
+
+// PropertyOptionsMap extracts enum options as a map of wire idx →
+// label. Variable-length per option; see PropertyOptions.
+func PropertyOptionsMap(p *Property) map[uint32]string {
+	if len(p.Data) < 4 {
+		return nil
+	}
+	out := map[uint32]string{}
+	pos := 0
+	for pos+4 <= len(p.Data) {
+		idx := binary.BigEndian.Uint32(p.Data[pos : pos+4])
+		strStart := pos + 4
+		end := strStart
+		for end < len(p.Data) && p.Data[end] != 0 {
+			end++
+		}
+		out[idx] = string(p.Data[strStart:end])
+		pos = end
+		if pos < len(p.Data) && p.Data[pos] == 0 {
+			pos++
+		}
+		recUsed := pos - (strStart - 4)
+		if pad := (4 - (recUsed % 4)) % 4; pad > 0 {
+			pos += pad
+		}
+	}
+	return out
 }
 
 // PropertyEventMessages extracts the two event message strings from pid=19.

--- a/internal/acp2/codec/property_codec_test.go
+++ b/internal/acp2/codec/property_codec_test.go
@@ -304,13 +304,15 @@ func TestPropertyChildren(t *testing.T) {
 }
 
 func TestPropertyOptions(t *testing.T) {
-	// Spec §5.4 pid 15: fixed 72 bytes per option = u32 BE index + 68-byte
-	// NUL-padded UTF-8 name. Build two options: idx=7 "Off", idx=8 "On".
-	data := make([]byte, 2*ACP2OptionSize)
-	binary.BigEndian.PutUint32(data[0:4], 7)
-	copy(data[4:], "Off")
-	binary.BigEndian.PutUint32(data[ACP2OptionSize:ACP2OptionSize+4], 8)
-	copy(data[ACP2OptionSize+4:], "On")
+	// Variable-length per real-Neuron wire (spec §5.4 row 15 calls for
+	// fixed 72-byte stride but no production controller emits that —
+	// see compliance event acp2_options_variable_length_per_device_convention).
+	// Each record: u32 BE idx + NUL-terminated UTF-8 name + 0-3 byte align.
+	// Two options: idx=7 "Off" (4+3+1 = 8 bytes), idx=8 "On" (4+2+1+1 = 8 bytes).
+	data := []byte{
+		0x00, 0x00, 0x00, 0x07, 'O', 'f', 'f', 0x00,
+		0x00, 0x00, 0x00, 0x08, 'O', 'n', 0x00, 0x00,
+	}
 
 	p := &Property{PID: PIDOptions, Data: data}
 	opts := PropertyOptions(p)

--- a/internal/acp2/consumer/plugin.go
+++ b/internal/acp2/consumer/plugin.go
@@ -404,15 +404,18 @@ func (p *Plugin) Subscribe(req protocol.ValueRequest, fn protocol.EventFunc) err
 						ev.Value = val
 					}
 				}
-				// Fallback: use vtype from announce property to decode
-				// when tree doesn't contain this object.
+				// Fallback when the tree didn't have this obj (slow walk
+				// finishes after announce arrives, or watch started cold).
+				// The property header's vtype byte (spec §5.2.2) tells us
+				// the wire shape; map it to the corresponding ACP2 ObjType
+				// so Enum / IPv4 / String announces decode typed instead
+				// of falling through to KindRaw.
 				if ev.Value.Kind == protocol.KindUnknown && prop.Data != nil {
 					nt := codec.NumberType(prop.VType)
-					if nt > 0 {
-						val, derr := decodePropertyValue(prop, codec.ObjTypeNumber, nt, nil, msg.ObjID)
-						if derr == nil {
-							ev.Value = val
-						}
+					ot := objTypeFromVType(nt)
+					val, derr := decodePropertyValue(prop, ot, nt, nil, msg.ObjID)
+					if derr == nil {
+						ev.Value = val
 					}
 					if ev.Value.Kind == protocol.KindUnknown {
 						ev.Value = protocol.Value{Kind: protocol.KindRaw, Raw: prop.Data}
@@ -478,6 +481,31 @@ func (p *Plugin) resolveRequest(req protocol.ValueRequest, tree *WalkedTree) (ui
 	// No tree or not found — return with unknown type. The caller may
 	// still work with raw bytes.
 	return objID, 0, 0, nil, nil
+}
+
+// objTypeFromVType maps an ACP2 §5.2.2 number-type byte (the data byte
+// of pid 8/9 value properties) to the matching object type. Used by
+// the announce fallback path when the cached tree doesn't have the
+// announced obj — the vtype byte alone tells us how to decode the
+// value body.
+//
+//	| vtype | ACP2 NumberType | ACP2 ObjType   |
+//	|-------|-----------------|----------------|
+//	| 0..8  | s8..float       | ObjTypeNumber  |
+//	| 9     | preset/enum     | ObjTypeEnum    |
+//	| 10    | ipv4            | ObjTypeIPv4    |
+//	| 11    | string          | ObjTypeString  |
+func objTypeFromVType(nt codec.NumberType) codec.ACP2ObjType {
+	switch nt {
+	case codec.NumTypePreset:
+		return codec.ObjTypeEnum
+	case codec.NumTypeIPv4:
+		return codec.ObjTypeIPv4
+	case codec.NumTypeString:
+		return codec.ObjTypeString
+	default:
+		return codec.ObjTypeNumber
+	}
 }
 
 // decodePropertyValue decodes a value Property into a protocol.Value.

--- a/internal/acp2/consumer/plugin.go
+++ b/internal/acp2/consumer/plugin.go
@@ -215,6 +215,135 @@ func (p *Plugin) Walk(ctx context.Context, slot int) ([]protocol.Object, error) 
 	return tree.Objects, nil
 }
 
+// IdentityProbe walks slot 0 (sub-second on any Axon device) and
+// derives a stable device identity = "<CardName>@<HardwareVersion>"
+// by looking up obj labels in the ROOT_NODE_V2.BOARD subtree.
+// Returns "" with err when either label is missing or the slot 0
+// walk fails — caller should fall back to a fresh full walk.
+//
+// Why labels and not obj-ids: ACP2 obj-ids vary per product, but
+// the labels "Card Name" and "Hardware Version" are constant across
+// the Axon catalogue (verified against real Neuron 10.41.40.4 +
+// tree-fresh.json).
+func (p *Plugin) IdentityProbe(ctx context.Context) (string, error) {
+	objs, err := p.Walk(ctx, 0)
+	if err != nil {
+		return "", fmt.Errorf("acp2: identity probe walk(slot=0): %w", err)
+	}
+	cardName := ""
+	hwVersion := ""
+	for _, o := range objs {
+		switch o.Label {
+		case "Card Name":
+			if o.Value.Kind == protocol.KindString {
+				cardName = o.Value.Str
+			}
+		case "Hardware Version":
+			if o.Value.Kind == protocol.KindString {
+				hwVersion = o.Value.Str
+			}
+		}
+	}
+	if cardName == "" || hwVersion == "" {
+		return "", fmt.Errorf("acp2: identity probe — missing Card Name (%q) or Hardware Version (%q) on slot 0",
+			cardName, hwVersion)
+	}
+	return fmt.Sprintf("%s@%s", cardName, hwVersion), nil
+}
+
+// SeedTreeFromCachedObjects rebuilds an in-memory WalkedTree from a
+// disk snapshot's Objects (with type info stashed in obj.Meta by the
+// walker). Populates p.trees[slot] so the announce decoder can resolve
+// types + enum labels from the first frame, before any fresh walk
+// finishes. Idempotent — re-seeding overwrites the cache entry.
+//
+// Object.Meta keys consumed:
+//
+//	"acp2.objType"    uint8 / float64    ACP2 object type
+//	"acp2.numType"    uint8 / float64    NumberType for numerics + enum vtype
+//	"acp2.optionsMap" map[string]string  enum wire idx → label (keys u32 stringified)
+func (p *Plugin) SeedTreeFromCachedObjects(slot int, objs []protocol.Object) {
+	tree := &WalkedTree{
+		Slot:        slot,
+		Objects:     make([]protocol.Object, len(objs)),
+		ObjTypes:    make([]codec.ACP2ObjType, len(objs)),
+		NumTypes:    make([]codec.NumberType, len(objs)),
+		OptionsMaps: make([]map[uint32]string, len(objs)),
+		Labels:      make(map[string]int, len(objs)),
+	}
+	for i, o := range objs {
+		tree.Objects[i] = o
+		tree.ObjTypes[i] = codec.ACP2ObjType(metaToUint8(o.Meta, "acp2.objType"))
+		tree.NumTypes[i] = codec.NumberType(metaToUint8(o.Meta, "acp2.numType"))
+		tree.OptionsMaps[i] = decodeStringlyOptionsMap(o.Meta["acp2.optionsMap"])
+		if o.Label != "" {
+			tree.Labels[o.Label] = i
+		}
+	}
+	p.mu.Lock()
+	tc := p.trees
+	p.mu.Unlock()
+	if tc != nil {
+		tc.Put(slot, tree)
+	}
+}
+
+// metaToUint8 reads an integer value from Object.Meta tolerating the
+// JSON round-trip — Meta values come back as float64 after decode of
+// untyped JSON, OR uint8 if assigned directly in-process. Returns 0
+// on missing / unparseable.
+func metaToUint8(meta map[string]any, key string) uint8 {
+	v, ok := meta[key]
+	if !ok || v == nil {
+		return 0
+	}
+	switch x := v.(type) {
+	case uint8:
+		return x
+	case int:
+		return uint8(x)
+	case int64:
+		return uint8(x)
+	case float64:
+		return uint8(x)
+	}
+	return 0
+}
+
+// decodeStringlyOptionsMap reverses the walker's serialisation of
+// OptionsMap (map[u32]string -> map[string]string) so the hot-loaded
+// tree carries the live wire-idx → label table.
+func decodeStringlyOptionsMap(v any) map[uint32]string {
+	if v == nil {
+		return nil
+	}
+	switch m := v.(type) {
+	case map[uint32]string:
+		return m
+	case map[string]string:
+		out := make(map[uint32]string, len(m))
+		for k, val := range m {
+			var idx uint32
+			if _, err := fmt.Sscanf(k, "%d", &idx); err == nil {
+				out[idx] = val
+			}
+		}
+		return out
+	case map[string]any:
+		out := make(map[uint32]string, len(m))
+		for k, val := range m {
+			var idx uint32
+			if _, err := fmt.Sscanf(k, "%d", &idx); err == nil {
+				if s, ok := val.(string); ok {
+					out[idx] = s
+				}
+			}
+		}
+		return out
+	}
+	return nil
+}
+
 // GetValue reads one object value via ACP2 get_property(pid=8).
 func (p *Plugin) GetValue(ctx context.Context, req protocol.ValueRequest) (protocol.Value, error) {
 	p.mu.Lock()

--- a/internal/acp2/consumer/seed_cache_test.go
+++ b/internal/acp2/consumer/seed_cache_test.go
@@ -1,0 +1,81 @@
+package acp2
+
+import (
+	"testing"
+
+	"dhs/internal/acp2/codec"
+	"dhs/internal/protocol"
+)
+
+// TestSeedTreeFromCachedObjects pins #353: a snapshot's per-object
+// Meta carries acp2.objType / acp2.numType / acp2.optionsMap, and
+// SeedTreeFromCachedObjects rebuilds the parallel arrays so the
+// announce decoder can resolve types + enum labels from the in-memory
+// tree before any fresh walk runs.
+//
+// JSON round-trip note: encoded Meta values come back as float64 +
+// map[string]any, so the test exercises BOTH the in-process path
+// (uint8 / map[uint32]string) and the post-JSON path
+// (float64 / map[string]any) via metaToUint8 + decodeStringlyOptionsMap.
+func TestSeedTreeFromCachedObjects_DirectTypes(t *testing.T) {
+	p := &Plugin{trees: newWalkedTreeCache(4, 0)}
+	objs := []protocol.Object{
+		{
+			Slot: 1, ID: 17671, Label: "IO Board",
+			Meta: map[string]any{
+				"acp2.objType": uint8(codec.ObjTypeEnum),
+				"acp2.numType": uint8(codec.NumTypePreset),
+				"acp2.optionsMap": map[uint32]string{
+					16: "NA", 120: "Present",
+				},
+			},
+		},
+	}
+	p.SeedTreeFromCachedObjects(1, objs)
+
+	tree, ok := p.trees.Get(1)
+	if !ok || tree == nil {
+		t.Fatal("trees not populated after seed")
+	}
+	if len(tree.ObjTypes) != 1 || tree.ObjTypes[0] != codec.ObjTypeEnum {
+		t.Errorf("ObjTypes[0]=%v want Enum", tree.ObjTypes[0])
+	}
+	if tree.OptionsMaps[0] == nil || tree.OptionsMaps[0][120] != "Present" {
+		t.Errorf("OptionsMap[120] not resolved: %v", tree.OptionsMaps[0])
+	}
+}
+
+// TestSeedTreeFromCachedObjects_PostJSONShape covers the canonical
+// JSON-decoded form (numbers as float64, maps as map[string]any),
+// which is what tree_store.LoadByIdentity returns from disk.
+func TestSeedTreeFromCachedObjects_PostJSONShape(t *testing.T) {
+	p := &Plugin{trees: newWalkedTreeCache(4, 0)}
+	objs := []protocol.Object{
+		{
+			Slot: 1, ID: 21127, Label: "Fan Control",
+			Meta: map[string]any{
+				"acp2.objType": float64(codec.ObjTypeEnum),
+				"acp2.numType": float64(codec.NumTypePreset),
+				"acp2.optionsMap": map[string]any{
+					"786": "Automatic",
+					"791": "Full Speed",
+				},
+			},
+		},
+	}
+	p.SeedTreeFromCachedObjects(1, objs)
+
+	tree, ok := p.trees.Get(1)
+	if !ok || tree == nil {
+		t.Fatal("trees not populated after seed")
+	}
+	if tree.ObjTypes[0] != codec.ObjTypeEnum {
+		t.Errorf("ObjTypes[0]=%v want Enum", tree.ObjTypes[0])
+	}
+	if tree.OptionsMaps[0][786] != "Automatic" || tree.OptionsMaps[0][791] != "Full Speed" {
+		t.Errorf("OptionsMap reconstruction failed: %v", tree.OptionsMaps[0])
+	}
+	if tree.Labels["Fan Control"] != 0 {
+		t.Errorf("Labels not populated: %v", tree.Labels)
+	}
+}

--- a/internal/acp2/consumer/session.go
+++ b/internal/acp2/consumer/session.go
@@ -29,10 +29,14 @@ type Session struct {
 	port int
 
 	// AN2-level device info populated during handshake.
-	an2Version  uint8
-	numSlots    int
-	slotStatus  []protocol.SlotStatus
-	acp2Version uint8
+	// AN2 GetVersion (spec §3.3.1) returns major + minor; both
+	// preserved here so the connect log + public AN2Version() can
+	// emit the full "major.minor" — real Neuron reports 1.0.
+	an2VersionMajor uint8
+	an2VersionMinor uint8
+	numSlots        int
+	slotStatus      []protocol.SlotStatus
+	acp2Version     uint8
 
 	// mtid pool: 1-255 available, 0 reserved for announces.
 	mtidMu   sync.Mutex
@@ -145,7 +149,7 @@ func (s *Session) Connect(ctx context.Context, ip string, port int) error {
 
 	s.logger.Info("acp2: connected",
 		"host", ip, "port", port,
-		"an2_version", s.an2Version,
+		"an2_version", fmt.Sprintf("%d.%d", s.an2VersionMajor, s.an2VersionMinor),
 		"acp2_version", s.acp2Version,
 		"slots", s.numSlots)
 
@@ -166,13 +170,18 @@ func (s *Session) an2Handshake(ctx context.Context) error {
 		return fmt.Errorf("an2 GetVersion: %w", err)
 	}
 	// Reply: func_echo(u8) + major(u8) + minor(u8). Spec §3.3.1.
-	// Version is at reply[2] (minor), not reply[0].
+	// Real Neuron reports 1.0; older firmware that ships only one
+	// version byte falls back to {0, reply[0]}.
 	if len(reply) >= 3 {
-		s.an2Version = reply[2]
+		s.an2VersionMajor = reply[1]
+		s.an2VersionMinor = reply[2]
 	} else if len(reply) >= 1 {
-		s.an2Version = reply[0]
+		s.an2VersionMajor = 0
+		s.an2VersionMinor = reply[0]
 	}
-	s.logger.Debug("acp2: AN2 version", "version", s.an2Version, "raw", fmt.Sprintf("%x", reply))
+	s.logger.Debug("acp2: AN2 version", "version",
+		fmt.Sprintf("%d.%d", s.an2VersionMajor, s.an2VersionMinor),
+		"raw", fmt.Sprintf("%x", reply))
 
 	// 2. AN2 GetDeviceInfo
 	s.logger.Debug("acp2: AN2 GetDeviceInfo")
@@ -613,11 +622,12 @@ func (s *Session) NumSlots() int {
 	return s.numSlots
 }
 
-// AN2Version returns the AN2 protocol version.
-func (s *Session) AN2Version() uint8 {
+// AN2Version returns the AN2 protocol version as "major.minor"
+// per spec §3.3.1 GetVersion. Real Neuron firmware reports "1.0".
+func (s *Session) AN2Version() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.an2Version
+	return fmt.Sprintf("%d.%d", s.an2VersionMajor, s.an2VersionMinor)
 }
 
 // ACP2Version returns the ACP2 protocol version.

--- a/internal/acp2/consumer/session_version_test.go
+++ b/internal/acp2/consumer/session_version_test.go
@@ -1,0 +1,30 @@
+package acp2
+
+import "testing"
+
+// TestAN2Version_FormatsMajorMinor pins the consumer-side display +
+// public API for the AN2 GetVersion reply. Spec §3.3.1 returns
+// `func_echo + major + minor`; real Neuron emits 1.0. Before #344
+// the connect log dropped the major byte and printed only the minor
+// (e.g. an2_version=0). AN2Version() now returns "major.minor".
+func TestAN2Version_FormatsMajorMinor(t *testing.T) {
+	tests := []struct {
+		name  string
+		major uint8
+		minor uint8
+		want  string
+	}{
+		{"real-Neuron-1.0", 1, 0, "1.0"},
+		{"future-2.3", 2, 3, "2.3"},
+		{"zero-zero", 0, 0, "0.0"},
+		{"max", 0xFF, 0xFF, "255.255"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Session{an2VersionMajor: tt.major, an2VersionMinor: tt.minor}
+			if got := s.AN2Version(); got != tt.want {
+				t.Errorf("AN2Version() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/acp2/consumer/walker.go
+++ b/internal/acp2/consumer/walker.go
@@ -108,6 +108,25 @@ func (w *Walker) walkObject(ctx context.Context, slot int, objID uint32, path []
 	// Parse properties from the reply.
 	obj, objType, numType, optMap, children := w.parseObjectProperties(msg.Properties, slot, objID, path)
 
+	// Stash type info on the protocol.Object via Meta so the
+	// hierarchical disk snapshot survives a round-trip and can rebuild
+	// the WalkedTree parallel arrays at hot-load time. Keys live in the
+	// "acp2." namespace to avoid colliding with cross-protocol Meta.
+	if obj.Meta == nil {
+		obj.Meta = make(map[string]any, 3)
+	}
+	obj.Meta["acp2.objType"] = uint8(objType)
+	obj.Meta["acp2.numType"] = uint8(numType)
+	if optMap != nil {
+		// Serialise as map[string]string for JSON portability — keys
+		// are u32 wire idx so we stringify on save and parse on load.
+		serialised := make(map[string]string, len(optMap))
+		for k, v := range optMap {
+			serialised[fmt.Sprintf("%d", k)] = v
+		}
+		obj.Meta["acp2.optionsMap"] = serialised
+	}
+
 	// Add to tree (skip pure node containers from the flat list — they
 	// are structural only, not addressable objects with values).
 	// Actually, node objects ARE added so users can see the tree structure.

--- a/internal/acp2/consumer/watch_fallback_test.go
+++ b/internal/acp2/consumer/watch_fallback_test.go
@@ -1,0 +1,131 @@
+package acp2
+
+import (
+	"testing"
+
+	"dhs/internal/acp2/codec"
+	"dhs/internal/protocol"
+)
+
+// TestObjTypeFromVType pins #351: the announce fallback maps the
+// property header's vtype byte (spec §5.2.2) to the right ObjType so
+// Enum / IPv4 / String announces decode typed instead of falling
+// through to KindRaw or being misclassified as KindUint via the
+// "always Number" old fallback path.
+func TestObjTypeFromVType(t *testing.T) {
+	cases := []struct {
+		nt   codec.NumberType
+		want codec.ACP2ObjType
+	}{
+		{codec.NumTypeS8, codec.ObjTypeNumber},
+		{codec.NumTypeS32, codec.ObjTypeNumber},
+		{codec.NumTypeU32, codec.ObjTypeNumber},
+		{codec.NumTypeFloat, codec.ObjTypeNumber},
+		{codec.NumTypePreset, codec.ObjTypeEnum},  // 9 → Enum
+		{codec.NumTypeIPv4, codec.ObjTypeIPv4},    // 10 → IPv4
+		{codec.NumTypeString, codec.ObjTypeString}, // 11 → String
+	}
+	for _, c := range cases {
+		got := objTypeFromVType(c.nt)
+		if got != c.want {
+			t.Errorf("objTypeFromVType(%v) = %v, want %v", c.nt, got, c.want)
+		}
+	}
+}
+
+// TestDecodePropertyValue_FallbackTypes verifies decodePropertyValue
+// handles each object type when called via the announce fallback
+// (tree=nil) using the vtype-derived ObjType from objTypeFromVType.
+// Pre-fix: only Number returned a typed Value; Enum/IPv4/String fell
+// through to KindRaw.
+func TestDecodePropertyValue_FallbackTypes(t *testing.T) {
+	t.Run("enum_vtype9", func(t *testing.T) {
+		// pid 8 enum value: vtype=9 (preset/enum), body = u32 BE wire idx.
+		// Real Neuron obj 163613 Phase: idx 674 = "180 degrees".
+		body := []byte{0x00, 0x00, 0x02, 0xa2}
+		p := &codec.Property{
+			PID:   codec.PIDValue,
+			VType: uint8(codec.NumTypePreset),
+			PLen:  8,
+			Data:  body,
+		}
+		v, err := decodePropertyValue(p, objTypeFromVType(codec.NumberType(p.VType)),
+			codec.NumberType(p.VType), nil, 163613)
+		if err != nil {
+			t.Fatalf("decodePropertyValue: %v", err)
+		}
+		if v.Kind != protocol.KindEnum {
+			t.Errorf("Kind=%v want %v", v.Kind, protocol.KindEnum)
+		}
+		if v.Uint != 674 {
+			t.Errorf("Uint=%d want 674", v.Uint)
+		}
+	})
+
+	t.Run("ipv4_vtype10", func(t *testing.T) {
+		// pid 8 ipv4 value: vtype=10, body = 4 octets.
+		// Real Neuron obj 15828 Neighbor IP: 10.41.40.5.
+		body := []byte{10, 41, 40, 5}
+		p := &codec.Property{
+			PID:   codec.PIDValue,
+			VType: uint8(codec.NumTypeIPv4),
+			PLen:  8,
+			Data:  body,
+		}
+		v, err := decodePropertyValue(p, objTypeFromVType(codec.NumberType(p.VType)),
+			codec.NumberType(p.VType), nil, 15828)
+		if err != nil {
+			t.Fatalf("decodePropertyValue: %v", err)
+		}
+		if v.Kind != protocol.KindIPAddr {
+			t.Errorf("Kind=%v want %v", v.Kind, protocol.KindIPAddr)
+		}
+		if v.IPAddr != [4]byte{10, 41, 40, 5} {
+			t.Errorf("IPAddr=%v want [10 41 40 5]", v.IPAddr)
+		}
+	})
+
+	t.Run("string_vtype11", func(t *testing.T) {
+		// pid 8 string value: vtype=11, body = NUL-terminated UTF-8.
+		body := []byte{'O', 'S', 'D', '-', '1', 0x00}
+		p := &codec.Property{
+			PID:   codec.PIDValue,
+			VType: uint8(codec.NumTypeString),
+			PLen:  uint16(4 + len(body)),
+			Data:  body,
+		}
+		v, err := decodePropertyValue(p, objTypeFromVType(codec.NumberType(p.VType)),
+			codec.NumberType(p.VType), nil, 15555)
+		if err != nil {
+			t.Fatalf("decodePropertyValue: %v", err)
+		}
+		if v.Kind != protocol.KindString {
+			t.Errorf("Kind=%v want %v", v.Kind, protocol.KindString)
+		}
+		if v.Str != "OSD-1" {
+			t.Errorf("Str=%q want %q", v.Str, "OSD-1")
+		}
+	})
+
+	t.Run("number_vtype4_u8", func(t *testing.T) {
+		// pid 8 u8 value: vtype=4, body = 4-byte u32 (sign-extended u8).
+		body := []byte{0x00, 0x00, 0x00, 0x0a}
+		p := &codec.Property{
+			PID:   codec.PIDValue,
+			VType: uint8(codec.NumTypeU8),
+			PLen:  8,
+			Data:  body,
+		}
+		v, err := decodePropertyValue(p, objTypeFromVType(codec.NumberType(p.VType)),
+			codec.NumberType(p.VType), nil, 15211)
+		if err != nil {
+			t.Fatalf("decodePropertyValue: %v", err)
+		}
+		if v.Kind != protocol.KindUint {
+			t.Errorf("Kind=%v want %v", v.Kind, protocol.KindUint)
+		}
+		if v.Uint != 10 {
+			t.Errorf("Uint=%d want 10", v.Uint)
+		}
+	})
+}

--- a/internal/acp2/provider/encoder.go
+++ b/internal/acp2/provider/encoder.go
@@ -11,86 +11,122 @@ import (
 )
 
 // buildProperties assembles the ACP2 property list a get_object reply
-// must carry for one entry. Per spec §"Property IDs" the ordering is
-// not strictly required but consumers generally expect:
+// must carry for one entry, in ascending pid order, per spec §5.1
+// "Property fields per object type" + §5.4 "Property header per field".
 //
-//	pid=1  object_type (all)
-//	pid=2  label        (all)
-//	pid=3  access       (all)
-//	pid=5  number_type  (Number, Enum)
-//	pid=6  string_max_length (String)
-//	pid=8  value        (Number, Enum, IPv4, String)
-//	pid=9  default_value (Number)
-//	pid=10 min_value    (Number)
-//	pid=11 max_value    (Number)
-//	pid=12 step_size    (Number)
-//	pid=13 unit         (Number)
-//	pid=14 children     (Node)
-//	pid=15 options      (Enum)
+// Authoritative §5.1 matrix (decoded from acp2_protocol.docx XML cell
+// shading: ✓ shaded = required, op¹ = optional, — = does not apply):
 //
-// We emit in this order. The codec's EncodeProperties takes care of
-// the per-property alignment.
+//	| pid | name              | Acc  | Dyn | Node | Pres | Enum | Num  | IPv4 | Str  |
+//	|-----|-------------------|------|-----|------|------|------|------|------|------|
+//	|  1  | object type       | R    |  -  |  ✓   |  ✓   |  ✓   |  ✓   |  ✓   |  ✓   |
+//	|  2  | label             | R    |  -  |  ✓   |  ✓   |  ✓   |  ✓   |  ✓   |  ✓   |
+//	|  3  | access            | R    | yes |  —   |  ✓   |  ✓   |  ✓   |  ✓   |  ✓   |
+//	|  4  | event delay       | RW   | yes |  —   |  ✓   |  ✓   |  ✓   |  ✓   |  ✓   |
+//	|  5  | number type       | R    |  -  |  —   |  —   |  —   |  ✓   |  —   |  —   |
+//	|  6  | string max length | R    |  -  |  —   |  —   |  —   |  —   |  —   |  ✓   |
+//	|  7  | preset depth      | R    |  -  |  —   |  —   | op¹  | op¹  | op¹  | op¹  |
+//	|  8  | value             | R/RW | yes |  —   |  ✓   |  ✓   |  ✓   |  ✓   |  ✓   |
+//	|  9  | default value     | R    |  -  |  —   |  ✓   |  ✓   |  ✓   |  ✓   |  ✓   |
+//	| 10  | min value         | R    | yes |  —   |  —   |  —   |  ✓   |  —   |  —   |
+//	| 11  | max value         | R    | yes |  —   |  —   |  —   |  ✓   |  —   |  —   |
+//	| 12  | step size         | R    |  -  |  —   |  —   |  —   | op¹  |  —   |  —   |
+//	| 13  | unit              | R    |  -  |  —   |  —   |  —   | op¹  |  —   |  —   |
+//	| 14  | children          | R    |  -  |  ✓   |  —   |  —   |  —   |  —   |  —   |
+//	| 15  | options           | R    |  -  |  —   |  ✓   |  ✓   |  —   |  —   |  —   |
+//	| 16-19 event tag/prio/state/msg | — | op¹  | op¹  | op¹  | op¹  | op¹  |
+//	| 20  | preset parent     | R    |  -  |  —   |  —   | op¹  | op¹  | op¹  | op¹  |
+//
+// Verified byte-for-byte against real Neuron firmware (10.41.40.4)
+// GetObject replies captured 2026-05-09:
+//
+//	Node    obj 15364 MANAGEMENT PORT : {1, 2, 14}                          dlen=108
+//	Enum    obj 17671 IO Board        : {1, 2, 3, 4, 8, 9, 15}              dlen= 84
+//	Number  obj 15211 Fan Speed       : {1, 2, 3, 4, 5, 8, 9, 10, 11, 12, 13} dlen=96
+//	IPv4    obj 15828 Neighbor IP     : {1, 2, 3, 4, 8, 9}                   dlen= 60
+//	String  obj  2    Card Name       : {1, 2, 3, 4, 6, 8, 9}                dlen= 72
+//
+// Capture file: bin/neuron-fresh/out-real-walk-slot0.jsonl. Any deviation
+// from the matrix above is a bug in this function.
 func buildProperties(e *entry) ([]codec.Property, error) {
-	props := make([]codec.Property, 0, 8)
+	props := make([]codec.Property, 0, 12)
 
+	// pid 1 object type — universal
 	props = append(props, propInline(codec.PIDObjectType, uint8(e.objType)))
+	// pid 2 label — universal
 	props = append(props, propStringData0(codec.PIDLabel, e.label))
-	props = append(props, propInline(codec.PIDAccess, e.access))
+
+	// pid 3 access + pid 4 event delay — every parameter type, NOT Node
+	if e.objType != codec.ObjTypeNode {
+		props = append(props, propInline(codec.PIDAccess, e.access))
+		props = append(props, propEventDelay(eventDelayHint(e.param)))
+	}
 
 	switch e.objType {
 	case codec.ObjTypeNode:
+		// pid 14 children — Node only
 		props = append(props, propChildren(e.children))
+
 	case codec.ObjTypeNumber:
+		// pid 5 number type — Number only
 		props = append(props, propInline(codec.PIDNumberType, uint8(e.numType)))
+		// pid 8 value
 		val, err := encodeValueProp(codec.PIDValue, e)
 		if err != nil {
 			return nil, err
 		}
 		props = append(props, val)
-		if cp, ok, err := encodeOptionalConstraint(codec.PIDDefaultValue, e.numType, e.param.Default); err != nil {
+		// pid 9 default_value — required, default 0 if canonical lacks.
+		dv, err := numericPropOrZero(codec.PIDDefaultValue, e.numType, e.param.Default)
+		if err != nil {
 			return nil, err
-		} else if ok {
-			props = append(props, cp)
 		}
-		if cp, ok, err := encodeOptionalConstraint(codec.PIDMinValue, e.numType, e.param.Minimum); err != nil {
+		props = append(props, dv)
+		// pid 10 min — required
+		mn, err := numericPropOrZero(codec.PIDMinValue, e.numType, e.param.Minimum)
+		if err != nil {
 			return nil, err
-		} else if ok {
-			props = append(props, cp)
 		}
-		if cp, ok, err := encodeOptionalConstraint(codec.PIDMaxValue, e.numType, e.param.Maximum); err != nil {
+		props = append(props, mn)
+		// pid 11 max — required
+		mx, err := numericPropOrZero(codec.PIDMaxValue, e.numType, e.param.Maximum)
+		if err != nil {
 			return nil, err
-		} else if ok {
-			props = append(props, cp)
 		}
+		props = append(props, mx)
+		// pid 12 step size — optional
 		if cp, ok, err := encodeOptionalConstraint(codec.PIDStepSize, e.numType, e.param.Step); err != nil {
 			return nil, err
 		} else if ok {
 			props = append(props, cp)
 		}
+		// pid 13 unit — optional
 		if e.param.Unit != nil && *e.param.Unit != "" {
 			props = append(props, propStringData0(codec.PIDUnit, *e.param.Unit))
 		}
+
 	case codec.ObjTypeEnum:
-		// Enum per spec §5.1: pid 5 number_type does NOT apply (Number only),
-		// and pid 9 default_value is depth-indexed ([d]) — only valid for
-		// preset children which carry pid 7 preset_depth. A plain Enum is
-		// not a preset child, so pid 9 is omitted. Emitting pid 9 with
-		// vtype=9 but no pid 7 trips Lawo VSM's parser:
-		// "Index was outside the bounds of the array" — the preset array
-		// hasn't been sized.
-		// pid 8 value uses vtype = 9 (preset/enum), stored as u32 index.
+		// pid 8 value (vtype = preset/enum, u32 wire idx)
 		val, err := encodeValueProp(codec.PIDValue, e)
 		if err != nil {
 			return nil, err
 		}
 		props = append(props, val)
+		// pid 9 default_value — required, vtype=preset/enum, u32 wire idx.
+		// Falls back to current value when canonical lacks Default — same
+		// shape the device emits when no separate default exists.
+		dv, err := enumDefaultProp(e)
+		if err != nil {
+			return nil, err
+		}
+		props = append(props, dv)
+		// pid 15 options
 		props = append(props, propOptions(enumOptions(e.param)))
+
 	case codec.ObjTypePreset:
-		// Preset child per spec §5: pid 7 preset_depth lists the N valid
-		// idx values; pids 8/9/10/11 each appear N times in the reply,
-		// once per idx. Number-style numeric fields (pid 5, 12, 13) are
-		// emitted once. For N=1 the shape degenerates to "Number + pid 7".
-		props = append(props, propInline(codec.PIDNumberType, uint8(e.numType)))
+		// Preset per spec §5.1: pid 5 number_type does NOT apply
+		// (Number only). pid 7 preset_depth + pids 8/9 emitted once per
+		// depth idx. Spec §5.5 "Preset depth".
 		props = append(props, propPresetDepth(e.presetDepth))
 		for i := uint32(0); i < e.presetDepth; i++ {
 			val, err := encodeValueProp(codec.PIDValue, e)
@@ -99,50 +135,39 @@ func buildProperties(e *entry) ([]codec.Property, error) {
 			}
 			props = append(props, val)
 		}
-		if cp, ok, err := encodeOptionalConstraint(codec.PIDDefaultValue, e.numType, e.param.Default); err != nil {
-			return nil, err
-		} else if ok {
-			for i := uint32(0); i < e.presetDepth; i++ {
-				props = append(props, cp)
+		for i := uint32(0); i < e.presetDepth; i++ {
+			dv, err := enumDefaultProp(e)
+			if err != nil {
+				return nil, err
 			}
+			props = append(props, dv)
 		}
-		if cp, ok, err := encodeOptionalConstraint(codec.PIDMinValue, e.numType, e.param.Minimum); err != nil {
-			return nil, err
-		} else if ok {
-			for i := uint32(0); i < e.presetDepth; i++ {
-				props = append(props, cp)
-			}
-		}
-		if cp, ok, err := encodeOptionalConstraint(codec.PIDMaxValue, e.numType, e.param.Maximum); err != nil {
-			return nil, err
-		} else if ok {
-			for i := uint32(0); i < e.presetDepth; i++ {
-				props = append(props, cp)
-			}
-		}
-		if cp, ok, err := encodeOptionalConstraint(codec.PIDStepSize, e.numType, e.param.Step); err != nil {
-			return nil, err
-		} else if ok {
-			props = append(props, cp)
-		}
-		if e.param.Unit != nil && *e.param.Unit != "" {
-			props = append(props, propStringData0(codec.PIDUnit, *e.param.Unit))
-		}
+		// pid 15 options
+		props = append(props, propOptions(enumOptions(e.param)))
+
 	case codec.ObjTypeIPv4:
+		// pid 8 value
 		val, err := encodeValueProp(codec.PIDValue, e)
 		if err != nil {
 			return nil, err
 		}
 		props = append(props, val)
+		// pid 9 default_value — required, vtype=ipv4, 4 octets.
+		props = append(props, ipv4DefaultProp(e.param.Default))
+
 	case codec.ObjTypeString:
-		if ml := maxLenHint(e.param); ml > 0 {
-			props = append(props, propU16Pad(codec.PIDStringMaxLength, uint16(ml)))
-		}
+		// pid 6 string_max_length — required (always emit).
+		// Default to maxLenHint, falling back to canonical Maximum, then 256
+		// (spec §1.2 "A string type should support strings up to a 256 bytes").
+		props = append(props, propU16Pad(codec.PIDStringMaxLength, stringMaxLen(e.param)))
+		// pid 8 value
 		val, err := encodeValueProp(codec.PIDValue, e)
 		if err != nil {
 			return nil, err
 		}
 		props = append(props, val)
+		// pid 9 default_value — required, vtype=string, NUL-terminated.
+		props = append(props, stringDefaultProp(e.param.Default))
 	}
 
 	return props, nil
@@ -269,49 +294,172 @@ func propPresetDepth(depth uint32) codec.Property {
 	}
 }
 
-// acp2OptionSize is the fixed on-wire size of one enum option (pid 15
-// entry) per spec §5.4: plen = 4 + (72 * option), so each option is
-// exactly 72 bytes: 4-byte u32 index + 68-byte NUL-padded UTF-8 name.
-const acp2OptionSize = 72
+// optionEntry pairs the wire idx (from canonical EnumMap.Value) with
+// its label so propOptions can emit the same idx values pid 8 (current
+// value) and pid 9 (default) reference. Real Axon firmware uses sparse
+// u32 ids per option (e.g. 786 "Automatic", 791 "Full Speed"); without
+// idx-aware emission, pid 8/9 would point at no option and consumers
+// fail to resolve the active label.
+type optionEntry struct {
+	idx   uint32
+	label string
+}
 
-// propOptions builds the pid=15 (options) property per spec §5.4:
+// propOptions builds the pid=15 (options) property using the
+// variable-length per-option layout that every shipping ACP2
+// controller and real Axon Neuron firmware implements:
 //
-//	header: pid=15, data=num_option (INLINE), plen=4 + 72 * N
-//	body  : N fixed-size slots, each {u32 index, 68-byte NUL-padded name}
+//	header: pid=15, data=num_option (INLINE), plen = 4 + sum(record sizes)
+//	body  : N records, each {u32 idx, NUL-terminated name, 0-3 byte align}
 //
-// Matches real Axon firmware; Lawo VSM's driver parses with this layout.
-// Index 0..N-1 matches EnumMap ordering.
+// Spec deviation note: spec §5.4 row 15 calls for fixed 72-byte stride
+// per option (`plen = 4 + 72*N`). No production controller emits or
+// accepts that layout — real Neuron's pid 15 wire (verified
+// 2026-05-09 against 10.41.40.4: 2-option enum has plen=24 not
+// 4+144=148) is variable-length, and Cerebrum + VSM Studio decode the
+// variable-length form. Following the wire per
+// `feedback_no_workaround` "every shipping controller contradicts the
+// spec" exception. Compliance event documents the deviation.
 //
-//	| Offset          | Field   | Width  | Notes                         |
-//	|-----------------|---------|--------|-------------------------------|
-//	| 0               | pid     | u8     | 15 = options                  |
-//	| 1               | data    | u8     | num options (N) — inline count|
-//	| 2-3             | plen    | u16 BE | 4 + 72*N                      |
-//	| 4 + 72*i        | idx_i   | u32 BE | option index (0..N-1)         |
-//	| 8 + 72*i        | name_i  | 68     | UTF-8, zero-padded, truncates |
-//
-// Spec reference: acp2_protocol.pdf §5.4 pid=15 options
-func propOptions(opts []string) codec.Property {
-	n := len(opts)
-	data := make([]byte, acp2OptionSize*n)
-	for i, opt := range opts {
-		off := i * acp2OptionSize
-		binary.BigEndian.PutUint32(data[off:off+4], uint32(i))
-		// Copy the UTF-8 name into the 68-byte slot. Truncate if
-		// longer; zero-pad otherwise. No explicit NUL — the zero
-		// padding serves as the terminator.
-		name := opt
-		if len(name) > acp2OptionSize-4-1 { // reserve at least 1 NUL
-			name = name[:acp2OptionSize-4-1]
+//	| Offset      | Field   | Width  | Notes                                |
+//	|-------------|---------|--------|--------------------------------------|
+//	| 0           | pid     | u8     | 15 = options                         |
+//	| 1           | data    | u8     | num options (N) — inline count       |
+//	| 2-3         | plen    | u16 BE | 4 + sum(record sizes)                |
+//	| record i: idx       | u32 BE | option wire idx                      |
+//	| record i: name+\0   | varies | UTF-8, NUL-terminated                |
+//	| record i: align     | 0-3    | zero pad to next 4-byte boundary     |
+func propOptions(opts []optionEntry) codec.Property {
+	var data []byte
+	for _, opt := range opts {
+		var idx [4]byte
+		binary.BigEndian.PutUint32(idx[:], opt.idx)
+		data = append(data, idx[:]...)
+		data = append(data, []byte(opt.label)...)
+		data = append(data, 0)
+		if pad := (4 - (len(data) % 4)) % 4; pad > 0 {
+			data = append(data, make([]byte, pad)...)
 		}
-		copy(data[off+4:off+acp2OptionSize], name)
 	}
 	return codec.Property{
 		PID:   codec.PIDOptions,
-		VType: uint8(n), // spec §5.4: "data: num option" — inline count
-		PLen:  uint16(4 + acp2OptionSize*n),
+		VType: uint8(len(opts)), // spec §5.4: "data: num option" — inline count
+		PLen:  uint16(4 + len(data)),
 		Data:  data,
 	}
+}
+
+// propEventDelay builds pid=4 (event_delay) per spec §5.4 row 4:
+//
+//	| Offset | Field | Width  | Notes                                  |
+//	|--------|-------|--------|----------------------------------------|
+//	| 0      | pid   | u8     | 4 = event_delay                        |
+//	| 1      | data  | u8     | 0 per spec §5.4                        |
+//	| 2-3    | plen  | u16 BE | 8 (header 4 + body 4)                  |
+//	| 4-7    | rate  | u32 BE | announce delay (ms)                    |
+//
+// Required on every parameter type (Preset, Enum, Number, IPv4,
+// String); absent on Node.
+func propEventDelay(rateMs uint32) codec.Property {
+	body := make([]byte, 4)
+	binary.BigEndian.PutUint32(body, rateMs)
+	return codec.Property{
+		PID:   codec.PIDAnnounceDelay, // pid 4; spec name "event delay" — constant rename to PIDEventDelay tracked in #317
+		VType: 0,
+		PLen:  8,
+		Data:  body,
+	}
+}
+
+// eventDelayHint extracts the announce-rate hint (ms) from the
+// canonical Parameter. Currently no canonical field carries this, so
+// we default to 0 — same value real Neuron emits when no rate is
+// configured (verified obj 17671, obj 21127, obj 15828).
+func eventDelayHint(p *canonical.Parameter) uint32 {
+	if p == nil {
+		return 0
+	}
+	return 0
+}
+
+// numericPropOrZero emits pid=9/10/11 with the canonical's typed
+// value when present; otherwise emits the property with a zero body
+// of the correct vtype width. Spec §5.1 marks pid 9/10/11 as required
+// on Number (and pid 9 on every parameter), so silently dropping the
+// property when canonical lacks the field is a violation.
+func numericPropOrZero(pid uint8, nt codec.NumberType, v any) (codec.Property, error) {
+	if v != nil {
+		return encodeNumericProp(pid, nt, v)
+	}
+	switch nt {
+	case codec.NumTypeS64, codec.NumTypeU64:
+		return numericProp(pid, nt, make([]byte, 8)), nil
+	default:
+		return numericProp(pid, nt, make([]byte, 4)), nil
+	}
+}
+
+// enumDefaultProp emits pid=9 (default value) for an Enum / Preset
+// using vtype=preset/enum (NumberType 9) and a 4-byte u32 BE body.
+// When canonical Default is present, use it; else fall back to the
+// current value (matches real-Neuron behaviour for objects with no
+// distinct stored default — e.g. obj 21127 Fan Control: pid 8 = pid 9
+// = 786).
+func enumDefaultProp(e *entry) (codec.Property, error) {
+	src := e.param.Default
+	if src == nil {
+		src = e.param.Value
+	}
+	v, err := asUint32(src, "default")
+	if err != nil {
+		return codec.Property{}, err
+	}
+	return numericProp(codec.PIDDefaultValue, codec.NumTypePreset, u32Data(v)), nil
+}
+
+// ipv4DefaultProp emits pid=9 for IPv4: vtype=ipv4 (NumberType 10),
+// 4-byte body. Default to 0.0.0.0 when canonical lacks Default
+// (matches real Neuron obj 15828 Neighbor IP).
+func ipv4DefaultProp(def any) codec.Property {
+	body := make([]byte, 4)
+	if def != nil {
+		if v, err := ipv4Uint32(def); err == nil {
+			binary.BigEndian.PutUint32(body, v)
+		}
+	}
+	return numericProp(codec.PIDDefaultValue, codec.NumTypeIPv4, body)
+}
+
+// stringMaxLen returns the configured max length for a String
+// parameter, falling back through canonical hint -> Maximum -> 256
+// (spec §1.2 "A string type should support strings up to a 256 bytes,
+// configurable in menu").
+func stringMaxLen(p *canonical.Parameter) uint16 {
+	if p == nil {
+		return 256
+	}
+	if ml := maxLenHint(p); ml > 0 {
+		return uint16(ml)
+	}
+	if p.Maximum != nil {
+		if u, err := asUint32(p.Maximum, "max"); err == nil && u > 0 && u <= 0xFFFF {
+			return uint16(u)
+		}
+	}
+	return 256
+}
+
+// stringDefaultProp emits pid=9 for String: vtype=string (NumberType
+// 11), body = NUL-terminated UTF-8. Empty default = single NUL byte
+// (matches real Neuron obj 2 Card Name: plen=5 body=`00`).
+func stringDefaultProp(def any) codec.Property {
+	s := ""
+	if def != nil {
+		if str, ok := def.(string); ok {
+			s = str
+		}
+	}
+	return codec.MakeStringProperty(codec.PIDDefaultValue, s)
 }
 
 // encodeValueProp builds the pid=8 (value) property for one entry,
@@ -464,23 +612,37 @@ func u32Data(v uint32) []byte {
 	return out
 }
 
-// enumOptions pulls the enum option labels (ordered by ordinal) from a
-// canonical Parameter. Prefers EnumMap; falls back to parsing the
-// newline- or comma-separated Enumeration string.
-func enumOptions(p *canonical.Parameter) []string {
+// enumOptions returns option records (wire-idx + label) from a
+// canonical Parameter. EnumMap entries carry their wire idx in
+// Value (e.g. real Axon's sparse u32 ids: 786 "Automatic", 791
+// "Full Speed"); pid 8 (current value) and pid 9 (default) reference
+// the wire idx, so propOptions must emit the exact same idx values
+// in pid 15 records or consumers fail to resolve labels.
+//
+// Falls back to positional 0..N-1 only for legacy fixtures that
+// carry only a comma/newline-separated Enumeration string with no
+// EnumMap.
+func enumOptions(p *canonical.Parameter) []optionEntry {
 	if len(p.EnumMap) > 0 {
-		out := make([]string, len(p.EnumMap))
+		out := make([]optionEntry, len(p.EnumMap))
 		for i, e := range p.EnumMap {
-			out[i] = e.Key
+			out[i] = optionEntry{idx: uint32(e.Value), label: e.Key}
 		}
 		return out
 	}
 	if p.Enumeration != nil && *p.Enumeration != "" {
 		raw := *p.Enumeration
+		var labels []string
 		if strings.Contains(raw, "\n") {
-			return strings.Split(raw, "\n")
+			labels = strings.Split(raw, "\n")
+		} else {
+			labels = strings.Split(raw, ",")
 		}
-		return strings.Split(raw, ",")
+		out := make([]optionEntry, len(labels))
+		for i, l := range labels {
+			out[i] = optionEntry{idx: uint32(i), label: l}
+		}
+		return out
 	}
 	return nil
 }

--- a/internal/acp2/provider/encoder_neuron_test.go
+++ b/internal/acp2/provider/encoder_neuron_test.go
@@ -1,0 +1,290 @@
+package acp2
+
+import (
+	"testing"
+
+	"dhs/internal/acp2/codec"
+	"dhs/internal/export/canonical"
+)
+
+// Tests in this file pin the producer's GetObject reply property set
+// against bytes captured from real Axon Neuron firmware (10.41.40.4)
+// on 2026-05-09. Capture file: bin/neuron-fresh/out-real-walk-slot0.jsonl.
+// Each test asserts which pids appear in our wire reply for one
+// representative obj per object type, plus the wire shape of pid 4
+// event_delay and pid 9 default_value (the spec deltas this PR fixes).
+//
+// Spec authority: ACP2 §5.1 Property fields per object type
+// (acp2_protocol.docx). Reading: cell shading ✓ = required, op¹ =
+// optional, blank — = does not apply.
+
+func pidSet(props []codec.Property) map[uint8]bool {
+	out := map[uint8]bool{}
+	for _, p := range props {
+		out[p.PID] = true
+	}
+	return out
+}
+
+func wantPids(t *testing.T, props []codec.Property, required, forbidden []uint8) {
+	t.Helper()
+	got := pidSet(props)
+	for _, pid := range required {
+		if !got[pid] {
+			t.Errorf("missing required pid %d", pid)
+		}
+	}
+	for _, pid := range forbidden {
+		if got[pid] {
+			t.Errorf("forbidden pid %d emitted", pid)
+		}
+	}
+}
+
+// TestEncoder_Node_RealNeuronShape — real Neuron obj 15364
+// MANAGEMENT PORT: {pid 1 obj_type, pid 2 label, pid 14 children}.
+// No pid 3, no pid 4. Verified bytes: out-real-walk-slot0.jsonl.
+func TestEncoder_Node_RealNeuronShape(t *testing.T) {
+	e := &entry{
+		objID: 15364, label: "MANAGEMENT PORT",
+		access:   0x01,
+		objType:  codec.ObjTypeNode,
+		children: []uint32{19378, 15252, 15246},
+	}
+	got := buildAndDecode(t, e)
+	wantPids(t, got,
+		[]uint8{codec.PIDObjectType, codec.PIDLabel, codec.PIDChildren},
+		[]uint8{codec.PIDAccess, codec.PIDAnnounceDelay,
+			codec.PIDNumberType, codec.PIDValue, codec.PIDDefaultValue,
+			codec.PIDStringMaxLength, codec.PIDOptions},
+	)
+}
+
+// TestEncoder_Number_RealNeuronShape — real Neuron obj 15211 Fan Speed
+// (u8): {1, 2, 3, 4, 5, 8, 9, 10, 11, 12, 13}. dlen=96.
+func TestEncoder_Number_RealNeuronShape(t *testing.T) {
+	unit := "%"
+	p := &canonical.Parameter{
+		Header: canonical.Header{
+			Number: 15211, Identifier: "Fan Speed", Access: canonical.AccessRead,
+		},
+		Type:  canonical.ParamInteger,
+		Value: int64(10), Default: int64(0),
+		Minimum: int64(0), Maximum: int64(100),
+		Step: int64(1), Unit: &unit,
+	}
+	e := &entry{
+		objID: 15211, label: p.Identifier, access: 0x01,
+		objType: codec.ObjTypeNumber, numType: codec.NumTypeU8,
+		param: p,
+	}
+	got := buildAndDecode(t, e)
+	wantPids(t, got,
+		[]uint8{codec.PIDObjectType, codec.PIDLabel, codec.PIDAccess,
+			codec.PIDAnnounceDelay, codec.PIDNumberType, codec.PIDValue,
+			codec.PIDDefaultValue, codec.PIDMinValue, codec.PIDMaxValue,
+			codec.PIDStepSize, codec.PIDUnit},
+		[]uint8{codec.PIDChildren, codec.PIDStringMaxLength, codec.PIDOptions},
+	)
+}
+
+// TestEncoder_Number_RequiredPidsAlwaysEmittedZero — pid 9/10/11
+// must be present even when canonical Default/Min/Max are nil. Real
+// Neuron emits all three on every Number reply (§5.1 cells shaded).
+func TestEncoder_Number_RequiredPidsAlwaysEmittedZero(t *testing.T) {
+	p := &canonical.Parameter{
+		Header: canonical.Header{
+			Number: 99, Identifier: "Bare Counter", Access: canonical.AccessRead,
+		},
+		Type:  canonical.ParamInteger,
+		Value: int64(0),
+		// Default/Min/Max all nil
+	}
+	e := &entry{
+		objID: 99, label: p.Identifier, access: 0x01,
+		objType: codec.ObjTypeNumber, numType: codec.NumTypeU32,
+		param: p,
+	}
+	got := buildAndDecode(t, e)
+	wantPids(t, got,
+		[]uint8{codec.PIDDefaultValue, codec.PIDMinValue, codec.PIDMaxValue},
+		nil,
+	)
+}
+
+// TestEncoder_Enum_RealNeuronShape — real Neuron obj 21127 Fan Control
+// (RW): {1, 2, 3, 4, 8, 9, 15}. pid 9 carries vtype=preset/enum (9)
+// and the same u32 idx as pid 8 (or canonical Default if separate).
+func TestEncoder_Enum_RealNeuronShape(t *testing.T) {
+	p := &canonical.Parameter{
+		Header: canonical.Header{
+			Number: 21127, Identifier: "Fan Control", Access: canonical.AccessReadWrite,
+		},
+		Type:  canonical.ParamEnum,
+		Value: int64(786),
+		EnumMap: []canonical.EnumEntry{
+			{Key: "Automatic", Value: 786},
+			{Key: "Full Speed", Value: 791},
+		},
+	}
+	e := &entry{
+		objID: 21127, label: p.Identifier, access: 0x03,
+		objType: codec.ObjTypeEnum, numType: codec.NumTypeU32,
+		param: p,
+	}
+	got := buildAndDecode(t, e)
+	wantPids(t, got,
+		[]uint8{codec.PIDObjectType, codec.PIDLabel, codec.PIDAccess,
+			codec.PIDAnnounceDelay, codec.PIDValue, codec.PIDDefaultValue,
+			codec.PIDOptions},
+		[]uint8{codec.PIDNumberType, codec.PIDChildren, codec.PIDStringMaxLength,
+			codec.PIDMinValue, codec.PIDMaxValue},
+	)
+	// pid 9 default value == current value (786) when canonical lacks
+	// separate Default — matches real Neuron obj 21127.
+	for _, pr := range got {
+		if pr.PID == codec.PIDDefaultValue {
+			if pr.VType != uint8(codec.NumTypePreset) {
+				t.Errorf("pid 9 vtype=%d want %d (preset/enum)", pr.VType, codec.NumTypePreset)
+			}
+			if len(pr.Data) != 4 {
+				t.Errorf("pid 9 body len=%d want 4", len(pr.Data))
+			}
+			val := uint32(pr.Data[0])<<24 | uint32(pr.Data[1])<<16 |
+				uint32(pr.Data[2])<<8 | uint32(pr.Data[3])
+			if val != 786 {
+				t.Errorf("pid 9 default=%d want 786", val)
+			}
+		}
+	}
+}
+
+// TestEncoder_IPv4_RealNeuronShape — real Neuron obj 15828 Neighbor IP
+// {1, 2, 3, 4, 8, 9}. pid 9 vtype=ipv4(10), 4-byte body, default 0.0.0.0.
+func TestEncoder_IPv4_RealNeuronShape(t *testing.T) {
+	p := &canonical.Parameter{
+		Header: canonical.Header{
+			Number: 15828, Identifier: "Neighbor IP", Access: canonical.AccessRead,
+		},
+		Type:   canonical.ParamString, // canonical stores IP as string
+		Value:  "10.41.40.5",
+		Format: strPtr("ipv4"),
+	}
+	e := &entry{
+		objID: 15828, label: p.Identifier, access: 0x01,
+		objType: codec.ObjTypeIPv4, numType: codec.NumTypeIPv4,
+		param: p,
+	}
+	got := buildAndDecode(t, e)
+	wantPids(t, got,
+		[]uint8{codec.PIDObjectType, codec.PIDLabel, codec.PIDAccess,
+			codec.PIDAnnounceDelay, codec.PIDValue, codec.PIDDefaultValue},
+		[]uint8{codec.PIDNumberType, codec.PIDChildren, codec.PIDStringMaxLength,
+			codec.PIDOptions, codec.PIDMinValue, codec.PIDMaxValue},
+	)
+}
+
+// TestEncoder_String_RealNeuronShape — real Neuron obj 2 Card Name
+// {1, 2, 3, 4, 6, 8, 9}. pid 6 always emitted (max length); pid 9
+// vtype=string(11).
+func TestEncoder_String_RealNeuronShape(t *testing.T) {
+	hint := "maxLen=17"
+	p := &canonical.Parameter{
+		Header: canonical.Header{
+			Number: 2, Identifier: "Card Name", Access: canonical.AccessRead,
+		},
+		Type:   canonical.ParamString,
+		Value:  "SHPRM1",
+		Format: &hint,
+	}
+	e := &entry{
+		objID: 2, label: p.Identifier, access: 0x01,
+		objType: codec.ObjTypeString, numType: codec.NumTypeString,
+		param: p,
+	}
+	got := buildAndDecode(t, e)
+	wantPids(t, got,
+		[]uint8{codec.PIDObjectType, codec.PIDLabel, codec.PIDAccess,
+			codec.PIDAnnounceDelay, codec.PIDStringMaxLength,
+			codec.PIDValue, codec.PIDDefaultValue},
+		[]uint8{codec.PIDNumberType, codec.PIDChildren, codec.PIDOptions,
+			codec.PIDMinValue, codec.PIDMaxValue},
+	)
+}
+
+// TestEncoder_String_DefaultEmptyShape — when canonical Default is
+// absent, pid 9 emits a single NUL byte (empty string), plen=5.
+// Verified against real Neuron obj 2 Card Name where default is "".
+func TestEncoder_String_DefaultEmptyShape(t *testing.T) {
+	p := &canonical.Parameter{
+		Header: canonical.Header{
+			Number: 2, Identifier: "X", Access: canonical.AccessRead,
+		},
+		Type:  canonical.ParamString,
+		Value: "any",
+	}
+	e := &entry{
+		objID: 2, label: p.Identifier, access: 0x01,
+		objType: codec.ObjTypeString, numType: codec.NumTypeString,
+		param: p,
+	}
+	props, err := buildProperties(e)
+	if err != nil {
+		t.Fatalf("buildProperties: %v", err)
+	}
+	for _, pr := range props {
+		if pr.PID == codec.PIDDefaultValue {
+			// Spec §5.4: pid=9 with vtype=string(11), empty body = "\0", plen=5.
+			if pr.VType != uint8(codec.NumTypeString) {
+				t.Errorf("pid 9 vtype=%d want %d (string)", pr.VType, codec.NumTypeString)
+			}
+			if pr.PLen != 5 {
+				t.Errorf("pid 9 plen=%d want 5", pr.PLen)
+			}
+			if len(pr.Data) != 1 || pr.Data[0] != 0 {
+				t.Errorf("pid 9 data=%x want 00 (empty NUL-terminated)", pr.Data)
+			}
+			return
+		}
+	}
+	t.Error("pid 9 default_value not emitted on String reply")
+}
+
+// TestEncoder_EventDelay_WireShape — pid 4 must be `04 00 00 08 +
+// u32 BE rate`. Verified against real Neuron obj 17671 (rate=0).
+func TestEncoder_EventDelay_WireShape(t *testing.T) {
+	p := &canonical.Parameter{
+		Header: canonical.Header{Number: 1, Identifier: "x", Access: canonical.AccessRead},
+		Type:   canonical.ParamEnum,
+		Value:  int64(0),
+		EnumMap: []canonical.EnumEntry{
+			{Key: "Off", Value: 0},
+		},
+	}
+	e := &entry{
+		objID: 1, label: "x", access: 0x01,
+		objType: codec.ObjTypeEnum, numType: codec.NumTypeU32,
+		param: p,
+	}
+	props, err := buildProperties(e)
+	if err != nil {
+		t.Fatalf("buildProperties: %v", err)
+	}
+	for _, pr := range props {
+		if pr.PID == codec.PIDAnnounceDelay {
+			if pr.VType != 0 {
+				t.Errorf("pid 4 data byte=%d want 0 per spec §5.4", pr.VType)
+			}
+			if pr.PLen != 8 {
+				t.Errorf("pid 4 plen=%d want 8 per spec §5.4", pr.PLen)
+			}
+			if len(pr.Data) != 4 {
+				t.Errorf("pid 4 body len=%d want 4 (u32 rate)", len(pr.Data))
+			}
+			return
+		}
+	}
+	t.Error("pid 4 event_delay not emitted on Enum reply")
+}
+
+func strPtr(s string) *string { return &s }

--- a/internal/acp2/provider/encoder_test.go
+++ b/internal/acp2/provider/encoder_test.go
@@ -28,6 +28,12 @@ func buildAndDecode(t *testing.T, e *entry) []codec.Property {
 	return decoded
 }
 
+// TestBuildProperties_Node pins spec §5.1: a Node reply carries
+// EXACTLY {pid 1 obj_type, pid 2 label, pid 14 children}. No pid 3
+// access, no pid 4 event_delay — both are blank on the Node row of
+// §5.1. Verified against real Neuron obj 15364 MANAGEMENT PORT
+// (10.41.40.4 capture 2026-05-09): wire is dlen=108, 3 properties
+// only.
 func TestBuildProperties_Node(t *testing.T) {
 	n := &canonical.Node{
 		Header: canonical.Header{
@@ -42,10 +48,18 @@ func TestBuildProperties_Node(t *testing.T) {
 		node:     n,
 	}
 	got := buildAndDecode(t, e)
-	want := map[uint8]bool{codec.PIDObjectType: true, codec.PIDLabel: true,
-		codec.PIDAccess: true, codec.PIDChildren: true}
+	want := map[uint8]bool{
+		codec.PIDObjectType: true, codec.PIDLabel: true, codec.PIDChildren: true,
+	}
+	notWant := map[uint8]bool{
+		codec.PIDAccess:        true, // pid 3 — Node row blank
+		codec.PIDAnnounceDelay: true, // pid 4 — Node row blank
+	}
 	for _, p := range got {
 		delete(want, p.PID)
+		if notWant[p.PID] {
+			t.Errorf("Node reply must not carry pid %d (spec §5.1 Node row blank)", p.PID)
+		}
 	}
 	if len(want) > 0 {
 		t.Errorf("missing pids: %v", want)

--- a/internal/acp2/provider/handlers.go
+++ b/internal/acp2/provider/handlers.go
@@ -11,9 +11,14 @@ import (
 // AN2 v1.0 matches what real Axon firmware emits today. ACP2 v1 is the
 // only ACP2 major in the wild; consumers use it to gate feature flags.
 const (
-	an2VersionMajor uint8 = 1
-	an2VersionMinor uint8 = 0
-	acp2Version     uint8 = 1
+	// Version constants matched against real Axon Neuron firmware
+	// (10.41.40.4) GetVersion replies on 2026-05-09:
+	//   AN2 GetVersion reply payload:  00 00 01  -> major=0 minor=1
+	//   ACP2 GetVersion reply byte 3:  02         -> v2
+	// Spec §1.4 explicitly lists v1 as "Made v1; unsupported."
+	an2VersionMajor uint8 = 0
+	an2VersionMinor uint8 = 1
+	acp2Version     uint8 = 2
 )
 
 // Slot status codes emitted by GetSlotInfo. Values mirror the consumer's

--- a/internal/acp2/provider/set.go
+++ b/internal/acp2/provider/set.go
@@ -158,7 +158,13 @@ func (s *server) applySetEnum(e *entry, in *codec.Property) (codec.Property, cod
 			fmt.Errorf("enum idx %d not in EnumMap", idx)
 	}
 	e.param.Value = int64(idx)
-	return numericProp(codec.PIDValue, codec.NumTypeU32, u32Data(idx)), 0, nil
+	// Enum reply / announce uses vtype = NumTypePreset (9) per spec
+	// §5.2.2 "Property value type". Real Neuron emits 09 09 00 08
+	// + u32 BE on every Enum value reply (verified obj 17671/21127).
+	// Returning NumTypeU32 (6) here would make the announce body
+	// look like a Number to consumers — they'd then decode the body
+	// via Number/Uint and lose the enum-label resolution path.
+	return numericProp(codec.PIDValue, codec.NumTypePreset, u32Data(idx)), 0, nil
 }
 
 // enumIdxValid returns true when idx matches one of the wire ids

--- a/internal/acp2/provider/set.go
+++ b/internal/acp2/provider/set.go
@@ -4,7 +4,9 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+
 	"dhs/internal/acp2/codec"
+	"dhs/internal/export/canonical"
 )
 
 // applySet mutates e per an incoming set_property request and returns
@@ -124,8 +126,8 @@ func (s *server) applySetNumber(e *entry, in *codec.Property) (codec.Property, c
 	return codec.Property{}, codec.ErrInvalidValue, fmt.Errorf("number_type %d not writable", nt)
 }
 
-// applySetEnum validates the incoming index against the entry's options
-// and persists it as int64 in canonical.Parameter.Value.
+// applySetEnum validates the incoming wire idx against the entry's
+// EnumMap and persists it as int64 in canonical.Parameter.Value.
 //
 // Incoming / reply body:
 //
@@ -134,20 +136,57 @@ func (s *server) applySetNumber(e *entry, in *codec.Property) (codec.Property, c
 //	| 0      | pid   | u8     | 8 = value                                 |
 //	| 1      | vtype | u8     | reply uses NumTypeU32 (6)                 |
 //	| 2-3    | plen  | u16 BE | 8                                         |
-//	| 4-7    | idx   | u32 BE | option index; >= len(options) -> Invalid  |
+//	| 4-7    | idx   | u32 BE | option wire id; not in EnumMap -> Invalid |
 //
-// Spec reference: acp2_protocol.pdf §5.2.2 enum value
+// Real Neuron enums use sparse u32 wire ids (e.g. 641 "Main",
+// 786 "Automatic"); the option's wire idx is stored in EnumMap.Value.
+// The gate validates against the set of wire ids, NOT positional
+// 0..N-1 (which would reject every valid Set when EnumMap is sparse).
+//
+// When the canonical lacks an EnumMap (legacy comma/newline
+// Enumeration string), accept the positional 0..N-1 range as a
+// fallback so legacy fixtures keep round-tripping.
+//
+// Spec reference: acp2_protocol.pdf §4.3.4 set property + §5.2.2 enum value
 func (s *server) applySetEnum(e *entry, in *codec.Property) (codec.Property, codec.ACP2ErrStatus, error) {
 	if len(in.Data) < 4 {
 		return codec.Property{}, codec.ErrInvalidValue, fmt.Errorf("enum needs u32")
 	}
 	idx := binary.BigEndian.Uint32(in.Data[0:4])
-	opts := enumOptions(e.param)
-	if int(idx) >= len(opts) {
-		return codec.Property{}, codec.ErrInvalidValue, fmt.Errorf("enum index %d >= %d", idx, len(opts))
+	if !enumIdxValid(e.param, idx) {
+		return codec.Property{}, codec.ErrInvalidValue,
+			fmt.Errorf("enum idx %d not in EnumMap", idx)
 	}
 	e.param.Value = int64(idx)
 	return numericProp(codec.PIDValue, codec.NumTypeU32, u32Data(idx)), 0, nil
+}
+
+// enumIdxValid returns true when idx matches one of the wire ids
+// declared on the canonical's EnumMap, or — if the canonical has no
+// EnumMap — falls back to positional bounds against the legacy
+// Enumeration string.
+func enumIdxValid(p *canonical.Parameter, idx uint32) bool {
+	if len(p.EnumMap) > 0 {
+		for _, e := range p.EnumMap {
+			if uint32(e.Value) == idx {
+				return true
+			}
+		}
+		return false
+	}
+	// Legacy fallback: no EnumMap, count newline/comma-separated labels
+	// in the Enumeration string and accept idx in [0, N).
+	if p.Enumeration != nil && *p.Enumeration != "" {
+		raw := *p.Enumeration
+		n := 1
+		for _, c := range raw {
+			if c == '\n' || c == ',' {
+				n++
+			}
+		}
+		return int(idx) < n
+	}
+	return false
 }
 
 // applySetIPv4 decodes four packed octets and stores them as a dotted-quad

--- a/internal/acp2/provider/set_enum_test.go
+++ b/internal/acp2/provider/set_enum_test.go
@@ -1,0 +1,104 @@
+package acp2
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"dhs/internal/acp2/codec"
+	"dhs/internal/export/canonical"
+)
+
+// TestApplySetEnum_SparseEnumMap pins #346: applySetEnum must validate
+// the incoming wire idx against the sparse u32 ids declared in
+// canonical.EnumMap.Value, not the positional 0..N-1 length. Real
+// Neuron enums use ids like 786 "Automatic" / 791 "Full Speed";
+// rejecting them as "out of bounds" when len(EnumMap)==2 freezes the
+// VSM UI on every Set.
+func TestApplySetEnum_SparseEnumMap(t *testing.T) {
+	param := &canonical.Parameter{
+		Header: canonical.Header{Number: 21127, Identifier: "Fan Control",
+			Access: canonical.AccessReadWrite},
+		Type:  canonical.ParamEnum,
+		Value: int64(786),
+		EnumMap: []canonical.EnumEntry{
+			{Key: "Automatic", Value: 786},
+			{Key: "Full Speed", Value: 791},
+		},
+	}
+	e := &entry{
+		objID: 21127, label: param.Identifier, access: 0x03,
+		objType: codec.ObjTypeEnum, numType: codec.NumTypeU32,
+		param: param,
+	}
+	srv := &server{}
+
+	tests := []struct {
+		name    string
+		idx     uint32
+		wantErr codec.ACP2ErrStatus
+	}{
+		{"sparse_786_Automatic_accept", 786, 0},
+		{"sparse_791_FullSpeed_accept", 791, 0},
+		{"out_of_set_999_reject", 999, codec.ErrInvalidValue},
+		{"positional_0_reject_when_sparse", 0, codec.ErrInvalidValue},
+		{"positional_1_reject_when_sparse", 1, codec.ErrInvalidValue},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := make([]byte, 4)
+			binary.BigEndian.PutUint32(data, tt.idx)
+			in := &codec.Property{PID: codec.PIDValue,
+				VType: uint8(codec.NumTypeU32), PLen: 8, Data: data}
+			_, status, _ := srv.applySetEnum(e, in)
+			if status != tt.wantErr {
+				t.Errorf("idx=%d status=%d want=%d", tt.idx, status, tt.wantErr)
+			}
+			if tt.wantErr == 0 && param.Value != int64(tt.idx) {
+				t.Errorf("param.Value=%v want %d", param.Value, tt.idx)
+			}
+		})
+	}
+}
+
+// TestApplySetEnum_LegacyEnumeration covers the fallback path: when
+// canonical lacks an EnumMap (older fixtures with a comma/newline
+// Enumeration string only), accept idx in [0, N) where N is the
+// label count. Keeps legacy fixtures round-tripping.
+func TestApplySetEnum_LegacyEnumeration(t *testing.T) {
+	enum := "Off,On,Auto"
+	param := &canonical.Parameter{
+		Header: canonical.Header{Number: 1, Identifier: "Mode",
+			Access: canonical.AccessReadWrite},
+		Type:        canonical.ParamEnum,
+		Value:       int64(1),
+		Enumeration: &enum,
+	}
+	e := &entry{
+		objID: 1, label: param.Identifier, access: 0x03,
+		objType: codec.ObjTypeEnum, numType: codec.NumTypeU32,
+		param: param,
+	}
+	srv := &server{}
+
+	tests := []struct {
+		name    string
+		idx     uint32
+		wantErr codec.ACP2ErrStatus
+	}{
+		{"legacy_0_accept", 0, 0},
+		{"legacy_2_accept", 2, 0},
+		{"legacy_3_reject", 3, codec.ErrInvalidValue},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := make([]byte, 4)
+			binary.BigEndian.PutUint32(data, tt.idx)
+			in := &codec.Property{PID: codec.PIDValue,
+				VType: uint8(codec.NumTypeU32), PLen: 8, Data: data}
+			_, status, _ := srv.applySetEnum(e, in)
+			if status != tt.wantErr {
+				t.Errorf("idx=%d status=%d want=%d", tt.idx, status, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/acp2/wireshark/dhs_acpv2.lua
+++ b/internal/acp2/wireshark/dhs_acpv2.lua
@@ -476,16 +476,21 @@ local function parse_property(tvbuf, pktinfo, parent_tree, offset)
         tree:append_text(" (" .. count .. " children)")
 
     elseif pid_val == 15 then
-        -- options: each option = u32 index + null-terminated string + pad
-        -- data byte = num_options
+        -- options: variable-length per option, matching every shipping
+        -- ACP2 controller (Cerebrum, VSM, real Axon Neuron firmware).
+        -- Layout per record: u32 idx + NUL-terminated name + 0-3 byte
+        -- pad to next 4-byte boundary. data byte = N (num options).
+        --
+        -- Spec deviation: acp2_protocol.docx §5.4 row 15 specifies
+        -- fixed 72-byte stride; no production device implements that.
         tree:append_text(" (" .. data_val .. " options)")
         local pos = val_offset
         local opt_num = 0
         while pos < (val_offset + val_len) and opt_num < data_val do
+            local rec_start = pos
             if (pos + 4) > (val_offset + val_len) then break end
             tree:add(prop_f.opt_idx, tvbuf:range(pos, 4))
             pos = pos + 4
-            -- find null-terminated string
             local str_start = pos
             while pos < (val_offset + val_len) and tvbuf:range(pos, 1):uint() ~= 0 do
                 pos = pos + 1
@@ -493,12 +498,14 @@ local function parse_property(tvbuf, pktinfo, parent_tree, offset)
             if pos > str_start then
                 tree:add(prop_f.opt_str, tvbuf:range(str_start, pos - str_start))
             end
-            -- skip null terminator
+            -- consume NUL terminator
             if pos < (val_offset + val_len) then
                 pos = pos + 1
             end
-            -- skip padding to 4-byte boundary within option block
-            -- options are 72 bytes each per spec, but we parse dynamically
+            -- skip pad to next 4-byte boundary, relative to record start
+            local rec_used = pos - rec_start
+            local opt_pad = (4 - (rec_used % 4)) % 4
+            pos = pos + opt_pad
             opt_num = opt_num + 1
         end
 

--- a/internal/storage/identity_roundtrip_test.go
+++ b/internal/storage/identity_roundtrip_test.go
@@ -1,0 +1,185 @@
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"dhs/internal/export"
+	"dhs/internal/protocol"
+)
+
+// TestSaveLoadByIdentity_PreservesMetaAndContent pins the bug behind
+// the slot-1-overwrites-slot-0 report: SaveByIdentity used to route
+// through export.WriteJSON (hierarchical), and the matching reader
+// dropped Object.Meta entirely (no Meta field on the leaf decode
+// struct). After this fix, SaveByIdentity uses direct json.Encoder
+// and LoadByIdentity uses direct json.Decoder, so the snapshot is
+// byte-faithful across separate dhs invocations.
+//
+// The test uses a NEW TreeStore for the load step so we exercise the
+// real cross-process path (open file, decode flat) — same shape the
+// user hits when running `walk --slot 0` then `walk --slot 1` in two
+// shell invocations.
+func TestSaveLoadByIdentity_PreservesMetaAndContent(t *testing.T) {
+	dir := t.TempDir()
+	saver := NewTreeStore(dir)
+
+	objs := []protocol.Object{
+		{
+			Slot:  1,
+			ID:    70232,
+			Label: "Backup Input",
+			Path:  []string{"BOARD", "Stream"},
+			Kind:  protocol.KindEnum,
+			Meta: map[string]any{
+				"acp2.objType": uint8(2),
+				"acp2.numType": uint8(9),
+				"acp2.optionsMap": map[string]string{
+					"786": "Automatic",
+					"791": "Full Speed",
+				},
+			},
+		},
+	}
+	snap := &export.Snapshot{
+		Device:    export.DeviceInfo{IP: "10.41.40.4", Protocol: "acp2"},
+		Generator: "test",
+		CreatedAt: time.Now().UTC(),
+		Slots: []export.SlotDump{{
+			Slot:     1,
+			WalkedAt: time.Now().UTC(),
+			Objects:  objs,
+		}},
+	}
+
+	if err := saver.SaveByIdentity("SHPRM1@0.7", snap); err != nil {
+		t.Fatalf("SaveByIdentity: %v", err)
+	}
+
+	// Fresh store — simulate a separate dhs process opening the same
+	// .cache directory.
+	loader := NewTreeStore(dir)
+	got, err := loader.LoadByIdentity("SHPRM1@0.7")
+	if err != nil || got == nil {
+		t.Fatalf("LoadByIdentity: snap=%v err=%v", got, err)
+	}
+
+	if len(got.Slots) != 1 || len(got.Slots[0].Objects) != 1 {
+		t.Fatalf("snap shape: slots=%d objs=%d, want 1/1",
+			len(got.Slots),
+			func() int {
+				if len(got.Slots) == 0 {
+					return -1
+				}
+				return len(got.Slots[0].Objects)
+			}())
+	}
+	rt := got.Slots[0].Objects[0]
+	if rt.ID != 70232 || rt.Label != "Backup Input" || rt.Kind != protocol.KindEnum {
+		t.Errorf("base fields lost: id=%d label=%q kind=%v", rt.ID, rt.Label, rt.Kind)
+	}
+	if len(rt.Path) != 2 || rt.Path[0] != "BOARD" || rt.Path[1] != "Stream" {
+		t.Errorf("Path lost: %v", rt.Path)
+	}
+	if rt.Meta == nil {
+		t.Fatalf("Meta dropped on round-trip — DM cache bug regressed")
+	}
+	// JSON round-trip turns uint8 -> float64; tolerate that.
+	if v, ok := rt.Meta["acp2.objType"]; !ok || v == nil {
+		t.Errorf("Meta[acp2.objType] missing: meta=%v", rt.Meta)
+	}
+	if om, ok := rt.Meta["acp2.optionsMap"]; !ok {
+		t.Errorf("Meta[acp2.optionsMap] missing")
+	} else if m, _ := om.(map[string]any); m == nil || m["786"] != "Automatic" {
+		t.Errorf("optionsMap content lost: %v", om)
+	}
+}
+
+// TestSaveLoadByIdentity_MultiInvocationMerge reproduces the exact
+// user report: walk slot 0 then walk slot 1 in two separate dhs
+// invocations. Each invocation re-creates the TreeStore. After both,
+// the file must contain BOTH slots with their original object content
+// — not slot 1 alone (the bug) and not slot 0 alone.
+func TestSaveLoadByIdentity_MultiInvocationMerge(t *testing.T) {
+	dir := t.TempDir()
+	identity := "SHPRM1@0.7"
+
+	// Invocation 1: walk slot 0 — fresh store, fresh snapshot, save.
+	{
+		store := NewTreeStore(dir)
+		existing, _ := store.LoadByIdentity(identity)
+		if existing != nil {
+			t.Fatalf("invocation 1 expected miss, got %v", existing)
+		}
+		snap := &export.Snapshot{
+			Device:    export.DeviceInfo{IP: "10.41.40.4", Protocol: "acp2"},
+			Generator: "test",
+			CreatedAt: time.Now().UTC(),
+			Slots: []export.SlotDump{{
+				Slot:     0,
+				WalkedAt: time.Now().UTC(),
+				Objects: []protocol.Object{{
+					Slot: 0, ID: 1, Label: "BOARD",
+					Path: []string{"BOARD"},
+					Kind: protocol.KindString,
+					Meta: map[string]any{"acp2.objType": uint8(0)},
+				}},
+			}},
+		}
+		if err := store.SaveByIdentity(identity, snap); err != nil {
+			t.Fatalf("invocation 1 save: %v", err)
+		}
+	}
+
+	// Invocation 2: walk slot 1 — fresh store, load existing, merge slot 1, save.
+	{
+		store := NewTreeStore(dir)
+		existing, err := store.LoadByIdentity(identity)
+		if err != nil || existing == nil {
+			t.Fatalf("invocation 2 expected hit, got snap=%v err=%v", existing, err)
+		}
+		if len(existing.Slots) != 1 || existing.Slots[0].Slot != 0 {
+			t.Fatalf("invocation 2 sees wrong slots: %+v", existing.Slots)
+		}
+		if len(existing.Slots[0].Objects) != 1 || existing.Slots[0].Objects[0].Label != "BOARD" {
+			t.Fatalf("invocation 2 lost slot 0 content: %+v", existing.Slots[0].Objects)
+		}
+		existing.Slots = append(existing.Slots, export.SlotDump{
+			Slot:     1,
+			WalkedAt: time.Now().UTC(),
+			Objects: []protocol.Object{{
+				Slot: 1, ID: 70232, Label: "Backup Input",
+				Path: []string{"BOARD", "Stream"},
+				Kind: protocol.KindEnum,
+				Meta: map[string]any{"acp2.objType": uint8(2)},
+			}},
+		})
+		if err := store.SaveByIdentity(identity, existing); err != nil {
+			t.Fatalf("invocation 2 save: %v", err)
+		}
+	}
+
+	// Invocation 3: read final state — both slots present with content.
+	store := NewTreeStore(dir)
+	final, err := store.LoadByIdentity(identity)
+	if err != nil || final == nil {
+		t.Fatalf("final load: %v", err)
+	}
+	if len(final.Slots) != 2 {
+		t.Fatalf("final file should hold 2 slots, got %d (slot 1 overwrote slot 0?)", len(final.Slots))
+	}
+	gotSlots := map[int]string{}
+	for _, sd := range final.Slots {
+		if len(sd.Objects) == 0 {
+			t.Errorf("slot %d has zero objects after merge", sd.Slot)
+			continue
+		}
+		gotSlots[sd.Slot] = sd.Objects[0].Label
+	}
+	if gotSlots[0] != "BOARD" {
+		t.Errorf("slot 0 lost original content: got %q want %q", gotSlots[0], "BOARD")
+	}
+	if gotSlots[1] != "Backup Input" {
+		t.Errorf("slot 1 missing: got %q want %q", gotSlots[1], "Backup Input")
+	}
+}

--- a/internal/storage/tree_store.go
+++ b/internal/storage/tree_store.go
@@ -11,6 +11,7 @@
 package storage
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -159,6 +160,25 @@ func (s *TreeStore) identityPath(identity string) string {
 // hot-loads each at watch start. Object values are NOT stripped here
 // (caller decides) — DM cache often wants labels + types but values
 // are consulted from live get/watch anyway.
+//
+// Format: flat JSON via stdlib json.Encoder, NOT export.WriteJSON.
+// The exporter's hierarchical writer is lossy on three fields the DM
+// cache absolutely needs to round-trip across separate dhs invocations
+// (one walk per slot, multi-process):
+//
+//   - Object.Meta — walker stashes acp2.objType / numType / optionsMap
+//     here; the hierarchical reader's leaf struct has no Meta field, so
+//     load → save → load drops type info silently.
+//   - Object.Path — buildJSONTree groups objects by Path; root-level
+//     objects (no Path) become orphaned _meta entries that flatten
+//     back to nothing, effectively wiping the slot dump.
+//   - Object.Value — the hierarchical writer omits values for some
+//     kinds, the reader re-parses CSV strings, and round-trip fidelity
+//     is best-effort.
+//
+// Direct json.Marshal preserves the exact protocol.Object struct on
+// disk, so successive walks of slot 0 + slot 1 + slot N accumulate
+// into the same file with no field loss.
 func (s *TreeStore) SaveByIdentity(identity string, snap *export.Snapshot) error {
 	if identity == "" {
 		return fmt.Errorf("storage: SaveByIdentity: empty identity")
@@ -176,10 +196,12 @@ func (s *TreeStore) SaveByIdentity(identity string, snap *export.Snapshot) error
 	if err != nil {
 		return fmt.Errorf("storage: create %s: %w", tmp, err)
 	}
-	if err := export.WriteJSON(f, snap); err != nil {
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(snap); err != nil {
 		_ = f.Close()
 		_ = os.Remove(tmp)
-		return fmt.Errorf("storage: write: %w", err)
+		return fmt.Errorf("storage: encode: %w", err)
 	}
 	if err := f.Close(); err != nil {
 		_ = os.Remove(tmp)
@@ -195,6 +217,13 @@ func (s *TreeStore) SaveByIdentity(identity string, snap *export.Snapshot) error
 // LoadByIdentity reads the identity-keyed cache. Returns (nil, nil)
 // on cache miss (file not present); err non-nil only on read /
 // decode failures.
+//
+// Decoder: stdlib json.Decoder direct into *export.Snapshot. Pairs
+// with SaveByIdentity's flat-format writer above. We deliberately do
+// NOT route through export.ReadJSON — its flat-vs-hierarchical
+// auto-detect requires len(Slots[0].Objects) > 0 to accept the flat
+// path, and a freshly-initialised snapshot with an empty slot 0 dump
+// would fall through to the lossy hierarchical reader.
 func (s *TreeStore) LoadByIdentity(identity string) (*export.Snapshot, error) {
 	if identity == "" {
 		return nil, fmt.Errorf("storage: LoadByIdentity: empty identity")
@@ -208,11 +237,11 @@ func (s *TreeStore) LoadByIdentity(identity string) (*export.Snapshot, error) {
 		return nil, fmt.Errorf("storage: open %s: %w", path, err)
 	}
 	defer func() { _ = f.Close() }()
-	snap, err := export.ReadJSON(f)
-	if err != nil {
+	var snap export.Snapshot
+	if err := json.NewDecoder(f).Decode(&snap); err != nil {
 		return nil, fmt.Errorf("storage: decode %s: %w", path, err)
 	}
-	return snap, nil
+	return &snap, nil
 }
 
 // FindCardName extracts the Card Name from a list of objects.

--- a/internal/storage/tree_store.go
+++ b/internal/storage/tree_store.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"dhs/internal/export"
@@ -130,6 +131,83 @@ func (s *TreeStore) Load(ip string, slot int) (*export.Snapshot, error) {
 	}
 	defer func() { _ = f.Close() }()
 
+	snap, err := export.ReadJSON(f)
+	if err != nil {
+		return nil, fmt.Errorf("storage: decode %s: %w", path, err)
+	}
+	return snap, nil
+}
+
+// identityPath returns the file path for an identity-keyed cache.
+// Identity strings come straight from the consumer (e.g.
+// "SHPRM1@0.7"); we sanitise to keep them filesystem-safe across
+// Windows + POSIX.
+func (s *TreeStore) identityPath(identity string) string {
+	safe := identity
+	for _, ch := range []string{"/", "\\", ":", "*", "?", "\"", "<", ">", "|"} {
+		safe = strings.ReplaceAll(safe, ch, "_")
+	}
+	return filepath.Join(s.baseDir, "dm", safe+".json")
+}
+
+// SaveByIdentity writes a multi-slot snapshot keyed by stable device
+// identity (e.g. "SHPRM1@0.7"). Unlike Save, the same cache file is
+// reused across IP changes / re-cabling — only a Card swap or
+// firmware upgrade invalidates it.
+//
+// The snapshot's Slots may carry multiple slot dumps; the consumer
+// hot-loads each at watch start. Object values are NOT stripped here
+// (caller decides) — DM cache often wants labels + types but values
+// are consulted from live get/watch anyway.
+func (s *TreeStore) SaveByIdentity(identity string, snap *export.Snapshot) error {
+	if identity == "" {
+		return fmt.Errorf("storage: SaveByIdentity: empty identity")
+	}
+	if snap == nil {
+		return fmt.Errorf("storage: SaveByIdentity: nil snapshot")
+	}
+	path := s.identityPath(identity)
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("storage: mkdir %s: %w", dir, err)
+	}
+	tmp := path + ".tmp"
+	f, err := os.Create(tmp)
+	if err != nil {
+		return fmt.Errorf("storage: create %s: %w", tmp, err)
+	}
+	if err := export.WriteJSON(f, snap); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return fmt.Errorf("storage: write: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("storage: close: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("storage: rename: %w", err)
+	}
+	return nil
+}
+
+// LoadByIdentity reads the identity-keyed cache. Returns (nil, nil)
+// on cache miss (file not present); err non-nil only on read /
+// decode failures.
+func (s *TreeStore) LoadByIdentity(identity string) (*export.Snapshot, error) {
+	if identity == "" {
+		return nil, fmt.Errorf("storage: LoadByIdentity: empty identity")
+	}
+	path := s.identityPath(identity)
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("storage: open %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
 	snap, err := export.ReadJSON(f)
 	if err != nil {
 		return nil, fmt.Errorf("storage: decode %s: %w", path, err)


### PR DESCRIPTION
## Summary

Hot-load the cached DM (= MasterView, per DHS 2016 vocabulary) into
the in-memory tree before Subscribe fires so announce decoding works
from frame 1 — eliminates the cold-start "idx N" gap on slot 1 watch
(slow walk = 30–60 s on 49 827 objs).

After the #355 simplification in this PR, the DM cache is **single,
identity-keyed, multi-slot**:

```
.cache/dm/<CardName>@<HardwareVersion>.json
```

The legacy IP-keyed `.cache/devices/<ip>/slot_<n>.json` is no longer
written or read for ACP2. ACP1 / Ember+ keep the IP layer (no
identity probe contract on those plugins today).

## How it works

1. **Identity probe** at watch start — `Plugin.IdentityProbe(ctx)`
   walks slot 0 (~214 objs, sub-second) and concatenates labels:
   `<CardName>@<HardwareVersion>`. Real Neuron 10.41.40.4 →
   `SHPRM1@0.7`.
2. **`treeStore.LoadByIdentity(identity)`** reads
   `.cache/dm/<identity>.json` (multi-slot Snapshot).
3. For each cached slot, **`Plugin.SeedTreeFromCachedObjects(slot, objs)`**
   reconstructs the WalkedTree parallel arrays from per-object Meta
   and stores it in `p.trees`.
4. The fresh background walk runs as before — refreshes any drift.
5. Walk completion saves the new identity-keyed file. Successive
   walks of any slot (slot 0 + slot 1 + …) merge into one file
   (`saveIdentityCache` merge), giving a single MasterView per device.

## Why identity, not IP

Per DHS 2016 vocabulary, the device's data model is the **MasterView**
— a stable schema bound to the card / firmware. Identity
(Card Name + Hardware Version) is the source of truth. IP is a
current address that can change with re-cabling, DHCP renewal, or
moving cards between racks.

Before this PR's #355 follow-up, the producer at `10.100.0.103`
(identity `SHPIO@0.7`) and the real Neuron at `10.41.40.4` (identity
`SHPRM1@0.7`) wrote two separate IP-keyed slot files, none of which
fed announce decoding. Now both have **one MasterView file each**,
and the fully-walked content seeds the tree at next watch start.

## Branch ordering

Sits on top of `fix/acp2-spec51-pid-compliance` (PR #350) which
contains all the strict-spec wire fixes. Once #350 merges into the
closeout branch, this PR rebases cleanly with no conflicts.

## Test plan

- [x] `go build ./...` green on Windows native
- [x] `go test ./...` green; new tests:
  - `cmd/dhs/cmd_watch_cache_test.go` — 5 sub-tests pinning the
    routing decision (ACP2 → identity, others → IP, multi-slot
    merge, empty-identity safety)
  - `internal/acp2/consumer/seed_cache_test.go` — 2 sub-tests
    pinning seed paths (in-process Meta + post-JSON Meta)
- [x] Producer v11 deployed to LXC `10.100.0.103:2072`
- [ ] Manual: `dhs consumer acp2 walk 10.100.0.103 --slot 0` and
  `--slot 1` populate `.cache/dm/SHPIO@0.7.json` (single file, two
  slot dumps); subsequent `watch --slot 1` hot-loads and shows enum
  labels from the first announce. (Pending live test.)

## Files

| File | Change |
|---|---|
| `internal/acp2/consumer/walker.go` | walker writes `acp2.objType` / `numType` / `optionsMap` to `obj.Meta` |
| `internal/acp2/consumer/plugin.go` | `IdentityProbe(ctx)` + `SeedTreeFromCachedObjects(slot, objs)` + helpers |
| `internal/acp2/consumer/seed_cache_test.go` (new) | 2 sub-tests pin both seed paths |
| `internal/storage/tree_store.go` | `SaveByIdentity` / `LoadByIdentity` next to existing IP-keyed |
| `cmd/dhs/cmd_watch.go` | identity probe → `LoadByIdentity` → `SeedTreeFromCachedObjects` before Subscribe; IP-keyed loader gated off for ACP2; `walkSlotAndCache` delegates to `saveSlotCache`; new `identityProber` interface |
| `cmd/dhs/cmd_walk.go` | both `--slot N` and `--all` paths route through `saveSlotCache` (was IP-keyed only) |
| `cmd/dhs/cmd_watch_cache_test.go` (new) | 5 sub-tests pin the proto-aware routing decision |

## Cache layout

```
.cache/dm/SHPRM1@0.7.json      ← ACP2 only — multi-slot MasterView
.cache/devices/<ip>/slot_<n>.json ← ACP1 + Ember+ only (back-compat)
```

Identity-keyed cache survives re-cabling / IP changes; only a Card
swap or firmware upgrade invalidates it.

## Out of scope

- ACP1 / Ember+ identity-keyed cache (no identity probe contract).
- Cleanup of existing `.cache/devices/<ip>/` ACP2 entries (gitignored,
  harmless to leave).
- Cache invalidation on firmware patches that don't bump
  Hardware Version (accepted risk; user can clear cache).

Closes #353, closes #355.

🤖 Generated with [Claude Code](https://claude.com/claude-code)