### PR TITLE
fix(cerebrum-nb): route verb expands --capture auto (#714)

### DIFF
--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -1871,6 +1871,7 @@ func cerebrumRoute(_ context.Context, args []string) error {
 		return err
 	}
 	cf.port = portArg
+	cerebrumExpandAutoPaths(cf, "route", host)
 
 	logger, _, lerr := cf.newLogger()
 	if lerr != nil {


### PR DESCRIPTION
Found during the virtual-resource level test: the route verb's own dial path skipped the auto-sentinel expansion, writing a literal ./auto file. Now expanded like every other cerebrum dial path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)