### PR TITLE
feat(cerebrum-nb): usage + replace - the source-side pair (#714)

### DIFF
--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -232,6 +232,14 @@ func runCerebrum(ctx context.Context, args []string) error {
 		return cerebrumWatch(ctx, rest)
 	case "route":
 		return cerebrumRoute(ctx, rest)
+	case "usage":
+		// Source usage / reverse tally, with virtual-chain resolution
+		// (#714 — the client-side correlation the NB API leaves to us).
+		return cerebrumUsage(ctx, rest)
+	case "replace":
+		// Source substitution: replace src A with B on every literal
+		// cell (#714). ADR-0007 ensure semantics.
+		return cerebrumReplace(ctx, rest)
 	case "export":
 		return cerebrumExportXpoint(ctx, rest)
 	case "list-sources":
@@ -282,6 +290,8 @@ VERBS
   list-sources             one-shot OBTAIN SRCE_MNE  → every source: ID + capability levels + label + alts  [--id N] [--out FILE]
   list-dests               one-shot OBTAIN DEST_MNE  → same for destinations (alias: list-destinations)     [--id N] [--out FILE]
   list-levels              one-shot OBTAIN LEVEL_MNE → every level ID + name  [--id N] [--out FILE]
+  usage                    source usage / reverse tally: WHERE is a source assigned (all dsts + levels). [--srce N = fan-out | --dest N = upstream chain] [--resolve = follow VIRTUAL chains to the effective source] [--format csv|ascii] [--out FILE|-] [--level L] [--router IP]
+  replace                  source substitution: replace src A with B on every LITERAL cell carrying A — virtual subscribers inherit through their own chains: --srce A --with B [--level L] [--check] [--output json] [--router IP]
   export                   one-shot OBTAIN wildcards → CSVs. Crosspoints only: [--out FILE] [--level N]. Full snapshot (src+dst+level mnemonics+xpoint+locks as -lock.csv+categories as -cat-src.csv/-cat-dst.csv): --out-dir DIR [--prefix P]. --router IP = PHYSICAL router (device-native numbering, cat files skipped — categories are RM-only; import back with the same --router). DEVICE snapshot (Tree/DM, acp2 parity — ONE file): --device NAME|IP [--by-name] --sub-device N --path "GROUP[;GROUP…]" --out FILE.json|yaml|csv [--format F] [--max-requests N]
   import                   ENSURE (ADR-0007): read live state, diff vs CSVs, converge only differences. --in-dir DIR [--prefix P] reads the set export wrote (missing files = out of scope), or per-file --xpoint (--csv alias) / --src / --dst / --levels / --lock (dest,state,levels[,locked_by] — absent cell untouched, clears need explicit RELEASED rows) / --cat-src / --cat-dst (categories: category,type,value rows — row order = slot order; builds the navigation panel). --check = report would_change, send nothing. --output json = ADR-0007 {changed|would_change, diff[]} on stdout. Empty cell/absent column = untouched; --allow-clear makes an empty MANAGED cell clear the live label. Run-twice = 0.
   list-devices             OBTAIN <device_change type='LIST'/>  [--device-type Router|SNMP|Device] [--names: join DEVICE_NAME + PRIMARY/SECONDARY state via one DETAILS obtain per IP — LIST itself never carries names (§5.4.1)]

--- a/cmd/dhs/cmd_cerebrum_usage.go
+++ b/cmd/dhs/cmd_cerebrum_usage.go
@@ -1,0 +1,460 @@
+package main
+
+// usage + replace — the source-side pair of the Matrix template
+// (#714, owner-designed 2026-08-19):
+//
+//	usage    WHERE is a source assigned (reverse tally / source usage),
+//	         optionally resolved through VIRTUAL resources — the
+//	         correlation the NB API correctly leaves to the client
+//	         (a dst's own crosspoint does not change when a virtual
+//	         upstream is re-fed; owner-confirmed semantics).
+//	replace  substitute source A with B on every LITERAL cell that
+//	         carries A (ADR-0007: --check first, diff-only, run-twice
+//	         = 0). Virtual chains inherit through their own feeds —
+//	         replace never resolves behind the operator's back.
+//
+// Both are client-side compositions over the existing ROUTE obtain /
+// action primitives — no new wire commands. Canonical shape: probel /
+// ember matrices can implement the same two verbs identically.
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"dhs/internal/cerebrum-nb/codec"
+)
+
+// cerebrumUsageRow is one LITERAL assignment (srce feeds dest on
+// levels), plus the virtual-chain resolution when requested.
+type cerebrumUsageRow struct {
+	Srce, Dest string
+	Levels     []string
+	Effective  string   // resolved physical source; "" = not resolved / marked
+	Via        []string // virtual hops crossed, in chain order
+	Mark       string   // "" | "loop" | "unfed"
+}
+
+// cerebrumDetectVirtuals returns the IDs that are VIRTUAL resources: a
+// virtual registers on BOTH faces with the same ID and the same
+// mnemonic (live staging 2026-08-18 — "Proc 1"/"Proc 2" as src 3/4 AND
+// dst 3/4). ID equality alone is NOT enough: physical routers number
+// srcs and dsts independently, so src 1 and dst 1 usually coexist
+// without being virtual — the mnemonic must match too. Heuristic by
+// necessity: the wire carries no virtual flag.
+func cerebrumDetectVirtuals(src, dst []cerebrumMneRow) map[string]bool {
+	srcName := map[string]string{}
+	for _, r := range src {
+		if r.ID != "" && r.Mnemonic != "" {
+			srcName[r.ID] = r.Mnemonic
+		}
+	}
+	out := map[string]bool{}
+	for _, r := range dst {
+		if r.ID == "" || r.Mnemonic == "" {
+			continue
+		}
+		if n, ok := srcName[r.ID]; ok && n == r.Mnemonic {
+			out[r.ID] = true
+		}
+	}
+	return out
+}
+
+// cerebrumResolveSrc follows the virtual chain upstream from srce at
+// one level: while srce is a virtual, the effective source is whatever
+// feeds that virtual's DEST face on the same level. Loop-guarded;
+// an unfed virtual ends the chain with mark "unfed".
+func cerebrumResolveSrc(srce, level string, feed map[string]string, virtuals map[string]bool) (eff string, via []string, mark string) {
+	cur := srce
+	seen := map[string]bool{}
+	for virtuals[cur] {
+		if seen[cur] {
+			return "", via, "loop"
+		}
+		seen[cur] = true
+		via = append(via, cur)
+		next, ok := feed[cur+"\x00"+level]
+		if !ok {
+			return "", via, "unfed"
+		}
+		cur = next
+	}
+	return cur, via, ""
+}
+
+// cerebrumBuildUsage turns the raw per-level route rows into
+// source-keyed usage rows (levels collapsed per identical
+// srce/dest/resolution), resolving virtual chains when resolve is set.
+func cerebrumBuildUsage(routes []routeSpec, virtuals map[string]bool, resolve bool) []cerebrumUsageRow {
+	feed := map[string]string{}
+	for _, r := range routes {
+		feed[r.Dest+"\x00"+r.Level] = r.Srce
+	}
+	type acc struct {
+		row  cerebrumUsageRow
+		seen map[string]bool
+	}
+	groups := map[string]*acc{}
+	var order []string
+	for _, r := range routes {
+		if r.Dest == "" || r.Srce == "" || r.Level == "" {
+			continue
+		}
+		eff, via, mark := "", []string(nil), ""
+		if resolve {
+			eff, via, mark = cerebrumResolveSrc(r.Srce, r.Level, feed, virtuals)
+		}
+		k := r.Srce + "\x00" + r.Dest + "\x00" + eff + "\x00" + strings.Join(via, ";") + "\x00" + mark
+		g := groups[k]
+		if g == nil {
+			g = &acc{row: cerebrumUsageRow{Srce: r.Srce, Dest: r.Dest, Effective: eff, Via: via, Mark: mark}, seen: map[string]bool{}}
+			groups[k] = g
+			order = append(order, k)
+		}
+		if !g.seen[r.Level] {
+			g.seen[r.Level] = true
+			g.row.Levels = append(g.row.Levels, r.Level)
+		}
+	}
+	out := make([]cerebrumUsageRow, 0, len(order))
+	for _, k := range order {
+		sortCerebrumIDs(groups[k].row.Levels)
+		out = append(out, groups[k].row)
+	}
+	return out
+}
+
+// formatCerebrumUsageCSV renders rows source-keyed. The resolved
+// columns appear only in resolve mode: effective_srce is the chain's
+// physical end ("" on loop/unfed — always loud in ascii, silent-empty
+// here so machine parsing stays simple), via lists the virtual hops.
+func formatCerebrumUsageCSV(rows []cerebrumUsageRow, resolve bool) string {
+	var b strings.Builder
+	if resolve {
+		b.WriteString("srce,dest,levels,effective_srce,via\n")
+	} else {
+		b.WriteString("srce,dest,levels\n")
+	}
+	for _, r := range rows {
+		b.WriteString(r.Srce)
+		b.WriteByte(',')
+		b.WriteString(r.Dest)
+		b.WriteByte(',')
+		b.WriteString(strings.Join(r.Levels, ";"))
+		if resolve {
+			b.WriteByte(',')
+			b.WriteString(r.Effective)
+			b.WriteByte(',')
+			b.WriteString(strings.Join(r.Via, ";"))
+		}
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// cerebrumUsageName renders "Label (id)" or just the id when no
+// mnemonic is known.
+func cerebrumUsageName(id string, names map[string]string) string {
+	if n := names[id]; n != "" {
+		return fmt.Sprintf("%s (%s)", n, id)
+	}
+	return id
+}
+
+// renderCerebrumUsageFanout prints the source-side tree: every dest
+// the source feeds, recursing INTO virtual dests to show their
+// subscribers (the "who follows this source" view). depth-guarded by
+// the same loop set the resolver uses.
+func renderCerebrumUsageFanout(w io.Writer, srce string, rows []cerebrumUsageRow, virtuals map[string]bool, srcNames, dstNames map[string]string, indent string, seen map[string]bool) {
+	if seen[srce] {
+		_, _ = fmt.Fprintf(w, "%s└── [loop!] %s\n", indent, cerebrumUsageName(srce, srcNames))
+		return
+	}
+	seen[srce] = true
+	defer delete(seen, srce)
+
+	var children []cerebrumUsageRow
+	for _, r := range rows {
+		if r.Srce == srce {
+			children = append(children, r)
+		}
+	}
+	for i, r := range children {
+		branch, next := "├──", "│   "
+		if i == len(children)-1 {
+			branch, next = "└──", "    "
+		}
+		label := cerebrumUsageName(r.Dest, dstNames)
+		if virtuals[r.Dest] {
+			_, _ = fmt.Fprintf(w, "%s%s %s  [virtual]  levels %s\n", indent, branch, label, strings.Join(r.Levels, ";"))
+			renderCerebrumUsageFanout(w, r.Dest, rows, virtuals, srcNames, dstNames, indent+next, seen)
+		} else {
+			_, _ = fmt.Fprintf(w, "%s%s %s  levels %s\n", indent, branch, label, strings.Join(r.Levels, ";"))
+		}
+	}
+}
+
+// renderCerebrumUsageChain prints the dest-side view: per level-group,
+// the chain upstream through virtuals to the effective source.
+func renderCerebrumUsageChain(w io.Writer, dest string, rows []cerebrumUsageRow, srcNames, dstNames map[string]string) {
+	var mine []cerebrumUsageRow
+	for _, r := range rows {
+		if r.Dest == dest {
+			mine = append(mine, r)
+		}
+	}
+	_, _ = fmt.Fprintf(w, "%s\n", cerebrumUsageName(dest, dstNames))
+	for i, r := range mine {
+		branch := "├──"
+		if i == len(mine)-1 {
+			branch = "└──"
+		}
+		chain := cerebrumUsageName(r.Srce, srcNames)
+		if len(r.Via) > 1 {
+			for _, hop := range r.Via[1:] {
+				chain += "  ← " + cerebrumUsageName(hop, srcNames) + " [virtual]"
+			}
+		}
+		suffix := ""
+		switch {
+		case r.Mark != "":
+			suffix = fmt.Sprintf("  [%s!]", r.Mark)
+		case len(r.Via) > 0:
+			suffix = fmt.Sprintf("  ← effective %s", cerebrumUsageName(r.Effective, srcNames))
+			chain += " [virtual]"
+		}
+		_, _ = fmt.Fprintf(w, "%s levels %s : fed by %s%s\n", branch, strings.Join(r.Levels, ";"), chain, suffix)
+	}
+}
+
+// cerebrumUsage drives `dhs consumer cerebrum-nb usage`.
+func cerebrumUsage(_ context.Context, args []string) error {
+	args = reorderFlagsFirst(args)
+	fs := flag.NewFlagSet("cerebrum-nb usage", flag.ContinueOnError)
+	cf := newCerebrumFlags(fs)
+	router := fs.String("router", "0.0.0.0", "router target (route-master sentinel 0.0.0.0 or a physical Router IP)")
+	srce := fs.String("srce", "", "filter: only this source's assignments (fan-out view in ascii)")
+	dest := fs.String("dest", "", "filter: only this dest's feeds (upstream-chain view in ascii)")
+	level := fs.String("level", "", "filter: one level only")
+	resolveFlag := fs.Bool("resolve", false, "resolve VIRTUAL chains: add effective_srce + via columns (csv) / render the full chain (ascii)")
+	format := fs.String("format", "csv", "output format: csv | ascii")
+	out := fs.String("out", "", "csv output file (omitted = snapshots/<proto>/<router>/usage.csv per ADR-0028; \"-\" = stdout)")
+	idle := fs.Duration("idle", 3*time.Second, "stop collecting this long after the last snapshot frame if no WILDCARD_COMPLETE arrives")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *format != "csv" && *format != "ascii" {
+		return cerebrumValErr("usage", fmt.Sprintf("--format must be csv or ascii, got %q", *format))
+	}
+	if *srce != "" && *dest != "" {
+		return cerebrumValErr("usage", "--srce and --dest are mutually exclusive (fan-out vs upstream-chain view)")
+	}
+	rest := fs.Args()
+	if len(rest) < 1 {
+		return cerebrumValErr("usage", "missing host[:port] argument")
+	}
+	host, portArg, err := splitHostPort(rest[0], cf.port)
+	if err != nil {
+		return err
+	}
+	cf.port = portArg
+	cerebrumExpandAutoPaths(cf, "usage", host)
+
+	p, err := cerebrumDial(cf, host, "usage")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = p.Disconnect() }()
+
+	st, err := cerebrumObtainState(context.Background(), p.Session(), *router, "ROUTER", *idle, cerebrumStateWant{
+		Routes: true, RouteLevel: *level,
+		SrcMne: true, DstMne: true,
+		Verb: "usage",
+	})
+	if err != nil {
+		return err
+	}
+	virtuals := cerebrumDetectVirtuals(st.Src, st.Dst)
+	rows := cerebrumBuildUsage(st.Routes, virtuals, *resolveFlag)
+
+	// Apply filters AFTER resolution (a --srce filter must not hide
+	// the chains that resolve back to it).
+	if *srce != "" || *dest != "" {
+		filtered := rows[:0]
+		for _, r := range rows {
+			if (*srce != "" && r.Srce == *srce) || (*dest != "" && r.Dest == *dest) {
+				filtered = append(filtered, r)
+			}
+		}
+		rows = filtered
+	}
+
+	srcNames, dstNames := map[string]string{}, map[string]string{}
+	for _, m := range dedupeCerebrumMnes(st.Src) {
+		srcNames[m.ID] = m.Mnemonic
+	}
+	for _, m := range dedupeCerebrumMnes(st.Dst) {
+		dstNames[m.ID] = m.Mnemonic
+	}
+
+	if *format == "ascii" {
+		switch {
+		case *dest != "":
+			renderCerebrumUsageChain(os.Stdout, *dest, rows, srcNames, dstNames)
+		case *srce != "":
+			fmt.Printf("%s\n", cerebrumUsageName(*srce, srcNames))
+			renderCerebrumUsageFanout(os.Stdout, *srce, cerebrumBuildUsage(st.Routes, virtuals, *resolveFlag), virtuals, srcNames, dstNames, "", map[string]bool{})
+		default:
+			// Full map: one fan-out block per feeding source, virtuals
+			// marked; virtual subscribers appear nested under their
+			// physical roots.
+			seenTop := map[string]bool{}
+			for _, r := range cerebrumBuildUsage(st.Routes, virtuals, *resolveFlag) {
+				if seenTop[r.Srce] || virtuals[r.Srce] {
+					continue
+				}
+				seenTop[r.Srce] = true
+				fmt.Printf("%s\n", cerebrumUsageName(r.Srce, srcNames))
+				renderCerebrumUsageFanout(os.Stdout, r.Srce, cerebrumBuildUsage(st.Routes, virtuals, *resolveFlag), virtuals, srcNames, dstNames, "", map[string]bool{})
+			}
+		}
+		return nil
+	}
+
+	csv := formatCerebrumUsageCSV(rows, *resolveFlag)
+	if *out == "-" {
+		fmt.Print(csv)
+		return nil
+	}
+	path := *out
+	if path == "" {
+		path = filepath.Join(snapshotDir("cerebrum-nb", *router), "usage.csv")
+		fmt.Fprintf(os.Stderr, "cerebrum-nb usage: default snapshot file %s (ADR-0028)\n", path)
+	}
+	if dir := filepath.Dir(path); dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	if err := os.WriteFile(path, []byte(csv), 0o644); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "cerebrum-nb usage: wrote %s (%d row(s))\n", path, len(rows))
+	return nil
+}
+
+// cerebrumReplace drives `dhs consumer cerebrum-nb replace` — replace
+// source A with B on every LITERAL cell carrying A (ADR-0007 ensure:
+// --check dry-run, diff-only apply, run-twice = 0 because nothing
+// carries A afterwards). Virtual subscribers inherit through their own
+// chains, untouched — substitution never resolves behind the
+// operator's back.
+func cerebrumReplace(_ context.Context, args []string) error {
+	args = reorderFlagsFirst(args)
+	fs := flag.NewFlagSet("cerebrum-nb replace", flag.ContinueOnError)
+	cf := newCerebrumFlags(fs)
+	router := fs.String("router", "0.0.0.0", "router target (route-master sentinel 0.0.0.0 or a physical Router IP)")
+	from := fs.String("srce", "", "source ID to replace (required)")
+	with := fs.String("with", "", "source ID that takes over (required)")
+	level := fs.String("level", "", "restrict to one level (omitted = every level where --srce is assigned)")
+	check := fs.Bool("check", false, "dry-run (ADR-0007): list the cells that would change, send nothing")
+	output := fs.String("output", "text", "output format: text | json (ADR-0002; json = {changed|would_change, diff[]})")
+	idle := fs.Duration("idle", 3*time.Second, "snapshot idle fallback")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *from == "" || *with == "" {
+		return cerebrumValErr("replace", "--srce and --with are required (replace source A with B)")
+	}
+	if *from == *with {
+		return cerebrumValErr("replace", "--srce and --with are the same source — nothing to do")
+	}
+	jsonOut, oerr := resolveEnsureOutput(*output, false)
+	if oerr != nil {
+		return oerr
+	}
+	rest := fs.Args()
+	if len(rest) < 1 {
+		return cerebrumValErr("replace", "missing host[:port] argument")
+	}
+	host, portArg, err := splitHostPort(rest[0], cf.port)
+	if err != nil {
+		return err
+	}
+	cf.port = portArg
+	cerebrumExpandAutoPaths(cf, "replace", host)
+
+	p, err := cerebrumDial(cf, host, "replace")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = p.Disconnect() }()
+	sess := p.Session()
+	logw := os.Stdout
+	if jsonOut {
+		logw = os.Stderr
+	}
+
+	st, err := cerebrumObtainState(context.Background(), sess, *router, "ROUTER", *idle, cerebrumStateWant{
+		Routes: true, RouteLevel: *level, Verb: "replace",
+	})
+	if err != nil {
+		return err
+	}
+
+	// The literal cells carrying --srce, in snapshot order.
+	var cells []routeSpec
+	for _, r := range st.Routes {
+		if r.Srce == *from {
+			cells = append(cells, r)
+		}
+	}
+	changed := len(cells) > 0
+	diffs := make([]ensureDiff, 0, len(cells))
+	for _, c := range cells {
+		diffs = append(diffs, ensureDiff{Field: fmt.Sprintf("route.%s.%s", c.Dest, c.Level), From: *from, To: *with})
+	}
+
+	if *check {
+		for _, c := range cells {
+			_, _ = fmt.Fprintf(logw, "[would-replace] dst=%s lvl=%s: src %s -> %s\n", c.Dest, c.Level, *from, *with)
+		}
+		_, _ = fmt.Fprintf(logw, "cerebrum-nb replace --check: would_change=%d cell(s) carrying src %s — nothing sent\n", len(cells), *from)
+		if jsonOut {
+			return emitEnsure(true, ensureResult{WouldChange: &changed, Diff: diffs})
+		}
+		return nil
+	}
+
+	fails := 0
+	for _, c := range cells {
+		body := &codec.RoutingAction{
+			Type:       "ROUTE",
+			IPAddress:  *router,
+			DeviceType: codec.DeviceType("ROUTER"),
+			DestID:     c.Dest,
+			SrceID:     *with,
+			LevelID:    c.Level,
+		}
+		if err := sess.Action(context.Background(), body); err != nil {
+			_, _ = fmt.Fprintf(logw, "[replace] NACK dst=%s lvl=%s reason=%s\n", c.Dest, c.Level, err)
+			fails++
+			continue
+		}
+		_, _ = fmt.Fprintf(logw, "[replace] OK   dst=%s lvl=%s: src %s -> %s\n", c.Dest, c.Level, *from, *with)
+	}
+	if fails > 0 {
+		return fmt.Errorf("%d/%d replace action(s) failed", fails, len(cells))
+	}
+	_, _ = fmt.Fprintf(logw, "cerebrum-nb replace: changed=%d cell(s); run again to verify 0 (nothing carries src %s any more)\n", len(cells), *from)
+	if jsonOut {
+		return emitEnsure(true, ensureResult{Changed: &changed, Diff: diffs})
+	}
+	return nil
+}

--- a/cmd/dhs/cmd_cerebrum_usage_test.go
+++ b/cmd/dhs/cmd_cerebrum_usage_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+// The staging-shaped fixture: Src 2 feeds virtual Proc 1; Proc 1 feeds
+// virtual Proc 2 and Dest 3; Proc 2 feeds Dest 1 and Dest 4; Src 2
+// also feeds Dest 2 on level 1 only. IDs: sources 1,2 physical; 3,4
+// virtual (same ID+name on both faces).
+func usageFixture() ([]routeSpec, map[string]bool) {
+	routes := []routeSpec{
+		{Dest: "2", Srce: "2", Level: "1"},
+		{Dest: "3", Srce: "2", Level: "1"}, {Dest: "3", Srce: "2", Level: "2"}, {Dest: "3", Srce: "2", Level: "3"},
+		{Dest: "4", Srce: "3", Level: "1"}, {Dest: "4", Srce: "3", Level: "2"}, {Dest: "4", Srce: "3", Level: "3"},
+		{Dest: "5", Srce: "3", Level: "1"}, {Dest: "5", Srce: "3", Level: "2"}, {Dest: "5", Srce: "3", Level: "3"},
+		{Dest: "1", Srce: "4", Level: "1"}, {Dest: "1", Srce: "4", Level: "2"}, {Dest: "1", Srce: "4", Level: "3"},
+	}
+	return routes, map[string]bool{"3": true, "4": true}
+}
+
+func TestCerebrumDetectVirtuals(t *testing.T) {
+	src := []cerebrumMneRow{{ID: "1", Mnemonic: "Src 1"}, {ID: "3", Mnemonic: "Proc 1"}}
+	dst := []cerebrumMneRow{{ID: "1", Mnemonic: "Dest 1"}, {ID: "3", Mnemonic: "Proc 1"}}
+	v := cerebrumDetectVirtuals(src, dst)
+	if !v["3"] {
+		t.Fatal("Proc 1 (same ID+name both faces) must be virtual")
+	}
+	if v["1"] {
+		t.Fatal("ID collision with different names must NOT be virtual")
+	}
+}
+
+func TestCerebrumResolveSrc(t *testing.T) {
+	routes, virtuals := usageFixture()
+	feed := map[string]string{}
+	for _, r := range routes {
+		feed[r.Dest+"\x00"+r.Level] = r.Srce
+	}
+	// Two-virtual chain: 4 -> (fed by 3) -> (fed by 2).
+	eff, via, mark := cerebrumResolveSrc("4", "2", feed, virtuals)
+	if eff != "2" || mark != "" || strings.Join(via, ";") != "4;3" {
+		t.Fatalf("chain = eff %q via %v mark %q", eff, via, mark)
+	}
+	// Physical source resolves to itself, no hops.
+	if eff, via, _ := cerebrumResolveSrc("2", "1", feed, virtuals); eff != "2" || len(via) != 0 {
+		t.Fatalf("physical = %q via %v", eff, via)
+	}
+	// Unfed virtual (no route into its dest face on that level).
+	unfedFeed := map[string]string{}
+	if eff, _, mark := cerebrumResolveSrc("3", "1", unfedFeed, virtuals); eff != "" || mark != "unfed" {
+		t.Fatalf("unfed = %q mark %q", eff, mark)
+	}
+	// Loop: 3 fed by 4, 4 fed by 3.
+	loopFeed := map[string]string{"3\x001": "4", "4\x001": "3"}
+	if eff, _, mark := cerebrumResolveSrc("3", "1", loopFeed, virtuals); eff != "" || mark != "loop" {
+		t.Fatalf("loop = %q mark %q", eff, mark)
+	}
+}
+
+func TestCerebrumBuildUsage_ResolveAndCollapse(t *testing.T) {
+	routes, virtuals := usageFixture()
+	rows := cerebrumBuildUsage(routes, virtuals, true)
+	byKey := map[string]cerebrumUsageRow{}
+	for _, r := range rows {
+		byKey[r.Srce+">"+r.Dest] = r
+	}
+	// Dest 1 fed by virtual 4, effective 2 via 4;3, all levels collapsed.
+	r := byKey["4>1"]
+	if r.Effective != "2" || strings.Join(r.Via, ";") != "4;3" || strings.Join(r.Levels, ";") != "1;2;3" {
+		t.Fatalf("dest1 row = %+v", r)
+	}
+	// Physical direct row keeps empty via.
+	if r := byKey["2>2"]; r.Effective != "2" || len(r.Via) != 0 || strings.Join(r.Levels, ";") != "1" {
+		t.Fatalf("dest2 row = %+v", r)
+	}
+
+	csv := formatCerebrumUsageCSV(rows, true)
+	if !strings.Contains(csv, "srce,dest,levels,effective_srce,via\n") ||
+		!strings.Contains(csv, "4,1,1;2;3,2,4;3\n") {
+		t.Fatalf("resolved csv:\n%s", csv)
+	}
+	plain := formatCerebrumUsageCSV(cerebrumBuildUsage(routes, virtuals, false), false)
+	if strings.Contains(plain, "effective") || !strings.Contains(plain, "2,3,1;2;3\n") {
+		t.Fatalf("literal csv:\n%s", plain)
+	}
+}
+
+func TestCerebrumUsageAsciiRenders(t *testing.T) {
+	routes, virtuals := usageFixture()
+	rows := cerebrumBuildUsage(routes, virtuals, true)
+	srcNames := map[string]string{"2": "Src 2", "3": "Proc 1", "4": "Proc 2"}
+	dstNames := map[string]string{"1": "Dest 1", "2": "Dest 2", "3": "Proc 1", "4": "Proc 2", "5": "Dest 3"}
+
+	var fan bytes.Buffer
+	renderCerebrumUsageFanout(&fan, "2", rows, virtuals, srcNames, dstNames, "", map[string]bool{})
+	s := fan.String()
+	// Nested virtuals with their subscribers, physical leaves plain.
+	if !strings.Contains(s, "[virtual]") || !strings.Contains(s, "Dest 1 (1)") || !strings.Contains(s, "Dest 2 (2)") {
+		t.Fatalf("fanout:\n%s", s)
+	}
+
+	var chain bytes.Buffer
+	renderCerebrumUsageChain(&chain, "1", rows, srcNames, dstNames)
+	c := chain.String()
+	if !strings.Contains(c, "effective Src 2 (2)") || !strings.Contains(c, "[virtual]") {
+		t.Fatalf("chain:\n%s", c)
+	}
+
+	// A dest fed by a PHYSICAL source (empty Via) must render without
+	// panicking (live-found 2026-08-19: Via[1:] on an empty slice).
+	var direct bytes.Buffer
+	renderCerebrumUsageChain(&direct, "2", rows, srcNames, dstNames)
+	if !strings.Contains(direct.String(), "fed by Src 2 (2)") {
+		t.Fatalf("direct chain:\n%s", direct.String())
+	}
+}
+
+func TestCerebrumUsageReplaceValidateFlags(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"usage-bad-format", []string{"usage", "h", "--format", "xml"}, "--format must be csv or ascii"},
+		{"usage-srce-and-dest", []string{"usage", "h", "--srce", "1", "--dest", "1"}, "mutually exclusive"},
+		{"usage-no-host", []string{"usage", "--srce", "1"}, "missing host"},
+		{"replace-no-args", []string{"replace", "h"}, "--srce and --with are required"},
+		{"replace-same", []string{"replace", "h", "--srce", "1", "--with", "1"}, "the same source"},
+		{"replace-no-host", []string{"replace", "--srce", "1", "--with", "2"}, "missing host"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := runCerebrum(context.Background(), c.args)
+			if err == nil || !strings.Contains(err.Error(), c.want) {
+				t.Fatalf("args %v: got %v, want %q", c.args, err, c.want)
+			}
+		})
+	}
+}

--- a/internal/cerebrum-nb/docs/verbs.md
+++ b/internal/cerebrum-nb/docs/verbs.md
@@ -357,6 +357,34 @@ unbound and shows no levels. Alternate labels print as `1=Black 4=ENG`
 config and not exposed over NB. `--id N` narrows to one resource, `--out`
 writes CSV instead of the table.
 
+### usage / replace — source-side pair (reverse tally + substitution)
+
+```
+# where is a source assigned (fan-out, virtuals resolved):
+dhs consumer cerebrum-nb usage HOST --user U --pass P --srce 2 --resolve --format ascii
+# what feeds a dest (upstream chain through virtuals):
+dhs consumer cerebrum-nb usage HOST --user U --pass P --dest 1 --resolve --format ascii
+# machine form (default file snapshots/<proto>/<router>/usage.csv; "-" = stdout):
+dhs consumer cerebrum-nb usage HOST --user U --pass P --resolve --out -
+#   srce,dest,levels[,effective_srce,via]
+
+# replace source A with B on every LITERAL cell carrying A:
+dhs consumer cerebrum-nb replace HOST --user U --pass P --srce A --with B [--level L] --check
+```
+
+- A VIRTUAL resource registers on both faces (same ID + same mnemonic —
+  the detection heuristic; the wire carries no flag). `--resolve`
+  follows chains upstream (virtual→virtual included), loop-guarded;
+  an unfed virtual or a cycle is marked, never silently resolved.
+- Owner-confirmed semantics (2026-08-19): a dst's own crosspoint does
+  NOT change when a virtual upstream is re-fed — the NB correctly does
+  not notify subscriber dests, and snapshots stay literal. `usage
+  --resolve` is the client-side correlation; `replace` touches literal
+  cells only, so virtual subscribers inherit through their own chains.
+- `replace` is ADR-0007: `--check` dry-run, diff-only apply, run-twice
+  = 0 (nothing carries A afterwards); every touched dest notifies
+  naturally. Matrix domain only (RM + physical routers via --router).
+
 ### export — full snapshot
 
 ```


### PR DESCRIPTION
Owner-designed after the virtual-resource verification: usage (reverse tally, --srce fan-out / --dest upstream chain, --resolve follows virtual chains to the effective source, csv + ascii, ADR-0028 default home) and replace (--srce A --with B, literal cells only, ADR-0007 check/apply/run-twice-0). Live-proven on staging in all views; one live-found panic fixed and pinned. Canonical shape for probel/ember later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)