### PR TITLE
feat(cli): probel-sw08p usage + replace verbs (#722 unit 1)

### DIFF
--- a/cmd/dhs/cmd_probel.go
+++ b/cmd/dhs/cmd_probel.go
@@ -109,6 +109,10 @@ func runProbelsw08p(ctx context.Context, args []string) error {
 		return runProbelImport(ctx, rest)
 	case "salvo-connect":
 		return runProbelSalvoConnect(ctx, rest)
+	case "usage":
+		return runProbelUsage(ctx, rest)
+	case "replace":
+		return runProbelReplace(ctx, rest)
 	}
 	return fmt.Errorf("unknown probel subcommand %q", sub)
 }
@@ -154,6 +158,11 @@ SUBCOMMANDS
                             + -xpoint.csv (crosspoints, dst <- src)
   import                    apply CSVs back, each file selectable: --src / --dst
                             (labels, --size picks width) / --xpoints; --dry-run
+  usage                     reverse tally on (matrix, level): where is each
+                            source assigned; --srce/--dest filter, --protect
+                            joins protect state, csv (ADR-0028 snapshot) | ascii
+  replace                   substitute source A with B on every crosspoint
+                            carrying A; --check dry-run (ADR-0007 ensure)
 
 EXAMPLES
   dhs consumer probel-sw08p interrogate         127.0.0.1:2008 --matrix 0 --level 0 --dst 5
@@ -161,6 +170,8 @@ EXAMPLES
   dhs consumer probel-sw08p bench 127.0.0.1:2008 --matrix 0,1 --size 65535 \
     --csv bench.csv --md bench.md
   dhs consumer probel-sw08p tally-dump          127.0.0.1:2008 --matrix 0 --level 0
+  dhs consumer probel-sw08p usage               127.0.0.1:2008 --matrix 0 --level 0 --srce 12 --format ascii
+  dhs consumer probel-sw08p replace             127.0.0.1:2008 --matrix 0 --level 0 --srce 12 --with 14 --check
   dhs consumer probel-sw08p watch               127.0.0.1:2008
 
 All commands log wire bytes (post-escape, post-framing) on stderr as a

--- a/cmd/dhs/cmd_probel_usage.go
+++ b/cmd/dhs/cmd_probel_usage.go
@@ -1,0 +1,327 @@
+package main
+
+// usage + replace — the source-side pair of the Matrix template
+// (#722, unit 1; canonical shape defined by cerebrum-nb #718):
+//
+//	usage    WHERE is a source assigned (reverse tally / source usage)
+//	         on one (matrix, level), built from the crosspoint tally
+//	         dump (rx 021 / tx 022/023). --protect joins the per-dst
+//	         protect state from the protect tally dump (rx 019/tx 020).
+//	replace  substitute source A with B on every crosspoint that
+//	         carries A (ADR-0007: --check first, diff-only, run-twice
+//	         = 0 because nothing carries A afterwards), one
+//	         CrosspointConnect (rx 002) per affected dst.
+//
+// Both are client-side compositions over the existing SW-P-08
+// primitives — no new wire commands. SW-P-08 has no virtual-resource
+// concept, so cerebrum's --resolve has no equivalent here.
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"dhs/internal/probel-sw08p/codec"
+	probelproto "dhs/internal/probel-sw08p/consumer"
+)
+
+// probelUsageRow is one reverse-tally assignment: src feeds dst on the
+// queried level. Protect carries the dst's protect state when the
+// caller joined it (--protect), else "".
+type probelUsageRow struct {
+	Src, Dst, Level int
+	Protect         string
+}
+
+// probelTallyTable flattens the byte/word dual-form TallyDumpResult
+// into one (firstDst, srcs) pair — the merged dst→src table.
+func probelTallyTable(res probelproto.TallyDumpResult) (firstDst int, srcs []int) {
+	if res.IsWord {
+		srcs = make([]int, len(res.Word.SourceIDs))
+		for i, s := range res.Word.SourceIDs {
+			srcs[i] = int(s)
+		}
+		return int(res.Word.FirstDestinationID), srcs
+	}
+	srcs = make([]int, len(res.Byte.SourceIDs))
+	for i, s := range res.Byte.SourceIDs {
+		srcs[i] = int(s)
+	}
+	return int(res.Byte.FirstDestinationID), srcs
+}
+
+// probelBuildUsage turns the dst→src table into source-keyed usage
+// rows, ordered by (src, dst). protect maps dst → rendered protect
+// state; nil = no protect join requested.
+func probelBuildUsage(firstDst int, srcs []int, level int, protect map[int]string) []probelUsageRow {
+	rows := make([]probelUsageRow, 0, len(srcs))
+	for i, src := range srcs {
+		dst := firstDst + i
+		rows = append(rows, probelUsageRow{Src: src, Dst: dst, Level: level, Protect: protect[dst]})
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		if rows[i].Src != rows[j].Src {
+			return rows[i].Src < rows[j].Src
+		}
+		return rows[i].Dst < rows[j].Dst
+	})
+	return rows
+}
+
+// probelFilterUsage keeps only the rows matching the src / dst filter
+// (-1 = no filter on that axis).
+func probelFilterUsage(rows []probelUsageRow, src, dst int) []probelUsageRow {
+	if src < 0 && dst < 0 {
+		return rows
+	}
+	out := rows[:0:0]
+	for _, r := range rows {
+		if (src >= 0 && r.Src == src) || (dst >= 0 && r.Dst == dst) {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// formatProbelUsageCSV renders rows with the canonical usage columns
+// (srce,dest,levels — same as cerebrum-nb usage); --protect appends a
+// protect column.
+func formatProbelUsageCSV(rows []probelUsageRow, withProtect bool) string {
+	var b strings.Builder
+	if withProtect {
+		b.WriteString("srce,dest,levels,protect\n")
+	} else {
+		b.WriteString("srce,dest,levels\n")
+	}
+	for _, r := range rows {
+		fmt.Fprintf(&b, "%d,%d,%d", r.Src, r.Dst, r.Level)
+		if withProtect {
+			b.WriteByte(',')
+			b.WriteString(r.Protect)
+		}
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// renderProbelUsageASCII prints the fan-out view: one block per
+// feeding source, every dst it feeds nested under it.
+func renderProbelUsageASCII(w io.Writer, rows []probelUsageRow) {
+	var lastSrc = -1
+	var block []probelUsageRow
+	flush := func() {
+		for i, r := range block {
+			branch := "├──"
+			if i == len(block)-1 {
+				branch = "└──"
+			}
+			suffix := ""
+			if r.Protect != "" {
+				suffix = "  [" + r.Protect + "]"
+			}
+			_, _ = fmt.Fprintf(w, "%s dst %d  level %d%s\n", branch, r.Dst, r.Level, suffix)
+		}
+		block = block[:0]
+	}
+	for _, r := range rows {
+		if r.Src != lastSrc {
+			flush()
+			lastSrc = r.Src
+			_, _ = fmt.Fprintf(w, "src %d\n", r.Src)
+		}
+		block = append(block, r)
+	}
+	flush()
+}
+
+// probelReplaceCells returns the dsts currently fed by src, in dst
+// order — the replace working set.
+func probelReplaceCells(rows []probelUsageRow, src int) []probelUsageRow {
+	var out []probelUsageRow
+	for _, r := range rows {
+		if r.Src == src {
+			out = append(out, r)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Dst < out[j].Dst })
+	return out
+}
+
+// probelUsageProtectMap renders the protect dump as dst → "state=N
+// device=M", skipping unprotected dsts so the CSV column stays empty
+// where nothing is protected.
+func probelUsageProtectMap(res codec.ProtectTallyDumpParams) map[int]string {
+	out := map[int]string{}
+	for i, it := range res.Items {
+		if it.State == codec.ProtectNone {
+			continue
+		}
+		out[int(res.FirstDestinationID)+i] = protectStateStr(it.State, int(it.DeviceID))
+	}
+	return out
+}
+
+// runProbelUsage drives `dhs consumer probel-sw08p usage`.
+func runProbelUsage(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("probel-usage", flag.ContinueOnError)
+	matrix := fs.Int("matrix", 0, "matrix id (0-255; global --mtx-id wins when set)")
+	srce := fs.Int("srce", -1, "filter: only this source's assignments")
+	dest := fs.Int("dest", -1, "filter: only this destination's feed")
+	withProtect := fs.Bool("protect", false, "join per-dst protect state (protect tally dump) as an extra column")
+	format := fs.String("format", "csv", "output format: csv | ascii")
+	out := fs.String("out", "", "csv output file (omitted = snapshots/probel-sw08p/<host>/usage.csv per ADR-0028; \"-\" = stdout)")
+	timeout := fs.Duration("timeout", 15*time.Second, "operation timeout")
+	addr, flagArgs := popPositional(args)
+	if addr == "" {
+		return fmt.Errorf("missing <host:port>")
+	}
+	if err := fs.Parse(flagArgs); err != nil {
+		return err
+	}
+	if *format != "csv" && *format != "ascii" {
+		return fmt.Errorf("--format must be csv or ascii, got %q", *format)
+	}
+	if *srce >= 0 && *dest >= 0 {
+		return fmt.Errorf("--srce and --dest are mutually exclusive")
+	}
+	cctx, cancel := context.WithTimeout(ctx, *timeout)
+	defer cancel()
+	p, closer, err := dialProbel(cctx, addr)
+	if err != nil {
+		return err
+	}
+	defer closer()
+	mtx, level := probelTarget(p, *matrix)
+	res, err := p.CrosspointTallyDump(cctx, mtx, level)
+	if err != nil {
+		return err
+	}
+	var protect map[int]string
+	if *withProtect {
+		pres, perr := p.ProtectTallyDump(cctx, mtx, level, 0)
+		if perr != nil {
+			return perr
+		}
+		protect = probelUsageProtectMap(pres)
+	}
+	firstDst, srcs := probelTallyTable(res)
+	rows := probelFilterUsage(probelBuildUsage(firstDst, srcs, int(level), protect), *srce, *dest)
+
+	if *format == "ascii" {
+		renderProbelUsageASCII(os.Stdout, rows)
+		return nil
+	}
+	csv := formatProbelUsageCSV(rows, *withProtect)
+	if *out == "-" {
+		fmt.Print(csv)
+		return nil
+	}
+	path := *out
+	if path == "" {
+		host, _, _ := splitHostPort(addr, probelproto.DefaultPort)
+		path = filepath.Join(snapshotDir("probel-sw08p", host), "usage.csv")
+		fmt.Fprintf(os.Stderr, "probel-sw08p usage: default snapshot file %s (ADR-0028)\n", path)
+	}
+	if dir := filepath.Dir(path); dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	if err := os.WriteFile(path, []byte(csv), 0o644); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "probel-sw08p usage: wrote %s (%d row(s))\n", path, len(rows))
+	return nil
+}
+
+// runProbelReplace drives `dhs consumer probel-sw08p replace` —
+// substitute source A with B on every crosspoint carrying A (ADR-0007
+// ensure: --check dry-run, diff-only apply, run-twice = 0).
+func runProbelReplace(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("probel-replace", flag.ContinueOnError)
+	matrix := fs.Int("matrix", 0, "matrix id (0-255; global --mtx-id wins when set)")
+	from := fs.Int("srce", -1, "source id to replace (required)")
+	with := fs.Int("with", -1, "source id that takes over (required)")
+	check := fs.Bool("check", false, "dry-run (ADR-0007): list the crosspoints that would change, send nothing")
+	output := fs.String("output", "text", "output format: text | json (ADR-0002; json = {changed|would_change, diff[]})")
+	timeout := fs.Duration("timeout", 30*time.Second, "operation timeout")
+	addr, flagArgs := popPositional(args)
+	if addr == "" {
+		return fmt.Errorf("missing <host:port>")
+	}
+	if err := fs.Parse(flagArgs); err != nil {
+		return err
+	}
+	if *from < 0 || *with < 0 {
+		return fmt.Errorf("--srce and --with are required (replace source A with B)")
+	}
+	if *from == *with {
+		return fmt.Errorf("--srce and --with are the same source — nothing to do")
+	}
+	jsonOut, oerr := resolveEnsureOutput(*output, false)
+	if oerr != nil {
+		return oerr
+	}
+	cctx, cancel := context.WithTimeout(ctx, *timeout)
+	defer cancel()
+	p, closer, err := dialProbel(cctx, addr)
+	if err != nil {
+		return err
+	}
+	defer closer()
+	logw := os.Stdout
+	if jsonOut {
+		logw = os.Stderr
+	}
+	mtx, level := probelTarget(p, *matrix)
+	res, err := p.CrosspointTallyDump(cctx, mtx, level)
+	if err != nil {
+		return err
+	}
+	firstDst, srcs := probelTallyTable(res)
+	cells := probelReplaceCells(probelBuildUsage(firstDst, srcs, int(level), nil), *from)
+
+	changed := len(cells) > 0
+	diffs := make([]ensureDiff, 0, len(cells))
+	for _, c := range cells {
+		diffs = append(diffs, ensureDiff{
+			Field: fmt.Sprintf("route.%d.%d", c.Dst, c.Level),
+			From:  fmt.Sprintf("%d", *from), To: fmt.Sprintf("%d", *with),
+		})
+	}
+
+	if *check {
+		for _, c := range cells {
+			_, _ = fmt.Fprintf(logw, "[would-replace] matrix=%d level=%d dst=%d: src %d -> %d\n", mtx, c.Level, c.Dst, *from, *with)
+		}
+		_, _ = fmt.Fprintf(logw, "probel-sw08p replace --check: would_change=%d crosspoint(s) carrying src %d — nothing sent\n", len(cells), *from)
+		if jsonOut {
+			return emitEnsure(true, ensureResult{WouldChange: &changed, Diff: diffs})
+		}
+		return nil
+	}
+
+	fails := 0
+	for _, c := range cells {
+		if _, err := p.CrosspointConnect(cctx, mtx, level, uint16(c.Dst), uint16(*with)); err != nil {
+			_, _ = fmt.Fprintf(logw, "[replace] FAIL matrix=%d level=%d dst=%d reason=%s\n", mtx, c.Level, c.Dst, err)
+			fails++
+			continue
+		}
+		_, _ = fmt.Fprintf(logw, "[replace] OK   matrix=%d level=%d dst=%d: src %d -> %d\n", mtx, c.Level, c.Dst, *from, *with)
+	}
+	if fails > 0 {
+		return fmt.Errorf("%d/%d replace connect(s) failed", fails, len(cells))
+	}
+	_, _ = fmt.Fprintf(logw, "probel-sw08p replace: changed=%d crosspoint(s); run again to verify 0 (nothing carries src %d any more)\n", len(cells), *from)
+	if jsonOut {
+		return emitEnsure(true, ensureResult{Changed: &changed, Diff: diffs})
+	}
+	return nil
+}

--- a/cmd/dhs/cmd_probel_usage_test.go
+++ b/cmd/dhs/cmd_probel_usage_test.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"dhs/internal/probel-sw08p/codec"
+	probelproto "dhs/internal/probel-sw08p/consumer"
+)
+
+// The 6-dst fixture on level 2, starting at dst 4: src 12 feeds dsts
+// 4 and 7, src 3 feeds dst 5, src 0 feeds dst 6 (0 is a valid source),
+// src 12 also feeds dst 8, src 9 feeds dst 9.
+func probelUsageFixture() (int, []int) {
+	return 4, []int{12, 3, 0, 12, 12, 9}
+}
+
+func TestProbelTallyTable_WordAndByte(t *testing.T) {
+	word := probelproto.TallyDumpResult{IsWord: true, Word: codec.CrosspointTallyDumpWordParams{
+		FirstDestinationID: 300, SourceIDs: []uint16{40000, 5},
+	}}
+	first, srcs := probelTallyTable(word)
+	if first != 300 || len(srcs) != 2 || srcs[0] != 40000 || srcs[1] != 5 {
+		t.Fatalf("word table = %d %v", first, srcs)
+	}
+	byteForm := probelproto.TallyDumpResult{Byte: codec.CrosspointTallyDumpByteParams{
+		FirstDestinationID: 4, SourceIDs: []uint8{12, 3},
+	}}
+	first, srcs = probelTallyTable(byteForm)
+	if first != 4 || len(srcs) != 2 || srcs[0] != 12 || srcs[1] != 3 {
+		t.Fatalf("byte table = %d %v", first, srcs)
+	}
+}
+
+func TestProbelBuildUsage_SortedBySrcThenDst(t *testing.T) {
+	first, srcs := probelUsageFixture()
+	rows := probelBuildUsage(first, srcs, 2, nil)
+	if len(rows) != 6 {
+		t.Fatalf("rows = %d", len(rows))
+	}
+	// Expected order: src 0 (dst 6), src 3 (dst 5), src 9 (dst 9),
+	// src 12 (dsts 4, 7, 8).
+	want := []probelUsageRow{
+		{Src: 0, Dst: 6, Level: 2}, {Src: 3, Dst: 5, Level: 2}, {Src: 9, Dst: 9, Level: 2},
+		{Src: 12, Dst: 4, Level: 2}, {Src: 12, Dst: 7, Level: 2}, {Src: 12, Dst: 8, Level: 2},
+	}
+	for i, w := range want {
+		if rows[i] != w {
+			t.Fatalf("row %d = %+v, want %+v", i, rows[i], w)
+		}
+	}
+}
+
+func TestProbelBuildUsage_ProtectJoin(t *testing.T) {
+	first, srcs := probelUsageFixture()
+	rows := probelBuildUsage(first, srcs, 2, map[int]string{7: "state=1 device=9"})
+	var hit bool
+	for _, r := range rows {
+		if r.Dst == 7 && r.Protect == "state=1 device=9" {
+			hit = true
+		}
+		if r.Dst != 7 && r.Protect != "" {
+			t.Fatalf("dst %d unexpectedly protected: %+v", r.Dst, r)
+		}
+	}
+	if !hit {
+		t.Fatal("dst 7 protect state not joined")
+	}
+}
+
+func TestProbelFilterUsage(t *testing.T) {
+	first, srcs := probelUsageFixture()
+	rows := probelBuildUsage(first, srcs, 2, nil)
+	if got := probelFilterUsage(rows, -1, -1); len(got) != len(rows) {
+		t.Fatalf("no-filter changed row count: %d", len(got))
+	}
+	bySrc := probelFilterUsage(rows, 12, -1)
+	if len(bySrc) != 3 {
+		t.Fatalf("src filter rows = %d", len(bySrc))
+	}
+	for _, r := range bySrc {
+		if r.Src != 12 {
+			t.Fatalf("src filter leaked %+v", r)
+		}
+	}
+	byDst := probelFilterUsage(rows, -1, 5)
+	if len(byDst) != 1 || byDst[0].Src != 3 {
+		t.Fatalf("dst filter = %+v", byDst)
+	}
+}
+
+func TestFormatProbelUsageCSV(t *testing.T) {
+	rows := []probelUsageRow{
+		{Src: 3, Dst: 5, Level: 2},
+		{Src: 12, Dst: 7, Level: 2, Protect: "state=1 device=9"},
+	}
+	plain := formatProbelUsageCSV(rows, false)
+	if !strings.HasPrefix(plain, "srce,dest,levels\n") {
+		t.Fatalf("plain header: %q", plain)
+	}
+	if !strings.Contains(plain, "3,5,2\n") || strings.Contains(plain, "state=1") {
+		t.Fatalf("plain body: %q", plain)
+	}
+	prot := formatProbelUsageCSV(rows, true)
+	if !strings.HasPrefix(prot, "srce,dest,levels,protect\n") {
+		t.Fatalf("protect header: %q", prot)
+	}
+	if !strings.Contains(prot, "3,5,2,\n") || !strings.Contains(prot, "12,7,2,state=1 device=9\n") {
+		t.Fatalf("protect body: %q", prot)
+	}
+}
+
+func TestRenderProbelUsageASCII(t *testing.T) {
+	first, srcs := probelUsageFixture()
+	rows := probelBuildUsage(first, srcs, 2, map[int]string{7: "state=1 device=9"})
+	var buf bytes.Buffer
+	renderProbelUsageASCII(&buf, rows)
+	out := buf.String()
+	for _, want := range []string{
+		"src 0\n└── dst 6  level 2\n",
+		"src 12\n├── dst 4  level 2\n├── dst 7  level 2  [state=1 device=9]\n└── dst 8  level 2\n",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("ascii missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestProbelReplaceCells(t *testing.T) {
+	first, srcs := probelUsageFixture()
+	rows := probelBuildUsage(first, srcs, 2, nil)
+	cells := probelReplaceCells(rows, 12)
+	if len(cells) != 3 || cells[0].Dst != 4 || cells[1].Dst != 7 || cells[2].Dst != 8 {
+		t.Fatalf("cells = %+v", cells)
+	}
+	if got := probelReplaceCells(rows, 77); len(got) != 0 {
+		t.Fatalf("absent src produced cells: %+v", got)
+	}
+}
+
+func TestProbelUsageProtectMap(t *testing.T) {
+	res := codec.ProtectTallyDumpParams{
+		FirstDestinationID: 10,
+		Items: []codec.ProtectTallyItem{
+			{State: codec.ProtectNone, DeviceID: 0},
+			{State: codec.ProtectProbel, DeviceID: 42},
+		},
+	}
+	m := probelUsageProtectMap(res)
+	if len(m) != 1 {
+		t.Fatalf("map = %+v (unprotected dst must be skipped)", m)
+	}
+	if m[11] != protectStateStr(codec.ProtectProbel, 42) {
+		t.Fatalf("dst 11 = %q", m[11])
+	}
+}
+
+// Validation paths that must fail before any dial happens.
+func TestRunProbelUsage_Validation(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		// = form: popPositional would otherwise pop a space-form flag
+		// value as the positional address (documented CLI shape).
+		{"missing addr", []string{"--srce=1"}, "missing <host:port>"},
+		{"bad format", []string{"127.0.0.1:2008", "--format", "xml"}, "--format"},
+		{"srce+dest", []string{"127.0.0.1:2008", "--srce", "1", "--dest", "2"}, "mutually exclusive"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := runProbelUsage(ctx, c.args)
+			if err == nil || !strings.Contains(err.Error(), c.want) {
+				t.Fatalf("err = %v, want %q", err, c.want)
+			}
+		})
+	}
+}
+
+func TestRunProbelReplace_Validation(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"missing addr", []string{"--srce=1", "--with=2"}, "missing <host:port>"},
+		{"missing pair", []string{"127.0.0.1:2008"}, "--srce and --with are required"},
+		{"same source", []string{"127.0.0.1:2008", "--srce", "3", "--with", "3"}, "same source"},
+		{"bad output", []string{"127.0.0.1:2008", "--srce", "1", "--with", "2", "--output", "xml"}, "expected text | json"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := runProbelReplace(ctx, c.args)
+			if err == nil || !strings.Contains(err.Error(), c.want) {
+				t.Fatalf("err = %v, want %q", err, c.want)
+			}
+		})
+	}
+}

--- a/docs/protocols/verbs.md
+++ b/docs/protocols/verbs.md
@@ -111,6 +111,8 @@ Global flag: `--capture FILE.jsonl`. Coordinates: `--matrix --level --dst --src`
 | `tally-dump` | dump every crosspoint on (matrix, level) | bulk read (streaming) |
 | `all/single-source-names`, `all/single-dest-names`, `all/single-source-assoc-names` | fetch labels | read |
 | `protect-interrogate/connect/disconnect/name/dump`, `master-protect` | protect (write-lock) family | owner-only authority |
+| `usage` | reverse tally: where is each source assigned (`--srce`/`--dest` filter, `--protect` joins protect state) | bulk read (#722) |
+| `replace` | substitute source A with B on every crosspoint carrying A (`--check` dry-run, ADR-0007) | bulk write (#722) |
 | `bench` | scale benchmark (interrogate-all + connect-all) | perf |
 
 ### probel-sw02p (SW-P-02)
@@ -238,6 +240,8 @@ acp2 diag → `dhs consumer acp2 diag <host> --port 2072`.
 | `connect` | route source → destination | `dhs consumer probel-sw08p connect <host> --port 2008 --matrix 0 --level 0 --dst 5 --src 12` |
 | `tally-dump` | stream every crosspoint on a level | `dhs consumer probel-sw08p tally-dump <host> --port 2008 --matrix 0 --level 0` |
 | `protect-connect` | owner-locked route | `dhs consumer probel-sw08p protect-connect <host> --port 2008 --matrix 0 --level 0 --dst 5 --src 12` |
+| `usage` | reverse tally (source-side view) | `dhs consumer probel-sw08p usage <host>:2008 --matrix 0 --level 0 --srce 12 --format ascii` |
+| `replace` | substitute src A → B everywhere | `dhs consumer probel-sw08p replace <host>:2008 --matrix 0 --level 0 --srce 12 --with 14 --check` |
 
 probel-sw02p is **watch-only** today (interrogate/connect/protect gated behind `approve seq N`): `dhs consumer probel-sw02p watch <host> --mtx-id 0 --level 0 --dsts 1-32`.
 


### PR DESCRIPTION
## What

Adds `usage` (reverse tally) + `replace` (source substitution) verbs to the probel-sw08p consumer CLI — unit 1 of the matrix-connector rollout.

## Why

Owner-mandated topic 7: bring the source-side pair from cerebrum-nb (#718) to every matrix connector. Design in #722.

Closes #731

## Scope

- [ ] acp1
- [ ] acp2
- [ ] emberplus
- [x] probel-sw08p / probel-sw02p
- [ ] osc / tsl / cerebrum-nb / amwa
- [ ] transport
- [ ] export
- [x] cli
- [ ] api
- [ ] core
- [ ] ci / chore

**Cross-protocol changes**: none — cmd/dhs composition layer only, no `internal/<proto>/` change.

## Wire evidence (protocol changes only)

No protocol behaviour change: both verbs compose existing Tier-2-proven primitives (rx 021 tally dump, rx 019 protect dump, rx 002 connect). No new wire commands, no codec edits.

## Reference controller

- [ ] Cerebrum still happy after this change
- [ ] VSM Studio still happy after this change
- [x] N/A (no protocol behaviour change)

## Type

- [x] feat — new feature
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] chore — maintenance, refactor, CI
- [ ] security — security fix or hardening

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `cmd/dhs/cmd_probel_usage.go` | new | usage + replace verbs (pure helpers + CLI drivers) |
| `cmd/dhs/cmd_probel_usage_test.go` | new | helper unit tests + pre-dial validation tests |
| `cmd/dhs/cmd_probel.go` | modified | dispatcher + help wiring |
| `docs/protocols/verbs.md` | modified | verb rows + worked examples |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test ./...` | all | 0 |
| `go vet ./...` | clean | — |
| `golangci-lint run` | clean | — |

## Device tested

- [ ] ACP1 producer 10.100.0.102
- [ ] ACP2 producer 10.100.0.103
- [ ] ACP1 emulator 10.6.239.113
- [ ] ACP2 real device 10.41.40.195
- [x] Other (specify): Tier-4 loopback vs own provider on 127.0.0.1:2038 (staging Snell 10.100.0.5 has no direct SW-P-08 port; real Neuron :7800 unreachable from this host; primitives already Tier-2 proven vs Commie + VSM)
- [ ] No device needed (pure codec / doc change)

**Live-LXC command + observed output** (paste verbatim):

```text
dhs consumer probel-sw08p usage 127.0.0.1:2038 --matrix 0 --level 0 --srce 3 --format ascii
src 3
├── dst 2  level 0
├── dst 5  level 0
└── dst 9  level 0

dhs consumer probel-sw08p replace 127.0.0.1:2038 --matrix 0 --level 0 --srce 3 --with 7 --output json
{changed:true,diff:[{field:route.2.0,from:3,to:7},{field:route.5.0,from:3,to:7},{field:route.9.0,from:3,to:7}]}
# run-twice:
{changed:false,diff:[]}
```

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [x] Integration tested on VM before PR (loopback; see Device tested)

## Approval

@yboujraf — requesting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)