### PR TITLE
feat(acp1): set validates --value client-side (bad input is exit 2)

### DIFF
--- a/cmd/dhs/cmd_set.go
+++ b/cmd/dhs/cmd_set.go
@@ -149,13 +149,28 @@ func runSet(ctx context.Context, args []string) error {
 		ID:    *id,
 		Round: *round,
 	}
+	// Client-side pre-flight for typed values: coerce --value to the object's
+	// kind and validate it before the wire write, so a bad enum / wrong type /
+	// read-only target fails as exit 2 (validation) instead of exit 1 (wire) —
+	// matching `ensure`. Out-of-range numerics are intentionally NOT rejected
+	// (the device clamps them). --raw bypasses this; the caller owns the bytes.
+	meta := findObjectMeta(plug, *slot, *group, *label, *id)
+	if *valueHex == "" && meta != nil {
+		want, cerr := coerceDesired(meta.Kind, *valueStr)
+		if cerr != nil {
+			return cerr
+		}
+		if v, ok := plug.(consumer.ValueValidator); ok {
+			if verr := v.ValidateValue(opCtx, req, want); verr != nil {
+				return verr
+			}
+		}
+		val = want
+	}
+
 	confirmed, err := plug.SetValue(opCtx, req, val)
 	if err != nil {
 		return err
-	}
-	var meta *consumer.Object
-	if *label != "" {
-		meta = findObjectByLabel(plug, *slot, *group, *label)
 	}
 	fmt.Println("confirmed " + formatValue(confirmed, meta))
 	if len(confirmed.Raw) > 0 {

--- a/scripts/acp1/verify-set.ps1
+++ b/scripts/acp1/verify-set.ps1
@@ -15,4 +15,18 @@ Check 'get reflects the set value' ($get -match 'value\s*=\s*5\b') $get
 & $dhs consumer acp1 set $t @sel --value 0 2>$null | Out-Null   # restore
 $get2 = (& $dhs consumer acp1 get $t @sel 2>$null) -join "`n"
 Check 'restored to 0' ($get2 -match 'value\s*=\s*0\b') $get2
+
+# --- client-side validation (exit 2 before the wire write) ---
+# Bad enum value: rejected client-side, not sent.
+& $dhs consumer acp1 set $t --slot 0 --group control --label Broadcasts --value Bogus 2>$null | Out-Null
+Check 'bad enum value rejected with exit 2' ($LASTEXITCODE -eq 2) "exit=$LASTEXITCODE"
+
+# Read-only target: rejected client-side.
+& $dhs consumer acp1 set $t --slot 0 --group identity --label 'Card name' --value Hax 2>$null | Out-Null
+Check 'read-only target rejected with exit 2' ($LASTEXITCODE -eq 2) "exit=$LASTEXITCODE"
+
+# Out-of-range numeric is NOT a validation error: the device clamps it (exit 0).
+& $dhs consumer acp1 set $t @sel --value 100 2>$null | Out-Null
+Check 'out-of-range numeric accepted, device clamps (exit 0)' ($LASTEXITCODE -eq 0) "exit=$LASTEXITCODE"
+& $dhs consumer acp1 set $t @sel --value 0 2>$null | Out-Null   # restore
 Complete-Checks 'set'


### PR DESCRIPTION
## What

`set` now validates `--value` client-side before the wire write — a bad enum, wrong type, or read-only target returns **exit 2** (validation), matching `ensure`.

## Why

`set` sent the raw `--value` straight to the device, so bad input failed at the wire layer (**exit 1**). Ansible's `failed_when` distinguishes usage errors (exit 2) from runtime/wire errors (exit 1), so bad input should be caught client-side as exit 2 — which `ensure` already does.

## How

- **cmd_set.go** — after object resolution: `findObjectMeta` + `coerceDesired` + the optional `consumer.ValueValidator` (reused from the ensure work), gated to typed values. `--raw` still bypasses (caller owns the bytes), and protocols without a validator fall back to the prior send-and-catch behaviour. Out-of-range numerics are intentionally **not** rejected — the device clamps them (exit 0).

## Tests

- `scripts/acp1/verify-set.ps1`: bad enum → exit 2, read-only target → exit 2, out-of-range numeric → exit 0 (clamped). **ALL PASS** vs the Synapse emulator.
- Live: bad enum exit 2 · read-only exit 2 · NetwPrefix 100 → stored 32 exit 0 · valid enum exit 0.

Closes #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)
