### PR TITLE
feat(cmd/dhs): invoke --format human pretty-prints getSalvo (refs #482)

### DIFF
--- a/cmd/dhs/cmd_invoke.go
+++ b/cmd/dhs/cmd_invoke.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"dhs/internal/consumer"
 	emberplus "dhs/internal/emberplus/consumer"
 )
 
@@ -17,6 +18,7 @@ func runInvoke(ctx context.Context, args []string) error {
 	slot := fs.Int("slot", 0, "slot number")
 	funcPath := fs.String("path", "", "dot-separated function path (e.g. router.functions.add)")
 	argsStr := fs.String("args", "", "comma-separated arguments (e.g. 3,5)")
+	format := fs.String("format", "raw", `result presentation: "raw" (default — provider's wire form) or "human" (pretty-print for getSalvo)`)
 	dmIdentity := fs.String("dm", "", `Ember+ only: identity-keyed DM hot-load (e.g. "dhs-emberplus-integration@1.0.0"). When set, the tree is seeded from .cache/dm/emberplus/<identity>.json and the per-call walk is skipped — refs #438, ADR-0022.`)
 	noWalk := fs.Bool("no-walk", false, "fail fast on cache miss instead of falling back to a wire walk")
 	host, rest, err := popHost(args)
@@ -26,6 +28,9 @@ func runInvoke(ctx context.Context, args []string) error {
 	_ = fs.Parse(rest)
 	if *funcPath == "" {
 		return fmt.Errorf("--path is required (e.g. router.functions.add)")
+	}
+	if *format != "raw" && *format != "human" {
+		return fmt.Errorf("%w: --format must be \"raw\" or \"human\", got %q", consumer.ErrInvalidFormat, *format)
 	}
 
 	// Parse arguments — RFC 4180 CSV so a quoted field can carry a comma
@@ -91,8 +96,31 @@ func runInvoke(ctx context.Context, args []string) error {
 	if result != nil {
 		fmt.Printf("invocation %d: success=%v\n", result.InvocationID, result.Success)
 		if len(result.Result) > 0 {
-			fmt.Printf("result: %v\n", result.Result)
+			// R11 #482 — pretty-print getSalvo when --format human.
+			// For every other function (and for --format raw) keep the
+			// existing wire-form display.
+			if *format == "human" && isGetSalvoPath(*funcPath) {
+				if s, ok := result.Result[0].(string); ok {
+					fmt.Println(formatGetSalvoHuman(s))
+				} else {
+					// Unexpected shape — fall back to raw so the operator
+					// still sees something.
+					fmt.Printf("result: %v\n", result.Result)
+				}
+			} else {
+				fmt.Printf("result: %v\n", result.Result)
+			}
 		}
 	}
 	return err
+}
+
+// isGetSalvoPath returns true when the function path's last segment is
+// "getSalvo". Used by R11 #482 to gate the pretty-print formatter.
+func isGetSalvoPath(path string) bool {
+	idx := strings.LastIndex(path, ".")
+	if idx < 0 {
+		return path == "getSalvo"
+	}
+	return path[idx+1:] == "getSalvo"
 }

--- a/cmd/dhs/cmd_invoke_format.go
+++ b/cmd/dhs/cmd_invoke_format.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// formatGetSalvoHuman pretty-prints a getSalvo wire-result string
+// (R11 #482). The provider serializes the salvo as
+//
+//	"tgt=src;tgt=src,src,src;..."
+//
+// — semicolon between targets, comma between sources within a target.
+// Output lines, one per target:
+//
+//	tgt 0 <- Src [0]
+//	tgt 1 <- Src [1]
+//	tgt 5 <- Src [3,4,5]
+//	tgt 7 <- Src []         (empty target — no sources)
+//
+// Returns "(empty salvo)" for an empty input.
+//
+// The parser is lenient — malformed rows are passed through verbatim
+// (prefixed with "row: ") so operators see whatever the provider emitted
+// rather than the formatter silently dropping a row.
+func formatGetSalvoHuman(serialized string) string {
+	serialized = strings.TrimSpace(serialized)
+	if serialized == "" {
+		return "(empty salvo)"
+	}
+	rows := strings.Split(serialized, ";")
+	out := make([]string, 0, len(rows))
+	for _, row := range rows {
+		row = strings.TrimSpace(row)
+		if row == "" {
+			continue
+		}
+		eq := strings.IndexByte(row, '=')
+		if eq < 0 {
+			// Malformed — pass through so the operator sees the raw shape.
+			out = append(out, fmt.Sprintf("row: %s", row))
+			continue
+		}
+		tgt := strings.TrimSpace(row[:eq])
+		srcs := strings.TrimSpace(row[eq+1:])
+		if srcs == "" {
+			out = append(out, fmt.Sprintf("tgt %s <- Src []", tgt))
+			continue
+		}
+		out = append(out, fmt.Sprintf("tgt %s <- Src [%s]", tgt, srcs))
+	}
+	if len(out) == 0 {
+		return "(empty salvo)"
+	}
+	return strings.Join(out, "\n")
+}

--- a/cmd/dhs/cmd_invoke_format_test.go
+++ b/cmd/dhs/cmd_invoke_format_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFormatGetSalvoHuman_Cases pins the R11 #482 human-format
+// presentation against every shape getSalvo can emit on the wire.
+func TestFormatGetSalvoHuman_Cases(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty string", in: "", want: "(empty salvo)"},
+		{name: "whitespace only", in: "   ", want: "(empty salvo)"},
+		{name: "single tgt single src", in: "0=0", want: "tgt 0 <- Src [0]"},
+		{name: "single tgt multi src", in: "5=3,4,5", want: "tgt 5 <- Src [3,4,5]"},
+		{name: "multiple tgts", in: "0=0;1=1;5=3,4,5", want: "tgt 0 <- Src [0]\ntgt 1 <- Src [1]\ntgt 5 <- Src [3,4,5]"},
+		{name: "empty src list", in: "7=", want: "tgt 7 <- Src []"},
+		{name: "mixed empty + filled", in: "0=0;7=;3=3,4", want: "tgt 0 <- Src [0]\ntgt 7 <- Src []\ntgt 3 <- Src [3,4]"},
+		{name: "trailing semicolon", in: "0=0;", want: "tgt 0 <- Src [0]"},
+		{name: "double semicolon skipped", in: "0=0;;1=1", want: "tgt 0 <- Src [0]\ntgt 1 <- Src [1]"},
+		{name: "spaces around tokens", in: " 0 = 0 ; 5 = 3,4,5 ", want: "tgt 0 <- Src [0]\ntgt 5 <- Src [3,4,5]"},
+		{name: "malformed row passed through", in: "0=0;bogus;1=1", want: "tgt 0 <- Src [0]\nrow: bogus\ntgt 1 <- Src [1]"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatGetSalvoHuman(tc.in); got != tc.want {
+				t.Errorf("formatGetSalvoHuman(%q) =\n%s\nwant:\n%s", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsGetSalvoPath pins the path-matching logic that gates when the
+// --format human flag triggers the salvo pretty-print.
+func TestIsGetSalvoPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{path: "getSalvo", want: true},
+		{path: "dhs-emberplus-integration.functions.getSalvo", want: true},
+		{path: "router.functions.getSalvo", want: true},
+		{path: "functions.setLock", want: false},
+		{path: "getSalvoSomethingElse", want: false},
+		{path: "", want: false},
+		{path: "getSalvo.subItem", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			if got := isGetSalvoPath(tc.path); got != tc.want {
+				t.Errorf("isGetSalvoPath(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFormatGetSalvoHuman_NoTrailingNewline pins that the formatter
+// returns a single string with no trailing newline — fmt.Println
+// adds one already.
+func TestFormatGetSalvoHuman_NoTrailingNewline(t *testing.T) {
+	got := formatGetSalvoHuman("0=0;1=1")
+	if strings.HasSuffix(got, "\n") {
+		t.Errorf("formatGetSalvoHuman trailing newline = %q, want no trailing newline", got)
+	}
+}

--- a/internal/consumer/errors.go
+++ b/internal/consumer/errors.go
@@ -49,6 +49,12 @@ var (
 	// echo indicates the write was refused (target locked, element
 	// offline, access denied).
 	ErrWriteRejected = errcode.New(errcode.LayerSession, "write-rejected", errcode.ClassRuntime)
+
+	// ErrInvalidFormat is returned when a CLI verb's --format flag
+	// receives a value outside the verb's supported set. Each verb
+	// owns its own supported set; the code is shared so scripts can
+	// dispatch on it uniformly.
+	ErrInvalidFormat = errcode.New(errcode.LayerValidation, "invalid-format", errcode.ClassUsage)
 )
 
 // DHSError is the root of all protocol-family errors. Both transport-layer


### PR DESCRIPTION
## Summary

**R11 — `invoke --format human` pretty-prints `getSalvo` (refs [#482](https://github.com/by-openclaw/go-acp/issues/482)).**

Add `--format {raw|human}` flag to the `invoke` verb. When invoking a function whose path ends in `getSalvo` and `--format human` is set, the wire-form result is rendered one line per target.

## What's in this PR

### New `--format` flag

| Value | Behaviour |
|---|---|
| `raw` (default) | provider's wire form: `"0=0;1=1;5=3,4,5"` |
| `human` | one line per target: `tgt N <- Src [a,b,c]` |
| anything else | `validation:invalid-format` (exit 2) |

For non-`getSalvo` functions and `--format raw`, behaviour is byte-identical to before.

### Pretty-print examples

```
$ dhs consumer emberplus invoke ... getSalvo --args "1.1.3,99" --format human
invocation 1: success=true
tgt 0 <- Src [0]
tgt 1 <- Src [1]
tgt 5 <- Src [3,4,5]
tgt 7 <- Src []
```

### New shared sentinel

`internal/consumer/errors.go`:

```go
ErrInvalidFormat = errcode.New(errcode.LayerValidation, "invalid-format", errcode.ClassUsage)
```

Reused by R22 [#487](https://github.com/by-openclaw/go-acp/issues/487) (`profile --format`) and R23 [#488](https://github.com/by-openclaw/go-acp/issues/488) (`validate --report`) when they land.

### Files

| File | Change |
|---|---|
| [`cmd/dhs/cmd_invoke.go`](https://github.com/by-openclaw/go-acp/blob/feat/invoke-format-human-482/cmd/dhs/cmd_invoke.go) | new `--format` flag · validates · pretty-prints when applicable |
| [`cmd/dhs/cmd_invoke_format.go`](https://github.com/by-openclaw/go-acp/blob/feat/invoke-format-human-482/cmd/dhs/cmd_invoke_format.go) (new) | `formatGetSalvoHuman` lenient parser |
| [`cmd/dhs/cmd_invoke_format_test.go`](https://github.com/by-openclaw/go-acp/blob/feat/invoke-format-human-482/cmd/dhs/cmd_invoke_format_test.go) (new) | 11 + 7 + 1 cases pinning shape |
| [`internal/consumer/errors.go`](https://github.com/by-openclaw/go-acp/blob/feat/invoke-format-human-482/internal/consumer/errors.go) | `ErrInvalidFormat` sentinel |

### Lenient parser

Malformed rows pass through with `row: ...` prefix so operators see whatever the provider emitted — no silent drops. Examples:

| Input | Output |
|---|---|
| `""` | `(empty salvo)` |
| `"0=0"` | `tgt 0 <- Src [0]` |
| `"5=3,4,5"` | `tgt 5 <- Src [3,4,5]` |
| `"7="` | `tgt 7 <- Src []` |
| `"0=0;bogus;1=1"` | `tgt 0 <- Src [0]` / `row: bogus` / `tgt 1 <- Src [1]` |

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./cmd/dhs -run "GetSalvo\|GetSalvoPath" -count=1` — 19 subtests pass
- [x] `go test ./... -count=1` — full suite green
- [x] `golangci-lint` clean (pre-commit hook passed)
- [x] Existing `invoke` tests unchanged behaviorally — `--format raw` is the default
- [ ] **Codeowner live verify** on the integration-test provider:
  - `invoke ... getSalvo --args "1.1.3,99"` → raw form (default)
  - `invoke ... getSalvo --args "1.1.3,99" --format human` → pretty form
  - `invoke ... setLock --args "1.1.3,3,true" --format human` → raw form (flag ignored for non-getSalvo)
  - `invoke ... --format bogus` → exit 2 + `validation:invalid-format: ...`

## Refs

Refs #482
Refs #468 (uses R1 typed error code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
