### PR TITLE
feat(acp1): client-side value validation for ensure - bad input is exit 2

### DIFF
--- a/cmd/dhs/cmd_ensure.go
+++ b/cmd/dhs/cmd_ensure.go
@@ -122,6 +122,22 @@ func runEnsure(ctx context.Context, args []string) error {
 	}
 
 	desired := strings.TrimSpace(*valueStr)
+
+	// Coerce --value to the object's kind so numeric range / type checks see
+	// a typed value (not a bare string), then pre-flight it through the
+	// plugin's client-side validator. Bad input is a validation error
+	// (exit 2 per error-codes.md) caught before any wire write — and before
+	// --check reports, so a dry-run rejects bad values too.
+	want, cerr := coerceDesired(current.Kind, desired)
+	if cerr != nil {
+		return cerr
+	}
+	if v, ok := plug.(consumer.ValueValidator); ok {
+		if verr := v.ValidateValue(opCtx, req, want); verr != nil {
+			return verr
+		}
+	}
+
 	curStr := canonicalValueStr(current)
 	changed := !valuesEqual(current, desired)
 
@@ -131,7 +147,7 @@ func runEnsure(ctx context.Context, args []string) error {
 	if !changed {
 		return emitEnsure(*asJSON, ensureResult{Changed: &changed, Previous: curStr, Current: curStr})
 	}
-	confirmed, err := plug.SetValue(opCtx, req, consumer.Value{Str: desired})
+	confirmed, err := plug.SetValue(opCtx, req, want)
 	if err != nil {
 		return err
 	}
@@ -203,6 +219,43 @@ func valuesEqual(cur consumer.Value, desired string) bool {
 		return e1 == nil && e2 == nil && cf == df
 	}
 	return false
+}
+
+// coerceDesired converts the --value string into a typed Value of the object's
+// kind so the client-side validator can range/type-check it. Str is always
+// retained so SetValue's encoder still sees the original text. Unparseable
+// input is a validation error (exit 2).
+func coerceDesired(kind consumer.ValueKind, s string) (consumer.Value, error) {
+	v := consumer.Value{Kind: kind, Str: s}
+	switch kind {
+	case consumer.KindInt:
+		n, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return v, ensureValErr(fmt.Sprintf("invalid integer %q", s))
+		}
+		v.Int = n
+	case consumer.KindUint:
+		n, err := strconv.ParseUint(s, 10, 64)
+		if err != nil {
+			return v, ensureValErr(fmt.Sprintf("invalid unsigned integer %q", s))
+		}
+		v.Uint = n
+	case consumer.KindFloat:
+		f, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return v, ensureValErr(fmt.Sprintf("invalid number %q", s))
+		}
+		v.Float = f
+	case consumer.KindBool:
+		b, err := strconv.ParseBool(s)
+		if err != nil {
+			return v, ensureValErr(fmt.Sprintf("invalid boolean %q", s))
+		}
+		v.Bool = b
+	}
+	// enum / string / ipaddr / alarm: Str carries the value; the validator
+	// checks it directly (enum membership, dotted-quad parse).
+	return v, nil
 }
 
 func helpEnsure() {

--- a/cmd/dhs/cmd_ensure_test.go
+++ b/cmd/dhs/cmd_ensure_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"testing"
 
 	"dhs/internal/consumer"
@@ -62,4 +63,69 @@ func TestValuesEqual(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestCoerceDesired pins the --value typing that feeds the client-side
+// validator: parseable input yields a typed Value of the object's kind (so
+// range/type checks see a number, not a bare string); unparseable input is a
+// *consumer.ValidationError (exit 2 per error-codes.md), never a runtime error.
+// Str is always retained so the SetValue encoder still sees the original text.
+func TestCoerceDesired(t *testing.T) {
+	t.Run("parseable", func(t *testing.T) {
+		cases := []struct {
+			name string
+			kind consumer.ValueKind
+			in   string
+			chk  func(consumer.Value) bool
+		}{
+			{"int", consumer.KindInt, "-3", func(v consumer.Value) bool { return v.Int == -3 }},
+			{"uint", consumer.KindUint, "10", func(v consumer.Value) bool { return v.Uint == 10 }},
+			{"float", consumer.KindFloat, "3.5", func(v consumer.Value) bool { return v.Float == 3.5 }},
+			{"bool", consumer.KindBool, "true", func(v consumer.Value) bool { return v.Bool }},
+			{"enum keeps str", consumer.KindEnum, "On", func(v consumer.Value) bool { return v.Str == "On" }},
+			{"string keeps str", consumer.KindString, "hi", func(v consumer.Value) bool { return v.Str == "hi" }},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				v, err := coerceDesired(tc.kind, tc.in)
+				if err != nil {
+					t.Fatalf("coerceDesired(%v, %q) err = %v, want nil", tc.kind, tc.in, err)
+				}
+				if v.Kind != tc.kind {
+					t.Errorf("Kind = %v, want %v", v.Kind, tc.kind)
+				}
+				if v.Str != tc.in {
+					t.Errorf("Str = %q, want %q (original text must be retained)", v.Str, tc.in)
+				}
+				if !tc.chk(v) {
+					t.Errorf("typed field not populated for %v from %q: %+v", tc.kind, tc.in, v)
+				}
+			})
+		}
+	})
+
+	t.Run("unparseable is exit-2 validation error", func(t *testing.T) {
+		cases := []struct {
+			name string
+			kind consumer.ValueKind
+			in   string
+		}{
+			{"int", consumer.KindInt, "abc"},
+			{"uint", consumer.KindUint, "-1"},
+			{"float", consumer.KindFloat, "x"},
+			{"bool", consumer.KindBool, "maybe"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := coerceDesired(tc.kind, tc.in)
+				if err == nil {
+					t.Fatalf("coerceDesired(%v, %q) err = nil, want validation error", tc.kind, tc.in)
+				}
+				var verr *consumer.ValidationError
+				if !errors.As(err, &verr) {
+					t.Errorf("err = %T, want *consumer.ValidationError (exit 2)", err)
+				}
+			})
+		}
+	})
 }

--- a/internal/acp1/consumer/value_validate.go
+++ b/internal/acp1/consumer/value_validate.go
@@ -219,30 +219,15 @@ func validateValueAgainstType(t codec.ObjectType, obj consumer.Object, val consu
 		return nil
 
 	case codec.TypeEnum:
-		// Accept Str that matches an EnumItem.
-		if val.Str != "" {
-			for _, item := range obj.EnumItems {
-				if item == val.Str {
-					return nil
-				}
-			}
-		}
-		// Accept numeric index within range.
-		var idx int
-		switch val.Kind {
-		case consumer.KindEnum, consumer.KindUint:
-			idx = int(val.Uint)
-			if val.Kind == consumer.KindEnum && val.Uint == 0 {
-				idx = int(val.Enum)
-			}
-		case consumer.KindInt:
-			idx = int(val.Int)
-		default:
-			return fmt.Errorf("%w: enum object got non-enum kind %v", consumer.ErrValidationFailed, val.Kind)
-		}
-		if idx < 0 || idx >= len(obj.EnumItems) {
-			return fmt.Errorf("%w: enum index %d (label %q) not in %d options",
-				consumer.ErrValidationFailed, idx, val.Str, len(obj.EnumItems))
+		// Delegate to the same resolver the encoder uses (coerceEnum) so the
+		// pre-flight check accepts EXACTLY what SetValue would accept: a known
+		// label OR a numeric index in range. A non-empty value that is neither
+		// (e.g. a mistyped option name) is rejected here as a client-side
+		// validation error (exit 2) instead of failing later at encode time
+		// (exit 1). Previously this branch treated an unmatched non-numeric
+		// label as index 0 and wrongly accepted it.
+		if _, err := coerceEnum(obj.EnumItems, val); err != nil {
+			return fmt.Errorf("%w: %v", consumer.ErrValidationFailed, err)
 		}
 		return nil
 

--- a/internal/acp1/consumer/value_validate_test.go
+++ b/internal/acp1/consumer/value_validate_test.go
@@ -62,6 +62,27 @@ func TestValidateValueAgainstType_Enum_OutOfOptionsRejects(t *testing.T) {
 	}
 }
 
+// Regression: a mistyped option name with no numeric index (Str set, Enum 0)
+// must be rejected, not silently treated as index 0. This is the input shape
+// `ensure --value Bogus` produces, and it must fail pre-flight (exit 2) the
+// same way the encoder's coerceEnum rejects it (was wrongly accepted before).
+func TestValidateValueAgainstType_Enum_UnknownLabelNoIndexRejects(t *testing.T) {
+	obj := consumer.Object{Access: rw, Kind: consumer.KindEnum, EnumItems: []string{"Off", "On", "Auto"}}
+	val := consumer.Value{Kind: consumer.KindEnum, Str: "Bogus"}
+	if err := validateValueAgainstType(codec.TypeEnum, obj, val); !errors.Is(err, consumer.ErrValidationFailed) {
+		t.Fatalf("want ErrValidationFailed for unknown label, got %v", err)
+	}
+}
+
+// A numeric index supplied as a string ("--value 2") is accepted when in range.
+func TestValidateValueAgainstType_Enum_NumericStringIndexAccepted(t *testing.T) {
+	obj := consumer.Object{Access: rw, Kind: consumer.KindEnum, EnumItems: []string{"Off", "On", "Auto"}}
+	val := consumer.Value{Kind: consumer.KindEnum, Str: "2"}
+	if err := validateValueAgainstType(codec.TypeEnum, obj, val); err != nil {
+		t.Fatalf("want nil for in-range numeric index, got %v", err)
+	}
+}
+
 func TestValidateValueAgainstType_Enum_KnownLabelAccepted(t *testing.T) {
 	obj := consumer.Object{Access: rw, Kind: consumer.KindEnum, EnumItems: []string{"Off", "On", "Auto"}}
 	val := consumer.Value{Kind: consumer.KindEnum, Str: "Auto"}

--- a/scripts/acp1/verify-ensure.ps1
+++ b/scripts/acp1/verify-ensure.ps1
@@ -43,6 +43,16 @@ Check 'apply Off changes the value (changed=true)' ($r -match '"changed":true') 
 $r = & $dhs consumer acp1 ensure $target @sel --value Off --json 2>$null
 Check 'apply Off twice is idempotent (changed=false)' ($r -match '"changed":false') $r
 
+# 5. bad enum value -> client-side validation rejects it with exit 2 (NOT a wire
+#    write, NOT exit 1). This is what Ansible's failed_when keys on.
+& $dhs consumer acp1 ensure $target @sel --value Bogus 2>$null | Out-Null
+Check 'bad enum value rejected with exit 2' ($LASTEXITCODE -eq 2) "exit=$LASTEXITCODE"
+
+# 6. --check with a bad value also rejects (validation runs before the dry-run
+#    report, so a dry-run cannot mask bad input).
+& $dhs consumer acp1 ensure $target @sel --value Bogus --check 2>$null | Out-Null
+Check 'bad value rejected even under --check (exit 2)' ($LASTEXITCODE -eq 2) "exit=$LASTEXITCODE"
+
 # restore to On (leave the device as we found it)
 & $dhs consumer acp1 ensure $target @sel --value On 2>$null | Out-Null
 


### PR DESCRIPTION
## What

`ensure --value` is now validated client-side before any wire write, so bad input fails as **exit 2** (validation) instead of **exit 1** (runtime/wire). This is the class distinction Ansible's `failed_when` relies on.

## Why

Per `docs/protocols/error-codes.md`: exit 0 ok / 1 runtime-wire / 2 usage-validation. Previously a mistyped `--value` reached the encoder and failed at the wire layer → exit 1. A dry-run (`--check`) didn't validate at all, so bad input was silently reported as "would change".

## How

- **cmd/dhs/cmd_ensure.go** — coerce `--value` to the object's kind (so numeric range/type checks see a typed value, not a bare string), then call `ValidateValue` (`consumer.ValueValidator`) before `SetValue`. Validation runs **before** the `--check` branch, so a dry-run also rejects bad input. The coerced typed value is what gets written.
- **internal/acp1/consumer/value_validate.go** — the enum pre-flight now delegates to `coerceEnum`, the same resolver the encoder uses, so validation accepts **exactly** what `SetValue` accepts (known label OR in-range numeric index). Fixes a real bug: a mistyped option name with no numeric index (`Str` set, `Enum` 0) was treated as index 0 and wrongly accepted, then failed later at encode (exit 1).

## Tests

- Unit: `coerceDesired` (parseable → typed value; unparseable → exit-2 `ValidationError`); enum validator (unknown label rejects, numeric-string index accepts).
- Integration (`scripts/acp1/verify-ensure.ps1`): bad enum value → exit 2 on both the apply and `--check` paths. **ALL PASS** vs the Synapse emulator. Idempotency contract still green (run-twice = 0 changes).

Closes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)
