### PR TITLE
docs(adr): coherence wave 1 - amendment policy, errata, acceptances, taxonomy

### DIFF
--- a/docs/adr/0003-license-jwt-eddsa-vault-transit.md
+++ b/docs/adr/0003-license-jwt-eddsa-vault-transit.md
@@ -76,8 +76,8 @@ and a clear error. There is no grace period, no degraded mode.
 ### Key rotation
 
 Annual rotation by default; immediate rotation on incident. Per
-ADR-0009 / ADR-0014 the rotation is performed via Vault Transit's
-`rotate` operation. Connector binaries embed the current public key
+ADR-0010 (Vault internal-only) the rotation is performed via Vault
+Transit's `rotate` operation. Connector binaries embed the current public key
 plus one previous version (grace period). The JWT header `kid`
 identifies which key version signed it.
 
@@ -98,3 +98,10 @@ identifies which key version signed it.
   binaries.
 - Auto-downgrade or grace-period extension on expiry.
 - Skipping signature verification under any flag.
+
+## Revisions
+
+- 2026-06-07 — errata: fixed the key-rotation citation (was
+  "Per ADR-0009 / ADR-0014" — neither covers rotation) to ADR-0010
+  (Vault internal-only). Per ADR-0015 Amendment policy; resolves
+  coherence-review C4. — by-rune

--- a/docs/adr/0007-ensure-verb.md
+++ b/docs/adr/0007-ensure-verb.md
@@ -62,11 +62,15 @@ Every connector exposes an `ensure` verb across all three roles
 
 ### Exit codes
 
+Per `docs/protocols/error-codes.md` (the error contract): the exit code reflects
+**outcome, not change**. Change is signalled only by the `changed` / `would_change`
+JSON field — never by the exit code.
+
 | Exit | Meaning |
 |---|---|
-| 0 | success — applied (or dry-run reported) |
-| 1 | error — failed to apply or to inspect |
-| 2 | success but `changed: true` (optional convention; some pipelines use this) |
+| 0 | success — applied, or dry-run reported (parse `changed` / `would_change` from JSON) |
+| 1 | runtime / wire error — failed to apply or to inspect |
+| 2 | usage / validation error (bad `--state`, invalid config) |
 
 ### Idempotency rules
 
@@ -92,3 +96,12 @@ Every connector exposes an `ensure` verb across all three roles
 - `ensure` mutating state when `--check` is passed.
 - Returning `changed: true` when nothing actually changed.
 - Skipping `diff` output (always emit, even if empty `[]`).
+
+## Revisions
+
+- 2026-06-07 — Exit-code table corrected (errata per ADR-0015 Amendment
+  policy): removed the "exit 2 = changed" convention, which collided with the
+  error contract in `docs/protocols/error-codes.md` (exit 2 = usage/validation).
+  `ensure` signals change only via the `changed` / `would_change` JSON field;
+  exit code reflects outcome (0 ok / 1 runtime / 2 validation). Resolves
+  coherence-review C1. — by-rune

--- a/docs/adr/0015-single-source-of-truth.md
+++ b/docs/adr/0015-single-source-of-truth.md
@@ -37,6 +37,16 @@ Other docs reference it by path/number; they never restate it.
 | Multi-OS support | ADR-0016 |
 | File-header template | ADR-0017 (parked) |
 | `info` verb build identity | ADR-0018 |
+| Documentation structure | ADR-0019 |
+| Capture + fixture layout | ADR-0020 |
+| Wire-trace JSONL contract | ADR-0021 |
+| Card data model | ADR-0022 |
+| Matrix entity | ADR-0023 |
+| Federation (mirror / virtual frame) | ADR-0024 |
+| Per-connector definition of done | ADR-0025 |
+| Agent communication style | ADR-0026 |
+| Workflow contract (DOD windows) | ADR-0027 |
+| ADR amendment / lifecycle | ADR-0015 (this one, §Amendment policy) |
 | Per-protocol wire facts | `internal/<proto>/CLAUDE.md` |
 | Per-protocol audit answers | `internal/<proto>/COMPLIANCE.md` |
 | Customer + license + asset records | Odoo (per ADR-0011) |
@@ -54,11 +64,22 @@ Other docs reference it by path/number; they never restate it.
 | `internal/<proto>/COMPLIANCE.md` | audit answers (per ADR-0008); never restates architectural rules |
 | `README.md` | one-line public summary; never restates |
 
-### No superseding
+### Amendment policy
 
-Once an ADR is `accepted`, it is permanent. If a new concern arises,
-write a new ADR for the new concern. Never overwrite or supersede.
-This prevents the slow drift that "supersede" patterns enable.
+Once an ADR is `accepted`, its **decision** is stable — but the file is
+**amendable in place** via a dated entry in a `## Revisions` trailer, for:
+
+- **errata** — typos, stale indexes, broken cross-references, wrong citations;
+- **clarifications** that do not change the decision;
+- **living-document additions** that extend (never reverse) the decision.
+
+A **substantive reversal** of an accepted decision still requires a **new ADR**
+documenting the new concern. ADRs are never deleted; there is no `superseded`
+status. Every amendment requires `@yboujraf` approval per ADR-0014.
+
+This legitimizes the existing living-document ADRs (0023 / 0025 / 0026) and lets
+defects be corrected without spawning a clarifying ADR per typo. (Replaces the
+former "accepted = permanent, never modify" rule — see Revisions.)
 
 ### Enforcement
 
@@ -84,8 +105,20 @@ When reviewing any change:
 ## Forbidden
 
 - Restating an ADR's content in another doc.
-- Modifying an ADR after it is `accepted` (status flip is forbidden;
-  the rule itself can be amended only via a new ADR documenting a
-  new concern).
+- **Reversing** an accepted ADR's decision by in-place edit — a reversal
+  requires a new ADR. (Errata / clarifications / living-document additions
+  via a dated `## Revisions` entry are permitted; see Amendment policy.)
+- Flipping an ADR's status backwards (e.g. `accepted` → `proposed`).
 - Introducing `superseded` / `deprecated` / `rejected-after-acceptance`
   status — the only valid states are `proposed` and `accepted`.
+
+## Revisions
+
+- 2026-06-07 — Amendment policy added: accepted ADRs may be amended in
+  place via a dated Revisions entry for errata / clarification /
+  living-document additions; decision reversals still require a new ADR.
+  Replaces the former absolute "accepted = permanent, never modify" rule,
+  which blocked even typo/stale-index/cross-reference fixes and contradicted
+  the living-document pattern already used by ADR-0023/0025/0026. Also
+  completed this ADR's stale "Where rules live" index (was 0001–0018; now
+  0001–0027). Authorized by `@yboujraf`. — by-rune

--- a/docs/adr/0025-per-connector-definition-of-done.md
+++ b/docs/adr/0025-per-connector-definition-of-done.md
@@ -44,7 +44,7 @@ forward progress on the connector.
 
 A binding definition of done closes the gate at the connector boundary:
 no per-connector PR is approved for merge unless the connector has all
-five deliverables below.
+six deliverables below.
 
 ## Decision
 
@@ -63,6 +63,30 @@ later" framing.
 | 5 | **Wireshark dissector** `internal/<proto>/wireshark/dhs_<proto>.lua` | Covers every transport, every wire version, every command / type-tag the connector implements. Per-frame Info column carries the discriminating arguments (matrix/level/dst/src for SW-P-08; slot/type/pid/stat for ACP2; address+typetag+argcount for OSC; etc.). | See `internal/<proto>/wireshark/` + root CLAUDE.md "Wireshark dissectors". |
 | 6 | **Replay fixture set** under `internal/<proto>/testdata/` | Layout: `testdata/protocol_types/<typename>/` (one folder per spec type / command / message kind, each containing the raw wire capture + canonical tree + per-type doc), `testdata/fixtures/` (multi-frame golden scenarios), `testdata/exports/` (canonical exports for round-trip checks). Reference shape: `internal/acp1/testdata/` (`.pcapng` raw + `.tree` canonical + per-type `.md`). | Lets every connector replay raw / pcap at any time, in CI, without needing live device access. Promotion rules from local `captures/<proto>/<ip>/<scenario>/` to committed `testdata/` live in `captures/README.md` (size cap, edge-case justification, byte-stability). |
 
+### Test taxonomy (expands deliverable 3)
+
+Deliverable 3's integration test is the top tier of a three-tier model; the
+per-verb specification lives in [`docs/protocols/verb-tests.md`](../protocols/verb-tests.md):
+
+| Tier | Proves | Oracle |
+|---|---|---|
+| **Unit** | codec + per-verb logic | the spec (expected bytes) + injected mock transport/clock (DI); no real sockets |
+| **Smoke** | verb is wired; flags parse; output + exit code correct | built binary, loopback / trivial target |
+| **Integration** | wire behaviour | **vendor emulator + real device — never our own provider**; idempotent verbs proven by Ansible run-twice = 0 changes |
+
+### Connector compliance principles (cross-cutting)
+
+Every deliverable is built to these; each references its owning source (ADR-0015):
+
+| Principle | Source |
+|---|---|
+| Dependency injection (transport / logger / clock as constructor params) | root CLAUDE.md "Architecture principles" |
+| OOP / encapsulation / separation of concerns (consumer never imports provider) | root CLAUDE.md; ADR-0006 |
+| Idempotency (`ensure`) | ADR-0007 |
+| Structured logs (`slog`, levels, `--log-format`) | docs/logging.md; ADR-0002 |
+| Discovery (protocol-native + optional mDNS for our producer) | ADR-0012 |
+| Error contract (exit 0/1/2, `<layer>:<code>`) | docs/protocols/error-codes.md |
+
 Documentation deliverables travel alongside but are not gated by the
 ADR — they are required at PR time per ADR-0015 (single source of
 truth):
@@ -72,7 +96,7 @@ truth):
 
 ## How to apply
 
-1. **Before starting work on any connector**, audit the connector against the five-deliverable checklist. Flag missing pieces explicitly.
+1. **Before starting work on any connector**, audit the connector against the six-deliverable checklist. Flag missing pieces explicitly.
 2. **Each PR must cite which deliverable it advances** for which connector, plus the state of the other four (`done` / `partial` / `missing`).
 3. **One PR advances one deliverable for one connector**. No PR can combine "connector A integration test" with "connector B fix" — that's the bundle pattern ADR-0013 already forbids, restated here for the avoidance of doubt.
 4. **No connector PR is approved for merge until all six exist** for that connector. The integration test in (3) is the truth source: green there = real green; failing there = the wire is broken, fix the wire, never the test.
@@ -114,3 +138,9 @@ truth):
   device. Reference shape: `internal/acp1/testdata/`. Promotion rules
   from `captures/` to `testdata/` already documented in
   `captures/README.md`.
+- 2026-06-07 — errata: corrected two stale "five-deliverable" mentions to
+  "six" (Context + How-to-apply lagged the 2026-05-17 #6 addition). Added
+  the three-tier **Test taxonomy** (→ `docs/protocols/verb-tests.md`)
+  expanding deliverable 3, and the cross-cutting **Connector compliance
+  principles** (DI, OOP/SoC, idempotency, structured logs, discovery, error
+  contract). Living-document additions per ADR-0015 Amendment policy. — by-rune

--- a/docs/adr/0026-agent-communication-style.md
+++ b/docs/adr/0026-agent-communication-style.md
@@ -1,6 +1,6 @@
 # ADR-0026 — Agent communication style
 
-Status: proposed
+Status: accepted
 
 This ADR is a living document (per ADR-0025 precedent). Add new facts in
 the Revisions trailer.
@@ -99,3 +99,6 @@ operator's redirection materially changes the work. "Go", "approuved",
 ## Revisions
 
 - 2026-05-18 — initial proposal.
+- 2026-06-07 — accepted. Was proposed-but-enforced (cited as binding in
+  root CLAUDE.md "Foundational ADRs" + docs/user.md). Formalized per
+  ADR-0015 Amendment policy; resolves coherence-review F7. — by-rune

--- a/docs/adr/0027-workflow-contract-dod-windows.md
+++ b/docs/adr/0027-workflow-contract-dod-windows.md
@@ -1,6 +1,6 @@
 # ADR-0027 — Workflow contract during DOD windows
 
-Status: proposed
+Status: accepted
 
 This ADR is a living document. Add new facts in the Revisions trailer.
 
@@ -130,3 +130,6 @@ criterion: clearest scope + smallest effort.
 
 - 2026-05-18 — initial proposal, derived from the workflow-contract
   feedback produced by the 2026-05-17 Ember+ session.
+- 2026-06-07 — accepted. Was proposed-but-enforced (governs the active
+  DOD-window workflow; cited in root CLAUDE.md). Formalized per ADR-0015
+  Amendment policy; resolves coherence-review F7. — by-rune

--- a/docs/protocols/verb-tests.md
+++ b/docs/protocols/verb-tests.md
@@ -1,0 +1,68 @@
+# Per-verb test specification
+
+**Status: proposed** (pending fold into ADR-0025). **Scope:** the Tree/DM generic
+verb set (acp1 / acp2 / emberplus) — the template; Matrix/Push/Bridge verbs follow
+the same three-tier shape (§4).
+
+**Sourcing (strict):**
+- **Definition** of each verb is owned by [`verbs.md`](verbs.md) / ADR-0002 — cited here, not restated (ADR-0015).
+- **Test tiers** are the established rules applied per verb, not new invention:
+  - **Unit** — CLAUDE.md "Testing": table-driven, **expected bytes from the spec**, `MockTransport` injected (DI), **no real sockets**.
+  - **Smoke** — built binary runs the verb, parses flags, emits output, exit 0; fast, no real device.
+  - **Integration** — **oracle-per-tier** (`repo-review` §7) + ADR-0025 #3: the **CLI** verb run against the **vendor emulator AND a real device**, result asserted; repeatable. A consumer is **never** validated against our own provider.
+
+---
+
+## 1. Tiers (definition)
+
+| Tier | Proves | Oracle / driver | Determinism |
+|---|---|---|---|
+| **Unit** | codec + per-verb logic | the spec (expected bytes) + injected mock transport/clock | fully deterministic, no network |
+| **Smoke** | the verb is wired, flags parse, output shape is right | built binary, loopback or trivial target | fast, CI-gating |
+| **Integration** | the verb behaves correctly on the wire | **vendor emulator + real device** (acp1: Synapse Simulator `10.6.239.113:2071` + Axon device) | repeatable; idempotent verbs via Ansible run-twice |
+
+---
+
+## 2. Per-verb spec (Tree/DM: acp1 / acp2 / emberplus)
+
+Definitions: see `verbs.md` §2. Below is **how each is tested**.
+
+| Verb | Unit | Smoke | Integration (vs emulator + device) |
+|---|---|---|---|
+| `info` | decode a mock device-info / slot-info reply (expected bytes) → assert slot count + per-slot status | `info <host>` exit 0, prints slot table | slot count + statuses match the device fixture |
+| `walk` | table-driven decode of **every object type** from mock replies → assert canonical objects (type, access, options, ranges) | `walk --slot 0` exit 0, >0 objects | object count + types match fixture for a known card |
+| `tree` | golden-output: render a fixed canonical tree → assert exact ASCII **and** PlantUML | `tree --slot 0` exit 0, valid `@startmindmap` | renders the **full** slot tree (current gap: shallow render) |
+| `get` | decode mock value reply per type (expected bytes) → assert `Value` (raw, kind, enum items, default) | `get … --label X` exit 0 | known value matches fixture |
+| `set` | (a) encode request = expected bytes (valid); (b) **client-side validation** rejects out-of-range / wrong-type / bad-enum with **exit 2** (table-driven) | valid value → exit 0; bad value → **exit 2** | `set` then `get` readback equals; bad input rejected exit 2, **no wire write** |
+| `watch` | decode mock announce frames → assert events; announce-gating logic (acp1 `Broadcasts` / acp2 `EnableProtocolEvents`) | `watch` binds + exits on `--timeout` | change a value on the peer → assert announce received |
+| `export` | canonical→json/yaml/csv golden; **CSV lossless** round-trip | `export --out f.json` exit 0, file schema-valid | export a slot → schema-valid → re-import is idempotent |
+| `import` | dry-run logic; **RW-only**; **mismatch skipped, non-blocking**; per-type pass/fail/skip tally | `import f.json --dry-run` exit 0, prints tally | import (dry-run then apply) → readback matches; mismatches skipped, exit 0 |
+| `extract` | meta+wire+tree triple shape (ADR-0020 Bucket 3) | `extract …` writes the triple | triple captured into fixture layout from a real walk |
+| `diff` | two canonical trees → expected text / CHANGELOG diff (golden); exit code reflects difference | `diff a.json b.json` exit code = diff? | offline — unit covers it |
+| `convert` | json↔yaml↔csv round-trip golden | `convert in.json out.csv` exit 0 | offline — unit covers it |
+| `discover` | parse mock discovery responses → device list | `discover` exit 0 | native subnet scan finds the emulator/our producer; mDNS path (optional) finds our producer |
+| `profile` | compliance-counter logic → strict / partial classification | `profile` exit 0 | classification matches (emulator = STRICT, verified 2026-06-07) |
+| `validate` | decode a fixture `frames.jsonl` → per-frame pass/fail | `validate fixture.jsonl` exit 0 | offline; optional re-decode of a captured real session |
+| `health` | 3-layer state logic with mock conn | `health` exit 0, prints layers | reachable / connected / live all true vs a live peer |
+| `ensure` *(to build)* | read→compare→decide; **idempotency** (2nd call = no change); `--check` performs no write; exit 0 + `changed` flag; validation → exit 2 | `ensure --check` exit 0, reports would-change | **Ansible playbook, run twice → 2nd run reports 0 changes** (the idempotency proof) |
+
+---
+
+## 3. Cross-cutting rules
+
+- **Exit codes** per `docs/protocols/error-codes.md`: `0` ok · `1` runtime/wire · `2` usage/validation. Every smoke/integration assertion checks the exit code, not just stdout. (`set`/`ensure` bad-input MUST be exit 2 — current acp1 gap: exit 1.)
+- **DI requirement:** unit tests substitute `MockTransport` (+ a mock clock for timeout/keep-alive verbs) — no real sockets, no real time.
+- **Oracle rule:** consumer integration runs against the **vendor emulator + real device**, never our own provider. Provider integration is verified by our *trusted* consumer (after the consumer passes) and finally by the manufacturer's controller (manual).
+- **Idempotency:** `ensure` (and any state-changing verb driven through Ansible) proves idempotency by the **run-twice = 0 changes** rule.
+
+## 4. Protocol-specific verbs (same three tiers)
+
+Matrix / Push / Bridge verbs use the identical Unit/Smoke/Integration shape; only
+the oracle device changes. Examples:
+
+| Verb | Unit | Smoke | Integration |
+|---|---|---|---|
+| probel `connect` | encode cmd-2 expected bytes; ACK/NAK handling | `connect --matrix 0 --level 0 --dst 5 --src 12` exit 0 | vs Commie/TS emulator + VSM → crosspoint routed, tally confirms |
+| osc `watch` | decode each type-tag from mock frames | `watch --listen udp:8000` binds | vs osc.js peer → message received, line shape matches dissector |
+| tsl `listen` | decode v3.1/v4.0/v5.0 frames (expected bytes) | `listen --bind :4000` binds | vs Miranda TSL emulator → tally frame decoded |
+| cerebrum `route` | encode ROUTE XML (golden) | `route --dest 60 --srce 60 --level 1` exit 0 | vs Cerebrum NB → route applied (consumer-only; no provider) |


### PR DESCRIPTION
ADR coherence wave 1. Per-ADR detail is in the commit body; each change is logged in its ADR Revisions trailer. go vet + golangci-lint clean. Closes #511