### PR TITLE
fix(export/csv): unify path separator to '.' (refs #419)

### DIFF
--- a/internal/export/csv.go
+++ b/internal/export/csv.go
@@ -118,13 +118,15 @@ func buildCSVRow(dev DeviceInfo, slot SlotDump, o protocol.Object) []string {
 	return row
 }
 
-// joinPath renders the object's Path slice as a slash-separated string.
-// For ACP1 (single-level) this is usually just "control" / "status" /
-// "identity" / "alarm" / "frame". Falls back to the legacy Group field
-// when Path is empty, so this works during the transition before ACP2.
+// joinPath renders the object's Path slice as a dot-separated string —
+// same convention as Ember+ OID, the importer's req.Path resolver, and
+// watch event paths (see feedback_path_separator). For ACP1 (single-
+// level) this is usually just "control" / "status" / "identity" /
+// "alarm" / "frame". Falls back to the legacy Group field when Path is
+// empty.
 func joinPath(o protocol.Object) string {
 	if len(o.Path) > 0 {
-		return strings.Join(o.Path, "/")
+		return strings.Join(o.Path, ".")
 	}
 	return o.Group
 }

--- a/internal/export/read_csv.go
+++ b/internal/export/read_csv.go
@@ -62,12 +62,18 @@ func ReadCSV(r io.Reader) (*Snapshot, error) {
 		if pathStr == "" {
 			pathStr = col(row, idx, "group")
 		}
-		// Split slash-separated path back into segments for ACP2
-		// hierarchical import (e.g. "ROOT_NODE_V2/PSU/1/Present").
+		// Split path back into segments for ACP2 hierarchical import
+		// (e.g. "ROOT_NODE_V2.PSU.1.Present"). Primary separator is "."
+		// (matches Ember+ OID + memory rule feedback_path_separator);
+		// "/" is accepted as a fallback so CSVs from earlier exports
+		// (pre-#419) still import.
 		var pathSegs []string
-		if strings.Contains(pathStr, "/") {
+		switch {
+		case strings.Contains(pathStr, "."):
+			pathSegs = strings.Split(pathStr, ".")
+		case strings.Contains(pathStr, "/"):
 			pathSegs = strings.Split(pathStr, "/")
-		} else if pathStr != "" {
+		case pathStr != "":
 			pathSegs = []string{pathStr}
 		}
 		// ACP1 resolver still matches by (Group, ID) / (Group, Label).

--- a/internal/export/roundtrip_test.go
+++ b/internal/export/roundtrip_test.go
@@ -116,6 +116,72 @@ func TestCSV_RoundTrip(t *testing.T) {
 	}
 }
 
+// Writer emits "." as the path separator (matches Ember+ OID and the
+// importer's req.Path resolver — see feedback_path_separator).
+func TestCSV_Writer_UsesDotSeparator(t *testing.T) {
+	snap := &export.Snapshot{
+		Device: export.DeviceInfo{Protocol: "acp2"},
+		Slots: []export.SlotDump{{
+			Slot: 1,
+			Objects: []protocol.Object{{
+				Slot: 1, ID: 67604,
+				Path:  []string{"ROOT-NODE-V2", "OUTPUT", "IP", "VIDEO", "STREAM 1", "LEG 1", "Destination IP"},
+				Label: "Destination IP", Kind: protocol.KindString, Access: 3,
+				Value: protocol.Value{Kind: protocol.KindString, Str: "239.129.1.20"},
+			}},
+		}},
+	}
+	var buf bytes.Buffer
+	if err := export.WriteCSV(&buf, snap); err != nil {
+		t.Fatalf("WriteCSV: %v", err)
+	}
+	out := buf.String()
+	if !bytes.Contains(buf.Bytes(), []byte("ROOT-NODE-V2.OUTPUT.IP.VIDEO.STREAM 1.LEG 1.Destination IP")) {
+		t.Errorf("expected dot-separated path in CSV, got: %s", out)
+	}
+	if bytes.Contains(buf.Bytes(), []byte("ROOT-NODE-V2/OUTPUT")) {
+		t.Errorf("CSV still emits slash-separated path: %s", out)
+	}
+}
+
+// Reader accepts the new "." separator (primary).
+func TestCSV_Reader_AcceptsDotSeparator(t *testing.T) {
+	csv := "ip,protocol,slot,oid,path,id,label,kind,access,value,value_name,unit,min,max,step,default,enum_items,max_len,alarm_priority,alarm_tag,alarm_on,alarm_off,slot_status\n" +
+		"10.100.0.103,acp2,1,,ROOT-NODE-V2.OUTPUT.IP.VIDEO.STREAM 1.LEG 1.Destination IP,67604,Destination IP,string,RW-,239.129.1.20,,,,,,,256,,,,,\n"
+	got, err := export.ReadCSV(bytes.NewReader([]byte(csv)))
+	if err != nil {
+		t.Fatalf("ReadCSV: %v", err)
+	}
+	if len(got.Slots) != 1 || len(got.Slots[0].Objects) != 1 {
+		t.Fatalf("got %d slots / %d objects, want 1/1", len(got.Slots), len(got.Slots[0].Objects))
+	}
+	o := got.Slots[0].Objects[0]
+	if len(o.Path) != 7 {
+		t.Fatalf("dot-split path: got %d segments, want 7 (%v)", len(o.Path), o.Path)
+	}
+	if o.Path[4] != "STREAM 1" {
+		t.Errorf("segment[4] preserves space: got %q, want %q", o.Path[4], "STREAM 1")
+	}
+}
+
+// Reader still accepts the legacy "/" separator so CSVs exported before
+// #419 keep importing cleanly.
+func TestCSV_Reader_BackwardCompat_SlashSeparator(t *testing.T) {
+	csv := "ip,protocol,slot,oid,path,id,label,kind,access,value,value_name,unit,min,max,step,default,enum_items,max_len,alarm_priority,alarm_tag,alarm_on,alarm_off,slot_status\n" +
+		"10.100.0.103,acp2,1,,ROOT-NODE-V2/OUTPUT/IP/VIDEO/STREAM 1/LEG 1/Destination IP,67604,Destination IP,string,RW-,239.129.1.20,,,,,,,256,,,,,\n"
+	got, err := export.ReadCSV(bytes.NewReader([]byte(csv)))
+	if err != nil {
+		t.Fatalf("ReadCSV: %v", err)
+	}
+	o := got.Slots[0].Objects[0]
+	if len(o.Path) != 7 {
+		t.Fatalf("slash-split path: got %d segments, want 7 (%v)", len(o.Path), o.Path)
+	}
+	if o.Path[6] != "Destination IP" {
+		t.Errorf("segment[6]: got %q, want %q", o.Path[6], "Destination IP")
+	}
+}
+
 func TestAllFormats_SameObjectCount(t *testing.T) {
 	snap := sampleSnapshot()
 


### PR DESCRIPTION
﻿## Summary
- Unify path separator across all export formats. Refs #419.
- Writer emits `.` (matches Ember+ OID + `feedback_path_separator`).
- Reader accepts `.` primary, `/` fallback for backward-compat with pre-#419 CSVs.

## Why
Everywhere else in the codebase (JSON, YAML, watch events, importer `req.Path`, canonicalize) joins paths with `.`. CSV writer was the lone hold-out using `/`. Audit:

| Where | Pre | Post |
|---|---|---|
| `internal/export/csv.go:127` | `/` | `.` |
| `internal/export/read_csv.go` | only `/` | `.` primary, `/` fallback |

## Tests added
- `TestCSV_Writer_UsesDotSeparator` — new exports use `.`
- `TestCSV_Reader_AcceptsDotSeparator` — new format round-trips
- `TestCSV_Reader_BackwardCompat_SlashSeparator` — old `/` exports still import

All 3 new + existing `TestCSV_RoundTrip`, `TestCSV_PreservesOIDAndPath`, `TestAllFormats_SameObjectCount`: PASS locally.

## Risk
- Operator-visible: paths in CSV column change shape from `A/B/C` to `A.B.C`. Spaces in segments (`STREAM 1`) are preserved unchanged.
- Backward-compat: reader fallback means existing `/`-formatted CSVs (e.g. `neuron-senders.csv` already on disk) still import.

Refs #419.
