### PR TITLE
fix(emberplus/consumer): GetSlotInfo sets IsOnline from sessionConnected (refs #458)

### DIFF
--- a/internal/emberplus/consumer/plugin.go
+++ b/internal/emberplus/consumer/plugin.go
@@ -490,11 +490,23 @@ func (p *Plugin) GetDeviceInfo(ctx context.Context) (consumer.DeviceInfo, error)
 
 // GetSlotInfo pretends the whole Ember+ tree is slot 0. Any other slot is
 // a usage error.
+//
+// IsOnline tracks the underlying session liveness — true when the consumer
+// is past Ember+ S101 handshake (sessionConnected). Ember+ has no per-slot
+// hot-plug semantics, so the slot follows the session bool 1:1. Refs #458.
 func (p *Plugin) GetSlotInfo(ctx context.Context, slot int) (consumer.SlotInfo, error) {
 	if slot != 0 {
 		return consumer.SlotInfo{}, fmt.Errorf("emberplus: only slot 0 supported")
 	}
-	return consumer.SlotInfo{Slot: 0, Status: consumer.SlotPresent}, nil
+	p.mu.Lock()
+	live := p.sessionConnected
+	p.mu.Unlock()
+	return consumer.SlotInfo{
+		Slot:     0,
+		Status:   consumer.SlotPresent,
+		State:    consumer.SlotStatePresent,
+		IsOnline: live,
+	}, nil
 }
 
 // Walk triggers a full GetDirectory and blocks until the tree stops

--- a/internal/emberplus/consumer/slot_info_test.go
+++ b/internal/emberplus/consumer/slot_info_test.go
@@ -1,0 +1,61 @@
+package emberplus
+
+import (
+	"context"
+	"testing"
+
+	"dhs/internal/consumer"
+)
+
+// TestGetSlotInfo_OnlineFollowsSession pins #458: the dhs-internal
+// SlotInfo.IsOnline must track p.sessionConnected. Pre-#458
+// GetSlotInfo returned the Go zero value (`false`) regardless of
+// liveness, so `dhs consumer emberplus info <host>` always printed
+// `online=false` even against a healthy connected provider.
+//
+// Ember+ has no slot hot-plug concept — the single virtual slot 0
+// follows the session bool 1:1.
+func TestGetSlotInfo_OnlineFollowsSession(t *testing.T) {
+	cases := []struct {
+		name      string
+		connected bool
+		want      bool
+	}{
+		{"disconnected -> online=false", false, false},
+		{"connected -> online=true", true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &Plugin{}
+			p.sessionConnected = tc.connected
+
+			si, err := p.GetSlotInfo(context.Background(), 0)
+			if err != nil {
+				t.Fatalf("GetSlotInfo: %v", err)
+			}
+			if si.IsOnline != tc.want {
+				t.Errorf("IsOnline = %v, want %v (sessionConnected=%v)", si.IsOnline, tc.want, tc.connected)
+			}
+			if si.Status != consumer.SlotPresent {
+				t.Errorf("Status = %v, want SlotPresent", si.Status)
+			}
+			if si.State != consumer.SlotStatePresent {
+				t.Errorf("State = %q, want SlotStatePresent", si.State)
+			}
+			if si.Slot != 0 {
+				t.Errorf("Slot = %d, want 0", si.Slot)
+			}
+		})
+	}
+}
+
+// TestGetSlotInfo_RejectsNonZeroSlot keeps the existing only-slot-0
+// guard from regressing when the IsOnline bit is added.
+func TestGetSlotInfo_RejectsNonZeroSlot(t *testing.T) {
+	p := &Plugin{}
+	p.sessionConnected = true
+
+	if _, err := p.GetSlotInfo(context.Background(), 1); err == nil {
+		t.Fatal("GetSlotInfo(slot=1): expected error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

`GetSlotInfo` returned the Go zero value for `IsOnline` regardless of session liveness, so `dhs consumer emberplus info <host>` printed `online=false` even against a healthy connected provider. Discovered during ADR-0025 Ember+ live audit.

## Fix

[internal/emberplus/consumer/plugin.go](internal/emberplus/consumer/plugin.go) `GetSlotInfo` now reads `p.sessionConnected` (under the existing mutex) and reports it as `IsOnline`. Ember+ has no per-slot hot-plug concept (the whole tree lives under a single virtual slot 0), so the slot follows the session bool 1:1.

Also populates the semantic `State` enum (`SlotStatePresent`) per the `consumer.SlotInfo` schema — previously left as Go zero, which the slot-state helper interpreted as "unknown".

## Scope distinction (not the same as wire-level isOnline)

Ember+ DTD 2.30+ `isOnline` is a per-Element bool on the wire (Node / Parameter / Matrix) — the provider already sets that on every Element and the consumer reads it correctly. This PR is purely about the dhs-internal `consumer.SlotInfo.IsOnline` Go field that powers the generic `info` CLI verb.

## Live re-verify (2026-05-17, bin/dhs.exe with this branch's HEAD)

```
$ dhs consumer emberplus info 127.0.0.1 --port 9100
device       127.0.0.1:9100
protocol     emberplus v1
slots        1

per-slot status:
  slot  0   status=present    online=true   (was: online=false)
```

## Test plan

- New `slot_info_test.go` pins 3 cases:
  - disconnected → `IsOnline=false`
  - connected → `IsOnline=true`
  - unchanged only-slot-0 guard
- `go test ./internal/emberplus/...` — 6 packages green
- `go build -o bin/dhs.exe ./cmd/dhs` — clean
- Live: above

Refs #458
