### PR TITLE
test(tsl): codec to 100% coverage (D)

### DIFF
--- a/internal/tsl/codec/tally_test.go
+++ b/internal/tsl/codec/tally_test.go
@@ -1,0 +1,45 @@
+package codec
+
+import "testing"
+
+// TestTallyColor_String pins the canonical spec names for every 2-bit
+// colour value plus the out-of-range fallback.
+func TestTallyColor_String(t *testing.T) {
+	cases := []struct {
+		in   TallyColor
+		want string
+	}{
+		{TallyOff, "off"},
+		{TallyRed, "red"},
+		{TallyGreen, "green"},
+		{TallyAmber, "amber"},
+		{TallyColor(4), "tally-color(4)"},     // out of the 2-bit range
+		{TallyColor(255), "tally-color(255)"}, // fallback path
+	}
+	for _, c := range cases {
+		if got := c.in.String(); got != c.want {
+			t.Errorf("TallyColor(%d).String() = %q, want %q", uint8(c.in), got, c.want)
+		}
+	}
+}
+
+// TestBrightness_String pins the canonical spec names for every 2-bit
+// brightness value plus the out-of-range fallback.
+func TestBrightness_String(t *testing.T) {
+	cases := []struct {
+		in   Brightness
+		want string
+	}{
+		{BrightnessOff, "off"},
+		{BrightnessOneSeveth, "1/7"},
+		{BrightnessHalf, "1/2"},
+		{BrightnessFull, "full"},
+		{Brightness(4), "brightness(4)"},     // out of the 2-bit range
+		{Brightness(255), "brightness(255)"}, // fallback path
+	}
+	for _, c := range cases {
+		if got := c.in.String(); got != c.want {
+			t.Errorf("Brightness(%d).String() = %q, want %q", uint8(c.in), got, c.want)
+		}
+	}
+}

--- a/internal/tsl/codec/v31_frame_test.go
+++ b/internal/tsl/codec/v31_frame_test.go
@@ -24,8 +24,8 @@ func TestV31Encode(t *testing.T) {
 		{
 			name: "addr 1, all tallies, full brightness, 'CAM 1' padded",
 			in: V31Frame{
-				Address:    1,
-				Tally1:     true, Tally2: true, Tally3: true, Tally4: true,
+				Address: 1,
+				Tally1:  true, Tally2: true, Tally3: true, Tally4: true,
 				Brightness: BrightnessFull,
 				Text:       "CAM 1",
 			},
@@ -184,6 +184,57 @@ func TestV31Decode_NullPadNote(t *testing.T) {
 	}
 }
 
+func TestV31Decode_CtrlBit7Set_FiresNote(t *testing.T) {
+	frame := make([]byte, V31FrameSize)
+	frame[0] = 0x80
+	frame[1] = V31CtrlBit7 // CTRL bit 7 set (spec requires it cleared)
+	for i := 2; i < V31FrameSize; i++ {
+		frame[i] = 0x20
+	}
+	f, err := DecodeV31(frame)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	found := false
+	for _, n := range f.Notes {
+		if n.Kind == "tsl_reserved_bit_set" && strings.Contains(n.Detail, "bit 7") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("want tsl_reserved_bit_set (bit 7) note, got %+v", f.Notes)
+	}
+}
+
+func TestV31Decode_NonPrintableLabelByte_FiresCharsetNote(t *testing.T) {
+	// A DATA byte that is neither 0x00 (null-pad path) nor in 0x20..0x7E
+	// must fire tsl_label_charset, keeping the raw bytes.
+	frame := make([]byte, V31FrameSize)
+	frame[0] = 0x80
+	frame[1] = 0x00
+	for i := 2; i < V31FrameSize; i++ {
+		frame[i] = 0x20
+	}
+	frame[V31DataIdx+3] = 0x7F // DEL — outside printable ASCII, non-null
+	f, err := DecodeV31(frame)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	found := false
+	for _, n := range f.Notes {
+		if n.Kind == "tsl_label_charset" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("want tsl_label_charset note, got %+v", f.Notes)
+	}
+	// Raw byte must be preserved verbatim in Text.
+	if f.Text[3] != 0x7F {
+		t.Errorf("raw DATA byte not preserved: Text[3]=0x%02x, want 0x7F", f.Text[3])
+	}
+}
+
 func TestV31Decode_AllAddressesRoundTrip(t *testing.T) {
 	for addr := uint8(0); addr <= V31AddressMax; addr++ {
 		frame := V31Frame{Address: addr, Text: "X"}
@@ -191,7 +242,7 @@ func TestV31Decode_AllAddressesRoundTrip(t *testing.T) {
 		if err != nil {
 			t.Fatalf("addr=%d encode: %v", addr, err)
 		}
-		if wire[0] != (addr|V31HeaderMSB) {
+		if wire[0] != (addr | V31HeaderMSB) {
 			t.Fatalf("addr=%d: wire[0]=0x%02x want 0x%02x", addr, wire[0], addr|V31HeaderMSB)
 		}
 		got, err := DecodeV31(wire)

--- a/internal/tsl/codec/v40_frame_test.go
+++ b/internal/tsl/codec/v40_frame_test.go
@@ -57,8 +57,8 @@ func TestV40Encode_SpecShape(t *testing.T) {
 func TestV40RoundTrip_NoNotes(t *testing.T) {
 	in := V40Frame{
 		V31: V31Frame{
-			Address:    10,
-			Tally2:     true, Tally4: true,
+			Address: 10,
+			Tally2:  true, Tally4: true,
 			Brightness: BrightnessHalf,
 			Text:       "PGM",
 		},
@@ -160,8 +160,8 @@ func TestV40Decode_VBCBit7Set_FiresNote(t *testing.T) {
 func TestV40Decode_CtrlBit6_CommandData_FiresNote(t *testing.T) {
 	// Build a raw v4.0 frame with CTRL.6 set (command data flag).
 	wire := make([]byte, V40FrameSize)
-	wire[0] = 0x80         // addr 0
-	wire[1] = 1 << 6       // CTRL bit 6 set
+	wire[0] = 0x80   // addr 0
+	wire[1] = 1 << 6 // CTRL bit 6 set
 	for i := 2; i < V31FrameSize; i++ {
 		wire[i] = 0x20
 	}
@@ -187,6 +187,71 @@ func TestV40Decode_TooShort(t *testing.T) {
 	_, err := DecodeV40(make([]byte, 19))
 	if !errors.Is(err, ErrV40FrameSize) {
 		t.Errorf("size=19 should hit ErrV40FrameSize, got %v", err)
+	}
+}
+
+func TestXByte_Encode_ReservedBit(t *testing.T) {
+	// Reserved (bit 6) must round-trip through Encode/Decode.
+	x := XByte{LH: TallyRed, Text: TallyGreen, RH: TallyAmber, Reserved: true}
+	b := x.Encode()
+	if b&v40XDataBit6Mask == 0 {
+		t.Fatalf("Reserved bit not set in encoded byte 0x%02x", b)
+	}
+	got := DecodeXByte(b)
+	if !got.Reserved {
+		t.Errorf("Reserved did not round-trip: %+v", got)
+	}
+	if got.LH != TallyRed || got.Text != TallyGreen || got.RH != TallyAmber {
+		t.Errorf("colour fields corrupted with Reserved set: %+v", got)
+	}
+}
+
+func TestComputeV40Chksum_ShortBody(t *testing.T) {
+	// A body shorter than the 18-byte v3.1 block returns 0 (guard arm).
+	if got := computeV40Chksum(make([]byte, V31FrameSize-1)); got != 0 {
+		t.Errorf("short body checksum = 0x%02x, want 0x00", got)
+	}
+}
+
+func TestV40Encode_PropagatesV31Error(t *testing.T) {
+	// V31.Encode rejects an out-of-range address; V40.Encode must surface it.
+	f := V40Frame{V31: V31Frame{Address: 200}}
+	if _, err := f.Encode(); !errors.Is(err, ErrV31AddressRng) {
+		t.Errorf("want ErrV31AddressRng propagated, got %v", err)
+	}
+}
+
+func TestV40Decode_PropagatesV31Error(t *testing.T) {
+	// v3.1 section with HEADER bit 7 clear is structurally unparseable.
+	wire := make([]byte, V40FrameSize)
+	wire[0] = 0x00 // HEADER MSB clear
+	if _, err := DecodeV40(wire); !errors.Is(err, ErrV31HeaderMSB) {
+		t.Errorf("want ErrV31HeaderMSB propagated, got %v", err)
+	}
+}
+
+func TestV40Decode_XDataCountExceedsAvailable_FiresNote(t *testing.T) {
+	// Minimum-size frame (20 bytes: v3.1 + CHKSUM + VBC, no XDATA) but VBC
+	// claims a non-zero XDATA count. available = len-20 = 0, count > 0.
+	wire := make([]byte, V31FrameSize+2)
+	wire[0] = 0x80
+	for i := 2; i < V31FrameSize; i++ {
+		wire[i] = 0x20
+	}
+	wire[V40ChksumIdx] = computeV40Chksum(wire[:V31FrameSize])
+	wire[V40VBCIdx] = 2 // minor=0, xdata count=2 but no XDATA bytes present
+	got, err := DecodeV40(wire)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	found := false
+	for _, n := range got.Notes {
+		if n.Kind == "tsl_v40_xdata_truncated" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("want tsl_v40_xdata_truncated note, got %+v", got.Notes)
 	}
 }
 

--- a/internal/tsl/codec/v50_dle_stx_test.go
+++ b/internal/tsl/codec/v50_dle_stx_test.go
@@ -48,7 +48,7 @@ func TestDLEFrame_ByteStuffing_SingleDLEInBody(t *testing.T) {
 
 func TestDLEFrame_ByteStuffing_MultipleFrames(t *testing.T) {
 	// Two successive frames in one stream.
-	a := []byte{0x02, 0x00, 0xAA, 0xBB}  // PBC=2, two data bytes
+	a := []byte{0x02, 0x00, 0xAA, 0xBB}     // PBC=2, two data bytes
 	b := []byte{0x03, 0x00, DLE, 0xCC, DLE} // PBC=3, includes 2 DLEs that get stuffed
 	stream := append(EncodeDLEFrame(a), EncodeDLEFrame(b)...)
 
@@ -104,6 +104,115 @@ func TestDLEFrame_TruncatedMidFrame(t *testing.T) {
 	_, err := NewDLEStreamDecoder(bytes.NewReader(stream), 0).ReadFrame()
 	if err == nil || err == io.EOF {
 		t.Errorf("want unexpected-EOF, got %v", err)
+	}
+}
+
+// errReader returns data once, then a fixed non-EOF error — used to drive
+// the ensureBytes reader-error arm that io.EOF can't reach.
+type errReader struct {
+	data []byte
+	err  error
+	done bool
+}
+
+func (r *errReader) Read(p []byte) (int, error) {
+	if !r.done && len(r.data) > 0 {
+		n := copy(p, r.data)
+		r.data = r.data[n:]
+		if len(r.data) == 0 {
+			r.done = true
+		}
+		return n, nil
+	}
+	return 0, r.err
+}
+
+// dataEOFReader returns its whole buffer plus io.EOF in a SINGLE Read call
+// (legal per io.Reader), then io.EOF forever after — exercising the
+// ensureBytes arm where k>0 and err==io.EOF arrive together with bytes
+// still buffered beyond what was requested.
+type dataEOFReader struct {
+	data []byte
+	done bool
+}
+
+func (r *dataEOFReader) Read(p []byte) (int, error) {
+	if r.done {
+		return 0, io.EOF
+	}
+	n := copy(p, r.data)
+	r.done = true
+	return n, io.EOF
+}
+
+func TestDLEFrame_DataPlusEOFSameRead_UnexpectedEOF(t *testing.T) {
+	// A Read that returns body bytes together with io.EOF (legal per the
+	// io.Reader contract) and leaves bytes still buffered exercises the
+	// ensureBytes "EOF with leftover" arm, which yields ErrUnexpectedEOF
+	// rather than a clean io.EOF.
+	r := &dataEOFReader{data: []byte{DLE, STX, 0x05}}
+	_, err := NewDLEStreamDecoder(r, 0).ReadFrame()
+	if err != io.ErrUnexpectedEOF {
+		t.Errorf("want ErrUnexpectedEOF, got %v", err)
+	}
+}
+
+func TestDLEFrame_ReaderError_Propagated(t *testing.T) {
+	// A non-EOF reader error mid-frame must propagate verbatim (not be
+	// remapped to ErrUnexpectedEOF).
+	sentinel := errors.New("network down")
+	r := &errReader{data: []byte{DLE, STX}, err: sentinel}
+	_, err := NewDLEStreamDecoder(r, 0).ReadFrame()
+	if !errors.Is(err, sentinel) {
+		t.Errorf("want sentinel reader error, got %v", err)
+	}
+}
+
+func TestDLEFrame_EOFAfterStartByte_UnexpectedEOF(t *testing.T) {
+	// Stream is exactly one DLE then EOF. The first byte (DLE) succeeds,
+	// the strict read of STX hits EOF → ErrUnexpectedEOF.
+	r := &errReader{data: []byte{DLE}, err: io.EOF}
+	_, err := NewDLEStreamDecoder(r, 0).ReadFrame()
+	if err != io.ErrUnexpectedEOF {
+		t.Errorf("want ErrUnexpectedEOF, got %v", err)
+	}
+}
+
+func TestDLEFrame_DLENotFollowedBySTX(t *testing.T) {
+	// DLE followed by a non-STX byte at start is a missing-start error.
+	stream := []byte{DLE, 0x03, 0x00, 0x00}
+	_, err := NewDLEStreamDecoder(bytes.NewReader(stream), 0).ReadFrame()
+	if !errors.Is(err, ErrDLEMissingStart) {
+		t.Errorf("want ErrDLEMissingStart, got %v", err)
+	}
+}
+
+func TestDLEFrame_TruncatedBeforePBC(t *testing.T) {
+	// DLE/STX then immediate EOF — can't read the 2-byte PBC.
+	stream := []byte{DLE, STX}
+	_, err := NewDLEStreamDecoder(bytes.NewReader(stream), 0).ReadFrame()
+	if err != io.ErrUnexpectedEOF {
+		t.Errorf("want ErrUnexpectedEOF reading PBC, got %v", err)
+	}
+}
+
+func TestDLEFrame_PBCExceedsMax(t *testing.T) {
+	// PBC larger than maxPktSize-2 must reject with ErrV50PacketTooLarge.
+	// maxPktSize=8 → max body PBC = 6; PBC=10 overflows.
+	stream := []byte{DLE, STX, 0x0A, 0x00} // PBC=10 LE
+	_, err := NewDLEStreamDecoder(bytes.NewReader(stream), 8).ReadFrame()
+	if !errors.Is(err, ErrV50PacketTooLarge) {
+		t.Errorf("want ErrV50PacketTooLarge, got %v", err)
+	}
+}
+
+func TestDLEFrame_TruncatedInsideEscape(t *testing.T) {
+	// A DLE in the body followed by EOF (no second escape byte) is a
+	// mid-frame truncation.
+	stream := []byte{DLE, STX, 0x02, 0x00, DLE} // PBC=2, then lone DLE, EOF
+	_, err := NewDLEStreamDecoder(bytes.NewReader(stream), 0).ReadFrame()
+	if err != io.ErrUnexpectedEOF {
+		t.Errorf("want ErrUnexpectedEOF inside escape, got %v", err)
 	}
 }
 

--- a/internal/tsl/codec/v50_packet_test.go
+++ b/internal/tsl/codec/v50_packet_test.go
@@ -1,8 +1,10 @@
 package codec
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -204,6 +206,212 @@ func TestV50Decode_PacketTooSmall(t *testing.T) {
 	_, err := DecodeV50(make([]byte, 4))
 	if !errors.Is(err, ErrV50PacketTooSmall) {
 		t.Errorf("want ErrV50PacketTooSmall, got %v", err)
+	}
+}
+
+func TestV50_SControl_RoundTrip(t *testing.T) {
+	// SControl body is opaque: Encode appends SControlRaw verbatim, Decode
+	// returns it in SControlRaw and fires the undefined-control note.
+	raw := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	in := V50Packet{SControl: true, Screen: 9, SControlRaw: raw}
+	wire, err := in.Encode()
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if wire[V50FLAGSIdx]&(1<<1) == 0 {
+		t.Errorf("SCONTROL flag bit not set: FLAGS=0x%02x", wire[V50FLAGSIdx])
+	}
+	got, err := DecodeV50(wire)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !got.SControl {
+		t.Errorf("SControl flag lost on decode")
+	}
+	if !bytes.Equal(got.SControlRaw, raw) {
+		t.Errorf("SControlRaw=% x, want % x", got.SControlRaw, raw)
+	}
+	found := false
+	for _, n := range got.Notes {
+		if n.Kind == "tsl_control_data_undefined" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("want tsl_control_data_undefined note, got %+v", got.Notes)
+	}
+}
+
+func TestV50Encode_TextTooLong(t *testing.T) {
+	// A single DMSG TEXT longer than 0xFFFF bytes hits the per-DMSG length
+	// guard before the packet-size guard. 0x10000 printable ASCII bytes.
+	long := strings.Repeat("A", 0x10000)
+	p := V50Packet{DMSGs: []DMSG{{Index: 0, Text: long}}}
+	_, err := p.Encode()
+	if err == nil || !strings.Contains(err.Error(), "TEXT too long") {
+		t.Errorf("want TEXT-too-long error, got %v", err)
+	}
+}
+
+func TestV50Encode_PacketTooLarge(t *testing.T) {
+	// Body just over the 2048-byte cap (after the 2-byte PBC) must reject.
+	// A ~2050-byte ASCII label keeps each DMSG length under 0xFFFF so the
+	// packet-size guard (not the TEXT guard) fires.
+	p := V50Packet{DMSGs: []DMSG{{Index: 0, Text: strings.Repeat("A", 2050)}}}
+	_, err := p.Encode()
+	if !errors.Is(err, ErrV50PacketTooLarge) {
+		t.Errorf("want ErrV50PacketTooLarge, got %v", err)
+	}
+}
+
+func TestV50Decode_PacketTooLarge(t *testing.T) {
+	// A buffer larger than the 2048 maximum is rejected before parsing.
+	big := make([]byte, V50MaxPacketSize+1)
+	if _, err := DecodeV50(big); !errors.Is(err, ErrV50PacketTooLarge) {
+		t.Errorf("want ErrV50PacketTooLarge, got %v", err)
+	}
+}
+
+func TestV50Decode_UnknownVersion_FiresNote(t *testing.T) {
+	in := V50Packet{DMSGs: []DMSG{{Index: 1, Text: "X"}}}
+	wire, err := in.Encode()
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	wire[V50VERIdx] = 1 // non-zero minor version
+	got, err := DecodeV50(wire)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	found := false
+	for _, n := range got.Notes {
+		if n.Kind == "tsl_version_mismatch" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("want tsl_version_mismatch note, got %+v", got.Notes)
+	}
+}
+
+func TestV50Decode_BroadcastIndex_FiresNote(t *testing.T) {
+	in := V50Packet{Screen: 0, DMSGs: []DMSG{{Index: V50BroadcastIdx, Text: "X"}}}
+	wire, err := in.Encode()
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	got, err := DecodeV50(wire)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	found := false
+	for _, n := range got.Notes {
+		if n.Kind == "tsl_broadcast_received" && strings.Contains(n.Detail, "INDEX") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("want broadcast INDEX note, got %+v", got.Notes)
+	}
+}
+
+func TestV50Decode_ReservedControlBits_FiresNote(t *testing.T) {
+	in := V50Packet{DMSGs: []DMSG{{Index: 1, ReservedBits: 0x05, Text: "X"}}}
+	wire, err := in.Encode()
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	got, err := DecodeV50(wire)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	found := false
+	for _, n := range got.Notes {
+		if n.Kind == "tsl_reserved_bit_set" && strings.Contains(n.Detail, "CONTROL") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("want CONTROL reserved-bit note, got %+v", got.Notes)
+	}
+	if got.DMSGs[0].ReservedBits != 0x05 {
+		t.Errorf("ReservedBits round-trip: got 0x%02x, want 0x05", got.DMSGs[0].ReservedBits)
+	}
+}
+
+func TestV50Decode_DMSGHeaderTruncated(t *testing.T) {
+	// Body has the 6-byte envelope plus 2 stray bytes — not enough for a
+	// 4-byte DMSG header (INDEX+CONTROL needs 4).
+	body := []byte{0x00 /*VER*/, 0x00 /*FLAGS*/, 0x00, 0x00 /*SCREEN*/, 0xAA, 0xBB}
+	pkt := make([]byte, 2+len(body))
+	binary.LittleEndian.PutUint16(pkt[V50PBCIdx:], uint16(len(body)))
+	copy(pkt[2:], body)
+	_, err := DecodeV50(pkt)
+	if !errors.Is(err, ErrV50DMSGTruncated) {
+		t.Errorf("want ErrV50DMSGTruncated (header), got %v", err)
+	}
+}
+
+func TestV50Decode_DMSGLengthTruncated(t *testing.T) {
+	// DMSG header present (INDEX+CONTROL, bit15=0) but no room for the
+	// 2-byte LENGTH field.
+	body := []byte{
+		0x00, 0x00, 0x00, 0x00, // VER, FLAGS, SCREEN
+		0x01, 0x00, // INDEX=1
+		0x00, 0x00, // CONTROL=0 (bit15 clear → LENGTH expected)
+	}
+	pkt := make([]byte, 2+len(body))
+	binary.LittleEndian.PutUint16(pkt[V50PBCIdx:], uint16(len(body)))
+	copy(pkt[2:], body)
+	_, err := DecodeV50(pkt)
+	if !errors.Is(err, ErrV50DMSGTruncated) {
+		t.Errorf("want ErrV50DMSGTruncated (LENGTH), got %v", err)
+	}
+}
+
+func TestV50Decode_DMSGTextExceedsBody(t *testing.T) {
+	// LENGTH claims more TEXT bytes than the body actually holds.
+	body := []byte{
+		0x00, 0x00, 0x00, 0x00, // VER, FLAGS, SCREEN
+		0x01, 0x00, // INDEX=1
+		0x00, 0x00, // CONTROL=0
+		0x10, 0x00, // LENGTH=16
+		'A', 'B', // only 2 TEXT bytes present
+	}
+	pkt := make([]byte, 2+len(body))
+	binary.LittleEndian.PutUint16(pkt[V50PBCIdx:], uint16(len(body)))
+	copy(pkt[2:], body)
+	_, err := DecodeV50(pkt)
+	if !errors.Is(err, ErrV50DMSGTruncated) {
+		t.Errorf("want ErrV50DMSGTruncated (TEXT), got %v", err)
+	}
+}
+
+func TestV50Decode_OddUTF16Length(t *testing.T) {
+	// UTF-16LE flag set but TEXT length is odd → decodeV50Text error,
+	// surfaced by DecodeV50.
+	body := []byte{
+		0x00,       // VER
+		0x01,       // FLAGS: UTF16LE
+		0x00, 0x00, // SCREEN
+		0x01, 0x00, // INDEX=1
+		0x00, 0x00, // CONTROL=0
+		0x03, 0x00, // LENGTH=3 (odd for UTF-16LE)
+		0x41, 0x00, 0x42, // 3 bytes
+	}
+	pkt := make([]byte, 2+len(body))
+	binary.LittleEndian.PutUint16(pkt[V50PBCIdx:], uint16(len(body)))
+	copy(pkt[2:], body)
+	_, err := DecodeV50(pkt)
+	if !errors.Is(err, ErrV50TextDecode) {
+		t.Errorf("want ErrV50TextDecode, got %v", err)
+	}
+}
+
+func TestDecodeV50Text_OddLengthDirect(t *testing.T) {
+	// Direct unit on the helper's odd-length guard.
+	if _, err := decodeV50Text([]byte{0x41}, true); !errors.Is(err, ErrV50TextDecode) {
+		t.Errorf("want ErrV50TextDecode for odd UTF-16LE input, got %v", err)
 	}
 }
 


### PR DESCRIPTION
Roadmap D — tsl codec 86.9%->100.0%, tests only. All three TSL UMD versions (v3.1/v4.0 serial-over-TCP, v5.0 TCP/UDP) + both v5.0 transports. No seam needed; no guard weakened. vet+lint clean. Floor in consolidated tsl floors PR. Closes #582.

🤖 Generated with [Claude Code](https://claude.com/claude-code)