### PR TITLE
feat(cerebrum-nb): wildcard-free src/dst inventory via category walk (export catalog.csv)

### DIFF
--- a/cmd/dhs/cmd_cerebrum_names.go
+++ b/cmd/dhs/cmd_cerebrum_names.go
@@ -115,6 +115,39 @@ func formatCerebrumMneCSV(keyCol string, rows []cerebrumMneRow) string {
 	return b.String()
 }
 
+// cerebrumCatalogRow is one configured item from the category walk — the
+// wildcard-free src/dst inventory (0v16 §5.2: CATEGORY_LIST then
+// CATEGORY_DETAILS per category; items are TYPE="SOURCE"/"DEST"/... with the
+// routable name in VALUE, §1.8 name-or-ID).
+type cerebrumCatalogRow struct {
+	Kind     string // item TYPE: SOURCE / DEST / SALVO / ...
+	Category string
+	Name     string // item VALUE — routable name
+}
+
+// formatCerebrumCatalogCSV renders the catalog as `kind,category,name` with
+// RFC 4180 quoting, sorted (kind, category, name) for stable diffs.
+func formatCerebrumCatalogCSV(rows []cerebrumCatalogRow) string {
+	sorted := append([]cerebrumCatalogRow(nil), rows...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		if sorted[i].Kind != sorted[j].Kind {
+			return sorted[i].Kind < sorted[j].Kind
+		}
+		if sorted[i].Category != sorted[j].Category {
+			return sorted[i].Category < sorted[j].Category
+		}
+		return sorted[i].Name < sorted[j].Name
+	})
+	var b strings.Builder
+	w := csv.NewWriter(&b)
+	_ = w.Write([]string{"kind", "category", "name"})
+	for _, r := range sorted {
+		_ = w.Write([]string{r.Kind, r.Category, r.Name})
+	}
+	w.Flush()
+	return b.String()
+}
+
 // crossLevelRoute reports whether a routing-snapshot row is a cross-level
 // route (source level differs from the row's dest level). The dest,srce,levels
 // CSV cannot represent those yet, so export skips them LOUDLY, never silently.

--- a/cmd/dhs/cmd_cerebrum_names_test.go
+++ b/cmd/dhs/cmd_cerebrum_names_test.go
@@ -189,6 +189,26 @@ func TestCerebrumImportSetGuardRails(t *testing.T) {
 	}
 }
 
+// TestFormatCerebrumCatalogCSV pins the catalog CSV shape (kind,category,name),
+// its (kind, category, name) ordering, and RFC 4180 quoting for names with
+// commas — the wildcard-free inventory leg from the §5.2 category walk.
+func TestFormatCerebrumCatalogCSV(t *testing.T) {
+	got := formatCerebrumCatalogCSV([]cerebrumCatalogRow{
+		{Kind: "SOURCE", Category: "SRC-V", Name: "EVS-2"},
+		{Kind: "DEST", Category: "DST-V", Name: "MON-1"},
+		{Kind: "SOURCE", Category: "SRC-A", Name: "MIC, boom"},
+		{Kind: "SOURCE", Category: "SRC-V", Name: "EVS-1"},
+	})
+	want := "kind,category,name\n" +
+		"DEST,DST-V,MON-1\n" +
+		"SOURCE,SRC-A,\"MIC, boom\"\n" +
+		"SOURCE,SRC-V,EVS-1\n" +
+		"SOURCE,SRC-V,EVS-2\n"
+	if got != want {
+		t.Errorf("catalog CSV:\n%s\nwant:\n%s", got, want)
+	}
+}
+
 // TestCerebrumExportSetFlags pins export's flag validation offline:
 // --out vs --out-dir exclusivity and the missing-host guard.
 func TestCerebrumExportSetFlags(t *testing.T) {

--- a/cmd/dhs/cmd_cerebrum_xpoint.go
+++ b/cmd/dhs/cmd_cerebrum_xpoint.go
@@ -566,6 +566,29 @@ collect:
 		return nil
 	}
 
+	// Category walk — the wildcard-free src/dst INVENTORY (0v16 §5.2): plain
+	// request/response OBTAINs, one CATEGORY_LIST then one CATEGORY_DETAILS per
+	// category. Enumerates every configured item (TYPE=SOURCE/DEST/... with the
+	// routable name), independent of routing state — a source appears here even
+	// if nothing routes from it. Degrades to an empty catalog with a warning.
+	var catalog []cerebrumCatalogRow
+	if list, lerr := obtainSingleCategoryChange(sess, cf.timeout, &codec.CategoryChange{Type: "CATEGORY_LIST"}, "CATEGORY_LIST"); lerr != nil {
+		fmt.Fprintf(os.Stderr, "cerebrum-nb export: CATEGORY_LIST refused (%v) — catalog CSV will be empty\n", lerr)
+	} else if list != nil && list.Category != nil {
+		for _, cat := range list.Category.Categories {
+			det, derr := obtainSingleCategoryChange(sess, cf.timeout, &codec.CategoryChange{Type: "CATEGORY_DETAILS", Category: cat}, "CATEGORY_DETAILS")
+			if derr != nil || det == nil || det.Category == nil || det.Category.Details == nil {
+				fmt.Fprintf(os.Stderr, "cerebrum-nb export: CATEGORY_DETAILS %q unavailable (%v)\n", cat, derr)
+				continue
+			}
+			for _, it := range det.Category.Details.Items {
+				if it.Value != "" {
+					catalog = append(catalog, cerebrumCatalogRow{Kind: it.Type, Category: cat, Name: it.Value})
+				}
+			}
+		}
+	}
+
 	if err := os.MkdirAll(*outDir, 0o755); err != nil {
 		return err
 	}
@@ -575,6 +598,7 @@ collect:
 		{*prefix + "-src.csv", formatCerebrumMneCSV("srce", dedupeCerebrumMnes(srcSnap))},
 		{*prefix + "-dst.csv", formatCerebrumMneCSV("dest", dedupeCerebrumMnes(dstSnap))},
 		{*prefix + "-level.csv", formatCerebrumMneCSV("level", dedupeCerebrumMnes(lvlSnap))},
+		{*prefix + "-catalog.csv", formatCerebrumCatalogCSV(catalog)},
 		{*prefix + "-xpoint.csv", xpCSV},
 	}
 	for _, f := range files {


### PR DESCRIPTION
The ROUTE snapshot is dest-keyed **state**, not inventory — a source appears once per dest it feeds, and an unrouted source never appears (user review). 0v16 §5.2 provides the inventory read with **no wildcards at all**: OBTAIN `CATEGORY_LIST` → OBTAIN `CATEGORY_DETAILS` per category (plain request/response); items are `TYPE=SOURCE/DEST/...` with the routable name in VALUE (§1.8 name-or-ID).

`export --out-dir` now also writes `<prefix>-catalog.csv` (`kind,category,name`): the configured src/dst catalogue as the operator sees it (NOC: 93 SRC-*/DST-* categories), independent of routing state and of *_MNE wildcard grants. Graceful degrade + unit-pinned CSV shape.

SUBSCRIBE remains watcher-only (`listen`).

Refs #670

🤖 Generated with [Claude Code](https://claude.com/claude-code)