### PR TITLE
feat(cli): probel-sw02p export verb (#738 unit 1)

### DIFF
--- a/cmd/dhs/cmd_probel02p.go
+++ b/cmd/dhs/cmd_probel02p.go
@@ -92,6 +92,8 @@ func runProbelsw02p(ctx context.Context, args []string) error {
 		return runProbelSW02Usage(ctx, rest)
 	case "replace":
 		return runProbelSW02Replace(ctx, rest)
+	case "export":
+		return runProbelSW02Export(ctx, rest)
 	}
 	return fmt.Errorf("unknown probel-sw02p subcommand %q", sub)
 }
@@ -135,6 +137,10 @@ SUBCOMMANDS
                       csv (ADR-0028 snapshot) | ascii
   replace             substitute source A with B on every dst carrying A
                       (rx 02/66); --check dry-run (ADR-0007 ensure)
+  export              write the router-pack file-set: -matrix.csv (ADR-0023
+                      descriptor) + -xpoint.csv (dest,srce,levels canonical
+                      grammar, from the rx 01/65 sweep); no label files —
+                      SW-P-02 has no name commands
   watch               subscribe to async tallies until Ctrl-C / --timeout
 
 EXAMPLES

--- a/cmd/dhs/cmd_probel02p_export.go
+++ b/cmd/dhs/cmd_probel02p_export.go
@@ -1,0 +1,135 @@
+package main
+
+// export for SW-P-02 (#738 unit 1) — the router-pack file-set this
+// wire can produce:
+//
+//	-matrix.csv   ADR-0023 descriptor (sizes from the global --dsts/
+//	              --srcs config or the rx 075 router configuration)
+//	-xpoint.csv   dest,srce,levels — the CANONICAL family grammar
+//	              (cerebrum-nb / ember+), built from the same rx 01/65
+//	              interrogate sweep the usage verb uses
+//
+// No label files: SW-P-02 has no name commands (omit-don't-fake — an
+// absent file states the wire lacks the concept). No category/lock
+// files for the same reason.
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"math/bits"
+	"os"
+	"strconv"
+	"time"
+
+	probelsw02proto "dhs/internal/probel-sw02p/consumer"
+)
+
+// sw02RouterConfigSizes extracts (destinations, sources) for one level
+// from the rx 075 response union — same level-map convention as
+// sw02RouterConfigDsts (entries appear for SET bits in bit order).
+func sw02RouterConfigSizes(rc probelsw02proto.RouterConfigResponse, level uint8) (dsts, srcs int) {
+	dsts = sw02RouterConfigDsts(rc, level)
+	if level > 27 {
+		return dsts, 0
+	}
+	pick := func(levelMap uint32, n int, val func(int) int) int {
+		if levelMap&(1<<level) == 0 {
+			return 0
+		}
+		idx := bits.OnesCount32(levelMap & ((1 << level) - 1))
+		if idx >= n {
+			return 0
+		}
+		return val(idx)
+	}
+	switch {
+	case rc.Response1 != nil:
+		srcs = pick(rc.Response1.LevelMap, len(rc.Response1.Levels),
+			func(i int) int { return int(rc.Response1.Levels[i].NumSources) })
+	case rc.Response2 != nil:
+		srcs = pick(rc.Response2.LevelMap, len(rc.Response2.Levels),
+			func(i int) int { return int(rc.Response2.Levels[i].NumSources) })
+	}
+	return dsts, srcs
+}
+
+// runProbelSW02Export drives `dhs consumer probel-sw02p export`.
+func runProbelSW02Export(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("probel-sw02p-export", flag.ContinueOnError)
+	outDir := fs.String("out", "", "output directory (omitted = snapshots/probel-sw02p/<host>/ with plain facet names, ADR-0028)")
+	prefix := fs.String("prefix", "sw02p", "CSV filename prefix (ignored in the default snapshot folder)")
+	extended := fs.Bool("extended", false, "force extended forms (rx 65) throughout")
+	timeout := fs.Duration("timeout", 120*time.Second, "overall timeout (one interrogate per dst)")
+	addr, flagArgs := popPositional(args)
+	if addr == "" {
+		return fmt.Errorf("missing <host:port>")
+	}
+	if err := fs.Parse(flagArgs); err != nil {
+		return err
+	}
+	if *outDir == "" {
+		*outDir = snapshotDir("probel-sw02p", hostOnly(addr))
+		*prefix = ""
+		fmt.Fprintf(os.Stderr, "probel-sw02p export: default snapshot folder %s (ADR-0028)\n", *outDir)
+	}
+	cctx, cancel := context.WithTimeout(ctx, *timeout)
+	defer cancel()
+	p, closer, err := dialProbelSW02(cctx, addr)
+	if err != nil {
+		return err
+	}
+	defer closer()
+
+	mc := p.MatrixConfig()
+	count, level, err := sw02UsageDstCount(cctx, p)
+	if err != nil {
+		return err
+	}
+	srcs := int(mc.Srcs)
+	if srcs == 0 {
+		if rc, rerr := p.SendRouterConfigRequest(cctx); rerr == nil {
+			_, srcs = sw02RouterConfigSizes(rc, mc.Level)
+		}
+	}
+
+	rows, err := sw02Interrogations(cctx, p, count, level, *extended)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(*outDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", *outDir, err)
+	}
+
+	// -matrix.csv — ADR-0023 descriptor. SW-P-02 routes one source per
+	// destination: behavior 1toN.
+	desc := matrixDesc{
+		Matrix:   strconv.Itoa(int(mc.MatrixID)),
+		Behavior: "1toN",
+		Targets:  count,
+		Sources:  srcs,
+	}
+	descPath := facetFile(*outDir, *prefix, "matrix")
+	if err := os.WriteFile(descPath, []byte(formatMatrixDescCSV([]matrixDesc{desc})), 0o644); err != nil {
+		return err
+	}
+
+	// -xpoint.csv — canonical family grammar (dest,srce,levels).
+	xrows := make([]cerebrumXpointRow, 0, len(rows))
+	for _, r := range rows {
+		xrows = append(xrows, cerebrumXpointRow{
+			Dest:   strconv.Itoa(r.Dst),
+			Srce:   strconv.Itoa(r.Src),
+			Levels: []string{strconv.Itoa(r.Level)},
+		})
+	}
+	xpPath := facetFile(*outDir, *prefix, "xpoint")
+	if err := os.WriteFile(xpPath, []byte(formatCerebrumXpointCSV(xrows)), 0o644); err != nil {
+		return err
+	}
+
+	fmt.Printf("exported matrix=%d level=%d:\n  %s  (descriptor %dx%d)\n  %s  (%d crosspoint(s))\n  (no label/category files — SW-P-02 has no name or category commands)\n",
+		mc.MatrixID, level, descPath, count, srcs, xpPath, len(xrows))
+	return nil
+}

--- a/cmd/dhs/cmd_probel02p_usage_test.go
+++ b/cmd/dhs/cmd_probel02p_usage_test.go
@@ -52,6 +52,41 @@ func TestSW02RouterConfigDsts(t *testing.T) {
 	}
 }
 
+func TestSW02RouterConfigSizes(t *testing.T) {
+	r1 := probelsw02proto.RouterConfigResponse{Response1: &codec.RouterConfigResponse1Params{
+		LevelMap: 0b1010,
+		Levels: []codec.RouterConfigResponse1LevelEntry{
+			{NumDestinations: 64, NumSources: 32},
+			{NumDestinations: 128, NumSources: 96},
+		},
+	}}
+	if d, s := sw02RouterConfigSizes(r1, 3); d != 128 || s != 96 {
+		t.Fatalf("level 3 = (%d,%d), want (128,96)", d, s)
+	}
+	if d, s := sw02RouterConfigSizes(r1, 0); d != 0 || s != 0 {
+		t.Fatalf("absent level = (%d,%d), want zeros", d, s)
+	}
+	if d, s := sw02RouterConfigSizes(r1, 28); d != 0 || s != 0 {
+		t.Fatalf("out-of-range level = (%d,%d), want zeros", d, s)
+	}
+	r2 := probelsw02proto.RouterConfigResponse{Response2: &codec.RouterConfigResponse2Params{
+		LevelMap: 0b1,
+		Levels:   []codec.RouterConfigResponse2LevelEntry{{NumDestinations: 16, NumSources: 8}},
+	}}
+	if d, s := sw02RouterConfigSizes(r2, 0); d != 16 || s != 8 {
+		t.Fatalf("r2 level 0 = (%d,%d), want (16,8)", d, s)
+	}
+	if d, s := sw02RouterConfigSizes(probelsw02proto.RouterConfigResponse{}, 0); d != 0 || s != 0 {
+		t.Fatalf("empty union = (%d,%d), want zeros", d, s)
+	}
+}
+
+func TestRunProbelSW02Export_Validation(t *testing.T) {
+	if err := runProbelSW02Export(context.Background(), []string{"--extended"}); err == nil || !strings.Contains(err.Error(), "missing <host:port>") {
+		t.Fatalf("err = %v, want missing host", err)
+	}
+}
+
 func TestSortProbelUsage(t *testing.T) {
 	rows := sortProbelUsage([]probelUsageRow{
 		{Src: 7, Dst: 2}, {Src: 3, Dst: 9}, {Src: 3, Dst: 1},


### PR DESCRIPTION
## What

Adds the `export` verb to probel-sw02p — descriptor + crosspoints, the router-pack file-set this wire can produce.

## Why

Unit 1 of #738 (uniform router pack for all router protocols): sw02p was the only matrix connector without export. Descriptor sizes come from the global --dsts/--srcs or rx 075; crosspoints from the same rx 01/65 sweep as usage, emitted in the CANONICAL family grammar (dest,srce,levels) from day one. No label/category files — the SW-P-02 wire has no such commands (omit-don't-fake).

Closes #739

## Scope

- [ ] acp1
- [ ] acp2
- [ ] emberplus
- [x] probel-sw08p / probel-sw02p
- [ ] osc / tsl / cerebrum-nb / amwa
- [ ] transport
- [ ] export
- [x] cli
- [ ] api
- [ ] core
- [ ] ci / chore

**Cross-protocol changes**: none — cmd/dhs composition layer only.

## Wire evidence (protocol changes only)

No new wire behaviour — composes existing rx 01/65 interrogate + rx 075 router-config.

## Reference controller

- [ ] Cerebrum still happy after this change
- [ ] VSM Studio still happy after this change
- [x] N/A (no protocol behaviour change)

## Type

- [x] feat — new feature
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] chore — maintenance, refactor, CI
- [ ] security — security fix or hardening

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `cmd/dhs/cmd_probel02p_export.go` | new | export verb + router-config sizes helper |
| `cmd/dhs/cmd_probel02p.go` | modified | dispatch + help |
| `cmd/dhs/cmd_probel02p_usage_test.go` | modified | sizes + validation tests |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test ./...` | all | 0 |
| `go vet ./...` | clean | — |
| `golangci-lint run` | clean | — |

## Device tested

- [ ] ACP1 producer 10.100.0.102
- [ ] ACP2 producer 10.100.0.103
- [ ] ACP1 emulator 10.6.239.113
- [ ] ACP2 real device 10.41.40.195
- [x] Other (specify): Tier-4 loopback vs own provider on 127.0.0.1:2041; run-twice = byte-identical pack (hash-verified)
- [ ] No device needed (pure codec / doc change)

**Live-LXC command + observed output** (paste verbatim):

```text
dhs consumer probel-sw02p --dsts 16 export 127.0.0.1:2041 --out pack1
exported matrix=0 level=0:
  pack1\sw02p-matrix.csv  (descriptor 16x16)
  pack1\sw02p-xpoint.csv  (2 crosspoint(s))

sw02p-matrix.csv: matrix,behavior,targets,sources,... / 0,1toN,16,16,0,0,
sw02p-xpoint.csv: dest,srce,levels / 2,3,0 / 7,3,0
run-twice hash compare: True (identical)
```

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [x] Integration tested on VM before PR (loopback; see Device tested)

## Approval

@yboujraf — requesting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)