### PR TITLE
docs(adr): ADR-0025 per-connector definition of done (5 deliverables)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,46 @@ One binary covers both directions:
 
 ---
 
+## Connector definition of done (ADR-0025)
+
+A connector is **DONE** only when all five deliverables exist together (per [ADR-0025](docs/adr/0025-per-connector-definition-of-done.md)). No "ship now, finish later" — fixes that build on partial connectors cause the regression-and-circle pattern this rule prevents.
+
+The five deliverables, one column each in the per-connector state table below:
+
+1. **Consumer** — strict-spec, every CLI verb the spec defines (Probel general/extended form selection is a tested boundary decision per command; Ember+ is DTD 2.60 only).
+2. **Producer** — strict-spec, every CLI verb the spec defines.
+3. **Integration test (CLI)** — Go tests under `internal/<proto>/integration/` that drive the actual `dhs consumer/producer <proto> <verb>` binary against a live producer. Per-test classification: PASS / FAIL-real / FAIL-expected (error-handling success) / TIMEOUT. PowerShell verify scripts can sit alongside for live-rig parity.
+4. **`.cache/dm` + manifest generator** — Go generator owned by the connector, called from test `setUp`, writes a local `.cache/dm/<proto>/...` + `.cache/manifest/...` next to the test files. Tests **MUST NOT** `t.Skip` when the cache is empty.
+5. **Wireshark `.lua` dissector** — `internal/<proto>/wireshark/dhs_<proto>.lua` covering every transport + version + command with per-frame Info column detail that uniquely identifies the message.
+
+Legend: ✅ done · 🟡 partial · ❌ missing or stub
+
+| Connector | Consumer | Producer | Integration test (CLI) | `.cache` generator | Wireshark `.lua` | Notes |
+|---|---|---|---|---|---|---|
+| **ACP1** | ✅ all verbs | ✅ | 🟡 smoke (4 funcs) — does not drive full CLI surface | ❌ | ✅ `dhs_acpv1.lua` | Needs CLI integration test covering walk/get/set/watch/discover end-to-end |
+| **ACP2** | ✅ all verbs | ✅ | ❌ `t.Skip("not implemented yet")` placeholder | ❌ | ✅ `dhs_acpv2.lua` | Integration test is a stub. Every PR claiming "ACP2 green" since this file landed has not been ACP2-tested at all. |
+| **Ember+ (DTD 2.60)** | 🟡 — dotted-path `resolveMatrix` bug fixed locally, not yet merged | 🟡 — same | 🟡 `scripts/emberplus/verify-emberplus-integration.ps1` (22 assertions, labels + per-tgt/src/XPT params only). No matrix-connect, no salvo, no reject paths, no streams. | ❌ — `scripts/emberplus/gen-emberplus-demo-dms.ps1` is PowerShell, not Go, lives outside the integration test folder | ✅ `dhs_emberplus.lua` | Highest-priority connector to bring to DoD next. |
+| **Probel SW-P-08** | ✅ all §3.2 cmds; general/extended form selection covered in `codec/` tests | ✅ multi-session tally + salvo fan-out validated | 🟡 heavy codec coverage (151 funcs) + smh emulator validation, but no `internal/probel-sw08p/integration/` CLI-binary tests | ❌ | ✅ `dhs_probel_sw08p.lua` | Codec layer exemplary; CLI integration layer absent. |
+| **Probel SW-P-02** | ✅ all §3 cmds; protect-blocks-connect with state echo | ✅ | 🟡 codec + provider unit tests; no CLI-binary integration | ❌ | ✅ `dhs_probel_sw02p.lua` | |
+| **OSC 1.0 / 1.1** | ✅ | ✅ | ✅ 6 files / 23 funcs under `internal/osc/integration/` — closest thing to a reference shape | ✅ pcap replay fixture + osc.js byte oracle | ✅ `dhs_osc.lua` | Reference for what a complete connector looks like under this ADR. |
+| **TSL UMD v3.1/v4/v5** | ✅ | ✅ | 🟡 4 files / 10 funcs — partial CLI coverage | ✅ testdata fixtures | ✅ `dhs_tsl.lua` | |
+| **EVS Cerebrum NB** | ✅ 12 verbs (UPPERCASE wire-form live-verified on production fleet) | ❌ deferred | ❌ 2 consumer unit tests, no CLI integration | ❌ | ✅ `dhs_cerebrum_nb.lua` | Provider intentionally deferred per scope. |
+| **AMWA NMOS** | 🟡 IS-04 walk + IS-04 Controller; IS-05/07/08/12/MS-05 plugins in-flight | 🟡 Node + Registry + Events serve | 🟡 AMWA Testing tool harness (external Python) — full conformance on IS-04-01/02 v1.0–v1.3 | 🟡 AMWA fixtures | 🟡 HTTP/WS layer in dissector | Spec-strict every published minor per `feedback_amwa_strict_all_versions` |
+
+### What's NOT YET tested (and why)
+
+| Connector | Untested area | Blocker |
+|---|---|---|
+| Ember+ | Real Lawo router (production hardware) — DTD 2.60 + matrices + streams | Waiting for VPN restoration to reach the production rig (codeowner note 2026-05-16) |
+| Ember+ | DHD provider full surface (1605 stream-param fanout) | Need a live DHD sample on the test rig — TinyEmberPlus DHD_Example1 covers the wire bug surface but not throughput/load |
+| Probel | Real EMTWO / Lawo VSM matrix at full N×M scale | Waiting for cross-vendor testbed access |
+| ACP2 | Real Synapse cards with enum-typed objects (#79) | Awaiting card sample with enum property exposure |
+| NMOS | Real-peer Cerebrum NMOS HA failover under load | Production rig access |
+
+Per-connector runbook (every CLI verb with a captured real-run example) is a separate deliverable per connector — tracked under `internal/<proto>/docs/runbook.md`.
+
+---
+
 ## Protocols
 
 | Protocol        | Transport         | Port      | Consumer | Provider | Docs |

--- a/docs/adr/0025-per-connector-definition-of-done.md
+++ b/docs/adr/0025-per-connector-definition-of-done.md
@@ -1,6 +1,6 @@
 # ADR-0025 — Per-connector definition of done
 
-Status: proposed
+Status: accepted
 
 This ADR is a **living document**. Add new facts in the Revisions
 trailer at the end. Do not spawn a new ADR number unless the whole

--- a/docs/adr/0025-per-connector-definition-of-done.md
+++ b/docs/adr/0025-per-connector-definition-of-done.md
@@ -1,0 +1,109 @@
+# ADR-0025 — Per-connector definition of done
+
+Status: proposed
+
+This ADR is a **living document**. Add new facts in the Revisions
+trailer at the end. Do not spawn a new ADR number unless the whole
+record is being superseded.
+
+## Context
+
+Earlier ADRs define **how** a connector is built:
+
+- ADR-0001 — one binary per connector, its own repo
+- ADR-0002 — canonical CLI verbs + flags
+- ADR-0009 — plugin supervisor
+- ADR-0013 — one approved unit = one commit
+- ADR-0014 — issue → branch → tests → PR → CI green → codeowner approval → merge
+- ADR-0015 — single source of truth per concern
+- ADR-0022 — Card / Frame / Slot / DM data model
+- ADR-0023 — Matrix as parallel entity
+
+Nothing in the existing ADR set defines **when a connector is finished**.
+Without that gate, PRs have repeatedly landed that fix one symptom
+against a partial connector — the test surface that voted green for the
+fix did not exercise the broken path, so the next session discovers a
+parallel gap on a different verb and the cycle restarts.
+
+The pattern is concrete:
+
+- A consumer-side bug ships green because the integration test
+  exercises only the codec layer, not the CLI binary end-to-end.
+- A provider-side bug ships green because the only integration test is
+  a `t.Skip` placeholder.
+- A CLI verb works against one identifier scheme (numeric OID) but not
+  another (dotted path) because the test surface doesn't drive the
+  CLI through both schemes.
+- A spec command is silently absent on a verb because no test asserts
+  the command surface.
+
+Each missing piece compounds the next: a partial consumer cannot be
+trusted against a partial provider, and a partial integration test
+cannot vouch for either side. The result is sustained churn without
+forward progress on the connector.
+
+A binding definition of done closes the gate at the connector boundary:
+no per-connector PR is approved for merge unless the connector has all
+five deliverables below.
+
+## Decision
+
+A connector is **DONE** only when **all five** deliverables below exist
+together. Missing any one of them means the connector is incomplete;
+work continues on that connector before the next connector starts and
+before any per-connector PR is approved for merge. No "ship now, finish
+later" framing.
+
+| # | Deliverable | Location | Notes |
+|---|---|---|---|
+| 1 | **Consumer** strict-to-spec, every CLI verb the spec defines | `internal/<proto>/consumer/` + `cmd/dhs/cmd_*.go` | Every spec command + every wire-form variant. Probel general/extended form selection is a tested boundary decision per command. Ember+ is DTD 2.60 only — no time spent on older DTDs. |
+| 2 | **Producer** strict-to-spec, every CLI verb the spec defines | `internal/<proto>/provider/` + `cmd/dhs/cmd_producer.go` | Same coverage rule as deliverable 1, inbound. |
+| 3 | **Integration test** driving the actual `dhs consumer/producer <proto> <verb>` CLI binary | `internal/<proto>/integration/` (Go, `-tags integration`) and/or `scripts/<proto>/verify-*.ps1` for live-rig parity | Per-test classification: `PASS` / `FAIL-real` (a real bug) / `FAIL-expected` (an error-handling reject path correctly rejected) / `TIMEOUT` (consumer sent CLI against a dead producer). Output must say *why* on every non-pass so the operator acts without reading source. |
+| 4 | **DM + manifest generator** | Go function under `internal/<proto>/integration/` that writes a local `.cache/dm/<proto>/...` + `.cache/manifest/...` next to the test files (NOT the codeowner's repo-root `.cache/`) | Tests invoke the generator in `setUp`. Tests **MUST NOT** `t.Skip` when the cache is empty — they must generate. The generator's Go source is the durable artefact. |
+| 5 | **Wireshark dissector** `internal/<proto>/wireshark/dhs_<proto>.lua` | Covers every transport, every wire version, every command / type-tag the connector implements. Per-frame Info column carries the discriminating arguments (matrix/level/dst/src for SW-P-08; slot/type/pid/stat for ACP2; address+typetag+argcount for OSC; etc.). | See `internal/<proto>/wireshark/` + `feedback_wireshark_fully_implemented`. |
+
+Documentation deliverables travel alongside but are not gated by the
+ADR — they are required at PR time per ADR-0015 (single source of
+truth):
+
+- **README** with a per-connector coverage table (what verbs, integration test status, what's tested live, what's NOT yet tested + reason — e.g. awaiting sample / real device).
+- **Runbook per connector** (`internal/<proto>/docs/runbook.md`) — every CLI verb described with: syntax, captured real-run example, expected output, common error modes.
+
+## How to apply
+
+1. **Before starting work on any connector**, audit the connector against the five-deliverable checklist. Flag missing pieces explicitly.
+2. **Each PR must cite which deliverable it advances** for which connector, plus the state of the other four (`done` / `partial` / `missing`).
+3. **One PR advances one deliverable for one connector**. No PR can combine "connector A integration test" with "connector B fix" — that's the bundle pattern ADR-0013 already forbids, restated here for the avoidance of doubt.
+4. **No connector PR is approved for merge until all five exist** for that connector. The integration test in (3) is the truth source: green there = real green; failing there = the wire is broken, fix the wire, never the test.
+5. **CI gates** must run the integration tests (Go `-tags integration` plus the PowerShell verify scripts where applicable). If CI does not run them, CI is not vouching for the connector.
+6. **Cross-protocol regressions are blockers** — any PR that touches shared layers (transport, manifest, storage, `cmd/dhs/*`) re-verifies every connector's integration test before merge per `feedback_no_cross_protocol_regression`.
+
+## Per-protocol scope reminders
+
+| Protocol | Scope clarification |
+|---|---|
+| ACP1 | All wire versions per `internal/acp1/CLAUDE.md`. |
+| ACP2 | AN2/TCP only per `internal/acp2/CLAUDE.md`. |
+| Ember+ | **DTD 2.60 only** — older DTD variants are not in scope. Spec p.85 ParameterContents, p.86 Commands, p.88-89 Matrix + ConnectionOperation. |
+| Probel SW-P-08 | All §3.2 commands + general AND extended form per command. Form selection is a tested boundary decision (`needsExtended()` ceilings per `feedback_probel_form_selection`). Salvo behaviour per `feedback_probel_salvo_connected`. |
+| Probel SW-P-02 | All §3 commands; protect-blocks-connect with state echo (`feedback_probel_protect_blocks_connect`). |
+| OSC | osc-v10 + osc-v11; UDP + TCP-LP (v10) + TCP-SLIP (v11). |
+| TSL UMD | v3.1 + v4 + v5 with per-vendor positional tally mapping (`project_tsl_extensions`). |
+| Cerebrum NB | XML-over-WS uppercase wire form; consumer 12 verbs; provider deferred. |
+| AMWA NMOS | Every published minor version in scope — no deferrals per `feedback_amwa_strict_all_versions`. |
+
+## What this ADR does NOT change
+
+- ADR-0001 — connectors still each live under `internal/<proto>/`.
+- ADR-0006 — codec packages stay stdlib-only.
+- ADR-0013 — one approved unit = one commit. ADR-0025 narrows the
+  *unit*: each unit advances one deliverable for one connector.
+- ADR-0014 — issue → branch → tests → PR → green → approval → merge.
+- ADR-0015 — every architectural rule has one ADR. ADR-0025 is the
+  single source for "connector definition of done" and is referenced
+  from `README.md`, `CLAUDE.md`, per-protocol `CLAUDE.md`, and
+  `memory/project_connector_definition_of_done.md`.
+
+## Revisions
+
+- 2026-05-16 — initial proposal (issue #447).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -51,6 +51,10 @@ There is no `superseded` / `deprecated` / `rejected-after-acceptance`.
 | [0019](0019-documentation-structure.md) | Documentation structure (split-aware) | accepted |
 | [0020](0020-capture-and-fixture-layout.md) | Capture and fixture file layout | accepted |
 | [0021](0021-wire-trace-jsonl-contract.md) | Wire-trace JSONL contract + replay semantics | accepted |
+| [0022](0022-card-data-model.md) | Card data model — Device/Frame/Slot/Card/DM | accepted |
+| [0023](0023-matrix-entity.md) | Matrix entity — matrix_id/level_id/size/behavior | accepted |
+| [0024](0024-federation-mirror-and-virtual-frame.md) | Federation — mirror frame vs virtual frame | accepted |
+| [0025](0025-per-connector-definition-of-done.md) | Per-connector definition of done (5 deliverables) | proposed |
 
 ## ADR-0017 parking note
 


### PR DESCRIPTION
## Summary

Adds **ADR-0025** locking the per-connector completion bar. A connector is DONE only when all five deliverables exist together:

1. **Consumer** — strict-spec, every CLI verb the spec defines (Probel general/extended form is a tested boundary decision; Ember+ is DTD 2.60 only).
2. **Producer** — same coverage rule, inbound.
3. **Integration test** under \`internal/<proto>/integration/\` driving the actual \`dhs consumer/producer <proto> <verb>\` CLI binary. Per-test classification: PASS / FAIL-real / FAIL-expected (error-handling success) / TIMEOUT.
4. **\`.cache/dm\` + manifest generator** owned by the connector, called from test \`setUp\`, writes a local \`.cache/dm/<proto>/...\` + \`.cache/manifest/...\` next to the test files. Tests must never \`t.Skip\` on empty cache.
5. **Wireshark \`.lua\` dissector** covering every transport + version + command with per-frame Info column detail.

Closes the regression-and-circle failure mode where PRs landed "green" against partial connectors — the integration-test placeholders (\`t.Skip\`) and the codec-only test coverage didn't exercise the broken CLI paths.

## What's in this PR

| File | Change |
|---|---|
| \`docs/adr/0025-per-connector-definition-of-done.md\` | New ADR, status \`proposed\` |
| \`docs/adr/README.md\` | Index updated with the missing rows for 0022/0023/0024 + new row for 0025 |
| \`README.md\` | New "Connector definition of done" section with: (a) per-connector 5-column state table (consumer / producer / integration test / \`.cache\` generator / Wireshark \`.lua\`), (b) "What's NOT YET tested (and why)" table flagging real-device blockers per connector |

## What's NOT in this PR

- **No code changes.** The rerootPaths fix for the Ember+ dotted-path bug stays in the local working tree, queued for a separate PR after this one lands.
- **No runbook.** The per-connector runbook (\`internal/<proto>/docs/runbook.md\` with every CLI verb's captured real-run example) is named in the ADR as a separate documentation deliverable, tracked per-connector in follow-up PRs.
- **No CI changes.** Once the standard is accepted, separate PRs wire \`-tags integration\` and PowerShell verifiers into CI per connector.

## Per-protocol scope reminders (in the ADR)

- **Ember+** — DTD 2.60 only.
- **Probel** — general/extended form selection is a tested boundary decision per command.

## ADR workflow

ADR is currently \`status: proposed\`. On your approval I'll flip it to \`status: accepted\` in a follow-up amend-and-push, then merge.

## Test plan

- [x] \`go build ./...\` clean (no code change but verified after the doc-only commit)
- [x] \`go test ./...\` 67/67 PASS (no regression)
- [x] Pre-commit hook (\`go vet\` + \`golangci-lint\`) clean
- [x] Markdown lint flags only the existing compact-table-pipe style used everywhere else in the project — cosmetic, ignored

Closes #447