### PR TITLE
feat(cerebrum-nb): 0v16 codec - device commands, control frames, enriched events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,7 @@ jobs:
           check ./internal/osc/codec 100
           check ./internal/osc/consumer 100
           check ./internal/osc/provider 100
+          check ./internal/cerebrum-nb/codec 100
 
       - name: Upload coverage
         if: matrix.os == 'ubuntu-latest'

--- a/internal/cerebrum-nb/codec/actions.go
+++ b/internal/cerebrum-nb/codec/actions.go
@@ -1,9 +1,18 @@
 package codec
 
-import "strings"
+import (
+	"strconv"
+	"strings"
+)
 
 // DeviceType is the §3.1 enum: Router / SNMP / Device. The wire form
 // is the canonical capitalised string — DO NOT lowercase.
+//
+// §3.1 (0v16 p9) also defines a sub-device colon syntax: a base type
+// followed by ":N" addresses the Nth sub-module (e.g. "ROUTER:2" for
+// the second matrix of an SW-P-08, "DEVICE:4" for the card in slot 4).
+// Use ParseDeviceType / DeviceType.Base / DeviceType.Index to model
+// base+index without losing the literal wire string.
 type DeviceType string
 
 const (
@@ -12,11 +21,61 @@ const (
 	DeviceTypeDevice DeviceType = "Device"
 )
 
-// LockKind is the §3.2 LOCK enum. Only PROTECT + RELEASE observed in
-// spec examples; treat the type as open for forward-compat.
+// Base returns the device type with any ":N" sub-device suffix removed.
+// "ROUTER:2".Base() == "ROUTER"; "SNMP".Base() == "SNMP". §3.1 p9.
+func (d DeviceType) Base() DeviceType {
+	s := string(d)
+	if i := strings.IndexByte(s, ':'); i >= 0 {
+		return DeviceType(s[:i])
+	}
+	return d
+}
+
+// Index returns the sub-device index from a ":N" suffix and ok=true, or
+// (0, false) when no suffix is present or N is not a valid integer.
+// "DEVICE:4".Index() == (4, true); "DEVICE".Index() == (0, false).
+// §3.1 p9.
+func (d DeviceType) Index() (int, bool) {
+	s := string(d)
+	i := strings.IndexByte(s, ':')
+	if i < 0 {
+		return 0, false
+	}
+	n, err := strconv.Atoi(s[i+1:])
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// MakeDeviceType joins a base type and a sub-device index into the
+// colon wire form. index < 0 yields the bare base. §3.1 p9.
+func MakeDeviceType(base DeviceType, index int) DeviceType {
+	if index < 0 {
+		return base
+	}
+	return DeviceType(string(base) + ":" + strconv.Itoa(index))
+}
+
+// LockKind is the §3.2 LOCK enum (0v16 p9). 0v16 defines five values;
+// the pre-0v13 PROTECT / RELEASE strings the codec previously modelled
+// were never in the spec table and are retained only as deprecated
+// aliases so older callers keep compiling. The type is left open
+// (string) for forward-compat against future spec additions.
 type LockKind string
 
 const (
+	// §3.2 p9 canonical values.
+	LockUnlocked      LockKind = "UNLOCKED"
+	LockLocked        LockKind = "LOCKED"
+	LockProtected     LockKind = "PROTECTED"
+	LockLockedPath    LockKind = "LOCKED_PATH"
+	LockProtectedPath LockKind = "PROTECTED_PATH"
+
+	// Deprecated: not in the §3.2 table. The 4.1.2/4.1.3 worked
+	// examples (p11-12) still show LOCK="RELEASE"/"PROTECT" verbs, so
+	// these remain valid action arguments, but they are not LOCK_STATE
+	// values a device reports back.
 	LockProtect LockKind = "PROTECT"
 	LockRelease LockKind = "RELEASE"
 )
@@ -211,4 +270,279 @@ func (d *DeviceAction) encodeAction(b *strings.Builder) {
 		Add("OBJECT", d.Object).
 		Add("VALUE", d.Value)
 	emitElement(b, "DEVICE", a, nil)
+}
+
+// ----------------------------------------------------------------------
+// §4.5 — Device Configuration (0v16 pp20-23)
+//
+// CRUD over the Cerebrum device tree. Unlike §4.1-§4.4 these are NOT
+// wrapped in <ACTION>; <DEVICE_CONFIGURATION> is itself a top-level
+// command, so it has its own EncodeDeviceConfiguration entry point.
+//
+// The body shape under <CONFIGURATION> varies by DEVICE_TYPE
+// (GENERIC / PANEL / ROUTER / SNMP). REMOVE carries no body (§4.5.2
+// p23). The RX reply is <DEVICE_CONFIGURATION …><RESULT VALUE="…"/>
+// </DEVICE_CONFIGURATION> — decoded as KindDeviceConfigResult.
+// ----------------------------------------------------------------------
+
+// DeviceConfigType is the §4.5 <DEVICE_CONFIGURATION TYPE=…> verb.
+type DeviceConfigType string
+
+const (
+	DeviceConfigAdd    DeviceConfigType = "ADD"
+	DeviceConfigModify DeviceConfigType = "MODIFY"
+	DeviceConfigRemove DeviceConfigType = "REMOVE"
+)
+
+// ConfigDeviceType is the §4.5 DEVICE_TYPE selector. Distinct from the
+// §3.1 DeviceType enum: §4.5 uses "GENERIC" where §3.1 uses "Device",
+// and adds "PANEL". Keep the literal spec strings (p20-23).
+type ConfigDeviceType string
+
+const (
+	ConfigDeviceGeneric ConfigDeviceType = "GENERIC"
+	ConfigDevicePanel   ConfigDeviceType = "PANEL"
+	ConfigDeviceRouter  ConfigDeviceType = "ROUTER"
+	ConfigDeviceSNMP    ConfigDeviceType = "SNMP"
+)
+
+// ConnectionType is the §4.5 <PROTOCOL_CONFIGURATION CONNECTION_TYPE=…>
+// enum (p20): ASYNC_HTTP / UDP / TCP / WEBSOCKET_SERVER.
+type ConnectionType string
+
+const (
+	ConnAsyncHTTP        ConnectionType = "ASYNC_HTTP"
+	ConnUDP              ConnectionType = "UDP"
+	ConnTCP              ConnectionType = "TCP"
+	ConnWebsocketServer  ConnectionType = "WEBSOCKET_SERVER"
+)
+
+// DeviceConfiguration is one §4.5 device CRUD command. Type selects the
+// verb; DeviceType selects which body builder runs (Generic / Panel /
+// Router / SNMP). For REMOVE, all body pointers are ignored (§4.5.2).
+type DeviceConfiguration struct {
+	Type       DeviceConfigType
+	IPAddress  string
+	DeviceName string // optional on ADD; required (with IP) on MODIFY
+	DeviceType ConfigDeviceType
+
+	// Exactly one of the following is honoured, chosen by DeviceType.
+	Generic *GenericConfig // DEVICE_TYPE="GENERIC" (§4.5.1.1 p20)
+	Panel   *PanelConfig   // DEVICE_TYPE="PANEL"   (§4.5.1.2 p21)
+	Router  *RouterConfig  // DEVICE_TYPE="ROUTER"  (§4.5.1.3 p22)
+	SNMP    *SNMPConfig    // DEVICE_TYPE="SNMP"    (§4.5.1.4 p23)
+}
+
+// ProtocolConfiguration is the §4.5.1.1 <PROTOCOL_CONFIGURATION> child
+// shared by GENERIC + PANEL bodies (p20-21).
+type ProtocolConfiguration struct {
+	ConnectionType ConnectionType
+	PortNumber     string
+	Timeout        string // milliseconds
+	PollPeriod     string // milliseconds
+	Virtualise     string // "0" or "1"
+	SecondaryIP    string // optional
+}
+
+func (p *ProtocolConfiguration) attrs() AttrsBuilder {
+	return AttrsBuilder{}.
+		Add("CONNECTION_TYPE", string(p.ConnectionType)).
+		Add("PORT_NUMBER", p.PortNumber).
+		Add("TIMEOUT", p.Timeout).
+		Add("POLL_PERIOD", p.PollPeriod).
+		Add("VIRTUALISE", p.Virtualise).
+		Add("SECONDARY_IP", p.SecondaryIP)
+}
+
+// GenericConfig is the §4.5.1.1 GENERIC body (p20):
+//
+//	<CONFIGURATION DEVICE VERSION NAME>
+//	  <PROTOCOL_CONFIGURATION …/>
+//	  [<PROTOCOL_SPECIFIC>…</PROTOCOL_SPECIFIC>]
+//	</CONFIGURATION>
+type GenericConfig struct {
+	Device  string
+	Version string
+	Name    string
+
+	Protocol *ProtocolConfiguration
+
+	// ProtocolSpecific, when non-nil, emits a <PROTOCOL_SPECIFIC>
+	// child. The spec (p20) says its content is protocol-dependent and
+	// not exhaustively documented; we carry raw inner XML so callers can
+	// supply whatever the target protocol needs without the codec
+	// guessing a schema. Empty string emits <PROTOCOL_SPECIFIC/>.
+	ProtocolSpecific *string
+}
+
+func (g *GenericConfig) encodeBody(b *strings.Builder) {
+	a := AttrsBuilder{}.
+		Add("DEVICE", g.Device).
+		Add("VERSION", g.Version).
+		Add("NAME", g.Name)
+	emitElement(b, "CONFIGURATION", a, func() {
+		if g.Protocol != nil {
+			emitElement(b, "PROTOCOL_CONFIGURATION", g.Protocol.attrs(), nil)
+		}
+		if g.ProtocolSpecific != nil {
+			emitRawChild(b, "PROTOCOL_SPECIFIC", nil, *g.ProtocolSpecific)
+		}
+	})
+}
+
+// PanelConfig is the §4.5.1.2 PANEL body (p21). It reuses
+// <PROTOCOL_CONFIGURATION> and adds a <PROTOCOL_SPECIFIC CPF PANEL_ID
+// PANEL_TYPE> wrapper around a <PANEL_CONFIG> child.
+type PanelConfig struct {
+	Device  string
+	Version string
+	Name    string
+
+	Protocol *ProtocolConfiguration
+
+	CPF       string
+	PanelID   string // optional
+	PanelType string
+
+	// PanelConfigInner is the raw inner XML of <PANEL_CONFIG>. The spec
+	// example shows an empty <PANEL_CONFIG></PANEL_CONFIG>; content is
+	// protocol-specific and undocumented (p21).
+	PanelConfigInner string
+}
+
+func (p *PanelConfig) encodeBody(b *strings.Builder) {
+	a := AttrsBuilder{}.
+		Add("DEVICE", p.Device).
+		Add("VERSION", p.Version).
+		Add("NAME", p.Name)
+	emitElement(b, "CONFIGURATION", a, func() {
+		if p.Protocol != nil {
+			emitElement(b, "PROTOCOL_CONFIGURATION", p.Protocol.attrs(), nil)
+		}
+		ps := AttrsBuilder{}.
+			Add("CPF", p.CPF).
+			Add("PANEL_ID", p.PanelID).
+			Add("PANEL_TYPE", p.PanelType)
+		emitElement(b, "PROTOCOL_SPECIFIC", ps, func() {
+			emitRawChild(b, "PANEL_CONFIG", nil, p.PanelConfigInner)
+		})
+	})
+}
+
+// RouterConfig is the §4.5.1.3 ROUTER body (p22):
+//
+//	<CONFIGURATION DEVICE NAME TYPE SECONDARY_IP>
+//	  <SERIAL [BAUD PARITY DATA_BITS STOP_BITS_IP ENABLE_DSOM]/>
+//	  <ROUTER MAX_LEVEL MAX_SOURCE MAX_DEST IP_PORT MASTER_SERVER/>
+//	</CONFIGURATION>
+type RouterConfig struct {
+	Device      string
+	Name        string
+	Type        string // numeric routing-device type id
+	SecondaryIP string // optional
+
+	Serial *SerialConfig // emits <SERIAL …/>; nil omits (spec shows <SERIAL/> in examples)
+	Router *RouterParams // emits <ROUTER …/>
+}
+
+// SerialConfig is the §4.5.1.3 <SERIAL> child (p22). All attrs optional;
+// the worked example uses the bare self-closing <SERIAL/> form.
+type SerialConfig struct {
+	Baud       string
+	Parity     string
+	DataBits   string
+	StopBitsIP string
+	EnableDSOM string
+}
+
+// RouterParams is the §4.5.1.3 <ROUTER> child (p22).
+type RouterParams struct {
+	MaxLevel     string
+	MaxSource    string
+	MaxDest      string
+	IPPort       string
+	MasterServer string
+}
+
+func (r *RouterConfig) encodeBody(b *strings.Builder) {
+	a := AttrsBuilder{}.
+		Add("DEVICE", r.Device).
+		Add("NAME", r.Name).
+		Add("TYPE", r.Type).
+		Add("SECONDARY_IP", r.SecondaryIP)
+	emitElement(b, "CONFIGURATION", a, func() {
+		if r.Serial != nil {
+			sa := AttrsBuilder{}.
+				Add("BAUD", r.Serial.Baud).
+				Add("PARITY", r.Serial.Parity).
+				Add("DATA_BITS", r.Serial.DataBits).
+				Add("STOP_BITS_IP", r.Serial.StopBitsIP).
+				Add("ENABLE_DSOM", r.Serial.EnableDSOM)
+			emitElement(b, "SERIAL", sa, nil)
+		}
+		if r.Router != nil {
+			ra := AttrsBuilder{}.
+				Add("MAX_LEVEL", r.Router.MaxLevel).
+				Add("MAX_SOURCE", r.Router.MaxSource).
+				Add("MAX_DEST", r.Router.MaxDest).
+				Add("IP_PORT", r.Router.IPPort).
+				Add("MASTER_SERVER", r.Router.MasterServer)
+			emitElement(b, "ROUTER", ra, nil)
+		}
+	})
+}
+
+// SNMPConfig is the §4.5.1.4 SNMP body (p23): <CONFIGURATION NAME PORT/>.
+type SNMPConfig struct {
+	Name string
+	Port string
+}
+
+func (s *SNMPConfig) encodeBody(b *strings.Builder) {
+	a := AttrsBuilder{}.
+		Add("NAME", s.Name).
+		Add("PORT", s.Port)
+	emitElement(b, "CONFIGURATION", a, nil)
+}
+
+// EncodeDeviceConfiguration builds the §4.5 top-level command:
+//
+//	<DEVICE_CONFIGURATION TYPE="ADD|MODIFY|REMOVE" IP_ADDRESS="…"
+//	    [DEVICE_NAME="…"] DEVICE_TYPE="…">
+//	  …body…
+//	</DEVICE_CONFIGURATION>
+//
+// REMOVE and any config whose body pointer is nil emit the self-closing
+// form (§4.5.2 p23 shows <DEVICE_CONFIGURATION …/> for REMOVE).
+func EncodeDeviceConfiguration(mtid uint32, dc *DeviceConfiguration) []byte {
+	var b strings.Builder
+	a := AttrsBuilder{}.
+		ForceAdd("TYPE", string(dc.Type)).
+		Add("IP_ADDRESS", dc.IPAddress).
+		Add("DEVICE_NAME", dc.DeviceName).
+		Add("DEVICE_TYPE", string(dc.DeviceType)).
+		ForceAdd("MTID", formatMTID(mtid))
+
+	body := dc.bodyFunc(&b)
+	emitElement(&b, "DEVICE_CONFIGURATION", a, body)
+	return []byte(b.String())
+}
+
+// bodyFunc returns the body closure for the configured DeviceType, or
+// nil when there is no body to emit (REMOVE, or a missing body struct).
+func (dc *DeviceConfiguration) bodyFunc(b *strings.Builder) func() {
+	if dc.Type == DeviceConfigRemove {
+		return nil
+	}
+	switch {
+	case dc.Generic != nil:
+		return func() { dc.Generic.encodeBody(b) }
+	case dc.Panel != nil:
+		return func() { dc.Panel.encodeBody(b) }
+	case dc.Router != nil:
+		return func() { dc.Router.encodeBody(b) }
+	case dc.SNMP != nil:
+		return func() { dc.SNMP.encodeBody(b) }
+	}
+	return nil
 }

--- a/internal/cerebrum-nb/codec/codec_0v16_test.go
+++ b/internal/cerebrum-nb/codec/codec_0v16_test.go
@@ -1,0 +1,921 @@
+package codec
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tests in this file pin the EVS Cerebrum Northbound API 0v16 additions
+// over the 0v13 baseline. Every expected byte / XML string is taken
+// FROM THE 0v16 PDF worked examples (page cites inline), not from the
+// codec's own output. 0v16 is a pure superset of 0v13 — the 0v13 tests
+// in codec_test.go must continue to pass unchanged.
+//
+// Spec: internal/cerebrum-nb/assets/Cerebrum Northbound API 0v16.pdf
+
+// ----------------------------------------------------------------------
+// §1.4 CONTINUE (p5) + §1.6 WILDCARD_COMPLETE (p6) control frames.
+// ----------------------------------------------------------------------
+
+func TestDecodeContinue(t *testing.T) {
+	// §1.4 p5: RX <CONTINUE/> after a BUSY.
+	f, err := Decode([]byte(`<CONTINUE/>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Kind != KindContinue {
+		t.Fatalf("kind: got %s want continue", f.Kind)
+	}
+}
+
+func TestDecodeWildcardComplete(t *testing.T) {
+	// §1.6 p6: RX <WILDCARD_COMPLETE MTID="1"/>.
+	f, err := Decode([]byte(`<WILDCARD_COMPLETE MTID="1"/>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Kind != KindWildcardComplete {
+		t.Fatalf("kind: got %s want wildcard_complete", f.Kind)
+	}
+	if f.MTID != "1" {
+		t.Fatalf("MTID: got %q want 1", f.MTID)
+	}
+}
+
+// ----------------------------------------------------------------------
+// §2.1 LOGIN_REPLY with DATASTORES body (p7).
+// ----------------------------------------------------------------------
+
+func TestDecodeLoginReply_Datastores(t *testing.T) {
+	// Verbatim §2.1 p7 worked example.
+	wire := `<LOGIN_REPLY MTID="1" API_VER="0.1">` +
+		`<DATASTORES>` +
+		`<DATASTORE NAME="Global Data Files\Index.xml" AVAILABLE="1"/>` +
+		`<DATASTORE NAME="Data Files\Device.xml" AVAILABLE="0"/>` +
+		`</DATASTORES>` +
+		`</LOGIN_REPLY>`
+	f, err := Decode([]byte(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Kind != KindLoginReply {
+		t.Fatalf("kind: got %s", f.Kind)
+	}
+	lr := f.LoginReply
+	if lr.MTID != "1" || lr.APIVer != "0.1" {
+		t.Fatalf("MTID/APIVer: %+v", lr)
+	}
+	if len(lr.Datastores) != 2 {
+		t.Fatalf("Datastores len = %d want 2", len(lr.Datastores))
+	}
+	if lr.Datastores[0].Name != `Global Data Files\Index.xml` || !lr.Datastores[0].Available {
+		t.Errorf("Datastores[0] = %+v", lr.Datastores[0])
+	}
+	if lr.Datastores[1].Name != `Data Files\Device.xml` || lr.Datastores[1].Available {
+		t.Errorf("Datastores[1] = %+v", lr.Datastores[1])
+	}
+}
+
+func TestDecodeLoginReply_NoDatastores_0v13Compat(t *testing.T) {
+	// 0v13 bare reply must still decode with Datastores == nil.
+	f, err := Decode([]byte(`<login_reply mtid="1" api_ver="0.13"/>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.LoginReply.APIVer != "0.13" || f.LoginReply.Datastores != nil {
+		t.Fatalf("got %+v", f.LoginReply)
+	}
+}
+
+// ----------------------------------------------------------------------
+// §3.1 DEVICE_TYPE sub-device colon syntax (p9).
+// ----------------------------------------------------------------------
+
+func TestDeviceType_ColonSyntax(t *testing.T) {
+	tests := []struct {
+		in        DeviceType
+		wantBase  DeviceType
+		wantIdx   int
+		wantHasIx bool
+	}{
+		// §3.1 p9 worked examples.
+		{"ROUTER", "ROUTER", 0, false},
+		{"ROUTER:2", "ROUTER", 2, true},
+		{"SNMP", "SNMP", 0, false},
+		{"DEVICE", "DEVICE", 0, false},
+		{"DEVICE:4", "DEVICE", 4, true},
+		{"DEVICE:nope", "DEVICE", 0, false}, // non-numeric suffix → no index
+	}
+	for _, tc := range tests {
+		if got := tc.in.Base(); got != tc.wantBase {
+			t.Errorf("%q.Base() = %q want %q", tc.in, got, tc.wantBase)
+		}
+		idx, ok := tc.in.Index()
+		if ok != tc.wantHasIx || idx != tc.wantIdx {
+			t.Errorf("%q.Index() = (%d,%v) want (%d,%v)", tc.in, idx, ok, tc.wantIdx, tc.wantHasIx)
+		}
+	}
+}
+
+func TestMakeDeviceType(t *testing.T) {
+	if got := MakeDeviceType("ROUTER", 2); got != "ROUTER:2" {
+		t.Errorf("MakeDeviceType(ROUTER,2) = %q want ROUTER:2", got)
+	}
+	if got := MakeDeviceType("SNMP", -1); got != "SNMP" {
+		t.Errorf("MakeDeviceType(SNMP,-1) = %q want SNMP", got)
+	}
+}
+
+// ----------------------------------------------------------------------
+// §3.2 LOCK 5-value enum (p9).
+// ----------------------------------------------------------------------
+
+func TestLockKind_FiveValues(t *testing.T) {
+	// §3.2 p9 table — all five canonical values present and exact.
+	want := []LockKind{LockUnlocked, LockLocked, LockProtected, LockLockedPath, LockProtectedPath}
+	wantStr := []string{"UNLOCKED", "LOCKED", "PROTECTED", "LOCKED_PATH", "PROTECTED_PATH"}
+	for i, lk := range want {
+		if string(lk) != wantStr[i] {
+			t.Errorf("LockKind[%d] = %q want %q", i, lk, wantStr[i])
+		}
+	}
+}
+
+// ----------------------------------------------------------------------
+// §4.5 Device Configuration encode (pp20-23) — the headline.
+// All want-strings are derived from the worked TX examples.
+// ----------------------------------------------------------------------
+
+func TestEncodeDeviceConfiguration_GenericAdd(t *testing.T) {
+	// §4.5.1.1 p20 worked example (attribute order normalised to the
+	// codec's AttrsBuilder declared order, values verbatim).
+	dc := &DeviceConfiguration{
+		Type:       DeviceConfigAdd,
+		IPAddress:  "10.10.10.1",
+		DeviceType: ConfigDeviceGeneric,
+		Generic: &GenericConfig{
+			Device:  "Shotoku STAR Protocol",
+			Version: "Latest",
+			Name:    "Shotoku STAR Protocol",
+			Protocol: &ProtocolConfiguration{
+				ConnectionType: ConnTCP,
+				PortNumber:     "8000",
+				Timeout:        "5000",
+				PollPeriod:     "3000",
+			},
+		},
+	}
+	got := string(EncodeDeviceConfiguration(7, dc))
+	want := `<DEVICE_CONFIGURATION TYPE="ADD" IP_ADDRESS="10.10.10.1" DEVICE_TYPE="GENERIC" MTID="7">` +
+		`<CONFIGURATION DEVICE="Shotoku STAR Protocol" VERSION="Latest" NAME="Shotoku STAR Protocol">` +
+		`<PROTOCOL_CONFIGURATION CONNECTION_TYPE="TCP" PORT_NUMBER="8000" TIMEOUT="5000" POLL_PERIOD="3000"/>` +
+		`</CONFIGURATION>` +
+		`</DEVICE_CONFIGURATION>`
+	if got != want {
+		t.Fatalf("\n got %s\nwant %s", got, want)
+	}
+}
+
+func TestEncodeDeviceConfiguration_GenericModify(t *testing.T) {
+	// §4.5.1.1 p20 MODIFY example carries DEVICE_NAME.
+	dc := &DeviceConfiguration{
+		Type:       DeviceConfigModify,
+		IPAddress:  "10.10.10.1",
+		DeviceName: "Shotoku STAR Protocol",
+		DeviceType: ConfigDeviceGeneric,
+		Generic: &GenericConfig{
+			Device:  "Shotoku STAR Protocol",
+			Version: "Latest",
+			Name:    "Shotoku STAR Protocol New",
+			Protocol: &ProtocolConfiguration{
+				ConnectionType: ConnTCP,
+				PortNumber:     "8000",
+				Timeout:        "5000",
+				PollPeriod:     "3000",
+			},
+		},
+	}
+	got := string(EncodeDeviceConfiguration(8, dc))
+	want := `<DEVICE_CONFIGURATION TYPE="MODIFY" IP_ADDRESS="10.10.10.1" DEVICE_NAME="Shotoku STAR Protocol" DEVICE_TYPE="GENERIC" MTID="8">` +
+		`<CONFIGURATION DEVICE="Shotoku STAR Protocol" VERSION="Latest" NAME="Shotoku STAR Protocol New">` +
+		`<PROTOCOL_CONFIGURATION CONNECTION_TYPE="TCP" PORT_NUMBER="8000" TIMEOUT="5000" POLL_PERIOD="3000"/>` +
+		`</CONFIGURATION>` +
+		`</DEVICE_CONFIGURATION>`
+	if got != want {
+		t.Fatalf("\n got %s\nwant %s", got, want)
+	}
+}
+
+func TestEncodeDeviceConfiguration_GenericWithProtocolSpecific(t *testing.T) {
+	// §4.5.1.1 p20 — optional <PROTOCOL_SPECIFIC> child; content is
+	// protocol-dependent so we carry raw inner XML. Empty inner emits
+	// the open/close pair.
+	empty := ""
+	dc := &DeviceConfiguration{
+		Type:       DeviceConfigAdd,
+		IPAddress:  "10.10.10.1",
+		DeviceType: ConfigDeviceGeneric,
+		Generic: &GenericConfig{
+			Device:           "X",
+			Protocol:         &ProtocolConfiguration{ConnectionType: ConnUDP, PortNumber: "9000"},
+			ProtocolSpecific: &empty,
+		},
+	}
+	got := string(EncodeDeviceConfiguration(1, dc))
+	want := `<DEVICE_CONFIGURATION TYPE="ADD" IP_ADDRESS="10.10.10.1" DEVICE_TYPE="GENERIC" MTID="1">` +
+		`<CONFIGURATION DEVICE="X">` +
+		`<PROTOCOL_CONFIGURATION CONNECTION_TYPE="UDP" PORT_NUMBER="9000"/>` +
+		`<PROTOCOL_SPECIFIC></PROTOCOL_SPECIFIC>` +
+		`</CONFIGURATION>` +
+		`</DEVICE_CONFIGURATION>`
+	if got != want {
+		t.Fatalf("\n got %s\nwant %s", got, want)
+	}
+}
+
+func TestEncodeDeviceConfiguration_PanelAdd(t *testing.T) {
+	// §4.5.1.2 p21 worked example.
+	dc := &DeviceConfiguration{
+		Type:       DeviceConfigAdd,
+		IPAddress:  "10.10.40.1",
+		DeviceType: ConfigDevicePanel,
+		Panel: &PanelConfig{
+			Device:  "CCP-1601",
+			Version: "Latest",
+			Name:    "Panel",
+			Protocol: &ProtocolConfiguration{
+				ConnectionType: ConnTCP,
+				PortNumber:     "8000",
+			},
+			CPF:       "DEFAULT.cpf",
+			PanelType: "CCP-1601",
+		},
+	}
+	got := string(EncodeDeviceConfiguration(3, dc))
+	want := `<DEVICE_CONFIGURATION TYPE="ADD" IP_ADDRESS="10.10.40.1" DEVICE_TYPE="PANEL" MTID="3">` +
+		`<CONFIGURATION DEVICE="CCP-1601" VERSION="Latest" NAME="Panel">` +
+		`<PROTOCOL_CONFIGURATION CONNECTION_TYPE="TCP" PORT_NUMBER="8000"/>` +
+		`<PROTOCOL_SPECIFIC CPF="DEFAULT.cpf" PANEL_TYPE="CCP-1601">` +
+		`<PANEL_CONFIG></PANEL_CONFIG>` +
+		`</PROTOCOL_SPECIFIC>` +
+		`</CONFIGURATION>` +
+		`</DEVICE_CONFIGURATION>`
+	if got != want {
+		t.Fatalf("\n got %s\nwant %s", got, want)
+	}
+}
+
+func TestEncodeDeviceConfiguration_RouterAdd(t *testing.T) {
+	// §4.5.1.3 p22 worked example: bare <SERIAL/> + <ROUTER …/>.
+	dc := &DeviceConfiguration{
+		Type:       DeviceConfigAdd,
+		IPAddress:  "10.10.20.1",
+		DeviceName: "Blackmagic Videohub TCP",
+		DeviceType: ConfigDeviceRouter,
+		Router: &RouterConfig{
+			Device: "Blackmagic Videohub TCP",
+			Name:   "Blackmagic Videohub TCP",
+			Type:   "20",
+			Serial: &SerialConfig{},
+			Router: &RouterParams{
+				MaxLevel:  "8",
+				MaxSource: "128",
+				MaxDest:   "128",
+			},
+		},
+	}
+	got := string(EncodeDeviceConfiguration(4, dc))
+	want := `<DEVICE_CONFIGURATION TYPE="ADD" IP_ADDRESS="10.10.20.1" DEVICE_NAME="Blackmagic Videohub TCP" DEVICE_TYPE="ROUTER" MTID="4">` +
+		`<CONFIGURATION DEVICE="Blackmagic Videohub TCP" NAME="Blackmagic Videohub TCP" TYPE="20">` +
+		`<SERIAL/>` +
+		`<ROUTER MAX_LEVEL="8" MAX_SOURCE="128" MAX_DEST="128"/>` +
+		`</CONFIGURATION>` +
+		`</DEVICE_CONFIGURATION>`
+	if got != want {
+		t.Fatalf("\n got %s\nwant %s", got, want)
+	}
+}
+
+func TestEncodeDeviceConfiguration_SNMPAdd(t *testing.T) {
+	// §4.5.1.4 p23 worked example.
+	dc := &DeviceConfiguration{
+		Type:       DeviceConfigAdd,
+		IPAddress:  "10.10.30.1",
+		DeviceType: ConfigDeviceSNMP,
+		SNMP:       &SNMPConfig{Name: "SNMP Device", Port: "161"},
+	}
+	got := string(EncodeDeviceConfiguration(5, dc))
+	want := `<DEVICE_CONFIGURATION TYPE="ADD" IP_ADDRESS="10.10.30.1" DEVICE_TYPE="SNMP" MTID="5">` +
+		`<CONFIGURATION NAME="SNMP Device" PORT="161"/>` +
+		`</DEVICE_CONFIGURATION>`
+	if got != want {
+		t.Fatalf("\n got %s\nwant %s", got, want)
+	}
+}
+
+func TestEncodeDeviceConfiguration_Remove(t *testing.T) {
+	// §4.5.2 p23 worked example: self-closing, no body.
+	dc := &DeviceConfiguration{
+		Type:       DeviceConfigRemove,
+		IPAddress:  "10.10.30.1",
+		DeviceType: ConfigDeviceSNMP,
+	}
+	got := string(EncodeDeviceConfiguration(6, dc))
+	want := `<DEVICE_CONFIGURATION TYPE="REMOVE" IP_ADDRESS="10.10.30.1" DEVICE_TYPE="SNMP" MTID="6"/>`
+	if got != want {
+		t.Fatalf("\n got %s\nwant %s", got, want)
+	}
+}
+
+func TestEncodeDeviceConfiguration_AddNoBodyStruct(t *testing.T) {
+	// ADD with no body struct set → self-closing (defensive: caller
+	// supplied only the envelope).
+	dc := &DeviceConfiguration{
+		Type:       DeviceConfigAdd,
+		IPAddress:  "10.0.0.9",
+		DeviceType: ConfigDeviceGeneric,
+	}
+	got := string(EncodeDeviceConfiguration(2, dc))
+	want := `<DEVICE_CONFIGURATION TYPE="ADD" IP_ADDRESS="10.0.0.9" DEVICE_TYPE="GENERIC" MTID="2"/>`
+	if got != want {
+		t.Fatalf("\n got %s\nwant %s", got, want)
+	}
+}
+
+func TestEncodeDeviceConfiguration_RouterNoChildren(t *testing.T) {
+	// Router body with neither <SERIAL> nor <ROUTER> set → empty
+	// <CONFIGURATION>…</CONFIGURATION> (exercises both nil branches).
+	dc := &DeviceConfiguration{
+		Type:       DeviceConfigAdd,
+		IPAddress:  "10.0.0.1",
+		DeviceType: ConfigDeviceRouter,
+		Router:     &RouterConfig{Name: "R"},
+	}
+	got := string(EncodeDeviceConfiguration(1, dc))
+	want := `<DEVICE_CONFIGURATION TYPE="ADD" IP_ADDRESS="10.0.0.1" DEVICE_TYPE="ROUTER" MTID="1">` +
+		`<CONFIGURATION NAME="R"></CONFIGURATION>` +
+		`</DEVICE_CONFIGURATION>`
+	if got != want {
+		t.Fatalf("\n got %s\nwant %s", got, want)
+	}
+}
+
+func TestEncodeDeviceConfiguration_GenericNoProtocol(t *testing.T) {
+	// Generic body without <PROTOCOL_CONFIGURATION> → exercises the nil
+	// protocol branch and the no-PROTOCOL_SPECIFIC path.
+	dc := &DeviceConfiguration{
+		Type:       DeviceConfigAdd,
+		IPAddress:  "10.0.0.2",
+		DeviceType: ConfigDeviceGeneric,
+		Generic:    &GenericConfig{Name: "G"},
+	}
+	got := string(EncodeDeviceConfiguration(1, dc))
+	want := `<DEVICE_CONFIGURATION TYPE="ADD" IP_ADDRESS="10.0.0.2" DEVICE_TYPE="GENERIC" MTID="1">` +
+		`<CONFIGURATION NAME="G"></CONFIGURATION>` +
+		`</DEVICE_CONFIGURATION>`
+	if got != want {
+		t.Fatalf("\n got %s\nwant %s", got, want)
+	}
+}
+
+func TestEncodeDeviceConfiguration_RouterFullSerial(t *testing.T) {
+	// Exercise every <SERIAL> + <ROUTER> attribute branch (p22 tables).
+	dc := &DeviceConfiguration{
+		Type:       DeviceConfigModify,
+		IPAddress:  "10.10.20.1",
+		DeviceName: "R",
+		DeviceType: ConfigDeviceRouter,
+		Router: &RouterConfig{
+			Device:      "Dev",
+			Name:        "R New",
+			Type:        "13",
+			SecondaryIP: "10.10.20.2",
+			Serial: &SerialConfig{
+				Baud: "9600", Parity: "NONE", DataBits: "8",
+				StopBitsIP: "1", EnableDSOM: "1",
+			},
+			Router: &RouterParams{
+				MaxLevel: "4", MaxSource: "64", MaxDest: "64",
+				IPPort: "9990", MasterServer: "1",
+			},
+		},
+	}
+	got := string(EncodeDeviceConfiguration(9, dc))
+	want := `<DEVICE_CONFIGURATION TYPE="MODIFY" IP_ADDRESS="10.10.20.1" DEVICE_NAME="R" DEVICE_TYPE="ROUTER" MTID="9">` +
+		`<CONFIGURATION DEVICE="Dev" NAME="R New" TYPE="13" SECONDARY_IP="10.10.20.2">` +
+		`<SERIAL BAUD="9600" PARITY="NONE" DATA_BITS="8" STOP_BITS_IP="1" ENABLE_DSOM="1"/>` +
+		`<ROUTER MAX_LEVEL="4" MAX_SOURCE="64" MAX_DEST="64" IP_PORT="9990" MASTER_SERVER="1"/>` +
+		`</CONFIGURATION>` +
+		`</DEVICE_CONFIGURATION>`
+	if got != want {
+		t.Fatalf("\n got %s\nwant %s", got, want)
+	}
+}
+
+func TestEncodeDeviceConfiguration_ProtocolConfigFullAttrs(t *testing.T) {
+	// Exercise VIRTUALISE + SECONDARY_IP branches of PROTOCOL_CONFIGURATION.
+	dc := &DeviceConfiguration{
+		Type:       DeviceConfigAdd,
+		IPAddress:  "10.0.0.1",
+		DeviceType: ConfigDeviceGeneric,
+		Generic: &GenericConfig{
+			Device: "D",
+			Protocol: &ProtocolConfiguration{
+				ConnectionType: ConnWebsocketServer,
+				PortNumber:     "80",
+				Timeout:        "1000",
+				PollPeriod:     "500",
+				Virtualise:     "1",
+				SecondaryIP:    "10.0.0.2",
+			},
+		},
+	}
+	got := string(EncodeDeviceConfiguration(1, dc))
+	if !strings.Contains(got, `CONNECTION_TYPE="WEBSOCKET_SERVER" PORT_NUMBER="80" TIMEOUT="1000" POLL_PERIOD="500" VIRTUALISE="1" SECONDARY_IP="10.0.0.2"`) {
+		t.Fatalf("protocol attrs not all emitted: %s", got)
+	}
+}
+
+func TestEncodeDeviceConfiguration_PanelWithIDAndInner(t *testing.T) {
+	// Exercise PANEL_ID branch + non-empty PANEL_CONFIG inner.
+	dc := &DeviceConfiguration{
+		Type:       DeviceConfigAdd,
+		IPAddress:  "10.10.40.1",
+		DeviceType: ConfigDevicePanel,
+		Panel: &PanelConfig{
+			Device:           "CCP",
+			CPF:              "X.cpf",
+			PanelID:          "12",
+			PanelType:        "CCP-1601",
+			PanelConfigInner: `<KEY ID="1"/>`,
+		},
+	}
+	got := string(EncodeDeviceConfiguration(1, dc))
+	want := `<DEVICE_CONFIGURATION TYPE="ADD" IP_ADDRESS="10.10.40.1" DEVICE_TYPE="PANEL" MTID="1">` +
+		`<CONFIGURATION DEVICE="CCP">` +
+		`<PROTOCOL_SPECIFIC CPF="X.cpf" PANEL_ID="12" PANEL_TYPE="CCP-1601">` +
+		`<PANEL_CONFIG><KEY ID="1"/></PANEL_CONFIG>` +
+		`</PROTOCOL_SPECIFIC>` +
+		`</CONFIGURATION>` +
+		`</DEVICE_CONFIGURATION>`
+	if got != want {
+		t.Fatalf("\n got %s\nwant %s", got, want)
+	}
+}
+
+// ----------------------------------------------------------------------
+// §4.5 RESULT reply decode (pp20-23).
+// ----------------------------------------------------------------------
+
+func TestDecodeDeviceConfigResult_Accepted(t *testing.T) {
+	// §4.5.1.1 p20 RX worked example.
+	wire := `<DEVICE_CONFIGURATION TYPE="ADD" IP_ADDRESS="10.10.10.1" DEVICE_TYPE="GENERIC">` +
+		`<RESULT VALUE="ACCEPTED"/>` +
+		`</DEVICE_CONFIGURATION>`
+	f, err := Decode([]byte(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Kind != KindDeviceConfigResult {
+		t.Fatalf("kind: got %s want device_config_result", f.Kind)
+	}
+	r := f.DeviceConfig
+	if r.Type != "ADD" || r.IPAddress != "10.10.10.1" || r.DeviceType != "GENERIC" {
+		t.Errorf("envelope: %+v", r)
+	}
+	if r.Value != "ACCEPTED" || !r.Accepted {
+		t.Errorf("result: %+v", r)
+	}
+}
+
+func TestDecodeDeviceConfigResult_Failed(t *testing.T) {
+	// §4.5.1.1 p20: <RESULT VALUE="FAILED"/>.
+	wire := `<DEVICE_CONFIGURATION TYPE="ADD" IP_ADDRESS="10.10.10.1" DEVICE_TYPE="GENERIC">` +
+		`<RESULT VALUE="FAILED"/>` +
+		`</DEVICE_CONFIGURATION>`
+	f, err := Decode([]byte(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.DeviceConfig.Accepted || f.DeviceConfig.Value != "FAILED" {
+		t.Fatalf("result: %+v", f.DeviceConfig)
+	}
+}
+
+func TestDecodeDeviceConfigResult_NoResultChild(t *testing.T) {
+	// Defensive: envelope with no <RESULT> child — Value empty, not accepted.
+	wire := `<DEVICE_CONFIGURATION TYPE="REMOVE" IP="10.0.0.1" DEVICE_TYPE="SNMP"/>`
+	f, err := Decode([]byte(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.DeviceConfig.IPAddress != "10.0.0.1" || f.DeviceConfig.Value != "" || f.DeviceConfig.Accepted {
+		t.Fatalf("result: %+v", f.DeviceConfig)
+	}
+}
+
+// ----------------------------------------------------------------------
+// §5.1.2 / §5.1.3 lock-change RX detail (p24).
+// ----------------------------------------------------------------------
+
+func TestDecodeRoutingChange_SrceLock_ValueChild(t *testing.T) {
+	// §5.1.2 p24: SRCE_LOCK detail in a <VALUE …/> child.
+	wire := `<ROUTING_CHANGE TYPE="SRCE_LOCK" DEVICE_NAME="MTX1" DEVICE_TYPE="ROUTER" SRCE_ID="1" LEVEL_NAME="UHD">` +
+		`<VALUE AVAILABLE="1" LOCK_STATE="LOCKED" LOCKED_BY="Admin" UNLOCK_TIME="" UNLOCK_DATE=""/>` +
+		`</ROUTING_CHANGE>`
+	f, err := Decode([]byte(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lk := f.Routing.Lock
+	if lk == nil {
+		t.Fatal("Lock nil")
+	}
+	if !lk.Available || lk.LockState != LockLocked || lk.LockedBy != "Admin" {
+		t.Errorf("Lock = %+v", lk)
+	}
+}
+
+func TestDecodeRoutingChange_DestLock_LockChild(t *testing.T) {
+	// §5.1.3 p24: DEST_LOCK detail in a <LOCK …/> child.
+	wire := `<ROUTING_CHANGE TYPE="DEST_LOCK" DEVICE_NAME="MTX1" DEVICE_TYPE="ROUTER" DEST_NAME="MON-1" LEVEL_ID="2">` +
+		`<LOCK AVAILABLE="1" LOCK_STATE="LOCKED" LOCKED_BY="Admin" UNLOCK_TIME="" UNLOCK_DATE=""/>` +
+		`</ROUTING_CHANGE>`
+	f, err := Decode([]byte(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lk := f.Routing.Lock
+	if lk == nil {
+		t.Fatal("Lock nil")
+	}
+	if !lk.Available || lk.LockState != LockLocked || lk.LockedBy != "Admin" {
+		t.Errorf("Lock = %+v", lk)
+	}
+}
+
+// ----------------------------------------------------------------------
+// §5.1.4 Level Mnemonic RX: ORIGINAL_MNE + RM_DEFAULT_DEVICE (p25).
+// ----------------------------------------------------------------------
+
+func TestDecodeRoutingChange_LevelMne_Rich(t *testing.T) {
+	// §5.1.4 p25 worked example.
+	wire := `<ROUTING_CHANGE TYPE="LEVEL_MNE" DEVICE_NAME="MTX1" IP_ADDRESS="192.168.0.1" DEVICE_TYPE="ROUTER" LEVEL_ID="2">` +
+		`<MNE AVAILABLE="1" MNEMONIC="HD" ORIGINAL_MNE="VIDEO_HD"/>` +
+		`<ALT_MNE_1 MNEMONIC="V_HD" AVAILABLE="1"/>` +
+		`<ALT_MNE_3 MNEMONIC="VHD" AVAILABLE="1"/>` +
+		`<ALT_MNE_4 AVAILABLE="0"/>` +
+		`<RM_DEFAULT_DEVICE DEVICE_NAME="Hybrid Router" DEVICE_TYPE="ROUTER" LEVEL_ID="1"/>` +
+		`</ROUTING_CHANGE>`
+	f, err := Decode([]byte(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := f.Routing
+	if r.Mnemonic != "HD" || r.OriginalMne != "VIDEO_HD" {
+		t.Errorf("mne: mnemonic=%q original=%q", r.Mnemonic, r.OriginalMne)
+	}
+	if r.Mnemonics[1] != "V_HD" || r.Mnemonics[3] != "VHD" {
+		t.Errorf("alt mnemonics: %+v", r.Mnemonics)
+	}
+	// ALT_MNE_4 AVAILABLE="0" must be dropped.
+	if _, ok := r.Mnemonics[4]; ok {
+		t.Errorf("alt_mne_4 (available=0) should be dropped: %+v", r.Mnemonics)
+	}
+	if r.RMDefaultDevice == nil {
+		t.Fatal("RMDefaultDevice nil")
+	}
+	if r.RMDefaultDevice.DeviceName != "Hybrid Router" || r.RMDefaultDevice.DeviceType != "ROUTER" || r.RMDefaultDevice.LevelID != "1" {
+		t.Errorf("RMDefaultDevice = %+v", r.RMDefaultDevice)
+	}
+}
+
+// ----------------------------------------------------------------------
+// §5.1.5 Source Mnemonic RX: ASSOCIATIONS with SRCE_ID + RM_* (p25-26).
+// ----------------------------------------------------------------------
+
+func TestDecodeRoutingChange_SrceMne_Associations(t *testing.T) {
+	// §5.1.5 pp25-26 worked example.
+	wire := `<ROUTING_CHANGE TYPE="SRCE_MNE" DEVICE_NAME="MTX1" DEVICE_TYPE="ROUTER" SRCE_NAME="CAM-1" LEVEL_ID="1">` +
+		`<MNE AVAILABLE="1" MNEMONIC="CAM-1" ORIGINAL_MNE="SRCE-1"/>` +
+		`<ALT_MNE_1 MNEMONIC="Camera-1" AVAILABLE="1"/>` +
+		`<ALT_MNE_2 MNEMONIC="Harry" AVAILABLE="1"/>` +
+		`<ASSOCIATIONS>` +
+		`<ASSOCIATION_1 SRCE_ID="1" RM_DEVICE_NAME="Hybrid Router" RM_DEVICE_TYPE="ROUTER" RM_LEVEL_ID="1" RM_REVERSED="0" RM_TAGS="Tag1" RM_IP_UID=""/>` +
+		`<ASSOCIATION_35 SRCE_ID="2" RM_DEVICE_NAME="Audio Router" RM_DEVICE_TYPE="ROUTER" RM_LEVEL_ID="13" RM_REVERSED="0" RM_TAGS="Tag2" RM_IP_UID=""/>` +
+		`</ASSOCIATIONS>` +
+		`</ROUTING_CHANGE>`
+	f, err := Decode([]byte(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := f.Routing
+	if r.OriginalMne != "SRCE-1" {
+		t.Errorf("original_mne = %q", r.OriginalMne)
+	}
+	if len(r.Associations) != 2 {
+		t.Fatalf("associations len = %d want 2", len(r.Associations))
+	}
+	a0 := r.Associations[0]
+	if a0.Index != 1 || a0.SrceID != "1" || a0.RMDeviceName != "Hybrid Router" || a0.RMLevelID != "1" || a0.RMTags != "Tag1" {
+		t.Errorf("Associations[0] = %+v", a0)
+	}
+	a1 := r.Associations[1]
+	if a1.Index != 35 || a1.SrceID != "2" || a1.RMDeviceName != "Audio Router" || a1.RMLevelID != "13" || a1.RMTags != "Tag2" {
+		t.Errorf("Associations[1] = %+v", a1)
+	}
+}
+
+func TestDecodeRoutingChange_DestMne_Associations(t *testing.T) {
+	// §5.1.6 p26: DEST_ID-keyed associations (no RM_TAGS in the example).
+	wire := `<ROUTING_CHANGE TYPE="DEST_MNE" DEVICE_NAME="MTX1" DEVICE_TYPE="ROUTER" DEST_ID="1" LEVEL_ID="2">` +
+		`<MNE AVAILABLE="1" MNEMONIC="MON-1" ORIGINAL_MNE="DEST-1"/>` +
+		`<ALT_MNE_1 MNEMONIC="Harrys Desk" AVAILABLE="1"/>` +
+		`<ASSOCIATIONS>` +
+		`<ASSOCIATION_1 DEST_ID="1" RM_DEVICE_NAME="Hybrid Router" RM_DEVICE_TYPE="ROUTER" RM_LEVEL_ID="1" RM_REVERSED="0" RM_IP_UID=""/>` +
+		`</ASSOCIATIONS>` +
+		`</ROUTING_CHANGE>`
+	f, err := Decode([]byte(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := f.Routing
+	if len(r.Associations) != 1 {
+		t.Fatalf("associations len = %d want 1", len(r.Associations))
+	}
+	a := r.Associations[0]
+	if a.Index != 1 || a.DestID != "1" || a.SrceID != "" || a.RMDeviceName != "Hybrid Router" {
+		t.Errorf("Associations[0] = %+v", a)
+	}
+}
+
+// ----------------------------------------------------------------------
+// §5.1.7 / §5.1.8 Routemaster Tags RX: pipe-delimited LIST (p27).
+// ----------------------------------------------------------------------
+
+func TestDecodeRoutingChange_SrceTags_Pipe(t *testing.T) {
+	// §5.1.7 p27: <TAGS AVAILABLE="1" LIST="Tag1|Tag2"/> — PIPE delimiter.
+	wire := `<ROUTING_CHANGE TYPE="RM_SRCE_TAGS" SRCE_ID="1" LEVEL_ID="1">` +
+		`<TAGS AVAILABLE="1" LIST="Tag1|Tag2"/>` +
+		`</ROUTING_CHANGE>`
+	f, err := Decode([]byte(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := f.Routing
+	if !r.TagsAvailable {
+		t.Error("TagsAvailable should be true")
+	}
+	if !equalSlice(r.TagList, []string{"Tag1", "Tag2"}) {
+		t.Errorf("TagList = %v want [Tag1 Tag2]", r.TagList)
+	}
+}
+
+func TestDecodeRoutingChange_DestTags_Pipe_NoAvailable(t *testing.T) {
+	// §5.1.8 p27: <TAGS LIST="Tag1|Tag2"/> — no AVAILABLE attr in example.
+	wire := `<ROUTING_CHANGE TYPE="RM_DEST_TAGS" DEST_ID="1" LEVEL_ID="1">` +
+		`<TAGS LIST="Tag1|Tag2"/>` +
+		`</ROUTING_CHANGE>`
+	f, err := Decode([]byte(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Routing.TagsAvailable {
+		t.Error("TagsAvailable should be false (attr absent)")
+	}
+	if !equalSlice(f.Routing.TagList, []string{"Tag1", "Tag2"}) {
+		t.Errorf("TagList = %v", f.Routing.TagList)
+	}
+}
+
+// ----------------------------------------------------------------------
+// §5.2.2 Category item optional GROUP attr (p28).
+// ----------------------------------------------------------------------
+
+func TestDecodeCategoryChange_ItemGroup(t *testing.T) {
+	// §5.2.2 p28 note: items may carry a GROUP attribute.
+	wire := `<CATEGORY_CHANGE TYPE="CATEGORY_DETAILS" CATEGORY="EVS">` +
+		`<DETAILS AVAILABLE="1" LABEL="EVS Sources" DESCRIPTION="All EVS Sources"/>` +
+		`<ITEMS>` +
+		`<ITEM_1 TYPE="SALVO" VALUE="Line up" GROUP="Multiviewer 1"/>` +
+		`</ITEMS>` +
+		`</CATEGORY_CHANGE>`
+	f, err := Decode([]byte(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	items := f.Category.Details.Items
+	if len(items) != 1 {
+		t.Fatalf("items len = %d want 1", len(items))
+	}
+	if items[0].Group != "Multiviewer 1" || items[0].Type != "SALVO" || items[0].Value != "Line up" {
+		t.Errorf("item = %+v", items[0])
+	}
+}
+
+// ----------------------------------------------------------------------
+// §5.3.3 Salvo Instance Details enriched (p28).
+// ----------------------------------------------------------------------
+
+func TestDecodeSalvoChange_InstanceDetails_Rich(t *testing.T) {
+	// §5.3.3 p28 worked example.
+	wire := `<SALVO_CHANGE TYPE="INSTANCE_DETAILS" GROUP="Multiviewer 1" INSTANCE="Line up">` +
+		`<DETAILS AVAILABLE="1" DESCRIPTION="The layout for line up" ACTIVE="1" DATE="02/07/2017" TIME="17:33:22:12"/>` +
+		`</SALVO_CHANGE>`
+	f, err := Decode([]byte(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := f.Salvo.InstanceDetails
+	if d == nil {
+		t.Fatal("InstanceDetails nil")
+	}
+	if !d.Available || d.Description != "The layout for line up" || !d.Active {
+		t.Errorf("details = %+v", d)
+	}
+	if d.Date != "02/07/2017" || d.Time != "17:33:22:12" {
+		t.Errorf("date/time = %q / %q", d.Date, d.Time)
+	}
+}
+
+// ----------------------------------------------------------------------
+// §5.4.3 Device Value rich OBJECT_VALUE (p29).
+// ----------------------------------------------------------------------
+
+func TestDecodeDeviceChange_Value_RichObjectValue(t *testing.T) {
+	// §5.4.3 p29 scalar worked example.
+	wire := `<DEVICE_CHANGE TYPE="VALUE" IP_ADDRESS="10.1.1.1" SUB_DEVICE="0" OBJECT="Status.Connected">` +
+		`<OBJECT_VALUE OBJECT="Status.Connected" VALUE="1" AVAILABLE="1" DATA_TYPE="INTEGER" READABLE="1" WRITABLE="0" UNITS="" LABEL="" DEFAULT="0" ENUM_LIST="On,Off"/>` +
+		`</DEVICE_CHANGE>`
+	f, err := Decode([]byte(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.Device.ObjectValues) != 1 {
+		t.Fatalf("ObjectValues len = %d want 1", len(f.Device.ObjectValues))
+	}
+	ov := f.Device.ObjectValues[0]
+	if ov.Object != "Status.Connected" || ov.Value != "1" || !ov.Available {
+		t.Errorf("ov core = %+v", ov)
+	}
+	if ov.DataType != "INTEGER" || !ov.Readable || ov.Writable {
+		t.Errorf("ov flags = %+v", ov)
+	}
+	if ov.Default != "0" || !equalSlice(ov.EnumList, []string{"On", "Off"}) {
+		t.Errorf("ov default/enum = %q / %v", ov.Default, ov.EnumList)
+	}
+	// Backwards-compat accessor points at first entry.
+	if f.Device.ObjectValue == nil || f.Device.ObjectValue.Object != "Status.Connected" {
+		t.Errorf("ObjectValue accessor = %+v", f.Device.ObjectValue)
+	}
+}
+
+func TestDecodeDeviceChange_Value_GroupMultipleObjectValues(t *testing.T) {
+	// §5.4.3 p29 group worked example — multiple OBJECT_VALUE children.
+	wire := `<DEVICE_CHANGE TYPE="VALUE" IP_ADDRESS="10.1.1.1" SUB_DEVICE="0" OBJECT="Status">` +
+		`<OBJECT_VALUE OBJECT="Status.Connected" VALUE="1" AVAILABLE="1" DATA_TYPE="INTEGER" READABLE="1" WRITABLE="0" UNITS="" LABEL="" DEFAULT="0" ENUM_LIST="On,Off"/>` +
+		`<OBJECT_VALUE OBJECT="Status.Version" VALUE="1.0.0.1" AVAILABLE="1" DATA_TYPE="STRING" READABLE="1" WRITABLE="0" UNITS="" LABEL="" DEFAULT="" ENUM_LIST=""/>` +
+		`</DEVICE_CHANGE>`
+	f, err := Decode([]byte(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.Device.ObjectValues) != 2 {
+		t.Fatalf("ObjectValues len = %d want 2", len(f.Device.ObjectValues))
+	}
+	if f.Device.ObjectValues[1].Object != "Status.Version" || f.Device.ObjectValues[1].DataType != "STRING" {
+		t.Errorf("ObjectValues[1] = %+v", f.Device.ObjectValues[1])
+	}
+}
+
+func TestDecodeDeviceChange_Value_WildcardTable(t *testing.T) {
+	// §5.4.3 p29 wildcard table path Devices.[*] worked example.
+	wire := `<DEVICE_CHANGE TYPE="VALUE" IP_ADDRESS="10.1.1.1" SUB_DEVICE="0" OBJECT="Devices.[*]">` +
+		`<OBJECT_VALUE OBJECT="Name" VALUE="Device1" AVAILABLE="1" DATA_TYPE="STRING" READABLE="1" WRITABLE="0" UNITS="" LABEL="" DEFAULT="" ENUM_LIST=""/>` +
+		`<OBJECT_VALUE OBJECT="Firmware Version" VALUE="1.0.0.2" AVAILABLE="1" DATA_TYPE="STRING" READABLE="1" WRITABLE="0" UNITS="" LABEL="" DEFAULT="" ENUM_LIST=""/>` +
+		`</DEVICE_CHANGE>`
+	f, err := Decode([]byte(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Device.Object != "Devices.[*]" {
+		t.Errorf("Object = %q", f.Device.Object)
+	}
+	if len(f.Device.ObjectValues) != 2 || f.Device.ObjectValues[1].Object != "Firmware Version" {
+		t.Errorf("ObjectValues = %+v", f.Device.ObjectValues)
+	}
+}
+
+// ----------------------------------------------------------------------
+// §5.5.1 Data Store obtain TX + reply (p30) — PATH/NAME ambiguity.
+// ----------------------------------------------------------------------
+
+func TestEncodeDatastoreObtain_EmitsPATH(t *testing.T) {
+	// §5.5.1 p30 TX example uses PATH=. We emit PATH (+ optional MTID).
+	items := []SubItem{
+		&DatastoreChange{Path: `Global Data Files\Index.xml`, MTID: "1"},
+	}
+	got := string(EncodeObtain(1, items))
+	want := `<OBTAIN MTID="1"><DATASTORE_CHANGE PATH="Global Data Files\Index.xml" MTID="1"/></OBTAIN>`
+	if got != want {
+		t.Fatalf("\n got %s\nwant %s", got, want)
+	}
+}
+
+func TestDecodeDatastoreObtain_AcceptsPATHandNAME(t *testing.T) {
+	// Decode must accept either spelling (ambiguity resolution).
+	for _, attr := range []string{"PATH", "NAME"} {
+		wire := `<DATASTORE_CHANGE ` + attr + `="store\x.xml" TYPE="ATTRIBUTE"/>`
+		f, err := Decode([]byte(wire))
+		if err != nil {
+			t.Fatalf("%s: %v", attr, err)
+		}
+		if f.Datastore.Path != `store\x.xml` {
+			t.Errorf("%s: Path = %q", attr, f.Datastore.Path)
+		}
+		if f.Datastore.Name != `store\x.xml` {
+			t.Errorf("%s: Name(alias) = %q", attr, f.Datastore.Name)
+		}
+	}
+}
+
+func TestDecodeDatastore_ReplyWithDataBody(t *testing.T) {
+	// §5.5.1 p30 reply: <DATASTORE_CHANGE TYPE="FILE" AVAILABLE="1">
+	// <DATA>…</DATA></DATASTORE_CHANGE>.
+	wire := `<DATASTORE_CHANGE TYPE="FILE" AVAILABLE="1">` +
+		`<DATA><PRESETS><PRESET_1 NAME="Active"/></PRESETS></DATA>` +
+		`</DATASTORE_CHANGE>`
+	f, err := Decode([]byte(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := f.Datastore
+	if d.Type != "FILE" || !d.Available {
+		t.Errorf("type/available = %q / %v", d.Type, d.Available)
+	}
+	if d.Terminator {
+		t.Error("reply with DATA body should NOT be a terminator")
+	}
+	// Body re-rendered (case-folded). Structure + values preserved.
+	if !strings.Contains(d.Data, `presets`) || !strings.Contains(d.Data, `name="Active"`) {
+		t.Errorf("Data = %q", d.Data)
+	}
+}
+
+func TestDecodeDatastore_BareTerminator(t *testing.T) {
+	// §5.5.1 p30: the <DATASTORE_CHANGE MTID="1"/> terminator that
+	// follows the DATA reply.
+	f, err := Decode([]byte(`<DATASTORE_CHANGE MTID="1"/>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := f.Datastore
+	if !d.Terminator {
+		t.Errorf("should be terminator: %+v", d)
+	}
+	if d.MTID != "1" || d.Type != "" {
+		t.Errorf("terminator = %+v", d)
+	}
+}
+
+func TestDecodeDatastore_ChangeEvent(t *testing.T) {
+	// §5.5.2 p31 worked example.
+	wire := `<DATASTORE_CHANGE NAME="Global Data Files\Index.xml" TYPE="ATTRIBUTE">` +
+		`<ELEMENT ATTRIBUTE="Attribute" PATH="Data\Element" VALUE="Value" AVAILABLE="1" CHILD_COUNT="0"/>` +
+		`</DATASTORE_CHANGE>`
+	f, err := Decode([]byte(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := f.Datastore
+	if d.Path != `Global Data Files\Index.xml` || d.Type != "ATTRIBUTE" {
+		t.Errorf("event envelope = %+v", d)
+	}
+	if d.Terminator {
+		t.Error("change event should not be a terminator")
+	}
+	if d.Element == nil {
+		t.Fatal("Element nil")
+	}
+	el := d.Element
+	if el.Attribute != "Attribute" || el.Path != `Data\Element` || el.Value != "Value" || !el.Available || el.ChildCount != "0" {
+		t.Errorf("Element = %+v", el)
+	}
+}
+
+// ----------------------------------------------------------------------
+// 0v13 regression: the original encoder/decoder behaviour is unchanged.
+// ----------------------------------------------------------------------
+
+func TestDatastoreSubscribe_0v16_PATH_overCSV(t *testing.T) {
+	// Ensure TAGS pipe split and category CSV split stay independent:
+	// a comma inside a tag value is NOT a delimiter.
+	wire := `<ROUTING_CHANGE TYPE="RM_SRCE_TAGS" SRCE_ID="1" LEVEL_ID="1"><TAGS LIST="Tag,A|Tag B"/></ROUTING_CHANGE>`
+	f, err := Decode([]byte(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !equalSlice(f.Routing.TagList, []string{"Tag,A", "Tag B"}) {
+		t.Errorf("TagList = %v want [Tag,A Tag B]", f.Routing.TagList)
+	}
+}

--- a/internal/cerebrum-nb/codec/codec_coverage_test.go
+++ b/internal/cerebrum-nb/codec/codec_coverage_test.go
@@ -1,0 +1,390 @@
+package codec
+
+import (
+	"encoding/xml"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestParseRoot_NonEOFTokenError exercises the defensive non-EOF error
+// arm of parseRoot's pre-root token loop via the nextToken test seam.
+// This arm can't be reached through real input (see the seam comment in
+// element.go), so the seam is overridden here to inject a non-EOF error.
+func TestParseRoot_NonEOFTokenError(t *testing.T) {
+	orig := nextToken
+	defer func() { nextToken = orig }()
+	want := errors.New("boom")
+	nextToken = func(*xml.Decoder) (xml.Token, error) { return nil, want }
+
+	_, err := ParseElement([]byte(`<ACK/>`))
+	if !errors.Is(err, want) {
+		t.Fatalf("err = %v, want wrapping %v", err, want)
+	}
+}
+
+// This file completes branch coverage of the codec, exercising the
+// §4.2-§4.4 action encoders, §5 subscribe-item encoders, the §6 NACK
+// table accessors, and the element-AST edge cases that the feature
+// tests don't reach. Where the bytes are on-wire, the want-strings are
+// derived from the 0v16 worked examples (page cites inline); for pure
+// helpers the assertions pin documented behaviour.
+
+// ----------------------------------------------------------------------
+// FrameKind.String — every arm including the unknown fallthrough.
+// ----------------------------------------------------------------------
+
+func TestFrameKindString_All(t *testing.T) {
+	tests := []struct {
+		k    FrameKind
+		want string
+	}{
+		{KindLoginReply, "login_reply"},
+		{KindPollReply, "poll_reply"},
+		{KindAck, "ack"},
+		{KindNack, "nack"},
+		{KindBusy, "busy"},
+		{KindContinue, "continue"},
+		{KindWildcardComplete, "wildcard_complete"},
+		{KindDeviceConfigResult, "device_config_result"},
+		{KindRoutingChange, "routing_change"},
+		{KindCategoryChange, "category_change"},
+		{KindSalvoChange, "salvo_change"},
+		{KindDeviceChange, "device_change"},
+		{KindDatastoreChange, "datastore_change"},
+		{KindUnknown, "unknown"},
+		{FrameKind(9999), "unknown"},
+	}
+	for _, tc := range tests {
+		if got := tc.k.String(); got != tc.want {
+			t.Errorf("FrameKind(%d).String() = %q want %q", tc.k, got, tc.want)
+		}
+	}
+}
+
+// ----------------------------------------------------------------------
+// §4.2 / §4.3 / §4.4 action encoders.
+// ----------------------------------------------------------------------
+
+func TestEncodeAction_Category(t *testing.T) {
+	// §4.2.1 p16 Modify Item worked example.
+	body := &CategoryAction{
+		Type:     "MODIFY_ITEM",
+		Category: "SERVERS",
+		Index:    "4",
+		ItemType: ItemSource,
+		Value:    "SRVR-1",
+	}
+	got := string(EncodeAction(1, body))
+	want := `<ACTION MTID="1"><CATEGORY TYPE="MODIFY_ITEM" CATEGORY="SERVERS" INDEX="4" ITEM_TYPE="SOURCE" VALUE="SRVR-1"/></ACTION>`
+	if got != want {
+		t.Fatalf("\n got %s\nwant %s", got, want)
+	}
+}
+
+func TestEncodeAction_CategoryCreate(t *testing.T) {
+	// §4.2.4 p16 Create Category — exercises NAME/LABEL/INHERITS/DESCRIPTION.
+	body := &CategoryAction{
+		Type:        "CREATE",
+		Name:        "SERVERS",
+		Label:       "Servers",
+		Inherits:    "PARENT_CATEGORY",
+		Description: "All Servers",
+	}
+	got := string(EncodeAction(1, body))
+	want := `<ACTION MTID="1"><CATEGORY TYPE="CREATE" NAME="SERVERS" LABEL="Servers" INHERITS="PARENT_CATEGORY" DESCRIPTION="All Servers"/></ACTION>`
+	if got != want {
+		t.Fatalf("\n got %s\nwant %s", got, want)
+	}
+}
+
+func TestEncodeAction_Salvo(t *testing.T) {
+	// §4.3.3 p18 Rename worked example.
+	body := &SalvoAction{
+		Type:     "RENAME",
+		Group:    "Multiviewer 1",
+		Instance: "Line up",
+		NewName:  "Line-up",
+	}
+	got := string(EncodeAction(1, body))
+	want := `<ACTION MTID="1"><SALVO TYPE="RENAME" GROUP="Multiviewer 1" INSTANCE="Line up" NEW_NAME="Line-up"/></ACTION>`
+	if got != want {
+		t.Fatalf("\n got %s\nwant %s", got, want)
+	}
+}
+
+func TestEncodeAction_SalvoDescription(t *testing.T) {
+	// §4.3.4 p18 Set Description — exercises DESCRIPTION arm.
+	body := &SalvoAction{
+		Type:        "DESCRIPTION",
+		Group:       "Multiviewer 1",
+		Instance:    "Line up",
+		Description: "The layout for line up",
+	}
+	got := string(EncodeAction(1, body))
+	want := `<ACTION MTID="1"><SALVO TYPE="DESCRIPTION" GROUP="Multiviewer 1" INSTANCE="Line up" DESCRIPTION="The layout for line up"/></ACTION>`
+	if got != want {
+		t.Fatalf("\n got %s\nwant %s", got, want)
+	}
+}
+
+func TestEncodeAction_Device(t *testing.T) {
+	// §4.4.1 p19 Set Value (DEVICE_NAME + SUB_DEVICE + OBJECT + VALUE).
+	body := &DeviceAction{
+		Type:       "SET_VALUE",
+		DeviceName: "Cam1",
+		SubDevice:  "1",
+		Object:     "PSU.Fan Control",
+		Value:      "Automatic",
+	}
+	got := string(EncodeAction(1, body))
+	want := `<ACTION MTID="1"><DEVICE TYPE="SET_VALUE" DEVICE_NAME="Cam1" SUB_DEVICE="1" OBJECT="PSU.Fan Control" VALUE="Automatic"/></ACTION>`
+	if got != want {
+		t.Fatalf("\n got %s\nwant %s", got, want)
+	}
+}
+
+func TestEncodeAction_RoutingFullAttrs(t *testing.T) {
+	// Exercise the association + tag attribute arms of RoutingAction
+	// (§4.1.7 p13 Source Association + §4.2.1 p15 RM tags fields).
+	body := &RoutingAction{
+		Type:               "SRCE_ASSOC",
+		IPAddress:          "10.0.0.1",
+		SrceName:           "CAM",
+		SrceLevelID:        "1",
+		SrceLevelName:      "HD",
+		DestName:           "MON",
+		DestLevelID:        "2",
+		DestLevelName:      "UHD",
+		UseTags:            "1",
+		LevelName:          "L",
+		Lock:               LockLocked,
+		Duration:           "1000",
+		Mnemonic:           "M",
+		AltMne:             "1",
+		OnDevice:           "0",
+		LogicalSrceID:      "199",
+		LogicalDestID:      "200",
+		LogicalLevelID:     "2",
+		TargetDeviceName:   "Hybrid",
+		TargetDeviceType:   ConfigDeviceTypeRouterAlias(),
+		TargetLevelID:      "1",
+		TargetSrceID:       "100",
+		TargetDestID:       "101",
+		TargetSenderName:   "atx01",
+		TargetReceiverName: "ARX-1",
+		SubDevice:          "0",
+		Tags:               "Tag1",
+	}
+	got := string(EncodeAction(1, body))
+	// Spot-check that the association + tag arms all serialised.
+	for _, sub := range []string{
+		`LOGICAL_SRCE_ID="199"`, `LOGICAL_DEST_ID="200"`, `TARGET_SENDER_NAME="atx01"`,
+		`TARGET_RECEIVER_NAME="ARX-1"`, `SUB_DEVICE="0"`, `TAGS="Tag1"`, `LOCK="LOCKED"`,
+	} {
+		if !strings.Contains(got, sub) {
+			t.Errorf("missing %s in %s", sub, got)
+		}
+	}
+}
+
+// ConfigDeviceTypeRouterAlias returns the §3.1 DeviceType for ROUTER as
+// used by routing association targets (kept local to avoid leaking a
+// test-only const into the package surface).
+func ConfigDeviceTypeRouterAlias() DeviceType { return DeviceType("ROUTER") }
+
+// ----------------------------------------------------------------------
+// §5 subscribe-item encoders (Category / Salvo / Device / Datastore).
+// ----------------------------------------------------------------------
+
+func TestEncodeSubscribe_CategoryChange(t *testing.T) {
+	// §5.2.2 p27 Category Details subscribe.
+	items := []SubItem{&CategoryChange{Type: "CATEGORY_DETAILS", Category: "EVS"}}
+	got := string(EncodeSubscribe(1, items))
+	want := `<SUBSCRIBE MTID="1"><CATEGORY_CHANGE TYPE="CATEGORY_DETAILS" CATEGORY="EVS"/></SUBSCRIBE>`
+	if got != want {
+		t.Fatalf("\n got %s\nwant %s", got, want)
+	}
+}
+
+func TestEncodeSubscribe_SalvoChange(t *testing.T) {
+	// §5.3.3 p28 Instance Details subscribe.
+	items := []SubItem{&SalvoChange{Type: "INSTANCE_DETAILS", Group: "Multiviewer 1", Instance: "Line up"}}
+	got := string(EncodeSubscribe(1, items))
+	want := `<SUBSCRIBE MTID="1"><SALVO_CHANGE TYPE="INSTANCE_DETAILS" GROUP="Multiviewer 1" INSTANCE="Line up"/></SUBSCRIBE>`
+	if got != want {
+		t.Fatalf("\n got %s\nwant %s", got, want)
+	}
+}
+
+func TestEncodeSubscribe_DeviceChangeValue(t *testing.T) {
+	// §5.4.3 p29 Device Value subscribe.
+	items := []SubItem{&DeviceChange{Type: "VALUE", DeviceName: "Camera1", SubDevice: "0", Object: "Status.Connected"}}
+	got := string(EncodeSubscribe(1, items))
+	want := `<SUBSCRIBE MTID="1"><DEVICE_CHANGE TYPE="VALUE" DEVICE_NAME="Camera1" SUB_DEVICE="0" OBJECT="Status.Connected"/></SUBSCRIBE>`
+	if got != want {
+		t.Fatalf("\n got %s\nwant %s", got, want)
+	}
+}
+
+func TestEncodeUnsubscribe_RoutingChange(t *testing.T) {
+	// §2.4 p8 UNSUBSCRIBE wraps the same item shape as SUBSCRIBE.
+	items := []SubItem{&RoutingChange{Type: "ROUTE", DeviceName: "MTX1", DeviceType: DeviceType("ROUTER")}}
+	got := string(EncodeUnsubscribe(2, items))
+	want := `<UNSUBSCRIBE MTID="2"><ROUTING_CHANGE TYPE="ROUTE" DEVICE_NAME="MTX1" DEVICE_TYPE="ROUTER"/></UNSUBSCRIBE>`
+	if got != want {
+		t.Fatalf("\n got %s\nwant %s", got, want)
+	}
+}
+
+// ----------------------------------------------------------------------
+// §6 NACK table accessors.
+// ----------------------------------------------------------------------
+
+func TestNackCode_Accessors(t *testing.T) {
+	if NackNotLoggedIn.Code() != "NOT_LOGGED_IN" {
+		t.Errorf("Code = %q", NackNotLoggedIn.Code())
+	}
+	if NackNotLoggedIn.Description() != "a successful login is required" {
+		t.Errorf("Description = %q", NackNotLoggedIn.Description())
+	}
+	if !strings.Contains(NackNotLoggedIn.String(), "NOT_LOGGED_IN") {
+		t.Errorf("String = %q", NackNotLoggedIn.String())
+	}
+}
+
+func TestNackCode_OutOfRange(t *testing.T) {
+	// Defensive arms for an id outside the §6 table.
+	bad := NackCode(999)
+	if bad.Code() != "UNKNOWN" {
+		t.Errorf("Code = %q want UNKNOWN", bad.Code())
+	}
+	if bad.Description() != "" {
+		t.Errorf("Description = %q want empty", bad.Description())
+	}
+	if !strings.Contains(bad.String(), "UNKNOWN") {
+		t.Errorf("String = %q", bad.String())
+	}
+	negative := NackCode(-1)
+	if negative.Code() != "UNKNOWN" || negative.Description() != "" {
+		t.Errorf("negative accessors: %q / %q", negative.Code(), negative.Description())
+	}
+}
+
+func TestNackCodeFromString_Miss(t *testing.T) {
+	if _, ok := NackCodeFromString("NO_SUCH_CODE"); ok {
+		t.Error("expected miss for unknown code")
+	}
+}
+
+func TestNackError_Error(t *testing.T) {
+	resolved := &NackError{ID: NackMtidError, Code: "MTID_ERROR"}
+	if !strings.Contains(resolved.Error(), "MTID_ERROR") {
+		t.Errorf("resolved Error = %q", resolved.Error())
+	}
+	unresolved := &NackError{ID: -1, Code: "WEIRD", Message: "huh"}
+	if !strings.Contains(unresolved.Error(), "WEIRD") || !strings.Contains(unresolved.Error(), "huh") {
+		t.Errorf("unresolved Error = %q", unresolved.Error())
+	}
+}
+
+func TestParseNack_DescriptionFallbackToText(t *testing.T) {
+	// description carried as element text, id resolved via code string.
+	f, err := Decode([]byte(`<nack mtid="1" code="NOT_LOGGED_IN">login first</nack>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Nack.ID != NackNotLoggedIn || f.Nack.Message != "login first" {
+		t.Fatalf("nack = %+v", f.Nack)
+	}
+}
+
+// ----------------------------------------------------------------------
+// element.go edge cases.
+// ----------------------------------------------------------------------
+
+func TestElement_NilSafety(t *testing.T) {
+	var e *Element
+	if e.Attr("x") != "" {
+		t.Error("nil.Attr should be empty")
+	}
+	if e.Child("x") != nil {
+		t.Error("nil.Child should be nil")
+	}
+	if e.ChildrenNamed("x") != nil {
+		t.Error("nil.ChildrenNamed should be nil")
+	}
+	if e.String() != "" {
+		t.Error("nil.String should be empty")
+	}
+}
+
+func TestParseElement_EmptyXML(t *testing.T) {
+	if _, err := ParseElement([]byte("   ")); err == nil {
+		t.Error("expected error for empty XML")
+	}
+}
+
+func TestParseElement_SkipsCommentsAndProcInst(t *testing.T) {
+	// Leading <?xml?>, a comment, then the root with a child comment.
+	wire := `<?xml version="1.0"?><!-- top --><ACK MTID="1"><!-- inner -->text</ACK>`
+	e, err := ParseElement([]byte(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e.Name != "ack" || e.Attr("mtid") != "1" || e.Text != "text" {
+		t.Fatalf("parsed = %+v", e)
+	}
+}
+
+func TestParseElement_MalformedReturnsError(t *testing.T) {
+	if _, err := ParseElement([]byte(`<ACK><UNCLOSED>`)); err == nil {
+		t.Error("expected parse error for unclosed element")
+	}
+}
+
+func TestElement_StringRoundtrip(t *testing.T) {
+	// String() renders attrs + children + text, escaping reserved chars
+	// in text. (Attr map order is non-deterministic, so assert on a
+	// single-attr element.)
+	e := &Element{
+		Name:  "root",
+		Attrs: map[string]string{"k": `a&b`},
+		Children: []*Element{
+			{Name: "child", Attrs: map[string]string{}, Text: "x<y>&z"},
+		},
+	}
+	got := e.String()
+	if !strings.Contains(got, `k="a&amp;b"`) {
+		t.Errorf("attr escape missing: %s", got)
+	}
+	if !strings.Contains(got, "x&lt;y&gt;&amp;z") {
+		t.Errorf("text escape missing: %s", got)
+	}
+	if !strings.Contains(got, "<child") {
+		t.Errorf("child missing: %s", got)
+	}
+}
+
+func TestXMLEscapeAttr_AllSpecials(t *testing.T) {
+	// Drive every arm of xmlEscapeAttr via a single-attr element.
+	e := &Element{Name: "x", Attrs: map[string]string{"a": "&<>\"'\n\r\t"}}
+	got := e.String()
+	for _, want := range []string{"&amp;", "&lt;", "&gt;", "&quot;", "&apos;", "&#10;", "&#13;", "&#9;"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %s in %s", want, got)
+		}
+	}
+}
+
+func TestEmitRawChild_WithAttrs(t *testing.T) {
+	// emitRawChild with non-nil attrs (the PANEL_SPECIFIC path covers the
+	// attr-bearing branch; assert escaping + verbatim inner here).
+	var b strings.Builder
+	emitRawChild(&b, "WRAP", []Attr{{"K", `a&b`}}, `<INNER/>`)
+	got := b.String()
+	want := `<WRAP K="a&amp;b"><INNER/></WRAP>`
+	if got != want {
+		t.Fatalf("got %s want %s", got, want)
+	}
+}

--- a/internal/cerebrum-nb/codec/codec_edges_test.go
+++ b/internal/cerebrum-nb/codec/codec_edges_test.go
@@ -1,0 +1,149 @@
+package codec
+
+import "testing"
+
+// Defensive-branch coverage: malformed-but-tolerated wire shapes that
+// the parsers absorb (skip a bad child, fall through to Unknown) rather
+// than erroring. These pin the spec-deviation-absorption posture
+// (root CLAUDE.md "Spec-strict, no-workaround").
+
+func TestParseRoutingChange_BadAltMneAndAssocIndexes(t *testing.T) {
+	// alt_mne_X / association_X with non-numeric suffixes must be
+	// skipped, not crash. The good siblings still parse.
+	wire := `<ROUTING_CHANGE TYPE="SRCE_MNE" SRCE_ID="1" LEVEL_ID="1">` +
+		`<MNE AVAILABLE="1" MNEMONIC="M"/>` +
+		`<ALT_MNE_X MNEMONIC="bad" AVAILABLE="1"/>` + // non-numeric → skipped
+		`<ALT_MNE_2 MNEMONIC="ok" AVAILABLE="1"/>` +
+		`<ASSOCIATIONS>` +
+		`<ASSOCIATION_X SRCE_ID="9"/>` + // non-numeric → skipped
+		`<NOT_AN_ASSOC FOO="1"/>` + // wrong prefix → skipped
+		`<ASSOCIATION_7 SRCE_ID="7"/>` +
+		`</ASSOCIATIONS>` +
+		`</ROUTING_CHANGE>`
+	f, err := Decode([]byte(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := f.Routing
+	if r.Mnemonics[2] != "ok" {
+		t.Errorf("alt_mne_2 = %q", r.Mnemonics[2])
+	}
+	if _, bad := r.Mnemonics[0]; !bad { // slot 0 from <MNE>
+		t.Errorf("primary mne missing: %+v", r.Mnemonics)
+	}
+	if len(r.Associations) != 1 || r.Associations[0].Index != 7 {
+		t.Fatalf("associations = %+v", r.Associations)
+	}
+}
+
+func TestParseCategoryChange_BadItemChildren(t *testing.T) {
+	// A non-item_ child and an item_ child with a non-numeric suffix are
+	// both skipped; the valid item survives.
+	wire := `<CATEGORY_CHANGE TYPE="CATEGORY_DETAILS" CATEGORY="C">` +
+		`<DETAILS AVAILABLE="1" LABEL="L"/>` +
+		`<ITEMS>` +
+		`<NOISE FOO="1"/>` + // no item_ prefix → skipped
+		`<ITEM_X TYPE="SOURCE" VALUE="bad"/>` + // non-numeric → skipped
+		`<ITEM_3 TYPE="SOURCE" VALUE="ok"/>` +
+		`</ITEMS>` +
+		`</CATEGORY_CHANGE>`
+	f, err := Decode([]byte(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	items := f.Category.Details.Items
+	if len(items) != 1 || items[0].Index != 3 || items[0].Value != "ok" {
+		t.Fatalf("items = %+v", items)
+	}
+}
+
+func TestParseDeviceChange_DetailsWithPopulatedSubDevices(t *testing.T) {
+	// §5.4.2 p29-style DETAILS with a populated <SUB_DEVICES> containing
+	// <DEVICE> children — exercises the sub-device loop + the
+	// instance/back-compat arms (device-level DEVICE_TYPE present and
+	// absent).
+	wire := `<DEVICE_CHANGE TYPE="DETAILS" IP_ADDRESS="10.1.1.1" DEVICE_TYPE="GENERIC">` +
+		`<DETAILS IP1="10.1.1.1" IP2="10.1.1.2" NAME="Synapse" TYPE="Synapse"/>` +
+		`<SERVICE IP1="172.10.1.100" IP2="172.10.2.100"/>` +
+		`<CONNECTION PRIMARY_STATE="ACTIVE" SECONDARY_STATE="UP"/>` +
+		`<SUB_DEVICES>` +
+		`<DEVICE IP="10.2.0.1" DEVICE_TYPE="DEVICE" DEVICE_NAME="Card1"/>` + // back-compat: DeviceType already set
+		`<DEVICE IP="10.2.0.2"><INSTANCE DEVICE_TYPE="ROUTER"/></DEVICE>` + // back-compat: DeviceType from instance
+		`</SUB_DEVICES>` +
+		`</DEVICE_CHANGE>`
+	f, err := Decode([]byte(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := f.Device
+	if d.Details == nil || d.Service == nil || d.Connection == nil {
+		t.Fatalf("nested nil: %+v", d)
+	}
+	if len(d.SubDevices) != 2 {
+		t.Fatalf("sub-devices = %+v", d.SubDevices)
+	}
+	if d.SubDevices[0].DeviceType != "DEVICE" || d.SubDevices[0].DeviceName != "Card1" {
+		t.Errorf("sub[0] = %+v", d.SubDevices[0])
+	}
+	if d.SubDevices[1].DeviceType != "ROUTER" {
+		t.Errorf("sub[1] back-compat DeviceType = %q", d.SubDevices[1].DeviceType)
+	}
+}
+
+func TestDecode_MalformedXMLErrors(t *testing.T) {
+	// Decode wraps a ParseElement failure (transport-level XML error).
+	if _, err := Decode([]byte(`<ACK><UNCLOSED>`)); err == nil {
+		t.Fatal("expected decode error on malformed XML")
+	}
+}
+
+func TestParseRoutingChange_MneUnavailableAndRouteChild(t *testing.T) {
+	// <MNE AVAILABLE="0"> is dropped (only ORIGINAL_MNE captured), and a
+	// TYPE=ROUTE row carries a <ROUTE> source child (§5.1.1 p23-24).
+	wire := `<ROUTING_CHANGE TYPE="ROUTE" DEVICE_NAME="MTX1" DEVICE_TYPE="ROUTER" DEST_ID="1" LEVEL_ID="2">` +
+		`<MNE AVAILABLE="0" ORIGINAL_MNE="GONE"/>` +
+		`<ROUTE AVAILABLE="1" SOURCE_ID="1" SOURCE_LEVEL_ID="1"/>` +
+		`</ROUTING_CHANGE>`
+	f, err := Decode([]byte(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := f.Routing
+	if r.OriginalMne != "GONE" {
+		t.Errorf("original_mne = %q", r.OriginalMne)
+	}
+	if _, ok := r.Mnemonics[0]; ok {
+		t.Errorf("unavailable MNE should be dropped: %+v", r.Mnemonics)
+	}
+	if r.RouteSourceID != "1" || r.RouteSourceLevelID != "1" || !r.RouteAvailable {
+		t.Errorf("route = id:%q lvl:%q avail:%v", r.RouteSourceID, r.RouteSourceLevelID, r.RouteAvailable)
+	}
+}
+
+func TestParseRoutingChange_AltMneWithoutPrimaryMne(t *testing.T) {
+	// An <ALT_MNE_N> arriving with no preceding <MNE> must still
+	// lazily-init the Mnemonics map (the nil-init arm in the alt branch).
+	wire := `<ROUTING_CHANGE TYPE="SRCE_MNE" SRCE_ID="1" LEVEL_ID="1">` +
+		`<ALT_MNE_2 MNEMONIC="solo" AVAILABLE="1"/>` +
+		`</ROUTING_CHANGE>`
+	f, err := Decode([]byte(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Routing.Mnemonics[2] != "solo" {
+		t.Fatalf("mnemonics = %+v", f.Routing.Mnemonics)
+	}
+}
+
+func TestParseDeviceChange_ListEntryWithExplicitDeviceType(t *testing.T) {
+	// A LIST <DEVICE> carrying DEVICE_TYPE directly (no <INSTANCE>) — the
+	// back-compat "DeviceType already set" branch.
+	wire := `<DEVICE_CHANGE TYPE="LIST"><DEVICE IP="10.0.0.1" DEVICE_TYPE="SNMP"/></DEVICE_CHANGE>`
+	f, err := Decode([]byte(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Device.Devices[0].DeviceType != "SNMP" || len(f.Device.Devices[0].DeviceTypes) != 0 {
+		t.Fatalf("entry = %+v", f.Device.Devices[0])
+	}
+}

--- a/internal/cerebrum-nb/codec/decode.go
+++ b/internal/cerebrum-nb/codec/decode.go
@@ -18,6 +18,9 @@ const (
 	KindAck
 	KindNack
 	KindBusy
+	KindContinue         // <CONTINUE/> flow-control after BUSY (§1.4 p5)
+	KindWildcardComplete // <WILDCARD_COMPLETE MTID/> end-of-snapshot (§1.6 p6)
+	KindDeviceConfigResult // <DEVICE_CONFIGURATION …><RESULT VALUE=…/> (§4.5 p20-23)
 
 	// Async events (§5)
 	KindRoutingChange
@@ -39,6 +42,12 @@ func (k FrameKind) String() string {
 		return "nack"
 	case KindBusy:
 		return "busy"
+	case KindContinue:
+		return "continue"
+	case KindWildcardComplete:
+		return "wildcard_complete"
+	case KindDeviceConfigResult:
+		return "device_config_result"
 	case KindRoutingChange:
 		return "routing_change"
 	case KindCategoryChange:
@@ -61,9 +70,10 @@ type Frame struct {
 	Root        *Element
 	CaseChanged bool
 
-	LoginReply *LoginReply
-	PollReply  *PollReply
-	Nack       *NackError
+	LoginReply   *LoginReply
+	PollReply    *PollReply
+	Nack         *NackError
+	DeviceConfig *DeviceConfigResult // KindDeviceConfigResult (§4.5)
 
 	Routing   *RoutingChange
 	Category  *CategoryChange
@@ -72,10 +82,34 @@ type Frame struct {
 	Datastore *DatastoreChange
 }
 
-// LoginReply is the body of <login_reply mtid="…" api_ver="…"/>.
+// LoginReply is the body of <LOGIN_REPLY MTID="…" API_VER="…">. As of
+// 0v16 (§2.1 p7) a successful login also carries a <DATASTORES> body
+// listing the Data Stores assigned to the Cerebrum API, each with an
+// AVAILABLE flag. Older servers omit it; Datastores is then nil.
 type LoginReply struct {
-	MTID   string
-	APIVer string
+	MTID       string
+	APIVer     string
+	Datastores []DatastoreEntry
+}
+
+// DatastoreEntry is one <DATASTORE NAME="…" AVAILABLE="0|1"/> row of a
+// 0v16 LOGIN_REPLY <DATASTORES> body (§2.1 p7). Name is the relative
+// path used later as the obtain key (§5.5.1). Available reports whether
+// the store was read successfully.
+type DatastoreEntry struct {
+	Name      string
+	Available bool
+}
+
+// DeviceConfigResult is the §4.5 reply body. The server echoes the
+// request's <DEVICE_CONFIGURATION> envelope wrapping a single
+// <RESULT VALUE="ACCEPTED|FAILED"/> (p20-23).
+type DeviceConfigResult struct {
+	Type       string // ADD / MODIFY / REMOVE (echoed)
+	IPAddress  string
+	DeviceType string
+	Value      string // ACCEPTED / FAILED
+	Accepted   bool   // Value == "ACCEPTED"
 }
 
 // PollReply is the body of <poll_reply mtid="…" CONNECTED_SERVER_ACTIVE
@@ -103,10 +137,7 @@ func Decode(data []byte) (*Frame, error) {
 	switch root.Name {
 	case "login_reply":
 		f.Kind = KindLoginReply
-		f.LoginReply = &LoginReply{
-			MTID:   root.Attr("mtid"),
-			APIVer: root.Attr("api_ver"),
-		}
+		f.LoginReply = parseLoginReply(root)
 	case "poll_reply":
 		f.Kind = KindPollReply
 		f.PollReply = &PollReply{
@@ -122,6 +153,13 @@ func Decode(data []byte) (*Frame, error) {
 		f.Nack = parseNack(root)
 	case "busy":
 		f.Kind = KindBusy
+	case "continue":
+		f.Kind = KindContinue
+	case "wildcard_complete":
+		f.Kind = KindWildcardComplete
+	case "device_configuration":
+		f.Kind = KindDeviceConfigResult
+		f.DeviceConfig = parseDeviceConfigResult(root)
 	case "routing_change":
 		f.Kind = KindRoutingChange
 		f.Routing = parseRoutingChange(root)
@@ -195,6 +233,42 @@ func parseNack(e *Element) *NackError {
 	return ne
 }
 
+// parseLoginReply reads <LOGIN_REPLY MTID API_VER> plus the optional
+// 0v16 <DATASTORES><DATASTORE NAME AVAILABLE/>…</DATASTORES> body
+// (§2.1 p7). Pre-0v16 servers omit the body; Datastores is then nil.
+func parseLoginReply(e *Element) *LoginReply {
+	lr := &LoginReply{
+		MTID:   e.Attr("mtid"),
+		APIVer: e.Attr("api_ver"),
+	}
+	if stores := e.Child("datastores"); stores != nil {
+		for _, ds := range stores.ChildrenNamed("datastore") {
+			lr.Datastores = append(lr.Datastores, DatastoreEntry{
+				Name:      ds.Attr("name"),
+				Available: parseBoolAttr(ds.Attr("available")),
+			})
+		}
+	}
+	return lr
+}
+
+// parseDeviceConfigResult reads the §4.5 reply envelope
+// <DEVICE_CONFIGURATION TYPE IP_ADDRESS DEVICE_TYPE><RESULT VALUE=…/>
+// </DEVICE_CONFIGURATION> (p20-23). The <RESULT> child carries the
+// ACCEPTED / FAILED verdict.
+func parseDeviceConfigResult(e *Element) *DeviceConfigResult {
+	r := &DeviceConfigResult{
+		Type:       e.Attr("type"),
+		IPAddress:  firstNonEmpty(e.Attr("ip_address"), e.Attr("ip")),
+		DeviceType: e.Attr("device_type"),
+	}
+	if res := e.Child("result"); res != nil {
+		r.Value = res.Attr("value")
+		r.Accepted = strEqualFold(r.Value, "ACCEPTED")
+	}
+	return r
+}
+
 func parseRoutingChange(e *Element) *RoutingChange {
 	r := &RoutingChange{
 		Type:       e.Attr("type"),
@@ -217,6 +291,11 @@ func parseRoutingChange(e *Element) *RoutingChange {
 	for _, c := range e.Children {
 		switch {
 		case c.Name == "mne":
+			// ORIGINAL_MNE is the device's un-overridden name
+			// (§5.1.4-§5.1.6 pp25-26); captured even when AVAILABLE="0".
+			if om := c.Attr("original_mne"); om != "" {
+				r.OriginalMne = om
+			}
 			if c.Attr("available") == "0" {
 				continue
 			}
@@ -244,6 +323,51 @@ func parseRoutingChange(e *Element) *RoutingChange {
 			r.RouteSourceID = c.Attr("source_id")
 			r.RouteSourceLevelID = c.Attr("source_level_id")
 			r.RouteAvailable = c.Attr("available") == "1"
+		case c.Name == "value" || c.Name == "lock":
+			// §5.1.2 SRCE_LOCK uses <VALUE …/>; §5.1.3 DEST_LOCK uses
+			// <LOCK …/> (p24). Same attribute set on both.
+			r.Lock = &RoutingLock{
+				Available:  parseBoolAttr(c.Attr("available")),
+				LockState:  LockKind(c.Attr("lock_state")),
+				LockedBy:   c.Attr("locked_by"),
+				UnlockTime: c.Attr("unlock_time"),
+				UnlockDate: c.Attr("unlock_date"),
+			}
+		case c.Name == "associations":
+			// §5.1.5/§5.1.6 pp25-26: positional <ASSOCIATION_N …/>.
+			for _, assoc := range c.Children {
+				n, ok := strings.CutPrefix(assoc.Name, "association_")
+				if !ok {
+					continue
+				}
+				idx, err := strconv.Atoi(n)
+				if err != nil {
+					continue
+				}
+				r.Associations = append(r.Associations, RoutingAssociation{
+					Index:        idx,
+					SrceID:       assoc.Attr("srce_id"),
+					DestID:       assoc.Attr("dest_id"),
+					RMDeviceName: assoc.Attr("rm_device_name"),
+					RMDeviceType: DeviceType(assoc.Attr("rm_device_type")),
+					RMLevelID:    assoc.Attr("rm_level_id"),
+					RMReversed:   assoc.Attr("rm_reversed"),
+					RMTags:       assoc.Attr("rm_tags"),
+					RMIPUID:      assoc.Attr("rm_ip_uid"),
+				})
+			}
+		case c.Name == "rm_default_device":
+			r.RMDefaultDevice = &RMDefaultDevice{
+				DeviceName: c.Attr("device_name"),
+				DeviceType: DeviceType(c.Attr("device_type")),
+				LevelID:    c.Attr("level_id"),
+			}
+		case c.Name == "tags":
+			// §5.1.7/§5.1.8 p27: <TAGS [AVAILABLE] LIST="Tag1|Tag2"/>.
+			// LIST uses the PIPE delimiter (0.13 change history p33),
+			// NOT the comma used by category/group LISTs.
+			r.TagsAvailable = parseBoolAttr(c.Attr("available"))
+			r.TagList = splitPipe(c.Attr("list"))
 		}
 	}
 	return r
@@ -293,6 +417,7 @@ func parseCategoryChange(e *Element) *CategoryChange {
 				Index: idx,
 				Type:  t,
 				Value: child.Attr("value"),
+				Group: child.Attr("group"),
 			})
 		}
 	}
@@ -323,7 +448,11 @@ func parseSalvoChange(e *Element) *SalvoChange {
 	// instance does not exist).
 	if det := e.Child("details"); det != nil && e.Attr("instance") != "" {
 		s.InstanceDetails = &SalvoInstanceDetails{
-			Available: parseBoolAttr(det.Attr("available")),
+			Available:   parseBoolAttr(det.Attr("available")),
+			Description: det.Attr("description"),
+			Active:      parseBoolAttr(det.Attr("active")),
+			Date:        det.Attr("date"),
+			Time:        det.Attr("time"),
 		}
 	}
 	return s
@@ -384,13 +513,25 @@ func parseDeviceChange(e *Element) *DeviceChange {
 			SecondaryState: conn.Attr("secondary_state"),
 		}
 	}
-	// TYPE=VALUE: <object_value available="0|1" object="..."/>
-	// (live wire 2026-04-27).
-	if ov := e.Child("object_value"); ov != nil {
-		d.ObjectValue = &DeviceObjectValue{
-			Available: parseBoolAttr(ov.Attr("available")),
+	// TYPE=VALUE: one or more <OBJECT_VALUE …/> children (§5.4.3 p29).
+	// A scalar object yields one; a group / table / wildcard path yields
+	// several. The full 0v16 descriptor is captured per entry.
+	for _, ov := range e.ChildrenNamed("object_value") {
+		d.ObjectValues = append(d.ObjectValues, DeviceObjectValue{
 			Object:    ov.Attr("object"),
-		}
+			Value:     ov.Attr("value"),
+			Available: parseBoolAttr(ov.Attr("available")),
+			DataType:  ov.Attr("data_type"),
+			Readable:  parseBoolAttr(ov.Attr("readable")),
+			Writable:  parseBoolAttr(ov.Attr("writable")),
+			Units:     ov.Attr("units"),
+			Label:     ov.Attr("label"),
+			Default:   ov.Attr("default"),
+			EnumList:  splitCSV(ov.Attr("enum_list")),
+		})
+	}
+	if len(d.ObjectValues) > 0 {
+		d.ObjectValue = &d.ObjectValues[0]
 	}
 	if subs := e.Child("sub_devices"); subs != nil {
 		for _, child := range subs.ChildrenNamed("device") {
@@ -429,13 +570,24 @@ func parseBoolAttr(s string) bool {
 }
 
 func splitCSV(s string) []string {
+	return splitOn(s, ',')
+}
+
+// splitPipe splits a Routemaster TAGS LIST on the '|' delimiter
+// (§4.2.1/§4.2.2 p15, §5.1.7/§5.1.8 p27, 0.13 change history p33). The
+// pipe delimiter is specific to Tags; category/group LISTs use comma.
+func splitPipe(s string) []string {
+	return splitOn(s, '|')
+}
+
+func splitOn(s string, sep byte) []string {
 	if s == "" {
 		return nil
 	}
 	out := make([]string, 0, 8)
 	start := 0
 	for i := 0; i < len(s); i++ {
-		if s[i] == ',' {
+		if s[i] == sep {
 			out = append(out, s[start:i])
 			start = i + 1
 		}
@@ -444,9 +596,49 @@ func splitCSV(s string) []string {
 	return out
 }
 
+// parseDatastoreChange decodes the three §5.5 RX shapes:
+//
+//   - Obtain reply (§5.5.1 p30): <DATASTORE_CHANGE TYPE="FILE"
+//     AVAILABLE="1"><DATA>…</DATA></DATASTORE_CHANGE>.
+//   - Bare terminator (§5.5.1 p30): <DATASTORE_CHANGE MTID="1"/> — no
+//     TYPE and no children.
+//   - Change event (§5.5.2 p31): <DATASTORE_CHANGE NAME="…" TYPE="…">
+//     <ELEMENT ATTRIBUTE PATH VALUE AVAILABLE CHILD_COUNT/>
+//     </DATASTORE_CHANGE>.
+//
+// Path accepts either PATH (the §5.5.1 example) or NAME (the §5.5.1
+// attribute table / §5.5.2 event) — see the PATH/NAME ambiguity note on
+// DatastoreChange.
 func parseDatastoreChange(e *Element) *DatastoreChange {
-	return &DatastoreChange{
-		Name: e.Attr("name"),
-		Type: e.Attr("type"),
+	path := firstNonEmpty(e.Attr("path"), e.Attr("name"))
+	d := &DatastoreChange{
+		Path:      path,
+		Name:      path, // deprecated alias, kept in sync for 0v13 callers
+		MTID:      e.Attr("mtid"),
+		Type:      e.Attr("type"),
+		Available: parseBoolAttr(e.Attr("available")),
 	}
+	if data := e.Child("data"); data != nil {
+		// Re-render the parsed body back to XML. Lossy on case
+		// (children are case-folded), but preserves structure + values.
+		var sb strings.Builder
+		for _, c := range data.Children {
+			writeElement(&sb, c)
+		}
+		d.Data = sb.String()
+	}
+	if el := e.Child("element"); el != nil {
+		d.Element = &DatastoreElement{
+			Attribute:  el.Attr("attribute"),
+			Path:       el.Attr("path"),
+			Value:      el.Attr("value"),
+			Available:  parseBoolAttr(el.Attr("available")),
+			ChildCount: el.Attr("child_count"),
+		}
+	}
+	// Bare terminator: a TYPE-less, child-less element carrying only MTID.
+	if d.Type == "" && len(e.Children) == 0 && d.MTID != "" {
+		d.Terminator = true
+	}
+	return d
 }

--- a/internal/cerebrum-nb/codec/element.go
+++ b/internal/cerebrum-nb/codec/element.go
@@ -79,9 +79,19 @@ func ParseElement(data []byte) (*Element, error) {
 	return parseRoot(dec)
 }
 
+// nextToken is a test seam over (*xml.Decoder).Token used only by
+// parseRoot. The non-EOF error arm of parseRoot's pre-root loop cannot
+// be provoked through ParseElement's public surface: any byte stream
+// that makes the tokenizer fail before the first StartElement fails
+// with io.EOF (empty / whitespace) or is surfaced later from inside
+// parseElement, not here. Tests override this var to inject a non-EOF
+// error and exercise that guard. Production behaviour is the default.
+// (Mirrors the tcpSetKeepAlive* seam in internal/probel-sw02p/codec.)
+var nextToken = func(dec *xml.Decoder) (xml.Token, error) { return dec.Token() }
+
 func parseRoot(dec *xml.Decoder) (*Element, error) {
 	for {
-		tok, err := dec.Token()
+		tok, err := nextToken(dec)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				return nil, errors.New("cerebrum-nb: empty XML")

--- a/internal/cerebrum-nb/codec/encode.go
+++ b/internal/cerebrum-nb/codec/encode.go
@@ -54,6 +54,30 @@ func emitElement(b *strings.Builder, name string, attrs []Attr, body func()) {
 	b.WriteByte('>')
 }
 
+// emitRawChild writes <name attrs>inner</name>, where inner is already
+// well-formed XML and is copied verbatim (NOT escaped). Used for the
+// §4.5 <PROTOCOL_SPECIFIC> / <PANEL_CONFIG> wrappers whose content is
+// protocol-dependent and undocumented (0v16 p20-21) — the codec must
+// not invent a schema, so callers supply raw inner XML. An empty inner
+// still emits the open/close pair (<name></name>), matching the spec's
+// <PANEL_CONFIG></PANEL_CONFIG> example.
+func emitRawChild(b *strings.Builder, name string, attrs []Attr, inner string) {
+	b.WriteByte('<')
+	b.WriteString(name)
+	for _, a := range attrs {
+		b.WriteByte(' ')
+		b.WriteString(a.Key)
+		b.WriteString(`="`)
+		xmlEscapeAttr(b, a.Value)
+		b.WriteByte('"')
+	}
+	b.WriteByte('>')
+	b.WriteString(inner)
+	b.WriteString("</")
+	b.WriteString(name)
+	b.WriteByte('>')
+}
+
 func formatMTID(mtid uint32) string {
 	return strconv.FormatUint(uint64(mtid), 10)
 }

--- a/internal/cerebrum-nb/codec/events.go
+++ b/internal/cerebrum-nb/codec/events.go
@@ -52,6 +52,62 @@ type RoutingChange struct {
 	RouteSourceID      string
 	RouteSourceLevelID string
 	RouteAvailable     bool
+
+	// Lock populates on RX for TYPE=SRCE_LOCK / DEST_LOCK (§5.1.2/§5.1.3
+	// p24). SRCE_LOCK carries the detail in a <VALUE …/> child;
+	// DEST_LOCK carries it in a <LOCK …/> child — the decoder accepts
+	// both element names. The 0v16 LOCK_STATE enum is the §3.2 five-value
+	// set (UNLOCKED / LOCKED / PROTECTED / LOCKED_PATH / PROTECTED_PATH).
+	Lock *RoutingLock
+
+	// OriginalMne / Associations / RMDefaultDevice populate on RX for
+	// the mnemonic rows (§5.1.4-§5.1.6 pp25-26). OriginalMne is the
+	// device's un-overridden mnemonic from the <MNE ORIGINAL_MNE=…/>
+	// child. RMDefaultDevice is present only on LEVEL_MNE for Routemaster
+	// levels. Associations carry per-level routing-master bindings.
+	OriginalMne     string
+	Associations    []RoutingAssociation
+	RMDefaultDevice *RMDefaultDevice
+
+	// Tags populates on RX for TYPE=RM_SRCE_TAGS / RM_DEST_TAGS
+	// (§5.1.7/§5.1.8 p27). The <TAGS LIST="Tag1|Tag2"/> child uses the
+	// pipe delimiter (§0.13 change-history p33), split into TagList.
+	TagsAvailable bool
+	TagList       []string
+}
+
+// RoutingLock is the lock detail of a SRCE_LOCK (<VALUE>) or DEST_LOCK
+// (<LOCK>) routing_change RX row (§5.1.2/§5.1.3 p24).
+type RoutingLock struct {
+	Available  bool
+	LockState  LockKind // §3.2 enum
+	LockedBy   string
+	UnlockTime string
+	UnlockDate string
+}
+
+// RoutingAssociation is one <ASSOCIATION_N …/> row of a mnemonic
+// routing_change RX (§5.1.5/§5.1.6 pp25-26). Index is the N suffix.
+// SRCE_ID is present on source-mnemonic rows, DEST_ID on destination
+// rows. The RM_* attributes are populated only for Routemaster sources.
+type RoutingAssociation struct {
+	Index        int
+	SrceID       string
+	DestID       string
+	RMDeviceName string
+	RMDeviceType DeviceType
+	RMLevelID    string
+	RMReversed   string
+	RMTags       string
+	RMIPUID      string
+}
+
+// RMDefaultDevice is the <RM_DEFAULT_DEVICE …/> child of a LEVEL_MNE
+// routing_change RX — present only for Routemaster levels (§5.1.4 p25).
+type RMDefaultDevice struct {
+	DeviceName string
+	DeviceType DeviceType
+	LevelID    string
 }
 
 func (r *RoutingChange) encodeSubItem(b *strings.Builder) {
@@ -115,6 +171,12 @@ type CategoryItem struct {
 	Index int
 	Type  string // "CATEGORY" | "SOURCE" | "DESTINATION" | "BLANK"
 	Value string
+
+	// Group is the optional GROUP attribute some item types carry
+	// (§5.2.2 p28 note: "Items may also contain a GROUP attribute for
+	// category types requiring group information" — e.g. SALVO items,
+	// per the §3.3 ITEM_TYPE table). Empty when absent.
+	Group string
 }
 
 func (c *CategoryChange) encodeSubItem(b *strings.Builder) {
@@ -151,10 +213,15 @@ type SalvoChange struct {
 	InstanceDetails *SalvoInstanceDetails
 }
 
-// SalvoInstanceDetails is the <details> child of a SALVO_CHANGE
-// TYPE=INSTANCE_DETAILS response.
+// SalvoInstanceDetails is the <DETAILS> child of a SALVO_CHANGE
+// TYPE=INSTANCE_DETAILS response (§5.3.3 p28). 0v16 enriches it with
+// DESCRIPTION / ACTIVE / DATE / TIME alongside AVAILABLE.
 type SalvoInstanceDetails struct {
-	Available bool
+	Available   bool
+	Description string
+	Active      bool
+	Date        string // e.g. "02/07/2017"
+	Time        string // e.g. "17:33:22:12"
 }
 
 func (s *SalvoChange) encodeSubItem(b *strings.Builder) {
@@ -199,14 +266,31 @@ type DeviceChange struct {
 	// false the server reports the object as unknown / unsupported;
 	// Value carries the live reading otherwise (verified shape on
 	// 2026-04-27 against a real Cerebrum returning available="0").
+	// For a single scalar object this is the first/only OBJECT_VALUE;
+	// ObjectValues carries every OBJECT_VALUE the server emitted.
 	ObjectValue *DeviceObjectValue
+
+	// ObjectValues holds all <OBJECT_VALUE …/> children of a TYPE=VALUE
+	// response. A scalar yields one entry; a group / table path (or a
+	// wildcard table path such as Devices.[*]) yields several (§5.4.3
+	// p29). ObjectValue == ObjectValues[0] when present.
+	ObjectValues []DeviceObjectValue
 }
 
-// DeviceObjectValue is the <object_value> child of a DEVICE_CHANGE
-// TYPE=VALUE response.
+// DeviceObjectValue is one <OBJECT_VALUE …/> child of a DEVICE_CHANGE
+// TYPE=VALUE response (§5.4.3 p29). 0v13 captured only Available +
+// Object; 0v16 carries the full descriptor.
 type DeviceObjectValue struct {
-	Available bool
 	Object    string
+	Value     string
+	Available bool
+	DataType  string // INTEGER / STRING / …
+	Readable  bool
+	Writable  bool
+	Units     string
+	Label     string
+	Default   string
+	EnumList  []string // ENUM_LIST="On,Off" split on comma
 }
 
 // DeviceEntry is one row of a TYPE=LIST DEVICE_CHANGE response (or one
@@ -266,16 +350,68 @@ func (d *DeviceChange) encodeSubItem(b *strings.Builder) {
 // §5.5 — Datastore events / subscribes
 // ----------------------------------------------------------------------
 
-// DatastoreChange covers §5.5: subscription/obtain by file path inside
-// a Cerebrum data store. RX replies echo this element with a TYPE
-// attribute (e.g. ATTRIBUTE).
+// DatastoreChange covers §5.5: subscription / obtain of a Cerebrum data
+// store by relative path, plus the two RX shapes (the obtain reply with
+// a <DATA> body, and the async change event with an <ELEMENT> body).
+//
+// PATH vs NAME ambiguity (§5.5.1 p30): the worked TX example uses
+// PATH="…", but the attribute table immediately below names the field
+// NAME. They cannot both be literal. Following the audit decision we
+// EMIT PATH (matching the only concrete example) and ACCEPT BOTH on
+// decode. See the report's flagged ambiguity.
 type DatastoreChange struct {
+	// Path is the relative store path. Used as the obtain/subscribe key
+	// (TX) and echoed on the change event (RX, in the NAME attribute).
+	Path string
+
+	// Name is a deprecated alias for Path, kept so 0v13-era callers that
+	// read DatastoreChange.Name keep compiling. The decoder mirrors Path
+	// into it. New code should use Path.
+	//
+	// Deprecated: use Path.
 	Name string
-	Type string // populated on RX, ignored on TX
+
+	// MTID, when non-empty on TX, is emitted as the optional §5.5.1
+	// MTID attribute so the bare terminator reply can be correlated.
+	MTID string
+
+	// Type populates on RX. Obtain reply: "FILE". Change event:
+	// "ATTRIBUTE" | "ELEMENT" | "FILE" (§5.5.2 p31).
+	Type string
+
+	// Available populates on the obtain reply (§5.5.1 p30) — whether the
+	// store file was read successfully.
+	Available bool
+
+	// Data is the raw inner XML of the <DATA>…</DATA> body of an obtain
+	// reply (§5.5.1 p30). Empty for the bare terminator and for change
+	// events.
+	Data string
+
+	// Terminator is true for the bare <DATASTORE_CHANGE MTID="…"/> that
+	// follows the <DATA> reply (§5.5.1 p30) — no TYPE, no body.
+	Terminator bool
+
+	// Element populates on a change event (§5.5.2 p31) from the single
+	// <ELEMENT …/> child.
+	Element *DatastoreElement
 }
 
+// DatastoreElement is the <ELEMENT …/> child of a §5.5.2 datastore
+// change event (p31).
+type DatastoreElement struct {
+	Attribute  string
+	Path       string
+	Value      string
+	Available  bool
+	ChildCount string
+}
+
+// encodeSubItem emits the §5.5.1 obtain/subscribe form. Per the
+// PATH/NAME resolution above we emit PATH (and optional MTID).
 func (d *DatastoreChange) encodeSubItem(b *strings.Builder) {
 	a := AttrsBuilder{}.
-		Add("NAME", d.Name)
+		Add("PATH", d.Path).
+		Add("MTID", d.MTID)
 	emitElement(b, "DATASTORE_CHANGE", a, nil)
 }


### PR DESCRIPTION
Brings the cerebrum-nb codec from the 0v13 baseline to the full EVS Cerebrum Northbound API 0v16 surface (pure superset; all 0v13 tests still pass). Codec coverage 100% + CI floor. All expected XML from the 0v16 PDF worked examples (page cites inline). Adds: the new device commands DEVICE_CONFIGURATION ADD/MODIFY/REMOVE (sec 4.5) for Generic/Panel/Router/SNMP + KindDeviceConfigResult; control frames CONTINUE + WILDCARD_COMPLETE; DATASTORES in LOGIN_REPLY; 5-value LOCK enum; enriched event decoders (lock-state, mnemonic ASSOCIATIONS/RM_*, rich OBJECT_VALUE, salvo details, category GROUP); data-store DATA body + pipe-delimited tags. Stdlib-only; compliance-on-deviation preserved. NOTE: data-store obtain PATH-vs-NAME is ambiguous in the PDF (example=PATH, table=NAME) - decoder accepts both; confirm against a live capture before locking the encoder. Codec phase only; consumer + write CLI verbs + fixtures + wireshark + docs(0v16) + live integration (NB-licence-gated) follow. Co-Authored-By Claude Opus 4.8.