### PR TITLE
test(emberplus): tier-3 integration vs TinyEmber+ (ADR-0025 #3)

### DIFF
--- a/ansible/playbooks/emberplus-integration.yml
+++ b/ansible/playbooks/emberplus-integration.yml
@@ -1,0 +1,82 @@
+---
+# Ember+ tier-3 integration CONTRACT TEST against a live VENDOR oracle (Lawo
+# TinyEmberPlus / TinyEmberPlusRouter, or a real Lawo box — never our own
+# provider), per ADR-0025 deliverable 3: "Ansible is the exclusive integration
+# / verify / deploy driver — no PowerShell .ps1 scripts." Live-rig parity
+# driver complementing the Go -tags integration body in
+# internal/emberplus/integration/external_test.go.
+#
+# Read-only verbs (info + walk) → changed_when:false → idempotent BY
+# CONSTRUCTION (run-twice = 0 changes). Skips cleanly when no oracle is set.
+#
+#   EMBERPLUS_TEST_HOST=10.6.239.113 DHS_BIN=bin/dhs \
+#     ansible-playbook -i inventory/hosts.ini playbooks/emberplus-integration.yml
+#   # router / matrix surface:
+#   EMBERPLUS_TEST_HOST=10.6.239.113 EMBERPLUS_TEST_PORT=9092 ansible-playbook ...
+#
+# TinyEmber+ speaks S101/TCP — 9000 (plain provider) / 9092 (router/matrix).
+- name: Ember+ tier-3 integration vs live TinyEmber+ oracle
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    dhs_bin: "{{ lookup('ansible.builtin.env', 'DHS_BIN') | default(playbook_dir + '/../../bin/dhs', true) }}"
+    ember_host: "{{ lookup('ansible.builtin.env', 'EMBERPLUS_TEST_HOST') | default('', true) }}"
+    ember_port: "{{ lookup('ansible.builtin.env', 'EMBERPLUS_TEST_PORT') | default('9000', true) }}"
+  tasks:
+    - name: Skip when no Ember+ oracle is configured
+      ansible.builtin.meta: end_play
+      when: (ember_host | length) == 0
+
+    - name: "info — read the device"
+      ansible.builtin.command:
+        argv:
+          - "{{ dhs_bin }}"
+          - consumer
+          - emberplus
+          - info
+          - "{{ ember_host }}"
+          - --port
+          - "{{ ember_port | string }}"
+          - --timeout
+          - 15s
+      register: ember_info
+      changed_when: false
+      failed_when: ember_info.rc != 0
+
+    - name: "ASSERT info reports a present device"
+      ansible.builtin.assert:
+        that:
+          - "'status=present' in ember_info.stdout"
+        fail_msg: "Ember+ info reported no present device from the live vendor oracle"
+        quiet: true
+
+    - name: "walk — full tree"
+      ansible.builtin.command:
+        argv:
+          - "{{ dhs_bin }}"
+          - consumer
+          - emberplus
+          - walk
+          - "{{ ember_host }}"
+          - --port
+          - "{{ ember_port | string }}"
+          - --timeout
+          - 45s
+      register: ember_walk
+      changed_when: false
+      failed_when: ember_walk.rc != 0
+
+    - name: "ASSERT walk exposes objects + at least one scalar parameter"
+      ansible.builtin.assert:
+        that:
+          - "'objects' in ember_walk.stdout"
+          - "('string' in ember_walk.stdout) or ('bool' in ember_walk.stdout) or ('int' in ember_walk.stdout) or ('real' in ember_walk.stdout)"
+        fail_msg: >-
+          Ember+ walk returned no objects / no scalar-typed parameter from the
+          live oracle — S101+BER+glow decode suspect.
+        quiet: true
+
+    - name: Ember+ integration result
+      ansible.builtin.debug:
+        msg: "Ember+ tier-3 integration: PASS vs {{ ember_host }}:{{ ember_port }} (vendor oracle, read-only / idempotent)"

--- a/internal/emberplus/integration/external_test.go
+++ b/internal/emberplus/integration/external_test.go
@@ -1,0 +1,116 @@
+//go:build integration
+
+// External-oracle integration for Ember+: drives the dhs consumer against a
+// real vendor Ember+ provider (TinyEmberPlus / TinyEmberPlusRouter, the Lawo
+// reference tools — NOT our own provider), per ADR-0025 deliverable-3's tier-3
+// oracle. The manifest_serve_test.go loopback test is the tier-4 regression net.
+//
+// Gated on EMBERPLUS_TEST_HOST (per-protocol env var, root CLAUDE.md). Skips
+// when unset — the vendor oracle is not always present. TinyEmber+ speaks
+// S101/TCP (9000 plain provider, 9092 router/matrix).
+//
+//	EMBERPLUS_TEST_HOST=10.6.239.113 EMBERPLUS_TEST_PORT=9000 \
+//	  go test -tags integration ./internal/emberplus/integration/ -run External -v
+//	# matrix surface:
+//	EMBERPLUS_TEST_HOST=10.6.239.113 EMBERPLUS_TEST_PORT=9092 go test ... -run External
+//
+// Assertions are STRUCTURAL — they prove our S101 + BER + glow decoder reads a
+// real vendor tree (a populated tree with at least one scalar-typed parameter),
+// independent of which tree the tool happens to host.
+package emberplus_integration
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// emberTarget returns the host+port of the live vendor oracle, or skips.
+func emberTarget(t *testing.T) (host, port string) {
+	t.Helper()
+	host = os.Getenv("EMBERPLUS_TEST_HOST")
+	if host == "" {
+		t.Skip("EMBERPLUS_TEST_HOST not set — skipping live TinyEmber+ oracle")
+	}
+	port = os.Getenv("EMBERPLUS_TEST_PORT")
+	if port == "" {
+		port = "9000" // TinyEmberPlus default provider port
+	}
+	return host, port
+}
+
+// hasScalarParam reports whether the walk output decoded at least one
+// scalar-typed Ember+ parameter (proving glow value decoding, not just the
+// node skeleton). Node containers render as "raw"; real parameters carry a
+// glow value type.
+func hasScalarParam(text string) bool {
+	for _, ty := range []string{" string ", " bool ", " int ", " real ", " enum "} {
+		if strings.Contains(text, ty) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestExternalEmberInfo asserts the consumer reports a present, online device
+// from the live vendor provider over S101/TCP.
+func TestExternalEmberInfo(t *testing.T) {
+	host, port := emberTarget(t)
+	bin := buildDHS(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, bin,
+		"consumer", "emberplus", "info", host,
+		"--port", port,
+		"--timeout", "15s",
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("consumer info vs vendor %s:%s failed: %v\n%s", host, port, err, out)
+	}
+	text := string(out)
+	if !strings.Contains(text, "status=present") {
+		t.Fatalf("info reports no present slot from live vendor provider:\n%s", text)
+	}
+	t.Logf("vendor Ember+ info: present\n%s", text)
+}
+
+// TestExternalEmberWalk asserts the consumer walks a substantial real tree and
+// decodes at least one scalar parameter.
+func TestExternalEmberWalk(t *testing.T) {
+	host, port := emberTarget(t)
+	bin := buildDHS(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, bin,
+		"consumer", "emberplus", "walk", host,
+		"--port", port,
+		"--timeout", "45s",
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("consumer walk vs vendor %s:%s failed: %v\n%s", host, port, err, out)
+	}
+	text := string(out)
+
+	count := parseObjectCount(t, text)
+	if count <= 0 {
+		t.Fatalf("walk returned no objects from live vendor provider:\n%s", firstN(text, 1200))
+	}
+	if !hasScalarParam(text) {
+		t.Fatalf("walk decoded no scalar-typed parameter from live vendor provider "+
+			"(only node skeleton?) — glow value decoding suspect:\n%s", firstN(text, 1200))
+	}
+	t.Logf("vendor Ember+ walk on %s:%s: %d objects, scalar parameters decoded", host, port, count)
+}
+
+// firstN returns up to n bytes of s for compact failure output.
+func firstN(s string, n int) string {
+	if len(s) > n {
+		return s[:n]
+	}
+	return s
+}


### PR DESCRIPTION
Go -tags integration + ansible/playbooks/emberplus-integration.yml driving the consumer vs TinyEmberPlus/Router (9000/9092). Verified live (Ansible, ok=5 changed=0 x2). Additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)