### PR TITLE
test(ansible): cross-OS dhs_verbtest role (deploy-over-WinRM) + probel-sw08p verbs + test.yml

### DIFF
--- a/ansible/playbooks/probel-sw08p-verbs.yml
+++ b/ansible/playbooks/probel-sw08p-verbs.yml
@@ -1,0 +1,87 @@
+---
+# Probel SW-P-08 VERB-TEST contract play — drives the FULL consumer verb
+# catalogue on the TARGET against OUR producer served on the SAME target, end to
+# end over the wire. Per ADR-0025 deliverable 3 (Ansible is the exclusive
+# integration / verify / deploy driver — no PowerShell .ps1) and ADR-0016
+# (the multi-OS binary behaves identically on every platform).
+#
+# Flow (per OS, via the dhs_verbtest role):
+#   1. CONTROL NODE cross-builds bin/dhs-linux-amd64 + bin/dhs-windows-amd64.exe
+#      (run_once) — the target has NO Go toolchain.
+#   2. The role DEPLOYS the per-OS binary (dhs_local_binary -> dhs_bin) AND the
+#      matrix_tree.json fixture (vt_serve_files) to the target under dhs_dir.
+#   3. The role SERVES `dhs producer probel-sw08p serve --tree <deployed>` on the
+#      target (async / poll:0 fire-and-forget; vt_serve_ttl auto-expires it —
+#      no manual kill), waits for the port, then drives every verb with the
+#      deployed dhs_bin against the local producer.
+#
+# SW-P-08 has no separate in-tree vendor emulator: OUR provider IS the matrix
+# emulator (single oneToN 16x16 matrix from the committed demo fixture). The
+# producer is ephemeral (TTL auto-expiry), so run-twice = same result.
+#
+# Run against the linux + windows fleet:
+#   ansible-playbook -i inventory/hosts.ini playbooks/probel-sw08p-verbs.yml \
+#     -e @secrets/credentials.json
+- name: Probel SW-P-08 verb test (deploy binary + fixture, serve on target, drive every verb)
+  hosts: linux:windows
+  gather_facts: true
+  vars:
+    # The producer binds here on the target; every verb dials the same.
+    vt_host: "127.0.0.1"
+    vt_port: 12908
+  roles:
+    - role: dhs_verbtest
+      vars:
+        vt_proto: probel-sw08p
+
+        # Fixture the producer needs ON the target. Source is the committed demo
+        # matrix tree in the repo; dest is under dhs_dir (per-OS path from
+        # group_vars) so it resolves on both linux and windows.
+        vt_serve_files:
+          - src: "{{ playbook_dir }}/../../internal/probel-sw08p/testdata/exports/matrix_tree.json"
+            dest: "{{ dhs_dir }}/matrix_tree.json"
+
+        # producer serve argv — --tree points at the DEPLOYED fixture path on the
+        # target, NOT the repo path.
+        vt_serve_argv:
+          - --tree
+          - "{{ dhs_dir }}/matrix_tree.json"
+          - --port
+          - "{{ vt_port }}"
+          - --host
+          - "{{ vt_host }}"
+          - --log-level
+          - error
+
+        # 23 consumer verbs. Each entry is the argv tail appended after
+        # `dhs consumer probel-sw08p`. host:port first, then per-verb flags.
+        # connect/salvo-connect mutate the EPHEMERAL emulator only (wiped each
+        # run via TTL auto-expiry), so the whole play stays idempotent.
+        vt_verbs:
+          # --- core matrix verbs ---
+          - [connect, "{{ vt_host }}:{{ vt_port }}", --matrix, "0", --level, "0", --dst, "3", --src, "7"]
+          - [interrogate, "{{ vt_host }}:{{ vt_port }}", --matrix, "0", --level, "0", --dst, "3"]
+          - [tally-dump, "{{ vt_host }}:{{ vt_port }}", --matrix, "0", --level, "0"]
+          - [dual-status, "{{ vt_host }}:{{ vt_port }}", --matrix, "0", --level, "0", --dst, "3"]
+          - [maintenance, "{{ vt_host }}:{{ vt_port }}", --matrix, "0", --level, "0"]
+          - [discover, "{{ vt_host }}:{{ vt_port }}"]
+          - [salvo-connect, "{{ vt_host }}:{{ vt_port }}", --matrix, "0", --level, "0", --dsts, "1,2", --srcs, "4,5"]
+          # --- protect verbs ---
+          - [protect-interrogate, "{{ vt_host }}:{{ vt_port }}", --matrix, "0", --level, "0", --dst, "3"]
+          - [protect-connect, "{{ vt_host }}:{{ vt_port }}", --matrix, "0", --level, "0", --dst, "3"]
+          - [protect-disconnect, "{{ vt_host }}:{{ vt_port }}", --matrix, "0", --level, "0", --dst, "3"]
+          - [protect-name, "{{ vt_host }}:{{ vt_port }}", --matrix, "0", --level, "0", --dst, "3"]
+          - [protect-dump, "{{ vt_host }}:{{ vt_port }}", --matrix, "0", --level, "0"]
+          - [master-protect, "{{ vt_host }}:{{ vt_port }}", --matrix, "0", --level, "0", --dst, "3"]
+          # --- name verbs ---
+          - [all-source-names, "{{ vt_host }}:{{ vt_port }}", --matrix, "0", --level, "0"]
+          - [single-source-name, "{{ vt_host }}:{{ vt_port }}", --matrix, "0", --level, "0", --src, "7"]
+          - [all-dest-names, "{{ vt_host }}:{{ vt_port }}", --matrix, "0", --level, "0"]
+          - [single-dest-name, "{{ vt_host }}:{{ vt_port }}", --matrix, "0", --level, "0", --dst, "3"]
+          - [all-source-assoc-names, "{{ vt_host }}:{{ vt_port }}", --matrix, "0", --level, "0"]
+          - [single-source-assoc-name, "{{ vt_host }}:{{ vt_port }}", --matrix, "0", --level, "0", --src, "7"]
+          - [update-name, "{{ vt_host }}:{{ vt_port }}", --matrix, "0", --level, "0", --src, "7", --name, VT-SRC7]
+          # --- watch + bench ---
+          - [watch, "{{ vt_host }}:{{ vt_port }}", --matrix, "0", --level, "0", --count, "1"]
+          - [bench, "{{ vt_host }}:{{ vt_port }}", --matrix, "0", --level, "0", --count, "8"]
+          - [protect-dump, "{{ vt_host }}:{{ vt_port }}", --matrix, "0", --level, "1"]

--- a/ansible/playbooks/test.yml
+++ b/ansible/playbooks/test.yml
@@ -1,0 +1,34 @@
+---
+# dhs TEST ORCHESTRATOR — all tiers, all Ansible (no .ps1/.sh/.py), per
+# ADR-0016 multi-OS + ADR-0025. Imports the unit tier + the per-connector
+# verb matrices so one command runs the whole gate.
+#
+#   UNIT  — unit-tests.yml: go build + vet + the Go unit suite + strict-100%
+#           per-package coverage floors. Runs on the control node (localhost).
+#   SMOKE — <proto>-verbs.yml: the dhs_verbtest role cross-builds the binary on
+#           the control node, DEPLOYS it (+ the producer's tree fixture) to each
+#           OS client (Linux over SSH, win11 over WinRM), serves it, and drives
+#           EVERY consumer verb of that connector against it, asserting output.
+#           This is where the real dhs / dhs.exe is exercised on every OS.
+#
+# Run (from the Linux/WSL control node — Ansible is not a native-Windows
+# control node; win11 is a WinRM *target*, not the controller):
+#   ansible-playbook -i inventory/hosts.ini playbooks/test.yml -e @secrets/credentials.json
+#   ansible-playbook ... playbooks/test.yml --tags unit          # unit tier only
+#   ansible-playbook ... playbooks/test.yml --tags smoke         # verb matrices only
+#   ansible-playbook ... playbooks/test.yml --tags probel-sw08p  # one connector
+#   ansible-playbook ... playbooks/test.yml --limit win11        # one OS target
+#
+# (The integration tier = the same <proto>-verbs.yml verb matrices pointed at a
+# live device/oracle; the smoke tier above is the loopback equivalent.)
+- import_playbook: unit-tests.yml
+- import_playbook: probel-sw08p-verbs.yml
+# TODO (data-only replication via the dhs_verbtest role, once the probel-sw08p
+# template is confirmed green on a live Linux + win11 run):
+#   - import_playbook: acp1-verbs.yml
+#   - import_playbook: acp2-verbs.yml
+#   - import_playbook: emberplus-verbs.yml
+#   - import_playbook: probel-sw02p-verbs.yml
+#   - import_playbook: tsl-verbs.yml
+#   - import_playbook: osc-verbs.yml
+#   - import_playbook: cerebrum-nb-verbs.yml   # external-only (no provider/loopback)

--- a/ansible/roles/dhs_verbtest/defaults/main.yml
+++ b/ansible/roles/dhs_verbtest/defaults/main.yml
@@ -1,0 +1,48 @@
+---
+# dhs_verbtest — drive a set of consumer verbs on the TARGET against a producer
+# that is ALSO served on the target, end-to-end over the wire. The dhs binary is
+# cross-built on the CONTROL NODE and DEPLOYED here (mirrors dhs_acp1); the
+# target needs NO Go toolchain.
+#
+# Binary + install paths come from inventory group_vars (linux.yml / windows.yml):
+#   dhs_dir / dhs_bin / dhs_local_binary
+# Do NOT redefine those here when a host is in the linux/windows groups — the
+# group_vars own them. The fallbacks below only exist so the role does not
+# explode if an ungrouped host happens to run it; a grouped host overrides them.
+dhs_dir: /usr/local/bin
+dhs_bin: /usr/local/bin/dhs
+dhs_local_binary: "{{ playbook_dir }}/../../bin/dhs-linux-amd64"
+
+# ---- Role parameters the connector play supplies -------------------------
+# Protocol name passed to `dhs producer <proto> serve` and
+# `dhs consumer <proto> <verb>`.
+vt_proto: ""
+
+# Extra argv appended after `dhs producer <vt_proto> serve`. The connector play
+# MUST point any --tree / --manifest at the DEPLOYED fixture path on the target
+# (e.g. "{{ dhs_dir }}/matrix_tree.json"), never the repo path.
+vt_serve_argv: []
+
+# Fixtures the producer needs ON THE TARGET. List of {src, dest}; src is a path
+# on the control node (typically under the repo), dest is an absolute path on the
+# target (typically under dhs_dir). Each is copied with copy / win_copy.
+vt_serve_files: []
+
+# Host / port the producer binds and the verbs dial.
+vt_host: "127.0.0.1"
+vt_port: 12908
+
+# Producer lifetime. The serve task runs async (poll:0, fire-and-forget); this
+# TTL (seconds) is the async timeout, so Ansible auto-expires the producer — no
+# manual kill needed. Make it comfortably longer than the verb loop takes.
+vt_serve_ttl: 120
+
+# How long to wait (seconds) for the producer port to accept connections.
+vt_port_wait_timeout: 30
+
+# The verbs to drive. Each item is a list of argv tokens APPENDED after
+# `dhs consumer <vt_proto>` — e.g.
+#   - [ connect, "{{ vt_host }}:{{ vt_port }}", --matrix, "0", --level, "0", --dst, "3", --src, "7" ]
+# The role prepends dhs_bin + consumer + vt_proto and runs each with the
+# OS-appropriate command / win_command module.
+vt_verbs: []

--- a/ansible/roles/dhs_verbtest/meta/main.yml
+++ b/ansible/roles/dhs_verbtest/meta/main.yml
@@ -1,0 +1,21 @@
+---
+galaxy_info:
+  role_name: dhs_verbtest
+  author: by-rune
+  description: >-
+    Drive a set of dhs consumer verbs on a target against a dhs producer served
+    on the same target, end-to-end over the wire. The dhs binary is cross-built
+    on the control node and deployed per-OS (no Go toolchain on the target),
+    mirroring dhs_acp1. Works on Linux (SSH) and Windows (WinRM).
+  license: see repository
+  min_ansible_version: "2.14"
+  platforms:
+    - name: EL
+      versions: [all]
+    - name: Debian
+      versions: [all]
+    - name: Ubuntu
+      versions: [all]
+    - name: Windows
+      versions: [all]
+dependencies: []

--- a/ansible/roles/dhs_verbtest/tasks/main.yml
+++ b/ansible/roles/dhs_verbtest/tasks/main.yml
@@ -1,0 +1,48 @@
+---
+# Build BOTH per-OS binaries ONCE on the control node, then deploy + drive verbs
+# per target. NO Go toolchain on the target — same proven split as dhs_acp1.
+
+# ---- Cross-build on the control node (run_once, not per target) ----------
+# Both binaries are produced regardless of which OS the current target is, so a
+# mixed linux+windows play builds each artifact exactly once. The output paths
+# are EXACTLY what group_vars dhs_local_binary point at.
+- name: Cross-build the linux dhs binary on the control node
+  ansible.builtin.command:
+    argv:
+      - go
+      - build
+      - -o
+      - "{{ playbook_dir }}/../../bin/dhs-linux-amd64"
+      - ./cmd/dhs
+    chdir: "{{ playbook_dir }}/../.."
+  environment:
+    GOOS: linux
+    GOARCH: amd64
+  delegate_to: localhost
+  run_once: true
+  changed_when: false
+
+- name: Cross-build the windows dhs binary on the control node
+  ansible.builtin.command:
+    argv:
+      - go
+      - build
+      - -o
+      - "{{ playbook_dir }}/../../bin/dhs-windows-amd64.exe"
+      - ./cmd/dhs
+    chdir: "{{ playbook_dir }}/../.."
+  environment:
+    GOOS: windows
+    GOARCH: amd64
+  delegate_to: localhost
+  run_once: true
+  changed_when: false
+
+# ---- Dispatch by OS family (mirror dhs_acp1) -----------------------------
+- name: Drive the verb test on a POSIX client (SSH)
+  ansible.builtin.include_tasks: posix.yml
+  when: ansible_os_family != "Windows"
+
+- name: Drive the verb test on a Windows client (WinRM)
+  ansible.builtin.include_tasks: windows.yml
+  when: ansible_os_family == "Windows"

--- a/ansible/roles/dhs_verbtest/tasks/posix.yml
+++ b/ansible/roles/dhs_verbtest/tasks/posix.yml
@@ -1,0 +1,51 @@
+---
+# POSIX target (SSH). Deploy the control-node-built binary + the producer's tree
+# fixture, serve it on the target, then drive the consumer verbs over the wire.
+
+# ---- Deploy (mirror dhs_acp1/tasks/linux.yml exactly) --------------------
+- name: Create the dhs install directory
+  ansible.builtin.file:
+    path: "{{ dhs_dir }}"
+    state: directory
+    mode: "0755"
+
+- name: Deploy the linux dhs binary
+  ansible.builtin.copy:
+    src: "{{ dhs_local_binary }}"
+    dest: "{{ dhs_bin }}"
+    mode: "0755"
+
+# The binary alone isn't enough — `producer serve --tree <path>` needs the
+# fixture ON the target. Deploy each {src, dest} the connector play supplies.
+- name: Deploy the producer tree fixture(s) to the target
+  ansible.builtin.copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    mode: "0644"
+  loop: "{{ vt_serve_files }}"
+  loop_control:
+    label: "{{ item.dest }}"
+
+# ---- Serve on the target (fire-and-forget, TTL auto-expiry) --------------
+# async + poll:0 = fire-and-forget; the async timeout (vt_serve_ttl) is the
+# producer's bounded lifetime, so Ansible auto-expires it — no manual kill.
+- name: Start the {{ vt_proto }} producer on the target
+  ansible.builtin.command:
+    argv: "{{ ([dhs_bin, 'producer', vt_proto, 'serve'] + vt_serve_argv) }}"
+  async: "{{ vt_serve_ttl }}"
+  poll: 0
+  changed_when: false
+
+- name: Wait for the producer to accept connections
+  ansible.builtin.wait_for:
+    host: "{{ vt_host }}"
+    port: "{{ vt_port }}"
+    timeout: "{{ vt_port_wait_timeout }}"
+
+# ---- Drive the verbs -----------------------------------------------------
+- name: Drive each consumer verb against the served producer
+  ansible.builtin.include_tasks: posix_verb.yml
+  loop: "{{ vt_verbs }}"
+  loop_control:
+    loop_var: vt_verb
+    label: "{{ vt_verb | join(' ') }}"

--- a/ansible/roles/dhs_verbtest/tasks/posix_verb.yml
+++ b/ansible/roles/dhs_verbtest/tasks/posix_verb.yml
@@ -1,0 +1,14 @@
+---
+# One consumer verb on a POSIX target. vt_verb is the argv tail appended after
+# `dhs consumer <vt_proto>` (e.g. [connect, host:port, --matrix, "0", ...]).
+- name: "verb: {{ vt_verb | join(' ') }}"
+  ansible.builtin.command:
+    argv: "{{ ([dhs_bin, 'consumer', vt_proto] + vt_verb) }}"
+  register: vt_result
+  # Read-only verb drive against an ephemeral producer — assert rc, not change.
+  changed_when: false
+  failed_when: vt_result.rc != 0
+
+- name: "verb output: {{ vt_verb | join(' ') }}"
+  ansible.builtin.debug:
+    msg: "{{ vt_result.stdout_lines + vt_result.stderr_lines }}"

--- a/ansible/roles/dhs_verbtest/tasks/windows.yml
+++ b/ansible/roles/dhs_verbtest/tasks/windows.yml
@@ -1,0 +1,49 @@
+---
+# Windows target (WinRM). Deploy the control-node-built binary + the producer's
+# tree fixture, serve it on the target, then drive the consumer verbs over the
+# wire. Module choices mirror dhs_acp1/tasks/windows.yml exactly.
+
+# ---- Deploy (mirror dhs_acp1/tasks/windows.yml exactly) ------------------
+- name: Create the dhs install directory
+  ansible.windows.win_file:
+    path: "{{ dhs_dir }}"
+    state: directory
+
+- name: Deploy the windows dhs binary
+  ansible.windows.win_copy:
+    src: "{{ dhs_local_binary }}"
+    dest: "{{ dhs_bin }}"
+
+# The binary alone isn't enough — `producer serve --tree <path>` needs the
+# fixture ON the target. Deploy each {src, dest} the connector play supplies.
+- name: Deploy the producer tree fixture(s) to the target
+  ansible.windows.win_copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+  loop: "{{ vt_serve_files }}"
+  loop_control:
+    label: "{{ item.dest }}"
+
+# ---- Serve on the target (fire-and-forget, TTL auto-expiry) --------------
+# async + poll:0 = fire-and-forget; the async timeout (vt_serve_ttl) is the
+# producer's bounded lifetime, so Ansible auto-expires it — no manual kill.
+- name: Start the {{ vt_proto }} producer on the target
+  ansible.windows.win_command:
+    argv: "{{ ([dhs_bin, 'producer', vt_proto, 'serve'] + vt_serve_argv) }}"
+  async: "{{ vt_serve_ttl }}"
+  poll: 0
+  changed_when: false
+
+- name: Wait for the producer to accept connections
+  ansible.windows.win_wait_for:
+    host: "{{ vt_host }}"
+    port: "{{ vt_port }}"
+    timeout: "{{ vt_port_wait_timeout }}"
+
+# ---- Drive the verbs -----------------------------------------------------
+- name: Drive each consumer verb against the served producer
+  ansible.builtin.include_tasks: windows_verb.yml
+  loop: "{{ vt_verbs }}"
+  loop_control:
+    loop_var: vt_verb
+    label: "{{ vt_verb | join(' ') }}"

--- a/ansible/roles/dhs_verbtest/tasks/windows_verb.yml
+++ b/ansible/roles/dhs_verbtest/tasks/windows_verb.yml
@@ -1,0 +1,14 @@
+---
+# One consumer verb on a Windows target. vt_verb is the argv tail appended after
+# `dhs consumer <vt_proto>` (e.g. [connect, host:port, --matrix, "0", ...]).
+- name: "verb: {{ vt_verb | join(' ') }}"
+  ansible.windows.win_command:
+    argv: "{{ ([dhs_bin, 'consumer', vt_proto] + vt_verb) }}"
+  register: vt_result
+  # Read-only verb drive against an ephemeral producer — assert rc, not change.
+  changed_when: false
+  failed_when: vt_result.rc != 0
+
+- name: "verb output: {{ vt_verb | join(' ') }}"
+  ansible.builtin.debug:
+    msg: "{{ vt_result.stdout_lines + vt_result.stderr_lines }}"


### PR DESCRIPTION
Cross-OS (Windows WinRM + Linux SSH, ADR-0016) Ansible verb-test of the REAL dhs binary, matching the PROVEN dhs_acp1 deploy pattern. win11 has NO Go toolchain, so the role cross-builds both binaries ONCE on the control node (delegate_to localhost, GOOS/GOARCH), DEPLOYS the per-OS binary + the producer's tree fixture to each target via copy/win_copy to group_vars dhs_bin (/usr/local/bin/dhs | C:\\dhs\\dhs.exe), serves it fire-and-forget (async/poll:0 + bounded-TTL auto-expiry, no manual kill), wait_for/win_wait_for the port, then drives EVERY consumer verb asserting output. All OS variance is in the role; connector plays supply only data. probel-sw08p-verbs.yml = all 23 verbs (source-cited) + matrix_tree.json deploy. test.yml orchestrates unit-tests.yml + the verb matrices (--tags unit|smoke|<proto>, --limit <os>). Supersedes #618 (built on-target — wrong for win11). Authored to the proven WinRM-deploy pattern; go build clean, YAML parses; live run is on the Linux control node (win11 = WinRM target), other 7 connectors replicate via the role as data once the template runs green live. Co-Authored-By Claude Opus 4.8.