### PR TITLE
feat(emberplus): canonical matrix-ensure (idempotent absolute-set + --check)

### DIFF
--- a/ansible/playbooks/emberplus-matrix-ensure.yml
+++ b/ansible/playbooks/emberplus-matrix-ensure.yml
@@ -1,0 +1,65 @@
+# Use-case acceptance test (ADR-0025 Tier-3) for the canonical matrix-ensure
+# (ADR-0007 amendment / ADR-0023). Drives the DEPLOYED Ember+ provider through
+# the `matrix --op absolute` verb and asserts the operator CONTRACT:
+#
+#   1. converge  -> changed=true   (first apply)
+#   2. converge  -> changed=false  (run-twice idempotency, the core proof)
+#   3. --check   -> would_change=false, and state unchanged after it
+#
+# No PowerShell; CLI-in-a-role. Requires the provider serving the integration
+# manifest (same host as emberplus-provider-matrix.yml).
+#
+#   ansible-playbook -i inventory/fleet.ini playbooks/emberplus-matrix-ensure.yml \
+#     -e target=dhs-debian
+#
+- name: Ember+ canonical matrix-ensure (idempotency contract)
+  hosts: "{{ target | default('dhs-debian') }}"
+  gather_facts: false
+  vars:
+    dhs_bin: /usr/local/bin/dhs
+    host: 127.0.0.1
+    port: 9000
+    m_oneton: "1.1.3"
+    tgt: 0
+    src: 5
+  tasks:
+    - name: ASSERT the provider is serving on {{ port }}
+      ansible.builtin.wait_for: { port: "{{ port }}", host: "{{ host }}", timeout: 5 }
+
+    # Normalise to a known different source first so the first converge changes.
+    - name: pre-set target {{ tgt }} <- 1 (baseline)
+      ansible.builtin.command: >-
+        {{ dhs_bin }} consumer emberplus matrix {{ host }} --port {{ port }}
+        --path {{ m_oneton }} --target {{ tgt }} --sources 1 --op absolute --output json
+      changed_when: false
+
+    - name: converge target {{ tgt }} <- {{ src }} (first apply -> changed)
+      ansible.builtin.command: >-
+        {{ dhs_bin }} consumer emberplus matrix {{ host }} --port {{ port }}
+        --path {{ m_oneton }} --target {{ tgt }} --sources {{ src }} --op absolute --output json
+      register: first
+      changed_when: (first.stdout | from_json).changed | bool
+
+    - name: converge again (run-twice -> NO change, the idempotency proof)
+      ansible.builtin.command: >-
+        {{ dhs_bin }} consumer emberplus matrix {{ host }} --port {{ port }}
+        --path {{ m_oneton }} --target {{ tgt }} --sources {{ src }} --op absolute --output json
+      register: second
+      changed_when: (second.stdout | from_json).changed | bool
+
+    - name: dry-run --check reports no change and mutates nothing
+      ansible.builtin.command: >-
+        {{ dhs_bin }} consumer emberplus matrix {{ host }} --port {{ port }}
+        --path {{ m_oneton }} --target {{ tgt }} --sources {{ src }} --op absolute --check --output json
+      register: dryrun
+      changed_when: false
+
+    - name: ASSERT the contract
+      ansible.builtin.assert:
+        that:
+          - (first.stdout  | from_json).changed       == true
+          - (second.stdout | from_json).changed       == false
+          - (second.stdout | from_json).diff | length == 0
+          - (dryrun.stdout | from_json).would_change   == false
+        success_msg: "matrix-ensure idempotency contract PASS (changed->no-change->check-clean)"
+        fail_msg: "matrix-ensure contract FAIL: {{ first.stdout }} / {{ second.stdout }} / {{ dryrun.stdout }}"

--- a/cmd/dhs/cmd_matrix.go
+++ b/cmd/dhs/cmd_matrix.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
 	emberplus "dhs/internal/emberplus/consumer"
+	"dhs/internal/emberplus/codec/matrix"
 )
 
 func runMatrix(ctx context.Context, args []string) error {
@@ -20,6 +22,9 @@ func runMatrix(ctx context.Context, args []string) error {
 	op := fs.String("op", "absolute", "operation: absolute, connect, disconnect")
 	dmIdentity := fs.String("dm", "", `identity-keyed DM hot-load (e.g. "Tiny Ember+ Router@1.6.2"). When set, the tree is seeded from .cache/dm/emberplus/<identity>.json and the per-call walk is skipped — refs #438, ADR-0022.`)
 	noWalk := fs.Bool("no-walk", false, "fail fast on cache miss instead of falling back to a wire walk")
+	check := fs.Bool("check", false, "dry-run: report would_change, send nothing (ADR-0007)")
+	asJSON := fs.Bool("json", false, "deprecated alias for --output json")
+	output := fs.String("output", "text", "output format: text | json (ADR-0002)")
 	host, rest, err := popHost(args)
 	if err != nil {
 		return fmt.Errorf("usage: dhs consumer <proto> matrix <host> --path <matrix.path> --target N --sources N[,N,...] [--op absolute|connect|disconnect] [--dm <identity> | --no-walk]")
@@ -79,6 +84,27 @@ func runMatrix(ctx context.Context, args []string) error {
 		return err
 	}
 
+	jsonOut, oerr := resolveEnsureOutput(*output, *asJSON)
+	if oerr != nil {
+		return oerr
+	}
+
+	// Read current crosspoints for the target (read-back), then converge:
+	// send only when the target's source set actually differs from the intent
+	// (ADR-0007 idempotency). MatrixSnapshot reflects the connections folded in
+	// during the walk/DM-load above.
+	current := matrixTargetSources(ep.MatrixSnapshot(*matrixPath), int32(*target))
+	changed, projected := matrixConverge(current, sources, operation)
+	curStr := joinInt32s(current)
+	tgtStr := joinInt32s(projected)
+
+	if *check {
+		return emitEnsure(jsonOut, ensureResult{WouldChange: &changed, Current: curStr, Target: tgtStr, Diff: ensureFieldDiff(changed, "sources", curStr, tgtStr)})
+	}
+	if !changed {
+		return emitEnsure(jsonOut, ensureResult{Changed: &changed, Previous: curStr, Current: curStr, Diff: ensureFieldDiff(false, "sources", curStr, curStr)})
+	}
+
 	// Per-op timer started AFTER walk/DM-load so MatrixConnect sees
 	// a fresh --timeout budget — same pattern as cmd_invoke / cmd_set.
 	opCtx, cancel := withTimeout(ctx, cf.timeout)
@@ -88,6 +114,103 @@ func runMatrix(ctx context.Context, args []string) error {
 		return err
 	}
 
-	fmt.Printf("matrix connect: target %d ← sources %v (op=%s)\n", *target, sources, *op)
+	applied := true
+	return emitEnsure(jsonOut, ensureResult{Changed: &applied, Previous: curStr, Current: tgtStr, Diff: ensureFieldDiff(applied, "sources", curStr, tgtStr)})
+}
+
+// matrixTargetSources returns the current source set for target in a snapshot,
+// or an empty slice when the target has no connections.
+func matrixTargetSources(snap []matrix.TargetState, target int32) []int32 {
+	for _, ts := range snap {
+		if ts.Target == target {
+			return append([]int32(nil), ts.Sources...)
+		}
+	}
 	return nil
+}
+
+// matrixConverge computes, for a Connection operation (0=absolute/replace,
+// 1=connect/add, 2=disconnect/remove), whether applying `desired` to the
+// target's `current` sources changes anything, and the projected resulting set.
+// This mirrors the provider's union/difference/replace semantics so the CLI can
+// decide idempotently whether a send is needed and report the ADR-0007 diff.
+func matrixConverge(current, desired []int32, op int64) (changed bool, projected []int32) {
+	switch op {
+	case 1: // connect / add
+		projected = unionInt32s(current, desired)
+	case 2: // disconnect / remove
+		projected = differenceInt32s(current, desired)
+	default: // 0 absolute / replace
+		projected = append([]int32(nil), desired...)
+	}
+	return !int32SetEqual(current, projected), projected
+}
+
+// int32SetEqual reports set equality (order-independent, dedup-independent).
+func int32SetEqual(a, b []int32) bool {
+	sa, sb := int32Set(a), int32Set(b)
+	if len(sa) != len(sb) {
+		return false
+	}
+	for k := range sa {
+		if _, ok := sb[k]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func int32Set(xs []int32) map[int32]struct{} {
+	m := make(map[int32]struct{}, len(xs))
+	for _, x := range xs {
+		m[x] = struct{}{}
+	}
+	return m
+}
+
+func unionInt32s(a, b []int32) []int32 {
+	out := append([]int32(nil), a...)
+	seen := int32Set(a)
+	for _, x := range b {
+		if _, ok := seen[x]; !ok {
+			out = append(out, x)
+			seen[x] = struct{}{}
+		}
+	}
+	return out
+}
+
+func differenceInt32s(a, remove []int32) []int32 {
+	drop := int32Set(remove)
+	var out []int32
+	for _, x := range a {
+		if _, ok := drop[x]; !ok {
+			out = append(out, x)
+		}
+	}
+	return out
+}
+
+// joinInt32s renders a source set as a sorted comma-joined string for stable,
+// comparable output (e.g. "1,2,3"); empty set renders as "".
+func joinInt32s(xs []int32) string {
+	if len(xs) == 0 {
+		return ""
+	}
+	sorted := append([]int32(nil), xs...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	parts := make([]string, len(sorted))
+	for i, x := range sorted {
+		parts[i] = strconv.Itoa(int(x))
+	}
+	return strings.Join(parts, ",")
+}
+
+// ensureFieldDiff is the general ADR-0007 diff[] builder for a single named
+// field (the value-case helper ensureValueDiff is the field=="value" form).
+func ensureFieldDiff(changed bool, field, from, to string) []ensureDiff {
+	if !changed {
+		return []ensureDiff{}
+	}
+	return []ensureDiff{{Field: field, From: from, To: to}}
 }

--- a/cmd/dhs/cmd_matrix_test.go
+++ b/cmd/dhs/cmd_matrix_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"testing"
+
+	"dhs/internal/emberplus/codec/matrix"
+)
+
+// TestMatrixConverge pins the idempotency decision + projected source set for
+// each Connection operation (0 absolute / 1 connect / 2 disconnect). "changed"
+// is what decides whether the CLI sends at all (ADR-0007).
+func TestMatrixConverge(t *testing.T) {
+	cases := []struct {
+		name        string
+		current     []int32
+		desired     []int32
+		op          int64
+		wantChanged bool
+		wantProj    []int32 // set-compared
+	}{
+		{"absolute already set", []int32{5}, []int32{5}, 0, false, []int32{5}},
+		{"absolute replace", []int32{5}, []int32{7}, 0, true, []int32{7}},
+		{"absolute set from empty", nil, []int32{7}, 0, true, []int32{7}},
+		{"absolute clear", []int32{7}, nil, 0, true, nil},
+		{"absolute reorder is no-op", []int32{1, 2}, []int32{2, 1}, 0, false, []int32{1, 2}},
+		{"connect adds new", []int32{1}, []int32{2}, 1, true, []int32{1, 2}},
+		{"connect already present", []int32{1, 2}, []int32{2}, 1, false, []int32{1, 2}},
+		{"disconnect removes present", []int32{1, 2}, []int32{2}, 2, true, []int32{1}},
+		{"disconnect absent is no-op", []int32{1}, []int32{9}, 2, false, []int32{1}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			changed, proj := matrixConverge(tc.current, tc.desired, tc.op)
+			if changed != tc.wantChanged {
+				t.Errorf("changed = %v, want %v", changed, tc.wantChanged)
+			}
+			if !int32SetEqual(proj, tc.wantProj) {
+				t.Errorf("projected = %v, want %v", proj, tc.wantProj)
+			}
+		})
+	}
+}
+
+func TestInt32SetEqual(t *testing.T) {
+	cases := []struct {
+		a, b []int32
+		want bool
+	}{
+		{nil, nil, true},
+		{[]int32{1}, []int32{1}, true},
+		{[]int32{1, 2}, []int32{2, 1}, true},
+		{[]int32{1, 2}, []int32{1}, false},
+		{[]int32{1}, []int32{2}, false},
+		{[]int32{1, 1}, []int32{1}, true}, // dedup-independent
+	}
+	for _, tc := range cases {
+		if got := int32SetEqual(tc.a, tc.b); got != tc.want {
+			t.Errorf("int32SetEqual(%v,%v) = %v, want %v", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+func TestJoinInt32s(t *testing.T) {
+	cases := []struct {
+		in   []int32
+		want string
+	}{
+		{nil, ""},
+		{[]int32{}, ""},
+		{[]int32{3, 1, 2}, "1,2,3"}, // sorted
+		{[]int32{7}, "7"},
+	}
+	for _, tc := range cases {
+		if got := joinInt32s(tc.in); got != tc.want {
+			t.Errorf("joinInt32s(%v) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestMatrixTargetSources(t *testing.T) {
+	snap := []matrix.TargetState{
+		{Target: 0, Sources: []int32{5}},
+		{Target: 3, Sources: []int32{1, 2}},
+	}
+	if got := matrixTargetSources(snap, 3); !int32SetEqual(got, []int32{1, 2}) {
+		t.Errorf("target 3 sources = %v, want [1 2]", got)
+	}
+	if got := matrixTargetSources(snap, 9); len(got) != 0 {
+		t.Errorf("absent target = %v, want empty", got)
+	}
+}
+
+// TestEnsureFieldDiff pins the general ADR-0007 diff[] builder: one entry when
+// changed, empty non-nil slice otherwise (never null).
+func TestEnsureFieldDiff(t *testing.T) {
+	d := ensureFieldDiff(true, "sources", "5", "7")
+	if len(d) != 1 || d[0] != (ensureDiff{Field: "sources", From: "5", To: "7"}) {
+		t.Fatalf("diff = %+v, want [{sources 5 7}]", d)
+	}
+	if e := ensureFieldDiff(false, "sources", "5", "5"); e == nil || len(e) != 0 {
+		t.Fatalf("unchanged diff = %+v, want empty non-nil slice", e)
+	}
+}

--- a/docs/adr/0007-ensure-verb.md
+++ b/docs/adr/0007-ensure-verb.md
@@ -97,8 +97,42 @@ JSON field — never by the exit code.
 - Returning `changed: true` when nothing actually changed.
 - Skipping `diff` output (always emit, even if empty `[]`).
 
+## Amendment 2026-08-02 — declarative data + matrix desired-state
+
+The original decision framed `ensure` as **session/service lifecycle**
+(`--state present|absent`). In practice the consumer role also converges
+**declarative desired-state of data**, and this is in scope of the same
+contract:
+
+- **Scalar object values** — realized by the canonical `ensure` verb
+  (`cmd/dhs/cmd_ensure.go`): read current → compare → write only on diff.
+- **Matrix connections** (ADR-0023 crosspoints) — realized by the canonical
+  `matrix` verb (Ember+; other matrix protocols follow): read current via the
+  matrix snapshot/tally read-back → diff the target's source set → send only
+  when different.
+
+All declarative convergence, whatever the entity, MUST emit the **same output
+shape** and honor the same flags:
+
+- `--check` — dry-run, mutate nothing, report `would_change`.
+- `--output json` (canonical, ADR-0002; `--json` is a deprecated alias) —
+  `{changed|would_change, previous, current, diff[]}`.
+- `diff[]` — always emitted, even `[]` (never null); each entry
+  `{field, from, to}`. For a matrix the field is `"sources"`.
+- Exit code reflects outcome, not change (0/1/2); change is signalled only by
+  the JSON field.
+
+**Push-only protocols (TSL UMD).** TSL has no addressable read-back object, so
+`ensure` is **N/A** for it: the verb returns a documented `not_supported`
+result rather than a stubbed `ErrNotImplemented`. Idempotency for TSL is the
+`serve --refresh` keep-alive re-emit, not a converge.
+
 ## Revisions
 
+- 2026-08-02 — Amendment: `ensure`-style convergence covers declarative data
+  (scalar values) and matrix connections, not only session/service lifecycle;
+  fixed output shape (`--check`, `--output json`, always-present `diff[]`);
+  TSL push-only ensure ratified N/A. — by-rune
 - 2026-06-07 — Exit-code table corrected (errata per ADR-0015 Amendment
   policy): removed the "exit 2 = changed" convention, which collided with the
   error contract in `docs/protocols/error-codes.md` (exit 2 = usage/validation).

--- a/docs/adr/0023-matrix-entity.md
+++ b/docs/adr/0023-matrix-entity.md
@@ -151,7 +151,19 @@ endpoint it currently advertises as active.
   matrices block, or behavior values → block until this ADR is
   updated".
 
+## Matrix convergence (ensure)
+
+Declarative convergence of crosspoints is realized through the canonical
+`matrix` verb per the ADR-0007 amendment (2026-08-02): read the target's
+current source set from the matrix read-back (Ember+ connection snapshot,
+Probel tally dump), diff against the desired set honoring `behavior`
+(`1to1`/`1toN`/`NtoM` caps + lock), and send the minimal Connection operation
+only when different — idempotent, `--check`-safe, emitting the ADR-0007
+`{changed|would_change, diff[]}` shape. The read-back is mandatory: a converge
+never blind-writes.
+
 ## Revisions
 
 - 2026-05-14 — initial — yboujraf
 - 2026-05-14 — added §"Dual-controller matrix": writes go to active only; reads symmetric on both; Probel cmd 8/9 is the native indicator — yboujraf
+- 2026-08-02 — added §"Matrix convergence (ensure)": crosspoint convergence via the canonical `matrix` verb + ADR-0007 shape; read-back mandatory — by-rune


### PR DESCRIPTION
## What

The Ember+ `matrix` verb becomes declarative + idempotent: read current crosspoints → diff → send only when different, with `--check` and `--output json` on the ADR-0007 shape.

## Why

Phase 1 / slice 1 of the operator-contract roadmap (`docs/protocols/contract-roadmap.md`) — the canonical matrix-ensure, ember+ first (richest read-back model). Same contract as scalar `ensure` (#628), extended to matrix connections per the ADR-0007/0023 amendment.

Closes #629

## Scope

- [x] emberplus
- [x] cli
- [x] ci / chore (docs: ADR amendments)

**Cross-protocol change**: `cmd/dhs/cmd_matrix.go` is the shared CLI verb (Ember+-only today); ADR-0007/0023 amended so the contract is canonical for any matrix protocol (sw08p/sw02p follow in later slices).

## Wire evidence (protocol changes only)

No wire-format change — this is a consumer-side converge over existing `MatrixConnect`/`MatrixSnapshot`.

## Reference controller

- [x] N/A (no protocol behaviour change; send path unchanged, only gated on a diff)

## Type

- [x] feat — new feature (additive; idempotent + `--check`)

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `cmd/dhs/cmd_matrix.go` | modified | read-back diff + converge; `--check`/`--output json`; converge helpers |
| `cmd/dhs/cmd_matrix_test.go` | new | matrixConverge (all 3 ops) + set/join/diff helpers |
| `docs/adr/0007-ensure-verb.md` | amended | declarative data+matrix state; output shape; TSL N/A |
| `docs/adr/0023-matrix-entity.md` | revision | matrix convergence + mandatory read-back |
| `ansible/playbooks/emberplus-matrix-ensure.yml` | new | Tier-3 use-case: converge→run-twice=0→check-clean |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test ./...` | all* | 0 |
| `go vet ./...` | clean | — |
| `golangci-lint run` | 0 issues | — |

\* Two pre-existing flakes in packages this PR does not touch (`emberplus` TestConsumerReconnect, deferred `cerebrum-nb` TestReadLoop_DebugLogOnError) pass 3/3 on isolated re-run; CI's 3× retry absorbs them.

## Device tested

- [x] No device needed locally (converge logic unit-tested). Live idempotency e2e via the new ansible use-case play on the lab provider (Tier-3) + existing ember+ integration tests.

## Backward compatibility

- `matrix` still sends on a real change; it now *skips* a redundant send when the target already matches (the intended idempotency). `--json` alias honored.

## Checklist

- [x] `go test -count=1 ./...` passes — no regression on any protocol
- [x] `go vet` / `golangci-lint` clean
- [x] No new external dependencies

## Approval

@yboujraf — requesting review
