### PR TITLE
docs(ccm): protocol skeleton - spec drop zone + review checklist (#706)

### DIFF
--- a/internal/ccm/CLAUDE.md
+++ b/internal/ccm/CLAUDE.md
@@ -1,0 +1,58 @@
+# CLAUDE.md — CCM (EVS Neuron REST API)
+
+Atomic per-protocol context for the CCM connector — the REST API EVS
+positions as the acp2 successor on Neuron (#706). Read the root
+`CLAUDE.md` first.
+
+**STATUS: SPEC-COLLECTION PHASE — no code lands in this tree until
+the spec review below is done and the owner gives the build go
+(design-first rule).** The acp2 connector stays regardless: the fleet
+is mixed-firmware.
+
+---
+
+## Folder layout (target shape, per root CLAUDE.md conventions)
+
+```
+internal/ccm/
+├── CLAUDE.md    ← this file
+├── assets/      ← DROP ZONE: everything EVS provides goes here
+│                  (OpenAPI/swagger JSON, PDFs, examples, postman
+│                  collections, firmware release notes)
+├── docs/        keys/endpoint catalogue + consumer.md (written
+│                  during spec review)
+├── codec/       (later) stdlib-only — likely thin: HTTP+JSON, the
+│                  "codec" is the OpenAPI schema types
+├── consumer/    (later) package ccm — implements consumer.Protocol
+└── wireshark/   (later) dhs_ccm.lua — HTTP/JSON dissection with
+                   per-endpoint Info columns (repo rule: every
+                   protocol ships a dissector, no exceptions)
+```
+
+## Spec sources (fill as they arrive)
+
+| Artifact | Where | Status |
+|---|---|---|
+| Live swagger from the on-site Neuron (`GET /swagger.json` or similar) | `assets/` | PENDING — day-1 capture when the device arrives (week of 2026-08-24) |
+| EVS-provided docs | `assets/` | PENDING — owner storing them here |
+
+## Review checklist (run when assets land)
+
+1. OpenAPI version + auth model (basic? token? none?) — feeds the
+   OAS tooling choice shared with dhs-srv.
+2. Endpoint → verb mapping: which canonical verbs (info/walk/get/
+   set/ensure/export/watch) the REST surface can back, and what the
+   subscription story is (polling? SSE? websocket?) — no-polling rule
+   applies if the wire allows better.
+3. Object model vs the acp2 tree: can CCM serve the SAME canonical
+   tree (label paths, DM identity Model@SwRev) so DMs/manifests/packs
+   stay protocol-agnostic? That is the acceptance bar.
+4. Parity matrix CCM↔acp2 per object: what disappears, what's new —
+   becomes the migration note for mixed fleets.
+5. Rate limits / concurrency — scale targets in root CLAUDE.md apply.
+
+## What NOT to do
+
+- No code before the checklist verdict + owner go.
+- Never delete or bypass the acp2 connector — mixed-firmware fleets
+  keep both.

--- a/internal/ccm/assets/EVS CCM Protocol Description 0v1.pdf
+++ b/internal/ccm/assets/EVS CCM Protocol Description 0v1.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ba945ec8b7381f45773614113dbc921e1988c2dbb7ee9e0fc19ed2829f2a936
+size 1324339

--- a/internal/ccm/assets/README.md
+++ b/internal/ccm/assets/README.md
@@ -1,0 +1,12 @@
+# CCM assets — drop zone
+
+Put everything EVS provides about the Neuron REST API (CCM) here:
+OpenAPI/swagger JSON, PDFs, Postman collections, examples, firmware
+notes. Large binaries: mind the LFS quota — prefer text (JSON/YAML)
+originals.
+
+Naming: keep EVS's original filenames, prefix with a date when
+versions collide (e.g. `2026-08-25_neuron-ccm-openapi.json`).
+
+The spec review checklist lives in ../CLAUDE.md — it runs as soon as
+the first artifact lands here.

--- a/internal/ccm/docs/README.md
+++ b/internal/ccm/docs/README.md
@@ -1,0 +1,10 @@
+# CCM docs
+
+Written during the spec review (see ../CLAUDE.md checklist):
+
+- `keys.md` — endpoint/field catalogue extracted from the OpenAPI
+  spec (fact-only, names verbatim — same discipline as
+  cerebrum-nb/docs/keys.md)
+- `consumer.md` — CLI walkthrough once the connector exists
+- `acp2-parity.md` — per-object CCM↔acp2 matrix (the migration note
+  for mixed-firmware fleets)

--- a/internal/ccm/docs/spec-review-0v1.md
+++ b/internal/ccm/docs/spec-review-0v1.md
@@ -1,0 +1,80 @@
+# CCM spec review — Protocol Description 0v1 (EVS, June 2026)
+
+Reviewed 2026-08-22 against the checklist in ../CLAUDE.md. Source:
+`assets/EVS CCM Protocol Description 0v1.pdf` (24 pp, Ian Hollamby).
+
+**Verdict: STRONG FIT. Every dhs canonical verb has a natural CCM
+backing, the no-polling doctrine is EVS's own (§13.3), and the stack
+aligns with our dhs-srv standards choice (OAS 3.1 + problem details +
+WS). One blocking spec gap: the matrix WRITE operation is not
+defined. Build estimate: medium — heavy reuse of existing dhs parts.**
+
+## 1. Transport, spec, auth
+
+| Aspect | CCM 0v1 | dhs consequence |
+|---|---|---|
+| Spec | OpenAPI **3.1.x**, served at `/api/docs/openapi.yml`, downloadable unauthenticated | same OAS tooling as dhs-srv; day-1 capture = this file |
+| Transport | HTTPS default (http lab-only), port 443 default | TLS client + `--insecure`/custom-CA flags; http mode for tshark captures |
+| Auth | JWT Bearer (§23, PROPOSAL): `/api/auth/login|refresh|change-password`; refresh-on-401 | token manager in the session layer; creds via .secrets like cerebrum |
+| Errors | §12 `GenericApiMessage{code,message}` for mutations; §23.6 RFC 7807 problem details for auth | TWO error shapes — EVS Q3 below |
+| JSON | camelCase, human-readable enums, ISO 8601/epoch datetimes, spinal-case URIs | canonicalization layer maps to our vocabulary |
+
+## 2. Canonical verb mapping (the acceptance bar — MET)
+
+| dhs verb | CCM backing |
+|---|---|
+| `info` | `GET /api/self` — productName/productVersion/apiVersion/components → **DM identity = productName@productVersion**, slots ≈ components |
+| `walk` | §4.4 recursive partial-path discovery: every `{id}` segment GETs as an id array, recursively → a GENERIC schema-free tree walk; every uuid object MUST carry `name` → names-not-ids natively |
+| `get` | `GET` resource (1:1 with subscribable payloads) |
+| `set` / `ensure` | `PATCH` (MANDATORY per §11.2, maps not arrays) → **202 async** + split request/status (§11.3): converge confirmation = read-back or subscription, not the HTTP reply. ADR-0007 fits; the check loop just moves after the 202 |
+| `watch` | WS `/ws`: CreateSubscription (wildcard `*` per path param), initial FULL state as one JSON Patch `replace ""` event **sent before the subscription response** (§13.3.8), then incremental RFC 6902 patches; dedup not guaranteed; reconnect ⇒ discard cache + resubscribe |
+| `matrix` / `usage` / `replace` | §17: `GET /matrix/{id}/info` (MatrixInfo: sources/destinations as path refs or inline MatrixEntry; per-channel slot uuids; `slot_type` for mixed essences; **named levels** with read/write flags e.g. current(ro)/main/backup) + `GET /matrix/{id}/state` (dst-uuid → src-uuid map; multi-level extended form). usage = invert the state map; levels column carries level NAMES (our grammar already stores levels as strings) |
+| `export` (router pack) | descriptor from info (state map ⇒ behavior 1toN), xpoint.csv `dest,srce,levels` with uuids, src/dst.csv from mandatory `name`s |
+| `discover` | `GET /api` root domains + `/api/self` + matrix enumeration |
+
+## 3. Reuse map (why the build is medium, not large)
+
+| Existing dhs part | Reused for |
+|---|---|
+| `internal/cerebrum-nb/codec/ws` (stdlib RFC 6455 client, lift-ready) | the `/ws` backchannel |
+| ensure/ADR-0007 framework, run-twice asserts | PATCH converge + post-202 confirm |
+| canonical tree + DM/manifest (ADR-0022) | identity + resource tree snapshot |
+| router pack grammar + usage/replace helpers (#722/#738/#746) | matrix legs |
+| compliance.Profile | absorbing spec Qs/deviations |
+| New codec pieces | JSON Patch applier (RFC 6902) + JSON Pointer (6901), WS message types, OpenAPI doc loader — all stdlib JSON |
+
+Wireshark: `dhs_ccm.lua` dissects HTTP+JSON and WS frames; TLS
+captures need lab http mode or SSLKEYLOGFILE — noted for the runbook.
+
+## 4. Questions for EVS (spec gaps found)
+
+1. **BLOCKING: how is a route SET?** §17 defines only GET info/state.
+   Implied `PATCH /matrix/{id}/state` with `{dstUuid: srcUuid}` (fits
+   §11.2 maps-not-arrays) — confirm verb, body shape, and per-level
+   addressing (extended-form PATCH vs `/state/main`? — their own open
+   Q in §17.2).
+2. Matrix salvos / locks / protects — absent; planned components or
+   out of scope?
+3. Which error schema governs non-auth mutations — §12
+   GenericApiMessage or RFC 7807 (§23.6)? (Recommend 7807/9457
+   everywhere — matches their own auth section.)
+4. §5.2 IO endpoint minimum expectations — "Paul to specify" (open in
+   their doc).
+5. §8 by-name alias routes (`/senders/by-name/...`) — their own open Q;
+   we'd consume it gladly (names-first UX).
+6. Auth §23 is PROPOSAL — confirm the on-site Neuron firmware's actual
+   state (and whether lab http is enabled on it).
+7. Rate limiting per subscription "future" (§13.3.2) — any current
+   server-side caps we should respect?
+
+## 5. Day-1 plan when the on-site Neuron arrives
+
+1. `GET /api/docs/openapi.yml` → commit to assets/ (the live spec
+   artifact, #706's unpark trigger).
+2. Root discovery + `/self` + full recursive walk capture (http lab
+   mode if available, else SSLKEYLOGFILE) → `dhs_ccm.lua` first cut
+   from real frames.
+3. Subscribe wildcard on one resource class; capture initial-state +
+   patch flow.
+4. Diff the real endpoint surface against this review; update the
+   EVS question list; then owner decides the build go (#706).


### PR DESCRIPTION
## What

Opens the CCM connector tree (`internal/ccm/`) in its spec-collection phase: CLAUDE.md with the target layout + the review checklist, `assets/` as the drop zone for everything EVS provides, `docs/` naming the artifacts the review will produce.

## Why

Owner request (2026-08-22): a place to store the CCM (EVS Neuron REST) protocol material so the spec review can produce "the best view to easily support it". Unparks the collection phase of #706; the on-site Neuron's live swagger joins `assets/` on day 1. No code until the checklist verdict + owner go (design-first). acp2 stays — mixed-firmware fleets keep both.

Refs #706

## Scope

- [ ] acp1
- [x] acp2
- [ ] emberplus
- [ ] probel-sw08p / probel-sw02p
- [ ] osc / tsl / cerebrum-nb / amwa
- [ ] transport
- [ ] export
- [ ] cli
- [ ] api
- [ ] core
- [x] ci / chore

**Cross-protocol changes**: docs-only new tree; no code, no imports.

## Wire evidence (protocol changes only)

N/A — documentation skeleton.

## Reference controller

- [ ] Cerebrum still happy after this change
- [ ] VSM Studio still happy after this change
- [x] N/A (no protocol behaviour change)

## Type

- [ ] feat — new feature
- [ ] fix — bug fix
- [x] docs — documentation only
- [ ] chore — maintenance, refactor, CI
- [ ] security — security fix or hardening

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `internal/ccm/CLAUDE.md` | new | phase gate + layout + review checklist |
| `internal/ccm/assets/README.md` | new | drop-zone conventions |
| `internal/ccm/docs/README.md` | new | planned artifacts (keys.md, acp2-parity.md) |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test ./...` | unaffected (no code) | — |

## Device tested

- [ ] ACP1 producer 10.100.0.102
- [ ] ACP2 producer 10.100.0.103
- [ ] ACP1 emulator 10.6.239.113
- [ ] ACP2 real device 10.41.40.195
- [ ] Other (specify)
- [x] No device needed (pure codec / doc change)

**Live-LXC command + observed output** (paste verbatim):

```text
N/A — docs only.
```

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [ ] Integration tested on VM before PR (N/A — docs)

## Approval

@yboujraf — requesting review

🤖 Generated with [Claude Code](https://claude.com/claude-code)