### PR TITLE
feat(cerebrum-nb): crosspoint export/import with multi-level rows

### DIFF
--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -133,6 +133,10 @@ func runCerebrum(ctx context.Context, args []string) error {
 		return cerebrumKeepaliveProbe(ctx, rest)
 	case "route":
 		return cerebrumRoute(ctx, rest)
+	case "export":
+		return cerebrumExportXpoint(ctx, rest)
+	case "import":
+		return cerebrumImportXpoint(ctx, rest)
 	case "lock":
 		return cerebrumLock(ctx, rest, codec.LockProtect)
 	case "unlock":
@@ -168,6 +172,8 @@ VERBS
   connect                  POLL (LOGIN auto when --user/--pass set)
   listen                   SUBSCRIBE — routing / category / salvo / device events; Ctrl+C to stop
   route                    ACTION <ROUTING TYPE='ROUTE'/> — single (--dest --srce --level), batch (--route dst:src:lvl), or --csv FILE
+  export                   SUBSCRIBE snapshot → write current crosspoints to a dest,srce,levels CSV  [--out FILE] [--idle DUR]
+  import                   apply a crosspoint CSV (dest,srce,levels; multi-level per row) as ROUTE actions  --csv FILE [--check]
   list-devices             OBTAIN <device_change type='LIST'/>  [--device-type Router|SNMP|Device]
   device-details           OBTAIN <device_change type='DETAILS'/>  --device IP --device-type DEVICE
   device-value             OBTAIN <device_change type='VALUE'/>    --device NAME --by-name --sub-device X --object Y

--- a/cmd/dhs/cmd_cerebrum_xpoint.go
+++ b/cmd/dhs/cmd_cerebrum_xpoint.go
@@ -1,0 +1,399 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"dhs/internal/cerebrum-nb/codec"
+	cerebrum "dhs/internal/cerebrum-nb/consumer"
+)
+
+// cerebrumXpointRow is one line of a Cerebrum crosspoint CSV: a destination fed
+// by a source across one OR MORE levels. Multi-level on a single row models the
+// common "all-level take" (video + audio + ... follow the same source); a
+// breakaway (a level fed by a different source) becomes its own row with its own
+// source. This is the round-trip shape shared by `export` (snapshot -> rows) and
+// `import` (rows -> ROUTE actions), and the same shape a salvo will reuse.
+type cerebrumXpointRow struct {
+	Dest   string
+	Srce   string
+	Levels []string
+}
+
+// parseCerebrumXpoint decodes a crosspoint CSV. The header (any order,
+// case-insensitive) needs dest + srce + a level column, which may be either:
+//
+//	levels  - a ';'-separated list on one row (multi-level take), e.g. "1;2;3"
+//	level   - a single level (legacy single-level form; still accepted)
+//
+// Blank lines and '#' comments are skipped. srcName is only for error messages.
+func parseCerebrumXpoint(data []byte, srcName string) ([]cerebrumXpointRow, error) {
+	lines := strings.Split(strings.ReplaceAll(string(data), "\r\n", "\n"), "\n")
+	// Skip leading blank/comment lines to find the header.
+	start := 0
+	for start < len(lines) && (strings.TrimSpace(lines[start]) == "" || strings.HasPrefix(strings.TrimSpace(lines[start]), "#")) {
+		start++
+	}
+	if start >= len(lines) {
+		return nil, fmt.Errorf("%s: empty (no header)", srcName)
+	}
+	header := strings.Split(strings.ToLower(strings.TrimSpace(lines[start])), ",")
+	idx := map[string]int{}
+	for i, h := range header {
+		idx[strings.TrimSpace(h)] = i
+	}
+	if _, ok := idx["dest"]; !ok {
+		return nil, fmt.Errorf("%s: missing column \"dest\"", srcName)
+	}
+	if _, ok := idx["srce"]; !ok {
+		return nil, fmt.Errorf("%s: missing column \"srce\"", srcName)
+	}
+	levelCol, multi := idx["levels"]
+	if !multi {
+		var ok bool
+		levelCol, ok = idx["level"]
+		if !ok {
+			return nil, fmt.Errorf("%s: missing level column (need \"levels\" or \"level\")", srcName)
+		}
+	}
+
+	var out []cerebrumXpointRow
+	for n, line := range lines[start+1:] {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		f := strings.Split(line, ",")
+		if len(f) < len(header) {
+			return nil, fmt.Errorf("%s line %d: %d columns < header %d", srcName, start+n+2, len(f), len(header))
+		}
+		dest := strings.TrimSpace(f[idx["dest"]])
+		srce := strings.TrimSpace(f[idx["srce"]])
+		levels := splitLevelCell(f[levelCol])
+		if dest == "" || srce == "" || len(levels) == 0 {
+			return nil, fmt.Errorf("%s line %d: dest, srce and at least one level are required", srcName, start+n+2)
+		}
+		out = append(out, cerebrumXpointRow{Dest: dest, Srce: srce, Levels: levels})
+	}
+	return out, nil
+}
+
+// splitLevelCell splits a levels cell on ';' (also tolerating '|' and
+// whitespace), trims, and drops empties - so "1; 2 ;3" -> ["1","2","3"].
+func splitLevelCell(cell string) []string {
+	raw := strings.FieldsFunc(cell, func(r rune) bool { return r == ';' || r == '|' || r == ' ' || r == '\t' })
+	out := make([]string, 0, len(raw))
+	for _, s := range raw {
+		if s = strings.TrimSpace(s); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// expandCerebrumXpoint flattens multi-level rows into one routeSpec per level,
+// in row-then-level order - the list `import` sends as individual ROUTE actions.
+func expandCerebrumXpoint(rows []cerebrumXpointRow) []routeSpec {
+	var out []routeSpec
+	for _, r := range rows {
+		for _, lvl := range r.Levels {
+			out = append(out, routeSpec{Dest: r.Dest, Srce: r.Srce, Level: lvl})
+		}
+	}
+	return out
+}
+
+// collapseCerebrumRoutes is the inverse used by `export`: it groups a flat route
+// list (one entry per dest/level as read from the snapshot) into multi-level
+// rows. Levels feeding a dest from the SAME source coalesce onto one row; a
+// level fed by a different source (breakaway) stays a separate row. Output is
+// deterministically ordered (dest, then srce, numeric-aware) so exports diff
+// cleanly and round-trip byte-stably.
+func collapseCerebrumRoutes(routes []routeSpec) []cerebrumXpointRow {
+	type acc struct {
+		dest, srce string
+		levels     []string
+		seen       map[string]bool
+	}
+	groups := map[string]*acc{}
+	var order []string
+	for _, r := range routes {
+		if r.Dest == "" || r.Srce == "" || r.Level == "" {
+			continue
+		}
+		k := r.Dest + "\x00" + r.Srce
+		g := groups[k]
+		if g == nil {
+			g = &acc{dest: r.Dest, srce: r.Srce, seen: map[string]bool{}}
+			groups[k] = g
+			order = append(order, k)
+		}
+		if !g.seen[r.Level] {
+			g.seen[r.Level] = true
+			g.levels = append(g.levels, r.Level)
+		}
+	}
+	rows := make([]cerebrumXpointRow, 0, len(order))
+	for _, k := range order {
+		g := groups[k]
+		sortCerebrumIDs(g.levels)
+		rows = append(rows, cerebrumXpointRow{Dest: g.dest, Srce: g.srce, Levels: g.levels})
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		if c := cmpCerebrumID(rows[i].Dest, rows[j].Dest); c != 0 {
+			return c < 0
+		}
+		return cmpCerebrumID(rows[i].Srce, rows[j].Srce) < 0
+	})
+	return rows
+}
+
+// formatCerebrumXpointCSV renders rows as a `dest,srce,levels` CSV with
+// ';'-joined levels - the exact shape parseCerebrumXpoint reads back.
+func formatCerebrumXpointCSV(rows []cerebrumXpointRow) string {
+	var b strings.Builder
+	b.WriteString("dest,srce,levels\n")
+	for _, r := range rows {
+		b.WriteString(r.Dest)
+		b.WriteByte(',')
+		b.WriteString(r.Srce)
+		b.WriteByte(',')
+		b.WriteString(strings.Join(r.Levels, ";"))
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// sortCerebrumIDs sorts ID strings numeric-first (so "2" < "10"), falling back
+// to lexicographic when a value is non-numeric.
+func sortCerebrumIDs(ids []string) {
+	sort.SliceStable(ids, func(i, j int) bool { return cmpCerebrumID(ids[i], ids[j]) < 0 })
+}
+
+// cmpCerebrumID compares two ID strings numerically when both parse as integers,
+// otherwise lexicographically. Returns -1/0/1.
+func cmpCerebrumID(a, b string) int {
+	ai, aerr := strconv.Atoi(strings.TrimSpace(a))
+	bi, berr := strconv.Atoi(strings.TrimSpace(b))
+	if aerr == nil && berr == nil {
+		switch {
+		case ai < bi:
+			return -1
+		case ai > bi:
+			return 1
+		default:
+			return 0
+		}
+	}
+	return strings.Compare(a, b)
+}
+
+// cerebrumImportXpoint applies a crosspoint CSV (dest,srce,levels) as a stream
+// of ROUTE actions — the northbound analogue of `probel-sw08p import --xpoint`.
+// Multi-level rows expand to one ROUTE per level. `--check` is a pure offline
+// dry-run: it prints exactly what would be sent and connects to nothing.
+func cerebrumImportXpoint(_ context.Context, args []string) error {
+	args = reorderFlagsFirst(args)
+	fs := flag.NewFlagSet("cerebrum-nb import", flag.ContinueOnError)
+	cf := newCerebrumFlags(fs)
+	router := fs.String("router", "0.0.0.0", "router IP target (route-master sentinel 0.0.0.0) or a physical Router IP")
+	deviceName := fs.String("device-name", "", "address by DEVICE_NAME instead of --router")
+	csvPath := fs.String("csv", "", "crosspoint CSV to import (columns dest,srce,levels) — required")
+	check := fs.Bool("check", false, "dry-run: print the ROUTE actions that would be sent; connect to nothing")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *csvPath == "" {
+		return fmt.Errorf("cerebrum-nb import: --csv FILE is required (columns dest,srce,levels)")
+	}
+	data, err := os.ReadFile(*csvPath)
+	if err != nil {
+		return err
+	}
+	rows, err := parseCerebrumXpoint(data, *csvPath)
+	if err != nil {
+		return err
+	}
+	routes := expandCerebrumXpoint(rows)
+	if len(routes) == 0 {
+		return fmt.Errorf("cerebrum-nb import: %s has no crosspoints", *csvPath)
+	}
+
+	// --check: offline dry-run, no connection.
+	if *check {
+		for _, r := range routes {
+			fmt.Printf("[would-route] dst=%s src=%s lvl=%s\n", r.Dest, r.Srce, r.Level)
+		}
+		fmt.Printf("cerebrum-nb import --check: %d crosspoint(s) across %d row(s) — nothing sent\n", len(routes), len(rows))
+		return nil
+	}
+
+	rest := fs.Args()
+	if len(rest) < 1 {
+		return fmt.Errorf("cerebrum-nb import: missing host[:port] argument (or pass --check for an offline dry-run)")
+	}
+	host, portArg, err := splitHostPort(rest[0], cf.port)
+	if err != nil {
+		return err
+	}
+	cf.port = portArg
+
+	p, err := cerebrumDial(cf, host)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = p.Disconnect() }()
+	sess := p.Session()
+
+	fails := 0
+	for _, r := range routes {
+		body := &codec.RoutingAction{
+			Type: "ROUTE", IPAddress: *router, DeviceName: *deviceName,
+			DeviceType: codec.DeviceType("ROUTER"),
+			DestID:     r.Dest, SrceID: r.Srce, LevelID: r.Level,
+		}
+		if err := sess.Action(context.Background(), body); err != nil {
+			fmt.Printf("[route] NACK dst=%s src=%s lvl=%s reason=%s\n", r.Dest, r.Srce, r.Level, err)
+			fails++
+			continue
+		}
+		fmt.Printf("[route] OK   dst=%s src=%s lvl=%s\n", r.Dest, r.Srce, r.Level)
+	}
+	if fails > 0 {
+		return fmt.Errorf("%d/%d crosspoints failed", fails, len(routes))
+	}
+	fmt.Printf("cerebrum-nb import: applied %d crosspoint(s) from %s\n", len(routes), *csvPath)
+	return nil
+}
+
+// cerebrumExportXpoint reads the router's current crosspoints by subscribing to
+// the ROUTING_CHANGE snapshot (route-master sentinel, DEST/LEVEL wildcards),
+// collapses them into multi-level rows, and writes the dest,srce,levels CSV that
+// `import` reads back — the northbound analogue of `probel-sw08p export`. It
+// stops on the WILDCARD_COMPLETE sentinel, or after the stream is quiet for
+// --idle.
+func cerebrumExportXpoint(ctx context.Context, args []string) error {
+	args = reorderFlagsFirst(args)
+	fs := flag.NewFlagSet("cerebrum-nb export", flag.ContinueOnError)
+	cf := newCerebrumFlags(fs)
+	router := fs.String("router", "0.0.0.0", "router IP target (route-master sentinel 0.0.0.0) or a physical Router IP")
+	deviceType := fs.String("device-type", "ROUTER", "route-master device type")
+	out := fs.String("out", "", "write the crosspoint CSV here (default: stdout)")
+	idle := fs.Duration("idle", 3*time.Second, "stop collecting this long after the last snapshot frame if no WILDCARD_COMPLETE arrives")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	rest := fs.Args()
+	if len(rest) < 1 {
+		return fmt.Errorf("cerebrum-nb export: missing host[:port] argument")
+	}
+	host, portArg, err := splitHostPort(rest[0], cf.port)
+	if err != nil {
+		return err
+	}
+	cf.port = portArg
+
+	p, err := cerebrumDial(cf, host)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = p.Disconnect() }()
+	sess := p.Session()
+
+	var mu sync.Mutex
+	var routes []routeSpec
+	tick := make(chan struct{}, 1)
+	done := make(chan struct{})
+	var once sync.Once
+
+	sess.OnEvent(codec.KindRoutingChange, func(f *codec.Frame) {
+		rc := f.Routing
+		if rc == nil || rc.Type != "ROUTE" || rc.RouteSourceID == "" {
+			return
+		}
+		mu.Lock()
+		routes = append(routes, routeSpec{Dest: rc.DestID, Srce: rc.RouteSourceID, Level: rc.LevelID})
+		mu.Unlock()
+		select {
+		case tick <- struct{}{}:
+		default:
+		}
+	})
+	sess.OnEvent(codec.KindWildcardComplete, func(*codec.Frame) {
+		once.Do(func() { close(done) })
+	})
+
+	subCtx, subCancel := context.WithCancel(context.Background())
+	defer subCancel()
+	item := &codec.RoutingChange{Type: "ROUTE", IPAddress: *router, DeviceType: codec.DeviceType(*deviceType), DestID: "*", LevelID: "*"}
+	if err := sess.Subscribe(subCtx, []codec.SubItem{item}); err != nil {
+		return fmt.Errorf("cerebrum-nb export: subscribe failed: %w", err)
+	}
+
+	// Collect until WILDCARD_COMPLETE, or until the stream goes quiet for --idle.
+	idleTimer := time.NewTimer(*idle)
+	defer idleTimer.Stop()
+collect:
+	for {
+		select {
+		case <-done:
+			break collect
+		case <-tick:
+			if !idleTimer.Stop() {
+				select {
+				case <-idleTimer.C:
+				default:
+				}
+			}
+			idleTimer.Reset(*idle)
+		case <-idleTimer.C:
+			break collect
+		case <-ctx.Done():
+			break collect
+		}
+	}
+
+	mu.Lock()
+	snap := append([]routeSpec(nil), routes...)
+	mu.Unlock()
+
+	csv := formatCerebrumXpointCSV(collapseCerebrumRoutes(snap))
+	if *out == "" {
+		fmt.Print(csv)
+		return nil
+	}
+	if err := os.WriteFile(*out, []byte(csv), 0o644); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "cerebrum-nb export: wrote %d crosspoint row(s) to %s\n", strings.Count(csv, "\n")-1, *out)
+	return nil
+}
+
+// cerebrumDial builds a plugin from the common flags and connects (no LOGIN —
+// see connectAndLogin). Shared by import/export; the host is already split out.
+func cerebrumDial(cf *cerebrumFlags, host string) (*cerebrum.Plugin, error) {
+	logLevel := slog.LevelInfo
+	if cf.debug {
+		logLevel = slog.LevelDebug
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel}))
+	p := cerebrum.NewPlugin(logger)
+	p.Username = cf.user
+	p.Password = cf.pass
+	p.UseTLS = cf.tls
+	p.InsecureSkipVerify = cf.insecure
+	dialCtx, cancel := context.WithTimeout(context.Background(), cf.timeout)
+	defer cancel()
+	if err := p.Connect(dialCtx, host, cf.port); err != nil {
+		return nil, err
+	}
+	return p, nil
+}

--- a/cmd/dhs/cmd_cerebrum_xpoint_test.go
+++ b/cmd/dhs/cmd_cerebrum_xpoint_test.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// TestCerebrumImportXpointCheckOffline pins that `import --check` is a pure
+// offline dry-run: it parses + expands the CSV and returns nil WITHOUT a host or
+// any connection (no host arg is given here).
+func TestCerebrumImportXpointCheckOffline(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "x.csv")
+	if err := os.WriteFile(p, []byte("dest,srce,levels\n60,60,1;2;3\n61,70,2\n"), 0o644); err != nil {
+		t.Fatalf("seed csv: %v", err)
+	}
+	if err := cerebrumImportXpoint(context.Background(), []string{"--csv", p, "--check"}); err != nil {
+		t.Fatalf("import --check offline: err = %v, want nil", err)
+	}
+}
+
+// TestCerebrumImportXpointErrors pins the guard rails: --csv is mandatory, a
+// malformed CSV is rejected, and apply-mode (no --check) needs a host.
+func TestCerebrumImportXpointErrors(t *testing.T) {
+	t.Run("missing --csv", func(t *testing.T) {
+		if err := cerebrumImportXpoint(context.Background(), []string{"--check"}); err == nil {
+			t.Fatal("err = nil, want error (missing --csv)")
+		}
+	})
+	t.Run("malformed csv", func(t *testing.T) {
+		p := filepath.Join(t.TempDir(), "bad.csv")
+		_ = os.WriteFile(p, []byte("dest,srce\n1,2\n"), 0o644) // no level column
+		if err := cerebrumImportXpoint(context.Background(), []string{"--csv", p, "--check"}); err == nil {
+			t.Fatal("err = nil, want error (no level column)")
+		}
+	})
+	t.Run("apply needs host", func(t *testing.T) {
+		p := filepath.Join(t.TempDir(), "x.csv")
+		_ = os.WriteFile(p, []byte("dest,srce,levels\n60,60,1\n"), 0o644)
+		if err := cerebrumImportXpoint(context.Background(), []string{"--csv", p}); err == nil {
+			t.Fatal("err = nil, want error (apply mode requires host)")
+		}
+	})
+}
+
+// TestCerebrumExportRequiresHost pins that export needs a host argument (it
+// errors before dialling when none is given).
+func TestCerebrumExportRequiresHost(t *testing.T) {
+	if err := cerebrumExportXpoint(context.Background(), []string{"--out", filepath.Join(t.TempDir(), "o.csv")}); err == nil {
+		t.Fatal("export without host: err = nil, want error")
+	}
+}
+
+// TestParseCerebrumXpoint pins the multi-level CSV parse: the `levels` column
+// splits on ';' onto one row; the legacy `level` column still yields a
+// single-level row; comments/blanks are skipped; missing columns and short rows
+// error.
+func TestParseCerebrumXpoint(t *testing.T) {
+	t.Run("multi-level levels column", func(t *testing.T) {
+		csv := "dest,srce,levels\n" +
+			"# a take across three levels\n" +
+			"60,60,1;2;3\n" +
+			"61, 70 , 2\n" // breakaway on level 2, with stray spaces
+		rows, err := parseCerebrumXpoint([]byte(csv), "t.csv")
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		want := []cerebrumXpointRow{
+			{Dest: "60", Srce: "60", Levels: []string{"1", "2", "3"}},
+			{Dest: "61", Srce: "70", Levels: []string{"2"}},
+		}
+		if !reflect.DeepEqual(rows, want) {
+			t.Errorf("rows = %+v, want %+v", rows, want)
+		}
+	})
+
+	t.Run("legacy single level column", func(t *testing.T) {
+		rows, err := parseCerebrumXpoint([]byte("dest,srce,level\n5,9,1\n"), "t.csv")
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if len(rows) != 1 || rows[0].Dest != "5" || rows[0].Srce != "9" ||
+			!reflect.DeepEqual(rows[0].Levels, []string{"1"}) {
+			t.Errorf("rows = %+v", rows)
+		}
+	})
+
+	t.Run("column order independent + CRLF", func(t *testing.T) {
+		rows, err := parseCerebrumXpoint([]byte("levels,dest,srce\r\n1;2,7,8\r\n"), "t.csv")
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if len(rows) != 1 || rows[0].Dest != "7" || rows[0].Srce != "8" ||
+			!reflect.DeepEqual(rows[0].Levels, []string{"1", "2"}) {
+			t.Errorf("rows = %+v", rows)
+		}
+	})
+
+	for _, tc := range []struct{ name, csv string }{
+		{"missing dest", "srce,levels\n1,2\n"},
+		{"missing level col", "dest,srce\n1,2\n"},
+		{"empty", "   \n # only a comment\n"},
+		{"short row", "dest,srce,levels\n60,60\n"},
+		{"blank fields", "dest,srce,levels\n,,\n"},
+		{"no levels in cell", "dest,srce,levels\n60,60,\n"},
+	} {
+		t.Run("error: "+tc.name, func(t *testing.T) {
+			if _, err := parseCerebrumXpoint([]byte(tc.csv), "t.csv"); err == nil {
+				t.Errorf("parse %q: err = nil, want error", tc.csv)
+			}
+		})
+	}
+}
+
+// TestExpandCerebrumXpoint pins that a multi-level row flattens to one routeSpec
+// per level, row-then-level order (the ROUTE-action stream import sends).
+func TestExpandCerebrumXpoint(t *testing.T) {
+	got := expandCerebrumXpoint([]cerebrumXpointRow{
+		{Dest: "60", Srce: "60", Levels: []string{"1", "2", "3"}},
+		{Dest: "61", Srce: "70", Levels: []string{"2"}},
+	})
+	want := []routeSpec{
+		{Dest: "60", Srce: "60", Level: "1"},
+		{Dest: "60", Srce: "60", Level: "2"},
+		{Dest: "60", Srce: "60", Level: "3"},
+		{Dest: "61", Srce: "70", Level: "2"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("expand = %+v, want %+v", got, want)
+	}
+}
+
+// TestCollapseCerebrumRoutes pins the export inverse: levels from the same
+// source coalesce onto one row; a breakaway source splits; output is
+// numeric-ordered and deduped.
+func TestCollapseCerebrumRoutes(t *testing.T) {
+	// Deliberately unordered + a duplicate + a breakaway (dest 61 level 2 from a
+	// different source than its level 1).
+	routes := []routeSpec{
+		{Dest: "61", Srce: "70", Level: "2"},
+		{Dest: "60", Srce: "60", Level: "10"},
+		{Dest: "60", Srce: "60", Level: "2"},
+		{Dest: "61", Srce: "61", Level: "1"},
+		{Dest: "60", Srce: "60", Level: "1"},
+		{Dest: "60", Srce: "60", Level: "2"}, // dup
+	}
+	got := collapseCerebrumRoutes(routes)
+	want := []cerebrumXpointRow{
+		{Dest: "60", Srce: "60", Levels: []string{"1", "2", "10"}}, // numeric: 2 < 10
+		{Dest: "61", Srce: "61", Levels: []string{"1"}},
+		{Dest: "61", Srce: "70", Levels: []string{"2"}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("collapse = %+v, want %+v", got, want)
+	}
+}
+
+// TestCerebrumXpointRoundTrip pins that expand -> collapse -> format -> parse is
+// stable: a set of routes exported and re-imported yields the same flat route
+// set.
+func TestCerebrumXpointRoundTrip(t *testing.T) {
+	orig := []routeSpec{
+		{Dest: "60", Srce: "60", Level: "1"},
+		{Dest: "60", Srce: "60", Level: "2"},
+		{Dest: "61", Srce: "70", Level: "2"},
+	}
+	csv := formatCerebrumXpointCSV(collapseCerebrumRoutes(orig))
+	rows, err := parseCerebrumXpoint([]byte(csv), "roundtrip")
+	if err != nil {
+		t.Fatalf("reparse exported CSV: %v\n%s", err, csv)
+	}
+	got := expandCerebrumXpoint(rows)
+	if !reflect.DeepEqual(got, orig) {
+		t.Errorf("round-trip mismatch:\ngot  %+v\nwant %+v\ncsv:\n%s", got, orig, csv)
+	}
+}
+
+// TestFormatCerebrumXpointCSV pins the exact serialized shape (header +
+// ';'-joined levels) so the format stays stable for operators + tooling.
+func TestFormatCerebrumXpointCSV(t *testing.T) {
+	got := formatCerebrumXpointCSV([]cerebrumXpointRow{{Dest: "60", Srce: "60", Levels: []string{"1", "2", "3"}}})
+	want := "dest,srce,levels\n60,60,1;2;3\n"
+	if got != want {
+		t.Errorf("format = %q, want %q", got, want)
+	}
+}
+
+// TestCmpCerebrumID pins numeric-aware ID comparison (so "2" < "10"), with a
+// lexicographic fallback when a value is non-numeric.
+func TestCmpCerebrumID(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"2", "10", -1},
+		{"10", "2", 1},
+		{"5", "5", 0},
+		{"abc", "abd", -1},
+		{"7", "x", -1}, // "7" < "x" lexicographically
+	}
+	for _, tc := range cases {
+		if got := cmpCerebrumID(tc.a, tc.b); got != tc.want {
+			t.Errorf("cmpCerebrumID(%q,%q) = %d, want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Gives Cerebrum NB the crosspoint export/import round-trip that probel-sw08p has, with **multi-level on one CSV row** — the shape requested.

## import`n- `import --csv FILE [--check]` — apply a `dest,srce,levels` CSV as ROUTE actions. `levels` is a `;`-list, so one row sets multiple levels; each expands to one ROUTE per level. `--check` is a pure **offline** dry-run.

## export
- `export [--out FILE] [--idle DUR]` — subscribe to the ROUTING_CHANGE snapshot, collapse into multi-level rows (shared source coalesces, breakaway splits), write the CSV `import` reads back. Stops on WILDCARD_COMPLETE or `--idle` quiet.

## CSV
```n dest,srce,levels
 60,60,1;2;3   # all-level take
 61,70,2       # breakaway on level 2
```n
Pure CSV codec fully unit-tested (parse/expand/collapse/format, round-trip, error cases). Verified live: `60,60,1;2;3` + `61,70,2` -> 4 crosspoints across 2 rows, nothing sent. Export's live snapshot is device-gated (no Cerebrum on the desk); its collapse/format is unit-tested. Same shape extends to salvo next.

Closes #667

🤖 Generated with [Claude Code](https://claude.com/claude-code)