### PR TITLE
feat(cerebrum-nb): evidence-grade wireshark dissector (#687)

### DIFF
--- a/internal/cerebrum-nb/wireshark/dhs_cerebrum_nb.lua
+++ b/internal/cerebrum-nb/wireshark/dhs_cerebrum_nb.lua
@@ -360,27 +360,31 @@ local function dissect_ws_frame(buffer, pinfo, tree, offset)
     subtree:add(f.ws_mask_key, buffer(mask_offset, 4))
   end
 
-  -- Unmask payload into a Lua string for display + parsing.
-  local payload_chars = {}
+  -- Payload into a Lua string for display + parsing. Server frames are
+  -- UNMASKED (RFC 6455 §5.1) and carry the big snapshot documents — take
+  -- them in ONE TvbRange:raw() call; a per-byte Lua loop here made live
+  -- decoding of production event streams visibly lag. Only client frames
+  -- are masked, and those are small (commands), so the per-byte unmask
+  -- loop stays for them alone.
+  local payload_str = ""
   if plen > 0 then
-    local raw = buffer(pos, plen):bytes()
     if masked then
+      local raw = buffer(pos, plen):bytes()
       local mk = {
         buffer(mask_offset,     1):uint(),
         buffer(mask_offset + 1, 1):uint(),
         buffer(mask_offset + 2, 1):uint(),
         buffer(mask_offset + 3, 1):uint(),
       }
+      local payload_chars = {}
       for i = 0, plen - 1 do
         payload_chars[i + 1] = string.char(bit_xor(raw:get_index(i), mk[(i % 4) + 1]))
       end
+      payload_str = table.concat(payload_chars)
     else
-      for i = 0, plen - 1 do
-        payload_chars[i + 1] = string.char(raw:get_index(i))
-      end
+      payload_str = buffer(pos, plen):raw()
     end
   end
-  local payload_str = table.concat(payload_chars)
 
   local arrow = direction_arrow(pinfo)
   local op_name = opcode_names[opcode] or string.format("op=0x%x", opcode)

--- a/internal/cerebrum-nb/wireshark/dhs_cerebrum_nb.lua
+++ b/internal/cerebrum-nb/wireshark/dhs_cerebrum_nb.lua
@@ -26,8 +26,23 @@
 --     The RESULT VALUE (ACCEPTED/FAILED) and DEVICE_TYPE attrs are pulled
 --     into the Info column so a device-config round-trip is readable at a
 --     glance.
+--   * Live-wire facts (2026-08 production captures — docs/keys.md
+--     "wire-actual" notes):
+--       LOCK / LOCK_STATE / LOCKED_BY on routing actions + events —
+--         incl. LOCK_STATE="RELEASED", the undocumented sixth value that
+--         is the wire-actual clearing state;
+--       top-level VALUE attr on DEVICE_CHANGE value events (change
+--         events carry VALUE on the root, NOT an OBJECT_VALUE child);
+--       MIN/MAX/STEP descriptor attrs on VALUE rows;
+--       positional <DEVICE_N …> sub-device children in DETAILS replies
+--         (surfaced as a sub-device count);
+--       MTID-less WILDCARD_COMPLETE — the live NOC emits a spurious one
+--         after every event (only MTID-carrying ones end a wildcard
+--         request) — flagged with an expert NOTE, not an error.
 --   * Per-message Info column with direction arrow + verb + key attrs
---     so each frame is uniquely identifiable at a glance
+--     (DEST_ID/SRCE_ID/LEVEL_ID, DEVICE_NAME/SUB_DEVICE/OBJECT,
+--     CATEGORY/GROUP/INSTANCE, MNEMONIC) so each frame is uniquely
+--     identifiable at a glance
 --   * Any XML root NOT in the known-root catalogue fires a Wireshark
 --     expert WARNING (never a silent fallthrough), per the root CLAUDE.md
 --     dissector rule.
@@ -79,6 +94,31 @@ f.xml_error_code  = ProtoField.string("dhs_cerebrum_nb.xml.error_code",   "ERROR
 -- 0v16 additions
 f.xml_device_type = ProtoField.string("dhs_cerebrum_nb.xml.device_type",  "DEVICE_TYPE")
 f.xml_result      = ProtoField.string("dhs_cerebrum_nb.xml.result",       "RESULT VALUE")
+-- Routing identity attrs (per-command Info detail)
+f.xml_dest_id     = ProtoField.string("dhs_cerebrum_nb.xml.dest_id",      "DEST_ID")
+f.xml_srce_id     = ProtoField.string("dhs_cerebrum_nb.xml.srce_id",      "SRCE_ID")
+f.xml_level_id    = ProtoField.string("dhs_cerebrum_nb.xml.level_id",     "LEVEL_ID")
+f.xml_mnemonic    = ProtoField.string("dhs_cerebrum_nb.xml.mnemonic",     "MNEMONIC")
+-- Lock attrs (wire-actual: LOCK on actions, LOCK_STATE + LOCKED_BY on
+-- events; RELEASED is the undocumented clearing value — live 2026-08-16)
+f.xml_lock        = ProtoField.string("dhs_cerebrum_nb.xml.lock",         "LOCK")
+f.xml_lock_state  = ProtoField.string("dhs_cerebrum_nb.xml.lock_state",   "LOCK_STATE")
+f.xml_locked_by   = ProtoField.string("dhs_cerebrum_nb.xml.locked_by",    "LOCKED_BY")
+-- Device-object attrs (§5.4 VALUE rows; top-level VALUE is wire-actual on
+-- change events — no OBJECT_VALUE child)
+f.xml_device_name = ProtoField.string("dhs_cerebrum_nb.xml.device_name",  "DEVICE_NAME")
+f.xml_sub_device  = ProtoField.string("dhs_cerebrum_nb.xml.sub_device",   "SUB_DEVICE")
+f.xml_object      = ProtoField.string("dhs_cerebrum_nb.xml.object",       "OBJECT")
+f.xml_value       = ProtoField.string("dhs_cerebrum_nb.xml.value",        "VALUE (top-level)")
+f.xml_min         = ProtoField.string("dhs_cerebrum_nb.xml.min",          "MIN")
+f.xml_max         = ProtoField.string("dhs_cerebrum_nb.xml.max",          "MAX")
+f.xml_step        = ProtoField.string("dhs_cerebrum_nb.xml.step",         "STEP")
+-- Category / salvo identity attrs
+f.xml_category    = ProtoField.string("dhs_cerebrum_nb.xml.category",     "CATEGORY")
+f.xml_group       = ProtoField.string("dhs_cerebrum_nb.xml.group",        "GROUP")
+f.xml_instance    = ProtoField.string("dhs_cerebrum_nb.xml.instance",     "INSTANCE")
+-- §5.4.2 DETAILS: positional <DEVICE_N …> sub-device children (wire-actual)
+f.xml_sub_count   = ProtoField.uint32("dhs_cerebrum_nb.xml.sub_devices",  "Sub-device children (DEVICE_N)", base.DEC)
 f.xml_text        = ProtoField.string("dhs_cerebrum_nb.xml.text",         "XML payload")
 
 -- Close
@@ -91,6 +131,7 @@ local ef = {
   rsv_set      = ProtoExpert.new("dhs_cerebrum_nb.rsv_set",      "Reserved bits set",         expert.group.MALFORMED,  expert.severity.WARN),
   big_control  = ProtoExpert.new("dhs_cerebrum_nb.big_control",  "Control frame >125 bytes",  expert.group.MALFORMED,  expert.severity.ERROR),
   unknown_root = ProtoExpert.new("dhs_cerebrum_nb.unknown_root", "Unknown Cerebrum NB XML root (not in 0v16 catalogue)", expert.group.UNDECODED, expert.severity.WARN),
+  spurious_wc  = ProtoExpert.new("dhs_cerebrum_nb.spurious_wc",  "MTID-less WILDCARD_COMPLETE (live NOC deviation — only MTID-carrying ones end a wildcard request)", expert.group.PROTOCOL, expert.severity.NOTE),
 }
 p_cnb.experts = ef
 
@@ -191,7 +232,54 @@ local function extract_xml_attrs(s)
     err         = xml_attr(s, "ERROR"),
     err_code    = xml_attr(s, "ERROR_CODE"),
     device_type = xml_attr(s, "DEVICE_TYPE"), -- 0v16 §4.5 DEVICE_CONFIGURATION
+    -- Routing identity (first occurrence = root/first row attrs; ROUTE
+    -- children's SOURCE_ID is a different attribute name, so no clash)
+    dest_id     = xml_attr(s, "DEST_ID"),
+    srce_id     = xml_attr(s, "SRCE_ID"),
+    level_id    = xml_attr(s, "LEVEL_ID"),
+    mnemonic    = xml_attr(s, "MNEMONIC"),
+    -- Lock (wire-actual): LOCK on actions; LOCK_STATE + LOCKED_BY on
+    -- events. LOCK_STATE must be read before LOCK — xml_attr matches the
+    -- substring "LOCK" inside "LOCK_STATE" otherwise.
+    lock_state  = xml_attr(s, "LOCK_STATE"),
+    locked_by   = xml_attr(s, "LOCKED_BY"),
+    -- Device-object rows (§5.4)
+    device_name = xml_attr(s, "DEVICE_NAME"),
+    sub_device  = xml_attr(s, "SUB_DEVICE"),
+    object      = xml_attr(s, "OBJECT"),
+    min         = xml_attr(s, "MIN"),
+    max         = xml_attr(s, "MAX"),
+    step        = xml_attr(s, "STEP"),
+    -- Category / salvo identity
+    category    = xml_attr(s, "CATEGORY"),
+    group       = xml_attr(s, "GROUP"),
+    instance    = xml_attr(s, "INSTANCE"),
   }
+
+  -- LOCK: whitespace-anchored so only the attribute NAME "LOCK" matches —
+  -- LOCK_STATE= / LOCKED_BY= continue with '_' (not '='), and enum text
+  -- like TYPE="DEST_LOCK" continues with '"'. TX actions nest the row
+  -- under <ACTION>, so the match runs over the whole document.
+  r.lock = s:match("[%s][Ll][Oo][Cc][Kk]%s*=%s*\"([^\"]*)\"")
+      or s:match("[%s][Ll][Oo][Cc][Kk]%s*=%s*'([^']*)'")
+
+  -- VALUE: whitespace-anchored, document-wide — covers the wire-actual
+  -- top-level VALUE on DEVICE_CHANGE value events (no OBJECT_VALUE child
+  -- there), the OBJECT_VALUE child's VALUE in obtain replies, and the
+  -- SET_VALUE action's VALUE under <ACTION>. DEVICE_CONFIGURATION is
+  -- excluded — its <RESULT VALUE=…> verdict is surfaced as RESULT instead.
+  if root ~= "DEVICE_CONFIGURATION" then
+    r.value = s:match("[%s][Vv][Aa][Ll][Uu][Ee]%s*=%s*\"([^\"]*)\"")
+        or s:match("[%s][Vv][Aa][Ll][Uu][Ee]%s*=%s*'([^']*)'")
+  end
+
+  -- §5.4.2 DETAILS wire-actual: positional <DEVICE_1 …> <DEVICE_2 …>
+  -- sub-device children. Count them for the Info column.
+  local n = 0
+  for _ in s:gmatch("<%s*[Dd][Ee][Vv][Ii][Cc][Ee]_%d+[%s/>]") do
+    n = n + 1
+  end
+  if n > 0 then r.sub_count = n end
 
   -- 0v16 §4.5 RX: <DEVICE_CONFIGURATION …><RESULT VALUE="ACCEPTED|FAILED"/>.
   -- Pull the RESULT child's VALUE so the verdict shows in Info. Scope the
@@ -307,9 +395,39 @@ local function dissect_ws_frame(buffer, pinfo, tree, offset)
       if x.mtid        then subtree:add(f.xml_mtid,        x.mtid);        info = info .. " mtid=" .. x.mtid end
       if x.typ         then subtree:add(f.xml_type,        x.typ);         info = info .. " TYPE=" .. x.typ end
       if x.device_type then subtree:add(f.xml_device_type, x.device_type); info = info .. " DEVICE_TYPE=" .. x.device_type end
+      -- Routing identity (the "which cell" half of every routing frame)
+      if x.dest_id     then subtree:add(f.xml_dest_id,     x.dest_id);     info = info .. " DEST=" .. x.dest_id end
+      if x.srce_id     then subtree:add(f.xml_srce_id,     x.srce_id);     info = info .. " SRCE=" .. x.srce_id end
+      if x.level_id    then subtree:add(f.xml_level_id,    x.level_id);    info = info .. " LVL=" .. x.level_id end
+      if x.mnemonic    then subtree:add(f.xml_mnemonic,    x.mnemonic);    info = info .. " MNE=" .. string.format("%q", x.mnemonic) end
+      -- Lock lifecycle (LOCK on actions; LOCK_STATE/LOCKED_BY on events —
+      -- RELEASED is the wire-actual clearing value, keys.md wire-actual)
+      if x.lock        then subtree:add(f.xml_lock,        x.lock);        info = info .. " LOCK=" .. x.lock end
+      if x.lock_state  then subtree:add(f.xml_lock_state,  x.lock_state);  info = info .. " LOCK_STATE=" .. x.lock_state end
+      if x.locked_by   then subtree:add(f.xml_locked_by,   x.locked_by);   info = info .. " BY=" .. string.format("%q", x.locked_by) end
+      -- Device-object rows (§5.4): identity + top-level VALUE + descriptor
+      if x.device_name then subtree:add(f.xml_device_name, x.device_name); info = info .. " DEV=" .. string.format("%q", x.device_name) end
+      if x.sub_device  then subtree:add(f.xml_sub_device,  x.sub_device);  info = info .. " SUB=" .. x.sub_device end
+      if x.object      then subtree:add(f.xml_object,      x.object);      info = info .. " OBJ=" .. string.format("%q", x.object) end
+      if x.value       then subtree:add(f.xml_value,       x.value);       info = info .. " VALUE=" .. string.format("%q", x.value) end
+      if x.min         then subtree:add(f.xml_min,  x.min)  end
+      if x.max         then subtree:add(f.xml_max,  x.max)  end
+      if x.step        then subtree:add(f.xml_step, x.step) end
+      if x.min and x.max then info = info .. string.format(" range=%s..%s", x.min, x.max) end
+      if x.sub_count   then subtree:add(f.xml_sub_count,   x.sub_count);   info = info .. " sub_devices=" .. x.sub_count end
+      -- Category / salvo identity
+      if x.category    then subtree:add(f.xml_category,    x.category);    info = info .. " CAT=" .. string.format("%q", x.category) end
+      if x.group       then subtree:add(f.xml_group,       x.group);       info = info .. " GRP=" .. string.format("%q", x.group) end
+      if x.instance    then subtree:add(f.xml_instance,    x.instance);    info = info .. " INST=" .. string.format("%q", x.instance) end
       if x.result      then subtree:add(f.xml_result,      x.result);      info = info .. " RESULT=" .. x.result end
       if x.err         then subtree:add(f.xml_error,       x.err);         info = info .. " ERROR=" .. x.err end
       if x.err_code    then subtree:add(f.xml_error_code,  x.err_code);    info = info .. " CODE=" .. x.err_code end
+      -- Live NOC deviation: a spurious MTID-less WILDCARD_COMPLETE follows
+      -- every event; only MTID-carrying ones end a wildcard request.
+      if x.root == "WILDCARD_COMPLETE" and not x.mtid then
+        root_item:add_proto_expert_info(ef.spurious_wc)
+        info = info .. " [spurious — no mtid]"
+      end
       -- Unknown root → expert WARNING (never a silent fallthrough).
       if not known_roots[x.root] then
         root_item:add_proto_expert_info(ef.unknown_root)

--- a/internal/cerebrum-nb/wireshark/dhs_cerebrum_nb.lua
+++ b/internal/cerebrum-nb/wireshark/dhs_cerebrum_nb.lua
@@ -297,15 +297,29 @@ end
 -- WebSocket frame dissector
 -------------------------------------------------------------------------------
 
--- Returns (consumed_bytes) on success, (0, true) when needs more bytes.
--- We do not call desegment APIs — relying on Wireshark's default TCP
--- reassembly preference (Edit → Preferences → Protocols → TCP → "Allow
--- subdissector to reassemble TCP streams"). When that's on, Wireshark
--- delivers the reassembled buffer to us; when off, we just decode
--- whatever fits in one segment and label partial frames.
+-- One TCP segment routinely carries SEVERAL complete WebSocket messages
+-- (the server coalesces small events — e.g. a ROUTING_CHANGE plus its
+-- WILDCARD_COMPLETE). Every document must appear in the Info column,
+-- separated — a packet-list row that shows only one of its documents
+-- (or mashes them together) is not usable as evidence.
+local function set_info(pinfo, first, s)
+  if first then
+    pinfo.cols.info:set(s)
+  else
+    pinfo.cols.info:append(" | " .. s)
+  end
+end
+
+-- Returns (consumed_bytes, needed_bytes). consumed > 0 = one full frame
+-- decoded. needed > 0 = the frame does not fit this buffer and EXACTLY
+-- that many more bytes are required — the caller passes it to
+-- pinfo.desegment_len so Wireshark reassembles the precise PDU (the
+-- contract built-in dissectors use; an approximate "one more byte" loop
+-- fractures giant snapshot messages and is not evidence-grade).
 local function dissect_ws_frame(buffer, pinfo, tree, offset)
   local available = buffer:len() - offset
-  if available < 2 then return 0, true end
+  if available < 2 then return 0, 2 - available end
+  local first = (offset == 0)
 
   local b0 = buffer(offset, 1):uint()
   local b1 = buffer(offset + 1, 1):uint()
@@ -316,14 +330,33 @@ local function dissect_ws_frame(buffer, pinfo, tree, offset)
   local masked = bit_and(b1, 0x80) ~= 0
   local len7   = bit_and(b1, 0x7f)
 
+  -- Header sanity (evidence-grade): a TCP out-of-order / lost-segment
+  -- region hands us bytes that start MID-PAYLOAD, and XML text misread
+  -- as a header would fabricate a frame ("op=0x5 len=84") or worse, a
+  -- fake TEXT frame whose "payload" starts mid-document (the truncated
+  -- ROUTE/ROU/VALUE roots seen on the 48MB production capture). RFC 6455
+  -- gives three hard invariants to reject those: the opcode set, RSV=0
+  -- (no extensions are negotiated on NB sessions), and the mask rule —
+  -- client frames are ALWAYS masked, server frames NEVER (§5.1). A
+  -- random byte pair passes all three ~2% of the time vs ~40% on the
+  -- opcode check alone.
+  local from_client = pinfo.src_port > pinfo.dst_port
+  local sane = opcode_names[opcode] ~= nil and rsv == 0 and masked == from_client
+  if not sane then
+    local subtree = tree:add(p_cnb, buffer(offset, available), "Mid-frame data (unaligned segment)")
+    subtree:add(f.phase, "unaligned")
+    set_info(pinfo, first, string.format("%s mid-frame data — unaligned segment (%d bytes; reassembly places the real frame)", direction_arrow(pinfo), available))
+    return available, 0
+  end
+
   local hdr_len = 2
   local plen = len7
   if len7 == 126 then
-    if available < hdr_len + 2 then return 0, true end
+    if available < hdr_len + 2 then return 0, (hdr_len + 2) - available end
     plen = buffer(offset + hdr_len, 2):uint()
     hdr_len = hdr_len + 2
   elseif len7 == 127 then
-    if available < hdr_len + 8 then return 0, true end
+    if available < hdr_len + 8 then return 0, (hdr_len + 8) - available end
     plen = buffer(offset + hdr_len, 8):uint64():tonumber()
     hdr_len = hdr_len + 8
   end
@@ -332,7 +365,7 @@ local function dissect_ws_frame(buffer, pinfo, tree, offset)
   if masked then hdr_len = hdr_len + 4 end
 
   local total_needed = hdr_len + plen
-  if available < total_needed then return 0, true end
+  if available < total_needed then return 0, total_needed - available end
 
   local pos = offset + hdr_len
   local subtree = tree:add(p_cnb, buffer(offset, total_needed), "WebSocket Frame")
@@ -437,9 +470,9 @@ local function dissect_ws_frame(buffer, pinfo, tree, offset)
         root_item:add_proto_expert_info(ef.unknown_root)
         info = info .. " [unknown root]"
       end
-      pinfo.cols.info:set(info)
+      set_info(pinfo, first, info)
     else
-      pinfo.cols.info:set(string.format("%s TEXT (no XML root) %d bytes", arrow, plen))
+      set_info(pinfo, first, string.format("%s TEXT (no XML root) %d bytes", arrow, plen))
     end
   elseif opcode == 0x8 then
 if plen >= 2 then
@@ -449,19 +482,19 @@ if plen >= 2 then
       if plen > 2 then
         reason = payload_str:sub(3)
         subtree:add(f.close_reason, buffer(pos + 2, plen - 2), reason)
-        pinfo.cols.info:set(string.format("%s CLOSE code=%d reason=%q", arrow, code, reason))
+        set_info(pinfo, first, string.format("%s CLOSE code=%d reason=%q", arrow, code, reason))
       else
-        pinfo.cols.info:set(string.format("%s CLOSE code=%d", arrow, code))
+        set_info(pinfo, first, string.format("%s CLOSE code=%d", arrow, code))
       end
     else
-      pinfo.cols.info:set(string.format("%s CLOSE", arrow))
+      set_info(pinfo, first, string.format("%s CLOSE", arrow))
     end
   elseif opcode == 0x9 then
-pinfo.cols.info:set(arrow .. " PING")
+set_info(pinfo, first, arrow .. " PING")
   elseif opcode == 0xA then
-pinfo.cols.info:set(arrow .. " PONG")
+set_info(pinfo, first, arrow .. " PONG")
   else
-pinfo.cols.info:set(string.format("%s %s len=%d", arrow, op_name, plen))
+set_info(pinfo, first, string.format("%s %s len=%d", arrow, op_name, plen))
   end
 
   return total_needed, false
@@ -517,13 +550,16 @@ function p_cnb.dissector(buffer, pinfo, tree)
   end
 
   -- WS frame mode. Decode as many full frames as fit in this buffer.
-  -- If the last one is partial, request reassembly via desegment_*.
+  -- If the last one is partial, request reassembly with the EXACT byte
+  -- count still missing — Wireshark then rebuilds the full PDU (multi-MB
+  -- snapshot documents included) and re-calls us once, so no frame is
+  -- ever decoded fractured.
   local offset = 0
   while offset < len do
-    local consumed, need_more = dissect_ws_frame(buffer, pinfo, tree, offset)
-    if need_more then
+    local consumed, needed = dissect_ws_frame(buffer, pinfo, tree, offset)
+    if needed and needed > 0 then
       pinfo.desegment_offset = offset
-      pinfo.desegment_len = 1 -- "give me more bytes; I'll figure out exact need next call"
+      pinfo.desegment_len = needed
       return offset > 0 and offset or nil
     end
     if consumed == 0 then break end


### PR DESCRIPTION
## What

Evidence-grade Wireshark dissector for cerebrum-nb: live-wire attribute coverage (locks/RELEASED, top-level VALUE, DEVICE_N, MIN/MAX/STEP, identity attrs), exact TCP reassembly, RFC-strict header sanity, and separated multi-document Info — validated against three production captures.

## Why

#687 (S6). The dissector is the byte-exact reference (root CLAUDE.md rule) and the owner's requirement is dispute-grade captures between the NB API and any controller: every command visible, nothing fractured, nothing fabricated. The pre-existing dissector lagged behind the 2026-08 live-wire discoveries and fractured giant snapshot documents.

Closes #687

## Scope

- [ ] acp1
- [ ] acp2
- [ ] emberplus
- [ ] probel-sw08p / probel-sw02p
- [x] osc / tsl / cerebrum-nb / amwa
- [ ] transport
- [ ] export
- [ ] cli
- [ ] api
- [ ] core
- [ ] ci / chore

**Cross-protocol changes**: none — one Lua file under `internal/cerebrum-nb/wireshark/`.

## Wire evidence (protocol changes only)

Three production captures (NOC 10.44.55.39:40009):

- 48MB mixed session: before the fix ~150 documents decoded with truncated roots (ROUTING_CH/ROU/R) and out-of-order segments fabricated fake frames ("op=0x5 len=84"); after: catalogue roots only, 1 honestly-labeled unaligned segment.
- 26MB export session: 47,619/47,619 documents reconcile 1:1 with the CLI's CSV files (5,952 SRCE_MNE + 5,952 DEST_MNE + 3 LEVEL_MNE + 17,856 ROUTE + 17,856 DEST_LOCK), zero partials.
- 20.7MB lossless import --check session (dumpcap -B 256): 29,763 events, OBTAIN/ACK/WILDCARD_COMPLETE 4/4/4, zero ACTION documents, zero NACK, zero lost segments — the pcap-level proof of the ADR-0007 ensure contract.

## Reference controller

- [x] Cerebrum still happy after this change
- [ ] VSM Studio still happy after this change
- [ ] N/A (no protocol behaviour change)

## Type

- [x] feat — new feature
- [x] fix — bug fix
- [ ] docs — documentation only
- [ ] chore — maintenance, refactor, CI
- [ ] security — security fix or hardening

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `internal/cerebrum-nb/wireshark/dhs_cerebrum_nb.lua` | modified | live-wire attrs as fields + Info (LOCK/LOCK_STATE incl. RELEASED/LOCKED_BY, top-level VALUE, MIN/MAX/STEP, DEVICE_N sub-device count, DEST/SRCE/LEVEL_ID, DEVICE_NAME/SUB_DEVICE/OBJECT, CATEGORY/GROUP/INSTANCE, MNEMONIC); expert NOTE on MTID-less WILDCARD_COMPLETE; exact desegment_len (frames spanning segments reassemble whole); RFC 6455 header sanity (opcode + RSV=0 + mask-matches-direction) so unaligned segments are labeled, never fabricated; multi-document Info separated with " \| "; unmasked payloads taken in one raw() call (live decode keeps pace with event streams) |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test ./...` | all (no Go change) | 0 |
| `go vet ./...` | clean | — |
| tshark 4.x load (`-X lua_script`, clean config, `-G protocols`) | proto + all fields register | — |

## Device tested

- [ ] ACP1 producer 10.100.0.102
- [ ] ACP2 producer 10.100.0.103
- [ ] ACP1 emulator 10.6.239.113
- [ ] ACP2 real device 10.41.40.195
- [x] Other (specify)
- [ ] No device needed (pure codec / doc change)

Three production NOC captures decoded end-to-end (see Wire evidence). Deployed to the operator VM alongside the test binary.

**Live-LXC command + observed output** (paste verbatim):

```text
tshark -r nb-api-import.pcapng -X lua_script:dhs_cerebrum_nb.lua -o dhs_cerebrum_nb.tcp_port:40009 -2 -T fields -e dhs_cerebrum_nb.xml.root
# observed histogram: ROUTING_CHANGE 29763, WILDCARD_COMPLETE 4, ACK 4, OBTAIN 4, LOGIN 1, LOGIN_REPLY 1
# zero ACTION / NACK / truncated roots / unaligned segments
```

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [x] Integration tested on VM before PR

## Approval

@yboujraf — requesting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
