### PR TITLE
refactor(emberplus): move integration-test fixtures into internal/emberplus/testdata/ (refs #460)

### DIFF
--- a/internal/emberplus/docs/integration-demo.md
+++ b/internal/emberplus/docs/integration-demo.md
@@ -14,8 +14,11 @@ walk completes in well under a second. All seeds live under
 
 ## 1. Generate seeds + start the producer
 
+Source-of-truth DMs + manifest live under
+`internal/emberplus/testdata/integration-test/` (per ADR-0025 #6).
+
 ```powershell
-# (Re)generate all DMs + manifest. Idempotent.
+# (Re)generate all DMs + manifest into internal/emberplus/testdata/integration-test/. Idempotent.
 powershell -ExecutionPolicy Bypass -File .\scripts\emberplus\gen-emberplus-demo-dms.ps1
 
 # (Optional) End-to-end verifier: labels + per-tgt/src/XPT params + crosspoints
@@ -24,9 +27,10 @@ powershell -ExecutionPolicy Bypass -File .\scripts\emberplus\gen-emberplus-demo-
 # Build the binary
 go build -o bin/dhs.exe ./cmd/dhs
 
-# Serve via the manifest
+# Serve from the testdata layout
 .\bin\dhs.exe producer emberplus serve `
-    --manifest .cache\manifest\emberplus-integration.json `
+    --manifest internal\emberplus\testdata\integration-test\manifest\emberplus-integration.json `
+    --cache-dir internal\emberplus\testdata\integration-test `
     --port 9100 `
     --log-level debug
 ```

--- a/internal/emberplus/testdata/integration-test/README.md
+++ b/internal/emberplus/testdata/integration-test/README.md
@@ -1,0 +1,60 @@
+# Ember+ integration-test source-of-truth
+
+Version-controlled DM cards + manifest assembled into the spec-clean
+Ember+ provider used by `internal/emberplus/integration/` Go tests, the
+operator runbook at [internal/emberplus/docs/runbook.md](../../docs/runbook.md),
+and the capture fixtures under [internal/emberplus/testdata/protocol_types/](../protocol_types/).
+
+Per ADR-0025 deliverable #6, the DM files live **inside the protocol
+folder** so they ship as part of the lift-to-own-repo unit. The
+runtime `.cache/dm/emberplus/` directory at the repo root is a
+gitignored derived cache; nothing here depends on it.
+
+## Layout
+
+```
+internal/emberplus/testdata/integration-test/
+├── README.md                      ← this file
+├── manifest/
+│   └── emberplus-integration.json ← Device → Frame → Slot manifest (ADR-0022)
+└── dm/
+    └── emberplus/
+        ├── identity-strict@1.0.0.json    ← product / company / version / DTD
+        ├── oneToOne-strict@1.0.0.json    ← 16×16, Pri+Sec labels, source-exclusive
+        ├── oneToN-strict@1.0.0.json      ← 16×16, Pri+Sec labels, locked target
+        ├── nToN-strict@1.0.0.json        ← 16×16, Pri+Sec, multi-src per tgt
+        ├── dynamic-strict@1.0.0.json     ← 128×128 declared, 16×16 sparse
+        ├── functions-strict@1.0.0.json   ← setLock/listLocks/storeSalvo/...
+        └── glow-types-strict@1.0.0.json  ← every ParameterType + streams id=0|>0
+```
+
+## Serve from this layout
+
+```powershell
+dhs producer emberplus serve `
+    --manifest internal/emberplus/testdata/integration-test/manifest/emberplus-integration.json `
+    --cache-dir internal/emberplus/testdata/integration-test `
+    --port 9100
+```
+
+`--cache-dir` is the root of the cache tree; `manifest.BuildExport` resolves
+each slot's `dm` field against `<cache-dir>/dm/emberplus/<dm>.json`. The
+default `.cache` value points at the gitignored runtime cache; pointing
+it here serves the source-of-truth fixtures directly.
+
+## Regenerate
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\emberplus\gen-emberplus-demo-dms.ps1
+```
+
+The script writes to this directory directly. Any drift between the
+script's output and the checked-in files is a regression — diff to
+catch it.
+
+## Refs
+
+- [ADR-0022](../../../../docs/adr/0022-card-data-model.md) — Card data model (Device / Frame / Slot / DM)
+- [ADR-0025](../../../../docs/adr/0025-per-connector-definition-of-done.md) — Per-connector definition of done; deliverable #6 (replay fixtures under testdata/)
+- [Operator runbook](../../docs/runbook.md) (in progress, tracked by #460)
+- [Capture fixtures](../protocol_types/) (in progress)

--- a/internal/emberplus/testdata/integration-test/dm/emberplus/dynamic-strict@1.0.0.json
+++ b/internal/emberplus/testdata/integration-test/dm/emberplus/dynamic-strict@1.0.0.json
@@ -1,0 +1,1763 @@
+{
+    "model":  "dynamic-strict",
+    "sw_rev":  "1.0.0",
+    "protocol":  "emberplus",
+    "root":  {
+                 "number":  4,
+                 "identifier":  "dynamic",
+                 "path":  "dynamic",
+                 "oid":  "1.4",
+                 "isOnline":  true,
+                 "access":  "read",
+                 "children":  [
+                                  {
+                                      "number":  1,
+                                      "identifier":  "labelsPrimary",
+                                      "path":  "dynamic.labelsPrimary",
+                                      "oid":  "1.4.1",
+                                      "isOnline":  true,
+                                      "access":  "read",
+                                      "children":  [
+                                                       {
+                                                           "number":  1,
+                                                           "identifier":  "targets",
+                                                           "path":  "dynamic.labelsPrimary.targets",
+                                                           "oid":  "1.4.1.1",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  0,
+                                                                                "identifier":  "t-0",
+                                                                                "path":  "dynamic.labelsPrimary.targets.t-0",
+                                                                                "oid":  "1.4.1.1.0",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-T0"
+                                                                            },
+                                                                            {
+                                                                                "number":  50,
+                                                                                "identifier":  "t-50",
+                                                                                "path":  "dynamic.labelsPrimary.targets.t-50",
+                                                                                "oid":  "1.4.1.1.50",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-T50"
+                                                                            },
+                                                                            {
+                                                                                "number":  137,
+                                                                                "identifier":  "t-137",
+                                                                                "path":  "dynamic.labelsPrimary.targets.t-137",
+                                                                                "oid":  "1.4.1.1.137",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-T137"
+                                                                            },
+                                                                            {
+                                                                                "number":  200,
+                                                                                "identifier":  "t-200",
+                                                                                "path":  "dynamic.labelsPrimary.targets.t-200",
+                                                                                "oid":  "1.4.1.1.200",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-T200"
+                                                                            },
+                                                                            {
+                                                                                "number":  350,
+                                                                                "identifier":  "t-350",
+                                                                                "path":  "dynamic.labelsPrimary.targets.t-350",
+                                                                                "oid":  "1.4.1.1.350",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-T350"
+                                                                            },
+                                                                            {
+                                                                                "number":  401,
+                                                                                "identifier":  "t-401",
+                                                                                "path":  "dynamic.labelsPrimary.targets.t-401",
+                                                                                "oid":  "1.4.1.1.401",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-T401"
+                                                                            },
+                                                                            {
+                                                                                "number":  500,
+                                                                                "identifier":  "t-500",
+                                                                                "path":  "dynamic.labelsPrimary.targets.t-500",
+                                                                                "oid":  "1.4.1.1.500",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-T500"
+                                                                            },
+                                                                            {
+                                                                                "number":  750,
+                                                                                "identifier":  "t-750",
+                                                                                "path":  "dynamic.labelsPrimary.targets.t-750",
+                                                                                "oid":  "1.4.1.1.750",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-T750"
+                                                                            },
+                                                                            {
+                                                                                "number":  888,
+                                                                                "identifier":  "t-888",
+                                                                                "path":  "dynamic.labelsPrimary.targets.t-888",
+                                                                                "oid":  "1.4.1.1.888",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-T888"
+                                                                            },
+                                                                            {
+                                                                                "number":  999,
+                                                                                "identifier":  "t-999",
+                                                                                "path":  "dynamic.labelsPrimary.targets.t-999",
+                                                                                "oid":  "1.4.1.1.999",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-T999"
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  2,
+                                                           "identifier":  "sources",
+                                                           "path":  "dynamic.labelsPrimary.sources",
+                                                           "oid":  "1.4.1.2",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  0,
+                                                                                "identifier":  "s-0",
+                                                                                "path":  "dynamic.labelsPrimary.sources.s-0",
+                                                                                "oid":  "1.4.1.2.0",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-S0"
+                                                                            },
+                                                                            {
+                                                                                "number":  50,
+                                                                                "identifier":  "s-50",
+                                                                                "path":  "dynamic.labelsPrimary.sources.s-50",
+                                                                                "oid":  "1.4.1.2.50",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-S50"
+                                                                            },
+                                                                            {
+                                                                                "number":  137,
+                                                                                "identifier":  "s-137",
+                                                                                "path":  "dynamic.labelsPrimary.sources.s-137",
+                                                                                "oid":  "1.4.1.2.137",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-S137"
+                                                                            },
+                                                                            {
+                                                                                "number":  200,
+                                                                                "identifier":  "s-200",
+                                                                                "path":  "dynamic.labelsPrimary.sources.s-200",
+                                                                                "oid":  "1.4.1.2.200",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-S200"
+                                                                            },
+                                                                            {
+                                                                                "number":  350,
+                                                                                "identifier":  "s-350",
+                                                                                "path":  "dynamic.labelsPrimary.sources.s-350",
+                                                                                "oid":  "1.4.1.2.350",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-S350"
+                                                                            },
+                                                                            {
+                                                                                "number":  401,
+                                                                                "identifier":  "s-401",
+                                                                                "path":  "dynamic.labelsPrimary.sources.s-401",
+                                                                                "oid":  "1.4.1.2.401",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-S401"
+                                                                            },
+                                                                            {
+                                                                                "number":  500,
+                                                                                "identifier":  "s-500",
+                                                                                "path":  "dynamic.labelsPrimary.sources.s-500",
+                                                                                "oid":  "1.4.1.2.500",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-S500"
+                                                                            },
+                                                                            {
+                                                                                "number":  750,
+                                                                                "identifier":  "s-750",
+                                                                                "path":  "dynamic.labelsPrimary.sources.s-750",
+                                                                                "oid":  "1.4.1.2.750",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-S750"
+                                                                            },
+                                                                            {
+                                                                                "number":  888,
+                                                                                "identifier":  "s-888",
+                                                                                "path":  "dynamic.labelsPrimary.sources.s-888",
+                                                                                "oid":  "1.4.1.2.888",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-S888"
+                                                                            },
+                                                                            {
+                                                                                "number":  999,
+                                                                                "identifier":  "s-999",
+                                                                                "path":  "dynamic.labelsPrimary.sources.s-999",
+                                                                                "oid":  "1.4.1.2.999",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-S999"
+                                                                            }
+                                                                        ]
+                                                       }
+                                                   ]
+                                  },
+                                  {
+                                      "number":  2,
+                                      "identifier":  "labelsSecondary",
+                                      "path":  "dynamic.labelsSecondary",
+                                      "oid":  "1.4.2",
+                                      "isOnline":  true,
+                                      "access":  "read",
+                                      "children":  [
+                                                       {
+                                                           "number":  1,
+                                                           "identifier":  "targets",
+                                                           "path":  "dynamic.labelsSecondary.targets",
+                                                           "oid":  "1.4.2.1",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  0,
+                                                                                "identifier":  "t-0",
+                                                                                "path":  "dynamic.labelsSecondary.targets.t-0",
+                                                                                "oid":  "1.4.2.1.0",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-T0"
+                                                                            },
+                                                                            {
+                                                                                "number":  50,
+                                                                                "identifier":  "t-50",
+                                                                                "path":  "dynamic.labelsSecondary.targets.t-50",
+                                                                                "oid":  "1.4.2.1.50",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-T50"
+                                                                            },
+                                                                            {
+                                                                                "number":  137,
+                                                                                "identifier":  "t-137",
+                                                                                "path":  "dynamic.labelsSecondary.targets.t-137",
+                                                                                "oid":  "1.4.2.1.137",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-T137"
+                                                                            },
+                                                                            {
+                                                                                "number":  200,
+                                                                                "identifier":  "t-200",
+                                                                                "path":  "dynamic.labelsSecondary.targets.t-200",
+                                                                                "oid":  "1.4.2.1.200",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-T200"
+                                                                            },
+                                                                            {
+                                                                                "number":  350,
+                                                                                "identifier":  "t-350",
+                                                                                "path":  "dynamic.labelsSecondary.targets.t-350",
+                                                                                "oid":  "1.4.2.1.350",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-T350"
+                                                                            },
+                                                                            {
+                                                                                "number":  401,
+                                                                                "identifier":  "t-401",
+                                                                                "path":  "dynamic.labelsSecondary.targets.t-401",
+                                                                                "oid":  "1.4.2.1.401",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-T401"
+                                                                            },
+                                                                            {
+                                                                                "number":  500,
+                                                                                "identifier":  "t-500",
+                                                                                "path":  "dynamic.labelsSecondary.targets.t-500",
+                                                                                "oid":  "1.4.2.1.500",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-T500"
+                                                                            },
+                                                                            {
+                                                                                "number":  750,
+                                                                                "identifier":  "t-750",
+                                                                                "path":  "dynamic.labelsSecondary.targets.t-750",
+                                                                                "oid":  "1.4.2.1.750",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-T750"
+                                                                            },
+                                                                            {
+                                                                                "number":  888,
+                                                                                "identifier":  "t-888",
+                                                                                "path":  "dynamic.labelsSecondary.targets.t-888",
+                                                                                "oid":  "1.4.2.1.888",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-T888"
+                                                                            },
+                                                                            {
+                                                                                "number":  999,
+                                                                                "identifier":  "t-999",
+                                                                                "path":  "dynamic.labelsSecondary.targets.t-999",
+                                                                                "oid":  "1.4.2.1.999",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-T999"
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  2,
+                                                           "identifier":  "sources",
+                                                           "path":  "dynamic.labelsSecondary.sources",
+                                                           "oid":  "1.4.2.2",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  0,
+                                                                                "identifier":  "s-0",
+                                                                                "path":  "dynamic.labelsSecondary.sources.s-0",
+                                                                                "oid":  "1.4.2.2.0",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-S0"
+                                                                            },
+                                                                            {
+                                                                                "number":  50,
+                                                                                "identifier":  "s-50",
+                                                                                "path":  "dynamic.labelsSecondary.sources.s-50",
+                                                                                "oid":  "1.4.2.2.50",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-S50"
+                                                                            },
+                                                                            {
+                                                                                "number":  137,
+                                                                                "identifier":  "s-137",
+                                                                                "path":  "dynamic.labelsSecondary.sources.s-137",
+                                                                                "oid":  "1.4.2.2.137",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-S137"
+                                                                            },
+                                                                            {
+                                                                                "number":  200,
+                                                                                "identifier":  "s-200",
+                                                                                "path":  "dynamic.labelsSecondary.sources.s-200",
+                                                                                "oid":  "1.4.2.2.200",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-S200"
+                                                                            },
+                                                                            {
+                                                                                "number":  350,
+                                                                                "identifier":  "s-350",
+                                                                                "path":  "dynamic.labelsSecondary.sources.s-350",
+                                                                                "oid":  "1.4.2.2.350",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-S350"
+                                                                            },
+                                                                            {
+                                                                                "number":  401,
+                                                                                "identifier":  "s-401",
+                                                                                "path":  "dynamic.labelsSecondary.sources.s-401",
+                                                                                "oid":  "1.4.2.2.401",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-S401"
+                                                                            },
+                                                                            {
+                                                                                "number":  500,
+                                                                                "identifier":  "s-500",
+                                                                                "path":  "dynamic.labelsSecondary.sources.s-500",
+                                                                                "oid":  "1.4.2.2.500",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-S500"
+                                                                            },
+                                                                            {
+                                                                                "number":  750,
+                                                                                "identifier":  "s-750",
+                                                                                "path":  "dynamic.labelsSecondary.sources.s-750",
+                                                                                "oid":  "1.4.2.2.750",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-S750"
+                                                                            },
+                                                                            {
+                                                                                "number":  888,
+                                                                                "identifier":  "s-888",
+                                                                                "path":  "dynamic.labelsSecondary.sources.s-888",
+                                                                                "oid":  "1.4.2.2.888",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-S888"
+                                                                            },
+                                                                            {
+                                                                                "number":  999,
+                                                                                "identifier":  "s-999",
+                                                                                "path":  "dynamic.labelsSecondary.sources.s-999",
+                                                                                "oid":  "1.4.2.2.999",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-S999"
+                                                                            }
+                                                                        ]
+                                                       }
+                                                   ]
+                                  },
+                                  {
+                                      "number":  4,
+                                      "identifier":  "targetParams",
+                                      "path":  "dynamic.targetParams",
+                                      "oid":  "1.4.4",
+                                      "isOnline":  true,
+                                      "access":  "read",
+                                      "children":  [
+                                                       {
+                                                           "number":  0,
+                                                           "identifier":  "0",
+                                                           "path":  "dynamic.targetParams.0",
+                                                           "oid":  "1.4.4.0",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "dynamic.targetParams.0.gain",
+                                                                                "oid":  "1.4.4.0.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "dynamic.targetParams.0.mode",
+                                                                                "oid":  "1.4.4.0.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "dynamic.targetParams.0.mute",
+                                                                                "oid":  "1.4.4.0.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  50,
+                                                           "identifier":  "50",
+                                                           "path":  "dynamic.targetParams.50",
+                                                           "oid":  "1.4.4.50",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "dynamic.targetParams.50.gain",
+                                                                                "oid":  "1.4.4.50.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "dynamic.targetParams.50.mode",
+                                                                                "oid":  "1.4.4.50.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "dynamic.targetParams.50.mute",
+                                                                                "oid":  "1.4.4.50.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  137,
+                                                           "identifier":  "137",
+                                                           "path":  "dynamic.targetParams.137",
+                                                           "oid":  "1.4.4.137",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "dynamic.targetParams.137.gain",
+                                                                                "oid":  "1.4.4.137.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "dynamic.targetParams.137.mode",
+                                                                                "oid":  "1.4.4.137.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "dynamic.targetParams.137.mute",
+                                                                                "oid":  "1.4.4.137.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  200,
+                                                           "identifier":  "200",
+                                                           "path":  "dynamic.targetParams.200",
+                                                           "oid":  "1.4.4.200",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "dynamic.targetParams.200.gain",
+                                                                                "oid":  "1.4.4.200.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "dynamic.targetParams.200.mode",
+                                                                                "oid":  "1.4.4.200.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "dynamic.targetParams.200.mute",
+                                                                                "oid":  "1.4.4.200.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  350,
+                                                           "identifier":  "350",
+                                                           "path":  "dynamic.targetParams.350",
+                                                           "oid":  "1.4.4.350",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "dynamic.targetParams.350.gain",
+                                                                                "oid":  "1.4.4.350.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "dynamic.targetParams.350.mode",
+                                                                                "oid":  "1.4.4.350.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "dynamic.targetParams.350.mute",
+                                                                                "oid":  "1.4.4.350.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  401,
+                                                           "identifier":  "401",
+                                                           "path":  "dynamic.targetParams.401",
+                                                           "oid":  "1.4.4.401",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "dynamic.targetParams.401.gain",
+                                                                                "oid":  "1.4.4.401.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "dynamic.targetParams.401.mode",
+                                                                                "oid":  "1.4.4.401.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "dynamic.targetParams.401.mute",
+                                                                                "oid":  "1.4.4.401.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  500,
+                                                           "identifier":  "500",
+                                                           "path":  "dynamic.targetParams.500",
+                                                           "oid":  "1.4.4.500",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "dynamic.targetParams.500.gain",
+                                                                                "oid":  "1.4.4.500.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "dynamic.targetParams.500.mode",
+                                                                                "oid":  "1.4.4.500.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "dynamic.targetParams.500.mute",
+                                                                                "oid":  "1.4.4.500.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  750,
+                                                           "identifier":  "750",
+                                                           "path":  "dynamic.targetParams.750",
+                                                           "oid":  "1.4.4.750",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "dynamic.targetParams.750.gain",
+                                                                                "oid":  "1.4.4.750.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "dynamic.targetParams.750.mode",
+                                                                                "oid":  "1.4.4.750.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "dynamic.targetParams.750.mute",
+                                                                                "oid":  "1.4.4.750.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  888,
+                                                           "identifier":  "888",
+                                                           "path":  "dynamic.targetParams.888",
+                                                           "oid":  "1.4.4.888",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "dynamic.targetParams.888.gain",
+                                                                                "oid":  "1.4.4.888.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "dynamic.targetParams.888.mode",
+                                                                                "oid":  "1.4.4.888.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "dynamic.targetParams.888.mute",
+                                                                                "oid":  "1.4.4.888.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  999,
+                                                           "identifier":  "999",
+                                                           "path":  "dynamic.targetParams.999",
+                                                           "oid":  "1.4.4.999",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "dynamic.targetParams.999.gain",
+                                                                                "oid":  "1.4.4.999.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "dynamic.targetParams.999.mode",
+                                                                                "oid":  "1.4.4.999.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "dynamic.targetParams.999.mute",
+                                                                                "oid":  "1.4.4.999.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       }
+                                                   ]
+                                  },
+                                  {
+                                      "number":  5,
+                                      "identifier":  "sourceParams",
+                                      "path":  "dynamic.sourceParams",
+                                      "oid":  "1.4.5",
+                                      "isOnline":  true,
+                                      "access":  "read",
+                                      "children":  [
+                                                       {
+                                                           "number":  0,
+                                                           "identifier":  "0",
+                                                           "path":  "dynamic.sourceParams.0",
+                                                           "oid":  "1.4.5.0",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "dynamic.sourceParams.0.gain",
+                                                                                "oid":  "1.4.5.0.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "dynamic.sourceParams.0.mode",
+                                                                                "oid":  "1.4.5.0.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "dynamic.sourceParams.0.mute",
+                                                                                "oid":  "1.4.5.0.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  50,
+                                                           "identifier":  "50",
+                                                           "path":  "dynamic.sourceParams.50",
+                                                           "oid":  "1.4.5.50",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "dynamic.sourceParams.50.gain",
+                                                                                "oid":  "1.4.5.50.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "dynamic.sourceParams.50.mode",
+                                                                                "oid":  "1.4.5.50.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "dynamic.sourceParams.50.mute",
+                                                                                "oid":  "1.4.5.50.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  137,
+                                                           "identifier":  "137",
+                                                           "path":  "dynamic.sourceParams.137",
+                                                           "oid":  "1.4.5.137",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "dynamic.sourceParams.137.gain",
+                                                                                "oid":  "1.4.5.137.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "dynamic.sourceParams.137.mode",
+                                                                                "oid":  "1.4.5.137.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "dynamic.sourceParams.137.mute",
+                                                                                "oid":  "1.4.5.137.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  200,
+                                                           "identifier":  "200",
+                                                           "path":  "dynamic.sourceParams.200",
+                                                           "oid":  "1.4.5.200",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "dynamic.sourceParams.200.gain",
+                                                                                "oid":  "1.4.5.200.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "dynamic.sourceParams.200.mode",
+                                                                                "oid":  "1.4.5.200.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "dynamic.sourceParams.200.mute",
+                                                                                "oid":  "1.4.5.200.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  350,
+                                                           "identifier":  "350",
+                                                           "path":  "dynamic.sourceParams.350",
+                                                           "oid":  "1.4.5.350",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "dynamic.sourceParams.350.gain",
+                                                                                "oid":  "1.4.5.350.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "dynamic.sourceParams.350.mode",
+                                                                                "oid":  "1.4.5.350.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "dynamic.sourceParams.350.mute",
+                                                                                "oid":  "1.4.5.350.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  401,
+                                                           "identifier":  "401",
+                                                           "path":  "dynamic.sourceParams.401",
+                                                           "oid":  "1.4.5.401",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "dynamic.sourceParams.401.gain",
+                                                                                "oid":  "1.4.5.401.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "dynamic.sourceParams.401.mode",
+                                                                                "oid":  "1.4.5.401.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "dynamic.sourceParams.401.mute",
+                                                                                "oid":  "1.4.5.401.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  500,
+                                                           "identifier":  "500",
+                                                           "path":  "dynamic.sourceParams.500",
+                                                           "oid":  "1.4.5.500",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "dynamic.sourceParams.500.gain",
+                                                                                "oid":  "1.4.5.500.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "dynamic.sourceParams.500.mode",
+                                                                                "oid":  "1.4.5.500.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "dynamic.sourceParams.500.mute",
+                                                                                "oid":  "1.4.5.500.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  750,
+                                                           "identifier":  "750",
+                                                           "path":  "dynamic.sourceParams.750",
+                                                           "oid":  "1.4.5.750",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "dynamic.sourceParams.750.gain",
+                                                                                "oid":  "1.4.5.750.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "dynamic.sourceParams.750.mode",
+                                                                                "oid":  "1.4.5.750.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "dynamic.sourceParams.750.mute",
+                                                                                "oid":  "1.4.5.750.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  888,
+                                                           "identifier":  "888",
+                                                           "path":  "dynamic.sourceParams.888",
+                                                           "oid":  "1.4.5.888",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "dynamic.sourceParams.888.gain",
+                                                                                "oid":  "1.4.5.888.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "dynamic.sourceParams.888.mode",
+                                                                                "oid":  "1.4.5.888.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "dynamic.sourceParams.888.mute",
+                                                                                "oid":  "1.4.5.888.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  999,
+                                                           "identifier":  "999",
+                                                           "path":  "dynamic.sourceParams.999",
+                                                           "oid":  "1.4.5.999",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "dynamic.sourceParams.999.gain",
+                                                                                "oid":  "1.4.5.999.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "dynamic.sourceParams.999.mode",
+                                                                                "oid":  "1.4.5.999.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "dynamic.sourceParams.999.mute",
+                                                                                "oid":  "1.4.5.999.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       }
+                                                   ]
+                                  },
+                                  {
+                                      "number":  3,
+                                      "identifier":  "matrix",
+                                      "path":  "dynamic.matrix",
+                                      "oid":  "1.4.3",
+                                      "isOnline":  true,
+                                      "access":  "readWrite",
+                                      "type":  "nToN",
+                                      "mode":  "nonLinear",
+                                      "targetCount":  1000,
+                                      "sourceCount":  1000,
+                                      "maximumTotalConnects":  50,
+                                      "maximumConnectsPerTarget":  4,
+                                      "parametersLocation":  null,
+                                      "gainParameterNumber":  null,
+                                      "labels":  [
+                                                     {
+                                                         "basePath":  "1.4.1",
+                                                         "description":  "Primary"
+                                                     },
+                                                     {
+                                                         "basePath":  "1.4.2",
+                                                         "description":  "Secondary"
+                                                     }
+                                                 ],
+                                      "targets":  [
+                                                      {
+                                                          "number":  0
+                                                      },
+                                                      {
+                                                          "number":  50
+                                                      },
+                                                      {
+                                                          "number":  137
+                                                      },
+                                                      {
+                                                          "number":  200
+                                                      },
+                                                      {
+                                                          "number":  350
+                                                      },
+                                                      {
+                                                          "number":  401
+                                                      },
+                                                      {
+                                                          "number":  500
+                                                      },
+                                                      {
+                                                          "number":  750
+                                                      },
+                                                      {
+                                                          "number":  888
+                                                      },
+                                                      {
+                                                          "number":  999
+                                                      }
+                                                  ],
+                                      "sources":  [
+                                                      {
+                                                          "number":  0
+                                                      },
+                                                      {
+                                                          "number":  50
+                                                      },
+                                                      {
+                                                          "number":  137
+                                                      },
+                                                      {
+                                                          "number":  200
+                                                      },
+                                                      {
+                                                          "number":  350
+                                                      },
+                                                      {
+                                                          "number":  401
+                                                      },
+                                                      {
+                                                          "number":  500
+                                                      },
+                                                      {
+                                                          "number":  750
+                                                      },
+                                                      {
+                                                          "number":  888
+                                                      },
+                                                      {
+                                                          "number":  999
+                                                      }
+                                                  ],
+                                      "connections":  [
+                                                          {
+                                                              "target":  0,
+                                                              "sources":  [
+                                                                              0
+                                                                          ],
+                                                              "operation":  "absolute",
+                                                              "disposition":  "tally",
+                                                              "locked":  false
+                                                          },
+                                                          {
+                                                              "target":  137,
+                                                              "sources":  [
+                                                                              401,
+                                                                              750
+                                                                          ],
+                                                              "operation":  "absolute",
+                                                              "disposition":  "tally",
+                                                              "locked":  false
+                                                          },
+                                                          {
+                                                              "target":  888,
+                                                              "sources":  [
+                                                                              999
+                                                                          ],
+                                                              "operation":  "absolute",
+                                                              "disposition":  "tally",
+                                                              "locked":  true
+                                                          }
+                                                      ],
+                                      "targetLabels":  null,
+                                      "sourceLabels":  null,
+                                      "targetParams":  null,
+                                      "sourceParams":  null,
+                                      "connectionParams":  null
+                                  }
+                              ]
+             },
+    "templates":  [
+
+                  ]
+}

--- a/internal/emberplus/testdata/integration-test/dm/emberplus/functions-strict@1.0.0.json
+++ b/internal/emberplus/testdata/integration-test/dm/emberplus/functions-strict@1.0.0.json
@@ -1,0 +1,162 @@
+{
+    "model":  "functions-strict",
+    "sw_rev":  "1.0.0",
+    "protocol":  "emberplus",
+    "root":  {
+                 "number":  5,
+                 "identifier":  "functions",
+                 "path":  "functions",
+                 "oid":  "1.5",
+                 "isOnline":  true,
+                 "access":  "read",
+                 "children":  [
+                                  {
+                                      "number":  1,
+                                      "identifier":  "setLock",
+                                      "path":  "functions.setLock",
+                                      "oid":  "1.5.1",
+                                      "isOnline":  true,
+                                      "access":  "read",
+                                      "arguments":  [
+                                                        {
+                                                            "name":  "matrixPath",
+                                                            "type":  "string"
+                                                        },
+                                                        {
+                                                            "name":  "target",
+                                                            "type":  "integer"
+                                                        },
+                                                        {
+                                                            "name":  "locked",
+                                                            "type":  "boolean"
+                                                        }
+                                                    ],
+                                      "result":  [
+                                                     {
+                                                         "name":  "previous",
+                                                         "type":  "boolean"
+                                                     }
+                                                 ]
+                                  },
+                                  {
+                                      "number":  2,
+                                      "identifier":  "listLocks",
+                                      "path":  "functions.listLocks",
+                                      "oid":  "1.5.2",
+                                      "isOnline":  true,
+                                      "access":  "read",
+                                      "arguments":  [
+                                                        {
+                                                            "name":  "matrixPath",
+                                                            "type":  "string"
+                                                        }
+                                                    ],
+                                      "result":  [
+                                                     {
+                                                         "name":  "locked",
+                                                         "type":  "string"
+                                                     }
+                                                 ]
+                                  },
+                                  {
+                                      "number":  3,
+                                      "identifier":  "storeSalvo",
+                                      "path":  "functions.storeSalvo",
+                                      "oid":  "1.5.3",
+                                      "isOnline":  true,
+                                      "access":  "read",
+                                      "arguments":  [
+                                                        {
+                                                            "name":  "matrixPath",
+                                                            "type":  "string"
+                                                        },
+                                                        {
+                                                            "name":  "salvoID",
+                                                            "type":  "integer"
+                                                        },
+                                                        {
+                                                            "name":  "targets",
+                                                            "type":  "string"
+                                                        }
+                                                    ],
+                                      "result":  [
+                                                     {
+                                                         "name":  "stored",
+                                                         "type":  "boolean"
+                                                     }
+                                                 ]
+                                  },
+                                  {
+                                      "number":  4,
+                                      "identifier":  "recallSalvo",
+                                      "path":  "functions.recallSalvo",
+                                      "oid":  "1.5.4",
+                                      "isOnline":  true,
+                                      "access":  "read",
+                                      "arguments":  [
+                                                        {
+                                                            "name":  "matrixPath",
+                                                            "type":  "string"
+                                                        },
+                                                        {
+                                                            "name":  "salvoID",
+                                                            "type":  "integer"
+                                                        }
+                                                    ],
+                                      "result":  [
+                                                     {
+                                                         "name":  "applied",
+                                                         "type":  "integer"
+                                                     }
+                                                 ]
+                                  },
+                                  {
+                                      "number":  5,
+                                      "identifier":  "listSalvos",
+                                      "path":  "functions.listSalvos",
+                                      "oid":  "1.5.5",
+                                      "isOnline":  true,
+                                      "access":  "read",
+                                      "arguments":  [
+                                                        {
+                                                            "name":  "matrixPath",
+                                                            "type":  "string"
+                                                        }
+                                                    ],
+                                      "result":  [
+                                                     {
+                                                         "name":  "salvos",
+                                                         "type":  "string"
+                                                     }
+                                                 ]
+                                  },
+                                  {
+                                      "number":  6,
+                                      "identifier":  "getSalvo",
+                                      "path":  "functions.getSalvo",
+                                      "oid":  "1.5.6",
+                                      "isOnline":  true,
+                                      "access":  "read",
+                                      "arguments":  [
+                                                        {
+                                                            "name":  "matrixPath",
+                                                            "type":  "string"
+                                                        },
+                                                        {
+                                                            "name":  "salvoID",
+                                                            "type":  "integer"
+                                                        }
+                                                    ],
+                                      "result":  [
+                                                     {
+                                                         "name":  "dump",
+                                                         "type":  "string"
+                                                     }
+                                                 ]
+                                  }
+                              ]
+             },
+    "templates":  [
+
+                  ]
+}

--- a/internal/emberplus/testdata/integration-test/dm/emberplus/glow-types-strict@1.0.0.json
+++ b/internal/emberplus/testdata/integration-test/dm/emberplus/glow-types-strict@1.0.0.json
@@ -1,0 +1,139 @@
+{
+    "model":  "glow-types-strict",
+    "sw_rev":  "1.0.0",
+    "protocol":  "emberplus",
+    "root":  {
+                 "number":  6,
+                 "identifier":  "types",
+                 "path":  "types",
+                 "oid":  "1.6",
+                 "isOnline":  true,
+                 "access":  "read",
+                 "children":  [
+                                  {
+                                      "number":  1,
+                                      "identifier":  "vInteger",
+                                      "path":  "types.vInteger",
+                                      "oid":  "1.6.1",
+                                      "isOnline":  true,
+                                      "access":  "readWrite",
+                                      "type":  "integer",
+                                      "value":  42,
+                                      "minimum":  -100,
+                                      "maximum":  100,
+                                      "step":  1
+                                  },
+                                  {
+                                      "number":  2,
+                                      "identifier":  "vReal",
+                                      "path":  "types.vReal",
+                                      "oid":  "1.6.2",
+                                      "isOnline":  true,
+                                      "access":  "readWrite",
+                                      "type":  "real",
+                                      "value":  3.14,
+                                      "minimum":  -1000,
+                                      "maximum":  1000
+                                  },
+                                  {
+                                      "number":  3,
+                                      "identifier":  "vString",
+                                      "path":  "types.vString",
+                                      "oid":  "1.6.3",
+                                      "isOnline":  true,
+                                      "access":  "readWrite",
+                                      "type":  "string",
+                                      "value":  "hello"
+                                  },
+                                  {
+                                      "number":  4,
+                                      "identifier":  "vBoolean",
+                                      "path":  "types.vBoolean",
+                                      "oid":  "1.6.4",
+                                      "isOnline":  true,
+                                      "access":  "readWrite",
+                                      "type":  "boolean",
+                                      "value":  true
+                                  },
+                                  {
+                                      "number":  5,
+                                      "identifier":  "vTrigger",
+                                      "path":  "types.vTrigger",
+                                      "oid":  "1.6.5",
+                                      "isOnline":  true,
+                                      "access":  "write",
+                                      "type":  "trigger",
+                                      "value":  null
+                                  },
+                                  {
+                                      "number":  6,
+                                      "identifier":  "vEnum",
+                                      "path":  "types.vEnum",
+                                      "oid":  "1.6.6",
+                                      "isOnline":  true,
+                                      "access":  "readWrite",
+                                      "type":  "enum",
+                                      "value":  1,
+                                      "enumMap":  [
+                                                      {
+                                                          "key":  "Off",
+                                                          "value":  0
+                                                      },
+                                                      {
+                                                          "key":  "Low",
+                                                          "value":  1
+                                                      },
+                                                      {
+                                                          "key":  "Medium",
+                                                          "value":  2
+                                                      },
+                                                      {
+                                                          "key":  "High",
+                                                          "value":  3
+                                                      }
+                                                  ]
+                                  },
+                                  {
+                                      "number":  7,
+                                      "identifier":  "vOctets",
+                                      "path":  "types.vOctets",
+                                      "oid":  "1.6.7",
+                                      "isOnline":  true,
+                                      "access":  "readWrite",
+                                      "type":  "octets",
+                                      "value":  "aGVsbG8="
+                                  },
+                                  {
+                                      "number":  10,
+                                      "identifier":  "vu_left",
+                                      "path":  "types.vu_left",
+                                      "oid":  "1.6.10",
+                                      "isOnline":  true,
+                                      "access":  "read",
+                                      "type":  "real",
+                                      "value":  -60,
+                                      "minimum":  -128,
+                                      "maximum":  15,
+                                      "format":  "%.2f dB",
+                                      "streamIdentifier":  1001
+                                  },
+                                  {
+                                      "number":  11,
+                                      "identifier":  "vu_right",
+                                      "path":  "types.vu_right",
+                                      "oid":  "1.6.11",
+                                      "isOnline":  true,
+                                      "access":  "read",
+                                      "type":  "real",
+                                      "value":  -60,
+                                      "minimum":  -128,
+                                      "maximum":  15,
+                                      "format":  "%.2f dB",
+                                      "streamIdentifier":  1002
+                                  }
+                              ]
+             },
+    "templates":  [
+
+                  ]
+}

--- a/internal/emberplus/testdata/integration-test/dm/emberplus/identity-strict@1.0.0.json
+++ b/internal/emberplus/testdata/integration-test/dm/emberplus/identity-strict@1.0.0.json
@@ -1,0 +1,48 @@
+{
+    "model":  "identity-strict",
+    "sw_rev":  "1.0.0",
+    "protocol":  "emberplus",
+    "root":  {
+                 "number":  0,
+                 "identifier":  "identity",
+                 "path":  "identity",
+                 "oid":  "1.0",
+                 "isOnline":  true,
+                 "access":  "read",
+                 "children":  [
+                                  {
+                                      "number":  1,
+                                      "identifier":  "product",
+                                      "path":  "identity.product",
+                                      "oid":  "1.0.1",
+                                      "isOnline":  true,
+                                      "access":  "read",
+                                      "type":  "string",
+                                      "value":  "dhs-emberplus-integration"
+                                  },
+                                  {
+                                      "number":  2,
+                                      "identifier":  "company",
+                                      "path":  "identity.company",
+                                      "oid":  "1.0.2",
+                                      "isOnline":  true,
+                                      "access":  "read",
+                                      "type":  "string",
+                                      "value":  "BY-Systems"
+                                  },
+                                  {
+                                      "number":  3,
+                                      "identifier":  "version",
+                                      "path":  "identity.version",
+                                      "oid":  "1.0.3",
+                                      "isOnline":  true,
+                                      "access":  "read",
+                                      "type":  "string",
+                                      "value":  "1.0.0"
+                                  }
+                              ]
+             },
+    "templates":  [
+
+                  ]
+}

--- a/internal/emberplus/testdata/integration-test/dm/emberplus/nToN-strict@1.0.0.json
+++ b/internal/emberplus/testdata/integration-test/dm/emberplus/nToN-strict@1.0.0.json
@@ -1,0 +1,1231 @@
+{
+    "model":  "nToN-strict",
+    "sw_rev":  "1.0.0",
+    "protocol":  "emberplus",
+    "root":  {
+                 "number":  3,
+                 "identifier":  "nToN",
+                 "path":  "nToN",
+                 "oid":  "1.3",
+                 "isOnline":  true,
+                 "access":  "read",
+                 "children":  [
+                                  {
+                                      "number":  1,
+                                      "identifier":  "labelsPrimary",
+                                      "path":  "nToN.labelsPrimary",
+                                      "oid":  "1.3.1",
+                                      "isOnline":  true,
+                                      "access":  "read",
+                                      "children":  [
+                                                       {
+                                                           "number":  1,
+                                                           "identifier":  "targets",
+                                                           "path":  "nToN.labelsPrimary.targets",
+                                                           "oid":  "1.3.1.1",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  0,
+                                                                                "identifier":  "t-0",
+                                                                                "path":  "nToN.labelsPrimary.targets.t-0",
+                                                                                "oid":  "1.3.1.1.0",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-T0"
+                                                                            },
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "t-1",
+                                                                                "path":  "nToN.labelsPrimary.targets.t-1",
+                                                                                "oid":  "1.3.1.1.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-T1"
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "t-2",
+                                                                                "path":  "nToN.labelsPrimary.targets.t-2",
+                                                                                "oid":  "1.3.1.1.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-T2"
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "t-3",
+                                                                                "path":  "nToN.labelsPrimary.targets.t-3",
+                                                                                "oid":  "1.3.1.1.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-T3"
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  2,
+                                                           "identifier":  "sources",
+                                                           "path":  "nToN.labelsPrimary.sources",
+                                                           "oid":  "1.3.1.2",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  0,
+                                                                                "identifier":  "s-0",
+                                                                                "path":  "nToN.labelsPrimary.sources.s-0",
+                                                                                "oid":  "1.3.1.2.0",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-S0"
+                                                                            },
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "s-1",
+                                                                                "path":  "nToN.labelsPrimary.sources.s-1",
+                                                                                "oid":  "1.3.1.2.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-S1"
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "s-2",
+                                                                                "path":  "nToN.labelsPrimary.sources.s-2",
+                                                                                "oid":  "1.3.1.2.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-S2"
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "s-3",
+                                                                                "path":  "nToN.labelsPrimary.sources.s-3",
+                                                                                "oid":  "1.3.1.2.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-S3"
+                                                                            }
+                                                                        ]
+                                                       }
+                                                   ]
+                                  },
+                                  {
+                                      "number":  2,
+                                      "identifier":  "labelsSecondary",
+                                      "path":  "nToN.labelsSecondary",
+                                      "oid":  "1.3.2",
+                                      "isOnline":  true,
+                                      "access":  "read",
+                                      "children":  [
+                                                       {
+                                                           "number":  1,
+                                                           "identifier":  "targets",
+                                                           "path":  "nToN.labelsSecondary.targets",
+                                                           "oid":  "1.3.2.1",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  0,
+                                                                                "identifier":  "t-0",
+                                                                                "path":  "nToN.labelsSecondary.targets.t-0",
+                                                                                "oid":  "1.3.2.1.0",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-T0"
+                                                                            },
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "t-1",
+                                                                                "path":  "nToN.labelsSecondary.targets.t-1",
+                                                                                "oid":  "1.3.2.1.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-T1"
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "t-2",
+                                                                                "path":  "nToN.labelsSecondary.targets.t-2",
+                                                                                "oid":  "1.3.2.1.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-T2"
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "t-3",
+                                                                                "path":  "nToN.labelsSecondary.targets.t-3",
+                                                                                "oid":  "1.3.2.1.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-T3"
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  2,
+                                                           "identifier":  "sources",
+                                                           "path":  "nToN.labelsSecondary.sources",
+                                                           "oid":  "1.3.2.2",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  0,
+                                                                                "identifier":  "s-0",
+                                                                                "path":  "nToN.labelsSecondary.sources.s-0",
+                                                                                "oid":  "1.3.2.2.0",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-S0"
+                                                                            },
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "s-1",
+                                                                                "path":  "nToN.labelsSecondary.sources.s-1",
+                                                                                "oid":  "1.3.2.2.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-S1"
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "s-2",
+                                                                                "path":  "nToN.labelsSecondary.sources.s-2",
+                                                                                "oid":  "1.3.2.2.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-S2"
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "s-3",
+                                                                                "path":  "nToN.labelsSecondary.sources.s-3",
+                                                                                "oid":  "1.3.2.2.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-S3"
+                                                                            }
+                                                                        ]
+                                                       }
+                                                   ]
+                                  },
+                                  {
+                                      "number":  3,
+                                      "identifier":  "params",
+                                      "path":  "nToN.params",
+                                      "oid":  "1.3.3",
+                                      "isOnline":  true,
+                                      "access":  "read",
+                                      "children":  [
+                                                       {
+                                                           "number":  0,
+                                                           "identifier":  "0",
+                                                           "path":  "nToN.params.0",
+                                                           "oid":  "1.3.3.0",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  0,
+                                                                                "identifier":  "0",
+                                                                                "path":  "nToN.params.0.0",
+                                                                                "oid":  "1.3.3.0.0",
+                                                                                "isOnline":  true,
+                                                                                "access":  "read",
+                                                                                "children":  [
+                                                                                                 {
+                                                                                                     "number":  1,
+                                                                                                     "identifier":  "gain",
+                                                                                                     "path":  "nToN.params.0.0.gain",
+                                                                                                     "oid":  "1.3.3.0.0.1",
+                                                                                                     "isOnline":  true,
+                                                                                                     "access":  "readWrite",
+                                                                                                     "type":  "integer",
+                                                                                                     "value":  0,
+                                                                                                     "minimum":  -1000,
+                                                                                                     "maximum":  100,
+                                                                                                     "step":  1
+                                                                                                 }
+                                                                                             ]
+                                                                            },
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "1",
+                                                                                "path":  "nToN.params.0.1",
+                                                                                "oid":  "1.3.3.0.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "read",
+                                                                                "children":  [
+                                                                                                 {
+                                                                                                     "number":  1,
+                                                                                                     "identifier":  "gain",
+                                                                                                     "path":  "nToN.params.0.1.gain",
+                                                                                                     "oid":  "1.3.3.0.1.1",
+                                                                                                     "isOnline":  true,
+                                                                                                     "access":  "readWrite",
+                                                                                                     "type":  "integer",
+                                                                                                     "value":  0,
+                                                                                                     "minimum":  -1000,
+                                                                                                     "maximum":  100,
+                                                                                                     "step":  1
+                                                                                                 }
+                                                                                             ]
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "2",
+                                                                                "path":  "nToN.params.0.2",
+                                                                                "oid":  "1.3.3.0.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "read",
+                                                                                "children":  [
+                                                                                                 {
+                                                                                                     "number":  1,
+                                                                                                     "identifier":  "gain",
+                                                                                                     "path":  "nToN.params.0.2.gain",
+                                                                                                     "oid":  "1.3.3.0.2.1",
+                                                                                                     "isOnline":  true,
+                                                                                                     "access":  "readWrite",
+                                                                                                     "type":  "integer",
+                                                                                                     "value":  0,
+                                                                                                     "minimum":  -1000,
+                                                                                                     "maximum":  100,
+                                                                                                     "step":  1
+                                                                                                 }
+                                                                                             ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "3",
+                                                                                "path":  "nToN.params.0.3",
+                                                                                "oid":  "1.3.3.0.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "read",
+                                                                                "children":  [
+                                                                                                 {
+                                                                                                     "number":  1,
+                                                                                                     "identifier":  "gain",
+                                                                                                     "path":  "nToN.params.0.3.gain",
+                                                                                                     "oid":  "1.3.3.0.3.1",
+                                                                                                     "isOnline":  true,
+                                                                                                     "access":  "readWrite",
+                                                                                                     "type":  "integer",
+                                                                                                     "value":  0,
+                                                                                                     "minimum":  -1000,
+                                                                                                     "maximum":  100,
+                                                                                                     "step":  1
+                                                                                                 }
+                                                                                             ]
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  1,
+                                                           "identifier":  "1",
+                                                           "path":  "nToN.params.1",
+                                                           "oid":  "1.3.3.1",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  0,
+                                                                                "identifier":  "0",
+                                                                                "path":  "nToN.params.1.0",
+                                                                                "oid":  "1.3.3.1.0",
+                                                                                "isOnline":  true,
+                                                                                "access":  "read",
+                                                                                "children":  [
+                                                                                                 {
+                                                                                                     "number":  1,
+                                                                                                     "identifier":  "gain",
+                                                                                                     "path":  "nToN.params.1.0.gain",
+                                                                                                     "oid":  "1.3.3.1.0.1",
+                                                                                                     "isOnline":  true,
+                                                                                                     "access":  "readWrite",
+                                                                                                     "type":  "integer",
+                                                                                                     "value":  0,
+                                                                                                     "minimum":  -1000,
+                                                                                                     "maximum":  100,
+                                                                                                     "step":  1
+                                                                                                 }
+                                                                                             ]
+                                                                            },
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "1",
+                                                                                "path":  "nToN.params.1.1",
+                                                                                "oid":  "1.3.3.1.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "read",
+                                                                                "children":  [
+                                                                                                 {
+                                                                                                     "number":  1,
+                                                                                                     "identifier":  "gain",
+                                                                                                     "path":  "nToN.params.1.1.gain",
+                                                                                                     "oid":  "1.3.3.1.1.1",
+                                                                                                     "isOnline":  true,
+                                                                                                     "access":  "readWrite",
+                                                                                                     "type":  "integer",
+                                                                                                     "value":  0,
+                                                                                                     "minimum":  -1000,
+                                                                                                     "maximum":  100,
+                                                                                                     "step":  1
+                                                                                                 }
+                                                                                             ]
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "2",
+                                                                                "path":  "nToN.params.1.2",
+                                                                                "oid":  "1.3.3.1.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "read",
+                                                                                "children":  [
+                                                                                                 {
+                                                                                                     "number":  1,
+                                                                                                     "identifier":  "gain",
+                                                                                                     "path":  "nToN.params.1.2.gain",
+                                                                                                     "oid":  "1.3.3.1.2.1",
+                                                                                                     "isOnline":  true,
+                                                                                                     "access":  "readWrite",
+                                                                                                     "type":  "integer",
+                                                                                                     "value":  0,
+                                                                                                     "minimum":  -1000,
+                                                                                                     "maximum":  100,
+                                                                                                     "step":  1
+                                                                                                 }
+                                                                                             ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "3",
+                                                                                "path":  "nToN.params.1.3",
+                                                                                "oid":  "1.3.3.1.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "read",
+                                                                                "children":  [
+                                                                                                 {
+                                                                                                     "number":  1,
+                                                                                                     "identifier":  "gain",
+                                                                                                     "path":  "nToN.params.1.3.gain",
+                                                                                                     "oid":  "1.3.3.1.3.1",
+                                                                                                     "isOnline":  true,
+                                                                                                     "access":  "readWrite",
+                                                                                                     "type":  "integer",
+                                                                                                     "value":  0,
+                                                                                                     "minimum":  -1000,
+                                                                                                     "maximum":  100,
+                                                                                                     "step":  1
+                                                                                                 }
+                                                                                             ]
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  2,
+                                                           "identifier":  "2",
+                                                           "path":  "nToN.params.2",
+                                                           "oid":  "1.3.3.2",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  0,
+                                                                                "identifier":  "0",
+                                                                                "path":  "nToN.params.2.0",
+                                                                                "oid":  "1.3.3.2.0",
+                                                                                "isOnline":  true,
+                                                                                "access":  "read",
+                                                                                "children":  [
+                                                                                                 {
+                                                                                                     "number":  1,
+                                                                                                     "identifier":  "gain",
+                                                                                                     "path":  "nToN.params.2.0.gain",
+                                                                                                     "oid":  "1.3.3.2.0.1",
+                                                                                                     "isOnline":  true,
+                                                                                                     "access":  "readWrite",
+                                                                                                     "type":  "integer",
+                                                                                                     "value":  0,
+                                                                                                     "minimum":  -1000,
+                                                                                                     "maximum":  100,
+                                                                                                     "step":  1
+                                                                                                 }
+                                                                                             ]
+                                                                            },
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "1",
+                                                                                "path":  "nToN.params.2.1",
+                                                                                "oid":  "1.3.3.2.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "read",
+                                                                                "children":  [
+                                                                                                 {
+                                                                                                     "number":  1,
+                                                                                                     "identifier":  "gain",
+                                                                                                     "path":  "nToN.params.2.1.gain",
+                                                                                                     "oid":  "1.3.3.2.1.1",
+                                                                                                     "isOnline":  true,
+                                                                                                     "access":  "readWrite",
+                                                                                                     "type":  "integer",
+                                                                                                     "value":  0,
+                                                                                                     "minimum":  -1000,
+                                                                                                     "maximum":  100,
+                                                                                                     "step":  1
+                                                                                                 }
+                                                                                             ]
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "2",
+                                                                                "path":  "nToN.params.2.2",
+                                                                                "oid":  "1.3.3.2.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "read",
+                                                                                "children":  [
+                                                                                                 {
+                                                                                                     "number":  1,
+                                                                                                     "identifier":  "gain",
+                                                                                                     "path":  "nToN.params.2.2.gain",
+                                                                                                     "oid":  "1.3.3.2.2.1",
+                                                                                                     "isOnline":  true,
+                                                                                                     "access":  "readWrite",
+                                                                                                     "type":  "integer",
+                                                                                                     "value":  0,
+                                                                                                     "minimum":  -1000,
+                                                                                                     "maximum":  100,
+                                                                                                     "step":  1
+                                                                                                 }
+                                                                                             ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "3",
+                                                                                "path":  "nToN.params.2.3",
+                                                                                "oid":  "1.3.3.2.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "read",
+                                                                                "children":  [
+                                                                                                 {
+                                                                                                     "number":  1,
+                                                                                                     "identifier":  "gain",
+                                                                                                     "path":  "nToN.params.2.3.gain",
+                                                                                                     "oid":  "1.3.3.2.3.1",
+                                                                                                     "isOnline":  true,
+                                                                                                     "access":  "readWrite",
+                                                                                                     "type":  "integer",
+                                                                                                     "value":  0,
+                                                                                                     "minimum":  -1000,
+                                                                                                     "maximum":  100,
+                                                                                                     "step":  1
+                                                                                                 }
+                                                                                             ]
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  3,
+                                                           "identifier":  "3",
+                                                           "path":  "nToN.params.3",
+                                                           "oid":  "1.3.3.3",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  0,
+                                                                                "identifier":  "0",
+                                                                                "path":  "nToN.params.3.0",
+                                                                                "oid":  "1.3.3.3.0",
+                                                                                "isOnline":  true,
+                                                                                "access":  "read",
+                                                                                "children":  [
+                                                                                                 {
+                                                                                                     "number":  1,
+                                                                                                     "identifier":  "gain",
+                                                                                                     "path":  "nToN.params.3.0.gain",
+                                                                                                     "oid":  "1.3.3.3.0.1",
+                                                                                                     "isOnline":  true,
+                                                                                                     "access":  "readWrite",
+                                                                                                     "type":  "integer",
+                                                                                                     "value":  0,
+                                                                                                     "minimum":  -1000,
+                                                                                                     "maximum":  100,
+                                                                                                     "step":  1
+                                                                                                 }
+                                                                                             ]
+                                                                            },
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "1",
+                                                                                "path":  "nToN.params.3.1",
+                                                                                "oid":  "1.3.3.3.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "read",
+                                                                                "children":  [
+                                                                                                 {
+                                                                                                     "number":  1,
+                                                                                                     "identifier":  "gain",
+                                                                                                     "path":  "nToN.params.3.1.gain",
+                                                                                                     "oid":  "1.3.3.3.1.1",
+                                                                                                     "isOnline":  true,
+                                                                                                     "access":  "readWrite",
+                                                                                                     "type":  "integer",
+                                                                                                     "value":  0,
+                                                                                                     "minimum":  -1000,
+                                                                                                     "maximum":  100,
+                                                                                                     "step":  1
+                                                                                                 }
+                                                                                             ]
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "2",
+                                                                                "path":  "nToN.params.3.2",
+                                                                                "oid":  "1.3.3.3.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "read",
+                                                                                "children":  [
+                                                                                                 {
+                                                                                                     "number":  1,
+                                                                                                     "identifier":  "gain",
+                                                                                                     "path":  "nToN.params.3.2.gain",
+                                                                                                     "oid":  "1.3.3.3.2.1",
+                                                                                                     "isOnline":  true,
+                                                                                                     "access":  "readWrite",
+                                                                                                     "type":  "integer",
+                                                                                                     "value":  0,
+                                                                                                     "minimum":  -1000,
+                                                                                                     "maximum":  100,
+                                                                                                     "step":  1
+                                                                                                 }
+                                                                                             ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "3",
+                                                                                "path":  "nToN.params.3.3",
+                                                                                "oid":  "1.3.3.3.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "read",
+                                                                                "children":  [
+                                                                                                 {
+                                                                                                     "number":  1,
+                                                                                                     "identifier":  "gain",
+                                                                                                     "path":  "nToN.params.3.3.gain",
+                                                                                                     "oid":  "1.3.3.3.3.1",
+                                                                                                     "isOnline":  true,
+                                                                                                     "access":  "readWrite",
+                                                                                                     "type":  "integer",
+                                                                                                     "value":  0,
+                                                                                                     "minimum":  -1000,
+                                                                                                     "maximum":  100,
+                                                                                                     "step":  1
+                                                                                                 }
+                                                                                             ]
+                                                                            }
+                                                                        ]
+                                                       }
+                                                   ]
+                                  },
+                                  {
+                                      "number":  5,
+                                      "identifier":  "targetParams",
+                                      "path":  "nToN.targetParams",
+                                      "oid":  "1.3.5",
+                                      "isOnline":  true,
+                                      "access":  "read",
+                                      "children":  [
+                                                       {
+                                                           "number":  0,
+                                                           "identifier":  "0",
+                                                           "path":  "nToN.targetParams.0",
+                                                           "oid":  "1.3.5.0",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "nToN.targetParams.0.gain",
+                                                                                "oid":  "1.3.5.0.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "nToN.targetParams.0.mode",
+                                                                                "oid":  "1.3.5.0.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "nToN.targetParams.0.mute",
+                                                                                "oid":  "1.3.5.0.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  1,
+                                                           "identifier":  "1",
+                                                           "path":  "nToN.targetParams.1",
+                                                           "oid":  "1.3.5.1",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "nToN.targetParams.1.gain",
+                                                                                "oid":  "1.3.5.1.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "nToN.targetParams.1.mode",
+                                                                                "oid":  "1.3.5.1.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "nToN.targetParams.1.mute",
+                                                                                "oid":  "1.3.5.1.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  2,
+                                                           "identifier":  "2",
+                                                           "path":  "nToN.targetParams.2",
+                                                           "oid":  "1.3.5.2",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "nToN.targetParams.2.gain",
+                                                                                "oid":  "1.3.5.2.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "nToN.targetParams.2.mode",
+                                                                                "oid":  "1.3.5.2.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "nToN.targetParams.2.mute",
+                                                                                "oid":  "1.3.5.2.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  3,
+                                                           "identifier":  "3",
+                                                           "path":  "nToN.targetParams.3",
+                                                           "oid":  "1.3.5.3",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "nToN.targetParams.3.gain",
+                                                                                "oid":  "1.3.5.3.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "nToN.targetParams.3.mode",
+                                                                                "oid":  "1.3.5.3.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "nToN.targetParams.3.mute",
+                                                                                "oid":  "1.3.5.3.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       }
+                                                   ]
+                                  },
+                                  {
+                                      "number":  6,
+                                      "identifier":  "sourceParams",
+                                      "path":  "nToN.sourceParams",
+                                      "oid":  "1.3.6",
+                                      "isOnline":  true,
+                                      "access":  "read",
+                                      "children":  [
+                                                       {
+                                                           "number":  0,
+                                                           "identifier":  "0",
+                                                           "path":  "nToN.sourceParams.0",
+                                                           "oid":  "1.3.6.0",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "nToN.sourceParams.0.gain",
+                                                                                "oid":  "1.3.6.0.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "nToN.sourceParams.0.mode",
+                                                                                "oid":  "1.3.6.0.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "nToN.sourceParams.0.mute",
+                                                                                "oid":  "1.3.6.0.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  1,
+                                                           "identifier":  "1",
+                                                           "path":  "nToN.sourceParams.1",
+                                                           "oid":  "1.3.6.1",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "nToN.sourceParams.1.gain",
+                                                                                "oid":  "1.3.6.1.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "nToN.sourceParams.1.mode",
+                                                                                "oid":  "1.3.6.1.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "nToN.sourceParams.1.mute",
+                                                                                "oid":  "1.3.6.1.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  2,
+                                                           "identifier":  "2",
+                                                           "path":  "nToN.sourceParams.2",
+                                                           "oid":  "1.3.6.2",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "nToN.sourceParams.2.gain",
+                                                                                "oid":  "1.3.6.2.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "nToN.sourceParams.2.mode",
+                                                                                "oid":  "1.3.6.2.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "nToN.sourceParams.2.mute",
+                                                                                "oid":  "1.3.6.2.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  3,
+                                                           "identifier":  "3",
+                                                           "path":  "nToN.sourceParams.3",
+                                                           "oid":  "1.3.6.3",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "nToN.sourceParams.3.gain",
+                                                                                "oid":  "1.3.6.3.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "nToN.sourceParams.3.mode",
+                                                                                "oid":  "1.3.6.3.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "nToN.sourceParams.3.mute",
+                                                                                "oid":  "1.3.6.3.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       }
+                                                   ]
+                                  },
+                                  {
+                                      "number":  4,
+                                      "identifier":  "matrix",
+                                      "path":  "nToN.matrix",
+                                      "oid":  "1.3.4",
+                                      "isOnline":  true,
+                                      "access":  "readWrite",
+                                      "type":  "nToN",
+                                      "mode":  "linear",
+                                      "targetCount":  4,
+                                      "sourceCount":  4,
+                                      "maximumTotalConnects":  16,
+                                      "maximumConnectsPerTarget":  2,
+                                      "parametersLocation":  "1.3.3",
+                                      "gainParameterNumber":  1,
+                                      "labels":  [
+                                                     {
+                                                         "basePath":  "1.3.1",
+                                                         "description":  "Primary"
+                                                     },
+                                                     {
+                                                         "basePath":  "1.3.2",
+                                                         "description":  "Secondary"
+                                                     }
+                                                 ],
+                                      "targets":  [
+                                                      {
+                                                          "number":  0
+                                                      },
+                                                      {
+                                                          "number":  1
+                                                      },
+                                                      {
+                                                          "number":  2
+                                                      },
+                                                      {
+                                                          "number":  3
+                                                      }
+                                                  ],
+                                      "sources":  [
+                                                      {
+                                                          "number":  0
+                                                      },
+                                                      {
+                                                          "number":  1
+                                                      },
+                                                      {
+                                                          "number":  2
+                                                      },
+                                                      {
+                                                          "number":  3
+                                                      }
+                                                  ],
+                                      "connections":  [
+                                                          {
+                                                              "target":  0,
+                                                              "sources":  [
+                                                                              0,
+                                                                              1
+                                                                          ],
+                                                              "operation":  "absolute",
+                                                              "disposition":  "tally",
+                                                              "locked":  false
+                                                          },
+                                                          {
+                                                              "target":  1,
+                                                              "sources":  [
+                                                                              1,
+                                                                              2
+                                                                          ],
+                                                              "operation":  "absolute",
+                                                              "disposition":  "tally",
+                                                              "locked":  false
+                                                          },
+                                                          {
+                                                              "target":  2,
+                                                              "sources":  [
+                                                                              2
+                                                                          ],
+                                                              "operation":  "absolute",
+                                                              "disposition":  "tally",
+                                                              "locked":  false
+                                                          },
+                                                          {
+                                                              "target":  3,
+                                                              "sources":  [
+
+                                                                          ],
+                                                              "operation":  "absolute",
+                                                              "disposition":  "tally",
+                                                              "locked":  false
+                                                          }
+                                                      ],
+                                      "targetLabels":  null,
+                                      "sourceLabels":  null,
+                                      "targetParams":  null,
+                                      "sourceParams":  null,
+                                      "connectionParams":  null
+                                  }
+                              ]
+             },
+    "templates":  [
+
+                  ]
+}

--- a/internal/emberplus/testdata/integration-test/dm/emberplus/oneToN-strict@1.0.0.json
+++ b/internal/emberplus/testdata/integration-test/dm/emberplus/oneToN-strict@1.0.0.json
@@ -1,0 +1,811 @@
+{
+    "model":  "oneToN-strict",
+    "sw_rev":  "1.0.0",
+    "protocol":  "emberplus",
+    "root":  {
+                 "number":  1,
+                 "identifier":  "oneToN",
+                 "path":  "oneToN",
+                 "oid":  "1.1",
+                 "isOnline":  true,
+                 "access":  "read",
+                 "children":  [
+                                  {
+                                      "number":  1,
+                                      "identifier":  "labelsPrimary",
+                                      "path":  "oneToN.labelsPrimary",
+                                      "oid":  "1.1.1",
+                                      "isOnline":  true,
+                                      "access":  "read",
+                                      "children":  [
+                                                       {
+                                                           "number":  1,
+                                                           "identifier":  "targets",
+                                                           "path":  "oneToN.labelsPrimary.targets",
+                                                           "oid":  "1.1.1.1",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  0,
+                                                                                "identifier":  "t-0",
+                                                                                "path":  "oneToN.labelsPrimary.targets.t-0",
+                                                                                "oid":  "1.1.1.1.0",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-T0"
+                                                                            },
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "t-1",
+                                                                                "path":  "oneToN.labelsPrimary.targets.t-1",
+                                                                                "oid":  "1.1.1.1.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-T1"
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "t-2",
+                                                                                "path":  "oneToN.labelsPrimary.targets.t-2",
+                                                                                "oid":  "1.1.1.1.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-T2"
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "t-3",
+                                                                                "path":  "oneToN.labelsPrimary.targets.t-3",
+                                                                                "oid":  "1.1.1.1.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-T3"
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  2,
+                                                           "identifier":  "sources",
+                                                           "path":  "oneToN.labelsPrimary.sources",
+                                                           "oid":  "1.1.1.2",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  0,
+                                                                                "identifier":  "s-0",
+                                                                                "path":  "oneToN.labelsPrimary.sources.s-0",
+                                                                                "oid":  "1.1.1.2.0",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-S0"
+                                                                            },
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "s-1",
+                                                                                "path":  "oneToN.labelsPrimary.sources.s-1",
+                                                                                "oid":  "1.1.1.2.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-S1"
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "s-2",
+                                                                                "path":  "oneToN.labelsPrimary.sources.s-2",
+                                                                                "oid":  "1.1.1.2.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-S2"
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "s-3",
+                                                                                "path":  "oneToN.labelsPrimary.sources.s-3",
+                                                                                "oid":  "1.1.1.2.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-S3"
+                                                                            }
+                                                                        ]
+                                                       }
+                                                   ]
+                                  },
+                                  {
+                                      "number":  2,
+                                      "identifier":  "labelsSecondary",
+                                      "path":  "oneToN.labelsSecondary",
+                                      "oid":  "1.1.2",
+                                      "isOnline":  true,
+                                      "access":  "read",
+                                      "children":  [
+                                                       {
+                                                           "number":  1,
+                                                           "identifier":  "targets",
+                                                           "path":  "oneToN.labelsSecondary.targets",
+                                                           "oid":  "1.1.2.1",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  0,
+                                                                                "identifier":  "t-0",
+                                                                                "path":  "oneToN.labelsSecondary.targets.t-0",
+                                                                                "oid":  "1.1.2.1.0",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-T0"
+                                                                            },
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "t-1",
+                                                                                "path":  "oneToN.labelsSecondary.targets.t-1",
+                                                                                "oid":  "1.1.2.1.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-T1"
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "t-2",
+                                                                                "path":  "oneToN.labelsSecondary.targets.t-2",
+                                                                                "oid":  "1.1.2.1.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-T2"
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "t-3",
+                                                                                "path":  "oneToN.labelsSecondary.targets.t-3",
+                                                                                "oid":  "1.1.2.1.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-T3"
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  2,
+                                                           "identifier":  "sources",
+                                                           "path":  "oneToN.labelsSecondary.sources",
+                                                           "oid":  "1.1.2.2",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  0,
+                                                                                "identifier":  "s-0",
+                                                                                "path":  "oneToN.labelsSecondary.sources.s-0",
+                                                                                "oid":  "1.1.2.2.0",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-S0"
+                                                                            },
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "s-1",
+                                                                                "path":  "oneToN.labelsSecondary.sources.s-1",
+                                                                                "oid":  "1.1.2.2.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-S1"
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "s-2",
+                                                                                "path":  "oneToN.labelsSecondary.sources.s-2",
+                                                                                "oid":  "1.1.2.2.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-S2"
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "s-3",
+                                                                                "path":  "oneToN.labelsSecondary.sources.s-3",
+                                                                                "oid":  "1.1.2.2.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-S3"
+                                                                            }
+                                                                        ]
+                                                       }
+                                                   ]
+                                  },
+                                  {
+                                      "number":  4,
+                                      "identifier":  "targetParams",
+                                      "path":  "oneToN.targetParams",
+                                      "oid":  "1.1.4",
+                                      "isOnline":  true,
+                                      "access":  "read",
+                                      "children":  [
+                                                       {
+                                                           "number":  0,
+                                                           "identifier":  "0",
+                                                           "path":  "oneToN.targetParams.0",
+                                                           "oid":  "1.1.4.0",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "oneToN.targetParams.0.gain",
+                                                                                "oid":  "1.1.4.0.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "oneToN.targetParams.0.mode",
+                                                                                "oid":  "1.1.4.0.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "oneToN.targetParams.0.mute",
+                                                                                "oid":  "1.1.4.0.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  1,
+                                                           "identifier":  "1",
+                                                           "path":  "oneToN.targetParams.1",
+                                                           "oid":  "1.1.4.1",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "oneToN.targetParams.1.gain",
+                                                                                "oid":  "1.1.4.1.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "oneToN.targetParams.1.mode",
+                                                                                "oid":  "1.1.4.1.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "oneToN.targetParams.1.mute",
+                                                                                "oid":  "1.1.4.1.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  2,
+                                                           "identifier":  "2",
+                                                           "path":  "oneToN.targetParams.2",
+                                                           "oid":  "1.1.4.2",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "oneToN.targetParams.2.gain",
+                                                                                "oid":  "1.1.4.2.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "oneToN.targetParams.2.mode",
+                                                                                "oid":  "1.1.4.2.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "oneToN.targetParams.2.mute",
+                                                                                "oid":  "1.1.4.2.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  3,
+                                                           "identifier":  "3",
+                                                           "path":  "oneToN.targetParams.3",
+                                                           "oid":  "1.1.4.3",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "oneToN.targetParams.3.gain",
+                                                                                "oid":  "1.1.4.3.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "oneToN.targetParams.3.mode",
+                                                                                "oid":  "1.1.4.3.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "oneToN.targetParams.3.mute",
+                                                                                "oid":  "1.1.4.3.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       }
+                                                   ]
+                                  },
+                                  {
+                                      "number":  5,
+                                      "identifier":  "sourceParams",
+                                      "path":  "oneToN.sourceParams",
+                                      "oid":  "1.1.5",
+                                      "isOnline":  true,
+                                      "access":  "read",
+                                      "children":  [
+                                                       {
+                                                           "number":  0,
+                                                           "identifier":  "0",
+                                                           "path":  "oneToN.sourceParams.0",
+                                                           "oid":  "1.1.5.0",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "oneToN.sourceParams.0.gain",
+                                                                                "oid":  "1.1.5.0.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "oneToN.sourceParams.0.mode",
+                                                                                "oid":  "1.1.5.0.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "oneToN.sourceParams.0.mute",
+                                                                                "oid":  "1.1.5.0.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  1,
+                                                           "identifier":  "1",
+                                                           "path":  "oneToN.sourceParams.1",
+                                                           "oid":  "1.1.5.1",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "oneToN.sourceParams.1.gain",
+                                                                                "oid":  "1.1.5.1.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "oneToN.sourceParams.1.mode",
+                                                                                "oid":  "1.1.5.1.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "oneToN.sourceParams.1.mute",
+                                                                                "oid":  "1.1.5.1.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  2,
+                                                           "identifier":  "2",
+                                                           "path":  "oneToN.sourceParams.2",
+                                                           "oid":  "1.1.5.2",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "oneToN.sourceParams.2.gain",
+                                                                                "oid":  "1.1.5.2.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "oneToN.sourceParams.2.mode",
+                                                                                "oid":  "1.1.5.2.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "oneToN.sourceParams.2.mute",
+                                                                                "oid":  "1.1.5.2.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  3,
+                                                           "identifier":  "3",
+                                                           "path":  "oneToN.sourceParams.3",
+                                                           "oid":  "1.1.5.3",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "oneToN.sourceParams.3.gain",
+                                                                                "oid":  "1.1.5.3.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "oneToN.sourceParams.3.mode",
+                                                                                "oid":  "1.1.5.3.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "oneToN.sourceParams.3.mute",
+                                                                                "oid":  "1.1.5.3.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       }
+                                                   ]
+                                  },
+                                  {
+                                      "number":  3,
+                                      "identifier":  "matrix",
+                                      "path":  "oneToN.matrix",
+                                      "oid":  "1.1.3",
+                                      "isOnline":  true,
+                                      "access":  "readWrite",
+                                      "type":  "oneToN",
+                                      "mode":  "linear",
+                                      "targetCount":  4,
+                                      "sourceCount":  4,
+                                      "maximumTotalConnects":  null,
+                                      "maximumConnectsPerTarget":  1,
+                                      "parametersLocation":  null,
+                                      "gainParameterNumber":  null,
+                                      "labels":  [
+                                                     {
+                                                         "basePath":  "1.1.1",
+                                                         "description":  "Primary"
+                                                     },
+                                                     {
+                                                         "basePath":  "1.1.2",
+                                                         "description":  "Secondary"
+                                                     }
+                                                 ],
+                                      "targets":  [
+                                                      {
+                                                          "number":  0
+                                                      },
+                                                      {
+                                                          "number":  1
+                                                      },
+                                                      {
+                                                          "number":  2
+                                                      },
+                                                      {
+                                                          "number":  3
+                                                      }
+                                                  ],
+                                      "sources":  [
+                                                      {
+                                                          "number":  0
+                                                      },
+                                                      {
+                                                          "number":  1
+                                                      },
+                                                      {
+                                                          "number":  2
+                                                      },
+                                                      {
+                                                          "number":  3
+                                                      }
+                                                  ],
+                                      "connections":  [
+                                                          {
+                                                              "target":  0,
+                                                              "sources":  [
+                                                                              0
+                                                                          ],
+                                                              "operation":  "absolute",
+                                                              "disposition":  "tally",
+                                                              "locked":  false
+                                                          },
+                                                          {
+                                                              "target":  1,
+                                                              "sources":  [
+                                                                              1
+                                                                          ],
+                                                              "operation":  "absolute",
+                                                              "disposition":  "tally",
+                                                              "locked":  false
+                                                          },
+                                                          {
+                                                              "target":  2,
+                                                              "sources":  [
+                                                                              2
+                                                                          ],
+                                                              "operation":  "absolute",
+                                                              "disposition":  "locked",
+                                                              "locked":  true
+                                                          },
+                                                          {
+                                                              "target":  3,
+                                                              "sources":  [
+                                                                              3
+                                                                          ],
+                                                              "operation":  "absolute",
+                                                              "disposition":  "tally",
+                                                              "locked":  false
+                                                          }
+                                                      ],
+                                      "targetLabels":  null,
+                                      "sourceLabels":  null,
+                                      "targetParams":  null,
+                                      "sourceParams":  null,
+                                      "connectionParams":  null
+                                  }
+                              ]
+             },
+    "templates":  [
+
+                  ]
+}

--- a/internal/emberplus/testdata/integration-test/dm/emberplus/oneToOne-strict@1.0.0.json
+++ b/internal/emberplus/testdata/integration-test/dm/emberplus/oneToOne-strict@1.0.0.json
@@ -1,0 +1,811 @@
+{
+    "model":  "oneToOne-strict",
+    "sw_rev":  "1.0.0",
+    "protocol":  "emberplus",
+    "root":  {
+                 "number":  1,
+                 "identifier":  "oneToOne",
+                 "path":  "oneToOne",
+                 "oid":  "1.2",
+                 "isOnline":  true,
+                 "access":  "read",
+                 "children":  [
+                                  {
+                                      "number":  1,
+                                      "identifier":  "labelsPrimary",
+                                      "path":  "oneToOne.labelsPrimary",
+                                      "oid":  "1.2.1",
+                                      "isOnline":  true,
+                                      "access":  "read",
+                                      "children":  [
+                                                       {
+                                                           "number":  1,
+                                                           "identifier":  "targets",
+                                                           "path":  "oneToOne.labelsPrimary.targets",
+                                                           "oid":  "1.2.1.1",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  0,
+                                                                                "identifier":  "t-0",
+                                                                                "path":  "oneToOne.labelsPrimary.targets.t-0",
+                                                                                "oid":  "1.2.1.1.0",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-T0"
+                                                                            },
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "t-1",
+                                                                                "path":  "oneToOne.labelsPrimary.targets.t-1",
+                                                                                "oid":  "1.2.1.1.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-T1"
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "t-2",
+                                                                                "path":  "oneToOne.labelsPrimary.targets.t-2",
+                                                                                "oid":  "1.2.1.1.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-T2"
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "t-3",
+                                                                                "path":  "oneToOne.labelsPrimary.targets.t-3",
+                                                                                "oid":  "1.2.1.1.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-T3"
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  2,
+                                                           "identifier":  "sources",
+                                                           "path":  "oneToOne.labelsPrimary.sources",
+                                                           "oid":  "1.2.1.2",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  0,
+                                                                                "identifier":  "s-0",
+                                                                                "path":  "oneToOne.labelsPrimary.sources.s-0",
+                                                                                "oid":  "1.2.1.2.0",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-S0"
+                                                                            },
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "s-1",
+                                                                                "path":  "oneToOne.labelsPrimary.sources.s-1",
+                                                                                "oid":  "1.2.1.2.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-S1"
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "s-2",
+                                                                                "path":  "oneToOne.labelsPrimary.sources.s-2",
+                                                                                "oid":  "1.2.1.2.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-S2"
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "s-3",
+                                                                                "path":  "oneToOne.labelsPrimary.sources.s-3",
+                                                                                "oid":  "1.2.1.2.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Pri-S3"
+                                                                            }
+                                                                        ]
+                                                       }
+                                                   ]
+                                  },
+                                  {
+                                      "number":  2,
+                                      "identifier":  "labelsSecondary",
+                                      "path":  "oneToOne.labelsSecondary",
+                                      "oid":  "1.2.2",
+                                      "isOnline":  true,
+                                      "access":  "read",
+                                      "children":  [
+                                                       {
+                                                           "number":  1,
+                                                           "identifier":  "targets",
+                                                           "path":  "oneToOne.labelsSecondary.targets",
+                                                           "oid":  "1.2.2.1",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  0,
+                                                                                "identifier":  "t-0",
+                                                                                "path":  "oneToOne.labelsSecondary.targets.t-0",
+                                                                                "oid":  "1.2.2.1.0",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-T0"
+                                                                            },
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "t-1",
+                                                                                "path":  "oneToOne.labelsSecondary.targets.t-1",
+                                                                                "oid":  "1.2.2.1.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-T1"
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "t-2",
+                                                                                "path":  "oneToOne.labelsSecondary.targets.t-2",
+                                                                                "oid":  "1.2.2.1.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-T2"
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "t-3",
+                                                                                "path":  "oneToOne.labelsSecondary.targets.t-3",
+                                                                                "oid":  "1.2.2.1.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-T3"
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  2,
+                                                           "identifier":  "sources",
+                                                           "path":  "oneToOne.labelsSecondary.sources",
+                                                           "oid":  "1.2.2.2",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  0,
+                                                                                "identifier":  "s-0",
+                                                                                "path":  "oneToOne.labelsSecondary.sources.s-0",
+                                                                                "oid":  "1.2.2.2.0",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-S0"
+                                                                            },
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "s-1",
+                                                                                "path":  "oneToOne.labelsSecondary.sources.s-1",
+                                                                                "oid":  "1.2.2.2.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-S1"
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "s-2",
+                                                                                "path":  "oneToOne.labelsSecondary.sources.s-2",
+                                                                                "oid":  "1.2.2.2.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-S2"
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "s-3",
+                                                                                "path":  "oneToOne.labelsSecondary.sources.s-3",
+                                                                                "oid":  "1.2.2.2.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "string",
+                                                                                "value":  "Sec-S3"
+                                                                            }
+                                                                        ]
+                                                       }
+                                                   ]
+                                  },
+                                  {
+                                      "number":  4,
+                                      "identifier":  "targetParams",
+                                      "path":  "oneToOne.targetParams",
+                                      "oid":  "1.2.4",
+                                      "isOnline":  true,
+                                      "access":  "read",
+                                      "children":  [
+                                                       {
+                                                           "number":  0,
+                                                           "identifier":  "0",
+                                                           "path":  "oneToOne.targetParams.0",
+                                                           "oid":  "1.2.4.0",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "oneToOne.targetParams.0.gain",
+                                                                                "oid":  "1.2.4.0.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "oneToOne.targetParams.0.mode",
+                                                                                "oid":  "1.2.4.0.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "oneToOne.targetParams.0.mute",
+                                                                                "oid":  "1.2.4.0.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  1,
+                                                           "identifier":  "1",
+                                                           "path":  "oneToOne.targetParams.1",
+                                                           "oid":  "1.2.4.1",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "oneToOne.targetParams.1.gain",
+                                                                                "oid":  "1.2.4.1.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "oneToOne.targetParams.1.mode",
+                                                                                "oid":  "1.2.4.1.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "oneToOne.targetParams.1.mute",
+                                                                                "oid":  "1.2.4.1.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  2,
+                                                           "identifier":  "2",
+                                                           "path":  "oneToOne.targetParams.2",
+                                                           "oid":  "1.2.4.2",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "oneToOne.targetParams.2.gain",
+                                                                                "oid":  "1.2.4.2.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "oneToOne.targetParams.2.mode",
+                                                                                "oid":  "1.2.4.2.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "oneToOne.targetParams.2.mute",
+                                                                                "oid":  "1.2.4.2.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  3,
+                                                           "identifier":  "3",
+                                                           "path":  "oneToOne.targetParams.3",
+                                                           "oid":  "1.2.4.3",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "oneToOne.targetParams.3.gain",
+                                                                                "oid":  "1.2.4.3.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "oneToOne.targetParams.3.mode",
+                                                                                "oid":  "1.2.4.3.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "oneToOne.targetParams.3.mute",
+                                                                                "oid":  "1.2.4.3.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       }
+                                                   ]
+                                  },
+                                  {
+                                      "number":  5,
+                                      "identifier":  "sourceParams",
+                                      "path":  "oneToOne.sourceParams",
+                                      "oid":  "1.2.5",
+                                      "isOnline":  true,
+                                      "access":  "read",
+                                      "children":  [
+                                                       {
+                                                           "number":  0,
+                                                           "identifier":  "0",
+                                                           "path":  "oneToOne.sourceParams.0",
+                                                           "oid":  "1.2.5.0",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "oneToOne.sourceParams.0.gain",
+                                                                                "oid":  "1.2.5.0.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "oneToOne.sourceParams.0.mode",
+                                                                                "oid":  "1.2.5.0.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "oneToOne.sourceParams.0.mute",
+                                                                                "oid":  "1.2.5.0.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  1,
+                                                           "identifier":  "1",
+                                                           "path":  "oneToOne.sourceParams.1",
+                                                           "oid":  "1.2.5.1",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "oneToOne.sourceParams.1.gain",
+                                                                                "oid":  "1.2.5.1.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "oneToOne.sourceParams.1.mode",
+                                                                                "oid":  "1.2.5.1.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "oneToOne.sourceParams.1.mute",
+                                                                                "oid":  "1.2.5.1.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  2,
+                                                           "identifier":  "2",
+                                                           "path":  "oneToOne.sourceParams.2",
+                                                           "oid":  "1.2.5.2",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "oneToOne.sourceParams.2.gain",
+                                                                                "oid":  "1.2.5.2.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "oneToOne.sourceParams.2.mode",
+                                                                                "oid":  "1.2.5.2.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "oneToOne.sourceParams.2.mute",
+                                                                                "oid":  "1.2.5.2.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       },
+                                                       {
+                                                           "number":  3,
+                                                           "identifier":  "3",
+                                                           "path":  "oneToOne.sourceParams.3",
+                                                           "oid":  "1.2.5.3",
+                                                           "isOnline":  true,
+                                                           "access":  "read",
+                                                           "children":  [
+                                                                            {
+                                                                                "number":  1,
+                                                                                "identifier":  "gain",
+                                                                                "path":  "oneToOne.sourceParams.3.gain",
+                                                                                "oid":  "1.2.5.3.1",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "integer",
+                                                                                "value":  0,
+                                                                                "minimum":  -1000,
+                                                                                "maximum":  100,
+                                                                                "step":  1
+                                                                            },
+                                                                            {
+                                                                                "number":  2,
+                                                                                "identifier":  "mode",
+                                                                                "path":  "oneToOne.sourceParams.3.mode",
+                                                                                "oid":  "1.2.5.3.2",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "enum",
+                                                                                "value":  0,
+                                                                                "enumMap":  [
+                                                                                                {
+                                                                                                    "key":  "auto",
+                                                                                                    "value":  0
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "manual",
+                                                                                                    "value":  1
+                                                                                                },
+                                                                                                {
+                                                                                                    "key":  "bypass",
+                                                                                                    "value":  2
+                                                                                                }
+                                                                                            ]
+                                                                            },
+                                                                            {
+                                                                                "number":  3,
+                                                                                "identifier":  "mute",
+                                                                                "path":  "oneToOne.sourceParams.3.mute",
+                                                                                "oid":  "1.2.5.3.3",
+                                                                                "isOnline":  true,
+                                                                                "access":  "readWrite",
+                                                                                "type":  "boolean",
+                                                                                "value":  false
+                                                                            }
+                                                                        ]
+                                                       }
+                                                   ]
+                                  },
+                                  {
+                                      "number":  3,
+                                      "identifier":  "matrix",
+                                      "path":  "oneToOne.matrix",
+                                      "oid":  "1.2.3",
+                                      "isOnline":  true,
+                                      "access":  "readWrite",
+                                      "type":  "oneToOne",
+                                      "mode":  "linear",
+                                      "targetCount":  4,
+                                      "sourceCount":  4,
+                                      "maximumTotalConnects":  null,
+                                      "maximumConnectsPerTarget":  1,
+                                      "parametersLocation":  null,
+                                      "gainParameterNumber":  null,
+                                      "labels":  [
+                                                     {
+                                                         "basePath":  "1.2.1",
+                                                         "description":  "Primary"
+                                                     },
+                                                     {
+                                                         "basePath":  "1.2.2",
+                                                         "description":  "Secondary"
+                                                     }
+                                                 ],
+                                      "targets":  [
+                                                      {
+                                                          "number":  0
+                                                      },
+                                                      {
+                                                          "number":  1
+                                                      },
+                                                      {
+                                                          "number":  2
+                                                      },
+                                                      {
+                                                          "number":  3
+                                                      }
+                                                  ],
+                                      "sources":  [
+                                                      {
+                                                          "number":  0
+                                                      },
+                                                      {
+                                                          "number":  1
+                                                      },
+                                                      {
+                                                          "number":  2
+                                                      },
+                                                      {
+                                                          "number":  3
+                                                      }
+                                                  ],
+                                      "connections":  [
+                                                          {
+                                                              "target":  0,
+                                                              "sources":  [
+                                                                              0
+                                                                          ],
+                                                              "operation":  "absolute",
+                                                              "disposition":  "tally",
+                                                              "locked":  false
+                                                          },
+                                                          {
+                                                              "target":  1,
+                                                              "sources":  [
+                                                                              1
+                                                                          ],
+                                                              "operation":  "absolute",
+                                                              "disposition":  "tally",
+                                                              "locked":  false
+                                                          },
+                                                          {
+                                                              "target":  2,
+                                                              "sources":  [
+                                                                              2
+                                                                          ],
+                                                              "operation":  "absolute",
+                                                              "disposition":  "tally",
+                                                              "locked":  false
+                                                          },
+                                                          {
+                                                              "target":  3,
+                                                              "sources":  [
+                                                                              3
+                                                                          ],
+                                                              "operation":  "absolute",
+                                                              "disposition":  "tally",
+                                                              "locked":  false
+                                                          }
+                                                      ],
+                                      "targetLabels":  null,
+                                      "sourceLabels":  null,
+                                      "targetParams":  null,
+                                      "sourceParams":  null,
+                                      "connectionParams":  null
+                                  }
+                              ]
+             },
+    "templates":  [
+
+                  ]
+}

--- a/internal/emberplus/testdata/integration-test/manifest/emberplus-integration.json
+++ b/internal/emberplus/testdata/integration-test/manifest/emberplus-integration.json
@@ -1,0 +1,62 @@
+{
+    "device":  {
+                   "name":  "dhs-emberplus-integration",
+                   "protocol":  "emberplus",
+                   "endpoints":  [
+                                     {
+                                         "ip":  "0.0.0.0",
+                                         "port":  9100,
+                                         "transport":  "tcp"
+                                     }
+                                 ]
+               },
+    "frames":  [
+                   {
+                       "name":  "main",
+                       "slots":  [
+                                     {
+                                         "addr":  {
+                                                      "oid":  "1.0"
+                                                  },
+                                         "dm":  "identity-strict@1.0.0"
+                                     },
+                                     {
+                                         "addr":  {
+                                                      "oid":  "1.1"
+                                                  },
+                                         "dm":  "oneToN-strict@1.0.0"
+                                     },
+                                     {
+                                         "addr":  {
+                                                      "oid":  "1.2"
+                                                  },
+                                         "dm":  "oneToOne-strict@1.0.0"
+                                     },
+                                     {
+                                         "addr":  {
+                                                      "oid":  "1.3"
+                                                  },
+                                         "dm":  "nToN-strict@1.0.0"
+                                     },
+                                     {
+                                         "addr":  {
+                                                      "oid":  "1.4"
+                                                  },
+                                         "dm":  "dynamic-strict@1.0.0"
+                                     },
+                                     {
+                                         "addr":  {
+                                                      "oid":  "1.5"
+                                                  },
+                                         "dm":  "functions-strict@1.0.0"
+                                     },
+                                     {
+                                         "addr":  {
+                                                      "oid":  "1.6"
+                                                  },
+                                         "dm":  "glow-types-strict@1.0.0"
+                                     }
+                                 ]
+                   }
+               ]
+}

--- a/scripts/emberplus/gen-emberplus-demo-dms.ps1
+++ b/scripts/emberplus/gen-emberplus-demo-dms.ps1
@@ -1,21 +1,28 @@
 # Generates the spec-clean Ember+ integration-test DM cards + manifest.
 #
-# Output:
-#   .cache/dm/emberplus/identity-strict@1.0.0.json
-#   .cache/dm/emberplus/oneToN-strict@1.0.0.json
-#   .cache/dm/emberplus/oneToOne-strict@1.0.0.json
-#   .cache/dm/emberplus/nToN-strict@1.0.0.json
-#   .cache/dm/emberplus/dynamic-strict@1.0.0.json
-#   .cache/dm/emberplus/functions-strict@1.0.0.json
-#   .cache/dm/emberplus/glow-types-strict@1.0.0.json
-#   .cache/manifest/emberplus-integration.json
+# Output (version-controlled source-of-truth, per ADR-0025 deliverable #6):
+#   internal/emberplus/testdata/integration-test/dm/emberplus/identity-strict@1.0.0.json
+#   internal/emberplus/testdata/integration-test/dm/emberplus/oneToN-strict@1.0.0.json
+#   internal/emberplus/testdata/integration-test/dm/emberplus/oneToOne-strict@1.0.0.json
+#   internal/emberplus/testdata/integration-test/dm/emberplus/nToN-strict@1.0.0.json
+#   internal/emberplus/testdata/integration-test/dm/emberplus/dynamic-strict@1.0.0.json
+#   internal/emberplus/testdata/integration-test/dm/emberplus/functions-strict@1.0.0.json
+#   internal/emberplus/testdata/integration-test/dm/emberplus/glow-types-strict@1.0.0.json
+#   internal/emberplus/testdata/integration-test/manifest/emberplus-integration.json
+#
+# Serve from this layout (cookbook command):
+#   dhs producer emberplus serve `
+#       --manifest internal/emberplus/testdata/integration-test/manifest/emberplus-integration.json `
+#       --cache-dir internal/emberplus/testdata/integration-test `
+#       --port 9100
 #
 # Re-run any time to regenerate. Idempotent.
 
 $ErrorActionPreference = 'Stop'
 $repoRoot = Resolve-Path "$PSScriptRoot\..\.."
-$dmDir = Join-Path $repoRoot ".cache\dm\emberplus"
-$manifestDir = Join-Path $repoRoot ".cache\manifest"
+$testdataRoot = Join-Path $repoRoot "internal\emberplus\testdata\integration-test"
+$dmDir = Join-Path $testdataRoot "dm\emberplus"
+$manifestDir = Join-Path $testdataRoot "manifest"
 New-Item -ItemType Directory -Force -Path $dmDir | Out-Null
 New-Item -ItemType Directory -Force -Path $manifestDir | Out-Null
 


### PR DESCRIPTION
## Summary

Move the Ember+ provider's spec-clean integration-test fixtures (manifest + 7 strict-canonical DMs) from `.cache/manifest/` + `.cache/dm/emberplus/` into `internal/emberplus/testdata/integration-test/` so the source-of-truth lives **inside the protocol folder** and ships as part of the lift-to-own-repo unit per ADR-0025 deliverable #6.

`.cache/` at the repo root stays gitignored and serves only as the runtime DM cache for the consumer plugin's `--dm` hot-load (per ADR-0022). No consumer code changed; the producer's `--cache-dir` flag now points at the testdata layout.

## Move

| From | To |
|---|---|
| `.cache/manifest/emberplus-integration.json` | `internal/emberplus/testdata/integration-test/manifest/` |
| `.cache/dm/emberplus/{identity,oneToOne,oneToN,nToN,dynamic,functions,glow-types}-strict@1.0.0.json` | `internal/emberplus/testdata/integration-test/dm/emberplus/` |

## Updates

- `scripts/emberplus/gen-emberplus-demo-dms.ps1` — writes to the testdata layout, header documents the new serve command.
- `internal/emberplus/docs/integration-demo.md` — cookbook command updated to `--manifest internal\emberplus\testdata\integration-test\... --cache-dir internal\emberplus\testdata\integration-test`.
- `internal/emberplus/testdata/integration-test/README.md` (new) — layout + regen + ADR refs + links to runbook (in progress).

## Live verification (2026-05-17, bin/dhs.exe @ this branch's HEAD)

```
$ dhs producer emberplus serve `
    --manifest internal/emberplus/testdata/integration-test/manifest/emberplus-integration.json `
    --cache-dir internal/emberplus/testdata/integration-test `
    --port 9100

level=INFO msg="producer manifest loaded" path=...integration-test/... device=dhs-emberplus-integration endpoints=1 frames=1
level=INFO msg=listening plugin=emberplus-provider addr=[::]:9100 tree_size=363
level=INFO msg="streamer started" plugin=emberplus-provider stream_count=2 interval=500ms
```

Walk via consumer returns the same **548-line tree dump** as before the move — tree shape unchanged.

## Test plan

- `go test ./internal/emberplus/...` — all 6 packages still green (no consumer / provider / codec code changed)
- `go build -o bin/dhs.exe ./cmd/dhs` — clean
- Live producer serve from new location ✓
- Live consumer walk against new producer ✓

## What this unblocks

Next PRs all read from this layout:

- **β** (feat): provider scope refresh — identity+DTD, params/gain layers, 16×16 matrices, source-exclusive oneToOne, multi-src nToN+dynamic
- **β'** (fix): #456 BuildExport reroots strict-canonical slot DM paths
- **γ** (test): capture batch under `internal/emberplus/testdata/protocol_types/<type>/`
- **δ** (docs): operator runbook prose `internal/emberplus/docs/runbook.md` (#460)
- **ε** (test): `internal/emberplus/integration/` Go scaffolding driving the captures (ADR-0025 #3 + #4)

Refs #460
