### PR TITLE
infra(fleet): inventory truth from Proxmox - real hosts, SSH for win11, testbed.md + PR template (#781)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -59,11 +59,9 @@ Closes #
 
 ## Device tested
 
-- [ ] ACP1 producer 10.100.0.102
-- [ ] ACP2 producer 10.100.0.103
-- [ ] ACP1 emulator 10.6.239.113
-- [ ] ACP2 real device 10.41.40.195
-- [ ] Other (specify)
+- [ ] Fleet producer — which host per `docs/testbed.md` (dhs-ubuntu .102 / dhs-debian .103 / dhs-rocky .105 / win11 .107)
+- [ ] Vendor emulator — Synapse ACP1 (office net 10.6.239.113) / TinyEmber+ (desk-03) / AMWA NMOS Testing tool (dhs-tools .106)
+- [ ] Real device — Neuron (ACP2 / CCM) / Cerebrum staging (.5) / other (specify)
 - [ ] No device needed (pure codec / doc change)
 
 **Live-LXC command + observed output** (paste verbatim):

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -4,7 +4,8 @@ Idempotent ACP1 device configuration by wrapping the `dhs` CLI `ensure` verb in
 an Ansible role. The same role runs on **Linux (SSH)** and **Windows (WinRM)**
 clients, so you prove the multi-OS `dhs` binary (ADR-0016) and the `ensure`
 idempotency contract behave identically on every platform in the Proxmox lab
-(lxc-debian / lxc-ubuntu / lxc-rocky / win11).
+(dhs-debian / dhs-ubuntu / dhs-rocky / dhs-tools / win11 — see
+`docs/testbed.md`; every play runs from the control node dhs-debian).
 
 This is the **authoritative idempotency layer**. The PowerShell scripts under
 `scripts/acp1/` are the fast smoke layer; here a real `ansible-playbook` run

--- a/ansible/inventory/group_vars/windows.yml
+++ b/ansible/inventory/group_vars/windows.yml
@@ -1,17 +1,19 @@
 ---
-# Windows clients (win11, winsrv) — reached over WinRM (Linux/macOS use SSH).
-# Requires the ansible.windows collection + pywinrm on the control node
-# (Debian/Ubuntu: `apt-get install python3-winrm`).
-ansible_connection: winrm
-# Auth (user `by-rune`, NOT Administrator) comes from the gitignored secrets
-# file, loaded at runtime so nothing secret hits git or shell history:
-#   ansible-playbook -i inventory/win.ini playbooks/site.yml -e @secrets/credentials.json
-# Same JSON structure migrates into ansible-vault later (see secrets/README.md).
-ansible_user: "{{ creds[inventory_hostname].ansible_user | default('by-rune') }}"
-ansible_password: "{{ creds[inventory_hostname].ansible_password | default('') }}"
-ansible_winrm_transport: ntlm
-ansible_winrm_server_cert_validation: ignore
-ansible_port: 5985
+# Windows clients (win11) — reached over SSH with key auth, exactly like the
+# Linux hosts (one actor-key model, #782). The WinRM/NTLM path
+# (windows/configure-winrm.ps1 + a password file) is retired: pywinrm is not
+# on the control node, the credentials file no longer exists, and OpenSSH
+# Server is installed + running on the VM.
+#
+# `by-rune` is in the local Administrators group, so sshd reads its keys
+# from C:\ProgramData\ssh\administrators_authorized_keys (NOT the profile
+# authorized_keys) — the dhs_access role manages that file.
+ansible_connection: ssh
+ansible_user: by-rune
+# sshd DefaultShell on the VM is cmd.exe today; dhs_access switches it to
+# PowerShell and flips this to `powershell` in the same change.
+ansible_shell_type: cmd
+ansible_become: false
 
 # Where the dhs binary is installed on the target and which local artifact to
 # deploy. Build it from the repo root before running:

--- a/ansible/inventory/host_vars/dhs-debian.yml
+++ b/ansible/inventory/host_vars/dhs-debian.yml
@@ -1,0 +1,19 @@
+---
+# dhs-debian — Proxmox LXC 651 "dhs.debian12", Debian 12 (bookworm).
+# Dual-NIC: eth0 10.100.0.103 (ansible_host) / eth1 10.100.0.108.
+# Roles: Ansible CONTROL NODE for the whole fleet; Docker host.
+# Never bring eth1/.108 down — it is part of the access path.
+# This host IS the control node: run local, no SSH loop-back needed.
+ansible_connection: local
+
+pve_vmid: 651
+pve_name: dhs.debian12
+os_label: "Debian 12"
+nics:
+  - { name: eth0, mac: "BC:24:11:80:E3:AC", ip: 10.100.0.103 }
+  - { name: eth1, mac: "BC:24:11:91:97:7C", ip: 10.100.0.108 }
+fleet_hostname: dhs-debian
+
+# Ember+ producer: our integration DM — the synthetic tree that carries the
+# n-to-n matrix plus the salvo/lock/protect builtin functions.
+ember_tree_src: "{{ playbook_dir }}/../files/trees/our-dm.tree.json"

--- a/ansible/inventory/host_vars/dhs-rocky.yml
+++ b/ansible/inventory/host_vars/dhs-rocky.yml
@@ -1,0 +1,15 @@
+---
+# dhs-rocky — Proxmox LXC 653 "dhs.rocky9", Rocky Linux 9.4.
+# Dual-NIC: eth0 10.100.0.105 (ansible_host) / eth1 10.100.0.104.
+# (.104 and .105 are the SAME host — older docs listed them as two.)
+pve_vmid: 653
+pve_name: dhs.rocky9
+os_label: "Rocky 9.4"
+nics:
+  - { name: eth0, mac: "BC:24:11:2B:F7:C7", ip: 10.100.0.105 }
+  - { name: eth1, mac: "BC:24:11:33:74:4A", ip: 10.100.0.104 }
+fleet_hostname: dhs-rocky
+
+# Ember+ producer: the Lawo PowerCore tree (1024-target matrix), rebuilt from
+# the committed real-device capture (internal/emberplus/testdata/fixtures/powercore).
+ember_tree_src: "{{ playbook_dir }}/../files/trees/powercore.tree.json"

--- a/ansible/inventory/host_vars/dhs-tools.yml
+++ b/ansible/inventory/host_vars/dhs-tools.yml
@@ -1,0 +1,11 @@
+---
+# dhs-tools — Proxmox LXC 655 "dhs.tools", Ubuntu, single NIC 10.100.0.106.
+# Tooling host: Docker + the AMWA NMOS Testing tool (scripts/amwa/*),
+# tshark / Wireshark dissector validation. Not a dhs producer host by
+# default (no ember_tree_src).
+pve_vmid: 655
+pve_name: dhs.tools
+os_label: "Ubuntu"
+nics:
+  - { name: eth0, mac: "BC:24:11:C1:92:FF", ip: 10.100.0.106 }
+fleet_hostname: dhs-tools

--- a/ansible/inventory/host_vars/dhs-ubuntu.yml
+++ b/ansible/inventory/host_vars/dhs-ubuntu.yml
@@ -1,0 +1,14 @@
+---
+# dhs-ubuntu — Proxmox LXC 652 "dhs.ubuntu24", Ubuntu 24.04 LTS.
+# Dual-NIC: eth0 10.100.0.102 (ansible_host) / eth1 10.100.0.101.
+pve_vmid: 652
+pve_name: dhs.ubuntu24
+os_label: "Ubuntu 24.04"
+nics:
+  - { name: eth0, mac: "BC:24:11:28:78:25", ip: 10.100.0.102 }
+  - { name: eth1, mac: "BC:24:11:B2:50:A5", ip: 10.100.0.101 }
+fleet_hostname: dhs-ubuntu
+
+# Ember+ producer: the DHD audio console tree, rebuilt from the committed
+# real-device capture (internal/emberplus/testdata/fixtures/dhd).
+ember_tree_src: "{{ playbook_dir }}/../files/trees/dhd.tree.json"

--- a/ansible/inventory/host_vars/win11.yml
+++ b/ansible/inventory/host_vars/win11.yml
@@ -1,0 +1,14 @@
+---
+# win11 — Proxmox VM 654 "dhs.win11", Windows 11 Pro (10.0.26200),
+# guest hostname DHS_WIN11, single NIC 10.100.0.107 (NOT .106 — that is
+# dhs-tools). Windows producer-parity row (ADR-0016), reached over SSH
+# as `by-rune` (local Administrators group).
+pve_vmid: 654
+pve_name: dhs.win11
+os_label: "Windows 11 Pro"
+nics:
+  - { name: "Ethernet 2", mac: "BC:24:11:10:AE:F8", ip: 10.100.0.107 }
+fleet_hostname: dhs-win11
+
+# Ember+ producer: our integration DM (matrix + salvo/lock functions).
+ember_tree_src: "{{ playbook_dir }}/../files/trees/our-dm.tree.json"

--- a/ansible/inventory/hosts.ini
+++ b/ansible/inventory/hosts.ini
@@ -1,26 +1,31 @@
-# dhs multi-OS client matrix (Proxmox lab).
+# dhs test fleet — Proxmox pve01 (10.6.224.5), bridge vmbrAPPS, VLAN 100
+# (10.100.0.0/24, gateway pfSense 10.100.0.1). Source of truth for names,
+# MACs and IPs is the Proxmox config (vmid per host_vars); docs/testbed.md
+# is rendered from the same facts. Every guest is DHCP today — addresses
+# are pinned by pfSense static mappings (MAC -> IP), see #786.
 #
-# Each host runs the dhs binary FOR ITS OS and converges the same ACP1 device,
-# proving the binary + the `ensure` idempotency contract behave identically on
-# every platform (ADR-0016 multi-OS). Linux LXC are reached over SSH; the
-# Windows VM over WinRM. Fill in the ansible_host IPs for your lab.
-#
-# The ACP1 device every client talks to is set by `dhs_device` in
-# group_vars/all.yml (the Synapse emulator or a real Axon rack - the oracle,
-# never our own provider).
+# Linux LXC are reached over SSH as root; the Windows VM over SSH as the
+# local admin-group user `by-rune` (key auth, no password file — #782).
+# Control node = dhs-debian (.103), see docs/testbed.md "Control node".
 
 [linux]
-lxc-debian ansible_host=10.0.0.11
-lxc-ubuntu ansible_host=10.0.0.12
-lxc-rocky  ansible_host=10.0.0.13
+dhs-debian  ansible_host=10.100.0.103
+dhs-ubuntu  ansible_host=10.100.0.102
+dhs-rocky   ansible_host=10.100.0.105
+dhs-tools   ansible_host=10.100.0.106
 
-# Any Windows host (Windows 11 or Windows Server) goes here. Run
-# windows/configure-winrm.ps1 once on each before the first playbook run.
 [windows]
-win11  ansible_host=10.0.0.21
-# winsrv ansible_host=10.0.0.22
+win11       ansible_host=10.100.0.107
 
-# Convenience group the playbook targets.
+# Ansible control node (runs every play; never PowerShell drivers).
+[control]
+dhs-debian
+
+# Hosts that run vendor tooling (AMWA NMOS Testing tool in Docker).
+[tooling]
+dhs-tools
+
+# dhs binary hosts: producers + consumer verbs per OS (ADR-0016 matrix).
 [dhs_clients:children]
 linux
 windows

--- a/docs/testbed.md
+++ b/docs/testbed.md
@@ -1,25 +1,38 @@
-# docs/testbed.md — Test fleet inventory and SSH access mesh
+# docs/testbed.md — Test fleet inventory and access
 
 Tracked, repo-local source of truth for the test fleet on the DMZ VLAN
-(`10.100.0.0/24`, routed via pfSense).
+(`10.100.0.0/24`, VLAN 100 on Proxmox bridge `vmbrAPPS`, gateway
+pfSense `10.100.0.1`). The facts below were re-verified against the
+Proxmox API (pve01, `10.6.224.5`) and the live guests on 2026-08-23;
+the Ansible inventory (`ansible/inventory/`) carries the SAME facts per
+host (`pve_vmid`, `nics`, `os_label`) — when one changes, both change
+in the same PR (epic #780).
 
 ## Fleet
 
-| Hostname | IP | Role | OS | Notes |
-| --- | --- | --- | --- | --- |
-| `dhs-debian` | `10.100.0.102` | dhs producer host | Debian 12 | OS-compat row, all four producers concurrently |
-| `dhs-ubuntu` | `10.100.0.103` | dhs producer host + Ansible controller | Ubuntu 24.04 | Current ACP2 reconnect/keepalive test target |
-| `dhs-rocky` | `10.100.0.104` | dhs producer host | Rocky 9.4 | OS-compat row |
-| `dhs-tools` | `10.100.0.105` | tooling host | Ubuntu 24.04 | Docker, AMWA NMOS Testing tool, tshark, Wireshark dissector validator |
-| `dhs-win11` | `10.100.0.106` | Windows producer host | Windows 11 Pro | Multi-OS matrix per ADR-0016; producer parity check for the Windows row |
-| `cerebrum` | `10.100.0.5` | external reference peer | (vendor appliance) | NMOS Registry + Node — not part of the test fleet, used as a real-peer integration target |
+| Inventory name | Proxmox | Guest OS | eth0 (`ansible_host`) | eth1 | Role |
+| --- | --- | --- | --- | --- | --- |
+| `dhs-debian` | LXC 651 `dhs.debian12` | Debian 12 | `10.100.0.103` | `10.100.0.108` | **Ansible control node**; dhs producer host; Docker |
+| `dhs-ubuntu` | LXC 652 `dhs.ubuntu24` | Ubuntu 24.04 | `10.100.0.102` | `10.100.0.101` | dhs producer host |
+| `dhs-rocky` | LXC 653 `dhs.rocky9` | Rocky 9.4 | `10.100.0.105` | `10.100.0.104` | dhs producer host (`.104` and `.105` are ONE host) |
+| `dhs-tools` | LXC 655 `dhs.tools` | Ubuntu | `10.100.0.106` | — | tooling: Docker, AMWA NMOS Testing tool (`scripts/amwa/`), tshark |
+| `win11` | VM 654 `dhs.win11` | Windows 11 Pro | `10.100.0.107` | — | Windows producer-parity row (ADR-0016); guest name `DHS_WIN11` |
+| `cerebrum` | VM 601 `vm-cerebrum-stg-01` | Windows 11 | `10.100.0.5` | — | external reference peer (EVS Cerebrum staging) — real-peer integration target, not part of the converge set |
 
-The three `dhs-*` Linux producer hosts validate the OS-compat axis from
-ADR-0016 without requiring vendor hardware. `dhs-tools` hosts the AMWA
-Testing tool peer + isolated Docker bridge. `dhs-win11` covers the
-Windows producer parity row required by ADR-0016.
+All LXCs are unprivileged with `nesting=1`. MAC addresses per NIC live
+in `ansible/inventory/host_vars/<name>.yml` (`nics:`).
 
-## Producer port plan (every Linux LXC + dhs-win11)
+Addressing: every guest is configured `ip=dhcp` in Proxmox; addresses
+are pinned as **pfSense static DHCP mappings keyed by MAC** (#786) so a
+rebuilt guest keeps its address with zero guest-side configuration.
+`ansible/playbooks/fleet-verify.yml` asserts live IP == inventory IP per
+NIC and fails loudly on drift.
+
+Guest hostnames are being made unique (`dhs-debian`, `dhs-ubuntu`,
+`dhs-rocky`, `dhs-tools`, `dhs-win11` = `fleet_hostname`, #783);
+today three LXCs still answer `dhs`, which collides in Avahi.
+
+## Producer port plan (every Linux LXC + win11)
 
 | Connector | Wire | Port |
 | --- | --- | --- |
@@ -27,66 +40,59 @@ Windows producer parity row required by ADR-0016.
 | ACP2 | TCP (AN2) | `2072` |
 | Ember+ | TCP (S101) | `9000` |
 | Probel SW-P-08 | TCP (DLE) | `2008` |
+| Probel SW-P-02 | TCP | `2002` |
 | AMWA NMOS Node | HTTP | `18080` |
+| mDNS (Avahi / Bonjour) | UDP | `5353` |
+| metrics (`--metrics-addr`) | HTTP | `9100` |
+| SSH / WinRM (mgmt) | TCP | `22` / `5985` |
 
 All producers run concurrently on the same host; one port per
 connector. The same producer binary is driven by `dhs consumer` and by
-external peers (Cerebrum @ `.5`, AMWA Testing tool in Docker on `.105`)
-so wire behaviour can be compared across drivers.
+external peers (Cerebrum @ `.5`, AMWA Testing tool in Docker on
+`dhs-tools` `.106`) so wire behaviour can be compared across drivers.
+Host firewalls are managed by the `dhs_firewall` role (#785).
 
-## SSH access mesh
+## Control node
 
-The agent (Claude, git author `by-rune`) needs passwordless SSH to and
-from every node in the fleet so it can launch / restart / probe
-producers from any host.
+`dhs-debian` (`.103`) runs every Ansible play — Linux hosts over SSH as
+`root`, the Windows VM over SSH as `by-rune` (key auth; WinRM/NTLM +
+password file is retired). It holds a clone of this (public) repo at
+`~/acp` and its own ed25519 key (`root@dhs`), which is one of the three
+fleet actor keys below. Never drive the fleet from a Windows
+workstation (PowerShell) — see ADR-0025 step 5.
 
-### Key material
+## Access — actor keys, not per-host keys
 
-- Single ed25519 keypair, no passphrase: `id_dhs_testbed` (private),
-  `id_dhs_testbed.pub` (public).
-- Generated once on `BY-DESK-03`, then distributed to every node so the
-  same `~/.ssh/id_dhs_testbed` exists on every Linux LXC and on the
-  Windows host. This makes the mesh symmetric — any node can SSH any
-  other node with the same key.
-- The agent shell on `BY-DESK-03` continues to use the existing key
-  `~/.ssh/by-rune_lxc` for outbound SSH (already present and working).
-  The new `id_dhs_testbed` mesh is for fleet-internal SSH and replaces
-  the desk-03-only path.
+Exactly three ed25519 identities are authorized on every host, managed
+by the `dhs_access` role (#782); anything else is removed:
 
-### Account
+| Actor | Key comment | Purpose |
+| --- | --- | --- |
+| by-rune (agent, desk-03) | `by-rune-dhs-lxc` | agent SSH to every host |
+| control node `.103` | `root@dhs` | Ansible → fleet |
+| codeowner | (owner's ed25519) | direct SSH |
 
-Login user is `root` on every Linux LXC (the `by-rune` user is
-rejected by sshd config on the LXCs; only `root` accepts the key —
-verified 2026-05-10). On `dhs-win11` the equivalent is the local
-Administrator user with OpenSSH server enabled.
+Linux: `/root/.ssh/authorized_keys` (login user is `root`; `by-rune` is
+rejected by sshd on the LXCs). Windows: `by-rune` is in the local
+Administrators group, so sshd reads
+`C:\ProgramData\ssh\administrators_authorized_keys` (strict ACL:
+SYSTEM + Administrators only) — the per-profile `authorized_keys` is
+ignored for admin users, which is why earlier key installs "did
+nothing". No GPG keys and no per-host keypairs are generated (commit
+signing belongs to the parked hardening topic).
 
-### Authorised destinations (mesh)
+## mDNS daemons
 
-| Source → | dhs-debian | dhs-ubuntu | dhs-rocky | dhs-tools | dhs-win11 | desk-03 |
-| --- | --- | --- | --- | --- | --- | --- |
-| dhs-debian | self | yes | yes | yes | yes | (pull only) |
-| dhs-ubuntu | yes | self | yes | yes | yes | (pull only) |
-| dhs-rocky | yes | yes | self | yes | yes | (pull only) |
-| dhs-tools | yes | yes | yes | self | yes | (pull only) |
-| dhs-win11 | yes | yes | yes | yes | self | (pull only) |
-| desk-03 | yes | yes | yes | yes | yes | self |
-
-`desk-03` initiates SSH outbound. The fleet does not SSH back into
-`desk-03` (the codeowner's workstation is on the OOB VLAN behind
-pfSense and is not reachable from the DMZ).
-
-### Distribution status
-
-- desk-03 → fleet: working via `~/.ssh/by-rune_lxc` (legacy key).
-- Fleet ↔ fleet: **NOT YET DISTRIBUTED.** The new `id_dhs_testbed`
-  keypair has not been generated or pushed. Tracked as a separate
-  infra task — see "Open work" below.
+Avahi 0.8 is installed and active on all four LXCs. Bonjour is NOT yet
+installed on `win11` (installers staged in `internal/amwa/assets/`);
+the `dhs_mdns` role (#784) installs it. dhs uses the stdlib mDNS
+fallback on Windows until the Bonjour backend (#195) lands.
 
 ## Producer launch and stop
 
 ### Linux LXC (Debian / Ubuntu / Rocky)
 
-Launch the four producers nohup-detached, writing logs to
+Launch the producers nohup-detached, writing logs to
 `/var/log/dhs-<proto>.log`. Example for ACP2:
 
 ```sh
@@ -100,39 +106,28 @@ Hard-stop by walking `/proc/*/exe` symlinks pointing to
 `/usr/local/bin/dhs` and killing each PID. Helper script at
 `bin/stop-dhs.sh`.
 
-### dhs-win11
+### win11
 
-OpenSSH server on the Windows host, `dhs.exe` placed under
-`C:\Program Files\dhs\dhs.exe`. Producer launch via PowerShell
-`Start-Process` with `-WindowStyle Hidden` and a redirect of
-stdout/stderr to log files under `C:\ProgramData\dhs\logs\`.
+OpenSSH Server on the VM, `dhs.exe` under `C:\dhs\dhs.exe` (see
+`ansible/inventory/group_vars/windows.yml`). Producer launch via
+`Start-Process -WindowStyle Hidden` with stdout/stderr redirected to
+`C:\ProgramData\dhs\logs\`.
 
 ## Caveats
 
 - `amwa/nmos-testing:latest` upstream regressed to the "Controller
   Testing Façade" on port 5001 after 2026-04-30. Pin to a pre-Façade
-  tag or run from source.
-- Win11 desk-03 (the codeowner's workstation) sits on the OOB VLAN and
-  cannot reach the DMZ via mDNS. `dhs-win11` (`.106`) on the DMZ
-  provides the Bonjour live test surface instead.
+  tag or run from source (#173).
+- desk-03 (the codeowner's workstation) sits on the OOB VLAN and cannot
+  reach the DMZ via mDNS. `win11` (`.107`) on the DMZ provides the
+  Windows mDNS live test surface instead.
 - Cerebrum drops `v1.0` from `api.versions` on registration — real-peer
   fact, not our bug.
-
-## Pending rig changes
-
-- Add `eth1` second NIC per `dhs-*` Linux LXC for dual-controller
-  redundancy testing per ADR-0022 (N-endpoints/Frame). Planned
-  pairings: `.102/.108`, `.103/.109`, `.104/.107`.
-- Bring `dhs-win11` (`.106`) online with the four producers running
-  to complete the multi-OS coverage matrix.
+- The Synapse ACP1 emulator referenced by `ansible/inventory/group_vars/all.yml`
+  (`10.6.239.113`) is on the office network, not the DMZ.
 
 ## Open work
 
-- Generate `id_dhs_testbed` keypair on `BY-DESK-03`.
-- Distribute private + public to every node in the fleet (LXCs +
-  Windows) and add the public to every `authorized_keys`.
-- Verify the mesh: from each node, `ssh -i ~/.ssh/id_dhs_testbed
-  <every-other-node>` succeeds without prompting.
-
-These are infra actions that require codeowner-side execution (key
-distribution touches credentials and is therefore not autonomous).
+Tracked in epic #780: fixed IPs (#786, pfSense mappings = owner action),
+unique hostnames (#783), actor-key convergence (#782), mDNS (#784),
+firewall (#785).


### PR DESCRIPTION
## What

Inventory truth for the test fleet, sourced from the Proxmox API and
live guests (2026-08-23): real `hosts.ini` (was 10.0.0.x placeholders
with names that did not bind the `host_vars`), per-host `host_vars`
with vmid / MACs / both NIC IPs / OS (previously untracked), Windows
group switched to key-based SSH, `docs/testbed.md` rewritten from the
same facts, PR-template device checklist made coherent.

Closes #781 (part of epic #780).

## Why

The fleet docs were wrong on 4 rows (.102/.103 OS swapped, tools is
.106 not .105, win11 is .107 not .106, .104/.105 are one Rocky host),
the tracked inventory was a template, and the WinRM/password path was
dead (pywinrm absent on the control node, credentials file gone) while
OpenSSH was up on the VM. Every later fleet role (#782-#786) needs one
authoritative host list.

## How

- `ansible/inventory/hosts.ini`: linux/windows/control/tooling groups,
  real `ansible_host` per host; control node `dhs-debian` = local.
- `group_vars/windows.yml`: `ansible_connection: ssh`, user `by-rune`,
  `ansible_shell_type: cmd` (sshd DefaultShell today; dhs_access #782
  flips to powershell).
- `host_vars/*.yml`: `pve_vmid`, `pve_name`, `os_label`, `nics`
  (MAC + IP per NIC), `fleet_hostname`; existing `ember_tree_src` kept.
- `docs/testbed.md`: fleet table, port plan (+sw-p-02, mDNS, metrics),
  control node, actor-key model, mDNS state, caveats, open work.
- `.github/PULL_REQUEST_TEMPLATE.md`: device checklist references
  testbed.md instead of hard-coded (partly wrong) IPs.

## Testing

Run from the control node (`dhs-debian` .103, repo clone `~/acp`):

```text
# ansible-inventory --graph  -> control/tooling/dhs_clients{linux,windows} as expected
# ansible dhs_clients -m ping -o ; ansible win11 -m ansible.windows.win_ping -o
dhs-rocky  | SUCCESS => {"ping": "pong"}
dhs-debian | SUCCESS => {"ping": "pong"}
dhs-ubuntu | SUCCESS => {"ping": "pong"}
dhs-tools  | SUCCESS => {"ping": "pong"}
win11      | SUCCESS => {"ping": "pong"}      # over SSH, key auth
# setup filter=ansible_distribution: Ubuntu / Rocky / Ubuntu / (debian local) / Windows facts OK
```

- [x] Doc + inventory only; `go vet` / `golangci-lint` pre-commit clean
- [x] No Go changes; CI unit/lint jobs unaffected

## Device tested

- [x] Fleet producer — all five fleet hosts reachable per new inventory
- [ ] Vendor emulator — n/a
- [ ] Real device — n/a
- [ ] No device needed (pure codec / doc change)

## Checklist

- [x] Linked issue (#781)
- [x] Conventional-commit title
- [x] No new external dependencies
- [x] ADR-0025 step 5 respected (Ansible from Linux control node, no PowerShell driver)