### PR TITLE
feat(emberplus/codec/matrix): typed error codes — R1e matrix layer (refs #468)

### DIFF
--- a/docs/protocols/error-codes.md
+++ b/docs/protocols/error-codes.md
@@ -89,10 +89,10 @@ Memory: `feedback_error_contract_cross_os` locks the rule across every connector
 
 | Code | Status | When | Anchor |
 |---|---|---|---|
-| `matrix:cardinality-exceeded` | pending (R1e) | matrix type (oneToOne / oneToN) limit violated | Ember+ Doc §p.33 |
-| `matrix:target-locked` | pending (R1e) | target's `ConnectionDisposition=Locked(3)` | Ember+ Doc §p.89; site already exists in `internal/emberplus/codec/matrix/state.go` |
-| `matrix:max-connects-per-target` | pending (R1e) | nToN per-target capacity exceeded | Ember+ Doc §p.88 |
-| `matrix:max-total-connects` | pending (R1e) | nToN total-connections capacity exceeded | Ember+ Doc §p.88 |
+| `matrix:target-locked` | defined (R1e) | target's `ConnectionDisposition=Locked(3)` blocks any state-mutating Connect/Disconnect | Ember+ Doc §p.89; site at `internal/emberplus/codec/matrix/state.go::CanConnect` |
+| `matrix:cardinality-exceeded` | defined (R1e) | oneToN / oneToOne matrix: target would have >1 source | Ember+ Doc §p.33 |
+| `matrix:max-connects-per-target` | defined (R1e) | nToN matrix: target's source count would exceed `MaxConnectsPerTarget` | Ember+ Doc §p.88 |
+| `matrix:max-total-connects` | defined (R1e) | nToN matrix: sum-across-all-targets would exceed `MaxTotalConnects` | Ember+ Doc §p.88 |
 
 ### emberplus
 

--- a/internal/emberplus/codec/matrix/errcode.go
+++ b/internal/emberplus/codec/matrix/errcode.go
@@ -1,0 +1,36 @@
+// Code sentinels for the matrix codec layer.
+//
+// Wraps the pre-flight CanConnect validation errors with typed
+// *errcode.Code instances so callers can dispatch via
+// errors.Is(err, matrix.ErrXxx). All Class 1 (runtime, exit 1).
+// Wire form: "matrix:<code>: <human message>".
+//
+// R1e migration — replaces the free-text fmt.Errorf strings in
+// state.go::CanConnect with typed sentinels per the Ember+ Doc §p.33
+// matrix-type cardinality rules + §p.89 ConnectionDisposition.locked.
+package matrix
+
+import "dhs/internal/errcode"
+
+// All matrix:* codes are runtime / spec-rejection failures (Class 1,
+// exit 1). They fire pre-flight at the consumer (and again at the
+// provider side after wire-receive) when a Connect would violate the
+// matrix type's cardinality or hit a locked target.
+var (
+	// ErrTargetLocked is returned when the target's current
+	// ConnectionDisposition is Locked(3). Per Ember+ Doc §p.89.
+	ErrTargetLocked = errcode.New(errcode.LayerMatrix, "target-locked", errcode.ClassRuntime)
+
+	// ErrCardinalityExceeded fires when a oneToN or oneToOne matrix
+	// would have more than one source connected to a target. Per
+	// Ember+ Doc §p.33.
+	ErrCardinalityExceeded = errcode.New(errcode.LayerMatrix, "cardinality-exceeded", errcode.ClassRuntime)
+
+	// ErrMaxConnectsPerTarget fires when an nToN matrix's per-target
+	// limit would be exceeded. Per Ember+ Doc §p.88.
+	ErrMaxConnectsPerTarget = errcode.New(errcode.LayerMatrix, "max-connects-per-target", errcode.ClassRuntime)
+
+	// ErrMaxTotalConnects fires when an nToN matrix's total-connections
+	// limit would be exceeded across all targets. Per Ember+ Doc §p.88.
+	ErrMaxTotalConnects = errcode.New(errcode.LayerMatrix, "max-total-connects", errcode.ClassRuntime)
+)

--- a/internal/emberplus/codec/matrix/errcode_test.go
+++ b/internal/emberplus/codec/matrix/errcode_test.go
@@ -1,0 +1,117 @@
+package matrix
+
+import (
+	"errors"
+	"testing"
+
+	"dhs/internal/emberplus/codec/glow"
+	"dhs/internal/errcode"
+)
+
+// TestMatrix_Sentinels_ShapeAndClass pins every matrix code's wire
+// shape + exit class.
+func TestMatrix_Sentinels_ShapeAndClass(t *testing.T) {
+	cases := []struct {
+		code *errcode.Code
+		want string
+	}{
+		{ErrTargetLocked, "matrix:target-locked"},
+		{ErrCardinalityExceeded, "matrix:cardinality-exceeded"},
+		{ErrMaxConnectsPerTarget, "matrix:max-connects-per-target"},
+		{ErrMaxTotalConnects, "matrix:max-total-connects"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			if got := tc.code.Error(); got != tc.want {
+				t.Errorf("Error() = %q, want %q", got, tc.want)
+			}
+			if tc.code.Layer != errcode.LayerMatrix {
+				t.Errorf("Layer = %q, want %q", tc.code.Layer, errcode.LayerMatrix)
+			}
+			if tc.code.Class != errcode.ClassRuntime {
+				t.Errorf("Class = %d, want ClassRuntime (1)", tc.code.Class)
+			}
+			if got := errcode.Exit(tc.code); got != 1 {
+				t.Errorf("Exit() = %d, want 1", got)
+			}
+		})
+	}
+}
+
+// TestCanConnect_LockedTarget_TypedError pins ErrTargetLocked.
+func TestCanConnect_LockedTarget_TypedError(t *testing.T) {
+	s := &State{
+		Type: glow.MatrixTypeOneToN,
+		Targets: map[int32]*TargetState{
+			2: {Sources: []int32{5}, Disposition: glow.ConnDispLocked},
+		},
+	}
+	err := s.CanConnect(2, []int32{7}, glow.ConnOpAbsolute)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ErrTargetLocked) {
+		t.Errorf("err = %v, want errors.Is(err, ErrTargetLocked)", err)
+	}
+}
+
+// TestCanConnect_OneToNCardinality_TypedError pins ErrCardinalityExceeded
+// for oneToN.
+func TestCanConnect_OneToNCardinality_TypedError(t *testing.T) {
+	s := &State{Type: glow.MatrixTypeOneToN}
+	err := s.CanConnect(0, []int32{1, 2}, glow.ConnOpAbsolute)
+	if err == nil {
+		t.Fatal("expected cardinality error, got nil")
+	}
+	if !errors.Is(err, ErrCardinalityExceeded) {
+		t.Errorf("err = %v, want errors.Is(err, ErrCardinalityExceeded)", err)
+	}
+}
+
+// TestCanConnect_OneToOneCardinality_TypedError mirrors the above for
+// oneToOne.
+func TestCanConnect_OneToOneCardinality_TypedError(t *testing.T) {
+	s := &State{Type: glow.MatrixTypeOneToOne}
+	err := s.CanConnect(0, []int32{1, 2}, glow.ConnOpAbsolute)
+	if err == nil {
+		t.Fatal("expected cardinality error, got nil")
+	}
+	if !errors.Is(err, ErrCardinalityExceeded) {
+		t.Errorf("err = %v, want errors.Is(err, ErrCardinalityExceeded)", err)
+	}
+}
+
+// TestCanConnect_NToNMaxPerTarget_TypedError pins ErrMaxConnectsPerTarget.
+func TestCanConnect_NToNMaxPerTarget_TypedError(t *testing.T) {
+	s := &State{
+		Type:                 glow.MatrixTypeNToN,
+		MaxConnectsPerTarget: 2,
+	}
+	err := s.CanConnect(0, []int32{1, 2, 3}, glow.ConnOpAbsolute)
+	if err == nil {
+		t.Fatal("expected per-target capacity error, got nil")
+	}
+	if !errors.Is(err, ErrMaxConnectsPerTarget) {
+		t.Errorf("err = %v, want errors.Is(err, ErrMaxConnectsPerTarget)", err)
+	}
+}
+
+// TestCanConnect_NToNMaxTotal_TypedError pins ErrMaxTotalConnects.
+func TestCanConnect_NToNMaxTotal_TypedError(t *testing.T) {
+	s := &State{
+		Type:             glow.MatrixTypeNToN,
+		MaxTotalConnects: 3,
+		Targets: map[int32]*TargetState{
+			0: {Sources: []int32{1, 2}},
+			1: {Sources: []int32{3}},
+			// 2 will get the request; with current 3 total, adding 1 more = 4 > max 3
+		},
+	}
+	err := s.CanConnect(2, []int32{4}, glow.ConnOpAbsolute)
+	if err == nil {
+		t.Fatal("expected total-capacity error, got nil")
+	}
+	if !errors.Is(err, ErrMaxTotalConnects) {
+		t.Errorf("err = %v, want errors.Is(err, ErrMaxTotalConnects)", err)
+	}
+}

--- a/internal/emberplus/codec/matrix/state.go
+++ b/internal/emberplus/codec/matrix/state.go
@@ -189,7 +189,7 @@ func (s *State) CanConnect(target int32, newSources []int32, op int64) error {
 	defer s.mu.RUnlock()
 
 	if cur, ok := s.Targets[target]; ok && cur.Disposition == glow.ConnDispLocked {
-		return fmt.Errorf("target %d is locked (spec p.89 ConnectionDisposition)", target)
+		return fmt.Errorf("%w: target %d is locked (spec p.89 ConnectionDisposition)", ErrTargetLocked, target)
 	}
 
 	// Spec p.89: ConnectionOperation.Disconnect removes the listed
@@ -206,13 +206,13 @@ func (s *State) CanConnect(target int32, newSources []int32, op int64) error {
 	switch s.Type {
 	case glow.MatrixTypeOneToN:
 		if len(projected) > 1 {
-			return fmt.Errorf("oneToN matrix: target %d would have %d sources (max 1) [spec p.33]",
-				target, len(projected))
+			return fmt.Errorf("%w: oneToN matrix: target %d would have %d sources (max 1) [spec p.33]",
+				ErrCardinalityExceeded, target, len(projected))
 		}
 	case glow.MatrixTypeOneToOne:
 		if len(projected) > 1 {
-			return fmt.Errorf("oneToOne matrix: target %d would have %d sources (max 1) [spec p.33]",
-				target, len(projected))
+			return fmt.Errorf("%w: oneToOne matrix: target %d would have %d sources (max 1) [spec p.33]",
+				ErrCardinalityExceeded, target, len(projected))
 		}
 		// Source exclusivity (spec p.33 literal) is NOT enforced here —
 		// see CanConnect doc-comment for the source-steal precedent.
@@ -220,8 +220,8 @@ func (s *State) CanConnect(target int32, newSources []int32, op int64) error {
 		// steal pre-flight and fires a compliance event. Refs #465.
 	case glow.MatrixTypeNToN:
 		if s.MaxConnectsPerTarget > 0 && int32(len(projected)) > s.MaxConnectsPerTarget {
-			return fmt.Errorf("nToN matrix: target %d would have %d sources (max %d per target) [spec p.33]",
-				target, len(projected), s.MaxConnectsPerTarget)
+			return fmt.Errorf("%w: nToN matrix: target %d would have %d sources (max %d per target) [spec p.33]",
+				ErrMaxConnectsPerTarget, target, len(projected), s.MaxConnectsPerTarget)
 		}
 		if s.MaxTotalConnects > 0 {
 			total := int32(len(projected))
@@ -232,8 +232,8 @@ func (s *State) CanConnect(target int32, newSources []int32, op int64) error {
 				total += int32(len(tstate.Sources))
 			}
 			if total > s.MaxTotalConnects {
-				return fmt.Errorf("nToN matrix: total connects would be %d (max %d) [spec p.33]",
-					total, s.MaxTotalConnects)
+				return fmt.Errorf("%w: nToN matrix: total connects would be %d (max %d) [spec p.33]",
+					ErrMaxTotalConnects, total, s.MaxTotalConnects)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

**R1e — matrix codec migration to typed error codes (R1 [#468](https://github.com/by-openclaw/go-acp/issues/468)).**

Fifth pass of the R1 epic. Every `fmt.Errorf` in `internal/emberplus/codec/matrix/state.go::CanConnect` now wraps a typed `*errcode.Code` sentinel.

## New sentinels (`internal/emberplus/codec/matrix/errcode.go`)

4 codes — all Class 1 (runtime, exit 1), layer `matrix`:

| Code | When | Spec |
|---|---|---|
| `matrix:target-locked` | target's `ConnectionDisposition=Locked(3)` blocks any state-mutating Connect/Disconnect | Ember+ Doc §p.89 |
| `matrix:cardinality-exceeded` | oneToN / oneToOne would have >1 source on a target | Ember+ Doc §p.33 |
| `matrix:max-connects-per-target` | nToN per-target capacity exceeded | Ember+ Doc §p.88 |
| `matrix:max-total-connects` | nToN total-connections capacity exceeded | Ember+ Doc §p.88 |

## Call sites migrated

All 5 sites in `state.go::CanConnect` — locked target, oneToN cardinality, oneToOne cardinality, nToN per-target, nToN total.

## Tests

| Test | Asserts |
|---|---|
| `TestMatrix_Sentinels_ShapeAndClass` | shape + Class=1 + Layer=matrix + Exit=1 (4 subtests) |
| `TestCanConnect_LockedTarget_TypedError` | locked target → `errors.Is(err, ErrTargetLocked)` |
| `TestCanConnect_OneToNCardinality_TypedError` | 2-src on oneToN → `errors.Is(err, ErrCardinalityExceeded)` |
| `TestCanConnect_OneToOneCardinality_TypedError` | 2-src on oneToOne → same |
| `TestCanConnect_NToNMaxPerTarget_TypedError` | per-target overflow → `errors.Is(err, ErrMaxConnectsPerTarget)` |
| `TestCanConnect_NToNMaxTotal_TypedError` | total-capacity overflow → `errors.Is(err, ErrMaxTotalConnects)` |

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/emberplus/codec/matrix -count=1` — `ok`
- [x] `go test ./... -count=1` — full suite green
- [x] `golangci-lint` clean (pre-commit hook passed)
- [x] Existing `state_test.go::TestCanConnect_*` tests unchanged behaviorally
- [ ] **Codeowner review** — rubber-stamp before R1f (emberplus invocation errors) builds on top

## Visible change

| Before | After |
|---|---|
| `target 2 is locked (spec p.89 ConnectionDisposition)` | `matrix:target-locked: target 2 is locked (spec p.89 ConnectionDisposition)` |
| `oneToN matrix: target 0 would have 2 sources (max 1) [spec p.33]` | `matrix:cardinality-exceeded: oneToN matrix: target 0 would have 2 sources (max 1) [spec p.33]` |

## Canonical doc

`docs/protocols/error-codes.md` — 4 `matrix:*` codes flipped from `pending` to `defined`.

## Migration ladder

| PR | Status | Scope |
|---|---|---|
| R1a [#491](https://github.com/by-openclaw/go-acp/pull/491) | ✅ merged | `internal/errcode/` |
| R1b [#492](https://github.com/by-openclaw/go-acp/pull/492) | ✅ merged | transport |
| R1c [#493](https://github.com/by-openclaw/go-acp/pull/493) | ✅ merged | S101 |
| R1d [#494](https://github.com/by-openclaw/go-acp/pull/494) | ✅ merged | BER + Glow |
| **R1e (this PR)** | open | matrix |
| R1f | next | emberplus invocation errors |
| R1g | next | rewire `internal/consumer/` typed sentinels |
| R1h | next | `cmd/dhs/` exit-code dispatcher + runbook follow-up |

## Refs

Refs #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)
