### PR TITLE
feat(cerebrum-nb): salvo --op description (0v16 §4.3 DESCRIPTION)

### DIFF
--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -549,10 +549,11 @@ func cerebrumListen(ctx context.Context, args []string) error {
 			Type: "ROUTE", IPAddress: router, DeviceType: codec.DeviceType("ROUTER"),
 			DestID: "*", LevelID: "*",
 		}},
-		{"ROUTING_CHANGE TYPE=SRCE_LOCK", &codec.RoutingChange{
-			Type: "SRCE_LOCK", IPAddress: router, DeviceType: codec.DeviceType("ROUTER"),
-			SrceID: "*",
-		}},
+		// SRCE_LOCK deliberately NOT subscribed: every live Cerebrum tested
+		// (RT + per-router, 2026-04..2026-08) NACKs it, and source locks
+		// are unreal in this production. Skipped with a notice below so a
+		// clean run shows 0 failed — re-add the row if a server ever
+		// grants it.
 		{"ROUTING_CHANGE TYPE=DEST_LOCK", &codec.RoutingChange{
 			Type: "DEST_LOCK", IPAddress: router, DeviceType: codec.DeviceType("ROUTER"),
 			DestID: "*", LevelID: "*",
@@ -582,7 +583,7 @@ func cerebrumListen(ctx context.Context, args []string) error {
 		}
 		ok++
 	}
-	fmt.Fprintf(os.Stderr, "subscribed: %d ok, %d failed; listening for events; Ctrl+C to stop\n", ok, fail)
+	fmt.Fprintf(os.Stderr, "subscribed: %d ok, %d failed (SRCE_LOCK skipped — every live Cerebrum NACKs it; re-enable if a server ever grants it); listening for events; Ctrl+C to stop\n", ok, fail)
 	<-ctx.Done()
 	return nil
 }

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -223,8 +223,8 @@ VERBS
   list-sources             one-shot OBTAIN SRCE_MNE  → every source: ID + capability levels + label + alts  [--id N] [--out FILE]
   list-dests               one-shot OBTAIN DEST_MNE  → same for destinations (alias: list-destinations)     [--id N] [--out FILE]
   list-levels              one-shot OBTAIN LEVEL_MNE → every level ID + name  [--id N] [--out FILE]
-  export                   one-shot OBTAIN wildcards → CSVs. Crosspoints only: [--out FILE] [--level N]. Full snapshot (src+dst+level mnemonics+xpoint): --out-dir DIR [--prefix P]
-  import                   ENSURE (ADR-0007): read live state, diff vs CSVs, converge only differences. --in-dir DIR [--prefix P] reads the set export wrote (missing files = out of scope), or per-file --xpoint (--csv alias) / --src / --dst / --levels. --check = report would_change, send nothing. --output json = ADR-0007 {changed|would_change, diff[]} on stdout. Empty cell/absent column = untouched; --allow-clear makes an empty MANAGED cell clear the live label. Run-twice = 0.
+  export                   one-shot OBTAIN wildcards → CSVs. Crosspoints only: [--out FILE] [--level N]. Full snapshot (src+dst+level mnemonics+xpoint+categories as -cat-src.csv/-cat-dst.csv): --out-dir DIR [--prefix P]
+  import                   ENSURE (ADR-0007): read live state, diff vs CSVs, converge only differences. --in-dir DIR [--prefix P] reads the set export wrote (missing files = out of scope), or per-file --xpoint (--csv alias) / --src / --dst / --levels / --cat-src / --cat-dst (categories: category,type,value rows — row order = slot order; builds the navigation panel). --check = report would_change, send nothing. --output json = ADR-0007 {changed|would_change, diff[]} on stdout. Empty cell/absent column = untouched; --allow-clear makes an empty MANAGED cell clear the live label. Run-twice = 0.
   list-devices             OBTAIN <device_change type='LIST'/>  [--device-type Router|SNMP|Device]
   device-details           OBTAIN <device_change type='DETAILS'/>  --device IP --device-type DEVICE
   device-value             OBTAIN <device_change type='VALUE'/>    --device NAME --by-name --sub-device X --object Y

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -557,9 +557,16 @@ func cerebrumListen(ctx context.Context, args []string) error {
 			Type: "DEST_LOCK", IPAddress: router, DeviceType: codec.DeviceType("ROUTER"),
 			DestID: "*", LevelID: "*",
 		}},
-		{"CATEGORY_CHANGE TYPE=CATEGORY_LIST", &codec.CategoryChange{Type: "CATEGORY_LIST"}},
-		{"SALVO_CHANGE TYPE=GROUP_LIST", &codec.SalvoChange{Type: "GROUP_LIST"}},
-		{"DEVICE_CHANGE TYPE=LIST", &codec.DeviceChange{Type: "LIST"}},
+	}
+	// Category / salvo / device rows exist only at Routemaster scope
+	// (owner rule: no cat/salvo on a physical ROUTER — 0.0.0.0 RT only).
+	// A per-router listen subscribes just the routing rows.
+	if router == "0.0.0.0" {
+		plan = append(plan,
+			sub{"CATEGORY_CHANGE TYPE=CATEGORY_LIST", &codec.CategoryChange{Type: "CATEGORY_LIST"}},
+			sub{"SALVO_CHANGE TYPE=GROUP_LIST", &codec.SalvoChange{Type: "GROUP_LIST"}},
+			sub{"DEVICE_CHANGE TYPE=LIST", &codec.DeviceChange{Type: "LIST"}},
+		)
 	}
 	var ok, fail int
 	for _, p := range plan {

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -1285,9 +1285,27 @@ func printEventLabeled(f *codec.Frame, srcNames map[string]string) {
 				fmt.Printf("           %-10s %-20s %s\n", d.DeviceType, displayName(d.DeviceName), d.IPAddress)
 			}
 		} else {
-			fmt.Printf("[device] %-8s type=%s name=%s ip=%s sub=%s obj=%s\n",
-				f.Device.Type, f.Device.DeviceType, f.Device.DeviceName,
-				f.Device.IPAddress, f.Device.SubDevice, f.Device.Object)
+			// Only print the attrs the row kind actually carries: SUB_DEVICE/
+			// OBJECT belong to VALUE rows; on DETAILS the name lives in the
+			// <DETAILS> child, not the outer attribute.
+			name := f.Device.DeviceName
+			if name == "" && f.Device.Details != nil {
+				name = f.Device.Details.Name
+			}
+			line := fmt.Sprintf("[device] %-8s type=%s", f.Device.Type, f.Device.DeviceType)
+			if name != "" {
+				line += " name=" + name
+			}
+			if f.Device.IPAddress != "" {
+				line += " ip=" + f.Device.IPAddress
+			}
+			if f.Device.SubDevice != "" {
+				line += " sub=" + f.Device.SubDevice
+			}
+			if f.Device.Object != "" {
+				line += " obj=" + f.Device.Object
+			}
+			fmt.Println(line)
 			for _, ov := range f.Device.ObjectValues {
 				fmt.Printf("           %-40s available=%s value=%q\n", ov.Object, boolFlag(ov.Available), ov.Value)
 			}

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -1291,10 +1291,14 @@ func printEventLabeled(f *codec.Frame, srcNames map[string]string) {
 		if srceName == "" && srcNames != nil {
 			srceName = srcNames[rawID]
 		}
-		fmt.Printf("[routing] %-8s dev=%s/%s srce=%s(%s) dest=%s(%s) lvl=%s(%s)\n",
+		line := fmt.Sprintf("[routing] %-8s dev=%s/%s srce=%s(%s) dest=%s(%s) lvl=%s(%s)",
 			rc.Type, rc.DeviceType, rc.DeviceName,
 			srceID, srceName, rc.DestID, rc.DestName,
 			rc.LevelID, rc.LevelName)
+		if rc.Lock != nil {
+			line += fmt.Sprintf(" state=%s by=%q", rc.Lock.LockState, rc.Lock.LockedBy)
+		}
+		fmt.Println(line)
 	case codec.KindCategoryChange:
 		if f.Category.Type == "CATEGORY_LIST" {
 			fmt.Printf("[category] CATEGORY_LIST count=%d %s\n", len(f.Category.Categories), summarise(f.Category.Categories))
@@ -1641,8 +1645,15 @@ func lockModeValue(mode string) (codec.LockKind, error) {
 		return codec.LockLockedPath, nil
 	case "protected_path", "protected-path":
 		return codec.LockProtectedPath, nil
+	case "released":
+		// Wire-actual, NOT spec (live 2026-08-16): a UI release reports
+		// LOCK_STATE="RELEASED" — a sixth value absent from the §3.2 table
+		// and the §4.1.2/4.1.3 worked examples (whose RELEASE the server
+		// NACKs, as it does UNLOCKED). RELEASED is the state machine's own
+		// cleared value and the candidate clearing action.
+		return codec.LockKind("RELEASED"), nil
 	default:
-		return "", fmt.Errorf("cerebrum-nb lock: unknown --mode %q (want unlocked|locked|protected|locked_path|protected_path)", mode)
+		return "", fmt.Errorf("cerebrum-nb lock: unknown --mode %q (want unlocked|locked|protected|locked_path|protected_path|released)", mode)
 	}
 }
 

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -232,7 +232,7 @@ VERBS
   device-value             OBTAIN <device_change type='VALUE'/>    --device NAME --by-name --sub-device X --object Y
   list-categories          OBTAIN <category_change type='CATEGORY_LIST'/>
   category-details         OBTAIN <category_change type='CATEGORY_DETAILS'/>  --category NAME
-  tree                     NB catalogue tree — canonical renderer (same as <proto> tree). Categories (§5.2: categories → SOURCE/DEST/CATEGORY items) + Salvos (§5.3: groups → instances → metadata)  [--domain salvos|categories|all] [--alt N | --no-mne] [--format ascii|plantuml] [--path P] [--depth N] [--filter S] [--out FILE]
+  tree                     NB catalogue tree — canonical renderer (same as <proto> tree). Categories (§5.2) + Salvos (§5.3)  [--domain salvos|categories|all] [--alt N | --no-mne]; DEVICE OBJECT TREE (acp2-walk analogue, §5.4.3 group obtains): --device NAME --by-name --sub-device N [--path GROUP] [--max-requests N]. Common: [--format ascii|plantuml] [--path P] [--depth N] [--filter S] [--out FILE]
   list-salvo-groups        OBTAIN <salvo_change type='GROUP_LIST'/>
   list-salvo-instances     OBTAIN <salvo_change type='INSTANCE_LIST'/>      --group NAME
   salvo-instance-details   OBTAIN <salvo_change type='INSTANCE_DETAILS'/>   --group NAME --instance NAME
@@ -764,7 +764,13 @@ func cerebrumDeviceValue(_ context.Context, args []string) error {
 		return fmt.Errorf("cerebrum-nb device-value: --device NAME is required (use --by-name)")
 	}
 	if subDev == "" || object == "" {
-		return fmt.Errorf("cerebrum-nb device-value: --sub-device and --object are both required")
+		return fmt.Errorf("cerebrum-nb device-value: --sub-device and --object are both required (use --object \".\" for the ROOT group listing)")
+	}
+	// Group paths return their CHILDREN (live 2026-08-16: a §5.4.3 obtain
+	// on "PROCESSING AUDIO" listed sub-groups as available=0 rows and leaf
+	// values inline) — "." is the CLI sentinel for the root listing.
+	if object == "." {
+		object = ""
 	}
 
 	p, sess, cf, _, err := connectAndLogin(rest, "device-value")
@@ -1201,7 +1207,10 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 		return fmt.Errorf("cerebrum-nb watch: --device IP|NAME is required")
 	}
 	if (subDev == "") != (object == "") {
-		return fmt.Errorf("cerebrum-nb watch: --sub-device and --object go together (both = VALUE watch, neither = DETAILS watch)")
+		return fmt.Errorf("cerebrum-nb watch: --sub-device and --object go together (both = VALUE watch, neither = DETAILS watch; --object \".\" = root group)")
+	}
+	if object == "." {
+		object = "" // root-group sentinel, same as device-value
 	}
 
 	args = reorderFlagsFirst(rest)

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -809,6 +809,15 @@ func cerebrumDeviceValue(_ context.Context, args []string) error {
 		if ov.Label != "" {
 			line += fmt.Sprintf(" label=%q", ov.Label)
 		}
+		if ov.Min != "" || ov.Max != "" {
+			line += fmt.Sprintf(" range=%s..%s", ov.Min, ov.Max)
+		}
+		if ov.Step != "" {
+			line += " step=" + ov.Step
+		}
+		if ov.Default != "" {
+			line += " default=" + ov.Default
+		}
 		if len(ov.EnumList) > 0 {
 			line += fmt.Sprintf(" enum=%s", strings.Join(ov.EnumList, "|"))
 		}
@@ -1226,8 +1235,11 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 	}
 
 	sess.OnEvent(codec.KindUnknown, func(f *codec.Frame) {
-		if f.Kind == codec.KindWildcardComplete && f.Root != nil && f.Root.Attr("mtid") == "" {
-			return
+		switch {
+		case f.Kind == codec.KindWildcardComplete && f.Root != nil && f.Root.Attr("mtid") == "":
+			return // spurious §1.6 deviation
+		case f.Kind == codec.KindAck:
+			return // transaction plumbing, not an event
 		}
 		printEventLabeled(f, nil)
 	})

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -230,7 +230,7 @@ VERBS
   device-value             OBTAIN <device_change type='VALUE'/>    --device NAME --by-name --sub-device X --object Y
   list-categories          OBTAIN <category_change type='CATEGORY_LIST'/>
   category-details         OBTAIN <category_change type='CATEGORY_DETAILS'/>  --category NAME
-  tree                     NB catalogue tree — canonical renderer (same as <proto> tree). Categories (§5.2: categories → SOURCE/DEST/CATEGORY items) + Salvos (§5.3: groups → instances → metadata)  [--domain salvos|categories|all] [--format ascii|plantuml] [--path P] [--depth N] [--filter S] [--out FILE]
+  tree                     NB catalogue tree — canonical renderer (same as <proto> tree). Categories (§5.2: categories → SOURCE/DEST/CATEGORY items) + Salvos (§5.3: groups → instances → metadata)  [--domain salvos|categories|all] [--alt N | --no-mne] [--format ascii|plantuml] [--path P] [--depth N] [--filter S] [--out FILE]
   list-salvo-groups        OBTAIN <salvo_change type='GROUP_LIST'/>
   list-salvo-instances     OBTAIN <salvo_change type='INSTANCE_LIST'/>      --group NAME
   salvo-instance-details   OBTAIN <salvo_change type='INSTANCE_DETAILS'/>   --group NAME --instance NAME

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -1586,7 +1586,7 @@ func routeTargetFromFlags(router, deviceName string) cerebrum.RouteTarget {
 
 func cerebrumLock(_ context.Context, args []string, mode codec.LockKind) error {
 	verb := "lock"
-	if mode == codec.LockRelease {
+	if mode == codec.LockRelease || mode == codec.LockReleased {
 		verb = "unlock"
 	}
 	args = reorderFlagsFirst(args)

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -276,19 +276,33 @@ func connectAndLogin(args []string, verb string) (*cerebrum.Plugin, *cerebrum.Se
 	if err := fs.Parse(args); err != nil {
 		return nil, nil, nil, nil, err
 	}
-	rest := fs.Args()
+	p, sess, rest, err := dialCerebrum(cf, fs.Args(), verb)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	return p, sess, cf, rest, nil
+}
+
+// dialCerebrum connects using ALREADY-PARSED connection flags. Verbs that
+// parse their own FlagSet (which registers the shared connection flags via
+// newCerebrumFlags) MUST call this with their cf + fs.Args() — handing
+// fs.Args() back to connectAndLogin re-parses only the leftover positionals,
+// silently dropping --port/--user/--pass/--log/--timeout (the bug that made
+// every §4 write verb dial the default port).
+func dialCerebrum(cf *cerebrumFlags, positionals []string, verb string) (*cerebrum.Plugin, *cerebrum.Session, []string, error) {
+	rest := positionals
 	if len(rest) < 1 {
-		return nil, nil, nil, nil, fmt.Errorf("cerebrum-nb %s: missing host[:port] argument", verb)
+		return nil, nil, nil, fmt.Errorf("cerebrum-nb %s: missing host[:port] argument", verb)
 	}
 	host, portArg, err := splitHostPort(rest[0], cf.port)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, err
 	}
 	cf.port = portArg
 
 	logger, _, lerr := cf.newLogger()
 	if lerr != nil {
-		return nil, nil, nil, nil, lerr
+		return nil, nil, nil, lerr
 	}
 
 	p := cerebrum.NewPlugin(logger)
@@ -306,14 +320,32 @@ func connectAndLogin(args []string, verb string) (*cerebrum.Plugin, *cerebrum.Se
 	ctx, cancel := context.WithTimeout(context.Background(), cf.timeout)
 	defer cancel()
 	if err := p.Connect(ctx, host, cf.port); err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, err
 	}
 	if p.Session().LoggedIn() {
 		fmt.Fprintf(os.Stderr, "connected; logged in.\n")
 	} else {
 		fmt.Fprintf(os.Stderr, "connected (no LOGIN — set --user/--pass for verbs that act on data).\n")
 	}
-	return p, p.Session(), cf, rest[1:], nil
+	return p, p.Session(), rest[1:], nil
+}
+
+// dialCerebrumAuth is dialCerebrum + mandatory authenticated session (the
+// §4 write-verb requirement — mirrors connectAndAuth for pre-parsed flags).
+func dialCerebrumAuth(cf *cerebrumFlags, positionals []string, verb string) (*cerebrum.Plugin, *cerebrum.Session, []string, error) {
+	p, sess, rest, err := dialCerebrum(cf, positionals, verb)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if !sess.LoggedIn() {
+		loginCtx, cancel := context.WithTimeout(context.Background(), cf.timeout)
+		defer cancel()
+		if err := p.Login(loginCtx); err != nil {
+			_ = p.Disconnect()
+			return nil, nil, nil, fmt.Errorf("cerebrum-nb %s: LOGIN required (set --user/--pass): %w", verb, err)
+		}
+	}
+	return p, sess, rest, nil
 }
 
 // ----------------------------------------------------------------------
@@ -1298,24 +1330,6 @@ func cerebrumRoute(_ context.Context, args []string) error {
 // $DHS_CEREBRUM_USER / $DHS_CEREBRUM_PASS) before sending the action.
 // ----------------------------------------------------------------------
 
-// connectAndAuth is connectAndLogin plus an explicit LOGIN — write actions
-// are rejected with NOT_LOGGED_IN on an unauthenticated session.
-func connectAndAuth(args []string, verb string) (*cerebrum.Plugin, *cerebrum.Session, *cerebrumFlags, []string, error) {
-	p, sess, cf, rest, err := connectAndLogin(args, verb)
-	if err != nil {
-		return nil, nil, nil, nil, err
-	}
-	if !sess.LoggedIn() {
-		loginCtx, cancel := context.WithTimeout(context.Background(), cf.timeout)
-		defer cancel()
-		if err := p.Login(loginCtx); err != nil {
-			_ = p.Disconnect()
-			return nil, nil, nil, nil, fmt.Errorf("cerebrum-nb %s: LOGIN required (set --user/--pass): %w", verb, err)
-		}
-	}
-	return p, sess, cf, rest, nil
-}
-
 // routeTargetFromFlags builds the router-addressing tuple. Defaults to the
 // route-master sentinel (0.0.0.0 / ROUTER) unless --router / --device-name
 // override it.
@@ -1338,7 +1352,7 @@ func cerebrumLock(_ context.Context, args []string, mode codec.LockKind) error {
 	}
 	args = reorderFlagsFirst(args)
 	fs := flag.NewFlagSet("cerebrum-nb "+verb, flag.ContinueOnError)
-	_ = newCerebrumFlags(fs)
+	cf := newCerebrumFlags(fs)
 	kind := fs.String("kind", "DEST_LOCK", "lock kind: SRCE_LOCK | DEST_LOCK")
 	router := fs.String("router", "0.0.0.0", "router IP target (route-master sentinel 0.0.0.0)")
 	deviceName := fs.String("device-name", "", "address by DEVICE_NAME instead of --router")
@@ -1365,12 +1379,12 @@ func cerebrumLock(_ context.Context, args []string, mode codec.LockKind) error {
 	if *srce == "" && *dest == "" {
 		return fmt.Errorf("cerebrum-nb %s: --srce or --dest is required", verb)
 	}
-	p, sess, cf2, _, err := connectAndAuth(fs.Args(), verb)
+	p, sess, _, err := dialCerebrumAuth(cf, fs.Args(), verb)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = p.Disconnect() }()
-	ctx, cancel := context.WithTimeout(context.Background(), cf2.timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), cf.timeout)
 	defer cancel()
 	if err := sess.Lock(ctx, *kind, mode, routeTargetFromFlags(*router, *deviceName), *srce, *dest, *level, *duration); err != nil {
 		return fmt.Errorf("cerebrum-nb %s: %w", verb, err)
@@ -1402,7 +1416,7 @@ func lockModeValue(mode string) (codec.LockKind, error) {
 func cerebrumSetMnemonic(_ context.Context, args []string) error {
 	args = reorderFlagsFirst(args)
 	fs := flag.NewFlagSet("cerebrum-nb set-mnemonic", flag.ContinueOnError)
-	_ = newCerebrumFlags(fs)
+	cf := newCerebrumFlags(fs)
 	kind := fs.String("kind", "DEST_MNE", "mnemonic kind: LEVEL_MNE | SRCE_MNE | DEST_MNE")
 	router := fs.String("router", "0.0.0.0", "router IP target")
 	deviceName := fs.String("device-name", "", "address by DEVICE_NAME")
@@ -1420,7 +1434,7 @@ func cerebrumSetMnemonic(_ context.Context, args []string) error {
 	if *mnemonic == "" {
 		return fmt.Errorf("cerebrum-nb set-mnemonic: --mnemonic is required")
 	}
-	p, sess, cf, _, err := connectAndAuth(fs.Args(), "set-mnemonic")
+	p, sess, _, err := dialCerebrumAuth(cf, fs.Args(), "set-mnemonic")
 	if err != nil {
 		return err
 	}
@@ -1437,7 +1451,7 @@ func cerebrumSetMnemonic(_ context.Context, args []string) error {
 func cerebrumSetTags(_ context.Context, args []string) error {
 	args = reorderFlagsFirst(args)
 	fs := flag.NewFlagSet("cerebrum-nb set-tags", flag.ContinueOnError)
-	_ = newCerebrumFlags(fs)
+	cf := newCerebrumFlags(fs)
 	kind := fs.String("kind", "RM_DEST_TAGS", "tags kind: RM_SRCE_TAGS | RM_DEST_TAGS")
 	router := fs.String("router", "0.0.0.0", "router IP target")
 	deviceName := fs.String("device-name", "", "address by DEVICE_NAME")
@@ -1453,7 +1467,7 @@ func cerebrumSetTags(_ context.Context, args []string) error {
 	if *tags == "" {
 		return fmt.Errorf("cerebrum-nb set-tags: --tags is required")
 	}
-	p, sess, cf, _, err := connectAndAuth(fs.Args(), "set-tags")
+	p, sess, _, err := dialCerebrumAuth(cf, fs.Args(), "set-tags")
 	if err != nil {
 		return err
 	}
@@ -1470,7 +1484,7 @@ func cerebrumSetTags(_ context.Context, args []string) error {
 func cerebrumSalvo(_ context.Context, args []string) error {
 	args = reorderFlagsFirst(args)
 	fs := flag.NewFlagSet("cerebrum-nb salvo", flag.ContinueOnError)
-	_ = newCerebrumFlags(fs)
+	cf := newCerebrumFlags(fs)
 	op := fs.String("op", "", "operation: run | save | rename | description | delete")
 	group := fs.String("group", "", "salvo group")
 	instance := fs.String("instance", "", "salvo instance")
@@ -1492,7 +1506,7 @@ func cerebrumSalvo(_ context.Context, args []string) error {
 	if salvoType == "DESCRIPTION" && *desc == "" {
 		return fmt.Errorf("cerebrum-nb salvo: --description is required for description")
 	}
-	p, sess, cf, _, err := connectAndAuth(fs.Args(), "salvo")
+	p, sess, _, err := dialCerebrumAuth(cf, fs.Args(), "salvo")
 	if err != nil {
 		return err
 	}
@@ -1509,7 +1523,7 @@ func cerebrumSalvo(_ context.Context, args []string) error {
 func cerebrumCategory(_ context.Context, args []string) error {
 	args = reorderFlagsFirst(args)
 	fs := flag.NewFlagSet("cerebrum-nb category", flag.ContinueOnError)
-	_ = newCerebrumFlags(fs)
+	cf := newCerebrumFlags(fs)
 	op := fs.String("op", "", "operation: create | modify | delete")
 	category := fs.String("category", "", "category name")
 	index := fs.String("index", "", "item index (modify)")
@@ -1526,7 +1540,7 @@ func cerebrumCategory(_ context.Context, args []string) error {
 	if *category == "" {
 		return fmt.Errorf("cerebrum-nb category: --category is required")
 	}
-	p, sess, cf, _, err := connectAndAuth(fs.Args(), "category")
+	p, sess, _, err := dialCerebrumAuth(cf, fs.Args(), "category")
 	if err != nil {
 		return err
 	}
@@ -1551,7 +1565,7 @@ func cerebrumCategory(_ context.Context, args []string) error {
 func cerebrumSetValue(_ context.Context, args []string) error {
 	args = reorderFlagsFirst(args)
 	fs := flag.NewFlagSet("cerebrum-nb set-value", flag.ContinueOnError)
-	_ = newCerebrumFlags(fs)
+	cf := newCerebrumFlags(fs)
 	device := fs.String("device", "", "device name (or use --ip)")
 	ip := fs.String("ip", "", "device IP address (alternative to --device, §4.4.1)")
 	subDevice := fs.String("sub-device", "", "sub-device")
@@ -1569,7 +1583,7 @@ func cerebrumSetValue(_ context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	p, sess, cf, _, err := connectAndAuth(fs.Args(), "set-value")
+	p, sess, _, err := dialCerebrumAuth(cf, fs.Args(), "set-value")
 	if err != nil {
 		return err
 	}
@@ -1621,7 +1635,7 @@ func setValueModeValue(mode string) (string, error) {
 func cerebrumObtainDatastore(_ context.Context, args []string) error {
 	args = reorderFlagsFirst(args)
 	fs := flag.NewFlagSet("cerebrum-nb obtain-datastore", flag.ContinueOnError)
-	_ = newCerebrumFlags(fs)
+	cf := newCerebrumFlags(fs)
 	name := fs.String("name", "", "datastore path/name")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -1629,7 +1643,7 @@ func cerebrumObtainDatastore(_ context.Context, args []string) error {
 	if *name == "" {
 		return fmt.Errorf("cerebrum-nb obtain-datastore: --name is required")
 	}
-	p, sess, cf, _, err := connectAndLogin(fs.Args(), "obtain-datastore")
+	p, sess, _, err := dialCerebrum(cf, fs.Args(), "obtain-datastore")
 	if err != nil {
 		return err
 	}
@@ -1686,7 +1700,7 @@ func cerebrumDeviceConfig(_ context.Context, args []string) error {
 	}
 	rest := reorderFlagsFirst(args[1:])
 	fs := flag.NewFlagSet("cerebrum-nb device-config "+op, flag.ContinueOnError)
-	_ = newCerebrumFlags(fs)
+	cf := newCerebrumFlags(fs)
 	deviceType := fs.String("device-type", "", "device type: generic | panel | router | snmp")
 	ip := fs.String("ip", "", "device IP_ADDRESS (required; the addressing key)")
 	dname := fs.String("device-name", "", "DEVICE_NAME (optional on add; with --ip identifies the device on modify)")
@@ -1739,7 +1753,7 @@ func cerebrumDeviceConfig(_ context.Context, args []string) error {
 		dc.DeviceType = dt
 	}
 
-	p, sess, cf, _, err := connectAndAuth(fs.Args(), "device-config")
+	p, sess, _, err := dialCerebrumAuth(cf, fs.Args(), "device-config")
 	if err != nil {
 		return err
 	}

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -173,6 +173,8 @@ func runCerebrum(ctx context.Context, args []string) error {
 		return cerebrumKeepaliveProbe(ctx, rest)
 	case "tree":
 		return cerebrumTree(ctx, rest)
+	case "watch":
+		return cerebrumWatch(ctx, rest)
 	case "route":
 		return cerebrumRoute(ctx, rest)
 	case "export":
@@ -235,6 +237,7 @@ VERBS
   list-salvo-instances     OBTAIN <salvo_change type='INSTANCE_LIST'/>      --group NAME
   salvo-instance-details   OBTAIN <salvo_change type='INSTANCE_DETAILS'/>   --group NAME --instance NAME
   keepalive-probe          DIAGNOSTIC — hold WS open, observe TCP keep-alives  [--idle DUR] [--send-login]
+  watch                    SUBSCRIBE one device (§5.4): --device IP [--device-type T] = DETAILS state watch; --device NAME --by-name --sub-device S --object O = VALUE watch (object path must be known — wildcards refused, live-verified)
 
   Write verbs (§4 ACTION — auto-LOGIN with --user/--pass; require an authenticated session)
   -----------------------  -----------------------------------------------
@@ -1160,6 +1163,82 @@ func obtainAndPrintDeviceList(sess *cerebrum.Session, deviceTypeFilter string) e
 	return nil
 }
 
+// cerebrumWatch subscribes to one device's changes — the DEVICE-class
+// analogue of `listen --router` (§2.4: SUBSCRIBE takes the same §5.4 rows):
+//
+//	watch --device IP [--device-type DEVICE|ROUTER|SNMP]
+//	    DETAILS subscribe — connection / sub-device state changes
+//	watch --device NAME --by-name --sub-device S --object O
+//	    VALUE subscribe — one object's value changes (object paths must be
+//	    known a priori; wildcards are refused on this row, live-verified)
+func cerebrumWatch(ctx context.Context, args []string) error {
+	device, deviceType, byName, rest, err := extractDeviceDetailsFlags(args)
+	if err != nil {
+		return err
+	}
+	subDev, rest, err := extractStringFlag(rest, "--sub-device")
+	if err != nil {
+		return err
+	}
+	object, rest, err := extractStringFlag(rest, "--object")
+	if err != nil {
+		return err
+	}
+	if device == "" {
+		return fmt.Errorf("cerebrum-nb watch: --device IP|NAME is required")
+	}
+	if (subDev == "") != (object == "") {
+		return fmt.Errorf("cerebrum-nb watch: --sub-device and --object go together (both = VALUE watch, neither = DETAILS watch)")
+	}
+
+	args = reorderFlagsFirst(rest)
+	fs := flag.NewFlagSet("cerebrum-nb watch", flag.ContinueOnError)
+	cf := newCerebrumFlags(fs)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	p, sess, _, err := dialCerebrumAuth(cf, fs.Args(), "watch")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = p.Disconnect() }()
+
+	dc := &codec.DeviceChange{}
+	if subDev != "" {
+		dc.Type = "VALUE"
+		dc.SubDevice = subDev
+		dc.Object = object
+		if byName {
+			dc.DeviceName = device
+		} else {
+			dc.IPAddress = device
+		}
+	} else {
+		// DETAILS addressing is IP-only (by-name NACKs — spec-conform).
+		dc.Type = "DETAILS"
+		dc.IPAddress = device
+		if deviceType == "" {
+			deviceType = "DEVICE"
+		}
+	}
+	if deviceType != "" {
+		dc.DeviceType = codec.DeviceType(strings.ToUpper(deviceType))
+	}
+
+	sess.OnEvent(codec.KindUnknown, func(f *codec.Frame) {
+		if f.Kind == codec.KindWildcardComplete && f.Root != nil && f.Root.Attr("mtid") == "" {
+			return
+		}
+		printEventLabeled(f, nil)
+	})
+	if err := sess.Subscribe(ctx, []codec.SubItem{dc}); err != nil {
+		return fmt.Errorf("cerebrum-nb watch: subscribe %s: %w", dc.Type, err)
+	}
+	fmt.Fprintf(os.Stderr, "watching DEVICE_CHANGE TYPE=%s on %s — Ctrl+C to stop\n", dc.Type, device)
+	<-ctx.Done()
+	return nil
+}
+
 // printEventLabeled renders one dispatched frame; srcNames (optional) joins
 // source labels by ID — the wire never carries a SOURCE_NAME on ROUTE rows
 // (§5.1.1), so listen pre-fetches the catalogue and fills them client-side.
@@ -1209,6 +1288,17 @@ func printEventLabeled(f *codec.Frame, srcNames map[string]string) {
 			fmt.Printf("[device] %-8s type=%s name=%s ip=%s sub=%s obj=%s\n",
 				f.Device.Type, f.Device.DeviceType, f.Device.DeviceName,
 				f.Device.IPAddress, f.Device.SubDevice, f.Device.Object)
+			for _, ov := range f.Device.ObjectValues {
+				fmt.Printf("           %-40s available=%s value=%q\n", ov.Object, boolFlag(ov.Available), ov.Value)
+			}
+			if c := f.Device.Connection; c != nil {
+				fmt.Printf("           connection primary=%q secondary=%q\n", c.PrimaryState, c.SecondaryState)
+			}
+			for _, sd := range f.Device.SubDevices {
+				if sd.PrimaryState != "" || sd.SecondaryState != "" {
+					fmt.Printf("           sub %02d %-20s primary=%q secondary=%q\n", sd.Index, displayName(sd.DeviceName), sd.PrimaryState, sd.SecondaryState)
+				}
+			}
 		}
 	case codec.KindDatastoreChange:
 		fmt.Printf("[datastore] %s type=%s\n", f.Datastore.Name, f.Datastore.Type)

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -218,7 +218,7 @@ VERBS
   Verb                     Wire
   -----------------------  -----------------------------------------------
   connect                  POLL (LOGIN auto when --user/--pass set)
-  listen                   SUBSCRIBE — routing / category / salvo / device events; Ctrl+C to stop
+  listen                   SUBSCRIBE — routing / category / salvo / device events; Ctrl+C to stop  [--router IP: point the routing subscriptions at a specific router instead of the route-master 0.0.0.0]
   route                    ACTION <ROUTING TYPE='ROUTE'/> — single (--dest --srce --level), batch (--route dst:src:lvl), or --csv FILE
   list-sources             one-shot OBTAIN SRCE_MNE  → every source: ID + capability levels + label + alts  [--id N] [--out FILE]
   list-dests               one-shot OBTAIN DEST_MNE  → same for destinations (alias: list-destinations)     [--id N] [--out FILE]
@@ -507,6 +507,17 @@ func cerebrumConnect(_ context.Context, args []string) error {
 }
 
 func cerebrumListen(ctx context.Context, args []string) error {
+	// --router points the ROUTING_CHANGE subscriptions at a specific
+	// router device instead of the route-master sentinel — the live
+	// experiment "does a crosspoint change surface per-device or only on
+	// the Routemaster?".
+	router, args, err := extractStringFlag(args, "--router")
+	if err != nil {
+		return err
+	}
+	if router == "" {
+		router = "0.0.0.0"
+	}
 	p, sess, _, _, err := connectAndLogin(args, "listen")
 	if err != nil {
 		return err
@@ -535,15 +546,15 @@ func cerebrumListen(ctx context.Context, args []string) error {
 		// row-specific ID wildcards from spec §5.1; missing them yields
 		// NACK ONE_OR_MORE_EVENTS_INVALID.
 		{"ROUTING_CHANGE TYPE=ROUTE", &codec.RoutingChange{
-			Type: "ROUTE", IPAddress: "0.0.0.0", DeviceType: codec.DeviceType("ROUTER"),
+			Type: "ROUTE", IPAddress: router, DeviceType: codec.DeviceType("ROUTER"),
 			DestID: "*", LevelID: "*",
 		}},
 		{"ROUTING_CHANGE TYPE=SRCE_LOCK", &codec.RoutingChange{
-			Type: "SRCE_LOCK", IPAddress: "0.0.0.0", DeviceType: codec.DeviceType("ROUTER"),
+			Type: "SRCE_LOCK", IPAddress: router, DeviceType: codec.DeviceType("ROUTER"),
 			SrceID: "*",
 		}},
 		{"ROUTING_CHANGE TYPE=DEST_LOCK", &codec.RoutingChange{
-			Type: "DEST_LOCK", IPAddress: "0.0.0.0", DeviceType: codec.DeviceType("ROUTER"),
+			Type: "DEST_LOCK", IPAddress: router, DeviceType: codec.DeviceType("ROUTER"),
 			DestID: "*", LevelID: "*",
 		}},
 		{"CATEGORY_CHANGE TYPE=CATEGORY_LIST", &codec.CategoryChange{Type: "CATEGORY_LIST"}},

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -741,8 +741,32 @@ func cerebrumDeviceValue(_ context.Context, args []string) error {
 	fmt.Printf("device      %s (%s)\n", d.IPAddress, displayName(d.DeviceName))
 	fmt.Printf("sub_device  %s\n", d.SubDevice)
 	fmt.Printf("object      %s\n", d.Object)
-	if d.ObjectValue != nil {
-		fmt.Printf("available   %s\n", boolFlag(d.ObjectValue.Available))
+	// Print EVERY OBJECT_VALUE child with the full 0v16 descriptor — a
+	// wildcard OBJECT/SUB_DEVICE obtain may return many.
+	if n := len(d.ObjectValues); n > 1 {
+		fmt.Printf("values      %d\n", n)
+	}
+	for _, ov := range d.ObjectValues {
+		line := fmt.Sprintf("  %-40s available=%s", ov.Object, boolFlag(ov.Available))
+		if ov.Value != "" {
+			line += fmt.Sprintf(" value=%q", ov.Value)
+		}
+		if ov.DataType != "" {
+			line += " type=" + ov.DataType
+		}
+		if ov.Readable || ov.Writable {
+			line += fmt.Sprintf(" rw=%s%s", boolFlag(ov.Readable), boolFlag(ov.Writable))
+		}
+		if ov.Units != "" {
+			line += " units=" + ov.Units
+		}
+		if ov.Label != "" {
+			line += fmt.Sprintf(" label=%q", ov.Label)
+		}
+		if len(ov.EnumList) > 0 {
+			line += fmt.Sprintf(" enum=%s", strings.Join(ov.EnumList, "|"))
+		}
+		fmt.Println(line)
 	}
 	return nil
 }

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -819,10 +819,10 @@ func cerebrumDeviceValue(_ context.Context, args []string) error {
 		if ov.Label != "" {
 			line += fmt.Sprintf(" label=%q", ov.Label)
 		}
-		if ov.Min != "" || ov.Max != "" {
+		if (ov.Min != "" || ov.Max != "") && ov.Min != ov.Max {
 			line += fmt.Sprintf(" range=%s..%s", ov.Min, ov.Max)
 		}
-		if ov.Step != "" {
+		if ov.Step != "" && ov.Step != "0.000000" {
 			line += " step=" + ov.Step
 		}
 		if ov.Default != "" {

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -243,7 +243,7 @@ VERBS
 
   Write verbs (§4 ACTION — auto-LOGIN with --user/--pass; require an authenticated session)
   -----------------------  -----------------------------------------------
-  lock                     ACTION <ROUTING LOCK='PROTECT'/>   --kind SRCE_LOCK|DEST_LOCK [--srce ID|--dest ID] --level ID [--duration S] [--mode locked|protected|locked_path|protected_path|unlocked]
+  lock                     ACTION <ROUTING LOCK='…'/>         --kind SRCE_LOCK|DEST_LOCK [--srce ID|--dest ID] [--level ID | "1;2;3" | omit = ALL levels] [--duration S] [--mode locked|protected|locked_path|protected_path|released]
   unlock                   ACTION <ROUTING LOCK='RELEASED'/>  (same flags as lock; RELEASED is the wire-actual clearing value — the spec's RELEASE/UNLOCKED NACK on live Cerebrums)
   device-config            <DEVICE_CONFIGURATION TYPE='ADD|MODIFY|REMOVE'/>  add|modify|remove --device-type generic|panel|router|snmp --ip IP [per-type flags]
   set-mnemonic             ACTION <ROUTING TYPE='*_MNE'/>     --kind LEVEL_MNE|SRCE_MNE|DEST_MNE [--srce|--dest ID] --level ID --mnemonic TXT [--alt SLOT]
@@ -1623,12 +1623,23 @@ func cerebrumLock(_ context.Context, args []string, mode codec.LockKind) error {
 		return err
 	}
 	defer func() { _ = p.Disconnect() }()
-	ctx, cancel := context.WithTimeout(context.Background(), cf.timeout)
-	defer cancel()
-	if err := sess.Lock(ctx, *kind, mode, routeTargetFromFlags(*router, *deviceName), *srce, *dest, *level, *duration); err != nil {
-		return fmt.Errorf("cerebrum-nb %s: %w", verb, err)
+	// --level takes one level, a ';'-separated list (client-side expansion,
+	// one action per level — the CSV grammar), or empty = the wire's
+	// all-level form (live-verified: locks every existing level in one
+	// action, nonexistent levels no-op).
+	levels := splitLevelCell(*level)
+	if len(levels) == 0 {
+		levels = []string{""}
 	}
-	fmt.Printf("[%s] OK %s mode=%s srce=%s dest=%s lvl=%s\n", verb, *kind, mode, displayDash(*srce), displayDash(*dest), displayDash(*level))
+	for _, lvl := range levels {
+		ctx, cancel := context.WithTimeout(context.Background(), cf.timeout)
+		err := sess.Lock(ctx, *kind, mode, routeTargetFromFlags(*router, *deviceName), *srce, *dest, lvl, *duration)
+		cancel()
+		if err != nil {
+			return fmt.Errorf("cerebrum-nb %s lvl=%s: %w", verb, displayDash(lvl), err)
+		}
+		fmt.Printf("[%s] OK %s mode=%s srce=%s dest=%s lvl=%s\n", verb, *kind, mode, displayDash(*srce), displayDash(*dest), displayDash(lvl))
+	}
 	return nil
 }
 

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -239,7 +240,8 @@ VERBS
   device-config            <DEVICE_CONFIGURATION TYPE='ADD|MODIFY|REMOVE'/>  add|modify|remove --device-type generic|panel|router|snmp --ip IP [per-type flags]
   set-mnemonic             ACTION <ROUTING TYPE='*_MNE'/>     --kind LEVEL_MNE|SRCE_MNE|DEST_MNE [--srce|--dest ID] --level ID --mnemonic TXT [--alt SLOT]
   set-tags                 ACTION <ROUTING TYPE='RM_*_TAGS'/> --kind RM_SRCE_TAGS|RM_DEST_TAGS [--srce|--dest ID] --tags a,b,c
-  salvo                    ACTION <SALVO TYPE='…'/>           --op run|save|rename|description|delete --group G [--instance I] [--new-name N] [--description D]
+  salvo                    ACTION <SALVO TYPE='…'/>           --op run|save|rename|description|delete --group G [--instance I] [--new-name N] [--description D] [--check] [--output json]
+                           ENSURE (ADR-0007): description/rename/delete read live state first — already-converged = changed:false, nothing sent; run/save are events (always fire, always changed). --check sends nothing.
   category                 ACTION <CATEGORY TYPE='…'/>        --op create|modify|delete --category C [--index N] [--name N] [--label L] [--description D]
   set-value                ACTION <DEVICE TYPE='SET_VALUE'/>  --device NAME --sub-device X --object Y --value V
   obtain-datastore         OBTAIN <datastore_change name='…'/>  --name PATH
@@ -1497,12 +1499,18 @@ func cerebrumSalvo(_ context.Context, args []string) error {
 	instance := fs.String("instance", "", "salvo instance")
 	newName := fs.String("new-name", "", "new name (rename)")
 	desc := fs.String("description", "", "description text (op=description; §4.3 DESCRIPTION)")
+	check := fs.Bool("check", false, "dry-run (ADR-0007): read live state, report would_change, send nothing")
+	output := fs.String("output", "text", "output format: text | json (ADR-0002; json = {changed|would_change, diff[]})")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 	salvoType, err := salvoOpType(*op)
 	if err != nil {
 		return err
+	}
+	jsonOut, oerr := resolveEnsureOutput(*output, false)
+	if oerr != nil {
+		return oerr
 	}
 	if *group == "" {
 		return fmt.Errorf("cerebrum-nb salvo: --group is required")
@@ -1518,10 +1526,84 @@ func cerebrumSalvo(_ context.Context, args []string) error {
 		return err
 	}
 	defer func() { _ = p.Disconnect() }()
+
+	// Ensure read phase (ADR-0007, probel-style: the verb itself converges).
+	// Stateful ops read live state and diff; RUN/SAVE are events — they
+	// always fire and always report changed (Ansible command-module rule).
+	changed := true
+	diffs := []ensureDiff{}
+	switch salvoType {
+	case "DESCRIPTION":
+		got, oe := obtainSingleSalvoChange(sess, cf.timeout,
+			&codec.SalvoChange{Type: "INSTANCE_DETAILS", Group: *group, Instance: *instance}, "INSTANCE_DETAILS")
+		if oe != nil {
+			return oe
+		}
+		if got == nil || got.Salvo == nil || got.Salvo.InstanceDetails == nil {
+			return fmt.Errorf("cerebrum-nb salvo: no INSTANCE_DETAILS reply for %s/%s (unknown instance?)", *group, *instance)
+		}
+		cur := got.Salvo.InstanceDetails.Description
+		if cur == *desc {
+			changed = false
+		} else {
+			diffs = append(diffs, ensureDiff{Field: "description", From: cur, To: *desc})
+		}
+	case "DELETE", "RENAME":
+		got, oe := obtainSingleSalvoChange(sess, cf.timeout,
+			&codec.SalvoChange{Type: "INSTANCE_LIST", Group: *group}, "INSTANCE_LIST")
+		if oe != nil {
+			return oe
+		}
+		if got == nil || got.Salvo == nil {
+			return fmt.Errorf("cerebrum-nb salvo: no INSTANCE_LIST reply for group %s", *group)
+		}
+		has := slices.Contains(got.Salvo.Instances, *instance)
+		if salvoType == "DELETE" {
+			if !has {
+				changed = false // already absent — idempotent no-op
+			} else {
+				diffs = append(diffs, ensureDiff{Field: "instance." + *instance, From: "present", To: "absent"})
+			}
+		} else {
+			switch {
+			case has:
+				diffs = append(diffs, ensureDiff{Field: "instance." + *instance, From: *instance, To: *newName})
+			case slices.Contains(got.Salvo.Instances, *newName):
+				changed = false // already renamed — idempotent no-op
+			default:
+				return fmt.Errorf("cerebrum-nb salvo: neither %q nor %q exists in group %q", *instance, *newName, *group)
+			}
+		}
+	default: // RUN / SAVE
+		diffs = append(diffs, ensureDiff{Field: "salvo." + displayDash(*instance), From: "", To: salvoType})
+	}
+
+	if *check {
+		if jsonOut {
+			return emitEnsure(true, ensureResult{WouldChange: &changed, Diff: diffs})
+		}
+		fmt.Printf("[salvo] --check %s group=%s instance=%s: would_change=%t — nothing sent\n",
+			salvoType, *group, displayDash(*instance), changed)
+		for _, d := range diffs {
+			fmt.Printf("  %s: %q -> %q\n", d.Field, d.From, d.To)
+		}
+		return nil
+	}
+	if !changed {
+		if jsonOut {
+			return emitEnsure(true, ensureResult{Changed: &changed, Diff: diffs})
+		}
+		fmt.Printf("[salvo] OK %s group=%s instance=%s (already converged — nothing sent)\n",
+			salvoType, *group, displayDash(*instance))
+		return nil
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), cf.timeout)
 	defer cancel()
 	if err := sess.Salvo(ctx, salvoType, *group, *instance, *newName, *desc); err != nil {
 		return fmt.Errorf("cerebrum-nb salvo: %w", err)
+	}
+	if jsonOut {
+		return emitEnsure(true, ensureResult{Changed: &changed, Diff: diffs})
 	}
 	fmt.Printf("[salvo] OK %s group=%s instance=%s\n", salvoType, *group, displayDash(*instance))
 	return nil

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -239,7 +239,7 @@ VERBS
   device-config            <DEVICE_CONFIGURATION TYPE='ADD|MODIFY|REMOVE'/>  add|modify|remove --device-type generic|panel|router|snmp --ip IP [per-type flags]
   set-mnemonic             ACTION <ROUTING TYPE='*_MNE'/>     --kind LEVEL_MNE|SRCE_MNE|DEST_MNE [--srce|--dest ID] --level ID --mnemonic TXT [--alt SLOT]
   set-tags                 ACTION <ROUTING TYPE='RM_*_TAGS'/> --kind RM_SRCE_TAGS|RM_DEST_TAGS [--srce|--dest ID] --tags a,b,c
-  salvo                    ACTION <SALVO TYPE='…'/>           --op run|save|rename|delete --group G [--instance I] [--new-name N] [--description D]
+  salvo                    ACTION <SALVO TYPE='…'/>           --op run|save|rename|description|delete --group G [--instance I] [--new-name N] [--description D]
   category                 ACTION <CATEGORY TYPE='…'/>        --op create|modify|delete --category C [--index N] [--name N] [--label L] [--description D]
   set-value                ACTION <DEVICE TYPE='SET_VALUE'/>  --device NAME --sub-device X --object Y --value V
   obtain-datastore         OBTAIN <datastore_change name='…'/>  --name PATH
@@ -1471,11 +1471,11 @@ func cerebrumSalvo(_ context.Context, args []string) error {
 	args = reorderFlagsFirst(args)
 	fs := flag.NewFlagSet("cerebrum-nb salvo", flag.ContinueOnError)
 	_ = newCerebrumFlags(fs)
-	op := fs.String("op", "", "operation: run | save | rename | delete")
+	op := fs.String("op", "", "operation: run | save | rename | description | delete")
 	group := fs.String("group", "", "salvo group")
 	instance := fs.String("instance", "", "salvo instance")
 	newName := fs.String("new-name", "", "new name (rename)")
-	desc := fs.String("description", "", "description (save)")
+	desc := fs.String("description", "", "description text (op=description; §4.3 DESCRIPTION)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -1488,6 +1488,9 @@ func cerebrumSalvo(_ context.Context, args []string) error {
 	}
 	if salvoType == "RENAME" && *newName == "" {
 		return fmt.Errorf("cerebrum-nb salvo: --new-name is required for rename")
+	}
+	if salvoType == "DESCRIPTION" && *desc == "" {
+		return fmt.Errorf("cerebrum-nb salvo: --description is required for description")
 	}
 	p, sess, cf, _, err := connectAndAuth(fs.Args(), "salvo")
 	if err != nil {
@@ -1854,12 +1857,14 @@ func salvoOpType(op string) (string, error) {
 		return "SAVE", nil
 	case "rename":
 		return "RENAME", nil
+	case "description":
+		return "DESCRIPTION", nil
 	case "delete":
 		return "DELETE", nil
 	case "":
-		return "", fmt.Errorf("cerebrum-nb salvo: --op is required (run|save|rename|delete)")
+		return "", fmt.Errorf("cerebrum-nb salvo: --op is required (run|save|rename|description|delete)")
 	default:
-		return "", fmt.Errorf("cerebrum-nb salvo: unknown --op %q (want run|save|rename|delete)", op)
+		return "", fmt.Errorf("cerebrum-nb salvo: unknown --op %q (want run|save|rename|description|delete)", op)
 	}
 }
 

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -671,6 +671,11 @@ func cerebrumDeviceDetails(_ context.Context, args []string) error {
 	if len(d.SubDevices) > 0 {
 		fmt.Printf("sub_devices  %d\n", len(d.SubDevices))
 		for _, e := range d.SubDevices {
+			if e.PrimaryState != "" || e.SecondaryState != "" {
+				// Positional DEVICE_N shape (live NOC): index + model + states.
+				fmt.Printf("  %02d  %-20s primary=%q secondary=%q\n", e.Index, displayName(e.DeviceName), e.PrimaryState, e.SecondaryState)
+				continue
+			}
 			fmt.Printf("  %-12s %-20s %s\n", e.DeviceType, displayName(e.DeviceName), e.IPAddress)
 		}
 	}

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -171,6 +171,8 @@ func runCerebrum(ctx context.Context, args []string) error {
 		return cerebrumSalvoInstanceDetails(ctx, rest)
 	case "keepalive-probe":
 		return cerebrumKeepaliveProbe(ctx, rest)
+	case "tree":
+		return cerebrumTree(ctx, rest)
 	case "route":
 		return cerebrumRoute(ctx, rest)
 	case "export":
@@ -228,6 +230,7 @@ VERBS
   device-value             OBTAIN <device_change type='VALUE'/>    --device NAME --by-name --sub-device X --object Y
   list-categories          OBTAIN <category_change type='CATEGORY_LIST'/>
   category-details         OBTAIN <category_change type='CATEGORY_DETAILS'/>  --category NAME
+  tree                     NB catalogue tree — canonical renderer (same as <proto> tree). Categories (§5.2: categories → SOURCE/DEST/CATEGORY items) + Salvos (§5.3: groups → instances → metadata)  [--domain salvos|categories|all] [--format ascii|plantuml] [--path P] [--depth N] [--filter S] [--out FILE]
   list-salvo-groups        OBTAIN <salvo_change type='GROUP_LIST'/>
   list-salvo-instances     OBTAIN <salvo_change type='INSTANCE_LIST'/>      --group NAME
   salvo-instance-details   OBTAIN <salvo_change type='INSTANCE_DETAILS'/>   --group NAME --instance NAME

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -524,9 +524,33 @@ func cerebrumListen(ctx context.Context, args []string) error {
 	}
 	defer func() { _ = p.Disconnect() }()
 
-	// Print every dispatched event. Wildcard-everything subscription.
+	// Source-label join: ROUTE rows never carry a source name (§5.1.1), so
+	// pre-fetch the source catalogue once and fill labels client-side.
+	// Lenient — a NACK (e.g. per-router MNE not granted) just means events
+	// print IDs only.
+	srcNames := map[string]string{}
+	if sess.LoggedIn() {
+		if st, serr := cerebrumObtainState(ctx, sess, router, "ROUTER", 10*time.Second, cerebrumStateWant{
+			SrcMne: true, Verb: "listen",
+		}); serr == nil {
+			for _, r := range st.Src {
+				srcNames[r.ID] = r.Mnemonic
+			}
+			fmt.Fprintf(os.Stderr, "source labels: %d loaded for %s\n", len(srcNames), router)
+		} else {
+			fmt.Fprintf(os.Stderr, "source labels unavailable for %s (%v) — events print IDs only\n", router, serr)
+		}
+	}
+
+	// Print every dispatched event. Wildcard-everything subscription. The
+	// spurious MTID-less WILDCARD_COMPLETE the server emits after every
+	// event (§1.6 deviation, live-verified) is suppressed from the display;
+	// MTID-carrying completes (real end-of-snapshot markers) still print.
 	sess.OnEvent(codec.KindUnknown, func(f *codec.Frame) {
-		printEvent(f)
+		if f.Kind == codec.KindWildcardComplete && f.Root != nil && f.Root.Attr("mtid") == "" {
+			return
+		}
+		printEventLabeled(f, srcNames)
 	})
 
 	// Submit one SUBSCRIBE per item, each with its own mtid, so a NACK
@@ -1136,7 +1160,10 @@ func obtainAndPrintDeviceList(sess *cerebrum.Session, deviceTypeFilter string) e
 	return nil
 }
 
-func printEvent(f *codec.Frame) {
+// printEventLabeled renders one dispatched frame; srcNames (optional) joins
+// source labels by ID — the wire never carries a SOURCE_NAME on ROUTE rows
+// (§5.1.1), so listen pre-fetches the catalogue and fills them client-side.
+func printEventLabeled(f *codec.Frame, srcNames map[string]string) {
 	switch f.Kind {
 	case codec.KindRoutingChange:
 		rc := f.Routing
@@ -1145,11 +1172,16 @@ func printEvent(f *codec.Frame) {
 		// top-level srce_id attribute. SRCE_LOCK / DEST_LOCK / *_MNE rows
 		// keep the source on the top-level attrs as before.
 		srceID, srceName := rc.SrceID, rc.SrceName
+		rawID := rc.SrceID
 		if rc.Type == "ROUTE" && rc.RouteSourceID != "" {
+			rawID = rc.RouteSourceID
 			srceID = rc.RouteSourceID
 			if rc.RouteSourceLevelID != "" && rc.RouteSourceLevelID != rc.LevelID {
 				srceID = fmt.Sprintf("%s@lvl%s", rc.RouteSourceID, rc.RouteSourceLevelID)
 			}
+		}
+		if srceName == "" && srcNames != nil {
+			srceName = srcNames[rawID]
 		}
 		fmt.Printf("[routing] %-8s dev=%s/%s srce=%s(%s) dest=%s(%s) lvl=%s(%s)\n",
 			rc.Type, rc.DeviceType, rc.DeviceName,

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -190,7 +190,9 @@ func runCerebrum(ctx context.Context, args []string) error {
 	case "lock":
 		return cerebrumLock(ctx, rest, codec.LockProtect)
 	case "unlock":
-		return cerebrumLock(ctx, rest, codec.LockRelease)
+		// Default = RELEASED, the wire-actual clearing value (live
+		// 2026-08-16: the spec's RELEASE / UNLOCKED both NACK 8).
+		return cerebrumLock(ctx, rest, codec.LockReleased)
 	case "device-config":
 		return cerebrumDeviceConfig(ctx, rest)
 	case "set-mnemonic":
@@ -242,7 +244,7 @@ VERBS
   Write verbs (§4 ACTION — auto-LOGIN with --user/--pass; require an authenticated session)
   -----------------------  -----------------------------------------------
   lock                     ACTION <ROUTING LOCK='PROTECT'/>   --kind SRCE_LOCK|DEST_LOCK [--srce ID|--dest ID] --level ID [--duration S] [--mode locked|protected|locked_path|protected_path|unlocked]
-  unlock                   ACTION <ROUTING LOCK='RELEASE'/>   (same flags as lock)
+  unlock                   ACTION <ROUTING LOCK='RELEASED'/>  (same flags as lock; RELEASED is the wire-actual clearing value — the spec's RELEASE/UNLOCKED NACK on live Cerebrums)
   device-config            <DEVICE_CONFIGURATION TYPE='ADD|MODIFY|REMOVE'/>  add|modify|remove --device-type generic|panel|router|snmp --ip IP [per-type flags]
   set-mnemonic             ACTION <ROUTING TYPE='*_MNE'/>     --kind LEVEL_MNE|SRCE_MNE|DEST_MNE [--srce|--dest ID] --level ID --mnemonic TXT [--alt SLOT]
   set-tags                 ACTION <ROUTING TYPE='RM_*_TAGS'/> --kind RM_SRCE_TAGS|RM_DEST_TAGS [--srce|--dest ID] --tags a,b,c

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -627,7 +627,11 @@ func cerebrumDeviceDetails(_ context.Context, args []string) error {
 		dc.IPAddress = device
 	}
 	if deviceType != "" {
-		dc.DeviceType = codec.DeviceType(deviceType)
+		// Wire-actual: the server is case-sensitive on DEVICE_TYPE values
+		// and accepts the UPPERCASE forms only (live 2026-08-16: "Router"
+		// NACKs 10, "ROUTER" answers) — normalize so operators can type
+		// either.
+		dc.DeviceType = codec.DeviceType(strings.ToUpper(deviceType))
 	}
 	obCtx, cancel := context.WithTimeout(context.Background(), cf.timeout)
 	defer cancel()

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -885,8 +885,15 @@ func cerebrumSalvoInstanceDetails(_ context.Context, args []string) error {
 	s := got.Salvo
 	fmt.Printf("group       %s\n", s.Group)
 	fmt.Printf("instance    %s\n", s.Instance)
-	if s.InstanceDetails != nil {
-		fmt.Printf("available   %s\n", boolFlag(s.InstanceDetails.Available))
+	if d := s.InstanceDetails; d != nil {
+		fmt.Printf("available   %s\n", boolFlag(d.Available))
+		fmt.Printf("active      %s\n", boolFlag(d.Active))
+		if d.Description != "" {
+			fmt.Printf("description %s\n", d.Description)
+		}
+		if d.Date != "" || d.Time != "" {
+			fmt.Printf("saved       %s %s\n", d.Date, d.Time)
+		}
 	}
 	return nil
 }

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -604,6 +604,9 @@ func cerebrumListen(ctx context.Context, args []string) error {
 		// dies the underlying read returns immediately.
 		err := sess.Subscribe(ctx, []codec.SubItem{p.item})
 		if err != nil {
+			if errors.Is(err, context.Canceled) || ctx.Err() != nil {
+				return nil // Ctrl+C mid-subscribe — clean exit
+			}
 			slog.Warn("subscribe failed", "plugin", "cerebrum-nb", "item", p.name, "err", err)
 			fail++
 			continue
@@ -612,6 +615,7 @@ func cerebrumListen(ctx context.Context, args []string) error {
 	}
 	fmt.Fprintf(os.Stderr, "subscribed: %d ok, %d failed (SRCE_LOCK skipped — every live Cerebrum NACKs it; re-enable if a server ever grants it); listening for events; Ctrl+C to stop\n", ok, fail)
 	<-ctx.Done()
+	fmt.Fprintln(os.Stderr, "listen stopped.")
 	return nil
 }
 
@@ -1244,10 +1248,14 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 		printEventLabeled(f, nil)
 	})
 	if err := sess.Subscribe(ctx, []codec.SubItem{dc}); err != nil {
+		if errors.Is(err, context.Canceled) || ctx.Err() != nil {
+			return nil // Ctrl+C during subscribe — clean exit, not an error
+		}
 		return fmt.Errorf("cerebrum-nb watch: subscribe %s: %w", dc.Type, err)
 	}
 	fmt.Fprintf(os.Stderr, "watching DEVICE_CHANGE TYPE=%s on %s — Ctrl+C to stop\n", dc.Type, device)
 	<-ctx.Done()
+	fmt.Fprintln(os.Stderr, "watch stopped.")
 	return nil
 }
 

--- a/cmd/dhs/cmd_cerebrum_cat.go
+++ b/cmd/dhs/cmd_cerebrum_cat.go
@@ -94,12 +94,15 @@ func parseCerebrumCatCSV(data []byte, kind, srcName string) ([]cerebrumCatDef, e
 		switch kind {
 		case "src":
 			if typ == "DEST" {
-				return nil, fmt.Errorf("%s line %d: DEST item in the SRC category file — keep SRC and DST files separate", srcName, start+n+2)
+				return nil, fmt.Errorf("%s line %d: DEST item in the SRC category file — keep SRC and DST files separate (genuinely mixed categories belong in the -cat-mixed.csv file)", srcName, start+n+2)
 			}
 		case "dst":
 			if typ == "SOURCE" || typ == "SRCE" {
-				return nil, fmt.Errorf("%s line %d: %s item in the DST category file — keep SRC and DST files separate", srcName, start+n+2, typ)
+				return nil, fmt.Errorf("%s line %d: %s item in the DST category file — keep SRC and DST files separate (genuinely mixed categories belong in the -cat-mixed.csv file)", srcName, start+n+2, typ)
 			}
+		case "mixed":
+			// both kinds legal — the file for categories whose subtree
+			// carries sources AND dests (e.g. a master category).
 		}
 		i, seen := byName[cat]
 		if !seen {

--- a/cmd/dhs/cmd_cerebrum_cat.go
+++ b/cmd/dhs/cmd_cerebrum_cat.go
@@ -224,21 +224,18 @@ func fetchCerebrumCategories(sess *cerebrum.Session, timeout time.Duration) ([]s
 }
 
 // classifyCerebrumCategories splits the live category set into src / dst
-// for the two-file export: a category counts as src when its subtree
-// contains any SOURCE/SRCE item, dst when it contains any DEST item
-// (recursing through CATEGORY references). Categories whose subtree has
-// both are reported in BOTH files (and counted for the caller's warning);
-// categories with neither (pure TEXT / empty) land where they are
-// referenced, or nowhere when unreferenced.
+// for the two-file export. A category's own DIRECT resource items decide
+// (owner rule: src stays src, dst stays dst — the SRC-/DST- name prefix
+// is convention, e.g. a "DST-…" gateway category may legitimately hold
+// SOURCE ports); only categories with NO direct resource items (pure
+// parents holding CATEGORY/TEXT rows, like the SOURCES / DESTINATIONS
+// masters) recurse into their children to inherit a side. A category
+// whose DIRECT items carry both kinds is reported as mixed (own file);
+// subtree diversity alone never makes a parent mixed.
 func classifyCerebrumCategories(names []string, details map[string]*codec.CategoryDetailsInfo) (src, dst map[string]bool, both []string) {
 	src = map[string]bool{}
 	dst = map[string]bool{}
-	var walk func(cat string, visited map[string]bool) (hasSrc, hasDst bool)
-	walk = func(cat string, visited map[string]bool) (bool, bool) {
-		if visited[cat] {
-			return false, false
-		}
-		visited[cat] = true
+	direct := func(cat string) (bool, bool) {
 		d := details[cat]
 		if d == nil {
 			return false, false
@@ -250,24 +247,48 @@ func classifyCerebrumCategories(names []string, details map[string]*codec.Catego
 				hasSrc = true
 			case "DEST", "DESTINATION":
 				hasDst = true
-			case "CATEGORY":
-				s, dd := walk(it.Value, visited)
-				hasSrc = hasSrc || s
-				hasDst = hasDst || dd
 			}
 		}
 		return hasSrc, hasDst
 	}
+	var subtree func(cat string, visited map[string]bool) (bool, bool)
+	subtree = func(cat string, visited map[string]bool) (bool, bool) {
+		if visited[cat] {
+			return false, false
+		}
+		visited[cat] = true
+		hasSrc, hasDst := direct(cat)
+		if hasSrc || hasDst {
+			return hasSrc, hasDst
+		}
+		d := details[cat]
+		if d == nil {
+			return false, false
+		}
+		for _, it := range d.Items {
+			if it.Type != "CATEGORY" {
+				continue
+			}
+			s, dd := subtree(it.Value, visited)
+			hasSrc = hasSrc || s
+			hasDst = hasDst || dd
+		}
+		return hasSrc, hasDst
+	}
 	for _, cat := range names {
-		hasSrc, hasDst := walk(cat, map[string]bool{})
+		hasSrc, hasDst := direct(cat)
+		if !hasSrc && !hasDst {
+			hasSrc, hasDst = subtree(cat, map[string]bool{})
+		}
+		if hasSrc && hasDst {
+			both = append(both, cat)
+			continue
+		}
 		if hasSrc {
 			src[cat] = true
 		}
 		if hasDst {
 			dst[cat] = true
-		}
-		if hasSrc && hasDst {
-			both = append(both, cat)
 		}
 	}
 	return src, dst, both

--- a/cmd/dhs/cmd_cerebrum_cat.go
+++ b/cmd/dhs/cmd_cerebrum_cat.go
@@ -169,6 +169,11 @@ func diffCerebrumCategory(cat string, live *codec.CategoryDetailsInfo, desired [
 	for i, want := range desired {
 		slot := i + 1
 		cur, ok := liveByIdx[slot]
+		// A desired BLANK over an empty (or already-BLANK) live slot is a
+		// no-op — gaps round-trip without churn.
+		if strings.EqualFold(want.Type, "BLANK") && (!ok || strings.EqualFold(cur.Type, "BLANK")) {
+			continue
+		}
 		if ok && strings.EqualFold(cur.Type, want.Type) && cur.Value == want.Value {
 			continue
 		}
@@ -295,7 +300,11 @@ func classifyCerebrumCategories(names []string, details map[string]*codec.Catego
 }
 
 // cerebrumCatDefsFromLive renders the live grids of the given categories
-// (in list order) as CSV defs — the export side of the round-trip.
+// (in list order) as CSV defs — the export side of the round-trip. The
+// wire omits BLANK slots but keeps real indices, so gaps are materialized
+// as explicit BLANK rows: row order in the CSV is then EXACTLY the live
+// slot order and the import diff reports 0 on an untouched export
+// (live-found: packed export produced 331 phantom re-pack changes).
 func cerebrumCatDefsFromLive(names []string, pick map[string]bool, details map[string]*codec.CategoryDetailsInfo) []cerebrumCatDef {
 	var defs []cerebrumCatDef
 	for _, cat := range names {
@@ -306,9 +315,21 @@ func cerebrumCatDefsFromLive(names []string, pick map[string]bool, details map[s
 		if d == nil {
 			continue
 		}
-		def := cerebrumCatDef{Name: cat}
+		byIdx := map[int]codec.CategoryItem{}
+		maxIdx := 0
 		for _, it := range d.Items {
-			def.Items = append(def.Items, cerebrumCatItem{Type: it.Type, Value: it.Value})
+			byIdx[it.Index] = it
+			if it.Index > maxIdx {
+				maxIdx = it.Index
+			}
+		}
+		def := cerebrumCatDef{Name: cat}
+		for slot := 1; slot <= maxIdx; slot++ {
+			if it, ok := byIdx[slot]; ok && !strings.EqualFold(it.Type, "BLANK") {
+				def.Items = append(def.Items, cerebrumCatItem{Type: it.Type, Value: it.Value})
+			} else {
+				def.Items = append(def.Items, cerebrumCatItem{Type: "BLANK", Value: ""})
+			}
 		}
 		defs = append(defs, def)
 	}

--- a/cmd/dhs/cmd_cerebrum_cat.go
+++ b/cmd/dhs/cmd_cerebrum_cat.go
@@ -1,0 +1,292 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"dhs/internal/cerebrum-nb/codec"
+	cerebrum "dhs/internal/cerebrum-nb/consumer"
+)
+
+// ----------------------------------------------------------------------
+// Category CSV — build/maintain the navigation panel (categories,
+// sub-categories, resources) from file, ensure-style (ADR-0007).
+//
+// Shape (minimal by owner decision — row order IS slot order):
+//
+//	category,type,value
+//	SRC-STUDIO-A,TEXT,Cameras
+//	SRC-STUDIO-A,SOURCE,10001
+//	SRC-ALL,CATEGORY,SRC-STUDIO-A
+//
+// SRC and DST live in SEPARATE files (probel file-set pattern:
+// <prefix>-cat-src.csv / <prefix>-cat-dst.csv): a DEST row in the src
+// file (or SOURCE/SRCE in the dst file) fails validation before any
+// wire I/O.
+// ----------------------------------------------------------------------
+
+// cerebrumCatItem is one desired item slot (§3.3 ITEM_TYPE + value).
+type cerebrumCatItem struct {
+	Type  string
+	Value string
+}
+
+// cerebrumCatDef is one category's complete desired grid, in slot order.
+type cerebrumCatDef struct {
+	Name  string
+	Items []cerebrumCatItem
+}
+
+// cerebrumCatItemTypes is the §3.3 ITEM_TYPE enum accepted in the CSV.
+var cerebrumCatItemTypes = map[string]bool{
+	"BLANK": true, "SRCE": true, "SOURCE": true, "DEST": true,
+	"CATEGORY": true, "SALVO": true, "INHERIT": true,
+	"TEXT": true, "FILE": true, "CUSTOM": true,
+}
+
+// parseCerebrumCatCSV decodes a category CSV. kind is "src" or "dst" and
+// enforces the SRC/DST file separation. Row order within a category is
+// the slot order (1-based). Blank lines and '#' comments are skipped.
+func parseCerebrumCatCSV(data []byte, kind, srcName string) ([]cerebrumCatDef, error) {
+	lines := strings.Split(strings.ReplaceAll(string(data), "\r\n", "\n"), "\n")
+	start := 0
+	for start < len(lines) && (strings.TrimSpace(lines[start]) == "" || strings.HasPrefix(strings.TrimSpace(lines[start]), "#")) {
+		start++
+	}
+	if start >= len(lines) {
+		return nil, fmt.Errorf("%s: empty (no header)", srcName)
+	}
+	header := strings.Split(strings.ToLower(strings.TrimSpace(lines[start])), ",")
+	idx := map[string]int{}
+	for i, h := range header {
+		idx[strings.TrimSpace(h)] = i
+	}
+	for _, col := range []string{"category", "type", "value"} {
+		if _, ok := idx[col]; !ok {
+			return nil, fmt.Errorf("%s: missing column %q (need category,type,value)", srcName, col)
+		}
+	}
+
+	var defs []cerebrumCatDef
+	byName := map[string]int{}
+	for n, line := range lines[start+1:] {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		f := strings.Split(line, ",")
+		if len(f) < len(header) {
+			return nil, fmt.Errorf("%s line %d: %d columns < header %d", srcName, start+n+2, len(f), len(header))
+		}
+		cat := strings.TrimSpace(f[idx["category"]])
+		typ := strings.ToUpper(strings.TrimSpace(f[idx["type"]]))
+		val := strings.TrimSpace(f[idx["value"]])
+		if cat == "" || typ == "" {
+			return nil, fmt.Errorf("%s line %d: category and type are required", srcName, start+n+2)
+		}
+		if !cerebrumCatItemTypes[typ] {
+			return nil, fmt.Errorf("%s line %d: unknown type %q (§3.3: BLANK|SRCE|SOURCE|DEST|CATEGORY|SALVO|INHERIT|TEXT|FILE|CUSTOM)", srcName, start+n+2, typ)
+		}
+		if val == "" && typ != "BLANK" {
+			return nil, fmt.Errorf("%s line %d: value is required for type %s", srcName, start+n+2, typ)
+		}
+		switch kind {
+		case "src":
+			if typ == "DEST" {
+				return nil, fmt.Errorf("%s line %d: DEST item in the SRC category file — keep SRC and DST files separate", srcName, start+n+2)
+			}
+		case "dst":
+			if typ == "SOURCE" || typ == "SRCE" {
+				return nil, fmt.Errorf("%s line %d: %s item in the DST category file — keep SRC and DST files separate", srcName, start+n+2, typ)
+			}
+		}
+		i, seen := byName[cat]
+		if !seen {
+			defs = append(defs, cerebrumCatDef{Name: cat})
+			i = len(defs) - 1
+			byName[cat] = i
+		}
+		defs[i].Items = append(defs[i].Items, cerebrumCatItem{Type: typ, Value: val})
+	}
+	if len(defs) == 0 {
+		return nil, fmt.Errorf("%s: no category rows", srcName)
+	}
+	return defs, nil
+}
+
+// formatCerebrumCatCSV renders defs back to the exact shape
+// parseCerebrumCatCSV reads — the export/import round-trip contract.
+func formatCerebrumCatCSV(defs []cerebrumCatDef) string {
+	var b strings.Builder
+	b.WriteString("category,type,value\n")
+	for _, d := range defs {
+		for _, it := range d.Items {
+			b.WriteString(d.Name)
+			b.WriteByte(',')
+			b.WriteString(it.Type)
+			b.WriteByte(',')
+			b.WriteString(it.Value)
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+// cerebrumCatChange is one converging category write.
+type cerebrumCatChange struct {
+	Cat   string
+	Op    string // CREATE | MODIFY_ITEM | (BLANK clear via MODIFY_ITEM)
+	Index int    // 1-based slot for MODIFY_ITEM
+	Type  string
+	Value string
+	From  string
+}
+
+// diffCerebrumCategory computes the per-slot converge for one category
+// (ADR-0007): desired row i owns slot i (1-based); a live slot beyond the
+// desired grid is cleared by writing ITEM_TYPE=BLANK (never DELETE_ITEM —
+// the spec does not define whether deletion shifts later indices, so
+// ensure must not assume). live == nil means the category does not exist:
+// a CREATE precedes the slot writes. Run-twice = 0.
+func diffCerebrumCategory(cat string, live *codec.CategoryDetailsInfo, desired []cerebrumCatItem) []cerebrumCatChange {
+	var out []cerebrumCatChange
+	liveByIdx := map[int]codec.CategoryItem{}
+	maxLive := 0
+	if live == nil {
+		out = append(out, cerebrumCatChange{Cat: cat, Op: "CREATE"})
+	} else {
+		for _, it := range live.Items {
+			liveByIdx[it.Index] = it
+			if it.Index > maxLive {
+				maxLive = it.Index
+			}
+		}
+	}
+	for i, want := range desired {
+		slot := i + 1
+		cur, ok := liveByIdx[slot]
+		if ok && strings.EqualFold(cur.Type, want.Type) && cur.Value == want.Value {
+			continue
+		}
+		from := ""
+		if ok {
+			from = fmt.Sprintf("%s %s", cur.Type, cur.Value)
+		}
+		out = append(out, cerebrumCatChange{
+			Cat: cat, Op: "MODIFY_ITEM", Index: slot,
+			Type: want.Type, Value: want.Value, From: from,
+		})
+	}
+	for slot := len(desired) + 1; slot <= maxLive; slot++ {
+		cur, ok := liveByIdx[slot]
+		if !ok || strings.EqualFold(cur.Type, "BLANK") {
+			continue
+		}
+		out = append(out, cerebrumCatChange{
+			Cat: cat, Op: "MODIFY_ITEM", Index: slot,
+			Type: "BLANK", Value: "",
+			From: fmt.Sprintf("%s %s", cur.Type, cur.Value),
+		})
+	}
+	return out
+}
+
+// fetchCerebrumCategories walks §5.2 once: CATEGORY_LIST then
+// CATEGORY_DETAILS per category. Shared by tree, export and import.
+func fetchCerebrumCategories(sess *cerebrum.Session, timeout time.Duration) ([]string, map[string]*codec.CategoryDetailsInfo, error) {
+	list, err := obtainSingleCategoryChange(sess, timeout,
+		&codec.CategoryChange{Type: "CATEGORY_LIST"}, "CATEGORY_LIST")
+	if err != nil {
+		return nil, nil, err
+	}
+	if list == nil || list.Category == nil {
+		return nil, nil, fmt.Errorf("cerebrum-nb: no CATEGORY_LIST reply within timeout")
+	}
+	names := list.Category.Categories
+	details := map[string]*codec.CategoryDetailsInfo{}
+	for _, cat := range names {
+		det, derr := obtainSingleCategoryChange(sess, timeout,
+			&codec.CategoryChange{Type: "CATEGORY_DETAILS", Category: cat}, "CATEGORY_DETAILS")
+		if derr != nil {
+			return nil, nil, derr
+		}
+		if det != nil && det.Category != nil {
+			details[cat] = det.Category.Details
+		} else {
+			details[cat] = nil
+		}
+	}
+	return names, details, nil
+}
+
+// classifyCerebrumCategories splits the live category set into src / dst
+// for the two-file export: a category counts as src when its subtree
+// contains any SOURCE/SRCE item, dst when it contains any DEST item
+// (recursing through CATEGORY references). Categories whose subtree has
+// both are reported in BOTH files (and counted for the caller's warning);
+// categories with neither (pure TEXT / empty) land where they are
+// referenced, or nowhere when unreferenced.
+func classifyCerebrumCategories(names []string, details map[string]*codec.CategoryDetailsInfo) (src, dst map[string]bool, both []string) {
+	src = map[string]bool{}
+	dst = map[string]bool{}
+	var walk func(cat string, visited map[string]bool) (hasSrc, hasDst bool)
+	walk = func(cat string, visited map[string]bool) (bool, bool) {
+		if visited[cat] {
+			return false, false
+		}
+		visited[cat] = true
+		d := details[cat]
+		if d == nil {
+			return false, false
+		}
+		hasSrc, hasDst := false, false
+		for _, it := range d.Items {
+			switch it.Type {
+			case "SOURCE", "SRCE":
+				hasSrc = true
+			case "DEST", "DESTINATION":
+				hasDst = true
+			case "CATEGORY":
+				s, dd := walk(it.Value, visited)
+				hasSrc = hasSrc || s
+				hasDst = hasDst || dd
+			}
+		}
+		return hasSrc, hasDst
+	}
+	for _, cat := range names {
+		hasSrc, hasDst := walk(cat, map[string]bool{})
+		if hasSrc {
+			src[cat] = true
+		}
+		if hasDst {
+			dst[cat] = true
+		}
+		if hasSrc && hasDst {
+			both = append(both, cat)
+		}
+	}
+	return src, dst, both
+}
+
+// cerebrumCatDefsFromLive renders the live grids of the given categories
+// (in list order) as CSV defs — the export side of the round-trip.
+func cerebrumCatDefsFromLive(names []string, pick map[string]bool, details map[string]*codec.CategoryDetailsInfo) []cerebrumCatDef {
+	var defs []cerebrumCatDef
+	for _, cat := range names {
+		if !pick[cat] {
+			continue
+		}
+		d := details[cat]
+		if d == nil {
+			continue
+		}
+		def := cerebrumCatDef{Name: cat}
+		for _, it := range d.Items {
+			def.Items = append(def.Items, cerebrumCatItem{Type: it.Type, Value: it.Value})
+		}
+		defs = append(defs, def)
+	}
+	return defs
+}

--- a/cmd/dhs/cmd_cerebrum_cat_test.go
+++ b/cmd/dhs/cmd_cerebrum_cat_test.go
@@ -48,6 +48,12 @@ func TestParseCerebrumCatCSV(t *testing.T) {
 			}
 		})
 	}
+
+	// kind=mixed accepts both resource kinds (the -cat-mixed.csv file).
+	mixedCSV := "category,type,value\nDESTINATIONS,DEST,4201\nDESTINATIONS,CATEGORY,SRC-ALL\nDESTINATIONS,SOURCE,7\n"
+	if _, err := parseCerebrumCatCSV([]byte(mixedCSV), "mixed", "m.csv"); err != nil {
+		t.Errorf("mixed kind must accept both: %v", err)
+	}
 }
 
 // TestDiffCerebrumCategory pins the per-slot ensure: identical grid = no

--- a/cmd/dhs/cmd_cerebrum_cat_test.go
+++ b/cmd/dhs/cmd_cerebrum_cat_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"dhs/internal/cerebrum-nb/codec"
+)
+
+// TestParseCerebrumCatCSV pins the minimal category CSV: row order = slot
+// order, §3.3 type validation, and the SRC/DST file separation rule.
+func TestParseCerebrumCatCSV(t *testing.T) {
+	csv := "category,type,value\n" +
+		"# nav panel\n" +
+		"SRC-STUDIO-A,TEXT,Cameras\n" +
+		"SRC-STUDIO-A,SOURCE,10001\n" +
+		"SRC-ALL,CATEGORY,SRC-STUDIO-A\n"
+	defs, err := parseCerebrumCatCSV([]byte(csv), "src", "t.csv")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	want := []cerebrumCatDef{
+		{Name: "SRC-STUDIO-A", Items: []cerebrumCatItem{{Type: "TEXT", Value: "Cameras"}, {Type: "SOURCE", Value: "10001"}}},
+		{Name: "SRC-ALL", Items: []cerebrumCatItem{{Type: "CATEGORY", Value: "SRC-STUDIO-A"}}},
+	}
+	if !reflect.DeepEqual(defs, want) {
+		t.Errorf("defs:\ngot  %+v\nwant %+v", defs, want)
+	}
+
+	// Round-trip: format -> parse is stable.
+	again, err := parseCerebrumCatCSV([]byte(formatCerebrumCatCSV(defs)), "src", "rt")
+	if err != nil || !reflect.DeepEqual(again, defs) {
+		t.Errorf("round-trip: %v / %+v", err, again)
+	}
+
+	for _, tc := range []struct{ name, kind, csv, want string }{
+		{"dest in src file", "src", "category,type,value\nC,DEST,5\n", "keep SRC and DST files separate"},
+		{"source in dst file", "dst", "category,type,value\nC,SOURCE,5\n", "keep SRC and DST files separate"},
+		{"bad type", "src", "category,type,value\nC,WAT,5\n", "unknown type"},
+		{"missing value", "src", "category,type,value\nC,SOURCE,\n", "value is required"},
+		{"no rows", "src", "category,type,value\n", "no category rows"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseCerebrumCatCSV([]byte(tc.csv), tc.kind, "t.csv")
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("err = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestDiffCerebrumCategory pins the per-slot ensure: identical grid = no
+// changes; differing/missing slots = MODIFY_ITEM; live slots beyond the
+// desired grid clear via ITEM_TYPE=BLANK (never DELETE_ITEM — index-shift
+// semantics undefined in the spec); absent category = CREATE + slots;
+// run-twice = 0.
+func TestDiffCerebrumCategory(t *testing.T) {
+	live := &codec.CategoryDetailsInfo{Items: []codec.CategoryItem{
+		{Index: 1, Type: "TEXT", Value: "Cameras"},
+		{Index: 2, Type: "SOURCE", Value: "10001"},
+		{Index: 3, Type: "SOURCE", Value: "10099"},
+	}}
+	desired := []cerebrumCatItem{
+		{Type: "TEXT", Value: "Cameras"},   // identical -> none
+		{Type: "SOURCE", Value: "10002"},   // differs -> modify slot 2
+	}
+	got := diffCerebrumCategory("C", live, desired)
+	want := []cerebrumCatChange{
+		{Cat: "C", Op: "MODIFY_ITEM", Index: 2, Type: "SOURCE", Value: "10002", From: "SOURCE 10001"},
+		{Cat: "C", Op: "MODIFY_ITEM", Index: 3, Type: "BLANK", Value: "", From: "SOURCE 10099"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("diff:\ngot  %+v\nwant %+v", got, want)
+	}
+
+	// Absent category: CREATE first, then every slot.
+	got = diffCerebrumCategory("NEW", nil, []cerebrumCatItem{{Type: "SOURCE", Value: "1"}})
+	if len(got) != 2 || got[0].Op != "CREATE" || got[1].Op != "MODIFY_ITEM" || got[1].Index != 1 {
+		t.Errorf("create diff = %+v", got)
+	}
+
+	// Run-twice = 0: live equal to desired yields nothing.
+	after := &codec.CategoryDetailsInfo{Items: []codec.CategoryItem{
+		{Index: 1, Type: "TEXT", Value: "Cameras"},
+		{Index: 2, Type: "SOURCE", Value: "10002"},
+		{Index: 3, Type: "BLANK", Value: ""},
+	}}
+	if again := diffCerebrumCategory("C", after, desired); len(again) != 0 {
+		t.Errorf("run-twice must be 0, got %+v", again)
+	}
+}
+
+// TestClassifyCerebrumCategories pins the SRC/DST export split: subtree
+// resource types decide, recursing through CATEGORY references; a subtree
+// with both kinds lands in both files and is reported.
+func TestClassifyCerebrumCategories(t *testing.T) {
+	names := []string{"SRC-A", "DST-B", "MIX", "PARENT-SRC"}
+	details := map[string]*codec.CategoryDetailsInfo{
+		"SRC-A":      {Items: []codec.CategoryItem{{Index: 1, Type: "SOURCE", Value: "1"}}},
+		"DST-B":      {Items: []codec.CategoryItem{{Index: 1, Type: "DEST", Value: "2"}}},
+		"MIX":        {Items: []codec.CategoryItem{{Index: 1, Type: "SOURCE", Value: "1"}, {Index: 2, Type: "DEST", Value: "2"}}},
+		"PARENT-SRC": {Items: []codec.CategoryItem{{Index: 1, Type: "CATEGORY", Value: "SRC-A"}}},
+	}
+	src, dst, both := classifyCerebrumCategories(names, details)
+	if !src["SRC-A"] || !src["PARENT-SRC"] || src["DST-B"] {
+		t.Errorf("src = %v", src)
+	}
+	if !dst["DST-B"] || dst["SRC-A"] {
+		t.Errorf("dst = %v", dst)
+	}
+	if len(both) != 1 || both[0] != "MIX" || !src["MIX"] || !dst["MIX"] {
+		t.Errorf("both = %v", both)
+	}
+}

--- a/cmd/dhs/cmd_cerebrum_cat_test.go
+++ b/cmd/dhs/cmd_cerebrum_cat_test.go
@@ -97,6 +97,40 @@ func TestDiffCerebrumCategory(t *testing.T) {
 	}
 }
 
+// TestCerebrumCatGapRoundTrip pins the live-found NOC bug: the wire omits
+// BLANK slots (grid 1,2,4 with 3 empty), so export must materialize gaps
+// as BLANK rows and the diff of that export against the same live state
+// must be EMPTY — no phantom re-pack (331 false changes on the first NOC
+// snapshot), no BLANK written onto an already-empty slot.
+func TestCerebrumCatGapRoundTrip(t *testing.T) {
+	live := &codec.CategoryDetailsInfo{Items: []codec.CategoryItem{
+		{Index: 1, Type: "SOURCE", Value: "9348"},
+		{Index: 2, Type: "SOURCE", Value: "9349"},
+		{Index: 4, Type: "SOURCE", Value: "9350"}, // slot 3 is a live gap
+	}}
+	names := []string{"SRC-HAIVISION"}
+	details := map[string]*codec.CategoryDetailsInfo{"SRC-HAIVISION": live}
+	defs := cerebrumCatDefsFromLive(names, map[string]bool{"SRC-HAIVISION": true}, details)
+	if len(defs) != 1 || len(defs[0].Items) != 4 {
+		t.Fatalf("defs = %+v, want 1 def with 4 rows (gap materialized)", defs)
+	}
+	if defs[0].Items[2].Type != "BLANK" {
+		t.Fatalf("slot 3 must export as BLANK, got %+v", defs[0].Items[2])
+	}
+	// The exported grid diffed against the same live state = zero changes.
+	if ch := diffCerebrumCategory("SRC-HAIVISION", live, defs[0].Items); len(ch) != 0 {
+		t.Errorf("untouched export must diff to 0, got %+v", ch)
+	}
+	// And the CSV itself round-trips through the parser.
+	reparsed, err := parseCerebrumCatCSV([]byte(formatCerebrumCatCSV(defs)), "src", "rt")
+	if err != nil {
+		t.Fatalf("reparse: %v", err)
+	}
+	if ch := diffCerebrumCategory("SRC-HAIVISION", live, reparsed[0].Items); len(ch) != 0 {
+		t.Errorf("parsed export must diff to 0, got %+v", ch)
+	}
+}
+
 // TestClassifyCerebrumCategories pins the SRC/DST export split: a
 // category's own DIRECT resource items decide (a "DST-…" gateway holding
 // SOURCE ports is a src category — names are convention); resource-less

--- a/cmd/dhs/cmd_cerebrum_cat_test.go
+++ b/cmd/dhs/cmd_cerebrum_cat_test.go
@@ -97,25 +97,34 @@ func TestDiffCerebrumCategory(t *testing.T) {
 	}
 }
 
-// TestClassifyCerebrumCategories pins the SRC/DST export split: subtree
-// resource types decide, recursing through CATEGORY references; a subtree
-// with both kinds lands in both files and is reported.
+// TestClassifyCerebrumCategories pins the SRC/DST export split: a
+// category's own DIRECT resource items decide (a "DST-…" gateway holding
+// SOURCE ports is a src category — names are convention); resource-less
+// parents inherit from their children; a parent with direct DEST items is
+// dst even when a referenced child carries sources (live NOC shape:
+// DESTINATIONS -> DST-PASSERELLES gateway); mixed = direct both only.
 func TestClassifyCerebrumCategories(t *testing.T) {
-	names := []string{"SRC-A", "DST-B", "MIX", "PARENT-SRC"}
+	names := []string{"SRC-A", "DST-B", "MIX", "PARENT-SRC", "DST-GATEWAY", "DESTINATIONS"}
 	details := map[string]*codec.CategoryDetailsInfo{
-		"SRC-A":      {Items: []codec.CategoryItem{{Index: 1, Type: "SOURCE", Value: "1"}}},
-		"DST-B":      {Items: []codec.CategoryItem{{Index: 1, Type: "DEST", Value: "2"}}},
-		"MIX":        {Items: []codec.CategoryItem{{Index: 1, Type: "SOURCE", Value: "1"}, {Index: 2, Type: "DEST", Value: "2"}}},
-		"PARENT-SRC": {Items: []codec.CategoryItem{{Index: 1, Type: "CATEGORY", Value: "SRC-A"}}},
+		"SRC-A":       {Items: []codec.CategoryItem{{Index: 1, Type: "SOURCE", Value: "1"}}},
+		"DST-B":       {Items: []codec.CategoryItem{{Index: 1, Type: "DEST", Value: "2"}}},
+		"MIX":         {Items: []codec.CategoryItem{{Index: 1, Type: "SOURCE", Value: "1"}, {Index: 2, Type: "DEST", Value: "2"}}},
+		"PARENT-SRC":  {Items: []codec.CategoryItem{{Index: 1, Type: "CATEGORY", Value: "SRC-A"}}},
+		"DST-GATEWAY": {Items: []codec.CategoryItem{{Index: 1, Type: "SOURCE", Value: "8601"}}},
+		"DESTINATIONS": {Items: []codec.CategoryItem{
+			{Index: 1, Type: "CATEGORY", Value: "DST-GATEWAY"},
+			{Index: 2, Type: "CATEGORY", Value: "DST-B"},
+			{Index: 3, Type: "DEST", Value: "4201"},
+		}},
 	}
 	src, dst, both := classifyCerebrumCategories(names, details)
-	if !src["SRC-A"] || !src["PARENT-SRC"] || src["DST-B"] {
+	if !src["SRC-A"] || !src["PARENT-SRC"] || !src["DST-GATEWAY"] || src["DST-B"] || src["DESTINATIONS"] {
 		t.Errorf("src = %v", src)
 	}
-	if !dst["DST-B"] || dst["SRC-A"] {
+	if !dst["DST-B"] || !dst["DESTINATIONS"] || dst["SRC-A"] || dst["DST-GATEWAY"] {
 		t.Errorf("dst = %v", dst)
 	}
-	if len(both) != 1 || both[0] != "MIX" || !src["MIX"] || !dst["MIX"] {
-		t.Errorf("both = %v", both)
+	if len(both) != 1 || both[0] != "MIX" || src["MIX"] || dst["MIX"] {
+		t.Errorf("both = %v (src[MIX]=%v dst[MIX]=%v)", both, src["MIX"], dst["MIX"])
 	}
 }

--- a/cmd/dhs/cmd_cerebrum_test.go
+++ b/cmd/dhs/cmd_cerebrum_test.go
@@ -54,6 +54,7 @@ func TestCerebrumWriteVerbsValidateFlags(t *testing.T) {
 		{"salvo-bad-op", []string{"salvo", "h", "--op", "frob", "--group", "G"}, "unknown --op"},
 		{"salvo-no-group", []string{"salvo", "h", "--op", "run"}, "--group is required"},
 		{"salvo-rename-no-name", []string{"salvo", "h", "--op", "rename", "--group", "G"}, "--new-name is required"},
+		{"salvo-desc-no-text", []string{"salvo", "h", "--op", "description", "--group", "G"}, "--description is required"},
 		// category: missing/unknown op, missing category.
 		{"cat-no-op", []string{"category", "h", "--category", "C"}, "--op is required"},
 		{"cat-bad-op", []string{"category", "h", "--op", "frob", "--category", "C"}, "unknown --op"},
@@ -101,7 +102,7 @@ func TestCerebrumWriteVerbsRequireHost(t *testing.T) {
 
 // TestSalvoOpType / TestCategoryOpType pin the op -> wire TYPE maps.
 func TestSalvoOpType(t *testing.T) {
-	cases := map[string]string{"run": "RUN", "save": "SAVE", "rename": "RENAME", "delete": "DELETE"}
+	cases := map[string]string{"run": "RUN", "save": "SAVE", "rename": "RENAME", "description": "DESCRIPTION", "delete": "DELETE"}
 	for in, want := range cases {
 		got, err := salvoOpType(in)
 		if err != nil || got != want {

--- a/cmd/dhs/cmd_cerebrum_test.go
+++ b/cmd/dhs/cmd_cerebrum_test.go
@@ -100,6 +100,26 @@ func TestCerebrumWriteVerbsRequireHost(t *testing.T) {
 	}
 }
 
+// TestWriteVerbPortReachesDial pins the dropped-connection-flags fix: the §4
+// write verbs (and obtain-datastore) parse the shared connection flags in
+// their own FlagSet, and those values MUST reach the dialer. Before the fix
+// they re-parsed only the leftover host, silently dialing the default port.
+// Port 1 on loopback refuses instantly; the dial error must name it.
+func TestWriteVerbPortReachesDial(t *testing.T) {
+	cases := [][]string{
+		{"salvo", "--op", "run", "--group", "G", "--user", "u", "--pass", "p", "--port", "1", "--timeout", "500ms", "127.0.0.1"},
+		{"obtain-datastore", "--name", "x", "--port", "1", "--timeout", "500ms", "127.0.0.1"},
+	}
+	for _, args := range cases {
+		t.Run(args[0], func(t *testing.T) {
+			err := runCerebrum(context.Background(), args)
+			if err == nil || !strings.Contains(err.Error(), ":1") {
+				t.Fatalf("verb %q: want dial error naming port 1, got %v", args[0], err)
+			}
+		})
+	}
+}
+
 // TestSalvoOpType / TestCategoryOpType pin the op -> wire TYPE maps.
 func TestSalvoOpType(t *testing.T) {
 	cases := map[string]string{"run": "RUN", "save": "SAVE", "rename": "RENAME", "description": "DESCRIPTION", "delete": "DELETE"}

--- a/cmd/dhs/cmd_cerebrum_tree.go
+++ b/cmd/dhs/cmd_cerebrum_tree.go
@@ -386,21 +386,40 @@ func cerebrumDeviceListTreeObjects(sess *cerebrum.Session, timeout time.Duration
 		return nil, fmt.Errorf("cerebrum-nb tree: no DEVICE_CHANGE TYPE=LIST reply within timeout")
 	}
 	var objs []consumer.Object
-	for _, d := range got.Device.Devices {
-		class := string(d.DeviceType)
+	seen := map[string]bool{}
+	emit := func(class, ip, name string) {
 		if class == "" {
 			class = "UNKNOWN"
 		}
+		key := class + "\x00" + ip
+		if ip == "" || seen[key] {
+			return
+		}
+		seen[key] = true
 		meta := "class=" + class
-		if d.DeviceName != "" {
-			meta += fmt.Sprintf(" name=%q", d.DeviceName)
+		if name != "" {
+			meta += fmt.Sprintf(" name=%q", name)
 		}
 		objs = append(objs, consumer.Object{
-			Path:  []string{"Devices", class, d.IPAddress},
-			Label: d.IPAddress,
+			Path:  []string{"Devices", class, ip},
+			Label: ip,
 			Kind:  consumer.KindString, Access: 1,
 			Value: consumer.Value{Kind: consumer.KindString, Str: meta},
 		})
+	}
+	// The route-master sentinel is synthesized (same as list-devices —
+	// the wire LIST does not carry it).
+	emit("ROUTER", "0.0.0.0", "Routemaster")
+	for _, d := range got.Device.Devices {
+		// One leaf PER CLASS INSTANCE — a device may be DEVICE and ROUTER
+		// at once (one <INSTANCE> per class on the wire).
+		classes := d.DeviceTypes
+		if len(classes) == 0 && d.DeviceType != "" {
+			classes = []codec.DeviceType{d.DeviceType}
+		}
+		for _, c := range classes {
+			emit(string(c), d.IPAddress, d.DeviceName)
+		}
 	}
 	return objs, nil
 }

--- a/cmd/dhs/cmd_cerebrum_tree.go
+++ b/cmd/dhs/cmd_cerebrum_tree.go
@@ -209,15 +209,6 @@ func cerebrumSalvoTreeObjects(sess *cerebrum.Session, timeout time.Duration) ([]
 // FILE, CUSTOM rows render verbatim. The index prefix preserves the
 // category's slot order in the sorted tree.
 func cerebrumCategoryTreeObjects(sess *cerebrum.Session, timeout time.Duration, alt int, noMne bool) ([]consumer.Object, error) {
-	list, err := obtainSingleCategoryChange(sess, timeout,
-		&codec.CategoryChange{Type: "CATEGORY_LIST"}, "CATEGORY_LIST")
-	if err != nil {
-		return nil, err
-	}
-	if list == nil || list.Category == nil {
-		return nil, fmt.Errorf("cerebrum-nb tree: no CATEGORY_LIST reply within timeout")
-	}
-
 	// Mnemonic join: ID -> label for SOURCE and DEST item rows. --alt picks
 	// the set (0 = primary, N = ALT_MNE slot N); --no-mne skips the join.
 	srcName := map[string]string{}
@@ -243,28 +234,24 @@ func cerebrumCategoryTreeObjects(sess *cerebrum.Session, timeout time.Duration, 
 		}
 	}
 
-	// Fetch every category's details once, then compose the FOREST:
-	// categories referenced as CATEGORY items nest under their parent
-	// (recursively — real sub-category subtrees, matching the UI Inherits/
-	// membership view) instead of duplicating at top level. Roots are the
-	// categories no other category references.
-	details := map[string]*codec.CategoryDetailsInfo{}
+	// Fetch every category's details once (shared §5.2 walk), then compose
+	// the FOREST: categories referenced as CATEGORY items nest under their
+	// parent (recursively — real sub-category subtrees, matching the UI
+	// Inherits/membership view) instead of duplicating at top level. Roots
+	// are the categories no other category references.
+	names, details, err := fetchCerebrumCategories(sess, timeout)
+	if err != nil {
+		return nil, err
+	}
 	referenced := map[string]bool{}
-	for _, cat := range list.Category.Categories {
-		det, derr := obtainSingleCategoryChange(sess, timeout,
-			&codec.CategoryChange{Type: "CATEGORY_DETAILS", Category: cat}, "CATEGORY_DETAILS")
-		if derr != nil {
-			return nil, derr
+	for _, d := range details {
+		if d == nil {
+			continue
 		}
-		if det != nil && det.Category != nil && det.Category.Details != nil {
-			details[cat] = det.Category.Details
-			for _, it := range det.Category.Details.Items {
-				if it.Type == "CATEGORY" {
-					referenced[it.Value] = true
-				}
+		for _, it := range d.Items {
+			if it.Type == "CATEGORY" {
+				referenced[it.Value] = true
 			}
-		} else {
-			details[cat] = nil
 		}
 	}
 
@@ -312,7 +299,7 @@ func cerebrumCategoryTreeObjects(sess *cerebrum.Session, timeout time.Duration, 
 			})
 		}
 	}
-	for _, cat := range list.Category.Categories {
+	for _, cat := range names {
 		if referenced[cat] {
 			continue // rendered under its parent(s)
 		}

--- a/cmd/dhs/cmd_cerebrum_tree.go
+++ b/cmd/dhs/cmd_cerebrum_tree.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"dhs/internal/cerebrum-nb/codec"
+	cerebrum "dhs/internal/cerebrum-nb/consumer"
+	"dhs/internal/consumer"
+)
+
+// cerebrumTree renders the NB-readable catalogue with the canonical tree
+// renderer (same flags and output shapes as `dhs consumer <proto> tree` —
+// ASCII or PlantUML mindmap). Two domains, both strictly what the 0v16 API
+// exposes — nothing extrapolated:
+//
+//	Salvos      §5.3  GROUP_LIST → INSTANCE_LIST → INSTANCE_DETAILS
+//	            (groups → instances → metadata; salvo ITEM rows are NOT
+//	            exposed over NB — live-verified 2026-08-16)
+//	Categories  §5.2  CATEGORY_LIST → CATEGORY_DETAILS per category
+//	            (categories → item rows: SOURCE / DEST names, nested
+//	            CATEGORY references, TEXT/FILE/CUSTOM — exactly the §3.3
+//	            ITEM_TYPE rows the wire returns)
+func cerebrumTree(_ context.Context, args []string) error {
+	args = reorderFlagsFirst(args)
+	fs := flag.NewFlagSet("cerebrum-nb tree", flag.ContinueOnError)
+	cf := newCerebrumFlags(fs)
+	format := fs.String("format", "ascii", `output format: "ascii" (default) or "plantuml"`)
+	depth := fs.Int("depth", 0, "max render depth from the focus node (0 = unlimited)")
+	out := fs.String("out", "", "write to this file instead of stdout")
+	filter := fs.String("filter", "", "case-insensitive substring filter (drops non-matching lines)")
+	focus := fs.String("path", "", `focus subtree at this dotted path (e.g. "Salvos.Salvo Group 1" or "Categories.SRC-INTERPHONIE")`)
+	domain := fs.String("domain", "all", "which catalogue(s) to walk: salvos | categories | all")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	switch *domain {
+	case "salvos", "categories", "all":
+	default:
+		return fmt.Errorf("cerebrum-nb tree: --domain must be salvos | categories | all, got %q", *domain)
+	}
+	if *format != "ascii" && *format != "plantuml" {
+		return fmt.Errorf("cerebrum-nb tree: --format must be \"ascii\" or \"plantuml\", got %q", *format)
+	}
+
+	// Open --out before any wire traffic so a bad path fails fast (missing
+	// parent directories are created, same contract as --log / --out CSV).
+	var writer io.Writer = os.Stdout
+	if *out != "" {
+		if dir := filepath.Dir(*out); dir != "." {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return err
+			}
+		}
+		f, ferr := os.Create(*out)
+		if ferr != nil {
+			return fmt.Errorf("open %s: %w", *out, ferr)
+		}
+		defer func() { _ = f.Close() }()
+		writer = f
+	}
+
+	p, sess, _, err := dialCerebrum(cf, fs.Args(), "tree")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = p.Disconnect() }()
+
+	var objs []consumer.Object
+	if *domain == "categories" || *domain == "all" {
+		catObjs, cerr := cerebrumCategoryTreeObjects(sess, cf.timeout)
+		if cerr != nil {
+			return cerr
+		}
+		objs = append(objs, catObjs...)
+	}
+	if *domain == "salvos" || *domain == "all" {
+		salvoObjs, serr := cerebrumSalvoTreeObjects(sess, cf.timeout)
+		if serr != nil {
+			return serr
+		}
+		objs = append(objs, salvoObjs...)
+	}
+
+	opts := treeRenderOpts{
+		FromPath: *focus,
+		Depth:    *depth,
+		ASCII:    *format == "ascii",
+		Filter:   *filter,
+	}
+	if *format == "plantuml" {
+		return renderTreePlantUML(writer, objs, opts)
+	}
+	return renderTree(writer, objs, opts)
+}
+
+// cerebrumSalvoTreeObjects walks §5.3 (GROUP_LIST → INSTANCE_LIST →
+// INSTANCE_DETAILS) into canonical objects under the "Salvos" root.
+func cerebrumSalvoTreeObjects(sess *cerebrum.Session, timeout time.Duration) ([]consumer.Object, error) {
+	groups, err := obtainSingleSalvoChange(sess, timeout,
+		&codec.SalvoChange{Type: "GROUP_LIST"}, "GROUP_LIST")
+	if err != nil {
+		return nil, err
+	}
+	if groups == nil || groups.Salvo == nil {
+		return nil, fmt.Errorf("cerebrum-nb tree: no GROUP_LIST reply within timeout")
+	}
+
+	var objs []consumer.Object
+	for _, g := range groups.Salvo.Groups {
+		il, ierr := obtainSingleSalvoChange(sess, timeout,
+			&codec.SalvoChange{Type: "INSTANCE_LIST", Group: g}, "INSTANCE_LIST")
+		if ierr != nil {
+			return nil, ierr
+		}
+		var instances []string
+		if il != nil && il.Salvo != nil {
+			instances = il.Salvo.Instances
+		}
+		if len(instances) == 0 {
+			objs = append(objs, consumer.Object{
+				Path: []string{"Salvos", g}, Label: g,
+				Kind: consumer.KindString, Access: 1,
+				Value: consumer.Value{Kind: consumer.KindString, Str: "(no instances)"},
+			})
+			continue
+		}
+		for _, inst := range instances {
+			dt, derr := obtainSingleSalvoChange(sess, timeout,
+				&codec.SalvoChange{Type: "INSTANCE_DETAILS", Group: g, Instance: inst}, "INSTANCE_DETAILS")
+			if derr != nil {
+				return nil, derr
+			}
+			meta := "(no details)"
+			if dt != nil && dt.Salvo != nil && dt.Salvo.InstanceDetails != nil {
+				d := dt.Salvo.InstanceDetails
+				meta = fmt.Sprintf("available=%s active=%s", boolFlag(d.Available), boolFlag(d.Active))
+				if d.Description != "" {
+					meta += fmt.Sprintf(" description=%q", d.Description)
+				}
+				if d.Date != "" || d.Time != "" {
+					meta += fmt.Sprintf(" saved=%s %s", d.Date, d.Time)
+				}
+			}
+			objs = append(objs, consumer.Object{
+				Path: []string{"Salvos", g, inst}, Label: inst,
+				Kind: consumer.KindString, Access: 1,
+				Value: consumer.Value{Kind: consumer.KindString, Str: meta},
+			})
+		}
+	}
+	return objs, nil
+}
+
+// cerebrumCategoryTreeObjects walks §5.2 (CATEGORY_LIST → CATEGORY_DETAILS
+// per category) into canonical objects under the "Categories" root. Item
+// rows render exactly as the wire returns them (§3.3 ITEM_TYPE + VALUE):
+// SOURCE / DEST names, nested CATEGORY references, TEXT / FILE / CUSTOM.
+// The index prefix preserves the category's slot order in the sorted tree.
+func cerebrumCategoryTreeObjects(sess *cerebrum.Session, timeout time.Duration) ([]consumer.Object, error) {
+	list, err := obtainSingleCategoryChange(sess, timeout,
+		&codec.CategoryChange{Type: "CATEGORY_LIST"}, "CATEGORY_LIST")
+	if err != nil {
+		return nil, err
+	}
+	if list == nil || list.Category == nil {
+		return nil, fmt.Errorf("cerebrum-nb tree: no CATEGORY_LIST reply within timeout")
+	}
+
+	var objs []consumer.Object
+	for _, cat := range list.Category.Categories {
+		det, derr := obtainSingleCategoryChange(sess, timeout,
+			&codec.CategoryChange{Type: "CATEGORY_DETAILS", Category: cat}, "CATEGORY_DETAILS")
+		if derr != nil {
+			return nil, derr
+		}
+		if det == nil || det.Category == nil || det.Category.Details == nil || len(det.Category.Details.Items) == 0 {
+			meta := "(no items)"
+			if det != nil && det.Category != nil && det.Category.Details != nil && det.Category.Details.Label != "" {
+				meta = fmt.Sprintf("label=%q (no items)", det.Category.Details.Label)
+			}
+			objs = append(objs, consumer.Object{
+				Path: []string{"Categories", cat}, Label: cat,
+				Kind: consumer.KindString, Access: 1,
+				Value: consumer.Value{Kind: consumer.KindString, Str: meta},
+			})
+			continue
+		}
+		for _, it := range det.Category.Details.Items {
+			objs = append(objs, consumer.Object{
+				Path:  []string{"Categories", cat, fmt.Sprintf("%04d %s", it.Index, it.Type)},
+				Label: it.Value, ID: it.Index,
+				Kind: consumer.KindString, Access: 1,
+				Value: consumer.Value{Kind: consumer.KindString, Str: it.Value},
+			})
+		}
+	}
+	return objs, nil
+}

--- a/cmd/dhs/cmd_cerebrum_tree.go
+++ b/cmd/dhs/cmd_cerebrum_tree.go
@@ -211,7 +211,10 @@ func cerebrumDeviceTreeObjects(sess *cerebrum.Session, timeout time.Duration, de
 		if ov.DataType != "" {
 			meta += " type=" + ov.DataType
 		}
-		if ov.Min != "" || ov.Max != "" {
+		// A degenerate MIN==MAX range carries no information (ENUMs report
+		// 0..0 — their real constraint is the enum list; Identifier-style
+		// INTEGERs likewise) — print range only when it constrains.
+		if (ov.Min != "" || ov.Max != "") && ov.Min != ov.Max {
 			meta += fmt.Sprintf(" range=%s..%s", ov.Min, ov.Max)
 		}
 		if len(ov.EnumList) > 0 {

--- a/cmd/dhs/cmd_cerebrum_tree.go
+++ b/cmd/dhs/cmd_cerebrum_tree.go
@@ -217,10 +217,19 @@ func cerebrumDeviceTreeObjects(sess *cerebrum.Session, timeout time.Duration, de
 		if len(ov.EnumList) > 0 {
 			meta += fmt.Sprintf(" enum=%s", strings.Join(ov.EnumList, "|"))
 		}
+		// Access bits from the wire descriptor (read=1, write=2 — the
+		// canonical access byte), so RW objects render as RW-, not R--.
+		var access uint8
+		if ov.Readable {
+			access |= 0x01
+		}
+		if ov.Writable {
+			access |= 0x02
+		}
 		objs = append(objs, consumer.Object{
 			Path:  append([]string{rootLabel}, strings.Split(ov.Object, ".")...),
 			Label: ov.Object,
-			Kind:  consumer.KindString, Access: 1,
+			Kind:  consumer.KindString, Access: access,
 			Value: consumer.Value{Kind: consumer.KindString, Str: meta},
 		})
 	}

--- a/cmd/dhs/cmd_cerebrum_tree.go
+++ b/cmd/dhs/cmd_cerebrum_tree.go
@@ -84,7 +84,20 @@ func cerebrumTree(_ context.Context, args []string) error {
 		if *subDev == "" {
 			return fmt.Errorf("cerebrum-nb tree: --device mode needs --sub-device (index from device-details)")
 		}
-		devObjs, derr := cerebrumDeviceTreeObjects(sess, cf.timeout, *device, *byName, *subDev, *focus, *maxReq)
+		// OBJECT="" is refused by the server (live: NACK 10) — the device
+		// root cannot be listed, so the walk is seeded from start groups:
+		// --path takes one group or a ';'-separated list (e.g. the top
+		// folders from the Object Browser).
+		var starts []string
+		for _, s := range strings.Split(*focus, ";") {
+			if s = strings.TrimSpace(s); s != "" && s != "." {
+				starts = append(starts, s)
+			}
+		}
+		if len(starts) == 0 {
+			return fmt.Errorf("cerebrum-nb tree: --device mode needs --path with one or more start groups (';'-separated) — the server refuses an empty OBJECT, so the root must be seeded (top folders from the device's Object Browser)")
+		}
+		devObjs, derr := cerebrumDeviceTreeObjects(sess, cf.timeout, *device, *byName, *subDev, starts, *maxReq)
 		if derr != nil {
 			return derr
 		}
@@ -167,10 +180,7 @@ func cerebrumExpandFocus(objs []consumer.Object, focus string) string {
 // re-classifies "single self-echo" answers as unavailable leaves. start
 // "" (or the "." sentinel) walks from the device root; maxReq caps the
 // obtain count.
-func cerebrumDeviceTreeObjects(sess *cerebrum.Session, timeout time.Duration, device string, byName bool, subDev, start string, maxReq int) ([]consumer.Object, error) {
-	if start == "." {
-		start = ""
-	}
+func cerebrumDeviceTreeObjects(sess *cerebrum.Session, timeout time.Duration, device string, byName bool, subDev string, starts []string, maxReq int) ([]consumer.Object, error) {
 	rootLabel := strings.TrimSpace(device)
 	requests := 0
 	obtain := func(object string) ([]codec.DeviceObjectValue, error) {
@@ -247,8 +257,10 @@ func cerebrumDeviceTreeObjects(sess *cerebrum.Session, timeout time.Duration, de
 		}
 		return nil
 	}
-	if err := walk(start); err != nil {
-		return nil, err
+	for _, start := range starts {
+		if err := walk(start); err != nil {
+			return nil, err
+		}
 	}
 	if truncated {
 		fmt.Fprintf(os.Stderr, "cerebrum-nb tree: WARNING — walk truncated at --max-requests=%d obtains (raise it for the full tree)\n", maxReq)

--- a/cmd/dhs/cmd_cerebrum_tree.go
+++ b/cmd/dhs/cmd_cerebrum_tree.go
@@ -36,6 +36,8 @@ func cerebrumTree(_ context.Context, args []string) error {
 	filter := fs.String("filter", "", "case-insensitive substring filter (drops non-matching lines)")
 	focus := fs.String("path", "", `focus subtree at this dotted path (e.g. "Salvos.Salvo Group 1" or "Categories.SRC-INTERPHONIE")`)
 	domain := fs.String("domain", "all", "which catalogue(s) to walk: salvos | categories | all")
+	alt := fs.Int("alt", 0, "label set for SOURCE/DEST item annotation: 0 = primary mnemonic, N = alternate set N (ALT_MNE, e.g. 1 = Panels on the NOC)")
+	noMne := fs.Bool("no-mne", false, "skip the mnemonic join — show raw item IDs only (also skips the two SRCE/DEST_MNE wildcard reads)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -73,7 +75,7 @@ func cerebrumTree(_ context.Context, args []string) error {
 
 	var objs []consumer.Object
 	if *domain == "categories" || *domain == "all" {
-		catObjs, cerr := cerebrumCategoryTreeObjects(sess, cf.timeout)
+		catObjs, cerr := cerebrumCategoryTreeObjects(sess, cf.timeout, *alt, *noMne)
 		if cerr != nil {
 			return cerr
 		}
@@ -166,7 +168,7 @@ func cerebrumSalvoTreeObjects(sess *cerebrum.Session, timeout time.Duration) ([]
 // the same reads list-sources / list-dests use). Nested CATEGORY, TEXT,
 // FILE, CUSTOM rows render verbatim. The index prefix preserves the
 // category's slot order in the sorted tree.
-func cerebrumCategoryTreeObjects(sess *cerebrum.Session, timeout time.Duration) ([]consumer.Object, error) {
+func cerebrumCategoryTreeObjects(sess *cerebrum.Session, timeout time.Duration, alt int, noMne bool) ([]consumer.Object, error) {
 	list, err := obtainSingleCategoryChange(sess, timeout,
 		&codec.CategoryChange{Type: "CATEGORY_LIST"}, "CATEGORY_LIST")
 	if err != nil {
@@ -176,20 +178,29 @@ func cerebrumCategoryTreeObjects(sess *cerebrum.Session, timeout time.Duration) 
 		return nil, fmt.Errorf("cerebrum-nb tree: no CATEGORY_LIST reply within timeout")
 	}
 
-	// Mnemonic join: ID -> primary label for SOURCE and DEST item rows.
-	st, err := cerebrumObtainState(context.Background(), sess, "0.0.0.0", "ROUTER", 15*time.Second, cerebrumStateWant{
-		SrcMne: true, DstMne: true, Verb: "tree",
-	})
-	if err != nil {
-		return nil, err
-	}
+	// Mnemonic join: ID -> label for SOURCE and DEST item rows. --alt picks
+	// the set (0 = primary, N = ALT_MNE slot N); --no-mne skips the join.
 	srcName := map[string]string{}
-	for _, r := range st.Src {
-		srcName[r.ID] = r.Mnemonic
-	}
 	dstName := map[string]string{}
-	for _, r := range st.Dst {
-		dstName[r.ID] = r.Mnemonic
+	if !noMne {
+		st, serr := cerebrumObtainState(context.Background(), sess, "0.0.0.0", "ROUTER", 15*time.Second, cerebrumStateWant{
+			SrcMne: true, DstMne: true, Verb: "tree",
+		})
+		if serr != nil {
+			return nil, serr
+		}
+		pick := func(r cerebrumMneRow) string {
+			if alt <= 0 {
+				return r.Mnemonic
+			}
+			return r.Alts[alt]
+		}
+		for _, r := range st.Src {
+			srcName[r.ID] = pick(r)
+		}
+		for _, r := range st.Dst {
+			dstName[r.ID] = pick(r)
+		}
 	}
 
 	var objs []consumer.Object

--- a/cmd/dhs/cmd_cerebrum_tree.go
+++ b/cmd/dhs/cmd_cerebrum_tree.go
@@ -203,26 +203,56 @@ func cerebrumCategoryTreeObjects(sess *cerebrum.Session, timeout time.Duration, 
 		}
 	}
 
-	var objs []consumer.Object
+	// Fetch every category's details once, then compose the FOREST:
+	// categories referenced as CATEGORY items nest under their parent
+	// (recursively — real sub-category subtrees, matching the UI Inherits/
+	// membership view) instead of duplicating at top level. Roots are the
+	// categories no other category references.
+	details := map[string]*codec.CategoryDetailsInfo{}
+	referenced := map[string]bool{}
 	for _, cat := range list.Category.Categories {
 		det, derr := obtainSingleCategoryChange(sess, timeout,
 			&codec.CategoryChange{Type: "CATEGORY_DETAILS", Category: cat}, "CATEGORY_DETAILS")
 		if derr != nil {
 			return nil, derr
 		}
-		if det == nil || det.Category == nil || det.Category.Details == nil || len(det.Category.Details.Items) == 0 {
+		if det != nil && det.Category != nil && det.Category.Details != nil {
+			details[cat] = det.Category.Details
+			for _, it := range det.Category.Details.Items {
+				if it.Type == "CATEGORY" {
+					referenced[it.Value] = true
+				}
+			}
+		} else {
+			details[cat] = nil
+		}
+	}
+
+	var objs []consumer.Object
+	var emit func(cat string, path []string, visited map[string]bool)
+	emit = func(cat string, path []string, visited map[string]bool) {
+		d := details[cat]
+		if d == nil || len(d.Items) == 0 {
 			meta := "(no items)"
-			if det != nil && det.Category != nil && det.Category.Details != nil && det.Category.Details.Label != "" {
-				meta = fmt.Sprintf("label=%q (no items)", det.Category.Details.Label)
+			if d != nil && d.Label != "" {
+				meta = fmt.Sprintf("label=%q (no items)", d.Label)
 			}
 			objs = append(objs, consumer.Object{
-				Path: []string{"Categories", cat}, Label: cat,
+				Path: path, Label: cat,
 				Kind: consumer.KindString, Access: 1,
 				Value: consumer.Value{Kind: consumer.KindString, Str: meta},
 			})
-			continue
+			return
 		}
-		for _, it := range det.Category.Details.Items {
+		for _, it := range d.Items {
+			if it.Type == "CATEGORY" {
+				if _, known := details[it.Value]; known && !visited[it.Value] {
+					visited[it.Value] = true
+					emit(it.Value, append(append([]string{}, path...), it.Value), visited)
+					continue
+				}
+				// Unknown target or cycle — render the reference verbatim.
+			}
 			val := it.Value
 			switch it.Type {
 			case "SOURCE", "SRCE":
@@ -235,12 +265,18 @@ func cerebrumCategoryTreeObjects(sess *cerebrum.Session, timeout time.Duration, 
 				}
 			}
 			objs = append(objs, consumer.Object{
-				Path:  []string{"Categories", cat, fmt.Sprintf("%04d %s", it.Index, it.Type)},
+				Path:  append(append([]string{}, path...), fmt.Sprintf("%04d %s", it.Index, it.Type)),
 				Label: it.Value, ID: it.Index,
 				Kind: consumer.KindString, Access: 1,
 				Value: consumer.Value{Kind: consumer.KindString, Str: val},
 			})
 		}
+	}
+	for _, cat := range list.Category.Categories {
+		if referenced[cat] {
+			continue // rendered under its parent(s)
+		}
+		emit(cat, []string{"Categories", cat}, map[string]bool{cat: true})
 	}
 	return objs, nil
 }

--- a/cmd/dhs/cmd_cerebrum_tree.go
+++ b/cmd/dhs/cmd_cerebrum_tree.go
@@ -35,8 +35,12 @@ func cerebrumTree(_ context.Context, args []string) error {
 	depth := fs.Int("depth", 0, "max render depth from the focus node (0 = unlimited)")
 	out := fs.String("out", "", "write to this file instead of stdout")
 	filter := fs.String("filter", "", "case-insensitive substring filter (drops non-matching lines)")
-	focus := fs.String("path", "", `focus subtree at this dotted path (e.g. "Salvos.Salvo Group 1" or "Categories.SRC-INTERPHONIE")`)
+	focus := fs.String("path", "", `focus subtree at this dotted path (e.g. "Salvos.Salvo Group 1" or "Categories.SRC-INTERPHONIE"; in --device mode: the start group, e.g. "PROCESSING AUDIO")`)
 	domain := fs.String("domain", "all", "which catalogue(s) to walk: salvos | categories | all")
+	device := fs.String("device", "", "DEVICE OBJECT TREE mode: walk one device's §5.4.3 object tree recursively (group obtains return children — live 2026-08-16). NAME with --by-name (exact string incl. whitespace!) or IP")
+	byName := fs.Bool("by-name", false, "--device is a DEVICE_NAME (exact, incl. trailing whitespace) instead of an IP")
+	subDev := fs.String("sub-device", "", "sub-device index for --device mode (from device-details, e.g. 1)")
+	maxReq := fs.Int("max-requests", 2000, "--device mode: cap on group obtains for the walk (safety against unexpected fan-out)")
 	alt := fs.Int("alt", 0, "label set for SOURCE/DEST item annotation: 0 = primary mnemonic, N = alternate set N (ALT_MNE, e.g. 1 = Panels on the NOC)")
 	noMne := fs.Bool("no-mne", false, "skip the mnemonic join — show raw item IDs only (also skips the two SRCE/DEST_MNE wildcard reads)")
 	if err := fs.Parse(args); err != nil {
@@ -75,23 +79,37 @@ func cerebrumTree(_ context.Context, args []string) error {
 	defer func() { _ = p.Disconnect() }()
 
 	var objs []consumer.Object
-	if *domain == "categories" || *domain == "all" {
-		catObjs, cerr := cerebrumCategoryTreeObjects(sess, cf.timeout, *alt, *noMne)
-		if cerr != nil {
-			return cerr
+	var renderFocus string
+	if *device != "" {
+		if *subDev == "" {
+			return fmt.Errorf("cerebrum-nb tree: --device mode needs --sub-device (index from device-details)")
 		}
-		objs = append(objs, catObjs...)
-	}
-	if *domain == "salvos" || *domain == "all" {
-		salvoObjs, serr := cerebrumSalvoTreeObjects(sess, cf.timeout)
-		if serr != nil {
-			return serr
+		devObjs, derr := cerebrumDeviceTreeObjects(sess, cf.timeout, *device, *byName, *subDev, *focus, *maxReq)
+		if derr != nil {
+			return derr
 		}
-		objs = append(objs, salvoObjs...)
+		objs = devObjs
+		renderFocus = "" // --path already scoped the walk itself
+	} else {
+		if *domain == "categories" || *domain == "all" {
+			catObjs, cerr := cerebrumCategoryTreeObjects(sess, cf.timeout, *alt, *noMne)
+			if cerr != nil {
+				return cerr
+			}
+			objs = append(objs, catObjs...)
+		}
+		if *domain == "salvos" || *domain == "all" {
+			salvoObjs, serr := cerebrumSalvoTreeObjects(sess, cf.timeout)
+			if serr != nil {
+				return serr
+			}
+			objs = append(objs, salvoObjs...)
+		}
+		renderFocus = cerebrumExpandFocus(objs, *focus)
 	}
 
 	opts := treeRenderOpts{
-		FromPath: cerebrumExpandFocus(objs, *focus),
+		FromPath: renderFocus,
 		Depth:    *depth,
 		ASCII:    *format == "ascii",
 		Filter:   *filter,
@@ -139,6 +157,104 @@ func cerebrumExpandFocus(objs []consumer.Object, focus string) string {
 		return focus
 	}
 	return strings.Join(best, ".")
+}
+
+// cerebrumDeviceTreeObjects walks one device's object tree over §5.4.3
+// VALUE obtains — the NB analogue of an acp2 walk (live 2026-08-16): a
+// GROUP path returns its CHILDREN as OBJECT_VALUE rows (sub-groups arrive
+// as available=0 empty rows, leaves carry the value), while a LEAF path
+// echoes itself as a single row. Recursion descends group candidates and
+// re-classifies "single self-echo" answers as unavailable leaves. start
+// "" (or the "." sentinel) walks from the device root; maxReq caps the
+// obtain count.
+func cerebrumDeviceTreeObjects(sess *cerebrum.Session, timeout time.Duration, device string, byName bool, subDev, start string, maxReq int) ([]consumer.Object, error) {
+	if start == "." {
+		start = ""
+	}
+	rootLabel := strings.TrimSpace(device)
+	requests := 0
+	obtain := func(object string) ([]codec.DeviceObjectValue, error) {
+		requests++
+		dc := &codec.DeviceChange{Type: "VALUE", SubDevice: subDev, Object: object}
+		if byName {
+			dc.DeviceName = device
+		} else {
+			dc.IPAddress = device
+		}
+		got, err := obtainSingleDeviceChange(sess, timeout, dc, "VALUE")
+		if err != nil {
+			return nil, err
+		}
+		if got == nil || got.Device == nil {
+			return nil, nil
+		}
+		return got.Device.ObjectValues, nil
+	}
+
+	var objs []consumer.Object
+	truncated := false
+	emitLeaf := func(ov codec.DeviceObjectValue) {
+		meta := fmt.Sprintf("available=%s", boolFlag(ov.Available))
+		if ov.Value != "" {
+			meta += fmt.Sprintf(" value=%q", ov.Value)
+		}
+		if ov.DataType != "" {
+			meta += " type=" + ov.DataType
+		}
+		if ov.Min != "" || ov.Max != "" {
+			meta += fmt.Sprintf(" range=%s..%s", ov.Min, ov.Max)
+		}
+		if len(ov.EnumList) > 0 {
+			meta += fmt.Sprintf(" enum=%s", strings.Join(ov.EnumList, "|"))
+		}
+		objs = append(objs, consumer.Object{
+			Path:  append([]string{rootLabel}, strings.Split(ov.Object, ".")...),
+			Label: ov.Object,
+			Kind:  consumer.KindString, Access: 1,
+			Value: consumer.Value{Kind: consumer.KindString, Str: meta},
+		})
+	}
+
+	var walk func(group string) error
+	walk = func(group string) error {
+		if requests >= maxReq {
+			truncated = true
+			return nil
+		}
+		rows, err := obtain(group)
+		if err != nil {
+			return err
+		}
+		// A single self-echo row = this path is a real LEAF (possibly
+		// unavailable), not a group.
+		if group != "" && len(rows) == 1 && rows[0].Object == group {
+			emitLeaf(rows[0])
+			return nil
+		}
+		for _, ov := range rows {
+			if ov.Object == group {
+				continue
+			}
+			// Group candidate: no value, not available, no descriptor —
+			// descend; the self-echo check above re-classifies real leaves.
+			if !ov.Available && ov.Value == "" && ov.DataType == "" {
+				if err := walk(ov.Object); err != nil {
+					return err
+				}
+				continue
+			}
+			emitLeaf(ov)
+		}
+		return nil
+	}
+	if err := walk(start); err != nil {
+		return nil, err
+	}
+	if truncated {
+		fmt.Fprintf(os.Stderr, "cerebrum-nb tree: WARNING — walk truncated at --max-requests=%d obtains (raise it for the full tree)\n", maxReq)
+	}
+	fmt.Fprintf(os.Stderr, "cerebrum-nb tree: device walk used %d obtain(s), %d object(s)\n", requests, len(objs))
+	return objs, nil
 }
 
 // cerebrumSalvoTreeObjects walks §5.3 (GROUP_LIST → INSTANCE_LIST →

--- a/cmd/dhs/cmd_cerebrum_tree.go
+++ b/cmd/dhs/cmd_cerebrum_tree.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -36,7 +37,7 @@ func cerebrumTree(_ context.Context, args []string) error {
 	out := fs.String("out", "", "write to this file instead of stdout")
 	filter := fs.String("filter", "", "case-insensitive substring filter (drops non-matching lines)")
 	focus := fs.String("path", "", `focus subtree at this dotted path (e.g. "Salvos.Salvo Group 1" or "Categories.SRC-INTERPHONIE"; in --device mode: the start group, e.g. "PROCESSING AUDIO")`)
-	domain := fs.String("domain", "all", "which catalogue(s) to walk: salvos | categories | all")
+	domain := fs.String("domain", "all", "which catalogue(s) to walk: sources | dests | categories | salvos | devices | all (all = every domain — the whole-Cerebrum tree; sources/dests are the 2 wildcard MNE reads, devices is the LIST read)")
 	device := fs.String("device", "", "DEVICE OBJECT TREE mode: walk one device's §5.4.3 object tree recursively (group obtains return children — live 2026-08-16). NAME with --by-name (exact string incl. whitespace!) or IP")
 	byName := fs.Bool("by-name", false, "--device is a DEVICE_NAME (exact, incl. trailing whitespace) instead of an IP")
 	subDev := fs.String("sub-device", "", "sub-device index for --device mode (from device-details, e.g. 1)")
@@ -47,9 +48,9 @@ func cerebrumTree(_ context.Context, args []string) error {
 		return err
 	}
 	switch *domain {
-	case "salvos", "categories", "all":
+	case "sources", "dests", "categories", "salvos", "devices", "all":
 	default:
-		return fmt.Errorf("cerebrum-nb tree: --domain must be salvos | categories | all, got %q", *domain)
+		return fmt.Errorf("cerebrum-nb tree: --domain must be sources | dests | categories | salvos | devices | all, got %q", *domain)
 	}
 	if *format != "ascii" && *format != "plantuml" {
 		return fmt.Errorf("cerebrum-nb tree: --format must be \"ascii\" or \"plantuml\", got %q", *format)
@@ -104,6 +105,13 @@ func cerebrumTree(_ context.Context, args []string) error {
 		objs = devObjs
 		renderFocus = "" // --path already scoped the walk itself
 	} else {
+		if *domain == "sources" || *domain == "dests" || *domain == "all" {
+			mneObjs, merr := cerebrumMneTreeObjects(sess, *domain, *alt)
+			if merr != nil {
+				return merr
+			}
+			objs = append(objs, mneObjs...)
+		}
 		if *domain == "categories" || *domain == "all" {
 			catObjs, cerr := cerebrumCategoryTreeObjects(sess, cf.timeout, *alt, *noMne)
 			if cerr != nil {
@@ -117,6 +125,13 @@ func cerebrumTree(_ context.Context, args []string) error {
 				return serr
 			}
 			objs = append(objs, salvoObjs...)
+		}
+		if *domain == "devices" || *domain == "all" {
+			devObjs, derr := cerebrumDeviceListTreeObjects(sess, cf.timeout)
+			if derr != nil {
+				return derr
+			}
+			objs = append(objs, devObjs...)
 		}
 		renderFocus = cerebrumExpandFocus(objs, *focus)
 	}
@@ -278,6 +293,90 @@ func cerebrumDeviceTreeObjects(sess *cerebrum.Session, timeout time.Duration, de
 		fmt.Fprintf(os.Stderr, "cerebrum-nb tree: WARNING — walk truncated at --max-requests=%d obtains (raise it for the full tree)\n", maxReq)
 	}
 	fmt.Fprintf(os.Stderr, "cerebrum-nb tree: device walk used %d obtain(s), %d object(s)\n", requests, len(objs))
+	return objs, nil
+}
+
+// cerebrumMneTreeObjects renders the Routemaster resource inventory as
+// tree domains: Sources / Dests roots with one leaf per resource — ID
+// (zero-padded so the sorted tree keeps numeric order), capability levels
+// (ASSOCIATION indices), label from the selected set (--alt) and the alt
+// list. domain "sources" | "dests" | "all" selects which wildcard MNE
+// reads run.
+func cerebrumMneTreeObjects(sess *cerebrum.Session, domain string, alt int) ([]consumer.Object, error) {
+	want := cerebrumStateWant{Verb: "tree"}
+	if domain == "sources" || domain == "all" {
+		want.SrcMne = true
+	}
+	if domain == "dests" || domain == "all" {
+		want.DstMne = true
+	}
+	st, err := cerebrumObtainState(context.Background(), sess, "0.0.0.0", "ROUTER", 15*time.Second, want)
+	if err != nil {
+		return nil, err
+	}
+	pad := func(id string) string {
+		if n, aerr := strconv.Atoi(strings.TrimSpace(id)); aerr == nil {
+			return fmt.Sprintf("%05d", n)
+		}
+		return id
+	}
+	emit := func(root string, rows []cerebrumMneRow) []consumer.Object {
+		var out []consumer.Object
+		for _, r := range rows {
+			label := r.Mnemonic
+			if alt > 0 {
+				label = r.Alts[alt]
+			}
+			meta := fmt.Sprintf("label=%q", label)
+			if len(r.Levels) > 0 {
+				meta += " levels=" + strings.Join(r.Levels, ";")
+			}
+			if len(r.Alts) > 0 && alt <= 0 {
+				meta += " alts=" + formatAlts(r.Alts)
+			}
+			out = append(out, consumer.Object{
+				Path:  []string{root, pad(r.ID)},
+				Label: r.ID,
+				Kind:  consumer.KindString, Access: 1,
+				Value: consumer.Value{Kind: consumer.KindString, Str: meta},
+			})
+		}
+		return out
+	}
+	var objs []consumer.Object
+	objs = append(objs, emit("Sources", st.Src)...)
+	objs = append(objs, emit("Dests", st.Dst)...)
+	return objs, nil
+}
+
+// cerebrumDeviceListTreeObjects renders the §5.4 LIST as a Devices tree:
+// Devices → class → IP (one leaf per class instance, mirroring the wire's
+// one-row-per-class shape).
+func cerebrumDeviceListTreeObjects(sess *cerebrum.Session, timeout time.Duration) ([]consumer.Object, error) {
+	got, err := obtainSingleDeviceChange(sess, timeout, &codec.DeviceChange{Type: "LIST"}, "LIST")
+	if err != nil {
+		return nil, err
+	}
+	if got == nil || got.Device == nil {
+		return nil, fmt.Errorf("cerebrum-nb tree: no DEVICE_CHANGE TYPE=LIST reply within timeout")
+	}
+	var objs []consumer.Object
+	for _, d := range got.Device.Devices {
+		class := string(d.DeviceType)
+		if class == "" {
+			class = "UNKNOWN"
+		}
+		meta := "class=" + class
+		if d.DeviceName != "" {
+			meta += fmt.Sprintf(" name=%q", d.DeviceName)
+		}
+		objs = append(objs, consumer.Object{
+			Path:  []string{"Devices", class, d.IPAddress},
+			Label: d.IPAddress,
+			Kind:  consumer.KindString, Access: 1,
+			Value: consumer.Value{Kind: consumer.KindString, Str: meta},
+		})
+	}
 	return objs, nil
 }
 

--- a/cmd/dhs/cmd_cerebrum_tree.go
+++ b/cmd/dhs/cmd_cerebrum_tree.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"dhs/internal/cerebrum-nb/codec"
@@ -90,7 +91,7 @@ func cerebrumTree(_ context.Context, args []string) error {
 	}
 
 	opts := treeRenderOpts{
-		FromPath: *focus,
+		FromPath: cerebrumExpandFocus(objs, *focus),
 		Depth:    *depth,
 		ASCII:    *format == "ascii",
 		Filter:   *filter,
@@ -99,6 +100,45 @@ func cerebrumTree(_ context.Context, args []string) error {
 		return renderTreePlantUML(writer, objs, opts)
 	}
 	return renderTree(writer, objs, opts)
+}
+
+// cerebrumExpandFocus resolves a --path that names a node ANYWHERE in the
+// tree, not only from the root: sub-category nesting means a category's
+// canonical path runs through its parents (Categories.DESTINATIONS.
+// DST-FUSION), but operators reference categories directly. The user's
+// dotted segments are matched as a contiguous subsequence of any object
+// path (case-insensitive, shallowest match wins) and expanded to the full
+// root path the renderer needs. No match returns the input unchanged so
+// the renderer's own error still fires.
+func cerebrumExpandFocus(objs []consumer.Object, focus string) string {
+	if focus == "" {
+		return focus
+	}
+	segs := strings.Split(focus, ".")
+	best := []string(nil)
+	for i := range objs {
+		p := objs[i].Path
+		for start := 0; start+len(segs) <= len(p); start++ {
+			ok := true
+			for j, s := range segs {
+				if !strings.EqualFold(p[start+j], s) {
+					ok = false
+					break
+				}
+			}
+			if ok {
+				full := p[:start+len(segs)]
+				if best == nil || len(full) < len(best) {
+					best = append([]string{}, full...)
+				}
+				break
+			}
+		}
+	}
+	if best == nil {
+		return focus
+	}
+	return strings.Join(best, ".")
 }
 
 // cerebrumSalvoTreeObjects walks §5.3 (GROUP_LIST → INSTANCE_LIST →

--- a/cmd/dhs/cmd_cerebrum_tree.go
+++ b/cmd/dhs/cmd_cerebrum_tree.go
@@ -160,8 +160,12 @@ func cerebrumSalvoTreeObjects(sess *cerebrum.Session, timeout time.Duration) ([]
 // cerebrumCategoryTreeObjects walks §5.2 (CATEGORY_LIST → CATEGORY_DETAILS
 // per category) into canonical objects under the "Categories" root. Item
 // rows render exactly as the wire returns them (§3.3 ITEM_TYPE + VALUE):
-// SOURCE / DEST names, nested CATEGORY references, TEXT / FILE / CUSTOM.
-// The index prefix preserves the category's slot order in the sorted tree.
+// SOURCE / DEST rows carry the routable ID on this class of plant
+// (§1.8 name-or-ID), so the leaf is annotated with the primary mnemonic
+// joined from the SRCE_MNE / DEST_MNE catalogue (two wildcard OBTAINs —
+// the same reads list-sources / list-dests use). Nested CATEGORY, TEXT,
+// FILE, CUSTOM rows render verbatim. The index prefix preserves the
+// category's slot order in the sorted tree.
 func cerebrumCategoryTreeObjects(sess *cerebrum.Session, timeout time.Duration) ([]consumer.Object, error) {
 	list, err := obtainSingleCategoryChange(sess, timeout,
 		&codec.CategoryChange{Type: "CATEGORY_LIST"}, "CATEGORY_LIST")
@@ -170,6 +174,22 @@ func cerebrumCategoryTreeObjects(sess *cerebrum.Session, timeout time.Duration) 
 	}
 	if list == nil || list.Category == nil {
 		return nil, fmt.Errorf("cerebrum-nb tree: no CATEGORY_LIST reply within timeout")
+	}
+
+	// Mnemonic join: ID -> primary label for SOURCE and DEST item rows.
+	st, err := cerebrumObtainState(context.Background(), sess, "0.0.0.0", "ROUTER", 15*time.Second, cerebrumStateWant{
+		SrcMne: true, DstMne: true, Verb: "tree",
+	})
+	if err != nil {
+		return nil, err
+	}
+	srcName := map[string]string{}
+	for _, r := range st.Src {
+		srcName[r.ID] = r.Mnemonic
+	}
+	dstName := map[string]string{}
+	for _, r := range st.Dst {
+		dstName[r.ID] = r.Mnemonic
 	}
 
 	var objs []consumer.Object
@@ -192,11 +212,22 @@ func cerebrumCategoryTreeObjects(sess *cerebrum.Session, timeout time.Duration) 
 			continue
 		}
 		for _, it := range det.Category.Details.Items {
+			val := it.Value
+			switch it.Type {
+			case "SOURCE", "SRCE":
+				if mne, ok := srcName[it.Value]; ok && mne != "" {
+					val = fmt.Sprintf("%s %q", it.Value, mne)
+				}
+			case "DEST", "DESTINATION":
+				if mne, ok := dstName[it.Value]; ok && mne != "" {
+					val = fmt.Sprintf("%s %q", it.Value, mne)
+				}
+			}
 			objs = append(objs, consumer.Object{
 				Path:  []string{"Categories", cat, fmt.Sprintf("%04d %s", it.Index, it.Type)},
 				Label: it.Value, ID: it.Index,
 				Kind: consumer.KindString, Access: 1,
-				Value: consumer.Value{Kind: consumer.KindString, Str: it.Value},
+				Value: consumer.Value{Kind: consumer.KindString, Str: val},
 			})
 		}
 	}

--- a/cmd/dhs/cmd_cerebrum_tree.go
+++ b/cmd/dhs/cmd_cerebrum_tree.go
@@ -106,7 +106,7 @@ func cerebrumTree(_ context.Context, args []string) error {
 		renderFocus = "" // --path already scoped the walk itself
 	} else {
 		if *domain == "sources" || *domain == "dests" || *domain == "all" {
-			mneObjs, merr := cerebrumMneTreeObjects(sess, *domain, *alt)
+			mneObjs, merr := cerebrumMneTreeObjects(sess, cf.timeout, *domain, *alt)
 			if merr != nil {
 				return merr
 			}
@@ -296,13 +296,14 @@ func cerebrumDeviceTreeObjects(sess *cerebrum.Session, timeout time.Duration, de
 	return objs, nil
 }
 
-// cerebrumMneTreeObjects renders the Routemaster resource inventory as
-// tree domains: Sources / Dests roots with one leaf per resource — ID
-// (zero-padded so the sorted tree keeps numeric order), capability levels
-// (ASSOCIATION indices), label from the selected set (--alt) and the alt
-// list. domain "sources" | "dests" | "all" selects which wildcard MNE
-// reads run.
-func cerebrumMneTreeObjects(sess *cerebrum.Session, domain string, alt int) ([]consumer.Object, error) {
+// cerebrumMneTreeObjects renders the resource inventory PER ROUTER (owner
+// rule: "RM first and then all the routers if exists"): Sources / Dests →
+// router node ("RM 0.0.0.0" then each ROUTER-class device from the §5.4
+// LIST) → one leaf per resource — ID zero-padded so the sorted tree keeps
+// numeric order, capability levels, label from the selected set (--alt)
+// and the alt list. A router that refuses the MNE reads is skipped with a
+// warning (lenient — per-router grants proven live 2026-08-16 on .27).
+func cerebrumMneTreeObjects(sess *cerebrum.Session, timeout time.Duration, domain string, alt int) ([]consumer.Object, error) {
 	want := cerebrumStateWant{Verb: "tree"}
 	if domain == "sources" || domain == "all" {
 		want.SrcMne = true
@@ -310,18 +311,33 @@ func cerebrumMneTreeObjects(sess *cerebrum.Session, domain string, alt int) ([]c
 	if domain == "dests" || domain == "all" {
 		want.DstMne = true
 	}
-	st, err := cerebrumObtainState(context.Background(), sess, "0.0.0.0", "ROUTER", 15*time.Second, want)
-	if err != nil {
-		return nil, err
+
+	// RM sentinel first, then every ROUTER-class device the plant lists.
+	routers := []string{"0.0.0.0"}
+	if got, err := obtainSingleDeviceChange(sess, timeout, &codec.DeviceChange{Type: "LIST"}, "LIST"); err == nil && got != nil && got.Device != nil {
+		seen := map[string]bool{"0.0.0.0": true}
+		for _, d := range got.Device.Devices {
+			isRouter := d.DeviceType == codec.DeviceType("ROUTER")
+			for _, t := range d.DeviceTypes {
+				if t == codec.DeviceType("ROUTER") {
+					isRouter = true
+				}
+			}
+			if isRouter && d.IPAddress != "" && !seen[d.IPAddress] {
+				seen[d.IPAddress] = true
+				routers = append(routers, d.IPAddress)
+			}
+		}
 	}
+
 	pad := func(id string) string {
 		if n, aerr := strconv.Atoi(strings.TrimSpace(id)); aerr == nil {
 			return fmt.Sprintf("%05d", n)
 		}
 		return id
 	}
-	emit := func(root string, rows []cerebrumMneRow) []consumer.Object {
-		var out []consumer.Object
+	var objs []consumer.Object
+	emit := func(root, routerNode string, rows []cerebrumMneRow) {
 		for _, r := range rows {
 			label := r.Mnemonic
 			if alt > 0 {
@@ -334,18 +350,27 @@ func cerebrumMneTreeObjects(sess *cerebrum.Session, domain string, alt int) ([]c
 			if len(r.Alts) > 0 && alt <= 0 {
 				meta += " alts=" + formatAlts(r.Alts)
 			}
-			out = append(out, consumer.Object{
-				Path:  []string{root, pad(r.ID)},
+			objs = append(objs, consumer.Object{
+				Path:  []string{root, routerNode, pad(r.ID)},
 				Label: r.ID,
 				Kind:  consumer.KindString, Access: 1,
 				Value: consumer.Value{Kind: consumer.KindString, Str: meta},
 			})
 		}
-		return out
 	}
-	var objs []consumer.Object
-	objs = append(objs, emit("Sources", st.Src)...)
-	objs = append(objs, emit("Dests", st.Dst)...)
+	for _, router := range routers {
+		node := router
+		if router == "0.0.0.0" {
+			node = "RM 0.0.0.0"
+		}
+		st, err := cerebrumObtainState(context.Background(), sess, router, "ROUTER", 15*time.Second, want)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "cerebrum-nb tree: router %s skipped (%v)\n", router, err)
+			continue
+		}
+		emit("Sources", node, st.Src)
+		emit("Dests", node, st.Dst)
+	}
 	return objs, nil
 }
 

--- a/cmd/dhs/cmd_cerebrum_tree.go
+++ b/cmd/dhs/cmd_cerebrum_tree.go
@@ -105,11 +105,13 @@ func cerebrumTree(_ context.Context, args []string) error {
 // cerebrumExpandFocus resolves a --path that names a node ANYWHERE in the
 // tree, not only from the root: sub-category nesting means a category's
 // canonical path runs through its parents (Categories.DESTINATIONS.
-// DST-FUSION), but operators reference categories directly. The user's
-// dotted segments are matched as a contiguous subsequence of any object
-// path (case-insensitive, shallowest match wins) and expanded to the full
-// root path the renderer needs. No match returns the input unchanged so
-// the renderer's own error still fires.
+// DST-FUSION), but operators reference categories directly — with or
+// without the intermediate levels. The user's dotted segments are matched
+// IN ORDER against any object path, gaps allowed (case-insensitive), so
+// "Categories.DST-FUSION", "DST-FUSION" and the full canonical path all
+// resolve. The prefix ending at the last matched segment becomes the
+// renderer focus; the shallowest match wins. No match returns the input
+// unchanged so the renderer's own error still fires.
 func cerebrumExpandFocus(objs []consumer.Object, focus string) string {
 	if focus == "" {
 		return focus
@@ -118,20 +120,18 @@ func cerebrumExpandFocus(objs []consumer.Object, focus string) string {
 	best := []string(nil)
 	for i := range objs {
 		p := objs[i].Path
-		for start := 0; start+len(segs) <= len(p); start++ {
-			ok := true
-			for j, s := range segs {
-				if !strings.EqualFold(p[start+j], s) {
-					ok = false
-					break
-				}
+		j := 0
+		end := -1
+		for k := 0; k < len(p) && j < len(segs); k++ {
+			if strings.EqualFold(p[k], segs[j]) {
+				j++
+				end = k
 			}
-			if ok {
-				full := p[:start+len(segs)]
-				if best == nil || len(full) < len(best) {
-					best = append([]string{}, full...)
-				}
-				break
+		}
+		if j == len(segs) {
+			full := p[:end+1]
+			if best == nil || len(full) < len(best) {
+				best = append([]string{}, full...)
 			}
 		}
 	}

--- a/cmd/dhs/cmd_cerebrum_tree_test.go
+++ b/cmd/dhs/cmd_cerebrum_tree_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"testing"
+
+	"dhs/internal/consumer"
+)
+
+// TestCerebrumExpandFocus pins the focus resolution against nested
+// category paths: user segments match IN ORDER with gaps allowed
+// (case-insensitive), expanding to the canonical path prefix ending at
+// the last matched segment; shallowest match wins; no match passes the
+// input through untouched.
+func TestCerebrumExpandFocus(t *testing.T) {
+	objs := []consumer.Object{
+		{Path: []string{"Categories", "DESTINATIONS", "DST-FUSION", "0001 TEXT"}},
+		{Path: []string{"Categories", "DESTINATIONS", "DST-CLIENTS", "DST-EBU", "0001 DEST"}},
+		{Path: []string{"Salvos", "Salvo Group 1", "Salvo_001"}},
+	}
+	cases := []struct{ in, want string }{
+		// gap between Categories and DST-FUSION (DESTINATIONS skipped)
+		{"Categories.DST-FUSION", "Categories.DESTINATIONS.DST-FUSION"},
+		// bare category name from any depth
+		{"DST-FUSION", "Categories.DESTINATIONS.DST-FUSION"},
+		{"DST-EBU", "Categories.DESTINATIONS.DST-CLIENTS.DST-EBU"},
+		// full canonical path resolves to itself
+		{"Categories.DESTINATIONS.DST-FUSION", "Categories.DESTINATIONS.DST-FUSION"},
+		// case-insensitive
+		{"categories.dst-clients", "Categories.DESTINATIONS.DST-CLIENTS"},
+		// salvo side
+		{"Salvo Group 1", "Salvos.Salvo Group 1"},
+		// no match passes through
+		{"Categories.NOPE", "Categories.NOPE"},
+		// empty stays empty
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := cerebrumExpandFocus(objs, c.in); got != c.want {
+			t.Errorf("expand(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/cmd/dhs/cmd_cerebrum_xpoint.go
+++ b/cmd/dhs/cmd_cerebrum_xpoint.go
@@ -222,6 +222,7 @@ func cerebrumImportXpoint(_ context.Context, args []string) error {
 	lvlPath := fs.String("levels", "", "level-mnemonic CSV to import (columns level,mnemonic — LEVEL_MNE, 0v16 §4.1.4)")
 	catSrcPath := fs.String("cat-src", "", "SRC category CSV (category,type,value — row order = slot order; builds/converges the navigation categories; DEST items rejected)")
 	catDstPath := fs.String("cat-dst", "", "DST category CSV (same shape; SOURCE items rejected)")
+	catMixedPath := fs.String("cat-mixed", "", "mixed category CSV (same shape; both kinds legal — export writes genuinely mixed-subtree categories here)")
 	inDir := fs.String("in-dir", "", "directory holding an export set: <prefix>-xpoint.csv / -src.csv / -dst.csv / -level.csv / -cat-src.csv / -cat-dst.csv (the exact files `export --out-dir` wrote; files absent from the dir are simply out of scope)")
 	prefix := fs.String("prefix", "cerebrum", "file prefix used with --in-dir (same default as export)")
 	check := fs.Bool("check", false, "dry-run: read live state, report would_change per cell, send nothing")
@@ -266,11 +267,12 @@ func cerebrumImportXpoint(_ context.Context, args []string) error {
 		resolve(lvlPath, "-level.csv")
 		resolve(catSrcPath, "-cat-src.csv")
 		resolve(catDstPath, "-cat-dst.csv")
-		fmt.Fprintf(os.Stderr, "cerebrum-nb import: --in-dir resolved xpoint=%s src=%s dst=%s levels=%s cat-src=%s cat-dst=%s\n",
-			orDash(xp), orDash(*srcPath), orDash(*dstPath), orDash(*lvlPath), orDash(*catSrcPath), orDash(*catDstPath))
+		resolve(catMixedPath, "-cat-mixed.csv")
+		fmt.Fprintf(os.Stderr, "cerebrum-nb import: --in-dir resolved xpoint=%s src=%s dst=%s levels=%s cat-src=%s cat-dst=%s cat-mixed=%s\n",
+			orDash(xp), orDash(*srcPath), orDash(*dstPath), orDash(*lvlPath), orDash(*catSrcPath), orDash(*catDstPath), orDash(*catMixedPath))
 	}
-	if xp == "" && *srcPath == "" && *dstPath == "" && *lvlPath == "" && *catSrcPath == "" && *catDstPath == "" {
-		return fmt.Errorf("cerebrum-nb import: nothing to import (pass --xpoint / --src / --dst / --levels / --cat-src / --cat-dst, or --in-dir DIR --prefix P)")
+	if xp == "" && *srcPath == "" && *dstPath == "" && *lvlPath == "" && *catSrcPath == "" && *catDstPath == "" && *catMixedPath == "" {
+		return fmt.Errorf("cerebrum-nb import: nothing to import (pass --xpoint / --src / --dst / --levels / --cat-src / --cat-dst / --cat-mixed, or --in-dir DIR --prefix P)")
 	}
 
 	// Parse everything up front so a malformed file fails before any wire I/O.
@@ -338,7 +340,11 @@ func cerebrumImportXpoint(_ context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	catDefs := append(append([]cerebrumCatDef{}, catSrcDefs...), catDstDefs...)
+	catMixedDefs, err := loadCat(*catMixedPath, "mixed")
+	if err != nil {
+		return err
+	}
+	catDefs := append(append(append([]cerebrumCatDef{}, catSrcDefs...), catDstDefs...), catMixedDefs...)
 
 	// Ensure semantics (ADR-0007): read live state, diff, converge only the
 	// differences. --check reports would_change and sends nothing. Both need
@@ -625,13 +631,24 @@ func cerebrumExportXpoint(ctx context.Context, args []string) error {
 		return cerr
 	}
 	srcPick, dstPick, mixed := classifyCerebrumCategories(catNames, catDetails)
-	if len(mixed) > 0 {
-		fmt.Fprintf(os.Stderr, "cerebrum-nb export: WARNING — %d categor(ies) carry BOTH source and dest resources (written to both files): %s\n", len(mixed), strings.Join(mixed, ", "))
+	// Mixed-subtree categories get their OWN file so the src/dst files stay
+	// pure (their parsers reject the other kind — round-trip must hold).
+	mixedPick := map[string]bool{}
+	for _, m := range mixed {
+		mixedPick[m] = true
+		delete(srcPick, m)
+		delete(dstPick, m)
 	}
 	files = append(files,
 		struct{ name, content string }{*prefix + "-cat-src.csv", formatCerebrumCatCSV(cerebrumCatDefsFromLive(catNames, srcPick, catDetails))},
 		struct{ name, content string }{*prefix + "-cat-dst.csv", formatCerebrumCatCSV(cerebrumCatDefsFromLive(catNames, dstPick, catDetails))},
 	)
+	if len(mixed) > 0 {
+		fmt.Fprintf(os.Stderr, "cerebrum-nb export: %d categor(ies) carry BOTH source and dest resources in their subtree — written to %s-cat-mixed.csv: %s\n", len(mixed), *prefix, strings.Join(mixed, ", "))
+		files = append(files,
+			struct{ name, content string }{*prefix + "-cat-mixed.csv", formatCerebrumCatCSV(cerebrumCatDefsFromLive(catNames, mixedPick, catDetails))},
+		)
+	}
 	for _, f := range files {
 		path := filepath.Join(*outDir, f.name)
 		if err := os.WriteFile(path, []byte(f.content), 0o644); err != nil {

--- a/cmd/dhs/cmd_cerebrum_xpoint.go
+++ b/cmd/dhs/cmd_cerebrum_xpoint.go
@@ -220,7 +220,9 @@ func cerebrumImportXpoint(_ context.Context, args []string) error {
 	srcPath := fs.String("src", "", "source-mnemonic CSV to import (columns srce,mnemonic — router mnemonics are per-ID, not per-level, 0v16 §4.1.5)")
 	dstPath := fs.String("dst", "", "dest-mnemonic CSV to import (columns dest,mnemonic — 0v16 §4.1.6)")
 	lvlPath := fs.String("levels", "", "level-mnemonic CSV to import (columns level,mnemonic — LEVEL_MNE, 0v16 §4.1.4)")
-	inDir := fs.String("in-dir", "", "directory holding an export set: <prefix>-xpoint.csv / -src.csv / -dst.csv / -level.csv (the exact files `export --out-dir` wrote; files absent from the dir are simply out of scope)")
+	catSrcPath := fs.String("cat-src", "", "SRC category CSV (category,type,value — row order = slot order; builds/converges the navigation categories; DEST items rejected)")
+	catDstPath := fs.String("cat-dst", "", "DST category CSV (same shape; SOURCE items rejected)")
+	inDir := fs.String("in-dir", "", "directory holding an export set: <prefix>-xpoint.csv / -src.csv / -dst.csv / -level.csv / -cat-src.csv / -cat-dst.csv (the exact files `export --out-dir` wrote; files absent from the dir are simply out of scope)")
 	prefix := fs.String("prefix", "cerebrum", "file prefix used with --in-dir (same default as export)")
 	check := fs.Bool("check", false, "dry-run: read live state, report would_change per cell, send nothing")
 	allowClear := fs.Bool("allow-clear", false, "an EMPTY cell in a managed label column CLEARS the live label (MNEMONIC=\"\" — clear form live-UNVERIFIED; always --check first)")
@@ -262,11 +264,13 @@ func cerebrumImportXpoint(_ context.Context, args []string) error {
 		resolve(srcPath, "-src.csv")
 		resolve(dstPath, "-dst.csv")
 		resolve(lvlPath, "-level.csv")
-		fmt.Fprintf(os.Stderr, "cerebrum-nb import: --in-dir resolved xpoint=%s src=%s dst=%s levels=%s\n",
-			orDash(xp), orDash(*srcPath), orDash(*dstPath), orDash(*lvlPath))
+		resolve(catSrcPath, "-cat-src.csv")
+		resolve(catDstPath, "-cat-dst.csv")
+		fmt.Fprintf(os.Stderr, "cerebrum-nb import: --in-dir resolved xpoint=%s src=%s dst=%s levels=%s cat-src=%s cat-dst=%s\n",
+			orDash(xp), orDash(*srcPath), orDash(*dstPath), orDash(*lvlPath), orDash(*catSrcPath), orDash(*catDstPath))
 	}
-	if xp == "" && *srcPath == "" && *dstPath == "" && *lvlPath == "" {
-		return fmt.Errorf("cerebrum-nb import: nothing to import (pass --xpoint and/or --src/--dst/--levels, or --in-dir DIR --prefix P)")
+	if xp == "" && *srcPath == "" && *dstPath == "" && *lvlPath == "" && *catSrcPath == "" && *catDstPath == "" {
+		return fmt.Errorf("cerebrum-nb import: nothing to import (pass --xpoint / --src / --dst / --levels / --cat-src / --cat-dst, or --in-dir DIR --prefix P)")
 	}
 
 	// Parse everything up front so a malformed file fails before any wire I/O.
@@ -316,6 +320,25 @@ func cerebrumImportXpoint(_ context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	loadCat := func(path, kind string) ([]cerebrumCatDef, error) {
+		if path == "" {
+			return nil, nil
+		}
+		data, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return nil, rerr
+		}
+		return parseCerebrumCatCSV(data, kind, path)
+	}
+	catSrcDefs, err := loadCat(*catSrcPath, "src")
+	if err != nil {
+		return err
+	}
+	catDstDefs, err := loadCat(*catDstPath, "dst")
+	if err != nil {
+		return err
+	}
+	catDefs := append(append([]cerebrumCatDef{}, catSrcDefs...), catDstDefs...)
 
 	// Ensure semantics (ADR-0007): read live state, diff, converge only the
 	// differences. --check reports would_change and sends nothing. Both need
@@ -338,12 +361,16 @@ func cerebrumImportXpoint(_ context.Context, args []string) error {
 	sess := p.Session()
 	target := routeTargetFromFlags(*router, *deviceName)
 
-	st, err := cerebrumObtainState(context.Background(), sess, *router, "ROUTER", 15*time.Second, cerebrumStateWant{
-		Routes: xp != "", SrcMne: *srcPath != "", DstMne: *dstPath != "", LvlMne: *lvlPath != "",
-		StrictMne: true, Verb: "import",
-	})
-	if err != nil {
-		return err
+	st := &cerebrumState{}
+	if xp != "" || *srcPath != "" || *dstPath != "" || *lvlPath != "" {
+		got, serr := cerebrumObtainState(context.Background(), sess, *router, "ROUTER", 15*time.Second, cerebrumStateWant{
+			Routes: xp != "", SrcMne: *srcPath != "", DstMne: *dstPath != "", LvlMne: *lvlPath != "",
+			StrictMne: true, Verb: "import",
+		})
+		if serr != nil {
+			return serr
+		}
+		st = got
 	}
 
 	routeChanges := diffCerebrumRoutes(st.Routes, routes)
@@ -351,7 +378,31 @@ func cerebrumImportXpoint(_ context.Context, args []string) error {
 	dstChanges := diffCerebrumMnemonics("DEST_MNE", st.Dst, dstRows, dstSlots, *allowClear)
 	lvlChanges := diffCerebrumMnemonics("LEVEL_MNE", st.Lvl, lvlRows, lvlSlots, *allowClear)
 	mneChanges := append(append(srcChanges, dstChanges...), lvlChanges...)
-	total := len(routeChanges) + len(mneChanges)
+
+	// Category leg (ensure): read the live §5.2 grids, diff per slot.
+	var catChanges []cerebrumCatChange
+	if len(catDefs) > 0 {
+		catNames, catDetails, cerr := fetchCerebrumCategories(sess, cf.timeout)
+		if cerr != nil {
+			return cerr
+		}
+		exists := map[string]bool{}
+		for _, n := range catNames {
+			exists[n] = true
+		}
+		for _, def := range catDefs {
+			var live *codec.CategoryDetailsInfo
+			if exists[def.Name] {
+				if d := catDetails[def.Name]; d != nil {
+					live = d
+				} else {
+					live = &codec.CategoryDetailsInfo{}
+				}
+			}
+			catChanges = append(catChanges, diffCerebrumCategory(def.Name, live, def.Items)...)
+		}
+	}
+	total := len(routeChanges) + len(mneChanges) + len(catChanges)
 
 	// ADR-0007 diff[] — always built (even empty), one entry per converging
 	// cell: route.<dest>.<level> or <kind>.<id>.<slot>.
@@ -362,6 +413,13 @@ func cerebrumImportXpoint(_ context.Context, args []string) error {
 	for _, c := range mneChanges {
 		diffs = append(diffs, ensureDiff{Field: fmt.Sprintf("%s.%s.%d", strings.ToLower(c.Kind), c.ID, c.Slot), From: c.From, To: c.To})
 	}
+	for _, c := range catChanges {
+		if c.Op == "CREATE" {
+			diffs = append(diffs, ensureDiff{Field: "category." + c.Cat, From: "", To: "CREATE"})
+			continue
+		}
+		diffs = append(diffs, ensureDiff{Field: fmt.Sprintf("category.%s.%d", c.Cat, c.Index), From: c.From, To: strings.TrimSpace(c.Type + " " + c.Value)})
+	}
 
 	if *check {
 		for _, c := range routeChanges {
@@ -370,8 +428,15 @@ func cerebrumImportXpoint(_ context.Context, args []string) error {
 		for _, c := range mneChanges {
 			_, _ = fmt.Fprintf(logw, "[would-%s] id=%s slot=%d: %q -> %q\n", strings.ToLower(c.Kind), c.ID, c.Slot, c.From, c.To)
 		}
-		_, _ = fmt.Fprintf(logw, "cerebrum-nb import --check: would_change=%d (%d route(s), %d label(s)) of %d crosspoint(s)/%d label row(s) desired — nothing sent\n",
-			total, len(routeChanges), len(mneChanges), len(routes), xpRows+len(srcRows)+len(dstRows)+len(lvlRows))
+		for _, c := range catChanges {
+			if c.Op == "CREATE" {
+				_, _ = fmt.Fprintf(logw, "[would-category] create %s\n", c.Cat)
+				continue
+			}
+			_, _ = fmt.Fprintf(logw, "[would-category] %s slot %d: %q -> %q\n", c.Cat, c.Index, c.From, strings.TrimSpace(c.Type+" "+c.Value))
+		}
+		_, _ = fmt.Fprintf(logw, "cerebrum-nb import --check: would_change=%d (%d route(s), %d label(s), %d category change(s)) of %d crosspoint(s)/%d label row(s)/%d categor(ies) desired — nothing sent\n",
+			total, len(routeChanges), len(mneChanges), len(catChanges), len(routes), xpRows+len(srcRows)+len(dstRows)+len(lvlRows), len(catDefs))
 		if jsonOut {
 			wc := total > 0
 			return emitEnsure(true, ensureResult{WouldChange: &wc, Diff: diffs})
@@ -416,10 +481,34 @@ func cerebrumImportXpoint(_ context.Context, args []string) error {
 		}
 		_, _ = fmt.Fprintf(logw, "[%s] OK   id=%s slot=%d: %q -> %q\n", strings.ToLower(c.Kind), c.ID, c.Slot, c.From, c.To)
 	}
+	for _, c := range catChanges {
+		actx, cancel := context.WithTimeout(context.Background(), cf.timeout)
+		var aerr error
+		switch c.Op {
+		case "CREATE":
+			aerr = sess.Category(actx, &codec.CategoryAction{Type: "CREATE", Name: c.Cat})
+		default: // MODIFY_ITEM (incl. BLANK clears)
+			aerr = sess.Category(actx, &codec.CategoryAction{
+				Type: "MODIFY_ITEM", Category: c.Cat,
+				Index: strconv.Itoa(c.Index), ItemType: codec.ItemType(c.Type), Value: c.Value,
+			})
+		}
+		cancel()
+		if aerr != nil {
+			_, _ = fmt.Fprintf(logw, "[category] NACK %s %s slot=%d reason=%s\n", c.Op, c.Cat, c.Index, aerr)
+			fails++
+			continue
+		}
+		if c.Op == "CREATE" {
+			_, _ = fmt.Fprintf(logw, "[category] OK   CREATE %s\n", c.Cat)
+		} else {
+			_, _ = fmt.Fprintf(logw, "[category] OK   %s slot %d: %q -> %q\n", c.Cat, c.Index, c.From, strings.TrimSpace(c.Type+" "+c.Value))
+		}
+	}
 	if fails > 0 {
 		return fmt.Errorf("cerebrum-nb import: %d action(s) failed", fails)
 	}
-	_, _ = fmt.Fprintf(logw, "cerebrum-nb import: changed=%d (%d route(s), %d label(s)); run again to verify 0\n", total, len(routeChanges), len(mneChanges))
+	_, _ = fmt.Fprintf(logw, "cerebrum-nb import: changed=%d (%d route(s), %d label(s), %d category change(s)); run again to verify 0\n", total, len(routeChanges), len(mneChanges), len(catChanges))
 	if jsonOut {
 		ch := total > 0
 		return emitEnsure(true, ensureResult{Changed: &ch, Diff: diffs})
@@ -528,6 +617,21 @@ func cerebrumExportXpoint(ctx context.Context, args []string) error {
 		{*prefix + "-level.csv", formatCerebrumMneCSVN("level", lvlD, nAlt)},
 		{*prefix + "-xpoint.csv", xpCSV},
 	}
+	// Category navigation files (§5.2 walk): SRC and DST kept in separate
+	// files by owner rule; a category whose subtree carries both kinds is
+	// written to both and warned about.
+	catNames, catDetails, cerr := fetchCerebrumCategories(p.Session(), cf.timeout)
+	if cerr != nil {
+		return cerr
+	}
+	srcPick, dstPick, mixed := classifyCerebrumCategories(catNames, catDetails)
+	if len(mixed) > 0 {
+		fmt.Fprintf(os.Stderr, "cerebrum-nb export: WARNING — %d categor(ies) carry BOTH source and dest resources (written to both files): %s\n", len(mixed), strings.Join(mixed, ", "))
+	}
+	files = append(files,
+		struct{ name, content string }{*prefix + "-cat-src.csv", formatCerebrumCatCSV(cerebrumCatDefsFromLive(catNames, srcPick, catDetails))},
+		struct{ name, content string }{*prefix + "-cat-dst.csv", formatCerebrumCatCSV(cerebrumCatDefsFromLive(catNames, dstPick, catDetails))},
+	)
 	for _, f := range files {
 		path := filepath.Join(*outDir, f.name)
 		if err := os.WriteFile(path, []byte(f.content), 0o644); err != nil {

--- a/internal/cerebrum-nb/codec/actions.go
+++ b/internal/cerebrum-nb/codec/actions.go
@@ -72,10 +72,18 @@ const (
 	LockLockedPath    LockKind = "LOCKED_PATH"
 	LockProtectedPath LockKind = "PROTECTED_PATH"
 
+	// Wire-actual, NOT spec (live NOC 2026-08-16): the clearing action a
+	// real Cerebrum ACCEPTS — and the LOCK_STATE it reports for cleared
+	// locks — is RELEASED, a sixth value absent from the §3.2 table and
+	// the worked examples. The spec's RELEASE/PROTECT and §3.2's
+	// UNLOCKED are all NACKed 8 as actions on that server.
+	LockReleased LockKind = "RELEASED"
+
 	// Deprecated: not in the §3.2 table. The 4.1.2/4.1.3 worked
 	// examples (p11-12) still show LOCK="RELEASE"/"PROTECT" verbs, so
-	// these remain valid action arguments, but they are not LOCK_STATE
-	// values a device reports back.
+	// these remain valid action arguments per the PDF, but a live NOC
+	// Cerebrum NACKs both (see LockReleased) and they are not
+	// LOCK_STATE values a device reports back.
 	LockProtect LockKind = "PROTECT"
 	LockRelease LockKind = "RELEASE"
 )

--- a/internal/cerebrum-nb/codec/codec_edges_test.go
+++ b/internal/cerebrum-nb/codec/codec_edges_test.go
@@ -57,6 +57,33 @@ func TestParseCategoryChange_BadItemChildren(t *testing.T) {
 	}
 }
 
+func TestParseDeviceChange_DetailsPositionalSubDevices(t *testing.T) {
+	// Live NOC frame 2026-08-16 (Neuron shelf bm-n-nnshf-004, DEVICE-class
+	// view): SUB_DEVICES carries positional <DEVICE_N TYPE="model"
+	// PRIMARY_STATE SECONDARY_STATE/> children — DEVICE_N like ITEM_N /
+	// ASSOCIATION_N, TYPE = sub-device model (class-filtered: the ROUTER-
+	// class sub-device of the same shelf is absent from the DEVICE view).
+	wire := `<DEVICE_CHANGE TYPE="DETAILS" IP_ADDRESS="10.44.72.27" DEVICE_TYPE="DEVICE">` +
+		`<DETAILS IP1="10.44.72.27" IP2="" NAME="bm-n-nnshf-004" TYPE="bm-n-nnshf-004"/>` +
+		`<SERVICE/>` +
+		`<CONNECTION PRIMARY_STATE="Connection Active" SECONDARY_STATE="Connection Not Configured"/>` +
+		`<SUB_DEVICES><DEVICE_1 TYPE="SHUFFLE-256" PRIMARY_STATE="Connection Active" SECONDARY_STATE="Connection Not Configured"/></SUB_DEVICES>` +
+		`</DEVICE_CHANGE>`
+	f, err := Decode([]byte(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := f.Device
+	if d == nil || len(d.SubDevices) != 1 {
+		t.Fatalf("SubDevices = %+v", d)
+	}
+	sd := d.SubDevices[0]
+	if sd.Index != 1 || sd.DeviceName != "SHUFFLE-256" ||
+		sd.PrimaryState != "Connection Active" || sd.SecondaryState != "Connection Not Configured" {
+		t.Errorf("sub-device = %+v", sd)
+	}
+}
+
 func TestParseDeviceChange_DetailsWithPopulatedSubDevices(t *testing.T) {
 	// §5.4.2 p29-style DETAILS with a populated <SUB_DEVICES> containing
 	// <DEVICE> children — exercises the sub-device loop + the

--- a/internal/cerebrum-nb/codec/codec_edges_test.go
+++ b/internal/cerebrum-nb/codec/codec_edges_test.go
@@ -57,6 +57,42 @@ func TestParseCategoryChange_BadItemChildren(t *testing.T) {
 	}
 }
 
+func TestParseDeviceChange_ValueChangeEventTopLevelAttr(t *testing.T) {
+	// Live NOC frame 2026-08-16 (CONVERT audio delay, VALUE SUBSCRIBE):
+	// change events carry the new value as a TOP-LEVEL attribute with no
+	// OBJECT_VALUE child — the decoder synthesizes one so consumers see a
+	// single shape.
+	wire := `<DEVICE_CHANGE TYPE="VALUE" IP_ADDRESS="10.44.72.28" DEVICE_NAME="bm-n-nncvt-001 " SUB_DEVICE="1" OBJECT="PROCESSING AUDIO.AUDIO DELAY.BANK 1.Delay" VALUE="2.000000"/>`
+	f, err := Decode([]byte(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := f.Device
+	if d == nil || len(d.ObjectValues) != 1 {
+		t.Fatalf("ObjectValues = %+v", d)
+	}
+	ov := d.ObjectValues[0]
+	if ov.Value != "2.000000" || !ov.Available || ov.Object != "PROCESSING AUDIO.AUDIO DELAY.BANK 1.Delay" {
+		t.Errorf("synthesized value = %+v", ov)
+	}
+}
+
+func TestParseDeviceChange_ValueDescriptorMinMaxStep(t *testing.T) {
+	// Live NOC snapshot 2026-08-16: the full descriptor carries MIN/MAX/
+	// STEP range attrs on FLOAT objects.
+	wire := `<DEVICE_CHANGE TYPE="VALUE" IP_ADDRESS="10.44.72.28" DEVICE_NAME="bm-n-nncvt-001 " SUB_DEVICE="1" OBJECT="PROCESSING AUDIO.AUDIO DELAY.BANK 1.Delay">` +
+		`<OBJECT_VALUE OBJECT="PROCESSING AUDIO.AUDIO DELAY.BANK 1.Delay" VALUE="0.000000" AVAILABLE="1" DATA_TYPE="FLOAT" READABLE="1" WRITABLE="1" MIN="0.000000" MAX="3000.000000" STEP="1.000000" DEFAULT="0.000000"/>` +
+		`</DEVICE_CHANGE>`
+	f, err := Decode([]byte(wire))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ov := f.Device.ObjectValue
+	if ov == nil || ov.Min != "0.000000" || ov.Max != "3000.000000" || ov.Step != "1.000000" || ov.Default != "0.000000" {
+		t.Errorf("descriptor = %+v", ov)
+	}
+}
+
 func TestParseDeviceChange_DetailsPositionalSubDevices(t *testing.T) {
 	// Live NOC frame 2026-08-16 (Neuron shelf bm-n-nnshf-004, DEVICE-class
 	// view): SUB_DEVICES carries positional <DEVICE_N TYPE="model"

--- a/internal/cerebrum-nb/codec/codec_edges_test.go
+++ b/internal/cerebrum-nb/codec/codec_edges_test.go
@@ -99,11 +99,13 @@ func TestParseDeviceChange_DetailsPositionalSubDevices(t *testing.T) {
 	// PRIMARY_STATE SECONDARY_STATE/> children — DEVICE_N like ITEM_N /
 	// ASSOCIATION_N, TYPE = sub-device model (class-filtered: the ROUTER-
 	// class sub-device of the same shelf is absent from the DEVICE view).
+	// DEVICE_X (non-numeric suffix) exercises the malformed-index guard —
+	// skipped, never decoded.
 	wire := `<DEVICE_CHANGE TYPE="DETAILS" IP_ADDRESS="10.44.72.27" DEVICE_TYPE="DEVICE">` +
 		`<DETAILS IP1="10.44.72.27" IP2="" NAME="bm-n-nnshf-004" TYPE="bm-n-nnshf-004"/>` +
 		`<SERVICE/>` +
 		`<CONNECTION PRIMARY_STATE="Connection Active" SECONDARY_STATE="Connection Not Configured"/>` +
-		`<SUB_DEVICES><DEVICE_1 TYPE="SHUFFLE-256" PRIMARY_STATE="Connection Active" SECONDARY_STATE="Connection Not Configured"/></SUB_DEVICES>` +
+		`<SUB_DEVICES><DEVICE_1 TYPE="SHUFFLE-256" PRIMARY_STATE="Connection Active" SECONDARY_STATE="Connection Not Configured"/><DEVICE_X TYPE="BOGUS"/></SUB_DEVICES>` +
 		`</DEVICE_CHANGE>`
 	f, err := Decode([]byte(wire))
 	if err != nil {

--- a/internal/cerebrum-nb/codec/decode.go
+++ b/internal/cerebrum-nb/codec/decode.go
@@ -515,7 +515,8 @@ func parseDeviceChange(e *Element) *DeviceChange {
 	}
 	// TYPE=VALUE: one or more <OBJECT_VALUE …/> children (§5.4.3 p29).
 	// A scalar object yields one; a group / table / wildcard path yields
-	// several. The full 0v16 descriptor is captured per entry.
+	// several. The full 0v16 descriptor is captured per entry, incl. the
+	// MIN/MAX/STEP range attrs (live 2026-08-16, CONVERT audio delay).
 	for _, ov := range e.ChildrenNamed("object_value") {
 		d.ObjectValues = append(d.ObjectValues, DeviceObjectValue{
 			Object:    ov.Attr("object"),
@@ -527,11 +528,27 @@ func parseDeviceChange(e *Element) *DeviceChange {
 			Units:     ov.Attr("units"),
 			Label:     ov.Attr("label"),
 			Default:   ov.Attr("default"),
+			Min:       ov.Attr("min"),
+			Max:       ov.Attr("max"),
+			Step:      ov.Attr("step"),
 			EnumList:  splitCSV(ov.Attr("enum_list")),
 		})
 	}
 	if len(d.ObjectValues) > 0 {
 		d.ObjectValue = &d.ObjectValues[0]
+	}
+	// Live-wire change-event shape (2026-08-16): after a VALUE SUBSCRIBE,
+	// each change arrives with the new value as a TOP-LEVEL attribute and
+	// NO OBJECT_VALUE child:
+	//   <DEVICE_CHANGE TYPE="VALUE" … OBJECT="…" VALUE="2.000000"/>
+	// Surface it as a synthesized ObjectValue so consumers see one shape.
+	if len(d.ObjectValues) == 0 && d.Type == "VALUE" {
+		if v := e.Attr("value"); v != "" {
+			d.ObjectValues = append(d.ObjectValues, DeviceObjectValue{
+				Object: d.Object, Value: v, Available: true,
+			})
+			d.ObjectValue = &d.ObjectValues[0]
+		}
 	}
 	if subs := e.Child("sub_devices"); subs != nil {
 		for _, child := range subs.ChildrenNamed("device") {

--- a/internal/cerebrum-nb/codec/decode.go
+++ b/internal/cerebrum-nb/codec/decode.go
@@ -550,6 +550,26 @@ func parseDeviceChange(e *Element) *DeviceChange {
 			}
 			d.SubDevices = append(d.SubDevices, entry)
 		}
+		// Live-NOC positional shape (2026-08-16, Neuron shelf): the child
+		// is <DEVICE_N TYPE="model" PRIMARY_STATE="..." SECONDARY_STATE=
+		// "..."/> — DEVICE_N like the ITEM_N / ASSOCIATION_N grids, TYPE
+		// carries the sub-device model name (not the §3.1 class enum).
+		for _, child := range subs.Children {
+			nStr, ok := strings.CutPrefix(child.Name, "device_")
+			if !ok {
+				continue
+			}
+			n, err := strconv.Atoi(nStr)
+			if err != nil {
+				continue
+			}
+			d.SubDevices = append(d.SubDevices, DeviceEntry{
+				Index:          n,
+				DeviceName:     child.Attr("type"),
+				PrimaryState:   child.Attr("primary_state"),
+				SecondaryState: child.Attr("secondary_state"),
+			})
+		}
 	}
 	return d
 }

--- a/internal/cerebrum-nb/codec/events.go
+++ b/internal/cerebrum-nb/codec/events.go
@@ -308,6 +308,16 @@ type DeviceEntry struct {
 	DeviceType  DeviceType   // first instance — convenience accessor
 	DeviceTypes []DeviceType // every <INSTANCE DEVICE_TYPE="..."/> emitted by the server
 	DeviceName  string
+
+	// Index / states populate for the positional SUB_DEVICES shape a live
+	// NOC Cerebrum emits under DETAILS (2026-08-16, Neuron shelf
+	// bm-n-nnshf-004): <SUB_DEVICES><DEVICE_1 TYPE="SHUFFLE-256"
+	// PRIMARY_STATE="Connection Active" SECONDARY_STATE="..."/> — the
+	// child is DEVICE_N (not <DEVICE>) and TYPE carries the sub-device
+	// model, which lands in DeviceName. Index is N.
+	Index          int
+	PrimaryState   string
+	SecondaryState string
 }
 
 // DeviceDetails is the <details> child of a DEVICE_CHANGE TYPE=DETAILS

--- a/internal/cerebrum-nb/codec/events.go
+++ b/internal/cerebrum-nb/codec/events.go
@@ -290,6 +290,9 @@ type DeviceObjectValue struct {
 	Units     string
 	Label     string
 	Default   string
+	Min       string // §5.4.3 range attrs (live 2026-08-16: MIN/MAX/STEP on FLOAT objects)
+	Max       string
+	Step      string
 	EnumList  []string // ENUM_LIST="On,Off" split on comma
 }
 

--- a/internal/cerebrum-nb/docs/README.md
+++ b/internal/cerebrum-nb/docs/README.md
@@ -34,6 +34,7 @@ EVS **Cerebrum Northbound API 0v16** (authoritative) — also branded
 | Reads | `list-devices` / `device-details` / `device-value` | device domain |
 | | `list-categories` / `category-details` | category domain (items = SOURCE/DEST names) |
 | | `list-salvo-groups` / `list-salvo-instances` / `salvo-instance-details` | salvo domain |
+| | `tree` | NB catalogue as the canonical ASCII / PlantUML tree — Categories (§5.2: categories → SOURCE/DEST/nested-CATEGORY items) + Salvos (§5.3: groups → instances → metadata; salvo item rows are not exposed over NB) — `--domain salvos\|categories\|all` |
 | | `obtain-datastore` | data store fetch |
 | Writes | `salvo` (run/save/rename/description/delete) · `category` (create/modify/delete) · `set-value` · `device-config` | §4 actions |
 

--- a/internal/cerebrum-nb/docs/README.md
+++ b/internal/cerebrum-nb/docs/README.md
@@ -35,7 +35,7 @@ EVS **Cerebrum Northbound API 0v16** (authoritative) — also branded
 | | `list-categories` / `category-details` | category domain (items = SOURCE/DEST names) |
 | | `list-salvo-groups` / `list-salvo-instances` / `salvo-instance-details` | salvo domain |
 | | `obtain-datastore` | data store fetch |
-| Writes | `salvo` (run/save/rename/delete) · `category` (create/modify/delete) · `set-value` · `device-config` | §4 actions |
+| Writes | `salvo` (run/save/rename/description/delete) · `category` (create/modify/delete) · `set-value` · `device-config` | §4 actions |
 
 Common flags: `--port` (default 40007) · `--user/--pass` (or `$DHS_CEREBRUM_USER/_PASS`)
 · `--tls` · `--timeout` · `--debug` (RX/TX XML to stderr) · **`--log FILE`**

--- a/internal/cerebrum-nb/docs/consumer.md
+++ b/internal/cerebrum-nb/docs/consumer.md
@@ -36,7 +36,7 @@ user-facing CLI reference.
 | `device-config` | `<DEVICE_CONFIGURATION TYPE='ADD\|MODIFY\|REMOVE'/>` — the 0v16 §4.5 device-tree CRUD command, `--device-type generic\|panel\|router\|snmp` |
 | `set-mnemonic` | `<action><routing TYPE='*_MNE'/></action>` — set a level / source / dest mnemonic |
 | `set-tags` | `<action><routing TYPE='RM_*_TAGS'/></action>` — Routemaster source / dest tags |
-| `salvo` | `<action><salvo TYPE='…'/></action>` — `--op run\|save\|rename\|delete` |
+| `salvo` | `<action><salvo TYPE='…'/></action>` — `--op run\|save\|rename\|description\|delete` |
 | `category` | `<action><category TYPE='…'/></action>` — `--op create\|modify\|delete` |
 | `set-value` | `<action><device TYPE='SET_VALUE'/></action>` — write a device object value |
 

--- a/internal/cerebrum-nb/docs/keys.md
+++ b/internal/cerebrum-nb/docs/keys.md
@@ -145,13 +145,15 @@ Three device classes:
 > RELEASED. `unlock` sends RELEASED by default. **All-level form
 > verified** (2026-08-16): omitting LEVEL locks every existing level in
 > one action (14 per-level events observed; nonexistent levels no-op
-> silently). **Ownership is INFORMATIONAL ONLY** (verified: an
-> Admin-owned lock was overwritten by YOB's LOCK action — LOCKED_BY
-> flipped — and then released; the server enforces nothing, LOCKED_BY
-> is display metadata, NB locks are advisory rather than protection).
-> RELEASED is also IDEMPOTENT: re-releasing a free cell ACKs and
+> silently). **Ownership between ADMIN-privileged actors is not
+> enforced** (verified: the XY panel's Admin lock was overwritten by
+> YOB's LOCK — LOCKED_BY flipped — and vice-versa; both actors carry
+> admin rights, so this proves admin-level override, NOT the absence
+> of enforcement in general — whether a NON-admin user can override /
+> release is untested, owner's TODO). LOCKED_BY is at minimum display
+> metadata. RELEASED is IDEMPOTENT: re-releasing a free cell ACKs and
 > re-emits the event. EVS follow-ups: confirm RELEASED is the
-> sanctioned clearing action; is ownership enforcement configurable?
+> sanctioned clearing action; document the lock permission model.
 
 Valid values for the `LOCK` / `lock` attribute on routing
 actions/events. Observed from spec examples:

--- a/internal/cerebrum-nb/docs/keys.md
+++ b/internal/cerebrum-nb/docs/keys.md
@@ -134,15 +134,17 @@ Three device classes:
 ### LOCK (§3.2)
 
 > **Wire-actual, NOT spec (live NOC 2026-08-16, DEST_LOCK on the
-> route-master):** the server ACCEPTS the five-mode set values
-> (`LOCKED` and `PROTECTED` verified; lock visible in the Matrix View)
-> but **NACKs 8 on every clearing value** — the §4.1.2/4.1.3 worked
-> examples' `RELEASE`, the legacy `PROTECT`, and the §3.2 `UNLOCKED`
-> alike — at least from a session other than the one that set the lock
-> (every CLI run is a fresh session). Release worked only via the UI.
-> Open EVS question: how does an NB client release a lock — owner /
-> same-session only, or not at all? Until answered, prefer timed locks
-> (`DURATION`) for automation.
+> route-master) — SOLVED:** the server accepts the five-mode set values
+> (`LOCKED`, `PROTECTED` verified; lock visible in the Matrix View) and
+> clears with **`LOCK="RELEASED"`** — a SIXTH value absent from the
+> §3.2 table and the worked examples, discovered by listening while the
+> UI released (DEST_LOCK events carry `LOCK_STATE` + **`LOCKED_BY`**;
+> cleared locks report `LOCK_STATE="RELEASED"`). The spec's documented
+> clearing forms all NACK 8: §4.1.2/4.1.3 `RELEASE`, legacy `PROTECT`,
+> §3.2 `UNLOCKED`. Cross-session release by the same NB user works with
+> RELEASED. `unlock` sends RELEASED by default. EVS follow-ups: confirm
+> RELEASED is the sanctioned clearing action; cross-USER release rules
+> (the UI's Admin could release YOB's lock).
 
 Valid values for the `LOCK` / `lock` attribute on routing
 actions/events. Observed from spec examples:

--- a/internal/cerebrum-nb/docs/keys.md
+++ b/internal/cerebrum-nb/docs/keys.md
@@ -142,9 +142,12 @@ Three device classes:
 > cleared locks report `LOCK_STATE="RELEASED"`). The spec's documented
 > clearing forms all NACK 8: §4.1.2/4.1.3 `RELEASE`, legacy `PROTECT`,
 > §3.2 `UNLOCKED`. Cross-session release by the same NB user works with
-> RELEASED. `unlock` sends RELEASED by default. EVS follow-ups: confirm
-> RELEASED is the sanctioned clearing action; cross-USER release rules
-> (the UI's Admin could release YOB's lock).
+> RELEASED. `unlock` sends RELEASED by default. **All-level form
+> verified** (2026-08-16): omitting LEVEL locks every existing level in
+> one action (14 per-level events observed; nonexistent levels no-op
+> silently). EVS follow-ups: confirm RELEASED is the sanctioned
+> clearing action; cross-USER release rules (the UI's Admin could
+> release YOB's lock).
 
 Valid values for the `LOCK` / `lock` attribute on routing
 actions/events. Observed from spec examples:

--- a/internal/cerebrum-nb/docs/keys.md
+++ b/internal/cerebrum-nb/docs/keys.md
@@ -133,6 +133,17 @@ Three device classes:
 
 ### LOCK (§3.2)
 
+> **Wire-actual, NOT spec (live NOC 2026-08-16, DEST_LOCK on the
+> route-master):** the server ACCEPTS the five-mode set values
+> (`LOCKED` and `PROTECTED` verified; lock visible in the Matrix View)
+> but **NACKs 8 on every clearing value** — the §4.1.2/4.1.3 worked
+> examples' `RELEASE`, the legacy `PROTECT`, and the §3.2 `UNLOCKED`
+> alike — at least from a session other than the one that set the lock
+> (every CLI run is a fresh session). Release worked only via the UI.
+> Open EVS question: how does an NB client release a lock — owner /
+> same-session only, or not at all? Until answered, prefer timed locks
+> (`DURATION`) for automation.
+
 Valid values for the `LOCK` / `lock` attribute on routing
 actions/events. Observed from spec examples:
 

--- a/internal/cerebrum-nb/docs/keys.md
+++ b/internal/cerebrum-nb/docs/keys.md
@@ -124,6 +124,13 @@ Three device classes:
 | `SNMP` | SNMP-managed device |
 | `Device` | Generic non-router, non-SNMP device |
 
+> **Wire-actual, NOT spec (live 2026-08-16):** the server is
+> case-sensitive on this attribute's VALUE and accepts only the
+> UPPERCASE forms — `DEVICE_TYPE="Router"` (the spec's own spelling)
+> NACKs 10, `DEVICE_TYPE="ROUTER"` answers. Same spec-vs-wire case
+> pattern as element names ("Element case on the wire" above). Encoder
+> policy: always emit UPPERCASE; CLI flags accept any case.
+
 ### LOCK (§3.2)
 
 Valid values for the `LOCK` / `lock` attribute on routing

--- a/internal/cerebrum-nb/docs/keys.md
+++ b/internal/cerebrum-nb/docs/keys.md
@@ -145,9 +145,13 @@ Three device classes:
 > RELEASED. `unlock` sends RELEASED by default. **All-level form
 > verified** (2026-08-16): omitting LEVEL locks every existing level in
 > one action (14 per-level events observed; nonexistent levels no-op
-> silently). EVS follow-ups: confirm RELEASED is the sanctioned
-> clearing action; cross-USER release rules (the UI's Admin could
-> release YOB's lock).
+> silently). **Ownership is INFORMATIONAL ONLY** (verified: an
+> Admin-owned lock was overwritten by YOB's LOCK action — LOCKED_BY
+> flipped — and then released; the server enforces nothing, LOCKED_BY
+> is display metadata, NB locks are advisory rather than protection).
+> RELEASED is also IDEMPOTENT: re-releasing a free cell ACKs and
+> re-emits the event. EVS follow-ups: confirm RELEASED is the
+> sanctioned clearing action; is ownership enforcement configurable?
 
 Valid values for the `LOCK` / `lock` attribute on routing
 actions/events. Observed from spec examples:

--- a/internal/cerebrum-nb/docs/runbook.md
+++ b/internal/cerebrum-nb/docs/runbook.md
@@ -71,7 +71,7 @@ device we serve (see [provider.md](provider.md)).
 | `device-config` | Add / modify / remove a device in the Cerebrum tree (0v16 §4.5) | `add\|modify\|remove --device-type generic\|panel\|router\|snmp --ip IP …` |
 | `set-mnemonic` | Set a level / source / dest mnemonic | `--kind LEVEL_MNE\|SRCE_MNE\|DEST_MNE --mnemonic TXT --level [--alt SLOT]` |
 | `set-tags` | Set Routemaster source / dest tags | `--kind RM_SRCE_TAGS\|RM_DEST_TAGS --tags a,b,c` |
-| `salvo` | Run / save / rename / set description / delete a salvo | `--op run\|save\|rename\|description\|delete --group [--instance --new-name --description]` |
+| `salvo` | Run / save / rename / set description / delete a salvo — ENSURE (ADR-0007): description/rename/delete read live state first (already converged = `changed:false`, nothing sent); run/save are events (always fire) | `--op run\|save\|rename\|description\|delete --group [--instance --new-name --description] [--check] [--output json]` |
 | `category` | Create / modify / delete a category | `--op create\|modify\|delete --category` |
 | `set-value` | Write a device object value | `--device --sub-device --object --value` |
 

--- a/internal/cerebrum-nb/docs/runbook.md
+++ b/internal/cerebrum-nb/docs/runbook.md
@@ -71,7 +71,7 @@ device we serve (see [provider.md](provider.md)).
 | `device-config` | Add / modify / remove a device in the Cerebrum tree (0v16 §4.5) | `add\|modify\|remove --device-type generic\|panel\|router\|snmp --ip IP …` |
 | `set-mnemonic` | Set a level / source / dest mnemonic | `--kind LEVEL_MNE\|SRCE_MNE\|DEST_MNE --mnemonic TXT --level [--alt SLOT]` |
 | `set-tags` | Set Routemaster source / dest tags | `--kind RM_SRCE_TAGS\|RM_DEST_TAGS --tags a,b,c` |
-| `salvo` | Run / save / rename / delete a salvo | `--op run\|save\|rename\|delete --group [--instance --new-name]` |
+| `salvo` | Run / save / rename / set description / delete a salvo | `--op run\|save\|rename\|description\|delete --group [--instance --new-name --description]` |
 | `category` | Create / modify / delete a category | `--op create\|modify\|delete --category` |
 | `set-value` | Write a device object value | `--device --sub-device --object --value` |
 


### PR DESCRIPTION
## What

Adds `salvo --op description` — the 0v16 §4.3 `DESCRIPTION` action (set a salvo instance's description), the last unmapped salvo TYPE.

## Why

Spec-literal NB command inventory follow-up (from the #676 out-of-scope list, split cat/salvo per owner): `salvo --op` covered 4 of 5 §4.3 TYPEs. The codec already encodes DESCRIPTION (pinned against the §4.3.4 worked example in `TestEncodeAction_SalvoDescription`) and the consumer already passes the text — only the CLI arm was missing.

Closes #678

## Scope

- [ ] acp1
- [ ] acp2
- [ ] emberplus
- [ ] probel-sw08p / probel-sw02p
- [x] osc / tsl / cerebrum-nb / amwa
- [ ] transport
- [ ] export
- [x] cli
- [ ] api
- [ ] core
- [ ] ci / chore

**Cross-protocol changes**: none — `cmd/dhs/cmd_cerebrum.go` op map + docs only.

## Wire evidence (protocol changes only)

No new wire form: the exact frame is already pinned byte-for-byte against the spec's §4.3.4 worked example (codec unit test):

```text
<ACTION MTID="1"><SALVO TYPE="DESCRIPTION" GROUP="Multiviewer 1" INSTANCE="Line up" DESCRIPTION="The layout for line up"/></ACTION>
```

## Reference controller

- [ ] Cerebrum still happy after this change
- [ ] VSM Studio still happy after this change
- [x] N/A (no protocol behaviour change — existing pinned wire form, new CLI mapping only)

## Type

- [x] feat — new feature

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `cmd/dhs/cmd_cerebrum.go` | modified | op map `description`→`DESCRIPTION`, `--description` required for the op, corrected flag/help text |
| `cmd/dhs/cmd_cerebrum_test.go` | modified | op-map case + missing-`--description` validation case |
| `internal/cerebrum-nb/docs/README.md` | modified | verb catalogue op list |
| `internal/cerebrum-nb/docs/runbook.md` | modified | salvo row op list |
| `internal/cerebrum-nb/docs/consumer.md` | modified | salvo row op list |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test -count=1 ./cmd/dhs/...` | ok | 0 |
| `go vet ./...` | clean | — |
| `golangci-lint run` | clean (pre-commit hook) | — |

## Device tested

- [ ] ACP1 producer 10.100.0.102
- [ ] ACP2 producer 10.100.0.103
- [ ] ACP1 emulator 10.6.239.113
- [ ] ACP2 real device 10.41.40.195
- [ ] Other (specify)
- [x] No device needed (pure codec / doc change) — wire form already spec-pinned; live salvo write can ride the staging window with the other write tests

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [ ] Integration tested on VM before PR (deferred to the staging write-test window with --allow-clear)

## Approval

@yboujraf — requesting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
