### PR TITLE
feat(cerebrum-nb): 0v16 consumer + write CLI verbs; ws+consumer 100%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,8 @@ jobs:
           check ./internal/osc/consumer 100
           check ./internal/osc/provider 100
           check ./internal/cerebrum-nb/codec 100
+          check ./internal/cerebrum-nb/codec/ws 100
+          check ./internal/cerebrum-nb/consumer 100
 
       - name: Upload coverage
         if: matrix.os == 'ubuntu-latest'

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -133,6 +133,24 @@ func runCerebrum(ctx context.Context, args []string) error {
 		return cerebrumKeepaliveProbe(ctx, rest)
 	case "route":
 		return cerebrumRoute(ctx, rest)
+	case "lock":
+		return cerebrumLock(ctx, rest, codec.LockProtect)
+	case "unlock":
+		return cerebrumLock(ctx, rest, codec.LockRelease)
+	case "device-config":
+		return cerebrumDeviceConfig(ctx, rest)
+	case "set-mnemonic":
+		return cerebrumSetMnemonic(ctx, rest)
+	case "set-tags":
+		return cerebrumSetTags(ctx, rest)
+	case "salvo":
+		return cerebrumSalvo(ctx, rest)
+	case "category":
+		return cerebrumCategory(ctx, rest)
+	case "set-value":
+		return cerebrumSetValue(ctx, rest)
+	case "obtain-datastore":
+		return cerebrumObtainDatastore(ctx, rest)
 	}
 	return fmt.Errorf("cerebrum-nb: unknown verb %q (run dhs consumer cerebrum-nb -h for the catalogue)", verb)
 }
@@ -159,6 +177,18 @@ VERBS
   list-salvo-instances     OBTAIN <salvo_change type='INSTANCE_LIST'/>      --group NAME
   salvo-instance-details   OBTAIN <salvo_change type='INSTANCE_DETAILS'/>   --group NAME --instance NAME
   keepalive-probe          DIAGNOSTIC — hold WS open, observe TCP keep-alives  [--idle DUR] [--send-login]
+
+  Write verbs (§4 ACTION — auto-LOGIN with --user/--pass; require an authenticated session)
+  -----------------------  -----------------------------------------------
+  lock                     ACTION <ROUTING LOCK='PROTECT'/>   --kind SRCE_LOCK|DEST_LOCK [--srce ID|--dest ID] --level ID [--duration S] [--mode locked|protected|locked_path|protected_path|unlocked]
+  unlock                   ACTION <ROUTING LOCK='RELEASE'/>   (same flags as lock)
+  device-config            <DEVICE_CONFIGURATION TYPE='ADD|MODIFY|REMOVE'/>  add|modify|remove --device-type generic|panel|router|snmp --ip IP [per-type flags]
+  set-mnemonic             ACTION <ROUTING TYPE='*_MNE'/>     --kind LEVEL_MNE|SRCE_MNE|DEST_MNE [--srce|--dest ID] --level ID --mnemonic TXT [--alt SLOT]
+  set-tags                 ACTION <ROUTING TYPE='RM_*_TAGS'/> --kind RM_SRCE_TAGS|RM_DEST_TAGS [--srce|--dest ID] --tags a,b,c
+  salvo                    ACTION <SALVO TYPE='…'/>           --op run|save|rename|delete --group G [--instance I] [--new-name N] [--description D]
+  category                 ACTION <CATEGORY TYPE='…'/>        --op create|modify|delete --category C [--index N] [--name N] [--label L] [--description D]
+  set-value                ACTION <DEVICE TYPE='SET_VALUE'/>  --device NAME --sub-device X --object Y --value V
+  obtain-datastore         OBTAIN <datastore_change name='…'/>  --name PATH
 
 FLAGS (order doesn't matter — flags can come before OR after the host)
   --port N                  WebSocket port (default 40007)
@@ -1199,4 +1229,599 @@ func cerebrumRoute(_ context.Context, args []string) error {
 		return fmt.Errorf("%d/%d routes failed", fails, len(routes))
 	}
 	return nil
+}
+
+// ----------------------------------------------------------------------
+// §4 write verbs — ACTION round-trips (ACK/NACK). These wrap the Session
+// action methods; each maps to a codec action encoder that exists today:
+//   lock / unlock / set-mnemonic / set-tags → codec.RoutingAction (§4.1)
+//   salvo                                    → codec.SalvoAction    (§4.3)
+//   category                                 → codec.CategoryAction (§4.2)
+//   set-value                                → codec.DeviceAction   (§4.4)
+//   obtain-datastore                         → codec.DatastoreChange (§5.5)
+//
+// All require an authenticated session (the server NACKs NOT_LOGGED_IN
+// otherwise), so they LOGIN after connect using --user/--pass (or
+// $DHS_CEREBRUM_USER / $DHS_CEREBRUM_PASS) before sending the action.
+// ----------------------------------------------------------------------
+
+// connectAndAuth is connectAndLogin plus an explicit LOGIN — write actions
+// are rejected with NOT_LOGGED_IN on an unauthenticated session.
+func connectAndAuth(args []string, verb string) (*cerebrum.Plugin, *cerebrum.Session, *cerebrumFlags, []string, error) {
+	p, sess, cf, rest, err := connectAndLogin(args, verb)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	if !sess.LoggedIn() {
+		loginCtx, cancel := context.WithTimeout(context.Background(), cf.timeout)
+		defer cancel()
+		if err := p.Login(loginCtx); err != nil {
+			_ = p.Disconnect()
+			return nil, nil, nil, nil, fmt.Errorf("cerebrum-nb %s: LOGIN required (set --user/--pass): %w", verb, err)
+		}
+	}
+	return p, sess, cf, rest, nil
+}
+
+// routeTargetFromFlags builds the router-addressing tuple. Defaults to the
+// route-master sentinel (0.0.0.0 / ROUTER) unless --router / --device-name
+// override it.
+func routeTargetFromFlags(router, deviceName string) cerebrum.RouteTarget {
+	t := cerebrum.DefaultRouteTarget()
+	if router != "" {
+		t.IPAddress = router
+	}
+	if deviceName != "" {
+		t.IPAddress = ""
+		t.DeviceName = deviceName
+	}
+	return t
+}
+
+func cerebrumLock(_ context.Context, args []string, mode codec.LockKind) error {
+	verb := "lock"
+	if mode == codec.LockRelease {
+		verb = "unlock"
+	}
+	args = reorderFlagsFirst(args)
+	fs := flag.NewFlagSet("cerebrum-nb "+verb, flag.ContinueOnError)
+	_ = newCerebrumFlags(fs)
+	kind := fs.String("kind", "DEST_LOCK", "lock kind: SRCE_LOCK | DEST_LOCK")
+	router := fs.String("router", "0.0.0.0", "router IP target (route-master sentinel 0.0.0.0)")
+	deviceName := fs.String("device-name", "", "address by DEVICE_NAME instead of --router")
+	srce := fs.String("srce", "", "source ID (SRCE_LOCK)")
+	dest := fs.String("dest", "", "destination ID (DEST_LOCK)")
+	level := fs.String("level", "", "level ID")
+	duration := fs.String("duration", "", "optional timed-lock duration")
+	// --mode (0v16 §3.2): override the default PROTECT/RELEASE verb with one
+	// of the five canonical LOCK_STATE values. Empty keeps the verb default.
+	modeFlag := fs.String("mode", "", "0v16 lock mode: locked | protected | locked_path | protected_path | unlocked (overrides the default "+verb+" verb)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := requireKind(*kind, verb, "SRCE_LOCK", "DEST_LOCK"); err != nil {
+		return err
+	}
+	if *modeFlag != "" {
+		m, err := lockModeValue(*modeFlag)
+		if err != nil {
+			return err
+		}
+		mode = m
+	}
+	if *srce == "" && *dest == "" {
+		return fmt.Errorf("cerebrum-nb %s: --srce or --dest is required", verb)
+	}
+	p, sess, cf2, _, err := connectAndAuth(fs.Args(), verb)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = p.Disconnect() }()
+	ctx, cancel := context.WithTimeout(context.Background(), cf2.timeout)
+	defer cancel()
+	if err := sess.Lock(ctx, *kind, mode, routeTargetFromFlags(*router, *deviceName), *srce, *dest, *level, *duration); err != nil {
+		return fmt.Errorf("cerebrum-nb %s: %w", verb, err)
+	}
+	fmt.Printf("[%s] OK %s mode=%s srce=%s dest=%s lvl=%s\n", verb, *kind, mode, displayDash(*srce), displayDash(*dest), displayDash(*level))
+	return nil
+}
+
+// lockModeValue maps a --mode string to one of the 0v16 §3.2 five-value
+// LOCK enum. Case-insensitive; rejects anything outside the canonical set so
+// the CLI never fabricates a wire value the codec doesn't define.
+func lockModeValue(mode string) (codec.LockKind, error) {
+	switch strings.ToLower(mode) {
+	case "unlocked":
+		return codec.LockUnlocked, nil
+	case "locked":
+		return codec.LockLocked, nil
+	case "protected":
+		return codec.LockProtected, nil
+	case "locked_path", "locked-path":
+		return codec.LockLockedPath, nil
+	case "protected_path", "protected-path":
+		return codec.LockProtectedPath, nil
+	default:
+		return "", fmt.Errorf("cerebrum-nb lock: unknown --mode %q (want unlocked|locked|protected|locked_path|protected_path)", mode)
+	}
+}
+
+func cerebrumSetMnemonic(_ context.Context, args []string) error {
+	args = reorderFlagsFirst(args)
+	fs := flag.NewFlagSet("cerebrum-nb set-mnemonic", flag.ContinueOnError)
+	_ = newCerebrumFlags(fs)
+	kind := fs.String("kind", "DEST_MNE", "mnemonic kind: LEVEL_MNE | SRCE_MNE | DEST_MNE")
+	router := fs.String("router", "0.0.0.0", "router IP target")
+	deviceName := fs.String("device-name", "", "address by DEVICE_NAME")
+	srce := fs.String("srce", "", "source ID")
+	dest := fs.String("dest", "", "destination ID")
+	level := fs.String("level", "", "level ID")
+	mnemonic := fs.String("mnemonic", "", "mnemonic text")
+	alt := fs.String("alt", "", "alternate mnemonic slot (ALT_MNE)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := requireKind(*kind, "set-mnemonic", "LEVEL_MNE", "SRCE_MNE", "DEST_MNE"); err != nil {
+		return err
+	}
+	if *mnemonic == "" {
+		return fmt.Errorf("cerebrum-nb set-mnemonic: --mnemonic is required")
+	}
+	p, sess, cf, _, err := connectAndAuth(fs.Args(), "set-mnemonic")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = p.Disconnect() }()
+	ctx, cancel := context.WithTimeout(context.Background(), cf.timeout)
+	defer cancel()
+	if err := sess.SetMnemonic(ctx, *kind, routeTargetFromFlags(*router, *deviceName), *srce, *dest, *level, *mnemonic, *alt); err != nil {
+		return fmt.Errorf("cerebrum-nb set-mnemonic: %w", err)
+	}
+	fmt.Printf("[set-mnemonic] OK %s mne=%q\n", *kind, *mnemonic)
+	return nil
+}
+
+func cerebrumSetTags(_ context.Context, args []string) error {
+	args = reorderFlagsFirst(args)
+	fs := flag.NewFlagSet("cerebrum-nb set-tags", flag.ContinueOnError)
+	_ = newCerebrumFlags(fs)
+	kind := fs.String("kind", "RM_DEST_TAGS", "tags kind: RM_SRCE_TAGS | RM_DEST_TAGS")
+	router := fs.String("router", "0.0.0.0", "router IP target")
+	deviceName := fs.String("device-name", "", "address by DEVICE_NAME")
+	srce := fs.String("srce", "", "source ID")
+	dest := fs.String("dest", "", "destination ID")
+	tags := fs.String("tags", "", "comma-separated tag list")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := requireKind(*kind, "set-tags", "RM_SRCE_TAGS", "RM_DEST_TAGS"); err != nil {
+		return err
+	}
+	if *tags == "" {
+		return fmt.Errorf("cerebrum-nb set-tags: --tags is required")
+	}
+	p, sess, cf, _, err := connectAndAuth(fs.Args(), "set-tags")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = p.Disconnect() }()
+	ctx, cancel := context.WithTimeout(context.Background(), cf.timeout)
+	defer cancel()
+	if err := sess.SetTags(ctx, *kind, routeTargetFromFlags(*router, *deviceName), *srce, *dest, *tags); err != nil {
+		return fmt.Errorf("cerebrum-nb set-tags: %w", err)
+	}
+	fmt.Printf("[set-tags] OK %s tags=%q\n", *kind, *tags)
+	return nil
+}
+
+func cerebrumSalvo(_ context.Context, args []string) error {
+	args = reorderFlagsFirst(args)
+	fs := flag.NewFlagSet("cerebrum-nb salvo", flag.ContinueOnError)
+	_ = newCerebrumFlags(fs)
+	op := fs.String("op", "", "operation: run | save | rename | delete")
+	group := fs.String("group", "", "salvo group")
+	instance := fs.String("instance", "", "salvo instance")
+	newName := fs.String("new-name", "", "new name (rename)")
+	desc := fs.String("description", "", "description (save)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	salvoType, err := salvoOpType(*op)
+	if err != nil {
+		return err
+	}
+	if *group == "" {
+		return fmt.Errorf("cerebrum-nb salvo: --group is required")
+	}
+	if salvoType == "RENAME" && *newName == "" {
+		return fmt.Errorf("cerebrum-nb salvo: --new-name is required for rename")
+	}
+	p, sess, cf, _, err := connectAndAuth(fs.Args(), "salvo")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = p.Disconnect() }()
+	ctx, cancel := context.WithTimeout(context.Background(), cf.timeout)
+	defer cancel()
+	if err := sess.Salvo(ctx, salvoType, *group, *instance, *newName, *desc); err != nil {
+		return fmt.Errorf("cerebrum-nb salvo: %w", err)
+	}
+	fmt.Printf("[salvo] OK %s group=%s instance=%s\n", salvoType, *group, displayDash(*instance))
+	return nil
+}
+
+func cerebrumCategory(_ context.Context, args []string) error {
+	args = reorderFlagsFirst(args)
+	fs := flag.NewFlagSet("cerebrum-nb category", flag.ContinueOnError)
+	_ = newCerebrumFlags(fs)
+	op := fs.String("op", "", "operation: create | modify | delete")
+	category := fs.String("category", "", "category name")
+	index := fs.String("index", "", "item index (modify)")
+	name := fs.String("name", "", "name (create)")
+	label := fs.String("label", "", "label")
+	desc := fs.String("description", "", "description")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	catType, err := categoryOpType(*op)
+	if err != nil {
+		return err
+	}
+	if *category == "" {
+		return fmt.Errorf("cerebrum-nb category: --category is required")
+	}
+	p, sess, cf, _, err := connectAndAuth(fs.Args(), "category")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = p.Disconnect() }()
+	ctx, cancel := context.WithTimeout(context.Background(), cf.timeout)
+	defer cancel()
+	act := &codec.CategoryAction{
+		Type:        catType,
+		Category:    *category,
+		Index:       *index,
+		Name:        *name,
+		Label:       *label,
+		Description: *desc,
+	}
+	if err := sess.Category(ctx, act); err != nil {
+		return fmt.Errorf("cerebrum-nb category: %w", err)
+	}
+	fmt.Printf("[category] OK %s category=%s\n", catType, *category)
+	return nil
+}
+
+func cerebrumSetValue(_ context.Context, args []string) error {
+	args = reorderFlagsFirst(args)
+	fs := flag.NewFlagSet("cerebrum-nb set-value", flag.ContinueOnError)
+	_ = newCerebrumFlags(fs)
+	device := fs.String("device", "", "device name (or use --ip)")
+	ip := fs.String("ip", "", "device IP address (alternative to --device, §4.4.1)")
+	subDevice := fs.String("sub-device", "", "sub-device")
+	object := fs.String("object", "", "object")
+	value := fs.String("value", "", "value to set")
+	isEnum := fs.Bool("is-enum", false, "VALUE is a string representation of an enumeration (§4.4.1 IS_ENUM)")
+	mode := fs.String("mode", "", "CSV write mode: SET|ADD_TAIL|INSERT_AT_HEAD|REMOVE (default SET)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if (*device == "" && *ip == "") || *subDevice == "" || *object == "" {
+		return fmt.Errorf("cerebrum-nb set-value: --device (or --ip), --sub-device and --object are required")
+	}
+	normMode, err := setValueModeValue(*mode)
+	if err != nil {
+		return err
+	}
+	p, sess, cf, _, err := connectAndAuth(fs.Args(), "set-value")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = p.Disconnect() }()
+	ctx, cancel := context.WithTimeout(context.Background(), cf.timeout)
+	defer cancel()
+	// Build the full §4.4 DEVICE SET_VALUE (incl. 0v16 IP_ADDRESS / IS_ENUM /
+	// MODE) and send it via the generic Action path.
+	body := &codec.DeviceAction{
+		Type:       "SET_VALUE",
+		DeviceName: *device,
+		IPAddress:  *ip,
+		SubDevice:  *subDevice,
+		Object:     *object,
+		Value:      *value,
+		IsEnum:     *isEnum,
+		Mode:       normMode,
+	}
+	if err := sess.Action(ctx, body); err != nil {
+		return fmt.Errorf("cerebrum-nb set-value: %w", err)
+	}
+	target := *device
+	if target == "" {
+		target = *ip
+	}
+	fmt.Printf("[set-value] OK %s.%s.%s = %q\n", target, *subDevice, *object, *value)
+	return nil
+}
+
+// setValueModeValue validates/normalises the set-value --mode flag to the
+// §4.4.1 CSV MODE enum. Empty = default (SET) and is omitted on the wire.
+func setValueModeValue(mode string) (string, error) {
+	switch strings.ToUpper(strings.TrimSpace(mode)) {
+	case "":
+		return "", nil
+	case "SET":
+		return "SET", nil
+	case "ADD_TAIL":
+		return "ADD_TAIL", nil
+	case "INSERT_AT_HEAD":
+		return "INSERT_AT_HEAD", nil
+	case "REMOVE":
+		return "REMOVE", nil
+	default:
+		return "", fmt.Errorf("cerebrum-nb set-value: unknown --mode %q (want SET|ADD_TAIL|INSERT_AT_HEAD|REMOVE)", mode)
+	}
+}
+
+func cerebrumObtainDatastore(_ context.Context, args []string) error {
+	args = reorderFlagsFirst(args)
+	fs := flag.NewFlagSet("cerebrum-nb obtain-datastore", flag.ContinueOnError)
+	_ = newCerebrumFlags(fs)
+	name := fs.String("name", "", "datastore path/name")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *name == "" {
+		return fmt.Errorf("cerebrum-nb obtain-datastore: --name is required")
+	}
+	p, sess, cf, _, err := connectAndLogin(fs.Args(), "obtain-datastore")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = p.Disconnect() }()
+
+	var got *codec.Frame
+	done := make(chan struct{})
+	var once sync.Once
+	signal := func() { once.Do(func() { close(done) }) }
+	timer := time.AfterFunc(cf.timeout, signal)
+	defer timer.Stop()
+	sess.OnEvent(codec.KindDatastoreChange, func(f *codec.Frame) {
+		got = f
+		signal()
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), cf.timeout)
+	defer cancel()
+	if err := sess.ObtainDatastore(ctx, *name); err != nil {
+		return fmt.Errorf("cerebrum-nb obtain-datastore: %w", err)
+	}
+	<-done
+	if got == nil || got.Datastore == nil {
+		fmt.Fprintln(os.Stderr, "(no DATASTORE_CHANGE response within timeout)")
+		return nil
+	}
+	ds := got.Datastore
+	fmt.Printf("name       %s\n", ds.Name)
+	fmt.Printf("type       %s\n", displayDash(ds.Type))
+	fmt.Printf("available  %s\n", boolFlag(ds.Available))
+	// 0v16 §5.5.1: the obtain reply carries the store body in <DATA>…</DATA>.
+	// Surface the raw inner XML so operators see the store contents directly.
+	if ds.Data != "" {
+		fmt.Printf("data       %d bytes\n", len(ds.Data))
+		fmt.Println(ds.Data)
+	} else {
+		fmt.Println("data       (none)")
+	}
+	return nil
+}
+
+// cerebrumDeviceConfig issues a 0v16 §4.5 DEVICE_CONFIGURATION command
+// (ADD / MODIFY / REMOVE) for one of the four device types (GENERIC / PANEL
+// / ROUTER / SNMP), mapping per-type flags to the codec config structs, and
+// prints the <RESULT VALUE="ACCEPTED|FAILED"/> verdict. Requires an
+// authenticated session.
+func cerebrumDeviceConfig(_ context.Context, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("cerebrum-nb device-config: missing operation (add|modify|remove)")
+	}
+	op := args[0]
+	cfgType, err := deviceConfigOpType(op)
+	if err != nil {
+		return err
+	}
+	rest := reorderFlagsFirst(args[1:])
+	fs := flag.NewFlagSet("cerebrum-nb device-config "+op, flag.ContinueOnError)
+	_ = newCerebrumFlags(fs)
+	deviceType := fs.String("device-type", "", "device type: generic | panel | router | snmp")
+	ip := fs.String("ip", "", "device IP_ADDRESS (required; the addressing key)")
+	dname := fs.String("device-name", "", "DEVICE_NAME (optional on add; with --ip identifies the device on modify)")
+
+	// shared GENERIC / PANEL body
+	device := fs.String("device", "", "DEVICE (driver/model identifier)")
+	version := fs.String("version", "", "VERSION")
+	name := fs.String("name", "", "NAME (display name; also the SNMP NAME)")
+	connType := fs.String("conn-type", "", "PROTOCOL connection type: ASYNC_HTTP | UDP | TCP | WEBSOCKET_SERVER")
+	port := fs.String("port-number", "", "PROTOCOL PORT_NUMBER (generic/panel/snmp body port)")
+	timeout := fs.String("timeout-ms", "", "PROTOCOL TIMEOUT (ms)")
+	poll := fs.String("poll", "", "PROTOCOL POLL_PERIOD (ms)")
+	// PANEL extras
+	cpf := fs.String("cpf", "", "PANEL CPF")
+	panelID := fs.String("panel-id", "", "PANEL PANEL_ID")
+	panelType := fs.String("panel-type", "", "PANEL PANEL_TYPE")
+	// ROUTER body
+	rtype := fs.String("router-type", "", "ROUTER numeric routing-device TYPE id")
+	baud := fs.String("baud", "", "ROUTER SERIAL BAUD")
+	parity := fs.String("parity", "", "ROUTER SERIAL PARITY")
+	maxLevel := fs.String("max-level", "", "ROUTER MAX_LEVEL")
+	maxSource := fs.String("max-source", "", "ROUTER MAX_SOURCE")
+	maxDest := fs.String("max-dest", "", "ROUTER MAX_DEST")
+	// SNMP body
+	snmpPort := fs.String("snmp-port", "", "SNMP PORT")
+
+	if err := fs.Parse(rest); err != nil {
+		return err
+	}
+	if *ip == "" {
+		return fmt.Errorf("cerebrum-nb device-config: --ip is required")
+	}
+	dc := &codec.DeviceConfiguration{
+		Type:       cfgType,
+		IPAddress:  *ip,
+		DeviceName: *dname,
+	}
+	if cfgType != codec.DeviceConfigRemove {
+		dt, buildErr := buildDeviceConfigBody(dc, *deviceType, deviceConfigBodyFlags{
+			device: *device, version: *version, name: *name,
+			connType: *connType, port: *port, timeout: *timeout, poll: *poll,
+			cpf: *cpf, panelID: *panelID, panelType: *panelType,
+			routerType: *rtype, baud: *baud, parity: *parity,
+			maxLevel: *maxLevel, maxSource: *maxSource, maxDest: *maxDest,
+			snmpPort: *snmpPort, snmpName: *name,
+		})
+		if buildErr != nil {
+			return buildErr
+		}
+		dc.DeviceType = dt
+	}
+
+	p, sess, cf, _, err := connectAndAuth(fs.Args(), "device-config")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = p.Disconnect() }()
+	ctx, cancel := context.WithTimeout(context.Background(), cf.timeout)
+	defer cancel()
+	res, err := sess.DeviceConfig(ctx, dc)
+	if err != nil {
+		return fmt.Errorf("cerebrum-nb device-config: %w", err)
+	}
+	fmt.Printf("[device-config] %s %s ip=%s result=%s\n", cfgType, dc.DeviceType, dc.IPAddress, displayDash(res.Value))
+	if !res.Accepted {
+		return fmt.Errorf("cerebrum-nb device-config: server returned %s", displayDash(res.Value))
+	}
+	return nil
+}
+
+// deviceConfigBodyFlags carries the flattened per-type body flags so
+// buildDeviceConfigBody can map them onto the right codec struct.
+type deviceConfigBodyFlags struct {
+	device, version, name             string
+	connType, port, timeout, poll     string
+	cpf, panelID, panelType           string
+	routerType, baud, parity          string
+	maxLevel, maxSource, maxDest      string
+	snmpPort, snmpName                string
+}
+
+// buildDeviceConfigBody attaches the body struct chosen by deviceType to dc
+// and returns the §4.5 ConfigDeviceType selector. Only the flags relevant to
+// the chosen type are consumed.
+func buildDeviceConfigBody(dc *codec.DeviceConfiguration, deviceType string, f deviceConfigBodyFlags) (codec.ConfigDeviceType, error) {
+	protocol := func() *codec.ProtocolConfiguration {
+		if f.connType == "" && f.port == "" && f.timeout == "" && f.poll == "" {
+			return nil
+		}
+		return &codec.ProtocolConfiguration{
+			ConnectionType: codec.ConnectionType(f.connType),
+			PortNumber:     f.port,
+			Timeout:        f.timeout,
+			PollPeriod:     f.poll,
+		}
+	}
+	switch strings.ToLower(deviceType) {
+	case "generic":
+		dc.Generic = &codec.GenericConfig{
+			Device: f.device, Version: f.version, Name: f.name,
+			Protocol: protocol(),
+		}
+		return codec.ConfigDeviceGeneric, nil
+	case "panel":
+		dc.Panel = &codec.PanelConfig{
+			Device: f.device, Version: f.version, Name: f.name,
+			Protocol:  protocol(),
+			CPF:       f.cpf,
+			PanelID:   f.panelID,
+			PanelType: f.panelType,
+		}
+		return codec.ConfigDevicePanel, nil
+	case "router":
+		rc := &codec.RouterConfig{
+			Device: f.device, Name: f.name, Type: f.routerType,
+		}
+		if f.baud != "" || f.parity != "" {
+			rc.Serial = &codec.SerialConfig{Baud: f.baud, Parity: f.parity}
+		}
+		if f.maxLevel != "" || f.maxSource != "" || f.maxDest != "" {
+			rc.Router = &codec.RouterParams{
+				MaxLevel: f.maxLevel, MaxSource: f.maxSource, MaxDest: f.maxDest,
+			}
+		}
+		dc.Router = rc
+		return codec.ConfigDeviceRouter, nil
+	case "snmp":
+		dc.SNMP = &codec.SNMPConfig{Name: f.snmpName, Port: f.snmpPort}
+		return codec.ConfigDeviceSNMP, nil
+	case "":
+		return "", fmt.Errorf("cerebrum-nb device-config: --device-type is required (generic|panel|router|snmp)")
+	default:
+		return "", fmt.Errorf("cerebrum-nb device-config: unknown --device-type %q (want generic|panel|router|snmp)", deviceType)
+	}
+}
+
+// deviceConfigOpType maps add|modify|remove to the §4.5 DEVICE_CONFIGURATION
+// TYPE verb.
+func deviceConfigOpType(op string) (codec.DeviceConfigType, error) {
+	switch strings.ToLower(op) {
+	case "add":
+		return codec.DeviceConfigAdd, nil
+	case "modify":
+		return codec.DeviceConfigModify, nil
+	case "remove":
+		return codec.DeviceConfigRemove, nil
+	default:
+		return "", fmt.Errorf("cerebrum-nb device-config: unknown operation %q (want add|modify|remove)", op)
+	}
+}
+
+// requireKind validates that kind is one of the allowed values.
+func requireKind(kind, verb string, allowed ...string) error {
+	for _, a := range allowed {
+		if strings.EqualFold(kind, a) {
+			return nil
+		}
+	}
+	return fmt.Errorf("cerebrum-nb %s: unknown --kind %q (want one of %s)", verb, kind, strings.Join(allowed, " | "))
+}
+
+// salvoOpType maps the --op string to a §4.3 SALVO TYPE.
+func salvoOpType(op string) (string, error) {
+	switch strings.ToLower(op) {
+	case "run":
+		return "RUN", nil
+	case "save":
+		return "SAVE", nil
+	case "rename":
+		return "RENAME", nil
+	case "delete":
+		return "DELETE", nil
+	case "":
+		return "", fmt.Errorf("cerebrum-nb salvo: --op is required (run|save|rename|delete)")
+	default:
+		return "", fmt.Errorf("cerebrum-nb salvo: unknown --op %q (want run|save|rename|delete)", op)
+	}
+}
+
+// categoryOpType maps the --op string to a §4.2 CATEGORY TYPE.
+func categoryOpType(op string) (string, error) {
+	switch strings.ToLower(op) {
+	case "create":
+		return "CREATE", nil
+	case "modify":
+		return "MODIFY_ITEM", nil
+	case "delete":
+		return "DELETE", nil
+	case "":
+		return "", fmt.Errorf("cerebrum-nb category: --op is required (create|modify|delete)")
+	default:
+		return "", fmt.Errorf("cerebrum-nb category: unknown --op %q (want create|modify|delete)", op)
+	}
 }

--- a/cmd/dhs/cmd_cerebrum_test.go
+++ b/cmd/dhs/cmd_cerebrum_test.go
@@ -1,0 +1,309 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"dhs/internal/cerebrum-nb/codec"
+)
+
+// These are flag-validation / dispatch smoke tests for the cerebrum-nb CLI.
+// They never touch the network: every assertion is on an error that fires
+// at parse/validation time, before connectAndLogin dials. There is no live
+// Cerebrum peer and no vendor emulator in this environment, so the wire
+// behaviour of these verbs is covered by the consumer package's fake-WS
+// tests, not here.
+
+func TestCerebrumUnknownVerb(t *testing.T) {
+	err := runCerebrum(context.Background(), []string{"bogus-verb"})
+	if err == nil || !strings.Contains(err.Error(), "unknown verb") {
+		t.Fatalf("want unknown verb error, got %v", err)
+	}
+}
+
+func TestCerebrumHelpNoArgs(t *testing.T) {
+	if err := runCerebrum(context.Background(), nil); err != nil {
+		t.Fatalf("help (no args) returned error: %v", err)
+	}
+	if err := runCerebrum(context.Background(), []string{"-h"}); err != nil {
+		t.Fatalf("help (-h) returned error: %v", err)
+	}
+}
+
+// TestCerebrumWriteVerbsValidateFlags pins the pre-dial flag validation for
+// every new §4 write verb. Each case must error before any network I/O.
+func TestCerebrumWriteVerbsValidateFlags(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		// lock / unlock: bad --kind, then missing srce/dest.
+		{"lock-bad-kind", []string{"lock", "h", "--kind", "WAT", "--dest", "1"}, "unknown --kind"},
+		{"lock-no-addr", []string{"lock", "h", "--kind", "DEST_LOCK"}, "--srce or --dest is required"},
+		{"unlock-bad-kind", []string{"unlock", "h", "--kind", "WAT"}, "unknown --kind"},
+		// set-mnemonic: bad kind + missing mnemonic.
+		{"mne-bad-kind", []string{"set-mnemonic", "h", "--kind", "WAT", "--mnemonic", "X"}, "unknown --kind"},
+		{"mne-no-text", []string{"set-mnemonic", "h", "--kind", "DEST_MNE"}, "--mnemonic is required"},
+		// set-tags: bad kind + missing tags.
+		{"tags-bad-kind", []string{"set-tags", "h", "--kind", "WAT", "--tags", "a"}, "unknown --kind"},
+		{"tags-no-tags", []string{"set-tags", "h", "--kind", "RM_DEST_TAGS"}, "--tags is required"},
+		// salvo: missing/unknown op, missing group, rename without new-name.
+		{"salvo-no-op", []string{"salvo", "h", "--group", "G"}, "--op is required"},
+		{"salvo-bad-op", []string{"salvo", "h", "--op", "frob", "--group", "G"}, "unknown --op"},
+		{"salvo-no-group", []string{"salvo", "h", "--op", "run"}, "--group is required"},
+		{"salvo-rename-no-name", []string{"salvo", "h", "--op", "rename", "--group", "G"}, "--new-name is required"},
+		// category: missing/unknown op, missing category.
+		{"cat-no-op", []string{"category", "h", "--category", "C"}, "--op is required"},
+		{"cat-bad-op", []string{"category", "h", "--op", "frob", "--category", "C"}, "unknown --op"},
+		{"cat-no-category", []string{"category", "h", "--op", "create"}, "--category is required"},
+		// set-value: missing required addressing.
+		{"setval-missing", []string{"set-value", "h", "--device", "D"}, "are required"},
+		// obtain-datastore: missing --name.
+		{"ds-no-name", []string{"obtain-datastore", "h"}, "--name is required"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := runCerebrum(context.Background(), c.args)
+			if err == nil {
+				t.Fatalf("args %v returned nil, want %q", c.args, c.want)
+			}
+			if !strings.Contains(err.Error(), c.want) {
+				t.Errorf("args %v error = %q, want substring %q", c.args, err.Error(), c.want)
+			}
+		})
+	}
+}
+
+// TestCerebrumWriteVerbsRequireHost: with valid flags but no host argument,
+// the verb must fail with "missing host" before dialing.
+func TestCerebrumWriteVerbsRequireHost(t *testing.T) {
+	cases := [][]string{
+		{"lock", "--kind", "DEST_LOCK", "--dest", "1", "--level", "1"},
+		{"unlock", "--kind", "DEST_LOCK", "--dest", "1", "--level", "1"},
+		{"set-mnemonic", "--kind", "DEST_MNE", "--dest", "1", "--mnemonic", "X"},
+		{"set-tags", "--kind", "RM_DEST_TAGS", "--dest", "1", "--tags", "a"},
+		{"salvo", "--op", "run", "--group", "G"},
+		{"category", "--op", "create", "--category", "C"},
+		{"set-value", "--device", "D", "--sub-device", "S", "--object", "O", "--value", "V"},
+		{"obtain-datastore", "--name", "p"},
+	}
+	for _, args := range cases {
+		t.Run(args[0], func(t *testing.T) {
+			err := runCerebrum(context.Background(), args)
+			if err == nil || !strings.Contains(err.Error(), "missing host") {
+				t.Fatalf("verb %q: want missing-host error, got %v", args[0], err)
+			}
+		})
+	}
+}
+
+// TestSalvoOpType / TestCategoryOpType pin the op -> wire TYPE maps.
+func TestSalvoOpType(t *testing.T) {
+	cases := map[string]string{"run": "RUN", "save": "SAVE", "rename": "RENAME", "delete": "DELETE"}
+	for in, want := range cases {
+		got, err := salvoOpType(in)
+		if err != nil || got != want {
+			t.Errorf("salvoOpType(%q) = %q,%v want %q", in, got, err, want)
+		}
+	}
+	if _, err := salvoOpType("nope"); err == nil {
+		t.Error("salvoOpType(nope) should error")
+	}
+}
+
+func TestCategoryOpType(t *testing.T) {
+	cases := map[string]string{"create": "CREATE", "modify": "MODIFY_ITEM", "delete": "DELETE"}
+	for in, want := range cases {
+		got, err := categoryOpType(in)
+		if err != nil || got != want {
+			t.Errorf("categoryOpType(%q) = %q,%v want %q", in, got, err, want)
+		}
+	}
+	if _, err := categoryOpType("nope"); err == nil {
+		t.Error("categoryOpType(nope) should error")
+	}
+}
+
+func TestRequireKind(t *testing.T) {
+	if err := requireKind("dest_lock", "lock", "SRCE_LOCK", "DEST_LOCK"); err != nil {
+		t.Fatalf("case-insensitive match failed: %v", err)
+	}
+	if err := requireKind("bogus", "lock", "SRCE_LOCK"); err == nil {
+		t.Fatal("requireKind(bogus) should error")
+	}
+}
+
+// TestCerebrumDeviceConfigValidateFlags pins the pre-dial validation for the
+// 0v16 device-config verb. Each case must error before any network I/O.
+func TestCerebrumDeviceConfigValidateFlags(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"no-op", []string{"device-config"}, "missing operation"},
+		{"bad-op", []string{"device-config", "frob", "--ip", "1.2.3.4"}, "unknown operation"},
+		{"add-no-ip", []string{"device-config", "add", "--device-type", "snmp", "h"}, "--ip is required"},
+		{"add-no-device-type", []string{"device-config", "add", "--ip", "1.2.3.4", "h"}, "--device-type is required"},
+		{"add-bad-device-type", []string{"device-config", "add", "--ip", "1.2.3.4", "--device-type", "frob", "h"}, "unknown --device-type"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := runCerebrum(context.Background(), c.args)
+			if err == nil || !strings.Contains(err.Error(), c.want) {
+				t.Fatalf("args %v error = %v, want substring %q", c.args, err, c.want)
+			}
+		})
+	}
+}
+
+// TestCerebrumDeviceConfigRequireHost: valid flags but no host → missing-host
+// error (REMOVE skips the body, so this also covers the no-body path).
+func TestCerebrumDeviceConfigRequireHost(t *testing.T) {
+	cases := [][]string{
+		{"device-config", "add", "--ip", "1.2.3.4", "--device-type", "generic", "--conn-type", "TCP", "--port-number", "9000", "--name", "G1"},
+		{"device-config", "add", "--ip", "1.2.3.4", "--device-type", "panel", "--cpf", "x", "--panel-type", "T"},
+		{"device-config", "add", "--ip", "1.2.3.4", "--device-type", "router", "--baud", "9600", "--max-level", "4"},
+		{"device-config", "add", "--ip", "1.2.3.4", "--device-type", "snmp", "--name", "S1", "--snmp-port", "161"},
+		{"device-config", "remove", "--ip", "1.2.3.4"},
+	}
+	for _, args := range cases {
+		t.Run(args[2], func(t *testing.T) {
+			err := runCerebrum(context.Background(), args)
+			if err == nil || !strings.Contains(err.Error(), "missing host") {
+				t.Fatalf("args %v: want missing-host, got %v", args, err)
+			}
+		})
+	}
+}
+
+// TestLockModeFlagRejectsBad: an unknown --mode on lock errors before dial.
+func TestLockModeFlagRejectsBad(t *testing.T) {
+	err := runCerebrum(context.Background(), []string{"lock", "h", "--kind", "DEST_LOCK", "--dest", "1", "--mode", "frob"})
+	if err == nil || !strings.Contains(err.Error(), "unknown --mode") {
+		t.Fatalf("want unknown --mode error, got %v", err)
+	}
+}
+
+func TestLockModeValue(t *testing.T) {
+	cases := map[string]codec.LockKind{
+		"unlocked":       codec.LockUnlocked,
+		"locked":         codec.LockLocked,
+		"protected":      codec.LockProtected,
+		"locked_path":    codec.LockLockedPath,
+		"locked-path":    codec.LockLockedPath,
+		"protected_path": codec.LockProtectedPath,
+		"protected-path": codec.LockProtectedPath,
+		"PROTECTED":      codec.LockProtected,
+	}
+	for in, want := range cases {
+		got, err := lockModeValue(in)
+		if err != nil || got != want {
+			t.Errorf("lockModeValue(%q) = %q,%v want %q", in, got, err, want)
+		}
+	}
+	if _, err := lockModeValue("nope"); err == nil {
+		t.Error("lockModeValue(nope) should error")
+	}
+}
+
+func TestDeviceConfigOpType(t *testing.T) {
+	cases := map[string]codec.DeviceConfigType{
+		"add": codec.DeviceConfigAdd, "modify": codec.DeviceConfigModify, "remove": codec.DeviceConfigRemove,
+		"ADD": codec.DeviceConfigAdd,
+	}
+	for in, want := range cases {
+		got, err := deviceConfigOpType(in)
+		if err != nil || got != want {
+			t.Errorf("deviceConfigOpType(%q) = %q,%v want %q", in, got, err, want)
+		}
+	}
+	if _, err := deviceConfigOpType("frob"); err == nil {
+		t.Error("deviceConfigOpType(frob) should error")
+	}
+}
+
+// TestBuildDeviceConfigBody pins the flag->codec-struct mapping for every
+// device type, including the optional sub-struct gating (protocol / serial /
+// router params only attached when their flags are set).
+func TestBuildDeviceConfigBody(t *testing.T) {
+	t.Run("generic-with-protocol", func(t *testing.T) {
+		dc := &codec.DeviceConfiguration{}
+		dt, err := buildDeviceConfigBody(dc, "generic", deviceConfigBodyFlags{
+			device: "DRV", name: "G1", connType: "TCP", port: "9000",
+		})
+		if err != nil || dt != codec.ConfigDeviceGeneric {
+			t.Fatalf("dt=%q err=%v", dt, err)
+		}
+		if dc.Generic == nil || dc.Generic.Protocol == nil || dc.Generic.Protocol.PortNumber != "9000" {
+			t.Fatalf("generic body = %+v", dc.Generic)
+		}
+	})
+	t.Run("generic-no-protocol", func(t *testing.T) {
+		dc := &codec.DeviceConfiguration{}
+		_, err := buildDeviceConfigBody(dc, "generic", deviceConfigBodyFlags{device: "DRV"})
+		if err != nil || dc.Generic == nil || dc.Generic.Protocol != nil {
+			t.Fatalf("expected nil protocol, got %+v err=%v", dc.Generic, err)
+		}
+	})
+	t.Run("panel", func(t *testing.T) {
+		dc := &codec.DeviceConfiguration{}
+		dt, err := buildDeviceConfigBody(dc, "panel", deviceConfigBodyFlags{cpf: "c", panelID: "5", panelType: "T"})
+		if err != nil || dt != codec.ConfigDevicePanel || dc.Panel == nil || dc.Panel.CPF != "c" {
+			t.Fatalf("panel body = %+v dt=%q err=%v", dc.Panel, dt, err)
+		}
+	})
+	t.Run("router-full", func(t *testing.T) {
+		dc := &codec.DeviceConfiguration{}
+		dt, err := buildDeviceConfigBody(dc, "router", deviceConfigBodyFlags{
+			routerType: "5", baud: "9600", parity: "N", maxLevel: "4", maxSource: "1024", maxDest: "1024",
+		})
+		if err != nil || dt != codec.ConfigDeviceRouter {
+			t.Fatalf("dt=%q err=%v", dt, err)
+		}
+		if dc.Router == nil || dc.Router.Serial == nil || dc.Router.Router == nil {
+			t.Fatalf("router body = %+v", dc.Router)
+		}
+	})
+	t.Run("router-no-subs", func(t *testing.T) {
+		dc := &codec.DeviceConfiguration{}
+		_, err := buildDeviceConfigBody(dc, "router", deviceConfigBodyFlags{routerType: "5"})
+		if err != nil || dc.Router == nil || dc.Router.Serial != nil || dc.Router.Router != nil {
+			t.Fatalf("expected bare router, got %+v err=%v", dc.Router, err)
+		}
+	})
+	t.Run("snmp", func(t *testing.T) {
+		dc := &codec.DeviceConfiguration{}
+		dt, err := buildDeviceConfigBody(dc, "snmp", deviceConfigBodyFlags{snmpName: "S1", snmpPort: "161"})
+		if err != nil || dt != codec.ConfigDeviceSNMP || dc.SNMP == nil || dc.SNMP.Port != "161" {
+			t.Fatalf("snmp body = %+v dt=%q err=%v", dc.SNMP, dt, err)
+		}
+	})
+	t.Run("empty-type", func(t *testing.T) {
+		if _, err := buildDeviceConfigBody(&codec.DeviceConfiguration{}, "", deviceConfigBodyFlags{}); err == nil {
+			t.Fatal("empty device-type should error")
+		}
+	})
+	t.Run("bad-type", func(t *testing.T) {
+		if _, err := buildDeviceConfigBody(&codec.DeviceConfiguration{}, "frob", deviceConfigBodyFlags{}); err == nil {
+			t.Fatal("bad device-type should error")
+		}
+	})
+}
+
+func TestRouteTargetFromFlags(t *testing.T) {
+	def := routeTargetFromFlags("0.0.0.0", "")
+	if def.IPAddress != "0.0.0.0" || def.DeviceType != codec.DeviceType("ROUTER") {
+		t.Fatalf("default target = %+v", def)
+	}
+	byName := routeTargetFromFlags("0.0.0.0", "MYDEV")
+	if byName.DeviceName != "MYDEV" || byName.IPAddress != "" {
+		t.Fatalf("device-name target = %+v", byName)
+	}
+	byIP := routeTargetFromFlags("10.1.2.3", "")
+	if byIP.IPAddress != "10.1.2.3" {
+		t.Fatalf("router IP target = %+v", byIP)
+	}
+}

--- a/internal/cerebrum-nb/codec/actions.go
+++ b/internal/cerebrum-nb/codec/actions.go
@@ -253,22 +253,32 @@ func (s *SalvoAction) encodeAction(b *strings.Builder) {
 // §4.4 — Device actions
 // ----------------------------------------------------------------------
 
-// DeviceAction is the §4.4 catalogue: SET_VALUE only (in 0.13).
+// DeviceAction is the §4.4 catalogue: SET_VALUE. 0v16 (§4.4.1 p19) adds
+// the IP_ADDRESS alternative to DEVICE_NAME, plus the IS_ENUM and MODE
+// attributes.
 type DeviceAction struct {
 	Type       string
 	DeviceName string
+	IPAddress  string // §4.4.1: DEVICE_NAME *or* IP_ADDRESS may address the device
 	SubDevice  string
 	Object     string
 	Value      string
+	IsEnum     bool   // §4.4.1: IS_ENUM="1" — VALUE is a string repr of an enum (0/omitted by default)
+	Mode       string // §4.4.1: CSV MODE — SET | ADD_TAIL | INSERT_AT_HEAD | REMOVE (SET by default)
 }
 
 func (d *DeviceAction) encodeAction(b *strings.Builder) {
 	a := AttrsBuilder{}.
 		ForceAdd("TYPE", d.Type).
 		Add("DEVICE_NAME", d.DeviceName).
+		Add("IP_ADDRESS", d.IPAddress).
 		Add("SUB_DEVICE", d.SubDevice).
 		Add("OBJECT", d.Object).
-		Add("VALUE", d.Value)
+		Add("VALUE", d.Value).
+		Add("MODE", d.Mode)
+	if d.IsEnum {
+		a = a.Add("IS_ENUM", "1")
+	}
 	emitElement(b, "DEVICE", a, nil)
 }
 

--- a/internal/cerebrum-nb/codec/codec_0v16_test.go
+++ b/internal/cerebrum-nb/codec/codec_0v16_test.go
@@ -313,6 +313,27 @@ func TestEncodeDeviceConfiguration_SNMPAdd(t *testing.T) {
 	}
 }
 
+func TestEncodeAction_DeviceSetValue_0v16(t *testing.T) {
+	// §4.4.1 p19 worked example: IS_ENUM + SUB_DEVICE + MODE, addressed
+	// by IP_ADDRESS instead of DEVICE_NAME. IS_ENUM emits only when true;
+	// MODE/IP_ADDRESS emit when non-empty. Attr order is the codec's
+	// deterministic order (XML attr order is not significant).
+	body := &DeviceAction{
+		Type:      "SET_VALUE",
+		IPAddress: "10.0.0.5",
+		SubDevice: "1",
+		Object:    "PSU.Fan Control",
+		Value:     "Automatic",
+		IsEnum:    true,
+		Mode:      "SET",
+	}
+	got := string(EncodeAction(1, body))
+	want := `<ACTION MTID="1"><DEVICE TYPE="SET_VALUE" IP_ADDRESS="10.0.0.5" SUB_DEVICE="1" OBJECT="PSU.Fan Control" VALUE="Automatic" MODE="SET" IS_ENUM="1"/></ACTION>`
+	if got != want {
+		t.Fatalf("\n got %s\nwant %s", got, want)
+	}
+}
+
 func TestEncodeDeviceConfiguration_Remove(t *testing.T) {
 	// §4.5.2 p23 worked example: self-closing, no body.
 	dc := &DeviceConfiguration{

--- a/internal/cerebrum-nb/codec/ws/conn.go
+++ b/internal/cerebrum-nb/codec/ws/conn.go
@@ -3,7 +3,6 @@ package ws
 import (
 	"bufio"
 	"context"
-	"crypto/rand"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -173,9 +172,12 @@ func (c *Conn) closeUnderlying() {
 	})
 }
 
-// newMaskKey returns 4 random bytes for client-to-server masking.
+// newMaskKey returns 4 random bytes for client-to-server masking. The
+// crypto/rand read goes through the randRead seam (seam.go) so the
+// otherwise-unreachable error arm in writeData / writeControl can be
+// driven by a test without weakening the guard.
 func newMaskKey() ([4]byte, error) {
 	var k [4]byte
-	_, err := rand.Read(k[:])
+	_, err := randRead(k[:])
 	return k, err
 }

--- a/internal/cerebrum-nb/codec/ws/frame.go
+++ b/internal/cerebrum-nb/codec/ws/frame.go
@@ -78,6 +78,12 @@ func readFrame(r io.Reader, maxPayload int64) (*frame, error) {
 		}
 		plen = int64(v)
 	}
+	// plenSeam is the identity in production: plen is derived from a 7-bit
+	// field (0..125), a u16 (case 126), or a u64 with its high bit already
+	// rejected (case 127), so it can never be negative on a real frame.
+	// The seam lets a test drive the defensive guard below without
+	// weakening it (see seam.go).
+	plen = plenSeam(plen)
 	if plen < 0 {
 		return nil, errors.New("ws: negative payload length")
 	}

--- a/internal/cerebrum-nb/codec/ws/handshake.go
+++ b/internal/cerebrum-nb/codec/ws/handshake.go
@@ -2,7 +2,6 @@ package ws
 
 import (
 	"bufio"
-	"crypto/rand"
 	"crypto/sha1"
 	"encoding/base64"
 	"errors"
@@ -25,7 +24,7 @@ const rfc6455GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 // extraHeaders are merged on top of the required RFC 6455 set.
 func upgradeRequest(w io.Writer, u *url.URL, extraHeaders http.Header) (key string, err error) {
 	var nonce [16]byte
-	if _, err := rand.Read(nonce[:]); err != nil {
+	if _, err := randRead(nonce[:]); err != nil {
 		return "", err
 	}
 	key = base64.StdEncoding.EncodeToString(nonce[:])

--- a/internal/cerebrum-nb/codec/ws/loopback_test.go
+++ b/internal/cerebrum-nb/codec/ws/loopback_test.go
@@ -157,10 +157,15 @@ func TestDial_DefaultPortInjected(t *testing.T) {
 		Dialer: &net.Dialer{Timeout: 200 * time.Millisecond},
 	})
 	if err == nil {
-		t.Fatal("expected dial failure to closed :80")
+		t.Fatal("expected dial failure to :80")
 	}
-	if !strings.Contains(err.Error(), "tcp dial") {
-		t.Fatalf("want tcp dial error, got %v", err)
+	// Prove the port-injection branch ran: the error must name the injected
+	// :80. We can't assert the *kind* of failure — on hosts where :80 is
+	// closed it's a "tcp dial" connection-refused; on hosts where something
+	// holds :80 (e.g. Windows http.sys) the TCP connect succeeds and the WS
+	// upgrade times out. Both name 127.0.0.1:80, which is what we're verifying.
+	if !strings.Contains(err.Error(), ":80") {
+		t.Fatalf("want error naming injected :80, got %v", err)
 	}
 }
 
@@ -171,10 +176,12 @@ func TestDial_WSSDefaultPortInjected(t *testing.T) {
 		Dialer: &net.Dialer{Timeout: 200 * time.Millisecond},
 	})
 	if err == nil {
-		t.Fatal("expected dial failure to closed :443")
+		t.Fatal("expected dial failure to :443")
 	}
-	if !strings.Contains(err.Error(), "tcp dial") {
-		t.Fatalf("want tcp dial error, got %v", err)
+	// As above: assert the injected :443 is named, not the failure kind
+	// (refused vs handshake/TLS timeout varies by host).
+	if !strings.Contains(err.Error(), ":443") {
+		t.Fatalf("want error naming injected :443, got %v", err)
 	}
 }
 

--- a/internal/cerebrum-nb/codec/ws/loopback_test.go
+++ b/internal/cerebrum-nb/codec/ws/loopback_test.go
@@ -636,9 +636,8 @@ func TestWrite_MaskKeyError(t *testing.T) {
 	// randRead), then swap the seam to fail only the per-write mask-key
 	// generation.
 	conn := dialEcho(t, s)
-	orig := randRead
-	randRead = func([]byte) (int, error) { return 0, errors.New("rand boom") }
-	defer func() { randRead = orig; _ = conn.c.Close() }()
+	restore := setRandRead(func([]byte) (int, error) { return 0, errors.New("rand boom") })
+	defer func() { restore(); _ = conn.c.Close() }()
 
 	// writeData path.
 	if err := conn.WriteText(context.Background(), []byte("x")); err == nil ||

--- a/internal/cerebrum-nb/codec/ws/loopback_test.go
+++ b/internal/cerebrum-nb/codec/ws/loopback_test.go
@@ -1,0 +1,772 @@
+package ws
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/tls"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeServer is an in-process RFC 6455 server side built directly on a
+// net.Listener. It is intentionally minimal — just enough to drive the
+// stdlib-only client in this package end to end (handshake + framed
+// read/write) without a third-party WS library or a live Cerebrum peer.
+type fakeServer struct {
+	ln net.Listener
+
+	// handshake controls how the server answers the upgrade. When nil it
+	// performs a correct RFC 6455 §4.2 accept; tests substitute it to
+	// drive the client's rejection paths.
+	handshake func(req *http.Request, br *bufio.Reader, conn net.Conn) (proceed bool)
+
+	// onConn, when non-nil, runs after a successful handshake with the
+	// post-handshake net.Conn so a test can push server frames.
+	onConn func(conn net.Conn)
+}
+
+func newFakeServer(t *testing.T) *fakeServer {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	s := &fakeServer{ln: ln}
+	go s.serve()
+	t.Cleanup(func() { _ = ln.Close() })
+	return s
+}
+
+func (s *fakeServer) url() string {
+	return "ws://" + s.ln.Addr().String() + "/"
+}
+
+func (s *fakeServer) serve() {
+	for {
+		conn, err := s.ln.Accept()
+		if err != nil {
+			return
+		}
+		go s.handle(conn)
+	}
+}
+
+func (s *fakeServer) handle(conn net.Conn) {
+	br := bufio.NewReader(conn)
+	req, err := http.ReadRequest(br)
+	if err != nil {
+		_ = conn.Close()
+		return
+	}
+	if s.handshake != nil {
+		if !s.handshake(req, br, conn) {
+			_ = conn.Close()
+			return
+		}
+	} else {
+		key := req.Header.Get("Sec-WebSocket-Key")
+		accept := computeAccept(key)
+		resp := "HTTP/1.1 101 Switching Protocols\r\n" +
+			"Upgrade: websocket\r\n" +
+			"Connection: Upgrade\r\n" +
+			"Sec-WebSocket-Accept: " + accept + "\r\n\r\n"
+		if _, err := io.WriteString(conn, resp); err != nil {
+			_ = conn.Close()
+			return
+		}
+	}
+	if s.onConn != nil {
+		s.onConn(conn)
+		return
+	}
+	_ = conn.Close()
+}
+
+// writeServerText sends an unmasked server->client text frame.
+func writeServerText(conn net.Conn, payload []byte) error {
+	return writeFrame(conn, true, OpText, payload, [4]byte{}, false)
+}
+
+// ----------------------------------------------------------------------
+// Dial — success + every rejection path
+// ----------------------------------------------------------------------
+
+func TestDial_Success_AndTextRoundTrip(t *testing.T) {
+	s := newFakeServer(t)
+	got := make(chan []byte, 1)
+	s.onConn = func(conn net.Conn) {
+		br := bufio.NewReader(conn)
+		// Read the client's (masked) text frame and echo its payload back.
+		f, err := readFrame(br, 0)
+		if err != nil {
+			return
+		}
+		_ = writeServerText(conn, f.payload)
+		got <- f.payload
+		// Hold open briefly so the client can read the echo.
+		time.Sleep(50 * time.Millisecond)
+		_ = conn.Close()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	conn, err := Dial(ctx, s.url(), nil)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer func() { _ = conn.Close(1000, "bye") }()
+
+	if conn.LocalAddr() == nil || conn.RemoteAddr() == nil {
+		t.Fatal("Local/RemoteAddr returned nil")
+	}
+	if err := conn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	if err := conn.SetWriteDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("SetWriteDeadline: %v", err)
+	}
+
+	if err := conn.WriteText(ctx, []byte("ping-xml")); err != nil {
+		t.Fatalf("WriteText: %v", err)
+	}
+	op, payload, err := conn.ReadMessage(ctx)
+	if err != nil {
+		t.Fatalf("ReadMessage: %v", err)
+	}
+	if op != OpText || string(payload) != "ping-xml" {
+		t.Fatalf("echo: op=%#x payload=%q", op, payload)
+	}
+	if g := <-got; string(g) != "ping-xml" {
+		t.Fatalf("server saw %q", g)
+	}
+}
+
+func TestDial_DefaultPortInjected(t *testing.T) {
+	// A ws:// URL without an explicit port must have :80 injected. We can't
+	// reach a real :80, so we only assert the dial fails on connection
+	// rather than on scheme/parse — proving the port-injection branch ran.
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	_, err := Dial(ctx, "ws://127.0.0.1/", &DialOptions{
+		Dialer: &net.Dialer{Timeout: 200 * time.Millisecond},
+	})
+	if err == nil {
+		t.Fatal("expected dial failure to closed :80")
+	}
+	if !strings.Contains(err.Error(), "tcp dial") {
+		t.Fatalf("want tcp dial error, got %v", err)
+	}
+}
+
+func TestDial_WSSDefaultPortInjected(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	_, err := Dial(ctx, "wss://127.0.0.1/", &DialOptions{
+		Dialer: &net.Dialer{Timeout: 200 * time.Millisecond},
+	})
+	if err == nil {
+		t.Fatal("expected dial failure to closed :443")
+	}
+	if !strings.Contains(err.Error(), "tcp dial") {
+		t.Fatalf("want tcp dial error, got %v", err)
+	}
+}
+
+func TestDial_BadURL(t *testing.T) {
+	_, err := Dial(context.Background(), "://bad-url", nil)
+	if err == nil || !strings.Contains(err.Error(), "parse url") {
+		t.Fatalf("want parse url error, got %v", err)
+	}
+}
+
+func TestDial_UnsupportedScheme(t *testing.T) {
+	_, err := Dial(context.Background(), "http://host/", nil)
+	if err == nil || !strings.Contains(err.Error(), "unsupported scheme") {
+		t.Fatalf("want unsupported scheme error, got %v", err)
+	}
+}
+
+func TestDial_TCPRefused(t *testing.T) {
+	// Listen then immediately close to get a guaranteed-dead port.
+	ln, _ := net.Listen("tcp", "127.0.0.1:0")
+	addr := ln.Addr().String()
+	_ = ln.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err := Dial(ctx, "ws://"+addr+"/", nil)
+	if err == nil || !strings.Contains(err.Error(), "tcp dial") {
+		t.Fatalf("want tcp dial error, got %v", err)
+	}
+}
+
+func TestDial_TLSHandshakeFails(t *testing.T) {
+	// A plain-TCP server speaking no TLS: the wss:// client's TLS
+	// handshake must fail.
+	s := newFakeServer(t)
+	addr := s.ln.Addr().String()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err := Dial(ctx, "wss://"+addr+"/", &DialOptions{
+		TLSConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+	})
+	if err == nil || !strings.Contains(err.Error(), "tls handshake") {
+		t.Fatalf("want tls handshake error, got %v", err)
+	}
+}
+
+func TestDial_UpgradeRejected_Non101(t *testing.T) {
+	s := newFakeServer(t)
+	s.handshake = func(_ *http.Request, _ *bufio.Reader, conn net.Conn) bool {
+		_, _ = io.WriteString(conn, "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n")
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err := Dial(ctx, s.url(), nil)
+	if err == nil || !strings.Contains(err.Error(), "upgrade failed") {
+		t.Fatalf("want upgrade failed error, got %v", err)
+	}
+}
+
+func TestDial_UpgradeMissingUpgradeHeader(t *testing.T) {
+	s := newFakeServer(t)
+	s.handshake = func(req *http.Request, _ *bufio.Reader, conn net.Conn) bool {
+		accept := computeAccept(req.Header.Get("Sec-WebSocket-Key"))
+		_, _ = io.WriteString(conn, "HTTP/1.1 101 Switching Protocols\r\n"+
+			"Connection: Upgrade\r\n"+
+			"Sec-WebSocket-Accept: "+accept+"\r\n\r\n")
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err := Dial(ctx, s.url(), nil)
+	if err == nil || !strings.Contains(err.Error(), "missing Upgrade") {
+		t.Fatalf("want missing Upgrade error, got %v", err)
+	}
+}
+
+func TestDial_UpgradeMissingConnectionHeader(t *testing.T) {
+	s := newFakeServer(t)
+	s.handshake = func(req *http.Request, _ *bufio.Reader, conn net.Conn) bool {
+		accept := computeAccept(req.Header.Get("Sec-WebSocket-Key"))
+		_, _ = io.WriteString(conn, "HTTP/1.1 101 Switching Protocols\r\n"+
+			"Upgrade: websocket\r\n"+
+			"Sec-WebSocket-Accept: "+accept+"\r\n\r\n")
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err := Dial(ctx, s.url(), nil)
+	if err == nil || !strings.Contains(err.Error(), "Connection: Upgrade") {
+		t.Fatalf("want missing Connection error, got %v", err)
+	}
+}
+
+func TestDial_UpgradeMissingAccept(t *testing.T) {
+	s := newFakeServer(t)
+	s.handshake = func(_ *http.Request, _ *bufio.Reader, conn net.Conn) bool {
+		_, _ = io.WriteString(conn, "HTTP/1.1 101 Switching Protocols\r\n"+
+			"Upgrade: websocket\r\n"+
+			"Connection: Upgrade\r\n\r\n")
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err := Dial(ctx, s.url(), nil)
+	if err == nil || !strings.Contains(err.Error(), "missing Sec-WebSocket-Accept") {
+		t.Fatalf("want missing Accept error, got %v", err)
+	}
+}
+
+func TestDial_UpgradeAcceptMismatch(t *testing.T) {
+	s := newFakeServer(t)
+	s.handshake = func(_ *http.Request, _ *bufio.Reader, conn net.Conn) bool {
+		_, _ = io.WriteString(conn, "HTTP/1.1 101 Switching Protocols\r\n"+
+			"Upgrade: websocket\r\n"+
+			"Connection: Upgrade\r\n"+
+			"Sec-WebSocket-Accept: WRONGVALUE=\r\n\r\n")
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err := Dial(ctx, s.url(), nil)
+	if err == nil || !strings.Contains(err.Error(), "Accept mismatch") {
+		t.Fatalf("want accept mismatch error, got %v", err)
+	}
+}
+
+func TestDial_UpgradeResponseGarbage(t *testing.T) {
+	s := newFakeServer(t)
+	s.handshake = func(_ *http.Request, _ *bufio.Reader, conn net.Conn) bool {
+		_, _ = io.WriteString(conn, "not-an-http-response\r\n")
+		_ = conn.Close()
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err := Dial(ctx, s.url(), nil)
+	if err == nil || !strings.Contains(err.Error(), "read upgrade response") {
+		t.Fatalf("want read upgrade response error, got %v", err)
+	}
+}
+
+func TestDial_ExtraHeadersMerged(t *testing.T) {
+	s := newFakeServer(t)
+	seen := make(chan string, 1)
+	s.handshake = func(req *http.Request, _ *bufio.Reader, conn net.Conn) bool {
+		seen <- req.Header.Get("Authorization")
+		accept := computeAccept(req.Header.Get("Sec-WebSocket-Key"))
+		_, _ = io.WriteString(conn, "HTTP/1.1 101 Switching Protocols\r\n"+
+			"Upgrade: websocket\r\n"+
+			"Connection: Upgrade\r\n"+
+			"Sec-WebSocket-Accept: "+accept+"\r\n\r\n")
+		return false // proceed=false so handle() doesn't fall through to onConn
+	}
+	h := http.Header{}
+	h.Set("Authorization", "Bearer xyz")
+	// Headers we own must be dropped even if the caller sets them.
+	h.Set("Upgrade", "nonsense")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, _ = Dial(ctx, s.url(), &DialOptions{Header: h})
+	if got := <-seen; got != "Bearer xyz" {
+		t.Fatalf("Authorization header not merged: %q", got)
+	}
+}
+
+// ----------------------------------------------------------------------
+// ReadMessage control-frame handling + fragmentation
+// ----------------------------------------------------------------------
+
+func dialEcho(t *testing.T, s *fakeServer) *Conn {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	conn, err := Dial(ctx, s.url(), nil)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	return conn
+}
+
+func TestReadMessage_PingTriggersPong_ThenText(t *testing.T) {
+	s := newFakeServer(t)
+	pongSeen := make(chan struct{}, 1)
+	s.onConn = func(conn net.Conn) {
+		// Server sends a Ping; client must auto-Pong, then we send text.
+		_ = writeFrame(conn, true, OpPing, []byte("hb"), [4]byte{}, false)
+		br := bufio.NewReader(conn)
+		// Expect the client's masked Pong.
+		f, err := readFrame(br, 0)
+		if err == nil && f.opcode == OpPong {
+			pongSeen <- struct{}{}
+		}
+		_ = writeServerText(conn, []byte("after-ping"))
+		time.Sleep(50 * time.Millisecond)
+		_ = conn.Close()
+	}
+	conn := dialEcho(t, s)
+	defer func() { _ = conn.Close(1000, "") }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	op, payload, err := conn.ReadMessage(ctx)
+	if err != nil {
+		t.Fatalf("ReadMessage: %v", err)
+	}
+	if op != OpText || string(payload) != "after-ping" {
+		t.Fatalf("got op=%#x payload=%q", op, payload)
+	}
+	select {
+	case <-pongSeen:
+	case <-time.After(time.Second):
+		t.Fatal("server never saw the auto-Pong")
+	}
+}
+
+func TestReadMessage_PongDropped(t *testing.T) {
+	s := newFakeServer(t)
+	s.onConn = func(conn net.Conn) {
+		_ = writeFrame(conn, true, OpPong, []byte("unsolicited"), [4]byte{}, false)
+		_ = writeServerText(conn, []byte("real"))
+		time.Sleep(50 * time.Millisecond)
+		_ = conn.Close()
+	}
+	conn := dialEcho(t, s)
+	defer func() { _ = conn.Close(1000, "") }()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, payload, err := conn.ReadMessage(ctx)
+	if err != nil || string(payload) != "real" {
+		t.Fatalf("Pong not dropped: payload=%q err=%v", payload, err)
+	}
+}
+
+func TestReadMessage_ServerCloseGivesEOF(t *testing.T) {
+	s := newFakeServer(t)
+	s.onConn = func(conn net.Conn) {
+		body := []byte{0x03, 0xe8} // code 1000
+		_ = writeFrame(conn, true, OpClose, body, [4]byte{}, false)
+		time.Sleep(50 * time.Millisecond)
+		_ = conn.Close()
+	}
+	conn := dialEcho(t, s)
+	defer func() { _ = conn.Close(1000, "") }()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, _, err := conn.ReadMessage(ctx)
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("want io.EOF on close, got %v", err)
+	}
+}
+
+func TestReadMessage_Fragmented(t *testing.T) {
+	s := newFakeServer(t)
+	s.onConn = func(conn net.Conn) {
+		// Text frame split into two continuation fragments.
+		_ = writeFrame(conn, false, OpText, []byte("<root"), [4]byte{}, false)
+		_ = writeFrame(conn, true, OpContinuation, []byte("/>"), [4]byte{}, false)
+		time.Sleep(50 * time.Millisecond)
+		_ = conn.Close()
+	}
+	conn := dialEcho(t, s)
+	defer func() { _ = conn.Close(1000, "") }()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	op, payload, err := conn.ReadMessage(ctx)
+	if err != nil {
+		t.Fatalf("ReadMessage: %v", err)
+	}
+	if op != OpText || string(payload) != "<root/>" {
+		t.Fatalf("reassembly: op=%#x payload=%q", op, payload)
+	}
+}
+
+func TestReadMessage_ContinuationWithoutData(t *testing.T) {
+	s := newFakeServer(t)
+	s.onConn = func(conn net.Conn) {
+		_ = writeFrame(conn, true, OpContinuation, []byte("orphan"), [4]byte{}, false)
+		time.Sleep(50 * time.Millisecond)
+		_ = conn.Close()
+	}
+	conn := dialEcho(t, s)
+	defer func() { _ = conn.Close(1000, "") }()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, _, err := conn.ReadMessage(ctx)
+	if err == nil || !strings.Contains(err.Error(), "continuation without preceding") {
+		t.Fatalf("want orphan-continuation error, got %v", err)
+	}
+}
+
+func TestReadMessage_NewDataMidFragmentation(t *testing.T) {
+	s := newFakeServer(t)
+	s.onConn = func(conn net.Conn) {
+		_ = writeFrame(conn, false, OpText, []byte("a"), [4]byte{}, false)
+		_ = writeFrame(conn, true, OpText, []byte("b"), [4]byte{}, false) // illegal: new data frame
+		time.Sleep(50 * time.Millisecond)
+		_ = conn.Close()
+	}
+	conn := dialEcho(t, s)
+	defer func() { _ = conn.Close(1000, "") }()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, _, err := conn.ReadMessage(ctx)
+	if err == nil || !strings.Contains(err.Error(), "mid-fragmentation") {
+		t.Fatalf("want mid-fragmentation error, got %v", err)
+	}
+}
+
+func TestReadMessage_UnknownOpcode(t *testing.T) {
+	s := newFakeServer(t)
+	s.onConn = func(conn net.Conn) {
+		// Opcode 0x3 is a reserved non-control data opcode.
+		_ = writeFrame(conn, true, 0x3, []byte("x"), [4]byte{}, false)
+		time.Sleep(50 * time.Millisecond)
+		_ = conn.Close()
+	}
+	conn := dialEcho(t, s)
+	defer func() { _ = conn.Close(1000, "") }()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, _, err := conn.ReadMessage(ctx)
+	if err == nil || !strings.Contains(err.Error(), "unknown opcode") {
+		t.Fatalf("want unknown opcode error, got %v", err)
+	}
+}
+
+func TestReadMessage_ReadError(t *testing.T) {
+	s := newFakeServer(t)
+	s.onConn = func(conn net.Conn) {
+		_ = conn.Close() // hang up immediately after handshake
+	}
+	conn := dialEcho(t, s)
+	defer func() { _ = conn.Close(1000, "") }()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, _, err := conn.ReadMessage(ctx)
+	if err == nil {
+		t.Fatal("want read error on closed conn")
+	}
+}
+
+// ----------------------------------------------------------------------
+// Write side: Ping, Close, control-too-large, deadline ctx
+// ----------------------------------------------------------------------
+
+func TestPing_And_Close(t *testing.T) {
+	s := newFakeServer(t)
+	frames := make(chan byte, 4)
+	s.onConn = func(conn net.Conn) {
+		br := bufio.NewReader(conn)
+		for {
+			f, err := readFrame(br, 0)
+			if err != nil {
+				return
+			}
+			frames <- f.opcode
+			if f.opcode == OpClose {
+				return
+			}
+		}
+	}
+	conn := dialEcho(t, s)
+	ctx := context.Background()
+	if err := conn.Ping(ctx, []byte("p")); err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+	if err := conn.Close(1000, "client closing"); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	// Second Close is a no-op returning the first error (nil here).
+	if err := conn.Close(1001, "again"); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	var sawPing, sawClose bool
+	timeout := time.After(time.Second)
+	for !sawPing || !sawClose {
+		select {
+		case op := <-frames:
+			switch op {
+			case OpPing:
+				sawPing = true
+			case OpClose:
+				sawClose = true
+			}
+		case <-timeout:
+			t.Fatalf("frames seen: ping=%v close=%v", sawPing, sawClose)
+		}
+	}
+}
+
+func TestClose_LongReasonTruncated(t *testing.T) {
+	s := newFakeServer(t)
+	bodyLen := make(chan int, 1)
+	s.onConn = func(conn net.Conn) {
+		br := bufio.NewReader(conn)
+		f, err := readFrame(br, 0)
+		if err == nil {
+			bodyLen <- len(f.payload)
+		}
+	}
+	conn := dialEcho(t, s)
+	long := strings.Repeat("x", 300)
+	if err := conn.Close(1000, long); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	select {
+	case n := <-bodyLen:
+		if n != 125 {
+			t.Fatalf("close body len = %d, want 125 (truncated)", n)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("server never saw the close frame")
+	}
+}
+
+func TestWriteControl_TooLarge(t *testing.T) {
+	s := newFakeServer(t)
+	s.onConn = func(conn net.Conn) { time.Sleep(100 * time.Millisecond); _ = conn.Close() }
+	conn := dialEcho(t, s)
+	defer func() { _ = conn.Close(1000, "") }()
+	err := conn.Ping(context.Background(), make([]byte, 200))
+	if err == nil || !strings.Contains(err.Error(), "control frame too large") {
+		t.Fatalf("want control-too-large error, got %v", err)
+	}
+}
+
+func TestWriteText_ContextDeadlineApplied(t *testing.T) {
+	s := newFakeServer(t)
+	s.onConn = func(conn net.Conn) {
+		br := bufio.NewReader(conn)
+		_, _ = readFrame(br, 0)
+		time.Sleep(50 * time.Millisecond)
+		_ = conn.Close()
+	}
+	conn := dialEcho(t, s)
+	defer func() { _ = conn.Close(1000, "") }()
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Second))
+	defer cancel()
+	if err := conn.WriteText(ctx, []byte("deadline-set")); err != nil {
+		t.Fatalf("WriteText with deadline: %v", err)
+	}
+}
+
+// ----------------------------------------------------------------------
+// newMaskKey error seam (genuinely-unreachable crypto/rand failure)
+// ----------------------------------------------------------------------
+
+func TestWrite_MaskKeyError(t *testing.T) {
+	s := newFakeServer(t)
+	s.onConn = func(conn net.Conn) { time.Sleep(100 * time.Millisecond); _ = conn.Close() }
+	// Dial FIRST with the real seam (upgradeRequest needs a working
+	// randRead), then swap the seam to fail only the per-write mask-key
+	// generation.
+	conn := dialEcho(t, s)
+	orig := randRead
+	randRead = func([]byte) (int, error) { return 0, errors.New("rand boom") }
+	defer func() { randRead = orig; _ = conn.c.Close() }()
+
+	// writeData path.
+	if err := conn.WriteText(context.Background(), []byte("x")); err == nil ||
+		!strings.Contains(err.Error(), "rand boom") {
+		t.Fatalf("WriteText mask err: %v", err)
+	}
+	// writeControl path.
+	if err := conn.Ping(context.Background(), []byte("x")); err == nil ||
+		!strings.Contains(err.Error(), "rand boom") {
+		t.Fatalf("Ping mask err: %v", err)
+	}
+}
+
+// ----------------------------------------------------------------------
+// frame.go remaining branches: 64-bit extended length, zero-length frame
+// ----------------------------------------------------------------------
+
+func TestReadFrame_64BitExtendedLength(t *testing.T) {
+	// Hand-build a 127-marker header declaring a tiny real payload so the
+	// 64-bit length branch in readFrame runs without allocating 4 GiB.
+	hdr := []byte{0x81, 127, 0, 0, 0, 0, 0, 0, 0, 3}
+	body := []byte("abc")
+	r := bufioReader(append(hdr, body...))
+	f, err := readFrame(r, 0)
+	if err != nil {
+		t.Fatalf("readFrame 64-bit: %v", err)
+	}
+	if string(f.payload) != "abc" {
+		t.Fatalf("payload = %q", f.payload)
+	}
+}
+
+func TestReadFrame_64BitHighBitSet(t *testing.T) {
+	hdr := []byte{0x81, 127, 0xFF, 0, 0, 0, 0, 0, 0, 0}
+	r := bufioReader(hdr)
+	if _, err := readFrame(r, 0); err == nil ||
+		!strings.Contains(err.Error(), "high bit set") {
+		t.Fatalf("want 64-bit high-bit error, got %v", err)
+	}
+}
+
+func TestReadFrame_ReservedBits(t *testing.T) {
+	hdr := []byte{0xF1, 0} // RSV1..3 set
+	r := bufioReader(hdr)
+	if _, err := readFrame(r, 0); err == nil ||
+		!strings.Contains(err.Error(), "reserved bits") {
+		t.Fatalf("want reserved-bits error, got %v", err)
+	}
+}
+
+func TestReadFrame_ZeroLength(t *testing.T) {
+	hdr := []byte{0x81, 0}
+	r := bufioReader(hdr)
+	f, err := readFrame(r, 0)
+	if err != nil {
+		t.Fatalf("readFrame zero-len: %v", err)
+	}
+	if len(f.payload) != 0 {
+		t.Fatalf("want empty payload, got %q", f.payload)
+	}
+}
+
+func TestReadFrame_TruncatedExt16(t *testing.T) {
+	// 126 marker but no following 2-byte length.
+	r := bufioReader([]byte{0x81, 126})
+	if _, err := readFrame(r, 0); err == nil {
+		t.Fatal("want truncated ext16 error")
+	}
+}
+
+func TestReadFrame_TruncatedExt64(t *testing.T) {
+	r := bufioReader([]byte{0x81, 127, 0, 0})
+	if _, err := readFrame(r, 0); err == nil {
+		t.Fatal("want truncated ext64 error")
+	}
+}
+
+func TestReadFrame_TruncatedMaskKey(t *testing.T) {
+	// masked bit set, payload len 1, but no mask key bytes.
+	r := bufioReader([]byte{0x81, 0x81})
+	if _, err := readFrame(r, 0); err == nil {
+		t.Fatal("want truncated mask-key error")
+	}
+}
+
+func TestReadFrame_TruncatedPayload(t *testing.T) {
+	// declares 5 bytes, supplies 2.
+	r := bufioReader([]byte{0x81, 5, 'h', 'i'})
+	if _, err := readFrame(r, 0); err == nil {
+		t.Fatal("want truncated payload error")
+	}
+}
+
+func TestReadFrame_MaskedRoundTripUnmask(t *testing.T) {
+	// masked server frame (rare, but the unmask path must run on RX).
+	var b []byte
+	key := [4]byte{1, 2, 3, 4}
+	tmp := bufioWriterBytes(func(w *writeCollector) {
+		_ = writeFrame(w, true, OpText, []byte("masked!"), key, true)
+	})
+	b = tmp
+	f, err := readFrame(bufioReader(b), 0)
+	if err != nil {
+		t.Fatalf("readFrame masked: %v", err)
+	}
+	if string(f.payload) != "masked!" || !f.masked {
+		t.Fatalf("masked roundtrip: %q masked=%v", f.payload, f.masked)
+	}
+}
+
+func TestWriteFrame_ZeroLengthUnmasked(t *testing.T) {
+	tmp := bufioWriterBytes(func(w *writeCollector) {
+		_ = writeFrame(w, true, OpText, nil, [4]byte{}, false)
+	})
+	f, err := readFrame(bufioReader(tmp), 0)
+	if err != nil {
+		t.Fatalf("readFrame zero unmasked: %v", err)
+	}
+	if len(f.payload) != 0 {
+		t.Fatalf("want empty payload")
+	}
+}
+
+// ----------------------------------------------------------------------
+// small test plumbing
+// ----------------------------------------------------------------------
+
+func bufioReader(b []byte) *bufio.Reader { return bufio.NewReader(bytes.NewReader(b)) }
+
+type writeCollector struct{ buf []byte }
+
+func (w *writeCollector) Write(p []byte) (int, error) { w.buf = append(w.buf, p...); return len(p), nil }
+
+func bufioWriterBytes(fn func(*writeCollector)) []byte {
+	w := &writeCollector{}
+	fn(w)
+	return w.buf
+}

--- a/internal/cerebrum-nb/codec/ws/seam.go
+++ b/internal/cerebrum-nb/codec/ws/seam.go
@@ -1,0 +1,34 @@
+package ws
+
+import "crypto/rand"
+
+// Test seam for the single genuinely-unreachable defensive branch in this
+// package: the crypto/rand read inside newMaskKey. It uses the same
+// transparent nil-hook / real-default pattern as the seams elsewhere in
+// the repo (cf. internal/tsl/{consumer,provider}/*_seam.go and
+// internal/probel-sw02p/{consumer,provider}/decode_seam.go): in production
+// the seam is the identity behaviour, so the guarded branch behaves exactly
+// as written; a test swaps the seam to drive the otherwise-dead error arm,
+// never to weaken it.
+//
+// Why it is unreachable in production: crypto/rand.Read on every supported
+// OS reads from the kernel CSPRNG (getrandom / RtlGenRandom / arc4random)
+// and is documented to always fill the buffer or never return; the
+// `if err != nil` arm in writeData / writeControl therefore cannot be
+// taken from a real call. The seam lets a test force that error so the
+// transport's write-side error propagation is still exercised, with the
+// guard left intact.
+
+// randRead reads len(b) random bytes into b. Production behaviour is
+// crypto/rand.Read; tests override to force the error return.
+var randRead = func(b []byte) (int, error) {
+	return rand.Read(b)
+}
+
+// plenSeam is the identity on every real frame: readFrame derives the
+// payload length from a 7-bit field, an unsigned 16-bit extension, or an
+// unsigned 64-bit extension whose high bit is rejected first — so it is
+// never negative in production. The seam exists only so a test can drive
+// the `plen < 0` defensive guard in readFrame, never to weaken it. Same
+// transparent nil-default pattern as the other seams in this package.
+var plenSeam = func(plen int64) int64 { return plen }

--- a/internal/cerebrum-nb/codec/ws/seam.go
+++ b/internal/cerebrum-nb/codec/ws/seam.go
@@ -1,34 +1,57 @@
 package ws
 
-import "crypto/rand"
+import (
+	"crypto/rand"
+	"sync/atomic"
+)
 
-// Test seam for the single genuinely-unreachable defensive branch in this
-// package: the crypto/rand read inside newMaskKey. It uses the same
-// transparent nil-hook / real-default pattern as the seams elsewhere in
-// the repo (cf. internal/tsl/{consumer,provider}/*_seam.go and
+// Test seams for the two genuinely-unreachable defensive branches in this
+// package: the crypto/rand read inside newMaskKey / the handshake nonce,
+// and the negative payload-length guard in readFrame. Same transparent
+// nil-hook / real-default pattern as the seams elsewhere in the repo (cf.
+// internal/tsl/{consumer,provider}/*_seam.go and
 // internal/probel-sw02p/{consumer,provider}/decode_seam.go): in production
-// the seam is the identity behaviour, so the guarded branch behaves exactly
-// as written; a test swaps the seam to drive the otherwise-dead error arm,
-// never to weaken it.
+// the hook is nil and the guarded branch behaves exactly as written; a test
+// installs a hook to drive the otherwise-dead arm, never to weaken it.
 //
-// Why it is unreachable in production: crypto/rand.Read on every supported
-// OS reads from the kernel CSPRNG (getrandom / RtlGenRandom / arc4random)
-// and is documented to always fill the buffer or never return; the
-// `if err != nil` arm in writeData / writeControl therefore cannot be
-// taken from a real call. The seam lets a test force that error so the
-// transport's write-side error propagation is still exercised, with the
-// guard left intact.
+// The hooks are stored in atomic.Pointer rather than plain package vars
+// because frame/handshake decoding runs on per-connection goroutines: a
+// test that swaps a hook must not data-race a concurrently-decoding
+// goroutine (the race detector flags an unsynchronised var write-vs-read
+// even though prod only ever reads). Atomic load on the read path is
+// negligible and keeps -race clean. Tests install hooks via setRandRead /
+// setPlenSeam (see seam_test.go), which return a restore func.
+//
+// Why each branch is unreachable in production:
+//   - crypto/rand.Read on every supported OS reads the kernel CSPRNG
+//     (getrandom / RtlGenRandom / arc4random) and always fills the buffer
+//     or never returns; the `if err != nil` arms in writeData / writeControl
+//     / handshake therefore cannot be taken from a real call.
+//   - readFrame derives the payload length from a 7-bit field (0..125), an
+//     unsigned 16-bit extension, or an unsigned 64-bit extension whose high
+//     bit is rejected first — so plen is never negative on a real frame.
+
+// randReadHook, when non-nil, replaces crypto/rand.Read. nil in production.
+var randReadHook atomic.Pointer[func(b []byte) (int, error)]
 
 // randRead reads len(b) random bytes into b. Production behaviour is
-// crypto/rand.Read; tests override to force the error return.
-var randRead = func(b []byte) (int, error) {
+// crypto/rand.Read; a test hook can force the error return.
+func randRead(b []byte) (int, error) {
+	if h := randReadHook.Load(); h != nil {
+		return (*h)(b)
+	}
 	return rand.Read(b)
 }
 
-// plenSeam is the identity on every real frame: readFrame derives the
-// payload length from a 7-bit field, an unsigned 16-bit extension, or an
-// unsigned 64-bit extension whose high bit is rejected first — so it is
-// never negative in production. The seam exists only so a test can drive
-// the `plen < 0` defensive guard in readFrame, never to weaken it. Same
-// transparent nil-default pattern as the other seams in this package.
-var plenSeam = func(plen int64) int64 { return plen }
+// plenSeamHook, when non-nil, rewrites the decoded payload length so a test
+// can drive readFrame's `plen < 0` guard. nil in production (identity).
+var plenSeamHook atomic.Pointer[func(plen int64) int64]
+
+// plenSeam is the identity on every real frame; the hook exists only so a
+// test can drive the negative-length defensive guard, never to weaken it.
+func plenSeam(plen int64) int64 {
+	if h := plenSeamHook.Load(); h != nil {
+		return (*h)(plen)
+	}
+	return plen
+}

--- a/internal/cerebrum-nb/codec/ws/seam_test.go
+++ b/internal/cerebrum-nb/codec/ws/seam_test.go
@@ -1,0 +1,16 @@
+package ws
+
+// Test-only helpers to install the seam hooks (see seam.go). Each returns a
+// restore func that clears the hook; install with `defer setX(f)()`. Atomic-
+// backed so installing/clearing a hook never data-races a live per-connection
+// decode goroutine (the reason the seams moved off plain package vars).
+
+func setRandRead(f func(b []byte) (int, error)) func() {
+	randReadHook.Store(&f)
+	return func() { randReadHook.Store(nil) }
+}
+
+func setPlenSeam(f func(plen int64) int64) func() {
+	plenSeamHook.Store(&f)
+	return func() { plenSeamHook.Store(nil) }
+}

--- a/internal/cerebrum-nb/codec/ws/unit_test.go
+++ b/internal/cerebrum-nb/codec/ws/unit_test.go
@@ -55,9 +55,7 @@ func TestUpgradeRequest_WriteError(t *testing.T) {
 }
 
 func TestUpgradeRequest_RandError(t *testing.T) {
-	orig := randRead
-	randRead = func([]byte) (int, error) { return 0, errors.New("rand fail") }
-	defer func() { randRead = orig }()
+	defer setRandRead(func([]byte) (int, error) { return 0, errors.New("rand fail") })()
 	u, _ := url.Parse("ws://host/")
 	_, err := upgradeRequest(errWriter{}, u, nil)
 	if err == nil || !strings.Contains(err.Error(), "rand fail") {
@@ -281,9 +279,7 @@ func TestUpgradeRequest_StarResourceURI(t *testing.T) {
 }
 
 func TestReadFrame_NegativeLengthGuard(t *testing.T) {
-	orig := plenSeam
-	plenSeam = func(int64) int64 { return -1 }
-	defer func() { plenSeam = orig }()
+	defer setPlenSeam(func(int64) int64 { return -1 })()
 	r := bufioReader([]byte{0x81, 1, 'x'})
 	if _, err := readFrame(r, 0); err == nil ||
 		!strings.Contains(err.Error(), "negative payload length") {
@@ -304,9 +300,8 @@ func TestReadMessage_PongWriteError(t *testing.T) {
 		_ = conn.Close()
 	}
 	conn := dialEcho(t, s)
-	orig := randRead
-	defer func() { randRead = orig; _ = conn.c.Close() }()
-	randRead = func([]byte) (int, error) { return 0, errors.New("pong rand boom") }
+	restore := setRandRead(func([]byte) (int, error) { return 0, errors.New("pong rand boom") })
+	defer func() { restore(); _ = conn.c.Close() }()
 	close(ready)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)

--- a/internal/cerebrum-nb/codec/ws/unit_test.go
+++ b/internal/cerebrum-nb/codec/ws/unit_test.go
@@ -1,0 +1,318 @@
+package ws
+
+import (
+	"bufio"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"math/big"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// selfSignedCert builds a throwaway TLS cert for the in-test wss:// server.
+func selfSignedCert(t *testing.T) tls.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "127.0.0.1"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+}
+
+// errWriter fails every Write — drives the write-error arms of
+// upgradeRequest / writeFrame.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) { return 0, errors.New("write boom") }
+
+func TestUpgradeRequest_WriteError(t *testing.T) {
+	u, _ := url.Parse("ws://host:40007/")
+	_, err := upgradeRequest(errWriter{}, u, nil)
+	if err == nil || !strings.Contains(err.Error(), "write boom") {
+		t.Fatalf("want write boom, got %v", err)
+	}
+}
+
+func TestUpgradeRequest_RandError(t *testing.T) {
+	orig := randRead
+	randRead = func([]byte) (int, error) { return 0, errors.New("rand fail") }
+	defer func() { randRead = orig }()
+	u, _ := url.Parse("ws://host/")
+	_, err := upgradeRequest(errWriter{}, u, nil)
+	if err == nil || !strings.Contains(err.Error(), "rand fail") {
+		t.Fatalf("want rand fail, got %v", err)
+	}
+}
+
+func TestUpgradeRequest_StarResource(t *testing.T) {
+	// A URL whose RequestURI is empty must map to "/" — exercise the
+	// resource-defaulting branch.
+	u := &url.URL{Scheme: "ws", Host: "h:1", Path: ""}
+	var w writeCollector
+	if _, err := upgradeRequest(&w, u, nil); err != nil {
+		t.Fatalf("upgradeRequest: %v", err)
+	}
+	if !strings.HasPrefix(string(w.buf), "GET / HTTP/1.1\r\n") {
+		t.Fatalf("resource not defaulted to /: %q", string(w.buf[:20]))
+	}
+}
+
+func TestWriteFrame_HeaderWriteError(t *testing.T) {
+	err := writeFrame(errWriter{}, true, OpText, []byte("hi"), [4]byte{}, false)
+	if err == nil || !strings.Contains(err.Error(), "write boom") {
+		t.Fatalf("want header write error, got %v", err)
+	}
+}
+
+// partialWriter writes the header successfully then fails on the body,
+// driving the payload-write error arm (both masked and unmasked).
+type partialWriter struct{ wrote bool }
+
+func (p *partialWriter) Write(b []byte) (int, error) {
+	if !p.wrote {
+		p.wrote = true
+		return len(b), nil
+	}
+	return 0, errors.New("body boom")
+}
+
+func TestWriteFrame_BodyWriteError_Unmasked(t *testing.T) {
+	err := writeFrame(&partialWriter{}, true, OpText, []byte("payload"), [4]byte{}, false)
+	if err == nil || !strings.Contains(err.Error(), "body boom") {
+		t.Fatalf("want unmasked body write error, got %v", err)
+	}
+}
+
+func TestWriteFrame_BodyWriteError_Masked(t *testing.T) {
+	err := writeFrame(&partialWriter{}, true, OpText, []byte("payload"), [4]byte{1, 2, 3, 4}, true)
+	if err == nil || !strings.Contains(err.Error(), "body boom") {
+		t.Fatalf("want masked body write error, got %v", err)
+	}
+}
+
+func TestHeaderHasToken(t *testing.T) {
+	if !headerHasToken("keep-alive, Upgrade", "upgrade") {
+		t.Fatal("token not found case-insensitively")
+	}
+	if headerHasToken("close", "upgrade") {
+		t.Fatal("false positive token match")
+	}
+	if headerHasToken("", "upgrade") {
+		t.Fatal("empty header matched")
+	}
+}
+
+func TestIsControl(t *testing.T) {
+	for _, op := range []byte{OpClose, OpPing, OpPong} {
+		if !IsControl(op) {
+			t.Fatalf("%#x should be control", op)
+		}
+	}
+	for _, op := range []byte{OpText, OpBinary, OpContinuation} {
+		if IsControl(op) {
+			t.Fatalf("%#x should not be control", op)
+		}
+	}
+}
+
+// fakeAddr / closedConn drive Conn.Close's underlying-close error arm.
+type closedConn struct{ net.Conn }
+
+func (closedConn) Write(b []byte) (int, error) { return len(b), nil }
+func (closedConn) Close() error                { return errors.New("close boom") }
+func (closedConn) LocalAddr() net.Addr         { return nil }
+func (closedConn) RemoteAddr() net.Addr        { return nil }
+func (closedConn) SetWriteDeadline(time.Time) error { return nil }
+func (closedConn) SetReadDeadline(time.Time) error  { return nil }
+func (closedConn) SetDeadline(time.Time) error      { return nil }
+
+func TestClose_UnderlyingCloseError(t *testing.T) {
+	c := newConn(closedConn{}, nil, 0)
+	err := c.Close(1000, "x")
+	if err == nil || !strings.Contains(err.Error(), "close boom") {
+		t.Fatalf("want underlying close error, got %v", err)
+	}
+}
+
+// ctrlWriteErrConn lets the close control-frame write fail so Close's
+// writeControl-error arm runs.
+type ctrlWriteErrConn struct{ closedConn }
+
+func (ctrlWriteErrConn) Write([]byte) (int, error) { return 0, errors.New("ctrl write boom") }
+
+func TestClose_ControlWriteError(t *testing.T) {
+	c := newConn(ctrlWriteErrConn{}, nil, 0)
+	err := c.Close(1000, "x")
+	if err == nil || !strings.Contains(err.Error(), "ctrl write boom") {
+		t.Fatalf("want control write error, got %v", err)
+	}
+}
+
+// ----------------------------------------------------------------------
+// TLS dial: real TLS listener exercises the wss:// success path + the
+// TLSConfig ServerName-clone branch.
+// ----------------------------------------------------------------------
+
+func newSelfSignedTLSServer(t *testing.T) (addr string, stop func()) {
+	t.Helper()
+	cert := selfSignedCert(t)
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{Certificates: []tls.Certificate{cert}})
+	if err != nil {
+		t.Fatalf("tls listen: %v", err)
+	}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				br := bufio.NewReader(c)
+				req, err := http.ReadRequest(br)
+				if err != nil {
+					_ = c.Close()
+					return
+				}
+				accept := computeAccept(req.Header.Get("Sec-WebSocket-Key"))
+				_, _ = c.Write([]byte("HTTP/1.1 101 Switching Protocols\r\n" +
+					"Upgrade: websocket\r\nConnection: Upgrade\r\n" +
+					"Sec-WebSocket-Accept: " + accept + "\r\n\r\n"))
+				time.Sleep(50 * time.Millisecond)
+				_ = c.Close()
+			}(conn)
+		}
+	}()
+	return ln.Addr().String(), func() { _ = ln.Close() }
+}
+
+func TestDial_WSS_Success_ServerNameClone(t *testing.T) {
+	addr, stop := newSelfSignedTLSServer(t)
+	defer stop()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	// Provide a TLSConfig WITHOUT ServerName so Dial takes the clone branch,
+	// and InsecureSkipVerify so the self-signed cert is accepted.
+	conn, err := Dial(ctx, "wss://"+addr+"/", &DialOptions{
+		TLSConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+	})
+	if err != nil {
+		t.Fatalf("wss Dial: %v", err)
+	}
+	_ = conn.Close(1000, "")
+}
+
+func TestDial_WSS_NilTLSConfig(t *testing.T) {
+	// nil TLSConfig drives the `cfg == nil` branch in Dial (default verify).
+	// The self-signed cert is rejected, but only AFTER the nil-config branch
+	// runs — which is what we want to cover.
+	addr, stop := newSelfSignedTLSServer(t)
+	defer stop()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err := Dial(ctx, "wss://"+addr+"/", &DialOptions{TLSConfig: nil})
+	if err == nil || !strings.Contains(err.Error(), "tls handshake") {
+		t.Fatalf("want tls handshake verify failure, got %v", err)
+	}
+}
+
+// hangupConn accepts then closes the TCP socket immediately so the client's
+// upgrade-request write fails — driving Dial's "write upgrade" error wrap.
+func TestDial_WriteUpgradeError(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = c.(*net.TCPConn).SetLinger(0) // RST on close
+			_ = c.Close()
+		}
+	}()
+	// Retry a few times: the write may occasionally land in the socket
+	// buffer before the RST is observed. We only assert that when Dial
+	// fails it is on the write-upgrade path (not handshake/parse).
+	var lastErr error
+	for i := 0; i < 20; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		_, lastErr = Dial(ctx, "ws://"+ln.Addr().String()+"/", nil)
+		cancel()
+		if lastErr != nil && strings.Contains(lastErr.Error(), "write upgrade") {
+			return
+		}
+	}
+	t.Skipf("could not provoke a write-upgrade error on this host (last err %v)", lastErr)
+}
+
+func TestUpgradeRequest_StarResourceURI(t *testing.T) {
+	u := &url.URL{Scheme: "ws", Host: "h:1", Opaque: "*"}
+	var w writeCollector
+	if _, err := upgradeRequest(&w, u, nil); err != nil {
+		t.Fatalf("upgradeRequest: %v", err)
+	}
+	if !strings.HasPrefix(string(w.buf), "GET / HTTP/1.1\r\n") {
+		t.Fatalf("'*' resource not defaulted to /: %q", string(w.buf[:20]))
+	}
+}
+
+func TestReadFrame_NegativeLengthGuard(t *testing.T) {
+	orig := plenSeam
+	plenSeam = func(int64) int64 { return -1 }
+	defer func() { plenSeam = orig }()
+	r := bufioReader([]byte{0x81, 1, 'x'})
+	if _, err := readFrame(r, 0); err == nil ||
+		!strings.Contains(err.Error(), "negative payload length") {
+		t.Fatalf("want negative-length guard, got %v", err)
+	}
+}
+
+// TestReadMessage_PongWriteError drives the OpPing -> writeControl(OpPong)
+// error arm in ReadMessage: the server sends a Ping, and the auto-Pong
+// write fails because the mask-key seam is forced to error.
+func TestReadMessage_PongWriteError(t *testing.T) {
+	s := newFakeServer(t)
+	ready := make(chan struct{})
+	s.onConn = func(conn net.Conn) {
+		<-ready
+		_ = writeFrame(conn, true, OpPing, []byte("hb"), [4]byte{}, false)
+		time.Sleep(100 * time.Millisecond)
+		_ = conn.Close()
+	}
+	conn := dialEcho(t, s)
+	orig := randRead
+	defer func() { randRead = orig; _ = conn.c.Close() }()
+	randRead = func([]byte) (int, error) { return 0, errors.New("pong rand boom") }
+	close(ready)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, _, err := conn.ReadMessage(ctx)
+	if err == nil || !strings.Contains(err.Error(), "pong rand boom") {
+		t.Fatalf("want pong write error, got %v", err)
+	}
+}

--- a/internal/cerebrum-nb/consumer/actions.go
+++ b/internal/cerebrum-nb/consumer/actions.go
@@ -1,0 +1,196 @@
+package cerebrumnb
+
+import (
+	"context"
+	"fmt"
+
+	"dhs/internal/cerebrum-nb/codec"
+)
+
+// This file adds the §4 write-action Session methods that wrap the codec
+// action encoders. Each is a thin, typed convenience over Session.Action
+// (ACK/NACK round-trip) so the CLI write verbs in cmd/dhs read uniformly.
+//
+// Scope note (0v16 codec on disk): every method below maps onto an action
+// body the codec actually encodes today — RoutingAction (§4.1),
+// CategoryAction (§4.2), SalvoAction (§4.3), DeviceAction (§4.4), plus the
+// 0v16 top-level DeviceConfiguration (§4.5). The codec's LockKind enum now
+// carries the full §3.2 five-value set (UNLOCKED / LOCKED / PROTECTED /
+// LOCKED_PATH / PROTECTED_PATH) alongside the deprecated PROTECT / RELEASE
+// action verbs; Lock takes any of them. DeviceAction still carries only
+// Type/DeviceName/SubDevice/Object/Value — it does NOT expose IS_ENUM or a
+// MODE (SET/ADD_TAIL/INSERT_AT_HEAD/REMOVE) field, so the 0v16 SET_VALUE
+// enum/mode surface is a codec gap and is not wired here (see DeviceConfig
+// below + the gap note returned to the caller).
+
+// Lock applies a routing lock. routingType selects SRCE_LOCK / DEST_LOCK
+// per spec §4.1; mode is the LockKind (PROTECT to lock, RELEASE to clear).
+// addr identifies the router target (IPAddress "0.0.0.0" + DEVICE_TYPE
+// "ROUTER" is the route-master sentinel) and the source/destination + level
+// addressing. duration is optional (timed locks).
+func (s *Session) Lock(ctx context.Context, routingType string, mode codec.LockKind, addr RouteTarget, srceID, destID, levelID, duration string) error {
+	body := &codec.RoutingAction{
+		Type:       routingType,
+		IPAddress:  addr.IPAddress,
+		DeviceName: addr.DeviceName,
+		DeviceType: addr.DeviceType,
+		SrceID:     srceID,
+		DestID:     destID,
+		LevelID:    levelID,
+		Lock:       mode,
+		Duration:   duration,
+	}
+	return s.Action(ctx, body)
+}
+
+// SetMnemonic writes a mnemonic via a §4.1 routing MNE action. mneType is
+// one of LEVEL_MNE / SRCE_MNE / DEST_MNE. The mnemonic string goes in
+// MNEMONIC; altSlot (optional) goes in ALT_MNE to address an alternate
+// mnemonic slot per §4.1.4-§4.1.6.
+func (s *Session) SetMnemonic(ctx context.Context, mneType string, addr RouteTarget, srceID, destID, levelID, mnemonic, altSlot string) error {
+	body := &codec.RoutingAction{
+		Type:       mneType,
+		IPAddress:  addr.IPAddress,
+		DeviceName: addr.DeviceName,
+		DeviceType: addr.DeviceType,
+		SrceID:     srceID,
+		DestID:     destID,
+		LevelID:    levelID,
+		Mnemonic:   mnemonic,
+		AltMne:     altSlot,
+	}
+	return s.Action(ctx, body)
+}
+
+// SetTags removes tags from a source or destination via the §4.1
+// RM_SRCE_TAGS / RM_DEST_TAGS routing action. tagsType selects which.
+// The spec only documents tag REMOVAL on the routing path; tags carries
+// the comma-separated tag list.
+func (s *Session) SetTags(ctx context.Context, tagsType string, addr RouteTarget, srceID, destID, tags string) error {
+	body := &codec.RoutingAction{
+		Type:       tagsType,
+		IPAddress:  addr.IPAddress,
+		DeviceName: addr.DeviceName,
+		DeviceType: addr.DeviceType,
+		SrceID:     srceID,
+		DestID:     destID,
+		Tags:       tags,
+	}
+	return s.Action(ctx, body)
+}
+
+// RouteTarget is the common router-addressing tuple shared by the routing
+// write actions. Use IPAddress="0.0.0.0" + DeviceType="ROUTER" for the
+// route-master sentinel, or a physical Router IP / DeviceName.
+type RouteTarget struct {
+	IPAddress  string
+	DeviceName string
+	DeviceType codec.DeviceType
+}
+
+// DefaultRouteTarget is the route-master sentinel used by every routing
+// write verb when the caller doesn't override the target.
+func DefaultRouteTarget() RouteTarget {
+	return RouteTarget{IPAddress: "0.0.0.0", DeviceType: codec.DeviceType("ROUTER")}
+}
+
+// Salvo issues a §4.3 salvo action: RUN / SAVE / RENAME / DESCRIPTION /
+// DELETE. group/instance address the salvo; newName is used by RENAME;
+// description by SAVE / DESCRIPTION.
+func (s *Session) Salvo(ctx context.Context, salvoType, group, instance, newName, description string) error {
+	body := &codec.SalvoAction{
+		Type:        salvoType,
+		Group:       group,
+		Instance:    instance,
+		NewName:     newName,
+		Description: description,
+	}
+	return s.Action(ctx, body)
+}
+
+// Category issues a §4.2 category action: CREATE / DELETE / DELETE_ITEM /
+// MODIFY_ITEM / MODIFY_ALL / MODIFY_DESC. The CategoryAction fields used
+// depend on TYPE; the encoder only emits the non-empty ones.
+func (s *Session) Category(ctx context.Context, act *codec.CategoryAction) error {
+	if act == nil {
+		return fmt.Errorf("cerebrum-nb: category: nil action")
+	}
+	return s.Action(ctx, act)
+}
+
+// SetDeviceValue issues a §4.4 DEVICE SET_VALUE action against a
+// (device, sub_device, object) tuple.
+func (s *Session) SetDeviceValue(ctx context.Context, deviceName, subDevice, object, value string) error {
+	body := &codec.DeviceAction{
+		Type:       "SET_VALUE",
+		DeviceName: deviceName,
+		SubDevice:  subDevice,
+		Object:     object,
+		Value:      value,
+	}
+	return s.Action(ctx, body)
+}
+
+// DeviceConfig issues a §4.5 DEVICE_CONFIGURATION command (the headline
+// 0v16 device CRUD verb) and returns the decoded <RESULT VALUE="…"/> reply.
+//
+// Unlike §4.1-§4.4 actions, DEVICE_CONFIGURATION is a top-level command (not
+// wrapped in <ACTION>), so it bypasses Session.Action and round-trips the
+// raw codec.EncodeDeviceConfiguration bytes directly. The server echoes the
+// request envelope wrapping a single <RESULT VALUE="ACCEPTED|FAILED"/>,
+// decoded as codec.KindDeviceConfigResult. A NACK is returned as the
+// NackError; a non-result/non-nack reply is an error.
+//
+// dc selects the verb (ADD/MODIFY/REMOVE) and the body builder (Generic /
+// Panel / Router / SNMP). REMOVE carries no body.
+func (s *Session) DeviceConfig(ctx context.Context, dc *codec.DeviceConfiguration) (*codec.DeviceConfigResult, error) {
+	if dc == nil {
+		return nil, fmt.Errorf("cerebrum-nb: device-config: nil configuration")
+	}
+	mtid := s.nextMTID()
+	payload := codec.EncodeDeviceConfiguration(mtid, dc)
+	f, err := s.roundTrip(ctx, mtid, payload)
+	if err != nil {
+		return nil, err
+	}
+	switch f.Kind {
+	case codec.KindDeviceConfigResult:
+		// The decoder always populates DeviceConfig for a
+		// device_configuration root (the <RESULT> child may be absent, in
+		// which case Value is empty and Accepted is false).
+		if !f.DeviceConfig.Accepted {
+			s.compliance.Event("cerebrum_device_config_failed")
+		}
+		return f.DeviceConfig, nil
+	case codec.KindBusy:
+		return nil, fmt.Errorf("cerebrum-nb: device-config: server busy (mtid %d)", mtid)
+	default:
+		return nil, fmt.Errorf("cerebrum-nb: device-config: unexpected reply %s", f.Kind)
+	}
+}
+
+// Unsubscribe sends a §2 UNSUBSCRIBE for the given items (the children
+// must match a prior SUBSCRIBE per spec) and waits for the ACK.
+func (s *Session) Unsubscribe(ctx context.Context, items []codec.SubItem) error {
+	mtid := s.nextMTID()
+	f, err := s.roundTrip(ctx, mtid, codec.EncodeUnsubscribe(mtid, items))
+	if err != nil {
+		return err
+	}
+	if f.Kind != codec.KindAck {
+		return fmt.Errorf("cerebrum-nb: unsubscribe: unexpected %s", f.Kind)
+	}
+	return nil
+}
+
+// ObtainDatastore issues an OBTAIN for a §5.5 datastore path. Snapshot
+// rows arrive asynchronously through the dispatcher (register an OnEvent
+// for codec.KindDatastoreChange first). Returns nil on the ACK.
+func (s *Session) ObtainDatastore(ctx context.Context, name string) error {
+	return s.Obtain(ctx, []codec.SubItem{&codec.DatastoreChange{Name: name}})
+}
+
+// SubscribeDatastore subscribes to changes for a §5.5 datastore path.
+func (s *Session) SubscribeDatastore(ctx context.Context, name string) error {
+	return s.Subscribe(ctx, []codec.SubItem{&codec.DatastoreChange{Name: name}})
+}

--- a/internal/cerebrum-nb/consumer/fakeserver_test.go
+++ b/internal/cerebrum-nb/consumer/fakeserver_test.go
@@ -1,0 +1,331 @@
+package cerebrumnb
+
+import (
+	"bufio"
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/binary"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeCerebrum is an in-process RFC 6455 server that speaks just enough of
+// the Cerebrum NB wire protocol to drive the consumer end to end. There is
+// NO live peer and NO vendor emulator available (NB licence missing), so
+// every consumer test runs against this fake: it completes the WebSocket
+// handshake, then a per-test handler reads client XML frames and writes
+// canned 0v13 reply / event frames (ACK / NACK / BUSY / LOGIN_REPLY /
+// POLL_REPLY / *_CHANGE) back.
+//
+// The handler runs on the post-handshake net.Conn. Helpers below read one
+// client text frame (unmasking it) and write a server text frame.
+type fakeCerebrum struct {
+	ln      net.Listener
+	handler func(fc *fakeConn)
+
+	mu    sync.Mutex
+	conns []net.Conn
+}
+
+// fakeConn wraps the server side of one accepted connection with framed
+// read/write helpers.
+type fakeConn struct {
+	c  net.Conn
+	br *bufio.Reader
+}
+
+func newFakeCerebrum(t *testing.T, handler func(*fakeConn)) *fakeCerebrum {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	fs := &fakeCerebrum{ln: ln, handler: handler}
+	go fs.serve()
+	t.Cleanup(func() {
+		_ = ln.Close()
+		fs.mu.Lock()
+		for _, c := range fs.conns {
+			_ = c.Close()
+		}
+		fs.mu.Unlock()
+	})
+	return fs
+}
+
+func (fs *fakeCerebrum) host() string {
+	return fs.ln.Addr().(*net.TCPAddr).IP.String()
+}
+func (fs *fakeCerebrum) port() int {
+	return fs.ln.Addr().(*net.TCPAddr).Port
+}
+
+func (fs *fakeCerebrum) serve() {
+	for {
+		c, err := fs.ln.Accept()
+		if err != nil {
+			return
+		}
+		fs.mu.Lock()
+		fs.conns = append(fs.conns, c)
+		fs.mu.Unlock()
+		go fs.handle(c)
+	}
+}
+
+func (fs *fakeCerebrum) handle(c net.Conn) {
+	br := bufio.NewReader(c)
+	req, err := http.ReadRequest(br)
+	if err != nil {
+		_ = c.Close()
+		return
+	}
+	key := req.Header.Get("Sec-WebSocket-Key")
+	h := sha1.New()
+	h.Write([]byte(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"))
+	accept := base64.StdEncoding.EncodeToString(h.Sum(nil))
+	resp := "HTTP/1.1 101 Switching Protocols\r\n" +
+		"Upgrade: websocket\r\nConnection: Upgrade\r\n" +
+		"Sec-WebSocket-Accept: " + accept + "\r\n\r\n"
+	if _, err := io.WriteString(c, resp); err != nil {
+		_ = c.Close()
+		return
+	}
+	if fs.handler != nil {
+		fs.handler(&fakeConn{c: c, br: br})
+	}
+}
+
+// readClientFrame reads one masked client text frame and returns the
+// unmasked payload. Control frames are skipped (Close ends the read).
+func (fc *fakeConn) readClientFrame() ([]byte, error) {
+	for {
+		var hdr [2]byte
+		if _, err := io.ReadFull(fc.br, hdr[:]); err != nil {
+			return nil, err
+		}
+		opcode := hdr[0] & 0x0f
+		masked := hdr[1]&0x80 != 0
+		plen := int64(hdr[1] & 0x7f)
+		switch plen {
+		case 126:
+			var ext [2]byte
+			if _, err := io.ReadFull(fc.br, ext[:]); err != nil {
+				return nil, err
+			}
+			plen = int64(binary.BigEndian.Uint16(ext[:]))
+		case 127:
+			var ext [8]byte
+			if _, err := io.ReadFull(fc.br, ext[:]); err != nil {
+				return nil, err
+			}
+			plen = int64(binary.BigEndian.Uint64(ext[:]))
+		}
+		var mask [4]byte
+		if masked {
+			if _, err := io.ReadFull(fc.br, mask[:]); err != nil {
+				return nil, err
+			}
+		}
+		body := make([]byte, plen)
+		if _, err := io.ReadFull(fc.br, body); err != nil {
+			return nil, err
+		}
+		if masked {
+			for i := range body {
+				body[i] ^= mask[i&3]
+			}
+		}
+		switch opcode {
+		case 0x8: // close
+			return nil, io.EOF
+		case 0x9, 0xA: // ping/pong — ignore
+			continue
+		default:
+			return body, nil
+		}
+	}
+}
+
+// writeText writes an unmasked server->client text frame.
+func (fc *fakeConn) writeText(payload []byte) error {
+	hdr := []byte{0x81}
+	n := len(payload)
+	switch {
+	case n <= 125:
+		hdr = append(hdr, byte(n))
+	case n <= 0xffff:
+		hdr = append(hdr, 126, 0, 0)
+		binary.BigEndian.PutUint16(hdr[len(hdr)-2:], uint16(n))
+	default:
+		hdr = append(hdr, 127)
+		ext := make([]byte, 8)
+		binary.BigEndian.PutUint64(ext, uint64(n))
+		hdr = append(hdr, ext...)
+	}
+	if _, err := fc.c.Write(hdr); err != nil {
+		return err
+	}
+	_, err := fc.c.Write(payload)
+	return err
+}
+
+// writePing writes a server->client ping (control frame, handled inline by
+// the client's ws.Conn and never surfaced to the consumer dispatcher).
+func (fc *fakeConn) writePing() error {
+	_, err := fc.c.Write([]byte{0x89, 0})
+	return err
+}
+
+// writeBinary writes a server->client BINARY frame. Cerebrum never speaks
+// binary; the consumer readLoop must drop it (and log) rather than decode.
+func (fc *fakeConn) writeBinary(payload []byte) error {
+	hdr := []byte{0x82, byte(len(payload))} // FIN + opcode 0x2, len <=125
+	if _, err := fc.c.Write(hdr); err != nil {
+		return err
+	}
+	_, err := fc.c.Write(payload)
+	return err
+}
+
+// mtidOf extracts the MTID="..." attribute value from a raw client frame
+// so canned replies can echo the right mtid.
+func mtidOf(frame []byte) string {
+	return attrOf(frame, "MTID")
+}
+
+func attrOf(frame []byte, key string) string {
+	s := string(frame)
+	needle := key + `="`
+	i := indexFold(s, needle)
+	if i < 0 {
+		return ""
+	}
+	i += len(needle)
+	j := i
+	for j < len(s) && s[j] != '"' {
+		j++
+	}
+	if j >= len(s) {
+		return ""
+	}
+	return s[i:j]
+}
+
+// indexFold is a tiny ASCII case-insensitive substring search (frames use
+// UPPERCASE keys; tests sometimes assert on them generically).
+func indexFold(s, sub string) int {
+	if sub == "" {
+		return 0
+	}
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if eqFold(s[i:i+len(sub)], sub) {
+			return i
+		}
+	}
+	return -1
+}
+
+func eqFold(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		ca, cb := a[i], b[i]
+		if 'a' <= ca && ca <= 'z' {
+			ca -= 32
+		}
+		if 'a' <= cb && cb <= 'z' {
+			cb -= 32
+		}
+		if ca != cb {
+			return false
+		}
+	}
+	return true
+}
+
+// serveLoginThen runs the standard login handshake (read one LOGIN, reply
+// LOGIN_REPLY) then hands off to next with the same fakeConn. Used by tests
+// that need a logged-in session before exercising another verb.
+func serveLoginThen(fc *fakeConn, apiVer string, next func(*fakeConn)) {
+	frame, err := fc.readClientFrame()
+	if err != nil {
+		return
+	}
+	mtid := mtidOf(frame)
+	_ = fc.writeText([]byte(`<LOGIN_REPLY MTID="` + mtid + `" API_VER="` + apiVer + `"/>`))
+	if next != nil {
+		next(fc)
+	}
+}
+
+// drainClient keeps reading (and discarding) client frames until the
+// connection closes — lets a handler stay alive while the test issues
+// several requests it answers inline via a callback.
+func drainClient(fc *fakeConn, onFrame func(frame []byte) (reply []byte, ok bool)) {
+	for {
+		frame, err := fc.readClientFrame()
+		if err != nil {
+			return
+		}
+		reply, ok := onFrame(frame)
+		if !ok {
+			return
+		}
+		if reply != nil {
+			if err := fc.writeText(reply); err != nil {
+				return
+			}
+		}
+	}
+}
+
+// ackFor builds an <ACK MTID="…"/> for the given client frame.
+func ackFor(frame []byte) []byte {
+	return []byte(`<ACK MTID="` + mtidOf(frame) + `"/>`)
+}
+
+// nackFor builds an <NACK> reply with the given error / error_code.
+func nackFor(frame []byte, errName string, code int) []byte {
+	return []byte(`<NACK MTID="` + mtidOf(frame) + `" ERROR="` + errName + `" ERROR_CODE="` + itoa(code) + `"/>`)
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var b [12]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		b[i] = '-'
+	}
+	return string(b[i:])
+}
+
+// waitFor polls cond until true or the deadline; fails the test otherwise.
+func waitFor(t *testing.T, d time.Duration, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("waitFor timed out: %s", msg)
+}

--- a/internal/cerebrum-nb/consumer/session.go
+++ b/internal/cerebrum-nb/consumer/session.go
@@ -387,19 +387,23 @@ func (s *Session) readLoop() {
 func (s *Session) dispatch(f *codec.Frame) {
 	// 1. Try to match an in-flight request by mtid.
 	if f.MTID != "" {
-		// Only Ack / Nack / Busy / LoginReply / PollReply are valid
-		// terminal replies for an in-flight request. ROUTING_CHANGE /
-		// CATEGORY_CHANGE / SALVO_CHANGE / DEVICE_CHANGE rows can carry
-		// the same MTID as the originating SUBSCRIBE (server streams the
-		// snapshot rows before the WILDCARD_COMPLETE + ACK), but they
-		// are notifications, not replies — routing them into the pending
-		// channel makes roundTrip return the first row instead of the
-		// ACK, which then mis-classifies the SUBSCRIBE as "unexpected
-		// ROUTING_CHANGE" failure. Send only terminal replies to the
-		// pending waiter; let everything else fan out to subscribers.
+		// Only Ack / Nack / Busy / LoginReply / PollReply /
+		// DeviceConfigResult are valid terminal replies for an in-flight
+		// request. ROUTING_CHANGE / CATEGORY_CHANGE / SALVO_CHANGE /
+		// DEVICE_CHANGE rows can carry the same MTID as the originating
+		// SUBSCRIBE (server streams the snapshot rows before the
+		// WILDCARD_COMPLETE + ACK), but they are notifications, not
+		// replies — routing them into the pending channel makes roundTrip
+		// return the first row instead of the ACK, which then
+		// mis-classifies the SUBSCRIBE as "unexpected ROUTING_CHANGE"
+		// failure. Send only terminal replies to the pending waiter; let
+		// everything else (including CONTINUE / WILDCARD_COMPLETE, which
+		// are flow-control notifications, not request terminators) fan out
+		// to subscribers.
 		switch f.Kind {
 		case codec.KindAck, codec.KindNack, codec.KindBusy,
-			codec.KindLoginReply, codec.KindPollReply:
+			codec.KindLoginReply, codec.KindPollReply,
+			codec.KindDeviceConfigResult:
 			s.mu.Lock()
 			ch, ok := s.pending[f.MTID]
 			s.mu.Unlock()
@@ -413,7 +417,26 @@ func (s *Session) dispatch(f *codec.Frame) {
 			}
 		}
 	}
-	// 2. Fan out to OnEvent subscribers.
+	// 2. Flow-control notifications (§1.4 CONTINUE after BUSY, §1.6
+	// WILDCARD_COMPLETE end-of-snapshot). These are not terminal replies
+	// to a request, so they fall through the mtid switch above and are
+	// logged here before fanning out — a listener that registered an
+	// OnEvent(KindContinue/KindWildcardComplete) still sees them.
+	switch f.Kind {
+	case codec.KindContinue:
+		// Server signals it has drained its BUSY backlog and the client
+		// may resume sending. Log + continue (no client-side throttle is
+		// modelled today); subscribers may react.
+		s.logger.Debug("flow-control: CONTINUE (resume after BUSY)", slog.String("mtid", f.MTID))
+		s.compliance.Event("cerebrum_continue_received")
+	case codec.KindWildcardComplete:
+		// End of an OBTAIN/SUBSCRIBE wildcard snapshot — every matching
+		// row has been sent. Subscribers use this as the "snapshot
+		// complete" marker.
+		s.logger.Debug("flow-control: WILDCARD_COMPLETE (snapshot done)", slog.String("mtid", f.MTID))
+	}
+
+	// 3. Fan out to OnEvent subscribers.
 	if f.Kind == codec.KindUnknown {
 		s.compliance.Event("cerebrum_unknown_notification")
 		return

--- a/internal/cerebrum-nb/consumer/session_0v16_test.go
+++ b/internal/cerebrum-nb/consumer/session_0v16_test.go
@@ -1,0 +1,303 @@
+package cerebrumnb
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"dhs/internal/cerebrum-nb/codec"
+)
+
+// ----------------------------------------------------------------------
+// 0v16 §4.5 DEVICE_CONFIGURATION — Session.DeviceConfig
+// ----------------------------------------------------------------------
+
+// deviceConfigResultFor builds the §4.5 reply envelope echoing the request's
+// MTID and wrapping a single <RESULT VALUE="…"/>.
+func deviceConfigResultFor(frame []byte, value string) []byte {
+	return []byte(`<DEVICE_CONFIGURATION MTID="` + mtidOf(frame) +
+		`" TYPE="ADD" IP_ADDRESS="10.0.0.9" DEVICE_TYPE="GENERIC"><RESULT VALUE="` +
+		value + `"/></DEVICE_CONFIGURATION>`)
+}
+
+func TestDeviceConfig_NilGuard(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) { _, _ = fc.readClientFrame() })
+	_, sess := dialFake(t, fs)
+	if _, err := sess.DeviceConfig(context.Background(), nil); err == nil ||
+		!strings.Contains(err.Error(), "nil configuration") {
+		t.Fatalf("want nil-config guard, got %v", err)
+	}
+}
+
+func TestDeviceConfig_Accepted_AllTypes(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		drainClient(fc, func(frame []byte) ([]byte, bool) {
+			return deviceConfigResultFor(frame, "ACCEPTED"), true
+		})
+	})
+	_, sess := dialFake(t, fs)
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+
+	cases := []struct {
+		name string
+		dc   *codec.DeviceConfiguration
+	}{
+		{"generic-add", &codec.DeviceConfiguration{
+			Type: codec.DeviceConfigAdd, IPAddress: "10.0.0.9", DeviceType: codec.ConfigDeviceGeneric,
+			Generic: &codec.GenericConfig{Device: "DRV", Name: "G1",
+				Protocol: &codec.ProtocolConfiguration{ConnectionType: codec.ConnTCP, PortNumber: "9000"}},
+		}},
+		{"panel-modify", &codec.DeviceConfiguration{
+			Type: codec.DeviceConfigModify, IPAddress: "10.0.0.9", DeviceName: "P1", DeviceType: codec.ConfigDevicePanel,
+			Panel: &codec.PanelConfig{Device: "DRV", Name: "P1", CPF: "cpf", PanelType: "T"},
+		}},
+		{"router-add", &codec.DeviceConfiguration{
+			Type: codec.DeviceConfigAdd, IPAddress: "10.0.0.9", DeviceType: codec.ConfigDeviceRouter,
+			Router: &codec.RouterConfig{Device: "DRV", Name: "R1", Type: "5",
+				Serial: &codec.SerialConfig{Baud: "9600"},
+				Router: &codec.RouterParams{MaxLevel: "4", MaxSource: "1024", MaxDest: "1024"}},
+		}},
+		{"snmp-add", &codec.DeviceConfiguration{
+			Type: codec.DeviceConfigAdd, IPAddress: "10.0.0.9", DeviceType: codec.ConfigDeviceSNMP,
+			SNMP: &codec.SNMPConfig{Name: "S1", Port: "161"},
+		}},
+		{"remove", &codec.DeviceConfiguration{
+			Type: codec.DeviceConfigRemove, IPAddress: "10.0.0.9", DeviceType: codec.ConfigDeviceGeneric,
+		}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			res, err := sess.DeviceConfig(ctx, c.dc)
+			if err != nil {
+				t.Fatalf("%s: %v", c.name, err)
+			}
+			if !res.Accepted || res.Value != "ACCEPTED" {
+				t.Fatalf("%s: result = %+v", c.name, res)
+			}
+		})
+	}
+}
+
+func TestDeviceConfig_Failed_FiresCompliance(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		drainClient(fc, func(frame []byte) ([]byte, bool) {
+			return deviceConfigResultFor(frame, "FAILED"), true
+		})
+	})
+	p, sess := dialFake(t, fs)
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	res, err := sess.DeviceConfig(ctx, &codec.DeviceConfiguration{
+		Type: codec.DeviceConfigAdd, IPAddress: "10.0.0.9", DeviceType: codec.ConfigDeviceSNMP,
+		SNMP: &codec.SNMPConfig{Name: "S1", Port: "161"},
+	})
+	if err != nil {
+		t.Fatalf("DeviceConfig: %v", err)
+	}
+	if res.Accepted {
+		t.Fatal("want not accepted")
+	}
+	if p.Compliance().Counts()["cerebrum_device_config_failed"] != 1 {
+		t.Fatalf("device_config_failed compliance not recorded: %+v", p.Compliance().Counts())
+	}
+}
+
+func TestDeviceConfig_EmptyResultBody(t *testing.T) {
+	// DEVICE_CONFIGURATION reply without a <RESULT> child → DeviceConfig is
+	// non-nil (parsed) but Value empty / not accepted; the method still
+	// returns it. To hit the explicit "empty RESULT body" arm we need
+	// f.DeviceConfig == nil, which the decoder never produces for a
+	// device_configuration root — so instead assert the no-RESULT reply is
+	// surfaced as a not-accepted result (the realistic shape).
+	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		drainClient(fc, func(frame []byte) ([]byte, bool) {
+			return []byte(`<DEVICE_CONFIGURATION MTID="` + mtidOf(frame) + `" TYPE="REMOVE"/>`), true
+		})
+	})
+	_, sess := dialFake(t, fs)
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	res, err := sess.DeviceConfig(ctx, &codec.DeviceConfiguration{
+		Type: codec.DeviceConfigRemove, IPAddress: "10.0.0.9", DeviceType: codec.ConfigDeviceGeneric,
+	})
+	if err != nil {
+		t.Fatalf("DeviceConfig: %v", err)
+	}
+	if res.Accepted {
+		t.Fatalf("no-RESULT reply should not be accepted: %+v", res)
+	}
+}
+
+func TestDeviceConfig_Nack(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		drainClient(fc, func(frame []byte) ([]byte, bool) {
+			return nackFor(frame, "NOT_LOGGED_IN", 6), true
+		})
+	})
+	_, sess := dialFake(t, fs)
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	_, err := sess.DeviceConfig(ctx, &codec.DeviceConfiguration{
+		Type: codec.DeviceConfigAdd, IPAddress: "10.0.0.9", DeviceType: codec.ConfigDeviceSNMP,
+		SNMP: &codec.SNMPConfig{Name: "S1", Port: "161"},
+	})
+	var ne *codec.NackError
+	if !errors.As(err, &ne) {
+		t.Fatalf("want NackError, got %v", err)
+	}
+}
+
+func TestDeviceConfig_Busy(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		drainClient(fc, func(frame []byte) ([]byte, bool) {
+			return []byte(`<BUSY MTID="` + mtidOf(frame) + `"/>`), true
+		})
+	})
+	_, sess := dialFake(t, fs)
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	_, err := sess.DeviceConfig(ctx, &codec.DeviceConfiguration{
+		Type: codec.DeviceConfigAdd, IPAddress: "10.0.0.9", DeviceType: codec.ConfigDeviceSNMP,
+		SNMP: &codec.SNMPConfig{Name: "S1", Port: "161"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "busy") {
+		t.Fatalf("want busy error, got %v", err)
+	}
+}
+
+func TestDeviceConfig_UnexpectedReply(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		drainClient(fc, func(frame []byte) ([]byte, bool) {
+			return []byte(`<POLL_REPLY MTID="` + mtidOf(frame) + `"/>`), true
+		})
+	})
+	_, sess := dialFake(t, fs)
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	_, err := sess.DeviceConfig(ctx, &codec.DeviceConfiguration{
+		Type: codec.DeviceConfigAdd, IPAddress: "10.0.0.9", DeviceType: codec.ConfigDeviceSNMP,
+		SNMP: &codec.SNMPConfig{Name: "S1", Port: "161"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "unexpected") {
+		t.Fatalf("want unexpected reply, got %v", err)
+	}
+}
+
+// TestDeviceConfig_RoundTripError drives the roundTrip-error arm (write fails
+// because the server closed the connection).
+func TestDeviceConfig_RoundTripError(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) { _ = fc.c.Close() })
+	_, sess := dialFake(t, fs)
+	waitFor(t, time.Second, func() bool {
+		c, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		_, err := sess.DeviceConfig(c, &codec.DeviceConfiguration{
+			Type: codec.DeviceConfigRemove, IPAddress: "10.0.0.9", DeviceType: codec.ConfigDeviceGeneric,
+		})
+		return err != nil
+	}, "device-config round-trip error after server close")
+}
+
+// ----------------------------------------------------------------------
+// 0v16 §1.4 CONTINUE / §1.6 WILDCARD_COMPLETE flow-control dispatch
+// ----------------------------------------------------------------------
+
+func TestDispatch_Continue_FiresComplianceAndFansOut(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		frame, err := fc.readClientFrame() // the SUBSCRIBE
+		if err != nil {
+			return
+		}
+		_ = fc.writeText(ackFor(frame))
+		// Push a free-standing CONTINUE flow-control frame.
+		_ = fc.writeText([]byte(`<CONTINUE/>`))
+		_, _ = fc.readClientFrame() // hold open
+	})
+	p, sess := dialFake(t, fs)
+
+	var continueN atomic.Int32
+	sess.OnEvent(codec.KindContinue, func(*codec.Frame) { continueN.Add(1) })
+
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	if err := sess.Subscribe(ctx, []codec.SubItem{&codec.DeviceChange{Type: "LIST"}}); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	waitFor(t, 2*time.Second, func() bool {
+		return continueN.Load() == 1 && p.Compliance().Counts()["cerebrum_continue_received"] == 1
+	}, "CONTINUE fan-out + compliance")
+}
+
+func TestDispatch_WildcardComplete_FansOut(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		frame, err := fc.readClientFrame() // the SUBSCRIBE
+		if err != nil {
+			return
+		}
+		_ = fc.writeText(ackFor(frame))
+		// Push the end-of-snapshot marker carrying the SUBSCRIBE mtid.
+		_ = fc.writeText([]byte(`<WILDCARD_COMPLETE MTID="` + mtidOf(frame) + `"/>`))
+		_, _ = fc.readClientFrame() // hold open
+	})
+	_, sess := dialFake(t, fs)
+
+	var doneN atomic.Int32
+	sess.OnEvent(codec.KindWildcardComplete, func(*codec.Frame) { doneN.Add(1) })
+
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	if err := sess.Subscribe(ctx, []codec.SubItem{&codec.DeviceChange{Type: "LIST"}}); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	waitFor(t, 2*time.Second, func() bool { return doneN.Load() == 1 }, "WILDCARD_COMPLETE snapshot marker")
+}
+
+// ----------------------------------------------------------------------
+// 0v16 §5.5 datastore obtain DATA body surfaced through ObtainDatastore
+// ----------------------------------------------------------------------
+
+func TestObtainDatastore_DataBody(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		frame, err := fc.readClientFrame() // the OBTAIN
+		if err != nil {
+			return
+		}
+		_ = fc.writeText(ackFor(frame))
+		// Obtain reply with a <DATA> body (§5.5.1).
+		_ = fc.writeText([]byte(`<DATASTORE_CHANGE TYPE="FILE" AVAILABLE="1"><DATA><ENTRY KEY="a" VALUE="1"/></DATA></DATASTORE_CHANGE>`))
+		_, _ = fc.readClientFrame() // hold open
+	})
+	_, sess := dialFake(t, fs)
+
+	got := make(chan *codec.DatastoreChange, 1)
+	sess.OnEvent(codec.KindDatastoreChange, func(f *codec.Frame) {
+		if f.Datastore != nil {
+			select {
+			case got <- f.Datastore:
+			default:
+			}
+		}
+	})
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	if err := sess.ObtainDatastore(ctx, "path/to/store"); err != nil {
+		t.Fatalf("ObtainDatastore: %v", err)
+	}
+	select {
+	case ds := <-got:
+		if !ds.Available {
+			t.Fatal("want available")
+		}
+		// The decoder case-folds child element names, so <ENTRY> renders
+		// back as <entry …/>. Assert on the lowercased form + the values.
+		if !strings.Contains(strings.ToLower(ds.Data), "entry") || !strings.Contains(ds.Data, `value="1"`) {
+			t.Fatalf("DATA body not surfaced: %q", ds.Data)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no datastore reply with DATA body")
+	}
+}

--- a/internal/cerebrum-nb/consumer/session_edge_test.go
+++ b/internal/cerebrum-nb/consumer/session_edge_test.go
@@ -1,0 +1,221 @@
+package cerebrumnb
+
+import (
+	"context"
+	"net"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"dhs/internal/cerebrum-nb/codec"
+)
+
+// nackAll answers every client frame with a NACK so roundTrip returns the
+// NACK as a transport-level error (the *roundTrip-error* arm, distinct from
+// the unexpected-kind arm exercised elsewhere).
+func nackAll(errName string, code int) func(*fakeConn) {
+	return func(fc *fakeConn) {
+		drainClient(fc, func(frame []byte) ([]byte, bool) {
+			return nackFor(frame, errName, code), true
+		})
+	}
+}
+
+func TestSubscribeObtainUnsub_RoundTripError(t *testing.T) {
+	fs := newFakeCerebrum(t, nackAll("ONE_OR_MORE_EVENTS_INVALID", 9))
+	_, sess := dialFake(t, fs)
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	if err := sess.Subscribe(ctx, []codec.SubItem{&codec.DeviceChange{Type: "LIST"}}); err == nil {
+		t.Fatal("subscribe: want NACK error")
+	}
+	if err := sess.Obtain(ctx, []codec.SubItem{&codec.DeviceChange{Type: "LIST"}}); err == nil {
+		t.Fatal("obtain: want NACK error")
+	}
+	if err := sess.UnsubscribeAll(ctx); err == nil {
+		t.Fatal("unsubscribe_all: want NACK error")
+	}
+	if err := sess.Unsubscribe(ctx, []codec.SubItem{&codec.DeviceChange{Type: "LIST"}}); err == nil {
+		t.Fatal("unsubscribe: want NACK error")
+	}
+}
+
+func TestRecordNack_NilGuard(t *testing.T) {
+	s := &Session{compliance: &Profile{}}
+	s.recordNack(nil) // must not panic; no count recorded
+	if len(s.compliance.Counts()) != 0 {
+		t.Fatalf("nil nack should record nothing, got %+v", s.compliance.Counts())
+	}
+}
+
+func TestLogin_UnexpectedReply(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		frame, err := fc.readClientFrame()
+		if err != nil {
+			return
+		}
+		// Reply with ACK instead of LOGIN_REPLY → unexpected-kind arm.
+		_ = fc.writeText(ackFor(frame))
+	})
+	p := NewPlugin(nil)
+	p.Username, p.Password = "u", "p"
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	err := p.Connect(ctx, fs.host(), fs.port())
+	if err == nil || !strings.Contains(err.Error(), "unexpected reply") {
+		t.Fatalf("want login unexpected reply, got %v", err)
+	}
+}
+
+func TestConnect_TLSPath(t *testing.T) {
+	// UseTLS=true drives the wss:// scheme branch in Connect AND the
+	// useTLS+insecure TLSConfig branch in newSession. The plain-TCP fake
+	// server speaks no TLS, so the dial fails at the TLS handshake — but
+	// only after both target branches have executed.
+	fs := newFakeCerebrum(t, func(fc *fakeConn) { _, _ = fc.readClientFrame() })
+	p := NewPlugin(nil)
+	p.UseTLS = true
+	p.InsecureSkipVerify = true
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err := p.Connect(ctx, fs.host(), fs.port())
+	if err == nil || !strings.Contains(err.Error(), "ws dial") {
+		t.Fatalf("want ws dial (tls) error, got %v", err)
+	}
+}
+
+func TestGetDeviceInfo_PollError(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		// Read the POLL, never reply → Poll times out.
+		_, _ = fc.readClientFrame()
+		time.Sleep(300 * time.Millisecond)
+	})
+	p, _ := dialFake(t, fs)
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	if _, err := p.GetDeviceInfo(ctx); err == nil {
+		t.Fatal("want GetDeviceInfo poll error")
+	}
+}
+
+func TestReadLoop_DropsBinary(t *testing.T) {
+	// The server waits for the client's SUBSCRIBE (so the test has already
+	// registered its OnEvent callback) before pushing a BINARY frame — which
+	// the readLoop must drop — followed by a TEXT routing event.
+	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		frame, err := fc.readClientFrame()
+		if err != nil {
+			return
+		}
+		_ = fc.writeText(ackFor(frame))
+		_ = fc.writeBinary([]byte("not-xml-binary"))
+		_ = fc.writeText([]byte(`<ROUTING_CHANGE TYPE="ROUTE" DEST_ID="1"/>`))
+		_, _ = fc.readClientFrame() // hold open until the client disconnects
+	})
+	_, sess := dialFake(t, fs)
+	var seen atomic.Int32
+	mu := make(chan struct{}, 1)
+	sess.OnEvent(codec.KindRoutingChange, func(*codec.Frame) {
+		seen.Add(1)
+		select {
+		case mu <- struct{}{}:
+		default:
+		}
+	})
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	if err := sess.Subscribe(ctx, []codec.SubItem{&codec.DeviceChange{Type: "LIST"}}); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	select {
+	case <-mu:
+	case <-time.After(2 * time.Second):
+		t.Fatal("routing event after binary not received")
+	}
+	if seen.Load() != 1 {
+		t.Fatalf("seen = %d, want 1 (binary dropped)", seen.Load())
+	}
+}
+
+// TestReadLoop_StopRXBranch deterministically drives the top-of-loop
+// `case <-s.stopRX: return` arm in readLoop: stopRX is closed BEFORE the
+// loop runs, so the first select returns immediately without ever touching
+// the (nil) conn. This branch is otherwise scheduling-dependent (close()
+// normally makes ReadMessage error first), so the explicit drive keeps the
+// 100% floor stable.
+func TestReadLoop_StopRXBranch(t *testing.T) {
+	s := &Session{
+		compliance: &Profile{},
+		pending:    map[string]chan *codec.Frame{},
+		stopRX:     make(chan struct{}),
+	}
+	close(s.stopRX)
+	done := make(chan struct{})
+	go func() { s.readLoop(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("readLoop did not return on pre-closed stopRX")
+	}
+}
+
+func TestSplitURLHostPort_ParseError(t *testing.T) {
+	// A control character makes url.Parse fail → ("", 0).
+	h, p := splitURLHostPort("ws://\x7f\x00bad")
+	if h != "" || p != 0 {
+		t.Fatalf("parse-error case: got (%q,%d), want empty", h, p)
+	}
+}
+
+// TestDispatch_ChannelFull drives the defensive "dropped reply (channel
+// full)" arm: a pending mtid waiter already has a buffered reply, and a
+// second terminal reply for the same mtid arrives before the waiter drains.
+func TestDispatch_ChannelFull(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) { _, _ = fc.readClientFrame() })
+	_, sess := dialFake(t, fs)
+
+	const mtid = "777"
+	ch := make(chan *codec.Frame, 1)
+	sess.mu.Lock()
+	sess.pending[mtid] = ch
+	sess.mu.Unlock()
+
+	first := &codec.Frame{Kind: codec.KindAck, MTID: mtid}
+	second := &codec.Frame{Kind: codec.KindAck, MTID: mtid}
+	sess.dispatch(first)  // fills the buffered channel
+	sess.dispatch(second) // hits the channel-full default arm (must not block)
+
+	select {
+	case got := <-ch:
+		if got != first {
+			t.Fatal("expected the first frame to be the buffered one")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no frame buffered")
+	}
+	// Clean up the manual pending entry.
+	sess.mu.Lock()
+	delete(sess.pending, mtid)
+	sess.mu.Unlock()
+}
+
+// TestReadLoop_DebugLogOnError exercises the non-EOF read-error debug-log
+// branch in readLoop by aborting the TCP connection mid-stream.
+func TestReadLoop_DebugLogOnError(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		// Write a partial frame header then RST the socket so the client's
+		// next ReadFull returns a non-EOF error.
+		_, _ = fc.c.Write([]byte{0x81, 0x05}) // declares 5-byte text, sends none
+		if tcp, ok := fc.c.(*net.TCPConn); ok {
+			_ = tcp.SetLinger(0)
+		}
+		_ = fc.c.Close()
+	})
+	p, _ := dialFake(t, fs)
+	// The readLoop will exit on the error; give it a moment. We can't assert
+	// the log line directly, but exercising the branch is the goal and the
+	// session must remain usable for Disconnect.
+	time.Sleep(150 * time.Millisecond)
+	_ = p.Disconnect()
+}

--- a/internal/cerebrum-nb/consumer/session_ws_test.go
+++ b/internal/cerebrum-nb/consumer/session_ws_test.go
@@ -1,0 +1,691 @@
+package cerebrumnb
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"dhs/internal/cerebrum-nb/codec"
+	"dhs/internal/consumer"
+)
+
+func conValReq(path string) consumer.ValueRequest { return consumer.ValueRequest{Path: path} }
+func conStrVal(s string) consumer.Value           { return consumer.Value{Kind: consumer.KindString, Str: s} }
+func conIntVal() consumer.Value                    { return consumer.Value{Kind: consumer.KindInt, Int: 1} }
+
+func ctx2s(t *testing.T) (context.Context, context.CancelFunc) {
+	t.Helper()
+	return context.WithTimeout(context.Background(), 2*time.Second)
+}
+
+// dialFake connects a Plugin to a fakeCerebrum WITHOUT auto-login (no
+// credentials). Returns the plugin + live session.
+func dialFake(t *testing.T, fs *fakeCerebrum) (*Plugin, *Session) {
+	t.Helper()
+	p := NewPlugin(nil)
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	if err := p.Connect(ctx, fs.host(), fs.port()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Disconnect() })
+	return p, p.Session()
+}
+
+// ----------------------------------------------------------------------
+// Connect / Login / Disconnect
+// ----------------------------------------------------------------------
+
+func TestConnect_NoLogin(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		// No credentials → Connect does not LOGIN; just hold the conn.
+		_, _ = fc.readClientFrame()
+	})
+	p, sess := dialFake(t, fs)
+	if sess == nil {
+		t.Fatal("nil session")
+	}
+	if sess.LoggedIn() {
+		t.Fatal("should not be logged in without creds")
+	}
+	h, port := sess.RemoteHostPort()
+	if h != fs.host() || port != fs.port() {
+		t.Fatalf("RemoteHostPort = %s:%d", h, port)
+	}
+	_ = p.Disconnect()
+	_ = p.Disconnect() // idempotent
+}
+
+func TestConnect_AutoLogin_Success(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		serveLoginThen(fc, "0.16", func(fc *fakeConn) { _, _ = fc.readClientFrame() })
+	})
+	p := NewPlugin(nil)
+	p.Username = "admin"
+	p.Password = "s3cr3t"
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	if err := p.Connect(ctx, fs.host(), fs.port()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = p.Disconnect() }()
+	sess := p.Session()
+	if !sess.LoggedIn() {
+		t.Fatal("expected logged in")
+	}
+	if sess.APIVersion() != "0.16" {
+		t.Fatalf("api_ver = %q", sess.APIVersion())
+	}
+	if sess.APIVersionMajor() != 0 {
+		t.Fatalf("api major = %d", sess.APIVersionMajor())
+	}
+}
+
+func TestConnect_AlreadyConnected(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) { _, _ = fc.readClientFrame() })
+	p, _ := dialFake(t, fs)
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	err := p.Connect(ctx, fs.host(), fs.port())
+	if err == nil || !strings.Contains(err.Error(), "already connected") {
+		t.Fatalf("want already-connected error, got %v", err)
+	}
+}
+
+func TestConnect_AutoLogin_Nack(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		frame, err := fc.readClientFrame()
+		if err != nil {
+			return
+		}
+		_ = fc.writeText(nackFor(frame, "INVALID_USER_OR_PASS", 0))
+	})
+	p := NewPlugin(nil)
+	p.Username = "x"
+	p.Password = "y"
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	err := p.Connect(ctx, fs.host(), fs.port())
+	if err == nil || !strings.Contains(err.Error(), "login") {
+		t.Fatalf("want login nack error, got %v", err)
+	}
+}
+
+func TestConnect_DialError(t *testing.T) {
+	p := NewPlugin(nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	// Port 0 → DefaultPort 40007 on localhost, nothing listening.
+	err := p.Connect(ctx, "127.0.0.1", 0)
+	if err == nil || !strings.Contains(err.Error(), "ws dial") {
+		t.Fatalf("want ws dial error, got %v", err)
+	}
+}
+
+func TestPlugin_Login_Guards(t *testing.T) {
+	p := NewPlugin(nil)
+	if err := p.Login(context.Background()); err == nil || !strings.Contains(err.Error(), "not connected") {
+		t.Fatalf("want not-connected, got %v", err)
+	}
+	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		serveLoginThen(fc, "0.16", func(fc *fakeConn) { _, _ = fc.readClientFrame() })
+	})
+	p, _ = dialFake(t, fs)
+	if err := p.Login(context.Background()); err == nil || !strings.Contains(err.Error(), "must be set") {
+		t.Fatalf("want creds-required, got %v", err)
+	}
+	p.Username, p.Password = "a", "b"
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	if err := p.Login(ctx); err != nil {
+		t.Fatalf("explicit Login: %v", err)
+	}
+}
+
+// ----------------------------------------------------------------------
+// Poll
+// ----------------------------------------------------------------------
+
+func TestPoll_Active(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		drainClient(fc, func(frame []byte) ([]byte, bool) {
+			return []byte(`<POLL_REPLY MTID="` + mtidOf(frame) +
+				`" CONNECTED_SERVER_ACTIVE="1" PRIMARY_SERVER_STATE="1" SECONDARY_SERVER_STATE="0"/>`), true
+		})
+	})
+	_, sess := dialFake(t, fs)
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	pr, err := sess.Poll(ctx)
+	if err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	if !pr.ConnectedServerActive || !pr.PrimaryServerState || pr.SecondaryServerState {
+		t.Fatalf("poll flags: %+v", pr)
+	}
+}
+
+func TestPoll_InactiveFiresCompliance(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		drainClient(fc, func(frame []byte) ([]byte, bool) {
+			return []byte(`<POLL_REPLY MTID="` + mtidOf(frame) + `" CONNECTED_SERVER_ACTIVE="0"/>`), true
+		})
+	})
+	p, sess := dialFake(t, fs)
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	if _, err := sess.Poll(ctx); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	if p.Compliance().Counts()["cerebrum_server_inactive"] != 1 {
+		t.Fatalf("expected cerebrum_server_inactive, got %+v", p.Compliance().Counts())
+	}
+}
+
+func TestPoll_UnexpectedReply(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		drainClient(fc, func(frame []byte) ([]byte, bool) { return ackFor(frame), true })
+	})
+	_, sess := dialFake(t, fs)
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	if _, err := sess.Poll(ctx); err == nil || !strings.Contains(err.Error(), "unexpected") {
+		t.Fatalf("want unexpected reply, got %v", err)
+	}
+}
+
+func TestPoll_Timeout(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) { _, _ = fc.readClientFrame() }) // never replies
+	_, sess := dialFake(t, fs)
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	if _, err := sess.Poll(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("want deadline exceeded, got %v", err)
+	}
+}
+
+// ----------------------------------------------------------------------
+// Action: ACK / NACK / BUSY
+// ----------------------------------------------------------------------
+
+func actionFakeReplying(reply func(frame []byte) []byte) func(*fakeConn) {
+	return func(fc *fakeConn) {
+		drainClient(fc, func(frame []byte) ([]byte, bool) { return reply(frame), true })
+	}
+}
+
+func TestAction_Ack(t *testing.T) {
+	fs := newFakeCerebrum(t, actionFakeReplying(func(f []byte) []byte { return ackFor(f) }))
+	_, sess := dialFake(t, fs)
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	if err := sess.SetDeviceValue(ctx, "DEV", "SUB", "OBJ", "42"); err != nil {
+		t.Fatalf("SetDeviceValue: %v", err)
+	}
+}
+
+func TestAction_Nack_RecordsCompliance(t *testing.T) {
+	fs := newFakeCerebrum(t, actionFakeReplying(func(f []byte) []byte {
+		return nackFor(f, "ONE_OR_MORE_ACTIONS_INVALID", 8)
+	}))
+	p, sess := dialFake(t, fs)
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	err := sess.SetDeviceValue(ctx, "DEV", "SUB", "OBJ", "42")
+	var ne *codec.NackError
+	if !errors.As(err, &ne) {
+		t.Fatalf("want NackError, got %v", err)
+	}
+	if p.Compliance().Counts()["cerebrum_nack_one_or_more_actions_invalid"] != 1 {
+		t.Fatalf("nack compliance not recorded: %+v", p.Compliance().Counts())
+	}
+}
+
+func TestAction_Nack_UnknownCode(t *testing.T) {
+	fs := newFakeCerebrum(t, actionFakeReplying(func(f []byte) []byte {
+		// Bogus error name + non-resolving code → ID stays -1.
+		return []byte(`<NACK MTID="` + mtidOf(f) + `" ERROR="WAT" ERROR_CODE="zzz"/>`)
+	}))
+	p, sess := dialFake(t, fs)
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	_ = sess.SetDeviceValue(ctx, "D", "S", "O", "v")
+	if p.Compliance().Counts()["cerebrum_nack_unknown"] != 1 {
+		t.Fatalf("want cerebrum_nack_unknown, got %+v", p.Compliance().Counts())
+	}
+}
+
+func TestAction_Busy(t *testing.T) {
+	fs := newFakeCerebrum(t, actionFakeReplying(func(f []byte) []byte {
+		return []byte(`<BUSY MTID="` + mtidOf(f) + `"/>`)
+	}))
+	p, sess := dialFake(t, fs)
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	err := sess.SetDeviceValue(ctx, "D", "S", "O", "v")
+	if err == nil || !strings.Contains(err.Error(), "busy") {
+		t.Fatalf("want busy error, got %v", err)
+	}
+	if p.Compliance().Counts()["cerebrum_busy_received"] != 1 {
+		t.Fatalf("busy compliance not recorded: %+v", p.Compliance().Counts())
+	}
+}
+
+func TestAction_UnexpectedReply(t *testing.T) {
+	fs := newFakeCerebrum(t, actionFakeReplying(func(f []byte) []byte {
+		return []byte(`<POLL_REPLY MTID="` + mtidOf(f) + `"/>`)
+	}))
+	_, sess := dialFake(t, fs)
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	err := sess.SetDeviceValue(ctx, "D", "S", "O", "v")
+	if err == nil || !strings.Contains(err.Error(), "unexpected") {
+		t.Fatalf("want unexpected reply, got %v", err)
+	}
+}
+
+// ----------------------------------------------------------------------
+// New write-action wrappers (all map to existing codec encoders)
+// ----------------------------------------------------------------------
+
+func TestActionWrappers_AllAck(t *testing.T) {
+	fs := newFakeCerebrum(t, actionFakeReplying(func(f []byte) []byte { return ackFor(f) }))
+	_, sess := dialFake(t, fs)
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	tgt := DefaultRouteTarget()
+
+	cases := []struct {
+		name string
+		call func() error
+	}{
+		{"lock", func() error { return sess.Lock(ctx, "DEST_LOCK", codec.LockProtect, tgt, "", "60", "1", "") }},
+		{"unlock", func() error { return sess.Lock(ctx, "DEST_LOCK", codec.LockRelease, tgt, "", "60", "1", "") }},
+		{"set-mnemonic", func() error { return sess.SetMnemonic(ctx, "DEST_MNE", tgt, "", "60", "1", "CAM1", "") }},
+		{"set-tags", func() error { return sess.SetTags(ctx, "RM_DEST_TAGS", tgt, "", "60", "live,hd") }},
+		{"salvo-run", func() error { return sess.Salvo(ctx, "RUN", "G", "I", "", "") }},
+		{"salvo-save", func() error { return sess.Salvo(ctx, "SAVE", "G", "I", "", "desc") }},
+		{"salvo-rename", func() error { return sess.Salvo(ctx, "RENAME", "G", "I", "NEW", "") }},
+		{"salvo-delete", func() error { return sess.Salvo(ctx, "DELETE", "G", "I", "", "") }},
+		{"category-create", func() error {
+			return sess.Category(ctx, &codec.CategoryAction{Type: "CREATE", Category: "C", Name: "N"})
+		}},
+		{"category-modify", func() error {
+			return sess.Category(ctx, &codec.CategoryAction{Type: "MODIFY_ITEM", Category: "C", Index: "1"})
+		}},
+		{"category-delete", func() error {
+			return sess.Category(ctx, &codec.CategoryAction{Type: "DELETE", Category: "C"})
+		}},
+		{"obtain-datastore", func() error { return sess.ObtainDatastore(ctx, "path/to/file") }},
+		{"subscribe-datastore", func() error { return sess.SubscribeDatastore(ctx, "path/to/file") }},
+		{"unsubscribe", func() error {
+			return sess.Unsubscribe(ctx, []codec.SubItem{&codec.DeviceChange{Type: "LIST"}})
+		}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if err := c.call(); err != nil {
+				t.Fatalf("%s: %v", c.name, err)
+			}
+		})
+	}
+}
+
+func TestCategory_NilGuard(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) { _, _ = fc.readClientFrame() })
+	_, sess := dialFake(t, fs)
+	if err := sess.Category(context.Background(), nil); err == nil ||
+		!strings.Contains(err.Error(), "nil action") {
+		t.Fatalf("want nil-action guard, got %v", err)
+	}
+}
+
+func TestUnsubscribe_Unexpected(t *testing.T) {
+	fs := newFakeCerebrum(t, actionFakeReplying(func(f []byte) []byte {
+		return []byte(`<POLL_REPLY MTID="` + mtidOf(f) + `"/>`)
+	}))
+	_, sess := dialFake(t, fs)
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	err := sess.Unsubscribe(ctx, []codec.SubItem{&codec.DeviceChange{Type: "LIST"}})
+	if err == nil || !strings.Contains(err.Error(), "unexpected") {
+		t.Fatalf("want unexpected, got %v", err)
+	}
+}
+
+// ----------------------------------------------------------------------
+// Subscribe / Obtain / UnsubscribeAll happy + error paths
+// ----------------------------------------------------------------------
+
+func TestSubscribeObtainUnsubscribeAll(t *testing.T) {
+	fs := newFakeCerebrum(t, actionFakeReplying(func(f []byte) []byte { return ackFor(f) }))
+	_, sess := dialFake(t, fs)
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	if err := sess.Subscribe(ctx, []codec.SubItem{&codec.DeviceChange{Type: "LIST"}}); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	if err := sess.Obtain(ctx, []codec.SubItem{&codec.DeviceChange{Type: "LIST"}}); err != nil {
+		t.Fatalf("obtain: %v", err)
+	}
+	if err := sess.UnsubscribeAll(ctx); err != nil {
+		t.Fatalf("unsubscribe_all: %v", err)
+	}
+}
+
+func TestSubscribe_Unexpected(t *testing.T) {
+	fs := newFakeCerebrum(t, actionFakeReplying(func(f []byte) []byte {
+		return []byte(`<BUSY MTID="` + mtidOf(f) + `"/>`)
+	}))
+	_, sess := dialFake(t, fs)
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	if err := sess.Subscribe(ctx, []codec.SubItem{&codec.DeviceChange{Type: "LIST"}}); err == nil ||
+		!strings.Contains(err.Error(), "unexpected") {
+		t.Fatalf("want unexpected, got %v", err)
+	}
+	if err := sess.Obtain(ctx, []codec.SubItem{&codec.DeviceChange{Type: "LIST"}}); err == nil {
+		t.Fatal("want obtain unexpected error")
+	}
+	if err := sess.UnsubscribeAll(ctx); err == nil {
+		t.Fatal("want unsubscribe_all unexpected error")
+	}
+}
+
+// ----------------------------------------------------------------------
+// Event dispatch + OnEvent + Cancel + listen (CONTINUE / snapshot)
+// ----------------------------------------------------------------------
+
+func TestDispatch_EventFanout_AndCancel(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		frame, err := fc.readClientFrame() // the SUBSCRIBE
+		if err != nil {
+			return
+		}
+		_ = fc.writeText(ackFor(frame))
+		// Stream a DEVICE_CHANGE snapshot row carrying the SUBSCRIBE mtid,
+		// then a free-standing ROUTING_CHANGE event.
+		_ = fc.writeText([]byte(`<DEVICE_CHANGE MTID="` + mtidOf(frame) + `" TYPE="LIST"><DEVICE IP="10.0.0.1"><INSTANCE DEVICE_TYPE="Router"/></DEVICE></DEVICE_CHANGE>`))
+		_ = fc.writeText([]byte(`<ROUTING_CHANGE TYPE="ROUTE" DEST_ID="60" SRCE_ID="61" LEVEL_ID="1"/>`))
+		_, _ = fc.readClientFrame() // hold open until the client disconnects
+	})
+	p, sess := dialFake(t, fs)
+
+	var devN, routeN atomic.Int32
+	// Active subscribers: the device sub reliably fires on the snapshot row
+	// (mtid-matched but non-terminal → fans out), the routing sub on the
+	// free-standing event.
+	sess.OnEvent(codec.KindDeviceChange, func(*codec.Frame) { devN.Add(1) })
+	sess.OnEvent(codec.KindRoutingChange, func(*codec.Frame) { routeN.Add(1) })
+	// A wildcard subscriber that we cancel BEFORE subscribing must NOT fire —
+	// this deterministically exercises Cancel's removal path (plus the
+	// nil-safe early return) without racing the event stream.
+	var cancelled atomic.Int32
+	wc := sess.OnEvent(codec.KindUnknown, func(*codec.Frame) { cancelled.Add(1) })
+	sess.Cancel(wc)
+	sess.Cancel(nil) // nil-safe
+
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	if err := sess.Subscribe(ctx, []codec.SubItem{&codec.DeviceChange{Type: "LIST"}}); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	// Both the device snapshot row and the routing event must reach their
+	// subscribers; wait on both so the fan-out path is covered regardless
+	// of scheduling.
+	waitFor(t, 2*time.Second, func() bool { return devN.Load() == 1 && routeN.Load() == 1 }, "both events")
+	if cancelled.Load() != 0 {
+		t.Fatalf("cancelled subscriber fired %d times", cancelled.Load())
+	}
+	_ = p.Disconnect()
+}
+
+func TestDispatch_DecodeFailureCompliance(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		_ = fc.writeText([]byte("<<<not-xml")) // undecodable
+		_, _ = fc.readClientFrame()            // hold open until the client disconnects
+	})
+	p, _ := dialFake(t, fs)
+	waitFor(t, time.Second, func() bool {
+		return p.Compliance().Counts()["cerebrum_decode_failed"] >= 1
+	}, "decode_failed compliance")
+}
+
+func TestDispatch_CaseNormalizedCompliance(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		// lowercase element name → CaseChanged.
+		_ = fc.writeText([]byte(`<routing_change type="ROUTE" dest_id="1"/>`))
+		_, _ = fc.readClientFrame() // hold open until the client disconnects
+	})
+	p, sess := dialFake(t, fs)
+	sess.OnEvent(codec.KindUnknown, func(*codec.Frame) {})
+	waitFor(t, time.Second, func() bool {
+		return p.Compliance().Counts()["cerebrum_case_normalized"] >= 1
+	}, "case_normalized compliance")
+}
+
+func TestDispatch_UnknownNotificationCompliance(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		_ = fc.writeText([]byte(`<SOMETHING_ELSE FOO="1"/>`))
+		_, _ = fc.readClientFrame() // hold open until the client disconnects
+	})
+	p, _ := dialFake(t, fs)
+	waitFor(t, time.Second, func() bool {
+		return p.Compliance().Counts()["cerebrum_unknown_notification"] >= 1
+	}, "unknown_notification compliance")
+}
+
+func TestReadLoop_DropsNonText(t *testing.T) {
+	// Wait for the client's SUBSCRIBE (callback registered) before pushing a
+	// PING (handled inline by ws.Conn, never reaching dispatch) and the TEXT
+	// routing event.
+	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		frame, err := fc.readClientFrame()
+		if err != nil {
+			return
+		}
+		_ = fc.writeText(ackFor(frame))
+		_ = fc.writePing()
+		_ = fc.writeText([]byte(`<ROUTING_CHANGE TYPE="ROUTE" DEST_ID="1"/>`))
+		_, _ = fc.readClientFrame() // hold open until the client disconnects
+	})
+	_, sess := dialFake(t, fs)
+	var n atomic.Int32
+	sess.OnEvent(codec.KindRoutingChange, func(*codec.Frame) { n.Add(1) })
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	if err := sess.Subscribe(ctx, []codec.SubItem{&codec.DeviceChange{Type: "LIST"}}); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	waitFor(t, 2*time.Second, func() bool { return n.Load() == 1 }, "routing after ping")
+}
+
+// ----------------------------------------------------------------------
+// MTID reuse compliance
+// ----------------------------------------------------------------------
+
+func TestMTIDReuse_Compliance(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		// Read the first POLL but never reply, so its mtid stays in-flight.
+		_, _ = fc.readClientFrame()
+		time.Sleep(300 * time.Millisecond)
+	})
+	p, sess := dialFake(t, fs)
+
+	// Pin the allocator so the second roundTrip reuses the same mtid string.
+	sess.mtidNext.Store(5)
+	go func() {
+		c, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+		defer cancel()
+		_, _ = sess.roundTrip(c, 5, []byte(`<POLL MTID="5"/>`))
+	}()
+	// Wait until mtid 5 is registered, then fire a duplicate.
+	waitFor(t, time.Second, func() bool {
+		sess.mu.Lock()
+		_, ok := sess.pending["5"]
+		sess.mu.Unlock()
+		return ok
+	}, "mtid 5 in flight")
+
+	c2, cancel2 := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel2()
+	_, err := sess.roundTrip(c2, 5, []byte(`<POLL MTID="5"/>`))
+	if err == nil || !strings.Contains(err.Error(), "already in flight") {
+		t.Fatalf("want mtid-in-flight error, got %v", err)
+	}
+	if p.Compliance().Counts()["cerebrum_mtid_reused"] != 1 {
+		t.Fatalf("mtid reuse compliance: %+v", p.Compliance().Counts())
+	}
+}
+
+func TestRoundTrip_WriteError(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) { _ = fc.c.Close() })
+	_, sess := dialFake(t, fs)
+	// Give the server a moment to close so the write fails.
+	waitFor(t, time.Second, func() bool {
+		c, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		_, err := sess.Poll(c)
+		return err != nil && strings.Contains(err.Error(), "write")
+	}, "write error after server close")
+}
+
+// ----------------------------------------------------------------------
+// consumer.Protocol shim methods
+// ----------------------------------------------------------------------
+
+func TestShim_GetDeviceInfo(t *testing.T) {
+	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		drainClient(fc, func(frame []byte) ([]byte, bool) {
+			return []byte(`<POLL_REPLY MTID="` + mtidOf(frame) + `" CONNECTED_SERVER_ACTIVE="1"/>`), true
+		})
+	})
+	p, _ := dialFake(t, fs)
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	di, err := p.GetDeviceInfo(ctx)
+	if err != nil {
+		t.Fatalf("GetDeviceInfo: %v", err)
+	}
+	if di.Port != fs.port() {
+		t.Fatalf("device info port = %d", di.Port)
+	}
+}
+
+func TestShim_NotConnectedErrors(t *testing.T) {
+	p := NewPlugin(nil)
+	ctx := context.Background()
+	if _, err := p.GetDeviceInfo(ctx); err == nil {
+		t.Fatal("GetDeviceInfo should error when not connected")
+	}
+	if _, err := p.SetValue(ctx, conValReq("x.y.z"), conStrVal("v")); err == nil {
+		t.Fatal("SetValue should error when not connected")
+	}
+	if p.Compliance() != nil {
+		t.Fatal("Compliance should be nil when not connected")
+	}
+	if p.Session() != nil {
+		t.Fatal("Session should be nil when not connected")
+	}
+}
+
+func TestShim_NotApplicable(t *testing.T) {
+	p := NewPlugin(nil)
+	if _, err := p.GetSlotInfo(context.Background(), 0); err == nil {
+		t.Fatal("GetSlotInfo should error")
+	}
+	if _, err := p.Walk(context.Background(), 0); err == nil {
+		t.Fatal("Walk should error")
+	}
+	if _, err := p.GetValue(context.Background(), conValReq("a")); err == nil {
+		t.Fatal("GetValue should error")
+	}
+	if err := p.Subscribe(conValReq("a"), nil); err == nil {
+		t.Fatal("Subscribe should error")
+	}
+	if err := p.Unsubscribe(conValReq("a")); err == nil {
+		t.Fatal("Unsubscribe should error")
+	}
+}
+
+func TestShim_SetValue(t *testing.T) {
+	fs := newFakeCerebrum(t, actionFakeReplying(func(f []byte) []byte { return ackFor(f) }))
+	p, _ := dialFake(t, fs)
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+
+	// Empty path → guard.
+	if _, err := p.SetValue(ctx, conValReq(""), conStrVal("v")); err == nil {
+		t.Fatal("empty path should error")
+	}
+	// Wrong kind → guard.
+	if _, err := p.SetValue(ctx, conValReq("a.b.c"), conIntVal()); err == nil {
+		t.Fatal("non-string value should error")
+	}
+	// Malformed path → guard from splitDevicePath.
+	if _, err := p.SetValue(ctx, conValReq("oneonly"), conStrVal("v")); err == nil {
+		t.Fatal("malformed path should error")
+	}
+	// Happy path.
+	v, err := p.SetValue(ctx, conValReq("DEV.SUB.OBJ"), conStrVal("hello"))
+	if err != nil {
+		t.Fatalf("SetValue: %v", err)
+	}
+	if v.Str != "hello" {
+		t.Fatalf("returned value = %q", v.Str)
+	}
+}
+
+func TestShim_SetValue_ActionError(t *testing.T) {
+	fs := newFakeCerebrum(t, actionFakeReplying(func(f []byte) []byte {
+		return nackFor(f, "NOT_LOGGED_IN", 6)
+	}))
+	p, _ := dialFake(t, fs)
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	if _, err := p.SetValue(ctx, conValReq("DEV.SUB.OBJ"), conStrVal("hello")); err == nil {
+		t.Fatal("want action nack error")
+	}
+}
+
+// ----------------------------------------------------------------------
+// Factory + NewPlugin
+// ----------------------------------------------------------------------
+
+func TestFactory(t *testing.T) {
+	f := &Factory{}
+	m := f.Meta()
+	if m.Name != "cerebrum-nb" || m.DefaultPort != DefaultPort {
+		t.Fatalf("meta = %+v", m)
+	}
+	if f.New(nil) == nil {
+		t.Fatal("New returned nil")
+	}
+	if NewPlugin(nil) == nil {
+		t.Fatal("NewPlugin(nil) returned nil")
+	}
+}
+
+// closeWhileReading exercises Session.close racing the readLoop EOF path.
+func TestClose_StopsReadLoop(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		defer wg.Done()
+		_, _ = fc.readClientFrame()
+		<-time.After(50 * time.Millisecond)
+	})
+	p, sess := dialFake(t, fs)
+	if err := sess.close(); err != nil && !errors.Is(err, io.EOF) {
+		t.Fatalf("close: %v", err)
+	}
+	// Second close is idempotent.
+	_ = sess.close()
+	_ = p.Disconnect()
+	wg.Wait()
+}


### PR DESCRIPTION
Completes the cerebrum-nb consumer to the full 0v16 surface (consumer 100%, codec/ws 100%, CI floors added). Consumer-only by design; tested entirely against an in-process fake WebSocket server (no live peer/emulator). Adds: Session.DeviceConfig (4.5 DEVICE_CONFIGURATION ADD/MODIFY/REMOVE for Generic/Panel/Router/SNMP + RESULT decode) + CLI device-config verb; 5-mode lock (--mode); CONTINUE + WILDCARD_COMPLETE dispatch in listen; datastore DATA body in obtain-datastore. Closes the SET_VALUE 4.4.1 gap byte-exact (p19): codec DeviceAction gains IP_ADDRESS/IS_ENUM/MODE, wired on set-value via Action. codec/ws to 100% (RFC6455 client) via loopback + transparent seams for the 2 unreachable arms. Additive only; 0v13 still decodes; compliance-on-deviation preserved (new events cerebrum_device_config_failed + cerebrum_continue_received). Verified: build/vet clean; tests pass; cover codec/consumer/ws all 100; lint 0; 10x no flakes; -race in CI. Stacked on the merged 0v16 codec (#613). Co-Authored-By Claude Opus 4.8.