### PR TITLE
feat(probel-sw02p): wire full consumer CLI verb set (mirror sw08p)

### DIFF
--- a/cmd/dhs/cmd_probel02p.go
+++ b/cmd/dhs/cmd_probel02p.go
@@ -44,6 +44,34 @@ func runProbelsw02p(ctx context.Context, args []string) error {
 	sub := args[0]
 	rest := args[1:]
 	switch sub {
+	case "interrogate":
+		return runProbelsw02pInterrogate(ctx, rest)
+	case "connect":
+		return runProbelsw02pConnect(ctx, rest)
+	case "connect-on-go":
+		return runProbelsw02pConnectOnGo(ctx, rest)
+	case "go":
+		return runProbelsw02pGo(ctx, rest)
+	case "salvo-connect":
+		return runProbelsw02pSalvoConnect(ctx, rest)
+	case "protect-connect":
+		return runProbelsw02pProtectConnect(ctx, rest)
+	case "protect-disconnect":
+		return runProbelsw02pProtectDisconnect(ctx, rest)
+	case "protect-interrogate":
+		return runProbelsw02pProtectInterrogate(ctx, rest)
+	case "protect-dump":
+		return runProbelsw02pProtectDump(ctx, rest)
+	case "protect-name":
+		return runProbelsw02pProtectName(ctx, rest)
+	case "dual-status":
+		return runProbelsw02pDualStatus(ctx, rest)
+	case "lock-status":
+		return runProbelsw02pLockStatus(ctx, rest)
+	case "status":
+		return runProbelsw02pStatus(ctx, rest)
+	case "router-config":
+		return runProbelsw02pRouterConfig(ctx, rest)
 	case "watch":
 		return runProbelsw02pWatch(ctx, rest)
 	}
@@ -70,10 +98,30 @@ GLOBAL FLAGS (apply to every subcommand)
   + rotating keep-alive ping at (re)connect.
 
 SUBCOMMANDS
-  watch       subscribe to async tallies until Ctrl-C / --timeout
+  interrogate         query current source on one dst (rx 01; --extended → rx 65)
+  connect             route a source to a destination (rx 02; --extended → rx 66)
+  connect-on-go       stage one crosspoint into the pending salvo buffer (rx 05)
+  go                  commit (--op set) or discard (--op clear) the pending buffer (rx 06)
+  salvo-connect       stage N crosspoints under a group then fire it (rx 35 + rx 36)
+  protect-connect     set a protect on a destination for a device (rx 102)
+  protect-disconnect  clear a protect on a destination (rx 104)
+  protect-interrogate read protect state on one destination (rx 101)
+  protect-dump        request a protect tally dump fan-out (rx 105)
+  protect-name        resolve a device id → 8-char name (rx 103)
+  dual-status         read dual-controller redundancy state (rx 050)
+  lock-status         read source-lock bitmap, GET only (rx 014; SW-P-02 lock is read-only)
+  status              read controller status — 2 (rx 07)
+  router-config       read router configuration / level map (rx 075)
+  watch               subscribe to async tallies until Ctrl-C / --timeout
 
 EXAMPLES
-  dhs consumer probel-sw02p watch 127.0.0.1:2002 --dsts 64 --srcs 64`)
+  dhs consumer probel-sw02p interrogate    127.0.0.1:2002 --dst 5
+  dhs consumer probel-sw02p connect        127.0.0.1:2002 --dst 5 --src 12
+  dhs consumer probel-sw02p connect        127.0.0.1:2002 --dst 5 --src 12 --extended
+  dhs consumer probel-sw02p salvo-connect  127.0.0.1:2002 --src 3 --dsts 0-7 --salvo 1
+  dhs consumer probel-sw02p protect-connect 127.0.0.1:2002 --dst 5 --device 9
+  dhs consumer probel-sw02p router-config   127.0.0.1:2002
+  dhs consumer probel-sw02p watch          127.0.0.1:2002 --dsts 64 --srcs 64`)
 }
 
 // probelSW02RecorderKey is the context.Context key for the optional

--- a/cmd/dhs/cmd_probel02p_test.go
+++ b/cmd/dhs/cmd_probel02p_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	codec02 "dhs/internal/probel-sw02p/codec"
+)
+
+// TestProbelSW02UnknownSubcommand — an unrecognised verb is a usage
+// error, not a panic / silent no-op. Mirrors the SW-P-08 dispatcher
+// contract (runProbelsw08p returns "unknown probel subcommand").
+func TestProbelSW02UnknownSubcommand(t *testing.T) {
+	err := runProbelsw02p(context.Background(), []string{"bogus-verb"})
+	if err == nil {
+		t.Fatal("expected error for unknown subcommand, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown probel-sw02p subcommand") {
+		t.Errorf("error = %q, want it to mention unknown subcommand", err.Error())
+	}
+}
+
+// TestProbelSW02HelpNoArgs — no args prints help (not an error). This is
+// the same contract every per-protocol dispatcher honours so
+// `dhs consumer probel-sw02p` shows the verb catalogue.
+func TestProbelSW02HelpNoArgs(t *testing.T) {
+	if err := runProbelsw02p(context.Background(), nil); err != nil {
+		t.Fatalf("help dispatch returned error: %v", err)
+	}
+	if err := runProbelsw02p(context.Background(), []string{"-h"}); err != nil {
+		t.Fatalf("help dispatch (-h) returned error: %v", err)
+	}
+}
+
+// TestProbelSW02VerbsRequireAddr — every dispatched verb that talks to a
+// device must reject a missing <host:port> with a usage error before it
+// ever dials. Catches a verb wired into the switch but missing its
+// popPositional guard. Mirrors SW-P-08's "missing <host:port>" contract.
+func TestProbelSW02VerbsRequireAddr(t *testing.T) {
+	verbs := []string{
+		"interrogate", "connect", "connect-on-go", "go", "salvo-connect",
+		"protect-connect", "protect-disconnect", "protect-interrogate",
+		"protect-dump", "protect-name", "dual-status", "lock-status",
+		"status", "router-config", "watch",
+	}
+	for _, v := range verbs {
+		t.Run(v, func(t *testing.T) {
+			err := runProbelsw02p(context.Background(), []string{v})
+			if err == nil {
+				t.Fatalf("verb %q with no <host:port> returned nil error", v)
+			}
+			if !strings.Contains(err.Error(), "missing <host:port>") {
+				t.Errorf("verb %q error = %q, want 'missing <host:port>'", v, err.Error())
+			}
+		})
+	}
+}
+
+// TestProbelSW02FlagValidation — out-of-range / malformed flags are
+// rejected at parse time (before dial). Pins the per-verb bounds checks
+// that mirror SW-P-08's --dst / --src / --device range guards.
+func TestProbelSW02FlagValidation(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"dst-range", []string{"interrogate", "127.0.0.1:2002", "--dst", "99999"}, "--dst out of range"},
+		{"src-range", []string{"connect", "127.0.0.1:2002", "--dst", "1", "--src", "99999"}, "--src out of range"},
+		{"device-range", []string{"protect-connect", "127.0.0.1:2002", "--dst", "1", "--device", "99999"}, "--device out of range"},
+		{"go-bad-op", []string{"go", "127.0.0.1:2002", "--op", "frobnicate"}, "unknown --op"},
+		{"salvo-no-dsts", []string{"salvo-connect", "127.0.0.1:2002", "--src", "1"}, "--dsts is required"},
+		{"status-bad-ctrl", []string{"status", "127.0.0.1:2002", "--controller", "middle"}, "unknown --controller"},
+		{"lock-bad-ctrl", []string{"lock-status", "127.0.0.1:2002", "--controller", "middle"}, "unknown --controller"},
+		{"protect-dump-count", []string{"protect-dump", "127.0.0.1:2002", "--count", "0"}, "--count out of range"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := runProbelsw02p(context.Background(), c.args)
+			if err == nil {
+				t.Fatalf("args %v returned nil error, want %q", c.args, c.want)
+			}
+			if !strings.Contains(err.Error(), c.want) {
+				t.Errorf("args %v error = %q, want substring %q", c.args, err.Error(), c.want)
+			}
+		})
+	}
+}
+
+// TestProbelSW02ParseGoOp pins the --op string → codec.GoOperation map.
+func TestProbelSW02ParseGoOp(t *testing.T) {
+	if op, err := parseGoOp("set"); err != nil || op != codec02.GoOpSet {
+		t.Errorf("parseGoOp(set) = %v, %v; want GoOpSet", op, err)
+	}
+	if op, err := parseGoOp("clear"); err != nil || op != codec02.GoOpClear {
+		t.Errorf("parseGoOp(clear) = %v, %v; want GoOpClear", op, err)
+	}
+	if _, err := parseGoOp("nope"); err == nil {
+		t.Error("parseGoOp(nope) = nil error, want failure")
+	}
+}
+
+// TestProbelSW02ParseController pins the --controller string → codec.Controller map.
+func TestProbelSW02ParseController(t *testing.T) {
+	for _, in := range []string{"lh", "LH", "0"} {
+		if c, err := parseController(in); err != nil || c != codec02.ControllerLH {
+			t.Errorf("parseController(%q) = %v, %v; want ControllerLH", in, c, err)
+		}
+	}
+	for _, in := range []string{"rh", "RH", "1"} {
+		if c, err := parseController(in); err != nil || c != codec02.ControllerRH {
+			t.Errorf("parseController(%q) = %v, %v; want ControllerRH", in, c, err)
+		}
+	}
+	if _, err := parseController("xx"); err == nil {
+		t.Error("parseController(xx) = nil error, want failure")
+	}
+}
+
+// TestProbelSW02ProtectStateName pins the display strings for every
+// ProtectState so the CLI output stays stable.
+func TestProbelSW02ProtectStateName(t *testing.T) {
+	cases := map[codec02.ProtectState]string{
+		codec02.ProtectNone:           "none",
+		codec02.ProtectProBel:         "probel",
+		codec02.ProtectProBelOverride: "probel-override",
+		codec02.ProtectOEM:            "oem",
+	}
+	for st, want := range cases {
+		if got := protectStateName(st); got != want {
+			t.Errorf("protectStateName(%d) = %q, want %q", st, got, want)
+		}
+	}
+}
+
+// TestProbelSW02GoGroupResultName pins the salvo go-done result strings.
+func TestProbelSW02GoGroupResultName(t *testing.T) {
+	cases := map[codec02.GoGroupResult]string{
+		codec02.GoGroupResultSet:     "set",
+		codec02.GoGroupResultCleared: "cleared",
+		codec02.GoGroupResultEmpty:   "empty",
+	}
+	for r, want := range cases {
+		if got := goGroupResultName(r); got != want {
+			t.Errorf("goGroupResultName(%d) = %q, want %q", r, got, want)
+		}
+	}
+}

--- a/cmd/dhs/cmd_probel02p_verbs.go
+++ b/cmd/dhs/cmd_probel02p_verbs.go
@@ -1,0 +1,635 @@
+package main
+
+// SW-P-02 consumer subcommands. CLI plumbing only — every verb here
+// dispatches to an existing Send* method on the probel-sw02p consumer
+// Plugin (internal/probel-sw02p/consumer). No new wire commands are
+// introduced; this file mirrors the SW-P-08 CLI shape
+// (cmd_probel.go / cmd_probel_salvo.go): popPositional <host:port>, a
+// per-command flag.FlagSet, a single round-trip, and a one-line decoded
+// reply on stdout (wire hex is logged on stderr by the codec client).
+//
+// SW-P-02 is single-matrix / single-level on the wire (§3.1), so unlike
+// SW-P-08 there are no --matrix / --level flags on these verbs; the
+// global --mtx-id / --level / --dsts / --srcs flags parsed at the
+// dispatcher feed the connection's MatrixConfig (bootstrap sweep +
+// keep-alive) and are documented in helpProbelSW02.
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"sync"
+	"time"
+
+	codec02 "dhs/internal/probel-sw02p/codec"
+)
+
+// probelSW02Flags is the common "host:port + dst/src + extended" tuple
+// shared by interrogate / connect.
+type probelSW02Flags struct {
+	addr      string
+	dst       int
+	src       int
+	extended  bool
+	badSource bool
+	timeout   time.Duration
+}
+
+func parseProbelSW02Flags(args []string, want struct{ src, badSource bool }) (probelSW02Flags, error) {
+	fs := flag.NewFlagSet("probel-sw02p", flag.ContinueOnError)
+	pf := probelSW02Flags{}
+	fs.IntVar(&pf.dst, "dst", 0, "destination id (0-16383)")
+	fs.IntVar(&pf.src, "src", 0, "source id (0-16383)")
+	fs.BoolVar(&pf.extended, "extended", false, "use the Extended wire form (rx 65/66, 14-bit dst/src)")
+	if want.badSource {
+		fs.BoolVar(&pf.badSource, "bad-source", false, "set the narrow Multiplier bad-source bit (rx 02 only; ignored when --extended)")
+	}
+	fs.DurationVar(&pf.timeout, "timeout", 5*time.Second, "operation timeout")
+	addr, flagArgs := popPositional(args)
+	if addr == "" {
+		return pf, fmt.Errorf("missing <host:port>")
+	}
+	if err := fs.Parse(flagArgs); err != nil {
+		return pf, err
+	}
+	pf.addr = addr
+	if pf.dst < 0 || pf.dst > 0x3FFF {
+		return pf, fmt.Errorf("--dst out of range (0-16383)")
+	}
+	if want.src && (pf.src < 0 || pf.src > 0x3FFF) {
+		return pf, fmt.Errorf("--src out of range (0-16383)")
+	}
+	return pf, nil
+}
+
+func runProbelsw02pInterrogate(ctx context.Context, args []string) error {
+	pf, err := parseProbelSW02Flags(args, struct{ src, badSource bool }{})
+	if err != nil {
+		return err
+	}
+	cctx, cancel := context.WithTimeout(ctx, pf.timeout)
+	defer cancel()
+	p, closer, err := dialProbelSW02(cctx, pf.addr)
+	if err != nil {
+		return err
+	}
+	defer closer()
+	if pf.extended {
+		reply, err := p.SendExtendedInterrogate(cctx, uint16(pf.dst))
+		if err != nil {
+			return err
+		}
+		fmt.Printf("extended tally  dst=%d → src=%d bad_source=%v update_off=%v\n",
+			reply.Destination, reply.Source, reply.BadSource, reply.UpdateOff)
+		return nil
+	}
+	reply, err := p.SendInterrogate(cctx, uint16(pf.dst))
+	if err != nil {
+		return err
+	}
+	fmt.Printf("tally  dst=%d → src=%d bad_source=%v\n",
+		reply.Destination, reply.Source, reply.BadSource)
+	return nil
+}
+
+func runProbelsw02pConnect(ctx context.Context, args []string) error {
+	pf, err := parseProbelSW02Flags(args, struct{ src, badSource bool }{src: true, badSource: true})
+	if err != nil {
+		return err
+	}
+	cctx, cancel := context.WithTimeout(ctx, pf.timeout)
+	defer cancel()
+	p, closer, err := dialProbelSW02(cctx, pf.addr)
+	if err != nil {
+		return err
+	}
+	defer closer()
+	if pf.extended {
+		reply, err := p.SendExtendedConnect(cctx, uint16(pf.dst), uint16(pf.src))
+		if err != nil {
+			return err
+		}
+		fmt.Printf("extended connected  dst=%d src=%d bad_source=%v update_off=%v\n",
+			reply.Destination, reply.Source, reply.BadSource, reply.UpdateOff)
+		return nil
+	}
+	reply, err := p.SendConnect(cctx, uint16(pf.dst), uint16(pf.src), pf.badSource)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("connected  dst=%d src=%d bad_source=%v\n",
+		reply.Destination, reply.Source, reply.BadSource)
+	return nil
+}
+
+func runProbelsw02pConnectOnGo(ctx context.Context, args []string) error {
+	pf, err := parseProbelSW02Flags(args, struct{ src, badSource bool }{src: true, badSource: true})
+	if err != nil {
+		return err
+	}
+	cctx, cancel := context.WithTimeout(ctx, pf.timeout)
+	defer cancel()
+	p, closer, err := dialProbelSW02(cctx, pf.addr)
+	if err != nil {
+		return err
+	}
+	defer closer()
+	ack, err := p.SendConnectOnGo(cctx, uint16(pf.dst), uint16(pf.src), pf.badSource)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("connect-on-go staged  dst=%d src=%d (call `go --op set` to commit)\n",
+		ack.Destination, ack.Source)
+	return nil
+}
+
+func runProbelsw02pGo(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("probel-sw02p-go", flag.ContinueOnError)
+	op := fs.String("op", "set", "operation: set (commit pending buffer) | clear (discard)")
+	timeout := fs.Duration("timeout", 5*time.Second, "operation timeout")
+	addr, flagArgs := popPositional(args)
+	if addr == "" {
+		return fmt.Errorf("missing <host:port>")
+	}
+	if err := fs.Parse(flagArgs); err != nil {
+		return err
+	}
+	goOp, err := parseGoOp(*op)
+	if err != nil {
+		return err
+	}
+	cctx, cancel := context.WithTimeout(ctx, *timeout)
+	defer cancel()
+	p, closer, err := dialProbelSW02(cctx, addr)
+	if err != nil {
+		return err
+	}
+	defer closer()
+	ack, err := p.SendGo(cctx, goOp)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("go done  op=%s result=%s\n", *op, goOpName(ack.Operation))
+	return nil
+}
+
+// runProbelsw02pSalvoConnect mirrors SW-P-08's salvo-connect: stage N
+// crosspoints under a named group (rx 35 CONNECT ON GO GROUP SALVO),
+// then fire the group atomically (rx 36 GO GROUP SALVO op=set), and
+// optionally clear it. Each staged slot routes --src → one dst.
+func runProbelsw02pSalvoConnect(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("probel-sw02p-salvo-connect", flag.ContinueOnError)
+	var (
+		src       = fs.Int("src", 0, "source id to route to every dst (0-1023, narrow salvo)")
+		dstsCSV   = fs.String("dsts", "", "destination ids (CSV or N-M range, e.g. '5' or '1,2,3' or '0-7')")
+		salvoID   = fs.Int("salvo", 1, "salvo group id (0-127)")
+		badSource = fs.Bool("bad-source", false, "set the narrow Multiplier bad-source bit on each staged slot")
+		clear     = fs.Bool("clear", false, "send a final rx 36 op=clear to wipe the staged group after firing")
+		timeout   = fs.Duration("timeout", 5*time.Second, "overall operation timeout")
+	)
+	addr, flagArgs := popPositional(args)
+	if addr == "" {
+		return fmt.Errorf("missing <host:port>")
+	}
+	if err := fs.Parse(flagArgs); err != nil {
+		return err
+	}
+	dsts, err := parseDsts(*dstsCSV)
+	if err != nil {
+		return err
+	}
+	if len(dsts) == 0 {
+		return fmt.Errorf("--dsts is required (e.g. --dsts 5 or --dsts 0-7)")
+	}
+	if *salvoID < 0 || *salvoID > 127 {
+		return fmt.Errorf("--salvo out of range (0-127)")
+	}
+
+	cctx, cancel := context.WithTimeout(ctx, *timeout)
+	defer cancel()
+	p, closer, err := dialProbelSW02(cctx, addr)
+	if err != nil {
+		return err
+	}
+	defer closer()
+
+	fmt.Printf("\n=== salvo-connect: src=%d salvo=%d dsts=%v ===\n\n", *src, *salvoID, dsts)
+
+	// Phase 1: N × CONNECT ON GO GROUP SALVO (rx 35 → tx 37 ack).
+	fmt.Printf("phase 1 — CONNECT ON GO GROUP SALVO × %d (one rx 35 per dst)\n", len(dsts))
+	for _, dst := range dsts {
+		ack, err := p.SendConnectOnGoGroupSalvo(cctx, uint16(dst), uint16(*src), uint8(*salvoID), *badSource)
+		if err != nil {
+			return fmt.Errorf("salvo-build dst=%d: %w", dst, err)
+		}
+		fmt.Printf("  dst=%-3d → tx 37 ack dst=%d src=%d salvo=%d\n",
+			dst, ack.Destination, ack.Source, ack.SalvoID)
+	}
+
+	// Phase 2: GO GROUP SALVO op=set (rx 36 → tx 38 ack).
+	fmt.Printf("\nphase 2 — GO GROUP SALVO op=set salvo=%d\n", *salvoID)
+	setAck, err := p.SendGoGroupSalvo(cctx, codec02.GoOpSet, uint8(*salvoID))
+	if err != nil {
+		return fmt.Errorf("salvo-go set: %w", err)
+	}
+	fmt.Printf("  tx 38 go-done result=%s salvo=%d\n", goGroupResultName(setAck.Result), setAck.SalvoID)
+
+	// Phase 3 (optional): GO GROUP SALVO op=clear.
+	if *clear {
+		fmt.Printf("\nphase 3 — GO GROUP SALVO op=clear salvo=%d\n", *salvoID)
+		clearAck, err := p.SendGoGroupSalvo(cctx, codec02.GoOpClear, uint8(*salvoID))
+		if err != nil {
+			return fmt.Errorf("salvo-go clear: %w", err)
+		}
+		fmt.Printf("  tx 38 go-done result=%s salvo=%d\n", goGroupResultName(clearAck.Result), clearAck.SalvoID)
+	}
+	return nil
+}
+
+func runProbelsw02pProtectConnect(ctx context.Context, args []string) error {
+	pf, device, err := parseProbelSW02ProtectFlags(args)
+	if err != nil {
+		return err
+	}
+	cctx, cancel := context.WithTimeout(ctx, pf.timeout)
+	defer cancel()
+	p, closer, err := dialProbelSW02(cctx, pf.addr)
+	if err != nil {
+		return err
+	}
+	defer closer()
+	reply, err := p.SendExtendedProtectConnect(cctx, uint16(pf.dst), uint16(device))
+	if err != nil {
+		return err
+	}
+	fmt.Printf("protect connected  dst=%d device=%d state=%s\n",
+		reply.Destination, reply.Device, protectStateName(reply.Protect))
+	return nil
+}
+
+func runProbelsw02pProtectDisconnect(ctx context.Context, args []string) error {
+	pf, device, err := parseProbelSW02ProtectFlags(args)
+	if err != nil {
+		return err
+	}
+	cctx, cancel := context.WithTimeout(ctx, pf.timeout)
+	defer cancel()
+	p, closer, err := dialProbelSW02(cctx, pf.addr)
+	if err != nil {
+		return err
+	}
+	defer closer()
+	reply, err := p.SendExtendedProtectDisconnect(cctx, uint16(pf.dst), uint16(device))
+	if err != nil {
+		return err
+	}
+	fmt.Printf("protect disconnected  dst=%d device=%d state=%s\n",
+		reply.Destination, reply.Device, protectStateName(reply.Protect))
+	return nil
+}
+
+func runProbelsw02pProtectInterrogate(ctx context.Context, args []string) error {
+	pf, _, err := parseProbelSW02ProtectFlags(args)
+	if err != nil {
+		return err
+	}
+	cctx, cancel := context.WithTimeout(ctx, pf.timeout)
+	defer cancel()
+	p, closer, err := dialProbelSW02(cctx, pf.addr)
+	if err != nil {
+		return err
+	}
+	defer closer()
+	reply, err := p.SendExtendedProtectInterrogate(cctx, uint16(pf.dst))
+	if err != nil {
+		return err
+	}
+	fmt.Printf("protect tally  dst=%d → state=%s device=%d\n",
+		reply.Destination, protectStateName(reply.Protect), reply.Device)
+	return nil
+}
+
+func runProbelsw02pProtectDump(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("probel-sw02p-protect-dump", flag.ContinueOnError)
+	startDst := fs.Int("first-dst", 0, "first destination id to dump (0-16383)")
+	count := fs.Int("count", 32, "number of protect entries to request (1-255; tx 100 fans out 32/frame)")
+	collect := fs.Duration("collect", 1*time.Second, "time to collect tx 100 fan-out frames after the request")
+	timeout := fs.Duration("timeout", 5*time.Second, "operation timeout")
+	addr, flagArgs := popPositional(args)
+	if addr == "" {
+		return fmt.Errorf("missing <host:port>")
+	}
+	if err := fs.Parse(flagArgs); err != nil {
+		return err
+	}
+	if *startDst < 0 || *startDst > 0x3FFF {
+		return fmt.Errorf("--first-dst out of range (0-16383)")
+	}
+	if *count < 1 || *count > 255 {
+		return fmt.Errorf("--count out of range (1-255)")
+	}
+	cctx, cancel := context.WithTimeout(ctx, *timeout)
+	defer cancel()
+	p, closer, err := dialProbelSW02(cctx, addr)
+	if err != nil {
+		return err
+	}
+	defer closer()
+
+	// rx 105 can trigger MULTIPLE tx 100 broadcasts (32 entries each);
+	// subscribe to the typed fan-out before sending so it is captured.
+	var mu sync.Mutex
+	var entries int
+	if err := p.SubscribeExtendedProtectTallyDump(func(dump codec02.ExtendedProtectTallyDumpParams) {
+		mu.Lock()
+		defer mu.Unlock()
+		if dump.Reset {
+			fmt.Println("  (controller reset sentinel — no entries)")
+			return
+		}
+		for _, it := range dump.Entries {
+			fmt.Printf("  dst=%d state=%s device=%d\n",
+				it.Destination, protectStateName(it.Protect), it.Device)
+			entries++
+		}
+	}); err != nil {
+		return err
+	}
+	if err := p.SendExtendedProtectTallyDumpRequest(cctx, uint16(*startDst), uint8(*count)); err != nil {
+		return err
+	}
+	// Wait for the fan-out (no synchronous reply on rx 105 itself).
+	timer := time.NewTimer(*collect)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+	case <-cctx.Done():
+	}
+	mu.Lock()
+	seen := entries
+	mu.Unlock()
+	fmt.Printf("protect tally-dump  first_dst=%d requested=%d entries_seen=%d\n",
+		*startDst, *count, seen)
+	return nil
+}
+
+func runProbelsw02pProtectName(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("probel-sw02p-protect-name", flag.ContinueOnError)
+	device := fs.Int("device", 0, "device id (0-1023)")
+	timeout := fs.Duration("timeout", 5*time.Second, "operation timeout")
+	addr, flagArgs := popPositional(args)
+	if addr == "" {
+		return fmt.Errorf("missing <host:port>")
+	}
+	if err := fs.Parse(flagArgs); err != nil {
+		return err
+	}
+	if *device < 0 || *device > 0x3FF {
+		return fmt.Errorf("--device out of range (0-1023)")
+	}
+	cctx, cancel := context.WithTimeout(ctx, *timeout)
+	defer cancel()
+	p, closer, err := dialProbelSW02(cctx, addr)
+	if err != nil {
+		return err
+	}
+	defer closer()
+	reply, err := p.SendProtectDeviceNameRequest(cctx, uint16(*device))
+	if err != nil {
+		return err
+	}
+	fmt.Printf("device %d name=%q\n", reply.Device, reply.Name)
+	return nil
+}
+
+func runProbelsw02pDualStatus(ctx context.Context, args []string) error {
+	addr, timeout, err := parseProbelSW02AddrOnly(args, "probel-sw02p-dual-status")
+	if err != nil {
+		return err
+	}
+	cctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	p, closer, err := dialProbelSW02(cctx, addr)
+	if err != nil {
+		return err
+	}
+	defer closer()
+	r, err := p.SendDualControllerStatusRequest(cctx)
+	if err != nil {
+		return err
+	}
+	who := "MASTER"
+	if r.Active == codec02.ActiveControllerSlave {
+		who = "SLAVE"
+	}
+	fmt.Printf("dual-controller  active=%s idle_faulty=%v\n",
+		who, r.IdleStatus == codec02.IdleControllerFaulty)
+	return nil
+}
+
+func runProbelsw02pLockStatus(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("probel-sw02p-lock-status", flag.ContinueOnError)
+	controller := fs.String("controller", "lh", "controller to query: lh | rh")
+	timeout := fs.Duration("timeout", 5*time.Second, "operation timeout")
+	addr, flagArgs := popPositional(args)
+	if addr == "" {
+		return fmt.Errorf("missing <host:port>")
+	}
+	if err := fs.Parse(flagArgs); err != nil {
+		return err
+	}
+	ctrl, err := parseController(*controller)
+	if err != nil {
+		return err
+	}
+	cctx, cancel := context.WithTimeout(ctx, *timeout)
+	defer cancel()
+	p, closer, err := dialProbelSW02(cctx, addr)
+	if err != nil {
+		return err
+	}
+	defer closer()
+	resp, err := p.SendSourceLockStatusRequest(cctx, ctrl)
+	if err != nil {
+		return err
+	}
+	locked := 0
+	for _, ok := range resp.Locked {
+		if ok {
+			locked++
+		}
+	}
+	fmt.Printf("source-lock (read-only)  controller=%s sources=%d locked=%d\n",
+		*controller, len(resp.Locked), locked)
+	for i, ok := range resp.Locked {
+		fmt.Printf("  src=%d locked=%v\n", i, ok)
+	}
+	return nil
+}
+
+func runProbelsw02pStatus(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("probel-sw02p-status", flag.ContinueOnError)
+	controller := fs.String("controller", "lh", "controller to query: lh | rh")
+	timeout := fs.Duration("timeout", 5*time.Second, "operation timeout")
+	addr, flagArgs := popPositional(args)
+	if addr == "" {
+		return fmt.Errorf("missing <host:port>")
+	}
+	if err := fs.Parse(flagArgs); err != nil {
+		return err
+	}
+	ctrl, err := parseController(*controller)
+	if err != nil {
+		return err
+	}
+	cctx, cancel := context.WithTimeout(ctx, *timeout)
+	defer cancel()
+	p, closer, err := dialProbelSW02(cctx, addr)
+	if err != nil {
+		return err
+	}
+	defer closer()
+	s, err := p.SendStatusRequest(cctx, ctrl)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("status  controller=%s idle=%v bus_fault=%v overheat=%v\n",
+		*controller, s.Idle, s.BusFault, s.Overheat)
+	return nil
+}
+
+func runProbelsw02pRouterConfig(ctx context.Context, args []string) error {
+	addr, timeout, err := parseProbelSW02AddrOnly(args, "probel-sw02p-router-config")
+	if err != nil {
+		return err
+	}
+	cctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	p, closer, err := dialProbelSW02(cctx, addr)
+	if err != nil {
+		return err
+	}
+	defer closer()
+	cfg, err := p.SendRouterConfigRequest(cctx)
+	if err != nil {
+		return err
+	}
+	switch {
+	case cfg.Response1 != nil:
+		r := cfg.Response1
+		fmt.Printf("router-config (response-1)  level_map=0x%07x levels=%d\n", r.LevelMap, len(r.Levels))
+		for i, lvl := range r.Levels {
+			fmt.Printf("  level[%d]  dsts=%d srcs=%d\n", i, lvl.NumDestinations, lvl.NumSources)
+		}
+	case cfg.Response2 != nil:
+		r := cfg.Response2
+		fmt.Printf("router-config (response-2)  level_map=0x%07x levels=%d\n", r.LevelMap, len(r.Levels))
+		for i, lvl := range r.Levels {
+			fmt.Printf("  level[%d]  dsts=%d srcs=%d start_dst=%d start_src=%d\n",
+				i, lvl.NumDestinations, lvl.NumSources, lvl.StartDestination, lvl.StartSource)
+		}
+	default:
+		fmt.Println("router-config  (empty response)")
+	}
+	return nil
+}
+
+// --- shared helpers ---
+
+// parseProbelSW02ProtectFlags parses host:port + dst + device for the
+// Extended PROTECT family (rx 101/102/104). SW-P-02 protect is keyed on
+// (dst, device) only — no matrix/level on the wire.
+func parseProbelSW02ProtectFlags(args []string) (probelSW02Flags, int, error) {
+	fs := flag.NewFlagSet("probel-sw02p-protect", flag.ContinueOnError)
+	var pf probelSW02Flags
+	fs.IntVar(&pf.dst, "dst", 0, "destination id (0-16383)")
+	device := 0
+	fs.IntVar(&device, "device", 0, "device id (0-16383)")
+	fs.DurationVar(&pf.timeout, "timeout", 5*time.Second, "operation timeout")
+	addr, flagArgs := popPositional(args)
+	if addr == "" {
+		return pf, 0, fmt.Errorf("missing <host:port>")
+	}
+	if err := fs.Parse(flagArgs); err != nil {
+		return pf, 0, err
+	}
+	pf.addr = addr
+	if pf.dst < 0 || pf.dst > 0x3FFF {
+		return pf, 0, fmt.Errorf("--dst out of range (0-16383)")
+	}
+	if device < 0 || device > 0x3FFF {
+		return pf, 0, fmt.Errorf("--device out of range (0-16383)")
+	}
+	return pf, device, nil
+}
+
+// parseProbelSW02AddrOnly handles the zero-arg verbs (dual-status,
+// router-config) that take only <host:port> + --timeout.
+func parseProbelSW02AddrOnly(args []string, name string) (string, time.Duration, error) {
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	timeout := fs.Duration("timeout", 5*time.Second, "operation timeout")
+	addr, flagArgs := popPositional(args)
+	if addr == "" {
+		return "", 0, fmt.Errorf("missing <host:port>")
+	}
+	if err := fs.Parse(flagArgs); err != nil {
+		return "", 0, err
+	}
+	return addr, *timeout, nil
+}
+
+func parseGoOp(s string) (codec02.GoOperation, error) {
+	switch s {
+	case "set":
+		return codec02.GoOpSet, nil
+	case "clear":
+		return codec02.GoOpClear, nil
+	}
+	return 0, fmt.Errorf("unknown --op %q (use set | clear)", s)
+}
+
+func goOpName(op codec02.GoOperation) string {
+	switch op {
+	case codec02.GoOpSet:
+		return "set"
+	case codec02.GoOpClear:
+		return "clear"
+	}
+	return fmt.Sprintf("0x%02x", byte(op))
+}
+
+func goGroupResultName(r codec02.GoGroupResult) string {
+	switch r {
+	case codec02.GoGroupResultSet:
+		return "set"
+	case codec02.GoGroupResultCleared:
+		return "cleared"
+	case codec02.GoGroupResultEmpty:
+		return "empty"
+	}
+	return fmt.Sprintf("0x%02x", byte(r))
+}
+
+func protectStateName(s codec02.ProtectState) string {
+	switch s {
+	case codec02.ProtectNone:
+		return "none"
+	case codec02.ProtectProBel:
+		return "probel"
+	case codec02.ProtectProBelOverride:
+		return "probel-override"
+	case codec02.ProtectOEM:
+		return "oem"
+	}
+	return fmt.Sprintf("0x%02x", byte(s))
+}
+
+func parseController(s string) (codec02.Controller, error) {
+	switch s {
+	case "lh", "LH", "0":
+		return codec02.ControllerLH, nil
+	case "rh", "RH", "1":
+		return codec02.ControllerRH, nil
+	}
+	return 0, fmt.Errorf("unknown --controller %q (use lh | rh)", s)
+}


### PR DESCRIPTION
Closes #599. sw02p consumer CLI wired from watch-only to the full verb set (interrogate/connect/connect-on-go/go/salvo-connect/protect-*/dual-status/lock-status/status/router-config), mirroring sw08p. CLI plumbing only — no new wire commands; all dispatch to existing 100%-covered Send* methods. 15 smoke tests; verified live vs loopback producer. build/vet/lint/test clean.\n\nKnown (pre-existing, identical in sw08p, flagged for separate fix): salvo-connect --dsts range flag shadowed by global --dsts.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)