### PR TITLE
test(emberplus): matrix-ensure idempotency integration test vs live vendor router (ADR-0025 deliverable 3)

### DIFF
--- a/internal/emberplus/integration/external_test.go
+++ b/internal/emberplus/integration/external_test.go
@@ -21,6 +21,7 @@ package emberplus_integration
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"os/exec"
 	"strings"
@@ -113,4 +114,93 @@ func firstN(s string, n int) string {
 		return s[:n]
 	}
 	return s
+}
+
+// ensureResult is the ADR-0007 JSON the matrix verb emits under --output json.
+// Only the outcome flags matter here; Changed/WouldChange are pointers so an
+// absent field stays nil rather than defaulting to false.
+type ensureResult struct {
+	Changed     *bool `json:"changed"`
+	WouldChange *bool `json:"would_change"`
+}
+
+// runMatrixJSON runs `consumer emberplus matrix ... --output json` and decodes
+// the ADR-0007 result. Skips the whole test when the provider has no matrix at
+// the requested path (a plain provider like TinyEmberPlus :9000), so the test
+// asserts only against a matrix-bearing router.
+func runMatrixJSON(t *testing.T, bin, host, port, path string, extra ...string) ensureResult {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	args := append([]string{
+		"consumer", "emberplus", "matrix", host,
+		"--port", port, "--path", path, "--output", "json", "--timeout", "20s",
+	}, extra...)
+	out, err := exec.CommandContext(ctx, bin, args...).CombinedOutput()
+	// The JSON line is the last non-log line; slog noise goes to the same pipe.
+	line := lastJSONLine(string(out))
+	if line == "" {
+		if err != nil {
+			t.Skipf("matrix %s not usable on %s:%s (no matrix at path?): %v\n%s", path, host, port, err, firstN(string(out), 600))
+		}
+		t.Fatalf("matrix verb produced no JSON line:\n%s", firstN(string(out), 600))
+	}
+	var r ensureResult
+	if jerr := json.Unmarshal([]byte(line), &r); jerr != nil {
+		t.Fatalf("decoding matrix JSON %q: %v", line, jerr)
+	}
+	return r
+}
+
+// lastJSONLine returns the last line that looks like a JSON object, so the
+// ADR-0007 result is picked out of interleaved slog output.
+func lastJSONLine(out string) string {
+	var found string
+	for _, ln := range strings.Split(out, "\n") {
+		ln = strings.TrimSpace(ln)
+		if strings.HasPrefix(ln, "{") && strings.HasSuffix(ln, "}") {
+			found = ln
+		}
+	}
+	return found
+}
+
+// TestExternalEmberMatrixIdempotent proves the ADR-0007 matrix-ensure contract
+// against a real vendor router (TinyEmberPlusRouter): an identical re-apply is a
+// no-op (changed:false), and --check reports drift without mutating. Independent
+// of the starting crosspoint state — it asserts the invariants, not a fixed
+// route. Env-gated (EMBERPLUS_TEST_HOST) and matrix-gated (skips on a provider
+// with no matrix at EMBERPLUS_TEST_MATRIX). Requires the router port, e.g.
+// EMBERPLUS_TEST_PORT=9092. Leaves target 0 routed to source 0.
+func TestExternalEmberMatrixIdempotent(t *testing.T) {
+	host, port := emberTarget(t)
+	bin := buildDHS(t)
+
+	path := os.Getenv("EMBERPLUS_TEST_MATRIX")
+	if path == "" {
+		path = "router.dynamic.matrix"
+	}
+	const target, srcA, srcB = "0", "0", "1"
+
+	// Apply target←srcA. Skips here if the provider has no such matrix.
+	runMatrixJSON(t, bin, host, port, path, "--target", target, "--sources", srcA, "--op", "absolute")
+
+	// Re-apply the identical connection: must be a no-op (run-twice = 0 changes).
+	again := runMatrixJSON(t, bin, host, port, path, "--target", target, "--sources", srcA, "--op", "absolute")
+	if again.Changed == nil || *again.Changed {
+		t.Fatalf("idempotency broken: identical matrix re-apply reported changed=%v, want changed:false", again.Changed)
+	}
+
+	// --check a different source: reports drift, sends nothing.
+	chk := runMatrixJSON(t, bin, host, port, path, "--target", target, "--sources", srcB, "--op", "absolute", "--check")
+	if chk.WouldChange == nil || !*chk.WouldChange {
+		t.Fatalf("--check to source %s reported would_change=%v, want would_change:true", srcB, chk.WouldChange)
+	}
+
+	// Re-apply srcA: still a no-op, proving --check did not mutate the crosspoint.
+	after := runMatrixJSON(t, bin, host, port, path, "--target", target, "--sources", srcA, "--op", "absolute")
+	if after.Changed == nil || *after.Changed {
+		t.Fatalf("--check mutated state: post-check re-apply reported changed=%v, want changed:false", after.Changed)
+	}
+	t.Logf("matrix-ensure idempotent on %s:%s path %s (re-apply no-op, --check non-mutating)", host, port, path)
 }


### PR DESCRIPTION
Turns the manual matrix-ensure idempotency proof — verified live against TinyEmberPlusRouter on the desk oracle — into a committed, repeatable integration test. Advances ADR-0025 deliverable 3 for Ember+ (integration driving the CLI against a **real vendor oracle**, not our own provider).

## Test
`TestExternalEmberMatrixIdempotent` asserts the ADR-0007 contract on the wire:
- identical matrix re-apply is a no-op (`changed:false`) — run-twice = 0 changes
- `--check` reports `would_change:true` and does not mutate the crosspoint
- invariant-based (not tied to a fixed route), so it holds against any starting state

Env-gated (`EMBERPLUS_TEST_HOST`) + matrix-gated (skips a plain provider with no matrix at `EMBERPLUS_TEST_MATRIX`, default `router.dynamic.matrix`). Build-tagged `integration`, so the default CI run does not compile it; `go vet -tags integration` is clean.

## Verified live (2026-08-11)
| Target | Result |
|---|---|
| `127.0.0.1:9092` TinyEmberPlusRouter | **PASS** — re-apply no-op, --check non-mutating |
| `127.0.0.1:9000` plain TinyEmberPlus | **SKIP** — no matrix (graceful) |

info + walk already PASS on both ports (present/online; 1860 and 4494 objects, scalars decoded).

Closes #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)