### PR TITLE
docs(emberplus): operational runbook — verb walkthrough + use-case status + R-item tracking

### DIFF
--- a/internal/emberplus/docs/runbook.md
+++ b/internal/emberplus/docs/runbook.md
@@ -1,8 +1,9 @@
 # Ember+ — operational runbook
 
-> Status: **PR δ in progress** — draft under codeowner review.
+> Status: **draft** under codeowner review (this PR).
 > Source-of-truth for verb-by-verb validation against the
-> integration-test fixture set. Capture batch (PR γ) lands separately.
+> integration-test fixture set. The capture batch (per-type fixtures
+> under `internal/emberplus/testdata/protocol_types/`) lands separately.
 
 ## Scope
 
@@ -69,26 +70,49 @@ Every matrix carries `sourceParams[N].gain`, `targetParams[N].gain`, and (nToN o
 
 ## Verb catalogue
 
-| Verb | Wire shape | Returns |
+| Verb | Status | Wire shape | Returns |
+|---|---|---|---|
+| `info` | ✅ | GetDirectory(root) + identity walk | per-slot online + status |
+| `walk` | ✅ | GetDirectory recursive | every object in the tree |
+| `get` | ✅ | GetDirectory(path) | one value |
+| `set` | ✅ | SetValue | confirmed value (or ValidationError) |
+| `watch` | ✅ | Subscribe(30) on streams + implicit on params/matrices | live stream of value/connection changes |
+| `matrix` | ✅ | Connect/Disconnect/Absolute on a Matrix | applied connection state |
+| `invoke` | ✅ | Invoke + InvocationResult | tuple result + Success=true/false |
+| `stream` | ✅ | Subscribe(30) on streamIdentifier filter | stream feed |
+| `profile` | ✅ | Walk + count compliance.Profile events | classification (strict / partial) |
+| `export` | 🟡 | Walk + write JSON/YAML/CSV | file at `--out` (Glow-type coverage gap — [#461](https://github.com/by-openclaw/go-acp/issues/461)) |
+| `import` | 🟡 | Read JSON/YAML/CSV + apply | tree state on remote (same gap) |
+| `extract` | ✅ | Walk + write per-product DM (meta+wire+tree) | files in fixture layout |
+| `diff` | ✅ | Two tree.json compared | text diff or CHANGELOG section |
+| `convert` | ✅ | Translate between JSON / YAML / CSV | offline file write |
+| `validate` | ✅ | Decode captured `frames.jsonl` through codec | PASS/FAIL per frame |
+| `bench` | 🟡 | Fire N matrix ops over 1 TCP session | total + ops/s (RFC 2544 + percentiles + cold-start pending [#474](https://github.com/by-openclaw/go-acp/issues/474)) |
+| `health` | ❌ **TODO** | 3-layer session liveness | not wired for Ember+ — [#300](https://github.com/by-openclaw/go-acp/issues/300) (consumer + provider) |
+| `discover` | ❌ **TODO** | mDNS scan on `_ember._tcp.local.` | pending [#477](https://github.com/by-openclaw/go-acp/issues/477) (consumer + provider) |
+
+Legend: ✅ working · 🟡 partial · ❌ not implemented.
+
+---
+
+## Addressing — by path vs by OID
+
+Every Ember+ object has two addresses: a **numeric OID** (e.g. `1.6.1`) and a **dotted label path** (e.g. `dhs-emberplus-integration.types.vInteger`). The runbook shows the **dotted path** form in commands; the **OID** is printed as a comment alongside each Happy-path example so operators can cross-reference Wireshark dissector output (`dhs_emberplus.*` fields) and capture files.
+
+Top-level OID map (current integration-test provider):
+
+| OID | Label | Notes |
 |---|---|---|
-| `info` | GetDirectory(root) + identity walk | per-slot online + status |
-| `walk` | GetDirectory recursive | every object in the tree |
-| `get` | GetDirectory(path) | one value |
-| `set` | SetValue | confirmed value (or ValidationError) |
-| `watch` | Subscribe(30) on streams + implicit on params/matrices | live stream of value/connection changes |
-| `matrix` | Connect/Disconnect/Absolute on a Matrix | applied connection state |
-| `invoke` | Invoke + InvocationResult | tuple result + Success=true/false |
-| `stream` | Explicit subscribe to streamIdentifier | stream feed |
-| `profile` | Walk + count compliance.Profile events | classification (strict / partial) |
-| `export` | Walk + write JSON/YAML/CSV | file at --out |
-| `import` | Read JSON/YAML/CSV + apply | tree state on remote |
-| `extract` | Walk + write per-product DM (meta+wire+tree) | files in fixture layout |
-| `diff` | Two tree.json compared | text diff or CHANGELOG section |
-| `convert` | Translate between JSON / YAML / CSV | offline file write |
-| `validate` | Decode captured frames.jsonl through codec | offline decoder check |
-| `bench` | Fire N matrix ops over 1 TCP session | latency + ops/s |
-| `health` | 3-layer session liveness | not implemented for Ember+ (#300) |
-| `discover` | mDNS scan | no mDNS for Ember+ today |
+| `1` | `dhs-emberplus-integration` | synthetic root |
+| `1.0` | `identity` | product / company / version / dtdVersion |
+| `1.1` | `oneToN` | 16×16 matrix |
+| `1.2` | `oneToOne` | 16×16 matrix |
+| `1.3` | `nToN` | 16×16 matrix |
+| `1.4` | `dynamic` | 128×128 declared, 16 sparse |
+| `1.5` | `functions` | builtins |
+| `1.6` | `types` | every ParameterType + 3 streams |
+
+> Today `--path` accepts the dotted label form only. Accepting OIDs in `--path` (e.g. `--path 1.6.1`) so operators can address by either form is pending **R21** (per memory `project_path_by_id`).
 
 ---
 
@@ -98,18 +122,21 @@ Every matrix carries `sourceParams[N].gain`, `targetParams[N].gain`, and (nToN o
 
 ```powershell
 .\bin\dhs.exe consumer emberplus info 127.0.0.1 --port 9100
+# OID = 1 (root)
 ```
 
 Expected:
 
 ```
 device       127.0.0.1:9100
-protocol     emberplus v1
+protocol     emberplus v1                ← TODO: surface DTD `2.60` from identity, not "v1" — R6 #470
 slots        1
 
 per-slot status:
   slot  0   status=present    online=true        ← post #459
 ```
+
+> The `protocol emberplus v1` line shows the internal plugin version, not the device's Ember+ DTD revision. **R6 [#470](https://github.com/by-openclaw/go-acp/issues/470)** rewires `info` to read `identity.dtdVersion` from the device and display the real DTD revision (e.g. `dtd 2.60`).
 
 ### Errors
 
@@ -127,16 +154,23 @@ per-slot status:
 
 ```powershell
 .\bin\dhs.exe consumer emberplus walk 127.0.0.1 --port 9100 --capture .audit\walks\demo.jsonl
+# OID = 1 (root) — recursive
 ```
 
-Expected: 548 lines of tree dump, `tree_size=1361` objects, DM auto-extracted to `.cache/dm/emberplus/dhs-emberplus-integration@1.0.0.json` for subsequent `--dm` hot-load.
+Expected: ≈548 lines of tree dump, `tree_size ≈ 1361` objects. Two files written:
+
+- `--capture` target: [.audit/walks/demo.jsonl](../../../.audit/walks/demo.jsonl) — raw S101 frames (hex + dir + ts per line, one frame per line) — per ADR-0021
+- DM auto-extract: [.cache/dm/emberplus/dhs-emberplus-integration@1.0.0.json](../../../.cache/dm/emberplus/) — feeds the `--dm` hot-load on subsequent verbs (per ADR-0022 card data model)
+
+> The DM file is the same byte-for-byte shape as the source-of-truth fixture at [`internal/emberplus/testdata/integration-test/dm/emberplus/`](../testdata/integration-test/dm/emberplus/). Captured walk → cached DM → hot-load saves the per-call wire walk on subsequent verbs.
 
 ### Errors
 
-| Trigger | Command | Expected |
-|---|---|---|
-| connection refused | `walk ... --port 9999` | s101 framing error |
-| timeout too small | `walk ... --timeout 1ms` | walk for "walk": context deadline exceeded |
+| Trigger | Command | Expected | Exit |
+|---|---|---|---|
+| connection refused | `walk ... --port 9999` | s101 framing error | 1 |
+| timeout too small | `walk ... --timeout 1ms` | `walk for "walk": context deadline exceeded` | 1 |
+| missing host | `walk --port 9100` | usage error | 2 |
 
 ---
 
@@ -144,44 +178,39 @@ Expected: 548 lines of tree dump, `tree_size=1361` objects, DM auto-extracted to
 
 ### Happy
 
+| OID | Path | Example value |
+|---|---|---|
+| `1.6.1` | `types.vInteger` | `42` |
+| `1.6.2` | `types.vReal` | `3.14` (factor=100, format=`%.2f`, unit=dB) |
+| `1.6.3` | `types.vString` | `"hello"` |
+| `1.6.4` | `types.vBoolean` | `true` |
+| `1.6.5` | `types.vTrigger` | trigger-type (read-only "tap") |
+| `1.6.6` | `types.vEnum` | `1` (enumMap: Off=0, Low=1, Medium=2, High=3) |
+| `1.6.7` | `types.vOctets` | `"aGVsbG8="` (known broken in some UIs; wire OK) |
+| `1.6.10` | `types.vu_zero` | `-60.00` (streamIdentifier=0 — must NOT be treated as absent) |
+| `1.6.11` | `types.vu_left` | live stream |
+| `1.6.12` | `types.vu_right` | live stream |
+| `1.0.4` | `identity.dtdVersion` | `"2.60"` |
+
 ```powershell
-# Each ParameterType
 .\bin\dhs.exe consumer emberplus get 127.0.0.1 --port 9100 --path dhs-emberplus-integration.types.vInteger
+# OID = 1.6.1
 # value = 42
 
-.\bin\dhs.exe consumer emberplus get 127.0.0.1 --port 9100 --path dhs-emberplus-integration.types.vReal
-# value = 3.14    (carries factor=100, format=%.2f, unit=dB)
-
-.\bin\dhs.exe consumer emberplus get 127.0.0.1 --port 9100 --path dhs-emberplus-integration.types.vString
-# value = "hello"
-
-.\bin\dhs.exe consumer emberplus get 127.0.0.1 --port 9100 --path dhs-emberplus-integration.types.vBoolean
-# value = true
-
-.\bin\dhs.exe consumer emberplus get 127.0.0.1 --port 9100 --path dhs-emberplus-integration.types.vEnum
-# value = 1    (enumMap: Off=0, Low=1, Medium=2, High=3)
-
-.\bin\dhs.exe consumer emberplus get 127.0.0.1 --port 9100 --path dhs-emberplus-integration.types.vOctets
-# value = "aGVsbG8="    (known broken in Cerebrum + EmberPlusView UIs, wire OK)
-
-# Stream parameters (id=0 + id>0)
-.\bin\dhs.exe consumer emberplus get 127.0.0.1 --port 9100 --path dhs-emberplus-integration.types.vu_zero
-# value = -60.00    (streamIdentifier=0 — must NOT be treated as absent)
-
-.\bin\dhs.exe consumer emberplus get 127.0.0.1 --port 9100 --path dhs-emberplus-integration.types.vu_left
-# value ≈ -60.00 → updates live
-
-# Identity
 .\bin\dhs.exe consumer emberplus get 127.0.0.1 --port 9100 --path dhs-emberplus-integration.identity.dtdVersion
+# OID = 1.0.4
 # value = "2.60"
 ```
 
+> Address by OID directly (`--path 1.6.1`) is pending **R21** (per [Addressing](#addressing--by-path-vs-by-oid)).
+
 ### Errors
 
-| Trigger | Command | Expected |
-|---|---|---|
-| wrong path | `get ... --path bogus.path.here` | `object not found (tree has 1361 entries)` |
-| missing required path | `get 127.0.0.1 --port 9100` | usage error |
+| Trigger | Command | Expected | Exit |
+|---|---|---|---|
+| wrong path | `get ... --path bogus.path.here` | `object not found (tree has 1361 entries)` | 1 |
+| missing required path | `get 127.0.0.1 --port 9100` | usage error | 2 |
+| connection refused | `get ... --port 9999` | s101 framing error | 1 |
 
 ---
 
@@ -192,6 +221,7 @@ Expected: 548 lines of tree dump, `tree_size=1361` objects, DM auto-extracted to
 ```powershell
 .\bin\dhs.exe consumer emberplus set 127.0.0.1 --port 9100 `
     --path dhs-emberplus-integration.nToN.targetParams.0.gain --value -25
+# OID = 1.3.targetParams.0.gain  (numeric form varies by parametersLocation seed)
 # confirmed value = -25
 
 .\bin\dhs.exe consumer emberplus set 127.0.0.1 --port 9100 `
@@ -200,51 +230,80 @@ Expected: 548 lines of tree dump, `tree_size=1361` objects, DM auto-extracted to
 
 .\bin\dhs.exe consumer emberplus set 127.0.0.1 --port 9100 `
     --path dhs-emberplus-integration.types.vEnum --value 3
+# OID = 1.6.6
 # confirmed value = 3
 ```
 
+> Out-of-range / step-mismatch / enum-by-label semantics pending **R16** (not yet filed).
+
 ### Errors (post #453)
 
-| Trigger | Command | Expected |
-|---|---|---|
-| unparseable int (#445) | `set ... gain --value -25.5` | `validation: value: invalid integer "-25.5"`, exit 2 |
-| unparseable int (letters) | `set ... gain --value abc` | `validation: value: invalid integer "abc"`, exit 2 |
-| unparseable real | `set ... vReal --value not-a-float` | `validation: value: invalid real "not-a-float"`, exit 2 |
-| enum overflow | `set ... vEnum --value 999` | `validation: value: invalid enum index "999"`, exit 2 |
-| write to read-only stream | `set ... vu_zero --value -10` | protocol error (provider rejects) |
-| wrong path | `set --path bogus --value 1` | object not found |
+| Trigger | Command | Expected | Exit |
+|---|---|---|---|
+| unparseable int (#445) | `set ... gain --value -25.5` | `validation: value: invalid integer "-25.5"` | 2 |
+| unparseable int (letters) | `set ... gain --value abc` | `validation: value: invalid integer "abc"` | 2 |
+| unparseable real | `set ... vReal --value not-a-float` | `validation: value: invalid real "not-a-float"` | 2 |
+| enum overflow | `set ... vEnum --value 999` | `validation: value: invalid enum index "999"` | 2 |
+| write to read-only stream | `set ... vu_zero --value -10` | protocol error (provider rejects) | 1 |
+| wrong path | `set --path bogus --value 1` | `object not found` | 1 |
 
 ---
 
-## 5. `watch` — live stream
+## 5. `watch` — live updates
+
+Three event sources, all delivered through the same `watch` feed:
+
+| Source | What it carries | Default behaviour |
+|---|---|---|
+| **stream params** | `streamIdentifier` payload — high-frequency vu / fader values | gated by Subscribe(30); use `--streams-only` to limit to these |
+| **glow params** | Parameter value-change announces (non-stream) | per `internal/emberplus/CLAUDE.md` "Known deviations" — provider broadcasts plain-Parameter announces to every connected session (libember-cpp / Lawo parity); no explicit subscribe required |
+| **matrix tally** | `Matrix.Connection` change announces (crosspoint set / disconnect) | as soon as the walker discovers a `Matrix` element, the consumer is implicitly subscribed; you receive every tally change without an explicit `Subscribe`. Default is "subscribe to changes", not "stream + glow" — adjust with `--streams-only` or `--path` to scope |
 
 ### Happy
 
 ```powershell
-# Watch all stream Parameters (3 streams: id=0, 1001, 1002)
+# All updates — stream + glow + matrix tally — one merged feed
+.\bin\dhs.exe consumer emberplus watch 127.0.0.1 --port 9100
+# OID scope = 1 (root) — every announce flows through
+
+# Streams only (suppress glow + tally noise)
 .\bin\dhs.exe consumer emberplus watch 127.0.0.1 --port 9100 --streams-only
 # Updates every ~500ms
 
-# Watch one specific path
+# Watch one stream Parameter
 .\bin\dhs.exe consumer emberplus watch 127.0.0.1 --port 9100 `
     --path dhs-emberplus-integration.types.vu_zero --streams-only
-# Only vu_zero updates
+# OID = 1.6.10 — only vu_zero updates
 
-# Watch the locked-target tally on oneToN
+# Watch a glow Parameter (non-stream) — change-of-value announces
+.\bin\dhs.exe consumer emberplus watch 127.0.0.1 --port 9100 `
+    --path dhs-emberplus-integration.nToN.targetParams.0.gain
+# Emits whenever target-0 gain changes (set by us or another session)
+
+# Watch matrix tally — every crosspoint connect/disconnect on the matrix
 .\bin\dhs.exe consumer emberplus watch 127.0.0.1 --port 9100 `
     --path dhs-emberplus-integration.oneToN.matrix
+# OID = 1.1 — tally announces fire on every Connect / Disconnect / Absolute
 ```
 
 ### Errors
 
-| Trigger | Command | Expected |
-|---|---|---|
-| connection refused | `watch ... --port 9999` | s101 framing error |
-| bad path filter | `watch --path bogus` | no events (filter matches nothing) |
+| Trigger | Command | Expected | Exit |
+|---|---|---|---|
+| connection refused | `watch ... --port 9999` | s101 framing error | 1 |
+| bad path filter | `watch --path bogus` | no events (filter matches nothing); exits clean on Ctrl-C | 0 / 1 |
+| missing host | `watch --port 9100` | usage error | 2 |
 
 ---
 
 ## 6. `matrix` — Connect / Disconnect / Absolute
+
+| Matrix | OID | Type | Capacity |
+|---|---|---|---|
+| oneToN | `1.1` | one source per target; multiple targets may share a source | 16×16 |
+| oneToOne | `1.2` | strict 1:1 — source-steal accepted (post #467) | 16×16 |
+| nToN | `1.3` | up to 4 sources/target, 64 total | 16×16 |
+| dynamic | `1.4` | sparse — 16 of 128² declared | 128×128 |
 
 ### Happy
 
@@ -253,6 +312,7 @@ Expected: 548 lines of tree dump, `tree_size=1361` objects, DM auto-extracted to
 .\bin\dhs.exe consumer emberplus matrix 127.0.0.1 --port 9100 `
     --path dhs-emberplus-integration.nToN.matrix `
     --target 10 --sources 3,4,5 --op absolute
+# OID = 1.3
 # matrix connect: target 10 ← sources [3 4 5] (op=absolute)
 
 # nToN — disconnect one source
@@ -265,110 +325,143 @@ Expected: 548 lines of tree dump, `tree_size=1361` objects, DM auto-extracted to
 .\bin\dhs.exe consumer emberplus matrix 127.0.0.1 --port 9100 `
     --path dhs-emberplus-integration.oneToN.matrix `
     --target 0 --sources 7 --op absolute
-# (target 0 now routed from src 7; prior src 0 dropped)
+# OID = 1.1 — target 0 now routed from src 7; prior src 0 dropped
 
 # oneToOne — source steal (post #467)
 .\bin\dhs.exe consumer emberplus matrix 127.0.0.1 --port 9100 `
     --path dhs-emberplus-integration.oneToOne.matrix `
     --target 0 --sources 5 --op absolute
-# matrix connect: target 0 ← sources [5] (op=absolute)
+# OID = 1.2 — matrix connect: target 0 ← sources [5] (op=absolute)
 # Source 5 was on target 5; now stolen to target 0 — target 5 implicitly disconnected.
 # Profile counter: onetoone_source_steal_accepted += 1
 ```
 
 ### Errors
 
-| Trigger | Command | Expected |
-|---|---|---|
-| oneToN over-cardinality | `matrix oneToN --target 0 --sources 1,2 --op absolute` | `matrix validation: oneToN matrix: target 0 would have 2 sources (max 1) [spec p.33]`, exit 1 |
-| nToN over capacity | `matrix nToN --target 0 --sources 0,1,2,3,4,5 --op absolute` | `matrix validation: nToN matrix: target 0 would have 5 sources (max 4 per target)`, exit 1 |
-| locked target | `matrix oneToN --target 2 --sources 5 --op absolute` | rejected by provider; tally announce echoes back unchanged with `disposition: locked` |
-| wrong matrix path | `matrix --path bogus` | matrix not found at path "bogus" |
+| Trigger | Command | Expected | Exit |
+|---|---|---|---|
+| oneToN over-cardinality | `matrix oneToN --target 0 --sources 1,2 --op absolute` | `matrix validation: oneToN matrix: target 0 would have 2 sources (max 1) [spec p.33]` | 1 |
+| nToN over capacity | `matrix nToN --target 0 --sources 0,1,2,3,4,5 --op absolute` | `matrix validation: nToN matrix: target 0 would have 5 sources (max 4 per target)` | 1 |
+| locked target | `matrix oneToN --target 2 --sources 5 --op absolute` | rejected by provider; tally announce echoes back unchanged with `disposition: locked` | 1 |
+| wrong matrix path | `matrix --path bogus` | `matrix not found at path "bogus"` | 1 |
+| missing target | `matrix ... --sources 1` (no `--target`) | usage error | 2 |
 
 ---
 
 ## 7. `invoke` — function RPC
 
+Function subtree at OID `1.5` carries six builtins:
+
+| OID | Path | Args (tuple) | Returns |
+|---|---|---|---|
+| `1.5.1` | `functions.setLock` | `(matrixRef, target, locked)` | `[previousLockState]` |
+| `1.5.2` | `functions.listLocks` | `(matrixRef)` | `[list of locked target indices]` |
+| `1.5.3` | `functions.storeSalvo` | `(matrixRef, slot, label)` | `[true]` |
+| `1.5.4` | `functions.recallSalvo` | `(matrixRef, slot)` | `[rowsRestored]` |
+| `1.5.5` | `functions.listSalvos` | `(matrixRef)` | `[list of slot IDs]` |
+| `1.5.6` | `functions.getSalvo` | `(matrixRef, slot)` | `[serialized tgt=src list]` — human format pending **R11** |
+
+`matrixRef` accepts both OID (`1.1.3` → `oneToN.matrix`) and dotted path (`dhs-emberplus-integration.oneToN.matrix`) post #466.
+
 ### Happy
 
 ```powershell
-# Lock target 3 on oneToN (matrix-OID or dotted path both work)
+# Lock target 3 on oneToN — by matrix OID
 .\bin\dhs.exe consumer emberplus invoke 127.0.0.1 --port 9100 `
     --path dhs-emberplus-integration.functions.setLock `
     --args "1.1.3,3,true"
-# invocation 1: success=true
-# result: [false]       (previous lock state — was unlocked)
+# OID = 1.5.1 — invocation 1: success=true
+# result: [false]       (previous lock state)
 
 # Same via dotted matrixRef (post #466)
 .\bin\dhs.exe consumer emberplus invoke 127.0.0.1 --port 9100 `
     --path dhs-emberplus-integration.functions.setLock `
     --args "dhs-emberplus-integration.oneToN.matrix,4,true"
-# invocation 1: success=true
-# result: [false]
+# invocation 1: success=true · result: [false]
 
 # List locked targets
 .\bin\dhs.exe consumer emberplus invoke 127.0.0.1 --port 9100 `
     --path dhs-emberplus-integration.functions.listLocks `
     --args "1.1.3"
-# result: [2,3,4]   (2 was pre-locked from seed)
+# OID = 1.5.2 — result: [2,3,4]   (2 was pre-locked from seed)
 
 # Store salvo — all current connections on oneToN
 .\bin\dhs.exe consumer emberplus invoke 127.0.0.1 --port 9100 `
     --path dhs-emberplus-integration.functions.storeSalvo `
     --args "1.1.3,99,"
-# result: [true]
+# OID = 1.5.3 — result: [true]
 
 # Get salvo dump
 .\bin\dhs.exe consumer emberplus invoke 127.0.0.1 --port 9100 `
     --path dhs-emberplus-integration.functions.getSalvo `
     --args "1.1.3,99"
-# result: ["0=0;1=1;3=3;..."]   (tgt=src list semicolon-separated)
+# OID = 1.5.6 — result: ["0=0;1=1;3=3;..."]   (tgt=src semicolon-separated; human format pending R11)
 
 # Recall salvo
 .\bin\dhs.exe consumer emberplus invoke 127.0.0.1 --port 9100 `
     --path dhs-emberplus-integration.functions.recallSalvo `
     --args "1.1.3,99"
-# result: [N]    (rows restored)
+# OID = 1.5.4 — result: [N]    (rows restored)
 ```
 
 ### Errors (post #455 / #457)
 
-| Trigger | Command | Expected |
-|---|---|---|
-| bogus matrixRef | `invoke setLock --args "bogus.path,1,true"` | `invocation 1: success=false` (was silent success pre-#457) |
-| missing arg | `invoke setLock --args "1.1.3"` | `setLock: need (matrixPath, target, locked)` |
-| wrong type arg | `invoke setLock --args "1.1.3,abc,true"` | bad arg types |
+| Trigger | Command | Expected | Exit |
+|---|---|---|---|
+| bogus matrixRef | `invoke setLock --args "bogus.path,1,true"` | `invocation 1: success=false` (was silent success pre-#457) | 1 |
+| missing arg | `invoke setLock --args "1.1.3"` | `setLock: need (matrixPath, target, locked)` | 1 |
+| wrong type arg | `invoke setLock --args "1.1.3,abc,true"` | bad arg types | 1 |
+| missing `--path` | `invoke --args "1.1.3,1,true"` | usage error | 2 |
 
 ---
 
 ## 8. `stream` — explicit subscribe
 
+Three streamIdentifier values declared by the integration-test provider:
+
+| streamIdentifier | OID | Path | Notes |
+|---|---|---|---|
+| `0` | `1.6.10` | `types.vu_zero` | id=0 is valid (NOT "absent") |
+| `1001` | `1.6.11` | `types.vu_left` | live audio meter |
+| `1002` | `1.6.12` | `types.vu_right` | live audio meter |
+
 ### Happy
 
 ```powershell
 .\bin\dhs.exe consumer emberplus stream 127.0.0.1 --port 9100 --id 0
-# Subscribes to streamIdentifier=0 only (vu_zero updates flow)
+# Subscribes to streamIdentifier=0 only (vu_zero at OID 1.6.10)
 
 .\bin\dhs.exe consumer emberplus stream 127.0.0.1 --port 9100 --id 1001
-# Subscribes to vu_left only
+# Subscribes to vu_left only (OID 1.6.11)
 
 .\bin\dhs.exe consumer emberplus stream 127.0.0.1 --port 9100 --id 0,1001
-# Subscribes to {vu_zero, vu_left} — R10 multi-subscribe
+# Subscribes to {vu_zero, vu_left} — R10 multi-subscribe post #479
 
 .\bin\dhs.exe consumer emberplus stream 127.0.0.1 --port 9100 --id 0,1001,1002
-# Subscribes to all three explicitly (equivalent to no flag)
+# All three explicitly (equivalent to no flag)
 
 .\bin\dhs.exe consumer emberplus stream 127.0.0.1 --port 9100
 # Subscribes to ALL streams (3 today)
 ```
 
+### Provider idle-eviction (pending R9 [#472](https://github.com/by-openclaw/go-acp/issues/472))
+
+If the consumer goes silent on S101 keepalive, the provider currently keeps streaming forever — accumulating dead subscribers. **R9** evicts an idle subscriber after N missed keepalive intervals (Subscribe(31) implicit on the provider side, free the slot).
+
+Today the operator-visible behavior on an abruptly-killed consumer:
+
+- producer log: `streamer pushed N frames to dead subscriber sid=...` (after R9: `streamer evicted idle subscriber sid=... idle=Xs`)
+- network: streams keep flowing to the consumer's port until OS-level FIN
+
 ### Errors
 
-| Case | Command | Error |
-|---|---|---|
-| bad token | `stream ... --id abc` | `validation: --id: bad token "abc"` |
-| empty token mid-csv | `stream ... --id 0,,1001` | `validation: --id: empty token in "0,,1001"` |
-| trailing comma | `stream ... --id 0,1001,` | `validation: --id: empty token in "0,1001,"` |
+| Case | Command | Error | Exit |
+|---|---|---|---|
+| bad token | `stream ... --id abc` | `validation: --id: bad token "abc"` | 2 |
+| empty token mid-csv | `stream ... --id 0,,1001` | `validation: --id: empty token in "0,,1001"` | 2 |
+| trailing comma | `stream ... --id 0,1001,` | `validation: --id: empty token in "0,1001,"` | 2 |
+| connection refused | `stream ... --port 9999` | s101 framing error | 1 |
+| missing host | `stream --port 9100` | usage error | 2 |
 
 ---
 
@@ -384,19 +477,41 @@ Expected: 548 lines of tree dump, `tree_size=1361` objects, DM auto-extracted to
 # no tolerance events observed — provider is fully spec-compliant
 ```
 
-After triggering source-steal (post #467), the counter `onetoone_source_steal_accepted` appears with its count.
+After triggering oneToOne source-steal (post #467), the counter `onetoone_source_steal_accepted` appears with its count.
+
+### Enhancements pending — R22 (not yet filed)
+
+Today `profile` aggregates into one classification line + an event count. The codeowner asked: could it be enhanced? Proposed scope for **R22**:
+
+| Enhancement | Today | After R22 |
+|---|---|---|
+| Per-event-kind breakdown | aggregate counter only | one row per `compliance.Event` kind with count + first/last timestamp |
+| Per-session attribution | n/a (aggregated across all sessions) | optional `--by-session` to group by remote peer |
+| Machine-readable output | text only | `--format json` for CI ingestion |
+| Time-windowed filter | n/a | `--since 5m` to only count recent events |
+| Event log dump | counter only | `--show-events` prints every observed `compliance.Event` with detail |
+
+### Errors
+
+| Trigger | Command | Expected | Exit |
+|---|---|---|---|
+| connection refused | `profile ... --port 9999` | s101 framing error | 1 |
+| missing host | `profile --port 9100` | usage error | 2 |
 
 ---
 
-## 10. `export` / `import` — round-trip (PARTIAL — #461)
+## 10. `export` / `import` — round-trip (PARTIAL — [#461](https://github.com/by-openclaw/go-acp/issues/461))
+
+Quick form:
 
 ```powershell
 .\bin\dhs.exe consumer emberplus export 127.0.0.1 --port 9100 --format yaml --out demo.yaml
-# Writes demo.yaml
-
 .\bin\dhs.exe consumer emberplus import demo.yaml --port 9100
-# (partial — Glow type coverage not complete; see #461)
 ```
+
+Full reference — `--format {json|yaml|csv}` matrix, partial-export header, `--dry-run` import with per-Glow-type pass/fail/skip tally, `--scope <path>` for sample exports, error codes, and the complete R4 [#461](https://github.com/by-openclaw/go-acp/issues/461) round-trip spec:
+
+→ **[`runbook/export-import.md`](runbook/export-import.md)**
 
 ---
 
@@ -406,17 +521,52 @@ After triggering source-steal (post #467), the counter `onetoone_source_steal_ac
 .\bin\dhs.exe consumer emberplus extract 127.0.0.1 --port 9100 `
     --manufacturer BY-Systems --product dhs-emberplus-integration `
     --direction in --version 1.0.0 --out .audit/extract-demo
+# OID = 1 (root) — recursive walk
 # Writes meta.json + wire.pcapng + tree.json under the fixture layout
 ```
+
+### Flags
+
+| Flag | Purpose | Example |
+|---|---|---|
+| `--manufacturer` | Manufacturer string baked into `meta.json` and the cache filename | `BY-Systems` |
+| `--product` | Product / Model name — drives `<Model@SwRev>.json` per ADR-0022 | `dhs-emberplus-integration` |
+| `--direction` | Capture direction from the **consumer's** perspective: `in` = device→consumer (announces, replies); `out` = consumer→device (commands). Stored in `meta.json` so replay tooling knows whether to feed frames forward or reverse | `in` |
+| `--version` | Software revision (SwRev) of the device being captured. Forms the cache filename `<Model@SwRev>.json` per ADR-0022. Multiple SwRev captures coexist side-by-side; the consumer hot-loads by exact match | `1.0.0` |
+| `--out` | Output directory; the triple `meta.json` + `wire.pcapng` + `tree.json` lands inside | `.audit/extract-demo` |
+
+Layout written:
+
+```
+.audit/extract-demo/
+├── meta.json     manufacturer + product + version + direction + capturedAt + protocol
+├── wire.pcapng   S101 frames replay-ready in Wireshark with dhs_emberplus.lua loaded
+└── tree.json     decoded Glow tree (same shape as .cache/dm/emberplus/<Model@SwRev>.json)
+```
+
+### Errors
+
+| Trigger | Command | Expected | Exit |
+|---|---|---|---|
+| target dir unwritable | `extract ... --out /no/perm/` | `extract: mkdir /no/perm: permission denied` | 1 |
+| missing required flag | `extract ... --product foo` (no `--version`) | usage error | 2 |
+| connection refused | `extract ... --port 9999` | s101 framing error | 1 |
+| invalid direction | `extract ... --direction sideways` | `validation: --direction: must be "in" or "out"` | 2 |
 
 ---
 
 ## 12. `validate` — offline frame decode (ADR-0021)
 
+Quick form:
+
 ```powershell
 .\bin\dhs.exe consumer emberplus validate captures/emberplus/runbook/walk-happy.jsonl
-# Decodes each frame through the codec; emits PASS / FAIL per frame
+# Decodes each frame through the codec; emits PASS / FAIL per frame + summary
 ```
+
+Full reference — Wireshark `--lua` mode ([#473](https://github.com/by-openclaw/go-acp/issues/473)), `--report <md|json>` structured report (R23 not yet filed), error codes, and the per-layer pass-rate table format:
+
+→ **[`runbook/validate.md`](runbook/validate.md)**
 
 ---
 
@@ -426,10 +576,32 @@ After triggering source-steal (post #467), the counter `onetoone_source_steal_ac
 .\bin\dhs.exe consumer emberplus bench 127.0.0.1 --port 9100 `
     --path dhs-emberplus-integration.nToN.matrix `
     --n 1000 --op connect --targets 16 --sources 16
-# total: 1000 ops in N ms, M ops/s
+# OID = 1.3 — total: 1000 ops in N ms, M ops/s
 ```
 
-Flags: `--path` (matrix path), `--n` (op count, default 100), `--op` (connect / absolute / disconnect, default connect), `--targets` / `--sources` (wrap modulo, default 4). No percentiles today — RFC 2544/8219 profile + cold-start + recovery pending **R13 #474**.
+Flags: `--path` (matrix path), `--n` (op count, default 100), `--op` (connect / absolute / disconnect, default connect), `--targets` / `--sources` (wrap modulo, default 4).
+
+### Pending — R13 [#474](https://github.com/by-openclaw/go-acp/issues/474) (expanded scope)
+
+Today only `matrix` ops are benchable. R13 [#474](https://github.com/by-openclaw/go-acp/issues/474) extends the verb with:
+
+| Per-op-kind profile | What it measures | Spec anchor |
+|---|---|---|
+| `--profile latency` | round-trip p50/p95/p99/p99.9 µs per op kind: `get` / `set` / `matrix` / `invoke` / **glow-walk** / **stream-subscribe** / **function-invoke** / **s101-keepalive** | RFC 2544 |
+| `--profile throughput` | max sustained ops/s with <1% frame loss over 60 s — per op kind | RFC 2544 §26 |
+| `--profile cold-start` | producer launch → "tree fully exposed + listener bound + streamer running" — p50/p95/p99 across N=10 launches | new (per ADR-0025) |
+| `--profile recovery` | TCP disconnect → first successful op after reconnect — p50/p95/p99 | new |
+| `--transport tcp` (today) / `--transport <variant>` | Ember+ is TCP-only on the wire; `--transport` becomes a placeholder for future variants (Ember+/UDP draft, Ember+/TLS) — today rejects anything but `tcp` | per Ember+ spec p.22 |
+
+### Errors
+
+| Trigger | Command | Expected | Exit |
+|---|---|---|---|
+| missing `--path` | `bench --port 9100 --n 100` | `--path is required` | 1 |
+| n ≤ 0 | `bench ... --n -1` | `--n must be > 0` | 1 |
+| invalid op | `bench ... --op spin` | `op must be connect, absolute, or disconnect` | 1 |
+| matrix path resolves to non-matrix | `bench ... --path dhs-emberplus-integration.types.vInteger` | `bench: target not a Matrix` | 1 |
+| connection refused | `bench ... --port 9999` | s101 framing error | 1 |
 
 ---
 
@@ -452,8 +624,8 @@ Current state on `main`. ✅ working, 🟡 partial, ❌ not implemented.
 | UC-11 | `extract` — per-product DM triple | ✅ | n/a | writes meta.json + wire.pcapng + tree.json |
 | UC-12 | `validate` — offline jsonl decode | ✅ | n/a | Go-codec PASS/FAIL per frame; Wireshark `--lua` mode pending **R12 #473** |
 | UC-13 | `bench` — matrix latency | 🟡 | ✅ | total + ops/s only today; no p50/p95/p99, no cold-start, no recovery — **R13 #474** |
-| UC-14 | `health` — 3-layer liveness | ❌ #300 | ✅ | not implemented for Ember+ consumer; protocol returns `does not implement HealthChecker yet` |
-| UC-15 | `discover` — mDNS | ❌ R18 #477 | ❌ R18 #477 | producer announce + consumer scan on `_ember._tcp.local.` both pending |
+| UC-14 | `health` — 3-layer liveness | ❌ [#300](https://github.com/by-openclaw/go-acp/issues/300) | ❌ [#300](https://github.com/by-openclaw/go-acp/issues/300) | TODO both: consumer-side verb returns `does not implement HealthChecker yet`; provider-side `IsOnline` aggregation per `project_session_health` exists but is not exposed through a control-plane endpoint |
+| UC-15 | `discover` — mDNS | ❌ R18 [#477](https://github.com/by-openclaw/go-acp/issues/477) | ❌ R18 [#477](https://github.com/by-openclaw/go-acp/issues/477) | TODO both: producer announce + consumer scan on `_ember._tcp.local.` |
 | UC-16 | `diff` / `convert` | ✅ | n/a | tree-vs-tree diff + format conversion both work offline |
 
 ---
@@ -462,24 +634,29 @@ Current state on `main`. ✅ working, 🟡 partial, ❌ not implemented.
 
 | R# | Issue | Status | Scope |
 |---|---|---|---|
-| R1 | [#468](https://github.com/by-openclaw/go-acp/issues/468) | open | layered error-code taxonomy |
-| R2/R3/R7 | (folded into PR δ) | pending | runbook prose + per-OS firewall snippet |
-| R4 | [#461](https://github.com/by-openclaw/go-acp/issues/461) | open + comment | export/import round-trip + `--dry-run` + `--scope` + per-type tally |
+| R1 | [#468](https://github.com/by-openclaw/go-acp/issues/468) | open | layered error-code taxonomy (covers exit-code mapping per error class) |
+| R2 | TBD | folded into this runbook | runbook prose (verb-by-verb walkthrough — this doc) |
+| R3 | TBD | folded into this runbook | runbook error coverage (each verb's Errors table) |
+| R4 | [#461](https://github.com/by-openclaw/go-acp/issues/461) | open + comment | export/import round-trip + `--dry-run` + `--scope` + per-type tally — full spec in [`runbook/export-import.md`](runbook/export-import.md) |
 | R5b | [#469](https://github.com/by-openclaw/go-acp/issues/469) | open | standalone `tree` verb + PlantUML |
-| R6 | [#470](https://github.com/by-openclaw/go-acp/issues/470) | open | `info` reads DTD version from device |
+| R6 | [#470](https://github.com/by-openclaw/go-acp/issues/470) | open | `info` reads DTD version from device (kills the "emberplus v1" line) |
+| R7 | TBD | folded into this runbook | runbook prose continued |
 | R8 | [#471](https://github.com/by-openclaw/go-acp/issues/471) | open | service installer epic (per-OS) |
-| R9 | [#472](https://github.com/by-openclaw/go-acp/issues/472) | open | provider stream idle-TTL eviction |
-| R10 | [#478](https://github.com/by-openclaw/go-acp/issues/478) | **landed #479** | `stream --id` CSV multi-subscribe |
+| R9 | [#472](https://github.com/by-openclaw/go-acp/issues/472) | open | provider stream idle-TTL eviction (no-keepalive → unsub streams) |
+| R10 | [#478](https://github.com/by-openclaw/go-acp/issues/478) | **landed [#479](https://github.com/by-openclaw/go-acp/pull/479)** | `stream --id` CSV multi-subscribe |
 | R11 | TBD | not yet filed | `getSalvo` human format `tgt N <- Src [a,b,c]` |
-| R12 | [#473](https://github.com/by-openclaw/go-acp/issues/473) | open | `validate --lua` via tshark |
-| R13 | [#474](https://github.com/by-openclaw/go-acp/issues/474) | open | `bench` RFC 2544 + cold-start + recovery |
+| R12 | [#473](https://github.com/by-openclaw/go-acp/issues/473) | open | `validate --lua` via tshark — see [`runbook/validate.md`](runbook/validate.md) |
+| R13 | [#474](https://github.com/by-openclaw/go-acp/issues/474) | open | `bench` RFC 2544 + cold-start + recovery; expanded scope: glow / function / stream / transport per-op-kind profiles |
 | R14 | [#475](https://github.com/by-openclaw/go-acp/issues/475) | open | `--ensure {present\|absent\|dryrun}` (Ansible) |
 | R15 | [#476](https://github.com/by-openclaw/go-acp/issues/476) | open | `-v` ladder + `--log-format {text\|json\|loki}` + `--log-only` |
 | R16 | TBD | not yet filed | `set` range/step round + enum-by-label |
-| R17 | (folded into R8) | pending | per-OS firewall rules + runas-admin |
-| R18 | [#477](https://github.com/by-openclaw/go-acp/issues/477) | open | bidirectional mDNS on `_ember._tcp.local.` |
+| R17 | folded into R8 | pending | per-OS firewall rules + runas-admin |
+| R18 | [#477](https://github.com/by-openclaw/go-acp/issues/477) | open | bidirectional mDNS on `_ember._tcp.local.` (consumer + provider) |
 | R19 | TBD | not yet filed | audit pass: consumer-vs-provider parity per use case |
 | R20 | TBD | not yet filed | matrix doc at `docs/protocols/use-cases/emberplus.md` |
+| **R21** | TBD | not yet filed | `--path` accepts OID alongside dotted label (per memory `project_path_by_id`) |
+| **R22** | TBD | not yet filed | `profile` verb enhancements: per-event-kind tally + JSON output + history/filter |
+| **R23** | TBD | not yet filed | `validate --report <md\|json>` structured report — see [`runbook/validate.md`](runbook/validate.md) |
 
 ---
 

--- a/internal/emberplus/docs/runbook.md
+++ b/internal/emberplus/docs/runbook.md
@@ -112,7 +112,70 @@ Top-level OID map (current integration-test provider):
 | `1.5` | `functions` | builtins |
 | `1.6` | `types` | every ParameterType + 3 streams |
 
-> Today `--path` accepts the dotted label form only. Accepting OIDs in `--path` (e.g. `--path 1.6.1`) so operators can address by either form is pending **R21** (per memory `project_path_by_id`).
+> Today `--path` accepts the dotted label form only. Accepting OIDs in `--path` (e.g. `--path 1.6.1`) so operators can address by either form is pending **R21 [#486](https://github.com/by-openclaw/go-acp/issues/486)** (per memory `project_path_by_id`).
+
+---
+
+## Exit codes & error taxonomy
+
+Today's binary emits free-text error messages on stderr + a coarse exit code. **R1 [#468](https://github.com/by-openclaw/go-acp/issues/468)** locks in a 4-class exit code scheme + a stable `<layer>:<code>` string so operators and scripts can dispatch on the code, not on free-text. The codes shown in every Errors table below are the **post-R1** contract.
+
+### Exit code classes (post R1)
+
+| Exit | Class | When |
+|---|---|---|
+| **0** | success | verb completed; no errors |
+| **1** | protocol error — wire OK but semantic rejection | `matrix:target-locked`, `matrix:cardinality-exceeded`, `emberplus:invocation-failed` |
+| **2** | usage / state error — caller's fault | `validation:*`, `plugin:object-not-found`, `plugin:not-connected` |
+| **3** | wire / decode error — network or peer fault | `transport:*`, `s101:*`, `glow:*`, `session:write-timeout` |
+
+### Layer prefixes
+
+| Prefix | Owned by | Examples |
+|---|---|---|
+| `transport:` | `internal/transport/` + OS sockets | `transport:refused`, `transport:timeout`, `transport:reset` |
+| `s101:` | `internal/emberplus/codec/s101/` | `s101:crc-mismatch`, `s101:bad-escape`, `s101:multi-frame-truncated` |
+| `glow:` | `internal/emberplus/codec/glow/` + `codec/ber/` | `glow:bad-tag`, `glow:bad-length`, `glow:bad-real`, `glow:unknown-application-tag` |
+| `matrix:` | `internal/emberplus/codec/matrix/` | `matrix:cardinality-exceeded`, `matrix:target-locked`, `matrix:max-connects-per-target` |
+| `emberplus:` | `internal/emberplus/consumer/` + `provider/` | `emberplus:invocation-failed`, `emberplus:invocation-failed-with-description` |
+| `validation:` | `internal/consumer/` validation layer | `validation:invalid-integer`, `validation:out-of-range-low`, `validation:invalid-enum-label` |
+| `plugin:` | `internal/<proto>/` plugin state | `plugin:not-connected`, `plugin:not-walked`, `plugin:object-not-found` |
+| `session:` | session-state layer | `session:write-timeout`, `session:write-coerced`, `session:dead` |
+
+### Ember+ doesn't define wire-level error codes
+
+Unlike ACP2 (`stat=1..5`) or HTTP (`4xx/5xx`), the Ember+ wire format carries **no native error codes**. The only error signals on the wire are:
+
+| Wire signal | Meaning |
+|---|---|
+| `InvocationResult.Success=false` | Invoke failed — **no reason code** |
+| `Connection.Disposition=locked` | target locked, write rejected |
+| `offlineElement` marker | element no longer valid (tombstone) |
+| free-text `description` field | sometimes used by providers for human reason |
+
+The `emberplus:*` and `matrix:*` codes are this project's invention layered on top of those signals; operators won't find them in the Ember+ Documentation PDF.
+
+### Scripting dispatch (Ansible / shell)
+
+```powershell
+$out = (.\bin\dhs.exe consumer emberplus set --path types.vInteger --value abc 2>&1)
+switch -Regex ($out) {
+    '^validation:'  { 'caller error — bad input' }
+    '^transport:'   { 'network problem — retry' }
+    '^matrix:'      { 'protocol rejection — investigate' }
+}
+# $LASTEXITCODE is one of 0 / 1 / 2 / 3
+```
+
+```yaml
+# Ansible task example
+- name: gain set
+  command: dhs consumer emberplus set --path ... --value -25
+  register: r
+  failed_when:
+    - r.rc != 0
+    - r.stderr is not search('^validation:invalid-enum-label')   # tolerate one specific code
+```
 
 ---
 
@@ -140,11 +203,11 @@ per-slot status:
 
 ### Errors
 
-| Trigger | Command | Expected | Exit |
+| Trigger | Command | Error code (post R1) | Exit |
 |---|---|---|---|
-| missing host | `dhs consumer emberplus info --port 9100` | `error: usage: dhs consumer <proto> info <host> [...]` | 2 |
-| connection refused | `dhs consumer emberplus info 127.0.0.1 --port 9999 --timeout 2s` | `s101 framing error: connect 127.0.0.1:9999: ... actively refused it` | 1 |
-| unreachable host | `dhs consumer emberplus info 192.0.2.1 --port 9100 --timeout 2s` | `s101 framing error: ... i/o timeout` | 1 |
+| missing host | `info --port 9100` | (usage error) | 2 |
+| connection refused | `info 127.0.0.1 --port 9999 --timeout 2s` | `transport:refused` | 3 |
+| unreachable host | `info 192.0.2.1 --port 9100 --timeout 2s` | `transport:timeout` | 3 |
 
 ---
 
@@ -166,11 +229,13 @@ Expected: ≈548 lines of tree dump, `tree_size ≈ 1361` objects. Two files wri
 
 ### Errors
 
-| Trigger | Command | Expected | Exit |
+| Trigger | Command | Error code (post R1) | Exit |
 |---|---|---|---|
-| connection refused | `walk ... --port 9999` | s101 framing error | 1 |
-| timeout too small | `walk ... --timeout 1ms` | `walk for "walk": context deadline exceeded` | 1 |
-| missing host | `walk --port 9100` | usage error | 2 |
+| connection refused | `walk ... --port 9999` | `transport:refused` | 3 |
+| timeout too small | `walk ... --timeout 1ms` | `transport:timeout` | 3 |
+| missing host | `walk --port 9100` | (usage error) | 2 |
+| bad S101 frame | (corrupted peer) | `s101:crc-mismatch` / `s101:bad-escape` | 3 |
+| unknown Glow tag | (peer emits non-spec tag) | `glow:unknown-application-tag` | 3 |
 
 ---
 
@@ -206,11 +271,13 @@ Expected: ≈548 lines of tree dump, `tree_size ≈ 1361` objects. Two files wri
 
 ### Errors
 
-| Trigger | Command | Expected | Exit |
+| Trigger | Command | Error code (post R1) | Exit |
 |---|---|---|---|
-| wrong path | `get ... --path bogus.path.here` | `object not found (tree has 1361 entries)` | 1 |
-| missing required path | `get 127.0.0.1 --port 9100` | usage error | 2 |
-| connection refused | `get ... --port 9999` | s101 framing error | 1 |
+| wrong path | `get ... --path bogus.path.here` | `plugin:object-not-found` | 2 |
+| invalid OID syntax (post R21) | `get ... --path 1..2` | `validation:invalid-oid` | 2 |
+| path resolves to non-Parameter | `get ... --path dhs-emberplus-integration.functions` | `plugin:wrong-kind` | 2 |
+| missing required path | `get 127.0.0.1 --port 9100` | (usage error) | 2 |
+| connection refused | `get ... --port 9999` | `transport:refused` | 3 |
 
 ---
 
@@ -236,16 +303,20 @@ Expected: ≈548 lines of tree dump, `tree_size ≈ 1361` objects. Two files wri
 
 > Out-of-range / step-mismatch / enum-by-label semantics pending **R16** (not yet filed).
 
-### Errors (post #453)
+### Errors (post #453 + post R16 [#483](https://github.com/by-openclaw/go-acp/issues/483))
 
-| Trigger | Command | Expected | Exit |
+| Trigger | Command | Error code (post R1) | Exit |
 |---|---|---|---|
-| unparseable int (#445) | `set ... gain --value -25.5` | `validation: value: invalid integer "-25.5"` | 2 |
-| unparseable int (letters) | `set ... gain --value abc` | `validation: value: invalid integer "abc"` | 2 |
-| unparseable real | `set ... vReal --value not-a-float` | `validation: value: invalid real "not-a-float"` | 2 |
-| enum overflow | `set ... vEnum --value 999` | `validation: value: invalid enum index "999"` | 2 |
-| write to read-only stream | `set ... vu_zero --value -10` | protocol error (provider rejects) | 1 |
-| wrong path | `set --path bogus --value 1` | `object not found` | 1 |
+| unparseable int (#445) | `set ... gain --value -25.5` | `validation:invalid-integer` | 2 |
+| unparseable int (letters) | `set ... gain --value abc` | `validation:invalid-integer` | 2 |
+| unparseable real | `set ... vReal --value not-a-float` | `validation:invalid-real` | 2 |
+| enum overflow | `set ... vEnum --value 999` | `validation:invalid-enum-index` | 2 |
+| **out of range low (R16)** | `set ... vInteger --value -200` (min=-100) | `validation:out-of-range-low` | 2 |
+| **out of range high (R16)** | `set ... vInteger --value 200` (max=100) | `validation:out-of-range-high` | 2 |
+| **step misaligned (R16)** | `set ... vReal --value 1.3` (step=0.5) | `validation:step-misaligned` | 2 |
+| **invalid enum label (R16)** | `set ... vEnum --value Bogus` | `validation:invalid-enum-label` | 2 |
+| write to read-only stream | `set ... vu_zero --value -10` | `emberplus:invocation-failed` (provider rejects) | 1 |
+| wrong path | `set --path bogus --value 1` | `plugin:object-not-found` | 2 |
 
 ---
 
@@ -288,11 +359,12 @@ Three event sources, all delivered through the same `watch` feed:
 
 ### Errors
 
-| Trigger | Command | Expected | Exit |
+| Trigger | Command | Error code (post R1) | Exit |
 |---|---|---|---|
-| connection refused | `watch ... --port 9999` | s101 framing error | 1 |
-| bad path filter | `watch --path bogus` | no events (filter matches nothing); exits clean on Ctrl-C | 0 / 1 |
-| missing host | `watch --port 9100` | usage error | 2 |
+| connection refused | `watch ... --port 9999` | `transport:refused` | 3 |
+| bad path filter | `watch --path bogus` | (no error — filter matches nothing; exits 0 on Ctrl-C) | 0 |
+| missing host | `watch --port 9100` | (usage error) | 2 |
+| connection lost mid-stream | (peer kills TCP) | `transport:reset` | 3 |
 
 ---
 
@@ -338,13 +410,15 @@ Three event sources, all delivered through the same `watch` feed:
 
 ### Errors
 
-| Trigger | Command | Expected | Exit |
+| Trigger | Command | Error code (post R1) | Exit |
 |---|---|---|---|
-| oneToN over-cardinality | `matrix oneToN --target 0 --sources 1,2 --op absolute` | `matrix validation: oneToN matrix: target 0 would have 2 sources (max 1) [spec p.33]` | 1 |
-| nToN over capacity | `matrix nToN --target 0 --sources 0,1,2,3,4,5 --op absolute` | `matrix validation: nToN matrix: target 0 would have 5 sources (max 4 per target)` | 1 |
-| locked target | `matrix oneToN --target 2 --sources 5 --op absolute` | rejected by provider; tally announce echoes back unchanged with `disposition: locked` | 1 |
-| wrong matrix path | `matrix --path bogus` | `matrix not found at path "bogus"` | 1 |
-| missing target | `matrix ... --sources 1` (no `--target`) | usage error | 2 |
+| oneToN over-cardinality | `matrix oneToN --target 0 --sources 1,2 --op absolute` | `matrix:cardinality-exceeded` | 1 |
+| nToN over capacity | `matrix nToN --target 0 --sources 0,1,2,3,4,5 --op absolute` | `matrix:max-connects-per-target` | 1 |
+| nToN total capacity | (sum exceeds `maxTotalConnects`) | `matrix:max-total-connects` | 1 |
+| locked target | `matrix oneToN --target 2 --sources 5 --op absolute` | `matrix:target-locked` (provider echoes `disposition:locked`) | 1 |
+| wrong matrix path | `matrix --path bogus` | `plugin:object-not-found` | 2 |
+| path resolves to non-Matrix | `matrix --path dhs-emberplus-integration.types.vInteger` | `plugin:wrong-kind` | 2 |
+| missing target | `matrix ... --sources 1` (no `--target`) | (usage error) | 2 |
 
 ---
 
@@ -406,12 +480,14 @@ Function subtree at OID `1.5` carries six builtins:
 
 ### Errors (post #455 / #457)
 
-| Trigger | Command | Expected | Exit |
+| Trigger | Command | Error code (post R1) | Exit |
 |---|---|---|---|
-| bogus matrixRef | `invoke setLock --args "bogus.path,1,true"` | `invocation 1: success=false` (was silent success pre-#457) | 1 |
-| missing arg | `invoke setLock --args "1.1.3"` | `setLock: need (matrixPath, target, locked)` | 1 |
-| wrong type arg | `invoke setLock --args "1.1.3,abc,true"` | bad arg types | 1 |
-| missing `--path` | `invoke --args "1.1.3,1,true"` | usage error | 2 |
+| bogus matrixRef | `invoke setLock --args "bogus.path,1,true"` | `emberplus:invocation-failed` (provider returns `Success=false`) | 1 |
+| description on failure | (provider returns `Success=false` + description) | `emberplus:invocation-failed-with-description` (description in stderr) | 1 |
+| missing arg | `invoke setLock --args "1.1.3"` | `validation:invocation-args-count` | 2 |
+| wrong type arg | `invoke setLock --args "1.1.3,abc,true"` | `validation:invocation-arg-type` | 2 |
+| missing `--path` | `invoke --args "1.1.3,1,true"` | (usage error) | 2 |
+| `--format bogus` (R11 [#482](https://github.com/by-openclaw/go-acp/issues/482)) | `invoke ... --format bogus` | `validation:invalid-format` | 2 |
 
 ---
 
@@ -455,13 +531,13 @@ Today the operator-visible behavior on an abruptly-killed consumer:
 
 ### Errors
 
-| Case | Command | Error | Exit |
+| Case | Command | Error code (post R1) | Exit |
 |---|---|---|---|
-| bad token | `stream ... --id abc` | `validation: --id: bad token "abc"` | 2 |
-| empty token mid-csv | `stream ... --id 0,,1001` | `validation: --id: empty token in "0,,1001"` | 2 |
-| trailing comma | `stream ... --id 0,1001,` | `validation: --id: empty token in "0,1001,"` | 2 |
-| connection refused | `stream ... --port 9999` | s101 framing error | 1 |
-| missing host | `stream --port 9100` | usage error | 2 |
+| bad token | `stream ... --id abc` | `validation:invalid-id-token` | 2 |
+| empty token mid-csv | `stream ... --id 0,,1001` | `validation:invalid-id-token` (empty) | 2 |
+| trailing comma | `stream ... --id 0,1001,` | `validation:invalid-id-token` (empty) | 2 |
+| connection refused | `stream ... --port 9999` | `transport:refused` | 3 |
+| missing host | `stream --port 9100` | (usage error) | 2 |
 
 ---
 
@@ -493,10 +569,13 @@ Today `profile` aggregates into one classification line + an event count. The co
 
 ### Errors
 
-| Trigger | Command | Expected | Exit |
+| Trigger | Command | Error code (post R1) | Exit |
 |---|---|---|---|
-| connection refused | `profile ... --port 9999` | s101 framing error | 1 |
-| missing host | `profile --port 9100` | usage error | 2 |
+| connection refused | `profile ... --port 9999` | `transport:refused` | 3 |
+| missing host | `profile --port 9100` | (usage error) | 2 |
+| invalid `--format` (R22 [#487](https://github.com/by-openclaw/go-acp/issues/487)) | `profile ... --format yaml` | `validation:invalid-format` | 2 |
+| invalid `--since` (R22) | `profile ... --since 5xx` | `validation:invalid-duration` | 2 |
+| `--by-session` without R24 (R22) | `profile ... --by-session` | `plugin:by-session-unavailable` | 2 |
 
 ---
 
@@ -546,12 +625,12 @@ Layout written:
 
 ### Errors
 
-| Trigger | Command | Expected | Exit |
+| Trigger | Command | Error code (post R1) | Exit |
 |---|---|---|---|
-| target dir unwritable | `extract ... --out /no/perm/` | `extract: mkdir /no/perm: permission denied` | 1 |
-| missing required flag | `extract ... --product foo` (no `--version`) | usage error | 2 |
-| connection refused | `extract ... --port 9999` | s101 framing error | 1 |
-| invalid direction | `extract ... --direction sideways` | `validation: --direction: must be "in" or "out"` | 2 |
+| target dir unwritable | `extract ... --out /no/perm/` | `transport:report-target-unwritable` | 1 |
+| missing required flag | `extract ... --product foo` (no `--version`) | (usage error) | 2 |
+| connection refused | `extract ... --port 9999` | `transport:refused` | 3 |
+| invalid direction | `extract ... --direction sideways` | `validation:invalid-direction` | 2 |
 
 ---
 
@@ -595,13 +674,13 @@ Today only `matrix` ops are benchable. R13 [#474](https://github.com/by-openclaw
 
 ### Errors
 
-| Trigger | Command | Expected | Exit |
+| Trigger | Command | Error code (post R1) | Exit |
 |---|---|---|---|
-| missing `--path` | `bench --port 9100 --n 100` | `--path is required` | 1 |
-| n ≤ 0 | `bench ... --n -1` | `--n must be > 0` | 1 |
-| invalid op | `bench ... --op spin` | `op must be connect, absolute, or disconnect` | 1 |
-| matrix path resolves to non-matrix | `bench ... --path dhs-emberplus-integration.types.vInteger` | `bench: target not a Matrix` | 1 |
-| connection refused | `bench ... --port 9999` | s101 framing error | 1 |
+| missing `--path` | `bench --port 9100 --n 100` | (usage error) | 2 |
+| n ≤ 0 | `bench ... --n -1` | `validation:invalid-n` | 2 |
+| invalid op | `bench ... --op spin` | `validation:invalid-op` | 2 |
+| path resolves to non-Matrix | `bench ... --path dhs-emberplus-integration.types.vInteger` | `plugin:wrong-kind` | 2 |
+| connection refused | `bench ... --port 9999` | `transport:refused` | 3 |
 
 ---
 
@@ -635,28 +714,30 @@ Current state on `main`. ✅ working, 🟡 partial, ❌ not implemented.
 | R# | Issue | Status | Scope |
 |---|---|---|---|
 | R1 | [#468](https://github.com/by-openclaw/go-acp/issues/468) | open | layered error-code taxonomy (covers exit-code mapping per error class) |
-| R2 | TBD | folded into this runbook | runbook prose (verb-by-verb walkthrough — this doc) |
-| R3 | TBD | folded into this runbook | runbook error coverage (each verb's Errors table) |
+| R2 | n/a — this doc | folded | runbook prose (verb-by-verb walkthrough — this doc) |
+| R3 | n/a — this doc | folded | runbook error coverage (each verb's Errors table) |
 | R4 | [#461](https://github.com/by-openclaw/go-acp/issues/461) | open + comment | export/import round-trip + `--dry-run` + `--scope` + per-type tally — full spec in [`runbook/export-import.md`](runbook/export-import.md) |
 | R5b | [#469](https://github.com/by-openclaw/go-acp/issues/469) | open | standalone `tree` verb + PlantUML |
 | R6 | [#470](https://github.com/by-openclaw/go-acp/issues/470) | open | `info` reads DTD version from device (kills the "emberplus v1" line) |
-| R7 | TBD | folded into this runbook | runbook prose continued |
+| R7 | n/a — this doc | folded | runbook prose continued |
 | R8 | [#471](https://github.com/by-openclaw/go-acp/issues/471) | open | service installer epic (per-OS) |
 | R9 | [#472](https://github.com/by-openclaw/go-acp/issues/472) | open | provider stream idle-TTL eviction (no-keepalive → unsub streams) |
 | R10 | [#478](https://github.com/by-openclaw/go-acp/issues/478) | **landed [#479](https://github.com/by-openclaw/go-acp/pull/479)** | `stream --id` CSV multi-subscribe |
-| R11 | TBD | not yet filed | `getSalvo` human format `tgt N <- Src [a,b,c]` |
+| R11 | [#482](https://github.com/by-openclaw/go-acp/issues/482) | open | `invoke --format human` pretty-prints `getSalvo` result |
 | R12 | [#473](https://github.com/by-openclaw/go-acp/issues/473) | open | `validate --lua` via tshark — see [`runbook/validate.md`](runbook/validate.md) |
 | R13 | [#474](https://github.com/by-openclaw/go-acp/issues/474) | open | `bench` RFC 2544 + cold-start + recovery; expanded scope: glow / function / stream / transport per-op-kind profiles |
 | R14 | [#475](https://github.com/by-openclaw/go-acp/issues/475) | open | `--ensure {present\|absent\|dryrun}` (Ansible) |
 | R15 | [#476](https://github.com/by-openclaw/go-acp/issues/476) | open | `-v` ladder + `--log-format {text\|json\|loki}` + `--log-only` |
-| R16 | TBD | not yet filed | `set` range/step round + enum-by-label |
+| R16 | [#483](https://github.com/by-openclaw/go-acp/issues/483) | open | `set` range / step round + enum-by-label client-side validation |
 | R17 | folded into R8 | pending | per-OS firewall rules + runas-admin |
 | R18 | [#477](https://github.com/by-openclaw/go-acp/issues/477) | open | bidirectional mDNS on `_ember._tcp.local.` (consumer + provider) |
-| R19 | TBD | not yet filed | audit pass: consumer-vs-provider parity per use case |
-| R20 | TBD | not yet filed | matrix doc at `docs/protocols/use-cases/emberplus.md` |
-| **R21** | TBD | not yet filed | `--path` accepts OID alongside dotted label (per memory `project_path_by_id`) |
-| **R22** | TBD | not yet filed | `profile` verb enhancements: per-event-kind tally + JSON output + history/filter |
-| **R23** | TBD | not yet filed | `validate --report <md\|json>` structured report — see [`runbook/validate.md`](runbook/validate.md) |
+| R19 | [#484](https://github.com/by-openclaw/go-acp/issues/484) | open | audit pass — consumer ↔ provider parity per use case + error-code surface |
+| R20 | [#485](https://github.com/by-openclaw/go-acp/issues/485) | open | per-protocol use-case matrix at `docs/protocols/use-cases/<proto>.md` |
+| R21 | [#486](https://github.com/by-openclaw/go-acp/issues/486) | open | `--path` accepts numeric OID alongside dotted label (per memory `project_path_by_id`) |
+| R22 | [#487](https://github.com/by-openclaw/go-acp/issues/487) | open | `profile` enhancements: per-event-kind + JSON + `--since` + `--by-session` + `--show-events` |
+| R23 | [#488](https://github.com/by-openclaw/go-acp/issues/488) | open | `validate --report <path.md\|path.json>` structured report |
+| R24 | [#489](https://github.com/by-openclaw/go-acp/issues/489) | open | provider session inventory — local-socket CLI + minimal HTML5 admin page on separate port |
+| R25 | [#490](https://github.com/by-openclaw/go-acp/issues/490) | open | provider runtime admin verbs — hot-reload toggles via local socket |
 
 ---
 

--- a/internal/emberplus/docs/runbook.md
+++ b/internal/emberplus/docs/runbook.md
@@ -118,16 +118,17 @@ Top-level OID map (current integration-test provider):
 
 ## Exit codes & error taxonomy
 
-Today's binary emits free-text error messages on stderr + a coarse exit code. **R1 [#468](https://github.com/by-openclaw/go-acp/issues/468)** locks in a 4-class exit code scheme + a stable `<layer>:<code>` string so operators and scripts can dispatch on the code, not on free-text. The codes shown in every Errors table below are the **post-R1** contract.
+Today's binary emits free-text error messages on stderr + a coarse exit code. **R1 [#468](https://github.com/by-openclaw/go-acp/issues/468)** locks in the standard Unix exit-code scheme (`0`/`1`/`2`) + a stable `<layer>:<code>: <message>` string in stderr so operators and scripts can dispatch on the code, not on free-text. **Diagnosis lives exclusively in the error string — never in the exit code.** The codes shown in every Errors table below are the **post-R1** contract.
 
-### Exit code classes (post R1)
+### Exit code classes (post R1) — Unix-standard, cross-OS uniform
 
 | Exit | Class | When |
 |---|---|---|
 | **0** | success | verb completed; no errors |
-| **1** | protocol error — wire OK but semantic rejection | `matrix:target-locked`, `matrix:cardinality-exceeded`, `emberplus:invocation-failed` |
-| **2** | usage / state error — caller's fault | `validation:*`, `plugin:object-not-found`, `plugin:not-connected` |
-| **3** | wire / decode error — network or peer fault | `transport:*`, `s101:*`, `glow:*`, `session:write-timeout` |
+| **1** | any runtime error — caller reads stderr for the precise code | `transport:*`, `s101:*`, `glow:*`, `matrix:*`, `emberplus:*`, `session:*` |
+| **2** | usage / state error — Go `flag` parse failure or caller's input fault | `validation:*`, `plugin:object-not-found`, `plugin:not-connected`, missing required flag |
+
+Never `3+`. Cross-OS: PowerShell `$LASTEXITCODE`, Bash `$?`, `cmd.exe %ERRORLEVEL%` all read the same scheme.
 
 ### Layer prefixes
 
@@ -206,8 +207,8 @@ per-slot status:
 | Trigger | Command | Error code (post R1) | Exit |
 |---|---|---|---|
 | missing host | `info --port 9100` | (usage error) | 2 |
-| connection refused | `info 127.0.0.1 --port 9999 --timeout 2s` | `transport:refused` | 3 |
-| unreachable host | `info 192.0.2.1 --port 9100 --timeout 2s` | `transport:timeout` | 3 |
+| connection refused | `info 127.0.0.1 --port 9999 --timeout 2s` | `transport:refused` | 1 |
+| unreachable host | `info 192.0.2.1 --port 9100 --timeout 2s` | `transport:timeout` | 1 |
 
 ---
 
@@ -231,11 +232,11 @@ Expected: ≈548 lines of tree dump, `tree_size ≈ 1361` objects. Two files wri
 
 | Trigger | Command | Error code (post R1) | Exit |
 |---|---|---|---|
-| connection refused | `walk ... --port 9999` | `transport:refused` | 3 |
-| timeout too small | `walk ... --timeout 1ms` | `transport:timeout` | 3 |
+| connection refused | `walk ... --port 9999` | `transport:refused` | 1 |
+| timeout too small | `walk ... --timeout 1ms` | `transport:timeout` | 1 |
 | missing host | `walk --port 9100` | (usage error) | 2 |
-| bad S101 frame | (corrupted peer) | `s101:crc-mismatch` / `s101:bad-escape` | 3 |
-| unknown Glow tag | (peer emits non-spec tag) | `glow:unknown-application-tag` | 3 |
+| bad S101 frame | (corrupted peer) | `s101:crc-mismatch` / `s101:bad-escape` | 1 |
+| unknown Glow tag | (peer emits non-spec tag) | `glow:unknown-application-tag` | 1 |
 
 ---
 
@@ -277,7 +278,7 @@ Expected: ≈548 lines of tree dump, `tree_size ≈ 1361` objects. Two files wri
 | invalid OID syntax (post R21) | `get ... --path 1..2` | `validation:invalid-oid` | 2 |
 | path resolves to non-Parameter | `get ... --path dhs-emberplus-integration.functions` | `plugin:wrong-kind` | 2 |
 | missing required path | `get 127.0.0.1 --port 9100` | (usage error) | 2 |
-| connection refused | `get ... --port 9999` | `transport:refused` | 3 |
+| connection refused | `get ... --port 9999` | `transport:refused` | 1 |
 
 ---
 
@@ -361,10 +362,10 @@ Three event sources, all delivered through the same `watch` feed:
 
 | Trigger | Command | Error code (post R1) | Exit |
 |---|---|---|---|
-| connection refused | `watch ... --port 9999` | `transport:refused` | 3 |
+| connection refused | `watch ... --port 9999` | `transport:refused` | 1 |
 | bad path filter | `watch --path bogus` | (no error — filter matches nothing; exits 0 on Ctrl-C) | 0 |
 | missing host | `watch --port 9100` | (usage error) | 2 |
-| connection lost mid-stream | (peer kills TCP) | `transport:reset` | 3 |
+| connection lost mid-stream | (peer kills TCP) | `transport:reset` | 1 |
 
 ---
 
@@ -536,7 +537,7 @@ Today the operator-visible behavior on an abruptly-killed consumer:
 | bad token | `stream ... --id abc` | `validation:invalid-id-token` | 2 |
 | empty token mid-csv | `stream ... --id 0,,1001` | `validation:invalid-id-token` (empty) | 2 |
 | trailing comma | `stream ... --id 0,1001,` | `validation:invalid-id-token` (empty) | 2 |
-| connection refused | `stream ... --port 9999` | `transport:refused` | 3 |
+| connection refused | `stream ... --port 9999` | `transport:refused` | 1 |
 | missing host | `stream --port 9100` | (usage error) | 2 |
 
 ---
@@ -571,7 +572,7 @@ Today `profile` aggregates into one classification line + an event count. The co
 
 | Trigger | Command | Error code (post R1) | Exit |
 |---|---|---|---|
-| connection refused | `profile ... --port 9999` | `transport:refused` | 3 |
+| connection refused | `profile ... --port 9999` | `transport:refused` | 1 |
 | missing host | `profile --port 9100` | (usage error) | 2 |
 | invalid `--format` (R22 [#487](https://github.com/by-openclaw/go-acp/issues/487)) | `profile ... --format yaml` | `validation:invalid-format` | 2 |
 | invalid `--since` (R22) | `profile ... --since 5xx` | `validation:invalid-duration` | 2 |
@@ -629,7 +630,7 @@ Layout written:
 |---|---|---|---|
 | target dir unwritable | `extract ... --out /no/perm/` | `transport:report-target-unwritable` | 1 |
 | missing required flag | `extract ... --product foo` (no `--version`) | (usage error) | 2 |
-| connection refused | `extract ... --port 9999` | `transport:refused` | 3 |
+| connection refused | `extract ... --port 9999` | `transport:refused` | 1 |
 | invalid direction | `extract ... --direction sideways` | `validation:invalid-direction` | 2 |
 
 ---
@@ -680,7 +681,7 @@ Today only `matrix` ops are benchable. R13 [#474](https://github.com/by-openclaw
 | n ≤ 0 | `bench ... --n -1` | `validation:invalid-n` | 2 |
 | invalid op | `bench ... --op spin` | `validation:invalid-op` | 2 |
 | path resolves to non-Matrix | `bench ... --path dhs-emberplus-integration.types.vInteger` | `plugin:wrong-kind` | 2 |
-| connection refused | `bench ... --port 9999` | `transport:refused` | 3 |
+| connection refused | `bench ... --port 9999` | `transport:refused` | 1 |
 
 ---
 

--- a/internal/emberplus/docs/runbook.md
+++ b/internal/emberplus/docs/runbook.md
@@ -1,0 +1,501 @@
+# Ember+ — operational runbook
+
+> Status: **PR δ in progress** — draft under codeowner review.
+> Source-of-truth for verb-by-verb validation against the
+> integration-test fixture set. Capture batch (PR γ) lands separately.
+
+## Scope
+
+| Dimension | Coverage |
+|---|---|
+| **Protocol** | Ember+ DTD `2.60` strict — older DTDs not in scope (per `internal/emberplus/CLAUDE.md`) |
+| **Roles** | dhs as **consumer** (outbound) and **provider** (inbound); both exercised against the integration-test fixture set |
+| **Producer source** | `internal/emberplus/testdata/integration-test/` — manifest + 7 strict DMs (identity, oneToN, oneToOne, nToN, dynamic, functions, glow-types). Regen script: `scripts/emberplus/gen-emberplus-demo-dms.ps1` |
+| **OS** | Windows 11 (primary host); Linux LXCs (Debian/Ubuntu/Rocky) parity |
+| **Out of scope** | mDNS discovery (R18 #477); `health` verb (#300); export/import full round-trip (#461); `validate --lua` (R12 #473) — listed in [Pending R-items](#pending-r-items) |
+
+Merged + live on `main`:
+
+| PR | Title |
+|---|---|
+| #463 | refactor(emberplus): testdata fixtures moved into `internal/emberplus/testdata/integration-test/` |
+| #480 (replaces #464) | feat(emberplus): scope refresh — DTD 2.60, 16×16 matrices, dynamic 128×128 sparse 16, stream id=0 |
+| #466 | fix(manifest): BuildExport reroots strict-canonical slot DM paths under synthetic root |
+| #467 | fix(emberplus/codec/matrix): oneToOne source-steal accepted + compliance event |
+| #479 | feat(emberplus/consumer): stream --id accepts CSV for multi-subscribe |
+| #459 | fix(emberplus/consumer): GetSlotInfo IsOnline correct |
+| #457 | fix(emberplus/provider): builtins return error on unresolved matrix |
+| #453 | fix(emberplus/consumer): set --value typed validation, no silent coerce |
+
+## Setup — build + serve
+
+```powershell
+git switch main
+git pull --ff-only origin main
+go build -o bin\dhs.exe ./cmd/dhs
+
+.\bin\dhs.exe producer emberplus serve `
+    --manifest internal\emberplus\testdata\integration-test\manifest\emberplus-integration.json `
+    --cache-dir internal\emberplus\testdata\integration-test `
+    --port 9100 `
+    --log-level info
+```
+
+Producer listens on `[::]:9100`. Expected log:
+
+```
+producer manifest loaded device=dhs-emberplus-integration endpoints=1 frames=1
+listening addr=[::]:9100 tree_size=1361
+streamer started stream_count=3 interval=500ms
+```
+
+> Tree size approximate (±10 across revisions). Track PID to
+> `.audit/producer.pid` for clean shutdown (see [Cleanup](#cleanup)).
+
+## Tree shape
+
+```
+dhs-emberplus-integration (synthetic root, oid "1")
+├── identity        (1.0)  — product / company / version / dtdVersion=2.60
+├── oneToN          (1.1)  — 16×16, Pri+Sec labels, target 2 PRE-LOCKED
+├── oneToOne        (1.2)  — 16×16, Pri+Sec labels, source-steal on SET
+├── nToN            (1.3)  — 16×16, Pri+Sec, maxConnectsPerTarget=4, multi-src seed
+├── dynamic         (1.4)  — 128×128 declared, 16 sparse with gaps, target 99 LOCKED
+├── functions       (1.5)  — setLock / listLocks / storeSalvo / recallSalvo / listSalvos / getSalvo
+└── types           (1.6)  — every ParameterType + 3 streams (id=0, id=1001, id=1002)
+```
+
+Every matrix carries `sourceParams[N].gain`, `targetParams[N].gain`, and (nToN only) per-XPT gain via `parametersLocation`.
+
+## Verb catalogue
+
+| Verb | Wire shape | Returns |
+|---|---|---|
+| `info` | GetDirectory(root) + identity walk | per-slot online + status |
+| `walk` | GetDirectory recursive | every object in the tree |
+| `get` | GetDirectory(path) | one value |
+| `set` | SetValue | confirmed value (or ValidationError) |
+| `watch` | Subscribe(30) on streams + implicit on params/matrices | live stream of value/connection changes |
+| `matrix` | Connect/Disconnect/Absolute on a Matrix | applied connection state |
+| `invoke` | Invoke + InvocationResult | tuple result + Success=true/false |
+| `stream` | Explicit subscribe to streamIdentifier | stream feed |
+| `profile` | Walk + count compliance.Profile events | classification (strict / partial) |
+| `export` | Walk + write JSON/YAML/CSV | file at --out |
+| `import` | Read JSON/YAML/CSV + apply | tree state on remote |
+| `extract` | Walk + write per-product DM (meta+wire+tree) | files in fixture layout |
+| `diff` | Two tree.json compared | text diff or CHANGELOG section |
+| `convert` | Translate between JSON / YAML / CSV | offline file write |
+| `validate` | Decode captured frames.jsonl through codec | offline decoder check |
+| `bench` | Fire N matrix ops over 1 TCP session | latency + ops/s |
+| `health` | 3-layer session liveness | not implemented for Ember+ (#300) |
+| `discover` | mDNS scan | no mDNS for Ember+ today |
+
+---
+
+## 1. `info` — device summary
+
+### Happy
+
+```powershell
+.\bin\dhs.exe consumer emberplus info 127.0.0.1 --port 9100
+```
+
+Expected:
+
+```
+device       127.0.0.1:9100
+protocol     emberplus v1
+slots        1
+
+per-slot status:
+  slot  0   status=present    online=true        ← post #459
+```
+
+### Errors
+
+| Trigger | Command | Expected | Exit |
+|---|---|---|---|
+| missing host | `dhs consumer emberplus info --port 9100` | `error: usage: dhs consumer <proto> info <host> [...]` | 2 |
+| connection refused | `dhs consumer emberplus info 127.0.0.1 --port 9999 --timeout 2s` | `s101 framing error: connect 127.0.0.1:9999: ... actively refused it` | 1 |
+| unreachable host | `dhs consumer emberplus info 192.0.2.1 --port 9100 --timeout 2s` | `s101 framing error: ... i/o timeout` | 1 |
+
+---
+
+## 2. `walk` — full tree enumeration
+
+### Happy
+
+```powershell
+.\bin\dhs.exe consumer emberplus walk 127.0.0.1 --port 9100 --capture .audit\walks\demo.jsonl
+```
+
+Expected: 548 lines of tree dump, `tree_size=1361` objects, DM auto-extracted to `.cache/dm/emberplus/dhs-emberplus-integration@1.0.0.json` for subsequent `--dm` hot-load.
+
+### Errors
+
+| Trigger | Command | Expected |
+|---|---|---|
+| connection refused | `walk ... --port 9999` | s101 framing error |
+| timeout too small | `walk ... --timeout 1ms` | walk for "walk": context deadline exceeded |
+
+---
+
+## 3. `get` — read one Parameter
+
+### Happy
+
+```powershell
+# Each ParameterType
+.\bin\dhs.exe consumer emberplus get 127.0.0.1 --port 9100 --path dhs-emberplus-integration.types.vInteger
+# value = 42
+
+.\bin\dhs.exe consumer emberplus get 127.0.0.1 --port 9100 --path dhs-emberplus-integration.types.vReal
+# value = 3.14    (carries factor=100, format=%.2f, unit=dB)
+
+.\bin\dhs.exe consumer emberplus get 127.0.0.1 --port 9100 --path dhs-emberplus-integration.types.vString
+# value = "hello"
+
+.\bin\dhs.exe consumer emberplus get 127.0.0.1 --port 9100 --path dhs-emberplus-integration.types.vBoolean
+# value = true
+
+.\bin\dhs.exe consumer emberplus get 127.0.0.1 --port 9100 --path dhs-emberplus-integration.types.vEnum
+# value = 1    (enumMap: Off=0, Low=1, Medium=2, High=3)
+
+.\bin\dhs.exe consumer emberplus get 127.0.0.1 --port 9100 --path dhs-emberplus-integration.types.vOctets
+# value = "aGVsbG8="    (known broken in Cerebrum + EmberPlusView UIs, wire OK)
+
+# Stream parameters (id=0 + id>0)
+.\bin\dhs.exe consumer emberplus get 127.0.0.1 --port 9100 --path dhs-emberplus-integration.types.vu_zero
+# value = -60.00    (streamIdentifier=0 — must NOT be treated as absent)
+
+.\bin\dhs.exe consumer emberplus get 127.0.0.1 --port 9100 --path dhs-emberplus-integration.types.vu_left
+# value ≈ -60.00 → updates live
+
+# Identity
+.\bin\dhs.exe consumer emberplus get 127.0.0.1 --port 9100 --path dhs-emberplus-integration.identity.dtdVersion
+# value = "2.60"
+```
+
+### Errors
+
+| Trigger | Command | Expected |
+|---|---|---|
+| wrong path | `get ... --path bogus.path.here` | `object not found (tree has 1361 entries)` |
+| missing required path | `get 127.0.0.1 --port 9100` | usage error |
+
+---
+
+## 4. `set` — write one Parameter
+
+### Happy
+
+```powershell
+.\bin\dhs.exe consumer emberplus set 127.0.0.1 --port 9100 `
+    --path dhs-emberplus-integration.nToN.targetParams.0.gain --value -25
+# confirmed value = -25
+
+.\bin\dhs.exe consumer emberplus set 127.0.0.1 --port 9100 `
+    --path dhs-emberplus-integration.nToN.targetParams.0.mute --value true
+# confirmed value = true
+
+.\bin\dhs.exe consumer emberplus set 127.0.0.1 --port 9100 `
+    --path dhs-emberplus-integration.types.vEnum --value 3
+# confirmed value = 3
+```
+
+### Errors (post #453)
+
+| Trigger | Command | Expected |
+|---|---|---|
+| unparseable int (#445) | `set ... gain --value -25.5` | `validation: value: invalid integer "-25.5"`, exit 2 |
+| unparseable int (letters) | `set ... gain --value abc` | `validation: value: invalid integer "abc"`, exit 2 |
+| unparseable real | `set ... vReal --value not-a-float` | `validation: value: invalid real "not-a-float"`, exit 2 |
+| enum overflow | `set ... vEnum --value 999` | `validation: value: invalid enum index "999"`, exit 2 |
+| write to read-only stream | `set ... vu_zero --value -10` | protocol error (provider rejects) |
+| wrong path | `set --path bogus --value 1` | object not found |
+
+---
+
+## 5. `watch` — live stream
+
+### Happy
+
+```powershell
+# Watch all stream Parameters (3 streams: id=0, 1001, 1002)
+.\bin\dhs.exe consumer emberplus watch 127.0.0.1 --port 9100 --streams-only
+# Updates every ~500ms
+
+# Watch one specific path
+.\bin\dhs.exe consumer emberplus watch 127.0.0.1 --port 9100 `
+    --path dhs-emberplus-integration.types.vu_zero --streams-only
+# Only vu_zero updates
+
+# Watch the locked-target tally on oneToN
+.\bin\dhs.exe consumer emberplus watch 127.0.0.1 --port 9100 `
+    --path dhs-emberplus-integration.oneToN.matrix
+```
+
+### Errors
+
+| Trigger | Command | Expected |
+|---|---|---|
+| connection refused | `watch ... --port 9999` | s101 framing error |
+| bad path filter | `watch --path bogus` | no events (filter matches nothing) |
+
+---
+
+## 6. `matrix` — Connect / Disconnect / Absolute
+
+### Happy
+
+```powershell
+# nToN — multi-source SET
+.\bin\dhs.exe consumer emberplus matrix 127.0.0.1 --port 9100 `
+    --path dhs-emberplus-integration.nToN.matrix `
+    --target 10 --sources 3,4,5 --op absolute
+# matrix connect: target 10 ← sources [3 4 5] (op=absolute)
+
+# nToN — disconnect one source
+.\bin\dhs.exe consumer emberplus matrix 127.0.0.1 --port 9100 `
+    --path dhs-emberplus-integration.nToN.matrix `
+    --target 10 --sources 4 --op disconnect
+# matrix connect: target 10 ← sources [4] (op=disconnect)
+
+# oneToN — replace single source
+.\bin\dhs.exe consumer emberplus matrix 127.0.0.1 --port 9100 `
+    --path dhs-emberplus-integration.oneToN.matrix `
+    --target 0 --sources 7 --op absolute
+# (target 0 now routed from src 7; prior src 0 dropped)
+
+# oneToOne — source steal (post #467)
+.\bin\dhs.exe consumer emberplus matrix 127.0.0.1 --port 9100 `
+    --path dhs-emberplus-integration.oneToOne.matrix `
+    --target 0 --sources 5 --op absolute
+# matrix connect: target 0 ← sources [5] (op=absolute)
+# Source 5 was on target 5; now stolen to target 0 — target 5 implicitly disconnected.
+# Profile counter: onetoone_source_steal_accepted += 1
+```
+
+### Errors
+
+| Trigger | Command | Expected |
+|---|---|---|
+| oneToN over-cardinality | `matrix oneToN --target 0 --sources 1,2 --op absolute` | `matrix validation: oneToN matrix: target 0 would have 2 sources (max 1) [spec p.33]`, exit 1 |
+| nToN over capacity | `matrix nToN --target 0 --sources 0,1,2,3,4,5 --op absolute` | `matrix validation: nToN matrix: target 0 would have 5 sources (max 4 per target)`, exit 1 |
+| locked target | `matrix oneToN --target 2 --sources 5 --op absolute` | rejected by provider; tally announce echoes back unchanged with `disposition: locked` |
+| wrong matrix path | `matrix --path bogus` | matrix not found at path "bogus" |
+
+---
+
+## 7. `invoke` — function RPC
+
+### Happy
+
+```powershell
+# Lock target 3 on oneToN (matrix-OID or dotted path both work)
+.\bin\dhs.exe consumer emberplus invoke 127.0.0.1 --port 9100 `
+    --path dhs-emberplus-integration.functions.setLock `
+    --args "1.1.3,3,true"
+# invocation 1: success=true
+# result: [false]       (previous lock state — was unlocked)
+
+# Same via dotted matrixRef (post #466)
+.\bin\dhs.exe consumer emberplus invoke 127.0.0.1 --port 9100 `
+    --path dhs-emberplus-integration.functions.setLock `
+    --args "dhs-emberplus-integration.oneToN.matrix,4,true"
+# invocation 1: success=true
+# result: [false]
+
+# List locked targets
+.\bin\dhs.exe consumer emberplus invoke 127.0.0.1 --port 9100 `
+    --path dhs-emberplus-integration.functions.listLocks `
+    --args "1.1.3"
+# result: [2,3,4]   (2 was pre-locked from seed)
+
+# Store salvo — all current connections on oneToN
+.\bin\dhs.exe consumer emberplus invoke 127.0.0.1 --port 9100 `
+    --path dhs-emberplus-integration.functions.storeSalvo `
+    --args "1.1.3,99,"
+# result: [true]
+
+# Get salvo dump
+.\bin\dhs.exe consumer emberplus invoke 127.0.0.1 --port 9100 `
+    --path dhs-emberplus-integration.functions.getSalvo `
+    --args "1.1.3,99"
+# result: ["0=0;1=1;3=3;..."]   (tgt=src list semicolon-separated)
+
+# Recall salvo
+.\bin\dhs.exe consumer emberplus invoke 127.0.0.1 --port 9100 `
+    --path dhs-emberplus-integration.functions.recallSalvo `
+    --args "1.1.3,99"
+# result: [N]    (rows restored)
+```
+
+### Errors (post #455 / #457)
+
+| Trigger | Command | Expected |
+|---|---|---|
+| bogus matrixRef | `invoke setLock --args "bogus.path,1,true"` | `invocation 1: success=false` (was silent success pre-#457) |
+| missing arg | `invoke setLock --args "1.1.3"` | `setLock: need (matrixPath, target, locked)` |
+| wrong type arg | `invoke setLock --args "1.1.3,abc,true"` | bad arg types |
+
+---
+
+## 8. `stream` — explicit subscribe
+
+### Happy
+
+```powershell
+.\bin\dhs.exe consumer emberplus stream 127.0.0.1 --port 9100 --id 0
+# Subscribes to streamIdentifier=0 only (vu_zero updates flow)
+
+.\bin\dhs.exe consumer emberplus stream 127.0.0.1 --port 9100 --id 1001
+# Subscribes to vu_left only
+
+.\bin\dhs.exe consumer emberplus stream 127.0.0.1 --port 9100 --id 0,1001
+# Subscribes to {vu_zero, vu_left} — R10 multi-subscribe
+
+.\bin\dhs.exe consumer emberplus stream 127.0.0.1 --port 9100 --id 0,1001,1002
+# Subscribes to all three explicitly (equivalent to no flag)
+
+.\bin\dhs.exe consumer emberplus stream 127.0.0.1 --port 9100
+# Subscribes to ALL streams (3 today)
+```
+
+### Errors
+
+| Case | Command | Error |
+|---|---|---|
+| bad token | `stream ... --id abc` | `validation: --id: bad token "abc"` |
+| empty token mid-csv | `stream ... --id 0,,1001` | `validation: --id: empty token in "0,,1001"` |
+| trailing comma | `stream ... --id 0,1001,` | `validation: --id: empty token in "0,1001,"` |
+
+---
+
+## 9. `profile` — compliance classification
+
+### Happy
+
+```powershell
+.\bin\dhs.exe consumer emberplus profile 127.0.0.1 --port 9100
+# host             127.0.0.1:9100
+# objects walked   1355
+# classification   strict
+# no tolerance events observed — provider is fully spec-compliant
+```
+
+After triggering source-steal (post #467), the counter `onetoone_source_steal_accepted` appears with its count.
+
+---
+
+## 10. `export` / `import` — round-trip (PARTIAL — #461)
+
+```powershell
+.\bin\dhs.exe consumer emberplus export 127.0.0.1 --port 9100 --format yaml --out demo.yaml
+# Writes demo.yaml
+
+.\bin\dhs.exe consumer emberplus import demo.yaml --port 9100
+# (partial — Glow type coverage not complete; see #461)
+```
+
+---
+
+## 11. `extract` — capture per-product DM triple
+
+```powershell
+.\bin\dhs.exe consumer emberplus extract 127.0.0.1 --port 9100 `
+    --manufacturer BY-Systems --product dhs-emberplus-integration `
+    --direction in --version 1.0.0 --out .audit/extract-demo
+# Writes meta.json + wire.pcapng + tree.json under the fixture layout
+```
+
+---
+
+## 12. `validate` — offline frame decode (ADR-0021)
+
+```powershell
+.\bin\dhs.exe consumer emberplus validate captures/emberplus/runbook/walk-happy.jsonl
+# Decodes each frame through the codec; emits PASS / FAIL per frame
+```
+
+---
+
+## 13. `bench` — matrix latency
+
+```powershell
+.\bin\dhs.exe consumer emberplus bench 127.0.0.1 --port 9100 `
+    --path dhs-emberplus-integration.nToN.matrix `
+    --n 1000 --op connect --targets 16 --sources 16
+# total: 1000 ops in N ms, M ops/s
+```
+
+Flags: `--path` (matrix path), `--n` (op count, default 100), `--op` (connect / absolute / disconnect, default connect), `--targets` / `--sources` (wrap modulo, default 4). No percentiles today — RFC 2544/8219 profile + cold-start + recovery pending **R13 #474**.
+
+---
+
+## Use-case status — Ember+ (Consumer + Provider)
+
+Current state on `main`. ✅ working, 🟡 partial, ❌ not implemented.
+
+| Seq | Use case | Consumer | Provider | Notes / refs |
+|---|---|---|---|---|
+| UC-1 | `info` — device summary | ✅ | ✅ | Online correct post #459 |
+| UC-2 | `walk` — full enumeration | ✅ | ✅ | tree_size ≈ 1361; DM auto-extracted to `.cache/dm/emberplus/<identity>@<rev>.json` |
+| UC-3 | `get` — single Parameter | ✅ | ✅ | every ParameterType + stream id=0 + id>0 + identity.dtdVersion |
+| UC-4 | `set` — single Parameter | ✅ | ✅ | typed-validation errors post #453; out-of-range / range-step rounding pending **R16** |
+| UC-5 | `watch` — live updates | ✅ | ✅ | streams + matrix tally + param announces |
+| UC-6 | `matrix` — Connect / Disconnect / Absolute | ✅ | ✅ | oneToOne source-steal accepted post #467 (fires `onetoone_source_steal_accepted`); oneToN over-cardinality + nToN capacity rejected client-side; lock honored |
+| UC-7 | `invoke` — function RPC | ✅ | ✅ | bogus matrixRef now errors post #457; dotted matrixRef resolves under synthetic root post #466 |
+| UC-8 | `stream` — explicit subscribe | ✅ R10 CSV | ✅ | `--id 0,1001` multi-subscribe post #479 |
+| UC-9 | `profile` — compliance counter | ✅ | n/a | reads provider profile; classification = strict by default |
+| UC-10 | `export` → `import` round-trip | 🟡 partial | 🟡 partial | Glow-type coverage gap — **#461 / R4**; `--dry-run` + per-type pass/fail/skip + `--scope` proposed in #461 comment |
+| UC-11 | `extract` — per-product DM triple | ✅ | n/a | writes meta.json + wire.pcapng + tree.json |
+| UC-12 | `validate` — offline jsonl decode | ✅ | n/a | Go-codec PASS/FAIL per frame; Wireshark `--lua` mode pending **R12 #473** |
+| UC-13 | `bench` — matrix latency | 🟡 | ✅ | total + ops/s only today; no p50/p95/p99, no cold-start, no recovery — **R13 #474** |
+| UC-14 | `health` — 3-layer liveness | ❌ #300 | ✅ | not implemented for Ember+ consumer; protocol returns `does not implement HealthChecker yet` |
+| UC-15 | `discover` — mDNS | ❌ R18 #477 | ❌ R18 #477 | producer announce + consumer scan on `_ember._tcp.local.` both pending |
+| UC-16 | `diff` / `convert` | ✅ | n/a | tree-vs-tree diff + format conversion both work offline |
+
+---
+
+## Pending R-items
+
+| R# | Issue | Status | Scope |
+|---|---|---|---|
+| R1 | [#468](https://github.com/by-openclaw/go-acp/issues/468) | open | layered error-code taxonomy |
+| R2/R3/R7 | (folded into PR δ) | pending | runbook prose + per-OS firewall snippet |
+| R4 | [#461](https://github.com/by-openclaw/go-acp/issues/461) | open + comment | export/import round-trip + `--dry-run` + `--scope` + per-type tally |
+| R5b | [#469](https://github.com/by-openclaw/go-acp/issues/469) | open | standalone `tree` verb + PlantUML |
+| R6 | [#470](https://github.com/by-openclaw/go-acp/issues/470) | open | `info` reads DTD version from device |
+| R8 | [#471](https://github.com/by-openclaw/go-acp/issues/471) | open | service installer epic (per-OS) |
+| R9 | [#472](https://github.com/by-openclaw/go-acp/issues/472) | open | provider stream idle-TTL eviction |
+| R10 | [#478](https://github.com/by-openclaw/go-acp/issues/478) | **landed #479** | `stream --id` CSV multi-subscribe |
+| R11 | TBD | not yet filed | `getSalvo` human format `tgt N <- Src [a,b,c]` |
+| R12 | [#473](https://github.com/by-openclaw/go-acp/issues/473) | open | `validate --lua` via tshark |
+| R13 | [#474](https://github.com/by-openclaw/go-acp/issues/474) | open | `bench` RFC 2544 + cold-start + recovery |
+| R14 | [#475](https://github.com/by-openclaw/go-acp/issues/475) | open | `--ensure {present\|absent\|dryrun}` (Ansible) |
+| R15 | [#476](https://github.com/by-openclaw/go-acp/issues/476) | open | `-v` ladder + `--log-format {text\|json\|loki}` + `--log-only` |
+| R16 | TBD | not yet filed | `set` range/step round + enum-by-label |
+| R17 | (folded into R8) | pending | per-OS firewall rules + runas-admin |
+| R18 | [#477](https://github.com/by-openclaw/go-acp/issues/477) | open | bidirectional mDNS on `_ember._tcp.local.` |
+| R19 | TBD | not yet filed | audit pass: consumer-vs-provider parity per use case |
+| R20 | TBD | not yet filed | matrix doc at `docs/protocols/use-cases/emberplus.md` |
+
+---
+
+## Cleanup
+
+```powershell
+# Preferred: Ctrl-C in the producer window (S101 keepalive + sessions
+# get a clean shutdown event, compliance counters flush to log).
+#
+# If running detached, kill by tracked PID:
+$pid = Get-Content .audit/producer.pid
+Stop-Process -Id $pid -Force
+```
+
+> ⚠ **Do NOT** broad-`Stop-Process dhs` while a Cerebrum control session
+> is live — sessions get torn mid-frame and the NB driver can hang
+> reconnect logic (memory: `feedback_no_multilayer_bundle`,
+> `feedback_dhs_process_discipline`). Track the PID at producer start
+> and use targeted shutdown.

--- a/internal/emberplus/docs/runbook/export-import.md
+++ b/internal/emberplus/docs/runbook/export-import.md
@@ -1,0 +1,132 @@
+# `export` / `import` — full reference
+
+Linked from the main runbook §10. This file is the canonical reference for the export/import round-trip on Ember+, including the full scope of [#461](https://github.com/by-openclaw/go-acp/issues/461) (R4).
+
+## Today on `main` (PARTIAL)
+
+Round-trip works for a subset of Glow types; gaps tracked in [#461](https://github.com/by-openclaw/go-acp/issues/461). The verb signatures match the rest of the catalogue (`--port`, `--out`, etc.).
+
+### `--format` matrix
+
+| `--format` | Extension | Typical use |
+|---|---|---|
+| `json` | `.json` | machine-readable; lossless re-import; default |
+| `yaml` | `.yaml` / `.yml` | human-edit-friendly; same schema as JSON |
+| `csv` | `.csv` | spreadsheet-friendly tabular view; flattens nested structure (matrix labels become indexed rows) |
+
+### Happy
+
+```powershell
+# Full tree export — every supported Glow type
+.\bin\dhs.exe consumer emberplus export 127.0.0.1 --port 9100 --format json --out demo.json
+.\bin\dhs.exe consumer emberplus export 127.0.0.1 --port 9100 --format yaml --out demo.yaml
+.\bin\dhs.exe consumer emberplus export 127.0.0.1 --port 9100 --format csv  --out demo.csv
+
+# Re-import on a fresh producer
+.\bin\dhs.exe consumer emberplus import demo.yaml --port 9100
+```
+
+### Partial export (current shape — header preserved)
+
+A partial export — e.g. only the `identity` subtree — keeps the document header (root identifier, dtdVersion, capture timestamp) so the importer can locate the slot:
+
+```yaml
+# demo-identity-only.yaml
+device:
+  identifier: dhs-emberplus-integration
+  dtdVersion: 2.60
+  capturedAt: 2026-05-17T13:22:00Z
+elements:
+  - oid: "1.0"
+    path: "identity"
+    type: node
+    children:
+      - oid: "1.0.1"
+        path: "identity.product"
+        type: parameter
+        value: "dhs-emberplus-integration"
+      # ... only identity subtree, no matrices / functions / types
+```
+
+Header rules:
+- `device.identifier` MUST match the importer's target — else fail with `validation: device-identifier-mismatch`
+- `device.dtdVersion` warns on mismatch but does not block (post #459 isOnline + post #466 reroot make this safe in most cases)
+- `device.capturedAt` is informational only
+
+## R4 [#461](https://github.com/by-openclaw/go-acp/issues/461) — full round-trip scope
+
+Round-trip on the integration demo:
+
+1. `export 127.0.0.1 --port 9100 --format yaml --out /tmp/dump.yaml` against the running demo
+2. Stop demo, start a fresh producer pointed at an empty manifest
+3. `import /tmp/dump.yaml --port 9100`
+4. `walk` → assert byte-identical canonical tree (or canonical-equivalent after deterministic normalisation)
+
+Coverage required across all Glow types:
+
+| Type | Notes |
+|---|---|
+| Node | + `isOnline` + `schemaIdentifiers` + `templateReference` (DTD 2.30+) |
+| Parameter | every `ParameterType` — Integer, Real, Boolean, String, Octets, Enum + `factor` + `step` + `format` + `default` + `min/max` + `enumMap` |
+| Matrix | every type (oneToOne / oneToN / nToN / dynamic) with labels (Pri + Sec), source/target/connection params (gain layers), connections, locked targets |
+| Function | tuple shape (args + results) |
+| Stream Parameter | `streamIdentifier` id=0 + id>0 |
+| Template / QualifiedTemplate | per ADR-0024 federation |
+
+## `--dry-run` import + per-type tally + `--scope` (extends R4 — see [#461 comment](https://github.com/by-openclaw/go-acp/issues/461#issuecomment-4470752301))
+
+### Dry-run import
+
+`dhs consumer emberplus import <file> --dry-run` parses the dump, resolves every node/parameter/matrix/function path against the live tree, and emits the diff — but sends zero wire traffic. Output format matches `--ensure dryrun` from [#475](https://github.com/by-openclaw/go-acp/issues/475) (R14) so operators see one consistent diff format across `set` / `matrix` / `invoke` / `import`.
+
+### Per-Glow-type pass/fail/skip classification
+
+```
+type=Node              count=42  ok=42  fail=0  skip=0
+type=Parameter         count=189 ok=187 fail=2  skip=0
+  fail: oneToN.target.0.gain (parse: factor missing)
+  fail: identity.dtdVersion (parse: not in DTD 2.60 enum)
+type=Matrix            count=4   ok=4   fail=0  skip=0
+type=Function          count=6   ok=6   fail=0  skip=0
+type=StreamParameter   count=3   ok=3   fail=0  skip=0
+type=Template          count=0   ok=0   fail=0  skip=0
+```
+
+- `skip` covers types the producer/consumer doesn't yet support (e.g. Template before federation lands)
+- `fail` is the bug surface — silent drops are unacceptable
+
+### `--scope <path>` for sample exports
+
+```powershell
+.\bin\dhs.exe consumer emberplus export ... --scope identity         --out identity.yaml
+.\bin\dhs.exe consumer emberplus export ... --scope mtx.oneToN       --out matrix-oneToN.yaml
+.\bin\dhs.exe consumer emberplus export ... --scope params.layers    --out params-layers.yaml
+.\bin\dhs.exe consumer emberplus export ... --scope func.builtin.recallSalvo --out func-recallSalvo.yaml
+```
+
+Use cases:
+- Build per-type test fixtures → one file per Glow type under `internal/emberplus/testdata/protocol_types/`
+- Operator handoff — "send me your identity tree" without dumping 65535² of matrix data
+- CI regression fixtures — small, type-focused dumps that exercise one code path
+
+`--scope` composes with `--format` and `--out`.
+
+## Errors
+
+| Trigger | Command | Expected | Exit |
+|---|---|---|---|
+| target file unwritable | `export ... --out /no/perm/dump.yaml` | `export: open /no/perm/dump.yaml: permission denied` | 1 |
+| input file missing | `import does-not-exist.yaml` | `import: open does-not-exist.yaml: no such file` | 1 |
+| device identifier mismatch | `import other-device.yaml --port 9100` | `validation: device-identifier-mismatch: expected "dhs-emberplus-integration", got "other-device"` | 2 |
+| dry-run on existing path that doesn't resolve | `import dump.yaml --dry-run` (with stale path) | per-type tally with `fail:` rows; exit 0 (dry-run never mutates) | 0 |
+| connection refused on import | `import ... --port 9999` | s101 framing error | 1 |
+| `--scope` with unknown subtree | `export ... --scope bogus` | `validation: --scope: object not found at path "bogus"` | 2 |
+
+## Refs
+
+- [ADR-0022 — Card data model](../../../../docs/adr/0022-card-data-model.md)
+- [ADR-0024 — Federation mirror vs virtual frame](../../../../docs/adr/0024-federation-mirror-and-virtual-frame.md)
+- [ADR-0025 — Per-connector definition of done](../../../../docs/adr/0025-connector-definition-of-done.md)
+- [#461](https://github.com/by-openclaw/go-acp/issues/461) — round-trip + dry-run + scope
+- [#475](https://github.com/by-openclaw/go-acp/issues/475) — R14 `--ensure` (shared diff format)
+- [#442](https://github.com/by-openclaw/go-acp/issues/442) — multi-sheet XLSX matrix export (separate)

--- a/internal/emberplus/docs/runbook/validate.md
+++ b/internal/emberplus/docs/runbook/validate.md
@@ -1,0 +1,114 @@
+# `validate` — full reference
+
+Linked from the main runbook §12. Offline frame decode + report generation (ADR-0021).
+
+## Today on `main`
+
+`validate` reads a `frames.jsonl` capture (the `--capture` output from `walk` / `watch`) and decodes each frame through the Go codec. Default output: PASS/FAIL per frame on stdout.
+
+### Happy
+
+```powershell
+.\bin\dhs.exe consumer emberplus validate captures/emberplus/runbook/walk-happy.jsonl
+# frame   0  PASS  s101+glow+ber  dir=rx ts=2026-05-17T13:22:01.123Z
+# frame   1  PASS  s101+glow+ber  dir=tx ts=2026-05-17T13:22:01.124Z
+# ...
+# frame 547  PASS  s101+glow+ber  dir=rx ts=2026-05-17T13:22:04.812Z
+#
+# summary: 548 frames, 548 PASS, 0 FAIL
+```
+
+### Wireshark dissector mode — R12 [#473](https://github.com/by-openclaw/go-acp/issues/473) (pending)
+
+`validate --lua` replays each frame through the project's Wireshark dissector (`internal/emberplus/wireshark/dhs_emberplus.lua`) via `tshark -X lua_script:<path>`. Output matches `tshark -V` text-tree format — useful for operators familiar with Wireshark.
+
+```powershell
+.\bin\dhs.exe consumer emberplus validate captures/emberplus/runbook/walk-happy.jsonl --lua
+# frame   0  ── Frame 1: 76 bytes on wire (608 bits), 76 bytes captured
+#                 dhs_emberplus
+#                     S101 framing
+#                         BOF: 0xfe
+#                         Length: 71
+#                     ...
+```
+
+Pending — see [#473](https://github.com/by-openclaw/go-acp/issues/473).
+
+## R23 (not yet filed) — `--report <md|json>`
+
+Generate a structured report file alongside the PASS/FAIL stdout:
+
+```powershell
+.\bin\dhs.exe consumer emberplus validate captures/emberplus/runbook/walk-happy.jsonl --report report.md
+.\bin\dhs.exe consumer emberplus validate captures/emberplus/runbook/walk-happy.jsonl --report report.json
+```
+
+### Markdown report shape
+
+```markdown
+# Validation report — walk-happy.jsonl
+
+- File: `captures/emberplus/runbook/walk-happy.jsonl`
+- Frames: 548
+- Pass:   548 (100.0%)
+- Fail:   0
+- Started: 2026-05-17T13:22:01.123Z
+- Ended:   2026-05-17T13:22:04.812Z
+
+## Per-layer pass rate
+
+| Layer | Pass | Fail | Notes |
+|---|---:|---:|---|
+| S101 framing | 548 | 0 | CRC + escape + keepalive all clean |
+| BER decode | 548 | 0 | every APPLICATION tag resolved |
+| Glow tree | 548 | 0 | every element type round-trips |
+| Streams | 12 | 0 | id=0 + id=1001 + id=1002 |
+
+## Failures
+
+(empty when all PASS — populated with frame# + offset + decoder error when FAIL)
+```
+
+### JSON report shape
+
+```json
+{
+  "file": "captures/emberplus/runbook/walk-happy.jsonl",
+  "frames": 548,
+  "pass": 548,
+  "fail": 0,
+  "started": "2026-05-17T13:22:01.123Z",
+  "ended": "2026-05-17T13:22:04.812Z",
+  "byLayer": {
+    "s101":   { "pass": 548, "fail": 0 },
+    "ber":    { "pass": 548, "fail": 0 },
+    "glow":   { "pass": 548, "fail": 0 },
+    "stream": { "pass": 12,  "fail": 0 }
+  },
+  "failures": []
+}
+```
+
+### Acceptance for R23
+
+- `--report report.md` writes a deterministic markdown report (timestamps + per-layer table + failure list)
+- `--report report.json` writes the same data as JSON for CI consumption
+- Mutually exclusive: `--report` and `--lua` can stack (`--lua` controls the per-frame decoder; `--report` controls the summary file)
+- If `--report` target unwritable → `validate: open <path>: permission denied`, exit 1
+
+## Errors
+
+| Trigger | Command | Expected | Exit |
+|---|---|---|---|
+| missing file | `validate does-not-exist.jsonl` | `validate: open does-not-exist.jsonl: no such file` | 1 |
+| not jsonl | `validate file.txt` | `validate: line 1: invalid JSON: ...` | 1 |
+| frame decode failure | (corrupted frame in jsonl) | `frame N  FAIL  layer=glow offset=...  decode: ...`; summary line counts FAIL | 1 |
+| tshark missing for `--lua` (R12) | `validate ... --lua` (no tshark on PATH) | `validation: tshark not found — install Wireshark (https://www.wireshark.org)` | 2 |
+| report target unwritable (R23) | `validate ... --report /no/perm/r.md` | `validate: open /no/perm/r.md: permission denied` | 1 |
+
+## Refs
+
+- [ADR-0021 — capture conventions + validate verb](../../../../docs/adr/0021-capture-conventions.md)
+- [`internal/emberplus/wireshark/dhs_emberplus.lua`](../../wireshark/dhs_emberplus.lua) — byte-exact dissector
+- [#473](https://github.com/by-openclaw/go-acp/issues/473) — R12 `--lua` mode
+- R23 (not yet filed) — `--report <md|json>`


### PR DESCRIPTION
## Summary

**Draft PR — codeowner tracking surface for the Ember+ operational runbook.**

Publishes `internal/emberplus/docs/runbook.md` + two linked sub-docs so the codeowner has a stable GitHub URL to read, comment, and track updates against (instead of bouncing through the local `.audit/runbook-draft.md` working copy).

Content reflects current `main` after the 5 recently-landed Ember+ PRs (#463, #480, #466, #467, #479) and earlier fixes (#453, #457, #459).

## What's in it

- **Scope** — protocol / role / OS coverage matrix + landed-PRs table
- **Setup** — single `git pull + go build + producer serve` block
- **Tree shape** — synthetic root + 7 children (identity, oneToN, oneToOne, nToN, dynamic, functions, types) with OIDs
- **Addressing — by path vs by OID** — top-level OID map; R21 [#486](https://github.com/by-openclaw/go-acp/issues/486) pending for `--path` accepting OID input
- **Exit codes & error taxonomy** — 4 exit-code classes (0/1/2/3) + 8 layer prefixes per R1 [#468](https://github.com/by-openclaw/go-acp/issues/468); Ember+-has-no-native-codes note; shell + Ansible dispatch examples
- **Verb catalogue** — 18 verbs with Status column (✅ / 🟡 / ❌); `health` + `discover` marked TODO
- **Per-verb sections (§1-§13)** — Happy + Errors for `info`, `walk`, `get`, `set`, `watch`, `matrix`, `invoke`, `stream`, `profile`, `export`/`import`, `extract`, `validate`, `bench`. Commands verified against actual flag definitions in `cmd/dhs/cmd_*.go`. Every Happy example annotates the OID alongside the dotted path. Every Errors table carries an Error-code column with the canonical `<layer>:<code>` string
- **Linked sub-docs** for the heavier verbs:
  - [`runbook/export-import.md`](https://github.com/by-openclaw/go-acp/blob/docs/emberplus-runbook-pr-delta/internal/emberplus/docs/runbook/export-import.md) — full R4 [#461](https://github.com/by-openclaw/go-acp/issues/461) round-trip spec + `--dry-run` + per-type pass/fail/skip + `--scope`
  - [`runbook/validate.md`](https://github.com/by-openclaw/go-acp/blob/docs/emberplus-runbook-pr-delta/internal/emberplus/docs/runbook/validate.md) — R12 [#473](https://github.com/by-openclaw/go-acp/issues/473) `--lua` mode + R23 [#488](https://github.com/by-openclaw/go-acp/issues/488) `--report <md|json>`
- **Use-case status table** — UC-1 … UC-16 with Consumer + Provider columns + landed-PR refs + pending-R# refs
- **Pending R-items table** — R1 … R25 linked to filed issues (#461, #468-#477, #482-#490) + R2/R3/R7 noted as folded into this runbook
- **Cleanup** — PID-tracked shutdown; warns against broad `Stop-Process dhs` while Cerebrum sessions live

## How to track updates

Each push to this branch updates the file in place. Stable URLs:

- PR Files tab (full diff): https://github.com/by-openclaw/go-acp/pull/481/files
- Runbook (latest SHA): https://github.com/by-openclaw/go-acp/blob/docs/emberplus-runbook-pr-delta/internal/emberplus/docs/runbook.md
- Sub-doc — export/import: https://github.com/by-openclaw/go-acp/blob/docs/emberplus-runbook-pr-delta/internal/emberplus/docs/runbook/export-import.md
- Sub-doc — validate: https://github.com/by-openclaw/go-acp/blob/docs/emberplus-runbook-pr-delta/internal/emberplus/docs/runbook/validate.md

Or `git fetch origin docs/emberplus-runbook-pr-delta` locally.

## Test plan

- [x] Markdown renders correctly on GitHub
- [x] Every verb command verified against actual flag definitions in `cmd/dhs/cmd_*.go`
- [x] All landed PR refs (#453, #457, #459, #463, #466, #467, #479, #480) cross-checked
- [x] All filed R-item issue refs (#461, #468-#478, #482-#490) reachable
- [x] OID lookup tables (§3 get, §6 matrix, §7 invoke, §8 stream) match the integration-test DM fixtures byte-for-byte
- [x] Exit-code taxonomy + Error-code column applied to every Errors table
- [ ] **Codeowner walkthrough** (this PR's purpose) — work through every verb, file inline comments where the runbook diverges from observed behavior

## Out of scope (folded into later PRs)

- Capture batch (per-type fixtures under `internal/emberplus/testdata/protocol_types/`) — separate PR
- R2/R3/R7 prose enrichment + R17 firewall snippet (per-OS) — fold into this PR or follow-up before merge
- Promotion to non-draft once content stabilizes after codeowner walkthrough

## Refs

Refs #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)
