### PR TITLE
feat(cerebrum-nb): probel-parity export/import trio (src + dst mnemonics + xpoint, multi-level)

### DIFF
--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -172,8 +172,8 @@ VERBS
   connect                  POLL (LOGIN auto when --user/--pass set)
   listen                   SUBSCRIBE — routing / category / salvo / device events; Ctrl+C to stop
   route                    ACTION <ROUTING TYPE='ROUTE'/> — single (--dest --srce --level), batch (--route dst:src:lvl), or --csv FILE
-  export                   SUBSCRIBE snapshot → CSVs. Crosspoints only: [--out FILE]. Probel-style trio (src+dst mnemonics+xpoint): --out-dir DIR [--prefix P]
-  import                   apply CSVs: --xpoint F (dest,srce,levels; --csv alias) + --src F / --dst F (mnemonics)  [--check]
+  export                   one-shot OBTAIN wildcards → CSVs. Crosspoints only: [--out FILE]. Full set (src+dst+level mnemonics+xpoint): --out-dir DIR [--prefix P]
+  import                   apply CSVs: --xpoint F (dest,srce,levels; --csv alias) + --src/--dst/--levels F (mnemonics, per-ID)  [--check]
   list-devices             OBTAIN <device_change type='LIST'/>  [--device-type Router|SNMP|Device]
   device-details           OBTAIN <device_change type='DETAILS'/>  --device IP --device-type DEVICE
   device-value             OBTAIN <device_change type='VALUE'/>    --device NAME --by-name --sub-device X --object Y

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -172,8 +172,8 @@ VERBS
   connect                  POLL (LOGIN auto when --user/--pass set)
   listen                   SUBSCRIBE — routing / category / salvo / device events; Ctrl+C to stop
   route                    ACTION <ROUTING TYPE='ROUTE'/> — single (--dest --srce --level), batch (--route dst:src:lvl), or --csv FILE
-  export                   SUBSCRIBE snapshot → write current crosspoints to a dest,srce,levels CSV  [--out FILE] [--idle DUR]
-  import                   apply a crosspoint CSV (dest,srce,levels; multi-level per row) as ROUTE actions  --csv FILE [--check]
+  export                   SUBSCRIBE snapshot → CSVs. Crosspoints only: [--out FILE]. Probel-style trio (src+dst mnemonics+xpoint): --out-dir DIR [--prefix P]
+  import                   apply CSVs: --xpoint F (dest,srce,levels; --csv alias) + --src F / --dst F (mnemonics)  [--check]
   list-devices             OBTAIN <device_change type='LIST'/>  [--device-type Router|SNMP|Device]
   device-details           OBTAIN <device_change type='DETAILS'/>  --device IP --device-type DEVICE
   device-value             OBTAIN <device_change type='VALUE'/>    --device NAME --by-name --sub-device X --object Y

--- a/cmd/dhs/cmd_cerebrum_names.go
+++ b/cmd/dhs/cmd_cerebrum_names.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bytes"
+	"encoding/csv"
+	"fmt"
+	"sort"
+	"strings"
+
+	"dhs/internal/cerebrum-nb/codec"
+)
+
+// Cerebrum src/dst mnemonic CSVs — the names leg of the probel-sw08p-style
+// export/import trio (<prefix>-src.csv / <prefix>-dst.csv / <prefix>-xpoint.csv).
+//
+// Shape (proper CSV, quoted, so mnemonics may contain commas):
+//
+//	srce,levels,mnemonic      dest,levels,mnemonic
+//	5121,1;2,"CAM 1"          5123,1,"MON 1"
+//
+// `levels` is the same ';'-separated multi-level list the xpoint CSV uses; a
+// legacy single `level` column is accepted on read. One row expands to one
+// SRCE_MNE / DEST_MNE action per level on import.
+
+// cerebrumMneRow is one line of a mnemonic CSV: an ID named `Mnemonic` across
+// one or more levels.
+type cerebrumMneRow struct {
+	ID       string
+	Levels   []string
+	Mnemonic string
+}
+
+// parseCerebrumMneCSV decodes a mnemonic CSV whose key column is keyCol
+// ("srce" or "dest"). Header is case-insensitive and order-independent;
+// '#' comment lines are skipped; quoting per RFC 4180 (encoding/csv).
+func parseCerebrumMneCSV(data []byte, keyCol, srcName string) ([]cerebrumMneRow, error) {
+	r := csv.NewReader(bytes.NewReader(data))
+	r.Comment = '#'
+	r.TrimLeadingSpace = true
+	recs, err := r.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", srcName, err)
+	}
+	if len(recs) == 0 {
+		return nil, fmt.Errorf("%s: empty (no header)", srcName)
+	}
+	idx := map[string]int{}
+	for i, h := range recs[0] {
+		idx[strings.ToLower(strings.TrimSpace(h))] = i
+	}
+	key, ok := idx[keyCol]
+	if !ok {
+		return nil, fmt.Errorf("%s: missing column %q", srcName, keyCol)
+	}
+	mne, ok := idx["mnemonic"]
+	if !ok {
+		return nil, fmt.Errorf("%s: missing column \"mnemonic\"", srcName)
+	}
+	lvlCol, multi := idx["levels"]
+	if !multi {
+		lvlCol, ok = idx["level"]
+		if !ok {
+			return nil, fmt.Errorf("%s: missing level column (need \"levels\" or \"level\")", srcName)
+		}
+	}
+	var out []cerebrumMneRow
+	for n, rec := range recs[1:] {
+		if len(rec) <= key || len(rec) <= mne || len(rec) <= lvlCol {
+			return nil, fmt.Errorf("%s row %d: too few columns", srcName, n+2)
+		}
+		id := strings.TrimSpace(rec[key])
+		levels := splitLevelCell(rec[lvlCol])
+		m := rec[mne]
+		if id == "" || len(levels) == 0 || m == "" {
+			return nil, fmt.Errorf("%s row %d: %s, level(s) and mnemonic are all required", srcName, n+2, keyCol)
+		}
+		out = append(out, cerebrumMneRow{ID: id, Levels: levels, Mnemonic: m})
+	}
+	return out, nil
+}
+
+// collapseCerebrumMnes groups per-(id,level) snapshot rows into multi-level
+// rows: levels sharing the same mnemonic for an ID coalesce; an ID whose
+// mnemonic differs per level keeps one row per distinct mnemonic. Levels are
+// deduped and numeric-sorted; rows are ordered (ID, mnemonic) for stable diffs.
+func collapseCerebrumMnes(rows []cerebrumMneRow) []cerebrumMneRow {
+	type acc struct {
+		id, mne string
+		levels  []string
+		seen    map[string]bool
+	}
+	groups := map[string]*acc{}
+	var order []string
+	for _, r := range rows {
+		if r.ID == "" || r.Mnemonic == "" {
+			continue
+		}
+		k := r.ID + "\x00" + r.Mnemonic
+		g := groups[k]
+		if g == nil {
+			g = &acc{id: r.ID, mne: r.Mnemonic, seen: map[string]bool{}}
+			groups[k] = g
+			order = append(order, k)
+		}
+		for _, lvl := range r.Levels {
+			if lvl != "" && !g.seen[lvl] {
+				g.seen[lvl] = true
+				g.levels = append(g.levels, lvl)
+			}
+		}
+	}
+	out := make([]cerebrumMneRow, 0, len(order))
+	for _, k := range order {
+		g := groups[k]
+		sortCerebrumIDs(g.levels)
+		out = append(out, cerebrumMneRow{ID: g.id, Levels: g.levels, Mnemonic: g.mne})
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if c := cmpCerebrumID(out[i].ID, out[j].ID); c != 0 {
+			return c < 0
+		}
+		return out[i].Mnemonic < out[j].Mnemonic
+	})
+	return out
+}
+
+// formatCerebrumMneCSV renders rows as `keyCol,levels,mnemonic` with RFC 4180
+// quoting — the exact shape parseCerebrumMneCSV reads back.
+func formatCerebrumMneCSV(keyCol string, rows []cerebrumMneRow) string {
+	var b strings.Builder
+	w := csv.NewWriter(&b)
+	_ = w.Write([]string{keyCol, "levels", "mnemonic"})
+	for _, r := range rows {
+		_ = w.Write([]string{r.ID, strings.Join(r.Levels, ";"), r.Mnemonic})
+	}
+	w.Flush()
+	return b.String()
+}
+
+// crossLevelRoute reports whether a routing-snapshot row is a cross-level
+// route (source level differs from the row's dest level). The dest,srce,levels
+// CSV cannot represent those yet, so export skips them LOUDLY, never silently.
+func crossLevelRoute(destLevelID, srcLevelID string) bool {
+	return srcLevelID != "" && destLevelID != "" && srcLevelID != destLevelID
+}
+
+// primaryMnemonic extracts the primary (slot 0) mnemonic from a *_MNE
+// routing_change RX row: Cerebrum returns slot-keyed child elements flattened
+// into Mnemonics[slot]; the TX-attr Mnemonic field is the fallback.
+func primaryMnemonic(rc *codec.RoutingChange) string {
+	if rc == nil {
+		return ""
+	}
+	if m, ok := rc.Mnemonics[0]; ok && m != "" {
+		return m
+	}
+	return rc.Mnemonic
+}

--- a/cmd/dhs/cmd_cerebrum_names.go
+++ b/cmd/dhs/cmd_cerebrum_names.go
@@ -10,33 +10,36 @@ import (
 	"dhs/internal/cerebrum-nb/codec"
 )
 
-// Cerebrum src/dst mnemonic CSVs — the names leg of the probel-sw08p-style
-// export/import trio (<prefix>-src.csv / <prefix>-dst.csv / <prefix>-xpoint.csv).
+// Cerebrum src/dst/level mnemonic CSVs — the names legs of the
+// probel-sw08p-style export/import set (<prefix>-src.csv / -dst.csv /
+// -level.csv / -xpoint.csv).
 //
-// Shape (proper CSV, quoted, so mnemonics may contain commas):
+// Per 0v16 §4.1.5/§4.1.6 a source/destination mnemonic on a ROUTER
+// (Routemaster) target is global for that ID — the LEVEL attribute exists only
+// for non-router devices ("ignored unless the DEVICE_TYPE is DEVICE",
+// §5.1.5/§5.1.6). So the mnemonic CSVs carry NO level column:
 //
-//	srce,levels,mnemonic      dest,levels,mnemonic
-//	5121,1;2,"CAM 1"          5123,1,"MON 1"
+//	srce,mnemonic        dest,mnemonic        level,mnemonic
+//	5121,"CAM 1, main"   5123,"MON 1"         1,LVL-1
 //
-// `levels` is the same ';'-separated multi-level list the xpoint CSV uses; a
-// legacy single `level` column is accepted on read. One row expands to one
-// SRCE_MNE / DEST_MNE action per level on import.
+// Level names themselves are per-level via LEVEL_MNE (§4.1.4). RFC 4180
+// quoting throughout (mnemonics may contain commas/quotes).
 
-// cerebrumMneRow is one line of a mnemonic CSV: an ID named `Mnemonic` across
-// one or more levels.
+// cerebrumMneRow is one line of a mnemonic CSV: an ID (source, destination or
+// level, per the file's key column) and its primary mnemonic.
 type cerebrumMneRow struct {
 	ID       string
-	Levels   []string
 	Mnemonic string
 }
 
 // parseCerebrumMneCSV decodes a mnemonic CSV whose key column is keyCol
-// ("srce" or "dest"). Header is case-insensitive and order-independent;
-// '#' comment lines are skipped; quoting per RFC 4180 (encoding/csv).
+// ("srce", "dest" or "level"). Header is case-insensitive and
+// order-independent; '#' comment lines are skipped; quoting per RFC 4180.
 func parseCerebrumMneCSV(data []byte, keyCol, srcName string) ([]cerebrumMneRow, error) {
 	r := csv.NewReader(bytes.NewReader(data))
 	r.Comment = '#'
 	r.TrimLeadingSpace = true
+	r.FieldsPerRecord = -1
 	recs, err := r.ReadAll()
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", srcName, err)
@@ -56,64 +59,39 @@ func parseCerebrumMneCSV(data []byte, keyCol, srcName string) ([]cerebrumMneRow,
 	if !ok {
 		return nil, fmt.Errorf("%s: missing column \"mnemonic\"", srcName)
 	}
-	lvlCol, multi := idx["levels"]
-	if !multi {
-		lvlCol, ok = idx["level"]
-		if !ok {
-			return nil, fmt.Errorf("%s: missing level column (need \"levels\" or \"level\")", srcName)
-		}
-	}
 	var out []cerebrumMneRow
 	for n, rec := range recs[1:] {
-		if len(rec) <= key || len(rec) <= mne || len(rec) <= lvlCol {
+		if len(rec) <= key || len(rec) <= mne {
 			return nil, fmt.Errorf("%s row %d: too few columns", srcName, n+2)
 		}
 		id := strings.TrimSpace(rec[key])
-		levels := splitLevelCell(rec[lvlCol])
 		m := rec[mne]
-		if id == "" || len(levels) == 0 || m == "" {
-			return nil, fmt.Errorf("%s row %d: %s, level(s) and mnemonic are all required", srcName, n+2, keyCol)
+		if id == "" || m == "" {
+			return nil, fmt.Errorf("%s row %d: %s and mnemonic are both required", srcName, n+2, keyCol)
 		}
-		out = append(out, cerebrumMneRow{ID: id, Levels: levels, Mnemonic: m})
+		out = append(out, cerebrumMneRow{ID: id, Mnemonic: m})
 	}
 	return out, nil
 }
 
-// collapseCerebrumMnes groups per-(id,level) snapshot rows into multi-level
-// rows: levels sharing the same mnemonic for an ID coalesce; an ID whose
-// mnemonic differs per level keeps one row per distinct mnemonic. Levels are
-// deduped and numeric-sorted; rows are ordered (ID, mnemonic) for stable diffs.
-func collapseCerebrumMnes(rows []cerebrumMneRow) []cerebrumMneRow {
-	type acc struct {
-		id, mne string
-		levels  []string
-		seen    map[string]bool
-	}
-	groups := map[string]*acc{}
-	var order []string
+// dedupeCerebrumMnes drops exact duplicate (ID, mnemonic) rows — the OBTAIN
+// snapshot may deliver one row per level for a router ID, all carrying the
+// same global mnemonic — and orders the result numeric-aware by ID (then
+// mnemonic) for stable diffs. Conflicting mnemonics for one ID are kept (both
+// rows), so an inconsistency is visible rather than silently resolved.
+func dedupeCerebrumMnes(rows []cerebrumMneRow) []cerebrumMneRow {
+	seen := map[string]bool{}
+	out := make([]cerebrumMneRow, 0, len(rows))
 	for _, r := range rows {
 		if r.ID == "" || r.Mnemonic == "" {
 			continue
 		}
 		k := r.ID + "\x00" + r.Mnemonic
-		g := groups[k]
-		if g == nil {
-			g = &acc{id: r.ID, mne: r.Mnemonic, seen: map[string]bool{}}
-			groups[k] = g
-			order = append(order, k)
+		if seen[k] {
+			continue
 		}
-		for _, lvl := range r.Levels {
-			if lvl != "" && !g.seen[lvl] {
-				g.seen[lvl] = true
-				g.levels = append(g.levels, lvl)
-			}
-		}
-	}
-	out := make([]cerebrumMneRow, 0, len(order))
-	for _, k := range order {
-		g := groups[k]
-		sortCerebrumIDs(g.levels)
-		out = append(out, cerebrumMneRow{ID: g.id, Levels: g.levels, Mnemonic: g.mne})
+		seen[k] = true
+		out = append(out, r)
 	}
 	sort.SliceStable(out, func(i, j int) bool {
 		if c := cmpCerebrumID(out[i].ID, out[j].ID); c != 0 {
@@ -124,14 +102,14 @@ func collapseCerebrumMnes(rows []cerebrumMneRow) []cerebrumMneRow {
 	return out
 }
 
-// formatCerebrumMneCSV renders rows as `keyCol,levels,mnemonic` with RFC 4180
+// formatCerebrumMneCSV renders rows as `keyCol,mnemonic` with RFC 4180
 // quoting — the exact shape parseCerebrumMneCSV reads back.
 func formatCerebrumMneCSV(keyCol string, rows []cerebrumMneRow) string {
 	var b strings.Builder
 	w := csv.NewWriter(&b)
-	_ = w.Write([]string{keyCol, "levels", "mnemonic"})
+	_ = w.Write([]string{keyCol, "mnemonic"})
 	for _, r := range rows {
-		_ = w.Write([]string{r.ID, strings.Join(r.Levels, ";"), r.Mnemonic})
+		_ = w.Write([]string{r.ID, r.Mnemonic})
 	}
 	w.Flush()
 	return b.String()

--- a/cmd/dhs/cmd_cerebrum_names_test.go
+++ b/cmd/dhs/cmd_cerebrum_names_test.go
@@ -11,45 +11,54 @@ import (
 	"dhs/internal/cerebrum-nb/codec"
 )
 
-// TestParseCerebrumMneCSV pins the mnemonic CSV parse: multi-level `levels`
-// lists, legacy `level`, RFC 4180 quoting (mnemonics may contain commas),
-// comments, column order independence, and the error cases.
+// TestParseCerebrumMneCSV pins the mnemonic CSV parse: two columns (key +
+// mnemonic — router mnemonics are per-ID, 0v16 §4.1.5/§4.1.6), RFC 4180
+// quoting (mnemonics may contain commas), comments, column-order
+// independence, all three key kinds, and the error cases.
 func TestParseCerebrumMneCSV(t *testing.T) {
-	t.Run("multi-level + quoted comma mnemonic", func(t *testing.T) {
-		csv := "srce,levels,mnemonic\n" +
+	t.Run("quoted comma mnemonic", func(t *testing.T) {
+		csv := "srce,mnemonic\n" +
 			"# names\n" +
-			"5121,1;2,\"CAM 1, main\"\n" +
-			"5122,1,CAM2\n"
+			"5121,\"CAM 1, main\"\n" +
+			"5122,CAM2\n"
 		rows, err := parseCerebrumMneCSV([]byte(csv), "srce", "t.csv")
 		if err != nil {
 			t.Fatalf("parse: %v", err)
 		}
 		want := []cerebrumMneRow{
-			{ID: "5121", Levels: []string{"1", "2"}, Mnemonic: "CAM 1, main"},
-			{ID: "5122", Levels: []string{"1"}, Mnemonic: "CAM2"},
+			{ID: "5121", Mnemonic: "CAM 1, main"},
+			{ID: "5122", Mnemonic: "CAM2"},
 		}
 		if !reflect.DeepEqual(rows, want) {
 			t.Errorf("rows = %+v, want %+v", rows, want)
 		}
 	})
 
-	t.Run("legacy level column + dest key + reordered", func(t *testing.T) {
-		rows, err := parseCerebrumMneCSV([]byte("mnemonic,dest,level\nMON1,5123,2\n"), "dest", "t.csv")
+	t.Run("dest key, reordered columns", func(t *testing.T) {
+		rows, err := parseCerebrumMneCSV([]byte("mnemonic,dest\nMON1,5123\n"), "dest", "t.csv")
 		if err != nil {
 			t.Fatalf("parse: %v", err)
 		}
-		if len(rows) != 1 || rows[0].ID != "5123" || rows[0].Mnemonic != "MON1" ||
-			!reflect.DeepEqual(rows[0].Levels, []string{"2"}) {
+		if len(rows) != 1 || rows[0].ID != "5123" || rows[0].Mnemonic != "MON1" {
+			t.Errorf("rows = %+v", rows)
+		}
+	})
+
+	t.Run("level key", func(t *testing.T) {
+		rows, err := parseCerebrumMneCSV([]byte("level,mnemonic\n1,LVL-1\n2,LVL-2\n"), "level", "t.csv")
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if len(rows) != 2 || rows[1].ID != "2" || rows[1].Mnemonic != "LVL-2" {
 			t.Errorf("rows = %+v", rows)
 		}
 	})
 
 	for _, tc := range []struct{ name, csv, key string }{
-		{"missing key col", "levels,mnemonic\n1,X\n", "srce"},
-		{"missing mnemonic col", "srce,levels\n1,1\n", "srce"},
-		{"missing level col", "srce,mnemonic\n1,X\n", "srce"},
+		{"missing key col", "mnemonic\nX\n", "srce"},
+		{"missing mnemonic col", "srce\n1\n", "srce"},
 		{"empty file", "", "srce"},
-		{"blank fields", "srce,levels,mnemonic\n,,\n", "srce"},
+		{"blank fields", "srce,mnemonic\n,\n", "srce"},
 	} {
 		t.Run("error: "+tc.name, func(t *testing.T) {
 			if _, err := parseCerebrumMneCSV([]byte(tc.csv), tc.key, "t.csv"); err == nil {
@@ -59,25 +68,25 @@ func TestParseCerebrumMneCSV(t *testing.T) {
 	}
 }
 
-// TestCollapseCerebrumMnes pins the export grouping: per-(id,level) snapshot
-// rows with the same mnemonic coalesce into one multi-level row; a different
-// mnemonic on another level stays separate; dedup + numeric ordering hold.
-func TestCollapseCerebrumMnes(t *testing.T) {
-	got := collapseCerebrumMnes([]cerebrumMneRow{
-		{ID: "5121", Levels: []string{"2"}, Mnemonic: "CAM1"},
-		{ID: "5121", Levels: []string{"10"}, Mnemonic: "CAM1"},
-		{ID: "5121", Levels: []string{"1"}, Mnemonic: "CAM1"},
-		{ID: "5121", Levels: []string{"1"}, Mnemonic: "CAM1"}, // dup
-		{ID: "5121", Levels: []string{"3"}, Mnemonic: "CAM1-HD"},
-		{ID: "111", Levels: []string{"1"}, Mnemonic: "VTR"},
+// TestDedupeCerebrumMnes pins the export cleanup: the OBTAIN snapshot may
+// deliver one row per level all carrying the same per-ID router mnemonic —
+// exact (ID,mnemonic) duplicates collapse to one row; a CONFLICTING mnemonic
+// for the same ID is kept visible; ordering is numeric-aware.
+func TestDedupeCerebrumMnes(t *testing.T) {
+	got := dedupeCerebrumMnes([]cerebrumMneRow{
+		{ID: "5121", Mnemonic: "CAM1"},
+		{ID: "5121", Mnemonic: "CAM1"}, // per-level repeat
+		{ID: "5121", Mnemonic: "CAM1"},
+		{ID: "5121", Mnemonic: "CAM1-B"}, // conflict stays visible
+		{ID: "111", Mnemonic: "VTR"},
 	})
 	want := []cerebrumMneRow{
-		{ID: "111", Levels: []string{"1"}, Mnemonic: "VTR"},
-		{ID: "5121", Levels: []string{"1", "2", "10"}, Mnemonic: "CAM1"},
-		{ID: "5121", Levels: []string{"3"}, Mnemonic: "CAM1-HD"},
+		{ID: "111", Mnemonic: "VTR"},
+		{ID: "5121", Mnemonic: "CAM1"},
+		{ID: "5121", Mnemonic: "CAM1-B"},
 	}
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("collapse = %+v, want %+v", got, want)
+		t.Errorf("dedupe = %+v, want %+v", got, want)
 	}
 }
 
@@ -85,8 +94,8 @@ func TestCollapseCerebrumMnes(t *testing.T) {
 // mnemonic containing a comma and a quote.
 func TestCerebrumMneCSVRoundTrip(t *testing.T) {
 	orig := []cerebrumMneRow{
-		{ID: "5121", Levels: []string{"1", "2"}, Mnemonic: `CAM "A", main`},
-		{ID: "5122", Levels: []string{"3"}, Mnemonic: "plain"},
+		{ID: "5121", Mnemonic: `CAM "A", main`},
+		{ID: "5122", Mnemonic: "plain"},
 	}
 	csv := formatCerebrumMneCSV("srce", orig)
 	back, err := parseCerebrumMneCSV([]byte(csv), "srce", "roundtrip")
@@ -132,30 +141,34 @@ func TestPrimaryMnemonic(t *testing.T) {
 	}
 }
 
-// TestCerebrumImportTrioCheckOffline pins that `import --check` with all three
-// files is a pure offline dry-run covering routes + src/dst mnemonics.
-func TestCerebrumImportTrioCheckOffline(t *testing.T) {
+// TestCerebrumImportSetCheckOffline pins that `import --check` with all four
+// files is a pure offline dry-run covering routes + src/dst/level mnemonics.
+func TestCerebrumImportSetCheckOffline(t *testing.T) {
 	dir := t.TempDir()
 	xp := filepath.Join(dir, "x.csv")
 	src := filepath.Join(dir, "s.csv")
 	dst := filepath.Join(dir, "d.csv")
+	lvl := filepath.Join(dir, "l.csv")
 	if err := os.WriteFile(xp, []byte("dest,srce,levels\n5123,5121,1;2\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(src, []byte("srce,levels,mnemonic\n5121,1;2,CAM1\n"), 0o644); err != nil {
+	if err := os.WriteFile(src, []byte("srce,mnemonic\n5121,CAM1\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(dst, []byte("dest,level,mnemonic\n5123,1,MON1\n"), 0o644); err != nil {
+	if err := os.WriteFile(dst, []byte("dest,mnemonic\n5123,MON1\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := cerebrumImportXpoint(context.Background(), []string{"--xpoint", xp, "--src", src, "--dst", dst, "--check"}); err != nil {
-		t.Fatalf("trio --check offline: err = %v, want nil", err)
+	if err := os.WriteFile(lvl, []byte("level,mnemonic\n1,LVL-1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := cerebrumImportXpoint(context.Background(), []string{"--xpoint", xp, "--src", src, "--dst", dst, "--levels", lvl, "--check"}); err != nil {
+		t.Fatalf("set --check offline: err = %v, want nil", err)
 	}
 }
 
-// TestCerebrumImportTrioGuardRails pins the new flag validation: --csv/--xpoint
+// TestCerebrumImportSetGuardRails pins the flag validation: --csv/--xpoint
 // exclusivity, nothing-to-import, malformed mnemonic CSV, apply needs host.
-func TestCerebrumImportTrioGuardRails(t *testing.T) {
+func TestCerebrumImportSetGuardRails(t *testing.T) {
 	dir := t.TempDir()
 	xp := filepath.Join(dir, "x.csv")
 	_ = os.WriteFile(xp, []byte("dest,srce,levels\n1,2,1\n"), 0o644)
@@ -167,7 +180,7 @@ func TestCerebrumImportTrioGuardRails(t *testing.T) {
 		t.Error("no inputs: err = nil, want error")
 	}
 	bad := filepath.Join(dir, "bad.csv")
-	_ = os.WriteFile(bad, []byte("srce,levels\n1,1\n"), 0o644) // no mnemonic col
+	_ = os.WriteFile(bad, []byte("srce\n1\n"), 0o644) // no mnemonic col
 	if err := cerebrumImportXpoint(context.Background(), []string{"--src", bad, "--check"}); err == nil {
 		t.Error("malformed --src: err = nil, want error")
 	}
@@ -176,9 +189,9 @@ func TestCerebrumImportTrioGuardRails(t *testing.T) {
 	}
 }
 
-// TestCerebrumExportTrioFlags pins export's new flag validation offline:
+// TestCerebrumExportSetFlags pins export's flag validation offline:
 // --out vs --out-dir exclusivity and the missing-host guard.
-func TestCerebrumExportTrioFlags(t *testing.T) {
+func TestCerebrumExportSetFlags(t *testing.T) {
 	if err := cerebrumExportXpoint(context.Background(), []string{"--out", "a.csv", "--out-dir", "d"}); err == nil ||
 		!strings.Contains(err.Error(), "mutually exclusive") {
 		t.Errorf("--out + --out-dir: err = %v, want mutually-exclusive error", err)

--- a/cmd/dhs/cmd_cerebrum_names_test.go
+++ b/cmd/dhs/cmd_cerebrum_names_test.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"dhs/internal/cerebrum-nb/codec"
+)
+
+// TestParseCerebrumMneCSV pins the mnemonic CSV parse: multi-level `levels`
+// lists, legacy `level`, RFC 4180 quoting (mnemonics may contain commas),
+// comments, column order independence, and the error cases.
+func TestParseCerebrumMneCSV(t *testing.T) {
+	t.Run("multi-level + quoted comma mnemonic", func(t *testing.T) {
+		csv := "srce,levels,mnemonic\n" +
+			"# names\n" +
+			"5121,1;2,\"CAM 1, main\"\n" +
+			"5122,1,CAM2\n"
+		rows, err := parseCerebrumMneCSV([]byte(csv), "srce", "t.csv")
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		want := []cerebrumMneRow{
+			{ID: "5121", Levels: []string{"1", "2"}, Mnemonic: "CAM 1, main"},
+			{ID: "5122", Levels: []string{"1"}, Mnemonic: "CAM2"},
+		}
+		if !reflect.DeepEqual(rows, want) {
+			t.Errorf("rows = %+v, want %+v", rows, want)
+		}
+	})
+
+	t.Run("legacy level column + dest key + reordered", func(t *testing.T) {
+		rows, err := parseCerebrumMneCSV([]byte("mnemonic,dest,level\nMON1,5123,2\n"), "dest", "t.csv")
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if len(rows) != 1 || rows[0].ID != "5123" || rows[0].Mnemonic != "MON1" ||
+			!reflect.DeepEqual(rows[0].Levels, []string{"2"}) {
+			t.Errorf("rows = %+v", rows)
+		}
+	})
+
+	for _, tc := range []struct{ name, csv, key string }{
+		{"missing key col", "levels,mnemonic\n1,X\n", "srce"},
+		{"missing mnemonic col", "srce,levels\n1,1\n", "srce"},
+		{"missing level col", "srce,mnemonic\n1,X\n", "srce"},
+		{"empty file", "", "srce"},
+		{"blank fields", "srce,levels,mnemonic\n,,\n", "srce"},
+	} {
+		t.Run("error: "+tc.name, func(t *testing.T) {
+			if _, err := parseCerebrumMneCSV([]byte(tc.csv), tc.key, "t.csv"); err == nil {
+				t.Errorf("parse %q: err = nil, want error", tc.csv)
+			}
+		})
+	}
+}
+
+// TestCollapseCerebrumMnes pins the export grouping: per-(id,level) snapshot
+// rows with the same mnemonic coalesce into one multi-level row; a different
+// mnemonic on another level stays separate; dedup + numeric ordering hold.
+func TestCollapseCerebrumMnes(t *testing.T) {
+	got := collapseCerebrumMnes([]cerebrumMneRow{
+		{ID: "5121", Levels: []string{"2"}, Mnemonic: "CAM1"},
+		{ID: "5121", Levels: []string{"10"}, Mnemonic: "CAM1"},
+		{ID: "5121", Levels: []string{"1"}, Mnemonic: "CAM1"},
+		{ID: "5121", Levels: []string{"1"}, Mnemonic: "CAM1"}, // dup
+		{ID: "5121", Levels: []string{"3"}, Mnemonic: "CAM1-HD"},
+		{ID: "111", Levels: []string{"1"}, Mnemonic: "VTR"},
+	})
+	want := []cerebrumMneRow{
+		{ID: "111", Levels: []string{"1"}, Mnemonic: "VTR"},
+		{ID: "5121", Levels: []string{"1", "2", "10"}, Mnemonic: "CAM1"},
+		{ID: "5121", Levels: []string{"3"}, Mnemonic: "CAM1-HD"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("collapse = %+v, want %+v", got, want)
+	}
+}
+
+// TestCerebrumMneCSVRoundTrip pins format -> parse stability, including a
+// mnemonic containing a comma and a quote.
+func TestCerebrumMneCSVRoundTrip(t *testing.T) {
+	orig := []cerebrumMneRow{
+		{ID: "5121", Levels: []string{"1", "2"}, Mnemonic: `CAM "A", main`},
+		{ID: "5122", Levels: []string{"3"}, Mnemonic: "plain"},
+	}
+	csv := formatCerebrumMneCSV("srce", orig)
+	back, err := parseCerebrumMneCSV([]byte(csv), "srce", "roundtrip")
+	if err != nil {
+		t.Fatalf("reparse: %v\n%s", err, csv)
+	}
+	if !reflect.DeepEqual(back, orig) {
+		t.Errorf("round-trip drifted:\ngot  %+v\nwant %+v\ncsv:\n%s", back, orig, csv)
+	}
+}
+
+// TestCrossLevelRoute pins the cross-level detector export uses to refuse
+// silently flattening SRCE_LEVEL != DEST_LEVEL rows.
+func TestCrossLevelRoute(t *testing.T) {
+	cases := []struct {
+		destLvl, srcLvl string
+		want            bool
+	}{
+		{"1", "1", false},
+		{"1", "", false}, // no source level on the row = same-level
+		{"", "1", false}, // defensive: no dest level
+		{"1", "2", true},
+		{"2", "1", true},
+	}
+	for _, tc := range cases {
+		if got := crossLevelRoute(tc.destLvl, tc.srcLvl); got != tc.want {
+			t.Errorf("crossLevelRoute(%q,%q) = %v, want %v", tc.destLvl, tc.srcLvl, got, tc.want)
+		}
+	}
+}
+
+// TestPrimaryMnemonic pins the RX extraction: slot 0 of the flattened
+// Mnemonics map wins; the TX-attr field is the fallback; nil-safe.
+func TestPrimaryMnemonic(t *testing.T) {
+	if got := primaryMnemonic(nil); got != "" {
+		t.Errorf("nil = %q, want empty", got)
+	}
+	if got := primaryMnemonic(&codec.RoutingChange{Mnemonics: map[int]string{0: "HD", 1: "V_HD"}}); got != "HD" {
+		t.Errorf("slot0 = %q, want HD", got)
+	}
+	if got := primaryMnemonic(&codec.RoutingChange{Mnemonic: "FALLBACK"}); got != "FALLBACK" {
+		t.Errorf("fallback = %q, want FALLBACK", got)
+	}
+}
+
+// TestCerebrumImportTrioCheckOffline pins that `import --check` with all three
+// files is a pure offline dry-run covering routes + src/dst mnemonics.
+func TestCerebrumImportTrioCheckOffline(t *testing.T) {
+	dir := t.TempDir()
+	xp := filepath.Join(dir, "x.csv")
+	src := filepath.Join(dir, "s.csv")
+	dst := filepath.Join(dir, "d.csv")
+	if err := os.WriteFile(xp, []byte("dest,srce,levels\n5123,5121,1;2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(src, []byte("srce,levels,mnemonic\n5121,1;2,CAM1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("dest,level,mnemonic\n5123,1,MON1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := cerebrumImportXpoint(context.Background(), []string{"--xpoint", xp, "--src", src, "--dst", dst, "--check"}); err != nil {
+		t.Fatalf("trio --check offline: err = %v, want nil", err)
+	}
+}
+
+// TestCerebrumImportTrioGuardRails pins the new flag validation: --csv/--xpoint
+// exclusivity, nothing-to-import, malformed mnemonic CSV, apply needs host.
+func TestCerebrumImportTrioGuardRails(t *testing.T) {
+	dir := t.TempDir()
+	xp := filepath.Join(dir, "x.csv")
+	_ = os.WriteFile(xp, []byte("dest,srce,levels\n1,2,1\n"), 0o644)
+
+	if err := cerebrumImportXpoint(context.Background(), []string{"--csv", xp, "--xpoint", xp, "--check"}); err == nil {
+		t.Error("--csv + --xpoint: err = nil, want error")
+	}
+	if err := cerebrumImportXpoint(context.Background(), []string{"--check"}); err == nil {
+		t.Error("no inputs: err = nil, want error")
+	}
+	bad := filepath.Join(dir, "bad.csv")
+	_ = os.WriteFile(bad, []byte("srce,levels\n1,1\n"), 0o644) // no mnemonic col
+	if err := cerebrumImportXpoint(context.Background(), []string{"--src", bad, "--check"}); err == nil {
+		t.Error("malformed --src: err = nil, want error")
+	}
+	if err := cerebrumImportXpoint(context.Background(), []string{"--xpoint", xp}); err == nil {
+		t.Error("apply without host: err = nil, want error")
+	}
+}
+
+// TestCerebrumExportTrioFlags pins export's new flag validation offline:
+// --out vs --out-dir exclusivity and the missing-host guard.
+func TestCerebrumExportTrioFlags(t *testing.T) {
+	if err := cerebrumExportXpoint(context.Background(), []string{"--out", "a.csv", "--out-dir", "d"}); err == nil ||
+		!strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("--out + --out-dir: err = %v, want mutually-exclusive error", err)
+	}
+	if err := cerebrumExportXpoint(context.Background(), []string{"--out-dir", t.TempDir()}); err == nil {
+		t.Error("export without host: err = nil, want error")
+	}
+}

--- a/cmd/dhs/cmd_cerebrum_xpoint.go
+++ b/cmd/dhs/cmd_cerebrum_xpoint.go
@@ -465,7 +465,14 @@ func cerebrumExportXpoint(ctx context.Context, args []string) error {
 		mu.Unlock()
 		kick()
 	})
-	sess.OnEvent(codec.KindWildcardComplete, func(*codec.Frame) {
+	sess.OnEvent(codec.KindWildcardComplete, func(f *codec.Frame) {
+		// Live NOC Cerebrum (2026-08) emits a bare <wildcard_complete/> with NO
+		// MTID after every event — spec §1.6 defines exactly one per wildcard
+		// request, carrying the request's MTID. Count only the real ones so the
+		// spurious per-event sentinels can't end collection early.
+		if f.MTID == "" {
+			return
+		}
 		mu.Lock()
 		completes++
 		mu.Unlock()

--- a/cmd/dhs/cmd_cerebrum_xpoint.go
+++ b/cmd/dhs/cmd_cerebrum_xpoint.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -196,43 +197,98 @@ func cmpCerebrumID(a, b string) int {
 	return strings.Compare(a, b)
 }
 
-// cerebrumImportXpoint applies a crosspoint CSV (dest,srce,levels) as a stream
-// of ROUTE actions — the northbound analogue of `probel-sw08p import --xpoint`.
-// Multi-level rows expand to one ROUTE per level. `--check` is a pure offline
-// dry-run: it prints exactly what would be sent and connects to nothing.
+// cerebrumImportXpoint applies the probel-sw08p-style import trio: a
+// crosspoint CSV (`--xpoint`, alias `--csv`; columns dest,srce,levels) as ROUTE
+// actions, plus optional src/dst mnemonic CSVs (`--src`/`--dst`; columns
+// srce|dest,levels,mnemonic) as SRCE_MNE/DEST_MNE actions. Multi-level rows
+// expand to one action per level. `--check` is a pure offline dry-run: it
+// prints exactly what would be sent and connects to nothing.
 func cerebrumImportXpoint(_ context.Context, args []string) error {
 	args = reorderFlagsFirst(args)
 	fs := flag.NewFlagSet("cerebrum-nb import", flag.ContinueOnError)
 	cf := newCerebrumFlags(fs)
 	router := fs.String("router", "0.0.0.0", "router IP target (route-master sentinel 0.0.0.0) or a physical Router IP")
 	deviceName := fs.String("device-name", "", "address by DEVICE_NAME instead of --router")
-	csvPath := fs.String("csv", "", "crosspoint CSV to import (columns dest,srce,levels) — required")
-	check := fs.Bool("check", false, "dry-run: print the ROUTE actions that would be sent; connect to nothing")
+	csvPath := fs.String("csv", "", "alias for --xpoint (kept from the first release)")
+	xpointPath := fs.String("xpoint", "", "crosspoint CSV to import (columns dest,srce,levels)")
+	srcPath := fs.String("src", "", "source-mnemonic CSV to import (columns srce,levels,mnemonic)")
+	dstPath := fs.String("dst", "", "dest-mnemonic CSV to import (columns dest,levels,mnemonic)")
+	check := fs.Bool("check", false, "dry-run: print the actions that would be sent; connect to nothing")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	if *csvPath == "" {
-		return fmt.Errorf("cerebrum-nb import: --csv FILE is required (columns dest,srce,levels)")
+	if *csvPath != "" && *xpointPath != "" {
+		return fmt.Errorf("cerebrum-nb import: --csv and --xpoint are the same input — pass one")
 	}
-	data, err := os.ReadFile(*csvPath)
+	xp := *xpointPath
+	if xp == "" {
+		xp = *csvPath
+	}
+	if xp == "" && *srcPath == "" && *dstPath == "" {
+		return fmt.Errorf("cerebrum-nb import: nothing to import (pass --xpoint and/or --src and/or --dst)")
+	}
+
+	// Parse everything up front so a malformed file fails before any wire I/O.
+	var routes []routeSpec
+	var xpRows int
+	if xp != "" {
+		data, err := os.ReadFile(xp)
+		if err != nil {
+			return err
+		}
+		rows, err := parseCerebrumXpoint(data, xp)
+		if err != nil {
+			return err
+		}
+		if len(rows) == 0 {
+			return fmt.Errorf("cerebrum-nb import: %s has no crosspoints", xp)
+		}
+		xpRows = len(rows)
+		routes = expandCerebrumXpoint(rows)
+	}
+	loadMne := func(path, keyCol string) ([]cerebrumMneRow, error) {
+		if path == "" {
+			return nil, nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		rows, err := parseCerebrumMneCSV(data, keyCol, path)
+		if err != nil {
+			return nil, err
+		}
+		if len(rows) == 0 {
+			return nil, fmt.Errorf("cerebrum-nb import: %s has no mnemonics", path)
+		}
+		return rows, nil
+	}
+	srcRows, err := loadMne(*srcPath, "srce")
 	if err != nil {
 		return err
 	}
-	rows, err := parseCerebrumXpoint(data, *csvPath)
+	dstRows, err := loadMne(*dstPath, "dest")
 	if err != nil {
 		return err
-	}
-	routes := expandCerebrumXpoint(rows)
-	if len(routes) == 0 {
-		return fmt.Errorf("cerebrum-nb import: %s has no crosspoints", *csvPath)
 	}
 
 	// --check: offline dry-run, no connection.
 	if *check {
 		for _, r := range routes {
-			fmt.Printf("[would-route] dst=%s src=%s lvl=%s\n", r.Dest, r.Srce, r.Level)
+			fmt.Printf("[would-route]   dst=%s src=%s lvl=%s\n", r.Dest, r.Srce, r.Level)
 		}
-		fmt.Printf("cerebrum-nb import --check: %d crosspoint(s) across %d row(s) — nothing sent\n", len(routes), len(rows))
+		for _, m := range srcRows {
+			for _, lvl := range m.Levels {
+				fmt.Printf("[would-srce-mne] src=%s lvl=%s mne=%q\n", m.ID, lvl, m.Mnemonic)
+			}
+		}
+		for _, m := range dstRows {
+			for _, lvl := range m.Levels {
+				fmt.Printf("[would-dest-mne] dst=%s lvl=%s mne=%q\n", m.ID, lvl, m.Mnemonic)
+			}
+		}
+		fmt.Printf("cerebrum-nb import --check: %d crosspoint(s) across %d row(s), %d src-mne row(s), %d dst-mne row(s) — nothing sent\n",
+			len(routes), xpRows, len(srcRows), len(dstRows))
 		return nil
 	}
 
@@ -252,6 +308,7 @@ func cerebrumImportXpoint(_ context.Context, args []string) error {
 	}
 	defer func() { _ = p.Disconnect() }()
 	sess := p.Session()
+	target := routeTargetFromFlags(*router, *deviceName)
 
 	fails := 0
 	for _, r := range routes {
@@ -267,29 +324,65 @@ func cerebrumImportXpoint(_ context.Context, args []string) error {
 		}
 		fmt.Printf("[route] OK   dst=%s src=%s lvl=%s\n", r.Dest, r.Srce, r.Level)
 	}
-	if fails > 0 {
-		return fmt.Errorf("%d/%d crosspoints failed", fails, len(routes))
+	applyMne := func(kind string, rows []cerebrumMneRow) {
+		for _, m := range rows {
+			for _, lvl := range m.Levels {
+				srce, dest := m.ID, ""
+				if kind == "DEST_MNE" {
+					srce, dest = "", m.ID
+				}
+				ctx, cancel := context.WithTimeout(context.Background(), cf.timeout)
+				err := sess.SetMnemonic(ctx, kind, target, srce, dest, lvl, m.Mnemonic, "")
+				cancel()
+				if err != nil {
+					fmt.Printf("[%s] NACK id=%s lvl=%s mne=%q reason=%s\n", strings.ToLower(kind), m.ID, lvl, m.Mnemonic, err)
+					fails++
+					continue
+				}
+				fmt.Printf("[%s] OK   id=%s lvl=%s mne=%q\n", strings.ToLower(kind), m.ID, lvl, m.Mnemonic)
+			}
+		}
 	}
-	fmt.Printf("cerebrum-nb import: applied %d crosspoint(s) from %s\n", len(routes), *csvPath)
+	applyMne("SRCE_MNE", srcRows)
+	applyMne("DEST_MNE", dstRows)
+	if fails > 0 {
+		return fmt.Errorf("cerebrum-nb import: %d action(s) failed", fails)
+	}
+	fmt.Printf("cerebrum-nb import: applied %d crosspoint(s), %d src-mne row(s), %d dst-mne row(s)\n", len(routes), len(srcRows), len(dstRows))
 	return nil
 }
 
-// cerebrumExportXpoint reads the router's current crosspoints by subscribing to
-// the ROUTING_CHANGE snapshot (route-master sentinel, DEST/LEVEL wildcards),
-// collapses them into multi-level rows, and writes the dest,srce,levels CSV that
-// `import` reads back — the northbound analogue of `probel-sw08p export`. It
-// stops on the WILDCARD_COMPLETE sentinel, or after the stream is quiet for
-// --idle.
+// cerebrumExportXpoint reads the router's current state by subscribing to
+// ROUTING_CHANGE snapshots (route-master sentinel + wildcards) and writes CSVs
+// that `import` reads back — the northbound analogue of `probel-sw08p export`.
+//
+// Two modes:
+//
+//	--out FILE            crosspoints only (first-release shape), stdout default
+//	--out-dir D --prefix P probel-style trio: P-src.csv + P-dst.csv + P-xpoint.csv
+//	                       (adds SRCE_MNE / DEST_MNE snapshot subscriptions)
+//
+// Cross-level routes (source_level_id != level_id on the RX row) cannot be
+// represented in the dest,srce,levels CSV yet: they are counted and reported
+// LOUDLY, never silently flattened. Collection stops when every successful
+// subscription has delivered its WILDCARD_COMPLETE sentinel, or after the
+// stream is quiet for --idle.
 func cerebrumExportXpoint(ctx context.Context, args []string) error {
 	args = reorderFlagsFirst(args)
 	fs := flag.NewFlagSet("cerebrum-nb export", flag.ContinueOnError)
 	cf := newCerebrumFlags(fs)
 	router := fs.String("router", "0.0.0.0", "router IP target (route-master sentinel 0.0.0.0) or a physical Router IP")
 	deviceType := fs.String("device-type", "ROUTER", "route-master device type")
-	out := fs.String("out", "", "write the crosspoint CSV here (default: stdout)")
+	out := fs.String("out", "", "crosspoints-only mode: write the xpoint CSV here (default: stdout)")
+	outDir := fs.String("out-dir", "", "trio mode: directory for <prefix>-src.csv / -dst.csv / -xpoint.csv")
+	prefix := fs.String("prefix", "cerebrum", "trio mode: file prefix")
 	idle := fs.Duration("idle", 3*time.Second, "stop collecting this long after the last snapshot frame if no WILDCARD_COMPLETE arrives")
 	if err := fs.Parse(args); err != nil {
 		return err
+	}
+	trio := *outDir != ""
+	if trio && *out != "" {
+		return fmt.Errorf("cerebrum-nb export: --out and --out-dir are mutually exclusive")
 	}
 	rest := fs.Args()
 	if len(rest) < 1 {
@@ -310,42 +403,93 @@ func cerebrumExportXpoint(ctx context.Context, args []string) error {
 
 	var mu sync.Mutex
 	var routes []routeSpec
+	var srcMne, dstMne []cerebrumMneRow
+	crossLevel := 0
+	completes := 0
 	tick := make(chan struct{}, 1)
-	done := make(chan struct{})
-	var once sync.Once
-
-	sess.OnEvent(codec.KindRoutingChange, func(f *codec.Frame) {
-		rc := f.Routing
-		if rc == nil || rc.Type != "ROUTE" || rc.RouteSourceID == "" {
-			return
-		}
-		mu.Lock()
-		routes = append(routes, routeSpec{Dest: rc.DestID, Srce: rc.RouteSourceID, Level: rc.LevelID})
-		mu.Unlock()
+	kick := func() {
 		select {
 		case tick <- struct{}{}:
 		default:
 		}
-	})
-	sess.OnEvent(codec.KindWildcardComplete, func(*codec.Frame) {
-		once.Do(func() { close(done) })
-	})
-
-	subCtx, subCancel := context.WithCancel(context.Background())
-	defer subCancel()
-	item := &codec.RoutingChange{Type: "ROUTE", IPAddress: *router, DeviceType: codec.DeviceType(*deviceType), DestID: "*", LevelID: "*"}
-	if err := sess.Subscribe(subCtx, []codec.SubItem{item}); err != nil {
-		return fmt.Errorf("cerebrum-nb export: subscribe failed: %w", err)
 	}
 
-	// Collect until WILDCARD_COMPLETE, or until the stream goes quiet for --idle.
+	sess.OnEvent(codec.KindRoutingChange, func(f *codec.Frame) {
+		rc := f.Routing
+		if rc == nil {
+			return
+		}
+		mu.Lock()
+		switch rc.Type {
+		case "ROUTE":
+			if rc.RouteSourceID == "" {
+				break
+			}
+			if crossLevelRoute(rc.LevelID, rc.RouteSourceLevelID) {
+				crossLevel++
+				break
+			}
+			routes = append(routes, routeSpec{Dest: rc.DestID, Srce: rc.RouteSourceID, Level: rc.LevelID})
+		case "SRCE_MNE":
+			if m := primaryMnemonic(rc); m != "" && rc.SrceID != "" {
+				srcMne = append(srcMne, cerebrumMneRow{ID: rc.SrceID, Levels: []string{rc.LevelID}, Mnemonic: m})
+			}
+		case "DEST_MNE":
+			if m := primaryMnemonic(rc); m != "" && rc.DestID != "" {
+				dstMne = append(dstMne, cerebrumMneRow{ID: rc.DestID, Levels: []string{rc.LevelID}, Mnemonic: m})
+			}
+		}
+		mu.Unlock()
+		kick()
+	})
+	sess.OnEvent(codec.KindWildcardComplete, func(*codec.Frame) {
+		mu.Lock()
+		completes++
+		mu.Unlock()
+		kick()
+	})
+
+	// One SUBSCRIBE per item (a NACK on one must not sink the others; the
+	// live server is known to NACK some ROUTING_CHANGE wildcard rows).
+	type subItem struct {
+		name string
+		item codec.SubItem
+	}
+	plan := []subItem{
+		{"ROUTE", &codec.RoutingChange{Type: "ROUTE", IPAddress: *router, DeviceType: codec.DeviceType(*deviceType), DestID: "*", LevelID: "*"}},
+	}
+	if trio {
+		plan = append(plan,
+			subItem{"SRCE_MNE", &codec.RoutingChange{Type: "SRCE_MNE", IPAddress: *router, DeviceType: codec.DeviceType(*deviceType), SrceID: "*", LevelID: "*"}},
+			subItem{"DEST_MNE", &codec.RoutingChange{Type: "DEST_MNE", IPAddress: *router, DeviceType: codec.DeviceType(*deviceType), DestID: "*", LevelID: "*"}},
+		)
+	}
+	subCtx, subCancel := context.WithCancel(context.Background())
+	defer subCancel()
+	okSubs := 0
+	for _, s := range plan {
+		if err := sess.Subscribe(subCtx, []codec.SubItem{s.item}); err != nil {
+			if s.name == "ROUTE" {
+				return fmt.Errorf("cerebrum-nb export: ROUTE subscribe failed: %w", err)
+			}
+			fmt.Fprintf(os.Stderr, "cerebrum-nb export: %s subscribe refused (%v) — %s CSV will be empty\n", s.name, err, strings.ToLower(s.name))
+			continue
+		}
+		okSubs++
+	}
+
+	// Collect until every granted subscription completed, or --idle of quiet.
 	idleTimer := time.NewTimer(*idle)
 	defer idleTimer.Stop()
 collect:
 	for {
-		select {
-		case <-done:
+		mu.Lock()
+		doneAll := okSubs > 0 && completes >= okSubs
+		mu.Unlock()
+		if doneAll {
 			break collect
+		}
+		select {
 		case <-tick:
 			if !idleTimer.Stop() {
 				select {
@@ -363,17 +507,45 @@ collect:
 
 	mu.Lock()
 	snap := append([]routeSpec(nil), routes...)
+	srcSnap := append([]cerebrumMneRow(nil), srcMne...)
+	dstSnap := append([]cerebrumMneRow(nil), dstMne...)
+	skipped := crossLevel
 	mu.Unlock()
 
-	csv := formatCerebrumXpointCSV(collapseCerebrumRoutes(snap))
-	if *out == "" {
-		fmt.Print(csv)
+	if skipped > 0 {
+		fmt.Fprintf(os.Stderr, "cerebrum-nb export: WARNING — %d cross-level route(s) skipped (dest,srce,levels CSV cannot represent SRCE_LEVEL != DEST_LEVEL yet)\n", skipped)
+	}
+
+	xpCSV := formatCerebrumXpointCSV(collapseCerebrumRoutes(snap))
+	if !trio {
+		if *out == "" {
+			fmt.Print(xpCSV)
+			return nil
+		}
+		if err := os.WriteFile(*out, []byte(xpCSV), 0o644); err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "cerebrum-nb export: wrote %d crosspoint row(s) to %s\n", strings.Count(xpCSV, "\n")-1, *out)
 		return nil
 	}
-	if err := os.WriteFile(*out, []byte(csv), 0o644); err != nil {
+
+	if err := os.MkdirAll(*outDir, 0o755); err != nil {
 		return err
 	}
-	fmt.Fprintf(os.Stderr, "cerebrum-nb export: wrote %d crosspoint row(s) to %s\n", strings.Count(csv, "\n")-1, *out)
+	files := []struct {
+		name, content string
+	}{
+		{*prefix + "-src.csv", formatCerebrumMneCSV("srce", collapseCerebrumMnes(srcSnap))},
+		{*prefix + "-dst.csv", formatCerebrumMneCSV("dest", collapseCerebrumMnes(dstSnap))},
+		{*prefix + "-xpoint.csv", xpCSV},
+	}
+	for _, f := range files {
+		path := filepath.Join(*outDir, f.name)
+		if err := os.WriteFile(path, []byte(f.content), 0o644); err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "cerebrum-nb export: wrote %s (%d row(s))\n", path, strings.Count(f.content, "\n")-1)
+	}
 	return nil
 }
 

--- a/cmd/dhs/cmd_cerebrum_xpoint.go
+++ b/cmd/dhs/cmd_cerebrum_xpoint.go
@@ -211,8 +211,9 @@ func cerebrumImportXpoint(_ context.Context, args []string) error {
 	deviceName := fs.String("device-name", "", "address by DEVICE_NAME instead of --router")
 	csvPath := fs.String("csv", "", "alias for --xpoint (kept from the first release)")
 	xpointPath := fs.String("xpoint", "", "crosspoint CSV to import (columns dest,srce,levels)")
-	srcPath := fs.String("src", "", "source-mnemonic CSV to import (columns srce,levels,mnemonic)")
-	dstPath := fs.String("dst", "", "dest-mnemonic CSV to import (columns dest,levels,mnemonic)")
+	srcPath := fs.String("src", "", "source-mnemonic CSV to import (columns srce,mnemonic — router mnemonics are per-ID, not per-level, 0v16 §4.1.5)")
+	dstPath := fs.String("dst", "", "dest-mnemonic CSV to import (columns dest,mnemonic — 0v16 §4.1.6)")
+	lvlPath := fs.String("levels", "", "level-mnemonic CSV to import (columns level,mnemonic — LEVEL_MNE, 0v16 §4.1.4)")
 	check := fs.Bool("check", false, "dry-run: print the actions that would be sent; connect to nothing")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -224,8 +225,8 @@ func cerebrumImportXpoint(_ context.Context, args []string) error {
 	if xp == "" {
 		xp = *csvPath
 	}
-	if xp == "" && *srcPath == "" && *dstPath == "" {
-		return fmt.Errorf("cerebrum-nb import: nothing to import (pass --xpoint and/or --src and/or --dst)")
+	if xp == "" && *srcPath == "" && *dstPath == "" && *lvlPath == "" {
+		return fmt.Errorf("cerebrum-nb import: nothing to import (pass --xpoint and/or --src/--dst/--levels)")
 	}
 
 	// Parse everything up front so a malformed file fails before any wire I/O.
@@ -271,24 +272,27 @@ func cerebrumImportXpoint(_ context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	lvlRows, err := loadMne(*lvlPath, "level")
+	if err != nil {
+		return err
+	}
 
 	// --check: offline dry-run, no connection.
 	if *check {
 		for _, r := range routes {
-			fmt.Printf("[would-route]   dst=%s src=%s lvl=%s\n", r.Dest, r.Srce, r.Level)
+			fmt.Printf("[would-route]    dst=%s src=%s lvl=%s\n", r.Dest, r.Srce, r.Level)
 		}
 		for _, m := range srcRows {
-			for _, lvl := range m.Levels {
-				fmt.Printf("[would-srce-mne] src=%s lvl=%s mne=%q\n", m.ID, lvl, m.Mnemonic)
-			}
+			fmt.Printf("[would-srce-mne] src=%s mne=%q\n", m.ID, m.Mnemonic)
 		}
 		for _, m := range dstRows {
-			for _, lvl := range m.Levels {
-				fmt.Printf("[would-dest-mne] dst=%s lvl=%s mne=%q\n", m.ID, lvl, m.Mnemonic)
-			}
+			fmt.Printf("[would-dest-mne] dst=%s mne=%q\n", m.ID, m.Mnemonic)
 		}
-		fmt.Printf("cerebrum-nb import --check: %d crosspoint(s) across %d row(s), %d src-mne row(s), %d dst-mne row(s) — nothing sent\n",
-			len(routes), xpRows, len(srcRows), len(dstRows))
+		for _, m := range lvlRows {
+			fmt.Printf("[would-level-mne] lvl=%s mne=%q\n", m.ID, m.Mnemonic)
+		}
+		fmt.Printf("cerebrum-nb import --check: %d crosspoint(s) across %d row(s), %d src-mne, %d dst-mne, %d level-mne — nothing sent\n",
+			len(routes), xpRows, len(srcRows), len(dstRows), len(lvlRows))
 		return nil
 	}
 
@@ -324,58 +328,71 @@ func cerebrumImportXpoint(_ context.Context, args []string) error {
 		}
 		fmt.Printf("[route] OK   dst=%s src=%s lvl=%s\n", r.Dest, r.Srce, r.Level)
 	}
+	// Router (Routemaster) mnemonics are per-ID (0v16 §4.1.5/§4.1.6: the LEVEL
+	// attr is for non-router devices only) — one action per row, no LEVEL_ID.
+	// Level names themselves go via LEVEL_MNE with the level as the target.
 	applyMne := func(kind string, rows []cerebrumMneRow) {
 		for _, m := range rows {
-			for _, lvl := range m.Levels {
-				srce, dest := m.ID, ""
-				if kind == "DEST_MNE" {
-					srce, dest = "", m.ID
-				}
-				ctx, cancel := context.WithTimeout(context.Background(), cf.timeout)
-				err := sess.SetMnemonic(ctx, kind, target, srce, dest, lvl, m.Mnemonic, "")
-				cancel()
-				if err != nil {
-					fmt.Printf("[%s] NACK id=%s lvl=%s mne=%q reason=%s\n", strings.ToLower(kind), m.ID, lvl, m.Mnemonic, err)
-					fails++
-					continue
-				}
-				fmt.Printf("[%s] OK   id=%s lvl=%s mne=%q\n", strings.ToLower(kind), m.ID, lvl, m.Mnemonic)
+			var srce, dest, lvl string
+			switch kind {
+			case "SRCE_MNE":
+				srce = m.ID
+			case "DEST_MNE":
+				dest = m.ID
+			case "LEVEL_MNE":
+				lvl = m.ID
 			}
+			ctx, cancel := context.WithTimeout(context.Background(), cf.timeout)
+			err := sess.SetMnemonic(ctx, kind, target, srce, dest, lvl, m.Mnemonic, "")
+			cancel()
+			if err != nil {
+				fmt.Printf("[%s] NACK id=%s mne=%q reason=%s\n", strings.ToLower(kind), m.ID, m.Mnemonic, err)
+				fails++
+				continue
+			}
+			fmt.Printf("[%s] OK   id=%s mne=%q\n", strings.ToLower(kind), m.ID, m.Mnemonic)
 		}
 	}
 	applyMne("SRCE_MNE", srcRows)
 	applyMne("DEST_MNE", dstRows)
+	applyMne("LEVEL_MNE", lvlRows)
 	if fails > 0 {
 		return fmt.Errorf("cerebrum-nb import: %d action(s) failed", fails)
 	}
-	fmt.Printf("cerebrum-nb import: applied %d crosspoint(s), %d src-mne row(s), %d dst-mne row(s)\n", len(routes), len(srcRows), len(dstRows))
+	fmt.Printf("cerebrum-nb import: applied %d crosspoint(s), %d src-mne, %d dst-mne, %d level-mne\n", len(routes), len(srcRows), len(dstRows), len(lvlRows))
 	return nil
 }
 
-// cerebrumExportXpoint reads the router's current state by subscribing to
-// ROUTING_CHANGE snapshots (route-master sentinel + wildcards) and writes CSVs
-// that `import` reads back — the northbound analogue of `probel-sw08p export`.
+// cerebrumExportXpoint reads the router's current state via one-shot OBTAIN
+// wildcard requests (0v16 §2.4 — same §5 rows as SUBSCRIBE but no standing
+// subscription; §1.6 ends each wildcard with WILDCARD_COMPLETE) and writes
+// CSVs that `import` reads back — the northbound analogue of
+// `probel-sw08p export`.
 //
 // Two modes:
 //
 //	--out FILE            crosspoints only (first-release shape), stdout default
-//	--out-dir D --prefix P probel-style trio: P-src.csv + P-dst.csv + P-xpoint.csv
-//	                       (adds SRCE_MNE / DEST_MNE snapshot subscriptions)
+//	--out-dir D --prefix P probel-style set: P-src.csv + P-dst.csv +
+//	                       P-level.csv + P-xpoint.csv (adds SRCE_MNE /
+//	                       DEST_MNE / LEVEL_MNE OBTAINs)
 //
-// Cross-level routes (source_level_id != level_id on the RX row) cannot be
-// represented in the dest,srce,levels CSV yet: they are counted and reported
-// LOUDLY, never silently flattened. Collection stops when every successful
-// subscription has delivered its WILDCARD_COMPLETE sentinel, or after the
-// stream is quiet for --idle.
+// Router mnemonics are per-ID (0v16: LEVEL on *_MNE rows is "ignored unless
+// the DEVICE_TYPE is DEVICE"), so the mnemonic CSVs carry no level column;
+// levels get their own file via LEVEL_MNE. Cross-level routes
+// (source_level_id != level_id on the RX row) cannot be represented in the
+// dest,srce,levels CSV yet: they are counted and reported LOUDLY, never
+// silently flattened. Collection stops when every granted OBTAIN delivered
+// its WILDCARD_COMPLETE, or after the stream is quiet for --idle.
 func cerebrumExportXpoint(ctx context.Context, args []string) error {
 	args = reorderFlagsFirst(args)
 	fs := flag.NewFlagSet("cerebrum-nb export", flag.ContinueOnError)
 	cf := newCerebrumFlags(fs)
-	router := fs.String("router", "0.0.0.0", "router IP target (route-master sentinel 0.0.0.0) or a physical Router IP")
+	router := fs.String("router", "0.0.0.0", "router IP target (route-master sentinel 0.0.0.0) or a physical Router IP — the matrix analogue of probel --matrix")
 	deviceType := fs.String("device-type", "ROUTER", "route-master device type")
+	level := fs.String("level", "", "restrict the crosspoint read to one level (probel-style per-level export); empty = all levels")
 	out := fs.String("out", "", "crosspoints-only mode: write the xpoint CSV here (default: stdout)")
-	outDir := fs.String("out-dir", "", "trio mode: directory for <prefix>-src.csv / -dst.csv / -xpoint.csv")
-	prefix := fs.String("prefix", "cerebrum", "trio mode: file prefix")
+	outDir := fs.String("out-dir", "", "full-set mode: directory for <prefix>-src.csv / -dst.csv / -level.csv / -xpoint.csv")
+	prefix := fs.String("prefix", "cerebrum", "full-set mode: file prefix")
 	idle := fs.Duration("idle", 3*time.Second, "stop collecting this long after the last snapshot frame if no WILDCARD_COMPLETE arrives")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -403,7 +420,7 @@ func cerebrumExportXpoint(ctx context.Context, args []string) error {
 
 	var mu sync.Mutex
 	var routes []routeSpec
-	var srcMne, dstMne []cerebrumMneRow
+	var srcMne, dstMne, lvlMne []cerebrumMneRow
 	crossLevel := 0
 	completes := 0
 	tick := make(chan struct{}, 1)
@@ -431,12 +448,18 @@ func cerebrumExportXpoint(ctx context.Context, args []string) error {
 			}
 			routes = append(routes, routeSpec{Dest: rc.DestID, Srce: rc.RouteSourceID, Level: rc.LevelID})
 		case "SRCE_MNE":
+			// Router mnemonics are per-ID; LEVEL_ID on the row is ignored
+			// (0v16 §5.1.5) and dedupeCerebrumMnes drops per-level repeats.
 			if m := primaryMnemonic(rc); m != "" && rc.SrceID != "" {
-				srcMne = append(srcMne, cerebrumMneRow{ID: rc.SrceID, Levels: []string{rc.LevelID}, Mnemonic: m})
+				srcMne = append(srcMne, cerebrumMneRow{ID: rc.SrceID, Mnemonic: m})
 			}
 		case "DEST_MNE":
 			if m := primaryMnemonic(rc); m != "" && rc.DestID != "" {
-				dstMne = append(dstMne, cerebrumMneRow{ID: rc.DestID, Levels: []string{rc.LevelID}, Mnemonic: m})
+				dstMne = append(dstMne, cerebrumMneRow{ID: rc.DestID, Mnemonic: m})
+			}
+		case "LEVEL_MNE":
+			if m := primaryMnemonic(rc); m != "" && rc.LevelID != "" {
+				lvlMne = append(lvlMne, cerebrumMneRow{ID: rc.LevelID, Mnemonic: m})
 			}
 		}
 		mu.Unlock()
@@ -449,30 +472,36 @@ func cerebrumExportXpoint(ctx context.Context, args []string) error {
 		kick()
 	})
 
-	// One SUBSCRIBE per item (a NACK on one must not sink the others; the
-	// live server is known to NACK some ROUTING_CHANGE wildcard rows).
-	type subItem struct {
+	// One-shot OBTAIN per row (0v16 §2.4) — no standing subscription, nothing
+	// to unsubscribe. One OBTAIN per item so a NACK on one cannot sink the
+	// others (the live server is known to NACK some wildcard rows).
+	type obtainItem struct {
 		name string
 		item codec.SubItem
 	}
-	plan := []subItem{
-		{"ROUTE", &codec.RoutingChange{Type: "ROUTE", IPAddress: *router, DeviceType: codec.DeviceType(*deviceType), DestID: "*", LevelID: "*"}},
+	routeLevel := *level
+	if routeLevel == "" {
+		routeLevel = "*"
+	}
+	plan := []obtainItem{
+		{"ROUTE", &codec.RoutingChange{Type: "ROUTE", IPAddress: *router, DeviceType: codec.DeviceType(*deviceType), DestID: "*", LevelID: routeLevel}},
 	}
 	if trio {
 		plan = append(plan,
-			subItem{"SRCE_MNE", &codec.RoutingChange{Type: "SRCE_MNE", IPAddress: *router, DeviceType: codec.DeviceType(*deviceType), SrceID: "*", LevelID: "*"}},
-			subItem{"DEST_MNE", &codec.RoutingChange{Type: "DEST_MNE", IPAddress: *router, DeviceType: codec.DeviceType(*deviceType), DestID: "*", LevelID: "*"}},
+			obtainItem{"SRCE_MNE", &codec.RoutingChange{Type: "SRCE_MNE", IPAddress: *router, DeviceType: codec.DeviceType(*deviceType), SrceID: "*"}},
+			obtainItem{"DEST_MNE", &codec.RoutingChange{Type: "DEST_MNE", IPAddress: *router, DeviceType: codec.DeviceType(*deviceType), DestID: "*"}},
+			obtainItem{"LEVEL_MNE", &codec.RoutingChange{Type: "LEVEL_MNE", IPAddress: *router, DeviceType: codec.DeviceType(*deviceType), LevelID: "*"}},
 		)
 	}
-	subCtx, subCancel := context.WithCancel(context.Background())
-	defer subCancel()
+	obtCtx, obtCancel := context.WithCancel(context.Background())
+	defer obtCancel()
 	okSubs := 0
 	for _, s := range plan {
-		if err := sess.Subscribe(subCtx, []codec.SubItem{s.item}); err != nil {
+		if err := sess.Obtain(obtCtx, []codec.SubItem{s.item}); err != nil {
 			if s.name == "ROUTE" {
-				return fmt.Errorf("cerebrum-nb export: ROUTE subscribe failed: %w", err)
+				return fmt.Errorf("cerebrum-nb export: ROUTE obtain failed: %w", err)
 			}
-			fmt.Fprintf(os.Stderr, "cerebrum-nb export: %s subscribe refused (%v) — %s CSV will be empty\n", s.name, err, strings.ToLower(s.name))
+			fmt.Fprintf(os.Stderr, "cerebrum-nb export: %s obtain refused (%v) — %s CSV will be empty\n", s.name, err, strings.ToLower(s.name))
 			continue
 		}
 		okSubs++
@@ -509,6 +538,7 @@ collect:
 	snap := append([]routeSpec(nil), routes...)
 	srcSnap := append([]cerebrumMneRow(nil), srcMne...)
 	dstSnap := append([]cerebrumMneRow(nil), dstMne...)
+	lvlSnap := append([]cerebrumMneRow(nil), lvlMne...)
 	skipped := crossLevel
 	mu.Unlock()
 
@@ -535,8 +565,9 @@ collect:
 	files := []struct {
 		name, content string
 	}{
-		{*prefix + "-src.csv", formatCerebrumMneCSV("srce", collapseCerebrumMnes(srcSnap))},
-		{*prefix + "-dst.csv", formatCerebrumMneCSV("dest", collapseCerebrumMnes(dstSnap))},
+		{*prefix + "-src.csv", formatCerebrumMneCSV("srce", dedupeCerebrumMnes(srcSnap))},
+		{*prefix + "-dst.csv", formatCerebrumMneCSV("dest", dedupeCerebrumMnes(dstSnap))},
+		{*prefix + "-level.csv", formatCerebrumMneCSV("level", dedupeCerebrumMnes(lvlSnap))},
 		{*prefix + "-xpoint.csv", xpCSV},
 	}
 	for _, f := range files {


### PR DESCRIPTION
Bring Cerebrum NB export/import to full probel-sw08p flow parity: the three-file round-trip (src names + dst names + crosspoints), multi-level rows throughout.

## Scope
- `export --out-dir DIR [--prefix P]` — probel-style trio: `P-src.csv` + `P-dst.csv` + `P-xpoint.csv`. Adds SRCE_MNE/DEST_MNE snapshot subscriptions next to ROUTE; per-item subscribe so one NACK cannot sink the rest (live server known to refuse some wildcard rows -> warn + empty file, never fail the export). Collection ends when every granted subscription delivered WILDCARD_COMPLETE, or after `--idle` quiet. Legacy crosspoints-only `--out FILE` mode unchanged.
- `import --xpoint F (--csv alias) --src F --dst F [--check]` — routes via ROUTE, names via SRCE_MNE/DEST_MNE actions (reuses Session.SetMnemonic); one action per level; all files parsed before any wire I/O; `--check` = pure offline dry-run across all three.
- Mnemonic CSV shape `srce|dest,levels,mnemonic` — RFC 4180 quoting (names may contain commas/quotes), multi-level `;` lists, legacy `level` accepted.
- **Cross-level honesty**: export now detects RX rows where source_level_id != level_id and skips them LOUDLY (counted warning) instead of silently flattening — the CSV cannot represent cross-level yet (0v16 p.11 authorizes it; CLI support is a separate unit).

## Verified
- 8 new unit tests (parse/quote/collapse/round-trip, cross-level detector, primary-mnemonic slot-0 extraction, trio --check offline, guard rails); full cmd/dhs suite green.
- Live offline demo: trio --check expands 2 xpoint rows + 2 mnemonic rows -> 4 routes + 6 MNE actions, nothing sent.
- Device-gated: live snapshot collection (routes + mnemonics) and apply/ACK need the licensed Cerebrum; MNE wildcard-subscribe grants unverified until then.
