### PR TITLE
feat(cerebrum-nb): --capture JSONL wire-trace on every verb (#242)

### DIFF
--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -68,6 +68,7 @@ type cerebrumFlags struct {
 	insecure bool
 	debug    bool
 	logPath  string
+	capture  string
 	timeout  time.Duration
 }
 
@@ -80,6 +81,7 @@ func newCerebrumFlags(fs *flag.FlagSet) *cerebrumFlags {
 	fs.BoolVar(&c.insecure, "insecure-skip-verify", false, "with --tls, skip TLS cert verification")
 	fs.BoolVar(&c.debug, "debug", false, "verbose RX/TX XML logging")
 	fs.StringVar(&c.logPath, "log", "", "write the diagnostic log (incl. RX/TX XML at full debug verbosity) to this file — clean UTF-8, no PowerShell 2> stderr wrapping; stderr stays silent")
+	fs.StringVar(&c.capture, "capture", "", "record every TX/RX XML document (ws text payload) to this JSONL wire-trace — the same --capture contract as every other connector (WARNING: contains the LOGIN frame in cleartext, treat as secret)")
 	fs.DurationVar(&c.timeout, "timeout", 5*time.Second, "per-request timeout")
 	return c
 }
@@ -302,6 +304,9 @@ FLAGS (order doesn't matter — flags can come before OR after the host)
   --insecure-skip-verify    with --tls, skip cert validation
   --debug                   verbose RX/TX XML logging (stderr)
   --log FILE                full debug log incl. RX/TX XML to FILE (clean UTF-8; stderr stays quiet)
+  --capture FILE            record every TX/RX XML document to a JSONL wire-trace — same contract as
+                            every other connector; replayable as an offline decoder oracle
+                            (WARNING: contains the LOGIN frame in cleartext — treat as secret)
   --timeout DUR             per-request timeout (default 5s — fail fast)
   --output text|json        structured stdout — every read verb emits one JSON document,
                             every write verb the ADR-0007 {changed|would_change, previous,
@@ -368,6 +373,7 @@ func dialCerebrum(cf *cerebrumFlags, positionals []string, verb string) (*cerebr
 	p.Password = cf.pass
 	p.UseTLS = cf.tls
 	p.InsecureSkipVerify = cf.insecure
+	p.Capture = cf.capture
 
 	scheme := "ws"
 	if cf.tls {
@@ -1856,6 +1862,7 @@ func cerebrumRoute(_ context.Context, args []string) error {
 	p.Password = cf.pass
 	p.UseTLS = cf.tls
 	p.InsecureSkipVerify = cf.insecure
+	p.Capture = cf.capture
 
 	dialCtx, dialCancel := context.WithTimeout(context.Background(), cf.timeout)
 	defer dialCancel()

--- a/cmd/dhs/cmd_cerebrum_xpoint.go
+++ b/cmd/dhs/cmd_cerebrum_xpoint.go
@@ -744,6 +744,7 @@ func cerebrumDial(cf *cerebrumFlags, host string) (*cerebrum.Plugin, error) {
 	p.Password = cf.pass
 	p.UseTLS = cf.tls
 	p.InsecureSkipVerify = cf.insecure
+	p.Capture = cf.capture
 	dialCtx, cancel := context.WithTimeout(context.Background(), cf.timeout)
 	defer cancel()
 	if err := p.Connect(dialCtx, host, cf.port); err != nil {

--- a/internal/cerebrum-nb/consumer/capture_test.go
+++ b/internal/cerebrum-nb/consumer/capture_test.go
@@ -1,0 +1,121 @@
+package cerebrumnb
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// captureRec mirrors transport.CaptureRecord for decoding the JSONL
+// wire-trace in assertions (kept local so the test reads standalone).
+type captureRec struct {
+	Proto string `json:"proto"`
+	Dir   string `json:"dir"`
+	Hex   string `json:"hex"`
+	Len   int    `json:"len"`
+}
+
+// TestConnect_CaptureRecordsWire proves the #242 contract: with
+// Plugin.Capture set, every TX/RX XML document lands in the JSONL
+// wire-trace with proto=cerebrum-nb and the exact wire bytes.
+func TestConnect_CaptureRecordsWire(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "capture.jsonl")
+	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		drainClient(fc, func(frame []byte) ([]byte, bool) {
+			return []byte(`<POLL_REPLY MTID="` + mtidOf(frame) +
+				`" CONNECTED_SERVER_ACTIVE="1" PRIMARY_SERVER_STATE="1" SECONDARY_SERVER_STATE="0"/>`), true
+		})
+	})
+	p := NewPlugin(nil)
+	p.Capture = path
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	if err := p.Connect(ctx, fs.host(), fs.port()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if _, err := p.Session().Poll(ctx); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	if err := p.Disconnect(); err != nil {
+		t.Fatalf("disconnect: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read capture: %v", err)
+	}
+	var tx, rx int
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line == "" {
+			continue
+		}
+		var r captureRec
+		if err := json.Unmarshal([]byte(line), &r); err != nil {
+			t.Fatalf("bad JSONL line %q: %v", line, err)
+		}
+		if r.Proto != "cerebrum-nb" {
+			t.Fatalf("proto = %q, want cerebrum-nb", r.Proto)
+		}
+		raw, err := hex.DecodeString(r.Hex)
+		if err != nil || len(raw) != r.Len {
+			t.Fatalf("hex/len mismatch on %q: %v", line, err)
+		}
+		doc := string(raw)
+		switch r.Dir {
+		case "tx":
+			tx++
+			if !strings.Contains(doc, "POLL") {
+				t.Fatalf("tx doc = %q, want the POLL document", doc)
+			}
+		case "rx":
+			rx++
+			if !strings.Contains(doc, "POLL_REPLY") {
+				t.Fatalf("rx doc = %q, want the POLL_REPLY document", doc)
+			}
+		default:
+			t.Fatalf("dir = %q", r.Dir)
+		}
+	}
+	if tx < 1 || rx < 1 {
+		t.Fatalf("capture holds tx=%d rx=%d records, want at least one each", tx, rx)
+	}
+}
+
+// TestConnect_CaptureCreateError: an uncreatable capture path fails
+// Connect up front with a --capture error (nothing dialed).
+func TestConnect_CaptureCreateError(t *testing.T) {
+	p := NewPlugin(nil)
+	p.Capture = filepath.Join(t.TempDir(), "no", "such", "dir", "x.jsonl")
+	ctx, cancel := ctx2s(t)
+	defer cancel()
+	err := p.Connect(ctx, "127.0.0.1", 1)
+	if err == nil || !strings.Contains(err.Error(), "--capture") {
+		t.Fatalf("want --capture create error, got %v", err)
+	}
+}
+
+// TestConnect_CaptureDialError: a dial failure with capture set closes
+// the recorder (no leaked handle) and surfaces the dial error.
+func TestConnect_CaptureDialError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "capture.jsonl")
+	p := NewPlugin(nil)
+	p.Capture = path
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	// Port 0 → DefaultPort 40007 on localhost, nothing listening (same
+	// assumption as TestConnect_DialError).
+	err := p.Connect(ctx, "127.0.0.1", 0)
+	if err == nil || !strings.Contains(err.Error(), "ws dial") {
+		t.Fatalf("want ws dial error, got %v", err)
+	}
+	// Recorder must be closed — on Windows an open handle would make
+	// the TempDir cleanup fail; removing explicitly proves it is free.
+	if rmErr := os.Remove(path); rmErr != nil {
+		t.Fatalf("capture file still locked after dial failure: %v", rmErr)
+	}
+}

--- a/internal/cerebrum-nb/consumer/plugin.go
+++ b/internal/cerebrum-nb/consumer/plugin.go
@@ -13,6 +13,7 @@ import (
 
 	"dhs/internal/cerebrum-nb/codec"
 	"dhs/internal/consumer"
+	"dhs/internal/transport"
 )
 
 func init() {
@@ -59,6 +60,11 @@ type Plugin struct {
 	// when UseTLS is true.
 	InsecureSkipVerify bool
 
+	// Capture, when set, records every TX/RX XML document (the ws text
+	// payload) to a JSONL wire-trace at this path — the same --capture
+	// contract every other connector honours (#242). Set before Connect.
+	Capture string
+
 	mu      sync.Mutex
 	session *Session
 }
@@ -103,8 +109,18 @@ func (p *Plugin) Connect(ctx context.Context, host string, port int) error {
 	}
 	url := fmt.Sprintf("%s://%s:%d/", scheme, host, port)
 
-	sess, err := newSession(ctx, p.logger, url, p.UseTLS, p.InsecureSkipVerify)
+	var rec *transport.Recorder
+	if p.Capture != "" {
+		r, rerr := transport.NewRecorder(p.Capture)
+		if rerr != nil {
+			return fmt.Errorf("cerebrum-nb: --capture: %w", rerr)
+		}
+		rec = r
+	}
+
+	sess, err := newSession(ctx, p.logger, url, p.UseTLS, p.InsecureSkipVerify, rec)
 	if err != nil {
+		_ = rec.Close() // nil-safe; don't leak the file on dial failure
 		return err
 	}
 

--- a/internal/cerebrum-nb/consumer/session.go
+++ b/internal/cerebrum-nb/consumer/session.go
@@ -15,6 +15,7 @@ import (
 	"sync/atomic"
 
 	"dhs/internal/cerebrum-nb/codec"
+	"dhs/internal/transport"
 	"dhs/internal/cerebrum-nb/codec/ws"
 )
 
@@ -30,6 +31,11 @@ type Session struct {
 	host       string
 	port       int
 	compliance *Profile
+	// rec, when non-nil, records every TX/RX XML document (the ws text
+	// payload — the wire truth above the RFC 6455 framing) to the
+	// standard JSONL wire-trace, same shape as every other connector's
+	// --capture (#242). transport.Recorder methods are nil-safe.
+	rec *transport.Recorder
 
 	mtidNext atomic.Uint32
 
@@ -88,8 +94,9 @@ func (p *Profile) Counts() map[string]int {
 }
 
 // newSession dials the Cerebrum WebSocket and starts the RX goroutine.
-// Login is performed by the caller via session.login.
-func newSession(ctx context.Context, logger *slog.Logger, urlStr string, useTLS, insecure bool) (*Session, error) {
+// Login is performed by the caller via session.login. rec may be nil
+// (no capture).
+func newSession(ctx context.Context, logger *slog.Logger, urlStr string, useTLS, insecure bool, rec *transport.Recorder) (*Session, error) {
 	opts := &ws.DialOptions{}
 	if useTLS && insecure {
 		opts.TLSConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec
@@ -105,6 +112,7 @@ func newSession(ctx context.Context, logger *slog.Logger, urlStr string, useTLS,
 		host:       host,
 		port:       port,
 		compliance: &Profile{},
+		rec:        rec,
 		pending:    map[string]chan *codec.Frame{},
 		stopRX:     make(chan struct{}),
 	}
@@ -184,6 +192,7 @@ func (s *Session) roundTrip(ctx context.Context, mtid uint32, payload []byte) (*
 	// Raw TX at debug level — the wire truth for diagnostics; --debug on the
 	// CLI promises "verbose RX/TX XML logging" and this is that promise.
 	s.logger.Debug("tx", slog.String("xml", string(payload)))
+	s.rec.Record("cerebrum-nb", "tx", payload)
 	if err := s.conn.WriteText(ctx, payload); err != nil {
 		return nil, fmt.Errorf("cerebrum-nb: write: %w", err)
 	}
@@ -372,6 +381,7 @@ func (s *Session) readLoop() {
 		}
 		// Raw RX at debug level — see the tx twin in roundTrip.
 		s.logger.Debug("rx", slog.String("xml", string(payload)))
+		s.rec.Record("cerebrum-nb", "rx", payload)
 		f, err := codec.Decode(payload)
 		if err != nil {
 			s.logger.Warn("decode failed",
@@ -464,6 +474,7 @@ func (s *Session) close() error {
 	s.closeOnce.Do(func() {
 		close(s.stopRX)
 		s.closeErr = s.conn.Close(1000, "client closing")
+		_ = s.rec.Close() // nil-safe; flush the --capture wire-trace
 	})
 	return s.closeErr
 }


### PR DESCRIPTION
## What

`--capture` for cerebrum-nb: every TX/RX XML document recorded to the standard JSONL wire-trace — the last connector without it. Uniform `--capture` across all 9 connectors (the ws variant #242 named).

## Why

#242 — owner "do it" (2026-08-17). `--capture` is shared connect-flag plumbing on every socket connector, but cerebrum-nb (WebSocket) only had `--log`. A capture against the real Cerebrum becomes an offline decoder oracle: replayable through the codec (`validate`, the #243 gap) and cross-checkable through the tshark dissector path (#473).

Part of #242 (re-scoped there: this closes the ws gap; the issue stays open only if the owner wants the http/nmos variant tracked further).

## Scope

- [ ] acp1
- [ ] acp2
- [ ] emberplus
- [ ] probel-sw08p / probel-sw02p
- [x] osc / tsl / cerebrum-nb / amwa
- [ ] transport
- [ ] export
- [x] cli
- [ ] api
- [ ] core
- [ ] ci / chore

**Cross-protocol changes**: none — cerebrum consumer + its CLI flags; the shared `transport.Recorder` is consumed as-is.

## Wire evidence (protocol changes only)

No wire behavior change — the recorder observes the exact ws text payloads (single TX hook in `roundTrip`, single RX hook in `readLoop`). Fake-server test asserts byte-exact hex round-trip of the POLL/POLL_REPLY documents.

## Reference controller

- [ ] Cerebrum still happy after this change
- [ ] VSM Studio still happy after this change
- [x] N/A (no protocol behaviour change)

## Type

- [x] feat — new feature
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] chore — maintenance, refactor, CI
- [ ] security — security fix or hardening

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `internal/cerebrum-nb/consumer/plugin.go` | modified | `Plugin.Capture` field; recorder created before dial, closed on dial failure |
| `internal/cerebrum-nb/consumer/session.go` | modified | recorder threaded into the session; TX record in `roundTrip`, RX record in `readLoop`, closed with the session (nil-safe throughout) |
| `internal/cerebrum-nb/consumer/capture_test.go` | new | fake-server tests: JSONL holds tx POLL + rx POLL_REPLY byte-exact; uncreatable path fails Connect with `--capture` error; dial failure releases the file handle |
| `cmd/dhs/cmd_cerebrum.go` | modified | `--capture` in the shared cerebrum flag set + help (cleartext-LOGIN warning); wired at both plugin builders |
| `cmd/dhs/cmd_cerebrum_xpoint.go` | modified | `--capture` wired at the export/import plugin builder |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test ./internal/cerebrum-nb/consumer/... ./cmd/dhs/...` | ok | 0 |
| coverage floor `internal/cerebrum-nb/consumer` | **100.0%** (Connect/newSession/close all 100%) | — |
| `go vet ./...` | clean | — |
| `golangci-lint run` | clean (pre-commit) | — |

## Device tested

- [ ] ACP1 producer 10.100.0.102
- [ ] ACP2 producer 10.100.0.103
- [ ] ACP1 emulator 10.6.239.113
- [ ] ACP2 real device 10.41.40.195
- [ ] Other (specify)
- [x] No device needed (pure codec / doc change)

Wire-observation only; first real-Cerebrum capture planned by the owner (becomes the committed decoder oracle).

**Live-LXC command + observed output** (paste verbatim):

```text
dhs consumer cerebrum-nb connect 10.44.55.39 --port 40009 --capture captures\cerebrum-nb\nb.jsonl
# expected: nb.jsonl lines {"ts":...,"proto":"cerebrum-nb","dir":"tx|rx","hex":...,"len":N}
```

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [ ] Integration tested on VM before PR (fake-server byte-exact tests; live capture is the owner's next NOC run)

## Approval

@yboujraf — requesting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
