### PR TITLE
infra(fleet): dhs_netaddr - static addressing from inventory, fleet renumbered per mgmt ports (#786)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -59,8 +59,8 @@ Closes #
 
 ## Device tested
 
-- [ ] Fleet producer — which host per `docs/testbed.md` (dhs-ubuntu .102 / dhs-debian .103 / dhs-rocky .105 / win11 .107)
-- [ ] Vendor emulator — Synapse ACP1 (office net 10.6.239.113) / TinyEmber+ (desk-03) / AMWA NMOS Testing tool (dhs-tools .106)
+- [ ] Fleet producer — which host per `docs/testbed.md` (dhs-debian .101 / dhs-ubuntu .102 / dhs-rocky .103 / win11 .105)
+- [ ] Vendor emulator — Synapse ACP1 (office net 10.6.239.113) / TinyEmber+ (desk-03) / AMWA NMOS Testing tool (dhs-tools .104)
 - [ ] Real device — Neuron (ACP2 / CCM) / Cerebrum staging (.5) / other (specify)
 - [ ] No device needed (pure codec / doc change)
 

--- a/ansible/inventory/host_vars/dhs-debian.yml
+++ b/ansible/inventory/host_vars/dhs-debian.yml
@@ -1,8 +1,8 @@
 ---
 # dhs-debian — Proxmox LXC 651 "dhs.debian12", Debian 12 (bookworm).
-# Dual-NIC: eth0 10.100.0.103 (ansible_host) / eth1 10.100.0.108.
+# Dual-NIC: eth0 10.100.0.101 (ansible_host) / eth1 10.100.0.111.
 # Roles: Ansible CONTROL NODE for the whole fleet; Docker host.
-# Never bring eth1/.108 down — it is part of the access path.
+# Never bring eth1/.111 down — it is part of the access path.
 # This host IS the control node: run local, no SSH loop-back needed.
 ansible_connection: local
 
@@ -10,8 +10,8 @@ pve_vmid: 651
 pve_name: dhs.debian12
 os_label: "Debian 12"
 nics:
-  - { name: eth0, mac: "BC:24:11:80:E3:AC", ip: 10.100.0.103 }
-  - { name: eth1, mac: "BC:24:11:91:97:7C", ip: 10.100.0.108 }
+  - { name: eth0, mac: "BC:24:11:80:E3:AC", ip: 10.100.0.101 }
+  - { name: eth1, mac: "BC:24:11:91:97:7C", ip: 10.100.0.111 }
 fleet_hostname: dhs-debian
 
 # Ember+ producer: our integration DM — the synthetic tree that carries the

--- a/ansible/inventory/host_vars/dhs-rocky.yml
+++ b/ansible/inventory/host_vars/dhs-rocky.yml
@@ -1,13 +1,13 @@
 ---
 # dhs-rocky — Proxmox LXC 653 "dhs.rocky9", Rocky Linux 9.4.
-# Dual-NIC: eth0 10.100.0.105 (ansible_host) / eth1 10.100.0.104.
-# (.104 and .105 are the SAME host — older docs listed them as two.)
+# Dual-NIC: eth0 10.100.0.103 (ansible_host) / eth1 10.100.0.113.
+# (one host, two mgmt ports; the old .104/.105 leases were this host.)
 pve_vmid: 653
 pve_name: dhs.rocky9
 os_label: "Rocky 9.4"
 nics:
-  - { name: eth0, mac: "BC:24:11:2B:F7:C7", ip: 10.100.0.105 }
-  - { name: eth1, mac: "BC:24:11:33:74:4A", ip: 10.100.0.104 }
+  - { name: eth0, mac: "BC:24:11:2B:F7:C7", ip: 10.100.0.103 }
+  - { name: eth1, mac: "BC:24:11:33:74:4A", ip: 10.100.0.113 }
 fleet_hostname: dhs-rocky
 
 # Ember+ producer: the Lawo PowerCore tree (1024-target matrix), rebuilt from

--- a/ansible/inventory/host_vars/dhs-tools.yml
+++ b/ansible/inventory/host_vars/dhs-tools.yml
@@ -1,5 +1,6 @@
 ---
-# dhs-tools — Proxmox LXC 655 "dhs.tools", Ubuntu, single NIC 10.100.0.106.
+# dhs-tools — Proxmox LXC 655 "dhs.tools", Ubuntu, single NIC 10.100.0.104
+# (static, #786; the old DHCP lease was .106).
 # Tooling host: Docker + the AMWA NMOS Testing tool (scripts/amwa/*),
 # tshark / Wireshark dissector validation. Not a dhs producer host by
 # default (no ember_tree_src).
@@ -7,7 +8,7 @@ pve_vmid: 655
 pve_name: dhs.tools
 os_label: "Ubuntu"
 nics:
-  - { name: eth0, mac: "BC:24:11:C1:92:FF", ip: 10.100.0.106 }
+  - { name: eth0, mac: "BC:24:11:C1:92:FF", ip: 10.100.0.104 }
 fleet_hostname: dhs-tools
 
 # Tooling host: no dhs producers -> only management rules (ssh, metrics).

--- a/ansible/inventory/host_vars/dhs-ubuntu.yml
+++ b/ansible/inventory/host_vars/dhs-ubuntu.yml
@@ -1,12 +1,12 @@
 ---
 # dhs-ubuntu — Proxmox LXC 652 "dhs.ubuntu24", Ubuntu 24.04 LTS.
-# Dual-NIC: eth0 10.100.0.102 (ansible_host) / eth1 10.100.0.101.
+# Dual-NIC: eth0 10.100.0.102 (ansible_host) / eth1 10.100.0.112.
 pve_vmid: 652
 pve_name: dhs.ubuntu24
 os_label: "Ubuntu 24.04"
 nics:
   - { name: eth0, mac: "BC:24:11:28:78:25", ip: 10.100.0.102 }
-  - { name: eth1, mac: "BC:24:11:B2:50:A5", ip: 10.100.0.101 }
+  - { name: eth1, mac: "BC:24:11:B2:50:A5", ip: 10.100.0.112 }
 fleet_hostname: dhs-ubuntu
 
 # Ember+ producer: the DHD audio console tree, rebuilt from the committed

--- a/ansible/inventory/host_vars/win11.yml
+++ b/ansible/inventory/host_vars/win11.yml
@@ -1,13 +1,13 @@
 ---
 # win11 — Proxmox VM 654 "dhs.win11", Windows 11 Pro (10.0.26200),
-# guest hostname DHS_WIN11, single NIC 10.100.0.107 (NOT .106 — that is
-# dhs-tools). Windows producer-parity row (ADR-0016), reached over SSH
-# as `by-rune` (local Administrators group).
+# guest hostname dhs-win11, single NIC 10.100.0.105 (static, #786; the old
+# DHCP lease was .107). Windows producer-parity row (ADR-0016), reached over
+# SSH as `by-rune` (local Administrators group).
 pve_vmid: 654
 pve_name: dhs.win11
 os_label: "Windows 11 Pro"
 nics:
-  - { name: "Ethernet 2", mac: "BC:24:11:10:AE:F8", ip: 10.100.0.107 }
+  - { name: "Ethernet 2", mac: "BC:24:11:10:AE:F8", ip: 10.100.0.105 }
 fleet_hostname: dhs-win11
 
 # Ember+ producer: our integration DM (matrix + salvo/lock functions).

--- a/ansible/inventory/hosts.ini
+++ b/ansible/inventory/hosts.ini
@@ -1,21 +1,24 @@
 # dhs test fleet — Proxmox pve01 (10.6.224.5), bridge vmbrAPPS, VLAN 100
 # (10.100.0.0/24, gateway pfSense 10.100.0.1). Source of truth for names,
 # MACs and IPs is the Proxmox config (vmid per host_vars); docs/testbed.md
-# is rendered from the same facts. Every guest is DHCP today — addresses
-# are pinned by pfSense static mappings (MAC -> IP), see #786.
+# is rendered from the same facts.
+#
+# Addressing is STATIC (dhs_netaddr role, #786): eth0 = mgmt-A (this
+# ansible_host, default gateway), eth1 = eth0 + 10 (mgmt-B, no default
+# route). No DHCP dependency.
 #
 # Linux LXC are reached over SSH as root; the Windows VM over SSH as the
 # local admin-group user `by-rune` (key auth, no password file — #782).
-# Control node = dhs-debian (.103), see docs/testbed.md "Control node".
+# Control node = dhs-debian, see docs/testbed.md "Control node".
 
 [linux]
-dhs-debian  ansible_host=10.100.0.103
+dhs-debian  ansible_host=10.100.0.101
 dhs-ubuntu  ansible_host=10.100.0.102
-dhs-rocky   ansible_host=10.100.0.105
-dhs-tools   ansible_host=10.100.0.106
+dhs-rocky   ansible_host=10.100.0.103
+dhs-tools   ansible_host=10.100.0.104
 
 [windows]
-win11       ansible_host=10.100.0.107
+win11       ansible_host=10.100.0.105
 
 # Ansible control node (runs every play; never PowerShell drivers).
 [control]

--- a/ansible/playbooks/fleet-converge.yml
+++ b/ansible/playbooks/fleet-converge.yml
@@ -19,3 +19,6 @@
     - dhs_hostname
     - dhs_mdns
     - dhs_firewall
+    # last: may reboot the CT to apply static addressing (#786); the control
+    # node's own reboot ends the play — re-run afterwards = 0 changes.
+    - dhs_netaddr

--- a/ansible/roles/dhs_netaddr/defaults/main.yml
+++ b/ansible/roles/dhs_netaddr/defaults/main.yml
@@ -1,0 +1,29 @@
+---
+# dhs_netaddr — STATIC addressing from the inventory truth (#786):
+#   LXCs: Proxmox CT config `netX: ...,ip=<addr>/24[,gw=<gw>]` (+ nameserver /
+#         searchdomain) written via the API from host_vars `nics:`; applied
+#         with a CT reboot (Proxmox re-renders the guest network config at
+#         start). Declarative at the hypervisor, Terraform-importable.
+#   win11: guest-side static IPv4 (New-NetIPAddress + DNS) = same source.
+# No DHCP dependency; pfSense only needs the range excluded from its pool as
+# hygiene. fleet-verify.yml keeps asserting live IP == inventory IP.
+#
+# Scheme (owner 2026-08-23, "reorganize per LXC two mgmt ports"):
+#   eth0 = mgmt-A (ansible_host, default gateway), eth1 = eth0 + 10 (mgmt-B,
+#   no default route). 101..105 / 111..113. Cerebrum staging stays .5.
+dhs_netaddr_prefix: 24
+dhs_netaddr_gateway: 10.100.0.1
+dhs_netaddr_dns: [10.100.0.1]
+dhs_netaddr_searchdomain: by-systems.arpa
+
+# Proxmox API (token vars come from the control-node-only secrets file,
+# -e @/root/.secrets/proxmox.yml — same as dhs_hostname).
+dhs_netaddr_proxmox_enabled: "{{ proxmox_token_id is defined and proxmox_token_secret is defined }}"
+proxmox_api_host: 10.6.224.5:8006
+proxmox_node: pve01
+proxmox_validate_certs: false
+
+# Reboot the CT after a config change so the static config is live (the old
+# DHCP lease would otherwise linger until expiry). The control node itself is
+# rebooted LAST and ends the play (re-run afterwards -> 0 changes).
+dhs_netaddr_reboot_ct: true

--- a/ansible/roles/dhs_netaddr/meta/main.yml
+++ b/ansible/roles/dhs_netaddr/meta/main.yml
@@ -1,0 +1,21 @@
+---
+galaxy_info:
+  role_name: dhs_netaddr
+  author: by-rune
+  description: >-
+    Static fleet addressing from the inventory truth: Proxmox CT network
+    config (ip/gw/nameserver/searchdomain via the API, CT reboot to apply)
+    for the LXCs, guest-side static IPv4 for the Windows VM. No DHCP
+    dependency. Idempotent: run-twice = 0 changes.
+  license: see repository
+  min_ansible_version: "2.14"
+  platforms:
+    - name: EL
+      versions: [all]
+    - name: Debian
+      versions: [all]
+    - name: Ubuntu
+      versions: [all]
+    - name: Windows
+      versions: [all]
+dependencies: []

--- a/ansible/roles/dhs_netaddr/tasks/main.yml
+++ b/ansible/roles/dhs_netaddr/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: Assert nics are declared
+  ansible.builtin.assert:
+    that:
+      - nics is defined
+      - nics | length > 0
+    fail_msg: "dhs_netaddr: {{ inventory_hostname }} needs nics: in host_vars"
+
+- name: Converge (Proxmox CT network config)
+  ansible.builtin.include_tasks: proxmox.yml
+  when:
+    - pve_vmid is defined
+    - ansible_os_family != "Windows"
+    - dhs_netaddr_proxmox_enabled | bool
+
+- name: Proxmox layer skipped (no token vars)
+  ansible.builtin.debug:
+    msg: "dhs_netaddr: pass -e @/root/.secrets/proxmox.yml to converge the CT network config"
+  when:
+    - pve_vmid is defined
+    - ansible_os_family != "Windows"
+    - not (dhs_netaddr_proxmox_enabled | bool)
+
+- name: Converge (Windows guest static IPv4)
+  ansible.builtin.include_tasks: windows.yml
+  when: ansible_os_family == "Windows"

--- a/ansible/roles/dhs_netaddr/tasks/proxmox.yml
+++ b/ansible/roles/dhs_netaddr/tasks/proxmox.yml
@@ -1,0 +1,89 @@
+---
+# Read the CT config, rewrite each netX line's ip=/gw= from the inventory
+# (keeping name/bridge/hwaddr/tag/type as they are), set nameserver and
+# searchdomain, PUT only what differs, then reboot the CT once.
+- name: Read the CT config from Proxmox
+  ansible.builtin.uri:
+    url: "https://{{ proxmox_api_host }}/api2/json/nodes/{{ proxmox_node }}/lxc/{{ pve_vmid }}/config"
+    headers:
+      Authorization: "PVEAPIToken={{ proxmox_token_id }}={{ proxmox_token_secret }}"
+    validate_certs: "{{ proxmox_validate_certs }}"
+    return_content: true
+  delegate_to: localhost
+  register: dhs_netaddr_ct
+
+# Proxmox normalizes the key order of a netX string (e.g. gw= before
+# hwaddr=), so compare the SET of key=value pairs, never the raw string —
+# otherwise every run looks different and reboots the CT.
+- name: Build the desired netX values (pairs, order-independent)
+  ansible.builtin.set_fact:
+    dhs_netaddr_desired: >-
+      {{ dhs_netaddr_desired | default({}) | combine({
+           ('net' ~ idx): (
+             ((dhs_netaddr_ct.json.data['net' ~ idx] | default('')) | split(',')
+               | reject('match', '^(ip|gw)=') | reject('equalto', '') | list)
+             + ['ip=' ~ item.ip ~ '/' ~ dhs_netaddr_prefix]
+             + (['gw=' ~ dhs_netaddr_gateway] if idx == 0 else [])
+           ) }) }}
+  loop: "{{ nics }}"
+  loop_control:
+    index_var: idx
+    label: "net{{ idx }}={{ item.ip }}"
+
+- name: Delta — netX lines whose pair-set differs
+  ansible.builtin.set_fact:
+    dhs_netaddr_changes: >-
+      {{ dhs_netaddr_changes | default({}) | combine(
+           {item.key: (item.value | join(','))}
+           if ((dhs_netaddr_ct.json.data[item.key] | default('')) | split(',') | reject('equalto', '') | sort | list)
+              != (item.value | sort | list)
+           else {}) }}
+  loop: "{{ dhs_netaddr_desired | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+
+- name: Delta — nameserver / searchdomain
+  ansible.builtin.set_fact:
+    dhs_netaddr_changes: >-
+      {{ dhs_netaddr_changes | default({})
+         | combine({'nameserver': dhs_netaddr_dns | join(' ')} if (dhs_netaddr_ct.json.data.nameserver | default('')) != (dhs_netaddr_dns | join(' ')) else {})
+         | combine({'searchdomain': dhs_netaddr_searchdomain} if (dhs_netaddr_ct.json.data.searchdomain | default('')) != dhs_netaddr_searchdomain else {}) }}
+
+- name: "Proxmox CT {{ pve_vmid }} network config -> static ({{ dhs_netaddr_changes | default({}) | dict2items | map(attribute='key') | join(',') }})"
+  ansible.builtin.uri:
+    url: "https://{{ proxmox_api_host }}/api2/json/nodes/{{ proxmox_node }}/lxc/{{ pve_vmid }}/config"
+    method: PUT
+    headers:
+      Authorization: "PVEAPIToken={{ proxmox_token_id }}={{ proxmox_token_secret }}"
+    body_format: form-urlencoded
+    body: "{{ dhs_netaddr_changes }}"
+    validate_certs: "{{ proxmox_validate_certs }}"
+  delegate_to: localhost
+  when: (dhs_netaddr_changes | default({})) | length > 0
+  changed_when: true
+  register: dhs_netaddr_put
+
+- name: "Reboot CT {{ pve_vmid }} so the static config is live"
+  ansible.builtin.uri:
+    url: "https://{{ proxmox_api_host }}/api2/json/nodes/{{ proxmox_node }}/lxc/{{ pve_vmid }}/status/reboot"
+    method: POST
+    headers:
+      Authorization: "PVEAPIToken={{ proxmox_token_id }}={{ proxmox_token_secret }}"
+    validate_certs: "{{ proxmox_validate_certs }}"
+  delegate_to: localhost
+  when:
+    - dhs_netaddr_put is changed
+    - dhs_netaddr_reboot_ct | bool
+  changed_when: true
+
+- name: Wait for the CT to answer on its (new) address
+  ansible.builtin.wait_for:
+    host: "{{ nics[0].ip }}"
+    port: 22
+    delay: 5
+    timeout: 180
+  delegate_to: localhost
+  when:
+    - dhs_netaddr_put is changed
+    - dhs_netaddr_reboot_ct | bool
+    - "'control' not in group_names"

--- a/ansible/roles/dhs_netaddr/tasks/windows.yml
+++ b/ansible/roles/dhs_netaddr/tasks/windows.yml
@@ -1,0 +1,27 @@
+---
+# Guest-side static IPv4 on the adapter that currently carries the fleet
+# address; idempotent (no change when already static with these values).
+# If the address changes, the SSH session moves with it — the inventory's
+# ansible_host is the new address, so the next task/run reconnects there.
+- name: Static IPv4 from inventory (address, prefix, gateway, DNS)
+  ansible.windows.win_shell: |
+    $ErrorActionPreference = 'Stop'
+    $want = '{{ nics[0].ip }}'; $prefix = {{ dhs_netaddr_prefix }}; $gw = '{{ dhs_netaddr_gateway }}'
+    $dns = @('{{ dhs_netaddr_dns | join("','") }}')
+    $nic = Get-NetAdapter | Where-Object { $_.Status -eq 'Up' -and $_.MacAddress -eq '{{ nics[0].mac | replace(":", "-") }}' } | Select-Object -First 1
+    if (-not $nic) { throw "adapter with MAC {{ nics[0].mac }} not found" }
+    $ifi = $nic.ifIndex
+    $ip4 = Get-NetIPAddress -InterfaceIndex $ifi -AddressFamily IPv4 -ErrorAction SilentlyContinue | Where-Object { $_.PrefixOrigin -ne 'WellKnown' }
+    $dhcp = (Get-NetIPInterface -InterfaceIndex $ifi -AddressFamily IPv4).Dhcp
+    $curDns = (Get-DnsClientServerAddress -InterfaceIndex $ifi -AddressFamily IPv4).ServerAddresses
+    $curGw = (Get-NetRoute -InterfaceIndex $ifi -DestinationPrefix '0.0.0.0/0' -ErrorAction SilentlyContinue | Select-Object -First 1).NextHop
+    $ok = ($dhcp -eq 'Disabled') -and ($ip4.IPAddress -contains $want) -and ($ip4 | Where-Object { $_.IPAddress -eq $want }).PrefixLength -eq $prefix -and ($curGw -eq $gw) -and (@($curDns) -join ',' -eq ($dns -join ','))
+    if ($ok) { 'OK'; exit 0 }
+    Set-NetIPInterface -InterfaceIndex $ifi -AddressFamily IPv4 -Dhcp Disabled
+    Get-NetIPAddress -InterfaceIndex $ifi -AddressFamily IPv4 -ErrorAction SilentlyContinue | Where-Object { $_.PrefixOrigin -ne 'WellKnown' -and $_.IPAddress -ne $want } | Remove-NetIPAddress -Confirm:$false -ErrorAction SilentlyContinue
+    Get-NetRoute -InterfaceIndex $ifi -DestinationPrefix '0.0.0.0/0' -ErrorAction SilentlyContinue | Remove-NetRoute -Confirm:$false -ErrorAction SilentlyContinue
+    if (-not ($ip4.IPAddress -contains $want)) { New-NetIPAddress -InterfaceIndex $ifi -IPAddress $want -PrefixLength $prefix -DefaultGateway $gw | Out-Null } else { New-NetRoute -InterfaceIndex $ifi -DestinationPrefix '0.0.0.0/0' -NextHop $gw | Out-Null }
+    Set-DnsClientServerAddress -InterfaceIndex $ifi -ServerAddresses $dns
+    'CHANGED'
+  register: dhs_netaddr_win
+  changed_when: "'CHANGED' in dhs_netaddr_win.stdout"

--- a/docs/testbed.md
+++ b/docs/testbed.md
@@ -10,23 +10,30 @@ in the same PR (epic #780).
 
 ## Fleet
 
-| Inventory name | Proxmox | Guest OS | eth0 (`ansible_host`) | eth1 | Role |
+| Inventory name | Proxmox | Guest OS | eth0 mgmt-A (`ansible_host`) | eth1 mgmt-B | Role |
 | --- | --- | --- | --- | --- | --- |
-| `dhs-debian` | LXC 651 `dhs.debian12` | Debian 12 | `10.100.0.103` | `10.100.0.108` | **Ansible control node**; dhs producer host; Docker |
-| `dhs-ubuntu` | LXC 652 `dhs.ubuntu24` | Ubuntu 24.04 | `10.100.0.102` | `10.100.0.101` | dhs producer host |
-| `dhs-rocky` | LXC 653 `dhs.rocky9` | Rocky 9.4 | `10.100.0.105` | `10.100.0.104` | dhs producer host (`.104` and `.105` are ONE host) |
-| `dhs-tools` | LXC 655 `dhs.tools` | Ubuntu | `10.100.0.106` | — | tooling: Docker, AMWA NMOS Testing tool (`scripts/amwa/`), tshark |
-| `win11` | VM 654 `dhs.win11` | Windows 11 Pro | `10.100.0.107` | — | Windows producer-parity row (ADR-0016); guest name `DHS_WIN11` |
+| `dhs-debian` | LXC 651 | Debian 12 | `10.100.0.101` | `10.100.0.111` | **Ansible control node**; dhs producer host; Docker |
+| `dhs-ubuntu` | LXC 652 | Ubuntu 24.04 | `10.100.0.102` | `10.100.0.112` | dhs producer host |
+| `dhs-rocky` | LXC 653 | Rocky 9.4 | `10.100.0.103` | `10.100.0.113` | dhs producer host |
+| `dhs-tools` | LXC 655 | Ubuntu | `10.100.0.104` | — | tooling: Docker, AMWA NMOS Testing tool (`scripts/amwa/`), tshark |
+| `win11` | VM 654 | Windows 11 Pro | `10.100.0.105` | — | Windows producer-parity row (ADR-0016); guest name `dhs-win11` |
 | `cerebrum` | VM 601 `vm-cerebrum-stg-01` | Windows 11 | `10.100.0.5` | — | external reference peer (EVS Cerebrum staging) — real-peer integration target, not part of the converge set |
 
 All LXCs are unprivileged with `nesting=1`. MAC addresses per NIC live
 in `ansible/inventory/host_vars/<name>.yml` (`nics:`).
 
-Addressing: every guest is configured `ip=dhcp` in Proxmox; addresses
-are pinned as **pfSense static DHCP mappings keyed by MAC** (#786) so a
-rebuilt guest keeps its address with zero guest-side configuration.
+Addressing is **static, from the inventory** (`dhs_netaddr` role, #786):
+one scheme across the fleet — eth0 = mgmt-A (`ansible_host`, default
+gateway `10.100.0.1`), eth1 = eth0 + 10 = mgmt-B (no default route);
+`.101–.105` / `.111–.113`, no overlaps, Cerebrum staging stays `.5`.
+LXCs get it in the Proxmox CT config (`netX: …,ip=<addr>/24[,gw=…]`,
+`nameserver`, `searchdomain`, written via the API, applied by a CT
+reboot); the Windows VM gets it guest-side. No DHCP dependency (pfSense
+only needs `.100–.120` excluded from its pool as hygiene).
 `ansible/playbooks/fleet-verify.yml` asserts live IP == inventory IP per
-NIC and fails loudly on drift.
+NIC and fails loudly on drift. Before 2026-08-23 the fleet ran on DHCP
+leases (`.101–.108`, win11 drifted `.106`→`.107`) — never reuse those
+old numbers from memory; this table is the truth.
 
 Guest hostnames equal the inventory name (`fleet_hostname`:
 `dhs-debian`, `dhs-ubuntu`, `dhs-rocky`, `dhs-tools`, `dhs-win11`),
@@ -56,12 +63,12 @@ names matter: three LXCs used to answer `dhs`, which collides in Avahi.
 All producers run concurrently on the same host; one port per
 connector. The same producer binary is driven by `dhs consumer` and by
 external peers (Cerebrum @ `.5`, AMWA Testing tool in Docker on
-`dhs-tools` `.106`) so wire behaviour can be compared across drivers.
+`dhs-tools` `.104`) so wire behaviour can be compared across drivers.
 Host firewalls are managed by the `dhs_firewall` role (#785): each host opens exactly the rule groups of the connectors it declares in `dhs_connectors` (host_vars) plus ssh/metrics(/winrm); other `dhs-*` rules are removed; Windows connector rules are scoped to `C:\dhs\dhs.exe`; the `nmos` group includes mDNS and requires `dhs_mdns`.
 
 ## Control node
 
-`dhs-debian` (`.103`) runs every Ansible play — Linux hosts over SSH as
+`dhs-debian` (`.101`) runs every Ansible play — Linux hosts over SSH as
 `root`, the Windows VM over SSH as `by-rune` (key auth; WinRM/NTLM +
 password file is retired). It holds a clone of this (public) repo at
 `~/acp` and its own ed25519 key (`root@dhs`), which is one of the three
@@ -78,7 +85,7 @@ by the `dhs_access` role (#782); anything else is removed:
 | Actor | Key comment | Purpose |
 | --- | --- | --- |
 | by-rune (agent, desk-03) | `by-rune-dhs-lxc` | agent SSH to every host |
-| control node `.103` | `root@dhs` | Ansible → fleet |
+| control node `.101` | `root@dhs` | Ansible → fleet |
 | codeowner | (owner's ed25519) | direct SSH |
 
 Linux: `/root/.ssh/authorized_keys` (login user is `root`; `by-rune` is
@@ -151,7 +158,7 @@ OpenSSH Server on the VM, `dhs.exe` under `C:\dhs\dhs.exe` (see
   Testing Façade" on port 5001 after 2026-04-30. Pin to a pre-Façade
   tag or run from source (#173).
 - desk-03 (the codeowner's workstation) sits on the OOB VLAN and cannot
-  reach the DMZ via mDNS. `win11` (`.107`) on the DMZ provides the
+  reach the DMZ via mDNS. `win11` (`.105`) on the DMZ provides the
   Windows mDNS live test surface instead.
 - Cerebrum drops `v1.0` from `api.versions` on registration — real-peer
   fact, not our bug.
@@ -160,6 +167,8 @@ OpenSSH Server on the VM, `dhs.exe` under `C:\dhs\dhs.exe` (see
 
 ## Open work
 
-Tracked in epic #780: fixed IPs (#786, pfSense mappings = owner action),
-unique hostnames (#783), actor-key convergence (#782), mDNS (#784),
-firewall (#785).
+Tracked in epic #780: static addressing (#786, `dhs_netaddr`), unique
+hostnames (#783), actor-key convergence (#782), mDNS (#784, #797),
+firewall (#785), host baseline (#800), OS updates + reboot (#799),
+win11 Ansible latency (#790). pfSense hygiene (owner, any time): exclude
+`10.100.0.100–120` from the DHCP pool.


### PR DESCRIPTION
## What

`dhs_netaddr` role + fleet renumbering: **static addressing from the
inventory**, one clean scheme per the two management ports of each LXC
(owner 2026-08-23): eth0 = mgmt-A (`ansible_host`, default gateway), eth1 =
eth0 + 10 = mgmt-B (no default route); `.101–.105` / `.111–.113`, no
overlaps, Cerebrum staging stays `.5`.

| Host | eth0 | eth1 |
|---|---|---|
| dhs-debian (control) | 10.100.0.101 | 10.100.0.111 |
| dhs-ubuntu | 10.100.0.102 | 10.100.0.112 |
| dhs-rocky | 10.100.0.103 | 10.100.0.113 |
| dhs-tools | 10.100.0.104 | — |
| win11 | 10.100.0.105 | — |

LXCs: Proxmox CT config `netX: …,ip=<addr>/24[,gw=10.100.0.1]` +
`nameserver` / `searchdomain` via the API (read-then-write, same pattern as
`dhs_hostname`), applied by a CT reboot. win11: guest-side static IPv4 + DNS
(adapter matched by MAC). Inventory (`hosts.ini`, `host_vars nics`),
`docs/testbed.md` fleet table + addressing section, and the PR-template
device checklist all carry the same numbers; `fleet-verify.yml` asserts
live == inventory. Supersedes the pfSense MAC-mapping plan — no DHCP
dependency at all (pfSense hygiene: exclude `.100–.120` from its pool).

Closes #786 (epic #780).

## Why

Owner: "why force MAC mappings instead of static IP on the LXCs? make sure
no duplicate IP and reorganize per LXC two mgmt ports; review the test
file + templates with the IP list". The inherited DHCP leases were
scattered (.105/.104 reversed, .103/.108, win11 drifted .106→.107) and
required pfSense access to pin.

## How

- `roles/dhs_netaddr/tasks/proxmox.yml`: GET config → rewrite `netX`
  `ip=`/`gw=` keeping name/bridge/hwaddr/tag/type → delta incl. nameserver /
  searchdomain → PUT only if different → `status/reboot` → wait for SSH on
  the new address (control node excluded from the wait: its reboot ends the
  play; re-run = 0 changes).
- `roles/dhs_netaddr/tasks/windows.yml`: `win_shell` idempotent static
  config (DHCP off, address/prefix, default route, DNS), changed only when
  something differs.
- `fleet-converge.yml`: `dhs_netaddr` runs LAST (reboots after everything
  else converged).

## Testing

Applied on the fleet in order tools → ubuntu → rocky → win11 → control node
(last); then `fleet-converge.yml` from the control node at its new address
= 0 changes and `fleet-verify.yml` green on the new numbers. Evidence posted
as a comment after the apply.

- [ ] apply + run-twice = 0 changes on all five hosts at the new addresses
- [ ] fleet-verify.yml green
- [x] No Go changes; pre-commit vet/lint clean

## Device tested

- [x] Fleet producer — all five fleet hosts
- [ ] Vendor emulator — n/a
- [ ] Real device — n/a
- [ ] No device needed (pure codec / doc change)

## Checklist

- [x] Linked issue (#786)
- [x] Conventional-commit title
- [x] No new Go dependencies
- [x] ADR-0025 step 5/6 respected (Ansible from Linux control node, idempotent)