### PR TITLE
fix(cli/import): skip walk on apply for ACP2/EmberPlus (#415)

### DIFF
--- a/internal/export/importer.go
+++ b/internal/export/importer.go
@@ -88,14 +88,17 @@ func LoadSnapshot(path string) (*Snapshot, error) {
 func Apply(ctx context.Context, plug protocol.Protocol, s *Snapshot, dryRun bool) (*ImportReport, error) {
 	rep := &ImportReport{DryRun: dryRun}
 
+	// Walk is only needed when the protocol's SetValue requires a
+	// pre-populated label/type map. ACP1 does (SetValue errors out
+	// without a tree — see internal/acp1/consumer/plugin.go:597).
+	// ACP2 + EmberPlus have per-object meta-fetch fallbacks, so the
+	// walk is dead weight when the CSV already carries obj-id (acp2)
+	// or OID/path (emberplus). Dry-run never reaches SetValue at all,
+	// so the walk is dead weight there for every protocol.
+	walkNeeded := !dryRun && s.Device.Protocol == "acp1"
+
 	for _, dump := range s.Slots {
-		// Make sure the plugin has a fresh tree for this slot so
-		// SetValue can resolve labels and encode values.
-		//
-		// In dry-run we never call SetValue, so the walk is dead weight —
-		// for ACP2 slot 1 it would be thousands of get_object round-trips
-		// just to print "would write". Skip it entirely on dry-run.
-		if !dryRun {
+		if walkNeeded {
 			if _, err := plug.Walk(ctx, dump.Slot); err != nil {
 				rep.Failures = append(rep.Failures,
 					fmt.Sprintf("slot %d walk failed: %v", dump.Slot, err))

--- a/internal/export/importer_test.go
+++ b/internal/export/importer_test.go
@@ -36,9 +36,9 @@ func (p *countingPlugin) SetValue(context.Context, protocol.ValueRequest, protoc
 func (p *countingPlugin) Subscribe(protocol.ValueRequest, protocol.EventFunc) error { return nil }
 func (p *countingPlugin) Unsubscribe(protocol.ValueRequest) error                   { return nil }
 
-func snapshotForTest() *Snapshot {
+func snapshotForTest(proto string) *Snapshot {
 	return &Snapshot{
-		Device: DeviceInfo{Protocol: "acp2"},
+		Device: DeviceInfo{Protocol: proto},
 		Slots: []SlotDump{
 			{
 				Slot: 1,
@@ -58,7 +58,7 @@ func snapshotForTest() *Snapshot {
 
 func TestApply_DryRunSkipsWalk(t *testing.T) {
 	p := &countingPlugin{}
-	rep, err := Apply(context.Background(), p, snapshotForTest(), true)
+	rep, err := Apply(context.Background(), p, snapshotForTest("acp2"), true)
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
@@ -79,16 +79,49 @@ func TestApply_DryRunSkipsWalk(t *testing.T) {
 	}
 }
 
-func TestApply_NonDryRunStillWalks(t *testing.T) {
+// ACP2 apply skips the walk — the CSV's obj-id is enough; SetValue's
+// fetchObjectMeta fallback supplies type metadata per row.
+func TestApply_ACP2_ApplySkipsWalk(t *testing.T) {
 	p := &countingPlugin{}
-	_, err := Apply(context.Background(), p, snapshotForTest(), false)
+	_, err := Apply(context.Background(), p, snapshotForTest("acp2"), false)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if p.walkCalls != 0 {
+		t.Errorf("acp2 apply must not call Walk; got %d", p.walkCalls)
+	}
+	if p.setCalls != 2 {
+		t.Errorf("acp2 apply must call SetValue per writable row; got %d, want 2", p.setCalls)
+	}
+}
+
+// EmberPlus apply also skips the walk — path/OID resolution is per-row.
+func TestApply_EmberPlus_ApplySkipsWalk(t *testing.T) {
+	p := &countingPlugin{}
+	_, err := Apply(context.Background(), p, snapshotForTest("emberplus"), false)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if p.walkCalls != 0 {
+		t.Errorf("emberplus apply must not call Walk; got %d", p.walkCalls)
+	}
+	if p.setCalls != 2 {
+		t.Errorf("emberplus apply must call SetValue per writable row; got %d, want 2", p.setCalls)
+	}
+}
+
+// ACP1 apply still walks — its SetValue requires the walked tree for
+// typed encoding (no per-object meta fallback).
+func TestApply_ACP1_ApplyWalks(t *testing.T) {
+	p := &countingPlugin{}
+	_, err := Apply(context.Background(), p, snapshotForTest("acp1"), false)
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
 	if p.walkCalls != 1 {
-		t.Errorf("apply must call Walk once per slot; got %d", p.walkCalls)
+		t.Errorf("acp1 apply must call Walk once per slot; got %d", p.walkCalls)
 	}
 	if p.setCalls != 2 {
-		t.Errorf("apply must call SetValue for each writable row; got %d, want 2", p.setCalls)
+		t.Errorf("acp1 apply must call SetValue per writable row; got %d, want 2", p.setCalls)
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #414. Apply was unconditionally walking the slot before iterating snapshot rows. For ACP2/EmberPlus that walk is dead weight: the CSV carries `id` (acp2) or `oid/path` (emberplus), and `SetValue` has a per-object meta-fetch fallback. ACP1 still needs the walk (its `SetValue` requires the walked tree for typed encoding).

Gate: walk only when `!dryRun && Protocol == acp1`.

## Measured (704-row `neuron-senders.csv` against ACP2 producer on .103)

| Path | Before | After |
|---|---:|---:|
| `--dry-run` (from #414) | minutes | 26 ms |
| Real apply (this PR) | **~5 min** | **360 ms** |

## Test plan

- [x] `TestApply_DryRunSkipsWalk`           dryRun=true, acp2  -> walks=0 sets=0
- [x] `TestApply_ACP2_ApplySkipsWalk`       dryRun=false, acp2 -> walks=0 sets=2
- [x] `TestApply_EmberPlus_ApplySkipsWalk`  dryRun=false, ep   -> walks=0 sets=2
- [x] `TestApply_ACP1_ApplyWalks`           dryRun=false, acp1 -> walks=1 sets=2 (no regression for ACP1)
- [x] `go test ./internal/export/...` green
- [x] `go build ./...` green; `golangci-lint` green (pre-commit)
- [x] Live smoke on .103 producer: `time dhs consumer acp2 import 127.0.0.1 --slot 1 --file /tmp/neuron-senders.csv` -> `real 0m0.360s`, output `applied 704, skipped 0, failed 0`

## Dependencies

Branches on top of [feat/cli-import-no-walk-413](https://github.com/by-openclaw/go-acp/pull/414). Merge #414 first, then this rebases cleanly.

Refs #415. (No auto-close; close requires explicit approval.)