### PR TITLE
feat(emberplus): canonical matrix xpoint export/import with ensure converge (#461)

### DIFF
--- a/cmd/dhs/cmd_emberplus_xpoint.go
+++ b/cmd/dhs/cmd_emberplus_xpoint.go
@@ -1,0 +1,553 @@
+package main
+
+// Canonical matrix crosspoint export/import for tree protocols whose
+// plugin exposes a matrix snapshot + connect surface (Ember+ today).
+// Same verbs, same CSV grammar, same ADR-0007 ensure semantics as
+// probel-sw08p and cerebrum-nb (#461, ADR-0002/0023):
+//
+//	export <host> --path <matrix> --out-dir DIR [--prefix P]
+//	    <prefix>-matrix.csv   ADR-0023 descriptor (one row per matrix)
+//	    <prefix>-xpoint.csv   dest,srce,levels  (levels fixed "0" — no
+//	                          levels in tree matrices; grammar parity)
+//	    <prefix>-src.csv      source labels, one column per label group
+//	    <prefix>-dst.csv      target labels, one column per label group
+//	import <host> --xpoint FILE [--matrix FILE] [--check] [--output json]
+//	    converge per target honoring the ADR-0023 behavior:
+//	      1to1 / 1toN  absolute takes (never toggles)
+//	      NtoM         connect the missing, EXPLICITLY disconnect the
+//	                   surplus (the file is authoritative per listed
+//	                   target; unlisted targets stay untouched)
+//
+// The wire operations (MatrixConnect / glow ConnOp*) are never exposed
+// on the CLI — owner rule: protocol commands stay internal.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"dhs/internal/consumer"
+	"dhs/internal/emberplus/codec/matrix"
+)
+
+// matrixXpointConn is the plugin surface the canonical crosspoint legs
+// need. Ember+ implements it; future tree protocols opt in by doing the
+// same — the generic code never names a protocol.
+type matrixXpointConn interface {
+	MatrixSnapshot(matrixPath string) []matrix.TargetState
+	MatrixConnect(ctx context.Context, matrixPath string, target int32, sources []int32, operation int64) error
+}
+
+// glow ConnectionOperation values (spec p.89) — internal only.
+const (
+	xpOpAbsolute   int64 = 0
+	xpOpConnect    int64 = 1
+	xpOpDisconnect int64 = 2
+)
+
+// matrixDesc is the ADR-0023 matrix entity as carried by -matrix.csv.
+type matrixDesc struct {
+	Matrix               string // dotted identifier path in the tree
+	Behavior             string // 1to1 | 1toN | NtoM | dynamic (ADR-0023)
+	Targets              int
+	Sources              int
+	MaxConnectsPerTarget int // 0 = unlimited / not stated
+	MaxTotalConnects     int // 0 = unlimited / not stated
+	Label                string
+}
+
+// behaviorFromGlowName maps the wire-level matrix type name (walk meta
+// "type": oneToN / oneToOne / nToN) onto the ADR-0023 behavior enum, so
+// protocol vocabulary never leaks into the files.
+func behaviorFromGlowName(name string) string {
+	switch strings.ToLower(name) {
+	case "onetoone":
+		return "1to1"
+	case "oneton":
+		return "1toN"
+	case "nton":
+		return "NtoM"
+	}
+	return "dynamic"
+}
+
+// ---------------------------------------------------------------------
+// -matrix.csv (ADR-0023 descriptor)
+// ---------------------------------------------------------------------
+
+func formatMatrixDescCSV(descs []matrixDesc) string {
+	var b strings.Builder
+	b.WriteString("matrix,behavior,targets,sources,max_connects_per_target,max_total_connects,label\n")
+	for _, d := range descs {
+		fmt.Fprintf(&b, "%s,%s,%d,%d,%d,%d,%s\n",
+			d.Matrix, d.Behavior, d.Targets, d.Sources,
+			d.MaxConnectsPerTarget, d.MaxTotalConnects, d.Label)
+	}
+	return b.String()
+}
+
+func parseMatrixDescCSV(data []byte, srcName string) ([]matrixDesc, error) {
+	lines := strings.Split(strings.ReplaceAll(string(data), "\r\n", "\n"), "\n")
+	start := 0
+	for start < len(lines) && (strings.TrimSpace(lines[start]) == "" || strings.HasPrefix(strings.TrimSpace(lines[start]), "#")) {
+		start++
+	}
+	if start >= len(lines) {
+		return nil, fmt.Errorf("%s: empty (no header)", srcName)
+	}
+	header := strings.Split(strings.ToLower(strings.TrimSpace(lines[start])), ",")
+	idx := map[string]int{}
+	for i, h := range header {
+		idx[strings.TrimSpace(h)] = i
+	}
+	for _, col := range []string{"matrix", "behavior"} {
+		if _, ok := idx[col]; !ok {
+			return nil, fmt.Errorf("%s: missing column %q", srcName, col)
+		}
+	}
+	atoi := func(f []string, col string) int {
+		i, ok := idx[col]
+		if !ok || i >= len(f) {
+			return 0
+		}
+		n, _ := strconv.Atoi(strings.TrimSpace(f[i]))
+		return n
+	}
+	var out []matrixDesc
+	for n, line := range lines[start+1:] {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		f := strings.Split(line, ",")
+		if len(f) < 2 {
+			return nil, fmt.Errorf("%s line %d: need at least matrix,behavior", srcName, start+n+2)
+		}
+		d := matrixDesc{
+			Matrix:               strings.TrimSpace(f[idx["matrix"]]),
+			Behavior:             strings.TrimSpace(f[idx["behavior"]]),
+			Targets:              atoi(f, "targets"),
+			Sources:              atoi(f, "sources"),
+			MaxConnectsPerTarget: atoi(f, "max_connects_per_target"),
+			MaxTotalConnects:     atoi(f, "max_total_connects"),
+		}
+		if i, ok := idx["label"]; ok && i < len(f) {
+			d.Label = strings.TrimSpace(f[i])
+		}
+		switch d.Behavior {
+		case "1to1", "1toN", "NtoM", "dynamic":
+		default:
+			return nil, fmt.Errorf("%s line %d: behavior %q (want 1to1|1toN|NtoM|dynamic per ADR-0023)", srcName, start+n+2, d.Behavior)
+		}
+		if d.Matrix == "" {
+			return nil, fmt.Errorf("%s line %d: empty matrix path", srcName, start+n+2)
+		}
+		out = append(out, d)
+	}
+	return out, nil
+}
+
+// ---------------------------------------------------------------------
+// walk-side helpers (descriptor + labels from the canonical objects)
+// ---------------------------------------------------------------------
+
+// findMatrixObject locates the walked matrix object addressed by a
+// dotted identifier path OR a numeric OID (same dual addressing as
+// every glow verb). A matrix object is recognized by its walk meta
+// ("element" == "matrix").
+func findMatrixObject(objs []consumer.Object, addr string) (consumer.Object, string, bool) {
+	for _, o := range objs {
+		if o.Meta == nil || o.Meta["element"] != "matrix" {
+			continue
+		}
+		dotted := strings.Join(o.Path, ".")
+		if addr == "" || strings.EqualFold(dotted, addr) || o.OID == addr {
+			return o, dotted, true
+		}
+	}
+	return consumer.Object{}, "", false
+}
+
+// listMatrixPaths names every matrix in the walked tree — the UX for a
+// missing/ambiguous --path.
+func listMatrixPaths(objs []consumer.Object) []string {
+	var out []string
+	for _, o := range objs {
+		if o.Meta != nil && o.Meta["element"] == "matrix" {
+			out = append(out, strings.Join(o.Path, ".")+" [oid="+o.OID+"]")
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func metaInt(m map[string]any, key string) int {
+	switch v := m[key].(type) {
+	case int:
+		return v
+	case int32:
+		return int(v)
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	}
+	return 0
+}
+
+func metaString(m map[string]any, key string) string {
+	if s, ok := m[key].(string); ok {
+		return s
+	}
+	return ""
+}
+
+// descFromObject builds the ADR-0023 descriptor from a walked matrix
+// object's meta.
+func descFromObject(o consumer.Object, dotted string) matrixDesc {
+	return matrixDesc{
+		Matrix:               dotted,
+		Behavior:             behaviorFromGlowName(metaString(o.Meta, "type")),
+		Targets:              metaInt(o.Meta, "targetCount"),
+		Sources:              metaInt(o.Meta, "sourceCount"),
+		MaxConnectsPerTarget: metaInt(o.Meta, "maximumConnectsPerTarget"),
+		MaxTotalConnects:     metaInt(o.Meta, "maximumTotalConnects"),
+		Label:                o.Label,
+	}
+}
+
+// labelGroups extracts the multi-level label sets from walk meta
+// ("targetLabels" / "sourceLabels": group → index → label). Returns the
+// sorted group names and the per-group maps.
+func labelGroups(o consumer.Object, key string) ([]string, map[string]map[string]string) {
+	raw, ok := o.Meta[key].(map[string]map[string]string)
+	if !ok || len(raw) == 0 {
+		return nil, nil
+	}
+	groups := make([]string, 0, len(raw))
+	for g := range raw {
+		groups = append(groups, g)
+	}
+	sort.Strings(groups)
+	return groups, raw
+}
+
+// formatMatrixLabelCSV renders one label CSV: keyCol ("dest"/"srce"),
+// one column per label group (the "many levels" of a tree matrix).
+// Rows sort numerically by index; indices come from the union of all
+// groups so a hole in one group cannot drop a row.
+func formatMatrixLabelCSV(keyCol string, groups []string, byGroup map[string]map[string]string) string {
+	seen := map[int]bool{}
+	var ids []int
+	for _, g := range groups {
+		for idx := range byGroup[g] {
+			if n, err := strconv.Atoi(idx); err == nil && !seen[n] {
+				seen[n] = true
+				ids = append(ids, n)
+			}
+		}
+	}
+	sort.Ints(ids)
+	var b strings.Builder
+	b.WriteString(keyCol)
+	for _, g := range groups {
+		b.WriteByte(',')
+		b.WriteString(g)
+	}
+	b.WriteByte('\n')
+	for _, id := range ids {
+		b.WriteString(strconv.Itoa(id))
+		for _, g := range groups {
+			b.WriteByte(',')
+			b.WriteString(byGroup[g][strconv.Itoa(id)])
+		}
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// ---------------------------------------------------------------------
+// export leg
+// ---------------------------------------------------------------------
+
+// runMatrixSetExport writes the canonical matrix file set for ONE
+// matrix selected by --path/--oid (or the only matrix in the tree).
+func runMatrixSetExport(plug consumer.Protocol, objs []consumer.Object, addr, outDir, prefix string) error {
+	mc, ok := plug.(matrixXpointConn)
+	if !ok {
+		return fmt.Errorf("%w: this protocol has no matrix surface — --out-dir matrix export unsupported", consumer.ErrValidationFailed)
+	}
+	obj, dotted, found := findMatrixObject(objs, addr)
+	if !found {
+		avail := listMatrixPaths(objs)
+		if len(avail) == 0 {
+			return fmt.Errorf("%w: no matrix in the walked tree", consumer.ErrValidationFailed)
+		}
+		return fmt.Errorf("%w: matrix %q not found; available:\n  %s", consumer.ErrValidationFailed, addr, strings.Join(avail, "\n  "))
+	}
+	desc := descFromObject(obj, dotted)
+
+	// Crosspoints from the live snapshot: one row per (target, source),
+	// levels fixed "0" (grammar parity with the levelled protocols).
+	var rows []cerebrumXpointRow
+	for _, ts := range mc.MatrixSnapshot(dotted) {
+		for _, src := range ts.Sources {
+			rows = append(rows, cerebrumXpointRow{
+				Dest:   strconv.Itoa(int(ts.Target)),
+				Srce:   strconv.Itoa(int(src)),
+				Levels: []string{"0"},
+			})
+		}
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		if c := cmpCerebrumID(rows[i].Dest, rows[j].Dest); c != 0 {
+			return c < 0
+		}
+		return cmpCerebrumID(rows[i].Srce, rows[j].Srce) < 0
+	})
+
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return err
+	}
+	files := []struct{ name, content string }{
+		{prefix + "-matrix.csv", formatMatrixDescCSV([]matrixDesc{desc})},
+		{prefix + "-xpoint.csv", formatCerebrumXpointCSV(rows)},
+	}
+	if groups, byGroup := labelGroups(obj, "sourceLabels"); groups != nil {
+		files = append(files, struct{ name, content string }{prefix + "-src.csv", formatMatrixLabelCSV("srce", groups, byGroup)})
+	}
+	if groups, byGroup := labelGroups(obj, "targetLabels"); groups != nil {
+		files = append(files, struct{ name, content string }{prefix + "-dst.csv", formatMatrixLabelCSV("dest", groups, byGroup)})
+	}
+	for _, f := range files {
+		p := filepath.Join(outDir, f.name)
+		if err := os.WriteFile(p, []byte(f.content), 0o644); err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "export: wrote %s (%d row(s))\n", p, strings.Count(f.content, "\n")-1)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------
+// import (converge) leg
+// ---------------------------------------------------------------------
+
+// xpointChange is one converging crosspoint action.
+type xpointChange struct {
+	Target  int32
+	Sources []int32
+	Op      int64  // xpOp*
+	From    string // display: current source set
+	To      string // display: desired source set
+}
+
+// diffMatrixXpoints computes the converge actions for desired rows
+// against the live snapshot, honoring the ADR-0023 behavior.
+func diffMatrixXpoints(desc matrixDesc, live []matrix.TargetState, rows []cerebrumXpointRow) ([]xpointChange, error) {
+	desired := map[int32][]int32{}
+	var order []int32
+	for _, r := range rows {
+		if len(r.Levels) != 1 || r.Levels[0] != "0" {
+			return nil, fmt.Errorf("%w: dest %s: levels must be \"0\" for a tree matrix (no levels — ADR-0023)", consumer.ErrValidationFailed, r.Dest)
+		}
+		t, err := strconv.Atoi(r.Dest)
+		if err != nil {
+			return nil, fmt.Errorf("%w: dest %q is not a target index", consumer.ErrValidationFailed, r.Dest)
+		}
+		s, err := strconv.Atoi(r.Srce)
+		if err != nil {
+			return nil, fmt.Errorf("%w: srce %q is not a source index", consumer.ErrValidationFailed, r.Srce)
+		}
+		tt := int32(t)
+		if _, seen := desired[tt]; !seen {
+			order = append(order, tt)
+		}
+		desired[tt] = append(desired[tt], int32(s))
+	}
+
+	// Behavior-level validation before anything is sent (exit 2).
+	for t, srcs := range desired {
+		switch desc.Behavior {
+		case "1to1", "1toN":
+			if len(srcs) > 1 {
+				return nil, fmt.Errorf("%w: dest %d has %d sources but behavior %s allows one", consumer.ErrValidationFailed, t, len(srcs), desc.Behavior)
+			}
+		case "NtoM":
+			if desc.MaxConnectsPerTarget > 0 && len(srcs) > desc.MaxConnectsPerTarget {
+				return nil, fmt.Errorf("%w: dest %d has %d sources > max_connects_per_target %d", consumer.ErrValidationFailed, t, len(srcs), desc.MaxConnectsPerTarget)
+			}
+		}
+	}
+
+	cur := map[int32][]int32{}
+	for _, ts := range live {
+		cur[ts.Target] = ts.Sources
+	}
+
+	joinSrcs := func(s []int32) string {
+		parts := make([]string, len(s))
+		for i, v := range s {
+			parts[i] = strconv.Itoa(int(v))
+		}
+		return strings.Join(parts, ";")
+	}
+
+	var out []xpointChange
+	for _, t := range order {
+		want := dedupInt32(desired[t])
+		have := dedupInt32(cur[t])
+		switch desc.Behavior {
+		case "NtoM":
+			add := subtractInt32(want, have)
+			del := subtractInt32(have, want)
+			if len(add) > 0 {
+				out = append(out, xpointChange{Target: t, Sources: add, Op: xpOpConnect, From: joinSrcs(have), To: joinSrcs(want)})
+			}
+			if len(del) > 0 {
+				out = append(out, xpointChange{Target: t, Sources: del, Op: xpOpDisconnect, From: joinSrcs(have), To: joinSrcs(want)})
+			}
+		default: // 1to1 / 1toN / dynamic → absolute take when different
+			if !equalInt32Sets(want, have) {
+				out = append(out, xpointChange{Target: t, Sources: want, Op: xpOpAbsolute, From: joinSrcs(have), To: joinSrcs(want)})
+			}
+		}
+	}
+	return out, nil
+}
+
+func dedupInt32(in []int32) []int32 {
+	seen := map[int32]bool{}
+	out := make([]int32, 0, len(in))
+	for _, v := range in {
+		if !seen[v] {
+			seen[v] = true
+			out = append(out, v)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+func subtractInt32(a, b []int32) []int32 {
+	inB := map[int32]bool{}
+	for _, v := range b {
+		inB[v] = true
+	}
+	var out []int32
+	for _, v := range a {
+		if !inB[v] {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+func equalInt32Sets(a, b []int32) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// runMatrixXpointImport converges one matrix to the xpoint CSV per the
+// ADR-0007 contract. Matrix identity + behavior come from -matrix.csv
+// when given, else from the live walked descriptor; a behavior mismatch
+// between file and live is a validation error.
+func runMatrixXpointImport(ctx context.Context, plug consumer.Protocol, objs []consumer.Object, xpointPath, matrixPath string, check, jsonOut bool) error {
+	mc, ok := plug.(matrixXpointConn)
+	if !ok {
+		return fmt.Errorf("%w: this protocol has no matrix surface — --xpoint import unsupported", consumer.ErrValidationFailed)
+	}
+
+	data, err := os.ReadFile(xpointPath)
+	if err != nil {
+		return err
+	}
+	rows, err := parseCerebrumXpoint(data, xpointPath)
+	if err != nil {
+		return err
+	}
+
+	var fileDesc *matrixDesc
+	if matrixPath != "" {
+		md, merr := os.ReadFile(matrixPath)
+		if merr != nil {
+			return merr
+		}
+		descs, perr := parseMatrixDescCSV(md, matrixPath)
+		if perr != nil {
+			return perr
+		}
+		if len(descs) != 1 {
+			return fmt.Errorf("%w: %s: exactly one matrix row expected (got %d)", consumer.ErrValidationFailed, matrixPath, len(descs))
+		}
+		fileDesc = &descs[0]
+	}
+
+	addr := ""
+	if fileDesc != nil {
+		addr = fileDesc.Matrix
+	}
+	obj, dotted, found := findMatrixObject(objs, addr)
+	if !found {
+		return fmt.Errorf("%w: matrix %q not found in the walked tree; available:\n  %s", consumer.ErrValidationFailed, addr, strings.Join(listMatrixPaths(objs), "\n  "))
+	}
+	liveDesc := descFromObject(obj, dotted)
+	desc := liveDesc
+	if fileDesc != nil {
+		if fileDesc.Behavior != liveDesc.Behavior {
+			return fmt.Errorf("%w: %s says behavior %s but the live matrix is %s — refusing to converge with the wrong rule", consumer.ErrValidationFailed, matrixPath, fileDesc.Behavior, liveDesc.Behavior)
+		}
+		desc = *fileDesc
+		desc.Matrix = dotted
+	}
+
+	changes, err := diffMatrixXpoints(desc, mc.MatrixSnapshot(dotted), rows)
+	if err != nil {
+		return err
+	}
+
+	logw := os.Stdout
+	if jsonOut {
+		logw = os.Stderr
+	}
+	diffs := make([]ensureDiff, 0, len(changes))
+	for _, c := range changes {
+		diffs = append(diffs, ensureDiff{Field: fmt.Sprintf("xpoint.%s.%d", dotted, c.Target), From: c.From, To: c.To})
+	}
+	changed := len(changes) > 0
+
+	if check {
+		for _, c := range changes {
+			_, _ = fmt.Fprintf(logw, "[would-xpoint] %s target=%d: %q -> %q\n", dotted, c.Target, c.From, c.To)
+		}
+		_, _ = fmt.Fprintf(logw, "import --check: would_change=%d of %d desired row(s) on %s (%s) — nothing sent\n", len(changes), len(rows), dotted, desc.Behavior)
+		if jsonOut {
+			return emitEnsure(true, ensureResult{WouldChange: &changed, Diff: diffs})
+		}
+		return nil
+	}
+	for _, c := range changes {
+		if err := mc.MatrixConnect(ctx, dotted, c.Target, c.Sources, c.Op); err != nil {
+			return fmt.Errorf("xpoint %s target %d: %w", dotted, c.Target, err)
+		}
+		_, _ = fmt.Fprintf(logw, "[xpoint] OK %s target=%d: %q -> %q\n", dotted, c.Target, c.From, c.To)
+	}
+	if len(changes) == 0 {
+		_, _ = fmt.Fprintf(logw, "[xpoint] already converged — %s (%s), nothing sent\n", dotted, desc.Behavior)
+	}
+	if jsonOut {
+		return emitEnsure(true, ensureResult{Changed: &changed, Diff: diffs})
+	}
+	return nil
+}

--- a/cmd/dhs/cmd_emberplus_xpoint_test.go
+++ b/cmd/dhs/cmd_emberplus_xpoint_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"dhs/internal/consumer"
+	"dhs/internal/emberplus/codec/matrix"
+)
+
+func TestBehaviorFromGlowName(t *testing.T) {
+	cases := map[string]string{
+		"oneToOne": "1to1", "oneToN": "1toN", "nToN": "NtoM",
+		"ONETOONE": "1to1", "weird": "dynamic", "": "dynamic",
+	}
+	for in, want := range cases {
+		if got := behaviorFromGlowName(in); got != want {
+			t.Errorf("behaviorFromGlowName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestMatrixDescCSVRoundTrip(t *testing.T) {
+	in := []matrixDesc{{
+		Matrix: "router.nToN.matrix", Behavior: "NtoM",
+		Targets: 16, Sources: 16,
+		MaxConnectsPerTarget: 4, MaxTotalConnects: 64, Label: "nToN",
+	}}
+	got, err := parseMatrixDescCSV([]byte(formatMatrixDescCSV(in)), "t.csv")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0] != in[0] {
+		t.Fatalf("round-trip = %+v, want %+v", got, in)
+	}
+}
+
+func TestMatrixDescCSVRejectsBadBehavior(t *testing.T) {
+	_, err := parseMatrixDescCSV([]byte("matrix,behavior\nm,nToN\n"), "t.csv")
+	if err == nil || !strings.Contains(err.Error(), "ADR-0023") {
+		t.Fatalf("protocol-vocabulary behavior must be rejected (ADR-0023 names only), got %v", err)
+	}
+}
+
+func TestDiffMatrixXpoints_NtoM(t *testing.T) {
+	desc := matrixDesc{Matrix: "m", Behavior: "NtoM", MaxConnectsPerTarget: 3}
+	live := []matrix.TargetState{
+		{Target: 6, Sources: []int32{6}},
+		{Target: 12, Sources: []int32{12}},
+	}
+	rows := []cerebrumXpointRow{
+		{Dest: "6", Srce: "3", Levels: []string{"0"}},
+		{Dest: "6", Srce: "6", Levels: []string{"0"}},
+		{Dest: "12", Srce: "9", Levels: []string{"0"}}, // replace 12 with 9
+	}
+	got, err := diffMatrixXpoints(desc, live, rows)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// target 6: connect {3}; target 12: connect {9} + disconnect {12}.
+	if len(got) != 3 {
+		t.Fatalf("changes = %+v, want 3", got)
+	}
+	if got[0].Target != 6 || got[0].Op != xpOpConnect || len(got[0].Sources) != 1 || got[0].Sources[0] != 3 {
+		t.Fatalf("change 0 = %+v", got[0])
+	}
+	if got[1].Op != xpOpConnect || got[1].Sources[0] != 9 {
+		t.Fatalf("change 1 = %+v", got[1])
+	}
+	if got[2].Op != xpOpDisconnect || got[2].Sources[0] != 12 {
+		t.Fatalf("change 2 = %+v (surplus must be EXPLICITLY disconnected)", got[2])
+	}
+}
+
+func TestDiffMatrixXpoints_OneToN_AbsoluteNoToggle(t *testing.T) {
+	desc := matrixDesc{Matrix: "m", Behavior: "1toN"}
+	live := []matrix.TargetState{{Target: 1, Sources: []int32{5}}}
+	rows := []cerebrumXpointRow{
+		{Dest: "1", Srce: "7", Levels: []string{"0"}},
+		{Dest: "2", Srce: "5", Levels: []string{"0"}},
+	}
+	got, err := diffMatrixXpoints(desc, live, rows)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("changes = %+v, want 2", got)
+	}
+	for _, c := range got {
+		if c.Op != xpOpAbsolute {
+			t.Fatalf("1toN converge must use absolute takes, got op %d", c.Op)
+		}
+	}
+}
+
+func TestDiffMatrixXpoints_Converged(t *testing.T) {
+	desc := matrixDesc{Matrix: "m", Behavior: "NtoM"}
+	live := []matrix.TargetState{{Target: 6, Sources: []int32{3, 6}}}
+	rows := []cerebrumXpointRow{
+		{Dest: "6", Srce: "6", Levels: []string{"0"}},
+		{Dest: "6", Srce: "3", Levels: []string{"0"}}, // order must not matter
+	}
+	got, err := diffMatrixXpoints(desc, live, rows)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("converged state produced changes: %+v", got)
+	}
+}
+
+func TestDiffMatrixXpoints_Validation(t *testing.T) {
+	// Non-zero level on a tree matrix.
+	_, err := diffMatrixXpoints(matrixDesc{Behavior: "NtoM"}, nil,
+		[]cerebrumXpointRow{{Dest: "1", Srce: "2", Levels: []string{"1"}}})
+	if !errors.Is(err, consumer.ErrValidationFailed) {
+		t.Fatalf("non-zero level: want validation error, got %v", err)
+	}
+	// Two sources on a 1toN dest.
+	_, err = diffMatrixXpoints(matrixDesc{Behavior: "1toN"}, nil,
+		[]cerebrumXpointRow{
+			{Dest: "1", Srce: "2", Levels: []string{"0"}},
+			{Dest: "1", Srce: "3", Levels: []string{"0"}},
+		})
+	if !errors.Is(err, consumer.ErrValidationFailed) {
+		t.Fatalf("1toN multi-source: want validation error, got %v", err)
+	}
+	// Over max_connects_per_target on NtoM.
+	_, err = diffMatrixXpoints(matrixDesc{Behavior: "NtoM", MaxConnectsPerTarget: 1}, nil,
+		[]cerebrumXpointRow{
+			{Dest: "1", Srce: "2", Levels: []string{"0"}},
+			{Dest: "1", Srce: "3", Levels: []string{"0"}},
+		})
+	if !errors.Is(err, consumer.ErrValidationFailed) {
+		t.Fatalf("NtoM over cap: want validation error, got %v", err)
+	}
+}
+
+func TestFormatMatrixLabelCSV_MultiGroup(t *testing.T) {
+	groups := []string{"Primary", "Short"}
+	byGroup := map[string]map[string]string{
+		"Primary": {"3": "AES-S-3", "6": "AES-S-6"},
+		"Short":   {"3": "S3"}, // hole at 6 must not drop the row
+	}
+	got := formatMatrixLabelCSV("srce", groups, byGroup)
+	want := "srce,Primary,Short\n3,AES-S-3,S3\n6,AES-S-6,\n"
+	if got != want {
+		t.Fatalf("label CSV:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}

--- a/cmd/dhs/cmd_export.go
+++ b/cmd/dhs/cmd_export.go
@@ -24,10 +24,12 @@ func runExport(ctx context.Context, args []string) error {
 	format := fs.String("format", "", "output format: json | yaml | csv (default: json or from --out extension)")
 	out := fs.String("out", "", "output file path (default: stdout)")
 	slot := fs.Int("slot", -1, "export only this slot (-1 = all present slots)")
-	pathFlag := fs.String("path", "", "filter objects by path prefix (e.g. BOARD, PSU/1)")
+	pathFlag := fs.String("path", "", "filter objects by path prefix (e.g. BOARD, PSU/1); with --out-dir: the matrix to export (dotted path or numeric OID)")
+	outDir := fs.String("out-dir", "", "canonical matrix file-set mode (#461): write <prefix>-matrix.csv / -xpoint.csv / -src.csv / -dst.csv for the matrix named by --path (same grammar as probel-sw08p / cerebrum-nb)")
+	prefix := fs.String("prefix", "matrix", "file prefix used with --out-dir")
 	host, rest, err := popHost(args)
 	if err != nil {
-		return fmt.Errorf("usage: dhs consumer <proto> export <host> [--format json|yaml|csv] [--out FILE] [--slot N] [--path SEG.SEG]")
+		return fmt.Errorf("usage: dhs consumer <proto> export <host> [--format json|yaml|csv] [--out FILE] [--slot N] [--path SEG.SEG] [--out-dir DIR --prefix P]")
 	}
 	_ = fs.Parse(rest)
 
@@ -74,6 +76,21 @@ func runExport(ctx context.Context, args []string) error {
 		Generator: "acp " + version,
 		CreatedAt: time.Now().UTC(),
 	}
+	// Canonical matrix file-set mode (#461): walk, then write the
+	// -matrix/-xpoint/-src/-dst CSV set for the selected matrix instead
+	// of a snapshot. Same verbs + grammar as the levelled protocols.
+	if *outDir != "" {
+		var all []consumer.Object
+		for s := 0; s < info.NumSlots; s++ {
+			objs, werr := plug.Walk(ctx, s)
+			if werr != nil {
+				continue
+			}
+			all = append(all, objs...)
+		}
+		return runMatrixSetExport(plug, all, *pathFlag, *outDir, *prefix)
+	}
+
 	for s := 0; s < info.NumSlots; s++ {
 		if *slot >= 0 && s != *slot {
 			continue

--- a/cmd/dhs/cmd_import.go
+++ b/cmd/dhs/cmd_import.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"dhs/internal/consumer"
 	"dhs/internal/export"
 )
 
@@ -63,11 +64,46 @@ func runImport(ctx context.Context, args []string) error {
 	fs.Var(&filterPaths, "path",
 		"apply only objects with this dotted path (e.g. \"BOARD.Gain A\"). Repeat for multiple. Mutually exclusive with --id.")
 
+	// Canonical matrix converge leg (#461): --xpoint FILE converges one
+	// matrix per ADR-0007 (same CSV grammar + ensure semantics as
+	// probel-sw08p / cerebrum-nb). --matrix FILE carries the ADR-0023
+	// descriptor (matrix identity + behavior); absent = live descriptor.
+	xpointPath := fs.String("xpoint", "", "crosspoint CSV to converge (dest,srce,levels — levels \"0\" on tree matrices)")
+	matrixPath := fs.String("matrix", "", "matrix descriptor CSV from export (-matrix.csv); absent = live walked descriptor")
+	check := fs.Bool("check", false, "with --xpoint: dry-run — read live state, report would_change, send nothing")
+	output := fs.String("output", "text", "with --xpoint: stdout format text | json (ADR-0007 {changed|would_change, diff[]})")
+
 	host, rest, err := popHost(args)
 	if err != nil {
-		return fmt.Errorf("usage: dhs consumer <proto> import <host> --file SNAPSHOT [--slot N] [--id N ...| --path P ...] [--dry-run]")
+		return fmt.Errorf("usage: dhs consumer <proto> import <host> --file SNAPSHOT [--slot N] [--id N ...| --path P ...] [--dry-run] | --xpoint FILE [--matrix FILE] [--check] [--output json]")
 	}
 	_ = fs.Parse(rest)
+
+	if *xpointPath != "" {
+		jsonOut, oerr := resolveEnsureOutput(*output, false)
+		if oerr != nil {
+			return oerr
+		}
+		plug, cleanup, cerr := connect(ctx, host, cf)
+		if cerr != nil {
+			return cerr
+		}
+		defer cleanup()
+		info, ierr := plug.GetDeviceInfo(ctx)
+		if ierr != nil {
+			return fmt.Errorf("device info: %w", ierr)
+		}
+		var all []consumer.Object
+		for s := 0; s < info.NumSlots; s++ {
+			objs, werr := plug.Walk(ctx, s)
+			if werr != nil {
+				continue
+			}
+			all = append(all, objs...)
+		}
+		return runMatrixXpointImport(ctx, plug, all, *xpointPath, *matrixPath, *check, jsonOut)
+	}
+
 	if *file == "" {
 		return fmt.Errorf("--file is required")
 	}


### PR DESCRIPTION
## What

Canonical matrix crosspoint export/import for ember+ — same verbs, same CSV grammar, same ADR-0007 ensure as probel-sw08p and cerebrum-nb. `export --path <matrix> --out-dir` writes `-matrix.csv` (ADR-0023 descriptor) + `-xpoint.csv` + `-src.csv`/`-dst.csv` (multi-group labels); `import --xpoint [--matrix] [--check] [--output json]` converges per target honoring the behavior.

## Why

#461 (owner re-scope 2026-08-17): export must be importable; protocol commands stay internal; templates/functions/streams are provider-owned and out of scope. The gap was pure wiring — export already emitted connections, import's Apply only knew `SetValue`. Now the crosspoint state converges through the canonical surface: `1to1`/`1toN` = absolute takes (never toggles); `NtoM` = connect the missing + **explicitly disconnect the surplus** (file authoritative per listed target; unlisted targets untouched). Validation before any send: behavior mismatch file-vs-live, non-zero level (tree matrices have no levels), multi-source on 1toN, over `max_connects_per_target`.

Closes #461

## Scope

- [ ] acp1
- [ ] acp2
- [x] emberplus
- [ ] probel-sw08p / probel-sw02p
- [ ] osc / tsl / cerebrum-nb / amwa
- [ ] transport
- [ ] export
- [x] cli
- [ ] api
- [ ] core
- [ ] ci / chore

**Cross-protocol changes**: `cmd_export.go`/`cmd_import.go` gain the canonical flags; the legs run only when the plugin implements the matrix surface (interface gate, no protocol names in the generic paths — the same seam `cmd_set.go` uses for ValidateValue).

## Wire evidence (protocol changes only)

Live vs **Tiny Ember+ Router 1.6.2** (127.0.0.1:9092), all three matrices:

- Export: nToN 4×4 (sparse non-linear indices 3/6/9/12, `Primary` label group as CSV column), oneToN 200×200, dynamic 2000×2000 — descriptor rows `NtoM/1toN/NtoM` mapped from glow types.
- `import --check` round-trip = `would_change:0` on all three sets.
- Full converge cycle on nToN: apply edit → `connect` target 6 `"6"→"3;6"` (changed:true + diff); re-check 0; restore from original export → **explicit disconnect** `"3;6"→"6"`; final check 0. Oracle left in its original state.

## Reference controller

- [ ] Cerebrum still happy after this change
- [ ] VSM Studio still happy after this change
- [x] N/A (no protocol behaviour change — consumer-side converge using existing MatrixConnect wire ops)

## Type

- [x] feat — new feature
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] chore — maintenance, refactor, CI
- [ ] security — security fix or hardening

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `cmd/dhs/cmd_emberplus_xpoint.go` | new | descriptor CSV (ADR-0023 vocabulary enforced), xpoint export from MatrixSnapshot, multi-group label CSVs, three-behavior diff + converge with validation-first, path/OID matrix addressing with available-matrix listing |
| `cmd/dhs/cmd_emberplus_xpoint_test.go` | new | behavior mapping, descriptor round-trip + vocabulary guard, NtoM/1toN/converged/validation diff arms, multi-group label CSV with holes |
| `cmd/dhs/cmd_export.go` | modified | `--out-dir`/`--prefix` canonical file-set mode (interface-gated) |
| `cmd/dhs/cmd_import.go` | modified | `--xpoint`/`--matrix`/`--check`/`--output` converge leg (interface-gated) |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test ./cmd/dhs/...` | ok | 0 |
| `go vet ./...` | clean | — |
| `golangci-lint run` | clean (pre-commit) | — |

## Device tested

- [ ] ACP1 producer 10.100.0.102
- [ ] ACP2 producer 10.100.0.103
- [ ] ACP1 emulator 10.6.239.113
- [ ] ACP2 real device 10.41.40.195
- [x] Other (specify)
- [ ] No device needed (pure codec / doc change)

Tiny Ember+ Router 1.6.2 on 127.0.0.1:9092 (Tier-2 vendor emulator), owner-authorized write tests; state restored.

**Live-LXC command + observed output** (paste verbatim):

```text
dhs consumer emberplus import 127.0.0.1 --port 9092 --xpoint nton-xpoint.csv --matrix nton-matrix.csv --check --output json
# observed: {"would_change":false,"diff":[]}
# converge cycle: {"changed":true,"diff":[{"field":"xpoint.router.nToN.matrix.6","from":"6","to":"3;6"}]} → restore → {"would_change":false}
```

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [x] Integration tested on VM before PR (live vs Tiny router, both directions)

## Approval

@yboujraf — requesting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
