### PR TITLE
fix(probel-sw02p): close test waits for the parked write to land

### DIFF
--- a/internal/probel-sw02p/codec/client_paths_test.go
+++ b/internal/probel-sw02p/codec/client_paths_test.go
@@ -283,11 +283,24 @@ func TestWrite(t *testing.T) {
 func TestCloseIdempotentAndWakesPending(t *testing.T) {
 	a, b := net.Pipe()
 	defer func() { _ = b.Close() }()
+	// The peer signals after its FIRST successful read: Send registers
+	// c.pending BEFORE conn.Write, so pending != nil alone does not
+	// prove the write finished — Close racing the in-flight write made
+	// the parked Send return a pipe-write error instead of the EOF
+	// wakeup (macOS main red, run 32537698497; ADR-0029 determinism
+	// rule). net.Pipe delivers one Write to one Read, so the first
+	// read = the whole frame is out of Send's hands.
+	frameRead := make(chan struct{})
 	go func() {
 		buf := make([]byte, 256)
+		first := true
 		for {
 			if _, err := b.Read(buf); err != nil {
 				return
+			}
+			if first {
+				first = false
+				close(frameRead)
 			}
 		}
 	}()
@@ -307,6 +320,11 @@ func TestCloseIdempotentAndWakesPending(t *testing.T) {
 		defer cli.mu.Unlock()
 		return cli.pending != nil
 	})
+	select {
+	case <-frameRead:
+	case <-time.After(2 * time.Second):
+		t.Fatal("peer never read the parked Send's frame")
+	}
 
 	if err := cli.Close(); err != nil {
 		t.Errorf("first Close: %v", err)


### PR DESCRIPTION
## What

Makes the sw02p codec close test wait until the peer has read the parked Send's frame before Closing.

## Why

Main red on macOS ([run 32537698497](https://github.com/by-openclaw/go-acp/actions/runs/32537698497)): Send registers c.pending BEFORE conn.Write, so waiting on pending!=nil does not prove the write finished; Close racing the in-flight write made the parked Send return a pipe-write error instead of the io.EOF wakeup. The peer now signals after its first successful read (net.Pipe delivers one Write to one Read) and the test Closes only after that. #694 class, fixed at the root per ADR-0029.

## Scope

- [ ] acp1
- [ ] acp2
- [ ] emberplus
- [x] probel-sw08p / probel-sw02p
- [ ] osc / tsl / cerebrum-nb / amwa
- [ ] transport
- [ ] export
- [ ] cli
- [ ] api
- [ ] core
- [ ] ci / chore

**Cross-protocol changes**: none - one test file.

## Wire evidence (protocol changes only)

N/A - test-only change.

## Reference controller

- [ ] Cerebrum still happy after this change
- [ ] VSM Studio still happy after this change
- [x] N/A (no protocol behaviour change)

## Type

- [ ] feat - new feature
- [x] fix - bug fix
- [ ] docs - documentation only
- [ ] chore - maintenance, refactor, CI
- [ ] security - security fix or hardening

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `internal/probel-sw02p/codec/client_paths_test.go` | modified | peer signals first read; Close gated on it |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test -count=50` + `-count=25 GOMAXPROCS=1` (target test) | 75 | 0 |
| `go test ./internal/probel-sw02p/codec/` | all | 0 |
| `go vet ./...` | clean | - |
| `golangci-lint run` | clean | - |

## Device tested

- [ ] ACP1 producer 10.100.0.102
- [ ] ACP2 producer 10.100.0.103
- [ ] ACP1 emulator 10.6.239.113
- [ ] ACP2 real device 10.41.40.195
- [ ] Other (specify)
- [x] No device needed (pure codec / doc change)

**Live-LXC command + observed output** (paste verbatim):

```text
go test -count=50 -run TestCloseIdempotentAndWakesPending ./internal/probel-sw02p/codec/
ok  	dhs/internal/probel-sw02p/codec	2.003s
```

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [ ] Integration tested on VM before PR (N/A - test-only)

## Approval

@yboujraf - requesting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)