### PR TITLE
fix: root-cause CI timing flakes; ADR-0029 event-step matrix; drop retries + coverage union (#694)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,28 +46,12 @@ jobs:
       - name: Vet
         run: go vet ./...
 
+      # One pass, no retries (ADR-0029): the timing flakes that motivated
+      # the old 3-attempt loop were root-caused and fixed deterministically
+      # (acp2 waiter-death protocol, probel-sw02p pre-bound listener). A red
+      # here is a real problem in this commit.
       - name: Unit tests
-        shell: bash
-        run: |
-          set -o pipefail
-          # A few consumer/provider tests exercise goroutine / reconnect /
-          # timer timing (net.Pipe, fast reconnect backoff, keep-alive) that
-          # can flake on a loaded CI runner even when the code is correct —
-          # the same class the coverage-floor step already retries. Retry the
-          # suite up to 3x and pass on the first green; a genuine failure
-          # fails all three attempts. Root-causing individual flakes is still
-          # tracked separately — this only stops them gating merges.
-          for attempt in 1 2 3; do
-            echo "::group::unit tests (attempt $attempt/3)"
-            if go test -count=1 -race ./...; then
-              echo "::endgroup::"
-              exit 0
-            fi
-            echo "::endgroup::"
-            echo "::warning::unit tests failed on attempt $attempt/3; retrying"
-          done
-          echo "::error::unit tests failed after 3 attempts"
-          exit 1
+        run: go test -count=1 -race ./...
 
       - name: Unit tests (coverage)
         if: matrix.os == 'ubuntu-latest'
@@ -75,99 +59,83 @@ jobs:
 
       # Per-package coverage floor for the gold-template connectors. Fails
       # the build if a package drops below its locked-in level (no-regression).
-      # Raise these as the tiered coverage push lands (see issues #539, #550).
+      # Computed from the single whole-repo profile above — no per-package
+      # re-runs, no retries, no union (ADR-0029): statement coverage is
+      # deterministic by test design (no racy select arms, injectable
+      # timings, pre-bound listeners). Package rows are selected by
+      # "^dhs/<pkg>/<file>.go:" so nested packages stay separate; a floor
+      # package with no rows at all is a hard failure (renamed package
+      # guard). On a miss the exact uncovered blocks are printed.
       - name: Coverage floor (acp1 + acp2 + emberplus)
         if: matrix.os == 'ubuntu-latest'
         run: |
           set -e
-          # Concurrency packages (consumer/provider) have goroutine/timer
-          # branches whose statement coverage depends on scheduling, so a
-          # single run on a loaded CI runner can leave a genuinely-coverable
-          # line uncovered — and because a loaded runner stays loaded, the
-          # same line can miss on all three consecutive attempts (a plain
-          # retry then fails even though the code is 100%-coverable).
-          #
-          # Fix: UNION the coverage profiles across up to 5 attempts. A
-          # statement is counted covered if it was hit in ANY attempt, so a
-          # line that is coverable at all converges into the union within a few
-          # runs; the loop returns early as soon as the union meets the floor,
-          # so non-flaky packages still cost one run. With per-run miss rate p
-          # for a scheduling-dependent line, a 5-attempt union false-fails with
-          # probability ~p^5 (e.g. p=0.2 -> 3e-4). The 100% bar stays genuine:
-          # a line no test can EVER reach is absent from every profile, so the
-          # union stays below the floor and fails all five attempts.
-          #
-          # When it does fail, we print the exact uncovered file:line blocks
-          # from the union — so a genuine gap (or a stubborn scheduling line) is
-          # named and fixed deterministically instead of being a mystery retry.
-          #
-          # union_pct FILE...       -> prints the unioned statement coverage %.
-          # union_uncovered FILE... -> prints the blocks uncovered in the union.
-          # Coverprofile rows are "pkg/file.go:sL.sC,eL.eC <numStmt> <count>";
-          # the first line ("mode: set") is skipped per file.
-          union_pct() {
-            awk '
-              FNR==1 { next }
-              { stmts[$1]=$2; if ($3+0>0) covered[$1]=1 }
+          pkg_pct() {   # pkg_pct <pkg-path>  ->  "<pct> <rows>"
+            awk -v pkg="$1" '
+              BEGIN { re = "^dhs/" pkg "/[^/]+\\.go:" }
+              $0 !~ re { next }
+              { stmts[$1]=$2; if ($3+0>0) covered[$1]=1; rows++ }
               END {
                 tot=0; cov=0
                 for (k in stmts) { tot+=stmts[k]; if (k in covered) cov+=stmts[k] }
-                if (tot==0) { print "100.0"; exit }
-                printf "%.1f\n", 100*cov/tot
+                if (tot==0) { print "0.0 0"; exit }
+                printf "%.1f %d\n", 100*cov/tot, rows
               }
-            ' "$@"
+            ' coverage.out
           }
-          union_uncovered() {
-            awk '
-              FNR==1 { next }
+          pkg_uncovered() {
+            awk -v pkg="$1" '
+              BEGIN { re = "^dhs/" pkg "/[^/]+\\.go:" }
+              $0 !~ re { next }
               { stmts[$1]=$2; if ($3+0>0) covered[$1]=1 }
               END { for (k in stmts) if (!(k in covered)) print "    " k "  (" stmts[k] " stmt)" }
-            ' "$@" | sort
+            ' coverage.out | sort
           }
+          fail=0
           check() {
-            local pkg=$1 floor=$2 pct tag
-            tag=$(printf '%s' "$pkg" | tr '/.' '__')
-            local profs=()
-            for attempt in 1 2 3 4 5; do
-              local pf="cov_${tag}.${attempt}.out"
-              go test -count=1 -covermode=set -coverprofile="$pf" "$pkg" >/dev/null
-              profs+=("$pf")
-              pct=$(union_pct "${profs[@]}")
-              printf '%s: union %s%% (floor %s%%, after attempt %s)\n' "$pkg" "$pct" "$floor" "$attempt"
-              if awk "BEGIN{exit !(${pct:-0}+0 >= $floor)}"; then return 0; fi
-            done
-            echo "::error::$pkg union coverage ${pct}% below floor $floor% after 5 attempts"
-            echo "uncovered blocks in the 5-attempt union (cover these deterministically):"
-            union_uncovered "${profs[@]}"
-            exit 1
+            local pkg=$1 floor=$2 pct rows
+            read -r pct rows <<<"$(pkg_pct "$pkg")"
+            if [ "$rows" = "0" ]; then
+              echo "::error::$pkg has no rows in coverage.out (package renamed or untested?)"
+              fail=1
+              return
+            fi
+            printf '%s: %s%% (floor %s%%, %s blocks)\n' "$pkg" "$pct" "$floor" "$rows"
+            if ! awk "BEGIN{exit !(${pct:-0}+0 >= $floor)}"; then
+              echo "::error::$pkg coverage ${pct}% below floor $floor%"
+              echo "uncovered blocks (cover these deterministically):"
+              pkg_uncovered "$pkg"
+              fail=1
+            fi
           }
-          check ./internal/acp1/codec 100
-          check ./internal/acp1/consumer 100
-          check ./internal/acp1/provider 100
-          check ./internal/acp2/codec 100
-          check ./internal/acp2/consumer 100
-          check ./internal/acp2/provider 100
-          check ./internal/emberplus/codec/ber 100
-          check ./internal/emberplus/codec/glow 100
-          check ./internal/emberplus/codec/matrix 100
-          check ./internal/emberplus/codec/s101 100
-          check ./internal/emberplus/consumer 100
-          check ./internal/emberplus/provider 100
-          check ./internal/probel-sw02p/codec 100
-          check ./internal/probel-sw02p/consumer 100
-          check ./internal/probel-sw02p/provider 100
-          check ./internal/probel-sw08p/codec 100
-          check ./internal/probel-sw08p/consumer 100
-          check ./internal/probel-sw08p/provider 100
-          check ./internal/tsl/codec 100
-          check ./internal/tsl/consumer 100
-          check ./internal/tsl/provider 100
-          check ./internal/osc/codec 100
-          check ./internal/osc/consumer 100
-          check ./internal/osc/provider 100
-          check ./internal/cerebrum-nb/codec 100
-          check ./internal/cerebrum-nb/codec/ws 100
-          check ./internal/cerebrum-nb/consumer 100
+          check internal/acp1/codec 100
+          check internal/acp1/consumer 100
+          check internal/acp1/provider 100
+          check internal/acp2/codec 100
+          check internal/acp2/consumer 100
+          check internal/acp2/provider 100
+          check internal/emberplus/codec/ber 100
+          check internal/emberplus/codec/glow 100
+          check internal/emberplus/codec/matrix 100
+          check internal/emberplus/codec/s101 100
+          check internal/emberplus/consumer 100
+          check internal/emberplus/provider 100
+          check internal/probel-sw02p/codec 100
+          check internal/probel-sw02p/consumer 100
+          check internal/probel-sw02p/provider 100
+          check internal/probel-sw08p/codec 100
+          check internal/probel-sw08p/consumer 100
+          check internal/probel-sw08p/provider 100
+          check internal/tsl/codec 100
+          check internal/tsl/consumer 100
+          check internal/tsl/provider 100
+          check internal/osc/codec 100
+          check internal/osc/consumer 100
+          check internal/osc/provider 100
+          check internal/cerebrum-nb/codec 100
+          check internal/cerebrum-nb/codec/ws 100
+          check internal/cerebrum-nb/consumer 100
+          exit $fail
 
       - name: Upload coverage
         if: matrix.os == 'ubuntu-latest'
@@ -212,25 +180,13 @@ jobs:
       - name: Vet
         run: go vet ./...
 
-      # Same 3-attempt retry as the main test matrix — the container jobs
-      # were the one place a timing flake could still gate a merge (live
-      # case 2026-08-17: TestRunDiagnostics_ConnectionClosed on rocky9
-      # reddened a main push that every other platform passed).
+      # One pass, no retries (ADR-0029). The live case that motivated the
+      # old 3-attempt loop (TestRunDiagnostics_ConnectionClosed on rocky9,
+      # 2026-08-17) was root-caused: a select racing a ready reply channel
+      # against a closed done channel — fixed with the deterministic
+      # waiter-death protocol in internal/acp2/consumer.
       - name: Unit tests
-        shell: bash
-        run: |
-          set -o pipefail
-          for attempt in 1 2 3; do
-            echo "::group::unit tests (attempt $attempt/3)"
-            if go test -count=1 ./...; then
-              echo "::endgroup::"
-              exit 0
-            fi
-            echo "::endgroup::"
-            echo "::warning::unit tests failed on attempt $attempt/3; retrying"
-          done
-          echo "::error::unit tests failed after 3 attempts"
-          exit 1
+        run: go test -count=1 ./...
 
   lint:
     name: Lint

--- a/docs/adr/0029-ci-event-step-matrix.md
+++ b/docs/adr/0029-ci-event-step-matrix.md
@@ -1,0 +1,150 @@
+# ADR-0029 — CI event→step matrix, no retries, single-pass coverage
+
+Status: proposed
+
+This ADR is a living document. Add new facts in the Revisions trailer.
+
+## Context
+
+The CI pipeline grew by patching symptoms and drifted from its
+original clear/fast shape (issue #694, owner audit request
+2026-08-17). Two accretions dominated:
+
+- **3-attempt retry loops** around the unit-test step (main matrix
+  and the RHEL container jobs), added after
+  `TestRunDiagnostics_ConnectionClosed` reddened a main push on
+  rocky9 (2026-08-17) that every other platform passed.
+- **5-attempt coverage UNION** in the per-package coverage-floor
+  step, added because statement coverage of goroutine/timer select
+  arms depended on scheduling, so a genuinely-coverable line could
+  miss the 100% floor on a loaded runner.
+
+Both mechanisms treat nondeterminism as weather instead of as a bug.
+The owner flagged the union twice: it is slow (up to 5 test runs per
+package × 27 packages) and it can mask a real regression — a test
+that fails 1 run in 3 sails through a retry loop forever.
+
+The root causes were fixed on the same branch that lands this ADR:
+
+- **acp2/consumer** — request waiters raced a ready reply channel
+  against a closed `done` channel in one `select`; Go picks a ready
+  arm pseudo-randomly, so "reply" vs "connection closed" (and the
+  coverage of each arm) was a coin flip when the peer replied and
+  hung up in one burst. Fixed with a deterministic waiter-death
+  protocol: the read loop's exit sweeps the waiter table under the
+  registration mutex, delivering a nil sentinel to every waiter (a
+  reply already delivered survives), and later registrations fail
+  fast. Every waiter receives exactly one value — no racy select arm
+  remains, and the diag probe/announce timings became injectable so
+  the tests run in milliseconds.
+- **probel-sw02p/provider** — the salvo integration test grabbed a
+  free port by listen-close-relisten; a parallel test sweep can steal
+  the port inside that window. Fixed by pre-binding the listener and
+  handing it to the provider (`ServeListener` on the concrete type).
+  A repo-wide sweep converted every other CI-run instance of the same
+  pattern (emberplus consumer loopback fixtures via an emberplus
+  `ServeListener` seam; the acp1 UDP zero-byte test serves on `:0`
+  directly and reads the bound address off the server).
+
+With the causes gone, the retries and the union are dead code, and
+the pipeline can be written down as one auditable step chain per
+event type so it cannot drift again.
+
+## Decision
+
+### Event→step matrix
+
+`.github/workflows/ci.yml` is the **only** workflow file. Each event
+type has exactly the steps below — adding a step, a retry, or a new
+workflow file requires updating this ADR in the same PR.
+
+| Event | Where | Steps (in order) |
+|---|---|---|
+| **COMMIT** (local) | `.githooks/pre-commit` | `go vet ./...` → `golangci-lint run ./...` |
+| **PR** (`pull_request` → main) | ci.yml | test matrix (ubuntu/windows/macos): tidy → build → vet → unit `-race` **once** · RHEL containers (rocky9/ubi9): build → vet → unit **once** · lint · cross-compile. Concurrency: a new push cancels the in-progress run on the outdated commit. |
+| **MERGE** (`push` → main) | ci.yml | same verification as PR, **never cancelled** (every merge commit keeps its own complete run) + coverage profile + per-package coverage floor + release-please bookkeeping behind the full gate. |
+| **RELEASE** (release-please PR merged → tag) | ci.yml `build-release` | cross-compile all targets → Windows version resource → optional Authenticode signing → package archives → SHA-256 manifest → upload to the GitHub Release. Changelog is owned by release-please only. |
+
+The coverage steps also run on PRs (ubuntu leg) so a floor regression
+is caught before merge, not after.
+
+### No retries — a red is a red
+
+Retry loops around test steps are **forbidden**, in CI and in local
+scripts. A test that needs a retry is flaky, and a flaky test is a
+bug in the test or the code under test: root-cause it (the two fixes
+above are the worked examples) instead of hiding it. The only
+acceptable response to a transient-infrastructure failure (runner
+died, network blip fetching modules) is re-running the job by hand —
+visibly, not silently in a loop.
+
+### Single-pass, deterministic coverage
+
+- The per-package floor is computed from the **one** whole-repo
+  coverage profile (`go test -coverprofile ./...`) — no per-package
+  re-runs, no union. Package rows are selected by
+  `^dhs/<pkg>/[^/]+\.go:` so nested packages (e.g.
+  `cerebrum-nb/codec` vs `cerebrum-nb/codec/ws`) stay separate.
+- A floor package with **no rows** in the profile is a hard failure
+  (guards against a renamed package silently passing).
+- On failure the step prints the exact uncovered blocks — a gap is
+  named, never a mystery retry.
+
+**Determinism rule for new tests:** statement coverage of every
+branch must not depend on goroutine scheduling. The patterns that
+achieve this, proven on this branch:
+
+1. **No racy select arms** — when two select arms can be ready
+   simultaneously, restructure so each outcome has exactly one
+   deterministic delivery path (acp2 nil-sentinel waiter protocol).
+2. **Injectable timings** — production timeouts stay; tests inject
+   millisecond values through an options struct, never by editing
+   globals (acp2 `diagTimings`).
+3. **No listen-close-relisten** — tests bind `127.0.0.1:0` once and
+   pass the listener to the server under test.
+
+Evidence at adoption: all 27 floor packages measured 100.0% on
+consecutive independent single runs after the fixes (acp2/consumer
+5×, probel-sw02p/provider 3×, full sweep 1×; previously 99.6% racy
+on acp2/consumer).
+
+### Speed budget
+
+Measured job baselines on the last pre-slim main run (2026-08-19):
+Test ubuntu 5.8 min (this job carried the union sweep) · windows
+2.7 min · macos 2.3 min · rocky9 1.8 min · rhel9-ubi 1.5 min · lint
+0.6 min · cross-compile 1.4 min. The new floor check is pure awk over
+the existing whole-repo profile (seconds) — the union sweep it
+replaces cost up to 135 extra package test runs, so the ubuntu job is
+expected at ≈ 4 min. A job that doubles its baseline is a regression
+to investigate, not a budget to raise silently.
+
+### Considered and rejected
+
+- **`paths-ignore` for docs-only commits** — rejected. Skipping the
+  workflow on docs commits would leave merge commits on main without
+  their own complete verification (owner rule), stall release-please
+  bookkeeping until the next code commit, and leave required PR
+  checks pending on docs-only PRs. The single-pass speed work makes
+  full runs cheap enough that the exemption is not worth its edge
+  cases.
+- **Keeping the union "just in case"** — rejected. With p the
+  per-run miss probability, the union passes with ~1−p⁵ even when a
+  line is missed 80% of runs — that is exactly the masking the owner
+  flagged. Determinism is enforced at the test-design level instead.
+
+## Consequences
+
+- CI is one documented chain per event; a red run means a real
+  problem in that commit, worth reading every time.
+- The coverage floor keeps its no-regression meaning: a line no test
+  can reach fails the floor immediately, on every run.
+- New concurrency code must ship with deterministic test seams
+  (§Determinism rule) or it will red the floor honestly.
+- Issues #690/#691 layering (single-workflow release gating,
+  concurrency groups) is retained; only the retry/union accretions
+  are removed.
+
+## Revisions
+
+- 2026-08-19 — initial version (issue #694).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -58,6 +58,7 @@ There is no `superseded` / `deprecated` / `rejected-after-acceptance`.
 | [0026](0026-agent-communication-style.md) | Agent communication style | proposed |
 | [0027](0027-workflow-contract-dod-windows.md) | Workflow contract during DOD windows | proposed |
 | [0028](0028-artifact-layout.md) | Artifact layout — one deterministic home per artifact, keyed by IP | proposed |
+| [0029](0029-ci-event-step-matrix.md) | CI event→step matrix — no retries, single-pass coverage | proposed |
 
 ## ADR-0017 parking note
 

--- a/internal/acp1/consumer/discover.go
+++ b/internal/acp1/consumer/discover.go
@@ -94,15 +94,18 @@ func Discover(ctx context.Context, cfg DiscoverConfig) ([]DiscoverResult, error)
 	go func() {
 		defer close(done)
 		for {
-			remaining := time.Until(deadline)
-			if remaining <= 0 {
-				return
-			}
-			rxCtx, cancel := context.WithTimeout(ctx, remaining)
+			// Per-iteration ctx capped at the discovery deadline: once the
+			// deadline passes, Receive fails immediately (the transport maps
+			// an expired read deadline to context.DeadlineExceeded), so the
+			// err arm below is the loop's single exit path. A separate
+			// loop-top remaining<=0 check would only ever execute when a
+			// datagram lands right at the deadline — a scheduling-dependent
+			// branch (#694 coverage class).
+			rxCtx, cancel := context.WithDeadline(ctx, deadline)
 			raw, addr, err := listener.Receive(rxCtx, codec.MaxPacket)
 			cancel()
 			if err != nil {
-				// Timeout or ctx cancel → exit loop.
+				// Deadline expiry or ctx cancel → exit loop.
 				return
 			}
 			// unreachable type-assert guard elided: transport.UDPListener.

--- a/internal/acp1/consumer/listener.go
+++ b/internal/acp1/consumer/listener.go
@@ -169,13 +169,13 @@ func (l *Listener) loop(ctx context.Context) {
 			// errors.Is(err, net.ErrClosed) check was therefore unreachable.)
 
 			// Transient error — log at debug and keep looping. A short
-			// sleep avoids tight-spin if the same error recurs.
+			// sleep avoids tight-spin if the same error recurs; the
+			// loop-top ctx check bounds shutdown latency to one sleep.
+			// (A ctx.Done arm inside a select here only ever executed
+			// when cancellation landed inside the 10 ms window — a
+			// scheduling-dependent branch, #694 coverage class.)
 			l.logger.Debug("acp1 listener receive error (retrying)", "err", err)
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(10 * time.Millisecond):
-			}
+			time.Sleep(10 * time.Millisecond)
 			continue
 		}
 

--- a/internal/acp1/provider/server_cov100_test.go
+++ b/internal/acp1/provider/server_cov100_test.go
@@ -219,13 +219,26 @@ func TestReadLoop_ZeroByteDatagram(t *testing.T) {
 	s := newTestServer(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
-	// Bind an ephemeral UDP port via Serve.
-	ln, _ := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
-	addr := ln.LocalAddr().String()
-	_ = ln.Close()
-	go func() { done <- s.Serve(ctx, addr) }()
-	// Wait until the server is up, then send a zero-byte datagram.
-	time.Sleep(80 * time.Millisecond)
+	// Serve on an ephemeral port directly and read the bound address off
+	// the server — no probe-socket close-then-rebind (the freed port can
+	// be stolen by a parallel test process, #694 flake class).
+	go func() { done <- s.Serve(ctx, "127.0.0.1:0") }()
+	var addr string
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		s.mu.Lock()
+		if s.conn != nil {
+			addr = s.conn.LocalAddr().String()
+		}
+		s.mu.Unlock()
+		if addr != "" {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if addr == "" {
+		t.Fatal("server socket never bound")
+	}
 	c, err := net.Dial("udp4", addr)
 	if err == nil {
 		_, _ = c.Write([]byte{})

--- a/internal/acp2/consumer/coverage_batch2_final_test.go
+++ b/internal/acp2/consumer/coverage_batch2_final_test.go
@@ -691,15 +691,16 @@ func TestKeepAliveProber_CtxCanceled(t *testing.T) {
 	p.ka.stopped.Wait()
 }
 
-// TestRunDiagnostics_ConnectionClosed covers the "connection closed"
-// (sess.done) arms of all three probe closures plus the announce-listen
-// loop: the server completes the AN2 + ACP2 handshake, then closes the
-// connection, so every subsequent probe's select takes the <-sess.done case
-// (and the announce loop breaks on sess.done). Skipped under -short.
+// TestRunDiagnostics_ConnectionClosed covers the connection-closed probe
+// outcomes plus the announce-listen loop's done arm: the server completes
+// the AN2 + ACP2 handshake, then closes the connection, so every probe
+// deterministically reports "error: connection closed" — the first probe
+// via either the nil sentinel or the addWaiter fail-fast (whichever side
+// of the readLoop exit it lands on), every later probe via fail-fast
+// (once one probe has observed the death, waitersDead is already set).
+// The announce window (1s) is longer than the probes take, so its select
+// deterministically takes the already-closed sess.done arm.
 func TestRunDiagnostics_ConnectionClosed(t *testing.T) {
-	if testing.Short() {
-		t.Skip("RunDiagnostics has multi-second probe timeouts; skipped in -short")
-	}
 	host, port, stop := handshakeListener(t, 5, func(c net.Conn, f *codec.AN2Frame) {
 		// First ACP2 frame is the handshake get_version. Answer it, then
 		// close so all RunDiagnostics probes see a dead session.
@@ -712,31 +713,32 @@ func TestRunDiagnostics_ConnectionClosed(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	results, err := RunDiagnostics(ctx, host, port, 1, testLogger())
+	// probe is generous: no probe in this test ever waits it out (each
+	// resolves via sentinel/fail-fast) — a short value here would let a
+	// stalled CI runner turn a pending sentinel into a spurious timeout.
+	results, err := runDiagnostics(ctx, host, port, 1, testLogger(),
+		diagTimings{probe: 2 * time.Second, announce: time.Second})
 	if err != nil {
-		t.Fatalf("RunDiagnostics: %v", err)
+		t.Fatalf("runDiagnostics: %v", err)
 	}
-	var sawClosed bool
+	if len(results) == 0 {
+		t.Fatal("runDiagnostics returned no results")
+	}
 	for _, r := range results {
-		if r.Status == "error: connection closed" {
-			sawClosed = true
-			break
+		if r.Status != "error: connection closed" {
+			t.Errorf("probe %q status = %q, want 'error: connection closed'", r.Name, r.Status)
 		}
-	}
-	if !sawClosed {
-		t.Error("expected at least one 'connection closed' probe result")
 	}
 }
 
-// TestRunDiagnostics_CloseDuringACMP covers the sess.done arms of the
-// sendACMP + sendProto4 closures: the server handshakes, answers ACP2 data
-// probes with errors, then closes the connection the moment it receives the
-// first ACMP (proto=3) frame — so that probe's select (its sendFrame already
-// succeeded into the socket buffer) observes sess.done. Skipped under -short.
+// TestRunDiagnostics_CloseDuringACMP deterministically covers BOTH
+// connection-death probe paths: the server handshakes, answers ACP2 data
+// probes with errors, then closes the connection the moment it receives
+// the first ACMP (proto=3) frame. That probe registered its waiter before
+// sending, so it resolves via the nil sentinel ("connection closed"); the
+// probes after it start with waitersDead already set, so they resolve via
+// the addWaiter fail-fast path.
 func TestRunDiagnostics_CloseDuringACMP(t *testing.T) {
-	if testing.Short() {
-		t.Skip("RunDiagnostics has multi-second probe timeouts; skipped in -short")
-	}
 	host, port, stop := rawListener(t, func(c net.Conn) {
 		defer func() { _ = c.Close() }()
 		_ = c.SetDeadline(time.Now().Add(10 * time.Second))
@@ -777,8 +779,8 @@ func TestRunDiagnostics_CloseDuringACMP(t *testing.T) {
 					MTID: 0, Type: codec.AN2TypeData,
 					Payload: []byte{byte(codec.ACP2TypeError), f.Payload[1], byte(codec.ErrInvalidObjID), 0}})
 			default:
-				// First ACMP (proto=3) or proto=4 frame → close so the probe's
-				// select hits <-sess.done (its sendFrame already succeeded).
+				// First ACMP (proto=3) or proto=4 frame → close so that
+				// probe (already registered + sent) gets the nil sentinel.
 				return
 			}
 		}
@@ -787,19 +789,30 @@ func TestRunDiagnostics_CloseDuringACMP(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	if _, err := RunDiagnostics(ctx, host, port, 1, testLogger()); err != nil {
-		t.Fatalf("RunDiagnostics: %v", err)
+	results, err := runDiagnostics(ctx, host, port, 1, testLogger(),
+		diagTimings{probe: 2 * time.Second, announce: time.Second})
+	if err != nil {
+		t.Fatalf("runDiagnostics: %v", err)
+	}
+	// The three ACMP probes + the proto=4 probe follow the close: all four
+	// must report the connection death, never a timeout.
+	var closed int
+	for _, r := range results {
+		if r.Status == "error: connection closed" {
+			closed++
+		}
+	}
+	if closed < 4 {
+		t.Errorf("got %d 'connection closed' probes, want >= 4; results=%+v", closed, results)
 	}
 }
 
-// TestRunDiagnostics_CloseDuringProto4 covers sendProto4's sess.done arm:
-// the server handshakes, lets the ACP2 + ACMP probes run to completion
-// (ACMP replies are dropped → 3 s timeouts), then closes the connection on
-// the first proto=4 frame so that probe's select observes sess.done.
+// TestRunDiagnostics_CloseDuringProto4 covers the probe timeout arm (the
+// ACMP replies are dropped while the connection stays alive, so those
+// probes deterministically wait out the injected probe timeout) and the
+// late connection death: the server closes on the first proto=4 frame,
+// so that probe resolves via the nil sentinel.
 func TestRunDiagnostics_CloseDuringProto4(t *testing.T) {
-	if testing.Short() {
-		t.Skip("RunDiagnostics has multi-second probe timeouts; skipped in -short")
-	}
 	host, port, stop := rawListener(t, func(c net.Conn) {
 		defer func() { _ = c.Close() }()
 		_ = c.SetDeadline(time.Now().Add(30 * time.Second))
@@ -839,9 +852,9 @@ func TestRunDiagnostics_CloseDuringProto4(t *testing.T) {
 					MTID: 0, Type: codec.AN2TypeData,
 					Payload: []byte{byte(codec.ACP2TypeError), f.Payload[1], byte(codec.ErrInvalidObjID), 0}})
 			case 3:
-				// ACMP probe — drop (no reply) so it runs to its 3 s timeout.
+				// ACMP probe — drop (no reply) so it waits out the probe timeout.
 			default:
-				// proto=4 probe → close so its select hits <-sess.done.
+				// proto=4 probe → close so it resolves via the nil sentinel.
 				return
 			}
 		}
@@ -850,34 +863,40 @@ func TestRunDiagnostics_CloseDuringProto4(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	if _, err := RunDiagnostics(ctx, host, port, 1, testLogger()); err != nil {
-		t.Fatalf("RunDiagnostics: %v", err)
+	results, err := runDiagnostics(ctx, host, port, 1, testLogger(),
+		diagTimings{probe: 300 * time.Millisecond, announce: 50 * time.Millisecond})
+	if err != nil {
+		t.Fatalf("runDiagnostics: %v", err)
+	}
+	// The three dropped-reply ACMP probes must report the timeout arm.
+	var timeouts int
+	for _, r := range results {
+		if r.Status == "timeout (300ms)" {
+			timeouts++
+		}
+	}
+	if timeouts < 3 {
+		t.Errorf("got %d timeout probes, want >= 3; results=%+v", timeouts, results)
 	}
 }
 
 // TestRunDiagnostics_ErrorReplies covers the ACP2 error-reply status arm
-// (msg.Type == error) in the sendRaw probe path: the server answers every
-// ACP2 data probe with an error frame. Skipped under -short because the
-// ACMP / proto=4 probes still run to their 3 s timeout.
+// (msg.Type == error) in the probe path: the server answers every ACP2
+// data probe with an error frame. The ACMP / proto=4 probes (replies
+// dropped by the readLoop) wait out the short injected probe timeout.
 func TestRunDiagnostics_ErrorReplies(t *testing.T) {
-	if testing.Short() {
-		t.Skip("RunDiagnostics has multi-second probe timeouts; skipped in -short")
-	}
 	srv, host, port := newFakeServer(t)
 	srv.onACP2 = func(slot uint8, req *codec.ACP2Message) *codec.ACP2Message {
 		return errorReply(codec.ErrInvalidObjID) // every ACP2 probe → fast error reply
 	}
 	defer srv.stop()
 
-	// Generous ctx so it stays live through the ACMP / proto=4 probes (whose
-	// replies the session readLoop drops → they run to their 3 s timeout,
-	// covering the sendACMP / sendProto4 timeout arms). A short ctx would
-	// expire mid-run and shunt later probes into the allocMTID-error path.
-	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	results, err := RunDiagnostics(ctx, host, port, 1, testLogger())
+	results, err := runDiagnostics(ctx, host, port, 1, testLogger(),
+		diagTimings{probe: 300 * time.Millisecond, announce: 50 * time.Millisecond})
 	if err != nil {
-		t.Fatalf("RunDiagnostics: %v", err)
+		t.Fatalf("runDiagnostics: %v", err)
 	}
 	var sawErr bool
 	for _, r := range results {

--- a/internal/acp2/consumer/diag.go
+++ b/internal/acp2/consumer/diag.go
@@ -16,10 +16,91 @@ type DiagResult struct {
 	Reply   string // hex of reply payload (if any)
 }
 
+// diagTimings bounds the per-probe reply wait and the announce-listen
+// window. Injectable so unit tests run in milliseconds; RunDiagnostics
+// always uses the production defaults.
+type diagTimings struct {
+	probe    time.Duration // per-probe reply timeout
+	announce time.Duration // announce-listen window before the obj-id probes
+}
+
+func defaultDiagTimings() diagTimings {
+	return diagTimings{probe: 3 * time.Second, announce: 2 * time.Second}
+}
+
+// diagProbe sends raw ACP2-shaped bytes inside one AN2 frame on any AN2
+// proto and resolves the outcome deterministically: a real reply, the
+// nil sentinel (connection died — see Session.failWaiters), the probe
+// timeout, or a fail-fast when the read loop already exited. Note that
+// the session readLoop only routes proto 0 (internal) and proto 2 (ACP2)
+// to waiters, so probes on proto 3 (ACMP) / proto 4 (vendor) can never
+// receive a real reply — only the timeout or the connection-closed
+// sentinel.
+func diagProbe(ctx context.Context, sess *Session, name string, proto codec.AN2Proto, an2Slot uint8, an2Type codec.AN2Type, payload []byte, probeTimeout time.Duration) DiagResult {
+	r := DiagResult{Name: name, Sent: fmt.Sprintf("%x", payload)}
+
+	// unreachable: allocMTID only errors on ctx cancellation. The diag
+	// probes run sequentially, each releasing its mtid before the next,
+	// so the 255-slot pool is never exhausted and (with a live ctx)
+	// alloc always succeeds.
+	mtid, _ := sess.allocMTID(ctx)
+	defer sess.releaseMTID(mtid)
+
+	// Patch mtid into payload byte 1 (ACP2 header byte 1 = mtid)
+	if len(payload) >= 2 {
+		payload[1] = mtid
+	}
+	r.Sent = fmt.Sprintf("%x", payload)
+
+	frame := &codec.AN2Frame{
+		Proto:   proto,
+		Slot:    an2Slot,
+		MTID:    0,
+		Type:    an2Type,
+		Payload: payload,
+	}
+
+	ch, werr := sess.addWaiter(mtid)
+	if werr != nil {
+		// The read loop already exited — no reply can ever arrive.
+		r.Status = "error: connection closed"
+		return r
+	}
+	defer sess.removeWaiter(mtid)
+
+	if serr := sess.sendFrame(ctx, frame); serr != nil {
+		r.Status = "error: send: " + serr.Error()
+		return r
+	}
+
+	timer := time.NewTimer(probeTimeout)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		r.Status = fmt.Sprintf("timeout (%s)", probeTimeout)
+	case msg := <-ch:
+		if msg == nil {
+			r.Status = "error: connection closed"
+			return r
+		}
+		if msg.Type == codec.ACP2TypeError {
+			r.Status = fmt.Sprintf("error: stat=%d", msg.Func)
+		} else {
+			r.Status = fmt.Sprintf("ok: type=%d func=%d", msg.Type, msg.Func)
+		}
+		r.Reply = fmt.Sprintf("%x", msg.Body)
+	}
+	return r
+}
+
 // RunDiagnostics connects to the device, completes the AN2 handshake,
 // then sends a series of ACP2 request variants to discover which
 // format the device accepts. Returns results for all probes.
 func RunDiagnostics(ctx context.Context, host string, port int, slot uint8, logger *slog.Logger) ([]DiagResult, error) {
+	return runDiagnostics(ctx, host, port, slot, logger, defaultDiagTimings())
+}
+
+func runDiagnostics(ctx context.Context, host string, port int, slot uint8, logger *slog.Logger, timings diagTimings) ([]DiagResult, error) {
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -32,80 +113,22 @@ func RunDiagnostics(ctx context.Context, host string, port int, slot uint8, logg
 
 	var results []DiagResult
 
-	// Helper: send raw ACP2 bytes inside AN2 data frame, wait for reply.
-	sendRaw := func(name string, an2Slot uint8, an2Type codec.AN2Type, payload []byte) DiagResult {
-		r := DiagResult{Name: name, Sent: fmt.Sprintf("%x", payload)}
-
-		// Allocate mtid.
-		// unreachable: allocMTID only errors on ctx cancellation. The diag
-		// probes run sequentially, each releasing its mtid before the next, so
-		// the 255-slot pool is never exhausted and (with a live ctx) alloc
-		// always succeeds.
-		mtid, _ := sess.allocMTID(ctx)
-		defer sess.releaseMTID(mtid)
-
-		// Patch mtid into payload byte 1 (ACP2 header byte 1 = mtid)
-		if len(payload) >= 2 {
-			payload[1] = mtid
-		}
-		r.Sent = fmt.Sprintf("%x", payload)
-
-		frame := &codec.AN2Frame{
-			Proto:   codec.AN2ProtoACP2,
-			Slot:    an2Slot,
-			MTID:    0,
-			Type:    an2Type,
-			Payload: payload,
-		}
-
-		ch := make(chan *codec.ACP2Message, 1)
-		sess.waitMu.Lock()
-		sess.waiters[mtid] = ch
-		sess.waitMu.Unlock()
-		defer func() {
-			sess.waitMu.Lock()
-			delete(sess.waiters, mtid)
-			sess.waitMu.Unlock()
-		}()
-
-		if serr := sess.sendFrame(ctx, frame); serr != nil {
-			r.Status = "error: send: " + serr.Error()
-			return r
-		}
-
-		timer := time.NewTimer(3 * time.Second)
-		defer timer.Stop()
-		select {
-		case <-timer.C:
-			r.Status = "timeout (3s)"
-		case <-sess.done:
-			r.Status = "error: connection closed"
-		case msg := <-ch:
-			// unreachable nil check: routeReply only ever sends a non-nil
-			// *ACP2Message into the waiter channel, so msg is never nil here.
-			if msg.Type == codec.ACP2TypeError {
-				r.Status = fmt.Sprintf("error: stat=%d", msg.Func)
-				r.Reply = fmt.Sprintf("%x", msg.Body)
-			} else {
-				r.Status = fmt.Sprintf("ok: type=%d func=%d", msg.Type, msg.Func)
-				r.Reply = fmt.Sprintf("%x", msg.Body)
-			}
-		}
-		return r
+	sendProbe := func(name string, proto codec.AN2Proto, an2Slot uint8, an2Type codec.AN2Type, payload []byte) DiagResult {
+		return diagProbe(ctx, sess, name, proto, an2Slot, an2Type, payload, timings.probe)
 	}
 
 	// --- Probe 1: get_object as spec says (12 bytes) on target slot via AN2 data ---
-	results = append(results, sendRaw(
+	results = append(results, sendProbe(
 		"get_object spec (AN2 data, 12 bytes)",
-		slot, codec.AN2TypeData,
+		codec.AN2ProtoACP2, slot, codec.AN2TypeData,
 		[]byte{0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 	))
 
 	// --- Probe 2: get_property pid=1 (object_type) on obj-id 0 ---
 	// Tests if ANY body-carrying function works.
-	results = append(results, sendRaw(
+	results = append(results, sendProbe(
 		"get_property pid=1 (AN2 data, 16 bytes)",
-		slot, codec.AN2TypeData,
+		codec.AN2ProtoACP2, slot, codec.AN2TypeData,
 		[]byte{
 			0x00, 0x00, 0x02, 0x01, // type=req, mtid, func=get_property, pid=1
 			0x00, 0x00, 0x00, 0x00, // obj-id=0
@@ -115,39 +138,39 @@ func RunDiagnostics(ctx context.Context, host string, port int, slot uint8, logg
 	))
 
 	// --- Probe 3: get_object without idx (8 bytes) ---
-	results = append(results, sendRaw(
+	results = append(results, sendProbe(
 		"get_object no idx (AN2 data, 8 bytes)",
-		slot, codec.AN2TypeData,
+		codec.AN2ProtoACP2, slot, codec.AN2TypeData,
 		[]byte{0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00},
 	))
 
 	// --- Probe 4: get_object minimal (4 bytes, like get_version but func=1) ---
-	results = append(results, sendRaw(
+	results = append(results, sendProbe(
 		"get_object minimal (AN2 data, 4 bytes)",
-		slot, codec.AN2TypeData,
+		codec.AN2ProtoACP2, slot, codec.AN2TypeData,
 		[]byte{0x00, 0x00, 0x01, 0x00},
 	))
 
 	// --- Probe 5: get_object via AN2 type=request instead of type=data ---
-	results = append(results, sendRaw(
+	results = append(results, sendProbe(
 		"get_object spec (AN2 REQUEST, 12 bytes)",
-		slot, codec.AN2TypeRequest,
+		codec.AN2ProtoACP2, slot, codec.AN2TypeRequest,
 		[]byte{0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 	))
 
 	// --- Probe 6: get_object with func byte prefix (like AN2 internal) ---
 	// What if the device expects: funcID(u8) + ACP2 payload?
-	results = append(results, sendRaw(
+	results = append(results, sendProbe(
 		"get_object with func prefix (AN2 data, 13 bytes)",
-		slot, codec.AN2TypeData,
+		codec.AN2ProtoACP2, slot, codec.AN2TypeData,
 		[]byte{0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 	))
 
 	// --- Probe 7: get_object on slot 0 (controller) ---
 	if slot != 0 {
-		results = append(results, sendRaw(
+		results = append(results, sendProbe(
 			"get_object spec on slot 0 (AN2 data, 12 bytes)",
-			0, codec.AN2TypeData,
+			codec.AN2ProtoACP2, 0, codec.AN2TypeData,
 			[]byte{0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 		))
 	}
@@ -157,9 +180,9 @@ func RunDiagnostics(ctx context.Context, host string, port int, slot uint8, logg
 	// dispatch falls through to the default case in handlers.go and
 	// replies with ErrProtocol. Covers the stat=0 fixture that no
 	// legal-framed probe can produce.
-	results = append(results, sendRaw(
+	results = append(results, sendProbe(
 		"unknown func=0xFF (AN2 data, 4 bytes)",
-		slot, codec.AN2TypeData,
+		codec.AN2ProtoACP2, slot, codec.AN2TypeData,
 		[]byte{0x00, 0x00, 0xFF, 0x00},
 	))
 
@@ -167,134 +190,31 @@ func RunDiagnostics(ctx context.Context, host string, port int, slot uint8, logg
 	// The device supports ACMP on both slots. Cerebrum might use ACMP
 	// instead of ACP2 to browse the object tree.
 
-	sendACMP := func(name string, an2Slot uint8, payload []byte) DiagResult {
-		r := DiagResult{Name: name, Sent: fmt.Sprintf("%x", payload)}
-
-		// unreachable: allocMTID only errors on ctx cancellation; the diag
-		// probes are sequential and release before the next, so the pool is
-		// never exhausted and (with a live ctx) alloc always succeeds.
-		mtid, _ := sess.allocMTID(ctx)
-		defer sess.releaseMTID(mtid)
-
-		if len(payload) >= 2 {
-			payload[1] = mtid
-		}
-		r.Sent = fmt.Sprintf("%x", payload)
-
-		frame := &codec.AN2Frame{
-			Proto:   3, // ACMP
-			Slot:    an2Slot,
-			MTID:    0,
-			Type:    codec.AN2TypeData,
-			Payload: payload,
-		}
-
-		ch := make(chan *codec.ACP2Message, 1)
-		sess.waitMu.Lock()
-		sess.waiters[mtid] = ch
-		sess.waitMu.Unlock()
-		defer func() {
-			sess.waitMu.Lock()
-			delete(sess.waiters, mtid)
-			sess.waitMu.Unlock()
-		}()
-
-		if serr := sess.sendFrame(ctx, frame); serr != nil {
-			r.Status = "error: send: " + serr.Error()
-			return r
-		}
-
-		timer := time.NewTimer(3 * time.Second)
-		defer timer.Stop()
-		// unreachable reply arm: readLoop routes only AN2 proto 0 (internal) and
-		// proto 2 (ACP2) to waiters; ACMP (proto=3) frames hit readLoop's default
-		// "ignore" arm, so the waiter channel `ch` never receives a reply here.
-		// Only the timeout and connection-closed arms can fire.
-		select {
-		case <-timer.C:
-			r.Status = "timeout (3s)"
-		case <-sess.done:
-			r.Status = "error: connection closed"
-		}
-		return r
-	}
-
 	// --- Probe 8: ACMP get_object (same ACP2 format, proto=3) ---
-	results = append(results, sendACMP(
+	results = append(results, sendProbe(
 		"ACMP get_object spec (proto=3, 12 bytes)",
-		slot,
+		3, slot, codec.AN2TypeData,
 		[]byte{0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 	))
 
 	// --- Probe 9: ACMP get_object minimal (proto=3, 4 bytes) ---
-	results = append(results, sendACMP(
+	results = append(results, sendProbe(
 		"ACMP get_object minimal (proto=3, 4 bytes)",
-		slot,
+		3, slot, codec.AN2TypeData,
 		[]byte{0x00, 0x00, 0x01, 0x00},
 	))
 
 	// --- Probe 10: ACMP get_version (proto=3, 4 bytes) ---
-	results = append(results, sendACMP(
+	results = append(results, sendProbe(
 		"ACMP get_version (proto=3, 4 bytes)",
-		slot,
+		3, slot, codec.AN2TypeData,
 		[]byte{0x00, 0x00, 0x00, 0x00},
 	))
 
 	// --- Probe 11: proto=4 get_object (vendor extension?) ---
-	sendProto4 := func(name string, payload []byte) DiagResult {
-		r := DiagResult{Name: name, Sent: fmt.Sprintf("%x", payload)}
-
-		// unreachable: allocMTID only errors on ctx cancellation; the diag
-		// probes are sequential and release before the next, so the pool is
-		// never exhausted and (with a live ctx) alloc always succeeds.
-		mtid, _ := sess.allocMTID(ctx)
-		defer sess.releaseMTID(mtid)
-
-		if len(payload) >= 2 {
-			payload[1] = mtid
-		}
-		r.Sent = fmt.Sprintf("%x", payload)
-
-		frame := &codec.AN2Frame{
-			Proto:   4, // vendor extension
-			Slot:    slot,
-			MTID:    0,
-			Type:    codec.AN2TypeData,
-			Payload: payload,
-		}
-
-		ch := make(chan *codec.ACP2Message, 1)
-		sess.waitMu.Lock()
-		sess.waiters[mtid] = ch
-		sess.waitMu.Unlock()
-		defer func() {
-			sess.waitMu.Lock()
-			delete(sess.waiters, mtid)
-			sess.waitMu.Unlock()
-		}()
-
-		if serr := sess.sendFrame(ctx, frame); serr != nil {
-			r.Status = "error: send: " + serr.Error()
-			return r
-		}
-
-		timer := time.NewTimer(3 * time.Second)
-		defer timer.Stop()
-		// unreachable reply arm: readLoop routes only AN2 proto 0 (internal) and
-		// proto 2 (ACP2) to waiters; proto=4 (vendor) frames hit readLoop's
-		// default "ignore" arm, so the waiter channel `ch` never receives a reply
-		// here. Only the timeout and connection-closed arms can fire.
-		select {
-		case <-timer.C:
-			r.Status = "timeout (3s)"
-		case <-sess.done:
-			r.Status = "error: connection closed"
-		}
-		return r
-	}
-
-	results = append(results, sendProto4(
+	results = append(results, sendProbe(
 		"proto=4 get_object (vendor, 12 bytes)",
+		4, slot, codec.AN2TypeData,
 		[]byte{0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 	))
 
@@ -302,22 +222,17 @@ func RunDiagnostics(ctx context.Context, host string, port int, slot uint8, logg
 	// The announces show obj-ids like 0x00018696. Try get_object with a
 	// real obj-id to test if the issue is "obj-id 0 doesn't exist".
 
-	// Listen for announces for 2 seconds to discover a real obj-id.
-	logger.Info("acp2 diag: listening for announces to discover real obj-ids (2s)...")
+	// Give a chatty device an announce window before the obj-id probes.
+	// Announce decoding happens in the session readLoop; this is a pure
+	// wait, cut short if the connection dies.
+	logger.Info("acp2 diag: listening for announces to discover real obj-ids...",
+		"window", timings.announce)
 	var discoveredObjIDs []uint32
-	annoTimer := time.NewTimer(2 * time.Second)
-	announceLoop:
-	for {
-		select {
-		case <-annoTimer.C:
-			break announceLoop
-		case <-sess.done:
-			break announceLoop
-		default:
-			// Check if any announce has been decoded by the reader.
-			// We peek at the raw frames the reader processes.
-			time.Sleep(50 * time.Millisecond)
-		}
+	annoTimer := time.NewTimer(timings.announce)
+	defer annoTimer.Stop()
+	select {
+	case <-annoTimer.C:
+	case <-sess.done:
 	}
 
 	// If we couldn't discover dynamically, use obj-ids seen in the log.
@@ -331,9 +246,9 @@ func RunDiagnostics(ctx context.Context, host string, port int, slot uint8, logg
 			byte(objID >> 24), byte(objID >> 16), byte(objID >> 8), byte(objID),
 			0x00, 0x00, 0x00, 0x00, // idx=0
 		}
-		results = append(results, sendRaw(
+		results = append(results, sendProbe(
 			fmt.Sprintf("get_object obj-id=0x%08X", objID),
-			slot, codec.AN2TypeData,
+			codec.AN2ProtoACP2, slot, codec.AN2TypeData,
 			payload,
 		))
 	}

--- a/internal/acp2/consumer/diag_loopback_test.go
+++ b/internal/acp2/consumer/diag_loopback_test.go
@@ -9,18 +9,11 @@ import (
 	"dhs/internal/acp2/codec"
 )
 
-// diag_loopback_test.go drives RunDiagnostics against the loopback peer.
-//
-// The happy path (TestRunDiagnostics) answers ACP2 data probes and is
-// gated behind -short being OFF because RunDiagnostics has hard-coded
-// 3 s per-probe timeouts plus a 2 s announce-listen window, and the
-// session readLoop drops proto=3 (ACMP) / proto=4 frames, so those
-// probes always run to their full 3 s timeout. Total ~15 s — kept out
-// of the fast path. The cheap dial-error path always runs.
+// diag_loopback_test.go drives the diagnostics run against the loopback
+// peer. The happy path answers ACP2 data probes; the session readLoop
+// drops proto=3 (ACMP) / proto=4 frames, so those probes wait out the
+// short injected probe timeout (production keeps the 3 s default).
 func TestRunDiagnostics(t *testing.T) {
-	if testing.Short() {
-		t.Skip("RunDiagnostics has hard-coded multi-second probe timeouts; skipped in -short")
-	}
 	srv, host, port := newFakeServer(t)
 
 	// Answer every ACP2 data request with a generic reply echoing mtid.
@@ -56,9 +49,10 @@ func TestRunDiagnostics(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	results, err := RunDiagnostics(ctx, host, port, 1, testLogger())
+	results, err := runDiagnostics(ctx, host, port, 1, testLogger(),
+		diagTimings{probe: 300 * time.Millisecond, announce: 50 * time.Millisecond})
 	if err != nil {
-		t.Fatalf("RunDiagnostics: %v", err)
+		t.Fatalf("runDiagnostics: %v", err)
 	}
 	if len(results) == 0 {
 		t.Fatal("RunDiagnostics returned no results")

--- a/internal/acp2/consumer/session.go
+++ b/internal/acp2/consumer/session.go
@@ -45,9 +45,13 @@ type Session struct {
 	mtidPool [255]bool // mtidPool[i] true = mtid (i+1) is in use
 	mtidCond *sync.Cond
 
-	// Pending request waiters: keyed by ACP2 mtid.
-	waitMu  sync.Mutex
-	waiters map[uint8]chan *codec.ACP2Message
+	// Pending request waiters: keyed by ACP2 mtid. waitersDead flips to
+	// true (under waitMu) when the read loop exits — after that no reply
+	// can ever arrive, so addWaiter refuses new registrations and
+	// failWaiters has already delivered the nil sentinel to existing ones.
+	waitMu      sync.Mutex
+	waiters     map[uint8]chan *codec.ACP2Message
+	waitersDead bool
 
 	// Announce listeners.
 	annMu     sync.Mutex
@@ -160,7 +164,10 @@ func (s *Session) Connect(ctx context.Context, ip string, port int) error {
 	s.host = ip
 	s.port = port
 	s.done = make(chan struct{})
+	s.waitMu.Lock()
 	s.waiters = make(map[uint8]chan *codec.ACP2Message)
+	s.waitersDead = false
+	s.waitMu.Unlock()
 
 	// Start the reader goroutine before the handshake so replies are routed.
 	// Pass conn explicitly: the loop must read from the exact connection this
@@ -298,15 +305,11 @@ func (s *Session) an2Request(ctx context.Context, funcID uint8, slot uint8, payl
 	// with a convention: AN2 internal replies come back with proto=0 and
 	// AN2 mtid matching. The reader goroutine routes them to a synthetic
 	// ACP2Message with MTID=an2MTID.
-	ch := make(chan *codec.ACP2Message, 1)
-	s.waitMu.Lock()
-	s.waiters[an2MTID] = ch
-	s.waitMu.Unlock()
-	defer func() {
-		s.waitMu.Lock()
-		delete(s.waiters, an2MTID)
-		s.waitMu.Unlock()
-	}()
+	ch, err := s.addWaiter(an2MTID)
+	if err != nil {
+		return nil, err
+	}
+	defer s.removeWaiter(an2MTID)
 
 	if err := s.sendFrame(ctx, frame); err != nil {
 		return nil, err
@@ -315,11 +318,11 @@ func (s *Session) an2Request(ctx context.Context, funcID uint8, slot uint8, payl
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
-	case <-s.done:
-		return nil, fmt.Errorf("acp2: connection closed")
 	case msg := <-ch:
-		// unreachable nil check: routeReply only ever sends a non-nil
-		// *ACP2Message into the waiter channel, so msg is never nil here.
+		if msg == nil {
+			// failWaiters' sentinel: the connection died before a reply.
+			return nil, fmt.Errorf("acp2: connection closed")
+		}
 		return msg.Body, nil
 	}
 }
@@ -353,15 +356,11 @@ func (s *Session) DoACP2(ctx context.Context, slot uint8, req *codec.ACP2Message
 		Payload: payload,
 	}
 
-	ch := make(chan *codec.ACP2Message, 1)
-	s.waitMu.Lock()
-	s.waiters[mtid] = ch
-	s.waitMu.Unlock()
-	defer func() {
-		s.waitMu.Lock()
-		delete(s.waiters, mtid)
-		s.waitMu.Unlock()
-	}()
+	ch, err := s.addWaiter(mtid)
+	if err != nil {
+		return nil, err
+	}
+	defer s.removeWaiter(mtid)
 
 	s.logger.Debug("acp2: sending request",
 		"slot", slot, "mtid", mtid, "func", req.Func,
@@ -375,11 +374,11 @@ func (s *Session) DoACP2(ctx context.Context, slot uint8, req *codec.ACP2Message
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
-	case <-s.done:
-		return nil, fmt.Errorf("acp2: connection closed while waiting for reply mtid=%d", mtid)
 	case reply := <-ch:
-		// unreachable nil check: routeReply only ever sends a non-nil
-		// *ACP2Message into the waiter channel, so reply is never nil here.
+		if reply == nil {
+			// failWaiters' sentinel: the connection died before a reply.
+			return nil, fmt.Errorf("acp2: connection closed while waiting for reply mtid=%d", mtid)
+		}
 		if reply.Type == codec.ACP2TypeError {
 			// Fire the per-stat-code compliance event so the session
 			// profile reflects spec-listed error frequencies. Status
@@ -442,6 +441,7 @@ func (s *Session) sendFrame(ctx context.Context, f *codec.AN2Frame) error {
 // pattern of capturing the conn locally and tolerating a closed socket.
 func (s *Session) readLoop(conn net.Conn) {
 	defer close(s.done)
+	defer s.failWaiters() // LIFO: waiters are swept before done closes
 
 	for {
 		frame, err := codec.ReadAN2Frame(conn)
@@ -596,6 +596,52 @@ func (s *Session) routeReply(mtid uint8, msg *codec.ACP2Message) {
 	} else {
 		s.logger.Debug("acp2: no waiter for mtid", "mtid", mtid)
 		s.note(OrphanReplyMtid)
+	}
+}
+
+// addWaiter registers a buffered reply channel for a mtid. It refuses
+// once the read loop has exited: after that point no reply can ever
+// arrive, and failWaiters' nil-sentinel sweep has already run, so a
+// late registrant would block until its context expired.
+func (s *Session) addWaiter(mtid uint8) (chan *codec.ACP2Message, error) {
+	ch := make(chan *codec.ACP2Message, 1)
+	s.waitMu.Lock()
+	defer s.waitMu.Unlock()
+	if s.waitersDead {
+		return nil, fmt.Errorf("acp2: connection closed")
+	}
+	s.waiters[mtid] = ch
+	return ch, nil
+}
+
+// removeWaiter drops the reply channel registered for a mtid.
+func (s *Session) removeWaiter(mtid uint8) {
+	s.waitMu.Lock()
+	delete(s.waiters, mtid)
+	s.waitMu.Unlock()
+}
+
+// failWaiters marks the waiter table dead and delivers a nil sentinel to
+// every registered waiter. It runs from readLoop's exit path, before done
+// is closed. waitMu serialises the sweep against addWaiter, so every
+// waiter deterministically receives exactly one value: the real reply
+// when routeReply delivered it before the connection died (the buffered
+// channel is already full, so the sentinel send is skipped), or nil.
+//
+// This is what makes "reply then immediate close" deterministic: waiters
+// used to select on s.done next to the reply channel, and when the peer
+// replied and hung up in one burst both arms were ready — Go picks a
+// ready select arm pseudo-randomly, so the outcome (and the statement
+// coverage) was a coin flip (issue #694 flake class).
+func (s *Session) failWaiters() {
+	s.waitMu.Lock()
+	defer s.waitMu.Unlock()
+	s.waitersDead = true
+	for _, ch := range s.waiters {
+		select {
+		case ch <- nil:
+		default: // real reply already buffered — the waiter takes that
+		}
 	}
 }
 

--- a/internal/acp2/consumer/session_waiters_test.go
+++ b/internal/acp2/consumer/session_waiters_test.go
@@ -1,0 +1,127 @@
+package acp2
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"dhs/internal/acp2/codec"
+	"dhs/internal/consumer"
+)
+
+// session_waiters_test.go pins the deterministic waiter-death protocol
+// (issue #694): the readLoop exit sweeps every registered waiter with a
+// nil sentinel under waitMu, preserving an already-delivered reply, and
+// later registrations fail fast. No test here depends on scheduling.
+
+// TestFailWaiters_SentinelAndPreservedReply drives failWaiters directly:
+// an empty waiter gets the nil sentinel, a waiter whose reply was already
+// delivered keeps the real reply (the sentinel send is skipped), and any
+// registration after the sweep is refused.
+func TestFailWaiters_SentinelAndPreservedReply(t *testing.T) {
+	s := NewSession(testLogger())
+
+	chEmpty, err := s.addWaiter(1)
+	if err != nil {
+		t.Fatalf("addWaiter(1): %v", err)
+	}
+	chFull, err := s.addWaiter(2)
+	if err != nil {
+		t.Fatalf("addWaiter(2): %v", err)
+	}
+	// Simulate routeReply having delivered before the connection died.
+	chFull <- &codec.ACP2Message{Type: codec.ACP2TypeReply, MTID: 2}
+
+	s.failWaiters()
+
+	if msg := <-chEmpty; msg != nil {
+		t.Errorf("empty waiter got %+v, want the nil sentinel", msg)
+	}
+	if msg := <-chFull; msg == nil || msg.MTID != 2 {
+		t.Errorf("delivered reply not preserved across the sweep: %+v", msg)
+	}
+	if _, err := s.addWaiter(3); err == nil {
+		t.Error("addWaiter after failWaiters must refuse")
+	}
+}
+
+// TestDoACP2_FailFastAfterDeath covers DoACP2's addWaiter error return:
+// once the read loop has exited, the request is refused before any frame
+// is sent (no connection needed).
+func TestDoACP2_FailFastAfterDeath(t *testing.T) {
+	s := NewSession(testLogger())
+	s.failWaiters()
+
+	_, err := s.DoACP2(context.Background(), 0, &codec.ACP2Message{
+		Type: codec.ACP2TypeRequest,
+		Func: codec.ACP2FuncGetVersion,
+	})
+	if err == nil || !strings.Contains(err.Error(), "connection closed") {
+		t.Fatalf("DoACP2 on dead session: got %v, want connection-closed error", err)
+	}
+}
+
+// TestAN2Request_FailFastAfterDeath covers an2Request's addWaiter error
+// return on a session whose read loop has exited.
+func TestAN2Request_FailFastAfterDeath(t *testing.T) {
+	s := NewSession(testLogger())
+	s.failWaiters()
+
+	_, err := s.an2Request(context.Background(), codec.AN2FuncGetVersion, 0, nil)
+	if err == nil || !strings.Contains(err.Error(), "connection closed") {
+		t.Fatalf("an2Request on dead session: got %v, want connection-closed error", err)
+	}
+}
+
+// TestRequests_SendErrorNotConnected covers the sendFrame error returns of
+// DoACP2 and an2Request (and sendFrame's conn==nil guard): the waiter table
+// is alive, but there is no connection to write to.
+func TestRequests_SendErrorNotConnected(t *testing.T) {
+	s := NewSession(testLogger())
+
+	_, err := s.DoACP2(context.Background(), 0, &codec.ACP2Message{
+		Type: codec.ACP2TypeRequest,
+		Func: codec.ACP2FuncGetVersion,
+	})
+	if !errors.Is(err, consumer.ErrNotConnected) {
+		t.Fatalf("DoACP2 without a conn: got %v, want ErrNotConnected", err)
+	}
+
+	_, err = s.an2Request(context.Background(), codec.AN2FuncGetVersion, 0, nil)
+	if !errors.Is(err, consumer.ErrNotConnected) {
+		t.Fatalf("an2Request without a conn: got %v, want ErrNotConnected", err)
+	}
+}
+
+// TestSendFrame_WriteError covers sendFrame's conn.Write error arm with a
+// deterministically dead pipe (no TCP race involved).
+func TestSendFrame_WriteError(t *testing.T) {
+	s := NewSession(testLogger())
+	c1, c2 := net.Pipe()
+	_ = c1.Close()
+	_ = c2.Close()
+	s.conn = c1
+
+	err := s.sendFrame(context.Background(), &codec.AN2Frame{
+		Proto: codec.AN2ProtoACP2, Type: codec.AN2TypeData, Payload: []byte{0, 0, 0, 0},
+	})
+	var te *consumer.TransportError
+	if !errors.As(err, &te) || te.Op != "send" {
+		t.Fatalf("sendFrame on closed pipe: got %v, want TransportError{Op: send}", err)
+	}
+}
+
+// TestDiagProbe_SendError covers diagProbe's send-error status arm: the
+// waiter table is alive but the session has no connection, so the probe
+// reports the send failure verbatim.
+func TestDiagProbe_SendError(t *testing.T) {
+	s := NewSession(testLogger())
+	r := diagProbe(context.Background(), s, "probe", codec.AN2ProtoACP2, 1,
+		codec.AN2TypeData, []byte{0x00, 0x00, 0x01, 0x00}, 100*time.Millisecond)
+	if !strings.HasPrefix(r.Status, "error: send: ") {
+		t.Fatalf("probe status = %q, want 'error: send: ...'", r.Status)
+	}
+}

--- a/internal/acp2/consumer/session_waiters_test.go
+++ b/internal/acp2/consumer/session_waiters_test.go
@@ -3,8 +3,11 @@ package acp2
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -73,6 +76,64 @@ func TestAN2Request_FailFastAfterDeath(t *testing.T) {
 	_, err := s.an2Request(context.Background(), codec.AN2FuncGetVersion, 0, nil)
 	if err == nil || !strings.Contains(err.Error(), "connection closed") {
 		t.Fatalf("an2Request on dead session: got %v, want connection-closed error", err)
+	}
+}
+
+// msgWaiter is a slog.Handler that signals a channel the first time a
+// record with the wanted message is handled. It lets a test observe
+// "this code path executed" without polling or sleeping.
+type msgWaiter struct {
+	want string
+	ch   chan struct{}
+	once sync.Once
+}
+
+func (h *msgWaiter) Enabled(context.Context, slog.Level) bool { return true }
+func (h *msgWaiter) Handle(_ context.Context, r slog.Record) error {
+	if r.Message == h.want {
+		h.once.Do(func() { close(h.ch) })
+	}
+	return nil
+}
+func (h *msgWaiter) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *msgWaiter) WithGroup(string) slog.Handler      { return h }
+
+// TestRunReconnectBackoff_FailureArm deterministically covers the
+// backoff loop's attempt-failed arm (warn + delay doubling). The loop
+// dials a dead port, so the first attempt always fails; the test waits
+// for the logged failure (msgWaiter — no timing guess) before closing
+// rc.done to stop the loop. Previously this arm was only covered when
+// TestReconnect_BackoffRetries' relisten goroutine happened to lose an
+// 850 ms scheduling race (#694 coverage class, named by the CI floor).
+func TestRunReconnectBackoff_FailureArm(t *testing.T) {
+	// A dead port: bind, close. Even if another process grabs it, the
+	// reconnect attempt still fails (an AN2 handshake against a stranger
+	// errors), which is all this test needs.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	host, portStr, _ := net.SplitHostPort(ln.Addr().String())
+	port, _ := strconv.Atoi(portStr)
+	_ = ln.Close()
+
+	failed := &msgWaiter{want: "acp2 reconnect: attempt failed", ch: make(chan struct{})}
+	p := &Plugin{logger: slog.New(failed)}
+	p.rc = &reconnectState{done: make(chan struct{})}
+
+	loopDone := make(chan struct{})
+	go func() { p.runReconnectBackoff(host, port); close(loopDone) }()
+
+	select {
+	case <-failed.ch: // the failure arm ran
+	case <-time.After(15 * time.Second):
+		t.Fatal("backoff loop never logged a failed attempt")
+	}
+	close(p.rc.done)
+	select {
+	case <-loopDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("backoff loop did not stop on rc.done")
 	}
 }
 

--- a/internal/cerebrum-nb/codec/ws/dial_upgrade_error_test.go
+++ b/internal/cerebrum-nb/codec/ws/dial_upgrade_error_test.go
@@ -1,0 +1,38 @@
+package ws
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestDial_UpgradeRequestError covers Dial's upgradeRequest-failure arm
+// (close the dialed conn, wrap as "ws: write upgrade") deterministically:
+// the rand seam fails the nonce read, so upgradeRequest errors before a
+// single byte hits the wire — no TCP reset race involved. Previously
+// this branch was only hit when a peer happened to reset the socket
+// mid-upgrade (#694 coverage class: single-run statement coverage must
+// not depend on scheduling).
+func TestDial_UpgradeRequestError(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+	// No Accept needed: the TCP connect completes via the kernel backlog,
+	// and Dial fails before the upgrade request is written.
+
+	defer setRandRead(func(b []byte) (int, error) {
+		return 0, errors.New("rand broken")
+	})()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err = Dial(ctx, "ws://"+ln.Addr().String(), nil)
+	if err == nil || !strings.Contains(err.Error(), "write upgrade") {
+		t.Fatalf("Dial with failing rand: got %v, want 'ws: write upgrade' error", err)
+	}
+}

--- a/internal/emberplus/consumer/coverage_livesession_test.go
+++ b/internal/emberplus/consumer/coverage_livesession_test.go
@@ -281,22 +281,21 @@ func startStreamMatrixProvider(t *testing.T) (string, func()) {
 		Access: canonical.AccessRead, Children: []canonical.Element{meter, mtx},
 	}}
 	srv := (&provider.Factory{}).New(nil, &canonical.Export{Root: root})
+	// Pre-bound listener: no close-then-rebind port-steal window and no
+	// dial-poll (#694 flake class).
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
 	addr := ln.Addr().String()
-	_ = ln.Close()
-	ctx, cancel := context.WithCancel(context.Background())
-	go func() { _ = srv.Serve(ctx, addr) }()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if c, derr := net.DialTimeout("tcp", addr, 100*time.Millisecond); derr == nil {
-			_ = c.Close()
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
+	sl, ok := srv.(interface {
+		ServeListener(context.Context, net.Listener) error
+	})
+	if !ok {
+		t.Fatal("provider does not expose ServeListener")
 	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { _ = sl.ServeListener(ctx, ln) }()
 	return addr, func() { cancel(); _ = srv.Stop() }
 }
 

--- a/internal/emberplus/consumer/coverage_loopback_test.go
+++ b/internal/emberplus/consumer/coverage_loopback_test.go
@@ -54,27 +54,23 @@ func startLoopbackProvider(t *testing.T) (string, func()) {
 
 	srv := (&provider.Factory{}).New(nil, &canonical.Export{Root: root})
 
-	// Grab a free port.
+	// Pre-bind the listener and hand it to the provider: no
+	// close-then-rebind window (port-steal race, #694 flake class) and
+	// no dial-poll — the kernel backlog queues connects from Listen on.
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
 	addr := ln.Addr().String()
-	_ = ln.Close()
+	sl, ok := srv.(interface {
+		ServeListener(context.Context, net.Listener) error
+	})
+	if !ok {
+		t.Fatal("provider does not expose ServeListener")
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	go func() { _ = srv.Serve(ctx, addr) }()
-
-	// Wait until the provider accepts connections.
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		c, derr := net.DialTimeout("tcp", addr, 100*time.Millisecond)
-		if derr == nil {
-			_ = c.Close()
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	go func() { _ = sl.ServeListener(ctx, ln) }()
 	return addr, func() { cancel(); _ = srv.Stop() }
 }
 

--- a/internal/emberplus/provider/coverage_test.go
+++ b/internal/emberplus/provider/coverage_test.go
@@ -274,6 +274,46 @@ func TestServe_TreeNotLoaded(t *testing.T) {
 	}
 }
 
+// TestServeListener covers the pre-bound-listener entry point (#694):
+// the happy path serves on the handed-over listener, and the nil-tree
+// guard closes it before erroring.
+func TestServeListener(t *testing.T) {
+	srv := newServer(nil, buildRichExport())
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	errc := make(chan error, 1)
+	go func() { errc <- srv.ServeListener(ctx, ln) }()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	_ = conn.Close()
+
+	cancel()
+	select {
+	case <-errc:
+	case <-time.After(2 * time.Second):
+		t.Error("ServeListener did not return after ctx cancel")
+	}
+
+	// Nil-tree guard: the listener must be closed on refusal.
+	bad := newServer(nil, &canonical.Export{})
+	ln2, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	if err := bad.ServeListener(context.Background(), ln2); err == nil {
+		t.Error("ServeListener with no tree should error")
+	}
+	if _, err := ln2.Accept(); err == nil {
+		t.Error("listener should be closed after the nil-tree refusal")
+	}
+}
+
 // TestServe_BadAddr covers the listen error path.
 func TestServe_BadAddr(t *testing.T) {
 	srv := newServer(nil, buildRichExport())

--- a/internal/emberplus/provider/server.go
+++ b/internal/emberplus/provider/server.go
@@ -66,6 +66,23 @@ func (s *server) Serve(ctx context.Context, addr string) error {
 	if err != nil {
 		return fmt.Errorf("listen %s: %w", addr, err)
 	}
+	return s.serveListener(ctx, ln)
+}
+
+// ServeListener serves on a pre-bound listener. Exported on the concrete
+// type (not part of the neutral provider.Provider interface) so tests in
+// other packages can bind "127.0.0.1:0" themselves and skip the
+// close-then-rebind window of the addr-based path — in a parallel test
+// sweep another process can steal the freed port (issue #694 flake class).
+func (s *server) ServeListener(ctx context.Context, ln net.Listener) error {
+	if s.tree == nil {
+		_ = ln.Close()
+		return fmt.Errorf("emberplus-provider: tree not loaded")
+	}
+	return s.serveListener(ctx, ln)
+}
+
+func (s *server) serveListener(ctx context.Context, ln net.Listener) error {
 	s.mu.Lock()
 	s.listener = ln
 	s.mu.Unlock()

--- a/internal/probel-sw02p/provider/integration_test.go
+++ b/internal/probel-sw02p/provider/integration_test.go
@@ -60,32 +60,29 @@ func TestIntegrationSalvoBroadcastsConnectedAcrossSessions(t *testing.T) {
 	srv := &provider.Factory{}
 	prov := srv.New(logger, exp)
 
+	// Pre-bind the listener and hand it to the provider: no
+	// close-then-rebind window (another process in a parallel test
+	// sweep can steal the freed port — #694 flake class), and no
+	// dial-poll needed — the kernel backlog queues connects from the
+	// moment Listen returns.
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
 	addr := ln.Addr().String()
-	if err := ln.Close(); err != nil {
-		t.Fatalf("close probe listener: %v", err)
+	sl, ok := prov.(interface {
+		ServeListener(context.Context, net.Listener) error
+	})
+	if !ok {
+		t.Fatal("provider does not expose ServeListener")
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	serveDone := make(chan error, 1)
 	go func() {
-		serveDone <- prov.Serve(ctx, addr)
+		serveDone <- sl.ServeListener(ctx, ln)
 	}()
-
-	// Wait up to 1 s for the listener to come online.
-	deadline := time.Now().Add(1 * time.Second)
-	for time.Now().Before(deadline) {
-		c, derr := net.DialTimeout("tcp", addr, 100*time.Millisecond)
-		if derr == nil {
-			_ = c.Close()
-			break
-		}
-		time.Sleep(25 * time.Millisecond)
-	}
 
 	// Two consumer plugins connect to the same provider.
 	fA := &consumer.Factory{}
@@ -148,8 +145,12 @@ func TestIntegrationSalvoBroadcastsConnectedAcrossSessions(t *testing.T) {
 	})
 	_ = aSawGoDone
 
-	// A stages three crosspoints under salvo 5.
-	sendCtx, sendCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	// A stages three crosspoints under salvo 5. Deadlines here and
+	// below are generous: the success path exits as soon as the frames
+	// land (loopback, microseconds), so the budget is only ever spent
+	// when something is genuinely broken — a tight budget just lets a
+	// stalled CI runner fake a failure.
+	sendCtx, sendCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer sendCancel()
 	for _, s := range []struct{ dst, src uint16 }{{0, 1}, {1, 2}, {2, 3}} {
 		if _, err := plA.SendConnectOnGoGroupSalvo(sendCtx, s.dst, s.src, 5, false); err != nil {
@@ -166,8 +167,8 @@ func TestIntegrationSalvoBroadcastsConnectedAcrossSessions(t *testing.T) {
 		t.Fatalf("A fire: %v (subscribe saw tx 38 on A? %v)", err, saw)
 	}
 
-	// Wait up to 2 s for B to observe 3 × tx 04 + 1 × tx 38.
-	deadline = time.Now().Add(2 * time.Second)
+	// Wait for B to observe 3 × tx 04 + 1 × tx 38 (early-exit poll).
+	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
 		bMu.Lock()
 		ready := len(bConnected) >= 3 && bGoDone != nil
@@ -200,7 +201,7 @@ func TestIntegrationSalvoBroadcastsConnectedAcrossSessions(t *testing.T) {
 	cancel()
 	select {
 	case <-serveDone:
-	case <-time.After(2 * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Error("provider Serve did not return after ctx cancel")
 	}
 }

--- a/internal/probel-sw02p/provider/server.go
+++ b/internal/probel-sw02p/provider/server.go
@@ -120,6 +120,17 @@ func (s *server) Serve(ctx context.Context, addr string) error {
 	return s.serveListener(ctx, ln)
 }
 
+// ServeListener accepts client sessions on a pre-bound listener until
+// ctx is cancelled. Exported on the concrete type (not part of the
+// neutral provider.Provider interface) so external-package tests can
+// bind "127.0.0.1:0" themselves and skip the close-then-rebind window
+// of the addr-based path — in a parallel test sweep another process
+// can steal the port between the probe listener's Close and Serve's
+// re-listen (issue #694 flake class).
+func (s *server) ServeListener(ctx context.Context, ln net.Listener) error {
+	return s.serveListener(ctx, ln)
+}
+
 // serveListener accepts client sessions on a pre-bound listener until
 // ctx is cancelled. Used by Serve once the listener is open and by
 // in-process tests that want to skip the close-then-rebind race


### PR DESCRIPTION
Closes #694.

The owner-requested CI audit, delivered as its three work items: the timing flakes root-caused and fixed deterministically, the compensating retry/union machinery removed, and the pipeline written down as one auditable step chain per event type (ADR-0029).

## Root causes fixed

**acp2/consumer — `TestRunDiagnostics_ConnectionClosed` class** (the live 2026-08-17 rocky9 main-push red). Request waiters selected on `<-s.done` next to their reply channel. When the peer replied and hung up in one burst, both arms were ready and Go picks a ready select arm pseudo-randomly — so "reply" vs "connection closed" was a coin flip, and the statement coverage of each arm was scheduling-dependent (the reason the coverage union existed). Fix: a deterministic waiter-death protocol — the read loop's exit sweeps the waiter table under the registration mutex (nil sentinel to every waiter, an already-delivered reply survives), and late registrations fail fast. Every waiter receives exactly one value; no racy select arm remains. The diag probe/announce timings became injectable, so the four formerly multi-second diag tests now run in milliseconds with strengthened assertions.

**probel-sw02p/provider — `TestIntegrationSalvoBroadcastsConnectedAcrossSessions`.** The test grabbed a free port by listen-close-relisten; in a parallel sweep another process can steal the port inside that window. Fix: `ServeListener` exported on the concrete provider type (neutral interface untouched) so the test pre-binds `127.0.0.1:0` and hands the listener over — no rebind window, no dial-poll.

## CI slimmed (ADR-0029)

- Unit tests run **once** everywhere; both 3-attempt retry loops removed.
- Coverage floor computed from the single whole-repo `coverage.out` with awk — the 5-attempt per-package union sweep removed (up to 135 package test runs saved on the ubuntu job, expected ≈ 5.8 → ≈ 4 min). Missing-package hard-fail guard added; misses print exact uncovered blocks.
- `paths-ignore` for docs-only commits considered and rejected (documented in the ADR): every merge commit on main keeps its own complete verification and release-please bookkeeping.

## Evidence

- acp2/consumer: 100.0% coverage on 5 consecutive single runs (was a stable-but-racy 99.6/100 union split); 30× stress of the flake class green.
- probel-sw02p/provider: 10× stress green; 100.0% on 3 single runs.
- All 27 floor packages: 100.0% single-pass, one full sweep.
- New floor step mirrored locally against a real whole-repo profile: 27/27 pass, renamed-package guard fires, sub-floor path prints uncovered blocks.
- 3 consecutive full-suite runs green with retries already removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
