### PR TITLE
docs(ansible): reusable WinRM bootstrap for Windows hosts (win11 + Server)

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -61,11 +61,33 @@ GOOS=windows GOARCH=amd64 go build -o bin/dhs-windows-amd64.exe ./cmd/dhs
 
 ## Configure
 
-- `inventory/hosts.ini` — set `ansible_host` for each LXC + the Win11 VM.
+- `inventory/hosts.ini` — set `ansible_host` for each LXC + each Windows host.
 - `group_vars/all.yml` — `dhs_device` (the ACP1 emulator / real rack — the oracle,
   never our own provider) and `dhs_objects` (the desired state to converge).
 - `group_vars/linux.yml` / `windows.yml` — connection user, binary paths. Put the
   WinRM password in `ansible-vault`, never plaintext.
+
+## Windows hosts (WinRM) — one-time setup
+
+Any Windows host (Windows 11 **or** Windows Server) is driven over WinRM the
+standard way. Run the bootstrap once per host, in an **elevated** PowerShell:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File windows\configure-winrm.ps1
+```
+
+It enables the WinRM listener + Negotiate/NTLM auth and — the part that's easy
+to miss — sets `LocalAccountTokenFilterPolicy=1`. Without that, a **local**
+admin's token is filtered on network logon and WinRM rejects auth (HTTP 401 /
+SSPI `0x8009030d`) even with a correct password and a working interactive
+login. After it runs, verify from the control node:
+
+```bash
+ansible <host> -i inventory/hosts.ini -m ansible.windows.win_ping   # -> pong
+```
+
+Supply the password with `ansible-vault` (or `--ask-pass`), never plaintext.
+Verified: `dhs-win11` converges over WinRM with run-twice = 0 changed.
 
 ## Run
 

--- a/ansible/inventory/hosts.ini
+++ b/ansible/inventory/hosts.ini
@@ -14,8 +14,11 @@ lxc-debian ansible_host=10.0.0.11
 lxc-ubuntu ansible_host=10.0.0.12
 lxc-rocky  ansible_host=10.0.0.13
 
+# Any Windows host (Windows 11 or Windows Server) goes here. Run
+# windows/configure-winrm.ps1 once on each before the first playbook run.
 [windows]
-win11 ansible_host=10.0.0.21
+win11  ansible_host=10.0.0.21
+# winsrv ansible_host=10.0.0.22
 
 # Convenience group the playbook targets.
 [dhs_clients:children]

--- a/ansible/windows/configure-winrm.ps1
+++ b/ansible/windows/configure-winrm.ps1
@@ -1,0 +1,61 @@
+<#
+.SYNOPSIS
+  Configure WinRM for Ansible on a Windows host (Windows 11 or Windows Server).
+  Idempotent - safe to re-run. Run ONCE per host from an ELEVATED PowerShell.
+
+.DESCRIPTION
+  Enables the standard NTLM/Negotiate-over-HTTP (port 5985) path that Ansible's
+  `winrm` connection uses (matches inventory/group_vars/windows.yml:
+  ansible_connection=winrm, transport=ntlm, port 5985).
+
+  The non-obvious requirement for a LOCAL account (workgroup / non-domain) is
+  LocalAccountTokenFilterPolicy=1. Without it, Windows UAC strips a local
+  admin's token on *network* logon, and WinRM rejects the authentication
+  (HTTP 401 / SSPI 0x8009030d) even though the password is correct and
+  interactive login works. This was the exact blocker on dhs-win11.
+
+  NTLM over HTTP is message-encrypted by pywinrm on the wire. For a hardened
+  setup prefer HTTPS (5986) + a real certificate; pass -AllowUnencrypted only
+  if you knowingly need plaintext (not recommended).
+
+.EXAMPLE
+  # On the Windows target, elevated:
+  powershell -ExecutionPolicy Bypass -File .\configure-winrm.ps1
+
+  # Then from the Ansible control node:
+  ansible <host> -i inventory/hosts.ini -m ansible.windows.win_ping
+#>
+[CmdletBinding()]
+param(
+    [switch]$AllowUnencrypted
+)
+$ErrorActionPreference = 'Stop'
+
+$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
+).IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)
+if (-not $isAdmin) { throw 'Run this from an elevated (Administrator) PowerShell.' }
+
+Write-Host '== Enable PS remoting: WinRM service + HTTP listener + firewall =='
+Enable-PSRemoting -Force -SkipNetworkProfileCheck | Out-Null
+
+Write-Host '== Allow Negotiate (NTLM) auth on the WinRM service =='
+Set-Item -Path WSMan:\localhost\Service\Auth\Negotiate -Value $true
+
+Write-Host '== LocalAccountTokenFilterPolicy=1 (local-admin network logon) =='
+$sys = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System'
+New-ItemProperty -Path $sys -Name LocalAccountTokenFilterPolicy -Value 1 -PropertyType DWord -Force | Out-Null
+
+if ($AllowUnencrypted) {
+    Write-Host '== AllowUnencrypted=true (NOT recommended; NTLM already encrypts payload) =='
+    Set-Item -Path WSMan:\localhost\Service\AllowUnencrypted -Value $true
+}
+
+Write-Host '== Headroom for Ansible modules (MaxMemoryPerShellMB) =='
+Set-Item -Path WSMan:\localhost\Shell\MaxMemoryPerShellMB -Value 1024
+
+Restart-Service WinRM
+
+Write-Host ''
+Write-Host 'WinRM is configured for Ansible (NTLM/Negotiate over HTTP 5985).'
+Write-Host 'Verify from the control node:'
+Write-Host '  ansible <host> -i inventory/hosts.ini -m ansible.windows.win_ping'


### PR DESCRIPTION
## What

A reusable, idempotent **WinRM bootstrap** so Ansible drives any Windows host (Windows 11 **or** Windows Server) the standard way — and the README documents the one non-obvious requirement.

## Why

`dhs-win11` rejected NTLM **network** auth (HTTP 401 / SSPI `0x8009030d`) even though the password was correct and interactive login worked. Root cause: UAC filters a **local** admin's token on network logon, so WinRM refuses auth. Setting `LocalAccountTokenFilterPolicy=1` (plus the listener + Negotiate auth, which were already present) fixed it.

Verified end to end: `ansible win11 -m ansible.windows.win_ping` → `pong`, and the `dhs_acp1` role converged `dhs-win11` over WinRM with **run-twice = 0 changed**.

## How

- **`ansible/windows/configure-winrm.ps1`** — elevated, idempotent, one-shot: `Enable-PSRemoting`, allow Negotiate/NTLM, `LocalAccountTokenFilterPolicy=1`, bump `MaxMemoryPerShellMB`. Identical on win11 and Windows Server. Parse-checked.
- **`ansible/inventory/hosts.ini`** — `[windows]` group documents that win11 + winsrv both go here after the bootstrap.
- **`ansible/README.md`** — "Windows hosts (WinRM) — one-time setup" with the run command, the `LocalAccountTokenFilterPolicy` rationale, and `win_ping` verification.

## Result

Full multi-OS Ansible matrix now works the standard way: **Linux × SSH + Windows × WinRM**. Same `dhs` binary + `ensure` contract, idempotent on every OS.

Closes #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)
