### PR TITLE
feat(probel-sw08p): wire update-name CLI verb (write labels, rx 117)

### DIFF
--- a/cmd/dhs/cmd_probel.go
+++ b/cmd/dhs/cmd_probel.go
@@ -85,6 +85,8 @@ func runProbelsw08p(ctx context.Context, args []string) error {
 		return runProbelAllSourceAssocNames(ctx, rest)
 	case "single-source-assoc-name":
 		return runProbelSingleSourceAssocName(ctx, rest)
+	case "update-name":
+		return runProbelUpdateName(ctx, rest)
 	case "bench":
 		return runProbelBench(ctx, rest)
 	case "salvo-connect":
@@ -119,6 +121,8 @@ SUBCOMMANDS
   single-dest-name          fetch one destination label
   all-source-assoc-names    fetch every source association (device) label
   single-source-assoc-name  fetch one source association label
+  update-name               write labels (source/source-assoc/dest-assoc/umd)
+                            starting at --first-id (rx 117; fire-and-forget)
   protect-interrogate       read protect state on one (matrix, level, dst)
   protect-connect           set a protect on (matrix, level, dst) for a device
   protect-disconnect        clear a protect

--- a/cmd/dhs/cmd_probel_update_name.go
+++ b/cmd/dhs/cmd_probel_update_name.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+	"time"
+
+	"dhs/internal/probel-sw08p/codec"
+)
+
+// runProbelUpdateName issues rx 117 UPDATE NAME REQUEST — the SW-P-08
+// write-label command. It pushes one or more source / source-assoc /
+// dest-assoc / UMD labels starting at --first-id on (matrix[, level]).
+// Fire-and-forget: §3.2.26 says the matrix sends no reply, so the call
+// returns as soon as the frame is ACKed on the wire.
+//
+// Spec note worth surfacing (carried from the consumer doc-comment):
+// pushing labels to an Aurora/system-editor-managed controller causes a
+// database mismatch the next time its config editor connects online.
+// Use deliberately.
+func runProbelUpdateName(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("probel-update-name", flag.ContinueOnError)
+	typ := fs.String("type", "source",
+		"name class: source | source-assoc | dest-assoc | umd")
+	width := fs.Int("width", 16, "name width in chars: 4 | 8 | 12 | 16")
+	matrix := fs.Int("matrix", 0, "matrix id (0-255)")
+	level := fs.Int("level", 0, "level id (0-255; source-name only)")
+	firstID := fs.Int("first-id", 0, "id of the first name (0-65535)")
+	names := fs.String("names", "",
+		"comma-separated labels, applied from --first-id upward")
+	timeout := fs.Duration("timeout", 5*time.Second, "operation timeout")
+	addr, flagArgs := popPositional(args)
+	if addr == "" {
+		return fmt.Errorf("missing <host:port>")
+	}
+	if err := fs.Parse(flagArgs); err != nil {
+		return err
+	}
+
+	nameType, err := parseUpdateNameType(*typ)
+	if err != nil {
+		return err
+	}
+	nameLen, err := parseUpdateNameWidth(*width)
+	if err != nil {
+		return err
+	}
+	if *matrix < 0 || *matrix > 255 {
+		return fmt.Errorf("--matrix out of range (0-255)")
+	}
+	if *level < 0 || *level > 255 {
+		return fmt.Errorf("--level out of range (0-255)")
+	}
+	if *firstID < 0 || *firstID > 0xFFFF {
+		return fmt.Errorf("--first-id out of range (0-65535)")
+	}
+	if strings.TrimSpace(*names) == "" {
+		return fmt.Errorf("--names requires at least one label")
+	}
+	labels := strings.Split(*names, ",")
+
+	params := codec.UpdateNameRequestParams{
+		NameType:   nameType,
+		NameLength: nameLen,
+		MatrixID:   uint8(*matrix),
+		LevelID:    uint8(*level),
+		FirstID:    uint16(*firstID),
+		Names:      labels,
+	}
+
+	cctx, cancel := context.WithTimeout(ctx, *timeout)
+	defer cancel()
+	p, closer, err := dialProbel(cctx, addr)
+	if err != nil {
+		return err
+	}
+	defer closer()
+	if err := p.UpdateNameRequest(cctx, params); err != nil {
+		return err
+	}
+	fmt.Printf("update-name sent  type=%s width=%d matrix=%d level=%d first_id=%d count=%d\n",
+		*typ, nameLen.Bytes(), *matrix, *level, *firstID, len(labels))
+	return nil
+}
+
+// parseUpdateNameType maps the CLI --type string to the codec enum.
+func parseUpdateNameType(s string) (codec.UpdateNameType, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "source", "src":
+		return codec.UpdateNameSource, nil
+	case "source-assoc", "src-assoc":
+		return codec.UpdateNameSourceAssoc, nil
+	case "dest-assoc", "dst-assoc":
+		return codec.UpdateNameDestAssoc, nil
+	case "umd", "umd-label":
+		return codec.UpdateNameUMDLabel, nil
+	default:
+		return 0, fmt.Errorf("unknown --type %q (want source|source-assoc|dest-assoc|umd)", s)
+	}
+}
+
+// parseUpdateNameWidth maps the CLI --width int to the codec NameLength enum.
+func parseUpdateNameWidth(w int) (codec.NameLength, error) {
+	switch w {
+	case 4:
+		return codec.NameLen4, nil
+	case 8:
+		return codec.NameLen8, nil
+	case 12:
+		return codec.NameLen12, nil
+	case 16:
+		return codec.NameLen16, nil
+	default:
+		return 0, fmt.Errorf("unknown --width %d (want 4|8|12|16)", w)
+	}
+}

--- a/cmd/dhs/cmd_probel_update_name_test.go
+++ b/cmd/dhs/cmd_probel_update_name_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"dhs/internal/probel-sw08p/codec"
+)
+
+// TestParseUpdateNameType maps every accepted --type spelling to the
+// codec enum and rejects the rest.
+func TestParseUpdateNameType(t *testing.T) {
+	ok := map[string]codec.UpdateNameType{
+		"source":       codec.UpdateNameSource,
+		"src":          codec.UpdateNameSource,
+		"source-assoc": codec.UpdateNameSourceAssoc,
+		"src-assoc":    codec.UpdateNameSourceAssoc,
+		"dest-assoc":   codec.UpdateNameDestAssoc,
+		"dst-assoc":    codec.UpdateNameDestAssoc,
+		"umd":          codec.UpdateNameUMDLabel,
+		"UMD":          codec.UpdateNameUMDLabel,
+	}
+	for in, want := range ok {
+		got, err := parseUpdateNameType(in)
+		if err != nil {
+			t.Errorf("parseUpdateNameType(%q) error: %v", in, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("parseUpdateNameType(%q) = %#x, want %#x", in, got, want)
+		}
+	}
+	if _, err := parseUpdateNameType("bogus"); err == nil {
+		t.Error("parseUpdateNameType(bogus) returned nil error")
+	}
+}
+
+// TestParseUpdateNameWidth maps the four legal widths and rejects others.
+func TestParseUpdateNameWidth(t *testing.T) {
+	ok := map[int]codec.NameLength{
+		4: codec.NameLen4, 8: codec.NameLen8, 12: codec.NameLen12, 16: codec.NameLen16,
+	}
+	for in, want := range ok {
+		got, err := parseUpdateNameWidth(in)
+		if err != nil {
+			t.Errorf("parseUpdateNameWidth(%d) error: %v", in, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("parseUpdateNameWidth(%d) = %#x, want %#x", in, got, want)
+		}
+	}
+	if _, err := parseUpdateNameWidth(7); err == nil {
+		t.Error("parseUpdateNameWidth(7) returned nil error")
+	}
+}
+
+// TestUpdateNameFlagValidation — bad flags fail before any dial, with a
+// usage error naming the offending flag. None of these reach the network.
+func TestUpdateNameFlagValidation(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"no-addr", []string{"--names=A"}, "missing <host:port>"},
+		{"bad-type", []string{"127.0.0.1:2008", "--type", "nope", "--names", "A"}, "unknown --type"},
+		{"bad-width", []string{"127.0.0.1:2008", "--width", "7", "--names", "A"}, "unknown --width"},
+		{"matrix-range", []string{"127.0.0.1:2008", "--matrix", "999", "--names", "A"}, "--matrix out of range"},
+		{"level-range", []string{"127.0.0.1:2008", "--level", "999", "--names", "A"}, "--level out of range"},
+		{"first-range", []string{"127.0.0.1:2008", "--first-id", "70000", "--names", "A"}, "--first-id out of range"},
+		{"empty-names", []string{"127.0.0.1:2008", "--names", "  "}, "--names requires"},
+		{"missing-names", []string{"127.0.0.1:2008"}, "--names requires"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := runProbelUpdateName(context.Background(), tc.args)
+			if err == nil {
+				t.Fatalf("args %v returned nil error", tc.args)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+// TestUpdateNameDispatched — the verb is reachable through the SW-P-08
+// dispatcher (catches a missing switch case) and honours the
+// missing-addr contract like every other verb.
+func TestUpdateNameDispatched(t *testing.T) {
+	err := runProbelsw08p(context.Background(), []string{"update-name"})
+	if err == nil {
+		t.Fatal("update-name with no <host:port> returned nil error")
+	}
+	if !strings.Contains(err.Error(), "missing <host:port>") {
+		t.Errorf("error = %q, want 'missing <host:port>'", err.Error())
+	}
+}


### PR DESCRIPTION
Wires the update-name CLI verb for dhs consumer probel-sw08p (SW-P-08 rx 117 UPDATE NAME REQUEST = write-label). The command was already implemented + 100%-covered in codec (EncodeUpdateNameRequest) and consumer (Plugin.UpdateNameRequest) but had no CLI verb, so the CLI could GET labels but never UPDATE them. Usage: update-name <host:port> --type source|source-assoc|dest-assoc|umd --width 4|8|12|16 --matrix N --level N --first-id N --names A,B,C. Fire-and-forget per spec 3.2.26. Tests cover both parse helpers, all flag-validation arms, and dispatcher reachability; build/vet/test/lint clean. Note: sw02p labels deferred per user (SW-P-02 has no source/dest label command); future epic will model matrix/router config import. Co-Authored-By Claude Opus 4.8.