### PR TITLE
docs(osc): full ADR-0025 docs set (message/push protocol)

### DIFF
--- a/internal/osc/docs/README.md
+++ b/internal/osc/docs/README.md
@@ -1,0 +1,50 @@
+# OSC — Open Sound Control 1.0 + 1.1
+
+OSC is a **message / push** protocol, not a Tree/DM or matrix connector. Any
+peer may send to any peer; there is no client/server handshake, no device tree
+to walk, and no addressable object catalogue. The dhs docs set is therefore
+adapted: the verbs are `watch` (consumer) and `send` / `fader` / `serve`
+(producer), and the Tree/DM-only sections (`get`/`set`/`inc`/`dec`/`reset` by
+OID, matrix crosspoints, tree walk, export/import) are marked **N/A** with the
+reason throughout.
+
+| Role | Doc | Status |
+|---|---|---|
+| **Verbs & config reference** | [verbs.md](verbs.md) | every verb + transport/pattern/wireshark/ansible/fixtures, with real captured samples |
+| Operator runbook | [runbook.md](runbook.md) | ✓ shipping |
+| Consumer | [consumer.md](consumer.md) | ✓ shipping — `watch` listener/monitor over UDP / TCP-LP / TCP-SLIP |
+| Provider | [provider.md](provider.md) | ✓ shipping — `send` / `fader` / `serve` push sender |
+
+## Registry entries (Pattern A — one entry per wire-incompatible version)
+
+| Registry name | Wire version | Transport surface |
+|---|---|---|
+| `osc-v10` | OSC 1.0 | UDP (primary) + TCP int32 length-prefix (`tcp-len`) |
+| `osc-v11` | OSC 1.1 | UDP + TCP SLIP (`tcp-slip`, RFC 1055 double-END); adds `T`/`F`/`N`/`I` + `[`/`]` array markers |
+
+Registration: `consumer.Register(&Factory{version: V10})` + `V11` in
+[`../consumer/plugin.go`](../consumer/plugin.go); the symmetric provider in
+[`../provider/`](../provider/). Default port is **8000** (common OSC
+convention — no port is officially mandated).
+
+## Spec documents
+
+| Document | Link | Description |
+|---|---|---|
+| OSC 1.0 spec | <https://opensoundcontrol.org/spec-1_0.html> | Authoritative 1.0 spec (CNMAT, UC Berkeley) |
+| OSC 1.1 spec | <https://opensoundcontrol.org/spec-1_1.html> | OSC 1.1 paper (community-accepted) |
+| Page index | <https://opensoundcontrol.org/page-list.html> | Index of all spec pages |
+| Wire format (this repo) | [../CLAUDE.md](../CLAUDE.md) | Byte-exact wire spec + quirks |
+| Wireshark dissector | [../wireshark/dhs_osc.lua](../wireshark/dhs_osc.lua) | Byte-exact reference — `Proto("dhs_osc", ...)`, filter `dhs_osc` |
+| Replay fixtures | [../testdata/fixtures/README.md](../testdata/fixtures/README.md) | Golden codec-produced `*.bin` packets |
+
+> **Citation rule.** Cite OSC from **opensoundcontrol.org** (the
+> CNMAT (UC Berkeley) home of Open Sound Control). Do **not** cite `osc.org` —
+> that is the Orlando Science Center, unrelated to Open Sound Control.
+
+## Definition of done
+
+This docs set is ADR-0025 deliverable 9 for OSC. See
+[`../../../docs/adr/0025-per-connector-definition-of-done.md`](../../../docs/adr/0025-per-connector-definition-of-done.md).
+</content>
+</invoke>

--- a/internal/osc/docs/consumer.md
+++ b/internal/osc/docs/consumer.md
@@ -1,0 +1,185 @@
+# OSC Consumer
+
+Consumer (listener / monitor) for Open Sound Control 1.0 + 1.1. OSC is a
+**message/push** protocol: the consumer binds a port and observes inbound
+packets — it does **not** dial a device, walk a tree, or read object values.
+The single verb is `watch`.
+
+---
+
+## References
+
+| Document | Path | Description |
+|---|---|---|
+| Spec (1.0, authoritative) | <https://opensoundcontrol.org/spec-1_0.html> | OSC 1.0 |
+| Spec (1.1) | <https://opensoundcontrol.org/spec-1_1.html> | OSC 1.1 additions |
+| Wire format | [../CLAUDE.md](../CLAUDE.md) | Byte-exact wire spec + quirks |
+| Wireshark dissector | [../wireshark/dhs_osc.lua](../wireshark/dhs_osc.lua) | Byte-exact reference (filter `dhs_osc`) |
+| Fixtures | [../testdata/fixtures/](../testdata/fixtures/) | Golden codec-produced `*.bin` packets |
+| Source | [../consumer/](../consumer/) | `package osc` — `Plugin`, `NewPluginV10` / `NewPluginV11` |
+| CLI dispatcher | [../../../cmd/dhs/cmd_osc.go](../../../cmd/dhs/cmd_osc.go) | `watch` handler |
+
+> Cite **opensoundcontrol.org**, never `osc.org` (Orlando Science Center).
+
+---
+
+## Transport
+
+| Kind | `--listen` value | Default port | Version | Framing |
+|---|---|---|---|---|
+| UDP | `udp:8000` | 8000 | both | one datagram = one packet |
+| TCP length-prefix | `tcp-len:8000` | 8000 | osc-v10 only | int32 BE size + packet |
+| TCP SLIP | `tcp-slip:8001` | 8001 | osc-v11 only | RFC 1055 double-END |
+
+### Firewall rules
+
+```
+UDP 8000  inbound              (UDP listener — primary)
+TCP 8000  inbound              (osc-v10 length-prefix)
+TCP 8001  inbound              (osc-v11 SLIP)
+UDP 8000  inbound broadcast    (broadcast / subnet-broadcast sources; SO_REUSEADDR)
+```
+
+### CLI
+
+```
+dhs consumer osc-v10 watch --listen udp:8000
+dhs consumer osc-v10 watch --listen tcp-len:8000
+dhs consumer osc-v11 watch --listen tcp-slip:8001 --pattern "/{pgm,pvw}"
+```
+
+---
+
+## Capabilities & Compliance Status
+
+| Capability | Spec | Status | Notes |
+|---|---|---|---|
+| UDP listener (default 8000) | 1.0 §"Transport" | ✅ fully compliant | SO_REUSEADDR; multi-listener (best-effort on platforms without SO_REUSEPORT) |
+| TCP length-prefix decode (1.0) | 1.0 framing | ✅ fully compliant | int32 BE size prefix; `osc-v10` only |
+| TCP SLIP decode (1.1) | 1.1 SLIP / RFC 1055 | ✅ fully compliant | double-END; `osc-v11` only |
+| Core type tags `i f s b` | 1.0 §"Type Tags" | ✅ fully compliant | decoded + printed |
+| Extended tags `h d t S c r m` | 1.0 (commonly impl.) | ✅ fully compliant | int64/float64/timetag/symbol/char/RGBA/MIDI |
+| 1.1 payload-less `T F N I` | 1.1 | ✅ fully compliant | zero-byte args; captured live (`,iTFNI`) |
+| 1.1 array markers `[ ]` | 1.1 | ✅ fully compliant | nested-sequence tags; captured live (`,i[ii]`) |
+| Bundle decode (recursive) | 1.0 §"Bundle" | ✅ fully compliant | fans element messages to subscribers in order |
+| Address-pattern subscription (`* ? [] {}`) | 1.0 §"Address Pattern Matching" | ✅ fully compliant | `*` matches within one part, not across `/` (captured) |
+| Compliance note `osc_type_tag_unknown` | — (our extension) | ✅ wired | fired by codec on an unknown tag |
+| Remaining compliance catalogue | — | ⏳ defined, wired incrementally | catalogue in [../CLAUDE.md](../CLAUDE.md); only `osc_type_tag_unknown` is wired in the decode path today |
+| Device info / walk / get / set | — | ⛔ not applicable | OSC has no device-info reply and no walkable object tree |
+| Export / import / tree report | — | ⛔ not applicable | no tree/DM to serialize |
+
+Legend: ✅ fully compliant · ⏳ pending · ⛔ not applicable.
+
+---
+
+## Timeouts
+
+OSC `watch` is a **passive listener with no request/reply**, so there are no
+per-request retry or receive timeouts. The listener runs until `ctx` is
+cancelled (Ctrl-C):
+
+```
+... — Ctrl-C to stop
+```
+
+> **N/A — retry / MTID / receive-timeout.** No transaction model exists; nothing
+> to retry or de-duplicate. ACP1's `--timeout` / `MaxRetries` have no analogue.
+
+---
+
+## Compliance Profile
+
+OSC absorbs spec deviations and records a `ComplianceNote` (see
+[`../codec/errors.go`](../codec/errors.go) `ComplianceNote{Kind, Detail}`). The
+named catalogue lives in [../CLAUDE.md](../CLAUDE.md):
+
+| Event | Fires when |
+|---|---|
+| `osc_type_tag_unknown` | type tag outside the known set received **(wired today)** |
+| `osc_alignment_violation` | OSC-string / OSC-blob not 4-byte padded |
+| `osc_truncated_message` | body ends before an expected argument boundary |
+| `osc_comma_missing` | type-tag string does not begin with `,` |
+| `osc_slip_truncated` | SLIP frame ends mid-packet on TCP |
+| `osc_array_unbalanced` | `[` without matching `]` in a 1.1 type-tag string |
+| `osc_bundle_nested_depth` | bundle nested beyond the compliance guard limit |
+
+Of these, only `osc_type_tag_unknown` is fired in the decode path today
+(`internal/osc/codec/message.go`); the remainder are defined and back the
+codec's typed errors (`ErrAlignment`, `ErrCommaMissing`, `ErrArrayUnbalanced`,
+…) and ship as decode paths are audited — same incremental posture as acp1.
+
+---
+
+## Error Reference
+
+| Name | Layer | When | Recovery |
+|---|---|---|---|
+| `--listen / --bind must be transport:port` | CLI | malformed `--listen` | use `udp:8000` form |
+| `transport=tcp-slip requires --protocol osc-v11` | CLI | SLIP on osc-v10 | use `osc-v11` (captured §verbs.md) |
+| `transport=tcp-len requires --protocol osc-v10` | CLI | length-prefix on osc-v11 | use `osc-v10` |
+| `unknown transport %q` | CLI | not udp/tcp-len/tcp-slip | pick a valid kind |
+| `ErrTruncated` | codec | payload ends early | absorb + note; frame skipped |
+| `ErrCommaMissing` | codec | type-tag lacks leading `,` | absorb + note |
+| `ErrArrayUnbalanced` | codec | `[` without `]` (1.1) | absorb + note |
+| `ErrTagUnknown` | codec | unknown type tag | absorb + fire `osc_type_tag_unknown` |
+
+---
+
+## Discovery
+
+> **N/A — OSC has no discovery.** A peer never advertises its address space.
+> "Discovery" is purely passive observation: bind a port with `watch` and record
+> which addresses + type-tags arrive. There is no `getObject`, root-count, or DM
+> cache to populate.
+
+---
+
+## Subscriptions (the live model)
+
+`watch` subscribes via `SubscribePattern(pattern, fn)`. Every matching inbound
+packet — message or bundle element — fires the callback, which prints one line:
+
+```
+[<transport>] <address>  ,<tags>  <arg1> <arg2> ...
+```
+
+Live-captured (UDP loopback, osc-v10):
+
+```
+[udp      ] /mixer/fader1  ,fsi  0.75 "PGM" 42
+```
+
+Bundles fan their element messages to subscribers in order (verified by
+`TestV10_UDP_Loopback_Bundle_FansToSubscribers`): a bundle of `/ch/1/mute`,
+`/ch/2/mute`, `/ch/3/label` delivers three separate callback lines.
+
+### Pattern matching (OSC 1.0 wildcards)
+
+`--pattern` accepts `*`, `?`, `[abc]`, `{a,b}`. `*` matches a run within one
+address part and does **not** cross `/`. Captured: `--pattern "/mixer/*/gain"`
+matched `/mixer/ch3/gain` and dropped `/other/skip`.
+
+---
+
+## Raw Capture
+
+The `watch` verb prints **decoded** lines to stdout (not raw hex). Byte-exact
+references are the committed golden fixtures
+([`../testdata/fixtures/*.bin`](../testdata/fixtures/), real codec output) and a
+live OS-socket pcapng under
+[`../testdata/scenarios/battery/`](../testdata/scenarios/battery/) for the
+Wireshark dissector replay.
+
+> **N/A — `--capture <path>.jsonl`.** The osc `watch` verb does not expose a
+> JSONL raw-frame capture flag today (unlike acp1). Capture live wire bytes with
+> Wireshark/tshark + `dhs_osc.lua`, or use the committed fixtures.
+
+---
+
+## Test Peer
+
+| Peer | Where | Role |
+|---|---|---|
+| osc.js reference | [../assets/test-harness](../assets/test-harness) | cross-implementation oracle (byte oracle + interop) |
+| dhs provider (loopback) | [../provider/](../provider/) | trusted-loopback regression only, after the osc.js tier passes |
+</content>

--- a/internal/osc/docs/provider.md
+++ b/internal/osc/docs/provider.md
@@ -1,0 +1,170 @@
+# OSC Provider
+
+> **Status: shipping**
+>
+> Producer (sender / responder) for Open Sound Control 1.0 + 1.1. OSC is a
+> **message/push** protocol, so the provider does not "serve a tree" the way the
+> ACP1 provider serves a canonical device. Instead it **pushes** OSC packets to a
+> destination (`send`, `fader`) or binds a port to log inbound traffic (`serve`).
+> Symmetric to the consumer at [../consumer/](../consumer/); reuses the same
+> `codec.Message` / `codec.Bundle` codec and type constants.
+>
+> CLI: `dhs producer osc-v10 send …` · `… fader …` · `… serve …`.
+> See [runbook.md](runbook.md) for the operator workflow.
+
+---
+
+## References
+
+| Document | Path |
+|---|---|
+| Spec (1.0 / 1.1) | <https://opensoundcontrol.org/spec-1_0.html> · <https://opensoundcontrol.org/spec-1_1.html> |
+| Wire format | [../CLAUDE.md](../CLAUDE.md) |
+| Wireshark dissector | [../wireshark/dhs_osc.lua](../wireshark/dhs_osc.lua) |
+| Source | [../provider/](../provider/) — `Server`, `NewServerV10` / `NewServerV11` |
+| CLI dispatcher | [../../../cmd/dhs/cmd_osc.go](../../../cmd/dhs/cmd_osc.go) |
+
+> Cite **opensoundcontrol.org**, never `osc.org` (Orlando Science Center).
+
+---
+
+## Verbs
+
+| Verb | Role | Key flags |
+|---|---|---|
+| `send` | emit one OSC message and exit | `--to host:port` `--transport` `--address` `--types` `[args…]` |
+| `fader` | continuous high-rate fader simulator (perf measurement) | `--to` `--transport` `--address` `--rate` `--duration` `--min` `--max` `--pattern ramp\|sine\|random` |
+| `serve` | bind a port and log inbound packets (act-as-OSC-device, no echo) | `--bind transport:port` `--pattern` |
+
+> **N/A — `serve --tree fixture.json`.** The ACP1 provider serves a canonical
+> tree.json as a device. OSC has no tree to serve; `serve` is a passive logger
+> (it shares the consumer's `watch` decode path), not a tree responder.
+
+---
+
+## send
+
+Builds one `codec.Message{Address, Args}` from `--address` + `--types` + the
+positional argument tokens, encodes it, and sends it over the chosen transport.
+Each `--types` char maps to one arg, except the payload-less `T F N I` and array
+markers `[ ]`, which consume **zero** tokens.
+
+Live-captured round-trips (consumer `watch` on the matching port shown what
+arrived):
+
+```
+# UDP, osc-v10
+$ dhs_osc.exe producer osc-v10 send --to 127.0.0.1:19000 --transport udp --address /mixer/fader1 --types fsi 0.75 PGM 42
+osc-v10 sent /mixer/fader1 [,fsi] to udp://127.0.0.1:19000
+# consumer decoded:  [udp      ] /mixer/fader1  ,fsi  0.75 "PGM" 42
+
+# RGBA colour (4 hex bytes)
+$ dhs_osc.exe producer osc-v10 send --to 127.0.0.1:19000 --transport udp --address /color --types r FF8800FF
+# consumer decoded:  [udp      ] /color  ,r  #ff8800ff
+
+# TCP length-prefix, osc-v10
+$ dhs_osc.exe producer osc-v10 send --to 127.0.0.1:19001 --transport tcp-len --address /q/go --types s START
+# consumer decoded:  [tcp-len  ] /q/go  ,s  "START"
+
+# TCP SLIP, osc-v11 — 1.1 payload-less tags + array
+$ dhs_osc.exe producer osc-v11 send --to 127.0.0.1:19002 --transport tcp-slip --address /q/go --types iTFNI 7
+# consumer decoded:  [tcp-slip ] /q/go  ,iTFNI  7 T F N I
+$ dhs_osc.exe producer osc-v11 send --to 127.0.0.1:19002 --transport tcp-slip --address /array --types "i[ii]" 1 10 20
+# consumer decoded:  [tcp-slip ] /array  ,i[ii]  1 [ 10 20 ]
+```
+
+### Type-tag → token mapping
+
+| Tags | Tokens consumed | Token format |
+|---|---|---|
+| `i` `h` | 1 | decimal int |
+| `f` `d` | 1 | decimal float |
+| `s` `S` | 1 | string |
+| `b` | 1 | hex blob |
+| `t` | 1 | u64 timetag (`0x…` accepted) |
+| `c` | 1 | first byte of the token |
+| `r` `m` | 1 | exactly 4 hex bytes |
+| `T` `F` `N` `I` `[` `]` | **0** | — (payload-less / markers) |
+
+> **Note — help shows `--args`.** The producer help text examples write
+> `--types ifs --args 42 3.14 hello`, but the implementation reads the trailing
+> **positional** tokens (`fs.Args()`), not an `--args` flag. Use bare positionals
+> after the flags, as in the captures above. A leading negative number directly
+> after `--types` is parsed by Go's flag package as an unknown flag
+> (`flag provided but not defined: -3.5`); place negatives only after at least one
+> preceding positional (captured: `--types if 1 -6.0` works).
+
+---
+
+## fader
+
+High-rate fader simulator for throughput / latency measurement. Sends a single
+float per frame at `--rate` Hz for `--duration`, in `ramp` / `sine` / `random`
+shape, and prints a perf summary to stderr.
+
+**Live-captured (UDP, 1000 Hz, 2 s, sine — real numbers from this host):**
+
+```
+$ dhs_osc.exe producer osc-v10 fader --to 127.0.0.1:19000 --transport udp --address /fader --rate 1000 --duration 2s --pattern sine
+osc-v10 fader → udp://127.0.0.1:19000  rate=1000Hz  duration=2s  pattern=sine  frames≈2000
+
+=== fader perf (udp) ===
+  frames     : 1979  (errors: 0)
+  wall       : 2.000349s
+  throughput : 989 frames/s
+  send-call latency  mean=3µs  p50=0s  p95=0s  p99=0s  max=1.029ms
+```
+
+(Frame count and latencies vary per run — these are one real measured run.)
+
+---
+
+## serve
+
+Binds a port and logs every inbound packet using the same decode path as the
+consumer `watch` verb — it does **not** echo or respond. Useful as a passive
+"act-as-OSC-device" sink.
+
+**Live-captured:**
+
+```
+$ dhs_osc.exe producer osc-v10 serve --bind udp:19009
+osc-v10 serving (logging) udp:19009 (pattern="") — Ctrl-C to stop
+# after a peer sent /play ,s "GO":
+[udp      ] /play  ,s  "GO"
+```
+
+---
+
+## Bundles
+
+The provider can group N messages under one timetag into a single outgoing
+bundle (`Server.SendBundle`). The consumer fans the element messages to
+subscribers in order. Verified by `TestV10_UDP_Loopback_Bundle_FansToSubscribers`
+(three element messages all delivered). The committed
+[`../testdata/fixtures/bundle_timetag.bin`](../testdata/fixtures/) (68 bytes,
+real codec output) pins the `#bundle` + NTP-timetag + element-size envelope.
+
+> **N/A — `--play` value drift.** ACP1's provider self-drives object value drift
+> for `watch`. OSC's equivalent live source is `fader` (continuous push) or a
+> `send` loop; there is no object tree to oscillate.
+
+---
+
+## Broadcast & multi-destination
+
+UDP providers honour broadcast / subnet-broadcast destinations (SO_BROADCAST on
+the egress socket, per [../CLAUDE.md](../CLAUDE.md)). Multiple `AddDestination`
+calls fan one message to several peers. There is no per-destination session or
+identity — OSC is connectionless in spirit even over TCP.
+
+---
+
+## Provider verb summary
+
+| Verb | Transport surface | Output |
+|---|---|---|
+| `send` | udp / tcp-len (v10) / tcp-slip (v11) | one packet, then exit; banner to stderr |
+| `fader` | same | continuous float push; perf summary to stderr |
+| `serve` | same (binds, logs) | decoded inbound lines to stdout |
+</content>

--- a/internal/osc/docs/runbook.md
+++ b/internal/osc/docs/runbook.md
@@ -1,0 +1,121 @@
+# OSC — operational runbook
+
+Quick-reference card for operators. For wire-format detail see
+[../CLAUDE.md](../CLAUDE.md); for in-depth behaviour see [consumer.md](consumer.md)
+and [provider.md](provider.md). OSC is a **message/push** protocol — there is no
+device to walk, get, or set; you listen (`watch`) or push (`send`/`fader`/`serve`).
+
+Spec: <https://opensoundcontrol.org/spec-1_0.html> ·
+<https://opensoundcontrol.org/spec-1_1.html> (not `osc.org`).
+
+---
+
+## Transport matrix
+
+| Kind | `--listen` / `--transport` | Default port | Version | Notes |
+|---|---|---:|---|---|
+| UDP | `udp` | 8000 | both | one datagram = one packet; SO_REUSEADDR multi-listener; broadcast-friendly |
+| TCP length-prefix | `tcp-len` | 8000 | osc-v10 only | int32 BE size + packet |
+| TCP SLIP | `tcp-slip` | 8001 | osc-v11 only | RFC 1055 double-END |
+
+The CLI enforces version↔framing: `tcp-slip` ⇒ `osc-v11`, `tcp-len` ⇒ `osc-v10`.
+
+## Verb reference
+
+### Consumer
+
+| Verb | What it does | Common flags |
+|---|---|---|
+| `dhs consumer osc-vNN watch --listen <kind>:<port>` | bind a port; print every inbound packet | `--pattern PAT` |
+
+> No `info` / `walk` / `get` / `set` / `export` — **N/A** for a push protocol
+> (no device tree / object catalogue).
+
+### Producer
+
+| Verb | What it does | Required / common flags |
+|---|---|---|
+| `dhs producer osc-vNN send --to <host:port> --transport <kind> --address /A --types TAGS [args…]` | push one message, exit | `--to`, `--transport`, `--address`, `--types` |
+| `dhs producer osc-vNN fader --to <host:port> --transport <kind>` | high-rate float push (perf) | `--rate`, `--duration`, `--min/--max`, `--pattern ramp\|sine\|random` |
+| `dhs producer osc-vNN serve --bind <kind>:<port>` | bind + log inbound (no echo) | `--pattern` |
+
+## Common flows
+
+### Monitor a control surface
+
+```
+dhs consumer osc-v10 watch --listen udp:8000
+dhs consumer osc-v10 watch --listen udp:8000 --pattern "/mixer/*/gain"
+```
+
+Live-captured output (loopback):
+
+```
+[udp      ] /mixer/fader1  ,fsi  0.75 "PGM" 42
+```
+
+### Push a value to a device (X32 / QLab / Companion)
+
+```
+dhs producer osc-v10 send --to 192.0.2.50:8000 --transport udp --address /ch/01/mix/fader --types f 0.5
+dhs producer osc-v11 send --to 192.0.2.50:8001 --transport tcp-slip --address /q/go --types T
+```
+
+### Measure throughput / latency
+
+```
+dhs producer osc-v10 fader --to 127.0.0.1:8000 --rate 1000 --duration 5s --pattern sine
+```
+
+Real measured run (UDP, 1000 Hz, 2 s on this host): `989 frames/s`,
+`mean=3µs max=1.029ms`, `errors: 0`.
+
+### Act as a passive OSC sink
+
+```
+dhs producer osc-v10 serve --bind udp:8000
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `transport=tcp-slip requires --protocol osc-v11` | SLIP requested on osc-v10 | use `osc-v11` (SLIP is 1.1 only) |
+| `transport=tcp-len requires --protocol osc-v10` | length-prefix on osc-v11 | use `osc-v10` (length-prefix is 1.0 only) |
+| `flag provided but not defined: -3.5` | negative value directly after `--types` | place negatives after a preceding positional (`--types if 1 -6.0`) |
+| `watch` shows nothing | wrong port/transport, or pattern too narrow | confirm `--listen` matches sender; `*` does not cross `/` (use `/a/*/c` not `/a/*`) |
+| Two listeners share a UDP port but only one receives | SO_REUSEPORT inactive (e.g. Windows) | expected; integration suite accepts partial reception |
+| 1.1 `T/F/N/I` not appearing as args | they are payload-less by design | they print as `T F N I` with no bytes — correct (captured) |
+
+## Idempotency
+
+OSC has no converge target (no read-back), so `ensure`-style idempotency does
+not apply. The Ansible play's run-twice = same-result holds at the **socket**
+level: each integration test binds an ephemeral socket and tears it down
+(`changed_when: false`). Pushing the same `send` twice emits two identical
+packets — there is no de-duplication.
+
+## Integration (Ansible — no .ps1)
+
+```
+# loopback only (CI / agent, no node):
+ansible-playbook -i inventory/hosts.ini playbooks/osc-integration.yml
+
+# + osc.js cross-impl oracle (install node + osc.js in ../assets/test-harness):
+ansible-playbook -i inventory/hosts.ini playbooks/osc-integration.yml -e osc_run_oscjs=true
+```
+
+Oracle-per-tier: the cross-implementation **osc.js** peer is the external oracle
+(not a lab host); loopback (our provider ↔ our consumer over real localhost
+sockets) is regression only. `OSC_TEST_HOST` is reserved for a future live-peer
+test and not used to gate today.
+
+## Pointers
+
+- Wire format: [../CLAUDE.md](../CLAUDE.md)
+- Consumer / Provider deep-dives: [consumer.md](consumer.md) · [provider.md](provider.md)
+- Verbs + captured samples: [verbs.md](verbs.md)
+- Wireshark dissector: [../wireshark/dhs_osc.lua](../wireshark/dhs_osc.lua)
+- Fixtures: [../testdata/fixtures/README.md](../testdata/fixtures/README.md)
+- ADR-0025 (definition of done): [../../../docs/adr/0025-per-connector-definition-of-done.md](../../../docs/adr/0025-per-connector-definition-of-done.md)
+</content>

--- a/internal/osc/docs/verbs.md
+++ b/internal/osc/docs/verbs.md
@@ -1,0 +1,262 @@
+# OSC — verbs & configuration reference
+
+Per-connector verb reference, same 12-section order as the acp1 / probel-sw02p
+docs so the set doesn't drift. **OSC is a message/push protocol** — it has no
+Tree/DM, no addressable object catalogue, and no matrix — so the Tree/DM-only
+sections (`get`/`set`/`inc`/`dec`/`reset` by OID, crosspoints, tree walk,
+export/import, ensure) are marked **N/A** with the reason, not invented.
+
+All samples below are **real**: either **live-captured** on this host with a
+purpose-built binary over loopback on unique ports (UDP 19000, TCP-LP 19001,
+TCP-SLIP 19002, plus 19005–19009), or **quoted from a committed codec-produced
+fixture** under [`../testdata/fixtures/`](../testdata/fixtures/) and clearly
+attributed. No wire bytes are hand-written.
+
+Wire format lives in [`../CLAUDE.md`](../CLAUDE.md); this file is the operator
+how-to. Verbs that exist: consumer `watch`; producer `send` `fader` `serve`.
+
+Spec: OSC 1.0 <https://opensoundcontrol.org/spec-1_0.html> · OSC 1.1
+<https://opensoundcontrol.org/spec-1_1.html> (not `osc.org`, which is
+the Orlando Science Center).
+
+---
+
+## 1. Transport configs
+
+OSC speaks three transports (see [`../CLAUDE.md`](../CLAUDE.md) "Wire layer"):
+
+| Kind | Flag value | Default port | Version | Notes |
+|---|---|---|---|---|
+| UDP | `udp` | 8000 | both | one datagram = one packet; broadcast-friendly; SO_REUSEADDR for multi-listener |
+| TCP length-prefix | `tcp-len` | 8000 | **osc-v10 only** | int32 BE size + packet (OSC 1.0) |
+| TCP SLIP | `tcp-slip` | 8001 | **osc-v11 only** | RFC 1055 double-END framing (OSC 1.1) |
+
+The version↔framing pairing is enforced at the CLI. Real captured guard errors:
+
+```
+$ dhs_osc.exe producer osc-v10 send --to 127.0.0.1:19002 --transport tcp-slip --address /x --types T
+error: transport=tcp-slip requires --protocol osc-v11 (SLIP is OSC 1.1 only)
+
+$ dhs_osc.exe producer osc-v11 send --to 127.0.0.1:19001 --transport tcp-len --address /x --types i 1
+error: transport=tcp-len requires --protocol osc-v10 (length-prefix is OSC 1.0 only)
+```
+
+Consumer binds with `--listen transport:port`; producer sends with
+`--transport KIND --to host:port` or binds a logger with `--bind transport:port`.
+
+```
+dhs consumer osc-v10 watch --listen udp:8000
+dhs producer osc-v10 send  --to 127.0.0.1:8000 --transport udp --address /a --types i 1
+dhs producer osc-v11 serve --bind tcp-slip:8001
+```
+
+## 2. Controllers & redundancy
+
+OSC has **no client identity on the wire** and no session — it is symmetric and
+connectionless in spirit. "Redundancy" is an app/deployment concern:
+
+- **Single peer (default):** one producer `send`s, one consumer `watch`es.
+- **Fan-out:** one producer `--to` each destination, or UDP broadcast/subnet
+  destinations (the codec/provider sets SO_BROADCAST on the egress socket).
+- **Multi-listener on one host:** UDP consumers set SO_REUSEADDR so several dhs
+  instances share a port (matches the ACP1 / TSL multi-listener contract). On
+  platforms where SO_REUSEPORT is not active (e.g. Windows) delivery to a shared
+  UDP port may land on only one binder — the integration suite accepts partial
+  reception (`TestV10_UDP_MultiInstance_SamePort`).
+
+> **N/A — redundant controller pairing.** ACP1's "2+ producer instances, one per
+> NIC/controller" model does not apply: OSC has no controller concept and no
+> announce-vs-transaction split to enforce TCP on. Fan-out is the only model.
+
+## 3. Logging & severity
+
+Logs go to **stderr**, decoded data to **stdout** (so `2>` captures logs, `1>`
+captures the decoded stream). The osc CLI wires a fixed `slog` text handler at
+`info` level on stderr for `watch` / `send` / `serve`; `fader` discards logs and
+prints only its perf summary to stderr. There is **no `--log-level` flag** on the
+osc verbs today (unlike acp1).
+
+Real captured stderr banner (UDP watch):
+
+```
+osc-v10 watching udp:19000 (pattern="") — Ctrl-C to stop
+```
+
+> **N/A — `--log-level` / `--log-format json`.** Not wired on osc verbs; severity
+> is fixed. Documented as absent rather than invented.
+
+## 4. info / walk
+
+> **N/A — `info` and `walk` do not exist for OSC.** OSC has no device-info reply
+> and no walkable object tree: a peer never advertises its address space, and
+> there is no `getObject`/root-count mechanism. Discovery is **passive** — bind a
+> port and observe which addresses arrive. The equivalent is `watch` (§8).
+
+## 5. get / set / inc / dec / reset
+
+> **N/A — there is no addressable object model.** OSC carries a free-form address
+> string + typed args per message; there is no OID, no value-read request, no
+> confirmed-echo, and no step/default semantics. A producer *pushes* a value with
+> `send` (§ producer.md); it never "reads" one. ACP1's `get/set/inc/dec/reset`
+> (setValue/setIncValue/setDecValue/setDefValue) have no OSC analogue.
+
+## 6. export / import
+
+> **N/A — nothing to export.** OSC has no tree/DM snapshot to serialize to
+> json/yaml/csv and no importable object set. The committed artifacts are golden
+> **wire packets** (`../testdata/fixtures/*.bin`), not a canonical tree — see §11
+> and [`../testdata/fixtures/README.md`](../testdata/fixtures/README.md).
+
+## 7. reports — tree ASCII & PlantUML mindmap
+
+> **N/A — no tree to render.** The `tree` verb requires a walkable object
+> hierarchy; OSC has none. The closest report is the per-message decoded line
+> emitted by `watch` (§8), which matches the Wireshark Info column field-for-field.
+
+## 8. watch (the only consumer verb)
+
+`watch` binds a port and prints every received packet as
+`[transport] /address ,tags arg1 arg2 …` — the same shape as the
+`dhs_osc.lua` dissector Info column, so terminal and Wireshark compare
+line-for-line. `--pattern` filters by OSC address pattern (default: all).
+
+**Live-captured (UDP, port 19000, osc-v10):**
+
+```
+# consumer
+$ dhs_osc.exe consumer osc-v10 watch --listen udp:19000
+# producer drove two messages:
+#   send --to 127.0.0.1:19000 --transport udp --address /mixer/fader1 --types fsi 0.75 PGM 42
+#   send --to 127.0.0.1:19000 --transport udp --address /color       --types r FF8800FF
+[udp      ] /mixer/fader1  ,fsi  0.75 "PGM" 42
+[udp      ] /color  ,r  #ff8800ff
+```
+
+**Live-captured (TCP length-prefix, port 19001, osc-v10):**
+
+```
+[tcp-len  ] /ch/1/gain  ,if  1 -6
+[tcp-len  ] /q/go  ,s  "START"
+```
+
+**Live-captured (TCP SLIP, port 19002, osc-v11 — payload-less tags + array):**
+
+```
+# send --transport tcp-slip --address /q/go   --types iTFNI 7
+# send --transport tcp-slip --address /array  --types "i[ii]" 1 10 20
+[tcp-slip ] /q/go  ,iTFNI  7 T F N I
+[tcp-slip ] /array  ,i[ii]  1 [ 10 20 ]
+```
+
+The `T F N I` print as zero-byte payload-less args and `[ … ]` are array markers
+— the OSC 1.1 additions, captured live, never fabricated.
+
+### Address-pattern filtering (real OSC wildcard semantics)
+
+`--pattern` uses OSC 1.0 wildcard syntax: `*` `?` `[abc]` `{a,b}`. Per spec, `*`
+matches a run **within one address part** (it does **not** cross `/`). Captured:
+
+```
+# watch --listen udp:19006 --pattern "/mixer/*/gain"
+# driven with /mixer/ch3/gain (matches) and /other/skip (dropped):
+[udp      ] /mixer/ch3/gain  ,f  3.5
+```
+
+`/other/skip` produced no line — the pattern correctly filtered it out.
+
+## 9. ensure() — idempotent converge
+
+> **N/A — no converge target.** `ensure` reads current value, compares to
+> `--value`, and writes if different. OSC cannot read a value back (no
+> get/reply), so there is no idempotent converge. The idempotency that **does**
+> apply to OSC is socket-level: each integration test binds an ephemeral socket
+> and tears it down, so the Ansible play's run-twice = same-result (§11). Pushing
+> the same message twice simply sends two identical datagrams.
+
+## 10. Wireshark
+
+Dissector: [`../wireshark/dhs_osc.lua`](../wireshark/dhs_osc.lua) —
+`Proto("dhs_osc", "OSC (dhs — Open Sound Control 1.0 + 1.1)")`. Decodes UDP +
+TCP length-prefix (1.0) + TCP SLIP (1.1), every type tag including 1.1
+payload-less + array markers, recursive bundle decode, with a per-message Info
+column of `address + type-tag + arg count`.
+
+| OS | Plugin dir |
+|---|---|
+| Windows | `%APPDATA%\Wireshark\plugins\` |
+| macOS / Linux | `~/.local/lib/wireshark/plugins/` |
+
+```
+# display filter:  dhs_osc
+# field filters:   dhs_osc.address, dhs_osc.type_tag, dhs_osc.arg_count
+tshark -r capture.pcapng -O dhs_osc -Y dhs_osc
+```
+
+Dissector-replay regression
+([`../integration/dissector_replay_test.go`](../integration/dissector_replay_test.go))
+runs `tshark -X lua_script:internal/osc/wireshark/dhs_osc.lua` over the committed
+multi-frame capture [`../testdata/scenarios/battery/capture.pcapng`](../testdata/scenarios/battery/capture.pcapng).
+
+## 11. Fixtures, Ansible & integration
+
+### Golden packet fixtures (real codec output)
+
+[`../testdata/fixtures/*.bin`](../testdata/fixtures/) are produced by the repo's
+own codec encode path (`codec.Message.Encode` / `codec.Bundle.Encode`) — never
+hand-written. `TestOSCFixtures` re-encodes each and asserts byte-identity, so a
+fixture can never drift from the codec. Real bytes, dumped from the committed
+files on this host:
+
+```
+# message_v11_payloadless.bin (20 bytes) — quoted from the committed fixture
+2f712f676f0000002c54464e4969000000000007
+#  └/q/go\0\0\0─┘ └,TFNIi\0\0──┘ └int32 7─┘
+#  address (8B)   type-tag (8B)   arg payload: only the 'i' has bytes;
+#                                  T/F/N/I are payload-less (OSC 1.1)
+
+# bundle_timetag.bin (68 bytes) — quoted from the committed fixture
+2362756e646c65000000000100000000...  ("#bundle\0" + NTP timetag 0x0000000100000000 + elements)
+
+# message_all_tags.bin (92 bytes) — quoted from the committed fixture
+2f6d697865722f6661646572310000002c696673626864745363726d00000000...
+#  /mixer/fader1 + type-tag string ",ifsbhdtScrm"
+```
+
+`message_v11_payloadless.bin` proves the 1.1 contract end-to-end: the type-tag
+string `,TFNIi` is encoded but **only the trailing `i` contributes argument
+bytes** (`00000007`) — `T`/`F`/`N`/`I` are zero-payload. This is the same packet
+the live `watch` capture in §8 decoded as `,iTFNI  7 T F N I`.
+
+### Ansible (exclusive integration driver — no .ps1)
+
+[`../../../ansible/playbooks/osc-integration.yml`](../../../ansible/playbooks/osc-integration.yml)
+has two tiers:
+
+```
+# loopback only (CI / agent, no node required):
+ansible-playbook -i inventory/hosts.ini playbooks/osc-integration.yml
+
+# plus the osc.js cross-impl oracle (install node + osc.js first):
+ansible-playbook -i inventory/hosts.ini playbooks/osc-integration.yml -e osc_run_oscjs=true
+```
+
+The oracle-per-tier rule (never validate our consumer with our own provider) is
+satisfied by a **cross-implementation oracle** — the osc.js reference peer in
+[`../assets/test-harness`](../assets/test-harness) — not by a lab host. The
+loopback tier runs our provider ↔ our consumer over real localhost UDP / TCP-LP /
+TCP-SLIP sockets (`-run TestV10|TestV11|TestMultiPeer`); each test binds an
+ephemeral socket and tears it down, so run-twice = same result (ADR-0025
+idempotency, `changed_when: false`).
+
+> **Note — `OSC_TEST_HOST`.** No osc integration test reads `OSC_TEST_HOST` /
+> `OSC_TEST_PORT` today. They are reserved for a future live-peer test (QLab /
+> X32 / Companion) and passed through to the external task environment, but are
+> deliberately **not** used to gate anything yet.
+
+## 12. See also
+
+- [`../CLAUDE.md`](../CLAUDE.md) — wire format, type tags, framing, quirks
+- [`./README.md`](./README.md) · [`./consumer.md`](./consumer.md) · [`./provider.md`](./provider.md) · [`./runbook.md`](./runbook.md)
+- [`../../../docs/adr/0025-per-connector-definition-of-done.md`](../../../docs/adr/0025-per-connector-definition-of-done.md)
+- OSC 1.0 / 1.1 specs: <https://opensoundcontrol.org/spec-1_0.html> · <https://opensoundcontrol.org/spec-1_1.html>
+</content>


### PR DESCRIPTION
Completes osc to ADR-0025 6/6 (docs deliverable). Mirrors the acp1 docs structure (README/consumer/provider/runbook + 12-section verbs.md), adapted for an OSC message/push protocol: object-model sections (get/set/inc/dec/reset, info/walk, export/import, tree, ensure) marked N/A with reason, not invented. Samples are real: producer to consumer loopback decodes captured live across UDP / TCP-length-prefix / TCP-SLIP (osc-v10 + osc-v11), plus wire hex from the committed codec-produced .bin fixtures (attributed) — the live tcp-slip /q/go decode matches message_v11_payloadless.bin. Spec cited from opensoundcontrol.org (NOT osc.org = Orlando Science Center). osc.js + real-device tiers noted as external/VPN-gated. Co-Authored-By Claude Opus 4.8.