### PR TITLE
fix(emberplus/codec/matrix): oneToOne source-steal accepted on CanConnect + compliance event (refs #465)

### DIFF
--- a/internal/emberplus/codec/matrix/state.go
+++ b/internal/emberplus/codec/matrix/state.go
@@ -168,7 +168,19 @@ func (s *State) Snapshot() []TargetState {
 // Rules (spec p.33–34, p.89):
 //
 //	oneToN:   exactly 1 source per target; connect replaces.
-//	oneToOne: 1 source per target AND source used once globally.
+//	oneToOne: 1 source per target. The "source used once globally"
+//	          spec clause (p.33) is NOT enforced here — every shipping
+//	          provider (Lawo VSM, EmberPlusView-as-provider, TinyEmber+)
+//	          implements source-steal: setting src=A on tgt=B implicitly
+//	          disconnects A from its prior target. Same precedent as
+//	          feedback_probel_salvo_connected — when every shipping
+//	          controller contradicts a literal spec clause, the connector
+//	          aligns with the controllers. The provider's
+//	          applyMatrixConnections handles the actual steal on receive.
+//	          The consumer-side plugin.MatrixConnect fires the
+//	          EmberPlusOneToOneSourceStealAccepted compliance event when
+//	          it detects an implicit steal pre-flight, so operators see
+//	          the deviation in the profile counter. Refs #465.
 //	nToN:     len(sources[t]) <= MaxConnectsPerTarget;
 //	          sum(all targets) <= MaxTotalConnects.
 //	any type: reject if target disposition is locked (disposition 3).
@@ -202,20 +214,10 @@ func (s *State) CanConnect(target int32, newSources []int32, op int64) error {
 			return fmt.Errorf("oneToOne matrix: target %d would have %d sources (max 1) [spec p.33]",
 				target, len(projected))
 		}
-		// Source exclusivity: no other target may already use any source.
-		for _, src := range projected {
-			for tgtNum, tstate := range s.Targets {
-				if tgtNum == target {
-					continue
-				}
-				for _, cur := range tstate.Sources {
-					if cur == src {
-						return fmt.Errorf("oneToOne matrix: source %d already used by target %d [spec p.33]",
-							src, tgtNum)
-					}
-				}
-			}
-		}
+		// Source exclusivity (spec p.33 literal) is NOT enforced here —
+		// see CanConnect doc-comment for the source-steal precedent.
+		// The consumer's plugin.MatrixConnect detects the implicit
+		// steal pre-flight and fires a compliance event. Refs #465.
 	case glow.MatrixTypeNToN:
 		if s.MaxConnectsPerTarget > 0 && int32(len(projected)) > s.MaxConnectsPerTarget {
 			return fmt.Errorf("nToN matrix: target %d would have %d sources (max %d per target) [spec p.33]",
@@ -236,6 +238,45 @@ func (s *State) CanConnect(target int32, newSources []int32, op int64) error {
 		}
 	}
 	return nil
+}
+
+// DetectOneToOneSourceSteal reports whether a SET on a oneToOne matrix
+// would implicitly disconnect any of the requested sources from a
+// prior target (the source-steal case documented in CanConnect's
+// doc-comment; refs #465). Returns the list of (target, source) pairs
+// whose disconnection is implied — empty when no steal is needed.
+//
+// Pure read; safe to call under any goroutine. Returns nil for
+// non-oneToOne matrices.
+func (s *State) DetectOneToOneSourceSteal(target int32, newSources []int32) []SourceStealPair {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.Type != glow.MatrixTypeOneToOne {
+		return nil
+	}
+	var stolen []SourceStealPair
+	for _, src := range newSources {
+		for tgtNum, tstate := range s.Targets {
+			if tgtNum == target {
+				continue
+			}
+			for _, cur := range tstate.Sources {
+				if cur == src {
+					stolen = append(stolen, SourceStealPair{FromTarget: tgtNum, Source: src})
+				}
+			}
+		}
+	}
+	return stolen
+}
+
+// SourceStealPair names one (target, source) pair whose source is
+// being implicitly disconnected by a oneToOne SET. Used by the
+// consumer's compliance reporting so each individual deviation is
+// visible (not collapsed to a single event for a multi-source SET).
+type SourceStealPair struct {
+	FromTarget int32
+	Source     int32
 }
 
 // projectSources simulates the union/difference/replace that the provider

--- a/internal/emberplus/codec/matrix/state_test.go
+++ b/internal/emberplus/codec/matrix/state_test.go
@@ -26,7 +26,13 @@ func TestCanConnect_OneToN(t *testing.T) {
 	}
 }
 
-func TestCanConnect_OneToOne_SourceExclusive(t *testing.T) {
+// TestCanConnect_OneToOne_SourceStealAccepted pins #465: oneToOne
+// source-already-used is NOT rejected by CanConnect. Every shipping
+// Ember+ provider (Lawo VSM, EmberPlusView, TinyEmber+) implements
+// source-steal — the source is implicitly disconnected from its prior
+// target on receive. The consumer accepts the SET and the
+// plugin.MatrixConnect layer fires a compliance event.
+func TestCanConnect_OneToOne_SourceStealAccepted(t *testing.T) {
 	s := &State{
 		Type:        glow.MatrixTypeOneToOne,
 		TargetCount: 4, SourceCount: 4,
@@ -34,11 +40,49 @@ func TestCanConnect_OneToOne_SourceExclusive(t *testing.T) {
 			1: {Target: 1, Sources: []int32{3}},
 		},
 	}
-	if err := s.CanConnect(2, []int32{3}, glow.ConnOpAbsolute); err == nil {
-		t.Fatal("oneToOne should reject source 3 on target 2 when target 1 already uses it")
+	// Source 3 currently routed to target 1; setting it on target 2
+	// would have been rejected pre-#465. Now accepted (provider steals).
+	if err := s.CanConnect(2, []int32{3}, glow.ConnOpAbsolute); err != nil {
+		t.Errorf("oneToOne source-steal must be accepted (provider handles disconnect): %v", err)
 	}
+	// Unused source on a fresh target still works.
 	if err := s.CanConnect(2, []int32{5}, glow.ConnOpAbsolute); err != nil {
-		t.Fatalf("oneToOne should accept unused source: %v", err)
+		t.Errorf("oneToOne should accept unused source: %v", err)
+	}
+	// Cardinality-1 invariant (≤1 source per target) still enforced.
+	if err := s.CanConnect(2, []int32{5, 6}, glow.ConnOpAbsolute); err == nil {
+		t.Error("oneToOne should still reject 2 sources on a target [spec p.33 cardinality]")
+	}
+}
+
+// TestDetectOneToOneSourceSteal pins the steal-detection helper used
+// by the consumer's MatrixConnect to fire OneToOneSourceStealAccepted.
+func TestDetectOneToOneSourceSteal(t *testing.T) {
+	s := &State{
+		Type:        glow.MatrixTypeOneToOne,
+		TargetCount: 4, SourceCount: 4,
+		Targets: map[int32]*TargetState{
+			1: {Target: 1, Sources: []int32{3}},
+			0: {Target: 0, Sources: []int32{0}},
+		},
+	}
+	// Setting target 2 ← source 3 steals source 3 from target 1.
+	stolen := s.DetectOneToOneSourceSteal(2, []int32{3})
+	if len(stolen) != 1 || stolen[0].FromTarget != 1 || stolen[0].Source != 3 {
+		t.Errorf("steal-detect = %+v, want [{FromTarget:1 Source:3}]", stolen)
+	}
+	// Setting target 5 ← source 99 (neither routed) — no steal.
+	if stolen := s.DetectOneToOneSourceSteal(5, []int32{99}); len(stolen) != 0 {
+		t.Errorf("steal-detect on unrouted source = %+v, want empty", stolen)
+	}
+	// Setting target 0 ← source 0 (self, no other target has it) — no steal.
+	if stolen := s.DetectOneToOneSourceSteal(0, []int32{0}); len(stolen) != 0 {
+		t.Errorf("steal-detect on self-routed source = %+v, want empty", stolen)
+	}
+	// Non-oneToOne matrix returns nil regardless of state.
+	s.Type = glow.MatrixTypeNToN
+	if stolen := s.DetectOneToOneSourceSteal(2, []int32{3}); stolen != nil {
+		t.Errorf("steal-detect on nToN = %+v, want nil", stolen)
 	}
 }
 

--- a/internal/emberplus/consumer/compliance_events.go
+++ b/internal/emberplus/consumer/compliance_events.go
@@ -144,4 +144,16 @@ const (
 	// reusing it across Parameters is a provider-side bug that
 	// causes value mis-dispatch.
 	StreamIDCollisionNoDescriptor = "stream_id_collision_no_descriptor"
+
+	// OneToOneSourceStealAccepted fires when the consumer issues a
+	// SET on an oneToOne matrix whose requested source is already
+	// routed to another target. Spec p.33 literal-reading says this
+	// is a violation (source must be used at most once globally), but
+	// every shipping Ember+ provider (Lawo VSM, EmberPlusView,
+	// TinyEmber+) implements source-steal: the source is implicitly
+	// disconnected from its prior target. The consumer accepts the
+	// SET (does NOT block via CanConnect) and fires this event so
+	// operators see the deviation in the profile counter. Refs #465,
+	// same precedent as feedback_probel_salvo_connected.
+	OneToOneSourceStealAccepted = "onetoone_source_steal_accepted"
 )

--- a/internal/emberplus/consumer/plugin.go
+++ b/internal/emberplus/consumer/plugin.go
@@ -947,6 +947,21 @@ func (p *Plugin) MatrixConnect(ctx context.Context, matrixPath string, target in
 		if err := entry.matrixState.CanConnect(target, sources, operation); err != nil {
 			return WrapProto("matrix validation", err)
 		}
+		// Fire one compliance event per implicit source-steal pair on
+		// oneToOne SETs (spec p.33 says source-exclusive, every
+		// shipping provider source-steals). Pre-flight detection lets
+		// the operator see the deviation in `dhs consumer emberplus
+		// profile`. Refs #465.
+		if stolen := entry.matrixState.DetectOneToOneSourceSteal(target, sources); len(stolen) > 0 {
+			for _, pair := range stolen {
+				p.profile.Note(OneToOneSourceStealAccepted)
+				p.logger.Debug("emberplus: oneToOne source-steal accepted",
+					"matrix_path", matrixPath,
+					"target", target,
+					"source", pair.Source,
+					"from_target", pair.FromTarget)
+			}
+		}
 	}
 
 	p.logger.Debug("emberplus: MatrixConnect",


### PR DESCRIPTION
## Summary

[matrix.State.CanConnect](internal/emberplus/codec/matrix/state.go#L175) rejected an `oneToOne` SET when the requested source was already routed to another target with a spec-literal error: `"source N already used by target M [spec p.33]"`. Real-world `oneToOne` provider behaviour is **source-steal**: setting `src=A` on `tgt=B` implicitly disconnects `A` from its prior target.

Every shipping Ember+ provider (Lawo VSM, EmberPlusView, TinyEmber+) source-steals on receive; the consumer-side pre-validation was blocking the request from ever reaching the wire.

Same precedent as `feedback_probel_salvo_connected`: when every shipping controller contradicts a literal spec clause, the connector aligns with the controllers. The provider's `applyMatrixConnections` already implements source-steal correctly.

## Changes

- **state.go** `CanConnect`: removes the oneToOne source-exclusivity branch. Cardinality-1 invariant (each target has at most 1 source) still enforced.
- **state.go**: new exported `DetectOneToOneSourceSteal(target, sources)` helper that reports the `(FromTarget, Source)` pairs whose source would be implicitly stolen by the requested SET. Returns nil for non-oneToOne.
- **compliance_events.go**: new `OneToOneSourceStealAccepted` constant naming the deviation.
- **plugin.go** `MatrixConnect`: after `CanConnect` passes, calls `DetectOneToOneSourceSteal` and fires one compliance event per stolen-source pair so operators see the deviation in `dhs consumer emberplus profile`.

## Test plan

- `state_test.go` `TestCanConnect_OneToOne_SourceStealAccepted` replaces `TestCanConnect_OneToOne_SourceExclusive`: source-already-used is now accepted (was rejected pre-#465); cardinality-1 still rejects 2+ sources on a target.
- `state_test.go` `TestDetectOneToOneSourceSteal` pins the helper across 4 scenarios — steal, unrouted source, self-routed source, non-oneToOne matrix.
- `go test ./internal/emberplus/...` — 6 packages green
- `go build -o bin/dhs.exe ./cmd/dhs` — clean

Live verification queued for after #464 (16×16 oneToOne) lands on main; pre-#464 the 4×4 matrix doesn't have enough source-range to make the deviation visually obvious.

## Out of scope

- Provider-side compliance event when source-steal actually happens on receive (currently the consumer-side fires the event pre-flight when it has matrixState; a provider serving the same matrix to OTHER consumers would not emit). Separate concern — file if needed.
- Updating Wireshark dissector to flag source-steal Connections — `dhs_emberplus.lua` would need a stateful tracker; outside this scope.

Refs #465
