### PR TITLE
infra(fleet): fleet-verify.yml - inventory vs live IP/hostname drift check + pfSense MAC table (#786)

### DIFF
--- a/ansible/playbooks/fleet-verify.yml
+++ b/ansible/playbooks/fleet-verify.yml
@@ -1,0 +1,40 @@
+---
+# Read-only drift check for the test fleet (#786, epic #780). Fails loudly
+# when a host's live state no longer matches the inventory truth:
+#   - every NIC IP declared in host_vars `nics:` is actually configured
+#   - the guest hostname equals `fleet_hostname`
+# Run from the control node:
+#   ansible-playbook playbooks/fleet-verify.yml
+# It also prints the MAC -> IP table for the pfSense static mappings.
+- name: Verify fleet addressing and names against the inventory
+  hosts: dhs_clients
+  gather_facts: true
+  tasks:
+    - name: Collect live IPv4 addresses
+      ansible.builtin.set_fact:
+        fv_live_ips: >-
+          {{ (ansible_ip_addresses | default([]) | select('match', '^\d+\.\d+\.\d+\.\d+$') | list)
+             if ansible_os_family == 'Windows'
+             else (ansible_all_ipv4_addresses | default([])) }}
+
+    - name: "Every inventory NIC IP is live on {{ inventory_hostname }}"
+      ansible.builtin.assert:
+        that: item.ip in fv_live_ips
+        fail_msg: >-
+          DRIFT: {{ inventory_hostname }} {{ item.name }} ({{ item.mac }}) should be
+          {{ item.ip }} but live IPv4s are {{ fv_live_ips | join(', ') }} —
+          check the pfSense static mapping (#786).
+        quiet: true
+      loop: "{{ nics }}"
+      loop_control:
+        label: "{{ item.name }}={{ item.ip }}"
+
+    - name: "Guest hostname equals fleet_hostname on {{ inventory_hostname }}"
+      ansible.builtin.assert:
+        that: (ansible_hostname | lower) == fleet_hostname
+        fail_msg: "DRIFT: {{ inventory_hostname }} hostname is {{ ansible_hostname }}, expected {{ fleet_hostname }} (#783)"
+        quiet: true
+
+    - name: pfSense static-mapping table (MAC -> IP) for this host
+      ansible.builtin.debug:
+        msg: "{{ nics | map(attribute='mac') | zip(nics | map(attribute='ip')) | map('join', ' -> ') | list }}"

--- a/docs/testbed.md
+++ b/docs/testbed.md
@@ -65,8 +65,10 @@ Host firewalls are managed by the `dhs_firewall` role (#785): each host opens ex
 `root`, the Windows VM over SSH as `by-rune` (key auth; WinRM/NTLM +
 password file is retired). It holds a clone of this (public) repo at
 `~/acp` and its own ed25519 key (`root@dhs`), which is one of the three
-fleet actor keys below. Never drive the fleet from a Windows
-workstation (PowerShell) — see ADR-0025 step 5.
+fleet actor keys below. After a fresh clone run
+`ansible-playbook playbooks/control-node.yml` (git-lfs + LFS pull of the
+shipped assets, Ansible collections). Never drive the fleet from a
+Windows workstation (PowerShell) — see ADR-0025 step 5.
 
 ## Access — actor keys, not per-host keys
 


### PR DESCRIPTION
## What

`playbooks/fleet-verify.yml`: read-only drift check â€” every NIC IP declared
in `host_vars` `nics:` must be live on the host, guest hostname must equal
`fleet_hostname`; prints the MAC â†’ IP table per host for the pfSense static
DHCP mappings.

Closes the Ansible half of #786 (epic #780). The pfSense static mappings
themselves are the owner's action (pfSense is not Ansible-managed); the MAC
table is in the issue and in this play's output.

Supersedes #793 (auto-closed by GitHub when its base branch was deleted on the #785 merge); same commit, rebased on main.

## Why

All fleet guests are DHCP â€” the .106/.107 confusion was pure lease drift.
Decision: keep guests on DHCP, pin addresses by MAC in pfSense (zero guest
config, survives rebuilds) and let Ansible FAIL LOUDLY when live state
diverges from the inventory truth.

## How

One play, `hosts: dhs_clients`, facts â†’ `set_fact` live IPv4 list (Linux
`ansible_all_ipv4_addresses`, Windows `ansible_ip_addresses`) â†’ `assert`
per NIC â†’ `assert` hostname â†’ `debug` MAC table.

## Testing

From dhs-debian (.103):

```text
# ansible-playbook playbooks/fleet-verify.yml
ok: [dhs-debian] eth0=10.100.0.103 eth1=10.100.0.108 | [dhs-ubuntu] eth0=.102 eth1=.101
ok: [dhs-rocky] eth0=.105 eth1=.104 | [dhs-tools] eth0=.106 | [win11] Ethernet 2=.107
ok: hostname == fleet_hostname on all five
PLAY RECAP all five hosts ok=5 changed=0 failed=0
```

- [x] Read-only (changed=0 by construction)
- [x] No Go changes; pre-commit vet/lint clean

## Device tested

- [x] Fleet producer â€” all five fleet hosts
- [ ] Vendor emulator â€” n/a
- [ ] Real device â€” n/a
- [ ] No device needed (pure codec / doc change)

## Checklist

- [x] Linked issue (#786)
- [x] Conventional-commit title
- [x] No new Go dependencies
- [x] ADR-0025 step 5 respected (Ansible from Linux control node)