### PR TITLE
fix(ci): setup-go tracks go.mod everywhere (release binaries broke)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        go: ["1.23"]
     steps:
       - uses: actions/checkout@v5
         with:
@@ -45,7 +44,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: ${{ matrix.go }}
+          go-version-file: go.mod
 
       - name: Go mod tidy
         run: go mod tidy
@@ -183,7 +182,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version-file: go.mod
 
       - name: Build
         run: go build -buildvcs=false ./...
@@ -212,7 +211,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version-file: go.mod
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
@@ -233,7 +232,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version-file: go.mod
 
       - name: Build all targets
         run: |
@@ -296,7 +295,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.22"
+          go-version-file: go.mod
 
       # Embed the Windows .exe version resource (CompanyName / ProductName /
       # FileVersion / LegalCopyright shown in the Properties dialog) from


### PR DESCRIPTION
## What

Every setup-go in ci.yml now uses go-version-file: go.mod (fixed "1.22"/"1.23" pins and the matrix go axis removed).

## Why

The v0.17.0 release run ([32570396862](https://github.com/by-openclaw/go-acp/actions/runs/32570396862)) tagged and created the release, but Build release binaries died in 24s: go.mod requires go >= 1.23.0, the job ran 1.22.12 with GOTOOLCHAIN=local (stale pin). Tracking go.mod makes toolchain drift structurally impossible. v0.17.0 assets are backfilled to the existing release with the job's exact recipe.

Closes #748

## Scope

- [ ] acp1
- [ ] acp2
- [ ] emberplus
- [ ] probel-sw08p / probel-sw02p
- [ ] osc / tsl / cerebrum-nb / amwa
- [ ] transport
- [ ] export
- [ ] cli
- [ ] api
- [ ] core
- [x] ci / chore

**Cross-protocol changes**: none — workflow file only.

## Wire evidence (protocol changes only)

N/A — CI config.

## Reference controller

- [ ] Cerebrum still happy after this change
- [ ] VSM Studio still happy after this change
- [x] N/A (no protocol behaviour change)

## Type

- [ ] feat — new feature
- [x] fix — bug fix
- [ ] docs — documentation only
- [ ] chore — maintenance, refactor, CI
- [ ] security — security fix or hardening

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `.github/workflows/ci.yml` | modified | all setup-go steps use go-version-file: go.mod |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| CI on this PR | pending | — |

## Device tested

- [ ] ACP1 producer 10.100.0.102
- [ ] ACP2 producer 10.100.0.103
- [ ] ACP1 emulator 10.6.239.113
- [ ] ACP2 real device 10.41.40.195
- [ ] Other (specify)
- [x] No device needed (pure codec / doc change)

**Live-LXC command + observed output** (paste verbatim):

```text
N/A — workflow-only; the proof is this PR's own green run under go-version-file.
```

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [ ] Integration tested on VM before PR (N/A — CI config)

## Approval

@yboujraf — requesting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)