### PR TITLE
feat(probel-sw02p): idempotent protect verbs (read-back + --check)

### DIFF
--- a/ansible/playbooks/probel-sw02p-protect-ensure.yml
+++ b/ansible/playbooks/probel-sw02p-protect-ensure.yml
@@ -1,0 +1,68 @@
+# Use-case acceptance test (ADR-0025 Tier-3) for the Probel SW-P-02 protect
+# ensure (idempotent protect-connect / protect-disconnect, ADR-0007). Same
+# contract as sw08 — identical JSON, so this is the sw08 protect play with the
+# proto swapped:
+#
+#   1. protect-connect     -> changed (if not already protected by --device)
+#   2. protect-connect     -> changed=false  (run-twice idempotency, the proof)
+#   3. protect-connect --check -> would_change=false
+#   4. protect-disconnect  -> changed ; re-run -> changed=false
+#
+# No PowerShell; CLI-in-a-role.
+#
+#   ansible-playbook -i inventory/probel.ini playbooks/probel-sw02p-protect-ensure.yml \
+#     -e 'addr=10.100.0.42:2002 dst=5 device=9'
+#
+- name: Probel SW-P-02 protect ensure (idempotency contract)
+  hosts: "{{ target | default('localhost') }}"
+  connection: "{{ conn | default('local') }}"
+  gather_facts: false
+  vars:
+    dhs_bin: dhs
+    addr: 127.0.0.1:2002
+    dst: 5
+    device: 9
+  tasks:
+    - name: converge protect (first)
+      ansible.builtin.command: >-
+        {{ dhs_bin }} consumer probel-sw02p protect-connect {{ addr }}
+        --dst {{ dst }} --device {{ device }} --output json
+      register: c1
+      changed_when: (c1.stdout | from_json).changed | bool
+
+    - name: converge protect again (run-twice -> NO change)
+      ansible.builtin.command: >-
+        {{ dhs_bin }} consumer probel-sw02p protect-connect {{ addr }}
+        --dst {{ dst }} --device {{ device }} --output json
+      register: c2
+      changed_when: (c2.stdout | from_json).changed | bool
+
+    - name: protect --check (would_change=false when converged)
+      ansible.builtin.command: >-
+        {{ dhs_bin }} consumer probel-sw02p protect-connect {{ addr }}
+        --dst {{ dst }} --device {{ device }} --check --output json
+      register: cchk
+      changed_when: false
+
+    - name: release protect, then re-run
+      ansible.builtin.command: >-
+        {{ dhs_bin }} consumer probel-sw02p protect-disconnect {{ addr }}
+        --dst {{ dst }} --device {{ device }} --output json
+      register: d1
+      changed_when: (d1.stdout | from_json).changed | bool
+
+    - name: release again (NO change)
+      ansible.builtin.command: >-
+        {{ dhs_bin }} consumer probel-sw02p protect-disconnect {{ addr }}
+        --dst {{ dst }} --device {{ device }} --output json
+      register: d2
+      changed_when: (d2.stdout | from_json).changed | bool
+
+    - name: ASSERT the contract
+      ansible.builtin.assert:
+        that:
+          - (c2.stdout   | from_json).changed       == false
+          - (cchk.stdout | from_json).would_change   == false
+          - (d2.stdout   | from_json).changed       == false
+        success_msg: "sw02p protect ensure idempotency contract PASS"
+        fail_msg: "sw02p protect ensure FAIL: c2={{ c2.stdout }} chk={{ cchk.stdout }} d2={{ d2.stdout }}"

--- a/cmd/dhs/cmd_probel02p_verbs.go
+++ b/cmd/dhs/cmd_probel02p_verbs.go
@@ -288,11 +288,19 @@ func runProbelsw02pSalvoConnect(ctx context.Context, args []string) error {
 	return nil
 }
 
+// runProbelsw02pProtectConnect converges dst to "protected by --device",
+// idempotently (ADR-0007): interrogates current protect state and only sends a
+// connect when not already ProtectProBel owned by that device. --check dry-run;
+// --output json emits the same {changed|would_change, diff[]} as every protocol.
 func runProbelsw02pProtectConnect(ctx context.Context, args []string) error {
 	pf, device, err := parseProbelSW02ProtectFlags(args)
 	if err != nil {
 		return err
 	}
+	jsonOut, oerr := resolveEnsureOutput(pf.output, false)
+	if oerr != nil {
+		return oerr
+	}
 	cctx, cancel := context.WithTimeout(ctx, pf.timeout)
 	defer cancel()
 	p, closer, err := dialProbelSW02(cctx, pf.addr)
@@ -300,20 +308,41 @@ func runProbelsw02pProtectConnect(ctx context.Context, args []string) error {
 		return err
 	}
 	defer closer()
+	cur, err := p.SendExtendedProtectInterrogate(cctx, uint16(pf.dst))
+	if err != nil {
+		return err
+	}
+	field := fmt.Sprintf("protect.%d", pf.dst)
+	from := fmt.Sprintf("state=%s device=%d", protectStateName(cur.Protect), cur.Device)
+	to := fmt.Sprintf("state=%s device=%d", protectStateName(codec02.ProtectProBel), device)
+	changed := cur.Protect != codec02.ProtectProBel || int(cur.Device) != device
+	if pf.check {
+		return emitEnsure(jsonOut, ensureResult{WouldChange: &changed, Current: from, Target: to, Diff: ensureFieldDiff(changed, field, from, to)})
+	}
+	if !changed {
+		return emitEnsure(jsonOut, ensureResult{Changed: &changed, Previous: from, Current: from, Diff: []ensureDiff{}})
+	}
 	reply, err := p.SendExtendedProtectConnect(cctx, uint16(pf.dst), uint16(device))
 	if err != nil {
 		return err
 	}
-	fmt.Printf("protect connected  dst=%d device=%d state=%s\n",
-		reply.Destination, reply.Device, protectStateName(reply.Protect))
-	return nil
+	now := fmt.Sprintf("state=%s device=%d", protectStateName(reply.Protect), reply.Device)
+	applied := true
+	return emitEnsure(jsonOut, ensureResult{Changed: &applied, Previous: from, Current: now, Diff: ensureFieldDiff(true, field, from, now)})
 }
 
+// runProbelsw02pProtectDisconnect converges dst to unprotected (ProtectNone),
+// idempotently: interrogates and only sends a disconnect when the dst is
+// currently protected. --check dry-run; --output json.
 func runProbelsw02pProtectDisconnect(ctx context.Context, args []string) error {
 	pf, device, err := parseProbelSW02ProtectFlags(args)
 	if err != nil {
 		return err
 	}
+	jsonOut, oerr := resolveEnsureOutput(pf.output, false)
+	if oerr != nil {
+		return oerr
+	}
 	cctx, cancel := context.WithTimeout(ctx, pf.timeout)
 	defer cancel()
 	p, closer, err := dialProbelSW02(cctx, pf.addr)
@@ -321,13 +350,27 @@ func runProbelsw02pProtectDisconnect(ctx context.Context, args []string) error {
 		return err
 	}
 	defer closer()
+	cur, err := p.SendExtendedProtectInterrogate(cctx, uint16(pf.dst))
+	if err != nil {
+		return err
+	}
+	field := fmt.Sprintf("protect.%d", pf.dst)
+	from := fmt.Sprintf("state=%s device=%d", protectStateName(cur.Protect), cur.Device)
+	to := fmt.Sprintf("state=%s device=%d", protectStateName(codec02.ProtectNone), 0)
+	changed := cur.Protect != codec02.ProtectNone
+	if pf.check {
+		return emitEnsure(jsonOut, ensureResult{WouldChange: &changed, Current: from, Target: to, Diff: ensureFieldDiff(changed, field, from, to)})
+	}
+	if !changed {
+		return emitEnsure(jsonOut, ensureResult{Changed: &changed, Previous: from, Current: from, Diff: []ensureDiff{}})
+	}
 	reply, err := p.SendExtendedProtectDisconnect(cctx, uint16(pf.dst), uint16(device))
 	if err != nil {
 		return err
 	}
-	fmt.Printf("protect disconnected  dst=%d device=%d state=%s\n",
-		reply.Destination, reply.Device, protectStateName(reply.Protect))
-	return nil
+	now := fmt.Sprintf("state=%s device=%d", protectStateName(reply.Protect), reply.Device)
+	applied := true
+	return emitEnsure(jsonOut, ensureResult{Changed: &applied, Previous: from, Current: now, Diff: ensureFieldDiff(true, field, from, now)})
 }
 
 func runProbelsw02pProtectInterrogate(ctx context.Context, args []string) error {
@@ -588,6 +631,8 @@ func parseProbelSW02ProtectFlags(args []string) (probelSW02Flags, int, error) {
 	device := 0
 	fs.IntVar(&device, "device", 0, "device id (0-16383)")
 	fs.DurationVar(&pf.timeout, "timeout", 5*time.Second, "operation timeout")
+	fs.BoolVar(&pf.check, "check", false, "dry-run: report would_change, send nothing (ADR-0007)")
+	fs.StringVar(&pf.output, "output", "text", "output format: text | json (ADR-0002)")
 	addr, flagArgs := popPositional(args)
 	if addr == "" {
 		return pf, 0, fmt.Errorf("missing <host:port>")


### PR DESCRIPTION
## What

sw02 `protect-connect` / `protect-disconnect` become idempotent — interrogate → apply only if the state differs, `--check` + `--output json`. Identical output to sw08 protect.

## Why

Probel consistency: every probel protect path now behaves like sw08 (#638), so Ansible treats sw02 protect identically.

Closes #643

## Scope

- [x] probel-sw08p / probel-sw02p
- [x] cli

## Wire evidence

Adds a read (extended protect-interrogate) before the existing connect/disconnect. Verified on the sw02 loopback provider:
```
protect-connect dst5 dev9 : changed:true none->probel dev9 ; re-run changed:false
protect-disconnect dst5   : changed:true probel->none      ; re-run changed:false
```

## Reference controller

- [x] N/A (no protocol behaviour change; owner-only authority ladder untouched, only gated on a diff)

## Type

- [x] feat — additive; idempotent + --check

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `cmd/dhs/cmd_probel02p_verbs.go` | modified | protect-connect/disconnect read-back diff; protect parser --check/--output |
| `ansible/playbooks/probel-sw02p-protect-ensure.yml` | new | Tier-3 use-case: connect→run-twice=0, disconnect symmetric |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test ./...` | all | 0 |
| `go vet` / `golangci-lint` | clean | — |

## Device tested

- [x] sw02 loopback provider — idempotency both ways proven.

## Approval

@yboujraf — requesting review
