### PR TITLE
infra(fleet): fleet-update.yml - OS updates, reboot-if-required, continue (win_updates / apt / dnf) (#799)

### DIFF
--- a/ansible/playbooks/fleet-update.yml
+++ b/ansible/playbooks/fleet-update.yml
@@ -1,0 +1,127 @@
+---
+# OS updates for the test fleet, with reboot-if-required and continuation
+# (epic #780). Proves in the lab what prod needs: Ansible patches the OS,
+# reboots only when the OS asks for it, regains access over the same SSH
+# path, and completes the remaining tasks.
+#
+#   cd ~/acp/ansible
+#   ansible-playbook playbooks/fleet-update.yml            # apply (may reboot hosts)
+#   ansible-playbook playbooks/fleet-update.yml            # again -> 0 updates, 0 changes
+#   ansible-playbook playbooks/fleet-update.yml -l win11   # one host
+#
+# The control node (group `control`) is never rebooted mid-play: it is
+# upgraded and a pending reboot is REPORTED; reboot it by hand between runs.
+
+- name: Windows — Windows Update via Ansible, reboot if required, continue
+  hosts: windows
+  gather_facts: true
+  tasks:
+    - name: Install Windows updates (security, critical, rollups, updates); reboot when required
+      ansible.windows.win_updates:
+        category_names:
+          - SecurityUpdates
+          - CriticalUpdates
+          - UpdateRollups
+          - Updates
+        state: installed
+        reboot: true
+        reboot_timeout: 1800
+      register: fu_win
+
+    - name: Windows update summary
+      ansible.builtin.debug:
+        msg: >-
+          {{ inventory_hostname }}: found={{ fu_win.found_update_count | default(0) }}
+          installed={{ fu_win.installed_update_count | default(0) }}
+          rebooted={{ fu_win.reboot_required | default(false) | ternary('pending', 'done/none') }}
+          titles={{ (fu_win.updates | default({})).values() | map(attribute='title') | list }}
+
+    # Continuation proof: these run AFTER any reboot win_updates performed.
+    - name: Post-update — host answers over SSH
+      ansible.windows.win_ping:
+
+    - name: Post-update — fleet services still running (sshd, Bonjour if installed)
+      ansible.windows.win_service_info:
+        name: "{{ item }}"
+      loop: [sshd, "Bonjour Service"]
+      register: fu_svc
+      failed_when: false
+
+    - name: Post-update — service states
+      ansible.builtin.debug:
+        msg: "{{ item.item }}: {{ (item.services | default([{'state':'absent'}]))[0].state }}"
+      loop: "{{ fu_svc.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+
+- name: "Linux — package upgrade, reboot if the OS requires it (control node reports only)"
+  hosts: linux
+  gather_facts: true
+  tasks:
+    - name: Upgrade packages (Debian/Ubuntu)
+      ansible.builtin.apt:
+        update_cache: true
+        upgrade: dist
+        autoremove: true
+      when: ansible_os_family == "Debian"
+      register: fu_apt
+
+    # `needs-restarting` (used below) ships in dnf-utils — a minimal Rocky
+    # image does not have it, and the reboot check then fails with rc=2.
+    - name: dnf-utils present (provides needs-restarting)
+      ansible.builtin.dnf:
+        name: dnf-utils
+        state: present
+      when: ansible_os_family == "RedHat"
+
+    - name: Upgrade packages (EL)
+      ansible.builtin.dnf:
+        name: "*"
+        state: latest
+      when: ansible_os_family == "RedHat"
+      register: fu_dnf
+
+    - name: Reboot required? (Debian/Ubuntu flag file)
+      ansible.builtin.stat:
+        path: /var/run/reboot-required
+      register: fu_rr_deb
+      when: ansible_os_family == "Debian"
+
+    - name: Reboot required? (EL needs-restarting)
+      ansible.builtin.command: needs-restarting -r
+      register: fu_rr_el
+      changed_when: false
+      failed_when: fu_rr_el.rc not in [0, 1]
+      when: ansible_os_family == "RedHat"
+
+    - name: Resolve reboot requirement
+      ansible.builtin.set_fact:
+        fu_reboot_required: >-
+          {{ (ansible_os_family == 'Debian' and (fu_rr_deb.stat.exists | default(false)))
+             or (ansible_os_family == 'RedHat' and (fu_rr_el.rc | default(0)) == 1) }}
+
+    - name: Reboot (not the control node) and wait for SSH to return
+      ansible.builtin.reboot:
+        reboot_timeout: 600
+        test_command: systemctl is-system-running --wait || true
+      when:
+        - fu_reboot_required | bool
+        - "'control' not in group_names"
+
+    - name: Control node needs a reboot — report only (never mid-play)
+      ansible.builtin.debug:
+        msg: "{{ inventory_hostname }} (control node) requires a reboot — do it between runs"
+      when:
+        - fu_reboot_required | bool
+        - "'control' in group_names"
+
+    # Continuation proof after a reboot.
+    - name: Post-update — host answers
+      ansible.builtin.ping:
+
+    - name: Post-update — avahi + sshd running
+      ansible.builtin.service_facts:
+
+    - name: Post-update — service states
+      ansible.builtin.debug:
+        msg: "avahi-daemon={{ ansible_facts.services['avahi-daemon.service'].state | default('absent') }} ssh={{ (ansible_facts.services['ssh.service'] | default(ansible_facts.services['sshd.service'] | default({'state':'absent'}))).state }}"

--- a/docs/testbed.md
+++ b/docs/testbed.md
@@ -176,6 +176,18 @@ OpenSSH Server on the VM, `dhs.exe` under `C:\dhs\dhs.exe` (see
 `Start-Process -WindowStyle Hidden` with stdout/stderr redirected to
 `C:\ProgramData\dhs\logs\`.
 
+## OS updates (reboot-if-required, then continue)
+
+`ansible/playbooks/fleet-update.yml` (#799) patches the fleet the way
+production will: Windows Update on `win11` through `win_updates`
+(security/critical/rollups/updates) with `reboot: true` — Ansible
+performs the reboot only when Windows requires it, waits for SSH to
+return on the same path and **continues** with the post-update tasks;
+`apt`/`dnf` upgrades on the LXCs with `reboot` only when the OS flags it
+(`/var/run/reboot-required`, `needs-restarting -r`). The control node is
+never rebooted mid-play (reported instead — reboot it between runs).
+Second run = 0 updates / 0 changes.
+
 ## Caveats
 
 - `amwa/nmos-testing:latest` upstream regressed to the "Controller
@@ -194,5 +206,5 @@ OpenSSH Server on the VM, `dhs.exe` under `C:\dhs\dhs.exe` (see
 Tracked in epic #780: static addressing (#786, `dhs_netaddr`), unique
 hostnames (#783), actor-key convergence (#782), mDNS (#784, #797),
 firewall (#785), host baseline (#800), OS updates + reboot (#799),
-win11 Ansible latency (#790). pfSense hygiene (owner, any time): exclude
-`10.100.0.100–120` from the DHCP pool.
+time sync + IPv6 (#804), win11 Ansible latency (#790). pfSense hygiene
+(owner, any time): exclude `10.100.0.100–120` from the DHCP pool.


### PR DESCRIPTION
## What

`playbooks/fleet-update.yml`: OS updates with reboot-if-required and
continuation — Windows Update on win11 via `win_updates` (security /
critical / rollups / updates, `reboot: true`), `apt`/`dnf` upgrades on the
LXCs with `reboot` only when the OS flags it (`/var/run/reboot-required`,
`needs-restarting -r`); the control node is never rebooted mid-play
(reported). Post-update tasks (ping, service states) prove Ansible regains
access and continues. testbed.md section.

Closes #799 (epic #780).

## Why

Owner 2026-08-23: "update windows package and ask reboot to apply update then
continue where you were — must be done in prod; make sure it works and you
get access back after reboot to complete tasks". Proved in the lab first.

## How

Two plays (windows, linux); `win_updates` performs the reboot itself and
waits; Linux uses `ansible.builtin.reboot` (`test_command: systemctl
is-system-running`) guarded by the OS reboot flag and `'control' not in
group_names`.

## Testing

Fleet proof from dhs-debian (.103) posted as a comment after the win11
host frees up: win11 updates installed + reboot performed by Ansible + play
continued; LXCs upgraded, reboot honored where flagged; second run 0 updates.

- [ ] win11: updates + reboot + continuation; run 2 = 0 changes
- [ ] LXCs: upgraded; run 2 = 0 changes
- [x] No Go changes; pre-commit vet/lint clean

## Device tested

- [x] Fleet producer — all five fleet hosts
- [ ] Vendor emulator — n/a
- [ ] Real device — n/a
- [ ] No device needed (pure codec / doc change)

## Checklist

- [x] Linked issue (#799)
- [x] Conventional-commit title
- [x] No new Go dependencies
- [x] ADR-0025 step 5 respected (Ansible from Linux control node)