### PR TITLE
test(acp1): extend live verify matrix to all 15 consumer verbs (+ fix convert dispatch)

### DIFF
--- a/cmd/dhs/cmd_convert.go
+++ b/cmd/dhs/cmd_convert.go
@@ -22,6 +22,10 @@ func runConvert(_ context.Context, args []string) error {
 	in := fs.String("in", "", "input snapshot file (.json, .yaml, .csv)")
 	out := fs.String("out", "", "output file path (format derived from extension)")
 	format := fs.String("format", "", "output format override: json | yaml | csv")
+	// `dhs consumer <proto> convert` injects --protocol; convert is offline
+	// and ignores it (mirrors diff). Lets convert be reached via the consumer
+	// dispatcher without "flag provided but not defined: -protocol".
+	_ = fs.String("protocol", "", "(ignored; convert is offline)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}

--- a/internal/acp1/docs/status.md
+++ b/internal/acp1/docs/status.md
@@ -28,11 +28,11 @@ Legend: ✅ verified live · 🟢 code + unit test · 🟡 partial · ⬜ not st
 | 8 | `export` | ✅ | `verify-export.ps1` (json/yaml/csv) | 0002 |
 | 9 | `import` | ✅ | `verify-import.ps1` (`--dry-run`, non-destructive) | 0002 |
 | 10 | `profile` | ✅ | `verify-profile.ps1` (objects walked + compliance classification) | 0002 |
-| 11 | `extract` | 🟢 | `cmd/dhs/cmd_extract.go` (DM triple capture) — not in live matrix | 0022 |
-| 12 | `diff` | 🟢 | `cmd/dhs/cmd_diff.go` (compare canonical trees) | 0002 |
-| 13 | `convert` | 🟢 | `cmd/dhs/cmd_convert.go` (offline json/yaml/csv) | 0002 |
-| 14 | `validate` | 🟢 | `cmd/dhs/cmd_validate.go` (offline codec validate) | 0006 |
-| 15 | `discover` | 🟡 | `cmd/dhs/cmd_discover.go` — native subnet scan present; **mDNS/SD-DNS not done** | 0012 |
+| 11 | `extract` | ✅ | `verify-extract.ps1` (DM triple: meta+wire+tree) | 0022 |
+| 12 | `diff` | ✅ | `verify-diff.ps1` (schema diff: no-change + mutated) | 0002 |
+| 13 | `convert` | ✅ | `verify-convert.ps1` (json→yaml; fixed `--protocol` dispatch) | 0002 |
+| 14 | `validate` | ✅ | `verify-validate.ps1` (offline frame decode) | 0006 · 0021 |
+| 15 | `discover` | 🟡 | `verify-discover.ps1` (native subnet scan ✅); **mDNS/SD-DNS still missing** | 0012 |
 
 `matrix` / `invoke` / `stream` are Ember+-only; `diag` is ACP2-only — N/A here.
 
@@ -68,7 +68,7 @@ Legend: ✅ verified live · 🟢 code + unit test · 🟡 partial · ⬜ not st
 | # | Tier | State | Evidence | ADR |
 |---:|---|:--:|---|---|
 | 33 | Unit (codec/consumer/provider) | 🟢 | ~25 `*_test.go`; CI green 7 OS matrices | 0025 #1/#2 |
-| 34 | Per-verb integration (PowerShell, vs emulator) | ✅ | `scripts/acp1/verify-*.ps1` + `verify-all.ps1` (10/10 PASS); skips clean when host unset (PR #526) | 0025 #3 |
+| 34 | Per-verb integration (PowerShell, vs emulator) | ✅ | `scripts/acp1/verify-*.ps1` + `verify-all.ps1` (15/15 PASS — incl extract/diff/convert/validate/discover); skips clean when host unset | 0025 #3 |
 | 35 | Idempotency (Ansible, run-twice = 0 changed) | ✅ | `ansible/` role+playbook (PR #528); proven on debian/ubuntu/rocky | 0007 · 0016 |
 | 36 | Multi-OS (one binary, every OS) | ✅ | cross-compile linux/win; live Debian·Ubuntu·Rocky·Win11 | 0016 |
 | 37 | WinRM bootstrap for Windows hosts (win11 + Server) | ✅ | `ansible/windows/configure-winrm.ps1` (PR #532); win11 `win_ping` pong + role run-twice=0 | 0016 |
@@ -117,8 +117,8 @@ Legend: ✅ verified live · 🟢 code + unit test · 🟡 partial · ⬜ not st
 
 ## 8. Known gaps / caveats (honest)
 
-1. **Discovery (#15)** — native subnet scan only; **mDNS / SD-DNS for the consumer is not implemented** (consumer-side discovery of dhs producers). Tracked separately.
-2. **Unit coverage** — consumer ~33% / codec ~64%; many consumer paths are only exercised by the integration tier, not unit tests. The PowerShell matrix + Ansible cover the runtime behaviour, but raising unit coverage is open.
-3. **`extract`/`diff`/`convert`/`validate`/`discover` (#11-15)** — implemented + unit-tested, but **not** in the live `verify-*.ps1` matrix yet.
-4. **Go `-tags integration` tier** — the repeatable integration is PowerShell + Ansible (driving the CLI vs the emulator); there is no in-tree Go integration test gated on `ACP1_TEST_HOST`. Optional, since the CLI-level matrix already proves behaviour against the oracle.
+1. **Discovery (#15)** — native subnet scan works (`verify-discover.ps1`), but **mDNS / SD-DNS for the consumer is not implemented** (consumer-side discovery of dhs producers). The remaining open feature.
+2. **Unit coverage** — consumer ~41% (raised from 33.7%, socket-method tests) / codec ~64%; some consumer paths are still only exercised by the integration tier. Further raising is open but no longer a headline gap.
+3. ~~`extract`/`diff`/`convert`/`validate`/`discover` not in the live matrix~~ — **RESOLVED**: all 15 consumer verbs now have `verify-*.ps1` scripts (the matrix is 15/15). `discover` covers the native scan only (see #1).
+4. **Go `-tags integration` tier** — the repeatable integration is PowerShell + Ansible (driving the CLI vs the emulator); there is no in-tree Go integration test gated on `ACP1_TEST_HOST`. Optional, since the CLI-level matrix already proves behaviour against the oracle (clarify with the team whether to add one).
 5. **win11 WinRM** requires the per-host bootstrap (`LocalAccountTokenFilterPolicy=1`); see `ansible/windows/configure-winrm.ps1`. SSH is an alternative transport that needs no NTLM.

--- a/scripts/acp1/verify-convert.ps1
+++ b/scripts/acp1/verify-convert.ps1
@@ -1,0 +1,20 @@
+# scripts/acp1/verify-convert.ps1 - acp1 `convert` integration test (offline).
+# Exports the device to JSON, then converts json -> yaml and asserts the output.
+# `convert` is offline but reached via `dhs consumer acp1 convert`; this also
+# guards the regression where it rejected the dispatcher-injected --protocol.
+. "$PSScriptRoot\_lib.ps1"
+$t = Resolve-Acp1Target
+$dhs = Resolve-Dhs
+$json = Join-Path $env:TEMP "acp1-conv-$PID.json"
+$yaml = Join-Path $env:TEMP "acp1-conv-$PID.yaml"
+
+& $dhs consumer acp1 export $t --slot 0 --out $json 2>$null | Out-Null
+Check 'export produced source json' (Test-Path $json) $json
+
+& $dhs consumer acp1 convert --in $json --out $yaml 2>$null | Out-Null
+Check 'convert exits 0 (accepts injected --protocol)' ($LASTEXITCODE -eq 0) "exit=$LASTEXITCODE"
+Check 'yaml output created'          (Test-Path $yaml) $yaml
+Check 'yaml is non-empty'            ((Test-Path $yaml) -and (Get-Item $yaml).Length -gt 0) $yaml
+
+Remove-Item $json, $yaml -ErrorAction SilentlyContinue
+Complete-Checks 'convert'

--- a/scripts/acp1/verify-diff.ps1
+++ b/scripts/acp1/verify-diff.ps1
@@ -1,0 +1,30 @@
+# scripts/acp1/verify-diff.ps1 - acp1 `diff` integration test (offline compare).
+# Captures a canonical tree (via extract), then: identical -> "no changes";
+# a mutated copy -> changes reported. `diff` is offline; reached via the
+# consumer dispatcher (accepts the injected --protocol, which it ignores).
+. "$PSScriptRoot\_lib.ps1"
+$t = Resolve-Acp1Target
+$dhs = Resolve-Dhs
+$dir = Join-Path $env:TEMP "acp1-diff-$PID"
+
+& $dhs consumer acp1 extract $t --manufacturer axon --product rrs18 `
+    --direction consumer --version 1601 --out $dir --slot 0 2>$null | Out-Null
+$tree = Join-Path $dir 'tree.json'
+Check 'tree captured for diff' (Test-Path $tree) $tree
+
+# identical inputs -> no changes
+$same = (& $dhs consumer acp1 diff $tree $tree 2>$null) -join "`n"
+Check 'identical trees report no changes' ($same -match 'no changes') $same
+
+# Mutated copy: diff is a SCHEMA diff (access/type/unit/enum/min-max/add-remove),
+# not a value diff, so flip a read-only object to readWrite. The trailing comma
+# avoids also matching "readWrite". Write WITHOUT a BOM ([IO.File]::WriteAllText)
+# — Set-Content -Encoding utf8 on PS 5.1 emits a BOM that breaks the JSON parse.
+$mod = Join-Path $dir 'tree-mod.json'
+$mutated = (Get-Content $tree -Raw) -replace '"access": "read",', '"access": "readWrite",'
+[System.IO.File]::WriteAllText($mod, $mutated)
+$chg = (& $dhs consumer acp1 diff $tree $mod 2>$null) -join "`n"
+Check 'mutated tree reports changes' (($chg -notmatch 'no changes') -and ($chg.Trim().Length -gt 0)) $chg
+
+Remove-Item -Recurse -Force $dir -ErrorAction SilentlyContinue
+Complete-Checks 'diff'

--- a/scripts/acp1/verify-discover.ps1
+++ b/scripts/acp1/verify-discover.ps1
@@ -1,0 +1,11 @@
+# scripts/acp1/verify-discover.ps1 - acp1 `discover` integration test.
+# Active+passive subnet scan; asserts it finds the test host.
+. "$PSScriptRoot\_lib.ps1"
+$t = Resolve-Acp1Target
+$dhs = Resolve-Dhs
+
+$out = (& $dhs consumer acp1 discover --duration 4s 2>$null) -join "`n"
+Check 'discover exits 0'              ($LASTEXITCODE -eq 0) "exit=$LASTEXITCODE"
+Check 'reports a device count'        ($out -match '\d+ device') $out
+Check 'discovers the test host'       ($out -match [regex]::Escape($t)) $out
+Complete-Checks 'discover'

--- a/scripts/acp1/verify-extract.ps1
+++ b/scripts/acp1/verify-extract.ps1
@@ -1,0 +1,18 @@
+# scripts/acp1/verify-extract.ps1 - acp1 `extract` integration test.
+# Captures a per-product DM triple (meta + wire + tree) from the device and
+# asserts all three artifacts are produced.
+. "$PSScriptRoot\_lib.ps1"
+$t = Resolve-Acp1Target
+$dhs = Resolve-Dhs
+$dir = Join-Path $env:TEMP "acp1-extract-$PID"
+
+& $dhs consumer acp1 extract $t --manufacturer axon --product rrs18 `
+    --direction consumer --version 1601 --out $dir --slot 0 2>$null | Out-Null
+Check 'extract exits 0' ($LASTEXITCODE -eq 0) "exit=$LASTEXITCODE"
+Check 'meta.json produced' (Test-Path (Join-Path $dir 'meta.json')) $dir
+Check 'tree.json produced' (Test-Path (Join-Path $dir 'tree.json')) $dir
+$frames = (Test-Path (Join-Path $dir 'wire.jsonl')) -or (Test-Path (Join-Path $dir 'raw.acp1.jsonl'))
+Check 'wire frames captured' $frames $dir
+
+Remove-Item -Recurse -Force $dir -ErrorAction SilentlyContinue
+Complete-Checks 'extract'

--- a/scripts/acp1/verify-validate.ps1
+++ b/scripts/acp1/verify-validate.ps1
@@ -1,0 +1,21 @@
+# scripts/acp1/verify-validate.ps1 - acp1 `validate` integration test (offline).
+# Captures wire frames (via extract), then decodes them back through the codec
+# offline (ADR-0021) and asserts a clean decode. Reached via the consumer
+# dispatcher.
+. "$PSScriptRoot\_lib.ps1"
+$t = Resolve-Acp1Target
+$dhs = Resolve-Dhs
+$dir = Join-Path $env:TEMP "acp1-validate-$PID"
+
+& $dhs consumer acp1 extract $t --manufacturer axon --product rrs18 `
+    --direction consumer --version 1601 --out $dir --slot 0 2>$null | Out-Null
+$frames = Join-Path $dir 'wire.jsonl'
+if (-not (Test-Path $frames)) { $frames = Join-Path $dir 'raw.acp1.jsonl' }
+Check 'wire frames captured for validate' (Test-Path $frames) $frames
+
+$out = (& $dhs consumer acp1 validate $frames 2>$null) -join "`n"
+Check 'validate exits 0'        ($LASTEXITCODE -eq 0) "exit=$LASTEXITCODE"
+Check 'reports decoded trames'  ($out -match '\d+ trames decoded') $out
+
+Remove-Item -Recurse -Force $dir -ErrorAction SilentlyContinue
+Complete-Checks 'validate'


### PR DESCRIPTION
## What

Extends the live `verify-*.ps1` matrix from 10 to **15 consumer verbs** — adding `extract`, `diff`, `convert`, `validate`, `discover` — and fixes a `convert` dispatch bug found along the way. Closes status-doc §8 gap #3.

## Bug fixed

`dhs consumer acp1 convert` failed with `flag provided but not defined: -protocol`: the consumer dispatcher injects `--protocol`, but `convert` (unlike `diff`) didn't define it, so the verb was unreachable via the consumer path. Now accepts + ignores it (`cmd/dhs/cmd_convert.go`).

## New scripts

| Script | Asserts |
|---|---|
| `verify-extract` | DM triple captured (meta + tree + wire) |
| `verify-diff` | identical → "no changes"; schema-mutated (access read→readWrite) → changes. (diff is a **schema** diff, not value; mutated file written BOM-free so JSON parses) |
| `verify-convert` | export → `convert` json→yaml; guards the `--protocol` regression |
| `verify-validate` | extract wire frames → offline decode → "N trames decoded" |
| `verify-discover` | active+passive scan finds the test host |

## Verified

All **15/15** scripts PASS vs the Synapse emulator (`verify-all.ps1`); clean skip when `ACP1_TEST_HOST` is unset. Status doc updated (verbs 11–15 → verified live, matrix 15/15, gaps refreshed).

Closes #537

🤖 Generated with [Claude Code](https://claude.com/claude-code)
