### PR TITLE
fix(cli/import): drop ACP1 walk gate (refs #423)

### DIFF
--- a/internal/acp1/consumer/plugin.go
+++ b/internal/acp1/consumer/plugin.go
@@ -527,10 +527,16 @@ func (p *Plugin) GetValue(ctx context.Context, req protocol.ValueRequest) (proto
 
 	obj, acpType, found := findObject(tree, group, id)
 	if !found {
-		// Walker never traverses root/frame/file groups, so lookups
-		// there always miss. Fall back to a group-based decode for the
-		// well-known types we understand even without walker context.
-		return decodeByGroup(group, reply.Value)
+		// No cached tree → try a single getObject to discover the type
+		// (refs #421). Mirrors SetValue's cold-cache path so get/set
+		// stay symmetric. Falls back to decodeByGroup if the meta
+		// fetch itself fails (covers root/frame/file groups the
+		// walker never traverses).
+		mObj, mType, mErr := p.fetchObjectMeta(ctx, req.Slot, group, id)
+		if mErr != nil {
+			return decodeByGroup(group, reply.Value)
+		}
+		obj, acpType = mObj, mType
 	}
 	return DecodeValueBytes(obj, acpType, reply.Value)
 }
@@ -828,9 +834,22 @@ func (p *Plugin) Unsubscribe(req protocol.ValueRequest) error {
 // exists in a different group, the error message suggests where it was
 // found — a common source of confusion for users who forget which group
 // a label belongs to.
+//
+// Importer-friendly cold-cache fall-through (#421): when Label is set
+// AND tree is nil AND a valid (Group, ID) is also provided, use the
+// explicit pair instead of erroring. CSV import rows carry id + label
+// for round-trip fidelity; label resolution needs a walked tree but
+// id doesn't, so this lets walk-free import work for ACP1.
 func resolve(req protocol.ValueRequest, tree *SlotTree) (codec.ObjGroup, byte, error) {
 	if req.Label != "" {
 		if tree == nil {
+			// Cold-cache fall-through: prefer the explicit (Group, ID)
+			// when supplied (CSV importer carries both for round-trip).
+			if req.Group != "" && req.ID >= 0 && req.ID <= 255 {
+				if g, ok := codec.ParseGroup(req.Group); ok {
+					return g, byte(req.ID), nil
+				}
+			}
 			return 0, 0, fmt.Errorf("%w: no walked tree for slot %d",
 				protocol.ErrUnknownLabel, req.Slot)
 		}

--- a/internal/export/importer.go
+++ b/internal/export/importer.go
@@ -96,14 +96,11 @@ func Apply(ctx context.Context, plug protocol.Protocol, s *Snapshot, dryRun bool
 	// rejects enum values outside the options list.
 	validator, _ := plug.(protocol.ValueValidator)
 
-	// Walk is only needed when the protocol's SetValue requires a
-	// pre-populated label/type map. ACP1 does (SetValue errors out
-	// without a tree — see internal/acp1/consumer/plugin.go:597).
-	// ACP2 + EmberPlus have per-object meta-fetch fallbacks, so the
-	// walk is dead weight when the CSV already carries obj-id (acp2)
-	// or OID/path (emberplus). Dry-run never reaches SetValue at all,
-	// so the walk is dead weight there for every protocol.
-	walkNeeded := !dryRun && s.Device.Protocol == "acp1"
+	// No protocol needs a pre-walk on import any more. ACP2 + EmberPlus
+	// have per-object meta fetch since v0.10.0; ACP1 gained the same
+	// pattern in #421. SetValue resolves type metadata per row via a
+	// single getObject on cache miss — cost is ~ms vs walking the slot.
+	walkNeeded := false
 
 	for _, dump := range s.Slots {
 		if walkNeeded {

--- a/internal/export/importer_test.go
+++ b/internal/export/importer_test.go
@@ -151,16 +151,17 @@ func TestApply_EmberPlus_ApplySkipsWalk(t *testing.T) {
 	}
 }
 
-// ACP1 apply still walks — its SetValue requires the walked tree for
-// typed encoding (no per-object meta fallback).
-func TestApply_ACP1_ApplyWalks(t *testing.T) {
+// ACP1 apply also skips the walk now (per #423). Plugin.SetValue
+// falls back to fetchObjectMeta on cache miss (#421), so the importer
+// no longer needs to pre-walk to populate type metadata.
+func TestApply_ACP1_ApplySkipsWalk(t *testing.T) {
 	p := &countingPlugin{}
 	_, err := Apply(context.Background(), p, snapshotForTest("acp1"), false)
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
-	if p.walkCalls != 1 {
-		t.Errorf("acp1 apply must call Walk once per slot; got %d", p.walkCalls)
+	if p.walkCalls != 0 {
+		t.Errorf("acp1 apply must not call Walk; got %d", p.walkCalls)
 	}
 	if p.setCalls != 2 {
 		t.Errorf("acp1 apply must call SetValue per writable row; got %d, want 2", p.setCalls)


### PR DESCRIPTION
﻿## Summary
Drops the protocol gate on import's walk-skip. With ACP1 gaining `fetchObjectMeta` + `ValueValidator` (peer PR #426), no protocol needs a pre-walk for import any more. Refs #423.

## Change
[importer.go:106](internal/export/importer.go#L106):

```diff
-walkNeeded := !dryRun && s.Device.Protocol == "acp1"
+walkNeeded := false
```

Per-row resolution: ACP2 via `ID` (since v0.10.0), Ember+ via `OID`, ACP1 via `(Group, ID)` (this PR's stack).

## Tests
- `TestApply_ACP1_ApplyWalks` → renamed `TestApply_ACP1_ApplySkipsWalk`. Asserts `walkCalls == 0` and `setCalls > 0`.
- Existing dry-run, ACP2, EmberPlus, validator skip tests preserved.

## Live verification (ACP1 producer on LXC 10.100.0.102)
| | Time |
|---|---|
| `import --dry-run` on 7-row CSV | ~0.6 s |
| `import` real apply on 7-row CSV | ~1.0 s |

No `walk slot N` line in stderr on either path. SetValue lands per row via `fetchObjectMeta` cold-cache fallback (one extra getObject per row).

## Stacked
Targets `main` after PR #426 (the meta-fetch + validator base) merges. If GitHub's auto-rebase complains, I'll rebase locally and force-push.

Refs #423.
