### PR TITLE
ci: lock osc coverage floors (100)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,9 @@ jobs:
           check ./internal/tsl/codec 100
           check ./internal/tsl/consumer 100
           check ./internal/tsl/provider 100
+          check ./internal/osc/codec 100
+          check ./internal/osc/consumer 100
+          check ./internal/osc/provider 100
 
       - name: Upload coverage
         if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
No-regression floors for osc codec/consumer/provider (all at 100% on main via #591/#593/#595).

🤖 Generated with [Claude Code](https://claude.com/claude-code)