### PR TITLE
feat(manifest): IP-keyed manifests per ADR-0028 (#703 unit 1)

### DIFF
--- a/cmd/dhs/cmd_cerebrum_extract.go
+++ b/cmd/dhs/cmd_cerebrum_extract.go
@@ -20,7 +20,7 @@ import (
 // obtains and persist the ADR-0022 card data model + manifest:
 //
 //	.cache/dm/cerebrum-nb/<Model@SwRev>.json   flat canonical Objects
-//	.cache/manifest/<device-slug>.json         device → sub-device → DM ref
+//	.cache/manifest/cerebrum-nb/<ip>.json      device → sub-device → DM ref (ADR-0028 IP key)
 //
 // The walk contract is `tree --device`'s, verbatim (seeded start
 // groups, recursion into group candidates, self-echo leaf
@@ -133,8 +133,18 @@ func cerebrumExtract(ctx context.Context, args []string) error {
 		objs = append(objs, cerebrum.CanonicalDeviceObject("", "", &rows[i], i))
 	}
 
+	// ADR-0028 manifest key = the device's OWN IP (never the NB server
+	// endpoint — every device behind one Cerebrum would collide on it).
+	// Known only when --device was addressed by IP; the by-name form
+	// falls back to the name slug, loudly.
+	deviceIP := ""
+	if !*byName {
+		deviceIP = *device
+	} else {
+		fmt.Fprintf(os.Stderr, "cerebrum-nb extract: NOTE — manifest keyed by name slug (device IP unknown when addressing --by-name); address --device by IP for the IP-keyed manifest (ADR-0028)\n")
+	}
 	identity := model + "@" + swRev
-	dmPath, mfPath, err := writeCerebrumExtract(identity, deviceName, host, port, *subDev, objs)
+	dmPath, mfPath, err := writeCerebrumExtract(identity, deviceName, deviceIP, host, port, *subDev, objs)
 	if err != nil {
 		return err
 	}
@@ -281,7 +291,7 @@ func cerebrumObtainIdentityLeaf(sess *cerebrum.Session, timeout time.Duration, d
 //
 // Pure persistence — no wire I/O — so tests drive it with fabricated
 // rows against a temp store.
-func writeCerebrumExtract(identity, deviceName, host string, port int, subDev string, objs []consumer.Object) (dmPath, mfPath string, err error) {
+func writeCerebrumExtract(identity, deviceName, deviceIP, host string, port int, subDev string, objs []consumer.Object) (dmPath, mfPath string, err error) {
 	if treeStore == nil {
 		return "", "", fmt.Errorf("cerebrum-nb extract: tree store not initialised (.cache unavailable)")
 	}
@@ -296,10 +306,12 @@ func writeCerebrumExtract(identity, deviceName, host string, port int, subDev st
 	mf := &manifest.Manifest{
 		Device: manifest.Device{
 			// Name is the exact wire DEVICE_NAME (incl. the live
-			// trailing-whitespace quirk); the slug sanitises it for
-			// the filename, Addr keeps it verbatim for addressing.
+			// trailing-whitespace quirk) trimmed for display; Addr
+			// keeps it verbatim for addressing. IP is the ADR-0028
+			// file key — the device's own IP, not the NB endpoint.
 			Name:     strings.TrimSpace(deviceName),
 			Protocol: "cerebrum-nb",
+			IP:       deviceIP,
 			Endpoints: []manifest.Endpoint{
 				// The endpoint is the Cerebrum NB server we consume
 				// through — devices are reached via the control

--- a/cmd/dhs/cmd_cerebrum_extract_test.go
+++ b/cmd/dhs/cmd_cerebrum_extract_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -54,10 +55,14 @@ func TestWriteCerebrumExtract(t *testing.T) {
 		Value: consumer.Value{Kind: consumer.KindFloat, Float: 5.5},
 	}}
 	// Trailing space on the wire name — the manifest Name is trimmed,
-	// the Addr keeps the verbatim form for addressing.
-	dmPath, mfPath, err := writeCerebrumExtract("SHPRM1@5.3.5", "cvt 1 ", "10.44.55.39", 40009, "1", objs)
+	// the Addr keeps the verbatim form for addressing. The manifest
+	// file key is the DEVICE's own IP (ADR-0028), not the NB endpoint.
+	dmPath, mfPath, err := writeCerebrumExtract("SHPRM1@5.3.5", "cvt 1 ", "10.44.72.28", "10.44.55.39", 40009, "1", objs)
 	if err != nil {
 		t.Fatalf("writeCerebrumExtract: %v", err)
+	}
+	if !strings.HasSuffix(mfPath, filepath.Join("manifest", "cerebrum-nb", "10.44.72.28.json")) {
+		t.Fatalf("manifest not IP-keyed per ADR-0028: %s", mfPath)
 	}
 
 	dm, err := os.ReadFile(dmPath)
@@ -73,7 +78,7 @@ func TestWriteCerebrumExtract(t *testing.T) {
 	if err != nil {
 		t.Fatalf("manifest file: %v", err)
 	}
-	for _, want := range []string{`"cvt 1"`, `"cvt 1 "`, `"sub_device": "1"`, `"SHPRM1@5.3.5.json"`, `"10.44.55.39"`, `40009`} {
+	for _, want := range []string{`"cvt 1"`, `"cvt 1 "`, `"sub_device": "1"`, `"SHPRM1@5.3.5.json"`, `"10.44.55.39"`, `40009`, `"ip": "10.44.72.28"`} {
 		if !strings.Contains(string(mf), want) {
 			t.Fatalf("manifest missing %s:\n%s", want, mf)
 		}
@@ -87,15 +92,15 @@ func TestWriteCerebrumExtract_Errors(t *testing.T) {
 	t.Cleanup(func() { treeStore = prev })
 
 	treeStore = nil
-	if _, _, err := writeCerebrumExtract("X@1", "d", "h", 1, "1", nil); err == nil || !strings.Contains(err.Error(), "not initialised") {
+	if _, _, err := writeCerebrumExtract("X@1", "d", "", "h", 1, "1", nil); err == nil || !strings.Contains(err.Error(), "not initialised") {
 		t.Fatalf("nil store: %v", err)
 	}
 
 	treeStore = datastore.NewTreeStore(t.TempDir())
-	if _, _, err := writeCerebrumExtract("", "d", "h", 1, "1", nil); err == nil || !strings.Contains(err.Error(), "write DM") {
+	if _, _, err := writeCerebrumExtract("", "d", "", "h", 1, "1", nil); err == nil || !strings.Contains(err.Error(), "write DM") {
 		t.Fatalf("empty identity: %v", err)
 	}
-	if _, _, err := writeCerebrumExtract("X@1", "", "h", 1, "1", nil); err == nil || !strings.Contains(err.Error(), "write manifest") {
+	if _, _, err := writeCerebrumExtract("X@1", "", "", "h", 1, "1", nil); err == nil || !strings.Contains(err.Error(), "write manifest") {
 		t.Fatalf("empty device name: %v", err)
 	}
 }

--- a/cmd/dhs/cmd_watch.go
+++ b/cmd/dhs/cmd_watch.go
@@ -763,8 +763,9 @@ func fallbackIdentity(host string) string {
 // acp* / probel; emberplus uses splitDMByMatrix directly because its
 // "slots" are derived from a single Walk's canonical tree.
 //
-// deviceName is the human-readable label that becomes the manifest
-// slug (.cache/manifest/<slug>.json); when empty, derives from the
+// deviceName is the human-readable device label stored in the
+// manifest (the file itself is IP-keyed per ADR-0028:
+// .cache/manifest/<proto>/<ip>.json); when empty, derives from the
 // first identity's Model part.
 type slotBinding struct {
 	Slot     int
@@ -786,6 +787,9 @@ func writeSlotManifest(deviceName, proto, host string, port int, bindings []slot
 		Device: manifest.Device{
 			Name:     deviceName,
 			Protocol: proto,
+			// Direct protocols: the device IS the endpoint — its host
+			// IP is the ADR-0028 identity key.
+			IP: host,
 			Endpoints: []manifest.Endpoint{
 				{IP: host, Port: port, Transport: defaultTransportFor(proto)},
 			},
@@ -882,7 +886,7 @@ func saveIdentityCache(store *datastore.TreeStore, identity, host, proto string,
 // walkSlotAndCache after the full provider DM lands; emits one
 // additional DM per slot-worthy root child so each matrix / function
 // subtree gets its own file under .cache/dm/emberplus/. Also writes
-// a manifest at .cache/manifest/<device-slug>.json so a future
+// a manifest at .cache/manifest/<proto>/<ip>.json (ADR-0028) so a future
 // consumer can resolve host:port → slot DMs without re-walking.
 // Quiet on success; warns on per-slot save errors.
 type dmSplitter interface {
@@ -916,6 +920,7 @@ func splitDMByMatrix(ctx context.Context, plug consumer.Protocol, host string, p
 		Device: manifest.Device{
 			Name:     deviceName,
 			Protocol: "emberplus",
+			IP:       host, // direct protocol: device == endpoint (ADR-0028 key)
 			Endpoints: []manifest.Endpoint{
 				{IP: host, Port: port, Transport: "tcp"},
 			},

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -142,7 +142,35 @@ func TestWrite(t *testing.T) {
 			t.Fatal("expected error for empty device name")
 		}
 	})
-	t.Run("success and slugify", func(t *testing.T) {
+	t.Run("empty protocol", func(t *testing.T) {
+		m := validManifest()
+		m.Device.Protocol = ""
+		if _, err := Write(t.TempDir(), m); err == nil {
+			t.Fatal("expected error for empty protocol (ADR-0028 key)")
+		}
+	})
+	t.Run("ip key (ADR-0028)", func(t *testing.T) {
+		cache := t.TempDir()
+		m := validManifest()
+		m.Device.IP = "10.100.0.103"
+		m.Device.FQDN = "neuron-test.plant.example"
+		path, err := Write(cache, m)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := filepath.Join(cache, "manifest", "acp2", "10.100.0.103.json")
+		if path != want {
+			t.Fatalf("path = %q, want %q", path, want)
+		}
+		got, err := Load(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Device.IP != "10.100.0.103" || got.Device.FQDN != "neuron-test.plant.example" {
+			t.Fatalf("ip/fqdn round-trip: %+v", got.Device)
+		}
+	})
+	t.Run("name-slug fallback when no IP", func(t *testing.T) {
 		cache := t.TempDir()
 		m := validManifest()
 		m.Device.Name = "Tiny Ember+ Router"
@@ -150,12 +178,43 @@ func TestWrite(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		want := filepath.Join(cache, "manifest", "tiny-ember-router.json")
+		want := filepath.Join(cache, "manifest", "acp2", "tiny-ember-router.json")
 		if path != want {
 			t.Fatalf("path = %q, want %q", path, want)
 		}
 		if _, err := os.Stat(path); err != nil {
 			t.Fatalf("file not written: %v", err)
+		}
+	})
+	t.Run("legacy name-keyed manifest migrated", func(t *testing.T) {
+		cache := t.TempDir()
+		// Old layout: manifest/<name-slug>.json with a different endpoint.
+		legacyDir := filepath.Join(cache, "manifest")
+		if err := os.MkdirAll(legacyDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		legacy := validManifest()
+		legacy.Device.Endpoints = []Endpoint{{IP: "10.100.0.109", Port: 2072, Transport: "tcp"}}
+		b, _ := json.Marshal(legacy)
+		legacyPath := filepath.Join(legacyDir, "neuron-test.json")
+		if err := os.WriteFile(legacyPath, b, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		m := validManifest()
+		m.Device.IP = "10.100.0.103"
+		path, err := Write(cache, m)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err := Load(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got.Device.Endpoints) != 2 {
+			t.Fatalf("legacy endpoints not merged: %+v", got.Device.Endpoints)
+		}
+		if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+			t.Fatalf("legacy file not retired: %v", err)
 		}
 	})
 	t.Run("merge unions endpoints", func(t *testing.T) {
@@ -193,7 +252,7 @@ func TestWrite(t *testing.T) {
 	})
 	t.Run("create error", func(t *testing.T) {
 		cache := t.TempDir()
-		dir := filepath.Join(cache, "manifest")
+		dir := filepath.Join(cache, "manifest", "acp2")
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatal(err)
 		}
@@ -207,7 +266,7 @@ func TestWrite(t *testing.T) {
 	})
 	t.Run("rename error", func(t *testing.T) {
 		cache := t.TempDir()
-		dir := filepath.Join(cache, "manifest")
+		dir := filepath.Join(cache, "manifest", "acp2")
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatal(err)
 		}

--- a/internal/manifest/types.go
+++ b/internal/manifest/types.go
@@ -14,8 +14,19 @@ type Manifest struct {
 
 // Device identifies one physical unit + its network endpoints.
 type Device struct {
-	Name      string     `json:"name"`
-	Protocol  string     `json:"protocol"`
+	Name     string `json:"name"`
+	Protocol string `json:"protocol"`
+	// IP is the device's own identity IP — the manifest FILE KEY per
+	// ADR-0028 (unique + static in the plant; rename-proof where
+	// names are not). Distinct from Endpoints (reachability): a
+	// device behind a control plane (cerebrum-nb) is reached via the
+	// server endpoint but keyed by its own IP. Empty IP falls back to
+	// the slugified Name (the ADR's IP-less edge case — callers warn).
+	IP string `json:"ip,omitempty"`
+	// FQDN is optional metadata only (ADR-0028: the devops direction,
+	// recorded now so a later DNS migration is a re-key script, not a
+	// schema change). NEVER a key.
+	FQDN      string     `json:"fqdn,omitempty"`
 	Endpoints []Endpoint `json:"endpoints"`
 }
 

--- a/internal/manifest/write.go
+++ b/internal/manifest/write.go
@@ -5,19 +5,27 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
-// Write serialises a Manifest to .cache/manifest/<device-slug>.json
-// atomically (tmp file + rename). Protocol-agnostic — same writer
-// serves emberplus, acp1, acp2, probel, future TSL / OSC.
+// Write serialises a Manifest to .cache/manifest/<proto>/<key>.json
+// atomically (tmp file + rename), where key is the device's identity
+// IP (ADR-0028), falling back to the slugified device name when no IP
+// is known (the IP-less edge case — callers warn loudly). Protocol-
+// agnostic — same writer serves emberplus, acp1, acp2, probel,
+// cerebrum-nb, future TSL / OSC.
 //
-// Merge behaviour: if a manifest already exists for this device slug,
+// Merge behaviour: if a manifest already exists for this key,
 // endpoints from the existing file are unioned with m.Device.Endpoints
 // (dedup by ip+port+transport). This is the redundant-controller path
 // — running `dhs watch` against the device's primary IP, then again
 // against the backup IP, accumulates both endpoints in one manifest.
 // Frames and slots are replaced wholesale by the new write (the
 // schema authority is the most recent walk).
+//
+// Legacy migration (pre-ADR-0028 layout, manifest/<name-slug>.json
+// with no proto subfolder): read once, endpoints merged in, legacy
+// file removed after the new write succeeds.
 //
 // Test seams for the two I/O arms that cannot be provoked through the
 // filesystem: a Manifest is always JSON-encodable so enc.Encode never
@@ -34,12 +42,26 @@ func Write(cacheDir string, m *Manifest) (string, error) {
 	if m == nil || m.Device.Name == "" {
 		return "", fmt.Errorf("manifest: Write: device name required")
 	}
-	slug := slugifyDeviceName(m.Device.Name)
-	dir := filepath.Join(cacheDir, "manifest")
+	if m.Device.Protocol == "" {
+		return "", fmt.Errorf("manifest: Write: device protocol required (the ADR-0028 key is manifest/<proto>/<ip>.json)")
+	}
+	key := m.Device.IP
+	if key == "" {
+		key = slugifyDeviceName(m.Device.Name)
+	}
+	dir := filepath.Join(cacheDir, "manifest", sanitizeKeySeg(m.Device.Protocol))
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", fmt.Errorf("manifest: mkdir %s: %w", dir, err)
 	}
-	path := filepath.Join(dir, slug+".json")
+	path := filepath.Join(dir, sanitizeKeySeg(key)+".json")
+
+	// Legacy migration: the pre-ADR-0028 name-keyed file (no proto
+	// subfolder). Its endpoints join the union; the file is removed
+	// after the new write lands.
+	legacy := filepath.Join(cacheDir, "manifest", slugifyDeviceName(m.Device.Name)+".json")
+	if prior, perr := Load(legacy); perr == nil && prior != nil {
+		m.Device.Endpoints = mergeEndpoints(prior.Device.Endpoints, m.Device.Endpoints)
+	}
 
 	// Endpoint merge: load existing if present, union with new.
 	if prior, perr := Load(path); perr == nil && prior != nil {
@@ -66,7 +88,23 @@ func Write(cacheDir string, m *Manifest) (string, error) {
 		_ = os.Remove(tmp)
 		return "", fmt.Errorf("manifest: rename: %w", err)
 	}
+	// New write landed — retire the legacy name-keyed file (read-once-
+	// rewritten per ADR-0028). Best-effort: a leftover legacy file is
+	// re-merged on the next write, never lost.
+	if legacy != path {
+		_ = os.Remove(legacy)
+	}
 	return path, nil
+}
+
+// sanitizeKeySeg strips characters that are illegal in filenames on
+// Windows + POSIX so IPs (IPv6 colons), protocol names and name-slug
+// fallbacks go to disk safely.
+func sanitizeKeySeg(s string) string {
+	for _, ch := range []string{"/", "\\", ":", "*", "?", "\"", "<", ">", "|"} {
+		s = strings.ReplaceAll(s, ch, "_")
+	}
+	return s
 }
 
 // mergeEndpoints unions prior + incoming, dedup by (ip, port,


### PR DESCRIPTION
Unit 1 of #703 (ADR-0028 artifact layout): the manifest file key becomes the device identity IP - manifest/<proto>/<ip>.json - with FQDN as metadata, name-slug fallback (loud) for IP-less targets, one manifest per device for redundant controllers, and read-once retirement of legacy name-keyed files. Full test suite green; manifest package arms covered (IP key, fallback, legacy migration, FQDN round-trip, empty-protocol guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)