### PR TITLE
fix(acp2): announces deliver to every session - ecosystem exception (#714)

### DIFF
--- a/internal/acp2/provider/serve_loopback_test.go
+++ b/internal/acp2/provider/serve_loopback_test.go
@@ -422,9 +422,13 @@ func TestServe_SetProperty_AnnounceFanout(t *testing.T) {
 	if ann.PID != codec.PIDValue {
 		t.Fatalf("announce pid=%d want %d", ann.PID, codec.PIDValue)
 	}
-	// The unsubscribed client must receive zero announces.
-	if n := unsub.announceCount(); n != 0 {
-		t.Fatalf("unsubscribed client got %d announces, want 0", n)
+	// The unsubscribed client receives the announce too — real Neurons
+	// deliver announces regardless of the EnableProtocolEvents gate
+	// (spec §3.3.4 says otherwise, but Lawo VSM's gadgetserver never
+	// sends the enable and depends on receiving announces; documented
+	// ecosystem exception, see broadcastAnnounce).
+	if !waitFor(t, time.Second, func() bool { return unsub.announceCount() >= 1 }) {
+		t.Fatal("unsubscribed client got no announce (ecosystem delivery)")
 	}
 
 	// Tree was actually mutated.

--- a/internal/acp2/provider/server.go
+++ b/internal/acp2/provider/server.go
@@ -177,20 +177,33 @@ func (s *server) broadcastAnnounce(slot uint8, ann *codec.ACP2Message) {
 		Payload: raw,
 	}
 
+	// Deliver to EVERY session, not only those that sent AN2
+	// EnableProtocolEvents([2]). The spec gates announces on the enable
+	// (§3.3.4), but the shipping ecosystem contradicts it: Lawo VSM's
+	// gadgetserver never sends EnableProtocolEvents on its acp2 session
+	// and still expects value announces (live-verified against staging
+	// 2026-08-20 — VSM connected, no enable, values froze), so the real
+	// Neuron necessarily announces regardless of the gate. Same
+	// documented-exception pattern as SW-P-08 salvo cmd-04 (root
+	// CLAUDE.md "Spec-strict, no-workaround posture"): follow the wire
+	// reality every field controller depends on, keep both counts in
+	// the log so the deviation stays observable per fanout.
 	s.mu.Lock()
 	totalSessions := len(s.sessions)
+	subscribed := 0
 	targets := make([]*session, 0, len(s.sessions))
 	for sess := range s.sessions {
 		if sess.enabled[codec.AN2ProtoACP2] {
-			targets = append(targets, sess)
+			subscribed++
 		}
+		targets = append(targets, sess)
 	}
 	s.mu.Unlock()
 
 	s.logger.Info("acp2 announce fanout",
 		slog.Int("slot", int(slot)),
 		slog.Int("sessions_total", totalSessions),
-		slog.Int("sessions_subscribed", len(targets)),
+		slog.Int("sessions_subscribed", subscribed),
 		slog.Int("frame_bytes", len(raw)+8),
 	)
 

--- a/internal/amwa/session/events/events_test.go
+++ b/internal/amwa/session/events/events_test.go
@@ -53,19 +53,19 @@ func TestSubscriberReceivesMatchingEvents(t *testing.T) {
 		t.Fatalf("Subscribe: %v", err)
 	}
 
-	// Wait until publisher registered our subscription.
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if pub.SubscriberCount() == 1 {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
+	// Wait until the publisher has APPLIED our subscription filter —
+	// not merely accepted the socket. SubscriberCount()==1 plus a fixed
+	// sleep was a timing guess: on a loaded runner the publish landed
+	// before serve() read the command_subscription frame, matched an
+	// empty source set, and the test saw 0 frames (windows-latest flake,
+	// ADR-0029 determinism rule).
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) && !pub.SubscribedTo(srcA) {
+		time.Sleep(10 * time.Millisecond)
 	}
-	if pub.SubscriberCount() != 1 {
-		t.Fatalf("publisher never registered subscriber")
+	if !pub.SubscribedTo(srcA) {
+		t.Fatalf("publisher never applied the subscription filter")
 	}
-	// Allow the publisher one tick to process the subscribe command.
-	time.Sleep(100 * time.Millisecond)
 
 	got := make(chan is07.Message, 4)
 	var runErr error
@@ -250,16 +250,29 @@ func TestSubscriberReplaceSubscriptionSet(t *testing.T) {
 	if err := sub.Subscribe([]string{srcA}); err != nil {
 		t.Fatalf("Subscribe A: %v", err)
 	}
-	deadline := time.Now().Add(1 * time.Second)
-	for time.Now().Before(deadline) && pub.SubscriberCount() == 0 {
-		time.Sleep(20 * time.Millisecond)
+	// Wait for the A filter to be APPLIED (content-aware — see
+	// SubscribedTo), then replace with B and wait for the swap. Fixed
+	// sleeps here were the same scheduling guess as the
+	// ReceivesMatchingEvents flake: an emit racing the un-applied
+	// replacement drops the frame.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) && !pub.SubscribedTo(srcA) {
+		time.Sleep(10 * time.Millisecond)
 	}
-	time.Sleep(100 * time.Millisecond)
+	if !pub.SubscribedTo(srcA) {
+		t.Fatal("subscription A never applied")
+	}
 
 	if err := sub.Subscribe([]string{srcB}); err != nil {
 		t.Fatalf("Subscribe B: %v", err)
 	}
-	time.Sleep(100 * time.Millisecond)
+	deadline = time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) && (!pub.SubscribedTo(srcB) || pub.SubscribedTo(srcA)) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !pub.SubscribedTo(srcB) || pub.SubscribedTo(srcA) {
+		t.Fatal("subscription replacement A→B never applied")
+	}
 
 	emitB := is07.EventBoolean{
 		EventCommon: is07.EventCommon{

--- a/internal/amwa/session/events/publisher.go
+++ b/internal/amwa/session/events/publisher.go
@@ -169,6 +169,28 @@ func (p *Publisher) SubscriberCount() int {
 	return len(p.clients)
 }
 
+// SubscribedTo reports whether any connected client currently has an
+// APPLIED subscription filter for the given source-id. This is the
+// observable state a caller must wait on before publishing:
+// SubscriberCount only proves a socket connected — the filter lands
+// later, when the client's command_subscription frame is read by
+// serve(). A publish in that window matches nothing (empty source
+// set), which is exactly the scheduling-dependent gap behind
+// TestSubscriberReceivesMatchingEvents flaking on loaded runners
+// (windows-latest, run 32421791860; ADR-0029 determinism rule).
+// Content-aware (not a count) so a full-replacement re-subscribe
+// (IS-07 semantics, A → B) is observable too.
+func (p *Publisher) SubscribedTo(srcID string) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	for _, c := range p.clients {
+		if c.matches(srcID) {
+			return true
+		}
+	}
+	return false
+}
+
 // serve runs the per-connection message loop until the client closes
 // or sends an unrecognised frame.
 func (p *Publisher) serve(ctx context.Context, ws *httpsession.WebSocket, remote string) {

--- a/internal/cerebrum-nb/consumer/session_edge_test.go
+++ b/internal/cerebrum-nb/consumer/session_edge_test.go
@@ -201,9 +201,15 @@ func TestDispatch_ChannelFull(t *testing.T) {
 }
 
 // TestReadLoop_DebugLogOnError exercises the non-EOF read-error debug-log
-// branch in readLoop by aborting the TCP connection mid-stream.
+// branch in readLoop by aborting the TCP connection mid-stream. The abort
+// is gated on a channel the test closes only AFTER Connect succeeded —
+// an unconditional abort raced the client's WS-upgrade read on loaded
+// runners and made dialFake fatal before the branch under test ever ran
+// (windows-latest, run 32422888171; ADR-0029 determinism rule).
 func TestReadLoop_DebugLogOnError(t *testing.T) {
+	release := make(chan struct{})
 	fs := newFakeCerebrum(t, func(fc *fakeConn) {
+		<-release
 		// Write a partial frame header then RST the socket so the client's
 		// next ReadFull returns a non-EOF error.
 		_, _ = fc.c.Write([]byte{0x81, 0x05}) // declares 5-byte text, sends none
@@ -213,6 +219,7 @@ func TestReadLoop_DebugLogOnError(t *testing.T) {
 		_ = fc.c.Close()
 	})
 	p, _ := dialFake(t, fs)
+	close(release) // client fully connected — abort mid-frame now
 	// The readLoop will exit on the error; give it a moment. We can't assert
 	// the log line directly, but exercising the branch is the goal and the
 	// session must remain usable for Disconnect.


### PR DESCRIPTION
Live-found with Lawo VSM Studio's gadgetserver against the staging
emulator (2026-08-20): VSM's acp2 driver never sends AN2
EnableProtocolEvents([2]) yet depends on receiving value announces -
with our spec-literal gate (SS3.3.4) its session stayed silent, so
value changes applied on the wire but VSM's ember+ side never
updated. The real Neuron therefore delivers announces regardless of
the gate; a shipping field controller relies on it.

Documented-exception pattern per root CLAUDE.md (same as SW-P-08
salvo cmd 04): broadcastAnnounce now targets every session; the
fanout log keeps sessions_total AND sessions_subscribed so the
deviation stays observable per event. Loopback test re-pinned:
unsubscribed clients now assert DELIVERY (was: assert silence).

Verified live: with the gate removed, VSM's session (attached
22:00:55) received the Direction announce at 22:00:57.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
