### PR TITLE
feat(cli): --log-format syslog - RFC 5424 with full severity ladder (#751 G6)

### DIFF
--- a/cmd/dhs/cmd_producer.go
+++ b/cmd/dhs/cmd_producer.go
@@ -49,7 +49,7 @@ func runProducer(ctx context.Context, protoName string, args []string) error {
 		host          = fs.String("host", "0.0.0.0", "TCP/UDP listen host (alias: --bind)")
 		bind          = fs.String("bind", "", "alternate spelling of --host. e.g. --bind 10.6.239.200 binds the listener AND pins the broadcast source IP to the VIP, so multi-instance emulators on the same machine appear as distinct From: addresses to consumers (#263).")
 		logLevel      = fs.String("log-level", "info", "log level: debug, info, warn, error")
-		logFormat     = fs.String("log-format", "text", "log format: text | json (json for Loki/Promtail)")
+		logFormat     = fs.String("log-format", "text", "log format: text | json (Loki/Promtail) | syslog (RFC 5424 lines, severity mapped incl. critical — #751 G6)")
 		announceDemo  = fs.Bool("announce-demo", false, "oscillate a target value every --announce-demo-interval and broadcast announces (acp1/acp2 only)")
 		announceSlot  = fs.Int("announce-demo-slot", 1, "slot for --announce-demo target")
 		announceGroup = fs.Int("announce-demo-group", 2, "acp1: object group for --announce-demo target (2=Control)")
@@ -494,12 +494,18 @@ func newLogger(level, format string) *slog.Logger {
 		lvl = slog.LevelWarn
 	case "error":
 		lvl = slog.LevelError
+	case "critical":
+		lvl = LevelCritical
 	default:
 		lvl = slog.LevelInfo
 	}
 	opts := &slog.HandlerOptions{Level: lvl}
-	if format == "json" {
+	switch format {
+	case "json":
 		return slog.New(slog.NewJSONHandler(os.Stderr, opts))
+	case "syslog":
+		// RFC 5424 lines for rsyslog/syslog-ng/promtail (#751 G6).
+		return slog.New(newSyslogHandler(os.Stderr, lvl))
 	}
 	return slog.New(slog.NewTextHandler(os.Stderr, opts))
 }

--- a/cmd/dhs/syslog_handler.go
+++ b/cmd/dhs/syslog_handler.go
@@ -1,0 +1,122 @@
+package main
+
+// RFC 5424 syslog output for dhs logs (#751 G6). `--log-format syslog`
+// renders every slog record as one RFC 5424 line on stderr, ready for
+// rsyslog/syslog-ng ingestion or promtail's syslog scraper:
+//
+//	<PRI>1 TIMESTAMP HOSTNAME dhs PROCID - - msg key=val ...
+//
+// Severity mapping (RFC 5424 §6.2.1, facility local0=16):
+//
+//	slog DEBUG → 7 (debug)     slog WARN  → 4 (warning)
+//	slog INFO  → 6 (info)      slog ERROR → 3 (error)
+//	LevelCritical (ERROR+4)    → 2 (critical)
+//
+// Attributes are appended to MSG as key=val pairs (values quoted when
+// they contain spaces); STRUCTURED-DATA stays "-" — honest and
+// parseable without registering an IANA enterprise number.
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// LevelCritical is the severity above ERROR (RFC 5424 "critical").
+// Use logger.Log(ctx, LevelCritical, ...) for conditions that mean
+// the process cannot continue safely.
+const LevelCritical = slog.Level(12)
+
+const syslogFacility = 16 // local0
+
+// syslogSeverity maps a slog level to the RFC 5424 severity code.
+func syslogSeverity(l slog.Level) int {
+	switch {
+	case l >= LevelCritical:
+		return 2
+	case l >= slog.LevelError:
+		return 3
+	case l >= slog.LevelWarn:
+		return 4
+	case l >= slog.LevelInfo:
+		return 6
+	default:
+		return 7
+	}
+}
+
+type syslogHandler struct {
+	mu       *sync.Mutex
+	w        io.Writer
+	min      slog.Level
+	hostname string
+	pid      int
+	attrs    []slog.Attr
+	group    string
+}
+
+func newSyslogHandler(w io.Writer, min slog.Level) *syslogHandler {
+	host, err := os.Hostname()
+	if err != nil || host == "" {
+		host = "-"
+	}
+	return &syslogHandler{mu: &sync.Mutex{}, w: w, min: min, hostname: host, pid: os.Getpid()}
+}
+
+func (h *syslogHandler) Enabled(_ context.Context, l slog.Level) bool { return l >= h.min }
+
+func (h *syslogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	c := *h
+	c.attrs = append(append([]slog.Attr{}, h.attrs...), attrs...)
+	return &c
+}
+
+func (h *syslogHandler) WithGroup(name string) slog.Handler {
+	c := *h
+	if name != "" {
+		if c.group != "" {
+			c.group += "."
+		}
+		c.group += name
+	}
+	return &c
+}
+
+func syslogVal(v slog.Value) string {
+	s := v.String()
+	if strings.ContainsAny(s, " \t\"") {
+		return strconv.Quote(s)
+	}
+	return s
+}
+
+func (h *syslogHandler) Handle(_ context.Context, r slog.Record) error {
+	var b strings.Builder
+	pri := syslogFacility*8 + syslogSeverity(r.Level)
+	ts := "-"
+	if !r.Time.IsZero() {
+		ts = r.Time.UTC().Format("2006-01-02T15:04:05.000Z")
+	}
+	fmt.Fprintf(&b, "<%d>1 %s %s dhs %d - - %s", pri, ts, h.hostname, h.pid, r.Message)
+	prefix := ""
+	if h.group != "" {
+		prefix = h.group + "."
+	}
+	for _, a := range h.attrs {
+		fmt.Fprintf(&b, " %s%s=%s", prefix, a.Key, syslogVal(a.Value))
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		fmt.Fprintf(&b, " %s%s=%s", prefix, a.Key, syslogVal(a.Value))
+		return true
+	})
+	b.WriteByte('\n')
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	_, err := io.WriteString(h.w, b.String())
+	return err
+}

--- a/cmd/dhs/syslog_handler_test.go
+++ b/cmd/dhs/syslog_handler_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSyslogSeverityMapping pins the RFC 5424 §6.2.1 mapping incl.
+// the critical level (#751 G6).
+func TestSyslogSeverityMapping(t *testing.T) {
+	cases := []struct {
+		level slog.Level
+		want  int
+	}{
+		{slog.LevelDebug, 7},
+		{slog.LevelInfo, 6},
+		{slog.LevelWarn, 4},
+		{slog.LevelError, 3},
+		{LevelCritical, 2},
+		{LevelCritical + 4, 2},
+	}
+	for _, c := range cases {
+		if got := syslogSeverity(c.level); got != c.want {
+			t.Fatalf("severity(%v) = %d, want %d", c.level, got, c.want)
+		}
+	}
+}
+
+func TestSyslogHandler_LineShape(t *testing.T) {
+	var buf bytes.Buffer
+	h := newSyslogHandler(&buf, slog.LevelInfo)
+	logger := slog.New(h).With("proto", "acp2")
+
+	// Below-min level dropped.
+	logger.Debug("dropped")
+	if buf.Len() != 0 {
+		t.Fatalf("debug not filtered: %q", buf.String())
+	}
+
+	logger.Warn("session lost", "remote", "10.0.0.1:2072", "note", "two words")
+	line := strings.TrimSuffix(buf.String(), "\n")
+
+	// <PRI>1 TIMESTAMP HOST dhs PID - - MSG attrs...
+	re := regexp.MustCompile(`^<(\d+)>1 (\S+) (\S+) dhs (\d+) - - session lost proto=acp2 remote=10\.0\.0\.1:2072 note="two words"$`)
+	m := re.FindStringSubmatch(line)
+	if m == nil {
+		t.Fatalf("line does not match RFC 5424 shape:\n%s", line)
+	}
+	if m[1] != "132" { // local0(16)*8 + warning(4)
+		t.Fatalf("PRI = %s, want 132", m[1])
+	}
+	if _, err := time.Parse("2006-01-02T15:04:05.000Z", m[2]); err != nil {
+		t.Fatalf("timestamp %q: %v", m[2], err)
+	}
+
+	// Group prefixes flatten dotted.
+	buf.Reset()
+	g := slog.New(h.WithGroup("session"))
+	g.Log(context.Background(), LevelCritical, "wedged", "id", 7)
+	crit := buf.String()
+	if !strings.HasPrefix(crit, "<130>1 ") { // 16*8+2
+		t.Fatalf("critical PRI wrong: %q", crit)
+	}
+	if !strings.Contains(crit, "session.id=7") {
+		t.Fatalf("group prefix missing: %q", crit)
+	}
+}


### PR DESCRIPTION
## What

`--log-format syslog` on the producer: RFC 5424 lines with the full severity ladder (including a new critical level) — G6 of the verb-parity/hardening pass.

## Why

#751 G6, owner requirement: logs with severity (info/warning/error/critical) exported in syslog format for the Prometheus/Grafana/Loki stack. Severity per RFC 5424 §6.2.1, facility local0; promtail's syslog scraper or rsyslog can ingest stderr directly.

Closes #767

## Scope

- [ ] acp1
- [ ] acp2
- [ ] emberplus
- [ ] probel-sw08p / probel-sw02p
- [ ] osc / tsl / cerebrum-nb / amwa
- [ ] transport
- [ ] export
- [x] cli
- [ ] api
- [ ] core
- [ ] ci / chore

**Cross-protocol changes**: none — logger construction in cmd/dhs.

## Wire evidence (protocol changes only)

N/A — logging only.

## Reference controller

- [ ] Cerebrum still happy after this change
- [ ] VSM Studio still happy after this change
- [x] N/A (no protocol behaviour change)

## Type

- [x] feat — new feature
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] chore — maintenance, refactor, CI
- [ ] security — security fix or hardening

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `cmd/dhs/syslog_handler.go` | new | RFC 5424 slog.Handler + LevelCritical |
| `cmd/dhs/syslog_handler_test.go` | new | severity map + line-shape pins |
| `cmd/dhs/cmd_producer.go` | modified | format=syslog + level=critical |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test ./...` | all | 0 |
| `go vet ./...` | clean | — |
| `golangci-lint run` | clean | — |

## Device tested

- [ ] ACP1 producer 10.100.0.102
- [ ] ACP2 producer 10.100.0.103
- [ ] ACP1 emulator 10.6.239.113
- [ ] ACP2 real device 10.41.40.195
- [x] Other (specify): live producer on 127.0.0.1:2049 with --log-format syslog
- [ ] No device needed (pure codec / doc change)

**Live-LXC command + observed output** (paste verbatim):

```text
dhs producer probel-sw02p serve --tree ... --log-format syslog
<134>1 2026-08-22T14:11:57.348Z BY-DESK-03 dhs 29980 - - probel-sw02p provider listening addr=127.0.0.1:2049 matrices=1
(PRI 134 = local0*8 + info)
```

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [x] Integration tested on VM before PR (live producer stderr; see Device tested)

## Approval

@yboujraf — requesting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)