### PR TITLE
feat(probel-sw02p): idempotent crosspoint connect (read-back + --check)

### DIFF
--- a/ansible/playbooks/probel-sw02p-xpoint-ensure.yml
+++ b/ansible/playbooks/probel-sw02p-xpoint-ensure.yml
@@ -1,0 +1,52 @@
+# Use-case acceptance test (ADR-0025 Tier-3) for the Probel SW-P-02 crosspoint
+# ensure (idempotent `connect`, ADR-0007). Same contract as sw08 — identical
+# JSON, so this play is the sw08 play with the proto/verb swapped:
+#
+#   1. connect     -> changed (if the dst wasn't already on --src)
+#   2. connect     -> changed=false  (run-twice idempotency, the proof)
+#   3. --check     -> would_change=false
+#
+# No PowerShell; CLI-in-a-role.
+#
+#   ansible-playbook -i inventory/probel.ini playbooks/probel-sw02p-xpoint-ensure.yml \
+#     -e 'addr=10.100.0.42:2002 dst=0 src=5'
+#
+- name: Probel SW-P-02 crosspoint ensure (idempotency contract)
+  hosts: "{{ target | default('localhost') }}"
+  connection: "{{ conn | default('local') }}"
+  gather_facts: false
+  vars:
+    dhs_bin: dhs
+    addr: 127.0.0.1:2002
+    dst: 0
+    src: 5
+  tasks:
+    - name: converge crosspoint (first connect)
+      ansible.builtin.command: >-
+        {{ dhs_bin }} consumer probel-sw02p connect {{ addr }}
+        --dst {{ dst }} --src {{ src }} --output json
+      register: first
+      changed_when: (first.stdout | from_json).changed | bool
+
+    - name: converge again (run-twice -> NO change, the idempotency proof)
+      ansible.builtin.command: >-
+        {{ dhs_bin }} consumer probel-sw02p connect {{ addr }}
+        --dst {{ dst }} --src {{ src }} --output json
+      register: second
+      changed_when: (second.stdout | from_json).changed | bool
+
+    - name: dry-run --check reports no change and sends nothing
+      ansible.builtin.command: >-
+        {{ dhs_bin }} consumer probel-sw02p connect {{ addr }}
+        --dst {{ dst }} --src {{ src }} --check --output json
+      register: dryrun
+      changed_when: false
+
+    - name: ASSERT the contract (identical to every other protocol)
+      ansible.builtin.assert:
+        that:
+          - (second.stdout | from_json).changed       == false
+          - (second.stdout | from_json).diff | length == 0
+          - (dryrun.stdout | from_json).would_change   == false
+        success_msg: "sw02p crosspoint ensure idempotency contract PASS"
+        fail_msg: "sw02p crosspoint ensure FAIL: 2nd={{ second.stdout }} check={{ dryrun.stdout }}"

--- a/cmd/dhs/cmd_probel02p_verbs.go
+++ b/cmd/dhs/cmd_probel02p_verbs.go
@@ -33,6 +33,8 @@ type probelSW02Flags struct {
 	extended  bool
 	badSource bool
 	timeout   time.Duration
+	check     bool
+	output    string
 }
 
 func parseProbelSW02Flags(args []string, want struct{ src, badSource bool }) (probelSW02Flags, error) {
@@ -45,6 +47,8 @@ func parseProbelSW02Flags(args []string, want struct{ src, badSource bool }) (pr
 		fs.BoolVar(&pf.badSource, "bad-source", false, "set the narrow Multiplier bad-source bit (rx 02 only; ignored when --extended)")
 	}
 	fs.DurationVar(&pf.timeout, "timeout", 5*time.Second, "operation timeout")
+	fs.BoolVar(&pf.check, "check", false, "dry-run: report would_change, send nothing (ADR-0007)")
+	fs.StringVar(&pf.output, "output", "text", "output format: text | json (ADR-0002)")
 	addr, flagArgs := popPositional(args)
 	if addr == "" {
 		return pf, fmt.Errorf("missing <host:port>")
@@ -92,10 +96,19 @@ func runProbelsw02pInterrogate(ctx context.Context, args []string) error {
 	return nil
 }
 
+// runProbelsw02pConnect converges dst to carry --src, idempotently (ADR-0007):
+// it interrogates the current source and only sends a connect when the dst is
+// not already routed from --src (and same bad-source bit). --check dry-runs;
+// --output json emits {changed|would_change, diff[]} — the same shape every
+// other protocol uses, so Ansible treats sw02 identically.
 func runProbelsw02pConnect(ctx context.Context, args []string) error {
 	pf, err := parseProbelSW02Flags(args, struct{ src, badSource bool }{src: true, badSource: true})
 	if err != nil {
 		return err
+	}
+	jsonOut, oerr := resolveEnsureOutput(pf.output, false)
+	if oerr != nil {
+		return oerr
 	}
 	cctx, cancel := context.WithTimeout(ctx, pf.timeout)
 	defer cancel()
@@ -104,22 +117,51 @@ func runProbelsw02pConnect(ctx context.Context, args []string) error {
 		return err
 	}
 	defer closer()
+
+	// Read current source (read-back) for the idempotency decision.
+	var curSrc int
+	var curBad bool
 	if pf.extended {
-		reply, err := p.SendExtendedConnect(cctx, uint16(pf.dst), uint16(pf.src))
-		if err != nil {
-			return err
+		cur, ierr := p.SendExtendedInterrogate(cctx, uint16(pf.dst))
+		if ierr != nil {
+			return ierr
 		}
-		fmt.Printf("extended connected  dst=%d src=%d bad_source=%v update_off=%v\n",
-			reply.Destination, reply.Source, reply.BadSource, reply.UpdateOff)
-		return nil
+		curSrc, curBad = int(cur.Source), cur.BadSource
+	} else {
+		cur, ierr := p.SendInterrogate(cctx, uint16(pf.dst))
+		if ierr != nil {
+			return ierr
+		}
+		curSrc, curBad = int(cur.Source), cur.BadSource
 	}
-	reply, err := p.SendConnect(cctx, uint16(pf.dst), uint16(pf.src), pf.badSource)
-	if err != nil {
-		return err
+	field := fmt.Sprintf("xpoint.%d", pf.dst)
+	from := fmt.Sprintf("src=%d bad_source=%v", curSrc, curBad)
+	to := fmt.Sprintf("src=%d bad_source=%v", pf.src, pf.badSource)
+	changed := curSrc != pf.src || curBad != pf.badSource
+
+	if pf.check {
+		return emitEnsure(jsonOut, ensureResult{WouldChange: &changed, Current: from, Target: to, Diff: ensureFieldDiff(changed, field, from, to)})
 	}
-	fmt.Printf("connected  dst=%d src=%d bad_source=%v\n",
-		reply.Destination, reply.Source, reply.BadSource)
-	return nil
+	if !changed {
+		return emitEnsure(jsonOut, ensureResult{Changed: &changed, Previous: from, Current: from, Diff: []ensureDiff{}})
+	}
+
+	var now string
+	if pf.extended {
+		reply, cerr := p.SendExtendedConnect(cctx, uint16(pf.dst), uint16(pf.src))
+		if cerr != nil {
+			return cerr
+		}
+		now = fmt.Sprintf("src=%d bad_source=%v", reply.Source, reply.BadSource)
+	} else {
+		reply, cerr := p.SendConnect(cctx, uint16(pf.dst), uint16(pf.src), pf.badSource)
+		if cerr != nil {
+			return cerr
+		}
+		now = fmt.Sprintf("src=%d bad_source=%v", reply.Source, reply.BadSource)
+	}
+	applied := true
+	return emitEnsure(jsonOut, ensureResult{Changed: &applied, Previous: from, Current: now, Diff: ensureFieldDiff(true, field, from, now)})
 }
 
 func runProbelsw02pConnectOnGo(ctx context.Context, args []string) error {


### PR DESCRIPTION
## What

Probel SW-P-02 `connect` becomes idempotent — interrogate current source → apply only if different, `--check` + `--output json`. Byte-identical output shape to sw08/ember+.

## Why

Phase 1 / duty #3 of the operator-contract roadmap. Brings sw02 onto the **same** contract as every other protocol, so an Ansible role treats it identically (swap the proto var).

Closes #639

## Scope

- [x] probel-sw08p / probel-sw02p
- [x] cli

## Wire evidence

Adds a read (interrogate) before the existing connect. Verified on the sw02 loopback provider:
```
connect dst0 src5 : changed:true  src=1023->5 ; re-run changed:false ; --check would_change:false
```

## Reference controller

- [x] N/A (no protocol behaviour change; connect path unchanged, only gated on a diff)

## Type

- [x] feat — additive; idempotent + --check

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `cmd/dhs/cmd_probel02p_verbs.go` | modified | connect read-back diff (narrow + extended); probelSW02Flags --check/--output |
| `ansible/playbooks/probel-sw02p-xpoint-ensure.yml` | new | Tier-3 use-case: connect→run-twice=0 |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test ./...` | all* | 0 |
| `go vet` / `golangci-lint` | clean | — |

\* one unrelated emberplus TestConsumerReconnect flake self-heals on CI retry (this change is cmd/dhs-only).

## Device tested

- [x] sw02 loopback provider — idempotency proven (see Wire evidence). Live device via the ansible play (Tier-3).

## Checklist

- [x] `go test -count=1 ./...` passes — no regression
- [x] `go vet` / `golangci-lint` clean

## Approval

@yboujraf — requesting review
