### PR TITLE
fix(emberplus): empty last packet completes multi-frame reassembly (#728)

### DIFF
--- a/internal/emberplus/consumer/session.go
+++ b/internal/emberplus/consumer/session.go
@@ -546,7 +546,13 @@ func (s *Session) readLoop() {
 		// device's Glow DTD revision without walking the tree. Refs
 		// #470.
 		s.noteDtd(frame.DTDMinor, frame.DTDMajor)
-		if len(frame.Payload) == 0 {
+		// NOTE: an empty payload must NOT short-circuit here. Lawo VSM
+		// Studio's gadgetserver terminates multi-packet messages with a
+		// payload-LESS last packet (flags 0x60) — skipping empty frames
+		// before the reassembly switch left the buffered document
+		// incomplete forever, so a whole VSM reply decoded to nothing
+		// ("connected, 0 objects", issue #728, live capture 2026-08-20).
+		if len(frame.Payload) == 0 && frame.Flags == s101.FlagSingle {
 			continue
 		}
 

--- a/internal/emberplus/consumer/vsm_dialect_test.go
+++ b/internal/emberplus/consumer/vsm_dialect_test.go
@@ -1,0 +1,98 @@
+package emberplus
+
+import (
+	"context"
+	"encoding/hex"
+	"net"
+	"testing"
+	"time"
+
+	"dhs/internal/emberplus/codec/s101"
+)
+
+// Captured live from a Lawo VSM Studio gadgetserver Ember+ provider
+// (10.6.239.117:9000, 2026-08-20, issue #728): the reply to
+// GetDirectory(root) is a multi-packet S101 message: a first packet
+// (flags 0x80) carrying the whole indefinite-length BER document
+// (Root > RootElementCollection > Node#1 "Device"), and a payload-less
+// last packet (flags 0x60). Frames are verbatim wire bytes incl. CRC.
+var vsmRootFirst, _ = hex.DecodeString(
+	"fe000e0001800102280260806b80a0806380a003020101a1803180a0080c06446576696365a2030101fddfa3030101fddf000000000000000000000000bed3ff")
+var vsmRootLast, _ = hex.DecodeString(
+	"fe000e000160010228029043ff")
+
+// TestWalk_VSMGadgetserverDialect replays the captured VSM exchange
+// against the real Connect+Walk pipeline: the fake provider answers
+// every EmBER frame with the captured multi-packet root reply. The
+// walk must at minimum store the delivered "Device" node (the live
+// failure was 0 objects, #728).
+func TestWalk_VSMGadgetserverDialect(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		r := s101.NewReader(conn)
+		for {
+			f, err := r.ReadFrame()
+			if err != nil {
+				return
+			}
+			if f.IsKeepAlive() {
+				if f.Command == s101.CmdKeepAliveReq {
+					w := s101.NewWriter(conn)
+					_ = w.WriteFrame(s101.NewKeepAliveResponse())
+				}
+				continue
+			}
+			if f.IsEmBER() {
+				// Reply exactly like VSM: first + empty last packet.
+				_, _ = conn.Write(vsmRootFirst)
+				_, _ = conn.Write(vsmRootLast)
+			}
+		}
+	}()
+
+	host, portStr, _ := net.SplitHostPort(ln.Addr().String())
+	var port int
+	for i := 0; i < len(portStr); i++ {
+		port = port*10 + int(portStr[i]-'0')
+	}
+
+	p := (&Factory{}).New(discardLogger()).(*Plugin)
+	// Short settle timings so the test finishes fast.
+	p.walkSettleInitial = 2 * time.Second
+	p.walkSettleInterval = 500 * time.Millisecond
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if err := p.Connect(ctx, host, port); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer func() { _ = p.Disconnect() }()
+
+	objs, err := p.Walk(ctx, 0)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if len(objs) == 0 {
+		t.Fatalf("walk stored 0 objects - the VSM 'Device' node was dropped (#728)")
+	}
+	var found bool
+	for _, o := range objs {
+		if o.Label == "Device" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("'Device' node not in snapshot: %+v", objs)
+	}
+}
+


### PR DESCRIPTION
Lawo VSM Studio's gadgetserver terminates multi-packet S101 messages
with a payload-LESS last packet (flags 0x60). The session read loop
skipped every empty-payload frame BEFORE the reassembly switch, so
the buffered document never completed and a whole VSM reply decoded
to nothing - connected, walked, 0 objects (live at 10.6.239.117:9000,
2026-08-20). BER indefinite-length and the glow layer were exonerated
by offline repro: the captured payload decodes cleanly through the
real s101 reader.

The empty-payload skip now applies only to single-packet frames; a
last packet always completes the assembly. Regression pinned by
TestWalk_VSMGadgetserverDialect replaying the captured VSM wire bytes
verbatim (frames incl CRC) through the real Connect+Walk pipeline.

emberplus/consumer holds 100.0% single-pass coverage.

Closes #728.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
