### PR TITLE
feat(errcode): typed error-code taxonomy foundation (R1a, refs #468)

### DIFF
--- a/docs/protocols/error-codes.md
+++ b/docs/protocols/error-codes.md
@@ -1,0 +1,185 @@
+# Error codes — canonical list
+
+Every error returned by dhs follows the contract:
+
+- **Exit code**: `0` success · `1` runtime / wire / protocol error · `2` usage / validation / state error. Standard Unix; never `3+`. Cross-OS uniform (PowerShell `$LASTEXITCODE`, Bash `$?`, `cmd.exe %ERRORLEVEL%` all parse the same).
+- **Stderr message**: `<layer>:<code>: <human message>` — stable, grep-able, identical on Linux / macOS / Windows.
+
+Implementation: `internal/errcode/` defines `Code` + `Layer` + `Class`. Each layer declares typed sentinels (e.g. `transport.ErrRefused`). Call sites wrap with `fmt.Errorf("%w: %s", ErrCode, dynamic)`. Callers dispatch with `errors.Is(err, transport.ErrRefused)` or `errcode.From(err)`. The CLI binary exits via `os.Exit(errcode.Exit(err))`.
+
+Memory: `feedback_error_contract_cross_os` locks the rule across every connector.
+
+---
+
+## Layers
+
+| Layer | Owned by | Exit class |
+|---|---|---|
+| `transport` | `internal/transport/` + Go `net` package | 1 |
+| `s101` | `internal/emberplus/codec/s101/` | 1 |
+| `glow` | `internal/emberplus/codec/glow/` | 1 |
+| `ber` | `internal/emberplus/codec/ber/` | 1 |
+| `matrix` | `internal/emberplus/codec/matrix/` | 1 |
+| `emberplus` | `internal/emberplus/{consumer,provider}/` | 1 |
+| `acp1` | `internal/acp1/` (future) | 1 |
+| `acp2` | `internal/acp2/` (future) | 1 |
+| `probel` | `internal/probel-*/` (future) | 1 |
+| `validation` | `internal/consumer/` validation layer | 2 |
+| `plugin` | `internal/<proto>/` plugin-state checks | 2 |
+| `session` | session-state layer | 1 |
+
+---
+
+## Codes
+
+> **Migration status**: this file is the canonical list. R1a (this PR) ships the `internal/errcode/` infrastructure only. Subsequent PRs (R1b, R1c, ...) migrate each layer's existing free-text errors to typed `*errcode.Code` sentinels. Codes listed below with `status: pending` are planned but not yet defined in code; codes with `status: defined` have a corresponding `Err<Code>` var in their layer's package.
+
+### transport
+
+| Code | Status | When | Anchor |
+|---|---|---|---|
+| `transport:refused` | pending (R1b) | TCP dial returns ECONNREFUSED | OS / Go `net.OpError` |
+| `transport:timeout` | pending (R1b) | dial / read / write deadline elapsed | OS / `net.Error.Timeout()` |
+| `transport:reset` | pending (R1b) | TCP RST mid-session | OS / ECONNRESET |
+
+### s101
+
+| Code | Status | When | Anchor |
+|---|---|---|---|
+| `s101:crc-mismatch` | pending (R1c) | CRC-16/CCITT verify failed on frame inner bytes | Ember+ Doc §S101 Framing p.94 |
+| `s101:bad-escape` | pending (R1c) | escape-stuffing rule violated (`0xFD 0xDE` expected) | spec p.94 |
+| `s101:unknown-message-type` | pending (R1c) | S101 header carries an unrecognized type byte | spec p.94 |
+| `s101:multi-frame-truncated` | pending (R1c) | MPM flag set but stream ended mid-message | spec p.94 |
+
+### glow / ber
+
+| Code | Status | When | Anchor |
+|---|---|---|---|
+| `glow:bad-tag` | pending (R1d) | BER tag parse failure | ITU-T X.690 §8.1 |
+| `glow:bad-length` | pending (R1d) | BER length encoding invalid | X.690 §8.1.3 |
+| `glow:bad-real` | pending (R1d) | BER REAL decode failed | X.690 §8.5 + memory `reference_emberplus_ber_real` |
+| `glow:unknown-application-tag` | pending (R1d) | APPLICATION tag not in the GlowDTD enum | Ember+ Doc §p.84-91 |
+| `ber:bad-relative-oid` | pending (R1d) | RELATIVE-OID decode failed | X.690 §8.20 |
+
+### matrix
+
+| Code | Status | When | Anchor |
+|---|---|---|---|
+| `matrix:cardinality-exceeded` | pending (R1e) | matrix type (oneToOne / oneToN) limit violated | Ember+ Doc §p.33 |
+| `matrix:target-locked` | pending (R1e) | target's `ConnectionDisposition=Locked(3)` | Ember+ Doc §p.89; site already exists in `internal/emberplus/codec/matrix/state.go` |
+| `matrix:max-connects-per-target` | pending (R1e) | nToN per-target capacity exceeded | Ember+ Doc §p.88 |
+| `matrix:max-total-connects` | pending (R1e) | nToN total-connections capacity exceeded | Ember+ Doc §p.88 |
+
+### emberplus
+
+| Code | Status | When | Anchor |
+|---|---|---|---|
+| `emberplus:invocation-failed` | pending (R1f) | `InvocationResult.Success=false`, no description | Ember+ Doc §p.92 |
+| `emberplus:invocation-failed-with-description` | pending (R1f) | `Success=false` + provider populated `description` | Ember+ Doc §p.92 |
+
+### validation
+
+| Code | Status | When | Anchor |
+|---|---|---|---|
+| `validation:invalid-integer` | partial (today emits free-text via `*consumer.ValidationError`; R1g formalizes) | `--value` not parseable as integer | dhs PR #453 |
+| `validation:invalid-real` | partial | `--value` not parseable as real | dhs PR #453 |
+| `validation:invalid-enum-index` | partial | `--value` outside enum range | dhs PR #453 |
+| `validation:invalid-enum-label` | pending (R16 [#483](https://github.com/by-openclaw/go-acp/issues/483)) | `--value` is label not in `enumMap` | Ember+ Doc §p.86 |
+| `validation:out-of-range-low` | pending (R16 [#483](https://github.com/by-openclaw/go-acp/issues/483)) | value below Parameter `minimum` | Ember+ Doc §p.86 |
+| `validation:out-of-range-high` | pending (R16 [#483](https://github.com/by-openclaw/go-acp/issues/483)) | value above Parameter `maximum` | Ember+ Doc §p.86 |
+| `validation:step-misaligned` | pending (R16 [#483](https://github.com/by-openclaw/go-acp/issues/483)) | value not on Parameter `step` grid | Ember+ Doc §p.86 |
+| `validation:invalid-oid` | pending (R21 [#486](https://github.com/by-openclaw/go-acp/issues/486)) | `--path` matches OID regex but bad syntax (`1..2`) | dhs |
+| `validation:invalid-format` | pending (R11 [#482](https://github.com/by-openclaw/go-acp/issues/482) · R22 [#487](https://github.com/by-openclaw/go-acp/issues/487)) | `--format` value not in supported set | dhs |
+| `validation:invalid-duration` | pending (R22 [#487](https://github.com/by-openclaw/go-acp/issues/487)) | `--since` not a Go duration | dhs |
+| `validation:invalid-id-token` | pending (R1g formalizes existing `--id` CSV errors from R10) | bad / empty token in CSV `--id` | dhs PR #479 (R10) |
+| `validation:invalid-direction` | pending (R1g) | `--direction` not `in` / `out` | dhs |
+| `validation:device-identifier-mismatch` | pending (R4 [#461](https://github.com/by-openclaw/go-acp/issues/461)) | import file's `device.identifier` ≠ target's | ADR-0022 |
+| `validation:admin-port-collides-with-wire` | pending (R24 [#489](https://github.com/by-openclaw/go-acp/issues/489)) | `--admin-addr` resolves to same `host:port` as wire `--port` | memory `feedback_admin_web_minimal` |
+| `validation:admin-feature-unknown` | pending (R25 [#490](https://github.com/by-openclaw/go-acp/issues/490)) | unknown admin feature name | dhs |
+| `validation:admin-action-invalid` | pending (R25) | admin action invalid for the named feature | dhs |
+| `validation:admin-restart-required` | pending (R25) | admin feature can only change at restart | dhs |
+| `validation:invalid-log-level` | pending (R25 + R15 [#476](https://github.com/by-openclaw/go-acp/issues/476)) | log-level value not in `info\|debug\|trace`... | dhs |
+
+### plugin
+
+| Code | Status | When | Anchor |
+|---|---|---|---|
+| `plugin:not-implemented` | partial (today: `ErrNotImplemented`) | plugin stub for unsupported operation | dhs `internal/consumer/errors.go:11` |
+| `plugin:not-connected` | partial (today: `ErrNotConnected`) | call requires a live transport and none established | dhs `internal/consumer/errors.go:15` |
+| `plugin:not-walked` | pending (R1g) | call requires walked tree state | dhs `internal/emberplus/consumer/plugin.go::ensureWalked` |
+| `plugin:object-not-found` | partial (today: `ErrObjectNotFound`) | tree miss on path / OID | dhs `internal/consumer/value_validator.go:34` |
+| `plugin:wrong-kind` | pending (R1g) | resolved object isn't the kind the verb needs (e.g. `set` on Node) | dhs |
+| `plugin:by-session-unavailable` | pending (R22 [#487](https://github.com/by-openclaw/go-acp/issues/487)) | `profile --by-session` and no R24 admin endpoint reachable | dhs |
+| `plugin:admin-socket-not-found` | pending (R25 [#490](https://github.com/by-openclaw/go-acp/issues/490)) | local admin socket not found (producer not running) | dhs |
+
+### session
+
+| Code | Status | When | Anchor |
+|---|---|---|---|
+| `session:write-timeout` | partial (today: `ErrWriteTimeout`) | write transmitted, no confirm within window | dhs `internal/consumer/errors.go:24` |
+| `session:write-coerced` | partial (today: `ErrWriteCoerced`) | provider echoed a different value (clamp/round) | dhs `internal/consumer/errors.go:30` |
+| `session:write-rejected` | partial (today: `ErrWriteRejected`) | provider's echo refuses the write | dhs `internal/consumer/errors.go:35` |
+| `session:dead` | pending (R1g) | session liveness layer reports dead | memory `project_session_health` |
+
+---
+
+## Cross-OS dispatch examples
+
+### Bash
+
+```bash
+err=$(dhs consumer emberplus set ... 2>&1)
+case "$err" in
+  transport:*)  echo "retry-able transport problem" ;;
+  validation:*) echo "fix input" ;;
+  matrix:*)     echo "protocol-level rejection" ;;
+  emberplus:invocation-failed*) echo "Invoke returned Success=false" ;;
+esac
+echo "exit: $?"
+```
+
+### PowerShell
+
+```powershell
+$err = (dhs consumer emberplus set ... 2>&1)
+switch -Regex ($err) {
+    '^transport:'  { 'retry-able transport problem' }
+    '^validation:' { 'fix input' }
+    '^matrix:'     { 'protocol-level rejection' }
+    '^emberplus:invocation-failed' { 'Invoke returned Success=false' }
+}
+"exit: $LASTEXITCODE"
+```
+
+### Ansible task
+
+```yaml
+- name: gain set
+  command: dhs consumer emberplus set --path ... --value -25
+  register: r
+  failed_when:
+    - r.rc != 0
+    - r.stderr is not search('^validation:invalid-enum-label')   # tolerate one specific code
+```
+
+---
+
+## CI gate (post R1d)
+
+A linter check runs on `main` push:
+
+1. Every `errcode.New(...)` invocation in the codebase has a corresponding `### <layer>` row in this file
+2. Every code listed in this file has a corresponding `Err<Code>` var in its layer's package
+3. Drift (orphaned codes or missing docs) fails the lint step
+
+Pattern: `make lint-error-codes` (alias for the CI step).
+
+---
+
+## Refs
+
+- R1 [#468](https://github.com/by-openclaw/go-acp/issues/468) — the parent epic
+- Memory `feedback_error_contract_cross_os` — locked contract
+- Memory `reference_emberplus_ber_real` — BER REAL convention anchor (referenced by `glow:bad-real`)
+- Memory `feedback_admin_web_minimal` — admin-port collision rule (referenced by `validation:admin-port-collides-with-wire`)
+- [`internal/emberplus/docs/runbook.md`](../../internal/emberplus/docs/runbook.md) — operator-facing summary

--- a/internal/errcode/errcode.go
+++ b/internal/errcode/errcode.go
@@ -1,0 +1,145 @@
+// Package errcode is the layered error-code taxonomy for dhs.
+//
+// Every error site in the codebase wraps a typed *Code so callers (CLI,
+// scripts, Ansible) can dispatch on a stable <layer>:<code> string without
+// parsing free-text messages. The contract is uniform across every connector
+// (Ember+, ACP1, ACP2, Probel, AMWA, ...) per memory
+// feedback_error_contract_cross_os.
+//
+// Wire shape on stderr:
+//
+//	<layer>:<code>: <human message>
+//
+// Examples:
+//
+//	transport:refused: connect 127.0.0.1:9100: connection refused
+//	validation:out-of-range-low: value -200 below minimum -100
+//	matrix:target-locked: target 2 is locked (spec p.89 ConnectionDisposition)
+//
+// CLI exit code: 0 on success, 2 on usage/validation, 1 on every other error.
+// Cross-OS uniform — PowerShell $LASTEXITCODE, Bash $?, cmd.exe %ERRORLEVEL%
+// all parse identically.
+//
+// Usage:
+//
+//	// Define a typed code in your layer package.
+//	var ErrRefused = errcode.New(errcode.LayerTransport, "refused", errcode.ClassRuntime)
+//
+//	// Wrap at the error site.
+//	if err != nil {
+//	    return fmt.Errorf("%w: connect %s: %v", ErrRefused, addr, err)
+//	}
+//
+//	// Dispatch at the call site.
+//	if errors.Is(err, transport.ErrRefused) { ... }
+//	if code := errcode.From(err); code != nil { ... }
+//	os.Exit(errcode.Exit(err))
+package errcode
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Layer is the system layer that owns a code. Layers map to package
+// boundaries: transport, codec sublayers (s101/glow/ber/matrix), plugin
+// state, session, validation, and per-protocol invocation errors.
+type Layer string
+
+const (
+	LayerTransport  Layer = "transport"
+	LayerS101       Layer = "s101"
+	LayerGlow       Layer = "glow"
+	LayerBER        Layer = "ber"
+	LayerMatrix     Layer = "matrix"
+	LayerEmberplus  Layer = "emberplus"
+	LayerACP1       Layer = "acp1"
+	LayerACP2       Layer = "acp2"
+	LayerProbel     Layer = "probel"
+	LayerValidation Layer = "validation"
+	LayerPlugin     Layer = "plugin"
+	LayerSession    Layer = "session"
+)
+
+// Class is the exit-code class for the CLI. Per
+// feedback_error_contract_cross_os the contract is Unix-standard 0/1/2 only.
+// Never 3+.
+type Class int
+
+const (
+	// ClassSuccess is exit 0 — verb completed.
+	ClassSuccess Class = 0
+	// ClassRuntime is exit 1 — any runtime / wire / protocol error.
+	// Caller reads stderr for the precise <layer>:<code>.
+	ClassRuntime Class = 1
+	// ClassUsage is exit 2 — Go flag parse failure, validation:* codes,
+	// plugin:object-not-found, plugin:not-connected — caller's input fault.
+	ClassUsage Class = 2
+)
+
+// Code is a typed error code. Used as a sentinel: wrap at the error site
+// with fmt.Errorf("%w: %s", code, dynamic) so errors.Is(err, code) walks
+// the chain.
+//
+// The stringified form is "<layer>:<name>" — that's the stable prefix
+// that scripts grep on. The dynamic detail (which path, which value)
+// follows after the colon.
+type Code struct {
+	Layer Layer
+	Name  string
+	Class Class
+}
+
+// New returns a typed error code. Caller owns the returned pointer; the
+// usual pattern is one package-level var per code.
+func New(layer Layer, name string, class Class) *Code {
+	if layer == "" {
+		panic("errcode.New: layer is empty")
+	}
+	if name == "" {
+		panic("errcode.New: name is empty")
+	}
+	return &Code{Layer: layer, Name: name, Class: class}
+}
+
+// Error makes *Code satisfy the error interface so it composes with
+// fmt.Errorf %w and errors.Is.
+func (c *Code) Error() string {
+	return fmt.Sprintf("%s:%s", c.Layer, c.Name)
+}
+
+// String returns the same form as Error — useful for log fields.
+func (c *Code) String() string {
+	return c.Error()
+}
+
+// From walks the err chain and returns the deepest typed *Code, or nil
+// if no typed code is in the chain.
+func From(err error) *Code {
+	for err != nil {
+		if c, ok := err.(*Code); ok {
+			return c
+		}
+		err = errors.Unwrap(err)
+	}
+	return nil
+}
+
+// Exit returns the CLI exit class for err.
+//
+//   - nil err → 0
+//   - typed *Code in chain → that code's Class
+//   - any other non-nil err → ClassRuntime (safe fallback)
+//
+// Callers wire this into os.Exit at the CLI boundary:
+//
+//	os.Exit(errcode.Exit(err))
+func Exit(err error) int {
+	if err == nil {
+		return int(ClassSuccess)
+	}
+	if c := From(err); c != nil {
+		return int(c.Class)
+	}
+	return int(ClassRuntime)
+}

--- a/internal/errcode/errcode_test.go
+++ b/internal/errcode/errcode_test.go
@@ -1,0 +1,146 @@
+package errcode_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"dhs/internal/errcode"
+)
+
+// Sentinel codes used by the tests — mirror the per-layer pattern callers
+// will adopt in R1b.
+var (
+	errTestRefused     = errcode.New(errcode.LayerTransport, "refused", errcode.ClassRuntime)
+	errTestTimeout     = errcode.New(errcode.LayerTransport, "timeout", errcode.ClassRuntime)
+	errTestInvalidInt  = errcode.New(errcode.LayerValidation, "invalid-integer", errcode.ClassUsage)
+	errTestNotFound    = errcode.New(errcode.LayerPlugin, "object-not-found", errcode.ClassUsage)
+	errTestMatrixLocked = errcode.New(errcode.LayerMatrix, "target-locked", errcode.ClassRuntime)
+)
+
+func TestCode_ErrorString(t *testing.T) {
+	cases := []struct {
+		code *errcode.Code
+		want string
+	}{
+		{errTestRefused, "transport:refused"},
+		{errTestTimeout, "transport:timeout"},
+		{errTestInvalidInt, "validation:invalid-integer"},
+		{errTestNotFound, "plugin:object-not-found"},
+		{errTestMatrixLocked, "matrix:target-locked"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			if got := tc.code.Error(); got != tc.want {
+				t.Errorf("Error() = %q, want %q", got, tc.want)
+			}
+			if got := tc.code.String(); got != tc.want {
+				t.Errorf("String() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCode_WrapAndIs(t *testing.T) {
+	wrapped := fmt.Errorf("%w: connect 127.0.0.1:9100: connection refused", errTestRefused)
+
+	if !errors.Is(wrapped, errTestRefused) {
+		t.Errorf("errors.Is on wrapped %v did not find errTestRefused", wrapped)
+	}
+	if errors.Is(wrapped, errTestTimeout) {
+		t.Errorf("errors.Is on wrapped should NOT match a different code")
+	}
+	wantPrefix := "transport:refused:"
+	if got := wrapped.Error(); got[:len(wantPrefix)] != wantPrefix {
+		t.Errorf("wrapped error = %q, want prefix %q", got, wantPrefix)
+	}
+}
+
+func TestFrom_FindsTypedCodeInChain(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want *errcode.Code
+	}{
+		{name: "nil", err: nil, want: nil},
+		{name: "plain error has no code", err: errors.New("plain"), want: nil},
+		{name: "raw code", err: errTestInvalidInt, want: errTestInvalidInt},
+		{name: "single wrap", err: fmt.Errorf("%w: x", errTestInvalidInt), want: errTestInvalidInt},
+		{name: "double wrap", err: fmt.Errorf("outer: %w", fmt.Errorf("%w: x", errTestMatrixLocked)), want: errTestMatrixLocked},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := errcode.From(tc.err)
+			if got != tc.want {
+				t.Errorf("From(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExit_MapsClassToOSExitCode(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "nil err → 0", err: nil, want: 0},
+		{name: "untyped err → 1 (runtime fallback)", err: errors.New("untyped"), want: 1},
+		{name: "runtime code → 1", err: errTestRefused, want: 1},
+		{name: "matrix runtime code → 1", err: errTestMatrixLocked, want: 1},
+		{name: "validation usage code → 2", err: errTestInvalidInt, want: 2},
+		{name: "plugin usage code → 2", err: errTestNotFound, want: 2},
+		{name: "wrapped runtime → 1", err: fmt.Errorf("%w: detail", errTestTimeout), want: 1},
+		{name: "wrapped usage → 2", err: fmt.Errorf("%w: detail", errTestInvalidInt), want: 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := errcode.Exit(tc.err); got != tc.want {
+				t.Errorf("Exit(%v) = %d, want %d", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExit_AcrossEveryClass(t *testing.T) {
+	// Pin the cross-OS contract: only 0, 1, or 2 — never 3+.
+	codes := []*errcode.Code{errTestRefused, errTestTimeout, errTestInvalidInt, errTestNotFound, errTestMatrixLocked}
+	for _, c := range codes {
+		exit := errcode.Exit(c)
+		if exit < 0 || exit > 2 {
+			t.Errorf("Exit(%v) = %d, want one of {0, 1, 2}", c, exit)
+		}
+	}
+}
+
+func TestNew_PanicsOnEmptyLayer(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("New with empty Layer should panic")
+		}
+	}()
+	_ = errcode.New("", "refused", errcode.ClassRuntime)
+}
+
+func TestNew_PanicsOnEmptyName(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("New with empty Name should panic")
+		}
+	}()
+	_ = errcode.New(errcode.LayerTransport, "", errcode.ClassRuntime)
+}
+
+// TestContract_StableShape pins the wire-shape contract on stderr.
+// Every typed code, wrapped with fmt.Errorf("%w: ...", ...), must
+// produce "<layer>:<code>: <detail>" — that's what scripts grep on.
+func TestContract_StableShape(t *testing.T) {
+	for _, c := range []*errcode.Code{errTestRefused, errTestInvalidInt, errTestMatrixLocked} {
+		wrapped := fmt.Errorf("%w: dynamic detail %d", c, 42)
+		s := wrapped.Error()
+		wantPrefix := string(c.Layer) + ":" + c.Name + ":"
+		if len(s) < len(wantPrefix) || s[:len(wantPrefix)] != wantPrefix {
+			t.Errorf("wrapped %v string = %q, want prefix %q", c, s, wantPrefix)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

**R1a — foundation pass for the layered error-code taxonomy (R1 [#468](https://github.com/by-openclaw/go-acp/issues/468)).**

Establishes the `internal/errcode/` infrastructure + canonical doc at `docs/protocols/error-codes.md`. **No existing call sites touched in this PR** — subsequent PRs (R1b … R1h) migrate each layer's free-text errors onto these typed sentinels.

Per memory `feedback_error_contract_cross_os` the contract is locked at:

| Surface | Value |
|---|---|
| **Exit code** | `0` success · `1` runtime/wire/protocol · `2` usage/validation. Standard Unix; never `3+` |
| **Stderr** | `<layer>:<code>: <human message>` — stable, grep-able, identical on Linux / macOS / Windows |
| **Cross-OS** | PowerShell `$LASTEXITCODE`, Bash `$?`, `cmd.exe %ERRORLEVEL%` all parse the same |

## What's in this PR

| File | Adds |
|---|---|
| [`internal/errcode/errcode.go`](https://github.com/by-openclaw/go-acp/blob/feat/error-codes-taxonomy-468/internal/errcode/errcode.go) | `Layer` · `Class` · `Code` · `New` · `From` · `Exit` |
| [`internal/errcode/errcode_test.go`](https://github.com/by-openclaw/go-acp/blob/feat/error-codes-taxonomy-468/internal/errcode/errcode_test.go) | 7 test funcs covering shape / wrap / `errors.Is` chain walk / exit mapping / panic on empty inputs / stable wire shape |
| [`docs/protocols/error-codes.md`](https://github.com/by-openclaw/go-acp/blob/feat/error-codes-taxonomy-468/docs/protocols/error-codes.md) | Canonical list of every layer + every planned code with status (pending/partial/defined), cross-referenced to the R-items that introduce them, plus Bash/PowerShell/Ansible dispatch examples |

## Design highlights

- **`*Code` is the sentinel.** Use as a package-level `var Err<Code> = errcode.New(LayerXxx, "name", ClassRuntime)`. Wrap at the error site with `fmt.Errorf("%w: %s", code, dynamic)`. `errors.Is(err, ErrCode)` works because the wrap is `%w` and `From()` walks `errors.Unwrap`.
- **`Exit(err)` always returns 0/1/2.** Untyped errors fall back to `ClassRuntime` (1). Codeowner-locked: never 3+.
- **`New` panics on empty inputs.** Catches typos at package-init time rather than at error-site time.

## Migration order (subsequent PRs)

Each builds on R1a. Listed here so reviewers know the path:

| PR | Scope |
|---|---|
| R1b | `internal/transport/` typed errors + call-site wrap |
| R1c | `internal/emberplus/codec/s101/` typed errors + wrap |
| R1d | `internal/emberplus/codec/{glow,ber}/` typed errors + wrap |
| R1e | `internal/emberplus/codec/matrix/` typed errors + wrap |
| R1f | `internal/emberplus/{consumer,provider}/` invocation errors |
| R1g | `internal/consumer/` validation/plugin/session — rewire existing untyped sentinels through `errcode` |
| R1h | `cmd/dhs/` exit-code dispatcher via `errcode.Exit` + runbook follow-up flipping every "(post R1)" label to live codes |

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/errcode -count=1` — `ok` (7 funcs)
- [x] `go test ./... -count=1` — full suite green across every package (no behavior change in this PR)
- [x] `golangci-lint` clean (pre-commit hook passed)
- [x] No existing call site touched — diff is 3 new files only
- [ ] **Codeowner review** — verify the contract shape matches `feedback_error_contract_cross_os`; rubber-stamp before R1b starts wrapping call sites

## Out of scope

- Migrating any existing `fmt.Errorf` call site — R1b onward
- CLI exit-code dispatcher in `cmd/dhs/` — R1h
- CI lint check for `errcode.New ↔ docs/protocols/error-codes.md` drift — R1h
- Other connectors' typed errors (ACP1, ACP2, Probel, etc.) — same pattern, separate epics

## Refs

Refs #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)
