### PR TITLE
docs(probel-sw08p): mark salvo-connect CLI working; add real capture

### DIFF
--- a/internal/probel-sw08p/docs/README.md
+++ b/internal/probel-sw08p/docs/README.md
@@ -41,7 +41,7 @@ default port 2008).
 Every wire sample in these docs is a **real captured frame** — the
 `{ts, proto, dir, hex, len}` JSONL emitted by `--capture` against the
 loopback provider, not hand-written hex. The capture procedure is
-documented in [runbook.md](runbook.md#capture-procedure-how-the-samples-in-these-docs-were-made);
-the one verb that cannot be driven from the CLI today
-(`salvo-connect`, blocked by a flag collision) is marked as such and its
-wire shape is taken from the integration test, never fabricated.
+documented in [runbook.md](runbook.md#capture-procedure-how-the-samples-in-these-docs-were-made).
+All verbs — including `salvo-connect` — are driven from the CLI; the
+`salvo-connect` trace is a real `--capture` of the build → go-set →
+go-clear flow (see [consumer.md](consumer.md#salvo-connect--controller-side-batch-route)).

--- a/internal/probel-sw08p/docs/consumer.md
+++ b/internal/probel-sw08p/docs/consumer.md
@@ -112,7 +112,7 @@ form flips bit 7). Full table in [`../CLAUDE.md`](../CLAUDE.md).
 | Name family 100/101/102/103/114/115 | §3.2.x | ✅ fully compliant | 4/8/12/16-char widths; space/NUL pad |
 | Update-name (write labels) | §3.2.26 | ✅ fully compliant | fire-and-forget (no reply) |
 | Dual-controller status | §3.2.8 | ✅ fully compliant | master/slave/active/idle-faulty |
-| Salvo connect-on-go + go (build / fire / clear) | §3.2.30 | ✅ codec + provider; ⚠ CLI blocked | see [salvo-connect](#salvo-connect--cli-blocked) |
+| Salvo connect-on-go + go (build / fire / clear) | §3.2.30 | ✅ codec + provider + CLI | see [salvo-connect](#salvo-connect--controller-side-batch-route) |
 | Application keepalive (auto-answer matrix ping) | TS #91 | ✅ fully compliant | plugin answers `tx 011` keepalive with `rx 034` |
 | Async tally fan-out (`watch`) | §3.2.3 | ✅ fully compliant | observes `tx 003` broadcast to all sessions |
 | Scale bench (persistent TCP, 2 mtx × 65535) | — (our extension) | ✅ fully compliant | per-cmd latency to CSV/MD |
@@ -269,19 +269,56 @@ dhs consumer probel-sw08p bench 127.0.0.1:2008 --matrix 0,1 --size 65535 --csv b
 Flags: `--phase interrogate|connect|both`, `--matrix CSV`, `--size N`,
 `--csv` / `--md`, `--progress N`, `--timeout DUR`, `--skip-warmup`.
 
-### `salvo-connect` — CLI BLOCKED
+### `salvo-connect` — controller-side batch route
+
+Stage many `dst←src` crosspoints into a numbered salvo group, then fire
+them together with one GO (a "take"). The verb wraps the two-phase wire
+flow: N × `cmd 120` BUILD (one per dst) → `cmd 121` GO `op=set`, and by
+default a trailing `cmd 121` GO `op=clear` to wipe the stage buffer.
 
 ```
-dhs consumer probel-sw08p salvo-connect 127.0.0.1:2008 --matrix 0 --level 0 --src 7 --dsts 0-2 --salvo 5
-→ error: --dsts: strconv.ParseUint: parsing "0-2": invalid syntax
+dhs consumer probel-sw08p salvo-connect 127.0.0.1:2008 --matrix 0 --level 0 --src 7 --dsts 10-11 --salvo 5
 ```
 
-The global `--dsts` matrix-config flag (parsed before sub-command
-dispatch) shadows `salvo-connect`'s own `--dsts`. The salvo path itself is
-proven working over TCP by the integration test
-[`TestSalvoConnectOnGoThenGo`](../integration/loopback_test.go); the CLI
-capture is **pending the flag fix** — no salvo CLI sample is fabricated.
-See [verbs.md §10](verbs.md#10-salvo-connect-controller-side-batch--cli-blocked-today).
+`--dsts` takes a CSV or `N-M` range (`5` · `1,3,5` · `0-7`) and every dst
+in it is routed to the single `--src` — the fan-out case (one source →
+many destinations). Mixed sources per dst are separate invocations (or
+separate wire frames): each `cmd 120` carries exactly one `(dst, src)`
+pair, and a dst appearing twice in a group is last-write-wins. Flags:
+`--matrix` / `--level` / `--src` / `--dsts` / `--salvo` (0-127),
+`--clear` (default true), `--wait` (async-tally settle), `--timeout`.
+
+> The verb owns its own `--dsts` (CSV/range) and `--level`; the global
+> matrix-config extractor is told to skip them for this subcommand
+> ([`cmd_probel.go`](../../../cmd/dhs/cmd_probel.go) `probelSubcommand`),
+> so `--dsts 0-7` reaches the verb intact. Regression-pinned by
+> [`cmd_probel_salvo_dsts_test.go`](../../../cmd/dhs/cmd_probel_salvo_dsts_test.go).
+
+Real wire trace of the command above, `--capture`'d against the loopback
+provider (`dhs producer probel-sw08p serve`). `10 06` is a DLE ACK (§2
+frame-level), elided per pair for brevity:
+
+```
+tx cmd=120 BUILD  mtx=0 lvl=0 dst=10 src=7 salvo=5   10 02 78 00 00 0a 07 05 06 6c 10 03
+rx cmd=122 ACK    mtx=0 lvl=0 dst=10 src=7 salvo=5   10 02 7a 00 00 0a 07 05 06 6a 10 03
+tx cmd=120 BUILD  mtx=0 lvl=0 dst=11 src=7 salvo=5   10 02 78 00 00 0b 07 05 06 6b 10 03
+rx cmd=122 ACK    mtx=0 lvl=0 dst=11 src=7 salvo=5   10 02 7a 00 00 0b 07 05 06 69 10 03
+tx cmd=121 GO     op=set   salvo=5                    10 02 79 00 05 03 7f 10 03
+rx cmd=123 DONE   status=Set salvo=5                  10 02 7b 00 05 03 7d 10 03
+rx cmd=004 CONN   mtx=0 lvl=0 dst=10 src=7            10 02 04 00 00 0a 07 05 e6 10 03
+rx cmd=004 CONN   mtx=0 lvl=0 dst=11 src=7            10 02 04 00 00 0b 07 05 e5 10 03
+tx cmd=121 GO     op=clear salvo=5                    10 02 79 01 05 03 7e 10 03
+rx cmd=123 DONE   status=None salvo=5                 10 02 7b 02 05 03 7b 10 03
+```
+
+The two `rx cmd 004 Connected` after the go-done are the documented #92
+deviation (see "Salvo commit emits `cmd 04`" below): the spec §3.2.30
+says a matrix should NOT emit `cmd 04` on the salvo path, but Commie and
+Lawo VSM only update tally from `cmd 04`, so our provider emits one per
+applied slot and fires `probel_salvo_emitted_connected`. The salvo path
+is also proven over TCP by
+[`TestSalvoConnectOnGoThenGo`](../integration/loopback_test.go). Byte-exact
+field decode: [`dhs_probel_sw08p.lua`](../wireshark/dhs_probel_sw08p.lua).
 
 ---
 
@@ -352,7 +389,7 @@ patched.
 | Frame | checksum / BTC mismatch | line-quality issue; dissector flags it |
 | Link | `DLE NAK` after 5× retry | command unsupported by the peer (compliance event) |
 | Validation | `--matrix out of range (0-255)`, `--device out of range (0-1023)` | fix the flag value |
-| CLI flag | `salvo-connect ... --dsts 0-2` collision | pending fix; see [salvo-connect](#salvo-connect--cli-blocked) |
+| CLI flag | `salvo-connect ... --dsts 0-2` (verb owns `--dsts`/`--level`) | resolved; see [salvo-connect](#salvo-connect--controller-side-batch-route) |
 
 ---
 

--- a/internal/probel-sw08p/docs/runbook.md
+++ b/internal/probel-sw08p/docs/runbook.md
@@ -13,7 +13,7 @@
 | **Roles** | dhs as **consumer** (outbound) and **provider** (inbound); both exercised against the loopback emulator |
 | **Producer source** | committed fixture [`../testdata/exports/matrix_tree.json`](../testdata/exports/matrix_tree.json) — one 16×16 one-to-N matrix at matrix 0 / level 0 |
 | **OS** | Windows 11 (primary host, PowerShell); Linux LXCs for Ansible parity |
-| **Out of scope** | `salvo-connect` CLI path (blocked by a flag collision — [§ salvo-connect](#salvo-connect--blocked)); live-matrix Tier-3 (VPN-gated) |
+| **Out of scope** | live-matrix Tier-3 (VPN-gated) |
 
 ## Setup — build + serve
 
@@ -70,9 +70,9 @@ positional defaults (`SRC 0001…`, `DST 0001…`, `DEV 0009`).
 | `discover` | composite | ✅ | dual-status + names + tally-dump |
 | `watch` | passive | ✅ | async tally feed |
 | `bench` | 001/002 ×N | ✅ | per-cmd latency CSV/MD |
-| `salvo-connect` | 120/121 → 122/123 | ⛔ CLI blocked | codec/provider OK; CLI flag collision |
+| `salvo-connect` | 120/121 → 122/123 | ✅ | build ×N → go set → go clear; verb owns `--dsts`/`--level` |
 
-Legend: ✅ working · ⛔ CLI-blocked.
+Legend: ✅ working.
 
 ---
 
@@ -337,21 +337,26 @@ per-op rows + a summary table.
 
 ---
 
-## salvo-connect — BLOCKED
+## salvo-connect — controller-side batch
 
 ```powershell
-.\bin\dhs.exe consumer probel-sw08p salvo-connect 127.0.0.1:2008 --matrix 0 --level 0 --src 7 --dsts 0-2 --salvo 5
-# error: --dsts: strconv.ParseUint: parsing "0-2": invalid syntax
+.\bin\dhs.exe consumer probel-sw08p salvo-connect 127.0.0.1:2008 --matrix 0 --level 0 --src 7 --dsts 10-11 --salvo 5
 ```
 
-The global `--dsts` matrix-config flag (parsed in `extractMatrixConfigFlags`
-before sub-command dispatch) shadows `salvo-connect`'s own `--dsts`. A
-range form errors; a single int is consumed by the global parser, leaving
-salvo's `--dsts` empty. This is a **real CLI flag collision, not a protocol
-limit**. The salvo path is proven working over a real TCP round-trip by
+Stages one `rx 120` per dst (each acked by `tx 122`), fires with
+`rx 121` op=set (`tx 123` Go-Done status=Set), then op=clear by default.
+`--dsts` takes a CSV or `N-M` range routed to the single `--src` (fan-out).
+The verb owns its `--dsts` / `--level`; `probelSubcommand` in
+[`cmd_probel.go`](../../../cmd/dhs/cmd_probel.go) makes the global
+matrix-config extractor skip them for this subcommand, so `--dsts 0-2`
+reaches the verb — pinned by
+[`cmd_probel_salvo_dsts_test.go`](../../../cmd/dhs/cmd_probel_salvo_dsts_test.go).
+The salvo path is proven working over a real TCP round-trip by
 [`TestSalvoConnectOnGoThenGo`](../integration/loopback_test.go) (stage 3
 slots via `rx 120` → fire via `rx 121` → `tx 123` Go-Done status=Set →
-every slot reads back). CLI capture is **pending the flag fix**.
+every slot reads back). Add `--capture salvo.jsonl` for a wire trace; the
+annotated trace is in
+[`consumer.md`](consumer.md#salvo-connect--controller-side-batch-route).
 
 ---
 

--- a/internal/probel-sw08p/docs/verbs.md
+++ b/internal/probel-sw08p/docs/verbs.md
@@ -316,25 +316,33 @@ device 9 name="DEV 0009"
 {"dir":"rx","hex":"100212000944455620303030390b121003","len":17}   ← tx 018 "DEV 0009"
 ```
 
-## 10. salvo-connect (controller-side batch — CLI BLOCKED today)
+## 10. salvo-connect (controller-side batch)
 
 `salvo-connect` mimics the VSM batch-connect flow: N × `rx 120 Connect-On-Go
 Salvo` (stage), then `rx 121 Go Salvo` op=set (fire), then op=clear (wipe).
 
-> **⚠ Not invokable from the CLI today.** The global `--dsts` matrix-config
-> flag (parsed in `extractMatrixConfigFlags` before sub-command dispatch)
-> shadows `salvo-connect`'s own `--dsts` flag. `--dsts 0-2` errors with
-> `--dsts: strconv.ParseUint: parsing "0-2": invalid syntax`; a single
-> int `--dsts 3` is eaten by the global parser, leaving salvo's `--dsts`
-> empty (`--dsts is required`). This is a real CLI flag collision, not a
-> protocol limit — **no salvo CLI sample is fabricated here.**
+```
+dhs consumer probel-sw08p salvo-connect 127.0.0.1:2008 --matrix 0 --level 0 --src 7 --dsts 10-11 --salvo 5
+```
 
-The underlying salvo path is proven working over a real TCP round-trip by
+`--dsts` accepts a CSV or `N-M` range; every dst is routed to the single
+`--src` (fan-out). The verb owns its own `--dsts` and `--level`: the
+global matrix-config extractor (`extractMatrixConfigFlags`) is told to
+skip them when `probelSubcommand(args) == "salvo-connect"`
+([`cmd_probel.go`](../../../cmd/dhs/cmd_probel.go)), so `--dsts 0-2`
+reaches the verb intact instead of being eaten by the global uint parser.
+Regression-pinned by
+[`cmd_probel_salvo_dsts_test.go`](../../../cmd/dhs/cmd_probel_salvo_dsts_test.go)
+(both SW-P-08 and SW-P-02 dispatchers; the global uint `--dsts` bootstrap
+still works for non-salvo verbs).
+
+The salvo path is also proven working over a real TCP round-trip by
 the loopback integration test
 [`TestSalvoConnectOnGoThenGo`](../integration/loopback_test.go) (stage 3
 slots → fire → every slot reads back via interrogate, `tx 123 Go-Done
 status=Set`). The wire shape is `rx 120` × N → `tx 122` ack × N →
-`rx 121` set → `tx 123` go-done. CLI capture is **pending the flag fix**.
+`rx 121` set → `tx 123` go-done. A `--capture`'d CLI trace of this verb is
+in [`consumer.md`](consumer.md#salvo-connect--controller-side-batch-route).
 
 > Spec-vs-reality note: §3.2.30 says the matrix emits **no** `cmd 04` on
 > the salvo path. Neither Commie nor Lawo VSM implement that listener


### PR DESCRIPTION
## What

The `salvo-connect` `--dsts` flag collision was **already fixed in code** (a `probelSubcommand` detector makes the global matrix-config extractor skip `--dsts`/`--level` for the subcommand, pinned by `cmd_probel_salvo_dsts_test.go`). But the probel-sw08p doc set still described the verb as "CLI BLOCKED / pending the flag fix" in four places. This PR makes the docs tell the truth and backs the claim with a real wire capture.

## Changes (docs only — no code)

- **consumer.md** — replaced the "`salvo-connect` — CLI BLOCKED" section with the working invocation, the fan-out `--dsts` semantics, and a real `--capture`'d wire trace of the build → go-set → go-clear flow (including the documented #92 `cmd 04 Connected` deviation). Fixed the stale capability status row and the error-reference punchlist row.
- **verbs.md** — §10 retitled; removed the "not invokable from the CLI" warning; documented the `probelSubcommand` skip and the CSV/range `--dsts`.
- **runbook.md** — removed `salvo-connect` from "out of scope"; flipped the verb status table to ✅; rewrote the "BLOCKED" section as a working procedure.
- **README.md** — dropped the "one verb that cannot be driven from the CLI" caveat; the "every sample is a real captured frame" promise now holds for salvo too.

## Verification

- Ran the CLI against a loopback provider (`dhs producer probel-sw08p serve`): 2× BUILD (cmd 120→122) → GO set (121→123 status=Set) → 2× Connected (cmd 04) → GO clear. The doc trace is that genuine capture.
- `go test ./cmd/dhs/ -run "Salvo|ProbelSubcommand|ProbelGlobalDsts"` — pass.
- Pre-commit (`go vet`, `golangci-lint`) — 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
