### PR TITLE
fix(manifest): enum replay serves the real option values (#714)

### DIFF
--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -181,6 +181,45 @@ func TestParamTypeAndFormat_ACP2Meta(t *testing.T) {
 	}
 }
 
+// TestEnumEntriesFromMeta pins the real-option-map path: acp2 walks
+// store the wire value -> name map (arbitrary u32 values, NOT 0..n-1)
+// in meta acp2.optionsMap; the EnumMap must carry those values sorted,
+// skipping unparseable entries, and return nil when absent.
+func TestEnumEntriesFromMeta(t *testing.T) {
+	entries := enumEntriesFromMeta(map[string]any{"acp2.optionsMap": map[string]any{
+		"1271": "Manual", "66": "2SI", "801": "SQD", "bogus": "X", "7": 3.14,
+	}})
+	if len(entries) != 3 {
+		t.Fatalf("entries = %+v, want 3", entries)
+	}
+	if entries[0].Key != "2SI" || entries[0].Value != 66 ||
+		entries[2].Key != "Manual" || entries[2].Value != 1271 {
+		t.Fatalf("entries = %+v", entries)
+	}
+	if enumEntriesFromMeta(map[string]any{}) != nil {
+		t.Error("absent map must return nil")
+	}
+	if enumEntriesFromMeta(map[string]any{"acp2.optionsMap": map[string]any{"x": "y"}}) != nil {
+		t.Error("no parseable entries must return nil")
+	}
+}
+
+// TestUnwrapValue_EnumRawPreferred pins the enum truncation fix: the
+// envelope's `enum` field is a u8 and loses the upper bytes of real
+// acp2 option values (u32 on the wire); the raw bytes win.
+func TestUnwrapValue_EnumRawPreferred(t *testing.T) {
+	// raw AAAE9w== = 0x000004F7 = 1271; enum field says 247.
+	v, ok := unwrapValue([]byte(`{"kind":"enum","raw":"AAAE9w==","enum":247}`))
+	if !ok || v != int64(1271) {
+		t.Fatalf("raw-preferred = %v %v, want 1271", v, ok)
+	}
+	// No raw → u8 fallback unchanged.
+	v, ok = unwrapValue([]byte(`{"kind":"enum","enum":247}`))
+	if !ok || v != int64(247) {
+		t.Fatalf("fallback = %v %v, want 247", v, ok)
+	}
+}
+
 func TestDMPath(t *testing.T) {
 	if got, want := DMPath(".cache", "acp2", "SHPRM1@5.3.5"),
 		filepath.Join(".cache", "dm", "acp2", "SHPRM1@5.3.5.json"); got != want {

--- a/internal/manifest/to_canonical.go
+++ b/internal/manifest/to_canonical.go
@@ -375,12 +375,23 @@ func buildSlotNode(slotNum int, sl Slot, dm *dmFile, devName string) (*canonical
 			f := formatHint
 			param.Format = &f
 		}
-		if typeStr == "enum" && len(o.EnumItems) > 0 {
-			entries := make([]canonical.EnumEntry, len(o.EnumItems))
-			for i, name := range o.EnumItems {
-				entries[i] = canonical.EnumEntry{Key: name, Value: int64(i)}
+		if typeStr == "enum" {
+			// acp2 walks store the REAL option map (wire value -> name)
+			// in meta acp2.optionsMap — real cards use arbitrary u32
+			// option values (e.g. CONVERT Hybrid "Manual"=1271), not
+			// 0..n-1 indexes. Serving index-valued options broke every
+			// enum on replay (9,774 wrong values on the real tree,
+			// live 2026-08-20). Fall back to sequential indexes only
+			// when no real map exists.
+			if entries := enumEntriesFromMeta(o.Meta); len(entries) > 0 {
+				param.EnumMap = entries
+			} else if len(o.EnumItems) > 0 {
+				entries := make([]canonical.EnumEntry, len(o.EnumItems))
+				for i, name := range o.EnumItems {
+					entries[i] = canonical.EnumEntry{Key: name, Value: int64(i)}
+				}
+				param.EnumMap = entries
 			}
-			param.EnumMap = entries
 		}
 		// Unwrap the consumer.Value envelope into a scalar the
 		// provider's tree builder accepts. The DM stores values as
@@ -626,6 +637,35 @@ func sanitiseScalar(typeStr, formatHint string, v any) any {
 	return v
 }
 
+// enumEntriesFromMeta builds the canonical EnumMap from an acp2 walk's
+// meta acp2.optionsMap ({"1271":"Manual", ...} — JSON object keys are
+// the wire values as decimal strings). Entries are sorted by wire
+// value for deterministic output. Returns nil when the meta is absent
+// or carries no parseable entries.
+func enumEntriesFromMeta(meta map[string]any) []canonical.EnumEntry {
+	m, ok := meta["acp2.optionsMap"].(map[string]any)
+	if !ok || len(m) == 0 {
+		return nil
+	}
+	entries := make([]canonical.EnumEntry, 0, len(m))
+	for k, v := range m {
+		val, err := strconv.ParseInt(k, 10, 64)
+		if err != nil {
+			continue
+		}
+		name, ok := v.(string)
+		if !ok {
+			continue
+		}
+		entries = append(entries, canonical.EnumEntry{Key: name, Value: val})
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Value < entries[j].Value })
+	return entries
+}
+
 // unwrapValue pulls the scalar out of a serialised consumer.Value
 // envelope:  {"kind":"int","int":42} → int64(42).
 // Returns (nil, false) on null, empty, or unsupported envelopes; the
@@ -648,9 +688,18 @@ func unwrapValue(raw []byte) (any, bool) {
 		Str   *string `json:"str"`
 		IP    string  `json:"ip"`
 		Enum  *uint8  `json:"enum"`
+		Raw   []byte  `json:"raw"` // base64 wire bytes (acp2 walks)
 	}
 	if err := json.Unmarshal(raw, &env); err != nil {
 		return nil, false
+	}
+	// Enum envelopes: the `enum` field is a u8 and TRUNCATES real acp2
+	// option values (u32 on the wire — CONVERT Hybrid "Manual"=1271
+	// became 247 on replay, live 2026-08-20). The raw wire bytes carry
+	// the full value; prefer them.
+	if env.Kind == "enum" && len(env.Raw) == 4 {
+		return int64(env.Raw[0])<<24 | int64(env.Raw[1])<<16 |
+			int64(env.Raw[2])<<8 | int64(env.Raw[3]), true
 	}
 	switch env.Kind {
 	case "string":


### PR DESCRIPTION
Fifth wire-found replay defect, and after it the emulation reaches
dual-oracle diff=0: a fresh consumer discovery of the emulator now
reproduces the real device's DM EXACTLY (49,827 + 214 objects, zero
field diffs).

Defects: (1) the consumer.Value envelope's enum field is a u8, so
replay truncated real acp2 option values (u32 on the wire - CONVERT
Hybrid "Manual"=1271 became 247); the raw wire bytes in the envelope
now win. (2) options were rebuilt as 0..n-1 indexes, but real cards
use arbitrary u32 option values; the walk's meta acp2.optionsMap
(value -> name) now feeds EnumMap directly, sorted, with the
sequential fallback kept for DMs without the map. 9,774 enum values
on the real CONVERT tree were wrong before this.

Deployed on dhs-rocky :2072; rediscovery diff against today's
real-device walk: 0 differences on both slots.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
