### PR TITLE
feat(emberplus/consumer): typed error codes — R1f Ember+ invocation failures (refs #468)

### DIFF
--- a/cmd/dhs/cmd_invoke.go
+++ b/cmd/dhs/cmd_invoke.go
@@ -84,13 +84,15 @@ func runInvoke(ctx context.Context, args []string) error {
 	defer cancel()
 
 	result, err := ep.InvokeFunction(opCtx, *funcPath, funcArgs)
-	if err != nil {
-		return err
+	// emberplus.InvokeFunction returns (result, ErrInvocationFailed) when
+	// the provider replies Success=false. Print the visible result before
+	// propagating the error so operators still see the (possibly-empty)
+	// tuple alongside the typed exit code.
+	if result != nil {
+		fmt.Printf("invocation %d: success=%v\n", result.InvocationID, result.Success)
+		if len(result.Result) > 0 {
+			fmt.Printf("result: %v\n", result.Result)
+		}
 	}
-
-	fmt.Printf("invocation %d: success=%v\n", result.InvocationID, result.Success)
-	if len(result.Result) > 0 {
-		fmt.Printf("result: %v\n", result.Result)
-	}
-	return nil
+	return err
 }

--- a/docs/protocols/error-codes.md
+++ b/docs/protocols/error-codes.md
@@ -98,8 +98,8 @@ Memory: `feedback_error_contract_cross_os` locks the rule across every connector
 
 | Code | Status | When | Anchor |
 |---|---|---|---|
-| `emberplus:invocation-failed` | pending (R1f) | `InvocationResult.Success=false`, no description | Ember+ Doc §p.92 |
-| `emberplus:invocation-failed-with-description` | pending (R1f) | `Success=false` + provider populated `description` | Ember+ Doc §p.92 |
+| `emberplus:invocation-failed` | defined (R1f) | `InvocationResult.Success=false` on the wire. `InvokeFunction` returns the result pointer alongside the typed error so callers can still print the (possibly-empty) result tuple while the error sets exit 1 | Ember+ Doc §p.92 |
+| `emberplus:invocation-failed-with-description` | defined (sentinel only, R1f) | reserved for the case when the codec decodes the optional `description` field — currently the codec doesn't parse it, so every `Success=false` maps to `emberplus:invocation-failed`. Codec extension is separate scope | Ember+ Doc §p.92 |
 
 ### validation
 

--- a/internal/emberplus/consumer/errcode.go
+++ b/internal/emberplus/consumer/errcode.go
@@ -1,0 +1,40 @@
+// Code sentinels for Ember+ consumer-side semantic failures.
+//
+// Wraps wire-level rejection signals (InvocationResult.Success=false,
+// Connection.Disposition=locked, offlineElement) with typed *errcode.Code
+// instances so callers (CLI, scripts, Ansible) can dispatch via
+// errors.Is(err, emberplus.ErrXxx).
+//
+// Ember+ has NO native wire-level error codes — the wire carries only
+// Success (boolean) + Disposition (4-value enum) + offlineElement marker.
+// These dhs sentinels are this project's invention layered on top of
+// those signals; operators won't find them in the Ember+ Documentation
+// PDF. Per memory feedback_error_contract_cross_os.
+//
+// Wire form: "emberplus:<code>: <human message>".
+package emberplus
+
+import "dhs/internal/errcode"
+
+// All emberplus:* codes are runtime semantic-rejection failures
+// (Class 1, exit 1).
+var (
+	// ErrInvocationFailed is returned when an Invoke completes with
+	// InvocationResult.Success=false on the wire. The caller's
+	// InvokeFunction still returns the *glow.InvocationResult so the
+	// result tuple (if any) is visible — but the error signals exit 1
+	// so scripts dispatch correctly.
+	//
+	// Per Ember+ Doc §p.92.
+	ErrInvocationFailed = errcode.New(errcode.LayerEmberplus, "invocation-failed", errcode.ClassRuntime)
+
+	// ErrInvocationFailedWithDescription is reserved for future use —
+	// once the codec parses the optional description field in
+	// InvocationResult (currently not decoded), failures carrying a
+	// non-empty description will use this code so operators can see
+	// the provider's human reason. For now, every Success=false maps
+	// to ErrInvocationFailed.
+	//
+	// Per Ember+ Doc §p.92.
+	ErrInvocationFailedWithDescription = errcode.New(errcode.LayerEmberplus, "invocation-failed-with-description", errcode.ClassRuntime)
+)

--- a/internal/emberplus/consumer/errcode_test.go
+++ b/internal/emberplus/consumer/errcode_test.go
@@ -1,0 +1,54 @@
+package emberplus
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"dhs/internal/errcode"
+)
+
+// TestEmberplus_Sentinels_ShapeAndClass pins every emberplus:* code's
+// wire shape + exit class.
+func TestEmberplus_Sentinels_ShapeAndClass(t *testing.T) {
+	cases := []struct {
+		code *errcode.Code
+		want string
+	}{
+		{ErrInvocationFailed, "emberplus:invocation-failed"},
+		{ErrInvocationFailedWithDescription, "emberplus:invocation-failed-with-description"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			if got := tc.code.Error(); got != tc.want {
+				t.Errorf("Error() = %q, want %q", got, tc.want)
+			}
+			if tc.code.Layer != errcode.LayerEmberplus {
+				t.Errorf("Layer = %q, want %q", tc.code.Layer, errcode.LayerEmberplus)
+			}
+			if tc.code.Class != errcode.ClassRuntime {
+				t.Errorf("Class = %d, want ClassRuntime (1)", tc.code.Class)
+			}
+			if got := errcode.Exit(tc.code); got != 1 {
+				t.Errorf("Exit() = %d, want 1", got)
+			}
+		})
+	}
+}
+
+// TestInvocationFailed_ErrorsIsDispatch pins that a wrap mirroring the
+// shape InvokeFunction emits on Success=false (`%w: invocation %d on %q`)
+// chains correctly for callers using errors.Is.
+func TestInvocationFailed_ErrorsIsDispatch(t *testing.T) {
+	err := fmt.Errorf("%w: invocation %d on %q", ErrInvocationFailed, 42, "router.functions.setLock")
+	if !errors.Is(err, ErrInvocationFailed) {
+		t.Errorf("err = %v, want errors.Is(err, ErrInvocationFailed)", err)
+	}
+	if got := errcode.Exit(err); got != 1 {
+		t.Errorf("Exit() = %d, want 1", got)
+	}
+	wantPrefix := "emberplus:invocation-failed:"
+	if got := err.Error(); len(got) < len(wantPrefix) || got[:len(wantPrefix)] != wantPrefix {
+		t.Errorf("err string = %q, want prefix %q", got, wantPrefix)
+	}
+}

--- a/internal/emberplus/consumer/plugin.go
+++ b/internal/emberplus/consumer/plugin.go
@@ -1053,6 +1053,16 @@ func (p *Plugin) InvokeFunction(ctx context.Context, funcPath string, args []any
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	case result := <-resultCh:
+		// Wire-level Success=false → typed error so the CLI exit
+		// dispatcher returns 1. The result pointer is still returned so
+		// callers can print the (possibly-empty) Result tuple alongside
+		// the error. Per memory feedback_error_contract_cross_os: the
+		// error string carries the diagnostic, exit code carries the
+		// pass/fail signal.
+		if result != nil && !result.Success {
+			return result, fmt.Errorf("%w: invocation %d on %q",
+				ErrInvocationFailed, result.InvocationID, funcPath)
+		}
 		return result, nil
 	}
 }


### PR DESCRIPTION
## Summary

**R1f — Ember+ invocation failure migration to typed error codes (R1 [#468](https://github.com/by-openclaw/go-acp/issues/468)).**

Sixth pass of the R1 epic. When the provider replies `InvocationResult.Success=false`, the consumer's `InvokeFunction` now returns a typed `*errcode.Code` error so the CLI exits 1 instead of 0.

## What's in this PR

### New sentinels (`internal/emberplus/consumer/errcode.go`)

| Code | Status | When |
|---|---|---|
| `emberplus:invocation-failed` | defined | `InvocationResult.Success=false` — every failure today maps here |
| `emberplus:invocation-failed-with-description` | sentinel only | reserved for when codec decodes the optional `description` field |

Ember+ Doc §p.92 — the wire format defines neither error codes nor a universal failure reason. dhs invents the `emberplus:*` taxonomy on top of the `Success` boolean (per memory `feedback_error_contract_cross_os`).

### Call-site migrations

**`InvokeFunction`** (`internal/emberplus/consumer/plugin.go`): On `Success=false`, returns `(result, ErrInvocationFailed)` wrapped with invocation ID + function path. The result pointer is preserved so callers can still print the tuple alongside the error.

**`runInvoke`** (`cmd/dhs/cmd_invoke.go`): Prints the result line first (success bool + tuple if any), then propagates the typed error so the binary exits 1 on `Success=false`.

### Behavior change visible to operators

| Before | After |
|---|---|
| Exit `0` even on failure | Exit `1` on `Success=false` |
| Caller had to grep `success=false` in stdout | Caller checks `$LASTEXITCODE` / `$?` or greps `^emberplus:invocation-failed` on stderr |
| No stable error code | `emberplus:invocation-failed: invocation N on "path"` on stderr |

Stdout still shows the success line + result tuple, so operators don't lose context.

### Tests

| Test | Asserts |
|---|---|
| `TestEmberplus_Sentinels_ShapeAndClass` | wire shape + Class=1 + Layer=emberplus + Exit=1 (2 subtests) |
| `TestInvocationFailed_ErrorsIsDispatch` | wrap shape matches what `InvokeFunction` emits, `errors.Is` finds the sentinel, `Exit()=1`, stderr prefix `emberplus:invocation-failed:` |

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/emberplus/consumer ./cmd/dhs -count=1` — `ok`
- [x] `go test ./... -count=1` — full suite green
- [x] `golangci-lint` clean (pre-commit hook passed)
- [x] Happy-path Invoke tests (Success=true) unchanged — only Success=false path returns a typed error
- [ ] **Codeowner live test** — run `invoke setLock --args "bogus.path,1,true"` against the integration-test provider and verify:
  - stdout: `invocation 1: success=false`
  - stderr: `emberplus:invocation-failed: invocation 1 on "...functions.setLock"`
  - `$LASTEXITCODE` is `1`

## Canonical doc

`docs/protocols/error-codes.md` — `emberplus:invocation-failed` flipped to `defined`. `emberplus:invocation-failed-with-description` marked as "defined (sentinel only)" — every `Success=false` routes to `invocation-failed` until the codec gains description-field parsing (separate scope).

## Migration ladder

| PR | Status | Scope |
|---|---|---|
| R1a [#491](https://github.com/by-openclaw/go-acp/pull/491) | ✅ merged | `internal/errcode/` |
| R1b [#492](https://github.com/by-openclaw/go-acp/pull/492) | ✅ merged | transport |
| R1c [#493](https://github.com/by-openclaw/go-acp/pull/493) | ✅ merged | S101 |
| R1d [#494](https://github.com/by-openclaw/go-acp/pull/494) | ✅ merged | BER + Glow |
| R1e [#495](https://github.com/by-openclaw/go-acp/pull/495) | ✅ merged | matrix |
| **R1f (this PR)** | open | emberplus invocation |
| R1g | next | rewire `internal/consumer/` typed sentinels |
| R1h | next | `cmd/dhs/` exit-code dispatcher + runbook follow-up |

## Refs

Refs #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)
