### PR TITLE
feat(cli): probel-sw08p point reads speak --output json (#751 G1a)

### DIFF
--- a/cmd/dhs/cmd_probel.go
+++ b/cmd/dhs/cmd_probel.go
@@ -442,6 +442,7 @@ func parseProbelFlags(args []string, want struct{ dst, src bool }) (probelFlags,
 	fs.IntVar(&pf.dst, "dst", 0, "destination id (0-65535)")
 	fs.IntVar(&pf.src, "src", 0, "source id (0-65535)")
 	fs.DurationVar(&pf.timeout, "timeout", 5*time.Second, "operation timeout")
+	fs.StringVar(&pf.output, "output", "text", "output format: text | json (ADR-0002; #751 G1)")
 	addr, flagArgs := popPositional(args)
 	if addr == "" {
 		return pf, fmt.Errorf("missing <host:port>")
@@ -481,6 +482,14 @@ func runProbelInterrogate(ctx context.Context, args []string) error {
 	reply, err := p.CrosspointInterrogate(cctx, matrix, level, uint16(pf.dst))
 	if err != nil {
 		return err
+	}
+	if jsonOut, oerr := resolveEnsureOutput(pf.output, false); oerr != nil {
+		return oerr
+	} else if jsonOut {
+		return emitReadJSON(probelInterrogateJSON{
+			Matrix: int(reply.MatrixID), Level: int(reply.LevelID),
+			Dest: int(reply.DestinationID), Srce: int(reply.SourceID),
+		})
 	}
 	fmt.Printf("crosspoint tally  matrix=%d level=%d dst=%d <- src=%d\n",
 		reply.MatrixID, reply.LevelID, reply.DestinationID, reply.SourceID)
@@ -589,12 +598,17 @@ func runProbelMaintenance(ctx context.Context, args []string) error {
 func runProbelDualStatus(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("probel-dual-status", flag.ContinueOnError)
 	timeout := fs.Duration("timeout", 5*time.Second, "operation timeout")
+	output := fs.String("output", "text", "output format: text | json (ADR-0002; #751 G1)")
 	addr, flagArgs := popPositional(args)
 	if addr == "" {
 		return fmt.Errorf("missing <host:port>")
 	}
 	if err := fs.Parse(flagArgs); err != nil {
 		return err
+	}
+	jsonOut, oerr := resolveEnsureOutput(*output, false)
+	if oerr != nil {
+		return oerr
 	}
 	cctx, cancel := context.WithTimeout(ctx, *timeout)
 	defer cancel()
@@ -610,6 +624,12 @@ func runProbelDualStatus(ctx context.Context, args []string) error {
 	who := "MASTER"
 	if r.SlaveActive {
 		who = "SLAVE"
+	}
+	if jsonOut {
+		return emitReadJSON(probelDualStatusJSON{
+			Who: who, Active: r.Active,
+			IdleFaulty: r.IdleControllerFaulty, SlaveActive: r.SlaveActive,
+		})
 	}
 	fmt.Printf("dual-controller  who=%s active=%v idle_faulty=%v\n",
 		who, r.Active, r.IdleControllerFaulty)
@@ -631,6 +651,11 @@ func runProbelTallyDump(ctx context.Context, args []string) error {
 	res, err := p.CrosspointTallyDump(cctx, matrix, level)
 	if err != nil {
 		return err
+	}
+	if jsonOut, oerr := resolveEnsureOutput(pf.output, false); oerr != nil {
+		return oerr
+	} else if jsonOut {
+		return emitReadJSON(probelTallyDumpToJSON(res))
 	}
 	if res.IsWord {
 		fmt.Printf("tally-dump (word) matrix=%d level=%d first_dst=%d tallies=%d\n",
@@ -693,6 +718,14 @@ func runProbelProtectInterrogate(ctx context.Context, args []string) error {
 		uint8(pf.matrix), uint8(pf.level), uint16(pf.dst), uint16(device))
 	if err != nil {
 		return err
+	}
+	if jsonOut, oerr := resolveEnsureOutput(pf.output, false); oerr != nil {
+		return oerr
+	} else if jsonOut {
+		return emitReadJSON(probelProtectJSON{
+			Matrix: int(reply.MatrixID), Level: int(reply.LevelID),
+			Dest: int(reply.DestinationID), State: int(reply.State), Device: int(reply.DeviceID),
+		})
 	}
 	fmt.Printf("protect tally  matrix=%d level=%d dst=%d -> state=%d device=%d\n",
 		reply.MatrixID, reply.LevelID, reply.DestinationID, reply.State, reply.DeviceID)
@@ -825,12 +858,17 @@ func runProbelProtectDump(ctx context.Context, args []string) error {
 	level := fs.Int("level", 0, "level id (0-255)")
 	firstDst := fs.Int("first-dst", 0, "first destination id to dump")
 	timeout := fs.Duration("timeout", 5*time.Second, "operation timeout")
+	output := fs.String("output", "text", "output format: text | json (ADR-0002; #751 G1)")
 	addr, flagArgs := popPositional(args)
 	if addr == "" {
 		return fmt.Errorf("missing <host:port>")
 	}
 	if err := fs.Parse(flagArgs); err != nil {
 		return err
+	}
+	jsonOut, oerr := resolveEnsureOutput(*output, false)
+	if oerr != nil {
+		return oerr
 	}
 	cctx, cancel := context.WithTimeout(ctx, *timeout)
 	defer cancel()
@@ -842,6 +880,9 @@ func runProbelProtectDump(ctx context.Context, args []string) error {
 	res, err := p.ProtectTallyDump(cctx, uint8(*matrix), uint8(*level), uint16(*firstDst))
 	if err != nil {
 		return err
+	}
+	if jsonOut {
+		return emitReadJSON(probelProtectDumpToJSON(res))
 	}
 	fmt.Printf("protect tally-dump matrix=%d level=%d first_dst=%d items=%d\n",
 		res.MatrixID, res.LevelID, res.FirstDestinationID, len(res.Items))

--- a/cmd/dhs/cmd_probel_json.go
+++ b/cmd/dhs/cmd_probel_json.go
@@ -1,0 +1,97 @@
+package main
+
+// --output json for the probel-sw08p point-read verbs (#751 G1a):
+// interrogate, tally-dump, dual-status, protect-interrogate,
+// protect-dump. One JSON object per invocation on stdout, field names
+// matching the canonical file grammar (dest/srce/levels — same
+// vocabulary as -xpoint.csv), so scripts and the ansible verb role
+// parse one shape family across CLI and pack files. Name reads keep
+// their CSV path via export (labels are a file-set concern).
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"dhs/internal/probel-sw08p/codec"
+	probelproto "dhs/internal/probel-sw08p/consumer"
+)
+
+// emitReadJSON marshals one read result to stdout.
+func emitReadJSON(v any) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(b))
+	return nil
+}
+
+// probelXpointJSON is one crosspoint in read output — the canonical
+// grammar's vocabulary.
+type probelXpointJSON struct {
+	Dest int `json:"dest"`
+	Srce int `json:"srce"`
+}
+
+type probelInterrogateJSON struct {
+	Matrix int `json:"matrix"`
+	Level  int `json:"level"`
+	Dest   int `json:"dest"`
+	Srce   int `json:"srce"`
+}
+
+type probelTallyDumpJSON struct {
+	Matrix int                `json:"matrix"`
+	Level  int                `json:"level"`
+	Form   string             `json:"form"` // "byte" | "word"
+	Rows   []probelXpointJSON `json:"rows"`
+}
+
+func probelTallyDumpToJSON(res probelproto.TallyDumpResult) probelTallyDumpJSON {
+	out := probelTallyDumpJSON{Form: "byte"}
+	first, srcs := probelTallyTable(res)
+	if res.IsWord {
+		out.Form = "word"
+		out.Matrix, out.Level = int(res.Word.MatrixID), int(res.Word.LevelID)
+	} else {
+		out.Matrix, out.Level = int(res.Byte.MatrixID), int(res.Byte.LevelID)
+	}
+	out.Rows = make([]probelXpointJSON, 0, len(srcs))
+	for i, s := range srcs {
+		out.Rows = append(out.Rows, probelXpointJSON{Dest: first + i, Srce: s})
+	}
+	return out
+}
+
+type probelDualStatusJSON struct {
+	Who         string `json:"who"` // MASTER | SLAVE
+	Active      bool   `json:"active"`
+	IdleFaulty  bool   `json:"idle_faulty"`
+	SlaveActive bool   `json:"slave_active"`
+}
+
+type probelProtectJSON struct {
+	Matrix int `json:"matrix"`
+	Level  int `json:"level"`
+	Dest   int `json:"dest"`
+	State  int `json:"state"`
+	Device int `json:"device"`
+}
+
+type probelProtectDumpJSON struct {
+	Matrix int                 `json:"matrix"`
+	Level  int                 `json:"level"`
+	Rows   []probelProtectJSON `json:"rows"`
+}
+
+func probelProtectDumpToJSON(res codec.ProtectTallyDumpParams) probelProtectDumpJSON {
+	out := probelProtectDumpJSON{Matrix: int(res.MatrixID), Level: int(res.LevelID)}
+	out.Rows = make([]probelProtectJSON, 0, len(res.Items))
+	for i, it := range res.Items {
+		out.Rows = append(out.Rows, probelProtectJSON{
+			Matrix: int(res.MatrixID), Level: int(res.LevelID),
+			Dest: int(res.FirstDestinationID) + i, State: int(it.State), Device: int(it.DeviceID),
+		})
+	}
+	return out
+}


### PR DESCRIPTION
## What

`--output json` on the probel-sw08p point-read verbs (interrogate, tally-dump, dual-status, protect-interrogate, protect-dump) — G1a of the verb-parity pass.

## Why

#751 G1: machine-readable reads for scripting/ansible; one vocabulary (dest/srce/matrix/level, same as the canonical pack grammar) across CLI output and files — and the field naming the future OAS 3.0 API will inherit.

Closes #757

## Scope

- [ ] acp1
- [ ] acp2
- [ ] emberplus
- [x] probel-sw08p / probel-sw02p
- [ ] osc / tsl / cerebrum-nb / amwa
- [ ] transport
- [ ] export
- [x] cli
- [ ] api
- [ ] core
- [ ] ci / chore

**Cross-protocol changes**: none — cmd/dhs output layer only.

## Wire evidence (protocol changes only)

N/A — output formatting only, wire unchanged.

## Reference controller

- [ ] Cerebrum still happy after this change
- [ ] VSM Studio still happy after this change
- [x] N/A (no protocol behaviour change)

## Type

- [x] feat — new feature
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] chore — maintenance, refactor, CI
- [ ] security — security fix or hardening

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `cmd/dhs/cmd_probel_json.go` | new | JSON shapes + converters |
| `cmd/dhs/cmd_probel.go` | modified | 5 verbs wired; shared --output flag |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test ./...` | all | 0 |
| `go vet ./...` | clean | — |
| `golangci-lint run` | clean | — |

## Device tested

- [ ] ACP1 producer 10.100.0.102
- [ ] ACP2 producer 10.100.0.103
- [ ] ACP1 emulator 10.6.239.113
- [ ] ACP2 real device 10.41.40.195
- [x] Other (specify): Tier-4 loopback vs own provider on 127.0.0.1:2046
- [ ] No device needed (pure codec / doc change)

**Live-LXC command + observed output** (paste verbatim):

```text
dhs consumer probel-sw08p interrogate 127.0.0.1:2046 --matrix 0 --level 0 --dst 3 --output json
{"matrix":0,"level":0,"dest":3,"srce":0}

dhs consumer probel-sw08p dual-status 127.0.0.1:2046 --output json
{"who":"MASTER","active":true,"idle_faulty":false,"slave_active":false}

dhs consumer probel-sw08p tally-dump 127.0.0.1:2046 --matrix 0 --output json
{"matrix":0,"level":0,"form":"byte","rows":[{"dest":0,"srce":0}, ...]}
```

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [x] Integration tested on VM before PR (loopback; see Device tested)

## Approval

@yboujraf — requesting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)