### PR TITLE
fix(amwa): deterministic shutdown deregister (kill CI-flaky DELETE race)

### DIFF
--- a/internal/amwa/provider/registration_client.go
+++ b/internal/amwa/provider/registration_client.go
@@ -271,6 +271,19 @@ func (c *RegistrationClient) Run(ctx context.Context) {
 			c.deregisterAll()
 			return
 		case <-ticker.C:
+			// A ticker tick and loopCtx.Done() can be ready in the same
+			// iteration; select picks at random, so we can land here with
+			// the context already cancelled. If we proceed, the heartbeat
+			// + cascade below run against the dead context, fail with
+			// "context canceled", and flip registered→false — which makes
+			// the subsequent deregisterAll() early-return and skip every
+			// shutdown DELETE (the flaky-test symptom). Bail straight to
+			// shutdown instead so the unregister still runs while we're
+			// still marked registered.
+			if loopCtx.Err() != nil {
+				c.deregisterAll()
+				return
+			}
 			// IS-04 v1.3.3 §3.1 — Node selects the highest-priority
 			// Registry from those *currently* advertised. If a
 			// higher-priority one appeared after we registered, switch:
@@ -326,6 +339,15 @@ func (c *RegistrationClient) Run(ctx context.Context) {
 			}
 			lastHeartbeat = time.Now()
 			err := c.sendHeartbeat(loopCtx)
+			if loopCtx.Err() != nil {
+				// The run context was cancelled while the heartbeat was
+				// in flight. Any error here is our own shutdown, not a
+				// Registry failure — do NOT clear registered or cascade
+				// (that would skip the shutdown DELETEs). Go straight to
+				// graceful deregistration.
+				c.deregisterAll()
+				return
+			}
 			if errors.Is(err, ErrRegistryNotFound) {
 				c.logger.Warn("provider/node: heartbeat 404 — re-registering")
 				atomic.AddUint64(&c.reregister, 1)


### PR DESCRIPTION
TestRegistrationClientPostsAllResources flaked on the Windows -race CI runner and, via fail-fast, cancelled the whole 3-OS test matrix for unrelated PRs. Root cause: a select race in RegistrationClient.Run -- on ctx cancel both loopCtx.Done() and ticker.C could be ready; when the tick won, sendHeartbeat ran on the canceled ctx, the error path cleared registered + ran the cascade (both 'context canceled'), and deregisterAll then early-returned on not-registered -> zero DELETEs. Fix: guard the ticker case so a tick selected at/after cancellation goes straight to deregisterAll while still registered, instead of running heartbeat/cascade on the dead context. Shutdown DELETEs already use a fresh context.Background timeout, so they now complete deterministically. No sleep added; heartbeat/cascade still stop on real cancel; the assertion (DELETEs required on shutdown) is unchanged. Verified: count=50 zero failures (was intermittent); -race runs in CI. Co-Authored-By Claude Opus 4.8.