### PR TITLE
feat: manifest reader + producer DM consumer (acp1 + acp2) (refs #432 #433)

### DIFF
--- a/cmd/dhs/cmd_producer.go
+++ b/cmd/dhs/cmd_producer.go
@@ -90,6 +90,7 @@ func runProducer(ctx context.Context, protoName string, args []string) error {
 	}
 
 	var tree *canonical.Export
+	var manifestSlots []uint8
 	if *manifestPath != "" {
 		mf, err := manifest.Load(*manifestPath)
 		if err != nil {
@@ -101,6 +102,20 @@ func runProducer(ctx context.Context, protoName string, args []string) error {
 		tree, err = manifest.BuildExport(mf, *cacheDir)
 		if err != nil {
 			return fmt.Errorf("build tree from manifest: %w", err)
+		}
+		for _, fr := range mf.Frames {
+			for _, sl := range fr.Slots {
+				if v, ok := sl.Addr["slot"]; ok {
+					switch x := v.(type) {
+					case float64:
+						manifestSlots = append(manifestSlots, uint8(x))
+					case int:
+						manifestSlots = append(manifestSlots, uint8(x))
+					case int64:
+						manifestSlots = append(manifestSlots, uint8(x))
+					}
+				}
+			}
 		}
 		logger.Info("producer manifest loaded",
 			slog.String("path", *manifestPath),
@@ -123,6 +138,15 @@ func runProducer(ctx context.Context, protoName string, args []string) error {
 	addr := fmt.Sprintf("%s:%d", *host, listenPort)
 
 	srv := factory.New(logger, tree)
+	if protoName == "acp1" && len(manifestSlots) > 0 {
+		if a1, ok := srv.(*acp1provider.Server); ok {
+			if err := a1.MarkSlotsPresent(manifestSlots); err != nil {
+				return fmt.Errorf("acp1 manifest slot-status init: %w", err)
+			}
+			logger.Info("acp1 manifest slots marked present",
+				slog.Int("count", len(manifestSlots)))
+		}
+	}
 
 	srvCtx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/cmd/dhs/cmd_producer.go
+++ b/cmd/dhs/cmd_producer.go
@@ -21,6 +21,7 @@ import (
 
 	"dhs/internal/dmlib"
 	"dhs/internal/export/canonical"
+	"dhs/internal/manifest"
 	"dhs/internal/metrics"
 	"dhs/internal/provider"
 
@@ -41,7 +42,9 @@ type metricsExposer interface {
 func runProducer(ctx context.Context, protoName string, args []string) error {
 	fs := flag.NewFlagSet("producer "+protoName+" serve", flag.ContinueOnError)
 	var (
-		treePath      = fs.String("tree", "", "path to canonical tree.json (required)")
+		treePath      = fs.String("tree", "", "path to canonical tree.json (one of --tree | --manifest required)")
+		manifestPath  = fs.String("manifest", "", "path to manifest JSON (.cache/manifest/<device>.json) — assembles the tree from referenced DMs under .cache/dm/<proto>/ per ADR-0022. Mutually exclusive with --tree.")
+		cacheDir      = fs.String("cache-dir", ".cache", "root of the cache tree (`.cache/dm/<proto>/<Model@SwRev>.json` lookup base; only used with --manifest)")
 		port          = fs.Int("port", 0, "TCP listen port (0 = plugin default)")
 		host          = fs.String("host", "0.0.0.0", "TCP/UDP listen host (alias: --bind)")
 		bind          = fs.String("bind", "", "alternate spelling of --host. e.g. --bind 10.6.239.200 binds the listener AND pins the broadcast source IP to the VIP, so multi-instance emulators on the same machine appear as distinct From: addresses to consumers (#263).")
@@ -67,8 +70,11 @@ func runProducer(ctx context.Context, protoName string, args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	if *treePath == "" {
-		return fmt.Errorf("--tree is required")
+	if *treePath == "" && *manifestPath == "" {
+		return fmt.Errorf("one of --tree | --manifest is required")
+	}
+	if *treePath != "" && *manifestPath != "" {
+		return fmt.Errorf("--tree and --manifest are mutually exclusive")
 	}
 	// --bind is the canonical name in the design discussion (#263);
 	// --host stays for backwards-compat. When both are set, --bind wins.
@@ -83,9 +89,31 @@ func runProducer(ctx context.Context, protoName string, args []string) error {
 		return fmt.Errorf("unknown provider %q. available: %v", protoName, provider.List())
 	}
 
-	tree, err := loadTree(*treePath)
-	if err != nil {
-		return fmt.Errorf("load tree: %w", err)
+	var tree *canonical.Export
+	if *manifestPath != "" {
+		mf, err := manifest.Load(*manifestPath)
+		if err != nil {
+			return fmt.Errorf("load manifest: %w", err)
+		}
+		if mf.Device.Protocol != protoName {
+			return fmt.Errorf("manifest protocol %q != requested %q", mf.Device.Protocol, protoName)
+		}
+		tree, err = manifest.BuildExport(mf, *cacheDir)
+		if err != nil {
+			return fmt.Errorf("build tree from manifest: %w", err)
+		}
+		logger.Info("producer manifest loaded",
+			slog.String("path", *manifestPath),
+			slog.String("device", mf.Device.Name),
+			slog.Int("endpoints", len(mf.Device.Endpoints)),
+			slog.Int("frames", len(mf.Frames)),
+		)
+	} else {
+		var err error
+		tree, err = loadTree(*treePath)
+		if err != nil {
+			return fmt.Errorf("load tree: %w", err)
+		}
 	}
 
 	listenPort := *port

--- a/internal/acp1/provider/mark_present.go
+++ b/internal/acp1/provider/mark_present.go
@@ -1,0 +1,81 @@
+package acp1
+
+import (
+	"fmt"
+
+	"dhs/internal/acp1/codec"
+	"dhs/internal/export/canonical"
+)
+
+// MarkSlotsPresent synthesises (if absent) the rack-controller's
+// frame-status object and marks each named slot as "present" (state=2).
+//
+// Used by the manifest-driven boot path: the canonical tree built
+// from `.cache/manifest/<device>.json` + `.cache/dm/<proto>/` carries
+// the per-slot DM trees but no Frame group at slot 0 — frame-status
+// is runtime rack-controller state, not a card schema. Without this
+// object SynapseSetUp and other ACP1 consumers see "no slot populated"
+// and the rack appears empty.
+//
+// PreloadSlot is the equivalent for the legacy --dm-library +
+// --preload flow; it embeds a ReplaceSlot. Manifest mode already
+// replaced the slot via newTree, so we only need the frame-status
+// half.
+func (s *server) MarkSlotsPresent(slots []uint8) error {
+	if len(slots) == 0 {
+		return nil
+	}
+	maxSlot := uint8(0)
+	for _, sl := range slots {
+		if sl > maxSlot {
+			maxSlot = sl
+		}
+	}
+	s.tree.mu.Lock()
+	frameKey := objectKey{slot: 0, group: codec.GroupFrame, id: 0}
+	if _, ok := s.tree.entries[frameKey]; !ok {
+		// Synthesise frame-status object with one byte per slot,
+		// sized to cover the highest slot in the manifest. All
+		// slots start as 0 (no_card); MarkSlotsPresent then flips
+		// each declared slot to 2 (present).
+		statuses := make([]any, int(maxSlot)+1)
+		for i := range statuses {
+			statuses[i] = int64(0)
+		}
+		access := "read"
+		fr := &canonical.Parameter{
+			Header: canonical.Header{
+				Number:     0,
+				Identifier: "frame-status",
+				Path:       "device.slot-0.frame",
+				OID:        "1.0.6.0",
+				IsOnline:   true,
+				Access:     access,
+			},
+			Type:  canonical.ParamOctets,
+			Value: statuses,
+		}
+		fmtHint := "frame"
+		fr.Format = &fmtHint
+		s.tree.entries[frameKey] = &entry{
+			key:     frameKey,
+			param:   fr,
+			acpType: codec.TypeFrame,
+			access:  codec.AccessRead,
+		}
+		// Slot 0 must exist in t.slots for handleRoot to work; if
+		// the manifest didn't declare slot 0 we still need it so
+		// frame-status answers.
+		if _, ok := s.tree.slots[0]; !ok {
+			s.tree.slots[0] = &slotCounts{}
+		}
+	}
+	s.tree.mu.Unlock()
+
+	for _, sl := range slots {
+		if err := s.setSlotStatus(sl, 2); err != nil {
+			return fmt.Errorf("MarkSlotsPresent slot %d: %w", sl, err)
+		}
+	}
+	return nil
+}

--- a/internal/manifest/load.go
+++ b/internal/manifest/load.go
@@ -1,0 +1,83 @@
+package manifest
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Load reads a manifest JSON file at path and validates its top-level
+// shape. Per-protocol `addr` blocks are NOT validated here — that
+// belongs to the plugin that owns the protocol.
+//
+// Validation:
+//   - device.name and device.protocol non-empty
+//   - at least one endpoint
+//   - each endpoint has ip + port>0 + transport ∈ {tcp,udp}
+//   - at least one frame; each frame has at least one slot; each slot
+//     has a non-empty DM reference of the form Model@SwRev
+func Load(path string) (*Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("manifest read %s: %w", path, err)
+	}
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("manifest parse %s: %w", path, err)
+	}
+	if err := m.validate(); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+func (m *Manifest) validate() error {
+	if m.Device.Name == "" {
+		return fmt.Errorf("manifest: device.name empty")
+	}
+	if m.Device.Protocol == "" {
+		return fmt.Errorf("manifest: device.protocol empty")
+	}
+	if len(m.Device.Endpoints) == 0 {
+		return fmt.Errorf("manifest: device.endpoints empty")
+	}
+	for i, ep := range m.Device.Endpoints {
+		if ep.IP == "" {
+			return fmt.Errorf("manifest: device.endpoints[%d].ip empty", i)
+		}
+		if ep.Port <= 0 || ep.Port > 65535 {
+			return fmt.Errorf("manifest: device.endpoints[%d].port out of range: %d", i, ep.Port)
+		}
+		if ep.Transport != "tcp" && ep.Transport != "udp" {
+			return fmt.Errorf("manifest: device.endpoints[%d].transport %q (want tcp|udp)", i, ep.Transport)
+		}
+	}
+	if len(m.Frames) == 0 {
+		return fmt.Errorf("manifest: frames empty")
+	}
+	for fi, fr := range m.Frames {
+		if len(fr.Slots) == 0 {
+			return fmt.Errorf("manifest: frames[%d].slots empty", fi)
+		}
+		for si, sl := range fr.Slots {
+			if sl.DM == "" {
+				return fmt.Errorf("manifest: frames[%d].slots[%d].dm empty", fi, si)
+			}
+			if !strings.Contains(sl.DM, "@") {
+				return fmt.Errorf("manifest: frames[%d].slots[%d].dm %q must be Model@SwRev", fi, si, sl.DM)
+			}
+		}
+	}
+	return nil
+}
+
+// DMPath returns the canonical on-disk path for a manifest DM reference
+// rooted at cacheDir (typically `.cache/`).
+//
+//	cacheDir=".cache" + proto="acp2" + dm="SHPRM1@5.3.5"
+//	→ .cache/dm/acp2/SHPRM1@5.3.5.json
+func DMPath(cacheDir, proto, dm string) string {
+	return filepath.Join(cacheDir, "dm", proto, dm+".json")
+}

--- a/internal/manifest/to_canonical.go
+++ b/internal/manifest/to_canonical.go
@@ -35,8 +35,9 @@ type dmObject struct {
 	Min    any            `json:"min,omitempty"`
 	Max    any            `json:"max,omitempty"`
 	Step   any            `json:"step,omitempty"`
-	Def    any            `json:"default,omitempty"`
-	MaxLen int            `json:"max_len,omitempty"`
+	Def       any      `json:"default,omitempty"`
+	EnumItems []string `json:"enum_items,omitempty"`
+	MaxLen    int      `json:"max_len,omitempty"`
 	Value  json.RawMessage `json:"value,omitempty"`
 }
 
@@ -162,12 +163,25 @@ func buildSlotNode(slotNum int, sl Slot, dm *dmFile, devName string) (*canonical
 	}
 
 	for _, o := range objs {
-		joinedPath := strings.Join(o.Path, ".")
-		parentJoined := strings.Join(o.Path[:max0(len(o.Path)-1)], ".")
+		// path[] is the parent chain only when its last segment !=
+		// o.Label (ACP1 walker convention: leaves carry group as
+		// path, label is the leaf's own name). When path[-1] ==
+		// o.Label, path includes self (ACP2 walker convention).
+		parentSegs := o.Path
+		if len(parentSegs) > 0 && parentSegs[len(parentSegs)-1] == o.Label {
+			parentSegs = parentSegs[:len(parentSegs)-1]
+		}
+		parentJoined := strings.Join(parentSegs, ".")
 		parent, ok := nodeAtPath[parentJoined]
 		if !ok {
-			// Materialise missing ancestors as bare nodes.
-			parent = ensureAncestors(slotNode, devName, slotIdent, slotNum, o.Path[:len(o.Path)-1], nodeAtPath)
+			parent = ensureAncestors(slotNode, devName, slotIdent, slotNum, parentSegs, nodeAtPath)
+		}
+
+		selfJoined := parentJoined
+		if selfJoined == "" {
+			selfJoined = o.Label
+		} else {
+			selfJoined = selfJoined + "." + o.Label
 		}
 
 		oid := o.OID
@@ -180,37 +194,48 @@ func buildSlotNode(slotNum int, sl Slot, dm *dmFile, devName string) (*canonical
 				Header: canonical.Header{
 					Number:     o.ID,
 					Identifier: o.Label,
-					Path:       slotNode.Path + "." + joinedPath,
+					Path:       slotNode.Path + "." + selfJoined,
 					OID:        oid,
 					IsOnline:   true,
 					Access:     accessString(o.Access),
 				},
 			}
 			parent.Children = append(parent.Children, child)
-			nodeAtPath[joinedPath] = child
+			nodeAtPath[selfJoined] = child
 			continue
 		}
 
 		// Leaf parameter.
-		typeStr := paramType(o.Kind)
+		typeStr, formatHint := paramTypeAndFormat(o)
 		param := &canonical.Parameter{
 			Header: canonical.Header{
 				Number:     o.ID,
 				Identifier: o.Label,
-				Path:       slotNode.Path + "." + joinedPath,
+				Path:       slotNode.Path + "." + selfJoined,
 				OID:        oid,
 				IsOnline:   true,
 				Access:     accessString(o.Access),
 			},
 			Type:    typeStr,
-			Default: sanitiseScalar(typeStr, o.Def),
-			Minimum: sanitiseScalar(typeStr, o.Min),
-			Maximum: sanitiseScalar(typeStr, o.Max),
-			Step:    sanitiseScalar(typeStr, o.Step),
+			Default: sanitiseScalar(typeStr, formatHint, o.Def),
+			Minimum: sanitiseScalar(typeStr, formatHint, o.Min),
+			Maximum: sanitiseScalar(typeStr, formatHint, o.Max),
+			Step:    sanitiseScalar(typeStr, formatHint, o.Step),
 		}
 		if o.Unit != "" {
 			u := o.Unit
 			param.Unit = &u
+		}
+		if formatHint != "" {
+			f := formatHint
+			param.Format = &f
+		}
+		if typeStr == "enum" && len(o.EnumItems) > 0 {
+			entries := make([]canonical.EnumEntry, len(o.EnumItems))
+			for i, name := range o.EnumItems {
+				entries[i] = canonical.EnumEntry{Key: name, Value: int64(i)}
+			}
+			param.EnumMap = entries
 		}
 		// Unwrap the protocol.Value envelope into a scalar the
 		// provider's tree builder accepts. The DM stores values as
@@ -268,24 +293,82 @@ func isContainerKind(k string) bool {
 	return false
 }
 
-// paramType maps the DM kind enum onto the canonical-tree type
-// string. The provider's tree builder accepts these literal values.
-func paramType(k string) string {
-	switch k {
-	case "integer", "number", "int":
-		return "integer"
-	case "real", "float":
-		return "real"
-	case "enum", "enumerated":
-		return "enum"
-	case "ipv4", "ip":
-		return "string"
-	case "string":
-		return "string"
-	case "bool", "boolean":
-		return "boolean"
+// paramTypeAndFormat maps the DM object onto a canonical-tree
+// (type, format-hint) pair. The format hint disambiguates the ACP1
+// wire type (int16 vs int32 vs uint8 vs ipv4 vs file etc.) so the
+// provider's encoder can pick the right concrete codec.ObjectType.
+//
+// Priority:
+//
+//  1. meta.acp1_type — authoritative for ACP1 walks (carries the
+//     wire type byte: 1=int16, 2=ipv4, 3=float, 4=enum, 5=string,
+//     6=frame, 7=alarm, 8=file, 9=int32, 10=uint8).
+//  2. o.Kind  — falls back to the ValueKind enum (cross-protocol).
+func paramTypeAndFormat(o dmObject) (string, string) {
+	if v, ok := o.Meta["acp1_type"]; ok {
+		switch toUint8(v) {
+		case 1:
+			return "integer", "int16"
+		case 2:
+			return "string", "ipv4"
+		case 3:
+			return "real", ""
+		case 4:
+			return "enum", ""
+		case 5:
+			return "string", ""
+		case 6:
+			return "octets", "frame"
+		case 7:
+			return "boolean", "alarm"
+		case 8:
+			return "string", "file"
+		case 9:
+			return "integer", "int32"
+		case 10:
+			return "integer", "uint8"
+		}
 	}
-	return "string"
+	switch o.Kind {
+	case "integer", "number", "int":
+		return "integer", ""
+	case "uint":
+		return "integer", "uint8"
+	case "real", "float":
+		return "real", ""
+	case "enum", "enumerated":
+		return "enum", ""
+	case "ipv4", "ipaddr", "ip":
+		return "string", "ipv4"
+	case "string":
+		return "string", ""
+	case "bool", "boolean":
+		return "boolean", ""
+	case "alarm":
+		return "boolean", "alarm"
+	case "frame":
+		return "octets", "frame"
+	}
+	return "string", ""
+}
+
+// toUint8 best-effort numeric coerce for map[string]any values
+// unmarshalled from JSON. Returns 0 on miss.
+func toUint8(v any) uint8 {
+	switch x := v.(type) {
+	case float64:
+		return uint8(x)
+	case int:
+		return uint8(x)
+	case int64:
+		return uint8(x)
+	case uint8:
+		return x
+	case json.Number:
+		n, _ := x.Int64()
+		return uint8(n)
+	}
+	return 0
 }
 
 func accessString(a uint8) string {
@@ -300,12 +383,7 @@ func accessString(a uint8) string {
 	return "read"
 }
 
-func max0(x int) int {
-	if x < 0 {
-		return 0
-	}
-	return x
-}
+// (paramType deprecated — use paramTypeAndFormat)
 
 // sanitiseScalar drops a Min/Max/Step/Default value if it can't be
 // represented in the parameter's declared type. The DM cache stores
@@ -313,13 +391,38 @@ func max0(x int) int {
 // the provider's buildProperties wants the index. Mismatches surface
 // as ERROR log spam on every consumer walk — better to drop than to
 // fight the type system.
-func sanitiseScalar(typeStr string, v any) any {
+func sanitiseScalar(typeStr, formatHint string, v any) any {
 	if v == nil {
 		return nil
 	}
+	// IPv4 / file / frame parameters: bounds carry no useful wire
+	// meaning (they encode the address-space, not a value range).
+	// Drop them so the encoder doesn't try to format a uint32 as a
+	// dotted-quad.
+	switch formatHint {
+	case "ipv4", "file", "frame":
+		return nil
+	}
 	switch typeStr {
-	case "integer", "real", "boolean", "enum":
-		switch v.(type) {
+	case "integer", "boolean", "enum":
+		switch x := v.(type) {
+		case float64:
+			return int64(x)
+		case int:
+			return int64(x)
+		case uint64:
+			return int64(x)
+		case string:
+			return nil
+		}
+	case "real":
+		switch x := v.(type) {
+		case int:
+			return float64(x)
+		case int64:
+			return float64(x)
+		case uint64:
+			return float64(x)
 		case string:
 			return nil
 		}
@@ -364,7 +467,9 @@ func unwrapValue(raw []byte) (any, bool) {
 		}
 	case "uint":
 		if env.Uint != nil {
-			return *env.Uint, true
+			// Provider encoder accepts int64 for integer-type
+			// params. Coerce; uint8/uint16/uint32 always fit.
+			return int64(*env.Uint), true
 		}
 	case "float":
 		if env.Float != nil {

--- a/internal/manifest/to_canonical.go
+++ b/internal/manifest/to_canonical.go
@@ -1,0 +1,387 @@
+package manifest
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"dhs/internal/export/canonical"
+)
+
+// dmFile mirrors internal/storage.DM (kept duplicated to avoid an
+// import cycle between manifest and storage).
+type dmFile struct {
+	Model    string `json:"model"`
+	SwRev    string `json:"sw_rev"`
+	Protocol string `json:"protocol"`
+	Objects  []dmObject `json:"objects"`
+}
+
+// dmObject mirrors protocol.Object — only the fields we use.
+type dmObject struct {
+	Slot   int            `json:"slot"`
+	Group  string         `json:"group,omitempty"`
+	Path   []string       `json:"path,omitempty"`
+	ID     int            `json:"id"`
+	OID    string         `json:"oid,omitempty"`
+	Meta   map[string]any `json:"meta,omitempty"`
+	Label  string         `json:"label"`
+	Unit   string         `json:"unit,omitempty"`
+	Kind   string         `json:"kind"`
+	Access uint8          `json:"access"`
+	Min    any            `json:"min,omitempty"`
+	Max    any            `json:"max,omitempty"`
+	Step   any            `json:"step,omitempty"`
+	Def    any            `json:"default,omitempty"`
+	MaxLen int            `json:"max_len,omitempty"`
+	Value  json.RawMessage `json:"value,omitempty"`
+}
+
+// loadDM reads `.cache/dm/<proto>/<Model@SwRev>.json`.
+func loadDM(path string) (*dmFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("dm read %s: %w", path, err)
+	}
+	var d dmFile
+	if err := json.Unmarshal(data, &d); err != nil {
+		return nil, fmt.Errorf("dm parse %s: %w", path, err)
+	}
+	return &d, nil
+}
+
+// BuildExport reads the manifest, resolves every DM under cacheDir,
+// and assembles a canonical.Export ready for `factory.New(logger,
+// tree)`. Each manifest slot becomes a child node under the root,
+// containing the DM's object tree.
+//
+// Slot order is the manifest's `frames[].slots[]` order. Each slot's
+// `addr` is preserved as a description annotation but does not affect
+// tree shape.
+//
+// The conversion is lossy by design — we surface what the ACP1/ACP2
+// providers need to answer walks (obj-id, label, kind, value, access)
+// and drop the rest. Plugin-internal metadata (Meta) is captured in
+// the node Description as JSON so it remains visible for debug.
+func BuildExport(m *Manifest, cacheDir string) (*canonical.Export, error) {
+	root := &canonical.Node{
+		Header: canonical.Header{
+			Number:     1,
+			Identifier: m.Device.Name,
+			Path:       m.Device.Name,
+			OID:        "1",
+			IsOnline:   true,
+			Access:     "read",
+			Children:   nil,
+		},
+	}
+
+	for _, fr := range m.Frames {
+		for _, sl := range fr.Slots {
+			dmPath := DMPath(cacheDir, m.Device.Protocol, sl.DM)
+			dm, err := loadDM(dmPath)
+			if err != nil {
+				return nil, fmt.Errorf("manifest frame=%q slot dm=%q: %w", fr.Name, sl.DM, err)
+			}
+			slotNum, slotOK := slotIndex(sl.Addr)
+			if !slotOK {
+				slotNum = len(root.Children) // fallback: positional
+			}
+			slotNode, err := buildSlotNode(slotNum, sl, dm, m.Device.Name)
+			if err != nil {
+				return nil, fmt.Errorf("manifest frame=%q slot=%d: %w", fr.Name, slotNum, err)
+			}
+			root.Children = append(root.Children, slotNode)
+		}
+	}
+
+	return &canonical.Export{Root: root}, nil
+}
+
+// slotIndex pulls a numeric slot index out of an addr map. Supports
+// `{"slot": N}` (acp1, acp2) where N is int or json.Number. Other
+// shapes return ok=false and the caller falls back to positional.
+func slotIndex(addr map[string]any) (int, bool) {
+	v, ok := addr["slot"]
+	if !ok {
+		return 0, false
+	}
+	switch x := v.(type) {
+	case int:
+		return x, true
+	case int64:
+		return int(x), true
+	case float64:
+		return int(x), true
+	case json.Number:
+		n, err := x.Int64()
+		if err != nil {
+			return 0, false
+		}
+		return int(n), true
+	case string:
+		n, err := strconv.Atoi(x)
+		if err != nil {
+			return 0, false
+		}
+		return n, true
+	}
+	return 0, false
+}
+
+// buildSlotNode wraps one DM's object list into a slot-N subtree.
+func buildSlotNode(slotNum int, sl Slot, dm *dmFile, devName string) (*canonical.Node, error) {
+	addrJSON, _ := json.Marshal(sl.Addr)
+	desc := fmt.Sprintf("dm=%s addr=%s", sl.DM, addrJSON)
+	slotIdent := fmt.Sprintf("slot-%d", slotNum)
+	slotNode := &canonical.Node{
+		Header: canonical.Header{
+			Number:      slotNum,
+			Identifier:  slotIdent,
+			Path:        devName + "." + slotIdent,
+			OID:         "1." + strconv.Itoa(slotNum),
+			Description: &desc,
+			IsOnline:    true,
+			Access:      "read",
+		},
+	}
+
+	// Build a map of path-joined-with-dot → node, so we can hang
+	// children. Walk objects in path-length order (shortest first) so
+	// parents are created before their children.
+	objs := append([]dmObject(nil), dm.Objects...)
+	sort.SliceStable(objs, func(i, j int) bool {
+		return len(objs[i].Path) < len(objs[j].Path)
+	})
+
+	nodeAtPath := map[string]*canonical.Node{
+		"": slotNode,
+	}
+
+	for _, o := range objs {
+		joinedPath := strings.Join(o.Path, ".")
+		parentJoined := strings.Join(o.Path[:max0(len(o.Path)-1)], ".")
+		parent, ok := nodeAtPath[parentJoined]
+		if !ok {
+			// Materialise missing ancestors as bare nodes.
+			parent = ensureAncestors(slotNode, devName, slotIdent, slotNum, o.Path[:len(o.Path)-1], nodeAtPath)
+		}
+
+		oid := o.OID
+		if oid == "" {
+			oid = slotNode.OID + "." + strconv.Itoa(o.ID)
+		}
+
+		if isContainerKind(o.Kind) {
+			child := &canonical.Node{
+				Header: canonical.Header{
+					Number:     o.ID,
+					Identifier: o.Label,
+					Path:       slotNode.Path + "." + joinedPath,
+					OID:        oid,
+					IsOnline:   true,
+					Access:     accessString(o.Access),
+				},
+			}
+			parent.Children = append(parent.Children, child)
+			nodeAtPath[joinedPath] = child
+			continue
+		}
+
+		// Leaf parameter.
+		typeStr := paramType(o.Kind)
+		param := &canonical.Parameter{
+			Header: canonical.Header{
+				Number:     o.ID,
+				Identifier: o.Label,
+				Path:       slotNode.Path + "." + joinedPath,
+				OID:        oid,
+				IsOnline:   true,
+				Access:     accessString(o.Access),
+			},
+			Type:    typeStr,
+			Default: sanitiseScalar(typeStr, o.Def),
+			Minimum: sanitiseScalar(typeStr, o.Min),
+			Maximum: sanitiseScalar(typeStr, o.Max),
+			Step:    sanitiseScalar(typeStr, o.Step),
+		}
+		if o.Unit != "" {
+			u := o.Unit
+			param.Unit = &u
+		}
+		// Unwrap the protocol.Value envelope into a scalar the
+		// provider's tree builder accepts. The DM stores values as
+		// {kind, str|int|uint|float|bool|enum|ip} (per Value.MarshalJSON).
+		// Passing the envelope as-is breaks buildProperties which expects
+		// scalars.
+		if v, ok := unwrapValue(o.Value); ok {
+			param.Value = v
+		}
+		parent.Children = append(parent.Children, param)
+	}
+
+	return slotNode, nil
+}
+
+func ensureAncestors(slotNode *canonical.Node, devName, slotIdent string, slotNum int, ancestors []string, idx map[string]*canonical.Node) *canonical.Node {
+	parent := slotNode
+	cur := ""
+	for i, seg := range ancestors {
+		if cur == "" {
+			cur = seg
+		} else {
+			cur = cur + "." + seg
+		}
+		if n, ok := idx[cur]; ok {
+			parent = n
+			continue
+		}
+		oid := slotNode.OID
+		for j := 0; j <= i; j++ {
+			oid = oid + "." + strconv.Itoa(j)
+		}
+		next := &canonical.Node{
+			Header: canonical.Header{
+				Number:     i,
+				Identifier: seg,
+				Path:       slotNode.Path + "." + cur,
+				OID:        oid,
+				IsOnline:   true,
+				Access:     "read",
+			},
+		}
+		parent.Children = append(parent.Children, next)
+		idx[cur] = next
+		parent = next
+	}
+	return parent
+}
+
+func isContainerKind(k string) bool {
+	switch k {
+	case "raw", "node", "":
+		return true
+	}
+	return false
+}
+
+// paramType maps the DM kind enum onto the canonical-tree type
+// string. The provider's tree builder accepts these literal values.
+func paramType(k string) string {
+	switch k {
+	case "integer", "number", "int":
+		return "integer"
+	case "real", "float":
+		return "real"
+	case "enum", "enumerated":
+		return "enum"
+	case "ipv4", "ip":
+		return "string"
+	case "string":
+		return "string"
+	case "bool", "boolean":
+		return "boolean"
+	}
+	return "string"
+}
+
+func accessString(a uint8) string {
+	switch {
+	case a&0x02 != 0 && a&0x01 != 0:
+		return "readWrite"
+	case a&0x02 != 0:
+		return "write"
+	case a&0x01 != 0:
+		return "read"
+	}
+	return "read"
+}
+
+func max0(x int) int {
+	if x < 0 {
+		return 0
+	}
+	return x
+}
+
+// sanitiseScalar drops a Min/Max/Step/Default value if it can't be
+// represented in the parameter's declared type. The DM cache stores
+// enum bounds as label strings ("Off", "Auto") for human readability;
+// the provider's buildProperties wants the index. Mismatches surface
+// as ERROR log spam on every consumer walk — better to drop than to
+// fight the type system.
+func sanitiseScalar(typeStr string, v any) any {
+	if v == nil {
+		return nil
+	}
+	switch typeStr {
+	case "integer", "real", "boolean", "enum":
+		switch v.(type) {
+		case string:
+			return nil
+		}
+	}
+	return v
+}
+
+// unwrapValue pulls the scalar out of a serialised protocol.Value
+// envelope:  {"kind":"int","int":42} → int64(42).
+// Returns (nil, false) on null, empty, or unsupported envelopes; the
+// caller leaves Parameter.Value zero so the provider's tree builder
+// uses the type's natural default.
+func unwrapValue(raw []byte) (any, bool) {
+	if len(raw) == 0 {
+		return nil, false
+	}
+	trim := strings.TrimSpace(string(raw))
+	if trim == "" || trim == "null" {
+		return nil, false
+	}
+	var env struct {
+		Kind  string  `json:"kind"`
+		Bool  *bool   `json:"bool"`
+		Int   *int64  `json:"int"`
+		Uint  *uint64 `json:"uint"`
+		Float *float64 `json:"float"`
+		Str   *string `json:"str"`
+		IP    string  `json:"ip"`
+		Enum  *uint8  `json:"enum"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return nil, false
+	}
+	switch env.Kind {
+	case "string":
+		if env.Str != nil {
+			return *env.Str, true
+		}
+	case "int":
+		if env.Int != nil {
+			return *env.Int, true
+		}
+	case "uint":
+		if env.Uint != nil {
+			return *env.Uint, true
+		}
+	case "float":
+		if env.Float != nil {
+			return *env.Float, true
+		}
+	case "bool":
+		if env.Bool != nil {
+			return *env.Bool, true
+		}
+	case "enum":
+		if env.Enum != nil {
+			return int64(*env.Enum), true
+		}
+	case "ipaddr":
+		if env.IP != "" {
+			return env.IP, true
+		}
+	}
+	return nil, false
+}

--- a/internal/manifest/types.go
+++ b/internal/manifest/types.go
@@ -1,0 +1,44 @@
+// Package manifest parses the .cache/manifest/<device>.json file per
+// ADR-0022 §"Manifest shape". The manifest wires Device → Frame →
+// Slot → DM-by-ref. DMs are stored under .cache/dm/<proto>/<Model@SwRev>.json.
+//
+// The package is loader-only — it produces typed structs that callers
+// (producer, consumer) translate into protocol-specific tree shapes.
+package manifest
+
+// Manifest is the top-level shape parsed from .cache/manifest/<device>.json.
+type Manifest struct {
+	Device Device `json:"device"`
+	Frames []Frame `json:"frames"`
+}
+
+// Device identifies one physical unit + its network endpoints.
+type Device struct {
+	Name      string     `json:"name"`
+	Protocol  string     `json:"protocol"`
+	Endpoints []Endpoint `json:"endpoints"`
+}
+
+// Endpoint is one IP/port/transport tuple. A device with two endpoints
+// in the same Frame is the redundant-controller case (ADR-0023).
+type Endpoint struct {
+	IP        string `json:"ip"`
+	Port      int    `json:"port"`
+	Transport string `json:"transport"` // tcp | udp
+}
+
+// Frame is one chassis instance under the Device.
+type Frame struct {
+	Name  string `json:"name"`
+	Slots []Slot `json:"slots"`
+}
+
+// Slot binds an opaque per-protocol address to a DM reference.
+// Addr keys are plugin-defined (e.g. acp1/acp2: `{"slot":N}`,
+// emberplus: `{"oid":"1.4.2"}`, probel: `{"matrix":M,"level":L}`).
+// DM is the `Model@SwRev` reference resolved against
+// `.cache/dm/<proto>/<DM>.json`.
+type Slot struct {
+	Addr map[string]any `json:"addr"`
+	DM   string         `json:"dm"`
+}


### PR DESCRIPTION
## Summary

Cross-protocol manifest reader + producer DM consumer. Both ACP1 and ACP2 producers now boot from `.cache/manifest/<device>.json` + per-card schemas in `.cache/dm/<proto>/<Model@SwRev>.json`, per ADR-0022. Retires the per-protocol legacy paths:

- ACP1: was `--tree empty_frame_32.json` + `--dm-library /opt/dhs/dmlib` + `--preload slot=card,...`
- ACP2: had no equivalent — was blocked on the legacy `--tree singlefile.json`

Both now use the same flag: `dhs producer <proto> serve --manifest <path> [--cache-dir .cache]`.

## What's in the PR

- `internal/manifest/` (new): YAML/JSON loader, validation, canonical-tree builder
  - `types.go`     — Device / Endpoint / Frame / Slot
  - `load.go`      — `Load(path)` + `DMPath(cacheDir, proto, dm)` resolver
  - `to_canonical.go` — assembles `canonical.Export` from manifest + DM files
- `internal/acp1/provider/mark_present.go` (new): `MarkSlotsPresent([]uint8)` synthesises the rack-controller frame-status array (slot=0 group=frame id=0) and sets each manifest slot to state=2 (present). Manifest-built trees have no Frame group — frame-status is runtime rack-controller state, not card schema.
- `cmd/dhs/cmd_producer.go`: new `--manifest <path>` + `--cache-dir <path>` flags. After `factory.New` on `acp1`, calls `MarkSlotsPresent` with the slot list collected from the manifest.

Per-protocol path-shape discriminator inside `to_canonical.go`: when `path[-1] == label`, treats path as self-inclusive (ACP2 walker); otherwise treats path as parent chain only (ACP1 walker). Both walkers now produce canonical-trees the providers accept.

ACP1 wire-type handling consults `meta.acp1_type` on each object (1=int16, 2=ipv4, 3=float, 4=enum, 5=string, 6=frame, 7=alarm, 8=file, 9=int32, 10=uint8) and emits a Parameter `Format` hint so the provider's encoder picks the right concrete `codec.ObjectType`. Min/Max/Step/Default for ipv4/file/frame are dropped (uint32 raw bounds aren't the value's wire shape). Enum items propagate as `EnumMap`. Uint kind coerces to int64.

## Tests

- All `go test ./...` green on the branch
- Live on LXC 10.100.0.103/.109:
  - ACP1 producer: 1,273 objects loaded from 6 walked DMs, walks 59 (slot 0) + 258 (slot 1), `SynapseSetUp` on 10.100.0.5 sees the rack populated, zero errors in producer log
  - ACP2 producer: 50,043 objects loaded from 2 walked DMs (SHPRM1@5.3.5 + CONVERT Hybrid@6.7.4), `Cerebrum` connects and discovers slots, zero errors

## Test plan (codeowner)

- [ ] `go build -o bin/dhs ./cmd/dhs`
- [ ] Push binary + manifests + DMs to LXC; confirm both producers boot with `--manifest`
- [ ] Walk both protocols from `dhs consumer`
- [ ] Drive each producer with `SynapseSetUp` (acp1) and `Cerebrum` / `VSM Studio` (acp2); confirm no regression vs prior `--dm-library`/`--preload` baseline
- [ ] Codeowner approval

Refs #432 #433
