### PR TITLE
chore(acp1): ansible playbooks for tshark dissector deploy + pcap relay

### DIFF
--- a/ansible/playbooks/acp1-capture.yml
+++ b/ansible/playbooks/acp1-capture.yml
@@ -1,0 +1,42 @@
+---
+# ACP1 pcap-relay: capture ACP1 (udp/tcp 2071) on a host whose tshark lacks
+# Lua (e.g. RHEL / Rocky 9 — Wireshark is built without Lua there), then
+# decode the pcap on the controller, which HAS the dhs_acpv1 dissector
+# (run deploy-dissector.yml on the controller first). Capturing needs no
+# Lua; only decoding does.
+#
+#   ansible-playbook -i inventory/fleet.ini playbooks/acp1-capture.yml -e target=dhs-rocky -e secs=12
+#
+# Capture is passive — drive ACP1 traffic (a set, or the producer's
+# announces) during the `secs` window so there is something to decode.
+- name: ACP1 pcap-relay (capture on target, decode on controller)
+  hosts: "{{ target | default('dhs-rocky') }}"
+  gather_facts: false
+  vars:
+    iface: any
+    secs: 12
+    pcap_remote: /tmp/acp1.pcap
+    pcap_local: "/tmp/acp1-{{ inventory_hostname }}.pcap"
+  tasks:
+    - name: Capture ACP1 traffic to a pcap (no Lua needed to capture)
+      ansible.builtin.shell: 'timeout {{ secs }} dumpcap -i {{ iface }} -f "udp port 2071 or tcp port 2071" -w {{ pcap_remote }}'
+      args:
+        executable: /bin/bash
+      failed_when: false
+
+    - name: Fetch the pcap to the controller
+      ansible.builtin.fetch:
+        src: "{{ pcap_remote }}"
+        dest: "{{ pcap_local }}"
+        flat: true
+
+    - name: Decode with the ACP1 dissector on the controller (has Lua)
+      delegate_to: localhost
+      ansible.builtin.command: "tshark -nr {{ pcap_local }}"
+      register: decoded
+      changed_when: false
+
+    - name: Show decoded ACP1
+      delegate_to: localhost
+      ansible.builtin.debug:
+        var: decoded.stdout_lines

--- a/ansible/playbooks/deploy-dissector.yml
+++ b/ansible/playbooks/deploy-dissector.yml
@@ -1,0 +1,49 @@
+---
+# Deploy the ACP1 tshark/Wireshark dissector (dhs_acpv1.lua) to every lab host
+# so `tshark` decodes ACP1 (udp/tcp 2071) on any host — the standard way to
+# track ACP1 on the wire. Idempotent.
+#
+#   ansible-playbook -i inventory/fleet.ini playbooks/deploy-dissector.yml
+#
+# NOTE: RHEL / Rocky 9 ship Wireshark built WITHOUT Lua, so tshark there
+# cannot load the dissector (verify shows NOT_LOADED). On those hosts capture
+# with dumpcap and decode on a Lua-enabled controller — see acp1-capture.yml.
+- name: Deploy ACP1 tshark dissector to the fleet
+  hosts: linux
+  gather_facts: false
+  vars:
+    lua_src: "{{ playbook_dir }}/../../internal/acp1/wireshark/dhs_acpv1.lua"
+  tasks:
+    - name: Locate the global wireshark plugins dir
+      ansible.builtin.shell: ls -d /usr/lib*/wireshark/plugins/*/ 2>/dev/null | head -1
+      register: plugdir
+      changed_when: false
+      failed_when: false
+
+    - name: Copy dissector to the global plugins dir
+      ansible.builtin.copy:
+        src: "{{ lua_src }}"
+        dest: "{{ plugdir.stdout }}dhs_acpv1.lua"
+        mode: "0644"
+      when: plugdir.stdout | length > 0
+
+    - name: Ensure personal plugins dir exists
+      ansible.builtin.file:
+        path: /root/.local/lib/wireshark/plugins
+        state: directory
+        mode: "0755"
+
+    - name: Copy dissector to the personal plugins dir
+      ansible.builtin.copy:
+        src: "{{ lua_src }}"
+        dest: /root/.local/lib/wireshark/plugins/dhs_acpv1.lua
+        mode: "0644"
+
+    - name: Verify tshark registers the dissector (NOT_LOADED where tshark lacks Lua)
+      ansible.builtin.shell: tshark -G protocols 2>/dev/null | grep -i acpv1 || echo NOT_LOADED
+      register: verify
+      changed_when: false
+
+    - name: Show dissector registration per host
+      ansible.builtin.debug:
+        msg: "{{ inventory_hostname }}: {{ verify.stdout }}"


### PR DESCRIPTION
﻿Adds two ansible playbooks (point #6 of the ACP1 close-out punch-list), matching the existing producer-frame.yml conventions.

- deploy-dissector.yml — pushes internal/acp1/wireshark/dhs_acpv1.lua to the Wireshark plugins dir across the linux fleet so tshark decodes ACP1 (udp/tcp 2071). Idempotent.
- acp1-capture.yml — pcap relay: capture on a host whose tshark lacks Lua (RHEL/Rocky ship Wireshark without Lua) via dumpcap, fetch, decode on the controller (which has the dissector).

Both verified live in the lab this session. No Go code changes.

Generated with Claude Code
