### PR TITLE
feat: ensure verb - idempotent value convergence (ADR-0007)

### DIFF
--- a/cmd/dhs/cmd_ensure.go
+++ b/cmd/dhs/cmd_ensure.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"dhs/internal/consumer"
+)
+
+// ensureValErr returns a client-side validation error — mapped to exit 2 by
+// type in cmd/dhs (docs/protocols/error-codes.md).
+func ensureValErr(reason string) *consumer.ValidationError {
+	return &consumer.ValidationError{Field: "ensure", Reason: reason}
+}
+
+// runEnsure converges one object to a desired value, idempotently (ADR-0007,
+// the Ansible primitive). It reads the current value, compares to --value, and
+// writes only if they differ — so a second run reports changed:false and sends
+// no write. `--check` is a dry-run (reports would_change, writes nothing).
+//
+// Per ADR-0007 the exit code reflects outcome, not change: 0 ok / 1 runtime /
+// 2 validation (per docs/protocols/error-codes.md). Change is signalled by the
+// `changed` / `would_change` field. ADR-0007's consumer `present` is realised
+// here as value convergence; `absent` (session/service teardown) is a
+// producer/registry concern and is rejected for the consumer value-ensure.
+func runEnsure(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("ensure", flag.ExitOnError)
+	cf := addCommonFlags(fs)
+	slot := fs.Int("slot", 0, "slot number (default 0)")
+	group := fs.String("group", "", "object group name")
+	label := fs.String("label", "", "object label")
+	id := fs.Int("id", -1, "object id within group")
+	pathFlag := fs.String("path", "", "tree path: dotted label OR numeric OID")
+	valueStr := fs.String("value", "", "desired value to converge to")
+	state := fs.String("state", "present", "present (converge --value) | absent (producer/registry only)")
+	check := fs.Bool("check", false, "dry-run: report would_change, write nothing")
+	asJSON := fs.Bool("json", false, "emit a JSON result (Ansible-friendly)")
+	noWalk := fs.Bool("no-walk", false, "fail on cache miss instead of walking the slot to resolve --path/--label")
+	dmIdentity := fs.String("dm", "", `Ember+ only: identity-keyed DM hot-load (e.g. "Tiny Ember+ Router@1.6.2").`)
+	host, rest, err := popHost(args)
+	if err != nil {
+		return fmt.Errorf("usage: dhs consumer <proto> ensure <host> --slot N (--path P | --label L | --id I) --value <v> [--state present] [--check] [--json]")
+	}
+	_ = fs.Parse(rest)
+
+	if *state != "present" {
+		return ensureValErr(fmt.Sprintf("--state %q: consumer ensure converges values with --state present only; absent (session/service teardown) is a producer/registry concern (ADR-0007)", *state))
+	}
+	valueSet := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "value" {
+			valueSet = true
+		}
+	})
+	if !valueSet {
+		return ensureValErr("--value is required for --state present")
+	}
+	if *pathFlag == "" && *label == "" && *id < 0 {
+		return ensureValErr("either --path, --label, or --id is required")
+	}
+	if *pathFlag != "" {
+		if err := validatePathOrOID(*pathFlag); err != nil {
+			return err
+		}
+	}
+
+	plug, cleanup, err := connect(ctx, host, cf)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	// Resolve --path / --label to an object id (mirror cmd_set.go).
+	resolvedFromCache := false
+	if cf.protocol == "emberplus" {
+		if err := ensureEmberplusTree(ctx, plug, host, cf.port, *dmIdentity, *slot, *noWalk); err != nil {
+			return err
+		}
+		resolvedFromCache = true
+	} else if *id < 0 {
+		if *pathFlag != "" {
+			if cachedID := resolvePathFromCache(host, cf.protocol, *slot, *pathFlag); cachedID >= 0 {
+				*id = cachedID
+				resolvedFromCache = true
+			}
+		}
+		if !resolvedFromCache && *label != "" {
+			if cachedID := resolveLabelFromCache(host, cf.protocol, *slot, *group, *label); cachedID >= 0 {
+				*id = cachedID
+				resolvedFromCache = true
+			}
+		}
+	}
+	if cf.protocol != "emberplus" && !resolvedFromCache && (*pathFlag != "" || *label != "") {
+		if *noWalk {
+			return ensureValErr(fmt.Sprintf("--no-walk: %q not found in cache for slot %d (run 'walk --slot %d' first or drop --no-walk)", orFirst(*pathFlag, *label), *slot, *slot))
+		}
+		if _, err := plug.Walk(ctx, *slot); err != nil {
+			return fmt.Errorf("walk for resolution: %w", err)
+		}
+		if *id < 0 && *label != "" {
+			if cachedID := resolveLabelFromCache(host, cf.protocol, *slot, *group, *label); cachedID >= 0 {
+				*id = cachedID
+			}
+		}
+	}
+
+	opCtx, cancel := withTimeout(ctx, cf.timeout)
+	defer cancel()
+
+	req := consumer.ValueRequest{Slot: *slot, Path: *pathFlag, Group: *group, Label: *label, ID: *id}
+
+	current, err := plug.GetValue(opCtx, req)
+	if err != nil {
+		return err
+	}
+
+	desired := strings.TrimSpace(*valueStr)
+	curStr := canonicalValueStr(current)
+	changed := !valuesEqual(current, desired)
+
+	if *check {
+		return emitEnsure(*asJSON, ensureResult{WouldChange: &changed, Current: curStr, Target: desired})
+	}
+	if !changed {
+		return emitEnsure(*asJSON, ensureResult{Changed: &changed, Previous: curStr, Current: curStr})
+	}
+	confirmed, err := plug.SetValue(opCtx, req, consumer.Value{Str: desired})
+	if err != nil {
+		return err
+	}
+	newStr := canonicalValueStr(confirmed)
+	return emitEnsure(*asJSON, ensureResult{Changed: &changed, Previous: curStr, Current: newStr})
+}
+
+// ensureResult is the structured outcome (ADR-0007 shape, simplified for the
+// consumer value case). Pointers distinguish apply (changed) from check
+// (would_change) and keep `false` from being omitted.
+type ensureResult struct {
+	Changed     *bool  `json:"changed,omitempty"`
+	WouldChange *bool  `json:"would_change,omitempty"`
+	Previous    string `json:"previous,omitempty"`
+	Current     string `json:"current,omitempty"`
+	Target      string `json:"target,omitempty"`
+}
+
+func emitEnsure(asJSON bool, r ensureResult) error {
+	if asJSON {
+		b, _ := json.Marshal(r)
+		fmt.Println(string(b))
+		return nil
+	}
+	switch {
+	case r.WouldChange != nil:
+		fmt.Printf("would_change=%t  current=%q  target=%q\n", *r.WouldChange, r.Current, r.Target)
+	case r.Changed != nil && *r.Changed:
+		fmt.Printf("changed=true  previous=%q  current=%q\n", r.Previous, r.Current)
+	default:
+		fmt.Printf("changed=false  current=%q (already converged)\n", r.Current)
+	}
+	return nil
+}
+
+// canonicalValueStr renders a Value to a comparable string per Kind — no unit
+// suffix, no formatting flourish (unlike formatValue), so it round-trips
+// against a user-supplied --value.
+func canonicalValueStr(v consumer.Value) string {
+	switch v.Kind {
+	case consumer.KindEnum, consumer.KindString, consumer.KindAlarm:
+		return v.Str
+	case consumer.KindBool:
+		return strconv.FormatBool(v.Bool)
+	case consumer.KindInt:
+		return strconv.FormatInt(v.Int, 10)
+	case consumer.KindUint:
+		return strconv.FormatUint(v.Uint, 10)
+	case consumer.KindFloat:
+		return strconv.FormatFloat(v.Float, 'g', -1, 64)
+	case consumer.KindIPAddr:
+		return net.IP(v.IPAddr[:]).String()
+	default:
+		return hex.EncodeToString(v.Raw)
+	}
+}
+
+// valuesEqual reports whether the current value already equals the desired
+// string, with numeric tolerance (so "3" == "3.0" for numeric kinds).
+func valuesEqual(cur consumer.Value, desired string) bool {
+	d := strings.TrimSpace(desired)
+	if canonicalValueStr(cur) == d {
+		return true
+	}
+	switch cur.Kind {
+	case consumer.KindInt, consumer.KindUint, consumer.KindFloat:
+		cf, e1 := strconv.ParseFloat(canonicalValueStr(cur), 64)
+		df, e2 := strconv.ParseFloat(d, 64)
+		return e1 == nil && e2 == nil && cf == df
+	}
+	return false
+}
+
+func helpEnsure() {
+	fmt.Println(`dhs consumer <proto> ensure <host> --slot N (--path P | --label L | --id I) --value <v> [--state present] [--check] [--json]
+
+Idempotent value convergence (ADR-0007). Reads the object, sets it ONLY if it
+differs from --value, and reports whether it changed. A second run is a no-op
+(changed=false). Use --check for a dry-run (writes nothing). --json emits an
+Ansible-friendly {changed|would_change, previous, current} result.
+
+Exit codes (docs/protocols/error-codes.md): 0 ok · 1 runtime/wire · 2 validation.
+Change is signalled by the field, never the exit code.
+
+Examples:
+  dhs consumer acp1 ensure 10.6.239.113 --slot 0 --group control --label Broadcasts --value On
+  dhs consumer acp1 ensure 10.6.239.113 --slot 0 --group control --label Broadcasts --value On --check --json`)
+}

--- a/cmd/dhs/cmd_ensure_test.go
+++ b/cmd/dhs/cmd_ensure_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"testing"
+
+	"dhs/internal/consumer"
+)
+
+// TestCanonicalValueStr pins the comparable-string rendering per ValueKind —
+// the form `ensure` compares a user-supplied --value against. No unit suffix,
+// no formatting flourish (unlike formatValue).
+func TestCanonicalValueStr(t *testing.T) {
+	cases := []struct {
+		name string
+		v    consumer.Value
+		want string
+	}{
+		{"enum", consumer.Value{Kind: consumer.KindEnum, Str: "On"}, "On"},
+		{"string", consumer.Value{Kind: consumer.KindString, Str: "Broadcasts"}, "Broadcasts"},
+		{"bool true", consumer.Value{Kind: consumer.KindBool, Bool: true}, "true"},
+		{"bool false", consumer.Value{Kind: consumer.KindBool, Bool: false}, "false"},
+		{"int negative", consumer.Value{Kind: consumer.KindInt, Int: -3}, "-3"},
+		{"uint", consumer.Value{Kind: consumer.KindUint, Uint: 10}, "10"},
+		{"float", consumer.Value{Kind: consumer.KindFloat, Float: 3.5}, "3.5"},
+		{"ipaddr", consumer.Value{Kind: consumer.KindIPAddr, IPAddr: [4]byte{192, 168, 1, 5}}, "192.168.1.5"},
+		{"raw hex", consumer.Value{Kind: consumer.KindRaw, Raw: []byte{0x01, 0xff}}, "01ff"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := canonicalValueStr(tc.v); got != tc.want {
+				t.Errorf("canonicalValueStr = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestValuesEqual pins the idempotency decision: equal means ensure performs no
+// write. Includes whitespace trimming and numeric tolerance (10 == 10.0).
+func TestValuesEqual(t *testing.T) {
+	cases := []struct {
+		name    string
+		cur     consumer.Value
+		desired string
+		want    bool
+	}{
+		{"enum match", consumer.Value{Kind: consumer.KindEnum, Str: "On"}, "On", true},
+		{"enum mismatch", consumer.Value{Kind: consumer.KindEnum, Str: "On"}, "Off", false},
+		{"enum trims whitespace", consumer.Value{Kind: consumer.KindEnum, Str: "On"}, "  On ", true},
+		{"string match", consumer.Value{Kind: consumer.KindString, Str: "hi"}, "hi", true},
+		{"int exact", consumer.Value{Kind: consumer.KindInt, Int: 10}, "10", true},
+		{"int tolerance 10 vs 10.0", consumer.Value{Kind: consumer.KindInt, Int: 10}, "10.0", true},
+		{"int mismatch", consumer.Value{Kind: consumer.KindInt, Int: 10}, "11", false},
+		{"float tolerance 3 vs 3.0", consumer.Value{Kind: consumer.KindFloat, Float: 3}, "3.0", true},
+		{"float mismatch", consumer.Value{Kind: consumer.KindFloat, Float: 3}, "4", false},
+		{"ipaddr match", consumer.Value{Kind: consumer.KindIPAddr, IPAddr: [4]byte{0, 0, 0, 0}}, "0.0.0.0", true},
+		{"ipaddr mismatch", consumer.Value{Kind: consumer.KindIPAddr, IPAddr: [4]byte{0, 0, 0, 0}}, "10.0.0.1", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := valuesEqual(tc.cur, tc.desired); got != tc.want {
+				t.Errorf("valuesEqual = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/dhs/main.go
+++ b/cmd/dhs/main.go
@@ -119,6 +119,7 @@ var commands = []command{
 	{"tree", "render the device object tree as ASCII or PlantUML mindmap (R5b)", helpTree, runTree},
 	{"get", "read one object value", helpGet, runGet},
 	{"set", "write one object value", helpSet, runSet},
+	{"ensure", "converge an object to --value, idempotently (--check dry-run; ADR-0007)", helpEnsure, runEnsure},
 	{"watch", "subscribe to live announcements", helpWatch, runWatch},
 	{"export", "dump a walked device to json / yaml / csv", helpExport, runExport},
 	{"import", "apply values from a json snapshot file", helpImport, runImport},

--- a/scripts/acp1/verify-ensure.ps1
+++ b/scripts/acp1/verify-ensure.ps1
@@ -1,0 +1,50 @@
+# scripts/acp1/verify-ensure.ps1 - repeatable acp1 `ensure` integration test.
+#
+# Drives the real dhs CLI against a live ACP1 device/emulator and asserts the
+# idempotency contract (read -> set-if-different -> changed; run-twice = 0
+# changes). Per ADR-0025 deliverable 3 + docs/protocols/verb-tests.md tier 3.
+#
+# Oracle: a real ACP1 device or the Synapse Simulator - NOT our own provider.
+#
+# Usage:
+#   $env:ACP1_TEST_HOST = '10.6.239.113'
+#   .\scripts\acp1\verify-ensure.ps1
+# Skips (exit 0) when ACP1_TEST_HOST is unset.
+
+$target = $env:ACP1_TEST_HOST
+if (-not $target) { Write-Host 'SKIP: ACP1_TEST_HOST not set'; exit 0 }
+
+$dhs = Join-Path $PSScriptRoot '..\..\bin\dhs.exe'
+if (-not (Test-Path $dhs)) {
+    Write-Error "dhs binary not found at $dhs (build: go build -o bin/dhs.exe ./cmd/dhs)"
+    exit 1
+}
+
+$sel  = @('--slot', '0', '--group', 'control', '--label', 'Broadcasts')
+$fail = 0
+function Check($name, $cond, $detail) {
+    if ($cond) { Write-Host "PASS  $name" }
+    else { Write-Host "FAIL  $name`n      got: $detail"; $script:fail++ }
+}
+
+# 1. dry-run: already On -> would_change=false, no write
+$r = & $dhs consumer acp1 ensure $target @sel --value On --check --json 2>$null
+Check 'check On is a no-op (would_change=false)' ($r -match '"would_change":false') $r
+
+# 2. apply On while already On -> changed=false (idempotent no-op)
+$r = & $dhs consumer acp1 ensure $target @sel --value On --json 2>$null
+Check 'apply On already converged (changed=false)' ($r -match '"changed":false') $r
+
+# 3. apply Off -> changed=true
+$r = & $dhs consumer acp1 ensure $target @sel --value Off --json 2>$null
+Check 'apply Off changes the value (changed=true)' ($r -match '"changed":true') $r
+
+# 4. apply Off again -> changed=false  (the idempotency proof: run-twice = 0 changes)
+$r = & $dhs consumer acp1 ensure $target @sel --value Off --json 2>$null
+Check 'apply Off twice is idempotent (changed=false)' ($r -match '"changed":false') $r
+
+# restore to On (leave the device as we found it)
+& $dhs consumer acp1 ensure $target @sel --value On 2>$null | Out-Null
+
+if ($fail -eq 0) { Write-Host "`nensure: ALL PASS"; exit 0 }
+Write-Host "`nensure: $fail FAILED"; exit 1


### PR DESCRIPTION
Generic idempotent ensure verb + unit + integration tests, built on the Protocol interface. go vet + golangci-lint clean; unit ok; integration ALL PASS vs the Synapse emulator (run-twice = 0 changes). Closes #513