### PR TITLE
fix(cli/import): dry-run skips full-slot walk (#413)

### DIFF
--- a/internal/export/importer.go
+++ b/internal/export/importer.go
@@ -91,11 +91,17 @@ func Apply(ctx context.Context, plug protocol.Protocol, s *Snapshot, dryRun bool
 	for _, dump := range s.Slots {
 		// Make sure the plugin has a fresh tree for this slot so
 		// SetValue can resolve labels and encode values.
-		if _, err := plug.Walk(ctx, dump.Slot); err != nil {
-			rep.Failures = append(rep.Failures,
-				fmt.Sprintf("slot %d walk failed: %v", dump.Slot, err))
-			rep.Failed += len(dump.Objects)
-			continue
+		//
+		// In dry-run we never call SetValue, so the walk is dead weight —
+		// for ACP2 slot 1 it would be thousands of get_object round-trips
+		// just to print "would write". Skip it entirely on dry-run.
+		if !dryRun {
+			if _, err := plug.Walk(ctx, dump.Slot); err != nil {
+				rep.Failures = append(rep.Failures,
+					fmt.Sprintf("slot %d walk failed: %v", dump.Slot, err))
+				rep.Failed += len(dump.Objects)
+				continue
+			}
 		}
 
 		for _, obj := range dump.Objects {

--- a/internal/export/importer_test.go
+++ b/internal/export/importer_test.go
@@ -1,0 +1,94 @@
+package export
+
+import (
+	"context"
+	"testing"
+
+	"dhs/internal/protocol"
+)
+
+// countingPlugin satisfies protocol.Protocol and counts Walk + SetValue
+// calls so tests can assert which device-touching paths Apply took.
+type countingPlugin struct {
+	walkCalls int
+	setCalls  int
+}
+
+func (p *countingPlugin) Connect(context.Context, string, int) error { return nil }
+func (p *countingPlugin) Disconnect() error                          { return nil }
+func (p *countingPlugin) GetDeviceInfo(context.Context) (protocol.DeviceInfo, error) {
+	return protocol.DeviceInfo{}, nil
+}
+func (p *countingPlugin) GetSlotInfo(context.Context, int) (protocol.SlotInfo, error) {
+	return protocol.SlotInfo{}, nil
+}
+func (p *countingPlugin) Walk(context.Context, int) ([]protocol.Object, error) {
+	p.walkCalls++
+	return nil, nil
+}
+func (p *countingPlugin) GetValue(context.Context, protocol.ValueRequest) (protocol.Value, error) {
+	return protocol.Value{}, nil
+}
+func (p *countingPlugin) SetValue(context.Context, protocol.ValueRequest, protocol.Value) (protocol.Value, error) {
+	p.setCalls++
+	return protocol.Value{}, nil
+}
+func (p *countingPlugin) Subscribe(protocol.ValueRequest, protocol.EventFunc) error { return nil }
+func (p *countingPlugin) Unsubscribe(protocol.ValueRequest) error                   { return nil }
+
+func snapshotForTest() *Snapshot {
+	return &Snapshot{
+		Device: DeviceInfo{Protocol: "acp2"},
+		Slots: []SlotDump{
+			{
+				Slot: 1,
+				Objects: []protocol.Object{
+					{ID: 67604, Path: []string{"OUTPUT", "IP", "VIDEO", "STREAM 1", "LEG 1", "Destination IP"},
+						Kind: protocol.KindString, Access: 0x03,
+						Value: protocol.Value{Kind: protocol.KindString, Str: "239.129.1.20"}},
+					{ID: 67605, Path: []string{"OUTPUT", "IP", "VIDEO", "STREAM 1", "LEG 1", "Destination Port"},
+						Kind: protocol.KindInt, Access: 0x03,
+						Value: protocol.Value{Kind: protocol.KindInt, Int: 12700}},
+					{ID: 99, Path: []string{"READ_ONLY"}, Kind: protocol.KindString, Access: 0x01},
+				},
+			},
+		},
+	}
+}
+
+func TestApply_DryRunSkipsWalk(t *testing.T) {
+	p := &countingPlugin{}
+	rep, err := Apply(context.Background(), p, snapshotForTest(), true)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if p.walkCalls != 0 {
+		t.Errorf("dry-run must not call Walk; got %d Walk call(s)", p.walkCalls)
+	}
+	if p.setCalls != 0 {
+		t.Errorf("dry-run must not call SetValue; got %d SetValue call(s)", p.setCalls)
+	}
+	if rep.Applied != 2 {
+		t.Errorf("dry-run report: applied=%d, want 2 (writable rows)", rep.Applied)
+	}
+	if rep.Skipped != 1 {
+		t.Errorf("dry-run report: skipped=%d, want 1 (read_only row)", rep.Skipped)
+	}
+	if !rep.DryRun {
+		t.Errorf("rep.DryRun must be true")
+	}
+}
+
+func TestApply_NonDryRunStillWalks(t *testing.T) {
+	p := &countingPlugin{}
+	_, err := Apply(context.Background(), p, snapshotForTest(), false)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if p.walkCalls != 1 {
+		t.Errorf("apply must call Walk once per slot; got %d", p.walkCalls)
+	}
+	if p.setCalls != 2 {
+		t.Errorf("apply must call SetValue for each writable row; got %d, want 2", p.setCalls)
+	}
+}


### PR DESCRIPTION
## Summary

- Dry-run no longer walks the full slot before iterating CSV rows. On ACP2 slot 1 (~49,827 objects) this drops the dry-run from minutes to ~26 ms (measured on the .103 producer with the 704-row `neuron-senders.csv`).
- The walked tree was only used by `SetValue` for typed encoding; dry-run never reaches `SetValue`, so the walk was dead weight.
- Non-dry-run behaviour unchanged — Walk still runs (ACP1 needs it for label-keyed encoding).

## Test plan

- [x] `TestApply_DryRunSkipsWalk` — counting mock plugin: `walkCalls == 0`, `setCalls == 0`, report `Applied=2 Skipped=1 DryRun=true`
- [x] `TestApply_NonDryRunStillWalks` — `walkCalls == 1`, `setCalls == 2`, confirms no regression
- [x] `go test ./internal/export/...` green
- [x] `go build ./...` green; `golangci-lint` green (pre-commit)
- [x] Live smoke on .103 producer: `time dhs consumer acp2 import 127.0.0.1 --slot 1 --file /tmp/neuron-senders.csv --dry-run` -> `real 0m0.026s`, output `would apply 704, skipped 0, failed 0`

Refs #413. (No auto-close on merge — close requires explicit approval.) Apply-time walk removal (ACP2/EmberPlus) deferred to #410 follow-up.