### PR TITLE
feat(probel-sw08p): idempotent protect verbs (read-back + --check)

### DIFF
--- a/ansible/playbooks/probel-sw08p-protect-ensure.yml
+++ b/ansible/playbooks/probel-sw08p-protect-ensure.yml
@@ -1,0 +1,70 @@
+# Use-case acceptance test (ADR-0025 Tier-3) for the Probel SW-P-08 protect
+# ensure (idempotent protect-connect / protect-disconnect, ADR-0007). Drives a
+# running matrix and asserts the contract:
+#
+#   1. protect-connect     -> changed (if not already protected by --device)
+#   2. protect-connect     -> changed=false  (run-twice idempotency, the proof)
+#   3. protect-connect --check -> would_change=false
+#   4. protect-disconnect  -> changed  (clears it)
+#   5. protect-disconnect  -> changed=false
+#
+# No PowerShell; CLI-in-a-role.
+#
+#   ansible-playbook -i inventory/probel.ini playbooks/probel-sw08p-protect-ensure.yml \
+#     -e 'addr=10.100.0.42:2008 dst=5 device=9'
+#
+- name: Probel SW-P-08 protect ensure (idempotency contract)
+  hosts: "{{ target | default('localhost') }}"
+  connection: "{{ conn | default('local') }}"
+  gather_facts: false
+  vars:
+    dhs_bin: dhs
+    addr: 127.0.0.1:2008
+    matrix: 0
+    level: 0
+    dst: 5
+    device: 9
+  tasks:
+    - name: converge protect (first)
+      ansible.builtin.command: >-
+        {{ dhs_bin }} consumer probel-sw08p protect-connect {{ addr }}
+        --matrix {{ matrix }} --level {{ level }} --dst {{ dst }} --device {{ device }} --output json
+      register: c1
+      changed_when: (c1.stdout | from_json).changed | bool
+
+    - name: converge protect again (run-twice -> NO change)
+      ansible.builtin.command: >-
+        {{ dhs_bin }} consumer probel-sw08p protect-connect {{ addr }}
+        --matrix {{ matrix }} --level {{ level }} --dst {{ dst }} --device {{ device }} --output json
+      register: c2
+      changed_when: (c2.stdout | from_json).changed | bool
+
+    - name: protect --check (would_change=false when converged)
+      ansible.builtin.command: >-
+        {{ dhs_bin }} consumer probel-sw08p protect-connect {{ addr }}
+        --matrix {{ matrix }} --level {{ level }} --dst {{ dst }} --device {{ device }} --check --output json
+      register: cchk
+      changed_when: false
+
+    - name: release protect, then re-run (idempotent both ways)
+      ansible.builtin.command: >-
+        {{ dhs_bin }} consumer probel-sw08p protect-disconnect {{ addr }}
+        --matrix {{ matrix }} --level {{ level }} --dst {{ dst }} --device {{ device }} --output json
+      register: d1
+      changed_when: (d1.stdout | from_json).changed | bool
+
+    - name: release again (NO change)
+      ansible.builtin.command: >-
+        {{ dhs_bin }} consumer probel-sw08p protect-disconnect {{ addr }}
+        --matrix {{ matrix }} --level {{ level }} --dst {{ dst }} --device {{ device }} --output json
+      register: d2
+      changed_when: (d2.stdout | from_json).changed | bool
+
+    - name: ASSERT the contract
+      ansible.builtin.assert:
+        that:
+          - (c2.stdout   | from_json).changed       == false
+          - (cchk.stdout | from_json).would_change   == false
+          - (d2.stdout   | from_json).changed       == false
+        success_msg: "sw08p protect ensure idempotency contract PASS"
+        fail_msg: "sw08p protect ensure FAIL: c2={{ c2.stdout }} chk={{ cchk.stdout }} d2={{ d2.stdout }}"

--- a/cmd/dhs/cmd_probel.go
+++ b/cmd/dhs/cmd_probel.go
@@ -417,6 +417,8 @@ type probelFlags struct {
 	dst     int
 	src     int
 	timeout time.Duration
+	check   bool
+	output  string
 }
 
 func parseProbelFlags(args []string, want struct{ dst, src bool }) (probelFlags, error) {
@@ -646,6 +648,8 @@ func parseProbelProtectFlags(args []string) (probelFlags, int, error) {
 	device := 0
 	fs.IntVar(&device, "device", 0, "device id (0-1023)")
 	fs.DurationVar(&pf.timeout, "timeout", 5*time.Second, "operation timeout")
+	fs.BoolVar(&pf.check, "check", false, "dry-run: report would_change, send nothing (ADR-0007)")
+	fs.StringVar(&pf.output, "output", "text", "output format: text | json (ADR-0002)")
 	addr, flagArgs := popPositional(args)
 	if addr == "" {
 		return pf, 0, fmt.Errorf("missing <host:port>")
@@ -682,11 +686,24 @@ func runProbelProtectInterrogate(ctx context.Context, args []string) error {
 	return nil
 }
 
+// protectStateStr renders a protect (state, device) pair for the ADR-0007 diff.
+func protectStateStr(state codec.ProtectState, device int) string {
+	return fmt.Sprintf("state=%d device=%d", state, device)
+}
+
+// runProbelProtectConnect converges dst to "protected by --device", idempotently
+// (ADR-0007): it reads ProtectInterrogate and only sends ProtectConnect when the
+// dst is not already ProtectProbel owned by that device. --check is a dry-run;
+// --output json emits {changed|would_change, diff[]}.
 func runProbelProtectConnect(ctx context.Context, args []string) error {
 	pf, device, err := parseProbelProtectFlags(args)
 	if err != nil {
 		return err
 	}
+	jsonOut, oerr := resolveEnsureOutput(pf.output, false)
+	if oerr != nil {
+		return oerr
+	}
 	cctx, cancel := context.WithTimeout(ctx, pf.timeout)
 	defer cancel()
 	p, closer, err := dialProbel(cctx, pf.addr)
@@ -694,20 +711,42 @@ func runProbelProtectConnect(ctx context.Context, args []string) error {
 		return err
 	}
 	defer closer()
+	cur, err := p.ProtectInterrogate(cctx,
+		uint8(pf.matrix), uint8(pf.level), uint16(pf.dst), uint16(device))
+	if err != nil {
+		return err
+	}
+	field := fmt.Sprintf("protect.%d.%d.%d", pf.matrix, pf.level, pf.dst)
+	from := protectStateStr(cur.State, int(cur.DeviceID))
+	to := protectStateStr(codec.ProtectProbel, device)
+	changed := cur.State != codec.ProtectProbel || int(cur.DeviceID) != device
+	if pf.check {
+		return emitEnsure(jsonOut, ensureResult{WouldChange: &changed, Current: from, Target: to, Diff: ensureFieldDiff(changed, field, from, to)})
+	}
+	if !changed {
+		return emitEnsure(jsonOut, ensureResult{Changed: &changed, Previous: from, Current: from, Diff: []ensureDiff{}})
+	}
 	reply, err := p.ProtectConnect(cctx,
 		uint8(pf.matrix), uint8(pf.level), uint16(pf.dst), uint16(device))
 	if err != nil {
 		return err
 	}
-	fmt.Printf("protect connected  matrix=%d level=%d dst=%d device=%d state=%d\n",
-		reply.MatrixID, reply.LevelID, reply.DestinationID, reply.DeviceID, reply.State)
-	return nil
+	now := protectStateStr(reply.State, int(reply.DeviceID))
+	applied := true
+	return emitEnsure(jsonOut, ensureResult{Changed: &applied, Previous: from, Current: now, Diff: ensureFieldDiff(true, field, from, now)})
 }
 
+// runProbelProtectDisconnect converges dst to unprotected (ProtectNone),
+// idempotently: reads ProtectInterrogate and only sends ProtectDisconnect when
+// the dst is currently protected. --check dry-run; --output json.
 func runProbelProtectDisconnect(ctx context.Context, args []string) error {
 	pf, device, err := parseProbelProtectFlags(args)
 	if err != nil {
 		return err
+	}
+	jsonOut, oerr := resolveEnsureOutput(pf.output, false)
+	if oerr != nil {
+		return oerr
 	}
 	cctx, cancel := context.WithTimeout(ctx, pf.timeout)
 	defer cancel()
@@ -716,14 +755,29 @@ func runProbelProtectDisconnect(ctx context.Context, args []string) error {
 		return err
 	}
 	defer closer()
+	cur, err := p.ProtectInterrogate(cctx,
+		uint8(pf.matrix), uint8(pf.level), uint16(pf.dst), uint16(device))
+	if err != nil {
+		return err
+	}
+	field := fmt.Sprintf("protect.%d.%d.%d", pf.matrix, pf.level, pf.dst)
+	from := protectStateStr(cur.State, int(cur.DeviceID))
+	to := protectStateStr(codec.ProtectNone, 0)
+	changed := cur.State != codec.ProtectNone
+	if pf.check {
+		return emitEnsure(jsonOut, ensureResult{WouldChange: &changed, Current: from, Target: to, Diff: ensureFieldDiff(changed, field, from, to)})
+	}
+	if !changed {
+		return emitEnsure(jsonOut, ensureResult{Changed: &changed, Previous: from, Current: from, Diff: []ensureDiff{}})
+	}
 	reply, err := p.ProtectDisconnect(cctx,
 		uint8(pf.matrix), uint8(pf.level), uint16(pf.dst), uint16(device))
 	if err != nil {
 		return err
 	}
-	fmt.Printf("protect disconnected  matrix=%d level=%d dst=%d device=%d state=%d\n",
-		reply.MatrixID, reply.LevelID, reply.DestinationID, reply.DeviceID, reply.State)
-	return nil
+	now := protectStateStr(reply.State, int(reply.DeviceID))
+	applied := true
+	return emitEnsure(jsonOut, ensureResult{Changed: &applied, Previous: from, Current: now, Diff: ensureFieldDiff(true, field, from, now)})
 }
 
 func runProbelProtectName(ctx context.Context, args []string) error {


### PR DESCRIPTION
## What

Probel SW-P-08 `protect-connect` / `protect-disconnect` become idempotent: read `ProtectInterrogate` → apply only if the state differs, with `--check` and `--output json`.

## Why

Phase 1 / duty #2 of the operator-contract roadmap — same ADR-0007 contract as crosspoints (#632) and labels (#636), now on protect. Was imperative fire-and-forget.

Closes #637

## Scope

- [x] probel-sw08p
- [x] cli

## Wire evidence

Adds a read (`cmd 10` protect-interrogate) before the existing `cmd 12/14`. Verified on the demo provider:
```
protect-connect dst5 dev9 : changed:true  state=0->1 dev9 ; re-run changed:false
protect-disconnect dst5   : changed:true  state=1->0        ; re-run changed:false
```

## Reference controller

- [x] N/A (no protocol behaviour change; connect/disconnect path unchanged, only gated on a diff)

## Type

- [x] feat — additive; idempotent + --check

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `cmd/dhs/cmd_probel.go` | modified | protect-connect/disconnect read-back diff; probelFlags --check/--output |
| `ansible/playbooks/probel-sw08p-protect-ensure.yml` | new | Tier-3 use-case: connect→run-twice=0, disconnect symmetric |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test ./...` | all | 0 |
| `go vet` / `golangci-lint` | clean | — |

## Device tested

- [x] Demo provider (loopback) — idempotency both ways proven (see Wire evidence). Live device via the ansible play (Tier-3).

## Notes

- Master-protect by another owner ≠ "protected by --device", so a connect still attempts and the device decides.
- Follow-up (#2b): bulk CSV `import --protect` + `export` protect CSV, reusing this read-back diff.

## Checklist

- [x] `go test -count=1 ./...` passes — no regression
- [x] `go vet` / `golangci-lint` clean

## Approval

@yboujraf — requesting review
