### PR TITLE
fix(probel-sw08p): close dispatch race that dropped streamed reply frames

### DIFF
--- a/internal/probel-sw08p/codec/client.go
+++ b/internal/probel-sw08p/codec/client.go
@@ -779,12 +779,34 @@ func (c *Client) dispatch(f Frame) {
 	listeners := append([]subscription(nil), c.readers...)
 	c.mu.Unlock()
 
+	// A pending Send claims the FIRST matching frame — but only once. We clear
+	// c.pending here, on the reader goroutine, the instant the frame is claimed,
+	// so the NEXT matching frame (e.g. the second tx 106 of a streamed name
+	// table) is delivered to the Subscribe listeners instead of being swallowed
+	// by an already-satisfied waiter.
+	//
+	// Previously c.pending was cleared only by Send's deferred cleanup, which
+	// runs on the *caller* goroutine and races this reader: a matrix streaming
+	// frame N+1 back-to-back could have it dispatched before that defer fired,
+	// so dispatch still saw the satisfied waiter and dropped the frame into
+	// waiter.reply — a buffered channel nobody reads again — losing it. That
+	// truncated multi-frame SendCollect results (the flaky *_MultiFrame tests,
+	// and, on a fast real matrix, dropped table rows). The claim is guarded by
+	// c.pending == waiter so a newer in-flight Send is never disturbed.
 	if waiter != nil && waiter.match != nil && waiter.match(f) {
-		select {
-		case waiter.reply <- replyResult{frame: f}:
-			return
-		default:
-			// reply slot already filled (duplicate frame?) — fall through.
+		c.mu.Lock()
+		claimed := c.pending == waiter
+		if claimed {
+			c.pending = nil
+		}
+		c.mu.Unlock()
+		if claimed {
+			select {
+			case waiter.reply <- replyResult{frame: f}:
+				return
+			default:
+				// reply slot already filled — fall through to listeners.
+			}
 		}
 	}
 	for _, s := range listeners {


### PR DESCRIPTION
## Problem

`TestAllDestAssocNames_MultiFrameMerge` (and its `AllSourceNames` / `CrosspointTallyDump` siblings) flake on CI — they failed the **push-to-`main`** run after #623 merged (and the prior emberplus merge). Not caused by any recent change: it's a long-standing transport race that the loaded CI runners hit often. On this Windows host the baseline reproduce rate was **17/30**.

## Root cause (transport layer, not the test)

`SendCollect` lets the pending `Send` waiter claim the **first** matching frame and every **later** frame reach the `Subscribe` collector. But `c.pending` was cleared only by `Send`'s deferred cleanup, which runs on the **caller** goroutine and races the **reader** goroutine. When a matrix streams frame N+1 back-to-back, the reader can dispatch it *before* that defer fires, so `dispatch` still sees the satisfied waiter and drops the frame into `waiter.reply` — a buffered channel nobody reads again — **losing it**. The collection returns only the first frame → merged table truncated.

This isn't test-only: a fast real matrix streaming a large name/tally table could silently drop rows the same way.

## Fix

Make the waiter strictly single-shot by clearing `c.pending` **inside `dispatch`, on the reader goroutine**, the instant the frame is claimed (guarded by `c.pending == waiter` so a newer in-flight `Send` is untouched). The single reader goroutine dispatches frames sequentially, so the next frame now **deterministically** sees `pending == nil` and reaches the collector. `Send`'s deferred clear becomes an idempotent no-op.

Removes the race entirely — not a timing tweak.

## Verification

- Windows (the flaky host): **17/30 → 0/40** failures.
- `codec` / `consumer` / `provider` suites all green.
- `codec` coverage stays **100%** (CI floor for all three probel packages is 100).
- The existing `*_MultiFrame*` tests are the regression guard — deterministic passes now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
