### PR TITLE
feat(cerebrum-nb): capability levels on src/dst lists (associations) — shuffle-decision input

### DIFF
--- a/cmd/dhs/cmd_cerebrum_list_mne.go
+++ b/cmd/dhs/cmd_cerebrum_list_mne.go
@@ -77,8 +77,14 @@ func cerebrumListMne(_ context.Context, args []string, mneType, keyCol string) e
 		if id == "" || m == "" {
 			return
 		}
+		row := cerebrumMneRow{ID: id, Mnemonic: m}
+		if mneType != "LEVEL_MNE" {
+			// Capability: which levels this src/dst EXISTS on (associations;
+			// row LEVEL_ID fallback) — the shuffle-decision input.
+			row.Levels = mneLevelsFromChange(rc, id)
+		}
 		mu.Lock()
-		rows = append(rows, cerebrumMneRow{ID: id, Mnemonic: m})
+		rows = append(rows, row)
 		mu.Unlock()
 		select {
 		case tick <- struct{}{}:
@@ -150,7 +156,27 @@ collect:
 	}
 	fmt.Printf("count %d\n", len(list))
 	for _, r := range list {
-		fmt.Printf("%8s  %s\n", r.ID, r.Mnemonic)
+		if mneType == "LEVEL_MNE" {
+			fmt.Printf("%8s  %s\n", r.ID, r.Mnemonic)
+			continue
+		}
+		lv := "-"
+		if len(r.Levels) > 0 {
+			lv = joinSemis(r.Levels)
+		}
+		fmt.Printf("%8s  %-16s  %s\n", r.ID, lv, r.Mnemonic)
 	}
 	return nil
+}
+
+// joinSemis joins level IDs with ';' (the same convention as the xpoint CSV).
+func joinSemis(ids []string) string {
+	out := ""
+	for i, s := range ids {
+		if i > 0 {
+			out += ";"
+		}
+		out += s
+	}
+	return out
 }

--- a/cmd/dhs/cmd_cerebrum_names.go
+++ b/cmd/dhs/cmd_cerebrum_names.go
@@ -173,11 +173,16 @@ func mneLevelsFromChange(rc *codec.RoutingChange, id string) []string {
 		if aid != "" && id != "" && aid != id {
 			continue
 		}
-		if a.RMLevelID != "" {
+		if a.RMLevelID != "" && a.RMLevelID != "*" {
 			out = append(out, a.RMLevelID)
 		}
 	}
-	if len(out) == 0 && rc.LevelID != "" {
+	// Fallback: the row's own LEVEL_ID — but NEVER the literal "*", which is
+	// just our wildcard filter echoed back ("attributes as per TX"). Live NOC
+	// rows without associations (logical resources, e.g. PGM cut-points) echo
+	// "*"; that means "no level binding reported", not "all levels" — leave
+	// the capability empty rather than invent one.
+	if len(out) == 0 && rc.LevelID != "" && rc.LevelID != "*" {
 		out = append(out, rc.LevelID)
 	}
 	return out

--- a/cmd/dhs/cmd_cerebrum_names.go
+++ b/cmd/dhs/cmd_cerebrum_names.go
@@ -26,9 +26,15 @@ import (
 // quoting throughout (mnemonics may contain commas/quotes).
 
 // cerebrumMneRow is one line of a mnemonic CSV: an ID (source, destination or
-// level, per the file's key column) and its primary mnemonic.
+// level, per the file's key column), its primary mnemonic, and — for src/dst
+// rows — the levels the resource EXISTS on (capability, from the §5.1.5/§5.1.6
+// ASSOCIATION children; RM_LEVEL_ID per binding). Capability, not state: the
+// xpoint CSV's levels are the routed ones; these are the routable ones — the
+// input to the straight-route vs cross-level(shuffle) decision (§4.1.1).
+// Renames stay per-ID (the levels column is inventory, never rename scope).
 type cerebrumMneRow struct {
 	ID       string
+	Levels   []string
 	Mnemonic string
 }
 
@@ -59,6 +65,9 @@ func parseCerebrumMneCSV(data []byte, keyCol, srcName string) ([]cerebrumMneRow,
 	if !ok {
 		return nil, fmt.Errorf("%s: missing column \"mnemonic\"", srcName)
 	}
+	// Optional capability column ("levels", ';'-list) on src/dst files. Import
+	// ignores it (renames are per-ID); parse keeps it for round-trip fidelity.
+	lvlCol, hasLevels := idx["levels"]
 	var out []cerebrumMneRow
 	for n, rec := range recs[1:] {
 		if len(rec) <= key || len(rec) <= mne {
@@ -69,7 +78,13 @@ func parseCerebrumMneCSV(data []byte, keyCol, srcName string) ([]cerebrumMneRow,
 		if id == "" || m == "" {
 			return nil, fmt.Errorf("%s row %d: %s and mnemonic are both required", srcName, n+2, keyCol)
 		}
-		out = append(out, cerebrumMneRow{ID: id, Mnemonic: m})
+		row := cerebrumMneRow{ID: id, Mnemonic: m}
+		if hasLevels && len(rec) > lvlCol {
+			if lv := splitLevelCell(rec[lvlCol]); len(lv) > 0 {
+				row.Levels = lv
+			}
+		}
+		out = append(out, row)
 	}
 	return out, nil
 }
@@ -80,18 +95,35 @@ func parseCerebrumMneCSV(data []byte, keyCol, srcName string) ([]cerebrumMneRow,
 // mnemonic) for stable diffs. Conflicting mnemonics for one ID are kept (both
 // rows), so an inconsistency is visible rather than silently resolved.
 func dedupeCerebrumMnes(rows []cerebrumMneRow) []cerebrumMneRow {
-	seen := map[string]bool{}
-	out := make([]cerebrumMneRow, 0, len(rows))
+	type acc struct {
+		row  cerebrumMneRow
+		seen map[string]bool
+	}
+	groups := map[string]*acc{}
+	var order []string
 	for _, r := range rows {
 		if r.ID == "" || r.Mnemonic == "" {
 			continue
 		}
 		k := r.ID + "\x00" + r.Mnemonic
-		if seen[k] {
-			continue
+		g := groups[k]
+		if g == nil {
+			g = &acc{row: cerebrumMneRow{ID: r.ID, Mnemonic: r.Mnemonic}, seen: map[string]bool{}}
+			groups[k] = g
+			order = append(order, k)
 		}
-		seen[k] = true
-		out = append(out, r)
+		// Merge capability levels across per-level snapshot repeats.
+		for _, lvl := range r.Levels {
+			if lvl != "" && !g.seen[lvl] {
+				g.seen[lvl] = true
+				g.row.Levels = append(g.row.Levels, lvl)
+			}
+		}
+	}
+	out := make([]cerebrumMneRow, 0, len(order))
+	for _, k := range order {
+		sortCerebrumIDs(groups[k].row.Levels)
+		out = append(out, groups[k].row)
 	}
 	sort.SliceStable(out, func(i, j int) bool {
 		if c := cmpCerebrumID(out[i].ID, out[j].ID); c != 0 {
@@ -102,17 +134,53 @@ func dedupeCerebrumMnes(rows []cerebrumMneRow) []cerebrumMneRow {
 	return out
 }
 
-// formatCerebrumMneCSV renders rows as `keyCol,mnemonic` with RFC 4180
-// quoting — the exact shape parseCerebrumMneCSV reads back.
+// formatCerebrumMneCSV renders rows with RFC 4180 quoting — the exact shape
+// parseCerebrumMneCSV reads back. src/dst files carry the capability column
+// (`keyCol,levels,mnemonic`); the level file is `level,mnemonic` (a levels
+// column on levels would be meaningless).
 func formatCerebrumMneCSV(keyCol string, rows []cerebrumMneRow) string {
 	var b strings.Builder
 	w := csv.NewWriter(&b)
-	_ = w.Write([]string{keyCol, "mnemonic"})
-	for _, r := range rows {
-		_ = w.Write([]string{r.ID, r.Mnemonic})
+	if keyCol == "level" {
+		_ = w.Write([]string{keyCol, "mnemonic"})
+		for _, r := range rows {
+			_ = w.Write([]string{r.ID, r.Mnemonic})
+		}
+	} else {
+		_ = w.Write([]string{keyCol, "levels", "mnemonic"})
+		for _, r := range rows {
+			_ = w.Write([]string{r.ID, strings.Join(r.Levels, ";"), r.Mnemonic})
+		}
 	}
 	w.Flush()
 	return b.String()
+}
+
+// mneLevelsFromChange extracts the capability levels for the row's resource
+// from a *_MNE routing_change RX: the ASSOCIATION children's RM_LEVEL_ID
+// (filtered to this row's ID when the association names one), plus the row's
+// own LEVEL_ID as fallback. Capability = levels the resource exists on.
+func mneLevelsFromChange(rc *codec.RoutingChange, id string) []string {
+	if rc == nil {
+		return nil
+	}
+	var out []string
+	for _, a := range rc.Associations {
+		aid := a.SrceID
+		if aid == "" {
+			aid = a.DestID
+		}
+		if aid != "" && id != "" && aid != id {
+			continue
+		}
+		if a.RMLevelID != "" {
+			out = append(out, a.RMLevelID)
+		}
+	}
+	if len(out) == 0 && rc.LevelID != "" {
+		out = append(out, rc.LevelID)
+	}
+	return out
 }
 
 // crossLevelRoute reports whether a routing-snapshot row is a cross-level

--- a/cmd/dhs/cmd_cerebrum_names_test.go
+++ b/cmd/dhs/cmd_cerebrum_names_test.go
@@ -256,6 +256,16 @@ func TestMneLevelsFromChange(t *testing.T) {
 	if got := mneLevelsFromChange(&codec.RoutingChange{SrceID: "7", LevelID: "4"}, "7"); !reflect.DeepEqual(got, []string{"4"}) {
 		t.Errorf("fallback = %v, want [4]", got)
 	}
+	// The wildcard echo must never leak into capability: a row with no
+	// associations and LEVEL_ID="*" (our own filter echoed back, live NOC
+	// 2026-08-15) yields NO levels — unknown, not "all".
+	if got := mneLevelsFromChange(&codec.RoutingChange{SrceID: "28576", LevelID: "*"}, "28576"); got != nil {
+		t.Errorf("wildcard echo = %v, want nil", got)
+	}
+	if got := mneLevelsFromChange(&codec.RoutingChange{SrceID: "9", LevelID: "*",
+		Associations: []codec.RoutingAssociation{{SrceID: "9", RMLevelID: "*"}}}, "9"); got != nil {
+		t.Errorf("wildcard assoc = %v, want nil", got)
+	}
 }
 
 // TestCerebrumListMneRequiresHost pins that the three inventory verbs error

--- a/cmd/dhs/cmd_cerebrum_names_test.go
+++ b/cmd/dhs/cmd_cerebrum_names_test.go
@@ -189,6 +189,75 @@ func TestCerebrumImportSetGuardRails(t *testing.T) {
 	}
 }
 
+// TestCerebrumMneCapabilityLevels pins the capability-levels pipeline: parse
+// accepts an optional `levels` column; dedupe MERGES levels across per-level
+// snapshot repeats (numeric order); format writes the levels column for
+// src/dst files but NOT for the level file; empty levels round-trip as empty.
+func TestCerebrumMneCapabilityLevels(t *testing.T) {
+	t.Run("dedupe merges levels", func(t *testing.T) {
+		got := dedupeCerebrumMnes([]cerebrumMneRow{
+			{ID: "5121", Mnemonic: "CAM1", Levels: []string{"2"}},
+			{ID: "5121", Mnemonic: "CAM1", Levels: []string{"1", "2"}},
+			{ID: "5121", Mnemonic: "CAM1", Levels: []string{"12"}},
+		})
+		want := []cerebrumMneRow{{ID: "5121", Mnemonic: "CAM1", Levels: []string{"1", "2", "12"}}}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("dedupe = %+v, want %+v", got, want)
+		}
+	})
+	t.Run("src file carries levels column", func(t *testing.T) {
+		got := formatCerebrumMneCSV("srce", []cerebrumMneRow{{ID: "5121", Mnemonic: "CAM1", Levels: []string{"1", "2", "12"}}})
+		want := "srce,levels,mnemonic\n5121,1;2;12,CAM1\n"
+		if got != want {
+			t.Errorf("src csv = %q, want %q", got, want)
+		}
+	})
+	t.Run("level file has no levels column", func(t *testing.T) {
+		got := formatCerebrumMneCSV("level", []cerebrumMneRow{{ID: "1", Mnemonic: "Video"}})
+		want := "level,mnemonic\n1,Video\n"
+		if got != want {
+			t.Errorf("level csv = %q, want %q", got, want)
+		}
+	})
+	t.Run("levels round-trip", func(t *testing.T) {
+		orig := []cerebrumMneRow{
+			{ID: "5121", Mnemonic: "CAM1", Levels: []string{"1", "2", "12"}},
+			{ID: "5122", Mnemonic: "GFX"}, // no levels -> empty cell -> stays nil
+		}
+		back, err := parseCerebrumMneCSV([]byte(formatCerebrumMneCSV("srce", orig)), "srce", "rt")
+		if err != nil {
+			t.Fatalf("reparse: %v", err)
+		}
+		if !reflect.DeepEqual(back, orig) {
+			t.Errorf("round-trip drifted:\ngot  %+v\nwant %+v", back, orig)
+		}
+	})
+}
+
+// TestMneLevelsFromChange pins capability extraction from a *_MNE RX row:
+// association RM_LEVEL_IDs win (filtered to the row's ID); the row's own
+// LEVEL_ID is the fallback; nil-safe.
+func TestMneLevelsFromChange(t *testing.T) {
+	if got := mneLevelsFromChange(nil, "1"); got != nil {
+		t.Errorf("nil rc = %v, want nil", got)
+	}
+	rc := &codec.RoutingChange{
+		SrceID:  "1",
+		LevelID: "9",
+		Associations: []codec.RoutingAssociation{
+			{SrceID: "1", RMLevelID: "1"},
+			{SrceID: "1", RMLevelID: "12"},
+			{SrceID: "2", RMLevelID: "3"}, // other resource — filtered out
+		},
+	}
+	if got := mneLevelsFromChange(rc, "1"); !reflect.DeepEqual(got, []string{"1", "12"}) {
+		t.Errorf("assoc levels = %v, want [1 12]", got)
+	}
+	if got := mneLevelsFromChange(&codec.RoutingChange{SrceID: "7", LevelID: "4"}, "7"); !reflect.DeepEqual(got, []string{"4"}) {
+		t.Errorf("fallback = %v, want [4]", got)
+	}
+}
+
 // TestCerebrumListMneRequiresHost pins that the three inventory verbs error
 // before dialling when no host is given (offline guard; the OBTAIN itself is
 // device-gated).

--- a/cmd/dhs/cmd_cerebrum_xpoint.go
+++ b/cmd/dhs/cmd_cerebrum_xpoint.go
@@ -448,14 +448,15 @@ func cerebrumExportXpoint(ctx context.Context, args []string) error {
 			}
 			routes = append(routes, routeSpec{Dest: rc.DestID, Srce: rc.RouteSourceID, Level: rc.LevelID})
 		case "SRCE_MNE":
-			// Router mnemonics are per-ID; LEVEL_ID on the row is ignored
-			// (0v16 §5.1.5) and dedupeCerebrumMnes drops per-level repeats.
+			// Mnemonic per-ID (0v16 §5.1.5); Levels = capability from the
+			// ASSOCIATION children (which levels the source exists on);
+			// dedupe merges per-level repeats.
 			if m := primaryMnemonic(rc); m != "" && rc.SrceID != "" {
-				srcMne = append(srcMne, cerebrumMneRow{ID: rc.SrceID, Mnemonic: m})
+				srcMne = append(srcMne, cerebrumMneRow{ID: rc.SrceID, Mnemonic: m, Levels: mneLevelsFromChange(rc, rc.SrceID)})
 			}
 		case "DEST_MNE":
 			if m := primaryMnemonic(rc); m != "" && rc.DestID != "" {
-				dstMne = append(dstMne, cerebrumMneRow{ID: rc.DestID, Mnemonic: m})
+				dstMne = append(dstMne, cerebrumMneRow{ID: rc.DestID, Mnemonic: m, Levels: mneLevelsFromChange(rc, rc.DestID)})
 			}
 		case "LEVEL_MNE":
 			if m := primaryMnemonic(rc); m != "" && rc.LevelID != "" {


### PR DESCRIPTION
Resource lists now show WHICH LEVELS each src/dst exists on (capability) — distinct from the xpoint CSV whose levels are routed state. Data source: §5.1.5/§5.1.6 ASSOCIATION children (RM_LEVEL_ID), already decoded, previously dropped at the CLI.

- `list-sources`/`list-dests`: LEVELS column (`ID  1;2;12  LABEL`); `list-levels` unchanged
- export src/dst CSVs: `srce,levels,mnemonic` / `dest,levels,mnemonic` (level file unchanged); dedupe merges per-level repeats numerically
- `import` ignores the levels column (renames stay per-ID per 0v16)

Enables the straight-route vs cross-level(shuffle) decision before routing (§4.1.1). Probel verb/flag parity preserved.

Refs #670

🤖 Generated with [Claude Code](https://claude.com/claude-code)