### PR TITLE
feat(watch): surface property unit on announces (closes #359)

### DIFF
--- a/cmd/dhs/cmd_watch.go
+++ b/cmd/dhs/cmd_watch.go
@@ -288,9 +288,17 @@ func runWatch(ctx context.Context, args []string) error {
 				continue
 			}
 
-			// Parameter event — value column.
+			// Parameter event — value column. Prefer the live unit
+			// carried on ev.Unit (#359 — populated by the plugin at
+			// announce-decode time from the in-memory tree). Fall back
+			// to the disk-cache unit when the live tree didn't have the
+			// object yet (cold start before walk finishes).
 			valStr := formatValueInline(ev.Value)
-			if unit, ok := unitCache[watchCacheKey(ev.Group, ev.ID)]; ok && unit != "" {
+			unit := ev.Unit
+			if unit == "" {
+				unit = unitCache[watchCacheKey(ev.Group, ev.ID)]
+			}
+			if unit != "" {
 				valStr += " " + unit
 			}
 			// Live description + access + freshness + changes tag.

--- a/internal/acp1/consumer/plugin.go
+++ b/internal/acp1/consumer/plugin.go
@@ -700,9 +700,11 @@ func (p *Plugin) Subscribe(req protocol.ValueRequest, fn protocol.EventFunc) err
 		}
 
 		// Try to look up the object by (group, id) in the cached tree
-		// so the callback gets a typed value and a resolved label.
+		// so the callback gets a typed value, a resolved label, and
+		// the engineering unit (#359).
 		if obj, acpType, found := findObject(tree, msg.ObjGroup, msg.ObjID); found {
 			ev.Label = obj.Label
+			ev.Unit = obj.Unit
 			if val, derr := DecodeValueBytes(obj, acpType, msg.Value); derr == nil {
 				ev.Value = val
 				// Keep the cached tree in sync with live events so

--- a/internal/acp2/consumer/plugin.go
+++ b/internal/acp2/consumer/plugin.go
@@ -532,6 +532,7 @@ func (p *Plugin) Subscribe(req protocol.ValueRequest, fn protocol.EventFunc) err
 				if tobj.ID == int(msg.ObjID) {
 					treeIdx = ti
 					ev.Label = tobj.Label
+					ev.Unit = tobj.Unit
 					break
 				}
 			}

--- a/internal/emberplus/consumer/plugin.go
+++ b/internal/emberplus/consumer/plugin.go
@@ -1871,6 +1871,7 @@ func (p *Plugin) notifySubscribers(entry *treeEntry) {
 			Path:        strings.Join(entry.obj.Path, "."),
 			Label:       entry.obj.Label,
 			Description: desc,
+			Unit:        entry.obj.Unit,
 			Access:      entry.obj.Access,
 			Group:       entry.obj.Group,
 			Value:       entry.obj.Value,

--- a/internal/protocol/event_unit_test.go
+++ b/internal/protocol/event_unit_test.go
@@ -1,0 +1,58 @@
+package protocol
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// TestEvent_Unit_RoundTrip pins the #359 contract: the new Unit field
+// on Event survives JSON encoding round-trip. Tolerates non-ASCII
+// engineering units (e.g. "°C") so protocols that carry localised
+// names (Ember+ Description-derived units, vendor-specific) round-trip
+// cleanly.
+//
+// Asserts behaviour, not the literal JSON shape — Event has no json
+// tags today, so the field name is Go-default ("Unit"). Adding tags
+// to the entire struct is out of scope for this change.
+func TestEvent_Unit_RoundTrip(t *testing.T) {
+	cases := []struct{ name, unit string }{
+		{"with unit", "dBFS"},
+		{"empty unit", ""},
+		{"non-ASCII tolerated", "°C"},
+		{"per-mille edge case", "‰"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ev := Event{
+				Slot:      1,
+				ID:        17671,
+				Label:     "Audio Gain",
+				Unit:      c.unit,
+				Timestamp: time.Unix(0, 0).UTC(),
+			}
+			raw, err := json.Marshal(ev)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			var rt Event
+			if err := json.Unmarshal(raw, &rt); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if rt.Unit != c.unit {
+				t.Errorf("round-trip Unit: got %q, want %q", rt.Unit, c.unit)
+			}
+		})
+	}
+}
+
+// TestEvent_Unit_DefaultEmpty pins that an Event constructed without
+// setting Unit (today's behaviour for protocols without unit semantics
+// like Probel SW-P-08/02, OSC, TSL UMD) carries an empty string —
+// downstream formatters can use that as the no-unit signal.
+func TestEvent_Unit_DefaultEmpty(t *testing.T) {
+	ev := Event{Slot: 0, ID: 1}
+	if ev.Unit != "" {
+		t.Errorf("default Event.Unit = %q, want empty string", ev.Unit)
+	}
+}

--- a/internal/protocol/types.go
+++ b/internal/protocol/types.go
@@ -521,6 +521,14 @@ type Event struct {
 	// value column so live description edits are visible.
 	Description string
 
+	// Unit is the engineering unit string for the element's value
+	// (e.g. "dBFS", "dB", "%", "Hz", "ms"). Plugins populate it from
+	// the in-memory tree at announce-decode time so the watcher can
+	// render `value unit` without a tree lookup. Empty for protocols
+	// that have no unit semantic on the wire (Probel SW-P-08/02, OSC,
+	// TSL UMD) or for objects that simply don't carry one.
+	Unit string
+
 	// Access encodes the read/write permission bits in effect at the
 	// time of the event. Bitmask: read=1, write=2, setDef=4 (matches
 	// Object.Access). Surfaced so live access changes are visible in


### PR DESCRIPTION
## Summary

Surface the engineering unit (e.g. `dBFS`, `dB`, `%`, `Hz`, `ms`) on every announce so the watch verb renders `0.15 dBFS` instead of `0.15`. Generic across protocols current and future — single contract, no per-protocol special-casing.

Reported by user 2026-05-09 after ACP2 strict-spec close-out (#358 merged): "enum, string, num, ip work. Only missing in watcher is the formating like 0.15 dBFS, the unit?"

Closes #359.

## Approach

| Step | What |
|---|---|
| **1. Neutral event field** | New `Unit string` on `protocol.Event` next to `Description`. Optional, default empty — backwards-compatible. |
| **2. Per-protocol population** | Each plugin's announce/event constructor copies `obj.Unit` from the in-memory tree at decode time, alongside the existing `ev.Label` lookup. ACP1, ACP2, Ember+ Parameter events covered. |
| **3. Watch formatter** | Prefers `ev.Unit`; falls back to the existing IP-keyed disk-cache `unitCache` for the cold-start window before the live tree is populated (preserves ACP1's safety net). |
| **4. Numeric formatting** | Unchanged. `formatValueInline` is a single-token render, no precision games — minimum risk of regression per user direction "minimize risk of mismatch". |

## Per-protocol behaviour

| Protocol | Source of unit |
|---|---|
| ACP1 | `Object.Unit` populated from per-type `unit` property (Integer / Long / Float / Byte). Walk + tree cache already round-trip it. |
| ACP2 | `Object.Unit` populated from pid 13. Walker + canonical encoder + DM cache all round-trip. |
| Ember+ | `Parameter.formula.unit` / Description-derived unit, captured into `Object.Unit` by the resolver. |
| Probel SW-P-08 / SW-P-02 | No per-property unit on the wire. `ev.Unit == ""` → no suffix appended. Output unchanged. |
| OSC | No unit semantic on the wire. Empty. Output unchanged. |
| TSL UMD | No unit semantic. Empty. Output unchanged. |
| AMWA NMOS | Future — Parameter description / NC Datatype-derived unit when the announce machinery lands. |

## Files

| File | Change |
|---|---|
| `internal/protocol/types.go` | new `Event.Unit` field with doc |
| `internal/protocol/event_unit_test.go` (new) | 2 tests pinning JSON round-trip + default-empty |
| `internal/acp1/consumer/plugin.go` | `ev.Unit = obj.Unit` at announce decode |
| `internal/acp2/consumer/plugin.go` | `ev.Unit = tobj.Unit` at announce decode |
| `internal/emberplus/consumer/plugin.go` | `ev.Unit = entry.obj.Unit` at parameter event |
| `cmd/dhs/cmd_watch.go` | prefer `ev.Unit`; existing `unitCache` kept as cold-start fallback |

## Test plan

- [x] `go build ./...` green
- [x] `go test ./...` green; new tests:
  - `TestEvent_Unit_RoundTrip` — JSON encoding round-trip with empty + ASCII + non-ASCII (`°C`, `‰`) units
  - `TestEvent_Unit_DefaultEmpty` — zero-value Event has empty Unit
- [x] Producer `dhs-acp2-v13` deployed to `10.100.0.103:2072`, listening, Cerebrum already connected
- [ ] Live: `dhs consumer acp2 watch 10.100.0.103 --port 2072 --slot 1` shows `value unit` on Number announces (pending user verification on real Neuron 10.41.40.4)

## Out of scope

- Numeric formatting precision (e.g. `0.150` vs `0.15`). Step / Min/Max-driven format choice is a separate issue if wanted.
- `unitCache` map removal — kept as ACP1 cold-start fallback. Future: when ACP1 has identity-probe + DM hot-load (parity with ACP2's #353), the IP-keyed unitCache becomes redundant and can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
