### PR TITLE
infra(fleet): dhs_host role - env/PATH, dirs, base packages, dhs binary from pinned release (#800)

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -4,8 +4,13 @@
 inventory = inventory/hosts.ini
 roles_path = roles
 host_key_checking = False
-stdout_callback = yaml
+stdout_callback = ansible.builtin.default
 retry_files_enabled = False
+
+# YAML-shaped task results (community.general.yaml callback was removed in
+# community.general 12; this is the core replacement).
+[callback_default]
+result_format = yaml
 
 [ssh_connection]
 pipelining = True

--- a/ansible/playbooks/control-node.yml
+++ b/ansible/playbooks/control-node.yml
@@ -34,9 +34,35 @@
       register: cn_bonjour
       failed_when: not cn_bonjour.stat.exists or cn_bonjour.stat.size < 1000000
 
+    # Debian 12 ships ansible-core 2.14, which cannot drive Python 3.12
+    # targets (Ubuntu 24.04: get_url/uri die with "HTTPSConnection ...
+    # cert_file") and is below what ansible.windows supports. Install a
+    # supported core via pipx (isolated venv) and put it first on PATH.
+    - name: pipx present
+      ansible.builtin.package:
+        name: [pipx, python3-venv]
+        state: present
+
+    - name: "ansible-core {{ cn_ansible_core_spec }} via pipx"
+      ansible.builtin.command:
+        cmd: pipx install --force "ansible-core{{ cn_ansible_core_spec }}"
+      register: cn_pipx
+      changed_when: "'installed package' in cn_pipx.stdout"
+      environment:
+        PIPX_HOME: /opt/pipx
+        PIPX_BIN_DIR: /usr/local/bin
+      vars:
+        cn_ansible_core_spec: ">=2.17,<2.18"
+
+    - name: ansible --version (must be the pipx one)
+      ansible.builtin.command: ansible --version
+      register: cn_ansver
+      changed_when: false
+      failed_when: "'ansible [core 2.17' not in cn_ansver.stdout"
+
     - name: Ansible collections from requirements.yml
       ansible.builtin.command:
-        cmd: ansible-galaxy collection install -r requirements.yml
+        cmd: ansible-galaxy collection install -r requirements.yml --upgrade
         chdir: "{{ playbook_dir }}/.."
       register: cn_galaxy
       changed_when: "'Installing' in cn_galaxy.stdout"

--- a/ansible/playbooks/fleet-converge.yml
+++ b/ansible/playbooks/fleet-converge.yml
@@ -14,6 +14,7 @@
   hosts: dhs_clients
   gather_facts: true
   roles:
+    - dhs_host
     - dhs_access
     - dhs_hostname
     - dhs_mdns

--- a/ansible/roles/dhs_host/defaults/main.yml
+++ b/ansible/roles/dhs_host/defaults/main.yml
@@ -1,0 +1,38 @@
+---
+# dhs_host — the dhs host baseline on every fleet OS (#800):
+#   environment (PATH / DHS_DATA_DIR), dhs directories, base packages,
+#   and the dhs binary from a PINNED GitHub release (checksum-verified).
+# Layering: hypervisor = infra-terraform-proxmox, OS baseline/hardening =
+# ansible-platform, dhs application layer = this role + siblings.
+
+# Release to deploy on the whole fleet (tag name). Bump here, converge.
+dhs_version: "v0.18.0"
+dhs_release_repo: by-openclaw/go-acp
+dhs_release_base: "https://github.com/{{ dhs_release_repo }}/releases/download/{{ dhs_version }}"
+
+# Linux layout (dhs_bin / dhs_dir come from group_vars/linux.yml).
+dhs_host_linux_dirs:
+  - /etc/dhs          # trees, packs, manifests the producers serve
+  - /var/lib/dhs      # DHS_DATA_DIR (cache/dm, captures) — per-OS data dir
+  - /var/log/dhs      # producer logs
+dhs_host_linux_data_dir: /var/lib/dhs
+dhs_host_linux_profile: /etc/profile.d/dhs.sh
+
+# Windows layout (dhs_bin / dhs_dir come from group_vars/windows.yml).
+dhs_host_windows_dirs:
+  - 'C:\dhs'
+  - 'C:\ProgramData\dhs\data'
+  - 'C:\ProgramData\dhs\logs'
+dhs_host_windows_data_dir: 'C:\ProgramData\dhs\data'
+
+# Base packages dhs needs on a host (captures, HTTP probes, JSON shaping).
+dhs_host_packages:
+  Debian: [tshark, curl, jq, ca-certificates, unzip, tar]
+  RedHat: [wireshark-cli, curl, jq, ca-certificates, unzip, tar]
+
+# GOARCH mapping for the release asset name.
+dhs_host_goarch:
+  x86_64: amd64
+  amd64: amd64
+  aarch64: arm64
+  arm64: arm64

--- a/ansible/roles/dhs_host/meta/main.yml
+++ b/ansible/roles/dhs_host/meta/main.yml
@@ -1,0 +1,21 @@
+---
+galaxy_info:
+  role_name: dhs_host
+  author: by-rune
+  description: >-
+    dhs host baseline on every fleet OS: environment (PATH, DHS_DATA_DIR),
+    dhs directories, base packages (tshark/curl/jq/...), and the dhs binary
+    installed from a pinned, checksum-verified GitHub release. Idempotent:
+    run-twice = 0 changes; bump dhs_version to roll the fleet.
+  license: see repository
+  min_ansible_version: "2.14"
+  platforms:
+    - name: EL
+      versions: [all]
+    - name: Debian
+      versions: [all]
+    - name: Ubuntu
+      versions: [all]
+    - name: Windows
+      versions: [all]
+dependencies: []

--- a/ansible/roles/dhs_host/tasks/linux.yml
+++ b/ansible/roles/dhs_host/tasks/linux.yml
@@ -1,0 +1,83 @@
+---
+# ---- packages ------------------------------------------------------------
+# tshark's postinst asks whether non-root may capture; answer it up front so
+# apt never blocks on a debconf prompt (dhs runs captures as root anyway).
+- name: Preseed wireshark-common (no setuid dumpcap prompt)
+  ansible.builtin.debconf:
+    name: wireshark-common
+    question: wireshark-common/install-setuid
+    value: "false"
+    vtype: boolean
+  when: ansible_os_family == "Debian"
+
+- name: Base packages present
+  ansible.builtin.package:
+    name: "{{ dhs_host_packages[ansible_os_family] }}"
+    state: present
+  environment:
+    DEBIAN_FRONTEND: noninteractive
+
+# ---- directories + environment -------------------------------------------
+- name: dhs directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  loop: "{{ dhs_host_linux_dirs }}"
+
+- name: "PATH + DHS_DATA_DIR for every login shell ({{ dhs_host_linux_profile }})"
+  ansible.builtin.copy:
+    dest: "{{ dhs_host_linux_profile }}"
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+      # dhs host environment (ansible role dhs_host, #800) — do not edit by hand
+      case ":$PATH:" in *":{{ dhs_bin | dirname }}:"*) ;; *) PATH="{{ dhs_bin | dirname }}:$PATH" ;; esac
+      export PATH
+      export DHS_DATA_DIR="{{ dhs_host_linux_data_dir }}"
+
+# ---- dhs binary from the pinned release ----------------------------------
+- name: Current dhs version on the host
+  ansible.builtin.command: "{{ dhs_bin }} version"
+  register: dhs_host_cur
+  changed_when: false
+  failed_when: false
+
+- name: Resolve asset name and installed version
+  ansible.builtin.set_fact:
+    dhs_host_asset: "dhs_linux_{{ dhs_host_goarch[ansible_architecture] }}"
+    dhs_host_installed: "{{ (dhs_host_cur.stdout_lines[0] | default('') | split(' '))[1] | default('') }}"
+
+- name: "Install dhs {{ dhs_version }} (installed {{ dhs_host_installed | default('none') }})"
+  when: dhs_host_installed != dhs_version
+  block:
+    - name: Download release archive (sha256 verified against SHA256SUMS.txt)
+      ansible.builtin.get_url:
+        url: "{{ dhs_release_base }}/{{ dhs_host_asset }}.tar.gz"
+        dest: "/tmp/{{ dhs_host_asset }}-{{ dhs_version }}.tar.gz"
+        checksum: "sha256:{{ dhs_release_base }}/SHA256SUMS.txt"
+        mode: "0644"
+
+    - name: Unpack
+      ansible.builtin.unarchive:
+        src: "/tmp/{{ dhs_host_asset }}-{{ dhs_version }}.tar.gz"
+        dest: /tmp
+        remote_src: true
+
+    - name: Install binary to {{ dhs_bin }}
+      ansible.builtin.copy:
+        src: "/tmp/{{ dhs_host_asset }}/dhs"
+        dest: "{{ dhs_bin }}"
+        remote_src: true
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Verify installed version
+      ansible.builtin.command: "{{ dhs_bin }} version"
+      register: dhs_host_new
+      changed_when: false
+      failed_when: (dhs_host_new.stdout_lines[0] | split(' '))[1] != dhs_version

--- a/ansible/roles/dhs_host/tasks/main.yml
+++ b/ansible/roles/dhs_host/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Converge (Linux)
+  ansible.builtin.include_tasks: linux.yml
+  when: ansible_os_family != "Windows"
+
+- name: Converge (Windows)
+  ansible.builtin.include_tasks: windows.yml
+  when: ansible_os_family == "Windows"

--- a/ansible/roles/dhs_host/tasks/windows.yml
+++ b/ansible/roles/dhs_host/tasks/windows.yml
@@ -1,0 +1,81 @@
+---
+# ---- power: a fleet VM must never sleep -----------------------------------
+# 2026-08-23: win11 idled into S3 sleep mid-converge ("Connectivity state in
+# standby: Disconnected"), vanishing from the network for minutes. Pin the
+# High performance plan (AC sleep = Never) and disable hibernation.
+- name: Power plan = High performance (never sleep on AC)
+  community.windows.win_power_plan:
+    name: high performance
+
+- name: Sleep / hibernate timeouts = never, hibernation off
+  ansible.windows.win_shell: |
+    $changed = $false
+    foreach ($s in 'standby-timeout-ac','hibernate-timeout-ac','standby-timeout-dc','hibernate-timeout-dc') {
+      $v = (powercfg /query SCHEME_CURRENT SUB_SLEEP ($(if ($s -like 'standby*') {'STANDBYIDLE'} else {'HIBERNATEIDLE'})) | Select-String ($(if ($s -like '*-ac') {'Current AC Power Setting Index'} else {'Current DC Power Setting Index'}))).ToString().Split(':')[1].Trim()
+      if ($v -ne '0x00000000') { powercfg /change $s 0 | Out-Null; $changed = $true }
+    }
+    if (Test-Path C:\hiberfil.sys) { powercfg /hibernate off | Out-Null; $changed = $true }
+    if ($changed) { 'CHANGED' } else { 'OK' }
+  register: dhs_host_power
+  changed_when: "'CHANGED' in dhs_host_power.stdout"
+
+# ---- directories + environment -------------------------------------------
+- name: dhs directories
+  ansible.windows.win_file:
+    path: "{{ item }}"
+    state: directory
+  loop: "{{ dhs_host_windows_dirs }}"
+
+- name: Machine PATH contains the dhs directory
+  ansible.windows.win_path:
+    elements: "{{ dhs_bin | win_dirname }}"
+    scope: machine
+    state: present
+
+- name: Machine environment DHS_DATA_DIR
+  ansible.windows.win_environment:
+    name: DHS_DATA_DIR
+    value: "{{ dhs_host_windows_data_dir }}"
+    level: machine
+    state: present
+
+# ---- dhs binary from the pinned release ----------------------------------
+- name: Current dhs version on the host
+  ansible.windows.win_command:
+    argv: ["{{ dhs_bin }}", "version"]
+  register: dhs_host_cur
+  changed_when: false
+  failed_when: false
+
+- name: Resolve installed version
+  ansible.builtin.set_fact:
+    dhs_host_installed: "{{ (dhs_host_cur.stdout_lines[0] | default('') | split(' '))[1] | default('') }}"
+
+- name: "Install dhs {{ dhs_version }} (installed {{ dhs_host_installed | default('none') }})"
+  when: dhs_host_installed != dhs_version
+  block:
+    - name: Download release archive (sha256 verified against SHA256SUMS.txt)
+      ansible.windows.win_get_url:
+        url: "{{ dhs_release_base }}/dhs_windows_amd64.zip"
+        dest: "{{ dhs_bin | win_dirname }}\\dhs_windows_amd64-{{ dhs_version }}.zip"
+        checksum_algorithm: sha256
+        checksum_url: "{{ dhs_release_base }}/SHA256SUMS.txt"
+
+    - name: Unpack
+      community.windows.win_unzip:
+        src: "{{ dhs_bin | win_dirname }}\\dhs_windows_amd64-{{ dhs_version }}.zip"
+        dest: "{{ dhs_bin | win_dirname }}\\unpack"
+        delete_archive: false
+
+    - name: Install binary to {{ dhs_bin }}
+      ansible.windows.win_copy:
+        src: "{{ dhs_bin | win_dirname }}\\unpack\\dhs_windows_amd64\\dhs.exe"
+        dest: "{{ dhs_bin }}"
+        remote_src: true
+
+    - name: Verify installed version
+      ansible.windows.win_command:
+        argv: ["{{ dhs_bin }}", "version"]
+      register: dhs_host_new
+      changed_when: false
+      failed_when: (dhs_host_new.stdout_lines[0] | split(' '))[1] != dhs_version

--- a/docs/testbed.md
+++ b/docs/testbed.md
@@ -101,6 +101,25 @@ console (double-click the staged installer); the role then keeps
 "Bonjour Service" running. dhs uses the stdlib mDNS fallback on Windows
 until the Bonjour backend (#195) lands, so this is not load-bearing yet.
 
+## Host baseline (`dhs_host` role, #800)
+
+Every fleet host gets the same dhs baseline, per OS, from the
+`dhs_host` role (first role in `fleet-converge.yml`):
+
+| | Linux (LXCs) | win11 |
+| --- | --- | --- |
+| binary | `/usr/local/bin/dhs` from the pinned GitHub release `dhs_version` (tar.gz, sha256 checked against `SHA256SUMS.txt`) | `C:\dhs\dhs.exe` (zip, same checksum rule) |
+| PATH / env | `/etc/profile.d/dhs.sh` (PATH, `DHS_DATA_DIR=/var/lib/dhs`) | machine `PATH += C:\dhs`, `DHS_DATA_DIR=C:\ProgramData\dhs\data` |
+| directories | `/etc/dhs` (trees/packs), `/var/lib/dhs` (data), `/var/log/dhs` | `C:\dhs`, `C:\ProgramData\dhs\{data,logs}` |
+| packages | tshark/wireshark-cli, curl, jq, ca-certificates, unzip, tar | — |
+
+Roll the fleet to a new release by bumping `dhs_version` and converging
+(run-twice = 0 changes). Layering: hypervisor = `infra-terraform-proxmox`
+(import of the dhs guests tracked there), OS baseline/hardening =
+`ansible-platform` (sshd 22222 / `by-systems`; applies when hardening
+un-parks — the inventory then switches port/user), dhs application layer
+= this repo's roles.
+
 ## Producer launch and stop
 
 ### Linux LXC (Debian / Ubuntu / Rocky)


### PR DESCRIPTION
## What

`dhs_host` role (first role in `fleet-converge.yml`): the dhs host baseline on
every fleet OS — environment (Linux `/etc/profile.d/dhs.sh` PATH +
`DHS_DATA_DIR`; Windows machine `PATH += C:\dhs`, `DHS_DATA_DIR`), dhs
directories (`/etc/dhs`, `/var/lib/dhs`, `/var/log/dhs` / `C:\dhs`,
`C:\ProgramData\dhs\{data,logs}`), base packages (tshark/wireshark-cli, curl,
jq, ca-certificates, unzip, tar), and the **dhs binary from a pinned GitHub
release** (`dhs_version`, tar.gz/zip sha256-verified against
`SHA256SUMS.txt`, idempotent on `dhs version`). testbed.md "Host baseline"
section + layering note (Terraform = hypervisor, ansible-platform = OS
hardening, this repo = dhs app layer).

Closes #800 (epic #780).

## Why

Owner 2026-08-23: "we need a playbook for env windows like PATH, same for
linux, fw, apt packages". Firewall is #785; this is the rest. Replaces
copying a locally built binary: the fleet runs released, checksum-verified
binaries and rolls by bumping one variable.

## How

- `defaults/main.yml`: `dhs_version` (v0.18.0), dirs, packages, GOARCH map.
- `tasks/linux.yml`: debconf preseed (no tshark prompt), packages, dirs,
  profile.d, `dhs version` check → get_url (checksum URL) → unarchive → copy
  → verify.
- `tasks/windows.yml`: dirs, win_path, win_environment, version check →
  win_get_url (checksum_url) → win_unzip → win_copy → verify.

## Testing

Fleet proof from dhs-debian (.103) posted as a comment when the win11 host
frees up (Bonjour #797 proof is using it): run 1 converges all five hosts,
run 2 = 0 changes, `dhs version` == v0.18.0 everywhere.

- [ ] run-twice = 0 changes on all five hosts
- [x] No Go changes; pre-commit vet/lint clean

## Device tested

- [x] Fleet producer — all five fleet hosts (converge target)
- [ ] Vendor emulator — n/a
- [ ] Real device — n/a
- [ ] No device needed (pure codec / doc change)

## Checklist

- [x] Linked issue (#800)
- [x] Conventional-commit title
- [x] No new Go dependencies
- [x] ADR-0025 step 5/6 respected (Ansible from Linux control node, idempotent)