### PR TITLE
feat(acp1): --play frame-status events, full-range random mode, clean Ctrl+C

### DIFF
--- a/cmd/dhs/cmd_producer.go
+++ b/cmd/dhs/cmd_producer.go
@@ -66,6 +66,7 @@ func runProducer(ctx context.Context, protoName string, args []string) error {
 		preload       = fs.String("preload", "", "acp1 only: pre-populate slots at boot with NO cascade. External controllers see a stable device from first walk and don't discard the cached template on producer restart. Format: slot=card[,slot=card,...] e.g. 0=axon/synapse/RRS18-1601/acp1,1=axon/synapse/2GS110-2728/acp1")
 		play          = fs.String("play", "", "acp1 only: oscillate objects with random values; each tick fires a spontaneous status announce. Pass `all` to oscillate every oscillatable object on every slot (slot 0 included), or a comma-separated path list 1.<slot+1>.<group>.<id>[,...] e.g. 1.1.3.6,1.1.3.7 oscillates Temp_Left + Temp_Right on slot 0")
 		playEvery     = fs.Duration("play-interval", 2*time.Second, "acp1 only: tick interval for --play")
+		playMode      = fs.String("play-mode", "walk", "acp1 only: --play value strategy — `walk` (mean-reverting drift, realistic) or `random` (force a uniform value across the object's full [min,max] each tick)")
 	)
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -293,10 +294,22 @@ func runProducer(ctx context.Context, protoName string, args []string) error {
 		// publishes spontaneous status announces on its own without
 		// any external trigger.
 		if *play != "" {
+			var fullRange bool
+			switch strings.ToLower(strings.TrimSpace(*playMode)) {
+			case "", "walk":
+				fullRange = false
+			case "random", "force":
+				fullRange = true
+			default:
+				return fmt.Errorf("--play-mode %q invalid (use walk | random)", *playMode)
+			}
 			if strings.EqualFold(strings.TrimSpace(*play), "all") {
-				acp1Srv.RunStatusPlayAll(srvCtx, *playEvery)
+				acp1Srv.RunStatusPlayAll(srvCtx, *playEvery, fullRange)
+				// "all" also drives the rack frame-status so consumers can
+				// detect slot insert/remove/error events on slot 0.
+				acp1Srv.RunFrameStatusPlay(srvCtx, *playEvery)
 			} else {
-				acp1Srv.RunStatusPlay(srvCtx, strings.Split(*play, ","), *playEvery)
+				acp1Srv.RunStatusPlay(srvCtx, strings.Split(*play, ","), *playEvery, fullRange)
 			}
 		}
 

--- a/internal/acp1/provider/play.go
+++ b/internal/acp1/provider/play.go
@@ -31,10 +31,11 @@ import (
 // with the same tick interval.
 //
 // Stops cleanly on ctx cancellation.
-func (s *server) RunStatusPlay(ctx context.Context, paths []string, interval time.Duration) {
+func (s *server) RunStatusPlay(ctx context.Context, paths []string, interval time.Duration, fullRange bool) {
 	if interval <= 0 {
 		interval = 2 * time.Second
 	}
+	started := 0
 	for _, p := range paths {
 		path := strings.TrimSpace(p)
 		if path == "" {
@@ -53,8 +54,13 @@ func (s *server) RunStatusPlay(ctx context.Context, paths []string, interval tim
 				slog.String("path", path))
 			continue
 		}
-		go s.playLoop(ctx, key, e, interval)
+		go s.playLoop(ctx, key, e, interval, fullRange)
+		started++
 	}
+	s.logger.Info("acp1 play started",
+		slog.Int("objects", started),
+		slog.Bool("full_range", fullRange),
+		slog.Duration("interval", interval))
 }
 
 // RunStatusPlayAll is the auto-discovery form of RunStatusPlay: instead of
@@ -68,21 +74,90 @@ func (s *server) RunStatusPlay(ctx context.Context, paths []string, interval tim
 // announce handling must cope with.
 //
 // Stops cleanly on ctx cancellation.
-func (s *server) RunStatusPlayAll(ctx context.Context, interval time.Duration) {
+func (s *server) RunStatusPlayAll(ctx context.Context, interval time.Duration, fullRange bool) {
 	if interval <= 0 {
 		interval = 2 * time.Second
 	}
 	keys := s.oscillatableTargets()
 	s.logger.Info("acp1 play all started",
 		slog.Int("objects", len(keys)),
+		slog.Bool("full_range", fullRange),
 		slog.Duration("interval", interval))
 	for _, k := range keys {
 		e, ok := s.tree.lookup(k)
 		if !ok {
 			continue
 		}
-		go s.playLoop(ctx, k, e, interval)
+		go s.playLoop(ctx, k, e, interval, fullRange)
 	}
+}
+
+// RunFrameStatusPlay oscillates the rack-controller frame-status object on
+// slot 0: each tick one random slot in the array is flipped to a random state
+// (no_card/powerup/boot/present/error/removed) and a frame-status announce is
+// broadcast. A consumer subscribed to slot 0 frame-status therefore sees a
+// stream of card insert / remove / error events to detect — the dynamic the
+// rack controller exposes. No-op if the served tree has no frame-status object.
+//
+// Stops cleanly on ctx cancellation.
+func (s *server) RunFrameStatusPlay(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = 2 * time.Second
+	}
+	if !s.hasFrameStatus() {
+		s.logger.Debug("acp1 play frame-status: no frame-status object, skipping")
+		return
+	}
+	s.logger.Info("acp1 play frame-status started", slog.Duration("interval", interval))
+	go func() {
+		r := rand.New(rand.NewSource(time.Now().UnixNano() ^ 0x5f1a))
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+			}
+			s.frameStatusTick(r)
+		}
+	}()
+}
+
+// hasFrameStatus reports whether the served tree carries the rack-controller
+// frame-status object.
+func (s *server) hasFrameStatus() bool {
+	s.tree.mu.RLock()
+	defer s.tree.mu.RUnlock()
+	e, ok := s.tree.entries[objectKey{slot: 0, group: codec.GroupFrame, id: 0}]
+	return ok && e != nil && e.param != nil
+}
+
+// frameStatusTick flips one random slot in the frame-status array to a random
+// state (0..5) and broadcasts the change via setSlotStatus. Returns the slot
+// and state it set, or ok=false when no frame-status object exists. Extracted
+// from RunFrameStatusPlay so it is unit-testable without goroutines/timers.
+func (s *server) frameStatusTick(r *rand.Rand) (uint8, uint8, bool) {
+	s.tree.mu.RLock()
+	e, ok := s.tree.entries[objectKey{slot: 0, group: codec.GroupFrame, id: 0}]
+	n := 0
+	if ok && e != nil && e.param != nil {
+		if statuses, ok2 := e.param.Value.([]any); ok2 {
+			n = len(statuses)
+		}
+	}
+	s.tree.mu.RUnlock()
+	if n == 0 {
+		return 0, 0, false
+	}
+	slot := uint8(r.Intn(n))
+	state := uint8(r.Intn(6)) // 0=no_card .. 5=boot
+	if err := s.setSlotStatus(slot, state); err != nil {
+		s.logger.Debug("acp1 play frame-status: set failed",
+			slog.Int("slot", int(slot)), slog.String("err", err.Error()))
+		return slot, state, false
+	}
+	return slot, state, true
 }
 
 // oscillatableTargets returns every object key in the served tree whose type
@@ -128,18 +203,22 @@ func oscillatable(t codec.ObjectType) bool {
 // the realistic operating band of the object — temperatures hover
 // near 24°C, packet counters near 0, etc. — instead of drifting to
 // the int16 extremes the schema's wide min/max would otherwise allow.
-func (s *server) playLoop(ctx context.Context, key objectKey, e *entry, interval time.Duration) {
+func (s *server) playLoop(ctx context.Context, key objectKey, e *entry, interval time.Duration, fullRange bool) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano() ^ int64(key.slot)<<16 ^ int64(key.id)))
 	nominal, _ := readIntBound(e.param.Value)
 	t := time.NewTicker(interval)
 	defer t.Stop()
-	s.logger.Info("acp1 play started",
+	// Per-object start is Debug, not Info: --play all spins up one loop per
+	// object across every slot, so an Info line each would bury the single
+	// "play all started" summary under hundreds of lines.
+	s.logger.Debug("acp1 play object started",
 		slog.String("path", e.param.Path),
 		slog.Int("slot", int(key.slot)),
 		slog.Int("group", int(key.group)),
 		slog.Int("id", int(key.id)),
 		slog.Int("acp_type", int(e.acpType)),
 		slog.Int64("nominal", nominal),
+		slog.Bool("full_range", fullRange),
 		slog.Duration("interval", interval),
 	)
 	for {
@@ -148,7 +227,7 @@ func (s *server) playLoop(ctx context.Context, key objectKey, e *entry, interval
 			return
 		case <-t.C:
 		}
-		raw, ok := s.randomBytesFor(e, r, nominal)
+		raw, ok := s.randomBytesFor(e, r, nominal, fullRange)
 		if !ok {
 			continue
 		}
@@ -185,22 +264,31 @@ func (s *server) playLoop(ctx context.Context, key objectKey, e *entry, interval
 //
 // Returns ok=false for types that don't oscillate naturally (Strings,
 // Floats — dedicated per-type oscillators TBD if needed).
-func (s *server) randomBytesFor(e *entry, r *rand.Rand, nominal int64) ([]byte, bool) {
+func (s *server) randomBytesFor(e *entry, r *rand.Rand, nominal int64, fullRange bool) ([]byte, bool) {
+	// nextInt picks the next value: a full-span uniform draw across [min,max]
+	// in random mode (the "force a swing" behaviour), or the mean-reverting
+	// walk in the default realistic mode.
+	nextInt := func(cur, minV, maxV int64) int64 {
+		if fullRange {
+			return uniformInt(r, minV, maxV)
+		}
+		return walkInt(r, cur, nominal, minV, maxV)
+	}
 	switch e.acpType {
 	case codec.TypeInteger:
 		minV, maxV := intBounds(e.param.Minimum, int64(-32768)), intBounds(e.param.Maximum, int64(32767))
 		cur, _ := readIntBound(e.param.Value)
-		v := walkInt(r, cur, nominal, minV, maxV)
+		v := nextInt(cur, minV, maxV)
 		return []byte{byte(v >> 8), byte(v)}, true
 	case codec.TypeLong:
 		minV, maxV := intBounds(e.param.Minimum, int64(-2147483648)), intBounds(e.param.Maximum, int64(2147483647))
 		cur, _ := readIntBound(e.param.Value)
-		v := walkInt(r, cur, nominal, minV, maxV)
+		v := nextInt(cur, minV, maxV)
 		return []byte{byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}, true
 	case codec.TypeByte:
 		minV, maxV := intBounds(e.param.Minimum, int64(0)), intBounds(e.param.Maximum, int64(255))
 		cur, _ := readIntBound(e.param.Value)
-		v := walkInt(r, cur, nominal, minV, maxV)
+		v := nextInt(cur, minV, maxV)
 		return []byte{byte(v)}, true
 	case codec.TypeEnum:
 		n := len(e.param.EnumMap)
@@ -248,6 +336,22 @@ func walkInt(r *rand.Rand, cur, nominal, minV, maxV int64) int64 {
 		v = maxV
 	}
 	return v
+}
+
+// uniformInt picks a uniform random value across the full [min, max] range —
+// the "force random from min-max" behaviour, in contrast to walkInt's gentle
+// mean-reverting drift. Bounds are swapped if inverted; an empty range returns
+// the single value. ACP1 numeric spans (int16 / int32 / uint8) never overflow
+// span+1 in int64, so Int63n is safe.
+func uniformInt(r *rand.Rand, minV, maxV int64) int64 {
+	if maxV < minV {
+		minV, maxV = maxV, minV
+	}
+	span := maxV - minV
+	if span <= 0 {
+		return minV
+	}
+	return minV + r.Int63n(span+1)
 }
 
 // readIntBound coerces a canonical numeric bound (any) to int64.

--- a/internal/acp1/provider/play_test.go
+++ b/internal/acp1/provider/play_test.go
@@ -1,8 +1,11 @@
 package acp1
 
 import (
+	"bytes"
 	"io"
 	"log/slog"
+	"math/rand"
+	"strings"
 	"testing"
 
 	"dhs/internal/acp1/codec"
@@ -137,5 +140,106 @@ func TestOscillatableTargets_SpansAllSlotsInclSlot0(t *testing.T) {
 	}
 	if !sawSlot0 {
 		t.Error("slot 0 objects were not included — --play all must cover slot 0")
+	}
+}
+
+func TestUniformInt(t *testing.T) {
+	r := rand.New(rand.NewSource(1))
+	if got := uniformInt(r, 5, 5); got != 5 {
+		t.Errorf("uniformInt(5,5) = %d, want 5 (degenerate range)", got)
+	}
+	for i := 0; i < 1000; i++ { // inverted bounds are swapped, not panicked
+		if v := uniformInt(r, 10, 0); v < 0 || v > 10 {
+			t.Fatalf("uniformInt(10,0) = %d, out of [0,10]", v)
+		}
+	}
+	sawMin, sawMax := false, false
+	for i := 0; i < 5000; i++ {
+		v := uniformInt(r, 0, 4)
+		if v < 0 || v > 4 {
+			t.Fatalf("uniformInt out of range: %d", v)
+		}
+		if v == 0 {
+			sawMin = true
+		}
+		if v == 4 {
+			sawMax = true
+		}
+	}
+	if !sawMin || !sawMax {
+		t.Errorf("uniformInt did not cover the full span (sawMin=%v sawMax=%v)", sawMin, sawMax)
+	}
+}
+
+// TestRandomBytesFor_FullRangeSpansBounds proves the "force random from min-max"
+// mode actually swings across the whole range — unlike the walk mode, which
+// only drifts ±1 from nominal and would never reach the far end quickly.
+func TestRandomBytesFor_FullRangeSpansBounds(t *testing.T) {
+	s := &server{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	e := &entry{acpType: codec.TypeByte, param: &canonical.Parameter{
+		Minimum: int64(0), Maximum: int64(32), Value: int64(10),
+	}}
+	r := rand.New(rand.NewSource(2))
+	sawFar := false
+	for i := 0; i < 2000; i++ {
+		raw, ok := s.randomBytesFor(e, r, 10, true) // fullRange=true
+		if !ok || len(raw) != 1 {
+			t.Fatalf("byte randomBytesFor: ok=%v len=%d", ok, len(raw))
+		}
+		v := int64(raw[0])
+		if v < 0 || v > 32 {
+			t.Fatalf("byte value %d out of [0,32]", v)
+		}
+		if v > 25 { // far from nominal 10 — walk mode would not get here fast
+			sawFar = true
+		}
+	}
+	if !sawFar {
+		t.Error("full-range mode never produced a far value — it is not spanning the range")
+	}
+}
+
+// TestFrameStatusTick_SetsValidState: one tick flips a slot to a valid state
+// (0..5) and the change is visible in the frame-status array — the dynamic a
+// consumer detects on slot 0.
+func TestFrameStatusTick_SetsValidState(t *testing.T) {
+	s := newTestServer(t) // frame-status [2,2,0,0]
+	r := rand.New(rand.NewSource(7))
+	slot, state, ok := s.frameStatusTick(r)
+	if !ok {
+		t.Fatal("frameStatusTick returned ok=false on a server with frame-status")
+	}
+	if state > 5 {
+		t.Errorf("state %d out of 0..5", state)
+	}
+	if got := readSlotStatus(t, s, slot); got != state {
+		t.Errorf("after tick slot %d status = %d, want %d", slot, got, state)
+	}
+}
+
+func TestFrameStatusTick_NoFrameStatusNoOp(t *testing.T) {
+	s := newServerFromSlots(t, cardSlot(1, "slot-1", "GIO-12")) // no frame-status
+	if _, _, ok := s.frameStatusTick(rand.New(rand.NewSource(1))); ok {
+		t.Error("frameStatusTick should be a no-op when no frame-status object exists")
+	}
+}
+
+// TestBroadcastAnnounce_SilentDuringShutdown pins the clean-Ctrl+C behaviour:
+// once the server is shutting down (closed=true, as the ctx-cancel path sets),
+// a racing --play announce must NOT spray a Warn. Without the guard every
+// in-flight play tick logged "acp1 announce send" on the closed socket.
+func TestBroadcastAnnounce_SilentDuringShutdown(t *testing.T) {
+	s := newTestServer(t)
+	var buf bytes.Buffer
+	s.logger = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	s.closed = true // simulate the shutdown window
+
+	s.broadcastAnnounce(&codec.Message{
+		MTID: 0, MType: codec.MTypeAnnounce,
+		ObjGroup: codec.GroupFrame, ObjID: 0, Value: []byte{2, 2},
+	})
+
+	if strings.Contains(buf.String(), "announce send") {
+		t.Errorf("announce Warn leaked during shutdown:\n%s", buf.String())
 	}
 }

--- a/internal/acp1/provider/server.go
+++ b/internal/acp1/provider/server.go
@@ -276,12 +276,21 @@ func (s *server) broadcastAnnounceSkip(ann *codec.Message, skipTCPSessionID uint
 
 	s.mu.Lock()
 	bc := s.bcast
+	closed := s.closed
 	s.mu.Unlock()
-	if bc == nil {
-		// No UDP listener — TCP / AN2 fan-out already done above.
+	if bc == nil || closed {
+		// No UDP listener, or we're shutting down. Skipping a broadcast on a
+		// closing socket keeps Ctrl-C output clean — without this, every
+		// in-flight --play tick would spray a Warn as its write races the
+		// socket close.
 		return
 	}
 	if _, err := bc.Write(out); err != nil {
+		// A closed socket during shutdown is expected, not a fault.
+		if errors.Is(err, net.ErrClosed) {
+			s.logger.Debug("acp1 announce skipped: socket closed during shutdown")
+			return
+		}
 		s.logger.Warn("acp1 announce send",
 			slog.String("err", err.Error()),
 			slog.String("dst", bc.RemoteAddr().String()),


### PR DESCRIPTION
## What

Three improvements to the `--play` live-device simulator.

### 1. Frame-status events on slot 0
`--play all` now also drives the rack-controller frame-status object: each tick one random slot flips to a random state (`no_card`/`powerup`/`boot`/`present`/`error`/`removed`) and a frame-status announce fires. A consumer watching slot 0 sees a stream of card insert/remove/error events to detect.

### 2. Full-range random mode
New `--play-mode {walk|random}`. `walk` (default) keeps the realistic mean-reverting drift; `random` **forces a uniform value across the object's full `[min,max]`** each tick.

### 3. Clean Ctrl+C
`broadcastAnnounce` now skips the UDP write when the server is shutting down and downgrades a `net.ErrClosed` write to Debug — previously every in-flight `--play` tick sprayed a `Warn` as its broadcast raced the socket close, burying the exit. Per-object "play started" logs dropped to Debug so `--play all` shows one summary line, not a flood.

## How

- **play.go** — `RunFrameStatusPlay` + `frameStatusTick` (reuse `setSlotStatus`); `uniformInt`; `fullRange` threaded through `RunStatusPlay`/`RunStatusPlayAll`/`playLoop`/`randomBytesFor`.
- **server.go** — `broadcastAnnounce` shutdown guard (`closed` short-circuit + `net.ErrClosed` → Debug).
- **cmd_producer.go** — `--play-mode` flag; `--play all` also starts `RunFrameStatusPlay`.

## Tests

- `uniformInt` covers the full span incl. min/max; swaps inverted bounds.
- `randomBytesFor` full-range spans far from nominal (walk would not).
- `frameStatusTick` sets a valid 0..5 state visible in the array; no-op without a frame-status object.
- `broadcastAnnounce` stays silent (no `Warn`) once closed — the clean-exit guard.
- Verified over loopback: `--play all --play-mode random` streamed frame-status transitions a consumer's `watch` decoded (`slot 0: error -> present`, `slot 1: no_card -> error`) across all slots; serve log stayed clean (one summary line).

## Usage

```
dhs producer acp1 serve --manifest <frame>.json --play all --play-mode random --play-interval 300ms
```

Closes #523

🤖 Generated with [Claude Code](https://claude.com/claude-code)
