### PR TITLE
test(emberplus): scalar-ensure idempotency integration test vs live vendor oracle (ADR-0025 deliverable 3)

### DIFF
--- a/internal/emberplus/integration/external_test.go
+++ b/internal/emberplus/integration/external_test.go
@@ -204,3 +204,92 @@ func TestExternalEmberMatrixIdempotent(t *testing.T) {
 	}
 	t.Logf("matrix-ensure idempotent on %s:%s path %s (re-apply no-op, --check non-mutating)", host, port, path)
 }
+
+// getScalarValue reads a scalar parameter via `consumer emberplus get --path`
+// and returns the current value, unquoted. ok=false when the path is not a
+// readable scalar (so the caller can skip). The verb prints `value = "..."`
+// for strings and `value = <v>` for numerics/bools.
+func getScalarValue(t *testing.T, bin, host, port, path string) (string, bool) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, bin,
+		"consumer", "emberplus", "get", host,
+		"--port", port, "--path", path, "--timeout", "20s",
+	).CombinedOutput()
+	if err != nil {
+		return "", false
+	}
+	for _, ln := range strings.Split(string(out), "\n") {
+		ln = strings.TrimSpace(ln)
+		if v, found := strings.CutPrefix(ln, "value = "); found {
+			return strings.Trim(strings.TrimSpace(v), `"`), true
+		}
+	}
+	return "", false
+}
+
+// runEnsureJSON runs `consumer emberplus ensure ... --output json` and decodes
+// the ADR-0007 result. Reuses ensureResult / lastJSONLine from the matrix test.
+func runEnsureJSON(t *testing.T, bin, host, port, path, value string, extra ...string) ensureResult {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	args := append([]string{
+		"consumer", "emberplus", "ensure", host,
+		"--port", port, "--path", path, "--value", value,
+		"--output", "json", "--timeout", "20s",
+	}, extra...)
+	out, err := exec.CommandContext(ctx, bin, args...).CombinedOutput()
+	line := lastJSONLine(string(out))
+	if line == "" {
+		t.Fatalf("ensure produced no JSON line (err=%v):\n%s", err, firstN(string(out), 600))
+	}
+	var r ensureResult
+	if jerr := json.Unmarshal([]byte(line), &r); jerr != nil {
+		t.Fatalf("decoding ensure JSON %q: %v", line, jerr)
+	}
+	return r
+}
+
+// TestExternalEmberScalarEnsureIdempotent proves the ADR-0007 scalar-ensure
+// contract against a real vendor provider: converging a parameter to its
+// CURRENT value is a no-op (changed:false), and --check to a different value
+// reports drift without mutating. Entirely non-mutating — it never leaves the
+// provider changed. Env-gated (EMBERPLUS_TEST_HOST); the writable scalar path
+// is EMBERPLUS_TEST_PARAM (default a router source label on :9092). Skips when
+// that path is not a readable scalar (e.g. wrong port / different tree).
+func TestExternalEmberScalarEnsureIdempotent(t *testing.T) {
+	host, port := emberTarget(t)
+	bin := buildDHS(t)
+
+	path := os.Getenv("EMBERPLUS_TEST_PARAM")
+	if path == "" {
+		path = "router.dynamic.labels.sources.s-0"
+	}
+
+	cur, ok := getScalarValue(t, bin, host, port, path)
+	if !ok || cur == "" {
+		t.Skipf("no readable scalar at %s on %s:%s — skipping", path, host, port)
+	}
+
+	// Converge to the current value: must be a no-op (run-twice = 0 changes).
+	noop := runEnsureJSON(t, bin, host, port, path, cur)
+	if noop.Changed == nil || *noop.Changed {
+		t.Fatalf("idempotency broken: ensure to current value %q reported changed=%v, want changed:false", cur, noop.Changed)
+	}
+
+	// --check to a guaranteed-different value: reports drift, sends nothing.
+	other := cur + "_dhs_probe"
+	chk := runEnsureJSON(t, bin, host, port, path, other, "--check")
+	if chk.WouldChange == nil || !*chk.WouldChange {
+		t.Fatalf("--check to %q reported would_change=%v, want would_change:true", other, chk.WouldChange)
+	}
+
+	// Converge to current again: still a no-op, proving --check did not mutate.
+	after := runEnsureJSON(t, bin, host, port, path, cur)
+	if after.Changed == nil || *after.Changed {
+		t.Fatalf("--check mutated state: post-check ensure reported changed=%v, want changed:false", after.Changed)
+	}
+	t.Logf("scalar-ensure idempotent on %s:%s path %s (current=%q; converge no-op, --check non-mutating)", host, port, path, cur)
+}


### PR DESCRIPTION
Rounds out ADR-0025 deliverable 3 for Ember+ with a scalar `ensure` integration test, alongside the matrix-ensure test (#660). Drives the CLI against a **real vendor oracle** (TinyEmber+/router), never our own provider.

`TestExternalEmberScalarEnsureIdempotent` is entirely **non-mutating**:
- converging a parameter to its **current** value is a no-op (`changed:false`) — run-twice = 0 changes
- `--check` to a different value reports `would_change:true` without mutating

Env-gated (`EMBERPLUS_TEST_HOST`); writable scalar via `EMBERPLUS_TEST_PARAM` (default a router source label on :9092); skips when not a readable scalar. Build-tagged `integration`; `go vet -tags integration` clean.

Verified live 2026-08-12: **PASS** vs `127.0.0.1:9092`, **SKIP** vs `:9000`.

Closes #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)