### PR TITLE
fix(cerebrum-nb): usage chain marker placement (#714)

### DIFF
--- a/cmd/dhs/cmd_cerebrum_usage.go
+++ b/cmd/dhs/cmd_cerebrum_usage.go
@@ -216,7 +216,11 @@ func renderCerebrumUsageChain(w io.Writer, dest string, rows []cerebrumUsageRow,
 			branch = "└──"
 		}
 		chain := cerebrumUsageName(r.Srce, srcNames)
-		if len(r.Via) > 1 {
+		if len(r.Via) > 0 {
+			// The literal feed itself is the chain's first virtual hop
+			// — its marker sits next to ITS name, then each further
+			// hop upstream carries its own.
+			chain += " [virtual]"
 			for _, hop := range r.Via[1:] {
 				chain += "  ← " + cerebrumUsageName(hop, srcNames) + " [virtual]"
 			}
@@ -227,7 +231,6 @@ func renderCerebrumUsageChain(w io.Writer, dest string, rows []cerebrumUsageRow,
 			suffix = fmt.Sprintf("  [%s!]", r.Mark)
 		case len(r.Via) > 0:
 			suffix = fmt.Sprintf("  ← effective %s", cerebrumUsageName(r.Effective, srcNames))
-			chain += " [virtual]"
 		}
 		_, _ = fmt.Fprintf(w, "%s levels %s : fed by %s%s\n", branch, strings.Join(r.Levels, ";"), chain, suffix)
 	}

--- a/cmd/dhs/cmd_cerebrum_usage_test.go
+++ b/cmd/dhs/cmd_cerebrum_usage_test.go
@@ -106,8 +106,14 @@ func TestCerebrumUsageAsciiRenders(t *testing.T) {
 	var chain bytes.Buffer
 	renderCerebrumUsageChain(&chain, "1", rows, srcNames, dstNames)
 	c := chain.String()
-	if !strings.Contains(c, "effective Src 2 (2)") || !strings.Contains(c, "[virtual]") {
+	// Exact hop markers (live-found display bug 2026-08-19: the literal
+	// feed's [virtual] tag landed at the END, printing "[virtual]
+	// [virtual]"): each virtual name carries its own marker, once.
+	if !strings.Contains(c, "fed by Proc 2 (4) [virtual]  ← Proc 1 (3) [virtual]  ← effective Src 2 (2)") {
 		t.Fatalf("chain:\n%s", c)
+	}
+	if strings.Contains(c, "[virtual] [virtual]") {
+		t.Fatalf("doubled marker:\n%s", c)
 	}
 
 	// A dest fed by a PHYSICAL source (empty Via) must render without


### PR DESCRIPTION
Live-found on the owner-built two-virtual chain: the literal feed's virtual tag landed at the chain end, printing doubled markers. Each hop now carries its own, pinned exact-string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)