### PR TITLE
fix(cli): make probel salvo-connect --dsts reachable; add sw02p to serve --help

### DIFF
--- a/cmd/dhs/cmd_probel.go
+++ b/cmd/dhs/cmd_probel.go
@@ -33,7 +33,19 @@ func runProbelsw08p(ctx context.Context, args []string) error {
 		defer func() { _ = rec.Close() }()
 		ctx = context.WithValue(ctx, probelRecorderKey{}, rec)
 	}
-	args, mc, mcSet, err := extractMatrixConfigFlags(args)
+	// The `salvo-connect` verb owns its own --dsts (CSV/range) and --level
+	// flags via its per-command flag.FlagSet (cmd_probel_salvo.go). The
+	// global matrix-config extractor below treats --dsts as a single uint
+	// (matrix bootstrap shape) and would eat `--dsts 0-2` first, failing
+	// on strconv.ParseUint and starving the verb of its own flag. Detect
+	// the subcommand up front and skip the conflicting globals so
+	// salvo-connect is reachable from the CLI. --mtx-id / --srcs are not
+	// defined by salvo-connect, so they stay globally consumable.
+	skip := map[string]bool(nil)
+	if probelSubcommand(args) == "salvo-connect" {
+		skip = map[string]bool{"--dsts": true, "--level": true}
+	}
+	args, mc, mcSet, err := extractMatrixConfigFlags(args, skip)
 	if err != nil {
 		return err
 	}
@@ -189,7 +201,13 @@ type probelMatrixConfigKey struct{}
 // (not required for verbs that don't need them; required for the
 // future bootstrap-sweep / keep-alive ping wiring that mirrors what
 // SW-P-02 ships).
-func extractMatrixConfigFlags(args []string) ([]string, probelproto.MatrixConfig, bool, error) {
+//
+// skip names a set of global flag spellings (e.g. "--dsts", "--level")
+// that a subcommand owns itself and that must NOT be consumed here —
+// both the flag and its value are passed through untouched so the
+// subcommand's own flag.FlagSet can parse them. Pass nil to consume
+// every global flag (the default for verbs with no conflicts).
+func extractMatrixConfigFlags(args []string, skip map[string]bool) ([]string, probelproto.MatrixConfig, bool, error) {
 	var mc probelproto.MatrixConfig
 	var seen bool
 	out := make([]string, 0, len(args))
@@ -258,6 +276,17 @@ func extractMatrixConfigFlags(args []string) ([]string, probelproto.MatrixConfig
 			out = append(out, a)
 			continue
 		}
+		// A subcommand-owned flag — pass it (and its value) through
+		// untouched so the verb's own flag.FlagSet parses it. The "=" form
+		// is a single token; the space form already advanced i past the
+		// value, so re-emit both.
+		if skip[name] {
+			out = append(out, a)
+			if !strings.Contains(a, "=") {
+				out = append(out, val)
+			}
+			continue
+		}
 		seen = true
 		switch name {
 		case "--mtx-id":
@@ -287,6 +316,35 @@ func extractMatrixConfigFlags(args []string) ([]string, probelproto.MatrixConfig
 		}
 	}
 	return out, mc, seen, nil
+}
+
+// probelSubcommand returns the subcommand verb in args (the first
+// non-flag token), looking past any global matrix-config flags that
+// precede it. It runs BEFORE extractMatrixConfigFlags so the dispatcher
+// can decide which global flags a verb owns itself (e.g. salvo-connect's
+// own --dsts / --level). Returns "" when no verb is present.
+//
+// Global flags that take a separate value token (space form) are
+// skipped together with that value so a verb appearing after
+// `--mtx-id 0` is still found. The "=" form consumes a single token.
+func probelSubcommand(args []string) string {
+	valued := map[string]bool{
+		"--mtx-id": true, "-mtx-id": true,
+		"--level": true, "-level": true,
+		"--dsts": true, "-dsts": true,
+		"--srcs": true, "-srcs": true,
+	}
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if !strings.HasPrefix(a, "-") {
+			return a
+		}
+		// "--flag=value" is one token; "--flag value" consumes the next.
+		if !strings.Contains(a, "=") && valued[a] {
+			i++
+		}
+	}
+	return ""
 }
 
 // extractCaptureFlag scans args for "--capture FILE" or "--capture=FILE"

--- a/cmd/dhs/cmd_probel02p.go
+++ b/cmd/dhs/cmd_probel02p.go
@@ -30,7 +30,19 @@ func runProbelsw02p(ctx context.Context, args []string) error {
 		defer func() { _ = rec.Close() }()
 		ctx = context.WithValue(ctx, probelSW02RecorderKey{}, rec)
 	}
-	args, mc, mcSet, err := extractSW02MatrixConfigFlags(args)
+	// The `salvo-connect` verb owns its own --dsts (CSV/range) flag via
+	// its per-command flag.FlagSet (runProbelsw02pSalvoConnect). The
+	// global matrix-config extractor below treats --dsts as a single uint
+	// (matrix bootstrap shape) and would eat `--dsts 0-2` first, failing
+	// on strconv.ParseUint and starving the verb of its own flag. Detect
+	// the subcommand up front and skip --dsts so salvo-connect is
+	// reachable from the CLI. SW-P-02 salvo-connect defines no
+	// --mtx-id / --level / --srcs, so those stay globally consumable.
+	skip := map[string]bool(nil)
+	if probelSW02Subcommand(args) == "salvo-connect" {
+		skip = map[string]bool{"--dsts": true}
+	}
+	args, mc, mcSet, err := extractSW02MatrixConfigFlags(args, skip)
 	if err != nil {
 		return err
 	}
@@ -135,7 +147,12 @@ type probelSW02MatrixConfigKey struct{}
 // extractSW02MatrixConfigFlags pulls --mtx-id / --level / --dsts /
 // --srcs / --initial-poll / --app-keepalive / --bootstrap-spacing
 // out of args BEFORE sub-command dispatch.
-func extractSW02MatrixConfigFlags(args []string) ([]string, probelsw02proto.MatrixConfig, bool, error) {
+//
+// skip names a set of global flag spellings (e.g. "--dsts") that a
+// subcommand owns itself and must NOT be consumed here — both the flag
+// and its value are passed through untouched so the subcommand's own
+// flag.FlagSet can parse them. Pass nil to consume every global flag.
+func extractSW02MatrixConfigFlags(args []string, skip map[string]bool) ([]string, probelsw02proto.MatrixConfig, bool, error) {
 	mc := probelsw02proto.MatrixConfig{InitialPoll: true}
 	var seen bool
 	out := make([]string, 0, len(args))
@@ -209,6 +226,17 @@ func extractSW02MatrixConfigFlags(args []string) ([]string, probelsw02proto.Matr
 			out = append(out, a)
 			continue
 		}
+		// A subcommand-owned flag — pass it (and its value) through
+		// untouched so the verb's own flag.FlagSet parses it. The "=" form
+		// is a single token; the space form already advanced i past the
+		// value, so re-emit both.
+		if skip[name] {
+			out = append(out, a)
+			if !strings.Contains(a, "=") {
+				out = append(out, val)
+			}
+			continue
+		}
 		seen = true
 		switch name {
 		case "--mtx-id":
@@ -262,6 +290,37 @@ func extractSW02MatrixConfigFlags(args []string) ([]string, probelsw02proto.Matr
 		}
 	}
 	return out, mc, seen, nil
+}
+
+// probelSW02Subcommand returns the subcommand verb in args (the first
+// non-flag token), looking past any global matrix-config flags that
+// precede it. It runs BEFORE extractSW02MatrixConfigFlags so the
+// dispatcher can decide which global flags a verb owns itself (e.g.
+// salvo-connect's own --dsts). Returns "" when no verb is present.
+//
+// Every SW-P-02 global flag takes a separate value token in the space
+// form, so each is skipped together with its value. The "=" form
+// consumes a single token.
+func probelSW02Subcommand(args []string) string {
+	valued := map[string]bool{
+		"--mtx-id": true, "-mtx-id": true,
+		"--level": true, "-level": true,
+		"--dsts": true, "-dsts": true,
+		"--srcs": true, "-srcs": true,
+		"--initial-poll": true, "-initial-poll": true,
+		"--app-keepalive": true, "-app-keepalive": true,
+		"--bootstrap-spacing": true, "-bootstrap-spacing": true,
+	}
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if !strings.HasPrefix(a, "-") {
+			return a
+		}
+		if !strings.Contains(a, "=") && valued[a] {
+			i++
+		}
+	}
+	return ""
 }
 
 // dialProbelSW02 mirrors dialProbel for sw08p — connect-or-die helper

--- a/cmd/dhs/cmd_probel_salvo_dsts_test.go
+++ b/cmd/dhs/cmd_probel_salvo_dsts_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// Regression for the salvo-connect --dsts shadowing bug (both probel
+// dispatchers). The GLOBAL matrix-config flag extractor parsed --dsts as
+// a single uint (matrix bootstrap shape) BEFORE subcommand dispatch, so
+// `salvo-connect ... --dsts 0-2` failed two ways at once:
+//   - strconv.ParseUint parsing "0-2": invalid syntax (range eaten by global)
+//   - --dsts is required (single value consumed, verb saw nothing)
+// The fix detects the salvo-connect subcommand up front and leaves
+// --dsts (and --level for SW-P-08) for the verb's own flag.FlagSet.
+//
+// These tests drive the real CLI parse path (runProbelsw08p /
+// runProbelsw02p) and assert the parse no longer errors. They use an
+// unreachable address with a tiny --timeout so the call fails on the
+// network dial (proving parsing succeeded) without a real device. The
+// assertion is purely on the error STRING: it must NOT mention the flag
+// parse failures, regardless of whether the dial itself errors.
+
+// flagParseErrorSubstrings are the two failure signatures the bug
+// produced. None may appear once parsing is fixed.
+var salvoFlagParseErrors = []string{
+	"--dsts is required",
+	`parsing "0-2"`,
+	"invalid syntax",
+}
+
+func assertNoFlagParseError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		// A nil error is also acceptable: it means parsing succeeded and
+		// the (loopback) dial happened to not error in this environment.
+		return
+	}
+	for _, bad := range salvoFlagParseErrors {
+		if strings.Contains(err.Error(), bad) {
+			t.Fatalf("salvo-connect --dsts 0-2 still hits a flag-parse error: %q (must contain none of %v)",
+				err.Error(), salvoFlagParseErrors)
+		}
+	}
+}
+
+// TestProbelSW08SalvoConnectDstsRange — `dhs consumer probel-sw08p
+// salvo-connect <addr> --dsts 0-2` parses the CSV/range --dsts owned by
+// the verb instead of failing in the global uint parser.
+func TestProbelSW08SalvoConnectDstsRange(t *testing.T) {
+	for _, dsts := range []string{"0-2", "1,3,5"} {
+		t.Run(dsts, func(t *testing.T) {
+			err := runProbelsw08p(context.Background(), []string{
+				"salvo-connect", "127.0.0.1:1",
+				"--src", "12", "--dsts", dsts, "--timeout", "50ms",
+			})
+			assertNoFlagParseError(t, err)
+		})
+	}
+}
+
+// TestProbelSW02SalvoConnectDstsRange — same for SW-P-02.
+func TestProbelSW02SalvoConnectDstsRange(t *testing.T) {
+	for _, dsts := range []string{"0-2", "1,3,5"} {
+		t.Run(dsts, func(t *testing.T) {
+			err := runProbelsw02p(context.Background(), []string{
+				"salvo-connect", "127.0.0.1:1",
+				"--src", "3", "--dsts", dsts, "--timeout", "50ms",
+			})
+			assertNoFlagParseError(t, err)
+		})
+	}
+}
+
+// TestProbelSubcommandDetection pins the up-front verb detector that
+// decides whether to skip the global --dsts / --level. It must find the
+// verb even when global matrix-config flags precede it (space and "="
+// forms).
+func TestProbelSubcommandDetection(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"plain", []string{"salvo-connect", "127.0.0.1:2008"}, "salvo-connect"},
+		{"after-mtx-space", []string{"--mtx-id", "0", "salvo-connect", "addr"}, "salvo-connect"},
+		{"after-mtx-eq", []string{"--mtx-id=0", "salvo-connect", "addr"}, "salvo-connect"},
+		{"other-verb", []string{"connect", "addr"}, "connect"},
+		{"empty", nil, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := probelSubcommand(c.args); got != c.want {
+				t.Errorf("probelSubcommand(%v) = %q, want %q", c.args, got, c.want)
+			}
+			if got := probelSW02Subcommand(c.args); got != c.want {
+				t.Errorf("probelSW02Subcommand(%v) = %q, want %q", c.args, got, c.want)
+			}
+		})
+	}
+}
+
+// TestProbelGlobalDstsStillBootstraps — the global --dsts bootstrap
+// shape must keep working for NON-salvo verbs (e.g. watch). A single
+// uint --dsts is consumed by the global extractor as before; passing a
+// range to a non-salvo verb still fails in the global parser (unchanged
+// behavior). This guards against the fix over-broadly skipping --dsts.
+func TestProbelGlobalDstsStillBootstraps(t *testing.T) {
+	// Non-salvo verb keeps the global uint semantics: a range is rejected
+	// by the global parser, proving --dsts is NOT skipped for it.
+	err := runProbelsw08p(context.Background(), []string{
+		"watch", "127.0.0.1:1", "--dsts", "0-2", "--timeout", "50ms",
+	})
+	if err == nil || !strings.Contains(err.Error(), "--dsts") {
+		t.Fatalf("non-salvo --dsts 0-2 should fail in the global parser, got: %v", err)
+	}
+}

--- a/cmd/dhs/main.go
+++ b/cmd/dhs/main.go
@@ -481,7 +481,7 @@ CONSUMER (outbound — connect to a device, query / control it)
     dhs consumer cerebrum-nb listen      10.6.239.50 --user admin --pass s3cr3t
 
 PRODUCER (inbound — serve a canonical tree to consumers over the wire)
-  Protocols: acp1 | acp2 | emberplus | probel-sw08p
+  Protocols: acp1 | acp2 | emberplus | probel-sw02p | probel-sw08p
   Verbs:     serve
 
   Examples:
@@ -549,7 +549,7 @@ USAGE
   dhs producer <protocol> serve [flags]
 
 PROTOCOLS
-  acp1 | acp2 | emberplus | probel-sw08p
+  acp1 | acp2 | emberplus | probel-sw02p | probel-sw08p
   osc-v10 | osc-v11   (run 'dhs producer osc-v10 -h' for OSC-specific verbs)
 
 FLAGS (common, slot-based protocols)


### PR DESCRIPTION
Two CLI-layer fixes (no wire/codec/consumer/provider change). 1) salvo-connect --dsts shadowing on BOTH probel-sw02p and probel-sw08p: the global matrix-config extractor parsed --dsts as a single uint before dispatch, eating salvo-connect's own CSV/range --dsts (e.g. 0-2) and failing strconv.ParseUint, making salvo-connect unreachable from the CLI. Each dispatcher now detects the salvo-connect verb up front and skips the conflicting globals, re-emitting them for the verb's own flag set; global --dsts bootstrap unchanged for every other verb. 2) producer serve --help omitted probel-sw02p — added. New regression tests prove salvo-connect parses --dsts 0-2 and 1,3,5 on both connectors and non-salvo verbs keep single-uint --dsts. build/vet/test/lint clean. Co-Authored-By Claude Opus 4.8.