### PR TITLE
test(probel-sw02p): loopback integration + replay fixtures (ADR-0025 #3/#5)

### DIFF
--- a/ansible/playbooks/probel-sw02p-integration.yml
+++ b/ansible/playbooks/probel-sw02p-integration.yml
@@ -1,0 +1,107 @@
+---
+# Probel SW-P-02 integration CONTRACT TEST, per ADR-0025 deliverable 3:
+# "Ansible is the exclusive integration / verify / deploy driver — no
+# PowerShell .ps1 scripts." Live-rig parity driver complementing the Go
+# -tags integration body in internal/probel-sw02p/integration/.
+#
+# SW-P-02 has no separate vendor emulator in-tree: OUR OWN provider IS the
+# matrix emulator (the loopback integration test starts it in-process,
+# binds a real TCP listener, and drives our consumer against it over the
+# wire). So this play has two tiers:
+#
+#   1. LOOPBACK (always): run `go test -tags integration` for the
+#      sw02p integration package. The provider emulator + consumer
+#      round-trips run entirely in-process — no external dependency, no
+#      VPN. The provider is torn down by the Go test, so the net effect
+#      is zero persistent change → run-twice = same result (ADR-0025
+#      idempotency). changed_when:false makes that explicit.
+#
+#   2. EXTERNAL (gated on PROBEL_SW02P_TEST_HOST): re-run the SAME Go
+#      integration body with the env var set, pointing the consumer at a
+#      real SW-P-02 matrix / vendor emulator on the lab network instead
+#      of the in-process provider. Skipped cleanly when the var is unset,
+#      so the play is safe to invoke unconditionally (CI / agent).
+#
+# dhs / go test logs are surfaced via register + debug stderr_lines so a
+# failing run shows the test output inline under `ansible-playbook -v`.
+#
+#   # loopback only:
+#   ansible-playbook -i inventory/hosts.ini playbooks/probel-sw02p-integration.yml
+#
+#   # plus the live matrix (lab, VPN):
+#   PROBEL_SW02P_TEST_HOST=10.100.0.42 \
+#     ansible-playbook -i inventory/hosts.ini playbooks/probel-sw02p-integration.yml
+#   # non-default port:
+#   PROBEL_SW02P_TEST_HOST=10.100.0.42 PROBEL_SW02P_TEST_PORT=2002 ansible-playbook ...
+- name: Probel SW-P-02 integration (loopback emulator + optional live matrix)
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    repo_root: "{{ playbook_dir }}/../.."
+    sw02p_pkg: "./internal/probel-sw02p/integration/"
+    sw02p_host: "{{ lookup('ansible.builtin.env', 'PROBEL_SW02P_TEST_HOST') | default('', true) }}"
+    sw02p_port: "{{ lookup('ansible.builtin.env', 'PROBEL_SW02P_TEST_PORT') | default('2002', true) }}"
+  tasks:
+    - name: "loopback — go test -tags integration (provider emulator in-process)"
+      ansible.builtin.command:
+        chdir: "{{ repo_root }}"
+        argv:
+          - go
+          - test
+          - -tags
+          - integration
+          - "{{ sw02p_pkg }}"
+          - -count=1
+      register: sw02p_loopback
+      changed_when: false
+      failed_when: sw02p_loopback.rc != 0
+
+    - name: "loopback — surface go test output"
+      ansible.builtin.debug:
+        msg: "{{ sw02p_loopback.stdout_lines + sw02p_loopback.stderr_lines }}"
+      when: sw02p_loopback is defined
+
+    - name: "ASSERT loopback integration passed"
+      ansible.builtin.assert:
+        that:
+          - sw02p_loopback.rc == 0
+          - "'ok' in sw02p_loopback.stdout or 'PASS' in sw02p_loopback.stdout"
+        fail_msg: "SW-P-02 loopback integration test failed — see stderr_lines above"
+        quiet: true
+
+    - name: SW-P-02 loopback result
+      ansible.builtin.debug:
+        msg: "SW-P-02 integration: PASS (loopback emulator — provider+consumer round-trip, read-only / idempotent)"
+
+    # ---- External tier (live matrix on the lab network) -----------------
+    - name: "external — go test -tags integration vs live SW-P-02 matrix"
+      ansible.builtin.command:
+        chdir: "{{ repo_root }}"
+        argv:
+          - go
+          - test
+          - -tags
+          - integration
+          - "{{ sw02p_pkg }}"
+          - -count=1
+      environment:
+        PROBEL_SW02P_TEST_HOST: "{{ sw02p_host }}"
+        PROBEL_SW02P_TEST_PORT: "{{ sw02p_port | string }}"
+      register: sw02p_external
+      changed_when: false
+      failed_when: sw02p_external.rc != 0
+      when: (sw02p_host | length) > 0
+
+    - name: "external — surface go test output"
+      ansible.builtin.debug:
+        msg: "{{ sw02p_external.stdout_lines + sw02p_external.stderr_lines }}"
+      when:
+        - (sw02p_host | length) > 0
+        - sw02p_external is defined
+        - sw02p_external.stdout_lines is defined
+
+    - name: SW-P-02 external result
+      ansible.builtin.debug:
+        msg: "SW-P-02 integration: PASS vs {{ sw02p_host }}:{{ sw02p_port }} (live matrix, read-only / idempotent)"
+      when: (sw02p_host | length) > 0

--- a/internal/probel-sw02p/integration/fixture_test.go
+++ b/internal/probel-sw02p/integration/fixture_test.go
@@ -1,0 +1,55 @@
+//go:build integration
+
+package probelsw02p_integration
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"dhs/internal/export"
+)
+
+// matrixTreeFixture is the committed canonical JSON export of the matrix
+// tree the loopback provider serves. It is produced from servedExport()
+// via the repo's own canonical-JSON writer so the on-disk fixture can
+// never drift from what the emulator actually serves.
+const matrixTreeFixture = "../testdata/exports/matrix_tree.json"
+
+// TestMatrixTreeExportFixture asserts the committed canonical JSON export
+// is byte-identical to what export.WriteCanonicalJSON emits for the
+// served matrix tree. Run with DHS_REGEN_FIXTURES=1 to (re)write the
+// fixture after an intentional tree change:
+//
+//	DHS_REGEN_FIXTURES=1 go test -tags integration \
+//	  ./internal/probel-sw02p/integration/ -run TestMatrixTreeExportFixture
+func TestMatrixTreeExportFixture(t *testing.T) {
+	var buf bytes.Buffer
+	if err := export.WriteCanonicalJSON(context.Background(), &buf, servedExport()); err != nil {
+		t.Fatalf("WriteCanonicalJSON: %v", err)
+	}
+	want := buf.Bytes()
+
+	if os.Getenv("DHS_REGEN_FIXTURES") == "1" {
+		if err := os.MkdirAll(filepath.Dir(matrixTreeFixture), 0o755); err != nil {
+			t.Fatalf("mkdir exports: %v", err)
+		}
+		if err := os.WriteFile(matrixTreeFixture, want, 0o644); err != nil {
+			t.Fatalf("write fixture: %v", err)
+		}
+		t.Logf("regenerated %s (%d bytes)", matrixTreeFixture, len(want))
+		return
+	}
+
+	got, err := os.ReadFile(matrixTreeFixture)
+	if err != nil {
+		t.Fatalf("read committed fixture %s: %v "+
+			"(regenerate with DHS_REGEN_FIXTURES=1)", matrixTreeFixture, err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("committed %s is stale — does not match the served matrix "+
+			"tree. Regenerate with DHS_REGEN_FIXTURES=1.", matrixTreeFixture)
+	}
+}

--- a/internal/probel-sw02p/integration/loopback_test.go
+++ b/internal/probel-sw02p/integration/loopback_test.go
@@ -1,0 +1,487 @@
+//go:build integration
+
+// Loopback integration test: our own SW-P-02 provider (the router
+// emulator) backs a real TCP listener; our own SW-P-02 consumer dials
+// it and drives the full codec → session → handler → fan-out stack
+// over the wire. Exercises encode → TCP (SOM 0xFF + 7-bit checksum, no
+// DLE) → decode → handler → broadcast → await-matcher end-to-end. No
+// external device required; the provider IS the matrix emulator, so the
+// loopback body is CI-safe.
+//
+// External mode: set PROBEL_SW02P_TEST_HOST (optionally
+// PROBEL_SW02P_TEST_PORT, default 2002) to point the same consumer
+// round-trips at a real SW-P-02 matrix / vendor emulator on the lab
+// network instead of the in-process provider. Mirrors the env-var
+// gating used by the osc / tsl / acp1 integration bodies.
+//
+// Run with:
+//
+//	go test -tags integration ./internal/probel-sw02p/integration/...
+//
+// Externally:
+//
+//	PROBEL_SW02P_TEST_HOST=10.100.0.42 \
+//	  go test -tags integration ./internal/probel-sw02p/integration/...
+package probelsw02p_integration
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"dhs/internal/export/canonical"
+	"dhs/internal/probel-sw02p/codec"
+	consumer "dhs/internal/probel-sw02p/consumer"
+	provider "dhs/internal/probel-sw02p/provider"
+)
+
+// matrixDsts / matrixSrcs bound the served matrix. The provider applies
+// rx 02 CONNECT leniently against these declared counts, so every test
+// dst/src must stay inside the matrix or the route is silently dropped
+// (no tx 04). Keep the addresses below well inside the bounds.
+const (
+	matrixDsts = 8
+	matrixSrcs = 8
+)
+
+const externalHostEnv = "PROBEL_SW02P_TEST_HOST"
+const externalPortEnv = "PROBEL_SW02P_TEST_PORT"
+
+// testEnv carries the per-test consumer endpoint plus a teardown hook.
+// In loopback mode the provider is started in-process; in external mode
+// it points at the lab host and the provider hook is a no-op.
+type testEnv struct {
+	host string
+	port int
+}
+
+// testLogger returns a debug logger when DHS_TEST_VERBOSE=1, otherwise a
+// silent one — mirrors the provider integration_test convention.
+func testLogger() *slog.Logger {
+	if os.Getenv("DHS_TEST_VERBOSE") == "1" {
+		return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	}
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// servedExport is the canonical matrix tree the loopback provider serves
+// — a single 1-to-N matrix of matrixDsts × matrixSrcs. This is the exact
+// shape committed under testdata/exports/matrix_tree.json (see
+// fixture_test.go), so the loopback emulator and the fixture never drift.
+func servedExport() *canonical.Export {
+	return &canonical.Export{
+		Root: &canonical.Node{
+			Header: canonical.Header{
+				Number: 1, Identifier: "router", OID: "1",
+				Children: []canonical.Element{
+					&canonical.Matrix{
+						Header: canonical.Header{
+							Number: 1, Identifier: "matrix-0", OID: "1.1",
+						},
+						Type:        canonical.MatrixOneToN,
+						Mode:        canonical.ModeLinear,
+						TargetCount: matrixDsts,
+						SourceCount: matrixSrcs,
+						Labels:      []canonical.MatrixLabel{{BasePath: "router.matrix-0.video"}},
+					},
+				},
+			},
+		},
+	}
+}
+
+// startLoopbackProvider binds a fresh provider to an ephemeral localhost
+// port and returns the bound endpoint. The provider is torn down when
+// the test finishes via t.Cleanup.
+func startLoopbackProvider(t *testing.T, logger *slog.Logger) testEnv {
+	t.Helper()
+
+	f := &provider.Factory{}
+	prov := f.New(logger, servedExport())
+
+	// Probe an ephemeral port, then hand the address to Serve. Mirrors
+	// the close-then-rebind pattern used by the provider integration
+	// test; the 1 s dial-wait below tolerates the rebind window.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("probe listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close probe listener: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- prov.Serve(ctx, addr) }()
+
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-serveDone:
+		case <-time.After(2 * time.Second):
+			t.Error("provider Serve did not return after ctx cancel")
+		}
+	})
+
+	// Wait up to 1 s for the listener to accept.
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		c, derr := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if derr == nil {
+			_ = c.Close()
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	host, port := splitHostPort(t, addr)
+	return testEnv{host: host, port: port}
+}
+
+// dialEnv resolves the consumer endpoint. When PROBEL_SW02P_TEST_HOST is
+// set, it targets that lab host (no in-process provider); otherwise it
+// spins up the loopback emulator. The matrix-config bootstrap sweep +
+// keep-alive poll is left disabled so tests drive exactly the frames
+// they assert — no background rx 01 noise.
+func dialEnv(t *testing.T) (*consumer.Plugin, func()) {
+	t.Helper()
+	logger := testLogger()
+
+	var env testEnv
+	if host := os.Getenv(externalHostEnv); host != "" {
+		port := codec.DefaultPort
+		if ps := os.Getenv(externalPortEnv); ps != "" {
+			p, err := strconv.Atoi(ps)
+			if err != nil {
+				t.Fatalf("%s=%q: %v", externalPortEnv, ps, err)
+			}
+			port = p
+		}
+		env = testEnv{host: host, port: port}
+		t.Logf("external mode: SW-P-02 matrix at %s:%d", host, port)
+	} else {
+		env = startLoopbackProvider(t, logger)
+	}
+
+	f := &consumer.Factory{}
+	pl, ok := f.New(logger).(*consumer.Plugin)
+	if !ok {
+		t.Fatal("consumer Factory.New did not return *Plugin")
+	}
+	// Disable the bootstrap rx 01 sweep + keep-alive so each test owns
+	// every frame on the wire.
+	pl.SetMatrixConfig(consumer.MatrixConfig{
+		InitialPoll:         false,
+		AppKeepaliveSpacing: -1,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := pl.Connect(ctx, env.host, env.port); err != nil {
+		t.Fatalf("consumer Connect %s:%d: %v", env.host, env.port, err)
+	}
+	return pl, func() { _ = pl.Disconnect() }
+}
+
+// sendCtx returns a 3 s send context — long enough to absorb the rebind
+// window and lab RTT, short enough to fail fast on a wedged matrix.
+func sendCtx(t *testing.T) (context.Context, context.CancelFunc) {
+	t.Helper()
+	return context.WithTimeout(context.Background(), 3*time.Second)
+}
+
+// TestConnectInterrogateRoundTrip drives rx 02 CONNECT then rx 01
+// INTERROGATE on the same destination and asserts the interrogate reads
+// back the source the connect just set — the basic "set a crosspoint and
+// read it back" contract over a real TCP round-trip.
+func TestConnectInterrogateRoundTrip(t *testing.T) {
+	pl, closer := dialEnv(t)
+	defer closer()
+
+	const dst, src = uint16(2), uint16(5)
+
+	ctx, cancel := sendCtx(t)
+	defer cancel()
+
+	cp, err := pl.SendConnect(ctx, dst, src, false)
+	if err != nil {
+		t.Fatalf("SendConnect(%d,%d): %v", dst, src, err)
+	}
+	if cp.Destination != dst || cp.Source != src {
+		t.Fatalf("tx 04 = (%d,%d); want (%d,%d)", cp.Destination, cp.Source, dst, src)
+	}
+
+	tally, err := pl.SendInterrogate(ctx, dst)
+	if err != nil {
+		t.Fatalf("SendInterrogate(%d): %v", dst, err)
+	}
+	if tally.Destination != dst {
+		t.Errorf("tx 03 dst = %d; want %d", tally.Destination, dst)
+	}
+	if tally.Source != src {
+		t.Errorf("tx 03 src = %d; want %d (route did not stick)", tally.Source, src)
+	}
+}
+
+// TestConnectTally drives a single rx 02 CONNECT and asserts the matrix
+// fans out the tx 04 CROSSPOINT CONNECTED tally to a SECOND consumer
+// session that never sent a frame — exercising the cross-session
+// broadcast path (§3.2.6 "issued on all ports").
+func TestConnectTally(t *testing.T) {
+	logger := testLogger()
+
+	// This cross-session assertion is loopback-only — it needs two
+	// sessions against the SAME emulator instance and observes the
+	// fan-out. Against an external matrix we cannot guarantee a second
+	// idle controller, so target only the loopback provider here.
+	if os.Getenv(externalHostEnv) != "" {
+		t.Skip("cross-session fan-out assertion is loopback-only; skipping in external mode")
+	}
+	env := startLoopbackProvider(t, logger)
+
+	// Controller A: the active driver.
+	fa := &consumer.Factory{}
+	plA := fa.New(logger).(*consumer.Plugin)
+	plA.SetMatrixConfig(consumer.MatrixConfig{InitialPoll: false, AppKeepaliveSpacing: -1})
+
+	// Controller B: a passive observer subscribed to every frame.
+	fb := &consumer.Factory{}
+	plB := fb.New(logger).(*consumer.Plugin)
+	plB.SetMatrixConfig(consumer.MatrixConfig{InitialPoll: false, AppKeepaliveSpacing: -1})
+
+	connCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := plA.Connect(connCtx, env.host, env.port); err != nil {
+		t.Fatalf("A connect: %v", err)
+	}
+	defer func() { _ = plA.Disconnect() }()
+	if err := plB.Connect(connCtx, env.host, env.port); err != nil {
+		t.Fatalf("B connect: %v", err)
+	}
+	defer func() { _ = plB.Disconnect() }()
+
+	clientB, err := plB.ExposeClient()
+	if err != nil {
+		t.Fatalf("B expose client: %v", err)
+	}
+	got := make(chan codec.ConnectedParams, 4)
+	clientB.Subscribe(func(f codec.Frame) {
+		if f.ID != codec.TxCrosspointConnected {
+			return
+		}
+		if p, derr := codec.DecodeConnected(f); derr == nil {
+			got <- p
+		}
+	})
+
+	const dst, src = uint16(3), uint16(6)
+	sctx, scancel := sendCtx(t)
+	defer scancel()
+
+	// Prove B's session is fully registered in the provider's session
+	// map BEFORE A drives the connect — otherwise A's fan-out can race
+	// ahead of B's accept and B misses the broadcast. A completed B
+	// round-trip guarantees the server has B in its session set.
+	if _, err := plB.SendInterrogate(sctx, 0); err != nil {
+		t.Fatalf("B warm-up interrogate: %v", err)
+	}
+
+	if _, err := plA.SendConnect(sctx, dst, src, false); err != nil {
+		t.Fatalf("A SendConnect: %v", err)
+	}
+
+	select {
+	case p := <-got:
+		if p.Destination != dst || p.Source != src {
+			t.Errorf("B observed tx 04 (%d,%d); want (%d,%d)", p.Destination, p.Source, dst, src)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("B never observed the tx 04 tally fan-out")
+	}
+}
+
+// TestProtectCycle drives the full protect lifecycle over the wire:
+// interrogate (unprotected) → rx 102 PROTECT CONNECT → interrogate
+// (Pro-Bel protected, owner echoed) → rx 104 PROTECT DIS-CONNECT →
+// interrogate (unprotected again). Pins the owner-only authority model's
+// happy path end-to-end.
+func TestProtectCycle(t *testing.T) {
+	pl, closer := dialEnv(t)
+	defer closer()
+
+	const dst, device = uint16(4), uint16(9)
+
+	ctx, cancel := sendCtx(t)
+	defer cancel()
+
+	// 1. Start unprotected.
+	pre, err := pl.SendExtendedProtectInterrogate(ctx, dst)
+	if err != nil {
+		t.Fatalf("pre interrogate: %v", err)
+	}
+	if pre.Protect != codec.ProtectNone {
+		t.Fatalf("pre-protect state = %d; want ProtectNone — test dst dirty", pre.Protect)
+	}
+
+	// 2. Protect for our device.
+	on, err := pl.SendExtendedProtectConnect(ctx, dst, device)
+	if err != nil {
+		t.Fatalf("protect-connect: %v", err)
+	}
+	if on.Protect != codec.ProtectProBel {
+		t.Errorf("after protect-connect state = %d; want ProtectProBel", on.Protect)
+	}
+	if on.Destination != dst || on.Device != device {
+		t.Errorf("tx 097 = (dst=%d, dev=%d); want (dst=%d, dev=%d)",
+			on.Destination, on.Device, dst, device)
+	}
+
+	// 3. Interrogate confirms the protect stuck with the right owner.
+	mid, err := pl.SendExtendedProtectInterrogate(ctx, dst)
+	if err != nil {
+		t.Fatalf("mid interrogate: %v", err)
+	}
+	if mid.Protect != codec.ProtectProBel || mid.Device != device {
+		t.Errorf("mid interrogate = (state=%d, dev=%d); want (ProtectProBel, %d)",
+			mid.Protect, mid.Device, device)
+	}
+
+	// 4. Disconnect by the owning device.
+	off, err := pl.SendExtendedProtectDisconnect(ctx, dst, device)
+	if err != nil {
+		t.Fatalf("protect-disconnect: %v", err)
+	}
+	if off.Protect != codec.ProtectNone {
+		t.Errorf("after protect-disconnect state = %d; want ProtectNone", off.Protect)
+	}
+
+	// 5. Interrogate confirms cleared.
+	post, err := pl.SendExtendedProtectInterrogate(ctx, dst)
+	if err != nil {
+		t.Fatalf("post interrogate: %v", err)
+	}
+	if post.Protect != codec.ProtectNone {
+		t.Errorf("post interrogate state = %d; want ProtectNone", post.Protect)
+	}
+}
+
+// TestDualControllerStatus drives rx 050 DUAL CONTROLLER STATUS REQUEST
+// and asserts the single-controller emulator answers Master active /
+// idle OK per its documented single-controller-by-construction policy.
+func TestDualControllerStatus(t *testing.T) {
+	pl, closer := dialEnv(t)
+	defer closer()
+
+	ctx, cancel := sendCtx(t)
+	defer cancel()
+
+	resp, err := pl.SendDualControllerStatusRequest(ctx)
+	if err != nil {
+		t.Fatalf("SendDualControllerStatusRequest: %v", err)
+	}
+	// External matrices with a real redundant pair may legitimately
+	// report Slave-active / idle-faulty — only assert the exact shape
+	// against our own loopback emulator.
+	if os.Getenv(externalHostEnv) == "" {
+		if resp.Active != codec.ActiveControllerMaster {
+			t.Errorf("active = %d; want ActiveControllerMaster", resp.Active)
+		}
+		if resp.IdleStatus != codec.IdleControllerOK {
+			t.Errorf("idle = %d; want IdleControllerOK", resp.IdleStatus)
+		}
+	}
+}
+
+// TestSourceLockStatus drives rx 014 SOURCE LOCK STATUS REQUEST and
+// asserts the emulator returns a lock bitmap. The software emulator has
+// no physical input cards, so it reports every declared source as
+// locked=true (§3.2.17 all-present interpretation).
+func TestSourceLockStatus(t *testing.T) {
+	pl, closer := dialEnv(t)
+	defer closer()
+
+	ctx, cancel := sendCtx(t)
+	defer cancel()
+
+	resp, err := pl.SendSourceLockStatusRequest(ctx, codec.ControllerLH)
+	if err != nil {
+		t.Fatalf("SendSourceLockStatusRequest: %v", err)
+	}
+	if len(resp.Locked) == 0 {
+		t.Fatal("source-lock response carried an empty bitmap")
+	}
+	if os.Getenv(externalHostEnv) == "" {
+		// Loopback emulator reports every source locked.
+		for i, locked := range resp.Locked {
+			if !locked {
+				t.Errorf("source %d reported unlocked; loopback emulator should report all locked", i)
+			}
+		}
+	}
+}
+
+// TestSalvoConnectOnGoThenGo stages three crosspoints under a named
+// salvo via rx 35 CONNECT ON GO GROUP SALVO, fires the group via rx 36
+// GO GROUP SALVO, and asserts the matrix returns tx 38 GO DONE GROUP
+// SALVO ACK (Set) and that every staged crosspoint reads back via a
+// follow-up rx 01 INTERROGATE — the salvo commit path end-to-end.
+func TestSalvoConnectOnGoThenGo(t *testing.T) {
+	pl, closer := dialEnv(t)
+	defer closer()
+
+	ctx, cancel := sendCtx(t)
+	defer cancel()
+
+	const salvoID = uint8(5)
+	slots := []struct{ dst, src uint16 }{{0, 1}, {1, 2}, {2, 3}}
+
+	for _, s := range slots {
+		ack, err := pl.SendConnectOnGoGroupSalvo(ctx, s.dst, s.src, salvoID, false)
+		if err != nil {
+			t.Fatalf("stage (%d,%d) salvo %d: %v", s.dst, s.src, salvoID, err)
+		}
+		if ack.Destination != s.dst || ack.Source != s.src || ack.SalvoID != salvoID {
+			t.Errorf("tx 37 ack = (%d,%d,salvo=%d); want (%d,%d,salvo=%d)",
+				ack.Destination, ack.Source, ack.SalvoID, s.dst, s.src, salvoID)
+		}
+	}
+
+	done, err := pl.SendGoGroupSalvo(ctx, codec.GoOpSet, salvoID)
+	if err != nil {
+		t.Fatalf("fire salvo %d: %v", salvoID, err)
+	}
+	if done.Result != codec.GoGroupResultSet || done.SalvoID != salvoID {
+		t.Errorf("tx 38 = %+v; want Result=Set SalvoID=%d", done, salvoID)
+	}
+
+	// Every staged crosspoint must now be live.
+	for _, s := range slots {
+		tally, err := pl.SendInterrogate(ctx, s.dst)
+		if err != nil {
+			t.Fatalf("post-go interrogate dst %d: %v", s.dst, err)
+		}
+		if tally.Source != s.src {
+			t.Errorf("dst %d reads src %d after GO; want %d", s.dst, tally.Source, s.src)
+		}
+	}
+}
+
+// splitHostPort turns "127.0.0.1:54321" into ("127.0.0.1", 54321).
+func splitHostPort(t *testing.T, addr string) (string, int) {
+	t.Helper()
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("SplitHostPort(%q): %v", addr, err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("parse port %q: %v", portStr, err)
+	}
+	return host, port
+}

--- a/internal/probel-sw02p/testdata/exports/matrix_tree.json
+++ b/internal/probel-sw02p/testdata/exports/matrix_tree.json
@@ -1,0 +1,42 @@
+{
+  "root": {
+    "number": 1,
+    "identifier": "router",
+    "path": "",
+    "oid": "1",
+    "isOnline": false,
+    "access": "",
+    "children": [
+      {
+        "number": 1,
+        "identifier": "matrix-0",
+        "path": "",
+        "oid": "1.1",
+        "isOnline": false,
+        "access": "",
+        "type": "oneToN",
+        "mode": "linear",
+        "targetCount": 8,
+        "sourceCount": 8,
+        "maximumTotalConnects": null,
+        "maximumConnectsPerTarget": null,
+        "parametersLocation": null,
+        "gainParameterNumber": null,
+        "labels": [
+          {
+            "basePath": "router.matrix-0.video",
+            "description": null
+          }
+        ],
+        "targets": null,
+        "sources": null,
+        "connections": null,
+        "targetLabels": null,
+        "sourceLabels": null,
+        "targetParams": null,
+        "sourceParams": null,
+        "connectionParams": null
+      }
+    ]
+  }
+}

--- a/internal/probel-sw02p/testdata/fixtures/README.md
+++ b/internal/probel-sw02p/testdata/fixtures/README.md
@@ -1,0 +1,61 @@
+# SW-P-02 Test Fixtures
+
+Replay fixtures + canonical exports for the SW-P-02 (Probel single-matrix
+single-level) connector, per ADR-0025 deliverable 8 (replay fixtures).
+
+This directory is the SW-P-02 sibling of `internal/acp1/testdata/` — same
+layout, same role: committed, real, minimal artifacts that let the codec
+and integration tests run without a live matrix.
+
+## Layout
+
+```
+internal/probel-sw02p/testdata/
+├── fixtures/
+│   └── README.md            ← this file
+├── exports/
+│   └── matrix_tree.json     canonical JSON export of the matrix tree
+│                            the loopback provider serves (8×8 1-to-N)
+└── protocol_types/          per-wire-type capture fixtures (frames.jsonl
+                             + capture.pcapng + tshark.tree); see its
+                             own README.md
+```
+
+## `exports/matrix_tree.json`
+
+Canonical-tree JSON export of the exact `canonical.Export` the
+in-process provider serves in the loopback integration test
+(`internal/probel-sw02p/integration/`). One `router` node containing a
+single `oneToN` / `linear` matrix sized 8 destinations × 8 sources, with
+one label base path.
+
+It is produced by the repo's own canonical-JSON writer
+(`export.WriteCanonicalJSON`) — **never hand-edited**. The integration
+test `TestMatrixTreeExportFixture` asserts the committed file is
+byte-identical to what the writer emits for the served tree, so the
+fixture can never drift from the emulator. After an intentional tree
+change, regenerate it:
+
+```
+DHS_REGEN_FIXTURES=1 go test -tags integration \
+  ./internal/probel-sw02p/integration/ -run TestMatrixTreeExportFixture
+```
+
+JSON only by design — matrix CSV export/import is out of scope for this
+connector.
+
+## `protocol_types/`
+
+Per-command wire-trace fixtures (one folder per command byte / verb),
+consumed by `internal/probel-sw02p/codec/*_test.go` for byte-level
+round-trips and by the Wireshark dissector cross-check. See
+`protocol_types/README.md` for the folder convention and how to promote
+a live `captures/probel-sw02p/<scenario>/frames.jsonl` into a committed
+fixture.
+
+## Pairing with `captures/`
+
+Live captures live LOCAL ONLY at
+`captures/probel-sw02p/<scenario>/frames.jsonl` (gitignored per
+ADR-0021). Trim + drop the relevant frames under the matching
+`protocol_types/<cmd>/` folder to promote them into a committed fixture.


### PR DESCRIPTION
Brings probel-sw02p up to the tsl/osc integration standard (ADR-0025 deliverables 3 + 5). SW-P-02 has no in-tree vendor emulator, so our own provider IS the matrix emulator: loopback (provider-emulates-router in-process over a real TCP listener) is the always-on tier; a live matrix is the env-gated add-on (PROBEL_SW02P_TEST_HOST). Adds: 7-test Go //go:build integration loopback suite (connect/interrogate round-trip, cross-session tx04 fan-out, protect cycle, dual-controller-status, source-lock-status, salvo connect-on-go to go); a fixture drift-guard; canonical JSON replay fixture (matrix CSV deferred per user); and a mirrored Ansible play (loopback + external tiers, log surfacing, idempotent). Verified locally: build clean; -tags integration 7/7 PASS; no-tags suite does not pick up integration; golangci-lint 0 issues; -race deferred to CI (no cgo on dev host). Co-Authored-By Claude Opus 4.8.