### PR TITLE
ci: lock tsl coverage floors (100)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,9 @@ jobs:
           check ./internal/probel-sw08p/codec 100
           check ./internal/probel-sw08p/consumer 100
           check ./internal/probel-sw08p/provider 100
+          check ./internal/tsl/codec 100
+          check ./internal/tsl/consumer 100
+          check ./internal/tsl/provider 100
 
       - name: Upload coverage
         if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
No-regression floors for tsl codec/consumer/provider (all at 100% on main now via #583/#585/#587).

🤖 Generated with [Claude Code](https://claude.com/claude-code)