### PR TITLE
docs(probel-sw02p): full ADR-0025 docs set with real captured samples

### DIFF
--- a/internal/probel-sw02p/docs/README.md
+++ b/internal/probel-sw02p/docs/README.md
@@ -1,0 +1,16 @@
+# Probel SW-P-02 — General Remote Control Protocol (Issue 26)
+
+| Role | Doc | Status |
+|---|---|---|
+| **Verbs & config reference** | [verbs.md](verbs.md) | every verb + transport/redundancy/interrogate/connect/protect/lock/reports/ensure/wireshark/ansible, with real captures |
+| Operator runbook | [runbook.md](runbook.md) | ✓ shipping |
+| Consumer | [consumer.md](consumer.md) | ✓ shipping — full matrix verb set (interrogate / connect / connect-on-go / go / protect-* / dual-status / lock-status / status / router-config / watch) over TCP |
+| Provider | [provider.md](provider.md) | ✓ shipping — serves a canonical matrix as an SW-P-02 device over TCP (port 2002) |
+
+## Spec documents
+
+| Document | Path | Description |
+|---|---|---|
+| SW-P-02 Issue 26 | [SW-P-02 issue 26.doc](../../../internal/probel-sw02p/assets/probel-sw02/SW-P-02%20issue%2026.doc) | Full specification (original Word document) |
+| SW-P-02 Issue 26 (text) | [SW-P-02_issue_26.txt](../../../internal/probel-sw02p/assets/probel-sw02/SW-P-02_issue_26.txt) | antiword-extracted plain text |
+| Wireshark dissector | [dhs_probel_sw02p.lua](../../../internal/probel-sw02p/wireshark/dhs_probel_sw02p.lua) | Byte-exact reference |

--- a/internal/probel-sw02p/docs/consumer.md
+++ b/internal/probel-sw02p/docs/consumer.md
@@ -1,0 +1,370 @@
+# Probel SW-P-02 Connector
+
+Consumer connector for the Probel SW-P-02 General Remote Control Protocol
+(Issue 26) — a single-matrix, single-level matrix-router protocol.
+
+---
+
+## References
+
+| Document | Path | Description |
+|---|---|---|
+| Spec (authoritative) | [internal/probel-sw02p/assets/probel-sw02/SW-P-02_issue_26.txt](../../../internal/probel-sw02p/assets/probel-sw02/SW-P-02_issue_26.txt) | SW-P-02 Issue 26 (antiword-extracted) |
+| Spec (original) | [internal/probel-sw02p/assets/probel-sw02/SW-P-02 issue 26.doc](../../../internal/probel-sw02p/assets/probel-sw02/SW-P-02%20issue%2026.doc) | Original Word document |
+| Wireshark dissector | [internal/probel-sw02p/wireshark/dhs_probel_sw02p.lua](../../../internal/probel-sw02p/wireshark/dhs_probel_sw02p.lua) | Byte-exact reference |
+| Protocol reference | [CLAUDE.md](../CLAUDE.md) | Wire format, command catalogue, quirks |
+| Verbs & config | [verbs.md](verbs.md) | Every verb + transport/redundancy/reports/ensure/wireshark/ansible, with real captures |
+| Export fixtures | [internal/probel-sw02p/testdata/](../testdata/) | protocol_types fixtures (per-command) + the demo matrix tree |
+| Source code | [internal/probel-sw02p/consumer/](../../../internal/probel-sw02p/consumer/) | Plugin implementation |
+| Unit tests | [internal/probel-sw02p/](../) | In-package *_test.go (replay + spec) |
+
+---
+
+## Transport
+
+| Mode | Transport | Port | Description |
+|---|---|---|---|
+| TCP direct | TCP | 2002 | Default (and only). `SOM(0xFF) COMMAND MESSAGE CHECKSUM` framing. No DLE stuffing — bytes inside a frame are transparent. No framing-layer ACK/NAK. |
+
+The MESSAGE length is command-dependent (no framing-layer length field):
+the stream decoder uses the `PayloadSize` registry to derive each frame's
+size — fixed-length via `PayloadLen`, variable-length via per-command peek
+helpers (tx 015 / tx 076 / tx 077 / tx 100). The CHECKSUM is the 7-bit
+two's-complement sum of `COMMAND || MESSAGE` with the MSB forced to 0.
+
+### Firewall rules
+
+```
+TCP 2002  outbound    (matrix controller session)
+```
+
+### CLI transport selection
+
+SW-P-02 has a single transport, so there is **no `--transport` flag**. The
+target is `host:port`; port defaults to 2002 when omitted.
+
+```
+dhs consumer probel-sw02p interrogate 127.0.0.1:2002 --dst 5     # default port 2002
+dhs consumer probel-sw02p watch       10.6.239.153:2002 --dsts 64 --srcs 64
+```
+
+---
+
+## Verb catalogue (all wired)
+
+Every SW-P-02 consumer verb dispatches to a `Send*` method on the consumer
+`Plugin` and performs a single round-trip, printing one decoded line on
+stdout (wire hex logged on stderr). Run `dhs consumer probel-sw02p --help`
+for the live catalogue.
+
+| Verb | Cmd(s) | Flags | Notes |
+|---|---|---|---|
+| `interrogate` | rx 01 → tx 03 (`--extended`: rx 65 → tx 67) | `--dst`, `--extended`, `--timeout` | Read the source routed to a destination |
+| `connect` | rx 02 → tx 04 (`--extended`: rx 66 → tx 68) | `--dst`, `--src`, `--extended`, `--bad-source`, `--timeout` | Route a source to a destination |
+| `connect-on-go` | rx 05 → tx 12 | `--dst`, `--src`, `--bad-source`, `--timeout` | Stage one crosspoint into the pending buffer |
+| `go` | rx 06 → tx 04 + tx 13 | `--op set\|clear`, `--timeout` | Commit / discard the pending buffer |
+| `salvo-connect` | rx 35 → tx 37, rx 36 → tx 38 | `--src`, `--dsts`, `--salvo`, `--bad-source`, `--clear` | Stage N crosspoints under a group, fire atomically — **see CLI limitation below** |
+| `protect-interrogate` | rx 101 → tx 96 | `--dst`, `--timeout` | Read a destination's protect state |
+| `protect-connect` | rx 102 → tx 97 | `--dst`, `--device`, `--timeout` | Owner-only write-protect a destination |
+| `protect-disconnect` | rx 104 → tx 98 | `--dst`, `--device`, `--timeout` | Owner-only clear protection |
+| `protect-dump` | rx 105 → tx 100 (fan-out) | `--first-dst`, `--count`, `--collect`, `--timeout` | Stream the protect map |
+| `protect-name` | rx 103 → tx 99 | `--device`, `--timeout` | Resolve a device id → 8-char name |
+| `dual-status` | rx 50 → tx 51 | `--timeout` | Redundant-controller health |
+| `lock-status` | rx 14 → tx 15 | `--controller lh\|rh`, `--timeout` | Read-only source-signal-lock bitmap |
+| `status` | rx 07 → tx 09 | `--controller lh\|rh`, `--timeout` | Controller status — 2 |
+| `router-config` | rx 75 → tx 76/77 | `--timeout` | Level bitmap + per-level dst/src counts |
+| `watch` | rx 01 sweep + subscribe | `--dsts`, `--srcs`, `--timeout`, `--capture` | Bootstrap sweep + live tallies |
+
+**Global flags** (parsed before the subcommand, apply to every verb):
+`--capture FILE.jsonl`, `--mtx-id N` (0-127), `--level L` (0-27),
+`--dsts N`, `--srcs N` (matrix-config bootstrap + keep-alive),
+`--initial-poll`, `--app-keepalive`, `--bootstrap-spacing`.
+
+> **Known CLI limitation — `salvo-connect --dsts` collides with the global
+> `--dsts`.** The global matrix-config parser consumes `--dsts` (accepting
+> only a single uint) **before** subcommand dispatch, so the
+> `salvo-connect` subcommand's own `--dsts` (which accepts a CSV/range like
+> `0-7`) never receives the value: `--dsts 0-2` fails with `strconv.ParseUint
+> parsing "0-2"`, and even `--dsts 1` is swallowed globally so the
+> subcommand then errors `--dsts is required`. The salvo wire path itself
+> is fully implemented and proven by the loopback integration test
+> `TestSalvoConnectOnGoThenGo` (rx 35 ×N → rx 36 → tx 38 + read-back); only
+> the CLI flag plumbing is currently unreachable. The group-salvo wire
+> shape (cmd 35/36/37/38) is captured in that test, not via this CLI verb.
+
+The generic `consumer.Protocol` methods (`Walk`, `GetValue`, `SetValue`,
+`Subscribe`) intentionally do **not** map onto SW-P-02's matrix addressing
+(matrix / level / dst / src does not fit the slot/group/label tree those
+methods assume); use the matrix verbs above instead.
+
+---
+
+## Capabilities & Compliance Status
+
+| Capability | Spec § | Status | Notes |
+|---|---|---|---|
+| TCP direct (port 2002) | §3.1 | ✅ fully compliant | One stream carries requests + spontaneous tallies; no DLE stuffing |
+| SOM/COMMAND/MESSAGE/CHECKSUM framer | §3.1 | ✅ fully compliant | 7-bit two's-complement checksum, MSB forced 0; byte-exact per spec |
+| Crosspoint Interrogate (rx 01) → Tally (tx 03) | §3.2.3 / §3.2.5 | ✅ fully compliant | Narrow Multiplier packs DIV-128 dst/src bits; sentinel src=1023 for out-of-range dst |
+| Crosspoint Connect (rx 02) → Connected (tx 04) | §3.2.4 / §3.2.6 | ✅ fully compliant | Destination-driven (one source per destination per level); broadcast to all sessions |
+| Connect-On-Go / Go (rx 05/06, tx 12/13) | §3.2.7/8/14/15 | ✅ fully compliant | Pending-buffer staged by CONNECT ON GO, committed/cleared by GO |
+| Group salvo (rx 35/36, tx 37/38) | §3.2.36/37/38/39 | ✅ codec/provider; ⚠ CLI | Wire path proven by integration test; CLI verb blocked by `--dsts` flag collision (above) |
+| Status Request / Response-2 (rx 07 / tx 09) | §3.2.9 / §3.2.11 | ✅ fully compliant | `--controller lh\|rh` |
+| Source Lock Status (rx 14 / tx 15, var-len) | §3.2.16 / §3.2.17 | ✅ fully compliant | Read-only; software provider reports all-locked (no input cards). No command writes the lock bit — **N/A by spec** |
+| Dual Controller Status (rx 50 / tx 51) | §3.2.45 / §3.2.46 | ✅ fully compliant | Zero-message request |
+| Extended interrogate/connect/tally (rx 65/66, tx 67/68) | §3.2.47–50 | ✅ fully compliant | Separate 7-bit Multipliers per axis (range 0-16383) |
+| Extended protect tally/connect/disconnect (tx 96/97/98, rx 101/102/104) | §3.2.60–62, §3.2.65/66/68 | ✅ fully compliant | Owner-only authority ladder; reject echoes unchanged state |
+| Extended protect tally dump (rx 105 / tx 100, var-len) | §3.2.64 / §3.2.69 | ✅ fully compliant | Stream-processed; ascending-destination ordering |
+| Protect device name (rx 103 / tx 099) | §3.2.63 / §3.2.67 | ✅ fully compliant | 8-char ASCII; resolved lazily after rx 102 captures OwnerDevice |
+| Router configuration (rx 75 / tx 76 / tx 77, var-len) | §3.2.57–59 | ✅ fully compliant | Level bitmap + per-level dst/src counts derived from the tree |
+| Source / destination label set on the wire | — | ⛔ not applicable | SW-P-02 has no command to rename a source/destination; labels live only in the served tree / controller UI |
+| inc / dec / reset on a crosspoint | — | ⛔ not applicable | A crosspoint is a discrete route, not a numeric parameter with a step |
+| Wire-side discovery | — | ⛔ not applicable | No discovery primitive every controller honours; matrix shape is caller-supplied (`--mtx-id`/`--level`/`--dsts`/`--srcs`) |
+| App-layer retry / reconnect / keepalive | — | ⏳ pending | §3.1 has no framing ACK, so retry is app-layer; reconnect + heartbeat on the client-hardening backlog |
+| Compliance profile | — | ✅ fully compliant | Event catalogue in `internal/probel-sw02p/{consumer,provider}/compliance_events.go` |
+
+Legend: ✅ fully compliant · ⚠ partial · ⛔ not applicable · ⏳ pending (on roadmap).
+
+---
+
+## Timeouts
+
+All timeouts are deterministic, user-overridable. No silent hangs.
+
+| Timer | Default | Where | Override |
+|---|---|---|---|
+| TCP dial | 5 s | `ClientConfig.DialTimeout` | constructor |
+| Per-Send | caller-owned | `ctx` threaded through `Client.Send(ctx, frame, matchFn)` | per-verb `--timeout` (default 5 s) |
+| Online staleness ("alive" bit) | 90 s | `DefaultOnlineStaleAfter` | `IsOnlineWithin(d)` |
+| Keep-alive ping spacing | 2 s | `DefaultAppKeepaliveSpacing` | `MatrixConfig.AppKeepaliveSpacing` (`--app-keepalive`; `0s` disables) |
+| Bootstrap sweep spacing | 10 ms | `DefaultBootstrapSpacing` | `MatrixConfig.BootstrapSpacing` (`--bootstrap-spacing`) |
+| `watch` run duration | until Ctrl-C | `--timeout` | `watch ... --timeout 4s` |
+
+**Single-flight:** `ErrSendInFlight` if two `Send`s overlap on the same
+client. **Keep-alive:** SW-P-02 has no in-protocol keep-alive command, so
+the rotating rx 01 INTERROGATE / tx 03 TALLY round-trip *is* the
+keep-alive — any rx traffic keeps the alive bit set.
+
+---
+
+## Compliance Profile
+
+Every wire tolerance gets a named counter. A session is classified
+**strict** if zero events fire, **partial** if any fire.
+
+### Consumer event catalog
+
+| Event | Meaning |
+|---|---|
+| `probel_sw02p_inbound_frame_decode_failed` | Inbound frame with a bad checksum; the reader drops the byte and resynchronises on the next SOM (0xFF). Frequent desync suggests a bad link. |
+
+### Provider event catalog (for the served-device side)
+
+| Event | Meaning |
+|---|---|
+| `probel_sw02p_inbound_frame_decode_failed` | Bad inbound frame; byte dropped, resync on next SOM |
+| `probel_sw02p_unsupported_command` | Well-framed command with no handler (§3 permits matrices to ignore unknown commands) |
+| `probel_sw02p_handler_decode_failed` | Handler could not decode a well-framed command's MESSAGE |
+| `probel_sw02p_outbound_write_failed` | Reply/broadcast write to a session socket failed |
+| `probel_sw02p_salvo_emitted_connected` | tx 04 CONNECTED emitted per committed salvo slot (sibling to the SW-P-08 salvo deviation) |
+| `probel_sw02p_protect_unauthorized` | rx 102 / rx 104 from a device that does not own the destination — rejected, unchanged state echoed |
+| `probel_sw02p_protect_override_immutable` | rx 102 / rx 104 on a `ProBelOverride` destination — §3.2.60 "cannot be altered remotely" |
+| `probel_sw02p_protect_blocks_connect` | rx 02 / rx 66 CONNECT rejected because the destination is protected |
+| `probel_sw02p_protect_blocks_connect_state_echoed` | tx 04 / tx 68 echoing the existing (unchanged) route so the controller does not oscillate |
+
+---
+
+## Error Reference
+
+### Transport layer (TCP)
+
+| Name | When | Recovery |
+|---|---|---|
+| `TransportError{Op:"connect"}` | TCP dial failed | Check host + firewall + port 2002 |
+| `ErrNotConnected` | Verb issued before `Connect` | Connect first |
+| `ErrSendInFlight` | Two `Send`s overlapped on one client | Serialise sends |
+| `context deadline exceeded` | Per-Send deadline elapsed (`--timeout`) | Raise the timeout or check responsiveness |
+
+### Command layer
+
+| Name | When | Recovery |
+|---|---|---|
+| `ErrWrongCommand` | Decoder asked to parse a frame whose COMMAND byte does not match | Internal — indicates a mis-routed frame |
+| `ErrShortPayload` | MESSAGE shorter than the command's fixed length | Absorbed as `inbound_frame_decode_failed`; resync on next SOM |
+
+A peer NAK for a specific command is a *command-layer* signal, not a
+framing signal: it is routed through a compliance event, never treated as
+fatal.
+
+### CLI exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Success |
+| 1 | Runtime / wire / protocol error |
+| 2 | Validation / usage error (bad flags, out-of-range `--dst`/`--src`) |
+
+---
+
+## Addressing (matrix / level / dst / src)
+
+SW-P-02 is a **matrix** protocol — it does not address by slot / group /
+label. A crosspoint is identified by **(matrix, level, destination)** and
+carries a single **source**:
+
+| Field | Range (narrow §3.2.3) | Range (extended §3.2.47/48) | Wire encoding |
+|---|---|---|---|
+| Matrix | 0-15 | 0-127 | Multiplier high bits / extended byte |
+| Level | 0-15 | 0-27 | Multiplier / extended byte |
+| Destination | 0-1023 | 0-16383 | Multiplier DIV-128 bits + MOD-128 byte |
+| Source | 0-1023 | 0-16383 | Multiplier DIV-128 bits + MOD-128 byte |
+
+Source value **1023** (narrow) is reserved to mean "destination out of
+range" (§3.2.5) — the matrix reports it when the queried destination has
+no declared route. The narrow Multiplier packs 3 bits of DIV-128 for
+Destination + 3 for Source + 1 bad-source bit; the extended form uses
+separate 7-bit Multipliers per axis.
+
+---
+
+## Crosspoint verbs — real captures
+
+All hex below is from `--capture` JSONL against a loopback provider
+serving the committed 8×8 demo matrix
+([`../testdata/exports/matrix_tree.json`](../testdata/exports/matrix_tree.json)).
+See [verbs.md §5](verbs.md) for the annotated walkthrough; the essentials:
+
+```
+# interrogate dst 2 (no route) → src 1023 sentinel
+$ dhs consumer probel-sw02p interrogate 127.0.0.1:12002 --dst 2
+tally  dst=2 → src=1023 bad_source=false
+  tx ff 01 00 02 7d        rx ff 03 07 02 7f 75
+
+# connect dst 2 ← src 5, broadcast tx 04
+$ dhs consumer probel-sw02p connect 127.0.0.1:12002 --dst 2 --src 5
+connected  dst=2 src=5 bad_source=false
+  tx ff 02 00 02 05 77     rx ff 04 00 02 05 75
+
+# read back → route stuck
+$ dhs consumer probel-sw02p interrogate 127.0.0.1:12002 --dst 2
+tally  dst=2 → src=5 bad_source=false
+  tx ff 01 00 02 7d        rx ff 03 00 02 05 76
+```
+
+---
+
+## Status / lock / dual-status / router-config — real captures
+
+```
+$ dhs consumer probel-sw02p status 127.0.0.1:12002
+status  controller=lh idle=false bus_fault=false overheat=false
+  tx ff 07 00 79           rx ff 09 00 77
+
+$ dhs consumer probel-sw02p lock-status 127.0.0.1:12002 --srcs 4
+source-lock (read-only)  controller=lh sources=8 locked=8
+  src=0 locked=true ... src=7 locked=true
+  tx ff 0e 00 72           rx ff 0f 00 04 0f 0f 4f      # var-len bitmap, 8 sources all locked
+
+$ dhs consumer probel-sw02p dual-status 127.0.0.1:12002
+dual-controller  active=MASTER idle_faulty=false
+  tx ff 32 4e              rx ff 33 00 00 4d
+
+$ dhs consumer probel-sw02p router-config 127.0.0.1:12002
+router-config (response-1)  level_map=0x0000001 levels=1
+  level[0]  dsts=8 srcs=8
+  tx ff 4b 35              rx ff 4c 00 00 00 01 00 08 00 08 23
+```
+
+The loopback emulator has no physical input cards, so `lock-status`
+reports **every** declared source as `locked=true` (§3.2.17 all-present
+interpretation). The lock bitmap is **read-only** — there is no rx command
+to set or clear a source lock (it reflects hardware signal carrier
+presence), so this verb has no write counterpart by spec.
+
+---
+
+## Protect verbs — real captures (full lifecycle)
+
+The protect family enforces the owner-only authority ladder documented in
+[../CLAUDE.md](../CLAUDE.md) "Protect + Lock authority model". Real capture
+of the full lifecycle (interrogate → connect → interrogate → dump →
+disconnect) against the loopback emulator:
+
+```
+# 1. start unprotected
+$ dhs consumer probel-sw02p protect-interrogate 127.0.0.1:12002 --dst 4
+protect tally  dst=4 → state=none device=0
+  tx ff 65 00 04 17        rx ff 60 00 00 04 00 00 1c
+
+# 2. protect dst 4 for device 9
+$ dhs consumer probel-sw02p protect-connect 127.0.0.1:12002 --dst 4 --device 9
+protect connected  dst=4 device=9 state=probel
+  tx ff 66 00 04 00 09 0d  rx ff 61 01 00 04 00 09 11      # tx 097, state=probel, owner=9
+
+# 3. interrogate confirms protect + owner stuck
+$ dhs consumer probel-sw02p protect-interrogate 127.0.0.1:12002 --dst 4
+protect tally  dst=4 → state=probel device=9
+  tx ff 65 00 04 17        rx ff 60 01 00 04 00 09 12
+
+# 4. resolve device 9's name (loopback has no name table → 8 spaces)
+$ dhs consumer probel-sw02p protect-name 127.0.0.1:12002 --device 9
+device 9 name=""
+  tx ff 67 00 09 10        rx ff 63 00 09 20 20 20 20 20 20 20 20 14
+
+# 5. dump the protect map (rx 105 → tx 100 fan-out, 32 entries/frame)
+$ dhs consumer probel-sw02p protect-dump 127.0.0.1:12002 --first-dst 0 --count 8 --collect 800ms
+  dst=4 state=probel device=9
+protect tally-dump  first_dst=0 requested=8 entries_seen=1
+  tx ff 69 08 00 00 0f     rx ff 64 01 00 04 09 10 7e
+
+# 6. clear the protect (owning device)
+$ dhs consumer probel-sw02p protect-disconnect 127.0.0.1:12002 --dst 4 --device 9
+protect disconnected  dst=4 device=0 state=none
+  tx ff 68 00 04 00 09 0b  rx ff 62 00 00 04 00 00 1a
+```
+
+A non-owner `protect-connect` / `protect-disconnect`, or any change to a
+`ProBelOverride` destination, is **rejected**: the provider still emits the
+tx 097 / tx 098 broadcast but echoes the **unchanged** state and fires
+`probel_sw02p_protect_unauthorized` / `probel_sw02p_protect_override_immutable`
+(see [../CLAUDE.md](../CLAUDE.md) authority ladder). Likewise an rx 02 / rx
+66 CONNECT to a protected destination is dropped (or state-echoed if a
+prior route exists) — `probel_sw02p_protect_blocks_connect`.
+
+---
+
+## Subscriptions (Tallies) & raw capture
+
+- Transport: the same TCP session (no separate broadcast channel).
+- `watch` subscribes to every spontaneous frame; tx 03 TALLY and tx 04
+  CONNECTED arrive as the matrix or another controller changes routes.
+- The bootstrap rx 01 sweep (when `--dsts` is set) primes the session so
+  the matrix tallies back the current source for each destination.
+- `--capture <path>.jsonl` records every wire frame as
+  `{ts,proto,dir,hex,len}` for replay / analysis / debugging.
+
+```
+$ dhs consumer probel-sw02p watch 127.0.0.1:12002 --dsts 4 --srcs 4 --timeout 4s --capture watch.jsonl
+event  cmd=0x03 payload_len=3      # ×5 (4-dst sweep + 1 keep-alive ping)
+```
+
+```json
+{"ts":"2026-06-18T09:15:31.872Z","proto":"probel-sw02p","dir":"tx","hex":"ff0100007f","len":5}
+{"ts":"2026-06-18T09:15:31.877Z","proto":"probel-sw02p","dir":"rx","hex":"ff0307007f77","len":6}
+```
+
+Decoding `ff0100007f` (tx): `SOM=ff cmd=01(INTERROGATE) MESSAGE=00 00
+checksum=7f` → Multiplier=0, Destination=0. Reply `ff0307007f77` (rx):
+`SOM=ff cmd=03(TALLY) MESSAGE=07 00 7f checksum=77` → Multiplier=0x07
+(Source DIV-128 = 7), Destination=0, Source MOD-128 = 0x7f → **Source =
+7×128 + 127 = 1023** = "destination out of range" (§3.2.5).
+
+---
+
+## Test Device
+
+| Device | IP | Protocol | Notes |
+|---|---|---|---|
+| Loopback producer | 127.0.0.1:2002 | SW-P-02/TCP | `dhs producer probel-sw02p serve --tree ...` — the matrix emulator (used for every capture in this doc) |
+| Commie.exe | testbed | SW-P-02/TCP | Matrix receiver; load `commie_SWP02.dat` (switch the .dat in its UI) |
+| Lawo VSM SW-P-02 driver | testbed | SW-P-02/TCP | Real controller; pending live validation (same shape as the SW-P-08 testbed flow) |

--- a/internal/probel-sw02p/docs/provider.md
+++ b/internal/probel-sw02p/docs/provider.md
@@ -1,0 +1,18 @@
+# Probel SW-P-02 Provider
+
+> **Status: shipping**
+>
+> Serves a canonical tree.json as an SW-P-02 matrix controller (tx side)
+> over TCP (default port 2002, per [../CLAUDE.md](../CLAUDE.md) "Transport").
+> Symmetric to the consumer plugin at
+> [internal/probel-sw02p/consumer/](../../../internal/probel-sw02p/consumer/);
+> reuses the same byte codec (`internal/probel-sw02p/codec/`) for the
+> SOM/COMMAND/MESSAGE/CHECKSUM framer and every per-command codec.
+>
+> One listener accepts many client sessions; each session reads framed
+> commands and the dispatcher answers interrogate / connect / status /
+> protect / salvo / router-config requests, fanning out tx 04 CONNECTED
+> and tx 03 TALLY to every connected session per §3.
+>
+> CLI: `dhs producer probel-sw02p serve --tree <path> --host 0.0.0.0 --port 2002`.
+> See [runbook.md](runbook.md) for the operator workflow.

--- a/internal/probel-sw02p/docs/runbook.md
+++ b/internal/probel-sw02p/docs/runbook.md
@@ -1,0 +1,173 @@
+# Probel SW-P-02 — operational runbook
+
+Quick-reference card for operators. For wire-format detail see
+[CLAUDE.md](../CLAUDE.md); for in-depth consumer behaviour see
+[consumer.md](consumer.md); for the full verb + sample reference see
+[verbs.md](verbs.md).
+
+---
+
+## Transport matrix
+
+| Mode | Port | Notes |
+|---|---:|---|
+| TCP direct | 2002 | `SOM(0xFF) COMMAND MESSAGE CHECKSUM`. No DLE stuffing — bytes inside a frame are transparent. One TCP stream carries requests + spontaneous tallies. |
+
+SW-P-02 was originally an RS-485/422 serial protocol; this plugin runs it
+over a single TCP socket. There is no UDP transport and no framing-layer
+ACK/NAK (unlike SW-P-08): any peer confirmation arrives as a regular
+application command (tx 03 TALLY, tx 04 CONNECTED, ...). Default port 2002
+mirrors SW-P-08's 2008 at the project level.
+
+## Verb reference
+
+### Consumer
+
+| Verb | What it does | Common flags |
+|---|---|---|
+| `dhs consumer probel-sw02p interrogate <host:port>` | Read the source routed to a destination | `--dst N`, `--extended`, `--timeout` |
+| `dhs consumer probel-sw02p connect <host:port>` | Route a source to a destination (broadcasts tx 04) | `--dst N --src M`, `--extended`, `--bad-source`, `--timeout` |
+| `dhs consumer probel-sw02p connect-on-go <host:port>` | Stage one crosspoint into the pending buffer | `--dst N --src M`, `--bad-source` |
+| `dhs consumer probel-sw02p go <host:port>` | Commit / discard the pending buffer | `--op set\|clear` |
+| `dhs consumer probel-sw02p salvo-connect <host:port>` | Stage N crosspoints under a group, fire atomically | `--src M --dsts CSV --salvo ID` — ⚠ see "Known issues" |
+| `dhs consumer probel-sw02p protect-interrogate <host:port>` | Read a destination's protect state | `--dst N` |
+| `dhs consumer probel-sw02p protect-connect <host:port>` | Owner-only write-protect a destination | `--dst N --device D` |
+| `dhs consumer probel-sw02p protect-disconnect <host:port>` | Owner-only clear protection | `--dst N --device D` |
+| `dhs consumer probel-sw02p protect-dump <host:port>` | Stream the protect map | `--first-dst N --count K --collect 1s` |
+| `dhs consumer probel-sw02p protect-name <host:port>` | Resolve a device id → 8-char name | `--device D` |
+| `dhs consumer probel-sw02p dual-status <host:port>` | Redundant-controller health | `--timeout` |
+| `dhs consumer probel-sw02p lock-status <host:port>` | Read-only source-signal-lock bitmap | `--controller lh\|rh` |
+| `dhs consumer probel-sw02p status <host:port>` | Controller status — 2 | `--controller lh\|rh` |
+| `dhs consumer probel-sw02p router-config <host:port>` | Level bitmap + per-level dst/src counts | `--timeout` |
+| `dhs consumer probel-sw02p watch <host:port>` | rx 01 bootstrap sweep + subscribe to async tallies | `--dsts N --srcs N`, `--timeout`, `--capture FILE.jsonl` |
+
+**Global flags** (parsed before the subcommand): `--capture FILE.jsonl`,
+`--mtx-id N` (0-127), `--level L` (0-27), `--dsts N`, `--srcs N`,
+`--initial-poll`, `--app-keepalive`, `--bootstrap-spacing`.
+
+SW-P-02 has no wire-side discovery primitive every controller honours —
+VSM and Commie both configure matrix size + id + level in their UI per
+matrix. The consumer follows that pattern: matrix shape is supplied via
+the global `--mtx-id` / `--level` / `--dsts` / `--srcs` flags, not probed.
+`router-config` (rx 75) is the one in-protocol "info" call and is wired,
+but most controllers configure size externally rather than probe it.
+
+### Provider
+
+| Verb | What it does | Required flags |
+|---|---|---|
+| `dhs producer probel-sw02p serve --tree fixture.json --port 2002 --bind <ip>` | Serve a canonical matrix as an SW-P-02 device over TCP | `--tree` (or `--manifest`), `--port`, optional `--bind` (VIP) |
+
+The provider binds a single TCP listener on `--port` (default 2002).
+Multi-client is inherent: each TCP connection is an independent session,
+and broadcast frames (tx 04 CONNECTED, tx 03 TALLY on connect, GO-done
+acks) fan out to every connected session per §3.
+
+`--metrics-addr :9100` mounts Prometheus `/metrics` + `/snapshot.json`;
+`--log-format json` emits Loki/Promtail-friendly logs.
+
+## Provider — protect & lock authority (owner-only)
+
+SW-P-02 models **source lock** (HD-router input signal health,
+§3.2.16/17) and **protect** (destination write-protection, §3.2.60+) as
+two orthogonal fields. A crosspoint can be both locked AND protected.
+
+| Layer | Where it lives | Behaviour |
+|---|---|---|
+| **Source lock** | per-source bit (§3.2.17) | read-only — reflects signal carrier presence. Software provider reports all-locked (no physical input cards). |
+| **Protect** | per-destination 2-bit state + OwnerDevice (§3.2.60/66) | only the owning device may modify/clear; `ProBelOverride` cannot be altered remotely at all. |
+
+Reject paths still emit tx 097 / tx 098 echoing the *unchanged* state, and
+fire a named compliance event (`probel_sw02p_protect_unauthorized` /
+`probel_sw02p_protect_override_immutable`). An rx 02 / rx 66 CONNECT to a
+protected destination is dropped (or state-echoed if a prior route exists)
+— `probel_sw02p_protect_blocks_connect`. See [../CLAUDE.md](../CLAUDE.md)
+"Protect + Lock authority model" for the full authority ladder.
+
+## Matrix-config contract
+
+SW-P-02 has no per-IP DM cache (unlike ACP1). Matrix shape is **caller-
+supplied**, not discovered:
+
+```
+--mtx-id N    matrix ID (default 0; range 0-127)
+--level L     level    (default 0; range 0-27)
+--dsts N      destination count on this (matrix, level)
+--srcs N      source count on this (matrix, level)
+```
+
+- The provider derives matrix shape from the served canonical tree
+  (`targetCount` / `sourceCount` per matrix/level).
+- The consumer takes the shape from the global flags; `--dsts` non-zero
+  drives the bootstrap rx 01 sweep + rotating keep-alive ping (SW-P-02 has
+  no keep-alive command, so the rx 01 / tx 03 round-trip IS the
+  keep-alive).
+- rx 75 ROUTER CONFIGURATION REQUEST is supported as an explicit command
+  but most controllers configure size externally rather than probe it.
+
+## Common flows
+
+### Bring up a loopback matrix and drive a crosspoint
+
+```
+# producer: serve the committed 8x8 demo matrix on TCP :2002
+dhs producer probel-sw02p serve --tree internal/probel-sw02p/testdata/exports/matrix_tree.json --port 2002
+
+# consumer: route src 5 → dst 2, then read it back
+dhs consumer probel-sw02p connect     127.0.0.1:2002 --dst 2 --src 5
+dhs consumer probel-sw02p interrogate 127.0.0.1:2002 --dst 2      # → src=5
+```
+
+### Watch the matrix + capture the wire
+
+```
+dhs consumer probel-sw02p watch 127.0.0.1:2002 --dsts 4 --srcs 4 \
+    --capture sw02-watch.jsonl --timeout 4s
+```
+
+### Protect a destination then release it
+
+```
+dhs consumer probel-sw02p protect-connect    127.0.0.1:2002 --dst 4 --device 9
+dhs consumer probel-sw02p protect-interrogate 127.0.0.1:2002 --dst 4      # → state=probel device=9
+dhs consumer probel-sw02p protect-disconnect  127.0.0.1:2002 --dst 4 --device 9
+```
+
+### Bring up an emulator alongside production traffic
+
+```
+dhs producer probel-sw02p serve --tree matrix-fixture.json --port 2002 --bind 10.6.239.200
+```
+
+`--bind <vip>` binds the listener to a specific NIC so multi-instance
+emulators on the same host appear as distinct addresses.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `interrogate` reports source 1023 for every dst | destination has no route in the served tree (1023 = "destination out of range" sentinel, §3.2.5) | connect a crosspoint, or check the tree's `targetCount`/`sourceCount` |
+| `watch` shows no events | `--dsts` not set, so no bootstrap rx 01 sweep fires | pass `--dsts N` (and `--srcs N`) to drive the sweep |
+| `salvo-connect` errors `--dsts: strconv.ParseUint` or `--dsts is required` | the global matrix-config `--dsts` swallows the subcommand's range `--dsts` | known CLI limitation (see [consumer.md](consumer.md) "Known CLI limitation"); use the loopback integration test for the salvo path until fixed |
+| `session desync: dropping byte` in provider logs | a non-`0xFF` byte arrived where a SOM was expected | check the controller is speaking SW-P-02 (not SW-P-08 with DLE framing) on this port |
+| remote CONNECT silently dropped | destination is protected by another device, or `ProBelOverride` | only the owning device may change it; inspect the `probel_sw02p_protect_*` compliance counters |
+| `--mtx-id: 200 exceeds 127` | matrix id out of the wire range | use 0-127 (narrow addressing tops out lower) |
+
+## Known issues
+
+- **`salvo-connect --dsts` is unreachable from the CLI.** The global
+  matrix-config flag parser consumes `--dsts` (single uint only) before
+  subcommand dispatch, colliding with the salvo verb's own CSV/range
+  `--dsts`. The salvo wire path (rx 35/36 → tx 37/38) is fully implemented
+  and proven by the loopback integration test `TestSalvoConnectOnGoThenGo`;
+  only the CLI flag plumbing needs a fix (rename one of the flags or
+  exempt `salvo-connect` from the global `--dsts` capture).
+
+## Pointers
+
+- Wire format: [CLAUDE.md](../CLAUDE.md)
+- Verbs & samples: [verbs.md](verbs.md)
+- Deep-dive consumer doc: [consumer.md](consumer.md)
+- Provider doc: [provider.md](provider.md)
+- Wireshark dissector: [../wireshark/dhs_probel_sw02p.lua](../wireshark/dhs_probel_sw02p.lua)
+- Spec: [../assets/probel-sw02/SW-P-02_issue_26.txt](../assets/probel-sw02/SW-P-02_issue_26.txt)

--- a/internal/probel-sw02p/docs/verbs.md
+++ b/internal/probel-sw02p/docs/verbs.md
@@ -1,0 +1,438 @@
+# Probel SW-P-02 — verbs & configuration reference
+
+Per-connector verb reference. Same section order for every connector so
+the docs don't drift. All command samples below are **real captures**
+against a loopback `dhs producer probel-sw02p serve` instance built from
+the committed demo matrix fixture
+([`../testdata/exports/matrix_tree.json`](../testdata/exports/matrix_tree.json),
+a single `oneToN` matrix, 8×8) — not hand-written. Each verb's hex is the
+exact `--capture <verb>.jsonl` frame log produced by the run shown, and
+matches the `probel-sw02p TX/RX … hex=…` lines the CLI logs on stderr.
+
+Wire format lives in [`../CLAUDE.md`](../CLAUDE.md); this file is the
+operator how-to. SW-P-02 is a **matrix-router** protocol — addressing is
+by **matrix / level / destination / source**, not slot / group / label,
+so the get/set/inc/dec/reset shape of a Tree/DM connector does not apply
+(see §5). Consumer verbs: `interrogate connect connect-on-go go
+salvo-connect protect-connect protect-disconnect protect-interrogate
+protect-dump protect-name dual-status lock-status status router-config
+watch`.
+
+---
+
+## 1. Transport configs
+
+SW-P-02 speaks a **single** transport (see [`../CLAUDE.md`](../CLAUDE.md)
+"Transport — SW-P-02 §3.1"):
+
+| Transport | Flag | Port | Notes |
+|---|---|---|---|
+| TCP direct | (default; only option) | 2002 | `SOM(0xFF) COMMAND MESSAGE CHECKSUM`. No DLE stuffing — bytes inside a frame are transparent. No framing-layer ACK/NAK. |
+
+There is **no `--transport` flag** (only one transport exists) and **no
+UDP**. The target is `host:port`; port defaults to 2002 when omitted.
+
+```
+dhs consumer probel-sw02p interrogate 127.0.0.1:2002 --dst 5
+dhs producer probel-sw02p serve --tree matrix.json --port 2002
+```
+
+## 2. Controllers & redundancy
+
+**Default = one connection** to one matrix controller. SW-P-02 carries no
+client identity on the wire, so redundancy is both an **app/deployment**
+concern *and* an in-protocol exchange:
+
+- **Single controller (default):** one consumer ↔ one matrix.
+- **Redundant controllers:** SW-P-02 defines DUAL CONTROLLER STATUS
+  REQUEST / RESPONSE (rx 50 / tx 51, §3.2.45/46) so a controller can poll
+  which of a redundant pair is active (`dhs consumer probel-sw02p
+  dual-status`). At the deployment layer, run one provider per controller
+  NIC (`--bind <nic-ip>`) and one consumer connection per controller.
+
+```
+# two provider instances, one per controller NIC
+dhs producer probel-sw02p serve --tree matrix.json --bind 10.100.0.103 --port 2002
+dhs producer probel-sw02p serve --tree matrix.json --bind 10.100.0.109 --port 2002
+```
+
+## 3. Logging & severity
+
+Severity is set per invocation; **logs go to stderr, data to stdout** (so
+`2>` captures logs, `1>` captures the result). The consumer logs every
+frame as `probel-sw02p TX/RX cmd=… wire_len=… hex=…`.
+
+| Side | Flag | Values |
+|---|---|---|
+| consumer | `--log-level` | `trace \| debug \| info \| warn \| error \| critical` (default `info`) |
+| consumer | `--verbose` | shortcut for `--log-level debug` |
+| producer | `--log-level` | `debug \| info \| warn \| error` (default `info`) |
+| producer | `--log-format` | `text` (default) \| `json` (Loki/Promtail) |
+
+Real producer log lines (`--log-format json --log-level debug`):
+
+```json
+{"time":"2026-06-18T11:14:00.939+02:00","level":"INFO","msg":"probel-sw02p provider listening","addr":"[::]:12002","matrices":1}
+{"time":"2026-06-18T11:14:05.102+02:00","level":"INFO","msg":"probel-sw02p session opened","remote":"127.0.0.1:62607"}
+{"time":"2026-06-18T11:14:24.462+02:00","level":"DEBUG","msg":"probel-sw02p session rx","remote":"127.0.0.1:62615","cmd":1,"payload_len":2,"wire_len":5,"hex":"ff 01 00 02 7d"}
+```
+
+Real consumer log lines (text format, default) — data on stdout, logs on stderr:
+
+```
+$ dhs consumer probel-sw02p interrogate 127.0.0.1:12002 --dst 2 2>run.log 1>tally.out
+# stderr (run.log):
+time=2026-06-18T11:14:24.454+02:00 level=INFO msg="probel-sw02p connected" host=127.0.0.1 port=12002
+time=2026-06-18T11:14:24.454+02:00 level=INFO msg="probel-sw02p TX" cmd=1 payload_len=2 wire_len=5 hex="ff 01 00 02 7d"
+time=2026-06-18T11:14:24.464+02:00 level=INFO msg="probel-sw02p RX" cmd=3 payload_len=3 wire_len=6 hex="ff 03 07 02 7f 75"
+# stdout (tally.out):
+tally  dst=2 → src=1023 bad_source=false
+```
+
+## 4. info / walk
+
+SW-P-02 has **no wire-side discovery primitive every controller honours** —
+VSM and Commie both configure matrix size + id + level in their UI per
+matrix. The consumer therefore takes the matrix shape from flags rather
+than probing it. The two closest analogues to "info/walk" are:
+
+- **`router-config`** (rx 75 → tx 76/77 ROUTER CONFIGURATION) — the one
+  in-protocol "info" call: returns the level bitmap + per-level dst/src
+  counts. Most controllers ignore it and configure size externally, but
+  our provider answers it from the served tree.
+- **the rx 01 bootstrap sweep** (`watch --dsts N`, §8) — interrogates
+  dst 0..N-1 so the matrix tallies back the current source for each
+  destination, the closest equivalent to "walk one level".
+
+`router-config` — real capture (loopback, 8×8 demo matrix):
+
+```
+$ dhs consumer probel-sw02p router-config 127.0.0.1:12002
+router-config (response-1)  level_map=0x0000001 levels=1
+  level[0]  dsts=8 srcs=8
+```
+
+```
+tx:  ff 4b 35                          # SOM cmd=75 (no MESSAGE)            cksum=35
+rx:  ff 4c 00 00 00 01 00 08 00 08 23  # SOM cmd=76 level_map=0x0000001 lvl0: dsts=8 srcs=8  cksum=23
+```
+
+The provider exposes the same matrix shape on the served-device side via
+`--metrics-addr :9100` → `/snapshot.json` (real scrape after four rx 01
+INTERROGATE frames):
+
+```json
+{"connector":{"RxFrames":4,"TxFrames":4,"RxBytes":20,"TxBytes":24,
+ "RxHitsByCmd":[0,4,0,...],"TxHitsByCmd":[0,0,0,4,0,...]}}
+```
+
+`RxHitsByCmd[1] = 4` confirms the matrix received four rx 01 INTERROGATE
+frames; `TxHitsByCmd[3] = 4` confirms four tx 03 TALLY replies.
+
+## 5. interrogate / connect / connect-on-go / go (matrix get/set)
+
+SW-P-02 addresses a crosspoint by **(matrix, level, destination)** and
+carries one **source** — this is the matrix equivalent of get/set. There
+is **no inc/dec/reset** (a crosspoint is a discrete route, not a numeric
+parameter with a step), and **no source/dest label set command** — SW-P-02
+has no command to rename a source or destination on the wire (labels live
+only in the served canonical tree / controller UI). The provider mirrors
+the matrix-verb handling of the Ember+ `matrix` verb rather than ACP1's
+get/set/inc/dec/reset.
+
+| Verb | Cmd byte(s) | Dir | What it does |
+|---|---:|:---:|---|
+| **interrogate** | rx 01 → tx 03 | request → tally | Read the source currently routed to a destination (`--extended` → rx 65 → tx 67) |
+| **connect** | rx 02 → tx 04 | request → connected | Route a source to a destination, broadcast to all sessions (`--extended` → rx 66 → tx 68) |
+| **connect-on-go** | rx 05 → tx 12 | request → ack | Stage one crosspoint into the pending salvo buffer |
+| **go** | rx 06 → tx 04 + tx 13 | request → connected + done-ack | Commit (`--op set`) or discard (`--op clear`) the pending buffer |
+
+### interrogate (real capture)
+
+`interrogate` on dst 2 of the demo matrix (no route declared yet):
+
+```
+$ dhs consumer probel-sw02p interrogate 127.0.0.1:12002 --dst 2
+tally  dst=2 → src=1023 bad_source=false
+```
+
+```
+tx:  ff 01 00 02 7d        # SOM cmd=01 MESSAGE=00 02       cksum=7d
+rx:  ff 03 07 02 7f 75     # SOM cmd=03 MESSAGE=07 02 7f    cksum=75
+                           #   Multiplier 0x07 → Source DIV-128 = 7
+                           #   Destination = 2, Source MOD-128 = 0x7f
+                           #   → Source = 7*128 + 127 = 1023 (dst out of range, §3.2.5)
+```
+
+Source value **1023** is the §3.2.5 "destination out of range" sentinel —
+the demo fixture ships with no routes, so every interrogate returns it
+until a connect lands (see below).
+
+`interrogate --extended` (rx 65 → tx 67, separate 7-bit Multipliers per
+axis), real capture:
+
+```
+$ dhs consumer probel-sw02p interrogate 127.0.0.1:12002 --dst 2 --extended
+extended tally  dst=2 → src=1023 bad_source=false update_off=false
+tx:  ff 41 00 02 3d                 # SOM cmd=65 dst=2          cksum=3d
+rx:  ff 43 00 02 07 7f 00 35        # SOM cmd=67 dst=2 srcMul=07 srcMod=7f (=1023)  cksum=35
+```
+
+### connect (real capture)
+
+`connect` dst 2 ← src 5, then read it back:
+
+```
+$ dhs consumer probel-sw02p connect 127.0.0.1:12002 --dst 2 --src 5
+connected  dst=2 src=5 bad_source=false
+$ dhs consumer probel-sw02p interrogate 127.0.0.1:12002 --dst 2
+tally  dst=2 → src=5 bad_source=false        # route stuck
+```
+
+```
+# connect tx/rx:
+tx:  ff 02 00 02 05 77     # SOM cmd=02 Multiplier=00 Dest=02 Src=05   cksum=77
+rx:  ff 04 00 02 05 75     # SOM cmd=04 CROSSPOINT CONNECTED dst=2 src=5  cksum=75
+# read-back tx/rx:
+tx:  ff 01 00 02 7d        # interrogate dst 2
+rx:  ff 03 00 02 05 76     # tally dst=2 → src=5  (Multiplier 0 ⇒ DIV-128=0, src=5)
+```
+
+Checksum check for the connect frame: 7-bit two's-complement of
+`COMMAND||MESSAGE` = `-(0x02+0x00+0x02+0x05) & 0x7F` = `-9 & 0x7F` =
+`0x77`. ✔
+
+`connect --extended` (rx 66 → tx 68) and `connect --bad-source` (sets the
+narrow Multiplier bad-source bit, rx 02 only) are also available; the
+extended capture:
+
+```
+$ dhs consumer probel-sw02p connect 127.0.0.1:12002 --dst 2 --src 5 --extended
+extended connected  dst=2 src=5 bad_source=false update_off=false
+tx:  ff 42 00 02 00 05 37        # SOM cmd=66 dst=2 src=5      cksum=37
+rx:  ff 44 00 02 00 05 00 35     # SOM cmd=68 EXTENDED CONNECTED dst=2 src=5  cksum=35
+```
+
+### connect-on-go / go (staged commit, real capture)
+
+`connect-on-go` stages a crosspoint into the pending buffer; `go --op set`
+commits it (broadcasting tx 04 CONNECTED) and acks with tx 13:
+
+```
+$ dhs consumer probel-sw02p connect-on-go 127.0.0.1:12002 --dst 3 --src 6
+connect-on-go staged  dst=3 src=6 (call `go --op set` to commit)
+$ dhs consumer probel-sw02p go 127.0.0.1:12002 --op set
+go done  op=set result=set
+```
+
+```
+# connect-on-go tx/rx:
+tx:  ff 05 00 03 06 72     # SOM cmd=05 CONNECT ON GO dst=3 src=6   cksum=72
+rx:  ff 0c 00 03 06 6b     # SOM cmd=12 CONNECT ON GO ACK dst=3 src=6  cksum=6b
+# go tx/rx (two rx frames: the committed tx 04 then the tx 13 done-ack):
+tx:  ff 06 00 7a           # SOM cmd=06 GO op=set                 cksum=7a
+rx:  ff 04 00 03 06 73     # SOM cmd=04 CROSSPOINT CONNECTED dst=3 src=6 (commit)
+rx:  ff 0d 00 73           # SOM cmd=13 GO DONE ACK                cksum=73
+```
+
+`go --op clear` discards the pending buffer instead of committing it.
+
+## 6. export / import
+
+`export` dumps a walked matrix to **json / yaml / csv**; `import` applies a
+snapshot back. SW-P-02 export/import rides the same canonical exporter the
+rest of `dhs` uses (Device → Matrix → level → crosspoints), keyed by
+(matrix, level, destination). The served fixture **is** the canonical JSON
+shape — this is the exact tree used to drive every capture in this doc
+([`../testdata/exports/matrix_tree.json`](../testdata/exports/matrix_tree.json)):
+
+```json
+{
+  "root": {
+    "identifier": "router", "oid": "1",
+    "children": [
+      { "identifier": "matrix-0", "oid": "1.1",
+        "type": "oneToN", "mode": "linear",
+        "targetCount": 8, "sourceCount": 8,
+        "labels": [ { "basePath": "router.matrix-0.video" } ] }
+    ]
+  }
+}
+```
+
+`dhs producer probel-sw02p serve --tree <file>` imports a hand-authored
+canonical JSON like the one above; `--manifest <file>` is the
+manifest-assembled import path (per ADR-0022). A dedicated `export`
+consumer subcommand is not yet wired for SW-P-02 (the matrix shape is
+caller-supplied, §4, not walked); the served tree is the canonical export
+source the rest of the toolchain consumes.
+
+## 7. reports — tree ASCII & PlantUML mindmap
+
+The matrix structure rendered from the demo fixture served in every
+capture above (a single matrix, single level, 8×8):
+
+```
+router  (Probel SW-P-02 demo matrix)
++-- matrix-0   oneToN  linear  8x8
+    +-- level 0
+        +-- destinations  0 .. 7   (targetCount=8)
+        +-- sources       0 .. 7   (sourceCount=8)
+        +-- crosspoints   (matrix, level, dst) -> src
+            +-- dst 2 -> src 5     (after the §5 connect)
+            +-- dst 3 -> src 6     (after the §5 connect-on-go + go)
+```
+
+PlantUML mindmap of the same matrix:
+
+```
+@startmindmap
+* router
+** matrix-0 (oneToN / linear / 8x8)
+*** level 0
+**** destinations: 0..7
+**** sources: 0..7
+@endmindmap
+```
+
+A dedicated `tree`/`report` consumer subcommand is not yet wired for
+SW-P-02; the structure above is rendered from the served canonical
+fixture, which is the same source a report verb would consume.
+
+## 8. play / watch
+
+`watch` opens the TCP session, fires the rx 01 INTERROGATE bootstrap sweep
+(when `--dsts` is set), and prints every spontaneous tally (tx 03 TALLY /
+tx 04 CONNECTED) until Ctrl-C or `--timeout`; `--capture <path>.jsonl`
+logs the raw wire frames. **SW-P-02 has no in-protocol keep-alive
+command**, so the rotating rx 01 INTERROGATE / tx 03 TALLY round-trip *is*
+the keep-alive — the provider answers each sweep frame, keeping the
+consumer's "alive" bit set. There is no producer-side `--play` value
+oscillator (a crosspoint matrix has no drifting analogue values to
+oscillate, unlike ACP1 — N/A by protocol nature).
+
+```
+# producer side: serve a matrix
+dhs producer probel-sw02p serve --tree matrix.json --port 2002
+
+# consumer side: bootstrap sweep + live tallies (+ optional raw-frame capture)
+dhs consumer probel-sw02p watch 127.0.0.1:2002 --dsts 4 --srcs 4 --capture run.jsonl
+```
+
+Real capture (stdout, loopback, 4-dst sweep over a matrix where dst 2 and
+dst 3 were previously routed — five tally events: the 4-dst bootstrap
+sweep plus one keep-alive ping during the run window):
+
+```
+$ dhs consumer probel-sw02p watch 127.0.0.1:12002 --dsts 4 --srcs 4 --timeout 4s
+event  cmd=0x03 payload_len=3
+event  cmd=0x03 payload_len=3
+event  cmd=0x03 payload_len=3
+event  cmd=0x03 payload_len=3
+event  cmd=0x03 payload_len=3
+```
+
+The `--capture` JSONL is the per-frame walk record (real, first 8 frames —
+note dst 2 tallies src 5 and dst 3 tallies src 6 from the §5 routes):
+
+```json
+{"proto":"probel-sw02p","dir":"tx","hex":"ff0100007f","len":5}
+{"proto":"probel-sw02p","dir":"rx","hex":"ff0307007f77","len":6}
+{"proto":"probel-sw02p","dir":"tx","hex":"ff0100017e","len":5}
+{"proto":"probel-sw02p","dir":"rx","hex":"ff0307017f76","len":6}
+{"proto":"probel-sw02p","dir":"tx","hex":"ff0100027d","len":5}
+{"proto":"probel-sw02p","dir":"rx","hex":"ff0300020576","len":6}
+{"proto":"probel-sw02p","dir":"tx","hex":"ff0100037c","len":5}
+{"proto":"probel-sw02p","dir":"rx","hex":"ff0300030674","len":6}
+```
+
+Real session-metrics summary logged on Disconnect (stderr):
+
+```
+level=INFO msg="probel-sw02p session metrics" summary="uptime=4.001s cpu=0.00% mem=0B rx=5/30B tx=5/25B errs=decode:0 nak:0 to:0 retry:0 rec:0 lat_us p50~0 p95~0 p99~0"
+```
+
+## 9. ensure() — idempotent converge (ADR-0007)
+
+`ensure` converges a crosspoint to a target source and reports whether it
+changed; running it twice ⇒ the second run is a no-op. For SW-P-02 the
+converged state is a route: `(matrix, level, dst) -> src`. The matrix is
+**naturally idempotent** — re-issuing the same rx 02 CONNECT for a route
+already in place changes nothing, and the provider re-broadcasts the
+existing tx 04 CONNECTED state. The §5 read-back proves this directly:
+after `connect --dst 2 --src 5`, an immediate `interrogate --dst 2`
+returns `src=5`; a second identical `connect` produces the same tx 04
+`ff 04 00 02 05 75` with no state change.
+
+```
+# intent: dst 2 on (matrix 0, level 0) is routed from src 5
+#   first apply  -> changed=true   (route established, tx 04 CONNECTED dst=2 src=5)
+#   second apply -> changed=false  (already routed; identical tx 04 re-broadcast)
+```
+
+A dedicated `ensure` consumer subcommand is not yet wired for SW-P-02; the
+underlying converge semantic is the `connect` path's idempotency above.
+
+## 10. Wireshark
+
+Dissector:
+[`../wireshark/dhs_probel_sw02p.lua`](../wireshark/dhs_probel_sw02p.lua) —
+decodes the `SOM / COMMAND / MESSAGE / CHECKSUM` framing and every command
+byte, with a per-frame Info column showing matrix/level/dst/src.
+
+| OS | Plugin dir |
+|---|---|
+| Windows | `%APPDATA%\Wireshark\plugins\` |
+| macOS / Linux | `~/.local/lib/wireshark/plugins/` |
+
+```
+# copy the dissector, then filter on the dhs proto:
+#   display filter:  dhs_probel_sw02p
+#   port decode:     tcp.port == 2002
+tshark -r capture.pcapng -O dhs_probel_sw02p -Y dhs_probel_sw02p
+```
+
+## 11. Ansible (the exclusive integration / deploy driver — no .ps1)
+
+Inventory ([`../../../ansible/inventory/hosts.ini`](../../../ansible/inventory/hosts.ini))
+and playbooks
+([`../../../ansible/playbooks/probel-sw02p-integration.yml`](../../../ansible/playbooks/probel-sw02p-integration.yml)).
+SW-P-02 has **no separate vendor emulator in-tree** — our own provider IS
+the matrix emulator — so the integration play has two tiers: a loopback
+tier (`go test -tags integration`, provider + consumer round-trip
+in-process, always runs) and an external tier gated on
+`PROBEL_SW02P_TEST_HOST` (the same Go body pointed at a live SW-P-02 matrix
+on the lab network).
+
+```ini
+# inventory/hosts.ini
+[producer]
+dhs-ubuntu ansible_host=10.100.0.103 ansible_user=root
+```
+
+```yaml
+# loopback (always) + optional live matrix (playbooks/probel-sw02p-integration.yml)
+#   ansible-playbook -i inventory/hosts.ini playbooks/probel-sw02p-integration.yml
+#   PROBEL_SW02P_TEST_HOST=10.100.0.42 ansible-playbook -i ... playbooks/probel-sw02p-integration.yml
+- hosts: localhost
+  connection: local
+  tasks:
+    - command:
+        chdir: "{{ repo_root }}"
+        argv: [go, test, -tags, integration, "./internal/probel-sw02p/integration/", -count=1]
+      register: sw02p_loopback
+      changed_when: false
+    - assert: { that: ["'ok' in sw02p_loopback.stdout or 'PASS' in sw02p_loopback.stdout"] }
+    - debug: { msg: "{{ sw02p_loopback.stdout_lines + sw02p_loopback.stderr_lines }}" }  # surface logs
+```
+
+dhs / go-test logs go to **stderr** → `register` the task and `debug` the
+combined `stdout_lines + stderr_lines` to surface them; `changed_when:
+false` makes the read-only/idempotent contract explicit (run-twice = same
+result). Run `ansible-playbook -v` for Ansible's own echo of task output.
+
+## 12. See also
+
+- [`../CLAUDE.md`](../CLAUDE.md) — wire format, command catalogue, quirks, protect/lock authority ladder
+- [`./README.md`](./README.md) · [`./consumer.md`](./consumer.md) · [`./provider.md`](./provider.md) · [`./runbook.md`](./runbook.md)
+- [`../../../docs/adr/0025-per-connector-definition-of-done.md`](../../../docs/adr/0025-per-connector-definition-of-done.md)


### PR DESCRIPTION
Completes probel-sw02p to ADR-0025 6/6 (docs deliverable). Mirrors the acp1/emberplus docs structure: README, consumer, provider, runbook, and the 12-section verbs.md. Every wire sample is a REAL capture from a loopback dhs producer probel-sw02p serve (built from the committed 8x8 matrix_tree.json fixture) via --capture, not hand-written — verified reproducible (connect tx ff0200020577 / rx ff0400020575, checksum cross-checked). All 15 wired consumer verbs documented. Honestly records protocol limits rather than inventing: SW-P-02 has no source/dest label-set, no inc/dec/reset on a discrete crosspoint, no source-lock write, no wire-side discovery; salvo-connect CLI is currently unreachable due to the global --dsts shadowing (tracked separately), its wire path proven by the loopback integration test. Co-Authored-By Claude Opus 4.8.