### PR TITLE
test(acp1): repeatable per-verb consumer integration matrix

### DIFF
--- a/scripts/acp1/_lib.ps1
+++ b/scripts/acp1/_lib.ps1
@@ -1,0 +1,50 @@
+# scripts/acp1/_lib.ps1 - shared helpers for the acp1 consumer integration
+# scripts (verify-<verb>.ps1). Dot-source it:  . "$PSScriptRoot\_lib.ps1"
+#
+# Every script drives the real dhs CLI against a live ACP1 peer named by
+# $env:ACP1_TEST_HOST - the Synapse Simulator or a real Axon device, i.e. the
+# VENDOR oracle. Never point these at our own provider (ADR / oracle rule:
+# a consumer is proven against ground truth, not against our producer).
+# Scripts skip cleanly (exit 0) when ACP1_TEST_HOST is unset, so CI stays green
+# without a device while the suite is still runnable on demand over VPN.
+
+$script:Acp1Fail = 0
+
+# Resolve-Acp1Target returns the test host or skips (exit 0) when unset.
+function Resolve-Acp1Target {
+    if (-not $env:ACP1_TEST_HOST) {
+        Write-Host 'SKIP: ACP1_TEST_HOST not set'
+        exit 0
+    }
+    return $env:ACP1_TEST_HOST
+}
+
+# Resolve-Dhs returns the path to the built dhs binary or fails (exit 1).
+function Resolve-Dhs {
+    $dhs = Join-Path $PSScriptRoot '..\..\bin\dhs.exe'
+    if (-not (Test-Path $dhs)) {
+        Write-Error "dhs binary not found at $dhs (build: go build -o bin/dhs.exe ./cmd/dhs)"
+        exit 1
+    }
+    return $dhs
+}
+
+# Check records one assertion: PASS when $cond is true, else FAIL (+ detail).
+function Check([string]$name, [bool]$cond, $detail) {
+    if ($cond) {
+        Write-Host "PASS  $name"
+    } else {
+        Write-Host "FAIL  $name`n      got: $detail"
+        $script:Acp1Fail++
+    }
+}
+
+# Complete-Checks prints the summary and exits 0 (all pass) or 1 (any fail).
+function Complete-Checks([string]$verb) {
+    if ($script:Acp1Fail -eq 0) {
+        Write-Host "`n${verb}: ALL PASS"
+        exit 0
+    }
+    Write-Host "`n${verb}: $script:Acp1Fail FAILED"
+    exit 1
+}

--- a/scripts/acp1/verify-all.ps1
+++ b/scripts/acp1/verify-all.ps1
@@ -1,0 +1,33 @@
+# scripts/acp1/verify-all.ps1 - run the full acp1 consumer integration matrix.
+#
+# Runs every verify-<verb>.ps1 in this directory against the live ACP1 peer named
+# by $env:ACP1_TEST_HOST (the Synapse Simulator or a real Axon device - the
+# vendor oracle, NEVER our own provider). Each script is isolated in its own
+# PowerShell process so one script's exit doesn't abort the run. Skips cleanly
+# (exit 0) when ACP1_TEST_HOST is unset.
+#
+# Usage:
+#   $env:ACP1_TEST_HOST = '10.6.239.113'
+#   .\scripts\acp1\verify-all.ps1
+if (-not $env:ACP1_TEST_HOST) {
+    Write-Host 'SKIP: ACP1_TEST_HOST not set (point it at the Synapse emulator / device host)'
+    exit 0
+}
+
+$scripts = Get-ChildItem -Path $PSScriptRoot -Filter 'verify-*.ps1' |
+    Where-Object { $_.Name -ne 'verify-all.ps1' } |
+    Sort-Object Name
+$fail = 0
+foreach ($s in $scripts) {
+    Write-Host "`n=== $($s.Name) ==="
+    & powershell -NoProfile -ExecutionPolicy Bypass -File $s.FullName
+    if ($LASTEXITCODE -ne 0) { $fail++ }
+}
+
+Write-Host "`n========================================"
+if ($fail -eq 0) {
+    Write-Host 'acp1 integration: ALL SCRIPTS PASS'
+    exit 0
+}
+Write-Host "acp1 integration: $fail SCRIPT(S) FAILED"
+exit 1

--- a/scripts/acp1/verify-export.ps1
+++ b/scripts/acp1/verify-export.ps1
@@ -1,0 +1,25 @@
+# scripts/acp1/verify-export.ps1 - acp1 `export` integration test.
+# Dumps slot 0 to JSON and asserts it parses + carries device/protocol + slots.
+. "$PSScriptRoot\_lib.ps1"
+$t = Resolve-Acp1Target
+$dhs = Resolve-Dhs
+$out = Join-Path $env:TEMP "acp1-export-$PID.json"
+
+& $dhs consumer acp1 export $t --slot 0 --out $out 2>$null | Out-Null
+Check 'export file created' (Test-Path $out) $out
+
+$ok = $false; $hasProto = $false; $hasSlots = $false; $j = $null
+if (Test-Path $out) {
+    try {
+        $j = Get-Content $out -Raw | ConvertFrom-Json
+        $ok = $true
+        $hasProto = ($j.device.protocol -eq 'acp1')
+        $hasSlots = (@($j.slots).Count -ge 1)
+    } catch {}
+}
+Check 'export is valid JSON'           $ok 'ConvertFrom-Json failed'
+Check 'export device.protocol is acp1' $hasProto "protocol=$($j.device.protocol)"
+Check 'export has at least one slot'   $hasSlots "slots=$(@($j.slots).Count)"
+
+Remove-Item $out -ErrorAction SilentlyContinue
+Complete-Checks 'export'

--- a/scripts/acp1/verify-get.ps1
+++ b/scripts/acp1/verify-get.ps1
@@ -1,0 +1,11 @@
+# scripts/acp1/verify-get.ps1 - acp1 `get` integration test.
+# Reads a known enum object and asserts value + kind + enum items.
+. "$PSScriptRoot\_lib.ps1"
+$t = Resolve-Acp1Target
+$dhs = Resolve-Dhs
+
+$txt = (& $dhs consumer acp1 get $t --slot 0 --group control --label Broadcasts 2>$null) -join "`n"
+Check 'returns a value'      ($txt -match 'value\s*=') $txt
+Check 'reports enum kind'    ($txt -match 'kind\s*=\s*enum') $txt
+Check 'lists enum items'     ($txt -match 'items\s*=\s*\[Off, On\]') $txt
+Complete-Checks 'get'

--- a/scripts/acp1/verify-import.ps1
+++ b/scripts/acp1/verify-import.ps1
@@ -1,0 +1,19 @@
+# scripts/acp1/verify-import.ps1 - acp1 `import` integration test.
+# Exports slot 0, then imports that snapshot with --dry-run (non-destructive):
+# asserts the round-trip parses and the dry-run completes without error and
+# writes nothing. Import-apply is intentionally NOT exercised here so the
+# device state is never mutated by the import test.
+. "$PSScriptRoot\_lib.ps1"
+$t = Resolve-Acp1Target
+$dhs = Resolve-Dhs
+$snap = Join-Path $env:TEMP "acp1-import-$PID.json"
+
+& $dhs consumer acp1 export $t --slot 0 --out $snap 2>$null | Out-Null
+Check 'snapshot exported for import' (Test-Path $snap) $snap
+
+$txt = (& $dhs consumer acp1 import $t --file $snap --dry-run 2>$null) -join "`n"
+Check 'dry-run import exits 0' ($LASTEXITCODE -eq 0) "exit=$LASTEXITCODE"
+Check 'dry-run produced a report' ($txt.Trim().Length -gt 0) $txt
+
+Remove-Item $snap -ErrorAction SilentlyContinue
+Complete-Checks 'import'

--- a/scripts/acp1/verify-info.ps1
+++ b/scripts/acp1/verify-info.ps1
@@ -1,0 +1,12 @@
+# scripts/acp1/verify-info.ps1 - acp1 `info` integration test.
+# Asserts the device-info reply: protocol, slot count, per-slot status.
+. "$PSScriptRoot\_lib.ps1"
+$t = Resolve-Acp1Target
+$dhs = Resolve-Dhs
+
+$txt = (& $dhs consumer acp1 info $t 2>$null) -join "`n"
+Check 'reports protocol acp1' ($txt -match 'protocol\s+acp1') $txt
+Check 'reports a slot count'  ($txt -match 'slots\s+\d+') $txt
+Check 'lists per-slot status' ($txt -match 'per-slot status') $txt
+Check 'slot 0 is present'     ($txt -match 'slot\s+0\s+status=present') $txt
+Complete-Checks 'info'

--- a/scripts/acp1/verify-profile.ps1
+++ b/scripts/acp1/verify-profile.ps1
@@ -1,0 +1,10 @@
+# scripts/acp1/verify-profile.ps1 - acp1 `profile` integration test.
+# Asserts the compliance profile reports objects walked + a classification.
+. "$PSScriptRoot\_lib.ps1"
+$t = Resolve-Acp1Target
+$dhs = Resolve-Dhs
+
+$txt = (& $dhs consumer acp1 profile $t 2>$null) -join "`n"
+Check 'reports objects walked'  ($txt -match 'objects walked\s+\d+') $txt
+Check 'reports a classification' ($txt -match 'classification\s+\w+') $txt
+Complete-Checks 'profile'

--- a/scripts/acp1/verify-set.ps1
+++ b/scripts/acp1/verify-set.ps1
@@ -1,0 +1,18 @@
+# scripts/acp1/verify-set.ps1 - acp1 `set` integration test.
+# Round-trips a numeric object (NetwPrefix, range 0..32): set -> confirm ->
+# read back -> restore to 0. Leaves the device as it was found.
+. "$PSScriptRoot\_lib.ps1"
+$t = Resolve-Acp1Target
+$dhs = Resolve-Dhs
+$sel = @('--slot', '0', '--group', 'control', '--label', 'NetwPrefix')
+
+$set = (& $dhs consumer acp1 set $t @sel --value 5 2>$null) -join "`n"
+Check 'set confirms the new value' ($set -match 'confirmed.*\b5\b') $set
+
+$get = (& $dhs consumer acp1 get $t @sel 2>$null) -join "`n"
+Check 'get reflects the set value' ($get -match 'value\s*=\s*5\b') $get
+
+& $dhs consumer acp1 set $t @sel --value 0 2>$null | Out-Null   # restore
+$get2 = (& $dhs consumer acp1 get $t @sel 2>$null) -join "`n"
+Check 'restored to 0' ($get2 -match 'value\s*=\s*0\b') $get2
+Complete-Checks 'set'

--- a/scripts/acp1/verify-tree.ps1
+++ b/scripts/acp1/verify-tree.ps1
@@ -1,0 +1,10 @@
+# scripts/acp1/verify-tree.ps1 - acp1 `tree` integration test.
+# Asserts the ASCII tree render shows branches + the control group.
+. "$PSScriptRoot\_lib.ps1"
+$t = Resolve-Acp1Target
+$dhs = Resolve-Dhs
+
+$txt = (& $dhs consumer acp1 tree $t --slot 0 2>$null) -join "`n"
+Check 'renders tree branches'  ($txt -match '\+--') $txt
+Check 'includes control group' ($txt -match '\+--\s*control') $txt
+Complete-Checks 'tree'

--- a/scripts/acp1/verify-walk.ps1
+++ b/scripts/acp1/verify-walk.ps1
@@ -1,0 +1,12 @@
+# scripts/acp1/verify-walk.ps1 - acp1 `walk` integration test.
+# Asserts the slot enumeration: groups + a known object + an object count.
+. "$PSScriptRoot\_lib.ps1"
+$t = Resolve-Acp1Target
+$dhs = Resolve-Dhs
+
+$txt = (& $dhs consumer acp1 walk $t --slot 0 2>$null) -join "`n"
+Check 'shows control group'    ($txt -match '\[control\]') $txt
+Check 'shows identity group'   ($txt -match '\[identity\]') $txt
+Check 'lists Broadcasts object' ($txt -match 'Broadcasts') $txt
+Check 'reports an object count' ($txt -match '\d+ objects') $txt
+Complete-Checks 'walk'

--- a/scripts/acp1/verify-watch.ps1
+++ b/scripts/acp1/verify-watch.ps1
@@ -1,0 +1,32 @@
+# scripts/acp1/verify-watch.ps1 - acp1 `watch` integration test.
+#
+# watch renders live UDP broadcast announces (MTID=0). Those are link-local
+# broadcasts that do NOT route across subnets, so a REMOTE DMZ emulator may
+# deliver none to this host. We therefore assert only that watch starts and
+# subscribes; receiving a live announce is reported but treated as SKIP (not
+# FAIL) when no announce arrives, since absence is a network-topology fact, not
+# a consumer bug. Run on the same L2 as the device to exercise the live path.
+. "$PSScriptRoot\_lib.ps1"
+$t = Resolve-Acp1Target
+$dhs = Resolve-Dhs
+$sel = @('--slot', '0', '--group', 'control', '--label', 'NetwPrefix')
+
+$job = Start-Job -ScriptBlock {
+    & $using:dhs consumer acp1 watch $using:t --slot 0 2>$null
+}
+Start-Sleep -Seconds 1
+# Provoke a value-change announce by toggling a numeric object.
+& $dhs consumer acp1 set $t @sel --value 7 2>$null | Out-Null
+Start-Sleep -Seconds 2
+Stop-Job $job
+$txt = (Receive-Job $job) -join "`n"
+Remove-Job $job -Force
+& $dhs consumer acp1 set $t @sel --value 0 2>$null | Out-Null   # restore
+
+Check 'watch starts and subscribes' ($txt -match 'watching') $txt
+if ($txt -match 'NetwPrefix|s0\.control|live') {
+    Check 'received a live announce' $true $txt
+} else {
+    Write-Host 'SKIP  no announce received (UDP broadcast not routed from remote emulator) - run on the same L2 to exercise'
+}
+Complete-Checks 'watch'


### PR DESCRIPTION
## What

A repeatable integration script per acp1 consumer verb, plus a runner — closing the ADR-0025 deliverable-3 gap (only `verify-ensure.ps1` existed before).

## Oracle

Scripts drive the real dhs CLI against `$env:ACP1_TEST_HOST` — the **Synapse Simulator or a real Axon device (the vendor oracle), never our own provider**. They skip cleanly (exit 0) when the host is unset, so CI stays green without a device while the suite runs on demand over VPN.

## Scripts

| Script | Asserts |
|---|---|
| `verify-info` | protocol, slot count, per-slot status, slot 0 present |
| `verify-walk` | control + identity groups, known object, object count |
| `verify-get` | value, enum kind, enum items |
| `verify-set` | round-trip: set → confirm → read-back → restore |
| `verify-tree` | ASCII branches + control group |
| `verify-export` | JSON parses, device.protocol=acp1, ≥1 slot |
| `verify-import` | snapshot round-trip + `--dry-run` only (never mutates) |
| `verify-profile` | objects walked + classification |
| `verify-watch` | subscribe; live announce reported (SKIP-tolerant — UDP broadcast may not route from a remote DMZ emulator) |
| `verify-all` | runs the whole matrix, each script isolated in its own process |
| `_lib.ps1` | shared `Resolve-Acp1Target` / `Resolve-Dhs` / `Check` / `Complete-Checks` |

## Verified

All 10 scripts **PASS** against the Synapse emulator (10.6.239.113) — `watch` included (a live announce was received). Clean **SKIP** (exit 0) when `ACP1_TEST_HOST` is unset.

Closes #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)
