### PR TITLE
fix(acp2-cache): SaveByIdentity drops Object.Meta — value decodes as raw(N) on hot-load (closes #361)

### DIFF
--- a/internal/storage/identity_roundtrip_test.go
+++ b/internal/storage/identity_roundtrip_test.go
@@ -1,0 +1,195 @@
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"dhs/internal/export"
+	"dhs/internal/protocol"
+)
+
+// TestSaveLoadByIdentity_PreservesMetaAndContent pins the regression
+// surfaced live on 2026-05-09: SaveByIdentity used to route through
+// export.WriteJSON (hierarchical), and the matching reader's leaf
+// decode struct in flattenJSONTree had no Meta field. So the disk
+// round-trip silently dropped Object.Meta — the exact map the ACP2
+// SeedTreeFromCachedObjects path needs (acp2.objType / numType /
+// optionsMap) to rebuild ObjTypes/NumTypes parallel arrays. Symptom:
+// watcher decoded enum labels and units but rendered numeric values
+// as `raw(N)` because seed couldn't recover the type info.
+//
+// Fix: SaveByIdentity uses stdlib json.Encoder direct on *Snapshot;
+// LoadByIdentity uses stdlib json.Decoder direct into *Snapshot. The
+// snapshot is byte-faithful across separate dhs invocations.
+//
+// The test uses a NEW TreeStore for the load step so we exercise the
+// real cross-process path (open file, decode flat) — same shape the
+// user hits when running `walk --slot 0` then `walk --slot 1` in two
+// shell invocations.
+func TestSaveLoadByIdentity_PreservesMetaAndContent(t *testing.T) {
+	dir := t.TempDir()
+	saver := NewTreeStore(dir)
+
+	objs := []protocol.Object{
+		{
+			Slot:  1,
+			ID:    70232,
+			Label: "Backup Input",
+			Path:  []string{"BOARD", "Stream"},
+			Kind:  protocol.KindEnum,
+			Unit:  "dBFS",
+			Meta: map[string]any{
+				"acp2.objType": uint8(2),
+				"acp2.numType": uint8(9),
+				"acp2.optionsMap": map[string]string{
+					"786": "Automatic",
+					"791": "Full Speed",
+				},
+			},
+		},
+	}
+	snap := &export.Snapshot{
+		Device:    export.DeviceInfo{IP: "10.41.40.4", Protocol: "acp2"},
+		Generator: "test",
+		CreatedAt: time.Now().UTC(),
+		Slots: []export.SlotDump{{
+			Slot:     1,
+			WalkedAt: time.Now().UTC(),
+			Objects:  objs,
+		}},
+	}
+
+	if err := saver.SaveByIdentity("SHPRM1@0.7", snap); err != nil {
+		t.Fatalf("SaveByIdentity: %v", err)
+	}
+
+	loader := NewTreeStore(dir)
+	got, err := loader.LoadByIdentity("SHPRM1@0.7")
+	if err != nil || got == nil {
+		t.Fatalf("LoadByIdentity: snap=%v err=%v", got, err)
+	}
+
+	if len(got.Slots) != 1 || len(got.Slots[0].Objects) != 1 {
+		t.Fatalf("snap shape: slots=%d objs=%d, want 1/1",
+			len(got.Slots),
+			func() int {
+				if len(got.Slots) == 0 {
+					return -1
+				}
+				return len(got.Slots[0].Objects)
+			}())
+	}
+	rt := got.Slots[0].Objects[0]
+	if rt.ID != 70232 || rt.Label != "Backup Input" || rt.Kind != protocol.KindEnum {
+		t.Errorf("base fields lost: id=%d label=%q kind=%v", rt.ID, rt.Label, rt.Kind)
+	}
+	if rt.Unit != "dBFS" {
+		t.Errorf("Unit lost on round-trip: got %q want %q", rt.Unit, "dBFS")
+	}
+	if len(rt.Path) != 2 || rt.Path[0] != "BOARD" || rt.Path[1] != "Stream" {
+		t.Errorf("Path lost: %v", rt.Path)
+	}
+	if rt.Meta == nil {
+		t.Fatalf("Meta dropped on round-trip — DM cache regression")
+	}
+	if v, ok := rt.Meta["acp2.objType"]; !ok || v == nil {
+		t.Errorf("Meta[acp2.objType] missing: meta=%v", rt.Meta)
+	}
+	if om, ok := rt.Meta["acp2.optionsMap"]; !ok {
+		t.Errorf("Meta[acp2.optionsMap] missing")
+	} else if m, _ := om.(map[string]any); m == nil || m["786"] != "Automatic" {
+		t.Errorf("optionsMap content lost: %v", om)
+	}
+}
+
+// TestSaveLoadByIdentity_MultiInvocationMerge reproduces the exact
+// user flow: walk slot 0 then walk slot 1 in two separate dhs
+// invocations. Each invocation re-creates the TreeStore. After both,
+// the file must contain BOTH slots with their original object content
+// — not slot 1 alone (the bug) and not slot 0 alone.
+func TestSaveLoadByIdentity_MultiInvocationMerge(t *testing.T) {
+	dir := t.TempDir()
+	identity := "SHPRM1@0.7"
+
+	{
+		store := NewTreeStore(dir)
+		existing, _ := store.LoadByIdentity(identity)
+		if existing != nil {
+			t.Fatalf("invocation 1 expected miss, got %v", existing)
+		}
+		snap := &export.Snapshot{
+			Device:    export.DeviceInfo{IP: "10.41.40.4", Protocol: "acp2"},
+			Generator: "test",
+			CreatedAt: time.Now().UTC(),
+			Slots: []export.SlotDump{{
+				Slot:     0,
+				WalkedAt: time.Now().UTC(),
+				Objects: []protocol.Object{{
+					Slot: 0, ID: 1, Label: "BOARD",
+					Path: []string{"BOARD"},
+					Kind: protocol.KindString,
+					Meta: map[string]any{"acp2.objType": uint8(0)},
+				}},
+			}},
+		}
+		if err := store.SaveByIdentity(identity, snap); err != nil {
+			t.Fatalf("invocation 1 save: %v", err)
+		}
+	}
+
+	{
+		store := NewTreeStore(dir)
+		existing, err := store.LoadByIdentity(identity)
+		if err != nil || existing == nil {
+			t.Fatalf("invocation 2 expected hit, got snap=%v err=%v", existing, err)
+		}
+		if len(existing.Slots) != 1 || existing.Slots[0].Slot != 0 {
+			t.Fatalf("invocation 2 sees wrong slots: %+v", existing.Slots)
+		}
+		if len(existing.Slots[0].Objects) != 1 || existing.Slots[0].Objects[0].Label != "BOARD" {
+			t.Fatalf("invocation 2 lost slot 0 content: %+v", existing.Slots[0].Objects)
+		}
+		existing.Slots = append(existing.Slots, export.SlotDump{
+			Slot:     1,
+			WalkedAt: time.Now().UTC(),
+			Objects: []protocol.Object{{
+				Slot: 1, ID: 70232, Label: "Backup Input",
+				Path: []string{"BOARD", "Stream"},
+				Kind: protocol.KindEnum,
+				Unit: "dBFS",
+				Meta: map[string]any{"acp2.objType": uint8(2)},
+			}},
+		})
+		if err := store.SaveByIdentity(identity, existing); err != nil {
+			t.Fatalf("invocation 2 save: %v", err)
+		}
+	}
+
+	store := NewTreeStore(dir)
+	final, err := store.LoadByIdentity(identity)
+	if err != nil || final == nil {
+		t.Fatalf("final load: %v", err)
+	}
+	if len(final.Slots) != 2 {
+		t.Fatalf("final file should hold 2 slots, got %d (slot 1 overwrote slot 0?)", len(final.Slots))
+	}
+	gotSlots := map[int]string{}
+	gotUnits := map[int]string{}
+	for _, sd := range final.Slots {
+		if len(sd.Objects) == 0 {
+			t.Errorf("slot %d has zero objects after merge", sd.Slot)
+			continue
+		}
+		gotSlots[sd.Slot] = sd.Objects[0].Label
+		gotUnits[sd.Slot] = sd.Objects[0].Unit
+	}
+	if gotSlots[0] != "BOARD" {
+		t.Errorf("slot 0 lost original content: got %q want %q", gotSlots[0], "BOARD")
+	}
+	if gotSlots[1] != "Backup Input" {
+		t.Errorf("slot 1 missing: got %q want %q", gotSlots[1], "Backup Input")
+	}
+	if gotUnits[1] != "dBFS" {
+		t.Errorf("slot 1 Unit lost on merge: got %q want %q", gotUnits[1], "dBFS")
+	}
+}

--- a/internal/storage/tree_store.go
+++ b/internal/storage/tree_store.go
@@ -11,6 +11,7 @@
 package storage
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -155,10 +156,25 @@ func (s *TreeStore) identityPath(identity string) string {
 // reused across IP changes / re-cabling — only a Card swap or
 // firmware upgrade invalidates it.
 //
-// The snapshot's Slots may carry multiple slot dumps; the consumer
-// hot-loads each at watch start. Object values are NOT stripped here
-// (caller decides) — DM cache often wants labels + types but values
-// are consulted from live get/watch anyway.
+// Format: flat JSON via stdlib json.Encoder, NOT export.WriteJSON.
+// The exporter's hierarchical writer is lossy on three fields the DM
+// cache absolutely needs to round-trip across separate dhs invocations
+// (one walk per slot, multi-process):
+//
+//   - Object.Meta — walker stashes acp2.objType / numType / optionsMap
+//     here; the hierarchical reader's leaf struct has no Meta field, so
+//     load → save → load drops type info silently and announces decode
+//     as raw(N) with the right Unit but wrong Kind.
+//   - Object.Path — buildJSONTree groups objects by Path; root-level
+//     objects (no Path) become orphaned _meta entries that flatten
+//     back to nothing.
+//   - Object.Value — the hierarchical writer omits values for some
+//     kinds, the reader re-parses CSV strings, and round-trip fidelity
+//     is best-effort.
+//
+// Direct json.Marshal preserves the exact protocol.Object struct on
+// disk, so successive walks of slot 0 + slot 1 + slot N accumulate
+// into the same file with no field loss.
 func (s *TreeStore) SaveByIdentity(identity string, snap *export.Snapshot) error {
 	if identity == "" {
 		return fmt.Errorf("storage: SaveByIdentity: empty identity")
@@ -176,10 +192,12 @@ func (s *TreeStore) SaveByIdentity(identity string, snap *export.Snapshot) error
 	if err != nil {
 		return fmt.Errorf("storage: create %s: %w", tmp, err)
 	}
-	if err := export.WriteJSON(f, snap); err != nil {
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(snap); err != nil {
 		_ = f.Close()
 		_ = os.Remove(tmp)
-		return fmt.Errorf("storage: write: %w", err)
+		return fmt.Errorf("storage: encode: %w", err)
 	}
 	if err := f.Close(); err != nil {
 		_ = os.Remove(tmp)
@@ -195,6 +213,13 @@ func (s *TreeStore) SaveByIdentity(identity string, snap *export.Snapshot) error
 // LoadByIdentity reads the identity-keyed cache. Returns (nil, nil)
 // on cache miss (file not present); err non-nil only on read /
 // decode failures.
+//
+// Decoder: stdlib json.Decoder direct into *export.Snapshot. Pairs
+// with SaveByIdentity's flat-format writer above. We deliberately do
+// NOT route through export.ReadJSON — its flat-vs-hierarchical
+// auto-detect requires len(Slots[0].Objects) > 0 to accept the flat
+// path, and a freshly-initialised snapshot with an empty slot 0 dump
+// would fall through to the lossy hierarchical reader.
 func (s *TreeStore) LoadByIdentity(identity string) (*export.Snapshot, error) {
 	if identity == "" {
 		return nil, fmt.Errorf("storage: LoadByIdentity: empty identity")
@@ -208,11 +233,11 @@ func (s *TreeStore) LoadByIdentity(identity string) (*export.Snapshot, error) {
 		return nil, fmt.Errorf("storage: open %s: %w", path, err)
 	}
 	defer func() { _ = f.Close() }()
-	snap, err := export.ReadJSON(f)
-	if err != nil {
+	var snap export.Snapshot
+	if err := json.NewDecoder(f).Decode(&snap); err != nil {
 		return nil, fmt.Errorf("storage: decode %s: %w", path, err)
 	}
-	return snap, nil
+	return &snap, nil
 }
 
 // FindCardName extracts the Card Name from a list of objects.


### PR DESCRIPTION
## Summary

Fixes the regression spotted live on 2026-05-09: ACP2 watch hot-load decoded labels + units correctly but every numeric value rendered as `raw(N)` (e.g. `raw(4) dBFS`).

Root cause: `SaveByIdentity` wrote DM cache via `export.WriteJSON` (hierarchical), and `LoadByIdentity` read it back via `export.ReadJSON`. The hierarchical reader's leaf struct in `flattenJSONTree` has no `Meta` field — so `Object.Meta` (the map carrying `acp2.objType` / `numType` / `optionsMap`) was silently dropped on every disk round-trip. With Meta lost, `Plugin.SeedTreeFromCachedObjects` couldn't recover type info for any object — `ObjType` and `NumType` defaulted to 0, and `decodePropertyValue` fell through to `KindRaw`.

`Object.Unit` is a top-level field with its own JSON tag, so the hierarchical reader does parse it — that's why units were rendered correctly on the same announce that had `raw(N)` values.

## Why it shipped

The fix existed as commit `2c5c818` ("fix(acp2-cache): SaveByIdentity uses flat JSON to round-trip Meta") on the `feat/acp2-dm-cache-hotload` branch (PR #354). When #354 was closed-as-superseded during the ACP2 strict-spec close-out drive, the cherry-pick onto `feat/acp2-strict-spec-closeout` picked only 2 of 3 commits (`f64e1f0` initial DM cache + `2cd3456` identity-only), missing the third (round-trip fix). The umbrella PR #358 merged into main without it.

This PR ports `2c5c818`'s content to main + adds two regression tests covering the exact failure mode.

Closes #361.

## Fix

```go
// SaveByIdentity:
enc := json.NewEncoder(f)
enc.SetIndent("", "  ")
if err := enc.Encode(snap); err != nil { ... }

// LoadByIdentity:
var snap export.Snapshot
if err := json.NewDecoder(f).Decode(&snap); err != nil { ... }
```

Direct stdlib JSON, full `protocol.Object` struct fidelity, no exporter intermediate. ACP1 + Ember+ keep `export.WriteJSON` / `ReadJSON` for their IP-keyed `.cache/devices/<ip>/slot_<n>.json` files (those are part of the documented export contract; the identity-keyed DM cache is a private internal format).

## Tests

`internal/storage/identity_roundtrip_test.go` (new):

| Test | What it pins |
|---|---|
| `TestSaveLoadByIdentity_PreservesMetaAndContent` | One save → fresh `TreeStore` → load (cross-process simulation). Asserts `Meta`, `Unit`, `Path`, nested `optionsMap` all survive. |
| `TestSaveLoadByIdentity_MultiInvocationMerge` | Three-invocation flow (save slot 0 → load + append slot 1 → load). Asserts both slots' object content + Unit survive merge. |

Both green locally on Windows. Full suite still green.

## Live verification (pending)

After this PR lands, the producer needs a v14 binary built from main and the user's local cache cleared:

```
del .cache\dm\SHPIO@0.7.json
.\bin\dhs.exe consumer acp2 walk  10.100.0.103 --port 2072 --slot 0
.\bin\dhs.exe consumer acp2 walk  10.100.0.103 --port 2072 --slot 1
.\bin\dhs.exe consumer acp2 watch 10.100.0.103 --port 2072 --slot 1
```

Expected: enum/string/IPv4 announces decode typed (today already working), Number announces decode typed with unit suffix (e.g. `0.15 dBFS`), no `raw(N)` rows.

## Stack with #360

This sits independent of PR #360 (Event.Unit). Both are needed for the full "value + unit" experience the user wanted:

- **#360** adds `Event.Unit` so the watcher can render the suffix
- **#361** restores the type round-trip so the value itself decodes correctly

#361 should land first (it's the regression fix on main); #360 rebases trivially on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
