### PR TITLE
infra(fleet): dhs_mdns role - Avahi pinned on Linux, Bonjour staged on win11, control-node play (#784)

### DIFF
--- a/ansible/playbooks/control-node.yml
+++ b/ansible/playbooks/control-node.yml
@@ -1,0 +1,42 @@
+---
+# Control-node prerequisites (dhs-debian .103), self-applied. Run once after a
+# fresh clone and whenever requirements change:
+#
+#   cd ~/acp/ansible && ansible-playbook playbooks/control-node.yml
+#
+# - git-lfs + `git lfs pull` for the LFS-tracked assets the fleet roles ship
+#   (Bonjour installer, PDFs) — without it a clone holds 132-byte pointers.
+# - the Ansible collections from requirements.yml.
+- name: Control node prerequisites
+  hosts: control
+  gather_facts: true
+  tasks:
+    - name: git + git-lfs present
+      ansible.builtin.package:
+        name: [git, git-lfs]
+        state: present
+
+    - name: git-lfs filters installed for root
+      ansible.builtin.command: git lfs install --skip-repo
+      register: cn_lfs_install
+      changed_when: "'Git LFS initialized' in cn_lfs_install.stdout and 'already' not in cn_lfs_install.stdout"
+
+    - name: LFS objects for the amwa assets pulled
+      ansible.builtin.command:
+        cmd: git lfs pull --include "internal/amwa/assets/*"
+        chdir: "{{ playbook_dir }}/../.."
+      register: cn_lfs_pull
+      changed_when: "'Downloading' in cn_lfs_pull.stdout or (cn_lfs_pull.stderr is search('Downloading'))"
+
+    - name: Bonjour installer is a real binary (> 1 MB)
+      ansible.builtin.stat:
+        path: "{{ playbook_dir }}/../../internal/amwa/assets/BonjourPSSetup.exe"
+      register: cn_bonjour
+      failed_when: not cn_bonjour.stat.exists or cn_bonjour.stat.size < 1000000
+
+    - name: Ansible collections from requirements.yml
+      ansible.builtin.command:
+        cmd: ansible-galaxy collection install -r requirements.yml
+        chdir: "{{ playbook_dir }}/.."
+      register: cn_galaxy
+      changed_when: "'Installing' in cn_galaxy.stdout"

--- a/ansible/playbooks/fleet-converge.yml
+++ b/ansible/playbooks/fleet-converge.yml
@@ -16,3 +16,4 @@
   roles:
     - dhs_access
     - dhs_hostname
+    - dhs_mdns

--- a/ansible/roles/dhs_mdns/defaults/main.yml
+++ b/ansible/roles/dhs_mdns/defaults/main.yml
@@ -1,0 +1,21 @@
+---
+# dhs_mdns — the system mDNS daemon every fleet host must run so dhs's
+# DNS-SD backends (Avahi-via-DBus on Linux, Bonjour on Windows — #194/#195)
+# and the AMWA NMOS Testing tool see the same names on the wire.
+#
+# Linux: avahi-daemon + tools (apt: Debian/Ubuntu, dnf: Rocky/EL).
+# Windows: Apple Bonjour Print Services (installs "Bonjour Service" +
+# C:\Windows\System32\dnssd.dll) from the repo-staged installer
+# internal/amwa/assets/BonjourPSSetup.exe (the SDK is a dev-machine
+# concern for building the CGo backend, not a fleet host requirement).
+dhs_mdns_linux_packages:
+  Debian: [avahi-daemon, avahi-utils, libnss-mdns]
+  RedHat: [avahi, avahi-tools]
+dhs_mdns_linux_service: avahi-daemon
+
+dhs_mdns_bonjour_installer_src: "{{ playbook_dir }}/../../internal/amwa/assets/BonjourPSSetup.exe"
+dhs_mdns_bonjour_installer_dst: 'C:\dhs\installers\BonjourPSSetup.exe'
+dhs_mdns_bonjour_service: Bonjour Service
+# Silent install hangs in non-interactive SSH sessions on Win11 (2026-08-23);
+# default = stage + report + manage the service once installed interactively.
+dhs_mdns_bonjour_silent_install: false

--- a/ansible/roles/dhs_mdns/handlers/main.yml
+++ b/ansible/roles/dhs_mdns/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart avahi (mdns)
+  ansible.builtin.service:
+    name: "{{ dhs_mdns_linux_service }}"
+    state: restarted

--- a/ansible/roles/dhs_mdns/meta/main.yml
+++ b/ansible/roles/dhs_mdns/meta/main.yml
@@ -1,0 +1,21 @@
+---
+galaxy_info:
+  role_name: dhs_mdns
+  author: by-rune
+  description: >-
+    Ensure the system mDNS daemon is installed, enabled and running on
+    every fleet host — Avahi on Linux, Apple Bonjour (from the repo-staged
+    installer) on Windows — so dhs DNS-SD backends and the AMWA testing
+    tool share one name space. Idempotent: run-twice = 0 changes.
+  license: see repository
+  min_ansible_version: "2.14"
+  platforms:
+    - name: EL
+      versions: [all]
+    - name: Debian
+      versions: [all]
+    - name: Ubuntu
+      versions: [all]
+    - name: Windows
+      versions: [all]
+dependencies: []

--- a/ansible/roles/dhs_mdns/tasks/linux.yml
+++ b/ansible/roles/dhs_mdns/tasks/linux.yml
@@ -1,0 +1,23 @@
+---
+- name: Avahi packages present
+  ansible.builtin.package:
+    name: "{{ dhs_mdns_linux_packages[ansible_os_family] }}"
+    state: present
+
+# Docker hosts: never announce on docker0 (172.17.0.1 is useless to peers
+# and wins the A-record race — seen on dhs-debian). Keyed on the interface
+# list so hosts without Docker stay untouched.
+- name: Avahi ignores docker0 on Docker hosts
+  ansible.builtin.lineinfile:
+    path: /etc/avahi/avahi-daemon.conf
+    regexp: '^\s*#?\s*deny-interfaces\s*='
+    line: "deny-interfaces=docker0"
+    insertafter: '^\[server\]'
+  when: "'docker0' in ansible_interfaces"
+  notify: restart avahi (mdns)
+
+- name: avahi-daemon enabled and running
+  ansible.builtin.service:
+    name: "{{ dhs_mdns_linux_service }}"
+    state: started
+    enabled: true

--- a/ansible/roles/dhs_mdns/tasks/main.yml
+++ b/ansible/roles/dhs_mdns/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Converge (Linux — Avahi)
+  ansible.builtin.include_tasks: linux.yml
+  when: ansible_os_family != "Windows"
+
+- name: Converge (Windows — Bonjour)
+  ansible.builtin.include_tasks: windows.yml
+  when: ansible_os_family == "Windows"

--- a/ansible/roles/dhs_mdns/tasks/windows.yml
+++ b/ansible/roles/dhs_mdns/tasks/windows.yml
@@ -1,0 +1,88 @@
+---
+# The installer is Git-LFS tracked: a clone without git-lfs holds a 132-byte
+# pointer file, which Windows rejects as "not compatible". Refuse to ship a
+# pointer — the control-node play (playbooks/control-node.yml) pulls LFS.
+- name: Installer on the control node is the real binary, not an LFS pointer
+  ansible.builtin.stat:
+    path: "{{ dhs_mdns_bonjour_installer_src }}"
+  delegate_to: localhost
+  run_once: true
+  register: dhs_mdns_installer_stat
+
+- name: Assert installer size (LFS pointer guard)
+  ansible.builtin.assert:
+    that:
+      - dhs_mdns_installer_stat.stat.exists
+      - dhs_mdns_installer_stat.stat.size > 1000000
+    fail_msg: >-
+      {{ dhs_mdns_bonjour_installer_src }} is {{ dhs_mdns_installer_stat.stat.size | default(0) }}
+      bytes — a Git LFS pointer. Run playbooks/control-node.yml (git-lfs + lfs pull) first.
+  run_once: true
+
+- name: Installer drop directory
+  ansible.windows.win_file:
+    path: "{{ dhs_mdns_bonjour_installer_dst | win_dirname }}"
+    state: directory
+
+- name: Stage the Bonjour installer from the repo assets
+  ansible.windows.win_copy:
+    src: "{{ dhs_mdns_bonjour_installer_src }}"
+    dest: "{{ dhs_mdns_bonjour_installer_dst }}"
+
+- name: Is Bonjour installed? (dnssd.dll present)
+  ansible.windows.win_stat:
+    path: C:\Windows\System32\dnssd.dll
+  register: dhs_mdns_dnssd
+
+# Silent install of Apple's InstallShield bootstrapper hangs in a
+# non-interactive SSH session on Windows 11 (verified 2026-08-23: both
+# `/quiet` and `/s /v"/qn"` — MSI 1603 or an invisible dialog, 25+ min).
+# Default is therefore: stage + report, and the operator installs once at
+# the console (double-click C:\dhs\installers\BonjourPSSetup.exe). Set
+# dhs_mdns_bonjour_silent_install: true to retry the bounded silent path.
+- name: Bonjour silent install attempt (bounded, opt-in)
+  ansible.windows.win_command:
+    argv:
+      - cmd.exe
+      - /c
+      - 'start /wait "" {{ dhs_mdns_bonjour_installer_dst }} /s /v"/qn /norestart"'
+  async: 600
+  poll: 15
+  register: dhs_mdns_silent
+  failed_when: false
+  changed_when: dhs_mdns_silent.rc | default(1) == 0
+  when:
+    - not dhs_mdns_dnssd.stat.exists
+    - dhs_mdns_bonjour_silent_install | bool
+
+# Separate register: a skipped task would otherwise overwrite the first
+# stat result with a {skipped: true} dict that has no .stat.
+- name: Re-check Bonjour after the silent attempt
+  ansible.windows.win_stat:
+    path: C:\Windows\System32\dnssd.dll
+  register: dhs_mdns_dnssd_after
+  when:
+    - not dhs_mdns_dnssd.stat.exists
+    - dhs_mdns_bonjour_silent_install | bool
+
+- name: Resolve Bonjour presence
+  ansible.builtin.set_fact:
+    dhs_mdns_bonjour_present: >-
+      {{ dhs_mdns_dnssd.stat.exists
+         or (dhs_mdns_dnssd_after.stat.exists | default(false)) }}
+
+- name: Bonjour not installed — operator action required (not a failure)
+  ansible.builtin.debug:
+    msg: >-
+      Bonjour is NOT installed on {{ inventory_hostname }}. Installer is staged at
+      {{ dhs_mdns_bonjour_installer_dst }} — run it once interactively at the
+      console; this role then keeps the service enabled (#784). dhs uses the
+      stdlib mDNS fallback meanwhile (#195).
+  when: not (dhs_mdns_bonjour_present | bool)
+
+- name: Bonjour Service running and automatic
+  ansible.windows.win_service:
+    name: "{{ dhs_mdns_bonjour_service }}"
+    state: started
+    start_mode: auto
+  when: dhs_mdns_bonjour_present | bool

--- a/docs/testbed.md
+++ b/docs/testbed.md
@@ -86,10 +86,14 @@ signing belongs to the parked hardening topic).
 
 ## mDNS daemons
 
-Avahi 0.8 is installed and active on all four LXCs. Bonjour is NOT yet
-installed on `win11` (installers staged in `internal/amwa/assets/`);
-the `dhs_mdns` role (#784) installs it. dhs uses the stdlib mDNS
-fallback on Windows until the Bonjour backend (#195) lands.
+Avahi 0.8 is installed, active and pinned by the `dhs_mdns` role on all
+four LXCs (Docker hosts exclude `docker0` from Avahi). On `win11` the
+role stages Apple's `BonjourPSSetup.exe` at `C:\dhs\installers\` and
+manages the service, but the silent install hangs in non-interactive
+sessions on Windows 11 — install it ONCE interactively at the VM
+console (double-click the staged installer); the role then keeps
+"Bonjour Service" running. dhs uses the stdlib mDNS fallback on Windows
+until the Bonjour backend (#195) lands, so this is not load-bearing yet.
 
 ## Producer launch and stop
 


### PR DESCRIPTION
## What

`dhs_mdns` role + `playbooks/control-node.yml`: Avahi pinned (packages,
service) on every LXC with `docker0` excluded on Docker hosts; on win11
the Apple Bonjour installer is staged from the repo assets, presence is
checked, the service is managed once installed, and an opt-in bounded
silent-install path exists. Control-node play installs git-lfs + pulls
the LFS-tracked assets and the collections. testbed.md mDNS section
updated.

Closes #784 (epic #780).

## Why

Owner directive: Avahi/Bonjour installed and set on every fleet host.
Avahi was installed by hand (not reproducible); `dhs-debian.local`
resolved to `172.17.0.1` (docker0) — now `10.100.0.108`. Bonjour was
absent on win11; the installer in the repo is Git-LFS, so the control
node (no git-lfs) shipped a 132-byte pointer ("not compatible with this
version of Windows") — the role now refuses pointers and the control-node
play pulls LFS.

Silent install of Apple's InstallShield bootstrapper hangs in a
non-interactive SSH session on Windows 11 (verified: `/quiet` and
`/s /v"/qn"` → MSI 1603 or an invisible dialog, 25+ min). Default is
stage + report (not a failure) + interactive one-time install at the
console; `dhs_mdns_bonjour_silent_install: true` retries a bounded
silent attempt. Bonjour is not load-bearing until #195 (stdlib mDNS
fallback on Windows).

## How

- `roles/dhs_mdns/{defaults,tasks,handlers,meta}` — Linux (package +
  `deny-interfaces=docker0` when docker0 exists + service), Windows
  (LFS guard, stage, stat, opt-in silent, debug notice, service when
  present; separate register for the re-check so a skipped task cannot
  clobber `.stat`).
- `playbooks/control-node.yml` — git-lfs, `git lfs pull --include
  internal/amwa/assets/*`, installer-size assert, collections.
- `fleet-converge.yml` — adds `dhs_mdns`; `docs/testbed.md` mDNS section.

## Testing

From dhs-debian (.103):

```text
# ansible-playbook playbooks/control-node.yml   -> changed=2 (git-lfs, lfs pull), installer 5436744 bytes
# RUN 1  fleet-converge.yml -e @/root/.secrets/proxmox.yml
changed: Avahi ignores docker0 (dhs-debian, dhs-tools) ; handler restart avahi ; installer staged (win11)
# RUN 2 / final full run
dhs-debian ok=17 changed=0 | dhs-rocky ok=16 changed=0 | dhs-tools ok=17 changed=0 | dhs-ubuntu ok=16 changed=0
win11 ok=20 changed=0 failed=0  (+ notice: Bonjour NOT installed, installer staged at C:\dhs\installers\)
# avahi-resolve: dhs-debian.local 10.100.0.108 (was 172.17.0.1) dhs-ubuntu .101 dhs-rocky .104 dhs-tools .106 dhs-win11 .107
```

- [x] run-twice = 0 changes on all five hosts
- [x] No Go changes; pre-commit vet/lint clean

## Device tested

- [x] Fleet producer — all five fleet hosts (converge target)
- [ ] Vendor emulator — n/a
- [ ] Real device — n/a
- [ ] No device needed (pure codec / doc change)

## Checklist

- [x] Linked issue (#784)
- [x] Conventional-commit title
- [x] No new Go dependencies
- [x] ADR-0025 step 5/6 respected (Ansible from Linux control node, idempotent)