### PR TITLE
feat(cmd): ADR-0028 deterministic default homes (#703 unit 2a)

### DIFF
--- a/cmd/dhs/artifact_paths.go
+++ b/cmd/dhs/artifact_paths.go
@@ -1,0 +1,95 @@
+package main
+
+// ADR-0028 path composer — the ONE place default artifact homes are
+// built. Every verb that lets a flag default composes here; unit-5 CI
+// tests pin each composed shape to the ADR table, so layout drift
+// fails the build instead of scattering files.
+//
+//	snapshots/<proto>/<key>/<facet>            operator state (export/import)
+//	captures/<proto>/<key>/<verb>[-<scope>]-<utcstamp>.jsonl   wire evidence
+//	.cache/logs/<proto>/<key>/<verb>.log       disposable diagnostics
+//
+// key = the device identity IP (the RM sentinel 0.0.0.0 included);
+// name-slug only where no IP exists (callers warn loudly).
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"dhs/internal/datastore"
+)
+
+// artifactRoot resolves the ADR-0028 bucket root (the directory
+// .cache/, snapshots/ and captures/ are siblings under). Falls back
+// to the current directory when the binary path cannot be resolved —
+// deterministic either way, never silent.
+func artifactRoot() string {
+	root, err := datastore.ProjectRoot()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: artifact root: %v — using current directory\n", err)
+		return "."
+	}
+	return root
+}
+
+// snapshotDir returns snapshots/<proto>/<key>/ — the one folder per
+// device that holds every state facet (params/xpoint/src/dst/…).
+func snapshotDir(proto, key string) string {
+	return filepath.Join(artifactRoot(), "snapshots",
+		datastore.SanitizePathSeg(proto), datastore.SanitizePathSeg(key))
+}
+
+// defaultCapturePath returns captures/<proto>/<key>/<verb>[-<scope>]-
+// <utcstamp>.jsonl — the self-describing wire-evidence location.
+func defaultCapturePath(proto, key, verb, scope string, now time.Time) string {
+	name := datastore.SanitizePathSeg(verb)
+	if scope != "" {
+		name += "-" + datastore.SanitizePathSeg(scope)
+	}
+	name += "-" + now.UTC().Format("20060102T1504Z") + ".jsonl"
+	return filepath.Join(artifactRoot(), "captures",
+		datastore.SanitizePathSeg(proto), datastore.SanitizePathSeg(key), name)
+}
+
+// defaultLogPath returns .cache/logs/<proto>/<key>/<verb>.log —
+// disposable diagnostics in the machine bucket.
+func defaultLogPath(proto, key, verb string) string {
+	return filepath.Join(artifactRoot(), ".cache", "logs",
+		datastore.SanitizePathSeg(proto), datastore.SanitizePathSeg(key),
+		datastore.SanitizePathSeg(verb)+".log")
+}
+
+// cerebrumExpandAutoPaths resolves the "auto" sentinel on --capture /
+// --log to the ADR-0028 defaults (verb-aware, keyed by the NB server
+// host we dial), creating parent directories. Called by every
+// cerebrum dial path before the logger / recorder open.
+func cerebrumExpandAutoPaths(cf *cerebrumFlags, verb, host string) {
+	if cf.capture == "auto" {
+		cf.capture = defaultCapturePath("cerebrum-nb", host, verb, "", time.Now())
+		_ = os.MkdirAll(filepath.Dir(cf.capture), 0o755)
+		fmt.Fprintf(os.Stderr, "cerebrum-nb %s: --capture auto → %s (ADR-0028)\n", verb, cf.capture)
+	}
+	if cf.logPath == "auto" {
+		cf.logPath = defaultLogPath("cerebrum-nb", host, verb)
+		_ = os.MkdirAll(filepath.Dir(cf.logPath), 0o755)
+		fmt.Fprintf(os.Stderr, "cerebrum-nb %s: --log auto → %s (ADR-0028)\n", verb, cf.logPath)
+	}
+}
+
+// facetName renders a facet filename. With a prefix the legacy
+// "<prefix>-<facet>.csv" shape is kept (explicit --out-dir/--in-dir
+// compatibility); the default snapshot folder uses the plain ADR
+// shape "<facet>.csv" — the folder already identifies the device.
+func facetName(prefix, facet string) string {
+	if prefix != "" {
+		return prefix + "-" + facet + ".csv"
+	}
+	return facet + ".csv"
+}
+
+// facetFile joins facetName inside dir.
+func facetFile(dir, prefix, facet string) string {
+	return filepath.Join(dir, facetName(prefix, facet))
+}

--- a/cmd/dhs/artifact_paths_test.go
+++ b/cmd/dhs/artifact_paths_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The ADR-0028 path-composer pins (unit-5 layer): every composed
+// default must match the ADR table shapes exactly — layout drift
+// fails the build here, not in the field.
+func TestArtifactPaths_ADR0028Shapes(t *testing.T) {
+	ts := time.Date(2026, 8, 17, 21, 30, 0, 0, time.UTC)
+
+	if got := snapshotDir("cerebrum-nb", "0.0.0.0"); !strings.HasSuffix(got,
+		filepath.Join("snapshots", "cerebrum-nb", "0.0.0.0")) {
+		t.Fatalf("snapshotDir RM = %q", got)
+	}
+	if got := snapshotDir("acp2", "10.44.72.28"); !strings.HasSuffix(got,
+		filepath.Join("snapshots", "acp2", "10.44.72.28")) {
+		t.Fatalf("snapshotDir device = %q", got)
+	}
+
+	if got := defaultCapturePath("cerebrum-nb", "10.44.55.39", "export", "rm", ts); !strings.HasSuffix(got,
+		filepath.Join("captures", "cerebrum-nb", "10.44.55.39", "export-rm-20260817T2130Z.jsonl")) {
+		t.Fatalf("capture path with scope = %q", got)
+	}
+	if got := defaultCapturePath("acp1", "10.100.0.103", "walk", "", ts); !strings.HasSuffix(got,
+		filepath.Join("captures", "acp1", "10.100.0.103", "walk-20260817T2130Z.jsonl")) {
+		t.Fatalf("capture path no scope = %q", got)
+	}
+
+	if got := defaultLogPath("cerebrum-nb", "10.44.55.39", "import"); !strings.HasSuffix(got,
+		filepath.Join(".cache", "logs", "cerebrum-nb", "10.44.55.39", "import.log")) {
+		t.Fatalf("log path = %q", got)
+	}
+
+	// IPv6 / Windows-illegal characters sanitise, never split paths.
+	if got := snapshotDir("amwa", "fd00::1"); strings.Contains(filepath.Base(got), ":") {
+		t.Fatalf("IPv6 key not sanitised: %q", got)
+	}
+}
+
+func TestFacetFile(t *testing.T) {
+	if got := facetFile("d", "", "xpoint"); got != filepath.Join("d", "xpoint.csv") {
+		t.Fatalf("plain facet = %q", got)
+	}
+	if got := facetFile("d", "noc", "xpoint"); got != filepath.Join("d", "noc-xpoint.csv") {
+		t.Fatalf("prefixed facet = %q", got)
+	}
+}

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -80,8 +80,8 @@ func newCerebrumFlags(fs *flag.FlagSet) *cerebrumFlags {
 	fs.BoolVar(&c.tls, "tls", false, "use wss:// instead of ws://")
 	fs.BoolVar(&c.insecure, "insecure-skip-verify", false, "with --tls, skip TLS cert verification")
 	fs.BoolVar(&c.debug, "debug", false, "verbose RX/TX XML logging")
-	fs.StringVar(&c.logPath, "log", "", "write the diagnostic log (incl. RX/TX XML at full debug verbosity) to this file — clean UTF-8, no PowerShell 2> stderr wrapping; stderr stays silent")
-	fs.StringVar(&c.capture, "capture", "", "record every TX/RX XML document (ws text payload) to this JSONL wire-trace — the same --capture contract as every other connector (WARNING: contains the LOGIN frame in cleartext, treat as secret)")
+	fs.StringVar(&c.logPath, "log", "", "write the diagnostic log (incl. RX/TX XML at full debug verbosity) to this file — clean UTF-8, no PowerShell 2> stderr wrapping; stderr stays silent. Literal \"auto\" = .cache/logs/cerebrum-nb/<host>/<verb>.log (ADR-0028)")
+	fs.StringVar(&c.capture, "capture", "", "record every TX/RX XML document (ws text payload) to this JSONL wire-trace — the same --capture contract as every other connector (WARNING: contains the LOGIN frame in cleartext, treat as secret). Literal \"auto\" = captures/cerebrum-nb/<host>/<verb>-<utcstamp>.jsonl (ADR-0028)")
 	fs.DurationVar(&c.timeout, "timeout", 5*time.Second, "per-request timeout")
 	return c
 }
@@ -378,6 +378,7 @@ func dialCerebrum(cf *cerebrumFlags, positionals []string, verb string) (*cerebr
 		return nil, nil, nil, err
 	}
 	cf.port = portArg
+	cerebrumExpandAutoPaths(cf, verb, host)
 
 	logger, _, lerr := cf.newLogger()
 	if lerr != nil {

--- a/cmd/dhs/cmd_cerebrum_export_device.go
+++ b/cmd/dhs/cmd_cerebrum_export_device.go
@@ -67,6 +67,11 @@ func cerebrumExportDevice(sess *cerebrum.Session, cf *cerebrumFlags, device stri
 
 	var w io.Writer = os.Stdout
 	if out != "" {
+		if dir := filepath.Dir(out); dir != "." {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return fmt.Errorf("create %s: %w", dir, err)
+			}
+		}
 		f, ferr := os.Create(out)
 		if ferr != nil {
 			return fmt.Errorf("create %s: %w", out, ferr)

--- a/cmd/dhs/cmd_cerebrum_list_mne.go
+++ b/cmd/dhs/cmd_cerebrum_list_mne.go
@@ -48,6 +48,7 @@ func cerebrumListMne(_ context.Context, args []string, mneType, keyCol string) e
 		return err
 	}
 	cf.port = portArg
+	cerebrumExpandAutoPaths(cf, "list-mne", host)
 
 	p, err := cerebrumDial(cf, host)
 	if err != nil {

--- a/cmd/dhs/cmd_cerebrum_xpoint.go
+++ b/cmd/dhs/cmd_cerebrum_xpoint.go
@@ -258,34 +258,45 @@ func cerebrumImportXpoint(_ context.Context, args []string) error {
 	if xp == "" {
 		xp = *csvPath
 	}
+	// ADR-0028 default home: no per-file flags and no --in-dir → read
+	// from the router's snapshot folder (exactly where the defaulted
+	// export writes, plain facet names). Import reads where export
+	// writes — neither picks a location.
+	if *inDir == "" && *deviceName == "" &&
+		xp == "" && *srcPath == "" && *dstPath == "" && *lvlPath == "" && *lockPath == "" &&
+		*catSrcPath == "" && *catDstPath == "" && *catMixedPath == "" {
+		*inDir = snapshotDir("cerebrum-nb", *router)
+		*prefix = ""
+		fmt.Fprintf(os.Stderr, "cerebrum-nb import: default snapshot folder %s (ADR-0028)\n", *inDir)
+	}
 	if *inDir != "" {
 		// Mirror export --out-dir: resolve every role not given explicitly to
-		// <in-dir>/<prefix>-<role>.csv, keeping only files that exist —
+		// <in-dir>/<facet file>, keeping only files that exist —
 		// missing files stay out of scope (partial-import semantics).
-		resolve := func(target *string, suffix string) {
+		resolve := func(target *string, facet string) {
 			if *target != "" {
 				return
 			}
-			p := filepath.Join(*inDir, *prefix+suffix)
+			p := facetFile(*inDir, *prefix, facet)
 			if _, err := os.Stat(p); err == nil {
 				*target = p
 			}
 		}
-		resolve(&xp, "-xpoint.csv")
-		resolve(srcPath, "-src.csv")
-		resolve(dstPath, "-dst.csv")
-		resolve(lvlPath, "-level.csv")
-		resolve(lockPath, "-lock.csv")
+		resolve(&xp, "xpoint")
+		resolve(srcPath, "src")
+		resolve(dstPath, "dst")
+		resolve(lvlPath, "level")
+		resolve(lockPath, "lock")
 		if nonRMTarget {
 			// The dir may hold a full RM export set — its cat files are out
 			// of scope for a physical-router import, never an error.
-			if _, err := os.Stat(filepath.Join(*inDir, *prefix+"-cat-src.csv")); err == nil {
-				fmt.Fprintf(os.Stderr, "cerebrum-nb import: physical-router target — %s-cat-*.csv in %s skipped (categories are route-master-only)\n", *prefix, *inDir)
+			if _, err := os.Stat(facetFile(*inDir, *prefix, "cat-src")); err == nil {
+				fmt.Fprintf(os.Stderr, "cerebrum-nb import: physical-router target — cat-*.csv in %s skipped (categories are route-master-only)\n", *inDir)
 			}
 		} else {
-			resolve(catSrcPath, "-cat-src.csv")
-			resolve(catDstPath, "-cat-dst.csv")
-			resolve(catMixedPath, "-cat-mixed.csv")
+			resolve(catSrcPath, "cat-src")
+			resolve(catDstPath, "cat-dst")
+			resolve(catMixedPath, "cat-mixed")
 		}
 		fmt.Fprintf(os.Stderr, "cerebrum-nb import: --in-dir resolved xpoint=%s src=%s dst=%s levels=%s lock=%s cat-src=%s cat-dst=%s cat-mixed=%s\n",
 			orDash(xp), orDash(*srcPath), orDash(*dstPath), orDash(*lvlPath), orDash(*lockPath), orDash(*catSrcPath), orDash(*catDstPath), orDash(*catMixedPath))
@@ -388,6 +399,7 @@ func cerebrumImportXpoint(_ context.Context, args []string) error {
 		return err
 	}
 	cf.port = portArg
+	cerebrumExpandAutoPaths(cf, "import", host)
 
 	p, err := cerebrumDial(cf, host)
 	if err != nil {
@@ -617,13 +629,34 @@ func cerebrumExportXpoint(ctx context.Context, args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	trio := *outDir != ""
-	if trio && *out != "" {
+	if *outDir != "" && *out != "" {
 		return cerebrumValErr("export", "--out and --out-dir are mutually exclusive")
 	}
-	if *device != "" && trio {
+	if *device != "" && *outDir != "" {
 		return cerebrumValErr("export", "--device (one snapshot file) and --out-dir (matrix file-set) are mutually exclusive — the Tree/DM domain has one facet, one file")
 	}
+	// ADR-0028 default homes: flags omitted → the deterministic
+	// snapshot folder, never a cwd surprise. --out "-" keeps the
+	// explicit stdout stream.
+	stdoutOut := *out == "-"
+	if stdoutOut {
+		*out = ""
+	}
+	if !stdoutOut && *out == "" && *outDir == "" {
+		if *device != "" {
+			// Device (Tree/DM) leg: one params file, keyed by the
+			// device's own identity (IP, or trimmed name fallback).
+			*out = filepath.Join(snapshotDir("cerebrum-nb", strings.TrimSpace(*device)), "params.csv")
+			fmt.Fprintf(os.Stderr, "cerebrum-nb export: default snapshot file %s (ADR-0028)\n", *out)
+		} else {
+			// Matrix leg: the FULL facet set into the router's folder,
+			// plain facet names (the folder identifies the target).
+			*outDir = snapshotDir("cerebrum-nb", *router)
+			*prefix = ""
+			fmt.Fprintf(os.Stderr, "cerebrum-nb export: default snapshot folder %s (ADR-0028)\n", *outDir)
+		}
+	}
+	trio := *outDir != ""
 	// Device-mode flag validation fires PRE-dial like every verb.
 	var deviceStarts []string
 	if *device != "" {
@@ -648,6 +681,7 @@ func cerebrumExportXpoint(ctx context.Context, args []string) error {
 		return err
 	}
 	cf.port = portArg
+	cerebrumExpandAutoPaths(cf, "export", host)
 
 	p, err := cerebrumDial(cf, host)
 	if err != nil {
@@ -702,13 +736,13 @@ func cerebrumExportXpoint(ctx context.Context, args []string) error {
 	files := []struct {
 		name, content string
 	}{
-		{*prefix + "-src.csv", formatCerebrumMneCSVN("srce", srcD, nAlt)},
-		{*prefix + "-dst.csv", formatCerebrumMneCSVN("dest", dstD, nAlt)},
-		{*prefix + "-level.csv", formatCerebrumMneCSVN("level", lvlD, nAlt)},
-		{*prefix + "-xpoint.csv", xpCSV},
+		{facetName(*prefix, "src"), formatCerebrumMneCSVN("srce", srcD, nAlt)},
+		{facetName(*prefix, "dst"), formatCerebrumMneCSVN("dest", dstD, nAlt)},
+		{facetName(*prefix, "level"), formatCerebrumMneCSVN("level", lvlD, nAlt)},
+		{facetName(*prefix, "xpoint"), xpCSV},
 		// DEST_LOCK snapshot — set cells only (unlocked = absent). Written on
 		// RM and physical routers alike (same grant as ROUTE, live-proven).
-		{*prefix + "-lock.csv", formatCerebrumLockCSV(st.Locks)},
+		{facetName(*prefix, "lock"), formatCerebrumLockCSV(st.Locks)},
 	}
 	// Category navigation files (§5.2 walk): SRC and DST kept in separate
 	// files by owner rule; a category whose subtree carries both kinds is
@@ -731,13 +765,13 @@ func cerebrumExportXpoint(ctx context.Context, args []string) error {
 			delete(dstPick, m)
 		}
 		files = append(files,
-			struct{ name, content string }{*prefix + "-cat-src.csv", formatCerebrumCatCSV(cerebrumCatDefsFromLive(catNames, srcPick, catDetails))},
-			struct{ name, content string }{*prefix + "-cat-dst.csv", formatCerebrumCatCSV(cerebrumCatDefsFromLive(catNames, dstPick, catDetails))},
+			struct{ name, content string }{facetName(*prefix, "cat-src"), formatCerebrumCatCSV(cerebrumCatDefsFromLive(catNames, srcPick, catDetails))},
+			struct{ name, content string }{facetName(*prefix, "cat-dst"), formatCerebrumCatCSV(cerebrumCatDefsFromLive(catNames, dstPick, catDetails))},
 		)
 		if len(mixed) > 0 {
-			fmt.Fprintf(os.Stderr, "cerebrum-nb export: %d categor(ies) carry BOTH source and dest resources in their subtree — written to %s-cat-mixed.csv: %s\n", len(mixed), *prefix, strings.Join(mixed, ", "))
+			fmt.Fprintf(os.Stderr, "cerebrum-nb export: %d categor(ies) carry BOTH source and dest resources in their subtree — written to %s: %s\n", len(mixed), facetName(*prefix, "cat-mixed"), strings.Join(mixed, ", "))
 			files = append(files,
-				struct{ name, content string }{*prefix + "-cat-mixed.csv", formatCerebrumCatCSV(cerebrumCatDefsFromLive(catNames, mixedPick, catDetails))},
+				struct{ name, content string }{facetName(*prefix, "cat-mixed"), formatCerebrumCatCSV(cerebrumCatDefsFromLive(catNames, mixedPick, catDetails))},
 			)
 		}
 	} else {

--- a/cmd/dhs/cmd_export.go
+++ b/cmd/dhs/cmd_export.go
@@ -29,9 +29,28 @@ func runExport(ctx context.Context, args []string) error {
 	prefix := fs.String("prefix", "matrix", "file prefix used with --out-dir")
 	host, rest, err := popHost(args)
 	if err != nil {
-		return fmt.Errorf("usage: dhs consumer <proto> export <host> [--format json|yaml|csv] [--out FILE] [--slot N] [--path SEG.SEG] [--out-dir DIR --prefix P]")
+		return fmt.Errorf("usage: dhs consumer <proto> export <host> [--format json|yaml|csv] [--out FILE | --out -] [--slot N] [--path SEG.SEG] [--out-dir DIR --prefix P]")
 	}
 	_ = fs.Parse(rest)
+
+	// ADR-0028 default home: --out omitted → snapshots/<proto>/<host>/
+	// params.<fmt> (deterministic, never a cwd surprise). --out "-"
+	// keeps the explicit stdout stream.
+	stdoutOut := *out == "-"
+	if stdoutOut {
+		*out = ""
+	}
+	if !stdoutOut && *out == "" && *outDir == "" {
+		ext := "json"
+		switch *format {
+		case "yaml", "yml":
+			ext = "yaml"
+		case "csv":
+			ext = "csv"
+		}
+		*out = filepath.Join(snapshotDir(cf.protocol, host), "params."+ext)
+		fmt.Fprintf(os.Stderr, "export: default snapshot file %s (ADR-0028)\n", *out)
+	}
 
 	// Format resolution: --format wins; otherwise guess from --out extension.
 	fmtStr := *format
@@ -123,6 +142,11 @@ func runExport(ctx context.Context, args []string) error {
 	// Pick the output writer: file or stdout.
 	var w io.Writer = os.Stdout
 	if *out != "" {
+		if dir := filepath.Dir(*out); dir != "." {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return fmt.Errorf("create %s: %w", dir, err)
+			}
+		}
 		f, ferr := os.Create(*out)
 		if ferr != nil {
 			return fmt.Errorf("create %s: %w", *out, ferr)

--- a/cmd/dhs/cmd_import.go
+++ b/cmd/dhs/cmd_import.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -105,7 +107,21 @@ func runImport(ctx context.Context, args []string) error {
 	}
 
 	if *file == "" {
-		return fmt.Errorf("--file is required")
+		// ADR-0028 default home: import reads exactly where the
+		// defaulted export writes — snapshots/<proto>/<host>/params.*
+		// (first existing of json/yaml/csv).
+		dir := snapshotDir(cf.protocol, host)
+		for _, name := range []string{"params.json", "params.yaml", "params.csv"} {
+			p := filepath.Join(dir, name)
+			if _, statErr := os.Stat(p); statErr == nil {
+				*file = p
+				fmt.Fprintf(os.Stderr, "import: default snapshot file %s (ADR-0028)\n", *file)
+				break
+			}
+		}
+		if *file == "" {
+			return fmt.Errorf("--file is required (no params.json/yaml/csv found in the default snapshot folder %s)", dir)
+		}
 	}
 	if len(filterIDs) > 0 && len(filterPaths) > 0 {
 		return fmt.Errorf("--id and --path are mutually exclusive; pick one addressing scheme")

--- a/internal/datastore/tree_store.go
+++ b/internal/datastore/tree_store.go
@@ -56,16 +56,34 @@ func (s *TreeStore) BaseDir() string {
 //   - otherwise (production, dropped binary), cache root is
 //     <binary-dir>/.cache/.
 func NewTreeStoreInProjectCache() (*TreeStore, error) {
+	root, err := ProjectRoot()
+	if err != nil {
+		return nil, err
+	}
+	return NewTreeStore(filepath.Join(root, ".cache")), nil
+}
+
+// ProjectRoot returns the directory every artifact bucket roots under
+// (ADR-0028): <X> when the binary lives at <X>/bin/ (dev / convention
+// layout — keeps artifacts OUT of bin/), else the binary's own dir.
+// .cache/, snapshots/ and captures/ are siblings under this root.
+func ProjectRoot() (string, error) {
 	exe, err := os.Executable()
 	if err != nil {
-		return nil, fmt.Errorf("storage: locate binary: %w", err)
+		return "", fmt.Errorf("storage: locate binary: %w", err)
 	}
 	parent := filepath.Dir(exe)
-	base := parent
 	if filepath.Base(parent) == "bin" {
-		base = filepath.Dir(parent)
+		return filepath.Dir(parent), nil
 	}
-	return NewTreeStore(filepath.Join(base, ".cache")), nil
+	return parent, nil
+}
+
+// SanitizePathSeg strips characters that are illegal in filenames on
+// Windows + POSIX — the shared sanitiser for ADR-0028 path segments
+// (IPs incl. IPv6 colons, protocol names, verb/scope labels).
+func SanitizePathSeg(s string) string {
+	return sanitizeSeg(s)
 }
 
 // IdentityPath returns the on-disk path a DM for (proto, identity)


### PR DESCRIPTION
Unit 2a of #703: the shared path composer + default homes wired into generic export/import and every cerebrum export/import leg, plus --capture auto / --log auto sentinels. Flags omitted -> snapshots/<proto>/<ip>/<facet> with plain facet names; --out - keeps stdout; import reads exactly where export writes. Composer shapes pinned by tests (the unit-5 CI layer starts here). Unit 2b (probel/ember dispatcher defaults + generic capture auto) follows on the same issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)