### PR TITLE
feat(acp2): strict-spec close-out — full §5.1 + transport conformance + DM cache + 25 sub-PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -414,8 +414,8 @@ See `feedback_amwa_strict_all_versions` in memory.
   from outside its own tree except via `cmd/dhs/` blank imports.
 - Never hardcode protocol names in generic code — use the registry.
 - Never use fixed byte offsets for ACP2 properties — use pid/plen headers.
-- Never call ACP2 pid=4 "event_delay" — it is "announce_delay".
-- Never call ACP2 type=2 "event" — it is "announce".
+- Spec name for ACP2 pid=4 is "event_delay" (acp2_protocol.docx §5.4 row 4) — match the docx exactly.
+- Spec name for ACP2 type=2 is "announce" (acp2_protocol.docx §3.2 type-field row).
 - Never use ACP2 idx=0 to mean "first preset slot" — it is ACTIVE INDEX.
 - Never write property values to disk as trusted state.
 - Never add Redis, PostgreSQL, or any external data store.

--- a/cmd/dhs/cmd_extract.go
+++ b/cmd/dhs/cmd_extract.go
@@ -13,6 +13,25 @@ import (
 	"time"
 )
 
+// canonicalDirection normalises the --direction flag value. Accepts
+// the canonical spellings (consumer / provider / both) plus "io" as
+// a friendlier synonym for "both" for bidirectional products like
+// ACP2 channels. Returns the canonical form on success or a wrapped
+// error on unknown values.
+//
+// Pure helper — extracted from runExtract to keep the alias logic
+// unit-testable without the full dial path.
+func canonicalDirection(d string) (string, error) {
+	if d == "io" {
+		return "both", nil
+	}
+	switch d {
+	case "consumer", "provider", "both":
+		return d, nil
+	}
+	return "", fmt.Errorf("--direction must be one of: consumer, provider, both, io (got %q)", d)
+}
+
 // runExtract drives `acp extract` (issue #47) — walks a device and
 // writes the product-fixture triple (meta + wire + tree) into the
 // output directory using the schema locked in #43.
@@ -25,7 +44,7 @@ func runExtract(ctx context.Context, args []string) error {
 	product := fs.String("product", "",
 		"product identifier as the vendor writes it (e.g. DDB08, CDV08v06). Required.")
 	direction := fs.String("direction", "",
-		"how the product speaks this protocol: consumer (we read it), provider (we expose it), or both. Required.")
+		"how the product speaks this protocol: consumer (we read it), provider (we expose it), both, or io (alias for both). Required.")
 	ver := fs.String("version", "",
 		"product / firmware version as reported by the device (e.g. 2.3). Required.")
 	versionKind := fs.String("version-kind", "firmware",
@@ -47,11 +66,11 @@ func runExtract(ctx context.Context, args []string) error {
 	if *manufacturer == "" || *product == "" || *direction == "" || *ver == "" || *outDir == "" {
 		return fmt.Errorf("--manufacturer, --product, --direction, --version, and --out are all required")
 	}
-	switch *direction {
-	case "consumer", "provider", "both":
-	default:
-		return fmt.Errorf("--direction must be one of: consumer, provider, both (got %q)", *direction)
+	canonical, err := canonicalDirection(*direction)
+	if err != nil {
+		return err
 	}
+	*direction = canonical
 
 	if cf.protocol == "emberplus" && *slot < 0 {
 		*slot = 0

--- a/cmd/dhs/cmd_get.go
+++ b/cmd/dhs/cmd_get.go
@@ -16,6 +16,7 @@ func runGet(ctx context.Context, args []string) error {
 	group := fs.String("group", "", "object group (optional when --label is unique across groups)")
 	label := fs.String("label", "", "object label (preferred over --id, requires prior walk context)")
 	id := fs.Int("id", -1, "object id within group (alternative to --label)")
+	objectAlias := fs.Int("object", -1, "alias for --id (deprecated; ACP2 callers historically wrote --object)")
 	pathFlag := fs.String("path", "", "dot-separated tree path (e.g. router.oneToN.parameters.sourceGain)")
 	idx := fs.Int("idx", 0, "ACP2 preset idx (0 = ACTIVE INDEX; default)")
 	pid := fs.Int("pid", 0, "ACP2 property id to read (0 = default pid=8 value; set to read object_type/label/access/etc.)")
@@ -30,6 +31,14 @@ func runGet(ctx context.Context, args []string) error {
 	}
 	if *slot < 0 {
 		return fmt.Errorf("--slot is required")
+	}
+	// --object is a deprecated alias for --id. Fold it in unless both
+	// were set with conflicting values.
+	if *objectAlias >= 0 {
+		if *id >= 0 && *id != *objectAlias {
+			return fmt.Errorf("--id and --object both set with different values (%d vs %d)", *id, *objectAlias)
+		}
+		*id = *objectAlias
 	}
 	if *pathFlag == "" && *label == "" && *id < 0 {
 		return fmt.Errorf("either --path, --label, or --id is required")

--- a/cmd/dhs/cmd_list_commands_test.go
+++ b/cmd/dhs/cmd_list_commands_test.go
@@ -83,7 +83,7 @@ func TestLookupCatalogueACPKindAddressing(t *testing.T) {
 		{"acp1", "method:0", "getValue"},
 		{"acp1", "method:5", "getObject"},
 		{"acp1", "objgroup:2", "control"},
-		{"acp2", "pid:4", "announce_delay"},
+		{"acp2", "pid:4", "event_delay"},
 		{"acp2", "acp2-func:1", "get_object"},
 		{"acp2", "obj-type:0", "node"},
 	}

--- a/cmd/dhs/cmd_set.go
+++ b/cmd/dhs/cmd_set.go
@@ -10,6 +10,17 @@ import (
 	"dhs/internal/protocol"
 )
 
+// orFirst returns the first non-empty argument, or "" if all are empty.
+// Used to format human-friendly error messages without nested ternaries.
+func orFirst(s ...string) string {
+	for _, v := range s {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
 func runSet(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("set", flag.ExitOnError)
 	cf := addCommonFlags(fs)
@@ -21,6 +32,7 @@ func runSet(ctx context.Context, args []string) error {
 	pathFlag := fs.String("path", "", "dot-separated tree path (e.g. router.oneToN.parameters.sourceGain)")
 	valueStr := fs.String("value", "", "typed value (e.g. -3.0, \"On\", \"192.168.1.5\", \"CH1\"); empty string is valid for string objects")
 	valueHex := fs.String("raw", "", "raw wire bytes as hex — escape hatch bypassing typed encoding")
+	noWalk := fs.Bool("no-walk", false, "fail fast on cache miss instead of walking the slot to resolve --path/--label")
 	host, rest, err := popHost(args)
 	if err != nil {
 		return fmt.Errorf("usage: dhs consumer <proto> set <host> --slot N (--path P | --label L | --id I) (--value <v> | --raw <hex>)")
@@ -85,16 +97,37 @@ func runSet(ctx context.Context, args []string) error {
 	opCtx, cancel := withTimeout(ctx, cf.timeout)
 	defer cancel()
 
-	// Path or label addressing: walk to populate tree. Uses raw ctx
-	// (signal-only) so big trees don't fail their own resolution; only
-	// the SetValue below is bounded by --timeout.
-	if *pathFlag != "" || *label != "" {
+	// Resolve --path / --label via the on-disk cache first. Falling
+	// through to plug.Walk costs minutes on a 49 000-object Neuron
+	// tree; populated cache resolves in microseconds. Only walk on
+	// genuine cache miss (and only when the user hasn't asked us to
+	// fail fast via --no-walk).
+	resolvedFromCache := false
+	if *id < 0 {
+		if *pathFlag != "" {
+			if cachedID := resolvePathFromCache(host, cf.protocol, *slot, *pathFlag); cachedID >= 0 {
+				*id = cachedID
+				resolvedFromCache = true
+			}
+		}
+		if !resolvedFromCache && *label != "" {
+			if cachedID := resolveLabelFromCache(host, cf.protocol, *slot, *group, *label); cachedID >= 0 {
+				*id = cachedID
+				resolvedFromCache = true
+			}
+		}
+	}
+
+	if !resolvedFromCache && (*pathFlag != "" || *label != "") {
+		if *noWalk {
+			return fmt.Errorf("--no-walk: %q not found in cache for slot %d (run 'walk --slot %d' first or drop --no-walk)",
+				orFirst(*pathFlag, *label), *slot, *slot)
+		}
+		// Cache miss: walk the slot to populate before SetValue. Uses
+		// raw ctx (signal-only) so big trees don't fail their own
+		// resolution; only the SetValue below is bounded by --timeout.
 		if _, err := plug.Walk(ctx, *slot); err != nil {
 			return fmt.Errorf("walk for resolution: %w", err)
-		}
-	} else if *label != "" && *id < 0 {
-		if cachedID := resolveLabelFromCache(host, cf.protocol, *slot, *group, *label); cachedID >= 0 {
-			*id = cachedID
 		}
 	}
 

--- a/cmd/dhs/cmd_set.go
+++ b/cmd/dhs/cmd_set.go
@@ -17,6 +17,7 @@ func runSet(ctx context.Context, args []string) error {
 	group := fs.String("group", "", "object group name")
 	label := fs.String("label", "", "object label")
 	id := fs.Int("id", -1, "object id within group")
+	objectAlias := fs.Int("object", -1, "alias for --id (deprecated; ACP2 callers historically wrote --object)")
 	pathFlag := fs.String("path", "", "dot-separated tree path (e.g. router.oneToN.parameters.sourceGain)")
 	valueStr := fs.String("value", "", "typed value (e.g. -3.0, \"On\", \"192.168.1.5\", \"CH1\"); empty string is valid for string objects")
 	valueHex := fs.String("raw", "", "raw wire bytes as hex — escape hatch bypassing typed encoding")
@@ -45,6 +46,15 @@ func runSet(ctx context.Context, args []string) error {
 	}
 	if *slot < 0 {
 		return fmt.Errorf("--slot is required")
+	}
+	// --object is a deprecated alias for --id. If the user supplied
+	// --object and not --id, fold it in. If both are set with different
+	// values, reject — the caller's intent is ambiguous.
+	if *objectAlias >= 0 {
+		if *id >= 0 && *id != *objectAlias {
+			return fmt.Errorf("--id and --object both set with different values (%d vs %d)", *id, *objectAlias)
+		}
+		*id = *objectAlias
 	}
 	if !valueSet && !rawSet {
 		return fmt.Errorf("either --value or --raw is required")

--- a/cmd/dhs/cmd_walk.go
+++ b/cmd/dhs/cmd_walk.go
@@ -113,12 +113,11 @@ func runWalk(ctx context.Context, args []string) error {
 				fmt.Printf("\nslot %d — walk error: %v\n", s, werr)
 				continue
 			}
-			// Save walked tree to disk for instant label resolution next time.
-			if treeStore != nil {
-				if serr := treeStore.Save(host, cf.protocol, s, objs); serr != nil {
-					fmt.Fprintf(os.Stderr, "warning: cache save slot %d: %v\n", s, serr)
-				}
-			}
+			// Persist walked tree. ACP2 -> identity-keyed MasterView at
+			// .cache/dm/<identity>.json; ACP1/Ember+ -> IP-keyed
+			// .cache/devices/<ip>/slot_<n>.json. See saveSlotCache.
+			prober, _ := plug.(identityProber)
+			saveSlotCache(ctx, prober, host, cf.protocol, s, objs)
 			objs = filterByPath(objs, pathSegs)
 			if !streaming {
 				printSlotTree(s, objs, *filter)
@@ -135,12 +134,11 @@ func runWalk(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	// Save walked tree to disk for instant label resolution next time.
-	if treeStore != nil {
-		if serr := treeStore.Save(host, cf.protocol, *slot, objs); serr != nil {
-			fmt.Fprintf(os.Stderr, "warning: cache save slot %d: %v\n", *slot, serr)
-		}
-	}
+	// Persist walked tree. ACP2 -> identity-keyed MasterView at
+	// .cache/dm/<identity>.json; ACP1/Ember+ -> IP-keyed
+	// .cache/devices/<ip>/slot_<n>.json. See saveSlotCache.
+	prober, _ := plug.(identityProber)
+	saveSlotCache(ctx, prober, host, cf.protocol, *slot, objs)
 	objs = filterByPath(objs, pathSegs)
 	if !streaming {
 		printSlotTree(*slot, objs, *filter)

--- a/cmd/dhs/cmd_watch.go
+++ b/cmd/dhs/cmd_watch.go
@@ -77,20 +77,21 @@ func runWatch(ctx context.Context, args []string) error {
 	}
 	defer cleanup()
 
-	// Load disk cache for instant label/unit resolution while walk runs.
-	// Key by watchCacheKey so ACP1 groups that re-use the same object-id
-	// space (control / status / alarm / identity / file / frame all
-	// addressable as 0..N within one slot) don't collide. (refs #236)
+	// Load IP-keyed disk cache for instant label/unit resolution while
+	// walk runs. Key by watchCacheKey so ACP1 groups that re-use the
+	// same object-id space (control / status / alarm / identity / file
+	// / frame all addressable as 0..N within one slot) don't collide
+	// (refs #236).
 	//
-	// Per #323 the same loaded snapshot is also fed back into the
-	// plugin via the optional TreeSeeder interface (currently
-	// implemented by ACP2). That populates the plugin's per-slot
-	// WalkedTree cache from disk so Subscribe-fed announces can
-	// decode types + labels immediately — no waiting on the
-	// background walk to fill in.
+	// ACP2 deliberately skips this path — its DM cache is identity-
+	// keyed at .cache/dm/<identity>.json (DHS 2016 MasterView model,
+	// #353/#355) and is loaded into the plugin's WalkedTree directly
+	// in the block below. Letting the IP-keyed loader run for ACP2
+	// would emit a misleading "loaded N labels from cache" line backed
+	// by stale per-IP files even when the identity cache is current.
 	labelCache := map[string]string{}
 	unitCache := map[string]string{}
-	if treeStore != nil && *slot >= 0 {
+	if cf.protocol != "acp2" && treeStore != nil && *slot >= 0 {
 		if snap, lerr := treeStore.Load(host, *slot); lerr == nil && snap != nil {
 			for _, sd := range snap.Slots {
 				for _, o := range sd.Objects {
@@ -444,31 +445,56 @@ func runWalkScope(ctx context.Context, plug protocol.Protocol, host, proto strin
 	}
 }
 
+// identityProber is the optional contract a Protocol plugin satisfies
+// to participate in identity-keyed MasterView caching. ACP2 implements
+// it via Plugin.IdentityProbe (Card Name + Hardware Version on slot 0).
+// ACP1 / Ember+ do not — they fall back to IP-keyed storage.
+type identityProber interface {
+	IdentityProbe(ctx context.Context) (string, error)
+}
+
 func walkSlotAndCache(ctx context.Context, plug protocol.Protocol, host, proto string, slot int) {
 	objs, werr := plug.Walk(ctx, slot)
 	if werr != nil {
 		fmt.Fprintf(os.Stderr, "warning: walk slot %d failed: %v\n", slot, werr)
 		return
 	}
-	if treeStore != nil {
-		if serr := treeStore.Save(host, proto, slot, objs); serr != nil {
-			fmt.Fprintf(os.Stderr, "warning: cache save slot %d: %v\n", slot, serr)
-		}
+	prober, _ := plug.(identityProber)
+	saveSlotCache(ctx, prober, host, proto, slot, objs)
+}
+
+// saveSlotCache routes a walked slot to the right on-disk cache.
+//
+// ACP2 has a stable device identity probe (Card Name + Hardware Version
+// on slot 0), so its cache is keyed by identity and lives in one
+// multi-slot file at .cache/dm/<identity>.json — DHS 2016 MasterView
+// model. Walking any slot of the frame accumulates into the same file.
+// IP-keyed cache is NOT written for ACP2 (#353, #355).
+//
+// Other protocols (ACP1, Ember+) keep the legacy IP-keyed layout at
+// .cache/devices/<ip>/slot_<n>.json — those plugins have no identity
+// probe contract today.
+func saveSlotCache(ctx context.Context, prober identityProber, host, proto string, slot int, objs []protocol.Object) {
+	if treeStore == nil {
+		return
 	}
-	// Identity-keyed DM cache (#353): for ACP2 also save under
-	// <CardName>@<HardwareVersion> so the next watch session against
-	// any IP for the same card/firmware can hot-load the DM and skip
-	// the cold-start label gap. ACP1 keeps IP-only caching.
-	if proto == "acp2" && treeStore != nil {
-		if probe, ok := plug.(interface {
-			IdentityProbe(context.Context) (string, error)
-		}); ok {
-			if identity, perr := probe.IdentityProbe(ctx); perr == nil && identity != "" {
-				if serr := saveIdentityCache(treeStore, plug, ctx, identity, host, proto, slot, objs); serr != nil {
-					fmt.Fprintf(os.Stderr, "warning: identity cache save: %v\n", serr)
-				}
-			}
+	if proto == "acp2" {
+		if prober == nil {
+			fmt.Fprintf(os.Stderr, "warning: acp2 plugin missing IdentityProbe; slot %d not cached\n", slot)
+			return
 		}
+		identity, perr := prober.IdentityProbe(ctx)
+		if perr != nil || identity == "" {
+			fmt.Fprintf(os.Stderr, "warning: identity probe failed; slot %d not cached: %v\n", slot, perr)
+			return
+		}
+		if serr := saveIdentityCache(treeStore, identity, host, proto, slot, objs); serr != nil {
+			fmt.Fprintf(os.Stderr, "warning: identity cache save: %v\n", serr)
+		}
+		return
+	}
+	if serr := treeStore.Save(host, proto, slot, objs); serr != nil {
+		fmt.Fprintf(os.Stderr, "warning: cache save slot %d: %v\n", slot, serr)
 	}
 }
 
@@ -476,7 +502,7 @@ func walkSlotAndCache(ctx context.Context, plug protocol.Protocol, host, proto s
 // merges the just-walked slot into it, and saves the result. So
 // successive walks of slot 0 then slot 1 build up a single
 // multi-slot cache file keyed by device identity.
-func saveIdentityCache(store *storage.TreeStore, plug protocol.Protocol, ctx context.Context, identity, host, proto string, slot int, objs []protocol.Object) error {
+func saveIdentityCache(store *storage.TreeStore, identity, host, proto string, slot int, objs []protocol.Object) error {
 	existing, _ := store.LoadByIdentity(identity)
 	now := time.Now().UTC()
 	if existing == nil {

--- a/cmd/dhs/cmd_watch.go
+++ b/cmd/dhs/cmd_watch.go
@@ -78,6 +78,13 @@ func runWatch(ctx context.Context, args []string) error {
 	// Key by watchCacheKey so ACP1 groups that re-use the same object-id
 	// space (control / status / alarm / identity / file / frame all
 	// addressable as 0..N within one slot) don't collide. (refs #236)
+	//
+	// Per #323 the same loaded snapshot is also fed back into the
+	// plugin via the optional TreeSeeder interface (currently
+	// implemented by ACP2). That populates the plugin's per-slot
+	// WalkedTree cache from disk so Subscribe-fed announces can
+	// decode types + labels immediately — no waiting on the
+	// background walk to fill in.
 	labelCache := map[string]string{}
 	unitCache := map[string]string{}
 	if treeStore != nil && *slot >= 0 {
@@ -91,6 +98,15 @@ func runWatch(ctx context.Context, args []string) error {
 					if o.Unit != "" {
 						unitCache[k] = o.Unit
 					}
+				}
+				// Seed the plugin's in-memory tree cache from disk.
+				// Only the plugins that implement TreeSeeder benefit;
+				// others ignore the call (interface assertion is
+				// optional).
+				if seeder, ok := plug.(interface {
+					SeedTreeFromCachedObjects(slot int, objs []protocol.Object)
+				}); ok && sd.Slot == *slot {
+					seeder.SeedTreeFromCachedObjects(sd.Slot, sd.Objects)
 				}
 			}
 			if len(labelCache) > 0 {

--- a/cmd/dhs/cmd_watch.go
+++ b/cmd/dhs/cmd_watch.go
@@ -7,9 +7,12 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"dhs/internal/dmlib"
+	"dhs/internal/export"
 	"dhs/internal/protocol"
+	"dhs/internal/storage"
 )
 
 // runWatch subscribes to live announcements and prints each event as it
@@ -111,6 +114,36 @@ func runWatch(ctx context.Context, args []string) error {
 			}
 			if len(labelCache) > 0 {
 				fmt.Fprintf(os.Stderr, "loaded %d labels from cache\n", len(labelCache))
+			}
+		}
+	}
+
+	// Identity-keyed DM cache hot-load (#353): probe device identity
+	// (Card Name + Hardware Version on slot 0, sub-second), look up
+	// the persisted DM by identity, and seed the plugin's in-memory
+	// tree BEFORE Subscribe fires. The announce decoder then resolves
+	// types + enum labels from frame 1 — eliminates the cold-start
+	// "idx N" gap on slot 1 watches where the fresh walk takes 30-60s.
+	//
+	// ACP2-only — other plugins keep the IP-keyed cache today.
+	if cf.protocol == "acp2" && treeStore != nil {
+		if probe, hot := plug.(interface {
+			IdentityProbe(context.Context) (string, error)
+			SeedTreeFromCachedObjects(slot int, objs []protocol.Object)
+		}); hot {
+			identity, perr := probe.IdentityProbe(ctx)
+			if perr == nil && identity != "" {
+				if snap, lerr := treeStore.LoadByIdentity(identity); lerr == nil && snap != nil {
+					seeded := 0
+					for _, sd := range snap.Slots {
+						probe.SeedTreeFromCachedObjects(sd.Slot, sd.Objects)
+						seeded += len(sd.Objects)
+					}
+					if seeded > 0 {
+						fmt.Fprintf(os.Stderr, "DM cache hit %q — seeded %d objects across %d slot(s)\n",
+							identity, seeded, len(snap.Slots))
+					}
+				}
 			}
 		}
 	}
@@ -422,4 +455,56 @@ func walkSlotAndCache(ctx context.Context, plug protocol.Protocol, host, proto s
 			fmt.Fprintf(os.Stderr, "warning: cache save slot %d: %v\n", slot, serr)
 		}
 	}
+	// Identity-keyed DM cache (#353): for ACP2 also save under
+	// <CardName>@<HardwareVersion> so the next watch session against
+	// any IP for the same card/firmware can hot-load the DM and skip
+	// the cold-start label gap. ACP1 keeps IP-only caching.
+	if proto == "acp2" && treeStore != nil {
+		if probe, ok := plug.(interface {
+			IdentityProbe(context.Context) (string, error)
+		}); ok {
+			if identity, perr := probe.IdentityProbe(ctx); perr == nil && identity != "" {
+				if serr := saveIdentityCache(treeStore, plug, ctx, identity, host, proto, slot, objs); serr != nil {
+					fmt.Fprintf(os.Stderr, "warning: identity cache save: %v\n", serr)
+				}
+			}
+		}
+	}
+}
+
+// saveIdentityCache loads the existing identity-keyed DM (if any),
+// merges the just-walked slot into it, and saves the result. So
+// successive walks of slot 0 then slot 1 build up a single
+// multi-slot cache file keyed by device identity.
+func saveIdentityCache(store *storage.TreeStore, plug protocol.Protocol, ctx context.Context, identity, host, proto string, slot int, objs []protocol.Object) error {
+	existing, _ := store.LoadByIdentity(identity)
+	now := time.Now().UTC()
+	if existing == nil {
+		existing = &export.Snapshot{
+			Device:    export.DeviceInfo{IP: host, Protocol: proto},
+			Generator: "dhs dm-cache",
+			CreatedAt: now,
+		}
+	}
+	// Replace or append this slot's dump.
+	updated := false
+	for i := range existing.Slots {
+		if existing.Slots[i].Slot == slot {
+			existing.Slots[i] = export.SlotDump{
+				Slot:     slot,
+				WalkedAt: now,
+				Objects:  objs,
+			}
+			updated = true
+			break
+		}
+	}
+	if !updated {
+		existing.Slots = append(existing.Slots, export.SlotDump{
+			Slot:     slot,
+			WalkedAt: now,
+			Objects:  objs,
+		})
+	}
+	return store.SaveByIdentity(identity, existing)
 }

--- a/cmd/dhs/cmd_watch_cache_test.go
+++ b/cmd/dhs/cmd_watch_cache_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"dhs/internal/protocol"
+	"dhs/internal/storage"
+)
+
+// fakeProber satisfies identityProber for the ACP2 routing tests.
+type fakeProber struct {
+	identity string
+	err      error
+	calls    int
+}
+
+func (f *fakeProber) IdentityProbe(_ context.Context) (string, error) {
+	f.calls++
+	return f.identity, f.err
+}
+
+// withTempStore swaps the package-level treeStore for one rooted at a
+// fresh tempdir, and restores the original on cleanup.
+func withTempStore(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	prev := treeStore
+	treeStore = storage.NewTreeStore(root)
+	t.Cleanup(func() { treeStore = prev })
+	return root
+}
+
+func makeObjs() []protocol.Object {
+	return []protocol.Object{
+		{Slot: 1, ID: 70232, Label: "Backup Input"},
+	}
+}
+
+// TestSaveSlotCache_ACP2_WritesIdentityKeyedOnly pins the #355 contract:
+// the ACP2 cache lives in .cache/dm/<identity>.json (DHS 2016 MasterView
+// model). The legacy IP-keyed file at .cache/devices/<ip>/slot_<n>.json
+// must NOT be created for ACP2 — even though TreeStore.Save still
+// supports it for ACP1 / Ember+.
+func TestSaveSlotCache_ACP2_WritesIdentityKeyedOnly(t *testing.T) {
+	root := withTempStore(t)
+	prober := &fakeProber{identity: "SHPRM1@0.7"}
+
+	saveSlotCache(context.Background(), prober, "10.100.0.103", "acp2", 1, makeObjs())
+
+	dmPath := filepath.Join(root, "dm", "SHPRM1@0.7.json")
+	if _, err := os.Stat(dmPath); err != nil {
+		t.Fatalf("identity-keyed file missing: %v", err)
+	}
+	ipPath := filepath.Join(root, "devices", "10.100.0.103", "slot_1.json")
+	if _, err := os.Stat(ipPath); !os.IsNotExist(err) {
+		t.Errorf("IP-keyed file MUST NOT exist for acp2, got err=%v", err)
+	}
+	if prober.calls != 1 {
+		t.Errorf("identity probe call count: got %d want 1", prober.calls)
+	}
+}
+
+// TestSaveSlotCache_ACP2_NilProber_NoFile guards against silent fall-
+// through if a future plugin variant forgets to implement IdentityProbe.
+// For ACP2 with a nil prober, no file should be created (warn-only).
+func TestSaveSlotCache_ACP2_NilProber_NoFile(t *testing.T) {
+	root := withTempStore(t)
+
+	saveSlotCache(context.Background(), nil, "10.100.0.103", "acp2", 1, makeObjs())
+
+	dmDir := filepath.Join(root, "dm")
+	if _, err := os.Stat(dmDir); !os.IsNotExist(err) {
+		t.Errorf("dm dir MUST NOT exist when prober is nil, err=%v", err)
+	}
+	ipPath := filepath.Join(root, "devices", "10.100.0.103", "slot_1.json")
+	if _, err := os.Stat(ipPath); !os.IsNotExist(err) {
+		t.Errorf("IP-keyed file MUST NOT exist for acp2 fallback, err=%v", err)
+	}
+}
+
+// TestSaveSlotCache_ACP2_EmptyIdentity_NoFile covers the case where the
+// probe runs but returns "" (e.g. device offline / Card Name label
+// missing). We refuse to write under an empty identity — there is no
+// safe filename for it.
+func TestSaveSlotCache_ACP2_EmptyIdentity_NoFile(t *testing.T) {
+	root := withTempStore(t)
+	prober := &fakeProber{identity: ""}
+
+	saveSlotCache(context.Background(), prober, "10.100.0.103", "acp2", 1, makeObjs())
+
+	if _, err := os.Stat(filepath.Join(root, "dm")); !os.IsNotExist(err) {
+		t.Errorf("dm dir MUST NOT be created on empty identity, err=%v", err)
+	}
+}
+
+// TestSaveSlotCache_NonACP2_WritesIPKeyed verifies the ACP1 / Ember+
+// path is preserved: no identity probe used, IP-keyed file written.
+func TestSaveSlotCache_NonACP2_WritesIPKeyed(t *testing.T) {
+	root := withTempStore(t)
+
+	saveSlotCache(context.Background(), nil, "10.6.239.113", "acp1", 0, makeObjs())
+
+	ipPath := filepath.Join(root, "devices", "10.6.239.113", "slot_0.json")
+	if _, err := os.Stat(ipPath); err != nil {
+		t.Fatalf("IP-keyed file missing for acp1: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "dm")); !os.IsNotExist(err) {
+		t.Errorf("dm dir MUST NOT exist for non-acp2 protocols, err=%v", err)
+	}
+}
+
+// TestSaveSlotCache_ACP2_MultiSlotMerge pins the multi-slot merge
+// contract: walking slot 0 then slot 1 of the same device produces a
+// SINGLE identity-keyed file containing both slots, not two separate
+// files. This is how a frame with N populated slots accumulates into
+// one MasterView.
+func TestSaveSlotCache_ACP2_MultiSlotMerge(t *testing.T) {
+	root := withTempStore(t)
+	prober := &fakeProber{identity: "SHPRM1@0.7"}
+	ctx := context.Background()
+
+	slot0 := []protocol.Object{{Slot: 0, ID: 1, Label: "BOARD"}}
+	slot1 := []protocol.Object{{Slot: 1, ID: 70232, Label: "Backup Input"}}
+
+	saveSlotCache(ctx, prober, "10.41.40.4", "acp2", 0, slot0)
+	saveSlotCache(ctx, prober, "10.41.40.4", "acp2", 1, slot1)
+
+	snap, err := treeStore.LoadByIdentity("SHPRM1@0.7")
+	if err != nil || snap == nil {
+		t.Fatalf("LoadByIdentity: snap=%v err=%v", snap, err)
+	}
+	if len(snap.Slots) != 2 {
+		t.Fatalf("merged file should hold 2 slots, got %d", len(snap.Slots))
+	}
+	gotSlots := map[int]bool{}
+	for _, sd := range snap.Slots {
+		gotSlots[sd.Slot] = true
+	}
+	if !gotSlots[0] || !gotSlots[1] {
+		t.Errorf("merged file missing slot(s): %v", gotSlots)
+	}
+
+	// Sanity: no per-slot files appeared on the IP-keyed path.
+	if _, err := os.Stat(filepath.Join(root, "devices")); !os.IsNotExist(err) {
+		t.Errorf("devices/ dir MUST NOT exist for acp2, err=%v", err)
+	}
+}

--- a/cmd/dhs/common.go
+++ b/cmd/dhs/common.go
@@ -245,6 +245,52 @@ func connect(ctx context.Context, host string, cf *commonFlags) (protocol.Protoc
 	return plug, cleanup, nil
 }
 
+// resolvePathFromCache tries to find an object ID from the disk cache
+// for path-based addressing. Path is a dot-separated label sequence
+// (e.g. "IDENTITY.User Label 1"); the lookup matches on the **suffix**
+// of the cached object's Path so partial parents work too. Returns
+// the ID if found, -1 otherwise.
+//
+// Avoids a full slot walk when the path is already in the cache —
+// previously the set / get verbs always issued plug.Walk(ctx, slot)
+// up-front, blocking for minutes on a 49 000-object Neuron tree.
+func resolvePathFromCache(host, proto string, slot int, path string) int {
+	if treeStore == nil || path == "" {
+		return -1
+	}
+	snap, err := treeStore.Load(host, slot)
+	if err != nil || snap == nil {
+		return -1
+	}
+	if snap.Device.Protocol != "" && snap.Device.Protocol != proto {
+		return -1
+	}
+	wanted := strings.Split(path, ".")
+	for _, sd := range snap.Slots {
+		for _, o := range sd.Objects {
+			if matchPathSuffix(o.Path, wanted) {
+				return o.ID
+			}
+		}
+	}
+	return -1
+}
+
+// matchPathSuffix reports whether wanted is a suffix of objPath
+// (element-wise, case-sensitive). Empty wanted matches nothing.
+func matchPathSuffix(objPath, wanted []string) bool {
+	if len(wanted) == 0 || len(objPath) < len(wanted) {
+		return false
+	}
+	off := len(objPath) - len(wanted)
+	for i := range wanted {
+		if objPath[off+i] != wanted[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // resolveLabelFromCache tries to find an object ID from the disk cache
 // for label-based addressing. Returns the ID if found, -1 otherwise.
 // This avoids a full walk when the label is in the disk cache.

--- a/cmd/dhs/flag_alias_test.go
+++ b/cmd/dhs/flag_alias_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestCanonicalDirection covers the alias logic per #324:
+//   - "consumer" / "provider" / "both" → identity (canonical forms)
+//   - "io" → "both" (friendlier synonym for bidirectional products)
+//   - anything else → error citing the allowed values.
+func TestCanonicalDirection(t *testing.T) {
+	cases := []struct {
+		in       string
+		want     string
+		wantErr  bool
+	}{
+		{"consumer", "consumer", false},
+		{"provider", "provider", false},
+		{"both", "both", false},
+		{"io", "both", false},
+		{"sideways", "", true},
+		{"", "", true},
+		{"IO", "", true}, // case-sensitive — "IO" is not "io"
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got, err := canonicalDirection(c.in)
+			if c.wantErr {
+				if err == nil {
+					t.Errorf("canonicalDirection(%q) = %q, want error", c.in, got)
+				}
+				if err != nil && !strings.Contains(err.Error(), "--direction must be one of") {
+					t.Errorf("canonicalDirection(%q) error = %v; want validator message", c.in, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("canonicalDirection(%q) error = %v; want nil", c.in, err)
+			}
+			if got != c.want {
+				t.Errorf("canonicalDirection(%q) = %q; want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/cmd/dhs/path_resolve_test.go
+++ b/cmd/dhs/path_resolve_test.go
@@ -1,0 +1,74 @@
+package main
+
+import "testing"
+
+// TestMatchPathSuffix covers the cache path-resolver matcher used by
+// resolvePathFromCache (cmd_set.go / cmd_get.go). The matcher must be
+// suffix-based so callers can address by full path, partial parents,
+// or just leaf label.
+func TestMatchPathSuffix(t *testing.T) {
+	cases := []struct {
+		name     string
+		objPath  []string
+		wanted   []string
+		expected bool
+	}{
+		{
+			name:     "exact full path",
+			objPath:  []string{"ROOT_NODE_V2", "IDENTITY", "User Label 1"},
+			wanted:   []string{"ROOT_NODE_V2", "IDENTITY", "User Label 1"},
+			expected: true,
+		},
+		{
+			name:     "two-segment suffix",
+			objPath:  []string{"ROOT_NODE_V2", "IDENTITY", "User Label 1"},
+			wanted:   []string{"IDENTITY", "User Label 1"},
+			expected: true,
+		},
+		{
+			name:     "leaf only",
+			objPath:  []string{"ROOT_NODE_V2", "IDENTITY", "User Label 1"},
+			wanted:   []string{"User Label 1"},
+			expected: true,
+		},
+		{
+			name:     "wrong parent rejected",
+			objPath:  []string{"ROOT_NODE_V2", "IDENTITY", "User Label 1"},
+			wanted:   []string{"GENERAL", "User Label 1"},
+			expected: false,
+		},
+		{
+			name:     "wanted longer than path",
+			objPath:  []string{"User Label 1"},
+			wanted:   []string{"IDENTITY", "User Label 1"},
+			expected: false,
+		},
+		{
+			name:     "empty wanted matches nothing",
+			objPath:  []string{"X"},
+			wanted:   []string{},
+			expected: false,
+		},
+		{
+			name:     "case-sensitive",
+			objPath:  []string{"identity", "user label 1"},
+			wanted:   []string{"User Label 1"},
+			expected: false,
+		},
+		{
+			name:     "spaces preserved in segments",
+			objPath:  []string{"INPUT.SDI", "CHANNEL 01", "Direction"},
+			wanted:   []string{"CHANNEL 01", "Direction"},
+			expected: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := matchPathSuffix(c.objPath, c.wanted)
+			if got != c.expected {
+				t.Errorf("matchPathSuffix(%v, %v) = %t; want %t",
+					c.objPath, c.wanted, got, c.expected)
+			}
+		})
+	}
+}

--- a/internal/acp2/CLAUDE.md
+++ b/internal/acp2/CLAUDE.md
@@ -129,7 +129,7 @@ Alignment: after each property, skip `(4 - (plen % 4)) % 4` bytes.
 |   1 | object_type       | R        |  -  |                           |
 |   2 | label             | R        |  -  | 0-terminated UTF-8        |
 |   3 | access            | R        |  Y  | 1=r, 2=w, 3=rw            |
-|   4 | announce_delay    | RW       |  Y  | u32 ms (NOT "event_delay")|
+|   4 | event_delay       | RW       |  Y  | u32 ms                    |
 |   5 | number_type       | R        |  -  |                           |
 |   6 | string_max_length | R        |  -  | u16                       |
 |   7 | preset_depth      | R        |  -  | optional; valid idx list  |
@@ -206,8 +206,8 @@ slot 0 = `[2,3,4]`, slot 1 = `[2,3]`. Our ACP2-only producer emits
 - ACP2 mtid pool: 1-255; 0 reserved for announces.
 - mtid NEVER reused while a request is in-flight.
 - EnableProtocolEvents MUST be called after every (re)connect.
-- pid=4 is "announce_delay" — NEVER call it "event_delay".
-- type=2 is "announce" — NEVER call it "event".
+- pid=4 is "event_delay" per spec §5.4 row 4.
+- type=2 is "announce" per spec §3.2 type-field row.
 - ACP2 strings are UTF-8; ACP1 strings are ASCII.
 - All multi-byte values are big-endian.
 
@@ -216,5 +216,5 @@ slot 0 = `[2,3,4]`, slot 1 = `[2,3]`. Our ACP2-only producer emits
 - Do NOT use fixed byte offsets for property data — use pid/plen headers.
 - Do NOT skip EnableProtocolEvents before expecting announces.
 - Do NOT reuse a live mtid.
-- Do NOT call pid=4 "event_delay".
+- Spec name for pid=4 is "event_delay" — match the docx exactly.
 - Do NOT use idx=0 to mean "first preset".

--- a/internal/acp2/CLAUDE.md
+++ b/internal/acp2/CLAUDE.md
@@ -183,6 +183,23 @@ Body:         obj-id(u32), idx(u32), property header for pid
 Only received after `AN2 EnableProtocolEvents([2])`. AN2 slot events
 (proto=0) are always received regardless.
 
+## AN2 reply byte shapes (§3.3, wire-verified)
+
+Every AN2 reply payload format is fixed by the spec table on its
+section page; copy from these and never paraphrase:
+
+| Func | § | Reply payload bytes | dlen |
+|---|---|---|---:|
+| GetVersion (0) | §3.3.1 | `func(u8) ver(u16BE)` | 3 |
+| GetDeviceInfo (1) | §3.3.2 | `func(u8) info(u8)` (info = total slot count incl slot 0) | 2 |
+| GetSlotInfo (2) | §3.3.3 | `func(u8) stat(u8) num(u8) protos(u8*num)` | 3+num |
+| EnableProtocolEvents (3) | §3.3.4 | `func(u8)` (single byte) | 1 |
+
+Slot proto list (§3.2.1 + §1.2.3) advertises *payload* protos only —
+never proto=0 (AN2-internal signalling layer). Real EVS Neuron emits
+slot 0 = `[2,3,4]`, slot 1 = `[2,3]`. Our ACP2-only producer emits
+`[2]`.
+
 ## Key invariants
 
 - AN2 mtid is always 0 for data frames.

--- a/internal/acp2/codec/codec.go
+++ b/internal/acp2/codec/codec.go
@@ -150,8 +150,11 @@ func EncodeACP2Message(m *ACP2Message) ([]byte, error) {
 //	| 3      | pid    | u8    | pid / padding / version number            |
 //
 // Body parsing rules:
-//   - type=3 error: first 4 body bytes (if present) decode as obj-id u32 BE.
-//     func byte is reinterpreted as ACP2ErrStatus via ToACP2Error.
+//   - type=3 error: per spec §"Error" the message is exactly the
+//     4-byte ACP2 header; no body. The func byte is reinterpreted as
+//     ACP2ErrStatus via ToACP2Error. Any trailing bytes are stashed
+//     in m.Body so a caller / compliance check can flag the
+//     deviation, but ObjID is NEVER populated from them.
 //   - reply + func=get_version: header only; pid holds the version byte.
 //   - reply / announce (funcs 1-3): body layout
 //     [0..3]   obj-id  u32 BE
@@ -178,11 +181,17 @@ func DecodeACP2Message(data []byte) (*ACP2Message, error) {
 	m.Body = make([]byte, len(body))
 	copy(m.Body, body)
 
-	// For error messages, extract obj-id from body if present.
+	// For error messages, the spec (§"Error", line 1207-1250 of
+	// acp2_protocol.docx) defines the message as exactly the 4-byte
+	// ACP2 header — NO body. Do not synthesise ObjID from any
+	// trailing bytes; doing so silently masks producer bugs in
+	// shipping peers and prevents detection of spec-non-compliant
+	// wire shapes.
 	if m.Type == ACP2TypeError {
-		if len(body) >= 4 {
-			m.ObjID = binary.BigEndian.Uint32(body[0:4])
-		}
+		// Trailing bytes (if any) remain in m.Body for caller-side
+		// compliance checks to inspect. ObjID stays 0 — clients
+		// needing to correlate the error with a specific request use
+		// the mtid, not a body-derived obj-id.
 		return m, nil
 	}
 

--- a/internal/acp2/codec/codec.go
+++ b/internal/acp2/codec/codec.go
@@ -84,18 +84,27 @@ func EncodeACP2Message(m *ACP2Message) ([]byte, error) {
 		return buf, nil
 
 	case ACP2FuncGetProperty:
-		// get_property request: header + obj-id(4) + idx(4) + property header(4)
-		buf := make([]byte, ACP2HeaderSize+8+4)
+		// get_property request per spec §"Get property" Request
+		// (acp2_protocol.docx line 990-1020): body = obj-id(u32 BE) +
+		// idx(u32 BE). The requested pid is carried in the ACP2
+		// header byte 3 — there is NO trailing property header in
+		// the request body.
+		//
+		//	| Offset | Field  | Width  | Notes                          |
+		//	|--------|--------|--------|--------------------------------|
+		//	| 0      | type   | u8     | 0 = request                    |
+		//	| 1      | mtid   | u8     | 1..255                         |
+		//	| 2      | func   | u8     | 2 = get_property               |
+		//	| 3      | pid    | u8     | property id requested          |
+		//	| 4-7    | obj-id | u32 BE | target object id               |
+		//	| 8-11   | idx    | u32 BE | preset idx (0 = ACTIVE INDEX)  |
+		buf := make([]byte, ACP2HeaderSize+8)
 		buf[0] = byte(m.Type)
 		buf[1] = m.MTID
 		buf[2] = byte(m.Func)
 		buf[3] = m.PID
 		binary.BigEndian.PutUint32(buf[4:8], m.ObjID)
 		binary.BigEndian.PutUint32(buf[8:12], m.Idx)
-		// Property header for the requested pid: pid, 0, plen=4
-		buf[12] = m.PID
-		buf[13] = 0
-		binary.BigEndian.PutUint16(buf[14:16], 4)
 		return buf, nil
 
 	case ACP2FuncSetProperty:

--- a/internal/acp2/codec/codec_test.go
+++ b/internal/acp2/codec/codec_test.go
@@ -147,13 +147,23 @@ func TestEncodeDecodeACP2Message_GetProperty(t *testing.T) {
 		t.Fatalf("Encode: %v", err)
 	}
 
-	// Should be header(4) + obj-id(4) + idx(4) + prop-header(4) = 16
-	if len(data) != 16 {
-		t.Fatalf("expected 16 bytes, got %d", len(data))
+	// Per spec §"Get property" Request (acp2_protocol.docx line 990-1020):
+	// body = obj-id (u32 BE) + idx (u32 BE). The pid is carried in ACP2
+	// header byte 3; there is NO trailing property header. Total = 12 bytes.
+	if len(data) != 12 {
+		t.Fatalf("expected 12 bytes (4 hdr + 4 obj-id + 4 idx) per spec; got %d", len(data))
 	}
 
-	// Verify the property header in the request.
-	if data[12] != PIDValue {
-		t.Errorf("prop pid: got %d, want %d", data[12], PIDValue)
+	// Verify pid in header byte 3.
+	if data[3] != PIDValue {
+		t.Errorf("ACP2 header byte 3 (pid): got %d, want %d", data[3], PIDValue)
+	}
+	// Verify obj-id at bytes 4-7.
+	if got := binary.BigEndian.Uint32(data[4:8]); got != 100 {
+		t.Errorf("obj-id: got %d, want 100", got)
+	}
+	// Verify idx at bytes 8-11.
+	if got := binary.BigEndian.Uint32(data[8:12]); got != 0 {
+		t.Errorf("idx: got %d, want 0", got)
 	}
 }

--- a/internal/acp2/codec/codec_test.go
+++ b/internal/acp2/codec/codec_test.go
@@ -93,16 +93,15 @@ func TestDecodeACP2Message_Reply(t *testing.T) {
 }
 
 func TestDecodeACP2Message_Error(t *testing.T) {
-	// Simulate an error reply: type=3, mtid=2, stat=1 (invalid obj-id), pid=0
-	// Body: obj-id = 99
-	body := make([]byte, 4)
-	binary.BigEndian.PutUint32(body, 99)
-	data := append([]byte{
-		byte(ACP2TypeError), // type
-		2,                    // mtid
-		byte(ErrInvalidObjID), // stat
-		0,                    // pid
-	}, body...)
+	// Per spec §"Error" (line 1207-1250): error message is exactly the
+	// 4-byte ACP2 header. No body. Decoder must NOT synthesise ObjID
+	// from any trailing bytes.
+	data := []byte{
+		byte(ACP2TypeError),    // type
+		2,                       // mtid
+		byte(ErrInvalidObjID),   // stat (in func slot)
+		0,                       // pid
+	}
 
 	msg, err := DecodeACP2Message(data)
 	if err != nil {
@@ -114,13 +113,41 @@ func TestDecodeACP2Message_Error(t *testing.T) {
 	if ACP2ErrStatus(msg.Func) != ErrInvalidObjID {
 		t.Errorf("stat: got %d, want %d", msg.Func, ErrInvalidObjID)
 	}
-	if msg.ObjID != 99 {
-		t.Errorf("obj-id: got %d, want 99", msg.ObjID)
+	if msg.ObjID != 0 {
+		t.Errorf("obj-id=%d want 0 (spec: error has no body)", msg.ObjID)
 	}
 
 	acp2Err := msg.ToACP2Error()
 	if acp2Err == nil {
 		t.Fatal("expected non-nil error")
+	}
+}
+
+// TestDecodeACP2Message_Error_TolerantOfTrailingBytes verifies that a
+// non-compliant peer that emits an error with a body (e.g. trailing
+// obj-id) does not crash the decoder, and that ObjID remains 0
+// (never synthesised from those bytes — they may be garbage).
+func TestDecodeACP2Message_Error_TolerantOfTrailingBytes(t *testing.T) {
+	body := make([]byte, 4)
+	binary.BigEndian.PutUint32(body, 99) // bogus trailing obj-id
+	data := append([]byte{
+		byte(ACP2TypeError),
+		3,
+		byte(ErrInvalidObjID),
+		0,
+	}, body...)
+
+	msg, err := DecodeACP2Message(data)
+	if err != nil {
+		t.Fatalf("Decode: %v (decoder must tolerate trailing bytes)", err)
+	}
+	if msg.ObjID != 0 {
+		t.Errorf("obj-id=%d want 0 (decoder MUST NOT synthesise obj-id "+
+			"from trailing bytes per spec §Error)", msg.ObjID)
+	}
+	if len(msg.Body) != 4 {
+		t.Errorf("Body len=%d want 4 (trailing bytes preserved for "+
+			"caller-side compliance inspection)", len(msg.Body))
 	}
 }
 

--- a/internal/acp2/codec/property_codec.go
+++ b/internal/acp2/codec/property_codec.go
@@ -34,9 +34,9 @@ func propertyPadding(plen uint16) int {
 //	| 4..    | value   | plen-4| raw bytes; absent when plen == 4          |
 //	| plen.. | padding | 0-3   | (4 - (plen % 4)) % 4 zero bytes           |
 //
-// pid=4 is announce_delay — never "event_delay".
+// pid=4 is event_delay per spec §5.4 row 4.
 //
-// Spec reference: acp2_protocol.pdf §Property Header, §Property IDs
+// Spec reference: acp2_protocol.docx §Property Header, §Property IDs
 func DecodeProperties(data []byte) ([]Property, error) {
 	var props []Property
 	offset := 0

--- a/internal/acp2/codec/property_codec.go
+++ b/internal/acp2/codec/property_codec.go
@@ -173,50 +173,78 @@ func PropertyChildren(p *Property) ([]uint32, error) {
 	return ids, nil
 }
 
-// ACP2OptionSize is the fixed on-wire size of one enum option per spec
-// §5.4 pid 15: 4-byte u32 index + 68-byte NUL-padded UTF-8 name = 72 bytes.
+// ACP2OptionSize is the spec-literal stride per option per
+// acp2_protocol.docx §5.4 row 15: 4-byte u32 index + 68-byte
+// NUL-padded UTF-8 name = 72 bytes. No production controller emits
+// this layout — kept for fixture/golden inspection only.
 const ACP2OptionSize = 72
 
-// PropertyOptions extracts enum option labels (ordered by wire position)
-// from a pid=15 property. Fixed 72-byte stride per spec §5.4.
+// PropertyOptions extracts enum option labels (ordered by wire
+// position) from a pid=15 property. Records are variable-length per
+// real-device convention: u32 idx + NUL-terminated name + 0-3 byte
+// pad to the next 4-byte boundary. Spec deviation tolerated; see
+// `acp2_options_variable_length_per_device_convention` compliance
+// event.
 func PropertyOptions(p *Property) []string {
-	if len(p.Data) < ACP2OptionSize {
+	m := PropertyOptionsMap(p)
+	if m == nil {
 		return nil
 	}
-	n := len(p.Data) / ACP2OptionSize
-	labels := make([]string, 0, n)
-	for i := 0; i < n; i++ {
-		off := i * ACP2OptionSize
-		labels = append(labels, trimZero(p.Data[off+4:off+ACP2OptionSize]))
-	}
-	return labels
-}
-
-// PropertyOptionsMap extracts enum options as a map of index → label.
-// Fixed 72-byte stride per spec §5.4 pid 15.
-func PropertyOptionsMap(p *Property) map[uint32]string {
-	if len(p.Data) < ACP2OptionSize {
-		return nil
-	}
-	n := len(p.Data) / ACP2OptionSize
-	m := make(map[uint32]string, n)
-	for i := 0; i < n; i++ {
-		off := i * ACP2OptionSize
-		idx := binary.BigEndian.Uint32(p.Data[off : off+4])
-		m[idx] = trimZero(p.Data[off+4 : off+ACP2OptionSize])
-	}
-	return m
-}
-
-// trimZero returns the UTF-8 prefix of b up to the first NUL byte (or
-// the full slice if none). Used for fixed-width NUL-padded name slots.
-func trimZero(b []byte) string {
-	for i, c := range b {
-		if c == 0 {
-			return string(b[:i])
+	// Re-walk to preserve wire order (map iteration is unordered).
+	out := make([]string, 0, len(m))
+	pos := 0
+	for pos < len(p.Data) {
+		if pos+4 > len(p.Data) {
+			break
+		}
+		strStart := pos + 4
+		end := strStart
+		for end < len(p.Data) && p.Data[end] != 0 {
+			end++
+		}
+		out = append(out, string(p.Data[strStart:end]))
+		// advance past name + NUL + pad
+		pos = end
+		if pos < len(p.Data) && p.Data[pos] == 0 {
+			pos++
+		}
+		recUsed := pos - (strStart - 4)
+		if pad := (4 - (recUsed % 4)) % 4; pad > 0 {
+			pos += pad
 		}
 	}
-	return string(b)
+	return out
+}
+
+// PropertyOptionsMap extracts enum options as a map of wire index →
+// label. Variable-length per option; see PropertyOptions.
+func PropertyOptionsMap(p *Property) map[uint32]string {
+	if len(p.Data) < 4 {
+		return nil
+	}
+	out := map[uint32]string{}
+	pos := 0
+	for pos < len(p.Data) {
+		if pos+4 > len(p.Data) {
+			break
+		}
+		idx := binary.BigEndian.Uint32(p.Data[pos : pos+4])
+		strStart := pos + 4
+		end := strStart
+		for end < len(p.Data) && p.Data[end] != 0 {
+			end++
+		}
+		out[idx] = string(p.Data[strStart:end])
+		pos = end
+		if pos < len(p.Data) && p.Data[pos] == 0 {
+			pos++
+		}
+		recUsed := pos - (strStart - 4)
+		if pad := (4 - (recUsed % 4)) % 4; pad > 0 {
+			pos += pad
+		}
+	}
+	return out
 }
 
 // PropertyEventMessages extracts the two event message strings from pid=19.

--- a/internal/acp2/codec/property_codec_test.go
+++ b/internal/acp2/codec/property_codec_test.go
@@ -304,13 +304,14 @@ func TestPropertyChildren(t *testing.T) {
 }
 
 func TestPropertyOptions(t *testing.T) {
-	// Spec §5.4 pid 15: fixed 72 bytes per option = u32 BE index + 68-byte
-	// NUL-padded UTF-8 name. Build two options: idx=7 "Off", idx=8 "On".
-	data := make([]byte, 2*ACP2OptionSize)
-	binary.BigEndian.PutUint32(data[0:4], 7)
-	copy(data[4:], "Off")
-	binary.BigEndian.PutUint32(data[ACP2OptionSize:ACP2OptionSize+4], 8)
-	copy(data[ACP2OptionSize+4:], "On")
+	// Variable-length per real-device convention: each record is
+	// u32 BE idx + NUL-terminated name + 0-3 byte align.
+	// Two options: idx=7 "Off" (4+3+1=8 bytes), idx=8 "On" (4+2+1+1=8 bytes).
+	// Wire: `00000007 4f 66 66 00 00000008 4f 6e 00 00` = 16 bytes.
+	data := []byte{
+		0x00, 0x00, 0x00, 0x07, 'O', 'f', 'f', 0x00,
+		0x00, 0x00, 0x00, 0x08, 'O', 'n', 0x00, 0x00,
+	}
 
 	p := &Property{PID: PIDOptions, Data: data}
 	opts := PropertyOptions(p)

--- a/internal/acp2/codec/types.go
+++ b/internal/acp2/codec/types.go
@@ -202,7 +202,7 @@ const (
 	PIDObjectType      uint8 = 1
 	PIDLabel           uint8 = 2
 	PIDAccess          uint8 = 3
-	PIDAnnounceDelay   uint8 = 4
+	PIDEventDelay      uint8 = 4
 	PIDNumberType      uint8 = 5
 	PIDStringMaxLength uint8 = 6
 	PIDPresetDepth     uint8 = 7

--- a/internal/acp2/consumer/catalogue.go
+++ b/internal/acp2/consumer/catalogue.go
@@ -79,7 +79,7 @@ func Catalogue() []CatalogueEntry {
 		{Kind: KindPid, ID: 1, Name: "object_type", SpecRef: "ACP2 §5"},
 		{Kind: KindPid, ID: 2, Name: "label", SpecRef: "ACP2 §5", Notes: "0-terminated UTF-8"},
 		{Kind: KindPid, ID: 3, Name: "access", SpecRef: "ACP2 §5", Notes: "1=r, 2=w, 3=rw"},
-		{Kind: KindPid, ID: 4, Name: "announce_delay", SpecRef: "ACP2 §5", Notes: "u32 ms — NOT 'event_delay'"},
+		{Kind: KindPid, ID: 4, Name: "event_delay", SpecRef: "ACP2 §5.4 row 4", Notes: "u32 BE rate (ms)"},
 		{Kind: KindPid, ID: 5, Name: "number_type", SpecRef: "ACP2 §5"},
 		{Kind: KindPid, ID: 6, Name: "string_max_length", SpecRef: "ACP2 §5", Notes: "u16"},
 		{Kind: KindPid, ID: 7, Name: "preset_depth", SpecRef: "ACP2 §5", Notes: "valid idx list"},

--- a/internal/acp2/consumer/compliance_events.go
+++ b/internal/acp2/consumer/compliance_events.go
@@ -133,6 +133,16 @@ const (
 	// device), we accept it + fire so the operator sees write-path
 	// coercion. Informational.
 	SetValueCoerced = "acp2_set_value_coerced"
+
+	// Spec p.4 §"Mtid": "ACP2 only uses the mtid to send a reply and
+	// does no other checks." Implies replies must carry an mtid that
+	// matches an in-flight request. When a reply arrives for a mtid
+	// the consumer is NOT currently waiting on, either:
+	//   - the peer reused a mtid we already released (peer bug), or
+	//   - our mtid pool released it too early (our bug — impossible
+	//     given defer-based release, but this catches regressions).
+	// Reply is dropped + fires. Informational.
+	OrphanReplyMtid = "acp2_orphan_reply_mtid"
 )
 
 // EventForErrStatus maps an ACP2 error status (spec p.5) to the

--- a/internal/acp2/consumer/mtid_pool_test.go
+++ b/internal/acp2/consumer/mtid_pool_test.go
@@ -1,0 +1,192 @@
+package acp2
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// newPoolTestSession builds a Session with the mtid pool ready (the
+// fields the pool exercises don't need a live TCP connection — alloc
+// /release just touch mtidPool + mtidCond + mtidMu).
+func newPoolTestSession() *Session {
+	s := &Session{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	s.mtidCond = sync.NewCond(&s.mtidMu)
+	return s
+}
+
+// TestMTIDPool_AllocateUniqueAndRelease spec p.4 §"Mtid": "ACP2 only
+// uses the mtid to send a reply and does no other checks." The
+// allocator MUST never hand out an mtid that's currently in flight.
+func TestMTIDPool_AllocateUniqueAndRelease(t *testing.T) {
+	s := newPoolTestSession()
+	ctx := context.Background()
+
+	// Allocate every mtid (1..255). Each must be unique.
+	seen := make(map[uint8]bool, 255)
+	got := make([]uint8, 0, 255)
+	for i := 0; i < 255; i++ {
+		m, err := s.allocMTID(ctx)
+		if err != nil {
+			t.Fatalf("allocMTID #%d: %v", i, err)
+		}
+		if m == 0 {
+			t.Fatalf("allocMTID returned 0 (reserved for announces)")
+		}
+		if seen[m] {
+			t.Fatalf("allocMTID returned duplicate in-flight mtid %d", m)
+		}
+		seen[m] = true
+		got = append(got, m)
+	}
+	if len(seen) != 255 {
+		t.Errorf("got %d unique mtids; want 255", len(seen))
+	}
+
+	// Release them all and verify the next alloc reuses freed slots.
+	for _, m := range got {
+		s.releaseMTID(m)
+	}
+	m2, err := s.allocMTID(ctx)
+	if err != nil {
+		t.Fatalf("alloc after full release: %v", err)
+	}
+	if m2 == 0 {
+		t.Fatal("allocMTID returned 0 after release")
+	}
+	s.releaseMTID(m2)
+}
+
+// TestMTIDPool_BlocksWhenExhausted verifies that a 256th concurrent
+// alloc blocks on mtidCond until a release. Spec p.4 says the mtid
+// space is 1..255; never wrap.
+func TestMTIDPool_BlocksWhenExhausted(t *testing.T) {
+	s := newPoolTestSession()
+	ctx := context.Background()
+
+	// Fill the pool.
+	held := make([]uint8, 0, 255)
+	for i := 0; i < 255; i++ {
+		m, err := s.allocMTID(ctx)
+		if err != nil {
+			t.Fatalf("alloc #%d: %v", i, err)
+		}
+		held = append(held, m)
+	}
+
+	// 256th call must block. Verify by racing it against a 50 ms
+	// release-trigger goroutine.
+	allocResult := make(chan uint8, 1)
+	allocErr := make(chan error, 1)
+	go func() {
+		m, err := s.allocMTID(ctx)
+		if err != nil {
+			allocErr <- err
+			return
+		}
+		allocResult <- m
+	}()
+
+	select {
+	case m := <-allocResult:
+		t.Fatalf("256th alloc returned %d immediately; expected to block", m)
+	case <-time.After(20 * time.Millisecond):
+		// Good — the 256th call is blocked.
+	}
+
+	// Release one and verify the blocked goroutine unblocks.
+	s.releaseMTID(held[42])
+
+	select {
+	case m := <-allocResult:
+		if m == 0 {
+			t.Errorf("alloc returned 0 after release")
+		}
+		// Clean up: release everything we still hold + the new one.
+		s.releaseMTID(m)
+		for i, h := range held {
+			if i == 42 {
+				continue // already released
+			}
+			s.releaseMTID(h)
+		}
+	case err := <-allocErr:
+		t.Fatalf("alloc errored after release: %v", err)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("alloc did not unblock after release")
+	}
+}
+
+// TestMTIDPool_ConcurrentAllocReleaseNeverDuplicates pounds the pool
+// with 50 goroutines each running 100 alloc/release cycles. Tracks
+// every (alloc, release) timestamp to detect any moment where two
+// goroutines hold the same mtid simultaneously.
+func TestMTIDPool_ConcurrentAllocReleaseNeverDuplicates(t *testing.T) {
+	s := newPoolTestSession()
+	ctx := context.Background()
+
+	const goroutines = 50
+	const iterations = 100
+
+	// inFlight tracks mtid -> bool atomically. Use a [256]uint32 with
+	// CAS to detect simultaneous holding.
+	var inFlight [256]uint32
+	var dupCount uint64
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				m, err := s.allocMTID(ctx)
+				if err != nil {
+					t.Errorf("alloc: %v", err)
+					return
+				}
+				if !atomic.CompareAndSwapUint32(&inFlight[m], 0, 1) {
+					atomic.AddUint64(&dupCount, 1)
+				}
+				// Hold for a short time, then release.
+				atomic.StoreUint32(&inFlight[m], 0)
+				s.releaseMTID(m)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if dupCount > 0 {
+		t.Errorf("mtid pool returned %d simultaneously-held mtids across %d goroutines x %d iterations",
+			dupCount, goroutines, iterations)
+	}
+}
+
+// TestMTIDPool_RespectsContextCancel verifies that allocMTID returns
+// ctx.Err() when the context cancels while waiting on a full pool.
+func TestMTIDPool_RespectsContextCancel(t *testing.T) {
+	s := newPoolTestSession()
+
+	// Fill the pool.
+	for i := 0; i < 255; i++ {
+		if _, err := s.allocMTID(context.Background()); err != nil {
+			t.Fatalf("fill alloc #%d: %v", i, err)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	_, err := s.allocMTID(ctx)
+	if err == nil {
+		t.Fatal("alloc on full pool with cancelled ctx returned no error")
+	}
+	if err != context.DeadlineExceeded && err != context.Canceled {
+		t.Errorf("alloc returned %v; want context.DeadlineExceeded", err)
+	}
+}

--- a/internal/acp2/consumer/placeholder_test.go
+++ b/internal/acp2/consumer/placeholder_test.go
@@ -91,12 +91,12 @@ func TestACP2MessageHeader(t *testing.T) {
 	}
 }
 
-// TestACP2ErrorDecode verifies error reply decoding.
+// TestACP2ErrorDecode verifies error reply decoding per spec §"Error":
+// the message is exactly the 4-byte ACP2 header, no body. ObjID is
+// NOT populated from any trailing bytes — clients correlate via mtid.
 func TestACP2ErrorDecode(t *testing.T) {
-	// Build: type=3, mtid=2, stat=4 (no access), pid=0, body: obj-id=50
-	body := make([]byte, 4)
-	binary.BigEndian.PutUint32(body, 50)
-	data := append([]byte{3, 2, 4, 0}, body...)
+	// Spec-compliant 4-byte error: type=3, mtid=2, stat=4, pid=0.
+	data := []byte{3, 2, 4, 0}
 
 	msg, err := codec.DecodeACP2Message(data)
 	if err != nil {
@@ -105,8 +105,8 @@ func TestACP2ErrorDecode(t *testing.T) {
 	if msg.Type != codec.ACP2TypeError {
 		t.Errorf("type: got %d, want 3", msg.Type)
 	}
-	if msg.ObjID != 50 {
-		t.Errorf("obj-id: got %d, want 50", msg.ObjID)
+	if msg.ObjID != 0 {
+		t.Errorf("obj-id=%d want 0 (spec: error has no body)", msg.ObjID)
 	}
 
 	acp2Err := msg.ToACP2Error()

--- a/internal/acp2/consumer/plugin.go
+++ b/internal/acp2/consumer/plugin.go
@@ -66,6 +66,117 @@ type Plugin struct {
 	profile *compliance.Profile
 }
 
+// SeedTreeFromCachedObjects rebuilds an in-memory WalkedTree from a
+// previously-walked + persisted snapshot and inserts it into the
+// per-slot tree cache. After this returns, the next Subscribe-fed
+// announce can decode types and labels immediately — no need to wait
+// for a fresh Walk to populate the cache.
+//
+// Used by the watch CLI on startup (cmd_watch.go #323): load the disk
+// snapshot, hand it to the plugin, then Subscribe. Without this, the
+// first set of announces render as `raw(N)` until the background walk
+// finishes (sometimes 30+ s on a 50 000-object Neuron tree).
+//
+// The snapshot's objects MUST carry acp2.objType + acp2.numType in
+// Meta (set by walker.go on a normal walk). Objects without those
+// keys are kept in the tree for label resolution but their value
+// decoding falls back to KindRaw — same as today.
+func (p *Plugin) SeedTreeFromCachedObjects(slot int, objs []protocol.Object) {
+	p.mu.Lock()
+	if p.trees == nil {
+		p.trees = newWalkedTreeCache(32, 10*time.Minute)
+	}
+	cache := p.trees
+	p.mu.Unlock()
+
+	tree := &WalkedTree{
+		Slot:        slot,
+		Objects:     make([]protocol.Object, 0, len(objs)),
+		ObjTypes:    make([]codec.ACP2ObjType, 0, len(objs)),
+		NumTypes:    make([]codec.NumberType, 0, len(objs)),
+		OptionsMaps: make([]map[uint32]string, 0, len(objs)),
+		Labels:      make(map[string]int, len(objs)),
+	}
+	for i, o := range objs {
+		// Fill ObjType / NumType from Meta. Default to ObjTypeNode /
+		// NumTypeS32 when absent — Nodes don't decode values, and
+		// the Subscribe path falls back to vtype-from-wire when
+		// ObjType is unset.
+		var ot codec.ACP2ObjType
+		var nt codec.NumberType
+		if o.Meta != nil {
+			if v, ok := o.Meta["acp2.objType"]; ok {
+				ot = codec.ACP2ObjType(metaToUint8(v))
+			}
+			if v, ok := o.Meta["acp2.numType"]; ok {
+				nt = codec.NumberType(metaToUint8(v))
+			}
+		}
+		var optMap map[uint32]string
+		if o.Meta != nil {
+			if v, ok := o.Meta["acp2.optionsMap"]; ok {
+				optMap = decodeStringlyOptionsMap(v)
+			}
+		}
+		tree.Objects = append(tree.Objects, o)
+		tree.ObjTypes = append(tree.ObjTypes, ot)
+		tree.NumTypes = append(tree.NumTypes, nt)
+		tree.OptionsMaps = append(tree.OptionsMaps, optMap)
+		if o.Label != "" {
+			tree.Labels[o.Label] = i
+		}
+	}
+	cache.Put(slot, tree)
+}
+
+// metaToUint8 coerces a Meta value into uint8. Tolerates the
+// JSON-decoded float64 that arrives when a snapshot round-trips
+// through encoding/json plus the in-memory uint8 the live walker
+// stashes. Returns 0 on unrecognised types.
+func metaToUint8(v any) uint8 {
+	switch x := v.(type) {
+	case uint8:
+		return x
+	case int:
+		return uint8(x)
+	case int64:
+		return uint8(x)
+	case float64:
+		return uint8(x)
+	}
+	return 0
+}
+
+// decodeStringlyOptionsMap turns a JSON-decoded `map[string]any`
+// (where keys are stringified u32 indices and values are labels)
+// back into the in-memory `map[uint32]string` shape WalkedTree
+// expects. Tolerates the live-walker shape (already correct) too.
+func decodeStringlyOptionsMap(v any) map[uint32]string {
+	switch x := v.(type) {
+	case map[uint32]string:
+		return x
+	case map[string]string:
+		out := make(map[uint32]string, len(x))
+		for k, lbl := range x {
+			var idx uint32
+			_, _ = fmt.Sscanf(k, "%d", &idx)
+			out[idx] = lbl
+		}
+		return out
+	case map[string]any:
+		out := make(map[uint32]string, len(x))
+		for k, lbl := range x {
+			var idx uint32
+			_, _ = fmt.Sscanf(k, "%d", &idx)
+			if s, ok := lbl.(string); ok {
+				out[idx] = s
+			}
+		}
+		return out
+	}
+	return nil
+}
+
 // ComplianceProfile returns the session-scoped compliance profile.
 // Returns nil if Connect hasn't been called yet. Safe to call from
 // any goroutine.

--- a/internal/acp2/consumer/plugin.go
+++ b/internal/acp2/consumer/plugin.go
@@ -326,6 +326,42 @@ func (p *Plugin) Walk(ctx context.Context, slot int) ([]protocol.Object, error) 
 	return tree.Objects, nil
 }
 
+// IdentityProbe walks slot 0 (sub-second on any Axon device) and
+// derives a stable device identity = "<CardName>@<HardwareVersion>"
+// by looking up obj labels in the ROOT_NODE_V2.BOARD subtree.
+// Returns "" with err when either label is missing or the slot 0
+// walk fails — caller should fall back to a fresh full walk.
+//
+// Why labels and not obj-ids: ACP2 obj-ids vary per product, but
+// the labels "Card Name" and "Hardware Version" are constant across
+// the Axon catalogue (verified against real Neuron 10.41.40.4 +
+// tree-fresh.json).
+func (p *Plugin) IdentityProbe(ctx context.Context) (string, error) {
+	objs, err := p.Walk(ctx, 0)
+	if err != nil {
+		return "", fmt.Errorf("acp2: identity probe walk(slot=0): %w", err)
+	}
+	cardName := ""
+	hwVersion := ""
+	for _, o := range objs {
+		switch o.Label {
+		case "Card Name":
+			if o.Value.Kind == protocol.KindString {
+				cardName = o.Value.Str
+			}
+		case "Hardware Version":
+			if o.Value.Kind == protocol.KindString {
+				hwVersion = o.Value.Str
+			}
+		}
+	}
+	if cardName == "" || hwVersion == "" {
+		return "", fmt.Errorf("acp2: identity probe — missing Card Name (%q) or Hardware Version (%q) on slot 0",
+			cardName, hwVersion)
+	}
+	return fmt.Sprintf("%s@%s", cardName, hwVersion), nil
+}
+
 // GetValue reads one object value via ACP2 get_property(pid=8).
 func (p *Plugin) GetValue(ctx context.Context, req protocol.ValueRequest) (protocol.Value, error) {
 	p.mu.Lock()

--- a/internal/acp2/consumer/plugin.go
+++ b/internal/acp2/consumer/plugin.go
@@ -515,15 +515,18 @@ func (p *Plugin) Subscribe(req protocol.ValueRequest, fn protocol.EventFunc) err
 						ev.Value = val
 					}
 				}
-				// Fallback: use vtype from announce property to decode
-				// when tree doesn't contain this object.
+				// Fallback when the tree didn't have this obj (slow walk
+				// finishes after announce arrives, or watch started cold).
+				// The property header's vtype byte (spec §5.2.2) tells us
+				// the wire shape; map it to the corresponding ACP2 ObjType
+				// so Enum / IPv4 / String announces decode typed instead
+				// of falling through to KindRaw.
 				if ev.Value.Kind == protocol.KindUnknown && prop.Data != nil {
 					nt := codec.NumberType(prop.VType)
-					if nt > 0 {
-						val, derr := decodePropertyValue(prop, codec.ObjTypeNumber, nt, nil, msg.ObjID)
-						if derr == nil {
-							ev.Value = val
-						}
+					ot := objTypeFromVType(nt)
+					val, derr := decodePropertyValue(prop, ot, nt, nil, msg.ObjID)
+					if derr == nil {
+						ev.Value = val
 					}
 					if ev.Value.Kind == protocol.KindUnknown {
 						ev.Value = protocol.Value{Kind: protocol.KindRaw, Raw: prop.Data}
@@ -589,6 +592,31 @@ func (p *Plugin) resolveRequest(req protocol.ValueRequest, tree *WalkedTree) (ui
 	// No tree or not found — return with unknown type. The caller may
 	// still work with raw bytes.
 	return objID, 0, 0, nil, nil
+}
+
+// objTypeFromVType maps an ACP2 §5.2.2 number-type byte (the data byte
+// of pid 8/9 value properties) to the matching object type. Used by
+// the announce fallback path when the cached tree doesn't have the
+// announced obj — the vtype byte alone tells us how to decode the
+// value body.
+//
+//	| vtype | ACP2 NumberType | ACP2 ObjType   |
+//	|-------|-----------------|----------------|
+//	| 0..8  | s8..float       | ObjTypeNumber  |
+//	| 9     | preset/enum     | ObjTypeEnum    |
+//	| 10    | ipv4            | ObjTypeIPv4    |
+//	| 11    | string          | ObjTypeString  |
+func objTypeFromVType(nt codec.NumberType) codec.ACP2ObjType {
+	switch nt {
+	case codec.NumTypePreset:
+		return codec.ObjTypeEnum
+	case codec.NumTypeIPv4:
+		return codec.ObjTypeIPv4
+	case codec.NumTypeString:
+		return codec.ObjTypeString
+	default:
+		return codec.ObjTypeNumber
+	}
 }
 
 // decodePropertyValue decodes a value Property into a protocol.Value.

--- a/internal/acp2/consumer/seed_cache_test.go
+++ b/internal/acp2/consumer/seed_cache_test.go
@@ -1,0 +1,81 @@
+package acp2
+
+import (
+	"testing"
+
+	"dhs/internal/acp2/codec"
+	"dhs/internal/protocol"
+)
+
+// TestSeedTreeFromCachedObjects pins #353: a snapshot's per-object
+// Meta carries acp2.objType / acp2.numType / acp2.optionsMap, and
+// SeedTreeFromCachedObjects rebuilds the parallel arrays so the
+// announce decoder can resolve types + enum labels from the in-memory
+// tree before any fresh walk runs.
+//
+// JSON round-trip note: encoded Meta values come back as float64 +
+// map[string]any, so the test exercises BOTH the in-process path
+// (uint8 / map[uint32]string) and the post-JSON path
+// (float64 / map[string]any) via metaToUint8 + decodeStringlyOptionsMap.
+func TestSeedTreeFromCachedObjects_DirectTypes(t *testing.T) {
+	p := &Plugin{trees: newWalkedTreeCache(4, 0)}
+	objs := []protocol.Object{
+		{
+			Slot: 1, ID: 17671, Label: "IO Board",
+			Meta: map[string]any{
+				"acp2.objType": uint8(codec.ObjTypeEnum),
+				"acp2.numType": uint8(codec.NumTypePreset),
+				"acp2.optionsMap": map[uint32]string{
+					16: "NA", 120: "Present",
+				},
+			},
+		},
+	}
+	p.SeedTreeFromCachedObjects(1, objs)
+
+	tree, ok := p.trees.Get(1)
+	if !ok || tree == nil {
+		t.Fatal("trees not populated after seed")
+	}
+	if len(tree.ObjTypes) != 1 || tree.ObjTypes[0] != codec.ObjTypeEnum {
+		t.Errorf("ObjTypes[0]=%v want Enum", tree.ObjTypes[0])
+	}
+	if tree.OptionsMaps[0] == nil || tree.OptionsMaps[0][120] != "Present" {
+		t.Errorf("OptionsMap[120] not resolved: %v", tree.OptionsMaps[0])
+	}
+}
+
+// TestSeedTreeFromCachedObjects_PostJSONShape covers the canonical
+// JSON-decoded form (numbers as float64, maps as map[string]any),
+// which is what tree_store.LoadByIdentity returns from disk.
+func TestSeedTreeFromCachedObjects_PostJSONShape(t *testing.T) {
+	p := &Plugin{trees: newWalkedTreeCache(4, 0)}
+	objs := []protocol.Object{
+		{
+			Slot: 1, ID: 21127, Label: "Fan Control",
+			Meta: map[string]any{
+				"acp2.objType": float64(codec.ObjTypeEnum),
+				"acp2.numType": float64(codec.NumTypePreset),
+				"acp2.optionsMap": map[string]any{
+					"786": "Automatic",
+					"791": "Full Speed",
+				},
+			},
+		},
+	}
+	p.SeedTreeFromCachedObjects(1, objs)
+
+	tree, ok := p.trees.Get(1)
+	if !ok || tree == nil {
+		t.Fatal("trees not populated after seed")
+	}
+	if tree.ObjTypes[0] != codec.ObjTypeEnum {
+		t.Errorf("ObjTypes[0]=%v want Enum", tree.ObjTypes[0])
+	}
+	if tree.OptionsMaps[0][786] != "Automatic" || tree.OptionsMaps[0][791] != "Full Speed" {
+		t.Errorf("OptionsMap reconstruction failed: %v", tree.OptionsMaps[0])
+	}
+	if tree.Labels["Fan Control"] != 0 {
+		t.Errorf("Labels not populated: %v", tree.Labels)
+	}
+}

--- a/internal/acp2/consumer/seed_tree_test.go
+++ b/internal/acp2/consumer/seed_tree_test.go
@@ -1,0 +1,146 @@
+package acp2
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"dhs/internal/acp2/codec"
+	"dhs/internal/protocol"
+)
+
+// TestSeedTreeFromCachedObjects pins the disk-cache fast-path for
+// watch (#323): a Plugin instance that hasn't done a live Walk should
+// still serve a populated WalkedTree out of trees.Get(slot) after the
+// CLI calls SeedTreeFromCachedObjects with the disk snapshot.
+//
+// The walker stashes acp2.objType / acp2.numType / acp2.optionsMap in
+// obj.Meta on a normal walk; those keys round-trip through the disk
+// JSON cache. SeedTreeFromCachedObjects reads them back to rebuild
+// the parallel ObjTypes / NumTypes / OptionsMaps slices Subscribe
+// needs to decode announces.
+func TestSeedTreeFromCachedObjects(t *testing.T) {
+	p := &Plugin{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	// Build snapshot-shaped objects: live-walker shape (uint8 in Meta).
+	objs := []protocol.Object{
+		{
+			Slot: 1, ID: 5, Label: "Volume",
+			Meta: map[string]any{
+				"acp2.objType": uint8(codec.ObjTypeNumber),
+				"acp2.numType": uint8(codec.NumTypeS32),
+			},
+		},
+		{
+			Slot: 1, ID: 6, Label: "Mute",
+			Meta: map[string]any{
+				"acp2.objType":    uint8(codec.ObjTypeEnum),
+				"acp2.numType":    uint8(codec.NumTypePreset),
+				"acp2.optionsMap": map[string]string{"0": "Off", "1": "On"},
+			},
+		},
+	}
+
+	p.SeedTreeFromCachedObjects(1, objs)
+
+	tree, ok := p.trees.Get(1)
+	if !ok || tree == nil {
+		t.Fatal("trees.Get(1) returned no tree after seed")
+	}
+	if len(tree.Objects) != 2 {
+		t.Fatalf("Objects len=%d want 2", len(tree.Objects))
+	}
+	if tree.ObjTypes[0] != codec.ObjTypeNumber {
+		t.Errorf("ObjTypes[0]=%v want Number", tree.ObjTypes[0])
+	}
+	if tree.NumTypes[0] != codec.NumTypeS32 {
+		t.Errorf("NumTypes[0]=%v want S32", tree.NumTypes[0])
+	}
+	if tree.ObjTypes[1] != codec.ObjTypeEnum {
+		t.Errorf("ObjTypes[1]=%v want Enum", tree.ObjTypes[1])
+	}
+	if tree.OptionsMaps[1] == nil {
+		t.Fatal("OptionsMaps[1] is nil; expected {0:Off, 1:On}")
+	}
+	if tree.OptionsMaps[1][0] != "Off" || tree.OptionsMaps[1][1] != "On" {
+		t.Errorf("OptionsMaps[1]=%v want {0:Off, 1:On}", tree.OptionsMaps[1])
+	}
+	if tree.Labels["Volume"] != 0 {
+		t.Errorf("Labels[Volume]=%d want 0", tree.Labels["Volume"])
+	}
+}
+
+// TestSeedTreeFromCachedObjects_JSONRoundTrip simulates the disk
+// reload path: Meta values arrive as JSON-decoded `float64` (numbers)
+// and `map[string]any` (nested map). SeedTreeFromCachedObjects must
+// coerce both shapes back into typed values.
+func TestSeedTreeFromCachedObjects_JSONRoundTrip(t *testing.T) {
+	p := &Plugin{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	objs := []protocol.Object{
+		{
+			Slot: 1, ID: 5, Label: "Vol",
+			Meta: map[string]any{
+				// JSON unmarshal into any → float64.
+				"acp2.objType": float64(codec.ObjTypeNumber),
+				"acp2.numType": float64(codec.NumTypeS32),
+			},
+		},
+		{
+			Slot: 1, ID: 6, Label: "Mode",
+			Meta: map[string]any{
+				"acp2.objType": float64(codec.ObjTypeEnum),
+				"acp2.numType": float64(codec.NumTypePreset),
+				// JSON-decoded options map: map[string]any with string values.
+				"acp2.optionsMap": map[string]any{"42": "A", "99": "Z"},
+			},
+		},
+	}
+	p.SeedTreeFromCachedObjects(1, objs)
+	tree, _ := p.trees.Get(1)
+	if tree == nil {
+		t.Fatal("no tree after seed (json round-trip)")
+	}
+	if tree.ObjTypes[0] != codec.ObjTypeNumber {
+		t.Errorf("ObjTypes[0]=%v want Number (float64 coercion failed)", tree.ObjTypes[0])
+	}
+	if tree.NumTypes[0] != codec.NumTypeS32 {
+		t.Errorf("NumTypes[0]=%v want S32", tree.NumTypes[0])
+	}
+	if tree.OptionsMaps[1] == nil {
+		t.Fatal("OptionsMaps[1] nil after JSON-shaped seed")
+	}
+	if tree.OptionsMaps[1][42] != "A" || tree.OptionsMaps[1][99] != "Z" {
+		t.Errorf("OptionsMaps[1]=%v want {42:A, 99:Z}", tree.OptionsMaps[1])
+	}
+}
+
+// TestSeedTreeFromCachedObjects_TimingFastPath asserts the seed
+// path doesn't take longer than the implicit Walk would on a 50k
+// tree. This is a smoke test: 5 000 objects must seed in under 50 ms
+// on a typical workstation; cache.Put is O(1) and our parallel
+// slice fills are O(n).
+func TestSeedTreeFromCachedObjects_TimingFastPath(t *testing.T) {
+	p := &Plugin{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	objs := make([]protocol.Object, 5000)
+	for i := range objs {
+		objs[i] = protocol.Object{
+			Slot: 1, ID: i + 1, Label: "x",
+			Meta: map[string]any{
+				"acp2.objType": uint8(codec.ObjTypeNumber),
+				"acp2.numType": uint8(codec.NumTypeS32),
+			},
+		}
+	}
+	start := time.Now()
+	p.SeedTreeFromCachedObjects(1, objs)
+	elapsed := time.Since(start)
+	if elapsed > 50*time.Millisecond {
+		t.Errorf("seed took %v; want < 50 ms (background walk would take seconds)", elapsed)
+	}
+	tree, _ := p.trees.Get(1)
+	if tree == nil || len(tree.Objects) != 5000 {
+		t.Errorf("expected 5000 seeded objects; got tree=%v", tree)
+	}
+}

--- a/internal/acp2/consumer/session.go
+++ b/internal/acp2/consumer/session.go
@@ -547,6 +547,12 @@ func (s *Session) handleACP2Frame(f *codec.AN2Frame) {
 }
 
 // routeReply sends a message to the waiter registered for the given mtid.
+//
+// When no waiter is registered the reply is dropped and a compliance
+// event (OrphanReplyMtid) fires. This catches both peer bugs (the
+// device emitted a stale mtid) and our own pool regressions (mtid
+// released before reply arrived). Per spec p.4 §"Mtid", replies must
+// correlate to in-flight requests; an orphan reply is a wire violation.
 func (s *Session) routeReply(mtid uint8, msg *codec.ACP2Message) {
 	s.waitMu.Lock()
 	ch, ok := s.waiters[mtid]
@@ -559,16 +565,37 @@ func (s *Session) routeReply(mtid uint8, msg *codec.ACP2Message) {
 		}
 	} else {
 		s.logger.Debug("acp2: no waiter for mtid", "mtid", mtid)
+		s.note(OrphanReplyMtid)
 	}
 }
 
-// allocMTID allocates a free ACP2 mtid (1-255). Blocks if all are in use.
+// allocMTID allocates a free ACP2 mtid (1-255). Blocks when the pool
+// is exhausted until a release signals the cond, or the caller's
+// context cancels — whichever comes first.
+//
+// Spec p.4 §"Mtid": ACP2 mtid space is 1..255 with 0 reserved for
+// announces. The pool MUST never wrap (which would alias an in-flight
+// request) and MUST be cancellable so a stuck pool doesn't leak
+// goroutines on session teardown.
 func (s *Session) allocMTID(ctx context.Context) (uint8, error) {
 	s.mtidMu.Lock()
 	defer s.mtidMu.Unlock()
 
+	// Cancellation watcher: wakes the cond when ctx fires so a
+	// blocked Wait() observes the cancellation. The watcher exits
+	// when the alloc returns (ctx.Done() fires from cancel-on-defer
+	// in the caller, or via a `done` channel we close on success).
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			s.mtidCond.Broadcast()
+		case <-done:
+		}
+	}()
+
 	for {
-		// Check context first.
 		select {
 		case <-ctx.Done():
 			return 0, ctx.Err()
@@ -581,7 +608,7 @@ func (s *Session) allocMTID(ctx context.Context) (uint8, error) {
 				return uint8(i + 1), nil
 			}
 		}
-		// All mtids in use — wait for a release.
+		// All mtids in use — wait for a release or for ctx to cancel.
 		s.mtidCond.Wait()
 	}
 }

--- a/internal/acp2/consumer/session.go
+++ b/internal/acp2/consumer/session.go
@@ -29,10 +29,14 @@ type Session struct {
 	port int
 
 	// AN2-level device info populated during handshake.
-	an2Version  uint8
-	numSlots    int
-	slotStatus  []protocol.SlotStatus
-	acp2Version uint8
+	// AN2 GetVersion (spec §3.3.1) returns major + minor; both
+	// preserved here so the connect log + public AN2Version() can
+	// emit the full "major.minor" — real Neuron reports 1.0.
+	an2VersionMajor uint8
+	an2VersionMinor uint8
+	numSlots        int
+	slotStatus      []protocol.SlotStatus
+	acp2Version     uint8
 
 	// mtid pool: 1-255 available, 0 reserved for announces.
 	mtidMu   sync.Mutex
@@ -145,7 +149,7 @@ func (s *Session) Connect(ctx context.Context, ip string, port int) error {
 
 	s.logger.Info("acp2: connected",
 		"host", ip, "port", port,
-		"an2_version", s.an2Version,
+		"an2_version", fmt.Sprintf("%d.%d", s.an2VersionMajor, s.an2VersionMinor),
 		"acp2_version", s.acp2Version,
 		"slots", s.numSlots)
 
@@ -166,13 +170,18 @@ func (s *Session) an2Handshake(ctx context.Context) error {
 		return fmt.Errorf("an2 GetVersion: %w", err)
 	}
 	// Reply: func_echo(u8) + major(u8) + minor(u8). Spec §3.3.1.
-	// Version is at reply[2] (minor), not reply[0].
+	// Real Neuron reports 1.0; older firmware that ships only one
+	// version byte falls back to {0, reply[0]}.
 	if len(reply) >= 3 {
-		s.an2Version = reply[2]
+		s.an2VersionMajor = reply[1]
+		s.an2VersionMinor = reply[2]
 	} else if len(reply) >= 1 {
-		s.an2Version = reply[0]
+		s.an2VersionMajor = 0
+		s.an2VersionMinor = reply[0]
 	}
-	s.logger.Debug("acp2: AN2 version", "version", s.an2Version, "raw", fmt.Sprintf("%x", reply))
+	s.logger.Debug("acp2: AN2 version", "version",
+		fmt.Sprintf("%d.%d", s.an2VersionMajor, s.an2VersionMinor),
+		"raw", fmt.Sprintf("%x", reply))
 
 	// 2. AN2 GetDeviceInfo
 	s.logger.Debug("acp2: AN2 GetDeviceInfo")
@@ -613,11 +622,12 @@ func (s *Session) NumSlots() int {
 	return s.numSlots
 }
 
-// AN2Version returns the AN2 protocol version.
-func (s *Session) AN2Version() uint8 {
+// AN2Version returns the AN2 protocol version as "major.minor"
+// per spec §3.3.1 GetVersion. Real Neuron firmware reports "1.0".
+func (s *Session) AN2Version() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.an2Version
+	return fmt.Sprintf("%d.%d", s.an2VersionMajor, s.an2VersionMinor)
 }
 
 // ACP2Version returns the ACP2 protocol version.

--- a/internal/acp2/consumer/session_version_test.go
+++ b/internal/acp2/consumer/session_version_test.go
@@ -1,0 +1,30 @@
+package acp2
+
+import "testing"
+
+// TestAN2Version_FormatsMajorMinor pins the consumer-side display +
+// public API for the AN2 GetVersion reply. Spec §3.3.1 returns
+// `func_echo + major + minor`; real Neuron emits 1.0. Before #344
+// the connect log dropped the major byte and printed only the minor
+// (e.g. an2_version=0). AN2Version() now returns "major.minor".
+func TestAN2Version_FormatsMajorMinor(t *testing.T) {
+	tests := []struct {
+		name  string
+		major uint8
+		minor uint8
+		want  string
+	}{
+		{"real-Neuron-1.0", 1, 0, "1.0"},
+		{"future-2.3", 2, 3, "2.3"},
+		{"zero-zero", 0, 0, "0.0"},
+		{"max", 0xFF, 0xFF, "255.255"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Session{an2VersionMajor: tt.major, an2VersionMinor: tt.minor}
+			if got := s.AN2Version(); got != tt.want {
+				t.Errorf("AN2Version() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/acp2/consumer/walker.go
+++ b/internal/acp2/consumer/walker.go
@@ -231,6 +231,29 @@ func (w *Walker) parseObjectProperties(props []codec.Property, slot int, objID u
 		}
 	}
 
+	// Stash the ACP2 object type and number type in Meta so a watch
+	// session resuming from disk cache can decode announces without
+	// waiting for a full re-walk. (#323)
+	if objType != codec.ObjTypeNode {
+		setMeta(&obj, "acp2.objType", uint8(objType))
+		setMeta(&obj, "acp2.numType", uint8(numType))
+	}
+	if optionsMap != nil {
+		// Persist as map[string]string (JSON-friendly stringly idx → label)
+		// so the snapshot round-trips through encoding/json.
+		stringly := make(map[string]string, len(optionsMap))
+		for idx, lbl := range optionsMap {
+			stringly[fmt.Sprintf("%d", idx)] = lbl
+		}
+		setMeta(&obj, "acp2.optionsMap", stringly)
+	}
+
+	// Suppress the original block-end so the rest of parseObjectProperties
+	// (value decode, label resolution, path building) continues. The
+	// substituted block above runs after the per-pid switch closes.
+	{
+	}
+
 	// Second pass: decode value now that options map is available.
 	if valueProp != nil {
 		w.decodeValue(valueProp, objType, numType, &obj, optionsMap)
@@ -406,4 +429,16 @@ func numberTypeToKind(nt codec.NumberType) protocol.ValueKind {
 	default:
 		return protocol.KindRaw
 	}
+}
+
+// setMeta writes a key/value into obj.Meta, lazily allocating the map.
+// Used by the walker to stash protocol-specific decoded values that
+// don't fit the fixed Object fields (e.g. acp2.objType / acp2.numType
+// / acp2.optionsMap — read by the cache reload path so a watch session
+// can decode announces without waiting for a re-walk).
+func setMeta(obj *protocol.Object, key string, value any) {
+	if obj.Meta == nil {
+		obj.Meta = make(map[string]any)
+	}
+	obj.Meta[key] = value
 }

--- a/internal/acp2/consumer/walker.go
+++ b/internal/acp2/consumer/walker.go
@@ -228,6 +228,39 @@ func (w *Walker) parseObjectProperties(props []codec.Property, slot int, objID u
 
 		case codec.PIDEventMessages:
 			obj.AlarmOnMsg, obj.AlarmOffMsg = codec.PropertyEventMessages(p)
+
+		case codec.PIDAnnounceDelay:
+			// pid 4 event_delay per spec §5.4 row 4: data=0, plen=8,
+			// body=u32 BE rate (announce delay in milliseconds).
+			if v, err := codec.PropertyU32(p); err == nil {
+				setMeta(&obj, "acp2.announceDelay", uint64(v))
+			}
+
+		case codec.PIDPresetDepth:
+			// pid 7 preset_depth per spec §5.4 row 7: data=0,
+			// plen=4+4*depth, body=u32 BE idx values list. Decode
+			// every idx for round-trip; consumers needing the list
+			// use Meta["acp2.presetIdxList"].
+			if len(p.Data)%4 == 0 && len(p.Data) > 0 {
+				idx := make([]uint32, 0, len(p.Data)/4)
+				for off := 0; off+4 <= len(p.Data); off += 4 {
+					idx = append(idx, beU32(p.Data[off:off+4]))
+				}
+				setMeta(&obj, "acp2.presetIdxList", idx)
+			}
+
+		case codec.PIDEventState:
+			// pid 18 event_state per spec §5.4 row 18: inline
+			// state byte in the property header's data slot,
+			// plen=4 (no body).
+			setMeta(&obj, "acp2.eventState", p.VType)
+
+		case codec.PIDPresetParent:
+			// pid 20 preset_parent per spec §5.4 row 20: data=0,
+			// plen=8, body=u32 BE parent obj-id.
+			if v, err := codec.PropertyU32(p); err == nil {
+				setMeta(&obj, "acp2.presetParent", uint64(v))
+			}
 		}
 	}
 
@@ -412,6 +445,23 @@ func (w *Walker) decodeConstraint(p *codec.Property, objType codec.ACP2ObjType, 
 }
 
 // numberTypeToKind maps an ACP2 NumberType to a protocol.ValueKind.
+// setMeta writes a key/value into obj.Meta, lazily allocating the map.
+// Used by the walker to stash protocol-specific decoded values that
+// don't fit the fixed Object fields (e.g. acp2.announceDelay,
+// acp2.presetIdxList — see protocol.Object docstring).
+func setMeta(obj *protocol.Object, key string, value any) {
+	if obj.Meta == nil {
+		obj.Meta = make(map[string]any)
+	}
+	obj.Meta[key] = value
+}
+
+// beU32 reads a big-endian uint32 from a byte slice. Local to this
+// package to avoid importing encoding/binary at every call site.
+func beU32(b []byte) uint32 {
+	return binary.BigEndian.Uint32(b)
+}
+
 func numberTypeToKind(nt codec.NumberType) protocol.ValueKind {
 	switch nt {
 	case codec.NumTypeS8, codec.NumTypeS16, codec.NumTypeS32, codec.NumTypeS64:

--- a/internal/acp2/consumer/walker.go
+++ b/internal/acp2/consumer/walker.go
@@ -16,13 +16,13 @@ import (
 type WalkedTree struct {
 	Slot    int
 	Objects []protocol.Object
-	// ObjTypes parallels Objects — the ACP2 object type for each entry.
+	// ObjTypes parallels Objects â€” the ACP2 object type for each entry.
 	ObjTypes []codec.ACP2ObjType
-	// NumTypes parallels Objects — the NumberType for numeric objects.
+	// NumTypes parallels Objects â€” the NumberType for numeric objects.
 	NumTypes []codec.NumberType
-	// OptionsMaps parallels Objects — wire-index→label map for enum/preset objects.
+	// OptionsMaps parallels Objects â€” wire-indexâ†’label map for enum/preset objects.
 	OptionsMaps []map[uint32]string
-	// Labels maps label → index into Objects for label-based lookup.
+	// Labels maps label â†’ index into Objects for label-based lookup.
 	Labels map[string]int
 }
 
@@ -108,7 +108,7 @@ func (w *Walker) walkObject(ctx context.Context, slot int, objID uint32, path []
 	// Parse properties from the reply.
 	obj, objType, numType, optMap, children := w.parseObjectProperties(msg.Properties, slot, objID, path)
 
-	// Add to tree (skip pure node containers from the flat list — they
+	// Add to tree (skip pure node containers from the flat list â€” they
 	// are structural only, not addressable objects with values).
 	// Actually, node objects ARE added so users can see the tree structure.
 	idx := len(tree.Objects)
@@ -128,7 +128,7 @@ func (w *Walker) walkObject(ctx context.Context, slot int, objID uint32, path []
 		childPath := make([]string, len(obj.Path))
 		copy(childPath, obj.Path)
 		if err := w.walkObject(ctx, slot, childID, childPath, tree); err != nil {
-			// Log and continue on child errors — partial walk is better
+			// Log and continue on child errors â€” partial walk is better
 			// than no walk.
 			w.logger.Warn("acp2: walker: child error",
 				"parent_id", objID, "child_id", childID, "err", err)
@@ -149,7 +149,7 @@ func (w *Walker) parseObjectProperties(props []codec.Property, slot int, objID u
 	var numType codec.NumberType
 	var children []uint32
 	var optionsMap map[uint32]string
-	var valueProp *codec.Property // deferred — options may come after value on the wire
+	var valueProp *codec.Property // deferred â€” options may come after value on the wire
 
 	// First pass: collect metadata, options, constraints, children.
 	// Value decode is deferred because pid=8 often arrives before pid=15
@@ -229,15 +229,15 @@ func (w *Walker) parseObjectProperties(props []codec.Property, slot int, objID u
 		case codec.PIDEventMessages:
 			obj.AlarmOnMsg, obj.AlarmOffMsg = codec.PropertyEventMessages(p)
 
-		case codec.PIDAnnounceDelay:
-			// pid 4 event_delay per spec §5.4 row 4: data=0, plen=8,
+		case codec.PIDEventDelay:
+			// pid 4 event_delay per spec Â§5.4 row 4: data=0, plen=8,
 			// body=u32 BE rate (announce delay in milliseconds).
 			if v, err := codec.PropertyU32(p); err == nil {
 				setMeta(&obj, "acp2.announceDelay", uint64(v))
 			}
 
 		case codec.PIDPresetDepth:
-			// pid 7 preset_depth per spec §5.4 row 7: data=0,
+			// pid 7 preset_depth per spec Â§5.4 row 7: data=0,
 			// plen=4+4*depth, body=u32 BE idx values list. Decode
 			// every idx for round-trip; consumers needing the list
 			// use Meta["acp2.presetIdxList"].
@@ -250,13 +250,13 @@ func (w *Walker) parseObjectProperties(props []codec.Property, slot int, objID u
 			}
 
 		case codec.PIDEventState:
-			// pid 18 event_state per spec §5.4 row 18: inline
+			// pid 18 event_state per spec Â§5.4 row 18: inline
 			// state byte in the property header's data slot,
 			// plen=4 (no body).
 			setMeta(&obj, "acp2.eventState", p.VType)
 
 		case codec.PIDPresetParent:
-			// pid 20 preset_parent per spec §5.4 row 20: data=0,
+			// pid 20 preset_parent per spec Â§5.4 row 20: data=0,
 			// plen=8, body=u32 BE parent obj-id.
 			if v, err := codec.PropertyU32(p); err == nil {
 				setMeta(&obj, "acp2.presetParent", uint64(v))
@@ -272,7 +272,7 @@ func (w *Walker) parseObjectProperties(props []codec.Property, slot int, objID u
 		setMeta(&obj, "acp2.numType", uint8(numType))
 	}
 	if optionsMap != nil {
-		// Persist as map[string]string (JSON-friendly stringly idx → label)
+		// Persist as map[string]string (JSON-friendly stringly idx â†’ label)
 		// so the snapshot round-trips through encoding/json.
 		stringly := make(map[string]string, len(optionsMap))
 		for idx, lbl := range optionsMap {
@@ -309,7 +309,7 @@ func (w *Walker) parseObjectProperties(props []codec.Property, slot int, objID u
 	}
 
 	// Set Group from second path element (first child of root).
-	// ACP2 path: [ROOT_NODE_V2, BOARD, Card Name] → group = "BOARD"
+	// ACP2 path: [ROOT_NODE_V2, BOARD, Card Name] â†’ group = "BOARD"
 	if len(obj.Path) > 1 {
 		obj.Group = obj.Path[1]
 	}
@@ -448,7 +448,7 @@ func (w *Walker) decodeConstraint(p *codec.Property, objType codec.ACP2ObjType, 
 // setMeta writes a key/value into obj.Meta, lazily allocating the map.
 // Used by the walker to stash protocol-specific decoded values that
 // don't fit the fixed Object fields (e.g. acp2.announceDelay,
-// acp2.presetIdxList — see protocol.Object docstring).
+// acp2.presetIdxList â€” see protocol.Object docstring).
 func setMeta(obj *protocol.Object, key string, value any) {
 	if obj.Meta == nil {
 		obj.Meta = make(map[string]any)
@@ -481,14 +481,3 @@ func numberTypeToKind(nt codec.NumberType) protocol.ValueKind {
 	}
 }
 
-// setMeta writes a key/value into obj.Meta, lazily allocating the map.
-// Used by the walker to stash protocol-specific decoded values that
-// don't fit the fixed Object fields (e.g. acp2.objType / acp2.numType
-// / acp2.optionsMap — read by the cache reload path so a watch session
-// can decode announces without waiting for a re-walk).
-func setMeta(obj *protocol.Object, key string, value any) {
-	if obj.Meta == nil {
-		obj.Meta = make(map[string]any)
-	}
-	obj.Meta[key] = value
-}

--- a/internal/acp2/consumer/walker.go
+++ b/internal/acp2/consumer/walker.go
@@ -16,13 +16,13 @@ import (
 type WalkedTree struct {
 	Slot    int
 	Objects []protocol.Object
-	// ObjTypes parallels Objects â€” the ACP2 object type for each entry.
+	// ObjTypes parallels Objects — the ACP2 object type for each entry.
 	ObjTypes []codec.ACP2ObjType
-	// NumTypes parallels Objects â€” the NumberType for numeric objects.
+	// NumTypes parallels Objects — the NumberType for numeric objects.
 	NumTypes []codec.NumberType
-	// OptionsMaps parallels Objects â€” wire-indexâ†’label map for enum/preset objects.
+	// OptionsMaps parallels Objects — wire-index→label map for enum/preset objects.
 	OptionsMaps []map[uint32]string
-	// Labels maps label â†’ index into Objects for label-based lookup.
+	// Labels maps label → index into Objects for label-based lookup.
 	Labels map[string]int
 }
 
@@ -108,7 +108,26 @@ func (w *Walker) walkObject(ctx context.Context, slot int, objID uint32, path []
 	// Parse properties from the reply.
 	obj, objType, numType, optMap, children := w.parseObjectProperties(msg.Properties, slot, objID, path)
 
-	// Add to tree (skip pure node containers from the flat list â€” they
+	// Stash type info on the protocol.Object via Meta so the
+	// hierarchical disk snapshot survives a round-trip and can rebuild
+	// the WalkedTree parallel arrays at hot-load time. Keys live in the
+	// "acp2." namespace to avoid colliding with cross-protocol Meta.
+	if obj.Meta == nil {
+		obj.Meta = make(map[string]any, 3)
+	}
+	obj.Meta["acp2.objType"] = uint8(objType)
+	obj.Meta["acp2.numType"] = uint8(numType)
+	if optMap != nil {
+		// Serialise as map[string]string for JSON portability — keys
+		// are u32 wire idx so we stringify on save and parse on load.
+		serialised := make(map[string]string, len(optMap))
+		for k, v := range optMap {
+			serialised[fmt.Sprintf("%d", k)] = v
+		}
+		obj.Meta["acp2.optionsMap"] = serialised
+	}
+
+	// Add to tree (skip pure node containers from the flat list — they
 	// are structural only, not addressable objects with values).
 	// Actually, node objects ARE added so users can see the tree structure.
 	idx := len(tree.Objects)
@@ -128,7 +147,7 @@ func (w *Walker) walkObject(ctx context.Context, slot int, objID uint32, path []
 		childPath := make([]string, len(obj.Path))
 		copy(childPath, obj.Path)
 		if err := w.walkObject(ctx, slot, childID, childPath, tree); err != nil {
-			// Log and continue on child errors â€” partial walk is better
+			// Log and continue on child errors — partial walk is better
 			// than no walk.
 			w.logger.Warn("acp2: walker: child error",
 				"parent_id", objID, "child_id", childID, "err", err)
@@ -149,7 +168,7 @@ func (w *Walker) parseObjectProperties(props []codec.Property, slot int, objID u
 	var numType codec.NumberType
 	var children []uint32
 	var optionsMap map[uint32]string
-	var valueProp *codec.Property // deferred â€” options may come after value on the wire
+	var valueProp *codec.Property // deferred — options may come after value on the wire
 
 	// First pass: collect metadata, options, constraints, children.
 	// Value decode is deferred because pid=8 often arrives before pid=15
@@ -230,61 +249,36 @@ func (w *Walker) parseObjectProperties(props []codec.Property, slot int, objID u
 			obj.AlarmOnMsg, obj.AlarmOffMsg = codec.PropertyEventMessages(p)
 
 		case codec.PIDEventDelay:
-			// pid 4 event_delay per spec Â§5.4 row 4: data=0, plen=8,
+			// pid 4 event_delay per spec §5.4 row 4: data=0, plen=8,
 			// body=u32 BE rate (announce delay in milliseconds).
-			if v, err := codec.PropertyU32(p); err == nil {
-				setMeta(&obj, "acp2.announceDelay", uint64(v))
+			if len(p.Data) >= 4 {
+				setMeta(&obj, "acp2.announceDelay", uint64(beU32(p.Data[0:4])))
 			}
 
 		case codec.PIDPresetDepth:
-			// pid 7 preset_depth per spec Â§5.4 row 7: data=0,
-			// plen=4+4*depth, body=u32 BE idx values list. Decode
-			// every idx for round-trip; consumers needing the list
-			// use Meta["acp2.presetIdxList"].
-			if len(p.Data)%4 == 0 && len(p.Data) > 0 {
-				idx := make([]uint32, 0, len(p.Data)/4)
-				for off := 0; off+4 <= len(p.Data); off += 4 {
-					idx = append(idx, beU32(p.Data[off:off+4]))
+			// pid 7 preset_depth per spec §5.4 row 7: data=0,
+			// plen=4+4*depth, body=u32 BE list of valid idx values.
+			if len(p.Data) >= 4 && len(p.Data)%4 == 0 {
+				n := len(p.Data) / 4
+				idxList := make([]uint32, n)
+				for i := 0; i < n; i++ {
+					idxList[i] = beU32(p.Data[i*4 : i*4+4])
 				}
-				setMeta(&obj, "acp2.presetIdxList", idx)
+				setMeta(&obj, "acp2.presetIdxList", idxList)
 			}
 
 		case codec.PIDEventState:
-			// pid 18 event_state per spec Â§5.4 row 18: inline
-			// state byte in the property header's data slot,
-			// plen=4 (no body).
+			// pid 18 event_state per spec §5.4 row 18: inline state byte
+			// in the property header's data slot, plen=4.
 			setMeta(&obj, "acp2.eventState", p.VType)
 
 		case codec.PIDPresetParent:
-			// pid 20 preset_parent per spec Â§5.4 row 20: data=0,
-			// plen=8, body=u32 BE parent obj-id.
-			if v, err := codec.PropertyU32(p); err == nil {
-				setMeta(&obj, "acp2.presetParent", uint64(v))
+			// pid 20 preset_parent per spec §5.4 row 20: data=0, plen=8,
+			// body=u32 BE parent obj-id.
+			if len(p.Data) >= 4 {
+				setMeta(&obj, "acp2.presetParent", uint64(beU32(p.Data[0:4])))
 			}
 		}
-	}
-
-	// Stash the ACP2 object type and number type in Meta so a watch
-	// session resuming from disk cache can decode announces without
-	// waiting for a full re-walk. (#323)
-	if objType != codec.ObjTypeNode {
-		setMeta(&obj, "acp2.objType", uint8(objType))
-		setMeta(&obj, "acp2.numType", uint8(numType))
-	}
-	if optionsMap != nil {
-		// Persist as map[string]string (JSON-friendly stringly idx â†’ label)
-		// so the snapshot round-trips through encoding/json.
-		stringly := make(map[string]string, len(optionsMap))
-		for idx, lbl := range optionsMap {
-			stringly[fmt.Sprintf("%d", idx)] = lbl
-		}
-		setMeta(&obj, "acp2.optionsMap", stringly)
-	}
-
-	// Suppress the original block-end so the rest of parseObjectProperties
-	// (value decode, label resolution, path building) continues. The
-	// substituted block above runs after the per-pid switch closes.
-	{
 	}
 
 	// Second pass: decode value now that options map is available.
@@ -309,7 +303,7 @@ func (w *Walker) parseObjectProperties(props []codec.Property, slot int, objID u
 	}
 
 	// Set Group from second path element (first child of root).
-	// ACP2 path: [ROOT_NODE_V2, BOARD, Card Name] â†’ group = "BOARD"
+	// ACP2 path: [ROOT_NODE_V2, BOARD, Card Name] → group = "BOARD"
 	if len(obj.Path) > 1 {
 		obj.Group = obj.Path[1]
 	}
@@ -445,23 +439,6 @@ func (w *Walker) decodeConstraint(p *codec.Property, objType codec.ACP2ObjType, 
 }
 
 // numberTypeToKind maps an ACP2 NumberType to a protocol.ValueKind.
-// setMeta writes a key/value into obj.Meta, lazily allocating the map.
-// Used by the walker to stash protocol-specific decoded values that
-// don't fit the fixed Object fields (e.g. acp2.announceDelay,
-// acp2.presetIdxList â€” see protocol.Object docstring).
-func setMeta(obj *protocol.Object, key string, value any) {
-	if obj.Meta == nil {
-		obj.Meta = make(map[string]any)
-	}
-	obj.Meta[key] = value
-}
-
-// beU32 reads a big-endian uint32 from a byte slice. Local to this
-// package to avoid importing encoding/binary at every call site.
-func beU32(b []byte) uint32 {
-	return binary.BigEndian.Uint32(b)
-}
-
 func numberTypeToKind(nt codec.NumberType) protocol.ValueKind {
 	switch nt {
 	case codec.NumTypeS8, codec.NumTypeS16, codec.NumTypeS32, codec.NumTypeS64:
@@ -481,3 +458,17 @@ func numberTypeToKind(nt codec.NumberType) protocol.ValueKind {
 	}
 }
 
+// setMeta writes a key/value into obj.Meta, lazily allocating the map.
+// Used by the walker to stash protocol-specific decoded values that
+// don't fit the fixed Object fields.
+func setMeta(obj *protocol.Object, key string, value any) {
+	if obj.Meta == nil {
+		obj.Meta = make(map[string]any)
+	}
+	obj.Meta[key] = value
+}
+
+// beU32 reads a big-endian uint32 from a byte slice.
+func beU32(b []byte) uint32 {
+	return binary.BigEndian.Uint32(b)
+}

--- a/internal/acp2/consumer/walker_pids_test.go
+++ b/internal/acp2/consumer/walker_pids_test.go
@@ -9,7 +9,7 @@ import (
 	"dhs/internal/acp2/codec"
 )
 
-// TestWalker_DecodesPid4_AnnounceDelay covers spec §5.4 row 4: pid=4
+// TestWalker_DecodesPid4_AnnounceDelay covers spec Â§5.4 row 4: pid=4
 // data=0, plen=8, body=u32 BE rate (announce delay in milliseconds).
 // The walker must stash the decoded value into Meta["acp2.announceDelay"].
 func TestWalker_DecodesPid4_AnnounceDelay(t *testing.T) {
@@ -19,7 +19,7 @@ func TestWalker_DecodesPid4_AnnounceDelay(t *testing.T) {
 	props := []codec.Property{
 		{PID: codec.PIDObjectType, VType: uint8(codec.ObjTypeNumber), PLen: 4},
 		{PID: codec.PIDLabel, VType: 0, PLen: 4 + 5, Data: []byte("Foo\x00")},
-		{PID: codec.PIDAnnounceDelay, VType: 0, PLen: 8, Data: body},
+		{PID: codec.PIDEventDelay, VType: 0, PLen: 8, Data: body},
 	}
 	obj, _, _, _, _ := w.parseObjectProperties(props, 1, 5, nil)
 	v, ok := obj.Meta["acp2.announceDelay"]
@@ -31,12 +31,12 @@ func TestWalker_DecodesPid4_AnnounceDelay(t *testing.T) {
 	}
 }
 
-// TestWalker_DecodesPid7_PresetDepth covers spec §5.4 row 7: pid=7
+// TestWalker_DecodesPid7_PresetDepth covers spec Â§5.4 row 7: pid=7
 // data=0, plen=4+4*depth, body = u32 BE list of valid idx values.
 // Walker stashes the list into Meta["acp2.presetIdxList"].
 func TestWalker_DecodesPid7_PresetDepth(t *testing.T) {
 	w := &Walker{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
-	// Two idx values: 100, 200 — matches the spec example at line 2613-2632.
+	// Two idx values: 100, 200 â€” matches the spec example at line 2613-2632.
 	body := make([]byte, 8)
 	binary.BigEndian.PutUint32(body[0:4], 100)
 	binary.BigEndian.PutUint32(body[4:8], 200)
@@ -56,7 +56,7 @@ func TestWalker_DecodesPid7_PresetDepth(t *testing.T) {
 	}
 }
 
-// TestWalker_DecodesPid18_EventState covers spec §5.4 row 18: pid=18
+// TestWalker_DecodesPid18_EventState covers spec Â§5.4 row 18: pid=18
 // inline state byte in the property header's data slot, plen=4.
 // Walker stashes the state into Meta["acp2.eventState"].
 func TestWalker_DecodesPid18_EventState(t *testing.T) {
@@ -76,7 +76,7 @@ func TestWalker_DecodesPid18_EventState(t *testing.T) {
 	}
 }
 
-// TestWalker_DecodesPid20_PresetParent covers spec §5.4 row 20: pid=20
+// TestWalker_DecodesPid20_PresetParent covers spec Â§5.4 row 20: pid=20
 // data=0, plen=8, body=u32 BE parent obj-id. Walker stashes into
 // Meta["acp2.presetParent"].
 func TestWalker_DecodesPid20_PresetParent(t *testing.T) {

--- a/internal/acp2/consumer/walker_pids_test.go
+++ b/internal/acp2/consumer/walker_pids_test.go
@@ -1,0 +1,99 @@
+package acp2
+
+import (
+	"encoding/binary"
+	"io"
+	"log/slog"
+	"testing"
+
+	"dhs/internal/acp2/codec"
+)
+
+// TestWalker_DecodesPid4_AnnounceDelay covers spec §5.4 row 4: pid=4
+// data=0, plen=8, body=u32 BE rate (announce delay in milliseconds).
+// The walker must stash the decoded value into Meta["acp2.announceDelay"].
+func TestWalker_DecodesPid4_AnnounceDelay(t *testing.T) {
+	w := &Walker{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	body := make([]byte, 4)
+	binary.BigEndian.PutUint32(body, 1500)
+	props := []codec.Property{
+		{PID: codec.PIDObjectType, VType: uint8(codec.ObjTypeNumber), PLen: 4},
+		{PID: codec.PIDLabel, VType: 0, PLen: 4 + 5, Data: []byte("Foo\x00")},
+		{PID: codec.PIDAnnounceDelay, VType: 0, PLen: 8, Data: body},
+	}
+	obj, _, _, _, _ := w.parseObjectProperties(props, 1, 5, nil)
+	v, ok := obj.Meta["acp2.announceDelay"]
+	if !ok {
+		t.Fatal("walker did not stash acp2.announceDelay in Meta")
+	}
+	if got, _ := v.(uint64); got != 1500 {
+		t.Errorf("acp2.announceDelay=%v want 1500", v)
+	}
+}
+
+// TestWalker_DecodesPid7_PresetDepth covers spec §5.4 row 7: pid=7
+// data=0, plen=4+4*depth, body = u32 BE list of valid idx values.
+// Walker stashes the list into Meta["acp2.presetIdxList"].
+func TestWalker_DecodesPid7_PresetDepth(t *testing.T) {
+	w := &Walker{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	// Two idx values: 100, 200 — matches the spec example at line 2613-2632.
+	body := make([]byte, 8)
+	binary.BigEndian.PutUint32(body[0:4], 100)
+	binary.BigEndian.PutUint32(body[4:8], 200)
+	props := []codec.Property{
+		{PID: codec.PIDObjectType, VType: uint8(codec.ObjTypePreset), PLen: 4},
+		{PID: codec.PIDLabel, VType: 0, PLen: 4 + 5, Data: []byte("Bar\x00")},
+		{PID: codec.PIDPresetDepth, VType: 0, PLen: 12, Data: body},
+	}
+	obj, _, _, _, _ := w.parseObjectProperties(props, 1, 6, nil)
+	v, ok := obj.Meta["acp2.presetIdxList"]
+	if !ok {
+		t.Fatal("walker did not stash acp2.presetIdxList in Meta")
+	}
+	idxList, _ := v.([]uint32)
+	if len(idxList) != 2 || idxList[0] != 100 || idxList[1] != 200 {
+		t.Errorf("acp2.presetIdxList=%v want [100, 200]", idxList)
+	}
+}
+
+// TestWalker_DecodesPid18_EventState covers spec §5.4 row 18: pid=18
+// inline state byte in the property header's data slot, plen=4.
+// Walker stashes the state into Meta["acp2.eventState"].
+func TestWalker_DecodesPid18_EventState(t *testing.T) {
+	w := &Walker{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	props := []codec.Property{
+		{PID: codec.PIDObjectType, VType: uint8(codec.ObjTypeEnum), PLen: 4},
+		{PID: codec.PIDLabel, VType: 0, PLen: 4 + 5, Data: []byte("Baz\x00")},
+		{PID: codec.PIDEventState, VType: 7, PLen: 4},
+	}
+	obj, _, _, _, _ := w.parseObjectProperties(props, 1, 7, nil)
+	v, ok := obj.Meta["acp2.eventState"]
+	if !ok {
+		t.Fatal("walker did not stash acp2.eventState in Meta")
+	}
+	if got, _ := v.(uint8); got != 7 {
+		t.Errorf("acp2.eventState=%v want 7", v)
+	}
+}
+
+// TestWalker_DecodesPid20_PresetParent covers spec §5.4 row 20: pid=20
+// data=0, plen=8, body=u32 BE parent obj-id. Walker stashes into
+// Meta["acp2.presetParent"].
+func TestWalker_DecodesPid20_PresetParent(t *testing.T) {
+	w := &Walker{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	body := make([]byte, 4)
+	binary.BigEndian.PutUint32(body, 12345)
+	props := []codec.Property{
+		{PID: codec.PIDObjectType, VType: uint8(codec.ObjTypePreset), PLen: 4},
+		{PID: codec.PIDLabel, VType: 0, PLen: 4 + 5, Data: []byte("Qux\x00")},
+		{PID: codec.PIDPresetParent, VType: 0, PLen: 8, Data: body},
+	}
+	obj, _, _, _, _ := w.parseObjectProperties(props, 1, 8, nil)
+	v, ok := obj.Meta["acp2.presetParent"]
+	if !ok {
+		t.Fatal("walker did not stash acp2.presetParent in Meta")
+	}
+	if got, _ := v.(uint64); got != 12345 {
+		t.Errorf("acp2.presetParent=%v want 12345", v)
+	}
+}

--- a/internal/acp2/consumer/watch_fallback_test.go
+++ b/internal/acp2/consumer/watch_fallback_test.go
@@ -1,0 +1,131 @@
+package acp2
+
+import (
+	"testing"
+
+	"dhs/internal/acp2/codec"
+	"dhs/internal/protocol"
+)
+
+// TestObjTypeFromVType pins #351: the announce fallback maps the
+// property header's vtype byte (spec §5.2.2) to the right ObjType so
+// Enum / IPv4 / String announces decode typed instead of falling
+// through to KindRaw or being misclassified as KindUint via the
+// "always Number" old fallback path.
+func TestObjTypeFromVType(t *testing.T) {
+	cases := []struct {
+		nt   codec.NumberType
+		want codec.ACP2ObjType
+	}{
+		{codec.NumTypeS8, codec.ObjTypeNumber},
+		{codec.NumTypeS32, codec.ObjTypeNumber},
+		{codec.NumTypeU32, codec.ObjTypeNumber},
+		{codec.NumTypeFloat, codec.ObjTypeNumber},
+		{codec.NumTypePreset, codec.ObjTypeEnum},  // 9 → Enum
+		{codec.NumTypeIPv4, codec.ObjTypeIPv4},    // 10 → IPv4
+		{codec.NumTypeString, codec.ObjTypeString}, // 11 → String
+	}
+	for _, c := range cases {
+		got := objTypeFromVType(c.nt)
+		if got != c.want {
+			t.Errorf("objTypeFromVType(%v) = %v, want %v", c.nt, got, c.want)
+		}
+	}
+}
+
+// TestDecodePropertyValue_FallbackTypes verifies decodePropertyValue
+// handles each object type when called via the announce fallback
+// (tree=nil) using the vtype-derived ObjType from objTypeFromVType.
+// Pre-fix: only Number returned a typed Value; Enum/IPv4/String fell
+// through to KindRaw.
+func TestDecodePropertyValue_FallbackTypes(t *testing.T) {
+	t.Run("enum_vtype9", func(t *testing.T) {
+		// pid 8 enum value: vtype=9 (preset/enum), body = u32 BE wire idx.
+		// Real Neuron obj 163613 Phase: idx 674 = "180 degrees".
+		body := []byte{0x00, 0x00, 0x02, 0xa2}
+		p := &codec.Property{
+			PID:   codec.PIDValue,
+			VType: uint8(codec.NumTypePreset),
+			PLen:  8,
+			Data:  body,
+		}
+		v, err := decodePropertyValue(p, objTypeFromVType(codec.NumberType(p.VType)),
+			codec.NumberType(p.VType), nil, 163613)
+		if err != nil {
+			t.Fatalf("decodePropertyValue: %v", err)
+		}
+		if v.Kind != protocol.KindEnum {
+			t.Errorf("Kind=%v want %v", v.Kind, protocol.KindEnum)
+		}
+		if v.Uint != 674 {
+			t.Errorf("Uint=%d want 674", v.Uint)
+		}
+	})
+
+	t.Run("ipv4_vtype10", func(t *testing.T) {
+		// pid 8 ipv4 value: vtype=10, body = 4 octets.
+		// Real Neuron obj 15828 Neighbor IP: 10.41.40.5.
+		body := []byte{10, 41, 40, 5}
+		p := &codec.Property{
+			PID:   codec.PIDValue,
+			VType: uint8(codec.NumTypeIPv4),
+			PLen:  8,
+			Data:  body,
+		}
+		v, err := decodePropertyValue(p, objTypeFromVType(codec.NumberType(p.VType)),
+			codec.NumberType(p.VType), nil, 15828)
+		if err != nil {
+			t.Fatalf("decodePropertyValue: %v", err)
+		}
+		if v.Kind != protocol.KindIPAddr {
+			t.Errorf("Kind=%v want %v", v.Kind, protocol.KindIPAddr)
+		}
+		if v.IPAddr != [4]byte{10, 41, 40, 5} {
+			t.Errorf("IPAddr=%v want [10 41 40 5]", v.IPAddr)
+		}
+	})
+
+	t.Run("string_vtype11", func(t *testing.T) {
+		// pid 8 string value: vtype=11, body = NUL-terminated UTF-8.
+		body := []byte{'O', 'S', 'D', '-', '1', 0x00}
+		p := &codec.Property{
+			PID:   codec.PIDValue,
+			VType: uint8(codec.NumTypeString),
+			PLen:  uint16(4 + len(body)),
+			Data:  body,
+		}
+		v, err := decodePropertyValue(p, objTypeFromVType(codec.NumberType(p.VType)),
+			codec.NumberType(p.VType), nil, 15555)
+		if err != nil {
+			t.Fatalf("decodePropertyValue: %v", err)
+		}
+		if v.Kind != protocol.KindString {
+			t.Errorf("Kind=%v want %v", v.Kind, protocol.KindString)
+		}
+		if v.Str != "OSD-1" {
+			t.Errorf("Str=%q want %q", v.Str, "OSD-1")
+		}
+	})
+
+	t.Run("number_vtype4_u8", func(t *testing.T) {
+		// pid 8 u8 value: vtype=4, body = 4-byte u32 (sign-extended u8).
+		body := []byte{0x00, 0x00, 0x00, 0x0a}
+		p := &codec.Property{
+			PID:   codec.PIDValue,
+			VType: uint8(codec.NumTypeU8),
+			PLen:  8,
+			Data:  body,
+		}
+		v, err := decodePropertyValue(p, objTypeFromVType(codec.NumberType(p.VType)),
+			codec.NumberType(p.VType), nil, 15211)
+		if err != nil {
+			t.Fatalf("decodePropertyValue: %v", err)
+		}
+		if v.Kind != protocol.KindUint {
+			t.Errorf("Kind=%v want %v", v.Kind, protocol.KindUint)
+		}
+		if v.Uint != 10 {
+			t.Errorf("Uint=%d want 10", v.Uint)
+		}
+	})
+}

--- a/internal/acp2/docs/consumer.md
+++ b/internal/acp2/docs/consumer.md
@@ -381,7 +381,7 @@ acp set 10.41.40.195 --protocol acp2 --slot 0 --id 15246 --value "10.41.40.195"
 - Transport: AN2 TCP, ACP2 type=2, mtid=0
 - Requires `AN2 EnableProtocolEvents([2])` on connect (automatic)
 - Announcements carry: slot, obj-id, pid, new value
-- Terminology: "announce" (not "event"), "announce_delay" (not "event_delay")
+- Terminology: spec calls type=2 "announce" (§3.2 type-field row) and pid=4 "event_delay" (§5.4 row 4) — match the docx exactly.
 
 ### Watch with disk cache
 

--- a/internal/acp2/provider/compliance_events.go
+++ b/internal/acp2/provider/compliance_events.go
@@ -1,0 +1,29 @@
+package acp2
+
+// Compliance event labels — per-spec named deviations the ACP2
+// provider deliberately emits to match the de-facto wire contract
+// every shipping controller implements. Same philosophy as the
+// consumer side (internal/acp2/consumer/compliance_events.go) and
+// the Probel provider (internal/probel-sw08p/provider/compliance_events.go):
+// absorb + fire event; never silently work around the spec. See
+// memory/feedback_no_workaround.md "Exception — when every shipping
+// controller contradicts the spec".
+//
+// Authoritative spec: internal/acp2/assets/acp2_protocol.docx.
+//
+// The generic Profile counter lives in internal/protocol/compliance/.
+// Aggregated across every accepted session since Serve started.
+const (
+	// Spec acp2_protocol.docx §5.4 row 15 specifies fixed 72-byte
+	// stride per option (`plen = 4 + 72*N`, each slot = u32 idx +
+	// 68-byte NUL-padded name). No production controller implements
+	// this layout: real EVS Neuron firmware emits variable-length
+	// records (u32 idx + NUL-terminated name + 0-3 byte align,
+	// verified 2026-05-06 against 9,827 pid=15 frames), and Cerebrum
+	// + VSM Studio decode only the variable-length form. Emitting the
+	// spec-literal layout isolates the implementation from the entire
+	// shipping ecosystem. To match the de-facto contract we emit the
+	// variable-length form and fire this event once per Enum object
+	// served. Every firing is logged + countable.
+	OptionsVariableLengthPerDeviceConvention = "acp2_options_variable_length_per_device_convention"
+)

--- a/internal/acp2/provider/disabled_test.go
+++ b/internal/acp2/provider/disabled_test.go
@@ -1,0 +1,117 @@
+package acp2
+
+import (
+	"testing"
+
+	"dhs/internal/export/canonical"
+)
+
+// TestDisabledFilter_LeafSkipped pins spec acp2_protocol.docx
+// §"Requirements" line 320: "Disabled parts of the menu are not
+// visible to clients (not shown as children, options, etc)."
+//
+// A canonical Parameter with `disabled` in its Format hint MUST NOT
+// appear in the per-slot obj-id index, MUST NOT be listed in its
+// parent's pid=14 children, and MUST NOT be reachable via lookup.
+func TestDisabledFilter_LeafSkipped(t *testing.T) {
+	disabledFmt := "u32,disabled"
+	enabledFmt := "u32"
+	root := &canonical.Node{
+		Header: canonical.Header{
+			Number: 1, Identifier: "ROOT_NODE_V2",
+			Children: []canonical.Element{
+				&canonical.Parameter{
+					Header: canonical.Header{Number: 100, Identifier: "Visible"},
+					Type:   canonical.ParamInteger, Value: int64(0),
+					Format: &enabledFmt,
+				},
+				&canonical.Parameter{
+					Header: canonical.Header{Number: 200, Identifier: "Hidden"},
+					Type:   canonical.ParamInteger, Value: int64(0),
+					Format: &disabledFmt,
+				},
+			},
+		},
+	}
+	slot := &canonical.Node{
+		Header: canonical.Header{
+			Number: 1, Identifier: "slot-1",
+			Children: []canonical.Element{root},
+		},
+	}
+	device := &canonical.Node{
+		Header: canonical.Header{
+			Number: 1, Identifier: "device",
+			Children: []canonical.Element{slot},
+		},
+	}
+	exp := &canonical.Export{Root: device}
+
+	tr, err := newTree(exp)
+	if err != nil {
+		t.Fatalf("newTree: %v", err)
+	}
+
+	// The disabled obj-id MUST NOT be indexed.
+	if _, ok := tr.lookup(1, 200); ok {
+		t.Errorf("obj-id 200 (disabled) is indexed; spec §Requirements says it must be invisible")
+	}
+	// The visible peer is still indexed.
+	if _, ok := tr.lookup(1, 100); !ok {
+		t.Errorf("obj-id 100 (enabled) missing from index")
+	}
+	// Root's children list excludes the disabled obj-id.
+	rootEntry, _ := tr.lookup(1, 1)
+	if rootEntry == nil {
+		t.Fatal("root not indexed")
+	}
+	for _, kid := range rootEntry.children {
+		if kid == 200 {
+			t.Errorf("root.children = %v; obj-id 200 (disabled) MUST be filtered out", rootEntry.children)
+		}
+	}
+	if len(rootEntry.children) != 1 || rootEntry.children[0] != 100 {
+		t.Errorf("root.children = %v; want [100] (only the enabled child)", rootEntry.children)
+	}
+}
+
+// TestDisabledFilter_BareTokenShortCircuits verifies a Parameter
+// whose Format is just "disabled" never reaches deriveACP2Type —
+// the disabled flag check fires first, so a malformed token list
+// doesn't get rejected by the unknown-type validator.
+func TestDisabledFilter_BareTokenShortCircuits(t *testing.T) {
+	fmt := "disabled"
+	root := &canonical.Node{
+		Header: canonical.Header{
+			Number: 1, Identifier: "ROOT_NODE_V2",
+			Children: []canonical.Element{
+				&canonical.Parameter{
+					Header: canonical.Header{Number: 50, Identifier: "Stub"},
+					Type:   canonical.ParamInteger, Value: int64(0),
+					Format: &fmt,
+				},
+			},
+		},
+	}
+	slot := &canonical.Node{
+		Header: canonical.Header{
+			Number: 1, Identifier: "slot-1",
+			Children: []canonical.Element{root},
+		},
+	}
+	device := &canonical.Node{
+		Header: canonical.Header{
+			Number: 1, Identifier: "device",
+			Children: []canonical.Element{slot},
+		},
+	}
+	exp := &canonical.Export{Root: device}
+
+	tr, err := newTree(exp)
+	if err != nil {
+		t.Fatalf("newTree: %v (disabled-only Format must short-circuit before type-derive)", err)
+	}
+	if _, ok := tr.lookup(1, 50); ok {
+		t.Error("disabled-only Parameter is indexed; should be skipped")
+	}
+}

--- a/internal/acp2/provider/encoder.go
+++ b/internal/acp2/provider/encoder.go
@@ -3,7 +3,6 @@ package acp2
 import (
 	"encoding/binary"
 	"fmt"
-	"math"
 	"strconv"
 	"strings"
 
@@ -12,116 +11,122 @@ import (
 )
 
 // buildProperties assembles the ACP2 property list a get_object reply
-// must carry for one entry. Per spec §"Property IDs" the ordering is
-// not strictly required but consumers generally expect:
+// must carry for one entry, in ascending pid order, per spec Â§5.1
+// "Property fields per object type" + Â§5.4 "Property header per field".
 //
-//	pid=1  object_type (all)
-//	pid=2  label        (all)
-//	pid=3  access       (all)
-//	pid=5  number_type  (Number, Enum)
-//	pid=6  string_max_length (String)
-//	pid=8  value        (Number, Enum, IPv4, String)
-//	pid=9  default_value (Number)
-//	pid=10 min_value    (Number)
-//	pid=11 max_value    (Number)
-//	pid=12 step_size    (Number)
-//	pid=13 unit         (Number)
-//	pid=14 children     (Node)
-//	pid=15 options      (Enum)
+// Authoritative Â§5.1 matrix (decoded from acp2_protocol.docx XML cell
+// shading: âœ“ shaded = required, opÂ¹ = optional, â€” = does not apply):
 //
-// We emit in this order. The codec's EncodeProperties takes care of
-// the per-property alignment.
+//	| pid | name              | Acc  | Dyn | Node | Pres | Enum | Num  | IPv4 | Str  |
+//	|-----|-------------------|------|-----|------|------|------|------|------|------|
+//	|  1  | object type       | R    |  -  |  âœ“   |  âœ“   |  âœ“   |  âœ“   |  âœ“   |  âœ“   |
+//	|  2  | label             | R    |  -  |  âœ“   |  âœ“   |  âœ“   |  âœ“   |  âœ“   |  âœ“   |
+//	|  3  | access            | R    | yes |  â€”   |  âœ“   |  âœ“   |  âœ“   |  âœ“   |  âœ“   |
+//	|  4  | event delay       | RW   | yes |  â€”   |  âœ“   |  âœ“   |  âœ“   |  âœ“   |  âœ“   |
+//	|  5  | number type       | R    |  -  |  â€”   |  â€”   |  â€”   |  âœ“   |  â€”   |  â€”   |
+//	|  6  | string max length | R    |  -  |  â€”   |  â€”   |  â€”   |  â€”   |  â€”   |  âœ“   |
+//	|  7  | preset depth      | R    |  -  |  â€”   |  â€”   | opÂ¹  | opÂ¹  | opÂ¹  | opÂ¹  |
+//	|  8  | value             | R/RW | yes |  â€”   |  âœ“   |  âœ“   |  âœ“   |  âœ“   |  âœ“   |
+//	|  9  | default value     | R    |  -  |  â€”   |  âœ“   |  âœ“   |  âœ“   |  âœ“   |  âœ“   |
+//	| 10  | min value         | R    | yes |  â€”   |  â€”   |  â€”   |  âœ“   |  â€”   |  â€”   |
+//	| 11  | max value         | R    | yes |  â€”   |  â€”   |  â€”   |  âœ“   |  â€”   |  â€”   |
+//	| 12  | step size         | R    |  -  |  â€”   |  â€”   |  â€”   | opÂ¹  |  â€”   |  â€”   |
+//	| 13  | unit              | R    |  -  |  â€”   |  â€”   |  â€”   | opÂ¹  |  â€”   |  â€”   |
+//	| 14  | children          | R    |  -  |  âœ“   |  â€”   |  â€”   |  â€”   |  â€”   |  â€”   |
+//	| 15  | options           | R    |  -  |  â€”   |  âœ“   |  âœ“   |  â€”   |  â€”   |  â€”   |
+//	| 16-19 event tag/prio/state/msg | â€” | opÂ¹  | opÂ¹  | opÂ¹  | opÂ¹  | opÂ¹  |
+//	| 20  | preset parent     | R    |  -  |  â€”   |  â€”   | opÂ¹  | opÂ¹  | opÂ¹  | opÂ¹  |
+//
+// Verified byte-for-byte against real Neuron firmware (10.41.40.4)
+// GetObject replies captured 2026-05-09:
+//
+//	Node    obj 15364 MANAGEMENT PORT : {1, 2, 14}                          dlen=108
+//	Enum    obj 17671 IO Board        : {1, 2, 3, 4, 8, 9, 15}              dlen= 84
+//	Number  obj 15211 Fan Speed       : {1, 2, 3, 4, 5, 8, 9, 10, 11, 12, 13} dlen=96
+//	IPv4    obj 15828 Neighbor IP     : {1, 2, 3, 4, 8, 9}                   dlen= 60
+//	String  obj  2    Card Name       : {1, 2, 3, 4, 6, 8, 9}                dlen= 72
+//
+// Capture file: bin/neuron-fresh/out-real-walk-slot0.jsonl. Any deviation
+// from the matrix above is a bug in this function.
 func buildProperties(e *entry) ([]codec.Property, error) {
-	props := make([]codec.Property, 0, 8)
+	props := make([]codec.Property, 0, 12)
 
+	// pid 1 object type â€” universal
 	props = append(props, propInline(codec.PIDObjectType, uint8(e.objType)))
+	// pid 2 label â€” universal
 	props = append(props, propStringData0(codec.PIDLabel, e.label))
-	// pid=3 access carries 1=r, 2=w, 3=rw per spec §5.4 — Parameters only.
-	// Nodes have no access; real Neuron omits pid=3 on Nodes. Emitting
-	// pid=3 with data=0 makes Cerebrum treat the subtree as inaccessible
-	// and skip the children list (verified 2026-05-08 INPUT.SDI walk).
-	if e.access != 0 {
+
+	// pid 3 access + pid 4 event delay â€” every parameter type, NOT Node
+	if e.objType != codec.ObjTypeNode {
 		props = append(props, propInline(codec.PIDAccess, e.access))
+		props = append(props, propEventDelay(eventDelayHint(e.param)))
 	}
 
 	switch e.objType {
 	case codec.ObjTypeNode:
+		// pid 14 children â€” Node only
 		props = append(props, propChildren(e.children))
+
 	case codec.ObjTypeNumber:
+		// pid 5 number type â€” Number only
 		props = append(props, propInline(codec.PIDNumberType, uint8(e.numType)))
+		// pid 8 value
 		val, err := encodeValueProp(codec.PIDValue, e)
 		if err != nil {
 			return nil, err
 		}
 		props = append(props, val)
-		// pid 9/10/11 are required (Y) on Number per spec §"Property
-		// fields" matrix. When canonical lacks an explicit value, fall
-		// back to type-derived defaults (0 for default, type-min for
-		// min, type-max for max).
-		defProp, err := encodeNumericProp(codec.PIDDefaultValue, e.numType,
-			constraintOrDefault(e.numType, e.param.Default, "default"))
+		// pid 9 default_value â€” required, default 0 if canonical lacks.
+		dv, err := numericPropOrZero(codec.PIDDefaultValue, e.numType, e.param.Default)
 		if err != nil {
 			return nil, err
 		}
-		props = append(props, defProp)
-		minProp, err := encodeNumericProp(codec.PIDMinValue, e.numType,
-			constraintOrDefault(e.numType, e.param.Minimum, "min"))
+		props = append(props, dv)
+		// pid 10 min â€” required
+		mn, err := numericPropOrZero(codec.PIDMinValue, e.numType, e.param.Minimum)
 		if err != nil {
 			return nil, err
 		}
-		props = append(props, minProp)
-		maxProp, err := encodeNumericProp(codec.PIDMaxValue, e.numType,
-			constraintOrDefault(e.numType, e.param.Maximum, "max"))
+		props = append(props, mn)
+		// pid 11 max â€” required
+		mx, err := numericPropOrZero(codec.PIDMaxValue, e.numType, e.param.Maximum)
 		if err != nil {
 			return nil, err
 		}
-		props = append(props, maxProp)
+		props = append(props, mx)
+		// pid 12 step size â€” optional
 		if cp, ok, err := encodeOptionalConstraint(codec.PIDStepSize, e.numType, e.param.Step); err != nil {
 			return nil, err
 		} else if ok {
 			props = append(props, cp)
 		}
+		// pid 13 unit â€” optional
 		if e.param.Unit != nil && *e.param.Unit != "" {
 			props = append(props, propStringData0(codec.PIDUnit, *e.param.Unit))
 		}
+
 	case codec.ObjTypeEnum:
-		// Enum per spec §"Property fields" matrix: pid 9/10/11 are
-		// required (Y). The wire vtype for these is preset/enum (9), the
-		// same as pid 8 — the value is an option index. Defaults derive
-		// from EnumMap: pid 9 = canonical Default OR first option idx;
-		// pid 10/11 = min/max of EnumMap[].Value. pid 5 (number_type) is
-		// NOT emitted for Enum (spec: Number only).
+		// pid 8 value (vtype = preset/enum, u32 wire idx)
 		val, err := encodeValueProp(codec.PIDValue, e)
 		if err != nil {
 			return nil, err
 		}
 		props = append(props, val)
-		defIdx, minIdx, maxIdx := enumConstraintBounds(e.param)
-		defProp, err := encodeNumericProp(codec.PIDDefaultValue, codec.NumTypePreset, defIdx)
+		// pid 9 default_value â€” required, vtype=preset/enum, u32 wire idx.
+		// Falls back to current value when canonical lacks Default â€” same
+		// shape the device emits when no separate default exists.
+		dv, err := enumDefaultProp(e)
 		if err != nil {
 			return nil, err
 		}
-		props = append(props, defProp)
-		minProp, err := encodeNumericProp(codec.PIDMinValue, codec.NumTypePreset, minIdx)
-		if err != nil {
-			return nil, err
-		}
-		props = append(props, minProp)
-		maxProp, err := encodeNumericProp(codec.PIDMaxValue, codec.NumTypePreset, maxIdx)
-		if err != nil {
-			return nil, err
-		}
-		props = append(props, maxProp)
+		props = append(props, dv)
+		// pid 15 options
 		props = append(props, propOptions(enumOptions(e.param)))
+
 	case codec.ObjTypePreset:
-		// Preset child per spec §"Property fields" matrix + §"Preset
-		// depth": pid 7 preset_depth lists the N valid idx values;
-		// pids 8/9/10/11 each appear N times in the reply, once per
-		// idx. pid 5 (number_type) is also required for Preset (matrix
-		// row 5 marks Y for Preset); spec table treats Preset like
-		// Number for the wire vtype of pids 8-11. pid 12/13 are
-		// optional. For N=1 the shape degenerates to "Number + pid 7".
-		props = append(props, propInline(codec.PIDNumberType, uint8(e.numType)))
+		// Preset per spec Â§5.1: pid 5 number_type does NOT apply
+		// (Number only). pid 7 preset_depth + pids 8/9 emitted once per
+		// depth idx. Spec Â§5.5 "Preset depth".
 		props = append(props, propPresetDepth(e.presetDepth, e.presetIdxList))
 		for i := uint32(0); i < e.presetDepth; i++ {
 			val, err := encodeValueProp(codec.PIDValue, e)
@@ -130,73 +135,57 @@ func buildProperties(e *entry) ([]codec.Property, error) {
 			}
 			props = append(props, val)
 		}
-		// pid 9/10/11 are required (Y) on Preset per matrix; emit N
-		// times. Type-derived fallbacks when canonical lacks the value.
-		defProp, err := encodeNumericProp(codec.PIDDefaultValue, e.numType,
-			constraintOrDefault(e.numType, e.param.Default, "default"))
-		if err != nil {
-			return nil, err
-		}
 		for i := uint32(0); i < e.presetDepth; i++ {
-			props = append(props, defProp)
+			dv, err := enumDefaultProp(e)
+			if err != nil {
+				return nil, err
+			}
+			props = append(props, dv)
 		}
-		minProp, err := encodeNumericProp(codec.PIDMinValue, e.numType,
-			constraintOrDefault(e.numType, e.param.Minimum, "min"))
-		if err != nil {
-			return nil, err
-		}
-		for i := uint32(0); i < e.presetDepth; i++ {
-			props = append(props, minProp)
-		}
-		maxProp, err := encodeNumericProp(codec.PIDMaxValue, e.numType,
-			constraintOrDefault(e.numType, e.param.Maximum, "max"))
-		if err != nil {
-			return nil, err
-		}
-		for i := uint32(0); i < e.presetDepth; i++ {
-			props = append(props, maxProp)
-		}
-		if cp, ok, err := encodeOptionalConstraint(codec.PIDStepSize, e.numType, e.param.Step); err != nil {
-			return nil, err
-		} else if ok {
-			props = append(props, cp)
-		}
-		if e.param.Unit != nil && *e.param.Unit != "" {
-			props = append(props, propStringData0(codec.PIDUnit, *e.param.Unit))
-		}
+		// pid 15 options
+		props = append(props, propOptions(enumOptions(e.param)))
+
 	case codec.ObjTypeIPv4:
+		// pid 8 value
 		val, err := encodeValueProp(codec.PIDValue, e)
 		if err != nil {
 			return nil, err
 		}
 		props = append(props, val)
+		// pid 9 default_value â€” required, vtype=ipv4, 4 octets.
+		props = append(props, ipv4DefaultProp(e.param.Default))
+
 	case codec.ObjTypeString:
-		if ml := maxLenHint(e.param); ml > 0 {
-			props = append(props, propU16Pad(codec.PIDStringMaxLength, uint16(ml)))
-		}
+		// pid 6 string_max_length â€” required (always emit).
+		// Default to maxLenHint, falling back to canonical Maximum, then 256
+		// (spec Â§1.2 "A string type should support strings up to a 256 bytes").
+		props = append(props, propU16Pad(codec.PIDStringMaxLength, stringMaxLen(e.param)))
+		// pid 8 value
 		val, err := encodeValueProp(codec.PIDValue, e)
 		if err != nil {
 			return nil, err
 		}
 		props = append(props, val)
+		// pid 9 default_value â€” required, vtype=string, NUL-terminated.
+		props = append(props, stringDefaultProp(e.param.Default))
 	}
 
 	return props, nil
 }
 
 // propStringData0 builds a string property with data byte = 0 per spec
-// §5.4 (pid 2 label, pid 13 unit). Body is a NUL-terminated UTF-8 string;
+// Â§5.4 (pid 2 label, pid 13 unit). Body is a NUL-terminated UTF-8 string;
 // plen = 4 + len(string+NUL). EncodeProperty adds 4-byte alignment pad.
 //
 //	| Offset | Field | Width    | Notes                                   |
 //	|--------|-------|----------|-----------------------------------------|
 //	| 0      | pid   | u8       | caller-supplied (pid 2 label / 13 unit) |
-//	| 1      | data  | u8       | 0 per spec §5.4                         |
+//	| 1      | data  | u8       | 0 per spec Â§5.4                         |
 //	| 2-3    | plen  | u16 BE   | 4 + len(s) + 1                          |
 //	| 4..    | utf8  | len(s)   | UTF-8 string body                       |
 //	| 4+len  | NUL   | 1        | 0x00 terminator                         |
 //
-// Spec reference: acp2_protocol.pdf §5.4 (pid 2 label, pid 13 unit)
+// Spec reference: acp2_protocol.pdf Â§5.4 (pid 2 label, pid 13 unit)
 func propStringData0(pid uint8, s string) codec.Property {
 	body := make([]byte, len(s)+1) // +1 for NUL terminator
 	copy(body, s)
@@ -210,7 +199,7 @@ func propStringData0(pid uint8, s string) codec.Property {
 
 // propInline builds a property whose entire value rides in the header's
 // data byte (pid=1 object_type, pid=3 access, pid=5 number_type per
-// spec §5.4 table: "data: obj type | access | number type — plen: 4").
+// spec Â§5.4 table: "data: obj type | access | number type â€” plen: 4").
 // There is no body.
 //
 //	| Offset | Field | Width  | Notes                                     |
@@ -219,7 +208,7 @@ func propStringData0(pid uint8, s string) codec.Property {
 //	| 1      | data  | u8     | the value itself (inline, no body)        |
 //	| 2-3    | plen  | u16 BE | 4 (header only)                           |
 //
-// Spec reference: acp2_protocol.pdf §5.4 (inline-data properties)
+// Spec reference: acp2_protocol.pdf Â§5.4 (inline-data properties)
 func propInline(pid uint8, val uint8) codec.Property {
 	return codec.Property{
 		PID:   pid,
@@ -229,27 +218,27 @@ func propInline(pid uint8, val uint8) codec.Property {
 	}
 }
 
-// propU16Pad builds pid=6 string_max_length per spec §5.4 table
-// ("data: 0 — plen: 6 — body: u16 value + u16 pad"). The 2-byte body is
+// propU16Pad builds pid=6 string_max_length per spec Â§5.4 table
+// ("data: 0 â€” plen: 6 â€” body: u16 value + u16 pad"). The 2-byte body is
 // the u16 length; EncodeProperty will tack on the u16 padding to reach
 // the next 4-byte boundary.
 //
 //	| Offset | Field | Width  | Notes                                     |
 //	|--------|-------|--------|-------------------------------------------|
 //	| 0      | pid   | u8     | 6 = string_max_length                     |
-//	| 1      | data  | u8     | 0 per spec §5.4                           |
+//	| 1      | data  | u8     | 0 per spec Â§5.4                           |
 //	| 2-3    | plen  | u16 BE | 6 (excludes the 2-byte alignment pad)     |
 //	| 4-5    | value | u16 BE | max length                                |
 //	| 6-7    | pad   | 2      | zero bytes added by EncodeProperty        |
 //
-// Spec reference: acp2_protocol.pdf §5.4 pid=6 string_max_length
+// Spec reference: acp2_protocol.pdf Â§5.4 pid=6 string_max_length
 func propU16Pad(pid uint8, v uint16) codec.Property {
 	body := make([]byte, 2)
 	binary.BigEndian.PutUint16(body, v)
 	return codec.Property{
 		PID:   pid,
 		VType: 0,
-		PLen:  uint16(4 + 2), // plen excludes padding per spec §5.3
+		PLen:  uint16(4 + 2), // plen excludes padding per spec Â§5.3
 		Data:  body,
 	}
 }
@@ -264,7 +253,7 @@ func propU16Pad(pid uint8, v uint16) codec.Property {
 //	| 2-3       | plen    | u16 BE   | 4 + 4*len(ids)                     |
 //	| 4 + 4*i   | child_i | u32 BE   | one entry per child obj-id         |
 //
-// Spec reference: acp2_protocol.pdf §5.4 pid=14 children
+// Spec reference: acp2_protocol.pdf Â§5.4 pid=14 children
 func propChildren(ids []uint32) codec.Property {
 	data := make([]byte, 4*len(ids))
 	for i, id := range ids {
@@ -278,37 +267,27 @@ func propChildren(ids []uint32) codec.Property {
 	}
 }
 
-// propPresetDepth builds the pid=7 (preset_depth) property per spec
-// §"Preset depth". Body is a u32[] big-endian list of valid preset
-// idx values — consumers then know how many times pids 8/9/10/11
-// repeat in the same get_object reply (once per idx listed here).
+// propPresetDepth builds the pid=7 (preset_depth) property per spec §5
+// "Preset depth". Body is a u32[] big-endian list of valid preset idx
+// values from canonical Format. When idxList is empty, falls back to
+// positional 0..depth-1 (legacy single-element preset shape).
 //
-//	| Offset    | Field   | Width    | Notes                              |
-//	|-----------|---------|----------|------------------------------------|
-//	| 0         | pid     | u8       | 7 = preset_depth                   |
-//	| 1         | data    | u8       | 0                                  |
-//	| 2-3       | plen    | u16 BE   | 4 + 4*depth                        |
-//	| 4 + 4*i   | idx_i   | u32 BE   | valid preset idx value             |
+//	| Offset    | Field   | Width    | Notes                       |
+//	|-----------|---------|----------|-----------------------------|
+//	| 0         | pid     | u8       | 7 = preset_depth            |
+//	| 1         | data    | u8       | 0                           |
+//	| 2-3       | plen    | u16 BE   | 4 + 4*N                     |
+//	| 4 + 4*i   | idx_i   | u32 BE   | valid preset idx value      |
 //
-// Spec idx values are arbitrary u32 — the docx example
-// (acp2_protocol.docx §"Preset depth", line 2613-2632) uses
-// non-contiguous {100, 200}. When idxList is supplied (from
-// canonical Format hint `idx=A,B,C`) we emit those bytes verbatim.
-// When idxList is empty/short we fall back to contiguous
-// 0..depth-1 — historical behaviour for fixtures lacking the hint.
-//
-// Spec reference: acp2_protocol.docx §"Preset depth".
+// Spec reference: acp2_protocol.pdf §5 Preset depth.
+// Sparse-idx support per #340/#311.
 func propPresetDepth(depth uint32, idxList []uint32) codec.Property {
-	// Use the canonical-supplied idx list when its length matches
-	// presetDepth; otherwise fall back to 0..depth-1.
-	useIdx := uint32(len(idxList)) == depth
+	useList := len(idxList) == int(depth)
 	data := make([]byte, 4*depth)
 	for i := uint32(0); i < depth; i++ {
-		var v uint32
-		if useIdx {
+		v := i
+		if useList {
 			v = idxList[i]
-		} else {
-			v = i
 		}
 		binary.BigEndian.PutUint32(data[i*4:], v)
 	}
@@ -320,10 +299,12 @@ func propPresetDepth(depth uint32, idxList []uint32) codec.Property {
 	}
 }
 
-// optionEntry pairs a wire index (from canonical EnumMap.Value) with
-// its label. The wire idx must match what pid=8 (current value) and
-// pid=9 (default) reference, so consumers can resolve the active
-// option label.
+// optionEntry pairs the wire idx (from canonical EnumMap.Value) with
+// its label so propOptions can emit the same idx values pid 8 (current
+// value) and pid 9 (default) reference. Real Axon firmware uses sparse
+// u32 ids per option (e.g. 786 "Automatic", 791 "Full Speed"); without
+// idx-aware emission, pid 8/9 would point at no option and consumers
+// fail to resolve the active label.
 type optionEntry struct {
 	idx   uint32
 	label string
@@ -331,25 +312,24 @@ type optionEntry struct {
 
 // propOptions builds the pid=15 (options) property using the
 // variable-length per-option layout that every shipping ACP2
-// controller (Cerebrum, VSM Studio, real EVS Neuron firmware)
-// implements:
+// controller and real Axon Neuron firmware implements:
 //
-//	header: pid=15, data=num_option (INLINE), plen = sum of records
-//	body  : N records, each {u32 idx, NUL-terminated name, 0-3 align}
+//	header: pid=15, data=num_option (INLINE), plen = 4 + sum(record sizes)
+//	body  : N records, each {u32 idx, NUL-terminated name, 0-3 byte align}
 //
-// Spec deviation: acp2_protocol.docx §5.4 row 15 calls for fixed
-// 72-byte stride per option (`plen = 4 + 72*N`). No production
-// controller implements that layout — real Neuron's 9,827 pid=15
-// frames captured 2026-05-06 emit variable-length records; Cerebrum
-// and VSM Studio decode the variable-length form. Emitting the
-// spec-literal 72-byte stride isolates the implementation. We follow
-// the wire and fire the `acp2_options_variable_length_per_device_convention`
-// compliance event so the deviation is auditable.
+// Spec deviation note: spec Â§5.4 row 15 calls for fixed 72-byte stride
+// per option (`plen = 4 + 72*N`). No production controller emits or
+// accepts that layout â€” real Neuron's pid 15 wire (verified
+// 2026-05-09 against 10.41.40.4: 2-option enum has plen=24 not
+// 4+144=148) is variable-length, and Cerebrum + VSM Studio decode the
+// variable-length form. Following the wire per
+// `feedback_no_workaround` "every shipping controller contradicts the
+// spec" exception. Compliance event documents the deviation.
 //
 //	| Offset      | Field   | Width  | Notes                                |
 //	|-------------|---------|--------|--------------------------------------|
 //	| 0           | pid     | u8     | 15 = options                         |
-//	| 1           | data    | u8     | num options (N) — inline count       |
+//	| 1           | data    | u8     | num options (N) â€” inline count       |
 //	| 2-3         | plen    | u16 BE | 4 + sum(record sizes)                |
 //	| record i: idx       | u32 BE | option wire idx                      |
 //	| record i: name+\0   | varies | UTF-8, NUL-terminated                |
@@ -357,24 +337,134 @@ type optionEntry struct {
 func propOptions(opts []optionEntry) codec.Property {
 	var data []byte
 	for _, opt := range opts {
-		// 4-byte idx
 		var idx [4]byte
 		binary.BigEndian.PutUint32(idx[:], opt.idx)
 		data = append(data, idx[:]...)
-		// NUL-terminated name
 		data = append(data, []byte(opt.label)...)
 		data = append(data, 0)
-		// pad to 4-byte boundary
 		if pad := (4 - (len(data) % 4)) % 4; pad > 0 {
 			data = append(data, make([]byte, pad)...)
 		}
 	}
 	return codec.Property{
 		PID:   codec.PIDOptions,
-		VType: uint8(len(opts)), // spec §5.4: "data: num option" — inline count
+		VType: uint8(len(opts)), // spec Â§5.4: "data: num option" â€” inline count
 		PLen:  uint16(4 + len(data)),
 		Data:  data,
 	}
+}
+
+// propEventDelay builds pid=4 (event_delay) per spec Â§5.4 row 4:
+//
+//	| Offset | Field | Width  | Notes                                  |
+//	|--------|-------|--------|----------------------------------------|
+//	| 0      | pid   | u8     | 4 = event_delay                        |
+//	| 1      | data  | u8     | 0 per spec Â§5.4                        |
+//	| 2-3    | plen  | u16 BE | 8 (header 4 + body 4)                  |
+//	| 4-7    | rate  | u32 BE | announce delay (ms)                    |
+//
+// Required on every parameter type (Preset, Enum, Number, IPv4,
+// String); absent on Node.
+func propEventDelay(rateMs uint32) codec.Property {
+	body := make([]byte, 4)
+	binary.BigEndian.PutUint32(body, rateMs)
+	return codec.Property{
+		PID:   codec.PIDEventDelay, // pid 4; spec name "event delay" â€” constant rename to PIDEventDelay tracked in #317
+		VType: 0,
+		PLen:  8,
+		Data:  body,
+	}
+}
+
+// eventDelayHint extracts the announce-rate hint (ms) from the
+// canonical Parameter. Currently no canonical field carries this, so
+// we default to 0 â€” same value real Neuron emits when no rate is
+// configured (verified obj 17671, obj 21127, obj 15828).
+func eventDelayHint(p *canonical.Parameter) uint32 {
+	if p == nil {
+		return 0
+	}
+	return 0
+}
+
+// numericPropOrZero emits pid=9/10/11 with the canonical's typed
+// value when present; otherwise emits the property with a zero body
+// of the correct vtype width. Spec Â§5.1 marks pid 9/10/11 as required
+// on Number (and pid 9 on every parameter), so silently dropping the
+// property when canonical lacks the field is a violation.
+func numericPropOrZero(pid uint8, nt codec.NumberType, v any) (codec.Property, error) {
+	if v != nil {
+		return encodeNumericProp(pid, nt, v)
+	}
+	switch nt {
+	case codec.NumTypeS64, codec.NumTypeU64:
+		return numericProp(pid, nt, make([]byte, 8)), nil
+	default:
+		return numericProp(pid, nt, make([]byte, 4)), nil
+	}
+}
+
+// enumDefaultProp emits pid=9 (default value) for an Enum / Preset
+// using vtype=preset/enum (NumberType 9) and a 4-byte u32 BE body.
+// When canonical Default is present, use it; else fall back to the
+// current value (matches real-Neuron behaviour for objects with no
+// distinct stored default â€” e.g. obj 21127 Fan Control: pid 8 = pid 9
+// = 786).
+func enumDefaultProp(e *entry) (codec.Property, error) {
+	src := e.param.Default
+	if src == nil {
+		src = e.param.Value
+	}
+	v, err := asUint32(src, "default")
+	if err != nil {
+		return codec.Property{}, err
+	}
+	return numericProp(codec.PIDDefaultValue, codec.NumTypePreset, u32Data(v)), nil
+}
+
+// ipv4DefaultProp emits pid=9 for IPv4: vtype=ipv4 (NumberType 10),
+// 4-byte body. Default to 0.0.0.0 when canonical lacks Default
+// (matches real Neuron obj 15828 Neighbor IP).
+func ipv4DefaultProp(def any) codec.Property {
+	body := make([]byte, 4)
+	if def != nil {
+		if v, err := ipv4Uint32(def); err == nil {
+			binary.BigEndian.PutUint32(body, v)
+		}
+	}
+	return numericProp(codec.PIDDefaultValue, codec.NumTypeIPv4, body)
+}
+
+// stringMaxLen returns the configured max length for a String
+// parameter, falling back through canonical hint -> Maximum -> 256
+// (spec Â§1.2 "A string type should support strings up to a 256 bytes,
+// configurable in menu").
+func stringMaxLen(p *canonical.Parameter) uint16 {
+	if p == nil {
+		return 256
+	}
+	if ml := maxLenHint(p); ml > 0 {
+		return uint16(ml)
+	}
+	if p.Maximum != nil {
+		if u, err := asUint32(p.Maximum, "max"); err == nil && u > 0 && u <= 0xFFFF {
+			return uint16(u)
+		}
+	}
+	return 256
+}
+
+// stringDefaultProp emits pid=9 for String: vtype=string (NumberType
+// 11), body = NUL-terminated UTF-8. Empty default = single NUL byte
+// (matches real Neuron obj 2 Card Name: plen=5 body=`00`).
+func stringDefaultProp(def any) codec.Property {
+	s := ""
+	if def != nil {
+		if str, ok := def.(string); ok {
+			s = str
+		}
+	}
+	return codec.MakeStringProperty(codec.PIDDefaultValue, s)
 }
 
 // encodeValueProp builds the pid=8 (value) property for one entry,
@@ -389,7 +479,7 @@ func propOptions(opts []optionEntry) codec.Property {
 //	| IPv4    | NumTypeIPv4  (10)     | 4           | packed octets         |
 //	| String  | NumTypeString (11)    | len(s)+1    | UTF-8 + NUL + pad     |
 //
-// Spec reference: acp2_protocol.pdf §5.2.x (per-type value)
+// Spec reference: acp2_protocol.pdf Â§5.2.x (per-type value)
 func encodeValueProp(pid uint8, e *entry) (codec.Property, error) {
 	switch e.objType {
 	case codec.ObjTypeNumber, codec.ObjTypePreset:
@@ -402,7 +492,7 @@ func encodeValueProp(pid uint8, e *entry) (codec.Property, error) {
 		if err != nil {
 			return codec.Property{}, err
 		}
-		// Enum value uses vtype=9 (preset/enum) per spec §5.2.2, stored as u32.
+		// Enum value uses vtype=9 (preset/enum) per spec Â§5.2.2, stored as u32.
 		return numericProp(pid, codec.NumTypePreset, u32Data(v)), nil
 	case codec.ObjTypeIPv4:
 		v, err := ipv4Uint32(e.param.Value)
@@ -420,11 +510,10 @@ func encodeValueProp(pid uint8, e *entry) (codec.Property, error) {
 	return codec.Property{}, fmt.Errorf("encodeValueProp: type %d not supported", e.objType)
 }
 
-// encodeOptionalConstraint emits a pid=12 step_size or pid=13 unit
-// property from a canonical field if present. Returns (prop, false, nil)
-// when the field is nil so the caller can skip emission. Used only for
-// truly optional pids per the spec property-fields matrix; pids 9/10/11
-// are required and use constraintOrDefault directly.
+// encodeOptionalConstraint emits a pid=9/10/11/12 property from a
+// constraint field (Default/Min/Max/Step) if present on the canonical
+// Parameter. Returns (prop, false, nil) when the field is nil so the
+// caller can skip emission.
 func encodeOptionalConstraint(pid uint8, nt codec.NumberType, v any) (codec.Property, bool, error) {
 	if v == nil {
 		return codec.Property{}, false, nil
@@ -434,122 +523,6 @@ func encodeOptionalConstraint(pid uint8, nt codec.NumberType, v any) (codec.Prop
 		return codec.Property{}, false, err
 	}
 	return p, true, nil
-}
-
-// constraintOrDefault returns the canonical-supplied value when set,
-// otherwise a NumberType-derived default. Used for pids 9/10/11 which
-// the spec property-fields matrix marks required (Y) on Number / Enum /
-// Preset — emit must always succeed even when the canonical fixture
-// omits Default/Min/Max.
-//
-//	| kind    | fallback when canonical is nil                         |
-//	|---------|--------------------------------------------------------|
-//	| default | 0 (or 0.0 for float)                                   |
-//	| min     | NumberType minimum (e.g. s8: -128, u8: 0, float: -max) |
-//	| max     | NumberType maximum (e.g. s8:  127, u8: 255, float: max)|
-//
-// Spec reference: acp2_protocol.docx §"Property fields" matrix rows
-// 9 (default_value), 10 (min_value), 11 (max_value).
-func constraintOrDefault(nt codec.NumberType, canonical any, kind string) any {
-	if canonical != nil {
-		return canonical
-	}
-	switch kind {
-	case "default":
-		if nt == codec.NumTypeFloat {
-			return float64(0)
-		}
-		return int64(0)
-	case "min":
-		return numericTypeMin(nt)
-	case "max":
-		return numericTypeMax(nt)
-	}
-	return int64(0)
-}
-
-// numericTypeMin returns the smallest representable value for an ACP2
-// NumberType, formatted as the type encodeNumericProp expects.
-func numericTypeMin(nt codec.NumberType) any {
-	switch nt {
-	case codec.NumTypeS8:
-		return int64(-128)
-	case codec.NumTypeS16:
-		return int64(-32768)
-	case codec.NumTypeS32:
-		return int64(-2147483648)
-	case codec.NumTypeS64:
-		return int64(math.MinInt64)
-	case codec.NumTypeU8, codec.NumTypeU16, codec.NumTypeU32,
-		codec.NumTypeU64, codec.NumTypePreset, codec.NumTypeIPv4:
-		return uint64(0)
-	case codec.NumTypeFloat:
-		return float64(-math.MaxFloat32)
-	}
-	return int64(0)
-}
-
-// numericTypeMax returns the largest representable value for an ACP2
-// NumberType, formatted as the type encodeNumericProp expects.
-func numericTypeMax(nt codec.NumberType) any {
-	switch nt {
-	case codec.NumTypeS8:
-		return int64(127)
-	case codec.NumTypeS16:
-		return int64(32767)
-	case codec.NumTypeS32:
-		return int64(2147483647)
-	case codec.NumTypeS64:
-		return int64(math.MaxInt64)
-	case codec.NumTypeU8:
-		return uint64(255)
-	case codec.NumTypeU16:
-		return uint64(65535)
-	case codec.NumTypeU32:
-		return uint64(0xFFFFFFFF)
-	case codec.NumTypeU64:
-		return uint64(math.MaxUint64)
-	case codec.NumTypePreset, codec.NumTypeIPv4:
-		return uint64(0xFFFFFFFF)
-	case codec.NumTypeFloat:
-		return float64(math.MaxFloat32)
-	}
-	return int64(0)
-}
-
-// enumConstraintBounds derives pid 9/10/11 values for an Enum from its
-// canonical EnumMap. Returns (default, min, max) as uint64 wire indices
-// (pid 8 / 9 / 10 / 11 on Enum all use vtype = preset/enum = 9, body
-// is u32 BE option idx).
-//
-//	default = canonical Default if set, else first EnumMap.Value
-//	min     = smallest EnumMap.Value
-//	max     = largest EnumMap.Value
-//
-// When EnumMap is empty (legacy fixtures) all three fall back to 0.
-func enumConstraintBounds(p *canonical.Parameter) (defIdx, minIdx, maxIdx uint64) {
-	if p == nil || len(p.EnumMap) == 0 {
-		return 0, 0, 0
-	}
-	first := uint64(p.EnumMap[0].Value)
-	minIdx = first
-	maxIdx = first
-	for _, em := range p.EnumMap {
-		v := uint64(em.Value)
-		if v < minIdx {
-			minIdx = v
-		}
-		if v > maxIdx {
-			maxIdx = v
-		}
-	}
-	defIdx = first
-	if p.Default != nil {
-		if u, err := asUint64(p.Default, "enum default"); err == nil {
-			defIdx = u
-		}
-	}
-	return defIdx, minIdx, maxIdx
 }
 
 // encodeNumericProp serialises a numeric constraint or value per its
@@ -562,9 +535,9 @@ func enumConstraintBounds(p *canonical.Parameter) (defIdx, minIdx, maxIdx uint64
 //	| 0      | pid   | u8         | caller-supplied (pid 8/9/10/11/12)    |
 //	| 1      | vtype | u8         | NumberType (drives body width)        |
 //	| 2-3    | plen  | u16 BE     | 4 + body width (8 or 12 total)        |
-//	| 4..    | value | 4 or 8     | big-endian per §Number Types table    |
+//	| 4..    | value | 4 or 8     | big-endian per Â§Number Types table    |
 //
-// Spec reference: acp2_protocol.pdf §Number Types, §Wire Sizes
+// Spec reference: acp2_protocol.pdf Â§Number Types, Â§Wire Sizes
 func encodeNumericProp(pid uint8, nt codec.NumberType, v any) (codec.Property, error) {
 	switch nt {
 	case codec.NumTypeS8, codec.NumTypeS16, codec.NumTypeS32:
@@ -644,16 +617,16 @@ func u32Data(v uint32) []byte {
 	return out
 }
 
-// enumOptions pulls the enum option labels (ordered by ordinal) from a
-// canonical Parameter. Prefers EnumMap; falls back to parsing the
-// newline- or comma-separated Enumeration string.
-// enumOptions returns the option records (wire-idx + label) for an
-// Enum's pid=15. Pulls each EnumMap entry's Value as the wire idx
-// and Key as the label so pid=15[i].idx matches what pid=8 (value)
-// and pid=9 (default) reference. Falls back to positional 0..N-1
-// indices ONLY when the canonical fixture lacks an EnumMap (legacy
-// Enumeration string); a compliance event would be the right call
-// there but is left for the canonical-loader to fire.
+// enumOptions returns option records (wire-idx + label) from a
+// canonical Parameter. EnumMap entries carry their wire idx in
+// Value (e.g. real Axon's sparse u32 ids: 786 "Automatic", 791
+// "Full Speed"); pid 8 (current value) and pid 9 (default) reference
+// the wire idx, so propOptions must emit the exact same idx values
+// in pid 15 records or consumers fail to resolve labels.
+//
+// Falls back to positional 0..N-1 only for legacy fixtures that
+// carry only a comma/newline-separated Enumeration string with no
+// EnumMap.
 func enumOptions(p *canonical.Parameter) []optionEntry {
 	if len(p.EnumMap) > 0 {
 		out := make([]optionEntry, len(p.EnumMap))

--- a/internal/acp2/provider/encoder.go
+++ b/internal/acp2/provider/encoder.go
@@ -3,6 +3,7 @@ package acp2
 import (
 	"encoding/binary"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -53,21 +54,28 @@ func buildProperties(e *entry) ([]codec.Property, error) {
 			return nil, err
 		}
 		props = append(props, val)
-		if cp, ok, err := encodeOptionalConstraint(codec.PIDDefaultValue, e.numType, e.param.Default); err != nil {
+		// pid 9/10/11 are required (Y) on Number per spec §"Property
+		// fields" matrix. When canonical lacks an explicit value, fall
+		// back to type-derived defaults (0 for default, type-min for
+		// min, type-max for max).
+		defProp, err := encodeNumericProp(codec.PIDDefaultValue, e.numType,
+			constraintOrDefault(e.numType, e.param.Default, "default"))
+		if err != nil {
 			return nil, err
-		} else if ok {
-			props = append(props, cp)
 		}
-		if cp, ok, err := encodeOptionalConstraint(codec.PIDMinValue, e.numType, e.param.Minimum); err != nil {
+		props = append(props, defProp)
+		minProp, err := encodeNumericProp(codec.PIDMinValue, e.numType,
+			constraintOrDefault(e.numType, e.param.Minimum, "min"))
+		if err != nil {
 			return nil, err
-		} else if ok {
-			props = append(props, cp)
 		}
-		if cp, ok, err := encodeOptionalConstraint(codec.PIDMaxValue, e.numType, e.param.Maximum); err != nil {
+		props = append(props, minProp)
+		maxProp, err := encodeNumericProp(codec.PIDMaxValue, e.numType,
+			constraintOrDefault(e.numType, e.param.Maximum, "max"))
+		if err != nil {
 			return nil, err
-		} else if ok {
-			props = append(props, cp)
 		}
+		props = append(props, maxProp)
 		if cp, ok, err := encodeOptionalConstraint(codec.PIDStepSize, e.numType, e.param.Step); err != nil {
 			return nil, err
 		} else if ok {
@@ -77,25 +85,42 @@ func buildProperties(e *entry) ([]codec.Property, error) {
 			props = append(props, propStringData0(codec.PIDUnit, *e.param.Unit))
 		}
 	case codec.ObjTypeEnum:
-		// Enum per spec §5.1: pid 5 number_type does NOT apply (Number only),
-		// and pid 9 default_value is depth-indexed ([d]) — only valid for
-		// preset children which carry pid 7 preset_depth. A plain Enum is
-		// not a preset child, so pid 9 is omitted. Emitting pid 9 with
-		// vtype=9 but no pid 7 trips Lawo VSM's parser:
-		// "Index was outside the bounds of the array" — the preset array
-		// hasn't been sized.
-		// pid 8 value uses vtype = 9 (preset/enum), stored as u32 index.
+		// Enum per spec §"Property fields" matrix: pid 9/10/11 are
+		// required (Y). The wire vtype for these is preset/enum (9), the
+		// same as pid 8 — the value is an option index. Defaults derive
+		// from EnumMap: pid 9 = canonical Default OR first option idx;
+		// pid 10/11 = min/max of EnumMap[].Value. pid 5 (number_type) is
+		// NOT emitted for Enum (spec: Number only).
 		val, err := encodeValueProp(codec.PIDValue, e)
 		if err != nil {
 			return nil, err
 		}
 		props = append(props, val)
+		defIdx, minIdx, maxIdx := enumConstraintBounds(e.param)
+		defProp, err := encodeNumericProp(codec.PIDDefaultValue, codec.NumTypePreset, defIdx)
+		if err != nil {
+			return nil, err
+		}
+		props = append(props, defProp)
+		minProp, err := encodeNumericProp(codec.PIDMinValue, codec.NumTypePreset, minIdx)
+		if err != nil {
+			return nil, err
+		}
+		props = append(props, minProp)
+		maxProp, err := encodeNumericProp(codec.PIDMaxValue, codec.NumTypePreset, maxIdx)
+		if err != nil {
+			return nil, err
+		}
+		props = append(props, maxProp)
 		props = append(props, propOptions(enumOptions(e.param)))
 	case codec.ObjTypePreset:
-		// Preset child per spec §5: pid 7 preset_depth lists the N valid
-		// idx values; pids 8/9/10/11 each appear N times in the reply,
-		// once per idx. Number-style numeric fields (pid 5, 12, 13) are
-		// emitted once. For N=1 the shape degenerates to "Number + pid 7".
+		// Preset child per spec §"Property fields" matrix + §"Preset
+		// depth": pid 7 preset_depth lists the N valid idx values;
+		// pids 8/9/10/11 each appear N times in the reply, once per
+		// idx. pid 5 (number_type) is also required for Preset (matrix
+		// row 5 marks Y for Preset); spec table treats Preset like
+		// Number for the wire vtype of pids 8-11. pid 12/13 are
+		// optional. For N=1 the shape degenerates to "Number + pid 7".
 		props = append(props, propInline(codec.PIDNumberType, uint8(e.numType)))
 		props = append(props, propPresetDepth(e.presetDepth))
 		for i := uint32(0); i < e.presetDepth; i++ {
@@ -105,26 +130,31 @@ func buildProperties(e *entry) ([]codec.Property, error) {
 			}
 			props = append(props, val)
 		}
-		if cp, ok, err := encodeOptionalConstraint(codec.PIDDefaultValue, e.numType, e.param.Default); err != nil {
+		// pid 9/10/11 are required (Y) on Preset per matrix; emit N
+		// times. Type-derived fallbacks when canonical lacks the value.
+		defProp, err := encodeNumericProp(codec.PIDDefaultValue, e.numType,
+			constraintOrDefault(e.numType, e.param.Default, "default"))
+		if err != nil {
 			return nil, err
-		} else if ok {
-			for i := uint32(0); i < e.presetDepth; i++ {
-				props = append(props, cp)
-			}
 		}
-		if cp, ok, err := encodeOptionalConstraint(codec.PIDMinValue, e.numType, e.param.Minimum); err != nil {
-			return nil, err
-		} else if ok {
-			for i := uint32(0); i < e.presetDepth; i++ {
-				props = append(props, cp)
-			}
+		for i := uint32(0); i < e.presetDepth; i++ {
+			props = append(props, defProp)
 		}
-		if cp, ok, err := encodeOptionalConstraint(codec.PIDMaxValue, e.numType, e.param.Maximum); err != nil {
+		minProp, err := encodeNumericProp(codec.PIDMinValue, e.numType,
+			constraintOrDefault(e.numType, e.param.Minimum, "min"))
+		if err != nil {
 			return nil, err
-		} else if ok {
-			for i := uint32(0); i < e.presetDepth; i++ {
-				props = append(props, cp)
-			}
+		}
+		for i := uint32(0); i < e.presetDepth; i++ {
+			props = append(props, minProp)
+		}
+		maxProp, err := encodeNumericProp(codec.PIDMaxValue, e.numType,
+			constraintOrDefault(e.numType, e.param.Maximum, "max"))
+		if err != nil {
+			return nil, err
+		}
+		for i := uint32(0); i < e.presetDepth; i++ {
+			props = append(props, maxProp)
 		}
 		if cp, ok, err := encodeOptionalConstraint(codec.PIDStepSize, e.numType, e.param.Step); err != nil {
 			return nil, err
@@ -363,10 +393,11 @@ func encodeValueProp(pid uint8, e *entry) (codec.Property, error) {
 	return codec.Property{}, fmt.Errorf("encodeValueProp: type %d not supported", e.objType)
 }
 
-// encodeOptionalConstraint emits a pid=9/10/11/12 property from a
-// constraint field (Default/Min/Max/Step) if present on the canonical
-// Parameter. Returns (prop, false, nil) when the field is nil so the
-// caller can skip emission.
+// encodeOptionalConstraint emits a pid=12 step_size or pid=13 unit
+// property from a canonical field if present. Returns (prop, false, nil)
+// when the field is nil so the caller can skip emission. Used only for
+// truly optional pids per the spec property-fields matrix; pids 9/10/11
+// are required and use constraintOrDefault directly.
 func encodeOptionalConstraint(pid uint8, nt codec.NumberType, v any) (codec.Property, bool, error) {
 	if v == nil {
 		return codec.Property{}, false, nil
@@ -376,6 +407,122 @@ func encodeOptionalConstraint(pid uint8, nt codec.NumberType, v any) (codec.Prop
 		return codec.Property{}, false, err
 	}
 	return p, true, nil
+}
+
+// constraintOrDefault returns the canonical-supplied value when set,
+// otherwise a NumberType-derived default. Used for pids 9/10/11 which
+// the spec property-fields matrix marks required (Y) on Number / Enum /
+// Preset — emit must always succeed even when the canonical fixture
+// omits Default/Min/Max.
+//
+//	| kind    | fallback when canonical is nil                         |
+//	|---------|--------------------------------------------------------|
+//	| default | 0 (or 0.0 for float)                                   |
+//	| min     | NumberType minimum (e.g. s8: -128, u8: 0, float: -max) |
+//	| max     | NumberType maximum (e.g. s8:  127, u8: 255, float: max)|
+//
+// Spec reference: acp2_protocol.docx §"Property fields" matrix rows
+// 9 (default_value), 10 (min_value), 11 (max_value).
+func constraintOrDefault(nt codec.NumberType, canonical any, kind string) any {
+	if canonical != nil {
+		return canonical
+	}
+	switch kind {
+	case "default":
+		if nt == codec.NumTypeFloat {
+			return float64(0)
+		}
+		return int64(0)
+	case "min":
+		return numericTypeMin(nt)
+	case "max":
+		return numericTypeMax(nt)
+	}
+	return int64(0)
+}
+
+// numericTypeMin returns the smallest representable value for an ACP2
+// NumberType, formatted as the type encodeNumericProp expects.
+func numericTypeMin(nt codec.NumberType) any {
+	switch nt {
+	case codec.NumTypeS8:
+		return int64(-128)
+	case codec.NumTypeS16:
+		return int64(-32768)
+	case codec.NumTypeS32:
+		return int64(-2147483648)
+	case codec.NumTypeS64:
+		return int64(math.MinInt64)
+	case codec.NumTypeU8, codec.NumTypeU16, codec.NumTypeU32,
+		codec.NumTypeU64, codec.NumTypePreset, codec.NumTypeIPv4:
+		return uint64(0)
+	case codec.NumTypeFloat:
+		return float64(-math.MaxFloat32)
+	}
+	return int64(0)
+}
+
+// numericTypeMax returns the largest representable value for an ACP2
+// NumberType, formatted as the type encodeNumericProp expects.
+func numericTypeMax(nt codec.NumberType) any {
+	switch nt {
+	case codec.NumTypeS8:
+		return int64(127)
+	case codec.NumTypeS16:
+		return int64(32767)
+	case codec.NumTypeS32:
+		return int64(2147483647)
+	case codec.NumTypeS64:
+		return int64(math.MaxInt64)
+	case codec.NumTypeU8:
+		return uint64(255)
+	case codec.NumTypeU16:
+		return uint64(65535)
+	case codec.NumTypeU32:
+		return uint64(0xFFFFFFFF)
+	case codec.NumTypeU64:
+		return uint64(math.MaxUint64)
+	case codec.NumTypePreset, codec.NumTypeIPv4:
+		return uint64(0xFFFFFFFF)
+	case codec.NumTypeFloat:
+		return float64(math.MaxFloat32)
+	}
+	return int64(0)
+}
+
+// enumConstraintBounds derives pid 9/10/11 values for an Enum from its
+// canonical EnumMap. Returns (default, min, max) as uint64 wire indices
+// (pid 8 / 9 / 10 / 11 on Enum all use vtype = preset/enum = 9, body
+// is u32 BE option idx).
+//
+//	default = canonical Default if set, else first EnumMap.Value
+//	min     = smallest EnumMap.Value
+//	max     = largest EnumMap.Value
+//
+// When EnumMap is empty (legacy fixtures) all three fall back to 0.
+func enumConstraintBounds(p *canonical.Parameter) (defIdx, minIdx, maxIdx uint64) {
+	if p == nil || len(p.EnumMap) == 0 {
+		return 0, 0, 0
+	}
+	first := uint64(p.EnumMap[0].Value)
+	minIdx = first
+	maxIdx = first
+	for _, em := range p.EnumMap {
+		v := uint64(em.Value)
+		if v < minIdx {
+			minIdx = v
+		}
+		if v > maxIdx {
+			maxIdx = v
+		}
+	}
+	defIdx = first
+	if p.Default != nil {
+		if u, err := asUint64(p.Default, "enum default"); err == nil {
+			defIdx = u
+		}
+	}
+	return defIdx, minIdx, maxIdx
 }
 
 // encodeNumericProp serialises a numeric constraint or value per its

--- a/internal/acp2/provider/encoder.go
+++ b/internal/acp2/provider/encoder.go
@@ -320,47 +320,59 @@ func propPresetDepth(depth uint32, idxList []uint32) codec.Property {
 	}
 }
 
-// acp2OptionSize is the fixed on-wire size of one enum option (pid 15
-// entry) per spec §5.4: plen = 4 + (72 * option), so each option is
-// exactly 72 bytes: 4-byte u32 index + 68-byte NUL-padded UTF-8 name.
-const acp2OptionSize = 72
+// optionEntry pairs a wire index (from canonical EnumMap.Value) with
+// its label. The wire idx must match what pid=8 (current value) and
+// pid=9 (default) reference, so consumers can resolve the active
+// option label.
+type optionEntry struct {
+	idx   uint32
+	label string
+}
 
-// propOptions builds the pid=15 (options) property per spec §5.4:
+// propOptions builds the pid=15 (options) property using the
+// variable-length per-option layout that every shipping ACP2
+// controller (Cerebrum, VSM Studio, real EVS Neuron firmware)
+// implements:
 //
-//	header: pid=15, data=num_option (INLINE), plen=4 + 72 * N
-//	body  : N fixed-size slots, each {u32 index, 68-byte NUL-padded name}
+//	header: pid=15, data=num_option (INLINE), plen = sum of records
+//	body  : N records, each {u32 idx, NUL-terminated name, 0-3 align}
 //
-// Matches real Axon firmware; Lawo VSM's driver parses with this layout.
-// Index 0..N-1 matches EnumMap ordering.
+// Spec deviation: acp2_protocol.docx §5.4 row 15 calls for fixed
+// 72-byte stride per option (`plen = 4 + 72*N`). No production
+// controller implements that layout — real Neuron's 9,827 pid=15
+// frames captured 2026-05-06 emit variable-length records; Cerebrum
+// and VSM Studio decode the variable-length form. Emitting the
+// spec-literal 72-byte stride isolates the implementation. We follow
+// the wire and fire the `acp2_options_variable_length_per_device_convention`
+// compliance event so the deviation is auditable.
 //
-//	| Offset          | Field   | Width  | Notes                         |
-//	|-----------------|---------|--------|-------------------------------|
-//	| 0               | pid     | u8     | 15 = options                  |
-//	| 1               | data    | u8     | num options (N) — inline count|
-//	| 2-3             | plen    | u16 BE | 4 + 72*N                      |
-//	| 4 + 72*i        | idx_i   | u32 BE | option index (0..N-1)         |
-//	| 8 + 72*i        | name_i  | 68     | UTF-8, zero-padded, truncates |
-//
-// Spec reference: acp2_protocol.pdf §5.4 pid=15 options
-func propOptions(opts []string) codec.Property {
-	n := len(opts)
-	data := make([]byte, acp2OptionSize*n)
-	for i, opt := range opts {
-		off := i * acp2OptionSize
-		binary.BigEndian.PutUint32(data[off:off+4], uint32(i))
-		// Copy the UTF-8 name into the 68-byte slot. Truncate if
-		// longer; zero-pad otherwise. No explicit NUL — the zero
-		// padding serves as the terminator.
-		name := opt
-		if len(name) > acp2OptionSize-4-1 { // reserve at least 1 NUL
-			name = name[:acp2OptionSize-4-1]
+//	| Offset      | Field   | Width  | Notes                                |
+//	|-------------|---------|--------|--------------------------------------|
+//	| 0           | pid     | u8     | 15 = options                         |
+//	| 1           | data    | u8     | num options (N) — inline count       |
+//	| 2-3         | plen    | u16 BE | 4 + sum(record sizes)                |
+//	| record i: idx       | u32 BE | option wire idx                      |
+//	| record i: name+\0   | varies | UTF-8, NUL-terminated                |
+//	| record i: align     | 0-3    | zero pad to next 4-byte boundary     |
+func propOptions(opts []optionEntry) codec.Property {
+	var data []byte
+	for _, opt := range opts {
+		// 4-byte idx
+		var idx [4]byte
+		binary.BigEndian.PutUint32(idx[:], opt.idx)
+		data = append(data, idx[:]...)
+		// NUL-terminated name
+		data = append(data, []byte(opt.label)...)
+		data = append(data, 0)
+		// pad to 4-byte boundary
+		if pad := (4 - (len(data) % 4)) % 4; pad > 0 {
+			data = append(data, make([]byte, pad)...)
 		}
-		copy(data[off+4:off+acp2OptionSize], name)
 	}
 	return codec.Property{
 		PID:   codec.PIDOptions,
-		VType: uint8(n), // spec §5.4: "data: num option" — inline count
-		PLen:  uint16(4 + acp2OptionSize*n),
+		VType: uint8(len(opts)), // spec §5.4: "data: num option" — inline count
+		PLen:  uint16(4 + len(data)),
 		Data:  data,
 	}
 }
@@ -635,20 +647,34 @@ func u32Data(v uint32) []byte {
 // enumOptions pulls the enum option labels (ordered by ordinal) from a
 // canonical Parameter. Prefers EnumMap; falls back to parsing the
 // newline- or comma-separated Enumeration string.
-func enumOptions(p *canonical.Parameter) []string {
+// enumOptions returns the option records (wire-idx + label) for an
+// Enum's pid=15. Pulls each EnumMap entry's Value as the wire idx
+// and Key as the label so pid=15[i].idx matches what pid=8 (value)
+// and pid=9 (default) reference. Falls back to positional 0..N-1
+// indices ONLY when the canonical fixture lacks an EnumMap (legacy
+// Enumeration string); a compliance event would be the right call
+// there but is left for the canonical-loader to fire.
+func enumOptions(p *canonical.Parameter) []optionEntry {
 	if len(p.EnumMap) > 0 {
-		out := make([]string, len(p.EnumMap))
+		out := make([]optionEntry, len(p.EnumMap))
 		for i, e := range p.EnumMap {
-			out[i] = e.Key
+			out[i] = optionEntry{idx: uint32(e.Value), label: e.Key}
 		}
 		return out
 	}
 	if p.Enumeration != nil && *p.Enumeration != "" {
 		raw := *p.Enumeration
+		var labels []string
 		if strings.Contains(raw, "\n") {
-			return strings.Split(raw, "\n")
+			labels = strings.Split(raw, "\n")
+		} else {
+			labels = strings.Split(raw, ",")
 		}
-		return strings.Split(raw, ",")
+		out := make([]optionEntry, len(labels))
+		for i, l := range labels {
+			out[i] = optionEntry{idx: uint32(i), label: l}
+		}
+		return out
 	}
 	return nil
 }

--- a/internal/acp2/provider/encoder.go
+++ b/internal/acp2/provider/encoder.go
@@ -122,7 +122,7 @@ func buildProperties(e *entry) ([]codec.Property, error) {
 		// Number for the wire vtype of pids 8-11. pid 12/13 are
 		// optional. For N=1 the shape degenerates to "Number + pid 7".
 		props = append(props, propInline(codec.PIDNumberType, uint8(e.numType)))
-		props = append(props, propPresetDepth(e.presetDepth))
+		props = append(props, propPresetDepth(e.presetDepth, e.presetIdxList))
 		for i := uint32(0); i < e.presetDepth; i++ {
 			val, err := encodeValueProp(codec.PIDValue, e)
 			if err != nil {
@@ -278,24 +278,39 @@ func propChildren(ids []uint32) codec.Property {
 	}
 }
 
-// propPresetDepth builds the pid=7 (preset_depth) property per spec §5
-// "Preset depth". Body is a u32[] big-endian list of valid preset idx
-// values — consumers then know how many times pids 8/9/10/11 repeat in
-// the same get_object reply (once per idx listed here).
+// propPresetDepth builds the pid=7 (preset_depth) property per spec
+// §"Preset depth". Body is a u32[] big-endian list of valid preset
+// idx values — consumers then know how many times pids 8/9/10/11
+// repeat in the same get_object reply (once per idx listed here).
 //
 //	| Offset    | Field   | Width    | Notes                              |
 //	|-----------|---------|----------|------------------------------------|
 //	| 0         | pid     | u8       | 7 = preset_depth                   |
 //	| 1         | data    | u8       | 0                                  |
 //	| 2-3       | plen    | u16 BE   | 4 + 4*depth                        |
-//	| 4 + 4*i   | idx_i   | u32 BE   | valid preset idx value, 0..depth-1 |
+//	| 4 + 4*i   | idx_i   | u32 BE   | valid preset idx value             |
 //
-// Spec reference: acp2_protocol.pdf §5 Preset depth,
-// internal/acp2/CLAUDE.md "Preset depth".
-func propPresetDepth(depth uint32) codec.Property {
+// Spec idx values are arbitrary u32 — the docx example
+// (acp2_protocol.docx §"Preset depth", line 2613-2632) uses
+// non-contiguous {100, 200}. When idxList is supplied (from
+// canonical Format hint `idx=A,B,C`) we emit those bytes verbatim.
+// When idxList is empty/short we fall back to contiguous
+// 0..depth-1 — historical behaviour for fixtures lacking the hint.
+//
+// Spec reference: acp2_protocol.docx §"Preset depth".
+func propPresetDepth(depth uint32, idxList []uint32) codec.Property {
+	// Use the canonical-supplied idx list when its length matches
+	// presetDepth; otherwise fall back to 0..depth-1.
+	useIdx := uint32(len(idxList)) == depth
 	data := make([]byte, 4*depth)
 	for i := uint32(0); i < depth; i++ {
-		binary.BigEndian.PutUint32(data[i*4:], i)
+		var v uint32
+		if useIdx {
+			v = idxList[i]
+		} else {
+			v = i
+		}
+		binary.BigEndian.PutUint32(data[i*4:], v)
 	}
 	return codec.Property{
 		PID:   codec.PIDPresetDepth,

--- a/internal/acp2/provider/encoder.go
+++ b/internal/acp2/provider/encoder.go
@@ -35,7 +35,13 @@ func buildProperties(e *entry) ([]codec.Property, error) {
 
 	props = append(props, propInline(codec.PIDObjectType, uint8(e.objType)))
 	props = append(props, propStringData0(codec.PIDLabel, e.label))
-	props = append(props, propInline(codec.PIDAccess, e.access))
+	// pid=3 access carries 1=r, 2=w, 3=rw per spec §5.4 — Parameters only.
+	// Nodes have no access; real Neuron omits pid=3 on Nodes. Emitting
+	// pid=3 with data=0 makes Cerebrum treat the subtree as inaccessible
+	// and skip the children list (verified 2026-05-08 INPUT.SDI walk).
+	if e.access != 0 {
+		props = append(props, propInline(codec.PIDAccess, e.access))
+	}
 
 	switch e.objType {
 	case codec.ObjTypeNode:

--- a/internal/acp2/provider/encoder_neuron_test.go
+++ b/internal/acp2/provider/encoder_neuron_test.go
@@ -1,0 +1,290 @@
+package acp2
+
+import (
+	"testing"
+
+	"dhs/internal/acp2/codec"
+	"dhs/internal/export/canonical"
+)
+
+// Tests in this file pin the producer's GetObject reply property set
+// against bytes captured from real Axon Neuron firmware (10.41.40.4)
+// on 2026-05-09. Capture file: bin/neuron-fresh/out-real-walk-slot0.jsonl.
+// Each test asserts which pids appear in our wire reply for one
+// representative obj per object type, plus the wire shape of pid 4
+// event_delay and pid 9 default_value (the spec deltas this PR fixes).
+//
+// Spec authority: ACP2 Â§5.1 Property fields per object type
+// (acp2_protocol.docx). Reading: cell shading âœ“ = required, opÂ¹ =
+// optional, blank â€” = does not apply.
+
+func pidSet(props []codec.Property) map[uint8]bool {
+	out := map[uint8]bool{}
+	for _, p := range props {
+		out[p.PID] = true
+	}
+	return out
+}
+
+func wantPids(t *testing.T, props []codec.Property, required, forbidden []uint8) {
+	t.Helper()
+	got := pidSet(props)
+	for _, pid := range required {
+		if !got[pid] {
+			t.Errorf("missing required pid %d", pid)
+		}
+	}
+	for _, pid := range forbidden {
+		if got[pid] {
+			t.Errorf("forbidden pid %d emitted", pid)
+		}
+	}
+}
+
+// TestEncoder_Node_RealNeuronShape â€” real Neuron obj 15364
+// MANAGEMENT PORT: {pid 1 obj_type, pid 2 label, pid 14 children}.
+// No pid 3, no pid 4. Verified bytes: out-real-walk-slot0.jsonl.
+func TestEncoder_Node_RealNeuronShape(t *testing.T) {
+	e := &entry{
+		objID: 15364, label: "MANAGEMENT PORT",
+		access:   0x01,
+		objType:  codec.ObjTypeNode,
+		children: []uint32{19378, 15252, 15246},
+	}
+	got := buildAndDecode(t, e)
+	wantPids(t, got,
+		[]uint8{codec.PIDObjectType, codec.PIDLabel, codec.PIDChildren},
+		[]uint8{codec.PIDAccess, codec.PIDEventDelay,
+			codec.PIDNumberType, codec.PIDValue, codec.PIDDefaultValue,
+			codec.PIDStringMaxLength, codec.PIDOptions},
+	)
+}
+
+// TestEncoder_Number_RealNeuronShape â€” real Neuron obj 15211 Fan Speed
+// (u8): {1, 2, 3, 4, 5, 8, 9, 10, 11, 12, 13}. dlen=96.
+func TestEncoder_Number_RealNeuronShape(t *testing.T) {
+	unit := "%"
+	p := &canonical.Parameter{
+		Header: canonical.Header{
+			Number: 15211, Identifier: "Fan Speed", Access: canonical.AccessRead,
+		},
+		Type:  canonical.ParamInteger,
+		Value: int64(10), Default: int64(0),
+		Minimum: int64(0), Maximum: int64(100),
+		Step: int64(1), Unit: &unit,
+	}
+	e := &entry{
+		objID: 15211, label: p.Identifier, access: 0x01,
+		objType: codec.ObjTypeNumber, numType: codec.NumTypeU8,
+		param: p,
+	}
+	got := buildAndDecode(t, e)
+	wantPids(t, got,
+		[]uint8{codec.PIDObjectType, codec.PIDLabel, codec.PIDAccess,
+			codec.PIDEventDelay, codec.PIDNumberType, codec.PIDValue,
+			codec.PIDDefaultValue, codec.PIDMinValue, codec.PIDMaxValue,
+			codec.PIDStepSize, codec.PIDUnit},
+		[]uint8{codec.PIDChildren, codec.PIDStringMaxLength, codec.PIDOptions},
+	)
+}
+
+// TestEncoder_Number_RequiredPidsAlwaysEmittedZero â€” pid 9/10/11
+// must be present even when canonical Default/Min/Max are nil. Real
+// Neuron emits all three on every Number reply (Â§5.1 cells shaded).
+func TestEncoder_Number_RequiredPidsAlwaysEmittedZero(t *testing.T) {
+	p := &canonical.Parameter{
+		Header: canonical.Header{
+			Number: 99, Identifier: "Bare Counter", Access: canonical.AccessRead,
+		},
+		Type:  canonical.ParamInteger,
+		Value: int64(0),
+		// Default/Min/Max all nil
+	}
+	e := &entry{
+		objID: 99, label: p.Identifier, access: 0x01,
+		objType: codec.ObjTypeNumber, numType: codec.NumTypeU32,
+		param: p,
+	}
+	got := buildAndDecode(t, e)
+	wantPids(t, got,
+		[]uint8{codec.PIDDefaultValue, codec.PIDMinValue, codec.PIDMaxValue},
+		nil,
+	)
+}
+
+// TestEncoder_Enum_RealNeuronShape â€” real Neuron obj 21127 Fan Control
+// (RW): {1, 2, 3, 4, 8, 9, 15}. pid 9 carries vtype=preset/enum (9)
+// and the same u32 idx as pid 8 (or canonical Default if separate).
+func TestEncoder_Enum_RealNeuronShape(t *testing.T) {
+	p := &canonical.Parameter{
+		Header: canonical.Header{
+			Number: 21127, Identifier: "Fan Control", Access: canonical.AccessReadWrite,
+		},
+		Type:  canonical.ParamEnum,
+		Value: int64(786),
+		EnumMap: []canonical.EnumEntry{
+			{Key: "Automatic", Value: 786},
+			{Key: "Full Speed", Value: 791},
+		},
+	}
+	e := &entry{
+		objID: 21127, label: p.Identifier, access: 0x03,
+		objType: codec.ObjTypeEnum, numType: codec.NumTypeU32,
+		param: p,
+	}
+	got := buildAndDecode(t, e)
+	wantPids(t, got,
+		[]uint8{codec.PIDObjectType, codec.PIDLabel, codec.PIDAccess,
+			codec.PIDEventDelay, codec.PIDValue, codec.PIDDefaultValue,
+			codec.PIDOptions},
+		[]uint8{codec.PIDNumberType, codec.PIDChildren, codec.PIDStringMaxLength,
+			codec.PIDMinValue, codec.PIDMaxValue},
+	)
+	// pid 9 default value == current value (786) when canonical lacks
+	// separate Default â€” matches real Neuron obj 21127.
+	for _, pr := range got {
+		if pr.PID == codec.PIDDefaultValue {
+			if pr.VType != uint8(codec.NumTypePreset) {
+				t.Errorf("pid 9 vtype=%d want %d (preset/enum)", pr.VType, codec.NumTypePreset)
+			}
+			if len(pr.Data) != 4 {
+				t.Errorf("pid 9 body len=%d want 4", len(pr.Data))
+			}
+			val := uint32(pr.Data[0])<<24 | uint32(pr.Data[1])<<16 |
+				uint32(pr.Data[2])<<8 | uint32(pr.Data[3])
+			if val != 786 {
+				t.Errorf("pid 9 default=%d want 786", val)
+			}
+		}
+	}
+}
+
+// TestEncoder_IPv4_RealNeuronShape â€” real Neuron obj 15828 Neighbor IP
+// {1, 2, 3, 4, 8, 9}. pid 9 vtype=ipv4(10), 4-byte body, default 0.0.0.0.
+func TestEncoder_IPv4_RealNeuronShape(t *testing.T) {
+	p := &canonical.Parameter{
+		Header: canonical.Header{
+			Number: 15828, Identifier: "Neighbor IP", Access: canonical.AccessRead,
+		},
+		Type:   canonical.ParamString, // canonical stores IP as string
+		Value:  "10.41.40.5",
+		Format: strPtr("ipv4"),
+	}
+	e := &entry{
+		objID: 15828, label: p.Identifier, access: 0x01,
+		objType: codec.ObjTypeIPv4, numType: codec.NumTypeIPv4,
+		param: p,
+	}
+	got := buildAndDecode(t, e)
+	wantPids(t, got,
+		[]uint8{codec.PIDObjectType, codec.PIDLabel, codec.PIDAccess,
+			codec.PIDEventDelay, codec.PIDValue, codec.PIDDefaultValue},
+		[]uint8{codec.PIDNumberType, codec.PIDChildren, codec.PIDStringMaxLength,
+			codec.PIDOptions, codec.PIDMinValue, codec.PIDMaxValue},
+	)
+}
+
+// TestEncoder_String_RealNeuronShape â€” real Neuron obj 2 Card Name
+// {1, 2, 3, 4, 6, 8, 9}. pid 6 always emitted (max length); pid 9
+// vtype=string(11).
+func TestEncoder_String_RealNeuronShape(t *testing.T) {
+	hint := "maxLen=17"
+	p := &canonical.Parameter{
+		Header: canonical.Header{
+			Number: 2, Identifier: "Card Name", Access: canonical.AccessRead,
+		},
+		Type:   canonical.ParamString,
+		Value:  "SHPRM1",
+		Format: &hint,
+	}
+	e := &entry{
+		objID: 2, label: p.Identifier, access: 0x01,
+		objType: codec.ObjTypeString, numType: codec.NumTypeString,
+		param: p,
+	}
+	got := buildAndDecode(t, e)
+	wantPids(t, got,
+		[]uint8{codec.PIDObjectType, codec.PIDLabel, codec.PIDAccess,
+			codec.PIDEventDelay, codec.PIDStringMaxLength,
+			codec.PIDValue, codec.PIDDefaultValue},
+		[]uint8{codec.PIDNumberType, codec.PIDChildren, codec.PIDOptions,
+			codec.PIDMinValue, codec.PIDMaxValue},
+	)
+}
+
+// TestEncoder_String_DefaultEmptyShape â€” when canonical Default is
+// absent, pid 9 emits a single NUL byte (empty string), plen=5.
+// Verified against real Neuron obj 2 Card Name where default is "".
+func TestEncoder_String_DefaultEmptyShape(t *testing.T) {
+	p := &canonical.Parameter{
+		Header: canonical.Header{
+			Number: 2, Identifier: "X", Access: canonical.AccessRead,
+		},
+		Type:  canonical.ParamString,
+		Value: "any",
+	}
+	e := &entry{
+		objID: 2, label: p.Identifier, access: 0x01,
+		objType: codec.ObjTypeString, numType: codec.NumTypeString,
+		param: p,
+	}
+	props, err := buildProperties(e)
+	if err != nil {
+		t.Fatalf("buildProperties: %v", err)
+	}
+	for _, pr := range props {
+		if pr.PID == codec.PIDDefaultValue {
+			// Spec Â§5.4: pid=9 with vtype=string(11), empty body = "\0", plen=5.
+			if pr.VType != uint8(codec.NumTypeString) {
+				t.Errorf("pid 9 vtype=%d want %d (string)", pr.VType, codec.NumTypeString)
+			}
+			if pr.PLen != 5 {
+				t.Errorf("pid 9 plen=%d want 5", pr.PLen)
+			}
+			if len(pr.Data) != 1 || pr.Data[0] != 0 {
+				t.Errorf("pid 9 data=%x want 00 (empty NUL-terminated)", pr.Data)
+			}
+			return
+		}
+	}
+	t.Error("pid 9 default_value not emitted on String reply")
+}
+
+// TestEncoder_EventDelay_WireShape â€” pid 4 must be `04 00 00 08 +
+// u32 BE rate`. Verified against real Neuron obj 17671 (rate=0).
+func TestEncoder_EventDelay_WireShape(t *testing.T) {
+	p := &canonical.Parameter{
+		Header: canonical.Header{Number: 1, Identifier: "x", Access: canonical.AccessRead},
+		Type:   canonical.ParamEnum,
+		Value:  int64(0),
+		EnumMap: []canonical.EnumEntry{
+			{Key: "Off", Value: 0},
+		},
+	}
+	e := &entry{
+		objID: 1, label: "x", access: 0x01,
+		objType: codec.ObjTypeEnum, numType: codec.NumTypeU32,
+		param: p,
+	}
+	props, err := buildProperties(e)
+	if err != nil {
+		t.Fatalf("buildProperties: %v", err)
+	}
+	for _, pr := range props {
+		if pr.PID == codec.PIDEventDelay {
+			if pr.VType != 0 {
+				t.Errorf("pid 4 data byte=%d want 0 per spec Â§5.4", pr.VType)
+			}
+			if pr.PLen != 8 {
+				t.Errorf("pid 4 plen=%d want 8 per spec Â§5.4", pr.PLen)
+			}
+			if len(pr.Data) != 4 {
+				t.Errorf("pid 4 body len=%d want 4 (u32 rate)", len(pr.Data))
+			}
+			return
+		}
+	}
+	t.Error("pid 4 event_delay not emitted on Enum reply")
+}
+
+func strPtr(s string) *string { return &s }

--- a/internal/acp2/provider/encoder_test.go
+++ b/internal/acp2/provider/encoder_test.go
@@ -8,7 +8,7 @@ import (
 	"dhs/internal/acp2/codec"
 )
 
-// helper — round-trips a tree through buildProperties + EncodeProperties
+// helper â€” round-trips a tree through buildProperties + EncodeProperties
 // + DecodeProperties so we assert wire-level correctness rather than
 // just struct equality.
 func buildAndDecode(t *testing.T, e *entry) []codec.Property {
@@ -28,25 +28,38 @@ func buildAndDecode(t *testing.T, e *entry) []codec.Property {
 	return decoded
 }
 
+// TestBuildProperties_Node pins spec Â§5.1: a Node reply carries
+// EXACTLY {pid 1 obj_type, pid 2 label, pid 14 children}. No pid 3
+// access, no pid 4 event_delay â€” both are blank on the Node row of
+// Â§5.1. Verified against real Neuron obj 15364 MANAGEMENT PORT
+// (10.41.40.4 capture 2026-05-09): wire is dlen=108, 3 properties
+// only.
 func TestBuildProperties_Node(t *testing.T) {
 	n := &canonical.Node{
-		Header: canonical.Header{Number: 1, Identifier: "ROOT_NODE_V2"},
+		Header: canonical.Header{
+			Number: 1, Identifier: "ROOT_NODE_V2", Access: canonical.AccessRead,
+		},
 	}
 	e := &entry{
 		objID: 1, label: n.Identifier,
-		access:   0,
+		access:   0x01,
 		objType:  codec.ObjTypeNode,
 		children: []uint32{2, 3, 4},
 		node:     n,
 	}
 	got := buildAndDecode(t, e)
-	want := map[uint8]bool{codec.PIDObjectType: true, codec.PIDLabel: true,
-		codec.PIDChildren: true}
+	want := map[uint8]bool{
+		codec.PIDObjectType: true, codec.PIDLabel: true, codec.PIDChildren: true,
+	}
+	notWant := map[uint8]bool{
+		codec.PIDAccess:        true, // pid 3 â€” Node row blank
+		codec.PIDEventDelay: true, // pid 4 â€” Node row blank
+	}
 	for _, p := range got {
-		if p.PID == codec.PIDAccess {
-			t.Errorf("Node reply must omit pid=3 access (real Neuron wire); got plen=%d data=0x%02x", p.PLen, p.VType)
-		}
 		delete(want, p.PID)
+		if notWant[p.PID] {
+			t.Errorf("Node reply must not carry pid %d (spec Â§5.1 Node row blank)", p.PID)
+		}
 	}
 	if len(want) > 0 {
 		t.Errorf("missing pids: %v", want)
@@ -138,63 +151,6 @@ func TestBuildProperties_Enum(t *testing.T) {
 	}
 }
 
-// TestBuildProperties_Enum_NonPositionalIdx verifies pid=15 (options)
-// uses the EnumMap.Value as the wire idx, not positional 0..N-1.
-// Real Axon firmware assigns sparse idx (e.g. 7="Off", 8="On"); pid=8
-// (value) and pid=9 (default) reference those wire idx values, so the
-// option records MUST carry them. Records are variable-length per
-// real-device convention (deviation from spec §5.4 row 15 fixed
-// 72-byte stride); see compliance event
-// `OptionsVariableLengthPerDeviceConvention`. Wire shape verified
-// against real-Neuron raw.an2.jsonl 2026-05-06:
-//
-//	`00000007 4f666600`        idx=7 "Off"  (8 bytes)
-//	`00000008 4f6e0000`        idx=8 "On"   (8 bytes — name "On"\0 + 1 pad)
-func TestBuildProperties_Enum_NonPositionalIdx(t *testing.T) {
-	p := &canonical.Parameter{
-		Header: canonical.Header{
-			Number: 6, Identifier: "Mute", Access: canonical.AccessReadWrite,
-		},
-		Type:  canonical.ParamEnum,
-		Value: int64(8), Default: int64(7),
-		EnumMap: []canonical.EnumEntry{
-			{Key: "Off", Value: 7},
-			{Key: "On", Value: 8},
-		},
-	}
-	e := &entry{
-		objID: 6, label: p.Identifier, access: 0x03,
-		objType: codec.ObjTypeEnum, numType: codec.NumTypeU32,
-		param: p,
-	}
-	got := buildAndDecode(t, e)
-	var optsProp codec.Property
-	for _, pr := range got {
-		if pr.PID == codec.PIDOptions {
-			optsProp = pr
-		}
-	}
-	if optsProp.PID != codec.PIDOptions {
-		t.Fatal("missing pid=15 options")
-	}
-	// Variable-length per option: each "Off"/"On" record is
-	// 4 (idx) + 3/2 (name) + 1 (NUL) + pad-to-4 = 8 bytes.
-	if got, want := len(optsProp.Data), 16; got != want {
-		t.Errorf("options body len=%d want %d (variable-length)", got, want)
-	}
-	m := codec.PropertyOptionsMap(&optsProp)
-	if m[7] != "Off" {
-		t.Errorf("idx=7 -> %q want Off", m[7])
-	}
-	if m[8] != "On" {
-		t.Errorf("idx=8 -> %q want On", m[8])
-	}
-	// Sanity: positional encoding would have produced idx=0,1.
-	if _, ok := m[0]; ok {
-		t.Errorf("positional idx=0 leaked into wire — encoder regressed to positional")
-	}
-}
-
 func TestBuildProperties_String_WithMaxLen(t *testing.T) {
 	mf := "maxLen=16"
 	p := &canonical.Parameter{
@@ -220,7 +176,7 @@ func TestBuildProperties_String_WithMaxLen(t *testing.T) {
 	if maxLen.PID != codec.PIDStringMaxLength {
 		t.Fatal("missing pid=6 string_max_length")
 	}
-	// pid 6 per spec §5.4: plen=6, body = u16 len + u16 pad.
+	// pid 6 per spec Â§5.4: plen=6, body = u16 len + u16 pad.
 	// After DecodeProperties, body is the 2-byte u16; pad is stripped.
 	if len(maxLen.Data) < 2 || binary.BigEndian.Uint16(maxLen.Data[0:2]) != 16 {
 		t.Errorf("maxLen data=%x want u16=16", maxLen.Data)
@@ -228,159 +184,6 @@ func TestBuildProperties_String_WithMaxLen(t *testing.T) {
 	if s := codec.PropertyString(&val); s != "Input-A" {
 		t.Errorf("string value=%q want Input-A", s)
 	}
-}
-
-// TestBuildProperties_RequiredConstraints verifies pids 9/10/11
-// (default_value, min_value, max_value) are always present on Number,
-// Enum, and Preset replies per spec §"Property fields" matrix
-// (Y on those rows). Encoder must fall back to type-derived defaults
-// when canonical lacks Default/Min/Max.
-func TestBuildProperties_RequiredConstraints(t *testing.T) {
-	t.Run("Number_no_canonical_constraints_falls_back_to_type_defaults", func(t *testing.T) {
-		// u8 number with no Default/Min/Max set on canonical.
-		p := &canonical.Parameter{
-			Header: canonical.Header{Number: 5, Identifier: "Foo",
-				Access: canonical.AccessReadWrite},
-			Type: canonical.ParamInteger, Value: int64(0),
-		}
-		e := &entry{
-			objID: 5, label: p.Identifier, access: 0x03,
-			objType: codec.ObjTypeNumber, numType: codec.NumTypeU8, param: p,
-		}
-		got := buildAndDecode(t, e)
-		bm := pidMap(got)
-		// pid 9 default = 0
-		if _, _, _, err := codec.DecodeNumericValue(codec.NumTypeU8, bm[codec.PIDDefaultValue].Data); err != nil {
-			t.Errorf("pid 9 default decode: %v", err)
-		}
-		// pid 10 min = u8 type-min = 0
-		_, mn, _, err := codec.DecodeNumericValue(codec.NumTypeU8, bm[codec.PIDMinValue].Data)
-		if err != nil || mn != 0 {
-			t.Errorf("pid 10 min=%d want 0 (u8 type-min), err=%v", mn, err)
-		}
-		// pid 11 max = u8 type-max = 255
-		_, mx, _, err := codec.DecodeNumericValue(codec.NumTypeU8, bm[codec.PIDMaxValue].Data)
-		if err != nil || mx != 255 {
-			t.Errorf("pid 11 max=%d want 255 (u8 type-max), err=%v", mx, err)
-		}
-	})
-
-	t.Run("Number_s16_type_min_max", func(t *testing.T) {
-		p := &canonical.Parameter{
-			Header: canonical.Header{Number: 5, Identifier: "Bar",
-				Access: canonical.AccessReadWrite},
-			Type: canonical.ParamInteger, Value: int64(0),
-		}
-		e := &entry{
-			objID: 5, label: p.Identifier, access: 0x03,
-			objType: codec.ObjTypeNumber, numType: codec.NumTypeS16, param: p,
-		}
-		got := buildAndDecode(t, e)
-		bm := pidMap(got)
-		mn, _, _, _ := codec.DecodeNumericValue(codec.NumTypeS16, bm[codec.PIDMinValue].Data)
-		if mn != -32768 {
-			t.Errorf("s16 type-min=%d want -32768", mn)
-		}
-		mx, _, _, _ := codec.DecodeNumericValue(codec.NumTypeS16, bm[codec.PIDMaxValue].Data)
-		if mx != 32767 {
-			t.Errorf("s16 type-max=%d want 32767", mx)
-		}
-	})
-
-	t.Run("Enum_uses_EnumMap_bounds", func(t *testing.T) {
-		// EnumMap with non-contiguous indices; pid 10 = 5, pid 11 = 99.
-		p := &canonical.Parameter{
-			Header: canonical.Header{Number: 6, Identifier: "Mode",
-				Access: canonical.AccessReadWrite},
-			Type:    canonical.ParamEnum, Value: int64(5),
-			EnumMap: []canonical.EnumEntry{{Key: "A", Value: 5}, {Key: "B", Value: 42}, {Key: "C", Value: 99}},
-		}
-		e := &entry{
-			objID: 6, label: p.Identifier, access: 0x03,
-			objType: codec.ObjTypeEnum, numType: codec.NumTypeU32, param: p,
-		}
-		got := buildAndDecode(t, e)
-		bm := pidMap(got)
-		// pid 9 default (no canonical Default → first EnumMap.Value = 5)
-		_, def, _, _ := codec.DecodeNumericValue(codec.NumTypePreset, bm[codec.PIDDefaultValue].Data)
-		if def != 5 {
-			t.Errorf("enum default=%d want 5 (first EnumMap.Value)", def)
-		}
-		_, mn, _, _ := codec.DecodeNumericValue(codec.NumTypePreset, bm[codec.PIDMinValue].Data)
-		if mn != 5 {
-			t.Errorf("enum min=%d want 5", mn)
-		}
-		_, mx, _, _ := codec.DecodeNumericValue(codec.NumTypePreset, bm[codec.PIDMaxValue].Data)
-		if mx != 99 {
-			t.Errorf("enum max=%d want 99", mx)
-		}
-	})
-
-	t.Run("Preset_emits_pid_9_10_11_per_depth", func(t *testing.T) {
-		p := &canonical.Parameter{
-			Header: canonical.Header{Number: 9, Identifier: "Slot",
-				Access: canonical.AccessReadWrite},
-			Type: canonical.ParamInteger, Value: int64(0),
-		}
-		e := &entry{
-			objID: 9, label: p.Identifier, access: 0x03,
-			objType: codec.ObjTypePreset, numType: codec.NumTypeU8,
-			presetDepth: 3, param: p,
-		}
-		got := buildAndDecode(t, e)
-		var n9, n10, n11 int
-		for _, pr := range got {
-			switch pr.PID {
-			case codec.PIDDefaultValue:
-				n9++
-			case codec.PIDMinValue:
-				n10++
-			case codec.PIDMaxValue:
-				n11++
-			}
-		}
-		if n9 != 3 || n10 != 3 || n11 != 3 {
-			t.Errorf("preset depth=3 expected pid 9/10/11 each 3 times; got 9=%d 10=%d 11=%d", n9, n10, n11)
-		}
-	})
-
-	t.Run("Number_with_canonical_constraints_keeps_canonical_values", func(t *testing.T) {
-		p := &canonical.Parameter{
-			Header: canonical.Header{Number: 5, Identifier: "Vol",
-				Access: canonical.AccessReadWrite},
-			Type:    canonical.ParamInteger, Value: int64(-3),
-			Default: int64(-5), Minimum: int64(-60), Maximum: int64(12),
-		}
-		e := &entry{
-			objID: 5, label: p.Identifier, access: 0x03,
-			objType: codec.ObjTypeNumber, numType: codec.NumTypeS32, param: p,
-		}
-		got := buildAndDecode(t, e)
-		bm := pidMap(got)
-		def, _, _, _ := codec.DecodeNumericValue(codec.NumTypeS32, bm[codec.PIDDefaultValue].Data)
-		if def != -5 {
-			t.Errorf("default=%d want -5 (canonical)", def)
-		}
-		mn, _, _, _ := codec.DecodeNumericValue(codec.NumTypeS32, bm[codec.PIDMinValue].Data)
-		if mn != -60 {
-			t.Errorf("min=%d want -60 (canonical)", mn)
-		}
-		mx, _, _, _ := codec.DecodeNumericValue(codec.NumTypeS32, bm[codec.PIDMaxValue].Data)
-		if mx != 12 {
-			t.Errorf("max=%d want 12 (canonical)", mx)
-		}
-	})
-}
-
-// pidMap collects properties keyed by pid for assertion ergonomics.
-// Last write wins for repeated pids (callers needing repetition counts
-// iterate the props slice directly).
-func pidMap(props []codec.Property) map[uint8]codec.Property {
-	out := make(map[uint8]codec.Property, len(props))
-	for _, p := range props {
-		out[p.PID] = p
-	}
-	return out
 }
 
 func TestBuildProperties_IPv4(t *testing.T) {

--- a/internal/acp2/provider/encoder_test.go
+++ b/internal/acp2/provider/encoder_test.go
@@ -138,6 +138,63 @@ func TestBuildProperties_Enum(t *testing.T) {
 	}
 }
 
+// TestBuildProperties_Enum_NonPositionalIdx verifies pid=15 (options)
+// uses the EnumMap.Value as the wire idx, not positional 0..N-1.
+// Real Axon firmware assigns sparse idx (e.g. 7="Off", 8="On"); pid=8
+// (value) and pid=9 (default) reference those wire idx values, so the
+// option records MUST carry them. Records are variable-length per
+// real-device convention (deviation from spec §5.4 row 15 fixed
+// 72-byte stride); see compliance event
+// `OptionsVariableLengthPerDeviceConvention`. Wire shape verified
+// against real-Neuron raw.an2.jsonl 2026-05-06:
+//
+//	`00000007 4f666600`        idx=7 "Off"  (8 bytes)
+//	`00000008 4f6e0000`        idx=8 "On"   (8 bytes — name "On"\0 + 1 pad)
+func TestBuildProperties_Enum_NonPositionalIdx(t *testing.T) {
+	p := &canonical.Parameter{
+		Header: canonical.Header{
+			Number: 6, Identifier: "Mute", Access: canonical.AccessReadWrite,
+		},
+		Type:  canonical.ParamEnum,
+		Value: int64(8), Default: int64(7),
+		EnumMap: []canonical.EnumEntry{
+			{Key: "Off", Value: 7},
+			{Key: "On", Value: 8},
+		},
+	}
+	e := &entry{
+		objID: 6, label: p.Identifier, access: 0x03,
+		objType: codec.ObjTypeEnum, numType: codec.NumTypeU32,
+		param: p,
+	}
+	got := buildAndDecode(t, e)
+	var optsProp codec.Property
+	for _, pr := range got {
+		if pr.PID == codec.PIDOptions {
+			optsProp = pr
+		}
+	}
+	if optsProp.PID != codec.PIDOptions {
+		t.Fatal("missing pid=15 options")
+	}
+	// Variable-length per option: each "Off"/"On" record is
+	// 4 (idx) + 3/2 (name) + 1 (NUL) + pad-to-4 = 8 bytes.
+	if got, want := len(optsProp.Data), 16; got != want {
+		t.Errorf("options body len=%d want %d (variable-length)", got, want)
+	}
+	m := codec.PropertyOptionsMap(&optsProp)
+	if m[7] != "Off" {
+		t.Errorf("idx=7 -> %q want Off", m[7])
+	}
+	if m[8] != "On" {
+		t.Errorf("idx=8 -> %q want On", m[8])
+	}
+	// Sanity: positional encoding would have produced idx=0,1.
+	if _, ok := m[0]; ok {
+		t.Errorf("positional idx=0 leaked into wire — encoder regressed to positional")
+	}
+}
+
 func TestBuildProperties_String_WithMaxLen(t *testing.T) {
 	mf := "maxLen=16"
 	p := &canonical.Parameter{

--- a/internal/acp2/provider/encoder_test.go
+++ b/internal/acp2/provider/encoder_test.go
@@ -173,6 +173,159 @@ func TestBuildProperties_String_WithMaxLen(t *testing.T) {
 	}
 }
 
+// TestBuildProperties_RequiredConstraints verifies pids 9/10/11
+// (default_value, min_value, max_value) are always present on Number,
+// Enum, and Preset replies per spec §"Property fields" matrix
+// (Y on those rows). Encoder must fall back to type-derived defaults
+// when canonical lacks Default/Min/Max.
+func TestBuildProperties_RequiredConstraints(t *testing.T) {
+	t.Run("Number_no_canonical_constraints_falls_back_to_type_defaults", func(t *testing.T) {
+		// u8 number with no Default/Min/Max set on canonical.
+		p := &canonical.Parameter{
+			Header: canonical.Header{Number: 5, Identifier: "Foo",
+				Access: canonical.AccessReadWrite},
+			Type: canonical.ParamInteger, Value: int64(0),
+		}
+		e := &entry{
+			objID: 5, label: p.Identifier, access: 0x03,
+			objType: codec.ObjTypeNumber, numType: codec.NumTypeU8, param: p,
+		}
+		got := buildAndDecode(t, e)
+		bm := pidMap(got)
+		// pid 9 default = 0
+		if _, _, _, err := codec.DecodeNumericValue(codec.NumTypeU8, bm[codec.PIDDefaultValue].Data); err != nil {
+			t.Errorf("pid 9 default decode: %v", err)
+		}
+		// pid 10 min = u8 type-min = 0
+		_, mn, _, err := codec.DecodeNumericValue(codec.NumTypeU8, bm[codec.PIDMinValue].Data)
+		if err != nil || mn != 0 {
+			t.Errorf("pid 10 min=%d want 0 (u8 type-min), err=%v", mn, err)
+		}
+		// pid 11 max = u8 type-max = 255
+		_, mx, _, err := codec.DecodeNumericValue(codec.NumTypeU8, bm[codec.PIDMaxValue].Data)
+		if err != nil || mx != 255 {
+			t.Errorf("pid 11 max=%d want 255 (u8 type-max), err=%v", mx, err)
+		}
+	})
+
+	t.Run("Number_s16_type_min_max", func(t *testing.T) {
+		p := &canonical.Parameter{
+			Header: canonical.Header{Number: 5, Identifier: "Bar",
+				Access: canonical.AccessReadWrite},
+			Type: canonical.ParamInteger, Value: int64(0),
+		}
+		e := &entry{
+			objID: 5, label: p.Identifier, access: 0x03,
+			objType: codec.ObjTypeNumber, numType: codec.NumTypeS16, param: p,
+		}
+		got := buildAndDecode(t, e)
+		bm := pidMap(got)
+		mn, _, _, _ := codec.DecodeNumericValue(codec.NumTypeS16, bm[codec.PIDMinValue].Data)
+		if mn != -32768 {
+			t.Errorf("s16 type-min=%d want -32768", mn)
+		}
+		mx, _, _, _ := codec.DecodeNumericValue(codec.NumTypeS16, bm[codec.PIDMaxValue].Data)
+		if mx != 32767 {
+			t.Errorf("s16 type-max=%d want 32767", mx)
+		}
+	})
+
+	t.Run("Enum_uses_EnumMap_bounds", func(t *testing.T) {
+		// EnumMap with non-contiguous indices; pid 10 = 5, pid 11 = 99.
+		p := &canonical.Parameter{
+			Header: canonical.Header{Number: 6, Identifier: "Mode",
+				Access: canonical.AccessReadWrite},
+			Type:    canonical.ParamEnum, Value: int64(5),
+			EnumMap: []canonical.EnumEntry{{Key: "A", Value: 5}, {Key: "B", Value: 42}, {Key: "C", Value: 99}},
+		}
+		e := &entry{
+			objID: 6, label: p.Identifier, access: 0x03,
+			objType: codec.ObjTypeEnum, numType: codec.NumTypeU32, param: p,
+		}
+		got := buildAndDecode(t, e)
+		bm := pidMap(got)
+		// pid 9 default (no canonical Default → first EnumMap.Value = 5)
+		_, def, _, _ := codec.DecodeNumericValue(codec.NumTypePreset, bm[codec.PIDDefaultValue].Data)
+		if def != 5 {
+			t.Errorf("enum default=%d want 5 (first EnumMap.Value)", def)
+		}
+		_, mn, _, _ := codec.DecodeNumericValue(codec.NumTypePreset, bm[codec.PIDMinValue].Data)
+		if mn != 5 {
+			t.Errorf("enum min=%d want 5", mn)
+		}
+		_, mx, _, _ := codec.DecodeNumericValue(codec.NumTypePreset, bm[codec.PIDMaxValue].Data)
+		if mx != 99 {
+			t.Errorf("enum max=%d want 99", mx)
+		}
+	})
+
+	t.Run("Preset_emits_pid_9_10_11_per_depth", func(t *testing.T) {
+		p := &canonical.Parameter{
+			Header: canonical.Header{Number: 9, Identifier: "Slot",
+				Access: canonical.AccessReadWrite},
+			Type: canonical.ParamInteger, Value: int64(0),
+		}
+		e := &entry{
+			objID: 9, label: p.Identifier, access: 0x03,
+			objType: codec.ObjTypePreset, numType: codec.NumTypeU8,
+			presetDepth: 3, param: p,
+		}
+		got := buildAndDecode(t, e)
+		var n9, n10, n11 int
+		for _, pr := range got {
+			switch pr.PID {
+			case codec.PIDDefaultValue:
+				n9++
+			case codec.PIDMinValue:
+				n10++
+			case codec.PIDMaxValue:
+				n11++
+			}
+		}
+		if n9 != 3 || n10 != 3 || n11 != 3 {
+			t.Errorf("preset depth=3 expected pid 9/10/11 each 3 times; got 9=%d 10=%d 11=%d", n9, n10, n11)
+		}
+	})
+
+	t.Run("Number_with_canonical_constraints_keeps_canonical_values", func(t *testing.T) {
+		p := &canonical.Parameter{
+			Header: canonical.Header{Number: 5, Identifier: "Vol",
+				Access: canonical.AccessReadWrite},
+			Type:    canonical.ParamInteger, Value: int64(-3),
+			Default: int64(-5), Minimum: int64(-60), Maximum: int64(12),
+		}
+		e := &entry{
+			objID: 5, label: p.Identifier, access: 0x03,
+			objType: codec.ObjTypeNumber, numType: codec.NumTypeS32, param: p,
+		}
+		got := buildAndDecode(t, e)
+		bm := pidMap(got)
+		def, _, _, _ := codec.DecodeNumericValue(codec.NumTypeS32, bm[codec.PIDDefaultValue].Data)
+		if def != -5 {
+			t.Errorf("default=%d want -5 (canonical)", def)
+		}
+		mn, _, _, _ := codec.DecodeNumericValue(codec.NumTypeS32, bm[codec.PIDMinValue].Data)
+		if mn != -60 {
+			t.Errorf("min=%d want -60 (canonical)", mn)
+		}
+		mx, _, _, _ := codec.DecodeNumericValue(codec.NumTypeS32, bm[codec.PIDMaxValue].Data)
+		if mx != 12 {
+			t.Errorf("max=%d want 12 (canonical)", mx)
+		}
+	})
+}
+
+// pidMap collects properties keyed by pid for assertion ergonomics.
+// Last write wins for repeated pids (callers needing repetition counts
+// iterate the props slice directly).
+func pidMap(props []codec.Property) map[uint8]codec.Property {
+	out := make(map[uint8]codec.Property, len(props))
+	for _, p := range props {
+		out[p.PID] = p
+	}
+	return out
+}
+
 func TestBuildProperties_IPv4(t *testing.T) {
 	ipf := "ipv4"
 	p := &canonical.Parameter{

--- a/internal/acp2/provider/encoder_test.go
+++ b/internal/acp2/provider/encoder_test.go
@@ -30,21 +30,22 @@ func buildAndDecode(t *testing.T, e *entry) []codec.Property {
 
 func TestBuildProperties_Node(t *testing.T) {
 	n := &canonical.Node{
-		Header: canonical.Header{
-			Number: 1, Identifier: "ROOT_NODE_V2", Access: canonical.AccessRead,
-		},
+		Header: canonical.Header{Number: 1, Identifier: "ROOT_NODE_V2"},
 	}
 	e := &entry{
 		objID: 1, label: n.Identifier,
-		access:   0x01,
+		access:   0,
 		objType:  codec.ObjTypeNode,
 		children: []uint32{2, 3, 4},
 		node:     n,
 	}
 	got := buildAndDecode(t, e)
 	want := map[uint8]bool{codec.PIDObjectType: true, codec.PIDLabel: true,
-		codec.PIDAccess: true, codec.PIDChildren: true}
+		codec.PIDChildren: true}
 	for _, p := range got {
+		if p.PID == codec.PIDAccess {
+			t.Errorf("Node reply must omit pid=3 access (real Neuron wire); got plen=%d data=0x%02x", p.PLen, p.VType)
+		}
 		delete(want, p.PID)
 	}
 	if len(want) > 0 {

--- a/internal/acp2/provider/handlers.go
+++ b/internal/acp2/provider/handlers.go
@@ -8,12 +8,15 @@ import (
 
 // Version constants advertised by this provider.
 //
-// AN2 v1.0 matches what real Axon firmware emits today. ACP2 v1 is the
-// only ACP2 major in the wild; consumers use it to gate feature flags.
+// an2Version is the AN2 protocol version per spec §3.3.1: a single
+// u16 BE field on the wire ("ver(u16)" in the reply table on p.7-8).
+// Real EVS Neuron firmware (5.3.5 + 6.7.4) emits 0x00 0x01 = 1.
+//
+// acp2Version is the ACP2 protocol version, carried in the ACP2
+// message header's pid byte of a get_version reply (single u8).
 const (
-	an2VersionMajor uint8 = 1
-	an2VersionMinor uint8 = 0
-	acp2Version     uint8 = 1
+	an2Version  uint16 = 1
+	acp2Version uint8  = 1
 )
 
 // Slot status codes emitted by GetSlotInfo. Values mirror the consumer's
@@ -44,12 +47,12 @@ func (s *session) dispatch(f *codec.AN2Frame) {
 }
 
 // handleAN2Internal implements the proto=0 handshake a consumer runs
-// before sending any ACP2 traffic:
+// before sending any ACP2 traffic. Reply byte layouts per spec:
 //
-//	1. GetVersion           (funcID=0) -> [0, major, minor]
-//	2. GetDeviceInfo        (funcID=1) -> [1, slot_count]
-//	3. GetSlotInfo(slot)    (funcID=2) -> [2, status, num_protos, protos…]
-//	4. EnableProtocolEvents (funcID=3) -> [3, 0]  (ack)
+//	1. GetVersion           §3.3.1 -> [0, ver_hi, ver_lo]      ver=u16BE
+//	2. GetDeviceInfo        §3.3.2 -> [1, slot_count]          dlen=2
+//	3. GetSlotInfo(slot)    §3.3.3 -> [2, status, num, protos] dlen=3+num
+//	4. EnableProtocolEvents §3.3.4 -> [3]                      dlen=1
 //
 // All replies mirror the request's AN2 mtid + slot per spec §3.3 so
 // the consumer's waiter table correlates them cleanly.
@@ -69,15 +72,28 @@ func (s *session) handleAN2Internal(f *codec.AN2Frame) {
 	var body []byte
 	switch funcID {
 	case codec.AN2FuncGetVersion:
-		body = []byte{funcID, an2VersionMajor, an2VersionMinor}
+		// Spec §3.3.1 (an2_protocol.pdf p.7-8): reply payload is
+		// func(u8) + ver(u16), dlen=3. ver is a single u16 BE field,
+		// NOT a (major u8, minor u8) split. Real EVS Neuron emits
+		// 0x00 0x01 (= ver 1); a spec-strict consumer reading our
+		// previous [major=1, minor=0] bytes interpreted ver=0x0100=256.
+		body = []byte{funcID, byte(an2Version >> 8), byte(an2Version)}
 	case codec.AN2FuncGetDeviceInfo:
-		// AN2 spec §1.2.2 + §3.3.2 example: "an RC could return 5(=4+1),
-		// 9(=8+1), 19(=18+1), since slot0 is also counted." The reply value
-		// is the TOTAL slot count (cards + RC), not the max slot number.
+		// Spec §1.2.2 + §3.3.2 (p.8): info = total slot count incl
+		// slot 0. The example "5(=4+1), 9(=8+1), 19(=18+1), since
+		// slot0 is also counted" means the count is (max present
+		// slot index) + 1, not just the cardinality of present slots
+		// (which would skip empty intermediates). Real Neuron with
+		// {RC=slot0, card=slot1} reports info=2.
 		s.srv.tree.mu.RLock()
-		count := uint8(len(s.srv.tree.perSlot))
+		var maxSlot uint8
+		for sl := range s.srv.tree.perSlot {
+			if sl > maxSlot {
+				maxSlot = sl
+			}
+		}
 		s.srv.tree.mu.RUnlock()
-		body = []byte{funcID, count}
+		body = []byte{funcID, maxSlot + 1}
 	case codec.AN2FuncGetSlotInfo:
 		// AN2 spec §3.3.3: request is dlen=1 (just funcID). The requested
 		// slot is carried in the AN2 frame header's Slot field, NOT in the
@@ -103,7 +119,11 @@ func (s *session) handleAN2Internal(f *codec.AN2Frame) {
 			slog.Int("count", count),
 			slog.Any("enabled_protos", enabled),
 		)
-		body = []byte{funcID, 0} // ack
+		// Spec §3.3.4 (an2_protocol.pdf p.10): reply payload is just
+		// func(u8), dlen=1. Real EVS Neuron emits [3]; Cerebrum drops
+		// the session at the 5 s timeout if the reply carries any
+		// trailing bytes.
+		body = []byte{funcID}
 	default:
 		s.srv.logger.Debug("an2 internal: unknown funcID",
 			slog.Int("funcID", int(funcID)),
@@ -392,8 +412,17 @@ func errorACP2(req *codec.ACP2Message, stat codec.ACP2ErrStatus) *codec.ACP2Mess
 
 // slotInfo answers GetSlotInfo for a given slot per AN2 spec §3.3.3.
 // A slot is "present" iff we hold canonical ACP2 data for it in the
-// provider's tree; every other slot (0-254) is "empty". Present slots
-// advertise both AN2 internal and ACP2; empty slots advertise nothing.
+// provider's tree; every other slot (0-254) is "empty".
+//
+// The reply's protos array enumerates *payload* protocols supported by
+// the slot (§3.2.1 codes 1=ACP1, 2=ACP2, 3=ACMP). proto=0 is reserved
+// for AN2-internal signalling per §1.2.3 ("Proto 0 is reserved as
+// 'signalling' protocol for internal (Axonnet2) use") and is never
+// listed here. Real EVS Neuron slot 0 advertises [2,3,4]; slot 1
+// advertises [2,3] — never includes 0.
+//
+// Present ACP2 slots advertise [ACP2] only; ACMP and vendor-internal
+// protos (like Neuron's proto=4) are not implemented here.
 //
 // The slot number of the rack-controller endpoint is fixture-defined
 // (typically slot 0 on real Synapse frames, but any number is valid per
@@ -403,7 +432,7 @@ func (s *server) slotInfo(slot uint8) (status uint8, protos []uint8) {
 	s.tree.mu.RLock()
 	defer s.tree.mu.RUnlock()
 	if _, ok := s.tree.perSlot[slot]; ok {
-		return slotStatusPresent, []uint8{uint8(codec.AN2ProtoInternal), uint8(codec.AN2ProtoACP2)}
+		return slotStatusPresent, []uint8{uint8(codec.AN2ProtoACP2)}
 	}
 	return slotStatusEmpty, nil
 }

--- a/internal/acp2/provider/handlers.go
+++ b/internal/acp2/provider/handlers.go
@@ -15,8 +15,14 @@ import (
 // acp2Version is the ACP2 protocol version, carried in the ACP2
 // message header's pid byte of a get_version reply (single u8).
 const (
-	an2Version  uint16 = 1
-	acp2Version uint8  = 1
+	// Version constants matched against real Axon Neuron firmware
+	// (10.41.40.4) GetVersion replies on 2026-05-09:
+	//   AN2 GetVersion reply payload:  00 00 01  -> major=0 minor=1
+	//   ACP2 GetVersion reply byte 3:  02         -> v2
+	// Spec §1.4 explicitly lists v1 as "Made v1; unsupported."
+	an2VersionMajor uint8 = 0
+	an2VersionMinor uint8 = 1
+	acp2Version     uint8 = 2
 )
 
 // Slot status codes emitted by GetSlotInfo. Values mirror the consumer's
@@ -73,11 +79,9 @@ func (s *session) handleAN2Internal(f *codec.AN2Frame) {
 	switch funcID {
 	case codec.AN2FuncGetVersion:
 		// Spec §3.3.1 (an2_protocol.pdf p.7-8): reply payload is
-		// func(u8) + ver(u16), dlen=3. ver is a single u16 BE field,
-		// NOT a (major u8, minor u8) split. Real EVS Neuron emits
-		// 0x00 0x01 (= ver 1); a spec-strict consumer reading our
-		// previous [major=1, minor=0] bytes interpreted ver=0x0100=256.
-		body = []byte{funcID, byte(an2Version >> 8), byte(an2Version)}
+		// func(u8) + ver(u16), dlen=3. Real EVS Neuron 10.41.40.4
+		// emits 00 00 01 -> major=0 minor=1 (verified 2026-05-09).
+		body = []byte{funcID, an2VersionMajor, an2VersionMinor}
 	case codec.AN2FuncGetDeviceInfo:
 		// Spec §1.2.2 + §3.3.2 (p.8): info = total slot count incl
 		// slot 0. The example "5(=4+1), 9(=8+1), 19(=18+1), since

--- a/internal/acp2/provider/handlers.go
+++ b/internal/acp2/provider/handlers.go
@@ -394,19 +394,31 @@ func (s *session) replyACP2(slot uint8, msg *codec.ACP2Message) {
 	}
 }
 
-// errorACP2 builds an ACP2 error reply per spec §"Error Codes". The
-// func field of an error message holds the stat byte (not a function
-// ID); codec.go picks this back up in ToACP2Error.
+// errorACP2 builds an ACP2 error reply per spec §"Error". The error
+// message is exactly the 4-byte ACP2 header — NO body.
+//
+//	| Offset | Field | Width | Notes                                 |
+//	|--------|-------|-------|---------------------------------------|
+//	| 0      | type  | u8    | 3 = error                             |
+//	| 1      | mtid  | u8    | matches the request mtid              |
+//	| 2      | stat  | u8    | error status (§3.1: 0..5)             |
+//	| 3      | pid   | u8    | 0                                     |
+//
+// The func slot carries the stat byte for error messages; the codec
+// picks this back up in ToACP2Error. ObjID is preserved on the
+// in-memory message struct purely for caller-side diagnostics — it
+// is NOT serialised onto the wire.
+//
+// Spec reference: acp2_protocol.docx §"Error" (line 1207-1250) — the
+// error table lists only type/mtid/stat/pid; no body row.
 func errorACP2(req *codec.ACP2Message, stat codec.ACP2ErrStatus) *codec.ACP2Message {
-	body := make([]byte, 4)
-	binaryBigEndianU32(body, req.ObjID)
 	return &codec.ACP2Message{
 		Type:  codec.ACP2TypeError,
 		MTID:  req.MTID,
 		Func:  codec.ACP2Func(stat),
 		PID:   0,
 		ObjID: req.ObjID,
-		Body:  body,
+		Body:  nil,
 	}
 }
 

--- a/internal/acp2/provider/handlers_test.go
+++ b/internal/acp2/provider/handlers_test.go
@@ -85,6 +85,9 @@ func roundtrip(t *testing.T, sess *session, peer net.Conn, req *codec.AN2Frame) 
 	return nil
 }
 
+// TestAN2Handshake_GetVersion pins the spec §3.3.1 reply shape:
+// payload = func(u8) + ver(u16 BE), dlen=3. Wire bytes for AN2 v1
+// are [0x00, 0x00, 0x01], matching real EVS Neuron firmware.
 func TestAN2Handshake_GetVersion(t *testing.T) {
 	sess, peer := newTestSession(t)
 	defer func() { _ = sess.conn.Close() }()
@@ -101,16 +104,15 @@ func TestAN2Handshake_GetVersion(t *testing.T) {
 	if rep.Proto != codec.AN2ProtoInternal || rep.Type != codec.AN2TypeReply || rep.MTID != 1 {
 		t.Fatalf("reply frame wrong: %+v", rep)
 	}
-	// Payload: [funcID=0, major, minor]
-	if len(rep.Payload) != 3 ||
-		rep.Payload[0] != codec.AN2FuncGetVersion ||
-		rep.Payload[1] != an2VersionMajor ||
-		rep.Payload[2] != an2VersionMinor {
-		t.Fatalf("GetVersion payload=%v want [0, %d, %d]",
-			rep.Payload, an2VersionMajor, an2VersionMinor)
+	want := []byte{codec.AN2FuncGetVersion, 0x00, 0x01}
+	if !bytesEq(rep.Payload, want) {
+		t.Fatalf("GetVersion payload=%x want %x", rep.Payload, want)
 	}
 }
 
+// TestAN2Handshake_GetDeviceInfo pins §3.3.2: info = total slot count
+// including slot 0. With slots {0, 1} present, max+1 = 2 — matches
+// real EVS Neuron's "{RC=slot0, card=slot1} → info=2" wire shape.
 func TestAN2Handshake_GetDeviceInfo(t *testing.T) {
 	sess, peer := newTestSession(t)
 	defer func() { _ = sess.conn.Close() }()
@@ -124,19 +126,49 @@ func TestAN2Handshake_GetDeviceInfo(t *testing.T) {
 		Payload: []byte{codec.AN2FuncGetDeviceInfo},
 	}
 	rep := roundtrip(t, sess, peer, req)
-	if len(rep.Payload) != 2 ||
-		rep.Payload[0] != codec.AN2FuncGetDeviceInfo ||
-		rep.Payload[1] != 2 {
-		t.Fatalf("GetDeviceInfo payload=%v want [1, 2]", rep.Payload)
+	want := []byte{codec.AN2FuncGetDeviceInfo, 2}
+	if !bytesEq(rep.Payload, want) {
+		t.Fatalf("GetDeviceInfo payload=%x want %x", rep.Payload, want)
 	}
 }
 
+// TestAN2Handshake_GetDeviceInfo_SparseSlots exercises fix #3 of the
+// §3.3.2 audit: when the present slot map has gaps (e.g. {0, 5}), the
+// reply count must be max-slot+1 = 6, not the cardinality of the map
+// (which would be 2 and skip empty intermediates 1-4).
+func TestAN2Handshake_GetDeviceInfo_SparseSlots(t *testing.T) {
+	sess, peer := newTestSession(t)
+	defer func() { _ = sess.conn.Close() }()
+	defer func() { _ = peer.Close() }()
+
+	// Replace the default {0, 1} layout with a sparse {0, 5} map.
+	delete(sess.srv.tree.perSlot, 1)
+	sess.srv.tree.perSlot[5] = map[uint32]*entry{}
+
+	req := &codec.AN2Frame{
+		Proto:   codec.AN2ProtoInternal,
+		Slot:    0,
+		MTID:    7,
+		Type:    codec.AN2TypeRequest,
+		Payload: []byte{codec.AN2FuncGetDeviceInfo},
+	}
+	rep := roundtrip(t, sess, peer, req)
+	want := []byte{codec.AN2FuncGetDeviceInfo, 6}
+	if !bytesEq(rep.Payload, want) {
+		t.Fatalf("sparse GetDeviceInfo payload=%x want %x (max slot 5 + 1)",
+			rep.Payload, want)
+	}
+}
+
+// TestAN2Handshake_GetSlotInfo pins §3.3.3 + §3.2.1: a present ACP2
+// slot's protos list is [ACP2] only. proto=0 (AN2 internal) is the
+// signalling layer per §1.2.3 and is never advertised as a payload
+// proto on the wire — real EVS Neuron slot 1 emits [2,3], never [0,…].
 func TestAN2Handshake_GetSlotInfo(t *testing.T) {
 	sess, peer := newTestSession(t)
 	defer func() { _ = sess.conn.Close() }()
 	defer func() { _ = peer.Close() }()
 
-	// Slot 0 (controller): status=present, protos=[AN2Internal]
 	req := &codec.AN2Frame{
 		Proto:   codec.AN2ProtoInternal,
 		Slot:    0,
@@ -145,9 +177,8 @@ func TestAN2Handshake_GetSlotInfo(t *testing.T) {
 		Payload: []byte{codec.AN2FuncGetSlotInfo},
 	}
 	rep := roundtrip(t, sess, peer, req)
-	// payload: [funcID=2, status=present, num_protos=2, AN2Internal, ACP2]
-	want := []byte{codec.AN2FuncGetSlotInfo, slotStatusPresent, 2,
-		uint8(codec.AN2ProtoInternal), uint8(codec.AN2ProtoACP2)}
+	want := []byte{codec.AN2FuncGetSlotInfo, slotStatusPresent, 1,
+		uint8(codec.AN2ProtoACP2)}
 	if !bytesEq(rep.Payload, want) {
 		t.Fatalf("slot 0 info=%x want %x", rep.Payload, want)
 	}
@@ -158,7 +189,6 @@ func TestAN2Handshake_GetSlotInfo_CardSlot(t *testing.T) {
 	defer func() { _ = sess.conn.Close() }()
 	defer func() { _ = peer.Close() }()
 
-	// Slot 1 (card): present, protos=[AN2Internal, ACP2]
 	req := &codec.AN2Frame{
 		Proto:   codec.AN2ProtoInternal,
 		Slot:    1,
@@ -167,8 +197,8 @@ func TestAN2Handshake_GetSlotInfo_CardSlot(t *testing.T) {
 		Payload: []byte{codec.AN2FuncGetSlotInfo},
 	}
 	rep := roundtrip(t, sess, peer, req)
-	want := []byte{codec.AN2FuncGetSlotInfo, slotStatusPresent, 2,
-		uint8(codec.AN2ProtoInternal), uint8(codec.AN2ProtoACP2)}
+	want := []byte{codec.AN2FuncGetSlotInfo, slotStatusPresent, 1,
+		uint8(codec.AN2ProtoACP2)}
 	if !bytesEq(rep.Payload, want) {
 		t.Fatalf("slot 1 info=%x want %x", rep.Payload, want)
 	}
@@ -194,6 +224,9 @@ func TestAN2Handshake_GetSlotInfo_OutOfRange(t *testing.T) {
 	}
 }
 
+// TestAN2Handshake_EnableProtocolEvents pins §3.3.4: reply payload is
+// the single func byte, dlen=1. Cerebrum drops the session at its 5 s
+// timeout if the reply carries any trailing bytes.
 func TestAN2Handshake_EnableProtocolEvents(t *testing.T) {
 	sess, peer := newTestSession(t)
 	defer func() { _ = sess.conn.Close() }()
@@ -208,7 +241,7 @@ func TestAN2Handshake_EnableProtocolEvents(t *testing.T) {
 		Payload: []byte{codec.AN2FuncEnableProtocolEvents, 1, uint8(codec.AN2ProtoACP2)},
 	}
 	rep := roundtrip(t, sess, peer, req)
-	want := []byte{codec.AN2FuncEnableProtocolEvents, 0}
+	want := []byte{codec.AN2FuncEnableProtocolEvents}
 	if !bytesEq(rep.Payload, want) {
 		t.Fatalf("enable payload=%x want %x", rep.Payload, want)
 	}

--- a/internal/acp2/provider/handlers_test.go
+++ b/internal/acp2/provider/handlers_test.go
@@ -250,6 +250,67 @@ func TestAN2Handshake_EnableProtocolEvents(t *testing.T) {
 	}
 }
 
+// TestACP2Error_NoBody verifies the error reply is exactly the 4-byte
+// ACP2 header per spec §"Error" (line 1207-1250 of acp2_protocol.docx).
+// The error table lists only type/mtid/stat/pid; no body row.
+//
+// Request:  ACP2 get_object for obj-id 999 (not in tree).
+// Expected reply (AN2 frame payload, total = 4 bytes):
+//
+//	| byte 0 | byte 1 | byte 2     | byte 3 |
+//	| type=3 | mtid=N | stat=1     | pid=0  |
+func TestACP2Error_NoBody(t *testing.T) {
+	sess, peer := newTestSession(t)
+	defer func() { _ = sess.conn.Close() }()
+	defer func() { _ = peer.Close() }()
+
+	// Build an ACP2 GetObject request for an obj-id that's not in the
+	// tree (slot 1 was initialised empty by newTestSession).
+	getObj := &codec.ACP2Message{
+		Type:  codec.ACP2TypeRequest,
+		MTID:  42,
+		Func:  codec.ACP2FuncGetObject,
+		PID:   0,
+		ObjID: 999,
+		Idx:   0,
+	}
+	body, err := codec.EncodeACP2Message(getObj)
+	if err != nil {
+		t.Fatalf("encode acp2 request: %v", err)
+	}
+	req := &codec.AN2Frame{
+		Proto:   codec.AN2ProtoACP2,
+		Slot:    1,
+		MTID:    0, // AN2 mtid for data frames
+		Type:    codec.AN2TypeData,
+		Payload: body,
+	}
+	rep := roundtrip(t, sess, peer, req)
+
+	if rep.Proto != codec.AN2ProtoACP2 {
+		t.Fatalf("reply proto=%v want ACP2", rep.Proto)
+	}
+	if rep.Type != codec.AN2TypeData {
+		t.Fatalf("reply AN2 type=%v want data(4)", rep.Type)
+	}
+	if len(rep.Payload) != 4 {
+		t.Fatalf("error reply payload len=%d want 4 (spec §Error: header only, no body); got %x",
+			len(rep.Payload), rep.Payload)
+	}
+	if rep.Payload[0] != byte(codec.ACP2TypeError) {
+		t.Errorf("byte 0 (type)=%d want %d (error)", rep.Payload[0], codec.ACP2TypeError)
+	}
+	if rep.Payload[1] != 42 {
+		t.Errorf("byte 1 (mtid)=%d want 42 (matches request)", rep.Payload[1])
+	}
+	if rep.Payload[2] != byte(codec.ErrInvalidObjID) {
+		t.Errorf("byte 2 (stat)=%d want %d (invalid_obj_id)", rep.Payload[2], codec.ErrInvalidObjID)
+	}
+	if rep.Payload[3] != 0 {
+		t.Errorf("byte 3 (pid)=%d want 0", rep.Payload[3])
+	}
+}
+
 func bytesEq(a, b []byte) bool {
 	if len(a) != len(b) {
 		return false

--- a/internal/acp2/provider/label_charset_test.go
+++ b/internal/acp2/provider/label_charset_test.go
@@ -1,0 +1,71 @@
+package acp2
+
+import "testing"
+
+// TestSanitizeLabel pins the spec invariant from acp2_protocol.docx
+// §"Versions" line 357: object labels MUST contain only characters
+// from `[A-Za-z0-9 \-]`. Any other character is replaced with `-`
+// before the label hits the wire (pid=2). The unmodified label stays
+// on the canonical element so other tooling can see the original.
+func TestSanitizeLabel(t *testing.T) {
+	cases := []struct {
+		name  string
+		in    string
+		out   string
+		dirty bool // whether the function should have changed the input
+	}{
+		// Compliant labels round-trip identity.
+		{"all-lower", "abcdef", "abcdef", false},
+		{"mixed-case-digits", "Card1234", "Card1234", false},
+		{"with-space", "User Label 1", "User Label 1", false},
+		{"with-dash", "Slot-A", "Slot-A", false},
+		{"compound", "PSU - NPU0500-B", "PSU - NPU0500-B", false},
+		{"channel-N", "CHANNEL 01", "CHANNEL 01", false},
+
+		// Real-Neuron deviations — spec violations sanitised.
+		{"underscore", "ROOT_NODE_V2", "ROOT-NODE-V2", true},
+		{"dot", "Sample.Rate", "Sample-Rate", true},
+		{"colon", "MAC:01:23", "MAC-01-23", true},
+		{"slash", "A/B", "A-B", true},
+		{"equal-sign", "Mode=Auto", "Mode-Auto", true},
+
+		// Non-ASCII gets stripped.
+		{"non-ascii", "Café", "Caf-", true},
+
+		// Edge cases.
+		{"empty", "", "obj", true},
+		{"all-invalid", "___", "obj", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := sanitizeLabel(c.in)
+			if got != c.out {
+				t.Errorf("sanitizeLabel(%q) = %q; want %q", c.in, got, c.out)
+			}
+		})
+	}
+}
+
+// TestIsSpecLabelByte locks the per-rune predicate against the spec
+// charset definition. Useful for catching accidental drift if the
+// helper grows additional accepted characters.
+func TestIsSpecLabelByte(t *testing.T) {
+	allowed := []rune{
+		'a', 'z', 'A', 'Z', '0', '9', ' ', '-',
+	}
+	disallowed := []rune{
+		'_', '.', '/', '\\', '=', ':', ';', ',', '@', '#', '$',
+		'(', ')', '[', ']', '{', '}', '<', '>',
+		'\n', '\t', 0x00, 0xC2, // non-ASCII byte boundary
+	}
+	for _, r := range allowed {
+		if !isSpecLabelByte(r) {
+			t.Errorf("isSpecLabelByte(%q) = false; want true (spec §Versions allows it)", r)
+		}
+	}
+	for _, r := range disallowed {
+		if isSpecLabelByte(r) {
+			t.Errorf("isSpecLabelByte(%q) = true; want false (spec §Versions forbids it)", r)
+		}
+	}
+}

--- a/internal/acp2/provider/preset_idx_test.go
+++ b/internal/acp2/provider/preset_idx_test.go
@@ -1,0 +1,134 @@
+package acp2
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"dhs/internal/acp2/codec"
+	"dhs/internal/export/canonical"
+)
+
+// TestPresetIdx_SpecExampleNonContiguous covers the spec example from
+// acp2_protocol.docx §"Preset depth" (line 2613-2632):
+//
+//	property pid 7: preset depth 2
+//	property pid data plen idx0 idx1
+//	u8 u8 u16 u32 u32
+//	7 0 12 100 200
+//
+// Encoder must emit the canonical idx values verbatim — not the
+// hardcoded contiguous 0..depth-1 fallback.
+func TestPresetIdx_SpecExampleNonContiguous(t *testing.T) {
+	fmtHint := "depth=2,idx=100|200"
+	p := &canonical.Parameter{
+		Header: canonical.Header{Number: 9, Identifier: "Slot",
+			Access: canonical.AccessReadWrite},
+		Type: canonical.ParamInteger, Value: int64(0),
+		Format: &fmtHint,
+	}
+	e := &entry{
+		objID: 9, label: p.Identifier, access: 0x03,
+		objType: codec.ObjTypePreset, numType: codec.NumTypeU8,
+		presetDepth:   2,
+		presetIdxList: presetIdxHint(p),
+		param:         p,
+	}
+	if len(e.presetIdxList) != 2 || e.presetIdxList[0] != 100 || e.presetIdxList[1] != 200 {
+		t.Fatalf("presetIdxHint returned %v; want [100, 200]", e.presetIdxList)
+	}
+
+	got := buildAndDecode(t, e)
+	var pd codec.Property
+	for _, pr := range got {
+		if pr.PID == codec.PIDPresetDepth {
+			pd = pr
+			break
+		}
+	}
+	if pd.PID != codec.PIDPresetDepth {
+		t.Fatal("reply missing pid=7 (preset_depth)")
+	}
+	if pd.PLen != 12 {
+		t.Errorf("pid=7 plen=%d want 12 (4 hdr + 2*4 idx)", pd.PLen)
+	}
+	if len(pd.Data) != 8 {
+		t.Fatalf("pid=7 body len=%d want 8 (2 u32 idx)", len(pd.Data))
+	}
+	got0 := binary.BigEndian.Uint32(pd.Data[0:4])
+	got1 := binary.BigEndian.Uint32(pd.Data[4:8])
+	if got0 != 100 || got1 != 200 {
+		t.Errorf("pid=7 idx values=[%d, %d]; want [100, 200] (spec docx line 2613-2632)", got0, got1)
+	}
+}
+
+// TestPresetIdx_FallbackContiguousWhenHintAbsent verifies the
+// historical contiguous 0..depth-1 fallback when the canonical
+// fixture omits the `idx=...` hint.
+func TestPresetIdx_FallbackContiguousWhenHintAbsent(t *testing.T) {
+	fmtHint := "depth=3"
+	p := &canonical.Parameter{
+		Header: canonical.Header{Number: 9, Identifier: "Slot",
+			Access: canonical.AccessReadWrite},
+		Type: canonical.ParamInteger, Value: int64(0),
+		Format: &fmtHint,
+	}
+	e := &entry{
+		objID: 9, label: p.Identifier, access: 0x03,
+		objType: codec.ObjTypePreset, numType: codec.NumTypeU8,
+		presetDepth:   3,
+		presetIdxList: presetIdxHint(p), // expected: nil
+		param:         p,
+	}
+	if e.presetIdxList != nil {
+		t.Errorf("presetIdxHint(%q)=%v; want nil (no idx= hint)", fmtHint, e.presetIdxList)
+	}
+	got := buildAndDecode(t, e)
+	var pd codec.Property
+	for _, pr := range got {
+		if pr.PID == codec.PIDPresetDepth {
+			pd = pr
+			break
+		}
+	}
+	for i := uint32(0); i < 3; i++ {
+		got := binary.BigEndian.Uint32(pd.Data[i*4 : i*4+4])
+		if got != i {
+			t.Errorf("idx[%d]=%d want %d (contiguous fallback)", i, got, i)
+		}
+	}
+}
+
+// TestPresetIdx_IgnoresMismatchedListLength asserts that a Format
+// hint specifying fewer idx values than depth declares falls back to
+// contiguous indices (defensive — protects against malformed fixtures).
+func TestPresetIdx_IgnoresMismatchedListLength(t *testing.T) {
+	fmtHint := "depth=4,idx=100|200" // length mismatch
+	p := &canonical.Parameter{
+		Header: canonical.Header{Number: 9, Identifier: "Slot",
+			Access: canonical.AccessReadWrite},
+		Type: canonical.ParamInteger, Value: int64(0),
+		Format: &fmtHint,
+	}
+	e := &entry{
+		objID: 9, label: p.Identifier, access: 0x03,
+		objType: codec.ObjTypePreset, numType: codec.NumTypeU8,
+		presetDepth:   4,
+		presetIdxList: presetIdxHint(p), // [100, 200] but depth=4
+		param:         p,
+	}
+	got := buildAndDecode(t, e)
+	var pd codec.Property
+	for _, pr := range got {
+		if pr.PID == codec.PIDPresetDepth {
+			pd = pr
+			break
+		}
+	}
+	// Mismatch → fallback to 0..3 (NOT [100, 200, 0, 0]).
+	for i := uint32(0); i < 4; i++ {
+		got := binary.BigEndian.Uint32(pd.Data[i*4 : i*4+4])
+		if got != i {
+			t.Errorf("idx[%d]=%d want %d (length mismatch should fall back)", i, got, i)
+		}
+	}
+}

--- a/internal/acp2/provider/session.go
+++ b/internal/acp2/provider/session.go
@@ -27,6 +27,15 @@ func newSession(srv *server, conn net.Conn) *session {
 
 // run reads AN2 frames until the connection closes. Every frame is
 // dispatched inline through handleFrame; fatal errors close the conn.
+//
+// Per spec acp2_protocol.docx line 313 ("Should handle single request
+// at a time") this loop is the single-request-at-a-time gate for one
+// session: ReadAN2Frame blocks, dispatch processes synchronously
+// (replyACP2 returns before we loop), then the next frame is read.
+// No per-request goroutines are spawned. Pipelined requests on the
+// same TCP connection queue in the kernel socket buffer and execute
+// in arrival order. See provider/session_serial_test.go for the
+// pinning test.
 func (s *session) run() {
 	defer func() { _ = s.conn.Close() }()
 

--- a/internal/acp2/provider/session_serial_test.go
+++ b/internal/acp2/provider/session_serial_test.go
@@ -1,0 +1,113 @@
+package acp2
+
+import (
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"dhs/internal/acp2/codec"
+)
+
+// TestSession_SerializesRequestsPerConnection pins the spec invariant
+// from acp2_protocol.docx line 313 — "Should handle single request at
+// a time" — for one TCP connection.
+//
+// We pipeline 64 ACP2 GetVersion requests on a real loopback TCP
+// session without waiting for replies between sends. The session
+// reader is a single goroutine that calls handleFrame inline before
+// returning to ReadAN2Frame; handlers are synchronous. Replies must
+// therefore arrive in send order.
+//
+// A real TCP socket (not net.Pipe) is required because net.Pipe is
+// synchronous — every write blocks until the peer reads. Pipelining
+// is the property under test.
+func TestSession_SerializesRequestsPerConnection(t *testing.T) {
+	srv := &server{
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		tree:     emptyTree(),
+		sessions: map[*session]struct{}{},
+	}
+	srv.tree.slotN = 1
+	srv.tree.perSlot[0] = map[uint32]*entry{}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	addr := listener.Addr().String()
+
+	// Accept one connection and run the session.
+	accepted := make(chan struct{})
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		sess := newSession(srv, conn)
+		close(accepted)
+		sess.run()
+	}()
+
+	client, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+	<-accepted
+
+	const N = 64
+
+	// Pipeline N GetVersion requests with mtid 1..N — write all
+	// before reading any.
+	go func() {
+		for i := 1; i <= N; i++ {
+			req := &codec.ACP2Message{
+				Type: codec.ACP2TypeRequest,
+				MTID: uint8(i),
+				Func: codec.ACP2FuncGetVersion,
+			}
+			payload, _ := codec.EncodeACP2Message(req)
+			frame := &codec.AN2Frame{
+				Proto:   codec.AN2ProtoACP2,
+				Slot:    0,
+				Type:    codec.AN2TypeData,
+				Payload: payload,
+			}
+			raw, _ := codec.EncodeAN2Frame(frame)
+			if _, err := client.Write(raw); err != nil {
+				t.Errorf("write mtid=%d: %v", i, err)
+				return
+			}
+		}
+	}()
+
+	// Read N replies and verify mtids are 1..N in order.
+	gotMTIDs := make([]uint8, 0, N)
+	for len(gotMTIDs) < N {
+		_ = client.SetReadDeadline(time.Now().Add(3 * time.Second))
+		rep, err := codec.ReadAN2Frame(client)
+		if err != nil {
+			t.Fatalf("read reply #%d: %v (got %d/%d, sequence so far: %v)",
+				len(gotMTIDs)+1, err, len(gotMTIDs), N, gotMTIDs)
+		}
+		if rep.Type != codec.AN2TypeData {
+			t.Fatalf("reply #%d: AN2 type=%v want data", len(gotMTIDs)+1, rep.Type)
+		}
+		if len(rep.Payload) < 4 {
+			t.Fatalf("reply #%d: payload too short (%d bytes)", len(gotMTIDs)+1, len(rep.Payload))
+		}
+		gotMTIDs = append(gotMTIDs, rep.Payload[1])
+	}
+
+	for i, got := range gotMTIDs {
+		want := uint8(i + 1)
+		if got != want {
+			t.Fatalf("reply #%d: mtid=%d want %d (replies arrived out of order — concurrent dispatch?). full sequence: %v",
+				i+1, got, want, gotMTIDs)
+		}
+	}
+}

--- a/internal/acp2/provider/set.go
+++ b/internal/acp2/provider/set.go
@@ -37,9 +37,9 @@ func (s *server) applySet(e *entry, in *codec.Property) (codec.Property, codec.A
 		return codec.Property{}, codec.ErrNoAccess, fmt.Errorf("no write access")
 	}
 	if in.PID != codec.PIDValue {
-		// MVP only accepts writes to pid=8 (value). announce_delay
-		// (pid=4) and event_prio (pid=17) are spec-writable too but
-		// out of MVP scope.
+		// MVP only accepts writes to pid=8 (value). event_delay (pid=4)
+		// and event_priority (pid=17) are also writable per spec §5.4
+		// (RW access in property-fields matrix) but out of MVP scope.
 		return codec.Property{}, codec.ErrInvalidPID, fmt.Errorf("only pid=8 is writable in MVP")
 	}
 

--- a/internal/acp2/provider/set.go
+++ b/internal/acp2/provider/set.go
@@ -4,7 +4,9 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+
 	"dhs/internal/acp2/codec"
+	"dhs/internal/export/canonical"
 )
 
 // applySet mutates e per an incoming set_property request and returns
@@ -124,8 +126,8 @@ func (s *server) applySetNumber(e *entry, in *codec.Property) (codec.Property, c
 	return codec.Property{}, codec.ErrInvalidValue, fmt.Errorf("number_type %d not writable", nt)
 }
 
-// applySetEnum validates the incoming index against the entry's options
-// and persists it as int64 in canonical.Parameter.Value.
+// applySetEnum validates the incoming wire idx against the entry's
+// EnumMap and persists it as int64 in canonical.Parameter.Value.
 //
 // Incoming / reply body:
 //
@@ -134,20 +136,57 @@ func (s *server) applySetNumber(e *entry, in *codec.Property) (codec.Property, c
 //	| 0      | pid   | u8     | 8 = value                                 |
 //	| 1      | vtype | u8     | reply uses NumTypeU32 (6)                 |
 //	| 2-3    | plen  | u16 BE | 8                                         |
-//	| 4-7    | idx   | u32 BE | option index; >= len(options) -> Invalid  |
+//	| 4-7    | idx   | u32 BE | option wire id; not in EnumMap -> Invalid |
 //
-// Spec reference: acp2_protocol.pdf §5.2.2 enum value
+// Real Neuron enums use sparse u32 wire ids (e.g. 641 "Main",
+// 786 "Automatic"); the option's wire idx is stored in EnumMap.Value.
+// The gate validates against the set of wire ids, NOT positional
+// 0..N-1 (which would reject every valid Set when EnumMap is sparse).
+//
+// When the canonical lacks an EnumMap (legacy comma/newline
+// Enumeration string), accept the positional 0..N-1 range as a
+// fallback so legacy fixtures keep round-tripping.
+//
+// Spec reference: acp2_protocol.pdf §4.3.4 set property + §5.2.2 enum value
 func (s *server) applySetEnum(e *entry, in *codec.Property) (codec.Property, codec.ACP2ErrStatus, error) {
 	if len(in.Data) < 4 {
 		return codec.Property{}, codec.ErrInvalidValue, fmt.Errorf("enum needs u32")
 	}
 	idx := binary.BigEndian.Uint32(in.Data[0:4])
-	opts := enumOptions(e.param)
-	if int(idx) >= len(opts) {
-		return codec.Property{}, codec.ErrInvalidValue, fmt.Errorf("enum index %d >= %d", idx, len(opts))
+	if !enumIdxValid(e.param, idx) {
+		return codec.Property{}, codec.ErrInvalidValue,
+			fmt.Errorf("enum idx %d not in EnumMap", idx)
 	}
 	e.param.Value = int64(idx)
 	return numericProp(codec.PIDValue, codec.NumTypeU32, u32Data(idx)), 0, nil
+}
+
+// enumIdxValid returns true when idx matches one of the wire ids
+// declared on the canonical's EnumMap, or — if the canonical has no
+// EnumMap — falls back to positional bounds against the legacy
+// Enumeration string.
+func enumIdxValid(p *canonical.Parameter, idx uint32) bool {
+	if len(p.EnumMap) > 0 {
+		for _, e := range p.EnumMap {
+			if uint32(e.Value) == idx {
+				return true
+			}
+		}
+		return false
+	}
+	// Legacy fallback: no EnumMap, count newline/comma-separated labels
+	// in the Enumeration string and accept idx in [0, N).
+	if p.Enumeration != nil && *p.Enumeration != "" {
+		raw := *p.Enumeration
+		n := 1
+		for _, c := range raw {
+			if c == '\n' || c == ',' {
+				n++
+			}
+		}
+		return int(idx) < n
+	}
+	return false
 }
 
 // applySetIPv4 decodes four packed octets and stores them as a dotted-quad

--- a/internal/acp2/provider/set_enum_test.go
+++ b/internal/acp2/provider/set_enum_test.go
@@ -1,0 +1,104 @@
+package acp2
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"dhs/internal/acp2/codec"
+	"dhs/internal/export/canonical"
+)
+
+// TestApplySetEnum_SparseEnumMap pins #346: applySetEnum must validate
+// the incoming wire idx against the sparse u32 ids declared in
+// canonical.EnumMap.Value, not the positional 0..N-1 length. Real
+// Neuron enums use ids like 786 "Automatic" / 791 "Full Speed";
+// rejecting them as "out of bounds" when len(EnumMap)==2 freezes the
+// VSM UI on every Set.
+func TestApplySetEnum_SparseEnumMap(t *testing.T) {
+	param := &canonical.Parameter{
+		Header: canonical.Header{Number: 21127, Identifier: "Fan Control",
+			Access: canonical.AccessReadWrite},
+		Type:  canonical.ParamEnum,
+		Value: int64(786),
+		EnumMap: []canonical.EnumEntry{
+			{Key: "Automatic", Value: 786},
+			{Key: "Full Speed", Value: 791},
+		},
+	}
+	e := &entry{
+		objID: 21127, label: param.Identifier, access: 0x03,
+		objType: codec.ObjTypeEnum, numType: codec.NumTypeU32,
+		param: param,
+	}
+	srv := &server{}
+
+	tests := []struct {
+		name    string
+		idx     uint32
+		wantErr codec.ACP2ErrStatus
+	}{
+		{"sparse_786_Automatic_accept", 786, 0},
+		{"sparse_791_FullSpeed_accept", 791, 0},
+		{"out_of_set_999_reject", 999, codec.ErrInvalidValue},
+		{"positional_0_reject_when_sparse", 0, codec.ErrInvalidValue},
+		{"positional_1_reject_when_sparse", 1, codec.ErrInvalidValue},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := make([]byte, 4)
+			binary.BigEndian.PutUint32(data, tt.idx)
+			in := &codec.Property{PID: codec.PIDValue,
+				VType: uint8(codec.NumTypeU32), PLen: 8, Data: data}
+			_, status, _ := srv.applySetEnum(e, in)
+			if status != tt.wantErr {
+				t.Errorf("idx=%d status=%d want=%d", tt.idx, status, tt.wantErr)
+			}
+			if tt.wantErr == 0 && param.Value != int64(tt.idx) {
+				t.Errorf("param.Value=%v want %d", param.Value, tt.idx)
+			}
+		})
+	}
+}
+
+// TestApplySetEnum_LegacyEnumeration covers the fallback path: when
+// canonical lacks an EnumMap (older fixtures with a comma/newline
+// Enumeration string only), accept idx in [0, N) where N is the
+// label count. Keeps legacy fixtures round-tripping.
+func TestApplySetEnum_LegacyEnumeration(t *testing.T) {
+	enum := "Off,On,Auto"
+	param := &canonical.Parameter{
+		Header: canonical.Header{Number: 1, Identifier: "Mode",
+			Access: canonical.AccessReadWrite},
+		Type:        canonical.ParamEnum,
+		Value:       int64(1),
+		Enumeration: &enum,
+	}
+	e := &entry{
+		objID: 1, label: param.Identifier, access: 0x03,
+		objType: codec.ObjTypeEnum, numType: codec.NumTypeU32,
+		param: param,
+	}
+	srv := &server{}
+
+	tests := []struct {
+		name    string
+		idx     uint32
+		wantErr codec.ACP2ErrStatus
+	}{
+		{"legacy_0_accept", 0, 0},
+		{"legacy_2_accept", 2, 0},
+		{"legacy_3_reject", 3, codec.ErrInvalidValue},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := make([]byte, 4)
+			binary.BigEndian.PutUint32(data, tt.idx)
+			in := &codec.Property{PID: codec.PIDValue,
+				VType: uint8(codec.NumTypeU32), PLen: 8, Data: data}
+			_, status, _ := srv.applySetEnum(e, in)
+			if status != tt.wantErr {
+				t.Errorf("idx=%d status=%d want=%d", tt.idx, status, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/acp2/provider/tree.go
+++ b/internal/acp2/provider/tree.go
@@ -127,9 +127,20 @@ func newTree(exp *canonical.Export) (*tree, error) {
 // obj-id index. Assigns entries with their canonical Number as obj-id;
 // each entry's `children` list is filled with the obj-ids of its
 // direct children (sufficient to serve pid=14 without re-walking).
+//
+// Per spec acp2_protocol.docx §"Requirements" line 320-332: "Disabled
+// parts of the menu are not visible to clients (not shown as children,
+// options, etc)." Entries whose canonical Format carries a `disabled`
+// token are skipped: never indexed, never appear in any pid=14
+// children list, never reachable via get_object.
 func flatten(slot uint8, parent uint32, el canonical.Element, index map[uint32]*entry) error {
 	switch x := el.(type) {
 	case *canonical.Node:
+		// Nodes use Format only on Parameters, not on the Node header,
+		// so disabled-via-Format applies to leaves; Node-level
+		// disabled is out of canonical schema today and would need a
+		// separate field. Honour the same rule when a future schema
+		// extension adds it.
 		id := uint32(x.Number)
 		e := &entry{
 			objID:   id,
@@ -146,6 +157,12 @@ func flatten(slot uint8, parent uint32, el canonical.Element, index map[uint32]*
 			if err != nil {
 				return err
 			}
+			// Skip disabled children: drop from pid=14 list AND
+			// skip recursive flatten so the obj-id is never
+			// indexed.
+			if isDisabledElement(c) {
+				continue
+			}
 			e.children = append(e.children, childID)
 			if err := flatten(slot, id, c, index); err != nil {
 				return err
@@ -153,6 +170,11 @@ func flatten(slot uint8, parent uint32, el canonical.Element, index map[uint32]*
 		}
 		return nil
 	case *canonical.Parameter:
+		// Belt-and-braces: even if the parent forgets to filter,
+		// a disabled leaf still doesn't land in the index.
+		if isDisabledParameter(x) {
+			return nil
+		}
 		id := uint32(x.Number)
 		objType, numType, err := deriveACP2Type(x)
 		if err != nil {
@@ -180,6 +202,29 @@ func flatten(slot uint8, parent uint32, el canonical.Element, index map[uint32]*
 		return nil
 	}
 	return nil
+}
+
+// isDisabledElement returns true when the element should be hidden
+// from clients per spec §"Requirements" disabled-menu rule. Today
+// only Parameter entries can carry the `disabled` Format hint;
+// Nodes always pass through.
+func isDisabledElement(el canonical.Element) bool {
+	if p, ok := el.(*canonical.Parameter); ok {
+		return isDisabledParameter(p)
+	}
+	return false
+}
+
+// isDisabledParameter checks for the `disabled` bare token in
+// Parameter.Format. Same convention as the type discriminator
+// (`preset`, `ipv4`) — a flag without a value.
+func isDisabledParameter(p *canonical.Parameter) bool {
+	for _, kv := range formatParts(p.Format) {
+		if kv == "disabled" {
+			return true
+		}
+	}
+	return false
 }
 
 // elementID returns the Header.Number of any canonical element.

--- a/internal/acp2/provider/tree.go
+++ b/internal/acp2/provider/tree.go
@@ -31,6 +31,14 @@ type entry struct {
 	// the bare "preset" token. Used to emit pid 7 and to size the
 	// per-idx repetition of pids 8/9/10/11 in get_object replies.
 	presetDepth uint32
+
+	// presetIdxList holds the explicit u32 idx values for pid 7
+	// (preset_depth) when the canonical fixture supplies them via
+	// `idx=A,B,C` in Format. Spec example (acp2_protocol.docx
+	// §"Preset depth", line 2613-2632) uses non-contiguous values
+	// like {100, 200}. When this slice is empty, the encoder falls
+	// back to contiguous 0..presetDepth-1 — the historical behaviour.
+	presetIdxList []uint32
 }
 
 // tree is the obj-id indexed snapshot the provider serves. ACP2 obj-ids
@@ -159,7 +167,8 @@ func flatten(slot uint8, parent uint32, el canonical.Element, index map[uint32]*
 			objType:     objType,
 			numType:     numType,
 			param:       x,
-			presetDepth: presetDepthHint(x),
+			presetDepth:   presetDepthHint(x),
+			presetIdxList: presetIdxHint(x),
 		}
 		if objType == codec.ObjTypePreset && e.presetDepth == 0 {
 			// Spec §5 requires at least one idx in pid 7 for preset children.
@@ -385,6 +394,42 @@ func presetDepthHint(p *canonical.Parameter) uint32 {
 		}
 	}
 	return 0
+}
+
+// presetIdxHint extracts the "idx=A|B|C" attribute from
+// Parameter.Format, returning the parsed u32 values. Used by the
+// encoder to emit pid 7 (preset_depth) with the spec-allowed
+// non-contiguous idx list (e.g. {100, 200} per acp2_protocol.docx
+// §"Preset depth" line 2613-2632) instead of synthesising contiguous
+// 0..N-1.
+//
+// The pipe `|` separates idx values rather than comma, because comma
+// is the existing top-level separator between Format hints
+// (`depth=2,maxLen=16,idx=100|200`). Returns nil when the hint is
+// absent or unparseable; callers fall back to contiguous indices.
+func presetIdxHint(p *canonical.Parameter) []uint32 {
+	for _, kv := range formatParts(p.Format) {
+		if !strings.HasPrefix(kv, "idx=") {
+			continue
+		}
+		raw := strings.TrimPrefix(kv, "idx=")
+		parts := strings.Split(raw, "|")
+		out := make([]uint32, 0, len(parts))
+		for _, p := range parts {
+			p = strings.TrimSpace(p)
+			if p == "" {
+				continue
+			}
+			var n uint32
+			if _, err := fmt.Sscanf(p, "%d", &n); err == nil {
+				out = append(out, n)
+			}
+		}
+		if len(out) > 0 {
+			return out
+		}
+	}
+	return nil
 }
 
 // maxLenHint extracts the "maxLen=N" attribute from Parameter.Format,

--- a/internal/acp2/provider/tree.go
+++ b/internal/acp2/provider/tree.go
@@ -133,6 +133,12 @@ func newTree(exp *canonical.Export) (*tree, error) {
 // options, etc)." Entries whose canonical Format carries a `disabled`
 // token are skipped: never indexed, never appear in any pid=14
 // children list, never reachable via get_object.
+//
+// Labels run through sanitizeLabel before being stored on the entry —
+// per spec acp2_protocol.docx §"Versions" line 357: "Object labels
+// only may contain out of a-z, A-Z, 0-9, ' ' and '-'." Any character
+// outside that set is replaced with `-`; the unmodified label remains
+// on the canonical element so downstream tooling sees the original.
 func flatten(slot uint8, parent uint32, el canonical.Element, index map[uint32]*entry) error {
 	switch x := el.(type) {
 	case *canonical.Node:
@@ -146,7 +152,7 @@ func flatten(slot uint8, parent uint32, el canonical.Element, index map[uint32]*
 			objID:   id,
 			slot:    slot,
 			parent:  parent,
-			label:   x.Identifier,
+			label:   sanitizeLabel(x.Identifier),
 			access:  deriveAccess(x.Access),
 			objType: codec.ObjTypeNode,
 			node:    x,
@@ -184,7 +190,7 @@ func flatten(slot uint8, parent uint32, el canonical.Element, index map[uint32]*
 			objID:       id,
 			slot:        slot,
 			parent:      parent,
-			label:       x.Identifier,
+			label:       sanitizeLabel(x.Identifier),
 			access:      deriveAccess(x.Access),
 			objType:     objType,
 			numType:     numType,
@@ -223,6 +229,65 @@ func isDisabledParameter(p *canonical.Parameter) bool {
 		if kv == "disabled" {
 			return true
 		}
+	}
+	return false
+}
+
+// sanitizeLabel returns the spec-compliant form of an ACP2 object
+// label. Per acp2_protocol.docx §"Versions" line 357 the wire allows
+// only [A-Za-z0-9 \-]; any other character is replaced with `-`.
+//
+// Real EVS Neuron firmware emits labels like "ROOT_NODE_V2" with an
+// underscore — non-compliant per spec. Sanitising here keeps OUR
+// wire spec-clean (per `feedback_acp2_spec_pdfs_only`); the
+// canonical element is unchanged so other consumers see the
+// original.
+//
+// Returns "obj" when the input becomes empty after stripping
+// (defensive — spec mandates a non-empty label).
+func sanitizeLabel(label string) string {
+	if label == "" {
+		return "obj"
+	}
+	dirty := false
+	for _, r := range label {
+		if !isSpecLabelByte(r) {
+			dirty = true
+			break
+		}
+	}
+	if !dirty {
+		return label
+	}
+	var b strings.Builder
+	b.Grow(len(label))
+	for _, r := range label {
+		if isSpecLabelByte(r) {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('-')
+		}
+	}
+	out := b.String()
+	if out == "" || strings.Trim(out, "-") == "" {
+		return "obj"
+	}
+	return out
+}
+
+// isSpecLabelByte reports whether r is in the ACP2 §"Versions"
+// label charset: ASCII letters, digits, space, dash. Anything else
+// (including non-ASCII, underscore, dot, etc.) is non-compliant.
+func isSpecLabelByte(r rune) bool {
+	switch {
+	case r >= 'a' && r <= 'z':
+		return true
+	case r >= 'A' && r <= 'Z':
+		return true
+	case r >= '0' && r <= '9':
+		return true
+	case r == ' ' || r == '-':
+		return true
 	}
 	return false
 }

--- a/internal/acp2/wireshark/dhs_acpv2.lua
+++ b/internal/acp2/wireshark/dhs_acpv2.lua
@@ -476,8 +476,13 @@ local function parse_property(tvbuf, pktinfo, parent_tree, offset)
         tree:append_text(" (" .. count .. " children)")
 
     elseif pid_val == 15 then
-        -- options: each option = u32 index + null-terminated string + pad
-        -- data byte = num_options
+        -- options: variable-length per option, matching every shipping
+        -- ACP2 controller (Cerebrum, VSM, real EVS Neuron firmware).
+        -- Layout per record: u32 idx + NUL-terminated name + 0-3 byte
+        -- pad to next 4-byte boundary. data byte = N (num options).
+        --
+        -- Spec deviation: acp2_protocol.docx §5.4 row 15 specifies
+        -- fixed 72-byte stride; no production device implements that.
         tree:append_text(" (" .. data_val .. " options)")
         local pos = val_offset
         local opt_num = 0
@@ -485,7 +490,6 @@ local function parse_property(tvbuf, pktinfo, parent_tree, offset)
             if (pos + 4) > (val_offset + val_len) then break end
             tree:add(prop_f.opt_idx, tvbuf:range(pos, 4))
             pos = pos + 4
-            -- find null-terminated string
             local str_start = pos
             while pos < (val_offset + val_len) and tvbuf:range(pos, 1):uint() ~= 0 do
                 pos = pos + 1
@@ -493,12 +497,14 @@ local function parse_property(tvbuf, pktinfo, parent_tree, offset)
             if pos > str_start then
                 tree:add(prop_f.opt_str, tvbuf:range(str_start, pos - str_start))
             end
-            -- skip null terminator
+            -- consume NUL terminator
             if pos < (val_offset + val_len) then
                 pos = pos + 1
             end
-            -- skip padding to 4-byte boundary within option block
-            -- options are 72 bytes each per spec, but we parse dynamically
+            -- skip pad to 4-byte boundary, relative to start of record
+            local rec_used = pos - (str_start - 4)
+            local opt_pad = (4 - (rec_used % 4)) % 4
+            pos = pos + opt_pad
             opt_num = opt_num + 1
         end
 

--- a/internal/acp2/wireshark/dhs_acpv2.lua
+++ b/internal/acp2/wireshark/dhs_acpv2.lua
@@ -124,7 +124,7 @@ local acp2_pid_valstr = {
     [1]  = "object_type",
     [2]  = "label",
     [3]  = "access",
-    [4]  = "event_delay",
+    [4]  = "announce_delay",
     [5]  = "number_type",
     [6]  = "string_max_length",
     [7]  = "preset_depth",
@@ -388,7 +388,7 @@ local function parse_property(tvbuf, pktinfo, parent_tree, offset)
         tree:add(prop_f.access, tvbuf:range(offset + 1, 1))
 
     elseif pid_val == 4 then
-        -- event_delay: u32 in value area
+        -- announce_delay: u32 in value area
         if val_len >= 4 then
             tree:add(prop_f.delay, tvbuf:range(val_offset, 4))
         end
@@ -477,7 +477,7 @@ local function parse_property(tvbuf, pktinfo, parent_tree, offset)
 
     elseif pid_val == 15 then
         -- options: variable-length per option, matching every shipping
-        -- ACP2 controller (Cerebrum, VSM, real EVS Neuron firmware).
+        -- ACP2 controller (Cerebrum, VSM, real Axon Neuron firmware).
         -- Layout per record: u32 idx + NUL-terminated name + 0-3 byte
         -- pad to next 4-byte boundary. data byte = N (num options).
         --
@@ -487,6 +487,7 @@ local function parse_property(tvbuf, pktinfo, parent_tree, offset)
         local pos = val_offset
         local opt_num = 0
         while pos < (val_offset + val_len) and opt_num < data_val do
+            local rec_start = pos
             if (pos + 4) > (val_offset + val_len) then break end
             tree:add(prop_f.opt_idx, tvbuf:range(pos, 4))
             pos = pos + 4
@@ -501,8 +502,8 @@ local function parse_property(tvbuf, pktinfo, parent_tree, offset)
             if pos < (val_offset + val_len) then
                 pos = pos + 1
             end
-            -- skip pad to 4-byte boundary, relative to start of record
-            local rec_used = pos - (str_start - 4)
+            -- skip pad to next 4-byte boundary, relative to record start
+            local rec_used = pos - rec_start
             local opt_pad = (4 - (rec_used % 4)) % 4
             pos = pos + opt_pad
             opt_num = opt_num + 1

--- a/internal/acp2/wireshark/dhs_acpv2.lua
+++ b/internal/acp2/wireshark/dhs_acpv2.lua
@@ -124,7 +124,7 @@ local acp2_pid_valstr = {
     [1]  = "object_type",
     [2]  = "label",
     [3]  = "access",
-    [4]  = "announce_delay",
+    [4]  = "event_delay",
     [5]  = "number_type",
     [6]  = "string_max_length",
     [7]  = "preset_depth",
@@ -388,7 +388,7 @@ local function parse_property(tvbuf, pktinfo, parent_tree, offset)
         tree:add(prop_f.access, tvbuf:range(offset + 1, 1))
 
     elseif pid_val == 4 then
-        -- announce_delay: u32 in value area
+        -- event_delay: u32 in value area
         if val_len >= 4 then
             tree:add(prop_f.delay, tvbuf:range(val_offset, 4))
         end

--- a/internal/storage/tree_store.go
+++ b/internal/storage/tree_store.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"dhs/internal/export"
@@ -130,6 +131,83 @@ func (s *TreeStore) Load(ip string, slot int) (*export.Snapshot, error) {
 	}
 	defer func() { _ = f.Close() }()
 
+	snap, err := export.ReadJSON(f)
+	if err != nil {
+		return nil, fmt.Errorf("storage: decode %s: %w", path, err)
+	}
+	return snap, nil
+}
+
+// identityPath returns the file path for an identity-keyed cache.
+// Identity strings come straight from the consumer (e.g.
+// "SHPRM1@0.7"); we sanitise to keep them filesystem-safe across
+// Windows + POSIX.
+func (s *TreeStore) identityPath(identity string) string {
+	safe := identity
+	for _, ch := range []string{"/", "\\", ":", "*", "?", "\"", "<", ">", "|"} {
+		safe = strings.ReplaceAll(safe, ch, "_")
+	}
+	return filepath.Join(s.baseDir, "dm", safe+".json")
+}
+
+// SaveByIdentity writes a multi-slot snapshot keyed by stable device
+// identity (e.g. "SHPRM1@0.7"). Unlike Save, the same cache file is
+// reused across IP changes / re-cabling — only a Card swap or
+// firmware upgrade invalidates it.
+//
+// The snapshot's Slots may carry multiple slot dumps; the consumer
+// hot-loads each at watch start. Object values are NOT stripped here
+// (caller decides) — DM cache often wants labels + types but values
+// are consulted from live get/watch anyway.
+func (s *TreeStore) SaveByIdentity(identity string, snap *export.Snapshot) error {
+	if identity == "" {
+		return fmt.Errorf("storage: SaveByIdentity: empty identity")
+	}
+	if snap == nil {
+		return fmt.Errorf("storage: SaveByIdentity: nil snapshot")
+	}
+	path := s.identityPath(identity)
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("storage: mkdir %s: %w", dir, err)
+	}
+	tmp := path + ".tmp"
+	f, err := os.Create(tmp)
+	if err != nil {
+		return fmt.Errorf("storage: create %s: %w", tmp, err)
+	}
+	if err := export.WriteJSON(f, snap); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return fmt.Errorf("storage: write: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("storage: close: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("storage: rename: %w", err)
+	}
+	return nil
+}
+
+// LoadByIdentity reads the identity-keyed cache. Returns (nil, nil)
+// on cache miss (file not present); err non-nil only on read /
+// decode failures.
+func (s *TreeStore) LoadByIdentity(identity string) (*export.Snapshot, error) {
+	if identity == "" {
+		return nil, fmt.Errorf("storage: LoadByIdentity: empty identity")
+	}
+	path := s.identityPath(identity)
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("storage: open %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
 	snap, err := export.ReadJSON(f)
 	if err != nil {
 		return nil, fmt.Errorf("storage: decode %s: %w", path, err)


### PR DESCRIPTION
## Summary

Closes the ACP2 strict-spec close-out epic. 19 sub-PRs merged into `feat/acp2-strict-spec-closeout`, plus 3 cherry-pick commits absorbing the content of 6 conflicting sub-PRs (#326, #328, #329, #342, #350, #354) onto the same branch — all 25 issues addressed.

Per memory `feedback_pr_per_protocol`: this is the protocol-per-PR umbrella. One approval closes every ACP2 issue in scope.

## Behavioural changes

| Area | Change | Reference |
|---|---|---|
| **Transport** | AN2 reply byte shapes match spec §3.3 + real Neuron wire | #303 |
| **Versions** | AN2 `0.1` major.minor (was u16 fudge), ACP2 `2` (was 1 — spec §1.4 says v1 unsupported) | #345, §5.1 cherry-pick |
| **§5.1 pid emission** | Full property fields matrix per docx cell-shading: pid 3 omit on Nodes; pid 4 emit on every Parameter; pid 5 omit on Preset; pid 6 always on String; pid 9/10/11 always on Number/Enum/Preset | #325, #327, §5.1 cherry-pick (#326/#328/#329/#350) |
| **Codec** | error decoder strict (no body), get_property body trim, pid=15 options variable-length per real-device convention, mtid pool ctx-cancellable | #330, #331, #333, #337, #343 |
| **Provider** | Single-request enforcement per spec line 313, applySetEnum sparse u32 idx, error reply body empty, label charset sanitize, disabled object filter, pid=7 from canonical Format | #338, #347, #341, #340, label charset cherry-pick (#342) |
| **Consumer** | Walker decodes pid 4/7/18/20, announce fallback decodes Enum/IPv4/String typed, watch persists tree types, set --path resolves via cache, mtid pool | #332, #352, #339, #335 |
| **CLI** | Flag taxonomy harmonisation, PIDAnnounceDelay → PIDEventDelay rename | #336, #334 |
| **DM cache** | Identity-keyed at `.cache/dm/<CardName>@<HardwareVersion>.json` (DHS 2016 MasterView model). Hot-load on watch start. Multi-slot merge. IP-keyed cache no longer used for ACP2 | DM cache cherry-pick (#354 / #353 / #355) |

## Sub-PRs merged into closeout

#303, #325, #327, #330, #331, #332, #333, #334, #335, #336, #337, #338, #339, #340, #341, #343, #345, #347, #352

## Sub-PRs closed-as-superseded (content cherry-picked)

| Closed PR | Cherry-pick commit on closeout | Issues addressed |
|---|---|---|
| #350 | `18856d0` | #349 (full §5.1) |
| #326 | `18856d0` (subsumed by #350) | #307 |
| #328 | `18856d0` (subsumed by #350) | #309 |
| #329 | `18856d0` (subsumed by #350) | #308 |
| #342 | `cd7af27` | #318 |
| #354 | `1602496` + `7325a92` | #353, #355 |

## Test plan

- [x] `go build ./...` green
- [x] `go test ./...` green on Windows native (full suite)
- [x] Live: producer v11 deployed `10.100.0.103:2072` (Axon DDB08, ~50k objects)
- [x] Live: real Axon Neuron `10.41.40.4` walked + watched, byte-verified against spec docx §5.1
- [x] DM cache: walk slot 0 → walk slot 1 → watch slot 1 hot-loads with labels from frame 1 (verified 2026-05-09)
- [ ] CI on this PR

## Closes

Closes #302, #306, #307, #308, #309, #310, #311, #313, #314, #315, #316, #317, #318, #319, #320, #321, #322, #323, #344, #346, #349, #351, #353, #355

(Plus issue tied to PR #336 if any — the CLI flag taxonomy work.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)