### PR TITLE
fix(cerebrum-nb): empty category CSV from snapshot dir = out of scope (#703)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,11 @@ ansible/secrets/*.vault
 /captures/*
 !/captures/README.md
 
+# ADR-0028 operator bucket: state snapshots written by the defaulted
+# export verbs (snapshots/<proto>/<ip>/<facet>). Working artifacts stay
+# local; CURATED copies live under internal/<proto>/testdata/.
+/snapshots/
+
 # Root-level assets/ is reserved as a scratch dir for ad-hoc debug /
 # validation runs. Real spec assets live under internal/<proto>/assets/.
 /assets/

--- a/cmd/dhs/cmd_cerebrum_extract.go
+++ b/cmd/dhs/cmd_cerebrum_extract.go
@@ -82,28 +82,34 @@ func cerebrumExtract(ctx context.Context, args []string) error {
 	}
 	defer func() { _ = p.Disconnect() }()
 
-	// Identity probe — acp2's IdentityProbe over NB: the device tree
-	// exposes the same identity objects, addressed by the acp2 labels
-	// root-stripped. Card Name is the Model; Product Version is the
-	// SwRev (Hardware Version fallback, same preference order as
-	// acp2). Overrides skip their obtain.
+	// Identity probe — the same discovery acp2's IdentityProbe does,
+	// over NB. Object labels are DRIVER-exact (case included): the
+	// Neuron family exposes "IDENTITY.Card Name" / "IDENTITY.Product
+	// Version", the Synapse family "Identity.Card name" / "Identity.
+	// Software rev" (both live-verified 2026-08-18). The ladder tries
+	// each family in turn; --product/--version skip their obtains.
 	deviceName := *device
 	model := *product
 	swRev := *version
+	probe := func(candidates ...string) string {
+		for _, obj := range candidates {
+			if v := cerebrumObtainIdentityLeaf(sess, cf.timeout, *device, *byName, *subDev, obj); v != "" {
+				return v
+			}
+		}
+		return ""
+	}
 	if model == "" {
-		model = cerebrumObtainIdentityLeaf(sess, cf.timeout, *device, *byName, *subDev, "IDENTITY.Card Name")
+		model = probe("IDENTITY.Card Name", "Identity.Card name")
 	}
 	if swRev == "" {
-		swRev = cerebrumObtainIdentityLeaf(sess, cf.timeout, *device, *byName, *subDev, "IDENTITY.Product Version")
-	}
-	if swRev == "" {
-		swRev = cerebrumObtainIdentityLeaf(sess, cf.timeout, *device, *byName, *subDev, "BOARD.Hardware Version")
+		swRev = probe("IDENTITY.Product Version", "Identity.Software rev", "BOARD.Hardware Version", "Identity.Hardware rev")
 	}
 	if model == "" {
-		return fmt.Errorf("cerebrum-nb extract: no Model — the device tree answered neither \"IDENTITY.Card Name\" nor an override; pass --product explicitly")
+		return fmt.Errorf("cerebrum-nb extract: no Model — the device tree answered no known Card-Name spelling (Neuron or Synapse family); pass --product explicitly")
 	}
 	if swRev == "" {
-		return fmt.Errorf("cerebrum-nb extract: no SwRev — the device tree answered neither \"IDENTITY.Product Version\" nor \"BOARD.Hardware Version\"; pass --version explicitly")
+		return fmt.Errorf("cerebrum-nb extract: no SwRev — the device tree answered no known version spelling (Neuron or Synapse family); pass --version explicitly")
 	}
 	fmt.Printf("identity: %s@%s (from the device tree — same objects as the acp2 probe)\n", model, swRev)
 

--- a/cmd/dhs/cmd_cerebrum_extract_test.go
+++ b/cmd/dhs/cmd_cerebrum_extract_test.go
@@ -85,6 +85,31 @@ func TestWriteCerebrumExtract(t *testing.T) {
 	}
 }
 
+// TestCerebrumImportEmptyCatFile pins the staging-found round-trip
+// contract (2026-08-18): a header-only category file AUTO-RESOLVED
+// from a snapshot dir is out of scope (import proceeds to the
+// missing-host error), while an EXPLICIT --cat-src with no rows keeps
+// the strict parse error.
+func TestCerebrumImportEmptyCatFile(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"cat-src.csv", "cat-dst.csv"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("category,type,value\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Resolved from --in-dir: empty cats skipped; the NEXT error is the
+	// missing host (files parsed fine).
+	err := runCerebrum(context.Background(), []string{"import", "--in-dir", dir, "--prefix", ""})
+	if err == nil || !strings.Contains(err.Error(), "missing host") {
+		t.Fatalf("dir-resolved empty cat must be skipped, got %v", err)
+	}
+	// Explicit flag: strict error stays.
+	err = runCerebrum(context.Background(), []string{"import", "--cat-src", filepath.Join(dir, "cat-src.csv")})
+	if err == nil || !strings.Contains(err.Error(), "no category rows") {
+		t.Fatalf("explicit empty cat must error, got %v", err)
+	}
+}
+
 // TestCerebrumDMCacheHit pins the ADR-0028 §6 skip: an existing
 // Model@SwRev file = hit (zero walk); missing file or nil store = miss.
 func TestCerebrumDMCacheHit(t *testing.T) {

--- a/cmd/dhs/cmd_cerebrum_xpoint.go
+++ b/cmd/dhs/cmd_cerebrum_xpoint.go
@@ -258,6 +258,11 @@ func cerebrumImportXpoint(_ context.Context, args []string) error {
 	if xp == "" {
 		xp = *csvPath
 	}
+	// Explicit-vs-resolved: a category file the OPERATOR named must
+	// parse strictly; one auto-resolved from a snapshot dir may be the
+	// empty file a zero-category export legitimately wrote (staging
+	// 2026-08-18) — that one is out of scope, not an error.
+	explicitCat := *catSrcPath != "" || *catDstPath != "" || *catMixedPath != ""
 	// ADR-0028 default home: no per-file flags and no --in-dir → read
 	// from the router's snapshot folder (exactly where the defaulted
 	// export writes, plain facet names). Import reads where export
@@ -371,7 +376,15 @@ func cerebrumImportXpoint(_ context.Context, args []string) error {
 		if rerr != nil {
 			return nil, rerr
 		}
-		return parseCerebrumCatCSV(data, kind, path)
+		defs, perr := parseCerebrumCatCSV(data, kind, path)
+		if perr != nil && !explicitCat && strings.Contains(perr.Error(), "no category rows") {
+			// Round-trip contract: export on a zero-category plant
+			// writes a header-only file; importing that same set back
+			// must not fail. Skipped LOUDLY, never silently.
+			fmt.Fprintf(os.Stderr, "cerebrum-nb import: %s is empty — categories out of scope\n", path)
+			return nil, nil
+		}
+		return defs, perr
 	}
 	catSrcDefs, err := loadCat(*catSrcPath, "src")
 	if err != nil {


### PR DESCRIPTION
Found live by the first ADR-0028 ensure loop on staging: a zero-category export writes header-only cat files, and re-importing them hard-errored. Dir-resolved empty cat files now skip loudly; explicit flags keep the strict error. Pinned both arms. Also adds /snapshots/ to .gitignore. Live after fix: zero-flag export -> import --check = would_change:false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)