### PR TITLE
feat(emberplus/consumer): info reports DTD version captured from S101 app-bytes (refs #470)

### DIFF
--- a/cmd/dhs/cmd_info.go
+++ b/cmd/dhs/cmd_info.go
@@ -30,6 +30,16 @@ func runInfo(ctx context.Context, args []string) error {
 	}
 	fmt.Printf("device       %s:%d\n", info.IP, info.Port)
 	fmt.Printf("protocol     %s v%d\n", cf.protocol, info.ProtocolVersion)
+	// R6 #470: surface the wire-level DTD revision the device advertises.
+	// "unknown" preserves a fixed-width column when the plugin has no
+	// equivalent surface (ACP1/ACP2 leave DeviceInfo.DtdVersion="") or
+	// the device's first frame carried no app-bytes and the identity
+	// fallback found nothing.
+	dtd := info.DtdVersion
+	if dtd == "" {
+		dtd = "unknown"
+	}
+	fmt.Printf("dtd_version  %s\n", dtd)
 	fmt.Printf("slots        %d\n", info.NumSlots)
 	fmt.Println()
 	fmt.Println("per-slot status:")

--- a/internal/consumer/types.go
+++ b/internal/consumer/types.go
@@ -29,6 +29,14 @@ type DeviceInfo struct {
 	// ProtocolVersion is the PVER byte for ACP1 (always 1 for v1.4 devices)
 	// or the ACP2 version number returned by get_version.
 	ProtocolVersion int
+
+	// DtdVersion is the wire-level protocol revision the device speaks,
+	// formatted as "major.minor". For Ember+ this is captured from the
+	// S101 app-bytes on the first EmBER frame (e.g. "2.60") or, as a
+	// fallback, from the identity.dtdVersion Parameter. Empty when the
+	// plugin has no equivalent surface (ACP1/ACP2) or the device did
+	// not advertise it. Refs #470.
+	DtdVersion string
 }
 
 // SlotStatus mirrors the ACP1 Frame Status byte values (spec p. 24).

--- a/internal/emberplus/codec/s101/frame.go
+++ b/internal/emberplus/codec/s101/frame.go
@@ -51,13 +51,15 @@ const (
 
 // Frame is a decoded S101 frame.
 type Frame struct {
-	Slot    byte   // slot (0x00)
-	MsgType byte   // message type: MsgEmBER or MsgKeepAlive
-	Command byte   // CmdEmBER, CmdKeepAliveReq, etc.
-	Version byte   // S101 version (0x01)
-	Flags   byte   // FlagSingle, FlagFirst, FlagLast
-	DTD     byte   // DTD identifier (0x01 = Glow)
-	Payload []byte // BER-encoded data (for EmBER frames)
+	Slot     byte   // slot (0x00)
+	MsgType  byte   // message type: MsgEmBER or MsgKeepAlive
+	Command  byte   // CmdEmBER, CmdKeepAliveReq, etc.
+	Version  byte   // S101 version (0x01)
+	Flags    byte   // FlagSingle, FlagFirst, FlagLast
+	DTD      byte   // DTD identifier (0x01 = Glow)
+	DTDMinor byte   // DTD minor version from app-bytes (e.g. 0x3C = 60); 0 when absent
+	DTDMajor byte   // DTD major version from app-bytes (e.g. 0x02 = 2); 0 when absent
+	Payload  []byte // BER-encoded data (for EmBER frames)
 }
 
 // Encode builds an S101 wire frame: BOF + header + escaped payload + CRC + EOF.
@@ -111,17 +113,29 @@ func Encode(f *Frame) []byte {
 		// dtd=161" against our provider. The de-facto contract is what
 		// the ecosystem honours, so we always emit the full 9-byte
 		// header.
+		// DTD app-bytes default to the canonical 2.60 advertised by
+		// the shipping Ember+ ecosystem; NewEmBERFrame seeds them via
+		// DTDMinorVersion / DTDMajorVersion. Callers may override (test
+		// fixtures simulating an older provider, replay tooling).
+		minor := f.DTDMinor
+		if minor == 0 {
+			minor = DTDMinorVersion
+		}
+		major := f.DTDMajor
+		if major == 0 {
+			major = DTDMajorVersion
+		}
 		raw = make([]byte, 0, 9+len(f.Payload))
 		raw = append(raw,
-			f.Slot,          // 0: slot
-			MsgEmBER,        // 1: message type
-			CmdEmBER,        // 2: command
-			VersionS101,     // 3: version
-			f.Flags,         // 4: flags
-			DTDGlow,         // 5: DTD type
-			AppBytesLen,     // 6: app bytes length (2)
-			DTDMinorVersion, // 7: DTD minor version (60)
-			DTDMajorVersion, // 8: DTD major version (2)
+			f.Slot,      // 0: slot
+			MsgEmBER,    // 1: message type
+			CmdEmBER,    // 2: command
+			VersionS101, // 3: version
+			f.Flags,     // 4: flags
+			DTDGlow,     // 5: DTD type
+			AppBytesLen, // 6: app bytes length (2)
+			minor,       // 7: DTD minor version
+			major,       // 8: DTD major version
 		)
 		raw = append(raw, f.Payload...)
 	}
@@ -226,8 +240,8 @@ func Decode(data []byte) (*Frame, error) {
 	if hasFullHeader {
 		f.DTD = content[5]
 		// content[6] = AppBytesLen (assumed 2)
-		// content[7] = DTD minor version
-		// content[8] = DTD major version
+		f.DTDMinor = content[7]
+		f.DTDMajor = content[8]
 		if len(content) > 9 {
 			f.Payload = content[9:]
 		}
@@ -289,13 +303,15 @@ func crcCCITT16(data []byte) uint16 {
 // NewEmBERFrame creates an S101 frame carrying a Glow BER payload.
 func NewEmBERFrame(payload []byte) *Frame {
 	return &Frame{
-		Slot:    SlotDefault,
-		MsgType: MsgEmBER,
-		Command: CmdEmBER,
-		Version: VersionS101,
-		Flags:   FlagSingle,
-		DTD:     DTDGlow,
-		Payload: payload,
+		Slot:     SlotDefault,
+		MsgType:  MsgEmBER,
+		Command:  CmdEmBER,
+		Version:  VersionS101,
+		Flags:    FlagSingle,
+		DTD:      DTDGlow,
+		DTDMinor: DTDMinorVersion,
+		DTDMajor: DTDMajorVersion,
+		Payload:  payload,
 	}
 }
 

--- a/internal/emberplus/codec/s101/frame_dtd_test.go
+++ b/internal/emberplus/codec/s101/frame_dtd_test.go
@@ -1,0 +1,65 @@
+package s101
+
+import "testing"
+
+// TestFrame_DTDAppBytes_Captured pins the R6 #470 requirement: every
+// EmBER frame carries the DTD minor/major in the 9-byte header
+// (offsets 7+8). Decode must surface them on the Frame so the session
+// can latch the device's wire-level DTD revision.
+func TestFrame_DTDAppBytes_Captured(t *testing.T) {
+	orig := NewEmBERFrame([]byte{0x60, 0x03, 0x01, 0x01, 0xFF})
+	// Encoder defaults to the canonical 2.60 advertised by the
+	// shipping Ember+ ecosystem (libember-cpp, EmberPlusView,
+	// TinyEmber+, Lawo VSM). Decode round-trip must read them back.
+	data := Encode(orig)
+	got, err := Decode(data)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got.DTDMinor != DTDMinorVersion {
+		t.Errorf("DTDMinor: got 0x%02X, want 0x%02X", got.DTDMinor, DTDMinorVersion)
+	}
+	if got.DTDMajor != DTDMajorVersion {
+		t.Errorf("DTDMajor: got 0x%02X, want 0x%02X", got.DTDMajor, DTDMajorVersion)
+	}
+}
+
+// TestFrame_DTDAppBytes_AltVersions exercises the codec against a
+// provider that advertises an older DTD (2.10 = 0x0A / 0x02) — every
+// legit minor/major byte must round-trip without coercion.
+func TestFrame_DTDAppBytes_AltVersions(t *testing.T) {
+	cases := []struct{ minor, major byte }{
+		{0x0A, 0x02}, // 2.10
+		{0x1E, 0x02}, // 2.30
+		{0x32, 0x02}, // 2.50
+		{0x3C, 0x02}, // 2.60
+	}
+	for _, c := range cases {
+		f := NewEmBERFrame([]byte{0x60, 0x01, 0x00})
+		f.DTDMinor = c.minor
+		f.DTDMajor = c.major
+		got, err := Decode(Encode(f))
+		if err != nil {
+			t.Fatalf("Decode (%d.%d): %v", c.major, c.minor, err)
+		}
+		if got.DTDMinor != c.minor || got.DTDMajor != c.major {
+			t.Errorf("round-trip %d.%d: got %d.%d",
+				c.major, c.minor, got.DTDMajor, got.DTDMinor)
+		}
+	}
+}
+
+// TestFrame_KeepAlive_NoDTDBytes confirms keep-alive frames carry no
+// app-bytes (their header is only 4 bytes per spec p.94). The session
+// must not latch DTD from keep-alive traffic — otherwise the dead-man
+// loop would surface a spurious 0.0 version on quiet sessions.
+func TestFrame_KeepAlive_NoDTDBytes(t *testing.T) {
+	got, err := Decode(Encode(NewKeepAliveRequest()))
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got.DTDMinor != 0 || got.DTDMajor != 0 {
+		t.Errorf("keep-alive carries DTD bytes: minor=0x%02X major=0x%02X (want 0/0)",
+			got.DTDMinor, got.DTDMajor)
+	}
+}

--- a/internal/emberplus/consumer/plugin.go
+++ b/internal/emberplus/consumer/plugin.go
@@ -479,13 +479,60 @@ func (p *Plugin) Disconnect() error {
 // host/port. The single-slot report lets generic code — `acp export`,
 // `acp import`, `--all` — iterate once instead of skipping the
 // provider entirely.
+//
+// DtdVersion (refs #470): primary source is S101 app-bytes (offsets 7+8
+// = DTD minor/major), latched by the session on the first EmBER frame.
+// When `info` runs before any payload exchange the session has only
+// seen the S101 handshake, so GetDeviceInfo probes the provider with a
+// root GetDirectory and waits briefly for its reply — every shipping
+// Ember+ provider answers GetDirectory(root) with a 9-byte header
+// carrying the DTD app-bytes. The fallback is reading
+// `identity.dtdVersion` from the walked tree (rare — only providers
+// that emit 5-byte S101 headers ever need this path). Both routes
+// best-effort; failure leaves DtdVersion="" and cmd_info prints
+// "dtd_version unknown".
 func (p *Plugin) GetDeviceInfo(ctx context.Context) (consumer.DeviceInfo, error) {
-	return consumer.DeviceInfo{
+	info := consumer.DeviceInfo{
 		IP:              p.connIP,
 		Port:            p.connPort,
 		ProtocolVersion: 1,
 		NumSlots:        1,
-	}, nil
+	}
+	info.DtdVersion = p.resolveDtdVersion(ctx)
+	return info, nil
+}
+
+// resolveDtdVersion returns the Ember+ DTD revision the connected
+// provider speaks. See GetDeviceInfo for the resolution order.
+func (p *Plugin) resolveDtdVersion(ctx context.Context) string {
+	s := p.currentSession()
+	if s == nil {
+		return ""
+	}
+	if v := s.DtdVersion(); v != "" {
+		return v
+	}
+	// Probe: provoke an EmBER reply so the session can latch app-bytes.
+	// Bounded wait — never hold up `info` for more than a short window.
+	probeCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	if err := s.SendGetDirectory(); err == nil {
+		if v := s.WaitForDtdVersion(probeCtx); v != "" {
+			return v
+		}
+	}
+	// Fallback: identity.dtdVersion in the walked tree. Skip the
+	// auto-walk — operators that want the slow path can run `walk`
+	// explicitly. If the tree is empty here the fallback simply
+	// returns "".
+	p.treeMu.RLock()
+	defer p.treeMu.RUnlock()
+	if entry, ok := p.pathIndex["identity.dtdVersion"]; ok {
+		if entry.obj.Value.Kind == consumer.KindString {
+			return entry.obj.Value.Str
+		}
+	}
+	return ""
 }
 
 // GetSlotInfo pretends the whole Ember+ tree is slot 0. Any other slot is

--- a/internal/emberplus/consumer/session.go
+++ b/internal/emberplus/consumer/session.go
@@ -65,6 +65,72 @@ type Session struct {
 	// to match the provider.
 	glowFormMu     sync.RWMutex
 	useLegacyGlow  bool
+
+	// dtdSeen latches the first DTD version advertised by the provider
+	// via S101 app-bytes (header offsets 7+8 = minor/major). Captured
+	// in readLoop on every EmBER frame; observable via DtdVersion()
+	// once dtdReady is closed. Refs #470.
+	dtdMu    sync.Mutex
+	dtdSeen  bool
+	dtdMinor byte
+	dtdMajor byte
+	dtdReady chan struct{}
+}
+
+// DtdVersion returns the DTD version advertised by the provider via
+// S101 app-bytes, formatted as "major.minor" (e.g. "2.60"). Returns ""
+// when no EmBER frame has been received yet, or the frames carried no
+// app-bytes (5-byte header variant). Refs #470.
+func (s *Session) DtdVersion() string {
+	s.dtdMu.Lock()
+	defer s.dtdMu.Unlock()
+	if !s.dtdSeen {
+		return ""
+	}
+	return fmt.Sprintf("%d.%d", s.dtdMajor, s.dtdMinor)
+}
+
+// WaitForDtdVersion blocks until the provider's DTD app-bytes have
+// been captured, or the context is cancelled. Returns the version
+// string (possibly "" if context fires before any EmBER frame is
+// received). Used by Plugin.GetDeviceInfo to provoke and read the
+// first frame's app-bytes without forcing a full Walk. Refs #470.
+func (s *Session) WaitForDtdVersion(ctx context.Context) string {
+	s.dtdMu.Lock()
+	if s.dtdSeen {
+		s.dtdMu.Unlock()
+		return s.DtdVersion()
+	}
+	ready := s.dtdReady
+	s.dtdMu.Unlock()
+	if ready == nil {
+		return ""
+	}
+	select {
+	case <-ready:
+	case <-ctx.Done():
+	}
+	return s.DtdVersion()
+}
+
+// noteDtd latches the first non-zero DTD minor/major seen on the wire.
+// Called from readLoop after every successful frame decode; subsequent
+// frames are ignored so a single boot-time observation pins the value.
+func (s *Session) noteDtd(minor, major byte) {
+	if minor == 0 && major == 0 {
+		return
+	}
+	s.dtdMu.Lock()
+	defer s.dtdMu.Unlock()
+	if s.dtdSeen {
+		return
+	}
+	s.dtdSeen = true
+	s.dtdMinor = minor
+	s.dtdMajor = major
+	if s.dtdReady != nil {
+		close(s.dtdReady)
+	}
 }
 
 // SetUseLegacyGlow pins the session to emit non-qualified Glow on
@@ -117,6 +183,7 @@ func NewSession(logger *slog.Logger) *Session {
 		keepAliveInterval: 10 * time.Second,
 		deadManThreshold:  30 * time.Second, // 3× keep-alive interval
 		invocations:       make(map[int32]chan *glow.InvocationResult),
+		dtdReady:          make(chan struct{}),
 	}
 }
 
@@ -465,7 +532,15 @@ func (s *Session) readLoop() {
 			continue
 		}
 
-		if !frame.IsEmBER() || len(frame.Payload) == 0 {
+		if !frame.IsEmBER() {
+			continue
+		}
+		// Latch DTD app-bytes from the first EmBER frame that carries
+		// the 9-byte header. Used by GetDeviceInfo to surface the
+		// device's Glow DTD revision without walking the tree. Refs
+		// #470.
+		s.noteDtd(frame.DTDMinor, frame.DTDMajor)
+		if len(frame.Payload) == 0 {
 			continue
 		}
 

--- a/internal/emberplus/consumer/session_dtd_test.go
+++ b/internal/emberplus/consumer/session_dtd_test.go
@@ -1,0 +1,112 @@
+package emberplus
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+// TestSession_DtdVersion_Latches pins the R6 #470 invariant: noteDtd
+// records the FIRST non-zero DTD minor/major seen and ignores
+// subsequent observations. A provider that downgrades mid-session
+// (rare; spec forbids) must not retroactively flip the version.
+func TestSession_DtdVersion_Latches(t *testing.T) {
+	s := NewSession(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	if got := s.DtdVersion(); got != "" {
+		t.Fatalf("pre-note DtdVersion: got %q, want empty", got)
+	}
+
+	s.noteDtd(0x3C, 0x02) // 2.60
+	if got := s.DtdVersion(); got != "2.60" {
+		t.Errorf("after first note: got %q, want 2.60", got)
+	}
+
+	// Second observation with different bytes must be ignored.
+	s.noteDtd(0x0A, 0x02) // 2.10 — should NOT overwrite
+	if got := s.DtdVersion(); got != "2.60" {
+		t.Errorf("after second note: got %q, want 2.60 (latch broken)", got)
+	}
+}
+
+// TestSession_NoteDtd_ZeroBytesIgnored guarantees the latch is not
+// poisoned by a frame that arrived without app-bytes (5-byte header
+// variant). A subsequent frame carrying the real bytes must still
+// latch successfully.
+func TestSession_NoteDtd_ZeroBytesIgnored(t *testing.T) {
+	s := NewSession(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	s.noteDtd(0, 0)
+	if got := s.DtdVersion(); got != "" {
+		t.Errorf("zero-byte note populated version: %q", got)
+	}
+
+	s.noteDtd(0x3C, 0x02)
+	if got := s.DtdVersion(); got != "2.60" {
+		t.Errorf("post-zero note: got %q, want 2.60", got)
+	}
+}
+
+// TestSession_WaitForDtdVersion_Notifies covers the probe path
+// GetDeviceInfo uses: a caller blocks on WaitForDtdVersion while a
+// concurrent goroutine (the readLoop in production) feeds the first
+// frame's app-bytes via noteDtd. The wait must unblock and return the
+// captured version.
+func TestSession_WaitForDtdVersion_Notifies(t *testing.T) {
+	s := NewSession(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan string, 1)
+	go func() { done <- s.WaitForDtdVersion(ctx) }()
+
+	// Give the waiter time to park on dtdReady.
+	time.Sleep(20 * time.Millisecond)
+	s.noteDtd(0x32, 0x02) // 2.50
+
+	select {
+	case got := <-done:
+		if got != "2.50" {
+			t.Errorf("WaitForDtdVersion: got %q, want 2.50", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("WaitForDtdVersion did not unblock after noteDtd")
+	}
+}
+
+// TestSession_WaitForDtdVersion_ContextCancelled covers the
+// no-app-bytes path: GetDeviceInfo's bounded probe must return ""
+// instead of hanging when the provider never sends an EmBER frame.
+func TestSession_WaitForDtdVersion_ContextCancelled(t *testing.T) {
+	s := NewSession(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	got := s.WaitForDtdVersion(ctx)
+	if got != "" {
+		t.Errorf("context-cancelled wait: got %q, want empty", got)
+	}
+}
+
+// TestSession_WaitForDtdVersion_AlreadyLatched: a caller that arrives
+// after the first frame must not block at all.
+func TestSession_WaitForDtdVersion_AlreadyLatched(t *testing.T) {
+	s := NewSession(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	s.noteDtd(0x3C, 0x02)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	got := s.WaitForDtdVersion(ctx)
+	if got != "2.60" {
+		t.Errorf("post-latch wait: got %q, want 2.60", got)
+	}
+	if elapsed := time.Since(start); elapsed > 20*time.Millisecond {
+		t.Errorf("post-latch wait blocked for %s (expected near-instant)", elapsed)
+	}
+}

--- a/internal/emberplus/docs/runbook.md
+++ b/internal/emberplus/docs/runbook.md
@@ -193,14 +193,15 @@ Expected:
 
 ```
 device       127.0.0.1:9100
-protocol     emberplus v1                ← TODO: surface DTD `2.60` from identity, not "v1" — R6 #470
+protocol     emberplus v1
+dtd_version  2.60                                 ← post R6 #470
 slots        1
 
 per-slot status:
   slot  0   status=present    online=true        ← post #459
 ```
 
-> The `protocol emberplus v1` line shows the internal plugin version, not the device's Ember+ DTD revision. **R6 [#470](https://github.com/by-openclaw/go-acp/issues/470)** rewires `info` to read `identity.dtdVersion` from the device and display the real DTD revision (e.g. `dtd 2.60`).
+> `dtd_version` is the wire-level Glow DTD revision the connected device advertises. It is captured from the S101 app-bytes on the first EmBER frame; if a provider emits the older 5-byte S101 header (no app-bytes), the plugin falls back to walking `identity.dtdVersion`. Both routes are best-effort — when neither produces a value the line reads `dtd_version unknown` and `info` still exits 0. Refs **R6 [#470](https://github.com/by-openclaw/go-acp/issues/470)**.
 
 ### Errors
 


### PR DESCRIPTION
## Summary

**R6 — `info` reports the wire-level Ember+ DTD version (refs [#470](https://github.com/by-openclaw/go-acp/issues/470)).**

`dhs consumer emberplus info <host>` now surfaces the Glow DTD revision the connected device advertises, replacing the misleading "protocol emberplus v1" tail (which is the dhs-internal plugin version, not the device's wire DTD).

```
device       127.0.0.1:9100
protocol     emberplus v1
dtd_version  2.60          ← new
slots        1

per-slot status:
  slot  0   status=present    online=true
```

## Resolution order

| Step | Source | When it wins |
|---|---|---|
| 1 | S101 app-bytes (header offsets 7+8 = DTD minor/major) | Every shipping Ember+ provider — libember-cpp / EmberPlusView / TinyEmber+ / Lawo VSM — emits the 9-byte header on every EmBER frame |
| 2 | Walk-cached `identity.dtdVersion` Parameter | Provider emits 5-byte S101 header (no app-bytes) **and** identity has been walked |
| 3 | Neither available | `dtd_version unknown` (info still exits `0`) |

The probe is **bounded** — `GetDeviceInfo` sends a root `GetDirectory` and waits up to 2 s for the reply's app-bytes. It does **not** force a full Walk, so `info` stays a fast verb on big trees.

## Wire layout (refresher)

S101 EmBER frame, 9-byte header — content offsets after unescape/CRC strip:

| Offset | Field | Value (canonical 2.60) |
|---:|---|---|
| 0 | slot | `0x00` |
| 1 | msgType | `0x0E` (MsgEmBER) |
| 2 | command | `0x00` (CmdEmBER) |
| 3 | version | `0x01` (VersionS101) |
| 4 | flags | `0xC0`/`0x80`/`0x40` |
| 5 | DTD | `0x01` (Glow) |
| 6 | appBytesLen | `0x02` |
| **7** | **DTD minor** | **`0x3C` (=60)** |
| **8** | **DTD major** | **`0x02` (=2)** |

The session's `noteDtd` latches offsets 7+8 on the first non-zero observation; subsequent frames are ignored so a mid-session downgrade can't retroactively flip the value.

## Files

| File | Change |
|---|---|
| [`internal/emberplus/codec/s101/frame.go`](https://github.com/by-openclaw/go-acp/blob/feat/info-dtd-version-470/internal/emberplus/codec/s101/frame.go) | `Frame.DTDMinor` + `DTDMajor` byte fields · `Decode` populates · `Encode` honors caller-set values (defaults via `NewEmBERFrame`) |
| [`internal/emberplus/codec/s101/frame_dtd_test.go`](https://github.com/by-openclaw/go-acp/blob/feat/info-dtd-version-470/internal/emberplus/codec/s101/frame_dtd_test.go) (new) | 3 cases — canonical 2.60 / alt versions 2.10/2.30/2.50 / keep-alive carries no DTD bytes |
| [`internal/emberplus/consumer/session.go`](https://github.com/by-openclaw/go-acp/blob/feat/info-dtd-version-470/internal/emberplus/consumer/session.go) | `dtdSeen`/`dtdMinor`/`dtdMajor` + `dtdReady` channel · `noteDtd` (first-wins latch) · `DtdVersion()` + `WaitForDtdVersion(ctx)` |
| [`internal/emberplus/consumer/session_dtd_test.go`](https://github.com/by-openclaw/go-acp/blob/feat/info-dtd-version-470/internal/emberplus/consumer/session_dtd_test.go) (new) | 5 cases — latch wins / zero bytes ignored / wait notifies / wait honors ctx cancel / wait skips block when already latched |
| [`internal/emberplus/consumer/plugin.go`](https://github.com/by-openclaw/go-acp/blob/feat/info-dtd-version-470/internal/emberplus/consumer/plugin.go) | `GetDeviceInfo` calls new `resolveDtdVersion` (cached → probe → identity fallback) |
| [`internal/consumer/types.go`](https://github.com/by-openclaw/go-acp/blob/feat/info-dtd-version-470/internal/consumer/types.go) | `DeviceInfo.DtdVersion string` (additive — ACP1/ACP2 leave `""`) |
| [`cmd/dhs/cmd_info.go`](https://github.com/by-openclaw/go-acp/blob/feat/info-dtd-version-470/cmd/dhs/cmd_info.go) | Prints `dtd_version <value\|unknown>` between protocol and slots |
| [`internal/emberplus/docs/runbook.md`](https://github.com/by-openclaw/go-acp/blob/feat/info-dtd-version-470/internal/emberplus/docs/runbook.md) | `info` expected-output block updated · explanatory note added |

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/emberplus/codec/s101 -run DTD -count=1` — 3 subtests pass
- [x] `go test ./internal/emberplus/consumer -run Dtd -count=1` — 5 subtests pass
- [x] `go test ./... -count=1` — full suite green
- [x] `golangci-lint` clean (pre-commit hook passed)
- [x] Existing `info` callers — ACP1, ACP2 — leave `DtdVersion=""`; cmd_info renders `dtd_version unknown` (additive, no breakage)
- [ ] **Codeowner live verify** on the integration-test producer:
  - `info 127.0.0.1 --port 9100` against `identity-strict@1.0.0` → `dtd_version 2.60`
  - `info` against a real Ember+ device (Lawo / TinyEmber+ / EmberPlusView) → matches device's advertised DTD
  - `info` against a hypothetical provider emitting 5-byte S101 header (none known in the wild) → falls back to identity walk if previously walked, else `unknown`

## Refs

Refs #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)
