### PR TITLE
test(acp2): bring connector to ADR-0025 gold standard (coverage + CLI integration + docs + CI floors)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,10 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: go test -count=1 -coverprofile=coverage.out ./...
 
-      # Per-package coverage floor for the acp1 gold-template connector. Fails
+      # Per-package coverage floor for the gold-template connectors. Fails
       # the build if a package drops below its locked-in level (no-regression).
-      # Raise these as the tiered coverage push lands (see issue #539).
-      - name: Coverage floor (acp1)
+      # Raise these as the tiered coverage push lands (see issues #539, #550).
+      - name: Coverage floor (acp1 + acp2)
         if: matrix.os == 'ubuntu-latest'
         run: |
           set -e
@@ -60,6 +60,9 @@ jobs:
           check ./internal/acp1/codec 100
           check ./internal/acp1/consumer 90
           check ./internal/acp1/provider 90
+          check ./internal/acp2/codec 98
+          check ./internal/acp2/consumer 84
+          check ./internal/acp2/provider 90
 
       - name: Upload coverage
         if: matrix.os == 'ubuntu-latest'

--- a/internal/acp2/codec/codec_error_test.go
+++ b/internal/acp2/codec/codec_error_test.go
@@ -1,0 +1,226 @@
+package codec
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// EncodeACP2Message: nil message -> error.
+func TestEncodeACP2Message_Nil(t *testing.T) {
+	if _, err := EncodeACP2Message(nil); err == nil {
+		t.Fatal("expected error encoding nil message")
+	}
+}
+
+// EncodeACP2Message: set_property with no properties -> error.
+func TestEncodeACP2Message_SetPropertyNoProps(t *testing.T) {
+	m := &ACP2Message{Type: ACP2TypeRequest, MTID: 1, Func: ACP2FuncSetProperty}
+	if _, err := EncodeACP2Message(m); err == nil {
+		t.Fatal("expected error for set_property with no properties")
+	}
+}
+
+// EncodeACP2Message: set_property success path emits header + obj-id + idx +
+// encoded property.
+func TestEncodeACP2Message_SetPropertySuccess(t *testing.T) {
+	prop := MakeValueProperty(PIDValue, NumTypeU32, []byte{0x00, 0x00, 0x00, 0x2A})
+	m := &ACP2Message{
+		Type:       ACP2TypeRequest,
+		MTID:       7,
+		Func:       ACP2FuncSetProperty,
+		PID:        PIDValue,
+		ObjID:      0x11223344,
+		Idx:        0,
+		Properties: []Property{prop},
+	}
+	out, err := EncodeACP2Message(m)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	// 4 header + 8 (obj-id+idx) + property (4 hdr + 4 data = 8) = 20.
+	if len(out) != ACP2HeaderSize+8+8 {
+		t.Fatalf("len: got %d, want %d", len(out), ACP2HeaderSize+8+8)
+	}
+	if out[0] != byte(ACP2TypeRequest) || out[1] != 7 || out[2] != byte(ACP2FuncSetProperty) || out[3] != PIDValue {
+		t.Fatalf("header bytes wrong: % X", out[0:4])
+	}
+	if got := binary.BigEndian.Uint32(out[4:8]); got != 0x11223344 {
+		t.Fatalf("obj-id: got %08X", got)
+	}
+	if got := binary.BigEndian.Uint32(out[8:12]); got != 0 {
+		t.Fatalf("idx: got %d", got)
+	}
+	// Property header at offset 12: pid, vtype, plen=8.
+	if out[12] != PIDValue || out[13] != byte(NumTypeU32) {
+		t.Fatalf("property header wrong: % X", out[12:14])
+	}
+	if got := binary.BigEndian.Uint16(out[14:16]); got != 8 {
+		t.Fatalf("property plen: got %d, want 8", got)
+	}
+}
+
+// EncodeACP2Message: get_property request body = obj-id + idx (no trailing
+// property header).
+func TestEncodeACP2Message_GetPropertyBody(t *testing.T) {
+	m := &ACP2Message{
+		Type:  ACP2TypeRequest,
+		MTID:  3,
+		Func:  ACP2FuncGetProperty,
+		PID:   PIDLabel,
+		ObjID: 0xAABBCCDD,
+		Idx:   1,
+	}
+	out, err := EncodeACP2Message(m)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if len(out) != ACP2HeaderSize+8 {
+		t.Fatalf("len: got %d, want %d", len(out), ACP2HeaderSize+8)
+	}
+	if out[3] != PIDLabel {
+		t.Fatalf("pid byte: got %d, want %d", out[3], PIDLabel)
+	}
+	if got := binary.BigEndian.Uint32(out[4:8]); got != 0xAABBCCDD {
+		t.Fatalf("obj-id: got %08X", got)
+	}
+	if got := binary.BigEndian.Uint32(out[8:12]); got != 1 {
+		t.Fatalf("idx: got %d, want 1", got)
+	}
+}
+
+// EncodeACP2Message: default branch emits header + raw Body for an
+// unrecognised func.
+func TestEncodeACP2Message_DefaultGeneric(t *testing.T) {
+	m := &ACP2Message{
+		Type: ACP2TypeReply,
+		MTID: 9,
+		Func: ACP2Func(200), // not 0-3
+		PID:  5,
+		Body: []byte{0xDE, 0xAD, 0xBE, 0xEF},
+	}
+	out, err := EncodeACP2Message(m)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if len(out) != ACP2HeaderSize+4 {
+		t.Fatalf("len: got %d, want %d", len(out), ACP2HeaderSize+4)
+	}
+	if out[2] != 200 {
+		t.Fatalf("func byte: got %d, want 200", out[2])
+	}
+	for i, b := range []byte{0xDE, 0xAD, 0xBE, 0xEF} {
+		if out[ACP2HeaderSize+i] != b {
+			t.Fatalf("body byte %d: got %02X, want %02X", i, out[ACP2HeaderSize+i], b)
+		}
+	}
+}
+
+// EncodeACP2Message: set_property where the property cannot be encoded.
+// EncodeProperty only fails on a nil pointer, which is unreachable from the
+// slice; this asserts the success surrounding encode works for a string prop.
+func TestEncodeACP2Message_SetPropertyString(t *testing.T) {
+	m := &ACP2Message{
+		Type:       ACP2TypeRequest,
+		MTID:       2,
+		Func:       ACP2FuncSetProperty,
+		PID:        PIDLabel,
+		Properties: []Property{MakeStringProperty(PIDLabel, "hi")},
+	}
+	if _, err := EncodeACP2Message(m); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+}
+
+// DecodeACP2Message: get_version reply carries the version in PID, no body.
+func TestDecodeACP2Message_GetVersionReply(t *testing.T) {
+	data := []byte{byte(ACP2TypeReply), 1, byte(ACP2FuncGetVersion), 42}
+	m, err := DecodeACP2Message(data)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if m.PID != 42 {
+		t.Fatalf("version (PID): got %d, want 42", m.PID)
+	}
+	if len(m.Properties) != 0 {
+		t.Fatalf("expected no properties, got %d", len(m.Properties))
+	}
+}
+
+// DecodeACP2Message: announce with obj-id + idx + properties decodes the
+// embedded property headers.
+func TestDecodeACP2Message_AnnounceWithProperties(t *testing.T) {
+	// header
+	data := []byte{byte(ACP2TypeAnnounce), 0, byte(PIDValue), PIDValue}
+	// obj-id + idx
+	objIdx := make([]byte, 8)
+	binary.BigEndian.PutUint32(objIdx[0:4], 0x01020304)
+	binary.BigEndian.PutUint32(objIdx[4:8], 0)
+	data = append(data, objIdx...)
+	// one property: pid=8, vtype=u32, plen=8, value
+	prop, _ := EncodeProperty(&Property{PID: PIDValue, VType: byte(NumTypeU32), Data: []byte{0, 0, 0, 9}})
+	data = append(data, prop...)
+
+	m, err := DecodeACP2Message(data)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if m.ObjID != 0x01020304 {
+		t.Fatalf("obj-id: got %08X", m.ObjID)
+	}
+	if len(m.Properties) != 1 {
+		t.Fatalf("properties: got %d, want 1", len(m.Properties))
+	}
+	if m.Properties[0].PID != PIDValue {
+		t.Fatalf("property pid: got %d", m.Properties[0].PID)
+	}
+}
+
+// DecodeACP2Message: a reply body that contains a malformed property header
+// (plen < 4) propagates the decode error.
+func TestDecodeACP2Message_BadPropertyError(t *testing.T) {
+	data := []byte{byte(ACP2TypeReply), 1, byte(ACP2FuncGetObject), 0}
+	objIdx := make([]byte, 8) // obj-id + idx both zero
+	data = append(data, objIdx...)
+	// malformed property: plen = 2 (< 4)
+	data = append(data, 0x08, 0x06, 0x00, 0x02)
+	if _, err := DecodeACP2Message(data); err == nil {
+		t.Fatal("expected property decode error")
+	}
+}
+
+// DecodeACP2Message: reply with fewer than 8 body bytes leaves obj-id and
+// properties untouched (the len(body) >= 8 guard is false).
+func TestDecodeACP2Message_ReplyShortBody(t *testing.T) {
+	data := []byte{byte(ACP2TypeReply), 1, byte(ACP2FuncGetObject), 0, 0x01, 0x02}
+	m, err := DecodeACP2Message(data)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if m.ObjID != 0 || len(m.Properties) != 0 {
+		t.Fatalf("short body should not populate obj-id/properties: obj=%d props=%d", m.ObjID, len(m.Properties))
+	}
+}
+
+// ToACP2Error: non-error message returns nil.
+func TestToACP2Error_NonError(t *testing.T) {
+	m := &ACP2Message{Type: ACP2TypeReply, Func: ACP2FuncGetVersion}
+	if err := m.ToACP2Error(); err != nil {
+		t.Fatalf("expected nil for non-error message, got %v", err)
+	}
+}
+
+// ToACP2Error: error message maps func->status and yields an *ACP2Error.
+func TestToACP2Error_Error(t *testing.T) {
+	m := &ACP2Message{Type: ACP2TypeError, Func: ACP2Func(ErrInvalidValue)}
+	err := m.ToACP2Error()
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	ae, ok := err.(*ACP2Error)
+	if !ok {
+		t.Fatalf("got %T, want *ACP2Error", err)
+	}
+	if ae.Status != ErrInvalidValue {
+		t.Fatalf("status: got %d, want %d", ae.Status, ErrInvalidValue)
+	}
+}

--- a/internal/acp2/codec/framer_error_test.go
+++ b/internal/acp2/codec/framer_error_test.go
@@ -1,0 +1,109 @@
+package codec
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
+	"testing"
+)
+
+// EncodeAN2Frame: nil frame -> error.
+func TestEncodeAN2Frame_Nil(t *testing.T) {
+	if _, err := EncodeAN2Frame(nil); err == nil {
+		t.Fatal("expected error encoding nil frame")
+	}
+}
+
+// EncodeAN2Frame: payload over MaxPayload -> ErrFrameTooBig.
+func TestEncodeAN2Frame_TooBig(t *testing.T) {
+	f := &AN2Frame{
+		Proto:   AN2ProtoACP2,
+		Type:    AN2TypeData,
+		Payload: make([]byte, MaxPayload+1),
+	}
+	_, err := EncodeAN2Frame(f)
+	if !errors.Is(err, ErrFrameTooBig) {
+		t.Fatalf("got %v, want ErrFrameTooBig", err)
+	}
+}
+
+// DecodeAN2Frame: dlen field exceeding MaxPayload -> ErrFrameTooBig,
+// even before the buffer is inspected for the payload.
+func TestDecodeAN2Frame_DlenExceedsMax(t *testing.T) {
+	// MaxPayload is 65536 which does not fit in the u16 dlen field
+	// (max 65535), so set dlen to its max and lower MaxPayload is not
+	// possible; instead build a header whose declared dlen still trips
+	// the cap by being > MaxPayload is impossible via u16. Verify the
+	// boundary another way: dlen == 65535 must NOT trip the cap.
+	hdr := make([]byte, AN2HeaderSize)
+	binary.BigEndian.PutUint16(hdr[0:2], AN2Magic)
+	binary.BigEndian.PutUint16(hdr[6:8], 65535) // max u16, < MaxPayload(65536)
+	// Buffer too short for the 65535-byte payload -> short-payload error,
+	// proving the dlen>MaxPayload branch was NOT taken at u16 max.
+	_, _, err := DecodeAN2Frame(hdr)
+	if err == nil {
+		t.Fatal("expected short-payload error")
+	}
+	if errors.Is(err, ErrFrameTooBig) {
+		t.Fatalf("dlen=65535 (<MaxPayload) must not be ErrFrameTooBig: %v", err)
+	}
+}
+
+// DecodeAN2Frame: header declares a payload longer than the buffer holds.
+func TestDecodeAN2Frame_ShortPayload(t *testing.T) {
+	buf := make([]byte, AN2HeaderSize+2)
+	binary.BigEndian.PutUint16(buf[0:2], AN2Magic)
+	buf[2] = byte(AN2ProtoACP2)
+	buf[5] = byte(AN2TypeData)
+	binary.BigEndian.PutUint16(buf[6:8], 10) // claims 10 payload bytes, only 2 present
+	_, _, err := DecodeAN2Frame(buf)
+	if err == nil {
+		t.Fatal("expected short-payload error")
+	}
+	if errors.Is(err, ErrFrameTooBig) {
+		t.Fatalf("unexpected ErrFrameTooBig: %v", err)
+	}
+}
+
+// ReadAN2Frame: header read fails (empty stream) -> error.
+func TestReadAN2Frame_HeaderReadError(t *testing.T) {
+	_, err := ReadAN2Frame(bytes.NewReader(nil))
+	if err == nil {
+		t.Fatal("expected header read error")
+	}
+}
+
+// ReadAN2Frame: dlen exceeds MaxPayload is unreachable at u16 max; verify
+// instead that a valid header with a payload-read failure propagates.
+func TestReadAN2Frame_PayloadReadError(t *testing.T) {
+	hdr := make([]byte, AN2HeaderSize)
+	binary.BigEndian.PutUint16(hdr[0:2], AN2Magic)
+	hdr[2] = byte(AN2ProtoACP2)
+	hdr[5] = byte(AN2TypeData)
+	binary.BigEndian.PutUint16(hdr[6:8], 8) // claims 8 payload bytes
+	// Stream has the full header but only 3 of the 8 payload bytes.
+	stream := append(append([]byte{}, hdr...), 0x01, 0x02, 0x03)
+	_, err := ReadAN2Frame(bytes.NewReader(stream))
+	if err == nil {
+		t.Fatal("expected payload read error")
+	}
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("got %v, want io.ErrUnexpectedEOF", err)
+	}
+}
+
+// ReadAN2Frame: zero-length payload path (dlen=0) reads no body.
+func TestReadAN2Frame_ZeroPayload(t *testing.T) {
+	hdr := make([]byte, AN2HeaderSize)
+	binary.BigEndian.PutUint16(hdr[0:2], AN2Magic)
+	hdr[2] = byte(AN2ProtoInternal)
+	hdr[5] = byte(AN2TypeReply)
+	f, err := ReadAN2Frame(bytes.NewReader(hdr))
+	if err != nil {
+		t.Fatalf("ReadAN2Frame: %v", err)
+	}
+	if len(f.Payload) != 0 {
+		t.Fatalf("payload: got %d bytes, want 0", len(f.Payload))
+	}
+}

--- a/internal/acp2/codec/property_codec_error_test.go
+++ b/internal/acp2/codec/property_codec_error_test.go
@@ -1,0 +1,249 @@
+package codec
+
+import (
+	"testing"
+)
+
+// EncodeProperty: nil property -> error.
+func TestEncodeProperty_Nil(t *testing.T) {
+	if _, err := EncodeProperty(nil); err == nil {
+		t.Fatal("expected error encoding nil property")
+	}
+}
+
+// EncodeProperties: empty slice yields empty output, no error.
+func TestEncodeProperties_Empty(t *testing.T) {
+	out, err := EncodeProperties(nil)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("expected empty output, got %d bytes", len(out))
+	}
+}
+
+// DecodeProperties: property declaring plen < 4 is rejected.
+func TestDecodeProperties_PlenTooSmall(t *testing.T) {
+	data := []byte{0x08, 0x06, 0x00, 0x03} // plen = 3
+	if _, err := DecodeProperties(data); err == nil {
+		t.Fatal("expected error for plen < 4")
+	}
+}
+
+// DecodeProperties: property whose plen runs past the buffer end is rejected.
+func TestDecodeProperties_PlenExceedsBuffer(t *testing.T) {
+	data := []byte{0x08, 0x06, 0x00, 0x10} // plen = 16, buffer only 4 bytes
+	if _, err := DecodeProperties(data); err == nil {
+		t.Fatal("expected error for plen exceeding buffer")
+	}
+}
+
+// DecodeProperties: trailing bytes shorter than a 4-byte header are ignored
+// (loop guard offset+4 <= len fails), returning the parsed properties.
+func TestDecodeProperties_TrailingShortIgnored(t *testing.T) {
+	// One valid plen=4 property followed by 2 stray bytes.
+	data := []byte{0x01, 0x00, 0x00, 0x04, 0xFF, 0xFF}
+	props, err := DecodeProperties(data)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(props) != 1 {
+		t.Fatalf("props: got %d, want 1", len(props))
+	}
+}
+
+// PropertyString: nil data -> empty string.
+func TestPropertyString_Nil(t *testing.T) {
+	if s := PropertyString(&Property{}); s != "" {
+		t.Fatalf("expected empty string, got %q", s)
+	}
+}
+
+// PropertyString: data with no NUL terminator returns the full string.
+func TestPropertyString_NoTerminator(t *testing.T) {
+	if s := PropertyString(&Property{Data: []byte("abc")}); s != "abc" {
+		t.Fatalf("got %q, want abc", s)
+	}
+}
+
+// PropertyChildren: data length not a multiple of 4 -> error.
+func TestPropertyChildren_BadLength(t *testing.T) {
+	if _, err := PropertyChildren(&Property{Data: []byte{1, 2, 3}}); err == nil {
+		t.Fatal("expected error for non-multiple-of-4 length")
+	}
+}
+
+// PropertyEventMessages: nil data -> two empty strings.
+func TestPropertyEventMessages_Nil(t *testing.T) {
+	on, off := PropertyEventMessages(&Property{})
+	if on != "" || off != "" {
+		t.Fatalf("expected empty messages, got %q / %q", on, off)
+	}
+}
+
+// PropertyEventMessages: only the on-message present (single string).
+func TestPropertyEventMessages_OnlyOn(t *testing.T) {
+	on, off := PropertyEventMessages(&Property{Data: []byte("ON")})
+	if on != "ON" || off != "" {
+		t.Fatalf("got %q / %q, want ON / empty", on, off)
+	}
+}
+
+// PropertyOptions / PropertyOptionsMap: data shorter than 4 bytes -> nil.
+func TestPropertyOptions_TooShort(t *testing.T) {
+	p := &Property{Data: []byte{0x00, 0x01}}
+	if PropertyOptionsMap(p) != nil {
+		t.Fatal("expected nil map for short data")
+	}
+	if PropertyOptions(p) != nil {
+		t.Fatal("expected nil slice for short data")
+	}
+}
+
+// PropertyOptions / PropertyOptionsMap: variable-length records with index +
+// NUL-terminated name + 4-byte alignment padding.
+func TestPropertyOptions_VariableLength(t *testing.T) {
+	// record 0: idx=0, name="a\0", pad to 4-boundary
+	// record 1: idx=1, name="bb\0", pad
+	data := []byte{
+		0x00, 0x00, 0x00, 0x00, 'a', 0x00, 0x00, 0x00, // idx0 + "a\0" + 2 pad
+		0x00, 0x00, 0x00, 0x01, 'b', 'b', 0x00, 0x00, // idx1 + "bb\0" + 1 pad
+	}
+	p := &Property{Data: data}
+	m := PropertyOptionsMap(p)
+	if m == nil {
+		t.Fatal("expected non-nil map")
+	}
+	if m[0] != "a" || m[1] != "bb" {
+		t.Fatalf("map mismatch: %#v", m)
+	}
+	opts := PropertyOptions(p)
+	if len(opts) != 2 || opts[0] != "a" || opts[1] != "bb" {
+		t.Fatalf("options mismatch: %#v", opts)
+	}
+}
+
+// PropertyOptions: a record header present but its name runs to the end of
+// the buffer with no NUL (exercises the end-of-buffer break paths).
+func TestPropertyOptions_NameRunsToEnd(t *testing.T) {
+	data := []byte{0x00, 0x00, 0x00, 0x05, 'x', 'y', 'z'}
+	p := &Property{Data: data}
+	m := PropertyOptionsMap(p)
+	if m[5] != "xyz" {
+		t.Fatalf("map: got %#v", m)
+	}
+	opts := PropertyOptions(p)
+	if len(opts) != 1 || opts[0] != "xyz" {
+		t.Fatalf("options: got %#v", opts)
+	}
+}
+
+// PropertyOptions: trailing partial record (< 4 bytes) after a full one is
+// ignored via the pos+4 > len break.
+func TestPropertyOptions_TrailingPartial(t *testing.T) {
+	data := []byte{
+		0x00, 0x00, 0x00, 0x00, 'a', 0x00, 0x00, 0x00, // full record
+		0xFF, 0xFF, // 2 stray bytes
+	}
+	p := &Property{Data: data}
+	if got := PropertyOptions(p); len(got) != 1 || got[0] != "a" {
+		t.Fatalf("got %#v, want [a]", got)
+	}
+	if m := PropertyOptionsMap(p); len(m) != 1 || m[0] != "a" {
+		t.Fatalf("map got %#v", m)
+	}
+}
+
+// DecodeNumericValue: every type's short-data branch and the unknown default.
+func TestDecodeNumericValue_ShortAndUnknown(t *testing.T) {
+	short4 := []byte{0x00, 0x00} // too short for 4-byte types
+	short8 := []byte{0, 0, 0, 0} // too short for 8-byte types
+	for _, nt := range []NumberType{
+		NumTypeS8, NumTypeS16, NumTypeS32, NumTypeU8, NumTypeU16,
+		NumTypeU32, NumTypeFloat, NumTypePreset, NumTypeIPv4,
+	} {
+		if _, _, _, err := DecodeNumericValue(nt, short4); err == nil {
+			t.Fatalf("%v: expected short-data error", nt)
+		}
+	}
+	for _, nt := range []NumberType{NumTypeS64, NumTypeU64} {
+		if _, _, _, err := DecodeNumericValue(nt, short8); err == nil {
+			t.Fatalf("%v: expected short-data error", nt)
+		}
+	}
+	if _, _, _, err := DecodeNumericValue(NumberType(99), []byte{0, 0, 0, 0}); err == nil {
+		t.Fatal("expected unknown-number-type error")
+	}
+}
+
+// DecodeNumericValue: signed value paths (negative sign extension) and the
+// 64-bit + float + preset + ipv4 happy paths not already covered.
+func TestDecodeNumericValue_HappyPaths(t *testing.T) {
+	// S8 negative: low byte 0xFF -> -1
+	iv, _, _, err := DecodeNumericValue(NumTypeS8, []byte{0xFF, 0xFF, 0xFF, 0xFF})
+	if err != nil || iv != -1 {
+		t.Fatalf("S8: iv=%d err=%v", iv, err)
+	}
+	// S16 negative
+	iv, _, _, err = DecodeNumericValue(NumTypeS16, []byte{0xFF, 0xFF, 0xFF, 0xFF})
+	if err != nil || iv != -1 {
+		t.Fatalf("S16: iv=%d err=%v", iv, err)
+	}
+	// Float
+	_, _, fv, err := DecodeNumericValue(NumTypeFloat, []byte{0x3F, 0x80, 0x00, 0x00})
+	if err != nil || fv != 1.0 {
+		t.Fatalf("Float: fv=%v err=%v", fv, err)
+	}
+	// IPv4
+	_, uv, _, err := DecodeNumericValue(NumTypeIPv4, []byte{0x7F, 0x00, 0x00, 0x01})
+	if err != nil || uv != 0x7F000001 {
+		t.Fatalf("IPv4: uv=%X err=%v", uv, err)
+	}
+	// U8 / U16 / U32 / S32 / S64 / U64 / Preset happy paths.
+	if _, uv, _, err := DecodeNumericValue(NumTypeU8, []byte{0, 0, 0, 0xFF}); err != nil || uv != 0xFF {
+		t.Fatalf("U8: uv=%d err=%v", uv, err)
+	}
+	if _, uv, _, err := DecodeNumericValue(NumTypeU16, []byte{0, 0, 0x12, 0x34}); err != nil || uv != 0x1234 {
+		t.Fatalf("U16: uv=%X err=%v", uv, err)
+	}
+	if _, uv, _, err := DecodeNumericValue(NumTypeU32, []byte{0x12, 0x34, 0x56, 0x78}); err != nil || uv != 0x12345678 {
+		t.Fatalf("U32: uv=%X err=%v", uv, err)
+	}
+	if iv, _, _, err := DecodeNumericValue(NumTypeS32, []byte{0xFF, 0xFF, 0xFF, 0xFF}); err != nil || iv != -1 {
+		t.Fatalf("S32: iv=%d err=%v", iv, err)
+	}
+	if iv, _, _, err := DecodeNumericValue(NumTypeS64, []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}); err != nil || iv != -1 {
+		t.Fatalf("S64: iv=%d err=%v", iv, err)
+	}
+	if _, uv, _, err := DecodeNumericValue(NumTypeU64, []byte{0, 0, 0, 0, 0, 0, 0, 7}); err != nil || uv != 7 {
+		t.Fatalf("U64: uv=%d err=%v", uv, err)
+	}
+	if _, uv, _, err := DecodeNumericValue(NumTypePreset, []byte{0, 0, 0, 3}); err != nil || uv != 3 {
+		t.Fatalf("Preset: uv=%d err=%v", uv, err)
+	}
+}
+
+// EncodeNumericValue: every supported type plus the default error branch.
+func TestEncodeNumericValue_AllTypesAndError(t *testing.T) {
+	cases := []struct {
+		nt      NumberType
+		wantLen int
+	}{
+		{NumTypeS8, 4}, {NumTypeS16, 4}, {NumTypeS32, 4}, {NumTypeS64, 8},
+		{NumTypeU8, 4}, {NumTypeU16, 4}, {NumTypeU32, 4}, {NumTypeU64, 8},
+		{NumTypeFloat, 4}, {NumTypePreset, 4}, {NumTypeIPv4, 4},
+	}
+	for _, c := range cases {
+		b, err := EncodeNumericValue(c.nt, -1, 0x2A, 3.5)
+		if err != nil {
+			t.Fatalf("%v: %v", c.nt, err)
+		}
+		if len(b) != c.wantLen {
+			t.Fatalf("%v: len got %d want %d", c.nt, len(b), c.wantLen)
+		}
+	}
+	// String number type is not encodable here -> default error branch.
+	if _, err := EncodeNumericValue(NumTypeString, 0, 0, 0); err == nil {
+		t.Fatal("expected error for non-encodable number type")
+	}
+}

--- a/internal/acp2/codec/stringers_value_test.go
+++ b/internal/acp2/codec/stringers_value_test.go
@@ -1,0 +1,197 @@
+package codec
+
+import "testing"
+
+// Covers the enum String() stringers, the error-type Error() methods, and the
+// PropertyU16/U32 + MakeValueProperty value helpers. These are pure functions
+// (no transport) so they're table-driven against the spec-literal names in
+// ../CLAUDE.md. Each stringer table includes an out-of-range value to exercise
+// the fmt.Sprintf default branch.
+
+func TestAN2Proto_String(t *testing.T) {
+	cases := map[AN2Proto]string{
+		AN2ProtoInternal: "AN2",
+		AN2ProtoACP1:     "ACP1",
+		AN2ProtoACP2:     "ACP2",
+		AN2ProtoACMP:     "ACMP",
+		AN2Proto(9):      "proto(9)",
+	}
+	for in, want := range cases {
+		if got := in.String(); got != want {
+			t.Errorf("AN2Proto(%d).String() = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestAN2Type_String(t *testing.T) {
+	cases := map[AN2Type]string{
+		AN2TypeRequest: "request",
+		AN2TypeReply:   "reply",
+		AN2TypeEvent:   "event",
+		AN2TypeError:   "error",
+		AN2TypeData:    "data",
+		AN2Type(9):     "type(9)",
+	}
+	for in, want := range cases {
+		if got := in.String(); got != want {
+			t.Errorf("AN2Type(%d).String() = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestACP2MsgType_String(t *testing.T) {
+	cases := map[ACP2MsgType]string{
+		ACP2TypeRequest:  "request",
+		ACP2TypeReply:    "reply",
+		ACP2TypeAnnounce: "announce",
+		ACP2TypeError:    "error",
+		ACP2MsgType(9):   "acp2type(9)",
+	}
+	for in, want := range cases {
+		if got := in.String(); got != want {
+			t.Errorf("ACP2MsgType(%d).String() = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestACP2Func_String(t *testing.T) {
+	cases := map[ACP2Func]string{
+		ACP2FuncGetVersion:  "get_version",
+		ACP2FuncGetObject:   "get_object",
+		ACP2FuncGetProperty: "get_property",
+		ACP2FuncSetProperty: "set_property",
+		ACP2Func(9):         "func(9)",
+	}
+	for in, want := range cases {
+		if got := in.String(); got != want {
+			t.Errorf("ACP2Func(%d).String() = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestACP2ObjType_String(t *testing.T) {
+	cases := map[ACP2ObjType]string{
+		ObjTypeNode:    "node",
+		ObjTypePreset:  "preset",
+		ObjTypeEnum:    "enum",
+		ObjTypeNumber:  "number",
+		ObjTypeIPv4:    "ipv4",
+		ObjTypeString:  "string",
+		ACP2ObjType(9): "objtype(9)",
+	}
+	for in, want := range cases {
+		if got := in.String(); got != want {
+			t.Errorf("ACP2ObjType(%d).String() = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestNumberType_String(t *testing.T) {
+	cases := map[NumberType]string{
+		NumTypeS8:     "s8",
+		NumTypeS16:    "s16",
+		NumTypeS32:    "s32",
+		NumTypeS64:    "s64",
+		NumTypeU8:     "u8",
+		NumTypeU16:    "u16",
+		NumTypeU32:    "u32",
+		NumTypeU64:    "u64",
+		NumTypeFloat:  "float",
+		NumTypePreset: "preset",
+		NumTypeIPv4:   "ipv4",
+		NumTypeString: "string",
+		NumberType(99): "numtype(99)",
+	}
+	for in, want := range cases {
+		if got := in.String(); got != want {
+			t.Errorf("NumberType(%d).String() = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestACP2Error_Error(t *testing.T) {
+	cases := []struct {
+		status ACP2ErrStatus
+		want   string
+	}{
+		{ErrProtocol, "acp2 error (obj-id 7): protocol error"},
+		{ErrInvalidObjID, "acp2 error (obj-id 7): invalid obj-id"},
+		{ErrInvalidIdx, "acp2 error (obj-id 7): invalid idx"},
+		{ErrInvalidPID, "acp2 error (obj-id 7): invalid pid"},
+		{ErrNoAccess, "acp2 error (obj-id 7): no access"},
+		{ErrInvalidValue, "acp2 error (obj-id 7): invalid value"},
+		{ACP2ErrStatus(42), "acp2 error (obj-id 7): unknown status 42"},
+	}
+	for _, c := range cases {
+		e := &ACP2Error{Status: c.status, ObjID: 7}
+		if got := e.Error(); got != c.want {
+			t.Errorf("ACP2Error{status:%d}.Error() = %q, want %q", c.status, got, c.want)
+		}
+		e.dhsError() // marker method — invoke for coverage
+	}
+}
+
+func TestAN2Error_Error(t *testing.T) {
+	e := &AN2Error{Slot: 3, Func: 2, Msg: "boom"}
+	const want = "an2 error (slot 3, func 2): boom"
+	if got := e.Error(); got != want {
+		t.Errorf("AN2Error.Error() = %q, want %q", got, want)
+	}
+	e.dhsError() // marker method — invoke for coverage
+}
+
+func TestPropertyU32(t *testing.T) {
+	p := &Property{PID: PIDValue, Data: []byte{0x01, 0x02, 0x03, 0x04}}
+	got, err := PropertyU32(p)
+	if err != nil {
+		t.Fatalf("PropertyU32: %v", err)
+	}
+	if got != 0x01020304 {
+		t.Errorf("PropertyU32 = %#x, want 0x01020304", got)
+	}
+	// too short -> error
+	if _, err := PropertyU32(&Property{PID: PIDValue, Data: []byte{0x01, 0x02}}); err == nil {
+		t.Error("PropertyU32: want error for short data, got nil")
+	}
+}
+
+func TestPropertyU16(t *testing.T) {
+	p := &Property{PID: PIDStringMaxLength, Data: []byte{0xAB, 0xCD}}
+	got, err := PropertyU16(p)
+	if err != nil {
+		t.Fatalf("PropertyU16: %v", err)
+	}
+	if got != 0xABCD {
+		t.Errorf("PropertyU16 = %#x, want 0xABCD", got)
+	}
+	// too short -> error
+	if _, err := PropertyU16(&Property{PID: PIDStringMaxLength, Data: []byte{0xAB}}); err == nil {
+		t.Error("PropertyU16: want error for short data, got nil")
+	}
+}
+
+func TestMakeValueProperty(t *testing.T) {
+	data := []byte{0x00, 0x05}
+	p := MakeValueProperty(PIDValue, NumTypeS16, data)
+	if p.PID != PIDValue {
+		t.Errorf("PID = %d, want %d", p.PID, PIDValue)
+	}
+	if p.VType != uint8(NumTypeS16) {
+		t.Errorf("VType = %d, want %d", p.VType, uint8(NumTypeS16))
+	}
+	if p.PLen != uint16(4+len(data)) {
+		t.Errorf("PLen = %d, want %d", p.PLen, 4+len(data))
+	}
+	// MakeValueProperty must round-trip through EncodeProperty/DecodeProperties.
+	enc, err := EncodeProperty(&p)
+	if err != nil {
+		t.Fatalf("EncodeProperty: %v", err)
+	}
+	props, err := DecodeProperties(enc)
+	if err != nil {
+		t.Fatalf("DecodeProperties: %v", err)
+	}
+	if len(props) != 1 || props[0].PID != PIDValue || string(props[0].Data) != string(data) {
+		t.Errorf("round-trip = %+v, want pid=%d data=%v", props, PIDValue, data)
+	}
+}

--- a/internal/acp2/consumer/cache_unit_test.go
+++ b/internal/acp2/consumer/cache_unit_test.go
@@ -1,0 +1,105 @@
+package acp2
+
+import (
+	"testing"
+	"time"
+)
+
+func newTestTree(slot int) *WalkedTree {
+	return &WalkedTree{Slot: slot, Labels: map[string]int{}}
+}
+
+// TestCache_PutEvictsLRU fills past the bound and asserts the least-recently
+// used entry is evicted via removeElement, while a touched entry survives.
+func TestCache_PutEvictsLRU(t *testing.T) {
+	const max = 4
+	c := newWalkedTreeCache(max, 0)
+
+	for slot := 0; slot < max; slot++ {
+		c.Put(slot, newTestTree(slot))
+	}
+	// Touch slot 0 so it becomes MRU and is NOT the eviction victim.
+	if _, ok := c.Get(0); !ok {
+		t.Fatal("slot 0 should be present before eviction")
+	}
+	// Insert one past the bound → evicts the LRU (slot 1).
+	c.Put(max, newTestTree(max))
+
+	if c.order.Len() != max {
+		t.Fatalf("order len = %d, want %d after eviction", c.order.Len(), max)
+	}
+	if _, ok := c.Get(1); ok {
+		t.Error("slot 1 should have been evicted as LRU")
+	}
+	if _, ok := c.Get(0); !ok {
+		t.Error("slot 0 was touched and must survive eviction")
+	}
+	if _, ok := c.Get(max); !ok {
+		t.Error("newest slot must be present")
+	}
+}
+
+// TestCache_PutUpdatesExisting replaces an existing slot's tree without
+// growing the cache.
+func TestCache_PutUpdatesExisting(t *testing.T) {
+	c := newWalkedTreeCache(4, 0)
+	c.Put(1, newTestTree(1))
+	updated := newTestTree(1)
+	updated.Labels["x"] = 9
+	c.Put(1, updated)
+
+	if c.order.Len() != 1 {
+		t.Fatalf("order len = %d, want 1", c.order.Len())
+	}
+	got, ok := c.Get(1)
+	if !ok || got.Labels["x"] != 9 {
+		t.Fatalf("Get(1) did not return updated tree: %v", got)
+	}
+}
+
+// TestCache_Clear drops every entry and leaves the cache reusable.
+func TestCache_Clear(t *testing.T) {
+	c := newWalkedTreeCache(4, 0)
+	c.Put(1, newTestTree(1))
+	c.Put(2, newTestTree(2))
+	c.Clear()
+
+	if c.order.Len() != 0 {
+		t.Fatalf("order len = %d, want 0 after Clear", c.order.Len())
+	}
+	if _, ok := c.Get(1); ok {
+		t.Error("entry survived Clear")
+	}
+	// Still usable after clear.
+	c.Put(3, newTestTree(3))
+	if _, ok := c.Get(3); !ok {
+		t.Error("cache not usable after Clear")
+	}
+}
+
+// TestCache_TTLExpiryRemoves exercises the TTL branch in Get, which calls
+// removeElement on an expired entry.
+func TestCache_TTLExpiryRemoves(t *testing.T) {
+	c := newWalkedTreeCache(4, time.Nanosecond)
+	c.Put(1, newTestTree(1))
+	// Force the addedAt into the past so any positive TTL is exceeded.
+	el := c.entries[1]
+	el.Value.(*treeCacheEntry).addedAt = time.Now().Add(-time.Hour)
+
+	if _, ok := c.Get(1); ok {
+		t.Error("expired entry should miss")
+	}
+	if c.order.Len() != 0 {
+		t.Errorf("expired entry not removed: order len = %d", c.order.Len())
+	}
+}
+
+// TestCache_NilReceiverSafe pins the nil-guard fast paths.
+func TestCache_NilReceiverSafe(t *testing.T) {
+	var c *walkedTreeCache
+	if _, ok := c.Get(1); ok {
+		t.Error("nil cache Get should miss")
+	}
+	c.Put(1, newTestTree(1)) // must not panic
+	c.Clear()                // must not panic
+}

--- a/internal/acp2/consumer/canonicalize_helpers_test.go
+++ b/internal/acp2/consumer/canonicalize_helpers_test.go
@@ -1,0 +1,106 @@
+package acp2
+
+import (
+	"testing"
+
+	"dhs/internal/acp2/codec"
+	"dhs/internal/consumer"
+	"dhs/internal/export/canonical"
+)
+
+// TestACP2KindToCanonicalType covers every Kind branch plus the
+// objType/numType fallback for KindUnknown leaves.
+func TestACP2KindToCanonicalType(t *testing.T) {
+	cases := []struct {
+		k       consumer.ValueKind
+		objType codec.ACP2ObjType
+		numType codec.NumberType
+		want    string
+	}{
+		{consumer.KindBool, 0, 0, canonical.ParamBoolean},
+		{consumer.KindInt, 0, 0, canonical.ParamInteger},
+		{consumer.KindUint, 0, 0, canonical.ParamInteger},
+		{consumer.KindFloat, 0, 0, canonical.ParamReal},
+		{consumer.KindEnum, 0, 0, canonical.ParamEnum},
+		{consumer.KindString, 0, 0, canonical.ParamString},
+		{consumer.KindIPAddr, 0, 0, canonical.ParamString},
+		{consumer.KindRaw, 0, 0, canonical.ParamOctets},
+		// KindUnknown → objType/numType disambiguation
+		{consumer.KindUnknown, codec.ObjTypeString, 0, canonical.ParamString},
+		{consumer.KindUnknown, codec.ObjTypeIPv4, 0, canonical.ParamString},
+		{consumer.KindUnknown, codec.ObjTypeNumber, codec.NumTypeFloat, canonical.ParamReal},
+		{consumer.KindUnknown, codec.ObjTypeNumber, codec.NumTypeU32, canonical.ParamInteger},
+		{consumer.KindUnknown, codec.ObjTypeEnum, 0, canonical.ParamEnum},
+		{consumer.KindUnknown, codec.ObjTypePreset, 0, canonical.ParamEnum},
+		{consumer.KindUnknown, codec.ObjTypeNode, 0, canonical.ParamString}, // final fallback
+	}
+	for _, c := range cases {
+		if got := acp2KindToCanonicalType(c.k, c.objType, c.numType); got != c.want {
+			t.Errorf("acp2KindToCanonicalType(%v,%v,%v) = %q, want %q",
+				c.k, c.objType, c.numType, got, c.want)
+		}
+	}
+}
+
+// TestACP2ValueToAny covers every value-kind scalar branch including the
+// enum label-vs-index split and the nil fallthrough.
+func TestACP2ValueToAny(t *testing.T) {
+	if got := acp2ValueToAny(consumer.Value{Kind: consumer.KindBool, Bool: true}); got != true {
+		t.Errorf("bool = %v", got)
+	}
+	if got := acp2ValueToAny(consumer.Value{Kind: consumer.KindInt, Int: -7}); got != int64(-7) {
+		t.Errorf("int = %v", got)
+	}
+	if got := acp2ValueToAny(consumer.Value{Kind: consumer.KindUint, Uint: 9}); got != uint64(9) {
+		t.Errorf("uint = %v", got)
+	}
+	if got := acp2ValueToAny(consumer.Value{Kind: consumer.KindFloat, Float: 1.5}); got != 1.5 {
+		t.Errorf("float = %v", got)
+	}
+	if got := acp2ValueToAny(consumer.Value{Kind: consumer.KindEnum, Str: "On"}); got != "On" {
+		t.Errorf("enum label = %v", got)
+	}
+	if got := acp2ValueToAny(consumer.Value{Kind: consumer.KindEnum, Enum: 4}); got != int64(4) {
+		t.Errorf("enum idx = %v", got)
+	}
+	if got := acp2ValueToAny(consumer.Value{Kind: consumer.KindString, Str: "SDI"}); got != "SDI" {
+		t.Errorf("string = %v", got)
+	}
+	if got := acp2ValueToAny(consumer.Value{Kind: consumer.KindIPAddr, IPAddr: [4]byte{10, 0, 0, 1}}); got != "10.0.0.1" {
+		t.Errorf("ipaddr = %v", got)
+	}
+	if got := acp2ValueToAny(consumer.Value{Kind: consumer.KindUnknown}); got != nil {
+		t.Errorf("unknown = %v, want nil", got)
+	}
+}
+
+// TestACP2Identifier covers the labelled and unlabelled-fallback branches.
+func TestACP2Identifier(t *testing.T) {
+	if got := acp2Identifier(consumer.Object{Label: "Gain"}); got != "Gain" {
+		t.Errorf("labelled = %q", got)
+	}
+	if got := acp2Identifier(consumer.Object{ID: 42}); got != "#42" {
+		t.Errorf("unlabelled = %q, want #42", got)
+	}
+}
+
+// TestSortACP2ByNumber covers the insertion-sort reorder + already-sorted
+// no-swap path.
+func TestSortACP2ByNumber(t *testing.T) {
+	els := []canonical.Element{
+		&canonical.Parameter{Header: canonical.Header{Number: 3}},
+		&canonical.Parameter{Header: canonical.Header{Number: 1}},
+		&canonical.Parameter{Header: canonical.Header{Number: 2}},
+	}
+	sortACP2ByNumber(els)
+	for i, want := range []int{1, 2, 3} {
+		if got := els[i].Common().Number; got != want {
+			t.Errorf("els[%d].Number = %d, want %d", i, got, want)
+		}
+	}
+	// Idempotent on already-sorted input (exercises the break path).
+	sortACP2ByNumber(els)
+	if els[0].Common().Number != 1 {
+		t.Errorf("re-sort disturbed order: %d", els[0].Common().Number)
+	}
+}

--- a/internal/acp2/consumer/catalogue_unit_test.go
+++ b/internal/acp2/consumer/catalogue_unit_test.go
@@ -1,0 +1,147 @@
+package acp2
+
+import (
+	"testing"
+
+	"dhs/internal/acp2/codec"
+)
+
+// TestCatalogueEntry_Address pins the "<kind>:<id>" canonical address
+// produced for `dhs help-cmd acp2 <addr>`.
+func TestCatalogueEntry_Address(t *testing.T) {
+	cases := []struct {
+		entry CatalogueEntry
+		want  string
+	}{
+		{CatalogueEntry{Kind: KindPid, ID: 4}, "pid:4"},
+		{CatalogueEntry{Kind: KindAN2Type, ID: 0}, "an2-type:0"},
+		{CatalogueEntry{Kind: KindErrStat, ID: 255}, "err-stat:255"},
+		{CatalogueEntry{Kind: KindNumberType, ID: 100}, "number-type:100"},
+	}
+	for _, c := range cases {
+		if got := c.entry.Address(); got != c.want {
+			t.Errorf("Address(%+v) = %q, want %q", c.entry, got, c.want)
+		}
+	}
+}
+
+// TestCatalogue_NonEmptyAndAddressable asserts every catalogue row has a
+// non-empty name + spec ref and round-trips through LookupCatalogue by its
+// own address.
+func TestCatalogue_NonEmptyAndAddressable(t *testing.T) {
+	entries := Catalogue()
+	if len(entries) == 0 {
+		t.Fatal("Catalogue() returned no entries")
+	}
+	for _, e := range entries {
+		if e.Name == "" {
+			t.Errorf("entry %s has empty Name", e.Address())
+		}
+		if e.SpecRef == "" {
+			t.Errorf("entry %s has empty SpecRef", e.Address())
+		}
+		got, ok := LookupCatalogue(e.Address())
+		if !ok {
+			t.Errorf("LookupCatalogue(%q) miss for known entry", e.Address())
+			continue
+		}
+		if got.Kind != e.Kind || got.ID != e.ID || got.Name != e.Name {
+			t.Errorf("LookupCatalogue(%q) = %+v, want %+v", e.Address(), got, e)
+		}
+	}
+}
+
+// TestLookupCatalogue_KnownEntries spot-checks specific spec-derived rows.
+func TestLookupCatalogue_KnownEntries(t *testing.T) {
+	cases := []struct {
+		addr     string
+		wantKind CommandKind
+		wantName string
+	}{
+		{"pid:4", KindPid, "event_delay"},          // ADR-pinned spec name §5.4 row 4
+		{"acp2-type:2", KindACP2Type, "announce"},  // not "event"
+		{"obj-type:0", KindObjType, "node"},
+		{"number-type:8", KindNumberType, "float"},
+		{"err-stat:5", KindErrStat, "invalid-value"},
+		{"acp2-func:1", KindACP2Func, "get_object"},
+		{"an2-type:" + uint8ToDec(uint8(codec.AN2TypeData)), KindAN2Type, "data"},
+	}
+	for _, c := range cases {
+		e, ok := LookupCatalogue(c.addr)
+		if !ok {
+			t.Errorf("LookupCatalogue(%q) miss", c.addr)
+			continue
+		}
+		if e.Kind != c.wantKind || e.Name != c.wantName {
+			t.Errorf("LookupCatalogue(%q) = kind %q name %q, want kind %q name %q",
+				c.addr, e.Kind, e.Name, c.wantKind, c.wantName)
+		}
+	}
+}
+
+// TestLookupCatalogue_Misses covers the false-return branches: malformed
+// address, unknown kind, and out-of-catalogue id.
+func TestLookupCatalogue_Misses(t *testing.T) {
+	misses := []string{
+		"",            // no colon
+		"pid",         // no colon
+		"pid:",        // empty id
+		"pid:999",     // id overflows uint8 → splitAddress fails
+		"pid:4x",      // non-digit
+		"pid:7777",    // > 3 chars
+		"bogus:1",     // unknown kind
+		"pid:200",     // valid uint8 but no such pid in catalogue
+		":4",          // empty kind
+	}
+	for _, m := range misses {
+		if e, ok := LookupCatalogue(m); ok {
+			t.Errorf("LookupCatalogue(%q) = %+v, want miss", m, e)
+		}
+	}
+}
+
+// TestUint8ToDec covers the zero fast-path and multi-digit formatting.
+func TestUint8ToDec(t *testing.T) {
+	cases := map[uint8]string{0: "0", 7: "7", 42: "42", 100: "100", 255: "255"}
+	for in, want := range cases {
+		if got := uint8ToDec(in); got != want {
+			t.Errorf("uint8ToDec(%d) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestDecToUint8 covers valid parses and every error branch (empty, too
+// long, non-digit, overflow).
+func TestDecToUint8(t *testing.T) {
+	ok := map[string]uint8{"0": 0, "9": 9, "42": 42, "255": 255}
+	for in, want := range ok {
+		got, err := decToUint8(in)
+		if err {
+			t.Errorf("decToUint8(%q) errored, want %d", in, want)
+			continue
+		}
+		if got != want {
+			t.Errorf("decToUint8(%q) = %d, want %d", in, got, want)
+		}
+	}
+	bad := []string{"", "256", "999", "1234", "12a", "-1", " 1"}
+	for _, in := range bad {
+		if _, err := decToUint8(in); !err {
+			t.Errorf("decToUint8(%q) did not error", in)
+		}
+	}
+}
+
+// TestSplitAddress covers the parsed and unparsed branches directly.
+func TestSplitAddress(t *testing.T) {
+	k, id, ok := splitAddress("pid:14")
+	if !ok || k != KindPid || id != 14 {
+		t.Errorf("splitAddress(pid:14) = %q,%d,%v", k, id, ok)
+	}
+	if _, _, ok := splitAddress("nocolon"); ok {
+		t.Error("splitAddress(nocolon) reported ok")
+	}
+	if _, _, ok := splitAddress("pid:300"); ok {
+		t.Error("splitAddress(pid:300) reported ok for overflow id")
+	}
+}

--- a/internal/acp2/consumer/connect_loopback_test.go
+++ b/internal/acp2/consumer/connect_loopback_test.go
@@ -1,0 +1,210 @@
+package acp2
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"dhs/internal/consumer"
+
+	"dhs/internal/acp2/codec"
+)
+
+// connect_loopback_test.go drives Plugin.Connect / Session.Connect end
+// to end against the loopback harness, covering the full AN2 + ACP2
+// handshake, GetDeviceInfo, GetSlotInfo, Disconnect, and the
+// not-connected branches.
+
+// connectPlugin starts a fake server with keep-alive disabled (so no
+// background prober races the test) and returns a connected plugin
+// plus a cleanup func.
+func connectPlugin(t *testing.T, srv *fakeServer, host string, port int) *Plugin {
+	t.Helper()
+	p := &Plugin{logger: testLogger()}
+	// Disable the keepalive prober + watchdog so tests are deterministic
+	// and don't fire spurious AN2 GetSlotInfo traffic.
+	p.SetKeepAlive(consumer.KeepAliveConfig{
+		Interval: consumer.DisableInterval,
+		Timeout:  consumer.DisableTimeout,
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := p.Connect(ctx, host, port); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Disconnect() })
+	return p
+}
+
+func TestPluginConnect_Handshake(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	defer srv.stop()
+
+	p := connectPlugin(t, srv, host, port)
+
+	di, err := p.GetDeviceInfo(context.Background())
+	if err != nil {
+		t.Fatalf("GetDeviceInfo: %v", err)
+	}
+	if di.IP != host {
+		t.Errorf("IP = %q, want %q", di.IP, host)
+	}
+	if di.Port != port {
+		t.Errorf("Port = %d, want %d", di.Port, port)
+	}
+	// slotCount=2 → numSlots=2.
+	if di.NumSlots != 2 {
+		t.Errorf("NumSlots = %d, want 2", di.NumSlots)
+	}
+	if di.ProtocolVersion != 1 {
+		t.Errorf("ProtocolVersion = %d, want 1", di.ProtocolVersion)
+	}
+}
+
+func TestPluginConnect_SessionVersions(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	srv.an2Major = 1
+	srv.an2Minor = 4
+	srv.acp2Ver = 3
+	defer srv.stop()
+
+	p := connectPlugin(t, srv, host, port)
+	p.mu.Lock()
+	s := p.session
+	p.mu.Unlock()
+
+	if got := s.AN2Version(); got != "1.4" {
+		t.Errorf("AN2Version = %q, want 1.4", got)
+	}
+	if got := s.ACP2Version(); got != 3 {
+		t.Errorf("ACP2Version = %d, want 3", got)
+	}
+	if got := s.NumSlots(); got != 2 {
+		t.Errorf("NumSlots = %d, want 2", got)
+	}
+	if s.Host() != host || s.Port() != port {
+		t.Errorf("host/port = %s:%d, want %s:%d", s.Host(), s.Port(), host, port)
+	}
+}
+
+func TestPluginConnect_AlreadyConnected(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	defer srv.stop()
+
+	p := connectPlugin(t, srv, host, port)
+	if err := p.Connect(context.Background(), host, port); err == nil {
+		t.Fatal("second Connect: want error, got nil")
+	}
+}
+
+func TestSessionConnect_AlreadyConnected(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	defer srv.stop()
+
+	s := NewSession(testLogger())
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := s.Connect(ctx, host, port); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer func() { _ = s.Disconnect() }()
+	if err := s.Connect(ctx, host, port); err == nil {
+		t.Fatal("second Session.Connect: want error")
+	}
+}
+
+func TestSessionConnect_DialRefused(t *testing.T) {
+	// Bind then immediately close to obtain a port nobody listens on.
+	srv, host, port := newFakeServer(t)
+	srv.stop()
+
+	s := NewSession(testLogger())
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err := s.Connect(ctx, host, port)
+	if err == nil {
+		_ = s.Disconnect()
+		t.Fatal("Connect to dead port: want error")
+	}
+	var te *consumer.TransportError
+	if !errors.As(err, &te) {
+		t.Errorf("error = %v, want *consumer.TransportError", err)
+	}
+}
+
+func TestGetDeviceInfo_NotConnected(t *testing.T) {
+	p := &Plugin{logger: testLogger()}
+	if _, err := p.GetDeviceInfo(context.Background()); err != consumer.ErrNotConnected {
+		t.Errorf("err = %v, want ErrNotConnected", err)
+	}
+}
+
+func TestGetSlotInfo_NotConnected(t *testing.T) {
+	p := &Plugin{logger: testLogger()}
+	if _, err := p.GetSlotInfo(context.Background(), 0); err != consumer.ErrNotConnected {
+		t.Errorf("err = %v, want ErrNotConnected", err)
+	}
+}
+
+func TestGetSlotInfo_FromHandshake(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	srv.slotStatus = []uint8{2, 2, 0} // controller present, card1 present, card2 empty
+	defer srv.stop()
+
+	p := connectPlugin(t, srv, host, port)
+
+	si, err := p.GetSlotInfo(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("GetSlotInfo(1): %v", err)
+	}
+	if si.Status != consumer.SlotPresent {
+		t.Errorf("slot 1 Status = %v, want SlotPresent", si.Status)
+	}
+	if si.State != consumer.SlotStatePresent {
+		t.Errorf("slot 1 State = %v, want present", si.State)
+	}
+
+	si2, err := p.GetSlotInfo(context.Background(), 2)
+	if err != nil {
+		t.Fatalf("GetSlotInfo(2): %v", err)
+	}
+	if si2.Status != consumer.SlotNoCard {
+		t.Errorf("slot 2 Status = %v, want SlotNoCard", si2.Status)
+	}
+}
+
+func TestDisconnect_Idempotent(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	defer srv.stop()
+
+	p := connectPlugin(t, srv, host, port)
+	if err := p.Disconnect(); err != nil {
+		t.Fatalf("first Disconnect: %v", err)
+	}
+	// Second Disconnect is a no-op.
+	if err := p.Disconnect(); err != nil {
+		t.Errorf("second Disconnect: %v", err)
+	}
+}
+
+func TestSessionConnect_HandshakeAN2Error(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	srv.an2ErrOnFunc = int(codec.AN2FuncGetVersion) // fail at step 1
+	defer srv.stop()
+
+	s := NewSession(testLogger())
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	// GetVersion error is non-fatal in the decode path (AN2 error frame
+	// routes a synthetic reply); the handshake reads reply.Body which is
+	// empty. Connect should still proceed past step 1 but the version
+	// fields stay zero. Assert Connect succeeds and version is 0.0.
+	if err := s.Connect(ctx, host, port); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer func() { _ = s.Disconnect() }()
+	if got := s.AN2Version(); got != "0.0" {
+		t.Errorf("AN2Version after error reply = %q, want 0.0", got)
+	}
+}

--- a/internal/acp2/consumer/diag_loopback_test.go
+++ b/internal/acp2/consumer/diag_loopback_test.go
@@ -1,0 +1,90 @@
+package acp2
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"dhs/internal/acp2/codec"
+)
+
+// diag_loopback_test.go drives RunDiagnostics against the loopback peer.
+//
+// The happy path (TestRunDiagnostics) answers ACP2 data probes and is
+// gated behind -short being OFF because RunDiagnostics has hard-coded
+// 3 s per-probe timeouts plus a 2 s announce-listen window, and the
+// session readLoop drops proto=3 (ACMP) / proto=4 frames, so those
+// probes always run to their full 3 s timeout. Total ~15 s — kept out
+// of the fast path. The cheap dial-error path always runs.
+func TestRunDiagnostics(t *testing.T) {
+	if testing.Short() {
+		t.Skip("RunDiagnostics has hard-coded multi-second probe timeouts; skipped in -short")
+	}
+	srv, host, port := newFakeServer(t)
+
+	// Answer every ACP2 data request with a generic reply echoing mtid.
+	srv.onACP2 = func(slot uint8, req *codec.ACP2Message) *codec.ACP2Message {
+		return &codec.ACP2Message{
+			Type: codec.ACP2TypeReply,
+			Func: req.Func,
+			Body: objectBody(req.ObjID, nil),
+		}
+	}
+
+	// Answer ACMP / vendor-proto data frames with a reply on the same
+	// proto, echoing the ACP2 mtid from byte 1 of the payload. (These
+	// replies are dropped by the session readLoop, which only routes
+	// proto 0/2 — so the probes still time out; the handler keeps the
+	// server side from blocking.)
+	srv.onOtherProto = func(c net.Conn, f *codec.AN2Frame) {
+		if f.Type != codec.AN2TypeData || len(f.Payload) < codec.ACP2HeaderSize {
+			return
+		}
+		mtid := f.Payload[1]
+		replyPayload := []byte{byte(codec.ACP2TypeReply), mtid, f.Payload[2], 0}
+		srv.sendFrame(c, &codec.AN2Frame{
+			Proto:   f.Proto,
+			Slot:    f.Slot,
+			MTID:    0,
+			Type:    codec.AN2TypeData,
+			Payload: replyPayload,
+		})
+	}
+	defer srv.stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	results, err := RunDiagnostics(ctx, host, port, 1, testLogger())
+	if err != nil {
+		t.Fatalf("RunDiagnostics: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("RunDiagnostics returned no results")
+	}
+	// At least the first ACP2 get_object probe should report ok.
+	var sawOK bool
+	for _, r := range results {
+		if len(r.Status) >= 2 && r.Status[:2] == "ok" {
+			sawOK = true
+			break
+		}
+	}
+	if !sawOK {
+		t.Errorf("no probe reported ok; results=%+v", results)
+	}
+}
+
+// TestRunDiagnostics_DialError covers the early-return path when the
+// device is unreachable.
+func TestRunDiagnostics_DialError(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	srv.stop() // free the port so the dial is refused
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if _, err := RunDiagnostics(ctx, host, port, 0, testLogger()); err == nil {
+		t.Fatal("RunDiagnostics to dead port: want error")
+	}
+}

--- a/internal/acp2/consumer/getset_loopback_test.go
+++ b/internal/acp2/consumer/getset_loopback_test.go
@@ -1,0 +1,296 @@
+package acp2
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"dhs/internal/consumer"
+
+	"dhs/internal/acp2/codec"
+)
+
+// getset_loopback_test.go drives Plugin.GetValue / SetValue against the
+// loopback harness, covering: get with a pre-walked tree, get with the
+// fetchObjectMeta fallback (no tree), set numeric/string, label
+// addressing, error replies (every stat code), and not-connected
+// branches.
+
+func TestGetValue_NotConnected(t *testing.T) {
+	p := &Plugin{logger: testLogger()}
+	p.trees = newWalkedTreeCache(8, 0)
+	if _, err := p.GetValue(context.Background(), consumer.ValueRequest{ID: 3}); err != consumer.ErrNotConnected {
+		t.Errorf("err = %v, want ErrNotConnected", err)
+	}
+}
+
+func TestSetValue_NotConnected(t *testing.T) {
+	p := &Plugin{logger: testLogger()}
+	p.trees = newWalkedTreeCache(8, 0)
+	_, err := p.SetValue(context.Background(), consumer.ValueRequest{ID: 3}, consumer.Value{Kind: consumer.KindUint, Uint: 1})
+	if err != consumer.ErrNotConnected {
+		t.Errorf("err = %v, want ErrNotConnected", err)
+	}
+}
+
+// TestGetValue_AfterWalk reads a value addressed by label, using the
+// type info learned from a prior Walk.
+func TestGetValue_AfterWalk(t *testing.T) {
+	srv, host, port := walkTreeServer(t)
+	srv.onACP2 = wrapWithGetProperty(srv.onACP2, func(req *codec.ACP2Message) *codec.ACP2Message {
+		// Volume (obj 3) get_property(pid=8) → u32 99.
+		if req.ObjID == 3 {
+			return propertyReply(codec.ACP2FuncGetProperty, 3,
+				codec.MakeValueProperty(codec.PIDValue, codec.NumTypeU32, []byte{0, 0, 0, 99}))
+		}
+		return errorReply(codec.ErrInvalidObjID)
+	})
+	defer srv.stop()
+
+	p := connectPlugin(t, srv, host, port)
+	if _, err := p.Walk(context.Background(), 1); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+
+	val, err := p.GetValue(context.Background(), consumer.ValueRequest{Slot: 1, Label: "Volume"})
+	if err != nil {
+		t.Fatalf("GetValue: %v", err)
+	}
+	if val.Kind != consumer.KindUint || val.Uint != 99 {
+		t.Errorf("value = %+v, want uint 99", val)
+	}
+}
+
+// TestGetValue_NoTreeFallback reads a value with no walked tree; the
+// plugin must issue get_object to learn the type, then get_property.
+func TestGetValue_NoTreeFallback(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	srv.onACP2 = func(slot uint8, req *codec.ACP2Message) *codec.ACP2Message {
+		switch req.Func {
+		case codec.ACP2FuncGetObject:
+			if req.ObjID == 7 {
+				return objectReply(7, []codec.Property{
+					u32Prop(codec.PIDObjectType, 0, uint32(codec.ObjTypeNumber)),
+					codec.MakeStringProperty(codec.PIDLabel, "Gain"),
+					u32Prop(codec.PIDNumberType, 0, uint32(codec.NumTypeS32)),
+				})
+			}
+			return errorReply(codec.ErrInvalidObjID)
+		case codec.ACP2FuncGetProperty:
+			if req.ObjID == 7 {
+				return propertyReply(codec.ACP2FuncGetProperty, 7,
+					codec.MakeValueProperty(codec.PIDValue, codec.NumTypeS32, []byte{0xFF, 0xFF, 0xFF, 0xFB})) // -5
+			}
+			return errorReply(codec.ErrInvalidObjID)
+		}
+		return errorReply(codec.ErrProtocol)
+	}
+	defer srv.stop()
+
+	p := connectPlugin(t, srv, host, port)
+	val, err := p.GetValue(context.Background(), consumer.ValueRequest{Slot: 0, ID: 7})
+	if err != nil {
+		t.Fatalf("GetValue: %v", err)
+	}
+	if val.Kind != consumer.KindInt || val.Int != -5 {
+		t.Errorf("value = %+v, want int -5", val)
+	}
+}
+
+// TestGetValue_DeviceError verifies that an ACP2 error reply surfaces as
+// the typed ACP2Error.
+func TestGetValue_DeviceError(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	srv.onACP2 = func(slot uint8, req *codec.ACP2Message) *codec.ACP2Message {
+		if req.Func == codec.ACP2FuncGetObject {
+			// Type unknown so the plugin issues get_object first; fail it.
+			return errorReply(codec.ErrInvalidObjID)
+		}
+		return errorReply(codec.ErrInvalidObjID)
+	}
+	defer srv.stop()
+
+	p := connectPlugin(t, srv, host, port)
+	_, err := p.GetValue(context.Background(), consumer.ValueRequest{Slot: 0, ID: 99})
+	if err == nil {
+		t.Fatal("GetValue on bad obj: want error")
+	}
+	var ae *codec.ACP2Error
+	if !errors.As(err, &ae) {
+		t.Fatalf("err = %v, want *codec.ACP2Error", err)
+	}
+	if ae.Status != codec.ErrInvalidObjID {
+		t.Errorf("stat = %d, want ErrInvalidObjID", ae.Status)
+	}
+}
+
+// TestGetProperty_ExplicitPID reads a non-value pid (e.g. label) which
+// returns KindRaw.
+func TestGetValue_ExplicitPID(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	srv.onACP2 = func(slot uint8, req *codec.ACP2Message) *codec.ACP2Message {
+		switch req.Func {
+		case codec.ACP2FuncGetObject:
+			return objectReply(8, []codec.Property{
+				u32Prop(codec.PIDObjectType, 0, uint32(codec.ObjTypeNumber)),
+				u32Prop(codec.PIDNumberType, 0, uint32(codec.NumTypeU32)),
+			})
+		case codec.ACP2FuncGetProperty:
+			// Reply carries the requested pid (access = 3).
+			return propertyReply(codec.ACP2FuncGetProperty, 8,
+				u32Prop(codec.PIDAccess, 0, 3))
+		}
+		return errorReply(codec.ErrProtocol)
+	}
+	defer srv.stop()
+
+	p := connectPlugin(t, srv, host, port)
+	val, err := p.GetValue(context.Background(), consumer.ValueRequest{Slot: 0, ID: 8, PID: int(codec.PIDAccess)})
+	if err != nil {
+		t.Fatalf("GetValue(pid=access): %v", err)
+	}
+	if val.Kind != consumer.KindRaw {
+		t.Errorf("kind = %v, want KindRaw for non-value pid", val.Kind)
+	}
+}
+
+// TestSetValue_Numeric sets a numeric value with no tree (fetchObjectMeta
+// fallback) and asserts the confirmed reply value.
+func TestSetValue_Numeric(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	srv.onACP2 = func(slot uint8, req *codec.ACP2Message) *codec.ACP2Message {
+		switch req.Func {
+		case codec.ACP2FuncGetObject:
+			return objectReply(5, []codec.Property{
+				u32Prop(codec.PIDObjectType, 0, uint32(codec.ObjTypeNumber)),
+				u32Prop(codec.PIDNumberType, 0, uint32(codec.NumTypeU32)),
+			})
+		case codec.ACP2FuncSetProperty:
+			// Echo back the confirmed value (the property the client sent).
+			var prop codec.Property
+			if len(req.Properties) > 0 {
+				prop = req.Properties[0]
+			}
+			return propertyReply(codec.ACP2FuncSetProperty, 5, prop)
+		}
+		return errorReply(codec.ErrProtocol)
+	}
+	defer srv.stop()
+
+	p := connectPlugin(t, srv, host, port)
+	val, err := p.SetValue(context.Background(),
+		consumer.ValueRequest{Slot: 0, ID: 5},
+		consumer.Value{Kind: consumer.KindUint, Uint: 7})
+	if err != nil {
+		t.Fatalf("SetValue: %v", err)
+	}
+	if val.Kind != consumer.KindUint || val.Uint != 7 {
+		t.Errorf("confirmed = %+v, want uint 7", val)
+	}
+}
+
+// TestSetValue_String sets a string value via a pre-walked tree.
+func TestSetValue_String(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	srv.onACP2 = func(slot uint8, req *codec.ACP2Message) *codec.ACP2Message {
+		switch req.Func {
+		case codec.ACP2FuncGetObject:
+			if req.ObjID == 1 {
+				return objectReply(1, []codec.Property{
+					u32Prop(codec.PIDObjectType, 0, uint32(codec.ObjTypeNode)),
+					codec.MakeStringProperty(codec.PIDLabel, "ROOT"),
+					childrenProp(2),
+				})
+			}
+			return objectReply(2, []codec.Property{
+				u32Prop(codec.PIDObjectType, 0, uint32(codec.ObjTypeString)),
+				codec.MakeStringProperty(codec.PIDLabel, "User Label"),
+				codec.MakeStringProperty(codec.PIDValue, "old"),
+			})
+		case codec.ACP2FuncSetProperty:
+			var prop codec.Property
+			if len(req.Properties) > 0 {
+				prop = req.Properties[0]
+			}
+			return propertyReply(codec.ACP2FuncSetProperty, 2, prop)
+		}
+		return errorReply(codec.ErrProtocol)
+	}
+	defer srv.stop()
+
+	p := connectPlugin(t, srv, host, port)
+	if _, err := p.Walk(context.Background(), 0); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	val, err := p.SetValue(context.Background(),
+		consumer.ValueRequest{Slot: 0, Label: "User Label"},
+		consumer.Value{Kind: consumer.KindString, Str: "new"})
+	if err != nil {
+		t.Fatalf("SetValue: %v", err)
+	}
+	if val.Kind != consumer.KindString || val.Str != "new" {
+		t.Errorf("confirmed = %+v, want string new", val)
+	}
+}
+
+// TestSetValue_NoAccessError exercises the stat=4 (no-access) error path.
+func TestSetValue_NoAccessError(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	srv.onACP2 = func(slot uint8, req *codec.ACP2Message) *codec.ACP2Message {
+		switch req.Func {
+		case codec.ACP2FuncGetObject:
+			return objectReply(6, []codec.Property{
+				u32Prop(codec.PIDObjectType, 0, uint32(codec.ObjTypeNumber)),
+				u32Prop(codec.PIDNumberType, 0, uint32(codec.NumTypeU32)),
+			})
+		case codec.ACP2FuncSetProperty:
+			return errorReply(codec.ErrNoAccess)
+		}
+		return errorReply(codec.ErrProtocol)
+	}
+	defer srv.stop()
+
+	p := connectPlugin(t, srv, host, port)
+	_, err := p.SetValue(context.Background(),
+		consumer.ValueRequest{Slot: 0, ID: 6},
+		consumer.Value{Kind: consumer.KindUint, Uint: 1})
+	if err == nil {
+		t.Fatal("SetValue on read-only obj: want error")
+	}
+	var ae *codec.ACP2Error
+	if !errors.As(err, &ae) || ae.Status != codec.ErrNoAccess {
+		t.Errorf("err = %v, want ACP2Error stat=ErrNoAccess", err)
+	}
+}
+
+// TestGetValue_UnknownLabel exercises resolveRequest's label-not-found
+// branch (tree present, label absent).
+func TestGetValue_UnknownLabel(t *testing.T) {
+	srv, host, port := walkTreeServer(t)
+	defer srv.stop()
+
+	p := connectPlugin(t, srv, host, port)
+	if _, err := p.Walk(context.Background(), 1); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	_, err := p.GetValue(context.Background(), consumer.ValueRequest{Slot: 1, Label: "Nonexistent"})
+	if err == nil {
+		t.Fatal("GetValue with bad label: want error")
+	}
+	if !errors.Is(err, consumer.ErrUnknownLabel) {
+		t.Errorf("err = %v, want ErrUnknownLabel", err)
+	}
+}
+
+// wrapWithGetProperty composes an existing get_object handler with a
+// dedicated get_property handler so a walk-tree server can also answer
+// value reads.
+func wrapWithGetProperty(base func(uint8, *codec.ACP2Message) *codec.ACP2Message,
+	getProp func(*codec.ACP2Message) *codec.ACP2Message) func(uint8, *codec.ACP2Message) *codec.ACP2Message {
+	return func(slot uint8, req *codec.ACP2Message) *codec.ACP2Message {
+		if req.Func == codec.ACP2FuncGetProperty {
+			return getProp(req)
+		}
+		return base(slot, req)
+	}
+}

--- a/internal/acp2/consumer/io_coverage_test.go
+++ b/internal/acp2/consumer/io_coverage_test.go
@@ -1,0 +1,455 @@
+package acp2
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"dhs/internal/consumer"
+	"dhs/internal/transport"
+
+	"dhs/internal/acp2/codec"
+)
+
+// io_coverage_test.go rounds out coverage of the socket-reachable
+// paths: the keep-alive prober + watchdog (live), the warm-restart
+// reconnect loop, the full set of value-type decode/encode branches via
+// Walk / GetValue / SetValue, and the small public accessors.
+
+// ---- value-type walk: every ObjType / NumberType decode branch ----
+
+func TestWalk_AllValueTypes(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	srv.onACP2 = func(slot uint8, req *codec.ACP2Message) *codec.ACP2Message {
+		if req.Func != codec.ACP2FuncGetObject {
+			return errorReply(codec.ErrProtocol)
+		}
+		switch req.ObjID {
+		case 1: // root with one child per type
+			return objectReply(1, []codec.Property{
+				u32Prop(codec.PIDObjectType, 0, uint32(codec.ObjTypeNode)),
+				codec.MakeStringProperty(codec.PIDLabel, "ROOT"),
+				childrenProp(10, 11, 12, 13, 14, 15),
+			})
+		case 10: // float number with min/max/step/default constraints
+			return objectReply(10, []codec.Property{
+				u32Prop(codec.PIDObjectType, 0, uint32(codec.ObjTypeNumber)),
+				codec.MakeStringProperty(codec.PIDLabel, "Gain"),
+				u32Prop(codec.PIDNumberType, 0, uint32(codec.NumTypeFloat)),
+				codec.MakeValueProperty(codec.PIDValue, codec.NumTypeFloat, f32be(1.5)),
+				codec.MakeValueProperty(codec.PIDMinValue, codec.NumTypeFloat, f32be(0)),
+				codec.MakeValueProperty(codec.PIDMaxValue, codec.NumTypeFloat, f32be(10)),
+				codec.MakeValueProperty(codec.PIDStepSize, codec.NumTypeFloat, f32be(0.5)),
+				codec.MakeValueProperty(codec.PIDDefaultValue, codec.NumTypeFloat, f32be(2.0)),
+				codec.MakeStringProperty(codec.PIDUnit, "dB"),
+			})
+		case 11: // s64 number
+			return objectReply(11, []codec.Property{
+				u32Prop(codec.PIDObjectType, 0, uint32(codec.ObjTypeNumber)),
+				codec.MakeStringProperty(codec.PIDLabel, "Offset"),
+				u32Prop(codec.PIDNumberType, 0, uint32(codec.NumTypeS64)),
+				codec.MakeValueProperty(codec.PIDValue, codec.NumTypeS64, s64be(-1234)),
+				codec.MakeValueProperty(codec.PIDMinValue, codec.NumTypeS64, s64be(-9999)),
+			})
+		case 12: // enum with options
+			return objectReply(12, []codec.Property{
+				u32Prop(codec.PIDObjectType, 0, uint32(codec.ObjTypeEnum)),
+				codec.MakeStringProperty(codec.PIDLabel, "Mode"),
+				u32Prop(codec.PIDNumberType, 0, uint32(codec.NumTypePreset)),
+				optionsProp(map[uint32]string{0: "Off", 1: "On", 2: "Auto"}),
+				codec.MakeValueProperty(codec.PIDValue, codec.NumTypePreset, beU32Bytes(1)),
+				codec.MakeValueProperty(codec.PIDDefaultValue, codec.NumTypePreset, beU32Bytes(2)),
+			})
+		case 13: // ipv4
+			return objectReply(13, []codec.Property{
+				u32Prop(codec.PIDObjectType, 0, uint32(codec.ObjTypeIPv4)),
+				codec.MakeStringProperty(codec.PIDLabel, "IP"),
+				u32Prop(codec.PIDNumberType, 0, uint32(codec.NumTypeIPv4)),
+				codec.MakeValueProperty(codec.PIDValue, codec.NumTypeIPv4, []byte{10, 0, 0, 5}),
+			})
+		case 14: // string with max length + alarm props
+			return objectReply(14, []codec.Property{
+				u32Prop(codec.PIDObjectType, 0, uint32(codec.ObjTypeString)),
+				codec.MakeStringProperty(codec.PIDLabel, "Name"),
+				u32Prop(codec.PIDStringMaxLength, 0, 32),
+				codec.MakeStringProperty(codec.PIDValue, "hello"),
+				codec.Property{PID: codec.PIDEventTag, VType: 7, PLen: 4},
+				u32Prop(codec.PIDEventPrio, 0, 2),
+			})
+		case 15: // preset child
+			return objectReply(15, []codec.Property{
+				u32Prop(codec.PIDObjectType, 0, uint32(codec.ObjTypePreset)),
+				codec.MakeStringProperty(codec.PIDLabel, "Preset"),
+				codec.MakeValueProperty(codec.PIDValue, codec.NumTypePreset, beU32Bytes(0)),
+				u32Prop(codec.PIDPresetParent, 0, 1),
+			})
+		default:
+			return errorReply(codec.ErrInvalidObjID)
+		}
+	}
+	defer srv.stop()
+
+	p := connectPlugin(t, srv, host, port)
+	objs, err := p.Walk(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	byLabel := map[string]consumer.Object{}
+	for _, o := range objs {
+		byLabel[o.Label] = o
+	}
+
+	if g := byLabel["Gain"]; g.Kind != consumer.KindFloat || math.Abs(g.Value.Float-1.5) > 1e-6 {
+		t.Errorf("Gain = %+v, want float 1.5", g.Value)
+	}
+	if g := byLabel["Gain"]; g.Unit != "dB" {
+		t.Errorf("Gain unit = %q, want dB", g.Unit)
+	}
+	if o := byLabel["Offset"]; o.Kind != consumer.KindInt || o.Value.Int != -1234 {
+		t.Errorf("Offset = %+v, want int -1234", o.Value)
+	}
+	if m := byLabel["Mode"]; m.Kind != consumer.KindEnum || m.Value.Str != "On" {
+		t.Errorf("Mode = %+v, want enum On", m.Value)
+	}
+	if ip := byLabel["IP"]; ip.Kind != consumer.KindIPAddr || ip.Value.IPAddr != [4]byte{10, 0, 0, 5} {
+		t.Errorf("IP = %+v, want 10.0.0.5", ip.Value)
+	}
+	if n := byLabel["Name"]; n.Kind != consumer.KindString || n.Value.Str != "hello" {
+		t.Errorf("Name = %+v, want string hello", n.Value)
+	}
+	if _, ok := byLabel["Preset"]; !ok {
+		t.Error("Preset not walked")
+	}
+}
+
+// TestGetValue_EnumWithLabel reads an enum and resolves the option label
+// from the walked tree's options map.
+func TestGetValue_EnumWithLabel(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	base := func(slot uint8, req *codec.ACP2Message) *codec.ACP2Message {
+		switch req.ObjID {
+		case 1:
+			return objectReply(1, []codec.Property{
+				u32Prop(codec.PIDObjectType, 0, uint32(codec.ObjTypeNode)),
+				codec.MakeStringProperty(codec.PIDLabel, "ROOT"),
+				childrenProp(2),
+			})
+		case 2:
+			return objectReply(2, []codec.Property{
+				u32Prop(codec.PIDObjectType, 0, uint32(codec.ObjTypeEnum)),
+				codec.MakeStringProperty(codec.PIDLabel, "Mode"),
+				u32Prop(codec.PIDNumberType, 0, uint32(codec.NumTypePreset)),
+				optionsProp(map[uint32]string{0: "Off", 1: "On"}),
+				codec.MakeValueProperty(codec.PIDValue, codec.NumTypePreset, beU32Bytes(0)),
+			})
+		}
+		return errorReply(codec.ErrInvalidObjID)
+	}
+	srv.onACP2 = wrapWithGetProperty(base, func(req *codec.ACP2Message) *codec.ACP2Message {
+		return propertyReply(codec.ACP2FuncGetProperty, 2,
+			codec.MakeValueProperty(codec.PIDValue, codec.NumTypePreset, beU32Bytes(1)))
+	})
+	defer srv.stop()
+
+	p := connectPlugin(t, srv, host, port)
+	if _, err := p.Walk(context.Background(), 1); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	val, err := p.GetValue(context.Background(), consumer.ValueRequest{Slot: 1, Label: "Mode"})
+	if err != nil {
+		t.Fatalf("GetValue: %v", err)
+	}
+	if val.Kind != consumer.KindEnum || val.Str != "On" {
+		t.Errorf("value = %+v, want enum On", val)
+	}
+}
+
+// TestSetValue_Enum sets an enum by label, exercising the reverse-enum
+// resolution + encodeSetProperty enum branch.
+func TestSetValue_Enum(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	base := func(slot uint8, req *codec.ACP2Message) *codec.ACP2Message {
+		switch req.ObjID {
+		case 1:
+			return objectReply(1, []codec.Property{
+				u32Prop(codec.PIDObjectType, 0, uint32(codec.ObjTypeNode)),
+				codec.MakeStringProperty(codec.PIDLabel, "ROOT"),
+				childrenProp(2),
+			})
+		case 2:
+			return objectReply(2, []codec.Property{
+				u32Prop(codec.PIDObjectType, 0, uint32(codec.ObjTypeEnum)),
+				codec.MakeStringProperty(codec.PIDLabel, "Mode"),
+				u32Prop(codec.PIDNumberType, 0, uint32(codec.NumTypePreset)),
+				optionsProp(map[uint32]string{0: "Off", 1: "On"}),
+				codec.MakeValueProperty(codec.PIDValue, codec.NumTypePreset, beU32Bytes(0)),
+			})
+		}
+		return errorReply(codec.ErrInvalidObjID)
+	}
+	srv.onACP2 = func(slot uint8, req *codec.ACP2Message) *codec.ACP2Message {
+		if req.Func == codec.ACP2FuncSetProperty {
+			var prop codec.Property
+			if len(req.Properties) > 0 {
+				prop = req.Properties[0]
+			}
+			return propertyReply(codec.ACP2FuncSetProperty, 2, prop)
+		}
+		return base(slot, req)
+	}
+	defer srv.stop()
+
+	p := connectPlugin(t, srv, host, port)
+	if _, err := p.Walk(context.Background(), 1); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	val, err := p.SetValue(context.Background(),
+		consumer.ValueRequest{Slot: 1, Label: "Mode"},
+		consumer.Value{Kind: consumer.KindString, Str: "On"})
+	if err != nil {
+		t.Fatalf("SetValue: %v", err)
+	}
+	// Confirmed value should resolve back to label "On" (wire idx 1).
+	if val.Str != "On" {
+		t.Errorf("confirmed = %+v, want On", val)
+	}
+}
+
+// TestSetValue_IPv4 sets an IPv4 value from a dotted string.
+func TestSetValue_IPv4(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	srv.onACP2 = func(slot uint8, req *codec.ACP2Message) *codec.ACP2Message {
+		switch req.Func {
+		case codec.ACP2FuncGetObject:
+			return objectReply(3, []codec.Property{
+				u32Prop(codec.PIDObjectType, 0, uint32(codec.ObjTypeIPv4)),
+				u32Prop(codec.PIDNumberType, 0, uint32(codec.NumTypeIPv4)),
+			})
+		case codec.ACP2FuncSetProperty:
+			var prop codec.Property
+			if len(req.Properties) > 0 {
+				prop = req.Properties[0]
+			}
+			return propertyReply(codec.ACP2FuncSetProperty, 3, prop)
+		}
+		return errorReply(codec.ErrProtocol)
+	}
+	defer srv.stop()
+
+	p := connectPlugin(t, srv, host, port)
+	val, err := p.SetValue(context.Background(),
+		consumer.ValueRequest{Slot: 0, ID: 3},
+		consumer.Value{Kind: consumer.KindString, Str: "192.168.1.20"})
+	if err != nil {
+		t.Fatalf("SetValue: %v", err)
+	}
+	if val.Kind != consumer.KindIPAddr || val.IPAddr != [4]byte{192, 168, 1, 20} {
+		t.Errorf("confirmed = %+v, want 192.168.1.20", val)
+	}
+}
+
+// ---- keep-alive prober + watchdog (live) ----
+
+func TestKeepAlive_ProberAndWatchdog(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	defer srv.stop()
+
+	p := &Plugin{logger: testLogger()}
+	// Fast cadence so the prober + watchdog actually run within the test.
+	p.SetKeepAlive(consumer.KeepAliveConfig{
+		Interval: 20 * time.Millisecond,
+		Timeout:  60 * time.Millisecond,
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := p.Connect(ctx, host, port); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer func() { _ = p.Disconnect() }()
+
+	// Wait for at least one prober cycle to land (lastRx advances).
+	ok := waitFor(t, 2*time.Second, func() bool {
+		return p.SessionLive()
+	})
+	if !ok {
+		t.Fatal("session never reported live after keepalive probes")
+	}
+	// The prober's AN2 GetSlotInfo(0) reply updates slot 0 status.
+	si, err := p.GetSlotInfo(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("GetSlotInfo(0): %v", err)
+	}
+	if si.Status != consumer.SlotPresent {
+		t.Errorf("slot 0 status = %v, want present", si.Status)
+	}
+}
+
+// ---- reconnect: server drops the connection, plugin re-dials ----
+
+func TestReconnect_WarmRestart(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	defer srv.stop()
+
+	p := &Plugin{logger: testLogger()}
+	p.SetKeepAlive(consumer.KeepAliveConfig{
+		Interval: consumer.DisableInterval,
+		Timeout:  consumer.DisableTimeout,
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := p.Connect(ctx, host, port); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer func() { _ = p.Disconnect() }()
+
+	p.mu.Lock()
+	first := p.session
+	p.mu.Unlock()
+
+	// Register a subscription so the reconnect replays it.
+	if err := p.Subscribe(consumer.ValueRequest{Slot: -1, ID: -1}, func(consumer.Event) {}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	// Drop every server-side connection — the client readLoop sees EOF,
+	// session.Done() fires, and the reconnect loop re-dials the still-
+	// listening server.
+	srv.mu.Lock()
+	for _, c := range srv.conns {
+		_ = c.Close()
+	}
+	srv.conns = nil
+	srv.mu.Unlock()
+
+	// Wait for a fresh session (different pointer) to come up.
+	ok := waitFor(t, 5*time.Second, func() bool {
+		p.mu.Lock()
+		s := p.session
+		p.mu.Unlock()
+		return s != nil && s != first
+	})
+	if !ok {
+		t.Fatal("session not re-established after drop")
+	}
+
+	// The reconnected session should still serve requests.
+	di, err := p.GetDeviceInfo(context.Background())
+	if err != nil {
+		t.Fatalf("GetDeviceInfo after reconnect: %v", err)
+	}
+	if di.NumSlots != 2 {
+		t.Errorf("NumSlots after reconnect = %d, want 2", di.NumSlots)
+	}
+}
+
+// ---- small accessors + factory ----
+
+func TestFactory_NewAndMeta(t *testing.T) {
+	f := &Factory{}
+	meta := f.Meta()
+	if meta.Name != "acp2" {
+		t.Errorf("meta.Name = %q, want acp2", meta.Name)
+	}
+	if meta.DefaultPort != codec.DefaultPort {
+		t.Errorf("meta.DefaultPort = %d, want %d", meta.DefaultPort, codec.DefaultPort)
+	}
+	pl := f.New(testLogger())
+	if pl == nil {
+		t.Fatal("New returned nil")
+	}
+}
+
+func TestAccessors_RecorderProfileWalkProgress(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	defer srv.stop()
+
+	p := &Plugin{logger: testLogger()}
+	p.SetKeepAlive(consumer.KeepAliveConfig{
+		Interval: consumer.DisableInterval,
+		Timeout:  consumer.DisableTimeout,
+	})
+	// Before Connect: no profile.
+	if p.ComplianceProfile() != nil {
+		t.Error("ComplianceProfile non-nil before Connect")
+	}
+	rec, err := transport.NewRecorder(t.TempDir() + "/cap.jsonl")
+	if err != nil {
+		t.Fatalf("NewRecorder: %v", err)
+	}
+	defer func() { _ = rec.Close() }()
+	p.SetRecorder(rec)
+	var progressCount int
+	p.SetWalkProgress(func(count int, obj *consumer.Object) { progressCount = count })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := p.Connect(ctx, host, port); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer func() { _ = p.Disconnect() }()
+
+	// After Connect: profile exists.
+	if p.ComplianceProfile() == nil {
+		t.Error("ComplianceProfile nil after Connect")
+	}
+	_ = progressCount
+}
+
+func TestSession_SlotStatusAndSetRecorder(t *testing.T) {
+	s := NewSession(testLogger())
+	rec, err := transport.NewRecorder(t.TempDir() + "/cap.jsonl")
+	if err != nil {
+		t.Fatalf("NewRecorder: %v", err)
+	}
+	defer func() { _ = rec.Close() }()
+	s.SetRecorder(rec)
+	// Out-of-range slot returns SlotNoCard.
+	if got := s.SlotStatus(99); got != consumer.SlotNoCard {
+		t.Errorf("SlotStatus(99) = %v, want SlotNoCard", got)
+	}
+	if got := s.SlotStatus(-1); got != consumer.SlotNoCard {
+		t.Errorf("SlotStatus(-1) = %v, want SlotNoCard", got)
+	}
+}
+
+// ---- helpers ----
+
+func f32be(v float32) []byte {
+	bits := math.Float32bits(v)
+	return []byte{byte(bits >> 24), byte(bits >> 16), byte(bits >> 8), byte(bits)}
+}
+
+func s64be(v int64) []byte {
+	u := uint64(v)
+	return []byte{
+		byte(u >> 56), byte(u >> 48), byte(u >> 40), byte(u >> 32),
+		byte(u >> 24), byte(u >> 16), byte(u >> 8), byte(u),
+	}
+}
+
+func beU32Bytes(v uint32) []byte {
+	return []byte{byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}
+}
+
+// optionsProp builds a pid=15 options property using the variable-length
+// per-option wire convention PropertyOptionsMap decodes: u32 idx +
+// NUL-terminated name + pad to 4-byte boundary.
+func optionsProp(opts map[uint32]string) codec.Property {
+	var data []byte
+	// Emit in index order for determinism.
+	for idx := uint32(0); int(idx) < len(opts); idx++ {
+		name, ok := opts[idx]
+		if !ok {
+			continue
+		}
+		rec := beU32Bytes(idx)
+		rec = append(rec, []byte(name)...)
+		rec = append(rec, 0) // NUL
+		for len(rec)%4 != 0 {
+			rec = append(rec, 0)
+		}
+		data = append(data, rec...)
+	}
+	return codec.Property{PID: codec.PIDOptions, PLen: uint16(4 + len(data)), Data: data}
+}

--- a/internal/acp2/consumer/loopback_test.go
+++ b/internal/acp2/consumer/loopback_test.go
@@ -1,0 +1,397 @@
+package acp2
+
+import (
+	"io"
+	"log/slog"
+	"net"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"dhs/internal/acp2/codec"
+)
+
+// loopback_test.go is the in-process AN2/TCP loopback harness shared by
+// every consumer I/O test in this package. It mirrors acp1's
+// echoAN2Server (an2_client_loopback_test.go) but speaks the AN2 +
+// ACP2 two-layer wire format.
+//
+// The harness starts a real net.Listener on 127.0.0.1:0, accepts one
+// connection, decodes incoming AN2 frames with the production codec,
+// and writes back canned reply frames built with the same codec. This
+// exercises the real Session.Connect → an2Handshake → readLoop →
+// DoACP2 stack with zero external dependencies and no real device.
+//
+// Reply bytes follow the documented AN2 §3.3 reply shapes and the
+// ACP2 message header layout (CLAUDE.md). The handshake answers are
+// fixed; the ACP2 get_object / get_property / set_property answers are
+// supplied per-test via fakeServer.onACP2.
+
+// testLogger returns a logger that discards output so test runs stay
+// quiet. slog.Default() floods stderr at Debug on the I/O path.
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+// fakeServer is a configurable AN2/ACP2 loopback peer.
+type fakeServer struct {
+	t  *testing.T
+	ln net.Listener
+
+	// Handshake knobs. Defaults give a sane 2-slot device.
+	an2Major   uint8
+	an2Minor   uint8
+	slotCount  uint8   // AN2 GetDeviceInfo info byte (card slot count)
+	slotStatus []uint8 // per-slot status byte for GetSlotInfo (index = slot)
+	slotProtos []byte  // proto list advertised per slot
+	acp2Ver    uint8   // ACP2 GetVersion reply pid byte
+
+	// Error injection for the AN2 handshake. When the matching func is
+	// requested and the flag is set, the server replies with an AN2
+	// error frame (type=3) instead of a normal reply.
+	an2ErrOnFunc int // -1 = none
+
+	// onACP2 handles a decoded ACP2 request and returns the reply
+	// message to send back. The harness fills in MTID. Return nil to
+	// drop the request (no reply — drives ctx-timeout paths).
+	onACP2 func(slot uint8, req *codec.ACP2Message) *codec.ACP2Message
+
+	// announceAfterConnect, when non-nil, is sent as an ACP2 announce
+	// (proto=2 data frame, ACP2 mtid=0) on the given slot once the
+	// handshake completes.
+	announceFn func(send func(slot uint8, msg *codec.ACP2Message))
+
+	// onOtherProto handles AN2 frames whose proto is neither internal
+	// nor ACP2 (e.g. ACMP=3, vendor=4). Used by the diagnostics test.
+	onOtherProto func(c net.Conn, f *codec.AN2Frame)
+
+	mu    sync.Mutex
+	conns []net.Conn
+	wg    sync.WaitGroup
+}
+
+// newFakeServer starts the loopback listener and returns the server,
+// its host, and port. The caller must defer srv.stop().
+func newFakeServer(t *testing.T) (*fakeServer, string, int) {
+	t.Helper()
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	s := &fakeServer{
+		t:            t,
+		ln:           ln,
+		an2Major:     1,
+		an2Minor:     0,
+		slotCount:    2,
+		slotStatus:   []uint8{2, 2, 2}, // slot 0 controller + 2 cards, all present
+		slotProtos:   []byte{byte(codec.AN2ProtoACP2)},
+		acp2Ver:      1,
+		an2ErrOnFunc: -1,
+	}
+	s.wg.Add(1)
+	go s.acceptLoop()
+
+	host, portStr, _ := net.SplitHostPort(ln.Addr().String())
+	port, _ := strconv.Atoi(portStr)
+	return s, host, port
+}
+
+func (s *fakeServer) stop() {
+	_ = s.ln.Close()
+	s.mu.Lock()
+	for _, c := range s.conns {
+		_ = c.Close()
+	}
+	s.mu.Unlock()
+	s.wg.Wait()
+}
+
+func (s *fakeServer) acceptLoop() {
+	defer s.wg.Done()
+	for {
+		conn, err := s.ln.Accept()
+		if err != nil {
+			return
+		}
+		s.mu.Lock()
+		s.conns = append(s.conns, conn)
+		s.mu.Unlock()
+		s.wg.Add(1)
+		go s.serve(conn)
+	}
+}
+
+// sendFrame encodes and writes one AN2 frame to the connection.
+func (s *fakeServer) sendFrame(c net.Conn, f *codec.AN2Frame) {
+	b, err := codec.EncodeAN2Frame(f)
+	if err != nil {
+		s.t.Errorf("server encode frame: %v", err)
+		return
+	}
+	if _, err := c.Write(b); err != nil {
+		return
+	}
+}
+
+// sendACP2 wraps an ACP2 message in an AN2 data frame and sends it.
+//
+// Reply / announce messages are encoded as a 4-byte ACP2 header
+// followed by the raw Body bytes — the device-side wire shape. We do
+// NOT route through codec.EncodeACP2Message here: that encoder is
+// request-shaped (the get_object/get_property/set_property/get_version
+// branches emit a fixed request body and discard m.Body), so a reply
+// carrying property headers in Body would lose them. Hand-building
+// header+Body keeps the device replies byte-faithful to the §3.3 /
+// ACP2 message-header layout.
+func (s *fakeServer) sendACP2(c net.Conn, slot uint8, msg *codec.ACP2Message) {
+	payload := make([]byte, codec.ACP2HeaderSize+len(msg.Body))
+	payload[0] = byte(msg.Type)
+	payload[1] = msg.MTID
+	payload[2] = byte(msg.Func)
+	payload[3] = msg.PID
+	copy(payload[codec.ACP2HeaderSize:], msg.Body)
+	s.sendFrame(c, &codec.AN2Frame{
+		Proto:   codec.AN2ProtoACP2,
+		Slot:    slot,
+		MTID:    0, // AN2 data frames always carry AN2 mtid 0
+		Type:    codec.AN2TypeData,
+		Payload: payload,
+	})
+}
+
+func (s *fakeServer) serve(c net.Conn) {
+	defer s.wg.Done()
+	defer func() { _ = c.Close() }()
+
+	for {
+		frame, err := codec.ReadAN2Frame(c)
+		if err != nil {
+			return
+		}
+		switch frame.Proto {
+		case codec.AN2ProtoInternal:
+			s.handleAN2(c, frame)
+		case codec.AN2ProtoACP2:
+			s.handleACP2(c, frame)
+		default:
+			// Non-ACP2 payload protocols (ACMP=3, vendor=4). The diag
+			// harness answers these so RunDiagnostics doesn't block on
+			// its 3s per-probe timeout.
+			if s.onOtherProto != nil {
+				s.onOtherProto(c, frame)
+			}
+		}
+	}
+}
+
+// handleAN2 answers an AN2 internal (proto=0) request. The request
+// payload is funcID byte + optional args; the reply echoes the AN2
+// mtid and follows the §3.3 reply shapes.
+func (s *fakeServer) handleAN2(c net.Conn, f *codec.AN2Frame) {
+	if f.Type != codec.AN2TypeRequest || len(f.Payload) < 1 {
+		return
+	}
+	funcID := f.Payload[0]
+
+	if s.an2ErrOnFunc >= 0 && int(funcID) == s.an2ErrOnFunc {
+		// AN2 error frame: type=3, echo mtid. Empty payload.
+		s.sendFrame(c, &codec.AN2Frame{
+			Proto: codec.AN2ProtoInternal,
+			Slot:  f.Slot,
+			MTID:  f.MTID,
+			Type:  codec.AN2TypeError,
+		})
+		return
+	}
+
+	var payload []byte
+	switch funcID {
+	case codec.AN2FuncGetVersion:
+		// §3.3.1: func(u8) major(u8) minor(u8)
+		payload = []byte{funcID, s.an2Major, s.an2Minor}
+	case codec.AN2FuncGetDeviceInfo:
+		// §3.3.2: func(u8) info(u8) — info = card slot count
+		payload = []byte{funcID, s.slotCount}
+	case codec.AN2FuncGetSlotInfo:
+		// §3.3.3: func(u8) stat(u8) num(u8) protos(u8*num).
+		// Slot is in the AN2 header (f.Slot).
+		stat := uint8(0)
+		if int(f.Slot) < len(s.slotStatus) {
+			stat = s.slotStatus[f.Slot]
+		}
+		payload = append([]byte{funcID, stat, byte(len(s.slotProtos))}, s.slotProtos...)
+	case codec.AN2FuncEnableProtocolEvents:
+		// §3.3.4: func(u8)
+		payload = []byte{funcID}
+	default:
+		return
+	}
+
+	s.sendFrame(c, &codec.AN2Frame{
+		Proto:   codec.AN2ProtoInternal,
+		Slot:    f.Slot,
+		MTID:    f.MTID,
+		Type:    codec.AN2TypeReply,
+		Payload: payload,
+	})
+}
+
+// handleACP2 answers an ACP2 data frame. get_version is answered by the
+// harness directly (handshake step 5); everything else is delegated to
+// onACP2 so each test can shape the object/property replies. The reply
+// MTID always echoes the request so the session's waiter map matches.
+func (s *fakeServer) handleACP2(c net.Conn, f *codec.AN2Frame) {
+	if f.Type != codec.AN2TypeData || len(f.Payload) < codec.ACP2HeaderSize {
+		return
+	}
+	req, err := codec.DecodeACP2Message(f.Payload)
+	if err != nil {
+		return
+	}
+	// DecodeACP2Message only populates ObjID/Idx/Properties for replies
+	// and announces — request bodies are left raw in req.Body. Parse the
+	// request body here so onACP2 handlers can dispatch on ObjID and
+	// inspect the set_property value the client sent.
+	parseRequestBody(req)
+
+	// get_version is part of the handshake — answer it unconditionally.
+	if req.Type == codec.ACP2TypeRequest && req.Func == codec.ACP2FuncGetVersion {
+		s.sendACP2(c, f.Slot, &codec.ACP2Message{
+			Type: codec.ACP2TypeReply,
+			MTID: req.MTID,
+			Func: codec.ACP2FuncGetVersion,
+			PID:  s.acp2Ver,
+		})
+		// Fire the optional announce once the handshake is done.
+		if s.announceFn != nil {
+			fn := s.announceFn
+			s.announceFn = nil
+			fn(func(slot uint8, msg *codec.ACP2Message) {
+				msg.MTID = 0
+				msg.Type = codec.ACP2TypeAnnounce
+				s.sendACP2(c, slot, msg)
+			})
+		}
+		return
+	}
+
+	if s.onACP2 == nil {
+		return
+	}
+	reply := s.onACP2(f.Slot, req)
+	if reply == nil {
+		return // drop — drives a context-timeout path
+	}
+	reply.MTID = req.MTID
+	s.sendACP2(c, f.Slot, reply)
+}
+
+// parseRequestBody fills req.ObjID / req.Idx / req.Properties from the
+// raw request body for funcs 1-3 (get_object, get_property,
+// set_property). The production decoder intentionally leaves these
+// fields zero for request-type messages; the loopback server needs
+// them to dispatch and to echo set values back.
+func parseRequestBody(req *codec.ACP2Message) {
+	switch req.Func {
+	case codec.ACP2FuncGetObject, codec.ACP2FuncGetProperty, codec.ACP2FuncSetProperty:
+	default:
+		return
+	}
+	if len(req.Body) < 8 {
+		return
+	}
+	req.ObjID = uint32(req.Body[0])<<24 | uint32(req.Body[1])<<16 | uint32(req.Body[2])<<8 | uint32(req.Body[3])
+	req.Idx = uint32(req.Body[4])<<24 | uint32(req.Body[5])<<16 | uint32(req.Body[6])<<8 | uint32(req.Body[7])
+	if len(req.Body) > 8 {
+		if props, err := codec.DecodeProperties(req.Body[8:]); err == nil {
+			req.Properties = props
+		}
+	}
+}
+
+// ---- reply builders ----
+
+// objectReply builds a get_object reply message carrying the supplied
+// properties for obj-id. Encodes the properties with the production
+// codec so the wire bytes match what a real device emits.
+func objectReply(objID uint32, props []codec.Property) *codec.ACP2Message {
+	return &codec.ACP2Message{
+		Type:       codec.ACP2TypeReply,
+		Func:       codec.ACP2FuncGetObject,
+		ObjID:      objID,
+		Idx:        0,
+		Properties: props,
+		Body:       objectBody(objID, props),
+	}
+}
+
+// propertyReply builds a get_property / set_property reply carrying a
+// single property for obj-id.
+func propertyReply(fn codec.ACP2Func, objID uint32, prop codec.Property) *codec.ACP2Message {
+	return &codec.ACP2Message{
+		Type:       codec.ACP2TypeReply,
+		Func:       fn,
+		ObjID:      objID,
+		Idx:        0,
+		Properties: []codec.Property{prop},
+		Body:       objectBody(objID, []codec.Property{prop}),
+	}
+}
+
+// errorReply builds an ACP2 error message with the given stat code. Per
+// spec the error message is the 4-byte header only; func carries stat.
+func errorReply(stat codec.ACP2ErrStatus) *codec.ACP2Message {
+	return &codec.ACP2Message{
+		Type: codec.ACP2TypeError,
+		Func: codec.ACP2Func(stat),
+	}
+}
+
+// objectBody encodes obj-id(u32) + idx(u32) + properties into the raw
+// Body bytes. The reply goes back out through EncodeACP2Message's
+// default branch (Func != get_object/property/set), which emits the
+// header followed by Body verbatim — so the device-side encoding stays
+// byte-faithful regardless of the func.
+func objectBody(objID uint32, props []codec.Property) []byte {
+	body := make([]byte, 8)
+	body[0] = byte(objID >> 24)
+	body[1] = byte(objID >> 16)
+	body[2] = byte(objID >> 8)
+	body[3] = byte(objID)
+	// idx stays 0
+	pb, _ := codec.EncodeProperties(props)
+	return append(body, pb...)
+}
+
+// u32Prop builds a property whose value is a single big-endian u32 —
+// the wire shape for object_type, access, number_type, etc. (pid data
+// stored as u32, low byte significant).
+func u32Prop(pid uint8, vtype uint8, v uint32) codec.Property {
+	data := []byte{byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}
+	return codec.Property{PID: pid, VType: vtype, PLen: uint16(4 + len(data)), Data: data}
+}
+
+// childrenProp builds a pid=14 children property (u32[] child obj-ids).
+func childrenProp(ids ...uint32) codec.Property {
+	data := make([]byte, 0, len(ids)*4)
+	for _, id := range ids {
+		data = append(data, byte(id>>24), byte(id>>16), byte(id>>8), byte(id))
+	}
+	return codec.Property{PID: codec.PIDChildren, PLen: uint16(4 + len(data)), Data: data}
+}
+
+// waitFor polls cond until it is true or the deadline elapses. Keeps
+// announce-delivery assertions deterministic without a fixed sleep.
+func waitFor(t *testing.T, d time.Duration, cond func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return cond()
+}

--- a/internal/acp2/consumer/session_io_test.go
+++ b/internal/acp2/consumer/session_io_test.go
@@ -1,0 +1,149 @@
+package acp2
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"dhs/internal/consumer"
+
+	"dhs/internal/acp2/codec"
+)
+
+// session_io_test.go exercises the session-layer routing branches that
+// the higher-level method tests don't reach directly: AN2 slot events
+// and AN2 errors on the read loop, orphan-reply handling, the
+// SessionHealth snapshot, and the raw-body fallbacks in GetValue.
+
+// TestSession_AN2SlotEvent pushes an unsolicited AN2 slot event
+// (proto=0, type=event) and asserts the session updates the cached slot
+// status (handleAN2Internal AN2TypeEvent branch).
+func TestSession_AN2SlotEvent(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	// After the handshake, push an AN2 slot event for slot 1 → status 0
+	// (card removed). The harness reuses announceFn as a post-handshake
+	// hook; we send a raw AN2 event frame instead of an ACP2 announce.
+	srv.announceFn = func(send func(slot uint8, msg *codec.ACP2Message)) {
+		// send is ACP2-only; reach the connection directly for the AN2
+		// event frame via the server's stored conn.
+		srv.mu.Lock()
+		conns := append([]net.Conn(nil), srv.conns...)
+		srv.mu.Unlock()
+		for _, c := range conns {
+			srv.sendFrame(c, &codec.AN2Frame{
+				Proto:   codec.AN2ProtoInternal,
+				Slot:    1,
+				MTID:    0,
+				Type:    codec.AN2TypeEvent,
+				Payload: []byte{0}, // status 0 = no card
+			})
+		}
+	}
+	defer srv.stop()
+
+	p := connectPlugin(t, srv, host, port)
+	p.mu.Lock()
+	s := p.session
+	p.mu.Unlock()
+
+	ok := waitFor(t, 2*time.Second, func() bool {
+		return s.SlotStatus(1) == consumer.SlotNoCard
+	})
+	if !ok {
+		t.Errorf("slot 1 status = %v, want SlotNoCard after AN2 event", s.SlotStatus(1))
+	}
+}
+
+// TestSession_OrphanReply pushes an ACP2 reply for an mtid with no
+// registered waiter — the session drops it and fires the orphan
+// compliance event (routeReply no-waiter branch).
+func TestSession_OrphanReply(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	defer srv.stop()
+
+	p := connectPlugin(t, srv, host, port)
+	prof := p.ComplianceProfile()
+	if prof == nil {
+		t.Fatal("nil compliance profile")
+	}
+
+	// Push an ACP2 reply with mtid=200 that no DoACP2 is waiting on,
+	// AFTER Connect so the session's compliance profile is attached.
+	srv.mu.Lock()
+	conns := append([]net.Conn(nil), srv.conns...)
+	srv.mu.Unlock()
+	for _, c := range conns {
+		srv.sendACP2(c, 0, &codec.ACP2Message{
+			Type: codec.ACP2TypeReply,
+			MTID: 200,
+			Func: codec.ACP2FuncGetObject,
+			Body: objectBody(1, nil),
+		})
+	}
+	// The orphan reply increments OrphanReplyMtid.
+	waitFor(t, 2*time.Second, func() bool {
+		return prof.Snapshot()[OrphanReplyMtid] > 0
+	})
+	if prof.Snapshot()[OrphanReplyMtid] == 0 {
+		t.Error("orphan reply did not fire OrphanReplyMtid event")
+	}
+}
+
+// TestSessionHealth covers the SessionHealth snapshot on a live session.
+func TestSessionHealth(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	defer srv.stop()
+
+	p := connectPlugin(t, srv, host, port)
+
+	h := p.SessionHealth(context.Background())
+	if !h.Connected {
+		t.Error("Connected = false on live session")
+	}
+	if !h.Reachable {
+		t.Error("Reachable = false on loopback session")
+	}
+	if h.LastRx.IsZero() {
+		t.Error("LastRx zero — handshake frames should have advanced it")
+	}
+}
+
+func TestSessionHealth_LoopbackNoSession(t *testing.T) {
+	p := &Plugin{logger: testLogger()}
+	h := p.SessionHealth(context.Background())
+	if h.Connected {
+		t.Error("Connected = true with no session")
+	}
+}
+
+// TestGetValue_RawBodyFallback exercises the branch where the reply does
+// not carry the requested pid at all — GetValue returns the raw body.
+func TestGetValue_RawBodyFallback(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	srv.onACP2 = func(slot uint8, req *codec.ACP2Message) *codec.ACP2Message {
+		switch req.Func {
+		case codec.ACP2FuncGetObject:
+			return objectReply(4, []codec.Property{
+				u32Prop(codec.PIDObjectType, 0, uint32(codec.ObjTypeNumber)),
+				u32Prop(codec.PIDNumberType, 0, uint32(codec.NumTypeU32)),
+			})
+		case codec.ACP2FuncGetProperty:
+			// Reply carries a DIFFERENT pid than requested (pid=8) →
+			// GetValue falls through to the raw-body return.
+			return propertyReply(codec.ACP2FuncGetProperty, 4,
+				u32Prop(codec.PIDAccess, 0, 1))
+		}
+		return errorReply(codec.ErrProtocol)
+	}
+	defer srv.stop()
+
+	p := connectPlugin(t, srv, host, port)
+	val, err := p.GetValue(context.Background(), consumer.ValueRequest{Slot: 0, ID: 4})
+	if err != nil {
+		t.Fatalf("GetValue: %v", err)
+	}
+	if val.Kind != consumer.KindRaw {
+		t.Errorf("kind = %v, want KindRaw fallback", val.Kind)
+	}
+}

--- a/internal/acp2/consumer/subscribe_loopback_test.go
+++ b/internal/acp2/consumer/subscribe_loopback_test.go
@@ -1,0 +1,205 @@
+package acp2
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"dhs/internal/consumer"
+
+	"dhs/internal/acp2/codec"
+)
+
+// subscribe_loopback_test.go drives Plugin.Subscribe / Unsubscribe and
+// the announce dispatch path. The harness fires one ACP2 announce right
+// after the handshake; the test asserts the registered callback
+// receives a decoded Event.
+
+// announceMsg builds an announce message for obj-id with a u32 value
+// property (the wire shape the device emits on a value change).
+func announceMsg(objID uint32, val uint32) *codec.ACP2Message {
+	valProp := codec.MakeValueProperty(codec.PIDValue, codec.NumTypeU32, beBytes(val))
+	return &codec.ACP2Message{
+		Type:  codec.ACP2TypeAnnounce,
+		PID:   codec.PIDValue,
+		ObjID: objID,
+		Idx:   0,
+		// Properties is read by the announce closure when the message is
+		// fed directly via feedAnnounce (bypassing the wire decode);
+		// Body carries the same bytes for the on-wire announce path.
+		Properties: []codec.Property{valProp},
+		Body:       objectBody(objID, []codec.Property{valProp}),
+	}
+}
+
+func beBytes(v uint32) []byte {
+	return []byte{byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}
+}
+
+func TestSubscribe_NotConnected(t *testing.T) {
+	p := &Plugin{logger: testLogger()}
+	err := p.Subscribe(consumer.ValueRequest{ID: 3}, func(consumer.Event) {})
+	if err != consumer.ErrNotConnected {
+		t.Errorf("err = %v, want ErrNotConnected", err)
+	}
+}
+
+func TestSubscribe_ReceivesAnnounce(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	// Fire an announce for obj-id 3 = 55 after the handshake completes.
+	srv.announceFn = func(send func(slot uint8, msg *codec.ACP2Message)) {
+		send(1, announceMsg(3, 55))
+	}
+	defer srv.stop()
+
+	p := &Plugin{logger: testLogger()}
+	p.SetKeepAlive(consumer.KeepAliveConfig{
+		Interval: consumer.DisableInterval,
+		Timeout:  consumer.DisableTimeout,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := p.Connect(ctx, host, port); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer func() { _ = p.Disconnect() }()
+
+	ch := make(chan consumer.Event, 4)
+	if err := p.Subscribe(consumer.ValueRequest{Slot: -1, ID: -1}, func(ev consumer.Event) {
+		ch <- ev
+	}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	// The handshake announce may have already fired before Subscribe was
+	// registered (it races Connect's return). Trigger a fresh announce
+	// deterministically by re-arming announceFn and issuing a request
+	// that the server answers — but simpler: directly push an announce
+	// through the live session from the server side via a second
+	// connection is not available. Instead, drive an announce by calling
+	// SubscribeAnnounces on the session and feeding a synthetic frame is
+	// white-box. We assert on the handshake announce if it arrived;
+	// otherwise we fall back to injecting through the session.
+	select {
+	case ev := <-ch:
+		if ev.ID != 3 {
+			t.Errorf("event ID = %d, want 3", ev.ID)
+		}
+		if ev.Value.Kind != consumer.KindUint || ev.Value.Uint != 55 {
+			t.Errorf("event value = %+v, want uint 55", ev.Value)
+		}
+		return
+	case <-time.After(200 * time.Millisecond):
+		// Handshake announce raced past Subscribe — inject one via the
+		// session's announce fan-out to prove the closure + dispatch.
+	}
+
+	p.mu.Lock()
+	s := p.session
+	p.mu.Unlock()
+	// Feed an announce straight into the session fan-out (same path the
+	// readLoop uses) to deterministically exercise the closure.
+	feedAnnounce(s, 1, announceMsg(3, 55))
+
+	select {
+	case ev := <-ch:
+		if ev.ID != 3 || ev.Value.Uint != 55 {
+			t.Errorf("event = %+v, want ID 3 value 55", ev)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("announce not delivered to subscriber")
+	}
+}
+
+// feedAnnounce invokes every registered announce subscriber with msg,
+// mimicking what session.handleACP2Frame does on an inbound announce.
+// White-box: reaches the unexported annSubs to make the dispatch
+// assertion deterministic regardless of handshake-announce timing.
+func feedAnnounce(s *Session, slot uint8, msg *codec.ACP2Message) {
+	s.annMu.Lock()
+	subs := make([]AnnounceFunc, 0, len(s.annSubs))
+	for _, fn := range s.annSubs {
+		subs = append(subs, fn)
+	}
+	s.annMu.Unlock()
+	for _, fn := range subs {
+		fn(slot, msg)
+	}
+}
+
+func TestSubscribe_FilterBySlot(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	defer srv.stop()
+
+	p := connectPlugin(t, srv, host, port)
+
+	ch := make(chan consumer.Event, 4)
+	if err := p.Subscribe(consumer.ValueRequest{Slot: 2, ID: -1}, func(ev consumer.Event) {
+		ch <- ev
+	}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	p.mu.Lock()
+	s := p.session
+	p.mu.Unlock()
+
+	// Announce on slot 1 must be filtered out (sub wants slot 2).
+	feedAnnounce(s, 1, announceMsg(3, 10))
+	// Announce on slot 2 must pass.
+	feedAnnounce(s, 2, announceMsg(3, 20))
+
+	select {
+	case ev := <-ch:
+		if ev.Slot != 2 {
+			t.Errorf("delivered slot = %d, want 2", ev.Slot)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("slot-2 announce not delivered")
+	}
+	// No second event (slot-1 was filtered).
+	select {
+	case ev := <-ch:
+		t.Errorf("unexpected second event: %+v", ev)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestUnsubscribe(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	defer srv.stop()
+
+	p := connectPlugin(t, srv, host, port)
+	req := consumer.ValueRequest{Slot: -1, ID: -1}
+
+	ch := make(chan consumer.Event, 4)
+	if err := p.Subscribe(req, func(ev consumer.Event) { ch <- ev }); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	if err := p.Unsubscribe(req); err != nil {
+		t.Fatalf("Unsubscribe: %v", err)
+	}
+
+	p.mu.Lock()
+	s := p.session
+	p.mu.Unlock()
+
+	feedAnnounce(s, 1, announceMsg(3, 99))
+	select {
+	case ev := <-ch:
+		t.Errorf("event delivered after Unsubscribe: %+v", ev)
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+func TestUnsubscribe_Unknown(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	defer srv.stop()
+
+	p := connectPlugin(t, srv, host, port)
+	// Unsubscribe a request that was never subscribed — no-op, no error.
+	if err := p.Unsubscribe(consumer.ValueRequest{ID: 1234}); err != nil {
+		t.Errorf("Unsubscribe unknown: %v", err)
+	}
+}

--- a/internal/acp2/consumer/validate_unit_test.go
+++ b/internal/acp2/consumer/validate_unit_test.go
@@ -1,0 +1,242 @@
+package acp2
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/hex"
+	"testing"
+
+	"dhs/internal/acp2/codec"
+	"dhs/internal/consumer"
+	"dhs/internal/wiretrace"
+)
+
+// acp2HeaderBytes builds a bare 4-byte ACP2 message header + optional body.
+func acp2HeaderBytes(typ codec.ACP2MsgType, mtid, funcOrStat, pid uint8, body []byte) []byte {
+	b := make([]byte, 4+len(body))
+	b[0] = byte(typ)
+	b[1] = mtid
+	b[2] = funcOrStat
+	b[3] = pid
+	copy(b[4:], body)
+	return b
+}
+
+// an2Wrap wraps a payload in an AN2 frame and returns it as a hex Trame.
+func an2Trame(t *testing.T, proto codec.AN2Proto, typ codec.AN2Type, mtid uint8, payload []byte, dir wiretrace.Direction, note string) wiretrace.Trame {
+	t.Helper()
+	raw, err := codec.EncodeAN2Frame(&codec.AN2Frame{
+		Proto:   proto,
+		Slot:    1,
+		MTID:    mtid,
+		Type:    typ,
+		Payload: payload,
+	})
+	if err != nil {
+		t.Fatalf("EncodeAN2Frame: %v", err)
+	}
+	return wiretrace.Trame{Direction: dir, Hex: hex.EncodeToString(raw), Note: note}
+}
+
+func u32BE(v uint32) []byte {
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, v)
+	return b
+}
+
+// TestValidate_HappyPath drives a clean request→reply→announce→error
+// sequence with no invariant violations.
+func TestValidate_HappyPath(t *testing.T) {
+	p := &Plugin{}
+	body := append(u32BE(100), u32BE(0)...) // obj-id, idx
+
+	req := acp2HeaderBytes(codec.ACP2TypeRequest, 7, uint8(codec.ACP2FuncGetProperty), 1, body)
+	rep := acp2HeaderBytes(codec.ACP2TypeReply, 7, uint8(codec.ACP2FuncGetProperty), 1, body)
+	ann := acp2HeaderBytes(codec.ACP2TypeAnnounce, 0, 0, 8, body)
+	errm := acp2HeaderBytes(codec.ACP2TypeError, 1, uint8(codec.ErrInvalidValue), 0, nil)
+
+	trames := []wiretrace.Trame{
+		an2Trame(t, codec.AN2ProtoACP2, codec.AN2TypeData, 0, req, wiretrace.DirectionTx, ""),
+		an2Trame(t, codec.AN2ProtoACP2, codec.AN2TypeData, 0, rep, wiretrace.DirectionRx, ""),
+		an2Trame(t, codec.AN2ProtoACP2, codec.AN2TypeData, 0, ann, wiretrace.DirectionRx, ""),
+		an2Trame(t, codec.AN2ProtoACP2, codec.AN2TypeData, 0, errm, wiretrace.DirectionRx, ""),
+	}
+
+	rep0, err := p.Validate(context.Background(), trames, consumer.ValidateOpts{})
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if rep0.TramesProcessed != 4 {
+		t.Errorf("TramesProcessed = %d, want 4", rep0.TramesProcessed)
+	}
+	if len(rep0.Errors) != 0 {
+		t.Errorf("unexpected errors: %v", rep0.Errors)
+	}
+	if len(rep0.Invariants) != 0 {
+		t.Errorf("unexpected invariants: %v", rep0.Invariants)
+	}
+	if rep0.PerDirection[wiretrace.DirectionTx] != 1 || rep0.PerDirection[wiretrace.DirectionRx] != 3 {
+		t.Errorf("per-direction = %v", rep0.PerDirection)
+	}
+}
+
+// TestValidate_InvariantViolations triggers each ACP2 invariant branch:
+// request mtid=0, reply mtid mismatch, announce mtid!=0, error stat out of
+// range, and unknown msg type.
+func TestValidate_InvariantViolations(t *testing.T) {
+	p := &Plugin{}
+	body := append(u32BE(1), u32BE(0)...)
+
+	req0 := acp2HeaderBytes(codec.ACP2TypeRequest, 0, uint8(codec.ACP2FuncGetProperty), 1, body) // mtid=0
+	reqOK := acp2HeaderBytes(codec.ACP2TypeRequest, 5, uint8(codec.ACP2FuncGetProperty), 1, body)
+	repBad := acp2HeaderBytes(codec.ACP2TypeReply, 9, uint8(codec.ACP2FuncGetProperty), 1, body) // mtid!=5
+	annBad := acp2HeaderBytes(codec.ACP2TypeAnnounce, 3, 0, 8, body)                             // mtid!=0
+	errBad := acp2HeaderBytes(codec.ACP2TypeError, 1, 99, 0, nil)                                // stat>5
+	unknown := acp2HeaderBytes(codec.ACP2MsgType(7), 1, 0, 0, body)                              // unknown type
+
+	trames := []wiretrace.Trame{
+		an2Trame(t, codec.AN2ProtoACP2, codec.AN2TypeData, 0, req0, wiretrace.DirectionTx, ""),
+		an2Trame(t, codec.AN2ProtoACP2, codec.AN2TypeData, 0, reqOK, wiretrace.DirectionTx, ""),
+		an2Trame(t, codec.AN2ProtoACP2, codec.AN2TypeData, 0, repBad, wiretrace.DirectionRx, ""),
+		an2Trame(t, codec.AN2ProtoACP2, codec.AN2TypeData, 0, annBad, wiretrace.DirectionRx, ""),
+		an2Trame(t, codec.AN2ProtoACP2, codec.AN2TypeData, 0, errBad, wiretrace.DirectionRx, ""),
+		an2Trame(t, codec.AN2ProtoACP2, codec.AN2TypeData, 0, unknown, wiretrace.DirectionRx, ""),
+	}
+	rep, err := p.Validate(context.Background(), trames, consumer.ValidateOpts{})
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if len(rep.Invariants) != 5 {
+		t.Fatalf("Invariants = %d (%v), want 5", len(rep.Invariants), rep.Invariants)
+	}
+}
+
+// TestValidate_ACP2FrameWrongAN2Type covers the "ACP2 must use AN2TypeData"
+// invariant branch.
+func TestValidate_ACP2FrameWrongAN2Type(t *testing.T) {
+	p := &Plugin{}
+	body := acp2HeaderBytes(codec.ACP2TypeRequest, 1, 2, 1, append(u32BE(1), u32BE(0)...))
+	trames := []wiretrace.Trame{
+		an2Trame(t, codec.AN2ProtoACP2, codec.AN2TypeRequest, 1, body, wiretrace.DirectionTx, ""),
+	}
+	rep, err := p.Validate(context.Background(), trames, consumer.ValidateOpts{})
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if len(rep.Invariants) != 1 {
+		t.Errorf("Invariants = %v, want 1 (wrong AN2 type)", rep.Invariants)
+	}
+}
+
+// TestValidate_AN2InternalMTIDZero covers the AN2-internal req/reply mtid=0
+// invariant branch.
+func TestValidate_AN2InternalMTIDZero(t *testing.T) {
+	p := &Plugin{}
+	trames := []wiretrace.Trame{
+		an2Trame(t, codec.AN2ProtoInternal, codec.AN2TypeRequest, 0, []byte{0x00}, wiretrace.DirectionTx, ""),
+	}
+	rep, err := p.Validate(context.Background(), trames, consumer.ValidateOpts{})
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if len(rep.Invariants) != 1 {
+		t.Errorf("Invariants = %v, want 1 (an2 internal mtid=0)", rep.Invariants)
+	}
+}
+
+// TestValidate_DecodeErrors covers the hex-decode and AN2-decode error
+// branches.
+func TestValidate_DecodeErrors(t *testing.T) {
+	p := &Plugin{}
+	trames := []wiretrace.Trame{
+		{Direction: wiretrace.DirectionRx, Hex: "zznothex"},  // hex decode fails
+		{Direction: wiretrace.DirectionRx, Hex: "0000000000000000"}, // bad AN2 magic
+	}
+	rep, err := p.Validate(context.Background(), trames, consumer.ValidateOpts{})
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if len(rep.Errors) != 2 {
+		t.Fatalf("Errors = %d (%v), want 2", len(rep.Errors), rep.Errors)
+	}
+	if rep.TramesProcessed != 0 {
+		t.Errorf("TramesProcessed = %d, want 0", rep.TramesProcessed)
+	}
+}
+
+// TestValidate_ACP2DecodeError covers the inner ACP2 decode failure branch
+// (AN2 frame is fine but the ACP2 payload is too short).
+func TestValidate_ACP2DecodeError(t *testing.T) {
+	p := &Plugin{}
+	trames := []wiretrace.Trame{
+		an2Trame(t, codec.AN2ProtoACP2, codec.AN2TypeData, 0, []byte{0x00, 0x01}, wiretrace.DirectionRx, ""),
+	}
+	rep, err := p.Validate(context.Background(), trames, consumer.ValidateOpts{})
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if len(rep.Errors) != 1 {
+		t.Errorf("Errors = %v, want 1 (acp2 decode)", rep.Errors)
+	}
+}
+
+// TestValidate_StopAt covers the early-stop branch on a matching note.
+func TestValidate_StopAt(t *testing.T) {
+	p := &Plugin{}
+	body := append(u32BE(1), u32BE(0)...)
+	req := acp2HeaderBytes(codec.ACP2TypeRequest, 1, uint8(codec.ACP2FuncGetProperty), 1, body)
+	trames := []wiretrace.Trame{
+		an2Trame(t, codec.AN2ProtoACP2, codec.AN2TypeData, 0, req, wiretrace.DirectionTx, "first"),
+		an2Trame(t, codec.AN2ProtoACP2, codec.AN2TypeData, 0, req, wiretrace.DirectionTx, "STOP"),
+		an2Trame(t, codec.AN2ProtoACP2, codec.AN2TypeData, 0, req, wiretrace.DirectionTx, "third"),
+	}
+	rep, err := p.Validate(context.Background(), trames, consumer.ValidateOpts{StopAt: "STOP"})
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if rep.StoppedAt != "STOP" {
+		t.Errorf("StoppedAt = %q, want STOP", rep.StoppedAt)
+	}
+	if rep.TramesProcessed != 2 {
+		t.Errorf("TramesProcessed = %d, want 2 (stopped before third)", rep.TramesProcessed)
+	}
+}
+
+// TestValidate_OutTreeNotImplemented covers the early-return guard.
+func TestValidate_OutTreeNotImplemented(t *testing.T) {
+	p := &Plugin{}
+	if _, err := p.Validate(context.Background(), nil, consumer.ValidateOpts{OutTree: "x.json"}); err == nil {
+		t.Error("expected error for --out-tree")
+	}
+	if _, err := p.Validate(context.Background(), nil, consumer.ValidateOpts{OutParams: "x.csv"}); err == nil {
+		t.Error("expected error for --out-params")
+	}
+}
+
+// TestValidate_ContextCancelled covers the ctx.Err() early-return branch.
+func TestValidate_ContextCancelled(t *testing.T) {
+	p := &Plugin{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	body := acp2HeaderBytes(codec.ACP2TypeRequest, 1, uint8(codec.ACP2FuncGetProperty), 1, append(u32BE(1), u32BE(0)...))
+	trames := []wiretrace.Trame{
+		an2Trame(t, codec.AN2ProtoACP2, codec.AN2TypeData, 0, body, wiretrace.DirectionTx, ""),
+	}
+	if _, err := p.Validate(ctx, trames, consumer.ValidateOpts{}); err == nil {
+		t.Error("expected context error")
+	}
+}
+
+// TestShortHex covers both the truncation and pass-through branches.
+func TestShortHex(t *testing.T) {
+	long := make([]byte, 32)
+	for i := range long {
+		long[i] = byte(i)
+	}
+	if got := shortHex(long); len(got) != 32 { // 16 bytes → 32 hex chars
+		t.Errorf("shortHex(32 bytes) len = %d, want 32", len(got))
+	}
+	if got := shortHex([]byte{0xAB, 0xCD}); got != "abcd" {
+		t.Errorf("shortHex short = %q, want abcd", got)
+	}
+}

--- a/internal/acp2/consumer/value_validate_unit_test.go
+++ b/internal/acp2/consumer/value_validate_unit_test.go
@@ -1,0 +1,85 @@
+package acp2
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"dhs/internal/acp2/codec"
+	"dhs/internal/consumer"
+)
+
+// TestValidateValue_NotConnected covers the nil-session guard at the top of
+// ValidateValue.
+func TestValidateValue_NotConnected(t *testing.T) {
+	p := &Plugin{trees: newWalkedTreeCache(4, 0)}
+	err := p.ValidateValue(context.Background(), consumer.ValueRequest{Slot: 1}, consumer.Value{})
+	if !errors.Is(err, consumer.ErrNotConnected) {
+		t.Fatalf("want ErrNotConnected, got %v", err)
+	}
+}
+
+// TestValidateValueAgainstType_RawBytesEscapeHatch covers the raw-bytes
+// trust path.
+func TestValidateValueAgainstType_RawBytesEscapeHatch(t *testing.T) {
+	val := consumer.Value{Raw: []byte{0xDE, 0xAD}}
+	if err := validateValueAgainstType(codec.ObjTypeNumber, codec.NumTypeU32, nil, val, nil); err != nil {
+		t.Fatalf("raw bytes should be trusted, got %v", err)
+	}
+}
+
+// TestValidateValueAgainstType_IPv4Empty covers the empty-IPv4 reject branch.
+func TestValidateValueAgainstType_IPv4Empty(t *testing.T) {
+	val := consumer.Value{Kind: consumer.KindString, Str: ""}
+	err := validateValueAgainstType(codec.ObjTypeIPv4, codec.NumTypeIPv4, nil, val, nil)
+	if !errors.Is(err, consumer.ErrValidationFailed) {
+		t.Fatalf("want ErrValidationFailed for empty ipv4, got %v", err)
+	}
+}
+
+// TestValidateValueAgainstType_IPv4WrongPartCount covers the malformed
+// (wrong number of octets) ipv4 branch.
+func TestValidateValueAgainstType_IPv4WrongPartCount(t *testing.T) {
+	val := consumer.Value{Kind: consumer.KindString, Str: "10.0.1"}
+	err := validateValueAgainstType(codec.ObjTypeIPv4, codec.NumTypeIPv4, nil, val, nil)
+	if !errors.Is(err, consumer.ErrValidationFailed) {
+		t.Fatalf("want ErrValidationFailed for 3-octet ipv4, got %v", err)
+	}
+}
+
+// TestValidateValueAgainstType_IPv4OctetOutOfRange covers the >255 octet
+// branch.
+func TestValidateValueAgainstType_IPv4OctetOutOfRange(t *testing.T) {
+	val := consumer.Value{Kind: consumer.KindString, Str: "10.0.0.999"}
+	err := validateValueAgainstType(codec.ObjTypeIPv4, codec.NumTypeIPv4, nil, val, nil)
+	if !errors.Is(err, consumer.ErrValidationFailed) {
+		t.Fatalf("want ErrValidationFailed for out-of-range octet, got %v", err)
+	}
+}
+
+// TestValidateValueAgainstType_IPv4FromIPAddr covers the non-zero IPAddr
+// fast-accept branch.
+func TestValidateValueAgainstType_IPv4FromIPAddr(t *testing.T) {
+	val := consumer.Value{Kind: consumer.KindIPAddr, IPAddr: [4]byte{192, 168, 1, 1}}
+	if err := validateValueAgainstType(codec.ObjTypeIPv4, codec.NumTypeIPv4, nil, val, nil); err != nil {
+		t.Fatalf("non-zero IPAddr should accept, got %v", err)
+	}
+}
+
+// TestValidateValueAgainstType_EnumNoOptionsBestEffort covers the
+// no-options-map best-effort accept branch.
+func TestValidateValueAgainstType_EnumNoOptionsBestEffort(t *testing.T) {
+	val := consumer.Value{Kind: consumer.KindEnum, Enum: 5}
+	if err := validateValueAgainstType(codec.ObjTypeEnum, codec.NumTypePreset, nil, val, nil); err != nil {
+		t.Fatalf("no options map should best-effort accept, got %v", err)
+	}
+}
+
+// TestValidateValueAgainstType_NodeAndUnknownAccept covers the node /
+// fall-through accept path.
+func TestValidateValueAgainstType_NodeAndUnknownAccept(t *testing.T) {
+	val := consumer.Value{Kind: consumer.KindString, Str: "anything"}
+	if err := validateValueAgainstType(codec.ObjTypeNode, codec.NumTypeU8, nil, val, nil); err != nil {
+		t.Fatalf("node container should accept, got %v", err)
+	}
+}

--- a/internal/acp2/consumer/walk_loopback_test.go
+++ b/internal/acp2/consumer/walk_loopback_test.go
@@ -1,0 +1,235 @@
+package acp2
+
+import (
+	"context"
+	"testing"
+
+	"dhs/internal/consumer"
+
+	"dhs/internal/acp2/codec"
+)
+
+// walk_loopback_test.go drives Plugin.Walk + the Walker DFS against the
+// loopback harness. The fake tree:
+//
+//	obj 1 ROOT_NODE_V2 (node) → children [2, 3]
+//	  obj 2 BOARD (node)       → children [4]
+//	    obj 4 Card Name (string) = "CONVERT Hybrid"
+//	  obj 3 Volume (number u32) = 42
+//
+// The walker tries obj-id 1 first (real-device convention), so the
+// server roots the tree at 1.
+
+func walkTreeServer(t *testing.T) (*fakeServer, string, int) {
+	srv, host, port := newFakeServer(t)
+	srv.onACP2 = func(slot uint8, req *codec.ACP2Message) *codec.ACP2Message {
+		if req.Func != codec.ACP2FuncGetObject {
+			return errorReply(codec.ErrProtocol)
+		}
+		switch req.ObjID {
+		case 1:
+			return objectReply(1, []codec.Property{
+				u32Prop(codec.PIDObjectType, 0, uint32(codec.ObjTypeNode)),
+				codec.MakeStringProperty(codec.PIDLabel, "ROOT_NODE_V2"),
+				childrenProp(2, 3),
+			})
+		case 2:
+			return objectReply(2, []codec.Property{
+				u32Prop(codec.PIDObjectType, 0, uint32(codec.ObjTypeNode)),
+				codec.MakeStringProperty(codec.PIDLabel, "BOARD"),
+				childrenProp(4),
+			})
+		case 3:
+			return objectReply(3, []codec.Property{
+				u32Prop(codec.PIDObjectType, 0, uint32(codec.ObjTypeNumber)),
+				codec.MakeStringProperty(codec.PIDLabel, "Volume"),
+				u32Prop(codec.PIDNumberType, 0, uint32(codec.NumTypeU32)),
+				codec.MakeValueProperty(codec.PIDValue, codec.NumTypeU32, []byte{0, 0, 0, 42}),
+				u32Prop(codec.PIDAccess, 0, 3),
+			})
+		case 4:
+			return objectReply(4, []codec.Property{
+				u32Prop(codec.PIDObjectType, 0, uint32(codec.ObjTypeString)),
+				codec.MakeStringProperty(codec.PIDLabel, "Card Name"),
+				codec.MakeStringProperty(codec.PIDValue, "CONVERT Hybrid"),
+			})
+		default:
+			return errorReply(codec.ErrInvalidObjID)
+		}
+	}
+	return srv, host, port
+}
+
+func TestWalk_FullTree(t *testing.T) {
+	srv, host, port := walkTreeServer(t)
+	defer srv.stop()
+
+	p := connectPlugin(t, srv, host, port)
+
+	objs, err := p.Walk(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if len(objs) != 4 {
+		t.Fatalf("walked %d objects, want 4", len(objs))
+	}
+
+	byLabel := map[string]consumer.Object{}
+	for _, o := range objs {
+		byLabel[o.Label] = o
+	}
+
+	root, ok := byLabel["ROOT_NODE_V2"]
+	if !ok {
+		t.Fatal("ROOT_NODE_V2 not in walk")
+	}
+	if root.ID != 1 {
+		t.Errorf("root ID = %d, want 1", root.ID)
+	}
+
+	vol, ok := byLabel["Volume"]
+	if !ok {
+		t.Fatal("Volume not walked")
+	}
+	if vol.Kind != consumer.KindUint || vol.Value.Uint != 42 {
+		t.Errorf("Volume = %+v, want uint 42", vol.Value)
+	}
+
+	card, ok := byLabel["Card Name"]
+	if !ok {
+		t.Fatal("Card Name not walked")
+	}
+	if card.Kind != consumer.KindString || card.Value.Str != "CONVERT Hybrid" {
+		t.Errorf("Card Name = %+v, want string CONVERT Hybrid", card.Value)
+	}
+	// Path should be ROOT_NODE_V2 → BOARD → Card Name.
+	if len(card.Path) != 3 || card.Path[1] != "BOARD" {
+		t.Errorf("Card Name path = %v, want [ROOT_NODE_V2 BOARD Card Name]", card.Path)
+	}
+}
+
+func TestWalk_Cached(t *testing.T) {
+	srv, host, port := walkTreeServer(t)
+	defer srv.stop()
+
+	p := connectPlugin(t, srv, host, port)
+
+	first, err := p.Walk(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Walk 1: %v", err)
+	}
+	// Second Walk returns the cached tree without re-fetching.
+	second, err := p.Walk(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Walk 2: %v", err)
+	}
+	if len(first) != len(second) {
+		t.Errorf("cached walk len mismatch: %d vs %d", len(first), len(second))
+	}
+}
+
+func TestWalk_NotConnected(t *testing.T) {
+	p := &Plugin{logger: testLogger()}
+	p.trees = newWalkedTreeCache(8, 0)
+	if _, err := p.Walk(context.Background(), 0); err != consumer.ErrNotConnected {
+		t.Errorf("err = %v, want ErrNotConnected", err)
+	}
+}
+
+func TestWalk_RootFallbackToZero(t *testing.T) {
+	// Server only knows obj-id 0 as the root; obj-id 1 errors. The
+	// walker must fall back from 1 to 0.
+	srv, host, port := newFakeServer(t)
+	srv.onACP2 = func(slot uint8, req *codec.ACP2Message) *codec.ACP2Message {
+		if req.Func != codec.ACP2FuncGetObject {
+			return errorReply(codec.ErrProtocol)
+		}
+		switch req.ObjID {
+		case 0:
+			return objectReply(0, []codec.Property{
+				u32Prop(codec.PIDObjectType, 0, uint32(codec.ObjTypeNode)),
+				codec.MakeStringProperty(codec.PIDLabel, "ROOT"),
+			})
+		default:
+			return errorReply(codec.ErrInvalidObjID)
+		}
+	}
+	defer srv.stop()
+
+	p := connectPlugin(t, srv, host, port)
+	objs, err := p.Walk(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if len(objs) != 1 || objs[0].Label != "ROOT" {
+		t.Fatalf("walk = %+v, want single ROOT", objs)
+	}
+}
+
+func TestWalk_RootError(t *testing.T) {
+	// Both obj-id 1 and 0 error → Walk returns an error.
+	srv, host, port := newFakeServer(t)
+	srv.onACP2 = func(slot uint8, req *codec.ACP2Message) *codec.ACP2Message {
+		return errorReply(codec.ErrInvalidObjID)
+	}
+	defer srv.stop()
+
+	p := connectPlugin(t, srv, host, port)
+	if _, err := p.Walk(context.Background(), 0); err == nil {
+		t.Fatal("Walk with no valid root: want error")
+	}
+}
+
+func TestIdentityProbe(t *testing.T) {
+	srv, host, port := newFakeServer(t)
+	srv.onACP2 = func(slot uint8, req *codec.ACP2Message) *codec.ACP2Message {
+		if req.Func != codec.ACP2FuncGetObject {
+			return errorReply(codec.ErrProtocol)
+		}
+		switch req.ObjID {
+		case 1:
+			return objectReply(1, []codec.Property{
+				u32Prop(codec.PIDObjectType, 0, uint32(codec.ObjTypeNode)),
+				codec.MakeStringProperty(codec.PIDLabel, "ROOT_NODE_V2"),
+				childrenProp(2),
+			})
+		case 2:
+			return objectReply(2, []codec.Property{
+				u32Prop(codec.PIDObjectType, 0, uint32(codec.ObjTypeNode)),
+				codec.MakeStringProperty(codec.PIDLabel, "IDENTITY"),
+				childrenProp(10, 11),
+			})
+		case 10:
+			return objectReply(10, []codec.Property{
+				u32Prop(codec.PIDObjectType, 0, uint32(codec.ObjTypeString)),
+				codec.MakeStringProperty(codec.PIDLabel, "Card Name"),
+				codec.MakeStringProperty(codec.PIDValue, "CONVERT Hybrid"),
+			})
+		case 11:
+			return objectReply(11, []codec.Property{
+				u32Prop(codec.PIDObjectType, 0, uint32(codec.ObjTypeString)),
+				codec.MakeStringProperty(codec.PIDLabel, "Product Version"),
+				codec.MakeStringProperty(codec.PIDValue, "5.3.5"),
+			})
+		default:
+			return errorReply(codec.ErrInvalidObjID)
+		}
+	}
+	defer srv.stop()
+
+	p := connectPlugin(t, srv, host, port)
+	id, err := p.IdentityProbe(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("IdentityProbe: %v", err)
+	}
+	if id != "CONVERT Hybrid@5.3.5" {
+		t.Errorf("identity = %q, want CONVERT Hybrid@5.3.5", id)
+	}
+}
+
+func TestIdentityProbe_NotConnected(t *testing.T) {
+	p := &Plugin{logger: testLogger()}
+	if _, err := p.IdentityProbe(context.Background(), 0); err != consumer.ErrNotConnected {
+		t.Errorf("err = %v, want ErrNotConnected", err)
+	}
+}

--- a/internal/acp2/docs/status.md
+++ b/internal/acp2/docs/status.md
@@ -1,0 +1,108 @@
+# ACP2 — feature & ADR-compliance status
+
+Single-page, numbered status of the ACP2 connector: every feature, its state,
+the evidence, and the ADR it satisfies. Strict — "verified live" means exercised
+against a real **EVS Neuron** (CONVERT Hybrid, the vendor oracle, never our own
+provider as the consumer oracle); "code" means implemented and unit-tested but
+not in the live verify matrix.
+
+- **As of:** 2026-06-13
+- **Spec:** `internal/acp2/assets/acp2_protocol.pdf` + `an2_protocol.pdf` · wire ref: `internal/acp2/wireshark/dhs_acpv2.lua`
+- **Transport:** AN2/TCP **only** (port 2072, AN2 proto=2) — no UDP, no direct TCP.
+- **Oracle:** real EVS Neuron CONVERT Hybrid (lab, reached from a device-side host) + our provider emulator (`dhs producer acp2 serve`, validated against Cerebrum + Lawo VSM) for the loopback-regression tier.
+- **Coverage:** codec **98.8%** · consumer **84.2%** · provider **90.0%** (CI floors enforce no-regression). Consumer < 90 because the residual gap is live-session / timer / device-response-shape branches reachable only via the integration tier (now present), not unit-coverable without a live peer.
+
+Legend: ✅ verified live · 🟢 code + unit test · 🟡 partial · ⬜ not started · — N/A
+
+---
+
+## 1. Consumer CLI verbs
+
+| # | Verb | State | Evidence | ADR |
+|---:|---|:--:|---|---|
+| 1 | `info` | ✅ | live vs real Neuron `10.44.72.28` (AN2 v0.1, ACP2 v2, 2 slots present); integration test asserts slot count | 0002 |
+| 2 | `walk` | 🟢 | integration test (full DFS over the served tree); consumer loopback `walk_loopback_test.go` | 0002 |
+| 3 | `tree` | 🟢 | shared tree renderer over the walked tree | 0002 |
+| 4 | `get` | 🟢 | integration get on a real leaf; `getset_loopback_test.go` (pid/idx, cold-cache, raw fallback) | 0002 |
+| 5 | `set` | 🟢 | integration set + round-trip confirm; `getset_loopback_test.go` (typed + raw + no-access) | 0002 |
+| 6 | `ensure` | 🟢 | converge-to-value, idempotent (`--check` dry-run) | 0007 |
+| 7 | `watch` | 🟢 | announce dispatch + decode after EnableProtocolEvents; `subscribe_loopback_test.go` | 0002 |
+| 8 | `export` | 🟢 | json/yaml/csv of a walked device | 0002 |
+| 9 | `import` | 🟢 | `--dry-run` non-destructive apply | 0002 |
+| 10 | `extract` | 🟢 | DM triple (meta + wire + tree) | 0022 |
+| 11 | `diff` | 🟢 | canonical tree.json schema diff | 0002 |
+| 12 | `convert` | 🟢 | json↔yaml↔csv (offline) | 0002 |
+| 13 | `validate` | 🟢 | offline frames.jsonl decode through the codec | 0006 · 0021 |
+| 14 | `diag` | 🟢 | ACP2 diagnostic probes (`diag_loopback_test.go`) | 0002 |
+| 15 | `health` | 🟢 | 3-layer session health (reachable / connected / live) | 0002 |
+
+`inc` / `dec` / `reset` are ACP1 setInc/Dec/Def methods — **N/A** for ACP2 (the
+spec defines only get_version / get_object / get_property / set_property; writes
+go through `set`). `matrix` / `invoke` / `stream` are Ember+-only — N/A.
+
+## 2. Consumer transport + protocol completeness
+
+| # | Item | State | Evidence | ADR |
+|---:|---|:--:|---|---|
+| 16 | AN2/TCP (2072, proto=2) — the only ACP2 transport | ✅ | live handshake vs real Neuron; `connect_loopback_test.go` | 0001 |
+| 17 | AN2 init sequence (GetVersion → GetDeviceInfo → GetSlotInfo → EnableProtocolEvents → ACP2 GetVersion) | ✅ | live + loopback; required before any ACP2 traffic | 0001 |
+| 18 | 4 ACP2 functions driveable from the consumer | 🟢 | get_version / get_object (walk/meta) / get_property (get) / set_property (set) | 0002 |
+| 19 | pid/idx addressing; preset idx=0 = ACTIVE INDEX (never "first slot") | 🟢 | `getset_loopback_test.go` (explicit-pid, idx) | 0006 |
+| 20 | Keep-alive prober + watchdog; warm-restart reconnect (replays subs) | 🟢 | `keepalive_test.go`, `io_coverage_test.go` (reconnect) | 0001 |
+
+## 3. Producer (`dhs producer acp2 serve`) — the emulator
+
+| # | Capability | State | Evidence | ADR |
+|---:|---|:--:|---|---|
+| 21 | Serve AN2/TCP (2072) from a canonical tree | 🟢 | `serve_loopback_test.go` (full Serve accept loop) | 0001 |
+| 22 | Validated against real controllers (Cerebrum, Lawo VSM) | ✅ | prior live runs — legitimizes use as the consumer's loopback oracle | 0025 #3 |
+| 23 | Per-object-type encode (node/preset/enum/number/ipv4/string) | 🟢 | `encoder_test.go`, `encoder_neuron_test.go`, `set_enum_test.go` | 0006 |
+| 24 | Announce broadcast on value change (after EnableProtocolEvents) | 🟢 | `serve_loopback_test.go` (broadcastAnnounce) | 0006 |
+| 25 | Multi-slot frame status from the served tree | 🟢 | loopback `info` shows N present slots | 0022 |
+
+## 4. Codec & wire (stdlib-only, lift-ready)
+
+| # | Item | State | Evidence | ADR |
+|---:|---|:--:|---|---|
+| 26 | AN2 framer (magic 0xC635, 8-byte header) + ACP2 4-byte header | 🟢 | `framer_test.go`, `codec_test.go` | 0006 |
+| 27 | Property codec (pid/plen headers, 4-byte alignment, all vtypes) | 🟢 | `property_codec_test.go`, `property_spec_test.go` | 0006 |
+| 28 | Stringers + value helpers + error types | 🟢 | `stringers_value_test.go` | 0006 |
+| 29 | Codec imports zero `dhs/*` (lift-ready) | 🟢 | import audit | 0006 |
+| 30 | Wireshark dissector `dhs_acpv2.lua` (AN2 + ACP2, all funcs/types) | 🟢 | `internal/acp2/wireshark/dhs_acpv2.lua` | 0025 #5 |
+
+## 5. Tests & tooling (oracle-per-tier)
+
+| # | Tier | State | Evidence | ADR |
+|---:|---|:--:|---|---|
+| 31 | Unit (codec / consumer / provider) | 🟢 | CI per-package coverage floor (no-regression gate) | 0025 #1/#2 |
+| 32 | Consumer integration — CLI-driving, loopback-regression | 🟢 | `internal/acp2/integration` — provider emulator + consumer over real AN2/TCP; info/walk/get/set | 0025 #3 |
+| 33 | Consumer integration — real device (env-gated) | 🟡 | same test honours `ACP2_TEST_HOST`; `info` verified live vs Neuron `10.44.72.28`; full verb matrix vs device pending a device-side runner | 0025 #3 |
+| 34 | Replay fixtures under `testdata/` | 🟢 | `protocol_types/` per-type captures (pcapng + tshark.tree) + `fixtures/` + `exports/` | 0025 #6 |
+| 35 | Idempotency — Ansible test tier (run-twice = 0 changed) | 🟡 | shared `ansible/playbooks/test-idempotency.yml` covers the `ensure` verb; acp2 emulator deploy to the fleet pending | 0007 · 0016 |
+
+## 6. Error contract
+
+| # | Rule | State | Evidence |
+|---:|---|:--:|---|
+| 36 | Exit 0 ok / 1 runtime-wire / 2 usage-validation | 🟢 | `cmd/dhs/main.go` `exitCode` |
+| 37 | ACP2 error stat codes 0-5 surfaced (protocol/obj-id/idx/pid/access/value) | 🟢 | `ACP2Error` + `stringers_value_test.go`; loopback error-reply paths |
+| 38 | Client-side value validation (range/enum/type) | 🟢 | `value_validate.go`; `value_validate_test.go` |
+
+## 7. ADR-0025 — definition of done (6 deliverables)
+
+| # | Deliverable | State | Notes |
+|---:|---|:--:|---|
+| D1 | Consumer strict-to-spec, every CLI verb | 🟢 | AN2/TCP + all 4 functions driveable; verbs 1-15; unit + loopback + live `info`. |
+| D2 | Producer strict-to-spec | 🟢 | Items 21-25; served loopback; validated live vs Cerebrum/VSM. |
+| D3 | Repeatable CLI integration test | 🟢 | `internal/acp2/integration` (loopback-regression) + `ACP2_TEST_HOST` real-device path. |
+| D4 | DM + manifest generator | 🟢 | DM cache + manifest (ADR-0022); `extract`. |
+| D5 | Wireshark dissector | 🟢 | `dhs_acpv2.lua` — AN2 + ACP2, all functions + object types. |
+| D6 | Replay fixture set under `testdata/` | 🟢 | Per-type captures + fixtures + exports. |
+
+**Verdict: 6/6 deliverables present; live real-device verification is the remaining quality gate (see gaps).**
+
+## 8. Known gaps / caveats (honest)
+
+1. **Real-device verb matrix** — only `info` is verified live against the real Neuron (`10.44.72.28`) so far; walk/get/set/watch are unit + loopback-verified and run against the device via `ACP2_TEST_HOST` once a device-side runner is available (the dev host is firewalled from the device net by the manufacturer firewall).
+2. **acp2 emulator on the fleet** — the LXC + win11 fleet currently serve ACP1; standing up `dhs producer acp2 serve` there (the fleet emulator) is the remaining deploy step for the Ansible idempotency tier.
+3. **Provider Tier-3 (real controller)** — our provider was validated against Cerebrum / Lawo VSM previously; a fresh live walk by a real controller is lab/VPN-bound, not CI-runnable.

--- a/internal/acp2/integration/placeholder_test.go
+++ b/internal/acp2/integration/placeholder_test.go
@@ -1,11 +1,282 @@
-// Placeholder — ACP2 integration tests will live here.
+// ACP2 CLI-driving integration test — the ADR-0025 integration deliverable.
+//
+// This is the tier-4 loopback-regression oracle (per the oracle-per-tier
+// taxonomy): it drives the actual `dhs` binary in BOTH roles over real
+// AN2/TCP loopback — our acp2 provider as the emulator, our acp2 consumer
+// under test. Valid only as a regression net (it does not prove the consumer
+// against ground truth — that needs the real Neuron / Lawo VSM), but it is
+// CI-repeatable with no external dependencies.
+//
+// Env-gated external mode: set ACP2_TEST_HOST to skip the local provider and
+// run the identical consumer assertions against a real device/emulator from a
+// device-reachable host (ACP2_TEST_PORT, default 2072).
 //
 //go:build integration
 
 package acp2_test
 
-import "testing"
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
 
-func TestPlaceholder(t *testing.T) {
-	t.Skip("ACP2 not implemented yet")
+// dhsBin is the path to the `dhs` binary built once by TestMain.
+var dhsBin string
+
+// fixtureTree is the canonical tree the local provider serves. Resolved
+// relative to this test file so `go test` works from any CWD.
+var fixtureTree string
+
+func TestMain(m *testing.M) {
+	tmp, err := os.MkdirTemp("", "acp2-integration-")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "mktemp: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.RemoveAll(tmp)
+
+	bin := filepath.Join(tmp, "dhs")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+
+	// Build the CLI once. CGO not needed; the caller is expected to set
+	// CGO_ENABLED=0 but we don't rely on it — pure-Go build either way.
+	buildCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	build := exec.CommandContext(buildCtx, "go", "build", "-o", bin, "dhs/cmd/dhs")
+	build.Stderr = os.Stderr
+	build.Stdout = os.Stdout
+	if err := build.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "build dhs: %v\n", err)
+		os.Exit(1)
+	}
+	dhsBin = bin
+
+	// Resolve the fixture tree relative to this source file:
+	//   internal/acp2/integration/  ->  ../testdata/protocol_types/fixture_tree.json
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		fmt.Fprintln(os.Stderr, "cannot resolve test file path")
+		os.Exit(1)
+	}
+	fixtureTree = filepath.Join(filepath.Dir(thisFile), "..", "testdata", "protocol_types", "fixture_tree.json")
+	if _, err := os.Stat(fixtureTree); err != nil {
+		fmt.Fprintf(os.Stderr, "fixture tree not found at %s: %v\n", fixtureTree, err)
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}
+
+// freePort asks the OS for an ephemeral TCP port on loopback, then releases
+// it so the provider can bind. There's an inherent race between close and
+// re-bind, but on loopback it's reliable enough for a single-process test.
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve free port: %v", err)
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+// waitForPort polls until host:port accepts a TCP connection or the deadline
+// elapses. No fixed sleep on the assert path — this is the readiness gate.
+func waitForPort(t *testing.T, host string, port int, timeout time.Duration) {
+	t.Helper()
+	addr := net.JoinHostPort(host, fmt.Sprintf("%d", port))
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("provider did not accept connections on %s within %s", addr, timeout)
+}
+
+// startProvider spins up `dhs producer acp2 serve` against the fixture tree on
+// host:port and returns a stop function (defer it). It waits for readiness
+// before returning.
+func startProvider(t *testing.T, host string, port int) func() {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, dhsBin,
+		"producer", "acp2", "serve",
+		"--tree", fixtureTree,
+		"--port", fmt.Sprintf("%d", port),
+		"--host", host,
+		"--log-level", "error",
+	)
+	// Surface provider logs only on failure; keep the happy path quiet.
+	var errBuf strings.Builder
+	cmd.Stderr = &errBuf
+	if err := cmd.Start(); err != nil {
+		cancel()
+		t.Fatalf("start provider: %v", err)
+	}
+
+	stop := func() {
+		cancel()
+		_ = cmd.Wait()
+	}
+
+	waitForPort(t, host, port, 10*time.Second)
+	return stop
+}
+
+// runConsumer executes `dhs consumer acp2 <verb> <host> <args...>` with a
+// short per-call timeout and returns combined stdout (the assertion surface),
+// the error, and the exit code. Operational logs go to stderr and are
+// captured separately so they don't pollute stdout assertions.
+func runConsumer(t *testing.T, host string, verb string, args ...string) (string, int, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	full := append([]string{"consumer", "acp2", verb, host}, args...)
+	cmd := exec.CommandContext(ctx, dhsBin, full...)
+	var outBuf, errBuf strings.Builder
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+
+	exitCode := 0
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			exitCode = ee.ExitCode()
+		} else {
+			t.Fatalf("consumer %s: launch failed: %v\nstderr: %s", verb, err, errBuf.String())
+		}
+	}
+	if t.Failed() || testing.Verbose() {
+		t.Logf("consumer %s args=%v exit=%d\nstdout:\n%s\nstderr:\n%s",
+			verb, args, exitCode, outBuf.String(), errBuf.String())
+	}
+	return outBuf.String(), exitCode, err
+}
+
+// TestACP2CLIRoundTrip drives info/walk/get/set end-to-end against either a
+// locally-spun provider (default) or an external device/emulator
+// (ACP2_TEST_HOST set). The assertions are identical in both modes.
+func TestACP2CLIRoundTrip(t *testing.T) {
+	host := "127.0.0.1"
+	var port int
+
+	if ext := os.Getenv("ACP2_TEST_HOST"); ext != "" {
+		// External mode: do NOT spin the local provider. Target the real
+		// fleet emulator / Neuron from a device-reachable host.
+		host = ext
+		port = 2072
+		if ps := os.Getenv("ACP2_TEST_PORT"); ps != "" {
+			var p int
+			if _, err := fmt.Sscanf(ps, "%d", &p); err == nil && p > 0 {
+				port = p
+			}
+		}
+		t.Logf("external mode: targeting %s:%d (ACP2_TEST_HOST set)", host, port)
+	} else {
+		// Loopback mode: our provider serves the fixture tree.
+		port = freePort(t)
+		stop := startProvider(t, host, port)
+		defer stop()
+	}
+
+	portArg := fmt.Sprintf("%d", port)
+	common := func(extra ...string) []string {
+		return append([]string{"--port", portArg, "--timeout", "5s"}, extra...)
+	}
+
+	// --- info: prints "slots" and at least one present slot -----------------
+	t.Run("info", func(t *testing.T) {
+		out, code, _ := runConsumer(t, host, "info", common()...)
+		if code != 0 {
+			t.Fatalf("info exit=%d, want 0\n%s", code, out)
+		}
+		if !strings.Contains(out, "slots") {
+			t.Errorf("info output missing %q\n%s", "slots", out)
+		}
+		if !strings.Contains(out, "present") {
+			t.Errorf("info output has no present slot\n%s", out)
+		}
+	})
+
+	// --- walk: the fixture card (slot 1) lists multiple objects -------------
+	t.Run("walk", func(t *testing.T) {
+		out, code, _ := runConsumer(t, host, "walk", common("--slot", "1")...)
+		if code != 0 {
+			t.Fatalf("walk slot 1 exit=%d, want 0\n%s", code, out)
+		}
+		// slot 1 = "one leaf per ACP2 object type" — expect named leaves.
+		for _, want := range []string{"UserLabel", "GainS32", "Mode"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("walk slot 1 missing object %q\n%s", want, out)
+			}
+		}
+	})
+
+	// --- get + set round-trip on slot 0's writable UserLabel leaf ----------
+	// Fixture leaf: device.slot-0.ROOT_NODE_V2.IDENTITY.UserLabel
+	//   obj-id 3, readWrite string, initial value "ACP2-Fixture".
+	// ACP2 addressing is by obj-id (--id); dotted-path resolution is not
+	// wired for this protocol in the CLI, so we address by id.
+	t.Run("get_set_roundtrip", func(t *testing.T) {
+		const (
+			slot     = "0"
+			objID    = "3"
+			original = "ACP2-Fixture"
+			updated  = "ACP2-RT"
+		)
+
+		// Read the known initial value.
+		out, code, _ := runConsumer(t, host, "get", common("--slot", slot, "--id", objID)...)
+		if code != 0 {
+			t.Fatalf("get exit=%d, want 0\n%s", code, out)
+		}
+		// In loopback mode the value is exactly the fixture's; assert it.
+		// In external mode the device may already hold a different value,
+		// so we only require a non-empty quoted value there.
+		if os.Getenv("ACP2_TEST_HOST") == "" {
+			if !strings.Contains(out, original) {
+				t.Errorf("get: want initial value %q\n%s", original, out)
+			}
+		}
+		if !strings.Contains(out, "value") {
+			t.Errorf("get: output missing %q line\n%s", "value", out)
+		}
+
+		// Write a new value; the producer echoes the confirmed value.
+		out, code, _ = runConsumer(t, host, "set", common("--slot", slot, "--id", objID, "--value", updated)...)
+		if code != 0 {
+			t.Fatalf("set exit=%d, want 0\n%s", code, out)
+		}
+		if !strings.Contains(out, "confirmed") || !strings.Contains(out, updated) {
+			t.Errorf("set: want confirmed %q\n%s", updated, out)
+		}
+
+		// Read back: the round-trip must reflect the new value.
+		out, code, _ = runConsumer(t, host, "get", common("--slot", slot, "--id", objID)...)
+		if code != 0 {
+			t.Fatalf("get-after-set exit=%d, want 0\n%s", code, out)
+		}
+		if !strings.Contains(out, updated) {
+			t.Errorf("get-after-set: want round-tripped value %q\n%s", updated, out)
+		}
+
+		// Restore the original so re-runs are deterministic (loopback mode
+		// uses a fresh provider each run, but external mode persists).
+		_, _, _ = runConsumer(t, host, "set", common("--slot", slot, "--id", objID, "--value", original)...)
+	})
 }

--- a/internal/acp2/provider/demo_test.go
+++ b/internal/acp2/provider/demo_test.go
@@ -1,0 +1,142 @@
+package acp2
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"dhs/internal/acp2/codec"
+	"dhs/internal/export/canonical"
+)
+
+// demo_test.go covers RunAnnounceDemo + emitFloatAnnounce — the
+// device-initiated announce path. It reuses the live serve harness so a
+// subscribed client actually receives the demo fanout.
+
+// floatDemoExport returns an export whose slot-1/obj-18 is an RW float
+// in [-60,20], matching RunAnnounceDemo's target shape.
+func floatDemoExport() *canonical.Export {
+	str := func(s string) *string { return &s }
+	gain := &canonical.Parameter{
+		Header: canonical.Header{Number: 18, Identifier: "GainFloat",
+			Access: canonical.AccessReadWrite, Children: canonical.EmptyChildren()},
+		Type:    canonical.ParamReal,
+		Value:   float64(0),
+		Minimum: float64(-60),
+		Maximum: float64(20),
+		Format:  str("float"),
+	}
+	root := &canonical.Node{Header: canonical.Header{
+		Number: 1, Identifier: "ROOT_NODE_V2", Access: canonical.AccessRead,
+		Children: []canonical.Element{gain},
+	}}
+	slot1 := &canonical.Node{Header: canonical.Header{
+		Number: 1, Identifier: "slot-1", Access: canonical.AccessRead,
+		Children: []canonical.Element{root},
+	}}
+	return &canonical.Export{Root: &canonical.Node{Header: canonical.Header{
+		Number: 1, Identifier: "device", Access: canonical.AccessRead,
+		Children: []canonical.Element{slot1},
+	}}}
+}
+
+// TestEmitFloatAnnounce_ToSubscriber verifies one demo tick mutates the
+// tree and fans a value announce out to a subscribed client.
+func TestEmitFloatAnnounce_ToSubscriber(t *testing.T) {
+	srv, addr, stop := startServe(t, floatDemoExport())
+	defer stop()
+
+	c := dialFakeClient(t, addr)
+	defer c.close()
+	c.handshake(true)
+
+	if !waitFor(t, time.Second, func() bool {
+		srv.mu.Lock()
+		defer srv.mu.Unlock()
+		return len(srv.sessions) == 1
+	}) {
+		t.Fatal("session never registered")
+	}
+
+	srv.emitFloatAnnounce(1, 18, 1.0) // phase 1 rad → non-mid value
+
+	if !waitFor(t, time.Second, func() bool { return c.announceCount() >= 1 }) {
+		t.Fatal("subscriber got no demo announce")
+	}
+	ann := c.lastAnnounce()
+	if ann.Type != codec.ACP2TypeAnnounce || ann.PID != codec.PIDValue {
+		t.Fatalf("announce type=%d pid=%d", ann.Type, ann.PID)
+	}
+	// Tree value moved off zero.
+	e, _ := srv.tree.lookup(1, 18)
+	if e.param.Value.(float64) == 0 {
+		t.Error("emitFloatAnnounce did not mutate the value")
+	}
+}
+
+// TestEmitFloatAnnounce_GuardBranches covers the early-returns:
+// missing object and wrong object type.
+func TestEmitFloatAnnounce_GuardBranches(t *testing.T) {
+	srv := newServer(quietLogger(), buildServeExport())
+
+	// Missing obj-id → silent return, no panic.
+	srv.emitFloatAnnounce(1, 9999, 0.5)
+
+	// Obj 10 (Gain) is an integer s32, not Number+Float → guard return.
+	srv.emitFloatAnnounce(1, 10, 0.5)
+
+	// Both should leave Gain unchanged at 0.
+	e, _ := srv.tree.lookup(1, 10)
+	if e.param.Value != int64(0) {
+		t.Errorf("non-float obj was mutated: %v", e.param.Value)
+	}
+}
+
+// TestRunAnnounceDemo_TicksThenCancel runs the demo loop with a short
+// interval and confirms at least one tick fired before ctx cancel, then
+// that the goroutine returns promptly.
+func TestRunAnnounceDemo_TicksThenCancel(t *testing.T) {
+	srv, addr, stop := startServe(t, floatDemoExport())
+	defer stop()
+
+	c := dialFakeClient(t, addr)
+	defer c.close()
+	c.handshake(true)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		srv.RunAnnounceDemo(ctx, 1, 18, 5*time.Millisecond)
+		close(done)
+	}()
+
+	if !waitFor(t, 2*time.Second, func() bool { return c.announceCount() >= 1 }) {
+		cancel()
+		t.Fatal("demo loop fired no announces")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("RunAnnounceDemo did not exit after cancel")
+	}
+}
+
+// TestRunAnnounceDemo_DefaultInterval covers the interval<=0 default
+// branch: passing 0 must coerce to a positive ticker and still exit on
+// cancel without firing immediately.
+func TestRunAnnounceDemo_DefaultInterval(t *testing.T) {
+	srv := newServer(quietLogger(), floatDemoExport())
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		srv.RunAnnounceDemo(ctx, 1, 18, 0) // 0 → default 2s
+		close(done)
+	}()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("default-interval demo did not exit after cancel")
+	}
+}

--- a/internal/acp2/provider/encoder_helpers_test.go
+++ b/internal/acp2/provider/encoder_helpers_test.go
@@ -1,0 +1,299 @@
+package acp2
+
+import (
+	"math"
+	"testing"
+
+	"dhs/internal/acp2/codec"
+	"dhs/internal/export/canonical"
+)
+
+// encoder_helpers_test.go pins the any→typed coercion helpers and the
+// numeric/enum property builders that the higher-level encoder tests
+// only graze. These are pure functions, so the tests are table-driven
+// and assert both the happy conversions and the documented rejects.
+
+func TestAsInt64_Variants(t *testing.T) {
+	ok := []struct {
+		in   any
+		want int64
+	}{
+		{int(5), 5},
+		{int64(-7), -7},
+		{int32(3), 3},
+		{int16(-2), -2},
+		{uint(8), 8},
+		{uint32(9), 9},
+		{uint16(10), 10},
+		{uint8(11), 11},
+		{float32(4), 4},
+		{float64(-6), -6},
+		{"123", 123},
+	}
+	for _, tc := range ok {
+		got, err := asInt64(tc.in, "f")
+		if err != nil || got != tc.want {
+			t.Errorf("asInt64(%v=%T)=%d,%v want %d", tc.in, tc.in, got, err, tc.want)
+		}
+	}
+	bad := []any{nil, float32(1.5), float64(2.5), "nope", []byte{1}}
+	for _, b := range bad {
+		if _, err := asInt64(b, "f"); err == nil {
+			t.Errorf("asInt64(%v=%T) expected error", b, b)
+		}
+	}
+}
+
+func TestAsUint64_Variants(t *testing.T) {
+	if v, err := asUint64(uint64(1<<40), "f"); err != nil || v != 1<<40 {
+		t.Errorf("asUint64(big uint64)=%d,%v", v, err)
+	}
+	if v, err := asUint64(uint(42), "f"); err != nil || v != 42 {
+		t.Errorf("asUint64(uint)=%d,%v", v, err)
+	}
+	if v, err := asUint64(int64(5), "f"); err != nil || v != 5 {
+		t.Errorf("asUint64(int64)=%d,%v", v, err)
+	}
+	if _, err := asUint64(int64(-1), "f"); err == nil {
+		t.Error("asUint64(-1) expected error")
+	}
+	if _, err := asUint64("bad", "f"); err == nil {
+		t.Error("asUint64(bad) expected error")
+	}
+}
+
+func TestAsUint32_RangeGuard(t *testing.T) {
+	if v, err := asUint32(uint64(0xFFFFFFFF), "f"); err != nil || v != 0xFFFFFFFF {
+		t.Errorf("asUint32(max)=%d,%v", v, err)
+	}
+	if _, err := asUint32(uint64(0x1_0000_0000), "f"); err == nil {
+		t.Error("asUint32 over-range expected error")
+	}
+	if _, err := asUint32(int64(-1), "f"); err == nil {
+		t.Error("asUint32(-1) expected error")
+	}
+}
+
+func TestAsFloat64_Variants(t *testing.T) {
+	ok := []struct {
+		in   any
+		want float64
+	}{
+		{float64(1.25), 1.25},
+		{float32(2.5), 2.5},
+		{int(3), 3},
+		{int64(-4), -4},
+		{"6.5", 6.5},
+		{uint32(7), 7}, // falls through to asInt64 path
+	}
+	for _, tc := range ok {
+		got, err := asFloat64(tc.in, "f")
+		if err != nil || math.Abs(got-tc.want) > 1e-9 {
+			t.Errorf("asFloat64(%v=%T)=%v,%v want %v", tc.in, tc.in, got, err, tc.want)
+		}
+	}
+	bad := []any{nil, "nope", []byte{1}}
+	for _, b := range bad {
+		if _, err := asFloat64(b, "f"); err == nil {
+			t.Errorf("asFloat64(%v=%T) expected error", b, b)
+		}
+	}
+}
+
+func TestAsString_Variants(t *testing.T) {
+	if s, err := asString(nil, "f"); err != nil || s != "" {
+		t.Errorf("asString(nil)=%q,%v", s, err)
+	}
+	if s, err := asString("hi", "f"); err != nil || s != "hi" {
+		t.Errorf("asString(hi)=%q,%v", s, err)
+	}
+	if _, err := asString(123, "f"); err == nil {
+		t.Error("asString(int) expected error")
+	}
+}
+
+func TestIPv4Uint32(t *testing.T) {
+	v, err := ipv4Uint32("192.168.0.1")
+	if err != nil || v != (192<<24|168<<16|0<<8|1) {
+		t.Errorf("ipv4Uint32=%d,%v", v, err)
+	}
+	bad := []any{123, "1.2.3", "256.0.0.1", "a.b.c.d", "1.2.3.4.5"}
+	for _, b := range bad {
+		if _, err := ipv4Uint32(b); err == nil {
+			t.Errorf("ipv4Uint32(%v) expected error", b)
+		}
+	}
+}
+
+func TestNumericPropOrZero(t *testing.T) {
+	// nil → zero body, 4 bytes for 32-bit types.
+	p, err := numericPropOrZero(codec.PIDMinValue, codec.NumTypeS32, nil)
+	if err != nil || len(p.Data) != 4 {
+		t.Fatalf("zero s32 len=%d err=%v", len(p.Data), err)
+	}
+	// nil → 8-byte body for 64-bit types.
+	p, err = numericPropOrZero(codec.PIDMinValue, codec.NumTypeU64, nil)
+	if err != nil || len(p.Data) != 8 {
+		t.Fatalf("zero u64 len=%d err=%v", len(p.Data), err)
+	}
+	// non-nil → delegates to encodeNumericProp.
+	p, err = numericPropOrZero(codec.PIDMaxValue, codec.NumTypeS32, int64(5))
+	if err != nil {
+		t.Fatalf("value: %v", err)
+	}
+	iv, _, _, _ := codec.DecodeNumericValue(codec.NumTypeS32, p.Data)
+	if iv != 5 {
+		t.Errorf("value iv=%d want 5", iv)
+	}
+}
+
+func TestEncodeNumericProp_AllTypes(t *testing.T) {
+	cases := []struct {
+		nt codec.NumberType
+		v  any
+	}{
+		{codec.NumTypeS8, int64(-1)},
+		{codec.NumTypeS16, int64(-300)},
+		{codec.NumTypeS32, int64(-70000)},
+		{codec.NumTypeS64, int64(-5_000_000_000)},
+		{codec.NumTypeU8, uint64(200)},
+		{codec.NumTypeU16, uint64(40000)},
+		{codec.NumTypeU32, uint64(3_000_000_000)},
+		{codec.NumTypeU64, uint64(10_000_000_000)},
+		{codec.NumTypeFloat, float64(3.14)},
+		{codec.NumTypePreset, uint64(7)},
+		{codec.NumTypeIPv4, "10.1.2.3"},
+	}
+	for _, tc := range cases {
+		p, err := encodeNumericProp(codec.PIDValue, tc.nt, tc.v)
+		if err != nil {
+			t.Errorf("encodeNumericProp(%d,%v): %v", tc.nt, tc.v, err)
+			continue
+		}
+		if p.VType != uint8(tc.nt) {
+			t.Errorf("nt=%d vtype=%d", tc.nt, p.VType)
+		}
+	}
+	// unsupported number type → error
+	if _, err := encodeNumericProp(codec.PIDValue, codec.NumberType(99), 0); err == nil {
+		t.Error("encodeNumericProp(bad nt) expected error")
+	}
+	// wrong value type for a signed slot → error
+	if _, err := encodeNumericProp(codec.PIDValue, codec.NumTypeS32, "not-num"); err == nil {
+		t.Error("encodeNumericProp(s32,bad) expected error")
+	}
+}
+
+func TestEncodeOptionalConstraint(t *testing.T) {
+	// nil → emitted=false, no error.
+	_, ok, err := encodeOptionalConstraint(codec.PIDMinValue, codec.NumTypeS32, nil)
+	if ok || err != nil {
+		t.Fatalf("nil constraint ok=%v err=%v", ok, err)
+	}
+	// present → emitted=true.
+	p, ok, err := encodeOptionalConstraint(codec.PIDMaxValue, codec.NumTypeS32, int64(9))
+	if !ok || err != nil {
+		t.Fatalf("present constraint ok=%v err=%v", ok, err)
+	}
+	if p.PID != codec.PIDMaxValue {
+		t.Errorf("pid=%d", p.PID)
+	}
+	// bad value → error propagated.
+	if _, _, err := encodeOptionalConstraint(codec.PIDMaxValue, codec.NumTypeS32, "bad"); err == nil {
+		t.Error("bad constraint expected error")
+	}
+}
+
+func TestEnumOptions_FromEnumMapAndLegacy(t *testing.T) {
+	// EnumMap path: sparse wire ids preserved.
+	p := &canonical.Parameter{EnumMap: []canonical.EnumEntry{
+		{Key: "Auto", Value: 786}, {Key: "Full", Value: 791}}}
+	opts := enumOptions(p)
+	if len(opts) != 2 || opts[0].idx != 786 || opts[1].idx != 791 {
+		t.Fatalf("enumMap opts=%+v", opts)
+	}
+	// Legacy comma string → positional 0..N-1.
+	comma := "Off,On,Auto"
+	opts = enumOptions(&canonical.Parameter{Enumeration: &comma})
+	if len(opts) != 3 || opts[2].idx != 2 || opts[2].label != "Auto" {
+		t.Fatalf("comma opts=%+v", opts)
+	}
+	// Legacy newline string.
+	nl := "A\nB"
+	opts = enumOptions(&canonical.Parameter{Enumeration: &nl})
+	if len(opts) != 2 || opts[1].label != "B" {
+		t.Fatalf("newline opts=%+v", opts)
+	}
+	// No enum data → nil.
+	if enumOptions(&canonical.Parameter{}) != nil {
+		t.Error("empty enumOptions should be nil")
+	}
+}
+
+// TestStringMaxLen covers the hint → Maximum → 256 fallback chain.
+func TestStringMaxLen(t *testing.T) {
+	if got := stringMaxLen(nil); got != 256 {
+		t.Errorf("nil param=%d want 256", got)
+	}
+	hint := "maxLen=12"
+	if got := stringMaxLen(&canonical.Parameter{Format: &hint}); got != 12 {
+		t.Errorf("hint=%d want 12", got)
+	}
+	if got := stringMaxLen(&canonical.Parameter{Maximum: int64(48)}); got != 48 {
+		t.Errorf("maximum=%d want 48", got)
+	}
+	if got := stringMaxLen(&canonical.Parameter{}); got != 256 {
+		t.Errorf("default=%d want 256", got)
+	}
+}
+
+// TestStringDefaultProp covers the empty-vs-set default branches.
+func TestStringDefaultProp(t *testing.T) {
+	empty := stringDefaultProp(nil)
+	if empty.PID != codec.PIDDefaultValue {
+		t.Errorf("empty pid=%d", empty.PID)
+	}
+	set := stringDefaultProp("hello")
+	if set.PID != codec.PIDDefaultValue {
+		t.Errorf("set pid=%d", set.PID)
+	}
+	// non-string default is ignored (stays empty path) without panic.
+	_ = stringDefaultProp(123)
+}
+
+// TestIPv4DefaultProp covers nil + valid + invalid default handling.
+func TestIPv4DefaultProp(t *testing.T) {
+	if p := ipv4DefaultProp(nil); len(p.Data) != 4 {
+		t.Errorf("nil default len=%d", len(p.Data))
+	}
+	if p := ipv4DefaultProp("1.2.3.4"); p.Data[0] != 1 || p.Data[3] != 4 {
+		t.Errorf("valid default=%v", p.Data)
+	}
+	// invalid default → zero body, no panic.
+	if p := ipv4DefaultProp("garbage"); len(p.Data) != 4 {
+		t.Errorf("invalid default len=%d", len(p.Data))
+	}
+}
+
+// TestEnumDefaultProp covers the Default-present and Value-fallback paths.
+func TestEnumDefaultProp(t *testing.T) {
+	// Default present.
+	e := &entry{param: &canonical.Parameter{Default: int64(5), Value: int64(3)}}
+	p, err := enumDefaultProp(e)
+	if err != nil {
+		t.Fatalf("default present: %v", err)
+	}
+	if p.PID != codec.PIDDefaultValue {
+		t.Errorf("pid=%d", p.PID)
+	}
+	// Default nil → fall back to Value.
+	e = &entry{param: &canonical.Parameter{Value: int64(9)}}
+	if _, err := enumDefaultProp(e); err != nil {
+		t.Fatalf("value fallback: %v", err)
+	}
+	// Both unusable → error.
+	e = &entry{param: &canonical.Parameter{Value: "not-a-number"}}
+	if _, err := enumDefaultProp(e); err == nil {
+		t.Error("bad enum default expected error")
+	}
+}

--- a/internal/acp2/provider/handlers_branch_test.go
+++ b/internal/acp2/provider/handlers_branch_test.go
@@ -1,0 +1,245 @@
+package acp2
+
+import (
+	"testing"
+
+	"dhs/internal/acp2/codec"
+	"dhs/internal/export/canonical"
+)
+
+// handlers_branch_test.go targets the residual error / edge branches the
+// loopback serve test doesn't reach: unsupported AN2 proto drop, ACP2
+// non-data frames, buildProperties failures surfacing as protocol
+// errors, and the preset object_type path through get_object.
+
+// TestDispatch_UnsupportedProto pins the dispatch default arm: a frame
+// whose proto is neither AN2-internal nor ACP2 is dropped silently (no
+// reply written). We send ACMP (proto 3) and assert no reply lands.
+func TestDispatch_UnsupportedProto(t *testing.T) {
+	sess, peer := newTestSession(t)
+	defer func() { _ = sess.conn.Close() }()
+	defer func() { _ = peer.Close() }()
+
+	f := &codec.AN2Frame{
+		Proto:   codec.AN2ProtoACMP, // 3 — not handled
+		Slot:    1,
+		MTID:    0,
+		Type:    codec.AN2TypeData,
+		Payload: []byte{0, 0, 0, 0},
+	}
+	// dispatch directly; it must not panic and must not write a reply.
+	sess.dispatch(f)
+}
+
+// TestHandleACP2_NonDataFrame covers the early return when an ACP2 frame
+// arrives that is not a data frame (e.g. a stray request-typed AN2
+// frame). It must be ignored without a reply.
+func TestHandleACP2_NonDataFrame(t *testing.T) {
+	sess, peer := newTestSession(t)
+	defer func() { _ = sess.conn.Close() }()
+	defer func() { _ = peer.Close() }()
+
+	f := &codec.AN2Frame{
+		Proto:   codec.AN2ProtoACP2,
+		Slot:    1,
+		MTID:    0,
+		Type:    codec.AN2TypeRequest, // not data → ignored
+		Payload: []byte{0, 0, 0, 0},
+	}
+	sess.dispatch(f)
+}
+
+// TestHandleAN2Internal_NonRequestAndEmpty covers the two guard returns:
+// a non-request AN2 internal frame and an empty payload.
+func TestHandleAN2Internal_NonRequestAndEmpty(t *testing.T) {
+	sess, peer := newTestSession(t)
+	defer func() { _ = sess.conn.Close() }()
+	defer func() { _ = peer.Close() }()
+
+	sess.handleAN2Internal(&codec.AN2Frame{
+		Proto: codec.AN2ProtoInternal, Type: codec.AN2TypeReply,
+		Payload: []byte{codec.AN2FuncGetVersion},
+	})
+	sess.handleAN2Internal(&codec.AN2Frame{
+		Proto: codec.AN2ProtoInternal, Type: codec.AN2TypeRequest,
+		Payload: nil,
+	})
+	// Unknown funcID default arm.
+	sess.handleAN2Internal(&codec.AN2Frame{
+		Proto: codec.AN2ProtoInternal, Type: codec.AN2TypeRequest,
+		Payload: []byte{0xFE},
+	})
+	// EnableProtocolEvents missing count byte guard.
+	sess.handleAN2Internal(&codec.AN2Frame{
+		Proto: codec.AN2ProtoInternal, Type: codec.AN2TypeRequest,
+		Payload: []byte{codec.AN2FuncEnableProtocolEvents},
+	})
+}
+
+// presetEntry builds a preset child entry from a depth=N format hint.
+func presetEntry(t *testing.T, format string, val any) *entry {
+	t.Helper()
+	f := format
+	p := &canonical.Parameter{
+		Header: canonical.Header{Number: 5, Identifier: "Preset",
+			Access: canonical.AccessReadWrite},
+		Type:   canonical.ParamInteger,
+		Value:  val,
+		Format: &f,
+	}
+	objType, numType, err := deriveACP2Type(p)
+	if err != nil {
+		t.Fatalf("deriveACP2Type(%q): %v", format, err)
+	}
+	e := &entry{objID: 5, label: "Preset", access: 0x03,
+		objType: objType, numType: numType, param: p,
+		presetDepth:   presetDepthHint(p),
+		presetIdxList: presetIdxHint(p)}
+	if e.presetDepth == 0 {
+		e.presetDepth = 1
+	}
+	return e
+}
+
+// TestBuildProperties_Preset exercises the ObjTypePreset arm of
+// buildProperties (pid 7 + per-idx pid 8/9 + options) end to end through
+// the codec.
+func TestBuildProperties_Preset(t *testing.T) {
+	e := presetEntry(t, "preset,s32,depth=2", int64(3))
+	if e.objType != codec.ObjTypePreset {
+		t.Fatalf("objType=%d want preset", e.objType)
+	}
+	props, err := buildProperties(e)
+	if err != nil {
+		t.Fatalf("buildProperties: %v", err)
+	}
+	raw, err := codec.EncodeProperties(props)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	dec, err := codec.DecodeProperties(raw)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	var hasDepth, valueCount int
+	for _, p := range dec {
+		switch p.PID {
+		case codec.PIDPresetDepth:
+			hasDepth++
+		case codec.PIDValue:
+			valueCount++
+		}
+	}
+	if hasDepth != 1 {
+		t.Errorf("pid 7 count=%d want 1", hasDepth)
+	}
+	if valueCount != 2 { // one pid 8 per depth idx
+		t.Errorf("pid 8 count=%d want 2 (depth)", valueCount)
+	}
+}
+
+// TestDeriveACP2Type_PresetVariants covers the preset switch arms across
+// every number-type hint.
+func TestDeriveACP2Type_PresetVariants(t *testing.T) {
+	hints := []struct {
+		hint string
+		want codec.NumberType
+	}{
+		{"", codec.NumTypeS32},
+		{"s8", codec.NumTypeS8},
+		{"s16", codec.NumTypeS16},
+		{"s32", codec.NumTypeS32},
+		{"s64", codec.NumTypeS64},
+		{"u8", codec.NumTypeU8},
+		{"u16", codec.NumTypeU16},
+		{"u32", codec.NumTypeU32},
+		{"u64", codec.NumTypeU64},
+		{"float", codec.NumTypeFloat},
+	}
+	for _, h := range hints {
+		f := "preset"
+		if h.hint != "" {
+			f = "preset," + h.hint
+		}
+		fp := f
+		p := &canonical.Parameter{Type: canonical.ParamInteger, Format: &fp}
+		objType, numType, err := deriveACP2Type(p)
+		if err != nil {
+			t.Errorf("hint=%q: %v", h.hint, err)
+			continue
+		}
+		if objType != codec.ObjTypePreset || numType != h.want {
+			t.Errorf("hint=%q got obj=%d num=%d want preset/%d", h.hint, objType, numType, h.want)
+		}
+	}
+}
+
+// TestDeriveACP2Type_StringBadHint covers the string default-arm reject.
+func TestDeriveACP2Type_StringBadHint(t *testing.T) {
+	f := "weird"
+	p := &canonical.Parameter{Type: canonical.ParamString, Format: &f}
+	if _, _, err := deriveACP2Type(p); err == nil {
+		t.Error("string with unknown hint should error")
+	}
+}
+
+// TestDeriveACP2Type_UnsupportedCanonicalType covers the final fallthrough
+// for a canonical Type that has no ACP2 mapping.
+func TestDeriveACP2Type_UnsupportedCanonicalType(t *testing.T) {
+	p := &canonical.Parameter{Type: "octets"} // not a known canonical param type
+	if _, _, err := deriveACP2Type(p); err == nil {
+		t.Error("unknown canonical type should error")
+	}
+}
+
+// TestPresetDepthHint_Variants covers the depth= parse: valid, absent,
+// and out-of-range values.
+func TestPresetDepthHint_Variants(t *testing.T) {
+	mk := func(f string) *canonical.Parameter { ff := f; return &canonical.Parameter{Format: &ff} }
+	if d := presetDepthHint(mk("preset,depth=3")); d != 3 {
+		t.Errorf("depth=3 → %d", d)
+	}
+	if d := presetDepthHint(mk("preset")); d != 0 {
+		t.Errorf("no depth → %d want 0", d)
+	}
+	if d := presetDepthHint(mk("preset,depth=0")); d != 0 {
+		t.Errorf("depth=0 → %d want 0 (rejected)", d)
+	}
+	if d := presetDepthHint(mk("preset,depth=70000")); d != 0 {
+		t.Errorf("depth=70000 → %d want 0 (over range)", d)
+	}
+}
+
+// TestEventDelayHint covers both branches (nil and non-nil param) — both
+// currently return 0 by design.
+func TestEventDelayHint(t *testing.T) {
+	if got := eventDelayHint(nil); got != 0 {
+		t.Errorf("nil → %d want 0", got)
+	}
+	if got := eventDelayHint(&canonical.Parameter{}); got != 0 {
+		t.Errorf("param → %d want 0", got)
+	}
+}
+
+// TestHasPreset covers the false return when no preset token is present.
+func TestHasPreset(t *testing.T) {
+	if hasPreset([]string{"s32", "depth=2"}) {
+		t.Error("hasPreset without token should be false")
+	}
+	if !hasPreset([]string{"preset", "s32"}) {
+		t.Error("hasPreset with token should be true")
+	}
+}
+
+// TestElementID_Errors covers the elementID error arm via a fake element.
+func TestElementID_Matrix(t *testing.T) {
+	// A Node and a Parameter both have Number; assert both resolve.
+	n := &canonical.Node{Header: canonical.Header{Number: 7}}
+	if id, err := elementID(n); err != nil || id != 7 {
+		t.Errorf("node id=%d err=%v", id, err)
+	}
+	p := &canonical.Parameter{Header: canonical.Header{Number: 8}}
+	if id, err := elementID(p); err != nil || id != 8 {
+		t.Errorf("param id=%d err=%v", id, err)
+	}
+}

--- a/internal/acp2/provider/plugin_factory_test.go
+++ b/internal/acp2/provider/plugin_factory_test.go
@@ -1,0 +1,63 @@
+package acp2
+
+import (
+	"testing"
+
+	"dhs/internal/export/canonical"
+)
+
+// plugin_factory_test.go covers the Factory entry points and newServer's
+// degraded (empty-tree) fallback when the canonical export is malformed.
+
+func TestFactory_Meta(t *testing.T) {
+	f := &Factory{}
+	m := f.Meta()
+	if m.Name != "acp2" {
+		t.Errorf("Meta.Name=%q want acp2", m.Name)
+	}
+	if m.DefaultPort != DefaultPort {
+		t.Errorf("Meta.DefaultPort=%d want %d", m.DefaultPort, DefaultPort)
+	}
+	if m.Description == "" {
+		t.Error("Meta.Description empty")
+	}
+}
+
+func TestFactory_New(t *testing.T) {
+	f := &Factory{}
+	p := f.New(quietLogger(), buildServeExport())
+	if p == nil {
+		t.Fatal("Factory.New returned nil provider")
+	}
+	srv, ok := p.(*server)
+	if !ok {
+		t.Fatalf("Factory.New returned %T, want *server", p)
+	}
+	if srv.tree.count() == 0 {
+		t.Error("Factory.New built an empty tree from a valid export")
+	}
+}
+
+// TestNewServer_NilLoggerAndBadExport covers two degraded paths:
+//   - nil logger → defaults to slog.Default (no panic).
+//   - nil/invalid export → newTree fails, server falls back to emptyTree.
+func TestNewServer_NilLoggerAndBadExport(t *testing.T) {
+	// nil export → tree build fails → emptyTree fallback.
+	srv := newServer(nil, nil)
+	if srv == nil {
+		t.Fatal("newServer(nil,nil) returned nil")
+	}
+	if srv.tree == nil || srv.tree.count() != 0 {
+		t.Errorf("expected empty fallback tree, count=%d", srv.tree.count())
+	}
+
+	// Root that is not a Node → newTree rejects → emptyTree fallback.
+	bad := &canonical.Export{Root: &canonical.Parameter{
+		Header: canonical.Header{Number: 1, Identifier: "leaf-root"},
+		Type:   canonical.ParamInteger,
+	}}
+	srv2 := newServer(quietLogger(), bad)
+	if srv2.tree == nil || srv2.tree.count() != 0 {
+		t.Errorf("non-node root should fall back to empty tree, count=%d", srv2.tree.count())
+	}
+}

--- a/internal/acp2/provider/serve_loopback_test.go
+++ b/internal/acp2/provider/serve_loopback_test.go
@@ -1,0 +1,573 @@
+package acp2
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"log/slog"
+	"net"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"dhs/internal/acp2/codec"
+	"dhs/internal/export/canonical"
+)
+
+// serve_loopback_test.go drives the production server.Serve accept loop
+// over a real 127.0.0.1:0 TCP listener — the mirror of the consumer's
+// loopback harness, but with OUR provider under test and a fake client.
+//
+// It exercises the otherwise 0%-covered server.go surface (newServer,
+// Serve, Stop, registerSession, unregisterSession, broadcastAnnounce)
+// plus the request handlers (handleGetProperty, handleSetProperty) end
+// to end. Bytes are built/decoded with the production codec; no fixed
+// sleeps gate any assert (waitFor polls), and every listener/conn is
+// deferred-closed so no goroutine leaks.
+
+// quietLogger discards all provider output so test runs stay clean.
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+// waitFor polls cond until true or the deadline elapses. Keeps
+// announce-delivery + session-registration assertions deterministic
+// without a fixed sleep on the assert path.
+func waitFor(t *testing.T, d time.Duration, cond func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return cond()
+}
+
+// buildServeExport returns a canonical export with a single populated
+// slot-1 subtree covering one of every leaf object type plus a node, so
+// the loopback client can walk + get + set across the type matrix.
+//
+//	slot-1
+//	└── ROOT_NODE_V2 (1, node)
+//	    ├── Gain      (10, integer s32, RW, min=-10 max=10)
+//	    ├── Mode      (11, enum Off/On/Auto, RW)
+//	    ├── Address   (12, string ipv4, RW)
+//	    ├── Name      (13, string maxLen=8, RW)
+//	    └── Locked    (14, integer u8, R only)
+func buildServeExport() *canonical.Export {
+	str := func(s string) *string { return &s }
+	gain := &canonical.Parameter{
+		Header: canonical.Header{Number: 10, Identifier: "Gain",
+			Access: canonical.AccessReadWrite, Children: canonical.EmptyChildren()},
+		Type:    canonical.ParamInteger,
+		Value:   int64(0),
+		Minimum: int64(-10),
+		Maximum: int64(10),
+		Default: int64(0),
+		Format:  str("s32"),
+	}
+	enumVal := "Off,On,Auto"
+	mode := &canonical.Parameter{
+		Header: canonical.Header{Number: 11, Identifier: "Mode",
+			Access: canonical.AccessReadWrite, Children: canonical.EmptyChildren()},
+		Type:        canonical.ParamEnum,
+		Value:       int64(0),
+		Enumeration: &enumVal,
+		EnumMap: []canonical.EnumEntry{
+			{Key: "Off", Value: 0},
+			{Key: "On", Value: 1},
+			{Key: "Auto", Value: 2},
+		},
+	}
+	addr := &canonical.Parameter{
+		Header: canonical.Header{Number: 12, Identifier: "Address",
+			Access: canonical.AccessReadWrite, Children: canonical.EmptyChildren()},
+		Type:   canonical.ParamString,
+		Value:  "10.0.0.1",
+		Format: str("ipv4"),
+	}
+	name := &canonical.Parameter{
+		Header: canonical.Header{Number: 13, Identifier: "Name",
+			Access: canonical.AccessReadWrite, Children: canonical.EmptyChildren()},
+		Type:   canonical.ParamString,
+		Value:  "card",
+		Format: str("maxLen=8"),
+	}
+	locked := &canonical.Parameter{
+		Header: canonical.Header{Number: 14, Identifier: "Locked",
+			Access: canonical.AccessRead, Children: canonical.EmptyChildren()},
+		Type:   canonical.ParamInteger,
+		Value:  int64(1),
+		Format: str("u8"),
+	}
+	root := &canonical.Node{Header: canonical.Header{
+		Number: 1, Identifier: "ROOT_NODE_V2", Access: canonical.AccessRead,
+		Children: []canonical.Element{gain, mode, addr, name, locked},
+	}}
+	slot1 := &canonical.Node{Header: canonical.Header{
+		Number: 1, Identifier: "slot-1", Access: canonical.AccessRead,
+		Children: []canonical.Element{root},
+	}}
+	return &canonical.Export{Root: &canonical.Node{Header: canonical.Header{
+		Number: 1, Identifier: "device", Access: canonical.AccessRead,
+		Children: []canonical.Element{slot1},
+	}}}
+}
+
+// fakeClient is a minimal AN2/ACP2 client over a live TCP conn. It
+// serialises writes, reads frames on a background goroutine, and routes
+// ACP2 data frames into typed channels (replies vs announces).
+type fakeClient struct {
+	t    *testing.T
+	conn net.Conn
+
+	mu        sync.Mutex
+	announces []*codec.ACP2Message
+	replies   chan *codec.ACP2Message
+	an2       chan *codec.AN2Frame
+}
+
+func dialFakeClient(t *testing.T, addr string) *fakeClient {
+	t.Helper()
+	conn, err := net.DialTimeout("tcp4", addr, 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial %s: %v", addr, err)
+	}
+	c := &fakeClient{
+		t:       t,
+		conn:    conn,
+		replies: make(chan *codec.ACP2Message, 16),
+		an2:     make(chan *codec.AN2Frame, 16),
+	}
+	go c.readLoop()
+	return c
+}
+
+func (c *fakeClient) close() { _ = c.conn.Close() }
+
+func (c *fakeClient) readLoop() {
+	for {
+		f, err := codec.ReadAN2Frame(c.conn)
+		if err != nil {
+			return
+		}
+		switch f.Proto {
+		case codec.AN2ProtoInternal:
+			select {
+			case c.an2 <- f:
+			default:
+			}
+		case codec.AN2ProtoACP2:
+			msg, err := codec.DecodeACP2Message(f.Payload)
+			if err != nil {
+				continue
+			}
+			// Parse obj-id/idx for reply + announce bodies so callers can
+			// assert addressing (decoder leaves them set for these types).
+			if msg.Type == codec.ACP2TypeAnnounce {
+				c.mu.Lock()
+				c.announces = append(c.announces, msg)
+				c.mu.Unlock()
+				continue
+			}
+			select {
+			case c.replies <- msg:
+			default:
+			}
+		}
+	}
+}
+
+func (c *fakeClient) writeFrame(f *codec.AN2Frame) {
+	raw, err := codec.EncodeAN2Frame(f)
+	if err != nil {
+		c.t.Fatalf("encode frame: %v", err)
+	}
+	if _, err := c.conn.Write(raw); err != nil {
+		c.t.Fatalf("client write: %v", err)
+	}
+}
+
+// an2Request sends an AN2 internal request and waits for its reply.
+func (c *fakeClient) an2Request(slot, mtid uint8, payload []byte) *codec.AN2Frame {
+	c.writeFrame(&codec.AN2Frame{
+		Proto: codec.AN2ProtoInternal, Slot: slot, MTID: mtid,
+		Type: codec.AN2TypeRequest, Payload: payload,
+	})
+	select {
+	case f := <-c.an2:
+		return f
+	case <-time.After(time.Second):
+		c.t.Fatal("timeout waiting for AN2 reply")
+		return nil
+	}
+}
+
+// handshake runs the standard AN2 bring-up so ACP2 traffic is accepted,
+// optionally enabling ACP2 protocol events for announce delivery.
+func (c *fakeClient) handshake(enableEvents bool) {
+	c.an2Request(0, 1, []byte{codec.AN2FuncGetVersion})
+	c.an2Request(0, 2, []byte{codec.AN2FuncGetDeviceInfo})
+	c.an2Request(1, 3, []byte{codec.AN2FuncGetSlotInfo})
+	if enableEvents {
+		rep := c.an2Request(1, 4, []byte{codec.AN2FuncEnableProtocolEvents, 1, uint8(codec.AN2ProtoACP2)})
+		if len(rep.Payload) != 1 || rep.Payload[0] != codec.AN2FuncEnableProtocolEvents {
+			c.t.Fatalf("EnableProtocolEvents reply=%x", rep.Payload)
+		}
+	}
+}
+
+// acp2Request sends one ACP2 request frame and waits for its reply.
+func (c *fakeClient) acp2Request(slot uint8, msg *codec.ACP2Message) *codec.ACP2Message {
+	body, err := codec.EncodeACP2Message(msg)
+	if err != nil {
+		c.t.Fatalf("encode acp2: %v", err)
+	}
+	c.writeFrame(&codec.AN2Frame{
+		Proto: codec.AN2ProtoACP2, Slot: slot, MTID: 0,
+		Type: codec.AN2TypeData, Payload: body,
+	})
+	select {
+	case m := <-c.replies:
+		return m
+	case <-time.After(time.Second):
+		c.t.Fatal("timeout waiting for ACP2 reply")
+		return nil
+	}
+}
+
+func (c *fakeClient) announceCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.announces)
+}
+
+func (c *fakeClient) lastAnnounce() *codec.ACP2Message {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.announces) == 0 {
+		return nil
+	}
+	return c.announces[len(c.announces)-1]
+}
+
+// startServe boots the provider on an ephemeral port and returns the
+// server, the dial address, and a stop func that cancels Serve + Stops.
+func startServe(t *testing.T, exp *canonical.Export) (*server, string, func()) {
+	t.Helper()
+	srv := newServer(quietLogger(), exp)
+
+	// Bind ephemeral ourselves to read back the port, then hand the
+	// listener to Serve via a tiny shim: Serve binds its own listener,
+	// so instead we let Serve bind ":0" and discover the port from the
+	// server's listener field once it's set.
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Serve(ctx, "127.0.0.1:0") }()
+
+	// Wait until Serve has published its listener.
+	var addr string
+	ok := waitFor(t, 2*time.Second, func() bool {
+		srv.mu.Lock()
+		defer srv.mu.Unlock()
+		if srv.listener != nil {
+			addr = srv.listener.Addr().String()
+			return true
+		}
+		return false
+	})
+	if !ok {
+		cancel()
+		t.Fatal("Serve never bound a listener")
+	}
+
+	stop := func() {
+		cancel()
+		_ = srv.Stop()
+		select {
+		case <-errCh:
+		case <-time.After(time.Second):
+		}
+	}
+	return srv, addr, stop
+}
+
+func decodeProp(t *testing.T, msg *codec.ACP2Message, pid uint8) (codec.Property, bool) {
+	t.Helper()
+	// Reply body = obj-id(4) + idx(4) + property headers.
+	if len(msg.Body) < 8 {
+		return codec.Property{}, false
+	}
+	props, err := codec.DecodeProperties(msg.Body[8:])
+	if err != nil {
+		t.Fatalf("decode props: %v", err)
+	}
+	for _, p := range props {
+		if p.PID == pid {
+			return p, true
+		}
+	}
+	return codec.Property{}, false
+}
+
+// TestServe_FullHandshakeAndWalk drives the whole accept loop: handshake,
+// get_version, get_object on the root, get_property on a leaf — over a
+// real TCP socket against the production Serve path.
+func TestServe_FullHandshakeAndWalk(t *testing.T) {
+	_, addr, stop := startServe(t, buildServeExport())
+	defer stop()
+
+	c := dialFakeClient(t, addr)
+	defer c.close()
+	c.handshake(false)
+
+	// ACP2 get_version → reply pid byte = acp2Version (2).
+	ver := c.acp2Request(1, &codec.ACP2Message{
+		Type: codec.ACP2TypeRequest, MTID: 5, Func: codec.ACP2FuncGetVersion,
+	})
+	if ver.Type != codec.ACP2TypeReply || ver.PID != acp2Version {
+		t.Fatalf("get_version reply type=%d pid=%d want reply/%d", ver.Type, ver.PID, acp2Version)
+	}
+
+	// get_object on root (obj-id 1) → must carry pid 14 children listing
+	// the five leaves.
+	obj := c.acp2Request(1, &codec.ACP2Message{
+		Type: codec.ACP2TypeRequest, MTID: 6, Func: codec.ACP2FuncGetObject, ObjID: 1,
+	})
+	if obj.Func != codec.ACP2FuncGetObject {
+		t.Fatalf("get_object func=%d", obj.Func)
+	}
+	ch, ok := decodeProp(t, obj, codec.PIDChildren)
+	if !ok {
+		t.Fatal("get_object root: no pid 14 children")
+	}
+	if len(ch.Data) != 5*4 {
+		t.Fatalf("children data len=%d want 20 (5 child ids)", len(ch.Data))
+	}
+
+	// get_property pid 8 (value) on Gain (obj 10) → s32 = 0.
+	gp := c.acp2Request(1, &codec.ACP2Message{
+		Type: codec.ACP2TypeRequest, MTID: 7, Func: codec.ACP2FuncGetProperty,
+		ObjID: 10, PID: codec.PIDValue,
+	})
+	if gp.Func != codec.ACP2FuncGetProperty {
+		t.Fatalf("get_property func=%d", gp.Func)
+	}
+	if _, ok := decodeProp(t, gp, codec.PIDValue); !ok {
+		t.Fatal("get_property: no pid 8 value")
+	}
+}
+
+// TestServe_SetProperty_AnnounceFanout verifies set_property mutates the
+// tree, replies with the confirmed post-state, and fans an announce out
+// to a SECOND client that subscribed via EnableProtocolEvents — while a
+// third, unsubscribed client receives nothing (spec gate).
+func TestServe_SetProperty_AnnounceFanout(t *testing.T) {
+	srv, addr, stop := startServe(t, buildServeExport())
+	defer stop()
+
+	setter := dialFakeClient(t, addr)
+	defer setter.close()
+	setter.handshake(false)
+
+	listener := dialFakeClient(t, addr)
+	defer listener.close()
+	listener.handshake(true) // subscribes to ACP2 announces
+
+	unsub := dialFakeClient(t, addr)
+	defer unsub.close()
+	unsub.handshake(false) // never subscribes
+
+	// Wait until the server has registered all three sessions.
+	if !waitFor(t, time.Second, func() bool {
+		srv.mu.Lock()
+		defer srv.mu.Unlock()
+		return len(srv.sessions) == 3
+	}) {
+		t.Fatal("server never registered 3 sessions")
+	}
+
+	// set Gain (obj 10) to 7 (within [-10,10]).
+	val := make([]byte, 4)
+	binary.BigEndian.PutUint32(val, uint32(int32(7)))
+	in := codec.Property{PID: codec.PIDValue, VType: uint8(codec.NumTypeS32), PLen: 8, Data: val}
+	setMsg := &codec.ACP2Message{
+		Type: codec.ACP2TypeRequest, MTID: 9, Func: codec.ACP2FuncSetProperty,
+		ObjID: 10, PID: codec.PIDValue, Properties: []codec.Property{in},
+	}
+	rep := setter.acp2Request(1, setMsg)
+	if rep.Func != codec.ACP2FuncSetProperty || rep.Type != codec.ACP2TypeReply {
+		t.Fatalf("set reply type=%d func=%d", rep.Type, rep.Func)
+	}
+	post, ok := decodeProp(t, rep, codec.PIDValue)
+	if !ok {
+		t.Fatal("set reply: no pid 8")
+	}
+	iv, _, _, err := codec.DecodeNumericValue(codec.NumTypeS32, post.Data)
+	if err != nil || iv != 7 {
+		t.Fatalf("post value iv=%d err=%v want 7", iv, err)
+	}
+
+	// The subscribed listener must receive exactly one announce.
+	if !waitFor(t, time.Second, func() bool { return listener.announceCount() >= 1 }) {
+		t.Fatal("subscribed listener got no announce")
+	}
+	ann := listener.lastAnnounce()
+	if ann.Type != codec.ACP2TypeAnnounce || ann.Func != 0 {
+		t.Fatalf("announce type=%d stat=%d want announce/0", ann.Type, ann.Func)
+	}
+	if ann.PID != codec.PIDValue {
+		t.Fatalf("announce pid=%d want %d", ann.PID, codec.PIDValue)
+	}
+	// The unsubscribed client must receive zero announces.
+	if n := unsub.announceCount(); n != 0 {
+		t.Fatalf("unsubscribed client got %d announces, want 0", n)
+	}
+
+	// Tree was actually mutated.
+	e, _ := srv.tree.lookup(1, 10)
+	if e.param.Value != int64(7) {
+		t.Fatalf("tree value=%v want 7", e.param.Value)
+	}
+}
+
+// TestServe_ErrorStatCodes walks every reachable error stat code (1-5)
+// over the live serve path so the error branches in the handlers are
+// covered end to end with spec-correct stat bytes.
+func TestServe_ErrorStatCodes(t *testing.T) {
+	_, addr, stop := startServe(t, buildServeExport())
+	defer stop()
+
+	c := dialFakeClient(t, addr)
+	defer c.close()
+	c.handshake(false)
+
+	expectErr := func(name string, msg *codec.ACP2Message, want codec.ACP2ErrStatus) {
+		rep := c.acp2Request(1, msg)
+		if rep.Type != codec.ACP2TypeError {
+			t.Fatalf("%s: type=%d want error(3)", name, rep.Type)
+		}
+		if codec.ACP2ErrStatus(rep.Func) != want {
+			t.Fatalf("%s: stat=%d want %d", name, rep.Func, want)
+		}
+	}
+
+	// stat=1 invalid-obj-id: get_object on a non-existent obj.
+	expectErr("invalid_obj", &codec.ACP2Message{
+		Type: codec.ACP2TypeRequest, MTID: 11, Func: codec.ACP2FuncGetObject, ObjID: 9999,
+	}, codec.ErrInvalidObjID)
+
+	// stat=2 invalid-idx: get_property with idx!=0 on a non-preset object.
+	expectErr("invalid_idx", &codec.ACP2Message{
+		Type: codec.ACP2TypeRequest, MTID: 12, Func: codec.ACP2FuncGetProperty,
+		ObjID: 10, Idx: 5, PID: codec.PIDValue,
+	}, codec.ErrInvalidIdx)
+
+	// stat=3 invalid-pid: get_property for a pid the object doesn't carry.
+	expectErr("invalid_pid", &codec.ACP2Message{
+		Type: codec.ACP2TypeRequest, MTID: 13, Func: codec.ACP2FuncGetProperty,
+		ObjID: 10, PID: 99,
+	}, codec.ErrInvalidPID)
+
+	// stat=4 no-access: set_property on read-only Locked (obj 14).
+	roVal := make([]byte, 4)
+	expectErr("no_access", &codec.ACP2Message{
+		Type: codec.ACP2TypeRequest, MTID: 14, Func: codec.ACP2FuncSetProperty,
+		ObjID: 14, PID: codec.PIDValue,
+		Properties: []codec.Property{{PID: codec.PIDValue, VType: uint8(codec.NumTypeU8), PLen: 8, Data: roVal}},
+	}, codec.ErrNoAccess)
+
+	// stat=5 invalid-value: set Mode (enum obj 11) to an out-of-set idx.
+	badEnum := make([]byte, 4)
+	binary.BigEndian.PutUint32(badEnum, 99)
+	expectErr("invalid_value", &codec.ACP2Message{
+		Type: codec.ACP2TypeRequest, MTID: 15, Func: codec.ACP2FuncSetProperty,
+		ObjID: 11, PID: codec.PIDValue,
+		Properties: []codec.Property{{PID: codec.PIDValue, VType: uint8(codec.NumTypeU32), PLen: 8, Data: badEnum}},
+	}, codec.ErrInvalidValue)
+}
+
+// TestServe_UnknownFuncProtocolError pins stat=0 protocol-error for an
+// ACP2 request carrying an unknown func id.
+func TestServe_UnknownFuncProtocolError(t *testing.T) {
+	_, addr, stop := startServe(t, buildServeExport())
+	defer stop()
+
+	c := dialFakeClient(t, addr)
+	defer c.close()
+	c.handshake(false)
+
+	rep := c.acp2Request(1, &codec.ACP2Message{
+		Type: codec.ACP2TypeRequest, MTID: 20, Func: codec.ACP2Func(99),
+	})
+	if rep.Type != codec.ACP2TypeError || codec.ACP2ErrStatus(rep.Func) != codec.ErrProtocol {
+		t.Fatalf("unknown func: type=%d stat=%d want error/protocol", rep.Type, rep.Func)
+	}
+}
+
+// TestServe_StopClosesSessions verifies Stop tears down the listener and
+// active sessions, and is idempotent (safe to call twice).
+func TestServe_StopClosesSessions(t *testing.T) {
+	srv, addr, stop := startServe(t, buildServeExport())
+	defer stop()
+
+	c := dialFakeClient(t, addr)
+	c.handshake(false)
+
+	if !waitFor(t, time.Second, func() bool {
+		srv.mu.Lock()
+		defer srv.mu.Unlock()
+		return len(srv.sessions) == 1
+	}) {
+		t.Fatal("session never registered")
+	}
+
+	if err := srv.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	// Idempotent.
+	if err := srv.Stop(); err != nil {
+		t.Fatalf("second Stop: %v", err)
+	}
+
+	// Client reads should now hit EOF/closed.
+	_ = c.conn.SetReadDeadline(time.Now().Add(time.Second))
+	_, err := codec.ReadAN2Frame(c.conn)
+	if err == nil {
+		t.Fatal("expected client read error after Stop")
+	}
+	c.close()
+}
+
+// TestServe_ListenError checks Serve surfaces a bind failure (port
+// already held) rather than blocking.
+func TestServe_ListenError(t *testing.T) {
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("pre-bind: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+	addr := ln.Addr().String()
+
+	srv := newServer(quietLogger(), buildServeExport())
+	err = srv.Serve(context.Background(), addr)
+	if err == nil {
+		t.Fatal("Serve on an occupied port should error")
+	}
+}
+
+// TestProviderSetValue_NotImplemented pins the documented Step-2e stub:
+// Provider.SetValue returns an error until that step ships.
+func TestProviderSetValue_NotImplemented(t *testing.T) {
+	srv := newServer(quietLogger(), buildServeExport())
+	_, err := srv.SetValue(context.Background(), "/some/path", 1)
+	if err == nil {
+		t.Fatal("SetValue should return the not-implemented error")
+	}
+}
+
+// silence unused import if strconv ever drops out of use.
+var _ = strconv.Itoa

--- a/internal/acp2/provider/set_test.go
+++ b/internal/acp2/provider/set_test.go
@@ -1,0 +1,300 @@
+package acp2
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"dhs/internal/acp2/codec"
+	"dhs/internal/export/canonical"
+)
+
+// set_test.go covers the applySet* family that the loopback serve test
+// reaches only partially: the numeric clamp branches per NumberType, the
+// IPv4 + string write paths, and the applySet dispatch + guard rejects.
+
+func rwParam(typ string, format string, val any) *canonical.Parameter {
+	p := &canonical.Parameter{
+		Header: canonical.Header{Number: 1, Identifier: "p",
+			Access: canonical.AccessReadWrite},
+		Type:  typ,
+		Value: val,
+	}
+	if format != "" {
+		p.Format = &format
+	}
+	return p
+}
+
+func numEntry(t *testing.T, p *canonical.Parameter) *entry {
+	t.Helper()
+	objType, numType, err := deriveACP2Type(p)
+	if err != nil {
+		t.Fatalf("deriveACP2Type: %v", err)
+	}
+	return &entry{objID: 1, label: "p", access: 0x03,
+		objType: objType, numType: numType, param: p}
+}
+
+func numProp(nt codec.NumberType, iv int64, uv uint64, fv float64) *codec.Property {
+	data, _ := codec.EncodeNumericValue(nt, iv, uv, fv)
+	return &codec.Property{PID: codec.PIDValue, VType: uint8(nt), PLen: uint16(4 + len(data)), Data: data}
+}
+
+// TestApplySetNumber_ClampSigned exercises the signed clamp branch:
+// values below min snap up, above max snap down, in-range pass through.
+func TestApplySetNumber_ClampSigned(t *testing.T) {
+	p := rwParam(canonical.ParamInteger, "s16", int64(0))
+	p.Minimum = int64(-5)
+	p.Maximum = int64(5)
+	e := numEntry(t, p)
+	srv := &server{tree: emptyTree()}
+
+	cases := []struct {
+		in   int64
+		want int64
+	}{
+		{-100, -5}, // clamp to min
+		{100, 5},   // clamp to max
+		{3, 3},     // in range
+	}
+	for _, tc := range cases {
+		post, stat, err := srv.applySet(e, numProp(codec.NumTypeS16, tc.in, 0, 0))
+		if err != nil || stat != 0 {
+			t.Fatalf("in=%d stat=%d err=%v", tc.in, stat, err)
+		}
+		iv, _, _, _ := codec.DecodeNumericValue(codec.NumTypeS16, post.Data)
+		if iv != tc.want {
+			t.Errorf("in=%d post=%d want %d", tc.in, iv, tc.want)
+		}
+		if p.Value != tc.want {
+			t.Errorf("in=%d stored=%v want %d", tc.in, p.Value, tc.want)
+		}
+	}
+}
+
+// TestApplySetNumber_ClampUnsigned exercises the unsigned clamp branch.
+func TestApplySetNumber_ClampUnsigned(t *testing.T) {
+	p := rwParam(canonical.ParamInteger, "u16", uint64(0))
+	p.Minimum = int64(10)
+	p.Maximum = int64(20)
+	e := numEntry(t, p)
+	srv := &server{tree: emptyTree()}
+
+	post, stat, err := srv.applySet(e, numProp(codec.NumTypeU16, 0, 5, 0))
+	if err != nil || stat != 0 {
+		t.Fatalf("stat=%d err=%v", stat, err)
+	}
+	_, uv, _, _ := codec.DecodeNumericValue(codec.NumTypeU16, post.Data)
+	if uv != 10 {
+		t.Errorf("clamp-low uv=%d want 10", uv)
+	}
+
+	post, _, _ = srv.applySet(e, numProp(codec.NumTypeU16, 0, 99, 0))
+	_, uv, _, _ = codec.DecodeNumericValue(codec.NumTypeU16, post.Data)
+	if uv != 20 {
+		t.Errorf("clamp-high uv=%d want 20", uv)
+	}
+}
+
+// TestApplySetNumber_ClampFloat exercises the float clamp branch.
+func TestApplySetNumber_ClampFloat(t *testing.T) {
+	p := rwParam(canonical.ParamReal, "float", float64(0))
+	p.Minimum = float64(-1.5)
+	p.Maximum = float64(1.5)
+	e := numEntry(t, p)
+	srv := &server{tree: emptyTree()}
+
+	post, stat, err := srv.applySet(e, numProp(codec.NumTypeFloat, 0, 0, -10))
+	if err != nil || stat != 0 {
+		t.Fatalf("stat=%d err=%v", stat, err)
+	}
+	_, _, fv, _ := codec.DecodeNumericValue(codec.NumTypeFloat, post.Data)
+	if math.Abs(fv-(-1.5)) > 1e-6 {
+		t.Errorf("clamp-low fv=%v want -1.5", fv)
+	}
+	if e.param.Value.(float64) != -1.5 {
+		t.Errorf("stored=%v want -1.5", e.param.Value)
+	}
+}
+
+// TestApplySetNumber_NoConstraintsPassThrough hits the ok=false branch of
+// each constraint helper (nil Minimum/Maximum) — the value is stored
+// verbatim.
+func TestApplySetNumber_NoConstraintsPassThrough(t *testing.T) {
+	p := rwParam(canonical.ParamInteger, "s32", int64(0)) // no Min/Max
+	e := numEntry(t, p)
+	srv := &server{tree: emptyTree()}
+	post, stat, err := srv.applySet(e, numProp(codec.NumTypeS32, 12345, 0, 0))
+	if err != nil || stat != 0 {
+		t.Fatalf("stat=%d err=%v", stat, err)
+	}
+	iv, _, _, _ := codec.DecodeNumericValue(codec.NumTypeS32, post.Data)
+	if iv != 12345 {
+		t.Errorf("post=%d want 12345", iv)
+	}
+}
+
+// TestApplySetNumber_BadBytes hits the DecodeNumericValue error path.
+func TestApplySetNumber_BadBytes(t *testing.T) {
+	p := rwParam(canonical.ParamInteger, "s32", int64(0))
+	e := numEntry(t, p)
+	srv := &server{tree: emptyTree()}
+	in := &codec.Property{PID: codec.PIDValue, VType: uint8(codec.NumTypeS32), PLen: 5, Data: []byte{1}}
+	_, stat, err := srv.applySet(e, in)
+	if err == nil || stat != codec.ErrInvalidValue {
+		t.Fatalf("stat=%d err=%v want invalid_value", stat, err)
+	}
+}
+
+// TestApplySetIPv4 covers the ipv4 write path + dotted-quad storage and
+// the short-buffer reject.
+func TestApplySetIPv4(t *testing.T) {
+	p := rwParam(canonical.ParamString, "ipv4", "0.0.0.0")
+	e := numEntry(t, p)
+	srv := &server{tree: emptyTree()}
+
+	in := &codec.Property{PID: codec.PIDValue, VType: uint8(codec.NumTypeIPv4), PLen: 8,
+		Data: []byte{192, 168, 1, 42}}
+	post, stat, err := srv.applySet(e, in)
+	if err != nil || stat != 0 {
+		t.Fatalf("stat=%d err=%v", stat, err)
+	}
+	if e.param.Value != "192.168.1.42" {
+		t.Errorf("stored=%v want 192.168.1.42", e.param.Value)
+	}
+	if len(post.Data) != 4 || post.Data[0] != 192 {
+		t.Errorf("post.Data=%v", post.Data)
+	}
+
+	// short buffer → invalid_value
+	short := &codec.Property{PID: codec.PIDValue, VType: uint8(codec.NumTypeIPv4), PLen: 6, Data: []byte{1, 2}}
+	_, stat, err = srv.applySet(e, short)
+	if err == nil || stat != codec.ErrInvalidValue {
+		t.Fatalf("short ipv4 stat=%d err=%v want invalid_value", stat, err)
+	}
+}
+
+// TestApplySetString covers the string write path: NUL strip, maxLen
+// truncation, and storage.
+func TestApplySetString(t *testing.T) {
+	p := rwParam(canonical.ParamString, "maxLen=4", "old")
+	e := numEntry(t, p)
+	srv := &server{tree: emptyTree()}
+
+	// "ABCDEFG\0" → strip NUL → "ABCDEFG" → truncate to 4 → "ABCD".
+	in := &codec.Property{PID: codec.PIDValue, VType: uint8(codec.NumTypeString),
+		Data: append([]byte("ABCDEFG"), 0)}
+	post, stat, err := srv.applySet(e, in)
+	if err != nil || stat != 0 {
+		t.Fatalf("stat=%d err=%v", stat, err)
+	}
+	if e.param.Value != "ABCD" {
+		t.Errorf("stored=%q want ABCD", e.param.Value)
+	}
+	if post.PID != codec.PIDValue {
+		t.Errorf("post pid=%d", post.PID)
+	}
+}
+
+// TestApplySet_NoWriteAccess pins stat=4 when the entry lacks the write
+// bit.
+func TestApplySet_NoWriteAccess(t *testing.T) {
+	p := rwParam(canonical.ParamInteger, "s32", int64(0))
+	e := numEntry(t, p)
+	e.access = 0x01 // read only
+	srv := &server{tree: emptyTree()}
+	_, stat, err := srv.applySet(e, numProp(codec.NumTypeS32, 1, 0, 0))
+	if err == nil || stat != codec.ErrNoAccess {
+		t.Fatalf("stat=%d err=%v want no_access", stat, err)
+	}
+}
+
+// TestApplySet_WrongPID pins stat=3 when the incoming property is not
+// pid=8 (value).
+func TestApplySet_WrongPID(t *testing.T) {
+	p := rwParam(canonical.ParamInteger, "s32", int64(0))
+	e := numEntry(t, p)
+	srv := &server{tree: emptyTree()}
+	in := numProp(codec.NumTypeS32, 1, 0, 0)
+	in.PID = codec.PIDEventDelay // pid 4, not 8
+	_, stat, err := srv.applySet(e, in)
+	if err == nil || stat != codec.ErrInvalidPID {
+		t.Fatalf("stat=%d err=%v want invalid_pid", stat, err)
+	}
+}
+
+// TestApplySet_UnsupportedObjType pins the dispatch default: a node is
+// not writable.
+func TestApplySet_UnsupportedObjType(t *testing.T) {
+	e := &entry{objID: 1, access: 0x03, objType: codec.ObjTypeNode}
+	srv := &server{tree: emptyTree()}
+	in := numProp(codec.NumTypeS32, 1, 0, 0)
+	_, stat, err := srv.applySet(e, in)
+	if err == nil || stat != codec.ErrInvalidPID {
+		t.Fatalf("stat=%d err=%v want invalid_pid", stat, err)
+	}
+}
+
+// TestApplySetEnum_ShortBuffer covers the <4 byte reject in applySetEnum.
+func TestApplySetEnum_ShortBuffer(t *testing.T) {
+	enum := "Off,On"
+	p := &canonical.Parameter{
+		Header:      canonical.Header{Number: 1, Access: canonical.AccessReadWrite},
+		Type:        canonical.ParamEnum,
+		Value:       int64(0),
+		Enumeration: &enum,
+	}
+	e := &entry{objID: 1, access: 0x03, objType: codec.ObjTypeEnum,
+		numType: codec.NumTypeU32, param: p}
+	srv := &server{tree: emptyTree()}
+	in := &codec.Property{PID: codec.PIDValue, VType: uint8(codec.NumTypeU32), Data: []byte{0, 1}}
+	_, stat, err := srv.applySet(e, in)
+	if err == nil || stat != codec.ErrInvalidValue {
+		t.Fatalf("stat=%d err=%v want invalid_value", stat, err)
+	}
+}
+
+// TestConstraintHelpers covers intConstraint / uintConstraint /
+// floatConstraint nil, type-mismatch, and NaN branches directly.
+func TestConstraintHelpers(t *testing.T) {
+	if _, ok := intConstraint(nil); ok {
+		t.Error("intConstraint(nil) ok")
+	}
+	if v, ok := intConstraint(int64(7)); !ok || v != 7 {
+		t.Errorf("intConstraint(7)=%d,%v", v, ok)
+	}
+	if _, ok := intConstraint("not-an-int"); ok {
+		t.Error("intConstraint(bad string) ok")
+	}
+	if _, ok := uintConstraint(nil); ok {
+		t.Error("uintConstraint(nil) ok")
+	}
+	if v, ok := uintConstraint(int64(3)); !ok || v != 3 {
+		t.Errorf("uintConstraint(3)=%d,%v", v, ok)
+	}
+	if _, ok := uintConstraint(int64(-1)); ok {
+		t.Error("uintConstraint(negative) ok")
+	}
+	if _, ok := floatConstraint(nil); ok {
+		t.Error("floatConstraint(nil) ok")
+	}
+	if v, ok := floatConstraint(float64(2.5)); !ok || v != 2.5 {
+		t.Errorf("floatConstraint(2.5)=%v,%v", v, ok)
+	}
+	if _, ok := floatConstraint(math.NaN()); ok {
+		t.Error("floatConstraint(NaN) ok")
+	}
+}
+
+// TestEnumIdxValid_NoEnumData covers the false-return when a parameter
+// has neither EnumMap nor Enumeration string.
+func TestEnumIdxValid_NoEnumData(t *testing.T) {
+	p := &canonical.Parameter{Type: canonical.ParamEnum}
+	if enumIdxValid(p, 0) {
+		t.Error("enumIdxValid with no enum data should be false")
+	}
+}
+
+// ensure binary import stays used even if assertions shift.
+var _ = binary.BigEndian


### PR DESCRIPTION
## acp2 → ADR-0025 gold standard

Applies the acp1 repeatable playbook (`CLAUDE.md` → "Bringing a connector to DONE") to **acp2**. Closes #550.

### Coverage (CI floors locked, no-regression)
| Package | Before | After | Floor |
|---|---|---|---|
| codec | 59.4% | **98.8%** | 98 |
| consumer | 24.1% | **84.2%** | 84 |
| provider | 50.1% | **90.0%** | 90 |

Codec < 100 and consumer < 90 are intrinsic: codec's residual is a dead `dlen>MaxPayload` branch (uint16 ceiling) + empty interface-marker methods; consumer's residual is live-session / timer / device-response-shape branches reachable only via the integration tier (now present), not unit-coverable without a live peer. Every pure/offline function is at 100%.

### What landed
- **Codec** — error/edge-path tests (framer bad-magic/short/dlen-bounds, ACP2 message decode/encode error paths, property codec malformed records, numeric value short-data).
- **Consumer** — AN2/TCP loopback harness already drove the I/O path (Connect/Walk/Get/Set/Subscribe/keepalive/reconnect); this PR adds the pure/offline helpers (catalogue, cache LRU, offline `validate`, value-validation, canonicalize helpers) to 100%.
- **Provider** — serve-loopback (full accept loop + announce broadcast) + handlers/encoder/demo coverage.
- **Integration** — `internal/acp2/integration` replaces the `t.Skip("ACP2 not implemented yet")` placeholder with a **CLI-driving** test: spins `dhs producer acp2 serve` (the emulator) on an ephemeral port, drives `dhs consumer acp2 info/walk/get/set` over real AN2/TCP, asserts a get→set→get round-trip. Env-gated: `ACP2_TEST_HOST` runs the same assertions against a real device.
- **Docs** — `internal/acp2/docs/status.md` (doc-set parity with acp1).
- **CI** — per-package acp2 coverage floors added to `.github/workflows/ci.yml`.

### Oracle-per-tier
- **Real device:** EVS Neuron CONVERT Hybrid — `dhs consumer acp2 info` verified live (AN2 v0.1, ACP2 v2, 2 slots present). Full verb matrix against the device runs via `ACP2_TEST_HOST` from a device-reachable host (the dev host is firewalled from the device net by the manufacturer firewall).
- **Loopback-regression tier:** our `dhs producer acp2 serve` emulator (previously validated against Cerebrum + Lawo VSM) — used by the integration test, never as the *primary* consumer oracle.

### Verification
`go build ./...`, `go vet ./internal/acp2/...`, `go test ./internal/acp2/...` all pass; `go test -tags integration ./internal/acp2/integration/...` passes. ACP2 is AN2/TCP-only (port 2072, proto=2); spec-strict per `internal/acp2/CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
