### PR TITLE
test(ansible): cross-OS dhs_verbtest role + probel-sw08p all-verbs template + site.yml

### DIFF
--- a/ansible/playbooks/probel-sw08p-verbs.yml
+++ b/ansible/playbooks/probel-sw08p-verbs.yml
@@ -1,0 +1,464 @@
+---
+# probel-sw08p-verbs.yml — the CROSS-OS verb-matrix smoke play for Probel
+# SW-P-08 / SW-P-88. This is the TEMPLATE the other 7 connectors copy: it
+# carries ONLY data (the producer serve args + the full consumer verb list)
+# and delegates ALL execution + every per-OS decision to the dhs_verbtest
+# role. There is no `command` vs `win_command` here, no wait_for vs
+# win_wait_for, no .exe handling — the role owns all of that (ADR-0016).
+#
+# The role:
+#   1. go build -o <repo>/bin/dhs[.exe] ./cmd/dhs   (portable; ext per-OS)
+#   2. start `dhs producer probel-sw08p serve --tree matrix_tree.json ...`
+#      fire-and-forget (async/poll:0, bounded TTL → async reaper tears it
+#      down, no manual kill; net change = zero → ADR-0025 idempotent)
+#   3. wait_for the loopback port
+#   4. drive every verb below + assert on stdout substrings
+#
+# Producer serve flags are sourced from cmd/dhs/cmd_producer.go:
+#   --tree   line 45   --port line 48   --host line 49   --log-level line 51
+# (the probel provider ignores acp1-only flags like --transport / --announce.)
+#
+# EVERY verb below is a real subcommand dispatched in
+# cmd/dhs/cmd_probel.go runProbelsw08p() switch (lines 61-106); each is
+# source-cited inline. assert_contains markers are the literal fmt.Printf
+# prefixes in the verb's run function (also cited).
+#
+#   ansible-playbook -i inventory/hosts.ini playbooks/probel-sw08p-verbs.yml
+#   # target a single OS group from the inventory:
+#   ansible-playbook -i inventory/hosts.ini playbooks/probel-sw08p-verbs.yml -l linux
+#   ansible-playbook -i inventory/hosts.ini playbooks/probel-sw08p-verbs.yml -l windows
+#
+# By default it runs on localhost (the controller's own OS). Point -l at an
+# inventory group to drive a remote Linux/macOS (SSH) or Windows (WinRM)
+# client — the role adapts with zero changes to this file.
+- name: Probel SW-P-08 cross-OS verb matrix (loopback, real binary)
+  hosts: "{{ vt_target | default('localhost') }}"
+  gather_facts: false
+  vars:
+    # Loopback bind/dial endpoint (also the role defaults; pinned here so the
+    # serve argv and the verb argv reference the same port unambiguously).
+    sw08p_host: "127.0.0.1"
+    sw08p_port: 12908
+    # The committed demo matrix fixture (single oneToN 16x16 matrix) — same
+    # artifact the legacy probel-sw08p-integration.yml serves.
+    sw08p_tree: "{{ playbook_dir }}/../../internal/probel-sw08p/testdata/exports/matrix_tree.json"
+    sw08p_addr: "{{ sw08p_host }}:{{ sw08p_port }}"
+  roles:
+    - role: dhs_verbtest
+      vars:
+        vt_proto: probel-sw08p
+        vt_host: "{{ sw08p_host }}"
+        vt_port: "{{ sw08p_port }}"
+
+        # ---- producer serve args (after the binary path) ------------------
+        # dhs producer probel-sw08p serve --tree <fixture> --port N --host H
+        #   --log-level error
+        # main.go dispatchProducer → runProducer (cmd_producer.go:42).
+        vt_serve_argv:
+          - producer
+          - probel-sw08p
+          - serve
+          - --tree
+          - "{{ sw08p_tree }}"
+          - --port
+          - "{{ sw08p_port | string }}"
+          - --host
+          - "{{ sw08p_host }}"
+          - --log-level
+          - error
+
+        # ---- the FULL consumer verb matrix -------------------------------
+        # Every entry's argv begins at `consumer` (the role prepends the
+        # binary path). Order: state-changing connect first so the read-backs
+        # have something to observe, then reads, then the write/diagnostic
+        # verbs. Each `# cmd_probel*.go:LINE` cites the dispatch + the output
+        # string the assert matches.
+        vt_verbs:
+          # connect — route dst 3 ← src 7. dispatch cmd_probel.go:77;
+          # runProbelConnect cmd_probel.go:449; output "crosspoint connected"
+          # cmd_probel.go:466.
+          - name: connect
+            argv:
+              - consumer
+              - probel-sw08p
+              - connect
+              - "{{ sw08p_addr }}"
+              - --matrix
+              - "0"
+              - --level
+              - "0"
+              - --dst
+              - "3"
+              - --src
+              - "7"
+            assert_contains:
+              - "crosspoint connected"
+              - "dst=3"
+              - "src=7"
+
+          # interrogate — read back dst 3. dispatch cmd_probel.go:63;
+          # runProbelInterrogate cmd_probel.go:428; output "crosspoint tally"
+          # cmd_probel.go:444.
+          - name: interrogate
+            argv:
+              - consumer
+              - probel-sw08p
+              - interrogate
+              - "{{ sw08p_addr }}"
+              - --matrix
+              - "0"
+              - --level
+              - "0"
+              - --dst
+              - "3"
+            assert_contains:
+              - "crosspoint tally"
+              - "dst=3"
+
+          # tally-dump — every crosspoint on M0 L0. dispatch cmd_probel.go:73;
+          # runProbelTallyDump cmd_probel.go:577; output "tally-dump (word|byte)"
+          # cmd_probel.go:594/601.
+          - name: tally-dump
+            argv:
+              - consumer
+              - probel-sw08p
+              - tally-dump
+              - "{{ sw08p_addr }}"
+              - --matrix
+              - "0"
+              - --level
+              - "0"
+            assert_contains:
+              - "tally-dump"
+
+          # dual-status — 1:1 redundancy state. dispatch cmd_probel.go:70;
+          # runProbelDualStatus cmd_probel.go:548; output "dual-controller"
+          # cmd_probel.go:573.
+          - name: dual-status
+            argv:
+              - consumer
+              - probel-sw08p
+              - dual-status
+              - "{{ sw08p_addr }}"
+            assert_contains:
+              - "dual-controller"
+
+          # all-source-names — every source label. dispatch cmd_probel.go:89;
+          # runProbelAllSourceNames cmd_probel_names.go:75; output
+          # "source names" cmd_probel_names.go:91.
+          - name: all-source-names
+            argv:
+              - consumer
+              - probel-sw08p
+              - all-source-names
+              - "{{ sw08p_addr }}"
+              - --matrix
+              - "0"
+              - --level
+              - "0"
+            assert_contains:
+              - "source names"
+
+          # single-source-name — one source label. dispatch cmd_probel.go:91;
+          # runProbelSingleSourceName cmd_probel_names.go:99; output
+          # "source name" cmd_probel_names.go:115.
+          - name: single-source-name
+            argv:
+              - consumer
+              - probel-sw08p
+              - single-source-name
+              - "{{ sw08p_addr }}"
+              - --matrix
+              - "0"
+              - --level
+              - "0"
+              - --src
+              - "0"
+            assert_contains:
+              - "source name"
+
+          # all-dest-names — every dest-assoc label. dispatch cmd_probel.go:93;
+          # runProbelAllDestAssocNames cmd_probel_names.go:120; output
+          # "dest assoc names" cmd_probel_names.go:136.
+          - name: all-dest-names
+            argv:
+              - consumer
+              - probel-sw08p
+              - all-dest-names
+              - "{{ sw08p_addr }}"
+              - --matrix
+              - "0"
+            assert_contains:
+              - "dest assoc names"
+
+          # single-dest-name — one dest-assoc label. dispatch cmd_probel.go:95;
+          # runProbelSingleDestAssocName cmd_probel_names.go:144; output
+          # "dest assoc name" cmd_probel_names.go:160.
+          - name: single-dest-name
+            argv:
+              - consumer
+              - probel-sw08p
+              - single-dest-name
+              - "{{ sw08p_addr }}"
+              - --matrix
+              - "0"
+              - --dst
+              - "0"
+            assert_contains:
+              - "dest assoc name"
+
+          # all-source-assoc-names — every source-assoc label. dispatch
+          # cmd_probel.go:97; runProbelAllSourceAssocNames
+          # cmd_probel_names.go:165; output "source assoc names"
+          # cmd_probel_names.go:181.
+          - name: all-source-assoc-names
+            argv:
+              - consumer
+              - probel-sw08p
+              - all-source-assoc-names
+              - "{{ sw08p_addr }}"
+              - --matrix
+              - "0"
+            assert_contains:
+              - "source assoc names"
+
+          # single-source-assoc-name — one source-assoc label. dispatch
+          # cmd_probel.go:99; runProbelSingleSourceAssocName
+          # cmd_probel_names.go:189; output "source assoc name"
+          # cmd_probel_names.go:205.
+          - name: single-source-assoc-name
+            argv:
+              - consumer
+              - probel-sw08p
+              - single-source-assoc-name
+              - "{{ sw08p_addr }}"
+              - --matrix
+              - "0"
+              - --src
+              - "0"
+            assert_contains:
+              - "source assoc name"
+
+          # discover — one-shot read-only sweep. dispatch cmd_probel.go:87;
+          # runProbelDiscover cmd_probel_names.go:214; output "=== discover"
+          # cmd_probel_names.go:238 + "dual-status" cmd_probel_names.go:241.
+          - name: discover
+            argv:
+              - consumer
+              - probel-sw08p
+              - discover
+              - "{{ sw08p_addr }}"
+              - --matrix
+              - "0"
+              - --level
+              - "0"
+            assert_contains:
+              - "=== discover"
+              - "dual-status"
+
+          # update-name — write a source label (rx 117, fire-and-forget).
+          # dispatch cmd_probel.go:101; runProbelUpdateName
+          # cmd_probel_update_name.go:23; output "update-name sent"
+          # cmd_probel_update_name.go:83.
+          - name: update-name
+            argv:
+              - consumer
+              - probel-sw08p
+              - update-name
+              - "{{ sw08p_addr }}"
+              - --type
+              - source
+              - --width
+              - "8"
+              - --matrix
+              - "0"
+              - --level
+              - "0"
+              - --first-id
+              - "0"
+              - --names
+              - "CAM1,CAM2"
+            assert_contains:
+              - "update-name sent"
+
+          # protect-interrogate — read protect on (M,L,dst). dispatch
+          # cmd_probel.go:75; runProbelProtectInterrogate cmd_probel.go:635;
+          # output "protect tally" cmd_probel.go:652.
+          - name: protect-interrogate
+            argv:
+              - consumer
+              - probel-sw08p
+              - protect-interrogate
+              - "{{ sw08p_addr }}"
+              - --matrix
+              - "0"
+              - --level
+              - "0"
+              - --dst
+              - "3"
+            assert_contains:
+              - "protect tally"
+
+          # protect-connect — set a protect for a device. dispatch
+          # cmd_probel.go:77 (case protect-connect); runProbelProtectConnect
+          # cmd_probel.go:657; output "protect connected" cmd_probel.go:674.
+          - name: protect-connect
+            argv:
+              - consumer
+              - probel-sw08p
+              - protect-connect
+              - "{{ sw08p_addr }}"
+              - --matrix
+              - "0"
+              - --level
+              - "0"
+              - --dst
+              - "3"
+              - --device
+              - "1"
+            assert_contains:
+              - "protect connected"
+
+          # protect-disconnect — clear a protect. dispatch cmd_probel.go:79;
+          # runProbelProtectDisconnect cmd_probel.go:679; output
+          # "protect disconnected" cmd_probel.go:696.
+          - name: protect-disconnect
+            argv:
+              - consumer
+              - probel-sw08p
+              - protect-disconnect
+              - "{{ sw08p_addr }}"
+              - --matrix
+              - "0"
+              - --level
+              - "0"
+              - --dst
+              - "3"
+              - --device
+              - "1"
+            assert_contains:
+              - "protect disconnected"
+
+          # protect-name — resolve device id → name. dispatch cmd_probel.go:81;
+          # runProbelProtectName cmd_probel.go:701; output "name=" (printf
+          # `device %d name=%q`) cmd_probel.go:723.
+          - name: protect-name
+            argv:
+              - consumer
+              - probel-sw08p
+              - protect-name
+              - "{{ sw08p_addr }}"
+              - --device
+              - "1"
+            assert_contains:
+              - "name="
+
+          # protect-dump — every protect on (M,L). dispatch cmd_probel.go:83;
+          # runProbelProtectDump cmd_probel.go:727; output "protect tally-dump"
+          # cmd_probel.go:751.
+          - name: protect-dump
+            argv:
+              - consumer
+              - probel-sw08p
+              - protect-dump
+              - "{{ sw08p_addr }}"
+              - --matrix
+              - "0"
+              - --level
+              - "0"
+            assert_contains:
+              - "protect tally-dump"
+
+          # master-protect — master-override protect connect. dispatch
+          # cmd_probel.go:85; runProbelMasterProtect cmd_probel.go:760; output
+          # "master-protect connected" cmd_probel.go:777.
+          - name: master-protect
+            argv:
+              - consumer
+              - probel-sw08p
+              - master-protect
+              - "{{ sw08p_addr }}"
+              - --matrix
+              - "0"
+              - --level
+              - "0"
+              - --dst
+              - "4"
+              - --device
+              - "2"
+            assert_contains:
+              - "master-protect connected"
+
+          # maintenance — soft-reset maintenance message. dispatch
+          # cmd_probel.go:69 (case maintenance); runProbelMaintenance
+          # cmd_probel.go:507; output "maintenance sent" cmd_probel.go:544.
+          - name: maintenance
+            argv:
+              - consumer
+              - probel-sw08p
+              - maintenance
+              - "{{ sw08p_addr }}"
+              - --function
+              - soft-reset
+            assert_contains:
+              - "maintenance sent"
+
+          # salvo-connect — VSM-style staged batch connect (cmd 120/121).
+          # dispatch cmd_probel.go:105; runProbelSalvoConnect
+          # cmd_probel_salvo.go:29; output "=== salvo-connect:"
+          # cmd_probel_salvo.go:92 + "=== summary ===" cmd_probel_salvo.go:146.
+          - name: salvo-connect
+            argv:
+              - consumer
+              - probel-sw08p
+              - salvo-connect
+              - "{{ sw08p_addr }}"
+              - --matrix
+              - "0"
+              - --level
+              - "0"
+              - --src
+              - "5"
+              - --dsts
+              - "0-2"
+              - --salvo
+              - "1"
+            assert_contains:
+              - "=== salvo-connect:"
+              - "=== summary ==="
+
+          # bench — tiny-size scale benchmark on a persistent TCP conn.
+          # --size kept small so the matrix runs fast. dispatch
+          # cmd_probel.go:103; runProbelBench cmd_probel_bench.go:30; output
+          # "=== Bench summary ===" cmd_probel_bench.go:104.
+          - name: bench
+            timeout: 120
+            argv:
+              - consumer
+              - probel-sw08p
+              - bench
+              - "{{ sw08p_addr }}"
+              - --matrix
+              - "0"
+              - --size
+              - "16"
+              - --progress
+              - "0"
+            assert_contains:
+              - "=== Bench summary ==="
+
+          # watch — subscribe to async tallies, bounded by --timeout so it
+          # returns instead of blocking on Ctrl-C. dispatch cmd_probel.go:67;
+          # runProbelWatch cmd_probel.go:474. Emits "event ..." only when a
+          # frame arrives, so we assert on a clean exit (rc==0) — no stdout
+          # marker is guaranteed for a quiet matrix.
+          - name: watch
+            timeout: 30
+            argv:
+              - consumer
+              - probel-sw08p
+              - watch
+              - "{{ sw08p_addr }}"
+              - --timeout
+              - "2s"
+            assert_contains: []

--- a/ansible/playbooks/site-legacy.yml
+++ b/ansible/playbooks/site-legacy.yml
@@ -1,0 +1,122 @@
+---
+# site-legacy.yml — the PRE-dhs_verbtest orchestrator (preserved verbatim).
+#
+# This is the original site.yml, kept under a new name when the role-based
+# cross-OS verb-matrix tier (dhs_verbtest + <proto>-verbs.yml) was introduced
+# and `site.yml` was repurposed as the new top-level entry point. It chains
+# the legacy *-integration.yml plays (POSIX-oriented loopback + external) and
+# the multi-OS ACP1 converge. Use this until every connector has migrated to a
+# <proto>-verbs.yml driven by the dhs_verbtest role, after which it can be
+# retired.
+#
+# Per ADR-0025 deliverable 3, Ansible is the EXCLUSIVE test / verify / deploy
+# driver (no PowerShell .ps1, no .sh, no .py wrapper). This single entry point
+# chains the three test tiers across EVERY connector:
+#
+#   UNIT        build + vet + go-test suite + per-package 100% coverage floors
+#               (unit-tests.yml).
+#   SMOKE       each connector's LOOPBACK tier — start the in-process
+#               provider / emulator (or, for push protocols, a backgrounded
+#               listener) and drive EVERY consumer + producer verb against it
+#               with a per-verb assert. Always runs; needs no lab network.
+#   INTEGRATION each connector's EXTERNAL tier — the read-safe verbs against a
+#               live oracle, gated on <PROTO>_TEST_HOST. Skips cleanly when the
+#               var is unset, so it is safe to run unconditionally.
+#
+# Every <proto>-integration.yml holds BOTH its smoke (loopback) tier and its
+# integration (external) tier; this orchestrator imports each one once and
+# tags the plays so an operator can select a tier or a single connector.
+#
+# TAGS
+#   unit          only unit-tests.yml
+#   smoke         loopback tier of every connector (no live oracle needed)
+#   integration   external tier of every connector (gated on <PROTO>_TEST_HOST)
+#   converge      the multi-OS ACP1 ensure/idempotency converge (live clients)
+#   per-proto     acp1 acp2 emberplus probel-sw08p probel-sw02p tsl osc
+#                 cerebrum-nb  — select one connector across all its tiers
+#
+# Because smoke + integration live in the same imported play, --tags smoke and
+# --tags integration both enter every <proto>-integration.yml; the loopback
+# blocks short-circuit when only-external is wanted (and vice-versa) via the
+# per-tier `when:` guards already inside each play. Use a per-proto tag to run
+# exactly one connector end to end.
+#
+# USAGE
+#   # everything (unit + every smoke tier; external tiers skip unless gated):
+#   ansible-playbook -i inventory/hosts.ini playbooks/site-legacy.yml
+#
+#   # one tier:
+#   ansible-playbook -i inventory/hosts.ini playbooks/site-legacy.yml --tags unit
+#   ansible-playbook -i inventory/hosts.ini playbooks/site-legacy.yml --tags smoke
+#
+#   # external tier vs a live oracle (gate per connector with its TEST_HOST):
+#   PROBEL_SW08P_TEST_HOST=10.100.0.42 \
+#     ansible-playbook -i inventory/hosts.ini playbooks/site-legacy.yml --tags integration
+#   ACP1_TEST_HOST=10.6.239.113 EMBERPLUS_TEST_HOST=10.6.239.113 \
+#     ansible-playbook -i inventory/hosts.ini playbooks/site-legacy.yml --tags integration
+#
+#   # a single connector across all its tiers:
+#   ansible-playbook -i inventory/hosts.ini playbooks/site-legacy.yml --tags emberplus
+#
+#   # the multi-OS converge (the original site.yml behaviour):
+#   ansible-playbook -i inventory/hosts.ini playbooks/site-legacy.yml --tags converge
+
+# ── UNIT ──────────────────────────────────────────────────────────────────
+- name: import unit-tests
+  ansible.builtin.import_playbook: unit-tests.yml
+  tags: [unit]
+
+# ── SMOKE (loopback) + INTEGRATION (external) per connector ─────────────────
+# Each import carries BOTH the smoke and integration tier; the smoke/integration
+# tags both apply so a tier selection reaches every connector, and the per-proto
+# tag selects one connector across its tiers.
+- name: import acp1 integration (loopback smoke + external)
+  ansible.builtin.import_playbook: acp1-integration.yml
+  tags: [smoke, integration, acp1]
+
+- name: import acp2 integration (loopback smoke + external)
+  ansible.builtin.import_playbook: acp2-integration.yml
+  tags: [smoke, integration, acp2]
+
+- name: import emberplus integration (loopback smoke + external)
+  ansible.builtin.import_playbook: emberplus-integration.yml
+  tags: [smoke, integration, emberplus]
+
+- name: import probel-sw08p integration (loopback smoke + external)
+  ansible.builtin.import_playbook: probel-sw08p-integration.yml
+  tags: [smoke, integration, probel-sw08p]
+
+- name: import probel-sw02p integration (loopback smoke + external)
+  ansible.builtin.import_playbook: probel-sw02p-integration.yml
+  tags: [smoke, integration, probel-sw02p]
+
+- name: import tsl integration (loopback smoke + external)
+  ansible.builtin.import_playbook: tsl-integration.yml
+  tags: [smoke, integration, tsl]
+
+- name: import osc integration (loopback smoke + external)
+  ansible.builtin.import_playbook: osc-integration.yml
+  tags: [smoke, integration, osc]
+
+# cerebrum-nb has NO provider / NO emulator (consumer-only, licensed oracle):
+# it carries ONLY an external tier, so it is tagged integration (not smoke).
+- name: import cerebrum-nb integration (external only — no loopback by design)
+  ansible.builtin.import_playbook: cerebrum-nb-integration.yml
+  tags: [integration, cerebrum-nb]
+
+# ── CONVERGE (multi-OS ACP1 ensure idempotency — live clients) ──────────────
+# Preserved from the original site.yml: converge ACP1 device state from every
+# OS client. Lives behind the `converge` tag so the default site run (unit +
+# smoke) does not require the dhs_clients inventory group to be reachable.
+#
+#   ansible-playbook playbooks/site-legacy.yml --tags converge          # apply
+#   ansible-playbook playbooks/site-legacy.yml --tags converge --check  # dry-run
+#
+# The second apply run must report 0 changed for every host on every OS — that
+# is the idempotency proof the `ensure` verb was built for.
+- name: Converge ACP1 device state from every OS client
+  hosts: dhs_clients
+  gather_facts: true
+  tags: [converge]
+  roles:
+    - dhs_acp1

--- a/ansible/playbooks/site.yml
+++ b/ansible/playbooks/site.yml
@@ -1,14 +1,107 @@
 ---
-# Converge the ACP1 device from every OS client in the lab.
+# site.yml — top-level CROSS-OS verb-test orchestrator for dhs (ADR-0016).
 #
-#   ansible-playbook playbooks/site.yml                 # apply
-#   ansible-playbook playbooks/site.yml --check         # dry-run (maps to ensure --check)
-#   ansible-playbook playbooks/site.yml                 # run again -> changed=0 (idempotent)
+# This is the new role-driven entry point built on the dhs_verbtest role. It
+# chains two tiers and is designed to run identically on Windows, Linux and
+# macOS — the OS portability lives entirely in the role, so this file (and
+# each <proto>-verbs.yml it imports) carries ZERO per-OS code.
 #
-# The second apply run must report 0 changed for every host on every OS - that
-# is the idempotency proof the `ensure` verb was built for.
-- name: Converge ACP1 device state from every OS client
-  hosts: dhs_clients
-  gather_facts: true
-  roles:
-    - dhs_acp1
+#   UNIT    build + vet + go-test suite + per-package 100% coverage floors
+#           (unit-tests.yml). Portable: `go test` runs on every OS.
+#   SMOKE   each connector's CROSS-OS verb matrix — the dhs_verbtest role
+#           builds the real binary, starts a loopback producer fire-and-forget
+#           (async/poll:0 + bounded TTL → the async reaper tears it down, no
+#           manual kill; net change = zero → ADR-0025 idempotent), waits for
+#           the port, then drives EVERY consumer verb + asserts on stdout.
+#
+# Per ADR-0025 deliverable 3, Ansible is the EXCLUSIVE test / verify / deploy
+# driver (no PowerShell .ps1, no .sh, no .py wrapper).
+#
+# The pre-existing POSIX-oriented orchestrator (legacy *-integration.yml plays
+# + the multi-OS ACP1 converge + the gated external/live-oracle tier) is
+# preserved verbatim as `site-legacy.yml`. Run that when you need the external
+# integration tier against a live matrix, or the ACP1 converge. As each of the
+# remaining 7 connectors gains a <proto>-verbs.yml (below), it migrates from
+# site-legacy.yml to here.
+#
+# ── TAGS ────────────────────────────────────────────────────────────────────
+#   unit          only unit-tests.yml
+#   smoke         the cross-OS verb matrix of every wired connector
+#   <proto>       one connector across its tiers (e.g. probel-sw08p)
+#
+# ── USAGE ───────────────────────────────────────────────────────────────────
+#   # everything wired so far (unit + every cross-OS verb matrix), on the
+#   # controller's own OS (localhost):
+#   ansible-playbook -i inventory/hosts.ini playbooks/site.yml
+#
+#   # one tier:
+#   ansible-playbook -i inventory/hosts.ini playbooks/site.yml --tags unit
+#   ansible-playbook -i inventory/hosts.ini playbooks/site.yml --tags smoke
+#
+#   # one connector:
+#   ansible-playbook -i inventory/hosts.ini playbooks/site.yml --tags probel-sw08p
+#
+#   # TARGET A SPECIFIC OS — the same plays, a different client. Each
+#   # <proto>-verbs.yml takes `hosts: {{ vt_target | default('localhost') }}`,
+#   # so pass an inventory group via -e vt_target=... (or -l to limit):
+#   ansible-playbook -i inventory/hosts.ini playbooks/site.yml -e vt_target=linux
+#   ansible-playbook -i inventory/hosts.ini playbooks/site.yml -e vt_target=windows
+#   ansible-playbook -i inventory/hosts.ini playbooks/site.yml -e vt_target=macos
+#   # (groups come from inventory/hosts.ini; the role auto-selects SSH vs WinRM
+#   #  modules off ansible_os_family — nothing in these plays changes per OS.)
+#
+# The EXTERNAL / live-oracle tier (read-safe verbs vs a real matrix gated on
+# <PROTO>_TEST_HOST) is NOT part of this verb-matrix orchestrator yet — it
+# still lives in site-legacy.yml. Folding it into the role (a vt_external_*
+# parameter set) is tracked in the role backlog.
+
+# ── UNIT ──────────────────────────────────────────────────────────────────
+- name: import unit-tests
+  ansible.builtin.import_playbook: unit-tests.yml
+  tags: [unit]
+
+# ── SMOKE (cross-OS verb matrix) per connector ──────────────────────────────
+# probel-sw08p is the proven template (richest verb set). Each import below is
+# one connector's <proto>-verbs.yml, which carries only data and delegates all
+# execution + OS dispatch to the dhs_verbtest role.
+- name: import probel-sw08p cross-OS verb matrix
+  ansible.builtin.import_playbook: probel-sw08p-verbs.yml
+  tags: [smoke, probel-sw08p]
+
+# ── TODO: remaining 7 connectors ────────────────────────────────────────────
+# Replicate probel-sw08p-verbs.yml per connector (copy the play, swap vt_proto
+# + vt_serve_argv + vt_verbs from that connector's cmd_<proto>.go verb table +
+# its committed fixture), then uncomment the matching import here. Order mirrors
+# the connector roadmap. NONE are wired yet — get the role reviewed on all
+# three OSes against probel-sw08p first, then this is pure data replication.
+#
+# - name: import probel-sw02p cross-OS verb matrix       # cmd_probel02p*.go
+#   ansible.builtin.import_playbook: probel-sw02p-verbs.yml
+#   tags: [smoke, probel-sw02p]
+#
+# - name: import acp1 cross-OS verb matrix               # cmd_acp1*.go / generic verb table
+#   ansible.builtin.import_playbook: acp1-verbs.yml
+#   tags: [smoke, acp1]
+#
+# - name: import acp2 cross-OS verb matrix               # cmd_acp2*.go / generic verb table
+#   ansible.builtin.import_playbook: acp2-verbs.yml
+#   tags: [smoke, acp2]
+#
+# - name: import emberplus cross-OS verb matrix          # generic verb table
+#   ansible.builtin.import_playbook: emberplus-verbs.yml
+#   tags: [smoke, emberplus]
+#
+# - name: import tsl cross-OS verb matrix                # cmd_tsl*.go (tsl-v31/40/50)
+#   ansible.builtin.import_playbook: tsl-verbs.yml
+#   tags: [smoke, tsl]
+#
+# - name: import osc cross-OS verb matrix                # cmd_osc*.go (osc-v10/v11)
+#   ansible.builtin.import_playbook: osc-verbs.yml
+#   tags: [smoke, osc]
+#
+# - name: import cerebrum-nb cross-OS verb matrix        # cmd_cerebrum*.go
+#   # NOTE: cerebrum-nb is consumer-only (no provider / no loopback producer),
+#   # so its play cannot use the role's serve+loopback path as-is — it needs an
+#   # external oracle. Wire it last and likely via the legacy external tier.
+#   ansible.builtin.import_playbook: cerebrum-nb-verbs.yml
+#   tags: [smoke, cerebrum-nb]

--- a/ansible/roles/dhs_verbtest/defaults/main.yml
+++ b/ansible/roles/dhs_verbtest/defaults/main.yml
@@ -1,0 +1,66 @@
+---
+# dhs_verbtest — OS-portable verb-matrix engine for the real dhs binary.
+#
+# A connector play sets vt_proto / vt_serve_argv / vt_verbs (+ optional
+# overrides) and includes this role. ALL OS-specific logic (which command
+# module, which wait_for, the binary extension) lives in the role, so a
+# connector play carries ZERO per-OS code. See tasks/main.yml for the
+# Windows-vs-POSIX dispatch and the async-expiry producer model.
+
+# --- binary resolution -----------------------------------------------------
+# The compiled binary's filename is OS-dependent (Windows needs .exe). The
+# role's own `go build` step (tasks/main.yml) writes to exactly this name, so
+# the built artifact and the path the verbs invoke always agree.
+dhs_bin_name: "{{ 'dhs.exe' if ansible_os_family == 'Windows' else 'dhs' }}"
+
+# Repo root, relative to the playbook (ansible/playbooks/<play>.yml → repo).
+vt_repo_root: "{{ playbook_dir }}/../.."
+
+# Resolve the binary path: honour the DHS_BIN env override first (lets an
+# operator point at a pre-built binary), else <repo>/bin/<dhs_bin_name>.
+# The default is a path under the repo so the role's build step and the verb
+# loop reference the same file on every OS.
+dhs_bin: >-
+  {{ lookup('ansible.builtin.env', 'DHS_BIN')
+     | default(vt_repo_root ~ '/bin/' ~ dhs_bin_name, true) }}
+
+# --- per-OS scratch dir for producer logs ----------------------------------
+# Windows has no /tmp; use the per-user TEMP. POSIX uses /tmp.
+vt_tmp: "{{ (ansible_env.TEMP | default('C:/Windows/Temp')) if ansible_os_family == 'Windows' else '/tmp' }}"
+
+# --- producer lifecycle knobs ----------------------------------------------
+# The loopback producer is started fire-and-forget with async/poll:0 and a
+# bounded TTL. When the TTL expires Ansible's async job reaper kills the
+# producer for us — NO manual nohup / pkill / Stop-Process is needed, and the
+# net effect across a run is zero persistent change (ADR-0025 idempotency).
+# The TTL must exceed the time the whole verb matrix takes to run.
+vt_serve_ttl: 120
+
+# Loopback host + port the producer binds and the verbs dial.
+vt_host: "127.0.0.1"
+vt_port: 12908
+
+# How long wait_for blocks for the producer's listening socket before failing.
+vt_wait_timeout: 30
+
+# Default per-verb timeout (seconds) for the command/win_command task wrapper.
+# This is the Ansible-side async ceiling for a single verb, distinct from any
+# CLI --timeout the verb argv itself carries.
+vt_verb_timeout: 60
+
+# --- role parameters a connector play MUST supply --------------------------
+# vt_proto        protocol name, e.g. "probel-sw08p" (used in dispatch + log names)
+# vt_serve_argv   producer serve args AFTER the binary path, e.g.
+#                 [producer, "{{ vt_proto }}", serve, --tree, "{{ tree }}",
+#                  --port, "{{ vt_port }}", --host, "{{ vt_host }}",
+#                  --log-level, error]
+# vt_verbs        list of verb specs, each:
+#                   name:            human label for the task + assert
+#                   argv:            full consumer argv AFTER the binary path
+#                   assert_contains: list of substrings every one of which
+#                                    must appear in stdout
+#                 (the binary path is prepended by the role, so a verb's argv
+#                  starts at `consumer`).
+vt_proto: ""
+vt_serve_argv: []
+vt_verbs: []

--- a/ansible/roles/dhs_verbtest/meta/main.yml
+++ b/ansible/roles/dhs_verbtest/meta/main.yml
@@ -1,0 +1,26 @@
+---
+galaxy_info:
+  role_name: dhs_verbtest
+  author: by-rune
+  description: >-
+    OS-portable verb-matrix engine. Given a connector's producer serve args
+    and its full consumer verb list, builds the real dhs binary, starts a
+    loopback producer fire-and-forget (async/poll:0 with a bounded TTL so the
+    async reaper tears it down — no manual kill), waits for the port, then
+    drives every consumer verb and asserts on stdout. All OS-specific logic
+    (command vs win_command, wait_for vs win_wait_for, dhs vs dhs.exe) lives
+    here, so connector plays carry zero per-OS code. Per ADR-0016 multi-OS.
+  license: see repository
+  min_ansible_version: "2.14"
+  platforms:
+    - name: EL
+      versions: [all]
+    - name: Debian
+      versions: [all]
+    - name: Ubuntu
+      versions: [all]
+    - name: MacOSX
+      versions: [all]
+    - name: Windows
+      versions: [all]
+dependencies: []

--- a/ansible/roles/dhs_verbtest/tasks/main.yml
+++ b/ansible/roles/dhs_verbtest/tasks/main.yml
@@ -1,0 +1,63 @@
+---
+# dhs_verbtest entry point. Three stages:
+#   1. Gather facts — we NEED ansible_os_family for every dispatch decision
+#      and ansible_env (Windows TEMP) for vt_tmp. Connector plays may run with
+#      gather_facts:false, so force it here, scoped to this task.
+#   2. Build the real dhs binary to {{ dhs_bin }}. `go build -o <path>
+#      ./cmd/dhs` is portable across Linux/macOS/Windows; the only OS variance
+#      is the .exe extension, already baked into dhs_bin_name → dhs_bin. The
+#      go toolchain itself is invoked with the OS-appropriate command module.
+#   3. Hand off to posix.yml or windows.yml — the only files that name an
+#      OS-specific module. Everything a connector play sees is OS-neutral.
+
+- name: Gather the minimum facts the role dispatches on (os_family, env)
+  ansible.builtin.setup:
+    gather_subset:
+      - "!all"
+      - "min"
+
+- name: Validate the role was given a connector to test
+  ansible.builtin.assert:
+    that:
+      - vt_proto | length > 0
+      - vt_serve_argv | length > 0
+      - vt_verbs | length > 0
+    fail_msg: >-
+      dhs_verbtest requires vt_proto, vt_serve_argv and vt_verbs to be set by
+      the calling play.
+    quiet: true
+
+# ---- build (POSIX) --------------------------------------------------------
+- name: "build — go build -o {{ dhs_bin }} ./cmd/dhs (POSIX)"
+  ansible.builtin.command:
+    chdir: "{{ vt_repo_root }}"
+    argv:
+      - go
+      - build
+      - -o
+      - "{{ dhs_bin }}"
+      - ./cmd/dhs
+  changed_when: false
+  when: ansible_os_family != "Windows"
+
+# ---- build (Windows) ------------------------------------------------------
+- name: "build — go build -o {{ dhs_bin }} ./cmd/dhs (Windows)"
+  ansible.windows.win_command:
+    chdir: "{{ vt_repo_root }}"
+    argv:
+      - go
+      - build
+      - -o
+      - "{{ dhs_bin }}"
+      - ./cmd/dhs
+  changed_when: false
+  when: ansible_os_family == "Windows"
+
+# ---- per-OS verb matrix ---------------------------------------------------
+- name: Run the verb matrix on a POSIX client (SSH)
+  ansible.builtin.include_tasks: posix.yml
+  when: ansible_os_family != "Windows"
+
+- name: Run the verb matrix on a Windows client (WinRM)
+  ansible.builtin.include_tasks: windows.yml
+  when: ansible_os_family == "Windows"

--- a/ansible/roles/dhs_verbtest/tasks/posix.yml
+++ b/ansible/roles/dhs_verbtest/tasks/posix.yml
@@ -1,0 +1,40 @@
+---
+# POSIX (Linux + macOS, over SSH) verb matrix for one connector.
+#
+# Producer lifecycle = async-expiry, NOT manual kill:
+#   - start with ansible.builtin.command + async: {{ vt_serve_ttl }} + poll: 0
+#     → fire-and-forget. Ansible launches the producer detached and returns
+#     immediately. When vt_serve_ttl elapses the async job reaper terminates
+#     it. There is no nohup, no pkill, no `always:` teardown — the producer
+#     auto-expires, so a re-run starts from the same fixture and the net
+#     persistent change is zero (ADR-0025 idempotency).
+#   - wait_for the TCP port makes the start race-safe: no verb runs until the
+#     producer is actually accepting connections.
+
+- name: "{{ vt_proto }} — start the loopback producer (fire-and-forget, auto-expiring)"
+  ansible.builtin.command:
+    argv: "{{ [dhs_bin] + vt_serve_argv }}"
+  async: "{{ vt_serve_ttl }}"
+  poll: 0
+  changed_when: false
+  register: vt_producer
+
+- name: "{{ vt_proto }} — wait for the producer to accept connections on {{ vt_host }}:{{ vt_port }}"
+  ansible.builtin.wait_for:
+    host: "{{ vt_host }}"
+    port: "{{ vt_port }}"
+    timeout: "{{ vt_wait_timeout }}"
+
+- name: "{{ vt_proto }} — run + assert every consumer verb against the loopback producer"
+  ansible.builtin.include_tasks: posix_verb.yml
+  loop: "{{ vt_verbs }}"
+  loop_control:
+    loop_var: vt_verb
+    label: "{{ vt_verb.name }}"
+
+- name: "{{ vt_proto }} — POSIX verb matrix result"
+  ansible.builtin.debug:
+    msg: >-
+      {{ vt_proto }} verb matrix: PASS ({{ vt_verbs | length }} verbs driven
+      against the loopback producer, asserted; producer auto-expires →
+      run-twice = same result)

--- a/ansible/roles/dhs_verbtest/tasks/posix_verb.yml
+++ b/ansible/roles/dhs_verbtest/tasks/posix_verb.yml
@@ -1,0 +1,29 @@
+---
+# Run ONE consumer verb (vt_verb) on POSIX, then assert its stdout.
+# Included once per item by posix.yml's loop, so the run + its assert share
+# the same vt_verb (no fragile index-zip across two registers).
+
+- name: "{{ vt_proto }} verb — {{ vt_verb.name }}"
+  ansible.builtin.command:
+    argv: "{{ [dhs_bin] + vt_verb.argv }}"
+  async: "{{ vt_verb.timeout | default(vt_verb_timeout) }}"
+  poll: 1
+  changed_when: false
+  failed_when: vt_verb_run.rc != 0
+  register: vt_verb_run
+
+- name: "{{ vt_proto }} verb — surface {{ vt_verb.name }} output (visible under -v)"
+  ansible.builtin.debug:
+    msg: "{{ vt_verb_run.stdout_lines | default([]) }}"
+
+- name: "{{ vt_proto }} verb — assert {{ vt_verb.name }} stdout contains its markers"
+  ansible.builtin.assert:
+    that:
+      - "vt_verb.assert_contains | difference(_present) | length == 0"
+    fail_msg: >-
+      {{ vt_proto }} verb '{{ vt_verb.name }}' stdout missing
+      {{ vt_verb.assert_contains | difference(_present) }} —
+      got: {{ vt_verb_run.stdout }}
+    quiet: true
+  vars:
+    _present: "{{ vt_verb.assert_contains | select('in', vt_verb_run.stdout) | list }}"

--- a/ansible/roles/dhs_verbtest/tasks/windows.yml
+++ b/ansible/roles/dhs_verbtest/tasks/windows.yml
@@ -1,0 +1,38 @@
+---
+# Windows (over WinRM) verb matrix for one connector. Same shape as posix.yml
+# but with the ansible.windows modules. The producer lifecycle is identical:
+# async/poll:0 fire-and-forget + bounded TTL → the async reaper tears the
+# producer down, NO manual Start-Process / Stop-Process kill. win_wait_for
+# makes the start race-safe before any verb runs.
+#
+# NOTE for the on-Windows verifier: win_command async + win_wait_for over
+# WinRM is the part most worth confirming live (see the role README / the
+# play header). The structure mirrors the proven POSIX path exactly.
+
+- name: "{{ vt_proto }} — start the loopback producer (fire-and-forget, auto-expiring)"
+  ansible.windows.win_command:
+    argv: "{{ [dhs_bin] + vt_serve_argv }}"
+  async: "{{ vt_serve_ttl }}"
+  poll: 0
+  changed_when: false
+  register: vt_producer
+
+- name: "{{ vt_proto }} — wait for the producer to accept connections on {{ vt_host }}:{{ vt_port }}"
+  ansible.windows.win_wait_for:
+    host: "{{ vt_host }}"
+    port: "{{ vt_port }}"
+    timeout: "{{ vt_wait_timeout }}"
+
+- name: "{{ vt_proto }} — run + assert every consumer verb against the loopback producer"
+  ansible.builtin.include_tasks: windows_verb.yml
+  loop: "{{ vt_verbs }}"
+  loop_control:
+    loop_var: vt_verb
+    label: "{{ vt_verb.name }}"
+
+- name: "{{ vt_proto }} — Windows verb matrix result"
+  ansible.builtin.debug:
+    msg: >-
+      {{ vt_proto }} verb matrix: PASS ({{ vt_verbs | length }} verbs driven
+      against the loopback producer, asserted; producer auto-expires →
+      run-twice = same result)

--- a/ansible/roles/dhs_verbtest/tasks/windows_verb.yml
+++ b/ansible/roles/dhs_verbtest/tasks/windows_verb.yml
@@ -1,0 +1,29 @@
+---
+# Run ONE consumer verb (vt_verb) on Windows, then assert its stdout.
+# Included once per item by windows.yml's loop. The assert logic is identical
+# to posix_verb.yml (stdout substring match) — only the run module differs.
+
+- name: "{{ vt_proto }} verb — {{ vt_verb.name }}"
+  ansible.windows.win_command:
+    argv: "{{ [dhs_bin] + vt_verb.argv }}"
+  async: "{{ vt_verb.timeout | default(vt_verb_timeout) }}"
+  poll: 1
+  changed_when: false
+  failed_when: vt_verb_run.rc != 0
+  register: vt_verb_run
+
+- name: "{{ vt_proto }} verb — surface {{ vt_verb.name }} output (visible under -v)"
+  ansible.builtin.debug:
+    msg: "{{ vt_verb_run.stdout_lines | default([]) }}"
+
+- name: "{{ vt_proto }} verb — assert {{ vt_verb.name }} stdout contains its markers"
+  ansible.builtin.assert:
+    that:
+      - "vt_verb.assert_contains | difference(_present) | length == 0"
+    fail_msg: >-
+      {{ vt_proto }} verb '{{ vt_verb.name }}' stdout missing
+      {{ vt_verb.assert_contains | difference(_present) }} —
+      got: {{ vt_verb_run.stdout }}
+    quiet: true
+  vars:
+    _present: "{{ vt_verb.assert_contains | select('in', vt_verb_run.stdout) | list }}"


### PR DESCRIPTION
Foundation for cross-OS (Windows + Linux + macOS, ADR-0016) Ansible verb testing of the REAL dhs binary (dhs.exe on Windows). Answers: yes, tests drive the actual binary, on all OSes. Role ansible/roles/dhs_verbtest: builds the binary (go build -> dhs/dhs.exe), starts the loopback producer fire-and-forget (async/poll:0 + bounded TTL; the async reaper auto-expires it -> NO per-OS nohup/pkill/Stop-Process, zero persistent change/idempotent), wait_for/win_wait_for for race-safety, then runs+asserts a connector's FULL verb list. All OS variance (command vs win_command, wait_for vs win_wait_for, .exe ext, temp dir) is confined to the role via ansible_os_family dispatch; connector plays carry zero per-OS code (supply only vt_proto/vt_serve_argv/vt_verbs). probel-sw08p-verbs.yml wires all 23 verbs (each cited to cmd/dhs source) as the template. site.yml orchestrates unit-tests.yml (tag unit) + verb plays (tags smoke/<proto>), OS-targeted via -e vt_target; old site.yml kept as site-legacy.yml; DHS_BIN overrides the binary path. Authored from source + the repo's roles/dhs_acp1 per-OS pattern; go build clean, YAML parses; NOT executed here (no ansible/WinRM on the dev host) — the Windows win_command-async path needs live confirmation. The other 7 connectors replicate via the role as a data-only follow-up. Co-Authored-By Claude Opus 4.8.