### PR TITLE
test(acp1): tier-3 integration vs live Synapse (ADR-0025 #3)

### DIFF
--- a/ansible/playbooks/acp1-integration.yml
+++ b/ansible/playbooks/acp1-integration.yml
@@ -1,0 +1,86 @@
+---
+# ACP1 tier-3 integration CONTRACT TEST against a live VENDOR oracle (the Axon
+# Synapse Simulator, or a real Axon rack — never our own provider), per
+# ADR-0025 deliverable 3: "Ansible is the exclusive integration / verify /
+# deploy driver — no PowerShell .ps1 scripts." This is the live-rig parity
+# driver that complements the Go -tags integration body in
+# internal/acp1/integration/synapse_external_test.go.
+#
+# Read-only verbs (info + walk) → changed_when:false → idempotent BY
+# CONSTRUCTION (run-twice = 0 changes). Skips cleanly when no oracle is
+# configured, so it is safe to invoke unconditionally (CI / agent).
+#
+#   ACP1_TEST_HOST=10.6.239.113 DHS_BIN=bin/dhs \
+#     ansible-playbook -i inventory/hosts.ini playbooks/acp1-integration.yml
+#
+# Synapse speaks ACP1 Mode A (UDP) on 2071. ACP1_TEST_PORT overrides.
+- name: ACP1 tier-3 integration vs live Synapse oracle
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    dhs_bin: "{{ lookup('ansible.builtin.env', 'DHS_BIN') | default(playbook_dir + '/../../bin/dhs', true) }}"
+    acp1_host: "{{ lookup('ansible.builtin.env', 'ACP1_TEST_HOST') | default('', true) }}"
+    acp1_port: "{{ lookup('ansible.builtin.env', 'ACP1_TEST_PORT') | default('2071', true) }}"
+  tasks:
+    - name: Skip when no ACP1 oracle is configured
+      ansible.builtin.meta: end_play
+      when: (acp1_host | length) == 0
+
+    - name: "info — read the rack"
+      ansible.builtin.command:
+        argv:
+          - "{{ dhs_bin }}"
+          - consumer
+          - acp1
+          - info
+          - "{{ acp1_host }}"
+          - --transport
+          - udp
+          - --port
+          - "{{ acp1_port | string }}"
+          - --timeout
+          - 15s
+      register: acp1_info
+      changed_when: false
+      failed_when: acp1_info.rc != 0
+
+    - name: "ASSERT info reports a populated rack"
+      ansible.builtin.assert:
+        that:
+          - "'slots' in acp1_info.stdout"
+          - "'status=present' in acp1_info.stdout"
+        fail_msg: "ACP1 info reported no present slot from the live vendor oracle"
+        quiet: true
+
+    - name: "walk slot 0 — rack controller"
+      ansible.builtin.command:
+        argv:
+          - "{{ dhs_bin }}"
+          - consumer
+          - acp1
+          - walk
+          - "{{ acp1_host }}"
+          - --transport
+          - udp
+          - --port
+          - "{{ acp1_port | string }}"
+          - --slot
+          - "0"
+          - --timeout
+          - 20s
+      register: acp1_walk
+      changed_when: false
+      failed_when: acp1_walk.rc != 0
+
+    - name: "ASSERT walk exposes objects + the Control group"
+      ansible.builtin.assert:
+        that:
+          - "'objects' in acp1_walk.stdout"
+          - "'[control]' in acp1_walk.stdout"
+        fail_msg: "ACP1 walk slot 0 returned no objects / no Control group from the live oracle"
+        quiet: true
+
+    - name: ACP1 integration result
+      ansible.builtin.debug:
+        msg: "ACP1 tier-3 integration: PASS vs {{ acp1_host }}:{{ acp1_port }} (vendor oracle, read-only / idempotent)"

--- a/internal/acp1/integration/synapse_external_test.go
+++ b/internal/acp1/integration/synapse_external_test.go
@@ -1,0 +1,113 @@
+//go:build integration
+
+// External-oracle integration for ACP1: drives the dhs consumer against the
+// real Axon **Synapse Simulator** (the vendor tool, NOT our own provider), per
+// the ADR-0025 deliverable-3 tier-3 oracle ("vendor emulator + real device,
+// never our own provider"). The loopback fixture test in manifest_serve_test.go
+// is the tier-4 regression net; this is the ground-truth check.
+//
+// Gated on ACP1_TEST_HOST (per root CLAUDE.md "integration tests gated on
+// per-protocol env vars"). When unset the test skips — the vendor oracle is not
+// always present. Synapse speaks ACP1 Mode A (UDP) on 2071.
+//
+//	ACP1_TEST_HOST=10.6.239.113 ACP1_TEST_PORT=2071 \
+//	  go test -tags integration ./internal/acp1/integration/ -run Synapse -v
+//
+// Assertions are STRUCTURAL — they assert what a real Synapse rack exposes
+// (a populated rack, a walkable controller slot with the Control group), not
+// our committed fixture's specific cards, because the live device's contents
+// differ from and are independent of our repo.
+package acp1_integration
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// synapseTarget returns the host+port of the live Synapse oracle, or skips.
+func synapseTarget(t *testing.T) (host, port string) {
+	t.Helper()
+	host = os.Getenv("ACP1_TEST_HOST")
+	if host == "" {
+		t.Skip("ACP1_TEST_HOST not set — skipping live Synapse Simulator oracle")
+	}
+	port = os.Getenv("ACP1_TEST_PORT")
+	if port == "" {
+		port = "2071" // Synapse Simulator default (ACP1 Mode A / UDP)
+	}
+	return host, port
+}
+
+// TestSynapseInfo asserts the consumer reports a populated rack from the live
+// Synapse Simulator over UDP.
+func TestSynapseInfo(t *testing.T) {
+	host, port := synapseTarget(t)
+	bin := buildDHS(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, bin,
+		"consumer", "acp1", "info", host,
+		"--transport", "udp",
+		"--port", port,
+		"--timeout", "15s",
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("consumer info vs Synapse %s:%s failed: %v\n%s", host, port, err, out)
+	}
+	text := string(out)
+
+	// A real Synapse rack reports a slot count and at least one present card.
+	if !strings.Contains(text, "slots") {
+		t.Fatalf("info missing slot-count header from live Synapse:\n%s", text)
+	}
+	if !strings.Contains(text, "status=present") {
+		t.Fatalf("info reports no present slot from live Synapse:\n%s", text)
+	}
+	t.Logf("Synapse info: populated rack confirmed\n%s", firstLines(text, 6))
+}
+
+// TestSynapseWalk walks the rack-controller slot 0 of the live Synapse and
+// asserts a non-trivial object set with the Control group present.
+func TestSynapseWalk(t *testing.T) {
+	host, port := synapseTarget(t)
+	bin := buildDHS(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, bin,
+		"consumer", "acp1", "walk", host,
+		"--transport", "udp",
+		"--port", port,
+		"--slot", "0",
+		"--timeout", "20s",
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("consumer walk slot 0 vs Synapse %s:%s failed: %v\n%s", host, port, err, out)
+	}
+	text := string(out)
+
+	count := parseObjectCount(t, text)
+	if count <= 0 {
+		t.Fatalf("walk slot 0 returned no objects from live Synapse:\n%s", text)
+	}
+	// The rack controller always exposes the Control group (network/broadcast
+	// config). Assert the group header so a degenerate single-object reply fails.
+	if !strings.Contains(text, "[control]") {
+		t.Fatalf("walk slot 0 missing [control] group from live Synapse:\n%s", text)
+	}
+	t.Logf("Synapse walk slot 0: %d objects, Control group present", count)
+}
+
+// firstLines returns up to n lines of s, for compact failure/log output.
+func firstLines(s string, n int) string {
+	lines := strings.SplitN(s, "\n", n+1)
+	if len(lines) > n {
+		lines = lines[:n]
+	}
+	return strings.Join(lines, "\n")
+}


### PR DESCRIPTION
Go -tags integration + ansible/playbooks/acp1-integration.yml driving the consumer vs the Axon Synapse Simulator. Verified live (Ansible, ok=5 changed=0). Additive; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)