### PR TITLE
feat(emberplus/consumer): stream --id accepts CSV for multi-subscribe (refs #478)

### DIFF
--- a/cmd/dhs/cmd_stream.go
+++ b/cmd/dhs/cmd_stream.go
@@ -14,21 +14,59 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 
 	"dhs/internal/consumer"
 	emberplus "dhs/internal/emberplus/consumer"
 )
 
+// parseStreamIDList parses the --id CSV form for cmd stream (R10 multi-subscribe).
+// "" → nil (subscribe to every stream).
+// "0" → [0].
+// "0,1001" → [0, 1001].
+// "0,0,1001" → [0, 1001] (de-duped).
+// Bad tokens return a "validation:" error so the CLI exits non-zero.
+func parseStreamIDList(csv string) ([]int64, error) {
+	csv = strings.TrimSpace(csv)
+	if csv == "" {
+		return nil, nil
+	}
+	seen := make(map[int64]struct{})
+	var out []int64
+	for _, tok := range strings.Split(csv, ",") {
+		tok = strings.TrimSpace(tok)
+		if tok == "" {
+			return nil, fmt.Errorf("validation: --id: empty token in %q", csv)
+		}
+		n, perr := strconv.ParseInt(tok, 10, 64)
+		if perr != nil {
+			return nil, fmt.Errorf("validation: --id: bad token %q", tok)
+		}
+		if _, dup := seen[n]; dup {
+			continue
+		}
+		seen[n] = struct{}{}
+		out = append(out, n)
+	}
+	return out, nil
+}
+
 func runStream(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("stream", flag.ExitOnError)
 	cf := addCommonFlags(fs)
-	streamID := fs.Int64("id", -1, "streamIdentifier filter (-1 = any)")
+	streamIDs := fs.String("id", "", `streamIdentifier filter — comma-separated list (e.g. "0,1001,1002"); empty subscribes to every stream`)
 	dmIdentity := fs.String("dm", "", `Ember+ only: identity-keyed DM hot-load (e.g. "Tiny Ember+ Router@1.6.2"). When set, the tree is seeded from .cache/dm/emberplus/<identity>.json and the per-call walk is skipped — refs #438, ADR-0022.`)
 	host, rest, err := popHost(args)
 	if err != nil {
-		return fmt.Errorf("usage: dhs consumer <proto> stream <host> [--id N]")
+		return fmt.Errorf("usage: dhs consumer <proto> stream <host> [--id N[,M,...]]")
 	}
 	_ = fs.Parse(rest)
+
+	filter, err := parseStreamIDList(*streamIDs)
+	if err != nil {
+		return err
+	}
 
 	plug, cleanup, err := connect(ctx, host, cf)
 	if err != nil {
@@ -57,7 +95,7 @@ func runStream(ctx context.Context, args []string) error {
 	// Find every parameter with a streamIdentifier. If --id is set,
 	// filter to only that one; otherwise subscribe to all streamed
 	// parameters. The walker has already populated the tree.
-	paths := ep.StreamParameterPaths(*streamID)
+	paths := ep.StreamParameterPaths(filter)
 	if len(paths) == 0 {
 		return fmt.Errorf("emberplus: no parameters with streamIdentifier found (walk a provider that exposes streams)")
 	}
@@ -109,10 +147,11 @@ OUT  subscribing to 12 stream parameter(s)
      …  (runs until Ctrl-C)
 
 USAGE
-  acp stream <host> [--port 9092] [--id N]
+  acp stream <host> [--port 9092] [--id N[,M,...]]
 
 FLAGS
-  --id N          filter by streamIdentifier (default: any)
+  --id LIST       streamIdentifier filter — comma-separated list of int64
+                  (e.g. "0,1001,1002"). Empty subscribes to every stream.
   [global flags accepted: --port, --timeout, --verbose]
 
 BEHAVIOUR
@@ -126,6 +165,8 @@ BEHAVIOUR
 EXAMPLES
   acp stream 127.0.0.1 --port 9092
   acp stream 127.0.0.1 --port 9092 --id 45
+  acp stream 127.0.0.1 --port 9092 --id 0,1001
+  acp stream 127.0.0.1 --port 9092 --id 0,1001,1002
 
 References: Ember+ Documentation v2.50 pp. 22, 29-31, 86, 93.`)
 }

--- a/cmd/dhs/cmd_stream_test.go
+++ b/cmd/dhs/cmd_stream_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseStreamIDList(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    []int64
+		wantErr string
+	}{
+		{name: "empty subscribes to all", in: "", want: nil},
+		{name: "whitespace only subscribes to all", in: "   ", want: nil},
+		{name: "single id", in: "0", want: []int64{0}},
+		{name: "single positive id", in: "1001", want: []int64{1001}},
+		{name: "csv two", in: "0,1001", want: []int64{0, 1001}},
+		{name: "csv three", in: "0,1001,1002", want: []int64{0, 1001, 1002}},
+		{name: "csv with spaces", in: " 0 , 1001 ,1002 ", want: []int64{0, 1001, 1002}},
+		{name: "negative id allowed", in: "-7", want: []int64{-7}},
+		{name: "dedup preserves first-seen order", in: "0,0,1001,0,1001", want: []int64{0, 1001}},
+
+		{name: "bad token alpha", in: "abc", wantErr: `bad token "abc"`},
+		{name: "bad token mid-csv", in: "0,abc", wantErr: `bad token "abc"`},
+		{name: "bad token trailing", in: "0,1001,xyz", wantErr: `bad token "xyz"`},
+		{name: "empty token mid-csv", in: "0,,1001", wantErr: "empty token"},
+		{name: "trailing comma", in: "0,1001,", wantErr: "empty token"},
+		{name: "leading comma", in: ",0,1001", wantErr: "empty token"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseStreamIDList(tc.in)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("parseStreamIDList(%q) = %v, want error containing %q", tc.in, got, tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("parseStreamIDList(%q) error = %q, want substring %q", tc.in, err.Error(), tc.wantErr)
+				}
+				if !strings.HasPrefix(err.Error(), "validation:") {
+					t.Errorf("parseStreamIDList(%q) error = %q, want validation: prefix", tc.in, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseStreamIDList(%q) unexpected error: %v", tc.in, err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("parseStreamIDList(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/emberplus/consumer/plugin.go
+++ b/internal/emberplus/consumer/plugin.go
@@ -970,15 +970,26 @@ func (p *Plugin) MatrixConnect(ctx context.Context, matrixPath string, target in
 }
 
 // StreamParameterPaths returns the numeric paths of every parameter
-// that carries a streamIdentifier. If filter >= 0 the result is limited
-// to that one streamIdentifier. Used by cmd stream (A8).
-func (p *Plugin) StreamParameterPaths(filter int64) []string {
+// that carries a streamIdentifier. If filter is empty, every stream
+// parameter is returned. Otherwise the result is limited to parameters
+// whose streamIdentifier appears in filter (R10 multi-subscribe).
+// Used by cmd stream (A8).
+func (p *Plugin) StreamParameterPaths(filter []int64) []string {
 	p.subsMu.RLock()
 	defer p.subsMu.RUnlock()
+	var allow map[int64]struct{}
+	if len(filter) > 0 {
+		allow = make(map[int64]struct{}, len(filter))
+		for _, id := range filter {
+			allow[id] = struct{}{}
+		}
+	}
 	var out []string
 	for id, paths := range p.streamIndex {
-		if filter >= 0 && id != filter {
-			continue
+		if allow != nil {
+			if _, ok := allow[id]; !ok {
+				continue
+			}
 		}
 		out = append(out, paths...)
 	}

--- a/internal/emberplus/consumer/stream_filter_test.go
+++ b/internal/emberplus/consumer/stream_filter_test.go
@@ -1,0 +1,66 @@
+package emberplus
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// TestStreamParameterPaths_Filter pins the R10 multi-subscribe contract:
+//   - nil / empty filter → return every indexed stream path
+//   - single-id filter → only paths registered under that id
+//   - multi-id filter → paths registered under any matching id (set union)
+//   - unknown id in filter → ignored, not an error
+func TestStreamParameterPaths_Filter(t *testing.T) {
+	p := &Plugin{
+		streamIndex: map[int64][]string{
+			0:    {"1.4.1"},
+			1001: {"1.4.2"},
+			1002: {"1.4.3"},
+		},
+	}
+
+	tests := []struct {
+		name   string
+		filter []int64
+		want   []string
+	}{
+		{name: "nil filter returns all", filter: nil, want: []string{"1.4.1", "1.4.2", "1.4.3"}},
+		{name: "empty slice returns all", filter: []int64{}, want: []string{"1.4.1", "1.4.2", "1.4.3"}},
+		{name: "single id 0", filter: []int64{0}, want: []string{"1.4.1"}},
+		{name: "single id 1001", filter: []int64{1001}, want: []string{"1.4.2"}},
+		{name: "two ids", filter: []int64{0, 1001}, want: []string{"1.4.1", "1.4.2"}},
+		{name: "all ids explicit", filter: []int64{0, 1001, 1002}, want: []string{"1.4.1", "1.4.2", "1.4.3"}},
+		{name: "unknown id ignored", filter: []int64{42}, want: nil},
+		{name: "known + unknown id", filter: []int64{0, 42}, want: []string{"1.4.1"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := p.StreamParameterPaths(tc.filter)
+			sort.Strings(got)
+			want := append([]string(nil), tc.want...)
+			sort.Strings(want)
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("StreamParameterPaths(%v) = %v, want %v", tc.filter, got, want)
+			}
+		})
+	}
+}
+
+// TestStreamParameterPaths_MultiPathPerID covers the case where one
+// streamIdentifier is shared by multiple parameters (legal per spec p.93).
+func TestStreamParameterPaths_MultiPathPerID(t *testing.T) {
+	p := &Plugin{
+		streamIndex: map[int64][]string{
+			7: {"1.4.1", "1.4.2", "1.4.3"},
+			9: {"1.5.1"},
+		},
+	}
+	got := p.StreamParameterPaths([]int64{7})
+	sort.Strings(got)
+	want := []string{"1.4.1", "1.4.2", "1.4.3"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("StreamParameterPaths([7]) = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- `dhs consumer emberplus stream --id` accepts a CSV of streamIdentifier ints
- Filter is set-membership: `--id 0,1001` subscribes to those two streams only
- Empty / absent flag still subscribes to every stream (was `--id -1`)
- Validation errors carry the `validation:` prefix (`bad token`, `empty token`)

## Behavior matrix

| Flag form | Behavior |
|---|---|
| `--id 0` | filter to {0} (same as today) |
| `--id 0,1001` | filter to {0, 1001} (NEW) |
| `--id 0,1001,1002` | filter to {0, 1001, 1002} (explicit "all") |
| `--id ""` / absent | subscribe to every stream |
| `--id abc` | `validation: --id: bad token "abc"` |
| `--id 0,,1001` | `validation: --id: empty token in "0,,1001"` |
| `--id 0,0,1001` | de-duped to {0, 1001} silently |

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` green across all packages (cmd/dhs + every protocol)
- [x] `cmd_stream_test.go` pins parseStreamIDList — 15 cases (happy CSV, dedup, negatives, bad tokens, empty tokens, leading/trailing comma)
- [x] `stream_filter_test.go` pins `StreamParameterPaths([]int64{...})` — nil/empty returns all, single id, two-id union, all-ids explicit, unknown id ignored, known+unknown mix, multi-path-per-id
- [ ] **Live verify (codeowner)**: against the integration demo with 3 streams (vu_zero=0, vu_left=1001, vu_right=1002):
  - `stream --id 0,1001` → only vu_zero + vu_left emit
  - `stream --id 0,1001,1002` → all three emit (equivalent to absent flag)
  - `stream --id abc` → exit non-zero, stderr `validation: --id: bad token "abc"`

## Refs

Refs #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)
