### PR TITLE
fix(acp1): ensure predicts device clamp so out-of-range stays idempotent

### DIFF
--- a/cmd/dhs/cmd_ensure.go
+++ b/cmd/dhs/cmd_ensure.go
@@ -138,11 +138,23 @@ func runEnsure(ctx context.Context, args []string) error {
 		}
 	}
 
+	// Predict the value the device will actually store. ACP1 clamps an
+	// out-of-range numeric setValue to [min,max] (spec p.28; emulator-verified:
+	// NetwPrefix max=32 stores 32 for a requested 100) rather than rejecting
+	// it. Comparing the raw --value would make `ensure --value 100` on a 0..32
+	// object report changed on every run (100 != stored 32). Clamping to the
+	// object's range client-side keeps the idempotency decision — and the
+	// --check dry-run — consistent with what the device will do.
+	target := desired
+	if meta := findObjectMeta(plug, *slot, *group, *label, *id); meta != nil {
+		target = predictStored(meta, current.Kind, desired)
+	}
+
 	curStr := canonicalValueStr(current)
-	changed := !valuesEqual(current, desired)
+	changed := !valuesEqual(current, target)
 
 	if *check {
-		return emitEnsure(*asJSON, ensureResult{WouldChange: &changed, Current: curStr, Target: desired})
+		return emitEnsure(*asJSON, ensureResult{WouldChange: &changed, Current: curStr, Target: target})
 	}
 	if !changed {
 		return emitEnsure(*asJSON, ensureResult{Changed: &changed, Previous: curStr, Current: curStr})
@@ -152,7 +164,11 @@ func runEnsure(ctx context.Context, args []string) error {
 		return err
 	}
 	newStr := canonicalValueStr(confirmed)
-	return emitEnsure(*asJSON, ensureResult{Changed: &changed, Previous: curStr, Current: newStr})
+	// Report the change actually observed (current -> confirmed), not the
+	// pre-set prediction, so a write that the device clamps back onto the
+	// current value still reports changed=false.
+	applied := !valuesEqual(current, newStr)
+	return emitEnsure(*asJSON, ensureResult{Changed: &applied, Previous: curStr, Current: newStr})
 }
 
 // ensureResult is the structured outcome (ADR-0007 shape, simplified for the
@@ -256,6 +272,111 @@ func coerceDesired(kind consumer.ValueKind, s string) (consumer.Value, error) {
 	// enum / string / ipaddr / alarm: Str carries the value; the validator
 	// checks it directly (enum membership, dotted-quad parse).
 	return v, nil
+}
+
+// findObjectMeta returns the cached walker Object for the resolved target so
+// ensure can read its numeric range. Matches by (group, id) first — ensure has
+// already resolved --path/--label to an id — then falls back to label. The
+// plugin's Walk is cached per slot, so this is a lookup, not a device hit.
+// Returns nil on miss (e.g. Ember+, where ensure doesn't pre-clamp).
+func findObjectMeta(plug consumer.Protocol, slot int, group, label string, id int) *consumer.Object {
+	objs, err := plug.Walk(context.Background(), slot)
+	if err != nil {
+		return nil
+	}
+	if id >= 0 {
+		for i := range objs {
+			if objs[i].ID == id && (group == "" || strings.EqualFold(objs[i].Group, group)) {
+				return &objs[i]
+			}
+		}
+	}
+	if label != "" {
+		for i := range objs {
+			if objs[i].Label == label && (group == "" || strings.EqualFold(objs[i].Group, group)) {
+				return &objs[i]
+			}
+		}
+	}
+	return nil
+}
+
+// predictStored returns the canonical string the device will store for a
+// setValue of `desired` on meta — clamped to the object's [min,max]. ACP1
+// clamps out-of-range numerics rather than rejecting them (spec p.28), so
+// mirroring that here keeps `ensure` idempotent and `--check` accurate. Only
+// numeric kinds are clamped; enum/string/ipaddr pass through unchanged (enums
+// are validated by membership, strings are length-checked client-side, and the
+// device echoes them verbatim).
+func predictStored(meta *consumer.Object, kind consumer.ValueKind, desired string) string {
+	s := strings.TrimSpace(desired)
+	if meta == nil {
+		return s
+	}
+	switch kind {
+	case consumer.KindInt, consumer.KindUint:
+		iv, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			f, ferr := strconv.ParseFloat(s, 64)
+			if ferr != nil {
+				return s
+			}
+			iv = int64(f)
+		}
+		if lo, ok := anyToFloat(meta.Min); ok && float64(iv) < lo {
+			iv = int64(lo)
+		}
+		if hi, ok := anyToFloat(meta.Max); ok && float64(iv) > hi {
+			iv = int64(hi)
+		}
+		return strconv.FormatInt(iv, 10)
+	case consumer.KindFloat:
+		fv, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return s
+		}
+		if lo, ok := anyToFloat(meta.Min); ok && fv < lo {
+			fv = lo
+		}
+		if hi, ok := anyToFloat(meta.Max); ok && fv > hi {
+			fv = hi
+		}
+		return strconv.FormatFloat(fv, 'g', -1, 64)
+	}
+	return s
+}
+
+// anyToFloat coerces a numeric `any` (consumer.Object.Min/Max are int64 /
+// uint64 / float64 depending on the object's ACP1 wire type) to float64 for
+// range comparison. Returns false for non-numeric or nil.
+func anyToFloat(v any) (float64, bool) {
+	switch n := v.(type) {
+	case int:
+		return float64(n), true
+	case int8:
+		return float64(n), true
+	case int16:
+		return float64(n), true
+	case int32:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case uint:
+		return float64(n), true
+	case uint8:
+		return float64(n), true
+	case uint16:
+		return float64(n), true
+	case uint32:
+		return float64(n), true
+	case uint64:
+		return float64(n), true
+	case float32:
+		return float64(n), true
+	case float64:
+		return n, true
+	}
+	return 0, false
 }
 
 func helpEnsure() {

--- a/cmd/dhs/cmd_ensure_test.go
+++ b/cmd/dhs/cmd_ensure_test.go
@@ -129,3 +129,39 @@ func TestCoerceDesired(t *testing.T) {
 		}
 	})
 }
+
+// TestPredictStored pins the client-side clamp that keeps ensure idempotent
+// against ACP1's device-side clamping: an out-of-range numeric --value is
+// predicted as the [min,max]-clamped value the device will actually store, so
+// the second run sees no change. Non-numeric kinds and nil meta pass through.
+func TestPredictStored(t *testing.T) {
+	uintMeta := &consumer.Object{Kind: consumer.KindUint, Min: uint64(0), Max: uint64(32)}
+	intMeta := &consumer.Object{Kind: consumer.KindInt, Min: int64(-50), Max: int64(150)}
+	floatMeta := &consumer.Object{Kind: consumer.KindFloat, Min: float64(0), Max: float64(10)}
+	cases := []struct {
+		name    string
+		meta    *consumer.Object
+		kind    consumer.ValueKind
+		desired string
+		want    string
+	}{
+		{"uint above max clamps", uintMeta, consumer.KindUint, "100", "32"},
+		{"uint in range passes", uintMeta, consumer.KindUint, "20", "20"},
+		{"uint at max passes", uintMeta, consumer.KindUint, "32", "32"},
+		{"int below min clamps", intMeta, consumer.KindInt, "-999", "-50"},
+		{"int above max clamps", intMeta, consumer.KindInt, "999", "150"},
+		{"int in range passes", intMeta, consumer.KindInt, "0", "0"},
+		{"float above max clamps", floatMeta, consumer.KindFloat, "12.5", "10"},
+		{"float in range passes", floatMeta, consumer.KindFloat, "3.5", "3.5"},
+		{"nil meta passes through", nil, consumer.KindUint, "100", "100"},
+		{"enum passes through", uintMeta, consumer.KindEnum, "On", "On"},
+		{"whitespace trimmed", uintMeta, consumer.KindUint, "  20 ", "20"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := predictStored(tc.meta, tc.kind, tc.desired); got != tc.want {
+				t.Errorf("predictStored = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/acp1/consumer/value_validate.go
+++ b/internal/acp1/consumer/value_validate.go
@@ -135,21 +135,13 @@ func validateValueAgainstType(t codec.ObjectType, obj consumer.Object, val consu
 		if val.Kind == consumer.KindString && val.Str != "" {
 			return fmt.Errorf("%w: integer object got string value %q", consumer.ErrValidationFailed, val.Str)
 		}
-		v := val.Int
-		// Cross-kind tolerance: KindUint / KindFloat callers can still
-		// resolve to a valid int. Float gets truncated.
-		if val.Kind == consumer.KindUint {
-			v = int64(val.Uint)
-		}
-		if val.Kind == consumer.KindFloat {
-			v = int64(val.Float)
-		}
-		if mn, ok := obj.Min.(int64); ok && v < mn {
-			return fmt.Errorf("%w: value %d below Min %d", consumer.ErrValidationFailed, v, mn)
-		}
-		if mx, ok := obj.Max.(int64); ok && v > mx {
-			return fmt.Errorf("%w: value %d above Max %d", consumer.ErrValidationFailed, v, mx)
-		}
+		// Out-of-range is intentionally NOT rejected. ACP1 devices clamp a
+		// setValue to [min,max] (spec p.28 "clamp to [min,max]"; verified on
+		// the Synapse emulator: NetwPrefix max=32 accepts 100 and stores 32).
+		// Rejecting here would make the consumer stricter than the device and
+		// break `ensure` idempotency — the consumer predicts the clamped value
+		// client-side instead (cmd/dhs predictStored). Type mismatch above is
+		// still a real client-side error the device cannot coerce away.
 		return nil
 
 	case codec.TypeByte:
@@ -177,24 +169,14 @@ func validateValueAgainstType(t codec.ObjectType, obj consumer.Object, val consu
 		if val.Kind == consumer.KindUnknown {
 			return fmt.Errorf("%w: float object got unparseable value", consumer.ErrValidationFailed)
 		}
-		f := val.Float
-		switch val.Kind {
-		case consumer.KindInt:
-			f = float64(val.Int)
-		case consumer.KindUint:
-			f = float64(val.Uint)
-		case consumer.KindString:
+		if val.Kind == consumer.KindString {
 			if val.Str == "" {
 				return fmt.Errorf("%w: float object got empty value", consumer.ErrValidationFailed)
 			}
 			return fmt.Errorf("%w: float object got string value %q", consumer.ErrValidationFailed, val.Str)
 		}
-		if mn, ok := obj.Min.(float64); ok && f < mn {
-			return fmt.Errorf("%w: value %v below Min %v", consumer.ErrValidationFailed, f, mn)
-		}
-		if mx, ok := obj.Max.(float64); ok && f > mx {
-			return fmt.Errorf("%w: value %v above Max %v", consumer.ErrValidationFailed, f, mx)
-		}
+		// Out-of-range is NOT rejected — the device clamps to [min,max], same
+		// as the Integer case above. The consumer predicts the clamped result.
 		return nil
 
 	case codec.TypeIPAddr:

--- a/internal/acp1/consumer/value_validate_test.go
+++ b/internal/acp1/consumer/value_validate_test.go
@@ -22,19 +22,23 @@ func TestValidateValueAgainstType_Integer_BadKindRejects(t *testing.T) {
 	}
 }
 
-func TestValidateValueAgainstType_Integer_BelowMinRejects(t *testing.T) {
+// Out-of-range numerics are NOT a validation error: ACP1 devices clamp a
+// setValue to [min,max] (spec p.28; emulator-verified). The validator must not
+// be stricter than the device — the consumer predicts the clamped value
+// client-side (cmd/dhs predictStored) to stay idempotent. Was a reject before.
+func TestValidateValueAgainstType_Integer_BelowMinAccepted(t *testing.T) {
 	obj := consumer.Object{Access: rw, Kind: consumer.KindInt, Min: int64(0), Max: int64(65535)}
 	val := consumer.Value{Kind: consumer.KindInt, Int: -1}
-	if err := validateValueAgainstType(codec.TypeInteger, obj, val); !errors.Is(err, consumer.ErrValidationFailed) {
-		t.Fatalf("want ErrValidationFailed, got %v", err)
+	if err := validateValueAgainstType(codec.TypeInteger, obj, val); err != nil {
+		t.Fatalf("want nil (device clamps to min), got %v", err)
 	}
 }
 
-func TestValidateValueAgainstType_Integer_AboveMaxRejects(t *testing.T) {
+func TestValidateValueAgainstType_Integer_AboveMaxAccepted(t *testing.T) {
 	obj := consumer.Object{Access: rw, Kind: consumer.KindInt, Min: int64(0), Max: int64(65535)}
 	val := consumer.Value{Kind: consumer.KindInt, Int: 999999}
-	if err := validateValueAgainstType(codec.TypeInteger, obj, val); !errors.Is(err, consumer.ErrValidationFailed) {
-		t.Fatalf("want ErrValidationFailed, got %v", err)
+	if err := validateValueAgainstType(codec.TypeInteger, obj, val); err != nil {
+		t.Fatalf("want nil (device clamps to max), got %v", err)
 	}
 }
 

--- a/scripts/acp1/verify-ensure.ps1
+++ b/scripts/acp1/verify-ensure.ps1
@@ -53,6 +53,27 @@ Check 'bad enum value rejected with exit 2' ($LASTEXITCODE -eq 2) "exit=$LASTEXI
 & $dhs consumer acp1 ensure $target @sel --value Bogus --check 2>$null | Out-Null
 Check 'bad value rejected even under --check (exit 2)' ($LASTEXITCODE -eq 2) "exit=$LASTEXITCODE"
 
+# --- numeric clamp idempotency (NetwPrefix: uint, range 0..32) -------------
+# ACP1 devices clamp an out-of-range setValue to [min,max] (spec p.28) instead
+# of rejecting it. ensure predicts that clamp client-side so it stays
+# idempotent and --check stays accurate.
+$nsel = @('--slot', '0', '--group', 'control', '--label', 'NetwPrefix')
+& $dhs consumer acp1 ensure $target @nsel --value 0 2>$null | Out-Null   # baseline
+
+# 7. out-of-range value converges to the clamped max (0 -> 32)
+$r = & $dhs consumer acp1 ensure $target @nsel --value 100 --json 2>$null
+Check 'out-of-range converges to clamped max (changed=true)' ($r -match '"changed":true') $r
+
+# 8. same out-of-range value again is a no-op: device already sits at clamp 32
+$r = & $dhs consumer acp1 ensure $target @nsel --value 100 --json 2>$null
+Check 'out-of-range is idempotent at clamp (changed=false)' ($r -match '"changed":false') $r
+
+# 9. --check predicts the clamp: would_change=false while sitting at 32
+$r = & $dhs consumer acp1 ensure $target @nsel --value 100 --check --json 2>$null
+Check 'check predicts clamp (would_change=false)' ($r -match '"would_change":false') $r
+
+& $dhs consumer acp1 ensure $target @nsel --value 0 2>$null | Out-Null   # restore
+
 # restore to On (leave the device as we found it)
 & $dhs consumer acp1 ensure $target @sel --value On 2>$null | Out-Null
 


### PR DESCRIPTION
## What

`ensure` now predicts ACP1's device-side clamp, so an out-of-range numeric `--value` stays idempotent instead of reporting `changed` on every run.

## Why

ACP1 devices **clamp** an out-of-range numeric `setValue` to `[min,max]` (spec p.28) — they do not reject it. Verified live on the Synapse emulator: `NetwPrefix` (range 0..32) ← 100 returns `confirmed=32`, exit 0.

[#516](https://github.com/by-openclaw/go-acp/pull/516)'s client-side validator rejected out-of-range numerics with exit 2, making the consumer stricter than the device and breaking idempotency:

| Run | current | desired | device stores | #516 result | this PR |
|---|---|---|---|---|---|
| 1 | 0 | 100 | 32 | exit 2 (reject) | changed=true → 32 |
| 2 | 32 | 100 | 32 | exit 2 (reject) | changed=false (no-op) |

## How

- **value_validate.go** — stop rejecting out-of-range on the integer/long/float branches (the device clamps). Type-mismatch, enum membership, read-only, and malformed-IP checks stay — the device genuinely rejects those. This also relaxes the import dry-run, consistent with device behaviour.
- **cmd_ensure.go** — `predictStored` clamps `--value` to the resolved object's `[min,max]` client-side; the idempotency decision and `--check` both run off that prediction. After the write, `changed` is recomputed from `current → confirmed` so a clamp landing on the current value reports `changed=false`. `findObjectMeta` reads the cached walker Object for the range.

## Tests

- Unit: `predictStored` (clamp above/below/in-range for uint/int/float; pass-through for enum/nil); validator units flipped to expect acceptance of out-of-range.
- Integration (`scripts/acp1/verify-ensure.ps1`): out-of-range converges to clamped max, rerun is a no-op (`changed=false`), `--check` predicts the clamp. **ALL PASS (9/9)** vs the Synapse emulator.

## Out of scope

Step-snapping and string truncation are device coercions left for later: spec p.28 specifies clamp only, and no emulator object exercises them yet.

Closes #517

🤖 Generated with [Claude Code](https://claude.com/claude-code)
