### PR TITLE
feat(cli): cerebrum-nb usage --names CSV parity (#751 G4)

### DIFF
--- a/cmd/dhs/cmd_cerebrum_usage.go
+++ b/cmd/dhs/cmd_cerebrum_usage.go
@@ -134,13 +134,19 @@ func cerebrumBuildUsage(routes []routeSpec, virtuals map[string]bool, resolve bo
 // columns appear only in resolve mode: effective_srce is the chain's
 // physical end ("" on loop/unfed — always loud in ascii, silent-empty
 // here so machine parsing stays simple), via lists the virtual hops.
-func formatCerebrumUsageCSV(rows []cerebrumUsageRow, resolve bool) string {
+// --names appends srce_label,dest_label (mnemonics — header-keyed,
+// #751 G4: same columns as the probel/ember+ usage CSVs).
+func formatCerebrumUsageCSV(rows []cerebrumUsageRow, resolve bool, srcNames, dstNames map[string]string) string {
+	withNames := srcNames != nil || dstNames != nil
 	var b strings.Builder
+	b.WriteString("srce,dest,levels")
 	if resolve {
-		b.WriteString("srce,dest,levels,effective_srce,via\n")
-	} else {
-		b.WriteString("srce,dest,levels\n")
+		b.WriteString(",effective_srce,via")
 	}
+	if withNames {
+		b.WriteString(",srce_label,dest_label")
+	}
+	b.WriteByte('\n')
 	for _, r := range rows {
 		b.WriteString(r.Srce)
 		b.WriteByte(',')
@@ -152,6 +158,12 @@ func formatCerebrumUsageCSV(rows []cerebrumUsageRow, resolve bool) string {
 			b.WriteString(r.Effective)
 			b.WriteByte(',')
 			b.WriteString(strings.Join(r.Via, ";"))
+		}
+		if withNames {
+			b.WriteByte(',')
+			b.WriteString(srcNames[r.Srce])
+			b.WriteByte(',')
+			b.WriteString(dstNames[r.Dest])
 		}
 		b.WriteByte('\n')
 	}
@@ -246,6 +258,7 @@ func cerebrumUsage(_ context.Context, args []string) error {
 	dest := fs.String("dest", "", "filter: only this dest's feeds (upstream-chain view in ascii)")
 	level := fs.String("level", "", "filter: one level only")
 	resolveFlag := fs.Bool("resolve", false, "resolve VIRTUAL chains: add effective_srce + via columns (csv) / render the full chain (ascii)")
+	withNames := fs.Bool("names", false, "csv: append srce_label,dest_label mnemonic columns (#751 G4 — same flag on every connector's usage; ascii always shows names)")
 	format := fs.String("format", "csv", "output format: csv | ascii")
 	out := fs.String("out", "", "csv output file (omitted = snapshots/<proto>/<router>/usage.csv per ADR-0028; \"-\" = stdout)")
 	idle := fs.Duration("idle", 3*time.Second, "stop collecting this long after the last snapshot frame if no WILDCARD_COMPLETE arrives")
@@ -330,7 +343,11 @@ func cerebrumUsage(_ context.Context, args []string) error {
 		return nil
 	}
 
-	csv := formatCerebrumUsageCSV(rows, *resolveFlag)
+	var csvSrcNames, csvDstNames map[string]string
+	if *withNames {
+		csvSrcNames, csvDstNames = srcNames, dstNames
+	}
+	csv := formatCerebrumUsageCSV(rows, *resolveFlag, csvSrcNames, csvDstNames)
 	if *out == "-" {
 		fmt.Print(csv)
 		return nil

--- a/cmd/dhs/cmd_cerebrum_usage_test.go
+++ b/cmd/dhs/cmd_cerebrum_usage_test.go
@@ -78,14 +78,22 @@ func TestCerebrumBuildUsage_ResolveAndCollapse(t *testing.T) {
 		t.Fatalf("dest2 row = %+v", r)
 	}
 
-	csv := formatCerebrumUsageCSV(rows, true)
+	csv := formatCerebrumUsageCSV(rows, true, nil, nil)
 	if !strings.Contains(csv, "srce,dest,levels,effective_srce,via\n") ||
 		!strings.Contains(csv, "4,1,1;2;3,2,4;3\n") {
 		t.Fatalf("resolved csv:\n%s", csv)
 	}
-	plain := formatCerebrumUsageCSV(cerebrumBuildUsage(routes, virtuals, false), false)
+	plain := formatCerebrumUsageCSV(cerebrumBuildUsage(routes, virtuals, false), false, nil, nil)
 	if strings.Contains(plain, "effective") || !strings.Contains(plain, "2,3,1;2;3\n") {
 		t.Fatalf("literal csv:\n%s", plain)
+	}
+	// --names appends the mnemonic columns (#751 G4), header-keyed and
+	// composable with --resolve.
+	named := formatCerebrumUsageCSV(rows, true,
+		map[string]string{"4": "Proc 2"}, map[string]string{"1": "Dest 1"})
+	if !strings.Contains(named, "srce,dest,levels,effective_srce,via,srce_label,dest_label\n") ||
+		!strings.Contains(named, "4,1,1;2;3,2,4;3,Proc 2,Dest 1\n") {
+		t.Fatalf("named csv:\n%s", named)
 	}
 }
 


### PR DESCRIPTION
## What

cerebrum-nb `usage` gains `--names` — srce_label,dest_label mnemonic columns in the CSV, composable with --resolve (G4, the final naming-parity leg).

## Why

#751 G4: all four matrix connectors now share the same usage flag and CSV columns. ascii was already labeled; mnemonics were already obtained — zero extra wire traffic.

Closes #763

## Scope

- [ ] acp1
- [ ] acp2
- [ ] emberplus
- [ ] probel-sw08p / probel-sw02p
- [x] osc / tsl / cerebrum-nb / amwa
- [ ] transport
- [ ] export
- [x] cli
- [ ] api
- [ ] core
- [ ] ci / chore

**Cross-protocol changes**: none — cmd/dhs output layer only.

## Wire evidence (protocol changes only)

N/A — output formatting only.

## Reference controller

- [ ] Cerebrum still happy after this change
- [ ] VSM Studio still happy after this change
- [x] N/A (no protocol behaviour change)

## Type

- [x] feat — new feature
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] chore — maintenance, refactor, CI
- [ ] security — security fix or hardening

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `cmd/dhs/cmd_cerebrum_usage.go` | modified | --names flag + label columns |
| `cmd/dhs/cmd_cerebrum_usage_test.go` | modified | resolve+names composition pinned |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test ./...` | all | 0 |
| `go vet ./...` | clean | — |
| `golangci-lint run` | clean | — |

## Device tested

- [ ] ACP1 producer 10.100.0.102
- [ ] ACP2 producer 10.100.0.103
- [ ] ACP1 emulator 10.6.239.113
- [ ] ACP2 real device 10.41.40.195
- [ ] Other (specify)
- [x] No device needed (pure codec / doc change) — column formatting pinned by unit test; wire obtain path unchanged

**Live-LXC command + observed output** (paste verbatim):

```text
unit-pinned: srce,dest,levels,effective_srce,via,srce_label,dest_label
             4,1,1;2;3,2,4;3,Proc 2,Dest 1
```

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [ ] Integration tested on VM before PR (output-only; staging run available on request)

## Approval

@yboujraf — requesting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)