### PR TITLE
fix(acp2): serve object labels verbatim - absorb the device charset deviation

### DIFF
--- a/internal/acp2/provider/label_charset_test.go
+++ b/internal/acp2/provider/label_charset_test.go
@@ -2,47 +2,45 @@ package acp2
 
 import "testing"
 
-// TestSanitizeLabel pins the spec invariant from acp2_protocol.docx
-// §"Versions" line 357: object labels MUST contain only characters
-// from `[A-Za-z0-9 \-]`. Any other character is replaced with `-`
-// before the label hits the wire (pid=2). The unmodified label stays
-// on the canonical element so other tooling can see the original.
-func TestSanitizeLabel(t *testing.T) {
+// TestWireLabel pins the emulation-fidelity contract: labels are served
+// VERBATIM (pid=2), even when they violate the spec charset of
+// acp2_protocol.docx §"Versions" line 357 — the real EVS Neuron emits
+// "ROOT_NODE_V2" with an underscore, and controllers (Cerebrum's Neuron
+// driver, live-proven 2026-08-20) bind their default object model by
+// exact label paths. The 2026-05-08 rewrite-to-charset behaviour
+// orphaned the whole tree behind a renamed root. The deviation is
+// surfaced via labelDeviatesSpec + the newTree counter instead of a
+// silent mutation. Empty labels still default to "obj" (spec mandates
+// non-empty).
+func TestWireLabel(t *testing.T) {
 	cases := []struct {
-		name  string
-		in    string
-		out   string
-		dirty bool // whether the function should have changed the input
+		name string
+		in   string
+		out  string
 	}{
-		// Compliant labels round-trip identity.
-		{"all-lower", "abcdef", "abcdef", false},
-		{"mixed-case-digits", "Card1234", "Card1234", false},
-		{"with-space", "User Label 1", "User Label 1", false},
-		{"with-dash", "Slot-A", "Slot-A", false},
-		{"compound", "PSU - NPU0500-B", "PSU - NPU0500-B", false},
-		{"channel-N", "CHANNEL 01", "CHANNEL 01", false},
-
-		// Real-Neuron deviations — spec violations sanitised.
-		{"underscore", "ROOT_NODE_V2", "ROOT-NODE-V2", true},
-		{"dot", "Sample.Rate", "Sample-Rate", true},
-		{"colon", "MAC:01:23", "MAC-01-23", true},
-		{"slash", "A/B", "A-B", true},
-		{"equal-sign", "Mode=Auto", "Mode-Auto", true},
-
-		// Non-ASCII gets stripped.
-		{"non-ascii", "Café", "Caf-", true},
-
-		// Edge cases.
-		{"empty", "", "obj", true},
-		{"all-invalid", "___", "obj", true},
+		{"compliant", "User Label 1", "User Label 1"},
+		{"underscore-verbatim", "ROOT_NODE_V2", "ROOT_NODE_V2"},
+		{"dot-verbatim", "Sample.Rate", "Sample.Rate"},
+		{"non-ascii-verbatim", "Café", "Café"},
+		{"empty", "", "obj"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := sanitizeLabel(c.in)
-			if got != c.out {
-				t.Errorf("sanitizeLabel(%q) = %q; want %q", c.in, got, c.out)
+			if got := wireLabel(c.in); got != c.out {
+				t.Errorf("wireLabel(%q) = %q; want %q", c.in, got, c.out)
 			}
 		})
+	}
+}
+
+// TestLabelDeviatesSpec pins the deviation predicate used for the
+// absorb-and-surface count.
+func TestLabelDeviatesSpec(t *testing.T) {
+	if labelDeviatesSpec("PSU - NPU0500-B") {
+		t.Error("compliant label flagged as deviating")
+	}
+	if !labelDeviatesSpec("ROOT_NODE_V2") {
+		t.Error("underscore label not flagged")
 	}
 }
 

--- a/internal/acp2/provider/server.go
+++ b/internal/acp2/provider/server.go
@@ -61,6 +61,13 @@ func newServer(logger *slog.Logger, exp *canonical.Export) *server {
 		return s
 	}
 	s.tree = t
+	if t.labelDeviations > 0 {
+		// Absorb-and-surface: the emulated device's labels violate the
+		// spec charset (real Neuron uses underscores). Served VERBATIM —
+		// controllers bind by exact labels — and reported here.
+		logger.Warn("acp2 provider: labels outside the spec charset served verbatim",
+			slog.Int("count", t.labelDeviations))
+	}
 	return s
 }
 

--- a/internal/acp2/provider/tree.go
+++ b/internal/acp2/provider/tree.go
@@ -48,6 +48,11 @@ type tree struct {
 	mu      sync.RWMutex
 	perSlot map[uint8]map[uint32]*entry
 	slotN   uint8
+	// labelDeviations counts entries whose wire label violates the
+	// ACP2 §"Versions" charset — served VERBATIM (emulation fidelity,
+	// see wireLabel) and surfaced here so newServer can log the count
+	// as the observable spec-deviation event.
+	labelDeviations int
 }
 
 func emptyTree() *tree {
@@ -120,6 +125,16 @@ func newTree(exp *canonical.Export) (*tree, error) {
 		}
 	}
 	t.slotN = maxSlot
+	for _, index := range t.perSlot {
+		for id, e := range index {
+			if id == 0 && e.objID != 0 {
+				continue // obj-id 0 alias of the slot root — counted once
+			}
+			if labelDeviatesSpec(e.label) {
+				t.labelDeviations++
+			}
+		}
+	}
 	return t, nil
 }
 
@@ -152,7 +167,7 @@ func flatten(slot uint8, parent uint32, el canonical.Element, index map[uint32]*
 			objID:   id,
 			slot:    slot,
 			parent:  parent,
-			label:   sanitizeLabel(x.Identifier),
+			label:   wireLabel(x.Identifier),
 			access:  deriveAccess(x.Access),
 			objType: codec.ObjTypeNode,
 			node:    x,
@@ -190,7 +205,7 @@ func flatten(slot uint8, parent uint32, el canonical.Element, index map[uint32]*
 			objID:       id,
 			slot:        slot,
 			parent:      parent,
-			label:       sanitizeLabel(x.Identifier),
+			label:       wireLabel(x.Identifier),
 			access:      deriveAccess(x.Access),
 			objType:     objType,
 			numType:     numType,
@@ -233,46 +248,39 @@ func isDisabledParameter(p *canonical.Parameter) bool {
 	return false
 }
 
-// sanitizeLabel returns the spec-compliant form of an ACP2 object
-// label. Per acp2_protocol.docx §"Versions" line 357 the wire allows
-// only [A-Za-z0-9 \-]; any other character is replaced with `-`.
+// wireLabel returns the label to serve on the wire (pid=2) —
+// VERBATIM, empty defaulting to "obj" (spec mandates non-empty).
 //
-// Real EVS Neuron firmware emits labels like "ROOT_NODE_V2" with an
-// underscore — non-compliant per spec. Sanitising here keeps OUR
-// wire spec-clean (per internal/acp2/CLAUDE.md); the
-// canonical element is unchanged so other consumers see the
-// original.
-//
-// Returns "obj" when the input becomes empty after stripping
-// (defensive — spec mandates a non-empty label).
-func sanitizeLabel(label string) string {
+// History: from 2026-05-08 (cd7af27e) to 2026-08-20 the provider
+// REWROTE labels to the spec charset of acp2_protocol.docx §"Versions"
+// line 357 ([A-Za-z0-9 \-]), turning the real Neuron's "ROOT_NODE_V2"
+// into "ROOT-NODE-V2". That mutation broke emulation: Cerebrum's
+// Neuron driver binds its default object model by exact label paths,
+// so a renamed root orphaned the whole tree (wire-proven live
+// 2026-08-20, staging capture vs a real-device walk of 10.44.72.18).
+// Per the repo's spec-strict posture the deviation is the DEVICE's,
+// and our job is to absorb and surface it — never to alter the data:
+// the emulator must state what the emulated hardware states.
+// labelDeviatesSpec reports the deviation so newTree can count + log
+// it (the observable event), replacing the silent rewrite.
+func wireLabel(label string) string {
 	if label == "" {
 		return "obj"
 	}
-	dirty := false
+	return label
+}
+
+// labelDeviatesSpec reports whether a label violates the ACP2
+// §"Versions" charset ([A-Za-z0-9 \-]). Real EVS Neuron firmware
+// does (underscores) — surfaced as a count at tree build, served
+// verbatim.
+func labelDeviatesSpec(label string) bool {
 	for _, r := range label {
 		if !isSpecLabelByte(r) {
-			dirty = true
-			break
+			return true
 		}
 	}
-	if !dirty {
-		return label
-	}
-	var b strings.Builder
-	b.Grow(len(label))
-	for _, r := range label {
-		if isSpecLabelByte(r) {
-			b.WriteRune(r)
-		} else {
-			b.WriteByte('-')
-		}
-	}
-	out := b.String()
-	if out == "" || strings.Trim(out, "-") == "" {
-		return "obj"
-	}
-	return out
+	return false
 }
 
 // isSpecLabelByte reports whether r is in the ACP2 §"Versions"


### PR DESCRIPTION
Refs #714. Third and decisive wire-found defect in the Neuron emulation.

**Method:** byte-diff of the emulator's `get_object(root)` reply (staging pcap, Cerebrum session) against the real device's reply to the identical request (today's raw.an2.jsonl walk of 10.44.72.18). The two 80-byte replies were identical **except** the label: real card `ROOT_NODE_V2`, emulator `ROOT-NODE-V2`.

**Cause:** since cd7af27e (2026-05-08) the provider rewrote labels to the spec charset (§""Versions"" line 357) — 146 labels on the real CONVERT Hybrid tree. Cerebrum's Neuron driver binds its default object model by exact label paths, so the renamed root orphaned the entire tree: objects browsed, never bound (""objects must be available by default"" — owner requirement).

**Fix:** labels ship verbatim (the deviation is the device's; absorb + surface per repo posture — newTree counts charset deviations, newServer logs the count). Empty labels still default to `obj`. Tests re-pinned to the verbatim contract. Deployed live on dhs-rocky :2072: wire now serves `ROOT_NODE_V2`, 146 deviations logged, 50,043 objects.

Known remaining cosmetic difference vs the real card: pid=14 children are served in sorted order, the card serves authored order — flagged for follow-up if the driver turns out to care.

🤖 Generated with [Claude Code](https://claude.com/claude-code)