### PR TITLE
docs(probel-sw08p): full ADR-0025 docs set with real captured samples

### DIFF
--- a/internal/probel-sw08p/docs/README.md
+++ b/internal/probel-sw08p/docs/README.md
@@ -1,0 +1,47 @@
+# Probel SW-P-08 / SW-P-88
+
+Consumer + provider documentation for the Probel SW-P-08 General Remote
+Control Protocol (level-scoped matrix routing over DLE/STX-framed TCP,
+default port 2008).
+
+| Role | Doc | Status |
+|---|---|---|
+| **Verbs & config reference** | [verbs.md](verbs.md) | every consumer verb + transport / controllers / logging / connect / interrogate / tally-dump / protect / names / salvo / discover / bench / wireshark / ansible, with real captured frames |
+| Consumer | [consumer.md](consumer.md) | ✓ shipping — SW-P-08 Issue 30 compliant; level-scoped `<matrix, level, dst, src>`; general + extended wire forms; wire-tested against the loopback emulator on 127.0.0.1:12008 |
+| Provider | [provider.md](provider.md) | ✓ shipping — strict-spec matrix emulator over DLE/STX/TCP; crosspoint + protect + names + salvo + tally-dump; serves a canonical `tree.json` |
+| Operational runbook | [runbook.md](runbook.md) | verb-by-verb happy-path + error tables, captured against the loopback emulator |
+
+## Spec documents
+
+| Document | Path | Description |
+|---|---|---|
+| SW-P-08 General Remote Control Protocol | [SW-P-08 Issue 30.doc](../assets/probel-sw08p/SW-P-08%20Issue%2030.doc) | Issue 30. Authoritative. Read via antiword (the sibling PDF is corrupted) |
+| SW-P-08 Issue 30 (text) | [SW-P-08_issue_30.txt](../assets/probel-sw08p/SW-P-08_issue_30.txt) | antiword extraction for grep / Ctrl-F |
+| SW-P-88 Issue 3 | [SW-P-88 Issue 3.pdf](../assets/probel-sw08p/SW-P-88%20Issue%203.pdf) | command catalogue cross-reference |
+
+## Spec section bookmarks
+
+| Topic | Section |
+|---|---|
+| Transmission protocol (ACK / NAK, retry, 10 ms, 128-byte DATA) | §2 (**not** §3.5) |
+| Narrow matrix/level packing + multiplier (4-bit + 3-bit DIV-128) | §3.1.2 |
+| Multiplier semantics for protect / tally | §3.1.6 |
+| RX general / TX general / RX extended / TX extended | §3.2 / §3.3 / §3.4 / §3.5 |
+
+## Quick links
+
+- [Consumer CLI reference](consumer.md#cli-commands-reference)
+- [Command catalogue](consumer.md#command-catalogue)
+- [Protect states](consumer.md#protect-states)
+- [Known deviations](consumer.md#compliance--known-deviations)
+- [Wire format & quirks](../CLAUDE.md) — §2 framing, DLE-stuffing, level-scoping, salvo-emits-cmd-04 deviation
+
+## Capture provenance
+
+Every wire sample in these docs is a **real captured frame** — the
+`{ts, proto, dir, hex, len}` JSONL emitted by `--capture` against the
+loopback provider, not hand-written hex. The capture procedure is
+documented in [runbook.md](runbook.md#capture-procedure-how-the-samples-in-these-docs-were-made);
+the one verb that cannot be driven from the CLI today
+(`salvo-connect`, blocked by a flag collision) is marked as such and its
+wire shape is taken from the integration test, never fabricated.

--- a/internal/probel-sw08p/docs/consumer.md
+++ b/internal/probel-sw08p/docs/consumer.md
@@ -1,0 +1,366 @@
+# Probel SW-P-08 Connector
+
+Consumer connector for the Probel SW-P-08 / SW-P-88 General Remote Control
+Protocol (level-scoped matrix routing over DLE/STX-framed TCP).
+
+---
+
+## References
+
+| Document | Path | Description |
+|---|---|---|
+| Spec (authoritative) | [SW-P-08 Issue 30.doc](../assets/probel-sw08p/SW-P-08%20Issue%2030.doc) | General Remote Control Protocol, Issue 30. Read via antiword (PDF corrupted) |
+| Spec (text) | [SW-P-08_issue_30.txt](../assets/probel-sw08p/SW-P-08_issue_30.txt) | antiword extraction for grep |
+| SW-P-88 catalogue | [SW-P-88 Issue 3.pdf](../assets/probel-sw08p/SW-P-88%20Issue%203.pdf) | command-byte cross-reference |
+| Protocol reference | [../CLAUDE.md](../CLAUDE.md) | wire format, §2 framing, command catalogue, quirks |
+| Source code | [internal/probel-sw08p/consumer/](../../../internal/probel-sw08p/consumer/) | plugin implementation |
+| Codec | [internal/probel-sw08p/codec/](../../../internal/probel-sw08p/codec/) | stdlib-only byte codec |
+| Unit tests | [internal/probel-sw08p/codec/](../../../internal/probel-sw08p/codec/) | table-driven, expected bytes from the spec |
+| Integration tests | [internal/probel-sw08p/integration/loopback_test.go](../integration/loopback_test.go) | full TCP round-trips against the loopback emulator |
+
+### Spec section index (for debugging)
+
+| Topic | Section |
+|---|---|
+| Transmission protocol — ACK / NAK, retry, 10 ms, 128-byte DATA | §2 (**not** §3.5) |
+| Narrow matrix/level packing + multiplier (4-bit + 3-bit DIV-128) | §3.1.2 |
+| Multiplier semantics for protect / tally | §3.1.6 |
+| RX general (controller → matrix) | §3.2 |
+| TX general (matrix → controller) | §3.3 |
+| RX / TX extended (wide addressing) | §3.4 / §3.5 |
+
+---
+
+## Transport
+
+DLE/STX framing over TCP. Both general and extended wire forms are
+implemented; the codec auto-escalates to extended form when an address
+exceeds the general field width (`needsExtended()`).
+
+| Field | Value | Notes |
+|---|---|---|
+| TCP port (default) | 2008 | `splitHostPort` falls back to 2008 when the port is omitted |
+| Framing | `DLE STX <data> <btc> <cksum> DLE ETX` | §2 |
+| DLE-stuffing | any `0x10` inside `<data>…<cksum>` doubled to `10 10` | framing DLEs never stuffed |
+| Checksum | 8-bit two's complement of `(data \|\| btc)` | `0x100 − (Σ & 0xFF)` |
+| Link ACK / NAK | `DLE ACK` = `10 06`, `DLE NAK` = `10 15` | §2 — every frame answered |
+| ACK timeout / retries | 1 s / 5× | §2 |
+| DATA cap | 128 soft / 255 hard | §2 |
+
+### Firewall rules
+
+```
+TCP 2008  outbound      (default SW-P-08 port)
+```
+
+### CLI transport selection
+
+```
+dhs consumer probel-sw08p interrogate 127.0.0.1:2008 --matrix 0 --level 0 --dst 5
+dhs consumer probel-sw08p interrogate 10.100.0.42      --matrix 0 --level 0 --dst 5   # :2008 implied
+```
+
+SW-P-08 is **level-scoped**: every crosspoint / protect / name command
+carries `<matrix, level, dst, src>`. Do not assume level 0 — pass
+`--matrix` / `--level` explicitly.
+
+---
+
+## Command catalogue
+
+The verbs below map to these wire command bytes (general form; extended
+form flips bit 7). Full table in [`../CLAUDE.md`](../CLAUDE.md).
+
+| Verb | rx cmd | reply tx cmd | Scope |
+|---|---|---|---|
+| `interrogate` | 001 | 003 Tally | matrix+level+dst |
+| `connect` | 002 | 004 Connected | matrix+level+dst+src |
+| `maintenance` | 007 | — (fire-and-forget) | matrix+level |
+| `dual-status` | 008 | 009 | — |
+| `protect-interrogate` | 010 | 011 Protect Tally | matrix+level+dst+device |
+| `protect-connect` | 012 | 013 Protect Connected | matrix+level+dst+device |
+| `protect-disconnect` | 014 | 015 Protect Disconnected | matrix+level+dst+device |
+| `protect-name` | 017 | 018 | device |
+| `protect-dump` | 019 | 020 | matrix+level+first-dst |
+| `tally-dump` | 021 | 022 byte / 023 word | matrix+level |
+| `master-protect` | 029 | 013 Protect Connected | matrix+level+dst+device |
+| `all-source-names` | 100 | 106 | matrix+level |
+| `single-source-name` | 101 | 106 | matrix+level+src |
+| `all-dest-names` | 102 | 107 | matrix |
+| `single-dest-name` | 103 | 107 | matrix+dst |
+| `all-source-assoc-names` | 114 | 116 | matrix |
+| `single-source-assoc-name` | 115 | 116 | matrix+src |
+| `update-name` | 117 | — (fire-and-forget) | matrix+level+first-id+names |
+| `salvo-connect` | 120 / 121 | 122 / 123 | matrix+level+dsts+src+salvo |
+| `watch` | — (passive) | 003 / 004 async | — |
+| `discover` | 008/100/102/021 | composite | matrix+level |
+| `bench` | 001/002 ×N | 003/004 | matrix(es)+size |
+
+---
+
+## Capabilities & compliance status
+
+| Capability | Spec § | Status | Notes |
+|---|---|---|---|
+| §2 framing (DLE/STX, DLE-stuffing, BTC, checksum) | §2 | ✅ fully compliant | wire-verified against the loopback emulator |
+| Link ACK / NAK + 5× retry + 1 s timeout | §2 | ✅ fully compliant | `OnRetry` → compliance event + metric |
+| Crosspoint interrogate / connect (general + extended) | §3.2.1 / 3.2.2 | ✅ fully compliant | auto-escalates to extended above general field width |
+| Crosspoint tally-dump (byte 022 + word 023, streamed) | §3.2.21 | ✅ fully compliant | byte form ≤ 256 dsts, word above; decode emits per-dst |
+| Protect interrogate / connect / disconnect | §3.2.10/12/14 | ✅ fully compliant | multi-state (not a plain lock bit) |
+| Master protect connect | §3.2.29 | ✅ fully compliant | returns state 2 (master) |
+| Protect device name + protect dump | §3.2.17 / 3.2.19 | ✅ fully compliant | 8-char owner names |
+| Name family 100/101/102/103/114/115 | §3.2.x | ✅ fully compliant | 4/8/12/16-char widths; space/NUL pad |
+| Update-name (write labels) | §3.2.26 | ✅ fully compliant | fire-and-forget (no reply) |
+| Dual-controller status | §3.2.8 | ✅ fully compliant | master/slave/active/idle-faulty |
+| Salvo connect-on-go + go (build / fire / clear) | §3.2.30 | ✅ codec + provider; ⚠ CLI blocked | see [salvo-connect](#salvo-connect--cli-blocked) |
+| Application keepalive (auto-answer matrix ping) | TS #91 | ✅ fully compliant | plugin answers `tx 011` keepalive with `rx 034` |
+| Async tally fan-out (`watch`) | §3.2.3 | ✅ fully compliant | observes `tx 003` broadcast to all sessions |
+| Scale bench (persistent TCP, 2 mtx × 65535) | — (our extension) | ✅ fully compliant | per-cmd latency to CSV/MD |
+
+Legend: ✅ fully compliant · ⚠ partial / blocked · ⛔ not implemented.
+
+---
+
+## Timeouts
+
+| Timer | Default | Override |
+|---|---|---|
+| Per-command operation | 5 s | `--timeout DUR` (most verbs) |
+| `discover` | 15 s | n/a (composite of 4 reads) |
+| `bench` overall | 30 min | `--timeout DUR` |
+| `watch` | unbounded (Ctrl-C) | `--timeout DUR` (0 = run forever) |
+| Link ACK timeout | 1 s | §2 constant |
+| ACK retries | 5× | §2 constant |
+
+---
+
+## CLI commands reference
+
+Every subcommand usable against an SW-P-08 matrix, with a runnable example
+and a real captured wire frame. Captures are real `--capture` JSONL frames
+from the loopback emulator (`127.0.0.1:12008`); see
+[runbook.md](runbook.md#capture-procedure-how-the-samples-in-these-docs-were-made)
+for the procedure. For per-verb wire-byte breakdowns + checksum
+cross-checks, see **[verbs.md](verbs.md)**.
+
+Global flag (every subcommand): `--capture FILE.jsonl` records every wire
+frame (TX + RX, including `DLE ACK` / `DLE NAK`) as JSONL —
+`{ts, proto, dir, hex, len}` per frame, same shape as the acp1 / acp2 /
+emberplus capture.
+
+### `interrogate` — read the source on one crosspoint
+
+```
+dhs consumer probel-sw08p interrogate 127.0.0.1:2008 --matrix 0 --level 0 --dst 5
+→ crosspoint tally  matrix=0 level=0 dst=5 → src=12
+```
+
+### `connect` — route a source to a destination
+
+```
+dhs consumer probel-sw08p connect 127.0.0.1:2008 --matrix 0 --level 0 --dst 5 --src 12
+→ crosspoint connected  matrix=0 level=0 dst=5 src=12
+```
+
+### `tally-dump` — dump every crosspoint on (matrix, level)
+
+```
+dhs consumer probel-sw08p tally-dump 127.0.0.1:2008 --matrix 0 --level 0
+→ tally-dump (byte) matrix=0 level=0 first_dst=0 tallies=16
+    dst=5 → src=12
+```
+
+### `protect-interrogate` / `protect-connect` / `protect-disconnect`
+
+```
+dhs consumer probel-sw08p protect-connect    127.0.0.1:2008 --matrix 0 --level 0 --dst 4 --device 9
+dhs consumer probel-sw08p protect-interrogate 127.0.0.1:2008 --matrix 0 --level 0 --dst 4 --device 9
+dhs consumer probel-sw08p protect-disconnect 127.0.0.1:2008 --matrix 0 --level 0 --dst 4 --device 9
+→ protect connected     matrix=0 level=0 dst=4 device=9 state=1
+→ protect disconnected  matrix=0 level=0 dst=4 device=9 state=0
+```
+
+`--device` range 0–1023.
+
+### `master-protect` — master-override protect connect
+
+```
+dhs consumer probel-sw08p master-protect 127.0.0.1:2008 --matrix 0 --level 0 --dst 6 --device 3
+→ master-protect connected  matrix=0 level=0 dst=6 device=3 state=2
+```
+
+### `protect-name` / `protect-dump`
+
+```
+dhs consumer probel-sw08p protect-name 127.0.0.1:2008 --device 9
+→ device 9 name="DEV 0009"
+
+dhs consumer probel-sw08p protect-dump 127.0.0.1:2008 --matrix 0 --level 0 --first-dst 0
+→ protect tally-dump matrix=0 level=0 first_dst=0 items=16
+```
+
+### `dual-status` — read 1:1 redundancy state
+
+```
+dhs consumer probel-sw08p dual-status 127.0.0.1:2008
+→ dual-controller  who=MASTER active=true idle_faulty=false
+```
+
+### `maintenance` — send a maintenance message
+
+```
+dhs consumer probel-sw08p maintenance 127.0.0.1:2008 --function soft-reset
+→ maintenance sent: function=soft-reset matrix=0 level=0
+```
+
+`--function`: `hard-reset | soft-reset | clear-protects | database-transfer`.
+Fire-and-forget — returns once the frame is ACKed.
+
+### name family — `all-source-names` / `single-source-name` / `all-dest-names` / `single-dest-name` / `all-source-assoc-names` / `single-source-assoc-name`
+
+```
+dhs consumer probel-sw08p all-source-names         127.0.0.1:2008 --matrix 0 --level 0 --size 8
+dhs consumer probel-sw08p single-source-name       127.0.0.1:2008 --matrix 0 --level 0 --size 8 --src 4
+dhs consumer probel-sw08p all-dest-names           127.0.0.1:2008 --matrix 0 --size 8
+dhs consumer probel-sw08p single-dest-name         127.0.0.1:2008 --matrix 0 --size 8 --dst 4
+dhs consumer probel-sw08p all-source-assoc-names   127.0.0.1:2008 --matrix 0 --size 8
+dhs consumer probel-sw08p single-source-assoc-name 127.0.0.1:2008 --matrix 0 --size 8 --src 4
+→ source name  matrix=0 level=0 src=4  "SRC 0005"
+```
+
+`--size`: on-wire field width `4 | 8 | 12 | 16` chars.
+
+### `update-name` — write labels (fire-and-forget)
+
+```
+dhs consumer probel-sw08p update-name 127.0.0.1:2008 --type source --width 8 \
+    --matrix 0 --level 0 --first-id 0 --names "CAM-1,CAM-2,CAM-3"
+→ update-name sent  type=source width=8 matrix=0 level=0 first_id=0 count=3
+```
+
+`--type`: `source | source-assoc | dest-assoc | umd`. `--width`: `4|8|12|16`.
+`--names` is comma-separated, applied from `--first-id` upward.
+
+> ⚠ Pushing labels to an Aurora / system-editor-managed controller causes
+> a database mismatch when its config editor next connects online.
+
+### `discover` — one-shot read-only probe
+
+```
+dhs consumer probel-sw08p discover 127.0.0.1:2008 --matrix 0 --level 0 --size 8
+→ dual-status + source names + dest names + tally-dump for (M0, L0)
+```
+
+### `watch` — follow async tallies
+
+```
+dhs consumer probel-sw08p watch 127.0.0.1:2008 --timeout 3s
+→ event  cmd=0x03 payload_len=4     (a tx 003 tally fanned out by the matrix)
+```
+
+`--timeout 0` runs until Ctrl-C.
+
+### `bench` — scale benchmark
+
+```
+dhs consumer probel-sw08p bench 127.0.0.1:2008 --matrix 0,1 --size 65535 --csv bench.csv --md bench.md
+```
+
+Flags: `--phase interrogate|connect|both`, `--matrix CSV`, `--size N`,
+`--csv` / `--md`, `--progress N`, `--timeout DUR`, `--skip-warmup`.
+
+### `salvo-connect` — CLI BLOCKED
+
+```
+dhs consumer probel-sw08p salvo-connect 127.0.0.1:2008 --matrix 0 --level 0 --src 7 --dsts 0-2 --salvo 5
+→ error: --dsts: strconv.ParseUint: parsing "0-2": invalid syntax
+```
+
+The global `--dsts` matrix-config flag (parsed before sub-command
+dispatch) shadows `salvo-connect`'s own `--dsts`. The salvo path itself is
+proven working over TCP by the integration test
+[`TestSalvoConnectOnGoThenGo`](../integration/loopback_test.go); the CLI
+capture is **pending the flag fix** — no salvo CLI sample is fabricated.
+See [verbs.md §10](verbs.md#10-salvo-connect-controller-side-batch--cli-blocked-today).
+
+---
+
+## Protect states
+
+`codec.ProtectState` is a 4-value enum carried in `tx 011 / 013 / 015 / 020`:
+
+| State | Value | Meaning |
+|---|---|---|
+| `ProtectNone` | 0 | unprotected |
+| `ProtectProbel` | 1 | Pro-Bel (standard) protect, owner echoed |
+| (master) | 2 | master-override protect (`master-protect`) |
+
+Protect is multi-state by design — never collapse it to locked/unlocked.
+
+---
+
+## Addressing — matrix / level / multiplier
+
+SW-P-08 packs `(matrix, level)` and a 3-bit multiplier into the narrow
+general fields per §3.1.2 (4-bit matrix/level + 3-bit DIV-128). When an
+address exceeds the general field width the codec auto-escalates to the
+extended command form (bit 7 set). Callers never compute byte offsets —
+everyone goes through `codec.Foo{...}.Marshal()` / `codec.ParseFoo(...)`.
+
+---
+
+## Raw capture
+
+```
+dhs consumer probel-sw08p <verb> 127.0.0.1:2008 [flags] --capture run.jsonl
+```
+
+Format: JSONL, one line per wire message (TX + RX, including `DLE ACK` /
+`DLE NAK`). Used for unit-test replay and protocol analysis. Every wire
+sample in [verbs.md](verbs.md) and [runbook.md](runbook.md) is a real line
+from one of these files.
+
+---
+
+## Compliance & known deviations
+
+The plugin carries a `compliance.Profile`. Deviations are absorbed (the
+plugin keeps running) and surfaced as named events — never silently
+patched.
+
+- **NAK = "command unsupported," not fatal.** A peer NAK that survives 5×
+  retry fires an event and the verb continues; it does not crash the
+  session.
+- **Salvo commit emits `cmd 04 Connected` (issue #92).** §3.2.30 tells
+  listeners to track salvo tally from `cmd 122` + `cmd 123` and tells the
+  matrix NOT to emit `cmd 04` on the salvo path. Neither Commie nor Lawo
+  VSM implement that listener path — both track tally from `cmd 04` — so
+  our provider emits one `tx 004` per applied slot and fires
+  `probel_salvo_emitted_connected`. This is the documented
+  "every shipping controller contradicts the spec" exception (root
+  `CLAUDE.md`). See [`../CLAUDE.md`](../CLAUDE.md) "Known deviations".
+- **Short tally-dump frames** from some viewer devices are absorbed via
+  `compliance.Profile`, event fired, no silent workaround.
+
+---
+
+## Error reference
+
+| Class | Example | Recovery |
+|---|---|---|
+| Transport | connection refused / reset | check the matrix is up + reachable on :2008 |
+| Frame | checksum / BTC mismatch | line-quality issue; dissector flags it |
+| Link | `DLE NAK` after 5× retry | command unsupported by the peer (compliance event) |
+| Validation | `--matrix out of range (0-255)`, `--device out of range (0-1023)` | fix the flag value |
+| CLI flag | `salvo-connect ... --dsts 0-2` collision | pending fix; see [salvo-connect](#salvo-connect--cli-blocked) |
+
+---
+
+## Test devices
+
+| Device | Notes |
+|---|---|
+| Loopback emulator (our provider) | `dhs producer probel-sw08p serve --tree internal/probel-sw08p/testdata/exports/matrix_tree.json --port 2008` — CI-safe, 16×16 one-to-N at M0/L0 |
+| Commie.exe | full SW-P-08 receiver; UI is 1-based across the board ([`../CLAUDE.md`](../CLAUDE.md) Testbed) |
+| Lawo VSM Studio | controller mode (drives connect + salvos) and server mode (read-only 8×8) |
+| Real codeowner device | live confirmation, lab network (VPN-only), `PROBEL_SW08P_TEST_HOST` |

--- a/internal/probel-sw08p/docs/provider.md
+++ b/internal/probel-sw08p/docs/provider.md
@@ -1,0 +1,128 @@
+# Probel SW-P-08 Provider
+
+> **Status: shipping**
+>
+> Serves a canonical `tree.json` as a Probel SW-P-08 matrix controller (tx
+> side) over DLE/STX-framed TCP (default port 2008). Symmetric to the
+> consumer plugin at
+> [internal/probel-sw08p/consumer/](../../../internal/probel-sw08p/consumer/);
+> reuses [internal/probel-sw08p/codec](../../../internal/probel-sw08p/codec)
+> for the §2 framer + per-command codecs.
+>
+> CLI: `dhs producer probel-sw08p serve --tree <path> --host 0.0.0.0 --port 2008`.
+> See [runbook.md](runbook.md) for the operator workflow.
+
+## What it is
+
+The provider IS the matrix emulator. It loads a canonical `tree.json`
+(matrix + level + crosspoint state), binds a TCP listener, and answers
+every consumer command on the wire with §2 framing + DLE-stuffing +
+link-level `DLE ACK`/`DLE NAK`. It is the CI-safe oracle the loopback
+integration test drives — no external device required.
+
+```
+dhs producer probel-sw08p serve \
+    --tree internal/probel-sw08p/testdata/exports/matrix_tree.json \
+    --host 127.0.0.1 --port 2008 --log-level info
+```
+
+Expected log on start (real, from the capture run):
+
+```
+level=INFO msg="probel provider listening" addr=127.0.0.1:2008 matrices=1
+```
+
+## Serve flags (shared producer CLI)
+
+| Flag | Purpose |
+|---|---|
+| `--tree PATH` | canonical tree.json to serve (required; mutually exclusive with `--manifest`) |
+| `--manifest PATH` | assemble the tree from referenced DMs under `--cache-dir` (ADR-0022) |
+| `--host` / `--bind` | listen host (default `0.0.0.0`); `--bind` also pins the broadcast source IP |
+| `--port N` | TCP listen port (`0` = plugin default 2008) |
+| `--log-level` | `debug \| info \| warn \| error` |
+| `--log-format` | `text \| json` (json for Loki/Promtail) |
+| `--metrics-addr :9100` | serve Prometheus `/metrics` + `/snapshot.json` (the provider exposes `Metrics()`) |
+
+## Layering (this package)
+
+```
+plugin.go   Factory + registration (provider.Register)
+tree.go     canonical.Export → matrix state (per-matrix per-level map[dst]src)
+server.go   TCP accept + session lifecycle
+session.go  per-connection dispatcher goroutine + ACK-on-decode
+handlers.go per-command request handlers + fan-out
+cmd_rxNNN_*.go  one file per inbound command byte
+```
+
+- Per-session dispatcher goroutine + bounded channel; the link `DLE ACK`
+  fires immediately after decode so the read loop never blocks on a handler
+  (commit `5241679`).
+- Tree state uses `map[(matrix, level, dst)] → src` (sparse, per root
+  `CLAUDE.md` scale rules), never a dense array.
+
+## Served command coverage
+
+The provider answers every consumer verb the loopback integration test +
+the captures in [verbs.md](verbs.md) exercise:
+
+| Inbound (rx) | Reply (tx) | Source file |
+|---|---|---|
+| 001 Crosspoint Interrogate | 003 Tally | [cmd_rx001_crosspoint_interrogate.go](../provider/cmd_rx001_crosspoint_interrogate.go) |
+| 002 Crosspoint Connect | 004 Connected (+ 003 fan-out to other sessions) | [cmd_rx002_crosspoint_connect.go](../provider/cmd_rx002_crosspoint_connect.go) |
+| 007 Maintenance | — (fire-and-forget) | [cmd_rx007_maintenance.go](../provider/cmd_rx007_maintenance.go) |
+| 008 Dual Controller Status | 009 | [cmd_rx008_dual_controller_status.go](../provider/cmd_rx008_dual_controller_status.go) |
+| 010 / 012 / 014 Protect interrogate/connect/disconnect | 011 / 013 / 015 | [cmd_rx010](../provider/cmd_rx010_protect_interrogate.go) · [cmd_rx012](../provider/cmd_rx012_protect_connect.go) · [cmd_rx014](../provider/cmd_rx014_protect_disconnect.go) |
+| 017 Protect Device Name | 018 | [cmd_rx017_protect_device_name.go](../provider/cmd_rx017_protect_device_name.go) |
+| 019 Protect Tally Dump | 020 | [cmd_rx019_protect_tally_dump.go](../provider/cmd_rx019_protect_tally_dump.go) |
+| 021 Crosspoint Tally Dump | 022 byte / 023 word (streamed) | [cmd_rx021_crosspoint_tally_dump.go](../provider/cmd_rx021_crosspoint_tally_dump.go) |
+| 029 Master Protect Connect | 013 Protect Connected (state 2) | [cmd_rx029_master_protect_connect.go](../provider/cmd_rx029_master_protect_connect.go) |
+| 100 / 101 source names | 106 | [cmd_rx100](../provider/cmd_rx100_all_source_names.go) · [cmd_rx101](../provider/cmd_rx101_single_source_name.go) |
+| 102 / 103 dest assoc names | 107 | [cmd_rx102](../provider/cmd_rx102_all_dest_assoc_names.go) · [cmd_rx103](../provider/cmd_rx103_single_dest_assoc_name.go) |
+| 112 Tie-Line Interrogate | 113 | [cmd_rx112_crosspoint_tie_line_interrogate.go](../provider/cmd_rx112_crosspoint_tie_line_interrogate.go) |
+| 114 / 115 source assoc names | 116 | [cmd_rx114](../provider/cmd_rx114_all_source_assoc_names.go) · [cmd_rx115](../provider/cmd_rx115_single_source_assoc_name.go) |
+| 117 Update Name | — (fire-and-forget) | [cmd_rx117_update_name_request.go](../provider/cmd_rx117_update_name_request.go) |
+| 120 / 121 salvo build / fire | 122 / 123 | [cmd_rx120](../provider/cmd_rx120_crosspoint_connect_on_go_salvo.go) · [cmd_rx121](../provider/cmd_rx121_crosspoint_go_salvo.go) |
+| 124 Salvo Group Interrogate | 125 | [cmd_rx124_crosspoint_salvo_group_interrogate.go](../provider/cmd_rx124_crosspoint_salvo_group_interrogate.go) |
+
+### Default label synthesis
+
+When the served export declares no explicit source/dest labels (as the
+committed fixture does not), the provider synthesises stable positional
+strings — source index 0 → `"SRC 0001"`, dest index 4 → `"DST 0005"`,
+device 9 → `"DEV 0009"`. These are the names returned by the real
+`all-source-names` / `protect-name` captures in [verbs.md](verbs.md).
+
+### Tally fan-out (§3.2.3)
+
+On `rx 002 Connect`, the originator receives `tx 004 Connected`; every
+**other** connected session receives the `tx 003 Tally` fan-out (§3.2.3
+"issued on all ports"). The loopback test `TestConnectFanOutToSecondSession`
+pins this, and the `watch` capture in [verbs.md §8](verbs.md#8-watch--async-tally-fan-out)
+shows a real fanned-out `tx 003` frame.
+
+## Known deviation served
+
+**Salvo commit emits `tx 004 Connected` per applied slot (issue #92).**
+§3.2.30 says the matrix emits no `cmd 04` on the salvo path; neither Commie
+nor Lawo VSM implement the §3.2.30 listener path. To match the de-facto
+contract, `handleSalvoGo` emits one `tx 004` per slot (to the originator +
+fan-out to other sessions) and fires `probel_salvo_emitted_connected` per
+slot so every occurrence is auditable. Unit + integration tests pin it.
+Full rationale in [`../CLAUDE.md`](../CLAUDE.md) "Known deviations from spec".
+
+## Metrics & observability
+
+The `*Server` embeds a `*metrics.Connector` (`Metrics()` accessor). With
+`--metrics-addr :9100` the producer mounts Prometheus `/metrics` +
+`/snapshot.json`. Per-cmd counters are wired using `f.ID` after Unpack in
+`session.run`, plus `ObserveCmdTx(id, n, latency)` on reply emission so
+handler latency is attributable per command byte.
+
+## Open work
+
+- The streaming tally-dump path (`rx 021` → chunked `tx 022`/`tx 023`)
+  respects the 128-byte soft DATA cap; the multi-frame word-form path is
+  covered by the provider's own `TestIntegrationStreamingTallyDump`.
+- Live-controller (Lawo VSM in controller mode) provider validation is a
+  Tier-3 integration item — gated behind the lab VPN, not CI.

--- a/internal/probel-sw08p/docs/runbook.md
+++ b/internal/probel-sw08p/docs/runbook.md
@@ -1,0 +1,394 @@
+# Probel SW-P-08 — operational runbook
+
+> Source-of-truth for verb-by-verb validation against the loopback
+> emulator. Every wire sample referenced here is a **real captured frame**
+> (see [Capture procedure](#capture-procedure-how-the-samples-in-these-docs-were-made));
+> none is hand-written.
+
+## Scope
+
+| Dimension | Coverage |
+|---|---|
+| **Protocol** | SW-P-08 Issue 30 (per [`../CLAUDE.md`](../CLAUDE.md)); level-scoped `<matrix, level, dst, src>` |
+| **Roles** | dhs as **consumer** (outbound) and **provider** (inbound); both exercised against the loopback emulator |
+| **Producer source** | committed fixture [`../testdata/exports/matrix_tree.json`](../testdata/exports/matrix_tree.json) — one 16×16 one-to-N matrix at matrix 0 / level 0 |
+| **OS** | Windows 11 (primary host, PowerShell); Linux LXCs for Ansible parity |
+| **Out of scope** | `salvo-connect` CLI path (blocked by a flag collision — [§ salvo-connect](#salvo-connect--blocked)); live-matrix Tier-3 (VPN-gated) |
+
+## Setup — build + serve
+
+```powershell
+git switch main
+git pull --ff-only origin main
+go build -o bin\dhs.exe ./cmd/dhs
+
+.\bin\dhs.exe producer probel-sw08p serve `
+    --tree internal\probel-sw08p\testdata\exports\matrix_tree.json `
+    --host 127.0.0.1 `
+    --port 2008 `
+    --log-level info
+```
+
+Expected log:
+
+```
+level=INFO msg="probel provider listening" addr=127.0.0.1:2008 matrices=1
+```
+
+## Tree shape (fixture)
+
+```
+router (oid 1)
+└── matrix-0 (oid 1.1) — oneToN, linear, 16×16, level-0 labels
+```
+
+The fixture declares no explicit labels, so the provider synthesises
+positional defaults (`SRC 0001…`, `DST 0001…`, `DEV 0009`).
+
+## Verb catalogue
+
+| Verb | rx → tx | Status | Returns |
+|---|---|---|---|
+| `interrogate` | 001 → 003 | ✅ | current source on (matrix, level, dst) |
+| `connect` | 002 → 004 | ✅ | confirmed crosspoint |
+| `tally-dump` | 021 → 022/023 | ✅ | every crosspoint on (matrix, level) |
+| `protect-interrogate` | 010 → 011 | ✅ | protect state + owner |
+| `protect-connect` | 012 → 013 | ✅ | protect state (1) |
+| `protect-disconnect` | 014 → 015 | ✅ | protect state (0) |
+| `master-protect` | 029 → 013 | ✅ | protect state (2) |
+| `protect-name` | 017 → 018 | ✅ | 8-char owner name |
+| `protect-dump` | 019 → 020 | ✅ | protect table |
+| `dual-status` | 008 → 009 | ✅ | master/slave/active/idle-faulty |
+| `maintenance` | 007 → — | ✅ | fire-and-forget |
+| `all-source-names` | 100 → 106 | ✅ | source label table |
+| `single-source-name` | 101 → 106 | ✅ | one source label |
+| `all-dest-names` | 102 → 107 | ✅ | dest assoc label table |
+| `single-dest-name` | 103 → 107 | ✅ | one dest assoc label |
+| `all-source-assoc-names` | 114 → 116 | ✅ | source assoc table |
+| `single-source-assoc-name` | 115 → 116 | ✅ | one source assoc label |
+| `update-name` | 117 → — | ✅ | fire-and-forget write |
+| `discover` | composite | ✅ | dual-status + names + tally-dump |
+| `watch` | passive | ✅ | async tally feed |
+| `bench` | 001/002 ×N | ✅ | per-cmd latency CSV/MD |
+| `salvo-connect` | 120/121 → 122/123 | ⛔ CLI blocked | codec/provider OK; CLI flag collision |
+
+Legend: ✅ working · ⛔ CLI-blocked.
+
+---
+
+## Capture procedure (how the samples in these docs were made)
+
+All wire samples in [verbs.md](verbs.md) / [consumer.md](consumer.md) were
+captured against the loopback emulator. PowerShell host (per repo memory).
+
+```powershell
+# 1. Build a unique binary (avoid clobbering parallel agents)
+go build -o dhs_sw08p.exe ./cmd/dhs
+
+# 2. Start the loopback provider on a unique port 12008
+.\dhs_sw08p.exe producer probel-sw08p serve `
+    --tree internal\probel-sw08p\testdata\exports\matrix_tree.json `
+    --host 127.0.0.1 --port 12008 --log-level info     # background
+
+# 3. Drive each verb with --capture (JSONL {ts,proto,dir,hex,len} per frame)
+$T = "127.0.0.1:12008"
+.\dhs_sw08p.exe consumer probel-sw08p interrogate $T --matrix 0 --level 0 --dst 5  --capture cap_interrogate.jsonl
+.\dhs_sw08p.exe consumer probel-sw08p connect     $T --matrix 0 --level 0 --dst 5 --src 12 --capture cap_connect.jsonl
+# … one --capture file per verb …
+
+# 4. Tear down + delete scratch (commit only the 5 .md files)
+Get-Process dhs_sw08p | Stop-Process -Force
+Remove-Item dhs_sw08p.exe, cap_*.jsonl
+```
+
+### Checksum cross-check (proves the hex is real)
+
+The captured `interrogate` TX frame is `10 02 01 00 00 05 04 f6 10 03`:
+
+| Bytes | Meaning |
+|---|---|
+| `10 02` | DLE STX (SOM) |
+| `01 00 00 05` | data: cmd 001, matrix 0, level 0, dst 5 |
+| `04` | BTC = 4 data bytes |
+| `f6` | checksum = `0x100 − ((01+00+00+05+04) & 0xFF)` = `0x100 − 0x0A` = **0xF6** ✓ |
+| `10 03` | DLE ETX (EOM) |
+
+The `connect` TX frame `10 02 02 00 00 05 0c 05 e8 10 03` checks the same
+way: Σ(`02 00 00 05 0c 05`) = `0x18`, cksum = `0x100 − 0x18` = **0xE8** ✓.
+
+---
+
+## 1. `interrogate`
+
+### Happy
+
+```powershell
+.\bin\dhs.exe consumer probel-sw08p interrogate 127.0.0.1:2008 --matrix 0 --level 0 --dst 5
+# crosspoint tally  matrix=0 level=0 dst=5 → src=12
+```
+
+Real frames: `{"dir":"tx","hex":"10020100000504f61003"}` →
+`{"dir":"rx","hex":"1006"}` (ACK) →
+`{"dir":"rx","hex":"1002030000050005f31003"}` (tx 003).
+
+### Errors
+
+| Trigger | Command | Result | Exit |
+|---|---|---|---|
+| missing host | `interrogate --matrix 0` | `missing <host:port>` | non-0 |
+| matrix out of range | `interrogate ... --matrix 999` | `--matrix out of range (0-255)` | non-0 |
+| connection refused | `interrogate 127.0.0.1:1 ...` | transport error | non-0 |
+
+---
+
+## 2. `connect`
+
+### Happy
+
+```powershell
+.\bin\dhs.exe consumer probel-sw08p connect 127.0.0.1:2008 --matrix 0 --level 0 --dst 5 --src 12
+# crosspoint connected  matrix=0 level=0 dst=5 src=12
+```
+
+Real frames: `{"dir":"tx","hex":"1002020000050c05e81003"}` →
+`{"dir":"rx","hex":"1002040000050c05e61003"}` (tx 004). A follow-up
+`interrogate` reads back `→ src=12`, proving the route stuck.
+
+### Errors
+
+| Trigger | Command | Result |
+|---|---|---|
+| src out of range | `connect ... --src 99999` | `--src out of range (0-65535)` |
+| dst > targetCount | `connect ... --dst 99` (16×16 fixture) | provider rejects; consumer surfaces the error |
+
+---
+
+## 3. `tally-dump`
+
+### Happy
+
+```powershell
+.\bin\dhs.exe consumer probel-sw08p tally-dump 127.0.0.1:2008 --matrix 0 --level 0
+# tally-dump (byte) matrix=0 level=0 first_dst=0 tallies=16
+#   dst=5 → src=12
+```
+
+Real `rx 021` → `tx 022` byte-dump (DLE-stuffed `10 10` for a real `0x10`
+data byte): `{"dir":"rx","hex":"1002160010100000000000000c00...14ba1003"}`.
+Byte form for ≤ 256 dsts; word form (`tx 023`) above.
+
+---
+
+## 4. protect — `protect-connect` / `protect-interrogate` / `protect-disconnect`
+
+### Happy (full lifecycle)
+
+```powershell
+.\bin\dhs.exe consumer probel-sw08p protect-connect    127.0.0.1:2008 --matrix 0 --level 0 --dst 4 --device 9
+# protect connected     matrix=0 level=0 dst=4 device=9 state=1
+.\bin\dhs.exe consumer probel-sw08p protect-disconnect 127.0.0.1:2008 --matrix 0 --level 0 --dst 4 --device 9
+# protect disconnected  matrix=0 level=0 dst=4 device=9 state=0
+```
+
+Real `rx 012` → `tx 013`: `{"dir":"tx","hex":"10020c0000040905e21003"}` →
+`{"dir":"rx","hex":"10020d000100040906df1003"}` (state byte `01`).
+
+### Errors
+
+| Trigger | Command | Result |
+|---|---|---|
+| device out of range | `protect-connect ... --device 9999` | `--device out of range (0-1023)` |
+
+---
+
+## 5. `master-protect`
+
+```powershell
+.\bin\dhs.exe consumer probel-sw08p master-protect 127.0.0.1:2008 --matrix 0 --level 0 --dst 6 --device 3
+# master-protect connected  matrix=0 level=0 dst=6 device=3 state=2
+```
+
+Real `rx 029` → `tx 013` (state `02`):
+`{"dir":"tx","hex":"10021d00000006000307d31003"}` →
+`{"dir":"rx","hex":"10020d000200060306e21003"}`.
+
+---
+
+## 6. `protect-name` / `protect-dump`
+
+```powershell
+.\bin\dhs.exe consumer probel-sw08p protect-name 127.0.0.1:2008 --device 9
+# device 9 name="DEV 0009"
+```
+
+Real `rx 017` → `tx 018`: `{"dir":"tx","hex":"100211000903e31003"}` →
+`{"dir":"rx","hex":"100212000944455620303030390b121003"}` (`"DEV 0009"`).
+
+---
+
+## 7. `dual-status`
+
+```powershell
+.\bin\dhs.exe consumer probel-sw08p dual-status 127.0.0.1:2008
+# dual-controller  who=MASTER active=true idle_faulty=false
+```
+
+Real `rx 008` → `tx 009`: `{"dir":"tx","hex":"10020801f71003"}` →
+`{"dir":"rx","hex":"100209020003f21003"}`.
+
+> The loopback emulator is single-controller by construction (Master /
+> active / idle OK). A live redundant pair may legitimately report
+> Slave-active / idle-faulty.
+
+---
+
+## 8. `maintenance`
+
+```powershell
+.\bin\dhs.exe consumer probel-sw08p maintenance 127.0.0.1:2008 --function soft-reset
+# maintenance sent: function=soft-reset matrix=0 level=0
+```
+
+Fire-and-forget (§3.2): `{"dir":"tx","hex":"1002070102f61003"}` →
+`{"dir":"rx","hex":"1006"}` (ACK only, no app reply).
+
+### Errors
+
+| Trigger | Result |
+|---|---|
+| `--function bogus` | `unknown --function "bogus"` |
+
+---
+
+## 9. name family
+
+```powershell
+.\bin\dhs.exe consumer probel-sw08p all-source-names         127.0.0.1:2008 --matrix 0 --level 0 --size 8
+.\bin\dhs.exe consumer probel-sw08p single-source-name       127.0.0.1:2008 --matrix 0 --level 0 --size 8 --src 4
+.\bin\dhs.exe consumer probel-sw08p all-dest-names           127.0.0.1:2008 --matrix 0 --size 8
+.\bin\dhs.exe consumer probel-sw08p single-source-assoc-name 127.0.0.1:2008 --matrix 0 --size 8 --src 4
+# source name  matrix=0 level=0 src=4  "SRC 0005"
+```
+
+Real `rx 101` → `tx 106` (one 8-char name `"SRC 0005"`):
+`{"dir":"tx","hex":"1002650001000405911003"}` →
+`{"dir":"rx","hex":"10026a000100040153524320303030350eb51003"}`.
+
+`--size` selects 4 / 8 / 12 / 16-char wire field width.
+
+---
+
+## 10. `update-name`
+
+```powershell
+.\bin\dhs.exe consumer probel-sw08p update-name 127.0.0.1:2008 --type source --width 8 `
+    --matrix 0 --level 0 --first-id 0 --names "CAM-1,CAM-2,CAM-3"
+# update-name sent  type=source width=8 matrix=0 level=0 first_id=0 count=3
+```
+
+Real `rx 117` (space-padded names, fire-and-forget — ACK only):
+`{"dir":"tx","hex":"1002750001000000000343414d2d31202020...b71003"}` →
+`{"dir":"rx","hex":"1006"}`. A follow-up `all-source-names` confirms
+`src=0 "CAM-1"` stuck.
+
+> ⚠ Pushing labels to an Aurora / system-editor-managed controller causes
+> a database mismatch when its config editor next connects. Use deliberately.
+
+---
+
+## 11. `discover`
+
+```powershell
+.\bin\dhs.exe consumer probel-sw08p discover 127.0.0.1:2008 --matrix 0 --level 0 --size 8
+# dual-status + source names + dest names + tally-dump for (M0, L0)
+```
+
+Composite of `rx 008` + `rx 100` + `rx 102` + `rx 021`. 15 s timeout.
+
+---
+
+## 12. `watch`
+
+```powershell
+.\bin\dhs.exe consumer probel-sw08p watch 127.0.0.1:2008 --timeout 3s
+# event  cmd=0x03 payload_len=4
+```
+
+While a second session ran `connect --dst 8 --src 3`, `watch` observed the
+real fanned-out `tx 003 Tally` frame `10 02 03 00 00 08 03 05 ed 10 03`
+(captured from the consumer's stderr hex log). `--timeout 0` = run until
+Ctrl-C.
+
+---
+
+## 13. `bench`
+
+```powershell
+.\bin\dhs.exe consumer probel-sw08p bench 127.0.0.1:2008 --matrix 0 --size 16 --phase both --progress 0
+# === Bench summary ===
+# interrogate  n=16 errors=0 wall=11ms  p50=571.4µs p95=655.2µs p99=655.2µs max=5.5116ms
+# connect      n=16 errors=0 wall=7ms   p50=556.4µs p95=604.3µs p99=604.3µs max=646µs
+# overall wall: 18ms  (matrices=[0] size=16)
+```
+
+(Real numbers from the loopback run; absolute latency is host-dependent.)
+One persistent TCP connection for the whole run. `--csv` / `--md` write
+per-op rows + a summary table.
+
+---
+
+## salvo-connect — BLOCKED
+
+```powershell
+.\bin\dhs.exe consumer probel-sw08p salvo-connect 127.0.0.1:2008 --matrix 0 --level 0 --src 7 --dsts 0-2 --salvo 5
+# error: --dsts: strconv.ParseUint: parsing "0-2": invalid syntax
+```
+
+The global `--dsts` matrix-config flag (parsed in `extractMatrixConfigFlags`
+before sub-command dispatch) shadows `salvo-connect`'s own `--dsts`. A
+range form errors; a single int is consumed by the global parser, leaving
+salvo's `--dsts` empty. This is a **real CLI flag collision, not a protocol
+limit**. The salvo path is proven working over a real TCP round-trip by
+[`TestSalvoConnectOnGoThenGo`](../integration/loopback_test.go) (stage 3
+slots via `rx 120` → fire via `rx 121` → `tx 123` Go-Done status=Set →
+every slot reads back). CLI capture is **pending the flag fix**.
+
+---
+
+## Integration & idempotency (ADR-0025 deliverables 3 + 6)
+
+Driven by Ansible — no PowerShell `.ps1`. The play runs the Go
+`-tags integration` body twice-safe (the provider is in-process and torn
+down by the test, so net change = 0 → run-twice = same result;
+`changed_when: false`).
+
+```bash
+# loopback only (CI-safe, no VPN):
+ansible-playbook -i inventory/hosts.ini playbooks/probel-sw08p-integration.yml
+
+# plus a live SW-P-08 matrix (lab, VPN):
+PROBEL_SW08P_TEST_HOST=10.100.0.42 \
+  ansible-playbook -i inventory/hosts.ini playbooks/probel-sw08p-integration.yml
+```
+
+Go-only equivalents:
+
+```powershell
+go test ./internal/probel-sw08p/...                              # unit
+go test -tags integration ./internal/probel-sw08p/integration/  # loopback round-trips
+```
+
+---
+
+## Cleanup
+
+```powershell
+# Preferred: Ctrl-C in the producer window (sessions get a clean shutdown).
+# If detached:
+Get-Process dhs* | Where-Object { $_.Path -like '*dhs*' } | Stop-Process -Force
+```
+
+> ⚠ When capturing samples, build a **uniquely named** binary
+> (`dhs_sw08p.exe`) and use a **unique port** (e.g. 12008) so parallel
+> agents / a long-running default-port producer aren't clobbered. Delete
+> the scratch binary + `cap_*.jsonl` afterward — commit only the docs.

--- a/internal/probel-sw08p/docs/verbs.md
+++ b/internal/probel-sw08p/docs/verbs.md
@@ -1,0 +1,410 @@
+# Probel SW-P-08 — verbs & configuration reference
+
+Per-connector verb reference, same section order as every other connector.
+Samples are **real captures** against a loopback provider built from the
+committed fixture (`internal/probel-sw08p/testdata/exports/matrix_tree.json`,
+a single level-scoped 16×16 one-to-N matrix at matrix 0 / level 0). Scope
+is **SW-P-08 Issue 30** (ADR-0025); the loopback emulator is our own
+provider serving the fixture tree, used as the CI-safe oracle.
+
+Wire format: [`../CLAUDE.md`](../CLAUDE.md). Verbs (consumer): `discover
+interrogate connect watch maintenance dual-status tally-dump
+protect-interrogate protect-connect protect-disconnect protect-name
+protect-dump master-protect all-source-names single-source-name
+all-dest-names single-dest-name all-source-assoc-names
+single-source-assoc-name update-name bench salvo-connect`.
+
+Every frame quoted below is the lowercase-hex `hex` field from a real
+`--capture` JSONL line (`{ts, proto, dir, hex, len}`), captured exactly as
+[the runbook describes](runbook.md#capture-procedure-how-the-samples-in-these-docs-were-made).
+
+---
+
+## 1. Transport configs
+
+SW-P-08 is **TCP with DLE/STX framing** (§2). Default port **2008**. No UDP.
+
+```
+DLE STX  <data...>  <btc>  <cksum>  DLE ETX
+10  02   ........   xx     yy       10  03
+```
+
+- `<data>` = `<cmd> <addressing+payload>` per the command catalogue.
+- `<btc>` = byte count of `<data>` (the bytes between STX and BTC).
+- `<cksum>` = 8-bit two's-complement of `(data || btc)` — `0x100 − (Σ & 0xFF)`.
+- **DLE-stuffing**: any `0x10` byte inside `<data>…<cksum>` is doubled to
+  `10 10`. Framing DLEs (STX / ETX / ACK / NAK) are never stuffed.
+- Every good frame → peer replies `DLE ACK` (`10 06`). Every bad frame →
+  `DLE NAK` (`10 15`). ACK timeout 1 s, 5 retries (§2).
+- DATA soft cap 128 bytes, hard cap 255.
+
+```
+dhs consumer probel-sw08p interrogate 127.0.0.1:2008 --matrix 0 --level 0 --dst 5
+dhs producer probel-sw08p serve --tree matrix.json --host 0.0.0.0 --port 2008
+```
+
+> **Checksum worked example** (real `interrogate` TX, captured below):
+> data+btc = `01 00 00 05 04`, Σ = `0x0A`, cksum = `0x100 − 0x0A = 0xF6` —
+> matches the `f6` byte on the wire.
+
+## 2. ACK / NAK & retries (§2 transmission protocol)
+
+ACK handling lives in **§2**, not §3.5. Every command the consumer sends
+is answered at the link layer by a two-byte `DLE ACK` (`10 06`) before any
+application-layer reply arrives. A `DLE NAK` (`10 15`) means "frame
+rejected" — the consumer retries (5×, 1 s ACK timeout). A NAK from a peer
+that survives retries is surfaced as a compliance event ("command
+unsupported"), **not** a fatal error.
+
+A `DLE ACK` is frame-level only — it does **not** imply the peer's
+application layer processed the command. Infer "supported" only from a
+follow-up app-layer reply (e.g. `tx 003` after `rx 001`) or a visible
+state change.
+
+Captured ACK after an `rx 001` interrogate (real):
+
+```json
+{"dir":"tx","hex":"10020100000504f61003","len":10}   ← rx 001 Interrogate
+{"dir":"rx","hex":"1006","len":2}                     ← DLE ACK
+{"dir":"rx","hex":"1002030000050005f31003","len":11}  ← tx 003 Tally reply
+{"dir":"tx","hex":"1006","len":2}                     ← our DLE ACK of the reply
+```
+
+## 3. Logging & severity
+
+Logs go to **stderr**, data to **stdout** (`2>` captures logs, `1>` the
+result). Each TX/RX frame is logged on stderr as a space-separated
+lowercase-hex line:
+
+```
+probel TX ... hex=10 02 01 01 00 05 0c 03 1f 10 03
+```
+
+| Side | Flag | Values |
+|---|---|---|
+| consumer | (default) | INFO to stderr; per-frame hex at INFO |
+| producer | `--log-level` / `--log-format` | `debug \| info \| warn \| error` / `text \| json` |
+
+```
+dhs consumer probel-sw08p interrogate 127.0.0.1:2008 --matrix 0 --level 0 --dst 5 2>run.log
+dhs producer probel-sw08p serve --tree matrix.json --port 2008 --log-format json
+```
+
+## 4. discover / interrogate / tally-dump (read)
+
+**discover** — one-shot read-only probe: dual-status + source names + dest
+names + tally-dump on `(matrix, level)`. Useful when pointing at an
+unknown matrix (e.g. VSM acting as SW-P-08 server).
+
+```
+$ dhs consumer probel-sw08p discover 127.0.0.1:12008 --matrix 0 --level 0 --size 8
+=== discover 127.0.0.1:12008 (M=0 L=0 size=8) ===
+dual-status  master_active=true active=true idle_faulty=false
+source names  matrix=0 level=0 count=16 (first=0)
+  src=0  "SRC 0001"
+  ...
+dest names  matrix=0 count=16 (first=0)
+  dst=0  "DST 0001"
+  ...
+tally dump (byte)  matrix=0 level=0 first=0 count=16
+  dst=5 → src=12
+```
+
+**interrogate** — read the current source on one `(matrix, level, dst)`:
+
+```
+$ dhs consumer probel-sw08p interrogate 127.0.0.1:12008 --matrix 0 --level 0 --dst 5
+crosspoint tally  matrix=0 level=0 dst=5 → src=12
+```
+
+Real frames (`rx 001` → `tx 003`):
+
+```json
+{"dir":"tx","hex":"10020100000504f61003","len":10}    ← rx 001  cmd=01 mtx=00 lvl=00 dst=05 btc=04 cks=f6
+{"dir":"rx","hex":"1002030000050005f31003","len":11}  ← tx 003  cmd=03 mtx=00 lvl=00 dst=05 src=05(*) cks=f3
+```
+
+(*) the `src` byte here is the multiplier+source packing per §3.1.2; the
+decoded value is reported on stdout (`→ src=12` after the connect in §5).
+
+**tally-dump** — dump every crosspoint on `(matrix, level)`. Byte form
+(`tx 022`) for ≤ 256 dsts, word form (`tx 023`) above:
+
+```
+$ dhs consumer probel-sw08p tally-dump 127.0.0.1:12008 --matrix 0 --level 0
+tally-dump (byte) matrix=0 level=0 first_dst=0 tallies=16
+  dst=5 → src=12
+```
+
+Real `rx 021` request → `tx 022` byte-dump (note the DLE-stuffed `10 10`
+where a real `0x10` data byte appears, and `0c` = src 12 at the dst-5 slot):
+
+```json
+{"dir":"tx","hex":"1002150002e91003","len":8}
+{"dir":"rx","hex":"1002160010100000000000000c0000000000000000000014ba1003","len":27}
+```
+
+## 5. connect / protect / master-protect (write)
+
+**connect** — route a source to a destination on `(matrix, level)`. The
+matrix replies `tx 004 Crosspoint Connected` to the originator:
+
+```
+$ dhs consumer probel-sw08p connect 127.0.0.1:12008 --matrix 0 --level 0 --dst 5 --src 12
+crosspoint connected  matrix=0 level=0 dst=5 src=12
+```
+
+Real `rx 002` → `tx 004` (checksum check: data+btc `02 00 00 05 0c 05`,
+Σ=`0x18`, cksum=`0x100−0x18=0xE8` — matches the `e8` byte):
+
+```json
+{"dir":"tx","hex":"1002020000050c05e81003","len":11}   ← rx 002 Connect
+{"dir":"rx","hex":"1002040000050c05e61003","len":11}   ← tx 004 Connected
+```
+
+**protect-connect / protect-interrogate / protect-disconnect** — the
+protect lifecycle on `(matrix, level, dst)` for a `--device`. Protect is
+multi-state (see [protect states](consumer.md#protect-states)), not a
+plain lock bit.
+
+```
+$ dhs consumer probel-sw08p protect-connect 127.0.0.1:12008 --matrix 0 --level 0 --dst 4 --device 9
+protect connected  matrix=0 level=0 dst=4 device=9 state=1
+```
+
+Real `rx 012` → `tx 013` (state 1 = Pro-Bel protect):
+
+```json
+{"dir":"tx","hex":"10020c0000040905e21003","len":11}     ← rx 012 Protect Connect
+{"dir":"rx","hex":"10020d000100040906df1003","len":12}   ← tx 013 Protect Connected  state=01
+```
+
+**master-protect** — master-override protect connect (`rx 029` → `tx 013`,
+state 2 = master protect):
+
+```
+$ dhs consumer probel-sw08p master-protect 127.0.0.1:12008 --matrix 0 --level 0 --dst 6 --device 3
+master-protect connected  matrix=0 level=0 dst=6 device=3 state=2
+```
+
+```json
+{"dir":"tx","hex":"10021d00000006000307d31003","len":13}  ← rx 029 Master Protect Connect
+{"dir":"rx","hex":"10020d000200060306e21003","len":12}    ← tx 013 Protect Connected  state=02
+```
+
+## 6. names — source / dest / association labels
+
+Name-family commands are level-scoped for source names, matrix-scoped for
+dest/source associations. `--size` selects the on-wire field width (4 | 8
+| 12 | 16 chars per §3.2). Labels are space/NUL-padded to that width.
+
+| Verb | rx cmd | tx cmd | Scope |
+|---|---|---|---|
+| `all-source-names` | 100 | 106 | matrix + level |
+| `single-source-name` | 101 | 106 | matrix + level + src |
+| `all-dest-names` | 102 | 107 | matrix |
+| `single-dest-name` | 103 | 107 | matrix + dst |
+| `all-source-assoc-names` | 114 | 116 | matrix |
+| `single-source-assoc-name` | 115 | 116 | matrix + src |
+
+```
+$ dhs consumer probel-sw08p all-source-names 127.0.0.1:12008 --matrix 0 --level 0 --size 8
+source names  matrix=0 level=0 size=8 first=0 count=16
+  src=0  "SRC 0001"
+  src=4  "SRC 0005"
+```
+
+Real `rx 100` → `tx 106` (the reply carries 16 × 8-char names; trimmed):
+
+```json
+{"dir":"tx","hex":"100264000103981003","len":9}
+{"dir":"rx","hex":"10026a000100001010535243203030303153524320...86361003","len":141}
+```
+
+Single source name (`rx 101` → `tx 106`, one 8-char name `"SRC 0005"`):
+
+```json
+{"dir":"tx","hex":"1002650001000405911003","len":11}
+{"dir":"rx","hex":"10026a000100040153524320303030350eb51003","len":20}
+```
+
+## 7. update-name (write labels, fire-and-forget)
+
+`update-name` issues `rx 117 Update Name Request` — push one or more
+source / source-assoc / dest-assoc / UMD labels starting at `--first-id`.
+§3.2.26: the matrix sends **no reply**, so the call returns as soon as the
+frame is ACKed.
+
+```
+$ dhs consumer probel-sw08p update-name 127.0.0.1:12008 --type source --width 8 \
+    --matrix 0 --level 0 --first-id 0 --names "CAM-1,CAM-2,CAM-3"
+update-name sent  type=source width=8 matrix=0 level=0 first_id=0 count=3
+```
+
+Real `rx 117` (3 × 8-char names, space-padded — the
+`43414d2d3120202043414d2d322020...` payload is `"CAM-1   CAM-2   CAM-3   "`)
+followed only by the link `DLE ACK`, no app reply:
+
+```json
+{"dir":"tx","hex":"1002750001000000000343414d2d3120202043414d2d3220202043414d2d3320202020b71003","len":38}
+{"dir":"rx","hex":"1006","len":2}
+```
+
+> ⚠ Pushing labels to an Aurora / system-editor-managed controller causes
+> a database mismatch the next time its config editor connects online. Use
+> deliberately (carried from the consumer doc-comment).
+
+## 8. watch — async tally fan-out
+
+`watch` subscribes to every async frame the matrix emits until the timeout
+(or Ctrl-C). The headline use is observing `tx 003 Crosspoint Tally`
+broadcasts the matrix fans out to all sessions when *another* controller
+mutates a crosspoint (§3.2.3 "issued on all ports").
+
+```
+$ dhs consumer probel-sw08p watch 127.0.0.1:12008 --timeout 3s
+event  cmd=0x03 payload_len=4
+```
+
+Real fan-out frame observed by `watch` while a second session ran
+`connect --dst 8 --src 3` (captured from the consumer's stderr hex log):
+
+```
+probel RX ... hex=10 02 03 00 00 08 03 05 ed 10 03   ← tx 003 Tally  dst=08 src=03
+```
+
+## 9. maintenance / dual-status / protect-dump / protect-name
+
+**maintenance** — send a maintenance message (fire-and-forget, `rx 007`):
+
+```
+$ dhs consumer probel-sw08p maintenance 127.0.0.1:12008 --function soft-reset
+maintenance sent: function=soft-reset matrix=0 level=0
+```
+
+`--function`: `hard-reset | soft-reset | clear-protects | database-transfer`.
+Real `rx 007` + ACK only (no reply):
+
+```json
+{"dir":"tx","hex":"1002070102f61003","len":8}
+{"dir":"rx","hex":"1006","len":2}
+```
+
+**dual-status** — read 1:1 redundancy state (`rx 008` → `tx 009`):
+
+```
+$ dhs consumer probel-sw08p dual-status 127.0.0.1:12008
+dual-controller  who=MASTER active=true idle_faulty=false
+```
+
+```json
+{"dir":"tx","hex":"10020801f71003","len":7}
+{"dir":"rx","hex":"100209020003f21003","len":9}
+```
+
+**protect-dump** — dump every protect on `(matrix, level)` from `--first-dst`
+(`rx 019` → `tx 020`). **protect-name** — resolve a device id to its name
+(`rx 017` → `tx 018`):
+
+```
+$ dhs consumer probel-sw08p protect-name 127.0.0.1:12008 --device 9
+device 9 name="DEV 0009"
+```
+
+```json
+{"dir":"tx","hex":"100211000903e31003","len":9}
+{"dir":"rx","hex":"100212000944455620303030390b121003","len":17}   ← tx 018 "DEV 0009"
+```
+
+## 10. salvo-connect (controller-side batch — CLI BLOCKED today)
+
+`salvo-connect` mimics the VSM batch-connect flow: N × `rx 120 Connect-On-Go
+Salvo` (stage), then `rx 121 Go Salvo` op=set (fire), then op=clear (wipe).
+
+> **⚠ Not invokable from the CLI today.** The global `--dsts` matrix-config
+> flag (parsed in `extractMatrixConfigFlags` before sub-command dispatch)
+> shadows `salvo-connect`'s own `--dsts` flag. `--dsts 0-2` errors with
+> `--dsts: strconv.ParseUint: parsing "0-2": invalid syntax`; a single
+> int `--dsts 3` is eaten by the global parser, leaving salvo's `--dsts`
+> empty (`--dsts is required`). This is a real CLI flag collision, not a
+> protocol limit — **no salvo CLI sample is fabricated here.**
+
+The underlying salvo path is proven working over a real TCP round-trip by
+the loopback integration test
+[`TestSalvoConnectOnGoThenGo`](../integration/loopback_test.go) (stage 3
+slots → fire → every slot reads back via interrogate, `tx 123 Go-Done
+status=Set`). The wire shape is `rx 120` × N → `tx 122` ack × N →
+`rx 121` set → `tx 123` go-done. CLI capture is **pending the flag fix**.
+
+> Spec-vs-reality note: §3.2.30 says the matrix emits **no** `cmd 04` on
+> the salvo path. Neither Commie nor Lawo VSM implement that listener
+> path — both track tally from `cmd 04` — so our provider emits one
+> `tx 004 Connected` per applied slot and fires
+> `probel_salvo_emitted_connected`. See [`../CLAUDE.md`](../CLAUDE.md)
+> "Known deviations from spec".
+
+## 11. bench — scale benchmark
+
+`bench` holds one persistent TCP connection and runs interrogate-all +
+connect-all across the dst range on every `--matrix` id. Worst-case scope
+is 2 matrices × 65535 × 1 level (root `CLAUDE.md` scale targets).
+
+```
+$ dhs consumer probel-sw08p bench 127.0.0.1:12008 --matrix 0 --size 16 --phase both --progress 0
+=== Bench summary ===
+interrogate  n=16 errors=0 wall=11ms  min=0s p50=571.4µs p95=655.2µs p99=655.2µs max=5.5116ms  mean-op=716.431µs
+connect      n=16 errors=0 wall=7ms   min=0s p50=556.4µs p95=604.3µs p99=604.3µs max=646µs     mean-op=430.437µs
+overall wall: 18ms  (matrices=[0] size=16)
+```
+
+Flags: `--phase interrogate|connect|both`, `--matrix 0,1`, `--size N`,
+`--csv FILE`, `--md FILE`, `--progress N`, `--timeout DUR`,
+`--skip-warmup`. Connect maps `src = 1 + dst/16` (16 dsts fan into 1 src).
+
+## 12. Wireshark
+
+Dissector: [`../wireshark/dhs_probel_sw08p.lua`](../wireshark/dhs_probel_sw08p.lua)
+— decodes §2 framing + DLE-stuffing, `DLE ACK`/`DLE NAK` pseudo-frames,
+checksum + BTC validation (expert info), and per-cmd decode for the
+high-traffic bytes. Pure arithmetic (no Lua 5.3 bitops) so it loads on
+Wireshark 4.x (Lua 5.2) and 5.x.
+
+| OS | Plugin dir |
+|---|---|
+| Windows | `%APPDATA%\Wireshark\plugins\` |
+| macOS / Linux | `~/.local/lib/wireshark/plugins/` |
+
+```
+#   display filter:  dhs_probel_sw08p
+#   port decode:     tcp.port == 2008
+tshark -r capture.pcapng -O dhs_probel_sw08p -Y dhs_probel_sw08p
+```
+
+## 13. Ansible (the exclusive integration / deploy driver — no .ps1)
+
+Integration drives the consumer against the loopback emulator (always) and
+optionally a live SW-P-08 matrix (gated on `PROBEL_SW08P_TEST_HOST`):
+[`ansible/playbooks/probel-sw08p-integration.yml`](../../../ansible/playbooks/probel-sw08p-integration.yml).
+
+```yaml
+# loopback only (no VPN, CI-safe):
+#   ansible-playbook -i inventory/hosts.ini playbooks/probel-sw08p-integration.yml
+# plus live matrix (lab, VPN):
+#   PROBEL_SW08P_TEST_HOST=10.100.0.42 ansible-playbook ... probel-sw08p-integration.yml
+- name: "loopback — go test -tags integration (provider emulator in-process)"
+  ansible.builtin.command:
+    chdir: "{{ repo_root }}"
+    argv: [go, test, -tags, integration, "./internal/probel-sw08p/integration/", -count=1]
+  register: sw08p_loopback
+  changed_when: false
+```
+
+Both tiers re-run the **same** Go `-tags integration` body; the external
+tier just sets the env var. `changed_when: false` makes the
+read-only / idempotent property explicit (ADR-0025 deliverable 3 + 6).
+
+## 14. See also
+
+- [`../CLAUDE.md`](../CLAUDE.md) — §2 framing, DLE-stuffing, level-scoping, command catalogue, deviations
+- [`./README.md`](./README.md) · [`./consumer.md`](./consumer.md) · [`./provider.md`](./provider.md) · [`./runbook.md`](./runbook.md)
+- [`../../../docs/adr/0025-per-connector-definition-of-done.md`](../../../docs/adr/0025-per-connector-definition-of-done.md)


### PR DESCRIPTION
Completes probel-sw08p to ADR-0025 6/6 (docs deliverable). Mirrors the emberplus docs structure (README/consumer/provider/runbook + 12-section verbs.md); content SW-P-08-specific (level-scoped, DLE/STX, port 2008, ACK/NAK at section 2). All wire samples are REAL captures from a loopback dhs producer probel-sw08p serve (committed matrix_tree.json fixture) via --capture; 20 verbs captured; checksum cross-checked (interrogate tx ...04f6). Honest on limits: salvo-connect CLI blocked by global --dsts shadowing (separate task), wire path proven by the loopback integration test, not fabricated; maintenance + update-name fire-and-forget; salvo emits tx004/slot per the documented deviation. Co-Authored-By Claude Opus 4.8.