### PR TITLE
fix(cerebrum-nb): category writes emit wire-actual SRCE spelling (#714)

### DIFF
--- a/internal/cerebrum-nb/codec/actions.go
+++ b/internal/cerebrum-nb/codec/actions.go
@@ -234,11 +234,20 @@ type CategoryAction struct {
 }
 
 func (c *CategoryAction) encodeAction(b *strings.Builder) {
+	// Wire-actual TX normalisation (live staging RM 2026-08-18): the
+	// server WRITES accept ITEM_TYPE="SRCE" and NACK 8 on "SOURCE",
+	// yet READS report the item back as TYPE="SOURCE" — an asymmetric
+	// enum. Emit the accepted spelling; the decoder keeps accepting
+	// both, and CSVs/round-trips keep the read shape (SOURCE).
+	itemType := c.ItemType
+	if itemType == ItemSource {
+		itemType = ItemSrce
+	}
 	a := AttrsBuilder{}.
 		ForceAdd("TYPE", c.Type).
 		Add("CATEGORY", c.Category).
 		Add("INDEX", c.Index).
-		Add("ITEM_TYPE", string(c.ItemType)).
+		Add("ITEM_TYPE", string(itemType)).
 		Add("VALUE", c.Value).
 		Add("NAME", c.Name).
 		Add("LABEL", c.Label).

--- a/internal/cerebrum-nb/codec/codec_coverage_test.go
+++ b/internal/cerebrum-nb/codec/codec_coverage_test.go
@@ -67,7 +67,11 @@ func TestFrameKindString_All(t *testing.T) {
 // ----------------------------------------------------------------------
 
 func TestEncodeAction_Category(t *testing.T) {
-	// §4.2.1 p16 Modify Item worked example.
+	// §4.2.1 p16 Modify Item worked example — EXCEPT the item type:
+	// the spec example writes ITEM_TYPE="SOURCE", but the live server
+	// NACKs 8 on it and accepts only "SRCE" (staging RM 2026-08-18;
+	// reads still report "SOURCE"). The encoder emits the wire-actual
+	// spelling — see TestEncodeCategoryAction_SourceSpelling.
 	body := &CategoryAction{
 		Type:     "MODIFY_ITEM",
 		Category: "SERVERS",
@@ -76,7 +80,7 @@ func TestEncodeAction_Category(t *testing.T) {
 		Value:    "SRVR-1",
 	}
 	got := string(EncodeAction(1, body))
-	want := `<ACTION MTID="1"><CATEGORY TYPE="MODIFY_ITEM" CATEGORY="SERVERS" INDEX="4" ITEM_TYPE="SOURCE" VALUE="SRVR-1"/></ACTION>`
+	want := `<ACTION MTID="1"><CATEGORY TYPE="MODIFY_ITEM" CATEGORY="SERVERS" INDEX="4" ITEM_TYPE="SRCE" VALUE="SRVR-1"/></ACTION>`
 	if got != want {
 		t.Fatalf("\n got %s\nwant %s", got, want)
 	}

--- a/internal/cerebrum-nb/codec/codec_test.go
+++ b/internal/cerebrum-nb/codec/codec_test.go
@@ -72,6 +72,28 @@ func TestEncodeObtain_DeviceList(t *testing.T) {
 	}
 }
 
+// TestEncodeCategoryAction_SourceSpelling pins the asymmetric §3.3
+// enum found live (staging RM 2026-08-18): WRITES accept only
+// ITEM_TYPE="SRCE" (SOURCE NACKs 8) while READS report "SOURCE".
+// The encoder emits the accepted spelling for either input.
+func TestEncodeCategoryAction_SourceSpelling(t *testing.T) {
+	for _, in := range []ItemType{ItemSource, ItemSrce} {
+		got := string(EncodeAction(5, &CategoryAction{
+			Type: "MODIFY_ITEM", Category: "C", Index: "2", ItemType: in, Value: "1",
+		}))
+		if !strings.Contains(got, `ITEM_TYPE="SRCE"`) {
+			t.Fatalf("input %s: want ITEM_TYPE=SRCE on the wire, got %s", in, got)
+		}
+	}
+	// DEST is symmetric — passes through unchanged.
+	got := string(EncodeAction(6, &CategoryAction{
+		Type: "MODIFY_ITEM", Category: "C", Index: "3", ItemType: ItemDest, Value: "1",
+	}))
+	if !strings.Contains(got, `ITEM_TYPE="DEST"`) {
+		t.Fatalf("DEST must pass through, got %s", got)
+	}
+}
+
 // TestEncodeObtain_ExplicitEmptyObject pins the root-discovery frame:
 // OBJECT="" is EMITTED literally with the flag set (Add() would drop
 // it), and stays absent without the flag — the two spellings are


### PR DESCRIPTION
First live category-write campaign finding: the sec-3.3 item enum is asymmetric - writes accept only SRCE (SOURCE NACKs 8), reads report SOURCE. Encoder normalises on TX, decoder accepts both, round-trips keep the read shape. Pinned; codec floor 100%. Live: delete -> CSV recreate -> run-twice 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)