### PR TITLE
ci: restore Go cache before setup-go with per-job keys; release-please v5 (#794)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,26 @@ jobs:
           # binaries are not read during the build.
           lfs: false
 
+      # Restore the Go module/build cache BEFORE Go runs: Go >= 1.23 drops
+      # golang.org/x/telemetry/config into GOMODCACHE on first go env, and
+      # setup-go's own restore (which runs after that) then dies with
+      # 'tar: File exists' on every job (#794). Per-job (+matrix) keys stop the
+      # 'Unable to reserve cache' races between jobs sharing one key.
+      - uses: actions/cache@v6
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/Library/Caches/go-build
+            ~\AppData\Local\go-build
+          key: go-${{ runner.os }}-${{ github.job }}${{ matrix.distro }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            go-${{ runner.os }}-${{ github.job }}${{ matrix.distro }}-
+
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Go mod tidy
         run: go mod tidy
@@ -180,9 +197,26 @@ jobs:
       - name: Fix git ownership
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+      # Restore the Go module/build cache BEFORE Go runs: Go >= 1.23 drops
+      # golang.org/x/telemetry/config into GOMODCACHE on first go env, and
+      # setup-go's own restore (which runs after that) then dies with
+      # 'tar: File exists' on every job (#794). Per-job (+matrix) keys stop the
+      # 'Unable to reserve cache' races between jobs sharing one key.
+      - uses: actions/cache@v6
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/Library/Caches/go-build
+            ~\AppData\Local\go-build
+          key: go-${{ runner.os }}-${{ github.job }}${{ matrix.distro }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            go-${{ runner.os }}-${{ github.job }}${{ matrix.distro }}-
+
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Build
         run: go build -buildvcs=false ./...
@@ -209,9 +243,26 @@ jobs:
           # binaries are not read during the build.
           lfs: false
 
+      # Restore the Go module/build cache BEFORE Go runs: Go >= 1.23 drops
+      # golang.org/x/telemetry/config into GOMODCACHE on first go env, and
+      # setup-go's own restore (which runs after that) then dies with
+      # 'tar: File exists' on every job (#794). Per-job (+matrix) keys stop the
+      # 'Unable to reserve cache' races between jobs sharing one key.
+      - uses: actions/cache@v6
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/Library/Caches/go-build
+            ~\AppData\Local\go-build
+          key: go-${{ runner.os }}-${{ github.job }}${{ matrix.distro }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            go-${{ runner.os }}-${{ github.job }}${{ matrix.distro }}-
+
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
@@ -230,9 +281,26 @@ jobs:
           # binaries are not read during the build.
           lfs: false
 
+      # Restore the Go module/build cache BEFORE Go runs: Go >= 1.23 drops
+      # golang.org/x/telemetry/config into GOMODCACHE on first go env, and
+      # setup-go's own restore (which runs after that) then dies with
+      # 'tar: File exists' on every job (#794). Per-job (+matrix) keys stop the
+      # 'Unable to reserve cache' races between jobs sharing one key.
+      - uses: actions/cache@v6
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/Library/Caches/go-build
+            ~\AppData\Local\go-build
+          key: go-${{ runner.os }}-${{ github.job }}${{ matrix.distro }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            go-${{ runner.os }}-${{ github.job }}${{ matrix.distro }}-
+
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Build all targets
         run: |
@@ -277,7 +345,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           release-type: go
@@ -293,9 +361,26 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Restore the Go module/build cache BEFORE Go runs: Go >= 1.23 drops
+      # golang.org/x/telemetry/config into GOMODCACHE on first go env, and
+      # setup-go's own restore (which runs after that) then dies with
+      # 'tar: File exists' on every job (#794). Per-job (+matrix) keys stop the
+      # 'Unable to reserve cache' races between jobs sharing one key.
+      - uses: actions/cache@v6
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/Library/Caches/go-build
+            ~\AppData\Local\go-build
+          key: go-${{ runner.os }}-${{ github.job }}${{ matrix.distro }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            go-${{ runner.os }}-${{ github.job }}${{ matrix.distro }}-
+
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
+          cache: false
 
       # Embed the Windows .exe version resource (CompanyName / ProductName /
       # FileVersion / LegalCopyright shown in the Properties dialog) from


### PR DESCRIPTION
## What

Fixes the two warning annotations on every CI run: `Failed to restore: tar
failed with exit code 2` (Lint / Test / Cross-compile) and the release-please
Node 20 deprecation.

Closes #794.

## Why

From the job log: setup-go@v7 installs Go, runs `go env` (Go >= 1.23
auto-downloads `golang.org/x/telemetry/config` into GOMODCACHE), then
restores its cache archive that also contains that module ->
`tar: Cannot open: File exists` -> exit 2 -> the restore FAILS on every
job, so the cache is dead weight and CI is slower than it should be; all
jobs sharing one key also race on `Unable to reserve cache`.
release-please-action v5.0.0 is the Node-24 build of v4 (no behavior change).

## How

- Every job: `actions/cache@v6` BEFORE `setup-go` (restores into an empty
  module cache), paths = GOMODCACHE + GOCACHE for Linux/macOS/Windows, key
  `go-<os>-<job>-<hash go.sum>` + prefix restore-keys; `setup-go`
  `cache: false`.
- `googleapis/release-please-action@v4` -> `@v5`.

## Testing

- [x] This PR's run must be green with NO `Failed to restore` annotation
  (first run per key = cache miss + save, no tar conflict).
- [ ] Post-merge: the SECOND main run shows `Cache restored from key:
  go-Linux-<job>-...` per job (PR-scope caches are not visible to main, so
  restore proof comes from main's second run).

## Device tested

- [x] No device needed (pure CI change)

## Checklist

- [x] Linked issue (#794)
- [x] Conventional-commit title
- [x] No new external dependencies (actions only; cache@v6 / release-please@v5 are Node-24 majors)