### PR TITLE
docs: canonise memory rules into ADRs + CLAUDE.md per ADR-0015

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ ADR wins.
 Foundational ADRs every agent reads first:
 
 | ADR | Topic |
-|---|---|
+| --- | --- |
 | [0001](docs/adr/0001-per-connector-binary-and-repo.md) | per-connector binary + own repo |
 | [0002](docs/adr/0002-canonical-cli-verbs-flags.md) | canonical CLI verbs + flags |
 | [0005](docs/adr/0005-dep-policy.md) | external dependency policy + manifest |
@@ -29,6 +29,16 @@ Foundational ADRs every agent reads first:
 | [0022](docs/adr/0022-card-data-model.md) | card data model — Device/Frame/Slot/Card/DM + manifest |
 | [0023](docs/adr/0023-matrix-entity.md) | matrix entity — matrix_id/level_id/size/behavior |
 | [0024](docs/adr/0024-federation-mirror-and-virtual-frame.md) | federation: mirror frame vs virtual frame |
+| [0025](docs/adr/0025-per-connector-definition-of-done.md) | per-connector definition of done (6 deliverables) |
+| [0026](docs/adr/0026-agent-communication-style.md) | agent communication style (brevity, progress markers, no menus) |
+| [0027](docs/adr/0027-workflow-contract-dod-windows.md) | workflow contract during DOD windows (PR timing override for ADR-0014) |
+
+Operational reference docs (not ADRs but binding repo-tracked sources):
+
+| Doc | Purpose |
+| --- | --- |
+| [`docs/user.md`](docs/user.md) | operator + agent role mapping, host preference |
+| [`docs/testbed.md`](docs/testbed.md) | DMZ VLAN fleet inventory + SSH access mesh |
 
 ---
 
@@ -176,8 +186,6 @@ Consequences:
 - Provider trees use `map[(matrix, level, dst)] → src`, not `[matrix][level][]src`.
 - Benchmarks include a worst-case 65535² tally-dump decode per protocol.
 
-See [project_scale_requirements] in memory.
-
 ---
 
 ## Performance + metrics (every protocol)
@@ -193,9 +201,6 @@ Producer surface: `dhs producer <proto> serve --metrics-addr :9100`
 serves `/metrics` (Prometheus + OpenMetrics) and `/snapshot.json`. CLI
 view: `dhs metrics show`. Full Grafana / Prometheus / Loki stack under
 `docs/deployment/grafana/`.
-
-See [`project_connector_metrics_v2`](.) and
-[`feedback_transport_metrics`](.) in memory for the full contract.
 
 ---
 
@@ -219,8 +224,6 @@ explicit sign-off.
 5. **No hidden state.** No package-level mutable vars outside the
    compile-time registries; cross-cutting concerns thread through
    constructors or `context.Context`.
-
-See [feedback_architecture_principles] in memory.
 
 ---
 
@@ -285,8 +288,6 @@ Install path (manual, one-time per dev machine):
 Install + filter guide in [docs/wireshark.md](docs/wireshark.md). A
 `make install-dissectors` target that copies every
 `internal/*/wireshark/*.lua` into the right place is on the backlog.
-
-See [feedback_wireshark_fully_implemented] in memory.
 
 ---
 
@@ -392,11 +393,7 @@ the salvo path. Neither Commie nor Lawo VSM implement that listener path;
 both update tally exclusively from §3.2.3 cmd 04 broadcasts. Our provider
 emits N × cmd 04 on salvo Set (§3.2.3 literal) and fires
 `probel_salvo_emitted_connected` per slot. Documented in
-`internal/probel-sw08p/CLAUDE.md` "Known deviations from spec" + memory
-entry `feedback_probel_salvo_connected`.
-
-See [feedback_no_workaround, feedback_spec_table_literal,
-feedback_probel_salvo_connected] in memory.
+`internal/probel-sw08p/CLAUDE.md` "Known deviations from spec".
 
 **AMWA NMOS — strict every published version.** For the AMWA NMOS suite
 specifically, no minor AMWA has published is ever "deferred", "out of
@@ -406,7 +403,6 @@ minor in that table is unimplemented today, it is *missing* and gets
 implemented, never reframed as a stable product decision. The only
 legitimate "land when stable" is for AMWA-WIP specs (IS-13, BCP-006-02,
 BCP-006-03, BCP-007-01) which carry no published stable release yet.
-See `feedback_amwa_strict_all_versions` in memory.
 
 ---
 

--- a/docs/adr/0026-agent-communication-style.md
+++ b/docs/adr/0026-agent-communication-style.md
@@ -1,0 +1,101 @@
+# ADR-0026 — Agent communication style
+
+Status: proposed
+
+This ADR is a living document (per ADR-0025 precedent). Add new facts in
+the Revisions trailer.
+
+## Context
+
+The operator has spent extended sessions (12 + hours, multiple times)
+re-stating the same communication preferences mid-flight: terse output,
+no A/B/C option menus, no walls of text, progress markers per substep,
+tables for facts not options. These preferences sat in agent memory
+(`feedback_response_brevity`, `feedback_progress_markers`,
+`feedback_style`) but memory is per-agent-runtime and not visible to a
+reviewer or to a fresh session, so the preferences kept getting violated
+and re-reinforced.
+
+Per ADR-0015 (single source of truth) any rule that constrains how the
+agent behaves on this project belongs in a tracked doc, not in memory.
+
+## Decision
+
+The agent's communication with the operator follows the rules below.
+Violations are correctable like any other ADR violation — they don't
+require chat-level reinforcement.
+
+### Brevity
+
+- One recommendation per turn. No option menus. No A/B/C tables of
+  alternatives.
+- End-of-turn summary in one or two sentences. What changed, what's
+  next.
+- Do not narrate internal deliberation. State results and decisions
+  directly.
+- Match response length to the task. A simple question gets a direct
+  answer, not headers and sections.
+
+### Tables
+
+Use tables only for facts (comparisons, mappings, structured data).
+Never for option lists the operator must choose from. For options,
+state the recommendation in prose and offer redirection.
+
+### Progress markers
+
+For non-trivial multi-step work, emit a short "Step Xy — title" marker
+at the start of each substep. Marker is one line. No paragraph between
+markers and the next tool call.
+
+### Code in responses
+
+Default to writing no inline code blocks in chat unless the operator
+asked to see code. Reference files via `[filename](path)` markdown
+links — let the operator open them in the editor instead of pasting.
+
+### Code comments in committed code
+
+Default to no comments. Add one short line only when the WHY is
+non-obvious (hidden constraint, subtle invariant, workaround for a
+specific bug). Never write multi-paragraph docstrings or multi-line
+comment blocks. Never reference the current task, fix, or callers in a
+comment ("used by X", "added for the Y flow"). Those belong in the PR
+description.
+
+### Confirmation discipline
+
+Only ask for confirmation at actual branch points — places where the
+operator's redirection materially changes the work. "Go", "approuved",
+"ok" all count as explicit approval. Ambiguous responses do not.
+
+### What NOT to do
+
+- No "want me to do X next?" follow-ups when the next step is obvious.
+- No option tables for "should I do A or B?" when the operator has
+  already stated direction.
+- No retrospective summaries of what just happened — the operator can
+  read the diff.
+- No filler ("Let me…", "I'll now…") before tool calls.
+- No emojis unless explicitly requested.
+
+## Consequences
+
+- Reviewers see consistent terse output across sessions without having
+  to re-reinforce in chat.
+- Fresh agent sessions read this ADR on startup via the canonical doc
+  surface (CLAUDE.md links here).
+- The legacy memory entries (`feedback_response_brevity`,
+  `feedback_progress_markers`, `feedback_style`) are deleted when this
+  ADR is accepted.
+
+## Forbidden
+
+- Multi-paragraph "let me explain…" before tool calls.
+- A/B/C option tables presented to the operator as decisions to make.
+- Mid-flight re-reinforcement chains ("reinforcement 2026-XX-YY") in
+  any tracked artifact, this ADR included. New facts go to Revisions.
+
+## Revisions
+
+- 2026-05-18 — initial proposal.

--- a/docs/adr/0027-workflow-contract-dod-windows.md
+++ b/docs/adr/0027-workflow-contract-dod-windows.md
@@ -1,0 +1,133 @@
+# ADR-0027 — Workflow contract during DOD windows
+
+Status: proposed
+
+This ADR is a living document. Add new facts in the Revisions trailer.
+
+## Context
+
+ADR-0014 (issue tracking discipline) defines the canonical workflow
+chain: issue → branch → tests → PR → CI green → `@yboujraf` codeowner
+approval → merge. That chain works well for steady-state contributions
+where one issue resolves in days.
+
+It fails during **DOD windows** — multi-week pushes to drive one
+connector to the six-deliverable Definition of Done in ADR-0025. The
+failure mode is concrete: opening a PR per atomic commit during a DOD
+window produces a stream of half-shipped, partly-tested PRs the
+operator has to triage individually, none of which clears the
+ADR-0025 gate alone. The 12-hour Ember+ session of 2026-05-17 ended
+with multiple open PRs against `main`, none of which advanced the
+overall connector beyond `partial` on ADR-0025's six deliverables.
+
+The fix is not to suspend ADR-0014 — it is to bind a tighter contract
+that overrides only the timing of the PR-opening step, leaving every
+other clause (codeowner approval, CI green, conventional commits) in
+place.
+
+## Decision
+
+When a connector is in a DOD window — meaning at least one of the six
+ADR-0025 deliverables is `missing` or `partial` — the rules below
+override the matching steps of ADR-0014. Steps not mentioned here
+remain exactly as ADR-0014 specifies.
+
+### Autonomous without per-step approval
+
+- Branch creation off `main`
+- Local edits, builds, unit tests
+- Atomic commit per tracked issue, conventional-commit subject
+- Push branch to `origin` for visibility
+- Reading code, running probes, running integration tests on the
+  testbed
+
+### Explicit operator approval required (`"go" / "approuved" / "ok"`)
+
+- `gh pr create` — opening any PR on GitHub
+- `gh pr merge` — merging any PR
+- Closing any tracked issue
+- Changing the scope of an issue
+- Any operation that touches shared infrastructure beyond the
+  feature branch
+
+### One commit per tracked issue
+
+ADR-0013 already requires "one approved unit = one commit." During a
+DOD window this is tightened: each atomic commit closes the scope of
+**one** tracked issue. Bundling two issues into one commit is
+forbidden — the bundle blurs which acceptance criteria applied.
+
+### Status reports are DOD-based
+
+The status of a DOD window is reported against the six ADR-0025
+deliverables, with evidence. Green unit tests are not progress. A
+commit landing on the feature branch is progress only when it
+advances a specific deliverable on a specific connector.
+
+Report format: one line per atomic commit landing.
+
+> feat(emberplus/provider): stream idle-TTL eviction — commit
+> `abc1234` — R9 #472 done locally on `feat/emberplus-stream-idle-ttl-472`
+
+No tables of alternatives. No "want me to do X next?" follow-ups.
+
+### No PR until DOD complete
+
+No `gh pr create` against `main` while a DOD deliverable on the
+target connector remains `missing` or `partial`. Atomic commits
+accumulate on the feature branches; the operator can pull / inspect
+at any time. A single connector-wide PR opens at the end of the DOD
+window per `feedback_pr_per_protocol`.
+
+Override: explicit operator instruction in chat — e.g. "open the PR
+for R9 right now" — opens the PR for that one item only.
+
+### No release-engine clutter on `main`
+
+The `.audit/` folder, `*-draft.md`, `*-wip.go`, and any other local
+scratch never lands on `main`. release-please reads conventional-commit
+subjects from `main` to bump the changelog; non-conventional clutter
+breaks the version cadence.
+
+### No option-table proposals during DOD
+
+When direction is clear (DOD-blocker work), the agent picks the next
+gap and executes. No "which gap first?" option tables. Selection
+criterion: clearest scope + smallest effort.
+
+## How to apply
+
+1. **Identify the DOD window.** A DOD window starts when an operator
+   names a target connector and ADR-0025 shows ≥ 1 `partial` / `missing`
+   deliverable. It ends when all six deliverables are `done` and the
+   connector PR merges.
+2. **Treat ADR-0014 as the parent contract** — every clause not
+   overridden here still binds.
+3. **For non-DOD work** (doc hygiene, infra fixes, separate-connector
+   bug fixes) ADR-0014 applies unchanged.
+4. **Operator override always wins.** Explicit chat instruction
+   ("open the PR for X now") supersedes any rule in this ADR.
+
+## Consequences
+
+- The PR triage queue during a DOD window stays small (zero) until the
+  window closes.
+- Operator time is spent on integration-test sign-off and scope
+  decisions, not on per-PR review.
+- The atomic-commit history on the feature branch is the audit trail
+  for what landed when, and remains available for `git log` review
+  before the consolidated PR opens.
+
+## Forbidden
+
+- Opening a PR for an atomic DOD commit without operator approval.
+- Bundling two issues into one commit.
+- Reporting "green tests" as progress instead of ADR-0025 deliverables.
+- Committing `.audit/` or draft files to `main`.
+- Proposing option tables to the operator during a DOD window.
+
+## Revisions
+
+- 2026-05-18 — initial proposal, derived from the
+  `memory/feedback_workflow_contract` entry produced by the
+  2026-05-17 Ember+ session.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,7 +20,7 @@ how connectors are built lives here.
 ## Status flow
 
 | Status | Meaning |
-|---|---|
+| --- | --- |
 | `proposed` | under discussion |
 | `accepted` | binding, permanent |
 
@@ -29,7 +29,7 @@ There is no `superseded` / `deprecated` / `rejected-after-acceptance`.
 ## Index
 
 | ID | Title | Status |
-|---|---|---|
+| --- | --- | --- |
 | [0001](0001-per-connector-binary-and-repo.md) | Per-connector binary and own repo | accepted |
 | [0002](0002-canonical-cli-verbs-flags.md) | Canonical CLI verbs and flags per role | accepted |
 | [0003](0003-license-jwt-eddsa-vault-transit.md) | License JWT-EdDSA signed by Vault Transit | accepted |
@@ -54,7 +54,9 @@ There is no `superseded` / `deprecated` / `rejected-after-acceptance`.
 | [0022](0022-card-data-model.md) | Card data model — Device/Frame/Slot/Card/DM | accepted |
 | [0023](0023-matrix-entity.md) | Matrix entity — matrix_id/level_id/size/behavior | accepted |
 | [0024](0024-federation-mirror-and-virtual-frame.md) | Federation — mirror frame vs virtual frame | accepted |
-| [0025](0025-per-connector-definition-of-done.md) | Per-connector definition of done (5 deliverables) | proposed |
+| [0025](0025-per-connector-definition-of-done.md) | Per-connector definition of done (six deliverables) | accepted |
+| [0026](0026-agent-communication-style.md) | Agent communication style | proposed |
+| [0027](0027-workflow-contract-dod-windows.md) | Workflow contract during DOD windows | proposed |
 
 ## ADR-0017 parking note
 

--- a/docs/testbed.md
+++ b/docs/testbed.md
@@ -1,0 +1,140 @@
+# docs/testbed.md — Test fleet inventory and SSH access mesh
+
+Tracked, repo-local source of truth for the test fleet on the DMZ VLAN
+(`10.100.0.0/24`, routed via pfSense). Replaces the legacy
+`memory/project_lxc_test_rig`, `memory/project_test_device`, and
+`memory/reference_lxc_ssh_access` entries.
+
+## Fleet
+
+| Hostname | IP | Role | OS | Notes |
+| --- | --- | --- | --- | --- |
+| `dhs-debian` | `10.100.0.102` | dhs producer host | Debian 12 | OS-compat row, all four producers concurrently |
+| `dhs-ubuntu` | `10.100.0.103` | dhs producer host + Ansible controller | Ubuntu 24.04 | Current ACP2 reconnect/keepalive test target |
+| `dhs-rocky` | `10.100.0.104` | dhs producer host | Rocky 9.4 | OS-compat row |
+| `dhs-tools` | `10.100.0.105` | tooling host | Ubuntu 24.04 | Docker, AMWA NMOS Testing tool, tshark, Wireshark dissector validator |
+| `dhs-win11` | `10.100.0.106` | Windows producer host | Windows 11 Pro | Multi-OS matrix per ADR-0016; producer parity check for the Windows row |
+| `cerebrum` | `10.100.0.5` | external reference peer | (vendor appliance) | NMOS Registry + Node — not part of the test fleet, used as a real-peer integration target |
+
+The three `dhs-*` Linux producer hosts validate the OS-compat axis from
+ADR-0016 without requiring vendor hardware. `dhs-tools` hosts the AMWA
+Testing tool peer + isolated Docker bridge. `dhs-win11` covers the
+Windows producer parity row required by ADR-0016.
+
+## Producer port plan (every Linux LXC + dhs-win11)
+
+| Connector | Wire | Port |
+| --- | --- | --- |
+| ACP1 | UDP + TCP | `2071` |
+| ACP2 | TCP (AN2) | `2072` |
+| Ember+ | TCP (S101) | `9000` |
+| Probel SW-P-08 | TCP (DLE) | `2008` |
+| AMWA NMOS Node | HTTP | `18080` |
+
+All producers run concurrently on the same host; one port per
+connector. The same producer binary is driven by `dhs consumer` and by
+external peers (Cerebrum @ `.5`, AMWA Testing tool in Docker on `.105`)
+so wire behaviour can be compared across drivers.
+
+## SSH access mesh
+
+The agent (Claude, git author `by-rune`) needs passwordless SSH to and
+from every node in the fleet so it can launch / restart / probe
+producers from any host.
+
+### Key material
+
+- Single ed25519 keypair, no passphrase: `id_dhs_testbed` (private),
+  `id_dhs_testbed.pub` (public).
+- Generated once on `BY-DESK-03`, then distributed to every node so the
+  same `~/.ssh/id_dhs_testbed` exists on every Linux LXC and on the
+  Windows host. This makes the mesh symmetric — any node can SSH any
+  other node with the same key.
+- The agent shell on `BY-DESK-03` continues to use the existing key
+  `~/.ssh/by-rune_lxc` for outbound SSH (already present and working).
+  The new `id_dhs_testbed` mesh is for fleet-internal SSH and replaces
+  the desk-03-only path.
+
+### Account
+
+Login user is `root` on every Linux LXC (the `by-rune` user is
+rejected by sshd config on the LXCs; only `root` accepts the key —
+verified 2026-05-10). On `dhs-win11` the equivalent is the local
+Administrator user with OpenSSH server enabled.
+
+### Authorised destinations (mesh)
+
+| Source → | dhs-debian | dhs-ubuntu | dhs-rocky | dhs-tools | dhs-win11 | desk-03 |
+| --- | --- | --- | --- | --- | --- | --- |
+| dhs-debian | self | yes | yes | yes | yes | (pull only) |
+| dhs-ubuntu | yes | self | yes | yes | yes | (pull only) |
+| dhs-rocky | yes | yes | self | yes | yes | (pull only) |
+| dhs-tools | yes | yes | yes | self | yes | (pull only) |
+| dhs-win11 | yes | yes | yes | yes | self | (pull only) |
+| desk-03 | yes | yes | yes | yes | yes | self |
+
+`desk-03` initiates SSH outbound. The fleet does not SSH back into
+`desk-03` (the codeowner's workstation is on the OOB VLAN behind
+pfSense and is not reachable from the DMZ).
+
+### Distribution status
+
+- desk-03 → fleet: working via `~/.ssh/by-rune_lxc` (legacy key).
+- Fleet ↔ fleet: **NOT YET DISTRIBUTED.** The new `id_dhs_testbed`
+  keypair has not been generated or pushed. Tracked as a separate
+  infra task — see "Open work" below.
+
+## Producer launch and stop
+
+### Linux LXC (Debian / Ubuntu / Rocky)
+
+Launch the four producers nohup-detached, writing logs to
+`/var/log/dhs-<proto>.log`. Example for ACP2:
+
+```sh
+nohup /usr/local/bin/dhs producer acp2 serve \
+  --tree /etc/dhs/tree.json \
+  --port 2072 --host 0.0.0.0 --log-level info \
+  > /var/log/dhs-acp2.log 2>&1 &
+```
+
+Hard-stop by walking `/proc/*/exe` symlinks pointing to
+`/usr/local/bin/dhs` and killing each PID. Helper script at
+`bin/stop-dhs.sh`.
+
+### dhs-win11
+
+OpenSSH server on the Windows host, `dhs.exe` placed under
+`C:\Program Files\dhs\dhs.exe`. Producer launch via PowerShell
+`Start-Process` with `-WindowStyle Hidden` and a redirect of
+stdout/stderr to log files under `C:\ProgramData\dhs\logs\`.
+
+## Caveats
+
+- `amwa/nmos-testing:latest` upstream regressed to the "Controller
+  Testing Façade" on port 5001 after 2026-04-30. Pin to a pre-Façade
+  tag or run from source.
+- Win11 desk-03 (the codeowner's workstation) sits on the OOB VLAN and
+  cannot reach the DMZ via mDNS. `dhs-win11` (`.106`) on the DMZ
+  provides the Bonjour live test surface instead.
+- Cerebrum drops `v1.0` from `api.versions` on registration — real-peer
+  fact, not our bug.
+
+## Pending rig changes
+
+- Add `eth1` second NIC per `dhs-*` Linux LXC for dual-controller
+  redundancy testing per ADR-0022 (N-endpoints/Frame). Planned
+  pairings: `.102/.108`, `.103/.109`, `.104/.107`.
+- Bring `dhs-win11` (`.106`) online with the four producers running
+  to complete the multi-OS coverage matrix.
+
+## Open work
+
+- Generate `id_dhs_testbed` keypair on `BY-DESK-03`.
+- Distribute private + public to every node in the fleet (LXCs +
+  Windows) and add the public to every `authorized_keys`.
+- Verify the mesh: from each node, `ssh -i ~/.ssh/id_dhs_testbed
+  <every-other-node>` succeeds without prompting.
+
+These are infra actions that require codeowner-side execution (key
+distribution touches credentials and is therefore not autonomous).

--- a/docs/user.md
+++ b/docs/user.md
@@ -6,10 +6,10 @@ entry.
 
 ## Roles
 
-| Role | Who | Authority |
+| Role | Identities | Authority |
 | --- | --- | --- |
-| **Codeowner** | `@yboujraf` (GitHub) = `by-rune` (git author) = `yboujraf@by-systems.be` (email) — same person, three handles | All scope decisions, all PR approvals, all merges, all issue closes. The codeowner approves; the agent never approves itself. Enforced via `.github/CODEOWNERS`. |
-| **DevOps (agent)** | Claude (this agent) | Executes the work: branches, builds, tests, atomic commits, pushes, runs probes, drives the testbed. Never opens PRs or merges or closes issues without explicit codeowner "go" / "approuved" / "ok". |
+| **Codeowner** (human) | GitHub `@yboujraf`, email `yboujraf@by-systems.be`, org BY-SYSTEMS SRL | All scope decisions, all PR approvals, all merges, all issue closes. The codeowner approves; the agent never approves itself. Enforced via `.github/CODEOWNERS`. |
+| **DevOps** (agent) | Claude (this agent), git author `by-rune` | Executes the work: branches, builds, tests, atomic commits, pushes, runs probes, drives the testbed. Never opens PRs or merges or closes issues without explicit codeowner "go" / "approuved" / "ok". Commits land under `by-rune` so `git log` cleanly distinguishes agent work from any human edits. |
 
 Solo dev project — there are no other humans contributing.
 

--- a/docs/user.md
+++ b/docs/user.md
@@ -1,0 +1,73 @@
+# docs/user.md — Roles, profile, and host preference
+
+Tracked, repo-local source of truth for who is the codeowner and what
+role the agent occupies. Replaces the legacy `memory/user_preferences.md`
+entry.
+
+## Roles
+
+| Role | Who | Authority |
+| --- | --- | --- |
+| **Codeowner** | `@yboujraf` (GitHub) = `by-rune` (git author) = `yboujraf@by-systems.be` (email) — same person, three handles | All scope decisions, all PR approvals, all merges, all issue closes. The codeowner approves; the agent never approves itself. Enforced via `.github/CODEOWNERS`. |
+| **DevOps (agent)** | Claude (this agent) | Executes the work: branches, builds, tests, atomic commits, pushes, runs probes, drives the testbed. Never opens PRs or merges or closes issues without explicit codeowner "go" / "approuved" / "ok". |
+
+Solo dev project — there are no other humans contributing.
+
+## Codeowner profile
+
+- Org: BY-SYSTEMS SRL
+- Workstation: `BY-DESK-03`, Windows 11 Pro, native Go (go1.26.2)
+- Editor: VS Code with Dev Containers extension available but unused
+- **Never address the codeowner by a first name.** The handle `yboujraf`
+  is canonical; do not infer a first name from it.
+
+## Host preference
+
+| Host the agent runs on | Shell to use | Why |
+| --- | --- | --- |
+| Windows 11 (desk-03) | PowerShell unconditionally | git-bash here spams `/etc/post-install/*.post` permission errors on every command |
+| Linux LXC / Devcontainer / WSL | Bash | native shell, clean output |
+| macOS | Bash / zsh | native shell |
+
+For file operations the agent prefers the dedicated tools (Glob, Grep,
+Read, Edit, Write) regardless of host.
+
+## Test fleet
+
+The agent operates against a separate VLAN (`10.100.0.0/24`) routed via
+pfSense. Full inventory + SSH access mesh in [`docs/testbed.md`](testbed.md).
+
+## Vendor reference drivers (NDA)
+
+A secondary reference driver predating this Go rewrite is held under NDA.
+The brand identifiers of NDA reference vendors must never appear in
+tracked artifacts — see ADR-NNNN once the NDA-vendor-name-policy ADR
+lands (pending).
+
+## What the agent does without asking
+
+Per the active DOD window (see ADR-0027 once accepted):
+
+- Branch creation
+- Local edits, builds, and unit tests
+- Atomic commits (one per tracked issue)
+- Push branches to origin for visibility
+- Reading code and running probes
+
+## What the agent must NOT do without explicit "go" / "approuved" / "ok"
+
+- `gh pr create` — opening any PR
+- `gh pr merge` — merging any PR
+- Closing any tracked issue
+- Changing scope of an issue
+- Force-pushing or amending published commits
+- Adding `Closes #N` to a commit body (default is `Refs #N`)
+- Uploading content to third-party web services
+- Modifying CI / `.github/workflows/`
+- Touching shared infrastructure (DNS, Vault, CODEOWNERS)
+
+## Communication style
+
+See ADR-0026 once accepted: terse, tables for facts not options, no A/B/C
+menus, progress markers per substep, end-of-turn summary in one or two
+sentences.

--- a/internal/emberplus/CLAUDE.md
+++ b/internal/emberplus/CLAUDE.md
@@ -57,6 +57,43 @@ TCP
         └── Glow trees: Node / Parameter / Matrix / Function
 ```
 
+## BER REAL — ecosystem reading
+
+X.690 §8.5.7 defines binary REAL as `N × 2^F × B^E` with `N` an
+unsigned integer. **No shipping Ember+ implementation reads it that
+way.** libember-cpp, libember-slim, EmberViewer, EmberPlusView, and
+every vendor controller verified to date read `N` as a normalised
+fraction with the binary point implicit after the leading 1:
+
+```
+value = sign × (N / 2^(bitlen(N)-1)) × B^E × 2^F
+```
+
+This is the "every shipping controller contradicts the spec" exception
+from the root `CLAUDE.md` "Spec-strict, no-workaround posture" — it
+qualifies (two-plus independent in-field implementations verified,
+X.690 §8.5.6 + §8.5.7.3 normalisation supports the fractional reading
+textually).
+
+Implementation:
+
+- Encoder `codec/ber/value.go::EncodeReal` — after IEEE-754
+  decompose + odd-mantissa normalisation, before emitting the wire
+  exponent, `exponent += bits.Len64(mantissa) - 1`.
+- Decoder `codec/ber/value.go::DecodeReal` — mirror:
+  `shift := bits.Len64(mant) - 1; v := sign * float64(mant) *
+  math.Pow(2, float64(exp*baseFactor + scale - shift))`.
+- Test pins: `codec/ber/ber_test.go::TestReal_EcosystemBytes` for
+  byte sequences 50 / 100 / 0.1 / 1 / 2 / 16;
+  `TestReal_RoundTrip` as secondary check.
+- Powers of two emit `mantissa=1, bitlen=1, shift=0` so 1.0 / 2.0 /
+  16.0 wire output is unchanged by the bias — only multi-bit
+  mantissas shift.
+
+No compliance event is fired — this is a wire-format choice
+documented inline, not a per-peer runtime deviation absorbed via
+`compliance.Profile`.
+
 ## GlowDTD tag numbers (APPLICATION class)
 
 ```

--- a/internal/probel-sw08p/CLAUDE.md
+++ b/internal/probel-sw08p/CLAUDE.md
@@ -31,6 +31,39 @@ internal/probel-sw08p/
   sibling `.pdf` is corrupted.
 - ACK handling lives in §2 (Transmission Protocol), NOT §3.5.
 
+### Reference hierarchy (tie-breaker order)
+
+When the spec is ambiguous on a wire detail, resolve in this order. Do
+not skip ahead — secondary sources don't override clearer spec
+language.
+
+| Tier | Source | Use case |
+| --- | --- | --- |
+| 1 | SW-P-08 Issue 30 spec (DOC above) | always read first; literal |
+| 1b | SW-P-02 Issue 26 spec at `internal/probel-sw02p/assets/probel-sw02/SW-P-02_issue_26.txt` | SW-P-02 wire detail only |
+| 2 | Wireshark dissector `internal/probel-sw08p/wireshark/dhs_probel_sw08p.lua` | framing tie-breaker when the spec leaves an edge case |
+| 3 | `Commie.exe` + saved `commie_SWP08.dat` / `commie_SWP02.dat` | cross-vendor sanity check only when both tiers above leave a gap |
+| 3b | Real codeowner device | live confirmation; occasional, never the primary source |
+
+Tools at `internal/probel-sw08p/assets/tools/` — `Commie.exe`,
+`commie_SWP02.dat`, `commie_SWP08.dat`.
+
+The historical in-tree TS emulator `assets/smh-probelsw08p/` was
+removed in PR #226. Do not reintroduce a secondary reference impl —
+spec is single source of truth.
+
+### Spec section bookmarks
+
+- §2 — transmission protocol (ACK / NAK, retry, 10 ms, 128-byte DATA;
+  **not** §3.5).
+- §3.1.2 — narrow matrix/level packing + multiplier (4-bit + 3-bit
+  DIV-128).
+- §3.1.6 — multiplier semantics for protect / tally.
+- §3.2.x — rx general.
+- §3.3.x — tx general.
+- §3.4.x — rx extended.
+- §3.5.x — tx extended.
+
 ## Transport — SW-P-08 §2
 
 - TCP connection to the matrix controller. Default port 2008.


### PR DESCRIPTION
## Summary

Apply ADR-0015 (single source of truth) to agent memory. Active memory
drops from 108 files to 1 (`MEMORY.md`, near-empty pointer index); 61
legacy files preserved under `memory/archive/` for a future canonisation
pass once the Ember+ DOD window closes.

## Atomic commits (9)

| # | Commit | What |
| --- | --- | --- |
| 1 | `5d5625d` | docs(user): add operator and agent role file |
| 2 | `68fd3de` | docs(user): correct role mapping — `by-rune` is the agent identity |
| 3 | `31e7933` | docs(adr): propose ADR-0026 agent communication style |
| 4 | `48bbc60` | docs(adr): propose ADR-0027 workflow contract during DOD windows |
| 5 | `b132a51` | docs(adr): register ADR-0026 + ADR-0027 in index and pad table separators |
| 6 | `e908cc2` | docs(testbed): add fleet inventory + SSH mesh layout |
| 7 | `406cf50` | docs(emberplus): document BER REAL ecosystem-fraction reading |
| 8 | `4206567` | docs(probel-sw08p): document reference hierarchy + spec bookmarks |
| 9 | `833825e` | docs(claude.md): strip stale memory pointers, add ADR-0025/26/27 + ops docs index |

## Test plan

- [x] Each atomic commit passes pre-commit (go vet + golangci-lint).
- [ ] CI green on the open PR.
- [ ] No code is touched — `internal/<proto>/` semantics unaffected.
- [ ] Reading `CLAUDE.md` top-to-bottom yields no broken `See [...]` references.
- [ ] Reading `docs/adr/README.md` index lists ADR-0026 + ADR-0027 as `proposed` and ADR-0025 as `accepted`.

## Notes

ADR-0026 and ADR-0027 are `proposed`; merging this PR adopts them as
binding `accepted` (no separate "accept" PR per the ADR README rule).

Independent of the Ember+ DOD branches — this PR is doc hygiene only,
no protocol code is touched.

Closes #505