### PR TITLE
test(probel-sw08p): consumer to 100% coverage (C)

### DIFF
--- a/internal/probel-sw08p/consumer/commands_names_salvo_test.go
+++ b/internal/probel-sw08p/consumer/commands_names_salvo_test.go
@@ -1,0 +1,530 @@
+package probelsw08p
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/consumer"
+)
+
+// ---- rx 100 All Source Names ----------------------------------------------
+
+func TestAllSourceNames(t *testing.T) {
+	p, peer, cleanup := newPeerHarness(t, replyWith(
+		codec.EncodeSourceNamesResponse(codec.SourceNamesResponseParams{
+			MatrixID: 0, LevelID: 0, NameLength: codec.NameLen8, FirstSourceID: 0,
+			Names: []string{"SRC1", "SRC2"},
+		}),
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	got, err := p.AllSourceNames(ctx, 0, 0, codec.NameLen8)
+	if err != nil {
+		t.Fatalf("AllSourceNames: %v", err)
+	}
+	if len(got.Names) != 2 || got.Names[0] != "SRC1" {
+		t.Errorf("names = %v; want [SRC1 SRC2]", got.Names)
+	}
+	req, _ := peer.lastRequest()
+	if req.ID != codec.RxAllSourceNamesRequest {
+		t.Errorf("req ID %#x; want RxAllSourceNamesRequest", req.ID)
+	}
+}
+
+func TestAllSourceNamesNotConnected(t *testing.T) {
+	_, err := freshPlugin().AllSourceNames(context.Background(), 0, 0, codec.NameLen8)
+	if !errors.Is(err, consumer.ErrNotConnected) {
+		t.Fatalf("err = %v; want ErrNotConnected", err)
+	}
+}
+
+func TestAllSourceNamesDecodeErr(t *testing.T) {
+	p, _, cleanup := newPeerHarness(t, replyWith(
+		codec.Frame{ID: codec.TxSourceNamesResponse, Payload: []byte{0x00}},
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	_, err := p.AllSourceNames(ctx, 0, 0, codec.NameLen8)
+	assertTransportDecodeErr(t, err)
+}
+
+// ---- rx 101 Single Source Name --------------------------------------------
+
+func TestSingleSourceName(t *testing.T) {
+	p, peer, cleanup := newPeerHarness(t, replyWith(
+		codec.EncodeSourceNamesResponse(codec.SourceNamesResponseParams{
+			NameLength: codec.NameLen8, FirstSourceID: 5, Names: []string{"ONE"},
+		}),
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	name, err := p.SingleSourceName(ctx, 0, 0, codec.NameLen8, 5)
+	if err != nil {
+		t.Fatalf("SingleSourceName: %v", err)
+	}
+	if name != "ONE" {
+		t.Errorf("name = %q; want ONE", name)
+	}
+	req, _ := peer.lastRequest()
+	if req.ID != codec.RxSingleSourceNameRequest {
+		t.Errorf("req ID %#x; want RxSingleSourceNameRequest", req.ID)
+	}
+}
+
+func TestSingleSourceNameEmpty(t *testing.T) {
+	// A response with zero names → method returns "".
+	p, _, cleanup := newPeerHarness(t, replyWith(
+		codec.EncodeSourceNamesResponse(codec.SourceNamesResponseParams{
+			NameLength: codec.NameLen8, Names: nil,
+		}),
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	name, err := p.SingleSourceName(ctx, 0, 0, codec.NameLen8, 0)
+	if err != nil {
+		t.Fatalf("SingleSourceName: %v", err)
+	}
+	if name != "" {
+		t.Errorf("name = %q; want empty", name)
+	}
+}
+
+func TestSingleSourceNameNotConnected(t *testing.T) {
+	_, err := freshPlugin().SingleSourceName(context.Background(), 0, 0, codec.NameLen8, 0)
+	if !errors.Is(err, consumer.ErrNotConnected) {
+		t.Fatalf("err = %v; want ErrNotConnected", err)
+	}
+}
+
+func TestSingleSourceNameDecodeErr(t *testing.T) {
+	p, _, cleanup := newPeerHarness(t, replyWith(
+		codec.Frame{ID: codec.TxSourceNamesResponse, Payload: []byte{0x00}},
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	_, err := p.SingleSourceName(ctx, 0, 0, codec.NameLen8, 0)
+	assertTransportDecodeErr(t, err)
+}
+
+// ---- rx 102 All Dest Assoc Names ------------------------------------------
+
+func TestAllDestAssocNames(t *testing.T) {
+	p, peer, cleanup := newPeerHarness(t, replyWith(
+		codec.EncodeDestAssocNamesResponse(codec.DestAssocNamesResponseParams{
+			NameLength: codec.NameLen8, Names: []string{"DST1"},
+		}),
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	got, err := p.AllDestAssocNames(ctx, 0, codec.NameLen8)
+	if err != nil {
+		t.Fatalf("AllDestAssocNames: %v", err)
+	}
+	if len(got.Names) != 1 || got.Names[0] != "DST1" {
+		t.Errorf("names = %v; want [DST1]", got.Names)
+	}
+	req, _ := peer.lastRequest()
+	if req.ID != codec.RxAllDestNamesRequest {
+		t.Errorf("req ID %#x; want RxAllDestNamesRequest", req.ID)
+	}
+}
+
+func TestAllDestAssocNamesNotConnected(t *testing.T) {
+	_, err := freshPlugin().AllDestAssocNames(context.Background(), 0, codec.NameLen8)
+	if !errors.Is(err, consumer.ErrNotConnected) {
+		t.Fatalf("err = %v; want ErrNotConnected", err)
+	}
+}
+
+func TestAllDestAssocNamesDecodeErr(t *testing.T) {
+	p, _, cleanup := newPeerHarness(t, replyWith(
+		codec.Frame{ID: codec.TxDestAssocNamesResponse, Payload: []byte{0x00}},
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	_, err := p.AllDestAssocNames(ctx, 0, codec.NameLen8)
+	assertTransportDecodeErr(t, err)
+}
+
+// ---- rx 103 Single Dest Assoc Name ----------------------------------------
+
+func TestSingleDestAssocName(t *testing.T) {
+	p, peer, cleanup := newPeerHarness(t, replyWith(
+		codec.EncodeDestAssocNamesResponse(codec.DestAssocNamesResponseParams{
+			NameLength: codec.NameLen8, FirstDestAssociationID: 2, Names: []string{"OUT"},
+		}),
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	name, err := p.SingleDestAssocName(ctx, 0, codec.NameLen8, 2)
+	if err != nil {
+		t.Fatalf("SingleDestAssocName: %v", err)
+	}
+	if name != "OUT" {
+		t.Errorf("name = %q; want OUT", name)
+	}
+	req, _ := peer.lastRequest()
+	if req.ID != codec.RxSingleDestNameRequest {
+		t.Errorf("req ID %#x; want RxSingleDestNameRequest", req.ID)
+	}
+}
+
+func TestSingleDestAssocNameEmpty(t *testing.T) {
+	p, _, cleanup := newPeerHarness(t, replyWith(
+		codec.EncodeDestAssocNamesResponse(codec.DestAssocNamesResponseParams{
+			NameLength: codec.NameLen8, Names: nil,
+		}),
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	name, err := p.SingleDestAssocName(ctx, 0, codec.NameLen8, 0)
+	if err != nil {
+		t.Fatalf("SingleDestAssocName: %v", err)
+	}
+	if name != "" {
+		t.Errorf("name = %q; want empty", name)
+	}
+}
+
+func TestSingleDestAssocNameNotConnected(t *testing.T) {
+	_, err := freshPlugin().SingleDestAssocName(context.Background(), 0, codec.NameLen8, 0)
+	if !errors.Is(err, consumer.ErrNotConnected) {
+		t.Fatalf("err = %v; want ErrNotConnected", err)
+	}
+}
+
+func TestSingleDestAssocNameDecodeErr(t *testing.T) {
+	p, _, cleanup := newPeerHarness(t, replyWith(
+		codec.Frame{ID: codec.TxDestAssocNamesResponse, Payload: []byte{0x00}},
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	_, err := p.SingleDestAssocName(ctx, 0, codec.NameLen8, 0)
+	assertTransportDecodeErr(t, err)
+}
+
+// ---- rx 112 Tie-Line Interrogate ------------------------------------------
+
+func TestTieLineInterrogate(t *testing.T) {
+	p, peer, cleanup := newPeerHarness(t, replyWith(
+		codec.EncodeTieLineTally(codec.TieLineTallyParams{
+			DestMatrixID: 0, DestAssociationID: 9,
+			Sources: []codec.TieLineSource{
+				{MatrixID: 0, LevelID: 0, SourceID: 5},
+			},
+		}),
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	got, err := p.TieLineInterrogate(ctx, 0, 9)
+	if err != nil {
+		t.Fatalf("TieLineInterrogate: %v", err)
+	}
+	if len(got.Sources) != 1 || got.Sources[0].SourceID != 5 {
+		t.Errorf("sources = %+v; want one src=5", got.Sources)
+	}
+	req, _ := peer.lastRequest()
+	if req.ID != codec.RxCrosspointTieLineInterrogate {
+		t.Errorf("req ID %#x; want RxCrosspointTieLineInterrogate", req.ID)
+	}
+}
+
+func TestTieLineInterrogateNotConnected(t *testing.T) {
+	_, err := freshPlugin().TieLineInterrogate(context.Background(), 0, 0)
+	if !errors.Is(err, consumer.ErrNotConnected) {
+		t.Fatalf("err = %v; want ErrNotConnected", err)
+	}
+}
+
+func TestTieLineInterrogateDecodeErr(t *testing.T) {
+	p, _, cleanup := newPeerHarness(t, replyWith(
+		codec.Frame{ID: codec.TxCrosspointTieLineTally, Payload: []byte{0x00}},
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	_, err := p.TieLineInterrogate(ctx, 0, 0)
+	assertTransportDecodeErr(t, err)
+}
+
+// ---- rx 114 All Source Assoc Names ----------------------------------------
+
+func TestAllSourceAssocNames(t *testing.T) {
+	p, peer, cleanup := newPeerHarness(t, replyWith(
+		codec.EncodeSourceAssocNamesResponse(codec.SourceAssocNamesResponseParams{
+			NameLength: codec.NameLen8, Names: []string{"SA1"},
+		}),
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	got, err := p.AllSourceAssocNames(ctx, 0, codec.NameLen8)
+	if err != nil {
+		t.Fatalf("AllSourceAssocNames: %v", err)
+	}
+	if len(got.Names) != 1 || got.Names[0] != "SA1" {
+		t.Errorf("names = %v; want [SA1]", got.Names)
+	}
+	req, _ := peer.lastRequest()
+	if req.ID != codec.RxAllSourceAssocNamesRequest {
+		t.Errorf("req ID %#x; want RxAllSourceAssocNamesRequest", req.ID)
+	}
+}
+
+func TestAllSourceAssocNamesNotConnected(t *testing.T) {
+	_, err := freshPlugin().AllSourceAssocNames(context.Background(), 0, codec.NameLen8)
+	if !errors.Is(err, consumer.ErrNotConnected) {
+		t.Fatalf("err = %v; want ErrNotConnected", err)
+	}
+}
+
+func TestAllSourceAssocNamesDecodeErr(t *testing.T) {
+	p, _, cleanup := newPeerHarness(t, replyWith(
+		codec.Frame{ID: codec.TxSourceAssocNamesResponse, Payload: []byte{0x00}},
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	_, err := p.AllSourceAssocNames(ctx, 0, codec.NameLen8)
+	assertTransportDecodeErr(t, err)
+}
+
+// ---- rx 115 Single Source Assoc Name --------------------------------------
+
+func TestSingleSourceAssocName(t *testing.T) {
+	p, peer, cleanup := newPeerHarness(t, replyWith(
+		codec.EncodeSourceAssocNamesResponse(codec.SourceAssocNamesResponseParams{
+			NameLength: codec.NameLen8, FirstSourceAssociationID: 1, Names: []string{"SAX"},
+		}),
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	name, err := p.SingleSourceAssocName(ctx, 0, codec.NameLen8, 1)
+	if err != nil {
+		t.Fatalf("SingleSourceAssocName: %v", err)
+	}
+	if name != "SAX" {
+		t.Errorf("name = %q; want SAX", name)
+	}
+	req, _ := peer.lastRequest()
+	if req.ID != codec.RxSingleSourceAssocNameRequest {
+		t.Errorf("req ID %#x; want RxSingleSourceAssocNameRequest", req.ID)
+	}
+}
+
+func TestSingleSourceAssocNameEmpty(t *testing.T) {
+	p, _, cleanup := newPeerHarness(t, replyWith(
+		codec.EncodeSourceAssocNamesResponse(codec.SourceAssocNamesResponseParams{
+			NameLength: codec.NameLen8, Names: nil,
+		}),
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	name, err := p.SingleSourceAssocName(ctx, 0, codec.NameLen8, 0)
+	if err != nil {
+		t.Fatalf("SingleSourceAssocName: %v", err)
+	}
+	if name != "" {
+		t.Errorf("name = %q; want empty", name)
+	}
+}
+
+func TestSingleSourceAssocNameNotConnected(t *testing.T) {
+	_, err := freshPlugin().SingleSourceAssocName(context.Background(), 0, codec.NameLen8, 0)
+	if !errors.Is(err, consumer.ErrNotConnected) {
+		t.Fatalf("err = %v; want ErrNotConnected", err)
+	}
+}
+
+func TestSingleSourceAssocNameDecodeErr(t *testing.T) {
+	p, _, cleanup := newPeerHarness(t, replyWith(
+		codec.Frame{ID: codec.TxSourceAssocNamesResponse, Payload: []byte{0x00}},
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	_, err := p.SingleSourceAssocName(ctx, 0, codec.NameLen8, 0)
+	assertTransportDecodeErr(t, err)
+}
+
+// ---- rx 117 Update Name Request (no reply) --------------------------------
+
+func TestUpdateNameRequest(t *testing.T) {
+	p, peer, cleanup := newPeerHarness(t, ackOnly)
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	err := p.UpdateNameRequest(ctx, codec.UpdateNameRequestParams{
+		NameType: codec.UpdateNameSource, NameLength: codec.NameLen8,
+		MatrixID: 0, LevelID: 0, FirstID: 1, Names: []string{"NEW"},
+	})
+	if err != nil {
+		t.Fatalf("UpdateNameRequest: %v", err)
+	}
+	req, _ := peer.lastRequest()
+	if req.ID != codec.RxUpdateNameRequest {
+		t.Errorf("req ID %#x; want RxUpdateNameRequest", req.ID)
+	}
+}
+
+func TestUpdateNameRequestNotConnected(t *testing.T) {
+	err := freshPlugin().UpdateNameRequest(context.Background(), codec.UpdateNameRequestParams{})
+	if !errors.Is(err, consumer.ErrNotConnected) {
+		t.Fatalf("err = %v; want ErrNotConnected", err)
+	}
+}
+
+func TestUpdateNameRequestSendErr(t *testing.T) {
+	p, _, cleanup := newPeerHarness(t, ackOnly)
+	cleanup()
+	err := p.UpdateNameRequest(context.Background(), codec.UpdateNameRequestParams{})
+	if err == nil {
+		t.Fatal("UpdateNameRequest after close returned nil; want send error")
+	}
+}
+
+// ---- rx 120 Salvo Connect-On-Go -------------------------------------------
+
+func TestSalvoConnectOnGo(t *testing.T) {
+	p, peer, cleanup := newPeerHarness(t, replyWith(
+		codec.EncodeSalvoConnectOnGoAck(codec.SalvoConnectOnGoAckParams{
+			MatrixID: 0, LevelID: 0, DestinationID: 3, SourceID: 4, SalvoID: 1,
+		}),
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	got, err := p.SalvoConnectOnGo(ctx, codec.SalvoConnectOnGoParams{
+		MatrixID: 0, LevelID: 0, DestinationID: 3, SourceID: 4, SalvoID: 1,
+	})
+	if err != nil {
+		t.Fatalf("SalvoConnectOnGo: %v", err)
+	}
+	if got.DestinationID != 3 || got.SalvoID != 1 {
+		t.Errorf("ack = %+v; want dst=3 salvo=1", got)
+	}
+	req, _ := peer.lastRequest()
+	if req.ID != codec.RxCrosspointConnectOnGoSalvo {
+		t.Errorf("req ID %#x; want RxCrosspointConnectOnGoSalvo", req.ID)
+	}
+}
+
+func TestSalvoConnectOnGoNotConnected(t *testing.T) {
+	_, err := freshPlugin().SalvoConnectOnGo(context.Background(), codec.SalvoConnectOnGoParams{})
+	if !errors.Is(err, consumer.ErrNotConnected) {
+		t.Fatalf("err = %v; want ErrNotConnected", err)
+	}
+}
+
+func TestSalvoConnectOnGoDecodeErr(t *testing.T) {
+	p, _, cleanup := newPeerHarness(t, replyWith(
+		codec.Frame{ID: codec.TxSalvoConnectOnGoAck, Payload: []byte{0x00}},
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	_, err := p.SalvoConnectOnGo(ctx, codec.SalvoConnectOnGoParams{})
+	assertTransportDecodeErr(t, err)
+}
+
+// ---- rx 121 Salvo Go ------------------------------------------------------
+
+func TestSalvoGo(t *testing.T) {
+	p, peer, cleanup := newPeerHarness(t, replyWith(
+		codec.EncodeSalvoGoDoneAck(codec.SalvoGoDoneAckParams{
+			Status: codec.SalvoDoneSet, SalvoID: 1,
+		}),
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	got, err := p.SalvoGo(ctx, codec.SalvoGoParams{Op: codec.SalvoOpSet, SalvoID: 1})
+	if err != nil {
+		t.Fatalf("SalvoGo: %v", err)
+	}
+	if got.Status != codec.SalvoDoneSet || got.SalvoID != 1 {
+		t.Errorf("ack = %+v; want set salvo=1", got)
+	}
+	req, _ := peer.lastRequest()
+	if req.ID != codec.RxCrosspointGoSalvo {
+		t.Errorf("req ID %#x; want RxCrosspointGoSalvo", req.ID)
+	}
+}
+
+func TestSalvoGoNotConnected(t *testing.T) {
+	_, err := freshPlugin().SalvoGo(context.Background(), codec.SalvoGoParams{})
+	if !errors.Is(err, consumer.ErrNotConnected) {
+		t.Fatalf("err = %v; want ErrNotConnected", err)
+	}
+}
+
+func TestSalvoGoDecodeErr(t *testing.T) {
+	p, _, cleanup := newPeerHarness(t, replyWith(
+		codec.Frame{ID: codec.TxSalvoGoDoneAck, Payload: []byte{0x00}},
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	_, err := p.SalvoGo(ctx, codec.SalvoGoParams{})
+	assertTransportDecodeErr(t, err)
+}
+
+// ---- rx 124 Salvo Group Interrogate ---------------------------------------
+
+func TestSalvoGroupInterrogate(t *testing.T) {
+	p, peer, cleanup := newPeerHarness(t, replyWith(
+		codec.EncodeSalvoGroupTally(codec.SalvoGroupTallyParams{
+			MatrixID: 0, LevelID: 0, DestinationID: 2, SourceID: 3,
+			SalvoID: 1, ConnectIndex: 0, Validity: codec.SalvoTallyValidLast,
+		}),
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	got, err := p.SalvoGroupInterrogate(ctx, codec.SalvoGroupInterrogateParams{
+		SalvoID: 1, ConnectIndex: 0,
+	})
+	if err != nil {
+		t.Fatalf("SalvoGroupInterrogate: %v", err)
+	}
+	if got.Validity != codec.SalvoTallyValidLast || got.DestinationID != 2 {
+		t.Errorf("tally = %+v; want last, dst=2", got)
+	}
+	req, _ := peer.lastRequest()
+	if req.ID != codec.RxCrosspointSalvoGroupInterrogate {
+		t.Errorf("req ID %#x; want RxCrosspointSalvoGroupInterrogate", req.ID)
+	}
+}
+
+func TestSalvoGroupInterrogateNotConnected(t *testing.T) {
+	_, err := freshPlugin().SalvoGroupInterrogate(context.Background(), codec.SalvoGroupInterrogateParams{})
+	if !errors.Is(err, consumer.ErrNotConnected) {
+		t.Fatalf("err = %v; want ErrNotConnected", err)
+	}
+}
+
+func TestSalvoGroupInterrogateDecodeErr(t *testing.T) {
+	p, _, cleanup := newPeerHarness(t, replyWith(
+		codec.Frame{ID: codec.TxSalvoGroupTally, Payload: []byte{0x00}},
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	_, err := p.SalvoGroupInterrogate(ctx, codec.SalvoGroupInterrogateParams{})
+	assertTransportDecodeErr(t, err)
+}

--- a/internal/probel-sw08p/consumer/commands_senderr_test.go
+++ b/internal/probel-sw08p/consumer/commands_senderr_test.go
@@ -1,0 +1,120 @@
+package probelsw08p
+
+import (
+	"context"
+	"testing"
+
+	"dhs/internal/probel-sw08p/codec"
+)
+
+// closedClientPlugin returns a Plugin whose codec.Client has been closed,
+// so any Send fails on the write path — exercising every command method's
+// "cli.Send returned err" wrapping branch.
+func closedClientPlugin(t *testing.T) *Plugin {
+	t.Helper()
+	p, _, cleanup := newPeerHarness(t, ackOnly)
+	cleanup() // closes client + pipe
+	return p
+}
+
+// TestCommandsSendError walks every reply-expecting command against a
+// closed client and asserts each returns a non-nil (wrapped) error from
+// the Send failure path.
+func TestCommandsSendError(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		call func(p *Plugin) error
+	}{
+		{"CrosspointInterrogate", func(p *Plugin) error {
+			_, err := p.CrosspointInterrogate(ctx, 0, 0, 0)
+			return err
+		}},
+		{"CrosspointConnect", func(p *Plugin) error {
+			_, err := p.CrosspointConnect(ctx, 0, 0, 0, 0)
+			return err
+		}},
+		{"DualControllerStatus", func(p *Plugin) error {
+			_, err := p.DualControllerStatus(ctx)
+			return err
+		}},
+		{"ProtectInterrogate", func(p *Plugin) error {
+			_, err := p.ProtectInterrogate(ctx, 0, 0, 0, 0)
+			return err
+		}},
+		{"ProtectConnect", func(p *Plugin) error {
+			_, err := p.ProtectConnect(ctx, 0, 0, 0, 0)
+			return err
+		}},
+		{"ProtectDisconnect", func(p *Plugin) error {
+			_, err := p.ProtectDisconnect(ctx, 0, 0, 0, 0)
+			return err
+		}},
+		{"ProtectDeviceName", func(p *Plugin) error {
+			_, err := p.ProtectDeviceName(ctx, 0)
+			return err
+		}},
+		{"ProtectTallyDump", func(p *Plugin) error {
+			_, err := p.ProtectTallyDump(ctx, 0, 0, 0)
+			return err
+		}},
+		{"CrosspointTallyDump", func(p *Plugin) error {
+			_, err := p.CrosspointTallyDump(ctx, 0, 0)
+			return err
+		}},
+		{"MasterProtectConnect", func(p *Plugin) error {
+			_, err := p.MasterProtectConnect(ctx, 0, 0, 0, 0)
+			return err
+		}},
+		{"AllSourceNames", func(p *Plugin) error {
+			_, err := p.AllSourceNames(ctx, 0, 0, codec.NameLen8)
+			return err
+		}},
+		{"SingleSourceName", func(p *Plugin) error {
+			_, err := p.SingleSourceName(ctx, 0, 0, codec.NameLen8, 0)
+			return err
+		}},
+		{"AllDestAssocNames", func(p *Plugin) error {
+			_, err := p.AllDestAssocNames(ctx, 0, codec.NameLen8)
+			return err
+		}},
+		{"SingleDestAssocName", func(p *Plugin) error {
+			_, err := p.SingleDestAssocName(ctx, 0, codec.NameLen8, 0)
+			return err
+		}},
+		{"TieLineInterrogate", func(p *Plugin) error {
+			_, err := p.TieLineInterrogate(ctx, 0, 0)
+			return err
+		}},
+		{"AllSourceAssocNames", func(p *Plugin) error {
+			_, err := p.AllSourceAssocNames(ctx, 0, codec.NameLen8)
+			return err
+		}},
+		{"SingleSourceAssocName", func(p *Plugin) error {
+			_, err := p.SingleSourceAssocName(ctx, 0, codec.NameLen8, 0)
+			return err
+		}},
+		{"SalvoConnectOnGo", func(p *Plugin) error {
+			_, err := p.SalvoConnectOnGo(ctx, codec.SalvoConnectOnGoParams{})
+			return err
+		}},
+		{"SalvoGo", func(p *Plugin) error {
+			_, err := p.SalvoGo(ctx, codec.SalvoGoParams{})
+			return err
+		}},
+		{"SalvoGroupInterrogate", func(p *Plugin) error {
+			_, err := p.SalvoGroupInterrogate(ctx, codec.SalvoGroupInterrogateParams{})
+			return err
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := closedClientPlugin(t)
+			if err := tc.call(p); err == nil {
+				t.Errorf("%s on closed client returned nil; want send error", tc.name)
+			}
+		})
+	}
+}

--- a/internal/probel-sw08p/consumer/commands_test.go
+++ b/internal/probel-sw08p/consumer/commands_test.go
@@ -1,0 +1,552 @@
+package probelsw08p
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/consumer"
+)
+
+// freshPlugin is an unconnected Plugin for the not-connected error paths.
+func freshPlugin() *Plugin {
+	return &Plugin{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+}
+
+// assertTransportDecodeErr checks err is a *consumer.TransportError with
+// Op=="decode" — the contract every per-command decode guard fulfils.
+func assertTransportDecodeErr(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("want decode TransportError, got nil")
+	}
+	var te *consumer.TransportError
+	if !errors.As(err, &te) {
+		t.Fatalf("want *consumer.TransportError, got %T (%v)", err, err)
+	}
+	if te.Op != "decode" {
+		t.Errorf("TransportError.Op = %q; want decode", te.Op)
+	}
+}
+
+const testTimeout = 2 * time.Second
+
+func ctxT(t *testing.T) (context.Context, context.CancelFunc) {
+	t.Helper()
+	return context.WithTimeout(context.Background(), testTimeout)
+}
+
+// ---- rx 001 Crosspoint Interrogate ----------------------------------------
+
+func TestCrosspointInterrogate(t *testing.T) {
+	p, peer, cleanup := newPeerHarness(t, replyWith(
+		codec.EncodeCrosspointTally(codec.CrosspointTallyParams{
+			MatrixID: 1, LevelID: 2, DestinationID: 42, SourceID: 7,
+		}),
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+
+	got, err := p.CrosspointInterrogate(ctx, 1, 2, 42)
+	if err != nil {
+		t.Fatalf("CrosspointInterrogate: %v", err)
+	}
+	if got.DestinationID != 42 || got.SourceID != 7 {
+		t.Errorf("tally = dst=%d src=%d; want 42,7", got.DestinationID, got.SourceID)
+	}
+	req, ok := peer.lastRequest()
+	if !ok || req.ID != codec.RxCrosspointInterrogate {
+		t.Errorf("peer saw req ID %#x; want RxCrosspointInterrogate", req.ID)
+	}
+}
+
+func TestCrosspointInterrogateNotConnected(t *testing.T) {
+	_, err := freshPlugin().CrosspointInterrogate(context.Background(), 0, 0, 0)
+	if !errors.Is(err, consumer.ErrNotConnected) {
+		t.Fatalf("err = %v; want ErrNotConnected", err)
+	}
+}
+
+func TestCrosspointInterrogateDecodeErr(t *testing.T) {
+	// Reply has the matched ID but a too-short payload → DecodeCrosspointTally
+	// returns ErrShortPayload, exercising the decode guard.
+	p, _, cleanup := newPeerHarness(t, replyWith(
+		codec.Frame{ID: codec.TxCrosspointTally, Payload: []byte{0x00}},
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	_, err := p.CrosspointInterrogate(ctx, 0, 0, 0)
+	assertTransportDecodeErr(t, err)
+}
+
+func TestCrosspointInterrogateTimeout(t *testing.T) {
+	// Peer ACKs but never replies → ctx deadline fires in the reply phase.
+	p, _, cleanup := newPeerHarness(t, ackOnly)
+	defer cleanup()
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	_, err := p.CrosspointInterrogate(ctx, 0, 0, 0)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v; want DeadlineExceeded", err)
+	}
+}
+
+// ---- rx 002 Crosspoint Connect --------------------------------------------
+
+func TestCrosspointConnect(t *testing.T) {
+	p, peer, cleanup := newPeerHarness(t, replyWith(
+		codec.EncodeCrosspointConnected(codec.CrosspointConnectedParams{
+			MatrixID: 0, LevelID: 0, DestinationID: 5, SourceID: 9,
+		}),
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	got, err := p.CrosspointConnect(ctx, 0, 0, 5, 9)
+	if err != nil {
+		t.Fatalf("CrosspointConnect: %v", err)
+	}
+	if got.DestinationID != 5 || got.SourceID != 9 {
+		t.Errorf("connected = dst=%d src=%d; want 5,9", got.DestinationID, got.SourceID)
+	}
+	req, _ := peer.lastRequest()
+	if req.ID != codec.RxCrosspointConnect {
+		t.Errorf("req ID %#x; want RxCrosspointConnect", req.ID)
+	}
+}
+
+func TestCrosspointConnectNotConnected(t *testing.T) {
+	_, err := freshPlugin().CrosspointConnect(context.Background(), 0, 0, 0, 0)
+	if !errors.Is(err, consumer.ErrNotConnected) {
+		t.Fatalf("err = %v; want ErrNotConnected", err)
+	}
+}
+
+func TestCrosspointConnectDecodeErr(t *testing.T) {
+	p, _, cleanup := newPeerHarness(t, replyWith(
+		codec.Frame{ID: codec.TxCrosspointConnected, Payload: []byte{0x00}},
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	_, err := p.CrosspointConnect(ctx, 0, 0, 0, 0)
+	assertTransportDecodeErr(t, err)
+}
+
+// ---- rx 007 Maintenance (no reply) ----------------------------------------
+
+func TestMaintenance(t *testing.T) {
+	p, peer, cleanup := newPeerHarness(t, ackOnly)
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	if err := p.Maintenance(ctx, codec.MaintClearProtects, 0xFF, 0xFF); err != nil {
+		t.Fatalf("Maintenance: %v", err)
+	}
+	req, _ := peer.lastRequest()
+	if req.ID != codec.RxMaintenance {
+		t.Errorf("req ID %#x; want RxMaintenance", req.ID)
+	}
+}
+
+func TestMaintenanceNotConnected(t *testing.T) {
+	err := freshPlugin().Maintenance(context.Background(), codec.MaintSoftReset, 0, 0)
+	if !errors.Is(err, consumer.ErrNotConnected) {
+		t.Fatalf("err = %v; want ErrNotConnected", err)
+	}
+}
+
+func TestMaintenanceSendErr(t *testing.T) {
+	// Close the client so Send fails on the write path → wrapped error.
+	p, _, cleanup := newPeerHarness(t, ackOnly)
+	cleanup() // closes the client + pipe before we Send
+	err := p.Maintenance(context.Background(), codec.MaintSoftReset, 0, 0)
+	if err == nil {
+		t.Fatal("Maintenance after close returned nil; want send error")
+	}
+}
+
+// ---- rx 008 Dual Controller Status ----------------------------------------
+
+func TestDualControllerStatus(t *testing.T) {
+	p, peer, cleanup := newPeerHarness(t, replyWith(
+		codec.EncodeDualControllerStatusResponse(codec.DualControllerStatusParams{
+			SlaveActive: true, Active: true, IdleControllerFaulty: false,
+		}),
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	got, err := p.DualControllerStatus(ctx)
+	if err != nil {
+		t.Fatalf("DualControllerStatus: %v", err)
+	}
+	if !got.SlaveActive || !got.Active || got.IdleControllerFaulty {
+		t.Errorf("status = %+v; want slave+active, idle ok", got)
+	}
+	req, _ := peer.lastRequest()
+	if req.ID != codec.RxDualControllerStatusRequest {
+		t.Errorf("req ID %#x; want RxDualControllerStatusRequest", req.ID)
+	}
+}
+
+func TestDualControllerStatusNotConnected(t *testing.T) {
+	_, err := freshPlugin().DualControllerStatus(context.Background())
+	if !errors.Is(err, consumer.ErrNotConnected) {
+		t.Fatalf("err = %v; want ErrNotConnected", err)
+	}
+}
+
+func TestDualControllerStatusDecodeErr(t *testing.T) {
+	p, _, cleanup := newPeerHarness(t, replyWith(
+		codec.Frame{ID: codec.TxDualControllerStatusResponse, Payload: []byte{0x00}},
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	_, err := p.DualControllerStatus(ctx)
+	assertTransportDecodeErr(t, err)
+}
+
+// ---- rx 010 Protect Interrogate -------------------------------------------
+
+func TestProtectInterrogate(t *testing.T) {
+	p, peer, cleanup := newPeerHarness(t, replyWith(
+		codec.EncodeProtectTally(codec.ProtectTallyParams{
+			MatrixID: 0, LevelID: 0, DestinationID: 3, DeviceID: 11, State: codec.ProtectProbel,
+		}),
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	got, err := p.ProtectInterrogate(ctx, 0, 0, 3, 11)
+	if err != nil {
+		t.Fatalf("ProtectInterrogate: %v", err)
+	}
+	if got.State != codec.ProtectProbel || got.DeviceID != 11 {
+		t.Errorf("got %+v; want state=Probel device=11", got)
+	}
+	req, _ := peer.lastRequest()
+	if req.ID != codec.RxProtectInterrogate {
+		t.Errorf("req ID %#x; want RxProtectInterrogate", req.ID)
+	}
+}
+
+func TestProtectInterrogateNotConnected(t *testing.T) {
+	_, err := freshPlugin().ProtectInterrogate(context.Background(), 0, 0, 0, 0)
+	if !errors.Is(err, consumer.ErrNotConnected) {
+		t.Fatalf("err = %v; want ErrNotConnected", err)
+	}
+}
+
+func TestProtectInterrogateDecodeErr(t *testing.T) {
+	p, _, cleanup := newPeerHarness(t, replyWith(
+		codec.Frame{ID: codec.TxProtectTally, Payload: []byte{0x00}},
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	_, err := p.ProtectInterrogate(ctx, 0, 0, 0, 0)
+	assertTransportDecodeErr(t, err)
+}
+
+// ---- rx 012 Protect Connect -----------------------------------------------
+
+func TestProtectConnect(t *testing.T) {
+	p, peer, cleanup := newPeerHarness(t, replyWith(
+		codec.EncodeProtectConnected(codec.ProtectConnectedParams{
+			DestinationID: 4, DeviceID: 8, State: codec.ProtectProbel,
+		}),
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	got, err := p.ProtectConnect(ctx, 0, 0, 4, 8)
+	if err != nil {
+		t.Fatalf("ProtectConnect: %v", err)
+	}
+	if got.DestinationID != 4 || got.DeviceID != 8 {
+		t.Errorf("got %+v; want dst=4 device=8", got)
+	}
+	req, _ := peer.lastRequest()
+	if req.ID != codec.RxProtectConnect {
+		t.Errorf("req ID %#x; want RxProtectConnect", req.ID)
+	}
+}
+
+func TestProtectConnectNotConnected(t *testing.T) {
+	_, err := freshPlugin().ProtectConnect(context.Background(), 0, 0, 0, 0)
+	if !errors.Is(err, consumer.ErrNotConnected) {
+		t.Fatalf("err = %v; want ErrNotConnected", err)
+	}
+}
+
+func TestProtectConnectDecodeErr(t *testing.T) {
+	p, _, cleanup := newPeerHarness(t, replyWith(
+		codec.Frame{ID: codec.TxProtectConnected, Payload: []byte{0x00}},
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	_, err := p.ProtectConnect(ctx, 0, 0, 0, 0)
+	assertTransportDecodeErr(t, err)
+}
+
+// ---- rx 014 Protect Disconnect --------------------------------------------
+
+func TestProtectDisconnect(t *testing.T) {
+	p, peer, cleanup := newPeerHarness(t, replyWith(
+		codec.EncodeProtectDisconnected(codec.ProtectDisconnectedParams{
+			DestinationID: 6, DeviceID: 2, State: codec.ProtectNone,
+		}),
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	got, err := p.ProtectDisconnect(ctx, 0, 0, 6, 2)
+	if err != nil {
+		t.Fatalf("ProtectDisconnect: %v", err)
+	}
+	if got.DestinationID != 6 || got.State != codec.ProtectNone {
+		t.Errorf("got %+v; want dst=6 state=None", got)
+	}
+	req, _ := peer.lastRequest()
+	if req.ID != codec.RxProtectDisconnect {
+		t.Errorf("req ID %#x; want RxProtectDisconnect", req.ID)
+	}
+}
+
+func TestProtectDisconnectNotConnected(t *testing.T) {
+	_, err := freshPlugin().ProtectDisconnect(context.Background(), 0, 0, 0, 0)
+	if !errors.Is(err, consumer.ErrNotConnected) {
+		t.Fatalf("err = %v; want ErrNotConnected", err)
+	}
+}
+
+func TestProtectDisconnectDecodeErr(t *testing.T) {
+	p, _, cleanup := newPeerHarness(t, replyWith(
+		codec.Frame{ID: codec.TxProtectDisconnected, Payload: []byte{0x00}},
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	_, err := p.ProtectDisconnect(ctx, 0, 0, 0, 0)
+	assertTransportDecodeErr(t, err)
+}
+
+// ---- rx 017 Protect Device Name -------------------------------------------
+
+func TestProtectDeviceName(t *testing.T) {
+	p, peer, cleanup := newPeerHarness(t, replyWith(
+		codec.EncodeProtectDeviceNameResponse(codec.ProtectDeviceNameResponseParams{
+			DeviceID: 12, DeviceName: "CAM1",
+		}),
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	name, err := p.ProtectDeviceName(ctx, 12)
+	if err != nil {
+		t.Fatalf("ProtectDeviceName: %v", err)
+	}
+	if name != "CAM1" {
+		t.Errorf("name = %q; want CAM1", name)
+	}
+	req, _ := peer.lastRequest()
+	if req.ID != codec.RxProtectDeviceNameRequest {
+		t.Errorf("req ID %#x; want RxProtectDeviceNameRequest", req.ID)
+	}
+}
+
+func TestProtectDeviceNameNotConnected(t *testing.T) {
+	_, err := freshPlugin().ProtectDeviceName(context.Background(), 0)
+	if !errors.Is(err, consumer.ErrNotConnected) {
+		t.Fatalf("err = %v; want ErrNotConnected", err)
+	}
+}
+
+func TestProtectDeviceNameDecodeErr(t *testing.T) {
+	p, _, cleanup := newPeerHarness(t, replyWith(
+		codec.Frame{ID: codec.TxProtectDeviceNameResponse, Payload: []byte{0x00}},
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	_, err := p.ProtectDeviceName(ctx, 0)
+	assertTransportDecodeErr(t, err)
+}
+
+// ---- rx 019 Protect Tally Dump --------------------------------------------
+
+func TestProtectTallyDump(t *testing.T) {
+	p, peer, cleanup := newPeerHarness(t, replyWith(
+		codec.EncodeProtectTallyDump(codec.ProtectTallyDumpParams{
+			MatrixID: 0, LevelID: 0, FirstDestinationID: 0,
+			Items: []codec.ProtectTallyItem{
+				{State: codec.ProtectProbel, DeviceID: 1},
+				{State: codec.ProtectNone, DeviceID: 0},
+			},
+		}),
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	got, err := p.ProtectTallyDump(ctx, 0, 0, 0)
+	if err != nil {
+		t.Fatalf("ProtectTallyDump: %v", err)
+	}
+	if len(got.Items) != 2 || got.Items[0].DeviceID != 1 {
+		t.Errorf("items = %+v; want 2 items, first device 1", got.Items)
+	}
+	req, _ := peer.lastRequest()
+	if req.ID != codec.RxProtectTallyDumpRequest {
+		t.Errorf("req ID %#x; want RxProtectTallyDumpRequest", req.ID)
+	}
+}
+
+func TestProtectTallyDumpNotConnected(t *testing.T) {
+	_, err := freshPlugin().ProtectTallyDump(context.Background(), 0, 0, 0)
+	if !errors.Is(err, consumer.ErrNotConnected) {
+		t.Fatalf("err = %v; want ErrNotConnected", err)
+	}
+}
+
+func TestProtectTallyDumpDecodeErr(t *testing.T) {
+	p, _, cleanup := newPeerHarness(t, replyWith(
+		codec.Frame{ID: codec.TxProtectTallyDump, Payload: []byte{0x00}},
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	_, err := p.ProtectTallyDump(ctx, 0, 0, 0)
+	assertTransportDecodeErr(t, err)
+}
+
+// ---- rx 021 Crosspoint Tally Dump (byte + word) ---------------------------
+
+func TestCrosspointTallyDumpByte(t *testing.T) {
+	p, peer, cleanup := newPeerHarness(t, replyWith(
+		codec.EncodeCrosspointTallyDumpByte(codec.CrosspointTallyDumpByteParams{
+			MatrixID: 0, LevelID: 0, FirstDestinationID: 0,
+			SourceIDs: []uint8{1, 2, 3},
+		}),
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	got, err := p.CrosspointTallyDump(ctx, 0, 0)
+	if err != nil {
+		t.Fatalf("CrosspointTallyDump: %v", err)
+	}
+	if got.IsWord {
+		t.Fatal("expected byte form")
+	}
+	if len(got.Byte.SourceIDs) != 3 || got.Byte.SourceIDs[2] != 3 {
+		t.Errorf("byte srcs = %v; want [1 2 3]", got.Byte.SourceIDs)
+	}
+	req, _ := peer.lastRequest()
+	if req.ID != codec.RxCrosspointTallyDumpRequest {
+		t.Errorf("req ID %#x; want RxCrosspointTallyDumpRequest", req.ID)
+	}
+}
+
+func TestCrosspointTallyDumpWord(t *testing.T) {
+	// FirstDestinationID > 191 forces word promotion on the byte encoder;
+	// build the word form directly so the reply is tx 023.
+	p, _, cleanup := newPeerHarness(t, replyWith(
+		codec.EncodeCrosspointTallyDumpWord(codec.CrosspointTallyDumpWordParams{
+			MatrixID: 0, LevelID: 0, FirstDestinationID: 0,
+			SourceIDs: []uint16{300, 1000},
+		}),
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	got, err := p.CrosspointTallyDump(ctx, 0, 0)
+	if err != nil {
+		t.Fatalf("CrosspointTallyDump word: %v", err)
+	}
+	if !got.IsWord {
+		t.Fatal("expected word form")
+	}
+	if len(got.Word.SourceIDs) != 2 || got.Word.SourceIDs[1] != 1000 {
+		t.Errorf("word srcs = %v; want [300 1000]", got.Word.SourceIDs)
+	}
+}
+
+func TestCrosspointTallyDumpNotConnected(t *testing.T) {
+	_, err := freshPlugin().CrosspointTallyDump(context.Background(), 0, 0)
+	if !errors.Is(err, consumer.ErrNotConnected) {
+		t.Fatalf("err = %v; want ErrNotConnected", err)
+	}
+}
+
+func TestCrosspointTallyDumpByteDecodeErr(t *testing.T) {
+	p, _, cleanup := newPeerHarness(t, replyWith(
+		codec.Frame{ID: codec.TxCrosspointTallyDumpByte, Payload: []byte{0x00}},
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	_, err := p.CrosspointTallyDump(ctx, 0, 0)
+	assertTransportDecodeErr(t, err)
+}
+
+func TestCrosspointTallyDumpWordDecodeErr(t *testing.T) {
+	p, _, cleanup := newPeerHarness(t, replyWith(
+		codec.Frame{ID: codec.TxCrosspointTallyDumpWord, Payload: []byte{0x00}},
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	_, err := p.CrosspointTallyDump(ctx, 0, 0)
+	assertTransportDecodeErr(t, err)
+}
+
+// ---- rx 029 Master Protect Connect ----------------------------------------
+
+func TestMasterProtectConnect(t *testing.T) {
+	p, peer, cleanup := newPeerHarness(t, replyWith(
+		codec.EncodeProtectConnected(codec.ProtectConnectedParams{
+			DestinationID: 7, DeviceID: 3, State: codec.ProtectProbelOver,
+		}),
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	got, err := p.MasterProtectConnect(ctx, 0, 0, 7, 3)
+	if err != nil {
+		t.Fatalf("MasterProtectConnect: %v", err)
+	}
+	if got.State != codec.ProtectProbelOver {
+		t.Errorf("state = %v; want ProbelOver", got.State)
+	}
+	req, _ := peer.lastRequest()
+	if req.ID != codec.RxMasterProtectConnect {
+		t.Errorf("req ID %#x; want RxMasterProtectConnect", req.ID)
+	}
+}
+
+func TestMasterProtectConnectNotConnected(t *testing.T) {
+	_, err := freshPlugin().MasterProtectConnect(context.Background(), 0, 0, 0, 0)
+	if !errors.Is(err, consumer.ErrNotConnected) {
+		t.Fatalf("err = %v; want ErrNotConnected", err)
+	}
+}
+
+func TestMasterProtectConnectDecodeErr(t *testing.T) {
+	p, _, cleanup := newPeerHarness(t, replyWith(
+		codec.Frame{ID: codec.TxProtectConnected, Payload: []byte{0x00}},
+	))
+	defer cleanup()
+	ctx, cancel := ctxT(t)
+	defer cancel()
+	_, err := p.MasterProtectConnect(ctx, 0, 0, 0, 0)
+	assertTransportDecodeErr(t, err)
+}

--- a/internal/probel-sw08p/consumer/connect_callbacks_test.go
+++ b/internal/probel-sw08p/consumer/connect_callbacks_test.go
@@ -1,0 +1,216 @@
+package probelsw08p
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"dhs/internal/probel-sw08p/codec"
+)
+
+// dialPlugin connects a Plugin to a TCP listener and returns it with a
+// cleanup. logger output is discarded.
+func dialPlugin(t *testing.T, port int) *Plugin {
+	t.Helper()
+	p := &Plugin{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := p.Connect(ctx, "127.0.0.1", port); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	return p
+}
+
+// TestConnectPortZeroDefault covers the `if port == 0 { port = DefaultPort }`
+// branch by binding a listener on DefaultPort and connecting with port 0.
+func TestConnectPortZeroDefault(t *testing.T) {
+	ln, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", itoa(codec.DefaultPort)))
+	if err != nil {
+		t.Skipf("DefaultPort %d not bindable on this host: %v", codec.DefaultPort, err)
+	}
+	defer func() { _ = ln.Close() }()
+	go func() {
+		c, aerr := ln.Accept()
+		if aerr != nil {
+			return
+		}
+		go func(c net.Conn) { _, _ = io.Copy(io.Discard, c) }(c)
+	}()
+
+	p := dialPlugin(t, 0) // port 0 → DefaultPort
+	defer func() { _ = p.Disconnect() }()
+	if p.port != codec.DefaultPort {
+		t.Errorf("resolved port = %d; want DefaultPort %d", p.port, codec.DefaultPort)
+	}
+}
+
+// TestConnectOnTimeout covers the OnTimeout compliance callback: a peer
+// that accepts but never ACKs forces the Send retry loop to time out.
+func TestConnectOnTimeout(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+	go func() {
+		c, aerr := ln.Accept()
+		if aerr != nil {
+			return
+		}
+		// Drain but never ACK.
+		go func(c net.Conn) { _, _ = io.Copy(io.Discard, c) }(c)
+	}()
+	port := portOf(t, ln)
+
+	p := dialPlugin(t, port)
+	defer func() { _ = p.Disconnect() }()
+
+	// Bound the call so we don't wait the full 5×1s retry budget; the
+	// first attempt's 1s ACK timer fires OnTimeout before ctx expires.
+	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+	defer cancel()
+	_ = p.Maintenance(ctx, codec.MaintSoftReset, 0, 0)
+
+	prof := p.ComplianceProfile()
+	if prof == nil {
+		t.Fatal("nil compliance profile")
+	}
+	if prof.Snapshot()[ACKTimeoutElapsed] == 0 {
+		t.Error("ACKTimeoutElapsed not recorded; OnTimeout callback never fired")
+	}
+}
+
+// TestConnectOnNoACK covers the OnNoACK callback: a peer that sends the
+// application reply BEFORE the §2 DLE ACK triggers the reply-before-ack
+// deviation path.
+func TestConnectOnNoACK(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	go func() {
+		c, aerr := ln.Accept()
+		if aerr != nil {
+			return
+		}
+		defer func() { _ = c.Close() }()
+		buf := make([]byte, 256)
+		acc := make([]byte, 0, 256)
+		for {
+			n, rerr := c.Read(buf)
+			if rerr != nil {
+				return
+			}
+			acc = append(acc, buf[:n]...)
+			for len(acc) >= 2 {
+				if codec.IsACK(acc) || codec.IsNAK(acc) {
+					acc = acc[2:]
+					continue
+				}
+				if acc[0] != codec.DLE {
+					acc = acc[1:]
+					continue
+				}
+				f, consumed, perr := codec.Unpack(acc)
+				if errors.Is(perr, io.ErrUnexpectedEOF) {
+					break
+				}
+				if perr != nil {
+					acc = acc[2:]
+					continue
+				}
+				acc = acc[consumed:]
+				if f.ID == codec.RxCrosspointInterrogate {
+					// Reply FIRST, then ACK — the reply-before-ack deviation.
+					reply := codec.EncodeCrosspointTally(codec.CrosspointTallyParams{
+						DestinationID: 1, SourceID: 2,
+					})
+					_, _ = c.Write(codec.Pack(reply))
+					_, _ = c.Write(codec.PackACK())
+				}
+			}
+		}
+	}()
+	port := portOf(t, ln)
+
+	p := dialPlugin(t, port)
+	defer func() { _ = p.Disconnect() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if _, err := p.CrosspointInterrogate(ctx, 0, 0, 1); err != nil {
+		t.Fatalf("CrosspointInterrogate: %v", err)
+	}
+	if p.ComplianceProfile().Snapshot()[ReplyWithoutACK] == 0 {
+		t.Error("ReplyWithoutACK not recorded; OnNoACK callback never fired")
+	}
+}
+
+// TestConnectOnCapSoft covers the OnCapSoft callback: an outbound frame
+// whose DATA field exceeds the 128-byte soft cap fires the oversize
+// compliance event.
+func TestConnectOnCapSoft(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+	go func() {
+		c, aerr := ln.Accept()
+		if aerr != nil {
+			return
+		}
+		defer func() { _ = c.Close() }()
+		buf := make([]byte, 1024)
+		for {
+			n, rerr := c.Read(buf)
+			if rerr != nil {
+				return
+			}
+			// ACK anything frame-shaped so the Send completes.
+			if n >= 2 && buf[0] == codec.DLE {
+				_, _ = c.Write(codec.PackACK())
+			}
+		}
+	}()
+	port := portOf(t, ln)
+
+	p := dialPlugin(t, port)
+	defer func() { _ = p.Disconnect() }()
+
+	cli, err := p.ExposeClient()
+	if err != nil {
+		t.Fatalf("ExposeClient: %v", err)
+	}
+	// 200-byte payload → DATA field (ID + payload) = 201 > DataCapSoft(128).
+	big := codec.Frame{ID: codec.RxMaintenance, Payload: make([]byte, 200)}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if _, err := cli.Send(ctx, big, nil); err != nil {
+		t.Fatalf("Send big frame: %v", err)
+	}
+	if p.ComplianceProfile().Snapshot()[DataFieldOversize] == 0 {
+		t.Error("DataFieldOversize not recorded; OnCapSoft callback never fired")
+	}
+}
+
+// itoa is a tiny int→string without importing strconv at call sites.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}

--- a/internal/probel-sw08p/consumer/harness_test.go
+++ b/internal/probel-sw08p/consumer/harness_test.go
@@ -1,0 +1,144 @@
+package probelsw08p
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"dhs/internal/probel-sw08p/codec"
+)
+
+// matrixPeer plays the matrix side of a SW-P-08 session over one half of
+// a net.Pipe. It runs a reader goroutine that, per SW-P-08 §2, emits a
+// DLE ACK for every well-framed inbound frame and then invokes the
+// caller-supplied handler with the decoded request. The handler returns
+// the reply frames (already codec.Encode*'d) the peer should write back;
+// each reply is Pack'd and is itself ACKed by the plugin's reader.
+//
+// A nil/empty reply slice means "ACK only, no application reply" — the
+// shape Maintenance / UpdateNameRequest expect.
+type matrixPeer struct {
+	t       *testing.T
+	conn    net.Conn
+	handler func(req codec.Frame) []codec.Frame
+
+	mu       sync.Mutex
+	requests []codec.Frame
+	done     chan struct{}
+}
+
+// newPeerHarness wires a Plugin to a fresh in-memory matrix peer. The
+// returned Plugin has a live codec.Client on the A side; the peer plays
+// the B side using handler to script replies. cleanup tears both down.
+func newPeerHarness(t *testing.T, handler func(req codec.Frame) []codec.Frame) (*Plugin, *matrixPeer, func()) {
+	t.Helper()
+	a, b := net.Pipe()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	disable := false
+	client := codec.NewClientFromConn(a, logger, codec.ClientConfig{WireHexLog: &disable})
+
+	peer := &matrixPeer{
+		t:       t,
+		conn:    b,
+		handler: handler,
+		done:    make(chan struct{}),
+	}
+	go peer.run()
+
+	p := &Plugin{logger: logger}
+	p.client = client
+	p.host = "test"
+	p.port = codec.DefaultPort
+
+	cleanup := func() {
+		_ = client.Close()
+		_ = b.Close()
+		select {
+		case <-peer.done:
+		case <-time.After(2 * time.Second):
+			t.Error("matrix peer did not exit")
+		}
+	}
+	return p, peer, cleanup
+}
+
+// run is the peer's read loop: accumulate bytes, ACK each frame, then
+// write the handler's replies.
+func (m *matrixPeer) run() {
+	defer close(m.done)
+	buf := make([]byte, 0, 512)
+	tmp := make([]byte, 512)
+	for {
+		n, err := m.conn.Read(tmp)
+		if err != nil {
+			return
+		}
+		buf = append(buf, tmp[:n]...)
+		for len(buf) >= 2 {
+			if codec.IsACK(buf) || codec.IsNAK(buf) {
+				buf = buf[2:]
+				continue
+			}
+			if buf[0] != codec.DLE {
+				buf = buf[1:]
+				continue
+			}
+			f, consumed, perr := codec.Unpack(buf)
+			if errors.Is(perr, io.ErrUnexpectedEOF) {
+				break
+			}
+			if perr != nil {
+				if _, werr := m.conn.Write(codec.PackNAK()); werr != nil {
+					return
+				}
+				buf = buf[2:]
+				continue
+			}
+			buf = buf[consumed:]
+
+			// Record the request before ACKing so a match==nil Send that
+			// returns on ACK alone always sees it via lastRequest().
+			m.mu.Lock()
+			m.requests = append(m.requests, f)
+			handler := m.handler
+			m.mu.Unlock()
+
+			// §2: ACK the request.
+			if _, werr := m.conn.Write(codec.PackACK()); werr != nil {
+				return
+			}
+
+			if handler == nil {
+				continue
+			}
+			for _, reply := range handler(f) {
+				if _, werr := m.conn.Write(codec.Pack(reply)); werr != nil {
+					return
+				}
+			}
+		}
+	}
+}
+
+// lastRequest returns the most recent decoded request the peer received.
+func (m *matrixPeer) lastRequest() (codec.Frame, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.requests) == 0 {
+		return codec.Frame{}, false
+	}
+	return m.requests[len(m.requests)-1], true
+}
+
+// replyOnce returns a handler that emits the given reply frames for the
+// first request and ACK-only thereafter.
+func replyWith(frames ...codec.Frame) func(codec.Frame) []codec.Frame {
+	return func(codec.Frame) []codec.Frame { return frames }
+}
+
+// ackOnly is a handler that never writes an application reply.
+func ackOnly(codec.Frame) []codec.Frame { return nil }

--- a/internal/probel-sw08p/consumer/keepalive_extra_test.go
+++ b/internal/probel-sw08p/consumer/keepalive_extra_test.go
@@ -1,0 +1,43 @@
+package probelsw08p
+
+import (
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+
+	"dhs/internal/probel-sw08p/codec"
+)
+
+// TestKeepaliveResponderIgnoresNonKeepalive: a frame that is not a
+// keepalive request is ignored (early return, no write).
+func TestKeepaliveResponderIgnoresNonKeepalive(t *testing.T) {
+	p := freshPlugin()
+	fn := p.keepaliveAutoResponder()
+	// A nil client is safe here because the ID check returns before any
+	// client use.
+	fn(nil, codec.Frame{ID: codec.TxCrosspointTally, Payload: []byte{1, 2, 3, 4}})
+}
+
+// TestKeepaliveResponderRejectsBadPayload: a keepalive-id frame carrying a
+// payload fails DecodeKeepaliveRequest and is dropped without a write.
+func TestKeepaliveResponderRejectsBadPayload(t *testing.T) {
+	p := freshPlugin()
+	fn := p.keepaliveAutoResponder()
+	fn(nil, codec.Frame{ID: codec.TxAppKeepaliveRequest, Payload: []byte{0xFF}})
+}
+
+// TestKeepaliveResponderWriteFailureLogged: a valid keepalive on a closed
+// client exercises the cli.Write error → Warn log branch.
+func TestKeepaliveResponderWriteFailureLogged(t *testing.T) {
+	a, b := net.Pipe()
+	_ = b.Close()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	disable := false
+	cli := codec.NewClientFromConn(a, logger, codec.ClientConfig{WireHexLog: &disable})
+	_ = cli.Close() // closing makes Write return net.ErrClosed
+
+	p := &Plugin{logger: logger}
+	fn := p.keepaliveAutoResponder()
+	fn(cli, codec.EncodeKeepaliveRequest()) // ID ok, payload empty → reaches Write, fails
+}

--- a/internal/probel-sw08p/consumer/plugin_extra_test.go
+++ b/internal/probel-sw08p/consumer/plugin_extra_test.go
@@ -1,0 +1,237 @@
+package probelsw08p
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/consumer"
+	"dhs/internal/export/canonical"
+	"dhs/internal/transport"
+)
+
+// portOf parses the port from a listener's address string.
+func portOf(t *testing.T, ln net.Listener) int {
+	t.Helper()
+	_, portStr, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatalf("SplitHostPort: %v", err)
+	}
+	var port int
+	for _, c := range portStr {
+		port = port*10 + int(c-'0')
+	}
+	return port
+}
+
+// ---- GetDeviceInfo / GetSlotInfo / ExposeClient / Unsubscribe -------------
+
+func TestGetDeviceInfoNotConnected(t *testing.T) {
+	_, err := freshPlugin().GetDeviceInfo(context.Background())
+	if !errors.Is(err, consumer.ErrNotConnected) {
+		t.Fatalf("err = %v; want ErrNotConnected", err)
+	}
+}
+
+func TestGetDeviceInfoConnected(t *testing.T) {
+	p, _, cleanup := newPeerHarness(t, ackOnly)
+	defer cleanup()
+	info, err := p.GetDeviceInfo(context.Background())
+	if err != nil {
+		t.Fatalf("GetDeviceInfo: %v", err)
+	}
+	if info.IP != "test" || info.Port != codec.DefaultPort {
+		t.Errorf("info = %+v; want IP=test port=%d", info, codec.DefaultPort)
+	}
+}
+
+func TestGetSlotInfoNotImplemented(t *testing.T) {
+	_, err := freshPlugin().GetSlotInfo(context.Background(), 0)
+	if !errors.Is(err, consumer.ErrNotImplemented) {
+		t.Fatalf("err = %v; want ErrNotImplemented", err)
+	}
+}
+
+func TestExposeClient(t *testing.T) {
+	p, _, cleanup := newPeerHarness(t, ackOnly)
+	defer cleanup()
+	cli, err := p.ExposeClient()
+	if err != nil {
+		t.Fatalf("ExposeClient: %v", err)
+	}
+	if cli == nil {
+		t.Fatal("ExposeClient returned nil client")
+	}
+}
+
+func TestExposeClientNotConnected(t *testing.T) {
+	_, err := freshPlugin().ExposeClient()
+	if !errors.Is(err, consumer.ErrNotConnected) {
+		t.Fatalf("err = %v; want ErrNotConnected", err)
+	}
+}
+
+func TestUnsubscribeNotImplemented(t *testing.T) {
+	if err := freshPlugin().Unsubscribe(consumer.ValueRequest{}); !errors.Is(err, consumer.ErrNotImplemented) {
+		t.Fatalf("err = %v; want ErrNotImplemented", err)
+	}
+}
+
+// ---- Connect: idempotency, conflict, and recorder wiring ------------------
+
+func TestConnectIdempotentAndConflict(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+	go func() {
+		for {
+			c, aerr := ln.Accept()
+			if aerr != nil {
+				return
+			}
+			go func(c net.Conn) { _, _ = io.Copy(io.Discard, c) }(c)
+		}
+	}()
+	port := portOf(t, ln)
+
+	p := &Plugin{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := p.Connect(ctx, "127.0.0.1", port); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer func() { _ = p.Disconnect() }()
+
+	// Same endpoint, port 0 → resolves to existing connection, idempotent nil.
+	if err := p.Connect(ctx, "127.0.0.1", 0); err != nil {
+		t.Errorf("idempotent Connect(port 0) = %v; want nil", err)
+	}
+	// Same endpoint, same port → idempotent nil.
+	if err := p.Connect(ctx, "127.0.0.1", port); err != nil {
+		t.Errorf("idempotent Connect(same port) = %v; want nil", err)
+	}
+	// Different host → conflict error.
+	if err := p.Connect(ctx, "127.0.0.2", port); err == nil {
+		t.Error("Connect to different host returned nil; want already-connected error")
+	}
+}
+
+func TestConnectDialError(t *testing.T) {
+	// Port 1 on loopback is almost certainly refused → TransportError.
+	p := &Plugin{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err := p.Connect(ctx, "127.0.0.1", 1)
+	if err == nil {
+		t.Fatal("Connect to refused port returned nil; want TransportError")
+	}
+	var te *consumer.TransportError
+	if !errors.As(err, &te) {
+		t.Fatalf("err = %T; want *consumer.TransportError", err)
+	}
+	if te.Op != "connect" {
+		t.Errorf("TransportError.Op = %q; want connect", te.Op)
+	}
+}
+
+func TestConnectWithRecorder(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	srvDone := make(chan struct{})
+	go func() {
+		defer close(srvDone)
+		c, aerr := ln.Accept()
+		if aerr != nil {
+			return
+		}
+		defer func() { _ = c.Close() }()
+		// Read the maintenance frame and ACK it so the recorder logs rx too.
+		buf := make([]byte, 256)
+		if _, rerr := c.Read(buf); rerr == nil {
+			_, _ = c.Write(codec.PackACK())
+		}
+		time.Sleep(50 * time.Millisecond)
+	}()
+	port := portOf(t, ln)
+
+	recPath := filepath.Join(t.TempDir(), "cap.jsonl")
+	rec, err := transport.NewRecorder(recPath)
+	if err != nil {
+		t.Fatalf("NewRecorder: %v", err)
+	}
+	defer func() { _ = rec.Close() }()
+
+	p := &Plugin{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	p.SetRecorder(rec)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := p.Connect(ctx, "127.0.0.1", port); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer func() { _ = p.Disconnect() }()
+
+	// Drive one frame so the recorder OnTx/OnRx wrappers run.
+	_ = p.Maintenance(ctx, codec.MaintSoftReset, 0, 0)
+	<-srvDone
+}
+
+// ---- Canonicalize ---------------------------------------------------------
+
+func TestCanonicalizeEmpty(t *testing.T) {
+	p := freshPlugin()
+	exp, err := p.Canonicalize(context.Background())
+	if err != nil {
+		t.Fatalf("Canonicalize: %v", err)
+	}
+	root, ok := exp.Root.(*canonical.Node)
+	if !ok {
+		t.Fatalf("root type = %T; want *canonical.Node", exp.Root)
+	}
+	if root.Identifier != "device" {
+		t.Errorf("root identifier = %q; want device", root.Identifier)
+	}
+	if len(root.Children) != 0 {
+		t.Errorf("empty config: children = %d; want 0", len(root.Children))
+	}
+}
+
+func TestCanonicalizeWithMatrixConfig(t *testing.T) {
+	p := freshPlugin()
+	p.host = "10.0.0.1"
+	p.SetMatrixConfig(MatrixConfig{MatrixID: 2, Level: 3, Dsts: 16, Srcs: 8})
+	exp, err := p.Canonicalize(context.Background())
+	if err != nil {
+		t.Fatalf("Canonicalize: %v", err)
+	}
+	root, ok := exp.Root.(*canonical.Node)
+	if !ok {
+		t.Fatalf("root type = %T; want *canonical.Node", exp.Root)
+	}
+	if root.Identifier != "10.0.0.1" {
+		t.Errorf("root identifier = %q; want host", root.Identifier)
+	}
+	if len(root.Children) != 1 {
+		t.Fatalf("children = %d; want 1 matrix", len(root.Children))
+	}
+}
+
+func TestCanonicalizeCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := freshPlugin().Canonicalize(ctx); err == nil {
+		t.Fatal("Canonicalize with canceled ctx returned nil; want error")
+	}
+}

--- a/internal/probel-sw08p/consumer/validate_extra_test.go
+++ b/internal/probel-sw08p/consumer/validate_extra_test.go
@@ -1,0 +1,120 @@
+package probelsw08p
+
+import (
+	"context"
+	"encoding/hex"
+	"testing"
+
+	"dhs/internal/probel-sw08p/codec"
+	"dhs/internal/consumer"
+	"dhs/internal/wiretrace"
+)
+
+func hexFrame(f codec.Frame) string {
+	return hex.EncodeToString(codec.Pack(f))
+}
+
+// TestValidateHappyPath drives ACK, NAK, a good application frame, an
+// unknown-command frame, a bad-hex trame, and a malformed (Unpack-failing)
+// frame in one pass — covering every branch of Validate + shortHex.
+func TestValidateHappyPath(t *testing.T) {
+	good := codec.EncodeCrosspointTally(codec.CrosspointTallyParams{DestinationID: 1, SourceID: 2})
+
+	// Unknown command id: a well-framed frame whose ID is not in the
+	// catalogue. 0x7E (126) is unused in the SW-P-08 table.
+	unknown := codec.Frame{ID: codec.CommandID(0x7E), Payload: []byte{0x00}}
+
+	// A frame that Unpack rejects: DLE STX then garbage with no DLE ETX
+	// resolution — corrupt the checksum by flipping the last data byte.
+	bad := codec.Pack(good)
+	badHex := hex.EncodeToString(bad[:len(bad)-2]) // truncate the DLE ETX → ErrUnpack path
+
+	trames := []wiretrace.Trame{
+		{Direction: wiretrace.DirectionRx, Hex: hex.EncodeToString(codec.PackACK())},
+		{Direction: wiretrace.DirectionRx, Hex: hex.EncodeToString(codec.PackNAK())},
+		{Direction: wiretrace.DirectionTx, Hex: hexFrame(good)},
+		{Direction: wiretrace.DirectionTx, Hex: hexFrame(unknown)},
+		{Direction: wiretrace.DirectionRx, Hex: "zzzz"},  // bad hex
+		{Direction: wiretrace.DirectionRx, Hex: badHex},  // Unpack error
+	}
+
+	p := freshPlugin()
+	report, err := p.Validate(context.Background(), trames, consumer.ValidateOpts{})
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	// ACK + NAK + good + unknown = 4 processed; bad-hex + Unpack-err = 2 errors.
+	if report.TramesProcessed != 4 {
+		t.Errorf("TramesProcessed = %d; want 4", report.TramesProcessed)
+	}
+	if len(report.Errors) != 2 {
+		t.Errorf("Errors = %d; want 2", len(report.Errors))
+	}
+	// NAK invariant + unknown-command invariant = at least 2 invariants.
+	if len(report.Invariants) < 2 {
+		t.Errorf("Invariants = %d; want >= 2", len(report.Invariants))
+	}
+}
+
+// TestValidateShortHexPrefix exercises the >16-byte truncation in shortHex
+// via a long malformed frame.
+func TestValidateShortHexPrefix(t *testing.T) {
+	// A long DLE STX-prefixed buffer with no valid framing → Unpack fails
+	// and HexPrefix runs shortHex over >16 bytes.
+	long := append([]byte{codec.DLE, codec.STX}, make([]byte, 40)...)
+	trames := []wiretrace.Trame{
+		{Direction: wiretrace.DirectionRx, Hex: hex.EncodeToString(long)},
+	}
+	p := freshPlugin()
+	report, err := p.Validate(context.Background(), trames, consumer.ValidateOpts{})
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if len(report.Errors) != 1 {
+		t.Fatalf("Errors = %d; want 1", len(report.Errors))
+	}
+	if len(report.Errors[0].HexPrefix) != 32 { // 16 bytes → 32 hex chars
+		t.Errorf("HexPrefix len = %d; want 32 (16 bytes)", len(report.Errors[0].HexPrefix))
+	}
+}
+
+func TestValidateStopAt(t *testing.T) {
+	good := codec.EncodeCrosspointTally(codec.CrosspointTallyParams{DestinationID: 1, SourceID: 2})
+	trames := []wiretrace.Trame{
+		{Direction: wiretrace.DirectionTx, Hex: hexFrame(good), Note: "first"},
+		{Direction: wiretrace.DirectionTx, Hex: hexFrame(good), Note: "stophere"},
+		{Direction: wiretrace.DirectionTx, Hex: hexFrame(good), Note: "after"},
+	}
+	p := freshPlugin()
+	report, err := p.Validate(context.Background(), trames, consumer.ValidateOpts{StopAt: "stophere"})
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if report.StoppedAt != "stophere" {
+		t.Errorf("StoppedAt = %q; want stophere", report.StoppedAt)
+	}
+	if report.TramesProcessed != 2 {
+		t.Errorf("TramesProcessed = %d; want 2 (stopped after second)", report.TramesProcessed)
+	}
+}
+
+func TestValidateOutTreeUnsupported(t *testing.T) {
+	p := freshPlugin()
+	if _, err := p.Validate(context.Background(), nil, consumer.ValidateOpts{OutTree: "x.json"}); err == nil {
+		t.Fatal("Validate with OutTree returned nil; want not-implemented error")
+	}
+	if _, err := p.Validate(context.Background(), nil, consumer.ValidateOpts{OutParams: "y.json"}); err == nil {
+		t.Fatal("Validate with OutParams returned nil; want not-implemented error")
+	}
+}
+
+func TestValidateContextCanceled(t *testing.T) {
+	good := codec.EncodeCrosspointTally(codec.CrosspointTallyParams{DestinationID: 1, SourceID: 2})
+	trames := []wiretrace.Trame{{Direction: wiretrace.DirectionTx, Hex: hexFrame(good)}}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	p := freshPlugin()
+	if _, err := p.Validate(ctx, trames, consumer.ValidateOpts{}); err == nil {
+		t.Fatal("Validate with canceled ctx returned nil; want ctx error")
+	}
+}


### PR DESCRIPTION
Roadmap C — probel-sw08p consumer 20.1%->100.0%, tests only (no production change). net.Pipe matrix peer; all command arms + compliance callbacks + validate + keepalive. vet+lint clean. Floor in consolidated PR. Closes #576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)