### PR TITLE
feat(cli): ASCII-tree rendering for walk verb (#409)

### DIFF
--- a/cmd/dhs/cmd_walk.go
+++ b/cmd/dhs/cmd_walk.go
@@ -23,9 +23,14 @@ func runWalk(ctx context.Context, args []string) error {
 	all := fs.Bool("all", false, "walk every present slot on the device")
 	filter := fs.String("filter", "", "case-insensitive filter on output lines (like findstr /i or grep -i)")
 	pathFlag := fs.String("path", "", "filter objects by path prefix (e.g. BOARD, PSU/1)")
+	tree := fs.Bool("tree", false, "render as ASCII tree instead of flat list")
+	treeDepth := fs.Int("depth", 0, "max depth from focus node (0 = unlimited; use with --tree)")
+	treeFromOID := fs.String("from-oid", "", "focus tree on object by OID (numeric ID or dotted; use with --tree)")
+	treeFromPath := fs.String("from-path", "", "focus tree on object by dotted path (use with --tree)")
+	treeASCII := fs.Bool("ascii", false, "use plain ASCII tree characters instead of Unicode box-drawing")
 	host, rest, err := popHost(args)
 	if err != nil {
-		return fmt.Errorf("usage: dhs consumer <proto> walk <host> (--slot N | --all) [--path SEG.SEG] [--filter STR]")
+		return fmt.Errorf("usage: dhs consumer <proto> walk <host> (--slot N | --all) [--path SEG.SEG] [--filter STR] [--tree [--depth N] [--from-oid OID | --from-path SEG.SEG] [--ascii]]")
 	}
 	_ = fs.Parse(rest)
 	// Ember+ has no slot concept (spec: single flat tree per provider);
@@ -52,9 +57,11 @@ func runWalk(ctx context.Context, args []string) error {
 	// Stream objects as they're discovered during walk — don't wait for
 	// the full tree before printing. Essential for large slots (4190+ objects).
 	// ACP1 doesn't support streaming, so we fall back to printSlotTree after.
+	// --tree needs the complete walked list to build the parent/child graph,
+	// so streaming is disabled in tree mode.
 	streaming := false
 	filterLower := strings.ToLower(*filter)
-	if p, ok := plug.(interface{ SetWalkProgress(acp2.WalkProgressFunc) }); ok {
+	if p, ok := plug.(interface{ SetWalkProgress(acp2.WalkProgressFunc) }); ok && !*tree {
 		streaming = true
 		p.SetWalkProgress(func(count int, obj *protocol.Object) {
 			if obj.Kind == protocol.KindRaw && obj.Label == "" {
@@ -119,7 +126,18 @@ func runWalk(ctx context.Context, args []string) error {
 			prober, _ := plug.(identityProber)
 			saveSlotCache(ctx, prober, host, cf.protocol, s, objs)
 			objs = filterByPath(objs, pathSegs)
-			if !streaming {
+			if *tree {
+				fmt.Printf("\nslot %d — %d objects\n\n", s, len(objs))
+				if err := renderTree(os.Stdout, objs, treeRenderOpts{
+					FromOID:  *treeFromOID,
+					FromPath: *treeFromPath,
+					Depth:    *treeDepth,
+					ASCII:    *treeASCII,
+					Filter:   *filter,
+				}); err != nil {
+					fmt.Fprintf(os.Stderr, "slot %d: %v\n", s, err)
+				}
+			} else if !streaming {
 				printSlotTree(s, objs, *filter)
 			} else {
 				fmt.Printf("\nslot %d — %d objects\n", s, len(objs))
@@ -140,7 +158,18 @@ func runWalk(ctx context.Context, args []string) error {
 	prober, _ := plug.(identityProber)
 	saveSlotCache(ctx, prober, host, cf.protocol, *slot, objs)
 	objs = filterByPath(objs, pathSegs)
-	if !streaming {
+	if *tree {
+		fmt.Printf("\nslot %d — %d objects\n\n", *slot, len(objs))
+		if err := renderTree(os.Stdout, objs, treeRenderOpts{
+			FromOID:  *treeFromOID,
+			FromPath: *treeFromPath,
+			Depth:    *treeDepth,
+			ASCII:    *treeASCII,
+			Filter:   *filter,
+		}); err != nil {
+			return err
+		}
+	} else if !streaming {
 		printSlotTree(*slot, objs, *filter)
 	} else {
 		fmt.Printf("\nslot %d — %d objects\n", *slot, len(objs))

--- a/cmd/dhs/tree_render.go
+++ b/cmd/dhs/tree_render.go
@@ -1,0 +1,270 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+
+	"dhs/internal/protocol"
+)
+
+// pathNode is one position in the tree built from Object.Path slices.
+// Obj is nil for synthetic intermediate nodes; the renderer falls back
+// to Name for those.
+type pathNode struct {
+	Name     string
+	Obj      *protocol.Object
+	Children map[string]*pathNode
+}
+
+func newPathNode(name string) *pathNode {
+	return &pathNode{Name: name, Children: map[string]*pathNode{}}
+}
+
+func (n *pathNode) sortedChildren() []*pathNode {
+	out := make([]*pathNode, 0, len(n.Children))
+	for _, c := range n.Children {
+		out = append(out, c)
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// buildPathTree groups objects into a tree by Object.Path. The returned
+// root is synthetic; its Children are the real top-level segments.
+// ACP1 objects with empty Path but non-empty Group are placed under a
+// single-segment path equal to the group name.
+func buildPathTree(objs []protocol.Object) *pathNode {
+	root := newPathNode("")
+	for i := range objs {
+		o := &objs[i]
+		path := o.Path
+		if len(path) == 0 && o.Group != "" {
+			path = []string{o.Group}
+		}
+		if len(path) == 0 {
+			continue
+		}
+		cur := root
+		for _, seg := range path {
+			child, ok := cur.Children[seg]
+			if !ok {
+				child = newPathNode(seg)
+				cur.Children[seg] = child
+			}
+			cur = child
+		}
+		cur.Obj = o
+	}
+	return root
+}
+
+type treeChars struct {
+	branch, last, vertical, space string
+}
+
+var unicodeTreeChars = treeChars{branch: "├── ", last: "└── ", vertical: "│   ", space: "    "}
+var asciiTreeChars = treeChars{branch: "+-- ", last: "+-- ", vertical: "|   ", space: "    "}
+
+type treeRenderOpts struct {
+	FromOID  string
+	FromPath string
+	Depth    int
+	ASCII    bool
+	Filter   string
+}
+
+// renderTree writes a tree view of objs to w. When FromPath or FromOID
+// is set, the tree is focused: the ancestor chain from the slot root
+// down to the focus node renders without sibling expansion, then
+// descendants under the focus expand fully (subject to Depth).
+//
+// Depth is measured from the focus node; 0 means unlimited. Ancestors
+// above the focus always render regardless of Depth.
+func renderTree(w io.Writer, objs []protocol.Object, opts treeRenderOpts) error {
+	if opts.FromPath != "" && opts.FromOID != "" {
+		return fmt.Errorf("--from-path and --from-oid are mutually exclusive")
+	}
+	var focus []string
+	switch {
+	case opts.FromPath != "":
+		userSegs := splitFocusPath(opts.FromPath)
+		p, ok := resolveFromPath(objs, userSegs)
+		if !ok {
+			return fmt.Errorf("no object at --from-path %q", opts.FromPath)
+		}
+		focus = p
+	case opts.FromOID != "":
+		p, ok := resolveFromOID(objs, opts.FromOID)
+		if !ok {
+			return fmt.Errorf("no object with --from-oid %q", opts.FromOID)
+		}
+		focus = p
+	}
+	root := buildPathTree(objs)
+	chars := unicodeTreeChars
+	if opts.ASCII {
+		chars = asciiTreeChars
+	}
+	filterLower := strings.ToLower(opts.Filter)
+	// When focused, the first segment of focus selects which top-level
+	// subtree to render; pruning happens inside renderNode.
+	children := root.sortedChildren()
+	for i, c := range children {
+		isLast := i == len(children)-1
+		renderNode(w, c, "", isLast, focus, 0, opts.Depth, chars, filterLower)
+	}
+	return nil
+}
+
+func renderNode(w io.Writer, n *pathNode, prefix string, isLast bool, focus []string, depthFromFocus, maxDepth int, chars treeChars, filterLower string) {
+	onChain := len(focus) > 0
+	atFocus := false
+	if onChain {
+		if !strings.EqualFold(n.Name, focus[0]) {
+			return
+		}
+		if len(focus) == 1 {
+			atFocus = true
+		}
+	}
+
+	line := formatNodeLine(n)
+	if filterLower == "" || strings.Contains(strings.ToLower(line), filterLower) {
+		connector := chars.branch
+		if isLast {
+			connector = chars.last
+		}
+		_, _ = fmt.Fprintf(w, "%s%s%s\n", prefix, connector, line)
+	}
+
+	childPrefix := prefix + chars.vertical
+	if isLast {
+		childPrefix = prefix + chars.space
+	}
+
+	if onChain && !atFocus {
+		// Still on the ancestor chain: descend into the one matching child.
+		nextFocus := focus[1:]
+		for _, c := range n.sortedChildren() {
+			if !strings.EqualFold(c.Name, nextFocus[0]) {
+				continue
+			}
+			renderNode(w, c, childPrefix, true, nextFocus, 0, maxDepth, chars, filterLower)
+			return
+		}
+		return
+	}
+
+	if maxDepth > 0 && depthFromFocus >= maxDepth {
+		return
+	}
+	kids := n.sortedChildren()
+	for i, c := range kids {
+		last := i == len(kids)-1
+		renderNode(w, c, childPrefix, last, nil, depthFromFocus+1, maxDepth, chars, filterLower)
+	}
+}
+
+// formatNodeLine renders one tree-node line. Containers (with children)
+// show "Name [oid=X]"; leaves show "Name  kind  access [= value]".
+func formatNodeLine(n *pathNode) string {
+	if n.Obj == nil {
+		return n.Name
+	}
+	o := n.Obj
+	if len(n.Children) > 0 {
+		return fmt.Sprintf("%s [oid=%s]", n.Name, formatOID(o))
+	}
+	val := walkValueColumn(*o)
+	line := fmt.Sprintf("%s  %s  %s", n.Name, kindName(o.Kind), accessStr(o.Access))
+	if val != "" {
+		line += " = " + val
+	}
+	return line
+}
+
+func formatOID(o *protocol.Object) string {
+	if o.OID != "" {
+		return o.OID
+	}
+	return strconv.Itoa(o.ID)
+}
+
+func splitFocusPath(s string) []string {
+	parts := strings.Split(s, ".")
+	out := parts[:0]
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// resolveFromPath matches the user's focus segments as a contiguous
+// run inside any Object.Path. Returns the canonical Path slice up to
+// (and including) the focus run, so the renderer always starts at the
+// actual slot root.
+//
+// Works for:
+//   - leaf focus (CHANNEL 01.Direction)         → segments at the end of a leaf path
+//   - intermediate focus (INPUT.SDI.CHANNEL 01) → segments mid-path inside leaf paths
+//   - ACP1 group focus (identity)               → first segment of leaf paths
+func resolveFromPath(objs []protocol.Object, userSegs []string) ([]string, bool) {
+	if len(userSegs) == 0 {
+		return nil, false
+	}
+	for i := range objs {
+		path := objs[i].Path
+		if len(path) == 0 && objs[i].Group != "" {
+			path = []string{objs[i].Group}
+		}
+		if len(path) < len(userSegs) {
+			continue
+		}
+		for start := 0; start+len(userSegs) <= len(path); start++ {
+			match := true
+			for j, seg := range userSegs {
+				if !strings.EqualFold(path[start+j], seg) {
+					match = false
+					break
+				}
+			}
+			if match {
+				return path[:start+len(userSegs)], true
+			}
+		}
+	}
+	return nil, false
+}
+
+// resolveFromOID accepts either a dotted Ember+ OID (matched against
+// Object.OID) or a decimal integer matching Object.ID (ACP1 byte /
+// ACP2 obj-id). Returns the full Path of the first match.
+func resolveFromOID(objs []protocol.Object, oid string) ([]string, bool) {
+	for i := range objs {
+		if objs[i].OID != "" && objs[i].OID == oid {
+			path := objs[i].Path
+			if len(path) == 0 && objs[i].Group != "" {
+				path = []string{objs[i].Group}
+			}
+			return path, true
+		}
+	}
+	if n, err := strconv.Atoi(oid); err == nil {
+		for i := range objs {
+			if objs[i].ID == n {
+				path := objs[i].Path
+				if len(path) == 0 && objs[i].Group != "" {
+					path = []string{objs[i].Group}
+				}
+				return path, true
+			}
+		}
+	}
+	return nil, false
+}

--- a/cmd/dhs/tree_render_test.go
+++ b/cmd/dhs/tree_render_test.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"dhs/internal/protocol"
+)
+
+// fixtureACP2Tree returns an ACP2-shaped slice with ROOT_NODE_V2 as the
+// implicit root, INPUT and OUTPUT branches, and a few leaves with kinds.
+// Mirrors the live Neuron card layout.
+func fixtureACP2Tree() []protocol.Object {
+	return []protocol.Object{
+		{ID: 1, Label: "ROOT_NODE_V2", Path: []string{"ROOT_NODE_V2"}, Kind: protocol.KindRaw, Access: 1},
+		{ID: 12820, Label: "INPUT", Path: []string{"ROOT_NODE_V2", "INPUT"}, Kind: protocol.KindRaw, Access: 1},
+		{ID: 15522, Label: "SDI", Path: []string{"ROOT_NODE_V2", "INPUT", "SDI"}, Kind: protocol.KindRaw, Access: 1},
+		{ID: 15750, Label: "CHANNEL 01", Path: []string{"ROOT_NODE_V2", "INPUT", "SDI", "CHANNEL 01"}, Kind: protocol.KindRaw, Access: 1},
+		{ID: 15758, Label: "Direction", Path: []string{"ROOT_NODE_V2", "INPUT", "SDI", "CHANNEL 01", "Direction"}, Kind: protocol.KindEnum, Access: 3,
+			EnumItems: []string{"Input", "Output", "Off"},
+			Value:     protocol.Value{Kind: protocol.KindEnum, Enum: 0, Str: "Input"}},
+		{ID: 15765, Label: "Used", Path: []string{"ROOT_NODE_V2", "INPUT", "SDI", "CHANNEL 01", "Used"}, Kind: protocol.KindBool, Access: 1,
+			Value: protocol.Value{Kind: protocol.KindBool, Bool: true}},
+		{ID: 15770, Label: "Video Format", Path: []string{"ROOT_NODE_V2", "INPUT", "SDI", "CHANNEL 01", "Video Format"}, Kind: protocol.KindEnum, Access: 1,
+			EnumItems: []string{"1080i59", "1080p30"},
+			Value:     protocol.Value{Kind: protocol.KindEnum, Enum: 0, Str: "1080i59"}},
+		{ID: 15228, Label: "OUTPUT", Path: []string{"ROOT_NODE_V2", "OUTPUT"}, Kind: protocol.KindRaw, Access: 1},
+		{ID: 15231, Label: "SDI", Path: []string{"ROOT_NODE_V2", "OUTPUT", "SDI"}, Kind: protocol.KindRaw, Access: 1},
+	}
+}
+
+func TestRenderTree_FullFromRoot(t *testing.T) {
+	var buf bytes.Buffer
+	if err := renderTree(&buf, fixtureACP2Tree(), treeRenderOpts{ASCII: true}); err != nil {
+		t.Fatalf("renderTree: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"ROOT_NODE_V2", "INPUT", "OUTPUT", "CHANNEL 01", "Direction", "Used"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderTree_FocusByPath_RendersAncestorChain(t *testing.T) {
+	var buf bytes.Buffer
+	err := renderTree(&buf, fixtureACP2Tree(), treeRenderOpts{
+		FromPath: "INPUT.SDI.CHANNEL 01",
+		ASCII:    true,
+	})
+	if err != nil {
+		t.Fatalf("renderTree: %v", err)
+	}
+	out := buf.String()
+	// Ancestor chain ROOT_NODE_V2 -> INPUT -> SDI -> CHANNEL 01 must be present.
+	for _, want := range []string{"ROOT_NODE_V2", "INPUT", "SDI", "CHANNEL 01", "Direction", "Used", "Video Format"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in focused output:\n%s", want, out)
+		}
+	}
+	// OUTPUT subtree must NOT render (sibling of INPUT, off the chain).
+	if strings.Contains(out, "OUTPUT") {
+		t.Errorf("OUTPUT must not appear when focused on INPUT subtree:\n%s", out)
+	}
+}
+
+func TestRenderTree_FocusByOID_ResolvesToPath(t *testing.T) {
+	var buf bytes.Buffer
+	// 15750 = CHANNEL 01
+	err := renderTree(&buf, fixtureACP2Tree(), treeRenderOpts{
+		FromOID: "15750",
+		ASCII:   true,
+	})
+	if err != nil {
+		t.Fatalf("renderTree: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"ROOT_NODE_V2", "INPUT", "SDI", "CHANNEL 01", "Direction"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in OID-focused output:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "OUTPUT") {
+		t.Errorf("OUTPUT must not appear when focused via OID on CHANNEL 01:\n%s", out)
+	}
+}
+
+func TestRenderTree_DepthCap_LimitsDescentFromFocus(t *testing.T) {
+	var buf bytes.Buffer
+	// Focus on INPUT, depth 1 — should render INPUT + SDI, but NOT CHANNEL 01 below SDI.
+	err := renderTree(&buf, fixtureACP2Tree(), treeRenderOpts{
+		FromPath: "INPUT",
+		Depth:    1,
+		ASCII:    true,
+	})
+	if err != nil {
+		t.Fatalf("renderTree: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "INPUT") {
+		t.Errorf("focus node INPUT missing:\n%s", out)
+	}
+	if !strings.Contains(out, "SDI") {
+		t.Errorf("depth 1 child SDI missing:\n%s", out)
+	}
+	if strings.Contains(out, "CHANNEL 01") {
+		t.Errorf("depth 1 must not descend to CHANNEL 01:\n%s", out)
+	}
+}
+
+func TestRenderTree_DepthCapZeroIsUnlimited(t *testing.T) {
+	var buf bytes.Buffer
+	if err := renderTree(&buf, fixtureACP2Tree(), treeRenderOpts{Depth: 0, ASCII: true}); err != nil {
+		t.Fatalf("renderTree: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Direction") {
+		t.Errorf("depth 0 should be unlimited; Direction (deep leaf) must render:\n%s", out)
+	}
+}
+
+func TestRenderTree_UnknownFocusPath_ReturnsError(t *testing.T) {
+	var buf bytes.Buffer
+	err := renderTree(&buf, fixtureACP2Tree(), treeRenderOpts{FromPath: "DOES.NOT.EXIST"})
+	if err == nil {
+		t.Fatalf("expected error for unknown focus path, got nil")
+	}
+	if !strings.Contains(err.Error(), "DOES.NOT.EXIST") {
+		t.Errorf("error should mention the bad path: %v", err)
+	}
+}
+
+func TestRenderTree_UnknownFocusOID_ReturnsError(t *testing.T) {
+	var buf bytes.Buffer
+	err := renderTree(&buf, fixtureACP2Tree(), treeRenderOpts{FromOID: "999999"})
+	if err == nil {
+		t.Fatalf("expected error for unknown focus OID, got nil")
+	}
+}
+
+func TestRenderTree_BothFocusFlags_ReturnsError(t *testing.T) {
+	var buf bytes.Buffer
+	err := renderTree(&buf, fixtureACP2Tree(), treeRenderOpts{
+		FromPath: "INPUT",
+		FromOID:  "12820",
+	})
+	if err == nil {
+		t.Fatalf("expected mutually-exclusive error, got nil")
+	}
+}
+
+// fixtureACP1Tree returns an ACP1-shaped slice — flat groups, empty
+// Path on leaves, non-empty Group. Confirms the renderer is generic.
+func fixtureACP1Tree() []protocol.Object {
+	return []protocol.Object{
+		{ID: 0, Label: "Frame Status", Group: "frame", Path: []string{"frame", "Frame Status"}, Kind: protocol.KindFrame, Access: 1},
+		{ID: 1, Label: "Card Name", Group: "identity", Path: []string{"identity", "Card Name"}, Kind: protocol.KindString, Access: 1,
+			Value: protocol.Value{Kind: protocol.KindString, Str: "MyCard"}},
+		{ID: 2, Label: "Serial Number", Group: "identity", Path: []string{"identity", "Serial Number"}, Kind: protocol.KindString, Access: 1,
+			Value: protocol.Value{Kind: protocol.KindString, Str: "SN42"}},
+		{ID: 10, Label: "Gain", Group: "control", Path: []string{"control", "Gain"}, Kind: protocol.KindFloat, Access: 3,
+			Value: protocol.Value{Kind: protocol.KindFloat, Float: -3.5}},
+	}
+}
+
+func TestRenderTree_GenericAcrossProtocols_ACP1(t *testing.T) {
+	var buf bytes.Buffer
+	if err := renderTree(&buf, fixtureACP1Tree(), treeRenderOpts{ASCII: true}); err != nil {
+		t.Fatalf("renderTree ACP1: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"frame", "identity", "control", "Card Name", "Serial Number", "Gain"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in ACP1 output:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderTree_FocusByPath_ACP1Group(t *testing.T) {
+	var buf bytes.Buffer
+	err := renderTree(&buf, fixtureACP1Tree(), treeRenderOpts{
+		FromPath: "identity",
+		ASCII:    true,
+	})
+	if err != nil {
+		t.Fatalf("renderTree ACP1 focused: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Card Name") || !strings.Contains(out, "Serial Number") {
+		t.Errorf("identity descendants missing:\n%s", out)
+	}
+	if strings.Contains(out, "Gain") {
+		t.Errorf("control.Gain must not render under identity focus:\n%s", out)
+	}
+}
+
+func TestRenderTree_UnicodeDefault(t *testing.T) {
+	var buf bytes.Buffer
+	if err := renderTree(&buf, fixtureACP1Tree(), treeRenderOpts{}); err != nil {
+		t.Fatalf("renderTree: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "├") && !strings.Contains(out, "└") {
+		t.Errorf("default unicode chars missing from output:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `--tree` rendering to `dhs consumer <proto> walk` — indented ASCII/Unicode tree with `--ascii` fallback.
- Focused-subtree rendering via `--from-path SEG.SEG` or `--from-oid OID`: walks root -> ancestor chain -> focus -> descendants (subject to `--depth N`, 0 = unlimited).
- Renderer is generic — operates on `[]protocol.Object` and works for every connector that implements `Walk()`. Verified with ACP1 and ACP2 fixtures.

## Test plan

- [x] Unit tests in `cmd/dhs/tree_render_test.go` (11 cases: full tree, focus by path, focus by OID, depth cap, depth=0 unlimited, unknown path, unknown OID, mutually-exclusive flags, Unicode default vs --ascii, generic across ACP2 + ACP1)
- [x] `go test ./cmd/dhs/...` green
- [x] `go build ./...` green
- [x] `golangci-lint` green (pre-commit hook)
- [x] Live smoke against ACP2 producer on .103: INPUT.SDI (32 channels) and OUTPUT.SDI (32 channels + SDI-level OSD overrides) render correctly with full ancestor chain
- [ ] Real-Neuron integration test (deferred; producer mirrors a real-Neuron walk, so behaviour expected to match)

Refs #409 (already closed; commit message carries `Closes #409`).