### PR TITLE
feat(cli): watch-listen alias parity on the push connectors (#751 G3)

### DIFF
--- a/cmd/dhs/cmd_osc.go
+++ b/cmd/dhs/cmd_osc.go
@@ -46,7 +46,9 @@ func runOSCConsumer(ctx context.Context, proto string, args []string) error {
 	verb := args[0]
 	rest := args[1:]
 	switch verb {
-	case "watch":
+	case "watch", "listen":
+		// watch = canonical; listen accepted for family parity with
+		// TSL's historical spelling (#751 G3).
 		return runOSCWatch(ctx, proto, rest)
 	case "validate":
 		// Canonical offline validate (#243): decode a captured

--- a/cmd/dhs/cmd_tsl.go
+++ b/cmd/dhs/cmd_tsl.go
@@ -39,7 +39,9 @@ func runTSLConsumer(ctx context.Context, proto string, args []string) error {
 	verb := args[0]
 	rest := args[1:]
 	switch verb {
-	case "listen":
+	case "listen", "watch":
+		// watch = canonical family spelling (osc/tree protos); listen
+		// kept as the historical TSL alias (#751 G3 parity).
 		return runTSLListen(ctx, proto, rest)
 	case "validate":
 		// The tsl plugin implements consumer.Validator; route to the generic
@@ -47,7 +49,7 @@ func runTSLConsumer(ctx context.Context, proto string, args []string) error {
 		// acp1/acp2/emberplus dispatch (main.go dispatchConsumer).
 		return runValidate(ctx, append([]string{"--protocol", proto}, rest...))
 	}
-	return fmt.Errorf("consumer %s: unknown verb %q (expected: listen | validate)", proto, verb)
+	return fmt.Errorf("consumer %s: unknown verb %q (expected: watch | listen | validate)", proto, verb)
 }
 
 // runTSLListen binds a UDP (or v5.0 TCP) listener and prints every
@@ -225,11 +227,13 @@ func printTSLConsumerHelp(w io.Writer, proto string) {
 dhs consumer `+proto+` — TSL UMD listener (push protocol from a switcher / VSM / Kaleido)
 
 USAGE
-  dhs consumer `+proto+` listen [--bind HOST:PORT] [--tcp]
+  dhs consumer `+proto+` watch [--bind HOST:PORT] [--tcp]
 
 VERBS
-  listen          bind a UDP listener (or v5.0 TCP listener with --tcp)
+  watch           bind a UDP listener (or v5.0 TCP listener with --tcp)
                   and print every decoded frame until Ctrl-C
+                  (alias: listen — historical TSL spelling)
+  validate        decode a captured frames.jsonl offline (ADR-0021)
 
 DEFAULT PORTS
   tsl-v31, tsl-v40   UDP 4000

--- a/docs/protocols/verbs.md
+++ b/docs/protocols/verbs.md
@@ -138,7 +138,7 @@ Global flags: `--mtx-id --level --dsts --srcs` (`--dsts` enables bootstrap rx01 
 | Protocol | Verb | Description | Scope |
 |---|---|---|---|
 | osc-v10 / osc-v11 | `watch` | bind a port, print every received OSC message (`--listen <transport>:<port> [--pattern]`) | listener/monitor |
-| tsl-v31 / v40 / v50 | `listen` | bind UDP (or v5.0 TCP `--tcp`) listener, print every decoded tally frame | one-way receiver |
+| tsl-v31 / v40 / v50 | `watch` (alias `listen`) | bind UDP (or v5.0 TCP `--tcp`) listener, print every decoded tally frame — `watch` is the canonical family spelling, accepted on osc too (#751 G3) | one-way receiver |
 
 ---
 


### PR DESCRIPTION
## What

The push-model bind-and-print verb accepts both spellings on both connectors: `watch` (canonical) and `listen` (historical TSL alias).

## Why

G3 of #751 (verb parity): tsl said `listen`, osc said `watch` for the same role — a scripting papercut and an API-naming inconsistency.

Closes #755

## Scope

- [ ] acp1
- [ ] acp2
- [ ] emberplus
- [ ] probel-sw08p / probel-sw02p
- [x] osc / tsl / cerebrum-nb / amwa
- [ ] transport
- [ ] export
- [x] cli
- [ ] api
- [ ] core
- [ ] ci / chore

**Cross-protocol changes**: none — two dispatcher case-lists + help.

## Wire evidence (protocol changes only)

N/A — CLI dispatch only, no wire behaviour.

## Reference controller

- [ ] Cerebrum still happy after this change
- [ ] VSM Studio still happy after this change
- [x] N/A (no protocol behaviour change)

## Type

- [x] feat — new feature
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] chore — maintenance, refactor, CI
- [ ] security — security fix or hardening

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `cmd/dhs/cmd_tsl.go` | modified | accepts watch; help shows canonical + alias |
| `cmd/dhs/cmd_osc.go` | modified | accepts listen |
| `docs/protocols/verbs.md` | modified | row updated |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test ./...` | all | 0 |
| `go vet ./...` | clean | — |
| `golangci-lint run` | clean | — |

## Device tested

- [ ] ACP1 producer 10.100.0.102
- [ ] ACP2 producer 10.100.0.103
- [ ] ACP1 emulator 10.6.239.113
- [ ] ACP2 real device 10.41.40.195
- [ ] Other (specify)
- [x] No device needed (pure codec / doc change)

**Live-LXC command + observed output** (paste verbatim):

```text
dhs consumer tsl-v50 watch --badflag   -> flag provided but not defined: -badflag  (dispatch reached the listener)
dhs consumer osc-v10 listen --badflag  -> flag provided but not defined: -badflag
dhs consumer tsl-v50 bogus             -> unknown verb "bogus" (expected: watch | listen | validate)
```

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [ ] Integration tested on VM before PR (N/A — dispatch alias)

## Approval

@yboujraf — requesting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)