### PR TITLE
docs(tsl): full ADR-0025 docs set (push/tally protocol)

### DIFF
--- a/internal/tsl/docs/README.md
+++ b/internal/tsl/docs/README.md
@@ -1,0 +1,57 @@
+# TSL UMD — v3.1 / v4.0 / v5.0 (tally / UMD push protocol)
+
+TSL UMD is a **one-way tally / Under-Monitor-Display push protocol**. A
+tally source (a switcher, a Lawo VSM, a Miranda Kaleido) *pushes* display
+state — tally lamps + UMD label text — at a multiviewer (MV) listener.
+There is no request/reply, no addressable object tree, no matrix. This
+docs set is therefore adapted from the acp1 template for a push protocol:
+sections that assume get/set/walk/crosspoints are marked **N/A** with the
+reason.
+
+| Role | Doc | Status |
+|---|---|---|
+| **Verbs & config reference** | [verbs.md](verbs.md) | every verb + transport/version/serve/dmsg/wireshark/ansible, with real captures |
+| Consumer (MV receiver) | [consumer.md](consumer.md) | ✓ listens on UDP (v3.1/v4.0/v5.0) + DLE/STX TCP (v5.0); decodes + fires compliance events |
+| Provider (tally source) | [provider.md](provider.md) | ✓ pushes frames to one or more MVs; `send` (one-shot) + `serve` (refresh loop) |
+| Operator runbook | [runbook.md](runbook.md) | ✓ quick-reference card |
+
+## Two roles, one direction
+
+```
+dhs consumer tsl-vNN listen [--bind HOST:PORT] [--tcp]    inbound  — MV receiver: decode + print tally frames
+dhs producer tsl-vNN send  --dest HOST:PORT [flags]       outbound — tally source: push one frame
+dhs producer tsl-vNN serve --dest HOST:PORT --refresh DUR outbound — tally source: push + re-emit on a loop
+```
+
+Unlike a Tree/DM connector (acp1, ember+) or a matrix connector (probel),
+the consumer never *queries* the producer — it can only listen for frames
+the producer chooses to send. The producer is the authoritative tally
+source; the consumer is a passive multiviewer-style sink.
+
+## Wire versions & default ports
+
+| Version | Transport | Default port | Tally model |
+|---|---|---|---|
+| v3.1 | UDP | 4000 | 4× binary tallies + 2-bit brightness; **no colour** |
+| v4.0 | UDP | 4004 (testbed; spec 4000) | v3.1 tallies + XDATA (L/R display × LH/Text/RH × 2-bit colour) |
+| v5.0 | UDP (≤2048 B) / TCP with DLE/STX wrapper | UDP 8901 (Kaleido); TCP 8902 (testbed; spec 8901) | LH/Text/RH (3× 2-bit colour) + 2-bit brightness, per DMSG; multi-DMSG groups |
+
+All ports are configurable (`--bind` on the consumer, `--dest` on the
+producer). The testbed port offsets (v4.0 → 4004, v5.0 TCP → 8902) exist
+because v3.1 owns UDP 4000 and v5.0 UDP owns 8901 on a single host; the
+spec uses 4000 / 8901 for both.
+
+## Spec documents
+
+| Document | Path | Description |
+|---|---|---|
+| TSL UMD protocol (PDF) | [tsl-umd-protocol.pdf](../assets/tsl-umd-protocol.pdf) | Spec PDF — authoritative |
+| Wireshark dissector | [dhs_tsl.lua](../wireshark/dhs_tsl.lua) | Byte-exact reference — decodes v3.1/v4.0 UDP + v5.0 UDP + v5.0 DLE/STX TCP |
+| Wire-format context | [CLAUDE.md](../CLAUDE.md) | Byte-exact wire spec + compliance events + quirks |
+
+## Replay fixtures
+
+Real wire bytes for every (version, transport) are committed at
+[`../testdata/fixtures/golden_frames.jsonl`](../testdata/fixtures/golden_frames.jsonl)
+— codec-generated, drift-guarded, never hand-edited. See
+[`../testdata/fixtures/README.md`](../testdata/fixtures/README.md).

--- a/internal/tsl/docs/consumer.md
+++ b/internal/tsl/docs/consumer.md
@@ -1,0 +1,192 @@
+# TSL UMD Connector — Consumer (multiviewer receiver)
+
+Consumer connector for TSL UMD v3.1 / v4.0 / v5.0. TSL is a **tally / UMD
+push protocol**: the consumer is a multiviewer-style *receiver* that binds a
+socket and decodes every frame a tally source (Lawo VSM, Miranda Kaleido,
+TallyArbiter, our own provider) pushes at it. It never queries the source —
+there is no request/reply.
+
+---
+
+## References
+
+| Document | Path | Description |
+|---|---|---|
+| Spec (authoritative) | [internal/tsl/assets/tsl-umd-protocol.pdf](../assets/tsl-umd-protocol.pdf) | TSL UMD spec PDF |
+| Wireshark dissector | [internal/tsl/wireshark/dhs_tsl.lua](../wireshark/dhs_tsl.lua) | Byte-exact reference (all 3 versions + UDP/TCP) |
+| Protocol reference | [internal/tsl/CLAUDE.md](../CLAUDE.md) | Wire format, compliance events, quirks |
+| Replay fixtures | [internal/tsl/testdata/fixtures/](../testdata/fixtures/) | golden_frames.jsonl — real wire bytes per (version, transport) |
+| Source code | [internal/tsl/consumer/](../consumer/) | Plugin implementation |
+| Integration tests | [internal/tsl/integration/](../integration/) | `//go:build integration` loopback round-trips |
+| Dispatcher | [cmd/dhs/cmd_tsl.go](../../../cmd/dhs/cmd_tsl.go) | `runTSLConsumer` / `runTSLListen` |
+
+---
+
+## Transport
+
+| Version | Transport | Default port | Description |
+|---|---|---|---|
+| v3.1 | UDP | 4000 | 18-byte datagram, one frame per datagram. No colour |
+| v4.0 | UDP | 4004 (testbed; spec 4000) | v3.1 frame + CHKSUM + VBC + XDATA |
+| v5.0 | UDP | 8901 (Kaleido) | PBC/VER/FLAGS/SCREEN + DMSG(s), ≤2048 B |
+| v5.0 | TCP | 8902 (testbed; spec 8901) | DLE/STX-wrapped, 0xFE byte-stuffing |
+
+### Firewall rules
+
+```
+UDP 4000  inbound    (v3.1, v4.0 spec port)
+UDP 8901  inbound    (v5.0 Kaleido)
+TCP 8902  inbound    (v5.0 DLE/STX)
+```
+
+### CLI transport selection
+
+```
+dhs consumer tsl-v31 listen --bind 0.0.0.0:4000          # v3.1 UDP
+dhs consumer tsl-v40 listen --bind 0.0.0.0:4004          # v4.0 UDP
+dhs consumer tsl-v50 listen --bind 0.0.0.0:8901          # v5.0 UDP
+dhs consumer tsl-v50 listen --bind 0.0.0.0:8902 --tcp    # v5.0 TCP (DLE/STX)
+```
+
+`--tcp` is rejected on v3.1/v4.0 (off-spec). Real guard:
+
+```
+$ dhs consumer tsl-v31 listen --tcp
+error: consumer tsl-v31: --tcp is only supported for tsl-v50
+```
+
+---
+
+## Capabilities & Compliance Status
+
+| Capability | Status | Notes |
+|---|---|---|
+| v3.1 UDP decode (18-byte frame) | ✅ fully compliant | HEADER/CTRL/DATA; 4 binary tallies + 2-bit brightness, no colour |
+| v4.0 UDP decode (v3.1 + CHKSUM + VBC + XDATA) | ✅ fully compliant | 2's-complement checksum verified; 2-byte XDATA → L/R display × LH/Text/RH colour |
+| v5.0 UDP decode (PBC/VER/FLAGS/SCREEN + DMSG+) | ✅ fully compliant | single + multi-DMSG; little-endian fields |
+| v5.0 TCP decode (DLE/STX wrapper) | ✅ fully compliant | 0xFE byte-unstuffing; SO_KEEPALIVE 30 s dead-socket detect |
+| UTF-16LE labels (FLAGS bit 0) | ✅ fully compliant | transcoded to UTF-8 for display; fires `tsl_charset_transcode` |
+| Broadcast (SCREEN / INDEX = 0xFFFF) | ✅ fully compliant | decoded; fires `tsl_broadcast_received` |
+| Compliance event absorption | ✅ fully compliant | reserved bits / checksum / version mismatch absorbed + fired, never silently patched |
+| Multi-source arbitration | ⛔ not applicable | TSL has no client identity; last frame wins per display — an app/deployment concern |
+| get / set / walk / export / import | ⛔ not applicable | push protocol — no request/reply, no addressable object tree |
+| `ensure` idempotent converge | ⛔ not applicable | no read-back to converge against |
+| v3.1/v4.0 over TCP | ⛔ out of scope | spec silent; TallyArbiter ships raw 18-byte chunks off-spec |
+
+Legend: ✅ fully compliant · ⛔ not applicable / out of scope.
+
+---
+
+## Timeouts
+
+TSL consumer is a passive listener — there are **no request/reply timeouts**
+(nothing is sent, so nothing can time out waiting for a reply). The only
+timer is the v5.0 TCP keep-alive:
+
+| Timer | Default | Where | Override |
+|---|---|---|---|
+| v5.0 TCP SO_KEEPALIVE period | 30 s | `--keepalive DUR` (TCP only) | `--keepalive 15s` |
+| UDP receive | none (blocking listen until ctx cancel) | — | Ctrl-C / ctx |
+
+The TSL v5 spec defines no app-layer heartbeat — a pcap audit confirmed VSM
+never sends one — so OS-layer SO_KEEPALIVE is the correct dead-socket
+detector for the persistent TCP path.
+
+---
+
+## Compliance Profile
+
+Every wire tolerance gets a named counter; the consumer absorbs the
+deviation (keeps decoding) and fires the event rather than silently working
+around it. Catalogue from [`../CLAUDE.md`](../CLAUDE.md):
+
+| Event | Fires when |
+|---|---|
+| `tsl_reserved_bit_set` | v3.1 CTRL bit 6 or v5.0 CONTROL bits 8-14 set |
+| `tsl_version_mismatch` | v4.0 VBC minor version != 0 |
+| `tsl_checksum_fail` | v4.0 CHKSUM mismatch |
+| `tsl_control_data_undefined` | v4.0 CTRL.6=1 or v5.0 CONTROL bit 15 set |
+| `tsl_unknown_display_index` | DMSG arrives for an INDEX not modelled |
+| `tsl_broadcast_received` | v5.0 SCREEN=0xFFFF or INDEX=0xFFFF |
+| `tsl_charset_transcode` | UTF-16LE label transcoded to UTF-8 |
+| `tsl_label_length_mismatch` | v3.1 packet arrives with != 16 DATA bytes |
+| `tsl_v31_null_pad` | v3.1 frame received with 0x00 pad (non-spec, TallyArbiter) |
+| `tsl_v5_tcp_unwrapped` | v5.0 TCP frame received without DLE/STX wrapper |
+
+A clean frame (no deviation) carries no notes — the loopback integration
+test asserts exactly this (`len(f.Notes) != 0` ⇒ fail).
+
+---
+
+## Error Reference
+
+### Transport / bind layer
+
+| Name | When | Recovery |
+|---|---|---|
+| `listen udp HOST:PORT: ...` | UDP bind failed (port in use, bad addr) | free the port or pick another `--bind` |
+| `listen tcp HOST:PORT: ...` | v5.0 TCP bind/accept failed | same |
+
+### Usage / validation (client-side, pre-bind)
+
+| Name | When |
+|---|---|
+| `consumer tsl-v31: --tcp is only supported for tsl-v50` | `--tcp` on v3.1/v4.0 |
+| `consumer <proto>: unknown verb %q (expected: listen)` | a verb other than `listen` |
+| `unknown TSL version %q` | proto not in {tsl-v31, tsl-v40, tsl-v50} |
+
+Wire-level deviations are **not errors** — they are absorbed and surfaced as
+compliance events (above), so a malformed-but-recoverable frame still
+decodes and the listener keeps running.
+
+---
+
+## Subscriptions (push frames)
+
+The consumer's entire job is a subscription: bind → decode → callback. The
+`listen` verb wires a `SubscribeV31` / `SubscribeV40` / `SubscribeV50`
+callback that prints each frame. There is no filter/selector on the wire —
+every frame the source pushes is delivered.
+
+Real v5.0 multi-DMSG decode (live loopback, three displays in one packet):
+
+```
+v5.0  remote=127.0.0.1:61443  screen=0  charset=ASCII  dmsgs=3
+      display=2  LH=red  Text=off  RH=off  brightness=full  UMD="PGM"
+      display=3  LH=off  Text=green  RH=off  brightness=full  UMD="PVW"
+      display=4  LH=off  Text=off  RH=amber  brightness=full  UMD="ISO"
+```
+
+---
+
+## Raw Capture
+
+There is no `--capture` flag wired on the TSL consumer today (unlike acp1's
+`--capture run.jsonl`). The committed
+[`../testdata/fixtures/golden_frames.jsonl`](../testdata/fixtures/golden_frames.jsonl)
+is the canonical real-bytes artifact — one JSON object per (version,
+transport):
+
+```json
+{"version":"v3.1","transport":"udp","description":"addr=7 tally1+tally4 brightness=full text=\"PGM LIVE\"","hex":"873950474d204c4956452020202020202020"}
+```
+
+To capture raw frames live, run a packet capture (tcpdump / Wireshark) and
+decode with the dissector (consumer.md → see verbs.md §10). Live vendor
+captures live LOCAL ONLY under `captures/tsl-vXX/<scenario>/` (gitignored,
+ADR-0021) and are promoted into `protocol_types/` fixtures by hand.
+
+---
+
+## Test Sources
+
+| Source | Role | Status |
+|---|---|---|
+| Our own provider (loopback) | in-process tally source for integration tests | ✅ all 3 versions, UDP + TCP |
+| Miranda TSL IP Emulator v1.02 | GVG Kaleido production harness — v5.0 UDP + TCP | live-validated 2026-04-26 (per CLAUDE.md testbed) |
+| Lawo VSM Studio | cross-vendor producer — v3.1 + v4.0 + v5.0 | live-validated 2026-04-26 |
+| TallyArbiter | OSS decoder cross-check (reference only) | not authoritative |
+
+Loopback is the only CI-safe path today; external sources are reached over
+VPN to the lab network and are not yet wired into the Go integration body
+(see [`../../../ansible/playbooks/tsl-integration.yml`](../../../ansible/playbooks/tsl-integration.yml)).

--- a/internal/tsl/docs/provider.md
+++ b/internal/tsl/docs/provider.md
@@ -1,0 +1,148 @@
+# TSL UMD Provider (tally / UMD source)
+
+> **Status: shipping**
+>
+> The TSL provider IS the tally source — the VSM/Kaleido-equivalent that
+> *pushes* tally + UMD frames at one or more multiviewers. Symmetric to the
+> consumer at [internal/tsl/consumer/](../consumer/); both sides share the
+> stdlib-only codec at [internal/tsl/codec/](../codec/).
+>
+> CLI: `dhs producer tsl-vNN send|serve --dest HOST:PORT [version flags]`.
+> See [runbook.md](runbook.md) for the operator workflow and [verbs.md](verbs.md)
+> for the full flag reference with real captures.
+
+---
+
+## Role
+
+Unlike a Tree/DM provider (acp1 serves a queryable canonical tree) or a
+matrix provider (probel answers crosspoint interrogations), the TSL provider
+is **fire-and-forget push**. It encodes one frame from its flags and sends
+it to every `--dest`; `serve` re-emits the same frame on a `--refresh` loop.
+There is no inbound request to answer, no tree to host, no state the
+consumer can read back.
+
+---
+
+## Verbs
+
+| Verb | What it does | Required flags |
+|---|---|---|
+| `send` | encode one frame from the flags and push **once** to every `--dest` | `--dest` (UDP); `--dest --tcp` (v5.0 TCP) |
+| `serve` | encode + push, then re-emit every `--refresh DURATION` until Ctrl-C | `--dest`, `--refresh` |
+
+Both build the frame identically; `serve` just adds the refresh ticker. With
+`--refresh 0` (the default), `serve` behaves like `send` (emit once, return).
+
+Real `send` confirmation (stderr):
+
+```
+$ dhs producer tsl-v31 send --dest 127.0.0.1:14000 --addr 7 --tally1 --tally4 --brightness 3 --text "PGM LIVE"
+tsl-v31 send emitted to 1 destination(s)
+```
+
+Real `serve` (refresh loop, stderr — one emit line, then re-emits silently
+every tick until Ctrl-C):
+
+```
+$ dhs producer tsl-v31 serve --dest 127.0.0.1:14000 --refresh 500ms --addr 3 --tally1 --text "REFRESH"
+tsl-v31 serve emitted to 1 destination(s)
+```
+
+---
+
+## Frame-build flags per version
+
+### v3.1 / v4.0 (binary tallies + address)
+
+| Flag | Meaning |
+|---|---|
+| `--addr N` | display address 0..126 |
+| `--tally1..4` | binary tally bits (CTRL bits 0-3) |
+| `--brightness 0..3` | 0=off 1=1/7 2=1/2 3=full |
+| `--text "STR"` | UMD label (≤16 ASCII; space-padded to 16) |
+| `--text-pad spaces` | DATA padding — spec is spaces; `nul` is rejected on tx (rx-tolerated only) |
+
+### v4.0 extra (XDATA colour)
+
+| Flag | Meaning |
+|---|---|
+| `--display-left lh:text:rh` | XDATA Xbyte L (off\|red\|green\|amber) |
+| `--display-right lh:text:rh` | XDATA Xbyte R |
+
+### v5.0 (DMSG colour + screen)
+
+| Flag | Meaning |
+|---|---|
+| `--screen N` | screen 0..65534 |
+| `--broadcast` | override screen with 0xFFFF (all screens) |
+| `--index N` | display index 0..65534 |
+| `--lh / --text-tally / --rh` | per-position colour (off\|red\|green\|amber) |
+| `--utf16` | encode TEXT as UTF-16LE (FLAGS bit 0) |
+| `--text "STR"` | UMD label |
+| `--dmsg "index=N,lh=...,text-tally=...,rh=...,brightness=N,umd=STR"` | repeatable composite DMSG; **overrides** the singular flags |
+| `--tcp` | push via TCP DLE/STX wrapper instead of UDP |
+| `--keepalive DUR` | TCP SO_KEEPALIVE period (default 30 s; `--tcp` only) |
+
+`--dmsg` is the v5.0 multi-display path (Miranda "Group display messages") —
+one packet carries N DMSGs. Real 3-DMSG capture is in [verbs.md](verbs.md) §8.
+
+---
+
+## Destinations & fan-out
+
+`--dest HOST:PORT` is **repeatable** — one `send`/`serve` pushes an identical
+frame to every destination. The producer binds a local UDP egress
+(`--bind`, default `0.0.0.0:0` ephemeral) once and reuses it for all UDP
+destinations. v5.0 TCP dials each `--dest` per emit.
+
+```
+# one source → three multiviewers, refreshed every second
+dhs producer tsl-v50 serve --dest mv-1:8901 --dest mv-2:8901 --dest mv-3:8901 \
+  --refresh 1s --screen 0 --index 2 --lh red --text "PGM"
+```
+
+For UDP, at least one `--dest` is required (real guard):
+
+```
+$ dhs producer tsl-v40 send
+error: producer tsl-v40 send: at least one --dest is required for UDP
+```
+
+---
+
+## Validation (client-side, pre-send)
+
+The producer validates every flag before encoding — bad input fails fast
+with exit code != 0 and a stderr message, nothing is sent. Real captures:
+
+```
+$ dhs producer tsl-v31 send --dest 127.0.0.1:14000 --addr 1 --text-pad nul
+error: --text-pad nul is reserved for off-spec emission and is not allowed on tx (spec is spaces); rx tolerates and fires tsl_v31_null_pad
+
+$ dhs producer tsl-v50 send --dest 127.0.0.1:18901 --dmsg "lh=red"
+error: --dmsg #1 "lh=red": missing index=N
+```
+
+Ranges: `--addr 0..126`, `--screen 0..65534`, `--index 0..65534`,
+`--brightness 0..3`, tally colours `off|red|green|amber`. Out-of-range
+values are rejected pre-send (e.g. `--brightness 5` → out of range 0..3).
+
+---
+
+## Spec-conformant emission (what the provider will NOT do)
+
+- **Never** pads v3.1 DATA with 0x00 — space-pad (0x20) per spec. `--text-pad nul` is refused on tx.
+- **Never** clears the wrong CTRL bits — brightness is CTRL bits 4-5 (not 5-6, the TallyArbiter bug).
+- **Never** emits v5.0 over TCP without the DLE/STX wrapper — `--tcp` always wraps and byte-stuffs 0xFE.
+- v3.1/v4.0 over TCP is not offered at all (off-spec).
+
+---
+
+## Pointers
+
+- Full flag reference + real captures: [verbs.md](verbs.md)
+- Operator runbook: [runbook.md](runbook.md)
+- Wire format (byte-exact): [../CLAUDE.md](../CLAUDE.md)
+- Dispatcher: [cmd/dhs/cmd_tsl_producer.go](../../../cmd/dhs/cmd_tsl_producer.go)
+- Source: [internal/tsl/provider/](../provider/) · codec [internal/tsl/codec/](../codec/)

--- a/internal/tsl/docs/runbook.md
+++ b/internal/tsl/docs/runbook.md
@@ -1,0 +1,118 @@
+# TSL UMD — operational runbook
+
+Quick-reference card for operators. For wire-format detail see
+[CLAUDE.md](../CLAUDE.md); for deep consumer/producer behaviour see
+[consumer.md](consumer.md) / [provider.md](provider.md); for the full verb
+reference with real captures see [verbs.md](verbs.md).
+
+TSL is a **push protocol**: a tally source (producer) pushes tally + UMD
+state at multiviewer listeners (consumers). No request/reply, no tree, no
+matrix.
+
+---
+
+## Transport matrix
+
+| Version | Transport | Default port | Notes |
+|---|---:|---|
+| v3.1 | UDP | 4000 | 18-byte frame. 4 binary tallies + brightness. No colour. |
+| v4.0 | UDP | 4004 (spec 4000) | v3.1 + CHKSUM + VBC + XDATA colour (L/R display). |
+| v5.0 | UDP | 8901 | PBC/VER/FLAGS/SCREEN + DMSG(s). ≤2048 B. Kaleido default. |
+| v5.0 | TCP | 8902 (spec 8901) | DLE/STX wrapper + 0xFE byte-stuffing. Use `--tcp`. |
+
+Testbed port offsets (v4.0→4004, v5.0 TCP→8902) exist only so all versions
+coexist on one host; the spec uses 4000 / 8901.
+
+## Verb reference
+
+### Consumer (multiviewer receiver)
+
+| Verb | What it does | Common flags |
+|---|---|---|
+| `dhs consumer tsl-v31 listen` | bind UDP, decode + print every v3.1 frame | `--bind HOST:PORT` |
+| `dhs consumer tsl-v40 listen` | same, v4.0 | `--bind HOST:PORT` |
+| `dhs consumer tsl-v50 listen` | same, v5.0 UDP (or TCP with `--tcp`) | `--bind HOST:PORT`, `--tcp`, `--keepalive DUR` |
+
+There is no `info` / `walk` / `get` / `set` / `export` (push protocol — see
+verbs.md §4-§7, §9 for the N/A rationale). `listen` is the only consumer verb.
+
+### Producer (tally source)
+
+| Verb | What it does | Required flags |
+|---|---|---|
+| `dhs producer tsl-vNN send --dest HOST:PORT [flags]` | encode one frame, push once | `--dest` (UDP) |
+| `dhs producer tsl-vNN serve --dest HOST:PORT --refresh DUR [flags]` | push + re-emit every DUR | `--dest`, `--refresh` |
+
+`--dest` is repeatable (fan-out to many MVs). `--tcp` is v5.0 only.
+
+## Common flows
+
+### Bring up a v3.1 tally feed to a multiviewer
+
+```
+# MV side (listener):
+dhs consumer tsl-v31 listen --bind 0.0.0.0:4000
+
+# tally-source side:
+dhs producer tsl-v31 serve --dest 10.0.0.5:4000 --refresh 1s --addr 7 --tally1 --text "PGM LIVE"
+```
+
+Real decoded frame on the MV side (loopback proof):
+
+```
+v3.1  remote=127.0.0.1:52223  addr=7  T1=ON T2=off T3=off T4=ON  brightness=full  UMD="PGM LIVE        "
+```
+
+### v5.0 Kaleido feed with a multi-display group
+
+```
+dhs producer tsl-v50 serve --dest kaleido:8901 --refresh 1s --screen 0 \
+  --dmsg "index=2,lh=red,umd=PGM" \
+  --dmsg "index=3,text-tally=green,umd=PVW" \
+  --dmsg "index=4,rh=amber,umd=ISO"
+```
+
+### v5.0 over TCP (DLE/STX) to a routable MV
+
+```
+dhs consumer tsl-v50 listen --bind 0.0.0.0:8902 --tcp
+dhs producer tsl-v50 send  --dest 10.0.0.5:8902 --tcp --screen 0 --index 2 --rh amber --text "ISO 2"
+```
+
+### Local loopback smoke test (no external gear)
+
+```
+# terminal 1:
+dhs consumer tsl-v50 listen --bind 127.0.0.1:18901
+# terminal 2:
+dhs producer tsl-v50 send --dest 127.0.0.1:18901 --screen 1 --index 11 --lh red --text-tally green --rh amber --text "CAM 1"
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `listen` shows nothing | no source pushing, wrong port, or firewall blocking UDP | confirm the producer's `--dest` matches the consumer's `--bind` port |
+| `--tcp` rejected on v3.1/v4.0 | TCP is v5.0-only (off-spec for v3.1/v4.0) | drop `--tcp`, or use v5.0 |
+| `at least one --dest is required` | producer run with no `--dest` (UDP) | add `--dest HOST:PORT` |
+| `--text-pad nul ... not allowed on tx` | tried off-spec NUL padding | use `--text-pad spaces` (the default) |
+| v4.0 consumer logs `tsl_checksum_fail` | source emitted a bad 2's-complement checksum | source bug — the frame is still absorbed + decoded |
+| UTF-16 label shows mojibake on a v5 consumer that expected ASCII | source set FLAGS bit 0 | the consumer transcodes automatically + fires `tsl_charset_transcode`; check the source's charset flag |
+| v5.0 TCP socket goes silent, no error | dead peer; TSL has no app heartbeat | SO_KEEPALIVE (30 s) detects it; tune with `--keepalive` |
+
+## Idempotency note
+
+`serve --refresh` re-emits the **same** frame unconditionally — it is a
+keep-alive refresh, not an idempotent converge. TSL has no read-back, so
+there is no `ensure`-style "run twice = no-op" at the protocol level. The
+Ansible loopback integration is idempotent in the test sense (run-twice =
+same PASS, sockets torn down each run) — see verbs.md §11.
+
+## Pointers
+
+- Wire format: [CLAUDE.md](../CLAUDE.md)
+- Verb reference + real captures: [verbs.md](verbs.md)
+- Consumer deep-dive: [consumer.md](consumer.md) · Provider: [provider.md](provider.md)
+- Wireshark dissector: [../wireshark/dhs_tsl.lua](../wireshark/dhs_tsl.lua)
+- Spec: [../assets/tsl-umd-protocol.pdf](../assets/tsl-umd-protocol.pdf)
+- Integration playbook: [../../../ansible/playbooks/tsl-integration.yml](../../../ansible/playbooks/tsl-integration.yml)

--- a/internal/tsl/docs/verbs.md
+++ b/internal/tsl/docs/verbs.md
@@ -1,0 +1,323 @@
+# TSL UMD — verbs & configuration reference
+
+Per-connector verb reference. Same 12-section order as the acp1 reference so
+the docs don't drift, **adapted for a tally/UMD push protocol** — sections
+that assume an addressable object model (get/set/inc/dec/reset by OID, walk
+a tree, matrix crosspoints, idempotent converge) are marked **N/A** with the
+reason, because TSL has no request/reply and no queryable state.
+
+All samples below are **real captures** from a producer→consumer loopback run
+on this host (Windows / PowerShell), captured 2026-06-18 with a binary built
+`go build -o dhs_tsl.exe ./cmd/dhs`, on unique loopback ports (v3.1 UDP 14000,
+v4.0 UDP 14004, v5.0 UDP 18901, v5.0 TCP 18902). Wire **hex** bytes are quoted
+from the committed, codec-generated
+[`../testdata/fixtures/golden_frames.jsonl`](../testdata/fixtures/golden_frames.jsonl)
+(clearly attributed) — never hand-written. Wire format lives in
+[`../CLAUDE.md`](../CLAUDE.md).
+
+Verbs: consumer `listen`; producer `send`, `serve`. (No get/set/walk —
+push protocol; see §4–§5, §9.)
+
+---
+
+## 1. Transport configs
+
+TSL is push-only; the consumer binds a listener and the producer dials a
+destination. Per version:
+
+| Version | Transport | Default port | Consumer flag | Producer flag |
+|---|---|---|---|---|
+| v3.1 | UDP | 4000 | `--bind HOST:PORT` | `--dest HOST:PORT` |
+| v4.0 | UDP | 4004 (testbed; spec 4000) | `--bind HOST:PORT` | `--dest HOST:PORT` |
+| v5.0 | UDP (≤2048 B) | 8901 | `--bind HOST:PORT` | `--dest HOST:PORT` |
+| v5.0 | TCP (DLE/STX wrapper) | 8902 (testbed; spec 8901) | `--bind HOST:PORT --tcp` | `--dest HOST:PORT --tcp` |
+
+`--tcp` is **v5.0 only** — v3.1/v4.0 over TCP is off-spec (see
+[`../CLAUDE.md`](../CLAUDE.md) "Out of scope"). Real validation of that
+guard:
+
+```
+$ dhs consumer tsl-v31 listen --tcp
+error: consumer tsl-v31: --tcp is only supported for tsl-v50
+```
+
+```
+# UDP listener / sender (default)
+dhs consumer tsl-v50 listen --bind 0.0.0.0:8901
+dhs producer tsl-v50 send  --dest 10.0.0.5:8901 --screen 0 --index 2 --lh red --text "PGM"
+
+# v5.0 TCP with DLE/STX wrapper
+dhs consumer tsl-v50 listen --bind 0.0.0.0:8902 --tcp
+dhs producer tsl-v50 send  --dest 10.0.0.5:8902 --tcp --screen 0 --index 2 --rh amber
+```
+
+The producer takes a **repeatable** `--dest` (push to several MVs at once)
+and an optional `--bind` for the local egress source (default `0.0.0.0:0`
+= ephemeral). For UDP at least one `--dest` is required:
+
+```
+$ dhs producer tsl-v40 send
+error: producer tsl-v40 send: at least one --dest is required for UDP
+```
+
+## 2. Controllers & redundancy
+
+**Default = one tally source pushing to one or more multiviewers.** TSL has
+no client identity on the wire and no session — redundancy is an
+**app/deployment** concern, not a protocol one:
+
+- **Single source (default):** one producer ↔ one or more MV listeners
+  (`--dest` repeatable).
+- **Redundant sources:** run **2+ producer instances** (e.g. main + backup
+  switcher), each pushing the same frames; the MV listener consumes whatever
+  arrives. There is no arbitration on the wire — last frame wins per display.
+- **Fan-out:** one producer, many `--dest` — every MV gets an identical copy.
+
+```
+# one source → three multiviewers
+dhs producer tsl-v50 serve --dest mv-1:8901 --dest mv-2:8901 --dest mv-3:8901 --refresh 1s \
+  --screen 0 --index 2 --lh red --text "PGM"
+```
+
+UDP push is connectionless: a producer that loses its MV silently keeps
+sending. v5.0 TCP adds OS-layer SO_KEEPALIVE (30 s, both ends) to detect a
+dead socket — TSL v5 defines no app-layer heartbeat.
+
+## 3. Logging & severity
+
+Logs go to **stderr**, decoded frames to **stdout** (so `2>` captures logs,
+`1>` captures the decode). Both sides log via `log/slog` at info level by
+default. There is no per-invocation `--log-level` flag wired for TSL today
+(unlike acp1) — severity is fixed at info; this is the one logging knob the
+TSL CLI does **not** expose yet.
+
+```
+dhs consumer tsl-v50 listen --bind 0.0.0.0:8901 1>frames.txt 2>run.log   # frames→file, logs→file
+```
+
+## 4. info / walk
+
+**N/A — push protocol.** TSL has no device-info request and no object tree to
+walk: the consumer cannot query the producer, it can only listen for pushed
+frames. The closest equivalent is `listen` (§8): every frame the producer
+sends is decoded and printed with full field labels. There is no `info` or
+`walk` verb.
+
+## 5. get / set / inc / dec / reset
+
+**N/A — push protocol.** TSL has no addressable objects and no
+request/reply, so there is nothing to `get`, `set`, `inc`, `dec`, or
+`reset`. The producer *encodes* tally/UMD state from flags and pushes it;
+the consumer *decodes* it. State is expressed by the producer's `send` flags
+(`--tally1..4`, `--lh/--text-tally/--rh`, `--brightness`, `--text`,
+`--display-left/--display-right`), documented in §8.
+
+## 6. export / import
+
+**N/A — push protocol.** There is no walked tree or device snapshot to
+export to json/yaml/csv, and nothing to import back. The replay analog of an
+export is the committed
+[`../testdata/fixtures/golden_frames.jsonl`](../testdata/fixtures/golden_frames.jsonl)
+— the exact on-wire bytes per (version, transport), codec-generated. Quoted
+real bytes (v3.1, UDP, from the committed golden fixture):
+
+```json
+{"version":"v3.1","transport":"udp","description":"addr=7 tally1+tally4 brightness=full text=\"PGM LIVE\"","hex":"873950474d204c4956452020202020202020"}
+```
+
+Decoding `87 39 50474d204c495645 2020202020202020`: HEADER `0x87` = addr 7
+(`0x80 | 7`), CTRL `0x39` = tally1+tally4 + brightness full (bits
+0,3,4,5), DATA = `"PGM LIVE"` space-padded to 16. This is exactly what the
+live `listen` capture decoded in §8.
+
+## 7. reports — tree ASCII & PlantUML mindmap
+
+**N/A — push protocol.** A TSL frame is flat (a handful of tally bits + one
+label, or a list of DMSGs) — there is no hierarchy to render as an ASCII
+tree or PlantUML mindmap. The `listen` output (§8) already prints every
+field per frame.
+
+## 8. listen — the decode verb (consumer)
+
+`listen` binds a UDP (or v5.0 TCP) socket and prints every decoded frame
+until Ctrl-C. This is the consumer's only verb.
+
+### v3.1 — 4 binary tallies + brightness, no colour
+
+Live loopback capture (producer drove addr 7, tally1+tally4, full
+brightness, `"PGM LIVE"` to UDP 14000):
+
+```
+$ dhs consumer tsl-v31 listen --bind 127.0.0.1:14000
+tsl-v31 consumer listening on udp://127.0.0.1:14000 (Ctrl-C to stop)
+v3.1  remote=127.0.0.1:52223  addr=7  T1=ON T2=off T3=off T4=ON  brightness=full  UMD="PGM LIVE        "
+```
+```
+# producer that drove it:
+dhs producer tsl-v31 send --dest 127.0.0.1:14000 --addr 7 --tally1 --tally4 --brightness 3 --text "PGM LIVE"
+```
+
+The decoded line matches the committed golden frame hex
+`873950474d204c4956452020202020202020` (§6) byte-for-byte — the doc is real.
+
+### v4.0 — v3.1 tallies + XDATA (L/R display × LH/Text/RH colour)
+
+Live loopback capture (UDP 14004):
+
+```
+$ dhs consumer tsl-v40 listen --bind 127.0.0.1:14004
+tsl-v40 consumer listening on udp://127.0.0.1:14004 (Ctrl-C to stop)
+v4.0  remote=127.0.0.1:49309  addr=11  T1=off T2=off T3=off T4=off  brightness=full  UMD="CAM 1 ISO       "
+      DisplayL  LH=red Text=green RH=amber
+      DisplayR  LH=green Text=red RH=off
+```
+```
+dhs producer tsl-v40 send --dest 127.0.0.1:14004 --addr 11 --text "CAM 1 ISO" --brightness 3 \
+  --display-left red:green:amber --display-right green:red:off
+```
+
+Matches committed golden frame `8b3543414d20312049534f...33021b24` (addr 11,
+displayL red/green/amber, displayR green/red/off, `"CAM 1 ISO"`).
+
+### v5.0 — single-DMSG (LH/Text/RH colour + brightness, per display)
+
+Live loopback capture (UDP 18901):
+
+```
+$ dhs consumer tsl-v50 listen --bind 127.0.0.1:18901
+tsl-v50 consumer listening on udp://127.0.0.1:18901 (Ctrl-C to stop)
+v5.0  remote=127.0.0.1:59614  screen=1  charset=ASCII  dmsgs=1
+      display=11  LH=red  Text=green  RH=amber  brightness=full  UMD="CAM 1"
+```
+```
+dhs producer tsl-v50 send --dest 127.0.0.1:18901 --screen 1 --index 11 \
+  --lh red --text-tally green --rh amber --text "CAM 1"
+```
+
+Matches committed golden frame `0f00000001000b00db00050043414d2031`
+(PBC=15, ver 0, flags 0, screen 1, DMSG index 11, CONTROL `0x00db`,
+len 5, `"CAM 1"`).
+
+### v5.0 — multi-DMSG group (Miranda "Group display messages")
+
+Live loopback capture — one packet, three DMSGs:
+
+```
+v5.0  remote=127.0.0.1:61443  screen=0  charset=ASCII  dmsgs=3
+      display=2  LH=red  Text=off  RH=off  brightness=full  UMD="PGM"
+      display=3  LH=off  Text=green  RH=off  brightness=full  UMD="PVW"
+      display=4  LH=off  Text=off  RH=amber  brightness=full  UMD="ISO"
+```
+```
+dhs producer tsl-v50 send --dest 127.0.0.1:18901 --screen 0 \
+  --dmsg "index=2,lh=red,rh=off,brightness=3,umd=PGM" \
+  --dmsg "index=3,text-tally=green,umd=PVW" \
+  --dmsg "index=4,rh=amber,umd=ISO"
+```
+
+`--dmsg` is repeatable and **overrides** the singular `--index/--lh/...`
+flags when present.
+
+### v5.0 — UTF-16LE label + broadcast screen
+
+Live loopback captures showing the `charset=UTF-16LE` flag (FLAGS bit 0) and
+the broadcast `screen=65535` (0xFFFF):
+
+```
+v5.0  remote=127.0.0.1:63281  screen=0  charset=UTF-16LE  dmsgs=1
+      display=5  LH=red  Text=off  RH=off  brightness=full  UMD="CAMERA"
+v5.0  remote=127.0.0.1:63282  screen=65535  charset=ASCII  dmsgs=1
+      display=0  LH=off  Text=off  RH=green  brightness=full  UMD="ALL"
+```
+```
+dhs producer tsl-v50 send --dest 127.0.0.1:18901 --screen 0 --utf16 --index 5 --lh red --text "CAMERA"
+dhs producer tsl-v50 send --dest 127.0.0.1:18901 --broadcast --index 0 --rh green --text "ALL"
+```
+
+### v5.0 — TCP with DLE/STX wrapper
+
+Live loopback capture (TCP 18902):
+
+```
+$ dhs consumer tsl-v50 listen --bind 127.0.0.1:18902 --tcp
+tsl-v50 consumer listening on tcp://127.0.0.1:18902 (Ctrl-C to stop)
+v5.0  remote=127.0.0.1:51532  screen=0  charset=ASCII  dmsgs=1
+      display=2  LH=off  Text=off  RH=amber  brightness=full  UMD="ISO 2"
+```
+```
+dhs producer tsl-v50 send --dest 127.0.0.1:18902 --tcp --screen 0 --index 2 --rh amber --text "ISO 2"
+```
+
+The committed golden TCP frame
+`fe020f000000fefefefe01fefed00005005354554646` (from the fixture)
+exercises the harder wire detail: `FE 02` DLE/STX opener, SCREEN `0xFEFE`
+byte-stuffed to `FE FE FE FE`, INDEX `0xFE01` → `FE FE 01`.
+
+## 9. ensure() — idempotent converge
+
+**N/A — push protocol.** `ensure` (ADR-0007) converges an addressable
+object to a target value and reports whether it changed — TSL has no
+addressable object and no read-back, so there is nothing to converge or
+diff against. The producer's `serve --refresh` re-emits the *same* frame
+on a loop (a keep-alive refresh, not a converge); it is unconditional, not
+idempotent-by-comparison. See §8 (serve) and the runbook.
+
+## 10. Wireshark
+
+Dissector: [`../wireshark/dhs_tsl.lua`](../wireshark/dhs_tsl.lua) — decodes
+v3.1 / v4.0 over UDP, v5.0 over UDP, and v5.0 over TCP (DLE/STX wrapper +
+0xFE byte-unstuffing), with a per-frame Info column and an expert warning on
+reserved-bit / unknown-version deviations.
+
+| OS | Plugin dir |
+|---|---|
+| Windows | `%APPDATA%\Wireshark\plugins\` |
+| macOS / Linux | `~/.local/lib/wireshark/plugins/` |
+
+Default ports decoded (overridable in the dissector preferences):
+v3.1 UDP 4000, v4.0 UDP 4004, v5.0 UDP 8901, v5.0 TCP 8902.
+
+```
+# copy the dissector, then filter on the dhs proto:
+#   display filter:  dhs_tsl
+#   port decode:     udp.port in {4000 4004 8901} || tcp.port == 8902
+tshark -r capture.pcapng -O dhs_tsl -Y dhs_tsl
+```
+
+## 11. Ansible (the exclusive integration / deploy driver — no .ps1)
+
+Integration is driven by Ansible:
+[`../../../ansible/playbooks/tsl-integration.yml`](../../../ansible/playbooks/tsl-integration.yml).
+Because TSL is push-only and the Go integration body
+([`../integration/`](../integration/)) is **loopback-only** today (our own
+provider pushes to our own consumer in-process across all three versions),
+the play has two tiers:
+
+1. **Loopback (always):** runs `go test -tags integration ./internal/tsl/integration/`
+   — provider+consumer round-trip for v3.1/v4.0/v5.0 plus the codec
+   golden-frame drift-guard. `changed_when: false` ⇒ run-twice = same
+   result (ADR-0025 idempotency).
+2. **External (gated on `TSL_TEST_HOST`):** **skipped by design** today —
+   the Go tests have no external dial path, so the play only prints a
+   "not yet supported" notice when `TSL_TEST_HOST` is set, rather than
+   silently re-running loopback. The upgrade path (Miranda IP Emulator /
+   Lawo VSM on the lab network) is documented inline in the playbook.
+
+```
+# loopback only (the supported path):
+ansible-playbook -i inventory/hosts.ini playbooks/tsl-integration.yml
+
+# with TSL_TEST_HOST set — prints the not-yet-supported notice:
+TSL_TEST_HOST=10.100.0.42 ansible-playbook -i inventory/hosts.ini playbooks/tsl-integration.yml
+```
+
+dhs / go-test logs go to **stderr** → the play `register`s the task and
+surfaces `stdout_lines + stderr_lines` via `debug` so a failing run shows
+the test output inline under `ansible-playbook -v`.
+
+## 12. See also
+
+- [`../CLAUDE.md`](../CLAUDE.md) — wire format (byte-exact), compliance events, quirks
+- [`./README.md`](./README.md) · [`./consumer.md`](./consumer.md) · [`./provider.md`](./provider.md) · [`./runbook.md`](./runbook.md)
+- [`../testdata/fixtures/golden_frames.jsonl`](../testdata/fixtures/golden_frames.jsonl) — real wire bytes per (version, transport)
+- [`../../../docs/adr/0025-per-connector-definition-of-done.md`](../../../docs/adr/0025-per-connector-definition-of-done.md)


### PR DESCRIPTION
Completes tsl to ADR-0025 6/6 (docs deliverable). Mirrors the acp1 docs structure (README/consumer/provider/runbook + 12-section verbs.md), adapted for a tally/UMD PUSH protocol: object-model sections (get/set/inc/dec/reset, walk, matrix, export, ensure) are marked N/A with the protocol reason, not invented. Samples are real: producer to consumer loopback decodes captured live (v3.1/v4.0/v5.0 UDP + v5.0 TCP) plus wire hex quoted from the committed codec-generated golden_frames.jsonl (attributed inline) — the live v3.1 decode matches golden hex byte-for-byte. External vendor sources (Miranda, Lawo VSM) noted as lab/VPN-gated, not faked. Co-Authored-By Claude Opus 4.8.