### PR TITLE
feat(acp2,cli): auto-reconnect on session loss with exponential backoff (closes #367)

### DIFF
--- a/cmd/dhs/common.go
+++ b/cmd/dhs/common.go
@@ -37,6 +37,9 @@ type commonFlags struct {
 	timeout           time.Duration
 	keepalive         time.Duration
 	keepaliveTimeout  time.Duration
+	reconnect         bool
+	reconnectCap      time.Duration
+	reconnectAttempts int
 	verbose           bool
 	logLevel          string
 	capture           string
@@ -77,6 +80,16 @@ func addCommonFlags(fs *flag.FlagSet) *commonFlags {
 		"keep-alive dead-man threshold (0 = 3× --keepalive; -1 = never "+
 			"declare session dead). Watch verb shows freshness=cache once "+
 			"this elapses without rx; values stay decoded against the cached schema.")
+	fs.BoolVar(&cf.reconnect, "reconnect", true,
+		"on session loss (TCP close / device crash / network drop), retry "+
+			"the connection with exponential backoff. Plugins that don't "+
+			"implement protocol.Reconnecter ignore this flag.")
+	fs.DurationVar(&cf.reconnectCap, "reconnect-cap", 0,
+		"cap on the exponential backoff between reconnect attempts "+
+			"(0 = plugin default 30s)")
+	fs.IntVar(&cf.reconnectAttempts, "reconnect-max-attempts", 0,
+		"maximum reconnect attempts before giving up "+
+			"(0 = unlimited; the watch verb keeps trying)")
 	fs.BoolVar(&cf.verbose, "verbose", false, "debug log output (shortcut for --log-level debug)")
 	fs.StringVar(&cf.logLevel, "log-level", "info", "log level: trace, debug, info, warn, error, critical")
 	fs.StringVar(&cf.capture, "capture", "",
@@ -214,6 +227,16 @@ func connect(ctx context.Context, host string, cf *commonFlags) (protocol.Protoc
 		ka.SetKeepAlive(protocol.KeepAliveConfig{
 			Interval: cf.keepalive,
 			Timeout:  cf.keepaliveTimeout,
+		})
+	}
+
+	// Reconnect — same plugin-optional pattern as KeepAliver. Plugins
+	// that don't implement Reconnecter silently ignore.
+	if rc, ok := plug.(protocol.Reconnecter); ok {
+		rc.SetReconnect(protocol.ReconnectConfig{
+			Cap:         cf.reconnectCap,
+			MaxAttempts: cf.reconnectAttempts,
+			Disabled:    !cf.reconnect,
 		})
 	}
 

--- a/internal/acp2/consumer/plugin.go
+++ b/internal/acp2/consumer/plugin.go
@@ -73,6 +73,27 @@ type Plugin struct {
 	// ka is the running keep-alive state when a session is up; nil
 	// before Connect and after Disconnect.
 	ka *keepAliveState
+
+	// reconnectCfg captures the operator's --reconnect* choice (#367).
+	// Zero values mean "use plugin defaults"; Disabled=true skips the
+	// loop entirely (current pre-#367 behaviour for fail-fast verbs).
+	reconnectCfg protocol.ReconnectConfig
+
+	// rc is the running reconnect state. Started by Connect on first
+	// success, kept alive across reconnect cycles, stopped by
+	// Disconnect.
+	rc *reconnectState
+
+	// host / port remembered from the first Connect so the reconnect
+	// loop can re-dial after a session loss.
+	host string
+	port int
+
+	// activeSubs records the subscriptions the operator registered
+	// via Subscribe so the reconnect loop can replay them after a
+	// successful re-handshake. Keyed by subKey to dedupe re-subscribe
+	// calls with the same filters.
+	activeSubs map[subKey]activeSubscription
 }
 
 // SeedTreeFromCachedObjects rebuilds an in-memory WalkedTree from a
@@ -247,6 +268,13 @@ func (p *Plugin) Connect(ctx context.Context, ip string, port int) error {
 	p.walker.OnProgress = p.walkProgress
 	p.trees = newWalkedTreeCache(32, 10*time.Minute)
 	p.subHandles = make(map[subKey]int)
+	if p.activeSubs == nil {
+		// Preserve activeSubs across reconnect cycles — the reconnect
+		// loop replays them. First Connect creates the map.
+		p.activeSubs = make(map[subKey]activeSubscription)
+	}
+	p.host = ip
+	p.port = port
 	p.profile = &compliance.Profile{}
 	s.SetProfile(p.profile)
 	// Start the keep-alive prober + watchdog (mirrors ACP1).
@@ -254,6 +282,10 @@ func (p *Plugin) Connect(ctx context.Context, ip string, port int) error {
 	// life of the session, not the caller's Connect ctx — we cancel
 	// via p.ka.done from Disconnect.
 	p.startKeepAlive(context.Background())
+	// Start the reconnect watcher (idempotent — only first call
+	// creates the goroutine; subsequent Connects from the reconnect
+	// loop itself find p.rc != nil and return).
+	p.startReconnect()
 	return nil
 }
 
@@ -263,8 +295,15 @@ func (p *Plugin) Disconnect() error {
 	defer p.mu.Unlock()
 
 	if p.session == nil {
+		// Even with no live session, the reconnect goroutine might
+		// be busy backing off — stop it so the caller's Disconnect
+		// is final.
+		p.stopReconnect()
 		return nil
 	}
+	// Stop reconnect first so it doesn't race the close + try to
+	// re-dial after we wanted out.
+	p.stopReconnect()
 	// Stop keep-alive before closing the socket so the prober's
 	// in-flight request doesn't race with conn.Close.
 	p.stopKeepAlive()
@@ -275,6 +314,7 @@ func (p *Plugin) Disconnect() error {
 		p.trees.Clear()
 	}
 	p.subHandles = nil
+	p.activeSubs = nil
 	return err
 }
 
@@ -623,7 +663,12 @@ func (p *Plugin) Subscribe(req protocol.ValueRequest, fn protocol.EventFunc) err
 	})
 
 	p.mu.Lock()
-	p.subHandles[reqToSubKey(req)] = id
+	key := reqToSubKey(req)
+	p.subHandles[key] = id
+	if p.activeSubs != nil {
+		// Track for replay across reconnects (#367).
+		p.activeSubs[key] = activeSubscription{req: req, fn: fn}
+	}
 	p.mu.Unlock()
 	return nil
 }
@@ -632,9 +677,13 @@ func (p *Plugin) Subscribe(req protocol.ValueRequest, fn protocol.EventFunc) err
 func (p *Plugin) Unsubscribe(req protocol.ValueRequest) error {
 	p.mu.Lock()
 	s := p.session
-	id, ok := p.subHandles[reqToSubKey(req)]
+	key := reqToSubKey(req)
+	id, ok := p.subHandles[key]
 	if ok {
-		delete(p.subHandles, reqToSubKey(req))
+		delete(p.subHandles, key)
+	}
+	if p.activeSubs != nil {
+		delete(p.activeSubs, key)
 	}
 	p.mu.Unlock()
 

--- a/internal/acp2/consumer/reconnect.go
+++ b/internal/acp2/consumer/reconnect.go
@@ -1,0 +1,244 @@
+package acp2
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"dhs/internal/protocol"
+)
+
+// Default reconnect cadence (mirrors the design in issue #367).
+//
+// 1 s initial, doubling up to 30 s cap. Two failed attempts and the
+// operator already feels it; eight attempts span ~120 s — enough to
+// wait out a controller restart without spamming the link.
+const (
+	defaultReconnectInitial = 1 * time.Second
+	defaultReconnectCap     = 30 * time.Second
+)
+
+// reconnectState holds the lifecycle of the reconnect goroutine.
+type reconnectState struct {
+	cfg protocol.ReconnectConfig
+
+	// done closes when the goroutine should exit (Disconnect path).
+	done chan struct{}
+
+	// stopped fires once the goroutine has returned.
+	stopped sync.WaitGroup
+}
+
+// activeSubscription is what we replay after a reconnect succeeds.
+// Captures the (request, callback) pair the operator handed to
+// Subscribe so the new session can re-register it without forcing
+// the watcher to do anything.
+type activeSubscription struct {
+	req protocol.ValueRequest
+	fn  protocol.EventFunc
+}
+
+// SetReconnect applies the operator's --reconnect-* choice. Must be
+// called before Connect (the goroutine starts on the first session
+// loss). Implements protocol.Reconnecter.
+func (p *Plugin) SetReconnect(cfg protocol.ReconnectConfig) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.reconnectCfg = cfg
+}
+
+// resolvedReconnect normalises p.reconnectCfg into the (initial, cap,
+// maxAttempts) tuple the goroutine actually uses. Disabled=true
+// returns initial=0 to signal "no reconnect at all".
+func (p *Plugin) resolvedReconnect() (initial, cap time.Duration, maxAttempts int) {
+	if p.reconnectCfg.Disabled {
+		return 0, 0, 0
+	}
+	initial = p.reconnectCfg.Initial
+	if initial <= 0 {
+		initial = defaultReconnectInitial
+	}
+	cap = p.reconnectCfg.Cap
+	if cap <= 0 {
+		cap = defaultReconnectCap
+	}
+	if cap < initial {
+		cap = initial
+	}
+	maxAttempts = p.reconnectCfg.MaxAttempts
+	return
+}
+
+// startReconnect launches the watcher goroutine that re-dials after a
+// session loss. Must be called with p.mu held; first invocation per
+// Connect() — the goroutine waits on the current session's Done().
+func (p *Plugin) startReconnect() {
+	initial, _, _ := p.resolvedReconnect()
+	if initial == 0 {
+		return // disabled
+	}
+	if p.rc != nil {
+		return // already running
+	}
+	p.rc = &reconnectState{cfg: p.reconnectCfg, done: make(chan struct{})}
+	p.rc.stopped.Add(1)
+	go p.reconnectLoop()
+}
+
+// stopReconnect signals the goroutine to exit and waits for it.
+// Idempotent. Must be called with p.mu held.
+func (p *Plugin) stopReconnect() {
+	if p.rc == nil {
+		return
+	}
+	close(p.rc.done)
+	p.mu.Unlock()
+	p.rc.stopped.Wait()
+	p.mu.Lock()
+	p.rc = nil
+}
+
+// reconnectLoop watches the current session's Done() channel. When
+// the read loop exits (TCP close), it attempts re-dial with
+// exponential backoff up to maxAttempts. On success, replays any
+// active subscriptions so the watcher transparently resumes.
+func (p *Plugin) reconnectLoop() {
+	defer p.rc.stopped.Done()
+
+	for {
+		// Snapshot what we need under the lock.
+		p.mu.Lock()
+		s := p.session
+		host := p.host
+		port := p.port
+		done := p.rc.done
+		p.mu.Unlock()
+
+		if s == nil {
+			// No session — nothing to watch. We're either pre-Connect
+			// or post-Disconnect. Either way, exit cleanly.
+			return
+		}
+
+		// Wait for either the session to die or the operator to
+		// signal Disconnect.
+		select {
+		case <-done:
+			return
+		case <-s.Done():
+			// Session is gone. Move to the reconnect path.
+		}
+
+		select {
+		case <-done:
+			return
+		default:
+		}
+
+		p.logger.Warn("acp2 reconnect: session lost, retrying",
+			slog.String("host", host),
+			slog.Int("port", port))
+
+		if err := p.runReconnectBackoff(host, port); err != nil {
+			p.logger.Warn("acp2 reconnect: gave up",
+				slog.String("err", err.Error()))
+			return
+		}
+		// Loop back: watch the new session's Done().
+	}
+}
+
+// runReconnectBackoff dials the device with exponential backoff.
+// Returns nil on success (a fresh Connect succeeded and subscriptions
+// were replayed); returns an error when MaxAttempts is hit or when
+// the operator cancels via stopReconnect.
+func (p *Plugin) runReconnectBackoff(host string, port int) error {
+	initial, capDur, maxAttempts := p.resolvedReconnect()
+	delay := initial
+	attempt := 0
+
+	for {
+		attempt++
+
+		p.mu.Lock()
+		done := p.rc.done
+		p.mu.Unlock()
+
+		select {
+		case <-done:
+			return nil
+		case <-time.After(delay):
+		}
+
+		p.logger.Info("acp2 reconnect: attempting",
+			slog.Int("attempt", attempt),
+			slog.Duration("delay", delay))
+
+		// Use a fresh context (caller's connect-ctx is long gone).
+		// 5 s dial timeout matches connect()'s floor.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		err := p.reconnectOnce(ctx, host, port)
+		cancel()
+
+		if err == nil {
+			p.logger.Info("acp2 reconnect: succeeded",
+				slog.Int("attempt", attempt))
+			return nil
+		}
+
+		p.logger.Debug("acp2 reconnect: attempt failed",
+			slog.Int("attempt", attempt),
+			slog.String("err", err.Error()))
+
+		if maxAttempts > 0 && attempt >= maxAttempts {
+			return err
+		}
+
+		delay *= 2
+		if delay > capDur {
+			delay = capDur
+		}
+	}
+}
+
+// reconnectOnce does one dial + handshake + subscription replay.
+// Acquires p.mu only for the brief windows where it's needed; the
+// long part (Connect's TCP dial + AN2 handshake) runs lock-free.
+func (p *Plugin) reconnectOnce(ctx context.Context, host string, port int) error {
+	// Snapshot active subscriptions to replay.
+	p.mu.Lock()
+	subs := make([]activeSubscription, 0, len(p.activeSubs))
+	for _, sub := range p.activeSubs {
+		subs = append(subs, sub)
+	}
+	// Stop keepalive cleanly — close ka.done, wait for the prober +
+	// watchdog goroutines to exit, then nil p.ka. Without this the
+	// stale goroutines keep referencing the old keepAliveState and
+	// panic on the next tick after p.session goes nil.
+	p.stopKeepAlive()
+	// Clear the old session pointer so Connect doesn't refuse with
+	// "already connected".
+	p.session = nil
+	p.walker = nil
+	if p.trees != nil {
+		p.trees.Clear()
+	}
+	p.subHandles = nil
+	p.mu.Unlock()
+
+	if err := p.Connect(ctx, host, port); err != nil {
+		return err
+	}
+
+	// Replay subscriptions.
+	for _, sub := range subs {
+		if err := p.Subscribe(sub.req, sub.fn); err != nil {
+			p.logger.Warn("acp2 reconnect: subscription replay failed",
+				slog.String("err", err.Error()))
+			// Continue replaying others — partial recovery is better
+			// than none.
+		}
+	}
+	return nil
+}

--- a/internal/acp2/consumer/reconnect_test.go
+++ b/internal/acp2/consumer/reconnect_test.go
@@ -1,0 +1,74 @@
+package acp2
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"dhs/internal/protocol"
+)
+
+func TestResolvedReconnect_Defaults(t *testing.T) {
+	p := &Plugin{logger: slog.Default()}
+	initial, cap, max := p.resolvedReconnect()
+	if initial != defaultReconnectInitial {
+		t.Errorf("default initial = %v, want %v", initial, defaultReconnectInitial)
+	}
+	if cap != defaultReconnectCap {
+		t.Errorf("default cap = %v, want %v", cap, defaultReconnectCap)
+	}
+	if max != 0 {
+		t.Errorf("default max = %d, want 0 (unlimited)", max)
+	}
+}
+
+func TestResolvedReconnect_Disabled(t *testing.T) {
+	p := &Plugin{logger: slog.Default()}
+	p.reconnectCfg = protocol.ReconnectConfig{Disabled: true}
+	initial, _, _ := p.resolvedReconnect()
+	if initial != 0 {
+		t.Errorf("disabled initial = %v, want 0", initial)
+	}
+}
+
+func TestResolvedReconnect_Custom(t *testing.T) {
+	p := &Plugin{logger: slog.Default()}
+	p.reconnectCfg = protocol.ReconnectConfig{
+		Initial:     500 * time.Millisecond,
+		Cap:         5 * time.Second,
+		MaxAttempts: 10,
+	}
+	initial, cap, max := p.resolvedReconnect()
+	if initial != 500*time.Millisecond {
+		t.Errorf("initial = %v, want 500ms", initial)
+	}
+	if cap != 5*time.Second {
+		t.Errorf("cap = %v, want 5s", cap)
+	}
+	if max != 10 {
+		t.Errorf("max = %d, want 10", max)
+	}
+}
+
+func TestResolvedReconnect_CapFloorsToInitial(t *testing.T) {
+	// Sanity: if user supplies cap < initial, cap is bumped up so
+	// the doubling never goes below the floor.
+	p := &Plugin{logger: slog.Default()}
+	p.reconnectCfg = protocol.ReconnectConfig{
+		Initial: 10 * time.Second,
+		Cap:     2 * time.Second,
+	}
+	initial, cap, _ := p.resolvedReconnect()
+	if cap != initial {
+		t.Errorf("cap = %v, want = initial %v", cap, initial)
+	}
+}
+
+func TestSetReconnect_StoresCfg(t *testing.T) {
+	p := &Plugin{logger: slog.Default()}
+	cfg := protocol.ReconnectConfig{Initial: 2 * time.Second, Cap: 30 * time.Second, MaxAttempts: 5}
+	p.SetReconnect(cfg)
+	if p.reconnectCfg != cfg {
+		t.Errorf("reconnectCfg = %+v, want %+v", p.reconnectCfg, cfg)
+	}
+}

--- a/internal/protocol/reconnect.go
+++ b/internal/protocol/reconnect.go
@@ -1,0 +1,44 @@
+package protocol
+
+import "time"
+
+// ReconnectConfig is the cross-protocol auto-reconnect configuration.
+// CLI flags --reconnect / --reconnect-cap / --reconnect-max-attempts
+// populate it, then connect() hands it to the plugin via SetReconnect
+// (optional capability — plugins that don't implement Reconnecter
+// silently ignore it).
+//
+// Zero values mean "use plugin default": Initial=0 → 1 s, Cap=0 → 30 s,
+// MaxAttempts=0 → unlimited. Disabled=true skips the reconnect loop
+// entirely (current pre-#367 behaviour for backwards-compat scripts
+// that prefer hard exit on session loss).
+type ReconnectConfig struct {
+	// Initial backoff delay before the first reconnect attempt after
+	// a session loss. 0 = plugin default (1 s).
+	Initial time.Duration
+
+	// Cap caps the exponential backoff. 0 = plugin default (30 s).
+	// Backoff doubles on each failed attempt up to this cap.
+	Cap time.Duration
+
+	// MaxAttempts limits the number of reconnect attempts before the
+	// plugin gives up. 0 = unlimited (the watch verb keeps retrying
+	// indefinitely; operator interrupts with Ctrl-C).
+	MaxAttempts int
+
+	// Disabled turns the reconnect loop off. Useful for short-lived
+	// CLI verbs (info / get / set) that should fail-fast rather than
+	// wait for retry. The watch / metrics serve verbs leave it false.
+	Disabled bool
+}
+
+// Reconnecter is the optional capability a plugin satisfies when it
+// supports automatic session re-establishment after loss. The plugin
+// owns the reconnect goroutine, exponential backoff, and re-issuing
+// any active subscriptions after a successful re-handshake.
+//
+// Plugins that don't implement Reconnecter are unaffected; the harness
+// type-asserts and only calls SetReconnect when satisfied.
+type Reconnecter interface {
+	SetReconnect(cfg ReconnectConfig)
+}


### PR DESCRIPTION
Stacks on #366 (acp2 keep-alive). Live-verified end-to-end:

```
T+0   watch connects
T+13  pkill -9 producer  -> session lost
T+14  attempt #1 delay=1s
T+18  attempt #2 delay=2s
T+24  attempt #3 delay=4s
T+34  attempt #4 delay=8s   <- producer restarted via setsid
T+52  attempt #5 delay=16s
T+52  acp2: connected + reconnect: succeeded attempt=5
```

Exponential backoff (1s -> 2s -> 4s -> 8s -> 16s, cap 30s), subscriptions replayed, watch resumed without operator intervention.

Closes #367.

🤖 Generated with [Claude Code](https://claude.com/claude-code)