### PR TITLE
fix(storage): emit slot-agnostic DM (refs #430)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ Foundational ADRs every agent reads first:
 | [0016](docs/adr/0016-multi-os-support.md) | multi-OS support per connector |
 | [0022](docs/adr/0022-card-data-model.md) | card data model — Device/Frame/Slot/Card/DM + manifest |
 | [0023](docs/adr/0023-matrix-entity.md) | matrix entity — matrix_id/level_id/size/behavior |
+| [0024](docs/adr/0024-federation-mirror-and-virtual-frame.md) | federation: mirror frame vs virtual frame |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,8 @@ Foundational ADRs every agent reads first:
 | [0014](docs/adr/0014-issue-tracking-discipline.md) | issue → branch → tests → PR → CI green → `@yboujraf` approval → merge |
 | [0015](docs/adr/0015-single-source-of-truth.md) | no duplicated rules across docs |
 | [0016](docs/adr/0016-multi-os-support.md) | multi-OS support per connector |
+| [0022](docs/adr/0022-card-data-model.md) | card data model — Device/Frame/Slot/Card/DM + manifest |
+| [0023](docs/adr/0023-matrix-entity.md) | matrix entity — matrix_id/level_id/size/behavior |
 
 ---
 
@@ -316,7 +318,7 @@ DHSError (base)
 Files only. No database. No Redis. Per ADR-0020 buckets:
 
 - **User config**: per-OS data dir (`~/.local/share/dhs/` etc.) — overridable via `--data-dir`.
-- **Cache** (gitignored): `.cache/` next to the binary. Per-protocol cache shape lives in [`internal/<proto>/docs/runbook.md`](internal/) (e.g. ACP2 = identity-keyed `dm/<id>.json`, ACP1 = IP-keyed `devices/<ip>/slot_<n>.json`).
+- **Cache** (gitignored): `.cache/` next to the binary. Layout per [ADR-0022](docs/adr/0022-card-data-model.md): `.cache/dm/<proto>/<Model@SwRev>.json` (versioned, never overwritten) + `.cache/manifest/<device-name>.yaml`.
 - **Captures** (gitignored, no LFS): `captures/<proto>/<scenario>/`.
 
 Value freshness: values load as **stale**, confirmed by a live source

--- a/cmd/dhs/cmd_watch.go
+++ b/cmd/dhs/cmd_watch.go
@@ -7,10 +7,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"time"
 
 	"dhs/internal/dmlib"
-	"dhs/internal/export"
 	"dhs/internal/protocol"
 	"dhs/internal/storage"
 )
@@ -576,22 +574,15 @@ func saveSlotCache(ctx context.Context, prober identityProber, host, proto strin
 	}
 }
 
-// saveIdentityCache writes a single-slot DM file keyed by card
-// identity. The DM is the schema of ONE card type — multi-slot
-// merging is gone (different slots can hold different cards →
-// different files; same card in multiple slots → same file written
-// once). Slot/frame composition is a runtime concern, not in the DM.
+// saveIdentityCache writes a per-card DM file (#430). DM is
+// slot-agnostic, host-agnostic — the schema of ONE card type. Two
+// slots holding the same card share the same DM file. Slot, IP, host
+// info are runtime state and never persisted into the DM.
+//
+// host + slot params kept for symmetry with the IP-keyed Save path
+// and for future logging; they are NOT written to disk.
 func saveIdentityCache(store *storage.TreeStore, identity, host, proto string, slot int, objs []protocol.Object) error {
-	now := time.Now().UTC()
-	snap := &export.Snapshot{
-		Device:    export.DeviceInfo{IP: host, Protocol: proto},
-		Generator: "dhs dm-cache",
-		CreatedAt: now,
-		Slots: []export.SlotDump{{
-			Slot:     slot,
-			WalkedAt: now,
-			Objects:  objs,
-		}},
-	}
-	return store.SaveByIdentity(proto, identity, snap)
+	_ = host
+	_ = slot
+	return store.SaveByIdentity(proto, identity, objs)
 }

--- a/docs/adr/0022-card-data-model.md
+++ b/docs/adr/0022-card-data-model.md
@@ -1,0 +1,176 @@
+# ADR-0022 — Card data model (Device / Frame / Slot / Card / DM)
+
+Status: accepted
+
+This ADR is a **living document**. Add new facts in the Revisions
+trailer at the end. Do not spawn a new ADR number unless the whole
+record is being superseded.
+
+## Context
+
+Every connector (ACP1, ACP2, Ember+, Probel, OSC, TSL, NMOS, future)
+needs the same entity model for physical inventory and the per-card
+setup surface. Without one, each protocol drifts on cache shape, slot
+semantics, redundancy modelling, and addressing tokens — and every
+atomic refactor breaks the others.
+
+NetBox is the industry-standard data model for physical inventory
+(`dcim.Device`, `dcim.Module`, `dcim.ModuleBay`, `dcim.ModuleType`,
+`dcim.Interface`, `dcim.PowerPort`, `ipam.IPAddress`). Aligning our
+vocabulary with NetBox prevents reinvention as the project grows
+(PSU pairs, LACP, OOB management, redundancy).
+
+## Decision
+
+### Entity hierarchy (every connector)
+
+```
+Device              physical unit (chassis / rack / standalone box)
+└── Frame[]         chassis instance per Device (usually 1)
+    └── Slot[]      card bays — sparse, empty bays omitted
+        └── Card    instance of a card model in that slot
+            └── DM  the card's protocol surface (objects)
+```
+
+Matrix is a separate entity — see ADR-0023.
+
+### DM is the schema
+
+| DM carries | DM does NOT carry |
+|---|---|
+| model, sw_rev, protocol, objects | slot, IP, port, host, num_slots, device block, generator/created_at envelope |
+
+- DM is keyed by `(Model, SwRev)` — nothing else.
+- DM is agnostic of IP, frame, slot, host, port.
+- Same card walked at any slot at any IP yields the **same DM file**.
+- Two slots holding the same card reference the same DM by string; no
+  on-disk duplication.
+
+### Storage layout (locked)
+
+```
+.cache/dm/<proto>/<Model@SwRev>.json     per-card schema, versioned
+.cache/manifest/<device-name>.yaml       per-device wiring
+```
+
+DM versioning rules:
+
+- New `(Model, SwRev)` observed → new file.
+- Never overwrite an existing DM file.
+- Never dedupe — two SwRevs with identical trees both persist.
+
+### Manifest shape
+
+The manifest answers **where**; the DM answers **what**.
+
+```yaml
+device:
+  name: <stable-name>
+  protocol: <proto>
+  endpoints:
+    - ip: <ipv4>
+      port: <int>
+      transport: tcp|udp          # L4 only; framing handled by plugin
+    # second endpoint = redundant controller (same Frame, standby)
+    - ip: <ipv4>
+      port: <int>
+      transport: tcp|udp
+frames:
+  - name: <frame-name>
+    slots:
+      - addr: <protocol-specific>  # opaque token, schema below
+        dm: <Model>@<SwRev>        # reference into .cache/dm/<proto>/
+```
+
+`addr` is an opaque object whose schema is owned by the plugin. Core
+only knows: each entry resolves to one DM file via `Model@SwRev`.
+
+| Protocol | `addr` shape |
+|---|---|
+| ACP1 | `{ slot: <int> }` |
+| ACP2 | `{ slot: <int> }` |
+| Ember+ | `{ oid: "<dotted.path>" }` (single tree; root or subtree per "card") |
+| Probel | `{ matrix: <int>, level: <int> }` (matrix-native; see ADR-0023) |
+| Future | plugin defines its own keys (unit id, mac, channel index, ...) |
+
+### Redundancy
+
+- Redundant controller = **N endpoints on ONE Frame** sharing the same
+  slots and DMs. Never modelled as N separate Frames.
+- The connector drives **exactly one session at any time**; the others
+  are standby. Election is lease-based for stateful protocols (per
+  `project_ha_architecture` memory).
+- LACP / bonded NICs are below the connector's view (OS exposes one
+  IP). Modelled in the manifest as a single endpoint.
+
+### Card NICs are DM objects, not Frame entities
+
+A card's NICs, IPs, VLANs, and per-port configuration are **objects
+inside the DM tree**, walked over the protocol like any other
+parameter. The Frame layer does NOT carry separate `Interface` records
+per card. NetBox vocabulary maps to the Frame layer only; below the
+Slot, everything is DM.
+
+### NetBox vocabulary mapping (Frame layer)
+
+| dhs concept | NetBox object |
+|---|---|
+| Device / Frame chassis | `dcim.Device` |
+| Frame model | `dcim.DeviceType` |
+| Slot (card bay) | `dcim.ModuleBay` |
+| Card (instance) | `dcim.Module` |
+| Card model | `dcim.ModuleType` |
+| PSU (×1 or ×2) | `dcim.PowerPort` |
+| Controller card | `dcim.Module` (role=controller) |
+| 2× controllers redundant | 2× `dcim.Module` + `dcim.VirtualChassis` |
+| OOB / iDRAC / iLO / BMC | `dcim.Interface` `mgmt_only=true` + `Device.oob_ip` |
+| Production IP | `ipam.IPAddress` → Interface, `Device.primary_ip4` |
+| Static IP | `ipam.IPAddress` `status=active` assigned to Interface |
+| Card-internal NIC, port, parameter | NOT in NetBox — lives inside the DM tree |
+
+### Where the Frame view is used
+
+- Monitoring + RCA: when an object disappears, the path
+  Object → DM → Card → Slot → Frame → Device → endpoint gives the
+  physical locator and the alert target.
+- Administration: firmware upgrade, hot-swap, capacity audit, NetBox
+  sync.
+
+The Frame view is NOT the operational surface — that is the DM (per
+protocol) feeding the federation layer.
+
+## Consequences
+
+- Single canonical layout — connectors stop re-deciding per-protocol
+  cache shape.
+- DM library and runtime cache collapse into one location
+  (`.cache/dm/<proto>/`).
+- Manifest enables multi-frame, multi-controller deployments without
+  schema changes.
+- NetBox alignment documented; any future NetBox sync exporter has a
+  pre-mapped vocabulary at the Frame layer.
+- ACP2 identity-keyed special case is retired; same layout for every
+  protocol.
+
+## Forbidden
+
+- DM files containing IP, port, slot, host, num_slots, device block,
+  generator, or created_at envelope.
+- IP-keyed DM cache (`.cache/devices/<ip>/...`) for any new protocol.
+- Modelling redundancy as multiple Frames per Device.
+- Per-card NIC/IP/port modelled at the Frame layer instead of inside
+  the DM tree.
+- Restating any of this in CLAUDE.md, per-connector CLAUDE.md, agent
+  files, or memory — those point at this ADR per ADR-0015.
+
+## Enforcement
+
+- PR review checklist line: "any change to DM cache layout, manifest
+  shape, or Frame entity → block until this ADR is updated".
+- CI check: DM JSON files MUST NOT contain top-level `device`,
+  `slots`, `created_at`, `generator`, `host`, `ip`, or `port`.
+- Memory `project_dhs_data_model.md` is a 3-line bookmark to this ADR.
+
+## Revisions
+
+- 2026-05-14 — initial — yboujraf

--- a/docs/adr/0022-card-data-model.md
+++ b/docs/adr/0022-card-data-model.md
@@ -128,6 +128,30 @@ Slot, everything is DM.
 | Static IP | `ipam.IPAddress` `status=active` assigned to Interface |
 | Card-internal NIC, port, parameter | NOT in NetBox — lives inside the DM tree |
 
+### Every connector uses the manifest — no legacy single-tree input
+
+Every producer (ACP1, ACP2, Ember+, Probel, OSC, TSL, NMOS, future)
+boots from `.cache/manifest/<device>.json` + `.cache/dm/<proto>/<Model@SwRev>.json`
+references. The legacy `--tree singlefile.json` path is parity debt and
+is being retired. Consumers and admin tooling resolve cards through the
+same manifest → DM lookup. No protocol may invent its own producer-input
+shape.
+
+### Default value sources
+
+A parameter's default value can come from two places. Both coexist; the
+UI override wins at runtime when both are present.
+
+| Source | Lives in | Scope |
+| --- | --- | --- |
+| Vendor default | the DM file (`.cache/dm/<proto>/<Model@SwRev>.json`, per-object `default` field walked off the card) | every instance of this Model@SwRev — baked into the catalogued schema |
+| UI override (per-DM) | side-car under `.cache/manifest/defaults/<Model@SwRev>.json` | every instance of this Model@SwRev — operator/SI overrides the vendor default for a card type |
+| UI override (per-instance) | manifest slot entry under `defaults: { obj-id-or-path: value }` | this physical card in this slot only |
+
+Resolution order at runtime: per-instance override → per-DM override →
+vendor default (DM file). `setDefValue` returns whatever this resolution
+produces.
+
 ### Where the Frame view is used
 
 - Monitoring + RCA: when an object disappears, the path
@@ -174,3 +198,4 @@ protocol) feeding the federation layer.
 ## Revisions
 
 - 2026-05-14 — initial — yboujraf
+- 2026-05-14 — every connector boots from manifest+DM; legacy `--tree singlefile.json` is retired parity debt. Default value resolves per-instance override → per-DM override → vendor DM default — yboujraf

--- a/docs/adr/0023-matrix-entity.md
+++ b/docs/adr/0023-matrix-entity.md
@@ -1,0 +1,159 @@
+# ADR-0023 — Matrix entity
+
+Status: accepted
+
+This ADR is a **living document**. Add new facts in the Revisions
+trailer at the end. Do not spawn a new ADR number unless the whole
+record is being superseded.
+
+## Context
+
+Routing matrices (Probel SW-P-08/SW-P-88, Ember+ matrix nodes, NMOS
+IS-05 connections, future fieldbus crossbars) are not cards in a slot
+and don't fit the Frame → Slot → Card hierarchy from ADR-0022. They
+need their own entity with its own addressing tokens.
+
+A matrix can be:
+- the entire payload of a protocol (Probel — every command is a matrix
+  operation),
+- a node inside a tree (Ember+ — matrix lives at a specific OID under
+  the device's tree),
+- a per-card surface (an SDI router card in a Synapse-style frame
+  exposing a small matrix via its DM objects).
+
+## Decision
+
+### Matrix is a parallel entity
+
+Matrix sits beside the Card/Frame hierarchy (ADR-0022), not under it.
+A single Device can carry:
+- zero or more Cards (Frame → Slot → Card → DM)
+- zero or more Matrices, each with its own coordinates
+
+### Matrix identity
+
+| Field | Meaning |
+|---|---|
+| `matrix_id` | integer per device |
+| `level_id` | level index (audio L/R/embed/multi-format/etc) |
+| `size` | `(destinations, sources)` tuple — scale rules per `project_scale_requirements` |
+| `behavior` | `1to1` / `1toN` / `NtoM` / `dynamic` |
+
+### Behavior values
+
+| Value | Meaning |
+|---|---|
+| `1to1` | one source feeds exactly one destination |
+| `1toN` | multiple destinations can take the same source (multicast / fan-out) |
+| `NtoM` | full crosspoint freedom |
+| `dynamic` | size or topology can change at runtime |
+
+### Addressing a crosspoint
+
+| Protocol | Coordinates to reach a crosspoint |
+|---|---|
+| Probel | `(matrix_id, level_id, dst_id, src_id)` |
+| Ember+ | OID path to matrix node + `(connection_target, connection_source)` per glow connection |
+| NMOS IS-05 | `(receiver_id, sender_id)` over `/connection/v1.x/single/receivers/<id>/staged|active` |
+| Future | plugin defines its own coordinates (channel, voice, group, ...) |
+
+### Manifest entry for a matrix
+
+When a Device exposes one or more matrices, the manifest adds a
+parallel `matrices` block beside `frames`:
+
+```yaml
+device:
+  name: <stable-name>
+  protocol: <proto>
+  endpoints: [...]
+frames: [...]      # optional — empty for pure-matrix devices like Probel
+matrices:
+  - matrix_id: 1
+    level_id: 0
+    size: [1024, 1024]
+    behavior: NtoM
+    label: "Main video"
+  - matrix_id: 1
+    level_id: 1
+    size: [1024, 1024]
+    behavior: NtoM
+    label: "Audio L"
+```
+
+For Ember+ matrix nodes, the matrix entry additionally carries the OID
+path of the matrix node in the tree:
+
+```yaml
+matrices:
+  - matrix_id: 1
+    level_id: 0
+    oid: "1.4.2"
+    size: [128, 128]
+    behavior: NtoM
+```
+
+### Scale floor
+
+Every plugin must cope with the minimums in
+`project_scale_requirements`:
+
+- 65 535 × 65 535 destinations × sources per matrix
+- 20 – 100 matrices per plant
+- streaming decoder mandatory (never buffer a full tally dump)
+- sparse maps (`map[(matrix, level, dst)] → src`), never dense arrays
+
+### Dual-controller matrix
+
+A matrix can be fronted by two controllers (redundancy). The model:
+
+| Aspect | Rule |
+| --- | --- |
+| Identifying the active controller | Protocol-native if available — for Probel SW-P-08 that is cmd 8 (Rx Dual Controller Status Request) → cmd 9 (Tx Dual Controller Status Response). For protocols without a native indicator, external lease (per `project_ha_architecture`). |
+| Writes (route change / SetValue) | Go to **active controller only**. The offline controller drops / no-ops — does NOT relay, does NOT act. |
+| Reads (GetStatus, tally, mnemonics) | Either controller serves; DB is mirrored. Read symmetry. |
+| Failover | Active indicator changes → consumer flips writes to the new active immediately; existing read sessions stay open on both. |
+
+This applies symmetrically to the provider (emulator): the emulator
+must answer cmd 8 / cmd 9 honestly and only accept route writes on the
+endpoint it currently advertises as active.
+
+### What the matrix entity does NOT carry
+
+- Card-internal config (timing, format, embed mode) — that lives in
+  the DM of the card hosting the matrix.
+- Physical inventory (slot, frame, controller) — that lives in the
+  Frame hierarchy of ADR-0022.
+- Network addressing (IP, port, transport) — that lives in the
+  manifest's `endpoints` block.
+
+## Consequences
+
+- One vocabulary for matrices across every protocol.
+- Probel manifests have `matrices` but typically no `frames`.
+- Ember+ manifests can have both `frames` (if the device also exposes
+  cards) and `matrices` (OID-anchored).
+- Federation layer can address any crosspoint through
+  `(device, matrix_id, level_id, dst, src)` regardless of protocol.
+
+## Forbidden
+
+- Modelling a matrix as a Card or as a Frame.
+- Per-protocol matrix coordinate schemas leaking into core code — they
+  stay in the plugin.
+- Buffering an entire tally dump in memory before emitting events.
+- Restating any of this in CLAUDE.md, per-connector CLAUDE.md, agent
+  files, or memory — those point at this ADR per ADR-0015.
+
+## Enforcement
+
+- PR review checklist line: "any change to matrix entity, manifest
+  matrices block, or behavior values → block until this ADR is
+  updated".
+- Memory `project_dhs_data_model.md` is a 3-line bookmark to this ADR
+  (alongside the ADR-0022 pointer).
+
+## Revisions
+
+- 2026-05-14 — initial — yboujraf
+- 2026-05-14 — added §"Dual-controller matrix": writes go to active only; reads symmetric on both; Probel cmd 8/9 is the native indicator — yboujraf

--- a/docs/adr/0024-federation-mirror-and-virtual-frame.md
+++ b/docs/adr/0024-federation-mirror-and-virtual-frame.md
@@ -1,0 +1,110 @@
+# ADR-0024 — Federation: mirror frame vs virtual frame
+
+Status: accepted
+
+This ADR is a **living document**. Add new facts in the Revisions
+trailer at the end. Do not spawn a new ADR number unless the whole
+record is being superseded.
+
+## Context
+
+ADR-0022 locks the per-device data model: a real device is one
+manifest (`.cache/manifest/<device>.json`) whose slots reference DMs
+under `.cache/dm/<proto>/`. That covers single-device deployments.
+
+The federation layer sits on top — one or more dhs instances expose
+composed views to external controllers. Two distinct modes exist:
+
+1. **Mirror**: forward a real device's frame+slots+DMs unchanged over
+   its native protocol. Same chassis identity, same wire shape.
+2. **Virtual**: assemble a new device whose slots are virtual cards
+   carrying objects pulled from any real device on any protocol.
+   Exposed over a chosen protocol — may differ from the source
+   protocols.
+
+Both modes coexist in the same dhs instance and the same registry.
+
+## Decision
+
+### Mirror frame
+
+A pass-through projection of a real device. The federation registers
+the same manifest under a federation-owned endpoint and translates
+every consumer request 1:1 to the upstream device. Identity, slot
+layout, DM references and addressing tokens are preserved. The
+external controller cannot distinguish the mirror from the original.
+
+Used for:
+
+- HA scale-out (cluster of dhs instances all mirror one device for N
+  controllers).
+- VLAN/network bridging without re-modelling.
+- Capture/replay rigs (the mirror records every frame; the upstream is
+  untouched).
+
+### Virtual frame
+
+A composed device synthesised from objects across one or more real
+devices and possibly across protocols. Each virtual slot carries a
+virtual card whose schema is declared at federation time, not walked
+off a physical card.
+
+Each object inside a virtual card carries an explicit reference back
+to its real source:
+
+```
+{
+  "id": <virtual-obj-id>,
+  "label": "<friendly-name>",
+  "kind": "<acp1-or-acp2-or-glow-or-...>",
+  "source": {
+    "device": "<source-manifest-name>",
+    "slot": <int>,            // OR
+    "oid":  "<dotted>",       // OR
+    "path": "<dotted>",
+    "obj_id": <int>
+  }
+}
+```
+
+The virtual frame manifest extends ADR-0022's shape with an
+`objects` array per virtual slot (replacing the `dm: Model@SwRev`
+reference). Standard cross-protocol address tokens — `slot` / `oid` /
+`path` / `obj_id` — disambiguate the source.
+
+Used for:
+
+- LogicalView per operator (curated subset across the plant).
+- Cross-vendor virtual device (e.g. a "Console" that fans audio to a
+  Lawo mc² and SDI metadata to an EVS Neuron via one Ember+ endpoint).
+- Test rigs that pin specific object combinations independent of
+  underlying hardware.
+
+### One registry, two modes
+
+dhs exposes both mirror and virtual entries from the same federation
+registry. External controllers see them indistinguishable from real
+devices — only the manifest's `kind` (`mirror` | `virtual`) tells the
+federation layer how to route requests.
+
+## Consequences
+
+- The "device" abstraction in ADR-0022 stays per-physical-unit. The
+  virtual entity is a separate kind, not a sub-type of Device.
+- Federation routing is the only layer that knows the mode; consumer
+  plugins never see it.
+- Virtual frames REQUIRE the manifest to be the single source of
+  truth — no legacy `--tree` path can compose this.
+
+## Forbidden
+
+- Modelling a virtual frame by editing a real device's DM. DMs are
+  per-physical-card schemas; never mutate to fake federation.
+- Per-protocol mirror logic in the consumer plugin (it lives in
+  federation only).
+- Restating any of this in CLAUDE.md, per-connector CLAUDE.md, agent
+  files, or memory — those point at this ADR per ADR-0015.
+
+## Revisions
+
+- 2026-05-14 — initial — yboujraf

--- a/internal/protocol/types.go
+++ b/internal/protocol/types.go
@@ -269,7 +269,7 @@ func parseKind(name string) ValueKind {
 // For ACP1 the (Group, ID) pair comes straight from the wire; for ACP2 the
 // ObjectID is the u32 obj-id and Group is always empty.
 type Object struct {
-	Slot  int    `json:"slot"`
+	Slot  int    `json:"slot,omitempty"`
 	Group string `json:"group,omitempty"` // ACP1 group name; empty for ACP2
 	// Path is the logical hierarchical location of the object. Single
 	// element for ACP1 (the group name); multi-element for ACP2 where

--- a/internal/storage/identity_roundtrip_test.go
+++ b/internal/storage/identity_roundtrip_test.go
@@ -5,37 +5,28 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"dhs/internal/export"
 	"dhs/internal/protocol"
 )
 
-// TestSaveLoadByIdentity_PreservesMetaAndContent pins the regression
-// surfaced live on 2026-05-09: SaveByIdentity used to route through
+// TestSaveLoadByIdentity_PreservesMetaAndContent pins the per-card DM
+// contract (#430): writer round-trips Object fields (Path, Unit, Meta
+// with nested maps) without dropping anything. Original 2026-05-09
+// regression was that SaveByIdentity used to route through
 // export.WriteJSON (hierarchical), and the matching reader's leaf
-// decode struct in flattenJSONTree had no Meta field. So the disk
-// round-trip silently dropped Object.Meta — the exact map the ACP2
-// SeedTreeFromCachedObjects path needs (acp2.objType / numType /
-// optionsMap) to rebuild ObjTypes/NumTypes parallel arrays. Symptom:
-// watcher decoded enum labels and units but rendered numeric values
-// as `raw(N)` because seed couldn't recover the type info.
-//
-// Fix: SaveByIdentity uses stdlib json.Encoder direct on *Snapshot;
-// LoadByIdentity uses stdlib json.Decoder direct into *Snapshot. The
-// snapshot is byte-faithful across separate dhs invocations.
-//
-// The test uses a NEW TreeStore for the load step so we exercise the
-// real cross-process path (open file, decode flat) — same shape the
-// user hits when running `walk --slot 0` then `walk --slot 1` in two
-// shell invocations.
+// decode struct in flattenJSONTree had no Meta field — load → save →
+// load silently dropped Object.Meta. Direct json.Encoder on the DM
+// struct (#430) preserves it.
 func TestSaveLoadByIdentity_PreservesMetaAndContent(t *testing.T) {
 	dir := t.TempDir()
 	saver := NewTreeStore(dir)
 
 	objs := []protocol.Object{
 		{
-			Slot:  1,
+			// Slot is set on purpose — writer must ZERO it (DM is
+			// slot-agnostic). Round-trip should come back with Slot=0.
+			Slot:  7,
 			ID:    70232,
 			Label: "Backup Input",
 			Path:  []string{"BOARD", "Stream"},
@@ -51,18 +42,8 @@ func TestSaveLoadByIdentity_PreservesMetaAndContent(t *testing.T) {
 			},
 		},
 	}
-	snap := &export.Snapshot{
-		Device:    export.DeviceInfo{IP: "10.41.40.4", Protocol: "acp2"},
-		Generator: "test",
-		CreatedAt: time.Now().UTC(),
-		Slots: []export.SlotDump{{
-			Slot:     1,
-			WalkedAt: time.Now().UTC(),
-			Objects:  objs,
-		}},
-	}
 
-	if err := saver.SaveByIdentity("acp2", "SHPRM1@0.7", snap); err != nil {
+	if err := saver.SaveByIdentity("acp2", "SHPRM1@0.7", objs); err != nil {
 		t.Fatalf("SaveByIdentity: %v", err)
 	}
 
@@ -73,16 +54,12 @@ func TestSaveLoadByIdentity_PreservesMetaAndContent(t *testing.T) {
 	}
 
 	if len(got.Slots) != 1 || len(got.Slots[0].Objects) != 1 {
-		t.Fatalf("snap shape: slots=%d objs=%d, want 1/1",
-			len(got.Slots),
-			func() int {
-				if len(got.Slots) == 0 {
-					return -1
-				}
-				return len(got.Slots[0].Objects)
-			}())
+		t.Fatalf("snap shape: slots=%d, want 1", len(got.Slots))
 	}
 	rt := got.Slots[0].Objects[0]
+	if rt.Slot != 0 {
+		t.Errorf("DM is slot-agnostic — writer must zero Slot, got Slot=%d", rt.Slot)
+	}
 	if rt.ID != 70232 || rt.Label != "Backup Input" || rt.Kind != protocol.KindEnum {
 		t.Errorf("base fields lost: id=%d label=%q kind=%v", rt.ID, rt.Label, rt.Kind)
 	}
@@ -105,114 +82,65 @@ func TestSaveLoadByIdentity_PreservesMetaAndContent(t *testing.T) {
 	}
 }
 
-// TestSaveLoadByIdentity_MultiInvocationMerge reproduces the exact
-// user flow: walk slot 0 then walk slot 1 in two separate dhs
-// invocations. Each invocation re-creates the TreeStore. After both,
-// the file must contain BOTH slots with their original object content
-// — not slot 1 alone (the bug) and not slot 0 alone.
-func TestSaveLoadByIdentity_MultiInvocationMerge(t *testing.T) {
+// TestSaveByIdentity_EmitsCleanDMShape asserts the on-disk JSON has
+// NONE of the pre-#430 envelope garbage: no `device`, no `slots`, no
+// `created_at`, no `generator`, no host instance fields. Only the
+// per-card DM contract: model, sw_rev, protocol, objects.
+func TestSaveByIdentity_EmitsCleanDMShape(t *testing.T) {
 	dir := t.TempDir()
-	identity := "SHPRM1@0.7"
-
-	{
-		store := NewTreeStore(dir)
-		existing, _ := store.LoadByIdentity("acp2", identity)
-		if existing != nil {
-			t.Fatalf("invocation 1 expected miss, got %v", existing)
-		}
-		snap := &export.Snapshot{
-			Device:    export.DeviceInfo{IP: "10.41.40.4", Protocol: "acp2"},
-			Generator: "test",
-			CreatedAt: time.Now().UTC(),
-			Slots: []export.SlotDump{{
-				Slot:     0,
-				WalkedAt: time.Now().UTC(),
-				Objects: []protocol.Object{{
-					Slot: 0, ID: 1, Label: "BOARD",
-					Path: []string{"BOARD"},
-					Kind: protocol.KindString,
-					Meta: map[string]any{"acp2.objType": uint8(0)},
-				}},
-			}},
-		}
-		if err := store.SaveByIdentity("acp2", identity, snap); err != nil {
-			t.Fatalf("invocation 1 save: %v", err)
-		}
-	}
-
-	{
-		store := NewTreeStore(dir)
-		existing, err := store.LoadByIdentity("acp2", identity)
-		if err != nil || existing == nil {
-			t.Fatalf("invocation 2 expected hit, got snap=%v err=%v", existing, err)
-		}
-		if len(existing.Slots) != 1 || existing.Slots[0].Slot != 0 {
-			t.Fatalf("invocation 2 sees wrong slots: %+v", existing.Slots)
-		}
-		if len(existing.Slots[0].Objects) != 1 || existing.Slots[0].Objects[0].Label != "BOARD" {
-			t.Fatalf("invocation 2 lost slot 0 content: %+v", existing.Slots[0].Objects)
-		}
-		existing.Slots = append(existing.Slots, export.SlotDump{
-			Slot:     1,
-			WalkedAt: time.Now().UTC(),
-			Objects: []protocol.Object{{
-				Slot: 1, ID: 70232, Label: "Backup Input",
-				Path: []string{"BOARD", "Stream"},
-				Kind: protocol.KindEnum,
-				Unit: "dBFS",
-				Meta: map[string]any{"acp2.objType": uint8(2)},
-			}},
-		})
-		if err := store.SaveByIdentity("acp2", identity, existing); err != nil {
-			t.Fatalf("invocation 2 save: %v", err)
-		}
-	}
-
 	store := NewTreeStore(dir)
-	final, err := store.LoadByIdentity("acp2", identity)
-	if err != nil || final == nil {
-		t.Fatalf("final load: %v", err)
+
+	objs := []protocol.Object{{
+		Slot: 0, ID: 0, Group: "identity", Label: "Card name",
+		Kind: protocol.KindString,
+	}}
+	if err := store.SaveByIdentity("acp1", "RRS18@1601", objs); err != nil {
+		t.Fatalf("SaveByIdentity: %v", err)
 	}
-	if len(final.Slots) != 2 {
-		t.Fatalf("final file should hold 2 slots, got %d (slot 1 overwrote slot 0?)", len(final.Slots))
+
+	raw, err := os.ReadFile(filepath.Join(dir, "dm", "acp1", "RRS18@1601.json"))
+	if err != nil {
+		t.Fatalf("read written file: %v", err)
 	}
-	gotSlots := map[int]string{}
-	gotUnits := map[int]string{}
-	for _, sd := range final.Slots {
-		if len(sd.Objects) == 0 {
-			t.Errorf("slot %d has zero objects after merge", sd.Slot)
-			continue
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	wantKeys := map[string]bool{"model": true, "sw_rev": true, "protocol": true, "objects": true}
+	for k := range probe {
+		if !wantKeys[k] {
+			t.Errorf("DM has forbidden top-level key %q — only {model, sw_rev, protocol, objects} allowed (#430). Raw: %s", k, raw)
 		}
-		gotSlots[sd.Slot] = sd.Objects[0].Label
-		gotUnits[sd.Slot] = sd.Objects[0].Unit
 	}
-	if gotSlots[0] != "BOARD" {
-		t.Errorf("slot 0 lost original content: got %q want %q", gotSlots[0], "BOARD")
+	for want := range wantKeys {
+		if _, ok := probe[want]; !ok {
+			t.Errorf("DM missing required top-level key %q", want)
+		}
 	}
-	if gotSlots[1] != "Backup Input" {
-		t.Errorf("slot 1 missing: got %q want %q", gotSlots[1], "Backup Input")
+
+	var dm DM
+	if err := json.Unmarshal(raw, &dm); err != nil {
+		t.Fatalf("DM decode: %v", err)
 	}
-	if gotUnits[1] != "dBFS" {
-		t.Errorf("slot 1 Unit lost on merge: got %q want %q", gotUnits[1], "dBFS")
+	if dm.Model != "RRS18" {
+		t.Errorf("model: got %q, want %q", dm.Model, "RRS18")
+	}
+	if dm.SwRev != "1601" {
+		t.Errorf("sw_rev: got %q, want %q", dm.SwRev, "1601")
+	}
+	if dm.Protocol != "acp1" {
+		t.Errorf("protocol: got %q, want %q", dm.Protocol, "acp1")
 	}
 }
 
-// TestIdentityPath_PerProtocolSubfolder pins the #424 layout: identity
-// caches now live under .cache/dm/<proto>/<identity>.json so ACP1 +
-// ACP2 + Ember+ can't collide on identical Model strings.
+// TestIdentityPath_PerProtocolSubfolder pins the #424 path layout
+// (per-proto subfolder) still works under the #430 DM-shape change.
 func TestIdentityPath_PerProtocolSubfolder(t *testing.T) {
 	dir := t.TempDir()
 	store := NewTreeStore(dir)
-	snap := &export.Snapshot{
-		Device:    export.DeviceInfo{IP: "10.6.239.113", Protocol: "acp1"},
-		CreatedAt: time.Now().UTC(),
-		Slots: []export.SlotDump{{
-			Slot:     0,
-			WalkedAt: time.Now().UTC(),
-			Objects:  []protocol.Object{{Slot: 0, ID: 0, Label: "Card name"}},
-		}},
-	}
-	if err := store.SaveByIdentity("acp1", "RRS18@1601", snap); err != nil {
+	objs := []protocol.Object{{Slot: 0, ID: 0, Label: "Card name"}}
+	if err := store.SaveByIdentity("acp1", "RRS18@1601", objs); err != nil {
 		t.Fatalf("SaveByIdentity: %v", err)
 	}
 	wantPath := filepath.Join(dir, "dm", "acp1", "RRS18@1601.json")
@@ -225,24 +153,21 @@ func TestIdentityPath_PerProtocolSubfolder(t *testing.T) {
 	}
 }
 
-// TestLoadByIdentity_FallbackToLegacyPath verifies that caches written
-// by older dhs versions (.cache/dm/<identity>.json without proto
-// subfolder) still import. Required during the transition window.
+// TestLoadByIdentity_FallbackToLegacyPath verifies pre-#424 path layout
+// (flat .cache/dm/<id>.json) still imports.
 func TestLoadByIdentity_FallbackToLegacyPath(t *testing.T) {
 	dir := t.TempDir()
-	// Hand-write a legacy-layout cache file.
 	legacyDir := filepath.Join(dir, "dm")
 	if err := os.MkdirAll(legacyDir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
 	legacyFile := filepath.Join(legacyDir, "CONVERT Hybrid@6.7.4.json")
+	// Hand-write a legacy Snapshot-shaped file (pre-#430).
 	snap := &export.Snapshot{
-		Device:    export.DeviceInfo{IP: "10.41.40.195", Protocol: "acp2"},
-		CreatedAt: time.Now().UTC(),
+		Device: export.DeviceInfo{IP: "10.41.40.195", Protocol: "acp2"},
 		Slots: []export.SlotDump{{
-			Slot:     1,
-			WalkedAt: time.Now().UTC(),
-			Objects:  []protocol.Object{{Slot: 1, ID: 67604, Label: "Destination IP"}},
+			Slot:    1,
+			Objects: []protocol.Object{{Slot: 1, ID: 67604, Label: "Destination IP"}},
 		}},
 	}
 	f, _ := os.Create(legacyFile)
@@ -261,5 +186,39 @@ func TestLoadByIdentity_FallbackToLegacyPath(t *testing.T) {
 	}
 	if len(got.Slots) != 1 || got.Slots[0].Objects[0].Label != "Destination IP" {
 		t.Errorf("legacy fallback decoded wrong content: %+v", got.Slots)
+	}
+}
+
+// TestLoadByIdentity_NewDMShape verifies the reader synthesises a
+// Snapshot from a #430-shaped file.
+func TestLoadByIdentity_NewDMShape(t *testing.T) {
+	dir := t.TempDir()
+	store := NewTreeStore(dir)
+	objs := []protocol.Object{
+		{Slot: 0, ID: 0, Label: "Card name", Kind: protocol.KindString},
+		{Slot: 0, ID: 1, Label: "User label", Kind: protocol.KindString},
+	}
+	if err := store.SaveByIdentity("acp2", "SHPRM1@0.7", objs); err != nil {
+		t.Fatalf("SaveByIdentity: %v", err)
+	}
+	got, err := store.LoadByIdentity("acp2", "SHPRM1@0.7")
+	if err != nil || got == nil {
+		t.Fatalf("LoadByIdentity: got=%v err=%v", got, err)
+	}
+	if got.Device.Protocol != "acp2" {
+		t.Errorf("synthesised Snapshot protocol: got %q, want %q", got.Device.Protocol, "acp2")
+	}
+	if got.Device.IP != "" {
+		t.Errorf("synthesised Snapshot must have empty IP (slot-agnostic), got %q", got.Device.IP)
+	}
+	if len(got.Slots) != 1 || len(got.Slots[0].Objects) != 2 {
+		t.Fatalf("synthesised shape: slots=%d objs=%d, want 1/2",
+			len(got.Slots),
+			func() int {
+				if len(got.Slots) == 0 {
+					return -1
+				}
+				return len(got.Slots[0].Objects)
+			}())
 	}
 }

--- a/internal/storage/tree_store.go
+++ b/internal/storage/tree_store.go
@@ -13,6 +13,7 @@ package storage
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -165,40 +166,71 @@ func sanitizeSeg(s string) string {
 	return s
 }
 
-// SaveByIdentity writes a multi-slot snapshot keyed by stable device
-// identity (e.g. "SHPRM1@0.7"). Unlike Save, the same cache file is
-// reused across IP changes / re-cabling — only a Card swap or
-// firmware upgrade invalidates it.
+// DM is the on-disk format for an identity-keyed cache file.
 //
-// Format: flat JSON via stdlib json.Encoder, NOT export.WriteJSON.
-// The exporter's hierarchical writer is lossy on three fields the DM
-// cache absolutely needs to round-trip across separate dhs invocations
-// (one walk per slot, multi-process):
+// Per DHS 2016 MasterView contract (refs #430): the DM is a per-card
+// schema — slot-agnostic, host-agnostic, instance-agnostic. The file
+// describes ONE card type. Two slots holding the same card load the
+// same DM file; two cards = two DM files. IP, port, slot number, host
+// info NEVER live in a DM.
 //
-//   - Object.Meta — walker stashes acp2.objType / numType / optionsMap
-//     here; the hierarchical reader's leaf struct has no Meta field, so
-//     load → save → load drops type info silently and announces decode
-//     as raw(N) with the right Unit but wrong Kind.
-//   - Object.Path — buildJSONTree groups objects by Path; root-level
-//     objects (no Path) become orphaned _meta entries that flatten
-//     back to nothing.
-//   - Object.Value — the hierarchical writer omits values for some
-//     kinds, the reader re-parses CSV strings, and round-trip fidelity
-//     is best-effort.
+// Identity = "<Model>@<SwRev>" (split on the last '@'). For ACP1 the
+// Identity Object Group's CardName + Software rev provide both;
+// ACP2 maps Card Name + Product Version equivalently.
+type DM struct {
+	Model    string            `json:"model"`
+	SwRev    string            `json:"sw_rev"`
+	Protocol string            `json:"protocol"`
+	Objects  []protocol.Object `json:"objects"`
+}
+
+// splitIdentity breaks "<Model>@<SwRev>" on the LAST '@' so a model
+// name containing '@' survives. Returns (model, swRev) with swRev = ""
+// when there's no '@' in the input.
+func splitIdentity(identity string) (string, string) {
+	i := strings.LastIndex(identity, "@")
+	if i < 0 {
+		return identity, ""
+	}
+	return identity[:i], identity[i+1:]
+}
+
+// SaveByIdentity writes the per-card DM to .cache/dm/<proto>/<identity>.json.
 //
-// Direct json.Marshal preserves the exact protocol.Object struct on
-// disk, so successive walks of slot 0 + slot 1 + slot N accumulate
-// into the same file with no field loss.
-func (s *TreeStore) SaveByIdentity(proto, identity string, snap *export.Snapshot) error {
+// On-disk shape is the slot-agnostic DM struct above: {model, sw_rev,
+// protocol, objects}. No `device` envelope, no `slots` wrapper, no
+// IP/port/num_slots — those are runtime state, not card schema. Per
+// DHS 2016, the DM is the schema of ONE card type and survives IP /
+// slot / re-cabling changes.
+//
+// Each Object's Slot field is zeroed before serialization: the DM
+// doesn't claim "this object lives in slot N" — slot is a frame
+// composition concern, defined by the frame manifest at producer
+// startup.
+//
+// Atomic write: tmp file + rename.
+func (s *TreeStore) SaveByIdentity(proto, identity string, objs []protocol.Object) error {
 	if proto == "" {
 		return fmt.Errorf("storage: SaveByIdentity: empty proto")
 	}
 	if identity == "" {
 		return fmt.Errorf("storage: SaveByIdentity: empty identity")
 	}
-	if snap == nil {
-		return fmt.Errorf("storage: SaveByIdentity: nil snapshot")
+	model, swRev := splitIdentity(identity)
+
+	// Zero Slot on each object — the DM is slot-agnostic.
+	clean := make([]protocol.Object, len(objs))
+	for i, o := range objs {
+		clean[i] = o
+		clean[i].Slot = 0
 	}
+	dm := DM{
+		Model:    model,
+		SwRev:    swRev,
+		Protocol: proto,
+		Objects:  clean,
+	}
+
 	path := s.identityPath(proto, identity)
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -211,7 +243,7 @@ func (s *TreeStore) SaveByIdentity(proto, identity string, snap *export.Snapshot
 	}
 	enc := json.NewEncoder(f)
 	enc.SetIndent("", "  ")
-	if err := enc.Encode(snap); err != nil {
+	if err := enc.Encode(dm); err != nil {
 		_ = f.Close()
 		_ = os.Remove(tmp)
 		return fmt.Errorf("storage: encode: %w", err)
@@ -228,15 +260,21 @@ func (s *TreeStore) SaveByIdentity(proto, identity string, snap *export.Snapshot
 }
 
 // LoadByIdentity reads the identity-keyed cache. Returns (nil, nil)
-// on cache miss (file not present); err non-nil only on read /
-// decode failures.
+// on cache miss; err non-nil only on read / decode failures.
 //
-// Decoder: stdlib json.Decoder direct into *export.Snapshot. Pairs
-// with SaveByIdentity's flat-format writer above. We deliberately do
-// NOT route through export.ReadJSON — its flat-vs-hierarchical
-// auto-detect requires len(Slots[0].Objects) > 0 to accept the flat
-// path, and a freshly-initialised snapshot with an empty slot 0 dump
-// would fall through to the lossy hierarchical reader.
+// Auto-detects on-disk shape:
+//   - New DM shape (#430): top-level keys {model, sw_rev, protocol,
+//     objects}. Slot-agnostic. Synthesised into a Snapshot at load
+//     time so existing callers keep working.
+//   - Legacy Snapshot shape (pre-#430): top-level keys {device, slots,
+//     ...}. Accepted for one release cycle, then dropped.
+//
+// Path resolution order:
+//   1. .cache/dm/<proto>/<identity>.json (new per-proto path, #425)
+//   2. .cache/dm/<identity>.json         (legacy flat path)
+//
+// Both paths can carry either DM or legacy Snapshot content — the
+// shape detection is content-based, not path-based.
 func (s *TreeStore) LoadByIdentity(proto, identity string) (*export.Snapshot, error) {
 	if proto == "" {
 		return nil, fmt.Errorf("storage: LoadByIdentity: empty proto")
@@ -244,14 +282,12 @@ func (s *TreeStore) LoadByIdentity(proto, identity string) (*export.Snapshot, er
 	if identity == "" {
 		return nil, fmt.Errorf("storage: LoadByIdentity: empty identity")
 	}
-	// Primary: new per-proto path .cache/dm/<proto>/<identity>.json.
 	path := s.identityPath(proto, identity)
 	f, err := os.Open(path)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return nil, fmt.Errorf("storage: open %s: %w", path, err)
 		}
-		// Backward compat fallback: pre-#424 path with no proto folder.
 		legacy := s.legacyIdentityPath(identity)
 		f, err = os.Open(legacy)
 		if err != nil {
@@ -263,9 +299,37 @@ func (s *TreeStore) LoadByIdentity(proto, identity string) (*export.Snapshot, er
 		path = legacy
 	}
 	defer func() { _ = f.Close() }()
-	var snap export.Snapshot
-	if err := json.NewDecoder(f).Decode(&snap); err != nil {
+
+	// Read once; decide format from a peek key.
+	raw, err := io.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("storage: read %s: %w", path, err)
+	}
+	// Cheap shape detection: probe one key from the top-level object.
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &probe); err != nil {
 		return nil, fmt.Errorf("storage: decode %s: %w", path, err)
+	}
+	if _, hasModel := probe["model"]; hasModel {
+		// New DM shape — synthesise a Snapshot wrapping the Objects.
+		var dm DM
+		if err := json.Unmarshal(raw, &dm); err != nil {
+			return nil, fmt.Errorf("storage: decode dm %s: %w", path, err)
+		}
+		snap := &export.Snapshot{
+			Device: export.DeviceInfo{Protocol: dm.Protocol},
+			Slots: []export.SlotDump{{
+				Slot:     0,
+				WalkedAt: time.Now().UTC(),
+				Objects:  dm.Objects,
+			}},
+		}
+		return snap, nil
+	}
+	// Legacy Snapshot shape — decode directly.
+	var snap export.Snapshot
+	if err := json.Unmarshal(raw, &snap); err != nil {
+		return nil, fmt.Errorf("storage: decode legacy %s: %w", path, err)
 	}
 	return &snap, nil
 }


### PR DESCRIPTION
﻿## Summary

- Drop the host-instance envelope (`device`, `slots`, `created_at`, `generator`, etc.) from `.cache/dm/<proto>/<id>.json` writes. DM is now strictly `{model, sw_rev, protocol, objects}` per ADR-0022.
- `SaveByIdentity` writes the clean DM via direct `json.Encoder` on the typed struct (no more route via the hierarchical `export.WriteJSON` that dropped `Object.Meta` for ACP2).
- `LoadByIdentity` reads the new shape and synthesises a `Snapshot` for the existing consumer hot-load path. Legacy pre-#430 file shape still loads.
- Per-object `Slot` zeroed before serialisation - the DM never claims "this object lives in slot N", per ADR-0022.
- Lock the cross-connector data model in two living ADRs:
  - ADR-0022 - Card data model (Device / Frame / Slot / Card / DM + manifest + NetBox vocabulary mapping + redundancy)
  - ADR-0023 - Matrix entity (matrix_id / level_id / size / behavior, active/passive vs active/active, Probel cmd 8/9)

## Tests

- `TestSaveLoadByIdentity_PreservesMetaAndContent` - round-trips `Path`, `Unit`, nested `Meta` maps without loss; asserts writer zeroes `Slot`.
- `TestSaveByIdentity_EmitsCleanDMShape` - top-level keys MUST be exactly `{model, sw_rev, protocol, objects}`; no forbidden envelope.
- `TestIdentityPath_PerProtocolSubfolder` - pins the per-proto layout and asserts legacy flat path is NOT written.
- `TestLoadByIdentity_FallbackToLegacyPath` - pre-#430 Snapshot-shaped files still import.
- `TestLoadByIdentity_NewDMShape` - Snapshot synthesis from the new shape.

## Test plan (codeowner-driven)

- [ ] Build binary from this branch: `go build -o bin/dhs ./cmd/dhs`
- [ ] Walk dhs producer on LXC 10.100.0.103 for ACP1 (`.cache/dm/acp1/<id>.json` shape + hot-load)
- [ ] Walk dhs producer on LXC 10.100.0.103 for ACP2 (`.cache/dm/acp2/<id>.json` shape + hot-load)
- [ ] Validate legacy `.cache/dm/<id>.json` files still load (fallback path)
- [ ] Codeowner approval

Refs #430

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
