### PR TITLE
feat(osc): validate verb with --out-tree address-space capture (#243)

### DIFF
--- a/cmd/dhs/cmd_osc.go
+++ b/cmd/dhs/cmd_osc.go
@@ -48,8 +48,13 @@ func runOSCConsumer(ctx context.Context, proto string, args []string) error {
 	switch verb {
 	case "watch":
 		return runOSCWatch(ctx, proto, rest)
+	case "validate":
+		// Canonical offline validate (#243): decode a captured
+		// frames.jsonl through the OSC codec; --out-tree aggregates the
+		// observed address space into a canonical tree.json.
+		return runValidate(ctx, append([]string{"--protocol", proto}, rest...))
 	}
-	return fmt.Errorf("consumer %s: unknown verb %q (expected: watch)", proto, verb)
+	return fmt.Errorf("consumer %s: unknown verb %q (expected: watch, validate)", proto, verb)
 }
 
 // runOSCProducer dispatches `dhs producer osc-vXX <verb> [args]`.

--- a/internal/osc/consumer/validate.go
+++ b/internal/osc/consumer/validate.go
@@ -1,0 +1,263 @@
+package osc
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"dhs/internal/consumer"
+	"dhs/internal/export"
+	"dhs/internal/osc/codec"
+	"dhs/internal/wiretrace"
+)
+
+// Compile-time assertion: the OSC Plugin satisfies consumer.Validator so
+// `dhs consumer osc-vXX validate <frames.jsonl>` resolves at the CLI
+// type-assert (cmd/dhs/cmd_validate.go). Closes the osc half of #243.
+var _ consumer.Validator = (*Plugin)(nil)
+
+// Validate decodes captured OSC wire-trace records (Trames per
+// ADR-0021) through the stdlib-only codec, offline — the replay
+// counterpart of the live listener. Coverage:
+//
+//   - UDP captures: one OSC packet (message or bundle) per trame.
+//   - TCP captures: OSC 1.0 length-prefix and OSC 1.1 SLIP framings are
+//     unwrapped transparently (a trame is one recorded read, so it
+//     carries exactly one framed packet).
+//   - Bundles recurse; every contained message counts.
+//
+// --out-tree aggregates the OBSERVED ADDRESS SPACE (last value wins per
+// address) into a canonical snapshot tree.json — turning a live capture
+// into a replayable address catalogue; --out-params emits the same rows
+// as a flat dump (.csv by extension, JSON otherwise).
+func (p *Plugin) Validate(ctx context.Context, trames []wiretrace.Trame, opts consumer.ValidateOpts) (*consumer.ValidateReport, error) {
+	report := &consumer.ValidateReport{
+		PerDirection: map[wiretrace.Direction]int{},
+	}
+
+	collect := opts.OutTree != "" || opts.OutParams != ""
+	objects := map[string]consumer.Object{}
+	var order []string
+
+	record := func(m codec.Message) {
+		if !collect {
+			return
+		}
+		if _, seen := objects[m.Address]; !seen {
+			order = append(order, m.Address)
+		}
+		obj := consumer.Object{
+			ID:     len(order) - 1,
+			Path:   splitOSCAddress(m.Address),
+			Label:  m.Address,
+			Access: 0x01, // observed = readable; OSC declares no access model
+			Meta: map[string]any{
+				"address": m.Address,
+				"typetag": string(argTags(m.Args)),
+				"args":    len(m.Args),
+			},
+		}
+		if o, seen := objects[m.Address]; seen {
+			obj.ID = o.ID // keep the first-seen ID stable
+		}
+		if len(m.Args) > 0 {
+			obj.Kind, obj.Value = oscArgToValue(m.Args[0])
+		}
+		objects[m.Address] = obj
+	}
+
+	var walk func(pkt codec.Packet, idx int)
+	walk = func(pkt codec.Packet, idx int) {
+		switch v := pkt.(type) {
+		case codec.Message:
+			record(v)
+			for _, n := range v.Notes {
+				report.Invariants = append(report.Invariants,
+					fmt.Sprintf("trame %d: %s%s", idx, n.Kind, noteDetail(n.Detail)))
+			}
+		case codec.Bundle:
+			// Bundle-level Notes don't exist in the codec today — only
+			// messages carry deviations. Recurse into the elements.
+			for _, el := range v.Elements {
+				walk(el, idx)
+			}
+		}
+	}
+
+	for i, t := range trames {
+		if err := ctx.Err(); err != nil {
+			return report, err
+		}
+		raw, err := hex.DecodeString(t.Hex)
+		if err != nil {
+			report.Errors = append(report.Errors, consumer.ValidateError{
+				TrameIndex: i,
+				Direction:  t.Direction,
+				Err:        fmt.Sprintf("hex decode: %v", err),
+			})
+			continue
+		}
+		pkt, err := decodeOSCTrame(raw)
+		if err != nil {
+			report.Errors = append(report.Errors, consumer.ValidateError{
+				TrameIndex: i,
+				Direction:  t.Direction,
+				HexPrefix:  oscShortHex(raw),
+				Err:        fmt.Sprintf("osc decode: %v", err),
+			})
+			continue
+		}
+
+		report.TramesProcessed++
+		report.PerDirection[t.Direction]++
+		walk(pkt, i)
+
+		if opts.StopAt != "" && t.Note == opts.StopAt {
+			report.StoppedAt = t.Note
+			break
+		}
+	}
+
+	if collect {
+		ordered := make([]consumer.Object, 0, len(order))
+		for _, addr := range order {
+			ordered = append(ordered, objects[addr])
+		}
+		snap := &export.Snapshot{
+			Device: export.DeviceInfo{
+				Protocol: p.version.name(),
+			},
+			Generator: "dhs validate --out-tree (osc)",
+			CreatedAt: time.Now().UTC(),
+			Slots: []export.SlotDump{{
+				Slot:     0,
+				Status:   consumer.SlotPresent.String(),
+				WalkedAt: time.Now().UTC(),
+				Objects:  ordered,
+			}},
+		}
+		if opts.OutTree != "" {
+			if err := writeOSCSnapshot(opts.OutTree, snap, true); err != nil {
+				return report, fmt.Errorf("write out-tree: %w", err)
+			}
+		}
+		if opts.OutParams != "" {
+			if err := writeOSCSnapshot(opts.OutParams, snap, false); err != nil {
+				return report, fmt.Errorf("write out-params: %w", err)
+			}
+		}
+	}
+
+	return report, nil
+}
+
+// decodeOSCTrame decodes one recorded read: a bare UDP packet, an OSC
+// 1.0 length-prefixed TCP read, or an OSC 1.1 SLIP-framed TCP read.
+func decodeOSCTrame(raw []byte) (codec.Packet, error) {
+	if pkt, err := codec.DecodePacket(raw); err == nil {
+		return pkt, nil
+	} else if len(raw) == 0 {
+		return nil, err
+	}
+	// SLIP framing (OSC 1.1 over TCP): frames delimited by 0xC0.
+	if raw[0] == 0xC0 {
+		r := codec.NewSLIPReader(bytes.NewReader(raw), len(raw))
+		inner, rerr := r.ReadPacket()
+		if rerr != nil {
+			return nil, fmt.Errorf("slip unwrap: %w", rerr)
+		}
+		return codec.DecodePacket(inner)
+	}
+	// Length-prefix framing (OSC 1.0 over TCP): int32 size + packet.
+	r := codec.NewLenPrefixReader(bytes.NewReader(raw), len(raw))
+	inner, rerr := r.ReadPacket()
+	if rerr != nil {
+		return nil, fmt.Errorf("len-prefix unwrap: %w", rerr)
+	}
+	return codec.DecodePacket(inner)
+}
+
+// splitOSCAddress maps "/mixer/ch/1/gain" onto the canonical path
+// segments the tree renderer / provider expect.
+func splitOSCAddress(addr string) []string {
+	parts := strings.Split(strings.TrimPrefix(addr, "/"), "/")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	if len(out) == 0 {
+		return []string{addr}
+	}
+	return out
+}
+
+// argTags renders the observed type-tag string ("ifs" …).
+func argTags(args []codec.Arg) []byte {
+	tags := make([]byte, 0, len(args))
+	for _, a := range args {
+		tags = append(tags, a.Tag)
+	}
+	return tags
+}
+
+// oscArgToValue maps one OSC argument onto the canonical Value model.
+func oscArgToValue(a codec.Arg) (consumer.ValueKind, consumer.Value) {
+	switch a.Tag {
+	case 'i':
+		return consumer.KindInt, consumer.Value{Kind: consumer.KindInt, Int: int64(a.Int32)}
+	case 'h':
+		return consumer.KindInt, consumer.Value{Kind: consumer.KindInt, Int: a.Int64}
+	case 'f':
+		return consumer.KindFloat, consumer.Value{Kind: consumer.KindFloat, Float: float64(a.Float32)}
+	case 'd':
+		return consumer.KindFloat, consumer.Value{Kind: consumer.KindFloat, Float: a.Float64}
+	case 's', 'S':
+		return consumer.KindString, consumer.Value{Kind: consumer.KindString, Str: a.String}
+	case 'b':
+		return consumer.KindRaw, consumer.Value{Kind: consumer.KindRaw, Raw: a.Blob}
+	case 't':
+		return consumer.KindUint, consumer.Value{Kind: consumer.KindUint, Uint: a.Uint64}
+	case 'T':
+		return consumer.KindBool, consumer.Value{Kind: consumer.KindBool, Bool: true}
+	case 'F':
+		return consumer.KindBool, consumer.Value{Kind: consumer.KindBool, Bool: false}
+	}
+	// N / I / arrays and future tags: observed but valueless.
+	return consumer.KindUnknown, consumer.Value{Kind: consumer.KindUnknown}
+}
+
+// writeOSCSnapshot writes the aggregated snapshot: forceJSON pins the
+// canonical tree.json shape; otherwise the extension picks the format
+// (.csv → CSV, anything else → JSON), mirroring the export verb.
+func writeOSCSnapshot(path string, snap *export.Snapshot, forceJSON bool) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	if !forceJSON && strings.EqualFold(filepath.Ext(path), ".csv") {
+		return export.WriteCSV(f, snap)
+	}
+	return export.WriteJSON(f, snap)
+}
+
+func noteDetail(detail string) string {
+	if detail == "" {
+		return ""
+	}
+	return " (" + detail + ")"
+}
+
+func oscShortHex(b []byte) string {
+	if len(b) > 16 {
+		b = b[:16]
+	}
+	return hex.EncodeToString(b)
+}

--- a/internal/osc/consumer/validate_test.go
+++ b/internal/osc/consumer/validate_test.go
@@ -1,0 +1,233 @@
+package osc
+
+import (
+	"context"
+	"encoding/hex"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"dhs/internal/consumer"
+	"dhs/internal/osc/codec"
+	"dhs/internal/wiretrace"
+)
+
+func encMsg(t *testing.T, m codec.Message) string {
+	t.Helper()
+	b, err := m.Encode()
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	return hex.EncodeToString(b)
+}
+
+func tr(dir wiretrace.Direction, hexStr string) wiretrace.Trame {
+	return wiretrace.Trame{Direction: dir, Hex: hexStr}
+}
+
+// full-tag message set: every oscArgToValue arm.
+func allTagTrames(t *testing.T) []wiretrace.Trame {
+	t.Helper()
+	msgs := []codec.Message{
+		{Address: "/int", Args: []codec.Arg{codec.Int32(7)}},
+		{Address: "/long", Args: []codec.Arg{{Tag: 'h', Int64: 9}}},
+		{Address: "/f", Args: []codec.Arg{codec.Float32(1.5)}},
+		{Address: "/d", Args: []codec.Arg{{Tag: 'd', Float64: 2.5}}},
+		{Address: "/s", Args: []codec.Arg{codec.String("hi")}},
+		{Address: "/sym", Args: []codec.Arg{{Tag: 'S', String: "sym"}}},
+		{Address: "/b", Args: []codec.Arg{{Tag: 'b', Blob: []byte{1, 2}}}},
+		{Address: "/t", Args: []codec.Arg{{Tag: 't', Uint64: 42}}},
+		{Address: "/on", Args: []codec.Arg{{Tag: 'T'}}},
+		{Address: "/off", Args: []codec.Arg{{Tag: 'F'}}},
+		{Address: "/nil", Args: []codec.Arg{{Tag: 'N'}}},
+		{Address: "/bare"}, // no args — Kind stays unknown
+	}
+	out := make([]wiretrace.Trame, 0, len(msgs))
+	for _, m := range msgs {
+		out = append(out, tr(wiretrace.DirectionRx, encMsg(t, m)))
+	}
+	return out
+}
+
+func newV10(t *testing.T) *Plugin {
+	t.Helper()
+	return NewPluginV10(slog.Default())
+}
+
+func TestValidate_MessagesAndOutputs(t *testing.T) {
+	dir := t.TempDir()
+	tree := filepath.Join(dir, "tree.json")
+	paramsCSV := filepath.Join(dir, "params.csv")
+
+	trames := allTagTrames(t)
+	// Repeat one address: last value wins, ID stays stable.
+	trames = append(trames, tr(wiretrace.DirectionTx, encMsg(t, codec.Message{
+		Address: "/int", Args: []codec.Arg{codec.Int32(8)},
+	})))
+
+	rep, err := newV10(t).Validate(context.Background(), trames, consumer.ValidateOpts{
+		OutTree: tree, OutParams: paramsCSV,
+	})
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if rep.TramesProcessed != len(trames) {
+		t.Fatalf("processed %d, want %d", rep.TramesProcessed, len(trames))
+	}
+	if rep.PerDirection[wiretrace.DirectionRx] != len(trames)-1 || rep.PerDirection[wiretrace.DirectionTx] != 1 {
+		t.Fatalf("per-direction = %+v", rep.PerDirection)
+	}
+	data, err := os.ReadFile(tree)
+	if err != nil {
+		t.Fatalf("out-tree: %v", err)
+	}
+	s := string(data)
+	if !strings.Contains(s, `"osc-v10"`) || !strings.Contains(s, "/int") {
+		t.Fatalf("tree.json missing protocol/address: %s", s[:min(200, len(s))])
+	}
+	if _, err := os.ReadFile(paramsCSV); err != nil {
+		t.Fatalf("out-params: %v", err)
+	}
+}
+
+func TestValidate_BundleRecursion(t *testing.T) {
+	inner, err := (codec.Message{Address: "/a", Args: []codec.Arg{codec.Int32(1)}}).Encode()
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle := codec.Bundle{Timetag: 1}
+	msg, err := codec.DecodeMessage(inner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle.Elements = []codec.Packet{msg, codec.Bundle{Timetag: 2, Elements: []codec.Packet{msg}}}
+	raw, err := bundle.Encode()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rep, err := newV10(t).Validate(context.Background(),
+		[]wiretrace.Trame{tr(wiretrace.DirectionRx, hex.EncodeToString(raw))},
+		consumer.ValidateOpts{OutTree: filepath.Join(t.TempDir(), "t.json")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.TramesProcessed != 1 {
+		t.Fatalf("processed = %d", rep.TramesProcessed)
+	}
+}
+
+func TestValidate_InvariantFromUnknownTag(t *testing.T) {
+	// Hand-built message with tag string ",z" — the codec records
+	// osc_type_tag_unknown as a ComplianceNote instead of failing.
+	raw := append([]byte("/x\x00\x00"), []byte(",z\x00\x00")...)
+	rep, err := newV10(t).Validate(context.Background(),
+		[]wiretrace.Trame{tr(wiretrace.DirectionRx, hex.EncodeToString(raw))},
+		consumer.ValidateOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rep.Invariants) != 1 || !strings.Contains(rep.Invariants[0], "osc_type_tag_unknown") {
+		t.Fatalf("invariants = %v", rep.Invariants)
+	}
+}
+
+func TestValidate_Framings(t *testing.T) {
+	inner, err := (codec.Message{Address: "/tcp", Args: []codec.Arg{codec.Int32(1)}}).Encode()
+	if err != nil {
+		t.Fatal(err)
+	}
+	trames := []wiretrace.Trame{
+		tr(wiretrace.DirectionRx, hex.EncodeToString(codec.EncodeLenPrefix(inner))),
+		tr(wiretrace.DirectionRx, hex.EncodeToString(codec.EncodeSLIP(inner))),
+	}
+	rep, err := newV10(t).Validate(context.Background(), trames, consumer.ValidateOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.TramesProcessed != 2 || len(rep.Errors) != 0 {
+		t.Fatalf("report = %+v", rep)
+	}
+}
+
+func TestValidate_ErrorArms(t *testing.T) {
+	trames := []wiretrace.Trame{
+		{Direction: wiretrace.DirectionRx, Hex: "zz"},               // hex error
+		tr(wiretrace.DirectionRx, "c0ff"),                           // SLIP garbage
+		tr(wiretrace.DirectionRx, "00000010deadbeef"),               // len-prefix truncated
+		tr(wiretrace.DirectionRx, hex.EncodeToString([]byte("Q"))),  // undecodable, non-framed
+		tr(wiretrace.DirectionRx, ""),                               // empty raw
+	}
+	rep, err := newV10(t).Validate(context.Background(), trames, consumer.ValidateOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.TramesProcessed != 0 || len(rep.Errors) != len(trames) {
+		t.Fatalf("report = %+v", rep)
+	}
+}
+
+func TestValidate_StopAtAndCancel(t *testing.T) {
+	m := encMsg(t, codec.Message{Address: "/a", Args: []codec.Arg{codec.Int32(1)}})
+	trames := []wiretrace.Trame{
+		{Direction: wiretrace.DirectionRx, Hex: m, Note: "here"},
+		tr(wiretrace.DirectionRx, m),
+	}
+	rep, err := newV10(t).Validate(context.Background(), trames, consumer.ValidateOpts{StopAt: "here"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.StoppedAt != "here" || rep.TramesProcessed != 1 {
+		t.Fatalf("stop-at report = %+v", rep)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := newV10(t).Validate(ctx, trames, consumer.ValidateOpts{}); err == nil {
+		t.Fatal("cancelled ctx must surface")
+	}
+}
+
+func TestValidate_OutputWriteErrors(t *testing.T) {
+	m := encMsg(t, codec.Message{Address: "/a", Args: []codec.Arg{codec.Int32(1)}})
+	bad := filepath.Join(t.TempDir(), "no", "such", "dir", "x.json")
+	if _, err := newV10(t).Validate(context.Background(),
+		[]wiretrace.Trame{tr(wiretrace.DirectionRx, m)},
+		consumer.ValidateOpts{OutTree: bad}); err == nil || !strings.Contains(err.Error(), "out-tree") {
+		t.Fatalf("want out-tree write error, got %v", err)
+	}
+	if _, err := newV10(t).Validate(context.Background(),
+		[]wiretrace.Trame{tr(wiretrace.DirectionRx, m)},
+		consumer.ValidateOpts{OutParams: bad}); err == nil || !strings.Contains(err.Error(), "out-params") {
+		t.Fatalf("want out-params write error, got %v", err)
+	}
+}
+
+func TestSplitOSCAddress(t *testing.T) {
+	if got := splitOSCAddress("/mixer/ch/1"); len(got) != 3 || got[0] != "mixer" {
+		t.Fatalf("split = %v", got)
+	}
+	if got := splitOSCAddress("/"); len(got) != 1 || got[0] != "/" {
+		t.Fatalf("degenerate split = %v", got)
+	}
+}
+
+func TestOSCHelperEdges(t *testing.T) {
+	if noteDetail("") != "" || noteDetail("x") != " (x)" {
+		t.Fatal("noteDetail")
+	}
+	if len(oscShortHex(make([]byte, 40))) != 32 {
+		t.Fatal("oscShortHex clamp")
+	}
+	if k, _ := oscArgToValue(codec.Arg{Tag: '?'}); k != consumer.KindUnknown {
+		t.Fatal("unknown tag kind")
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
## What

`validate` for osc (both versions) with a working `--out-tree`: decode a captured `frames.jsonl` offline through the codec and aggregate the observed OSC address space into a canonical snapshot `tree.json`.

## Why

#243 (osc leg — owner "do it"). osc had no `consumer.Validator` at all; the verb wasn't even dispatched. With this, a live OSC capture becomes a replayable address catalogue — the same capture→oracle chain as the other connectors, and the discovery tool OSC needs (its address space is otherwise invisible without vendor docs).

Part of #243 — remaining legs recorded there (tsl `--out-tree` is itself still a stub; cerebrum-nb `validate` is proposed with D2).

## Scope

- [ ] acp1
- [ ] acp2
- [ ] emberplus
- [ ] probel-sw08p / probel-sw02p
- [x] osc / tsl / cerebrum-nb / amwa
- [ ] transport
- [ ] export
- [x] cli
- [ ] api
- [ ] core
- [ ] ci / chore

**Cross-protocol changes**: none — osc consumer + one dispatch case in `cmd_osc.go` routing to the existing generic `runValidate`.

## Wire evidence (protocol changes only)

Offline decoder only — no wire behavior change. Framing coverage pinned by tests: bare UDP packets, OSC 1.0 TCP length-prefix, OSC 1.1 SLIP (both unwrapped transparently), recursive bundles, and the `osc_type_tag_unknown` compliance note surfaced as an invariant.

## Reference controller

- [ ] Cerebrum still happy after this change
- [ ] VSM Studio still happy after this change
- [x] N/A (no protocol behaviour change)

## Type

- [x] feat — new feature
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] chore — maintenance, refactor, CI
- [ ] security — security fix or hardening

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `internal/osc/consumer/validate.go` | new | `consumer.Validator` implementation: per-direction counts, invariants from ComplianceNotes, `--stop-at`, transparent len-prefix/SLIP unwrap, `--out-tree` (observed addresses → canonical objects, last value wins, stable IDs) + `--out-params` (.csv/JSON) |
| `internal/osc/consumer/validate_test.go` | new | table-driven: every arg-tag mapping, bundle recursion, all framings, all error arms, stop-at/cancel, output write errors, helpers |
| `cmd/dhs/cmd_osc.go` | modified | `validate` case dispatching to the generic runner |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test ./internal/osc/consumer/... ./cmd/dhs/...` | ok | 0 |
| coverage floor `internal/osc/consumer` | **100.0%** (all new functions 100%) | — |
| `go vet ./...` | clean | — |
| `golangci-lint run` | clean (pre-commit) | — |

## Device tested

- [ ] ACP1 producer 10.100.0.102
- [ ] ACP2 producer 10.100.0.103
- [ ] ACP1 emulator 10.6.239.113
- [ ] ACP2 real device 10.41.40.195
- [ ] Other (specify)
- [x] No device needed (pure codec / doc change)

Offline decode of codec-encoded fixtures (spec-derived bytes); live captures come free once any OSC peer session runs with `--capture`.

**Live-LXC command + observed output** (paste verbatim):

```text
dhs consumer osc-v10 validate frames.jsonl --out-tree tree.json
# expected: "validate: N trames decoded" + tree.json carrying the observed address space
```

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [ ] Integration tested on VM before PR (offline verb; fixtures are codec-generated spec bytes)

## Approval

@yboujraf — requesting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
