### PR TITLE
feat(emberplus/codec/{ber,glow}): typed error codes — R1d BER + Glow layers (refs #468)

### DIFF
--- a/docs/protocols/error-codes.md
+++ b/docs/protocols/error-codes.md
@@ -73,11 +73,17 @@ Memory: `feedback_error_contract_cross_os` locks the rule across every connector
 
 | Code | Status | When | Anchor |
 |---|---|---|---|
-| `glow:bad-tag` | pending (R1d) | BER tag parse failure | ITU-T X.690 §8.1 |
-| `glow:bad-length` | pending (R1d) | BER length encoding invalid | X.690 §8.1.3 |
-| `glow:bad-real` | pending (R1d) | BER REAL decode failed | X.690 §8.5 + memory `reference_emberplus_ber_real` |
-| `glow:unknown-application-tag` | pending (R1d) | APPLICATION tag not in the GlowDTD enum | Ember+ Doc §p.84-91 |
-| `ber:bad-relative-oid` | pending (R1d) | RELATIVE-OID decode failed | X.690 §8.20 |
+| `glow:decode-failed` | defined (R1d) | `DecodeRoot` top-level wrap; preserves the underlying `ber:*` cause in the `errors.Is` chain via dual-`%w` so callers can dispatch on either layer | dhs |
+| `ber:truncated` | defined (R1d) | input buffer ends mid-element (insufficient bytes for declared tag / length / content) | X.690 §8.1 |
+| `ber:tag-too-long` | defined (R1d) | high-tag-number form exceeds 4-byte cap (X.690 §8.1.2.4 permits unbounded; dhs caps for safety) | X.690 §8.1.2.4 |
+| `ber:length-too-long` | defined (R1d) | long-form length exceeds 4-byte cap (X.690 §8.1.3.5 permits unbounded; dhs caps for safety) | X.690 §8.1.3.5 |
+| `ber:invalid-real` | defined (R1d) | REAL bytes fail to decode per X.690 §8.5 + the Ember+ ecosystem normalised-fraction convention | X.690 §8.5 + memory `reference_emberplus_ber_real` |
+| `ber:integer-overflow` | defined (R1d) | INTEGER content bytes encode a value outside int64 range | X.690 §8.3 |
+| `glow:bad-tag` | pending (future) | unknown APPLICATION tag at glow-schema level — currently surfaces as `ber:tag-too-long` or cascades to `glow:decode-failed` | Ember+ Doc §p.84-91 |
+| `glow:bad-length` | pending (future) | alias for `ber:length-too-long` in glow-schema context | X.690 §8.1.3 |
+| `glow:bad-real` | pending (future) | alias for `ber:invalid-real` in glow-schema context | X.690 §8.5 |
+| `glow:unknown-application-tag` | pending (future) | APPLICATION tag valid in BER but not in the GlowDTD enum (1..25) | Ember+ Doc §p.84-91 |
+| `ber:bad-relative-oid` | pending (future) | RELATIVE-OID decode failed — no callsite emits this distinctly today | X.690 §8.20 |
 
 ### matrix
 

--- a/internal/emberplus/codec/ber/errors.go
+++ b/internal/emberplus/codec/ber/errors.go
@@ -1,11 +1,38 @@
 package ber
 
-import "errors"
+import "dhs/internal/errcode"
 
+// Code sentinels for the BER (ASN.1 Basic Encoding Rules) decode layer.
+//
+// Wraps raw decode failures with typed *errcode.Code instances so callers
+// can dispatch via errors.Is(err, ber.ErrXxx). All Class 1 (runtime, exit 1).
+// Wire form on stderr: "ber:<code>: <human message>".
+//
+// R1d migration — promotes the prior package-private errors.New sentinels
+// to typed errcode.Code and exports them so external callers (glow decoder,
+// CLI exit dispatcher) can recognise them.
 var (
-	errTruncated      = errors.New("ber: truncated input")
-	errTagTooLong     = errors.New("ber: tag number exceeds 4 bytes")
-	errLengthTooLong  = errors.New("ber: length exceeds 4 bytes")
-	errInvalidReal    = errors.New("ber: invalid REAL encoding")
-	errOverflow       = errors.New("ber: integer overflow")
+	// ErrTruncated is returned when the input buffer ends mid-element
+	// (insufficient bytes for the declared tag / length / content).
+	ErrTruncated = errcode.New(errcode.LayerBER, "truncated", errcode.ClassRuntime)
+
+	// ErrTagTooLong is returned when a high-tag-number form exceeds the
+	// 4-byte limit dhs enforces (X.690 §8.1.2.4 permits unbounded
+	// extension; dhs caps at 4 bytes for safety).
+	ErrTagTooLong = errcode.New(errcode.LayerBER, "tag-too-long", errcode.ClassRuntime)
+
+	// ErrLengthTooLong is returned when a long-form length exceeds 4
+	// bytes (X.690 §8.1.3.5 permits unbounded; dhs caps at 4 bytes).
+	ErrLengthTooLong = errcode.New(errcode.LayerBER, "length-too-long", errcode.ClassRuntime)
+
+	// ErrInvalidReal is returned when REAL bytes fail to decode per
+	// X.690 §8.5 + the Ember+ ecosystem normalised-fraction convention
+	// (see memory reference_emberplus_ber_real and TestReal_EcosystemBytes
+	// in codec/ber/value_test.go).
+	ErrInvalidReal = errcode.New(errcode.LayerBER, "invalid-real", errcode.ClassRuntime)
+
+	// ErrOverflow is returned when an INTEGER's content bytes encode a
+	// value outside int64 range.
+	ErrOverflow = errcode.New(errcode.LayerBER, "integer-overflow", errcode.ClassRuntime)
 )
+

--- a/internal/emberplus/codec/ber/errors_test.go
+++ b/internal/emberplus/codec/ber/errors_test.go
@@ -1,0 +1,52 @@
+package ber
+
+import (
+	"errors"
+	"testing"
+
+	"dhs/internal/errcode"
+)
+
+// TestBER_Sentinels_ShapeAndClass pins every BER code's wire shape +
+// exit class.
+func TestBER_Sentinels_ShapeAndClass(t *testing.T) {
+	cases := []struct {
+		code *errcode.Code
+		want string
+	}{
+		{ErrTruncated, "ber:truncated"},
+		{ErrTagTooLong, "ber:tag-too-long"},
+		{ErrLengthTooLong, "ber:length-too-long"},
+		{ErrInvalidReal, "ber:invalid-real"},
+		{ErrOverflow, "ber:integer-overflow"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			if got := tc.code.Error(); got != tc.want {
+				t.Errorf("Error() = %q, want %q", got, tc.want)
+			}
+			if tc.code.Layer != errcode.LayerBER {
+				t.Errorf("Layer = %q, want %q", tc.code.Layer, errcode.LayerBER)
+			}
+			if tc.code.Class != errcode.ClassRuntime {
+				t.Errorf("Class = %d, want ClassRuntime (1)", tc.code.Class)
+			}
+			if got := errcode.Exit(tc.code); got != 1 {
+				t.Errorf("Exit() = %d, want 1", got)
+			}
+		})
+	}
+}
+
+// TestBER_DecodeTruncated_TypedError pins that DecodeAll on insufficient
+// bytes returns errors.Is(err, ErrTruncated).
+func TestBER_DecodeTruncated_TypedError(t *testing.T) {
+	// Single byte: tag without length or content.
+	_, err := DecodeAll([]byte{0x30})
+	if err == nil {
+		t.Fatal("expected truncated error, got nil")
+	}
+	if !errors.Is(err, ErrTruncated) {
+		t.Errorf("err = %v, want errors.Is(err, ErrTruncated)", err)
+	}
+}

--- a/internal/emberplus/codec/ber/length.go
+++ b/internal/emberplus/codec/ber/length.go
@@ -52,12 +52,12 @@ func EncodeLength(length int) []byte {
 //	| 0x00..0x7F  | short definite    | length = first octet (0..127)       |
 //	| 0x80        | indefinite        | length = -1 (EOC-terminated value)  |
 //	| 0x81..0x84  | long definite (N) | next N octets = big-endian length   |
-//	| >= 0x85     | rejected          | errLengthTooLong (cap at 4 octets)  |
+//	| >= 0x85     | rejected          | ErrLengthTooLong (cap at 4 octets)  |
 //
 // Spec reference: ITU-T X.690 §8.1.3 (Length octets).
 func DecodeLength(buf []byte) (int, int, error) {
 	if len(buf) == 0 {
-		return 0, 0, errTruncated
+		return 0, 0, ErrTruncated
 	}
 
 	first := buf[0]
@@ -75,10 +75,10 @@ func DecodeLength(buf []byte) (int, int, error) {
 	// Long form: n = number of subsequent length octets.
 	n := int(first & 0x7F)
 	if n > 4 {
-		return 0, 0, errLengthTooLong
+		return 0, 0, ErrLengthTooLong
 	}
 	if len(buf) < 1+n {
-		return 0, 0, errTruncated
+		return 0, 0, ErrTruncated
 	}
 
 	length := 0

--- a/internal/emberplus/codec/ber/tag.go
+++ b/internal/emberplus/codec/ber/tag.go
@@ -102,7 +102,7 @@ func EncodeTag(t Tag) []byte {
 // Spec reference: ITU-T X.690 §8.1.2 (Identifier octets).
 func DecodeTag(buf []byte) (Tag, int, error) {
 	if len(buf) == 0 {
-		return Tag{}, 0, errTruncated
+		return Tag{}, 0, ErrTruncated
 	}
 
 	first := buf[0]
@@ -154,8 +154,8 @@ func decodeBase128(buf []byte) (uint32, int, error) {
 			return val, i + 1, nil
 		}
 		if i > 4 {
-			return 0, 0, errTagTooLong
+			return 0, 0, ErrTagTooLong
 		}
 	}
-	return 0, 0, errTruncated
+	return 0, 0, ErrTruncated
 }

--- a/internal/emberplus/codec/ber/tlv.go
+++ b/internal/emberplus/codec/ber/tlv.go
@@ -62,7 +62,7 @@ func EncodeTLV(t TLV) []byte {
 // Spec reference: ITU-T X.690 §8.1.1 (General rules for BER).
 func DecodeTLV(buf []byte) (TLV, int, error) {
 	if len(buf) == 0 {
-		return TLV{}, 0, errTruncated
+		return TLV{}, 0, ErrTruncated
 	}
 
 	tag, tagLen, err := DecodeTag(buf)
@@ -84,7 +84,7 @@ func DecodeTLV(buf []byte) (TLV, int, error) {
 		pos := headerLen
 		for {
 			if pos+2 > len(buf) {
-				return TLV{}, 0, errTruncated
+				return TLV{}, 0, ErrTruncated
 			}
 			// Check for EOC.
 			if buf[pos] == 0x00 && buf[pos+1] == 0x00 {
@@ -103,7 +103,7 @@ func DecodeTLV(buf []byte) (TLV, int, error) {
 
 	// Definite length.
 	if headerLen+length > len(buf) {
-		return TLV{}, 0, errTruncated
+		return TLV{}, 0, ErrTruncated
 	}
 
 	t := TLV{Tag: tag}

--- a/internal/emberplus/codec/ber/value.go
+++ b/internal/emberplus/codec/ber/value.go
@@ -241,7 +241,7 @@ func EncodeOctetString(b []byte) []byte {
 // Spec reference: ITU-T X.690 §8.2 (Encoding of a boolean value).
 func DecodeBoolean(data []byte) (bool, error) {
 	if len(data) != 1 {
-		return false, errTruncated
+		return false, ErrTruncated
 	}
 	return data[0] != 0, nil
 }
@@ -253,16 +253,16 @@ func DecodeBoolean(data []byte) (bool, error) {
 //	|   0    | MSB      |   1   | sign bit in bit 7; drives 64-bit sign-pad |
 //	|  1..N  | low bytes|  N-1  | big-endian remainder                      |
 //
-// Rejects encodings longer than 8 octets (errOverflow); the Glow subset
+// Rejects encodings longer than 8 octets (ErrOverflow); the Glow subset
 // never emits INTEGER wider than int64 in practice.
 //
 // Spec reference: ITU-T X.690 §8.3 (Encoding of an integer value).
 func DecodeInteger(data []byte) (int64, error) {
 	if len(data) == 0 {
-		return 0, errTruncated
+		return 0, ErrTruncated
 	}
 	if len(data) > 8 {
-		return 0, errOverflow
+		return 0, ErrOverflow
 	}
 
 	// Sign-extend to 8 bytes.
@@ -316,7 +316,7 @@ func DecodeReal(data []byte) (float64, error) {
 
 	// Decimal form (bit 7 = 0, bit 6 = 0) — not emitted by Glow, reject.
 	if first&0xC0 == 0x00 {
-		return 0, errInvalidReal
+		return 0, ErrInvalidReal
 	}
 
 	// Binary form: bit 7 = 1.
@@ -335,7 +335,7 @@ func DecodeReal(data []byte) (float64, error) {
 		case 2:
 			baseFactor = 4 // × 2^4 = base 16
 		default:
-			return 0, errInvalidReal
+			return 0, ErrInvalidReal
 		}
 		// Scaling factor: bits 3-2. Added to mantissa.
 		scale := int((first >> 2) & 0x03)
@@ -354,13 +354,13 @@ func DecodeReal(data []byte) (float64, error) {
 			expStart = 1
 		default:
 			if len(data) < 2 {
-				return 0, errInvalidReal
+				return 0, ErrInvalidReal
 			}
 			expLen = int(data[1])
 			expStart = 2
 		}
 		if expLen == 0 || expStart+expLen > len(data) {
-			return 0, errInvalidReal
+			return 0, ErrInvalidReal
 		}
 		exp, err := DecodeInteger(data[expStart : expStart+expLen])
 		if err != nil {
@@ -369,7 +369,7 @@ func DecodeReal(data []byte) (float64, error) {
 		// Mantissa — remaining bytes, unsigned big-endian.
 		mantBytes := data[expStart+expLen:]
 		if len(mantBytes) == 0 {
-			return 0, errInvalidReal
+			return 0, ErrInvalidReal
 		}
 		var mant uint64
 		for _, b := range mantBytes {
@@ -387,7 +387,7 @@ func DecodeReal(data []byte) (float64, error) {
 		v := sign * float64(mant) * math.Pow(2.0, float64(int(exp)*baseFactor+scale-shift))
 		return v, nil
 	}
-	return 0, errInvalidReal
+	return 0, ErrInvalidReal
 }
 
 // DecodeUTF8String reads a BER UTF8String from value bytes.

--- a/internal/emberplus/codec/glow/decoder.go
+++ b/internal/emberplus/codec/glow/decoder.go
@@ -30,7 +30,9 @@ import (
 func DecodeRoot(data []byte) ([]Element, error) {
 	tlvs, err := ber.DecodeAll(data)
 	if err != nil {
-		return nil, fmt.Errorf("glow decode: %w", err)
+		// Two %w preserves both glow:* and ber:* in the errors.Is chain
+		// so callers can dispatch on either layer.
+		return nil, fmt.Errorf("%w: %w", ErrDecodeFailed, err)
 	}
 	var out []Element
 	for _, tlv := range tlvs {

--- a/internal/emberplus/codec/glow/errcode.go
+++ b/internal/emberplus/codec/glow/errcode.go
@@ -1,0 +1,23 @@
+// Code sentinels for the Glow decode layer.
+//
+// Glow sits on top of BER (every element is a BER APPLICATION-tagged
+// SEQUENCE / SEQUENCE OF). Most decode failures bubble up from the BER
+// layer (ber:truncated, ber:tag-too-long, etc.) and the Glow layer adds
+// the schema context.
+//
+// Wire form: "glow:<code>: <human message>".
+//
+// R1d migration — adds Glow-level wrap sentinels so callers can distinguish
+// "the byte-level BER decode failed" (ber:*) from "the Ember+ schema layer
+// rejected the message" (glow:*).
+package glow
+
+import "dhs/internal/errcode"
+
+// All glow:* codes are runtime decode failures (Class 1, exit 1).
+var (
+	// ErrDecodeFailed wraps a top-level DecodeRoot failure. The
+	// underlying ber:* error is preserved in the chain so callers can
+	// errors.Is against the specific BER cause.
+	ErrDecodeFailed = errcode.New(errcode.LayerGlow, "decode-failed", errcode.ClassRuntime)
+)

--- a/internal/emberplus/codec/glow/errcode_test.go
+++ b/internal/emberplus/codec/glow/errcode_test.go
@@ -1,0 +1,51 @@
+package glow
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"dhs/internal/emberplus/codec/ber"
+	"dhs/internal/errcode"
+)
+
+// TestGlow_Sentinels_ShapeAndClass pins the glow:decode-failed code's
+// wire shape + class.
+func TestGlow_Sentinels_ShapeAndClass(t *testing.T) {
+	if got := ErrDecodeFailed.Error(); got != "glow:decode-failed" {
+		t.Errorf("Error() = %q, want %q", got, "glow:decode-failed")
+	}
+	if ErrDecodeFailed.Layer != errcode.LayerGlow {
+		t.Errorf("Layer = %q, want %q", ErrDecodeFailed.Layer, errcode.LayerGlow)
+	}
+	if ErrDecodeFailed.Class != errcode.ClassRuntime {
+		t.Errorf("Class = %d, want ClassRuntime (1)", ErrDecodeFailed.Class)
+	}
+	if got := errcode.Exit(ErrDecodeFailed); got != 1 {
+		t.Errorf("Exit() = %d, want 1", got)
+	}
+}
+
+// TestDecodeRoot_BadBytes_WrapsBothLayers pins that a BER decode failure
+// produces an error that:
+//   - matches errors.Is(err, glow.ErrDecodeFailed) — the wrap layer
+//   - matches errors.Is(err, ber.ErrTruncated)    — the underlying cause
+//
+// This is the operator-facing benefit of the layered taxonomy: scripts
+// can dispatch at any layer in the chain.
+func TestDecodeRoot_BadBytes_WrapsBothLayers(t *testing.T) {
+	// Single byte: tag without length/content — triggers ber:truncated.
+	_, err := DecodeRoot([]byte{0x60})
+	if err == nil {
+		t.Fatal("expected decode error, got nil")
+	}
+	if !errors.Is(err, ErrDecodeFailed) {
+		t.Errorf("err = %v, want errors.Is(err, glow.ErrDecodeFailed)", err)
+	}
+	if !errors.Is(err, ber.ErrTruncated) {
+		t.Errorf("err = %v, want errors.Is(err, ber.ErrTruncated) — underlying cause should chain through", err)
+	}
+	if !strings.HasPrefix(err.Error(), "glow:decode-failed:") {
+		t.Errorf("err string = %q, want glow:decode-failed: prefix", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary

**R1d — BER + Glow decode layers migration to typed error codes (R1 [#468](https://github.com/by-openclaw/go-acp/issues/468)).**

Builds on the previous R1 PRs:
- R1a [#491](https://github.com/by-openclaw/go-acp/pull/491) — `internal/errcode/` infrastructure
- R1b [#492](https://github.com/by-openclaw/go-acp/pull/492) — transport layer
- R1c [#493](https://github.com/by-openclaw/go-acp/pull/493) — S101 framing layer

## What's in this PR

### BER sentinels promoted to public typed codes

`internal/emberplus/codec/ber/errors.go` rewritten — 5 sentinels promoted from package-private `errors.New` strings to exported `*errcode.Code`:

| Code | When |
|---|---|
| `ber:truncated` | input ends mid-element |
| `ber:tag-too-long` | high-tag-number > 4 bytes (dhs safety cap) |
| `ber:length-too-long` | long-form length > 4 bytes (dhs safety cap) |
| `ber:invalid-real` | REAL bytes fail X.690 §8.5 + Ember+ ecosystem convention |
| `ber:integer-overflow` | INTEGER value outside int64 range |

Callsites in `tag.go` / `length.go` / `tlv.go` / `value.go` renamed `errTruncated` → `ErrTruncated` etc. (4 files, mechanical rename).

### Glow decode wrap

`internal/emberplus/codec/glow/errcode.go` (new) — 1 sentinel:

| Code | When |
|---|---|
| `glow:decode-failed` | `DecodeRoot` top-level wrap; preserves underlying `ber:*` cause via dual-`%w` |

The dual-`%w` is the operator-facing benefit: one error chains to BOTH layers in `errors.Is`, so scripts can dispatch on either:

```bash
err=$(dhs consumer emberplus walk ... 2>&1)
case "$err" in
  glow:decode-failed*) echo "Ember+ schema layer rejected the message" ;;
  ber:*)               echo "byte-level BER decode failed" ;;
esac
```

Even though the wrapped error string is `glow:decode-failed: ber:truncated`, `errors.Is(err, ber.ErrTruncated)` returns true because `fmt.Errorf("%w: %w", outer, inner)` puts both in the chain (Go 1.20+).

## Tests

| Test file | Asserts |
|---|---|
| `ber/errors_test.go` | wire shape + Class=1 + Layer=ber + Exit=1 for all 5 codes (5 subtests) · DecodeAll on single byte → `errors.Is(err, ErrTruncated)` |
| `glow/errcode_test.go` | shape + class for `ErrDecodeFailed` · `DecodeRoot` on bad bytes chains to BOTH `glow.ErrDecodeFailed` AND `ber.ErrTruncated` via dual-`%w` |

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/emberplus/codec/ber -count=1` — `ok`
- [x] `go test ./internal/emberplus/codec/glow -count=1` — `ok`
- [x] `go test ./... -count=1` — full suite green
- [x] `golangci-lint` clean (pre-commit hook passed)
- [x] BER private callsites mechanically renamed; no other behavior change
- [x] Glow decoder still propagates inner BER errors for `errors.Is` dispatch (pinned by `TestDecodeRoot_BadBytes_WrapsBothLayers`)
- [ ] **Codeowner review** — rubber-stamp before R1e (matrix layer) builds on top

## Visible change

| Before | After |
|---|---|
| `ber: truncated input` | `ber:truncated: <context>` |
| `glow decode: ber: truncated input` | `glow:decode-failed: ber:truncated: <context>` |

Same operator dispatch story as R1b/R1c — error strings flip from free-text to `<layer>:<code>: <message>`.

## Canonical doc

`docs/protocols/error-codes.md`:
- 5 `ber:*` codes flipped from `pending` to `defined`
- 1 `glow:decode-failed` code added as `defined`
- Spec-completeness aliases (`glow:bad-tag`, `glow:bad-length`, `glow:bad-real`, `glow:unknown-application-tag`) marked as future — they currently cascade through the existing codes; splitting requires schema-context awareness in the decoder
- `ber:bad-relative-oid` kept as `pending` — no distinct callsite today

## Migration ladder

| PR | Status | Scope |
|---|---|---|
| R1a [#491](https://github.com/by-openclaw/go-acp/pull/491) | ✅ merged | `internal/errcode/` infrastructure |
| R1b [#492](https://github.com/by-openclaw/go-acp/pull/492) | ✅ merged | transport layer |
| R1c [#493](https://github.com/by-openclaw/go-acp/pull/493) | ✅ merged | S101 codec layer |
| **R1d (this PR)** | open | BER + Glow decode layers |
| R1e | next | `internal/emberplus/codec/matrix/` |
| R1f | next | `internal/emberplus/{consumer,provider}/` invocation errors |
| R1g | next | rewire existing `internal/consumer/` typed sentinels through `errcode` |
| R1h | next | `cmd/dhs/` exit-code dispatcher + runbook follow-up |

## Refs

Refs #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)
