### PR TITLE
fix(export): deterministic ReadJSON readback (fixes TestValidateOutTree flake)

### DIFF
--- a/internal/export/json.go
+++ b/internal/export/json.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"time"
 
@@ -298,8 +299,19 @@ func readHierarchicalJSON(raw json.RawMessage) (*Snapshot, error) {
 // flattenJSONTree recursively walks a nested JSON map and produces flat
 // protocol.Object entries. Each leaf has "id", "kind", "value" etc.
 // Each branch is a container node with sub-keys.
+//
+// Sort the map keys before iteration so the resulting slice order is
+// deterministic. Without this, callers that compare against expected
+// positional output (e.g. validate_out_tree_test.go) flake roughly
+// 50% of CI runs because Go map iteration is randomised.
 func flattenJSONTree(tree map[string]json.RawMessage, slot int, path []string, out *[]protocol.Object) {
-	for name, raw := range tree {
+	names := make([]string, 0, len(tree))
+	for name := range tree {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		raw := tree[name]
 		curPath := append(append([]string{}, path...), name)
 
 		// Try to parse as leaf (has "id" and "kind" fields).


### PR DESCRIPTION
## Summary

`flattenJSONTree` in `internal/export/json.go` iterated a `map[string]json.RawMessage` directly. Go's map iteration is randomised, so the order of objects produced by `ReadJSON` was non-deterministic. Tests that asserted positional output flaked ~50% of the time on every platform.

## Repro

`TestValidateOutTree_WritesSnapshot` in `internal/acp1/consumer/`:
- locally on Windows: passes a few times, then `--- FAIL` out of nowhere
- CI Windows run on PR #356: failed [run 25589109265](https://github.com/by-openclaw/go-acp/actions/runs/25589109265/job/75123345009)
- CI Ubuntu run on main on 2026-05-06: same `--- FAIL: TestValidateOutTree_WritesSnapshot` ([run 25432129263](https://github.com/by-openclaw/go-acp/actions/runs/25432129263))

The test asserts `got[0].Group == control` and `got[1].Group == identity`, expecting the writer's `sort.SliceStable` order to survive round-trip. It does on the write side (validate.go:180); it does NOT on the read side because `flattenJSONTree` did `for name := range tree`.

## Fix

Sort the map keys before iterating:

```go
names := make([]string, 0, len(tree))
for name := range tree {
    names = append(names, name)
}
sort.Strings(names)
for _, name := range names { ... }
```

13-line change. Adds `sort` import.

## Verification

`go test ./internal/acp1/consumer -count=10` on Windows: 10/10 pass.
`go test ./...` full suite green — no other test depended on the random readback order.

## Why ship as a separate PR

PR #356 is documentation-only (per-protocol runbooks + CLI usage strings + CLAUDE.md trim). Mixing this code fix in would muddy the scope. After this PR lands on main, #356 will rebase + re-run CI on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)