### PR TITLE
feat(cli): tree-proto get/info speak --output json (#751 G1c)

### DIFF
--- a/cmd/dhs/cmd_get.go
+++ b/cmd/dhs/cmd_get.go
@@ -21,6 +21,7 @@ func runGet(ctx context.Context, args []string) error {
 	idx := fs.Int("idx", 0, "ACP2 preset idx (0 = ACTIVE INDEX; default)")
 	pid := fs.Int("pid", 0, "ACP2 property id to read (0 = default pid=8 value; set to read object_type/label/access/etc.)")
 	dmIdentity := fs.String("dm", "", `Ember+ only: identity-keyed DM hot-load (e.g. "Tiny Ember+ Router@1.6.2"). When set, the tree is seeded from .cache/dm/emberplus/<identity>.json and the per-call walk is skipped — refs #438, ADR-0022.`)
+	output := fs.String("output", "text", "output format: text | json (ADR-0002; #751 G1)")
 	host, rest, err := popHost(args)
 	if err != nil {
 		return fmt.Errorf("usage: dhs consumer <proto> get <host> --slot N (--path P | --label L | --id I) [--capture out.jsonl]")
@@ -96,6 +97,24 @@ func runGet(ctx context.Context, args []string) error {
 	if *label != "" {
 		meta = findObjectByLabel(plug, *slot, *group, *label)
 	}
+	if jsonOut, oerr := resolveEnsureOutput(*output, false); oerr != nil {
+		return oerr
+	} else if jsonOut {
+		out := getValueJSON{
+			Slot: *slot, Path: *pathFlag, Group: *group, Label: *label,
+			Value: formatValue(val, meta),
+		}
+		if *id >= 0 {
+			out.ID = id
+		}
+		if len(val.Raw) > 0 {
+			out.Raw = hex.EncodeToString(val.Raw)
+		}
+		if meta != nil {
+			out.Label = meta.Label
+		}
+		return emitReadJSON(out)
+	}
 	fmt.Println(formatValue(val, meta))
 	if len(val.Raw) > 0 {
 		fmt.Printf("raw  = %s\n", hex.EncodeToString(val.Raw))
@@ -104,4 +123,17 @@ func runGet(ctx context.Context, args []string) error {
 		printObjectMeta(*meta)
 	}
 	return nil
+}
+
+// getValueJSON is the machine shape of one point read (#751 G1c).
+// Value carries the same human formatting as text mode (units, enum
+// names); Raw is the wire hex when the protocol exposes it.
+type getValueJSON struct {
+	Slot  int    `json:"slot"`
+	Path  string `json:"path,omitempty"`
+	Group string `json:"group,omitempty"`
+	Label string `json:"label,omitempty"`
+	ID    *int   `json:"id,omitempty"`
+	Value string `json:"value"`
+	Raw   string `json:"raw,omitempty"`
 }

--- a/cmd/dhs/cmd_info.go
+++ b/cmd/dhs/cmd_info.go
@@ -9,11 +9,16 @@ import (
 func runInfo(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("info", flag.ExitOnError)
 	cf := addCommonFlags(fs)
+	output := fs.String("output", "text", "output format: text | json (ADR-0002; #751 G1)")
 	host, rest, err := popHost(args)
 	if err != nil {
 		return fmt.Errorf("usage: dhs consumer <proto> info <host> [--port N] [--timeout DUR]")
 	}
 	_ = fs.Parse(rest)
+	jsonOut, oerr := resolveEnsureOutput(*output, false)
+	if oerr != nil {
+		return oerr
+	}
 
 	plug, cleanup, err := connect(ctx, host, cf)
 	if err != nil {
@@ -27,6 +32,24 @@ func runInfo(ctx context.Context, args []string) error {
 	info, err := plug.GetDeviceInfo(opCtx)
 	if err != nil {
 		return err
+	}
+	if jsonOut {
+		out := deviceInfoJSON{
+			Device: fmt.Sprintf("%s:%d", info.IP, info.Port), Protocol: cf.protocol,
+			ProtocolVersion: info.ProtocolVersion, DtdVersion: info.DtdVersion,
+			Slots: info.NumSlots,
+		}
+		for slot := 0; slot < info.NumSlots; slot++ {
+			si, serr := plug.GetSlotInfo(opCtx, slot)
+			s := slotInfoJSON{Slot: slot}
+			if serr != nil {
+				s.Error = serr.Error()
+			} else {
+				s.Status, s.Online = si.Status.String(), si.IsOnline
+			}
+			out.SlotStatus = append(out.SlotStatus, s)
+		}
+		return emitReadJSON(out)
 	}
 	fmt.Printf("device       %s:%d\n", info.IP, info.Port)
 	fmt.Printf("protocol     %s v%d\n", cf.protocol, info.ProtocolVersion)
@@ -52,4 +75,22 @@ func runInfo(ctx context.Context, args []string) error {
 		fmt.Printf("  slot %2d   status=%-10s online=%t\n", slot, si.Status, si.IsOnline)
 	}
 	return nil
+}
+
+// deviceInfoJSON / slotInfoJSON are the machine shape of `info`
+// (#751 G1c). Per-slot errors are carried, never swallowed.
+type deviceInfoJSON struct {
+	Device          string         `json:"device"`
+	Protocol        string         `json:"protocol"`
+	ProtocolVersion int            `json:"protocol_version"`
+	DtdVersion      string         `json:"dtd_version,omitempty"`
+	Slots           int            `json:"slots"`
+	SlotStatus      []slotInfoJSON `json:"slot_status"`
+}
+
+type slotInfoJSON struct {
+	Slot   int    `json:"slot"`
+	Status string `json:"status,omitempty"`
+	Online bool   `json:"online"`
+	Error  string `json:"error,omitempty"`
 }


### PR DESCRIPTION
## What

`--output json` on the tree-proto point reads — `get` and `info` — closing the G1 series (#751): every point-read verb on every connector now has machine output in one vocabulary.

## Why

#751 G1c. get: {slot, path/group/label/id, value, raw}; info: device identity + per-slot status with per-slot errors carried.

Closes #765

## Scope

- [x] acp1
- [x] acp2
- [x] emberplus
- [ ] probel-sw08p / probel-sw02p
- [ ] osc / tsl / cerebrum-nb / amwa
- [ ] transport
- [ ] export
- [x] cli
- [ ] api
- [ ] core
- [ ] ci / chore

**Cross-protocol changes**: cmd/dhs output layer only — the generic get/info verbs shared by the tree protos.

## Wire evidence (protocol changes only)

N/A — output formatting only.

## Reference controller

- [ ] Cerebrum still happy after this change
- [ ] VSM Studio still happy after this change
- [x] N/A (no protocol behaviour change)

## Type

- [x] feat — new feature
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] chore — maintenance, refactor, CI
- [ ] security — security fix or hardening

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `cmd/dhs/cmd_get.go` | modified | getValueJSON shape + wiring |
| `cmd/dhs/cmd_info.go` | modified | deviceInfoJSON/slotInfoJSON + wiring |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test ./...` | all | 0 |
| `go vet ./...` | clean | — |
| `golangci-lint run` | clean | — |

## Device tested

- [ ] ACP1 producer 10.100.0.102
- [ ] ACP2 producer 10.100.0.103
- [ ] ACP1 emulator 10.6.239.113
- [ ] ACP2 real device 10.41.40.195
- [x] Other (specify): Tier-4 loopback vs own ember+ provider on 127.0.0.1:9094
- [ ] No device needed (pure codec / doc change)

**Live-LXC command + observed output** (paste verbatim):

```text
dhs consumer emberplus info 127.0.0.1 --port 9094 --output json
{"device":"127.0.0.1:9094","protocol":"emberplus","protocol_version":1,"dtd_version":"2.60","slots":1,"slot_status":[{"slot":0,"status":"present","online":true}]}

dhs consumer emberplus get 127.0.0.1 --port 9094 --path "1.1.1" --dm "Tiny Ember+ Router@1.6.2" --output json
{"slot":0,"path":"1.1.1","value":"value = ?  (kind 0)"}
```

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [x] Integration tested on VM before PR (loopback; see Device tested)

## Approval

@yboujraf — requesting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)