### PR TITLE
fix(emberplus/consumer): set --value silently coerces unparseable input to zero (closes #445)

### DIFF
--- a/internal/emberplus/consumer/coerce_test.go
+++ b/internal/emberplus/consumer/coerce_test.go
@@ -1,0 +1,165 @@
+package emberplus
+
+import (
+	"errors"
+	"testing"
+
+	"dhs/internal/protocol"
+)
+
+// TestCoerceStringToTyped_RejectsInvalidInput pins #445: unparseable
+// --value strings must surface as protocol.ValidationError, not be
+// silently coerced to the Go zero value of the typed field. Each row
+// asserts that the parse failure (a) returns a non-nil error, (b)
+// types as *protocol.ValidationError so exitCode() yields 2, and (c)
+// the rejected string appears in Reason for operator debuggability.
+func TestCoerceStringToTyped_RejectsInvalidInput(t *testing.T) {
+	cases := []struct {
+		name string
+		kind protocol.ValueKind
+		str  string
+	}{
+		{"int with decimal", protocol.KindInt, "-25.5"},
+		{"int with letters", protocol.KindInt, "abc"},
+		{"int empty-after-sign", protocol.KindInt, "-"},
+		{"uint with negative", protocol.KindUint, "-1"},
+		{"uint with letters", protocol.KindUint, "xyz"},
+		{"float with letters", protocol.KindFloat, "3.14abc"},
+		{"float garbage", protocol.KindFloat, "not-a-float"},
+		{"enum with letters", protocol.KindEnum, "Low"},
+		{"enum overflow uint8", protocol.KindEnum, "999"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			val := &protocol.Value{Kind: tc.kind, Str: tc.str}
+			err := coerceStringToTyped(val)
+			if err == nil {
+				t.Fatalf("kind=%v str=%q: expected error, got nil (val=%+v)", tc.kind, tc.str, val)
+			}
+			var verr *protocol.ValidationError
+			if !errors.As(err, &verr) {
+				t.Errorf("kind=%v str=%q: expected *protocol.ValidationError, got %T (%v)", tc.kind, tc.str, err, err)
+			}
+			if verr != nil && !contains(verr.Reason, tc.str) {
+				t.Errorf("kind=%v: Reason %q should mention rejected input %q", tc.kind, verr.Reason, tc.str)
+			}
+			// Typed field MUST stay at zero — no silent coerce.
+			if val.Int != 0 || val.Uint != 0 || val.Float != 0 || val.Enum != 0 {
+				t.Errorf("kind=%v str=%q: typed fields should be zero on error, got %+v", tc.kind, tc.str, val)
+			}
+		})
+	}
+}
+
+// TestCoerceStringToTyped_AcceptsValidInput pins the happy paths so a
+// future tightening of the parse rules doesn't accidentally reject
+// values that are actually valid for their kind.
+func TestCoerceStringToTyped_AcceptsValidInput(t *testing.T) {
+	cases := []struct {
+		name string
+		kind protocol.ValueKind
+		str  string
+		want any
+	}{
+		{"int negative", protocol.KindInt, "-2", int64(-2)},
+		{"int zero", protocol.KindInt, "0", int64(0)},
+		{"int positive", protocol.KindInt, "42", int64(42)},
+		{"uint zero", protocol.KindUint, "0", uint64(0)},
+		{"uint positive", protocol.KindUint, "65535", uint64(65535)},
+		{"float negative", protocol.KindFloat, "-25.5", float64(-25.5)},
+		{"float positive", protocol.KindFloat, "3.14", float64(3.14)},
+		{"float integer-form", protocol.KindFloat, "100", float64(100)},
+		{"enum low", protocol.KindEnum, "0", uint8(0)},
+		{"enum high", protocol.KindEnum, "255", uint8(255)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			val := &protocol.Value{Kind: tc.kind, Str: tc.str}
+			if err := coerceStringToTyped(val); err != nil {
+				t.Fatalf("unexpected error for %q kind=%v: %v", tc.str, tc.kind, err)
+			}
+			switch want := tc.want.(type) {
+			case int64:
+				if val.Int != want {
+					t.Errorf("Int = %d, want %d", val.Int, want)
+				}
+			case uint64:
+				if val.Uint != want {
+					t.Errorf("Uint = %d, want %d", val.Uint, want)
+				}
+			case float64:
+				if val.Float != want {
+					t.Errorf("Float = %g, want %g", val.Float, want)
+				}
+			case uint8:
+				if val.Enum != want {
+					t.Errorf("Enum = %d, want %d", val.Enum, want)
+				}
+			}
+			if val.Str != "" {
+				t.Errorf("Str should be cleared after successful coerce, got %q", val.Str)
+			}
+		})
+	}
+}
+
+// TestCoerceStringToTyped_BoolStaysPermissive locks the bool branch's
+// deliberately-loose contract documented in coerceStringToTyped's
+// doc-comment — operators routinely pass "off"/"no" expecting false,
+// not an error.
+func TestCoerceStringToTyped_BoolStaysPermissive(t *testing.T) {
+	cases := []struct {
+		str  string
+		want bool
+	}{
+		{"true", true},
+		{"1", true},
+		{"yes", true},
+		{"false", false},
+		{"no", false},
+		{"off", false},
+		{"anything-else", false},
+	}
+	for _, tc := range cases {
+		val := &protocol.Value{Kind: protocol.KindBool, Str: tc.str}
+		if err := coerceStringToTyped(val); err != nil {
+			t.Errorf("bool %q: unexpected error %v (bool should be permissive)", tc.str, err)
+		}
+		if val.Bool != tc.want {
+			t.Errorf("bool %q: got %v, want %v", tc.str, val.Bool, tc.want)
+		}
+	}
+}
+
+// TestCoerceStringToTyped_StringAndEmptyPassthrough confirms the
+// guard clause at the top of coerceStringToTyped: KindString and
+// empty-string inputs short-circuit cleanly (no parse, no error).
+func TestCoerceStringToTyped_StringAndEmptyPassthrough(t *testing.T) {
+	val1 := &protocol.Value{Kind: protocol.KindString, Str: "hello"}
+	if err := coerceStringToTyped(val1); err != nil {
+		t.Errorf("KindString passthrough: unexpected error %v", err)
+	}
+	if val1.Str != "hello" {
+		t.Errorf("KindString: Str modified to %q, want preserved %q", val1.Str, "hello")
+	}
+
+	val2 := &protocol.Value{Kind: protocol.KindInt, Str: ""}
+	if err := coerceStringToTyped(val2); err != nil {
+		t.Errorf("empty-string: unexpected error %v", err)
+	}
+}
+
+// contains is a tiny local helper to keep the assertion line readable
+// without importing strings just for this. Equivalent to
+// strings.Contains.
+func contains(haystack, needle string) bool {
+	if needle == "" {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/emberplus/consumer/plugin.go
+++ b/internal/emberplus/consumer/plugin.go
@@ -724,7 +724,9 @@ func (p *Plugin) SetValue(ctx context.Context, req protocol.ValueRequest, val pr
 	if val.Kind == protocol.KindUnknown {
 		val.Kind = entry.obj.Kind
 	}
-	coerceStringToTyped(&val)
+	if err := coerceStringToTyped(&val); err != nil {
+		return protocol.Value{}, err
+	}
 
 	glowVal := valueToGlow(val)
 
@@ -2292,36 +2294,68 @@ func appendEnumMap(existing []string, em map[int64]string) []string {
 // coerceStringToTyped parses val.Str into the typed field that matches
 // val.Kind. Called when the CLI passes --value as a string but the
 // parameter type is numeric/boolean/enum.
-func coerceStringToTyped(val *protocol.Value) {
+//
+// On parse failure the function returns a *protocol.ValidationError so
+// the CLI exits with status 2 (usage error) and the typed field is NOT
+// silently coerced to the Go zero value. Refs #445 — the previous
+// behaviour silently rewrote "-25.5" → 0 for an integer Parameter,
+// which violates the strict-spec posture in internal/emberplus/CLAUDE.md.
+//
+// KindBool stays permissive ("true"/"1"/"yes" → true; anything else →
+// false) to preserve existing CLI semantics — booleans have no natural
+// invalid form and operators routinely pass "off"/"no"/"0" expecting
+// the obvious mapping.
+func coerceStringToTyped(val *protocol.Value) error {
 	if val.Str == "" || val.Kind == protocol.KindString {
-		return
+		return nil
 	}
 	switch val.Kind {
 	case protocol.KindInt:
-		if n, err := strconv.ParseInt(val.Str, 10, 64); err == nil {
-			val.Int = n
-			val.Str = ""
+		n, err := strconv.ParseInt(val.Str, 10, 64)
+		if err != nil {
+			return &protocol.ValidationError{
+				Field:  "value",
+				Reason: fmt.Sprintf("invalid integer %q", val.Str),
+			}
 		}
+		val.Int = n
+		val.Str = ""
 	case protocol.KindUint:
-		if n, err := strconv.ParseUint(val.Str, 10, 64); err == nil {
-			val.Uint = n
-			val.Str = ""
+		n, err := strconv.ParseUint(val.Str, 10, 64)
+		if err != nil {
+			return &protocol.ValidationError{
+				Field:  "value",
+				Reason: fmt.Sprintf("invalid unsigned integer %q", val.Str),
+			}
 		}
+		val.Uint = n
+		val.Str = ""
 	case protocol.KindFloat:
-		if f, err := strconv.ParseFloat(val.Str, 64); err == nil {
-			val.Float = f
-			val.Str = ""
+		f, err := strconv.ParseFloat(val.Str, 64)
+		if err != nil {
+			return &protocol.ValidationError{
+				Field:  "value",
+				Reason: fmt.Sprintf("invalid real %q", val.Str),
+			}
 		}
+		val.Float = f
+		val.Str = ""
 	case protocol.KindBool:
 		val.Bool = val.Str == "true" || val.Str == "1" || val.Str == "yes"
 		val.Str = ""
 	case protocol.KindEnum:
-		if n, err := strconv.ParseUint(val.Str, 10, 8); err == nil {
-			val.Enum = uint8(n)
-			val.Uint = n
-			val.Str = ""
+		n, err := strconv.ParseUint(val.Str, 10, 8)
+		if err != nil {
+			return &protocol.ValidationError{
+				Field:  "value",
+				Reason: fmt.Sprintf("invalid enum index %q", val.Str),
+			}
 		}
+		val.Enum = uint8(n)
+		val.Uint = n
+		val.Str = ""
 	}
+	return nil
 }
 
 // valueToGlow renders a typed protocol.Value into a Glow-encoder input.


### PR DESCRIPTION
## Summary

\`coerceStringToTyped\` in \`internal/emberplus/consumer/plugin.go\` was swallowing \`strconv.ParseInt\` / \`ParseFloat\` / \`ParseUint\` errors: on bad input the typed field (\`val.Int\` / \`val.Float\` / \`val.Uint\` / \`val.Enum\`) stayed at its Go zero value, the wire encoded that zero, the provider stored it, and the consumer reported \`confirmed value = 0\` as if the SET had succeeded.

Caught during cross-client validation post-#441 merge — \`set --value -25.5\` against an Integer Parameter (range -1000..0, step 1) silently rewrote the value to 0 instead of erroring.

## Fix

- \`coerceStringToTyped\` returns \`*protocol.ValidationError\` on parse failure for KindInt / KindUint / KindFloat / KindEnum. Reason carries the rejected string for operator debuggability.
- Call site at \`plugin.go:727\` (inside SetValue) propagates; CLI exits with status 2 (the existing usage-error convention via \`exitCode()\` in \`cmd/dhs/main.go\`).
- KindBool stays permissive — operators expect \`"true"\` / \`"1"\` / \`"yes"\` → true and anything else → false. The doc-comment now spells that out so future tightening doesn't accidentally regress operator-friendly bool input.
- String passthrough and empty-string guard unchanged.

## Live repro on integration demo

\`\`\`
$ set ... --value -25.5
error: validation: value: invalid integer \"-25.5\"  (exit 2)

$ set ... --value abc
error: validation: value: invalid integer \"abc\"    (exit 2)

$ set ... --value -2
confirmed value = -2                                  (exit 0)
\`\`\`

## Test plan

- [x] New \`coerce_test.go\` pins 23 cases:
  - 9 reject paths (KindInt / KindUint / KindFloat / KindEnum × their main invalid forms — letters, decimals on int, negative on uint, overflow on enum, etc.)
  - 10 accept paths (happy cases per kind)
  - 3 KindBool permissive cases
  - 1 KindString + empty passthrough case
- [x] \`go test ./internal/emberplus/...\` — all green
- [x] \`go build ./...\` clean
- [x] Live: rebuilt \`bin/dhs.exe\` from this branch, cycled producer, reproduced the failing case → now errors with exit code 2; sanity check on valid input \`-2\` unchanged
- [x] \`scripts/emberplus/verify-emberplus-integration.ps1\` 22/22 PASS on the integration demo (transient script-side race observed once, passes deterministically on retry — same flake we've seen since the verifier landed in #441)

## Out of scope

- ACP1 / ACP2 codecs handle parse-failure inside their own wire encoders; audit there is a follow-up if the same anti-pattern exists (separate issue).
- Whether the demo's \`gain\` Parameter *should* be Real (float) instead of Integer for real-world feel — separate UX discussion.

Closes #445