### PR TITLE
feat(emberplus/consumer): set --value range / step / enum-by-label validation (refs #483)

### DIFF
--- a/cmd/dhs/cmd_set.go
+++ b/cmd/dhs/cmd_set.go
@@ -33,6 +33,7 @@ func runSet(ctx context.Context, args []string) error {
 	valueStr := fs.String("value", "", "typed value (e.g. -3.0, \"On\", \"192.168.1.5\", \"CH1\"); empty string is valid for string objects")
 	valueHex := fs.String("raw", "", "raw wire bytes as hex — escape hatch bypassing typed encoding")
 	noWalk := fs.Bool("no-walk", false, "fail fast on cache miss instead of walking the slot to resolve --path/--label")
+	round := fs.Bool("round", false, "R16 #483: snap an off-step numeric --value to the nearest legal step instead of erroring with validation:step-misaligned (Ember+ only — non-numeric Parameters return validation:round-not-applicable)")
 	dmIdentity := fs.String("dm", "", `Ember+ only: identity-keyed DM hot-load (e.g. "Tiny Ember+ Router@1.6.2"). When set, the tree is seeded from .cache/dm/emberplus/<identity>.json and the walk is skipped — refs #438, ADR-0022.`)
 	host, rest, err := popHost(args)
 	if err != nil {
@@ -141,6 +142,7 @@ func runSet(ctx context.Context, args []string) error {
 		Group: *group,
 		Label: *label,
 		ID:    *id,
+		Round: *round,
 	}
 	confirmed, err := plug.SetValue(opCtx, req, val)
 	if err != nil {

--- a/cmd/dhs/exitcode_test.go
+++ b/cmd/dhs/exitcode_test.go
@@ -49,6 +49,13 @@ func TestExitCode_LockedContract(t *testing.T) {
 		{name: "plugin:unknown-label → 2", err: consumer.ErrUnknownLabel, want: 2},
 		{name: "plugin:object-not-found → 2", err: consumer.ErrObjectNotFound, want: 2},
 		{name: "plugin:identity-unresolved → 2", err: consumer.ErrIdentityUnresolved, want: 2},
+		{name: "validation:invalid-format → 2", err: consumer.ErrInvalidFormat, want: 2},
+		{name: "validation:out-of-range-low → 2", err: consumer.ErrOutOfRangeLow, want: 2},
+		{name: "validation:out-of-range-high → 2", err: consumer.ErrOutOfRangeHigh, want: 2},
+		{name: "validation:step-misaligned → 2", err: consumer.ErrStepMisaligned, want: 2},
+		{name: "validation:invalid-enum-label → 2", err: consumer.ErrInvalidEnumLabel, want: 2},
+		{name: "validation:enum-not-supported → 2", err: consumer.ErrEnumNotSupported, want: 2},
+		{name: "validation:round-not-applicable → 2", err: consumer.ErrRoundNotApplicable, want: 2},
 
 		// Wrapped chains — the typed code is still discovered.
 		{name: "wrapped transport:refused → 1", err: fmt.Errorf("%w: connect 127.0.0.1:9100: ...", transport.ErrRefused), want: 1},
@@ -89,6 +96,9 @@ func TestExitCode_NeverThreeOrMore(t *testing.T) {
 		consumer.ErrNotImplemented, consumer.ErrNotConnected, consumer.ErrUnknownLabel,
 		consumer.ErrWriteTimeout, consumer.ErrWriteCoerced, consumer.ErrWriteRejected,
 		consumer.ErrObjectNotFound, consumer.ErrValidationFailed, consumer.ErrIdentityUnresolved,
+		consumer.ErrInvalidFormat,
+		consumer.ErrOutOfRangeLow, consumer.ErrOutOfRangeHigh, consumer.ErrStepMisaligned,
+		consumer.ErrInvalidEnumLabel, consumer.ErrEnumNotSupported, consumer.ErrRoundNotApplicable,
 	}
 	for _, s := range sentinels {
 		got := exitCode(s)

--- a/docs/protocols/error-codes.md
+++ b/docs/protocols/error-codes.md
@@ -109,10 +109,12 @@ Memory: `feedback_error_contract_cross_os` locks the rule across every connector
 | `validation:invalid-integer` | partial (today emits free-text via `*consumer.ValidationError`; R1g formalizes) | `--value` not parseable as integer | dhs PR #453 |
 | `validation:invalid-real` | partial | `--value` not parseable as real | dhs PR #453 |
 | `validation:invalid-enum-index` | partial | `--value` outside enum range | dhs PR #453 |
-| `validation:invalid-enum-label` | pending (R16 [#483](https://github.com/by-openclaw/go-acp/issues/483)) | `--value` is label not in `enumMap` | Ember+ Doc §p.86 |
-| `validation:out-of-range-low` | pending (R16 [#483](https://github.com/by-openclaw/go-acp/issues/483)) | value below Parameter `minimum` | Ember+ Doc §p.86 |
-| `validation:out-of-range-high` | pending (R16 [#483](https://github.com/by-openclaw/go-acp/issues/483)) | value above Parameter `maximum` | Ember+ Doc §p.86 |
-| `validation:step-misaligned` | pending (R16 [#483](https://github.com/by-openclaw/go-acp/issues/483)) | value not on Parameter `step` grid | Ember+ Doc §p.86 |
+| `validation:invalid-enum-label` | defined (R16 [#483](https://github.com/by-openclaw/go-acp/issues/483)) | `--value` is label not in `enumMap` | Ember+ Doc §p.86 |
+| `validation:out-of-range-low` | defined (R16 [#483](https://github.com/by-openclaw/go-acp/issues/483)) | value below Parameter `minimum` | Ember+ Doc §p.86 |
+| `validation:out-of-range-high` | defined (R16 [#483](https://github.com/by-openclaw/go-acp/issues/483)) | value above Parameter `maximum` | Ember+ Doc §p.86 |
+| `validation:step-misaligned` | defined (R16 [#483](https://github.com/by-openclaw/go-acp/issues/483)) | value not on Parameter `step` grid | Ember+ Doc §p.86 |
+| `validation:enum-not-supported` | defined (R16 [#483](https://github.com/by-openclaw/go-acp/issues/483)) | `--value` is a label but Parameter has no `enumMap` | Ember+ Doc §p.86 |
+| `validation:round-not-applicable` | defined (R16 [#483](https://github.com/by-openclaw/go-acp/issues/483)) | `--round` passed but target Parameter is non-numeric | dhs |
 | `validation:invalid-host` | defined (R1b) | host string empty on Dial | dhs |
 | `validation:invalid-port` | defined (R1b) | port outside [1, 65535] on Dial or [0, 65535] on Listen | dhs |
 | `validation:empty-payload` | defined (R1b) | Send called with a zero-length payload | dhs |

--- a/internal/consumer/errors.go
+++ b/internal/consumer/errors.go
@@ -55,6 +55,43 @@ var (
 	// owns its own supported set; the code is shared so scripts can
 	// dispatch on it uniformly.
 	ErrInvalidFormat = errcode.New(errcode.LayerValidation, "invalid-format", errcode.ClassUsage)
+
+	// ErrOutOfRangeLow is returned by SetValue when --value is
+	// numerically less than the Parameter's declared minimum (Ember+
+	// Contents [3]). Caught pre-send so the operator sees the limit
+	// instead of relying on the provider to either coerce or reject
+	// silently. Refs R16 #483.
+	ErrOutOfRangeLow = errcode.New(errcode.LayerValidation, "out-of-range-low", errcode.ClassUsage)
+
+	// ErrOutOfRangeHigh is returned by SetValue when --value exceeds
+	// the Parameter's declared maximum (Ember+ Contents [4]). Refs
+	// R16 #483.
+	ErrOutOfRangeHigh = errcode.New(errcode.LayerValidation, "out-of-range-high", errcode.ClassUsage)
+
+	// ErrStepMisaligned is returned by SetValue when --value is not
+	// an integer multiple of the Parameter's declared step (Ember+
+	// Contents [11]), measured from the minimum when present and 0
+	// otherwise. Strict by default; the CLI's --round flag rounds to
+	// the nearest legal step and continues. Refs R16 #483.
+	ErrStepMisaligned = errcode.New(errcode.LayerValidation, "step-misaligned", errcode.ClassUsage)
+
+	// ErrInvalidEnumLabel is returned by SetValue when --value is a
+	// string that does not appear in the Parameter's enumMap (the
+	// integer-keyed label table from Ember+ Contents [15]). Refs R16
+	// #483.
+	ErrInvalidEnumLabel = errcode.New(errcode.LayerValidation, "invalid-enum-label", errcode.ClassUsage)
+
+	// ErrEnumNotSupported is returned by SetValue when --value is a
+	// label-shaped string but the target Parameter is KindEnum
+	// without an enumMap (no integer-to-label table on the wire).
+	// The operator must address by integer index instead. Refs R16
+	// #483.
+	ErrEnumNotSupported = errcode.New(errcode.LayerValidation, "enum-not-supported", errcode.ClassUsage)
+
+	// ErrRoundNotApplicable is returned by SetValue when --round was
+	// passed but the target Parameter is non-numeric (string, enum,
+	// bool — nothing to snap to). Refs R16 #483.
+	ErrRoundNotApplicable = errcode.New(errcode.LayerValidation, "round-not-applicable", errcode.ClassUsage)
 )
 
 // DHSError is the root of all protocol-family errors. Both transport-layer

--- a/internal/consumer/types.go
+++ b/internal/consumer/types.go
@@ -365,6 +365,13 @@ type ValueRequest struct {
 	// means "the plugin's default property" — ACP2 reads pid=8 (value).
 	// Pass 1 to read object_type, 2 label, 3 access, etc. ACP2-specific.
 	PID int
+
+	// Round, when true on a SetValue call, snaps an off-step numeric
+	// --value to the nearest legal step instead of returning
+	// validation:step-misaligned. Ignored on non-numeric Parameters
+	// (which return validation:round-not-applicable when Round=true).
+	// Read paths ignore this field. Refs R16 #483.
+	Round bool
 }
 
 // Value is a decoded object value. Exactly one of the typed fields is set

--- a/internal/emberplus/consumer/plugin.go
+++ b/internal/emberplus/consumer/plugin.go
@@ -736,7 +736,18 @@ func (p *Plugin) SetValue(ctx context.Context, req consumer.ValueRequest, val co
 	if val.Kind == consumer.KindUnknown {
 		val.Kind = entry.obj.Kind
 	}
+	// R16 #483: resolve enum label → integer index BEFORE the type
+	// coerce so `--value "Low"` on `{Off=0, Low=1, ...}` works
+	// transparently. Numeric input passes through unchanged.
+	if err := resolveEnumLabelToIndex(&val, entry.glowParam); err != nil {
+		return consumer.Value{}, err
+	}
 	if err := coerceStringToTyped(&val); err != nil {
+		return consumer.Value{}, err
+	}
+	// R16 #483: range / step gate. Strict by default; --round snaps
+	// off-step numerics to the nearest legal grid point.
+	if err := applyParameterConstraints(&val, entry.glowParam, req); err != nil {
 		return consumer.Value{}, err
 	}
 

--- a/internal/emberplus/consumer/set_constraints.go
+++ b/internal/emberplus/consumer/set_constraints.go
@@ -1,0 +1,169 @@
+package emberplus
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+
+	"dhs/internal/consumer"
+	"dhs/internal/emberplus/codec/glow"
+)
+
+// resolveEnumLabelToIndex turns a label-shaped --value (`"Low"`) into the
+// integer index it represents in the Parameter's enumMap. Called before
+// coerceStringToTyped so the downstream parser sees a numeric string.
+//
+// Behavior:
+//   - val.Kind != KindEnum                          → no-op
+//   - val.Str empty / already numeric               → no-op
+//   - enumMap empty                                 → ErrEnumNotSupported
+//   - val.Str matches an enumMap label              → val.Str = "<int>"
+//   - val.Str does not match any label              → ErrInvalidEnumLabel
+//     (stderr lists valid labels alphabetised)
+//
+// Refs R16 #483.
+func resolveEnumLabelToIndex(val *consumer.Value, param *glow.Parameter) error {
+	if val.Kind != consumer.KindEnum {
+		return nil
+	}
+	if val.Str == "" {
+		return nil
+	}
+	if _, err := strconv.ParseUint(val.Str, 10, 64); err == nil {
+		// Numeric already; existing pipeline handles it.
+		return nil
+	}
+	if param == nil || len(param.EnumMap) == 0 {
+		return fmt.Errorf("%w: --value %q is a label but Parameter has no enumMap",
+			consumer.ErrEnumNotSupported, val.Str)
+	}
+	for idx, lbl := range param.EnumMap {
+		if lbl == val.Str {
+			val.Str = strconv.FormatInt(idx, 10)
+			return nil
+		}
+	}
+	labels := make([]string, 0, len(param.EnumMap))
+	for _, lbl := range param.EnumMap {
+		labels = append(labels, lbl)
+	}
+	sort.Strings(labels)
+	return fmt.Errorf("%w: --value %q not in enumMap (valid labels: %s)",
+		consumer.ErrInvalidEnumLabel, val.Str, strings.Join(labels, ", "))
+}
+
+// applyParameterConstraints checks a coerced typed Value against the
+// Parameter's declared minimum / maximum / step (Ember+ Contents [3]
+// [4] [11]). Numeric Parameters only — KindString / KindBool / KindEnum
+// flow straight through (enum range is implicit in the enumMap lookup;
+// out-of-range integer enums are a separate concern: provider-side).
+//
+// When req.Round is true and the value is off-step, the function snaps
+// to the nearest legal step in place and returns nil. When req.Round is
+// false, off-step returns ErrStepMisaligned.
+//
+// req.Round on a non-numeric Parameter returns ErrRoundNotApplicable.
+//
+// Refs R16 #483.
+func applyParameterConstraints(val *consumer.Value, param *glow.Parameter, req consumer.ValueRequest) error {
+	if param == nil {
+		return nil
+	}
+	switch val.Kind {
+	case consumer.KindInt, consumer.KindUint, consumer.KindFloat:
+		// Numeric — apply min / max / step below.
+	default:
+		if req.Round {
+			return fmt.Errorf("%w: --round is only meaningful for numeric Parameters (this one is %s)",
+				consumer.ErrRoundNotApplicable, val.Kind)
+		}
+		return nil
+	}
+
+	want := asFloat(val)
+	if min, ok := asNumber(param.Minimum); ok && want < min {
+		return fmt.Errorf("%w: --value %v below minimum %v",
+			consumer.ErrOutOfRangeLow, want, min)
+	}
+	if max, ok := asNumber(param.Maximum); ok && want > max {
+		return fmt.Errorf("%w: --value %v above maximum %v",
+			consumer.ErrOutOfRangeHigh, want, max)
+	}
+	step, hasStep := asNumber(param.Step)
+	if !hasStep || step <= 0 {
+		return nil
+	}
+	// Anchor the step grid at minimum when present (matches Lawo VSM
+	// + libember-cpp behavior); fall back to 0 otherwise.
+	anchor := 0.0
+	if min, ok := asNumber(param.Minimum); ok {
+		anchor = min
+	}
+	offset := want - anchor
+	steps := math.Round(offset / step)
+	snapped := anchor + steps*step
+	if math.Abs(snapped-want) < step*1e-9 {
+		// Already on-grid (within float epsilon).
+		return nil
+	}
+	if !req.Round {
+		return fmt.Errorf("%w: --value %v not aligned to step %v (nearest legal value: %v). Pass --round to snap",
+			consumer.ErrStepMisaligned, want, step, snapped)
+	}
+	writeFloat(val, snapped)
+	return nil
+}
+
+// asNumber returns the float64 view of a Parameter.{Minimum,Maximum,
+// Step} field. The Glow decoder leaves these as `any` (int64 or
+// float64); both are flattened to float64 for comparison. nil / other
+// types → not present.
+func asNumber(v any) (float64, bool) {
+	switch x := v.(type) {
+	case nil:
+		return 0, false
+	case int64:
+		return float64(x), true
+	case int32:
+		return float64(x), true
+	case int:
+		return float64(x), true
+	case float64:
+		return x, true
+	case float32:
+		return float64(x), true
+	}
+	return 0, false
+}
+
+// asFloat returns the Value's numeric body as float64. Caller is
+// responsible for confirming Kind is numeric.
+func asFloat(val *consumer.Value) float64 {
+	switch val.Kind {
+	case consumer.KindInt:
+		return float64(val.Int)
+	case consumer.KindUint:
+		return float64(val.Uint)
+	case consumer.KindFloat:
+		return val.Float
+	}
+	return 0
+}
+
+// writeFloat back-projects a snapped float64 into the right typed body
+// for the Value's Kind. Used by --round to commit the snap result.
+func writeFloat(val *consumer.Value, f float64) {
+	switch val.Kind {
+	case consumer.KindInt:
+		val.Int = int64(math.Round(f))
+	case consumer.KindUint:
+		if f < 0 {
+			f = 0
+		}
+		val.Uint = uint64(math.Round(f))
+	case consumer.KindFloat:
+		val.Float = f
+	}
+}

--- a/internal/emberplus/consumer/set_constraints_test.go
+++ b/internal/emberplus/consumer/set_constraints_test.go
@@ -1,0 +1,179 @@
+package emberplus
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"dhs/internal/consumer"
+	"dhs/internal/emberplus/codec/glow"
+)
+
+// TestResolveEnumLabel_HappyPath pins the R16 #483 acceptance: a
+// label-shaped --value resolves to the integer index via the
+// Parameter's enumMap (Ember+ Contents [15]).
+func TestResolveEnumLabel_HappyPath(t *testing.T) {
+	param := &glow.Parameter{
+		EnumMap: map[int64]string{0: "Off", 1: "Low", 2: "Medium", 3: "High"},
+	}
+	val := &consumer.Value{Kind: consumer.KindEnum, Str: "Low"}
+	if err := resolveEnumLabelToIndex(val, param); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if val.Str != "1" {
+		t.Errorf("Str: got %q, want %q", val.Str, "1")
+	}
+}
+
+// TestResolveEnumLabel_NumericPassthrough confirms a numeric string
+// stays untouched — coerceStringToTyped handles the actual parse.
+func TestResolveEnumLabel_NumericPassthrough(t *testing.T) {
+	param := &glow.Parameter{
+		EnumMap: map[int64]string{0: "Off", 1: "Low"},
+	}
+	val := &consumer.Value{Kind: consumer.KindEnum, Str: "1"}
+	if err := resolveEnumLabelToIndex(val, param); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if val.Str != "1" {
+		t.Errorf("numeric Str mutated: got %q, want %q", val.Str, "1")
+	}
+}
+
+// TestResolveEnumLabel_NotInMap pins ErrInvalidEnumLabel: a label not
+// present in enumMap fires the typed error and the stderr lists the
+// valid labels alphabetised so the operator can pick.
+func TestResolveEnumLabel_NotInMap(t *testing.T) {
+	param := &glow.Parameter{
+		EnumMap: map[int64]string{0: "Off", 1: "Low", 2: "High"},
+	}
+	val := &consumer.Value{Kind: consumer.KindEnum, Str: "Bogus"}
+	err := resolveEnumLabelToIndex(val, param)
+	if err == nil {
+		t.Fatal("expected ErrInvalidEnumLabel, got nil")
+	}
+	if !errors.Is(err, consumer.ErrInvalidEnumLabel) {
+		t.Errorf("got %v, want ErrInvalidEnumLabel", err)
+	}
+	if !strings.Contains(err.Error(), "High") || !strings.Contains(err.Error(), "Low") || !strings.Contains(err.Error(), "Off") {
+		t.Errorf("error message must list valid labels: %v", err)
+	}
+}
+
+// TestResolveEnumLabel_NoEnumMap fires ErrEnumNotSupported when the
+// Parameter is KindEnum but the wire never carried an enumMap.
+func TestResolveEnumLabel_NoEnumMap(t *testing.T) {
+	param := &glow.Parameter{}
+	val := &consumer.Value{Kind: consumer.KindEnum, Str: "Low"}
+	err := resolveEnumLabelToIndex(val, param)
+	if !errors.Is(err, consumer.ErrEnumNotSupported) {
+		t.Errorf("got %v, want ErrEnumNotSupported", err)
+	}
+}
+
+// TestResolveEnumLabel_NonEnumKind: non-enum kinds short-circuit.
+func TestResolveEnumLabel_NonEnumKind(t *testing.T) {
+	param := &glow.Parameter{}
+	val := &consumer.Value{Kind: consumer.KindString, Str: "hello"}
+	if err := resolveEnumLabelToIndex(val, param); err != nil {
+		t.Errorf("non-enum kind must short-circuit: %v", err)
+	}
+}
+
+// TestConstraints_RangeLow pins ErrOutOfRangeLow.
+func TestConstraints_RangeLow(t *testing.T) {
+	param := &glow.Parameter{Minimum: int64(-100), Maximum: int64(100)}
+	val := &consumer.Value{Kind: consumer.KindInt, Int: -150}
+	err := applyParameterConstraints(val, param, consumer.ValueRequest{})
+	if !errors.Is(err, consumer.ErrOutOfRangeLow) {
+		t.Errorf("got %v, want ErrOutOfRangeLow", err)
+	}
+}
+
+// TestConstraints_RangeHigh pins ErrOutOfRangeHigh.
+func TestConstraints_RangeHigh(t *testing.T) {
+	param := &glow.Parameter{Minimum: int64(-100), Maximum: int64(100)}
+	val := &consumer.Value{Kind: consumer.KindInt, Int: 250}
+	err := applyParameterConstraints(val, param, consumer.ValueRequest{})
+	if !errors.Is(err, consumer.ErrOutOfRangeHigh) {
+		t.Errorf("got %v, want ErrOutOfRangeHigh", err)
+	}
+}
+
+// TestConstraints_InRange happy path — value within [min, max] and on
+// the step grid passes unchanged.
+func TestConstraints_InRange(t *testing.T) {
+	param := &glow.Parameter{Minimum: int64(-100), Maximum: int64(100), Step: int64(5)}
+	val := &consumer.Value{Kind: consumer.KindInt, Int: 25}
+	if err := applyParameterConstraints(val, param, consumer.ValueRequest{}); err != nil {
+		t.Errorf("in-range on-step: %v", err)
+	}
+	if val.Int != 25 {
+		t.Errorf("value mutated: %d", val.Int)
+	}
+}
+
+// TestConstraints_StepMisaligned pins strict-mode rejection: off-step
+// without --round fires ErrStepMisaligned and the error message names
+// the nearest legal value so the operator can correct.
+func TestConstraints_StepMisaligned(t *testing.T) {
+	param := &glow.Parameter{Minimum: float64(0), Maximum: float64(10), Step: float64(0.5)}
+	val := &consumer.Value{Kind: consumer.KindFloat, Float: 1.3}
+	err := applyParameterConstraints(val, param, consumer.ValueRequest{})
+	if !errors.Is(err, consumer.ErrStepMisaligned) {
+		t.Fatalf("got %v, want ErrStepMisaligned", err)
+	}
+	if !strings.Contains(err.Error(), "1.5") {
+		t.Errorf("error must include nearest legal value (1.5): %v", err)
+	}
+}
+
+// TestConstraints_StepSnap pins --round behavior: off-step value snaps
+// in place to the nearest legal grid point.
+func TestConstraints_StepSnap(t *testing.T) {
+	param := &glow.Parameter{Minimum: float64(0), Maximum: float64(10), Step: float64(0.5)}
+	val := &consumer.Value{Kind: consumer.KindFloat, Float: 1.3}
+	err := applyParameterConstraints(val, param, consumer.ValueRequest{Round: true})
+	if err != nil {
+		t.Fatalf("--round: unexpected error %v", err)
+	}
+	if val.Float != 1.5 {
+		t.Errorf("snap: got %v, want 1.5", val.Float)
+	}
+}
+
+// TestConstraints_RoundNotApplicable pins ErrRoundNotApplicable: passing
+// --round on a non-numeric Parameter is a user error.
+func TestConstraints_RoundNotApplicable(t *testing.T) {
+	param := &glow.Parameter{}
+	val := &consumer.Value{Kind: consumer.KindString, Str: "hello"}
+	err := applyParameterConstraints(val, param, consumer.ValueRequest{Round: true})
+	if !errors.Is(err, consumer.ErrRoundNotApplicable) {
+		t.Errorf("got %v, want ErrRoundNotApplicable", err)
+	}
+}
+
+// TestConstraints_NoMinMaxNoStep — Parameter without any constraint
+// fields applied: every numeric value passes through unchanged.
+func TestConstraints_NoConstraints(t *testing.T) {
+	param := &glow.Parameter{}
+	val := &consumer.Value{Kind: consumer.KindInt, Int: 9999}
+	if err := applyParameterConstraints(val, param, consumer.ValueRequest{}); err != nil {
+		t.Errorf("unconstrained value: %v", err)
+	}
+}
+
+// TestConstraints_StepAnchorAtMinimum — step grid anchors at the
+// minimum (matches libember-cpp + Lawo VSM convention). With min=2
+// step=3, legal values are 2, 5, 8, 11... 4 snaps to 5; 7 snaps to 8.
+func TestConstraints_StepAnchorAtMinimum(t *testing.T) {
+	param := &glow.Parameter{Minimum: int64(2), Maximum: int64(20), Step: int64(3)}
+	val := &consumer.Value{Kind: consumer.KindInt, Int: 4}
+	err := applyParameterConstraints(val, param, consumer.ValueRequest{Round: true})
+	if err != nil {
+		t.Fatalf("snap: %v", err)
+	}
+	if val.Int != 5 {
+		t.Errorf("anchored snap: got %d, want 5 (min=2 step=3 → grid 2,5,8,...)", val.Int)
+	}
+}

--- a/internal/emberplus/docs/runbook.md
+++ b/internal/emberplus/docs/runbook.md
@@ -302,7 +302,14 @@ Expected: ≈548 lines of tree dump, `tree_size ≈ 1361` objects. Two files wri
 # confirmed value = 3
 ```
 
-> Out-of-range / step-mismatch / enum-by-label semantics pending **R16** (not yet filed).
+> Out-of-range / step-mismatch / enum-by-label semantics are live as of **R16 [#483](https://github.com/by-openclaw/go-acp/issues/483)**:
+>
+> - Numeric `--value` below/above the Parameter's declared `minimum`/`maximum` (Ember+ Contents [3]/[4]) → `validation:out-of-range-low` / `validation:out-of-range-high` (exit `2`).
+> - Numeric `--value` not aligned to the declared `step` (Contents [11]) → `validation:step-misaligned` (exit `2`); the message names the nearest legal grid point. Pass `--round` to snap and continue.
+> - Enum `--value` as a **label** (e.g. `--value Low` on `{Off=0, Low=1, Medium=2, High=3}`) → resolved via the Parameter's enumMap to the integer index, then sent on the wire.
+> - Enum label not present in enumMap → `validation:invalid-enum-label` (exit `2`); stderr lists valid labels alphabetised.
+> - Enum label on a Parameter that ships **no** enumMap → `validation:enum-not-supported` (exit `2`) — address by integer index.
+> - `--round` on a non-numeric Parameter (string / enum / bool) → `validation:round-not-applicable` (exit `2`).
 
 ### Errors (post #453 + post R16 [#483](https://github.com/by-openclaw/go-acp/issues/483))
 
@@ -694,7 +701,7 @@ Current state on `main`. ✅ working, 🟡 partial, ❌ not implemented.
 | UC-1 | `info` — device summary | ✅ | ✅ | Online correct post #459 |
 | UC-2 | `walk` — full enumeration | ✅ | ✅ | tree_size ≈ 1361; DM auto-extracted to `.cache/dm/emberplus/<identity>@<rev>.json` |
 | UC-3 | `get` — single Parameter | ✅ | ✅ | every ParameterType + stream id=0 + id>0 + identity.dtdVersion |
-| UC-4 | `set` — single Parameter | ✅ | ✅ | typed-validation errors post #453; out-of-range / range-step rounding pending **R16** |
+| UC-4 | `set` — single Parameter | ✅ | ✅ | typed-validation errors post #453; range / step / enum-by-label live post R16 [#483](https://github.com/by-openclaw/go-acp/issues/483) (with `--round` snap) |
 | UC-5 | `watch` — live updates | ✅ | ✅ | streams + matrix tally + param announces |
 | UC-6 | `matrix` — Connect / Disconnect / Absolute | ✅ | ✅ | oneToOne source-steal accepted post #467 (fires `onetoone_source_steal_accepted`); oneToN over-cardinality + nToN capacity rejected client-side; lock honored |
 | UC-7 | `invoke` — function RPC | ✅ | ✅ | bogus matrixRef now errors post #457; dotted matrixRef resolves under synthetic root post #466 |


### PR DESCRIPTION
## Summary

**R16 — `set --value` range / step / enum-by-label client-side validation (refs [#483](https://github.com/by-openclaw/go-acp/issues/483)).**

Pre-send guard on `Plugin.SetValue` so the provider never silently coerces an out-of-range numeric, rounds an off-step value, or rejects an enum-by-label because the consumer never sent the integer index. Operator sees the rule that bit them, with the exact numbers, before any wire frame leaves the box.

## Behavior table

| Case | Today | After R16 |
|---|---|---|
| Out of range (low) | request sent; provider may coerce silently | client rejects with `validation:out-of-range-low` (exit `2`); message names min + value |
| Out of range (high) | same | `validation:out-of-range-high` (exit `2`) |
| Step misaligned | sent as-is; provider may round | `validation:step-misaligned` (exit `2`); message names nearest legal grid point. Pass `--round` to snap and continue |
| Enum by label (`--value Low`) | `validation:invalid-enum-index` (exit `2`) | accepted; resolved via `enumMap` → integer index, sent |
| Enum by label not in `enumMap` | n/a | `validation:invalid-enum-label` (exit `2`); stderr lists valid labels alphabetised |
| Enum by label on Parameter with no `enumMap` | n/a | `validation:enum-not-supported` (exit `2`) — address by integer index |
| `--round` on non-numeric Parameter | n/a | `validation:round-not-applicable` (exit `2`) |
| Enum by integer (today's form) | accepted | unchanged — byte-compatible |

## CLI examples

```powershell
.\bin\dhs.exe consumer emberplus set ... --path types.vReal --value 1.3
# validation:step-misaligned: --value 1.3 not aligned to step 0.5 (nearest legal value: 1.5). Pass --round to snap.
# exit: 2

.\bin\dhs.exe consumer emberplus set ... --path types.vReal --value 1.3 --round
# confirmed value = 1.5
# exit: 0

.\bin\dhs.exe consumer emberplus set ... --path types.vEnum --value Low
# confirmed value = Low (integer 1)
# exit: 0

.\bin\dhs.exe consumer emberplus set ... --path types.vEnum --value Bogus
# validation:invalid-enum-label: --value "Bogus" not in enumMap (valid labels: High, Low, Medium, Off)
# exit: 2
```

## New sentinels

[`internal/consumer/errors.go`](https://github.com/by-openclaw/go-acp/blob/feat/set-range-step-enumlabel-483/internal/consumer/errors.go):

| Sentinel | Wire code | Class |
|---|---|---|
| `ErrOutOfRangeLow` | `validation:out-of-range-low` | 2 |
| `ErrOutOfRangeHigh` | `validation:out-of-range-high` | 2 |
| `ErrStepMisaligned` | `validation:step-misaligned` | 2 |
| `ErrInvalidEnumLabel` | `validation:invalid-enum-label` | 2 |
| `ErrEnumNotSupported` | `validation:enum-not-supported` | 2 |
| `ErrRoundNotApplicable` | `validation:round-not-applicable` | 2 |

## ValueRequest extension

```go
type ValueRequest struct {
    ...
    Round bool   // set-only; off-step numeric snap-to-grid
}
```

CLI exposes via the new `set --round` flag.

## Files

| File | Change |
|---|---|
| [`internal/consumer/errors.go`](https://github.com/by-openclaw/go-acp/blob/feat/set-range-step-enumlabel-483/internal/consumer/errors.go) | 6 new sentinels |
| [`internal/consumer/types.go`](https://github.com/by-openclaw/go-acp/blob/feat/set-range-step-enumlabel-483/internal/consumer/types.go) | `ValueRequest.Round bool` field |
| [`internal/emberplus/consumer/set_constraints.go`](https://github.com/by-openclaw/go-acp/blob/feat/set-range-step-enumlabel-483/internal/emberplus/consumer/set_constraints.go) (new) | `resolveEnumLabelToIndex` + `applyParameterConstraints` |
| [`internal/emberplus/consumer/set_constraints_test.go`](https://github.com/by-openclaw/go-acp/blob/feat/set-range-step-enumlabel-483/internal/emberplus/consumer/set_constraints_test.go) (new) | 13 cases — enum labels (5) + range (3) + step (3) + guard (2) |
| [`internal/emberplus/consumer/plugin.go`](https://github.com/by-openclaw/go-acp/blob/feat/set-range-step-enumlabel-483/internal/emberplus/consumer/plugin.go) | SetValue wires both helpers (enum resolve → coerce → constraints) |
| [`cmd/dhs/cmd_set.go`](https://github.com/by-openclaw/go-acp/blob/feat/set-range-step-enumlabel-483/cmd/dhs/cmd_set.go) | `--round` flag, threaded into `ValueRequest.Round` |
| [`cmd/dhs/exitcode_test.go`](https://github.com/by-openclaw/go-acp/blob/feat/set-range-step-enumlabel-483/cmd/dhs/exitcode_test.go) | R1h sweep gains all 6 R16 sentinels |
| [`internal/emberplus/docs/runbook.md`](https://github.com/by-openclaw/go-acp/blob/feat/set-range-step-enumlabel-483/internal/emberplus/docs/runbook.md) | `set` section callout rewritten · UC-4 row flipped to live |
| [`docs/protocols/error-codes.md`](https://github.com/by-openclaw/go-acp/blob/feat/set-range-step-enumlabel-483/docs/protocols/error-codes.md) | 3 codes flipped `pending` → `defined` · 2 new codes added |

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/emberplus/consumer -run "Constraints|EnumLabel" -v -count=1` — 13 cases pass
- [x] `go test ./cmd/dhs -run "ExitCode" -v -count=1` — 35 + 39 sweep cases pass (all 6 R16 sentinels mapped to exit 2)
- [x] `go test ./... -count=1` — full suite green
- [x] `golangci-lint` clean (pre-commit hook passed)
- [x] Wire shape unchanged — value sent on the wire is always the integer index / typed number (consumer-side guard only, byte-compatible with prior callers using integer enum input)
- [ ] **Codeowner live verify** on the integration-test producer (`glow-types-strict@1.0.0` DM):
  - `set --path types.vInteger --value -150` → `validation:out-of-range-low`
  - `set --path types.vInteger --value 150` → `validation:out-of-range-high`
  - `set --path types.vReal --value 1.3` → `validation:step-misaligned`
  - `set --path types.vReal --value 1.3 --round` → confirmed 1.5, exit 0
  - `set --path types.vEnum --value Low` → confirmed 1, exit 0
  - `set --path types.vEnum --value Bogus` → `validation:invalid-enum-label`
  - `set --path types.vString --value hello --round` → `validation:round-not-applicable`

## Refs

Refs #483
Refs #468 (uses R1 typed error code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
