### PR TITLE
infra(fleet): dhs_mdns installs Bonjour unattended - carve CAB, Bonjour64.msi /qn, no operator step (#797)

### DIFF
--- a/ansible/roles/dhs_mdns/defaults/main.yml
+++ b/ansible/roles/dhs_mdns/defaults/main.yml
@@ -16,6 +16,7 @@ dhs_mdns_linux_service: avahi-daemon
 dhs_mdns_bonjour_installer_src: "{{ playbook_dir }}/../../internal/amwa/assets/BonjourPSSetup.exe"
 dhs_mdns_bonjour_installer_dst: 'C:\dhs\installers\BonjourPSSetup.exe'
 dhs_mdns_bonjour_service: Bonjour Service
-# Silent install hangs in non-interactive SSH sessions on Win11 (2026-08-23);
-# default = stage + report + manage the service once installed interactively.
-dhs_mdns_bonjour_silent_install: false
+# Where the embedded CAB is carved/expanded to (Bonjour64.msi = the core
+# package dhs needs; the bootstrapper's own silent mode only installs the
+# Print Services MSI, which fails without the core — #797).
+dhs_mdns_bonjour_extract_dir: 'C:\dhs\installers\bonjour'

--- a/ansible/roles/dhs_mdns/tasks/windows.yml
+++ b/ansible/roles/dhs_mdns/tasks/windows.yml
@@ -29,60 +29,43 @@
     src: "{{ dhs_mdns_bonjour_installer_src }}"
     dest: "{{ dhs_mdns_bonjour_installer_dst }}"
 
-- name: Is Bonjour installed? (dnssd.dll present)
-  ansible.windows.win_stat:
-    path: C:\Windows\System32\dnssd.dll
-  register: dhs_mdns_dnssd
+# Apple's BonjourPSSetup.exe is a bootstrapper around an embedded CAB with
+# six MSIs; in silent mode it installs only BonjourPS64.msi (Print
+# Services) which fails "requires Bonjour 2.0 ... install the Bonjour core
+# package first" (MSI 1603 / hang). dhs needs only the core: carve the CAB
+# at the MSCF header whose cbCabinet fits the file, expand it, and install
+# Bonjour64.msi with msiexec /qn. Idempotent: skipped once the MSI exists.
+- name: Extract Bonjour64.msi from the bootstrapper (carve CAB + expand)
+  ansible.windows.win_shell: |
+    $ErrorActionPreference = 'Stop'
+    $exe = '{{ dhs_mdns_bonjour_installer_dst }}'
+    $out = '{{ dhs_mdns_bonjour_extract_dir }}'
+    New-Item -ItemType Directory -Force -Path $out | Out-Null
+    $bytes = [IO.File]::ReadAllBytes($exe)
+    $off = -1; $len = 0
+    for ($i = 0; $i -lt $bytes.Length - 16; $i++) {
+      if ($bytes[$i] -eq 0x4D -and $bytes[$i+1] -eq 0x53 -and $bytes[$i+2] -eq 0x43 -and $bytes[$i+3] -eq 0x46) {
+        $l = [BitConverter]::ToUInt32($bytes, $i + 8)
+        if ($l -gt 1000000 -and ($i + $l) -le $bytes.Length) { $off = $i; $len = $l; break }
+      }
+    }
+    if ($off -lt 0) { throw "no embedded cabinet found in $exe" }
+    $cab = Join-Path $out 'bonjour.cab'
+    $fs = [IO.File]::Create($cab); $fs.Write($bytes, $off, [int]$len); $fs.Close()
+    & expand.exe -F:* $cab $out | Out-Null
+    if (-not (Test-Path (Join-Path $out 'Bonjour64.msi'))) { throw "Bonjour64.msi not found after expand" }
+    "extracted cabinet @$off len=$len"
+  args:
+    creates: "{{ dhs_mdns_bonjour_extract_dir }}\\Bonjour64.msi"
 
-# Silent install of Apple's InstallShield bootstrapper hangs in a
-# non-interactive SSH session on Windows 11 (verified 2026-08-23: both
-# `/quiet` and `/s /v"/qn"` — MSI 1603 or an invisible dialog, 25+ min).
-# Default is therefore: stage + report, and the operator installs once at
-# the console (double-click C:\dhs\installers\BonjourPSSetup.exe). Set
-# dhs_mdns_bonjour_silent_install: true to retry the bounded silent path.
-- name: Bonjour silent install attempt (bounded, opt-in)
-  ansible.windows.win_command:
-    argv:
-      - cmd.exe
-      - /c
-      - 'start /wait "" {{ dhs_mdns_bonjour_installer_dst }} /s /v"/qn /norestart"'
-  async: 600
-  poll: 15
-  register: dhs_mdns_silent
-  failed_when: false
-  changed_when: dhs_mdns_silent.rc | default(1) == 0
-  when:
-    - not dhs_mdns_dnssd.stat.exists
-    - dhs_mdns_bonjour_silent_install | bool
-
-# Separate register: a skipped task would otherwise overwrite the first
-# stat result with a {skipped: true} dict that has no .stat.
-- name: Re-check Bonjour after the silent attempt
-  ansible.windows.win_stat:
-    path: C:\Windows\System32\dnssd.dll
-  register: dhs_mdns_dnssd_after
-  when:
-    - not dhs_mdns_dnssd.stat.exists
-    - dhs_mdns_bonjour_silent_install | bool
-
-- name: Resolve Bonjour presence
-  ansible.builtin.set_fact:
-    dhs_mdns_bonjour_present: >-
-      {{ dhs_mdns_dnssd.stat.exists
-         or (dhs_mdns_dnssd_after.stat.exists | default(false)) }}
-
-- name: Bonjour not installed — operator action required (not a failure)
-  ansible.builtin.debug:
-    msg: >-
-      Bonjour is NOT installed on {{ inventory_hostname }}. Installer is staged at
-      {{ dhs_mdns_bonjour_installer_dst }} — run it once interactively at the
-      console; this role then keeps the service enabled (#784). dhs uses the
-      stdlib mDNS fallback meanwhile (#195).
-  when: not (dhs_mdns_bonjour_present | bool)
+- name: Install Bonjour core (Bonjour64.msi) silently
+  ansible.windows.win_package:
+    path: "{{ dhs_mdns_bonjour_extract_dir }}\\Bonjour64.msi"
+    arguments: /qn /norestart
+    state: present
 
 - name: Bonjour Service running and automatic
   ansible.windows.win_service:
     name: "{{ dhs_mdns_bonjour_service }}"
     state: started
     start_mode: auto
-  when: dhs_mdns_bonjour_present | bool

--- a/docs/testbed.md
+++ b/docs/testbed.md
@@ -94,12 +94,13 @@ signing belongs to the parked hardening topic).
 
 Avahi 0.8 is installed, active and pinned by the `dhs_mdns` role on all
 four LXCs (Docker hosts exclude `docker0` from Avahi). On `win11` the
-role stages Apple's `BonjourPSSetup.exe` at `C:\dhs\installers\` and
-manages the service, but the silent install hangs in non-interactive
-sessions on Windows 11 — install it ONCE interactively at the VM
-console (double-click the staged installer); the role then keeps
-"Bonjour Service" running. dhs uses the stdlib mDNS fallback on Windows
-until the Bonjour backend (#195) lands, so this is not load-bearing yet.
+role installs Apple Bonjour unattended: it stages `BonjourPSSetup.exe`
+at `C:\dhs\installers\`, carves the embedded CAB, expands it and
+installs the core `Bonjour64.msi` with `msiexec /qn` (the bootstrapper's
+own silent mode only installs the Print-Services MSI, which fails
+without the core — #797), then keeps "Bonjour Service" running /
+automatic. dhs uses the stdlib mDNS fallback on Windows until the
+Bonjour backend (#195) lands.
 
 ## Host baseline (`dhs_host` role, #800)
 


### PR DESCRIPTION
## What

`dhs_mdns` now installs Apple Bonjour on win11 **unattended**: stage
`BonjourPSSetup.exe` (LFS guard), carve the embedded CAB at the `MSCF`
header whose `cbCabinet` fits the file, `expand -F:*`, install the core
`Bonjour64.msi` with `msiexec /qn /norestart` (win_package, idempotent by
product code), keep "Bonjour Service" running/automatic. The opt-in
silent flag and the "operator installs at the console" notice are gone.
testbed.md mDNS section updated.

Closes #797 (completes #784, epic #780).

## Why

Owner: Ansible must install Bonjour, not the operator. Root cause from
the MSI log of the earlier failures: Apple's bootstrapper bundles six
MSIs and in silent mode installs only `BonjourPS64.msi` (Print Services),
which fails 1603 / hangs with *"Bonjour Print Services requires Bonjour
2.0 or newer ... install the Bonjour core package first"*. dhs needs only
the core.

## How

- `tasks/windows.yml`: `win_shell` carve+expand (`creates:
  <extract_dir>\Bonjour64.msi`), `win_package` MSI `/qn /norestart`,
  `win_service`.
- `defaults/main.yml`: `dhs_mdns_bonjour_extract_dir`, flag removed.
- Verified by hand first on win11: cabinet @ offset 90848, cbCabinet
  5228595 (= the bootstrapper log's "Total length of cabinet file"),
  msiexec exit 0 in ~10 s, dnssd.dll present, service Running/Auto.

## Testing

Clean-slate proof from dhs-debian (.103): uninstall the core, then
`fleet-converge.yml -l win11` twice — posted as a comment below when the
run completes.

- [ ] run 1 installs unattended; run 2 = 0 changes (ADR-0007)
- [x] No Go changes; pre-commit vet/lint clean

## Device tested

- [x] Fleet producer — win11 (10.100.0.107)
- [ ] Vendor emulator — n/a
- [ ] Real device — n/a
- [ ] No device needed (pure codec / doc change)

## Checklist

- [x] Linked issue (#797)
- [x] Conventional-commit title
- [x] No new Go dependencies
- [x] ADR-0025 step 5/6 respected (Ansible from Linux control node, idempotent)