### PR TITLE
feat(acp1): Ansible role + playbook wrapping CLI ensure (multi-OS)

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,88 @@
+# dhs ACP1 — Ansible role + playbook
+
+Idempotent ACP1 device configuration by wrapping the `dhs` CLI `ensure` verb in
+an Ansible role. The same role runs on **Linux (SSH)** and **Windows (WinRM)**
+clients, so you prove the multi-OS `dhs` binary (ADR-0016) and the `ensure`
+idempotency contract behave identically on every platform in the Proxmox lab
+(lxc-debian / lxc-ubuntu / lxc-rocky / win11).
+
+This is the **authoritative idempotency layer**. The PowerShell scripts under
+`scripts/acp1/` are the fast smoke layer; here a real `ansible-playbook` run
+*is* the consumer, so "run twice → 0 changes" is proven, not simulated.
+
+## Why wrap the CLI (not a custom module)
+
+The CLI `ensure` already owns all the protocol logic — read current → predict the
+device clamp → validate → set-if-different — and emits Ansible-friendly JSON
+(`{changed|would_change, previous, current}`) plus the exit-code contract
+(`0` ok / `1` runtime / `2` validation). The role just maps Ansible semantics
+onto it, so there is one source of truth and no duplicated wire logic. A custom
+`dhs_value` module is a later nicety, not a prerequisite.
+
+| Ansible | → dhs CLI | Effect |
+|---|---|---|
+| `changed_when` reads the JSON | `ensure --json` `changed` field | `changed` reflects the device, not "the command ran" |
+| `--check` mode | `ensure --check` (task `check_mode: false`) | `ansible-playbook --check` is a real dry-run |
+| `failed_when: rc != 0` | exit `1`/`2` | runtime + validation failures fail the play; bad input is exit 2 |
+
+## Layout
+
+```
+ansible/
+  ansible.cfg
+  requirements.yml          # ansible.windows collection
+  inventory/
+    hosts.ini               # linux (ssh) + windows (winrm) — set your IPs
+    group_vars/{all,linux,windows}.yml
+  roles/dhs_acp1/
+    defaults/main.yml
+    tasks/{main,linux,windows}.yml
+    meta/main.yml
+  playbooks/site.yml
+```
+
+## Prerequisites
+
+Control node (Linux or WSL — Ansible is not a native-Windows control node):
+
+```bash
+pip install ansible pywinrm
+ansible-galaxy collection install -r requirements.yml
+```
+
+Build the per-OS `dhs` binaries the role deploys (from the repo root):
+
+```bash
+GOOS=linux   GOARCH=amd64 go build -o bin/dhs-linux-amd64     ./cmd/dhs
+GOOS=windows GOARCH=amd64 go build -o bin/dhs-windows-amd64.exe ./cmd/dhs
+```
+
+(PowerShell: `$env:GOOS='linux'; $env:GOARCH='amd64'; go build -o bin/dhs-linux-amd64 ./cmd/dhs`)
+
+## Configure
+
+- `inventory/hosts.ini` — set `ansible_host` for each LXC + the Win11 VM.
+- `group_vars/all.yml` — `dhs_device` (the ACP1 emulator / real rack — the oracle,
+  never our own provider) and `dhs_objects` (the desired state to converge).
+- `group_vars/linux.yml` / `windows.yml` — connection user, binary paths. Put the
+  WinRM password in `ansible-vault`, never plaintext.
+
+## Run
+
+```bash
+cd ansible
+ansible-playbook playbooks/site.yml            # apply
+ansible-playbook playbooks/site.yml --check    # dry-run (maps to ensure --check)
+ansible-playbook playbooks/site.yml            # again → every host: ok, changed=0
+```
+
+The second apply reporting **0 changed on every OS** is the idempotency proof.
+An out-of-range numeric (e.g. a `NetwPrefix` above its max) converges to the
+device's clamped value and stays idempotent — the CLI predicts the clamp
+client-side. A bad value (unknown enum, wrong type) fails the play with exit 2.
+
+## Status
+
+Authored against the verified CLI contract (`--json` `changed`, `--check`,
+exit `0/1/2` — all green vs the Synapse emulator). The live multi-OS run-twice
+proof executes on your Proxmox control node; this host has no Ansible runtime.

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,11 @@
+# Ansible config for the dhs multi-OS client matrix.
+# Run from this directory:  ansible-playbook playbooks/site.yml
+[defaults]
+inventory = inventory/hosts.ini
+roles_path = roles
+host_key_checking = False
+stdout_callback = yaml
+retry_files_enabled = False
+
+[ssh_connection]
+pipelining = True

--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -1,0 +1,12 @@
+---
+# The ACP1 device every client converges. The Synapse emulator or a real Axon
+# rack - the vendor oracle, never our own provider.
+dhs_device: "10.6.239.113"
+dhs_port: 2071
+
+# Desired object state. Each item becomes one `dhs ... ensure` call, idempotent:
+# a second playbook run reports changed=0. Out-of-range numerics are clamped to
+# [min,max] by the device and predicted client-side, so they stay idempotent too.
+dhs_objects:
+  - { slot: 0, group: control, label: Broadcasts, value: "On" }
+  - { slot: 0, group: control, label: NetwPrefix, value: "0" }

--- a/ansible/inventory/group_vars/linux.yml
+++ b/ansible/inventory/group_vars/linux.yml
@@ -1,0 +1,11 @@
+---
+# Linux LXC clients, reached over SSH.
+ansible_connection: ssh
+ansible_user: root            # set to your LXC user; key-based auth recommended
+
+# Where the dhs binary is installed on the target and which local artifact to
+# deploy. Build it from the repo root before running:
+#   GOOS=linux GOARCH=amd64 go build -o bin/dhs-linux-amd64 ./cmd/dhs
+dhs_dir: /usr/local/bin
+dhs_bin: /usr/local/bin/dhs
+dhs_local_binary: "{{ playbook_dir }}/../../bin/dhs-linux-amd64"

--- a/ansible/inventory/group_vars/windows.yml
+++ b/ansible/inventory/group_vars/windows.yml
@@ -1,0 +1,19 @@
+---
+# Windows client, reached over WinRM. Requires the ansible.windows collection
+# on the control node + pywinrm (pip install pywinrm).
+ansible_connection: winrm
+ansible_user: Administrator
+# Do NOT store the password in plaintext. Use ansible-vault:
+#   ansible-vault encrypt_string '<pw>' --name ansible_password
+# then paste the vaulted block here, or pass --ask-vault-pass at runtime.
+# ansible_password: !vault | ...
+ansible_winrm_transport: ntlm
+ansible_winrm_server_cert_validation: ignore
+ansible_port: 5985
+
+# Where the dhs binary is installed on the target and which local artifact to
+# deploy. Build it from the repo root before running:
+#   GOOS=windows GOARCH=amd64 go build -o bin/dhs-windows-amd64.exe ./cmd/dhs
+dhs_dir: 'C:\dhs'
+dhs_bin: 'C:\dhs\dhs.exe'
+dhs_local_binary: "{{ playbook_dir }}/../../bin/dhs-windows-amd64.exe"

--- a/ansible/inventory/hosts.ini
+++ b/ansible/inventory/hosts.ini
@@ -1,0 +1,23 @@
+# dhs multi-OS client matrix (Proxmox lab).
+#
+# Each host runs the dhs binary FOR ITS OS and converges the same ACP1 device,
+# proving the binary + the `ensure` idempotency contract behave identically on
+# every platform (ADR-0016 multi-OS). Linux LXC are reached over SSH; the
+# Windows VM over WinRM. Fill in the ansible_host IPs for your lab.
+#
+# The ACP1 device every client talks to is set by `dhs_device` in
+# group_vars/all.yml (the Synapse emulator or a real Axon rack - the oracle,
+# never our own provider).
+
+[linux]
+lxc-debian ansible_host=10.0.0.11
+lxc-ubuntu ansible_host=10.0.0.12
+lxc-rocky  ansible_host=10.0.0.13
+
+[windows]
+win11 ansible_host=10.0.0.21
+
+# Convenience group the playbook targets.
+[dhs_clients:children]
+linux
+windows

--- a/ansible/playbooks/site.yml
+++ b/ansible/playbooks/site.yml
@@ -1,0 +1,14 @@
+---
+# Converge the ACP1 device from every OS client in the lab.
+#
+#   ansible-playbook playbooks/site.yml                 # apply
+#   ansible-playbook playbooks/site.yml --check         # dry-run (maps to ensure --check)
+#   ansible-playbook playbooks/site.yml                 # run again -> changed=0 (idempotent)
+#
+# The second apply run must report 0 changed for every host on every OS - that
+# is the idempotency proof the `ensure` verb was built for.
+- name: Converge ACP1 device state from every OS client
+  hosts: dhs_clients
+  gather_facts: true
+  roles:
+    - dhs_acp1

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,0 +1,4 @@
+---
+# Install on the control node:  ansible-galaxy collection install -r requirements.yml
+collections:
+  - name: ansible.windows   # win_command / win_copy / win_file for the Windows client

--- a/ansible/roles/dhs_acp1/defaults/main.yml
+++ b/ansible/roles/dhs_acp1/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+# Safe defaults; real values come from inventory group_vars.
+dhs_device: "127.0.0.1"
+dhs_port: 2071
+dhs_objects: []
+
+# Overridden per-OS in group_vars (linux.yml / windows.yml).
+dhs_dir: /usr/local/bin
+dhs_bin: /usr/local/bin/dhs
+dhs_local_binary: "{{ playbook_dir }}/../../bin/dhs-linux-amd64"

--- a/ansible/roles/dhs_acp1/meta/main.yml
+++ b/ansible/roles/dhs_acp1/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  role_name: dhs_acp1
+  author: by-rune
+  description: >-
+    Converge ACP1 device object state idempotently by wrapping the dhs CLI
+    `consumer acp1 ensure` verb. Works on Linux (SSH) and Windows (WinRM).
+  license: see repository
+  min_ansible_version: "2.14"
+  platforms:
+    - name: EL
+      versions: [all]
+    - name: Debian
+      versions: [all]
+    - name: Ubuntu
+      versions: [all]
+    - name: Windows
+      versions: [all]
+dependencies: []

--- a/ansible/roles/dhs_acp1/tasks/linux.yml
+++ b/ansible/roles/dhs_acp1/tasks/linux.yml
@@ -1,0 +1,51 @@
+---
+- name: Create the dhs install directory
+  ansible.builtin.file:
+    path: "{{ dhs_dir }}"
+    state: directory
+    mode: "0755"
+
+- name: Deploy the linux dhs binary
+  ansible.builtin.copy:
+    src: "{{ dhs_local_binary }}"
+    dest: "{{ dhs_bin }}"
+    mode: "0755"
+
+- name: Converge each ACP1 object (idempotent via ensure)
+  ansible.builtin.command:
+    argv: "{{ _dhs_argv + (['--check'] if ansible_check_mode else []) }}"
+  vars:
+    _dhs_argv:
+      - "{{ dhs_bin }}"
+      - consumer
+      - acp1
+      - ensure
+      - "{{ dhs_device }}"
+      - --port
+      - "{{ dhs_port | string }}"
+      - --slot
+      - "{{ item.slot | default(0) | string }}"
+      - --group
+      - "{{ item.group }}"
+      - --label
+      - "{{ item.label }}"
+      - --value
+      - "{{ item.value | string }}"
+      - --json
+  loop: "{{ dhs_objects }}"
+  loop_control:
+    label: "{{ item.group }}/{{ item.label }}={{ item.value }}"
+  register: dhs_ensure
+  # Run our own command even under --check; we map Ansible check mode onto the
+  # CLI's --check above rather than letting Ansible skip the task.
+  check_mode: false
+  # changed reflects the DEVICE, not "the command ran": parse the ensure JSON
+  # (changed on apply, would_change under --check). Guarded on rc==0 so a
+  # failure's non-JSON stderr is never fed to from_json.
+  changed_when: >-
+    dhs_ensure.rc == 0 and
+    ((dhs_ensure.stdout | from_json).would_change | bool
+       if ansible_check_mode
+       else (dhs_ensure.stdout | from_json).changed | bool)
+  # exit 1 (runtime/wire) and exit 2 (client-side validation) both fail the play.
+  failed_when: dhs_ensure.rc != 0

--- a/ansible/roles/dhs_acp1/tasks/main.yml
+++ b/ansible/roles/dhs_acp1/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+# Dispatch by OS family so the same role drives Linux (SSH) and Windows (WinRM)
+# clients with the OS-appropriate modules and binary.
+- name: Converge ACP1 state on a POSIX client (SSH)
+  ansible.builtin.include_tasks: linux.yml
+  when: ansible_os_family != "Windows"
+
+- name: Converge ACP1 state on a Windows client (WinRM)
+  ansible.builtin.include_tasks: windows.yml
+  when: ansible_os_family == "Windows"

--- a/ansible/roles/dhs_acp1/tasks/windows.yml
+++ b/ansible/roles/dhs_acp1/tasks/windows.yml
@@ -1,0 +1,43 @@
+---
+- name: Create the dhs install directory
+  ansible.windows.win_file:
+    path: "{{ dhs_dir }}"
+    state: directory
+
+- name: Deploy the windows dhs binary
+  ansible.windows.win_copy:
+    src: "{{ dhs_local_binary }}"
+    dest: "{{ dhs_bin }}"
+
+- name: Converge each ACP1 object (idempotent via ensure)
+  ansible.windows.win_command:
+    argv: "{{ _dhs_argv + (['--check'] if ansible_check_mode else []) }}"
+  vars:
+    _dhs_argv:
+      - "{{ dhs_bin }}"
+      - consumer
+      - acp1
+      - ensure
+      - "{{ dhs_device }}"
+      - --port
+      - "{{ dhs_port | string }}"
+      - --slot
+      - "{{ item.slot | default(0) | string }}"
+      - --group
+      - "{{ item.group }}"
+      - --label
+      - "{{ item.label }}"
+      - --value
+      - "{{ item.value | string }}"
+      - --json
+  loop: "{{ dhs_objects }}"
+  loop_control:
+    label: "{{ item.group }}/{{ item.label }}={{ item.value }}"
+  register: dhs_ensure
+  check_mode: false
+  changed_when: >-
+    dhs_ensure.rc == 0 and
+    ((dhs_ensure.stdout | from_json).would_change | bool
+       if ansible_check_mode
+       else (dhs_ensure.stdout | from_json).changed | bool)
+  failed_when: dhs_ensure.rc != 0


### PR DESCRIPTION
## What

An Ansible role + playbook that converges ACP1 device state by wrapping the CLI `consumer acp1 ensure` verb — the **authoritative idempotency layer** the verb was designed for. The same role runs on Linux (SSH) and Windows (WinRM), so the multi-OS `dhs` binary (ADR-0016) and the idempotency contract are proven identical across the Proxmox lab (lxc-debian/ubuntu/rocky + win11).

The PowerShell suite under `scripts/acp1/` stays as the fast smoke layer; here a real `ansible-playbook` run *is* the consumer, so "run twice → 0 changes" is proven, not simulated.

## Why wrap the CLI, not a custom module

The CLI already owns read → clamp-predict → validate → set-if-different and emits Ansible-friendly JSON + the `0/1/2` exit contract. The role maps Ansible semantics onto it — one source of truth, no duplicated wire logic. A custom `dhs_value` module is a later nicety.

| Ansible | → dhs CLI |
|---|---|
| `changed_when` reads ensure JSON (`changed` / `would_change`) | `ensure --json` |
| `--check` (task `check_mode: false`) | `ensure --check` |
| `failed_when: rc != 0` | exit 1 runtime / exit 2 validation |

## Layout

`ansible/` — `ansible.cfg`, `requirements.yml` (ansible.windows), `inventory/` (hosts.ini ssh+winrm groups + group_vars), `roles/dhs_acp1/` (tasks dispatch by OS → deploy binary + loop `ensure` over `dhs_objects`), `playbooks/site.yml`, `README.md`.

## Verification

- `dhs` cross-compiles to linux/amd64 + windows/amd64 from one source (confirmed; CI already gates cross-compile).
- All 10 YAML files validated (`yaml.safe_load`, 10/10).
- The live multi-OS run-twice proof + `ansible-lint` run on the Linux/WSL control node — this Windows host has no Ansible runtime (WSL disabled). The CLI contract the role relies on (`--json` changed, `--check`, exit 0/1/2) is already green vs the Synapse emulator.

Closes #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)
