### PR TITLE
feat(cli): router pack meta.json + format doc (#738 units 3-4)

### DIFF
--- a/cmd/dhs/cmd_cerebrum_xpoint.go
+++ b/cmd/dhs/cmd_cerebrum_xpoint.go
@@ -800,7 +800,7 @@ func cerebrumExportXpoint(ctx context.Context, args []string) error {
 		}
 		fmt.Fprintf(os.Stderr, "cerebrum-nb export: wrote %s (%d row(s))\n", path, strings.Count(f.content, "\n")-1)
 	}
-	return nil
+	return writePackMeta(*outDir, "cerebrum-nb", host+" router="+*router)
 }
 
 // cerebrumRouterIsRM reports whether the --router target is the central

--- a/cmd/dhs/cmd_emberplus_xpoint.go
+++ b/cmd/dhs/cmd_emberplus_xpoint.go
@@ -275,8 +275,9 @@ func formatMatrixLabelCSV(keyCol string, groups []string, byGroup map[string]map
 // ---------------------------------------------------------------------
 
 // runMatrixSetExport writes the canonical matrix file set for ONE
-// matrix selected by --path/--oid (or the only matrix in the tree).
-func runMatrixSetExport(plug consumer.Protocol, objs []consumer.Object, addr, outDir, prefix string) error {
+// matrix selected by --path/--oid (or the only matrix in the tree),
+// plus the pack meta.json (#738).
+func runMatrixSetExport(plug consumer.Protocol, objs []consumer.Object, addr, outDir, prefix, proto, target string) error {
 	mc, ok := plug.(matrixXpointConn)
 	if !ok {
 		return fmt.Errorf("%w: this protocol has no matrix surface — --out-dir matrix export unsupported", consumer.ErrValidationFailed)
@@ -330,7 +331,7 @@ func runMatrixSetExport(plug consumer.Protocol, objs []consumer.Object, addr, ou
 		}
 		fmt.Fprintf(os.Stderr, "export: wrote %s (%d row(s))\n", p, strings.Count(f.content, "\n")-1)
 	}
-	return nil
+	return writePackMeta(outDir, proto, target)
 }
 
 // ---------------------------------------------------------------------

--- a/cmd/dhs/cmd_export.go
+++ b/cmd/dhs/cmd_export.go
@@ -107,7 +107,7 @@ func runExport(ctx context.Context, args []string) error {
 			}
 			all = append(all, objs...)
 		}
-		return runMatrixSetExport(plug, all, *pathFlag, *outDir, *prefix)
+		return runMatrixSetExport(plug, all, *pathFlag, *outDir, *prefix, cf.protocol, host)
 	}
 
 	for s := 0; s < info.NumSlots; s++ {

--- a/cmd/dhs/cmd_probel02p_export.go
+++ b/cmd/dhs/cmd_probel02p_export.go
@@ -131,5 +131,5 @@ func runProbelSW02Export(ctx context.Context, args []string) error {
 
 	fmt.Printf("exported matrix=%d level=%d:\n  %s  (descriptor %dx%d)\n  %s  (%d crosspoint(s))\n  (no label/category files — SW-P-02 has no name or category commands)\n",
 		mc.MatrixID, level, descPath, count, srcs, xpPath, len(xrows))
-	return nil
+	return writePackMeta(*outDir, "probel-sw02p", hostOnly(addr))
 }

--- a/cmd/dhs/cmd_probel_csv.go
+++ b/cmd/dhs/cmd_probel_csv.go
@@ -149,7 +149,7 @@ func runProbelExport(ctx context.Context, args []string) error {
 
 	fmt.Printf("exported matrix=%d level=%d:\n  %s  (descriptor)\n  %s  (%d sources)\n  %s  (%d dests)\n  %s  (%d crosspoints)\n  %s  (%d protect row(s))\n  (label_16 left empty — read cmds support 4/8/12 only; fill it for import)\n",
 		mtx, level, descPath, srcPath, len(srcLabels[codec.NameLen12]), dstPath, len(dstLabels[codec.NameLen12]), xpPath, nXP, protPath, nProt)
-	return nil
+	return writePackMeta(*outDir, "probel-sw08p", hostOnly(addr))
 }
 
 // writeProbelProtectCSV emits the protect dump as

--- a/cmd/dhs/pack_meta.go
+++ b/cmd/dhs/pack_meta.go
@@ -1,0 +1,48 @@
+package main
+
+// Router-pack meta.json (#738 unit 3). Every export that writes a
+// pack folder drops a meta.json beside the facet files so the pack is
+// self-describing: which protocol, which target, when, which tool
+// build, and which pack format revision.
+//
+// Evolvability rules (#738): pack_version bumps on any format change;
+// new concepts land as new FILES, new attributes as appended COLUMNS
+// keyed by header; readers ignore unknown extras and hard-fail on
+// missing required files. That keeps every pack on disk diffable
+// against packs extracted years apart.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// packVersion is the current router-pack format revision.
+const packVersion = "1.0.0"
+
+type packMeta struct {
+	PackVersion string `json:"pack_version"`
+	Protocol    string `json:"protocol"`
+	Target      string `json:"target"`
+	GeneratedAt string `json:"generated_at"`
+	ToolVersion string `json:"tool_version"`
+	ToolCommit  string `json:"tool_commit,omitempty"`
+}
+
+// writePackMeta writes dir/meta.json for one export invocation.
+func writePackMeta(dir, proto, target string) error {
+	m := packMeta{
+		PackVersion: packVersion,
+		Protocol:    proto,
+		Target:      target,
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		ToolVersion: version,
+		ToolCommit:  commit,
+	}
+	b, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "meta.json"), append(b, '\n'), 0o644)
+}

--- a/docs/protocols/router-pack.md
+++ b/docs/protocols/router-pack.md
@@ -1,0 +1,59 @@
+# Router pack — the uniform export file-set (#738)
+
+One `export` invocation per router-capable connector writes one
+self-describing folder — the input for the per-device acceptance
+report and the cross-protocol correlated report. Default location:
+the ADR-0028 snapshot home, `snapshots/<proto>/<target>/`.
+
+## Layout
+
+| File | Content | Written by |
+|---|---|---|
+| `meta.json` | pack_version, protocol, target, generated_at, tool version/commit | every connector, always |
+| `<p>-matrix.csv` | ADR-0023 descriptor: `matrix,behavior,targets,sources,max_connects_per_target,max_total_connects,label` | cerebrum-nb*, probel-sw08p, probel-sw02p, emberplus |
+| `<p>-xpoint.csv` | crosspoints, canonical grammar `dest,srce,levels` (+ protocol extras as appended columns, e.g. sw08p `matrix_id`) | all four |
+| `<p>-src.csv` / `<p>-dst.csv` | label tables — columns are the protocol's label axis (alt-mnemonics on cerebrum-nb, widths 4/8/12/16 on sw08p, label groups on ember+) | cerebrum-nb, sw08p, ember+ |
+| `<p>-level.csv` | level mnemonics | cerebrum-nb |
+| `<p>-cat-src/-dst/-mixed.csv` | categories | cerebrum-nb (route master only) |
+| `<p>-lock.csv` / `<p>-protect.csv` | locks (nb) / protects (sw08p) | cerebrum-nb, sw08p |
+| `tree.json` | canonical object tree | tree-model protocols via `extract` (ADR-0022) |
+
+\* cerebrum-nb descriptor: pending upstream of its matrix row.
+
+## Rules
+
+1. **Omit, don't fake.** A file is absent iff the protocol has no such
+   concept on the wire (SW-P-02 has no label commands → no src/dst
+   files; ember+/probel have no categories → no cat files). An absent
+   file means "concept does not exist here", an empty file means "the
+   router has zero of them" — never conflate the two.
+2. **Column-level parity inside shared files.** The `levels` column is
+   present in every `-xpoint.csv`; protocols without levels write `0`
+   (tree matrices). One grammar → one parser, one differ, one import.
+3. **Evolvability.** `meta.json:pack_version` bumps on any format
+   change. New concept = new FILE. New attribute = new COLUMN appended
+   and keyed by header name (parsers index by header, never by
+   position). Readers ignore unknown files/columns and hard-fail on
+   missing required ones. Old packs stay readable forever; sw08p's
+   legacy `matrix_id,level_id,dst_id,src_id` xpoint files remain
+   importable via header sniffing.
+4. **Wire evidence rides along, optionally.** `--capture FILE.jsonl`
+   records the raw frames of the same invocation (offline decode via
+   `validate`, ADR-0021); `--log` keeps the slog trail. Both live in
+   their ADR-0028 homes (`captures/<proto>/<target>/`). cerebrum-nb
+   captures contain the LOGIN in cleartext — treat as secrets, never
+   commit.
+5. **Determinism.** Exporting twice against unchanged state yields
+   byte-identical facet files (meta.json differs only in
+   generated_at). `import --check` against a just-exported pack is
+   `would_change=0`.
+
+## Per-connector invocation
+
+```bash
+dhs consumer cerebrum-nb  export <host>            # full set incl. cats/locks (RM)
+dhs consumer probel-sw08p export <host> --matrix N # descriptor+labels+xpoints+protect
+dhs consumer probel-sw02p --dsts N export <host>   # descriptor+xpoints
+dhs consumer emberplus    export <host> --path <matrix> --out-dir DIR
+dhs consumer <tree-proto> extract <host>           # tree.json (DM triple, ADR-0022)
+```

--- a/internal/emberplus/CLAUDE.md
+++ b/internal/emberplus/CLAUDE.md
@@ -182,6 +182,15 @@ S101 layer. Respond to every request promptly.
   `TestReal_EcosystemBytes` (50.0 → `80 05 19`, 100.0 → `80 06 19`,
   0.1 → `80 fc 0c cc cc cc cc cc cd`). Verified live against EmberViewer
   v2.40.0.35 + Lawo VSM Studio.
+- VSM multi-packet dialect (#728/#729): Lawo VSM's gadgetserver
+  terminates multi-packet S101 messages with a payload-LESS last
+  packet (flags 0x60). This dialect is NOT universally supported —
+  Cerebrum-as-consumer rejects it (owner-observed 2026-08-22). Our
+  consumer ACCEPTS both terminations (empty last packet completes
+  reassembly; empty-frame skip applies only to FlagSingle — pinned by
+  `consumer/vsm_dialect_test.go`), but our provider EMITS only the
+  spec dialect: `provider/session.go writeEmBERChunks` always puts
+  payload in the last chunk. Never emit the VSM form.
 - S101 reader resyncs on a second BOF mid-frame (`codec/s101/reader.go`).
   Spec mandates 0xFE escape-stuffing; Lawo VSM-as-consumer emits a 15-byte
   non-S101 preamble before its first real frame on every reconnect, and


### PR DESCRIPTION
## What

Adds meta.json to every router-pack export and the pack format reference doc — units 3+4 of #738, completing the router-pack rollout.

## Why

The pack must be self-describing (pack_version, protocol, target, timestamp, tool build) so acceptance reports and cross-protocol correlation (topics 9/10) can trust what they read, and so format evolution is governed (version bump; new concept = new file; new attribute = appended header-keyed column; readers ignore unknowns).

Also records the VSM multi-packet dialect quirk in the ember+ CLAUDE.md (owner-raised: Cerebrum-as-consumer rejects it): our consumer ACCEPTS both terminations, our provider only ever EMITS spec framing.

Closes #744

## Scope

- [ ] acp1
- [ ] acp2
- [x] emberplus
- [x] probel-sw08p / probel-sw02p
- [x] osc / tsl / cerebrum-nb / amwa
- [ ] transport
- [ ] export
- [x] cli
- [ ] api
- [ ] core
- [ ] ci / chore

**Cross-protocol changes**: cmd/dhs composition layer only — one shared meta writer called from four export legs; no `internal/<proto>/` code change (ember+ CLAUDE.md is docs).

## Wire evidence (protocol changes only)

No wire behaviour change — meta.json is a local file beside the CSVs.

## Reference controller

- [ ] Cerebrum still happy after this change
- [ ] VSM Studio still happy after this change
- [x] N/A (no protocol behaviour change)

## Type

- [x] feat — new feature
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] chore — maintenance, refactor, CI
- [ ] security — security fix or hardening

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `cmd/dhs/pack_meta.go` | new | packMeta struct + writePackMeta |
| `cmd/dhs/cmd_cerebrum_xpoint.go` | modified | meta on full-set export |
| `cmd/dhs/cmd_probel_csv.go` | modified | meta on sw08p export |
| `cmd/dhs/cmd_probel02p_export.go` | modified | meta on sw02p export |
| `cmd/dhs/cmd_emberplus_xpoint.go` / `cmd_export.go` | modified | meta on matrix-set export (proto+target params) |
| `docs/protocols/router-pack.md` | new | pack format reference |
| `internal/emberplus/CLAUDE.md` | modified | VSM dialect quirk (accept-only, never emit) |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test ./...` | all | 0 |
| `go vet ./...` | clean | — |
| `golangci-lint run` | clean | — |

## Device tested

- [ ] ACP1 producer 10.100.0.102
- [ ] ACP2 producer 10.100.0.103
- [ ] ACP1 emulator 10.6.239.113
- [ ] ACP2 real device 10.41.40.195
- [x] Other (specify): Tier-4 loopback (sw02p provider 127.0.0.1:2043)
- [ ] No device needed (pure codec / doc change)

**Live-LXC command + observed output** (paste verbatim):

```text
dhs consumer probel-sw02p --dsts 16 export 127.0.0.1:2043 --out pack
pack\meta.json:
{
  "pack_version": "1.0.0",
  "protocol": "probel-sw02p",
  "target": "127.0.0.1",
  "generated_at": "2026-08-21T23:48:50Z",
  "tool_version": "dev"
}
```

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [x] Integration tested on VM before PR (loopback; see Device tested)

## Approval

@yboujraf — requesting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)