### PR TITLE
feat(cerebrum-nb): ensure import + Route-Master snapshot export (ADR-0007)

### DIFF
--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -27,6 +28,7 @@ type cerebrumFlags struct {
 	tls      bool
 	insecure bool
 	debug    bool
+	logPath  string
 	timeout  time.Duration
 }
 
@@ -38,8 +40,45 @@ func newCerebrumFlags(fs *flag.FlagSet) *cerebrumFlags {
 	fs.BoolVar(&c.tls, "tls", false, "use wss:// instead of ws://")
 	fs.BoolVar(&c.insecure, "insecure-skip-verify", false, "with --tls, skip TLS cert verification")
 	fs.BoolVar(&c.debug, "debug", false, "verbose RX/TX XML logging")
+	fs.StringVar(&c.logPath, "log", "", "write the diagnostic log (incl. RX/TX XML at full debug verbosity) to this file — clean UTF-8, no PowerShell 2> stderr wrapping; stderr stays silent")
 	fs.DurationVar(&c.timeout, "timeout", 5*time.Second, "per-request timeout")
 	return c
+}
+
+// newLogger builds the verb logger per flags: --log FILE writes a clean
+// debug-verbosity log to the file (stderr untouched — avoids PowerShell 5.1
+// wrapping redirected native stderr into error records, the "red flag");
+// otherwise stderr at Warn (quiet success) or Debug with --debug. The
+// returned closer is a no-op for stderr.
+func (c *cerebrumFlags) newLogger() (*slog.Logger, func(), error) {
+	if c.logPath != "" {
+		if dir := filepath.Dir(c.logPath); dir != "." {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return nil, nil, fmt.Errorf("--log %s: %w", c.logPath, err)
+			}
+		}
+		f, err := os.Create(c.logPath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("--log %s: %w", c.logPath, err)
+		}
+		return slog.New(slog.NewTextHandler(f, &slog.HandlerOptions{Level: slog.LevelDebug})), func() { _ = f.Close() }, nil
+	}
+	level := slog.LevelWarn // quiet stderr on success (PS 2> flags any stderr as error)
+	if c.debug {
+		level = slog.LevelDebug
+	}
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})), func() {}, nil
+}
+
+// cerebrumWriteFile writes an output file, creating missing parent
+// directories first (so --out captures\x.csv works on a fresh host).
+func cerebrumWriteFile(path string, data []byte) error {
+	if dir := filepath.Dir(path); dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	return os.WriteFile(path, data, 0o644)
 }
 
 // reorderFlagsFirst moves any tokens that look like Go flags (start with
@@ -137,7 +176,7 @@ func runCerebrum(ctx context.Context, args []string) error {
 		return cerebrumExportXpoint(ctx, rest)
 	case "list-sources":
 		return cerebrumListMne(ctx, rest, "SRCE_MNE", "srce")
-	case "list-dests":
+	case "list-dests", "list-destinations":
 		return cerebrumListMne(ctx, rest, "DEST_MNE", "dest")
 	case "list-levels":
 		return cerebrumListMne(ctx, rest, "LEVEL_MNE", "level")
@@ -178,11 +217,11 @@ VERBS
   connect                  POLL (LOGIN auto when --user/--pass set)
   listen                   SUBSCRIBE — routing / category / salvo / device events; Ctrl+C to stop
   route                    ACTION <ROUTING TYPE='ROUTE'/> — single (--dest --srce --level), batch (--route dst:src:lvl), or --csv FILE
-  list-sources             one-shot OBTAIN SRCE_MNE  → every configured source ID + label   [--out FILE]
-  list-dests               one-shot OBTAIN DEST_MNE  → every configured destination ID + label  [--out FILE]
-  list-levels              one-shot OBTAIN LEVEL_MNE → every level ID + name  [--out FILE]
-  export                   one-shot OBTAIN wildcards → CSVs. Crosspoints only: [--out FILE]. Full set (src+dst+level mnemonics+xpoint): --out-dir DIR [--prefix P]
-  import                   apply CSVs: --xpoint F (dest,srce,levels; --csv alias) + --src/--dst/--levels F (mnemonics, per-ID)  [--check]
+  list-sources             one-shot OBTAIN SRCE_MNE  → every source: ID + capability levels + label + alts  [--id N] [--out FILE]
+  list-dests               one-shot OBTAIN DEST_MNE  → same for destinations (alias: list-destinations)     [--id N] [--out FILE]
+  list-levels              one-shot OBTAIN LEVEL_MNE → every level ID + name  [--id N] [--out FILE]
+  export                   one-shot OBTAIN wildcards → CSVs. Crosspoints only: [--out FILE] [--level N]. Full snapshot (src+dst+level mnemonics+xpoint): --out-dir DIR [--prefix P]
+  import                   ENSURE (ADR-0007): read live state, diff vs CSVs, converge only differences. --in-dir DIR [--prefix P] reads the set export wrote (missing files = out of scope), or per-file --xpoint (--csv alias) / --src / --dst / --levels. --check = report would_change, send nothing. --output json = ADR-0007 {changed|would_change, diff[]} on stdout. Empty cell/absent column = untouched; --allow-clear makes an empty MANAGED cell clear the live label. Run-twice = 0.
   list-devices             OBTAIN <device_change type='LIST'/>  [--device-type Router|SNMP|Device]
   device-details           OBTAIN <device_change type='DETAILS'/>  --device IP --device-type DEVICE
   device-value             OBTAIN <device_change type='VALUE'/>    --device NAME --by-name --sub-device X --object Y
@@ -211,7 +250,8 @@ FLAGS (order doesn't matter — flags can come before OR after the host)
   --pass P                  NB password (or $DHS_CEREBRUM_PASS)
   --tls                     use wss:// instead of ws://
   --insecure-skip-verify    with --tls, skip cert validation
-  --debug                   verbose RX/TX XML logging
+  --debug                   verbose RX/TX XML logging (stderr)
+  --log FILE                full debug log incl. RX/TX XML to FILE (clean UTF-8; stderr stays quiet)
   --timeout DUR             per-request timeout (default 5s — fail fast)
 
 EXAMPLES
@@ -246,11 +286,10 @@ func connectAndLogin(args []string, verb string) (*cerebrum.Plugin, *cerebrum.Se
 	}
 	cf.port = portArg
 
-	logLevel := slog.LevelInfo
-	if cf.debug {
-		logLevel = slog.LevelDebug
+	logger, _, lerr := cf.newLogger()
+	if lerr != nil {
+		return nil, nil, nil, nil, lerr
 	}
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel}))
 
 	p := cerebrum.NewPlugin(logger)
 	p.Username = cf.user
@@ -1199,11 +1238,10 @@ func cerebrumRoute(_ context.Context, args []string) error {
 	}
 	cf.port = portArg
 
-	logLevel := slog.LevelInfo
-	if cf.debug {
-		logLevel = slog.LevelDebug
+	logger, _, lerr := cf.newLogger()
+	if lerr != nil {
+		return lerr
 	}
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel}))
 
 	p := cerebrum.NewPlugin(logger)
 	p.Username = cf.user

--- a/cmd/dhs/cmd_cerebrum_list_mne.go
+++ b/cmd/dhs/cmd_cerebrum_list_mne.go
@@ -31,6 +31,8 @@ func cerebrumListMne(_ context.Context, args []string, mneType, keyCol string) e
 	cf := newCerebrumFlags(fs)
 	router := fs.String("router", "0.0.0.0", "router IP target (route-master sentinel 0.0.0.0) or a physical Router IP")
 	deviceType := fs.String("device-type", "ROUTER", "route-master device type")
+	id := fs.String("id", "*", "query ONE resource ID instead of the wildcard (diagnostic single-row OBTAIN)")
+	level := fs.String("level", "*", "LEVEL_ID filter to send (server requires the attribute present; a concrete value is echoed back in the RX row)")
 	idle := fs.Duration("idle", 5*time.Second, "stop collecting this long after the last row if no WILDCARD_COMPLETE arrives")
 	out := fs.String("out", "", "write the list as a CSV here (default: print a table)")
 	if err := fs.Parse(args); err != nil {
@@ -77,11 +79,11 @@ func cerebrumListMne(_ context.Context, args []string, mneType, keyCol string) e
 		if id == "" || m == "" {
 			return
 		}
-		row := cerebrumMneRow{ID: id, Mnemonic: m}
+		row := cerebrumMneRow{ID: id, Mnemonic: m, Alts: altMnemonics(rc)}
 		if mneType != "LEVEL_MNE" {
 			// Capability: which levels this src/dst EXISTS on (associations;
 			// row LEVEL_ID fallback) — the shuffle-decision input.
-			row.Levels = mneLevelsFromChange(rc, id)
+			row.Levels = mneLevelsFromChange(rc)
 		}
 		mu.Lock()
 		rows = append(rows, row)
@@ -109,13 +111,13 @@ func cerebrumListMne(_ context.Context, args []string, mneType, keyCol string) e
 	item := &codec.RoutingChange{Type: mneType, IPAddress: *router, DeviceType: codec.DeviceType(*deviceType)}
 	switch mneType {
 	case "SRCE_MNE":
-		item.SrceID = "*"
-		item.LevelID = "*"
+		item.SrceID = *id
+		item.LevelID = *level
 	case "DEST_MNE":
-		item.DestID = "*"
-		item.LevelID = "*"
+		item.DestID = *id
+		item.LevelID = *level
 	case "LEVEL_MNE":
-		item.LevelID = "*"
+		item.LevelID = *id
 	}
 	obtCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -148,7 +150,7 @@ collect:
 	mu.Unlock()
 
 	if *out != "" {
-		if err := os.WriteFile(*out, []byte(formatCerebrumMneCSV(keyCol, list)), 0o644); err != nil {
+		if err := cerebrumWriteFile(*out, []byte(formatCerebrumMneCSV(keyCol, list))); err != nil {
 			return err
 		}
 		fmt.Fprintf(os.Stderr, "cerebrum-nb list-%s: wrote %d row(s) to %s\n", keyCol, len(list), *out)
@@ -157,14 +159,14 @@ collect:
 	fmt.Printf("count %d\n", len(list))
 	for _, r := range list {
 		if mneType == "LEVEL_MNE" {
-			fmt.Printf("%8s  %s\n", r.ID, r.Mnemonic)
+			fmt.Printf("%8s  %-24s  %s\n", r.ID, r.Mnemonic, formatAlts(r.Alts))
 			continue
 		}
 		lv := "-"
 		if len(r.Levels) > 0 {
 			lv = joinSemis(r.Levels)
 		}
-		fmt.Printf("%8s  %-16s  %s\n", r.ID, lv, r.Mnemonic)
+		fmt.Printf("%8s  %-16s  %-28s  %s\n", r.ID, lv, r.Mnemonic, formatAlts(r.Alts))
 	}
 	return nil
 }

--- a/cmd/dhs/cmd_cerebrum_names.go
+++ b/cmd/dhs/cmd_cerebrum_names.go
@@ -5,6 +5,7 @@ import (
 	"encoding/csv"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"dhs/internal/cerebrum-nb/codec"
@@ -36,22 +37,31 @@ type cerebrumMneRow struct {
 	ID       string
 	Levels   []string
 	Mnemonic string
+	// Alts holds the alternate mnemonic sets (slot -> value, slot >= 1) — the
+	// "levels of labels". RX carries an ALT_MNE_N child only for slots WITH a
+	// value, so presence == used. Slot MEANING is plant config (NOC: 1=Panels,
+	// 2=Ref_Short_Edit, 3=Ref_Long_Edit, 4=Engineer, 5=Ref_Long_Tech); the
+	// wire knows only indexes.
+	Alts map[int]string
 }
 
 // parseCerebrumMneCSV decodes a mnemonic CSV whose key column is keyCol
 // ("srce", "dest" or "level"). Header is case-insensitive and
 // order-independent; '#' comment lines are skipped; quoting per RFC 4180.
-func parseCerebrumMneCSV(data []byte, keyCol, srcName string) ([]cerebrumMneRow, error) {
+// The second return lists the alt_N slots PRESENT IN THE HEADER (sorted) —
+// the managed columns; --allow-clear may only clear cells in managed columns.
+// An empty mnemonic cell is legal (row managed for alts / clear-mode only).
+func parseCerebrumMneCSV(data []byte, keyCol, srcName string) ([]cerebrumMneRow, []int, error) {
 	r := csv.NewReader(bytes.NewReader(data))
 	r.Comment = '#'
 	r.TrimLeadingSpace = true
 	r.FieldsPerRecord = -1
 	recs, err := r.ReadAll()
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w", srcName, err)
+		return nil, nil, fmt.Errorf("%s: %w", srcName, err)
 	}
 	if len(recs) == 0 {
-		return nil, fmt.Errorf("%s: empty (no header)", srcName)
+		return nil, nil, fmt.Errorf("%s: empty (no header)", srcName)
 	}
 	idx := map[string]int{}
 	for i, h := range recs[0] {
@@ -59,34 +69,55 @@ func parseCerebrumMneCSV(data []byte, keyCol, srcName string) ([]cerebrumMneRow,
 	}
 	key, ok := idx[keyCol]
 	if !ok {
-		return nil, fmt.Errorf("%s: missing column %q", srcName, keyCol)
+		return nil, nil, fmt.Errorf("%s: missing column %q", srcName, keyCol)
 	}
 	mne, ok := idx["mnemonic"]
 	if !ok {
-		return nil, fmt.Errorf("%s: missing column \"mnemonic\"", srcName)
+		return nil, nil, fmt.Errorf("%s: missing column \"mnemonic\"", srcName)
 	}
+	var headerSlots []int
+	for h := range idx {
+		if strings.HasPrefix(h, "alt_") {
+			if slot, aerr := strconv.Atoi(h[4:]); aerr == nil && slot >= 1 {
+				headerSlots = append(headerSlots, slot)
+			}
+		}
+	}
+	sort.Ints(headerSlots)
 	// Optional capability column ("levels", ';'-list) on src/dst files. Import
 	// ignores it (renames are per-ID); parse keeps it for round-trip fidelity.
 	lvlCol, hasLevels := idx["levels"]
 	var out []cerebrumMneRow
 	for n, rec := range recs[1:] {
 		if len(rec) <= key || len(rec) <= mne {
-			return nil, fmt.Errorf("%s row %d: too few columns", srcName, n+2)
+			return nil, nil, fmt.Errorf("%s row %d: too few columns", srcName, n+2)
 		}
 		id := strings.TrimSpace(rec[key])
-		m := rec[mne]
-		if id == "" || m == "" {
-			return nil, fmt.Errorf("%s row %d: %s and mnemonic are both required", srcName, n+2, keyCol)
+		if id == "" {
+			return nil, nil, fmt.Errorf("%s row %d: %s is required", srcName, n+2, keyCol)
 		}
-		row := cerebrumMneRow{ID: id, Mnemonic: m}
+		row := cerebrumMneRow{ID: id, Mnemonic: rec[mne]}
 		if hasLevels && len(rec) > lvlCol {
 			if lv := splitLevelCell(rec[lvlCol]); len(lv) > 0 {
 				row.Levels = lv
 			}
 		}
+		for h, col := range idx {
+			if !strings.HasPrefix(h, "alt_") || len(rec) <= col || rec[col] == "" {
+				continue
+			}
+			slot, aerr := strconv.Atoi(h[4:])
+			if aerr != nil || slot < 1 {
+				continue
+			}
+			if row.Alts == nil {
+				row.Alts = map[int]string{}
+			}
+			row.Alts[slot] = rec[col]
+		}
 		out = append(out, row)
 	}
-	return out, nil
+	return out, headerSlots, nil
 }
 
 // dedupeCerebrumMnes drops exact duplicate (ID, mnemonic) rows — the OBTAIN
@@ -119,6 +150,18 @@ func dedupeCerebrumMnes(rows []cerebrumMneRow) []cerebrumMneRow {
 				g.row.Levels = append(g.row.Levels, lvl)
 			}
 		}
+		// Merge alternate mnemonics (first value per slot wins).
+		for slot, v := range r.Alts {
+			if v == "" {
+				continue
+			}
+			if g.row.Alts == nil {
+				g.row.Alts = map[int]string{}
+			}
+			if _, ok := g.row.Alts[slot]; !ok {
+				g.row.Alts[slot] = v
+			}
+		}
 	}
 	out := make([]cerebrumMneRow, 0, len(order))
 	for _, k := range order {
@@ -134,23 +177,56 @@ func dedupeCerebrumMnes(rows []cerebrumMneRow) []cerebrumMneRow {
 	return out
 }
 
+// maxAltSlot returns the highest alternate-mnemonic slot present across rows
+// (0 = none), so the CSV grows exactly the alt_1..alt_N columns the plant uses.
+func maxAltSlot(rows []cerebrumMneRow) int {
+	max := 0
+	for _, r := range rows {
+		for k := range r.Alts {
+			if k > max {
+				max = k
+			}
+		}
+	}
+	return max
+}
+
 // formatCerebrumMneCSV renders rows with RFC 4180 quoting — the exact shape
 // parseCerebrumMneCSV reads back. src/dst files carry the capability column
-// (`keyCol,levels,mnemonic`); the level file is `level,mnemonic` (a levels
-// column on levels would be meaningless).
+// (`keyCol,levels,mnemonic[,alt_1..alt_N]`); the level file is
+// `level,mnemonic[,alt_1..alt_N]` (levels column on levels is meaningless).
+// Alt columns appear only when at least one row uses that slot; empty cell =
+// slot unused on that resource.
 func formatCerebrumMneCSV(keyCol string, rows []cerebrumMneRow) string {
+	return formatCerebrumMneCSVN(keyCol, rows, maxAltSlot(rows))
+}
+
+// formatCerebrumMneCSVN is formatCerebrumMneCSV with an explicit alt-column
+// count — the export uses the plant-wide maximum so src/dst/level files all
+// carry the same alt_1..alt_N headers (an empty column is editable: fill a
+// cell and import converges it).
+func formatCerebrumMneCSVN(keyCol string, rows []cerebrumMneRow, nAlt int) string {
 	var b strings.Builder
 	w := csv.NewWriter(&b)
-	if keyCol == "level" {
-		_ = w.Write([]string{keyCol, "mnemonic"})
-		for _, r := range rows {
-			_ = w.Write([]string{r.ID, r.Mnemonic})
+	hdr := []string{keyCol}
+	if keyCol != "level" {
+		hdr = append(hdr, "levels")
+	}
+	hdr = append(hdr, "mnemonic")
+	for i := 1; i <= nAlt; i++ {
+		hdr = append(hdr, fmt.Sprintf("alt_%d", i))
+	}
+	_ = w.Write(hdr)
+	for _, r := range rows {
+		rec := []string{r.ID}
+		if keyCol != "level" {
+			rec = append(rec, strings.Join(r.Levels, ";"))
 		}
-	} else {
-		_ = w.Write([]string{keyCol, "levels", "mnemonic"})
-		for _, r := range rows {
-			_ = w.Write([]string{r.ID, strings.Join(r.Levels, ";"), r.Mnemonic})
+		rec = append(rec, r.Mnemonic)
+		for i := 1; i <= nAlt; i++ {
+			rec = append(rec, r.Alts[i])
 		}
+		_ = w.Write(rec)
 	}
 	w.Flush()
 	return b.String()
@@ -160,32 +236,45 @@ func formatCerebrumMneCSV(keyCol string, rows []cerebrumMneRow) string {
 // from a *_MNE routing_change RX: the ASSOCIATION children's RM_LEVEL_ID
 // (filtered to this row's ID when the association names one), plus the row's
 // own LEVEL_ID as fallback. Capability = levels the resource exists on.
-func mneLevelsFromChange(rc *codec.RoutingChange, id string) []string {
+func mneLevelsFromChange(rc *codec.RoutingChange) []string {
 	if rc == nil {
 		return nil
 	}
+	// Live NOC wire truth (frames-src.log 2026-08-15, cross-checked against
+	// the Routemaster UI): the ASSOCIATION_n INDEX is the Routemaster level
+	// the binding lives on (ASSOCIATION_1 = level 1/Video: its RM_IP_UID names
+	// the Video sender). RM_LEVEL_ID is the level INSIDE the bound physical
+	// device (0 on single-level SDI/NMOS devices) and the association SRCE_ID/
+	// DEST_ID is the device port UID (e.g. 4026531837) — NEVER the row's
+	// resource ID, so no ID filtering.
 	var out []string
 	for _, a := range rc.Associations {
-		aid := a.SrceID
-		if aid == "" {
-			aid = a.DestID
-		}
-		if aid != "" && id != "" && aid != id {
-			continue
-		}
-		if a.RMLevelID != "" && a.RMLevelID != "*" {
-			out = append(out, a.RMLevelID)
+		if a.Index > 0 {
+			out = append(out, strconv.Itoa(a.Index))
 		}
 	}
 	// Fallback: the row's own LEVEL_ID — but NEVER the literal "*", which is
-	// just our wildcard filter echoed back ("attributes as per TX"). Live NOC
-	// rows without associations (logical resources, e.g. PGM cut-points) echo
-	// "*"; that means "no level binding reported", not "all levels" — leave
-	// the capability empty rather than invent one.
+	// just our wildcard filter echoed back ("attributes as per TX"). No
+	// associations and no concrete level = no binding reported: leave the
+	// capability empty rather than invent one.
 	if len(out) == 0 && rc.LevelID != "" && rc.LevelID != "*" {
 		out = append(out, rc.LevelID)
 	}
 	return out
+}
+
+// cerebrumNoRouteSentinel reports whether a ROUTE child's SOURCE_ID is one of
+// the live NOC's undocumented "no route" markers rather than a real source
+// (frames-xp.log 2026-08-15, 178,584 cells): "0" (12,248x, with
+// SOURCE_LEVEL_ID=0), "4294967294" (0xFFFFFFFE, 164,093x = disconnected) and
+// "4294967295" (0xFFFFFFFF, 474x). Only 1,769 cells carried real sources.
+// Cells with a sentinel are unrouted: no CSV row, no warning.
+func cerebrumNoRouteSentinel(sourceID string) bool {
+	switch sourceID {
+	case "", "0", "4294967294", "4294967295":
+		return true
+	}
+	return false
 }
 
 // crossLevelRoute reports whether a routing-snapshot row is a cross-level
@@ -206,4 +295,40 @@ func primaryMnemonic(rc *codec.RoutingChange) string {
 		return m
 	}
 	return rc.Mnemonic
+}
+
+// altMnemonics extracts the alternate sets (slot >= 1) from a *_MNE RX row —
+// nil when the resource uses none.
+func altMnemonics(rc *codec.RoutingChange) map[int]string {
+	if rc == nil {
+		return nil
+	}
+	var out map[int]string
+	for slot, v := range rc.Mnemonics {
+		if slot >= 1 && v != "" {
+			if out == nil {
+				out = map[int]string{}
+			}
+			out[slot] = v
+		}
+	}
+	return out
+}
+
+// formatAlts renders a compact used-slots view for table output, e.g.
+// "1=Black 4=ENG" — "-" when no alternate is set.
+func formatAlts(alts map[int]string) string {
+	if len(alts) == 0 {
+		return "-"
+	}
+	slots := make([]int, 0, len(alts))
+	for k := range alts {
+		slots = append(slots, k)
+	}
+	sort.Ints(slots)
+	parts := make([]string, 0, len(slots))
+	for _, s := range slots {
+		parts = append(parts, fmt.Sprintf("%d=%s", s, alts[s]))
+	}
+	return strings.Join(parts, " ")
 }

--- a/cmd/dhs/cmd_cerebrum_names_test.go
+++ b/cmd/dhs/cmd_cerebrum_names_test.go
@@ -21,7 +21,7 @@ func TestParseCerebrumMneCSV(t *testing.T) {
 			"# names\n" +
 			"5121,\"CAM 1, main\"\n" +
 			"5122,CAM2\n"
-		rows, err := parseCerebrumMneCSV([]byte(csv), "srce", "t.csv")
+		rows, _, err := parseCerebrumMneCSV([]byte(csv), "srce", "t.csv")
 		if err != nil {
 			t.Fatalf("parse: %v", err)
 		}
@@ -35,7 +35,7 @@ func TestParseCerebrumMneCSV(t *testing.T) {
 	})
 
 	t.Run("dest key, reordered columns", func(t *testing.T) {
-		rows, err := parseCerebrumMneCSV([]byte("mnemonic,dest\nMON1,5123\n"), "dest", "t.csv")
+		rows, _, err := parseCerebrumMneCSV([]byte("mnemonic,dest\nMON1,5123\n"), "dest", "t.csv")
 		if err != nil {
 			t.Fatalf("parse: %v", err)
 		}
@@ -45,7 +45,7 @@ func TestParseCerebrumMneCSV(t *testing.T) {
 	})
 
 	t.Run("level key", func(t *testing.T) {
-		rows, err := parseCerebrumMneCSV([]byte("level,mnemonic\n1,LVL-1\n2,LVL-2\n"), "level", "t.csv")
+		rows, _, err := parseCerebrumMneCSV([]byte("level,mnemonic\n1,LVL-1\n2,LVL-2\n"), "level", "t.csv")
 		if err != nil {
 			t.Fatalf("parse: %v", err)
 		}
@@ -61,7 +61,7 @@ func TestParseCerebrumMneCSV(t *testing.T) {
 		{"blank fields", "srce,mnemonic\n,\n", "srce"},
 	} {
 		t.Run("error: "+tc.name, func(t *testing.T) {
-			if _, err := parseCerebrumMneCSV([]byte(tc.csv), tc.key, "t.csv"); err == nil {
+			if _, _, err := parseCerebrumMneCSV([]byte(tc.csv), tc.key, "t.csv"); err == nil {
 				t.Errorf("parse %q: err = nil, want error", tc.csv)
 			}
 		})
@@ -98,12 +98,86 @@ func TestCerebrumMneCSVRoundTrip(t *testing.T) {
 		{ID: "5122", Mnemonic: "plain"},
 	}
 	csv := formatCerebrumMneCSV("srce", orig)
-	back, err := parseCerebrumMneCSV([]byte(csv), "srce", "roundtrip")
+	back, _, err := parseCerebrumMneCSV([]byte(csv), "srce", "roundtrip")
 	if err != nil {
 		t.Fatalf("reparse: %v\n%s", err, csv)
 	}
 	if !reflect.DeepEqual(back, orig) {
 		t.Errorf("round-trip drifted:\ngot  %+v\nwant %+v\ncsv:\n%s", back, orig, csv)
+	}
+}
+
+// TestCerebrumAltMnemonics pins the alternate-label pipeline: extraction from
+// the RX slot map (slot>=1 only), dynamic alt_N CSV columns sized to the
+// highest used slot, byte-stable round-trip, dedupe slot-merge, and the
+// compact table rendering.
+func TestCerebrumAltMnemonics(t *testing.T) {
+	t.Run("extract slots >= 1", func(t *testing.T) {
+		got := altMnemonics(&codec.RoutingChange{Mnemonics: map[int]string{0: "PRIMARY", 1: "Black", 4: "ENG"}})
+		if !reflect.DeepEqual(got, map[int]string{1: "Black", 4: "ENG"}) {
+			t.Errorf("alts = %v", got)
+		}
+		if altMnemonics(nil) != nil || altMnemonics(&codec.RoutingChange{}) != nil {
+			t.Error("nil/empty rc must yield nil alts")
+		}
+	})
+	t.Run("csv columns + round-trip", func(t *testing.T) {
+		rows := []cerebrumMneRow{
+			{ID: "11", Levels: []string{"1", "2"}, Mnemonic: "SRC-A", Alts: map[int]string{1: "Black", 4: "ENG, x"}},
+			{ID: "12", Levels: []string{"1"}, Mnemonic: "SRC-B"},
+		}
+		csvText := formatCerebrumMneCSV("srce", rows)
+		wantHdr := "srce,levels,mnemonic,alt_1,alt_2,alt_3,alt_4\n"
+		if !strings.HasPrefix(csvText, wantHdr) {
+			t.Fatalf("header = %q, want prefix %q", csvText[:60], wantHdr)
+		}
+		back, _, err := parseCerebrumMneCSV([]byte(csvText), "srce", "rt")
+		if err != nil {
+			t.Fatalf("reparse: %v", err)
+		}
+		if !reflect.DeepEqual(back, rows) {
+			t.Errorf("round-trip drifted:\ngot  %+v\nwant %+v", back, rows)
+		}
+	})
+	t.Run("no alts -> no alt columns", func(t *testing.T) {
+		csvText := formatCerebrumMneCSV("srce", []cerebrumMneRow{{ID: "1", Mnemonic: "X"}})
+		if !strings.HasPrefix(csvText, "srce,levels,mnemonic\n") {
+			t.Errorf("unexpected header: %q", csvText)
+		}
+	})
+	t.Run("dedupe merges slots", func(t *testing.T) {
+		got := dedupeCerebrumMnes([]cerebrumMneRow{
+			{ID: "11", Mnemonic: "A", Alts: map[int]string{1: "Black"}},
+			{ID: "11", Mnemonic: "A", Alts: map[int]string{4: "ENG"}},
+		})
+		want := []cerebrumMneRow{{ID: "11", Mnemonic: "A", Alts: map[int]string{1: "Black", 4: "ENG"}}}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("dedupe = %+v, want %+v", got, want)
+		}
+	})
+	t.Run("table rendering", func(t *testing.T) {
+		if got := formatAlts(map[int]string{4: "ENG", 1: "Black"}); got != "1=Black 4=ENG" {
+			t.Errorf("formatAlts = %q", got)
+		}
+		if got := formatAlts(nil); got != "-" {
+			t.Errorf("formatAlts(nil) = %q", got)
+		}
+	})
+}
+
+// TestCerebrumNoRouteSentinel pins the live-wire "no route" markers (NOC
+// 2026-08-15): 0, 0xFFFFFFFE, 0xFFFFFFFF and empty are unrouted cells; real
+// source IDs are not.
+func TestCerebrumNoRouteSentinel(t *testing.T) {
+	for _, s := range []string{"", "0", "4294967294", "4294967295"} {
+		if !cerebrumNoRouteSentinel(s) {
+			t.Errorf("sentinel %q not detected", s)
+		}
+	}
+	for _, s := range []string{"1", "11", "9191", "28576"} {
+		if cerebrumNoRouteSentinel(s) {
+			t.Errorf("real source %q misclassified as sentinel", s)
+		}
 	}
 }
 
@@ -141,28 +215,26 @@ func TestPrimaryMnemonic(t *testing.T) {
 	}
 }
 
-// TestCerebrumImportSetCheckOffline pins that `import --check` with all four
-// files is a pure offline dry-run covering routes + src/dst/level mnemonics.
-func TestCerebrumImportSetCheckOffline(t *testing.T) {
+// TestCerebrumImportCheckNeedsHost pins the ENSURE contract (ADR-0007):
+// `--check` reads live state to compute would_change, so it requires the
+// host — a check without one errors, mentioning live state, and the error
+// arrives only AFTER all files parsed cleanly (parse-before-wire).
+func TestCerebrumImportCheckNeedsHost(t *testing.T) {
 	dir := t.TempDir()
 	xp := filepath.Join(dir, "x.csv")
 	src := filepath.Join(dir, "s.csv")
-	dst := filepath.Join(dir, "d.csv")
-	lvl := filepath.Join(dir, "l.csv")
 	if err := os.WriteFile(xp, []byte("dest,srce,levels\n5123,5121,1;2\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(src, []byte("srce,mnemonic\n5121,CAM1\n"), 0o644); err != nil {
+	if err := os.WriteFile(src, []byte("srce,mnemonic,alt_1\n5121,CAM1,Black\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(dst, []byte("dest,mnemonic\n5123,MON1\n"), 0o644); err != nil {
-		t.Fatal(err)
+	err := cerebrumImportXpoint(context.Background(), []string{"--xpoint", xp, "--src", src, "--check"})
+	if err == nil {
+		t.Fatal("--check without host: err = nil, want error (ensure needs live state)")
 	}
-	if err := os.WriteFile(lvl, []byte("level,mnemonic\n1,LVL-1\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := cerebrumImportXpoint(context.Background(), []string{"--xpoint", xp, "--src", src, "--dst", dst, "--levels", lvl, "--check"}); err != nil {
-		t.Fatalf("set --check offline: err = %v, want nil", err)
+	if !strings.Contains(err.Error(), "live state") {
+		t.Errorf("error should explain the live-state requirement, got: %v", err)
 	}
 }
 
@@ -224,7 +296,7 @@ func TestCerebrumMneCapabilityLevels(t *testing.T) {
 			{ID: "5121", Mnemonic: "CAM1", Levels: []string{"1", "2", "12"}},
 			{ID: "5122", Mnemonic: "GFX"}, // no levels -> empty cell -> stays nil
 		}
-		back, err := parseCerebrumMneCSV([]byte(formatCerebrumMneCSV("srce", orig)), "srce", "rt")
+		back, _, err := parseCerebrumMneCSV([]byte(formatCerebrumMneCSV("srce", orig)), "srce", "rt")
 		if err != nil {
 			t.Fatalf("reparse: %v", err)
 		}
@@ -234,37 +306,36 @@ func TestCerebrumMneCapabilityLevels(t *testing.T) {
 	})
 }
 
-// TestMneLevelsFromChange pins capability extraction from a *_MNE RX row:
-// association RM_LEVEL_IDs win (filtered to the row's ID); the row's own
-// LEVEL_ID is the fallback; nil-safe.
+// TestMneLevelsFromChange pins capability extraction from a *_MNE RX row —
+// LIVE-WIRE semantics (NOC frames-src.log 2026-08-15, cross-checked against
+// the Routemaster UI): the ASSOCIATION_n INDEX is the Routemaster level; the
+// association SRCE_ID is a device port UID (never the row's resource ID, so
+// no filtering); RM_LEVEL_ID is the level inside the physical device and is
+// NOT used. Row LEVEL_ID is the fallback, except the "*" wildcard echo.
 func TestMneLevelsFromChange(t *testing.T) {
-	if got := mneLevelsFromChange(nil, "1"); got != nil {
+	if got := mneLevelsFromChange(nil); got != nil {
 		t.Errorf("nil rc = %v, want nil", got)
 	}
+	// Live shape: port-UID SRCE_ID, RM_LEVEL_ID=0, index = RM level.
 	rc := &codec.RoutingChange{
-		SrceID:  "1",
-		LevelID: "9",
+		SrceID:  "11",
+		LevelID: "*",
 		Associations: []codec.RoutingAssociation{
-			{SrceID: "1", RMLevelID: "1"},
-			{SrceID: "1", RMLevelID: "12"},
-			{SrceID: "2", RMLevelID: "3"}, // other resource — filtered out
+			{Index: 1, SrceID: "4026531837", RMLevelID: "0"},
+			{Index: 2, SrceID: "4026531837", RMLevelID: "0"},
+			{Index: 3, SrceID: "4026531837", RMLevelID: "0"},
 		},
 	}
-	if got := mneLevelsFromChange(rc, "1"); !reflect.DeepEqual(got, []string{"1", "12"}) {
-		t.Errorf("assoc levels = %v, want [1 12]", got)
+	if got := mneLevelsFromChange(rc); !reflect.DeepEqual(got, []string{"1", "2", "3"}) {
+		t.Errorf("assoc index levels = %v, want [1 2 3]", got)
 	}
-	if got := mneLevelsFromChange(&codec.RoutingChange{SrceID: "7", LevelID: "4"}, "7"); !reflect.DeepEqual(got, []string{"4"}) {
+	if got := mneLevelsFromChange(&codec.RoutingChange{SrceID: "7", LevelID: "4"}); !reflect.DeepEqual(got, []string{"4"}) {
 		t.Errorf("fallback = %v, want [4]", got)
 	}
-	// The wildcard echo must never leak into capability: a row with no
-	// associations and LEVEL_ID="*" (our own filter echoed back, live NOC
-	// 2026-08-15) yields NO levels — unknown, not "all".
-	if got := mneLevelsFromChange(&codec.RoutingChange{SrceID: "28576", LevelID: "*"}, "28576"); got != nil {
+	// The wildcard echo must never leak into capability: no associations and
+	// LEVEL_ID="*" (our own filter echoed back) yields NO levels.
+	if got := mneLevelsFromChange(&codec.RoutingChange{SrceID: "28576", LevelID: "*"}); got != nil {
 		t.Errorf("wildcard echo = %v, want nil", got)
-	}
-	if got := mneLevelsFromChange(&codec.RoutingChange{SrceID: "9", LevelID: "*",
-		Associations: []codec.RoutingAssociation{{SrceID: "9", RMLevelID: "*"}}}, "9"); got != nil {
-		t.Errorf("wildcard assoc = %v, want nil", got)
 	}
 }
 

--- a/cmd/dhs/cmd_cerebrum_state.go
+++ b/cmd/dhs/cmd_cerebrum_state.go
@@ -1,0 +1,290 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"dhs/internal/cerebrum-nb/codec"
+	cerebrum "dhs/internal/cerebrum-nb/consumer"
+)
+
+// Shared live-state collection + ensure diffing for the cerebrum-nb
+// export/import pair. Everything here is OBTAIN-based (0v16 §2.4 one-shot
+// request/response — SUBSCRIBE stays watcher-only in `listen`).
+
+// cerebrumStateWant selects which snapshots to OBTAIN.
+type cerebrumStateWant struct {
+	Routes     bool
+	RouteLevel string // crosspoint read restricted to one level; "" = all ("*")
+	SrcMne     bool
+	DstMne     bool
+	LvlMne     bool
+	// StrictMne: a refused *_MNE obtain is an error (import needs live state
+	// to diff against) instead of a warn-and-empty (export's degrade).
+	StrictMne bool
+	Verb      string // message prefix: "export" / "import"
+}
+
+// cerebrumState is the raw collected snapshot (un-deduped, un-collapsed).
+type cerebrumState struct {
+	Routes     []routeSpec
+	Src        []cerebrumMneRow
+	Dst        []cerebrumMneRow
+	Lvl        []cerebrumMneRow
+	CrossLevel int // routes skipped: SRCE_LEVEL != DEST_LEVEL (shuffle parked)
+}
+
+// cerebrumObtainState issues one-shot OBTAINs (one per row kind so a NACK on
+// one cannot sink the others), collects RX rows until every granted request
+// delivered its MTID-carrying WILDCARD_COMPLETE (live NOC also emits spurious
+// MTID-less ones — ignored), with idle as the quiet-stream fallback.
+func cerebrumObtainState(ctx context.Context, sess *cerebrum.Session, router, deviceType string, idle time.Duration, want cerebrumStateWant) (*cerebrumState, error) {
+	var mu sync.Mutex
+	st := &cerebrumState{}
+	completes := 0
+	tick := make(chan struct{}, 1)
+	kick := func() {
+		select {
+		case tick <- struct{}{}:
+		default:
+		}
+	}
+
+	sess.OnEvent(codec.KindRoutingChange, func(f *codec.Frame) {
+		rc := f.Routing
+		if rc == nil {
+			return
+		}
+		mu.Lock()
+		switch rc.Type {
+		case "ROUTE":
+			// Undocumented live-wire sentinels (0 / 0xFFFFFFFE / 0xFFFFFFFF)
+			// mean "cell unrouted" — not a route, not a warning.
+			if cerebrumNoRouteSentinel(rc.RouteSourceID) {
+				break
+			}
+			if crossLevelRoute(rc.LevelID, rc.RouteSourceLevelID) {
+				st.CrossLevel++
+				break
+			}
+			st.Routes = append(st.Routes, routeSpec{Dest: rc.DestID, Srce: rc.RouteSourceID, Level: rc.LevelID})
+		case "SRCE_MNE":
+			if m := primaryMnemonic(rc); m != "" && rc.SrceID != "" {
+				st.Src = append(st.Src, cerebrumMneRow{ID: rc.SrceID, Mnemonic: m, Levels: mneLevelsFromChange(rc), Alts: altMnemonics(rc)})
+			}
+		case "DEST_MNE":
+			if m := primaryMnemonic(rc); m != "" && rc.DestID != "" {
+				st.Dst = append(st.Dst, cerebrumMneRow{ID: rc.DestID, Mnemonic: m, Levels: mneLevelsFromChange(rc), Alts: altMnemonics(rc)})
+			}
+		case "LEVEL_MNE":
+			if m := primaryMnemonic(rc); m != "" && rc.LevelID != "" {
+				st.Lvl = append(st.Lvl, cerebrumMneRow{ID: rc.LevelID, Mnemonic: m, Alts: altMnemonics(rc)})
+			}
+		}
+		mu.Unlock()
+		kick()
+	})
+	sess.OnEvent(codec.KindWildcardComplete, func(f *codec.Frame) {
+		if f.MTID == "" { // spurious per-event sentinel (live NOC deviation)
+			return
+		}
+		mu.Lock()
+		completes++
+		mu.Unlock()
+		kick()
+	})
+
+	type obtainItem struct {
+		name string
+		item codec.SubItem
+	}
+	var plan []obtainItem
+	if want.Routes {
+		lvl := want.RouteLevel
+		if lvl == "" {
+			lvl = "*"
+		}
+		plan = append(plan, obtainItem{"ROUTE", &codec.RoutingChange{Type: "ROUTE", IPAddress: router, DeviceType: codec.DeviceType(deviceType), DestID: "*", LevelID: lvl}})
+	}
+	// LEVEL_ID="*" on the MNE filters is REQUIRED by live NOC Cerebrum
+	// (NACK 10 without it, 2026-08-15) and spec-harmless on routers.
+	if want.SrcMne {
+		plan = append(plan, obtainItem{"SRCE_MNE", &codec.RoutingChange{Type: "SRCE_MNE", IPAddress: router, DeviceType: codec.DeviceType(deviceType), SrceID: "*", LevelID: "*"}})
+	}
+	if want.DstMne {
+		plan = append(plan, obtainItem{"DEST_MNE", &codec.RoutingChange{Type: "DEST_MNE", IPAddress: router, DeviceType: codec.DeviceType(deviceType), DestID: "*", LevelID: "*"}})
+	}
+	if want.LvlMne {
+		plan = append(plan, obtainItem{"LEVEL_MNE", &codec.RoutingChange{Type: "LEVEL_MNE", IPAddress: router, DeviceType: codec.DeviceType(deviceType), LevelID: "*"}})
+	}
+	if len(plan) == 0 {
+		return st, nil
+	}
+
+	obtCtx, obtCancel := context.WithCancel(context.Background())
+	defer obtCancel()
+	okSubs := 0
+	for _, s := range plan {
+		if err := sess.Obtain(obtCtx, []codec.SubItem{s.item}); err != nil {
+			if s.name == "ROUTE" || want.StrictMne {
+				return nil, fmt.Errorf("cerebrum-nb %s: %s obtain failed: %w", want.Verb, s.name, err)
+			}
+			fmt.Fprintf(os.Stderr, "cerebrum-nb %s: %s obtain refused (%v) — %s CSV will be empty\n", want.Verb, s.name, err, strings.ToLower(s.name))
+			continue
+		}
+		okSubs++
+	}
+
+	idleTimer := time.NewTimer(idle)
+	defer idleTimer.Stop()
+collect:
+	for {
+		mu.Lock()
+		doneAll := okSubs > 0 && completes >= okSubs
+		mu.Unlock()
+		if doneAll {
+			break collect
+		}
+		select {
+		case <-tick:
+			if !idleTimer.Stop() {
+				select {
+				case <-idleTimer.C:
+				default:
+				}
+			}
+			idleTimer.Reset(idle)
+		case <-idleTimer.C:
+			break collect
+		case <-ctx.Done():
+			break collect
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	out := &cerebrumState{
+		Routes:     append([]routeSpec(nil), st.Routes...),
+		Src:        append([]cerebrumMneRow(nil), st.Src...),
+		Dst:        append([]cerebrumMneRow(nil), st.Dst...),
+		Lvl:        append([]cerebrumMneRow(nil), st.Lvl...),
+		CrossLevel: st.CrossLevel,
+	}
+	return out, nil
+}
+
+// ---------------------------------------------------------------------------
+// Ensure diffing (ADR-0007): desired CSV vs live snapshot -> minimal changes.
+// ---------------------------------------------------------------------------
+
+// cerebrumMneChange is one label cell to converge: slot 0 = primary mnemonic,
+// slot >= 1 = alternate set N (NOC: 1=Panels, 2=Ref_Short_Edit, ...).
+type cerebrumMneChange struct {
+	Kind string // SRCE_MNE / DEST_MNE / LEVEL_MNE
+	ID   string
+	Slot int
+	From string // live value ("" = unset)
+	To   string
+}
+
+// diffCerebrumMnemonics computes the label cells whose desired (non-empty)
+// value differs from live. Empty desired cells and absent columns are NEVER
+// changes by default (empty = unmanaged, not "clear"); resources absent from
+// the CSV are untouched. With allowClear, an EMPTY cell in a MANAGED column
+// (headerSlots; the primary column is always managed) whose live value is set
+// becomes a clear-write (To: ""). Deterministic order: numeric ID, then slot.
+func diffCerebrumMnemonics(kind string, live, desired []cerebrumMneRow, headerSlots []int, allowClear bool) []cerebrumMneChange {
+	cur := map[string]cerebrumMneRow{}
+	for _, r := range dedupeCerebrumMnes(live) {
+		if _, dup := cur[r.ID]; !dup {
+			cur[r.ID] = r
+		}
+	}
+	var out []cerebrumMneChange
+	for _, d := range desired {
+		lv := cur[d.ID]
+		if d.Mnemonic != "" && d.Mnemonic != lv.Mnemonic {
+			out = append(out, cerebrumMneChange{Kind: kind, ID: d.ID, Slot: 0, From: lv.Mnemonic, To: d.Mnemonic})
+		} else if allowClear && d.Mnemonic == "" && lv.Mnemonic != "" {
+			out = append(out, cerebrumMneChange{Kind: kind, ID: d.ID, Slot: 0, From: lv.Mnemonic, To: ""})
+		}
+		// Managed alt slots: the row's own values plus (in clear mode) every
+		// header column, so an empty managed cell can clear.
+		slotSet := map[int]bool{}
+		for s := range d.Alts {
+			slotSet[s] = true
+		}
+		if allowClear {
+			for _, s := range headerSlots {
+				slotSet[s] = true
+			}
+		}
+		slots := make([]int, 0, len(slotSet))
+		for s := range slotSet {
+			slots = append(slots, s)
+		}
+		sort.Ints(slots)
+		for _, s := range slots {
+			want := d.Alts[s]
+			var have string
+			if lv.Alts != nil {
+				have = lv.Alts[s]
+			}
+			switch {
+			case want != "" && want != have:
+				out = append(out, cerebrumMneChange{Kind: kind, ID: d.ID, Slot: s, From: have, To: want})
+			case want == "" && allowClear && have != "":
+				out = append(out, cerebrumMneChange{Kind: kind, ID: d.ID, Slot: s, From: have, To: ""})
+			}
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if c := cmpCerebrumID(out[i].ID, out[j].ID); c != 0 {
+			return c < 0
+		}
+		return out[i].Slot < out[j].Slot
+	})
+	return out
+}
+
+// diffCerebrumRoutes computes the crosspoint cells (dest, level) whose desired
+// source differs from live. Cells absent from the CSV are untouched (the
+// import never disconnects). From carries the live source ("" = unrouted).
+type cerebrumRouteChange struct {
+	Dest, Level, From, To string
+}
+
+func diffCerebrumRoutes(live, desired []routeSpec) []cerebrumRouteChange {
+	cur := map[string]string{} // dest\x00level -> src
+	for _, r := range live {
+		cur[r.Dest+"\x00"+r.Level] = r.Srce
+	}
+	var out []cerebrumRouteChange
+	for _, d := range desired {
+		if have := cur[d.Dest+"\x00"+d.Level]; have != d.Srce {
+			out = append(out, cerebrumRouteChange{Dest: d.Dest, Level: d.Level, From: have, To: d.Srce})
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if c := cmpCerebrumID(out[i].Dest, out[j].Dest); c != 0 {
+			return c < 0
+		}
+		return cmpCerebrumID(out[i].Level, out[j].Level) < 0
+	})
+	return out
+}
+
+// altSlotArg renders a change's slot for Session.SetMnemonic: primary = "",
+// alternate = its index.
+func altSlotArg(slot int) string {
+	if slot <= 0 {
+		return ""
+	}
+	return strconv.Itoa(slot)
+}

--- a/cmd/dhs/cmd_cerebrum_state_test.go
+++ b/cmd/dhs/cmd_cerebrum_state_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestDiffCerebrumMnemonics pins the label ensure-diff (ADR-0007): only
+// non-empty desired cells that differ from live become changes; empty cells
+// and resources absent from the CSV are never touched; slot 0 = primary,
+// slots >= 1 = alternates; deterministic (ID, slot) order.
+func TestDiffCerebrumMnemonics(t *testing.T) {
+	live := []cerebrumMneRow{
+		{ID: "11", Mnemonic: "SRC-A", Alts: map[int]string{1: "Black"}},
+		{ID: "12", Mnemonic: "SRC-B"},
+		{ID: "13", Mnemonic: "SRC-C", Alts: map[int]string{1: "Mire-3"}},
+	}
+	desired := []cerebrumMneRow{
+		{ID: "11", Mnemonic: "SRC-A", Alts: map[int]string{1: "Cam-A", 4: "ENG"}}, // alt1 rename + alt4 new
+		{ID: "12", Mnemonic: "SRC-B2"},                                            // primary rename
+		{ID: "13", Mnemonic: "SRC-C", Alts: map[int]string{1: "Mire-3"}},          // identical -> no change
+		{ID: "99", Mnemonic: "NEW"},                                               // live row absent -> set from ""
+	}
+	got := diffCerebrumMnemonics("SRCE_MNE", live, desired, nil, false)
+	want := []cerebrumMneChange{
+		{Kind: "SRCE_MNE", ID: "11", Slot: 1, From: "Black", To: "Cam-A"},
+		{Kind: "SRCE_MNE", ID: "11", Slot: 4, From: "", To: "ENG"},
+		{Kind: "SRCE_MNE", ID: "12", Slot: 0, From: "SRC-B", To: "SRC-B2"},
+		{Kind: "SRCE_MNE", ID: "99", Slot: 0, From: "", To: "NEW"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("diff:\ngot  %+v\nwant %+v", got, want)
+	}
+
+	// Empty desired cells never clear: live has alt_1, desired row carries no
+	// alts and empty primary -> zero changes.
+	got = diffCerebrumMnemonics("SRCE_MNE", live, []cerebrumMneRow{{ID: "11", Mnemonic: ""}}, nil, false)
+	if len(got) != 0 {
+		t.Errorf("empty desired cells must be ignored, got %+v", got)
+	}
+
+	// --allow-clear: an empty managed cell whose live value is set becomes a
+	// clear-write (To: ""), for the primary and for header-managed alt slots.
+	clr := diffCerebrumMnemonics("SRCE_MNE", live, []cerebrumMneRow{{ID: "11", Mnemonic: ""}}, []int{1}, true)
+	wantClr := []cerebrumMneChange{
+		{Kind: "SRCE_MNE", ID: "11", Slot: 0, From: "SRC-A", To: ""},
+		{Kind: "SRCE_MNE", ID: "11", Slot: 1, From: "Black", To: ""},
+	}
+	if !reflect.DeepEqual(clr, wantClr) {
+		t.Errorf("allow-clear diff:\ngot  %+v\nwant %+v", clr, wantClr)
+	}
+	// Clear mode never touches unmanaged columns (slot 1 absent from header)
+	// or cells already empty live.
+	clr = diffCerebrumMnemonics("SRCE_MNE", live, []cerebrumMneRow{{ID: "11", Mnemonic: "SRC-A"}}, []int{4}, true)
+	if len(clr) != 0 {
+		t.Errorf("allow-clear must not touch unmanaged/empty cells, got %+v", clr)
+	}
+
+	// Run-twice = 0: applying `want` to live then re-diffing yields nothing.
+	after := []cerebrumMneRow{
+		{ID: "11", Mnemonic: "SRC-A", Alts: map[int]string{1: "Cam-A", 4: "ENG"}},
+		{ID: "12", Mnemonic: "SRC-B2"},
+		{ID: "13", Mnemonic: "SRC-C", Alts: map[int]string{1: "Mire-3"}},
+		{ID: "99", Mnemonic: "NEW"},
+	}
+	if again := diffCerebrumMnemonics("SRCE_MNE", after, desired, nil, false); len(again) != 0 {
+		t.Errorf("run-twice must be 0 changes, got %+v", again)
+	}
+}
+
+// TestDiffCerebrumRoutes pins the crosspoint ensure-diff: only cells whose
+// desired source differs from live change; identical cells and cells absent
+// from the CSV are untouched (import never disconnects); run-twice = 0.
+func TestDiffCerebrumRoutes(t *testing.T) {
+	live := []routeSpec{
+		{Dest: "13", Srce: "12", Level: "1"},
+		{Dest: "13", Srce: "14", Level: "2"},
+		{Dest: "20", Srce: "5", Level: "1"},
+	}
+	desired := []routeSpec{
+		{Dest: "13", Srce: "12", Level: "1"}, // identical -> none
+		{Dest: "13", Srce: "11", Level: "2"}, // differs -> change
+		{Dest: "30", Srce: "7", Level: "1"},  // unrouted live -> change from ""
+	}
+	got := diffCerebrumRoutes(live, desired)
+	want := []cerebrumRouteChange{
+		{Dest: "13", Level: "2", From: "14", To: "11"},
+		{Dest: "30", Level: "1", From: "", To: "7"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("diff:\ngot  %+v\nwant %+v", got, want)
+	}
+	// Live cell 20<-5 untouched (absent from CSV). Run-twice:
+	after := []routeSpec{
+		{Dest: "13", Srce: "12", Level: "1"},
+		{Dest: "13", Srce: "11", Level: "2"},
+		{Dest: "20", Srce: "5", Level: "1"},
+		{Dest: "30", Srce: "7", Level: "1"},
+	}
+	if again := diffCerebrumRoutes(after, desired); len(again) != 0 {
+		t.Errorf("run-twice must be 0 changes, got %+v", again)
+	}
+}
+
+// TestAltSlotArg pins the SetMnemonic slot rendering: primary = empty,
+// alternate = its index.
+func TestAltSlotArg(t *testing.T) {
+	if got := altSlotArg(0); got != "" {
+		t.Errorf("slot 0 = %q, want empty", got)
+	}
+	if got := altSlotArg(4); got != "4" {
+		t.Errorf("slot 4 = %q", got)
+	}
+}

--- a/cmd/dhs/cmd_cerebrum_xpoint.go
+++ b/cmd/dhs/cmd_cerebrum_xpoint.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"dhs/internal/cerebrum-nb/codec"
@@ -197,6 +195,14 @@ func cmpCerebrumID(a, b string) int {
 	return strings.Compare(a, b)
 }
 
+// orDash renders an empty (out-of-scope) path as "-" in scope reports.
+func orDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
 // cerebrumImportXpoint applies the probel-sw08p-style import trio: a
 // crosspoint CSV (`--xpoint`, alias `--csv`; columns dest,srce,levels) as ROUTE
 // actions, plus optional src/dst mnemonic CSVs (`--src`/`--dst`; columns
@@ -214,9 +220,23 @@ func cerebrumImportXpoint(_ context.Context, args []string) error {
 	srcPath := fs.String("src", "", "source-mnemonic CSV to import (columns srce,mnemonic — router mnemonics are per-ID, not per-level, 0v16 §4.1.5)")
 	dstPath := fs.String("dst", "", "dest-mnemonic CSV to import (columns dest,mnemonic — 0v16 §4.1.6)")
 	lvlPath := fs.String("levels", "", "level-mnemonic CSV to import (columns level,mnemonic — LEVEL_MNE, 0v16 §4.1.4)")
-	check := fs.Bool("check", false, "dry-run: print the actions that would be sent; connect to nothing")
+	inDir := fs.String("in-dir", "", "directory holding an export set: <prefix>-xpoint.csv / -src.csv / -dst.csv / -level.csv (the exact files `export --out-dir` wrote; files absent from the dir are simply out of scope)")
+	prefix := fs.String("prefix", "cerebrum", "file prefix used with --in-dir (same default as export)")
+	check := fs.Bool("check", false, "dry-run: read live state, report would_change per cell, send nothing")
+	allowClear := fs.Bool("allow-clear", false, "an EMPTY cell in a managed label column CLEARS the live label (MNEMONIC=\"\" — clear form live-UNVERIFIED; always --check first)")
+	output := fs.String("output", "text", "output format: text|json — json emits the ADR-0007 {changed|would_change, diff[]} shape on stdout (per-action detail goes to stderr)")
 	if err := fs.Parse(args); err != nil {
 		return err
+	}
+	jsonOut, oerr := resolveEnsureOutput(*output, false)
+	if oerr != nil {
+		return oerr
+	}
+	// In JSON mode stdout carries only the ensure result (Ansible parses it);
+	// per-change narration moves to stderr.
+	logw := os.Stdout
+	if jsonOut {
+		logw = os.Stderr
 	}
 	if *csvPath != "" && *xpointPath != "" {
 		return fmt.Errorf("cerebrum-nb import: --csv and --xpoint are the same input — pass one")
@@ -225,8 +245,28 @@ func cerebrumImportXpoint(_ context.Context, args []string) error {
 	if xp == "" {
 		xp = *csvPath
 	}
+	if *inDir != "" {
+		// Mirror export --out-dir: resolve every role not given explicitly to
+		// <in-dir>/<prefix>-<role>.csv, keeping only files that exist —
+		// missing files stay out of scope (partial-import semantics).
+		resolve := func(target *string, suffix string) {
+			if *target != "" {
+				return
+			}
+			p := filepath.Join(*inDir, *prefix+suffix)
+			if _, err := os.Stat(p); err == nil {
+				*target = p
+			}
+		}
+		resolve(&xp, "-xpoint.csv")
+		resolve(srcPath, "-src.csv")
+		resolve(dstPath, "-dst.csv")
+		resolve(lvlPath, "-level.csv")
+		fmt.Fprintf(os.Stderr, "cerebrum-nb import: --in-dir resolved xpoint=%s src=%s dst=%s levels=%s\n",
+			orDash(xp), orDash(*srcPath), orDash(*dstPath), orDash(*lvlPath))
+	}
 	if xp == "" && *srcPath == "" && *dstPath == "" && *lvlPath == "" {
-		return fmt.Errorf("cerebrum-nb import: nothing to import (pass --xpoint and/or --src/--dst/--levels)")
+		return fmt.Errorf("cerebrum-nb import: nothing to import (pass --xpoint and/or --src/--dst/--levels, or --in-dir DIR --prefix P)")
 	}
 
 	// Parse everything up front so a malformed file fails before any wire I/O.
@@ -247,58 +287,42 @@ func cerebrumImportXpoint(_ context.Context, args []string) error {
 		xpRows = len(rows)
 		routes = expandCerebrumXpoint(rows)
 	}
-	loadMne := func(path, keyCol string) ([]cerebrumMneRow, error) {
+	loadMne := func(path, keyCol string) ([]cerebrumMneRow, []int, error) {
 		if path == "" {
-			return nil, nil
+			return nil, nil, nil
 		}
 		data, err := os.ReadFile(path)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		rows, err := parseCerebrumMneCSV(data, keyCol, path)
+		rows, slots, err := parseCerebrumMneCSV(data, keyCol, path)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if len(rows) == 0 {
-			return nil, fmt.Errorf("cerebrum-nb import: %s has no mnemonics", path)
+			return nil, nil, fmt.Errorf("cerebrum-nb import: %s has no mnemonics", path)
 		}
-		return rows, nil
+		return rows, slots, nil
 	}
-	srcRows, err := loadMne(*srcPath, "srce")
+	srcRows, srcSlots, err := loadMne(*srcPath, "srce")
 	if err != nil {
 		return err
 	}
-	dstRows, err := loadMne(*dstPath, "dest")
+	dstRows, dstSlots, err := loadMne(*dstPath, "dest")
 	if err != nil {
 		return err
 	}
-	lvlRows, err := loadMne(*lvlPath, "level")
+	lvlRows, lvlSlots, err := loadMne(*lvlPath, "level")
 	if err != nil {
 		return err
 	}
 
-	// --check: offline dry-run, no connection.
-	if *check {
-		for _, r := range routes {
-			fmt.Printf("[would-route]    dst=%s src=%s lvl=%s\n", r.Dest, r.Srce, r.Level)
-		}
-		for _, m := range srcRows {
-			fmt.Printf("[would-srce-mne] src=%s mne=%q\n", m.ID, m.Mnemonic)
-		}
-		for _, m := range dstRows {
-			fmt.Printf("[would-dest-mne] dst=%s mne=%q\n", m.ID, m.Mnemonic)
-		}
-		for _, m := range lvlRows {
-			fmt.Printf("[would-level-mne] lvl=%s mne=%q\n", m.ID, m.Mnemonic)
-		}
-		fmt.Printf("cerebrum-nb import --check: %d crosspoint(s) across %d row(s), %d src-mne, %d dst-mne, %d level-mne — nothing sent\n",
-			len(routes), xpRows, len(srcRows), len(dstRows), len(lvlRows))
-		return nil
-	}
-
+	// Ensure semantics (ADR-0007): read live state, diff, converge only the
+	// differences. --check reports would_change and sends nothing. Both need
+	// the live state, so both need the host.
 	rest := fs.Args()
 	if len(rest) < 1 {
-		return fmt.Errorf("cerebrum-nb import: missing host[:port] argument (or pass --check for an offline dry-run)")
+		return fmt.Errorf("cerebrum-nb import: missing host[:port] argument (needed to read live state — ensure semantics)")
 	}
 	host, portArg, err := splitHostPort(rest[0], cf.port)
 	if err != nil {
@@ -314,52 +338,92 @@ func cerebrumImportXpoint(_ context.Context, args []string) error {
 	sess := p.Session()
 	target := routeTargetFromFlags(*router, *deviceName)
 
+	st, err := cerebrumObtainState(context.Background(), sess, *router, "ROUTER", 15*time.Second, cerebrumStateWant{
+		Routes: xp != "", SrcMne: *srcPath != "", DstMne: *dstPath != "", LvlMne: *lvlPath != "",
+		StrictMne: true, Verb: "import",
+	})
+	if err != nil {
+		return err
+	}
+
+	routeChanges := diffCerebrumRoutes(st.Routes, routes)
+	srcChanges := diffCerebrumMnemonics("SRCE_MNE", st.Src, srcRows, srcSlots, *allowClear)
+	dstChanges := diffCerebrumMnemonics("DEST_MNE", st.Dst, dstRows, dstSlots, *allowClear)
+	lvlChanges := diffCerebrumMnemonics("LEVEL_MNE", st.Lvl, lvlRows, lvlSlots, *allowClear)
+	mneChanges := append(append(srcChanges, dstChanges...), lvlChanges...)
+	total := len(routeChanges) + len(mneChanges)
+
+	// ADR-0007 diff[] — always built (even empty), one entry per converging
+	// cell: route.<dest>.<level> or <kind>.<id>.<slot>.
+	diffs := make([]ensureDiff, 0, total)
+	for _, c := range routeChanges {
+		diffs = append(diffs, ensureDiff{Field: fmt.Sprintf("route.%s.%s", c.Dest, c.Level), From: c.From, To: c.To})
+	}
+	for _, c := range mneChanges {
+		diffs = append(diffs, ensureDiff{Field: fmt.Sprintf("%s.%s.%d", strings.ToLower(c.Kind), c.ID, c.Slot), From: c.From, To: c.To})
+	}
+
+	if *check {
+		for _, c := range routeChanges {
+			_, _ = fmt.Fprintf(logw, "[would-route] dst=%s lvl=%s: %q -> src %s\n", c.Dest, c.Level, c.From, c.To)
+		}
+		for _, c := range mneChanges {
+			_, _ = fmt.Fprintf(logw, "[would-%s] id=%s slot=%d: %q -> %q\n", strings.ToLower(c.Kind), c.ID, c.Slot, c.From, c.To)
+		}
+		_, _ = fmt.Fprintf(logw, "cerebrum-nb import --check: would_change=%d (%d route(s), %d label(s)) of %d crosspoint(s)/%d label row(s) desired — nothing sent\n",
+			total, len(routeChanges), len(mneChanges), len(routes), xpRows+len(srcRows)+len(dstRows)+len(lvlRows))
+		if jsonOut {
+			wc := total > 0
+			return emitEnsure(true, ensureResult{WouldChange: &wc, Diff: diffs})
+		}
+		return nil
+	}
+
 	fails := 0
-	for _, r := range routes {
+	for _, c := range routeChanges {
 		body := &codec.RoutingAction{
 			Type: "ROUTE", IPAddress: *router, DeviceName: *deviceName,
 			DeviceType: codec.DeviceType("ROUTER"),
-			DestID:     r.Dest, SrceID: r.Srce, LevelID: r.Level,
+			DestID:     c.Dest, SrceID: c.To, LevelID: c.Level,
 		}
 		if err := sess.Action(context.Background(), body); err != nil {
-			fmt.Printf("[route] NACK dst=%s src=%s lvl=%s reason=%s\n", r.Dest, r.Srce, r.Level, err)
+			_, _ = fmt.Fprintf(logw, "[route] NACK dst=%s src=%s lvl=%s reason=%s\n", c.Dest, c.To, c.Level, err)
 			fails++
 			continue
 		}
-		fmt.Printf("[route] OK   dst=%s src=%s lvl=%s\n", r.Dest, r.Srce, r.Level)
+		_, _ = fmt.Fprintf(logw, "[route] OK   dst=%s lvl=%s: %q -> src %s\n", c.Dest, c.Level, c.From, c.To)
 	}
 	// Router (Routemaster) mnemonics are per-ID (0v16 §4.1.5/§4.1.6: the LEVEL
-	// attr is for non-router devices only) — one action per row, no LEVEL_ID.
-	// Level names themselves go via LEVEL_MNE with the level as the target.
-	applyMne := func(kind string, rows []cerebrumMneRow) {
-		for _, m := range rows {
-			var srce, dest, lvl string
-			switch kind {
-			case "SRCE_MNE":
-				srce = m.ID
-			case "DEST_MNE":
-				dest = m.ID
-			case "LEVEL_MNE":
-				lvl = m.ID
-			}
-			ctx, cancel := context.WithTimeout(context.Background(), cf.timeout)
-			err := sess.SetMnemonic(ctx, kind, target, srce, dest, lvl, m.Mnemonic, "")
-			cancel()
-			if err != nil {
-				fmt.Printf("[%s] NACK id=%s mne=%q reason=%s\n", strings.ToLower(kind), m.ID, m.Mnemonic, err)
-				fails++
-				continue
-			}
-			fmt.Printf("[%s] OK   id=%s mne=%q\n", strings.ToLower(kind), m.ID, m.Mnemonic)
+	// attr is for non-router devices only); alternate sets address by slot
+	// index (ALT_MNE=n). Level names go via LEVEL_MNE with the level as target.
+	for _, c := range mneChanges {
+		var srce, dest, lvl string
+		switch c.Kind {
+		case "SRCE_MNE":
+			srce = c.ID
+		case "DEST_MNE":
+			dest = c.ID
+		case "LEVEL_MNE":
+			lvl = c.ID
 		}
+		actx, cancel := context.WithTimeout(context.Background(), cf.timeout)
+		err := sess.SetMnemonic(actx, c.Kind, target, srce, dest, lvl, c.To, altSlotArg(c.Slot))
+		cancel()
+		if err != nil {
+			_, _ = fmt.Fprintf(logw, "[%s] NACK id=%s slot=%d mne=%q reason=%s\n", strings.ToLower(c.Kind), c.ID, c.Slot, c.To, err)
+			fails++
+			continue
+		}
+		_, _ = fmt.Fprintf(logw, "[%s] OK   id=%s slot=%d: %q -> %q\n", strings.ToLower(c.Kind), c.ID, c.Slot, c.From, c.To)
 	}
-	applyMne("SRCE_MNE", srcRows)
-	applyMne("DEST_MNE", dstRows)
-	applyMne("LEVEL_MNE", lvlRows)
 	if fails > 0 {
 		return fmt.Errorf("cerebrum-nb import: %d action(s) failed", fails)
 	}
-	fmt.Printf("cerebrum-nb import: applied %d crosspoint(s), %d src-mne, %d dst-mne, %d level-mne\n", len(routes), len(srcRows), len(dstRows), len(lvlRows))
+	_, _ = fmt.Fprintf(logw, "cerebrum-nb import: changed=%d (%d route(s), %d label(s)); run again to verify 0\n", total, len(routeChanges), len(mneChanges))
+	if jsonOut {
+		ch := total > 0
+		return emitEnsure(true, ensureResult{Changed: &ch, Diff: diffs})
+	}
 	return nil
 }
 
@@ -416,145 +480,19 @@ func cerebrumExportXpoint(ctx context.Context, args []string) error {
 		return err
 	}
 	defer func() { _ = p.Disconnect() }()
-	sess := p.Session()
 
-	var mu sync.Mutex
-	var routes []routeSpec
-	var srcMne, dstMne, lvlMne []cerebrumMneRow
-	crossLevel := 0
-	completes := 0
-	tick := make(chan struct{}, 1)
-	kick := func() {
-		select {
-		case tick <- struct{}{}:
-		default:
-		}
-	}
-
-	sess.OnEvent(codec.KindRoutingChange, func(f *codec.Frame) {
-		rc := f.Routing
-		if rc == nil {
-			return
-		}
-		mu.Lock()
-		switch rc.Type {
-		case "ROUTE":
-			if rc.RouteSourceID == "" {
-				break
-			}
-			if crossLevelRoute(rc.LevelID, rc.RouteSourceLevelID) {
-				crossLevel++
-				break
-			}
-			routes = append(routes, routeSpec{Dest: rc.DestID, Srce: rc.RouteSourceID, Level: rc.LevelID})
-		case "SRCE_MNE":
-			// Mnemonic per-ID (0v16 §5.1.5); Levels = capability from the
-			// ASSOCIATION children (which levels the source exists on);
-			// dedupe merges per-level repeats.
-			if m := primaryMnemonic(rc); m != "" && rc.SrceID != "" {
-				srcMne = append(srcMne, cerebrumMneRow{ID: rc.SrceID, Mnemonic: m, Levels: mneLevelsFromChange(rc, rc.SrceID)})
-			}
-		case "DEST_MNE":
-			if m := primaryMnemonic(rc); m != "" && rc.DestID != "" {
-				dstMne = append(dstMne, cerebrumMneRow{ID: rc.DestID, Mnemonic: m, Levels: mneLevelsFromChange(rc, rc.DestID)})
-			}
-		case "LEVEL_MNE":
-			if m := primaryMnemonic(rc); m != "" && rc.LevelID != "" {
-				lvlMne = append(lvlMne, cerebrumMneRow{ID: rc.LevelID, Mnemonic: m})
-			}
-		}
-		mu.Unlock()
-		kick()
+	st, err := cerebrumObtainState(ctx, p.Session(), *router, *deviceType, *idle, cerebrumStateWant{
+		Routes: true, RouteLevel: *level,
+		SrcMne: trio, DstMne: trio, LvlMne: trio,
+		Verb: "export",
 	})
-	sess.OnEvent(codec.KindWildcardComplete, func(f *codec.Frame) {
-		// Live NOC Cerebrum (2026-08) emits a bare <wildcard_complete/> with NO
-		// MTID after every event — spec §1.6 defines exactly one per wildcard
-		// request, carrying the request's MTID. Count only the real ones so the
-		// spurious per-event sentinels can't end collection early.
-		if f.MTID == "" {
-			return
-		}
-		mu.Lock()
-		completes++
-		mu.Unlock()
-		kick()
-	})
-
-	// One-shot OBTAIN per row (0v16 §2.4) — no standing subscription, nothing
-	// to unsubscribe. One OBTAIN per item so a NACK on one cannot sink the
-	// others (the live server is known to NACK some wildcard rows).
-	type obtainItem struct {
-		name string
-		item codec.SubItem
+	if err != nil {
+		return err
 	}
-	routeLevel := *level
-	if routeLevel == "" {
-		routeLevel = "*"
+	if st.CrossLevel > 0 {
+		fmt.Fprintf(os.Stderr, "cerebrum-nb export: WARNING — %d cross-level route(s) (src level != dst level) not exported: shuffle representation not yet supported\n", st.CrossLevel)
 	}
-	plan := []obtainItem{
-		{"ROUTE", &codec.RoutingChange{Type: "ROUTE", IPAddress: *router, DeviceType: codec.DeviceType(*deviceType), DestID: "*", LevelID: routeLevel}},
-	}
-	if trio {
-		// LEVEL_ID="*" on the MNE filters is REQUIRED by live NOC Cerebrum
-		// (NACK 10 without it, 2026-08-15) and spec-harmless on routers.
-		plan = append(plan,
-			obtainItem{"SRCE_MNE", &codec.RoutingChange{Type: "SRCE_MNE", IPAddress: *router, DeviceType: codec.DeviceType(*deviceType), SrceID: "*", LevelID: "*"}},
-			obtainItem{"DEST_MNE", &codec.RoutingChange{Type: "DEST_MNE", IPAddress: *router, DeviceType: codec.DeviceType(*deviceType), DestID: "*", LevelID: "*"}},
-			obtainItem{"LEVEL_MNE", &codec.RoutingChange{Type: "LEVEL_MNE", IPAddress: *router, DeviceType: codec.DeviceType(*deviceType), LevelID: "*"}},
-		)
-	}
-	obtCtx, obtCancel := context.WithCancel(context.Background())
-	defer obtCancel()
-	okSubs := 0
-	for _, s := range plan {
-		if err := sess.Obtain(obtCtx, []codec.SubItem{s.item}); err != nil {
-			if s.name == "ROUTE" {
-				return fmt.Errorf("cerebrum-nb export: ROUTE obtain failed: %w", err)
-			}
-			fmt.Fprintf(os.Stderr, "cerebrum-nb export: %s obtain refused (%v) — %s CSV will be empty\n", s.name, err, strings.ToLower(s.name))
-			continue
-		}
-		okSubs++
-	}
-
-	// Collect until every granted subscription completed, or --idle of quiet.
-	idleTimer := time.NewTimer(*idle)
-	defer idleTimer.Stop()
-collect:
-	for {
-		mu.Lock()
-		doneAll := okSubs > 0 && completes >= okSubs
-		mu.Unlock()
-		if doneAll {
-			break collect
-		}
-		select {
-		case <-tick:
-			if !idleTimer.Stop() {
-				select {
-				case <-idleTimer.C:
-				default:
-				}
-			}
-			idleTimer.Reset(*idle)
-		case <-idleTimer.C:
-			break collect
-		case <-ctx.Done():
-			break collect
-		}
-	}
-
-	mu.Lock()
-	snap := append([]routeSpec(nil), routes...)
-	srcSnap := append([]cerebrumMneRow(nil), srcMne...)
-	dstSnap := append([]cerebrumMneRow(nil), dstMne...)
-	lvlSnap := append([]cerebrumMneRow(nil), lvlMne...)
-	skipped := crossLevel
-	mu.Unlock()
-
-	if skipped > 0 {
-		fmt.Fprintf(os.Stderr, "cerebrum-nb export: WARNING — %d cross-level route(s) skipped (dest,srce,levels CSV cannot represent SRCE_LEVEL != DEST_LEVEL yet)\n", skipped)
-	}
+	snap, srcSnap, dstSnap, lvlSnap := st.Routes, st.Src, st.Dst, st.Lvl
 
 	xpCSV := formatCerebrumXpointCSV(collapseCerebrumRoutes(snap))
 	if !trio {
@@ -562,7 +500,7 @@ collect:
 			fmt.Print(xpCSV)
 			return nil
 		}
-		if err := os.WriteFile(*out, []byte(xpCSV), 0o644); err != nil {
+		if err := cerebrumWriteFile(*out, []byte(xpCSV)); err != nil {
 			return err
 		}
 		fmt.Fprintf(os.Stderr, "cerebrum-nb export: wrote %d crosspoint row(s) to %s\n", strings.Count(xpCSV, "\n")-1, *out)
@@ -572,12 +510,22 @@ collect:
 	if err := os.MkdirAll(*outDir, 0o755); err != nil {
 		return err
 	}
+	srcD, dstD, lvlD := dedupeCerebrumMnes(srcSnap), dedupeCerebrumMnes(dstSnap), dedupeCerebrumMnes(lvlSnap)
+	// Same alt_1..alt_N headers on all three files (plant-wide max), so an
+	// empty column is fillable on any resource kind.
+	nAlt := maxAltSlot(srcD)
+	if n := maxAltSlot(dstD); n > nAlt {
+		nAlt = n
+	}
+	if n := maxAltSlot(lvlD); n > nAlt {
+		nAlt = n
+	}
 	files := []struct {
 		name, content string
 	}{
-		{*prefix + "-src.csv", formatCerebrumMneCSV("srce", dedupeCerebrumMnes(srcSnap))},
-		{*prefix + "-dst.csv", formatCerebrumMneCSV("dest", dedupeCerebrumMnes(dstSnap))},
-		{*prefix + "-level.csv", formatCerebrumMneCSV("level", dedupeCerebrumMnes(lvlSnap))},
+		{*prefix + "-src.csv", formatCerebrumMneCSVN("srce", srcD, nAlt)},
+		{*prefix + "-dst.csv", formatCerebrumMneCSVN("dest", dstD, nAlt)},
+		{*prefix + "-level.csv", formatCerebrumMneCSVN("level", lvlD, nAlt)},
 		{*prefix + "-xpoint.csv", xpCSV},
 	}
 	for _, f := range files {
@@ -593,11 +541,10 @@ collect:
 // cerebrumDial builds a plugin from the common flags and connects (no LOGIN —
 // see connectAndLogin). Shared by import/export; the host is already split out.
 func cerebrumDial(cf *cerebrumFlags, host string) (*cerebrum.Plugin, error) {
-	logLevel := slog.LevelInfo
-	if cf.debug {
-		logLevel = slog.LevelDebug
+	logger, _, lerr := cf.newLogger()
+	if lerr != nil {
+		return nil, lerr
 	}
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel}))
 	p := cerebrum.NewPlugin(logger)
 	p.Username = cf.user
 	p.Password = cf.pass

--- a/cmd/dhs/cmd_cerebrum_xpoint_test.go
+++ b/cmd/dhs/cmd_cerebrum_xpoint_test.go
@@ -5,19 +5,20 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
-// TestCerebrumImportXpointCheckOffline pins that `import --check` is a pure
-// offline dry-run: it parses + expands the CSV and returns nil WITHOUT a host or
-// any connection (no host arg is given here).
-func TestCerebrumImportXpointCheckOffline(t *testing.T) {
+// TestCerebrumImportXpointCheckNeedsHost pins the ensure contract for the
+// crosspoint leg: --check computes would_change against live state, so a
+// host is required even for the dry-run.
+func TestCerebrumImportXpointCheckNeedsHost(t *testing.T) {
 	p := filepath.Join(t.TempDir(), "x.csv")
 	if err := os.WriteFile(p, []byte("dest,srce,levels\n60,60,1;2;3\n61,70,2\n"), 0o644); err != nil {
 		t.Fatalf("seed csv: %v", err)
 	}
-	if err := cerebrumImportXpoint(context.Background(), []string{"--csv", p, "--check"}); err != nil {
-		t.Fatalf("import --check offline: err = %v, want nil", err)
+	if err := cerebrumImportXpoint(context.Background(), []string{"--csv", p, "--check"}); err == nil {
+		t.Fatal("import --check without host: err = nil, want error (ensure reads live state)")
 	}
 }
 
@@ -36,11 +37,53 @@ func TestCerebrumImportXpointErrors(t *testing.T) {
 			t.Fatal("err = nil, want error (no level column)")
 		}
 	})
+	t.Run("unknown --output format", func(t *testing.T) {
+		p := filepath.Join(t.TempDir(), "x.csv")
+		_ = os.WriteFile(p, []byte("dest,srce,levels\n60,60,1\n"), 0o644)
+		err := cerebrumImportXpoint(context.Background(), []string{"--csv", p, "--output", "xml", "--check"})
+		if err == nil || !strings.Contains(err.Error(), "expected text | json") {
+			t.Fatalf("err = %v, want expected-text|json error", err)
+		}
+	})
 	t.Run("apply needs host", func(t *testing.T) {
 		p := filepath.Join(t.TempDir(), "x.csv")
 		_ = os.WriteFile(p, []byte("dest,srce,levels\n60,60,1\n"), 0o644)
 		if err := cerebrumImportXpoint(context.Background(), []string{"--csv", p}); err == nil {
 			t.Fatal("err = nil, want error (apply mode requires host)")
+		}
+	})
+}
+
+// TestCerebrumImportInDir pins the export-mirror form: --in-dir DIR --prefix P
+// resolves <P>-xpoint/-src/-dst/-level.csv, keeps only files that exist
+// (partial scope), and an empty dir is "nothing to import".
+func TestCerebrumImportInDir(t *testing.T) {
+	t.Run("resolves existing files", func(t *testing.T) {
+		dir := t.TempDir()
+		// Only the src file exists — xpoint/dst/level stay out of scope.
+		_ = os.WriteFile(filepath.Join(dir, "noc-src.csv"), []byte("srce,mnemonic\n1,CAM1\n"), 0o644)
+		err := cerebrumImportXpoint(context.Background(), []string{"--in-dir", dir, "--prefix", "noc", "--check"})
+		// Files resolved + parsed fine, so the failure must be the missing
+		// host (ensure reads live state) — NOT "nothing to import".
+		if err == nil || !strings.Contains(err.Error(), "host") {
+			t.Fatalf("err = %v, want missing-host error", err)
+		}
+	})
+	t.Run("empty dir = nothing to import", func(t *testing.T) {
+		err := cerebrumImportXpoint(context.Background(), []string{"--in-dir", t.TempDir(), "--check"})
+		if err == nil || !strings.Contains(err.Error(), "nothing to import") {
+			t.Fatalf("err = %v, want nothing-to-import error", err)
+		}
+	})
+	t.Run("explicit flag wins over --in-dir", func(t *testing.T) {
+		dir := t.TempDir()
+		_ = os.WriteFile(filepath.Join(dir, "cerebrum-xpoint.csv"), []byte("dest,srce,levels\n1,2,1\n"), 0o644)
+		bad := filepath.Join(dir, "explicit.csv")
+		_ = os.WriteFile(bad, []byte("dest,srce\n1,2\n"), 0o644) // malformed: no level col
+		err := cerebrumImportXpoint(context.Background(), []string{"--in-dir", dir, "--xpoint", bad, "--check"})
+		// The malformed EXPLICIT file must be the one parsed (and rejected).
+		if err == nil || !strings.Contains(err.Error(), "explicit.csv") {
+			t.Fatalf("err = %v, want parse error on explicit.csv", err)
 		}
 	})
 }

--- a/internal/cerebrum-nb/CLAUDE.md
+++ b/internal/cerebrum-nb/CLAUDE.md
@@ -46,7 +46,7 @@ internal/cerebrum-nb/
 ├── docs/
 │   ├── keys.md           wire-key catalogue (spec extract)
 │   ├── consumer.md       CLI walkthrough
-│   ├── verbs.md          12-section verb + sample reference (0v16)
+│   ├── verbs.md          13-section verb + sample reference (0v16)
 │   ├── runbook.md        operator quick-reference card
 │   ├── provider.md       provider rationale — consumer-only by design (N/A)
 │   └── README.md         one-page overview

--- a/internal/cerebrum-nb/codec/actions.go
+++ b/internal/cerebrum-nb/codec/actions.go
@@ -135,6 +135,11 @@ type RoutingAction struct {
 	Mnemonic string
 	AltMne   string
 	OnDevice string
+	// EmptyMnemonic forces MNEMONIC="" onto the wire (normally empty attrs
+	// are omitted) — the label-CLEAR form. 0v16 does not document clearing;
+	// an explicit empty string is the plausible mechanism (RX announces a
+	// cleared alt by omitting its slot). Live server behaviour unverified.
+	EmptyMnemonic bool
 
 	// ASSOC actions
 	LogicalSrceID    string
@@ -151,6 +156,15 @@ type RoutingAction struct {
 
 	// RM_TAGS actions
 	Tags string
+}
+
+// addMnemonic emits MNEMONIC normally (omitted when empty), or force-emits
+// MNEMONIC="" for the clear form (RoutingAction.EmptyMnemonic).
+func (a AttrsBuilder) addMnemonic(v string, forceEmpty bool) AttrsBuilder {
+	if forceEmpty {
+		return a.ForceAdd("MNEMONIC", v)
+	}
+	return a.Add("MNEMONIC", v)
 }
 
 // encodeAction satisfies ActionBody. Spec §4.1 attributes use
@@ -174,7 +188,7 @@ func (r *RoutingAction) encodeAction(b *strings.Builder) {
 		Add("LEVEL_NAME", r.LevelName).
 		Add("LOCK", string(r.Lock)).
 		Add("DURATION", r.Duration).
-		Add("MNEMONIC", r.Mnemonic).
+		addMnemonic(r.Mnemonic, r.EmptyMnemonic).
 		Add("ALT_MNE", r.AltMne).
 		Add("ON_DEVICE", r.OnDevice).
 		Add("LOGICAL_SRCE_ID", r.LogicalSrceID).

--- a/internal/cerebrum-nb/codec/actions_clear_test.go
+++ b/internal/cerebrum-nb/codec/actions_clear_test.go
@@ -1,0 +1,32 @@
+package codec
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestEncodeAction_MnemonicClear pins the label-CLEAR wire form: with
+// EmptyMnemonic set, MNEMONIC="" is force-emitted (normally empty attrs are
+// omitted); without it, an empty Mnemonic stays off the wire. 0v16 does not
+// document clearing — this explicit-empty form is the plausible mechanism,
+// gated behind the CLI's --allow-clear until live-verified.
+func TestEncodeAction_MnemonicClear(t *testing.T) {
+	clear := EncodeAction(7, &RoutingAction{
+		Type: "SRCE_MNE", IPAddress: "0.0.0.0", DeviceType: DeviceType("ROUTER"),
+		SrceID: "11", AltMne: "1", EmptyMnemonic: true,
+	})
+	if !strings.Contains(string(clear), `MNEMONIC=""`) {
+		t.Errorf("clear form must force-emit MNEMONIC=\"\": %s", clear)
+	}
+	if !strings.Contains(string(clear), `ALT_MNE="1"`) {
+		t.Errorf("clear form must keep the alt slot: %s", clear)
+	}
+
+	normal := EncodeAction(8, &RoutingAction{
+		Type: "SRCE_MNE", IPAddress: "0.0.0.0", DeviceType: DeviceType("ROUTER"),
+		SrceID: "11",
+	})
+	if strings.Contains(string(normal), "MNEMONIC") {
+		t.Errorf("without EmptyMnemonic an empty Mnemonic must be omitted: %s", normal)
+	}
+}

--- a/internal/cerebrum-nb/consumer/actions.go
+++ b/internal/cerebrum-nb/consumer/actions.go
@@ -58,6 +58,9 @@ func (s *Session) SetMnemonic(ctx context.Context, mneType string, addr RouteTar
 		LevelID:    levelID,
 		Mnemonic:   mnemonic,
 		AltMne:     altSlot,
+		// An explicitly empty mnemonic is the CLEAR form: force MNEMONIC=""
+		// onto the wire (callers gate this behind --allow-clear).
+		EmptyMnemonic: mnemonic == "",
 	}
 	return s.Action(ctx, body)
 }

--- a/internal/cerebrum-nb/consumer/session.go
+++ b/internal/cerebrum-nb/consumer/session.go
@@ -181,6 +181,9 @@ func (s *Session) roundTrip(ctx context.Context, mtid uint32, payload []byte) (*
 		s.mu.Unlock()
 	}()
 
+	// Raw TX at debug level — the wire truth for diagnostics; --debug on the
+	// CLI promises "verbose RX/TX XML logging" and this is that promise.
+	s.logger.Debug("tx", slog.String("xml", string(payload)))
 	if err := s.conn.WriteText(ctx, payload); err != nil {
 		return nil, fmt.Errorf("cerebrum-nb: write: %w", err)
 	}
@@ -367,6 +370,8 @@ func (s *Session) readLoop() {
 			s.logger.Debug("dropping non-text frame", slog.Int("opcode", int(op)))
 			continue
 		}
+		// Raw RX at debug level — see the tx twin in roundTrip.
+		s.logger.Debug("rx", slog.String("xml", string(payload)))
 		f, err := codec.Decode(payload)
 		if err != nil {
 			s.logger.Warn("decode failed",

--- a/internal/cerebrum-nb/docs/README.md
+++ b/internal/cerebrum-nb/docs/README.md
@@ -9,36 +9,78 @@ EVS **Cerebrum Northbound API 0v16** (authoritative) — also branded
 | Doc | What it covers |
 |---|---|
 | [keys.md](keys.md) | Authoritative element / attribute / enum catalogue (the wire facts) |
-| [verbs.md](verbs.md) | 12-section verb + sample reference (device-config, 5-mode lock, datastore) |
+| [verbs.md](verbs.md) | 13-section verb + sample reference (device-config, 5-mode lock, datastore, inventory + snapshot export/import ensure) |
 | [consumer.md](consumer.md) | CLI walkthrough + portable Windows install recipe |
 | [runbook.md](runbook.md) | Operator quick-reference card |
 | [provider.md](provider.md) | Provider rationale — consumer-only by design (N/A) |
 | [../CLAUDE.md](../CLAUDE.md) | Atomic per-protocol context — wire layer, mtid, quirks, "what NOT to do" |
 
+## Verb catalogue (complete)
+
+| Group | Verb | What it does |
+|---|---|---|
+| Session | `connect` | POLL round-trip (auto-LOGIN with `--user/--pass`) |
+| | `listen` | SUBSCRIBE watcher — routing / category / salvo / device events until Ctrl+C |
+| | `keepalive-probe` | diagnostic idle hold (TCP keep-alive observation) |
+| **Inventory** (one-shot OBTAIN, no subscribe) | `list-sources` | every configured source: **ID · capability levels · label · alt labels** (`--id N` single, `--out` CSV) |
+| | `list-dests` (alias `list-destinations`) | same for destinations |
+| | `list-levels` | the level catalogue: ID + name (+ alts) |
+| **Snapshot** | `export` | one-shot OBTAIN reads → CSVs. Crosspoints only: `--out FILE` (`--level N` per-level). Full Route-Master snapshot: `--out-dir DIR --prefix P` → `P-src.csv` / `P-dst.csv` / `P-level.csv` / `P-xpoint.csv` (uniform `alt_1..alt_N` columns) |
+| | `import` | **ENSURE (ADR-0007)**: read live state, diff vs CSVs, converge only differences. `--in-dir DIR [--prefix P]` (reads the set `export --out-dir` wrote) or per-file `--xpoint` (routes; never disconnects) + `--src/--dst/--levels` (labels, any slot incl. alternates). `--check` = would_change report, sends nothing. Empty cell = untouched; `--allow-clear` makes an empty managed cell a clear-write (**live-UNVERIFIED**). Run-twice = 0 |
+| Routing | `route` | single / batch (`--route d:s:l`) / `--csv` crosspoint takes |
+| | `lock` / `unlock` | 5-mode DEST/SRCE lock |
+| Labels | `set-mnemonic` | one label write — primary or `--alt N` slot |
+| | `set-tags` | Routemaster tags |
+| Reads | `list-devices` / `device-details` / `device-value` | device domain |
+| | `list-categories` / `category-details` | category domain (items = SOURCE/DEST names) |
+| | `list-salvo-groups` / `list-salvo-instances` / `salvo-instance-details` | salvo domain |
+| | `obtain-datastore` | data store fetch |
+| Writes | `salvo` (run/save/rename/delete) · `category` (create/modify/delete) · `set-value` · `device-config` | §4 actions |
+
+Common flags: `--port` (default 40007) · `--user/--pass` (or `$DHS_CEREBRUM_USER/_PASS`)
+· `--tls` · `--timeout` · `--debug` (RX/TX XML to stderr) · **`--log FILE`**
+(full debug log incl. RX/TX XML to a clean UTF-8 file — no PowerShell `2>`
+wrapping; note it contains the LOGIN frame in clear text).
+
 ## Status
 
-- Consumer plugin: **complete at 0v16** — codec + WS framing +
-  Login/Poll/Action/Subscribe/Obtain/Unsubscribe/UnsubscribeAll +
-  DeviceConfiguration; CLI verbs (`connect` / `listen` / `route` /
-  `lock` / `unlock` / `set-mnemonic` / `set-tags` / `salvo` / `category`
-  / `set-value` / `device-config` / `list-devices` / `device-details` /
-  `device-value` / `list-categories` / `category-details` /
-  `list-salvo-groups` / `list-salvo-instances` / `salvo-instance-details`
-  / `obtain-datastore` / `keepalive-probe`); Wireshark dissector;
-  unit tests; codec-generated fixtures + drift-guard.
-- **Provider plugin: N/A by design** — Cerebrum is a northbound API we
-  consume; there is no "serve Cerebrum" role. See [provider.md](provider.md).
-- Real-peer interop validation: pending the NB northbound **licence**
-  (currently missing on the lab Cerebrum) — the Ansible verb play
-  ([`../../../ansible/playbooks/cerebrum-nb-integration.yml`](../../../ansible/playbooks/cerebrum-nb-integration.yml))
-  is written + ready and skips until host + creds + licence exist.
+- Consumer plugin **complete at 0v16**; provider **N/A by design**
+  ([provider.md](provider.md)).
+- **Live-validated against a production Cerebrum (NOC, 2026-08)**: login,
+  listen, list-sources/dests/levels (12k+ resources, ID+labels+capability
+  levels verified against the Route-Master UI), full snapshot export,
+  crosspoint export (sentinel-filtered), route takes, and the full
+  `import` ensure loop — untouched snapshot `--check` = would_change=0
+  (1.7k xpoints + 25.9k label rows), a single CSV edit detected as
+  exactly 1 change, and apply wrote that one alternate label
+  (confirmed in the Cerebrum UI).
+- **Pending staging validation**: `--allow-clear` (the `MNEMONIC=""`
+  clear form) only.
+
+## Live-wire truths (production-verified; NOT in the 0v16 PDF)
+
+- `ASSOCIATION_n` **index = Routemaster level** of the binding; association
+  `SRCE_ID/DEST_ID` is a device-port UID, `RM_LEVEL_ID` is the level inside
+  the bound device. A row with no ASSOCIATIONS block = resource unbound.
+- ROUTE snapshot covers **every dest × level cell**; `SOURCE_ID` `0`,
+  `4294967294` (0xFFFFFFFE) and `4294967295` are **no-route sentinels**.
+- OBTAIN/SUBSCRIBE filters must carry **every wildcardable attribute**
+  (`LEVEL_ID="*"` included) or the server NACKs (9/10). RX rows echo the
+  filter ("attributes as per TX") — `LEVEL_ID="*"` in a reply is the echo,
+  never data.
+- Only the MTID-carrying `WILDCARD_COMPLETE` ends a wildcard read; the
+  server also emits spurious MTID-less ones per event.
+- Alternate label sets are addressed **by index only**; the set names are
+  Cerebrum config (this plant: 1=Panels, 2=Ref_Short_Edit, 3=Ref_Long_Edit,
+  4=Engineer, 5=Ref_Long_Tech). No NB command lists that mapping.
+- The Cerebrum cluster does **not** sync NB credentials between
+  primary/backup.
 
 ## Wire samples
 
-Every wire sample in these docs comes from the committed
-[codec-generated fixtures](../testdata/fixtures/README.md) — **not a live
-capture** (a live capture is pending the NB licence). The fixtures are
-produced by the codec and pinned byte-for-byte by a drift-guard.
+Wire samples in these docs come from the committed
+[codec-generated fixtures](../testdata/fixtures/README.md), cross-checked
+2026-08 against live captures from the production NOC Cerebrum.
 
 ## Spec sources
 

--- a/internal/cerebrum-nb/docs/verbs.md
+++ b/internal/cerebrum-nb/docs/verbs.md
@@ -323,9 +323,9 @@ It is **gated** on `CEREBRUM_TEST_HOST` (+ `DHS_CEREBRUM_USER` /
 `meta: end_play` skips cleanly when unset — so it is safe to invoke
 unconditionally.
 
-> **The live run requires the NB northbound LICENCE enabled on the
-> Cerebrum** — currently missing. The play is written + ready and skips
-> until host + creds + licence all exist.
+> The NB licence is now present (2026-06) and the read-side verbs were
+> live-verified against a production Cerebrum (2026-08). The play still
+> gates on the env vars and skips cleanly when unset.
 
 ```
 CEREBRUM_TEST_HOST=10.6.239.50 DHS_CEREBRUM_USER=admin DHS_CEREBRUM_PASS=s3cr3t \
@@ -336,7 +336,80 @@ Read-only verbs → `changed_when: false` → idempotent by construction
 (run-twice = 0 changes). dhs logs go to stderr → tasks `register` and
 `debug` the combined `stdout_lines + stderr_lines`.
 
-## 12. See also
+## 12. Inventory + snapshot — list-* / export / import (ensure)
+
+The probel-sw08p-parity operator surface: enumerate the Route-Master,
+snapshot it to CSVs, and converge live state back from (possibly edited)
+CSVs. All reads are **one-shot OBTAIN** (§2.4) — never SUBSCRIBE; the read
+ends on the MTID-carrying `WILDCARD_COMPLETE` (§1.6).
+
+### list-sources / list-dests (alias `list-destinations`) / list-levels
+
+```
+dhs consumer cerebrum-nb list-sources 10.6.239.50 --user U --pass P [--id N] [--out FILE]
+```
+
+One row per resource: `ID · LEVELS · LABEL · ALTS`. **Capability levels**
+come from the `ASSOCIATION_n` indices (index = Routemaster level — live-wire
+fact, not in the 0v16 PDF); a resource with no ASSOCIATIONS block is
+unbound and shows no levels. Alternate labels print as `1=Black 4=ENG`
+(slot index, §4.1.5 `ALT_MNE=n`); the slot→set-name mapping is Cerebrum
+config and not exposed over NB. `--id N` narrows to one resource, `--out`
+writes CSV instead of the table.
+
+### export — full snapshot
+
+```
+# crosspoints only (optionally one level):
+dhs consumer cerebrum-nb export HOST --user U --pass P --out xp.csv [--level N]
+# full Route-Master snapshot:
+dhs consumer cerebrum-nb export HOST --user U --pass P --out-dir DIR --prefix noc
+#   → noc-src.csv  noc-dst.csv  noc-level.csv  noc-xpoint.csv
+```
+
+- Mnemonic CSVs: `<kind>_id,levels,mnemonic,alt_1..alt_N` — alt columns are
+  **uniform plant-wide** (sized to the highest used slot across the whole
+  snapshot), `levels` is `;`-separated capability levels.
+- Xpoint CSV: `dest,srce,level` — one row per **routed** cell. The server
+  answers every dest × level cell; `SOURCE_ID` `0` / `4294967294` /
+  `4294967295` are undocumented **no-route sentinels** and are filtered.
+- Cross-level routes (src level ≠ dst level) are skipped with a warning —
+  shuffle representation is not yet supported (parked).
+
+### import — ENSURE (ADR-0007)
+
+```
+# mirror of export --out-dir — reads the same file set back:
+dhs consumer cerebrum-nb import HOST --user U --pass P --in-dir DIR --prefix noc [--check] [--allow-clear]
+# or per-file (partial scope):
+dhs consumer cerebrum-nb import HOST --user U --pass P \
+  [--xpoint xp.csv] [--src s.csv] [--dst d.csv] [--levels l.csv] [--check] [--allow-clear]
+```
+
+`--in-dir` resolves `<prefix>-xpoint.csv / -src.csv / -dst.csv /
+-level.csv`; files absent from the directory are simply out of scope, and
+an explicit per-file flag overrides its `--in-dir` counterpart.
+
+Diff-first: reads live state over the same OBTAINs, diffs against the
+CSVs, sends **only the differences** (`ROUTE` actions / `*_MNE` writes via
+`ALT_MNE=n`). Contract:
+
+- `--check` — online dry-run: prints `[would-*] …` lines + `would_change=N`,
+  sends nothing (a host is still required — ensure reads live state).
+- Partial CSV = partial scope: rows/files absent are never touched.
+- Empty label cell = untouched, **unless** `--allow-clear` AND the column is
+  managed (present in the CSV header; primary always managed) AND the live
+  value is set → clear-write (`MNEMONIC=""`). ⚠ the clear wire-form is
+  **live-unverified** — staging only.
+- Route import never disconnects — an unrouted live cell only changes if
+  the CSV routes it.
+- Run-twice = 0 changes (idempotent by construction).
+- `--output json` — the canonical ADR-0007 shape on stdout
+  (`{changed|would_change, diff[]}`, one `diff[]` entry per cell:
+  `route.<dest>.<level>` / `<kind>.<id>.<slot>`); per-change narration
+  moves to stderr so Ansible can parse stdout.
+
+## 13. See also
 
 - [`../CLAUDE.md`](../CLAUDE.md) — wire format, mtid, quirks, "what NOT to do"
 - [`README.md`](README.md) · [`consumer.md`](consumer.md) · [`runbook.md`](runbook.md) · [`provider.md`](provider.md) · [`keys.md`](keys.md)


### PR DESCRIPTION
## What

`cerebrum-nb` ensure import + Route-Master snapshot export (probel-sw08p parity, ADR-0007), live-verified against a production Cerebrum.

## Why

Operators need the same snapshot/converge workflow on the Cerebrum NB route-master that probel-sw08p already has: export the plant to CSVs, edit offline, dry-run, converge only the differences. Also closes the ADR-0007 gap (no `--output json` machine shape on cerebrum convergence).

Closes #676

## Scope

- [ ] acp1
- [ ] acp2
- [ ] emberplus
- [ ] probel-sw08p / probel-sw02p
- [x] osc / tsl / cerebrum-nb / amwa
- [ ] transport
- [ ] export
- [x] cli
- [ ] api
- [ ] core
- [ ] ci / chore

**Cross-protocol changes**: `cmd/dhs/cmd_cerebrum_*.go` only (the cerebrum verb surface lives there by existing layout); reuses the shared `ensureResult`/`emitEnsure`/`resolveEnsureOutput` helpers from `cmd_ensure.go` — that reuse is the point (identical ADR-0007 shape across protocols), not a new coupling.

## Wire evidence (protocol changes only)

Live production Cerebrum (NOC route-master, 10.44.55.39:40009, 2026-08-15/16), operator-driven:

```text
dhs consumer cerebrum-nb import 10.44.55.39 --port 40009 --user *** --pass *** --in-dir captures\cerebrum-nb --prefix noc --check --output json
# untouched snapshot:
{"would_change":false,"diff":[]}   # over 1,762 xpoints + 25,868 label rows
# after editing one CSV cell (src 11 alt_1 Black -> Blackk):
{"would_change":true,"diff":[{"field":"srce_mne.11.1","from":"Black","to":"Blackk"}]}

dhs consumer cerebrum-nb import ... --in-dir captures\cerebrum-nb --prefix noc
[srce_mne] OK   id=11 slot=1: "Blackk" -> "Black"
cerebrum-nb import: changed=1 (0 route(s), 1 label(s)); run again to verify 0
# immediate re-run:
cerebrum-nb import: changed=0 (0 route(s), 0 label(s)); run again to verify 0
```

The applied label was visually confirmed in the Cerebrum Routemaster UI (Sources tab, Panels column) before being reverted the same way. Undocumented wire facts absorbed + documented: ROUTE no-route sentinels (SOURCE_ID 0/4294967294/4294967295), ASSOCIATION_n index = RM level, mandatory LEVEL_ID="*" on wildcard filters.

## Reference controller

- [x] Cerebrum still happy after this change
- [ ] VSM Studio still happy after this change
- [ ] N/A (no protocol behaviour change)

## Type

- [x] feat — new feature

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `cmd/dhs/cmd_cerebrum_state.go` | new | shared OBTAIN state collector + ensure diff engines (routes, mnemonics incl. allow-clear) |
| `cmd/dhs/cmd_cerebrum_state_test.go` | new | diff-contract tests: partial scope, allow-clear, run-twice=0 |
| `cmd/dhs/cmd_cerebrum_xpoint.go` | modified | export full-set mode (`--out-dir/--prefix`, sentinel filter, `--level`); import rewritten as ensure (`--check`, `--in-dir`, `--output json`, `--allow-clear`) |
| `cmd/dhs/cmd_cerebrum_xpoint_test.go` | modified | ensure/`--in-dir`/`--output` guard-rail tests |
| `cmd/dhs/cmd_cerebrum_names.go` | modified | mnemonic CSV parse/format with uniform `alt_1..alt_N` columns, capability levels, sentinels |
| `cmd/dhs/cmd_cerebrum_names_test.go` | modified | parse/dedupe/round-trip/alt-column tests |
| `cmd/dhs/cmd_cerebrum_list_mne.go` | modified | list-sources/dests/levels: levels + alts columns, `--id`, CSV out via mkdir-safe writer |
| `cmd/dhs/cmd_cerebrum.go` | modified | `--log FILE` logger, `list-destinations` alias, mkdir-safe output writer, full help |
| `internal/cerebrum-nb/codec/actions.go` | modified | `EmptyMnemonic` ForceAdd — the `MNEMONIC=""` clear wire form |
| `internal/cerebrum-nb/codec/actions_clear_test.go` | new | pins clear form emits `MNEMONIC=""`, normal form omits it |
| `internal/cerebrum-nb/consumer/actions.go` | modified | SetMnemonic("") selects the clear form |
| `internal/cerebrum-nb/consumer/session.go` | modified | raw RX/TX XML at debug level (was promised by `--debug`, never logged) |
| `internal/cerebrum-nb/docs/README.md` | modified | verb catalogue, live-validation status, live-wire truths |
| `internal/cerebrum-nb/docs/verbs.md` | modified | new §12 inventory + snapshot/ensure reference |
| `internal/cerebrum-nb/CLAUDE.md` | modified | verbs.md section count |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test -count=1 ./...` | all packages ok | 0 |
| `go vet ./...` | clean | — |
| `golangci-lint run` | clean (pre-commit hook) | — |

## Device tested

- [ ] ACP1 producer 10.100.0.102
- [ ] ACP2 producer 10.100.0.103
- [ ] ACP1 emulator 10.6.239.113
- [ ] ACP2 real device 10.41.40.195
- [x] Other (specify): production Cerebrum NB, NOC route-master 10.44.55.39:40009 (operator-driven)
- [ ] No device needed (pure codec / doc change)

**Live-LXC command + observed output** (paste verbatim):

```text
dhs consumer cerebrum-nb import 10.44.55.39 --port 40009 --user *** --pass *** --in-dir captures\cerebrum-nb --prefix noc --check
cerebrum-nb import: --in-dir resolved xpoint=captures\cerebrum-nb\noc-xpoint.csv src=captures\cerebrum-nb\noc-src.csv dst=captures\cerebrum-nb\noc-dst.csv levels=captures\cerebrum-nb\noc-level.csv
cerebrum-nb import --check: would_change=0 (0 route(s), 0 label(s)) of 1762 crosspoint(s)/25868 label row(s) desired — nothing sent
```

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [x] Integration tested on VM before PR (live production Cerebrum, read side + single-label apply; `--allow-clear` deliberately untested — staging-gated)

## Approval

@yboujraf — requesting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
