### PR TITLE
refactor(storage): unify DM cache layout to .cache/dm/<proto>/<id>.json (refs #424)

### DIFF
--- a/cmd/dhs/cmd_watch.go
+++ b/cmd/dhs/cmd_watch.go
@@ -147,7 +147,7 @@ func runWatch(ctx context.Context, args []string) error {
 				if perr != nil || identity == "" {
 					continue
 				}
-				snap, lerr := treeStore.LoadByIdentity(identity)
+				snap, lerr := treeStore.LoadByIdentity(cf.protocol, identity)
 				if lerr != nil || snap == nil || len(snap.Slots) == 0 {
 					continue
 				}
@@ -593,5 +593,5 @@ func saveIdentityCache(store *storage.TreeStore, identity, host, proto string, s
 			Objects:  objs,
 		}},
 	}
-	return store.SaveByIdentity(identity, snap)
+	return store.SaveByIdentity(proto, identity, snap)
 }

--- a/cmd/dhs/cmd_watch_cache_test.go
+++ b/cmd/dhs/cmd_watch_cache_test.go
@@ -55,7 +55,7 @@ func TestSaveSlotCache_ACP2_WritesIdentityKeyedOnly(t *testing.T) {
 
 	saveSlotCache(context.Background(), prober, "10.100.0.103", "acp2", 1, makeObjs())
 
-	dmPath := filepath.Join(root, "dm", "SHPRM1@0.7.json")
+	dmPath := filepath.Join(root, "dm", "acp2", "SHPRM1@0.7.json")
 	if _, err := os.Stat(dmPath); err != nil {
 		t.Fatalf("identity-keyed file missing: %v", err)
 	}
@@ -136,7 +136,7 @@ func TestSaveSlotCache_ACP2_DifferentCardsTwoFiles(t *testing.T) {
 	saveSlotCache(ctx, prober, "10.41.40.4", "acp2", 1, slot1)
 
 	for _, id := range []string{"SHPRM1@0.7", "SHPIO@0.7"} {
-		snap, err := treeStore.LoadByIdentity(id)
+		snap, err := treeStore.LoadByIdentity("acp2", id)
 		if err != nil || snap == nil {
 			t.Fatalf("LoadByIdentity(%q): snap=%v err=%v", id, snap, err)
 		}
@@ -167,9 +167,9 @@ func TestSaveSlotCache_ACP2_SameCardTwoSlots_OneFile(t *testing.T) {
 	saveSlotCache(ctx, prober, "10.41.40.4", "acp2", 0, slot0Objs)
 	saveSlotCache(ctx, prober, "10.41.40.4", "acp2", 1, slot1Objs)
 
-	files, err := os.ReadDir(filepath.Join(root, "dm"))
+	files, err := os.ReadDir(filepath.Join(root, "dm", "acp2"))
 	if err != nil {
-		t.Fatalf("read dm dir: %v", err)
+		t.Fatalf("read dm/acp2 dir: %v", err)
 	}
 	if len(files) != 1 {
 		names := make([]string, 0, len(files))

--- a/internal/storage/identity_roundtrip_test.go
+++ b/internal/storage/identity_roundtrip_test.go
@@ -1,6 +1,9 @@
 package storage
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -59,12 +62,12 @@ func TestSaveLoadByIdentity_PreservesMetaAndContent(t *testing.T) {
 		}},
 	}
 
-	if err := saver.SaveByIdentity("SHPRM1@0.7", snap); err != nil {
+	if err := saver.SaveByIdentity("acp2", "SHPRM1@0.7", snap); err != nil {
 		t.Fatalf("SaveByIdentity: %v", err)
 	}
 
 	loader := NewTreeStore(dir)
-	got, err := loader.LoadByIdentity("SHPRM1@0.7")
+	got, err := loader.LoadByIdentity("acp2", "SHPRM1@0.7")
 	if err != nil || got == nil {
 		t.Fatalf("LoadByIdentity: snap=%v err=%v", got, err)
 	}
@@ -113,7 +116,7 @@ func TestSaveLoadByIdentity_MultiInvocationMerge(t *testing.T) {
 
 	{
 		store := NewTreeStore(dir)
-		existing, _ := store.LoadByIdentity(identity)
+		existing, _ := store.LoadByIdentity("acp2", identity)
 		if existing != nil {
 			t.Fatalf("invocation 1 expected miss, got %v", existing)
 		}
@@ -132,14 +135,14 @@ func TestSaveLoadByIdentity_MultiInvocationMerge(t *testing.T) {
 				}},
 			}},
 		}
-		if err := store.SaveByIdentity(identity, snap); err != nil {
+		if err := store.SaveByIdentity("acp2", identity, snap); err != nil {
 			t.Fatalf("invocation 1 save: %v", err)
 		}
 	}
 
 	{
 		store := NewTreeStore(dir)
-		existing, err := store.LoadByIdentity(identity)
+		existing, err := store.LoadByIdentity("acp2", identity)
 		if err != nil || existing == nil {
 			t.Fatalf("invocation 2 expected hit, got snap=%v err=%v", existing, err)
 		}
@@ -160,13 +163,13 @@ func TestSaveLoadByIdentity_MultiInvocationMerge(t *testing.T) {
 				Meta: map[string]any{"acp2.objType": uint8(2)},
 			}},
 		})
-		if err := store.SaveByIdentity(identity, existing); err != nil {
+		if err := store.SaveByIdentity("acp2", identity, existing); err != nil {
 			t.Fatalf("invocation 2 save: %v", err)
 		}
 	}
 
 	store := NewTreeStore(dir)
-	final, err := store.LoadByIdentity(identity)
+	final, err := store.LoadByIdentity("acp2", identity)
 	if err != nil || final == nil {
 		t.Fatalf("final load: %v", err)
 	}
@@ -191,5 +194,72 @@ func TestSaveLoadByIdentity_MultiInvocationMerge(t *testing.T) {
 	}
 	if gotUnits[1] != "dBFS" {
 		t.Errorf("slot 1 Unit lost on merge: got %q want %q", gotUnits[1], "dBFS")
+	}
+}
+
+// TestIdentityPath_PerProtocolSubfolder pins the #424 layout: identity
+// caches now live under .cache/dm/<proto>/<identity>.json so ACP1 +
+// ACP2 + Ember+ can't collide on identical Model strings.
+func TestIdentityPath_PerProtocolSubfolder(t *testing.T) {
+	dir := t.TempDir()
+	store := NewTreeStore(dir)
+	snap := &export.Snapshot{
+		Device:    export.DeviceInfo{IP: "10.6.239.113", Protocol: "acp1"},
+		CreatedAt: time.Now().UTC(),
+		Slots: []export.SlotDump{{
+			Slot:     0,
+			WalkedAt: time.Now().UTC(),
+			Objects:  []protocol.Object{{Slot: 0, ID: 0, Label: "Card name"}},
+		}},
+	}
+	if err := store.SaveByIdentity("acp1", "RRS18@1601", snap); err != nil {
+		t.Fatalf("SaveByIdentity: %v", err)
+	}
+	wantPath := filepath.Join(dir, "dm", "acp1", "RRS18@1601.json")
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Fatalf("expected file at new layout %s: %v", wantPath, err)
+	}
+	legacyPath := filepath.Join(dir, "dm", "RRS18@1601.json")
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Errorf("legacy path MUST NOT be written: %s err=%v", legacyPath, err)
+	}
+}
+
+// TestLoadByIdentity_FallbackToLegacyPath verifies that caches written
+// by older dhs versions (.cache/dm/<identity>.json without proto
+// subfolder) still import. Required during the transition window.
+func TestLoadByIdentity_FallbackToLegacyPath(t *testing.T) {
+	dir := t.TempDir()
+	// Hand-write a legacy-layout cache file.
+	legacyDir := filepath.Join(dir, "dm")
+	if err := os.MkdirAll(legacyDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	legacyFile := filepath.Join(legacyDir, "CONVERT Hybrid@6.7.4.json")
+	snap := &export.Snapshot{
+		Device:    export.DeviceInfo{IP: "10.41.40.195", Protocol: "acp2"},
+		CreatedAt: time.Now().UTC(),
+		Slots: []export.SlotDump{{
+			Slot:     1,
+			WalkedAt: time.Now().UTC(),
+			Objects:  []protocol.Object{{Slot: 1, ID: 67604, Label: "Destination IP"}},
+		}},
+	}
+	f, _ := os.Create(legacyFile)
+	if err := json.NewEncoder(f).Encode(snap); err != nil {
+		t.Fatalf("write legacy: %v", err)
+	}
+	_ = f.Close()
+
+	store := NewTreeStore(dir)
+	got, err := store.LoadByIdentity("acp2", "CONVERT Hybrid@6.7.4")
+	if err != nil {
+		t.Fatalf("LoadByIdentity: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("legacy fallback missed file: %s", legacyFile)
+	}
+	if len(got.Slots) != 1 || got.Slots[0].Objects[0].Label != "Destination IP" {
+		t.Errorf("legacy fallback decoded wrong content: %+v", got.Slots)
 	}
 }

--- a/internal/storage/tree_store.go
+++ b/internal/storage/tree_store.go
@@ -142,13 +142,27 @@ func (s *TreeStore) Load(ip string, slot int) (*export.Snapshot, error) {
 // identityPath returns the file path for an identity-keyed cache.
 // Identity strings come straight from the consumer (e.g.
 // "SHPRM1@0.7"); we sanitise to keep them filesystem-safe across
-// Windows + POSIX.
-func (s *TreeStore) identityPath(identity string) string {
-	safe := identity
+// Windows + POSIX. Per #424, files now live under a per-protocol
+// subfolder so ACP1 / ACP2 / Ember+ caches don't collide on
+// identical Model strings.
+func (s *TreeStore) identityPath(proto, identity string) string {
+	return filepath.Join(s.baseDir, "dm", sanitizeSeg(proto), sanitizeSeg(identity)+".json")
+}
+
+// legacyIdentityPath returns the pre-#424 file path (no <proto>/
+// subfolder). Kept so LoadByIdentity can fall back to caches written
+// by older versions of dhs.
+func (s *TreeStore) legacyIdentityPath(identity string) string {
+	return filepath.Join(s.baseDir, "dm", sanitizeSeg(identity)+".json")
+}
+
+// sanitizeSeg strips characters that are illegal in filenames on
+// Windows + POSIX so identity strings + proto names go to disk safely.
+func sanitizeSeg(s string) string {
 	for _, ch := range []string{"/", "\\", ":", "*", "?", "\"", "<", ">", "|"} {
-		safe = strings.ReplaceAll(safe, ch, "_")
+		s = strings.ReplaceAll(s, ch, "_")
 	}
-	return filepath.Join(s.baseDir, "dm", safe+".json")
+	return s
 }
 
 // SaveByIdentity writes a multi-slot snapshot keyed by stable device
@@ -175,14 +189,17 @@ func (s *TreeStore) identityPath(identity string) string {
 // Direct json.Marshal preserves the exact protocol.Object struct on
 // disk, so successive walks of slot 0 + slot 1 + slot N accumulate
 // into the same file with no field loss.
-func (s *TreeStore) SaveByIdentity(identity string, snap *export.Snapshot) error {
+func (s *TreeStore) SaveByIdentity(proto, identity string, snap *export.Snapshot) error {
+	if proto == "" {
+		return fmt.Errorf("storage: SaveByIdentity: empty proto")
+	}
 	if identity == "" {
 		return fmt.Errorf("storage: SaveByIdentity: empty identity")
 	}
 	if snap == nil {
 		return fmt.Errorf("storage: SaveByIdentity: nil snapshot")
 	}
-	path := s.identityPath(identity)
+	path := s.identityPath(proto, identity)
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("storage: mkdir %s: %w", dir, err)
@@ -220,17 +237,30 @@ func (s *TreeStore) SaveByIdentity(identity string, snap *export.Snapshot) error
 // auto-detect requires len(Slots[0].Objects) > 0 to accept the flat
 // path, and a freshly-initialised snapshot with an empty slot 0 dump
 // would fall through to the lossy hierarchical reader.
-func (s *TreeStore) LoadByIdentity(identity string) (*export.Snapshot, error) {
+func (s *TreeStore) LoadByIdentity(proto, identity string) (*export.Snapshot, error) {
+	if proto == "" {
+		return nil, fmt.Errorf("storage: LoadByIdentity: empty proto")
+	}
 	if identity == "" {
 		return nil, fmt.Errorf("storage: LoadByIdentity: empty identity")
 	}
-	path := s.identityPath(identity)
+	// Primary: new per-proto path .cache/dm/<proto>/<identity>.json.
+	path := s.identityPath(proto, identity)
 	f, err := os.Open(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("storage: open %s: %w", path, err)
 		}
-		return nil, fmt.Errorf("storage: open %s: %w", path, err)
+		// Backward compat fallback: pre-#424 path with no proto folder.
+		legacy := s.legacyIdentityPath(identity)
+		f, err = os.Open(legacy)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("storage: open %s: %w", legacy, err)
+		}
+		path = legacy
 	}
 	defer func() { _ = f.Close() }()
 	var snap export.Snapshot


### PR DESCRIPTION
﻿## Summary
Per-protocol subfolder for identity-keyed DM cache. Refs #424.

| Where | Before | After |
|---|---|---|
| ACP1 cache | `.cache/devices/<ip>/slot_*.json` (IP-keyed) | `.cache/dm/acp1/<Model>@<SwRev>.json` (identity-keyed) |
| ACP2 cache | `.cache/dm/<CardName>@<HwVer>.json` (flat) | `.cache/dm/acp2/<Model>@<SwRev>.json` (per-proto subfolder) |

## Behaviour
- Writer always emits new path
- Reader falls back to pre-#424 flat `.cache/dm/<id>.json` so caches from older dhs versions still hot-load during transition
- API: `SaveByIdentity(proto, identity, snap)` / `LoadByIdentity(proto, identity)` — new `proto` param
- Callers updated: `cmd_watch.go` hot-load + `saveIdentityCache`
- ACP1 + ACP2 IdentityProbe implementations unchanged (already return `Model@Version`)

## Tests
| Test | Asserts |
|---|---|
| `TestIdentityPath_PerProtocolSubfolder` | Writer emits `.cache/dm/<proto>/<id>.json`, not flat |
| `TestLoadByIdentity_FallbackToLegacyPath` | Reader still loads pre-#424 flat path |
| `TestSaveLoadByIdentity_PreservesMetaAndContent` (existing) | Round-trip preserves Meta + Unit + Path + optionsMap |
| `TestSaveLoadByIdentity_MultiInvocationMerge` (existing) | Two-slot accumulation works |
| `TestSaveSlotCache_ACP2_*` (existing) | cmd_watch routing unchanged |

All 4 new + 4 existing storage tests pass locally. `cmd/dhs` + `internal/storage` full suite green.

## Risk
Operators who relied on flat `.cache/dm/` paths in scripts will see files move into `<proto>/` subfolders. Reader fallback covers existing caches; new caches use new path.

Refs #424.
