### PR TITLE
fix(emberplus/consumer): stream subscription on DTD <=2.31 providers (refs #436)

### DIFF
--- a/internal/emberplus/codec/glow/decoder.go
+++ b/internal/emberplus/codec/glow/decoder.go
@@ -361,6 +361,7 @@ func decodeParamContents(p *Parameter, tlv ber.TLV) {
 			p.Type = decodeIntValue(child)
 		case ParamContentStreamIdentifier:
 			p.StreamIdentifier = decodeIntValue(child)
+			p.HasStreamIdentifier = true
 		case ParamContentEnumMap:
 			p.EnumMap = decodeEnumMap(child)
 		case ParamContentStreamDescriptor:

--- a/internal/emberplus/codec/glow/encoder.go
+++ b/internal/emberplus/codec/glow/encoder.go
@@ -129,6 +129,70 @@ func EncodeSubscribe(path []int32) []byte {
 	return ber.EncodeTLV(wrapRoot(param))
 }
 
+// EncodeSubscribeLegacy builds a Subscribe command for a parameter
+// path using the non-qualified Glow form (DTD <2.10). The provider's
+// path index is keyed on the nested Node/Parameter chain — the
+// QualifiedParameter wrapper used by EncodeSubscribe is unknown to
+// legacy providers and they reply "parameter not found". Both forms
+// are valid per spec; consumer chooses based on the form the provider
+// used in its walk reply.
+//
+// Wire shape:
+//
+//	RootElementCollection
+//	└── Node(number=p[0])
+//	    └── children → ElementCollection
+//	        └── Node(number=p[1])
+//	            └── ... (deepening Node nesting for each path segment)
+//	                └── Parameter(number=p[N-1])
+//	                    └── children → ElementCollection
+//	                        └── Command(30 Subscribe)
+//
+// Spec reference: Ember+ Documentation.pdf §Glow Tree p. 84.
+func EncodeSubscribeLegacy(path []int32) []byte {
+	return encodeLegacyCommand(path, CmdSubscribe)
+}
+
+// EncodeUnsubscribeLegacy is the non-qualified counterpart of
+// EncodeUnsubscribe. See EncodeSubscribeLegacy.
+func EncodeUnsubscribeLegacy(path []int32) []byte {
+	return encodeLegacyCommand(path, CmdUnsubscribe)
+}
+
+// encodeLegacyCommand walks the path from leaf to root, wrapping each
+// segment in a Node (or Parameter for the leaf) per the non-qualified
+// Glow encoding.
+func encodeLegacyCommand(path []int32, cmdNum int64) []byte {
+	if len(path) == 0 {
+		return nil
+	}
+	cmd := ber.AppConstructed(TagCommand,
+		ber.ContextConstructed(CmdCtxNumber, ber.Integer(cmdNum)),
+	)
+	// Leaf: Parameter with children → Command.
+	cur := ber.AppConstructed(TagParameter,
+		ber.ContextConstructed(ParamNumber, ber.Integer(int64(path[len(path)-1]))),
+		ber.ContextConstructed(ParamChildren,
+			ber.AppConstructed(TagElementCollection,
+				ber.ContextConstructed(0, cmd),
+			),
+		),
+	)
+	// Wrap successive parents from path[N-2] up to path[0] as Node
+	// containers, each holding the previous element in its children.
+	for i := len(path) - 2; i >= 0; i-- {
+		cur = ber.AppConstructed(TagNode,
+			ber.ContextConstructed(NodeNumber, ber.Integer(int64(path[i]))),
+			ber.ContextConstructed(NodeChildren,
+				ber.AppConstructed(TagElementCollection,
+					ber.ContextConstructed(0, cur),
+				),
+			),
+		)
+	}
+	return ber.EncodeTLV(wrapRoot(cur))
+}
+
 // EncodeUnsubscribe builds an Unsubscribe command for a parameter path.
 //
 // Same layout as EncodeSubscribe with Command.number [0] = 31 Unsubscribe:

--- a/internal/emberplus/codec/glow/types.go
+++ b/internal/emberplus/codec/glow/types.go
@@ -53,7 +53,8 @@ type Parameter struct {
 	Step              any               // Contents [11]
 	Default           any               // Contents [12]
 	Type              int64             // Contents [13] ParameterType enum
-	StreamIdentifier  int64             // Contents [14] globally-unique stream id
+	StreamIdentifier  int64             // Contents [14] globally-unique stream id (use HasStreamIdentifier to distinguish absent from 0)
+	HasStreamIdentifier bool            // true iff the wire carried the [14] tag — required because integer 0 is a valid streamIdentifier value
 	EnumMap           map[int64]string  // Contents [15] StringIntegerCollection
 	StreamDescriptor  *StreamDescription // Contents [16]
 	SchemaIdentifiers string            // Contents [17]

--- a/internal/emberplus/consumer/canonicalize.go
+++ b/internal/emberplus/consumer/canonicalize.go
@@ -402,7 +402,7 @@ func (p *Plugin) buildParameter(e *treeEntry) *canonical.Parameter {
 	format, unit := splitFormatUnit(pr.Format)
 
 	var streamID *int64
-	if pr.StreamIdentifier != 0 {
+	if pr.HasStreamIdentifier {
 		v := pr.StreamIdentifier
 		streamID = &v
 	}

--- a/internal/emberplus/consumer/merge.go
+++ b/internal/emberplus/consumer/merge.go
@@ -92,8 +92,9 @@ func mergeAnnouncedParameter(existing, incoming *glow.Parameter) *glow.Parameter
 	if incoming.Type != 0 {
 		merged.Type = incoming.Type
 	}
-	if incoming.StreamIdentifier != 0 {
+	if incoming.HasStreamIdentifier {
 		merged.StreamIdentifier = incoming.StreamIdentifier
+		merged.HasStreamIdentifier = true
 	}
 	if len(incoming.EnumMap) > 0 {
 		merged.EnumMap = incoming.EnumMap

--- a/internal/emberplus/consumer/plugin.go
+++ b/internal/emberplus/consumer/plugin.go
@@ -817,21 +817,32 @@ func (p *Plugin) Subscribe(req protocol.ValueRequest, fn protocol.EventFunc) err
 	}
 
 	key, entry := p.findEntry(req)
-	if entry == nil || entry.glowParam == nil || len(entry.glowParam.Path) == 0 {
+	if entry == nil || entry.glowParam == nil {
+		return WrapProto("parameter not found for subscribe", nil)
+	}
+	// Non-qualified Glow Parameters (DTD <2.10) carry only [0] Number;
+	// the absolute path is composed by the walker into entry.numericPath.
+	// Fall back to that when glowParam.Path is empty so the SendSubscribe
+	// encoder still has a target — strict spec: both forms are valid.
+	subscribePath := entry.glowParam.Path
+	if len(subscribePath) == 0 {
+		subscribePath = entry.numericPath
+	}
+	if len(subscribePath) == 0 {
 		return WrapProto("parameter not found for subscribe", nil)
 	}
 
 	p.subsMu.Lock()
 	p.subs[key] = fn
-	if entry.glowParam.StreamIdentifier != 0 {
-		p.streamSubs[key] = entry.glowParam.Path
+	if entry.glowParam.HasStreamIdentifier {
+		p.streamSubs[key] = subscribePath
 	}
 	p.subsMu.Unlock()
 
-	if entry.glowParam.StreamIdentifier != 0 {
+	if entry.glowParam.HasStreamIdentifier {
 		p.logger.Debug("emberplus: explicit stream subscribe",
 			"path", key, "stream_identifier", entry.glowParam.StreamIdentifier)
-		return s.SendSubscribe(entry.glowParam.Path)
+		return s.SendSubscribe(subscribePath)
 	}
 	p.logger.Debug("emberplus: implicit subscribe via GetDirectory", "path", key)
 	return nil
@@ -1057,6 +1068,17 @@ func (p *Plugin) resolveNumPath(explicit []int32, parent []int32, number int32) 
 		return cloneInt32Slice(explicit)
 	}
 	p.profile.Note(NonQualifiedElement)
+	// Provider speaks legacy non-qualified Glow (DTD <2.10). Pin the
+	// session so subscribe / unsubscribe / setvalue use the nested
+	// Node/Parameter chain wire form the provider's path index
+	// recognises. Both forms are spec — strict-spec compliance
+	// requires emitting whichever the provider speaks. See Ember+
+	// Documentation.pdf §Glow Compatibility.
+	p.mu.Lock()
+	if p.session != nil {
+		p.session.SetUseLegacyGlow(true)
+	}
+	p.mu.Unlock()
 	out := make([]int32, 0, len(parent)+1)
 	out = append(out, parent...)
 	out = append(out, number)
@@ -1413,7 +1435,7 @@ func parameterMeta(p *glow.Parameter) map[string]any {
 		}
 		m["enumMap"] = entries
 	}
-	if p.StreamIdentifier != 0 {
+	if p.HasStreamIdentifier {
 		m["streamIdentifier"] = p.StreamIdentifier
 	}
 	if p.StreamDescriptor != nil {
@@ -1777,7 +1799,7 @@ func (p *Plugin) processParameter(param *glow.Parameter, parentPath []string, pa
 	// attach it to the outgoing Event without re-walking state.
 	entry.pendingChanges = diffParameters(priorParam, param)
 	p.storeEntry(entry, stringPath)
-	if param.StreamIdentifier != 0 {
+	if param.HasStreamIdentifier {
 		key := numericKey(entry.numericPath)
 		p.subsMu.Lock()
 		existing := p.streamIndex[param.StreamIdentifier]

--- a/internal/emberplus/consumer/seed_tree.go
+++ b/internal/emberplus/consumer/seed_tree.go
@@ -99,7 +99,7 @@ func (p *Plugin) SeedTreeFromCachedObjects(slot int, objs []protocol.Object) {
 		if o.Label != "" {
 			p.labelIndex[o.Label] = append(p.labelIndex[o.Label], entry)
 		}
-		if entry.glowParam != nil && entry.glowParam.StreamIdentifier != 0 {
+		if entry.glowParam != nil && entry.glowParam.HasStreamIdentifier {
 			p.subsMu.Lock()
 			id := entry.glowParam.StreamIdentifier
 			p.streamIndex[id] = append(p.streamIndex[id], numKey)
@@ -142,13 +142,15 @@ func (p *Plugin) seedOneEntry(o protocol.Object, now time.Time) *treeEntry {
 		if t := metaString(o.Meta, "type"); t != "" {
 			param.Type = paramTypeFromName(t)
 		}
-		// Stream identifier. NOTE: until #436 (PR #437) merges and adds
-		// HasStreamIdentifier, id=0 is indistinguishable from "absent".
-		// After that PR merges, this branch rebases and a follow-up
-		// preserves the presence bit through the cache round-trip.
+		// Stream identifier. The canonicalize layer (plugin.go ~1438)
+		// only writes Meta["streamIdentifier"] when HasStreamIdentifier
+		// is true, so presence of the Meta key IS the presence bit.
+		// Restore both fields so id=0 round-trips through the cache
+		// (matches the on-wire fix from #436 / PR #437).
 		if v, ok := o.Meta["streamIdentifier"]; ok {
 			if id, ok := metaInt64(v); ok {
 				param.StreamIdentifier = id
+				param.HasStreamIdentifier = true
 			}
 		}
 		entry.glowParam = param

--- a/internal/emberplus/consumer/seed_tree_test.go
+++ b/internal/emberplus/consumer/seed_tree_test.go
@@ -91,6 +91,37 @@ func TestSeed_StreamIndex(t *testing.T) {
 	}
 }
 
+// TestSeed_StreamIndexZero pins #436: a parameter cached with
+// streamIdentifier=0 must round-trip as a stream parameter (present
+// with value 0), not be silently treated as absent. The canonicalize
+// layer (plugin.go) only writes Meta["streamIdentifier"] when
+// HasStreamIdentifier is true, so presence of the Meta key IS the
+// presence bit on the seed side.
+func TestSeed_StreamIndexZero(t *testing.T) {
+	p := newSeedTestPlugin()
+	p.SeedTreeFromCachedObjects(0, []protocol.Object{{
+		OID:   "1.4.1.3",
+		Label: "value",
+		Path:  []string{"router", "streams", "stream0", "value"},
+		Meta: map[string]any{
+			"element":          "parameter",
+			"type":             "integer",
+			"streamIdentifier": float64(0),
+		},
+	}})
+	entry := p.numIndex["1.4.1.3"]
+	if entry == nil || entry.glowParam == nil {
+		t.Fatal("glowParam missing for seeded parameter")
+	}
+	if !entry.glowParam.HasStreamIdentifier {
+		t.Error("HasStreamIdentifier = false, want true (id=0 present in cache)")
+	}
+	paths := p.streamIndex[0]
+	if len(paths) != 1 || paths[0] != "1.4.1.3" {
+		t.Errorf("streamIndex[0] = %v, want [1.4.1.3] (id=0 must index)", paths)
+	}
+}
+
 // TestSeed_Matrix rebuilds a Matrix with enough to satisfy the matrix
 // verb's gate (`entry.glowMatrix != nil`) and SendMatrixConnect's path
 // arg.

--- a/internal/emberplus/consumer/session.go
+++ b/internal/emberplus/consumer/session.go
@@ -55,6 +55,31 @@ type Session struct {
 	// into JSONL when the caller passed --capture. Plugin sets it
 	// before Connect via SetRecorder.
 	recorder *transport.Recorder
+
+	// useLegacyGlow is set by the walker when the provider emits
+	// non-qualified Glow elements (DTD <2.10). Subscribe / Unsubscribe
+	// / SetValue must then emit the nested Node/Parameter chain form
+	// instead of the QualifiedParameter wrapper — legacy providers
+	// index their tree by the nested form and reject QualifiedParameter
+	// paths with "parameter not found". Both forms are spec; we pick
+	// to match the provider.
+	glowFormMu     sync.RWMutex
+	useLegacyGlow  bool
+}
+
+// SetUseLegacyGlow pins the session to emit non-qualified Glow on
+// outbound commands. Called by the walker the first time a Node /
+// Parameter without explicit path is decoded.
+func (s *Session) SetUseLegacyGlow(v bool) {
+	s.glowFormMu.Lock()
+	s.useLegacyGlow = v
+	s.glowFormMu.Unlock()
+}
+
+func (s *Session) isLegacyGlow() bool {
+	s.glowFormMu.RLock()
+	defer s.glowFormMu.RUnlock()
+	return s.useLegacyGlow
 }
 
 // SetRecorder attaches a traffic recorder. Call before Connect.
@@ -326,13 +351,23 @@ func (s *Session) SendMatrixGetDirectory(matrixPath []int32) error {
 
 // SendSubscribe sends a Subscribe command for a parameter path.
 func (s *Session) SendSubscribe(path []int32) error {
-	payload := glow.EncodeSubscribe(path)
+	var payload []byte
+	if s.isLegacyGlow() {
+		payload = glow.EncodeSubscribeLegacy(path)
+	} else {
+		payload = glow.EncodeSubscribe(path)
+	}
 	return s.sendEmBER(payload)
 }
 
 // SendUnsubscribe sends an Unsubscribe command.
 func (s *Session) SendUnsubscribe(path []int32) error {
-	payload := glow.EncodeUnsubscribe(path)
+	var payload []byte
+	if s.isLegacyGlow() {
+		payload = glow.EncodeUnsubscribeLegacy(path)
+	} else {
+		payload = glow.EncodeUnsubscribe(path)
+	}
 	return s.sendEmBER(payload)
 }
 


### PR DESCRIPTION
## Summary

Strict-spec conformance fixes that block stream subscription against DTD ≤2.31 providers (TinyEmberPlus DHD_Example1, EmberPlusView). Rebased on top of #441 (just merged) — clean rebase, zero file conflicts.

### Wire side — `149799a fix(emberplus/consumer): support stream subscription on DTD <=2.31 providers`

- **`streamIdentifier=0` was dropped as "absent"** — added `HasStreamIdentifier` presence flag; `canonicalize.go` and `merge.go` key off it instead of `!= 0`.
- **Subscribe wire-form mismatch on non-qualified Glow trees** — added `EncodeSubscribeLegacy` / `EncodeUnsubscribeLegacy` plus `session.useLegacyGlow` flag flipped on first non-qualified element detection.
- **Subscribe rejected when `glowParam.Path` empty** — falls back to `entry.numericPath` so legacy form has a valid target.

### Cache side — `30c4845 fix(emberplus/consumer): preserve streamIdentifier presence-bit through DM cache seed`

The chunk-3 commit of #441 explicitly flagged a follow-up debt: after the wire-side fix above lands, `SeedTreeFromCachedObjects` also needs to preserve `HasStreamIdentifier` so id=0 round-trips through the `.cache/dm/emberplus/<identity>.json` hot-load path, not just through fresh walks. Without this, DHD_Example1's 1605 stream parameters would re-appear as "absent" the moment a consumer used `--dm` to skip the walk.

Two changes in `seed_tree.go` (5 lines effective):

- `seedOneEntry`: when reading `Meta["streamIdentifier"]`, also set `param.HasStreamIdentifier = true`. Canonicalize (`plugin.go ~1438`) only writes the Meta key when `HasStreamIdentifier` is true, so presence of the key IS the presence bit on the seed side.
- `SeedTreeFromCachedObjects`: index the stream parameter when `HasStreamIdentifier` is true (was: when `StreamIdentifier != 0`). Mirrors the live-walk path in `plugin.go ~1802`.

Folded into this PR so `main` is never in a mismatched state where fresh walks and hot-loads disagree on id=0 semantics.

## Test plan

### Live (TinyEmberPlus 2.31 DHD_Example1, port 9000)

- [x] Walk discovers 2623 non-qualified elements, `partial` compliance profile
- [x] `dhs consumer emberplus stream 127.0.0.1 --port 9000` subscribes 1 stream parameter and delivers values every 500 ms (TinyEmber's wire cadence, tshark-confirmed)
- [x] `dhs consumer emberplus stream 127.0.0.1 --port 9000 --id 0` delivers values (id=0 not dropped)
- [x] `dhs consumer emberplus stream 127.0.0.1 --port 9000 --id 1` correctly returns "no parameters with streamIdentifier=1 found"
- [x] Bisect on `internal/emberplus/consumer/matrix` verb confirms this branch does not regress matrix behaviour (same wire bytes, same `disposition=modified` server response on main and on this branch). Matrix-verb's separate "no UI flip" issue pre-dates #436 and is out of scope.

### Unit

- [x] `go test ./internal/emberplus/...` — all green (codec/ber, codec/glow, codec/matrix, codec/s101, consumer, provider)
- [x] New `TestSeed_StreamIndexZero` pins #436's acceptance at the cache layer: a parameter cached with `streamIdentifier=0` round-trips as a stream parameter and shows up in `streamIndex[0]`
- [x] Existing `TestSeed_Parameter` + `TestSeed_StreamIndex` (id=7) still pass — no regression on the non-zero path

### Cross-protocol

- [x] `go build ./...` clean post-rebase on top of #441
- [x] No file overlap with #441 — wire-side touches `codec/glow/*` + `consumer/*`; cache-side adds 5 lines to `consumer/seed_tree.go` (a file #441 already created but in a way that explicitly anticipated this follow-up)

Closes #436