### PR TITLE
feat(acp1): --play all oscillates every slot with random values (slot 0 too)

### DIFF
--- a/cmd/dhs/cmd_producer.go
+++ b/cmd/dhs/cmd_producer.go
@@ -64,7 +64,7 @@ func runProducer(ctx context.Context, protoName string, args []string) error {
 		insertTiming  = fs.String("insert-timing", "real", "acp1 only: cascade timing for slot insert (real / fast)")
 		dmLibraryRoot = fs.String("dm-library", "", "acp1 only: DM library root for admin slot.load (#260)")
 		preload       = fs.String("preload", "", "acp1 only: pre-populate slots at boot with NO cascade. External controllers see a stable device from first walk and don't discard the cached template on producer restart. Format: slot=card[,slot=card,...] e.g. 0=axon/synapse/RRS18-1601/acp1,1=axon/synapse/2GS110-2728/acp1")
-		play          = fs.String("play", "", "acp1 only: comma-separated object paths the producer should oscillate with random values. Each tick fires a spontaneous status announce. Format: 1.<slot+1>.<group>.<id>[,...] e.g. 1.1.3.6,1.1.3.7,1.1.3.10 oscillates Temp_Left + Temp_Right + Rx_Packet_Loss on slot 0")
+		play          = fs.String("play", "", "acp1 only: oscillate objects with random values; each tick fires a spontaneous status announce. Pass `all` to oscillate every oscillatable object on every slot (slot 0 included), or a comma-separated path list 1.<slot+1>.<group>.<id>[,...] e.g. 1.1.3.6,1.1.3.7 oscillates Temp_Left + Temp_Right on slot 0")
 		playEvery     = fs.Duration("play-interval", 2*time.Second, "acp1 only: tick interval for --play")
 	)
 	if err := fs.Parse(args); err != nil {
@@ -293,8 +293,11 @@ func runProducer(ctx context.Context, protoName string, args []string) error {
 		// publishes spontaneous status announces on its own without
 		// any external trigger.
 		if *play != "" {
-			paths := strings.Split(*play, ",")
-			acp1Srv.RunStatusPlay(srvCtx, paths, *playEvery)
+			if strings.EqualFold(strings.TrimSpace(*play), "all") {
+				acp1Srv.RunStatusPlayAll(srvCtx, *playEvery)
+			} else {
+				acp1Srv.RunStatusPlay(srvCtx, strings.Split(*play, ","), *playEvery)
+			}
 		}
 
 		// Admin RPC always runs alongside the wire transports so the

--- a/internal/acp1/provider/play.go
+++ b/internal/acp1/provider/play.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"math/rand"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -54,6 +55,68 @@ func (s *server) RunStatusPlay(ctx context.Context, paths []string, interval tim
 		}
 		go s.playLoop(ctx, key, e, interval)
 	}
+}
+
+// RunStatusPlayAll is the auto-discovery form of RunStatusPlay: instead of
+// naming each object path, it walks the served tree and oscillates EVERY
+// oscillatable object on EVERY slot — including slot 0, the rack controller —
+// with a spontaneous status announce per change. Read-only status objects and
+// writable control objects alike are driven (the provider owns the tree);
+// String / Float / File / Frame / Alarm objects have no natural random form
+// and are skipped. Models a fully live rack where every sensor, counter, and
+// enum on every card drifts on its own — the wire-traffic load a consumer's
+// announce handling must cope with.
+//
+// Stops cleanly on ctx cancellation.
+func (s *server) RunStatusPlayAll(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = 2 * time.Second
+	}
+	keys := s.oscillatableTargets()
+	s.logger.Info("acp1 play all started",
+		slog.Int("objects", len(keys)),
+		slog.Duration("interval", interval))
+	for _, k := range keys {
+		e, ok := s.tree.lookup(k)
+		if !ok {
+			continue
+		}
+		go s.playLoop(ctx, k, e, interval)
+	}
+}
+
+// oscillatableTargets returns every object key in the served tree whose type
+// can be driven by the oscillator (mirrors randomBytesFor), sorted by
+// slot/group/id for deterministic startup. Spans all slots, slot 0 included.
+func (s *server) oscillatableTargets() []objectKey {
+	s.tree.mu.RLock()
+	defer s.tree.mu.RUnlock()
+	keys := make([]objectKey, 0, len(s.tree.entries))
+	for k, e := range s.tree.entries {
+		if e != nil && oscillatable(e.acpType) {
+			keys = append(keys, k)
+		}
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].slot != keys[j].slot {
+			return keys[i].slot < keys[j].slot
+		}
+		if keys[i].group != keys[j].group {
+			return keys[i].group < keys[j].group
+		}
+		return keys[i].id < keys[j].id
+	})
+	return keys
+}
+
+// oscillatable reports whether an object type has a random form the oscillator
+// can produce. Mirrors the type switch in randomBytesFor exactly.
+func oscillatable(t codec.ObjectType) bool {
+	switch t {
+	case codec.TypeInteger, codec.TypeLong, codec.TypeByte, codec.TypeEnum, codec.TypeIPAddr:
+		return true
+	}
+	return false
 }
 
 // playLoop oscillates one entry. A separate goroutine per path so each

--- a/internal/acp1/provider/play_test.go
+++ b/internal/acp1/provider/play_test.go
@@ -1,0 +1,141 @@
+package acp1
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"dhs/internal/acp1/codec"
+	"dhs/internal/export/canonical"
+)
+
+func hintp(s string) *string { return &s }
+
+// playTreeServer builds a 2-slot frame whose objects cover every type the
+// oscillator must include (Byte, Enum, Integer, IPAddr) and every type it must
+// skip (String identity, Frame status). Slot 0 (rack controller) carries
+// oscillatable objects too, so the test can prove "slot 0 included".
+func playTreeServer(t *testing.T) *server {
+	t.Helper()
+	r := canonical.AccessRead
+	rw := canonical.AccessReadWrite
+	param := func(num int, ident, typ, fmtHint string) *canonical.Parameter {
+		p := &canonical.Parameter{
+			Header: canonical.Header{
+				Number: num, Identifier: ident, Access: rw,
+				Children: canonical.EmptyChildren(),
+			},
+			Type: typ,
+		}
+		if fmtHint != "" {
+			p.Format = hintp(fmtHint)
+		}
+		switch typ {
+		case canonical.ParamInteger:
+			p.Value = int64(0)
+		case canonical.ParamEnum:
+			p.Value = int64(0)
+		case canonical.ParamString:
+			p.Value = ""
+		}
+		return p
+	}
+	group := func(num int, ident string, kids ...canonical.Element) *canonical.Node {
+		return &canonical.Node{Header: canonical.Header{
+			Number: num, Identifier: ident, Access: r, Children: kids,
+		}}
+	}
+
+	// Slot 0: rack controller — a Byte + Enum (oscillatable), a String
+	// identity (skip), and the Frame status object (skip).
+	slot0 := &canonical.Node{Header: canonical.Header{
+		Number: 0, Identifier: "slot-0", Access: r,
+		Children: []canonical.Element{
+			group(1, "identity", param(0, "Card name", canonical.ParamString, "")),
+			group(2, "control",
+				param(0, "NetwPrefix", canonical.ParamInteger, "uint8"), // Byte
+				param(1, "Broadcasts", canonical.ParamEnum, ""),         // Enum
+			),
+			group(6, "frame", &canonical.Parameter{
+				Header: canonical.Header{Number: 0, Identifier: "frame-status",
+					Access: r, Children: canonical.EmptyChildren()},
+				Type:   canonical.ParamOctets,
+				Format: hintp("frame"),
+				Value:  []any{int64(2), int64(2)},
+			}),
+		},
+	}}
+
+	// Slot 1: a card with an Integer control (oscillatable).
+	slot1 := &canonical.Node{Header: canonical.Header{
+		Number: 1, Identifier: "slot-1", Access: r,
+		Children: []canonical.Element{
+			group(2, "control", param(0, "Level", canonical.ParamInteger, "")),
+		},
+	}}
+
+	exp := &canonical.Export{Root: &canonical.Node{Header: canonical.Header{
+		Number: 1, Identifier: "device", Access: r,
+		Children: []canonical.Element{slot0, slot1},
+	}}}
+	return newServer(slog.New(slog.NewTextHandler(io.Discard, nil)), exp)
+}
+
+func TestOscillatable(t *testing.T) {
+	cases := []struct {
+		t    codec.ObjectType
+		want bool
+	}{
+		{codec.TypeInteger, true},
+		{codec.TypeLong, true},
+		{codec.TypeByte, true},
+		{codec.TypeEnum, true},
+		{codec.TypeIPAddr, true},
+		{codec.TypeString, false},
+		{codec.TypeFloat, false},
+		{codec.TypeFrame, false},
+		{codec.TypeAlarm, false},
+		{codec.TypeFile, false},
+	}
+	for _, c := range cases {
+		if got := oscillatable(c.t); got != c.want {
+			t.Errorf("oscillatable(%v) = %v, want %v", c.t, got, c.want)
+		}
+	}
+}
+
+// TestOscillatableTargets_SpansAllSlotsInclSlot0 is the heart of the feature:
+// `--play all` must drive every oscillatable object on every slot, slot 0
+// included, and skip String/Frame objects.
+func TestOscillatableTargets_SpansAllSlotsInclSlot0(t *testing.T) {
+	s := playTreeServer(t)
+	got := s.oscillatableTargets()
+
+	want := []objectKey{
+		{slot: 0, group: codec.GroupControl, id: 0}, // slot 0 Byte
+		{slot: 0, group: codec.GroupControl, id: 1}, // slot 0 Enum
+		{slot: 1, group: codec.GroupControl, id: 0}, // slot 1 Integer
+	}
+	if len(got) != len(want) {
+		t.Fatalf("oscillatableTargets = %v (len %d), want len %d", got, len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("target[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+
+	// Explicitly assert slot 0 is represented and the skipped types are not.
+	var sawSlot0 bool
+	for _, k := range got {
+		if k.slot == 0 {
+			sawSlot0 = true
+		}
+		if k.group == codec.GroupIdentity || k.group == codec.GroupFrame {
+			t.Errorf("non-oscillatable object leaked into targets: %+v", k)
+		}
+	}
+	if !sawSlot0 {
+		t.Error("slot 0 objects were not included — --play all must cover slot 0")
+	}
+}


### PR DESCRIPTION
## What

`dhs producer acp1 serve --play all` oscillates every oscillatable object on every slot — **slot 0 (rack controller) included** — with random values, firing spontaneous announces. One flag turns a served frame into a fully live rack.

## Why

`--play` previously required naming each object path (`1.<slot+1>.<group>.<id>`). For a multi-card frame that means hand-enumerating every object on every slot — impractical.

## How

- **play.go** — `RunStatusPlayAll` walks the served tree and starts an independent oscillator per oscillatable object across all slots. `oscillatableTargets` collects + sorts the keys (slot/group/id); `oscillatable` reports the drivable types, mirroring `randomBytesFor` (Integer/Long/Byte/Enum/IPAddr). String/Float/File/Frame/Alarm are skipped. Reuses the existing mean-reverting `playLoop` so values stay realistic.
- **cmd_producer.go** — `--play` accepts the sentinel `all` (case-insensitive) → `RunStatusPlayAll`; any other value is still the comma-separated path list. Flag help updated.

## Tests

- `play_test.go`: `oscillatable` type table; `oscillatableTargets` spans all slots **including slot 0** and excludes String/Frame objects (the core guarantee).
- Verified end-to-end over loopback: a 3-slot manifest served with `--play all` streamed ~1700 announces in 3s from slot 0 (control + status) and the card slots — confirming every slot oscillates.

Closes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)
