### PR TITLE
feat(probel-sw08p): bulk protect import (import --protect CSV, idempotent)

### DIFF
--- a/ansible/playbooks/probel-sw08p-protect-csv-ensure.yml
+++ b/ansible/playbooks/probel-sw08p-protect-csv-ensure.yml
@@ -1,0 +1,53 @@
+# Use-case acceptance test (ADR-0025 Tier-3) for the Probel SW-P-08 bulk
+# protect ensure (`import --protect`, ADR-0007). Same contract as crosspoints
+# and labels — provision a whole plant's protect state from a CSV, idempotently.
+#
+#   1. import --protect -> changed (if any dst not in desired state)
+#   2. import --protect -> changed=false  (run-twice idempotency, the proof)
+#   3. --check          -> would_change=false
+#
+# No PowerShell; CLI-in-a-role. Provide <in_dir>/<prefix>-protect.csv
+# (matrix_id,level_id,dst_id,state,device ; state = none|probel).
+#
+#   ansible-playbook -i inventory/probel.ini playbooks/probel-sw08p-protect-csv-ensure.yml \
+#     -e 'addr=10.100.0.42:2008 in_dir=routes/mcr'
+#
+- name: Probel SW-P-08 bulk protect ensure (idempotency contract)
+  hosts: "{{ target | default('localhost') }}"
+  connection: "{{ conn | default('local') }}"
+  gather_facts: false
+  vars:
+    dhs_bin: dhs
+    addr: 127.0.0.1:2008
+    in_dir: routes
+    prefix: sw08p
+  tasks:
+    - name: converge protect states (first import)
+      ansible.builtin.command: >-
+        {{ dhs_bin }} consumer probel-sw08p import {{ addr }}
+        --in {{ in_dir }} --prefix {{ prefix }} --protect --output json
+      register: first
+      changed_when: (first.stdout | from_json).changed | bool
+
+    - name: converge again (run-twice -> NO change, the idempotency proof)
+      ansible.builtin.command: >-
+        {{ dhs_bin }} consumer probel-sw08p import {{ addr }}
+        --in {{ in_dir }} --prefix {{ prefix }} --protect --output json
+      register: second
+      changed_when: (second.stdout | from_json).changed | bool
+
+    - name: dry-run --check sends nothing
+      ansible.builtin.command: >-
+        {{ dhs_bin }} consumer probel-sw08p import {{ addr }}
+        --in {{ in_dir }} --prefix {{ prefix }} --protect --check --output json
+      register: dryrun
+      changed_when: false
+
+    - name: ASSERT the contract
+      ansible.builtin.assert:
+        that:
+          - (second.stdout | from_json).changed       == false
+          - (second.stdout | from_json).diff | length == 0
+          - (dryrun.stdout | from_json).would_change   == false
+        success_msg: "sw08p bulk protect ensure idempotency contract PASS"
+        fail_msg: "sw08p bulk protect ensure FAIL: 2nd={{ second.stdout }} check={{ dryrun.stdout }}"

--- a/cmd/dhs/cmd_probel_csv.go
+++ b/cmd/dhs/cmd_probel_csv.go
@@ -232,6 +232,7 @@ func runProbelImport(ctx context.Context, args []string) error {
 	doSrc := fs.Bool("src", false, "import source labels (<prefix>-src.csv)")
 	doDst := fs.Bool("dst", false, "import destination labels (<prefix>-dst.csv)")
 	doXpoints := fs.Bool("xpoints", false, "import crosspoints (<prefix>-xpoint.csv; converges the matrix, idempotent)")
+	doProtect := fs.Bool("protect", false, "import protect states (<prefix>-protect.csv; converges protect, idempotent)")
 	timeout := fs.Duration("timeout", 300*time.Second, "overall timeout")
 	addr, flagArgs := popPositional(args)
 	if addr == "" {
@@ -240,8 +241,8 @@ func runProbelImport(ctx context.Context, args []string) error {
 	if err := fs.Parse(flagArgs); err != nil {
 		return err
 	}
-	// No selector → default to labels only (never auto-reroute crosspoints).
-	if !*doSrc && !*doDst && !*doXpoints {
+	// No selector → default to labels only (never auto-reroute crosspoints/protect).
+	if !*doSrc && !*doDst && !*doXpoints && !*doProtect {
 		*doSrc, *doDst = true, true
 	}
 	width, err := parseNameLen(strconv.Itoa(*size))
@@ -281,6 +282,99 @@ func runProbelImport(ctx context.Context, args []string) error {
 			return err
 		}
 	}
+	if *doProtect {
+		if err := applyProbelProtectCSV(cctx, p, filepath.Join(*inDir, *prefix+"-protect.csv"), dry, jsonOut); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// parseProtectDesired maps a protect-CSV state cell to a desired ProtectState.
+// Accepts "none"/"0"/"unprotected" and "probel"/"1"/"protected".
+func parseProtectDesired(s string) (codec.ProtectState, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "none", "0", "unprotected":
+		return codec.ProtectNone, true
+	case "probel", "1", "protected":
+		return codec.ProtectProbel, true
+	}
+	return 0, false
+}
+
+// applyProbelProtectCSV converges destination protect state to the CSV,
+// idempotently (ADR-0007). Each row is matrix_id,level_id,dst_id,state,device
+// (state = none|probel); it reads ProtectInterrogate and only sends a
+// protect-connect / protect-disconnect when the state (and owner, for probel)
+// differs. check=true is a dry-run.
+func applyProbelProtectCSV(ctx context.Context, p *probelproto.Plugin, path string, check, jsonOut bool) error {
+	rows, err := readProbelCSV(path)
+	if err != nil {
+		return err
+	}
+	total := 0
+	diffs := []ensureDiff{}
+	for _, rec := range rows[1:] {
+		if len(rec) < 5 {
+			continue
+		}
+		mtx, e1 := strconv.Atoi(strings.TrimSpace(rec[0]))
+		lvl, e2 := strconv.Atoi(strings.TrimSpace(rec[1]))
+		dst, e3 := strconv.Atoi(strings.TrimSpace(rec[2]))
+		dev, e4 := strconv.Atoi(strings.TrimSpace(rec[4]))
+		want, okState := parseProtectDesired(rec[3])
+		if e1 != nil || e2 != nil || e3 != nil || e4 != nil || !okState {
+			continue
+		}
+		total++
+		cur, ierr := p.ProtectInterrogate(ctx, uint8(mtx), uint8(lvl), uint16(dst), uint16(dev))
+		if ierr != nil {
+			return fmt.Errorf("protect-interrogate dst=%d: %w", dst, ierr)
+		}
+		var changed bool
+		if want == codec.ProtectProbel {
+			changed = cur.State != codec.ProtectProbel || int(cur.DeviceID) != dev
+		} else {
+			changed = cur.State != codec.ProtectNone
+		}
+		if !changed {
+			continue
+		}
+		from := fmt.Sprintf("state=%d device=%d", cur.State, cur.DeviceID)
+		toDev := dev
+		if want == codec.ProtectNone {
+			toDev = 0
+		}
+		to := fmt.Sprintf("state=%d device=%d", want, toDev)
+		diffs = append(diffs, ensureDiff{Field: fmt.Sprintf("protect.%d.%d.%d", mtx, lvl, dst), From: from, To: to})
+		if check {
+			continue
+		}
+		if want == codec.ProtectProbel {
+			if _, cerr := p.ProtectConnect(ctx, uint8(mtx), uint8(lvl), uint16(dst), uint16(dev)); cerr != nil {
+				return fmt.Errorf("protect-connect dst=%d: %w", dst, cerr)
+			}
+		} else {
+			if _, cerr := p.ProtectDisconnect(ctx, uint8(mtx), uint8(lvl), uint16(dst), uint16(dev)); cerr != nil {
+				return fmt.Errorf("protect-disconnect dst=%d: %w", dst, cerr)
+			}
+		}
+	}
+	changed := len(diffs) > 0
+	if jsonOut {
+		res := ensureResult{Diff: diffs}
+		if check {
+			res.WouldChange = &changed
+		} else {
+			res.Changed = &changed
+		}
+		return emitEnsure(true, res)
+	}
+	verb := "applied"
+	if check {
+		verb = "would apply"
+	}
+	fmt.Printf("protect: %s %d of %d changes from %s\n", verb, len(diffs), total, filepath.Base(path))
 	return nil
 }
 

--- a/cmd/dhs/cmd_probel_csv_test.go
+++ b/cmd/dhs/cmd_probel_csv_test.go
@@ -57,6 +57,36 @@ func TestTallyToMap(t *testing.T) {
 	})
 }
 
+// TestParseProtectDesired pins the protect-CSV state-cell mapping (none/probel
+// in words or 0/1), and that unknown cells are rejected.
+func TestParseProtectDesired(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantOK   bool
+		wantNone bool // true => ProtectNone, false => ProtectProbel
+	}{
+		{"none", true, true},
+		{"0", true, true},
+		{"unprotected", true, true},
+		{"probel", true, false},
+		{"1", true, false},
+		{"protected", true, false},
+		{"  Probel ", true, false},
+		{"bogus", false, false},
+		{"", false, false},
+	}
+	for _, tc := range cases {
+		got, ok := parseProtectDesired(tc.in)
+		if ok != tc.wantOK {
+			t.Errorf("parseProtectDesired(%q) ok = %v, want %v", tc.in, ok, tc.wantOK)
+			continue
+		}
+		if ok && (got == 0) != tc.wantNone {
+			t.Errorf("parseProtectDesired(%q) = %d, wantNone=%v", tc.in, got, tc.wantNone)
+		}
+	}
+}
+
 // TestTrimLabel pins the fixed-width pad stripping so a read-back name compares
 // equal to a CSV label (SW-P-08 pads names with trailing space or NUL).
 func TestTrimLabel(t *testing.T) {


### PR DESCRIPTION
Completes sw08 protect for bulk provisioning (Ansible), consistent with --xpoints/--src/--dst. import --protect reads <prefix>-protect.csv (matrix,level,dst,state,device) and converges per-dst via ProtectInterrogate. --check + --output json, identical shape.

Verified loopback: import --protect changed:true (protect.0.0.5 0->1 dev9) -> re-run changed:false -> --check would_change:false. parseProtectDesired unit-tested; ansible play added. go test ./... green; vet+lint clean.

Closes #645

@yboujraf — requesting review