### PR TITLE
feat(cli): canonical producer stop verb (pidfile-based, cross-platform)

### DIFF
--- a/cmd/dhs/cmd_producer.go
+++ b/cmd/dhs/cmd_producer.go
@@ -67,6 +67,7 @@ func runProducer(ctx context.Context, protoName string, args []string) error {
 		play          = fs.String("play", "", "acp1 only: oscillate objects with random values; each tick fires a spontaneous status announce. Pass `all` to oscillate every oscillatable object on every slot (slot 0 included), or a comma-separated path list 1.<slot+1>.<group>.<id>[,...] e.g. 1.1.3.6,1.1.3.7 oscillates Temp_Left + Temp_Right on slot 0")
 		playEvery     = fs.Duration("play-interval", 2*time.Second, "acp1 only: tick interval for --play")
 		playMode      = fs.String("play-mode", "walk", "acp1 only: --play value strategy — `walk` (mean-reverting drift, realistic) or `random` (force a uniform value across the object's full [min,max] each tick)")
+		pidfile       = fs.String("pidfile", "", "if set, write this process's PID to PATH on start (removed on exit) so `dhs producer <proto> stop --pidfile PATH` can signal it")
 	)
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -81,6 +82,15 @@ func runProducer(ctx context.Context, protoName string, args []string) error {
 	// --host stays for backwards-compat. When both are set, --bind wins.
 	if *bind != "" {
 		*host = *bind
+	}
+
+	// Write a PID file for `producer stop` to signal, removed on exit. Atomic
+	// (.tmp + rename) per the repo's file-write convention.
+	if *pidfile != "" {
+		if err := writePIDFile(*pidfile); err != nil {
+			return fmt.Errorf("write pidfile: %w", err)
+		}
+		defer func() { _ = os.Remove(*pidfile) }()
 	}
 
 	logger := newLogger(*logLevel, *logFormat)

--- a/cmd/dhs/cmd_producer_stop.go
+++ b/cmd/dhs/cmd_producer_stop.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// writePIDFile atomically writes the current process PID to path (.tmp +
+// rename, per the repo's file-write convention). Called by `serve --pidfile`.
+func writePIDFile(path string) error {
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(strconv.Itoa(os.Getpid())+"\n"), 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// runProducerStop implements the canonical producer `stop` verb (ADR-0002):
+// read the PID file a `serve --pidfile` instance wrote and signal it. Graceful
+// on Unix (SIGTERM → serve's signal.NotifyContext teardown); hard kill on
+// Windows (no cross-process SIGTERM in the Go stdlib). See stopProcess in the
+// build-tagged cmd_producer_stop_{unix,windows}.go.
+func runProducerStop(_ context.Context, protoName string, args []string) error {
+	fs := flag.NewFlagSet("producer "+protoName+" stop", flag.ContinueOnError)
+	pidfile := fs.String("pidfile", "", "PID file the target `serve --pidfile` wrote (required)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *pidfile == "" {
+		return fmt.Errorf("producer %s stop: --pidfile is required (the path serve was started with)", protoName)
+	}
+	data, err := os.ReadFile(*pidfile)
+	if err != nil {
+		return fmt.Errorf("read pidfile %s: %w", *pidfile, err)
+	}
+	pidStr := strings.TrimSpace(string(data))
+	pid, err := strconv.Atoi(pidStr)
+	if err != nil {
+		return fmt.Errorf("pidfile %s: invalid PID %q: %w", *pidfile, pidStr, err)
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("find process %d: %w", pid, err)
+	}
+	if err := stopProcess(proc); err != nil {
+		return fmt.Errorf("signal process %d: %w", pid, err)
+	}
+	_ = os.Remove(*pidfile)
+	fmt.Printf("producer %s stop: signaled pid %d (pidfile %s)\n", protoName, pid, *pidfile)
+	return nil
+}

--- a/cmd/dhs/cmd_producer_stop_unix.go
+++ b/cmd/dhs/cmd_producer_stop_unix.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+// stopProcess sends a graceful SIGTERM so the target serve's
+// signal.NotifyContext(os.Interrupt, SIGTERM) teardown runs and it shuts down
+// cleanly (drains sessions, removes its pidfile).
+func stopProcess(p *os.Process) error {
+	return p.Signal(syscall.SIGTERM)
+}

--- a/cmd/dhs/cmd_producer_stop_windows.go
+++ b/cmd/dhs/cmd_producer_stop_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package main
+
+import "os"
+
+// stopProcess terminates the target process. Windows has no cross-process
+// SIGTERM equivalent in the Go stdlib (os.Process.Signal only supports Kill for
+// other processes), so this is a hard kill. The serve process's own PID file is
+// cleaned up here by runProducerStop rather than by the killed process's defer.
+func stopProcess(p *os.Process) error {
+	return p.Kill()
+}

--- a/cmd/dhs/main.go
+++ b/cmd/dhs/main.go
@@ -358,6 +358,8 @@ func dispatchProducer(ctx context.Context, args []string) error {
 		// there is one implementation. Requires the server started with
 		// --metrics-addr; pass --url http://host:port/snapshot.json.
 		return runMetricsShow(ctx, rest)
+	case "stop":
+		return runProducerStop(ctx, proto, rest)
 	case "validate":
 		// Offline decode of a captured frames.jsonl through the codec — the
 		// same generic validator the consumer side uses (direction-agnostic);
@@ -374,7 +376,7 @@ func dispatchProducer(ctx context.Context, args []string) error {
 		}
 		return runACP1Fuzz(ctx, rest)
 	}
-	return fmt.Errorf("producer %s: unknown verb %q (expected: serve | tree | status | validate | admin | fuzz)", proto, verb)
+	return fmt.Errorf("producer %s: unknown verb %q (expected: serve | tree | status | stop | validate | admin | fuzz)", proto, verb)
 }
 
 // dispatchRegistry routes `dhs registry <proto> <verb> [args]`. The


### PR DESCRIPTION
Adds the canonical producer `stop` verb (ADR-0002). serve --pidfile writes its PID; stop --pidfile signals it — graceful SIGTERM on Unix, hard kill on Windows (build-tagged). Verified end-to-end (serve :2008 -> stop -> process dead, pidfile removed, port closed). go test ./... green; vet+lint clean.

Closes #653

@yboujraf — requesting review