### PR TITLE
ci: release-please PR stops spawning action_required runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,16 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # The release-please PR touches ONLY these two bot-owned files and is
+    # re-force-pushed on every merge to main; each force-push spawned a CI
+    # run that parked at action_required (bot-authored PR + workflow
+    # approval policy) — pure noise, never green (ADR-0029 revision
+    # 2026-08-19). Skipping the PR event for exactly these files kills
+    # that. Push-to-main verification is untouched: the release merge
+    # commit still gets its own complete run.
+    paths-ignore:
+      - CHANGELOG.md
+      - .release-please-manifest.json
 
 # One live run per ref: a new push to a PR branch cancels the in-progress
 # run on the outdated commit (no more two same-titled rows per PR). Runs on

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
             awk -v pkg="$1" '
               BEGIN { re = "^dhs/" pkg "/[^/]+\\.go:" }
               $0 !~ re { next }
+              $2+0 == 0 { next }   # zero-statement blocks cannot affect the pct
               { stmts[$1]=$2; if ($3+0>0) covered[$1]=1 }
               END { for (k in stmts) if (!(k in covered)) print "    " k "  (" stmts[k] " stmt)" }
             ' coverage.out | sort

--- a/docs/adr/0029-ci-event-step-matrix.md
+++ b/docs/adr/0029-ci-event-step-matrix.md
@@ -128,6 +128,16 @@ to investigate, not a budget to raise silently.
   checks pending on docs-only PRs. The single-pass speed work makes
   full runs cheap enough that the exemption is not worth its edge
   cases.
+
+  One narrow exception (revision 2026-08-19): the **pull_request**
+  trigger ignores `CHANGELOG.md` + `.release-please-manifest.json` —
+  the two bot-owned files that are the release-please PR's entire
+  diff. That PR is force-pushed on every merge to main, and each
+  force-push spawned a CI run that parked at `action_required`
+  (bot-authored PR + workflow approval policy): permanent noise in
+  the Actions list, never a real verification. The `push` trigger is
+  untouched, so the release merge commit itself still gets its own
+  complete run — the owner rule holds.
 - **Keeping the union "just in case"** — rejected. With p the
   per-run miss probability, the union passes with ~1−p⁵ even when a
   line is missed 80% of runs — that is exactly the masking the owner
@@ -148,3 +158,7 @@ to investigate, not a budget to raise silently.
 ## Revisions
 
 - 2026-08-19 — initial version (issue #694).
+- 2026-08-19 — pull_request trigger ignores the two release-please
+  bot files (CHANGELOG.md, .release-please-manifest.json) so the
+  release PR stops spawning permanently-action_required runs on
+  every merge; push-to-main verification unchanged.

--- a/internal/emberplus/consumer/coverage_session_loops_test.go
+++ b/internal/emberplus/consumer/coverage_session_loops_test.go
@@ -136,6 +136,51 @@ func TestKeepAliveLoop_Tick(t *testing.T) {
 	}
 }
 
+// TestKeepAliveLoop_ClosedSession deterministically covers the tick arm's
+// closed-session return: the session is marked closed BEFORE the loop
+// starts and keepAliveDone stays open, so the first tick is the only
+// possible wake-up and must exit through the closed check. (Previously
+// this arm was only hit when a tick raced Disconnect inside the
+// tick-vs-done window — #694 coverage class, named by the CI floor.)
+func TestKeepAliveLoop_ClosedSession(t *testing.T) {
+	s, _, _, cleanup := wireSession(t, 5*time.Millisecond, time.Hour)
+	defer cleanup()
+
+	s.mu.Lock()
+	s.closed = true
+	s.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() { s.keepAliveLoop(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Error("keepAliveLoop did not exit on the closed-session check")
+	}
+}
+
+// TestKeepAliveLoop_WriteError deterministically covers the tick arm's
+// write-failure return: the underlying pipe is closed before the loop
+// starts (session NOT marked closed, keepAliveDone open), so the first
+// tick reaches WriteFrame and gets an immediate ErrClosedPipe.
+func TestKeepAliveLoop_WriteError(t *testing.T) {
+	s, _, _, cleanup := wireSession(t, 5*time.Millisecond, time.Hour)
+	defer cleanup()
+
+	s.mu.Lock()
+	c := s.conn
+	s.mu.Unlock()
+	_ = c.Close() // writer now fails instantly; closed flag stays false
+
+	done := make(chan struct{})
+	go func() { s.keepAliveLoop(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Error("keepAliveLoop did not exit on the keep-alive write error")
+	}
+}
+
 // TestDeadManLoop_Fires drives deadManLoop with a tiny threshold and a
 // backdated lastRX so it declares the session dead and fires the
 // disconnected state change.


### PR DESCRIPTION
Answers the owner's question: why duplicate Actions runs for the same task, and why the release-please PR looks mismatched.

**Findings (verified against the run list + PR #696):**
- The per-merge *pair* (PR run + main push run) is by design — ADR-0029 keeps every main commit fully verified.
- The actual noise: every merge force-pushes `release-please--branches--main`, and each force-push spawned a CI run that parked at **action_required** (bot-authored PR + workflow approval policy) — one permanently-pending ""chore(main): release 0.17.0"" row per merge, and the release PR shows no checks at all.
- Nothing blocks the release: PR #696 is MERGEABLE (main has no required status checks); it simply waited on the owner's release gate.

**Fix:** the release PR's diff is always exactly `CHANGELOG.md` + `.release-please-manifest.json`, so the `pull_request` trigger now ignores those two bot-owned files — no run is created for the release PR at all. The `push` trigger is untouched: the release merge commit still gets its own complete run. ADR-0029 carries the revision (narrow exception to the rejected broad paths-ignore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)