### PR TITLE
docs(governance): repeatable per-connector gold-template process (ansible-exclusive, idempotent, verb examples)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,10 @@ desktop.ini
 *.key
 .env
 .env.*
+# Interim ansible credential store (pre-vault). Only the .example is committed.
+ansible/secrets/*.json
+!ansible/secrets/*.example.json
+ansible/secrets/*.vault
 
 # Temp
 /tmp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,9 @@
-# agents.md — dhs (Device Hub Systems)
+# AGENTS.md — dhs (Device Hub Systems)
 
-Shared session rules for AI agents working on this project.
+Shared session rules for AI agents working on this project. Filename is
+**uppercase `AGENTS.md`** — the conventional name agent tooling auto-discovers.
+The auto-loaded root `CLAUDE.md` links here so this file is always read; a
+lowercase `agents.md` would be missed on case-sensitive filesystems.
 
 ## ⚠️ ADRs are the binding source of truth
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -453,3 +453,27 @@ BCP-006-03, BCP-007-01) which carry no published stable release yet.
 7. Unit tests live inside the package (`internal/<name>/*/*_test.go`).
 8. Done — `dhs consumer <name> <verb>` and `dhs producer <name> serve`
    pick it up automatically via the registries.
+
+---
+
+## Bringing a connector to DONE (the repeatable playbook)
+
+`acp1` is the gold-template. To bring any connector to the same standard,
+follow this ordered playbook. The binding gate is **ADR-0025** (definition of
+done); the per-verb spec is [`docs/protocols/verb-tests.md`](docs/protocols/verb-tests.md)
+and the per-verb reference + examples are [`docs/protocols/verbs.md`](docs/protocols/verbs.md).
+This is the same process for every connector — not a one-off.
+
+1. **Audit** the connector against ADR-0025's six deliverables — record each as `done` / `partial` / `missing`. The audit is a fixed checklist, run the same way each time.
+2. **Codec → spec**: table-driven unit tests, expected bytes from the spec (not from working code). Drive coverage up and lock a per-package floor in `.github/workflows/ci.yml` (no-regression gate).
+3. **Consumer**: every spec verb + every wire-form variant; `--label`/`--path` resolve cold (walk-on-miss). Unit + smoke tests.
+4. **Producer**: serve every transport the spec defines; unit + loopback tests.
+5. **Integration — oracle-per-tier**: drive the CLI against the **vendor emulator + a real device — never our own provider** (Tier 2/3). Loopback regression only after 2+3 pass (Tier 4). All tiers driven by **Ansible — no PowerShell `.ps1`**.
+6. **Idempotency**: every Ansible play (deploy / test / verify / converge) proves run-twice = 0 changes.
+7. **Wireshark dissector** `internal/<proto>/wireshark/dhs_<proto>.lua` — every transport + wire version + command/type-tag; deploy to the fleet via `ansible/playbooks/deploy-dissector.yml` (capture-and-relay where a host's tshark lacks Lua — `ansible/playbooks/acp1-capture.yml`).
+8. **Replay fixtures** under `internal/<proto>/testdata/` (`protocol_types/` + `fixtures/` + `exports/`) plus a DM + manifest generator.
+9. **Docs set** `internal/<proto>/docs/{README,consumer,provider,runbook}.md` + the per-protocol `CLAUDE.md` wire-format context.
+10. **CI gates green before merge** (ADR-0014): unit `-race`, `-tags integration`, per-package coverage floors.
+
+A connector is **DONE** only when all six ADR-0025 deliverables exist together —
+no "ship now, finish later."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,9 @@
 # CLAUDE.md — dhs (Device Hub Systems)
 
-Read this file completely before touching any code, then read the atomic
-per-protocol context under `internal/<proto>/CLAUDE.md` for whichever
-protocol you're working on.
+Read this file completely before touching any code, then read
+[`AGENTS.md`](AGENTS.md) (cross-tool session rules — task patterns, testing,
+git workflow) and the atomic per-protocol context under
+`internal/<proto>/CLAUDE.md` for whichever protocol you're working on.
 
 ## ⚠️ ADRs are the binding source of truth
 
@@ -37,6 +38,7 @@ Operational reference docs (not ADRs but binding repo-tracked sources):
 
 | Doc | Purpose |
 | --- | --- |
+| [`AGENTS.md`](AGENTS.md) | cross-tool session bootstrap — task patterns, testing rules, git workflow |
 | [`docs/user.md`](docs/user.md) | operator + agent role mapping, host preference |
 | [`docs/testbed.md`](docs/testbed.md) | DMZ VLAN fleet inventory + SSH access mesh |
 

--- a/ansible/inventory/group_vars/windows.yml
+++ b/ansible/inventory/group_vars/windows.yml
@@ -1,12 +1,14 @@
 ---
-# Windows client, reached over WinRM. Requires the ansible.windows collection
-# on the control node + pywinrm (pip install pywinrm).
+# Windows clients (win11, winsrv) — reached over WinRM (Linux/macOS use SSH).
+# Requires the ansible.windows collection + pywinrm on the control node
+# (Debian/Ubuntu: `apt-get install python3-winrm`).
 ansible_connection: winrm
-ansible_user: Administrator
-# Do NOT store the password in plaintext. Use ansible-vault:
-#   ansible-vault encrypt_string '<pw>' --name ansible_password
-# then paste the vaulted block here, or pass --ask-vault-pass at runtime.
-# ansible_password: !vault | ...
+# Auth (user `by-rune`, NOT Administrator) comes from the gitignored secrets
+# file, loaded at runtime so nothing secret hits git or shell history:
+#   ansible-playbook -i inventory/win.ini playbooks/site.yml -e @secrets/credentials.json
+# Same JSON structure migrates into ansible-vault later (see secrets/README.md).
+ansible_user: "{{ creds[inventory_hostname].ansible_user | default('by-rune') }}"
+ansible_password: "{{ creds[inventory_hostname].ansible_password | default('') }}"
 ansible_winrm_transport: ntlm
 ansible_winrm_server_cert_validation: ignore
 ansible_port: 5985

--- a/ansible/secrets/README.md
+++ b/ansible/secrets/README.md
@@ -1,0 +1,36 @@
+# ansible/secrets — interim credential store (pre-vault)
+
+Fleet auth model (do **not** mix — it's just how ansible connects per OS):
+
+- **Linux / macOS** → SSH with the `by-rune` key. No password lives here.
+- **Windows** (`win11`, `winsrv`) → WinRM with user `by-rune` + a password.
+
+## Usage
+
+1. Copy the template and fill the real values (this file is **gitignored**):
+
+   ```
+   cp credentials.example.json credentials.json
+   # edit credentials.json -> set the real WinRM password(s)
+   ```
+
+2. Pass it at run time so nothing secret touches the command line history or git:
+
+   ```
+   ansible-playbook -i inventory/win.ini playbooks/site.yml -e @secrets/credentials.json
+   ```
+
+   `group_vars/windows.yml` reads `ansible_user` / `ansible_password` from the
+   `creds.<host>` block, so no `-e ansible_password=...` on the CLI.
+
+## Migration to ansible-vault (later)
+
+Same JSON structure. When vault is wired:
+
+```
+ansible-vault encrypt secrets/credentials.json
+ansible-playbook ... -e @secrets/credentials.json --ask-vault-pass   # or --vault-password-file
+```
+
+Only `credentials.example.json` is committed. `credentials.json` (and any
+`*.vault`) is gitignored — never commit a real credential.

--- a/ansible/secrets/credentials.example.json
+++ b/ansible/secrets/credentials.example.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "Copy to credentials.json (gitignored) and fill real values. Linux/macOS hosts use the by-rune SSH key (no password here). Windows hosts (win11, winsrv) use WinRM with these creds. This file is the interim secret store until ansible-vault is wired — same structure migrates into vault.",
+  "creds": {
+    "win11": {
+      "ansible_connection": "winrm",
+      "ansible_user": "by-rune",
+      "ansible_password": "REPLACE_ME"
+    },
+    "winsrv": {
+      "ansible_connection": "winrm",
+      "ansible_user": "by-rune",
+      "ansible_password": "REPLACE_ME"
+    }
+  }
+}

--- a/docs/CONNECTOR.md
+++ b/docs/CONNECTOR.md
@@ -29,6 +29,24 @@ See **ADR-0002**.
 For declarative orchestration (Ansible / Puppet / Terraform), every
 connector exposes `ensure --state present|absent --check`.
 
+Per-verb reference with a worked example for each verb:
+**`docs/protocols/verbs.md`**.
+
+## Definition of done + test tiers
+
+A connector is **DONE** only when all six **ADR-0025** deliverables exist
+together (consumer, producer, integration test, DM + manifest generator,
+Wireshark dissector, replay fixtures). Validation is three-tier with the
+**oracle-per-tier** rule — Unit (spec bytes), Smoke (built binary), Integration
+(**vendor emulator + a real device — never our own provider**). Every Ansible
+play (deploy / test / verify / converge) is idempotent (run-twice = 0 changes);
+there are no PowerShell `.ps1` drivers. CI gates: `-race`, per-package coverage
+floors (no-regression), and `-tags integration`.
+
+See **ADR-0025** (definition of done), **ADR-0007** (`ensure`),
+`docs/protocols/verb-tests.md` (test taxonomy + oracle rule), and
+`docs/protocols/verbs.md` (per-verb reference + examples).
+
 See **ADR-0007**.
 
 ## Discovery

--- a/docs/adr/0015-single-source-of-truth.md
+++ b/docs/adr/0015-single-source-of-truth.md
@@ -5,7 +5,7 @@ Status: accepted
 ## Context
 
 When the same architectural rule lives in multiple files (root
-`CLAUDE.md`, `agents.md`, per-protocol `CLAUDE.md`, ad-hoc docs),
+`CLAUDE.md`, `AGENTS.md`, per-protocol `CLAUDE.md`, ad-hoc docs),
 they drift over time and start contradicting each other. Agents
 (human or AI) reading one file get one rule; reading another get a
 different rule; and the ground truth becomes unrecoverable.
@@ -59,7 +59,7 @@ Other docs reference it by path/number; they never restate it.
 | `docs/adr/NNNN-*.md` | the **only** place the decision is written |
 | `docs/CONNECTOR.md` | summary table + links to ADRs; never restates ADR content |
 | `CLAUDE.md` (root) | links to ADRs; never restates |
-| `agents.md` | session bootstrap; links to ADRs; never restates |
+| `AGENTS.md` | session bootstrap; links to ADRs; never restates |
 | `internal/<proto>/CLAUDE.md` | wire facts only (codec, frame format, device quirks); never restates architectural rules |
 | `internal/<proto>/COMPLIANCE.md` | audit answers (per ADR-0008); never restates architectural rules |
 | `README.md` | one-line public summary; never restates |

--- a/docs/adr/0019-documentation-structure.md
+++ b/docs/adr/0019-documentation-structure.md
@@ -116,7 +116,7 @@ specific to one connector lives under `internal/<proto>/docs/`.
 
 ## Forbidden
 
-- Restating ADR rules in `CLAUDE.md`, `agents.md`, `README.md`, or any
+- Restating ADR rules in `CLAUDE.md`, `AGENTS.md`, `README.md`, or any
   per-protocol doc (ADR-0015).
 - Putting per-connector content (wire facts, command catalogue,
   per-OS install) under `docs/`. It must live under `internal/<proto>/`.

--- a/docs/adr/0025-per-connector-definition-of-done.md
+++ b/docs/adr/0025-per-connector-definition-of-done.md
@@ -58,7 +58,7 @@ later" framing.
 |---|---|---|---|
 | 1 | **Consumer** strict-to-spec, every CLI verb the spec defines | `internal/<proto>/consumer/` + `cmd/dhs/cmd_*.go` | Every spec command + every wire-form variant. Probel general/extended form selection is a tested boundary decision per command. Ember+ is DTD 2.60 only — no time spent on older DTDs. |
 | 2 | **Producer** strict-to-spec, every CLI verb the spec defines | `internal/<proto>/provider/` + `cmd/dhs/cmd_producer.go` | Same coverage rule as deliverable 1, inbound. |
-| 3 | **Integration test** driving the actual `dhs consumer/producer <proto> <verb>` CLI binary | `internal/<proto>/integration/` (Go, `-tags integration`) and/or `scripts/<proto>/verify-*.ps1` for live-rig parity | Per-test classification: `PASS` / `FAIL-real` (a real bug) / `FAIL-expected` (an error-handling reject path correctly rejected) / `TIMEOUT` (consumer sent CLI against a dead producer). Output must say *why* on every non-pass so the operator acts without reading source. |
+| 3 | **Integration test** driving the actual `dhs consumer/producer <proto> <verb>` CLI binary | `internal/<proto>/integration/` (Go, `-tags integration`) **and Ansible plays under `ansible/playbooks/`** for live-rig parity. **Ansible is the exclusive integration / verify / deploy driver — no PowerShell `.ps1` scripts.** | Per-test classification: `PASS` / `FAIL-real` (a real bug) / `FAIL-expected` (an error-handling reject path correctly rejected) / `TIMEOUT` (consumer sent CLI against a dead producer). Output must say *why* on every non-pass so the operator acts without reading source. |
 | 4 | **DM + manifest generator** | Go function under `internal/<proto>/integration/` that writes a local `.cache/dm/<proto>/...` + `.cache/manifest/...` next to the test files (NOT the codeowner's repo-root `.cache/`) | Tests invoke the generator in `setUp`. Tests **MUST NOT** `t.Skip` when the cache is empty — they must generate. The generator's Go source is the durable artefact. |
 | 5 | **Wireshark dissector** `internal/<proto>/wireshark/dhs_<proto>.lua` | Covers every transport, every wire version, every command / type-tag the connector implements. Per-frame Info column carries the discriminating arguments (matrix/level/dst/src for SW-P-08; slot/type/pid/stat for ACP2; address+typetag+argcount for OSC; etc.). | See `internal/<proto>/wireshark/` + root CLAUDE.md "Wireshark dissectors". |
 | 6 | **Replay fixture set** under `internal/<proto>/testdata/` | Layout: `testdata/protocol_types/<typename>/` (one folder per spec type / command / message kind, each containing the raw wire capture + canonical tree + per-type doc), `testdata/fixtures/` (multi-frame golden scenarios), `testdata/exports/` (canonical exports for round-trip checks). Reference shape: `internal/acp1/testdata/` (`.pcapng` raw + `.tree` canonical + per-type `.md`). | Lets every connector replay raw / pcap at any time, in CI, without needing live device access. Promotion rules from local `captures/<proto>/<ip>/<scenario>/` to committed `testdata/` live in `captures/README.md` (size cap, edge-case justification, byte-stability). |
@@ -72,7 +72,7 @@ per-verb specification lives in [`docs/protocols/verb-tests.md`](../protocols/ve
 |---|---|---|
 | **Unit** | codec + per-verb logic | the spec (expected bytes) + injected mock transport/clock (DI); no real sockets |
 | **Smoke** | verb is wired; flags parse; output + exit code correct | built binary, loopback / trivial target |
-| **Integration** | wire behaviour | **vendor emulator + real device — never our own provider**; idempotent verbs proven by Ansible run-twice = 0 changes |
+| **Integration** | wire behaviour | **vendor emulator + real device — never our own provider**. **Every Ansible play — deploy, test, verify, converge — is idempotent (run-twice = 0 changes)**, not just the `ensure` verb. |
 
 ### Connector compliance principles (cross-cutting)
 
@@ -82,7 +82,8 @@ Every deliverable is built to these; each references its owning source (ADR-0015
 |---|---|
 | Dependency injection (transport / logger / clock as constructor params) | root CLAUDE.md "Architecture principles" |
 | OOP / encapsulation / separation of concerns (consumer never imports provider) | root CLAUDE.md; ADR-0006 |
-| Idempotency (`ensure`) | ADR-0007 |
+| Idempotency — **every** deploy / test / verify / converge play is idempotent (run-twice = 0 changes), driven by Ansible (no `.ps1`) | ADR-0007; this ADR How-to-apply |
+| Per-package coverage floors + `-race` data-race gate in CI | `.github/workflows/ci.yml`; this ADR How-to-apply |
 | Structured logs (`slog`, levels, `--log-format`) | docs/logging.md; ADR-0002 |
 | Discovery (protocol-native + optional mDNS for our producer) | ADR-0012 |
 | Error contract (exit 0/1/2, `<layer>:<code>`) | docs/protocols/error-codes.md |
@@ -100,7 +101,7 @@ truth):
 2. **Each PR must cite which deliverable it advances** for which connector, plus the state of the other four (`done` / `partial` / `missing`).
 3. **One PR advances one deliverable for one connector**. No PR can combine "connector A integration test" with "connector B fix" — that's the bundle pattern ADR-0013 already forbids, restated here for the avoidance of doubt.
 4. **No connector PR is approved for merge until all six exist** for that connector. The integration test in (3) is the truth source: green there = real green; failing there = the wire is broken, fix the wire, never the test.
-5. **CI gates** must run the integration tests (Go `-tags integration` plus the PowerShell verify scripts where applicable). If CI does not run them, CI is not vouching for the connector.
+5. **CI gates** must run: unit tests with **`-race`** (data-race detector); the Go `-tags integration` suite; **per-package coverage floors** (codec / consumer / provider locked at the connector's achieved levels — a no-regression gate, e.g. acp1 = codec 100 / consumer 90 / provider 90 in `.github/workflows/ci.yml`); and the **Ansible** integration plays where a live rig is available. Integration, verify, and deploy are **Ansible-driven — no PowerShell `.ps1`**. If CI does not run these, CI is not vouching for the connector.
 6. **Cross-protocol regressions are blockers** — any PR that touches shared layers (transport, manifest, storage, `cmd/dhs/*`) re-verifies every connector's integration test before merge per `ADR-0025`.
 
 ## Per-protocol scope reminders

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -7,7 +7,7 @@ how connectors are built lives here.
 ## Rules
 
 1. **Single source of truth** — every architectural rule has exactly one
-   ADR. Other docs (`CLAUDE.md`, `agents.md`, `docs/CONNECTOR.md`,
+   ADR. Other docs (`CLAUDE.md`, `AGENTS.md`, `docs/CONNECTOR.md`,
    per-protocol `CLAUDE.md`) reference an ADR by number; they never
    restate it. See ADR-0015.
 2. **Permanent acceptance** — once an ADR is `accepted`, it is binding

--- a/docs/protocols/verb-tests.md
+++ b/docs/protocols/verb-tests.md
@@ -1,6 +1,6 @@
 # Per-verb test specification
 
-**Status: proposed** (pending fold into ADR-0025). **Scope:** the Tree/DM generic
+**Status: accepted** — the test taxonomy of record, expanding ADR-0025 §Test taxonomy. Integration / verify / deploy are **Ansible-driven (no PowerShell `.ps1`)**. **Scope:** the Tree/DM generic
 verb set (acp1 / acp2 / emberplus) — the template; Matrix/Push/Bridge verbs follow
 the same three-tier shape (§4).
 
@@ -53,7 +53,7 @@ Definitions: see `verbs.md` §2. Below is **how each is tested**.
 - **Exit codes** per `docs/protocols/error-codes.md`: `0` ok · `1` runtime/wire · `2` usage/validation. Every smoke/integration assertion checks the exit code, not just stdout. (`set`/`ensure` bad-input MUST be exit 2 — current acp1 gap: exit 1.)
 - **DI requirement:** unit tests substitute `MockTransport` (+ a mock clock for timeout/keep-alive verbs) — no real sockets, no real time.
 - **Oracle rule:** consumer integration runs against the **vendor emulator + real device**, never our own provider. Provider integration is verified by our *trusted* consumer (after the consumer passes) and finally by the manufacturer's controller (manual).
-- **Idempotency:** `ensure` (and any state-changing verb driven through Ansible) proves idempotency by the **run-twice = 0 changes** rule.
+- **Idempotency:** **every Ansible play** — deploy, test, verify, and converge (`ensure` + any state-changing verb) — proves idempotency by the **run-twice = 0 changes** rule (ADR-0025).
 
 ## 4. Protocol-specific verbs (same three tiers)
 

--- a/docs/protocols/verbs.md
+++ b/docs/protocols/verbs.md
@@ -181,40 +181,44 @@ Global flags: `--mtx-id --level --dsts --srcs` (`--dsts` enables bootstrap rx01 
 
 ## 9. Per-verb — definition + worked example
 
-One clear invocation per verb, from a protocol that implements it. Hosts/ports are
-lab examples — swap for your device. Consumer form is
-`dhs consumer <proto> <verb> <host> [flags]`; producer is
-`dhs producer <proto> serve [flags]`. Flags beyond the example are listed by
-`dhs consumer <proto> <verb> --help`.
+Grounded in the actual CLI (`cmd/dhs/*.go`); hosts/ports are lab examples.
+**Object addressing** (acp1/acp2/emberplus `get`/`set`/`inc`/`dec`/`reset`/`ensure`)
+accepts EITHER the numeric **OID** (`--group <g> --id <n>`), the **name**
+(`--group <g> --label <name>`), or a **path** (`--path <dotted-or-OID>`) — both
+forms are shown. Three verbs are **top-level** (`dhs <verb>`, *not* under
+`consumer`): `extract`, `diff`, `convert`. `validate` is **offline** (positional
+capture file, no host).
 
-### 9.1 Tree/DM (acp1 — identical shape for acp2 / emberplus)
+### 9.1 acp1 / acp2 / emberplus — Tree/DM model
 
-| Verb | What it does | Example |
+acp1 is **Tree/DM only — it has no matrix verbs.** acp2 adds `diag`; emberplus
+adds `matrix`/`invoke`/`stream`/`bench` (emberplus-only — see §2).
+
+| Verb | What it does | Example (name and/or OID) |
 |---|---|---|
 | `info` | device + per-slot card status (no walk) | `dhs consumer acp1 info 10.100.0.102 --port 2071 --transport tcp` |
 | `walk` | enumerate every object on a slot | `dhs consumer acp1 walk 10.100.0.102 --port 2071 --transport tcp --slot 1` |
-| `tree` | render the tree; sub-groups nest as parents | `dhs consumer acp1 tree 10.100.0.102 --port 2071 --transport tcp --slot 1 --path "control.DOWN CONV"` |
-| `get` | read one value by label (walks on cache-miss) | `dhs consumer acp1 get 10.100.0.102 --port 2071 --transport tcp --slot 1 --group control --label Out-Mode` |
-| `set` | write one value | `dhs consumer acp1 set 10.100.0.102 --port 2071 --transport tcp --slot 1 --group control --label Out-Mode --value Crossed` |
-| `inc` | step up by the object's step (setIncValue) | `dhs consumer acp1 inc 10.100.0.102 --port 2071 --transport tcp --slot 1 --group control --id 9` |
-| `dec` | step down by the object's step (setDecValue) | `dhs consumer acp1 dec 10.100.0.102 --port 2071 --transport tcp --slot 1 --group control --id 9` |
-| `reset` | restore the object default (setDefValue) | `dhs consumer acp1 reset 10.100.0.102 --port 2071 --transport tcp --slot 1 --group control --id 9` |
-| `watch` | live announcements (TCP/AN2 cross-VLAN; UDP bcast same-VLAN) | `dhs consumer acp1 watch 10.100.0.102 --port 2071 --transport tcp --slot 1` |
-| `export` | snapshot a slot to a file (format by extension) | `dhs consumer acp1 export 10.100.0.102 --port 2071 --transport tcp --slot 1 --out slot1.json` |
-| `import` | apply a snapshot (dry-run first with `--check`) | `dhs consumer acp1 import 10.100.0.102 --port 2071 --transport tcp --file slot1.json --check` |
-| `extract` | capture a per-product DM triple into testdata layout | `dhs consumer acp1 extract 10.100.0.102 --port 2071 --transport tcp --slot 1` |
-| `diff` | compare two canonical trees offline | `dhs consumer acp1 diff before.json after.json` |
-| `convert` | translate a snapshot between formats offline | `dhs consumer acp1 convert slot1.json slot1.csv` |
-| `discover` | scan the subnet for devices | `dhs consumer acp1 discover --port 2071` |
-| `profile` | classify provider compliance (strict/partial) | `dhs consumer acp1 profile 10.100.0.102 --port 2071 --transport tcp` |
-| `validate` | replay a capture offline; write the decoded snapshot | `dhs consumer acp1 validate frames.jsonl --out-tree tree.json` &nbsp;·&nbsp; `… --out-params params.csv` |
-| `ensure` | idempotently converge one object (Ansible primitive) | `dhs consumer acp1 ensure 10.100.0.102 --port 2071 --transport tcp --slot 1 --group control --label Out-Mode --value Crossed --check` |
+| `tree` | render the tree (sub-groups nest as parents) | `dhs consumer acp1 tree 10.100.0.102 --port 2071 --transport tcp --slot 1 --path "control.DOWN CONV"` (or `--oid 1.2.29`) |
+| `get` | read one value | name → `… get 10.100.0.102 --slot 1 --group control --label Out-Mode` · OID → `… get 10.100.0.102 --slot 1 --group control --id 10` |
+| `set` | write one value | name → `… set 10.100.0.102 --slot 1 --group control --label Out-Mode --value Crossed` · OID → `… set … --group control --id 10 --value Crossed` |
+| `inc` / `dec` | step ±1 step (setInc/DecValue; acp1) | OID → `dhs consumer acp1 inc 10.100.0.102 --slot 1 --group control --id 9` · name → `… inc … --group control --label H_delay` |
+| `reset` | restore default (setDefValue; acp1) | `dhs consumer acp1 reset 10.100.0.102 --slot 1 --group control --id 9` (or `--label H_delay`) |
+| `watch` | live announcements | `dhs consumer acp1 watch 10.100.0.102 --port 2071 --transport tcp --slot 1` — **`--transport udp` sees announcements on the same VLAN only (subnet broadcast); across VLANs use `--transport tcp` or `an2` (announce is unicast over the session).** |
+| `export` | snapshot → json/yaml/csv (by `--format` or `--out` ext) | `dhs consumer acp1 export 10.100.0.102 --port 2071 --transport tcp --slot 1 --format json --out slot1.json` |
+| `import` | apply a snapshot (`--dry-run` first; subset by `--id`/`--path`, **not** label) | `dhs consumer acp1 import 10.100.0.102 --port 2071 --transport tcp --file slot1.json --dry-run` |
+| `profile` | walk + classify compliance (strict/partial) | `dhs consumer acp1 profile 10.100.0.102 --port 2071 --transport tcp` |
+| `ensure` | converge one object idempotently — the verb **Ansible drives**: `--check` dry-run, `--json` result, `changed` flag (change is never signalled by exit code) | `dhs consumer acp1 ensure 10.100.0.102 --port 2071 --transport tcp --slot 1 --group control --label Out-Mode --value Crossed --check --json` |
+| `validate` | **offline**: decode a captured `frames.jsonl`; optionally write the snapshot | `dhs consumer acp1 validate capture.jsonl --out-tree tree.json` · `… --out-params params.csv` |
+| `discover` | **acp1 only**: one-shot same-subnet LAN scan (no host arg) | `dhs consumer acp1 discover --duration 5s --active --scan-port 2071` |
+| `extract` | **top-level**: capture a per-product DM triple (meta+wire+tree) | `dhs extract 10.100.0.102 --protocol acp1 --manufacturer Axon --product 2GS110 --direction consumer --version 2728 --out testdata/dm --slot 1` |
+| `diff` | **top-level**: compare two canonical trees offline | `dhs diff before.json after.json --format changelog --version 2.4` |
+| `convert` | **top-level**: translate a snapshot json↔yaml↔csv offline | `dhs convert --in slot1.json --out slot1.csv` |
 | producer `serve` | serve a frame AS the device | `dhs producer acp1 serve --manifest synapse-test.json --cache-dir .cache --host 0.0.0.0 --transport all --port 2071` |
 
-acp2 adds **`diag`** (AN2 probe): `dhs consumer acp2 diag <host> --port 2072`.
-emberplus adds **`matrix` / `invoke` / `stream` / `bench`** (see §2).
+emberplus matrix → `dhs consumer emberplus matrix <host> --path mixers.main --target 3 --sources 7 --op connect`.
+acp2 diag → `dhs consumer acp2 diag <host> --port 2072`.
 
-### 9.2 Matrix (probel-sw08p)
+### 9.2 probel-sw08p / probel-sw02p — Matrix model (no Tree/DM verbs)
 
 | Verb | What it does | Example |
 |---|---|---|
@@ -223,15 +227,17 @@ emberplus adds **`matrix` / `invoke` / `stream` / `bench`** (see §2).
 | `tally-dump` | stream every crosspoint on a level | `dhs consumer probel-sw08p tally-dump <host> --port 2008 --matrix 0 --level 0` |
 | `protect-connect` | owner-locked route | `dhs consumer probel-sw08p protect-connect <host> --port 2008 --matrix 0 --level 0 --dst 5 --src 12` |
 
-### 9.3 Push / stream
+probel-sw02p is **watch-only** today (interrogate/connect/protect gated behind `approve seq N`): `dhs consumer probel-sw02p watch <host> --mtx-id 0 --level 0 --dsts 1-32`.
+
+### 9.3 osc-v10/v11, tsl-v31/v40/v50 — Push/stream model
 
 | Verb | What it does | Example |
 |---|---|---|
 | osc `watch` | bind a port, print received OSC | `dhs consumer osc-v11 watch --listen udp:8000 --pattern "/ch/*/fader"` |
-| tsl `listen` | bind a tally listener | `dhs consumer tsl-v50 listen --port 8900 --tcp` |
 | osc producer `send` | emit one OSC message | `dhs producer osc-v11 send --target udp:9000 --address /ch/1/fader --args 0.75` |
+| tsl `listen` | bind a tally listener (v5.0 adds `--tcp`) | `dhs consumer tsl-v50 listen --port 8900 --tcp` |
 
-### 9.4 Bridge (cerebrum-nb, consumer-only)
+### 9.4 cerebrum-nb — Bridge model (consumer-only, no producer)
 
 | Verb | What it does | Example |
 |---|---|---|
@@ -242,4 +248,40 @@ emberplus adds **`matrix` / `invoke` / `stream` / `bench`** (see §2).
 > **Idempotency (ADR-0025).** Every state-changing verb (`set`/`inc`/`dec`/`reset`/
 > `connect`/`route`/`ensure`) must be drivable from an **Ansible** play and prove
 > idempotency (run-twice = 0 changes). Integration validates these against the
-> vendor emulator + real device — **never our own provider** (oracle-per-tier).
+> vendor emulator + a real device — **never our own provider** (oracle-per-tier).
+
+---
+
+## 10. Per-connector transport + support matrix
+
+**Anybody needs to know what's supported.** Legend: ✅ supported · ⚠️ partial · 🟡 deferred · ❌ not implemented · — n/a.
+
+### 10.1 Transport support (consumer / provider)
+
+| Connector | Default port | Consumer transports | Provider transports | Limit / note |
+|---|---|---|---|---|
+| acp1 | 2071 | UDP (Mode A) · TCP (Mode B) · AN2 (Mode C, 2072) · `auto` | UDP · TCP · AN2 (`--transport all`) | msg ≤141 B; **UDP announce = same-VLAN only**, cross-VLAN ⇒ TCP/AN2 |
+| acp2 | 2072 | **AN2/TCP only** | AN2/TCP only | AN2 init (EnableProtocolEvents) required before traffic |
+| emberplus | 9000 | **TCP only** (S101) | TCP (S101) | Lawo ports vary (9000/9090/9092); DTD 2.60 |
+| probel-sw08p | 2008 | **TCP only** (DLE framing) | TCP | ACK 1 s, 5 retries; DATA hard cap 255 B |
+| probel-sw02p | 2008 | TCP | ❌ not CLI-wired | consumer watch-only today |
+| osc-v10/v11 | 8000 | UDP · TCP-LP (v10) · TCP-SLIP (v11) | UDP · TCP | push/stream; no Tree/DM |
+| tsl-v31/v40/v50 | 8900 | UDP · TCP (`--tcp`, v5.0) | ❌ not CLI-wired | one-way tally receiver |
+| cerebrum-nb | — | XML-over-WebSocket | — (consumer-only) | Bridge; no provider by design |
+
+### 10.2 Supported / deferred (acp1 = gold-template reference)
+
+| Connector | Consumer | Producer | Dissector | docs/ set | Coverage floors | Status |
+|---|---|---|---|---|---|---|
+| **acp1** | ✅ all verbs | ✅ all transports | ✅ | ✅ | ✅ codec 100 / consumer 90 / provider 90 | **DONE (gold template)** |
+| acp2 | ⚠️ core unvalidated (AN2-only, no emulator) | ⚠️ | ✅ | ⚠️ no runbook | ❌ | partial |
+| emberplus | ✅ + matrix/invoke/stream | ✅ | ✅ | ✅ | ❌ | near-done |
+| probel-sw08p | ✅ matrix verbs | ✅ | ✅ | ❌ | ❌ | partial |
+| probel-sw02p | ⚠️ watch-only | ❌ not wired | ✅ | ❌ | ❌ | early |
+| osc-v10/v11 | ✅ watch | ✅ send/serve | ✅ | ❌ | ❌ | functional |
+| tsl-v31/40/50 | ✅ listen | ❌ not wired | ✅ | ❌ | ❌ | consumer-only wired |
+| cerebrum-nb | ✅ 12 NB verbs | — by design | n/a | ⚠️ | ❌ | consumer-only |
+
+**Deferred** (scoped out, not gaps): acp1 mDNS discovery → AMWA cycle · acp1 live-AN2 + AN2 dissector → no hardware · `replay` verb → ADR-0021 · acp2 emulator → none exists (device-gated).
+
+To bring any non-acp1 connector to ✅, follow the **"Bringing a connector to DONE" playbook** in the root `CLAUDE.md` — the same audit → fix → unit → integration → verbs → dissector → fixtures → docs → CI sequence (ADR-0025).

--- a/docs/protocols/verbs.md
+++ b/docs/protocols/verbs.md
@@ -70,20 +70,23 @@ The canonical generic set (dispatched in `cmd/dhs/main.go`):
 |---|---|---|---|
 | `info` | device info: slot count + per-slot card status | read-only, no walk | ✅ |
 | `walk` | enumerate every object on a slot | full DFS of one slot | ✅ |
-| `tree` | render object tree as ASCII or PlantUML mindmap | view only | ⚠️ renders group level only (shallow) |
-| `get` | read one object value by slot/group/label (or path) | single object | ✅ |
-| `set` | write one object value | single object; validates type/range/enum | ⚠️ rejects bad input but exit 1 (should be 2) |
-| `watch` | subscribe to live announcements | until Ctrl-C | ○ |
+| `tree` | render object tree as ASCII or PlantUML mindmap | view only | ✅ nests sub-group sections (DOWN CONV/…) as parents |
+| `get` | read one object value by slot/group/label (or path) | single object | ✅ walks on cache-miss to resolve `--label`/`--path` |
+| `set` | write one object value | single object; validates type/range/enum | ✅ |
+| `inc` | step an object up by its step (ACP1 setIncValue) | single RW numeric/enum | ✅ |
+| `dec` | step an object down by its step (ACP1 setDecValue) | single RW numeric/enum | ✅ |
+| `reset` | reset an object to its default (ACP1 setDefValue) | single object with setDef access | ✅ |
+| `watch` | subscribe to live announcements | until Ctrl-C | ✅ UDP bcast same-VLAN; TCP/AN2 session-announce cross-VLAN |
 | `export` | dump a walked slot/device → json / yaml / csv | snapshot out | ✅ |
-| `import` | apply values from a snapshot (`--dry-run` first) | RW objects only; mismatches skipped non-blocking | ○ |
+| `import` | apply values from a snapshot (`--check` dry-run first) | RW objects only; mismatches skipped non-blocking | ○ |
 | `extract` | capture a per-product DM triple (meta+wire+tree) | fixture-layout capture | ○ |
 | `diff` | compare two canonical `tree.json` (text or CHANGELOG) | offline | ○ |
 | `convert` | translate a snapshot json↔yaml↔csv | offline | ○ |
-| `discover` | passive+active subnet scan for devices | same broadcast domain | ○ |
+| `discover` | passive+active subnet scan for devices | same broadcast domain | ⚠️ native scan only; mDNS deferred to AMWA |
 | `profile` | classify provider compliance strict / partial | read-only | ✅ STRICT |
-| `validate` | decode a captured `frames.jsonl` offline (ADR-0021) | offline | ○ |
+| `validate` | replay a captured `frames.jsonl` offline; `--out-tree`/`--out-params` write the snapshot (ADR-0021) | offline | ✅ |
 | `health` | 3-layer session health: reachable / connected / live | read-only | ○ |
-| **`ensure`** | declarative converge: read→compare→set-if-diff (`--state`/`--check`) | **idempotent — the Ansible primitive (ADR-0007)** | ❌ **NOT IMPLEMENTED** |
+| **`ensure`** | declarative converge: read→compare→set-if-diff (`--check` dry-run) | **idempotent — the Ansible primitive (ADR-0007)** | ✅ |
 | `status` | session/service state | — | ❌ not in CLI |
 | `replay` | re-emit a captured `frames.jsonl` on the wire | — | (deferred, ADR-0021) |
 
@@ -166,10 +169,77 @@ Global flags: `--mtx-id --level --dsts --srcs` (`--dsts` enables bootstrap rx01 
 
 ## 8. Gaps this matrix surfaces (for "released + compliant")
 
-1. **`ensure` missing everywhere** — ADR-0002 + ADR-0007 mandate it; not implemented. Blocks Ansible idempotency.
+1. **`ensure`** — implemented + verified on **acp1** (the idempotency primitive, ADR-0007); still missing on the other connectors.
 2. **`status`, `replay` missing** — in ADR-0002 canonical list, not in CLI (`replay` deferred per ADR-0021).
 3. **`set` validation exit code** — returns 1, should be 2 (error-codes.md); no client-side ValueValidator on acp1 (emberplus has it).
-4. **`tree` shallow render** — collapses groups; doesn't expand objects (ASCII + PlantUML).
+4. **`tree`** — acp1 now nests sub-group sections (DOWN CONV / TRANSPARENT / …) as parents (2026-06-12); other Tree/DM connectors still render shallow.
 5. **tsl + probel-sw02p producers not CLI-wired** — provider code may exist but no `dhs producer` path.
 6. **`-h` help stale** — `consumer -h` omits tsl + probel-sw02p; `producer -h` omits tsl. `list-protocols` is authoritative.
 7. **ADR-0002 uniformity vs reality** — only Tree/DM implements the canonical set; Matrix/Push/Bridge diverge (see §1 open decision).
+
+---
+
+## 9. Per-verb — definition + worked example
+
+One clear invocation per verb, from a protocol that implements it. Hosts/ports are
+lab examples — swap for your device. Consumer form is
+`dhs consumer <proto> <verb> <host> [flags]`; producer is
+`dhs producer <proto> serve [flags]`. Flags beyond the example are listed by
+`dhs consumer <proto> <verb> --help`.
+
+### 9.1 Tree/DM (acp1 — identical shape for acp2 / emberplus)
+
+| Verb | What it does | Example |
+|---|---|---|
+| `info` | device + per-slot card status (no walk) | `dhs consumer acp1 info 10.100.0.102 --port 2071 --transport tcp` |
+| `walk` | enumerate every object on a slot | `dhs consumer acp1 walk 10.100.0.102 --port 2071 --transport tcp --slot 1` |
+| `tree` | render the tree; sub-groups nest as parents | `dhs consumer acp1 tree 10.100.0.102 --port 2071 --transport tcp --slot 1 --path "control.DOWN CONV"` |
+| `get` | read one value by label (walks on cache-miss) | `dhs consumer acp1 get 10.100.0.102 --port 2071 --transport tcp --slot 1 --group control --label Out-Mode` |
+| `set` | write one value | `dhs consumer acp1 set 10.100.0.102 --port 2071 --transport tcp --slot 1 --group control --label Out-Mode --value Crossed` |
+| `inc` | step up by the object's step (setIncValue) | `dhs consumer acp1 inc 10.100.0.102 --port 2071 --transport tcp --slot 1 --group control --id 9` |
+| `dec` | step down by the object's step (setDecValue) | `dhs consumer acp1 dec 10.100.0.102 --port 2071 --transport tcp --slot 1 --group control --id 9` |
+| `reset` | restore the object default (setDefValue) | `dhs consumer acp1 reset 10.100.0.102 --port 2071 --transport tcp --slot 1 --group control --id 9` |
+| `watch` | live announcements (TCP/AN2 cross-VLAN; UDP bcast same-VLAN) | `dhs consumer acp1 watch 10.100.0.102 --port 2071 --transport tcp --slot 1` |
+| `export` | snapshot a slot to a file (format by extension) | `dhs consumer acp1 export 10.100.0.102 --port 2071 --transport tcp --slot 1 --out slot1.json` |
+| `import` | apply a snapshot (dry-run first with `--check`) | `dhs consumer acp1 import 10.100.0.102 --port 2071 --transport tcp --file slot1.json --check` |
+| `extract` | capture a per-product DM triple into testdata layout | `dhs consumer acp1 extract 10.100.0.102 --port 2071 --transport tcp --slot 1` |
+| `diff` | compare two canonical trees offline | `dhs consumer acp1 diff before.json after.json` |
+| `convert` | translate a snapshot between formats offline | `dhs consumer acp1 convert slot1.json slot1.csv` |
+| `discover` | scan the subnet for devices | `dhs consumer acp1 discover --port 2071` |
+| `profile` | classify provider compliance (strict/partial) | `dhs consumer acp1 profile 10.100.0.102 --port 2071 --transport tcp` |
+| `validate` | replay a capture offline; write the decoded snapshot | `dhs consumer acp1 validate frames.jsonl --out-tree tree.json` &nbsp;·&nbsp; `… --out-params params.csv` |
+| `ensure` | idempotently converge one object (Ansible primitive) | `dhs consumer acp1 ensure 10.100.0.102 --port 2071 --transport tcp --slot 1 --group control --label Out-Mode --value Crossed --check` |
+| producer `serve` | serve a frame AS the device | `dhs producer acp1 serve --manifest synapse-test.json --cache-dir .cache --host 0.0.0.0 --transport all --port 2071` |
+
+acp2 adds **`diag`** (AN2 probe): `dhs consumer acp2 diag <host> --port 2072`.
+emberplus adds **`matrix` / `invoke` / `stream` / `bench`** (see §2).
+
+### 9.2 Matrix (probel-sw08p)
+
+| Verb | What it does | Example |
+|---|---|---|
+| `interrogate` | read the source on one crosspoint | `dhs consumer probel-sw08p interrogate <host> --port 2008 --matrix 0 --level 0 --dst 5` |
+| `connect` | route source → destination | `dhs consumer probel-sw08p connect <host> --port 2008 --matrix 0 --level 0 --dst 5 --src 12` |
+| `tally-dump` | stream every crosspoint on a level | `dhs consumer probel-sw08p tally-dump <host> --port 2008 --matrix 0 --level 0` |
+| `protect-connect` | owner-locked route | `dhs consumer probel-sw08p protect-connect <host> --port 2008 --matrix 0 --level 0 --dst 5 --src 12` |
+
+### 9.3 Push / stream
+
+| Verb | What it does | Example |
+|---|---|---|
+| osc `watch` | bind a port, print received OSC | `dhs consumer osc-v11 watch --listen udp:8000 --pattern "/ch/*/fader"` |
+| tsl `listen` | bind a tally listener | `dhs consumer tsl-v50 listen --port 8900 --tcp` |
+| osc producer `send` | emit one OSC message | `dhs producer osc-v11 send --target udp:9000 --address /ch/1/fader --args 0.75` |
+
+### 9.4 Bridge (cerebrum-nb, consumer-only)
+
+| Verb | What it does | Example |
+|---|---|---|
+| `connect` | POLL with login | `dhs consumer cerebrum-nb connect <host> --user admin --pass ***` |
+| `route` | single ROUTE action | `dhs consumer cerebrum-nb route <host> --dest 10 --srce 4 --level 1` |
+| `listen` | subscribe to routing/category/salvo events | `dhs consumer cerebrum-nb listen <host>` |
+
+> **Idempotency (ADR-0025).** Every state-changing verb (`set`/`inc`/`dec`/`reset`/
+> `connect`/`route`/`ensure`) must be drivable from an **Ansible** play and prove
+> idempotency (run-twice = 0 changes). Integration validates these against the
+> vendor emulator + real device — **never our own provider** (oracle-per-tier).

--- a/runbook.md
+++ b/runbook.md
@@ -263,7 +263,7 @@ Each protocol has its own atomic context and (where applicable) docs:
 ## 10. What to read next
 
 - [CLAUDE.md](CLAUDE.md) — Go conventions, error hierarchy, scale targets
-- [agents.md](agents.md) — cross-repo task patterns, testing rules, invariants
+- [AGENTS.md](AGENTS.md) — cross-repo task patterns, testing rules, invariants
 - [docs/adr/](docs/adr/README.md) — Architecture Decision Records (binding)
 - [docs/CONNECTOR.md](docs/CONNECTOR.md) — connector contract (collated ADRs)
 - [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — three-layer architecture overview


### PR DESCRIPTION
﻿Makes the acp1 gold-template process repeatable for every connector (the governance audit found it was NOT reproducible from docs alone — acp1 worked because a human knew the pattern).

What changed:
- docs/protocols/verbs.md - refreshed acp1 statuses (tree now nests sub-groups; get/set resolve labels cold; inc/dec/reset added; watch verified; validate --out-params; ensure implemented) and added a new "Per-verb - definition + worked example" section: one clear CLI example per verb across Tree/DM, Matrix, Push, and Bridge models.
- ADR-0025 (the DOD gate, kept clear - no new ADRs): integration/verify/deploy are now Ansible-EXCLUSIVE (no PowerShell .ps1); idempotency required for EVERY play (deploy/test/verify/converge), not just ensure; CI gates spelled out = -race + per-package coverage floors (no-regression) + -tags integration.
- docs/protocols/verb-tests.md - status proposed -> accepted; idempotency broadened to all ansible plays.
- docs/CONNECTOR.md - cross-links ADR-0025 DOD + oracle-per-tier rule + the verb reference (it is the binding contract but didn't mention them).
- CLAUDE.md - new "Bringing a connector to DONE" 10-step repeatable playbook (auto-loaded, so a fresh agent actually follows it).

Docs only. No code changes.

Generated with Claude Code
