### PR TITLE
feat(ansible): generic dhs_verb role - JSON results + ADR-0007 assert (#751 G7)

### DIFF
--- a/ansible/playbooks/dhs-verb-examples.yml
+++ b/ansible/playbooks/dhs-verb-examples.yml
@@ -1,0 +1,69 @@
+---
+# dhs_verb example plays (#751 G7) — the patterns for driving ANY
+# consumer verb from Ansible with JSON results and ADR-0007 asserts.
+# Run from the Linux control node (docs/user.md); targets need the dhs
+# binary installed (dhs_acp1 / dhs_verbtest deploy it).
+#
+#   ansible-playbook -i inventory/hosts.yml playbooks/dhs-verb-examples.yml \
+#     -e device=10.100.0.104:2072
+#
+# Pattern 1 — point read, result as a fact:
+- name: Read one value (get, JSON parsed)
+  hosts: dhs_clients
+  gather_facts: true
+  tasks:
+    - name: acp2 get via dhs_verb
+      ansible.builtin.include_role:
+        name: dhs_verb
+      vars:
+        dv_proto: acp2
+        dv_argv: [get, "{{ device }}", --slot, "1", --id, "18"]
+
+    - name: Show the parsed value
+      ansible.builtin.debug:
+        msg: "value = {{ dv_result_json.value }}"
+
+# Pattern 2 — survey a router, JSON document:
+- name: Survey a SW-P-02 router (discover)
+  hosts: dhs_clients
+  gather_facts: true
+  tasks:
+    - name: discover via dhs_verb
+      ansible.builtin.include_role:
+        name: dhs_verb
+      vars:
+        dv_proto: probel-sw02p
+        dv_global_argv: [--dsts, "16"]
+        dv_argv: [discover, "{{ device }}"]
+
+    - name: Routed crosspoints
+      ansible.builtin.debug:
+        msg: "{{ dv_result_json.xpoints }}"
+
+# Pattern 3 — ensure-shaped write with the run-twice assert:
+- name: Converge one crosspoint idempotently (ADR-0007 assert)
+  hosts: dhs_clients
+  gather_facts: true
+  tasks:
+    - name: sw02p connect via dhs_verb (asserted idempotent)
+      ansible.builtin.include_role:
+        name: dhs_verb
+      vars:
+        dv_proto: probel-sw02p
+        dv_argv: [connect, "{{ device }}", --dst, "4", --src, "6"]
+        dv_ensure_assert: true
+
+# Pattern 4 — extract the router pack (export; file-set on the client,
+# meta.json included per #738):
+- name: Export the router pack
+  hosts: dhs_clients
+  gather_facts: true
+  tasks:
+    - name: export via dhs_verb (no JSON — export writes files)
+      ansible.builtin.include_role:
+        name: dhs_verb
+      vars:
+        dv_proto: probel-sw02p
+        dv_global_argv: [--dsts, "16"]
+        dv_argv: [export, "{{ device }}"]
+        dv_output_json: false

--- a/ansible/roles/dhs_verb/defaults/main.yml
+++ b/ansible/roles/dhs_verb/defaults/main.yml
@@ -1,0 +1,39 @@
+---
+# dhs_verb — run ONE dhs consumer verb against a REAL device or a
+# long-lived producer, from any managed host (#751 G7). This is the
+# ops-facing sibling of dhs_verbtest (which serves its own ephemeral
+# producer for CI): dhs_verb assumes the binary is installed
+# (dhs_acp1 / dhs_verbtest deploy it) and the target device is live.
+#
+# JSON is the default contract (--output json landed on every point
+# read + ensure-shaped write in #751 G1): the parsed result is
+# registered as dv_result_json for downstream tasks, and change
+# reporting comes from the verb's OWN {changed} field — Ansible's
+# changed status mirrors ADR-0007, not a guess.
+#
+# Binary paths come from inventory group_vars (linux.yml/windows.yml);
+# fallbacks mirror dhs_verbtest.
+dhs_bin: /usr/local/bin/dhs
+
+# ---- Role parameters ------------------------------------------------------
+# Protocol registry name (acp1, acp2, emberplus, probel-sw08p,
+# probel-sw02p, cerebrum-nb, tsl-v50, ...).
+dv_proto: ""
+
+# Global argv BEFORE the verb (dispatcher-level flags, e.g. probel's
+# --mtx-id/--level/--dsts or --capture FILE.jsonl).
+dv_global_argv: []
+
+# The verb and everything after it: target host[:port] + per-verb
+# flags, e.g. [get, "10.100.0.104:2072", --slot, "1", --path, "..."].
+dv_argv: []
+
+# Append `--output json` and parse stdout into dv_result_json.
+# Disable only for verbs without machine output (watch, tree ascii).
+dv_output_json: true
+
+# ADR-0007 idempotency assert: run the verb a SECOND time and fail
+# unless the second run reports changed=false / would_change=false.
+# Use on ensure-shaped writes (ensure, connect, import, replace,
+# protect-connect, ...). Requires dv_output_json.
+dv_ensure_assert: false

--- a/ansible/roles/dhs_verb/meta/main.yml
+++ b/ansible/roles/dhs_verb/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  role_name: dhs_verb
+  author: by-rune
+  description: >-
+    Run one dhs consumer verb against a live device from any managed
+    host, with JSON output parsed into a registered fact and an
+    optional ADR-0007 idempotency assertion (run-twice = changed
+    false). The ops-facing sibling of dhs_verbtest. Works on Linux
+    (SSH) and Windows (WinRM).
+  license: see repository
+  min_ansible_version: "2.14"
+  platforms:
+    - name: EL
+      versions: [all]
+    - name: Debian
+      versions: [all]
+    - name: Ubuntu
+      versions: [all]
+    - name: Windows
+      versions: [all]
+dependencies: []

--- a/ansible/roles/dhs_verb/tasks/main.yml
+++ b/ansible/roles/dhs_verb/tasks/main.yml
@@ -1,0 +1,53 @@
+---
+# One consumer verb, OS-dispatched. The full argv is assembled once so
+# both paths run the identical command.
+- name: Validate role parameters
+  ansible.builtin.assert:
+    that:
+      - dv_proto | length > 0
+      - dv_argv | length > 0
+      - not dv_ensure_assert or dv_output_json
+    fail_msg: >-
+      dhs_verb needs dv_proto + dv_argv; dv_ensure_assert requires
+      dv_output_json (the assert reads the ADR-0007 {changed} field).
+
+- name: Assemble the verb argv
+  ansible.builtin.set_fact:
+    dv_full_argv: >-
+      {{ [dhs_bin, 'consumer', dv_proto] + dv_global_argv + dv_argv
+         + (['--output', 'json'] if dv_output_json else []) }}
+
+- name: Run the verb (POSIX)
+  ansible.builtin.include_tasks: run_posix.yml
+  when: ansible_os_family != "Windows"
+
+- name: Run the verb (Windows)
+  ansible.builtin.include_tasks: run_windows.yml
+  when: ansible_os_family == "Windows"
+
+- name: Parse the JSON result
+  ansible.builtin.set_fact:
+    dv_result_json: "{{ dv_run.stdout | from_json }}"
+  when: dv_output_json
+
+# Ansible change status = the verb's OWN ADR-0007 verdict, never a
+# guess. Read-only verbs (no changed field) report unchanged.
+- name: Report change per the verb's ADR-0007 field
+  ansible.builtin.set_fact:
+    dv_changed: "{{ dv_output_json and (dv_result_json.changed | default(false)) }}"
+
+- name: Idempotency assert — second run must be a no-op (ADR-0007)
+  when: dv_ensure_assert
+  block:
+    - name: Re-run the verb
+      ansible.builtin.include_tasks: "{{ 'run_windows.yml' if ansible_os_family == 'Windows' else 'run_posix.yml' }}"
+
+    - name: Assert run-twice = 0
+      ansible.builtin.assert:
+        that:
+          - not ((dv_run.stdout | from_json).changed | default(false))
+          - not ((dv_run.stdout | from_json).would_change | default(false))
+        fail_msg: >-
+          {{ dv_proto }} {{ dv_argv | join(' ') }}: second run still
+          reports changes — the verb is NOT idempotent (ADR-0007
+          violation): {{ dv_run.stdout }}

--- a/ansible/roles/dhs_verb/tasks/run_posix.yml
+++ b/ansible/roles/dhs_verb/tasks/run_posix.yml
@@ -1,0 +1,7 @@
+---
+- name: "dhs consumer {{ dv_proto }} {{ dv_argv | join(' ') }}"
+  ansible.builtin.command:
+    argv: "{{ dv_full_argv }}"
+  register: dv_run
+  changed_when: false # real change status is set from the JSON verdict
+  failed_when: dv_run.rc != 0

--- a/ansible/roles/dhs_verb/tasks/run_windows.yml
+++ b/ansible/roles/dhs_verb/tasks/run_windows.yml
@@ -1,0 +1,7 @@
+---
+- name: "dhs consumer {{ dv_proto }} {{ dv_argv | join(' ') }}"
+  ansible.windows.win_command:
+    argv: "{{ dv_full_argv }}"
+  register: dv_run
+  changed_when: false # real change status is set from the JSON verdict
+  failed_when: dv_run.rc != 0


### PR DESCRIPTION
## What

Generic `dhs_verb` ansible role: any consumer verb, any protocol, from any managed host — JSON results parsed into a fact, change status taken from the verb's own ADR-0007 verdict, and an optional run-twice idempotency assert. Plus an example playbook with the four core patterns.

## Why

#751 G7 (owner mandate: "ansible role, playbook how to set get/set/extract any verbs"). Built on the #751 G1 JSON surface — this is why G1 came first.

Closes #771

## Scope

- [ ] acp1
- [ ] acp2
- [ ] emberplus
- [ ] probel-sw08p / probel-sw02p
- [ ] osc / tsl / cerebrum-nb / amwa
- [ ] transport
- [ ] export
- [ ] cli
- [ ] api
- [ ] core
- [x] ci / chore

**Cross-protocol changes**: ansible only — no Go code.

## Wire evidence (protocol changes only)

N/A — orchestration only.

## Reference controller

- [ ] Cerebrum still happy after this change
- [ ] VSM Studio still happy after this change
- [x] N/A (no protocol behaviour change)

## Type

- [x] feat — new feature
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] chore — maintenance, refactor, CI
- [ ] security — security fix or hardening

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `ansible/roles/dhs_verb/**` | new | role: defaults, meta, OS-dispatched tasks, JSON parse, ADR-0007 assert |
| `ansible/playbooks/dhs-verb-examples.yml` | new | 4 patterns: read→fact, survey, asserted converge, pack export |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| YAML parse (all role + playbook files) | 6/6 | 0 |
| `go test ./...` | unaffected | — |

## Device tested

- [ ] ACP1 producer 10.100.0.102
- [ ] ACP2 producer 10.100.0.103
- [ ] ACP1 emulator 10.6.239.113
- [ ] ACP2 real device 10.41.40.195
- [ ] Other (specify)
- [x] No device needed (pure codec / doc change) — orchestration; first live run from the .103 control node on the next fleet session (per docs/user.md ansible runs never execute from this Windows box)

**Live-LXC command + observed output** (paste verbatim):

```text
ansible-playbook -i inventory/hosts.yml playbooks/dhs-verb-examples.yml -e device=<ip:port>
(pending .103 session — role mirrors the proven dhs_verbtest conventions verbatim)
```

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [ ] Integration tested on VM before PR (pending first .103 run; YAML-validated)

## Approval

@yboujraf — requesting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)