### PR TITLE
fix(emberplus/provider): builtins return error on unresolved matrix instead of silent success (refs #455)

### DIFF
--- a/internal/emberplus/provider/builtins.go
+++ b/internal/emberplus/provider/builtins.go
@@ -199,7 +199,7 @@ func (s *server) makeBuiltinSetLock() FunctionImpl {
 		}
 		oid, _, ok := s.resolveMatrix(matrixRef)
 		if !ok {
-			return []any{false}, nil
+			return nil, fmt.Errorf("setLock: matrix %q not found", matrixRef)
 		}
 		prev := s.locks.set(oid, target, on)
 		return []any{prev}, nil
@@ -219,7 +219,7 @@ func (s *server) makeBuiltinListLocks() FunctionImpl {
 		}
 		oid, _, ok := s.resolveMatrix(matrixRef)
 		if !ok {
-			return []any{""}, nil
+			return nil, fmt.Errorf("listLocks: matrix %q not found", matrixRef)
 		}
 		targets := s.locks.list(oid)
 		parts := make([]string, len(targets))
@@ -262,9 +262,11 @@ func builtinSum(args []any) ([]any, error) {
 // resolveMatrix accepts either a numeric OID ("1.4.3") or a dotted
 // identifier path ("router.nToN.matrix") and returns the canonical OID
 // plus the underlying Matrix element. Returns ("", nil, false) if the
-// ref does not resolve to a Matrix — so storeSalvo/recallSalvo reject
-// attempts against label string params, nodes, or bogus OIDs rather
-// than silently keying into the salvo store.
+// ref does not resolve to a Matrix — every caller (setLock /
+// listLocks / storeSalvo / recallSalvo / listSalvos / getSalvo)
+// surfaces the miss as a *function-level error* so the consumer's
+// InvocationResult carries Success=false rather than a falsy default
+// indistinguishable from a real result. Refs #455.
 func (s *server) resolveMatrix(ref string) (string, *canonical.Matrix, bool) {
 	e, ok := s.tree.lookupOID(ref)
 	if !ok {
@@ -300,7 +302,7 @@ func (s *server) makeBuiltinRecallSalvo() FunctionImpl {
 		}
 		oid, _, ok := s.resolveMatrix(matrixRef)
 		if !ok {
-			return []any{int64(0)}, nil
+			return nil, fmt.Errorf("recallSalvo: matrix %q not found", matrixRef)
 		}
 		conns, ok := s.salvos.recall(oid, salvoID)
 		if !ok {
@@ -361,8 +363,11 @@ func filterConnectionsByTargets(conns []canonical.MatrixConnection, list string)
 //                                  delimited strings.
 //
 // Returns true if at least one connection was stored. False when the
-// matrix resolves but no listed target has any current sources, or the
-// ref does not resolve to a Matrix.
+// matrix resolves but no listed target has any current sources.
+// Returns (nil, err) — i.e. Success=false on the wire — when the ref
+// does not resolve to a Matrix; the consumer must distinguish "no
+// connections to snapshot" (success=true, result=false) from "matrix
+// not found" (success=false). Refs #455.
 func (s *server) makeBuiltinStoreSalvo() FunctionImpl {
 	return func(args []any) ([]any, error) {
 		if len(args) < 2 {
@@ -381,7 +386,7 @@ func (s *server) makeBuiltinStoreSalvo() FunctionImpl {
 		}
 		oid, m, ok := s.resolveMatrix(matrixRef)
 		if !ok {
-			return []any{false}, nil
+			return nil, fmt.Errorf("storeSalvo: matrix %q not found", matrixRef)
 		}
 		filtered := filterConnectionsByTargets(m.Connections, targetFilter)
 		if len(filtered) == 0 {
@@ -396,9 +401,11 @@ func (s *server) makeBuiltinStoreSalvo() FunctionImpl {
 // IDs for the given matrix, ascending. Args:
 //   - args[0] string matrixPath — OID or dotted identifier path
 //
-// Empty string if the matrix has no salvos yet. Returns an empty string
-// for non-matrix refs rather than an error so consumers can probe
-// cheaply without trapping exceptions.
+// Empty string if the matrix has no salvos yet. Returns (nil, err) —
+// Success=false on the wire — when the ref does not resolve to a
+// Matrix; the consumer must distinguish "no salvos stored yet"
+// (success=true, result="") from "matrix not found"
+// (success=false). Refs #455.
 func (s *server) makeBuiltinListSalvos() FunctionImpl {
 	return func(args []any) ([]any, error) {
 		if len(args) < 1 {
@@ -410,7 +417,7 @@ func (s *server) makeBuiltinListSalvos() FunctionImpl {
 		}
 		oid, _, ok := s.resolveMatrix(matrixRef)
 		if !ok {
-			return []any{""}, nil
+			return nil, fmt.Errorf("listSalvos: matrix %q not found", matrixRef)
 		}
 		ids := s.salvos.list(oid)
 		parts := make([]string, len(ids))
@@ -432,8 +439,9 @@ func (s *server) makeBuiltinListSalvos() FunctionImpl {
 // Example: salvo with target 0 → [1,2], target 5 → [3], target 7 → []
 // returns "0=1,2;5=3;7=".
 //
-// Empty string for an unknown matrix or salvo ID — same cheap-probe
-// convention as listSalvos.
+// Empty string for an unknown salvo ID inside a valid matrix. Returns
+// (nil, err) — Success=false on the wire — when the ref does not
+// resolve to a Matrix at all. Refs #455.
 func (s *server) makeBuiltinGetSalvo() FunctionImpl {
 	return func(args []any) ([]any, error) {
 		if len(args) < 2 {
@@ -449,7 +457,7 @@ func (s *server) makeBuiltinGetSalvo() FunctionImpl {
 		}
 		oid, _, ok := s.resolveMatrix(matrixRef)
 		if !ok {
-			return []any{""}, nil
+			return nil, fmt.Errorf("getSalvo: matrix %q not found", matrixRef)
 		}
 		conns, ok := s.salvos.recall(oid, salvoID)
 		if !ok {

--- a/internal/emberplus/provider/builtins_test.go
+++ b/internal/emberplus/provider/builtins_test.go
@@ -1,0 +1,112 @@
+package emberplus
+
+import (
+	"strings"
+	"testing"
+
+	"dhs/internal/export/canonical"
+)
+
+// TestBuiltins_ErrorOnUnresolvedMatrix pins #455: every builtin that
+// accepts a matrixPath (setLock / listLocks / storeSalvo / recallSalvo /
+// listSalvos / getSalvo) must return (nil, err) — Success=false on the
+// wire — when resolveMatrix(matrixRef) misses, so the consumer can
+// distinguish "matrix not found" from a real falsy result.
+//
+// Pre-#455 the same builtins silently returned a falsy default
+// (`[]any{false}`, `[]any{""}`, `[]any{int64(0)}`) on miss, which the
+// consumer's invoke verb prints as "invocation 1: success=true
+// result: [false]" — indistinguishable from a real operation that
+// returned false.
+func TestBuiltins_ErrorOnUnresolvedMatrix(t *testing.T) {
+	m := &canonical.Matrix{Type: canonical.MatrixOneToN}
+	srv := buildMatrixTree(t, m)
+
+	cases := []struct {
+		name string
+		fn   FunctionImpl
+		args []any
+	}{
+		{"setLock", srv.makeBuiltinSetLock(), []any{"bogus.path", int64(0), true}},
+		{"listLocks", srv.makeBuiltinListLocks(), []any{"bogus.path"}},
+		{"storeSalvo", srv.makeBuiltinStoreSalvo(), []any{"bogus.path", int64(7), ""}},
+		{"recallSalvo", srv.makeBuiltinRecallSalvo(), []any{"bogus.path", int64(7)}},
+		{"listSalvos", srv.makeBuiltinListSalvos(), []any{"bogus.path"}},
+		{"getSalvo", srv.makeBuiltinGetSalvo(), []any{"bogus.path", int64(7)}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := tc.fn(tc.args)
+			if err == nil {
+				t.Fatalf("expected non-nil error on unresolved matrix, got nil (res=%v)", res)
+			}
+			if res != nil {
+				t.Errorf("on error the result tuple must be nil (so Success=false), got %v", res)
+			}
+			if !strings.Contains(err.Error(), "bogus.path") {
+				t.Errorf("error %q should mention the rejected matrixRef", err.Error())
+			}
+			if !strings.Contains(err.Error(), tc.name) {
+				t.Errorf("error %q should name the builtin (%s)", err.Error(), tc.name)
+			}
+		})
+	}
+}
+
+// TestBuiltins_HappyPathUnchanged confirms the resolved-matrix path
+// still returns (result, nil) — the fix in #455 must only impact the
+// previously-silent miss branch, not the working path.
+func TestBuiltins_HappyPathUnchanged(t *testing.T) {
+	m := &canonical.Matrix{
+		Type: canonical.MatrixNToN,
+		Connections: []canonical.MatrixConnection{
+			{Target: 0, Sources: []int64{1}},
+		},
+	}
+	srv := buildMatrixTree(t, m)
+
+	if res, err := srv.makeBuiltinSetLock()([]any{"1.1", int64(0), true}); err != nil {
+		t.Errorf("setLock happy path: unexpected error %v", err)
+	} else if len(res) != 1 || res[0] != false {
+		t.Errorf("setLock happy path: result %v, want [false] (prev unlocked)", res)
+	}
+	if _, err := srv.makeBuiltinListLocks()([]any{"1.1"}); err != nil {
+		t.Errorf("listLocks happy path: unexpected error %v", err)
+	}
+	if res, err := srv.makeBuiltinStoreSalvo()([]any{"1.1", int64(1), ""}); err != nil {
+		t.Errorf("storeSalvo happy path: unexpected error %v", err)
+	} else if len(res) != 1 || res[0] != true {
+		t.Errorf("storeSalvo happy path: result %v, want [true]", res)
+	}
+	if res, err := srv.makeBuiltinListSalvos()([]any{"1.1"}); err != nil {
+		t.Errorf("listSalvos happy path: unexpected error %v", err)
+	} else if len(res) != 1 {
+		t.Errorf("listSalvos happy path: result %v, want non-empty string tuple", res)
+	}
+	if _, err := srv.makeBuiltinRecallSalvo()([]any{"1.1", int64(1)}); err != nil {
+		t.Errorf("recallSalvo happy path: unexpected error %v", err)
+	}
+	if _, err := srv.makeBuiltinGetSalvo()([]any{"1.1", int64(1)}); err != nil {
+		t.Errorf("getSalvo happy path: unexpected error %v", err)
+	}
+}
+
+// TestBuiltins_NonMatrixRefIsError covers a sub-case of #455: when the
+// ref resolves to *something* in the tree but it isn't a Matrix
+// element, resolveMatrix returns ok=false. Same error contract — the
+// builtin must surface that rather than silently coerce.
+func TestBuiltins_NonMatrixRefIsError(t *testing.T) {
+	// buildMatrixTree's root is a Node with OID="1" — point at it
+	// (not the matrix at "1.1") and confirm the builtin errors.
+	m := &canonical.Matrix{Type: canonical.MatrixOneToN}
+	srv := buildMatrixTree(t, m)
+
+	_, err := srv.makeBuiltinSetLock()([]any{"1", int64(0), true})
+	if err == nil {
+		t.Fatal("setLock against non-matrix OID should error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error %q should say 'not found'", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary

Six builtin function callbacks in `internal/emberplus/provider/builtins.go` silently swallowed the `resolveMatrix(matrixRef)` miss and returned a non-error result indistinguishable from a real result: `setLock`, `listLocks`, `recallSalvo`, `storeSalvo`, `listSalvos`, `getSalvo` each took the `if !ok { return []any{<default>}, nil }` branch on an unresolved matrix ref, which the consumer's `invoke` verb prints as `invocation 1: success=true result: [<default>]` — identical to a successful call that genuinely returned the default value.

Same anti-pattern as #445 / PR #453's silent-coerce. Per `FunctionImpl`'s contract ([invoke.go:14-15](internal/emberplus/provider/invoke.go#L14-L15)) returning `(nil, err)` is the only way to produce `InvocationResult.Success=false` on the wire.

Discovered during ADR-0025 Ember+ live audit walking every CLI verb against the integration demo.

## Fix

Each of the six callsites changes `if !ok { return []any{<default>}, nil }` to `if !ok { return nil, fmt.Errorf("<builtin>: matrix %q not found", matrixRef) }`. The error path is already wired through [invoke.go:53-56](internal/emberplus/provider/invoke.go#L53-L56) — `s.logger.Debug("invoke: function returned error", ...)` and the wire-level `InvocationResult.Success=false`.

Doc comments updated to spell out the distinction the consumer must make: empty results *inside a valid matrix* (no salvos yet, no targets to snapshot) remain `success=true, result=<empty>`; the matrix-not-found case is the only path that flips `Success=false`. `recallSalvo`'s salvo-not-in-store case is preserved as `success=true, result=[0]` — only the matrix-ref resolution is upgraded to an error.

## Live re-verify (2026-05-17 on bin/dhs.exe with this branch's HEAD)

Producer up on `:9100` from `.cache/manifest/emberplus-integration.json` (strict-canonical demo DMs).

```
# A. bogus matrixRef — now Success=false (was silent success)
$ invoke storeSalvo --args "bogus.path.here,99,"
invocation 1: success=false

# B. valid OID — unchanged happy path
$ invoke storeSalvo --args "1.1.3,99,"
invocation 1: success=true
result: [true]

# C. listSalvos confirms salvo 99 actually stored by call B
$ invoke listSalvos --args "1.1.3"
invocation 1: success=true
result: [99]
```

## Test plan

- New `builtins_test.go` pins three scenarios:
  - 6 builtins × unresolved-matrix → non-nil error mentioning the builtin name + rejected ref
  - 6 builtins happy path unchanged (valid OID → expected result tuple, no error)
  - non-matrix-element ref (pointing at a Node) errors the same way (one rep — `setLock`)
- `go test ./internal/emberplus/...` — 6 packages green (ber / glow / matrix / s101 / consumer / provider)
- `go build -o bin/dhs.exe ./cmd/dhs` — clean
- Live: producer restarted with new binary, scenarios A/B/C above verified

## Out of scope

- The consumer's `invoke` verb still exits 0 on `Success=false` (only connection-level failures bubble to exit-code). Separate UX question for a follow-up issue if operators want `dhs … invoke … -> exit 2 on Success=false` semantics.
- `lookupPath` itself still doesn't see device-prefixed paths when strict-canonical slot DMs are used — that's #456 (`BuildExport` needs to reroot slot DM paths under the synthetic root). Bug A makes the failure visible; Bug B fixes the underlying byIDP gap.

Refs #455
