### PR TITLE
feat(cerebrum-nb): list-sources / list-dests / list-levels inventory verbs (one-shot OBTAIN, ID+label)

### DIFF
--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -135,6 +135,12 @@ func runCerebrum(ctx context.Context, args []string) error {
 		return cerebrumRoute(ctx, rest)
 	case "export":
 		return cerebrumExportXpoint(ctx, rest)
+	case "list-sources":
+		return cerebrumListMne(ctx, rest, "SRCE_MNE", "srce")
+	case "list-dests":
+		return cerebrumListMne(ctx, rest, "DEST_MNE", "dest")
+	case "list-levels":
+		return cerebrumListMne(ctx, rest, "LEVEL_MNE", "level")
 	case "import":
 		return cerebrumImportXpoint(ctx, rest)
 	case "lock":
@@ -172,6 +178,9 @@ VERBS
   connect                  POLL (LOGIN auto when --user/--pass set)
   listen                   SUBSCRIBE — routing / category / salvo / device events; Ctrl+C to stop
   route                    ACTION <ROUTING TYPE='ROUTE'/> — single (--dest --srce --level), batch (--route dst:src:lvl), or --csv FILE
+  list-sources             one-shot OBTAIN SRCE_MNE  → every configured source ID + label   [--out FILE]
+  list-dests               one-shot OBTAIN DEST_MNE  → every configured destination ID + label  [--out FILE]
+  list-levels              one-shot OBTAIN LEVEL_MNE → every level ID + name  [--out FILE]
   export                   one-shot OBTAIN wildcards → CSVs. Crosspoints only: [--out FILE]. Full set (src+dst+level mnemonics+xpoint): --out-dir DIR [--prefix P]
   import                   apply CSVs: --xpoint F (dest,srce,levels; --csv alias) + --src/--dst/--levels F (mnemonics, per-ID)  [--check]
   list-devices             OBTAIN <device_change type='LIST'/>  [--device-type Router|SNMP|Device]

--- a/cmd/dhs/cmd_cerebrum_list_mne.go
+++ b/cmd/dhs/cmd_cerebrum_list_mne.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"dhs/internal/cerebrum-nb/codec"
+)
+
+// list-sources / list-dests / list-levels — first-class inventory verbs.
+//
+// Each issues ONE one-shot OBTAIN (0v16 §2.4) of the corresponding *_MNE
+// wildcard row (§5.1.4-§5.1.6) against the route-master and prints every
+// configured ID with its label — the full catalogue a controller needs to
+// make any crosspoint by ID or by name (§1.8). No SUBSCRIBE anywhere: the
+// request ends with the MTID-carrying WILDCARD_COMPLETE (§1.6), with --idle
+// as the quiet-stream fallback.
+//
+//	dhs consumer cerebrum-nb list-sources 10.44.55.39 --port 40009 --user U --pass P
+//	dhs consumer cerebrum-nb list-levels  10.44.55.39 --port 40009 --out levels.csv
+//
+// --out writes the same CSV shape the export set uses (srce|dest|level +
+// mnemonic), so the file feeds straight into `import`.
+func cerebrumListMne(_ context.Context, args []string, mneType, keyCol string) error {
+	args = reorderFlagsFirst(args)
+	fs := flag.NewFlagSet("cerebrum-nb list-"+keyCol, flag.ContinueOnError)
+	cf := newCerebrumFlags(fs)
+	router := fs.String("router", "0.0.0.0", "router IP target (route-master sentinel 0.0.0.0) or a physical Router IP")
+	deviceType := fs.String("device-type", "ROUTER", "route-master device type")
+	idle := fs.Duration("idle", 5*time.Second, "stop collecting this long after the last row if no WILDCARD_COMPLETE arrives")
+	out := fs.String("out", "", "write the list as a CSV here (default: print a table)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	rest := fs.Args()
+	if len(rest) < 1 {
+		return fmt.Errorf("cerebrum-nb list-%s: missing host[:port] argument", keyCol)
+	}
+	host, portArg, err := splitHostPort(rest[0], cf.port)
+	if err != nil {
+		return err
+	}
+	cf.port = portArg
+
+	p, err := cerebrumDial(cf, host)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = p.Disconnect() }()
+	sess := p.Session()
+
+	var mu sync.Mutex
+	var rows []cerebrumMneRow
+	done := make(chan struct{})
+	var once sync.Once
+	tick := make(chan struct{}, 1)
+
+	sess.OnEvent(codec.KindRoutingChange, func(f *codec.Frame) {
+		rc := f.Routing
+		if rc == nil || rc.Type != mneType {
+			return
+		}
+		var id string
+		switch mneType {
+		case "SRCE_MNE":
+			id = rc.SrceID
+		case "DEST_MNE":
+			id = rc.DestID
+		case "LEVEL_MNE":
+			id = rc.LevelID
+		}
+		m := primaryMnemonic(rc)
+		if id == "" || m == "" {
+			return
+		}
+		mu.Lock()
+		rows = append(rows, cerebrumMneRow{ID: id, Mnemonic: m})
+		mu.Unlock()
+		select {
+		case tick <- struct{}{}:
+		default:
+		}
+	})
+	sess.OnEvent(codec.KindWildcardComplete, func(f *codec.Frame) {
+		// Only the MTID-carrying sentinel ends the request (§1.6); live NOC
+		// Cerebrum also emits spurious MTID-less ones per event.
+		if f.MTID == "" {
+			return
+		}
+		once.Do(func() { close(done) })
+	})
+
+	item := &codec.RoutingChange{Type: mneType, IPAddress: *router, DeviceType: codec.DeviceType(*deviceType)}
+	switch mneType {
+	case "SRCE_MNE":
+		item.SrceID = "*"
+	case "DEST_MNE":
+		item.DestID = "*"
+	case "LEVEL_MNE":
+		item.LevelID = "*"
+	}
+	obtCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := sess.Obtain(obtCtx, []codec.SubItem{item}); err != nil {
+		return fmt.Errorf("cerebrum-nb list-%s: %s obtain refused: %w", keyCol, mneType, err)
+	}
+
+	idleTimer := time.NewTimer(*idle)
+	defer idleTimer.Stop()
+collect:
+	for {
+		select {
+		case <-done:
+			break collect
+		case <-tick:
+			if !idleTimer.Stop() {
+				select {
+				case <-idleTimer.C:
+				default:
+				}
+			}
+			idleTimer.Reset(*idle)
+		case <-idleTimer.C:
+			break collect
+		}
+	}
+
+	mu.Lock()
+	list := dedupeCerebrumMnes(rows)
+	mu.Unlock()
+
+	if *out != "" {
+		if err := os.WriteFile(*out, []byte(formatCerebrumMneCSV(keyCol, list)), 0o644); err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "cerebrum-nb list-%s: wrote %d row(s) to %s\n", keyCol, len(list), *out)
+		return nil
+	}
+	fmt.Printf("count %d\n", len(list))
+	for _, r := range list {
+		fmt.Printf("%8s  %s\n", r.ID, r.Mnemonic)
+	}
+	return nil
+}

--- a/cmd/dhs/cmd_cerebrum_names_test.go
+++ b/cmd/dhs/cmd_cerebrum_names_test.go
@@ -189,6 +189,21 @@ func TestCerebrumImportSetGuardRails(t *testing.T) {
 	}
 }
 
+// TestCerebrumListMneRequiresHost pins that the three inventory verbs error
+// before dialling when no host is given (offline guard; the OBTAIN itself is
+// device-gated).
+func TestCerebrumListMneRequiresHost(t *testing.T) {
+	for _, tc := range []struct{ mneType, key string }{
+		{"SRCE_MNE", "srce"},
+		{"DEST_MNE", "dest"},
+		{"LEVEL_MNE", "level"},
+	} {
+		if err := cerebrumListMne(context.Background(), []string{"--idle", "1s"}, tc.mneType, tc.key); err == nil {
+			t.Errorf("list-%s without host: err = nil, want error", tc.key)
+		}
+	}
+}
+
 // TestCerebrumExportSetFlags pins export's flag validation offline:
 // --out vs --out-dir exclusivity and the missing-host guard.
 func TestCerebrumExportSetFlags(t *testing.T) {


### PR DESCRIPTION
First-class inventory verbs per user direction: `list-sources` / `list-dests` / `list-levels`.

Each issues ONE one-shot OBTAIN (0v16 §2.4) of the corresponding *_MNE wildcard row (§5.1.4–§5.1.6) against the route-master and prints every configured **ID + label** — the catalogue a controller needs to make any crosspoint by ID or name (§1.8). No SUBSCRIBE anywhere; ends on the MTID-carrying WILDCARD_COMPLETE (live NOC's spurious MTID-less sentinels ignored), `--idle` fallback. `--out` writes the export-set CSV shape, feeding straight into `import`.

Offline guard tests; live leg device-gated on the NOC Cerebrum (10.44.55.39:40009).

Refs #670

🤖 Generated with [Claude Code](https://claude.com/claude-code)