### PR TITLE
feat(cli): emberplus usage + replace verbs (#722 unit 3)

### DIFF
--- a/cmd/dhs/cmd_emberplus_usage.go
+++ b/cmd/dhs/cmd_emberplus_usage.go
@@ -1,0 +1,342 @@
+package main
+
+// usage + replace for Ember+ matrices (#722, unit 3; canonical shape
+// defined by cerebrum-nb #718, row/format helpers shared with the
+// probel units in cmd_probel_usage.go).
+//
+//	usage    WHERE is a source assigned on one matrix (reverse tally),
+//	         built from the walked tree's connection snapshot. Levels
+//	         column fixed "0" — tree matrices have no levels (grammar
+//	         parity with the levelled protocols, same as export).
+//	replace  substitute source A with B on every target that carries A
+//	         (ADR-0007: --check first, diff-only, run-twice = 0),
+//	         honoring the ADR-0023 behavior: 1to1 / 1toN / dynamic take
+//	         the substituted set ABSOLUTELY (pinned semantics — never
+//	         toggles), NtoM connects the missing source and EXPLICITLY
+//	         disconnects the replaced one.
+//
+// Both are client-side compositions over the walked tree +
+// MatrixConnect — the wire operations stay internal (owner rule).
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"dhs/internal/consumer"
+	emberplus "dhs/internal/emberplus/consumer"
+	"dhs/internal/emberplus/codec/matrix"
+)
+
+// emberUsageRows flattens a matrix connection snapshot into
+// source-keyed usage rows (level fixed 0 — tree matrices have no
+// levels).
+func emberUsageRows(snap []matrix.TargetState) []probelUsageRow {
+	var rows []probelUsageRow
+	for _, ts := range snap {
+		for _, src := range ts.Sources {
+			rows = append(rows, probelUsageRow{Src: int(src), Dst: int(ts.Target), Level: 0})
+		}
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		if rows[i].Src != rows[j].Src {
+			return rows[i].Src < rows[j].Src
+		}
+		return rows[i].Dst < rows[j].Dst
+	})
+	return rows
+}
+
+func containsInt32(xs []int32, v int32) bool {
+	for _, x := range xs {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
+// emberReplacePlan computes the converge actions that substitute
+// source `from` with `to` on every target carrying `from`, honoring
+// the ADR-0023 behavior (see file header).
+func emberReplacePlan(behavior string, snap []matrix.TargetState, from, to int32) []xpointChange {
+	var out []xpointChange
+	for _, ts := range snap {
+		if !containsInt32(ts.Sources, from) {
+			continue
+		}
+		have := dedupInt32(ts.Sources)
+		want := make([]int32, 0, len(have))
+		for _, s := range have {
+			if s == from {
+				s = to
+			}
+			want = append(want, s)
+		}
+		want = dedupInt32(want)
+		switch behavior {
+		case "NtoM":
+			add := subtractInt32(want, have)
+			del := subtractInt32(have, want)
+			if len(add) > 0 {
+				out = append(out, xpointChange{Target: ts.Target, Sources: add, Op: xpOpConnect, From: joinInt32s(have), To: joinInt32s(want)})
+			}
+			if len(del) > 0 {
+				out = append(out, xpointChange{Target: ts.Target, Sources: del, Op: xpOpDisconnect, From: joinInt32s(have), To: joinInt32s(want)})
+			}
+		default: // 1to1 / 1toN / dynamic — absolute take (never toggles)
+			out = append(out, xpointChange{Target: ts.Target, Sources: want, Op: xpOpAbsolute, From: joinInt32s(have), To: joinInt32s(want)})
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Target < out[j].Target })
+	return out
+}
+
+// emberValidSourceIDs collects the matrix's valid source numbers from
+// its walked sourceLabels meta (union across label groups). Empty map
+// = the matrix declares no source list (sparse validation impossible).
+// Ember+ matrices legally have SPARSE id sets, and at least one
+// shipping provider (TinyEmber+ 1.6.2, live 2026-08-21) SILENTLY
+// ignores connections naming an id outside the set — so replace warns
+// loudly instead of letting the substitution vanish.
+func emberValidSourceIDs(o consumer.Object) map[int]bool {
+	groups, byGroup := labelGroups(o, "sourceLabels")
+	out := map[int]bool{}
+	for _, g := range groups {
+		for idx := range byGroup[g] {
+			if n, err := strconv.Atoi(idx); err == nil {
+				out[n] = true
+			}
+		}
+	}
+	return out
+}
+
+func helpEmberUsage() {
+	fmt.Println(`dhs consumer emberplus usage <host> [--port N] [--path <matrix.path>] [--srce N | --dest N] [--format csv|ascii] [--out PATH] [--dm <identity> | --no-walk]
+
+Reverse tally for ONE Ember+ matrix: where is each source assigned.
+Built from the walked tree's connection snapshot — no wire mutation.
+--path selects the matrix (dotted label path or numeric OID); omitted =
+the only matrix in the tree. Levels column is fixed "0" (tree matrices
+have no levels — grammar parity with the levelled protocols).
+
+  --srce N        only this source's assignments (fan-out view in ascii)
+  --dest N        only this target's feed
+  --format        csv (default) | ascii
+  --out PATH      csv file (omitted = snapshots/emberplus/<host>/usage.csv
+                  per ADR-0028; "-" = stdout)
+
+EXAMPLES
+  dhs consumer emberplus usage 10.100.0.102 --port 9000 --path router.nToN.matrix --srce 3 --format ascii`)
+}
+
+func helpEmberReplace() {
+	fmt.Println(`dhs consumer emberplus replace <host> [--port N] --srce A --with B [--path <matrix.path>] [--check] [--output text|json] [--dm <identity> | --no-walk]
+
+Substitute source A with B on every target of ONE matrix that carries A
+(ADR-0007 ensure: --check dry-run, diff-only apply, run-twice = 0).
+Honors the ADR-0023 behavior: 1to1 / 1toN / dynamic take the substituted
+source set ABSOLUTELY (never toggles); NtoM connects B and EXPLICITLY
+disconnects A.
+
+EXAMPLES
+  dhs consumer emberplus replace 10.100.0.102 --port 9000 --path router.nToN.matrix --srce 3 --with 7 --check`)
+}
+
+// runEmberUsage drives `dhs consumer emberplus usage`.
+func runEmberUsage(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("emberplus-usage", flag.ContinueOnError)
+	cf := addCommonFlags(fs)
+	slot := fs.Int("slot", 0, "slot number")
+	matrixPath := fs.String("path", "", "matrix path: dotted label OR numeric OID (omitted = the only matrix in the tree)")
+	srce := fs.Int("srce", -1, "filter: only this source's assignments")
+	dest := fs.Int("dest", -1, "filter: only this target's feed")
+	format := fs.String("format", "csv", "output format: csv | ascii")
+	out := fs.String("out", "", "csv output file (omitted = snapshots/emberplus/<host>/usage.csv per ADR-0028; \"-\" = stdout)")
+	dmIdentity := fs.String("dm", "", "identity-keyed DM hot-load (ADR-0022): seed the tree from cache, skip the walk")
+	noWalk := fs.Bool("no-walk", false, "fail fast on cache miss instead of falling back to a wire walk")
+	host, rest, err := popHost(args)
+	if err != nil {
+		return fmt.Errorf("usage: dhs consumer emberplus usage <host> [--path <matrix.path>] [--srce N | --dest N] [--format csv|ascii]")
+	}
+	if err := fs.Parse(rest); err != nil {
+		return err
+	}
+	if *format != "csv" && *format != "ascii" {
+		return fmt.Errorf("--format must be csv or ascii, got %q", *format)
+	}
+	if *srce >= 0 && *dest >= 0 {
+		return fmt.Errorf("--srce and --dest are mutually exclusive")
+	}
+	if *matrixPath != "" {
+		if err := validatePathOrOID(*matrixPath); err != nil {
+			return err
+		}
+	}
+
+	plug, cleanup, err := connect(ctx, host, cf)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	ep, ok := plug.(*emberplus.Plugin)
+	if !ok {
+		return fmt.Errorf("usage (matrix reverse tally) is only supported for Ember+ protocol")
+	}
+	if err := ensureEmberplusTree(ctx, plug, host, cf.port, *dmIdentity, *slot, *noWalk); err != nil {
+		return err
+	}
+	wctx, cancel := withTimeout(ctx, cf.timeout)
+	defer cancel()
+	objs, err := plug.Walk(wctx, *slot)
+	if err != nil {
+		return err
+	}
+	_, dotted, found := findMatrixObject(objs, *matrixPath)
+	if !found {
+		avail := listMatrixPaths(objs)
+		if len(avail) == 0 {
+			return fmt.Errorf("no matrix in the walked tree")
+		}
+		return fmt.Errorf("matrix %q not found; available:\n  %s", *matrixPath, strings.Join(avail, "\n  "))
+	}
+	rows := probelFilterUsage(emberUsageRows(ep.MatrixSnapshot(dotted)), *srce, *dest)
+
+	if *format == "ascii" {
+		renderProbelUsageASCII(os.Stdout, rows)
+		return nil
+	}
+	csv := formatProbelUsageCSV(rows, false)
+	if *out == "-" {
+		fmt.Print(csv)
+		return nil
+	}
+	path := *out
+	if path == "" {
+		path = filepath.Join(snapshotDir("emberplus", host), "usage.csv")
+		fmt.Fprintf(os.Stderr, "emberplus usage: default snapshot file %s (ADR-0028)\n", path)
+	}
+	if dir := filepath.Dir(path); dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	if err := os.WriteFile(path, []byte(csv), 0o644); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "emberplus usage: wrote %s (%d row(s))\n", path, len(rows))
+	return nil
+}
+
+// runEmberReplace drives `dhs consumer emberplus replace`.
+func runEmberReplace(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("emberplus-replace", flag.ContinueOnError)
+	cf := addCommonFlags(fs)
+	slot := fs.Int("slot", 0, "slot number")
+	matrixPath := fs.String("path", "", "matrix path: dotted label OR numeric OID (omitted = the only matrix in the tree)")
+	from := fs.Int("srce", -1, "source number to replace (required)")
+	with := fs.Int("with", -1, "source number that takes over (required)")
+	check := fs.Bool("check", false, "dry-run (ADR-0007): list the targets that would change, send nothing")
+	output := fs.String("output", "text", "output format: text | json (ADR-0002; json = {changed|would_change, diff[]})")
+	dmIdentity := fs.String("dm", "", "identity-keyed DM hot-load (ADR-0022): seed the tree from cache, skip the walk")
+	noWalk := fs.Bool("no-walk", false, "fail fast on cache miss instead of falling back to a wire walk")
+	host, rest, err := popHost(args)
+	if err != nil {
+		return fmt.Errorf("usage: dhs consumer emberplus replace <host> --srce A --with B [--path <matrix.path>] [--check]")
+	}
+	if err := fs.Parse(rest); err != nil {
+		return err
+	}
+	if *from < 0 || *with < 0 {
+		return fmt.Errorf("--srce and --with are required (replace source A with B)")
+	}
+	if *from == *with {
+		return fmt.Errorf("--srce and --with are the same source — nothing to do")
+	}
+	jsonOut, oerr := resolveEnsureOutput(*output, false)
+	if oerr != nil {
+		return oerr
+	}
+	if *matrixPath != "" {
+		if err := validatePathOrOID(*matrixPath); err != nil {
+			return err
+		}
+	}
+
+	plug, cleanup, err := connect(ctx, host, cf)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	ep, ok := plug.(*emberplus.Plugin)
+	if !ok {
+		return fmt.Errorf("replace (matrix source substitution) is only supported for Ember+ protocol")
+	}
+	if err := ensureEmberplusTree(ctx, plug, host, cf.port, *dmIdentity, *slot, *noWalk); err != nil {
+		return err
+	}
+	wctx, wcancel := withTimeout(ctx, cf.timeout)
+	defer wcancel()
+	objs, err := plug.Walk(wctx, *slot)
+	if err != nil {
+		return err
+	}
+	obj, dotted, found := findMatrixObject(objs, *matrixPath)
+	if !found {
+		avail := listMatrixPaths(objs)
+		if len(avail) == 0 {
+			return fmt.Errorf("no matrix in the walked tree")
+		}
+		return fmt.Errorf("matrix %q not found; available:\n  %s", *matrixPath, strings.Join(avail, "\n  "))
+	}
+	desc := descFromObject(obj, dotted)
+	if valid := emberValidSourceIDs(obj); len(valid) > 0 && !valid[*with] {
+		fmt.Fprintf(os.Stderr, "WARNING: source %d is not in %s's declared source set — providers may SILENTLY ignore the substitution (TinyEmber+ does)\n", *with, dotted)
+	}
+	changes := emberReplacePlan(desc.Behavior, ep.MatrixSnapshot(dotted), int32(*from), int32(*with))
+
+	logw := os.Stdout
+	if jsonOut {
+		logw = os.Stderr
+	}
+	diffs := make([]ensureDiff, 0, len(changes))
+	for _, c := range changes {
+		diffs = append(diffs, ensureDiff{Field: fmt.Sprintf("xpoint.%s.%d", dotted, c.Target), From: c.From, To: c.To})
+	}
+	changed := len(changes) > 0
+
+	if *check {
+		for _, c := range changes {
+			_, _ = fmt.Fprintf(logw, "[would-replace] %s target=%d: %q -> %q\n", dotted, c.Target, c.From, c.To)
+		}
+		_, _ = fmt.Fprintf(logw, "emberplus replace --check: would_change=%d action(s) on %s (%s) carrying src %d — nothing sent\n", len(changes), dotted, desc.Behavior, *from)
+		if jsonOut {
+			return emitEnsure(true, ensureResult{WouldChange: &changed, Diff: diffs})
+		}
+		return nil
+	}
+
+	opCtx, cancel := withTimeout(ctx, cf.timeout)
+	defer cancel()
+	for _, c := range changes {
+		if err := ep.MatrixConnect(opCtx, dotted, c.Target, c.Sources, c.Op); err != nil {
+			return fmt.Errorf("replace %s target %d: %w", dotted, c.Target, err)
+		}
+		_, _ = fmt.Fprintf(logw, "[replace] OK %s target=%d: %q -> %q\n", dotted, c.Target, c.From, c.To)
+	}
+	if len(changes) == 0 {
+		_, _ = fmt.Fprintf(logw, "emberplus replace: nothing carries src %d on %s — already converged\n", *from, dotted)
+	} else {
+		_, _ = fmt.Fprintf(logw, "emberplus replace: changed=%d action(s); run again to verify 0 (nothing carries src %d any more)\n", len(changes), *from)
+	}
+	if jsonOut {
+		return emitEnsure(true, ensureResult{Changed: &changed, Diff: diffs})
+	}
+	return nil
+}

--- a/cmd/dhs/cmd_emberplus_usage_test.go
+++ b/cmd/dhs/cmd_emberplus_usage_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"dhs/internal/consumer"
+	"dhs/internal/emberplus/codec/matrix"
+)
+
+func TestEmberValidSourceIDs(t *testing.T) {
+	o := consumer.Object{Meta: map[string]any{
+		"sourceLabels": map[string]map[string]string{
+			"labels": {"3": "S3", "6": "S6"},
+			"alt":    {"9": "S9", "bogus": "X"},
+		},
+	}}
+	v := emberValidSourceIDs(o)
+	if len(v) != 3 || !v[3] || !v[6] || !v[9] {
+		t.Fatalf("valid ids = %v", v)
+	}
+	if len(emberValidSourceIDs(consumer.Object{Meta: map[string]any{}})) != 0 {
+		t.Fatal("no labels must yield empty set")
+	}
+}
+
+// Fixture: target 0 fed by src 3; target 2 fed by srcs 3+7 (NtoM
+// shape); target 5 fed by src 9 (untouched by a 3→7 replace).
+func emberUsageFixture() []matrix.TargetState {
+	return []matrix.TargetState{
+		{Target: 2, Sources: []int32{3, 7}},
+		{Target: 0, Sources: []int32{3}},
+		{Target: 5, Sources: []int32{9}},
+	}
+}
+
+func TestEmberUsageRows(t *testing.T) {
+	rows := emberUsageRows(emberUsageFixture())
+	want := []probelUsageRow{
+		{Src: 3, Dst: 0}, {Src: 3, Dst: 2}, {Src: 7, Dst: 2}, {Src: 9, Dst: 5},
+	}
+	if len(rows) != len(want) {
+		t.Fatalf("rows = %+v", rows)
+	}
+	for i, w := range want {
+		if rows[i] != w {
+			t.Fatalf("row %d = %+v, want %+v", i, rows[i], w)
+		}
+	}
+}
+
+func TestEmberReplacePlan_AbsoluteBehaviors(t *testing.T) {
+	// 1toN: every carrying target becomes an absolute take of the
+	// substituted set — never a toggle (pinned oneToOne semantics).
+	plan := emberReplacePlan("1toN", emberUsageFixture(), 3, 7)
+	if len(plan) != 2 {
+		t.Fatalf("plan = %+v", plan)
+	}
+	if plan[0].Target != 0 || plan[0].Op != xpOpAbsolute || joinInt32s(plan[0].Sources) != "7" {
+		t.Fatalf("target 0 change = %+v", plan[0])
+	}
+	// Target 2 carried 3 AND 7 — substitution dedups to {7}.
+	if plan[1].Target != 2 || plan[1].Op != xpOpAbsolute || joinInt32s(plan[1].Sources) != "7" {
+		t.Fatalf("target 2 change = %+v", plan[1])
+	}
+	// Target 5 (src 9) untouched.
+	for _, c := range plan {
+		if c.Target == 5 {
+			t.Fatalf("target 5 must not appear: %+v", c)
+		}
+	}
+}
+
+func TestEmberReplacePlan_NtoM(t *testing.T) {
+	plan := emberReplacePlan("NtoM", emberUsageFixture(), 3, 7)
+	// Target 0: connect 7 + disconnect 3 (two actions).
+	// Target 2: 7 already present → disconnect 3 only.
+	var t0, t2 []xpointChange
+	for _, c := range plan {
+		switch c.Target {
+		case 0:
+			t0 = append(t0, c)
+		case 2:
+			t2 = append(t2, c)
+		default:
+			t.Fatalf("unexpected target %d: %+v", c.Target, c)
+		}
+	}
+	if len(t0) != 2 || t0[0].Op != xpOpConnect || joinInt32s(t0[0].Sources) != "7" ||
+		t0[1].Op != xpOpDisconnect || joinInt32s(t0[1].Sources) != "3" {
+		t.Fatalf("target 0 actions = %+v", t0)
+	}
+	if len(t2) != 1 || t2[0].Op != xpOpDisconnect || joinInt32s(t2[0].Sources) != "3" {
+		t.Fatalf("target 2 actions = %+v", t2)
+	}
+}
+
+func TestEmberReplacePlan_NoCarrier(t *testing.T) {
+	if plan := emberReplacePlan("1toN", emberUsageFixture(), 77, 7); len(plan) != 0 {
+		t.Fatalf("absent src produced plan: %+v", plan)
+	}
+}
+
+func TestRunEmberUsage_Validation(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"bad format", []string{"127.0.0.1", "--format", "xml"}, "--format"},
+		{"srce+dest", []string{"127.0.0.1", "--srce", "1", "--dest", "2"}, "mutually exclusive"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := runEmberUsage(ctx, c.args)
+			if err == nil || !strings.Contains(err.Error(), c.want) {
+				t.Fatalf("err = %v, want %q", err, c.want)
+			}
+		})
+	}
+}
+
+func TestRunEmberReplace_Validation(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"missing pair", []string{"127.0.0.1"}, "--srce and --with are required"},
+		{"same source", []string{"127.0.0.1", "--srce", "3", "--with", "3"}, "same source"},
+		{"bad output", []string{"127.0.0.1", "--srce", "1", "--with", "2", "--output", "xml"}, "expected text | json"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := runEmberReplace(ctx, c.args)
+			if err == nil || !strings.Contains(err.Error(), c.want) {
+				t.Fatalf("err = %v, want %q", err, c.want)
+			}
+		})
+	}
+}

--- a/cmd/dhs/main.go
+++ b/cmd/dhs/main.go
@@ -171,6 +171,8 @@ var commands = []command{
 	{"convert", "translate a snapshot file between json / yaml / csv (offline)", helpConvert, runConvert},
 	{"discover", "passive + active scan for devices on the local subnet", helpDiscover, runDiscover},
 	{"matrix", "set matrix crosspoint connections (Ember+ only)", helpMatrix, runMatrix},
+	{"usage", "matrix reverse tally: where is each source assigned (Ember+ only)", helpEmberUsage, runEmberUsage},
+	{"replace", "substitute matrix source A with B everywhere (Ember+ only; --check dry-run)", helpEmberReplace, runEmberReplace},
 	{"invoke", "invoke an Ember+ function (RPC)", helpInvoke, runInvoke},
 	{"stream", "subscribe to Ember+ stream parameters", helpStream, runStream},
 	{"profile", "classify Ember+ provider compliance (strict / partial)", helpProfile, runProfile},

--- a/docs/protocols/verbs.md
+++ b/docs/protocols/verbs.md
@@ -91,7 +91,10 @@ The canonical generic set (dispatched in `cmd/dhs/main.go`):
 | `replay` | re-emit a captured `frames.jsonl` on the wire | — | (deferred, ADR-0021) |
 
 Per-protocol additions (Tree/DM): **emberplus** adds `matrix`, `invoke`, `stream`,
-`bench`; **acp2** adds `diag` (AN2 diagnostic probes).
+`bench`, `usage` (matrix reverse tally: where is each source assigned; #722) and
+`replace` (substitute matrix source A with B everywhere, `--check` dry-run,
+ADR-0007; behavior-aware — 1to1/1toN absolute take, NtoM connect+disconnect);
+**acp2** adds `diag` (AN2 diagnostic probes).
 
 ---
 


### PR DESCRIPTION
## What

Adds `usage` (matrix reverse tally) + `replace` (behavior-aware source substitution) verbs for Ember+ — unit 3, completing the matrix-connector rollout.

## Why

Owner-mandated topic 7 (#722): the source-side pair on every matrix connector (cerebrum-nb #718, probel-sw08p #732, probel-sw02p #734). Replace honors the pinned ADR-0023 semantics: 1to1/1toN/dynamic = absolute take (never toggles), NtoM = connect missing + explicit disconnect. Warns when --with is outside the matrix declared source set (Ember+ id sets are legally sparse; TinyEmber+ silently ignores invalid ids - live-proven).

Closes #736
Closes #722

## Scope

- [ ] acp1
- [ ] acp2
- [x] emberplus
- [ ] probel-sw08p / probel-sw02p
- [ ] osc / tsl / cerebrum-nb / amwa
- [ ] transport
- [ ] export
- [x] cli
- [ ] api
- [ ] core
- [ ] ci / chore

**Cross-protocol changes**: none - cmd/dhs composition layer only (Ember+-gated entries in the shared Tree/DM verb table, same pattern as `matrix`).

## Wire evidence (protocol changes only)

No new wire behaviour - composes the existing walk + MatrixConnect. Live capture of the replace exchange decoded: QualifiedMatrix path 1.2.3, Connection target/sources/operation per Glow p.89.

## Reference controller

- [ ] Cerebrum still happy after this change
- [x] VSM Studio still happy after this change
- [ ] N/A (no protocol behaviour change)

TinyEmber+ 1.6.2 (vendor oracle, Tier 2): valid replace 12->9 landed and was restored 9->12; state verified via usage between each step.

## Type

- [x] feat - new feature
- [ ] fix - bug fix
- [ ] docs - documentation only
- [ ] chore - maintenance, refactor, CI
- [ ] security - security fix or hardening

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `cmd/dhs/cmd_emberplus_usage.go` | new | usage + replace verbs, behavior-aware plan, sparse-id guard |
| `cmd/dhs/cmd_emberplus_usage_test.go` | new | plan/rows/guard unit tests + validation tests |
| `cmd/dhs/main.go` | modified | verb table entries |
| `docs/protocols/verbs.md` | modified | Tree/DM additions row |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test ./...` | all | 0 |
| `go vet ./...` | clean | - |
| `golangci-lint run` | clean | - |

## Device tested

- [ ] ACP1 producer 10.100.0.102
- [ ] ACP2 producer 10.100.0.103
- [ ] ACP1 emulator 10.6.239.113
- [ ] ACP2 real device 10.41.40.195
- [x] Other (specify): TinyEmber+ 1.6.2 vendor oracle on 127.0.0.1:9092 (Tier 2)
- [ ] No device needed (pure codec / doc change)

**Live-LXC command + observed output** (paste verbatim):

```text
dhs consumer emberplus replace 127.0.0.1 --port 9092 --path router.nToN.matrix --srce 12 --with 9 --output json
{"changed":true,"diff":[{"field":"xpoint.router.nToN.matrix.12","from":"12","to":"9"},{"field":"xpoint.router.nToN.matrix.12","from":"12","to":"9"}]}

dhs consumer emberplus usage 127.0.0.1 --port 9092 --path router.nToN.matrix --out -
srce,dest,levels
9,12,0

# invalid --with warns before sending:
WARNING: source 8 is not in router.nToN.matrix's declared source set - providers may SILENTLY ignore the substitution (TinyEmber+ does)
```

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [x] Integration tested on VM before PR (TinyEmber+ vendor oracle)

## Approval

@yboujraf - requesting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)