### PR TITLE
ci: lock probel coverage floors (100)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,11 @@ jobs:
           check ./internal/emberplus/consumer 100
           check ./internal/emberplus/provider 100
           check ./internal/probel-sw02p/codec 100
+          check ./internal/probel-sw02p/consumer 100
+          check ./internal/probel-sw02p/provider 100
+          check ./internal/probel-sw08p/codec 100
+          check ./internal/probel-sw08p/consumer 100
+          check ./internal/probel-sw08p/provider 100
 
       - name: Upload coverage
         if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
No-regression floors for the 5 probel packages taken to 100% (sw02p consumer/provider, sw08p codec/consumer/provider); sw02p codec already floored in #569. All packages are at 100% on main now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)