### PR TITLE
feat(cerebrum-nb): category MODIFY_ALL / MODIFY_DESC / DELETE_ITEM + item wiring

### DIFF
--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -250,7 +250,7 @@ VERBS
   set-tags                 ACTION <ROUTING TYPE='RM_*_TAGS'/> --kind RM_SRCE_TAGS|RM_DEST_TAGS [--srce|--dest ID] --tags a,b,c
   salvo                    ACTION <SALVO TYPE='…'/>           --op run|save|rename|description|delete --group G [--instance I] [--new-name N] [--description D] [--check] [--output json]
                            ENSURE (ADR-0007): description/rename/delete read live state first — already-converged = changed:false, nothing sent; run/save are events (always fire, always changed). --check sends nothing.
-  category                 ACTION <CATEGORY TYPE='…'/>        --op create|modify|delete --category C [--index N] [--name N] [--label L] [--description D]
+  category                 ACTION <CATEGORY TYPE='…'/>        --op create|modify|modify-all|modify-desc|delete|delete-item --category C [--index N] [--item-type T] [--value V] [--name N] [--label L] [--inherits P] [--description D]
   set-value                ACTION <DEVICE TYPE='SET_VALUE'/>  --device NAME --sub-device X --object Y --value V
   obtain-datastore         OBTAIN <datastore_change name='…'/>  --name PATH
 
@@ -1861,12 +1861,15 @@ func cerebrumCategory(_ context.Context, args []string) error {
 	args = reorderFlagsFirst(args)
 	fs := flag.NewFlagSet("cerebrum-nb category", flag.ContinueOnError)
 	cf := newCerebrumFlags(fs)
-	op := fs.String("op", "", "operation: create | modify | delete")
+	op := fs.String("op", "", "operation: create | modify | modify-all | modify-desc | delete | delete-item")
 	category := fs.String("category", "", "category name")
-	index := fs.String("index", "", "item index (modify)")
+	index := fs.String("index", "", "item index (modify / delete-item)")
+	itemType := fs.String("item-type", "", "§3.3 ITEM_TYPE (modify / modify-all): BLANK|SRCE|SOURCE|DEST|CATEGORY|SALVO|INHERIT|TEXT|FILE|CUSTOM")
+	value := fs.String("value", "", "item value (modify); comma-separated list (modify-all)")
 	name := fs.String("name", "", "name (create)")
-	label := fs.String("label", "", "label")
-	desc := fs.String("description", "", "description")
+	label := fs.String("label", "", "label (create)")
+	inherits := fs.String("inherits", "", "parent category (create)")
+	desc := fs.String("description", "", "description (create / modify-desc)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -1874,8 +1877,35 @@ func cerebrumCategory(_ context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	it, err := categoryItemType(*itemType)
+	if err != nil {
+		return err
+	}
 	if *category == "" {
 		return fmt.Errorf("cerebrum-nb category: --category is required")
+	}
+	// Required attrs per the §4.2 table.
+	switch catType {
+	case "MODIFY_ITEM":
+		if *index == "" || it == "" || *value == "" {
+			return fmt.Errorf("cerebrum-nb category: --index, --item-type and --value are required for modify (§4.2 MODIFY_ITEM)")
+		}
+	case "MODIFY_ALL":
+		if it == "" || *value == "" {
+			return fmt.Errorf("cerebrum-nb category: --item-type and --value are required for modify-all (§4.2 MODIFY_ALL)")
+		}
+	case "MODIFY_DESC":
+		if *desc == "" {
+			return fmt.Errorf("cerebrum-nb category: --description is required for modify-desc (§4.2 MODIFY_DESC)")
+		}
+	case "DELETE_ITEM":
+		if *index == "" {
+			return fmt.Errorf("cerebrum-nb category: --index is required for delete-item (§4.2 DELETE_ITEM)")
+		}
+	case "CREATE":
+		if *name == "" {
+			return fmt.Errorf("cerebrum-nb category: --name is required for create (§4.2 CREATE)")
+		}
 	}
 	p, sess, _, err := dialCerebrumAuth(cf, fs.Args(), "category")
 	if err != nil {
@@ -1888,8 +1918,11 @@ func cerebrumCategory(_ context.Context, args []string) error {
 		Type:        catType,
 		Category:    *category,
 		Index:       *index,
+		ItemType:    it,
+		Value:       *value,
 		Name:        *name,
 		Label:       *label,
+		Inherits:    *inherits,
 		Description: *desc,
 	}
 	if err := sess.Category(ctx, act); err != nil {
@@ -2219,18 +2252,40 @@ func salvoOpType(op string) (string, error) {
 	}
 }
 
-// categoryOpType maps the --op string to a §4.2 CATEGORY TYPE.
+// categoryOpType maps the --op string to a §4.2 CATEGORY TYPE (all six).
 func categoryOpType(op string) (string, error) {
 	switch strings.ToLower(op) {
 	case "create":
 		return "CREATE", nil
 	case "modify":
 		return "MODIFY_ITEM", nil
+	case "modify-all":
+		return "MODIFY_ALL", nil
+	case "modify-desc":
+		return "MODIFY_DESC", nil
 	case "delete":
 		return "DELETE", nil
+	case "delete-item":
+		return "DELETE_ITEM", nil
 	case "":
-		return "", fmt.Errorf("cerebrum-nb category: --op is required (create|modify|delete)")
+		return "", fmt.Errorf("cerebrum-nb category: --op is required (create|modify|modify-all|modify-desc|delete|delete-item)")
 	default:
-		return "", fmt.Errorf("cerebrum-nb category: unknown --op %q (want create|modify|delete)", op)
+		return "", fmt.Errorf("cerebrum-nb category: unknown --op %q (want create|modify|modify-all|modify-desc|delete|delete-item)", op)
 	}
+}
+
+// categoryItemType validates a --item-type against the §3.3 ITEM_TYPE enum
+// (empty is allowed — the attribute is simply omitted).
+func categoryItemType(s string) (codec.ItemType, error) {
+	if s == "" {
+		return "", nil
+	}
+	it := codec.ItemType(strings.ToUpper(s))
+	switch it {
+	case codec.ItemBlank, codec.ItemSrce, codec.ItemSource, codec.ItemDest,
+		codec.ItemCategory, codec.ItemSalvo, codec.ItemInherit,
+		codec.ItemText, codec.ItemFile, codec.ItemCustom:
+		return it, nil
+	}
+	return "", fmt.Errorf("cerebrum-nb category: unknown --item-type %q (§3.3: BLANK|SRCE|SOURCE|DEST|CATEGORY|SALVO|INHERIT|TEXT|FILE|CUSTOM)", s)
 }

--- a/cmd/dhs/cmd_cerebrum_test.go
+++ b/cmd/dhs/cmd_cerebrum_test.go
@@ -55,10 +55,17 @@ func TestCerebrumWriteVerbsValidateFlags(t *testing.T) {
 		{"salvo-no-group", []string{"salvo", "h", "--op", "run"}, "--group is required"},
 		{"salvo-rename-no-name", []string{"salvo", "h", "--op", "rename", "--group", "G"}, "--new-name is required"},
 		{"salvo-desc-no-text", []string{"salvo", "h", "--op", "description", "--group", "G"}, "--description is required"},
-		// category: missing/unknown op, missing category.
+		// category: missing/unknown op, missing category, per-op required attrs
+		// (§4.2 table), bad §3.3 item-type.
 		{"cat-no-op", []string{"category", "h", "--category", "C"}, "--op is required"},
 		{"cat-bad-op", []string{"category", "h", "--op", "frob", "--category", "C"}, "unknown --op"},
 		{"cat-no-category", []string{"category", "h", "--op", "create"}, "--category is required"},
+		{"cat-create-no-name", []string{"category", "h", "--op", "create", "--category", "C"}, "--name is required"},
+		{"cat-modify-missing", []string{"category", "h", "--op", "modify", "--category", "C", "--index", "1"}, "--index, --item-type and --value are required"},
+		{"cat-modify-all-missing", []string{"category", "h", "--op", "modify-all", "--category", "C"}, "--item-type and --value are required"},
+		{"cat-modify-desc-missing", []string{"category", "h", "--op", "modify-desc", "--category", "C"}, "--description is required"},
+		{"cat-delete-item-missing", []string{"category", "h", "--op", "delete-item", "--category", "C"}, "--index is required"},
+		{"cat-bad-item-type", []string{"category", "h", "--op", "modify-all", "--category", "C", "--item-type", "WAT", "--value", "V"}, "unknown --item-type"},
 		// set-value: missing required addressing.
 		{"setval-missing", []string{"set-value", "h", "--device", "D"}, "are required"},
 		// obtain-datastore: missing --name.
@@ -86,7 +93,7 @@ func TestCerebrumWriteVerbsRequireHost(t *testing.T) {
 		{"set-mnemonic", "--kind", "DEST_MNE", "--dest", "1", "--mnemonic", "X"},
 		{"set-tags", "--kind", "RM_DEST_TAGS", "--dest", "1", "--tags", "a"},
 		{"salvo", "--op", "run", "--group", "G"},
-		{"category", "--op", "create", "--category", "C"},
+		{"category", "--op", "create", "--category", "C", "--name", "N"},
 		{"set-value", "--device", "D", "--sub-device", "S", "--object", "O", "--value", "V"},
 		{"obtain-datastore", "--name", "p"},
 	}
@@ -135,7 +142,10 @@ func TestSalvoOpType(t *testing.T) {
 }
 
 func TestCategoryOpType(t *testing.T) {
-	cases := map[string]string{"create": "CREATE", "modify": "MODIFY_ITEM", "delete": "DELETE"}
+	cases := map[string]string{
+		"create": "CREATE", "modify": "MODIFY_ITEM", "modify-all": "MODIFY_ALL",
+		"modify-desc": "MODIFY_DESC", "delete": "DELETE", "delete-item": "DELETE_ITEM",
+	}
 	for in, want := range cases {
 		got, err := categoryOpType(in)
 		if err != nil || got != want {

--- a/internal/cerebrum-nb/docs/README.md
+++ b/internal/cerebrum-nb/docs/README.md
@@ -36,7 +36,7 @@ EVS **Cerebrum Northbound API 0v16** (authoritative) — also branded
 | | `list-salvo-groups` / `list-salvo-instances` / `salvo-instance-details` | salvo domain |
 | | `tree` | NB catalogue as the canonical ASCII / PlantUML tree — Categories (§5.2: categories → SOURCE/DEST/nested-CATEGORY items) + Salvos (§5.3: groups → instances → metadata; salvo item rows are not exposed over NB) — `--domain salvos\|categories\|all` |
 | | `obtain-datastore` | data store fetch |
-| Writes | `salvo` (run/save/rename/description/delete) · `category` (create/modify/delete) · `set-value` · `device-config` | §4 actions |
+| Writes | `salvo` (run/save/rename/description/delete) · `category` (create/modify/modify-all/modify-desc/delete/delete-item) · `set-value` · `device-config` | §4 actions |
 
 Common flags: `--port` (default 40007) · `--user/--pass` (or `$DHS_CEREBRUM_USER/_PASS`)
 · `--tls` · `--timeout` · `--debug` (RX/TX XML to stderr) · **`--log FILE`**

--- a/internal/cerebrum-nb/docs/consumer.md
+++ b/internal/cerebrum-nb/docs/consumer.md
@@ -37,7 +37,7 @@ user-facing CLI reference.
 | `set-mnemonic` | `<action><routing TYPE='*_MNE'/></action>` — set a level / source / dest mnemonic |
 | `set-tags` | `<action><routing TYPE='RM_*_TAGS'/></action>` — Routemaster source / dest tags |
 | `salvo` | `<action><salvo TYPE='…'/></action>` — `--op run\|save\|rename\|description\|delete` |
-| `category` | `<action><category TYPE='…'/></action>` — `--op create\|modify\|delete` |
+| `category` | `<action><category TYPE='…'/></action>` — `--op create\|modify\|modify-all\|modify-desc\|delete\|delete-item` |
 | `set-value` | `<action><device TYPE='SET_VALUE'/></action>` — write a device object value |
 
 See [verbs.md](verbs.md) for per-verb flags and codec-generated wire

--- a/internal/cerebrum-nb/docs/runbook.md
+++ b/internal/cerebrum-nb/docs/runbook.md
@@ -72,7 +72,7 @@ device we serve (see [provider.md](provider.md)).
 | `set-mnemonic` | Set a level / source / dest mnemonic | `--kind LEVEL_MNE\|SRCE_MNE\|DEST_MNE --mnemonic TXT --level [--alt SLOT]` |
 | `set-tags` | Set Routemaster source / dest tags | `--kind RM_SRCE_TAGS\|RM_DEST_TAGS --tags a,b,c` |
 | `salvo` | Run / save / rename / set description / delete a salvo — ENSURE (ADR-0007): description/rename/delete read live state first (already converged = `changed:false`, nothing sent); run/save are events (always fire) | `--op run\|save\|rename\|description\|delete --group [--instance --new-name --description] [--check] [--output json]` |
-| `category` | Create / modify / delete a category | `--op create\|modify\|delete --category` |
+| `category` | Create / modify item(s) / set description / delete a category or item | `--op create\|modify\|modify-all\|modify-desc\|delete\|delete-item --category [--index --item-type --value --name --label --inherits --description]` |
 | `set-value` | Write a device object value | `--device --sub-device --object --value` |
 
 ## Logging


### PR DESCRIPTION
## What

Completes the §4.2 category catalogue: `category` gains `modify-all`, `modify-desc`, `delete-item` (6/6 spec TYPEs) and wires the codec's `ITEM_TYPE`/`VALUE`/`INHERITS` fields the CLI never exposed.

## Why

Spec-literal NB command inventory follow-up (owner split: category separate from salvo). `MODIFY_ITEM` was half-wired — a modify could not actually set an item's type or value; three TYPEs had no mapping at all.

Closes #680

## Scope

- [ ] acp1
- [ ] acp2
- [ ] emberplus
- [ ] probel-sw08p / probel-sw02p
- [x] osc / tsl / cerebrum-nb / amwa
- [x] cli
- [ ] transport / export / api / core / ci

**Cross-protocol changes**: none — cerebrum verb surface + docs only.

## Wire evidence (protocol changes only)

No new wire forms: all six `<CATEGORY TYPE='…'/>` shapes are the §4.2 catalogue the codec already encodes (CREATE pinned against the §4.2.1 worked example). Category READ side (grids, sub-categories, BLANK gaps) was live-proven on the NOC in #679; write apply is deliberately untested on production (mutates operator navigation) — staged for 10.100.0.105 / scratch categories.

## Reference controller

- [x] N/A (no protocol behaviour change — existing pinned wire forms, new CLI mappings only)

## Type

- [x] feat — new feature

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `cmd/dhs/cmd_cerebrum.go` | modified | op map 6/6 TYPEs, `--item-type` (§3.3-validated) / `--value` / `--inherits` flags, per-op required-attr validation (§4.2 table) |
| `cmd/dhs/cmd_cerebrum_test.go` | modified | full op map + per-op validation + bad item-type cases |
| `internal/cerebrum-nb/docs/README.md` | modified | verb catalogue op list |
| `internal/cerebrum-nb/docs/consumer.md` | modified | op list |
| `internal/cerebrum-nb/docs/runbook.md` | modified | category row |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test -count=1 ./cmd/dhs/...` | ok | 0 |
| `go vet ./...` | clean | — |
| `golangci-lint run` | clean (pre-commit hook) | — |

## Device tested

- [x] No device needed (pinned wire forms; write apply staged for 10.100.0.105)

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [ ] Integration tested on VM before PR (write apply deliberately staged — production categories are operator navigation)

## Approval

@yboujraf — merge delegated by owner for this task (S0 sequence); squash-merge per ADR-0013. Note: the category verb's ensure treatment (read-first converge) lands uniformly with the other five write verbs in #681, not piecemeal here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
