### PR TITLE
feat(tsl): route the validate verb (offline capture decode)

### DIFF
--- a/cmd/dhs/cmd_tsl.go
+++ b/cmd/dhs/cmd_tsl.go
@@ -21,6 +21,12 @@ import (
 //
 //	listen [--bind HOST:PORT] [--tcp]   bind a UDP (or v5.0 TCP) listener
 //	                                    and print every decoded frame.
+//	validate <frames.jsonl>             decode a captured trace offline
+//	                                    through the codec (per ADR-0021).
+//
+// TSL is push-only with no read-back, so the idempotent `ensure` verb is
+// N/A for it (ratified in the ADR-0007 amendment): "keep it set" is the
+// producer's `serve --refresh`, not a converge.
 //
 // `proto` is one of `tsl-v31` / `tsl-v40` / `tsl-v50`.
 func runTSLConsumer(ctx context.Context, proto string, args []string) error {
@@ -33,8 +39,13 @@ func runTSLConsumer(ctx context.Context, proto string, args []string) error {
 	switch verb {
 	case "listen":
 		return runTSLListen(ctx, proto, rest)
+	case "validate":
+		// The tsl plugin implements consumer.Validator; route to the generic
+		// offline validator with --protocol injected, exactly like the
+		// acp1/acp2/emberplus dispatch (main.go dispatchConsumer).
+		return runValidate(ctx, append([]string{"--protocol", proto}, rest...))
 	}
-	return fmt.Errorf("consumer %s: unknown verb %q (expected: listen)", proto, verb)
+	return fmt.Errorf("consumer %s: unknown verb %q (expected: listen | validate)", proto, verb)
 }
 
 // runTSLListen binds a UDP (or v5.0 TCP) listener and prints every

--- a/cmd/dhs/cmd_tsl_validate_test.go
+++ b/cmd/dhs/cmd_tsl_validate_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestTSLValidateRouted pins that `validate` is a dispatched tsl verb (not the
+// switch's "unknown verb" default) for every tsl version. It uses a nonexistent
+// capture so the call fails on file-open inside runValidate — proving the
+// dispatch reached the generic offline validator, which is the routing fix.
+func TestTSLValidateRouted(t *testing.T) {
+	for _, proto := range []string{"tsl-v31", "tsl-v40", "tsl-v50"} {
+		t.Run(proto, func(t *testing.T) {
+			err := runTSLConsumer(context.Background(), proto, []string{"validate", "does-not-exist-capture.jsonl"})
+			if err == nil {
+				t.Fatalf("%s validate on a missing file returned nil; expected a file-open error (routing still proven)", proto)
+			}
+			if strings.Contains(err.Error(), "unknown verb") {
+				t.Fatalf("%s: validate is not routed: %v", proto, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Route the TSL `validate` verb (offline capture decode) — it was implemented on the plugin but not dispatched.

## Why

Phase 2 / duty #4. `runTSLConsumer` only handled `listen`, so the tsl `consumer.Validator` was unreachable from the CLI. TSL is push-only with no read-back (UDP or TCP), so `ensure` is genuinely N/A — this routes the verb that *does* apply to a push protocol: offline trace decode.

Closes #641

## Scope

- [x] osc / tsl / cerebrum-nb / amwa
- [x] cli

## Type

- [x] feat

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `cmd/dhs/cmd_tsl.go` | modified | `validate` case → generic validator with `--protocol` injected; N/A-ensure doc |
| `cmd/dhs/cmd_tsl_validate_test.go` | new | routing pinned across v3.1/v4.0/v5.0 |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test ./...` | all | 0 |
| `go vet` / `golangci-lint` | clean | — |

Verified: `dhs consumer tsl-v31 validate <capture.jsonl>` → "1 trames decoded, rx: 1".

## Device tested

- [x] No device needed (offline decode).

## Note

TSL "keep it set" liveness stays the producer's `serve --refresh` (per the ADR-0007 amendment) — not an idempotent converge.

## Approval

@yboujraf — requesting review
