### PR TITLE
infra(fleet): dhs_hostname role - unique guest + Proxmox CT names, Avahi re-announce (#783)

### DIFF
--- a/ansible/playbooks/fleet-converge.yml
+++ b/ansible/playbooks/fleet-converge.yml
@@ -15,3 +15,4 @@
   gather_facts: true
   roles:
     - dhs_access
+    - dhs_hostname

--- a/ansible/roles/dhs_hostname/defaults/main.yml
+++ b/ansible/roles/dhs_hostname/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+# dhs_hostname — every fleet host is named after its inventory entry
+# (`fleet_hostname` in host_vars), in BOTH layers that own a name:
+#
+#   1. the guest (hostnamectl / Rename-Computer + /etc/hosts, Avahi re-announce)
+#   2. the Proxmox CT config (`hostname=`), because Proxmox rewrites the
+#      guest's /etc/hostname from that field at every container start —
+#      a guest-only rename silently reverts on reboot.
+#
+# Layer 2 needs the Proxmox API token; it is read from a control-node-only
+# vars file that never enters git:
+#   ansible-playbook playbooks/fleet-converge.yml -e @/root/.secrets/proxmox.yml
+# When the token vars are absent the Proxmox step is skipped (and reported),
+# the guest layer still converges.
+dhs_hostname_proxmox_enabled: "{{ proxmox_token_id is defined and proxmox_token_secret is defined }}"
+proxmox_api_host: 10.6.224.5:8006
+proxmox_node: pve01
+proxmox_validate_certs: false

--- a/ansible/roles/dhs_hostname/handlers/main.yml
+++ b/ansible/roles/dhs_hostname/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: restart avahi
+  ansible.builtin.service:
+    name: avahi-daemon
+    state: restarted
+  failed_when: false   # hosts without Avahi (none today) must not fail the rename

--- a/ansible/roles/dhs_hostname/meta/main.yml
+++ b/ansible/roles/dhs_hostname/meta/main.yml
@@ -1,0 +1,21 @@
+---
+galaxy_info:
+  role_name: dhs_hostname
+  author: by-rune
+  description: >-
+    Give every fleet host its unique inventory name in both layers that own
+    it — the guest (hostnamectl / Rename-Computer, /etc/hosts, Avahi
+    re-announce) and the Proxmox CT config — so mDNS names never collide
+    and a reboot cannot revert the name. Idempotent: run-twice = 0 changes.
+  license: see repository
+  min_ansible_version: "2.14"
+  platforms:
+    - name: EL
+      versions: [all]
+    - name: Debian
+      versions: [all]
+    - name: Ubuntu
+      versions: [all]
+    - name: Windows
+      versions: [all]
+dependencies: []

--- a/ansible/roles/dhs_hostname/tasks/linux.yml
+++ b/ansible/roles/dhs_hostname/tasks/linux.yml
@@ -1,0 +1,20 @@
+---
+- name: "hostname = {{ fleet_hostname }}"
+  ansible.builtin.hostname:
+    name: "{{ fleet_hostname }}"
+  notify: restart avahi
+
+- name: /etc/hosts maps 127.0.1.1 to the fleet name
+  ansible.builtin.lineinfile:
+    path: /etc/hosts
+    regexp: '^127\.0\.1\.1\s'
+    line: "127.0.1.1 {{ fleet_hostname }}"
+    insertafter: '^127\.0\.0\.1\s'
+  notify: restart avahi
+
+- name: Avahi announces the system hostname (no host-name override)
+  ansible.builtin.lineinfile:
+    path: /etc/avahi/avahi-daemon.conf
+    regexp: '^\s*host-name\s*='
+    state: absent
+  notify: restart avahi

--- a/ansible/roles/dhs_hostname/tasks/main.yml
+++ b/ansible/roles/dhs_hostname/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+- name: Assert the host declares fleet_hostname
+  ansible.builtin.assert:
+    that:
+      - fleet_hostname is defined
+      - fleet_hostname is match('^[a-z][a-z0-9-]{1,62}$')
+    fail_msg: "dhs_hostname: {{ inventory_hostname }} needs a valid fleet_hostname in host_vars"
+
+- name: Converge (Linux guest)
+  ansible.builtin.include_tasks: linux.yml
+  when: ansible_os_family != "Windows"
+
+- name: Converge (Windows guest)
+  ansible.builtin.include_tasks: windows.yml
+  when: ansible_os_family == "Windows"
+
+- name: Converge (Proxmox CT config hostname)
+  ansible.builtin.include_tasks: proxmox.yml
+  when:
+    - pve_vmid is defined
+    - ansible_os_family != "Windows"   # VMs carry no hostname= in their config
+
+- name: Proxmox layer skipped (no token vars) — guest rename will revert at next CT start
+  ansible.builtin.debug:
+    msg: "dhs_hostname: pass -e @/root/.secrets/proxmox.yml to also converge the Proxmox CT hostname"
+  when:
+    - pve_vmid is defined
+    - ansible_os_family != "Windows"
+    - not (dhs_hostname_proxmox_enabled | bool)

--- a/ansible/roles/dhs_hostname/tasks/proxmox.yml
+++ b/ansible/roles/dhs_hostname/tasks/proxmox.yml
@@ -1,0 +1,30 @@
+---
+# Runs on the control node against the Proxmox API (read-then-write so a
+# second run is a no-op). Only the `hostname=` field of the CT config is
+# touched.
+- name: Read the CT config from Proxmox
+  ansible.builtin.uri:
+    url: "https://{{ proxmox_api_host }}/api2/json/nodes/{{ proxmox_node }}/lxc/{{ pve_vmid }}/config"
+    headers:
+      Authorization: "PVEAPIToken={{ proxmox_token_id }}={{ proxmox_token_secret }}"
+    validate_certs: "{{ proxmox_validate_certs }}"
+    return_content: true
+  delegate_to: localhost
+  register: dhs_hostname_ct
+  when: dhs_hostname_proxmox_enabled | bool
+
+- name: "Proxmox CT {{ pve_vmid }} hostname = {{ fleet_hostname }}"
+  ansible.builtin.uri:
+    url: "https://{{ proxmox_api_host }}/api2/json/nodes/{{ proxmox_node }}/lxc/{{ pve_vmid }}/config"
+    method: PUT
+    headers:
+      Authorization: "PVEAPIToken={{ proxmox_token_id }}={{ proxmox_token_secret }}"
+    body_format: form-urlencoded
+    body:
+      hostname: "{{ fleet_hostname }}"
+    validate_certs: "{{ proxmox_validate_certs }}"
+  delegate_to: localhost
+  when:
+    - dhs_hostname_proxmox_enabled | bool
+    - (dhs_hostname_ct.json.data.hostname | default('')) != fleet_hostname
+  changed_when: true

--- a/ansible/roles/dhs_hostname/tasks/windows.yml
+++ b/ansible/roles/dhs_hostname/tasks/windows.yml
@@ -1,0 +1,12 @@
+---
+# Rename-Computer needs a reboot to take effect; win_reboot waits for the
+# host to come back on the same SSH path, so the play continues.
+- name: "computer name = {{ fleet_hostname }}"
+  ansible.windows.win_hostname:
+    name: "{{ fleet_hostname }}"
+  register: dhs_hostname_win
+
+- name: Reboot to apply the new computer name
+  ansible.windows.win_reboot:
+    reboot_timeout: 600
+  when: dhs_hostname_win.reboot_required | default(false)

--- a/docs/testbed.md
+++ b/docs/testbed.md
@@ -28,9 +28,12 @@ rebuilt guest keeps its address with zero guest-side configuration.
 `ansible/playbooks/fleet-verify.yml` asserts live IP == inventory IP per
 NIC and fails loudly on drift.
 
-Guest hostnames are being made unique (`dhs-debian`, `dhs-ubuntu`,
-`dhs-rocky`, `dhs-tools`, `dhs-win11` = `fleet_hostname`, #783);
-today three LXCs still answer `dhs`, which collides in Avahi.
+Guest hostnames equal the inventory name (`fleet_hostname`:
+`dhs-debian`, `dhs-ubuntu`, `dhs-rocky`, `dhs-tools`, `dhs-win11`),
+converged by the `dhs_hostname` role (#783) in BOTH layers — the guest
+and the Proxmox CT config (Proxmox rewrites `/etc/hostname` from its
+config at every CT start, so a guest-only rename would revert). Unique
+names matter: three LXCs used to answer `dhs`, which collides in Avahi.
 
 ## Producer port plan (every Linux LXC + win11)
 


### PR DESCRIPTION
## What

`dhs_hostname` role: every fleet host gets its unique inventory name
(`fleet_hostname`) in both layers that own a name — the guest
(hostnamectl / Rename-Computer + reboot, `/etc/hosts` 127.0.1.1, Avahi
re-announce) and the Proxmox CT config (`hostname=` via the API, read-then-
write) — plus `fleet-converge.yml` wiring and the testbed.md paragraph.

Closes #783 (epic #780).

## Why

Three LXCs answered `dhs` and Rocky `dhs.rocky9`: Avahi renamed them
(`dhs-2.local`...), making NMOS DNS-SD tests non-deterministic. A guest-only
rename reverts at the next CT start because Proxmox rewrites
`/etc/hostname` from its config — hence the Proxmox layer.

## How

- `tasks/linux.yml`: `hostname` module, `/etc/hosts` line, no `host-name=`
  override in avahi-daemon.conf, handler restarts avahi.
- `tasks/windows.yml`: `win_hostname` + `win_reboot` when required.
- `tasks/proxmox.yml`: `uri` GET config → PUT `hostname=` only if different,
  delegated to the control node; token comes from a control-node-only vars
  file (`-e @/root/.secrets/proxmox.yml`, svc-rune@pve identity, never in
  git); without it the step is skipped and reported.
- `defaults/main.yml`: API host/node, enable flag derived from token vars.

## Testing

From dhs-debian (.103):

```text
# RUN 1  ansible-playbook playbooks/fleet-converge.yml -e @/root/.secrets/proxmox.yml
changed: hostname (dhs-debian, dhs-ubuntu, dhs-rocky, dhs-tools) ; /etc/hosts ; avahi restarted
changed: computer name = dhs-win11 (win11) ; reboot (win11)
changed: Proxmox CT 651/652/653/655 hostname
PLAY RECAP dhs-* changed=4 failed=0 | win11 changed=2 failed=0
# RUN 2
PLAY RECAP dhs-debian/rocky/tools/ubuntu changed=0 | win11 changed=0   <- ADR-0007
# hostname on each host:  dhs-debian dhs-ubuntu dhs-rocky dhs-tools dhs-win11
# avahi-resolve -4 -n <name>.local:
dhs-debian.local 172.17.0.1 (docker0 — excluded by dhs_mdns #784)  dhs-ubuntu.local 10.100.0.101
dhs-rocky.local 10.100.0.104  dhs-tools.local 10.100.0.106  dhs-win11.local 10.100.0.107
# Proxmox CT hostnames: 651 dhs-debian · 652 dhs-ubuntu · 653 dhs-rocky · 655 dhs-tools
```

- [x] run-twice = 0 changes on all five hosts
- [x] No Go changes; pre-commit vet/lint clean

## Device tested

- [x] Fleet producer — all five fleet hosts (converge target)
- [ ] Vendor emulator — n/a
- [ ] Real device — n/a
- [ ] No device needed (pure codec / doc change)

## Checklist

- [x] Linked issue (#783)
- [x] Conventional-commit title
- [x] No new Go dependencies
- [x] ADR-0025 step 5/6 respected (Ansible from Linux control node, idempotent)