### PR TITLE
test(ansible): cross-OS verb plays for all connectors (push mode + acp1 + probel-sw02p…)

### DIFF
--- a/ansible/playbooks/acp1-verbs.yml
+++ b/ansible/playbooks/acp1-verbs.yml
@@ -1,0 +1,102 @@
+---
+# ACP1 VERB-TEST contract play — deploy the per-OS binary + the committed
+# synapse manifest/DM fixture, serve our acp1 producer on the target, and drive
+# the consumer verbs against it end to end over the wire. Mirrors
+# probel-sw08p-verbs.yml via the dhs_verbtest role (cross-build on control node,
+# deploy per OS, serve, drive). Per ADR-0025 deliverable 3 + ADR-0016.
+#
+# ACP1 has NO single committed tree.json — the producer assembles its tree from
+# a manifest (--manifest) + the referenced DMs under <cache-dir>/dm/acp1/ per
+# ADR-0022 (same shape acp2-integration.yml uses). We therefore deploy the
+# manifest AND each DM to a cache layout under dhs_dir and point --manifest /
+# --cache-dir at the DEPLOYED paths (never the repo path).
+#
+# Serve over TCP (Mode B, --transport tcp): the role's wait_for probes a TCP
+# port, and the consumer dials the same with --transport tcp. (Mode A UDP can't
+# be wait_for-probed cross-OS; TCP gives a deterministic loopback contract.)
+#
+# The producer is ephemeral (TTL auto-expiry), so run-twice = same result.
+#
+#   ansible-playbook -i inventory/hosts.ini playbooks/acp1-verbs.yml \
+#     -e @secrets/credentials.json
+- name: ACP1 verb test (deploy binary + manifest/DM fixture, serve on target, drive verbs)
+  hosts: linux:windows
+  gather_facts: true
+  vars:
+    vt_host: "127.0.0.1"
+    vt_port: 12071
+    # Repo fixture roots (control node) for the synapse manifest + its DMs.
+    acp1_fix: "{{ playbook_dir }}/../../internal/acp1/testdata/integration-test"
+  roles:
+    - role: dhs_verbtest
+      vars:
+        vt_proto: acp1
+
+        # Deploy the manifest + every DM it references into a cache layout under
+        # dhs_dir. manifest.BuildExport resolves DMs at <cache-dir>/dm/acp1/.
+        vt_serve_files:
+          - src: "{{ acp1_fix }}/manifest/synapse-test.json"
+            dest: "{{ dhs_dir }}/acp1fix/manifest/synapse-test.json"
+          - src: "{{ acp1_fix }}/dm/acp1/RRS18@1601.json"
+            dest: "{{ dhs_dir }}/acp1fix/dm/acp1/RRS18@1601.json"
+          - src: "{{ acp1_fix }}/dm/acp1/2GS110@2728.json"
+            dest: "{{ dhs_dir }}/acp1fix/dm/acp1/2GS110@2728.json"
+          - src: "{{ acp1_fix }}/dm/acp1/2HF110@4326.json"
+            dest: "{{ dhs_dir }}/acp1fix/dm/acp1/2HF110@4326.json"
+          - src: "{{ acp1_fix }}/dm/acp1/GED130@2522.json"
+            dest: "{{ dhs_dir }}/acp1fix/dm/acp1/GED130@2522.json"
+          - src: "{{ acp1_fix }}/dm/acp1/SDB20@0806.json"
+            dest: "{{ dhs_dir }}/acp1fix/dm/acp1/SDB20@0806.json"
+          - src: "{{ acp1_fix }}/dm/acp1/2GS110@2929.json"
+            dest: "{{ dhs_dir }}/acp1fix/dm/acp1/2GS110@2929.json"
+
+        # producer serve argv (cmd/dhs/cmd_producer.go runProducer). --manifest +
+        # --cache-dir + --transport tcp; bind loopback on the test port.
+        vt_serve_argv:
+          - --manifest
+          - "{{ dhs_dir }}/acp1fix/manifest/synapse-test.json"
+          - --cache-dir
+          - "{{ dhs_dir }}/acp1fix"
+          - --transport
+          - tcp
+          - --port
+          - "{{ vt_port }}"
+          - --host
+          - "{{ vt_host }}"
+          - --log-level
+          - error
+
+        # Consumer verbs (generic table, cmd/dhs/main.go:155-180). Each dials
+        # the served producer over TCP. host is the first token; --transport tcp
+        # + --port pin Mode B. Writable target: slot 2 (2HF110) Float "GainA"
+        # (id 59, access readWrite, step 1) — used for get/set/inc/dec/reset/
+        # ensure. NOTE: `watch` is intentionally omitted — the generic watch has
+        # no --timeout/--count bound (cmd_watch.go:44) and blocks until Ctrl-C,
+        # so it cannot be driven non-interactively in the serve loop.
+        vt_verbs:
+          # info — rack + per-slot status (cmd_info.go:9 / main.go:156).
+          - [info, "{{ vt_host }}", --transport, tcp, --port, "{{ vt_port }}", --timeout, "15s"]
+          # walk slot 0 — rack controller (cmd_walk.go / main.go:157).
+          - [walk, "{{ vt_host }}", --transport, tcp, --port, "{{ vt_port }}", --slot, "0", --timeout, "20s"]
+          # tree slot 2 — render object tree (cmd_tree.go:28 / main.go:158).
+          - [tree, "{{ vt_host }}", --transport, tcp, --port, "{{ vt_port }}", --slot, "2", --timeout, "20s"]
+          # get GainA — read one Float value (cmd_get.go:12 / main.go:159).
+          - [get, "{{ vt_host }}", --transport, tcp, --port, "{{ vt_port }}", --slot, "2", --label, GainA, --timeout, "15s"]
+          # set GainA — write a Float value (cmd_set.go:24 / main.go:160).
+          - [set, "{{ vt_host }}", --transport, tcp, --port, "{{ vt_port }}", --slot, "2", --label, GainA, --value, "3", --timeout, "15s"]
+          # inc — setIncValue, ACP1 method 2 (cmd_mutate.go:21 / main.go:161).
+          - [inc, "{{ vt_host }}", --transport, tcp, --port, "{{ vt_port }}", --slot, "2", --label, GainA, --timeout, "15s"]
+          # dec — setDecValue, ACP1 method 3 (cmd_mutate.go:22 / main.go:162).
+          - [dec, "{{ vt_host }}", --transport, tcp, --port, "{{ vt_port }}", --slot, "2", --label, GainA, --timeout, "15s"]
+          # reset — setDefValue, ACP1 method 4 (cmd_mutate.go:23 / main.go:163).
+          - [reset, "{{ vt_host }}", --transport, tcp, --port, "{{ vt_port }}", --slot, "2", --label, GainA, --timeout, "15s"]
+          # ensure — converge GainA idempotently (cmd_ensure.go:32 / main.go:164).
+          - [ensure, "{{ vt_host }}", --transport, tcp, --port, "{{ vt_port }}", --slot, "2", --label, GainA, --value, "3", --timeout, "15s"]
+          # export slot 0 to json on stdout (cmd_export.go:21 / main.go:166).
+          - [export, "{{ vt_host }}", --transport, tcp, --port, "{{ vt_port }}", --slot, "0", --format, json, --timeout, "20s"]
+          # health — 3-layer session health (cmd_health.go:15 / main.go:178).
+          - [health, "{{ vt_host }}", --transport, tcp, --port, "{{ vt_port }}", --timeout, "15s"]
+          # profile — compliance classification (cmd_profile.go:39 / main.go:175).
+          - [profile, "{{ vt_host }}", --transport, tcp, --port, "{{ vt_port }}", --timeout, "20s"]
+          # discover — bounded LAN scan; acp1-only (cmd_discover.go:16 / main.go:171).
+          - [discover, --duration, "2s", --scan-port, "{{ vt_port }}"]

--- a/ansible/playbooks/acp2-verbs.yml
+++ b/ansible/playbooks/acp2-verbs.yml
@@ -1,0 +1,88 @@
+---
+# ACP2 VERB-TEST contract play — deploy the per-OS binary + the committed
+# Neuron manifest/DM fixture, serve our acp2 producer on the target, and drive
+# the consumer verbs against it end to end over the wire. Mirrors
+# acp1-verbs.yml via the dhs_verbtest role (cross-build on control node, deploy
+# per OS, serve, drive). Per ADR-0025 deliverable 3 + ADR-0016.
+#
+# ACP2 has NO single committed tree.json and NO vendor emulator (the Neuron is
+# our own emulator): the producer assembles its tree from a manifest
+# (--manifest) + the referenced DMs under <cache-dir>/dm/acp2/ per ADR-0022
+# (same shape acp2-integration.yml uses). We therefore deploy the manifest AND
+# each DM to a cache layout under dhs_dir and point --manifest / --cache-dir at
+# the DEPLOYED paths (never the repo path).
+#
+# Transport: ACP2 is AN2/TCP only (cmd/dhs/main.go:520). The producer's serve
+# loop runs the provider's default Serve (cmd/dhs/cmd_producer.go:416 — the
+# --transport flag is acp1-only, cmd_producer.go:60), and the consumer dials
+# with --port only (default --transport auto is TCP-first, common.go:67). The
+# role's wait_for probes the same TCP port. Default ACP2 port is 2072
+# (internal/acp2/codec/types.go:23); we serve on a distinct test port.
+#
+# The producer is ephemeral (TTL auto-expiry), so run-twice = same result.
+#
+#   ansible-playbook -i inventory/hosts.ini playbooks/acp2-verbs.yml \
+#     -e @secrets/credentials.json
+- name: ACP2 verb test (deploy binary + manifest/DM fixture, serve on target, drive verbs)
+  hosts: linux:windows
+  gather_facts: true
+  vars:
+    vt_host: "127.0.0.1"
+    vt_port: 12072
+    # Repo fixture roots (control node) for the Neuron manifest + its DMs.
+    acp2_fix: "{{ playbook_dir }}/../../internal/acp2/testdata/integration-test"
+  roles:
+    - role: dhs_verbtest
+      vars:
+        vt_proto: acp2
+
+        # Deploy the manifest + every DM it references into a cache layout under
+        # dhs_dir. manifest.BuildExport resolves DMs at <cache-dir>/dm/acp2/.
+        # The two DMs are the slots in neuron-test.json (slot 0 SHPRM1, slot 1
+        # CONVERT Hybrid).
+        vt_serve_files:
+          - src: "{{ acp2_fix }}/manifest/neuron-test.json"
+            dest: "{{ dhs_dir }}/acp2fix/manifest/neuron-test.json"
+          - src: "{{ acp2_fix }}/dm/acp2/SHPRM1@5.3.5.json"
+            dest: "{{ dhs_dir }}/acp2fix/dm/acp2/SHPRM1@5.3.5.json"
+          - src: "{{ acp2_fix }}/dm/acp2/CONVERT Hybrid@6.7.4.json"
+            dest: "{{ dhs_dir }}/acp2fix/dm/acp2/CONVERT Hybrid@6.7.4.json"
+
+        # producer serve argv (cmd/dhs/cmd_producer.go runProducer). --manifest +
+        # --cache-dir (lines 46-47) + --port/--host (48-49); bind loopback on the
+        # test port. No --transport: it is acp1-only (cmd_producer.go:60) and
+        # acp2 serves its default AN2/TCP.
+        vt_serve_argv:
+          - --manifest
+          - "{{ dhs_dir }}/acp2fix/manifest/neuron-test.json"
+          - --cache-dir
+          - "{{ dhs_dir }}/acp2fix"
+          - --port
+          - "{{ vt_port }}"
+          - --host
+          - "{{ vt_host }}"
+          - --log-level
+          - error
+
+        # Consumer verbs (generic table, cmd/dhs/main.go:155-180; dispatched via
+        # dispatchConsumer with --protocol acp2 injected, main.go:262-316). Each
+        # dials the served producer; host is the first token; --port pins the
+        # test port (common.go:71), --timeout the per-op deadline (common.go:72).
+        # NOTE: `watch` is intentionally omitted — the generic watch has no
+        # --timeout/--count bound (cmd_watch.go has no timeout flag) so it blocks
+        # until Ctrl-C and cannot run non-interactively. Mirrors acp1-verbs.yml.
+        vt_verbs:
+          # info — rack + per-slot status (cmd_info.go / main.go:156).
+          - [info, "{{ vt_host }}", --port, "{{ vt_port }}", --timeout, "15s"]
+          # walk slot 0 — SHPRM1 rack controller (cmd_walk.go:22 / main.go:157).
+          - [walk, "{{ vt_host }}", --port, "{{ vt_port }}", --slot, "0", --timeout, "25s"]
+          # walk slot 1 — CONVERT Hybrid card (cmd_walk.go:22 / main.go:157).
+          - [walk, "{{ vt_host }}", --port, "{{ vt_port }}", --slot, "1", --timeout, "25s"]
+          # tree slot 0 — render object tree (cmd_tree.go:31 / main.go:158).
+          - [tree, "{{ vt_host }}", --port, "{{ vt_port }}", --slot, "0", --timeout, "25s"]
+          # export slot 0 to json on stdout (cmd_export.go:24-26 / main.go:166).
+          - [export, "{{ vt_host }}", --port, "{{ vt_port }}", --slot, "0", --format, json, --timeout, "25s"]
+          # diag slot 0 — ACP2 diagnostic probes (cmd_diag.go:17 / main.go:176).
+          - [diag, "{{ vt_host }}", --port, "{{ vt_port }}", --slot, "0", --timeout, "20s"]
+          # health — 3-layer session health (cmd_health.go / main.go:178).
+          - [health, "{{ vt_host }}", --port, "{{ vt_port }}", --timeout, "15s"]

--- a/ansible/playbooks/cerebrum-nb-verbs.yml
+++ b/ansible/playbooks/cerebrum-nb-verbs.yml
@@ -1,0 +1,294 @@
+---
+# Cerebrum NB VERB-TEST contract play (EXTERNAL-ONLY) — deploy the per-OS binary
+# to each target, then drive the READ-ONLY Cerebrum Northbound consumer verbs
+# against a LIVE, licensed EVS Cerebrum oracle. Per ADR-0025 deliverable 3 +
+# ADR-0016.
+#
+# ⚠ LICENCE REQUIRED. A live run needs the NB northbound LICENCE enabled on the
+# target Cerebrum (one licence per active WebSocket session). Cerebrum is
+# consumer-only: there is NO provider and NO emulator (internal/cerebrum-nb/
+# docs/provider.md), so there is NO serve/push/loopback tier — this play does
+# NOT use the dhs_verbtest role's serve or push paths. It mirrors that role's
+# cross-OS DEPLOY (copy/win_copy) + the dhs_acp1 per-OS command dispatch, but
+# INLINE (deploy binary, then run read-only verbs against the external oracle).
+#
+# GATING: skips cleanly (meta: end_play) unless CEREBRUM_TEST_HOST +
+# DHS_CEREBRUM_USER + DHS_CEREBRUM_PASS are all set, so it is safe to invoke
+# unconditionally (CI / agent). Read-only verbs (connect / list-* / *-details /
+# keepalive-probe) → changed_when:false → idempotent BY CONSTRUCTION.
+#
+# Cerebrum NB speaks XML-over-WebSocket on TCP 40007 (CEREBRUM_TEST_PORT
+# overrides). The cross-build of bin/dhs-* happens on the control node exactly
+# as the dhs_verbtest role does it (go build per GOOS), so the target needs no
+# Go toolchain.
+#
+#   CEREBRUM_TEST_HOST=10.6.239.50 \
+#   DHS_CEREBRUM_USER=admin DHS_CEREBRUM_PASS=s3cr3t \
+#     ansible-playbook -i inventory/hosts.ini playbooks/cerebrum-nb-verbs.yml
+- name: Cerebrum NB verb test (deploy binary per OS, drive read-only verbs vs live oracle)
+  hosts: linux:windows
+  gather_facts: true
+  vars:
+    # Oracle coordinates from the environment (control-node env), mirroring
+    # cerebrum-nb-integration.yml. Empty → skip.
+    cerebrum_host: "{{ lookup('ansible.builtin.env', 'CEREBRUM_TEST_HOST') | default('', true) }}"
+    cerebrum_port: "{{ lookup('ansible.builtin.env', 'CEREBRUM_TEST_PORT') | default('40007', true) }}"
+    cerebrum_user: "{{ lookup('ansible.builtin.env', 'DHS_CEREBRUM_USER') | default('', true) }}"
+    cerebrum_pass: "{{ lookup('ansible.builtin.env', 'DHS_CEREBRUM_PASS') | default('', true) }}"
+  tasks:
+    - name: Skip when no Cerebrum oracle is configured (host or creds unset)
+      ansible.builtin.meta: end_play
+      when: >-
+        (cerebrum_host | length) == 0
+        or (cerebrum_user | length) == 0
+        or (cerebrum_pass | length) == 0
+
+    # ---- Cross-build BOTH per-OS binaries ONCE on the control node ----------
+    # Mirrors dhs_verbtest/tasks/main.yml: build each artifact regardless of the
+    # current target so a mixed linux+windows play builds each exactly once. The
+    # output paths are EXACTLY what group_vars dhs_local_binary point at.
+    - name: Cross-build the linux dhs binary on the control node
+      ansible.builtin.command:
+        argv:
+          - go
+          - build
+          - -o
+          - "{{ playbook_dir }}/../../bin/dhs-linux-amd64"
+          - ./cmd/dhs
+        chdir: "{{ playbook_dir }}/../.."
+      environment:
+        GOOS: linux
+        GOARCH: amd64
+      delegate_to: localhost
+      run_once: true
+      changed_when: false
+
+    - name: Cross-build the windows dhs binary on the control node
+      ansible.builtin.command:
+        argv:
+          - go
+          - build
+          - -o
+          - "{{ playbook_dir }}/../../bin/dhs-windows-amd64.exe"
+          - ./cmd/dhs
+        chdir: "{{ playbook_dir }}/../.."
+      environment:
+        GOOS: windows
+        GOARCH: amd64
+      delegate_to: localhost
+      run_once: true
+      changed_when: false
+
+    # ---- Deploy the per-OS binary (mirror dhs_acp1 deploy tasks) ------------
+    # POSIX (SSH) — file + copy.
+    - name: Create the dhs install directory (POSIX)
+      ansible.builtin.file:
+        path: "{{ dhs_dir }}"
+        state: directory
+        mode: "0755"
+      when: ansible_os_family != "Windows"
+
+    - name: Deploy the linux dhs binary (POSIX)
+      ansible.builtin.copy:
+        src: "{{ dhs_local_binary }}"
+        dest: "{{ dhs_bin }}"
+        mode: "0755"
+      when: ansible_os_family != "Windows"
+
+    # Windows (WinRM) — win_file + win_copy.
+    - name: Create the dhs install directory (Windows)
+      ansible.windows.win_file:
+        path: "{{ dhs_dir }}"
+        state: directory
+      when: ansible_os_family == "Windows"
+
+    - name: Deploy the windows dhs binary (Windows)
+      ansible.windows.win_copy:
+        src: "{{ dhs_local_binary }}"
+        dest: "{{ dhs_bin }}"
+      when: ansible_os_family == "Windows"
+
+    # ---- Drive the READ-ONLY consumer verbs (cmd/dhs/cmd_cerebrum.go) -------
+    # Dispatcher: runCerebrum switch (cmd_cerebrum.go:111-155). Common flags
+    # --port/--user/--pass/--timeout from newCerebrumFlags (cmd_cerebrum.go:33-43).
+    # Each verb is read-only (OBTAIN / POLL / DIAGNOSTIC) → changed_when:false.
+    # Per OS, command (POSIX) vs win_command (Windows) — mirrors dhs_acp1.
+
+    # connect — POLL sanity + redundancy probe (cmd_cerebrum.go:112,396).
+    - name: "connect — LOGIN + POLL (POSIX)"
+      ansible.builtin.command:
+        argv:
+          - "{{ dhs_bin }}"
+          - consumer
+          - cerebrum-nb
+          - connect
+          - "{{ cerebrum_host }}"
+          - --port
+          - "{{ cerebrum_port | string }}"
+          - --user
+          - "{{ cerebrum_user }}"
+          - --pass
+          - "{{ cerebrum_pass }}"
+          - --timeout
+          - "15s"
+      register: cere_connect_posix
+      changed_when: false
+      failed_when: cere_connect_posix.rc != 0
+      when: ansible_os_family != "Windows"
+
+    - name: "connect — LOGIN + POLL (Windows)"
+      ansible.windows.win_command:
+        argv:
+          - "{{ dhs_bin }}"
+          - consumer
+          - cerebrum-nb
+          - connect
+          - "{{ cerebrum_host }}"
+          - --port
+          - "{{ cerebrum_port | string }}"
+          - --user
+          - "{{ cerebrum_user }}"
+          - --pass
+          - "{{ cerebrum_pass }}"
+          - --timeout
+          - "15s"
+      register: cere_connect_win
+      changed_when: false
+      failed_when: cere_connect_win.rc != 0
+      when: ansible_os_family == "Windows"
+
+    # list-devices — OBTAIN device_change LIST (cmd_cerebrum.go:116,481).
+    - name: "list-devices — OBTAIN device list (POSIX)"
+      ansible.builtin.command:
+        argv:
+          - "{{ dhs_bin }}"
+          - consumer
+          - cerebrum-nb
+          - list-devices
+          - "{{ cerebrum_host }}"
+          - --port
+          - "{{ cerebrum_port | string }}"
+          - --user
+          - "{{ cerebrum_user }}"
+          - --pass
+          - "{{ cerebrum_pass }}"
+          - --timeout
+          - "20s"
+      register: cere_devices_posix
+      changed_when: false
+      failed_when: cere_devices_posix.rc != 0
+      when: ansible_os_family != "Windows"
+
+    - name: "list-devices — OBTAIN device list (Windows)"
+      ansible.windows.win_command:
+        argv:
+          - "{{ dhs_bin }}"
+          - consumer
+          - cerebrum-nb
+          - list-devices
+          - "{{ cerebrum_host }}"
+          - --port
+          - "{{ cerebrum_port | string }}"
+          - --user
+          - "{{ cerebrum_user }}"
+          - --pass
+          - "{{ cerebrum_pass }}"
+          - --timeout
+          - "20s"
+      register: cere_devices_win
+      changed_when: false
+      failed_when: cere_devices_win.rc != 0
+      when: ansible_os_family == "Windows"
+
+    # list-categories — OBTAIN category_change CATEGORY_LIST (cmd_cerebrum.go:122,652).
+    - name: "list-categories — OBTAIN category list (POSIX)"
+      ansible.builtin.command:
+        argv:
+          - "{{ dhs_bin }}"
+          - consumer
+          - cerebrum-nb
+          - list-categories
+          - "{{ cerebrum_host }}"
+          - --port
+          - "{{ cerebrum_port | string }}"
+          - --user
+          - "{{ cerebrum_user }}"
+          - --pass
+          - "{{ cerebrum_pass }}"
+          - --timeout
+          - "20s"
+      register: cere_cats_posix
+      changed_when: false
+      failed_when: cere_cats_posix.rc != 0
+      when: ansible_os_family != "Windows"
+
+    - name: "list-categories — OBTAIN category list (Windows)"
+      ansible.windows.win_command:
+        argv:
+          - "{{ dhs_bin }}"
+          - consumer
+          - cerebrum-nb
+          - list-categories
+          - "{{ cerebrum_host }}"
+          - --port
+          - "{{ cerebrum_port | string }}"
+          - --user
+          - "{{ cerebrum_user }}"
+          - --pass
+          - "{{ cerebrum_pass }}"
+          - --timeout
+          - "20s"
+      register: cere_cats_win
+      changed_when: false
+      failed_when: cere_cats_win.rc != 0
+      when: ansible_os_family == "Windows"
+
+    # list-salvo-groups — OBTAIN salvo_change GROUP_LIST (cmd_cerebrum.go:126,717).
+    - name: "list-salvo-groups — OBTAIN salvo group list (POSIX)"
+      ansible.builtin.command:
+        argv:
+          - "{{ dhs_bin }}"
+          - consumer
+          - cerebrum-nb
+          - list-salvo-groups
+          - "{{ cerebrum_host }}"
+          - --port
+          - "{{ cerebrum_port | string }}"
+          - --user
+          - "{{ cerebrum_user }}"
+          - --pass
+          - "{{ cerebrum_pass }}"
+          - --timeout
+          - "20s"
+      register: cere_salvos_posix
+      changed_when: false
+      failed_when: cere_salvos_posix.rc != 0
+      when: ansible_os_family != "Windows"
+
+    - name: "list-salvo-groups — OBTAIN salvo group list (Windows)"
+      ansible.windows.win_command:
+        argv:
+          - "{{ dhs_bin }}"
+          - consumer
+          - cerebrum-nb
+          - list-salvo-groups
+          - "{{ cerebrum_host }}"
+          - --port
+          - "{{ cerebrum_port | string }}"
+          - --user
+          - "{{ cerebrum_user }}"
+          - --pass
+          - "{{ cerebrum_pass }}"
+          - --timeout
+          - "20s"
+      register: cere_salvos_win
+      changed_when: false
+      failed_when: cere_salvos_win.rc != 0
+      when: ansible_os_family == "Windows"
+
+    - name: Cerebrum NB verb test result
+      ansible.builtin.debug:
+        msg: >-
+          Cerebrum NB verb test: drove connect + list-devices + list-categories
+          + list-salvo-groups vs {{ cerebrum_host }}:{{ cerebrum_port }}
+          (live licensed oracle, read-only / idempotent; no provider / no loopback by design)

--- a/ansible/playbooks/emberplus-verbs.yml
+++ b/ansible/playbooks/emberplus-verbs.yml
@@ -1,0 +1,116 @@
+---
+# Ember+ VERB-TEST contract play — deploy the per-OS binary + the committed
+# Ember+ manifest/DM fixture, serve our emberplus producer on the target, and
+# drive the consumer verbs against it end to end over the wire. Mirrors
+# probel-sw08p-verbs.yml / acp1-verbs.yml via the dhs_verbtest role (cross-build
+# on control node, deploy per OS, serve, drive). Per ADR-0025 deliverable 3 +
+# ADR-0016.
+#
+# Ember+ has NO single committed tree.json: like acp1/acp2 the producer
+# assembles its tree from a manifest (--manifest) + the referenced DMs under
+# <cache-dir>/dm/emberplus/ per ADR-0022. The manifest device name is
+# "dhs-emberplus-integration" (internal/emberplus/testdata/integration-test/
+# manifest/emberplus-integration.json), so served tree paths are prefixed with
+# that name — e.g. the nToN matrix is dhs-emberplus-integration.nToN.matrix
+# (cmd/dhs/main.go:190-192 bench help is authoritative for the composed path).
+# We deploy the manifest AND each of the 7 DMs to a cache layout under dhs_dir
+# and point --manifest / --cache-dir at the DEPLOYED paths (never the repo path).
+#
+# Transport: Ember+ is S101 over TCP (internal/emberplus/CLAUDE.md "Transport").
+# The producer's serve loop runs the provider's default Serve
+# (cmd/dhs/cmd_producer.go:416); the consumer dials with --port only. The role's
+# wait_for probes the same TCP port. Default Ember+ port is 9010
+# (internal/emberplus/provider/plugin.go:28); we serve on a distinct test port.
+#
+# OUR provider IS the Ember+ emulator (committed DM fixture). The producer is
+# ephemeral (TTL auto-expiry); matrix/invoke mutate the EPHEMERAL emulator only,
+# so run-twice = same result.
+#
+#   ansible-playbook -i inventory/hosts.ini playbooks/emberplus-verbs.yml \
+#     -e @secrets/credentials.json
+- name: Ember+ verb test (deploy binary + manifest/DM fixture, serve on target, drive verbs)
+  hosts: linux:windows
+  gather_facts: true
+  vars:
+    vt_host: "127.0.0.1"
+    vt_port: 19010
+    # Repo fixture roots (control node) for the Ember+ manifest + its DMs.
+    ember_fix: "{{ playbook_dir }}/../../internal/emberplus/testdata/integration-test"
+  roles:
+    - role: dhs_verbtest
+      vars:
+        vt_proto: emberplus
+
+        # Deploy the manifest + every DM it references into a cache layout under
+        # dhs_dir. manifest.BuildExport resolves DMs at <cache-dir>/dm/emberplus/.
+        # The 7 DMs are the slots in emberplus-integration.json (oid 1.0..1.6).
+        vt_serve_files:
+          - src: "{{ ember_fix }}/manifest/emberplus-integration.json"
+            dest: "{{ dhs_dir }}/emberfix/manifest/emberplus-integration.json"
+          - src: "{{ ember_fix }}/dm/emberplus/identity-strict@1.0.0.json"
+            dest: "{{ dhs_dir }}/emberfix/dm/emberplus/identity-strict@1.0.0.json"
+          - src: "{{ ember_fix }}/dm/emberplus/oneToN-strict@1.0.0.json"
+            dest: "{{ dhs_dir }}/emberfix/dm/emberplus/oneToN-strict@1.0.0.json"
+          - src: "{{ ember_fix }}/dm/emberplus/oneToOne-strict@1.0.0.json"
+            dest: "{{ dhs_dir }}/emberfix/dm/emberplus/oneToOne-strict@1.0.0.json"
+          - src: "{{ ember_fix }}/dm/emberplus/nToN-strict@1.0.0.json"
+            dest: "{{ dhs_dir }}/emberfix/dm/emberplus/nToN-strict@1.0.0.json"
+          - src: "{{ ember_fix }}/dm/emberplus/dynamic-strict@1.0.0.json"
+            dest: "{{ dhs_dir }}/emberfix/dm/emberplus/dynamic-strict@1.0.0.json"
+          - src: "{{ ember_fix }}/dm/emberplus/functions-strict@1.0.0.json"
+            dest: "{{ dhs_dir }}/emberfix/dm/emberplus/functions-strict@1.0.0.json"
+          - src: "{{ ember_fix }}/dm/emberplus/glow-types-strict@1.0.0.json"
+            dest: "{{ dhs_dir }}/emberfix/dm/emberplus/glow-types-strict@1.0.0.json"
+
+        # producer serve argv (cmd/dhs/cmd_producer.go runProducer). --manifest +
+        # --cache-dir (lines 46-47) + --port/--host (48-49). No --transport: it
+        # is acp1-only (cmd_producer.go:60); emberplus serves S101/TCP by default.
+        vt_serve_argv:
+          - --manifest
+          - "{{ dhs_dir }}/emberfix/manifest/emberplus-integration.json"
+          - --cache-dir
+          - "{{ dhs_dir }}/emberfix"
+          - --port
+          - "{{ vt_port }}"
+          - --host
+          - "{{ vt_host }}"
+          - --log-level
+          - error
+
+        # Consumer verbs (generic table, cmd/dhs/main.go:155-180; dispatched via
+        # dispatchConsumer with --protocol emberplus injected, main.go:262-316).
+        # Each dials the served producer; host is the first token; --port pins
+        # the test port (common.go:71), --timeout the per-op deadline
+        # (common.go:72). Ember+ addresses by dotted --path (cmd_get.go:20,
+        # cmd_matrix.go:17, cmd_invoke.go:19) prefixed with the device name.
+        # NOTE: `watch` and `stream` are intentionally omitted — both block on
+        # ctx until Ctrl-C with no --timeout/--count bound, so they cannot run
+        # non-interactively in the serve loop. Mirrors acp1-verbs.yml's watch
+        # omission.
+        vt_verbs:
+          # info — provider device summary (cmd_info.go / main.go:156).
+          - [info, "{{ vt_host }}", --port, "{{ vt_port }}", --timeout, "20s"]
+          # walk slot 0 — full glow tree (cmd_walk.go:22 / main.go:157).
+          - [walk, "{{ vt_host }}", --port, "{{ vt_port }}", --slot, "0", --timeout, "45s"]
+          # tree slot 0 — render object tree (cmd_tree.go:31 / main.go:158).
+          - [tree, "{{ vt_host }}", --port, "{{ vt_port }}", --slot, "0", --timeout, "45s"]
+          # get a scalar parameter on the identity node by path (cmd_get.go:20 /
+          # main.go:159). identity is oid 1.0; product is a string parameter.
+          - [get, "{{ vt_host }}", --port, "{{ vt_port }}", --path, "dhs-emberplus-integration.identity.product", --timeout, "20s"]
+          # matrix — connect a crosspoint on the nToN matrix (cmd_matrix.go:16-21
+          # / main.go:172). path prefixed with the device name; op=connect.
+          - [matrix, "{{ vt_host }}", --port, "{{ vt_port }}", --path, "dhs-emberplus-integration.nToN.matrix", --target, "0", --sources, "1", --op, connect, --timeout, "30s"]
+          # invoke — call an Ember+ function (cmd_invoke.go:18-22 / main.go:173).
+          # functions node is oid 1.5; listLocks (oid 1.5.2) takes a single
+          # string arg matrixPath (functions-strict@1.0.0.json), so --args is
+          # the matrix path. --args is comma-separated (cmd_invoke.go:20).
+          - [invoke, "{{ vt_host }}", --port, "{{ vt_port }}", --path, "dhs-emberplus-integration.functions.listLocks", --args, "dhs-emberplus-integration.nToN.matrix", --timeout, "30s"]
+          # profile — classify provider compliance (cmd_profile.go / main.go:175).
+          - [profile, "{{ vt_host }}", --port, "{{ vt_port }}", --timeout, "30s"]
+          # export slot 0 to json on stdout (cmd_export.go:24-26 / main.go:166).
+          - [export, "{{ vt_host }}", --port, "{{ vt_port }}", --slot, "0", --format, json, --timeout, "45s"]
+          # bench — N matrix crosspoint ops over one TCP session (cmd_emberplus_bench.go
+          # / main.go:179). --dm + --path per the bench help (main.go:190-192).
+          - [bench, "{{ vt_host }}", --port, "{{ vt_port }}", --dm, "dhs-emberplus-integration@1.0.0", --path, "dhs-emberplus-integration.nToN.matrix", --n, "8", --op, connect]
+          # health — 3-layer session health (cmd_health.go / main.go:178).
+          - [health, "{{ vt_host }}", --port, "{{ vt_port }}", --timeout, "20s"]

--- a/ansible/playbooks/osc-verbs.yml
+++ b/ansible/playbooks/osc-verbs.yml
@@ -1,0 +1,68 @@
+---
+# OSC (Open Sound Control 1.0 + 1.1) VERB-TEST contract play (PUSH mode) —
+# deploy the per-OS binary, start a backgrounded consumer WATCH on the target
+# that decodes received messages to a capture file, fire producer SENDs, then
+# read the capture back and assert the watcher decoded the address + args.
+# Mirrors osc-integration.yml's loopback tier but driven entirely through the
+# dhs_verbtest role (push mode). Per ADR-0025 deliverable 3 + ADR-0016.
+#
+# OSC is a symmetric PUSH protocol (cmd/dhs/cmd_osc.go:1-16): a producer SENDs
+# to a consumer that WATCHes. There is no serve+query, so this uses the role's
+# push path (vt_mode: push):
+#   - vt_listen_argv     → consumer watch ... (cmd_osc.go:74 runOSCWatch)
+#   - vt_send_argv_list  → producer send ...  (cmd_osc.go:117 runOSCSend)
+#   - vt_push_assert_contains → decoded tokens the watcher must print
+#
+# VERSION SCOPE: the role prepends a SINGLE `dhs consumer <vt_proto>` for the
+# watcher and `dhs producer <vt_proto>` for every send, so one play pins ONE
+# version. This play pins osc-v11 over UDP (works for both versions; default
+# port 8000, cmd_osc.go:76). Transport variants tcp-len (osc-v10 only) and
+# tcp-slip (osc-v11 only) are gated by requireVersion (cmd_osc.go:344-352): a
+# tcp-len play needs vt_proto: osc-v10; a tcp-slip play needs vt_proto: osc-v11.
+# The osc-integration.yml loopback covers the udp path for osc-v11; per-transport
+# verb plays can be added by cloning this file with the matching vt_proto +
+# --listen / --transport.
+#
+# The watcher is ephemeral (TTL auto-expiry via the role) and a single UDP
+# datagram leaves no persistent state, so run-twice = same result (ADR-0025).
+#
+#   ansible-playbook -i inventory/hosts.ini playbooks/osc-verbs.yml \
+#     -e @secrets/credentials.json
+- name: OSC verb test (deploy binary, watch on target, send messages, assert decode)
+  hosts: linux:windows
+  gather_facts: true
+  vars:
+    vt_host: "127.0.0.1"
+    vt_port: 18050
+  roles:
+    - role: dhs_verbtest
+      vars:
+        vt_proto: osc-v11
+        vt_mode: push
+
+        # Consumer WATCH argv tail (after `dhs consumer osc-v11`). UDP listener
+        # on the test port — cmd_osc.go:74-113 runOSCWatch, --listen transport:port
+        # at cmd_osc.go:76. The role captures its decoded stdout to vt_listen_capture.
+        vt_listen_argv:
+          - watch
+          - --listen
+          - "udp:{{ vt_port }}"
+
+        # Producer SEND argvs (each appended after `dhs producer osc-v11`).
+        # send is one-shot emit — cmd_osc.go:62-63 / runOSCSend. Flags: --to
+        # (cmd_osc.go:119), --transport (120), --address (121), --types (122);
+        # positional args follow --types (cmd_osc.go:134 fs.Args). The type-tag
+        # 'i' consumes one int token, 's' one string (cmd_osc.go:386,426).
+        vt_send_argv_list:
+          - [send, --to, "{{ vt_host }}:{{ vt_port }}", --transport, udp, --address, "/vt/int", --types, i, "7"]
+          - [send, --to, "{{ vt_host }}:{{ vt_port }}", --transport, udp, --address, "/vt/str", --types, s, "VT-OSC"]
+
+        # Tokens the watcher MUST have decoded. printPacket renders each message
+        # as "[transport] /address  ,tags  args" (cmd_osc.go:516-527); a string
+        # arg is quoted via strconv.Quote (cmd_osc.go:549). So the watcher prints
+        # e.g.  [udp      ] /vt/int  ,i  7   and   [udp      ] /vt/str  ,s  "VT-OSC".
+        vt_push_assert_contains:
+          - "/vt/int"
+          - ",i"
+          - "/vt/str"
+          - '"VT-OSC"'

--- a/ansible/playbooks/probel-sw02p-verbs.yml
+++ b/ansible/playbooks/probel-sw02p-verbs.yml
@@ -1,0 +1,82 @@
+---
+# Probel SW-P-02 VERB-TEST contract play — drives the FULL consumer verb
+# catalogue on the TARGET against OUR producer served on the SAME target, end to
+# end over the wire. Mirrors probel-sw08p-verbs.yml exactly (deploy binary +
+# fixture, serve on target, drive every verb) per ADR-0025 deliverable 3
+# (Ansible the exclusive integration/verify/deploy driver) and ADR-0016
+# (one multi-OS binary, identical on every platform).
+#
+# SW-P-02 is single-matrix / single-level on the wire (§3.1), so unlike SW-P-08
+# the verbs carry NO --matrix / --level flags — host:port first, then per-verb
+# --dst / --src etc. (cmd/dhs/cmd_probel02p.go dispatcher lines 59-89).
+#
+# SW-P-02 has no separate vendor emulator: OUR provider IS the matrix emulator
+# (the committed demo matrix tree). The producer is ephemeral (TTL auto-expiry),
+# so run-twice = same result.
+#
+#   ansible-playbook -i inventory/hosts.ini playbooks/probel-sw02p-verbs.yml \
+#     -e @secrets/credentials.json
+- name: Probel SW-P-02 verb test (deploy binary + fixture, serve on target, drive every verb)
+  hosts: linux:windows
+  gather_facts: true
+  vars:
+    vt_host: "127.0.0.1"
+    vt_port: 12902
+  roles:
+    - role: dhs_verbtest
+      vars:
+        vt_proto: probel-sw02p
+
+        # Committed single-matrix demo tree; dest under dhs_dir (per-OS path).
+        vt_serve_files:
+          - src: "{{ playbook_dir }}/../../internal/probel-sw02p/testdata/exports/matrix_tree.json"
+            dest: "{{ dhs_dir }}/sw02p_matrix_tree.json"
+
+        # producer serve argv — --tree points at the DEPLOYED fixture on target.
+        vt_serve_argv:
+          - --tree
+          - "{{ dhs_dir }}/sw02p_matrix_tree.json"
+          - --port
+          - "{{ vt_port }}"
+          - --host
+          - "{{ vt_host }}"
+          - --log-level
+          - error
+
+        # Every SW-P-02 consumer verb (cmd_probel02p.go switch, lines 59-89).
+        # Each entry is the argv tail after `dhs consumer probel-sw02p`.
+        vt_verbs:
+          # --- core routing verbs ---
+          # connect: route src→dst (rx 02). cmd_probel02p.go:95 runProbelsw02pConnect.
+          - [connect, "{{ vt_host }}:{{ vt_port }}", --dst, "2", --src, "5"]
+          # interrogate: read current src on a dst (rx 01). cmd_probel02p.go:65.
+          - [interrogate, "{{ vt_host }}:{{ vt_port }}", --dst, "2"]
+          # connect-on-go: stage one crosspoint into the pending buffer (rx 05). :125.
+          - [connect-on-go, "{{ vt_host }}:{{ vt_port }}", --dst, "3", --src, "6"]
+          # go: commit the pending buffer (rx 06, --op set). :146.
+          - [go, "{{ vt_host }}:{{ vt_port }}", --op, set]
+          # salvo-connect: stage N crosspoints under a group then fire (rx 35+36). :180.
+          - [salvo-connect, "{{ vt_host }}:{{ vt_port }}", --src, "4", --dsts, "0-3", --salvo, "1"]
+          # --- protect family (Extended rx 101/102/104/105/103) ---
+          # protect-interrogate: read protect state on a dst (rx 101). :291.
+          - [protect-interrogate, "{{ vt_host }}:{{ vt_port }}", --dst, "2"]
+          # protect-connect: set a protect for a device (rx 102). :249.
+          - [protect-connect, "{{ vt_host }}:{{ vt_port }}", --dst, "2", --device, "9"]
+          # protect-disconnect: clear a protect (rx 104). :270.
+          - [protect-disconnect, "{{ vt_host }}:{{ vt_port }}", --dst, "2", --device, "9"]
+          # protect-dump: request a protect tally-dump fan-out (rx 105). :312.
+          - [protect-dump, "{{ vt_host }}:{{ vt_port }}", --first-dst, "0", --count, "8", --collect, "1s"]
+          # protect-name: resolve a device id → name (rx 103). :376.
+          - [protect-name, "{{ vt_host }}:{{ vt_port }}", --device, "9"]
+          # --- status / config (read-only) ---
+          # dual-status: dual-controller redundancy state (rx 050). :405.
+          - [dual-status, "{{ vt_host }}:{{ vt_port }}"]
+          # lock-status: source-lock bitmap, GET-only (rx 014). :430.
+          - [lock-status, "{{ vt_host }}:{{ vt_port }}", --controller, lh]
+          # status: controller status-2 (rx 07). :470.
+          - [status, "{{ vt_host }}:{{ vt_port }}", --controller, lh]
+          # router-config: router config / level map (rx 075). :501.
+          - [router-config, "{{ vt_host }}:{{ vt_port }}"]
+          # --- watch (bounded with --timeout so it returns) ---
+          # watch: subscribe to async tallies until --timeout (cmd_probel02p.go:351).
+          - [watch, "{{ vt_host }}:{{ vt_port }}", --dsts, "8", --srcs, "8", --timeout, "3s"]

--- a/ansible/playbooks/test.yml
+++ b/ansible/playbooks/test.yml
@@ -22,13 +22,17 @@
 # (The integration tier = the same <proto>-verbs.yml verb matrices pointed at a
 # live device/oracle; the smoke tier above is the loopback equivalent.)
 - import_playbook: unit-tests.yml
+# SMOKE — per-connector verb matrices (data-only replication via the dhs_verbtest
+# role). serve mode: probel-sw08p / probel-sw02p / acp1 / acp2 / emberplus drive
+# `producer serve` + every consumer verb. push mode: tsl / osc start a consumer
+# listen + fire producer sends, asserting the decoded frames. external-only:
+# cerebrum-nb deploys the binary and drives read-only verbs vs a live licensed
+# oracle (skips cleanly when CEREBRUM_TEST_HOST + creds are unset).
 - import_playbook: probel-sw08p-verbs.yml
-# TODO (data-only replication via the dhs_verbtest role, once the probel-sw08p
-# template is confirmed green on a live Linux + win11 run):
-#   - import_playbook: acp1-verbs.yml
-#   - import_playbook: acp2-verbs.yml
-#   - import_playbook: emberplus-verbs.yml
-#   - import_playbook: probel-sw02p-verbs.yml
-#   - import_playbook: tsl-verbs.yml
-#   - import_playbook: osc-verbs.yml
-#   - import_playbook: cerebrum-nb-verbs.yml   # external-only (no provider/loopback)
+- import_playbook: probel-sw02p-verbs.yml
+- import_playbook: acp1-verbs.yml
+- import_playbook: acp2-verbs.yml
+- import_playbook: emberplus-verbs.yml
+- import_playbook: tsl-verbs.yml
+- import_playbook: osc-verbs.yml
+- import_playbook: cerebrum-nb-verbs.yml   # external-only (no provider/loopback)

--- a/ansible/playbooks/tsl-verbs.yml
+++ b/ansible/playbooks/tsl-verbs.yml
@@ -1,0 +1,68 @@
+---
+# TSL UMD VERB-TEST contract play (PUSH mode) — deploy the per-OS binary, start
+# a backgrounded consumer LISTEN on the target that decodes received frames to a
+# capture file, fire producer SENDs, then read the capture back and assert the
+# pushed UMD labels were decoded. Mirrors tsl-integration.yml's loopback tier
+# but driven entirely through the dhs_verbtest role (push mode). Per ADR-0025
+# deliverable 3 + ADR-0016.
+#
+# TSL is a tally/UMD PUSH protocol (cmd/dhs/cmd_tsl.go:17-25): the producer is
+# the tally SOURCE (send/serve) and the consumer is the LISTENER (listen). There
+# is no serve+query, so this uses the role's push path (vt_mode: push):
+#   - vt_listen_argv     → consumer listen ... (cmd_tsl.go:42 runTSLListen)
+#   - vt_send_argv_list  → producer send ...   (cmd_tsl_producer.go:121 runTSLSend)
+#   - vt_push_assert_contains → decoded tokens the listener must print
+#
+# VERSION SCOPE: the dhs_verbtest role prepends a SINGLE `dhs consumer <vt_proto>`
+# for the listener and `dhs producer <vt_proto>` for every send, so one play
+# pins ONE wire version (a v3.1 listener cannot decode a v5.0 frame). This play
+# pins tsl-v50 (the richest frame: screen + DMSG + tally colours), matching the
+# tsl-integration.yml loopback choice. v3.1 / v4.0 send+listen are exercised by
+# tsl-integration.yml's verb-drive; per-version verb plays can be added by
+# cloning this file with vt_proto: tsl-v31 / tsl-v40 and the matching flags
+# (cmd_tsl_producer.go:92-100 v3.1/v4.0 flags; defaultTSLPort 4000 vs 8901,
+# cmd_tsl.go:184-191).
+#
+# The listener is ephemeral (TTL auto-expiry via the role) and a single UDP push
+# leaves no persistent state, so run-twice = same result (ADR-0025 idempotency).
+#
+#   ansible-playbook -i inventory/hosts.ini playbooks/tsl-verbs.yml \
+#     -e @secrets/credentials.json
+- name: TSL UMD verb test (deploy binary, listen on target, push frames, assert decode)
+  hosts: linux:windows
+  gather_facts: true
+  vars:
+    vt_host: "127.0.0.1"
+    vt_port: 18950
+  roles:
+    - role: dhs_verbtest
+      vars:
+        vt_proto: tsl-v50
+        vt_mode: push
+
+        # Consumer LISTEN argv tail (after `dhs consumer tsl-v50`). UDP listener
+        # bound on the test port — cmd_tsl.go:42-49 runTSLListen, --bind at
+        # cmd_tsl.go:44. The role captures its decoded stdout to vt_listen_capture.
+        vt_listen_argv:
+          - listen
+          - --bind
+          - "{{ vt_host }}:{{ vt_port }}"
+
+        # Producer SEND argvs (each appended after `dhs producer tsl-v50`).
+        # send is one-shot UDP emit — cmd_tsl_producer.go:34-35 / runTSLSend.
+        # v5.0 flags: --dest (cmd_tsl_producer.go:86), --screen (106), --index
+        # (109), --lh (110), --text-tally (111), --rh (112), --text (89),
+        # --brightness (90). Two distinct DMSGs prove multiple frames decode.
+        vt_send_argv_list:
+          - [send, --dest, "{{ vt_host }}:{{ vt_port }}", --screen, "0", --index, "2", --lh, red, --text, "PGM-VT50"]
+          - [send, --dest, "{{ vt_host }}:{{ vt_port }}", --screen, "0", --index, "3", --rh, amber, --text, "PVW-VT50"]
+
+        # Tokens the listener MUST have decoded. The v5.0 listener prints
+        # `UMD=%q`, `LH=...`, `RH=...` per DMSG (cmd_tsl.go:108-123 SubscribeV50
+        # output: "display=%d  LH=%s  Text=%s  RH=%s  brightness=%s  UMD=%q").
+        # The version banner is "tsl-v50 consumer listening on ..." (cmd_tsl.go:82).
+        vt_push_assert_contains:
+          - 'UMD="PGM-VT50"'
+          - 'UMD="PVW-VT50"'
+          - "LH=red"
+          - "RH=amber"

--- a/ansible/roles/dhs_verbtest/defaults/main.yml
+++ b/ansible/roles/dhs_verbtest/defaults/main.yml
@@ -18,6 +18,22 @@ dhs_local_binary: "{{ playbook_dir }}/../../bin/dhs-linux-amd64"
 # `dhs consumer <proto> <verb>`.
 vt_proto: ""
 
+# Test mode. Two shapes:
+#   serve  (default) — producer serve <proto> on the target, then drive a set
+#                      of consumer verbs that DIAL the served producer. Used by
+#                      the matrix/tree connectors (probel-sw02p/sw08p, acp1,
+#                      acp2, emberplus). Honours vt_serve_argv / vt_serve_files /
+#                      vt_verbs.
+#   push           — PUSH protocols (tsl, osc): there is no serve+query. Instead
+#                      a consumer LISTENS (backgrounded, async/poll:0, decoded
+#                      output captured to a file on the target) and a producer
+#                      SENDS one or more frames; the role then reads the
+#                      listener's captured file back and asserts the pushed
+#                      frame was decoded. Honours vt_listen_argv /
+#                      vt_send_argv_list / vt_push_assert_contains. vt_serve_*
+#                      and vt_verbs are ignored in push mode.
+vt_mode: serve
+
 # Extra argv appended after `dhs producer <vt_proto> serve`. The connector play
 # MUST point any --tree / --manifest at the DEPLOYED fixture path on the target
 # (e.g. "{{ dhs_dir }}/matrix_tree.json"), never the repo path.
@@ -46,3 +62,34 @@ vt_port_wait_timeout: 30
 # The role prepends dhs_bin + consumer + vt_proto and runs each with the
 # OS-appropriate command / win_command module.
 vt_verbs: []
+
+# ---- PUSH mode parameters (vt_mode: push) --------------------------------
+# The consumer LISTEN argv tail, appended after `dhs consumer <vt_proto>` —
+# e.g. [ listen, --bind, "0.0.0.0:8901", --tcp ]. The role redirects the
+# listener's decoded stdout to vt_listen_capture on the target.
+vt_listen_argv: []
+
+# One or more producer SEND invocations. Each item is the argv tail appended
+# after `dhs producer <vt_proto>` — e.g.
+#   - [ send, --dest, "127.0.0.1:8901", --tcp, --screen, "0", ... ]
+# Every entry runs in sequence after the listener is up; long-running listeners
+# pick up each frame.
+vt_send_argv_list: []
+
+# Absolute path on the TARGET where the backgrounded listener's decoded output
+# is captured (then read back + asserted). Defaults under dhs_dir, which is
+# per-OS from group_vars (/usr/local/bin on linux, C:\dhs on windows), so this
+# one expression resolves on both target families.
+vt_listen_capture: "{{ dhs_dir }}/dhs-{{ vt_proto }}-listen.out"
+
+# Substrings that MUST appear in the captured listener output after the sends.
+# Each is asserted with `<token> in capture`.
+vt_push_assert_contains: []
+
+# How long (seconds) the backgrounded listener runs. async timeout bounds it so
+# Ansible auto-expires it — no manual kill. Must outlast the send loop + read.
+vt_listen_ttl: 30
+
+# Seconds to let the listener bind + the sent frames arrive before reading the
+# capture back. Push transports (UDP/TCP) deliver fast; a small settle suffices.
+vt_push_settle: 5

--- a/ansible/roles/dhs_verbtest/tasks/main.yml
+++ b/ansible/roles/dhs_verbtest/tasks/main.yml
@@ -38,11 +38,29 @@
   run_once: true
   changed_when: false
 
-# ---- Dispatch by OS family (mirror dhs_acp1) -----------------------------
-- name: Drive the verb test on a POSIX client (SSH)
+# ---- Dispatch by OS family (mirror dhs_acp1) × test mode ------------------
+# serve mode = producer serve + consumer verbs (matrix/tree connectors).
+# push  mode = consumer listen (backgrounded) + producer send (tsl/osc).
+- name: Drive the SERVE verb test on a POSIX client (SSH)
   ansible.builtin.include_tasks: posix.yml
-  when: ansible_os_family != "Windows"
+  when:
+    - ansible_os_family != "Windows"
+    - vt_mode == "serve"
 
-- name: Drive the verb test on a Windows client (WinRM)
+- name: Drive the SERVE verb test on a Windows client (WinRM)
   ansible.builtin.include_tasks: windows.yml
-  when: ansible_os_family == "Windows"
+  when:
+    - ansible_os_family == "Windows"
+    - vt_mode == "serve"
+
+- name: Drive the PUSH verb test on a POSIX client (SSH)
+  ansible.builtin.include_tasks: posix_push.yml
+  when:
+    - ansible_os_family != "Windows"
+    - vt_mode == "push"
+
+- name: Drive the PUSH verb test on a Windows client (WinRM)
+  ansible.builtin.include_tasks: windows_push.yml
+  when:
+    - ansible_os_family == "Windows"
+    - vt_mode == "push"

--- a/ansible/roles/dhs_verbtest/tasks/posix_push.yml
+++ b/ansible/roles/dhs_verbtest/tasks/posix_push.yml
@@ -1,0 +1,88 @@
+---
+# POSIX target (SSH) — PUSH protocols (tsl / osc). Deploy the control-node-built
+# binary, start a backgrounded consumer LISTEN that decodes received frames to a
+# capture file, fire one or more producer SENDs, then read the capture back and
+# assert the pushed frames were decoded. No serve, no on-target build.
+
+# ---- Deploy (mirror dhs_acp1/tasks/linux.yml exactly) --------------------
+- name: Create the dhs install directory
+  ansible.builtin.file:
+    path: "{{ dhs_dir }}"
+    state: directory
+    mode: "0755"
+
+- name: Deploy the linux dhs binary
+  ansible.builtin.copy:
+    src: "{{ dhs_local_binary }}"
+    dest: "{{ dhs_bin }}"
+    mode: "0755"
+
+# Any fixtures the push test needs on the target (usually none for tsl/osc).
+- name: Deploy push fixtures to the target
+  ansible.builtin.copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    mode: "0644"
+  loop: "{{ vt_serve_files }}"
+  loop_control:
+    label: "{{ item.dest }}"
+
+# ---- Start the listener (fire-and-forget, TTL auto-expiry) ---------------
+# async + poll:0 = fire-and-forget; vt_listen_ttl is the listener's bounded
+# lifetime, so Ansible auto-expires it. The decoded frames the consumer prints
+# on stdout are redirected into vt_listen_capture so a later slurp can assert
+# them. dhs logs go to stderr (kept out of the capture). Each argv token is
+# shell-quoted, then the redirect appended — so the listener is a single safe
+# shell line over SSH.
+- name: Start the {{ vt_proto }} consumer listener on the target
+  ansible.builtin.shell:
+    cmd: >-
+      {{ ([dhs_bin, 'consumer', vt_proto] + vt_listen_argv)
+         | map('quote') | join(' ') }}
+      > {{ vt_listen_capture | quote }} 2>/dev/null
+  async: "{{ vt_listen_ttl }}"
+  poll: 0
+  changed_when: false
+
+- name: Give the listener a moment to bind its socket
+  ansible.builtin.pause:
+    seconds: 2
+
+# ---- Fire the producer send(s) ------------------------------------------
+# A non-zero rc on any send fails the task by default (command module). The
+# send is a one-shot UDP/TCP emit — assert rc, not change.
+- name: "send: producer {{ vt_proto }}"
+  ansible.builtin.command:
+    argv: "{{ ([dhs_bin, 'producer', vt_proto] + item) }}"
+  loop: "{{ vt_send_argv_list }}"
+  loop_control:
+    label: "{{ item | join(' ') }}"
+  changed_when: false
+
+# ---- Let the frames arrive, read the capture, assert --------------------
+- name: Let the pushed frames arrive at the listener
+  ansible.builtin.pause:
+    seconds: "{{ vt_push_settle }}"
+
+- name: Read the listener capture back from the target
+  ansible.builtin.slurp:
+    src: "{{ vt_listen_capture }}"
+  register: vt_capture_raw
+
+- name: Decode the captured listener output
+  ansible.builtin.set_fact:
+    vt_capture: "{{ vt_capture_raw.content | b64decode }}"
+
+- name: "push capture: {{ vt_proto }}"
+  ansible.builtin.debug:
+    msg: "{{ vt_capture.split('\n') }}"
+
+- name: ASSERT the listener decoded every pushed frame
+  ansible.builtin.assert:
+    that:
+      - "item in vt_capture"
+    fail_msg: "{{ vt_proto }} listener did not capture expected token: {{ item }}"
+    quiet: true
+  loop: "{{ vt_push_assert_contains }}"
+  loop_control:
+    label: "{{ item }}"

--- a/ansible/roles/dhs_verbtest/tasks/windows_push.yml
+++ b/ansible/roles/dhs_verbtest/tasks/windows_push.yml
@@ -1,0 +1,82 @@
+---
+# Windows target (WinRM) — PUSH protocols (tsl / osc). Deploy the
+# control-node-built binary, start a backgrounded consumer LISTEN that decodes
+# received frames to a capture file, fire one or more producer SENDs, then read
+# the capture back and assert the pushed frames were decoded. Module choices
+# mirror dhs_acp1/tasks/windows.yml. No serve, no on-target build.
+
+# ---- Deploy (mirror dhs_acp1/tasks/windows.yml exactly) ------------------
+- name: Create the dhs install directory
+  ansible.windows.win_file:
+    path: "{{ dhs_dir }}"
+    state: directory
+
+- name: Deploy the windows dhs binary
+  ansible.windows.win_copy:
+    src: "{{ dhs_local_binary }}"
+    dest: "{{ dhs_bin }}"
+
+# Any fixtures the push test needs on the target (usually none for tsl/osc).
+- name: Deploy push fixtures to the target
+  ansible.windows.win_copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+  loop: "{{ vt_serve_files }}"
+  loop_control:
+    label: "{{ item.dest }}"
+
+# ---- Start the listener (fire-and-forget, TTL auto-expiry) ---------------
+# async + poll:0 = fire-and-forget; vt_listen_ttl bounds the listener so Ansible
+# auto-expires it. The decoded frames the consumer prints on stdout are
+# redirected to vt_listen_capture (a Windows path); stderr (dhs logs) is
+# dropped. win_shell runs the line under PowerShell on the target.
+- name: Start the {{ vt_proto }} consumer listener on the target
+  ansible.windows.win_shell: >-
+    & {{ dhs_bin }} consumer {{ vt_proto }} {{ vt_listen_argv | join(' ') }}
+    1> {{ vt_listen_capture }} 2> $null
+  async: "{{ vt_listen_ttl }}"
+  poll: 0
+  changed_when: false
+
+- name: Give the listener a moment to bind its socket
+  ansible.builtin.pause:
+    seconds: 2
+
+# ---- Fire the producer send(s) ------------------------------------------
+# A non-zero rc on any send fails the task by default (win_command). The send
+# is a one-shot UDP/TCP emit — assert rc, not change.
+- name: "send: producer {{ vt_proto }}"
+  ansible.windows.win_command:
+    argv: "{{ ([dhs_bin, 'producer', vt_proto] + item) }}"
+  loop: "{{ vt_send_argv_list }}"
+  loop_control:
+    label: "{{ item | join(' ') }}"
+  changed_when: false
+
+# ---- Let the frames arrive, read the capture, assert --------------------
+- name: Let the pushed frames arrive at the listener
+  ansible.builtin.pause:
+    seconds: "{{ vt_push_settle }}"
+
+- name: Read the listener capture back from the target
+  ansible.windows.win_slurp:
+    src: "{{ vt_listen_capture }}"
+  register: vt_capture_raw
+
+- name: Decode the captured listener output
+  ansible.builtin.set_fact:
+    vt_capture: "{{ vt_capture_raw.content | b64decode }}"
+
+- name: "push capture: {{ vt_proto }}"
+  ansible.builtin.debug:
+    msg: "{{ vt_capture.split('\n') }}"
+
+- name: ASSERT the listener decoded every pushed frame
+  ansible.builtin.assert:
+    that:
+      - "item in vt_capture"
+    fail_msg: "{{ vt_proto }} listener did not capture expected token: {{ item }}"
+    quiet: true
+  loop: "{{ vt_push_assert_contains }}"
+  loop_control:
+    label: "{{ item }}"


### PR DESCRIPTION
Replicates the cross-OS dhs_verbtest verb-test pattern (merged #619) to the remaining connectors. Each play deploys the per-OS binary + fixtures (control-node cross-build, no Go on target), serves/listens on the target, and drives EVERY verb asserting output — Linux (SSH) + win11 (WinRM). Batch 1 (this commit): adds a PUSH mode to the role (vt_mode serve|push; posix_push/windows_push) for tally/OSC protocols; probel-sw02p-verbs.yml (15 verbs); acp1-verbs.yml (manifest+DM deploy, TCP Mode B). Still to add on this branch: acp2, emberplus (serve), tsl, osc (push), cerebrum-nb (external) + test.yml wiring. Verbs cited to cmd/dhs source; authored to the proven WinRM/SSH deploy pattern; live run on the control node. Co-Authored-By Claude Opus 4.8.