### PR TITLE
fix(cerebrum-nb): LEVEL_ID wildcard required on SRCE/DEST_MNE obtain filters (live-verified)

### DIFF
--- a/cmd/dhs/cmd_cerebrum_list_mne.go
+++ b/cmd/dhs/cmd_cerebrum_list_mne.go
@@ -94,12 +94,20 @@ func cerebrumListMne(_ context.Context, args []string, mneType, keyCol string) e
 		once.Do(func() { close(done) })
 	})
 
+	// Live NOC Cerebrum (2026-08-15) NACKs 10:ONE_OR_MORE_OBTAINS_INVALID when
+	// LEVEL_ID is absent from the SRCE_MNE / DEST_MNE filter, even though the
+	// spec marks it router-ignored (§5.1.5/§5.1.6): this server requires every
+	// wildcardable attribute to be present. LEVEL_ID="*" is spec-harmless on
+	// routers, so send it always. (Same pattern: ROUTE/DEST_LOCK with
+	// LEVEL_ID="*" were granted; SRCE_LOCK without it was refused.)
 	item := &codec.RoutingChange{Type: mneType, IPAddress: *router, DeviceType: codec.DeviceType(*deviceType)}
 	switch mneType {
 	case "SRCE_MNE":
 		item.SrceID = "*"
+		item.LevelID = "*"
 	case "DEST_MNE":
 		item.DestID = "*"
+		item.LevelID = "*"
 	case "LEVEL_MNE":
 		item.LevelID = "*"
 	}

--- a/cmd/dhs/cmd_cerebrum_xpoint.go
+++ b/cmd/dhs/cmd_cerebrum_xpoint.go
@@ -494,9 +494,11 @@ func cerebrumExportXpoint(ctx context.Context, args []string) error {
 		{"ROUTE", &codec.RoutingChange{Type: "ROUTE", IPAddress: *router, DeviceType: codec.DeviceType(*deviceType), DestID: "*", LevelID: routeLevel}},
 	}
 	if trio {
+		// LEVEL_ID="*" on the MNE filters is REQUIRED by live NOC Cerebrum
+		// (NACK 10 without it, 2026-08-15) and spec-harmless on routers.
 		plan = append(plan,
-			obtainItem{"SRCE_MNE", &codec.RoutingChange{Type: "SRCE_MNE", IPAddress: *router, DeviceType: codec.DeviceType(*deviceType), SrceID: "*"}},
-			obtainItem{"DEST_MNE", &codec.RoutingChange{Type: "DEST_MNE", IPAddress: *router, DeviceType: codec.DeviceType(*deviceType), DestID: "*"}},
+			obtainItem{"SRCE_MNE", &codec.RoutingChange{Type: "SRCE_MNE", IPAddress: *router, DeviceType: codec.DeviceType(*deviceType), SrceID: "*", LevelID: "*"}},
+			obtainItem{"DEST_MNE", &codec.RoutingChange{Type: "DEST_MNE", IPAddress: *router, DeviceType: codec.DeviceType(*deviceType), DestID: "*", LevelID: "*"}},
 			obtainItem{"LEVEL_MNE", &codec.RoutingChange{Type: "LEVEL_MNE", IPAddress: *router, DeviceType: codec.DeviceType(*deviceType), LevelID: "*"}},
 		)
 	}


### PR DESCRIPTION
Live NOC Cerebrum NACKs 10:ONE_OR_MORE_OBTAINS_INVALID when LEVEL_ID is absent from the SRCE_MNE/DEST_MNE OBTAIN filter — this server requires every wildcardable attribute present, though 0v16 marks level router-ignored (§5.1.5/§5.1.6). LEVEL_ID=* is spec-harmless on routers; send it always (list verbs + export).

**USER-VERIFIED live 2026-08-15**: with the fix, list-sources / list-dests / list-levels all return the full ID+label catalogue from the Route Master (levels 14/14).

Refs #670

🤖 Generated with [Claude Code](https://claude.com/claude-code)