### PR TITLE
test(tsl): replay fixtures + Ansible integration play (ADR-0025 #3/#5)

### DIFF
--- a/ansible/playbooks/tsl-integration.yml
+++ b/ansible/playbooks/tsl-integration.yml
@@ -1,0 +1,101 @@
+---
+# TSL UMD integration CONTRACT TEST, per ADR-0025 deliverable 3:
+# "Ansible is the exclusive integration / verify / deploy driver — no
+# PowerShell .ps1 scripts." Live-rig parity driver complementing the Go
+# -tags integration body in internal/tsl/integration/.
+#
+# TSL is a tally/UMD PUSH protocol (v3.1 / v4.0 UDP, v5.0 UDP + DLE/STX
+# TCP), not a matrix. OUR OWN provider IS the tally source: the loopback
+# integration tests start it in-process, bind a real UDP/TCP socket, and
+# drive our consumer against it over the wire (encode → socket → decode →
+# subscribe callback). So this play has two tiers:
+#
+#   1. LOOPBACK (always): run `go test -tags integration` for the tsl
+#      integration package. The provider + consumer round-trips run
+#      entirely in-process across all three wire versions — no external
+#      dependency, no VPN. Every socket is torn down by the Go test, so
+#      run-twice = same result (ADR-0025 idempotency). changed_when:false
+#      makes that explicit. This tier also runs the codec-driven golden-
+#      frame drift-guard (TestGoldenFrameFixtures) + round-trip
+#      (TestGoldenFramesRoundTrip), so a stale committed fixture fails
+#      the play.
+#
+#   2. EXTERNAL (gated on TSL_TEST_HOST): SKIPPED BY DESIGN today. Unlike
+#      the probel-swNNp plays, the Go integration body under
+#      internal/tsl/integration/ is LOOPBACK-ONLY — none of the tests read
+#      a *_TEST_HOST env var or dial an external tally source. Wiring an
+#      external go-test re-run here would invent an untested external path
+#      (forbidden — the test would silently still hit loopback). So this
+#      tier only PRINTS a clear "not yet supported" notice when
+#      TSL_TEST_HOST is set, and is otherwise inert. When the Go tests grow
+#      a real external dial path (Miranda IP Emulator / Lawo VSM on the lab
+#      network — see internal/tsl/CLAUDE.md "Testbed"), replace the notice
+#      task with an external `go test` invocation exporting TSL_TEST_HOST,
+#      mirroring playbooks/probel-sw02p-integration.yml.
+#
+# dhs / go test logs are surfaced via register + debug stderr_lines so a
+# failing run shows the test output inline under `ansible-playbook -v`.
+#
+#   # loopback only (the supported path):
+#   ansible-playbook -i inventory/hosts.ini playbooks/tsl-integration.yml
+#
+#   # with TSL_TEST_HOST set — prints the not-yet-supported notice:
+#   TSL_TEST_HOST=10.100.0.42 \
+#     ansible-playbook -i inventory/hosts.ini playbooks/tsl-integration.yml
+- name: TSL UMD integration (loopback provider+consumer, all three versions)
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    repo_root: "{{ playbook_dir }}/../.."
+    tsl_pkg: "./internal/tsl/integration/"
+    # Convention-consistent with ACP1_TEST_HOST / PROBEL_SW0Np_TEST_HOST.
+    # The Go tests do not yet read it (loopback-only) — see header note.
+    tsl_host: "{{ lookup('ansible.builtin.env', 'TSL_TEST_HOST') | default('', true) }}"
+  tasks:
+    - name: "loopback — go test -tags integration (provider+consumer in-process)"
+      ansible.builtin.command:
+        chdir: "{{ repo_root }}"
+        argv:
+          - go
+          - test
+          - -tags
+          - integration
+          - "{{ tsl_pkg }}"
+          - -count=1
+      register: tsl_loopback
+      changed_when: false
+      failed_when: tsl_loopback.rc != 0
+
+    - name: "loopback — surface go test output"
+      ansible.builtin.debug:
+        msg: "{{ tsl_loopback.stdout_lines + tsl_loopback.stderr_lines }}"
+      when: tsl_loopback is defined
+
+    - name: "ASSERT loopback integration passed"
+      ansible.builtin.assert:
+        that:
+          - tsl_loopback.rc == 0
+          - "'ok' in tsl_loopback.stdout or 'PASS' in tsl_loopback.stdout"
+        fail_msg: "TSL loopback integration test failed — see stderr_lines above"
+        quiet: true
+
+    - name: TSL loopback result
+      ansible.builtin.debug:
+        msg: >-
+          TSL integration: PASS (loopback — v3.1/v4.0/v5.0 provider+consumer
+          round-trip + codec golden-frame drift-guard, read-only / idempotent)
+
+    # ---- External tier (live tally source on the lab network) -----------
+    # SKIPPED BY DESIGN: the Go tests are loopback-only today (no external
+    # dial path). We do NOT re-run go test with TSL_TEST_HOST set because it
+    # would silently still test loopback. See header note for the upgrade path.
+    - name: "external — NOT YET SUPPORTED notice"
+      ansible.builtin.debug:
+        msg: >-
+          TSL_TEST_HOST={{ tsl_host }} is set, but internal/tsl/integration/
+          is loopback-only — no external dial path exists yet. Skipping the
+          external tier (would otherwise re-test loopback). Add a real
+          external go-test path to the integration body first, then wire it
+          here mirroring playbooks/probel-sw02p-integration.yml.
+      when: (tsl_host | length) > 0

--- a/internal/tsl/integration/fixture_test.go
+++ b/internal/tsl/integration/fixture_test.go
@@ -1,0 +1,254 @@
+//go:build integration
+
+package tsl_integration
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"dhs/internal/tsl/codec"
+)
+
+// goldenFramesFixture is the committed golden wire-byte fixture for the
+// TSL UMD codec. Unlike the matrix connectors (which export a canonical
+// tree), TSL is a tally/UMD PUSH protocol with no walkable tree — the
+// natural replay fixture is the exact on-wire frame for each version.
+//
+// Every line is one JSON object {version, transport, description, hex}
+// where hex is the lower-case hex of bytes produced by the REAL codec
+// encode path (V31Frame.Encode / V40Frame.Encode / V50Packet.Encode,
+// the last optionally DLE/STX-wrapped via EncodeDLEFrame). The file is
+// NEVER hand-edited — TestGoldenFrameFixtures regenerates it from the
+// codec and the drift-guard asserts the committed bytes still match.
+const goldenFramesFixture = "../testdata/fixtures/golden_frames.jsonl"
+
+// goldenFrame is one committed wire sample.
+type goldenFrame struct {
+	Version     string `json:"version"`     // "v3.1" | "v4.0" | "v5.0"
+	Transport   string `json:"transport"`   // "udp" | "tcp-dle-stx"
+	Description string `json:"description"` // human scenario label
+	Hex         string `json:"hex"`         // lower-case hex of the wire bytes
+}
+
+// buildGoldenFrames constructs the canonical sample set and encodes each
+// through the real codec. The struct literals are the source of truth for
+// the *semantics*; the bytes are derived, never fabricated.
+func buildGoldenFrames(t *testing.T) []goldenFrame {
+	t.Helper()
+
+	var out []goldenFrame
+
+	enc := func(b []byte, err error, version, transport, desc string) {
+		t.Helper()
+		if err != nil {
+			t.Fatalf("encode %s/%s (%s): %v", version, transport, desc, err)
+		}
+		out = append(out, goldenFrame{
+			Version:     version,
+			Transport:   transport,
+			Description: desc,
+			Hex:         hex.EncodeToString(b),
+		})
+	}
+
+	// --- v3.1 (18-byte UDP frame, §3.0) -------------------------------
+	v31 := codec.V31Frame{
+		Address:    7,
+		Tally1:     true,
+		Tally4:     true,
+		Brightness: codec.BrightnessFull,
+		Text:       "PGM LIVE",
+	}
+	b, err := v31.Encode()
+	enc(b, err, "v3.1", "udp", "addr=7 tally1+tally4 brightness=full text=\"PGM LIVE\"")
+
+	// --- v4.0 (v3.1 + CHKSUM + VBC + 2-byte XDATA, §4.0) --------------
+	v40 := codec.V40Frame{
+		V31: codec.V31Frame{
+			Address:    11,
+			Tally1:     true,
+			Tally3:     true,
+			Brightness: codec.BrightnessFull,
+			Text:       "CAM 1 ISO",
+		},
+		DisplayLeft:  codec.XByte{LH: codec.TallyRed, Text: codec.TallyGreen, RH: codec.TallyAmber},
+		DisplayRight: codec.XByte{LH: codec.TallyGreen, Text: codec.TallyRed, RH: codec.TallyOff},
+	}
+	b, err = v40.Encode()
+	enc(b, err, "v4.0", "udp", "addr=11 displayL=red/green/amber displayR=green/red/off text=\"CAM 1 ISO\"")
+
+	// --- v5.0 single-DMSG ASCII over UDP (§5.0) -----------------------
+	v50ascii := codec.V50Packet{
+		Screen: 1,
+		DMSGs: []codec.DMSG{
+			{
+				Index:      11,
+				LH:         codec.TallyRed,
+				TextTally:  codec.TallyGreen,
+				RH:         codec.TallyAmber,
+				Brightness: codec.BrightnessFull,
+				Text:       "CAM 1",
+			},
+		},
+	}
+	b, err = v50ascii.Encode()
+	enc(b, err, "v5.0", "udp", "screen=1 single-DMSG index=11 lh=red/text=green/rh=amber ascii text=\"CAM 1\"")
+
+	// --- v5.0 multi-DMSG UTF-16LE over UDP ----------------------------
+	v50utf16 := codec.V50Packet{
+		UTF16LE: true,
+		DMSGs: []codec.DMSG{
+			{Index: 0, LH: codec.TallyRed, Text: "CAMÉRA"},
+			{Index: 1, LH: codec.TallyGreen, Text: "日本語"},
+			{Index: 2, LH: codec.TallyAmber, Text: "HOLA"},
+		},
+	}
+	b, err = v50utf16.Encode()
+	enc(b, err, "v5.0", "udp", "screen=0 multi-DMSG utf-16le text=[CAMÉRA,日本語,HOLA]")
+
+	// --- v5.0 over TCP with DLE/STX wrapper + 0xFE byte-stuffing ------
+	v50tcp := codec.V50Packet{
+		Screen: 0xFEFE, // forces 0xFE → 0xFE 0xFE stuffing in the wrapper
+		DMSGs: []codec.DMSG{
+			{Index: 0xFE01, LH: codec.TallyRed, Brightness: codec.BrightnessFull, Text: "STUFF"},
+		},
+	}
+	raw, err := v50tcp.Encode()
+	if err != nil {
+		t.Fatalf("encode v5.0 tcp body: %v", err)
+	}
+	wrapped := codec.EncodeDLEFrame(raw)
+	enc(wrapped, nil, "v5.0", "tcp-dle-stx", "screen=0xFEFE dmsg index=0xFE01 lh=red — exercises DLE/STX wrap + 0xFE stuffing")
+
+	return out
+}
+
+// marshalGoldenFrames renders the sample set to the committed JSONL
+// representation (one object per line, trailing newline).
+func marshalGoldenFrames(frames []goldenFrame) ([]byte, error) {
+	var buf bytes.Buffer
+	for _, f := range frames {
+		line, err := json.Marshal(f)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(line)
+		buf.WriteByte('\n')
+	}
+	return buf.Bytes(), nil
+}
+
+// TestGoldenFrameFixtures is the TSL sibling of the matrix connectors'
+// TestMatrixTreeExportFixture drift-guard. It asserts the committed
+// golden_frames.jsonl is byte-identical to what the real codec emits for
+// the canonical sample set, so the fixture can never drift from the
+// codec. Regenerate after an intentional wire change with:
+//
+//	DHS_REGEN_FIXTURES=1 go test -tags integration \
+//	  ./internal/tsl/integration/ -run TestGoldenFrameFixtures
+func TestGoldenFrameFixtures(t *testing.T) {
+	frames := buildGoldenFrames(t)
+	want, err := marshalGoldenFrames(frames)
+	if err != nil {
+		t.Fatalf("marshal golden frames: %v", err)
+	}
+
+	if os.Getenv("DHS_REGEN_FIXTURES") == "1" {
+		if err := os.MkdirAll(filepath.Dir(goldenFramesFixture), 0o755); err != nil {
+			t.Fatalf("mkdir fixtures: %v", err)
+		}
+		if err := os.WriteFile(goldenFramesFixture, want, 0o644); err != nil {
+			t.Fatalf("write fixture: %v", err)
+		}
+		t.Logf("regenerated %s (%d frames, %d bytes)", goldenFramesFixture, len(frames), len(want))
+		return
+	}
+
+	got, err := os.ReadFile(goldenFramesFixture)
+	if err != nil {
+		t.Fatalf("read committed fixture %s: %v "+
+			"(regenerate with DHS_REGEN_FIXTURES=1)", goldenFramesFixture, err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("committed %s is stale — does not match codec-encoded golden "+
+			"frames. Regenerate with DHS_REGEN_FIXTURES=1.", goldenFramesFixture)
+	}
+}
+
+// TestGoldenFramesRoundTrip proves every committed golden frame decodes
+// back through the real codec to a structurally valid frame with NO
+// compliance notes — i.e. the fixtures are clean, spec-conformant wire
+// samples, not hand-fabricated bytes. This is the "fixtures must be REAL
+// (round-trip through the codec)" guarantee.
+func TestGoldenFramesRoundTrip(t *testing.T) {
+	data, err := os.ReadFile(goldenFramesFixture)
+	if err != nil {
+		t.Fatalf("read fixture: %v (regenerate with DHS_REGEN_FIXTURES=1)", err)
+	}
+	for i, line := range bytes.Split(bytes.TrimRight(data, "\n"), []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		var gf goldenFrame
+		if err := json.Unmarshal(line, &gf); err != nil {
+			t.Fatalf("line %d: unmarshal: %v", i, err)
+		}
+		raw, err := hex.DecodeString(gf.Hex)
+		if err != nil {
+			t.Fatalf("line %d: hex decode: %v", i, err)
+		}
+		switch {
+		case gf.Version == "v3.1":
+			f, err := codec.DecodeV31(raw)
+			if err != nil {
+				t.Errorf("line %d (%s): DecodeV31: %v", i, gf.Description, err)
+				continue
+			}
+			if len(f.Notes) != 0 {
+				t.Errorf("line %d (%s): clean frame has notes: %+v", i, gf.Description, f.Notes)
+			}
+		case gf.Version == "v4.0":
+			f, err := codec.DecodeV40(raw)
+			if err != nil {
+				t.Errorf("line %d (%s): DecodeV40: %v", i, gf.Description, err)
+				continue
+			}
+			if len(f.Notes) != 0 || len(f.V31.Notes) != 0 {
+				t.Errorf("line %d (%s): clean frame has notes: v31=%+v v40=%+v",
+					i, gf.Description, f.V31.Notes, f.Notes)
+			}
+		case gf.Version == "v5.0" && gf.Transport == "tcp-dle-stx":
+			dec := codec.NewDLEStreamDecoder(bytes.NewReader(raw), 0)
+			body, err := dec.ReadFrame()
+			if err != nil {
+				t.Errorf("line %d (%s): DLE ReadFrame: %v", i, gf.Description, err)
+				continue
+			}
+			if _, err := codec.DecodeV50(body); err != nil {
+				t.Errorf("line %d (%s): DecodeV50: %v", i, gf.Description, err)
+			}
+		case gf.Version == "v5.0":
+			p, err := codec.DecodeV50(raw)
+			if err != nil {
+				t.Errorf("line %d (%s): DecodeV50: %v", i, gf.Description, err)
+				continue
+			}
+			// The only note a clean v5.0 UTF-16LE frame legitimately
+			// carries is tsl_charset_transcode (informational, fired per
+			// transcoded DMSG — not a spec deviation). Any other note on a
+			// golden sample means the bytes aren't clean.
+			for _, n := range p.Notes {
+				if n.Kind != "tsl_charset_transcode" {
+					t.Errorf("line %d (%s): clean frame has deviation note: %+v",
+						i, gf.Description, n)
+				}
+			}
+		default:
+			t.Errorf("line %d: unknown version/transport %q/%q", i, gf.Version, gf.Transport)
+		}
+	}
+}

--- a/internal/tsl/testdata/fixtures/README.md
+++ b/internal/tsl/testdata/fixtures/README.md
@@ -1,0 +1,93 @@
+# TSL UMD Test Fixtures
+
+Replay fixtures for the TSL UMD (v3.1 / v4.0 / v5.0) connector, per
+ADR-0025 deliverable 8 (replay fixtures).
+
+This directory is the TSL sibling of `internal/probel-sw02p/testdata/` —
+same role: committed, real, minimal artifacts that let the codec and
+integration tests run without a live tally source. Because TSL is a
+tally/UMD **PUSH** protocol (not a matrix), there is no canonical tree to
+export; the natural replay fixture is the **exact on-wire frame for each
+version**, so the analog of probel's `exports/matrix_tree.json` is
+`fixtures/golden_frames.jsonl`.
+
+## Layout
+
+```
+internal/tsl/testdata/
+├── fixtures/
+│   ├── README.md            ← this file
+│   └── golden_frames.jsonl  codec-encoded golden wire bytes, one per
+│                            (version, transport) — the drift-guard target
+└── protocol_types/          per-wire-type capture fixtures (frames.jsonl
+                             + capture.pcapng + tshark.tree); see its
+                             own README.md
+```
+
+## `fixtures/golden_frames.jsonl`
+
+One JSON object per line:
+
+| Field | Meaning |
+| --- | --- |
+| `version` | `v3.1` / `v4.0` / `v5.0` |
+| `transport` | `udp` / `tcp-dle-stx` (v5.0 DLE/STX-wrapped TCP) |
+| `description` | human scenario label |
+| `hex` | lower-case hex of the wire bytes |
+
+The committed samples:
+
+| Version | Transport | Scenario |
+| --- | --- | --- |
+| v3.1 | UDP | 18-byte frame, addr 7, tally1+tally4, full brightness, `"PGM LIVE"` |
+| v4.0 | UDP | v3.1 block + CHKSUM + VBC + 2-byte XDATA (both displays, all colours) |
+| v5.0 | UDP | single-DMSG ASCII, screen 1, `"CAM 1"` |
+| v5.0 | UDP | multi-DMSG UTF-16LE (`CAMÉRA` / `日本語` / `HOLA`) |
+| v5.0 | TCP | DLE/STX wrapper + 0xFE byte-stuffing (SCREEN=0xFEFE) |
+
+### NEVER hand-edited — generated from the real codec
+
+The `hex` bytes are produced by the repo's own codec encode path
+(`codec.V31Frame.Encode` / `codec.V40Frame.Encode` /
+`codec.V50Packet.Encode`, the last wrapped via `codec.EncodeDLEFrame`).
+The struct literals in
+`internal/tsl/integration/fixture_test.go` (`buildGoldenFrames`) are the
+source of truth for the *semantics*; the bytes are **derived, never
+fabricated**.
+
+Two guards in that file pin the fixture:
+
+- `TestGoldenFrameFixtures` — drift-guard. Asserts the committed file is
+  byte-identical to what the codec re-emits for the canonical sample set
+  (the TSL sibling of probel's `TestMatrixTreeExportFixture`).
+- `TestGoldenFramesRoundTrip` — decodes every committed frame back
+  through `DecodeV31` / `DecodeV40` / `DLEStreamDecoder` + `DecodeV50`
+  and asserts a clean parse with no deviation notes — proving the bytes
+  are spec-conformant, not hand-fabricated.
+
+Both carry `//go:build integration`, so a plain `go test ./...` never
+runs them. After an intentional wire change, regenerate:
+
+```
+DHS_REGEN_FIXTURES=1 go test -tags integration \
+  ./internal/tsl/integration/ -run TestGoldenFrameFixtures
+```
+
+then commit the updated `golden_frames.jsonl`.
+
+## `protocol_types/`
+
+Per-wire-type capture fixtures (one folder per version + frame-type),
+consumed by `internal/tsl/codec/*_test.go` for byte-level round-trips and
+by the Wireshark dissector cross-check. See `protocol_types/README.md` for
+the folder convention and how to promote a live
+`captures/tsl-vXX/<scenario>/frames.jsonl` into a committed fixture.
+
+## Pairing with `captures/`
+
+Live captures live LOCAL ONLY at `captures/tsl-vXX/<scenario>/
+frames.jsonl` (gitignored, per ADR-0021). Trim + drop the relevant
+frames under the matching `protocol_types/<version>/` folder to promote
+them into a committed fixture. The golden-frame fixture here is the
+codec-generated baseline; live captures complement it with real
+vendor-emitted bytes (Miranda / Lawo VSM).

--- a/internal/tsl/testdata/fixtures/golden_frames.jsonl
+++ b/internal/tsl/testdata/fixtures/golden_frames.jsonl
@@ -1,0 +1,5 @@
+{"version":"v3.1","transport":"udp","description":"addr=7 tally1+tally4 brightness=full text=\"PGM LIVE\"","hex":"873950474d204c4956452020202020202020"}
+{"version":"v4.0","transport":"udp","description":"addr=11 displayL=red/green/amber displayR=green/red/off text=\"CAM 1 ISO\"","hex":"8b3543414d20312049534f2020202020202033021b24"}
+{"version":"v5.0","transport":"udp","description":"screen=1 single-DMSG index=11 lh=red/text=green/rh=amber ascii text=\"CAM 1\"","hex":"0f00000001000b00db00050043414d2031"}
+{"version":"v5.0","transport":"udp","description":"screen=0 multi-DMSG utf-16le text=[CAMÉRA,日本語,HOLA]","hex":"300000010000000010000c00430041004d00c90052004100010020000600e5652c679e8a02003000080048004f004c004100"}
+{"version":"v5.0","transport":"tcp-dle-stx","description":"screen=0xFEFE dmsg index=0xFE01 lh=red — exercises DLE/STX wrap + 0xFE stuffing","hex":"fe020f000000fefefefe01fefed00005005354554646"}


### PR DESCRIPTION
Completes tsl's fixtures + Ansible deliverables to the probel standard (loopback integration tests already existed). Adds: //go:build integration golden-frame generator + drift-guard + round-trip proof (all bytes produced by the real codec encode path, never hand-fabricated; DHS_REGEN_FIXTURES=1 to regen); golden_frames.jsonl with 5 real wire frames (v3.1/v4.0/v5.0 UDP ASCII + UTF-16LE multi-DMSG + v5.0 TCP DLE/STX) + README; Ansible play (loopback always-on; external tier reserved on TSL_TEST_HOST printing a not-yet-supported notice since the Go body is loopback-only — not faked). Verified locally: build clean; -tags integration 12/12 PASS; regen byte-stable + drift-guard PASS; no-tags suite clean; golangci-lint 0 issues. Co-Authored-By Claude Opus 4.8.