### PR TITLE
feat(cli): canonical producer ensure verb (ADR-0007 lifecycle)

### DIFF
--- a/cmd/dhs/cmd_producer_ensure.go
+++ b/cmd/dhs/cmd_producer_ensure.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+)
+
+// pidfileRunning treats the presence of the pidfile as "serving": serve writes
+// it on start and removes it on graceful exit; stop removes it too. Simple and
+// cross-platform (no liveness syscall). A stale file after a hard crash is the
+// documented edge case.
+func pidfileRunning(pidfile string) bool {
+	_, err := os.Stat(pidfile)
+	return err == nil
+}
+
+// producerEnsurePlan is the pure ADR-0007 decision for the producer lifecycle:
+// given the desired state and whether an instance is currently running, return
+// the current-state string and whether a change is needed. ok=false for an
+// unrecognised state (the caller emits the exit-2 validation error). Kept pure
+// so the truth table is unit-tested without touching processes or stdout.
+func producerEnsurePlan(state string, running bool) (from string, changed, ok bool) {
+	from = "absent"
+	if running {
+		from = "present"
+	}
+	switch state {
+	case "present":
+		return from, !running, true
+	case "absent":
+		return from, running, true
+	default:
+		return from, false, false
+	}
+}
+
+// runProducerEnsure is the canonical producer `ensure` verb (ADR-0007):
+// declaratively converge a serving instance to --state present|absent, keyed on
+// its --pidfile.
+//
+//   - absent: idempotent teardown — stop the running instance (reusing
+//     signalPIDFile) or no-op if already stopped.
+//   - present: no-op if already running; on --check report the drift. Actually
+//     starting a foreground service isn't ensure's job (it can't start-and-
+//     return), so apply-present when stopped errors with a pointer to `serve`
+//     under a supervisor — the honest boundary, not a fake success.
+//
+// Emits the same {changed|would_change, diff[]} shape as every other ensure.
+func runProducerEnsure(_ context.Context, protoName string, args []string) error {
+	fs := flag.NewFlagSet("producer "+protoName+" ensure", flag.ContinueOnError)
+	state := fs.String("state", "present", "desired state: present | absent (ADR-0007)")
+	pidfile := fs.String("pidfile", "", "PID file the target serve wrote (required)")
+	check := fs.Bool("check", false, "dry-run: report would_change, do nothing")
+	output := fs.String("output", "text", "output format: text | json (ADR-0002)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *pidfile == "" {
+		return fmt.Errorf("producer %s ensure: --pidfile is required", protoName)
+	}
+	jsonOut, oerr := resolveEnsureOutput(*output, false)
+	if oerr != nil {
+		return oerr
+	}
+
+	const field = "producer"
+	running := pidfileRunning(*pidfile)
+	from, changed, ok := producerEnsurePlan(*state, running)
+	if !ok {
+		return ensureValErr(fmt.Sprintf("--state %q: expected present | absent", *state))
+	}
+
+	// Dry-run: report drift, touch nothing.
+	if *check {
+		return emitEnsure(jsonOut, ensureResult{WouldChange: &changed, Current: from, Target: *state, Diff: ensureFieldDiff(changed, field, from, *state)})
+	}
+	// Already converged.
+	if !changed {
+		return emitEnsure(jsonOut, ensureResult{Changed: &changed, Previous: from, Current: from, Diff: []ensureDiff{}})
+	}
+	// Apply. present-when-stopped is the honest boundary: ensure can't
+	// foreground-start-and-return, so it errors with a pointer to `serve` under a
+	// supervisor rather than faking changed:true.
+	if *state == "present" {
+		return fmt.Errorf("producer %s ensure --state present: not running (pidfile %s absent) — a foreground service can't be started by ensure; run `dhs producer %s serve --pidfile %s ...` under your service manager",
+			protoName, *pidfile, protoName, *pidfile)
+	}
+	// absent + running → stop.
+	if _, err := signalPIDFile(*pidfile); err != nil {
+		return err
+	}
+	applied := true
+	return emitEnsure(jsonOut, ensureResult{Changed: &applied, Previous: "present", Current: "absent", Diff: ensureFieldDiff(true, field, "present", "absent")})
+}

--- a/cmd/dhs/cmd_producer_ensure_test.go
+++ b/cmd/dhs/cmd_producer_ensure_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"dhs/internal/consumer"
+)
+
+// TestProducerEnsurePlan pins the ADR-0007 truth table for the producer
+// lifecycle: present converges an already-running instance to no-op and flags a
+// stopped one as drift; absent is the mirror; an unknown state is not ok (the
+// caller turns that into an exit-2 validation error). Run-twice idempotency
+// follows directly — after the first apply the running flag flips, so the second
+// call returns changed=false.
+func TestProducerEnsurePlan(t *testing.T) {
+	cases := []struct {
+		name        string
+		state       string
+		running     bool
+		wantFrom    string
+		wantChanged bool
+		wantOK      bool
+	}{
+		{"present + running = no-op", "present", true, "present", false, true},
+		{"present + stopped = drift", "present", false, "absent", true, true},
+		{"absent + running = stop", "absent", true, "present", true, true},
+		{"absent + stopped = no-op", "absent", false, "absent", false, true},
+		{"unknown state not ok", "paused", true, "present", false, false},
+		{"empty state not ok", "", false, "absent", false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			from, changed, ok := producerEnsurePlan(tc.state, tc.running)
+			if from != tc.wantFrom || changed != tc.wantChanged || ok != tc.wantOK {
+				t.Errorf("producerEnsurePlan(%q,%v) = (%q,%v,%v), want (%q,%v,%v)",
+					tc.state, tc.running, from, changed, ok, tc.wantFrom, tc.wantChanged, tc.wantOK)
+			}
+		})
+	}
+}
+
+// TestPidfileRunning pins the state indicator: pidfile present = serving,
+// absent = stopped. Presence, not liveness, keeps it cross-platform.
+func TestPidfileRunning(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "none.pid")
+	if pidfileRunning(missing) {
+		t.Errorf("pidfileRunning(%q) = true, want false (file absent)", missing)
+	}
+	present := filepath.Join(dir, "there.pid")
+	if err := os.WriteFile(present, []byte("123\n"), 0o644); err != nil {
+		t.Fatalf("seed pidfile: %v", err)
+	}
+	if !pidfileRunning(present) {
+		t.Errorf("pidfileRunning(%q) = false, want true (file present)", present)
+	}
+}
+
+// TestRunProducerEnsure_RequiresPidfile pins that --pidfile is mandatory: no
+// state can be decided without it, so the verb errors before doing anything.
+func TestRunProducerEnsure_RequiresPidfile(t *testing.T) {
+	if err := runProducerEnsure(context.Background(), "emberplus", []string{"--state", "absent"}); err == nil {
+		t.Fatal("runProducerEnsure without --pidfile: err = nil, want error")
+	}
+}
+
+// TestRunProducerEnsure_UnknownStateIsExit2 pins that a bad --state is a
+// client-side validation error (exit 2), not a runtime failure.
+func TestRunProducerEnsure_UnknownStateIsExit2(t *testing.T) {
+	pid := filepath.Join(t.TempDir(), "x.pid")
+	err := runProducerEnsure(context.Background(), "emberplus", []string{"--state", "paused", "--pidfile", pid})
+	if err == nil {
+		t.Fatal("runProducerEnsure --state paused: err = nil, want validation error")
+	}
+	var verr *consumer.ValidationError
+	if !errors.As(err, &verr) {
+		t.Errorf("err = %T, want *consumer.ValidationError (exit 2)", err)
+	}
+}
+
+// TestRunProducerEnsure_AbsentNoop pins that absent against a stopped instance
+// is a clean no-op (no error, no file to signal).
+func TestRunProducerEnsure_AbsentNoop(t *testing.T) {
+	pid := filepath.Join(t.TempDir(), "stopped.pid")
+	if err := runProducerEnsure(context.Background(), "emberplus", []string{"--state", "absent", "--pidfile", pid, "--output", "json"}); err != nil {
+		t.Fatalf("absent no-op: err = %v, want nil", err)
+	}
+}
+
+// TestRunProducerEnsure_PresentApplyStoppedErrors pins the honest boundary:
+// applying present to a stopped instance can't foreground-start it, so it errors
+// rather than reporting a fake change. --check on the same state must NOT error
+// (it only reports drift).
+func TestRunProducerEnsure_PresentApplyStoppedErrors(t *testing.T) {
+	pid := filepath.Join(t.TempDir(), "stopped.pid")
+	if err := runProducerEnsure(context.Background(), "emberplus", []string{"--state", "present", "--pidfile", pid}); err == nil {
+		t.Fatal("present apply on stopped instance: err = nil, want error (cannot foreground-start)")
+	}
+	if err := runProducerEnsure(context.Background(), "emberplus", []string{"--state", "present", "--pidfile", pid, "--check", "--output", "json"}); err != nil {
+		t.Fatalf("present --check on stopped instance: err = %v, want nil (drift report, not error)", err)
+	}
+}
+
+// TestRunProducerEnsure_AbsentCheckLeavesPidfile pins that --check is a true
+// dry-run: it reports would_change but does not remove the pidfile.
+func TestRunProducerEnsure_AbsentCheckLeavesPidfile(t *testing.T) {
+	pid := filepath.Join(t.TempDir(), "running.pid")
+	if err := os.WriteFile(pid, []byte("123\n"), 0o644); err != nil {
+		t.Fatalf("seed pidfile: %v", err)
+	}
+	if err := runProducerEnsure(context.Background(), "emberplus", []string{"--state", "absent", "--pidfile", pid, "--check", "--output", "json"}); err != nil {
+		t.Fatalf("absent --check: err = %v, want nil", err)
+	}
+	if !pidfileRunning(pid) {
+		t.Error("absent --check removed the pidfile; dry-run must not touch state")
+	}
+}

--- a/cmd/dhs/cmd_producer_stop.go
+++ b/cmd/dhs/cmd_producer_stop.go
@@ -33,23 +33,34 @@ func runProducerStop(_ context.Context, protoName string, args []string) error {
 	if *pidfile == "" {
 		return fmt.Errorf("producer %s stop: --pidfile is required (the path serve was started with)", protoName)
 	}
-	data, err := os.ReadFile(*pidfile)
+	pid, err := signalPIDFile(*pidfile)
 	if err != nil {
-		return fmt.Errorf("read pidfile %s: %w", *pidfile, err)
+		return err
+	}
+	fmt.Printf("producer %s stop: signaled pid %d (pidfile %s)\n", protoName, pid, *pidfile)
+	return nil
+}
+
+// signalPIDFile reads a PID file, signals that process (graceful on Unix / kill
+// on Windows via stopProcess), removes the file, and returns the PID. Shared by
+// `stop` and `ensure --state absent`.
+func signalPIDFile(pidfile string) (int, error) {
+	data, err := os.ReadFile(pidfile)
+	if err != nil {
+		return 0, fmt.Errorf("read pidfile %s: %w", pidfile, err)
 	}
 	pidStr := strings.TrimSpace(string(data))
 	pid, err := strconv.Atoi(pidStr)
 	if err != nil {
-		return fmt.Errorf("pidfile %s: invalid PID %q: %w", *pidfile, pidStr, err)
+		return 0, fmt.Errorf("pidfile %s: invalid PID %q: %w", pidfile, pidStr, err)
 	}
 	proc, err := os.FindProcess(pid)
 	if err != nil {
-		return fmt.Errorf("find process %d: %w", pid, err)
+		return 0, fmt.Errorf("find process %d: %w", pid, err)
 	}
 	if err := stopProcess(proc); err != nil {
-		return fmt.Errorf("signal process %d: %w", pid, err)
+		return 0, fmt.Errorf("signal process %d: %w", pid, err)
 	}
-	_ = os.Remove(*pidfile)
-	fmt.Printf("producer %s stop: signaled pid %d (pidfile %s)\n", protoName, pid, *pidfile)
-	return nil
+	_ = os.Remove(pidfile)
+	return pid, nil
 }

--- a/cmd/dhs/main.go
+++ b/cmd/dhs/main.go
@@ -360,6 +360,12 @@ func dispatchProducer(ctx context.Context, args []string) error {
 		return runMetricsShow(ctx, rest)
 	case "stop":
 		return runProducerStop(ctx, proto, rest)
+	case "ensure":
+		// Canonical ADR-0007 ensure for the serving instance: converge to
+		// --state present|absent keyed on --pidfile (idempotent teardown; drift
+		// report for present). See runProducerEnsure for the honest boundary on
+		// apply-present.
+		return runProducerEnsure(ctx, proto, rest)
 	case "validate":
 		// Offline decode of a captured frames.jsonl through the codec — the
 		// same generic validator the consumer side uses (direction-agnostic);
@@ -376,7 +382,7 @@ func dispatchProducer(ctx context.Context, args []string) error {
 		}
 		return runACP1Fuzz(ctx, rest)
 	}
-	return fmt.Errorf("producer %s: unknown verb %q (expected: serve | tree | status | stop | validate | admin | fuzz)", proto, verb)
+	return fmt.Errorf("producer %s: unknown verb %q (expected: serve | tree | status | stop | ensure | validate | admin | fuzz)", proto, verb)
 }
 
 // dispatchRegistry routes `dhs registry <proto> <verb> [args]`. The
@@ -563,7 +569,15 @@ func printProducerHelp() {
 	fmt.Println(`dhs producer — inbound (serve a canonical tree over the wire)
 
 USAGE
-  dhs producer <protocol> serve [flags]
+  dhs producer <protocol> <verb> [flags]
+
+VERBS
+  serve     bind the transport(s) and serve the canonical tree
+  tree      print the canonical tree that would be served (no bind)
+  status    live runtime snapshot of a serving instance (--url .../snapshot.json)
+  stop      signal a 'serve --pidfile PATH' instance to shut down (--pidfile PATH)
+  ensure    ADR-0007 converge to --state present|absent, keyed on --pidfile
+  validate  offline decode a captured frames.jsonl through the codec
 
 PROTOCOLS
   acp1 | acp2 | emberplus | probel-sw02p | probel-sw08p


### PR DESCRIPTION
## What

Adds the canonical **`ensure`** verb to the producer surface (ADR-0007), the last lifecycle verb missing from `serve | tree | status | stop | validate`:

```
dhs producer <proto> ensure --state present|absent --pidfile PATH [--check] [--output json]
```

So a serving instance converges to a declared lifecycle state idempotently from an Ansible role — same `changed_when: (r.stdout|from_json).changed` pattern as every consumer-side entity.

## Behaviour

| state | current | result |
|---|---|---|
| `absent` | running | stop it → `changed:true` |
| `absent` | stopped | no-op → `changed:false` |
| `present` | running | no-op → `changed:false` |
| `present` | stopped | `--check`: `would_change:true`; **apply: error** |

`present` apply on a stopped instance **errors** with a pointer to `serve` under a supervisor rather than faking `changed:true` — a foreground service can't be started-and-returned, and ADR-0007 forbids reporting a change that didn't happen. That's the honest boundary, documented in the code and help.

Output is byte-identical to every other ensure:

```json
{"changed":true,"previous":"present","current":"absent","diff":[{"field":"producer","from":"present","to":"absent"}]}
```

## How

- `producerEnsurePlan(state, running)` — pure decision helper, unit-tested as a truth table.
- `runProducerEnsure` — flags, emit, and the apply paths; reuses `signalPIDFile` (extracted from `stop`) for teardown.
- pidfile presence (`os.Stat`) is the state indicator — no cross-platform liveness syscall.
- Wired into `dispatchProducer`; producer help gains a VERBS section.

## Tests

- Unit: truth table, `--pidfile` required, unknown state = exit-2 validation error, `--check` non-mutation, present-apply-stopped errors.
- Loopback (local, Windows): `serve --pidfile` → `present`(no-op) → `absent --check`(drift, pidfile untouched) → `absent`(stop, pidfile removed) → `absent`(no-op). All four transitions matched the contract exactly.
- `go build ./...`, `go vet`, full `cmd/dhs` suite green.

Closes #655

🤖 Generated with [Claude Code](https://claude.com/claude-code)
