### PR TITLE
feat(acp2,cli): auto-reconnect on session loss + surface IsOnline (closes #367)

### DIFF
--- a/cmd/dhs/cmd_info.go
+++ b/cmd/dhs/cmd_info.go
@@ -39,7 +39,7 @@ func runInfo(ctx context.Context, args []string) error {
 			fmt.Printf("  slot %2d   <error: %v>\n", slot, err)
 			continue
 		}
-		fmt.Printf("  slot %2d   %s\n", slot, si.Status)
+		fmt.Printf("  slot %2d   status=%-10s online=%t\n", slot, si.Status, si.IsOnline)
 	}
 	return nil
 }

--- a/cmd/dhs/cmd_watch.go
+++ b/cmd/dhs/cmd_watch.go
@@ -71,7 +71,7 @@ func runWatch(ctx context.Context, args []string) error {
 	}
 	enricher := newHotPlugEnricher(resolver, *autoWalkOnPlug, os.Stdout)
 
-	plug, cleanup, err := connect(ctx, host, cf)
+	plug, cleanup, err := connectWithRetry(ctx, host, cf)
 	if err != nil {
 		return err
 	}

--- a/cmd/dhs/common.go
+++ b/cmd/dhs/common.go
@@ -245,6 +245,49 @@ func connect(ctx context.Context, host string, cf *commonFlags) (protocol.Protoc
 	return plug, cleanup, nil
 }
 
+// connectWithRetry wraps connect() with the same exponential backoff
+// the per-plugin warm-restart watcher uses (1s → 2s → 4s → 8s → 16s →
+// 30s cap). Used by long-running verbs like `watch` so the operator can
+// launch them before the producer is up — they wait, log progress, and
+// transparently proceed once the server appears. Bails on ctx cancel
+// (Ctrl-C); never bails on transport error alone.
+//
+// One-shot verbs (info, walk, get, set, health) keep the fail-fast
+// connect() so a typo'd IP doesn't hang forever.
+func connectWithRetry(ctx context.Context, host string, cf *commonFlags) (protocol.Protocol, func(), error) {
+	const (
+		initial = 1 * time.Second
+		cap_    = 30 * time.Second
+	)
+	delay := initial
+	attempt := 0
+	for {
+		attempt++
+		plug, cleanup, err := connect(ctx, host, cf)
+		if err == nil {
+			if attempt > 1 {
+				fmt.Fprintf(os.Stderr, "connect: succeeded on attempt %d\n", attempt)
+			}
+			return plug, cleanup, nil
+		}
+		if ctx.Err() != nil {
+			return nil, nil, ctx.Err()
+		}
+		fmt.Fprintf(os.Stderr, "connect: attempt %d failed: %v (retry in %s)\n",
+			attempt, err, delay)
+
+		select {
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+		case <-time.After(delay):
+		}
+		delay *= 2
+		if delay > cap_ {
+			delay = cap_
+		}
+	}
+}
+
 // resolvePathFromCache tries to find an object ID from the disk cache
 // for path-based addressing. Path is a dot-separated label sequence
 // (e.g. "IDENTITY.User Label 1"); the lookup matches on the **suffix**

--- a/internal/acp2/consumer/plugin.go
+++ b/internal/acp2/consumer/plugin.go
@@ -48,11 +48,24 @@ type Plugin struct {
 	session *Session
 	walker  *Walker
 
-	// trees caches the walked object tree per slot (LRU + TTL).
+	// host + port preserve the last successful Connect target so the
+	// reconnect goroutine knows where to re-dial after session loss.
+	host string
+	port int
+
+	// trees caches walked / DM-seeded object trees per slot (LRU,
+	// no TTL — see Connect for the reasoning).
 	trees *walkedTreeCache
 
-	// Announce subscription tracking.
-	subHandles map[subKey]int // subKey → session announce subscription ID
+	// activeSubs survives reconnects: each entry holds the operator's
+	// (req, fn) plus the current session's subscription handle. On
+	// reconnect, sessionID is refreshed by re-registering the closure
+	// on the new session.
+	activeSubs map[subKey]*activeSubscription
+
+	// rc owns the warm-restart watcher goroutine. nil before Connect
+	// and after Disconnect; non-nil between.
+	rc *reconnectState
 
 	// Optional traffic capture.
 	recorder *transport.Recorder
@@ -93,7 +106,7 @@ type Plugin struct {
 func (p *Plugin) SeedTreeFromCachedObjects(slot int, objs []protocol.Object) {
 	p.mu.Lock()
 	if p.trees == nil {
-		p.trees = newWalkedTreeCache(32, 10*time.Minute)
+		p.trees = newWalkedTreeCache(32, 0)
 	}
 	cache := p.trees
 	p.mu.Unlock()
@@ -206,6 +219,16 @@ func reqToSubKey(req protocol.ValueRequest) subKey {
 	return subKey{req.Slot, req.Label, req.ID}
 }
 
+// activeSubscription holds one operator-issued Subscribe across the
+// lifetime of the Plugin. Survives session loss: req + fn are stable;
+// sessionID is refreshed each reconnect by registering the closure on
+// the new session.
+type activeSubscription struct {
+	req       protocol.ValueRequest
+	fn        protocol.EventFunc
+	sessionID int
+}
+
 // SetRecorder attaches a traffic recorder. Call before Connect.
 func (p *Plugin) SetRecorder(rec *transport.Recorder) {
 	p.mu.Lock()
@@ -245,8 +268,20 @@ func (p *Plugin) Connect(ctx context.Context, ip string, port int) error {
 	p.session = s
 	p.walker = NewWalker(s, p.logger)
 	p.walker.OnProgress = p.walkProgress
-	p.trees = newWalkedTreeCache(32, 10*time.Minute)
-	p.subHandles = make(map[subKey]int)
+	p.host = ip
+	p.port = port
+	if p.trees == nil {
+		// TTL=0 → never expire. ACP2 schema is immutable for the
+		// session; the cache is the only label/type source after a
+		// DM-cache seed, and reconnect cycles can run minutes — long
+		// enough to age out a 10-min TTL and silently degrade
+		// post-reconnect announces to bare IDs (no path / label /
+		// access). LRU bound (32) still caps memory.
+		p.trees = newWalkedTreeCache(32, 0)
+	}
+	if p.activeSubs == nil {
+		p.activeSubs = make(map[subKey]*activeSubscription)
+	}
 	p.profile = &compliance.Profile{}
 	s.SetProfile(p.profile)
 	// Start the keep-alive prober + watchdog (mirrors ACP1).
@@ -254,6 +289,10 @@ func (p *Plugin) Connect(ctx context.Context, ip string, port int) error {
 	// life of the session, not the caller's Connect ctx — we cancel
 	// via p.ka.done from Disconnect.
 	p.startKeepAlive(context.Background())
+	// Start the warm-restart watcher. Idempotent — no-op on reconnect
+	// path (the goroutine is already running and will simply observe
+	// the new session via p.session on its next loop iteration).
+	p.startReconnectLoop()
 	return nil
 }
 
@@ -265,8 +304,9 @@ func (p *Plugin) Disconnect() error {
 	if p.session == nil {
 		return nil
 	}
-	// Stop keep-alive before closing the socket so the prober's
-	// in-flight request doesn't race with conn.Close.
+	// Stop the warm-restart watcher first so it doesn't try to redial
+	// during teardown. Then keep-alive, then the socket itself.
+	p.stopReconnectLoop()
 	p.stopKeepAlive()
 	err := p.session.Disconnect()
 	p.session = nil
@@ -274,7 +314,7 @@ func (p *Plugin) Disconnect() error {
 	if p.trees != nil {
 		p.trees.Clear()
 	}
-	p.subHandles = nil
+	p.activeSubs = nil
 	return err
 }
 
@@ -536,20 +576,57 @@ func (p *Plugin) SetValue(ctx context.Context, req protocol.ValueRequest, val pr
 	return protocol.Value{Kind: protocol.KindRaw, Raw: msg.Body}, nil
 }
 
-// Subscribe registers a callback for ACP2 announces matching req.
+// Subscribe registers a callback for ACP2 announces matching req. The
+// (req, fn) pair is stored in p.activeSubs so it survives session loss
+// — on reconnect, the same closure is re-registered on the new session
+// (see reconnectOnce).
 func (p *Plugin) Subscribe(req protocol.ValueRequest, fn protocol.EventFunc) error {
 	p.mu.Lock()
 	s := p.session
-	p.mu.Unlock()
 	if s == nil {
+		p.mu.Unlock()
 		return protocol.ErrNotConnected
 	}
+	if p.activeSubs == nil {
+		p.activeSubs = make(map[subKey]*activeSubscription)
+	}
+	sub := &activeSubscription{req: req, fn: fn}
+	sub.sessionID = s.SubscribeAnnounces(p.buildAnnounceClosure(req, fn))
+	p.activeSubs[reqToSubKey(req)] = sub
+	p.mu.Unlock()
+	return nil
+}
 
+// Unsubscribe removes a previously registered Subscribe.
+func (p *Plugin) Unsubscribe(req protocol.ValueRequest) error {
+	p.mu.Lock()
+	s := p.session
+	key := reqToSubKey(req)
+	sub, ok := p.activeSubs[key]
+	if ok {
+		delete(p.activeSubs, key)
+	}
+	p.mu.Unlock()
+
+	if ok && s != nil {
+		s.UnsubscribeAnnounces(sub.sessionID)
+	}
+	return nil
+}
+
+// buildAnnounceClosure produces the AnnounceFunc that filters incoming
+// announces by req and invokes fn with a decoded protocol.Event.
+// Extracted so reconnectOnce can re-register the same shape against a
+// fresh session without re-running Subscribe (which would also re-emit
+// the activeSubs bookkeeping). The closure captures p, req, fn — none
+// of which change on reconnect, so the same logic applies before and
+// after.
+func (p *Plugin) buildAnnounceClosure(req protocol.ValueRequest, fn protocol.EventFunc) AnnounceFunc {
 	slot := req.Slot
 	wantID := req.ID
 	wantLabel := req.Label
 
-	id := s.SubscribeAnnounces(func(annSlot uint8, msg *codec.ACP2Message) {
+	return func(annSlot uint8, msg *codec.ACP2Message) {
 		if slot >= 0 && int(annSlot) != slot {
 			return
 		}
@@ -620,28 +697,7 @@ func (p *Plugin) Subscribe(req protocol.ValueRequest, fn protocol.EventFunc) err
 		}
 
 		fn(ev)
-	})
-
-	p.mu.Lock()
-	p.subHandles[reqToSubKey(req)] = id
-	p.mu.Unlock()
-	return nil
-}
-
-// Unsubscribe removes a previously registered Subscribe.
-func (p *Plugin) Unsubscribe(req protocol.ValueRequest) error {
-	p.mu.Lock()
-	s := p.session
-	id, ok := p.subHandles[reqToSubKey(req)]
-	if ok {
-		delete(p.subHandles, reqToSubKey(req))
 	}
-	p.mu.Unlock()
-
-	if ok && s != nil {
-		s.UnsubscribeAnnounces(id)
-	}
-	return nil
 }
 
 // ---- Internal helpers ----

--- a/internal/acp2/consumer/reconnect.go
+++ b/internal/acp2/consumer/reconnect.go
@@ -1,0 +1,186 @@
+package acp2
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// Backoff schedule for warm-restart reconnection: 1s → 2s → 4s → 8s →
+// 16s → 30s (cap), retry forever until the operator hits Ctrl-C or
+// calls Disconnect. No flags — the goal is "transparent recovery";
+// adjustable knobs would only encourage operators to misconfigure them.
+const (
+	defaultReconnectInitial = 1 * time.Second
+	defaultReconnectCap     = 30 * time.Second
+)
+
+// reconnectState owns the goroutine that watches the current session's
+// Done() channel and, on session loss, re-dials with exponential
+// backoff and replays every active subscription on the new session.
+//
+// Lifecycle: started inside Connect after a successful handshake;
+// stopped inside Disconnect before the socket closes.
+type reconnectState struct {
+	done    chan struct{}
+	stopped sync.WaitGroup
+}
+
+// startReconnectLoop launches the warm-restart watcher. Caller must
+// hold p.mu. No-op if already running.
+func (p *Plugin) startReconnectLoop() {
+	if p.rc != nil {
+		return
+	}
+	p.rc = &reconnectState{done: make(chan struct{})}
+	p.rc.stopped.Add(1)
+	go p.reconnectLoop()
+}
+
+// stopReconnectLoop signals the goroutine and waits for it. Releases
+// p.mu while waiting so the goroutine can acquire it on its way out
+// (mirrors stopKeepAlive's pattern). Caller must hold p.mu.
+func (p *Plugin) stopReconnectLoop() {
+	if p.rc == nil {
+		return
+	}
+	close(p.rc.done)
+	p.mu.Unlock()
+	p.rc.stopped.Wait()
+	p.mu.Lock()
+	p.rc = nil
+}
+
+// reconnectLoop is the warm-restart driver. Reads the current session
+// + remote endpoint under the lock, blocks on session.Done(), and on
+// loss runs the backoff dial. After a successful reconnect, loops back
+// to watch the new session's Done().
+func (p *Plugin) reconnectLoop() {
+	defer p.rc.stopped.Done()
+
+	for {
+		p.mu.Lock()
+		s := p.session
+		host := p.host
+		port := p.port
+		done := p.rc.done
+		p.mu.Unlock()
+
+		if s == nil {
+			return // pre-Connect or post-Disconnect
+		}
+
+		select {
+		case <-done:
+			return
+		case <-s.Done():
+			// session closed — TCP gone, readLoop returned, etc.
+		}
+
+		select {
+		case <-done:
+			return
+		default:
+		}
+
+		p.logger.Warn("acp2 reconnect: session lost, reconnecting",
+			slog.String("host", host),
+			slog.Int("port", port))
+
+		p.runReconnectBackoff(host, port)
+		// loop back to watch new session.Done()
+	}
+}
+
+// runReconnectBackoff dials with exponential backoff until the dial
+// succeeds OR stopReconnectLoop fires. Each successful dial replays
+// every activeSubscription on the fresh session.
+func (p *Plugin) runReconnectBackoff(host string, port int) {
+	delay := defaultReconnectInitial
+	attempt := 0
+
+	for {
+		attempt++
+
+		p.mu.Lock()
+		done := p.rc.done
+		p.mu.Unlock()
+
+		select {
+		case <-done:
+			return
+		case <-time.After(delay):
+		}
+
+		p.logger.Info("acp2 reconnect: attempting",
+			slog.Int("attempt", attempt),
+			slog.Duration("delay", delay))
+
+		// Fresh ctx — caller's Connect ctx is long gone. 5s dial floor
+		// matches connect() helper's dialTimeout floor.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		replayed, err := p.reconnectOnce(ctx, host, port)
+		cancel()
+
+		if err == nil {
+			p.logger.Info("acp2 reconnect: connected",
+				slog.Int("attempt", attempt),
+				slog.Int("replayed_subscriptions", replayed))
+			return
+		}
+
+		p.logger.Warn("acp2 reconnect: attempt failed",
+			slog.Int("attempt", attempt),
+			slog.String("err", err.Error()))
+
+		delay *= 2
+		if delay > defaultReconnectCap {
+			delay = defaultReconnectCap
+		}
+	}
+}
+
+// reconnectOnce drops every reference to the dead session, runs a
+// fresh Connect (full AN2 + ACP2 handshake including
+// EnableProtocolEvents), and re-registers every activeSubscription on
+// the new session. Returns (nil, N) on full success.
+//
+// Why we re-Connect rather than just re-dialing the socket: ACP2
+// announces only flow after AN2 EnableProtocolEvents on the current
+// session. Re-running Connect is the spec-correct way to reach that
+// state — the new session also gets a fresh keepalive, walker, and
+// compliance profile.
+func (p *Plugin) reconnectOnce(ctx context.Context, host string, port int) (int, error) {
+	p.mu.Lock()
+	// Drop the dead session. stopKeepAlive is idempotent and tolerates
+	// session==nil (the prober/watchdog goroutines hold their own ka
+	// pointer). Walker holds a stale session ref — drop it too.
+	p.stopKeepAlive()
+	p.session = nil
+	p.walker = nil
+	// activeSubs is preserved — that's the whole point.
+	p.mu.Unlock()
+
+	if err := p.Connect(ctx, host, port); err != nil {
+		return 0, err
+	}
+
+	p.mu.Lock()
+	s := p.session
+	if s == nil {
+		p.mu.Unlock()
+		return 0, fmt.Errorf("acp2 reconnect: session nil after Connect succeeded")
+	}
+	replayed := 0
+	for _, sub := range p.activeSubs {
+		// New session → fresh subscription handle. The closure is
+		// rebuilt from the original (req, fn) so the operator's filter
+		// is preserved verbatim.
+		sub.sessionID = s.SubscribeAnnounces(p.buildAnnounceClosure(sub.req, sub.fn))
+		replayed++
+	}
+	p.mu.Unlock()
+	return replayed, nil
+}

--- a/internal/acp2/consumer/session.go
+++ b/internal/acp2/consumer/session.go
@@ -397,7 +397,7 @@ func (s *Session) sendFrame(ctx context.Context, f *codec.AN2Frame) error {
 	if err != nil {
 		return err
 	}
-	s.logger.Debug("acp2: sendFrame",
+	s.logger.Debug("acp2: tx",
 		"proto", f.Proto, "slot", f.Slot, "mtid", f.MTID, "type", f.Type,
 		"frame_hex", fmt.Sprintf("%x", data))
 
@@ -437,9 +437,9 @@ func (s *Session) readLoop() {
 		frame, err := codec.ReadAN2Frame(conn)
 		if err != nil {
 			if err == io.EOF || isClosedErr(err) {
-				s.logger.Debug("acp2: reader: connection closed")
+				s.logger.Debug("acp2: rx: connection closed")
 			} else {
-				s.logger.Debug("acp2: reader: connection closed", "err", err)
+				s.logger.Debug("acp2: rx: connection closed", "err", err)
 			}
 			s.closeErr = err
 			return
@@ -462,7 +462,7 @@ func (s *Session) readLoop() {
 			len(frame.Payload) >= 1 &&
 			frame.Payload[0] == byte(codec.ACP2TypeAnnounce)
 		if !isAnnounce {
-			s.logger.Debug("acp2: reader: frame",
+			s.logger.Debug("acp2: rx",
 				"proto", frame.Proto, "slot", frame.Slot,
 				"mtid", frame.MTID, "type", frame.Type,
 				"dlen", len(frame.Payload),
@@ -475,7 +475,7 @@ func (s *Session) readLoop() {
 		case codec.AN2ProtoACP2:
 			s.handleACP2Frame(frame)
 		default:
-			s.logger.Debug("acp2: reader: ignoring frame with proto", "proto", frame.Proto)
+			s.logger.Debug("acp2: rx: ignoring frame with proto", "proto", frame.Proto)
 		}
 	}
 }
@@ -536,15 +536,10 @@ func (s *Session) handleACP2Frame(f *codec.AN2Frame) {
 	}
 
 	if msg.Type == codec.ACP2TypeAnnounce {
-		// Announce debug: include first 20 bytes hex for diagnosis.
-		hexDump := fmt.Sprintf("%x", f.Payload)
-		if len(hexDump) > 40 {
-			hexDump = hexDump[:40] + "..."
-		}
-		s.logger.Debug("acp2: announce",
-			"slot", f.Slot, "obj_id", msg.ObjID, "pid", msg.PID,
-			"props", len(msg.Properties), "dlen", len(f.Payload), "hex", hexDump)
-		// Fan out to all subscribers.
+		// Announces fan out silently — per `feedback_logging` they're
+		// the high-volume hot path and the watch verb already prints
+		// every dispatched event with full decoding. Logging here
+		// would double-print and truncate the wire bytes besides.
 		s.annMu.Lock()
 		subs := make([]AnnounceFunc, 0, len(s.annSubs))
 		for _, fn := range s.annSubs {


### PR DESCRIPTION
## Summary

- ACP2 watch sessions now survive both producer cycling (warm restart) and producer-not-yet-up startup (cold start), with no operator-visible flags
- Backoff: 1s → 2s → 4s → 8s → 16s → 30s cap, retry forever until Ctrl-C
- Subscription state is plugin-scoped, so the watcher transparently resumes after reconnect
- `info` verb now exposes the `online=true|false` column populated by #365 keepalive

## Why no flags

Per the user's directive ("stop to add flags on cli for nothing"), reconnect is intended to be transparent. Knobs would only encourage misconfiguration; if a hard timeout becomes operationally necessary later, a flag can be added without breaking the default.

## Behaviour overview

| Layer | Trigger | What happens |
|---|---|---|
| Cold start | `dhs consumer acp2 watch <host>` and producer is down | retry with backoff until producer comes up |
| Warm restart | producer killed mid-watch | `WARN session lost, reconnecting` → backoff dial → `INFO acp2 reconnect: connected attempt=N replayed_subscriptions=K` → announces resume |
| One-shot verbs (info, walk, get, set, health) | unreachable host | fail-fast — typo'd IPs do not hang forever |

## Live verification 2026-05-10 (against producer .103, CONVERT Hybrid)

**Phase 1 — cold start (producer down)**
```
connect: attempt 1 failed: dial tcp 10.100.0.103:9999: refused (retry in 1s)
connect: attempt 2 failed: dial tcp 10.100.0.103:9999: refused (retry in 2s)
[backoff schedule confirmed 1s -> 2s -> 4s ... cap 30s]
```

**Phase 2 — warm restart**
```
03:09:55  WARN acp2 reconnect: session lost, reconnecting
03:09:56  attempt 1 (delay 1s) failed
03:09:58  attempt 2 (delay 2s) failed
03:10:02  attempt 3 (delay 4s) failed
03:10:10  attempt 4 (delay 8s) failed
03:10:26  attempt 5 (delay 16s) failed
03:11:16  attempt 6 (delay 30s) -- INFO acp2 reconnect: connected
          replayed_subscriptions=1
03:12:22  s1.IDENTITY.3  ROOT-NODE-V2.IDENTITY.User Label 1  RW-  live  "youssef"
          [announce flowed end-to-end through replayed subscription
           with full path / label / access resolution]
```

The post-reconnect announce row is the merge-gate proof: subscription replay works AND the seeded tree survives reconnect (TTL=0 fix).

## Drive-by fixes bundled

- `walkedTreeCache` TTL 10m → 0 (LRU only). The previous TTL silently expired the DM-seeded tree mid-session, which surfaced post-reconnect as announces with empty path/label/access.
- Removed the per-announce DEBUG log that truncated wire bytes to 40 hex chars (per `feedback_logging` "never truncate log data").
- Renamed log labels: `acp2: sendFrame` → `acp2: tx`, `acp2: reader: frame` → `acp2: rx` (OPNsense-style direction-first).
- `info` verb prints `online=true|false` per slot (closes #365's display gap).

## Test plan

- [x] `go test -count=1 ./internal/acp2/consumer/...` — pass
- [x] `go vet ./...` (pre-commit hook) — pass
- [x] `golangci-lint run` (pre-commit hook) — pass
- [x] Live cold-start retry verified against unreachable port
- [x] Live warm-restart cycle verified end-to-end against `.103` (kill producer → 6 backoff attempts → restart → reconnect → trigger value change → announce row in watch with full resolution)

Closes #367