### PR TITLE
feat(probel-sw08p): idempotent crosspoint import (read-tally diff + --check)

### DIFF
--- a/ansible/playbooks/probel-sw08p-xpoint-ensure.yml
+++ b/ansible/playbooks/probel-sw08p-xpoint-ensure.yml
@@ -1,0 +1,54 @@
+# Use-case acceptance test (ADR-0025 Tier-3) for the Probel SW-P-08 crosspoint
+# ensure (idempotent `import --xpoints`, ADR-0007 / ADR-0023). Drives a running
+# SW-P-08 matrix (real device or the demo provider) and asserts the contract:
+#
+#   1. import  -> changed=true   (first converge)
+#   2. import  -> changed=false  (run-twice idempotency, the core proof)
+#   3. --check -> would_change=false (dry-run, sends nothing)
+#
+# No PowerShell; CLI-in-a-role. Provide <in_dir>/<prefix>-xpoint.csv
+# (matrix_id,level_id,dst_id,src_id) on the control node.
+#
+#   ansible-playbook -i inventory/probel.ini playbooks/probel-sw08p-xpoint-ensure.yml \
+#     -e 'addr=10.100.0.42:2008 in_dir=routes/mcr'
+#
+- name: Probel SW-P-08 crosspoint ensure (idempotency contract)
+  hosts: "{{ target | default('localhost') }}"
+  connection: "{{ conn | default('local') }}"
+  gather_facts: false
+  vars:
+    dhs_bin: dhs
+    addr: 127.0.0.1:2008
+    in_dir: routes
+    prefix: sw08p
+  tasks:
+    - name: converge crosspoints (first import -> changed)
+      ansible.builtin.command: >-
+        {{ dhs_bin }} consumer probel-sw08p import {{ addr }}
+        --in {{ in_dir }} --prefix {{ prefix }} --xpoints --output json
+      register: first
+      changed_when: (first.stdout | from_json).changed | bool
+
+    - name: converge again (run-twice -> NO change, the idempotency proof)
+      ansible.builtin.command: >-
+        {{ dhs_bin }} consumer probel-sw08p import {{ addr }}
+        --in {{ in_dir }} --prefix {{ prefix }} --xpoints --output json
+      register: second
+      changed_when: (second.stdout | from_json).changed | bool
+
+    - name: dry-run --check reports no change and sends nothing
+      ansible.builtin.command: >-
+        {{ dhs_bin }} consumer probel-sw08p import {{ addr }}
+        --in {{ in_dir }} --prefix {{ prefix }} --xpoints --check --output json
+      register: dryrun
+      changed_when: false
+
+    - name: ASSERT the contract
+      ansible.builtin.assert:
+        that:
+          - (first.stdout  | from_json).changed       == true
+          - (second.stdout | from_json).changed       == false
+          - (second.stdout | from_json).diff | length == 0
+          - (dryrun.stdout | from_json).would_change   == false
+        success_msg: "sw08p crosspoint ensure idempotency contract PASS"
+        fail_msg: "sw08p crosspoint ensure FAIL: {{ first.stdout }} / {{ second.stdout }} / {{ dryrun.stdout }}"

--- a/cmd/dhs/cmd_probel_csv.go
+++ b/cmd/dhs/cmd_probel_csv.go
@@ -227,9 +227,11 @@ func runProbelImport(ctx context.Context, args []string) error {
 	prefix := fs.String("prefix", "sw08p", "CSV filename prefix")
 	size := fs.Int("size", 8, "which label width column to import: 4 | 8 | 12 | 16")
 	dryRun := fs.Bool("dry-run", false, "preview the would-send actions without sending")
+	check := fs.Bool("check", false, "dry-run alias (ADR-0007): preview would_change, send nothing")
+	output := fs.String("output", "text", "output format: text | json (ADR-0002; xpoints emit the ADR-0007 shape)")
 	doSrc := fs.Bool("src", false, "import source labels (<prefix>-src.csv)")
 	doDst := fs.Bool("dst", false, "import destination labels (<prefix>-dst.csv)")
-	doXpoints := fs.Bool("xpoints", false, "import crosspoints (<prefix>-xpoint.csv; RE-ROUTES the matrix)")
+	doXpoints := fs.Bool("xpoints", false, "import crosspoints (<prefix>-xpoint.csv; converges the matrix, idempotent)")
 	timeout := fs.Duration("timeout", 300*time.Second, "overall timeout")
 	addr, flagArgs := popPositional(args)
 	if addr == "" {
@@ -250,6 +252,11 @@ func runProbelImport(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	jsonOut, oerr := resolveEnsureOutput(*output, false)
+	if oerr != nil {
+		return oerr
+	}
+	dry := *dryRun || *check
 
 	cctx, cancel := context.WithTimeout(ctx, *timeout)
 	defer cancel()
@@ -260,17 +267,17 @@ func runProbelImport(ctx context.Context, args []string) error {
 	defer closer()
 
 	if *doSrc {
-		if err := applyProbelNameCSV(cctx, p, filepath.Join(*inDir, *prefix+"-src.csv"), "source", col, width, *dryRun); err != nil {
+		if err := applyProbelNameCSV(cctx, p, filepath.Join(*inDir, *prefix+"-src.csv"), "source", col, width, dry); err != nil {
 			return err
 		}
 	}
 	if *doDst {
-		if err := applyProbelNameCSV(cctx, p, filepath.Join(*inDir, *prefix+"-dst.csv"), "dest-assoc", col, width, *dryRun); err != nil {
+		if err := applyProbelNameCSV(cctx, p, filepath.Join(*inDir, *prefix+"-dst.csv"), "dest-assoc", col, width, dry); err != nil {
 			return err
 		}
 	}
 	if *doXpoints {
-		if err := applyProbelXpointCSV(cctx, p, filepath.Join(*inDir, *prefix+"-xpoint.csv"), *dryRun); err != nil {
+		if err := applyProbelXpointCSV(cctx, p, filepath.Join(*inDir, *prefix+"-xpoint.csv"), dry, jsonOut); err != nil {
 			return err
 		}
 	}
@@ -360,12 +367,16 @@ func applyProbelNameCSV(ctx context.Context, p *probelproto.Plugin, path, typ st
 }
 
 // applyProbelXpointCSV connects each dst <- src crosspoint from the CSV.
-func applyProbelXpointCSV(ctx context.Context, p *probelproto.Plugin, path string, dryRun bool) error {
-	rows, err := readProbelCSV(path)
-	if err != nil {
-		return err
-	}
-	n := 0
+type xpointRow struct {
+	mtx, lvl uint8
+	dst, src uint16
+}
+
+// parseXpointRows reads the xpoint CSV (skipping the header) into typed rows,
+// silently dropping short (<4 field) or non-integer rows — same leniency as the
+// original importer.
+func parseXpointRows(rows [][]string) []xpointRow {
+	var out []xpointRow
 	for _, rec := range rows[1:] {
 		if len(rec) < 4 {
 			continue
@@ -377,17 +388,101 @@ func applyProbelXpointCSV(ctx context.Context, p *probelproto.Plugin, path strin
 		if e1 != nil || e2 != nil || e3 != nil || e4 != nil {
 			continue
 		}
-		if !dryRun {
-			if _, err := p.CrosspointConnect(ctx, uint8(mtx), uint8(lvl), uint16(dst), uint16(src)); err != nil {
-				return fmt.Errorf("connect dst=%d src=%d: %w", dst, src, err)
+		out = append(out, xpointRow{uint8(mtx), uint8(lvl), uint16(dst), uint16(src)})
+	}
+	return out
+}
+
+// tallyToMap flattens a tally-dump result into dst→src. The dump carries a
+// contiguous SourceIDs slice starting at FirstDestinationID.
+func tallyToMap(res probelproto.TallyDumpResult) map[uint16]uint16 {
+	m := map[uint16]uint16{}
+	if res.IsWord {
+		first := res.Word.FirstDestinationID
+		for i, s := range res.Word.SourceIDs {
+			m[first+uint16(i)] = s
+		}
+		return m
+	}
+	first := uint16(res.Byte.FirstDestinationID)
+	for i, s := range res.Byte.SourceIDs {
+		m[first+uint16(i)] = uint16(s)
+	}
+	return m
+}
+
+// xpointDiff decides, for one desired dst←src against the current tally,
+// whether the crosspoint needs changing and renders the "from" value ("" when
+// the destination is currently unrouted / absent from the tally).
+func xpointDiff(current map[uint16]uint16, dst, src uint16) (changed bool, from string) {
+	cur, ok := current[dst]
+	if ok && cur == src {
+		return false, "" // already routed as desired — idempotent skip
+	}
+	if ok {
+		return true, strconv.Itoa(int(cur))
+	}
+	return true, ""
+}
+
+// applyProbelXpointCSV converges the matrix crosspoints to the CSV, idempotently
+// (ADR-0007 / ADR-0023): it reads the live tally per (matrix,level) once, sends
+// CrosspointConnect only for rows that differ, and reports the ADR-0007
+// {changed|would_change, diff[]} shape. check=true is a dry-run (no send).
+func applyProbelXpointCSV(ctx context.Context, p *probelproto.Plugin, path string, check, jsonOut bool) error {
+	rows, err := readProbelCSV(path)
+	if err != nil {
+		return err
+	}
+	parsed := parseXpointRows(rows)
+
+	// Read current tally once per (matrix,level) — never per row (scale).
+	current := map[[2]uint8]map[uint16]uint16{}
+	for _, r := range parsed {
+		key := [2]uint8{r.mtx, r.lvl}
+		if _, ok := current[key]; ok {
+			continue
+		}
+		res, terr := p.CrosspointTallyDump(ctx, r.mtx, r.lvl)
+		if terr != nil {
+			return fmt.Errorf("tally-dump matrix=%d level=%d: %w", r.mtx, r.lvl, terr)
+		}
+		current[key] = tallyToMap(res)
+	}
+
+	diffs := []ensureDiff{}
+	for _, r := range parsed {
+		changed, from := xpointDiff(current[[2]uint8{r.mtx, r.lvl}], r.dst, r.src)
+		if !changed {
+			continue
+		}
+		diffs = append(diffs, ensureDiff{
+			Field: fmt.Sprintf("%d.%d.%d", r.mtx, r.lvl, r.dst),
+			From:  from,
+			To:    strconv.Itoa(int(r.src)),
+		})
+		if !check {
+			if _, err := p.CrosspointConnect(ctx, r.mtx, r.lvl, r.dst, r.src); err != nil {
+				return fmt.Errorf("connect dst=%d src=%d: %w", r.dst, r.src, err)
 			}
 		}
-		n++
+	}
+
+	changed := len(diffs) > 0
+	if jsonOut {
+		res := ensureResult{Diff: diffs}
+		if check {
+			res.WouldChange = &changed
+		} else {
+			res.Changed = &changed
+		}
+		return emitEnsure(true, res)
 	}
 	verb := "connected"
-	if dryRun {
+	if check {
 		verb = "would connect"
 	}
-	fmt.Printf("crosspoints: %s %d routes (dst <- src) from %s\n", verb, n, filepath.Base(path))
+	fmt.Printf("crosspoints: %s %d of %d routes (%d already converged) from %s\n",
+		verb, len(diffs), len(parsed), len(parsed)-len(diffs), filepath.Base(path))
 	return nil
 }

--- a/cmd/dhs/cmd_probel_csv_test.go
+++ b/cmd/dhs/cmd_probel_csv_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"testing"
+
+	codec "dhs/internal/probel-sw08p/codec"
+	probelproto "dhs/internal/probel-sw08p/consumer"
+)
+
+// TestXpointDiff pins the per-crosspoint idempotency decision: skip when the
+// destination already carries the desired source; otherwise change, rendering
+// the current source as "from" ("" when the dst is unrouted / absent).
+func TestXpointDiff(t *testing.T) {
+	cur := map[uint16]uint16{0: 3, 1: 5}
+	cases := []struct {
+		name        string
+		dst, src    uint16
+		wantChanged bool
+		wantFrom    string
+	}{
+		{"already routed -> skip", 0, 3, false, ""},
+		{"different source -> change", 1, 9, true, "5"},
+		{"unrouted dst -> change from empty", 7, 4, true, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			changed, from := xpointDiff(cur, tc.dst, tc.src)
+			if changed != tc.wantChanged || from != tc.wantFrom {
+				t.Errorf("xpointDiff(dst=%d,src=%d) = (%v,%q), want (%v,%q)",
+					tc.dst, tc.src, changed, from, tc.wantChanged, tc.wantFrom)
+			}
+		})
+	}
+}
+
+// TestTallyToMap pins flattening a tally-dump (byte + word form) into dst→src,
+// honoring the contiguous SourceIDs starting at FirstDestinationID.
+func TestTallyToMap(t *testing.T) {
+	t.Run("byte form", func(t *testing.T) {
+		res := probelproto.TallyDumpResult{
+			Byte: codec.CrosspointTallyDumpByteParams{FirstDestinationID: 0, SourceIDs: []uint8{3, 4}},
+		}
+		m := tallyToMap(res)
+		if m[0] != 3 || m[1] != 4 || len(m) != 2 {
+			t.Errorf("byte tally = %v, want {0:3, 1:4}", m)
+		}
+	})
+	t.Run("word form with offset", func(t *testing.T) {
+		res := probelproto.TallyDumpResult{
+			IsWord: true,
+			Word:   codec.CrosspointTallyDumpWordParams{FirstDestinationID: 2, SourceIDs: []uint16{7, 8}},
+		}
+		m := tallyToMap(res)
+		if m[2] != 7 || m[3] != 8 || len(m) != 2 {
+			t.Errorf("word tally = %v, want {2:7, 3:8}", m)
+		}
+	})
+}
+
+// TestParseXpointRows pins the lenient CSV parse: header skipped, short and
+// non-integer rows dropped, valid rows typed.
+func TestParseXpointRows(t *testing.T) {
+	rows := [][]string{
+		{"matrix_id", "level_id", "dst_id", "src_id"}, // header (skipped)
+		{"0", "0", "0", "3"},                          // valid
+		{"0", "0", "1"},                               // short -> dropped
+		{"0", "0", "x", "4"},                          // non-int -> dropped
+		{"1", "0", "7", "9"},                          // valid
+	}
+	got := parseXpointRows(rows)
+	if len(got) != 2 {
+		t.Fatalf("parsed %d rows, want 2: %+v", len(got), got)
+	}
+	if got[0] != (xpointRow{0, 0, 0, 3}) || got[1] != (xpointRow{1, 0, 7, 9}) {
+		t.Errorf("parsed = %+v, want [{0 0 0 3} {1 0 7 9}]", got)
+	}
+}


### PR DESCRIPTION
## What

`import --xpoints` for Probel SW-P-08 becomes idempotent: read the live tally → diff → send `CrosspointConnect` only for rows that differ, with `--check` and `--output json`.

## Why

Phase 1 / slice 2 of the operator-contract roadmap — your live crosspoint case, on the same ADR-0007/0023 contract as `ensure` (#628) and the Ember+ matrix-ensure (#630). Was fire-and-forget (re-routed every row, no read-back, no `changed`).

Closes #631

## Scope

- [x] probel-sw08p
- [x] cli

**Cross-protocol change**: none — `cmd/dhs/cmd_probel_csv.go` only; reuses the shared `ensureResult`/`emitEnsure`/`ensureFieldDiff` from #628/#630.

## Wire evidence (protocol changes only)

No wire-format change. New behaviour is a read (`cmd 21`→`22` tally-dump) before the existing `cmd 2` connects. Verified capture against the demo provider:
```
import #1: TX cmd21 -> RX cmd22 (all src=0) -> TX cmd2 dst0<-3, dst2 cmd2 dst1<-4 -> {"changed":true,"diff":[{"0.0.0":"0->3"},{"0.0.1":"0->4"}]}
import #2: TX cmd21 -> RX cmd22 (03 04 ...)  -> no connects           -> {"changed":false,"diff":[]}
--check : -> {"would_change":false,"diff":[]}
```

## Reference controller

- [x] N/A (no protocol behaviour change; connect path unchanged, only gated on a diff)

## Type

- [x] feat — additive; idempotent + `--check`

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `cmd/dhs/cmd_probel_csv.go` | modified | applyProbelXpointCSV converge (read-tally diff); `--check`/`--output` in runProbelImport; helpers |
| `cmd/dhs/cmd_probel_csv_test.go` | new | xpointDiff / tallyToMap / parseXpointRows |
| `ansible/playbooks/probel-sw08p-xpoint-ensure.yml` | new | Tier-3 use-case: import→run-twice=0→check-clean |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test ./...` | all | 0 |
| `go vet` / `golangci-lint` | clean | — |

## Device tested

- [x] Demo provider (loopback) — idempotency proven (see Wire evidence). Live device via the ansible use-case play (Tier-3).

## Backward compatibility

- `import --xpoints` now skips already-routed crosspoints instead of blindly re-sending (the intended idempotency); text output is a richer summary. `--dry-run` still works; `--check` is its ADR-0007 alias.

## Checklist

- [x] `go test -count=1 ./...` passes — no regression
- [x] `go vet` / `golangci-lint` clean
- [x] No new external dependencies

## Approval

@yboujraf — requesting review
