### PR TITLE
fix(ansible): drive CLI verbs (not go test) in probel/tsl/osc integration plays

### DIFF
--- a/ansible/playbooks/osc-integration.yml
+++ b/ansible/playbooks/osc-integration.yml
@@ -1,147 +1,174 @@
 ---
 # OSC (Open Sound Control 1.0 + 1.1) integration CONTRACT TEST, per
 # ADR-0025 deliverable 3: "Ansible is the exclusive integration / verify
-# / deploy driver — no PowerShell .ps1 scripts." Live-rig parity driver
-# complementing the Go -tags integration body in
-# internal/osc/integration/.
+# / deploy driver — no PowerShell .ps1 scripts." This play drives the REAL
+# dhs CLI verbs (the built binary), mirroring the gold-template
+# acp1/acp2/emberplus plays — NOT `go test`.
 #
-# OSC is a symmetric push protocol — any peer can send to any peer; there
-# is no client/server handshake and no single device "address" the
-# consumer dials by host the way SW-P-02/08 dial a matrix. The
-# oracle-per-tier rule (never validate our consumer with our own
-# provider) is therefore satisfied by a *cross-implementation* oracle —
-# the osc.js reference peer (internal/osc/assets/test-harness) — NOT by a
-# lab host env var. So this play's two tiers differ from the probel
-# plays:
+# OSC is a symmetric PUSH protocol: a producer sends to a consumer that
+# watches. So like TSL, the loopback tier starts the CONSUMER first (a
+# backgrounded `watch` capturing stdout to a temp file), then runs the
+# PRODUCER once to send a message, then asserts the watcher printed the
+# address + arg it received.
 #
-#   1. LOOPBACK (always): run `go test -tags integration` for the osc
-#      integration package, restricted to the in-process loopback +
-#      multi-peer suites (our provider <-> our consumer over real
-#      localhost UDP / TCP-LP / TCP-SLIP sockets). No external
-#      dependency, no VPN, no node. Each test binds an ephemeral socket
-#      and tears it down — zero persistent change → run-twice = same
-#      result (ADR-0025 idempotency). changed_when:false makes that
-#      explicit. The dissector-replay suite (tshark) and osc.js suite
-#      self-Skip cleanly when their tools are absent, so running the
-#      whole package here is also safe.
+#   1. LOOPBACK (always): `dhs consumer osc-v11 watch --listen udp:N`
+#      backgrounded → `dhs producer osc-v11 send --to 127.0.0.1:N
+#      --transport udp --address /test --types i 7` → assert the watcher
+#      stdout shows "/test" and the int arg "7". The watcher is ephemeral
+#      (torn down each run in `always`), so run-twice = same result
+#      (ADR-0025 idempotency). changed_when:false throughout — a single
+#      datagram leaves no persistent state.
 #
-#   2. EXTERNAL / ORACLE (gated on node + osc.js): re-run the SAME Go
-#      integration body restricted to the OSCJS interop suite, which
-#      drives the osc.js Node reference peer as an independent encoder /
-#      decoder over the wire (byte oracle + UDP + TCP-LP + TCP-SLIP +
-#      fan-in). Those tests t.Skip() themselves when `node` is not on
-#      PATH or osc.js is not installed, so this tier is safe to invoke
-#      unconditionally: a missing toolchain surfaces as a clean Go
-#      SKIP, never a failure.
+#   2. EXTERNAL (gated on OSC_TEST_HOST): send the SAME message to a live
+#      OSC peer on the lab network (QLab / X32 / Companion). A `send` of an
+#      address with one int arg is trivially safe. We cannot observe the
+#      remote peer from here, so the external tier asserts only that the
+#      producer emitted to the destination. Skipped when the var is unset.
 #
-# NOTE on OSC_TEST_HOST: the OSC integration tests currently expose NO
-# external-host redirect (no test reads OSC_TEST_HOST / OSC_TEST_PORT).
-# Per ADR-0025's no-circular-oracle rule the cross-impl oracle (osc.js)
-# is the external tier, not a lab IP. OSC_TEST_HOST is RESERVED for a
-# future live-peer test (e.g. QLab / X32 / Companion on the lab net); it
-# is passed through to the external task's environment so that the day a
-# test honours it, this play already feeds it — but it is deliberately
-# NOT used to gate or branch today, because wiring a gate to a code path
-# no test supports would be an untested external path.
+# dhs logs go to stderr → register + debug stdout_lines + stderr_lines to
+# surface them under `ansible-playbook -v`.
 #
-# dhs / go test logs are surfaced via register + debug stderr_lines so a
-# failing run shows the test output inline under `ansible-playbook -v`.
-#
-#   # loopback only (CI / agent, no node required):
+#   # loopback only:
 #   ansible-playbook -i inventory/hosts.ini playbooks/osc-integration.yml
 #
-#   # plus the osc.js cross-impl oracle (install node + osc.js first):
-#   #   cd internal/osc/assets/test-harness && npm install
-#   ansible-playbook -i inventory/hosts.ini playbooks/osc-integration.yml \
-#     -e osc_run_oscjs=true
-- name: OSC integration (loopback peers + optional osc.js cross-impl oracle)
+#   # plus a live OSC peer (lab, VPN):
+#   OSC_TEST_HOST=10.100.0.42 \
+#     ansible-playbook -i inventory/hosts.ini playbooks/osc-integration.yml
+#   OSC_TEST_HOST=10.100.0.42 OSC_TEST_PORT=8000 ansible-playbook ...
+- name: OSC integration (loopback verb-drive osc-v11 + optional live peer)
   hosts: localhost
   connection: local
   gather_facts: false
   vars:
-    repo_root: "{{ playbook_dir }}/../.."
-    osc_pkg: "./internal/osc/integration/"
-    # Loopback tier: in-process provider<->consumer over real sockets.
-    # Restricted to the loopback + multi-peer suites by -run so the tier
-    # is deterministic regardless of node / tshark availability.
-    osc_loopback_run: "TestV10|TestV11|TestMultiPeer"
-    # External/oracle tier: the osc.js interop suite. Opt-in via
-    # -e osc_run_oscjs=true once node + osc.js are installed.
-    osc_run_oscjs: false
-    osc_oscjs_run: "TestOSCJS"
-    # RESERVED future live-peer redirect — see header note. Passed
-    # through to the external task environment but not used to gate.
+    dhs_bin: "{{ lookup('ansible.builtin.env', 'DHS_BIN') | default(playbook_dir + '/../../bin/dhs', true) }}"
     osc_host: "{{ lookup('ansible.builtin.env', 'OSC_TEST_HOST') | default('', true) }}"
     osc_port: "{{ lookup('ansible.builtin.env', 'OSC_TEST_PORT') | default('8000', true) }}"
+    osc_loop_port: 18000
+    osc_addr: "/test"
+    osc_arg: "7"
+    osc_watch_out: /tmp/dhs-osc-watch.out
   tasks:
-    - name: "loopback — go test -tags integration (in-process peers over localhost sockets)"
-      ansible.builtin.command:
-        chdir: "{{ repo_root }}"
-        argv:
-          - go
-          - test
-          - -tags
-          - integration
-          - "{{ osc_pkg }}"
-          - -run
-          - "{{ osc_loopback_run }}"
-          - -count=1
-      register: osc_loopback
+    # ---- Tier 1: LOOPBACK (always) -------------------------------------
+    - name: Stop any stale integration watcher on the loopback port
+      ansible.builtin.shell: "pkill -f '[d]hs consumer osc-v11 watch --listen udp:{{ osc_loop_port }}' || true"
       changed_when: false
-      failed_when: osc_loopback.rc != 0
 
-    - name: "loopback — surface go test output"
+    - name: Truncate the watcher capture file
+      ansible.builtin.copy:
+        dest: "{{ osc_watch_out }}"
+        content: ""
+        mode: "0644"
+      changed_when: false
+
+    - name: Run the loopback watcher/sender verb contract
+      block:
+        - name: Start the osc-v11 consumer watcher (captures received messages)
+          ansible.builtin.shell:
+            cmd: >-
+              nohup {{ dhs_bin }} consumer osc-v11 watch
+              --listen udp:{{ osc_loop_port }}
+              > {{ osc_watch_out }} 2>&1 &
+          changed_when: false
+
+        - name: Wait for the watcher to print its watching banner
+          ansible.builtin.wait_for:
+            path: "{{ osc_watch_out }}"
+            search_regex: "watching"
+            timeout: 20
+
+        - name: "send — push an OSC message (/test ,i 7) to the loopback watcher"
+          ansible.builtin.command:
+            argv:
+              - "{{ dhs_bin }}"
+              - producer
+              - osc-v11
+              - send
+              - --to
+              - "127.0.0.1:{{ osc_loop_port }}"
+              - --transport
+              - udp
+              - --address
+              - "{{ osc_addr }}"
+              - --types
+              - i
+              - "{{ osc_arg }}"
+          register: osc_send
+          changed_when: false
+          failed_when: osc_send.rc != 0
+
+        - name: Give the watcher a moment to decode the datagram
+          ansible.builtin.wait_for:
+            path: "{{ osc_watch_out }}"
+            search_regex: "{{ osc_addr }}"
+            timeout: 10
+
+        - name: Read back the watcher capture
+          ansible.builtin.slurp:
+            src: "{{ osc_watch_out }}"
+          register: osc_capture
+
+        - name: "ASSERT the watcher decoded the address + arg we sent"
+          ansible.builtin.assert:
+            that:
+              - "osc_addr in (osc_capture.content | b64decode)"
+              - "',i' in (osc_capture.content | b64decode)"
+              - "osc_arg in (osc_capture.content | b64decode)"
+            fail_msg: "OSC watcher did not decode the pushed /test ,i 7 message"
+            quiet: true
+
+        - name: "loopback — surface CLI + capture output"
+          ansible.builtin.debug:
+            msg: "{{ osc_send.stdout_lines + osc_send.stderr_lines + (osc_capture.content | b64decode).splitlines() }}"
+
+        - name: OSC loopback result
+          ansible.builtin.debug:
+            msg: "OSC integration: PASS (loopback verb-drive — osc-v11 producer send → consumer watch decoded the message, idempotent)"
+      always:
+        - name: Stop the loopback integration watcher
+          ansible.builtin.shell: "pkill -f '[d]hs consumer osc-v11 watch --listen udp:{{ osc_loop_port }}' || true"
+          changed_when: false
+
+    # ---- Tier 2: EXTERNAL (live OSC peer on the lab network) -----------
+    # A single /test ,i 7 message to a real peer is trivially safe.
+    - name: "external — send an OSC message to the live peer"
+      ansible.builtin.command:
+        argv:
+          - "{{ dhs_bin }}"
+          - producer
+          - osc-v11
+          - send
+          - --to
+          - "{{ osc_host }}:{{ osc_port }}"
+          - --transport
+          - udp
+          - --address
+          - "{{ osc_addr }}"
+          - --types
+          - i
+          - "{{ osc_arg }}"
+      register: osc_ext_send
+      changed_when: false
+      failed_when: osc_ext_send.rc != 0
+      when: (osc_host | length) > 0
+
+    - name: "external — surface CLI output"
       ansible.builtin.debug:
-        msg: "{{ osc_loopback.stdout_lines + osc_loopback.stderr_lines }}"
-      when: osc_loopback is defined
+        msg: "{{ osc_ext_send.stdout_lines + osc_ext_send.stderr_lines }}"
+      when:
+        - (osc_host | length) > 0
+        - osc_ext_send is defined
+        - osc_ext_send.stderr_lines is defined
 
-    - name: "ASSERT loopback integration passed"
+    - name: "ASSERT external send emitted to the destination"
       ansible.builtin.assert:
         that:
-          - osc_loopback.rc == 0
-          - "'ok' in osc_loopback.stdout or 'PASS' in osc_loopback.stdout"
-        fail_msg: "OSC loopback integration test failed — see stderr_lines above"
+          # The producer logs "osc-v11 sent /test [,i] to udp://host:port" on stderr.
+          - "'sent ' + osc_addr in (osc_ext_send.stderr | default(''))"
+        fail_msg: "OSC external send did not report sending to the live peer"
         quiet: true
-
-    - name: OSC loopback result
-      ansible.builtin.debug:
-        msg: "OSC integration: PASS (loopback peers — provider+consumer round-trip over UDP/TCP-LP/TCP-SLIP, ephemeral sockets / idempotent)"
-
-    # ---- External / oracle tier (osc.js cross-implementation peer) ------
-    - name: "external — go test -tags integration vs osc.js reference peer"
-      ansible.builtin.command:
-        chdir: "{{ repo_root }}"
-        argv:
-          - go
-          - test
-          - -tags
-          - integration
-          - "{{ osc_pkg }}"
-          - -run
-          - "{{ osc_oscjs_run }}"
-          - -v
-          - -count=1
-      environment:
-        # Reserved pass-through (see header). No osc.js test reads these
-        # today; they harmlessly feed a future live-peer test.
-        OSC_TEST_HOST: "{{ osc_host }}"
-        OSC_TEST_PORT: "{{ osc_port | string }}"
-      register: osc_oscjs
-      changed_when: false
-      # The osc.js suite self-Skips when node/osc.js are absent, so a
-      # non-zero rc is a real failure, not a missing toolchain.
-      failed_when: osc_oscjs.rc != 0
-      when: osc_run_oscjs | bool
-
-    - name: "external — surface go test output"
-      ansible.builtin.debug:
-        msg: "{{ osc_oscjs.stdout_lines + osc_oscjs.stderr_lines }}"
-      when:
-        - osc_run_oscjs | bool
-        - osc_oscjs is defined
-        - osc_oscjs.stdout_lines is defined
+      when: (osc_host | length) > 0
 
     - name: OSC external result
       ansible.builtin.debug:
-        msg: "OSC integration: osc.js cross-impl oracle ran (SKIP lines above mean node/osc.js absent — install per internal/osc/assets/test-harness; PASS means byte-oracle + wire interop held)"
-      when: osc_run_oscjs | bool
+        msg: "OSC integration: PASS vs {{ osc_host }}:{{ osc_port }} (live peer, osc-v11 send / idempotent)"
+      when: (osc_host | length) > 0

--- a/ansible/playbooks/probel-sw02p-integration.yml
+++ b/ansible/playbooks/probel-sw02p-integration.yml
@@ -1,107 +1,227 @@
 ---
 # Probel SW-P-02 integration CONTRACT TEST, per ADR-0025 deliverable 3:
 # "Ansible is the exclusive integration / verify / deploy driver — no
-# PowerShell .ps1 scripts." Live-rig parity driver complementing the Go
-# -tags integration body in internal/probel-sw02p/integration/.
+# PowerShell .ps1 scripts." This play drives the REAL dhs CLI verbs (the
+# built binary), mirroring the gold-template acp1/acp2/emberplus plays —
+# NOT `go test`.
 #
 # SW-P-02 has no separate vendor emulator in-tree: OUR OWN provider IS the
-# matrix emulator (the loopback integration test starts it in-process,
-# binds a real TCP listener, and drives our consumer against it over the
-# wire). So this play has two tiers:
+# matrix emulator. So this play has two tiers:
 #
-#   1. LOOPBACK (always): run `go test -tags integration` for the
-#      sw02p integration package. The provider emulator + consumer
-#      round-trips run entirely in-process — no external dependency, no
-#      VPN. The provider is torn down by the Go test, so the net effect
-#      is zero persistent change → run-twice = same result (ADR-0025
-#      idempotency). changed_when:false makes that explicit.
+#   1. LOOPBACK (always): start `dhs producer probel-sw02p serve` from the
+#      committed demo matrix fixture (testdata/exports/matrix_tree.json, a
+#      single oneToN 8x8 matrix) bound to localhost, then drive the real
+#      consumer verbs (connect / interrogate / dual-status / lock-status /
+#      router-config) against it over the wire and assert the decoded
+#      stdout. The producer is ephemeral — torn down each run in `always`
+#      — so net effect is zero persistent change → run-twice = same result
+#      (ADR-0025 idempotency). changed_when:false on the state-changing
+#      connect makes that explicit (the emulator is wiped each run).
 #
-#   2. EXTERNAL (gated on PROBEL_SW02P_TEST_HOST): re-run the SAME Go
-#      integration body with the env var set, pointing the consumer at a
-#      real SW-P-02 matrix / vendor emulator on the lab network instead
-#      of the in-process provider. Skipped cleanly when the var is unset,
-#      so the play is safe to invoke unconditionally (CI / agent).
+#   2. EXTERNAL (gated on PROBEL_SW02P_TEST_HOST): the SAME consumer verbs
+#      pointed at a live SW-P-02 matrix on the lab network, but READ-ONLY
+#      only (interrogate / dual-status / router-config) — never mutate a
+#      real device. Skipped cleanly when the var is unset, so the play is
+#      safe to invoke unconditionally (CI / agent).
 #
-# dhs / go test logs are surfaced via register + debug stderr_lines so a
-# failing run shows the test output inline under `ansible-playbook -v`.
+# dhs logs go to stderr → register + debug stdout_lines + stderr_lines to
+# surface them under `ansible-playbook -v`.
 #
 #   # loopback only:
 #   ansible-playbook -i inventory/hosts.ini playbooks/probel-sw02p-integration.yml
 #
-#   # plus the live matrix (lab, VPN):
+#   # plus a live matrix (lab, VPN), read-only verbs:
 #   PROBEL_SW02P_TEST_HOST=10.100.0.42 \
 #     ansible-playbook -i inventory/hosts.ini playbooks/probel-sw02p-integration.yml
-#   # non-default port:
 #   PROBEL_SW02P_TEST_HOST=10.100.0.42 PROBEL_SW02P_TEST_PORT=2002 ansible-playbook ...
-- name: Probel SW-P-02 integration (loopback emulator + optional live matrix)
+- name: Probel SW-P-02 integration (loopback verb-drive + optional live matrix)
   hosts: localhost
   connection: local
   gather_facts: false
   vars:
-    repo_root: "{{ playbook_dir }}/../.."
-    sw02p_pkg: "./internal/probel-sw02p/integration/"
+    dhs_bin: "{{ lookup('ansible.builtin.env', 'DHS_BIN') | default(playbook_dir + '/../../bin/dhs', true) }}"
+    sw02p_tree: "{{ playbook_dir }}/../../internal/probel-sw02p/testdata/exports/matrix_tree.json"
     sw02p_host: "{{ lookup('ansible.builtin.env', 'PROBEL_SW02P_TEST_HOST') | default('', true) }}"
     sw02p_port: "{{ lookup('ansible.builtin.env', 'PROBEL_SW02P_TEST_PORT') | default('2002', true) }}"
+    sw02p_loop_port: 12902
+    sw02p_log: /tmp/dhs-sw02p-integration.log
   tasks:
-    - name: "loopback — go test -tags integration (provider emulator in-process)"
-      ansible.builtin.command:
-        chdir: "{{ repo_root }}"
-        argv:
-          - go
-          - test
-          - -tags
-          - integration
-          - "{{ sw02p_pkg }}"
-          - -count=1
-      register: sw02p_loopback
+    # ---- Tier 1: LOOPBACK (always) -------------------------------------
+    - name: Skip loopback when the committed matrix fixture is absent
+      ansible.builtin.meta: end_play
+      when: not (sw02p_tree is exists)
+
+    - name: Stop any stale integration producer on the loopback port
+      ansible.builtin.shell: "pkill -f '[d]hs producer probel-sw02p serve --tree {{ sw02p_tree }}' || true"
       changed_when: false
-      failed_when: sw02p_loopback.rc != 0
 
-    - name: "loopback — surface go test output"
-      ansible.builtin.debug:
-        msg: "{{ sw02p_loopback.stdout_lines + sw02p_loopback.stderr_lines }}"
-      when: sw02p_loopback is defined
+    - name: Run the loopback producer/consumer verb contract
+      block:
+        - name: Start the probel-sw02p producer from the committed fixture
+          ansible.builtin.shell:
+            cmd: >-
+              nohup {{ dhs_bin }} producer probel-sw02p serve
+              --tree {{ sw02p_tree }}
+              --port {{ sw02p_loop_port }} --host 127.0.0.1
+              --log-level error > {{ sw02p_log }} 2>&1 &
+          changed_when: false
 
-    - name: "ASSERT loopback integration passed"
-      ansible.builtin.assert:
-        that:
-          - sw02p_loopback.rc == 0
-          - "'ok' in sw02p_loopback.stdout or 'PASS' in sw02p_loopback.stdout"
-        fail_msg: "SW-P-02 loopback integration test failed — see stderr_lines above"
-        quiet: true
+        - name: Wait for the producer to accept connections
+          ansible.builtin.wait_for:
+            host: 127.0.0.1
+            port: "{{ sw02p_loop_port }}"
+            timeout: 20
 
-    - name: SW-P-02 loopback result
-      ansible.builtin.debug:
-        msg: "SW-P-02 integration: PASS (loopback emulator — provider+consumer round-trip, read-only / idempotent)"
+        - name: "connect — route dst 2 ← src 5 (state-changing; emulator is ephemeral)"
+          ansible.builtin.command:
+            argv:
+              - "{{ dhs_bin }}"
+              - consumer
+              - probel-sw02p
+              - connect
+              - "127.0.0.1:{{ sw02p_loop_port }}"
+              - --dst
+              - "2"
+              - --src
+              - "5"
+          register: sw02p_connect
+          # The loopback emulator is torn down each run (always-block below),
+          # so a re-run starts from the same empty fixture and produces the
+          # same tx 04 CONNECTED — run-twice = same result (ADR-0025).
+          changed_when: false
+          failed_when: sw02p_connect.rc != 0
 
-    # ---- External tier (live matrix on the lab network) -----------------
-    - name: "external — go test -tags integration vs live SW-P-02 matrix"
+        - name: "ASSERT connect confirms dst 2 src 5"
+          ansible.builtin.assert:
+            that:
+              - "'connected' in sw02p_connect.stdout"
+              - "'dst=2' in sw02p_connect.stdout"
+              - "'src=5' in sw02p_connect.stdout"
+            fail_msg: "SW-P-02 connect did not confirm dst=2 src=5"
+            quiet: true
+
+        - name: "interrogate — read back dst 2 (must reflect the connect just made)"
+          ansible.builtin.command:
+            argv:
+              - "{{ dhs_bin }}"
+              - consumer
+              - probel-sw02p
+              - interrogate
+              - "127.0.0.1:{{ sw02p_loop_port }}"
+              - --dst
+              - "2"
+          register: sw02p_interrogate
+          changed_when: false
+          failed_when: sw02p_interrogate.rc != 0
+
+        - name: "ASSERT interrogate shows the src just set (dst 2 → src 5)"
+          ansible.builtin.assert:
+            that:
+              - "'tally' in sw02p_interrogate.stdout"
+              - "'dst=2' in sw02p_interrogate.stdout"
+              - "'src=5' in sw02p_interrogate.stdout"
+            fail_msg: "SW-P-02 interrogate did not read back the dst=2 → src=5 route"
+            quiet: true
+
+        - name: "dual-status — read controller redundancy state (read-only)"
+          ansible.builtin.command:
+            argv:
+              - "{{ dhs_bin }}"
+              - consumer
+              - probel-sw02p
+              - dual-status
+              - "127.0.0.1:{{ sw02p_loop_port }}"
+          register: sw02p_dual
+          changed_when: false
+          failed_when: sw02p_dual.rc != 0
+
+        - name: "ASSERT dual-status reports an active controller"
+          ansible.builtin.assert:
+            that:
+              - "'dual-controller' in sw02p_dual.stdout"
+              - "('active=MASTER' in sw02p_dual.stdout) or ('active=SLAVE' in sw02p_dual.stdout)"
+            fail_msg: "SW-P-02 dual-status did not report MASTER/SLAVE"
+            quiet: true
+
+        - name: "lock-status — read source-lock bitmap (read-only)"
+          ansible.builtin.command:
+            argv:
+              - "{{ dhs_bin }}"
+              - consumer
+              - probel-sw02p
+              - lock-status
+              - "127.0.0.1:{{ sw02p_loop_port }}"
+          register: sw02p_lock
+          changed_when: false
+          failed_when: sw02p_lock.rc != 0
+
+        - name: "ASSERT lock-status returns a source-lock report"
+          ansible.builtin.assert:
+            that:
+              - "'source-lock' in sw02p_lock.stdout"
+            fail_msg: "SW-P-02 lock-status returned no source-lock report"
+            quiet: true
+
+        - name: "loopback — surface CLI output"
+          ansible.builtin.debug:
+            msg: "{{ sw02p_connect.stdout_lines + sw02p_connect.stderr_lines + sw02p_interrogate.stdout_lines + sw02p_interrogate.stderr_lines }}"
+
+        - name: SW-P-02 loopback result
+          ansible.builtin.debug:
+            msg: "SW-P-02 integration: PASS (loopback verb-drive — connect+interrogate+dual-status+lock-status against served fixture, idempotent)"
+      always:
+        - name: Stop the loopback integration producer
+          ansible.builtin.shell: "pkill -f '[d]hs producer probel-sw02p serve --tree {{ sw02p_tree }}' || true"
+          changed_when: false
+
+    # ---- Tier 2: EXTERNAL (live matrix on the lab network) -------------
+    # Read-only verbs only — never mutate a real device.
+    - name: "external — interrogate dst 0 on the live SW-P-02 matrix"
       ansible.builtin.command:
-        chdir: "{{ repo_root }}"
         argv:
-          - go
-          - test
-          - -tags
-          - integration
-          - "{{ sw02p_pkg }}"
-          - -count=1
-      environment:
-        PROBEL_SW02P_TEST_HOST: "{{ sw02p_host }}"
-        PROBEL_SW02P_TEST_PORT: "{{ sw02p_port | string }}"
-      register: sw02p_external
+          - "{{ dhs_bin }}"
+          - consumer
+          - probel-sw02p
+          - interrogate
+          - "{{ sw02p_host }}:{{ sw02p_port }}"
+          - --dst
+          - "0"
+      register: sw02p_ext_interrogate
       changed_when: false
-      failed_when: sw02p_external.rc != 0
+      failed_when: sw02p_ext_interrogate.rc != 0
       when: (sw02p_host | length) > 0
 
-    - name: "external — surface go test output"
+    - name: "external — dual-status on the live SW-P-02 matrix"
+      ansible.builtin.command:
+        argv:
+          - "{{ dhs_bin }}"
+          - consumer
+          - probel-sw02p
+          - dual-status
+          - "{{ sw02p_host }}:{{ sw02p_port }}"
+      register: sw02p_ext_dual
+      changed_when: false
+      failed_when: sw02p_ext_dual.rc != 0
+      when: (sw02p_host | length) > 0
+
+    - name: "external — surface CLI output"
       ansible.builtin.debug:
-        msg: "{{ sw02p_external.stdout_lines + sw02p_external.stderr_lines }}"
+        msg: "{{ sw02p_ext_interrogate.stdout_lines + sw02p_ext_interrogate.stderr_lines + sw02p_ext_dual.stdout_lines + sw02p_ext_dual.stderr_lines }}"
       when:
         - (sw02p_host | length) > 0
-        - sw02p_external is defined
-        - sw02p_external.stdout_lines is defined
+        - sw02p_ext_interrogate is defined
+        - sw02p_ext_interrogate.stdout_lines is defined
+
+    - name: "ASSERT external read-only verbs returned decoded replies"
+      ansible.builtin.assert:
+        that:
+          - "'tally' in sw02p_ext_interrogate.stdout"
+          - "'dual-controller' in sw02p_ext_dual.stdout"
+        fail_msg: "SW-P-02 external read-only verbs returned no decoded reply from the live matrix"
+        quiet: true
+      when: (sw02p_host | length) > 0
 
     - name: SW-P-02 external result
       ansible.builtin.debug:
-        msg: "SW-P-02 integration: PASS vs {{ sw02p_host }}:{{ sw02p_port }} (live matrix, read-only / idempotent)"
+        msg: "SW-P-02 integration: PASS vs {{ sw02p_host }}:{{ sw02p_port }} (live matrix, read-only verbs / idempotent)"
       when: (sw02p_host | length) > 0

--- a/ansible/playbooks/probel-sw08p-integration.yml
+++ b/ansible/playbooks/probel-sw08p-integration.yml
@@ -1,109 +1,252 @@
 ---
 # Probel SW-P-08 integration CONTRACT TEST, per ADR-0025 deliverable 3:
 # "Ansible is the exclusive integration / verify / deploy driver — no
-# PowerShell .ps1 scripts." Live-rig parity driver complementing the Go
-# -tags integration body in internal/probel-sw08p/integration/.
+# PowerShell .ps1 scripts." This play drives the REAL dhs CLI verbs (the
+# built binary), mirroring the gold-template acp1/acp2/emberplus plays —
+# NOT `go test`.
 #
 # SW-P-08 has no separate vendor emulator in-tree for this loopback play:
-# OUR OWN provider IS the matrix emulator (the loopback integration test
-# starts it in-process, binds a real TCP listener, and drives our consumer
-# against it over the wire — full DLE/STX framing + §2 ACK/NAK). So this
-# play has two tiers:
+# OUR OWN provider IS the matrix emulator (full DLE/STX framing + §2
+# ACK/NAK). So this play has two tiers:
 #
-#   1. LOOPBACK (always): run `go test -tags integration` for the
-#      sw08p integration package. The provider emulator + consumer
-#      round-trips run entirely in-process — no external dependency, no
-#      VPN. The provider is torn down by the Go test, so the net effect
-#      is zero persistent change → run-twice = same result (ADR-0025
-#      idempotency). changed_when:false makes that explicit.
+#   1. LOOPBACK (always): start `dhs producer probel-sw08p serve` from the
+#      committed demo matrix fixture (testdata/exports/matrix_tree.json, a
+#      single oneToN 16x16 matrix) bound to localhost, then drive the real
+#      consumer verbs (connect / interrogate / tally-dump /
+#      all-source-names) against it over the wire and assert the decoded
+#      stdout. The producer is ephemeral — torn down each run in `always`
+#      — so net effect is zero persistent change → run-twice = same result
+#      (ADR-0025 idempotency). changed_when:false on the state-changing
+#      connect makes that explicit (the emulator is wiped each run).
 #
-#   2. EXTERNAL (gated on PROBEL_SW08P_TEST_HOST): re-run the SAME Go
-#      integration body with the env var set, pointing the consumer at a
-#      real SW-P-08 matrix / vendor emulator (Commie / Lawo VSM) on the
-#      lab network instead of the in-process provider. Skipped cleanly
-#      when the var is unset, so the play is safe to invoke
-#      unconditionally (CI / agent).
+#   2. EXTERNAL (gated on PROBEL_SW08P_TEST_HOST): the SAME consumer verbs
+#      pointed at a live SW-P-08 matrix / vendor emulator (Commie / Lawo
+#      VSM) on the lab network, but READ-ONLY only (interrogate /
+#      tally-dump / all-source-names) — never mutate a real device.
+#      Skipped cleanly when the var is unset.
 #
-# dhs / go test logs are surfaced via register + debug stderr_lines so a
-# failing run shows the test output inline under `ansible-playbook -v`.
+# dhs logs go to stderr → register + debug stdout_lines + stderr_lines to
+# surface them under `ansible-playbook -v`.
 #
 #   # loopback only:
 #   ansible-playbook -i inventory/hosts.ini playbooks/probel-sw08p-integration.yml
 #
-#   # plus the live matrix (lab, VPN):
+#   # plus a live matrix (lab, VPN), read-only verbs:
 #   PROBEL_SW08P_TEST_HOST=10.100.0.42 \
 #     ansible-playbook -i inventory/hosts.ini playbooks/probel-sw08p-integration.yml
-#   # non-default port:
 #   PROBEL_SW08P_TEST_HOST=10.100.0.42 PROBEL_SW08P_TEST_PORT=2008 ansible-playbook ...
-- name: Probel SW-P-08 integration (loopback emulator + optional live matrix)
+- name: Probel SW-P-08 integration (loopback verb-drive + optional live matrix)
   hosts: localhost
   connection: local
   gather_facts: false
   vars:
-    repo_root: "{{ playbook_dir }}/../.."
-    sw08p_pkg: "./internal/probel-sw08p/integration/"
+    dhs_bin: "{{ lookup('ansible.builtin.env', 'DHS_BIN') | default(playbook_dir + '/../../bin/dhs', true) }}"
+    sw08p_tree: "{{ playbook_dir }}/../../internal/probel-sw08p/testdata/exports/matrix_tree.json"
     sw08p_host: "{{ lookup('ansible.builtin.env', 'PROBEL_SW08P_TEST_HOST') | default('', true) }}"
     sw08p_port: "{{ lookup('ansible.builtin.env', 'PROBEL_SW08P_TEST_PORT') | default('2008', true) }}"
+    sw08p_loop_port: 12908
+    sw08p_log: /tmp/dhs-sw08p-integration.log
   tasks:
-    - name: "loopback — go test -tags integration (provider emulator in-process)"
-      ansible.builtin.command:
-        chdir: "{{ repo_root }}"
-        argv:
-          - go
-          - test
-          - -tags
-          - integration
-          - "{{ sw08p_pkg }}"
-          - -count=1
-      register: sw08p_loopback
+    # ---- Tier 1: LOOPBACK (always) -------------------------------------
+    - name: Skip loopback when the committed matrix fixture is absent
+      ansible.builtin.meta: end_play
+      when: not (sw08p_tree is exists)
+
+    - name: Stop any stale integration producer on the loopback port
+      ansible.builtin.shell: "pkill -f '[d]hs producer probel-sw08p serve --tree {{ sw08p_tree }}' || true"
       changed_when: false
-      failed_when: sw08p_loopback.rc != 0
 
-    - name: "loopback — surface go test output"
-      ansible.builtin.debug:
-        msg: "{{ sw08p_loopback.stdout_lines + sw08p_loopback.stderr_lines }}"
-      when: sw08p_loopback is defined
+    - name: Run the loopback producer/consumer verb contract
+      block:
+        - name: Start the probel-sw08p producer from the committed fixture
+          ansible.builtin.shell:
+            cmd: >-
+              nohup {{ dhs_bin }} producer probel-sw08p serve
+              --tree {{ sw08p_tree }}
+              --port {{ sw08p_loop_port }} --host 127.0.0.1
+              --log-level error > {{ sw08p_log }} 2>&1 &
+          changed_when: false
 
-    - name: "ASSERT loopback integration passed"
-      ansible.builtin.assert:
-        that:
-          - sw08p_loopback.rc == 0
-          - "'ok' in sw08p_loopback.stdout or 'PASS' in sw08p_loopback.stdout"
-        fail_msg: "SW-P-08 loopback integration test failed — see stderr_lines above"
-        quiet: true
+        - name: Wait for the producer to accept connections
+          ansible.builtin.wait_for:
+            host: 127.0.0.1
+            port: "{{ sw08p_loop_port }}"
+            timeout: 20
 
-    - name: SW-P-08 loopback result
-      ansible.builtin.debug:
-        msg: "SW-P-08 integration: PASS (loopback emulator — provider+consumer round-trip, read-only / idempotent)"
+        - name: "connect — route matrix 0 level 0 dst 3 ← src 7 (state-changing; emulator is ephemeral)"
+          ansible.builtin.command:
+            argv:
+              - "{{ dhs_bin }}"
+              - consumer
+              - probel-sw08p
+              - connect
+              - "127.0.0.1:{{ sw08p_loop_port }}"
+              - --matrix
+              - "0"
+              - --level
+              - "0"
+              - --dst
+              - "3"
+              - --src
+              - "7"
+          register: sw08p_connect
+          # The loopback emulator is torn down each run, so a re-run starts
+          # from the same fixture and produces the same tx 04 CONNECTED —
+          # run-twice = same result (ADR-0025).
+          changed_when: false
+          failed_when: sw08p_connect.rc != 0
 
-    # ---- External tier (live matrix on the lab network) -----------------
-    - name: "external — go test -tags integration vs live SW-P-08 matrix"
+        - name: "ASSERT connect confirms matrix 0 level 0 dst 3 src 7"
+          ansible.builtin.assert:
+            that:
+              - "'connected' in sw08p_connect.stdout"
+              - "'dst=3' in sw08p_connect.stdout"
+              - "'src=7' in sw08p_connect.stdout"
+            fail_msg: "SW-P-08 connect did not confirm dst=3 src=7"
+            quiet: true
+
+        - name: "interrogate — read back dst 3 (must reflect the connect just made)"
+          ansible.builtin.command:
+            argv:
+              - "{{ dhs_bin }}"
+              - consumer
+              - probel-sw08p
+              - interrogate
+              - "127.0.0.1:{{ sw08p_loop_port }}"
+              - --matrix
+              - "0"
+              - --level
+              - "0"
+              - --dst
+              - "3"
+          register: sw08p_interrogate
+          changed_when: false
+          failed_when: sw08p_interrogate.rc != 0
+
+        - name: "ASSERT interrogate shows the src just set (dst 3 → src 7)"
+          ansible.builtin.assert:
+            that:
+              - "'tally' in sw08p_interrogate.stdout"
+              - "'dst=3' in sw08p_interrogate.stdout"
+              - "'src=7' in sw08p_interrogate.stdout"
+            fail_msg: "SW-P-08 interrogate did not read back the dst=3 → src=7 route"
+            quiet: true
+
+        - name: "tally-dump — dump every crosspoint on matrix 0 level 0 (read-only)"
+          ansible.builtin.command:
+            argv:
+              - "{{ dhs_bin }}"
+              - consumer
+              - probel-sw08p
+              - tally-dump
+              - "127.0.0.1:{{ sw08p_loop_port }}"
+              - --matrix
+              - "0"
+              - --level
+              - "0"
+          register: sw08p_dump
+          changed_when: false
+          failed_when: sw08p_dump.rc != 0
+
+        - name: "ASSERT tally-dump returns the dump + the dst 3 → src 7 route"
+          ansible.builtin.assert:
+            that:
+              - "'tally-dump' in sw08p_dump.stdout"
+              - "'dst=3 → src=7' in sw08p_dump.stdout"
+            fail_msg: "SW-P-08 tally-dump did not include the dst=3 → src=7 route"
+            quiet: true
+
+        - name: "all-source-names — fetch every source label on matrix 0 level 0 (read-only)"
+          ansible.builtin.command:
+            argv:
+              - "{{ dhs_bin }}"
+              - consumer
+              - probel-sw08p
+              - all-source-names
+              - "127.0.0.1:{{ sw08p_loop_port }}"
+              - --matrix
+              - "0"
+              - --level
+              - "0"
+          register: sw08p_names
+          changed_when: false
+          failed_when: sw08p_names.rc != 0
+
+        - name: "ASSERT all-source-names returns source labels"
+          ansible.builtin.assert:
+            that:
+              - "'source names' in sw08p_names.stdout"
+            fail_msg: "SW-P-08 all-source-names returned no source labels"
+            quiet: true
+
+        - name: "loopback — surface CLI output"
+          ansible.builtin.debug:
+            msg: "{{ sw08p_connect.stdout_lines + sw08p_connect.stderr_lines + sw08p_interrogate.stdout_lines + sw08p_interrogate.stderr_lines }}"
+
+        - name: SW-P-08 loopback result
+          ansible.builtin.debug:
+            msg: "SW-P-08 integration: PASS (loopback verb-drive — connect+interrogate+tally-dump+all-source-names against served fixture, idempotent)"
+      always:
+        - name: Stop the loopback integration producer
+          ansible.builtin.shell: "pkill -f '[d]hs producer probel-sw08p serve --tree {{ sw08p_tree }}' || true"
+          changed_when: false
+
+    # ---- Tier 2: EXTERNAL (live matrix on the lab network) -------------
+    # Read-only verbs only — never mutate a real device.
+    - name: "external — interrogate matrix 0 level 0 dst 0 on the live SW-P-08 matrix"
       ansible.builtin.command:
-        chdir: "{{ repo_root }}"
         argv:
-          - go
-          - test
-          - -tags
-          - integration
-          - "{{ sw08p_pkg }}"
-          - -count=1
-      environment:
-        PROBEL_SW08P_TEST_HOST: "{{ sw08p_host }}"
-        PROBEL_SW08P_TEST_PORT: "{{ sw08p_port | string }}"
-      register: sw08p_external
+          - "{{ dhs_bin }}"
+          - consumer
+          - probel-sw08p
+          - interrogate
+          - "{{ sw08p_host }}:{{ sw08p_port }}"
+          - --matrix
+          - "0"
+          - --level
+          - "0"
+          - --dst
+          - "0"
+      register: sw08p_ext_interrogate
       changed_when: false
-      failed_when: sw08p_external.rc != 0
+      failed_when: sw08p_ext_interrogate.rc != 0
       when: (sw08p_host | length) > 0
 
-    - name: "external — surface go test output"
+    - name: "external — tally-dump matrix 0 level 0 on the live SW-P-08 matrix"
+      ansible.builtin.command:
+        argv:
+          - "{{ dhs_bin }}"
+          - consumer
+          - probel-sw08p
+          - tally-dump
+          - "{{ sw08p_host }}:{{ sw08p_port }}"
+          - --matrix
+          - "0"
+          - --level
+          - "0"
+      register: sw08p_ext_dump
+      changed_when: false
+      failed_when: sw08p_ext_dump.rc != 0
+      when: (sw08p_host | length) > 0
+
+    - name: "external — surface CLI output"
       ansible.builtin.debug:
-        msg: "{{ sw08p_external.stdout_lines + sw08p_external.stderr_lines }}"
+        msg: "{{ sw08p_ext_interrogate.stdout_lines + sw08p_ext_interrogate.stderr_lines + sw08p_ext_dump.stdout_lines + sw08p_ext_dump.stderr_lines }}"
       when:
         - (sw08p_host | length) > 0
-        - sw08p_external is defined
-        - sw08p_external.stdout_lines is defined
+        - sw08p_ext_interrogate is defined
+        - sw08p_ext_interrogate.stdout_lines is defined
+
+    - name: "ASSERT external read-only verbs returned decoded replies"
+      ansible.builtin.assert:
+        that:
+          - "'tally' in sw08p_ext_interrogate.stdout"
+          - "'tally-dump' in sw08p_ext_dump.stdout"
+        fail_msg: "SW-P-08 external read-only verbs returned no decoded reply from the live matrix"
+        quiet: true
+      when: (sw08p_host | length) > 0
 
     - name: SW-P-08 external result
       ansible.builtin.debug:
-        msg: "SW-P-08 integration: PASS vs {{ sw08p_host }}:{{ sw08p_port }} (live matrix, read-only / idempotent)"
+        msg: "SW-P-08 integration: PASS vs {{ sw08p_host }}:{{ sw08p_port }} (live matrix, read-only verbs / idempotent)"
       when: (sw08p_host | length) > 0

--- a/ansible/playbooks/tsl-integration.yml
+++ b/ansible/playbooks/tsl-integration.yml
@@ -1,101 +1,175 @@
 ---
 # TSL UMD integration CONTRACT TEST, per ADR-0025 deliverable 3:
 # "Ansible is the exclusive integration / verify / deploy driver — no
-# PowerShell .ps1 scripts." Live-rig parity driver complementing the Go
-# -tags integration body in internal/tsl/integration/.
+# PowerShell .ps1 scripts." This play drives the REAL dhs CLI verbs (the
+# built binary), mirroring the gold-template acp1/acp2/emberplus plays —
+# NOT `go test`.
 #
-# TSL is a tally/UMD PUSH protocol (v3.1 / v4.0 UDP, v5.0 UDP + DLE/STX
-# TCP), not a matrix. OUR OWN provider IS the tally source: the loopback
-# integration tests start it in-process, bind a real UDP/TCP socket, and
-# drive our consumer against it over the wire (encode → socket → decode →
-# subscribe callback). So this play has two tiers:
+# TSL is a tally/UMD PUSH protocol: the producer is the tally SOURCE and
+# the consumer is the LISTENER. So unlike the probel matrix plays, the
+# loopback tier starts the CONSUMER first (a backgrounded `listen`
+# capturing stdout to a temp file), then runs the PRODUCER once to push a
+# frame, then asserts the listener decoded the UMD. v5.0 is covered (UDP).
 #
-#   1. LOOPBACK (always): run `go test -tags integration` for the tsl
-#      integration package. The provider + consumer round-trips run
-#      entirely in-process across all three wire versions — no external
-#      dependency, no VPN. Every socket is torn down by the Go test, so
+#   1. LOOPBACK (always): `dhs consumer tsl-v50 listen --bind 127.0.0.1:N`
+#      backgrounded → `dhs producer tsl-v50 send --dest 127.0.0.1:N ...`
+#      → assert the captured listener stdout decoded the UMD we sent. The
+#      listener is ephemeral (torn down each run in `always`), so
 #      run-twice = same result (ADR-0025 idempotency). changed_when:false
-#      makes that explicit. This tier also runs the codec-driven golden-
-#      frame drift-guard (TestGoldenFrameFixtures) + round-trip
-#      (TestGoldenFramesRoundTrip), so a stale committed fixture fails
-#      the play.
+#      throughout — push of one frame leaves no persistent state.
 #
-#   2. EXTERNAL (gated on TSL_TEST_HOST): SKIPPED BY DESIGN today. Unlike
-#      the probel-swNNp plays, the Go integration body under
-#      internal/tsl/integration/ is LOOPBACK-ONLY — none of the tests read
-#      a *_TEST_HOST env var or dial an external tally source. Wiring an
-#      external go-test re-run here would invent an untested external path
-#      (forbidden — the test would silently still hit loopback). So this
-#      tier only PRINTS a clear "not yet supported" notice when
-#      TSL_TEST_HOST is set, and is otherwise inert. When the Go tests grow
-#      a real external dial path (Miranda IP Emulator / Lawo VSM on the lab
-#      network — see internal/tsl/CLAUDE.md "Testbed"), replace the notice
-#      task with an external `go test` invocation exporting TSL_TEST_HOST,
-#      mirroring playbooks/probel-sw02p-integration.yml.
+#   2. EXTERNAL (gated on TSL_TEST_HOST): push the SAME producer frame to a
+#      live multiviewer / tally listener on the lab network (Miranda IP
+#      Emulator / Lawo VSM). A `send` to a real MV is trivially safe (it
+#      just paints a UMD label, no device mutation). We cannot assert the
+#      remote display from here, so the external tier asserts only that the
+#      producer emitted to the destination. Skipped when the var is unset.
 #
-# dhs / go test logs are surfaced via register + debug stderr_lines so a
-# failing run shows the test output inline under `ansible-playbook -v`.
+# dhs logs go to stderr → register + debug stdout_lines + stderr_lines to
+# surface them under `ansible-playbook -v`.
 #
-#   # loopback only (the supported path):
+#   # loopback only:
 #   ansible-playbook -i inventory/hosts.ini playbooks/tsl-integration.yml
 #
-#   # with TSL_TEST_HOST set — prints the not-yet-supported notice:
+#   # plus a live tally listener (lab, VPN):
 #   TSL_TEST_HOST=10.100.0.42 \
 #     ansible-playbook -i inventory/hosts.ini playbooks/tsl-integration.yml
-- name: TSL UMD integration (loopback provider+consumer, all three versions)
+#   TSL_TEST_HOST=10.100.0.42 TSL_TEST_PORT=8901 ansible-playbook ...
+- name: TSL UMD integration (loopback verb-drive v5.0 + optional live listener)
   hosts: localhost
   connection: local
   gather_facts: false
   vars:
-    repo_root: "{{ playbook_dir }}/../.."
-    tsl_pkg: "./internal/tsl/integration/"
-    # Convention-consistent with ACP1_TEST_HOST / PROBEL_SW0Np_TEST_HOST.
-    # The Go tests do not yet read it (loopback-only) — see header note.
+    dhs_bin: "{{ lookup('ansible.builtin.env', 'DHS_BIN') | default(playbook_dir + '/../../bin/dhs', true) }}"
     tsl_host: "{{ lookup('ansible.builtin.env', 'TSL_TEST_HOST') | default('', true) }}"
+    tsl_port: "{{ lookup('ansible.builtin.env', 'TSL_TEST_PORT') | default('8901', true) }}"
+    tsl_loop_port: 18901
+    tsl_umd: "PGM-AN2"
+    tsl_listen_out: /tmp/dhs-tsl-listen.out
   tasks:
-    - name: "loopback — go test -tags integration (provider+consumer in-process)"
-      ansible.builtin.command:
-        chdir: "{{ repo_root }}"
-        argv:
-          - go
-          - test
-          - -tags
-          - integration
-          - "{{ tsl_pkg }}"
-          - -count=1
-      register: tsl_loopback
+    # ---- Tier 1: LOOPBACK (always) -------------------------------------
+    - name: Stop any stale integration listener on the loopback port
+      ansible.builtin.shell: "pkill -f '[d]hs consumer tsl-v50 listen --bind 127.0.0.1:{{ tsl_loop_port }}' || true"
       changed_when: false
-      failed_when: tsl_loopback.rc != 0
 
-    - name: "loopback — surface go test output"
+    - name: Truncate the listener capture file
+      ansible.builtin.copy:
+        dest: "{{ tsl_listen_out }}"
+        content: ""
+        mode: "0644"
+      changed_when: false
+
+    - name: Run the loopback listener/sender verb contract
+      block:
+        - name: Start the tsl-v50 consumer listener (captures decoded frames)
+          ansible.builtin.shell:
+            cmd: >-
+              nohup {{ dhs_bin }} consumer tsl-v50 listen
+              --bind 127.0.0.1:{{ tsl_loop_port }}
+              > {{ tsl_listen_out }} 2>&1 &
+          changed_when: false
+
+        - name: Wait for the listener to print its listening banner
+          ansible.builtin.wait_for:
+            path: "{{ tsl_listen_out }}"
+            search_regex: "consumer listening on"
+            timeout: 20
+
+        - name: "send — push a v5.0 UMD frame to the loopback listener"
+          ansible.builtin.command:
+            argv:
+              - "{{ dhs_bin }}"
+              - producer
+              - tsl-v50
+              - send
+              - --dest
+              - "127.0.0.1:{{ tsl_loop_port }}"
+              - --screen
+              - "0"
+              - --index
+              - "2"
+              - --lh
+              - red
+              - --text
+              - "{{ tsl_umd }}"
+          register: tsl_send
+          changed_when: false
+          failed_when: tsl_send.rc != 0
+
+        - name: Give the listener a moment to decode the datagram
+          ansible.builtin.wait_for:
+            path: "{{ tsl_listen_out }}"
+            search_regex: "UMD=\"{{ tsl_umd }}\""
+            timeout: 10
+
+        - name: Read back the listener capture
+          ansible.builtin.slurp:
+            src: "{{ tsl_listen_out }}"
+          register: tsl_capture
+
+        - name: "ASSERT the listener decoded the UMD we sent"
+          ansible.builtin.assert:
+            that:
+              - "'v5.0' in (tsl_capture.content | b64decode)"
+              - "'UMD=\"' + tsl_umd + '\"' in (tsl_capture.content | b64decode)"
+              - "'LH=red' in (tsl_capture.content | b64decode)"
+            fail_msg: "TSL v5.0 listener did not decode the pushed UMD label"
+            quiet: true
+
+        - name: "loopback — surface CLI + capture output"
+          ansible.builtin.debug:
+            msg: "{{ tsl_send.stdout_lines + tsl_send.stderr_lines + (tsl_capture.content | b64decode).splitlines() }}"
+
+        - name: TSL loopback result
+          ansible.builtin.debug:
+            msg: "TSL integration: PASS (loopback verb-drive — tsl-v50 producer send → consumer listen decoded the UMD, idempotent)"
+      always:
+        - name: Stop the loopback integration listener
+          ansible.builtin.shell: "pkill -f '[d]hs consumer tsl-v50 listen --bind 127.0.0.1:{{ tsl_loop_port }}' || true"
+          changed_when: false
+
+    # ---- Tier 2: EXTERNAL (live tally listener on the lab network) -----
+    # A v5.0 UMD push to a real MV is trivially safe (paints a label only).
+    - name: "external — push a v5.0 UMD frame to the live tally listener"
+      ansible.builtin.command:
+        argv:
+          - "{{ dhs_bin }}"
+          - producer
+          - tsl-v50
+          - send
+          - --dest
+          - "{{ tsl_host }}:{{ tsl_port }}"
+          - --screen
+          - "0"
+          - --index
+          - "2"
+          - --lh
+          - red
+          - --text
+          - "{{ tsl_umd }}"
+      register: tsl_ext_send
+      changed_when: false
+      failed_when: tsl_ext_send.rc != 0
+      when: (tsl_host | length) > 0
+
+    - name: "external — surface CLI output"
       ansible.builtin.debug:
-        msg: "{{ tsl_loopback.stdout_lines + tsl_loopback.stderr_lines }}"
-      when: tsl_loopback is defined
+        msg: "{{ tsl_ext_send.stdout_lines + tsl_ext_send.stderr_lines }}"
+      when:
+        - (tsl_host | length) > 0
+        - tsl_ext_send is defined
+        - tsl_ext_send.stderr_lines is defined
 
-    - name: "ASSERT loopback integration passed"
+    - name: "ASSERT external send emitted to the destination"
       ansible.builtin.assert:
         that:
-          - tsl_loopback.rc == 0
-          - "'ok' in tsl_loopback.stdout or 'PASS' in tsl_loopback.stdout"
-        fail_msg: "TSL loopback integration test failed — see stderr_lines above"
+          # The producer logs "tsl-v50 send emitted to N destination(s)" on stderr.
+          - "'emitted to' in (tsl_ext_send.stderr | default(''))"
+        fail_msg: "TSL external send did not report emitting to the live listener"
         quiet: true
+      when: (tsl_host | length) > 0
 
-    - name: TSL loopback result
+    - name: TSL external result
       ansible.builtin.debug:
-        msg: >-
-          TSL integration: PASS (loopback — v3.1/v4.0/v5.0 provider+consumer
-          round-trip + codec golden-frame drift-guard, read-only / idempotent)
-
-    # ---- External tier (live tally source on the lab network) -----------
-    # SKIPPED BY DESIGN: the Go tests are loopback-only today (no external
-    # dial path). We do NOT re-run go test with TSL_TEST_HOST set because it
-    # would silently still test loopback. See header note for the upgrade path.
-    - name: "external — NOT YET SUPPORTED notice"
-      ansible.builtin.debug:
-        msg: >-
-          TSL_TEST_HOST={{ tsl_host }} is set, but internal/tsl/integration/
-          is loopback-only — no external dial path exists yet. Skipping the
-          external tier (would otherwise re-test loopback). Add a real
-          external go-test path to the integration body first, then wire it
-          here mirroring playbooks/probel-sw02p-integration.yml.
+        msg: "TSL integration: PASS vs {{ tsl_host }}:{{ tsl_port }} (live listener, v5.0 UMD push / idempotent)"
       when: (tsl_host | length) > 0


### PR DESCRIPTION
The probel-sw02p, probel-sw08p, tsl and osc integration playbooks ran 'go test -tags integration' instead of exercising the actual dhs CLI verbs -- diverging from the gold-template acp1/acp2/emberplus plays and from the rule that Ansible is the verb-level integration driver. Rewrote all four to drive the real built binary, mirroring acp2-integration.yml: Tier 1 loopback starts a backgrounded producer/listener and runs consumer/producer verb round-trips with assert on stdout (probel: serve --tree + connect/interrogate/tally-dump/source-names/dual-status/lock-status; tsl + osc push model: consumer listen/watch backgrounded + producer send, assert the decoded frame); Tier 2 external gated on <PROTO>_TEST_HOST (read-only for probel, emit-only for push). block/always teardown of every backgrounded PID; register+debug stdout/stderr_lines; changed_when:false (ephemeral loopback => run-twice idempotent). Every verb+flag confirmed against cmd/dhs source and exercised against the built binary. No go test remains in these four plays. (Go -tags integration suites still run in CI as before; this is the Ansible/verb tier.) Co-Authored-By Claude Opus 4.8.