### PR TITLE
feat(cli): ensure emits diff[] + canonical --output (alias --json)

### DIFF
--- a/cmd/dhs/cmd_ensure.go
+++ b/cmd/dhs/cmd_ensure.go
@@ -40,7 +40,8 @@ func runEnsure(ctx context.Context, args []string) error {
 	valueStr := fs.String("value", "", "desired value to converge to")
 	state := fs.String("state", "present", "present (converge --value) | absent (producer/registry only)")
 	check := fs.Bool("check", false, "dry-run: report would_change, write nothing")
-	asJSON := fs.Bool("json", false, "emit a JSON result (Ansible-friendly)")
+	asJSON := fs.Bool("json", false, "deprecated alias for --output json")
+	output := fs.String("output", "text", "output format: text | json (ADR-0002; yaml reserved, not yet supported)")
 	noWalk := fs.Bool("no-walk", false, "fail on cache miss instead of walking the slot to resolve --path/--label")
 	dmIdentity := fs.String("dm", "", `Ember+ only: identity-keyed DM hot-load (e.g. "Tiny Ember+ Router@1.6.2").`)
 	host, rest, err := popHost(args)
@@ -48,6 +49,11 @@ func runEnsure(ctx context.Context, args []string) error {
 		return fmt.Errorf("usage: dhs consumer <proto> ensure <host> --slot N (--path P | --label L | --id I) --value <v> [--state present] [--check] [--json]")
 	}
 	_ = fs.Parse(rest)
+
+	jsonOut, oerr := resolveEnsureOutput(*output, *asJSON)
+	if oerr != nil {
+		return oerr
+	}
 
 	if *state != "present" {
 		return ensureValErr(fmt.Sprintf("--state %q: consumer ensure converges values with --state present only; absent (session/service teardown) is a producer/registry concern (ADR-0007)", *state))
@@ -154,10 +160,10 @@ func runEnsure(ctx context.Context, args []string) error {
 	changed := !valuesEqual(current, target)
 
 	if *check {
-		return emitEnsure(*asJSON, ensureResult{WouldChange: &changed, Current: curStr, Target: target})
+		return emitEnsure(jsonOut, ensureResult{WouldChange: &changed, Current: curStr, Target: target, Diff: ensureValueDiff(changed, curStr, target)})
 	}
 	if !changed {
-		return emitEnsure(*asJSON, ensureResult{Changed: &changed, Previous: curStr, Current: curStr})
+		return emitEnsure(jsonOut, ensureResult{Changed: &changed, Previous: curStr, Current: curStr, Diff: ensureValueDiff(changed, curStr, curStr)})
 	}
 	confirmed, err := plug.SetValue(opCtx, req, want)
 	if err != nil {
@@ -168,18 +174,55 @@ func runEnsure(ctx context.Context, args []string) error {
 	// pre-set prediction, so a write that the device clamps back onto the
 	// current value still reports changed=false.
 	applied := !valuesEqual(current, newStr)
-	return emitEnsure(*asJSON, ensureResult{Changed: &applied, Previous: curStr, Current: newStr})
+	return emitEnsure(jsonOut, ensureResult{Changed: &applied, Previous: curStr, Current: newStr, Diff: ensureValueDiff(applied, curStr, newStr)})
+}
+
+// resolveEnsureOutput maps the canonical --output flag (ADR-0002) and the
+// deprecated --json alias to a single json-vs-text decision. --output json (or
+// the --json alias) selects JSON; text is the default. yaml is reserved by
+// ADR-0002 but not yet implemented; anything else is a validation error (exit 2
+// per error-codes.md).
+func resolveEnsureOutput(output string, jsonAlias bool) (bool, error) {
+	switch output {
+	case "text":
+		return jsonAlias, nil
+	case "json":
+		return true, nil
+	case "yaml":
+		return false, ensureValErr("--output yaml: not yet supported (use --output json)")
+	default:
+		return false, ensureValErr(fmt.Sprintf("--output %q: expected text | json", output))
+	}
 }
 
 // ensureResult is the structured outcome (ADR-0007 shape, simplified for the
 // consumer value case). Pointers distinguish apply (changed) from check
 // (would_change) and keep `false` from being omitted.
 type ensureResult struct {
-	Changed     *bool  `json:"changed,omitempty"`
-	WouldChange *bool  `json:"would_change,omitempty"`
-	Previous    string `json:"previous,omitempty"`
-	Current     string `json:"current,omitempty"`
-	Target      string `json:"target,omitempty"`
+	Changed     *bool        `json:"changed,omitempty"`
+	WouldChange *bool        `json:"would_change,omitempty"`
+	Previous    string       `json:"previous,omitempty"`
+	Current     string       `json:"current,omitempty"`
+	Target      string       `json:"target,omitempty"`
+	Diff        []ensureDiff `json:"diff"`
+}
+
+// ensureDiff is one field-level change in the ADR-0007 diff[] array.
+type ensureDiff struct {
+	Field string `json:"field"`
+	From  string `json:"from"`
+	To    string `json:"to"`
+}
+
+// ensureValueDiff builds the ADR-0007 diff[] for the single-value ensure case:
+// one {field:"value", from, to} entry when the value changes, an empty but
+// non-nil slice otherwise. ADR-0007 §Forbidden requires diff to always be
+// emitted (even []), so this never returns nil.
+func ensureValueDiff(changed bool, from, to string) []ensureDiff {
+	if !changed {
+		return []ensureDiff{}
+	}
+	return []ensureDiff{{Field: "value", From: from, To: to}}
 }
 
 func emitEnsure(asJSON bool, r ensureResult) error {

--- a/cmd/dhs/cmd_ensure_test.go
+++ b/cmd/dhs/cmd_ensure_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"dhs/internal/consumer"
@@ -163,5 +165,80 @@ func TestPredictStored(t *testing.T) {
 				t.Errorf("predictStored = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestResolveEnsureOutput pins the canonical --output flag (ADR-0002) and the
+// deprecated --json alias mapping to a single json/text decision, and that yaml
+// / unknown formats are exit-2 validation errors.
+func TestResolveEnsureOutput(t *testing.T) {
+	cases := []struct {
+		name      string
+		output    string
+		jsonAlias bool
+		wantJSON  bool
+		wantErr   bool
+	}{
+		{"text default", "text", false, false, false},
+		{"text + --json alias", "text", true, true, false},
+		{"output json", "json", false, true, false},
+		{"output json + alias", "json", true, true, false},
+		{"yaml not yet supported", "yaml", false, false, true},
+		{"unknown format", "xml", false, false, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveEnsureOutput(tc.output, tc.jsonAlias)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("resolveEnsureOutput(%q,%v) err = nil, want validation error", tc.output, tc.jsonAlias)
+				}
+				var verr *consumer.ValidationError
+				if !errors.As(err, &verr) {
+					t.Errorf("err = %T, want *consumer.ValidationError (exit 2)", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveEnsureOutput(%q,%v) err = %v, want nil", tc.output, tc.jsonAlias, err)
+			}
+			if got != tc.wantJSON {
+				t.Errorf("resolveEnsureOutput(%q,%v) = %v, want %v", tc.output, tc.jsonAlias, got, tc.wantJSON)
+			}
+		})
+	}
+}
+
+// TestEnsureValueDiff pins the ADR-0007 diff[] for the value case: one
+// {field:"value",from,to} entry when changed, an empty but NON-nil slice when
+// not (ADR-0007 §Forbidden: diff must always be emitted, even []).
+func TestEnsureValueDiff(t *testing.T) {
+	t.Run("changed yields one entry", func(t *testing.T) {
+		d := ensureValueDiff(true, "On", "Off")
+		if len(d) != 1 || d[0] != (ensureDiff{Field: "value", From: "On", To: "Off"}) {
+			t.Fatalf("diff = %+v, want [{value On Off}]", d)
+		}
+	})
+	t.Run("unchanged yields empty non-nil slice", func(t *testing.T) {
+		d := ensureValueDiff(false, "On", "On")
+		if d == nil {
+			t.Fatal("diff is nil; ADR-0007 requires an empty [], never null")
+		}
+		if len(d) != 0 {
+			t.Fatalf("diff = %+v, want []", d)
+		}
+	})
+}
+
+// TestEnsureResultDiffAlwaysEmitted pins that ensureResult always serialises a
+// diff array (never omitted, never null), per ADR-0007 §Forbidden.
+func TestEnsureResultDiffAlwaysEmitted(t *testing.T) {
+	no := false
+	b, err := json.Marshal(ensureResult{Changed: &no, Current: "On", Diff: ensureValueDiff(false, "On", "On")})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(b), `"diff":[]`) {
+		t.Errorf("json = %s; want it to contain \"diff\":[] (ADR-0007 always emits diff)", b)
 	}
 }


### PR DESCRIPTION
## What

`ensure` now always emits the ADR-0007 `diff[]` array and gains the canonical `--output json|text` flag (with `--json` kept as a deprecated alias).

## Why

Phase 0 / PR1 of the operator-contract roadmap (`docs/protocols/contract-roadmap.md`). ADR-0007 requires `diff[]` to always be present (even `[]`); ADR-0002 defines `--output` as the canonical format flag. This is the shared output shape everything downstream (matrix-ensure) will emit.

Closes #627

## Scope

- [x] cli (shared `ensure` verb — affects acp1, acp2, emberplus)
- [ ] core / api / transport / export
- [ ] any single protocol

**Cross-protocol change**: `cmd/dhs/cmd_ensure.go` is the shared consumer verb; the change is additive and backward-compatible (no protocol behaviour touched).

## Reference controller

- [x] N/A (no protocol behaviour change)

## Type

- [x] feat — new feature (additive, backward-compatible)

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `cmd/dhs/cmd_ensure.go` | modified | `diff[]` always emitted; `resolveEnsureOutput` maps `--output`/`--json`; `ensureDiff`/`ensureValueDiff` |
| `cmd/dhs/cmd_ensure_test.go` | modified | tests: `--output`/alias resolution, diff[] population, always-emitted diff |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test ./...` | all | 0 |
| `go vet ./...` | clean | — |
| `golangci-lint run` | 0 issues | — |

## Device tested

- [x] No device needed (CLI/output-shape change; all protocols exercised via unit suite)

## Backward compatibility

- `--json` still works (deprecated alias for `--output json`); existing tests unchanged.
- `--output` defaults to `text`; `--output yaml` returns an exit-2 validation error (reserved, not yet implemented).

## Checklist

- [x] `go test -count=1 ./...` passes — no regression on any protocol
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies

## Approval

@yboujraf — requesting review
