### PR TITLE
feat(cli): probel-sw02p usage + replace verbs (#722 unit 2)

### DIFF
--- a/cmd/dhs/cmd_probel02p.go
+++ b/cmd/dhs/cmd_probel02p.go
@@ -88,6 +88,10 @@ func runProbelsw02p(ctx context.Context, args []string) error {
 		return runProbelsw02pRouterConfig(ctx, rest)
 	case "watch":
 		return runProbelsw02pWatch(ctx, rest)
+	case "usage":
+		return runProbelSW02Usage(ctx, rest)
+	case "replace":
+		return runProbelSW02Replace(ctx, rest)
 	}
 	return fmt.Errorf("unknown probel-sw02p subcommand %q", sub)
 }
@@ -126,6 +130,11 @@ SUBCOMMANDS
   lock-status         read source-lock bitmap, GET only (rx 014; SW-P-02 lock is read-only)
   status              read controller status — 2 (rx 07)
   router-config       read router configuration / level map (rx 075)
+  usage               reverse tally: one interrogate per dst (rx 01/65 sweep;
+                      size from --dsts or rx 075); --srce/--dest filter,
+                      csv (ADR-0028 snapshot) | ascii
+  replace             substitute source A with B on every dst carrying A
+                      (rx 02/66); --check dry-run (ADR-0007 ensure)
   watch               subscribe to async tallies until Ctrl-C / --timeout
 
 EXAMPLES

--- a/cmd/dhs/cmd_probel02p_usage.go
+++ b/cmd/dhs/cmd_probel02p_usage.go
@@ -1,0 +1,267 @@
+package main
+
+// usage + replace for SW-P-02 (#722, unit 2; canonical shape defined
+// by cerebrum-nb #718, row/format helpers shared with probel-sw08p).
+//
+// SW-P-02 has no crosspoint tally dump, so usage sweeps one
+// interrogate (rx 01, or rx 65 extended) per destination on the
+// single configured (matrix, level); replace substitutes source A
+// with B via one connect (rx 02 / rx 66) per affected dst (ADR-0007:
+// --check first, diff-only, run-twice = 0). Extended forms
+// auto-escalate whenever an id exceeds the narrow 0-1023 range (root
+// CLAUDE.md scale rule); --extended forces them throughout.
+//
+// The destination count comes from the global --dsts matrix config;
+// when unset, the router configuration request (rx 075) supplies the
+// level's size.
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"math/bits"
+	"os"
+	"path/filepath"
+	"time"
+
+	probelsw02proto "dhs/internal/probel-sw02p/consumer"
+)
+
+// sw02NarrowOutOfRange is the tx 03 sentinel: Source 1023 = the
+// interrogated destination does not exist (§3.2.5).
+const sw02NarrowOutOfRange = 1023
+
+// sw02RouterConfigDsts extracts the destination count for one level
+// from the rx 075 response union. The level map is a 28-bit set;
+// entries appear in bit-0 → bit-27 order for SET bits only, so the
+// entry index is the popcount of the lower bits. Returns 0 when the
+// level is absent from the map (or the union is empty).
+func sw02RouterConfigDsts(rc probelsw02proto.RouterConfigResponse, level uint8) int {
+	if level > 27 {
+		return 0
+	}
+	pick := func(levelMap uint32, n int, dsts func(int) int) int {
+		if levelMap&(1<<level) == 0 {
+			return 0
+		}
+		idx := bits.OnesCount32(levelMap & ((1 << level) - 1))
+		if idx >= n {
+			return 0
+		}
+		return dsts(idx)
+	}
+	switch {
+	case rc.Response1 != nil:
+		return pick(rc.Response1.LevelMap, len(rc.Response1.Levels),
+			func(i int) int { return int(rc.Response1.Levels[i].NumDestinations) })
+	case rc.Response2 != nil:
+		return pick(rc.Response2.LevelMap, len(rc.Response2.Levels),
+			func(i int) int { return int(rc.Response2.Levels[i].NumDestinations) })
+	}
+	return 0
+}
+
+// runProbelSW02Usage drives `dhs consumer probel-sw02p usage`.
+func runProbelSW02Usage(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("probel-sw02p-usage", flag.ContinueOnError)
+	srce := fs.Int("srce", -1, "filter: only this source's assignments")
+	dest := fs.Int("dest", -1, "filter: only this destination's feed")
+	extended := fs.Bool("extended", false, "force extended forms (rx 65) throughout")
+	format := fs.String("format", "csv", "output format: csv | ascii")
+	out := fs.String("out", "", "csv output file (omitted = snapshots/probel-sw02p/<host>/usage.csv per ADR-0028; \"-\" = stdout)")
+	timeout := fs.Duration("timeout", 60*time.Second, "operation timeout (one interrogate per dst)")
+	addr, flagArgs := popPositional(args)
+	if addr == "" {
+		return fmt.Errorf("missing <host:port>")
+	}
+	if err := fs.Parse(flagArgs); err != nil {
+		return err
+	}
+	if *format != "csv" && *format != "ascii" {
+		return fmt.Errorf("--format must be csv or ascii, got %q", *format)
+	}
+	if *srce >= 0 && *dest >= 0 {
+		return fmt.Errorf("--srce and --dest are mutually exclusive")
+	}
+	cctx, cancel := context.WithTimeout(ctx, *timeout)
+	defer cancel()
+	p, closer, err := dialProbelSW02(cctx, addr)
+	if err != nil {
+		return err
+	}
+	defer closer()
+	count, level, err := sw02UsageDstCount(cctx, p)
+	if err != nil {
+		return err
+	}
+	rows, err := sw02Interrogations(cctx, p, count, level, *extended)
+	if err != nil {
+		return err
+	}
+	rows = probelFilterUsage(sortProbelUsage(rows), *srce, *dest)
+
+	if *format == "ascii" {
+		renderProbelUsageASCII(os.Stdout, rows)
+		return nil
+	}
+	csv := formatProbelUsageCSV(rows, false)
+	if *out == "-" {
+		fmt.Print(csv)
+		return nil
+	}
+	path := *out
+	if path == "" {
+		host, _, _ := splitHostPort(addr, probelsw02proto.DefaultPort)
+		path = filepath.Join(snapshotDir("probel-sw02p", host), "usage.csv")
+		fmt.Fprintf(os.Stderr, "probel-sw02p usage: default snapshot file %s (ADR-0028)\n", path)
+	}
+	if dir := filepath.Dir(path); dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	if err := os.WriteFile(path, []byte(csv), 0o644); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "probel-sw02p usage: wrote %s (%d row(s))\n", path, len(rows))
+	return nil
+}
+
+// sw02UsageDstCount resolves the sweep size: the global --dsts matrix
+// config when set, else the router configuration (rx 075) size for
+// the configured level. Also returns the level for row display.
+func sw02UsageDstCount(ctx context.Context, p *probelsw02proto.Plugin) (count, level int, err error) {
+	mc := p.MatrixConfig()
+	level = int(mc.Level)
+	if mc.Dsts > 0 {
+		return int(mc.Dsts), level, nil
+	}
+	rc, rerr := p.SendRouterConfigRequest(ctx)
+	if rerr != nil {
+		return 0, level, fmt.Errorf("--dsts not set and router-config (rx 075) failed: %w", rerr)
+	}
+	if n := sw02RouterConfigDsts(rc, mc.Level); n > 0 {
+		return n, level, nil
+	}
+	return 0, level, fmt.Errorf("--dsts not set and router-config reports no destinations on level %d", level)
+}
+
+// sw02Interrogations sweeps dsts 0..count-1 (rx 01, auto-escalating
+// to rx 65 past the narrow range or when forced) into usage rows,
+// skipping the narrow out-of-range sentinel.
+func sw02Interrogations(ctx context.Context, p *probelsw02proto.Plugin, count, level int, extended bool) ([]probelUsageRow, error) {
+	rows := make([]probelUsageRow, 0, count)
+	for dst := 0; dst < count; dst++ {
+		if extended || dst > sw02NarrowOutOfRange {
+			t, err := p.SendExtendedInterrogate(ctx, uint16(dst))
+			if err != nil {
+				return nil, fmt.Errorf("extended interrogate dst %d: %w", dst, err)
+			}
+			rows = append(rows, probelUsageRow{Src: int(t.Source), Dst: int(t.Destination), Level: level})
+			continue
+		}
+		t, err := p.SendInterrogate(ctx, uint16(dst))
+		if err != nil {
+			return nil, fmt.Errorf("interrogate dst %d: %w", dst, err)
+		}
+		if t.Source == sw02NarrowOutOfRange {
+			continue
+		}
+		rows = append(rows, probelUsageRow{Src: int(t.Source), Dst: int(t.Destination), Level: level})
+	}
+	return rows, nil
+}
+
+// runProbelSW02Replace drives `dhs consumer probel-sw02p replace` —
+// substitute source A with B on every destination carrying A
+// (ADR-0007 ensure: --check dry-run, diff-only apply, run-twice = 0).
+func runProbelSW02Replace(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("probel-sw02p-replace", flag.ContinueOnError)
+	from := fs.Int("srce", -1, "source id to replace (required)")
+	with := fs.Int("with", -1, "source id that takes over (required)")
+	extended := fs.Bool("extended", false, "force extended forms (rx 65/66) throughout")
+	check := fs.Bool("check", false, "dry-run (ADR-0007): list the destinations that would change, send nothing")
+	output := fs.String("output", "text", "output format: text | json (ADR-0002; json = {changed|would_change, diff[]})")
+	timeout := fs.Duration("timeout", 60*time.Second, "operation timeout")
+	addr, flagArgs := popPositional(args)
+	if addr == "" {
+		return fmt.Errorf("missing <host:port>")
+	}
+	if err := fs.Parse(flagArgs); err != nil {
+		return err
+	}
+	if *from < 0 || *with < 0 {
+		return fmt.Errorf("--srce and --with are required (replace source A with B)")
+	}
+	if *from == *with {
+		return fmt.Errorf("--srce and --with are the same source — nothing to do")
+	}
+	jsonOut, oerr := resolveEnsureOutput(*output, false)
+	if oerr != nil {
+		return oerr
+	}
+	cctx, cancel := context.WithTimeout(ctx, *timeout)
+	defer cancel()
+	p, closer, err := dialProbelSW02(cctx, addr)
+	if err != nil {
+		return err
+	}
+	defer closer()
+	logw := os.Stdout
+	if jsonOut {
+		logw = os.Stderr
+	}
+	count, level, err := sw02UsageDstCount(cctx, p)
+	if err != nil {
+		return err
+	}
+	rows, err := sw02Interrogations(cctx, p, count, level, *extended)
+	if err != nil {
+		return err
+	}
+	cells := probelReplaceCells(rows, *from)
+
+	changed := len(cells) > 0
+	diffs := make([]ensureDiff, 0, len(cells))
+	for _, c := range cells {
+		diffs = append(diffs, ensureDiff{
+			Field: fmt.Sprintf("route.%d.%d", c.Dst, c.Level),
+			From:  fmt.Sprintf("%d", *from), To: fmt.Sprintf("%d", *with),
+		})
+	}
+
+	if *check {
+		for _, c := range cells {
+			_, _ = fmt.Fprintf(logw, "[would-replace] level=%d dst=%d: src %d -> %d\n", c.Level, c.Dst, *from, *with)
+		}
+		_, _ = fmt.Fprintf(logw, "probel-sw02p replace --check: would_change=%d destination(s) carrying src %d — nothing sent\n", len(cells), *from)
+		if jsonOut {
+			return emitEnsure(true, ensureResult{WouldChange: &changed, Diff: diffs})
+		}
+		return nil
+	}
+
+	fails := 0
+	for _, c := range cells {
+		var cerr error
+		if *extended || c.Dst > sw02NarrowOutOfRange || *with > sw02NarrowOutOfRange {
+			_, cerr = p.SendExtendedConnect(cctx, uint16(c.Dst), uint16(*with))
+		} else {
+			_, cerr = p.SendConnect(cctx, uint16(c.Dst), uint16(*with), false)
+		}
+		if cerr != nil {
+			_, _ = fmt.Fprintf(logw, "[replace] FAIL level=%d dst=%d reason=%s\n", c.Level, c.Dst, cerr)
+			fails++
+			continue
+		}
+		_, _ = fmt.Fprintf(logw, "[replace] OK   level=%d dst=%d: src %d -> %d\n", c.Level, c.Dst, *from, *with)
+	}
+	if fails > 0 {
+		return fmt.Errorf("%d/%d replace connect(s) failed", fails, len(cells))
+	}
+	_, _ = fmt.Fprintf(logw, "probel-sw02p replace: changed=%d destination(s); run again to verify 0 (nothing carries src %d any more)\n", len(cells), *from)
+	if jsonOut {
+		return emitEnsure(true, ensureResult{Changed: &changed, Diff: diffs})
+	}
+	return nil
+}

--- a/cmd/dhs/cmd_probel02p_usage_test.go
+++ b/cmd/dhs/cmd_probel02p_usage_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"dhs/internal/probel-sw02p/codec"
+	probelsw02proto "dhs/internal/probel-sw02p/consumer"
+)
+
+func TestSW02RouterConfigDsts(t *testing.T) {
+	// Levels 1 and 3 present (bits 1+3); entries in bit order: level 1
+	// has 64 dsts, level 3 has 128.
+	r1 := probelsw02proto.RouterConfigResponse{Response1: &codec.RouterConfigResponse1Params{
+		LevelMap: 0b1010,
+		Levels: []codec.RouterConfigResponse1LevelEntry{
+			{NumDestinations: 64, NumSources: 32},
+			{NumDestinations: 128, NumSources: 96},
+		},
+	}}
+	if got := sw02RouterConfigDsts(r1, 1); got != 64 {
+		t.Fatalf("level 1 = %d, want 64", got)
+	}
+	if got := sw02RouterConfigDsts(r1, 3); got != 128 {
+		t.Fatalf("level 3 = %d, want 128", got)
+	}
+	if got := sw02RouterConfigDsts(r1, 0); got != 0 {
+		t.Fatalf("absent level = %d, want 0", got)
+	}
+	if got := sw02RouterConfigDsts(r1, 28); got != 0 {
+		t.Fatalf("out-of-range level = %d, want 0", got)
+	}
+
+	// RESPONSE-2 variant, same level-map convention.
+	r2 := probelsw02proto.RouterConfigResponse{Response2: &codec.RouterConfigResponse2Params{
+		LevelMap: 0b1,
+		Levels:   []codec.RouterConfigResponse2LevelEntry{{NumDestinations: 16, NumSources: 16}},
+	}}
+	if got := sw02RouterConfigDsts(r2, 0); got != 16 {
+		t.Fatalf("r2 level 0 = %d, want 16", got)
+	}
+
+	// Malformed: level bit set but entry list too short — and the
+	// empty union.
+	short := probelsw02proto.RouterConfigResponse{Response1: &codec.RouterConfigResponse1Params{LevelMap: 0b1}}
+	if got := sw02RouterConfigDsts(short, 0); got != 0 {
+		t.Fatalf("short entries = %d, want 0", got)
+	}
+	if got := sw02RouterConfigDsts(probelsw02proto.RouterConfigResponse{}, 0); got != 0 {
+		t.Fatalf("empty union = %d, want 0", got)
+	}
+}
+
+func TestSortProbelUsage(t *testing.T) {
+	rows := sortProbelUsage([]probelUsageRow{
+		{Src: 7, Dst: 2}, {Src: 3, Dst: 9}, {Src: 3, Dst: 1},
+	})
+	want := []probelUsageRow{{Src: 3, Dst: 1}, {Src: 3, Dst: 9}, {Src: 7, Dst: 2}}
+	for i, w := range want {
+		if rows[i] != w {
+			t.Fatalf("row %d = %+v, want %+v", i, rows[i], w)
+		}
+	}
+}
+
+func TestRunProbelSW02Usage_Validation(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"missing addr", []string{"--srce=1"}, "missing <host:port>"},
+		{"bad format", []string{"127.0.0.1:2002", "--format", "xml"}, "--format"},
+		{"srce+dest", []string{"127.0.0.1:2002", "--srce", "1", "--dest", "2"}, "mutually exclusive"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := runProbelSW02Usage(ctx, c.args)
+			if err == nil || !strings.Contains(err.Error(), c.want) {
+				t.Fatalf("err = %v, want %q", err, c.want)
+			}
+		})
+	}
+}
+
+func TestRunProbelSW02Replace_Validation(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"missing addr", []string{"--srce=1", "--with=2"}, "missing <host:port>"},
+		{"missing pair", []string{"127.0.0.1:2002"}, "--srce and --with are required"},
+		{"same source", []string{"127.0.0.1:2002", "--srce", "3", "--with", "3"}, "same source"},
+		{"bad output", []string{"127.0.0.1:2002", "--srce", "1", "--with", "2", "--output", "xml"}, "expected text | json"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := runProbelSW02Replace(ctx, c.args)
+			if err == nil || !strings.Contains(err.Error(), c.want) {
+				t.Fatalf("err = %v, want %q", err, c.want)
+			}
+		})
+	}
+}

--- a/cmd/dhs/cmd_probel_usage.go
+++ b/cmd/dhs/cmd_probel_usage.go
@@ -65,6 +65,11 @@ func probelBuildUsage(firstDst int, srcs []int, level int, protect map[int]strin
 		dst := firstDst + i
 		rows = append(rows, probelUsageRow{Src: src, Dst: dst, Level: level, Protect: protect[dst]})
 	}
+	return sortProbelUsage(rows)
+}
+
+// sortProbelUsage orders rows source-keyed: by (src, dst).
+func sortProbelUsage(rows []probelUsageRow) []probelUsageRow {
 	sort.SliceStable(rows, func(i, j int) bool {
 		if rows[i].Src != rows[j].Src {
 			return rows[i].Src < rows[j].Src

--- a/docs/protocols/verbs.md
+++ b/docs/protocols/verbs.md
@@ -120,10 +120,13 @@ Global flags: `--mtx-id --level --dsts --srcs` (`--dsts` enables bootstrap rx01 
 
 | Verb | Description | Scope |
 |---|---|---|
+| `interrogate` / `connect` | one crosspoint read / write (rx 01/02; `--extended` → rx 65/66) | single dst |
+| `connect-on-go` / `go` / `salvo-connect` | staged crosspoints + commit (rx 05/06/35/36) | salvo |
+| `protect-interrogate/connect/disconnect/name/dump` | protect family (rx 101-105) | owner-only authority |
+| `dual-status` / `lock-status` / `status` / `router-config` | controller state reads (rx 050/014/07/075) | read |
+| `usage` | reverse tally: one interrogate per dst (rx 01/65 sweep; size from `--dsts` or rx 075) | bulk read (#722) |
+| `replace` | substitute source A with B on every dst carrying A (`--check` dry-run, ADR-0007) | bulk write (#722) |
 | `watch` | subscribe to async tallies (`--timeout`) | until Ctrl-C / timeout |
-
-> sw02p consumer is **watch-only today**; interrogate/connect/protect are gated
-> behind `approve seq N` (per-command queue). Most commands not yet wired.
 
 ---
 


### PR DESCRIPTION
## What

Adds `usage` (reverse tally via rx 01/65 interrogate sweep) + `replace` (source substitution via rx 02/66) verbs to the probel-sw02p consumer CLI — unit 2 of the matrix-connector rollout.

## Why

Owner-mandated topic 7 (#722): the source-side pair from cerebrum-nb (#718) on every matrix connector. SW-P-02 has no tally dump, so usage sweeps one interrogate per dst (size from `--dsts` or rx 075 router-config), skipping the narrow 1023 out-of-range sentinel; extended forms auto-escalate past narrow ids.

Closes #733

## Scope

- [ ] acp1
- [ ] acp2
- [ ] emberplus
- [x] probel-sw08p / probel-sw02p
- [ ] osc / tsl / cerebrum-nb / amwa
- [ ] transport
- [ ] export
- [x] cli
- [ ] api
- [ ] core
- [ ] ci / chore

**Cross-protocol changes**: none — cmd/dhs composition layer only (shared row/format helpers with the sw08p unit live in cmd/dhs too).

## Wire evidence (protocol changes only)

No protocol behaviour change: composition of existing primitives (rx 01/65 interrogate, rx 075 router-config, rx 02/66 connect). Loopback wire log shows the sweep: 16× `rx 01` (`ff 01 00 NN ck`) answered by `tx 03` tallies, sentinel `7f` (1023) dsts skipped.

## Reference controller

- [ ] Cerebrum still happy after this change
- [ ] VSM Studio still happy after this change
- [x] N/A (no protocol behaviour change)

## Type

- [x] feat — new feature
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] chore — maintenance, refactor, CI
- [ ] security — security fix or hardening

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `cmd/dhs/cmd_probel02p_usage.go` | new | usage + replace verbs (rx 01/65 sweep, rx 075 size, rx 02/66 apply) |
| `cmd/dhs/cmd_probel02p_usage_test.go` | new | router-config level-map tests + validation tests |
| `cmd/dhs/cmd_probel02p.go` | modified | dispatcher + help wiring |
| `cmd/dhs/cmd_probel_usage.go` | modified | sortProbelUsage helper extracted for reuse |
| `docs/protocols/verbs.md` | modified | sw02p verb rows (corrects stale watch-only note) |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test ./...` | all | 0 |
| `go vet ./...` | clean | — |
| `golangci-lint run` | clean | — |

## Device tested

- [ ] ACP1 producer 10.100.0.102
- [ ] ACP2 producer 10.100.0.103
- [ ] ACP1 emulator 10.6.239.113
- [ ] ACP2 real device 10.41.40.195
- [x] Other (specify): Tier-4 loopback vs own provider on 127.0.0.1:2039 (no reachable SW-P-02 endpoint from this host; primitives Tier-2 proven vs VSM earlier)
- [ ] No device needed (pure codec / doc change)

**Live-LXC command + observed output** (paste verbatim):

```text
dhs consumer probel-sw02p --dsts 16 usage 127.0.0.1:2039 --srce 5 --format ascii
src 5
├── dst 1  level 0
└── dst 4  level 0

dhs consumer probel-sw02p --dsts 16 replace 127.0.0.1:2039 --srce 5 --with 9 --output json
{changed:true,diff:[{field:route.1.0,from:5,to:9},{field:route.4.0,from:5,to:9}]}
# run-twice:
{changed:false,diff:[]}
```

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [x] Integration tested on VM before PR (loopback; see Device tested)

## Approval

@yboujraf — requesting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)