### PR TITLE
feat(probel-sw08p): idempotent label import (read-name diff + --check)

### DIFF
--- a/ansible/playbooks/probel-sw08p-label-ensure.yml
+++ b/ansible/playbooks/probel-sw08p-label-ensure.yml
@@ -1,0 +1,57 @@
+# Use-case acceptance test (ADR-0025 Tier-3) for the Probel SW-P-08 label
+# ensure (idempotent `import --src`, ADR-0007). Drives a running matrix (real
+# device or the demo provider) and asserts the contract:
+#
+#   1. import source labels -> changed=true   (first converge, if any differ)
+#   2. import again         -> changed=false  (run-twice idempotency, the proof)
+#   3. --check              -> would_change=false
+#
+# No PowerShell; CLI-in-a-role. Provide <in_dir>/<prefix>-src.csv
+# (matrix_id,level_id,src_id,default_label,label_4,label_8,label_12,label_16) —
+# an `export` produces it in the right shape. Use --size 4|8|12 for the
+# idempotency proof; width 16 has no read-back and always sends (documented).
+# One selector per run so stdout is a single JSON object (dst is symmetric).
+#
+#   ansible-playbook -i inventory/probel.ini playbooks/probel-sw08p-label-ensure.yml \
+#     -e 'addr=10.100.0.42:2008 in_dir=routes/mcr size=8'
+#
+- name: Probel SW-P-08 label ensure (idempotency contract)
+  hosts: "{{ target | default('localhost') }}"
+  connection: "{{ conn | default('local') }}"
+  gather_facts: false
+  vars:
+    dhs_bin: dhs
+    addr: 127.0.0.1:2008
+    in_dir: routes
+    prefix: sw08p
+    size: 8
+  tasks:
+    - name: converge source labels (first import)
+      ansible.builtin.command: >-
+        {{ dhs_bin }} consumer probel-sw08p import {{ addr }}
+        --in {{ in_dir }} --prefix {{ prefix }} --src --size {{ size }} --output json
+      register: first
+      changed_when: (first.stdout | from_json).changed | bool
+
+    - name: converge again (run-twice -> NO change, the idempotency proof)
+      ansible.builtin.command: >-
+        {{ dhs_bin }} consumer probel-sw08p import {{ addr }}
+        --in {{ in_dir }} --prefix {{ prefix }} --src --size {{ size }} --output json
+      register: second
+      changed_when: (second.stdout | from_json).changed | bool
+
+    - name: dry-run --check sends nothing
+      ansible.builtin.command: >-
+        {{ dhs_bin }} consumer probel-sw08p import {{ addr }}
+        --in {{ in_dir }} --prefix {{ prefix }} --src --size {{ size }} --check --output json
+      register: dryrun
+      changed_when: false
+
+    - name: ASSERT the contract
+      ansible.builtin.assert:
+        that:
+          - (second.stdout | from_json).changed       == false
+          - (second.stdout | from_json).diff | length == 0
+          - (dryrun.stdout | from_json).would_change   == false
+        success_msg: "sw08p label ensure idempotency contract PASS"
+        fail_msg: "sw08p label ensure FAIL: 2nd={{ second.stdout }} check={{ dryrun.stdout }}"

--- a/cmd/dhs/cmd_probel_csv.go
+++ b/cmd/dhs/cmd_probel_csv.go
@@ -267,12 +267,12 @@ func runProbelImport(ctx context.Context, args []string) error {
 	defer closer()
 
 	if *doSrc {
-		if err := applyProbelNameCSV(cctx, p, filepath.Join(*inDir, *prefix+"-src.csv"), "source", col, width, dry); err != nil {
+		if err := applyProbelNameCSV(cctx, p, filepath.Join(*inDir, *prefix+"-src.csv"), "source", col, width, dry, jsonOut); err != nil {
 			return err
 		}
 	}
 	if *doDst {
-		if err := applyProbelNameCSV(cctx, p, filepath.Join(*inDir, *prefix+"-dst.csv"), "dest-assoc", col, width, dry); err != nil {
+		if err := applyProbelNameCSV(cctx, p, filepath.Join(*inDir, *prefix+"-dst.csv"), "dest-assoc", col, width, dry, jsonOut); err != nil {
 			return err
 		}
 	}
@@ -297,9 +297,42 @@ func readProbelCSV(path string) ([][]string, error) {
 	return r.ReadAll()
 }
 
-// applyProbelNameCSV pushes one width column of labels via update-name. Labels
-// are batched into contiguous id runs sized to fit the SW-P-08 DATA cap.
-func applyProbelNameCSV(ctx context.Context, p *probelproto.Plugin, path, typ string, col int, width codec.NameLength, dryRun bool) error {
+type labelItem struct {
+	id       int
+	label    string
+	mtx, lvl uint8
+}
+
+// parseLabelItems reads the typed label rows (id from col 2, label from the
+// width column), dropping short/non-integer rows.
+func parseLabelItems(rows [][]string, col int) []labelItem {
+	var items []labelItem
+	for _, rec := range rows[1:] {
+		if len(rec) <= col {
+			continue
+		}
+		id, e1 := strconv.Atoi(strings.TrimSpace(rec[2]))
+		mtx, e2 := strconv.Atoi(strings.TrimSpace(rec[0]))
+		lvl, e3 := strconv.Atoi(strings.TrimSpace(rec[1]))
+		if e1 != nil || e2 != nil || e3 != nil {
+			continue
+		}
+		items = append(items, labelItem{id: id, label: rec[col], mtx: uint8(mtx), lvl: uint8(lvl)})
+	}
+	return items
+}
+
+// trimLabel strips the trailing space / NUL padding SW-P-08 applies to
+// fixed-width name fields, so a read-back name compares equal to a CSV label.
+func trimLabel(s string) string { return strings.TrimRight(s, " \x00") }
+
+// applyProbelNameCSV converges one width column of labels to the CSV,
+// idempotently (ADR-0007): it reads the current names back (widths 4/8/12) and
+// sends update-name only for labels that differ, reporting the ADR-0007
+// {changed|would_change, diff[]} shape. Width 16 has no read-back command, so
+// those labels are always (re)sent and reported changed — a documented
+// carve-out. check=true is a dry-run (no send).
+func applyProbelNameCSV(ctx context.Context, p *probelproto.Plugin, path, typ string, col int, width codec.NameLength, check, jsonOut bool) error {
 	rows, err := readProbelCSV(path)
 	if err != nil {
 		return err
@@ -311,58 +344,121 @@ func applyProbelNameCSV(ctx context.Context, p *probelproto.Plugin, path, typ st
 	if err != nil {
 		return err
 	}
-	type item struct {
-		id       int
-		label    string
-		mtx, lvl uint8
-	}
-	var items []item
-	for _, rec := range rows[1:] {
-		if len(rec) <= col {
-			continue
+	items := parseLabelItems(rows, col)
+
+	// Read current names for the read-back diff. SW-P-08 read commands support
+	// 4/8/12-char widths only; width 16 cannot be read back.
+	readable := width.Bytes() <= 12
+	isSource := typ == "source"
+	current := map[[3]int]string{} // {mtx, lvl-or-0, id} -> trimmed name
+	if readable {
+		done := map[[2]uint8]bool{}
+		for _, it := range items {
+			k := [2]uint8{it.mtx, it.lvl}
+			if !isSource {
+				k[1] = 0 // dest names are matrix-scoped, not level-scoped
+			}
+			if done[k] {
+				continue
+			}
+			done[k] = true
+			if isSource {
+				r, rerr := p.AllSourceNames(ctx, it.mtx, it.lvl, width)
+				if rerr != nil {
+					return fmt.Errorf("all-source-names matrix=%d level=%d: %w", it.mtx, it.lvl, rerr)
+				}
+				for i, n := range r.Names {
+					current[[3]int{int(it.mtx), int(it.lvl), int(r.FirstSourceID) + i}] = trimLabel(n)
+				}
+			} else {
+				r, rerr := p.AllDestAssocNames(ctx, it.mtx, width)
+				if rerr != nil {
+					return fmt.Errorf("all-dest-names matrix=%d: %w", it.mtx, rerr)
+				}
+				for i, n := range r.Names {
+					current[[3]int{int(it.mtx), 0, int(r.FirstDestAssociationID) + i}] = trimLabel(n)
+				}
+			}
 		}
-		id, e1 := strconv.Atoi(strings.TrimSpace(rec[2]))
-		mtx, e2 := strconv.Atoi(strings.TrimSpace(rec[0]))
-		lvl, e3 := strconv.Atoi(strings.TrimSpace(rec[1]))
-		if e1 != nil || e2 != nil || e3 != nil {
-			continue
-		}
-		items = append(items, item{id: id, label: rec[col], mtx: uint8(mtx), lvl: uint8(lvl)})
 	}
-	perFrame := 120 / int(width.Bytes())
-	if perFrame < 1 {
-		perFrame = 1
-	}
-	sent := 0
-	for i := 0; i < len(items); {
-		start := items[i]
-		names := []string{start.label}
-		j := i + 1
-		for j < len(items) && items[j].id == items[j-1].id+1 && len(names) < perFrame {
-			names = append(names, items[j].label)
-			j++
+
+	// Diff: keep only labels that differ from the device.
+	changedItems := make([]labelItem, 0, len(items))
+	diffs := []ensureDiff{}
+	for _, it := range items {
+		key := [3]int{int(it.mtx), int(it.lvl), it.id}
+		if !isSource {
+			key[1] = 0
 		}
-		if dryRun {
-			fmt.Printf("[dry-run] %s update-name matrix=%d level=%d first=%d count=%d width=%d\n",
-				typ, start.mtx, start.lvl, start.id, len(names), width.Bytes())
-		} else {
-			err := p.UpdateNameRequest(ctx, codec.UpdateNameRequestParams{
+		want := trimLabel(it.label)
+		// An id absent from the read-back is unlabeled on the device (name ""),
+		// so map-miss defaults to "". Skipping when cur == want (including both
+		// empty) is what makes the whole table idempotent — otherwise the many
+		// unlabeled slots (""→"") would re-send on every run.
+		cur := current[key]
+		if readable && cur == want {
+			continue // already set (or both empty) — idempotent skip
+		}
+		changedItems = append(changedItems, it)
+		field := fmt.Sprintf("src.%d.%d.%d", it.mtx, it.lvl, it.id)
+		if !isSource {
+			field = fmt.Sprintf("dst.%d.%d", it.mtx, it.id)
+		}
+		from := cur
+		if !readable {
+			from = "?" // width 16: no read-back
+		}
+		diffs = append(diffs, ensureDiff{Field: field, From: from, To: want})
+	}
+
+	// Apply changed labels, batched into contiguous same-(matrix,level) id runs
+	// sized to the SW-P-08 DATA cap. Skipped entirely on --check.
+	if !check {
+		perFrame := 120 / int(width.Bytes())
+		if perFrame < 1 {
+			perFrame = 1
+		}
+		for i := 0; i < len(changedItems); {
+			start := changedItems[i]
+			names := []string{start.label}
+			j := i + 1
+			for j < len(changedItems) &&
+				changedItems[j].mtx == start.mtx && changedItems[j].lvl == start.lvl &&
+				changedItems[j].id == changedItems[j-1].id+1 && len(names) < perFrame {
+				names = append(names, changedItems[j].label)
+				j++
+			}
+			if err := p.UpdateNameRequest(ctx, codec.UpdateNameRequestParams{
 				NameType: nameType, NameLength: width,
 				MatrixID: start.mtx, LevelID: start.lvl,
 				FirstID: uint16(start.id), Names: names,
-			})
-			if err != nil {
+			}); err != nil {
 				return fmt.Errorf("update-name %s first=%d: %w", typ, start.id, err)
 			}
+			i = j
 		}
-		sent += len(names)
-		i = j
+	}
+
+	changed := len(diffs) > 0
+	if jsonOut {
+		res := ensureResult{Diff: diffs}
+		if check {
+			res.WouldChange = &changed
+		} else {
+			res.Changed = &changed
+		}
+		return emitEnsure(true, res)
 	}
 	verb := "updated"
-	if dryRun {
+	if check {
 		verb = "would update"
 	}
-	fmt.Printf("%s labels: %s %d (width %d) from %s\n", typ, verb, sent, width.Bytes(), filepath.Base(path))
+	note := ""
+	if !readable {
+		note = " (width 16: no read-back — always sent)"
+	}
+	fmt.Printf("%s labels: %s %d of %d (width %d)%s from %s\n",
+		typ, verb, len(diffs), len(items), width.Bytes(), note, filepath.Base(path))
 	return nil
 }
 

--- a/cmd/dhs/cmd_probel_csv_test.go
+++ b/cmd/dhs/cmd_probel_csv_test.go
@@ -57,6 +57,46 @@ func TestTallyToMap(t *testing.T) {
 	})
 }
 
+// TestTrimLabel pins the fixed-width pad stripping so a read-back name compares
+// equal to a CSV label (SW-P-08 pads names with trailing space or NUL).
+func TestTrimLabel(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"VID", "VID"},
+		{"VID ", "VID"},
+		{"VID\x00\x00", "VID"},
+		{"VID  \x00", "VID"},
+		{"", ""},
+		{"  ", ""},
+	}
+	for _, tc := range cases {
+		if got := trimLabel(tc.in); got != tc.want {
+			t.Errorf("trimLabel(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestParseLabelItems pins the label CSV parse (id from col 2, label from the
+// width column at `col`): header skipped, short/non-integer rows dropped.
+func TestParseLabelItems(t *testing.T) {
+	// columns: matrix_id,level_id,src_id,default_label,label_4,label_8,...
+	col := 4 // label_4
+	rows := [][]string{
+		{"matrix_id", "level_id", "src_id", "default_label", "label_4"}, // header
+		{"0", "0", "0", "", "VID1"},                                     // valid
+		{"0", "0", "1"},                                                 // short -> dropped
+		{"1", "0", "x", "", "BAD"},                                      // non-int id -> dropped
+		{"1", "0", "7", "", "AUX7"},                                     // valid
+	}
+	got := parseLabelItems(rows, col)
+	if len(got) != 2 {
+		t.Fatalf("parsed %d, want 2: %+v", len(got), got)
+	}
+	if got[0] != (labelItem{id: 0, label: "VID1", mtx: 0, lvl: 0}) ||
+		got[1] != (labelItem{id: 7, label: "AUX7", mtx: 1, lvl: 0}) {
+		t.Errorf("parsed = %+v, want [{0 VID1 0 0} {7 AUX7 1 0}]", got)
+	}
+}
+
 // TestParseXpointRows pins the lenient CSV parse: header skipped, short and
 // non-integer rows dropped, valid rows typed.
 func TestParseXpointRows(t *testing.T) {


### PR DESCRIPTION
## What

`import --src` / `import --dst` (Probel SW-P-08 labels) become idempotent: read current names → diff → `update-name` only the changed ones, with `--check` and `--output json`.

## Why

Phase 1 / duty #1 of the operator-contract roadmap — same ADR-0007 contract as the crosspoint ensure (#632), now on labels. Was fire-and-forget (re-sent every label every run).

Closes #635

## Scope

- [x] probel-sw08p
- [x] cli

## Wire evidence

No wire-format change — adds a read (`cmd 100/102` name request) before the existing `cmd 117` update-name. Verified on the demo provider:
```
export -> import --src --dst   : changed:false / changed:false (idempotent)
modified src0 label            : changed:true diff src.0.0.0 "SRC"->"NEWX"
re-import                       : changed:false diff []
```

## Reference controller

- [x] N/A (no protocol behaviour change; update-name path unchanged, only gated on a diff)

## Type

- [x] feat — additive; idempotent + --check

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `cmd/dhs/cmd_probel_csv.go` | modified | applyProbelNameCSV read-name diff; parseLabelItems/trimLabel helpers; --check/--output |
| `cmd/dhs/cmd_probel_csv_test.go` | modified | trimLabel + parseLabelItems tests |
| `ansible/playbooks/probel-sw08p-label-ensure.yml` | new | Tier-3 use-case: import→run-twice=0 |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test ./...` | all | 0 |
| `go vet` / `golangci-lint` | clean | — |

## Device tested

- [x] Demo provider (loopback) — idempotency + change-detection proven (see Wire evidence). Live device via the ansible use-case play (Tier-3).

## Notes

- Width 16 has no read-back command → those labels always send and report changed (documented carve-out). Widths 4/8/12 converge idempotently.
- An id absent from the read-back is treated as unlabeled ("") so unlabeled slots don't re-send every run.

## Checklist

- [x] `go test -count=1 ./...` passes — no regression
- [x] `go vet` / `golangci-lint` clean

## Approval

@yboujraf — requesting review
