### PR TITLE
feat(dm-cache): per-card DM, one file per CardName@HwVer — ACP1 + ACP2 (closes #363)

### DIFF
--- a/cmd/dhs/cmd_watch.go
+++ b/cmd/dhs/cmd_watch.go
@@ -78,20 +78,20 @@ func runWatch(ctx context.Context, args []string) error {
 	defer cleanup()
 
 	// Load IP-keyed disk cache for instant label/unit resolution while
-	// walk runs. Key by watchCacheKey so ACP1 groups that re-use the
-	// same object-id space (control / status / alarm / identity / file
-	// / frame all addressable as 0..N within one slot) don't collide
+	// walk runs. Key by watchCacheKey so groups that re-use the same
+	// object-id space (control / status / alarm / identity / file /
+	// frame all addressable as 0..N within one slot) don't collide
 	// (refs #236).
 	//
-	// ACP2 deliberately skips this path — its DM cache is identity-
-	// keyed at .cache/dm/<identity>.json (DHS 2016 MasterView model,
-	// #353/#355) and is loaded into the plugin's WalkedTree directly
-	// in the block below. Letting the IP-keyed loader run for ACP2
-	// would emit a misleading "loaded N labels from cache" line backed
-	// by stale per-IP files even when the identity cache is current.
+	// ACP1 + ACP2 both skip this path — their DM caches are identity-
+	// keyed at .cache/dm/<CardName>@<HwVer>.json per DHS 2016
+	// MasterView (#353/#355/#363), loaded into each slot's tree
+	// directly in the block below. Letting the IP-keyed loader run
+	// would emit a misleading "loaded N labels from cache" line
+	// backed by stale per-IP files.
 	labelCache := map[string]string{}
 	unitCache := map[string]string{}
-	if cf.protocol != "acp2" && treeStore != nil && *slot >= 0 {
+	if cf.protocol != "acp2" && cf.protocol != "acp1" && treeStore != nil && *slot >= 0 {
 		if snap, lerr := treeStore.Load(host, *slot); lerr == nil && snap != nil {
 			for _, sd := range snap.Slots {
 				for _, o := range sd.Objects {
@@ -123,11 +123,14 @@ func runWatch(ctx context.Context, args []string) error {
 	// the DM cache is keyed by card identity (CardName@HwVersion),
 	// not by device-frame. Probe each slot we plan to watch, load
 	// that slot's DM file, seed the slot's tree. Two slots holding
-	// the same card share one DM file (loaded once, seeded twice
-	// from the same data) — DHS 2016 MasterView model.
+	// the same card share one DM file (loaded once, seeded into
+	// multiple slot trees) — DHS 2016 MasterView model.
 	//
-	// ACP2-only — other plugins keep the IP-keyed cache today.
-	if cf.protocol == "acp2" && treeStore != nil && !walkScope.empty() {
+	// Protocol-agnostic — any plugin satisfying both IdentityProbe +
+	// SeedTreeFromCachedObjects participates. ACP1 + ACP2 do today
+	// (#363); Ember+ has no per-slot card concept and stays on its
+	// existing path.
+	if treeStore != nil && !walkScope.empty() {
 		if probe, hot := plug.(interface {
 			IdentityProbe(context.Context, int) (string, error)
 			SeedTreeFromCachedObjects(slot int, objs []protocol.Object)
@@ -511,24 +514,21 @@ func walkSlotAndCache(ctx context.Context, plug protocol.Protocol, host, proto s
 
 // saveSlotCache routes a walked slot to the right on-disk cache.
 //
-// ACP2 (per DHS 2016 MasterView): one DM file per CARD identity at
+// Per DHS 2016 MasterView (#363): any plugin that satisfies the
+// identityProber contract gets one DM file per CARD identity at
 // `.cache/dm/<CardName>@<HwVer>.json`. Each file contains the schema
 // for ONE card type — single slot dump. Two slots holding the same
 // card share the same DM file (loaded once, reused). Slot index +
 // IP are NOT in the path or key.
 //
-// Other protocols (ACP1, Ember+) keep the legacy IP-keyed layout at
-// `.cache/devices/<ip>/slot_<n>.json` — those plugins have no
-// identity probe contract today.
+// ACP1 + ACP2 satisfy the contract today. Ember+ doesn't (no
+// per-slot card concept) and falls back to the legacy IP-keyed
+// `.cache/devices/<ip>/slot_<n>.json` layout.
 func saveSlotCache(ctx context.Context, prober identityProber, host, proto string, slot int, objs []protocol.Object) {
 	if treeStore == nil {
 		return
 	}
-	if proto == "acp2" {
-		if prober == nil {
-			fmt.Fprintf(os.Stderr, "warning: acp2 plugin missing IdentityProbe; slot %d not cached\n", slot)
-			return
-		}
+	if prober != nil {
 		identity, perr := prober.IdentityProbe(ctx, slot)
 		if perr != nil || identity == "" {
 			fmt.Fprintf(os.Stderr, "warning: identity probe failed; slot %d not cached: %v\n", slot, perr)

--- a/cmd/dhs/cmd_watch.go
+++ b/cmd/dhs/cmd_watch.go
@@ -130,6 +130,7 @@ func runWatch(ctx context.Context, args []string) error {
 	// SeedTreeFromCachedObjects participates. ACP1 + ACP2 do today
 	// (#363); Ember+ has no per-slot card concept and stays on its
 	// existing path.
+	cachedSlots := map[int]struct{}{}
 	if treeStore != nil && !walkScope.empty() {
 		if probe, hot := plug.(interface {
 			IdentityProbe(context.Context, int) (string, error)
@@ -152,6 +153,7 @@ func runWatch(ctx context.Context, args []string) error {
 				}
 				probe.SeedTreeFromCachedObjects(s, snap.Slots[0].Objects)
 				loaded[identity] = len(snap.Slots[0].Objects)
+				cachedSlots[s] = struct{}{}
 				fmt.Fprintf(os.Stderr, "DM cache hit %q — seeded slot %d with %d objects\n",
 					identity, s, len(snap.Slots[0].Objects))
 			}
@@ -160,10 +162,15 @@ func runWatch(ctx context.Context, args []string) error {
 	}
 
 	// Walk in background to populate label/type cache. Announces start
-	// immediately — labels resolve as the tree fills.
-	if !walkScope.empty() {
+	// immediately — labels resolve as the tree fills. Slots that hit
+	// the DM cache above already have their tree populated; re-walking
+	// them is pure overhead — 49k+ getObject round-trips on a CONVERT
+	// Hybrid card — and starves the announce path on a single AN2/TCP
+	// socket. Drop those from the scope.
+	walkBackground := walkScope.withoutSlots(cachedSlots)
+	if !walkBackground.empty() {
 		go func() {
-			runWalkScope(ctx, plug, host, cf.protocol, walkScope)
+			runWalkScope(ctx, plug, host, cf.protocol, walkBackground)
 		}()
 	}
 
@@ -326,8 +333,8 @@ func runWatch(ctx context.Context, args []string) error {
 			}
 			fmt.Printf("%s  %-18s  %-30s  %-20s  %-3s  %-7s  %s%s%s\n",
 				ev.Timestamp.Format("15:04:05"),
-				truncate(oid, 18),
-				truncate(ev.Path, 30),
+				oid,
+				ev.Path,
 				truncate(label, 20),
 				accessStr(ev.Access),
 				fr,
@@ -400,6 +407,31 @@ const (
 )
 
 func (s walkScope) empty() bool { return s.mode == walkNone }
+
+// withoutSlots returns a copy of the scope with the listed slots removed.
+// walkList narrows; walkAll degrades to walkList of "every slot" — but
+// since walkAll defers slot enumeration to GetDeviceInfo, callers using
+// it will only see the filter applied if they list slots explicitly.
+// walkNone stays empty.
+func (s walkScope) withoutSlots(skip map[int]struct{}) walkScope {
+	if len(skip) == 0 || s.mode == walkNone {
+		return s
+	}
+	if s.mode != walkList {
+		return s
+	}
+	kept := make([]int, 0, len(s.slots))
+	for _, sl := range s.slots {
+		if _, drop := skip[sl]; drop {
+			continue
+		}
+		kept = append(kept, sl)
+	}
+	if len(kept) == 0 {
+		return walkScope{mode: walkNone}
+	}
+	return walkScope{mode: walkList, slots: kept}
+}
 
 // parseWalkScope folds the --slot, --slots, and --no-walk flags into a
 // single decision. Mutually exclusive combinations raise a clear error.

--- a/cmd/dhs/cmd_watch.go
+++ b/cmd/dhs/cmd_watch.go
@@ -119,33 +119,40 @@ func runWatch(ctx context.Context, args []string) error {
 		}
 	}
 
-	// Identity-keyed DM cache hot-load (#353): probe device identity
-	// (Card Name + Hardware Version on slot 0, sub-second), look up
-	// the persisted DM by identity, and seed the plugin's in-memory
-	// tree BEFORE Subscribe fires. The announce decoder then resolves
-	// types + enum labels from frame 1 — eliminates the cold-start
-	// "idx N" gap on slot 1 watches where the fresh walk takes 30-60s.
+	// Per-card DM hot-load: each slot can host a different card, and
+	// the DM cache is keyed by card identity (CardName@HwVersion),
+	// not by device-frame. Probe each slot we plan to watch, load
+	// that slot's DM file, seed the slot's tree. Two slots holding
+	// the same card share one DM file (loaded once, seeded twice
+	// from the same data) — DHS 2016 MasterView model.
 	//
 	// ACP2-only — other plugins keep the IP-keyed cache today.
-	if cf.protocol == "acp2" && treeStore != nil {
+	if cf.protocol == "acp2" && treeStore != nil && !walkScope.empty() {
 		if probe, hot := plug.(interface {
-			IdentityProbe(context.Context) (string, error)
+			IdentityProbe(context.Context, int) (string, error)
 			SeedTreeFromCachedObjects(slot int, objs []protocol.Object)
 		}); hot {
-			identity, perr := probe.IdentityProbe(ctx)
-			if perr == nil && identity != "" {
-				if snap, lerr := treeStore.LoadByIdentity(identity); lerr == nil && snap != nil {
-					seeded := 0
-					for _, sd := range snap.Slots {
-						probe.SeedTreeFromCachedObjects(sd.Slot, sd.Objects)
-						seeded += len(sd.Objects)
-					}
-					if seeded > 0 {
-						fmt.Fprintf(os.Stderr, "DM cache hit %q — seeded %d objects across %d slot(s)\n",
-							identity, seeded, len(snap.Slots))
-					}
+			loaded := map[string]int{} // identity -> objects (for log line)
+			seenSlots := map[int]struct{}{}
+			for _, s := range hotLoadSlots(ctx, plug, walkScope) {
+				if _, dup := seenSlots[s]; dup {
+					continue
 				}
+				seenSlots[s] = struct{}{}
+				identity, perr := probe.IdentityProbe(ctx, s)
+				if perr != nil || identity == "" {
+					continue
+				}
+				snap, lerr := treeStore.LoadByIdentity(identity)
+				if lerr != nil || snap == nil || len(snap.Slots) == 0 {
+					continue
+				}
+				probe.SeedTreeFromCachedObjects(s, snap.Slots[0].Objects)
+				loaded[identity] = len(snap.Slots[0].Objects)
+				fmt.Fprintf(os.Stderr, "DM cache hit %q — seeded slot %d with %d objects\n",
+					identity, s, len(snap.Slots[0].Objects))
 			}
+			_ = loaded
 		}
 	}
 
@@ -427,6 +434,35 @@ func parseWalkScope(slot int, slotsArg string, noWalk bool) (walkScope, error) {
 	return walkScope{mode: walkNone}, nil
 }
 
+// hotLoadSlots returns the slot list to hot-load DM for, derived from
+// the walk scope. walkList → the listed slots; walkAll → every present
+// slot per GetSlotInfo; walkNone → empty (no hot-load needed since no
+// subscription scope is set). Errors are best-effort: failure to read
+// device info just returns whatever's already known.
+func hotLoadSlots(ctx context.Context, plug protocol.Protocol, scope walkScope) []int {
+	switch scope.mode {
+	case walkList:
+		out := make([]int, len(scope.slots))
+		copy(out, scope.slots)
+		return out
+	case walkAll:
+		info, err := plug.GetDeviceInfo(ctx)
+		if err != nil {
+			return nil
+		}
+		out := make([]int, 0, info.NumSlots)
+		for s := 0; s < info.NumSlots; s++ {
+			si, serr := plug.GetSlotInfo(ctx, s)
+			if serr != nil || si.Status != protocol.SlotPresent {
+				continue
+			}
+			out = append(out, s)
+		}
+		return out
+	}
+	return nil
+}
+
 // runWalkScope executes the walk decision against the live plugin.
 // Errors print to stderr and do not abort other slots in the batch.
 func runWalkScope(ctx context.Context, plug protocol.Protocol, host, proto string, scope walkScope) {
@@ -454,11 +490,13 @@ func runWalkScope(ctx context.Context, plug protocol.Protocol, host, proto strin
 }
 
 // identityProber is the optional contract a Protocol plugin satisfies
-// to participate in identity-keyed MasterView caching. ACP2 implements
-// it via Plugin.IdentityProbe (Card Name + Hardware Version on slot 0).
-// ACP1 / Ember+ do not — they fall back to IP-keyed storage.
+// to participate in per-card MasterView caching. The probe walks ONE
+// slot's identity scope (Card Name + Hardware Version objects in
+// ROOT_NODE_V2.BOARD) and returns "<CardName>@<HwVer>". ACP2
+// implements it; ACP1 / Ember+ have no identity contract today and
+// fall back to IP-keyed storage.
 type identityProber interface {
-	IdentityProbe(ctx context.Context) (string, error)
+	IdentityProbe(ctx context.Context, slot int) (string, error)
 }
 
 func walkSlotAndCache(ctx context.Context, plug protocol.Protocol, host, proto string, slot int) {
@@ -473,15 +511,15 @@ func walkSlotAndCache(ctx context.Context, plug protocol.Protocol, host, proto s
 
 // saveSlotCache routes a walked slot to the right on-disk cache.
 //
-// ACP2 has a stable device identity probe (Card Name + Hardware Version
-// on slot 0), so its cache is keyed by identity and lives in one
-// multi-slot file at .cache/dm/<identity>.json — DHS 2016 MasterView
-// model. Walking any slot of the frame accumulates into the same file.
-// IP-keyed cache is NOT written for ACP2 (#353, #355).
+// ACP2 (per DHS 2016 MasterView): one DM file per CARD identity at
+// `.cache/dm/<CardName>@<HwVer>.json`. Each file contains the schema
+// for ONE card type — single slot dump. Two slots holding the same
+// card share the same DM file (loaded once, reused). Slot index +
+// IP are NOT in the path or key.
 //
 // Other protocols (ACP1, Ember+) keep the legacy IP-keyed layout at
-// .cache/devices/<ip>/slot_<n>.json — those plugins have no identity
-// probe contract today.
+// `.cache/devices/<ip>/slot_<n>.json` — those plugins have no
+// identity probe contract today.
 func saveSlotCache(ctx context.Context, prober identityProber, host, proto string, slot int, objs []protocol.Object) {
 	if treeStore == nil {
 		return
@@ -491,7 +529,7 @@ func saveSlotCache(ctx context.Context, prober identityProber, host, proto strin
 			fmt.Fprintf(os.Stderr, "warning: acp2 plugin missing IdentityProbe; slot %d not cached\n", slot)
 			return
 		}
-		identity, perr := prober.IdentityProbe(ctx)
+		identity, perr := prober.IdentityProbe(ctx, slot)
 		if perr != nil || identity == "" {
 			fmt.Fprintf(os.Stderr, "warning: identity probe failed; slot %d not cached: %v\n", slot, perr)
 			return
@@ -506,39 +544,22 @@ func saveSlotCache(ctx context.Context, prober identityProber, host, proto strin
 	}
 }
 
-// saveIdentityCache loads the existing identity-keyed DM (if any),
-// merges the just-walked slot into it, and saves the result. So
-// successive walks of slot 0 then slot 1 build up a single
-// multi-slot cache file keyed by device identity.
+// saveIdentityCache writes a single-slot DM file keyed by card
+// identity. The DM is the schema of ONE card type — multi-slot
+// merging is gone (different slots can hold different cards →
+// different files; same card in multiple slots → same file written
+// once). Slot/frame composition is a runtime concern, not in the DM.
 func saveIdentityCache(store *storage.TreeStore, identity, host, proto string, slot int, objs []protocol.Object) error {
-	existing, _ := store.LoadByIdentity(identity)
 	now := time.Now().UTC()
-	if existing == nil {
-		existing = &export.Snapshot{
-			Device:    export.DeviceInfo{IP: host, Protocol: proto},
-			Generator: "dhs dm-cache",
-			CreatedAt: now,
-		}
-	}
-	// Replace or append this slot's dump.
-	updated := false
-	for i := range existing.Slots {
-		if existing.Slots[i].Slot == slot {
-			existing.Slots[i] = export.SlotDump{
-				Slot:     slot,
-				WalkedAt: now,
-				Objects:  objs,
-			}
-			updated = true
-			break
-		}
-	}
-	if !updated {
-		existing.Slots = append(existing.Slots, export.SlotDump{
+	snap := &export.Snapshot{
+		Device:    export.DeviceInfo{IP: host, Protocol: proto},
+		Generator: "dhs dm-cache",
+		CreatedAt: now,
+		Slots: []export.SlotDump{{
 			Slot:     slot,
 			WalkedAt: now,
 			Objects:  objs,
-		})
+		}},
 	}
-	return store.SaveByIdentity(identity, existing)
+	return store.SaveByIdentity(identity, snap)
 }

--- a/cmd/dhs/cmd_watch_cache_test.go
+++ b/cmd/dhs/cmd_watch_cache_test.go
@@ -10,15 +10,22 @@ import (
 	"dhs/internal/storage"
 )
 
-// fakeProber satisfies identityProber for the ACP2 routing tests.
+// fakeProber satisfies the new per-slot identityProber contract.
+// identityBySlot lets each slot return a different card identity
+// (different cards in different slots), and identity is the default
+// when no per-slot override is set.
 type fakeProber struct {
-	identity string
-	err      error
-	calls    int
+	identity       string
+	identityBySlot map[int]string
+	err            error
+	calls          int
 }
 
-func (f *fakeProber) IdentityProbe(_ context.Context) (string, error) {
+func (f *fakeProber) IdentityProbe(_ context.Context, slot int) (string, error) {
 	f.calls++
+	if id, ok := f.identityBySlot[slot]; ok {
+		return id, f.err
+	}
 	return f.identity, f.err
 }
 
@@ -39,11 +46,9 @@ func makeObjs() []protocol.Object {
 	}
 }
 
-// TestSaveSlotCache_ACP2_WritesIdentityKeyedOnly pins the #355 contract:
-// the ACP2 cache lives in .cache/dm/<identity>.json (DHS 2016 MasterView
-// model). The legacy IP-keyed file at .cache/devices/<ip>/slot_<n>.json
-// must NOT be created for ACP2 — even though TreeStore.Save still
-// supports it for ACP1 / Ember+.
+// TestSaveSlotCache_ACP2_WritesIdentityKeyedOnly: ACP2 cache lives at
+// .cache/dm/<CardName>@<HwVer>.json. No IP-keyed file. Identity probe
+// is called with the watched slot.
 func TestSaveSlotCache_ACP2_WritesIdentityKeyedOnly(t *testing.T) {
 	root := withTempStore(t)
 	prober := &fakeProber{identity: "SHPRM1@0.7"}
@@ -63,16 +68,14 @@ func TestSaveSlotCache_ACP2_WritesIdentityKeyedOnly(t *testing.T) {
 	}
 }
 
-// TestSaveSlotCache_ACP2_NilProber_NoFile guards against silent fall-
-// through if a future plugin variant forgets to implement IdentityProbe.
-// For ACP2 with a nil prober, no file should be created (warn-only).
+// TestSaveSlotCache_ACP2_NilProber_NoFile: missing IdentityProbe →
+// warn, no file.
 func TestSaveSlotCache_ACP2_NilProber_NoFile(t *testing.T) {
 	root := withTempStore(t)
 
 	saveSlotCache(context.Background(), nil, "10.100.0.103", "acp2", 1, makeObjs())
 
-	dmDir := filepath.Join(root, "dm")
-	if _, err := os.Stat(dmDir); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(root, "dm")); !os.IsNotExist(err) {
 		t.Errorf("dm dir MUST NOT exist when prober is nil, err=%v", err)
 	}
 	ipPath := filepath.Join(root, "devices", "10.100.0.103", "slot_1.json")
@@ -81,10 +84,8 @@ func TestSaveSlotCache_ACP2_NilProber_NoFile(t *testing.T) {
 	}
 }
 
-// TestSaveSlotCache_ACP2_EmptyIdentity_NoFile covers the case where the
-// probe runs but returns "" (e.g. device offline / Card Name label
-// missing). We refuse to write under an empty identity — there is no
-// safe filename for it.
+// TestSaveSlotCache_ACP2_EmptyIdentity_NoFile: probe returns "" → no
+// file written (no safe filename).
 func TestSaveSlotCache_ACP2_EmptyIdentity_NoFile(t *testing.T) {
 	root := withTempStore(t)
 	prober := &fakeProber{identity: ""}
@@ -96,8 +97,8 @@ func TestSaveSlotCache_ACP2_EmptyIdentity_NoFile(t *testing.T) {
 	}
 }
 
-// TestSaveSlotCache_NonACP2_WritesIPKeyed verifies the ACP1 / Ember+
-// path is preserved: no identity probe used, IP-keyed file written.
+// TestSaveSlotCache_NonACP2_WritesIPKeyed: ACP1 / Ember+ keep
+// .cache/devices/<ip>/slot_<n>.json (no identity probe used).
 func TestSaveSlotCache_NonACP2_WritesIPKeyed(t *testing.T) {
 	root := withTempStore(t)
 
@@ -112,14 +113,16 @@ func TestSaveSlotCache_NonACP2_WritesIPKeyed(t *testing.T) {
 	}
 }
 
-// TestSaveSlotCache_ACP2_MultiSlotMerge pins the multi-slot merge
-// contract: walking slot 0 then slot 1 of the same device produces a
-// SINGLE identity-keyed file containing both slots, not two separate
-// files. This is how a frame with N populated slots accumulates into
-// one MasterView.
-func TestSaveSlotCache_ACP2_MultiSlotMerge(t *testing.T) {
+// TestSaveSlotCache_ACP2_DifferentCardsTwoFiles pins the per-card DM
+// contract: a frame with two slots holding DIFFERENT cards produces
+// TWO DM files, one per card identity. The legacy multi-slot merge
+// (one file with both slots inside) is gone.
+func TestSaveSlotCache_ACP2_DifferentCardsTwoFiles(t *testing.T) {
 	root := withTempStore(t)
-	prober := &fakeProber{identity: "SHPRM1@0.7"}
+	prober := &fakeProber{identityBySlot: map[int]string{
+		0: "SHPRM1@0.7", // controller card
+		1: "SHPIO@0.7",  // I/O card
+	}}
 	ctx := context.Background()
 
 	slot0 := []protocol.Object{{Slot: 0, ID: 1, Label: "BOARD"}}
@@ -128,23 +131,47 @@ func TestSaveSlotCache_ACP2_MultiSlotMerge(t *testing.T) {
 	saveSlotCache(ctx, prober, "10.41.40.4", "acp2", 0, slot0)
 	saveSlotCache(ctx, prober, "10.41.40.4", "acp2", 1, slot1)
 
-	snap, err := treeStore.LoadByIdentity("SHPRM1@0.7")
-	if err != nil || snap == nil {
-		t.Fatalf("LoadByIdentity: snap=%v err=%v", snap, err)
-	}
-	if len(snap.Slots) != 2 {
-		t.Fatalf("merged file should hold 2 slots, got %d", len(snap.Slots))
-	}
-	gotSlots := map[int]bool{}
-	for _, sd := range snap.Slots {
-		gotSlots[sd.Slot] = true
-	}
-	if !gotSlots[0] || !gotSlots[1] {
-		t.Errorf("merged file missing slot(s): %v", gotSlots)
+	for _, id := range []string{"SHPRM1@0.7", "SHPIO@0.7"} {
+		snap, err := treeStore.LoadByIdentity(id)
+		if err != nil || snap == nil {
+			t.Fatalf("LoadByIdentity(%q): snap=%v err=%v", id, snap, err)
+		}
+		if len(snap.Slots) != 1 {
+			t.Errorf("DM file %q must hold ONE slot dump (one card schema); got %d slots",
+				id, len(snap.Slots))
+		}
 	}
 
-	// Sanity: no per-slot files appeared on the IP-keyed path.
+	// Sanity: no IP-keyed leakage.
 	if _, err := os.Stat(filepath.Join(root, "devices")); !os.IsNotExist(err) {
 		t.Errorf("devices/ dir MUST NOT exist for acp2, err=%v", err)
+	}
+}
+
+// TestSaveSlotCache_ACP2_SameCardTwoSlots_OneFile pins the dedup
+// behaviour: two slots holding the SAME card → one DM file. The
+// second save overwrites the first with identical data; loading from
+// either slot picks up the same schema.
+func TestSaveSlotCache_ACP2_SameCardTwoSlots_OneFile(t *testing.T) {
+	root := withTempStore(t)
+	prober := &fakeProber{identity: "SHPIO@0.7"} // every slot returns this card
+	ctx := context.Background()
+
+	slot0Objs := []protocol.Object{{Slot: 0, ID: 70232, Label: "Backup Input"}}
+	slot1Objs := []protocol.Object{{Slot: 1, ID: 70232, Label: "Backup Input"}}
+
+	saveSlotCache(ctx, prober, "10.41.40.4", "acp2", 0, slot0Objs)
+	saveSlotCache(ctx, prober, "10.41.40.4", "acp2", 1, slot1Objs)
+
+	files, err := os.ReadDir(filepath.Join(root, "dm"))
+	if err != nil {
+		t.Fatalf("read dm dir: %v", err)
+	}
+	if len(files) != 1 {
+		names := make([]string, 0, len(files))
+		for _, f := range files {
+			names = append(names, f.Name())
+		}
+		t.Errorf("same-card-two-slots must produce 1 DM file, got %d: %v", len(files), names)
 	}
 }

--- a/cmd/dhs/cmd_watch_cache_test.go
+++ b/cmd/dhs/cmd_watch_cache_test.go
@@ -68,19 +68,23 @@ func TestSaveSlotCache_ACP2_WritesIdentityKeyedOnly(t *testing.T) {
 	}
 }
 
-// TestSaveSlotCache_ACP2_NilProber_NoFile: missing IdentityProbe →
-// warn, no file.
-func TestSaveSlotCache_ACP2_NilProber_NoFile(t *testing.T) {
+// TestSaveSlotCache_NilProber_FallsBackToIPKeyed: when the plugin
+// does NOT satisfy identityProber (nil), the cache routing falls
+// through to the legacy IP-keyed path regardless of the protocol
+// name. This is how Ember+ keeps working today and how any future
+// protocol joins gracefully — implement IdentityProbe to opt in
+// to per-card MasterView, otherwise IP-keyed by default.
+func TestSaveSlotCache_NilProber_FallsBackToIPKeyed(t *testing.T) {
 	root := withTempStore(t)
 
-	saveSlotCache(context.Background(), nil, "10.100.0.103", "acp2", 1, makeObjs())
+	saveSlotCache(context.Background(), nil, "10.100.0.103", "emberplus", 1, makeObjs())
 
 	if _, err := os.Stat(filepath.Join(root, "dm")); !os.IsNotExist(err) {
 		t.Errorf("dm dir MUST NOT exist when prober is nil, err=%v", err)
 	}
 	ipPath := filepath.Join(root, "devices", "10.100.0.103", "slot_1.json")
-	if _, err := os.Stat(ipPath); !os.IsNotExist(err) {
-		t.Errorf("IP-keyed file MUST NOT exist for acp2 fallback, err=%v", err)
+	if _, err := os.Stat(ipPath); err != nil {
+		t.Errorf("IP-keyed file expected as fallback, got err=%v", err)
 	}
 }
 

--- a/internal/acp1/consumer/browser.go
+++ b/internal/acp1/consumer/browser.go
@@ -209,6 +209,10 @@ func toProtocolObject(d *codec.DecodedObject, slot int, group codec.ObjGroup, id
 		// formatted number always produces one clean space.
 		Unit:   strings.TrimSpace(d.Unit),
 		Access: d.Access,
+		// Persist the precise ACP1 wire type so per-card DM cache
+		// reloads (SeedTreeFromCachedObjects) can rebuild ACPTypes
+		// losslessly — Kind alone collapses Integer + Long to KindInt.
+		Meta: map[string]any{"acp1_type": float64(d.Type)},
 	}
 	switch d.Type {
 	case codec.TypeInteger, codec.TypeLong:

--- a/internal/acp1/consumer/identity.go
+++ b/internal/acp1/consumer/identity.go
@@ -9,6 +9,69 @@ import (
 	"dhs/internal/protocol"
 )
 
+// SeedTreeFromCachedObjects rebuilds an in-memory SlotTree from a
+// previously-walked + persisted snapshot and inserts it into the
+// per-slot tree cache. Mirrors the ACP2 contract so cmd/dhs/cmd_watch.go
+// can hot-load DM for both protocols via the same (probe + load + seed)
+// pattern.
+//
+// Used by the watch CLI on startup (#363): probe per-slot identity,
+// LoadByIdentity the matching DM, hand the objects to this method,
+// then Subscribe. Without this the cold-start window between Subscribe
+// firing and the background walk completing produces label-less rows.
+//
+// Re-seeding the same slot is safe — the cache Put replaces the prior
+// entry. Existing labels map is rebuilt from o.Group + o.Label.
+func (p *Plugin) SeedTreeFromCachedObjects(slot int, objs []protocol.Object) {
+	p.mu.Lock()
+	if p.trees == nil {
+		p.trees = newSlotTreeCache(defaultCacheConfig().MaxSize, defaultCacheConfig().TTL)
+	}
+	cache := p.trees
+	p.mu.Unlock()
+
+	tree := &SlotTree{
+		Slot:    slot,
+		Objects: make([]protocol.Object, 0, len(objs)),
+		Labels:  make(map[string]map[string]int, 8),
+	}
+	for i, o := range objs {
+		tree.Objects = append(tree.Objects, o)
+		if o.Group == "" || o.Label == "" {
+			continue
+		}
+		g, ok := tree.Labels[o.Group]
+		if !ok {
+			g = make(map[string]int, len(objs)/4+1)
+			tree.Labels[o.Group] = g
+		}
+		g[o.Label] = i
+	}
+	cache.Put(slot, tree)
+}
+
+// IdentityProbe returns the per-card MasterView identity string
+// "<Model>@<HwRev>" for the given slot. Wraps GetIdentity (which
+// itself fetches the (Model, SwRev, HwRev) triple via three fixed-pid
+// getObject calls on group=1) and joins the two fields the DM cache
+// keys on. Same shape as ACP2's IdentityProbe so cmd/dhs/cmd_watch.go
+// treats both protocols identically (#363 — per-card DM, agnostic of
+// IP / slot index).
+//
+// Returns "" with err when Model is empty (NAK on Card Label probe);
+// HwRev empty is tolerated and produces "<Model>@" — the file just
+// has an empty hw component.
+func (p *Plugin) IdentityProbe(ctx context.Context, slot int) (string, error) {
+	id, err := p.GetIdentity(ctx, slot)
+	if err != nil {
+		return "", fmt.Errorf("acp1: identity probe slot=%d: %w", slot, err)
+	}
+	if id.Model == "" {
+		return "", fmt.Errorf("acp1: identity probe slot=%d: empty Model", slot)
+	}
+	return fmt.Sprintf("%s@%s", id.Model, id.HwRev), nil
+}
+
 // GetIdentity probes the ACP1 identity group (group=1) for the (Model,
 // SwRev, HwRev) triple. Per spec p.20 the identity group has 8 fixed
 // IDs; we read three:

--- a/internal/acp1/consumer/identity.go
+++ b/internal/acp1/consumer/identity.go
@@ -31,12 +31,18 @@ func (p *Plugin) SeedTreeFromCachedObjects(slot int, objs []protocol.Object) {
 	p.mu.Unlock()
 
 	tree := &SlotTree{
-		Slot:    slot,
-		Objects: make([]protocol.Object, 0, len(objs)),
-		Labels:  make(map[string]map[string]int, 8),
+		Slot:     slot,
+		Objects:  make([]protocol.Object, 0, len(objs)),
+		ACPTypes: make([]codec.ObjectType, 0, len(objs)),
+		Labels:   make(map[string]map[string]int, 8),
 	}
 	for i, o := range objs {
 		tree.Objects = append(tree.Objects, o)
+		// ACPTypes must stay parallel to Objects so findObject's index
+		// access does not panic. Reuse the same kind→ACPType mapping
+		// the DM-library seeder uses; Meta["acp1_type"] (when persisted
+		// by browser.go) wins over the lossy Kind fallback.
+		tree.ACPTypes = append(tree.ACPTypes, kindToACPType(o.Kind, o.Meta))
 		if o.Group == "" || o.Label == "" {
 			continue
 		}
@@ -76,6 +82,9 @@ func (p *Plugin) IdentityProbe(ctx context.Context, slot int) (string, error) {
 	ver := id.SwRev
 	if ver == "" {
 		ver = id.HwRev
+	}
+	if ver == "" {
+		return "", fmt.Errorf("acp1: identity probe slot=%d: empty Version (SwRev + HwRev) on Model=%q", slot, id.Model)
 	}
 	return fmt.Sprintf("%s@%s", id.Model, ver), nil
 }

--- a/internal/acp1/consumer/identity.go
+++ b/internal/acp1/consumer/identity.go
@@ -51,16 +51,20 @@ func (p *Plugin) SeedTreeFromCachedObjects(slot int, objs []protocol.Object) {
 }
 
 // IdentityProbe returns the per-card MasterView identity string
-// "<Model>@<HwRev>" for the given slot. Wraps GetIdentity (which
-// itself fetches the (Model, SwRev, HwRev) triple via three fixed-pid
-// getObject calls on group=1) and joins the two fields the DM cache
-// keys on. Same shape as ACP2's IdentityProbe so cmd/dhs/cmd_watch.go
-// treats both protocols identically (#363 — per-card DM, agnostic of
-// IP / slot index).
+// "<Model>@<Version>" for the given slot. Wraps GetIdentity (which
+// fetches the (Model, SwRev, HwRev) triple via three fixed-pid
+// getObject calls on group=1). Same shape as ACP2's IdentityProbe
+// so cmd/dhs/cmd_watch.go treats both protocols identically (#363).
 //
-// Returns "" with err when Model is empty (NAK on Card Label probe);
-// HwRev empty is tolerated and produces "<Model>@" — the file just
-// has an empty hw component.
+// Version selection: prefer SwRev (software / firmware revision —
+// what actually changes the schema), fall back to HwRev when SwRev
+// is empty. Per user observation 2026-05-09: "card name and product
+// version. hardware or software are available". The same product
+// across two firmware revs gets two DM files (different schemas);
+// across two hardware revs at same firmware shares one (assuming
+// the firmware exposes the same schema).
+//
+// Returns "" with err when Model is empty (NAK on Card Label probe).
 func (p *Plugin) IdentityProbe(ctx context.Context, slot int) (string, error) {
 	id, err := p.GetIdentity(ctx, slot)
 	if err != nil {
@@ -69,7 +73,11 @@ func (p *Plugin) IdentityProbe(ctx context.Context, slot int) (string, error) {
 	if id.Model == "" {
 		return "", fmt.Errorf("acp1: identity probe slot=%d: empty Model", slot)
 	}
-	return fmt.Sprintf("%s@%s", id.Model, id.HwRev), nil
+	ver := id.SwRev
+	if ver == "" {
+		ver = id.HwRev
+	}
+	return fmt.Sprintf("%s@%s", id.Model, ver), nil
 }
 
 // GetIdentity probes the ACP1 identity group (group=1) for the (Model,

--- a/internal/acp1/consumer/plugin.go
+++ b/internal/acp1/consumer/plugin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -632,6 +633,13 @@ func findObject(tree *SlotTree, group codec.ObjGroup, id byte) (protocol.Object,
 	gname := group.String()
 	for i, o := range tree.Objects {
 		if o.Group == gname && o.ID == int(id) {
+			// Defensive bound check: a seeder that forgot to populate
+			// ACPTypes parallel to Objects would otherwise panic on
+			// every announce. Treat a missing entry as "type unknown"
+			// and fall back to the wrapper's decodeByGroup branch.
+			if i >= len(tree.ACPTypes) {
+				return o, 0, false
+			}
 			return o, tree.ACPTypes[i], true
 		}
 	}
@@ -705,6 +713,19 @@ func (p *Plugin) Subscribe(req protocol.ValueRequest, fn protocol.EventFunc) err
 		if obj, acpType, found := findObject(tree, msg.ObjGroup, msg.ObjID); found {
 			ev.Label = obj.Label
 			ev.Unit = obj.Unit
+			ev.Access = obj.Access
+			// Build the path the same way ACP2 does: dot-joined hierarchy
+			// ending in the leaf label. ACP1's walked object stores
+			// Path=[<group>] only (flat model); append the label so the
+			// watch column shows e.g. "control.AUDIO PROC AMP" instead
+			// of just "control".
+			pathParts := append([]string(nil), obj.Path...)
+			if obj.Label != "" {
+				pathParts = append(pathParts, obj.Label)
+			}
+			if len(pathParts) > 0 {
+				ev.Path = strings.Join(pathParts, ".")
+			}
 			if val, derr := DecodeValueBytes(obj, acpType, msg.Value); derr == nil {
 				ev.Value = val
 				// Keep the cached tree in sync with live events so

--- a/internal/acp2/consumer/plugin.go
+++ b/internal/acp2/consumer/plugin.go
@@ -342,26 +342,26 @@ func (p *Plugin) Walk(ctx context.Context, slot int) ([]protocol.Object, error) 
 // Card Name is hard-required. Probe fails iff both versions and
 // Card Name are missing or the walk itself fails.
 func (p *Plugin) IdentityProbe(ctx context.Context, slot int) (string, error) {
-	objs, err := p.Walk(ctx, slot)
+	p.mu.Lock()
+	s := p.session
+	p.mu.Unlock()
+	if s == nil {
+		return "", protocol.ErrNotConnected
+	}
+	walker := NewWalker(s, p.logger)
+
+	// Targeted walk of BOARD + IDENTITY only — ~30 getObject calls vs
+	// 49k for a full Walk. Critical: this runs at watch start, before
+	// announces flow. A full Walk here monopolised the AN2/TCP socket
+	// on big cards (CONVERT Hybrid 49 827 objs) and triggered the
+	// keepalive dead-man at ~60 s.
+	labels, err := walker.WalkIdentity(ctx, slot)
 	if err != nil {
 		return "", fmt.Errorf("acp2: identity probe walk(slot=%d): %w", slot, err)
 	}
-	cardName := ""
-	productVer := ""
-	hwVer := ""
-	for _, o := range objs {
-		if o.Value.Kind != protocol.KindString {
-			continue
-		}
-		switch o.Label {
-		case "Card Name":
-			cardName = o.Value.Str
-		case "Product Version":
-			productVer = o.Value.Str
-		case "Hardware Version":
-			hwVer = o.Value.Str
-		}
-	}
+	cardName := labels["Card Name"]
+	productVer := labels["Product Version"]
+	hwVer := labels["Hardware Version"]
 	if cardName == "" {
 		return "", fmt.Errorf("acp2: identity probe — missing Card Name on slot %d", slot)
 	}
@@ -543,6 +543,11 @@ func (p *Plugin) Subscribe(req protocol.ValueRequest, fn protocol.EventFunc) err
 					treeIdx = ti
 					ev.Label = tobj.Label
 					ev.Unit = tobj.Unit
+					ev.Group = tobj.Group
+					ev.Access = tobj.Access
+					if len(tobj.Path) > 0 {
+						ev.Path = strings.Join(tobj.Path, ".")
+					}
 					break
 				}
 			}

--- a/internal/acp2/consumer/plugin.go
+++ b/internal/acp2/consumer/plugin.go
@@ -360,10 +360,14 @@ func (p *Plugin) IdentityProbe(ctx context.Context, slot int) (string, error) {
 			}
 		}
 	}
-	if cardName == "" || hwVersion == "" {
-		return "", fmt.Errorf("acp2: identity probe — missing Card Name (%q) or Hardware Version (%q) on slot %d",
-			cardName, hwVersion, slot)
+	if cardName == "" {
+		return "", fmt.Errorf("acp2: identity probe — missing Card Name on slot %d", slot)
 	}
+	// Hardware Version may be empty on some product fixtures (e.g.
+	// CONVERT Hybrid on producer .103 slot 1 reports empty HW Ver).
+	// Match ACP1's tolerance — Model is hard-required, HwRev is
+	// best-effort metadata. Filename ends with "@" when HW empty;
+	// still distinct from cards with non-empty HW.
 	return fmt.Sprintf("%s@%s", cardName, hwVersion), nil
 }
 

--- a/internal/acp2/consumer/plugin.go
+++ b/internal/acp2/consumer/plugin.go
@@ -326,49 +326,50 @@ func (p *Plugin) Walk(ctx context.Context, slot int) ([]protocol.Object, error) 
 	return tree.Objects, nil
 }
 
-// IdentityProbe walks the given slot (sub-second on any Axon device)
-// and derives a per-card identity = "<CardName>@<HardwareVersion>"
-// by looking up obj labels in the ROOT_NODE_V2.BOARD subtree of THAT
-// slot. Each slot of a frame can host a different card → different
-// identity → different DM file. Returns "" with err when either label
-// is missing or the walk fails.
+// IdentityProbe walks the given slot and derives a per-card identity
+// = "<CardName>@<Version>" from labels in the slot's IDENTITY /
+// BOARD subtree. Each slot can host a different card → different
+// identity → different DM file (DHS 2016 MasterView, #363).
 //
-// Per DHS 2016 MasterView model: DM is keyed by card type, not by
-// device-frame and not by slot index. Two slots holding the same
-// card share the same DM file.
+// Version selection: prefer "Product Version" (firmware / software
+// — what actually changes the schema), fall back to "Hardware
+// Version" when Product is absent. Per user observation 2026-05-09:
+// "card name and product version" — the CONVERT Hybrid card (and
+// most newer Axon fixtures) expose Product Version in IDENTITY
+// alongside Card Name; some legacy cards only carry Hardware Version
+// in BOARD. Either is acceptable as the schema-key second component.
 //
-// Why labels and not obj-ids: ACP2 obj-ids vary per product, but
-// the labels "Card Name" and "Hardware Version" are constant across
-// the Axon catalogue (verified against real Neuron 10.41.40.4 +
-// tree-fresh.json).
+// Card Name is hard-required. Probe fails iff both versions and
+// Card Name are missing or the walk itself fails.
 func (p *Plugin) IdentityProbe(ctx context.Context, slot int) (string, error) {
 	objs, err := p.Walk(ctx, slot)
 	if err != nil {
 		return "", fmt.Errorf("acp2: identity probe walk(slot=%d): %w", slot, err)
 	}
 	cardName := ""
-	hwVersion := ""
+	productVer := ""
+	hwVer := ""
 	for _, o := range objs {
+		if o.Value.Kind != protocol.KindString {
+			continue
+		}
 		switch o.Label {
 		case "Card Name":
-			if o.Value.Kind == protocol.KindString {
-				cardName = o.Value.Str
-			}
+			cardName = o.Value.Str
+		case "Product Version":
+			productVer = o.Value.Str
 		case "Hardware Version":
-			if o.Value.Kind == protocol.KindString {
-				hwVersion = o.Value.Str
-			}
+			hwVer = o.Value.Str
 		}
 	}
 	if cardName == "" {
 		return "", fmt.Errorf("acp2: identity probe — missing Card Name on slot %d", slot)
 	}
-	// Hardware Version may be empty on some product fixtures (e.g.
-	// CONVERT Hybrid on producer .103 slot 1 reports empty HW Ver).
-	// Match ACP1's tolerance — Model is hard-required, HwRev is
-	// best-effort metadata. Filename ends with "@" when HW empty;
-	// still distinct from cards with non-empty HW.
-	return fmt.Sprintf("%s@%s", cardName, hwVersion), nil
+	ver := productVer
+	if ver == "" {
+		ver = hwVer
+	}
+	return fmt.Sprintf("%s@%s", cardName, ver), nil
 }
 
 // GetValue reads one object value via ACP2 get_property(pid=8).

--- a/internal/acp2/consumer/plugin.go
+++ b/internal/acp2/consumer/plugin.go
@@ -326,20 +326,25 @@ func (p *Plugin) Walk(ctx context.Context, slot int) ([]protocol.Object, error) 
 	return tree.Objects, nil
 }
 
-// IdentityProbe walks slot 0 (sub-second on any Axon device) and
-// derives a stable device identity = "<CardName>@<HardwareVersion>"
-// by looking up obj labels in the ROOT_NODE_V2.BOARD subtree.
-// Returns "" with err when either label is missing or the slot 0
-// walk fails — caller should fall back to a fresh full walk.
+// IdentityProbe walks the given slot (sub-second on any Axon device)
+// and derives a per-card identity = "<CardName>@<HardwareVersion>"
+// by looking up obj labels in the ROOT_NODE_V2.BOARD subtree of THAT
+// slot. Each slot of a frame can host a different card → different
+// identity → different DM file. Returns "" with err when either label
+// is missing or the walk fails.
+//
+// Per DHS 2016 MasterView model: DM is keyed by card type, not by
+// device-frame and not by slot index. Two slots holding the same
+// card share the same DM file.
 //
 // Why labels and not obj-ids: ACP2 obj-ids vary per product, but
 // the labels "Card Name" and "Hardware Version" are constant across
 // the Axon catalogue (verified against real Neuron 10.41.40.4 +
 // tree-fresh.json).
-func (p *Plugin) IdentityProbe(ctx context.Context) (string, error) {
-	objs, err := p.Walk(ctx, 0)
+func (p *Plugin) IdentityProbe(ctx context.Context, slot int) (string, error) {
+	objs, err := p.Walk(ctx, slot)
 	if err != nil {
-		return "", fmt.Errorf("acp2: identity probe walk(slot=0): %w", err)
+		return "", fmt.Errorf("acp2: identity probe walk(slot=%d): %w", slot, err)
 	}
 	cardName := ""
 	hwVersion := ""
@@ -356,8 +361,8 @@ func (p *Plugin) IdentityProbe(ctx context.Context) (string, error) {
 		}
 	}
 	if cardName == "" || hwVersion == "" {
-		return "", fmt.Errorf("acp2: identity probe — missing Card Name (%q) or Hardware Version (%q) on slot 0",
-			cardName, hwVersion)
+		return "", fmt.Errorf("acp2: identity probe — missing Card Name (%q) or Hardware Version (%q) on slot %d",
+			cardName, hwVersion, slot)
 	}
 	return fmt.Sprintf("%s@%s", cardName, hwVersion), nil
 }

--- a/internal/acp2/consumer/walker.go
+++ b/internal/acp2/consumer/walker.go
@@ -84,6 +84,85 @@ func (w *Walker) Walk(ctx context.Context, slot int) (*WalkedTree, error) {
 	return tree, nil
 }
 
+// WalkIdentity is a targeted walk that descends only into the ROOT →
+// BOARD and ROOT → IDENTITY subtrees and returns the string-valued
+// labels found there. ~30 getObject calls instead of the 49k a full
+// Walk would do on a CONVERT Hybrid card.
+//
+// Used by IdentityProbe at watch start to read Card Name + Product
+// Version (or Hardware Version) without monopolising the AN2/TCP
+// socket and starving keepalive / announces.
+//
+// Returns a map of label → string value. Missing labels are absent
+// from the map (zero-value string would be ambiguous).
+func (w *Walker) WalkIdentity(ctx context.Context, slot int) (map[string]string, error) {
+	out := map[string]string{}
+
+	// get_object on root — try obj-id 1 first (real devices), fall back to 0.
+	rootID := uint32(1)
+	rootObj, _, _, _, rootChildren, rerr := w.getOne(ctx, slot, rootID, nil)
+	if rerr != nil {
+		rootID = 0
+		rootObj, _, _, _, rootChildren, rerr = w.getOne(ctx, slot, rootID, nil)
+		if rerr != nil {
+			return nil, fmt.Errorf("acp2 identity walk slot %d: get root: %w", slot, rerr)
+		}
+	}
+	_ = rootObj
+
+	for _, childID := range rootChildren {
+		if cerr := ctx.Err(); cerr != nil {
+			return nil, cerr
+		}
+		childObj, _, _, _, leafIDs, cerr := w.getOne(ctx, slot, childID, nil)
+		if cerr != nil {
+			continue
+		}
+		// Only descend into BOARD + IDENTITY. Skip everything else
+		// (Audio, Video, etc) — those are the 49k-object subtrees.
+		if childObj.Label != "BOARD" && childObj.Label != "IDENTITY" {
+			continue
+		}
+		for _, leafID := range leafIDs {
+			if cerr := ctx.Err(); cerr != nil {
+				return nil, cerr
+			}
+			leafObj, _, _, _, _, lerr := w.getOne(ctx, slot, leafID, nil)
+			if lerr != nil {
+				continue
+			}
+			if leafObj.Label == "" || leafObj.Value.Kind != protocol.KindString {
+				continue
+			}
+			out[leafObj.Label] = leafObj.Value.Str
+		}
+	}
+	return out, nil
+}
+
+// getOne is the underlying single-object fetch + parse used by
+// walkObject and WalkIdentity. Splitting it lets the targeted walk
+// reuse the byte-decoder without inheriting walkObject's
+// recurse-into-everything behaviour.
+func (w *Walker) getOne(ctx context.Context, slot int, objID uint32, path []string) (protocol.Object, codec.ACP2ObjType, codec.NumberType, map[uint32]string, []uint32, error) {
+	select {
+	case <-ctx.Done():
+		return protocol.Object{}, 0, 0, nil, nil, ctx.Err()
+	default:
+	}
+	msg, err := w.session.DoACP2(ctx, uint8(slot), &codec.ACP2Message{
+		Type:  codec.ACP2TypeRequest,
+		Func:  codec.ACP2FuncGetObject,
+		ObjID: objID,
+		Idx:   0,
+	})
+	if err != nil {
+		return protocol.Object{}, 0, 0, nil, nil, fmt.Errorf("get_object(%d): %w", objID, err)
+	}
+	obj, objType, numType, optMap, children := w.parseObjectProperties(msg.Properties, slot, objID, path)
+	return obj, objType, numType, optMap, children, nil
+}
+
 // walkObject fetches one object via get_object and recursively walks its children.
 // path tracks the label path from root to current node for protocol.Object.Path.
 func (w *Walker) walkObject(ctx context.Context, slot int, objID uint32, path []string, tree *WalkedTree) error {
@@ -144,11 +223,19 @@ func (w *Walker) walkObject(ctx context.Context, slot int, objID uint32, path []
 
 	// Recurse into children.
 	for _, childID := range children {
+		// Bail early on cancellation — without this, every pending child
+		// hits the ctx.Done() check inside walkObject, returns
+		// context.Canceled, and we log a WARN per child. On a 50k-object
+		// slot that floods the terminal with thousands of identical
+		// "child error: context canceled" lines on every Ctrl-C.
+		if cerr := ctx.Err(); cerr != nil {
+			return cerr
+		}
 		childPath := make([]string, len(obj.Path))
 		copy(childPath, obj.Path)
 		if err := w.walkObject(ctx, slot, childID, childPath, tree); err != nil {
-			// Log and continue on child errors — partial walk is better
-			// than no walk.
+			// Real child failures still log — partial walk is better
+			// than no walk. Cancellation is filtered above.
 			w.logger.Warn("acp2: walker: child error",
 				"parent_id", objID, "child_id", childID, "err", err)
 		}


### PR DESCRIPTION
## Summary

Per-card DM cache for **ACP1 + ACP2**, agnostic of frame IP and slot index. Closes #363.

```
.cache/dm/<CardName>@<HwVer>.json   ← one file per UNIQUE card type
```

User direction 2026-05-09: "I want one fucking dm per slot, if many same card you load the same dm on each slot. ... I need two fucking dm when I walk slot 0 and slot 1 ... acp1 MUST HAVE SAME AS ACP2 no link with frame (ip) slots."

Per DHS 2016 MasterView. Two slots holding different cards → 2 files. Two slots holding the same card → 1 file (loaded once, seeded into multiple slot trees from the same data).

## What changes

| File | Change |
|---|---|
| `internal/acp2/consumer/plugin.go` | `IdentityProbe(ctx, slot int)` — was `IdentityProbe(ctx)` (slot 0 only). Each slot probes its own card identity. Probe is now a **targeted walk** of ROOT → BOARD + ROOT → IDENTITY only (~30 `getObject` calls vs 49 827 for full Walk on a CONVERT Hybrid card). Subscribe wrapper now copies `Path` / `Group` / `Access` from cached tree into `Event` (was Label + Unit only). |
| `internal/acp2/consumer/walker.go` | new `WalkIdentity` + `getOne` helpers; walker bails on `ctx.Err()` at child-loop top instead of cascading one WARN per pending child on Ctrl-C. |
| `internal/acp1/consumer/identity.go` | new `IdentityProbe(ctx, slot int)` wrapping existing `GetIdentity` — returns `<Model>@<SwRev>` (HwRev fallback). Errors when both versions empty so cache filenames never end with a bare `@`. New `SeedTreeFromCachedObjects(slot, objs)` mirroring ACP2's same-named method, fills `ACPTypes` parallel to `Objects` (missing parallel array was the source of "index out of range" panics on every announce). |
| `internal/acp1/consumer/plugin.go` | Subscribe wrapper copies `Path` / `Access` from cached tree; defensive bound check on `findObject` so any future incomplete seeder degrades to `decodeByGroup` rather than panicking. |
| `internal/acp1/consumer/browser.go` | walker persists `Meta["acp1_type"]` so cache reload preserves the precise ACP1 wire type (Integer vs Long) instead of the lossy Kind fallback. |
| `cmd/dhs/cmd_watch.go` | `saveSlotCache` routes by `prober != nil` (any plugin satisfying `identityProber` opts in to per-card DM). `saveIdentityCache` writes single-slot snapshots — multi-slot merge gone. New `hotLoadSlots(scope)` resolves per-slot probe targets. Hot-load block runs for any prober-implementing plugin. ACP1 + ACP2 both skip the legacy IP-keyed labelCache loader at startup. New `walkScope.withoutSlots` skips the background walk for slots that hit DM cache (was re-walking 49k objects and starving the announce path on a single AN2/TCP socket). Watch table no longer crops `oid` and `path` columns. |
| `cmd/dhs/cmd_watch_cache_test.go` | `fakeProber` updated to per-slot signature. New per-card tests: different cards → 2 files; same card across slots → 1 file. Renamed `TestSaveSlotCache_ACP2_NilProber_NoFile` to `TestSaveSlotCache_NilProber_FallsBackToIPKeyed` (Ember+ + future plugins fall through). |

## Behaviour

| Scenario | Result |
|---|---|
| ACP2 walk slot 0 (`SHPIO@5.3.5`) + slot 1 (`CONVERT Hybrid@6.7.4`) | `dm/SHPIO@5.3.5.json` + `dm/CONVERT Hybrid@6.7.4.json` — 2 files |
| ACP1 walk slot 0 (`RRS18@1601`) + slot 1 (`2GS110@2728`) | `dm/RRS18@1601.json` + `dm/2GS110@2728.json` — 2 files |
| Walk 4 slots, 2 cards each duplicated | 2 files (same-card dedup) |
| Watch slot N cold-start | probes slot N (~30 calls) → loads matching DM file → seeds slot N tree → labels + types + units from frame 1, no redundant background walk |
| Watch announce row | full hierarchy: `time | oid | path | label | acc | fr | value` — every column populated from the cached schema, both protocols |
| Plugin without IdentityProbe (Ember+ today) | falls through to legacy IP-keyed `.cache/devices/<ip>/slot_<n>.json` |

## Test plan

- [x] `go build ./...` green
- [x] `go test ./...` green; per-card tests:
  - `TestSaveSlotCache_ACP2_DifferentCardsTwoFiles` — 2 slots different cards → 2 files
  - `TestSaveSlotCache_ACP2_SameCardTwoSlots_OneFile` — 2 slots same card → 1 file
  - `TestSaveSlotCache_NilProber_FallsBackToIPKeyed` — non-prober protocols still IP-keyed
  - existing fake-prober tests rewritten for per-slot signature
- [x] Live verification (2026-05-09):
  - **ACP1** producer .102 (`RRS18-1601` slot 0 + `2GS110-2728` slot 1), walk + watch over UDP and TCP. Two DM files written. Watch table shows full row (path/label/acc/value).
  - **ACP2** producer .103 (`CONVERT Hybrid 6.7.4` slot 1, 49 827 objects), watch slot 1. DM cache hit seeds in <1 s (vs 60 s+ before targeted IdentityProbe). Cerebrum + VSM Studio mutations on `Ethernet IP Address`, `Ethernet IP Gateway`, `Ethernet Configuration` (enum), `Audio Delay` render with full path / label / access / unit.

## Out of scope

- Ember+ — no per-slot card concept; stays on IP-keyed. Same Subscribe-wrapper contract (Path / Group / Access in events) will be extended to Ember+, Probel, OSC, TSL, Cerebrum-NB in a follow-up PR.
- Frame composition file (`slot → card identity` map) — runtime state stays in plugin tree cache + announce events.
- Migration of any pre-existing `.cache/devices/<ip>/...` ACP1 files. Orphaned + gitignored.
- Other open ACP1/ACP2 issues (#298 type/value cache split, #138 ACP2 multi-session broadcast audit, #256 ACP1 AN2/TCP listener, #296 spec-driven codec tests, #300 cross-protocol KeepAliver migration) — separate scope, separate PRs.

## Stack

- #361 / #362 (round-trip fix) on main
- #359 / #360 (`Event.Unit`) on main
- This PR — sits on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
