### PR TITLE
chore(ci): bump actions to Node-24 majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,14 +35,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           # LFS disabled (free plan quota hit). CI jobs only need Go
           # source to build/test/lint; LFS'd assets/** PDFs and vendor
           # binaries are not read during the build.
           lfs: false
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
 
@@ -149,7 +149,7 @@ jobs:
 
       - name: Upload coverage
         if: matrix.os == 'ubuntu-latest'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: coverage
           path: coverage.out
@@ -170,7 +170,7 @@ jobs:
       - name: Install git + git-lfs
         run: dnf install -y git git-lfs
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           # LFS disabled (free plan quota hit). CI jobs only need Go
           # source to build/test/lint; LFS'd assets/** PDFs and vendor
@@ -180,7 +180,7 @@ jobs:
       - name: Fix git ownership
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
 
@@ -202,19 +202,19 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           # LFS disabled (free plan quota hit). CI jobs only need Go
           # source to build/test/lint; LFS'd assets/** PDFs and vendor
           # binaries are not read during the build.
           lfs: false
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.1.6
 
@@ -223,14 +223,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test, test-rhel, lint]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           # LFS disabled (free plan quota hit). CI jobs only need Go
           # source to build/test/lint; LFS'd assets/** PDFs and vendor
           # binaries are not read during the build.
           lfs: false
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
 
@@ -253,7 +253,7 @@ jobs:
           done
 
       - name: Upload binaries
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: binaries
           path: dist/
@@ -291,9 +291,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
 
@@ -376,7 +376,7 @@ jobs:
           cat SHA256SUMS.txt
 
       - name: Upload to GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.release-please.outputs.tag_name }}
           files: |


### PR DESCRIPTION
## What

Bumps every Node-20-era action in ci.yml to its current major: checkout v7, setup-go v7, upload-artifact v7, golangci-lint-action v9, action-gh-release v3. release-please stays at v4 deliberately.

## Why

Owner-approved: the Actions annotations were a wall of "Node.js 20 is deprecated" warnings plus failing cache restores (tar exit 2). New majors run native Node 24 and rotate the cache keys; the stale repo caches were deleted alongside.

Closes #761

## Scope

- [ ] acp1
- [ ] acp2
- [ ] emberplus
- [ ] probel-sw08p / probel-sw02p
- [ ] osc / tsl / cerebrum-nb / amwa
- [ ] transport
- [ ] export
- [ ] cli
- [ ] api
- [ ] core
- [x] ci / chore

**Cross-protocol changes**: none — workflow file only.

## Wire evidence (protocol changes only)

N/A — CI config.

## Reference controller

- [ ] Cerebrum still happy after this change
- [ ] VSM Studio still happy after this change
- [x] N/A (no protocol behaviour change)

## Type

- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] docs — documentation only
- [x] chore — maintenance, refactor, CI
- [ ] security — security fix or hardening

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `.github/workflows/ci.yml` | modified | five action majors bumped |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| CI on this PR (the proof itself) | pending | — |

## Device tested

- [ ] ACP1 producer 10.100.0.102
- [ ] ACP2 producer 10.100.0.103
- [ ] ACP1 emulator 10.6.239.113
- [ ] ACP2 real device 10.41.40.195
- [ ] Other (specify)
- [x] No device needed (pure codec / doc change)

**Live-LXC command + observed output** (paste verbatim):

```text
N/A — workflow-only; acceptance = this PR's run green with no Node-20 annotations.
```

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [ ] Integration tested on VM before PR (N/A — CI config)

## Approval

@yboujraf — requesting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)