### PR TITLE
ci: union coverage profiles across retry attempts to kill the floor flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,19 +74,47 @@ jobs:
           set -e
           # Concurrency packages (consumer/provider) have goroutine/timer
           # branches whose statement coverage depends on scheduling, so a
-          # single run on a loaded CI runner can dip ~0.1% even though the
-          # code is genuinely 100%-coverable (verified repeatedly locally).
-          # Retry up to 3x and pass on the first run that meets the floor;
-          # a real regression fails all three. The bar is still a genuine
-          # 100% — this only stabilises the measurement of timing branches.
+          # single run on a loaded CI runner can leave a genuinely-coverable
+          # line uncovered — and because a loaded runner stays loaded, the
+          # same line can miss on all three consecutive attempts (a plain
+          # retry then fails even though the code is 100%-coverable).
+          #
+          # Fix: UNION the coverage profiles across attempts. A statement is
+          # counted covered if it was hit in ANY attempt, so a line that is
+          # coverable at all converges into the union within a few runs. The
+          # 100% bar stays genuine: a line no test can ever reach is absent
+          # from every profile, so the union stays below the floor and fails
+          # all three attempts. This removes the scheduling flake (all
+          # protocols) without weakening the gate.
+          #
+          # union_pct FILE...  -> prints the unioned statement coverage %.
+          # Coverprofile rows are "pkg/file.go:sL.sC,eL.eC <numStmt> <count>";
+          # the first line ("mode: set") is skipped per file.
+          union_pct() {
+            awk '
+              FNR==1 { next }
+              { stmts[$1]=$2; if ($3+0>0) covered[$1]=1 }
+              END {
+                tot=0; cov=0
+                for (k in stmts) { tot+=stmts[k]; if (k in covered) cov+=stmts[k] }
+                if (tot==0) { print "100.0"; exit }
+                printf "%.1f\n", 100*cov/tot
+              }
+            ' "$@"
+          }
           check() {
-            local pct
+            local pkg=$1 floor=$2 pct tag
+            tag=$(printf '%s' "$pkg" | tr '/.' '__')
+            local profs=()
             for attempt in 1 2 3; do
-              pct=$(go test -count=1 -cover "$1" | sed -n 's/.*coverage: \([0-9.]*\)%.*/\1/p')
-              printf '%s: %s%% (floor %s%%, attempt %s)\n' "$1" "$pct" "$2" "$attempt"
-              if awk "BEGIN{exit !(${pct:-0}+0 >= $2)}"; then return 0; fi
+              local pf="cov_${tag}.${attempt}.out"
+              go test -count=1 -covermode=set -coverprofile="$pf" "$pkg" >/dev/null
+              profs+=("$pf")
+              pct=$(union_pct "${profs[@]}")
+              printf '%s: union %s%% (floor %s%%, after attempt %s)\n' "$pkg" "$pct" "$floor" "$attempt"
+              if awk "BEGIN{exit !(${pct:-0}+0 >= $floor)}"; then return 0; fi
             done
-            echo "::error::$1 coverage ${pct}% below floor $2% after 3 attempts"
+            echo "::error::$pkg union coverage ${pct}% below floor $floor% after 3 attempts"
             exit 1
           }
           check ./internal/acp1/codec 100


### PR DESCRIPTION
## Problem

The coverage-floor step retries up to 3x, but recomputes coverage from scratch each attempt. On a loaded runner a genuinely-coverable goroutine/timer branch can stay uncovered across **all three consecutive attempts** (the runner stays loaded), so the gate fails even though the code is 100%-coverable.

Observed live: the post-merge `main` CI for the docs-only merge #657 failed with `internal/acp1/consumer` at **99.9%, all 3 attempts** — nothing in a docs change can alter coverage, so it was pure measurement flake. A whole-run rerun then passed. This is the recurring "flake after every PR" class.

## Fix

Union the per-attempt coverprofiles. A statement counts as covered if it was hit in **any** attempt, so a coverable line converges into the union within a few runs. The 100% bar stays genuine — a line no test can ever reach is absent from every profile, so the union stays below the floor and fails all three attempts.

Systemic: lives in the shared floor step, so it covers **every** floored package (all protocols) — not per-line whack-a-mole.

## Verified

Against real `acp1/consumer` profiles:

| Scenario | Union % | Outcome |
|---|---|---|
| single run, one block flaked to 0 | 99.9% | today's failure |
| union with a run that covers it | **100.0%** | healed |
| block missed in every run (real regression) | 99.9% | still fails |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
