### PR TITLE
ci: pin setup-go to 1.23 to match go.mod (fix toolchain-cache tar collision)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        go: ["1.22"]
+        go: ["1.23"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -130,7 +130,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.23"
 
       - name: Build
         run: go build -buildvcs=false ./...
@@ -154,7 +154,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.23"
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
@@ -175,7 +175,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.23"
 
       - name: Build all targets
         run: |


### PR DESCRIPTION
go.mod declares 'go 1.23.0' but the CI workflow pinned setup-go to 1.22, so every job auto-downloaded the go1.23.0 toolchain into the module cache; on a setup-go cache HIT that toolchain tarball was re-extracted over existing files, failing with 'tar: ...toolchain@v0.0.1-go1.23.0...: Cannot open: File exists' and (via matrix fail-fast) cancelling the other OS jobs. This recurred on #602/#612/#613/#614, forcing manual reruns. Fix: bump go-version 1.22 -> 1.23 (matching go.mod) across the test matrix, test-rhel, lint and build-all jobs, so setup-go installs 1.23 directly and no separate toolchain is downloaded/cached. Closes the recurring flake. Co-Authored-By Claude Opus 4.8.