### PR TITLE
test(probel-sw02p): provider to 100% coverage (C)

### DIFF
--- a/internal/probel-sw02p/provider/cmd_handler_gaps_test.go
+++ b/internal/probel-sw02p/provider/cmd_handler_gaps_test.go
@@ -1,0 +1,412 @@
+package probelsw02p
+
+import (
+	"testing"
+
+	"dhs/internal/probel-sw02p/codec"
+)
+
+// TestGoHandlerDecodeError confirms a short-payload rx 06 GO flows back
+// as a decode error (ErrShortPayload) with no broadcast — §3.2.8 needs
+// the 1-byte Operation field.
+func TestGoHandlerDecodeError(t *testing.T) {
+	srv := newTestServer(t)
+	bad := codec.Frame{ID: codec.RxGo, Payload: nil}
+	res, err := srv.dispatch(bad)
+	if err == nil {
+		t.Fatal("want ErrShortPayload; got nil")
+	}
+	if res.reply != nil || len(res.broadcast) != 0 {
+		t.Errorf("got reply/broadcast on decode error; want none")
+	}
+}
+
+// TestGoSetSkipsOutOfRangeSlot covers the applyConnectLenient==false
+// branch in handleGo op=Set: a slot whose dst exceeds the declared
+// targetCount (4) is silently skipped — no tx 04 for it, no
+// SalvoEmittedConnected increment — while a valid slot in the same
+// salvo still applies. Only the valid slot + the trailing tx 13 appear.
+func TestGoSetSkipsOutOfRangeSlot(t *testing.T) {
+	srv := newTestServer(t) // targetCount = sourceCount = 4
+
+	// Stage one in-range slot (dst=1 src=2) and one out-of-range
+	// (dst=999) directly on the pending buffer.
+	srv.tree.appendPending(0, 0, pendingSlot{Destination: 1, Source: 2})
+	srv.tree.appendPending(0, 0, pendingSlot{Destination: 999, Source: 2})
+
+	before := srv.profile.Snapshot()[SalvoEmittedConnected]
+	res, err := srv.dispatch(codec.EncodeGo(codec.GoParams{Operation: codec.GoOpSet}))
+	if err != nil {
+		t.Fatalf("dispatch rx 06: %v", err)
+	}
+	// 1 × tx 04 (only the valid slot) + 1 × tx 13.
+	if len(res.broadcast) != 2 {
+		t.Fatalf("broadcast len = %d; want 2 (1 tx04 + 1 tx13)", len(res.broadcast))
+	}
+	if res.broadcast[0].ID != codec.TxCrosspointConnected {
+		t.Errorf("broadcast[0] ID = %#x; want TxCrosspointConnected", res.broadcast[0].ID)
+	}
+	cp, _ := codec.DecodeConnected(res.broadcast[0])
+	if cp.Destination != 1 || cp.Source != 2 {
+		t.Errorf("tx 04 = (%d,%d); want (1,2)", cp.Destination, cp.Source)
+	}
+	if res.broadcast[1].ID != codec.TxGoDoneAck {
+		t.Errorf("broadcast[1] ID = %#x; want TxGoDoneAck", res.broadcast[1].ID)
+	}
+	if after := srv.profile.Snapshot()[SalvoEmittedConnected]; after != before+1 {
+		t.Errorf("SalvoEmittedConnected %d -> %d; want +1 (skipped slot not counted)", before, after)
+	}
+	// Out-of-range slot never recorded.
+	state := srv.tree.matrices[matrixKey{matrix: 0, level: 0}]
+	if _, ok := state.sources[999]; ok {
+		t.Errorf("tree[999] recorded; want absent (skipped)")
+	}
+}
+
+// TestGoUnknownOperationAbsorbsAndAcks covers the third arm of
+// handleGo: an Operation byte that is neither 0x00 (Set) nor 0x01
+// (Clear). The handler absorbs it via HandlerDecodeFailed and still
+// replies with a neutral tx 13 GO DONE ACK (op=Set) so the controller
+// does not hang. No tree mutation, no tx 04.
+func TestGoUnknownOperationAbsorbsAndAcks(t *testing.T) {
+	srv := newTestServer(t)
+
+	// Stage a slot first; the unknown-op path drains pending but must
+	// NOT apply it.
+	srv.tree.appendPending(0, 0, pendingSlot{Destination: 1, Source: 2})
+	before := srv.profile.Snapshot()[HandlerDecodeFailed]
+
+	// Operation = 0x02 (unknown). Build the frame directly — EncodeGo
+	// would coerce only known ops; a raw 1-byte payload exercises the
+	// unknown-op arm.
+	res, err := srv.dispatch(codec.Frame{ID: codec.RxGo, Payload: []byte{0x02}})
+	if err != nil {
+		t.Fatalf("dispatch rx 06 unknown op: %v", err)
+	}
+	if len(res.broadcast) != 1 {
+		t.Fatalf("broadcast len = %d; want 1 (neutral tx 13)", len(res.broadcast))
+	}
+	if res.broadcast[0].ID != codec.TxGoDoneAck {
+		t.Errorf("broadcast[0] ID = %#x; want TxGoDoneAck", res.broadcast[0].ID)
+	}
+	ack, _ := codec.DecodeGoDoneAck(res.broadcast[0])
+	if ack.Operation != codec.GoOpSet {
+		t.Errorf("neutral ack op = %#x; want GoOpSet", ack.Operation)
+	}
+	if after := srv.profile.Snapshot()[HandlerDecodeFailed]; after != before+1 {
+		t.Errorf("HandlerDecodeFailed %d -> %d; want +1", before, after)
+	}
+	// Pending was drained but never applied.
+	state := srv.tree.matrices[matrixKey{matrix: 0, level: 0}]
+	if _, ok := state.sources[1]; ok {
+		t.Errorf("tree[1] applied on unknown-op path; want untouched")
+	}
+}
+
+// TestGoGroupSalvoHandlerDecodeError confirms a short-payload rx 36
+// flows back as a decode error — §3.2.37 needs 2 MESSAGE bytes.
+func TestGoGroupSalvoHandlerDecodeError(t *testing.T) {
+	srv := newTestServer(t)
+	bad := codec.Frame{ID: codec.RxGoGroupSalvo, Payload: []byte{0x00}} // 1 byte
+	res, err := srv.dispatch(bad)
+	if err == nil {
+		t.Fatal("want ErrShortPayload; got nil")
+	}
+	if res.reply != nil || len(res.broadcast) != 0 {
+		t.Errorf("got reply/broadcast on decode error; want none")
+	}
+}
+
+// TestGoGroupSalvoSetSkipsOutOfRangeSlot covers the
+// applyConnectLenient==false skip inside handleGoGroupSalvo op=Set.
+func TestGoGroupSalvoSetSkipsOutOfRangeSlot(t *testing.T) {
+	srv := newTestServer(t)
+
+	srv.tree.appendPendingGroup(0, 0, 3, pendingSlot{Destination: 1, Source: 2})
+	srv.tree.appendPendingGroup(0, 0, 3, pendingSlot{Destination: 999, Source: 2})
+
+	before := srv.profile.Snapshot()[SalvoEmittedConnected]
+	res, err := srv.dispatch(codec.EncodeGoGroupSalvo(codec.GoGroupSalvoParams{
+		Operation: codec.GoOpSet, SalvoID: 3,
+	}))
+	if err != nil {
+		t.Fatalf("dispatch rx 36: %v", err)
+	}
+	// 1 × tx 04 + 1 × tx 38.
+	if len(res.broadcast) != 2 {
+		t.Fatalf("broadcast len = %d; want 2", len(res.broadcast))
+	}
+	ack, _ := codec.DecodeGoDoneGroupSalvoAck(res.broadcast[1])
+	if ack.Result != codec.GoGroupResultSet || ack.SalvoID != 3 {
+		t.Errorf("ack = %+v; want Result=Set SalvoID=3", ack)
+	}
+	if after := srv.profile.Snapshot()[SalvoEmittedConnected]; after != before+1 {
+		t.Errorf("SalvoEmittedConnected %d -> %d; want +1", before, after)
+	}
+}
+
+// TestGoGroupSalvoClearDrainsNonEmptyGroup covers the op=Clear arm with
+// a populated SalvoID → Result=Cleared, no tx 04, no tree mutation.
+func TestGoGroupSalvoClearDrainsNonEmptyGroup(t *testing.T) {
+	srv := newTestServer(t)
+
+	srv.tree.appendPendingGroup(0, 0, 4, pendingSlot{Destination: 1, Source: 2})
+	before := srv.profile.Snapshot()[SalvoEmittedConnected]
+
+	res, err := srv.dispatch(codec.EncodeGoGroupSalvo(codec.GoGroupSalvoParams{
+		Operation: codec.GoOpClear, SalvoID: 4,
+	}))
+	if err != nil {
+		t.Fatalf("dispatch rx 36 clear: %v", err)
+	}
+	if len(res.broadcast) != 1 {
+		t.Fatalf("broadcast len = %d; want 1 (tx 38 only)", len(res.broadcast))
+	}
+	ack, _ := codec.DecodeGoDoneGroupSalvoAck(res.broadcast[0])
+	if ack.Result != codec.GoGroupResultCleared || ack.SalvoID != 4 {
+		t.Errorf("ack = %+v; want Result=Cleared SalvoID=4", ack)
+	}
+	// No tree mutation on clear.
+	state := srv.tree.matrices[matrixKey{matrix: 0, level: 0}]
+	if _, ok := state.sources[1]; ok {
+		t.Errorf("clear path applied slot; want untouched")
+	}
+	if after := srv.profile.Snapshot()[SalvoEmittedConnected]; after != before {
+		t.Errorf("SalvoEmittedConnected moved on clear: %d -> %d", before, after)
+	}
+}
+
+// TestGoGroupSalvoClearEmptyGroupReportsEmpty covers the op=Clear arm
+// when the SalvoID has no staged slots → Result=Empty.
+func TestGoGroupSalvoClearEmptyGroupReportsEmpty(t *testing.T) {
+	srv := newTestServer(t)
+	res, err := srv.dispatch(codec.EncodeGoGroupSalvo(codec.GoGroupSalvoParams{
+		Operation: codec.GoOpClear, SalvoID: 77,
+	}))
+	if err != nil {
+		t.Fatalf("dispatch rx 36 clear empty: %v", err)
+	}
+	if len(res.broadcast) != 1 {
+		t.Fatalf("broadcast len = %d; want 1", len(res.broadcast))
+	}
+	ack, _ := codec.DecodeGoDoneGroupSalvoAck(res.broadcast[0])
+	if ack.Result != codec.GoGroupResultEmpty {
+		t.Errorf("Result = %#x; want GoGroupResultEmpty", ack.Result)
+	}
+}
+
+// TestGoGroupSalvoUnknownOperationAbsorbsAndAcks covers the third arm
+// of handleGoGroupSalvo: an Operation byte that is neither Set nor
+// Clear is absorbed (HandlerDecodeFailed) and answered with a neutral
+// tx 38 (Result=Empty).
+func TestGoGroupSalvoUnknownOperationAbsorbsAndAcks(t *testing.T) {
+	srv := newTestServer(t)
+
+	srv.tree.appendPendingGroup(0, 0, 5, pendingSlot{Destination: 1, Source: 2})
+	before := srv.profile.Snapshot()[HandlerDecodeFailed]
+
+	// Operation = 0x02 (unknown), SalvoID = 5. Build frame directly:
+	// byte 0 = Operation, byte 1 = SalvoID (per §3.2.37 layout).
+	res, err := srv.dispatch(codec.Frame{ID: codec.RxGoGroupSalvo, Payload: []byte{0x02, 0x05}})
+	if err != nil {
+		t.Fatalf("dispatch rx 36 unknown op: %v", err)
+	}
+	if len(res.broadcast) != 1 {
+		t.Fatalf("broadcast len = %d; want 1 (neutral tx 38)", len(res.broadcast))
+	}
+	ack, _ := codec.DecodeGoDoneGroupSalvoAck(res.broadcast[0])
+	if ack.Result != codec.GoGroupResultEmpty || ack.SalvoID != 5 {
+		t.Errorf("neutral ack = %+v; want Result=Empty SalvoID=5", ack)
+	}
+	if after := srv.profile.Snapshot()[HandlerDecodeFailed]; after != before+1 {
+		t.Errorf("HandlerDecodeFailed %d -> %d; want +1", before, after)
+	}
+}
+
+// TestConnectOnGoGroupSalvoHandlerDecodeError confirms a short-payload
+// rx 35 flows back as a decode error.
+func TestConnectOnGoGroupSalvoHandlerDecodeError(t *testing.T) {
+	srv := newTestServer(t)
+	bad := codec.Frame{ID: codec.RxConnectOnGoGroupSalvo, Payload: []byte{0x00, 0x01, 0x02}} // 3 bytes, want 4
+	res, err := srv.dispatch(bad)
+	if err == nil {
+		t.Fatal("want ErrShortPayload; got nil")
+	}
+	if res.reply != nil {
+		t.Errorf("got reply on decode error; want none")
+	}
+}
+
+// TestExtendedConnectOnGoGroupSalvoHandlerDecodeError confirms a
+// short-payload rx 71 flows back as a decode error.
+func TestExtendedConnectOnGoGroupSalvoHandlerDecodeError(t *testing.T) {
+	srv := newTestServer(t)
+	bad := codec.Frame{ID: codec.RxExtendedConnectOnGoGroupSalvo, Payload: []byte{0x00, 0x01, 0x02, 0x03}} // 4, want 5
+	res, err := srv.dispatch(bad)
+	if err == nil {
+		t.Fatal("want ErrShortPayload; got nil")
+	}
+	if res.reply != nil {
+		t.Errorf("got reply on decode error; want none")
+	}
+}
+
+// TestExtendedConnectOnGoHandlerDecodeError confirms a short-payload
+// rx 69 flows back as a decode error.
+func TestExtendedConnectOnGoHandlerDecodeError(t *testing.T) {
+	srv := newTestServer(t)
+	bad := codec.Frame{ID: codec.RxExtendedConnectOnGo, Payload: []byte{0x00, 0x01, 0x02}} // 3, want 4
+	res, err := srv.dispatch(bad)
+	if err == nil {
+		t.Fatal("want ErrShortPayload; got nil")
+	}
+	if res.reply != nil {
+		t.Errorf("got reply on decode error; want none")
+	}
+}
+
+// TestExtendedInterrogateHandlerDecodeError confirms a short-payload
+// rx 65 flows back as a decode error.
+func TestExtendedInterrogateHandlerDecodeError(t *testing.T) {
+	srv := newTestServer(t)
+	bad := codec.Frame{ID: codec.RxExtendedInterrogate, Payload: []byte{0x00}} // 1, want 2
+	res, err := srv.dispatch(bad)
+	if err == nil {
+		t.Fatal("want ErrShortPayload; got nil")
+	}
+	if res.reply != nil {
+		t.Errorf("got reply on decode error; want none")
+	}
+}
+
+// TestExtendedConnectHandlerDecodeError confirms a short-payload rx 66
+// flows back as a decode error.
+func TestExtendedConnectHandlerDecodeError(t *testing.T) {
+	srv := newTestServer(t)
+	bad := codec.Frame{ID: codec.RxExtendedConnect, Payload: []byte{0x00, 0x01, 0x02}} // 3, want 4
+	res, err := srv.dispatch(bad)
+	if err == nil {
+		t.Fatal("want ErrShortPayload; got nil")
+	}
+	if res.reply != nil || len(res.broadcast) != 0 {
+		t.Errorf("got reply/broadcast on decode error; want none")
+	}
+}
+
+// TestExtendedConnectSkipsOutOfRangeSlot covers the
+// applyConnectLenient==false branch in handleExtendedConnect (rx 66):
+// an unprotected dst outside the declared count is dropped with no
+// tx 68 broadcast.
+func TestExtendedConnectSkipsOutOfRangeSlot(t *testing.T) {
+	srv := newTestServer(t) // targetCount = sourceCount = 4
+	in := codec.EncodeExtendedConnect(codec.ExtendedConnectParams{Destination: 999, Source: 1})
+	res, err := srv.dispatch(in)
+	if err != nil {
+		t.Fatalf("dispatch rx 66: %v", err)
+	}
+	if res.reply != nil || len(res.broadcast) != 0 {
+		t.Errorf("out-of-range rx 66: reply=%+v broadcast=%d; want empty", res.reply, len(res.broadcast))
+	}
+	if _, ok := srv.tree.matrices[matrixKey{matrix: 0, level: 0}].sources[999]; ok {
+		t.Errorf("tree[999] recorded; want absent")
+	}
+}
+
+// TestExtendedProtectConnectHandlerDecodeError confirms a short-payload
+// rx 102 flows back as a decode error.
+func TestExtendedProtectConnectHandlerDecodeError(t *testing.T) {
+	srv := newTestServer(t)
+	bad := codec.Frame{ID: codec.RxExtendedProtectConnect, Payload: []byte{0x00, 0x01, 0x02}} // 3, want 4
+	res, err := srv.dispatch(bad)
+	if err == nil {
+		t.Fatal("want ErrShortPayload; got nil")
+	}
+	if res.reply != nil || len(res.broadcast) != 0 {
+		t.Errorf("got reply/broadcast on decode error; want none")
+	}
+}
+
+// TestDualControllerStatusRequestWrongCommandGuard exercises the
+// decode-error arm of handleDualControllerStatusRequest. The §3.2.45
+// request carries a zero-length MESSAGE, so the decoder has no
+// short-payload arm — the only error it can return is ErrWrongCommand
+// (mismatched ID). dispatch() never routes a wrong ID here, so the
+// guard is reached by calling the handler directly with a mismatched
+// frame, the same way a future direct caller would.
+func TestDualControllerStatusRequestWrongCommandGuard(t *testing.T) {
+	srv := newTestServer(t)
+	res, err := srv.handleDualControllerStatusRequest(codec.Frame{ID: codec.RxInterrogate})
+	if err == nil {
+		t.Fatal("want ErrWrongCommand; got nil")
+	}
+	if res.reply != nil {
+		t.Errorf("got reply on decode error; want none")
+	}
+}
+
+// TestRouterConfigRequestWrongCommandGuard exercises the decode-error
+// arm of handleRouterConfigRequest. Like rx 050, §3.2.57 carries a
+// zero-length MESSAGE so the only decoder error is ErrWrongCommand;
+// reach it via a direct handler call with a mismatched ID.
+func TestRouterConfigRequestWrongCommandGuard(t *testing.T) {
+	srv := newTestServer(t)
+	res, err := srv.handleRouterConfigRequest(codec.Frame{ID: codec.RxInterrogate})
+	if err == nil {
+		t.Fatal("want ErrWrongCommand; got nil")
+	}
+	if res.reply != nil {
+		t.Errorf("got reply on decode error; want none")
+	}
+}
+
+// TestProtectDeviceNameRequestResolvesOwnerName covers the
+// protectEntriesByDevice name-resolution branch in
+// handleProtectDeviceNameRequest: when a protect entry for the queried
+// (non-self) Device Number carries a non-empty OwnerName, the tx 099
+// reply echoes that name rather than the empty fallback.
+func TestProtectDeviceNameRequestResolvesOwnerName(t *testing.T) {
+	srv := newTestServer(t)
+
+	// Seed a protect entry owned by Device 42 with a resolved name.
+	srv.tree.mu.Lock()
+	st := srv.tree.matrices[matrixKey{matrix: 0, level: 0}]
+	if st.protect == nil {
+		st.protect = map[uint16]protectEntry{}
+	}
+	st.protect[1] = protectEntry{
+		State:       codec.ProtectProBel,
+		OwnerDevice: 42,
+		OwnerName:   "VSM-CTRL",
+	}
+	srv.tree.mu.Unlock()
+
+	// Query Device 42 (not the server's self device number).
+	in := codec.EncodeProtectDeviceNameRequest(codec.ProtectDeviceNameRequestParams{Device: 42})
+	res, err := srv.dispatch(in)
+	if err != nil {
+		t.Fatalf("dispatch rx 103: %v", err)
+	}
+	if res.reply == nil || res.reply.ID != codec.TxProtectDeviceNameResponse {
+		t.Fatalf("reply missing / wrong ID: %+v", res.reply)
+	}
+	out, err := codec.DecodeProtectDeviceNameResponse(*res.reply)
+	if err != nil {
+		t.Fatalf("decode tx 099: %v", err)
+	}
+	if out.Device != 42 {
+		t.Errorf("tx 099 Device = %d; want 42", out.Device)
+	}
+	if got := trimName(out.Name); got != "VSM-CTRL" {
+		t.Errorf("tx 099 Name = %q; want %q", got, "VSM-CTRL")
+	}
+}
+
+// trimName strips the space-padding the §3.2.63 encoder applies to the
+// fixed 8-char name field.
+func trimName(s string) string {
+	end := len(s)
+	for end > 0 && s[end-1] == ' ' {
+		end--
+	}
+	return s[:end]
+}

--- a/internal/probel-sw02p/provider/cmd_rx001_interrogate.go
+++ b/internal/probel-sw02p/provider/cmd_rx001_interrogate.go
@@ -16,7 +16,7 @@ import (
 // clear — per-device bad-source tracking is out of scope for this
 // plugin until a real router reports it.
 func (s *server) handleInterrogate(f codec.Frame) (handlerResult, error) {
-	p, err := codec.DecodeInterrogate(f)
+	p, err := decoded(codec.DecodeInterrogate(f))
 	if err != nil {
 		return handlerResult{}, err
 	}

--- a/internal/probel-sw02p/provider/decode_seam.go
+++ b/internal/probel-sw02p/provider/decode_seam.go
@@ -1,0 +1,49 @@
+package probelsw02p
+
+// Test seams for branches that production code paths cannot reach
+// because an upstream layer pre-validates the input. These are the
+// SAME transparent nil-hook-in-prod pattern used elsewhere in the
+// codebase: in production every hook is nil, so `decoded` is a pure
+// passthrough and `treeBuildErr` is always nil — the guarded branches
+// behave exactly as written. Tests set a hook to drive the otherwise
+// dead defensive arm, never to weaken it.
+//
+// Why each seam exists (see provider/CLAUDE.md + codec/framer.go):
+//
+//   - decodeErrHook / decoded: codec.Unpack consults PayloadSize /
+//     PayloadLen and only yields a Frame whose MESSAGE is exactly the
+//     length every per-command codec.DecodeXxx requires. By the time a
+//     frame reaches a handler the only DecodeXxx error possible is
+//     ErrWrongCommand, which dispatch never triggers (it routes by
+//     matching ID). So the handler-decode-error arm in session.run
+//     ("herr != nil") is unreachable from the wire. Routing one
+//     handler's decode through `decoded` lets a test force that error
+//     and prove the session absorbs it (HandlerDecodeFailed) and keeps
+//     reading, without touching the guard body.
+//
+//   - treeBuildErrHook: newTree never returns a non-nil error for any
+//     canonical.Export (it degrades gracefully, returning an empty tree
+//     for nil / malformed input). newServer's "tree build failed"
+//     fallback is therefore defensive-only. The hook lets a test inject
+//     the failure and prove newServer logs + substitutes an empty tree
+//     rather than panicking on a nil tree.
+
+// decodeErrHook, when non-nil, forces the next `decoded` call to return
+// its error instead of the real decode result. Nil in production.
+var decodeErrHook func() error
+
+// decoded routes a per-command codec.DecodeXxx result through the test
+// seam. In production (hook nil) it is an identity passthrough — the
+// (value, err) pair is returned verbatim, so the guard that checks the
+// error behaves exactly as if the codec were called directly. When the
+// hook is set it overrides err, leaving value at its zero/decoded form.
+func decoded[T any](v T, err error) (T, error) {
+	if decodeErrHook != nil {
+		return v, decodeErrHook()
+	}
+	return v, err
+}
+
+// treeBuildErrHook, when non-nil, forces newServer's newTree call to be
+// treated as failed. Nil in production, where newTree never errors.
+var treeBuildErrHook func() error

--- a/internal/probel-sw02p/provider/decode_seam_test.go
+++ b/internal/probel-sw02p/provider/decode_seam_test.go
@@ -1,0 +1,147 @@
+package probelsw02p
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"dhs/internal/export/canonical"
+	"dhs/internal/probel-sw02p/codec"
+)
+
+// TestDecodedPassthrough pins the production (hook == nil) behaviour of
+// the decoded seam: it returns the (value, err) pair verbatim so the
+// guard it feeds is identical to calling the codec directly.
+func TestDecodedPassthrough(t *testing.T) {
+	if decodeErrHook != nil {
+		t.Fatal("decodeErrHook must be nil by default (production passthrough)")
+	}
+	wantErr := errors.New("real decode error")
+	got, err := decoded(GoParamsZero(), wantErr)
+	if !errors.Is(err, wantErr) {
+		t.Errorf("decoded err = %v; want %v (passthrough)", err, wantErr)
+	}
+	_ = got
+
+	v, err := decoded(7, nil)
+	if v != 7 || err != nil {
+		t.Errorf("decoded(7,nil) = (%d,%v); want (7,nil)", v, err)
+	}
+}
+
+// GoParamsZero is a tiny typed-zero helper so the generic decoded call
+// above has a concrete type to instantiate.
+func GoParamsZero() codec.GoParams { return codec.GoParams{} }
+
+// TestSessionRunHandlerDecodeErrorSeam covers session.run's
+// handler-decode-error arm (the "herr != nil" branch). That arm is
+// unreachable from the wire because codec.Unpack pre-validates MESSAGE
+// length, so handleInterrogate's codec.DecodeInterrogate cannot fail on
+// a framed rx 01. The decodeErrHook seam forces that decode to fail for
+// the duration of the test; the session must absorb it
+// (HandlerDecodeFailed + ObserveDecodeError) and keep reading.
+func TestSessionRunHandlerDecodeErrorSeam(t *testing.T) {
+	forced := errors.New("forced handler decode failure")
+	decodeErrHook = func() error { return forced }
+	defer func() { decodeErrHook = nil }()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	srv := newServer(logger, nil)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- srv.serveListener(ctx, ln) }()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	// A well-formed rx 01 INTERROGATE: Unpack succeeds, but the forced
+	// hook makes handleInterrogate's decode return an error, driving the
+	// session's herr != nil arm.
+	in := codec.Pack(codec.EncodeInterrogate(codec.InterrogateParams{Destination: 1}))
+	if _, err := conn.Write(in); err != nil {
+		t.Fatalf("write rx 01: %v", err)
+	}
+
+	// HandlerDecodeFailed must fire; the session must NOT reply.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if srv.profile.Snapshot()[HandlerDecodeFailed] >= 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := srv.profile.Snapshot()[HandlerDecodeFailed]; got < 1 {
+		t.Errorf("HandlerDecodeFailed = %d; want >= 1", got)
+	}
+	if got := srv.metrics.Snapshot().DecodeErrors; got < 1 {
+		t.Errorf("metrics DecodeErrors = %d; want >= 1", got)
+	}
+
+	// Session still alive: clear the hook and prove a follow-up rx 01
+	// now gets a tx 03 TALLY reply.
+	decodeErrHook = nil
+	good := codec.Pack(codec.EncodeInterrogate(codec.InterrogateParams{Destination: 1}))
+	if _, err := conn.Write(good); err != nil {
+		t.Fatalf("write rx 01 #2: %v", err)
+	}
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 0, 32)
+	tmp := make([]byte, 32)
+	var gotReply bool
+	for !gotReply {
+		n, rerr := conn.Read(tmp)
+		if n > 0 {
+			buf = append(buf, tmp[:n]...)
+			if f, _, derr := codec.Unpack(buf); derr == nil && f.ID == codec.TxTally {
+				gotReply = true
+			}
+		}
+		if rerr != nil {
+			break
+		}
+	}
+	if !gotReply {
+		t.Error("session did not survive the forced decode error (no tx 03 after recovery)")
+	}
+
+	cancel()
+	select {
+	case <-serveDone:
+	case <-time.After(2 * time.Second):
+		t.Error("serveListener did not return")
+	}
+}
+
+// TestNewServerTreeBuildFailureSeam covers newServer's defensive
+// "tree build failed" fallback. newTree never returns an error for any
+// canonical.Export, so the fallback is unreachable in production. The
+// treeBuildErrHook seam forces the failure; newServer must log it and
+// substitute an empty (non-nil) tree rather than leaving tree nil.
+func TestNewServerTreeBuildFailureSeam(t *testing.T) {
+	treeBuildErrHook = func() error { return errors.New("forced tree build failure") }
+	defer func() { treeBuildErrHook = nil }()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	srv := newServer(logger, &canonical.Export{Root: &canonical.Node{
+		Header: canonical.Header{Number: 1, Identifier: "root", OID: "1"},
+	}})
+	if srv.tree == nil {
+		t.Fatal("tree = nil after forced build failure; want empty fallback tree")
+	}
+	if srv.tree.Size() != 0 {
+		t.Errorf("fallback tree size = %d; want 0 (empty substitute)", srv.tree.Size())
+	}
+}

--- a/internal/probel-sw02p/provider/server.go
+++ b/internal/probel-sw02p/provider/server.go
@@ -87,6 +87,9 @@ func newServer(logger *slog.Logger, exp *canonical.Export) *server {
 		logger = slog.Default()
 	}
 	t, err := newTree(exp)
+	if treeBuildErrHook != nil {
+		err = treeBuildErrHook()
+	}
 	if err != nil {
 		logger.Error("probel-sw02p provider: tree build failed", slog.String("err", err.Error()))
 		t = &tree{matrices: map[matrixKey]*matrixState{}}

--- a/internal/probel-sw02p/provider/server_lifecycle_test.go
+++ b/internal/probel-sw02p/provider/server_lifecycle_test.go
@@ -1,0 +1,614 @@
+package probelsw02p
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"dhs/internal/probel-sw02p/codec"
+)
+
+// dialServed spins up a server on a loopback listener via serveListener
+// and returns a connected client socket plus a cleanup func. The
+// returned context cancel + server stop run on cleanup.
+func dialServed(t *testing.T) (*server, net.Conn, func()) {
+	t.Helper()
+	srv := newTestServer(t)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- srv.serveListener(ctx, ln) }()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		cancel()
+		t.Fatalf("dial: %v", err)
+	}
+	cleanup := func() {
+		_ = conn.Close()
+		cancel()
+		select {
+		case <-serveDone:
+		case <-time.After(2 * time.Second):
+			t.Error("serveListener did not return after cancel")
+		}
+	}
+	return srv, conn, cleanup
+}
+
+// readFrame reads exactly one SW-P-02 frame from conn with a deadline.
+func readFrame(t *testing.T, conn net.Conn) (codec.Frame, bool) {
+	t.Helper()
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 0, 64)
+	tmp := make([]byte, 64)
+	for {
+		n, err := conn.Read(tmp)
+		if n > 0 {
+			buf = append(buf, tmp[:n]...)
+			if f, _, derr := codec.Unpack(buf); derr == nil {
+				return f, true
+			}
+		}
+		if err != nil {
+			return codec.Frame{}, false
+		}
+	}
+}
+
+// TestSessionRoundTripStatusRequest drives a real rx 07 STATUS REQUEST
+// over a live socket and reads back the tx 09 reply — exercising
+// session.run's read → Unpack → dispatch → write reply path end to end.
+func TestSessionRoundTripStatusRequest(t *testing.T) {
+	_, conn, cleanup := dialServed(t)
+	defer cleanup()
+
+	in := codec.Pack(codec.EncodeStatusRequest(codec.StatusRequestParams{Controller: codec.ControllerLH}))
+	if _, err := conn.Write(in); err != nil {
+		t.Fatalf("write rx 07: %v", err)
+	}
+	f, ok := readFrame(t, conn)
+	if !ok {
+		t.Fatal("no reply frame")
+	}
+	if f.ID != codec.TxStatusResponse2 {
+		t.Errorf("reply ID = %#x; want TxStatusResponse2", f.ID)
+	}
+}
+
+// TestSessionBroadcastReachesSender drives an rx 02 CONNECT, which
+// produces a tx 04 broadcast (no point-to-point reply). The sending
+// session is also a fan-out target (§3.2.6 "all ports"), so it must
+// receive the tx 04 — exercising session.run's broadcast loop + fanOut.
+func TestSessionBroadcastReachesSender(t *testing.T) {
+	_, conn, cleanup := dialServed(t)
+	defer cleanup()
+
+	in := codec.Pack(codec.EncodeConnect(codec.ConnectParams{Destination: 1, Source: 2}))
+	if _, err := conn.Write(in); err != nil {
+		t.Fatalf("write rx 02: %v", err)
+	}
+	f, ok := readFrame(t, conn)
+	if !ok {
+		t.Fatal("no broadcast frame")
+	}
+	if f.ID != codec.TxCrosspointConnected {
+		t.Errorf("broadcast ID = %#x; want TxCrosspointConnected", f.ID)
+	}
+}
+
+// TestSessionDesyncDropsLeadingGarbage feeds a leading non-SOM byte
+// before a valid rx 07 frame. session.run must drop the garbage byte
+// (desync path) and still process the trailing frame.
+func TestSessionDesyncDropsLeadingGarbage(t *testing.T) {
+	_, conn, cleanup := dialServed(t)
+	defer cleanup()
+
+	in := codec.Pack(codec.EncodeStatusRequest(codec.StatusRequestParams{Controller: codec.ControllerLH}))
+	// Prepend three junk (non-0xFF) bytes.
+	garbage := append([]byte{0x00, 0x12, 0x34}, in...)
+	if _, err := conn.Write(garbage); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	f, ok := readFrame(t, conn)
+	if !ok {
+		t.Fatal("no reply after desync recovery")
+	}
+	if f.ID != codec.TxStatusResponse2 {
+		t.Errorf("reply ID = %#x; want TxStatusResponse2", f.ID)
+	}
+}
+
+// TestSessionBadChecksumAbsorbed feeds a frame with a corrupted
+// checksum followed by a valid frame. The bad frame fires the
+// InboundFrameDecodeFailed compliance event and the session resyncs to
+// the valid one — exercising session.run's derr != nil arm.
+func TestSessionBadChecksumAbsorbed(t *testing.T) {
+	srv, conn, cleanup := dialServed(t)
+	defer cleanup()
+
+	bad := codec.Pack(codec.EncodeStatusRequest(codec.StatusRequestParams{Controller: codec.ControllerLH}))
+	bad[len(bad)-1] ^= 0x01 // corrupt checksum (still 7-bit; flips low bit)
+	good := codec.Pack(codec.EncodeStatusRequest(codec.StatusRequestParams{Controller: codec.ControllerRH}))
+	if _, err := conn.Write(append(bad, good...)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	f, ok := readFrame(t, conn)
+	if !ok {
+		t.Fatal("no reply after bad-checksum resync")
+	}
+	if f.ID != codec.TxStatusResponse2 {
+		t.Errorf("reply ID = %#x; want TxStatusResponse2", f.ID)
+	}
+	// The corrupted frame must have been noted.
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		if srv.profile.Snapshot()[InboundFrameDecodeFailed] >= 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := srv.profile.Snapshot()[InboundFrameDecodeFailed]; got < 1 {
+		t.Errorf("InboundFrameDecodeFailed = %d; want >= 1", got)
+	}
+}
+
+// TestServeBindsAndStops covers Serve (the addr-based path) plus Stop:
+// Serve binds a real port, Stop closes the listener, and Serve returns
+// nil (net.ErrClosed is swallowed).
+func TestServeBindsAndStops(t *testing.T) {
+	srv := newTestServer(t)
+	ctx := context.Background()
+
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- srv.Serve(ctx, "127.0.0.1:0") }()
+
+	// Wait until the listener is bound.
+	deadline := time.Now().Add(2 * time.Second)
+	var addr string
+	for time.Now().Before(deadline) {
+		srv.mu.Lock()
+		if srv.listener != nil {
+			addr = srv.listener.Addr().String()
+		}
+		srv.mu.Unlock()
+		if addr != "" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if addr == "" {
+		t.Fatal("Serve never bound a listener")
+	}
+
+	// Open a session so Stop has a session to drop.
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	if err := srv.Stop(); err != nil {
+		t.Errorf("Stop: %v", err)
+	}
+	// Second Stop is idempotent (closed already).
+	if err := srv.Stop(); err != nil {
+		t.Errorf("Stop (2nd) = %v; want nil (idempotent)", err)
+	}
+	select {
+	case err := <-serveDone:
+		if err != nil {
+			t.Errorf("Serve returned %v; want nil after Stop", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("Serve did not return after Stop")
+	}
+}
+
+// TestServeListenError covers Serve's listen-failure arm: an invalid
+// address yields a wrapped error.
+func TestServeListenError(t *testing.T) {
+	srv := newTestServer(t)
+	err := srv.Serve(context.Background(), "256.256.256.256:99999")
+	if err == nil {
+		t.Fatal("Serve(bad addr) = nil; want error")
+	}
+}
+
+// TestStopWithoutListener covers Stop's nil-listener arm: a server that
+// never served has listener == nil, so Stop returns nil.
+func TestStopWithoutListener(t *testing.T) {
+	srv := newTestServer(t)
+	if err := srv.Stop(); err != nil {
+		t.Errorf("Stop(no listener) = %v; want nil", err)
+	}
+}
+
+// TestNewServerNilLogger covers the logger == nil arm of newServer:
+// a nil logger is replaced with slog.Default() and the server still
+// builds.
+func TestNewServerNilLogger(t *testing.T) {
+	srv := newServer(nil, nil)
+	if srv == nil || srv.logger == nil {
+		t.Fatal("newServer(nil,nil) produced nil server/logger")
+	}
+	if srv.tree == nil {
+		t.Error("tree = nil; want non-nil even for nil export")
+	}
+}
+
+// TestSetValueAppliesAndCoerces covers SetValue end to end (the API
+// path): a valid path + int value applies a crosspoint and returns the
+// coerced source.
+func TestSetValueAppliesAndCoerces(t *testing.T) {
+	srv := newTestServer(t) // matrix 0 level 0, counts 4/4
+	out, err := srv.SetValue(context.Background(), "0.0.1", 2)
+	if err != nil {
+		t.Fatalf("SetValue: %v", err)
+	}
+	m, ok := out.(map[string]uint16)
+	if !ok || m["src"] != 2 {
+		t.Errorf("SetValue out = %v; want map[src:2]", out)
+	}
+	if got, ok := srv.tree.matrices[matrixKey{matrix: 0, level: 0}].sources[1]; !ok || got != 2 {
+		t.Errorf("tree[1] = (%d, %v); want (2, true)", got, ok)
+	}
+}
+
+// TestSetValueBadPath covers SetValue's parse-error arm.
+func TestSetValueBadPath(t *testing.T) {
+	srv := newTestServer(t)
+	if _, err := srv.SetValue(context.Background(), "not-a-path", 1); err == nil {
+		t.Error("SetValue(bad path) = nil; want error")
+	}
+}
+
+// TestSetValueBadValue covers SetValue's coerce-error arm.
+func TestSetValueBadValue(t *testing.T) {
+	srv := newTestServer(t)
+	if _, err := srv.SetValue(context.Background(), "0.0.1", struct{}{}); err == nil {
+		t.Error("SetValue(bad value) = nil; want error")
+	}
+}
+
+// TestSetValueApplyError covers SetValue's applyConnect-error arm: a
+// valid path/value whose dst exceeds the declared count fails.
+func TestSetValueApplyError(t *testing.T) {
+	srv := newTestServer(t) // counts 4/4
+	if _, err := srv.SetValue(context.Background(), "0.0.99", 1); err == nil {
+		t.Error("SetValue(dst oob) = nil; want error")
+	}
+}
+
+// TestParseCrosspointPath covers parseCrosspointPath success + both
+// failure arms (malformed + out-of-range).
+func TestParseCrosspointPath(t *testing.T) {
+	m, l, d, err := parseCrosspointPath("2.3.4")
+	if err != nil || m != 2 || l != 3 || d != 4 {
+		t.Errorf("parse(2.3.4) = (%d,%d,%d,%v); want (2,3,4,nil)", m, l, d, err)
+	}
+	if _, _, _, err := parseCrosspointPath("bad"); err == nil {
+		t.Error("parse(bad) = nil; want error")
+	}
+	if _, _, _, err := parseCrosspointPath("999.0.0"); err == nil {
+		t.Error("parse(matrix oob) = nil; want error")
+	}
+	if _, _, _, err := parseCrosspointPath("0.999.0"); err == nil {
+		t.Error("parse(level oob) = nil; want error")
+	}
+	if _, _, _, err := parseCrosspointPath("0.0.99999999"); err == nil {
+		t.Error("parse(dst oob) = nil; want error")
+	}
+}
+
+// TestCoerceSource covers every type arm of coerceSource plus the
+// default error arm.
+func TestCoerceSource(t *testing.T) {
+	cases := []struct {
+		in   any
+		want uint16
+	}{
+		{int(5), 5},
+		{int32(6), 6},
+		{int64(7), 7},
+		{uint16(8), 8},
+		{uint32(9), 9},
+		{uint64(10), 10},
+		{float64(11), 11},
+	}
+	for _, c := range cases {
+		got, err := coerceSource(c.in)
+		if err != nil || got != c.want {
+			t.Errorf("coerceSource(%T %v) = (%d, %v); want (%d, nil)", c.in, c.in, got, err, c.want)
+		}
+	}
+	if _, err := coerceSource("nope"); err == nil {
+		t.Error("coerceSource(string) = nil; want error")
+	}
+}
+
+// TestRemoteAddrNilConn covers the remoteAddr nil-conn guard.
+func TestRemoteAddrNilConn(t *testing.T) {
+	s := &session{}
+	if got := s.remoteAddr(); got != "" {
+		t.Errorf("remoteAddr(nil conn) = %q; want empty", got)
+	}
+}
+
+// TestSessionCloseIdempotent covers session.close: closing once shuts
+// the socket, closing again is a no-op (closed guard).
+func TestSessionCloseIdempotent(t *testing.T) {
+	a, b := net.Pipe()
+	defer func() { _ = b.Close() }()
+	s := &session{conn: a}
+	s.close()
+	if !s.closed {
+		t.Error("session not marked closed after close()")
+	}
+	s.close() // second call hits the early-return guard
+}
+
+// TestFanOutWriteFailureNotesEventAndContinues covers fanOut's
+// write-error arm: a session whose socket is already closed makes the
+// write fail, which fires OutboundWriteFailed and continues to the next
+// session rather than aborting.
+func TestFanOutWriteFailureNotesEventAndContinues(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	srv := newServer(logger, nil)
+
+	// A dead session: pipe with the far end already closed so Write
+	// errors deterministically.
+	a, b := net.Pipe()
+	_ = a.Close()
+	_ = b.Close()
+	dead := &session{conn: a}
+
+	srv.mu.Lock()
+	srv.sessions[dead] = struct{}{}
+	srv.mu.Unlock()
+
+	before := srv.profile.Snapshot()[OutboundWriteFailed]
+	frame := codec.Pack(codec.EncodeStatusRequest(codec.StatusRequestParams{}))
+	srv.fanOut(frame, codec.RxStatusRequest)
+
+	if got := srv.profile.Snapshot()[OutboundWriteFailed]; got != before+1 {
+		t.Errorf("OutboundWriteFailed %d -> %d; want +1", before, got)
+	}
+}
+
+// TestSessionRunReturnsOnCancelledContext covers the ctx.Err() guard
+// at the top of session.run's read loop: a context that is already
+// cancelled makes run return before the first Read.
+func TestSessionRunReturnsOnCancelledContext(t *testing.T) {
+	srv := newTestServer(t)
+	a, b := net.Pipe()
+	defer func() { _ = b.Close() }()
+	sess := newSession(srv, a)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel
+
+	done := make(chan struct{})
+	go func() {
+		sess.run(ctx)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("session.run did not return for cancelled ctx")
+	}
+}
+
+// TestSessionRunReadErrorDebugBranch covers session.run's read-error
+// arm for a non-EOF / non-ErrClosed error: a read deadline that has
+// already elapsed makes conn.Read return a timeout error, which hits
+// the debug-log branch and ends the session.
+func TestSessionRunReadErrorDebugBranch(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	srv := newServer(logger, nil)
+
+	a, b := net.Pipe()
+	defer func() { _ = b.Close() }()
+	// Force Read to fail immediately with a (non-EOF) deadline error.
+	_ = a.SetReadDeadline(time.Now().Add(-time.Second))
+	sess := newSession(srv, a)
+
+	done := make(chan struct{})
+	go func() {
+		sess.run(context.Background())
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("session.run did not return on read error")
+	}
+}
+
+// TestSessionRunPartialFrameWaitsThenCompletes covers the
+// io.ErrUnexpectedEOF "break and read more" arm of session.run: a frame
+// delivered in two writes (header first, then the rest) must still be
+// processed once complete.
+func TestSessionRunPartialFrameWaitsThenCompletes(t *testing.T) {
+	_, conn, cleanup := dialServed(t)
+	defer cleanup()
+
+	in := codec.Pack(codec.EncodeStatusRequest(codec.StatusRequestParams{Controller: codec.ControllerLH}))
+	// Send all but the final (checksum) byte, pause, then the rest.
+	if _, err := conn.Write(in[:len(in)-1]); err != nil {
+		t.Fatalf("write partial: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	if _, err := conn.Write(in[len(in)-1:]); err != nil {
+		t.Fatalf("write tail: %v", err)
+	}
+	f, ok := readFrame(t, conn)
+	if !ok {
+		t.Fatal("no reply after partial-frame reassembly")
+	}
+	if f.ID != codec.TxStatusResponse2 {
+		t.Errorf("reply ID = %#x; want TxStatusResponse2", f.ID)
+	}
+}
+
+// TestSessionRunDebugLoggingPath covers the
+// logger.Enabled(LevelDebug) rx-logging block of session.run by running
+// a session with a debug-level logger and sending a valid frame.
+func TestSessionRunDebugLoggingPath(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	srv := newServer(logger, nil)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- srv.serveListener(ctx, ln) }()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	in := codec.Pack(codec.EncodeStatusRequest(codec.StatusRequestParams{}))
+	if _, err := conn.Write(in); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	f, ok := readFrame(t, conn)
+	if !ok || f.ID != codec.TxStatusResponse2 {
+		t.Fatalf("debug-path round trip failed: ok=%v frame=%+v", ok, f)
+	}
+	cancel()
+	select {
+	case <-serveDone:
+	case <-time.After(2 * time.Second):
+		t.Error("serveListener did not return")
+	}
+}
+
+// TestSessionRunUnsupportedCommandContinues covers session.run's
+// "reply == nil && broadcast empty" arm: a well-framed but unsupported
+// command id is absorbed (UnsupportedCommand event) and the session
+// keeps reading, answering a following supported frame.
+func TestSessionRunUnsupportedCommandContinues(t *testing.T) {
+	srv, conn, cleanup := dialServed(t)
+	defer cleanup()
+
+	// 0x6E (110) is a registered codec command in the catalogue? No —
+	// use a Tx-only command that dispatch has no handler for but which
+	// the codec PayloadLen knows, so Unpack succeeds and dispatch
+	// returns an empty result. tx 04 CONNECTED (TxCrosspointConnected)
+	// has a fixed 3-byte payload and no Rx handler.
+	unsupported := codec.Pack(codec.EncodeConnected(codec.ConnectedParams{Destination: 0, Source: 0}))
+	if _, err := conn.Write(unsupported); err != nil {
+		t.Fatalf("write unsupported: %v", err)
+	}
+	// Follow with a supported rx 07 to prove the session is still alive.
+	good := codec.Pack(codec.EncodeStatusRequest(codec.StatusRequestParams{}))
+	if _, err := conn.Write(good); err != nil {
+		t.Fatalf("write good: %v", err)
+	}
+	f, ok := readFrame(t, conn)
+	if !ok || f.ID != codec.TxStatusResponse2 {
+		t.Fatalf("session did not survive unsupported cmd: ok=%v frame=%+v", ok, f)
+	}
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		if srv.profile.Snapshot()[UnsupportedCommand] >= 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := srv.profile.Snapshot()[UnsupportedCommand]; got < 1 {
+		t.Errorf("UnsupportedCommand = %d; want >= 1", got)
+	}
+}
+
+// errListener is a net.Listener whose Accept returns a fixed non-
+// ErrClosed error, used to drive serveListener's "return err" arm
+// (the path that does NOT swallow net.ErrClosed / context.Canceled).
+type errListener struct{ err error }
+
+func (e errListener) Accept() (net.Conn, error) { return nil, e.err }
+func (e errListener) Close() error              { return nil }
+func (e errListener) Addr() net.Addr            { return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1)} }
+
+// TestServeListenerReturnsAcceptError covers serveListener's non-
+// swallowed error return (line "return err"): an Accept that fails with
+// an error other than net.ErrClosed / context.Canceled propagates out.
+func TestServeListenerReturnsAcceptError(t *testing.T) {
+	srv := newTestServer(t)
+	sentinel := errors.New("synthetic accept failure")
+	err := srv.serveListener(context.Background(), errListener{err: sentinel})
+	if !errors.Is(err, sentinel) {
+		t.Errorf("serveListener err = %v; want %v", err, sentinel)
+	}
+}
+
+// TestAcceptLoopReturnsOnCancelledContext covers acceptLoop's ctx.Err()
+// guard at the top of the loop: a pre-cancelled context returns
+// context.Canceled before Accept is called.
+func TestAcceptLoopReturnsOnCancelledContext(t *testing.T) {
+	srv := newTestServer(t)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := srv.acceptLoop(ctx, ln); !errors.Is(err, context.Canceled) {
+		t.Errorf("acceptLoop(cancelled) = %v; want context.Canceled", err)
+	}
+}
+
+// TestSessionWriteFailureClosesSession covers session.run's
+// write-failure return arm: a handler reply written to a peer whose
+// socket has gone away makes session.write fail, firing
+// OutboundWriteFailed and ending the session loop.
+func TestSessionWriteFailureClosesSession(t *testing.T) {
+	srv := newTestServer(t)
+
+	// net.Pipe gives a synchronous in-memory conn; closing the far end
+	// makes the provider's Write fail once it tries to send a reply.
+	provConn, peerConn := net.Pipe()
+	sess := newSession(srv, provConn)
+	srv.mu.Lock()
+	srv.sessions[sess] = struct{}{}
+	srv.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		sess.run(ctx)
+		close(done)
+	}()
+
+	// Send a rx 07 STATUS REQUEST; the handler will try to write tx 09.
+	in := codec.Pack(codec.EncodeStatusRequest(codec.StatusRequestParams{}))
+	go func() {
+		_, _ = peerConn.Write(in)
+		// Close the peer so the provider's reply Write fails.
+		_ = peerConn.Close()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("session.run did not exit after write failure")
+	}
+}

--- a/internal/probel-sw02p/provider/tree_test.go
+++ b/internal/probel-sw02p/provider/tree_test.go
@@ -1,0 +1,373 @@
+package probelsw02p
+
+import (
+	"testing"
+
+	"dhs/internal/export/canonical"
+	"dhs/internal/probel-sw02p/codec"
+)
+
+// strptr is a tiny *string helper for canonical Description fields.
+func strptr(s string) *string { return &s }
+
+// TestNewTreeNilExport confirms newTree tolerates a nil Export and a
+// nil Root — both yield an empty (but non-nil) tree.
+func TestNewTreeNilExport(t *testing.T) {
+	t1, err := newTree(nil)
+	if err != nil {
+		t.Fatalf("newTree(nil): %v", err)
+	}
+	if t1 == nil || t1.Size() != 0 {
+		t.Errorf("newTree(nil) = %+v; want empty tree", t1)
+	}
+	t2, err := newTree(&canonical.Export{Root: nil})
+	if err != nil {
+		t.Fatalf("newTree(Root=nil): %v", err)
+	}
+	if t2.Size() != 0 {
+		t.Errorf("newTree(Root=nil) size = %d; want 0", t2.Size())
+	}
+}
+
+// TestVisitSkipsNilChild covers the e == nil guard in visit: a Node
+// whose Children slice contains a nil element must not panic and must
+// still register the sibling Matrix.
+func TestVisitSkipsNilChild(t *testing.T) {
+	exp := &canonical.Export{
+		Root: &canonical.Node{
+			Header: canonical.Header{Number: 1, Identifier: "root", OID: "1",
+				Children: []canonical.Element{
+					nil,
+					&canonical.Matrix{
+						Header:      canonical.Header{Number: 1, Identifier: "m", OID: "1.1"},
+						TargetCount: 2, SourceCount: 2,
+					},
+				},
+			},
+		},
+	}
+	tr, err := newTree(exp)
+	if err != nil {
+		t.Fatalf("newTree: %v", err)
+	}
+	if tr.Size() != 1 {
+		t.Errorf("size = %d; want 1 (nil child skipped, matrix kept)", tr.Size())
+	}
+}
+
+// TestAddMatrixNonPositiveNumberMapsToMatrixZero covers the
+// m.Number <= 0 branch in addMatrix: a Matrix with Number 0 is stored
+// at matrix id 0 (rather than underflowing uint8(Number-1)).
+func TestAddMatrixNonPositiveNumberMapsToMatrixZero(t *testing.T) {
+	exp := &canonical.Export{
+		Root: &canonical.Node{
+			Header: canonical.Header{Number: 1, Identifier: "root", OID: "1",
+				Children: []canonical.Element{
+					&canonical.Matrix{
+						Header:      canonical.Header{Number: 0, Identifier: "m", OID: "1.1"},
+						TargetCount: 2, SourceCount: 2,
+					},
+				},
+			},
+		},
+	}
+	tr, err := newTree(exp)
+	if err != nil {
+		t.Fatalf("newTree: %v", err)
+	}
+	if _, ok := tr.matrices[matrixKey{matrix: 0, level: 0}]; !ok {
+		t.Errorf("matrix Number=0 not stored at id 0; matrices = %+v", tr.matrices)
+	}
+}
+
+// TestAddMatrixWithLevelsAndLabels exercises the multi-level branch of
+// addMatrix + labelKey (Description present) + buildLabels (outer map
+// with a resolvable inner map, plus a bad ordinal key that is skipped).
+func TestAddMatrixWithLevelsAndLabels(t *testing.T) {
+	exp := &canonical.Export{
+		Root: &canonical.Node{
+			Header: canonical.Header{Number: 1, Identifier: "root", OID: "1",
+				Children: []canonical.Element{
+					&canonical.Matrix{
+						Header:      canonical.Header{Number: 1, Identifier: "m", OID: "1.1"},
+						TargetCount: 3, SourceCount: 3,
+						Labels: []canonical.MatrixLabel{
+							{BasePath: "root.m.video", Description: strptr("Primary")},
+						},
+						TargetLabels: map[string]map[string]string{
+							"Primary": {
+								"0":   "OUT 1",
+								"2":   "OUT 3",
+								"bad": "ignored", // non-numeric key → skipped
+								"9":   "oob",     // >= n → skipped
+							},
+						},
+						SourceLabels: map[string]map[string]string{
+							"Primary": {"1": "IN 2"},
+						},
+					},
+				},
+			},
+		},
+	}
+	tr, err := newTree(exp)
+	if err != nil {
+		t.Fatalf("newTree: %v", err)
+	}
+	st, ok := tr.matrices[matrixKey{matrix: 0, level: 0}]
+	if !ok {
+		t.Fatal("level 0 not registered")
+	}
+	if len(st.targetLabels) != 3 {
+		t.Fatalf("targetLabels len = %d; want 3", len(st.targetLabels))
+	}
+	if st.targetLabels[0] != "OUT 1" || st.targetLabels[2] != "OUT 3" {
+		t.Errorf("targetLabels = %v; want [OUT 1, '', OUT 3]", st.targetLabels)
+	}
+	if st.targetLabels[1] != "" {
+		t.Errorf("targetLabels[1] = %q; want empty (no key)", st.targetLabels[1])
+	}
+	if st.sourceLabels[1] != "IN 2" {
+		t.Errorf("sourceLabels[1] = %q; want IN 2", st.sourceLabels[1])
+	}
+}
+
+// TestLabelKeyFallsBackToBasePath covers labelKey's BasePath branch:
+// a level with no Description (nil) keys the label maps by BasePath, so
+// a TargetLabels map keyed by BasePath resolves.
+func TestLabelKeyFallsBackToBasePath(t *testing.T) {
+	exp := &canonical.Export{
+		Root: &canonical.Node{
+			Header: canonical.Header{Number: 1, Identifier: "root", OID: "1",
+				Children: []canonical.Element{
+					&canonical.Matrix{
+						Header:      canonical.Header{Number: 1, Identifier: "m", OID: "1.1"},
+						TargetCount: 1, SourceCount: 1,
+						Labels: []canonical.MatrixLabel{
+							{BasePath: "root.m.video"}, // Description nil → BasePath key
+						},
+						TargetLabels: map[string]map[string]string{
+							"root.m.video": {"0": "OUT 1"},
+						},
+					},
+				},
+			},
+		},
+	}
+	tr, err := newTree(exp)
+	if err != nil {
+		t.Fatalf("newTree: %v", err)
+	}
+	st := tr.matrices[matrixKey{matrix: 0, level: 0}]
+	if st.targetLabels[0] != "OUT 1" {
+		t.Errorf("targetLabels[0] = %q; want OUT 1 (BasePath key)", st.targetLabels[0])
+	}
+}
+
+// TestLabelKeyEmptyDescriptionFallsBackToBasePath covers the
+// *Description != "" half of labelKey: a non-nil but empty Description
+// also falls back to BasePath.
+func TestLabelKeyEmptyDescriptionFallsBackToBasePath(t *testing.T) {
+	got := labelKey(canonical.MatrixLabel{BasePath: "bp", Description: strptr("")})
+	if got != "bp" {
+		t.Errorf("labelKey(empty desc) = %q; want bp", got)
+	}
+}
+
+// TestBuildLabelsMissingInnerKey covers buildLabels' inner-not-found
+// branch: an outer map that lacks the requested level key returns an
+// all-empty slice sized to n.
+func TestBuildLabelsMissingInnerKey(t *testing.T) {
+	out := buildLabels(map[string]map[string]string{"Other": {"0": "x"}}, "Primary", 2)
+	if len(out) != 2 || out[0] != "" || out[1] != "" {
+		t.Errorf("buildLabels(missing key) = %v; want two empties", out)
+	}
+}
+
+// TestApplyConnectErrors covers the three error arms of applyConnect:
+// unknown matrix, dst out of range, src out of range.
+func TestApplyConnectErrors(t *testing.T) {
+	srv := newTestServer(t) // matrix 0 level 0, counts 4/4
+
+	if err := srv.tree.applyConnect(9, 9, 0, 0); err == nil {
+		t.Error("applyConnect(unknown matrix) = nil; want error")
+	}
+	if err := srv.tree.applyConnect(0, 0, 99, 0); err == nil {
+		t.Error("applyConnect(dst oob) = nil; want error")
+	}
+	if err := srv.tree.applyConnect(0, 0, 0, 99); err == nil {
+		t.Error("applyConnect(src oob) = nil; want error")
+	}
+	// Happy path still works.
+	if err := srv.tree.applyConnect(0, 0, 1, 2); err != nil {
+		t.Errorf("applyConnect(valid) = %v; want nil", err)
+	}
+}
+
+// TestDrainPendingUnknownMatrix covers drainPending's unknown-key arm:
+// a GO on a matrix with no state returns nil rather than erroring.
+func TestDrainPendingUnknownMatrix(t *testing.T) {
+	tr := &tree{matrices: map[matrixKey]*matrixState{}}
+	if got := tr.drainPending(7, 3); got != nil {
+		t.Errorf("drainPending(unknown) = %v; want nil", got)
+	}
+}
+
+// TestProtectClearRejectsOverride covers protectClear's
+// ProbelOverride arm: clearing a ProtectProBelOverride entry is
+// rejected and echoes the unchanged entry.
+func TestProtectClearRejectsOverride(t *testing.T) {
+	srv := newTestServer(t)
+	srv.tree.mu.Lock()
+	st := srv.tree.matrices[matrixKey{matrix: 0, level: 0}]
+	st.protect = map[uint16]protectEntry{
+		1: {State: codec.ProtectProBelOverride, OwnerDevice: 7},
+	}
+	srv.tree.mu.Unlock()
+
+	entry, res := srv.tree.protectClear(1, 7)
+	if res != protectApplyRejectedOverride {
+		t.Errorf("protectClear(override) = %v; want protectApplyRejectedOverride", res)
+	}
+	if entry.State != codec.ProtectProBelOverride {
+		t.Errorf("echoed state = %v; want unchanged ProbelOverride", entry.State)
+	}
+}
+
+// TestProtectClearAbsentDstNoOp covers protectClear's !exists arm when
+// the protect map exists but the queried dst has no entry: the result
+// is an accepted no-op echoing State=None. Distinct from the
+// protect==nil early return — here the map is non-nil.
+func TestProtectClearAbsentDstNoOp(t *testing.T) {
+	srv := newTestServer(t)
+	srv.tree.mu.Lock()
+	st := srv.tree.matrices[matrixKey{matrix: 0, level: 0}]
+	// Non-nil map with an unrelated entry so the dst lookup misses.
+	st.protect = map[uint16]protectEntry{
+		1: {State: codec.ProtectProBel, OwnerDevice: 7},
+	}
+	srv.tree.mu.Unlock()
+
+	entry, res := srv.tree.protectClear(99, 7) // dst 99 absent
+	if res != protectApplyAccepted {
+		t.Errorf("protectClear(absent dst) = %v; want protectApplyAccepted", res)
+	}
+	if entry.State != codec.ProtectNone {
+		t.Errorf("echoed state = %v; want ProtectNone", entry.State)
+	}
+}
+
+// TestSourceLockSnapshotSkipsNonMatrixZero covers the key.matrix != 0
+// continue arm of sourceLockSnapshot: only matrix-0 levels contribute
+// to the source count; a wider matrix-1 level is ignored.
+func TestSourceLockSnapshotSkipsNonMatrixZero(t *testing.T) {
+	tr := &tree{matrices: map[matrixKey]*matrixState{
+		{matrix: 0, level: 0}: {sourceCount: 2, sources: map[uint16]uint16{}},
+		{matrix: 1, level: 0}: {sourceCount: 9, sources: map[uint16]uint16{}}, // ignored
+	}}
+	got := tr.sourceLockSnapshot()
+	if len(got) != 2 {
+		t.Fatalf("snapshot len = %d; want 2 (matrix-1 ignored)", len(got))
+	}
+	for i, v := range got {
+		if !v {
+			t.Errorf("snapshot[%d] = false; want true (software default)", i)
+		}
+	}
+}
+
+// TestProtectDumpCountCap covers the count-limit branch of protectDump:
+// with more stored entries than count, only the first count (in
+// ascending-dst order) are returned.
+func TestProtectDumpCountCap(t *testing.T) {
+	srv := newTestServer(t)
+	srv.tree.mu.Lock()
+	st := srv.tree.matrices[matrixKey{matrix: 0, level: 0}]
+	st.protect = map[uint16]protectEntry{
+		5: {State: codec.ProtectProBel, OwnerDevice: 1},
+		2: {State: codec.ProtectProBel, OwnerDevice: 1},
+		8: {State: codec.ProtectProBel, OwnerDevice: 1},
+		1: {State: codec.ProtectProBel, OwnerDevice: 1},
+	}
+	srv.tree.mu.Unlock()
+
+	out := srv.tree.protectDump(0, 2)
+	if len(out) != 2 {
+		t.Fatalf("protectDump(count=2) len = %d; want 2", len(out))
+	}
+	if out[0].Destination != 1 || out[1].Destination != 2 {
+		t.Errorf("protectDump order = [%d,%d]; want ascending [1,2]",
+			out[0].Destination, out[1].Destination)
+	}
+}
+
+// TestProtectEntriesByDeviceMatches covers protectEntriesByDevice's
+// match loop: only entries whose OwnerDevice equals the query are
+// returned.
+func TestProtectEntriesByDeviceMatches(t *testing.T) {
+	srv := newTestServer(t)
+	srv.tree.mu.Lock()
+	st := srv.tree.matrices[matrixKey{matrix: 0, level: 0}]
+	st.protect = map[uint16]protectEntry{
+		1: {State: codec.ProtectProBel, OwnerDevice: 42, OwnerName: "A"},
+		2: {State: codec.ProtectProBel, OwnerDevice: 99},
+		3: {State: codec.ProtectProBel, OwnerDevice: 42},
+	}
+	srv.tree.mu.Unlock()
+
+	got := srv.tree.protectEntriesByDevice(42)
+	if len(got) != 2 {
+		t.Fatalf("protectEntriesByDevice(42) len = %d; want 2", len(got))
+	}
+	for _, e := range got {
+		if e.OwnerDevice != 42 {
+			t.Errorf("entry OwnerDevice = %d; want 42", e.OwnerDevice)
+		}
+	}
+	// No match → empty (non-nil) slice.
+	if none := srv.tree.protectEntriesByDevice(7); len(none) != 0 {
+		t.Errorf("protectEntriesByDevice(7) = %v; want empty", none)
+	}
+}
+
+// TestProtectEntriesByDeviceNoProtectMap covers the early-return arm
+// when matrix 0 has no protect map at all.
+func TestProtectEntriesByDeviceNoProtectMap(t *testing.T) {
+	tr := &tree{matrices: map[matrixKey]*matrixState{}}
+	if got := tr.protectEntriesByDevice(1); got != nil {
+		t.Errorf("protectEntriesByDevice(no matrix) = %v; want nil", got)
+	}
+}
+
+// TestSourceLockSnapshotEmptyTree covers the maxSrc == 0 arm: a tree
+// whose matrix 0 declares no sources returns nil.
+func TestSourceLockSnapshotEmptyTree(t *testing.T) {
+	tr := &tree{matrices: map[matrixKey]*matrixState{
+		{matrix: 0, level: 0}: {sources: map[uint16]uint16{}}, // sourceCount 0
+	}}
+	if got := tr.sourceLockSnapshot(); got != nil {
+		t.Errorf("sourceLockSnapshot(no sources) = %v; want nil", got)
+	}
+}
+
+// TestLookupSourceUnknownMatrix covers lookupSource's unknown-matrix
+// arm.
+func TestLookupSourceUnknownMatrix(t *testing.T) {
+	tr := &tree{matrices: map[matrixKey]*matrixState{}}
+	if _, ok := tr.lookupSource(0, 0, 0); ok {
+		t.Error("lookupSource(unknown) ok = true; want false")
+	}
+}
+
+// TestApplyConnectLenientSrcOutOfRange covers the src-out-of-range skip
+// in applyConnectLenient: a declared sourceCount rejects an oversized
+// source while leaving the tree untouched.
+func TestApplyConnectLenientSrcOutOfRange(t *testing.T) {
+	srv := newTestServer(t) // counts 4/4
+	if ok := srv.tree.applyConnectLenient(0, 0, 0, 99); ok {
+		t.Error("applyConnectLenient(src oob) = true; want false")
+	}
+	if _, ok := srv.tree.matrices[matrixKey{matrix: 0, level: 0}].sources[0]; ok {
+		t.Error("tree[0] recorded despite src oob")
+	}
+}


### PR DESCRIPTION
Roadmap C — probel-sw02p provider 80.8%->100.0%. Protect/lock/salvo/compliance + server/session lifecycle tested via crafted input; two framer-shadowed guards covered with transparent nil-hook seams (guards unchanged). vet+lint+build clean. Floor in consolidated PR. Closes #572.

🤖 Generated with [Claude Code](https://claude.com/claude-code)