### PR TITLE
test(probel-sw02p): codec to 100% coverage + CI floor (C)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
           check ./internal/emberplus/codec/s101 100
           check ./internal/emberplus/consumer 100
           check ./internal/emberplus/provider 100
+          check ./internal/probel-sw02p/codec 100
 
       - name: Upload coverage
         if: matrix.os == 'ubuntu-latest'

--- a/internal/probel-sw02p/codec/catalogue_lookup_test.go
+++ b/internal/probel-sw02p/codec/catalogue_lookup_test.go
@@ -1,0 +1,120 @@
+package codec
+
+import "testing"
+
+// TestCommandsCatalogueConsistency pins the catalogue helpers
+// (Commands / CommandByID) against the parallel command_names.go
+// helpers (CommandName / CommandIDs). All four are derived from the
+// same §3.2 command table, so they must agree byte-for-byte:
+//
+//   - every CommandSpec.ID is known to CommandName and the Name field
+//     matches CommandName exactly,
+//   - every id reported by CommandIDs has a CommandSpec via CommandByID,
+//   - the two sets contain exactly the same command bytes.
+//
+// This is the spec-derived invariant the catalogue must satisfy; a
+// drift between the two tables (a command added to one switch but not
+// the other) fails here.
+func TestCommandsCatalogueConsistency(t *testing.T) {
+	cmds := Commands()
+	if len(cmds) == 0 {
+		t.Fatal("Commands() returned empty catalogue")
+	}
+
+	specByID := make(map[CommandID]CommandSpec, len(cmds))
+	for _, c := range cmds {
+		if _, dup := specByID[c.ID]; dup {
+			t.Errorf("duplicate catalogue entry for id %#x", c.ID)
+		}
+		specByID[c.ID] = c
+
+		// Name must match command_names.go exactly.
+		if got := CommandName(c.ID); got != c.Name {
+			t.Errorf("id %#x: CommandName=%q catalogue Name=%q", c.ID, got, c.Name)
+		}
+		// Every supported catalogue command must have a non-empty
+		// SpecRef and be flagged Supported (all shipped bytes are).
+		if c.SpecRef == "" {
+			t.Errorf("id %#x (%s): empty SpecRef", c.ID, c.Name)
+		}
+		if !c.Supported {
+			t.Errorf("id %#x (%s): Supported=false; every shipped byte is supported", c.ID, c.Name)
+		}
+
+		// CommandByID round-trip.
+		spec, ok := CommandByID(c.ID)
+		if !ok {
+			t.Errorf("CommandByID(%#x) ok=false; want true", c.ID)
+		}
+		if spec != c {
+			t.Errorf("CommandByID(%#x) = %+v; want %+v", c.ID, spec, c)
+		}
+	}
+
+	// CommandIDs set must equal the catalogue id set.
+	ids := CommandIDs()
+	if len(ids) != len(cmds) {
+		t.Errorf("CommandIDs len=%d; Commands len=%d", len(ids), len(cmds))
+	}
+	idSet := make(map[CommandID]bool, len(ids))
+	for _, id := range ids {
+		idSet[id] = true
+		if _, ok := specByID[id]; !ok {
+			t.Errorf("CommandIDs has %#x but Commands() does not", id)
+		}
+		// Every CommandIDs entry must resolve via CommandName.
+		if CommandName(id) == "" {
+			t.Errorf("CommandIDs has %#x but CommandName returns empty", id)
+		}
+	}
+	for id := range specByID {
+		if !idSet[id] {
+			t.Errorf("Commands() has %#x but CommandIDs does not", id)
+		}
+	}
+}
+
+// TestCommandByIDUnknown confirms the lookup returns false for a byte
+// outside this codec's catalogue (0x00 is not a defined SW-P-02
+// command).
+func TestCommandByIDUnknown(t *testing.T) {
+	if spec, ok := CommandByID(CommandID(0x00)); ok {
+		t.Errorf("CommandByID(0x00) ok=true spec=%+v; want false", spec)
+	}
+	if spec, ok := CommandByID(CommandID(0xAA)); ok {
+		t.Errorf("CommandByID(0xAA) ok=true spec=%+v; want false", spec)
+	}
+}
+
+// TestCommandNameUnknown confirms CommandName returns the empty string
+// for an unregistered command byte (the default switch arm).
+func TestCommandNameUnknown(t *testing.T) {
+	for _, id := range []CommandID{0x00, 0x10, 0xAA, 0xFF} {
+		if got := CommandName(id); got != "" {
+			t.Errorf("CommandName(%#x) = %q; want empty", id, got)
+		}
+	}
+}
+
+// TestCommandNameSpotChecks pins a few representative bytes to their
+// §3.2 names so a typo in the switch is caught independently of the
+// catalogue cross-check above.
+func TestCommandNameSpotChecks(t *testing.T) {
+	cases := []struct {
+		id   CommandID
+		want string
+	}{
+		{RxInterrogate, "interrogate"},
+		{RxConnect, "connect"},
+		{TxTally, "tally"},
+		{TxCrosspointConnected, "crosspoint_connected"},
+		{RxGo, "go"},
+		{TxExtendedProtectTallyDump, "extended_protect_tally_dump"},
+		{RxExtendedProtectTallyDumpRequest, "extended_protect_tally_dump_request"},
+	}
+	for _, tc := range cases {
+		if got := CommandName(tc.id); got != tc.want {
+			t.Errorf("CommandName(%#x) = %q; want %q", tc.id, got, tc.want)
+		}
+	}
+}

--- a/internal/probel-sw02p/codec/client.go
+++ b/internal/probel-sw02p/codec/client.go
@@ -151,6 +151,16 @@ func NewClientFromConn(conn net.Conn, logger *slog.Logger, cfg ClientConfig) *Cl
 // applyTCPKeepalive enables SO_KEEPALIVE on a dialed TCP connection.
 // period == 0 → DefaultTCPKeepalivePeriod; period < 0 → disable.
 // Logs at Debug if the conn isn't a *net.TCPConn (e.g. test pipe).
+// Test seams for the two keep-alive setsockopt calls. On a live *net.TCPConn
+// the SetKeepAlivePeriod failure arm can't be provoked in isolation (any fd
+// state that fails the second call also fails the first, which returns early),
+// so tests override these to exercise that branch. Production behaviour is the
+// default (cf. the bcastDialErrHook idiom in the acp1 provider).
+var (
+	tcpSetKeepAlive       = func(tc *net.TCPConn, on bool) error { return tc.SetKeepAlive(on) }
+	tcpSetKeepAlivePeriod = func(tc *net.TCPConn, d time.Duration) error { return tc.SetKeepAlivePeriod(d) }
+)
+
 func applyTCPKeepalive(conn net.Conn, period time.Duration, logger *slog.Logger) {
 	if period < 0 {
 		return
@@ -162,11 +172,11 @@ func applyTCPKeepalive(conn net.Conn, period time.Duration, logger *slog.Logger)
 	if !ok {
 		return
 	}
-	if err := tc.SetKeepAlive(true); err != nil {
+	if err := tcpSetKeepAlive(tc, true); err != nil {
 		logger.Debug("probel-sw02p SetKeepAlive failed", slog.String("err", err.Error()))
 		return
 	}
-	if err := tc.SetKeepAlivePeriod(period); err != nil {
+	if err := tcpSetKeepAlivePeriod(tc, period); err != nil {
 		logger.Debug("probel-sw02p SetKeepAlivePeriod failed", slog.String("err", err.Error()))
 	}
 }

--- a/internal/probel-sw02p/codec/client_branches_test.go
+++ b/internal/probel-sw02p/codec/client_branches_test.go
@@ -1,0 +1,217 @@
+package codec
+
+import (
+	"context"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestMinHelper pins both arms of the min() helper used by readLoop's
+// decode-error HexDump clamp: a < b returns a, a >= b returns b
+// (including the equal case).
+func TestMinHelper(t *testing.T) {
+	cases := []struct{ a, b, want int }{
+		{1, 2, 1},  // a < b
+		{5, 3, 3},  // a > b
+		{4, 4, 4},  // a == b
+		{64, 64, 64},
+		{100, 64, 64},
+	}
+	for _, tc := range cases {
+		if got := min(tc.a, tc.b); got != tc.want {
+			t.Errorf("min(%d,%d) = %d; want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+// TestSendMatchedReply drives the successful reply-delivery arm of both
+// Send (the select case receiving on waiter.reply) and dispatch (the
+// matched-frame reply-send `return`). Client B emits a frame that
+// Client A's in-flight Send matcher accepts.
+func TestSendMatchedReply(t *testing.T) {
+	a, b := net.Pipe()
+	logger := quietLogger()
+	cfg := ClientConfig{WireHexLog: boolPtr(false)}
+	clientA := NewClientFromConn(a, logger, cfg)
+	clientB := NewClientFromConn(b, logger, cfg)
+	defer func() { _ = clientA.Close() }()
+	defer func() { _ = clientB.Close() }()
+
+	// A sends a request and waits for a TxConnectOnGoAck reply.
+	replyCh := make(chan Frame, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		f, err := clientA.Send(ctx,
+			Frame{ID: RxConnectOnGo, Payload: []byte{0x00, 0x01, 0x02}},
+			func(f Frame) bool { return f.ID == TxConnectOnGoAck })
+		if err != nil {
+			errCh <- err
+			return
+		}
+		replyCh <- f
+	}()
+
+	// B reads A's request, then sends the matching ack back.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	clientB.Subscribe(func(req Frame) {
+		defer wg.Done()
+		if req.ID != RxConnectOnGo {
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		ack := EncodeConnectOnGoAck(ConnectOnGoAckParams{Destination: 1, Source: 2})
+		_, _ = clientB.Send(ctx, ack, nil)
+	})
+
+	select {
+	case f := <-replyCh:
+		if f.ID != TxConnectOnGoAck {
+			t.Errorf("matched reply ID = %#x; want TxConnectOnGoAck", f.ID)
+		}
+	case err := <-errCh:
+		t.Fatalf("Send returned error: %v", err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("Send never received its matched reply")
+	}
+}
+
+// TestReadLoopPartialFrameAccumulates covers readLoop's
+// io.ErrUnexpectedEOF break: a frame split across two writes must not
+// dispatch until the whole frame has arrived, exercising the
+// "accumulate more bytes" branch.
+func TestReadLoopPartialFrameAccumulates(t *testing.T) {
+	a, b := net.Pipe()
+	defer func() { _ = a.Close() }()
+	defer func() { _ = b.Close() }()
+	cli := NewClientFromConn(a, quietLogger(), ClientConfig{WireHexLog: boolPtr(false)})
+	defer func() { _ = cli.Close() }()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	cli.Subscribe(func(f Frame) {
+		if f.ID == RxConnectOnGo {
+			wg.Done()
+		}
+	})
+
+	frame := Pack(Frame{ID: RxConnectOnGo, Payload: []byte{0x00, 0x01, 0x02}})
+	// Split so the first write delivers SOM+cmd+1 byte (>=3, so the
+	// scan loop runs) but the full frame has not arrived → Unpack
+	// returns io.ErrUnexpectedEOF and readLoop breaks to read more.
+	go func() {
+		_, _ = b.Write(frame[:3])
+		time.Sleep(30 * time.Millisecond)
+		_, _ = b.Write(frame[3:])
+	}()
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("split frame never reassembled + dispatched")
+	}
+}
+
+// TestReadLoopDecodeErrorShortBuffer feeds a corrupted-checksum frame
+// SHORTER than 64 bytes so readLoop's decode-error HexDump clamp calls
+// min() on the (len < 64) side, complementing
+// TestReadLoopDecodeErrorResync which exercises the (len > 64) side.
+func TestReadLoopDecodeErrorShortBuffer(t *testing.T) {
+	a, b := net.Pipe()
+	defer func() { _ = a.Close() }()
+	defer func() { _ = b.Close() }()
+	cli := NewClientFromConn(a, quietLogger(), ClientConfig{WireHexLog: boolPtr(false)})
+	defer func() { _ = cli.Close() }()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	cli.Subscribe(func(f Frame) {
+		if f.ID == RxConnectOnGo && len(f.Payload) == 3 && f.Payload[0] == 0x07 {
+			wg.Done()
+		}
+	})
+
+	bad := Pack(Frame{ID: RxConnectOnGo, Payload: []byte{0x00, 0x01, 0x02}})
+	bad[len(bad)-1] ^= 0x7F // corrupt checksum (< 64-byte buffer)
+	good := Pack(Frame{ID: RxConnectOnGo, Payload: []byte{0x07, 0x08, 0x09}})
+	go func() {
+		_, _ = b.Write(bad)
+		_, _ = b.Write(good)
+	}()
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("valid frame after short-buffer decode error never dispatched")
+	}
+}
+
+// TestFailPendingReplySlotFull covers the default arm of failPending:
+// when the reader exits but the in-flight waiter's reply channel is
+// already full (buffered cap 1, slot taken), the error-send must fall
+// through to default rather than block. We install a pending waiter with
+// a pre-filled reply channel, then close the peer so the reader exits
+// and failPending runs.
+func TestFailPendingReplySlotFull(t *testing.T) {
+	a, b := net.Pipe()
+	cli := NewClientFromConn(a, quietLogger(), ClientConfig{WireHexLog: boolPtr(false)})
+	defer func() { _ = cli.Close() }()
+
+	waiter := &pendingWaiter{
+		match: func(Frame) bool { return true },
+		reply: make(chan replyResult, 1),
+	}
+	waiter.reply <- replyResult{} // pre-fill so failPending hits default
+	cli.mu.Lock()
+	cli.pending = waiter
+	cli.mu.Unlock()
+
+	// Peer close → reader Read returns io.EOF → readLoop calls
+	// failPending(err); the reply slot is full so the select default arm
+	// runs without blocking.
+	_ = b.Close()
+
+	select {
+	case <-cli.readerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("readLoop did not exit; failPending may have blocked")
+	}
+	// The pre-filled value must still be the one in the channel (the EOF
+	// send was dropped via default).
+	select {
+	case r := <-waiter.reply:
+		if r.err != nil {
+			t.Errorf("reply slot held err %v; want the pre-filled zero value", r.err)
+		}
+	default:
+		t.Error("reply channel unexpectedly empty")
+	}
+}
+
+// TestReadLoopExitOnEOF confirms the reader goroutine exits cleanly
+// (closing readerDone) when the peer closes, exercising the read-error
+// return arm of readLoop.
+func TestReadLoopExitOnEOF(t *testing.T) {
+	a, b := net.Pipe()
+	cli := NewClientFromConn(a, quietLogger(), ClientConfig{WireHexLog: boolPtr(false)})
+	_ = b.Close() // peer close → Read returns io.EOF → reader exits
+
+	select {
+	case <-cli.readerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("readLoop did not exit after peer close")
+	}
+	if err := cli.Close(); err != nil && err != io.EOF {
+		t.Errorf("Close after reader exit: %v", err)
+	}
+}

--- a/internal/probel-sw02p/codec/client_keepalive_error_test.go
+++ b/internal/probel-sw02p/codec/client_keepalive_error_test.go
@@ -1,0 +1,53 @@
+package codec
+
+import (
+	"net"
+	"testing"
+)
+
+// TestApplyTCPKeepaliveErrorPaths covers the two error-log branches of
+// applyTCPKeepalive: SetKeepAlive and SetKeepAlivePeriod returning an
+// error. Both fail when the underlying TCP socket is already closed —
+// SetsockoptInt on a closed fd returns "use of closed network
+// connection". We dial a real loopback listener (so the conn is a
+// genuine *net.TCPConn, satisfying the type assertion), then Close it
+// before invoking the helper so both setsockopt calls error out and the
+// Debug-log arms run. The helper must not panic and must return
+// normally.
+func TestApplyTCPKeepaliveErrorPaths(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = l.Close() }()
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		c, _ := l.Accept()
+		accepted <- c
+	}()
+
+	conn, err := net.Dial("tcp", l.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	srv := <-accepted
+	if srv != nil {
+		defer func() { _ = srv.Close() }()
+	}
+
+	tc, ok := conn.(*net.TCPConn)
+	if !ok {
+		t.Fatalf("dialed conn is %T; want *net.TCPConn", conn)
+	}
+	// Close the socket so SetKeepAlive / SetKeepAlivePeriod operate on a
+	// closed fd and both return an error → exercises both Debug-log
+	// branches.
+	if err := tc.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// period > 0 so we skip the period<0 (disable) and period==0
+	// (default) early arms and reach both setsockopt calls.
+	applyTCPKeepalive(tc, 17, quietLogger())
+}

--- a/internal/probel-sw02p/codec/client_keepalive_seam_test.go
+++ b/internal/probel-sw02p/codec/client_keepalive_seam_test.go
@@ -1,0 +1,45 @@
+package codec
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestApplyTCPKeepalivePeriodError covers the SetKeepAlivePeriod failure arm of
+// applyTCPKeepalive. On a live *net.TCPConn that branch can't be provoked in
+// isolation (any fd state failing SetKeepAlivePeriod also fails SetKeepAlive,
+// which returns first), so we drive it through the package test seams: make the
+// first call succeed and the second fail.
+func TestApplyTCPKeepalivePeriodError(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+	if _, ok := conn.(*net.TCPConn); !ok {
+		t.Fatalf("expected *net.TCPConn, got %T", conn)
+	}
+
+	origAlive, origPeriod := tcpSetKeepAlive, tcpSetKeepAlivePeriod
+	defer func() { tcpSetKeepAlive, tcpSetKeepAlivePeriod = origAlive, origPeriod }()
+
+	calledAlive := false
+	tcpSetKeepAlive = func(*net.TCPConn, bool) error { calledAlive = true; return nil }
+	tcpSetKeepAlivePeriod = func(*net.TCPConn, time.Duration) error { return errors.New("boom") }
+
+	// Must not panic; exercises the SetKeepAlivePeriod-failed Debug branch.
+	applyTCPKeepalive(conn, time.Second, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	if !calledAlive {
+		t.Fatal("SetKeepAlive seam was not invoked")
+	}
+}

--- a/internal/probel-sw02p/codec/client_paths_test.go
+++ b/internal/probel-sw02p/codec/client_paths_test.go
@@ -1,0 +1,472 @@
+package codec
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// quietLogger returns a logger that discards output so the wire-hex
+// INFO logs don't spam test output.
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// TestDialError covers the Dial error path: dialing an address with no
+// listener returns a wrapped error and a nil Client. Uses 127.0.0.1
+// port 1 (privileged, never listening in CI) with a tiny timeout so the
+// test stays fast.
+func TestDialError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	cli, err := Dial(ctx, "127.0.0.1:1", quietLogger(), ClientConfig{
+		DialTimeout: 200 * time.Millisecond,
+	})
+	if err == nil {
+		_ = cli.Close()
+		t.Fatal("Dial to dead port: got nil err; want connection error")
+	}
+	if cli != nil {
+		t.Errorf("Dial error returned non-nil client %v", cli)
+	}
+}
+
+// TestDialDefaultsAndNilLogger drives Dial with a zero ClientConfig and
+// nil logger so the default-DialTimeout, default-ReadBufferSize, and
+// nil-logger fallback branches all execute against a real loopback
+// listener.
+func TestDialDefaultsAndNilLogger(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = l.Close() }()
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		c, _ := l.Accept()
+		accepted <- c
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	// nil logger + zero cfg → default timeout / buffer branches.
+	cli, err := Dial(ctx, l.Addr().String(), nil, ClientConfig{})
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer func() { _ = cli.Close() }()
+	srv := <-accepted
+	if srv != nil {
+		defer func() { _ = srv.Close() }()
+	}
+}
+
+// TestNewClientFromConnNilLoggerDefaultBuffer covers the nil-logger and
+// zero-ReadBufferSize default arms of NewClientFromConn (the loopback
+// test already covers the non-default path).
+func TestNewClientFromConnNilLoggerDefaultBuffer(t *testing.T) {
+	a, b := net.Pipe()
+	defer func() { _ = b.Close() }()
+	cli := NewClientFromConn(a, nil, ClientConfig{}) // nil logger, zero buffer
+	if cli.logger == nil {
+		t.Error("nil logger was not replaced with slog.Default()")
+	}
+	_ = cli.Close()
+}
+
+// TestApplyTCPKeepaliveDisabled covers the period < 0 early return
+// (keep-alive explicitly disabled) and the non-*net.TCPConn early
+// return (a net.Pipe end is not a TCPConn). Neither should panic or
+// mutate the conn.
+func TestApplyTCPKeepaliveDisabled(t *testing.T) {
+	a, b := net.Pipe()
+	defer func() { _ = a.Close() }()
+	defer func() { _ = b.Close() }()
+
+	// period < 0 → disabled, returns before the type assertion.
+	applyTCPKeepalive(a, -1, quietLogger())
+	// period == 0 with a non-TCPConn → default period, then the
+	// type-assertion early return (ok == false).
+	applyTCPKeepalive(a, 0, quietLogger())
+}
+
+// TestSendInFlight covers the ErrSendInFlight guard: a second Send
+// while the first is still awaiting a reply must be rejected. The first
+// Send uses a matcher (so it parks on waiter.reply) and never gets a
+// reply within the window.
+func TestSendInFlight(t *testing.T) {
+	a, b := net.Pipe()
+	defer func() { _ = a.Close() }()
+	defer func() { _ = b.Close() }()
+	// Drain whatever the client writes so Write() never blocks.
+	go func() {
+		buf := make([]byte, 256)
+		for {
+			if _, err := b.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+
+	cli := NewClientFromConn(a, quietLogger(), ClientConfig{WireHexLog: boolPtr(false)})
+	defer func() { _ = cli.Close() }()
+
+	// First Send parks waiting for a reply that never comes.
+	started := make(chan struct{})
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		close(started)
+		_, _ = cli.Send(ctx, Frame{ID: RxConnectOnGo, Payload: []byte{0, 1, 2}},
+			func(Frame) bool { return false })
+	}()
+	<-started
+	// Give the first Send time to install c.pending.
+	waitFor(t, func() bool {
+		cli.mu.Lock()
+		defer cli.mu.Unlock()
+		return cli.pending != nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err := cli.Send(ctx, Frame{ID: RxGo, Payload: []byte{0}}, func(Frame) bool { return true })
+	if !errors.Is(err, ErrSendInFlight) {
+		t.Errorf("second Send: got %v; want ErrSendInFlight", err)
+	}
+}
+
+// TestSendOnClosedClient covers the closed/nil-conn guard in Send: a
+// Send after Close returns net.ErrClosed.
+func TestSendOnClosedClient(t *testing.T) {
+	a, b := net.Pipe()
+	_ = b.Close()
+	cli := NewClientFromConn(a, quietLogger(), ClientConfig{WireHexLog: boolPtr(false)})
+	_ = cli.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err := cli.Send(ctx, Frame{ID: RxGo, Payload: []byte{0}}, nil)
+	if !errors.Is(err, net.ErrClosed) {
+		t.Errorf("Send on closed client: got %v; want net.ErrClosed", err)
+	}
+}
+
+// TestSendWriteError covers the conn.Write error arm of Send: closing
+// the peer end mid-flight makes the pipe Write fail.
+func TestSendWriteError(t *testing.T) {
+	a, b := net.Pipe()
+	// Close the peer so any Write on a returns io.ErrClosedPipe.
+	_ = b.Close()
+	cli := NewClientFromConn(a, quietLogger(), ClientConfig{WireHexLog: boolPtr(false)})
+	defer func() { _ = cli.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err := cli.Send(ctx, Frame{ID: RxGo, Payload: []byte{0}}, nil)
+	if err == nil {
+		t.Fatal("Send with dead peer: got nil; want write error")
+	}
+}
+
+// TestSendCtxCancel covers the ctx.Done() arm of Send: a Send with a
+// matcher whose reply never arrives returns ctx.Err() when the context
+// deadline elapses.
+func TestSendCtxCancel(t *testing.T) {
+	a, b := net.Pipe()
+	defer func() { _ = a.Close() }()
+	defer func() { _ = b.Close() }()
+	go func() {
+		buf := make([]byte, 256)
+		for {
+			if _, err := b.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+	cli := NewClientFromConn(a, quietLogger(), ClientConfig{WireHexLog: boolPtr(false)})
+	defer func() { _ = cli.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_, err := cli.Send(ctx, Frame{ID: RxConnectOnGo, Payload: []byte{0, 1, 2}},
+		func(Frame) bool { return false })
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("Send ctx cancel: got %v; want context.DeadlineExceeded", err)
+	}
+}
+
+// TestSendWireHexLogObserver covers the WireHexLog INFO branch and the
+// OnTx observer callback in Send (match == nil fire-and-forget path).
+func TestSendWireHexLogObserver(t *testing.T) {
+	a, b := net.Pipe()
+	defer func() { _ = a.Close() }()
+	defer func() { _ = b.Close() }()
+	go func() {
+		buf := make([]byte, 256)
+		for {
+			if _, err := b.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+
+	var txSeen [][]byte
+	var mu sync.Mutex
+	cli := NewClientFromConn(a, quietLogger(), ClientConfig{
+		WireHexLog: boolPtr(true), // exercise the hex-log branch
+		OnTx:       func(raw []byte) { mu.Lock(); txSeen = append(txSeen, raw); mu.Unlock() },
+	})
+	defer func() { _ = cli.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if _, err := cli.Send(ctx, Frame{ID: RxGo, Payload: []byte{0}}, nil); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(txSeen) != 1 {
+		t.Errorf("OnTx fired %d times; want 1", len(txSeen))
+	}
+}
+
+// TestWrite covers Client.Write: the happy path (OnTx observer fires +
+// bytes hit the wire) and the closed-client guard (net.ErrClosed).
+func TestWrite(t *testing.T) {
+	a, b := net.Pipe()
+	defer func() { _ = b.Close() }()
+
+	var got []byte
+	done := make(chan struct{})
+	go func() {
+		buf := make([]byte, 16)
+		n, _ := b.Read(buf)
+		got = append(got, buf[:n]...)
+		close(done)
+	}()
+
+	var observed []byte
+	cli := NewClientFromConn(a, quietLogger(), ClientConfig{
+		WireHexLog: boolPtr(false),
+		OnTx:       func(raw []byte) { observed = append(observed, raw...) },
+	})
+
+	raw := []byte{SOM, 0x07, 0x79}
+	if err := cli.Write(raw); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("peer never received Write bytes")
+	}
+	if len(observed) != len(raw) {
+		t.Errorf("OnTx observed %d bytes; want %d", len(observed), len(raw))
+	}
+
+	// Closed client → net.ErrClosed.
+	_ = cli.Close()
+	if err := cli.Write(raw); !errors.Is(err, net.ErrClosed) {
+		t.Errorf("Write on closed client: got %v; want net.ErrClosed", err)
+	}
+}
+
+// TestCloseIdempotentAndWakesPending covers Close's pending-waiter
+// wakeup arm and the already-closed early return (double Close).
+func TestCloseIdempotentAndWakesPending(t *testing.T) {
+	a, b := net.Pipe()
+	defer func() { _ = b.Close() }()
+	go func() {
+		buf := make([]byte, 256)
+		for {
+			if _, err := b.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+	cli := NewClientFromConn(a, quietLogger(), ClientConfig{WireHexLog: boolPtr(false)})
+
+	// Park a Send so c.pending is non-nil when Close fires.
+	done := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_, err := cli.Send(ctx, Frame{ID: RxConnectOnGo, Payload: []byte{0, 1, 2}},
+			func(Frame) bool { return false })
+		done <- err
+	}()
+	waitFor(t, func() bool {
+		cli.mu.Lock()
+		defer cli.mu.Unlock()
+		return cli.pending != nil
+	})
+
+	if err := cli.Close(); err != nil {
+		t.Errorf("first Close: %v", err)
+	}
+	// The parked Send must be woken with io.EOF from Close's pending arm.
+	select {
+	case err := <-done:
+		if !errors.Is(err, io.EOF) {
+			t.Errorf("parked Send woke with %v; want io.EOF", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not wake the pending Send")
+	}
+
+	// Second Close → already-closed early return (returns nil).
+	if err := cli.Close(); err != nil {
+		t.Errorf("second Close: got %v; want nil", err)
+	}
+}
+
+// TestReadLoopDispatchAndHexLog drives the readLoop happy path with
+// WireHexLog enabled and an OnRx observer, then sends a desync byte
+// followed by a real frame to exercise the resync (drop-one-byte) arm.
+func TestReadLoopDispatchAndHexLog(t *testing.T) {
+	a, b := net.Pipe()
+	defer func() { _ = a.Close() }()
+	defer func() { _ = b.Close() }()
+
+	var rxCount int
+	var mu sync.Mutex
+	cli := NewClientFromConn(a, quietLogger(), ClientConfig{
+		WireHexLog: boolPtr(true), // exercise RX hex-log branch
+		OnRx:       func([]byte) { mu.Lock(); rxCount++; mu.Unlock() },
+	})
+	defer func() { _ = cli.Close() }()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	cli.Subscribe(func(f Frame) {
+		if f.ID == RxConnectOnGo {
+			wg.Done()
+		}
+	})
+
+	// Write a stray non-SOM byte (desync → dropped) followed by a valid
+	// frame so the reader resyncs and dispatches it.
+	frame := Pack(Frame{ID: RxConnectOnGo, Payload: []byte{0x00, 0x01, 0x02}})
+	go func() {
+		_, _ = b.Write([]byte{0x00}) // desync byte
+		_, _ = b.Write(frame)
+	}()
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("frame after desync byte never dispatched")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if rxCount == 0 {
+		t.Error("OnRx never fired")
+	}
+}
+
+// TestReadLoopDecodeErrorResync feeds a frame with a bad checksum so
+// Unpack returns ErrBadChecksum; the reader logs a decode error, drops
+// one byte, and keeps scanning. A following valid frame must still be
+// dispatched. The bad frame is padded > 64 bytes so the min() helper in
+// the decode-error HexDump path is exercised.
+func TestReadLoopDecodeErrorResync(t *testing.T) {
+	a, b := net.Pipe()
+	defer func() { _ = a.Close() }()
+	defer func() { _ = b.Close() }()
+
+	cli := NewClientFromConn(a, quietLogger(), ClientConfig{WireHexLog: boolPtr(false)})
+	defer func() { _ = cli.Close() }()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	cli.Subscribe(func(f Frame) {
+		if f.ID == RxConnectOnGo {
+			wg.Done()
+		}
+	})
+
+	// Build a long SOM-led buffer that decodes as an unknown/short
+	// command so Unpack errors and the reader drops bytes one at a
+	// time. Use a known-command frame with a corrupted checksum, padded
+	// with trailing junk > 64 bytes so HexDump's min(len,64) clamp runs.
+	bad := Pack(Frame{ID: RxConnectOnGo, Payload: []byte{0x00, 0x01, 0x02}})
+	bad[len(bad)-1] ^= 0x7F // corrupt checksum → ErrBadChecksum
+	junk := make([]byte, 80) // > 64 so min() picks 64
+	good := Pack(Frame{ID: RxConnectOnGo, Payload: []byte{0x03, 0x04, 0x05}})
+
+	go func() {
+		_, _ = b.Write(bad)
+		_, _ = b.Write(junk)
+		_, _ = b.Write(good)
+	}()
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("valid frame after decode error never dispatched")
+	}
+}
+
+// TestDispatchReplySlotFilled covers the "reply slot already filled"
+// fall-through arm of dispatch: a matched frame whose waiter.reply
+// channel is already full falls through to the async listeners instead
+// of blocking. We pre-fill the reply channel, then drive a matching
+// frame through dispatch and assert a listener still receives it.
+func TestDispatchReplySlotFilled(t *testing.T) {
+	a, b := net.Pipe()
+	defer func() { _ = a.Close() }()
+	defer func() { _ = b.Close() }()
+	cli := NewClientFromConn(a, quietLogger(), ClientConfig{WireHexLog: boolPtr(false)})
+	defer func() { _ = cli.Close() }()
+
+	// Install a pending waiter whose reply channel is already full, with
+	// a matcher that matches everything.
+	waiter := &pendingWaiter{
+		match: func(Frame) bool { return true },
+		reply: make(chan replyResult, 1),
+	}
+	waiter.reply <- replyResult{} // pre-fill so the select hits default
+	cli.mu.Lock()
+	cli.pending = waiter
+	cli.mu.Unlock()
+
+	got := make(chan Frame, 1)
+	cli.Subscribe(func(f Frame) { got <- f })
+
+	cli.dispatch(Frame{ID: RxConnectOnGo, Payload: []byte{0, 1, 2}})
+	select {
+	case f := <-got:
+		if f.ID != RxConnectOnGo {
+			t.Errorf("listener got %#x; want RxConnectOnGo", f.ID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("matched-but-full frame did not fall through to listeners")
+	}
+}
+
+// boolPtr is a tiny helper for the *bool WireHexLog config knob.
+func boolPtr(b bool) *bool { return &b }
+
+// waitFor spins until cond() is true or a 2s deadline elapses.
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("waitFor: condition never became true")
+}

--- a/internal/probel-sw02p/codec/decode_error_paths_test.go
+++ b/internal/probel-sw02p/codec/decode_error_paths_test.go
@@ -1,0 +1,171 @@
+package codec
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+// TestDecodersRejectWrongID exercises the ErrWrongCommand guard on
+// every per-command decoder that the coverage report flagged as
+// missing its wrong-ID arm. Each decoder is handed a frame whose ID is
+// some OTHER command byte (the request/response sibling) so the very
+// first guard fires. The payload is sized correctly so only the ID
+// mismatch — not a length check — is the rejection cause.
+func TestDecodersRejectWrongID(t *testing.T) {
+	// wrongID is any command byte different from the one the decoder
+	// expects; pad is a payload long enough to clear the length guard
+	// (so the ID guard is unambiguously the one firing).
+	cases := []struct {
+		name    string
+		wrongID CommandID
+		pad     int
+		decode  func(Frame) error
+	}{
+		{"DecodeGo", TxGoDoneAck, 1, func(f Frame) error { _, e := DecodeGo(f); return e }},
+		{"DecodeGoGroupSalvo", RxGo, 2, func(f Frame) error { _, e := DecodeGoGroupSalvo(f); return e }},
+		{"DecodeConnectOnGoGroupSalvo", RxConnectOnGo, 4, func(f Frame) error { _, e := DecodeConnectOnGoGroupSalvo(f); return e }},
+		{"DecodeExtendedConnectOnGoGroupSalvo", RxConnectOnGoGroupSalvo, 5, func(f Frame) error { _, e := DecodeExtendedConnectOnGoGroupSalvo(f); return e }},
+		{"DecodeConnected", TxTally, 3, func(f Frame) error { _, e := DecodeConnected(f); return e }},
+		{"DecodeGoDoneAck", RxGo, 1, func(f Frame) error { _, e := DecodeGoDoneAck(f); return e }},
+		{"DecodeConnectOnGoGroupSalvoAck", RxConnectOnGoGroupSalvo, 4, func(f Frame) error { _, e := DecodeConnectOnGoGroupSalvoAck(f); return e }},
+		{"DecodeGoDoneGroupSalvoAck", RxGoGroupSalvo, 2, func(f Frame) error { _, e := DecodeGoDoneGroupSalvoAck(f); return e }},
+		{"DecodeExtendedConnectOnGoGroupSalvoAck", RxExtendedConnectOnGoGroupSalvo, 5, func(f Frame) error { _, e := DecodeExtendedConnectOnGoGroupSalvoAck(f); return e }},
+		{"DecodeExtendedConnected", RxExtendedConnect, 5, func(f Frame) error { _, e := DecodeExtendedConnected(f); return e }},
+		{"DecodeExtendedProtectConnected", TxExtendedProtectDisconnected, 5, func(f Frame) error { _, e := DecodeExtendedProtectConnected(f); return e }},
+		{"DecodeExtendedProtectDisconnected", TxExtendedProtectConnected, 5, func(f Frame) error { _, e := DecodeExtendedProtectDisconnected(f); return e }},
+		{"DecodeSourceLockStatusResponse", TxRouterConfigResponse1, 4, func(f Frame) error { _, e := DecodeSourceLockStatusResponse(f); return e }},
+		{"DecodeRouterConfigResponse1", TxSourceLockStatusResponse, 4, func(f Frame) error { _, e := DecodeRouterConfigResponse1(f); return e }},
+		{"DecodeRouterConfigResponse2", TxRouterConfigResponse1, 4, func(f Frame) error { _, e := DecodeRouterConfigResponse2(f); return e }},
+		{"DecodeExtendedProtectTallyDump", TxRouterConfigResponse2, 1, func(f Frame) error { _, e := DecodeExtendedProtectTallyDump(f); return e }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := Frame{ID: tc.wrongID, Payload: make([]byte, tc.pad)}
+			if err := tc.decode(f); !errors.Is(err, ErrWrongCommand) {
+				t.Errorf("%s wrong-ID: got %v; want ErrWrongCommand", tc.name, err)
+			}
+		})
+	}
+}
+
+// TestDecodersRejectShortPayload exercises the ErrShortPayload guard on
+// every fixed-length decoder flagged by the coverage report. Each
+// decoder is handed a correctly-typed frame whose payload is one byte
+// short of the spec'd minimum, so the length guard — not the ID guard —
+// is the rejection cause.
+func TestDecodersRejectShortPayload(t *testing.T) {
+	cases := []struct {
+		name    string
+		id      CommandID
+		shortTo int // payload length one below the required minimum
+		decode  func(Frame) error
+	}{
+		{"DecodeGo", RxGo, PayloadLenGo - 1, func(f Frame) error { _, e := DecodeGo(f); return e }},
+		{"DecodeGoGroupSalvo", RxGoGroupSalvo, PayloadLenGoGroupSalvo - 1, func(f Frame) error { _, e := DecodeGoGroupSalvo(f); return e }},
+		{"DecodeConnectOnGoGroupSalvo", RxConnectOnGoGroupSalvo, PayloadLenConnectOnGoGroupSalvo - 1, func(f Frame) error { _, e := DecodeConnectOnGoGroupSalvo(f); return e }},
+		{"DecodeExtendedConnectOnGoGroupSalvo", RxExtendedConnectOnGoGroupSalvo, PayloadLenExtendedConnectOnGoGroupSalvo - 1, func(f Frame) error { _, e := DecodeExtendedConnectOnGoGroupSalvo(f); return e }},
+		{"DecodeConnected", TxCrosspointConnected, PayloadLenConnected - 1, func(f Frame) error { _, e := DecodeConnected(f); return e }},
+		{"DecodeConnectOnGoAck", TxConnectOnGoAck, PayloadLenConnectOnGoAck - 1, func(f Frame) error { _, e := DecodeConnectOnGoAck(f); return e }},
+		{"DecodeGoDoneAck", TxGoDoneAck, PayloadLenGoDoneAck - 1, func(f Frame) error { _, e := DecodeGoDoneAck(f); return e }},
+		{"DecodeConnectOnGoGroupSalvoAck", TxConnectOnGoGroupSalvoAck, PayloadLenConnectOnGoGroupSalvoAck - 1, func(f Frame) error { _, e := DecodeConnectOnGoGroupSalvoAck(f); return e }},
+		{"DecodeGoDoneGroupSalvoAck", TxGoDoneGroupSalvoAck, PayloadLenGoDoneGroupSalvoAck - 1, func(f Frame) error { _, e := DecodeGoDoneGroupSalvoAck(f); return e }},
+		{"DecodeExtendedConnectOnGoGroupSalvoAck", TxExtendedConnectOnGoGroupSalvoAck, PayloadLenExtendedConnectOnGoGroupSalvoAck - 1, func(f Frame) error { _, e := DecodeExtendedConnectOnGoGroupSalvoAck(f); return e }},
+		{"DecodeExtendedConnected", TxExtendedConnected, PayloadLenExtendedConnected - 1, func(f Frame) error { _, e := DecodeExtendedConnected(f); return e }},
+		{"DecodeExtendedProtectConnected", TxExtendedProtectConnected, PayloadLenExtendedProtectConnected - 1, func(f Frame) error { _, e := DecodeExtendedProtectConnected(f); return e }},
+		{"DecodeExtendedProtectDisconnected", TxExtendedProtectDisconnected, PayloadLenExtendedProtectDisconnected - 1, func(f Frame) error { _, e := DecodeExtendedProtectDisconnected(f); return e }},
+		// Variable-length: short header (< 2 / < 4 bytes) trips the
+		// minimum-length guard before any size math.
+		{"DecodeSourceLockStatusResponse", TxSourceLockStatusResponse, 1, func(f Frame) error { _, e := DecodeSourceLockStatusResponse(f); return e }},
+		{"DecodeRouterConfigResponse1", TxRouterConfigResponse1, RouterConfigLevelMapBytes - 1, func(f Frame) error { _, e := DecodeRouterConfigResponse1(f); return e }},
+		{"DecodeRouterConfigResponse2", TxRouterConfigResponse2, RouterConfigLevelMapBytes - 1, func(f Frame) error { _, e := DecodeRouterConfigResponse2(f); return e }},
+		{"DecodeExtendedProtectTallyDump", TxExtendedProtectTallyDump, 0, func(f Frame) error { _, e := DecodeExtendedProtectTallyDump(f); return e }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := Frame{ID: tc.id, Payload: make([]byte, tc.shortTo)}
+			if err := tc.decode(f); !errors.Is(err, ErrShortPayload) {
+				t.Errorf("%s short: got %v; want ErrShortPayload", tc.name, err)
+			}
+		})
+	}
+}
+
+// TestEncodersBadSourceFlag pins the Multiplier bit-3 "bad source" arm
+// of the narrow §3.2.3-layout encoders (tx 03 TALLY, tx 04 CONNECTED,
+// rx 35 CONNECT ON GO GROUP SALVO). §3.2.3: bit 3 of the Multiplier is
+// the bad-source flag; setting BadSource must set 0x08 and survive a
+// round-trip.
+func TestEncodersBadSourceFlag(t *testing.T) {
+	t.Run("tally", func(t *testing.T) {
+		f := EncodeTally(TallyParams{Destination: 1, Source: 2, BadSource: true})
+		// Multiplier = 0x08, Dst=0x01, Src=0x02.
+		want := []byte{0x08, 0x01, 0x02}
+		if !bytes.Equal(f.Payload, want) {
+			t.Fatalf("payload = %X; want %X", f.Payload, want)
+		}
+		got, err := DecodeTally(f)
+		if err != nil {
+			t.Fatalf("DecodeTally: %v", err)
+		}
+		if !got.BadSource || got.Destination != 1 || got.Source != 2 {
+			t.Errorf("decoded = %+v; want dst=1 src=2 badSource=true", got)
+		}
+	})
+
+	t.Run("connected", func(t *testing.T) {
+		f := EncodeConnected(ConnectedParams{Destination: 1, Source: 2, BadSource: true})
+		want := []byte{0x08, 0x01, 0x02}
+		if !bytes.Equal(f.Payload, want) {
+			t.Fatalf("payload = %X; want %X", f.Payload, want)
+		}
+		got, err := DecodeConnected(f)
+		if err != nil {
+			t.Fatalf("DecodeConnected: %v", err)
+		}
+		if !got.BadSource {
+			t.Errorf("decoded BadSource=false; want true (%+v)", got)
+		}
+	})
+
+	t.Run("connect_on_go_group_salvo", func(t *testing.T) {
+		f := EncodeConnectOnGoGroupSalvo(ConnectOnGoGroupSalvoParams{
+			Destination: 1, Source: 2, SalvoID: 5, BadSource: true,
+		})
+		// Multiplier=0x08 Dst=0x01 Src=0x02 Salvo=0x05.
+		want := []byte{0x08, 0x01, 0x02, 0x05}
+		if !bytes.Equal(f.Payload, want) {
+			t.Fatalf("payload = %X; want %X", f.Payload, want)
+		}
+		got, err := DecodeConnectOnGoGroupSalvo(f)
+		if err != nil {
+			t.Fatalf("DecodeConnectOnGoGroupSalvo: %v", err)
+		}
+		if !got.BadSource || got.SalvoID != 5 {
+			t.Errorf("decoded = %+v; want salvo=5 badSource=true", got)
+		}
+	})
+}
+
+// TestEncodeExtendedConnectedStatusBits pins the tx 68 Status byte arms
+// (§3.2.50): bit 0 = crosspoint-update-disabled, bit 1 = bad-source.
+// EncodeExtendedConnected sets these from UpdateOff / BadSource — the
+// flagged-true paths were uncovered.
+func TestEncodeExtendedConnectedStatusBits(t *testing.T) {
+	f := EncodeExtendedConnected(ExtendedConnectedParams{
+		Destination: 5000, Source: 10000, UpdateOff: true, BadSource: true,
+	})
+	// dst=5000 → DIV128=39 (0x27) MOD128=8; src=10000 → DIV128=78 (0x4E) MOD128=16.
+	// Status = bit0|bit1 = 0x03.
+	want := []byte{0x27, 0x08, 0x4E, 0x10, 0x03}
+	if !bytes.Equal(f.Payload, want) {
+		t.Fatalf("payload = %X; want %X", f.Payload, want)
+	}
+	got, err := DecodeExtendedConnected(f)
+	if err != nil {
+		t.Fatalf("DecodeExtendedConnected: %v", err)
+	}
+	if !got.UpdateOff || !got.BadSource || got.Destination != 5000 || got.Source != 10000 {
+		t.Errorf("decoded = %+v; want dst=5000 src=10000 updateOff+badSource", got)
+	}
+}

--- a/internal/probel-sw02p/codec/framer_unpack_test.go
+++ b/internal/probel-sw02p/codec/framer_unpack_test.go
@@ -1,0 +1,71 @@
+package codec
+
+import (
+	"errors"
+	"io"
+	"testing"
+)
+
+// TestUnpackVariableLenNeedsMoreBytes covers the isVariableLenCommand
+// true arm of Unpack: a known variable-length command (tx 100 Extended
+// PROTECT TALLY DUMP) whose MESSAGE bytes have not yet fully arrived
+// must return io.ErrUnexpectedEOF (keep reading), NOT ErrUnknownCommand.
+//
+// The Count byte declares 5 entries (1 + 4*5 = 21 MESSAGE bytes) but
+// only the Count byte is buffered, so PayloadSize returns the full size
+// and the want-length check trips io.ErrUnexpectedEOF.
+func TestUnpackVariableLenNeedsMoreBytes(t *testing.T) {
+	// SOM + cmd(100=0x64) + Count=5 + a stray byte → 4 bytes total, far
+	// short of the 1+1+21+1 = 24 the dump needs.
+	buf := []byte{SOM, 0x64, 0x05, 0x00}
+	_, _, err := Unpack(buf)
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Errorf("partial tx100: got %v; want io.ErrUnexpectedEOF", err)
+	}
+}
+
+// TestUnpackVariableLenSizerNotReady covers the other isVariableLenCommand
+// arm: a variable-length command whose size cannot even be computed yet
+// because the length-determining header byte is missing. tx 100 with no
+// Count byte buffered → tallyDumpPayloadSize returns (0,false) →
+// isVariableLenCommand true → io.ErrUnexpectedEOF.
+func TestUnpackVariableLenSizerNotReady(t *testing.T) {
+	// Only SOM + cmd + one trailing byte; the Count peek is buf[2:] = 1
+	// byte, which IS enough for tallyDumpPayloadSize. Use tx 076 instead,
+	// whose sizer needs 4 header bytes — give it fewer.
+	buf := []byte{SOM, 0x4C, 0x00, 0x00} // tx076, only 2 of 4 map bytes
+	_, _, err := Unpack(buf)
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Errorf("partial tx076 header: got %v; want io.ErrUnexpectedEOF", err)
+	}
+}
+
+// TestUnpackBadChecksum covers the ErrBadChecksum arm of Unpack on a
+// fully-buffered, known fixed-length frame whose trailing checksum byte
+// has been corrupted.
+func TestUnpackBadChecksum(t *testing.T) {
+	wire := Pack(Frame{ID: RxConnectOnGo, Payload: []byte{0x00, 0x01, 0x02}})
+	wire[len(wire)-1] ^= 0x01 // flip a checksum bit
+	_, _, err := Unpack(wire)
+	if !errors.Is(err, ErrBadChecksum) {
+		t.Errorf("corrupt checksum: got %v; want ErrBadChecksum", err)
+	}
+}
+
+// TestUnpackBadSOM covers the ErrBadSOM arm of Unpack (leading byte not
+// 0xFF).
+func TestUnpackBadSOM(t *testing.T) {
+	_, _, err := Unpack([]byte{0x00, 0x06, 0x00, 0x7A})
+	if !errors.Is(err, ErrBadSOM) {
+		t.Errorf("bad SOM: got %v; want ErrBadSOM", err)
+	}
+}
+
+// TestUnpackTooShort covers the < 3 byte minimum arm of Unpack.
+func TestUnpackTooShort(t *testing.T) {
+	for _, buf := range [][]byte{nil, {SOM}, {SOM, 0x06}} {
+		if _, _, err := Unpack(buf); !errors.Is(err, io.ErrUnexpectedEOF) {
+			t.Errorf("Unpack(%X): got %v; want io.ErrUnexpectedEOF", buf, err)
+		}
+	}
+}

--- a/internal/probel-sw02p/codec/varlen_decode_test.go
+++ b/internal/probel-sw02p/codec/varlen_decode_test.go
@@ -1,0 +1,169 @@
+package codec
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestRouterConfigResponse1EntriesTruncated exercises the SECOND
+// ErrShortPayload guard in DecodeRouterConfigResponse1: the 4-byte
+// level map declares N levels but fewer than 4*N entry bytes follow.
+// §3.2.58 ties the per-level entry count to the level-map popcount, so
+// a frame whose entry region is short is malformed.
+func TestRouterConfigResponse1EntriesTruncated(t *testing.T) {
+	// Level map with two bits set → 2 entries (8 bytes) expected, but
+	// supply only the 4-byte map + 4 bytes (1 entry's worth).
+	hdr := packLevelMap((1 << 0) | (1 << 1))
+	payload := append(hdr[:], 0x00, 0x01, 0x00, 0x01) // only one entry follows
+	f := Frame{ID: TxRouterConfigResponse1, Payload: payload}
+	if _, err := DecodeRouterConfigResponse1(f); !errors.Is(err, ErrShortPayload) {
+		t.Errorf("got %v; want ErrShortPayload", err)
+	}
+}
+
+// TestRouterConfigResponse2EntriesTruncated exercises the second
+// ErrShortPayload guard in DecodeRouterConfigResponse2 (10-byte
+// entries per §3.2.59).
+func TestRouterConfigResponse2EntriesTruncated(t *testing.T) {
+	hdr := packLevelMap(1 << 0) // one level → 10 entry bytes expected
+	payload := append(hdr[:], 0x00, 0x01, 0x00, 0x01) // only 4 of 10
+	f := Frame{ID: TxRouterConfigResponse2, Payload: payload}
+	if _, err := DecodeRouterConfigResponse2(f); !errors.Is(err, ErrShortPayload) {
+		t.Errorf("got %v; want ErrShortPayload", err)
+	}
+}
+
+// TestRouterConfigResponse2PayloadSizeShortHeader covers the
+// (0, false) early-return arm of routerConfigResponse2PayloadSize when
+// fewer than the 4 level-map bytes have been buffered — the stream
+// scanner must keep reading. Driven through Unpack with a truncated
+// frame so we exercise the real call path.
+func TestRouterConfigResponse2PayloadSizeShortHeader(t *testing.T) {
+	// Build a valid tx 077 frame, then hand Unpack only SOM + CMD + 2
+	// header bytes: PayloadSize → routerConfigResponse2PayloadSize sees
+	// a 2-byte peek (< 4) → (0,false) → variable-len path returns
+	// io.ErrUnexpectedEOF.
+	p := RouterConfigResponse2Params{
+		LevelMap: 1 << 0,
+		Levels:   []RouterConfigResponse2LevelEntry{{NumDestinations: 4, NumSources: 4}},
+	}
+	wire := Pack(EncodeRouterConfigResponse2(p))
+	if _, _, err := Unpack(wire[:4]); err == nil {
+		t.Errorf("truncated tx077: got nil err; want io.ErrUnexpectedEOF")
+	}
+}
+
+// TestRouterConfigResponse1PayloadSizeShortHeader mirrors the above for
+// tx 076's size helper.
+func TestRouterConfigResponse1PayloadSizeShortHeader(t *testing.T) {
+	p := RouterConfigResponse1Params{
+		LevelMap: 1 << 0,
+		Levels:   []RouterConfigResponse1LevelEntry{{NumDestinations: 4, NumSources: 4}},
+	}
+	wire := Pack(EncodeRouterConfigResponse1(p))
+	if _, _, err := Unpack(wire[:4]); err == nil {
+		t.Errorf("truncated tx076: got nil err; want io.ErrUnexpectedEOF")
+	}
+}
+
+// TestSourceLockResponseHeaderDisagrees exercises the second
+// ErrShortPayload guard in DecodeSourceLockStatusResponse: bytes 1-2
+// self-declare the total MESSAGE length (§3.2.17); if that declaration
+// disagrees with the actual payload length the frame is malformed.
+func TestSourceLockResponseHeaderDisagrees(t *testing.T) {
+	// Declare a total of 6 bytes but supply only 4 (2 header + 2 bitmap).
+	f := Frame{ID: TxSourceLockStatusResponse, Payload: []byte{0x00, 0x06, 0x00, 0x00}}
+	if _, err := DecodeSourceLockStatusResponse(f); !errors.Is(err, ErrShortPayload) {
+		t.Errorf("got %v; want ErrShortPayload", err)
+	}
+}
+
+// TestSourceLockResponsePayloadSizeShortHeader covers the (0, false)
+// early-return arm of sourceLockStatusResponsePayloadSize when fewer
+// than the 2 header bytes are buffered.
+func TestSourceLockResponsePayloadSizeShortHeader(t *testing.T) {
+	got, ok := sourceLockStatusResponsePayloadSize([]byte{0x00})
+	if ok || got != 0 {
+		t.Errorf("short header: got (%d,%v); want (0,false)", got, ok)
+	}
+}
+
+// TestExtendedProtectTallyDumpEntriesTruncated exercises the second
+// ErrShortPayload guard in DecodeExtendedProtectTallyDump: the leading
+// Count byte declares N entries but fewer than 4*N entry bytes follow
+// (§3.2.64).
+func TestExtendedProtectTallyDumpEntriesTruncated(t *testing.T) {
+	// Count=2 → 8 entry bytes expected; supply only 4.
+	f := Frame{ID: TxExtendedProtectTallyDump, Payload: []byte{0x02, 0x00, 0x00, 0x00, 0x00}}
+	if _, err := DecodeExtendedProtectTallyDump(f); !errors.Is(err, ErrShortPayload) {
+		t.Errorf("got %v; want ErrShortPayload", err)
+	}
+}
+
+// TestTallyDumpPayloadSizeShortHeader covers the (0, false)
+// early-return arm of tallyDumpPayloadSize when the Count byte has not
+// arrived yet.
+func TestTallyDumpPayloadSizeShortHeader(t *testing.T) {
+	got, ok := tallyDumpPayloadSize(nil)
+	if ok || got != 0 {
+		t.Errorf("empty peek: got (%d,%v); want (0,false)", got, ok)
+	}
+}
+
+// TestTallyDumpPayloadSizeVariants pins the three sizing arms of
+// tallyDumpPayloadSize against §3.2.64:
+//   - Count=0   → 1 byte (count only, empty dump)
+//   - Count=127 → 1 byte (AURORA reset sentinel, no entries)
+//   - Count=N   → 1 + 4*N bytes
+func TestTallyDumpPayloadSizeVariants(t *testing.T) {
+	cases := []struct {
+		count byte
+		want  int
+	}{
+		{0, 1},
+		{ExtendedProtectTallyDumpResetSentinel, 1},
+		{1, 5},
+		{32, 1 + 4*32},
+	}
+	for _, tc := range cases {
+		got, ok := tallyDumpPayloadSize([]byte{tc.count})
+		if !ok || got != tc.want {
+			t.Errorf("tallyDumpPayloadSize(count=%d) = (%d,%v); want (%d,true)",
+				tc.count, got, ok, tc.want)
+		}
+	}
+}
+
+// TestExtendedProtectTallyDumpResetRoundTrip pins the §3.2.64 reset
+// sentinel (Count=127) on both encode and decode, and the empty-dump
+// (Count=0) path — exercising the Reset branch of the encoder and the
+// sentinel branch of the decoder.
+func TestExtendedProtectTallyDumpResetRoundTrip(t *testing.T) {
+	resetFrame := EncodeExtendedProtectTallyDump(ExtendedProtectTallyDumpParams{Reset: true})
+	if len(resetFrame.Payload) != 1 || resetFrame.Payload[0] != ExtendedProtectTallyDumpResetSentinel {
+		t.Fatalf("reset payload = %X; want single sentinel byte", resetFrame.Payload)
+	}
+	got, err := DecodeExtendedProtectTallyDump(resetFrame)
+	if err != nil {
+		t.Fatalf("Decode reset: %v", err)
+	}
+	if !got.Reset || len(got.Entries) != 0 {
+		t.Errorf("decoded reset = %+v; want Reset=true no entries", got)
+	}
+
+	// Non-reset dump with one entry — exercises the encode + decode
+	// entry loop including the packed Device/Protect byte.
+	entry := ExtendedProtectTallyDumpEntry{
+		Destination: 5000, Device: 300, Protect: ProtectProBel,
+	}
+	f := EncodeExtendedProtectTallyDump(ExtendedProtectTallyDumpParams{
+		Entries: []ExtendedProtectTallyDumpEntry{entry},
+	})
+	dec, err := DecodeExtendedProtectTallyDump(f)
+	if err != nil {
+		t.Fatalf("Decode entry: %v", err)
+	}
+	if dec.Reset || len(dec.Entries) != 1 || dec.Entries[0] != entry {
+		t.Errorf("decoded = %+v; want single entry %+v", dec, entry)
+	}
+}


### PR DESCRIPTION
Roadmap C — probel-sw02p codec 80.5%->100.0%, table-driven SW-P-02 spec tests + locked CI floor. One prod change: applyTCPKeepalive test seams (bcastDialErrHook idiom), behaviour unchanged; no error handling weakened. -race runs in CI. Closes #568.

🤖 Generated with [Claude Code](https://claude.com/claude-code)