### PR TITLE
feat(cli): producer tree + validate verbs (canonical, ADR-0002)

### DIFF
--- a/cmd/dhs/cmd_producer_tree.go
+++ b/cmd/dhs/cmd_producer_tree.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+
+	"dhs/internal/export/canonical"
+	"dhs/internal/manifest"
+)
+
+// runProducerTree loads the canonical tree a producer would serve (from --tree
+// or --manifest) and prints it — no device or running server needed. Canonical
+// producer verb (ADR-0002): lets an operator inspect / validate exactly what
+// `serve` will expose. `--output json` prints the canonical tree; text prints
+// it with a source header.
+func runProducerTree(_ context.Context, protoName string, args []string) error {
+	fs := flag.NewFlagSet("producer "+protoName+" tree", flag.ContinueOnError)
+	treePath := fs.String("tree", "", "path to canonical tree.json (one of --tree | --manifest required)")
+	manifestPath := fs.String("manifest", "", "path to manifest JSON (assembles the tree from DMs under --cache-dir)")
+	cacheDir := fs.String("cache-dir", ".cache", "cache root for --manifest DM lookup")
+	output := fs.String("output", "text", "output format: text | json")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *treePath == "" && *manifestPath == "" {
+		return fmt.Errorf("producer %s tree: one of --tree | --manifest is required", protoName)
+	}
+	if *treePath != "" && *manifestPath != "" {
+		return fmt.Errorf("producer %s tree: --tree and --manifest are mutually exclusive", protoName)
+	}
+
+	var (
+		tree *canonical.Export
+		err  error
+		src  = *treePath
+	)
+	if *manifestPath != "" {
+		src = *manifestPath
+		mf, merr := manifest.Load(*manifestPath)
+		if merr != nil {
+			return fmt.Errorf("load manifest: %w", merr)
+		}
+		if mf.Device.Protocol != protoName {
+			return fmt.Errorf("manifest protocol %q != requested %q", mf.Device.Protocol, protoName)
+		}
+		tree, err = manifest.BuildExport(mf, *cacheDir)
+		if err != nil {
+			return fmt.Errorf("build tree from manifest: %w", err)
+		}
+	} else {
+		tree, err = loadTree(*treePath)
+		if err != nil {
+			return fmt.Errorf("load tree: %w", err)
+		}
+	}
+
+	b, err := json.MarshalIndent(tree, "", "  ")
+	if err != nil {
+		return fmt.Errorf("render tree: %w", err)
+	}
+	if *output == "json" {
+		fmt.Println(string(b))
+		return nil
+	}
+	fmt.Printf("producer %s tree (from %s):\n%s\n", protoName, src, string(b))
+	return nil
+}

--- a/cmd/dhs/main.go
+++ b/cmd/dhs/main.go
@@ -349,6 +349,13 @@ func dispatchProducer(ctx context.Context, args []string) error {
 	switch verb {
 	case "serve":
 		return runProducer(ctx, proto, rest)
+	case "tree":
+		return runProducerTree(ctx, proto, rest)
+	case "validate":
+		// Offline decode of a captured frames.jsonl through the codec — the
+		// same generic validator the consumer side uses (direction-agnostic);
+		// inject --protocol like dispatchConsumer does.
+		return runValidate(ctx, append([]string{"--protocol", proto}, rest...))
 	case "admin":
 		if proto != "acp1" {
 			return fmt.Errorf("producer %s: admin verb is acp1-only (advances #258)", proto)
@@ -360,7 +367,7 @@ func dispatchProducer(ctx context.Context, args []string) error {
 		}
 		return runACP1Fuzz(ctx, rest)
 	}
-	return fmt.Errorf("producer %s: unknown verb %q (expected: serve | admin | fuzz)", proto, verb)
+	return fmt.Errorf("producer %s: unknown verb %q (expected: serve | tree | validate | admin | fuzz)", proto, verb)
 }
 
 // dispatchRegistry routes `dhs registry <proto> <verb> [args]`. The


### PR DESCRIPTION
Adds canonical producer verbs `tree` (load+render the served canonical tree from --tree/--manifest, no serve needed, --output json) and `validate` (offline frames decode via the generic validator). Generic-dispatch producers (acp1/acp2/emberplus/probel). Verified: probel-sw08p tree renders; validate routes. go test ./... green; vet+lint clean.

Closes #649

@yboujraf — requesting review