### PR TITLE
fix(manifest): BuildExport reroots strict-canonical slot DM paths under synthetic root (refs #456)

### DIFF
--- a/internal/manifest/reroot_paths_test.go
+++ b/internal/manifest/reroot_paths_test.go
@@ -1,0 +1,116 @@
+package manifest
+
+import (
+	"testing"
+
+	"dhs/internal/export/canonical"
+)
+
+// TestRerootPaths_StrictCanonical pins #456: when a slot DM is grafted
+// under a synthetic root whose identifier differs from the slot's
+// Root.Path first segment, every descendant's Path must be rewritten
+// to begin with the synthetic root.
+//
+// This is the case for the spec-clean integration-test DMs (per the
+// scope refresh in #464): identity-strict / oneToN-strict / etc. all
+// carry bare paths ("oneToN.X.Y") because no single shared prefix
+// exists across the slot Roots. Without rerooting, the provider's
+// byIDP index in internal/emberplus/provider/tree.go ends up keyed
+// by the un-prefixed paths and the dotted form a consumer naturally
+// assembles ("<device>.oneToN.X.Y") fails to resolve.
+func TestRerootPaths_StrictCanonical(t *testing.T) {
+	leaf := &canonical.Parameter{
+		Header: canonical.Header{
+			Number: 1, Identifier: "gain", Path: "oneToN.matrix.gain", OID: "1.1.3.1",
+		},
+		Type: "integer",
+	}
+	mid := &canonical.Node{
+		Header: canonical.Header{
+			Number: 3, Identifier: "matrix", Path: "oneToN.matrix", OID: "1.1.3",
+			Children: []canonical.Element{leaf},
+		},
+	}
+	slot := &canonical.Node{
+		Header: canonical.Header{
+			Number: 1, Identifier: "oneToN", Path: "oneToN", OID: "1.1",
+			Children: []canonical.Element{mid},
+		},
+	}
+
+	rerootPaths(slot, "dhs-emberplus-integration")
+
+	if got, want := slot.Path, "dhs-emberplus-integration.oneToN"; got != want {
+		t.Errorf("slot Path = %q, want %q", got, want)
+	}
+	if got, want := mid.Path, "dhs-emberplus-integration.oneToN.matrix"; got != want {
+		t.Errorf("mid Path = %q, want %q", got, want)
+	}
+	if got, want := leaf.Path, "dhs-emberplus-integration.oneToN.matrix.gain"; got != want {
+		t.Errorf("leaf Path = %q, want %q", got, want)
+	}
+}
+
+// TestRerootPaths_Idempotent confirms a second call with the same
+// prefix is a no-op — needed because a re-run gen script + producer
+// restart could legitimately call rerootPaths twice on the same
+// in-RAM tree if a refactor ever caches it.
+func TestRerootPaths_Idempotent(t *testing.T) {
+	n := &canonical.Node{
+		Header: canonical.Header{
+			Number: 1, Identifier: "x", Path: "x", OID: "1",
+			Children: []canonical.Element{
+				&canonical.Parameter{Header: canonical.Header{Identifier: "y", Path: "x.y", OID: "1.1"}, Type: "string"},
+			},
+		},
+	}
+	rerootPaths(n, "dev")
+	first := n.Path
+	rerootPaths(n, "dev")
+	if first != n.Path {
+		t.Errorf("rerootPaths not idempotent: 1st=%q 2nd=%q", first, n.Path)
+	}
+	if got, want := n.Path, "dev.x"; got != want {
+		t.Errorf("Path = %q, want %q", got, want)
+	}
+	// Leaf still consistent
+	leaf := n.Header.Children[0].Common()
+	if got, want := leaf.Path, "dev.x.y"; got != want {
+		t.Errorf("leaf Path = %q, want %q", got, want)
+	}
+}
+
+// TestRerootPaths_AlreadyPrefixed leaves paths alone when the slot DM
+// already carries the device-prefixed form (e.g. the legacy Tiny
+// Ember+ Router 1.6.2 DMs whose slot Root.Path starts with "router"
+// when the synthetic root is also "router").
+func TestRerootPaths_AlreadyPrefixed(t *testing.T) {
+	n := &canonical.Node{
+		Header: canonical.Header{
+			Number: 1, Identifier: "router", Path: "router", OID: "1",
+			Children: []canonical.Element{
+				&canonical.Parameter{Header: canonical.Header{Identifier: "x", Path: "router.x", OID: "1.1"}, Type: "string"},
+			},
+		},
+	}
+	rerootPaths(n, "router")
+	if got, want := n.Path, "router"; got != want {
+		t.Errorf("Path = %q, want %q (no double-prefix)", got, want)
+	}
+	leaf := n.Header.Children[0].Common()
+	if got, want := leaf.Path, "router.x"; got != want {
+		t.Errorf("leaf Path = %q, want %q (no double-prefix)", got, want)
+	}
+}
+
+// TestRerootPaths_EmptyPrefixIsNoOp guards against accidental
+// rerooting when BuildExport's rootIdent computation degrades to "".
+func TestRerootPaths_EmptyPrefixIsNoOp(t *testing.T) {
+	n := &canonical.Node{
+		Header: canonical.Header{Identifier: "x", Path: "x", OID: "1"},
+	}
+	rerootPaths(n, "")
+	if got, want := n.Path, "x"; got != want {
+		t.Errorf("Path = %q, want %q (empty prefix should not mutate)", got, want)
+	}
+}

--- a/internal/manifest/to_canonical.go
+++ b/internal/manifest/to_canonical.go
@@ -116,6 +116,15 @@ func BuildExport(m *Manifest, cacheDir string) (*canonical.Export, error) {
 				if derr != nil {
 					return nil, fmt.Errorf("manifest frame=%q slot dm=%q: parse canonical root: %w", fr.Name, sl.DM, derr)
 				}
+				// Reroot the grafted subtree's internal Path values to
+				// be device-prefixed. Strict-canonical slot DMs (per
+				// the Ember+ integration-test fixtures) carry paths
+				// like "oneToN.matrix" instead of "<device>.oneToN.matrix";
+				// without rerooting the provider's byIDP index ends up
+				// with un-prefixed paths and builtin function args of
+				// the form "<device>.<matrix>.matrix" don't resolve.
+				// Refs #456.
+				rerootPaths(slotEl, rootIdent)
 				root.Children = append(root.Children, slotEl)
 				if len(dm.Templates) > 0 {
 					collectedTemplates = append(collectedTemplates, dm.Templates...)
@@ -137,6 +146,41 @@ func BuildExport(m *Manifest, cacheDir string) (*canonical.Export, error) {
 	}
 
 	return &canonical.Export{Root: root, Templates: collectedTemplates}, nil
+}
+
+// rerootPaths walks the canonical element subtree rooted at el and
+// rewrites every Header.Path so it begins with prefix + ".". If a
+// node's existing Path is empty, equals prefix, or already starts
+// with prefix + ".", it is left alone — this makes the helper
+// idempotent and safe to call regardless of whether the source DM
+// carried a device-prefixed root (e.g. dhs-emberplus-integration
+// strict DMs use bare "oneToN.X" paths while Tiny Ember+ Router uses
+// "router.oneToN.X"; both end up consistently prefixed after).
+//
+// Refs #456 — the provider's byIDP index in tree.go uses Header.Path
+// verbatim, so the dotted lookup form callers naturally assemble
+// (device-rooted) must match what the tree was indexed under.
+func rerootPaths(el canonical.Element, prefix string) {
+	if el == nil || prefix == "" {
+		return
+	}
+	hdr := el.Common()
+	if hdr == nil {
+		return
+	}
+	switch {
+	case hdr.Path == "":
+		// nothing to reroot — defensive guard for malformed DMs
+	case hdr.Path == prefix:
+		// already at the synthetic root; nothing to prepend
+	case strings.HasPrefix(hdr.Path, prefix+"."):
+		// already prefixed (e.g. legacy "router.X" + prefix="router")
+	default:
+		hdr.Path = prefix + "." + hdr.Path
+	}
+	for _, child := range hdr.Children {
+		rerootPaths(child, prefix)
+	}
 }
 
 // deriveSharedRootIdentifier inspects every slot DM referenced by the


### PR DESCRIPTION
## Summary

`BuildExport` in [internal/manifest/to_canonical.go](internal/manifest/to_canonical.go) grafts strict-canonical slot DMs under the synthetic root without re-rooting their internal `Header.Path` values. With slot DMs whose `Root.Path` is just `oneToN` / `oneToOne` / etc. (the spec-clean fixtures from #464), the provider's `byIDP` index in [internal/emberplus/provider/tree.go](internal/emberplus/provider/tree.go#L67) ends up keyed by the un-prefixed paths, so builtin function calls with the natural device-rooted form silently miss (post #457: now surfaces as `Success=false` with `"<builtin>: matrix \"<dotted-ref>\" not found"`).

## Fix

New `rerootPaths(el, prefix)` helper called from `BuildExport` after `canonical.UnmarshalElement` and before appending the slotEl as a child of the synthetic root. Walks the grafted subtree, prepends `<rootIdent>.` to every `Header.Path` that does not already start with that prefix.

Idempotent + no-op when prefix is empty + no-op when path already begins with prefix. `deriveSharedRootIdentifier` still wins where it can (legacy Tiny Ember+ Router 1.6.2 with slot Root.Path=`router.X` stays correctly prefixed under rootIdent=`router`); `rerootPaths` only kicks in when the slot DM's internal paths haven't been pre-prefixed.

## Test plan

- New `reroot_paths_test.go` pins 4 cases:
  - strict-canonical multi-level subtree → every Path device-prefixed
  - idempotent double-call → no double-prefix
  - already-prefixed → no-op
  - empty prefix → no-op
- `go test ./internal/manifest/... ./internal/emberplus/...` — 7 packages green
- `go build -o bin/dhs.exe ./cmd/dhs` — clean

Live verification is queued for after this + #464 both land on main; the bug surfaces only when the strict-canonical 16×16 test provider from the testdata layout (introduced in #463 + #464) is served. The unit tests cover the rerooting logic deterministically against synthetic in-memory canonical Elements.

## Out of scope

- Backfilling the `BuildExport` doc to describe the rerooting in detail — minor; the helper's own doc-comment carries the rationale + refs.

Refs #456
