### PR TITLE
infra(fleet): dhs_firewall role - per-connector rule groups (dhs_connectors), program-scoped on Windows, enforce flag (#785)

### DIFF
--- a/ansible/inventory/host_vars/dhs-debian.yml
+++ b/ansible/inventory/host_vars/dhs-debian.yml
@@ -17,3 +17,7 @@ fleet_hostname: dhs-debian
 # Ember+ producer: our integration DM — the synthetic tree that carries the
 # n-to-n matrix plus the salvo/lock/protect builtin functions.
 ember_tree_src: "{{ playbook_dir }}/../files/trees/our-dm.tree.json"
+
+# Connectors this host serves -> dhs_firewall opens exactly these rule groups
+# (nmos also needs the dhs_mdns daemon). Add/remove with the producer deploy.
+dhs_connectors: [acp1, acp2, emberplus, probel-sw08p, probel-sw02p, nmos]

--- a/ansible/inventory/host_vars/dhs-rocky.yml
+++ b/ansible/inventory/host_vars/dhs-rocky.yml
@@ -13,3 +13,7 @@ fleet_hostname: dhs-rocky
 # Ember+ producer: the Lawo PowerCore tree (1024-target matrix), rebuilt from
 # the committed real-device capture (internal/emberplus/testdata/fixtures/powercore).
 ember_tree_src: "{{ playbook_dir }}/../files/trees/powercore.tree.json"
+
+# Connectors this host serves -> dhs_firewall opens exactly these rule groups
+# (nmos also needs the dhs_mdns daemon). Add/remove with the producer deploy.
+dhs_connectors: [acp1, acp2, emberplus, probel-sw08p, probel-sw02p, nmos]

--- a/ansible/inventory/host_vars/dhs-tools.yml
+++ b/ansible/inventory/host_vars/dhs-tools.yml
@@ -9,3 +9,6 @@ os_label: "Ubuntu"
 nics:
   - { name: eth0, mac: "BC:24:11:C1:92:FF", ip: 10.100.0.106 }
 fleet_hostname: dhs-tools
+
+# Tooling host: no dhs producers -> only management rules (ssh, metrics).
+dhs_connectors: []

--- a/ansible/inventory/host_vars/dhs-ubuntu.yml
+++ b/ansible/inventory/host_vars/dhs-ubuntu.yml
@@ -12,3 +12,7 @@ fleet_hostname: dhs-ubuntu
 # Ember+ producer: the DHD audio console tree, rebuilt from the committed
 # real-device capture (internal/emberplus/testdata/fixtures/dhd).
 ember_tree_src: "{{ playbook_dir }}/../files/trees/dhd.tree.json"
+
+# Connectors this host serves -> dhs_firewall opens exactly these rule groups
+# (nmos also needs the dhs_mdns daemon). Add/remove with the producer deploy.
+dhs_connectors: [acp1, acp2, emberplus, probel-sw08p, probel-sw02p, nmos]

--- a/ansible/inventory/host_vars/win11.yml
+++ b/ansible/inventory/host_vars/win11.yml
@@ -12,3 +12,7 @@ fleet_hostname: dhs-win11
 
 # Ember+ producer: our integration DM (matrix + salvo/lock functions).
 ember_tree_src: "{{ playbook_dir }}/../files/trees/our-dm.tree.json"
+
+# Connectors this host serves -> dhs_firewall opens exactly these rule groups
+# (nmos also needs the dhs_mdns daemon). Add/remove with the producer deploy.
+dhs_connectors: [acp1, acp2, emberplus, probel-sw08p, probel-sw02p, nmos]

--- a/ansible/playbooks/fleet-converge.yml
+++ b/ansible/playbooks/fleet-converge.yml
@@ -17,3 +17,4 @@
     - dhs_access
     - dhs_hostname
     - dhs_mdns
+    - dhs_firewall

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -2,4 +2,6 @@
 # Install on the control node:  ansible-galaxy collection install -r requirements.yml
 collections:
   - name: ansible.windows   # win_command / win_copy / win_acl / win_service for the Windows client
-  - name: ansible.posix     # authorized_key (exclusive) for the Linux hosts
+  - name: ansible.posix     # authorized_key (exclusive), firewalld
+  - name: community.general # ufw
+  - name: community.windows # win_firewall_rule / win_firewall

--- a/ansible/roles/dhs_firewall/defaults/main.yml
+++ b/ansible/roles/dhs_firewall/defaults/main.yml
@@ -1,0 +1,82 @@
+---
+# dhs_firewall — per-PROTOCOL host-firewall rules, on every OS (ufw on
+# Debian/Ubuntu, firewalld on EL, Windows Defender Firewall on win11).
+#
+# A host opens exactly the rule groups for the connectors it serves
+# (`dhs_connectors`, declared in host_vars — add `emberplus` when you deploy
+# the Ember+ producer there, remove it when you don't) plus the management
+# groups below; every other dhs-* rule from the catalogue is REMOVED. So the
+# open surface always equals the deployed connectors — never "everything".
+#
+# Windows: connector rules are scoped to the dhs program (authorized app +
+# port), not bare ports; management rules (ssh/winrm) stay port rules.
+#
+# Two modes, on purpose:
+#   dhs_firewall_enforce: false  (default today) — rules PRESENT/ABSENT per
+#       the lists, enforcement state left as found (ufw inactive, firewalld
+#       stored offline, win11 profiles as they are). Nothing working today
+#       gets blocked; the rule set is converged and reviewable.
+#   dhs_firewall_enforce: true   — additionally enable ufw / firewalld and
+#       turn the win11 profiles ON (default-deny inbound except the rules).
+#       That flip IS the hardening step (parked topic) — one variable.
+dhs_firewall_enforce: false
+
+# Management groups every host gets (Windows adds winrm).
+dhs_firewall_base_groups: [ssh, metrics]
+dhs_firewall_windows_base_groups: [winrm]
+
+# Connectors this host serves — override per host in host_vars.
+dhs_connectors: []
+
+# Catalogue: group -> rules. Ports come from the producers' CLI defaults
+# (cmd_nmos.go binds) and the testbed port plan; `nmos` includes mDNS and
+# REQUIRES the dhs_mdns role (Avahi / Bonjour) on the same host.
+dhs_firewall_catalogue:
+  ssh:
+    - { port: 22,    proto: tcp }
+  winrm:
+    - { port: 5985,  proto: tcp }
+  metrics:
+    - { port: 9100,  proto: tcp, program: true }
+  acp1:
+    - { port: 2071,  proto: udp, program: true }
+    - { port: 2071,  proto: tcp, program: true }
+  acp2:
+    - { port: 2072,  proto: tcp, program: true }
+  emberplus:
+    - { port: 9000,  proto: tcp, program: true }
+  probel-sw08p:
+    - { port: 2008,  proto: tcp, program: true }
+  probel-sw02p:
+    - { port: 2002,  proto: tcp, program: true }
+  nmos:
+    - { port: 8080,  proto: tcp, program: true }   # Node API (CLI default bind)
+    - { port: 18080, proto: tcp, program: true }   # Node API (fleet port plan)
+    - { port: 8235,  proto: tcp, program: true }   # Registration/Query API + WS
+    - { port: 8090,  proto: tcp, program: true }   # IS-07 events WS
+    - { port: 10641, proto: tcp, program: true }   # IS-09 System API
+    - { port: 5353,  proto: udp }                  # mDNS (Avahi/Bonjour/stdlib)
+
+# Program the Windows connector rules are scoped to.
+dhs_firewall_windows_program: "{{ dhs_bin | default('C:\\dhs\\dhs.exe') }}"
+
+# Legacy rules from the first role version (catalogue-wide, un-scoped names
+# `dhs-<group>`; cerebrum-nb 40007 which is Cerebrum's port, not ours).
+# Always removed: ufw matches by comment, firewalld by port, Windows by name.
+dhs_firewall_legacy:
+  - { name: dhs-ssh,           port: 22,    proto: tcp }
+  - { name: dhs-acp1-udp,      port: 2071,  proto: udp }
+  - { name: dhs-acp1-tcp,      port: 2071,  proto: tcp }
+  - { name: dhs-acp2,          port: 2072,  proto: tcp }
+  - { name: dhs-emberplus,     port: 9000,  proto: tcp }
+  - { name: dhs-probel-sw08p,  port: 2008,  proto: tcp }
+  - { name: dhs-probel-sw02p,  port: 2002,  proto: tcp }
+  - { name: dhs-nmos-node,     port: 8080,  proto: tcp }
+  - { name: dhs-nmos-node-alt, port: 18080, proto: tcp }
+  - { name: dhs-nmos-events,   port: 8090,  proto: tcp }
+  - { name: dhs-nmos-registry, port: 8235,  proto: tcp }
+  - { name: dhs-nmos-system,   port: 10641, proto: tcp }
+  - { name: dhs-cerebrum-nb,   port: 40007, proto: tcp }
+  - { name: dhs-mdns,          port: 5353,  proto: udp }
+  - { name: dhs-metrics,       port: 9100,  proto: tcp }
+  - { name: dhs-winrm,         port: 5985,  proto: tcp }

--- a/ansible/roles/dhs_firewall/meta/main.yml
+++ b/ansible/roles/dhs_firewall/meta/main.yml
@@ -1,0 +1,21 @@
+---
+galaxy_info:
+  role_name: dhs_firewall
+  author: by-rune
+  description: >-
+    Converge the per-protocol transport port rules on every fleet host
+    (ufw / firewalld / Windows Defender Firewall). Rules are always present;
+    enforcement (enable + default-deny) is one variable, dhs_firewall_enforce,
+    so the hardening flip is a reviewable one-liner. Idempotent.
+  license: see repository
+  min_ansible_version: "2.14"
+  platforms:
+    - name: EL
+      versions: [all]
+    - name: Debian
+      versions: [all]
+    - name: Ubuntu
+      versions: [all]
+    - name: Windows
+      versions: [all]
+dependencies: []

--- a/ansible/roles/dhs_firewall/tasks/debian.yml
+++ b/ansible/roles/dhs_firewall/tasks/debian.yml
@@ -1,0 +1,36 @@
+---
+- name: ufw present
+  ansible.builtin.package:
+    name: ufw
+    state: present
+
+- name: "ufw rules per connector group (present/absent)"
+  community.general.ufw:
+    rule: allow
+    port: "{{ item.port }}"
+    proto: "{{ item.proto }}"
+    comment: "{{ item.name }}"
+    delete: "{{ item.state == 'absent' }}"
+  loop: "{{ dhs_firewall_rules }}"
+  loop_control:
+    label: "{{ item.name }} {{ item.state }}"
+
+# ufw deletes match the full spec INCLUDING the comment, so the old
+# catalogue-wide rules must be removed under their original names.
+- name: "ufw legacy rules removed"
+  community.general.ufw:
+    rule: allow
+    port: "{{ item.port }}"
+    proto: "{{ item.proto }}"
+    comment: "{{ item.name }}"
+    delete: true
+  loop: "{{ dhs_firewall_legacy }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: ufw enabled (enforce mode only)
+  community.general.ufw:
+    state: enabled
+    policy: deny
+    direction: incoming
+  when: dhs_firewall_enforce | bool

--- a/ansible/roles/dhs_firewall/tasks/main.yml
+++ b/ansible/roles/dhs_firewall/tasks/main.yml
@@ -1,0 +1,39 @@
+---
+# Desired groups = management base (+ Windows base) + this host's connectors.
+# Every catalogue rule is then either present (group desired) or absent —
+# so the open surface always equals the deployed connectors.
+- name: Resolve the desired rule groups for this host
+  ansible.builtin.set_fact:
+    dhs_firewall_groups: >-
+      {{ (dhs_firewall_base_groups
+          + (dhs_firewall_windows_base_groups if ansible_os_family == 'Windows' else [])
+          + (dhs_connectors | default([]))) | unique }}
+
+- name: Assert every desired group has a catalogue entry
+  ansible.builtin.assert:
+    that: item in dhs_firewall_catalogue
+    fail_msg: "dhs_firewall: no rule group for connector '{{ item }}' — add it to dhs_firewall_catalogue"
+  loop: "{{ dhs_firewall_groups }}"
+
+- name: Build the full rule list (present for desired groups, absent otherwise)
+  ansible.builtin.set_fact:
+    dhs_firewall_rules: >-
+      {{ (dhs_firewall_rules | default([])) + [ item.1 | combine({
+           'group': item.0.key,
+           'name': 'dhs-' ~ item.0.key ~ '-' ~ item.1.port ~ '-' ~ item.1.proto,
+           'state': ('present' if item.0.key in dhs_firewall_groups else 'absent') }) ] }}
+  loop: "{{ dhs_firewall_catalogue | dict2items | subelements('value') }}"
+  loop_control:
+    label: "{{ item.0.key }}:{{ item.1.port }}/{{ item.1.proto }}"
+
+- name: Converge (Debian/Ubuntu — ufw)
+  ansible.builtin.include_tasks: debian.yml
+  when: ansible_os_family == "Debian"
+
+- name: Converge (EL — firewalld)
+  ansible.builtin.include_tasks: redhat.yml
+  when: ansible_os_family == "RedHat"
+
+- name: Converge (Windows — Defender Firewall)
+  ansible.builtin.include_tasks: windows.yml
+  when: ansible_os_family == "Windows"

--- a/ansible/roles/dhs_firewall/tasks/redhat.yml
+++ b/ansible/roles/dhs_firewall/tasks/redhat.yml
@@ -1,0 +1,44 @@
+---
+- name: firewalld present
+  ansible.builtin.package:
+    name: firewalld
+    state: present
+
+# Rules are written to the permanent config offline when firewalld is not
+# running (enforce=false), and applied live + permanent when it is.
+- name: Is firewalld running?
+  ansible.builtin.command: systemctl is-active firewalld
+  register: dhs_firewall_fwd
+  changed_when: false
+  failed_when: false
+
+- name: "firewalld ports per connector group (enabled/disabled)"
+  ansible.posix.firewalld:
+    port: "{{ item.port }}/{{ item.proto }}"
+    permanent: true
+    immediate: "{{ dhs_firewall_fwd.stdout == 'active' }}"
+    offline: "{{ dhs_firewall_fwd.stdout != 'active' }}"
+    state: "{{ 'enabled' if item.state == 'present' else 'disabled' }}"
+  loop: "{{ dhs_firewall_rules }}"
+  loop_control:
+    label: "{{ item.name }} {{ item.state }}"
+
+# Legacy ports that are no longer in the catalogue at all (firewalld has
+# no rule names — ports not covered by the catalogue are disabled here).
+- name: "firewalld legacy-only ports disabled"
+  ansible.posix.firewalld:
+    port: "{{ item.port }}/{{ item.proto }}"
+    permanent: true
+    immediate: "{{ dhs_firewall_fwd.stdout == 'active' }}"
+    offline: "{{ dhs_firewall_fwd.stdout != 'active' }}"
+    state: disabled
+  loop: "{{ dhs_firewall_legacy | rejectattr('port', 'in', dhs_firewall_rules | map(attribute='port') | list) | list }}"
+  loop_control:
+    label: "{{ item.name }} {{ item.port }}/{{ item.proto }}"
+
+- name: firewalld enabled and running (enforce mode only)
+  ansible.builtin.service:
+    name: firewalld
+    state: started
+    enabled: true
+  when: dhs_firewall_enforce | bool

--- a/ansible/roles/dhs_firewall/tasks/windows.yml
+++ b/ansible/roles/dhs_firewall/tasks/windows.yml
@@ -1,0 +1,34 @@
+---
+# Connector rules are scoped to the dhs program (authorized app + port);
+# management rules (ssh / winrm) and mDNS are port rules. Rules are named
+# dhs-<group>-<port>-<proto>; absent groups are removed by name.
+- name: "Defender inbound rules per connector group (present/absent)"
+  community.windows.win_firewall_rule:
+    name: "{{ item.name }}"
+    localport: "{{ item.port }}"
+    protocol: "{{ item.proto }}"
+    program: "{{ dhs_firewall_windows_program if (item.program | default(false)) else omit }}"
+    direction: in
+    action: allow
+    profiles: [domain, private, public]
+    enabled: true
+    state: "{{ item.state }}"
+  loop: "{{ dhs_firewall_rules }}"
+  loop_control:
+    label: "{{ item.name }} {{ item.state }}"
+
+# Legacy rule names from the first role version (dhs-<group> without
+# port/proto, catalogue-wide) — removed so only the per-group names remain.
+- name: Remove legacy un-scoped dhs-* rules
+  community.windows.win_firewall_rule:
+    name: "{{ item.name }}"
+    state: absent
+  loop: "{{ dhs_firewall_legacy }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Firewall profiles ON (enforce mode only)
+  community.windows.win_firewall:
+    profiles: [Domain, Private, Public]
+    state: enabled
+  when: dhs_firewall_enforce | bool

--- a/docs/testbed.md
+++ b/docs/testbed.md
@@ -44,7 +44,11 @@ names matter: three LXCs used to answer `dhs`, which collides in Avahi.
 | Ember+ | TCP (S101) | `9000` |
 | Probel SW-P-08 | TCP (DLE) | `2008` |
 | Probel SW-P-02 | TCP | `2002` |
-| AMWA NMOS Node | HTTP | `18080` |
+| AMWA NMOS Node | HTTP | `8080` (CLI default) / `18080` (fleet plan) |
+| AMWA NMOS Registry (Registration/Query) | HTTP + WS | `8235` |
+| AMWA NMOS IS-07 events | WS | `8090` |
+| AMWA NMOS IS-09 System | HTTP | `10641` |
+| Cerebrum NB | TCP | `40007` |
 | mDNS (Avahi / Bonjour) | UDP | `5353` |
 | metrics (`--metrics-addr`) | HTTP | `9100` |
 | SSH / WinRM (mgmt) | TCP | `22` / `5985` |
@@ -53,7 +57,7 @@ All producers run concurrently on the same host; one port per
 connector. The same producer binary is driven by `dhs consumer` and by
 external peers (Cerebrum @ `.5`, AMWA Testing tool in Docker on
 `dhs-tools` `.106`) so wire behaviour can be compared across drivers.
-Host firewalls are managed by the `dhs_firewall` role (#785).
+Host firewalls are managed by the `dhs_firewall` role (#785): each host opens exactly the rule groups of the connectors it declares in `dhs_connectors` (host_vars) plus ssh/metrics(/winrm); other `dhs-*` rules are removed; Windows connector rules are scoped to `C:\dhs\dhs.exe`; the `nmos` group includes mDNS and requires `dhs_mdns`.
 
 ## Control node
 


### PR DESCRIPTION
## What

`dhs_firewall` role: **per-connector** host-firewall rule groups on every OS
(ufw / firewalld / Windows Defender). Each host declares the connectors it
serves (`dhs_connectors` in host_vars); the role opens exactly those groups
plus ssh/metrics(/winrm) and REMOVES every other `dhs-*` rule from the
catalogue. Windows connector rules are scoped to the dhs program
(authorized app + port), not bare ports. The `nmos` group includes mDNS
5353/udp and requires `dhs_mdns`. One switch, `dhs_firewall_enforce`
(default false), turns enforcement on later (hardening = parked).

Closes #785 (epic #780).

## Why

Owner directive (2026-08-23): don't apply all firewall rules everywhere —
per protocol, opened with the connector's deployment ("install Ember+ then
open its rules; NMOS needs ports + Bonjour/Avahi"), and on Windows
authorize the app, not just ports. Before: Linux policy-accept, Rocky no
firewall, win11 only mDNS/WinRM rules.

## How

- `defaults/main.yml`: `dhs_firewall_catalogue` (group → rules, `program:
  true` marks app-scoped rules), base groups, `dhs_connectors: []`.
- `tasks/main.yml`: groups = base (+ windows base) + connectors → one rule
  list with `state: present|absent` per catalogue entry → OS dispatch.
- `debian.yml` ufw allow/delete; `redhat.yml` firewalld enabled/disabled
  (permanent, offline when not running); `windows.yml`
  win_firewall_rule present/absent with `program` for connector rules,
  legacy un-scoped names removed. Enforce blocks unchanged.
- host_vars: producer hosts `[acp1, acp2, emberplus, probel-sw08p,
  probel-sw02p, nmos]`, dhs-tools `[]`.

## Testing

From dhs-debian (.103) — see last comment for the post-rework run; the
first-version run landed rules on all five hosts with run-twice = 0.

- [ ] run-twice = 0 changes on all five hosts (rework run, posted below)
- [x] No Go changes; pre-commit vet/lint clean

## Device tested

- [x] Fleet producer — all five fleet hosts (converge target)
- [ ] Vendor emulator — n/a
- [ ] Real device — n/a
- [ ] No device needed (pure codec / doc change)

## Checklist

- [x] Linked issue (#785)
- [x] Conventional-commit title
- [x] No new Go dependencies (Ansible collections only)
- [x] ADR-0025 step 5/6 respected (Ansible from Linux control node, idempotent)