### PR TITLE
docs(acp): per-protocol runbook + CLI usage sweep + CLAUDE.md trim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,75 +180,20 @@ See [project_scale_requirements] in memory.
 
 ## Performance + metrics (every protocol)
 
-Every protocol's transport / session layer MUST expose live metrics on
-its connector:
+Every transport / session layer exposes live metrics on its connector:
+frames/bytes (rx, tx), latency p50/p95/p99 (µs), errors (NAK, decode,
+reconnect), memory, CPU%, uptime. Use `atomic.Uint64` for counters,
+log-linear histogram for latency, no mutex on the hot path. The
+neutral `ConnectorMetrics` struct lives in `internal/protocol/` and
+`internal/provider/`; each plugin exposes `Metrics()` on its session.
 
-- **Frames**: rx/sec, tx/sec, rx total, tx total
-- **Bytes**: rx/sec, tx/sec, rx total, tx total
-- **Latency**: rx→tx handler turnaround p50/p95/p99 (µs)
-- **Errors**: NAK count, frame-decode errors, reconnect count
-- **Memory**: bytes attributable to connector buffers + tree
-- **CPU %**: share of process CPU in this connector's goroutines
-- **Uptime**: last-frame timestamp per direction
+Producer surface: `dhs producer <proto> serve --metrics-addr :9100`
+serves `/metrics` (Prometheus + OpenMetrics) and `/snapshot.json`. CLI
+view: `dhs metrics show`. Full Grafana / Prometheus / Loki stack under
+`docs/deployment/grafana/`.
 
-Neutral `ConnectorMetrics` struct defined in `internal/protocol/` (for
-consumer) and `internal/provider/` (for provider); each plugin exposes
-`Metrics() ConnectorMetrics` on its session. Use `atomic.Uint64` for
-counters (no mutex on the hot path); HDR/log-linear histogram for
-latency. Do not pull in Prometheus client-libs until dhs-srv wires a
-scrape endpoint.
-
-Surfaces:
-
-1. Printed on session close in debug mode.
-2. Emitted as a `protocol.Event` tick every ~10 s in watch mode.
-3. Reachable via HTTP from dhs-srv when that lands.
-
-See [feedback_transport_metrics] and [project_connector_metrics_v2]
-in memory.
-
-### Metrics surface on the producer (landed 2026-04-22)
-
-`internal/metrics/` package provides:
-- `Connector` — per-session counters: rx/tx frames + bytes, per-cmd
-  `[256]atomic.Uint64` hit counts (rx and tx split), latency histogram
-  (7 log-linear µs buckets), errors (decode, NAK, timeout, reconnect),
-  Task-Manager fields (CPU%, treeBytes, poolBytes, inflightBytes,
-  diskBytes).
-- `Process` — runtime.MemStats + NumGoroutine + GC snapshot with a
-  periodic sampler.
-- `PromRegistry` — wires `prometheus/client_golang` GoCollector +
-  ProcessCollector + custom `dhs_connector_*` / `dhs_process_*`
-  collectors.
-- `WriteCSV` / `WriteMarkdown` — snapshot renderers for the CLI
-  export subcommand.
-
-Producer wiring:
-```
-dhs producer <proto> serve --tree ... --port N \
-    --metrics-addr :9100 \
-    --log-format json
-```
-- `/metrics` serves Prom text exposition + OpenMetrics.
-- `/snapshot.json` serves Snapshot + ProcessSnapshot JSON.
-- `--log-format json` emits `slog.NewJSONHandler` output for
-  Loki/Promtail.
-
-Consumer CLI:
-```
-dhs metrics show                  # live Task-Manager view (MD)
-dhs metrics export --format csv   # dump snapshot to CSV
-dhs metrics export --format md --file report.md
-```
-
-Every protocol plugin satisfies the optional `metricsExposer`
-interface (`Metrics() *metrics.Connector`) to participate in
-`--metrics-addr`. Probel is wired today; ACP1 / ACP2 / Ember+
-roll in D8 of the v2 chain.
-
-Full Grafana + Prometheus + Loki stack under
-`docs/deployment/grafana/`: docker-compose, alert rules YAML,
-pre-provisioned dashboard JSON.
+See [`project_connector_metrics_v2`](.) and
+[`feedback_transport_metrics`](.) in memory for the full contract.
 
 ---
 
@@ -368,36 +313,15 @@ DHSError (base)
 
 ## Storage
 
-No database. No Redis. Files only.
+Files only. No database. No Redis. Per ADR-0020 buckets:
 
-```
-Linux:    ~/.local/share/dhs/
-macOS:    ~/Library/Application Support/dhs/
-Windows:  %APPDATA%\dhs\
-Override: --data-dir flag or config.yaml
-```
+- **User config**: per-OS data dir (`~/.local/share/dhs/` etc.) — overridable via `--data-dir`.
+- **Cache** (gitignored): `.cache/` next to the binary. Per-protocol cache shape lives in [`internal/<proto>/docs/runbook.md`](internal/) (e.g. ACP2 = identity-keyed `dm/<id>.json`, ACP1 = IP-keyed `devices/<ip>/slot_<n>.json`).
+- **Captures** (gitignored, no LFS): `captures/<proto>/<scenario>/`.
 
-- `devices.yaml` → written only on add/remove
-- `slot_{n}.yaml` → written only after a successful walk
-- log entries → never written; in-memory circular buffer (1000 entries)
-
-### Value freshness (cache invariants)
-
-Property values ARE written to disk as a **stale cache** for fast startup.
-Values on disk are NEVER trusted — they load as `stale` and must be
-confirmed by a live source (announcement / get / walk) before being treated
-as current.
-
-States: `stale` → `live` → `updated`.
-
-Startup priority: load stale → subscribe to what the view needs →
-background walk fills the rest. If a walk result and an announcement race
-for the same object, the announcement wins.
-
-> **Performance at scale:** 100-1000 devices × 44k objects/slot needs a
-> smart scheduling algorithm (staggered walks, per-device rate limits,
-> subscription-first). Not implemented yet — revisit when the future
-> `dhs-srv` handles multiple devices concurrently.
+Value freshness: values load as **stale**, confirmed by a live source
+(announce / get / walk) before being treated as current. Announces win
+over walk if they race for the same object.
 
 ---
 
@@ -423,14 +347,10 @@ for the same object, the announcement wins.
 
 ### Testing
 
-- Unit tests: table-driven with expected byte sequences pulled from the
-  authoritative spec, not from working code.
-- Integration tests: `//go:build integration`, skip without env var:
-  - ACP1: `ACP1_TEST_HOST`
-  - ACP2: `ACP2_TEST_HOST`
-  - Ember+: `EMBERPLUS_TEST_HOST`
-- CI runs unit tests only — never integration against real or emulated
-  devices.
+Unit tests: table-driven, expected bytes from the spec (not working code).
+Integration tests: `//go:build integration`, gated on per-protocol env vars
+(`ACP1_TEST_HOST`, `ACP2_TEST_HOST`, `EMBERPLUS_TEST_HOST`). CI runs
+unit only — never integration.
 
 ### Naming
 

--- a/cmd/dhs/cmd_diag.go
+++ b/cmd/dhs/cmd_diag.go
@@ -17,7 +17,7 @@ func runDiag(ctx context.Context, args []string) error {
 	slot := fs.Int("slot", 0, "target slot")
 	host, rest, err := popHost(args)
 	if err != nil {
-		return fmt.Errorf("usage: acp diag <host> [--slot N]")
+		return fmt.Errorf("usage: dhs consumer <proto> diag <host> [--slot N]")
 	}
 	_ = fs.Parse(rest)
 	_ = cf

--- a/cmd/dhs/cmd_diff.go
+++ b/cmd/dhs/cmd_diff.go
@@ -35,7 +35,7 @@ func runDiff(ctx context.Context, args []string) error {
 	}
 	rest := fs.Args()
 	if len(rest) != 2 {
-		return fmt.Errorf("usage: acp diff <before-tree.json> <after-tree.json> [--format text|changelog] [--version V] [--date D] [--into PATH]")
+		return fmt.Errorf("usage: dhs diff <before-tree.json> <after-tree.json> [--format text|changelog] [--version V] [--date D] [--into PATH]")
 	}
 
 	before, err := loadCanonicalExport(rest[0])

--- a/cmd/dhs/cmd_export.go
+++ b/cmd/dhs/cmd_export.go
@@ -27,7 +27,7 @@ func runExport(ctx context.Context, args []string) error {
 	pathFlag := fs.String("path", "", "filter objects by path prefix (e.g. BOARD, PSU/1)")
 	host, rest, err := popHost(args)
 	if err != nil {
-		return fmt.Errorf("usage: acp export <host> [--format F] [--out FILE]")
+		return fmt.Errorf("usage: dhs consumer <proto> export <host> [--format json|yaml|csv] [--out FILE] [--slot N] [--path SEG.SEG]")
 	}
 	_ = fs.Parse(rest)
 

--- a/cmd/dhs/cmd_extract.go
+++ b/cmd/dhs/cmd_extract.go
@@ -40,7 +40,7 @@ func runExtract(ctx context.Context, args []string) error {
 
 	host, rest, err := popHost(args)
 	if err != nil {
-		return fmt.Errorf("usage: acp extract <host> --protocol P --manufacturer M --product X --direction D --version V --out DIR [--slot N]")
+		return fmt.Errorf("usage: dhs extract <host> --protocol P --manufacturer M --product X --direction D --version V --out DIR [--slot N]")
 	}
 	_ = fs.Parse(rest)
 

--- a/cmd/dhs/cmd_get.go
+++ b/cmd/dhs/cmd_get.go
@@ -21,7 +21,7 @@ func runGet(ctx context.Context, args []string) error {
 	pid := fs.Int("pid", 0, "ACP2 property id to read (0 = default pid=8 value; set to read object_type/label/access/etc.)")
 	host, rest, err := popHost(args)
 	if err != nil {
-		return fmt.Errorf("usage: acp get <host> --slot N (--path P | --label L | --id I)")
+		return fmt.Errorf("usage: dhs consumer <proto> get <host> --slot N (--path P | --label L | --id I) [--capture out.jsonl]")
 	}
 	_ = fs.Parse(rest)
 	// Ember+ has no slot concept; default to 0 so users don't have to pass it.

--- a/cmd/dhs/cmd_import.go
+++ b/cmd/dhs/cmd_import.go
@@ -65,7 +65,7 @@ func runImport(ctx context.Context, args []string) error {
 
 	host, rest, err := popHost(args)
 	if err != nil {
-		return fmt.Errorf("usage: acp import <host> --file SNAPSHOT [--slot N] [--id N ...| --path P ...] [--dry-run]")
+		return fmt.Errorf("usage: dhs consumer <proto> import <host> --file SNAPSHOT [--slot N] [--id N ...| --path P ...] [--dry-run]")
 	}
 	_ = fs.Parse(rest)
 	if *file == "" {

--- a/cmd/dhs/cmd_info.go
+++ b/cmd/dhs/cmd_info.go
@@ -11,7 +11,7 @@ func runInfo(ctx context.Context, args []string) error {
 	cf := addCommonFlags(fs)
 	host, rest, err := popHost(args)
 	if err != nil {
-		return fmt.Errorf("usage: acp info <host>")
+		return fmt.Errorf("usage: dhs consumer <proto> info <host> [--port N] [--timeout DUR]")
 	}
 	_ = fs.Parse(rest)
 

--- a/cmd/dhs/cmd_invoke.go
+++ b/cmd/dhs/cmd_invoke.go
@@ -18,7 +18,7 @@ func runInvoke(ctx context.Context, args []string) error {
 	argsStr := fs.String("args", "", "comma-separated arguments (e.g. 3,5)")
 	host, rest, err := popHost(args)
 	if err != nil {
-		return fmt.Errorf("usage: acp invoke <host> --path <func.path> [--args val1,val2,...]")
+		return fmt.Errorf("usage: dhs consumer <proto> invoke <host> --path <func.path> [--args val1,val2,...]")
 	}
 	_ = fs.Parse(rest)
 	if *funcPath == "" {

--- a/cmd/dhs/cmd_matrix.go
+++ b/cmd/dhs/cmd_matrix.go
@@ -20,7 +20,7 @@ func runMatrix(ctx context.Context, args []string) error {
 	op := fs.String("op", "absolute", "operation: absolute, connect, disconnect")
 	host, rest, err := popHost(args)
 	if err != nil {
-		return fmt.Errorf("usage: acp matrix <host> --path <matrix.path> --target N --sources N[,N,...] [--op absolute|connect|disconnect]")
+		return fmt.Errorf("usage: dhs consumer <proto> matrix <host> --path <matrix.path> --target N --sources N[,N,...] [--op absolute|connect|disconnect]")
 	}
 	_ = fs.Parse(rest)
 	if *matrixPath == "" {

--- a/cmd/dhs/cmd_profile.go
+++ b/cmd/dhs/cmd_profile.go
@@ -41,7 +41,7 @@ func runProfile(ctx context.Context, args []string) error {
 	cf := addCommonFlags(fs)
 	host, rest, err := popHost(args)
 	if err != nil {
-		return fmt.Errorf("usage: acp profile <host> [--port 9000] [--timeout DUR]")
+		return fmt.Errorf("usage: dhs consumer <proto> profile <host> [--port N] [--timeout DUR]")
 	}
 	_ = fs.Parse(rest)
 

--- a/cmd/dhs/cmd_set.go
+++ b/cmd/dhs/cmd_set.go
@@ -22,7 +22,7 @@ func runSet(ctx context.Context, args []string) error {
 	valueHex := fs.String("raw", "", "raw wire bytes as hex — escape hatch bypassing typed encoding")
 	host, rest, err := popHost(args)
 	if err != nil {
-		return fmt.Errorf("usage: acp set <host> --slot N (--path P | --label L | --id I) --value <v>")
+		return fmt.Errorf("usage: dhs consumer <proto> set <host> --slot N (--path P | --label L | --id I) (--value <v> | --raw <hex>)")
 	}
 	_ = fs.Parse(rest)
 	// Detect whether --value / --raw were explicitly passed (even if

--- a/cmd/dhs/cmd_stream.go
+++ b/cmd/dhs/cmd_stream.go
@@ -25,7 +25,7 @@ func runStream(ctx context.Context, args []string) error {
 	streamID := fs.Int64("id", -1, "streamIdentifier filter (-1 = any)")
 	host, rest, err := popHost(args)
 	if err != nil {
-		return fmt.Errorf("usage: acp stream <host> [--id N]")
+		return fmt.Errorf("usage: dhs consumer <proto> stream <host> [--id N]")
 	}
 	_ = fs.Parse(rest)
 

--- a/cmd/dhs/cmd_walk.go
+++ b/cmd/dhs/cmd_walk.go
@@ -25,7 +25,7 @@ func runWalk(ctx context.Context, args []string) error {
 	pathFlag := fs.String("path", "", "filter objects by path prefix (e.g. BOARD, PSU/1)")
 	host, rest, err := popHost(args)
 	if err != nil {
-		return fmt.Errorf("usage: acp walk <host> (--slot N | --all)")
+		return fmt.Errorf("usage: dhs consumer <proto> walk <host> (--slot N | --all) [--path SEG.SEG] [--filter STR]")
 	}
 	_ = fs.Parse(rest)
 	// Ember+ has no slot concept (spec: single flat tree per provider);

--- a/cmd/dhs/cmd_watch.go
+++ b/cmd/dhs/cmd_watch.go
@@ -53,7 +53,7 @@ func runWatch(ctx context.Context, args []string) error {
 		"DM library root for hot-plug enrichment (#254). Empty disables identity probe + seed.")
 	host, rest, err := popHost(args)
 	if err != nil {
-		return fmt.Errorf("usage: acp watch <host> [--slot N | --slots 1,3,7 | --slots all] [--no-walk] [--auto-walk-on-plug] [--dm-library <path>] [--group G] [--label L]")
+		return fmt.Errorf("usage: dhs consumer <proto> watch <host> [--slot N | --slots 1,3,7 | --slots all] [--no-walk] [--auto-walk-on-plug] [--dm-library <path>] [--group G] [--label L]")
 	}
 	_ = fs.Parse(rest)
 

--- a/internal/acp1/docs/README.md
+++ b/internal/acp1/docs/README.md
@@ -2,6 +2,7 @@
 
 | Role | Doc | Status |
 |---|---|---|
+| Operator runbook | [runbook.md](runbook.md) | ✓ shipping |
 | Consumer | [consumer.md](consumer.md) | ✓ shipping |
 | Provider | [provider.md](provider.md) | TODO |
 

--- a/internal/acp1/docs/runbook.md
+++ b/internal/acp1/docs/runbook.md
@@ -1,0 +1,103 @@
+# ACP1 — operational runbook
+
+Quick-reference card for operators. For wire-format detail see
+[CLAUDE.md](../CLAUDE.md); for in-depth consumer behaviour see
+[consumer.md](consumer.md).
+
+---
+
+## Transport matrix
+
+| Mode | Port | Notes |
+|---|---:|---|
+| UDP direct (Mode A) | 2071 | One datagram = one ACP1 message. Stateless. Simulator + most legacy fixtures. |
+| TCP direct (Mode B) | 2071 | u32 BE MLEN prefix per message (MLEN > 8). |
+| AN2/TCP (Mode C) | 2072 | AN2 dlen frame. Required for receiving announces (per-session `EnableProtocolEvents([1])`). |
+
+The consumer auto-detects the transport with `--transport tcp` / `--transport udp` / `--transport an2`. Default: UDP. Receiving announces requires AN2.
+
+## Verb reference
+
+### Consumer
+
+| Verb | What it does | Common flags | Cache effect |
+|---|---|---|---|
+| `dhs consumer acp1 info <ip>` | Read identity + slot count | `--transport`, `--port`, `--timeout` | none |
+| `dhs consumer acp1 walk <ip>` | Discover one slot's full DM | `--slot N` or `--all`, `--path BOARD`, `--filter foo` | writes `.cache/devices/<ip>/slot_<n>.json` (IP-keyed; ACP1 has no identity probe) |
+| `dhs consumer acp1 get <ip>` | Read one property | `--slot N --group control --id 4` (or `--label`) | reads cached labels for resolution |
+| `dhs consumer acp1 set <ip>` | Write one property | same as `get` plus `--value …` | none (live device only) |
+| `dhs consumer acp1 watch <ip>` | Subscribe to announces | `--slot N`, `--group G`, `--label L`, `--id I`, `--no-walk`, `--auto-walk-on-plug` | reads `slot_<n>.json` for label resolution while live tree fills |
+| `dhs consumer acp1 export <ip> --format json|yaml|csv` | Dump tree to a file | `--out path.json` | none |
+| `dhs consumer acp1 import <file>` | Replay a captured tree | offline | none |
+
+### Provider
+
+| Verb | What it does | Required flags |
+|---|---|---|
+| `dhs producer acp1 serve --tree fixture.json --port 2071 --bind <ip>` | Serve UDP + TCP + AN2 from one fixture | `--tree`, `--port`, optional `--bind` (VIP) |
+
+The provider listens on **all three transports simultaneously** on the same `--port` (UDP + TCP-direct) plus `--port + 1` for AN2/TCP — i.e. `--port 2071` exposes UDP/TCP at 2071 and AN2/TCP at 2072. Multi-client is inherent: each TCP/AN2 connection is an independent session.
+
+## Provider — broadcasts gating (announce flag)
+
+Two layers; both must be true for a consumer to receive an announce.
+
+| Layer | Where it lives | How to toggle |
+|---|---|---|
+| **1. Provider broadcasts gate** | `Identity.Broadcasts` object on the device's tree (per spec p.20) | the customer flips it via `dhs consumer acp1 set <ip> --slot 0 --group identity --label Broadcasts --value 1` |
+| **2. Per-AN2-session opt-in** | Per consumer connection | the consumer plugin sends `AN2 EnableProtocolEvents([1])` after connect; happens automatically on `watch` |
+
+If the gate (layer 1) is OFF, the provider emits no announces to anyone. If layer 2 is missing, that one consumer sees nothing while others may still receive. UDP/TCP-direct consumers never receive announces by design — only AN2 sessions do.
+
+## DM cache contract
+
+ACP1 keeps **IP-keyed** caching:
+
+```
+.cache/devices/<ip>/slot_<n>.json
+```
+
+- `walk` writes the file on every successful walk (one per slot).
+- `watch` reads the file at startup for instant label/unit resolution while the background walk completes.
+- ACP1 has no identity probe (Card Name + Hardware Version aren't at fixed labels across products), so the cache cannot survive an IP change. Re-cabling means re-walking.
+- The IP-keyed cache stores values stripped (`Value: zero`); only labels + types + ranges persist.
+
+## Common flows
+
+### First-time bring-up
+
+```
+dhs consumer acp1 info  10.6.239.113
+dhs consumer acp1 walk  10.6.239.113 --all       # populates cache for every present slot
+dhs consumer acp1 watch 10.6.239.113 --slot 0    # labels resolve from frame 1
+```
+
+### Continuous monitoring across reboot
+
+```
+dhs consumer acp1 watch 10.6.239.113 --slots all     # all present slots, labels from cache
+```
+
+### Bring up an emulator alongside production traffic
+
+```
+dhs producer acp1 serve --tree neuron-fixture.json --port 2071 --bind 10.6.239.200
+```
+
+`--bind <vip>` pins the listener AND the broadcast source IP, so multi-instance emulators on the same host appear as distinct From: addresses (ref #263).
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `watch` shows raw IDs, no labels | No prior walk for this IP | `walk --slot N` or `walk --all` first |
+| `watch` shows nothing despite live activity on the device | Broadcasts gate OFF on the provider, OR consumer not on AN2 | flip Broadcasts via `set …Broadcasts 1`, or pass `--transport an2` |
+| `watch --slots 0` also shows slot 1 announces | Multi-slot list filter is permissive (Subscribe accepts only one slot) | use `--slot 0` (singular) for strict slot filter |
+| Cache stale after re-cabling | IP-keyed cache invalidated by Card Name mismatch on next walk | the validator detects this — `walk` again |
+
+## Pointers
+
+- Wire format: [CLAUDE.md](../CLAUDE.md)
+- Deep-dive consumer doc: [consumer.md](consumer.md)
+- Wireshark dissector: [../wireshark/dhs_acpv1.lua](../wireshark/dhs_acpv1.lua)
+- Spec PDF: [../assets/AXON-ACP_v1_4.pdf](../assets/AXON-ACP_v1_4.pdf)

--- a/internal/acp2/docs/README.md
+++ b/internal/acp2/docs/README.md
@@ -2,6 +2,7 @@
 
 | Role | Doc | Status |
 |---|---|---|
+| Operator runbook | [runbook.md](runbook.md) | ✓ shipping |
 | Consumer | [consumer.md](consumer.md) | ✓ shipping |
 | Provider | [provider.md](provider.md) | TODO |
 

--- a/internal/acp2/docs/runbook.md
+++ b/internal/acp2/docs/runbook.md
@@ -1,0 +1,112 @@
+# ACP2 — operational runbook
+
+Quick-reference card for operators. For wire-format detail see
+[CLAUDE.md](../CLAUDE.md); for in-depth consumer behaviour see
+[consumer.md](consumer.md).
+
+---
+
+## Transport matrix
+
+| Mode | Port | Notes |
+|---|---:|---|
+| AN2/TCP | 2072 | **Only transport.** ACP2 has no UDP / TCP-direct. AN2 proto byte = 2. AN2 framer carries every request, reply, and announce. |
+
+The consumer always uses AN2/TCP; no `--transport` selection. Default `--port 2072`.
+
+## Verb reference
+
+### Consumer
+
+| Verb | What it does | Common flags | Cache effect |
+|---|---|---|---|
+| `dhs consumer acp2 info <ip>` | Read AN2 + ACP2 versions, slot count | `--port`, `--timeout` | none |
+| `dhs consumer acp2 walk <ip>` | Discover one slot's full DM | `--slot N` or `--all`, `--path BOARD.Stream`, `--filter foo`, `--capture out.jsonl` | writes `.cache/dm/<CardName>@<HardwareVersion>.json` (multi-slot, identity-keyed) |
+| `dhs consumer acp2 get <ip>` | Read one property | `--slot N --id 70232`, `--capture out.jsonl` | reads identity-keyed cache for label resolution |
+| `dhs consumer acp2 set <ip>` | Write one property | same as `get` plus `--value …` | none |
+| `dhs consumer acp2 watch <ip>` | Subscribe to announces | `--slot N`, `--id I`, `--no-walk` | hot-loads `.cache/dm/<identity>.json` before Subscribe → labels from frame 1 |
+
+### Provider
+
+| Verb | What it does | Required flags |
+|---|---|---|
+| `dhs producer acp2 serve --tree fixture.json --port 2072 --bind <ip>` | Serve AN2/TCP from one fixture | `--tree`, `--port`, optional `--bind` |
+
+Multi-client is inherent: each AN2 session is independent. Announces are fanned to every session that has called `EnableProtocolEvents([2])`.
+
+## Provider — broadcasts gating (announce flag)
+
+| Layer | Where it lives | How to toggle |
+|---|---|---|
+| **1. Provider broadcasts gate** | tree-level on/off (mirrored from ACP1 §p.20) | flip via `dhs consumer acp2 set <ip> --slot 0 --label Broadcasts --value 1` |
+| **2. Per-AN2-session opt-in** | per consumer connection | sent automatically by the consumer plugin on `watch`: `AN2 EnableProtocolEvents([2])` |
+
+Both layers must be true for a consumer to see announces. The provider drops announces silently when the gate is OFF.
+
+## DM cache contract
+
+ACP2 uses **identity-keyed** caching exclusively (DHS 2016 MasterView model — see memory `project_acp2_dm_cache`):
+
+```
+.cache/dm/<CardName>@<HardwareVersion>.json   ← single file per device, multi-slot
+```
+
+- Identity = labels `Card Name` + `Hardware Version` on slot 0 (sub-second probe at watch start). Real Neuron 10.41.40.4 → `SHPRM1@0.7`.
+- Walking any slot of the frame **accumulates** into the same file via merge — slot 0 + slot 1 + slot N share one MasterView.
+- The cache survives re-cabling and IP changes; only a Card swap or firmware bump (Hardware Version change) invalidates it.
+- File format: flat JSON via stdlib `json.Encoder` (NOT `export.WriteJSON` — that hierarchical writer drops `Object.Meta` which is load-bearing for type info on round-trip).
+- `watch` start: identity probe → `LoadByIdentity` → seed the in-memory `WalkedTree` for every cached slot **before** Subscribe fires → enum labels resolve from the very first announce.
+
+## Common flows
+
+### First-time bring-up against the producer emulator
+
+```
+dhs consumer acp2 info  10.100.0.103 --port 2072
+dhs consumer acp2 walk  10.100.0.103 --port 2072 --slot 0   # primes slot 0 in dm/<id>.json
+dhs consumer acp2 walk  10.100.0.103 --port 2072 --slot 1   # merges slot 1 into the same file
+dhs consumer acp2 watch 10.100.0.103 --port 2072 --slot 1   # hot-loads, labels frame 1
+```
+
+After both walks, the file contains every slot you walked. Restart `watch` any time — labels resolve immediately.
+
+### Inspect a single object
+
+```
+dhs consumer acp2 get 10.100.0.103 --port 2072 --slot 1 --id 70232 --capture out.jsonl
+# → value = "Stream 16" (enum idx 8)
+# → out.jsonl contains the raw AN2 frames for replay / spec audit
+```
+
+### Bring up an emulator on a VIP alongside production traffic
+
+```
+dhs producer acp2 serve --tree neuron-fixture.json --port 2072 --bind 10.100.0.200
+```
+
+### Verify cache state
+
+```
+type .cache\dm\SHPRM1@0.7.json | findstr "\"slot\":"
+# expect "slot": 0 AND "slot": 1
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `watch` shows `idx N` for enums, no labels | DM cache file missing the watched slot, OR identity probe failed | run `walk --slot N` once; then check `.cache/dm/<identity>.json` exists with that slot |
+| `loaded N labels from cache` line still appears | running an old binary (pre-#355) — that path is disabled for ACP2 | rebuild: `go build -o bin/dhs.exe ./cmd/dhs` |
+| `walk --slot 1` overwrites `walk --slot 0`'s data | running an old binary (pre-#356 round-trip fix) | rebuild + delete the corrupt file: `del .cache\dm\<id>.json` |
+| Producer emits no announces to any consumer | Broadcasts gate is OFF on the tree | `set --label Broadcasts --value 1` |
+| One consumer sees no announces while another does | that consumer didn't send `EnableProtocolEvents([2])` | it's automatic on `watch`; check the binary version |
+| `watch --slots 0` leaks slot 1 announces | multi-slot lists don't filter (Subscribe takes a single slot) | use `--slot 0` (singular) for strict filter |
+| Cache says `<Card>@<HwVer>` for a different device than expected | producer fixture identity differs from real device | each device has its own file by design — no cross-pollination |
+
+## Pointers
+
+- Wire format + spec audit: [CLAUDE.md](../CLAUDE.md)
+- Deep-dive consumer doc: [consumer.md](consumer.md)
+- Wireshark dissector: [../wireshark/dhs_acpv2.lua](../wireshark/dhs_acpv2.lua)
+- Spec docx: [../assets/acp2_protocol.docx](../assets/acp2_protocol.docx)
+- AN2 transport spec: [../assets/an2_protocol.pdf](../assets/an2_protocol.pdf)


### PR DESCRIPTION
## Summary

Operator-facing runbook for ACP1 and ACP2 living next to each protocol's existing wire-spec `CLAUDE.md` and deep-dive `consumer.md`. Plus a sweep of stale `usage: acp <verb>` CLI strings (left over from the pre-`dhs` rename), and a trim of the top-level `CLAUDE.md` per ADR-0015 (single source of truth) — every rule preserved, only narrative compressed.

## Why

After the ACP2 DM cache work (#353/#354/#355) and the round-trip fix (#356), the operator-side contract had grown without a one-page reference:

- "Which transport for which protocol?"
- "Provider broadcasts gate vs per-session `EnableProtocolEvents` — where do I toggle?"
- "Where does the DM cache live, and what restarts hot-load with labels from frame 1?"
- "What flags does `dhs consumer acp2 walk` take and what does it write to disk?"

Each protocol's deep-dive `consumer.md` answers these questions, but spread across 400-500 lines per protocol. The runbook is the quick-reference card.

## Runbook contents (each protocol)

| Section | What it covers |
|---|---|
| Transport matrix | port + framer + when to use each |
| Verb reference | one row per verb, what it does, common flags, cache effect |
| Provider broadcasts gating | the two layers (tree-level + per-AN2-session) and how to flip each |
| DM cache contract | exact filename, multi-slot merge, identity vs IP keying, what invalidates |
| Common flows | first-time bring-up, restart-with-cache, VIP emulator, single-object inspect |
| Troubleshooting | symptom → likely cause → fix table |
| Pointers | wire spec, deep-dive consumer.md, dissector, asset PDFs |

## CLI usage sweep

14 files in `cmd/dhs/` had `usage: acp <verb>` strings dating back before the binary was renamed to `dhs`. Replaced with the canonical `dhs consumer <proto> <verb>` (or `dhs <verb>` for protocol-agnostic verbs like `diff` / `extract`). No behavioural change — just the help text users see when they pass `--help` or invalid args.

## CLAUDE.md trim

536 → 456 lines (-80, ~15%). Specifically:

| Section | Before | After | Why |
|---|---:|---:|---|
| Performance + metrics | 70 lines of Prometheus / Grafana / CSV setup | 15 lines (rule + pointer) | full contract already in `project_connector_metrics_v2` memory + `docs/deployment/grafana/` |
| Storage | 30 lines of per-OS data-dir + freshness narrative | 10 lines | per-protocol cache shape now lives in each protocol's `runbook.md` (single source); ADR-0020 owns the bucket layout |
| Coding conventions / Testing | integration-test env var enumeration + file-layout repeat | trimmed | already in per-protocol `consumer.md` and folder-layout section above |

Every rule preserved. No behavioural directives removed. Per ADR-0015.

## Test plan

- [x] `go build ./...` green
- [x] `go test ./...` green (`cmd/dhs`, `internal/storage` confirmed; nothing exercised by docs changes)
- [ ] Spot-check `--help` output:
  ```
  .\bin\dhs.exe consumer acp1 walk
  .\bin\dhs.exe consumer acp2 watch
  ```
  Expect the new `usage: dhs consumer <proto> <verb>` string.

## Files

- `internal/acp1/docs/runbook.md` (new, 103 lines)
- `internal/acp2/docs/runbook.md` (new, 112 lines)
- `internal/acp1/docs/README.md`, `internal/acp2/docs/README.md` — link the runbook in the role table
- `cmd/dhs/cmd_{walk,watch,get,set,info,diag,diff,export,extract,import,invoke,matrix,profile,stream}.go` — usage strings
- `CLAUDE.md` — 80-line trim

🤖 Generated with [Claude Code](https://claude.com/claude-code)