### PR TITLE
feat(cli): rtree - labels + levels in every usage view (#746)

### DIFF
--- a/cmd/dhs/cmd_emberplus_usage.go
+++ b/cmd/dhs/cmd_emberplus_usage.go
@@ -40,7 +40,7 @@ func emberUsageRows(snap []matrix.TargetState) []probelUsageRow {
 	var rows []probelUsageRow
 	for _, ts := range snap {
 		for _, src := range ts.Sources {
-			rows = append(rows, probelUsageRow{Src: int(src), Dst: int(ts.Target), Level: 0})
+			rows = append(rows, probelUsageRow{Src: int(src), Dst: int(ts.Target), Levels: "0"})
 		}
 	}
 	sort.SliceStable(rows, func(i, j int) bool {
@@ -94,6 +94,36 @@ func emberReplacePlan(behavior string, snap []matrix.TargetState, from, to int32
 		}
 	}
 	sort.SliceStable(out, func(i, j int) bool { return out[i].Target < out[j].Target })
+	return out
+}
+
+// emberUsageLabelMap flattens one label group of a walked matrix into
+// id → label. group "" selects the first group alphabetically (the
+// primary). Labels are FREE on ember+ — they ride in the walked tree.
+func emberUsageLabelMap(o consumer.Object, metaKey, group string) map[int]string {
+	groups, byGroup := labelGroups(o, metaKey)
+	if len(groups) == 0 {
+		return nil
+	}
+	pick := groups[0]
+	if group != "" {
+		found := false
+		for _, g := range groups {
+			if g == group {
+				pick, found = g, true
+				break
+			}
+		}
+		if !found {
+			return nil
+		}
+	}
+	out := map[int]string{}
+	for idx, label := range byGroup[pick] {
+		if n, err := strconv.Atoi(idx); err == nil && label != "" {
+			out[n] = label
+		}
+	}
 	return out
 }
 
@@ -157,6 +187,8 @@ func runEmberUsage(ctx context.Context, args []string) error {
 	matrixPath := fs.String("path", "", "matrix path: dotted label OR numeric OID (omitted = the only matrix in the tree)")
 	srce := fs.Int("srce", -1, "filter: only this source's assignments")
 	dest := fs.Int("dest", -1, "filter: only this target's feed")
+	withLabels := fs.Bool("names", false, "resolve src/dst names from the matrix label groups (free — no extra wire traffic); csv appends srce_label,dest_label. (--labels is taken by the canonical-labels mode)")
+	labelGroup := fs.String("name-group", "", "which label group to use with --names (omitted = the first group)")
 	format := fs.String("format", "csv", "output format: csv | ascii")
 	out := fs.String("out", "", "csv output file (omitted = snapshots/emberplus/<host>/usage.csv per ADR-0028; \"-\" = stdout)")
 	dmIdentity := fs.String("dm", "", "identity-keyed DM hot-load (ADR-0022): seed the tree from cache, skip the walk")
@@ -198,7 +230,7 @@ func runEmberUsage(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	_, dotted, found := findMatrixObject(objs, *matrixPath)
+	obj, dotted, found := findMatrixObject(objs, *matrixPath)
 	if !found {
 		avail := listMatrixPaths(objs)
 		if len(avail) == 0 {
@@ -206,13 +238,19 @@ func runEmberUsage(ctx context.Context, args []string) error {
 		}
 		return fmt.Errorf("matrix %q not found; available:\n  %s", *matrixPath, strings.Join(avail, "\n  "))
 	}
-	rows := probelFilterUsage(emberUsageRows(ep.MatrixSnapshot(dotted)), *srce, *dest)
+	rows := emberUsageRows(ep.MatrixSnapshot(dotted))
+	if *withLabels {
+		applyProbelUsageLabels(rows,
+			emberUsageLabelMap(obj, "sourceLabels", *labelGroup),
+			emberUsageLabelMap(obj, "targetLabels", *labelGroup))
+	}
+	rows = probelFilterUsage(rows, *srce, *dest)
 
 	if *format == "ascii" {
 		renderProbelUsageASCII(os.Stdout, rows)
 		return nil
 	}
-	csv := formatProbelUsageCSV(rows, false)
+	csv := formatProbelUsageCSV(rows, false, *withLabels)
 	if *out == "-" {
 		fmt.Print(csv)
 		return nil

--- a/cmd/dhs/cmd_emberplus_usage_test.go
+++ b/cmd/dhs/cmd_emberplus_usage_test.go
@@ -9,6 +9,30 @@ import (
 	"dhs/internal/emberplus/codec/matrix"
 )
 
+func TestEmberUsageLabelMap(t *testing.T) {
+	o := consumer.Object{Meta: map[string]any{
+		"sourceLabels": map[string]map[string]string{
+			"primary": {"3": "SDI In 1", "bogus": "X", "9": ""},
+			"alt":     {"3": "Alt 3"},
+		},
+	}}
+	// Default group = first alphabetically ("alt").
+	if m := emberUsageLabelMap(o, "sourceLabels", ""); m[3] != "Alt 3" || len(m) != 1 {
+		t.Fatalf("default group map = %v", m)
+	}
+	// Explicit group; non-int ids and empty labels dropped.
+	if m := emberUsageLabelMap(o, "sourceLabels", "primary"); m[3] != "SDI In 1" || len(m) != 1 {
+		t.Fatalf("primary map = %v", m)
+	}
+	// Unknown group / missing meta → nil.
+	if m := emberUsageLabelMap(o, "sourceLabels", "nope"); m != nil {
+		t.Fatalf("unknown group = %v", m)
+	}
+	if m := emberUsageLabelMap(consumer.Object{Meta: map[string]any{}}, "sourceLabels", ""); m != nil {
+		t.Fatalf("no meta = %v", m)
+	}
+}
+
 func TestEmberValidSourceIDs(t *testing.T) {
 	o := consumer.Object{Meta: map[string]any{
 		"sourceLabels": map[string]map[string]string{
@@ -38,7 +62,8 @@ func emberUsageFixture() []matrix.TargetState {
 func TestEmberUsageRows(t *testing.T) {
 	rows := emberUsageRows(emberUsageFixture())
 	want := []probelUsageRow{
-		{Src: 3, Dst: 0}, {Src: 3, Dst: 2}, {Src: 7, Dst: 2}, {Src: 9, Dst: 5},
+		{Src: 3, Dst: 0, Levels: "0"}, {Src: 3, Dst: 2, Levels: "0"},
+		{Src: 7, Dst: 2, Levels: "0"}, {Src: 9, Dst: 5, Levels: "0"},
 	}
 	if len(rows) != len(want) {
 		t.Fatalf("rows = %+v", rows)

--- a/cmd/dhs/cmd_probel02p_export.go
+++ b/cmd/dhs/cmd_probel02p_export.go
@@ -121,7 +121,7 @@ func runProbelSW02Export(ctx context.Context, args []string) error {
 		xrows = append(xrows, cerebrumXpointRow{
 			Dest:   strconv.Itoa(r.Dst),
 			Srce:   strconv.Itoa(r.Src),
-			Levels: []string{strconv.Itoa(r.Level)},
+			Levels: []string{r.Levels},
 		})
 	}
 	xpPath := facetFile(*outDir, *prefix, "xpoint")

--- a/cmd/dhs/cmd_probel02p_usage.go
+++ b/cmd/dhs/cmd_probel02p_usage.go
@@ -22,6 +22,7 @@ import (
 	"math/bits"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	probelsw02proto "dhs/internal/probel-sw02p/consumer"
@@ -104,7 +105,7 @@ func runProbelSW02Usage(ctx context.Context, args []string) error {
 		renderProbelUsageASCII(os.Stdout, rows)
 		return nil
 	}
-	csv := formatProbelUsageCSV(rows, false)
+	csv := formatProbelUsageCSV(rows, false, false)
 	if *out == "-" {
 		fmt.Print(csv)
 		return nil
@@ -157,7 +158,7 @@ func sw02Interrogations(ctx context.Context, p *probelsw02proto.Plugin, count, l
 			if err != nil {
 				return nil, fmt.Errorf("extended interrogate dst %d: %w", dst, err)
 			}
-			rows = append(rows, probelUsageRow{Src: int(t.Source), Dst: int(t.Destination), Level: level})
+			rows = append(rows, probelUsageRow{Src: int(t.Source), Dst: int(t.Destination), Levels: strconv.Itoa(level)})
 			continue
 		}
 		t, err := p.SendInterrogate(ctx, uint16(dst))
@@ -167,7 +168,7 @@ func sw02Interrogations(ctx context.Context, p *probelsw02proto.Plugin, count, l
 		if t.Source == sw02NarrowOutOfRange {
 			continue
 		}
-		rows = append(rows, probelUsageRow{Src: int(t.Source), Dst: int(t.Destination), Level: level})
+		rows = append(rows, probelUsageRow{Src: int(t.Source), Dst: int(t.Destination), Levels: strconv.Itoa(level)})
 	}
 	return rows, nil
 }
@@ -225,14 +226,14 @@ func runProbelSW02Replace(ctx context.Context, args []string) error {
 	diffs := make([]ensureDiff, 0, len(cells))
 	for _, c := range cells {
 		diffs = append(diffs, ensureDiff{
-			Field: fmt.Sprintf("route.%d.%d", c.Dst, c.Level),
+			Field: fmt.Sprintf("route.%d.%s", c.Dst, c.Levels),
 			From:  fmt.Sprintf("%d", *from), To: fmt.Sprintf("%d", *with),
 		})
 	}
 
 	if *check {
 		for _, c := range cells {
-			_, _ = fmt.Fprintf(logw, "[would-replace] level=%d dst=%d: src %d -> %d\n", c.Level, c.Dst, *from, *with)
+			_, _ = fmt.Fprintf(logw, "[would-replace] level=%s dst=%d: src %d -> %d\n", c.Levels, c.Dst, *from, *with)
 		}
 		_, _ = fmt.Fprintf(logw, "probel-sw02p replace --check: would_change=%d destination(s) carrying src %d — nothing sent\n", len(cells), *from)
 		if jsonOut {
@@ -250,11 +251,11 @@ func runProbelSW02Replace(ctx context.Context, args []string) error {
 			_, cerr = p.SendConnect(cctx, uint16(c.Dst), uint16(*with), false)
 		}
 		if cerr != nil {
-			_, _ = fmt.Fprintf(logw, "[replace] FAIL level=%d dst=%d reason=%s\n", c.Level, c.Dst, cerr)
+			_, _ = fmt.Fprintf(logw, "[replace] FAIL level=%s dst=%d reason=%s\n", c.Levels, c.Dst, cerr)
 			fails++
 			continue
 		}
-		_, _ = fmt.Fprintf(logw, "[replace] OK   level=%d dst=%d: src %d -> %d\n", c.Level, c.Dst, *from, *with)
+		_, _ = fmt.Fprintf(logw, "[replace] OK   level=%s dst=%d: src %d -> %d\n", c.Levels, c.Dst, *from, *with)
 	}
 	if fails > 0 {
 		return fmt.Errorf("%d/%d replace connect(s) failed", fails, len(cells))

--- a/cmd/dhs/cmd_probel_usage.go
+++ b/cmd/dhs/cmd_probel_usage.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -32,11 +33,16 @@ import (
 )
 
 // probelUsageRow is one reverse-tally assignment: src feeds dst on the
-// queried level. Protect carries the dst's protect state when the
-// caller joined it (--protect), else "".
+// listed levels (";"-joined display string — a multi-level sweep
+// collapses identical (src, dst) rows). Protect carries the dst's
+// protect state when the caller joined it (--protect); SrcLabel /
+// DstLabel carry resolved names when the caller joined them
+// (--labels). Shared by every matrix connector's usage view (#746).
 type probelUsageRow struct {
-	Src, Dst, Level int
-	Protect         string
+	Src, Dst           int
+	Levels             string
+	Protect            string
+	SrcLabel, DstLabel string
 }
 
 // probelTallyTable flattens the byte/word dual-form TallyDumpResult
@@ -63,9 +69,48 @@ func probelBuildUsage(firstDst int, srcs []int, level int, protect map[int]strin
 	rows := make([]probelUsageRow, 0, len(srcs))
 	for i, src := range srcs {
 		dst := firstDst + i
-		rows = append(rows, probelUsageRow{Src: src, Dst: dst, Level: level, Protect: protect[dst]})
+		rows = append(rows, probelUsageRow{Src: src, Dst: dst, Levels: strconv.Itoa(level), Protect: protect[dst]})
 	}
 	return sortProbelUsage(rows)
+}
+
+// collapseProbelUsage merges rows identical in everything but level
+// into one row with a ";"-joined levels column (cerebrum-nb grammar).
+// Input order is preserved for the first occurrence of each group.
+func collapseProbelUsage(rows []probelUsageRow) []probelUsageRow {
+	type key struct {
+		src, dst                    int
+		protect, srcLabel, dstLabel string
+	}
+	idx := map[key]int{}
+	out := make([]probelUsageRow, 0, len(rows))
+	for _, r := range rows {
+		k := key{r.Src, r.Dst, r.Protect, r.SrcLabel, r.DstLabel}
+		if i, ok := idx[k]; ok {
+			out[i].Levels += ";" + r.Levels
+			continue
+		}
+		idx[k] = len(out)
+		out = append(out, r)
+	}
+	return out
+}
+
+// applyProbelUsageLabels resolves src/dst ids to names in place.
+// Missing ids stay unlabeled — never invented.
+func applyProbelUsageLabels(rows []probelUsageRow, srcNames, dstNames map[int]string) {
+	for i := range rows {
+		rows[i].SrcLabel = srcNames[rows[i].Src]
+		rows[i].DstLabel = dstNames[rows[i].Dst]
+	}
+}
+
+// usageName renders "id (Label)" or the bare id when no label is known.
+func usageName(kind string, id int, label string) string {
+	if label != "" {
+		return fmt.Sprintf("%s %d (%s)", kind, id, label)
+	}
+	return fmt.Sprintf("%s %d", kind, id)
 }
 
 // sortProbelUsage orders rows source-keyed: by (src, dst).
@@ -95,20 +140,29 @@ func probelFilterUsage(rows []probelUsageRow, src, dst int) []probelUsageRow {
 }
 
 // formatProbelUsageCSV renders rows with the canonical usage columns
-// (srce,dest,levels — same as cerebrum-nb usage); --protect appends a
-// protect column.
-func formatProbelUsageCSV(rows []probelUsageRow, withProtect bool) string {
+// (srce,dest,levels — same as cerebrum-nb usage); --protect and
+// --labels append their columns (header-keyed, #738 rule 2).
+func formatProbelUsageCSV(rows []probelUsageRow, withProtect, withLabels bool) string {
 	var b strings.Builder
+	b.WriteString("srce,dest,levels")
 	if withProtect {
-		b.WriteString("srce,dest,levels,protect\n")
-	} else {
-		b.WriteString("srce,dest,levels\n")
+		b.WriteString(",protect")
 	}
+	if withLabels {
+		b.WriteString(",srce_label,dest_label")
+	}
+	b.WriteByte('\n')
 	for _, r := range rows {
-		fmt.Fprintf(&b, "%d,%d,%d", r.Src, r.Dst, r.Level)
+		fmt.Fprintf(&b, "%d,%d,%s", r.Src, r.Dst, r.Levels)
 		if withProtect {
 			b.WriteByte(',')
 			b.WriteString(r.Protect)
+		}
+		if withLabels {
+			b.WriteByte(',')
+			b.WriteString(r.SrcLabel)
+			b.WriteByte(',')
+			b.WriteString(r.DstLabel)
 		}
 		b.WriteByte('\n')
 	}
@@ -116,7 +170,8 @@ func formatProbelUsageCSV(rows []probelUsageRow, withProtect bool) string {
 }
 
 // renderProbelUsageASCII prints the fan-out view: one block per
-// feeding source, every dst it feeds nested under it.
+// feeding source, every dst it feeds nested under it, labels in
+// parentheses when resolved.
 func renderProbelUsageASCII(w io.Writer, rows []probelUsageRow) {
 	var lastSrc = -1
 	var block []probelUsageRow
@@ -130,7 +185,7 @@ func renderProbelUsageASCII(w io.Writer, rows []probelUsageRow) {
 			if r.Protect != "" {
 				suffix = "  [" + r.Protect + "]"
 			}
-			_, _ = fmt.Fprintf(w, "%s dst %d  level %d%s\n", branch, r.Dst, r.Level, suffix)
+			_, _ = fmt.Fprintf(w, "%s %s  levels %s%s\n", branch, usageName("dst", r.Dst, r.DstLabel), r.Levels, suffix)
 		}
 		block = block[:0]
 	}
@@ -138,7 +193,7 @@ func renderProbelUsageASCII(w io.Writer, rows []probelUsageRow) {
 		if r.Src != lastSrc {
 			flush()
 			lastSrc = r.Src
-			_, _ = fmt.Fprintf(w, "src %d\n", r.Src)
+			_, _ = fmt.Fprintf(w, "%s\n", usageName("src", r.Src, r.SrcLabel))
 		}
 		block = append(block, r)
 	}
@@ -172,16 +227,47 @@ func probelUsageProtectMap(res codec.ProtectTallyDumpParams) map[int]string {
 	return out
 }
 
+// parseLevelList parses a --levels CSV ("0,1,2") into wire level ids.
+func parseLevelList(s string) ([]uint8, error) {
+	var out []uint8
+	for _, part := range strings.Split(s, ",") {
+		n, err := strconv.Atoi(strings.TrimSpace(part))
+		if err != nil || n < 0 || n > 255 {
+			return nil, fmt.Errorf("--levels: %q is not a level id (0-255)", part)
+		}
+		out = append(out, uint8(n))
+	}
+	return out, nil
+}
+
+// probelFetchUsageLabels reads the source names for one (matrix,
+// level) — cmd 100 is level-scoped — as id → trimmed label.
+func probelFetchUsageLabels(ctx context.Context, p *probelproto.Plugin, mtx, level uint8) (map[int]string, error) {
+	r, err := p.AllSourceNames(ctx, mtx, level, codec.NameLen12)
+	if err != nil {
+		return nil, fmt.Errorf("all-source-names level %d: %w", level, err)
+	}
+	out := map[int]string{}
+	for i, n := range r.Names {
+		if n = trimLabel(n); n != "" {
+			out[int(r.FirstSourceID)+i] = n
+		}
+	}
+	return out, nil
+}
+
 // runProbelUsage drives `dhs consumer probel-sw08p usage`.
 func runProbelUsage(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("probel-usage", flag.ContinueOnError)
 	matrix := fs.Int("matrix", 0, "matrix id (0-255; global --mtx-id wins when set)")
 	srce := fs.Int("srce", -1, "filter: only this source's assignments")
 	dest := fs.Int("dest", -1, "filter: only this destination's feed")
-	withProtect := fs.Bool("protect", false, "join per-dst protect state (protect tally dump) as an extra column")
+	withProtect := fs.Bool("protect", false, "join per-dst protect state (protect tally dump) as an extra column (single-level runs only)")
+	withLabels := fs.Bool("names", false, "resolve src/dst names (cmd 100/102) — ascii shows \"id (Label)\", csv appends srce_label,dest_label (same flag name on every connector's usage; --labels is the tree-proto canonical-labels mode)")
+	levelsFlag := fs.String("levels", "", "comma-separated level sweep (e.g. 0,1,2); omitted = the single global --level; rows collapse per (src,dst) with a combined levels column")
 	format := fs.String("format", "csv", "output format: csv | ascii")
 	out := fs.String("out", "", "csv output file (omitted = snapshots/probel-sw08p/<host>/usage.csv per ADR-0028; \"-\" = stdout)")
-	timeout := fs.Duration("timeout", 15*time.Second, "operation timeout")
+	timeout := fs.Duration("timeout", 30*time.Second, "operation timeout")
 	addr, flagArgs := popPositional(args)
 	if addr == "" {
 		return fmt.Errorf("missing <host:port>")
@@ -195,6 +281,16 @@ func runProbelUsage(ctx context.Context, args []string) error {
 	if *srce >= 0 && *dest >= 0 {
 		return fmt.Errorf("--srce and --dest are mutually exclusive")
 	}
+	var levels []uint8
+	if *levelsFlag != "" {
+		var lerr error
+		if levels, lerr = parseLevelList(*levelsFlag); lerr != nil {
+			return lerr
+		}
+	}
+	if *withProtect && len(levels) > 1 {
+		return fmt.Errorf("--protect needs a single level (protect state is per (dst, level) — a collapsed multi-level row cannot carry it)")
+	}
 	cctx, cancel := context.WithTimeout(ctx, *timeout)
 	defer cancel()
 	p, closer, err := dialProbel(cctx, addr)
@@ -202,27 +298,59 @@ func runProbelUsage(ctx context.Context, args []string) error {
 		return err
 	}
 	defer closer()
-	mtx, level := probelTarget(p, *matrix)
-	res, err := p.CrosspointTallyDump(cctx, mtx, level)
-	if err != nil {
-		return err
+	mtx, globalLevel := probelTarget(p, *matrix)
+	if len(levels) == 0 {
+		levels = []uint8{globalLevel}
 	}
-	var protect map[int]string
-	if *withProtect {
-		pres, perr := p.ProtectTallyDump(cctx, mtx, level, 0)
-		if perr != nil {
-			return perr
+
+	// Dest assoc names are matrix-scoped — one fetch covers the sweep.
+	var dstNames map[int]string
+	if *withLabels {
+		r, derr := p.AllDestAssocNames(cctx, mtx, codec.NameLen12)
+		if derr != nil {
+			return fmt.Errorf("all-dest-names: %w", derr)
 		}
-		protect = probelUsageProtectMap(pres)
+		dstNames = map[int]string{}
+		for i, n := range r.Names {
+			if n = trimLabel(n); n != "" {
+				dstNames[int(r.FirstDestAssociationID)+i] = n
+			}
+		}
 	}
-	firstDst, srcs := probelTallyTable(res)
-	rows := probelFilterUsage(probelBuildUsage(firstDst, srcs, int(level), protect), *srce, *dest)
+
+	var rows []probelUsageRow
+	for _, lvl := range levels {
+		res, derr := p.CrosspointTallyDump(cctx, mtx, lvl)
+		if derr != nil {
+			return fmt.Errorf("tally-dump level %d: %w", lvl, derr)
+		}
+		var protect map[int]string
+		if *withProtect {
+			pres, perr := p.ProtectTallyDump(cctx, mtx, lvl, 0)
+			if perr != nil {
+				return perr
+			}
+			protect = probelUsageProtectMap(pres)
+		}
+		firstDst, srcs := probelTallyTable(res)
+		lvlRows := probelBuildUsage(firstDst, srcs, int(lvl), protect)
+		if *withLabels {
+			// Source names are LEVEL-scoped (cmd 100) — fetch per level.
+			srcNames, serr := probelFetchUsageLabels(cctx, p, mtx, lvl)
+			if serr != nil {
+				return serr
+			}
+			applyProbelUsageLabels(lvlRows, srcNames, dstNames)
+		}
+		rows = append(rows, lvlRows...)
+	}
+	rows = probelFilterUsage(collapseProbelUsage(sortProbelUsage(rows)), *srce, *dest)
 
 	if *format == "ascii" {
 		renderProbelUsageASCII(os.Stdout, rows)
 		return nil
 	}
-	csv := formatProbelUsageCSV(rows, *withProtect)
+	csv := formatProbelUsageCSV(rows, *withProtect, *withLabels)
 	if *out == "-" {
 		fmt.Print(csv)
 		return nil
@@ -296,14 +424,14 @@ func runProbelReplace(ctx context.Context, args []string) error {
 	diffs := make([]ensureDiff, 0, len(cells))
 	for _, c := range cells {
 		diffs = append(diffs, ensureDiff{
-			Field: fmt.Sprintf("route.%d.%d", c.Dst, c.Level),
+			Field: fmt.Sprintf("route.%d.%s", c.Dst, c.Levels),
 			From:  fmt.Sprintf("%d", *from), To: fmt.Sprintf("%d", *with),
 		})
 	}
 
 	if *check {
 		for _, c := range cells {
-			_, _ = fmt.Fprintf(logw, "[would-replace] matrix=%d level=%d dst=%d: src %d -> %d\n", mtx, c.Level, c.Dst, *from, *with)
+			_, _ = fmt.Fprintf(logw, "[would-replace] matrix=%d level=%s dst=%d: src %d -> %d\n", mtx, c.Levels, c.Dst, *from, *with)
 		}
 		_, _ = fmt.Fprintf(logw, "probel-sw08p replace --check: would_change=%d crosspoint(s) carrying src %d — nothing sent\n", len(cells), *from)
 		if jsonOut {
@@ -315,11 +443,11 @@ func runProbelReplace(ctx context.Context, args []string) error {
 	fails := 0
 	for _, c := range cells {
 		if _, err := p.CrosspointConnect(cctx, mtx, level, uint16(c.Dst), uint16(*with)); err != nil {
-			_, _ = fmt.Fprintf(logw, "[replace] FAIL matrix=%d level=%d dst=%d reason=%s\n", mtx, c.Level, c.Dst, err)
+			_, _ = fmt.Fprintf(logw, "[replace] FAIL matrix=%d level=%s dst=%d reason=%s\n", mtx, c.Levels, c.Dst, err)
 			fails++
 			continue
 		}
-		_, _ = fmt.Fprintf(logw, "[replace] OK   matrix=%d level=%d dst=%d: src %d -> %d\n", mtx, c.Level, c.Dst, *from, *with)
+		_, _ = fmt.Fprintf(logw, "[replace] OK   matrix=%d level=%s dst=%d: src %d -> %d\n", mtx, c.Levels, c.Dst, *from, *with)
 	}
 	if fails > 0 {
 		return fmt.Errorf("%d/%d replace connect(s) failed", fails, len(cells))

--- a/cmd/dhs/cmd_probel_usage_test.go
+++ b/cmd/dhs/cmd_probel_usage_test.go
@@ -43,8 +43,8 @@ func TestProbelBuildUsage_SortedBySrcThenDst(t *testing.T) {
 	// Expected order: src 0 (dst 6), src 3 (dst 5), src 9 (dst 9),
 	// src 12 (dsts 4, 7, 8).
 	want := []probelUsageRow{
-		{Src: 0, Dst: 6, Level: 2}, {Src: 3, Dst: 5, Level: 2}, {Src: 9, Dst: 9, Level: 2},
-		{Src: 12, Dst: 4, Level: 2}, {Src: 12, Dst: 7, Level: 2}, {Src: 12, Dst: 8, Level: 2},
+		{Src: 0, Dst: 6, Levels: "2"}, {Src: 3, Dst: 5, Levels: "2"}, {Src: 9, Dst: 9, Levels: "2"},
+		{Src: 12, Dst: 4, Levels: "2"}, {Src: 12, Dst: 7, Levels: "2"}, {Src: 12, Dst: 8, Levels: "2"},
 	}
 	for i, w := range want {
 		if rows[i] != w {
@@ -93,17 +93,17 @@ func TestProbelFilterUsage(t *testing.T) {
 
 func TestFormatProbelUsageCSV(t *testing.T) {
 	rows := []probelUsageRow{
-		{Src: 3, Dst: 5, Level: 2},
-		{Src: 12, Dst: 7, Level: 2, Protect: "state=1 device=9"},
+		{Src: 3, Dst: 5, Levels: "2"},
+		{Src: 12, Dst: 7, Levels: "2", Protect: "state=1 device=9"},
 	}
-	plain := formatProbelUsageCSV(rows, false)
+	plain := formatProbelUsageCSV(rows, false, false)
 	if !strings.HasPrefix(plain, "srce,dest,levels\n") {
 		t.Fatalf("plain header: %q", plain)
 	}
 	if !strings.Contains(plain, "3,5,2\n") || strings.Contains(plain, "state=1") {
 		t.Fatalf("plain body: %q", plain)
 	}
-	prot := formatProbelUsageCSV(rows, true)
+	prot := formatProbelUsageCSV(rows, true, false)
 	if !strings.HasPrefix(prot, "srce,dest,levels,protect\n") {
 		t.Fatalf("protect header: %q", prot)
 	}
@@ -119,8 +119,8 @@ func TestRenderProbelUsageASCII(t *testing.T) {
 	renderProbelUsageASCII(&buf, rows)
 	out := buf.String()
 	for _, want := range []string{
-		"src 0\n└── dst 6  level 2\n",
-		"src 12\n├── dst 4  level 2\n├── dst 7  level 2  [state=1 device=9]\n└── dst 8  level 2\n",
+		"src 0\n└── dst 6  levels 2\n",
+		"src 12\n├── dst 4  levels 2\n├── dst 7  levels 2  [state=1 device=9]\n└── dst 8  levels 2\n",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("ascii missing %q in:\n%s", want, out)


### PR DESCRIPTION
## What

Labels + levels in every matrix usage view (rtree): ascii shows `src 12 (CAM 3)` / `dst 5 (MON 1)  levels 0;1`; CSV appends `srce_label,dest_label` with `--names`.

## Why

Owner go on the rtree design (#746, example files accepted): bring every connector's usage up to the cerebrum-nb standard. sw08p resolves names via cmd 100 (level-scoped) + cmd 102 and sweeps `--levels 0,1,2` with per-(src,dst) collapse; ember+ reads names from the walked label groups (zero extra wire; `--name-group` selects). sw02p stays ids-only (no label commands on that wire). Flag is `--names` everywhere — `--labels` was already the tree-proto canonical-labels mode.

Closes #746

## Scope

- [ ] acp1
- [ ] acp2
- [x] emberplus
- [x] probel-sw08p / probel-sw02p
- [ ] osc / tsl / cerebrum-nb / amwa
- [ ] transport
- [ ] export
- [x] cli
- [ ] api
- [ ] core
- [ ] ci / chore

**Cross-protocol changes**: none — cmd/dhs composition layer only (shared usage row/format helpers).

## Wire evidence (protocol changes only)

No new wire behaviour — composes existing name reads (cmd 100/102) and tally dumps; ember+ labels come from the already-walked tree.

## Reference controller

- [ ] Cerebrum still happy after this change
- [ ] VSM Studio still happy after this change
- [x] N/A (no protocol behaviour change)

## Type

- [x] feat — new feature
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] chore — maintenance, refactor, CI
- [ ] security — security fix or hardening

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `cmd/dhs/cmd_probel_usage.go` | modified | row struct (labels + collapsed levels), collapse/apply helpers, sw08p --names + --levels |
| `cmd/dhs/cmd_probel02p_usage.go` / `cmd_probel02p_export.go` | modified | Levels string migration |
| `cmd/dhs/cmd_emberplus_usage.go` | modified | --names / --name-group from walked label groups |
| `cmd/dhs/*_usage_test.go` | modified | collapse, label join, group-pick, CSV column tests |
| `docs/protocols/verbs.md` | modified | verb rows |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test ./...` | all | 0 |
| `go vet ./...` | clean | — |
| `golangci-lint run` | clean | — |

## Device tested

- [ ] ACP1 producer 10.100.0.102
- [ ] ACP2 producer 10.100.0.103
- [ ] ACP1 emulator 10.6.239.113
- [ ] ACP2 real device 10.41.40.195
- [x] Other (specify): TinyEmber+ 1.6.2 vendor oracle 127.0.0.1:9092 (Tier 2, ember+ --names) + Tier-4 loopback sw08p 127.0.0.1:2044 (--names + --levels sweep)
- [ ] No device needed (pure codec / doc change)

**Live-LXC command + observed output** (paste verbatim):

```text
dhs consumer emberplus usage 127.0.0.1 --port 9092 --path router.nToN.matrix --names --format ascii
src 12 (AES-S-12)
└── dst 12 (AES-T-12)  levels 0

dhs consumer probel-sw08p usage 127.0.0.1:2044 --matrix 0 --levels 0,1 --names --srce 8 --out -
srce,dest,levels,srce_label,dest_label
8,3,0,SRC 0009,DST 0004
```

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [x] Integration tested on VM before PR (TinyEmber+ oracle + loopback)

## Approval

@yboujraf — requesting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)