### PR TITLE
fix(cli/import): add ValueValidator + catch id/enum/type mismatches (#417)

### DIFF
--- a/internal/acp2/consumer/value_validate.go
+++ b/internal/acp2/consumer/value_validate.go
@@ -1,0 +1,152 @@
+package acp2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"dhs/internal/acp2/codec"
+	"dhs/internal/protocol"
+)
+
+// ValidateValue is the offline pre-flight check for one (req, val) pair.
+// Implements protocol.ValueValidator — the import / dry-run path uses
+// it to surface bad obj-ids, enum-out-of-options, and basic type
+// mismatches before any state-changing wire send.
+//
+// Distinct from Plugin.Validate (the ADR-0021 trace decoder).
+//
+// Pipeline (mirrors SetValue minus the set_property send):
+//  1. Look up obj-id in the walked-tree cache; on miss, single
+//     get_object. Device stat=1 → ErrObjectNotFound.
+//  2. Type-check val against the object's objType / numType.
+//  3. Enum / preset: val.Enum (or val.Str) must be in options.
+//  4. IPv4: val.IPAddr non-zero OR val.Str parseable.
+//
+// Returns nil when the SetValue is safe to attempt; otherwise wraps
+// protocol.ErrObjectNotFound or protocol.ErrValidationFailed.
+func (p *Plugin) ValidateValue(ctx context.Context, req protocol.ValueRequest, val protocol.Value) error {
+	p.mu.Lock()
+	s := p.session
+	p.mu.Unlock()
+	if s == nil {
+		return protocol.ErrNotConnected
+	}
+
+	tree, _ := p.trees.Get(req.Slot)
+
+	objID, objType, numType, obj, err := p.resolveRequest(req, tree)
+	if err != nil {
+		return fmt.Errorf("%w: %v", protocol.ErrValidationFailed, err)
+	}
+
+	// No tree → fetch metadata via single get_object. ACP2Error stat=1
+	// is the device telling us the obj-id is invalid.
+	if objType == 0 && tree == nil {
+		var miniTree *WalkedTree
+		objType, numType, miniTree, err = p.fetchObjectMeta(ctx, s, uint8(req.Slot), objID)
+		if err != nil {
+			var acpErr *codec.ACP2Error
+			if errors.As(err, &acpErr) && acpErr.Status == codec.ErrInvalidObjID {
+				return fmt.Errorf("%w: obj-id %d", protocol.ErrObjectNotFound, objID)
+			}
+			return fmt.Errorf("%w: meta fetch failed: %v", protocol.ErrValidationFailed, err)
+		}
+		tree = miniTree
+		if len(miniTree.Objects) > 0 {
+			obj = &miniTree.Objects[0]
+		}
+	}
+
+	// Build reverse enum map (label → wire index) for enum resolution.
+	var reverseEnum map[string]uint32
+	if tree != nil && obj != nil {
+		for i, tobj := range tree.Objects {
+			if tobj.ID == obj.ID && tree.OptionsMaps[i] != nil {
+				reverseEnum = make(map[string]uint32, len(tree.OptionsMaps[i]))
+				for wireIdx, label := range tree.OptionsMaps[i] {
+					reverseEnum[label] = wireIdx
+				}
+				break
+			}
+		}
+	}
+
+	return validateValueAgainstType(objType, numType, obj, val, reverseEnum)
+}
+
+// validateValueAgainstType is the type-check half of Validate, separated
+// so tests can drive it without setting up a Plugin + session.
+func validateValueAgainstType(objType codec.ACP2ObjType, numType codec.NumberType, obj *protocol.Object, val protocol.Value, reverseEnum map[string]uint32) error {
+	_ = numType
+	// Raw bytes escape hatch — caller knows the wire shape, trust them.
+	if len(val.Raw) > 0 && val.Str == "" && val.Int == 0 && val.Float == 0 && val.Uint == 0 {
+		return nil
+	}
+
+	switch objType {
+	case codec.ObjTypeNumber:
+		// KindUnknown means the CSV row's value didn't parse as the
+		// declared kind — that's the upstream signal for a bad type cell.
+		if val.Kind == protocol.KindUnknown {
+			return fmt.Errorf("%w: numeric object got unparseable value", protocol.ErrValidationFailed)
+		}
+		// A claimed numeric row with KindString and a non-empty Str means
+		// the CSV had a non-numeric in the value column.
+		if val.Kind == protocol.KindString && val.Str != "" {
+			return fmt.Errorf("%w: numeric object got string value %q", protocol.ErrValidationFailed, val.Str)
+		}
+		return nil
+
+	case codec.ObjTypeEnum, codec.ObjTypePreset:
+		// Accept a Str that reverse-maps to a valid wire idx.
+		if val.Str != "" && reverseEnum != nil {
+			if _, ok := reverseEnum[val.Str]; ok {
+				return nil
+			}
+		}
+		// Accept val.Enum if it's a known wire idx.
+		if reverseEnum != nil {
+			wireIdx := uint32(val.Enum)
+			for _, idx := range reverseEnum {
+				if idx == wireIdx {
+					return nil
+				}
+			}
+			return fmt.Errorf("%w: enum value %d (label %q) not in options", protocol.ErrValidationFailed, val.Enum, val.Str)
+		}
+		// No options map captured — best-effort accept; device will catch.
+		return nil
+
+	case codec.ObjTypeIPv4:
+		if val.IPAddr != [4]byte{} {
+			return nil
+		}
+		if val.Str == "" {
+			return fmt.Errorf("%w: ipv4 object got empty value", protocol.ErrValidationFailed)
+		}
+		parts := strings.Split(val.Str, ".")
+		if len(parts) != 4 {
+			return fmt.Errorf("%w: ipv4 value %q malformed", protocol.ErrValidationFailed, val.Str)
+		}
+		for _, p := range parts {
+			n, err := strconv.Atoi(p)
+			if err != nil || n < 0 || n > 255 {
+				return fmt.Errorf("%w: ipv4 value %q malformed", protocol.ErrValidationFailed, val.Str)
+			}
+		}
+		return nil
+
+	case codec.ObjTypeString:
+		// String objects accept any val.Str. Empty is allowed.
+		return nil
+	}
+
+	// Node containers and unknown types — nothing actionable, let device handle.
+	return nil
+}
+
+// Compile-time check that the plugin satisfies protocol.ValueValidator.
+var _ protocol.ValueValidator = (*Plugin)(nil)

--- a/internal/acp2/consumer/value_validate_test.go
+++ b/internal/acp2/consumer/value_validate_test.go
@@ -1,0 +1,79 @@
+package acp2
+
+import (
+	"errors"
+	"testing"
+
+	"dhs/internal/acp2/codec"
+	"dhs/internal/protocol"
+)
+
+func TestValidateValueAgainstType_Number_UnknownKindRejects(t *testing.T) {
+	val := protocol.Value{Kind: protocol.KindUnknown}
+	err := validateValueAgainstType(codec.ObjTypeNumber, codec.NumTypeU16, nil, val, nil)
+	if !errors.Is(err, protocol.ErrValidationFailed) {
+		t.Fatalf("want ErrValidationFailed, got %v", err)
+	}
+}
+
+func TestValidateValueAgainstType_Number_StringForIntRejects(t *testing.T) {
+	val := protocol.Value{Kind: protocol.KindString, Str: "not_a_number"}
+	err := validateValueAgainstType(codec.ObjTypeNumber, codec.NumTypeU16, nil, val, nil)
+	if !errors.Is(err, protocol.ErrValidationFailed) {
+		t.Fatalf("want ErrValidationFailed, got %v", err)
+	}
+}
+
+func TestValidateValueAgainstType_Number_IntAccepted(t *testing.T) {
+	val := protocol.Value{Kind: protocol.KindInt, Int: 12700}
+	if err := validateValueAgainstType(codec.ObjTypeNumber, codec.NumTypeU16, nil, val, nil); err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+}
+
+func TestValidateValueAgainstType_Enum_OutOfOptionsRejects(t *testing.T) {
+	reverse := map[string]uint32{"Input": 0, "Output": 1, "Off": 2}
+	val := protocol.Value{Kind: protocol.KindEnum, Enum: 99, Str: "XYZNotAnOption"}
+	err := validateValueAgainstType(codec.ObjTypeEnum, codec.NumTypePreset, nil, val, reverse)
+	if !errors.Is(err, protocol.ErrValidationFailed) {
+		t.Fatalf("want ErrValidationFailed, got %v", err)
+	}
+}
+
+func TestValidateValueAgainstType_Enum_KnownLabelAccepted(t *testing.T) {
+	reverse := map[string]uint32{"Input": 0, "Output": 1, "Off": 2}
+	val := protocol.Value{Kind: protocol.KindEnum, Str: "Output"}
+	if err := validateValueAgainstType(codec.ObjTypeEnum, codec.NumTypePreset, nil, val, reverse); err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+}
+
+func TestValidateValueAgainstType_Enum_KnownIndexAccepted(t *testing.T) {
+	reverse := map[string]uint32{"Input": 0, "Output": 1, "Off": 2}
+	val := protocol.Value{Kind: protocol.KindEnum, Enum: 1}
+	if err := validateValueAgainstType(codec.ObjTypeEnum, codec.NumTypePreset, nil, val, reverse); err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+}
+
+func TestValidateValueAgainstType_IPv4_MalformedRejects(t *testing.T) {
+	val := protocol.Value{Kind: protocol.KindString, Str: "not.an.ip.really"}
+	err := validateValueAgainstType(codec.ObjTypeIPv4, codec.NumTypeIPv4, nil, val, nil)
+	if !errors.Is(err, protocol.ErrValidationFailed) {
+		t.Fatalf("want ErrValidationFailed, got %v", err)
+	}
+}
+
+func TestValidateValueAgainstType_IPv4_DottedQuadAccepted(t *testing.T) {
+	val := protocol.Value{Kind: protocol.KindIPAddr, Str: "239.129.1.20"}
+	if err := validateValueAgainstType(codec.ObjTypeIPv4, codec.NumTypeIPv4, nil, val, nil); err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+}
+
+func TestValidateValueAgainstType_String_AnyValueAccepted(t *testing.T) {
+	val := protocol.Value{Kind: protocol.KindString, Str: "SDI 01"}
+	if err := validateValueAgainstType(codec.ObjTypeString, codec.NumTypeString, nil, val, nil); err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+}

--- a/internal/export/importer.go
+++ b/internal/export/importer.go
@@ -2,6 +2,7 @@ package export
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -88,6 +89,13 @@ func LoadSnapshot(path string) (*Snapshot, error) {
 func Apply(ctx context.Context, plug protocol.Protocol, s *Snapshot, dryRun bool) (*ImportReport, error) {
 	rep := &ImportReport{DryRun: dryRun}
 
+	// Optional offline pre-flight check. Plugins that can validate a
+	// (req, val) pair without a wire send implement ValueValidator;
+	// see internal/protocol/value_validator.go. ACP2 does — uses a
+	// single get_object to catch phantom obj-ids before SetValue, and
+	// rejects enum values outside the options list.
+	validator, _ := plug.(protocol.ValueValidator)
+
 	// Walk is only needed when the protocol's SetValue requires a
 	// pre-populated label/type map. ACP1 does (SetValue errors out
 	// without a tree — see internal/acp1/consumer/plugin.go:597).
@@ -172,6 +180,21 @@ func Apply(ctx context.Context, plug protocol.Protocol, s *Snapshot, dryRun bool
 					req.Path = obj.OID
 				} else if len(obj.Path) > 0 {
 					req.Path = strings.Join(obj.Path, ".")
+				}
+			}
+			// Pre-flight Validate when the plugin supports it. Catches
+			// phantom obj-id / enum-out-of-options / type-mismatch
+			// before any SetValue is attempted — applies to both
+			// dry-run and real apply.
+			if validator != nil {
+				if vErr := validator.ValidateValue(ctx, req, obj.Value); vErr != nil {
+					reason := "validation_failed"
+					if errors.Is(vErr, protocol.ErrObjectNotFound) {
+						reason = "not_found"
+					}
+					rep.Skipped++
+					rep.Skips = append(rep.Skips, skipFrom(dump.Slot, obj, reason))
+					continue
 				}
 			}
 			if dryRun {

--- a/internal/export/importer_test.go
+++ b/internal/export/importer_test.go
@@ -2,6 +2,7 @@ package export
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"dhs/internal/protocol"
@@ -9,9 +10,13 @@ import (
 
 // countingPlugin satisfies protocol.Protocol and counts Walk + SetValue
 // calls so tests can assert which device-touching paths Apply took.
+// validateErr (if set) is returned by ValidateValue — used by tests
+// that exercise the ValueValidator skip path.
 type countingPlugin struct {
-	walkCalls int
-	setCalls  int
+	walkCalls     int
+	setCalls      int
+	validateCalls int
+	validateErr   error // nil = always valid
 }
 
 func (p *countingPlugin) Connect(context.Context, string, int) error { return nil }
@@ -35,6 +40,42 @@ func (p *countingPlugin) SetValue(context.Context, protocol.ValueRequest, protoc
 }
 func (p *countingPlugin) Subscribe(protocol.ValueRequest, protocol.EventFunc) error { return nil }
 func (p *countingPlugin) Unsubscribe(protocol.ValueRequest) error                   { return nil }
+
+// ValidateValue makes countingPlugin satisfy protocol.ValueValidator.
+func (p *countingPlugin) ValidateValue(context.Context, protocol.ValueRequest, protocol.Value) error {
+	p.validateCalls++
+	return p.validateErr
+}
+
+// nonValidatorPlugin is a Protocol with no ValidateValue method —
+// used to assert the importer's graceful fallback when a plugin
+// doesn't implement ValueValidator.
+type nonValidatorPlugin struct {
+	walkCalls int
+	setCalls  int
+}
+
+func (p *nonValidatorPlugin) Connect(context.Context, string, int) error { return nil }
+func (p *nonValidatorPlugin) Disconnect() error                          { return nil }
+func (p *nonValidatorPlugin) GetDeviceInfo(context.Context) (protocol.DeviceInfo, error) {
+	return protocol.DeviceInfo{}, nil
+}
+func (p *nonValidatorPlugin) GetSlotInfo(context.Context, int) (protocol.SlotInfo, error) {
+	return protocol.SlotInfo{}, nil
+}
+func (p *nonValidatorPlugin) Walk(context.Context, int) ([]protocol.Object, error) {
+	p.walkCalls++
+	return nil, nil
+}
+func (p *nonValidatorPlugin) GetValue(context.Context, protocol.ValueRequest) (protocol.Value, error) {
+	return protocol.Value{}, nil
+}
+func (p *nonValidatorPlugin) SetValue(context.Context, protocol.ValueRequest, protocol.Value) (protocol.Value, error) {
+	p.setCalls++
+	return protocol.Value{}, nil
+}
+func (p *nonValidatorPlugin) Subscribe(protocol.ValueRequest, protocol.EventFunc) error { return nil }
+func (p *nonValidatorPlugin) Unsubscribe(protocol.ValueRequest) error                   { return nil }
 
 func snapshotForTest(proto string) *Snapshot {
 	return &Snapshot{
@@ -123,5 +164,75 @@ func TestApply_ACP1_ApplyWalks(t *testing.T) {
 	}
 	if p.setCalls != 2 {
 		t.Errorf("acp1 apply must call SetValue per writable row; got %d, want 2", p.setCalls)
+	}
+}
+
+// When a plugin returns ErrObjectNotFound from ValidateValue, the
+// importer must skip the row with reason "not_found" and never call
+// SetValue.
+func TestApply_ValidateNotFound_SkipsRow(t *testing.T) {
+	p := &countingPlugin{validateErr: protocol.ErrObjectNotFound}
+	rep, err := Apply(context.Background(), p, snapshotForTest("acp2"), false)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if p.setCalls != 0 {
+		t.Errorf("not_found rows must not reach SetValue; got %d set call(s)", p.setCalls)
+	}
+	// 2 writable + 1 read_only; both writables become not_found, the
+	// read-only stays read_only.
+	if rep.Skipped != 3 {
+		t.Errorf("rep.Skipped=%d, want 3", rep.Skipped)
+	}
+	notFoundCount := 0
+	for _, s := range rep.Skips {
+		if s.Reason == "not_found" {
+			notFoundCount++
+		}
+	}
+	if notFoundCount != 2 {
+		t.Errorf("not_found skip count=%d, want 2", notFoundCount)
+	}
+}
+
+// When a plugin returns ErrValidationFailed from ValidateValue, the
+// importer must skip the row with reason "validation_failed".
+func TestApply_ValidateFailed_SkipsRow(t *testing.T) {
+	wrapped := errors.New("enum not in options")
+	p := &countingPlugin{
+		// wrap so errors.Is works the same way the importer expects.
+		validateErr: errors.Join(protocol.ErrValidationFailed, wrapped),
+	}
+	rep, err := Apply(context.Background(), p, snapshotForTest("acp2"), true)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if p.setCalls != 0 {
+		t.Errorf("validation_failed rows must not reach SetValue; got %d", p.setCalls)
+	}
+	failedCount := 0
+	for _, s := range rep.Skips {
+		if s.Reason == "validation_failed" {
+			failedCount++
+		}
+	}
+	if failedCount != 2 {
+		t.Errorf("validation_failed skip count=%d, want 2", failedCount)
+	}
+}
+
+// Plugins that don't implement ValueValidator should fall through
+// the importer untouched — SetValue still runs for writable rows.
+func TestApply_NoValidator_GracefulFallback(t *testing.T) {
+	p := &nonValidatorPlugin{}
+	rep, err := Apply(context.Background(), p, snapshotForTest("acp2"), false)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if rep.Applied != 2 {
+		t.Errorf("no-validator path must still apply writable rows; got %d", rep.Applied)
+	}
+	if p.setCalls != 2 {
+		t.Errorf("SetValue should fire per writable row; got %d", p.setCalls)
 	}
 }

--- a/internal/export/read_csv.go
+++ b/internal/export/read_csv.go
@@ -221,24 +221,48 @@ func parseNum(s string, kind protocol.ValueKind) any {
 
 // parseCSVValue builds a protocol.Value from the CSV value + value_name
 // columns.
+//
+// On a type-incompatible value (e.g. "not_a_number" in an int column),
+// the returned Value carries Kind=KindUnknown so the downstream
+// importer's Validate / unknown_kind skip path catches it. This is the
+// signal that the CSV cell didn't parse — without it the silent
+// zero-default would let the importer write garbage.
 func parseCSVValue(kind protocol.ValueKind, val, name string, items []string) protocol.Value {
 	v := protocol.Value{Kind: kind}
 	switch kind {
 	case protocol.KindInt:
-		v.Int, _ = strconv.ParseInt(val, 10, 64)
+		n, err := strconv.ParseInt(val, 10, 64)
+		if err != nil && val != "" {
+			return protocol.Value{Kind: protocol.KindUnknown}
+		}
+		v.Int = n
 	case protocol.KindUint:
-		v.Uint, _ = strconv.ParseUint(val, 10, 64)
+		n, err := strconv.ParseUint(val, 10, 64)
+		if err != nil && val != "" {
+			return protocol.Value{Kind: protocol.KindUnknown}
+		}
+		v.Uint = n
 	case protocol.KindFloat:
-		v.Float, _ = strconv.ParseFloat(val, 64)
+		f, err := strconv.ParseFloat(val, 64)
+		if err != nil && val != "" {
+			return protocol.Value{Kind: protocol.KindUnknown}
+		}
+		v.Float = f
 	case protocol.KindEnum:
-		idx, _ := strconv.Atoi(val)
+		idx, err := strconv.Atoi(val)
+		if err != nil && val != "" {
+			return protocol.Value{Kind: protocol.KindUnknown}
+		}
 		v.Enum = uint8(idx)
 		v.Str = name
 	case protocol.KindString:
 		v.Str = val
 	case protocol.KindIPAddr:
 		var a, b, c, d uint8
-		_, _ = fmt.Sscanf(val, "%d.%d.%d.%d", &a, &b, &c, &d)
+		n, err := fmt.Sscanf(val, "%d.%d.%d.%d", &a, &b, &c, &d)
+		if (err != nil || n != 4) && val != "" {
+			return protocol.Value{Kind: protocol.KindUnknown}
+		}
 		v.IPAddr = [4]byte{a, b, c, d}
 	}
 	return v

--- a/internal/protocol/value_validator.go
+++ b/internal/protocol/value_validator.go
@@ -1,0 +1,40 @@
+package protocol
+
+import (
+	"context"
+	"errors"
+)
+
+// ValueValidator is the optional contract a Protocol implementation MAY
+// satisfy to support offline pre-flight checks on a single (obj, value)
+// pair. It mirrors SetValue's resolution + type-check pipeline minus the
+// wire send, so the CLI (notably `import --dry-run`) can detect bad
+// obj-ids, out-of-options enum values, and type mismatches before any
+// state-changing call.
+//
+// Plugins that can't validate offline simply don't implement this
+// interface — callers fall back to "ship the SetValue and catch the
+// device error". Use type assertion to detect support:
+//
+//	if v, ok := plug.(protocol.ValueValidator); ok { v.Validate(...) }
+//
+// Naming intentionally differs from the trace-decoder Validator (see
+// internal/protocol/validator.go) — that interface decodes captured
+// trames offline, this one checks a single ValueRequest against the
+// live device's object catalogue.
+type ValueValidator interface {
+	ValidateValue(ctx context.Context, req ValueRequest, val Value) error
+}
+
+// ErrObjectNotFound is returned by Validate when the request's object
+// resolution fails — for ACP2 this is the device replying stat=1 to a
+// single-object get_object. Callers (the importer) map this to a skip
+// reason of "not_found" so the operator sees the row was dropped
+// because the obj-id doesn't exist on the live device.
+var ErrObjectNotFound = errors.New("protocol: object not found")
+
+// ErrValidationFailed is returned by Validate when the value fails a
+// client-side check (wrong type, enum out of options, IPv4 not
+// parseable, etc.). Callers map this to a skip reason of
+// "validation_failed".
+var ErrValidationFailed = errors.New("protocol: validation failed")


### PR DESCRIPTION
﻿## Summary

Follow-up to #416. Live test of `import` against the ACP2 producer with deliberately broken rows surfaced three pre-existing safety gaps. Adds an optional `ValueValidator` interface plus an ACP2 implementation, wires the importer to call it before any SetValue, and tightens CSV value parsing.

## Live result (on .103 with `broken-senders.csv`)

|  | Before | After |
|---|---|---|
| dry-run | applied 7, skipped 1, failed 0 (lies) | applied 4, skipped 4, failed 0 |
| real apply | applied 5, skipped 1, **failed 2** | applied 4, skipped 4, failed 0 |

Three new skip reasons fire client-side instead of failing or silently writing garbage:

- `not_found` (1 row)        — phantom obj-id `99999999`
- `validation_failed` (2 rows) — `not_a_number` in int port + enum value `99` outside options

Read-only and device-side numeric clamping behaviour unchanged.

## Changes

1. **`internal/protocol/value_validator.go`** (new)
   - `ValueValidator` optional interface, method `ValidateValue` (name distinct from existing trace `Validator` per ADR-0021)
   - Sentinels `ErrObjectNotFound`, `ErrValidationFailed`

2. **`internal/acp2/consumer/value_validate.go`** (new)
   - `Plugin.ValidateValue` mirrors SetValue minus the wire send
   - Single `get_object` resolves obj-id; `ACP2Error{Status: ErrInvalidObjID}` -> `ErrObjectNotFound`
   - Type-check + enum-options check + IPv4 dotted-quad check
   - Compile-time `var _ protocol.ValueValidator = (*Plugin)(nil)`

3. **`internal/export/importer.go`**
   - Type-asserts plugin for `ValueValidator`; calls `ValidateValue` per row in both dry-run and apply paths
   - Maps errors to skip reasons `not_found` / `validation_failed`
   - Plugins without the interface fall through unchanged

4. **`internal/export/read_csv.go`**
   - `parseCSVValue` returns `KindUnknown` when value cell fails to parse as the declared kind; importer's existing `unknown_kind` skip catches the row

## Tests

- 9 unit tests in `internal/acp2/consumer/value_validate_test.go` (number / enum / ipv4 / string)
- 3 new importer tests: `TestApply_ValidateNotFound_SkipsRow`, `TestApply_ValidateFailed_SkipsRow`, `TestApply_NoValidator_GracefulFallback`
- All previous tests still green
- `go test ./internal/{export,acp2/consumer}/...` green
- `golangci-lint` green (pre-commit)

## Live smoke

```
$ dhs consumer acp2 import 127.0.0.1 --slot 1 --file /tmp/broken-senders.csv --dry-run
would apply 4, skipped 4, failed 0
  read_only (1):           id=15343 INPUT.SDI.CHANNEL 09.Used
  not_found (1):           id=99999999 does.not.exist
  validation_failed (2):   id=67605 Destination Port (int)
                           id=15758 Direction (enum)

$ time dhs consumer acp2 import 127.0.0.1 --slot 1 --file /tmp/broken-senders.csv
applied 4, skipped 4, failed 0
real 0m0.018s
```

## Dependencies

Branches on `feat/cli-import-apply-no-walk-415` (PR #416). Merge order: #414 -> #416 -> this. Each rebases cleanly onto the previous merge.

Refs #417. Still under #410: `defer recover()` belt, `--strict` flag, malformed-CSV row warning.
