### PR TITLE
feat(acp1): provider serves a populated multi-card frame from the tree

### DIFF
--- a/cmd/dhs/cmd_producer.go
+++ b/cmd/dhs/cmd_producer.go
@@ -90,7 +90,6 @@ func runProducer(ctx context.Context, protoName string, args []string) error {
 	}
 
 	var tree *canonical.Export
-	var manifestSlots []uint8
 	if *manifestPath != "" {
 		mf, err := manifest.Load(*manifestPath)
 		if err != nil {
@@ -102,20 +101,6 @@ func runProducer(ctx context.Context, protoName string, args []string) error {
 		tree, err = manifest.BuildExport(mf, *cacheDir)
 		if err != nil {
 			return fmt.Errorf("build tree from manifest: %w", err)
-		}
-		for _, fr := range mf.Frames {
-			for _, sl := range fr.Slots {
-				if v, ok := sl.Addr["slot"]; ok {
-					switch x := v.(type) {
-					case float64:
-						manifestSlots = append(manifestSlots, uint8(x))
-					case int:
-						manifestSlots = append(manifestSlots, uint8(x))
-					case int64:
-						manifestSlots = append(manifestSlots, uint8(x))
-					}
-				}
-			}
 		}
 		logger.Info("producer manifest loaded",
 			slog.String("path", *manifestPath),
@@ -138,13 +123,17 @@ func runProducer(ctx context.Context, protoName string, args []string) error {
 	addr := fmt.Sprintf("%s:%d", *host, listenPort)
 
 	srv := factory.New(logger, tree)
-	if protoName == "acp1" && len(manifestSlots) > 0 {
+	// Initialise the rack-controller frame-status from the served tree so a
+	// multi-card frame (via --tree OR --manifest) reports its populated slots
+	// as present from the first walk, instead of an empty rack. Derived from
+	// the tree itself, so a hand-authored multi-slot tree.json works without a
+	// manifest. --preload installs further slots after this with its own
+	// present-marking.
+	if protoName == "acp1" {
 		if a1, ok := srv.(*acp1provider.Server); ok {
-			if err := a1.MarkSlotsPresent(manifestSlots); err != nil {
-				return fmt.Errorf("acp1 manifest slot-status init: %w", err)
+			if err := a1.MarkTreeSlotsPresent(); err != nil {
+				return fmt.Errorf("acp1 frame-status init: %w", err)
 			}
-			logger.Info("acp1 manifest slots marked present",
-				slog.Int("count", len(manifestSlots)))
 		}
 	}
 

--- a/internal/acp1/provider/mark_present.go
+++ b/internal/acp1/provider/mark_present.go
@@ -2,10 +2,32 @@ package acp1
 
 import (
 	"fmt"
+	"sort"
 
 	"dhs/internal/acp1/codec"
 	"dhs/internal/export/canonical"
 )
+
+// MarkTreeSlotsPresent marks every slot that carries card objects in the
+// served tree as "present" in the rack-controller frame-status object,
+// synthesising that object if absent. It derives the populated slots from the
+// tree itself rather than an explicit list, so a multi-card frame served via
+// --tree (a hand-authored tree.json with several slots) reports a correct
+// frame-status without a manifest — fixing the case where consumers saw an
+// empty rack despite per-slot identities being served. Slots with no card
+// objects stay no_card. Idempotent: a no-card frame leaves frame-status alone.
+func (s *server) MarkTreeSlotsPresent() error {
+	s.tree.mu.RLock()
+	slots := make([]uint8, 0, len(s.tree.slots))
+	for sl, counts := range s.tree.slots {
+		if counts.hasCard() {
+			slots = append(slots, sl)
+		}
+	}
+	s.tree.mu.RUnlock()
+	sort.Slice(slots, func(i, j int) bool { return slots[i] < slots[j] })
+	return s.MarkSlotsPresent(slots)
+}
 
 // MarkSlotsPresent synthesises (if absent) the rack-controller's
 // frame-status object and marks each named slot as "present" (state=2).

--- a/internal/acp1/provider/mark_present_test.go
+++ b/internal/acp1/provider/mark_present_test.go
@@ -1,0 +1,95 @@
+package acp1
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"dhs/internal/acp1/codec"
+	"dhs/internal/export/canonical"
+)
+
+// cardSlot builds a minimal populated card slot: one identity label, enough
+// for newTree to count it as a card (numIdentity > 0).
+func cardSlot(num int, ident, model string) *canonical.Node {
+	r := canonical.AccessRead
+	return &canonical.Node{
+		Header: canonical.Header{
+			Number: num, Identifier: ident, Access: r,
+			Children: []canonical.Element{
+				&canonical.Node{
+					Header: canonical.Header{
+						Number: 1, Identifier: "identity", Access: r,
+						Children: []canonical.Element{
+							&canonical.Parameter{
+								Header: canonical.Header{
+									Number: 0, Identifier: "Model", Access: r,
+									Children: canonical.EmptyChildren(),
+								},
+								Type:  canonical.ParamString,
+								Value: model,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func newServerFromSlots(t *testing.T, slots ...*canonical.Node) *server {
+	t.Helper()
+	children := make([]canonical.Element, len(slots))
+	for i, sl := range slots {
+		children[i] = sl
+	}
+	exp := &canonical.Export{Root: &canonical.Node{
+		Header: canonical.Header{
+			Number: 1, Identifier: "device", Access: canonical.AccessRead,
+			Children: children,
+		},
+	}}
+	return newServer(slog.New(slog.NewTextHandler(io.Discard, nil)), exp)
+}
+
+// TestMarkTreeSlotsPresent_MultiCardFrame is the multi-card frame case: a tree
+// served via --tree with several populated slots and NO frame-status object.
+// MarkTreeSlotsPresent must synthesise frame-status sized to the highest slot
+// and mark each populated slot present (2), leaving gaps as no_card (0). Before
+// this, only the explicit manifest slot list drove frame-status, so a
+// hand-authored multi-slot tree.json served an empty-looking rack.
+func TestMarkTreeSlotsPresent_MultiCardFrame(t *testing.T) {
+	// Slots 0, 1, 3 populated; slot 2 is an empty gap.
+	s := newServerFromSlots(t,
+		cardSlot(0, "slot-0", "RRS18"),
+		cardSlot(1, "slot-1", "GIO-12"),
+		cardSlot(3, "slot-3", "2GS110"),
+	)
+
+	if e := s.tree.entries[objectKey{slot: 0, group: codec.GroupFrame, id: 0}]; e != nil {
+		t.Fatal("setup: frame-status should be absent before MarkTreeSlotsPresent")
+	}
+
+	if err := s.MarkTreeSlotsPresent(); err != nil {
+		t.Fatalf("MarkTreeSlotsPresent: %v", err)
+	}
+
+	want := map[uint8]uint8{0: 2, 1: 2, 2: 0, 3: 2} // present except the gap
+	for slot, st := range want {
+		if got := readSlotStatus(t, s, slot); got != st {
+			t.Errorf("slot %d status = %d, want %d", slot, got, st)
+		}
+	}
+}
+
+// TestMarkTreeSlotsPresent_EmptyFrameNoOp: a tree with no card slots must not
+// synthesise a frame-status object — there is nothing present to report.
+func TestMarkTreeSlotsPresent_EmptyFrameNoOp(t *testing.T) {
+	s := newServerFromSlots(t)
+	if err := s.MarkTreeSlotsPresent(); err != nil {
+		t.Fatalf("MarkTreeSlotsPresent: %v", err)
+	}
+	if e := s.tree.entries[objectKey{slot: 0, group: codec.GroupFrame, id: 0}]; e != nil {
+		t.Error("no cards → frame-status should not be synthesised")
+	}
+}

--- a/internal/acp1/provider/tree.go
+++ b/internal/acp1/provider/tree.go
@@ -140,6 +140,17 @@ type slotCounts struct {
 	numFile     uint8
 }
 
+// hasCard reports whether the slot carries any addressable card object
+// (any non-frame group). A slot synthesised only to host the rack
+// frame-status object has all-zero counts and is not itself a card.
+func (c *slotCounts) hasCard() bool {
+	if c == nil {
+		return false
+	}
+	return c.numIdentity > 0 || c.numControl > 0 || c.numStatus > 0 ||
+		c.numAlarm > 0 || c.numFile > 0
+}
+
 // newTree flattens a canonical.Export into the (slot, group, id) index.
 // Shape expected (mirror of acp1.Canonicalize output):
 //


### PR DESCRIPTION
## What

The ACP1 provider now serves a **populated multi-card frame** from the served tree: frame-status reports every populated slot as present, derived from the tree itself, for both `--tree` and `--manifest`.

## Why

A multi-slot tree was flattened and answered per-slot identity correctly, but the rack-controller frame-status was only initialised from the explicit *manifest* slot list. A frame served via `--tree` (a hand-authored multi-slot tree.json) left frame-status all `no_card`, so a consumer's `info` reported an empty rack even though `walk --slot N` returned each card's identity.

## How

- **mark_present.go** — `MarkTreeSlotsPresent` derives the populated slots from the served tree (slots carrying card objects), marks them present, and synthesises the frame-status object if absent. A no-card tree is left untouched.
- **tree.go** — `slotCounts.hasCard` reports whether a slot carries any addressable card object, so a slot synthesised only to host frame-status is not itself counted as a card.
- **cmd_producer.go** — call `MarkTreeSlotsPresent` for acp1 in both serve modes, replacing the manifest-only path and its slot-list collection. `--preload` still installs further slots afterward.

## Tests

- `mark_present_test.go`: multi-card frame (slots 0,1,3 present; gap slot 2 stays `no_card`; frame-status synthesised + sized to max slot); empty-frame no-op.
- Verified end-to-end over loopback: a 3-slot manifest serve reports all three slots `status=present` via `info`, and `walk --slot 1` returns that slot's own card identity (`2GS110`), distinct from the slot-0 controller (`RRS18`).

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)
