### PR TITLE
test(cmd): ADR-0028 acceptance matrix in executable form (#703 unit 5)

### DIFF
--- a/cmd/dhs/artifact_paths_test.go
+++ b/cmd/dhs/artifact_paths_test.go
@@ -50,3 +50,71 @@ func TestFacetFile(t *testing.T) {
 		t.Fatalf("prefixed facet = %q", got)
 	}
 }
+
+// TestArtifactPaths_AcceptanceMatrix is the ADR-0028 acceptance table
+// in executable form (#703 unit 5): one row per proto × folder-class ×
+// artifact. A change to any composed default fails HERE first — the
+// CI layer of the three-layer verification plan.
+func TestArtifactPaths_AcceptanceMatrix(t *testing.T) {
+	ts := time.Date(2026, 8, 18, 9, 0, 0, 0, time.UTC)
+
+	snapshotRows := []struct {
+		proto, key string
+		facets     []string
+	}{
+		// Matrix-domain folder classes (facet sets per connector
+		// capability — a missing facet is a protocol fact).
+		{"cerebrum-nb", "0.0.0.0", []string{"xpoint", "src", "dst", "level", "lock", "cat-src", "cat-dst", "cat-mixed"}}, // Route Master
+		{"cerebrum-nb", "10.44.72.24", []string{"xpoint", "src", "dst", "level"}},                                       // physical router
+		{"probel-sw08p", "10.44.72.27", []string{"xpoint", "src", "dst", "protect"}},                                    // lock/protect in-protocol
+		// Tree/DM folder classes: one facet, params.
+		{"cerebrum-nb", "10.44.72.28", nil},
+		{"acp1", "10.100.0.103", nil},
+		{"acp2", "10.100.0.103", nil},
+		{"emberplus", "10.6.239.103", nil},
+		{"osc-v11", "10.100.0.104", nil},
+	}
+	for _, row := range snapshotRows {
+		dir := snapshotDir(row.proto, row.key)
+		want := filepath.Join("snapshots", row.proto, row.key)
+		if !strings.HasSuffix(dir, want) {
+			t.Fatalf("snapshotDir(%s,%s) = %q, want suffix %q", row.proto, row.key, dir, want)
+		}
+		for _, facet := range row.facets {
+			if got := facetFile(dir, "", facet); got != filepath.Join(dir, facet+".csv") {
+				t.Fatalf("facet %s in %s = %q", facet, dir, got)
+			}
+		}
+	}
+
+	captureRows := []struct{ proto, key, verb, scope, want string }{
+		{"cerebrum-nb", "10.44.55.39", "extract", "10.44.72.28", "extract-10.44.72.28-20260818T0900Z.jsonl"},
+		{"acp2", "10.100.0.103", "walk", "", "walk-20260818T0900Z.jsonl"},
+		{"probel-sw08p", "10.44.72.27", "import", "", "import-20260818T0900Z.jsonl"},
+		{"tsl-v50", "10.100.0.106", "listen", "", "listen-20260818T0900Z.jsonl"},
+	}
+	for _, row := range captureRows {
+		got := defaultCapturePath(row.proto, row.key, row.verb, row.scope, ts)
+		want := filepath.Join("captures", row.proto, row.key, row.want)
+		if !strings.HasSuffix(got, want) {
+			t.Fatalf("capture(%s,%s,%s) = %q, want suffix %q", row.proto, row.verb, row.scope, got, want)
+		}
+	}
+
+	logRows := []struct{ proto, key, verb string }{
+		{"cerebrum-nb", "10.44.55.39", "export"},
+		{"acp1", "10.100.0.103", "watch"},
+	}
+	for _, row := range logRows {
+		got := defaultLogPath(row.proto, row.key, row.verb)
+		want := filepath.Join(".cache", "logs", row.proto, row.key, row.verb+".log")
+		if !strings.HasSuffix(got, want) {
+			t.Fatalf("log(%s,%s) = %q, want suffix %q", row.proto, row.verb, got, want)
+		}
+	}
+
+	// Key rules: RM sentinel is a valid key; ports never leak into keys.
+	if hostOnly("10.44.55.39:40009") != "10.44.55.39" || hostOnly("0.0.0.0") != "0.0.0.0" {
+		t.Fatal("hostOnly key rule violated")
+	}
+}


### PR DESCRIPTION
Unit 5 of #703: the ADR-0028 acceptance table as a table-driven test - proto x folder-class x artifact, facet-capability sets per connector, capture/log default shapes, key rules. Layout drift fails CI before it reaches the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)