### PR TITLE
fix(cli): verb --help prints the verb's usage, not the catalogue (#462)

### DIFF
--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -180,7 +180,9 @@ func isKnownBoolFlag(a string) bool {
 
 // runCerebrum is the dispatcher for `dhs consumer cerebrum-nb <verb>`.
 func runCerebrum(ctx context.Context, args []string) error {
-	if len(args) == 0 || hasHelpFlag(args) {
+	// Help IN PLACE of a verb = catalogue; a help flag AFTER the verb
+	// belongs to the verb's own FlagSet (#462).
+	if len(args) == 0 || isHelpToken(args[0]) {
 		printCerebrumHelp()
 		return nil
 	}

--- a/cmd/dhs/cmd_nmos.go
+++ b/cmd/dhs/cmd_nmos.go
@@ -33,7 +33,9 @@ import (
 
 // runNMOSConsumer dispatches `dhs consumer nmos <verb> [args]`.
 func runNMOSConsumer(ctx context.Context, args []string) error {
-	if len(args) == 0 || hasHelpFlag(args) {
+	// Help IN PLACE of a verb = catalogue; after the verb it belongs to
+	// the verb's own FlagSet (#462).
+	if len(args) == 0 || isHelpToken(args[0]) {
 		printNMOSConsumerHelp()
 		return nil
 	}
@@ -54,7 +56,7 @@ func runNMOSConsumer(ctx context.Context, args []string) error {
 
 // runNMOSProducer dispatches `dhs producer nmos <verb> [args]`.
 func runNMOSProducer(ctx context.Context, args []string) error {
-	if len(args) == 0 || hasHelpFlag(args) {
+	if len(args) == 0 || isHelpToken(args[0]) {
 		printNMOSProducerHelp()
 		return nil
 	}
@@ -71,7 +73,7 @@ func runNMOSProducer(ctx context.Context, args []string) error {
 
 // runNMOSRegistry dispatches `dhs registry nmos <verb> [args]`.
 func runNMOSRegistry(ctx context.Context, args []string) error {
-	if len(args) == 0 || hasHelpFlag(args) {
+	if len(args) == 0 || isHelpToken(args[0]) {
 		printNMOSRegistryHelp()
 		return nil
 	}

--- a/cmd/dhs/cmd_nmos_events.go
+++ b/cmd/dhs/cmd_nmos_events.go
@@ -22,7 +22,9 @@ import (
 
 // runNMOSEventsConsumer dispatches `dhs consumer nmos events <verb>`.
 func runNMOSEventsConsumer(ctx context.Context, args []string) error {
-	if len(args) == 0 || hasHelpFlag(args) {
+	// Help IN PLACE of a verb = catalogue; after the verb it belongs to
+	// the verb's own FlagSet (#462).
+	if len(args) == 0 || isHelpToken(args[0]) {
 		printNMOSEventsConsumerHelp()
 		return nil
 	}
@@ -37,7 +39,7 @@ func runNMOSEventsConsumer(ctx context.Context, args []string) error {
 
 // runNMOSEventsProducer dispatches `dhs producer nmos events <verb>`.
 func runNMOSEventsProducer(ctx context.Context, args []string) error {
-	if len(args) == 0 || hasHelpFlag(args) {
+	if len(args) == 0 || isHelpToken(args[0]) {
 		printNMOSEventsProducerHelp()
 		return nil
 	}

--- a/cmd/dhs/cmd_osc.go
+++ b/cmd/dhs/cmd_osc.go
@@ -37,7 +37,9 @@ import (
 
 // runOSCConsumer dispatches `dhs consumer osc-vXX <verb> [args]`.
 func runOSCConsumer(ctx context.Context, proto string, args []string) error {
-	if len(args) == 0 || hasHelpFlag(args) {
+	// Help IN PLACE of a verb = catalogue; after the verb it belongs to
+	// the verb's own FlagSet (#462).
+	if len(args) == 0 || isHelpToken(args[0]) {
 		printOSCConsumerHelp(proto)
 		return nil
 	}
@@ -52,7 +54,7 @@ func runOSCConsumer(ctx context.Context, proto string, args []string) error {
 
 // runOSCProducer dispatches `dhs producer osc-vXX <verb> [args]`.
 func runOSCProducer(ctx context.Context, proto string, args []string) error {
-	if len(args) == 0 || hasHelpFlag(args) {
+	if len(args) == 0 || isHelpToken(args[0]) {
 		printOSCProducerHelp(proto)
 		return nil
 	}

--- a/cmd/dhs/cmd_probel.go
+++ b/cmd/dhs/cmd_probel.go
@@ -52,7 +52,9 @@ func runProbelsw08p(ctx context.Context, args []string) error {
 	if mcSet {
 		ctx = context.WithValue(ctx, probelMatrixConfigKey{}, mc)
 	}
-	if len(args) == 0 || hasHelpFlag(args) {
+	// Help IN PLACE of a verb = catalogue; after the verb it belongs to
+	// the verb's own FlagSet (#462).
+	if len(args) == 0 || isHelpToken(args[0]) {
 		helpProbel()
 		return nil
 	}

--- a/cmd/dhs/cmd_probel02p.go
+++ b/cmd/dhs/cmd_probel02p.go
@@ -49,7 +49,9 @@ func runProbelsw02p(ctx context.Context, args []string) error {
 	if mcSet {
 		ctx = context.WithValue(ctx, probelSW02MatrixConfigKey{}, mc)
 	}
-	if len(args) == 0 || hasHelpFlag(args) {
+	// Help IN PLACE of a verb = catalogue; after the verb it belongs to
+	// the verb's own FlagSet (#462).
+	if len(args) == 0 || isHelpToken(args[0]) {
 		helpProbelSW02()
 		return nil
 	}

--- a/cmd/dhs/cmd_tsl.go
+++ b/cmd/dhs/cmd_tsl.go
@@ -30,7 +30,9 @@ import (
 //
 // `proto` is one of `tsl-v31` / `tsl-v40` / `tsl-v50`.
 func runTSLConsumer(ctx context.Context, proto string, args []string) error {
-	if len(args) == 0 || hasHelpFlag(args) {
+	// Help IN PLACE of a verb = catalogue; after the verb it belongs to
+	// the verb's own FlagSet (#462).
+	if len(args) == 0 || isHelpToken(args[0]) {
 		printTSLConsumerHelp(os.Stdout, proto)
 		return nil
 	}

--- a/cmd/dhs/cmd_tsl_producer.go
+++ b/cmd/dhs/cmd_tsl_producer.go
@@ -24,7 +24,9 @@ import (
 //
 // `proto` is one of `tsl-v31` / `tsl-v40` / `tsl-v50`.
 func runTSLProducer(ctx context.Context, proto string, args []string) error {
-	if len(args) == 0 || hasHelpFlag(args) {
+	// Help IN PLACE of a verb = catalogue; after the verb it belongs to
+	// the verb's own FlagSet (#462).
+	if len(args) == 0 || isHelpToken(args[0]) {
 		printTSLProducerHelp(os.Stdout, proto)
 		return nil
 	}

--- a/cmd/dhs/main.go
+++ b/cmd/dhs/main.go
@@ -30,6 +30,7 @@ package main
 import (
 	"context"
 	"errors"
+	"flag"
 	"fmt"
 	"os"
 	"os/signal"
@@ -204,6 +205,21 @@ func main() {
 		os.Exit(0)
 	}
 
+	// A verb-level `--help` is answered by the verb's own FlagSet (it
+	// prints that verb's usage + flags and Parse returns flag.ErrHelp).
+	// Help is success, not an error — exit 0 silently instead of the
+	// "error: flag: help requested" + catalogue fallback (#462).
+	exitOnErr := func(err error) {
+		if err == nil {
+			return
+		}
+		if errors.Is(err, flag.ErrHelp) {
+			os.Exit(0)
+		}
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(exitCode(err))
+	}
+
 	switch args[0] {
 	case "help", "-h", "--h", "--help":
 		printTopHelp()
@@ -230,28 +246,16 @@ func main() {
 		}
 		return
 	case "consumer":
-		if err := dispatchConsumer(ctx, args[1:]); err != nil {
-			fmt.Fprintln(os.Stderr, "error:", err)
-			os.Exit(exitCode(err))
-		}
+		exitOnErr(dispatchConsumer(ctx, args[1:]))
 		return
 	case "producer":
-		if err := dispatchProducer(ctx, args[1:]); err != nil {
-			fmt.Fprintln(os.Stderr, "error:", err)
-			os.Exit(exitCode(err))
-		}
+		exitOnErr(dispatchProducer(ctx, args[1:]))
 		return
 	case "registry":
-		if err := dispatchRegistry(ctx, args[1:]); err != nil {
-			fmt.Fprintln(os.Stderr, "error:", err)
-			os.Exit(exitCode(err))
-		}
+		exitOnErr(dispatchRegistry(ctx, args[1:]))
 		return
 	case "metrics":
-		if err := runMetrics(ctx, args[1:]); err != nil {
-			fmt.Fprintln(os.Stderr, "error:", err)
-			os.Exit(exitCode(err))
-		}
+		exitOnErr(runMetrics(ctx, args[1:]))
 		return
 	}
 
@@ -298,7 +302,11 @@ func dispatchConsumer(ctx context.Context, args []string) error {
 		return runNMOSConsumer(ctx, rest)
 	}
 
-	if len(rest) == 0 || hasHelpFlag(rest) {
+	// Catalogue help ONLY when help is asked in place of a verb — a help
+	// flag AFTER the verb belongs to the verb (#462: hasHelpFlag over the
+	// whole argv made `walk --help` print this catalogue and shadowed the
+	// per-verb help below).
+	if len(rest) == 0 || isHelpToken(rest[0]) {
 		printConsumerHelp()
 		return nil
 	}
@@ -340,7 +348,9 @@ func dispatchProducer(ctx context.Context, args []string) error {
 	if proto == "nmos" {
 		return runNMOSProducer(ctx, rest)
 	}
-	if len(rest) == 0 || hasHelpFlag(rest) {
+	// Same rule as dispatchConsumer (#462): help IN PLACE of a verb =
+	// catalogue; help after the verb belongs to the verb's own FlagSet.
+	if len(rest) == 0 || isHelpToken(rest[0]) {
 		printProducerHelp()
 		return nil
 	}


### PR DESCRIPTION
## What

`dhs consumer <proto> <verb> --help` now prints that verb's usage; the catalogue prints only when help is asked in place of a verb. Uniform across every dispatcher.

## Why

#462 — every dispatcher gated on `hasHelpFlag(args)` over the whole argv, so the help flag matched before the verb was extracted, the protocol catalogue printed, and the per-verb help paths were unreachable dead code. Reproduced live before the fix. Owner rule applied: same verb, same behavior on every protocol.

Closes #462

## Scope

- [ ] acp1
- [ ] acp2
- [ ] emberplus
- [ ] probel-sw08p / probel-sw02p
- [ ] osc / tsl / cerebrum-nb / amwa
- [ ] transport
- [ ] export
- [x] cli
- [ ] api
- [ ] core
- [ ] ci / chore

**Cross-protocol changes**: `cmd/dhs/*` dispatch only — deliberately cross-protocol because the help rule must be identical everywhere (ADR-0002); no protocol package touched.

## Wire evidence (protocol changes only)

N/A — CLI dispatch only, nothing on any wire.

## Reference controller

- [ ] Cerebrum still happy after this change
- [ ] VSM Studio still happy after this change
- [x] N/A (no protocol behaviour change)

## Type

- [ ] feat — new feature
- [x] fix — bug fix
- [ ] docs — documentation only
- [ ] chore — maintenance, refactor, CI
- [ ] security — security fix or hardening

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `cmd/dhs/main.go` | modified | consumer/producer gates check `isHelpToken(rest[0])` instead of scanning the whole argv; `exitOnErr` treats `flag.ErrHelp` as success (exit 0, no "error:" line) |
| `cmd/dhs/cmd_cerebrum.go`, `cmd_probel.go`, `cmd_probel02p.go`, `cmd_osc.go`, `cmd_tsl.go`, `cmd_tsl_producer.go`, `cmd_nmos.go`, `cmd_nmos_events.go` | modified | same one-line gate change in every per-protocol dispatcher |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test ./cmd/dhs/...` | ok | 0 |
| `go vet ./...` | clean | — |
| `golangci-lint run` | clean (pre-commit) | — |

Manual matrix verified on the built binary:
- `dhs consumer acp1 walk --help` → walk's usage, exit 0
- `dhs consumer cerebrum-nb lock --help` → lock's FlagSet usage + flags, exit 0
- `dhs consumer acp1 --help` / `dhs consumer --help` → catalogues unchanged

## Device tested

- [ ] ACP1 producer 10.100.0.102
- [ ] ACP2 producer 10.100.0.103
- [ ] ACP1 emulator 10.6.239.113
- [ ] ACP2 real device 10.41.40.195
- [ ] Other (specify)
- [x] No device needed (pure codec / doc change)

**Live-LXC command + observed output** (paste verbatim):

```text
dhs consumer acp1 walk --help
# observed:
# acp walk — enumerate every object on a slot
# IN   acp walk 10.6.239.113 --slot 0
# ... (per-verb usage; previously printed the whole consumer catalogue)
```

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [x] Integration tested on VM before PR (manual CLI matrix on the built binary)

## Approval

@yboujraf — requesting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
