### PR TITLE
infra(fleet): time sync (win11 w32time), IPv4-only statement + IPv6/offset checks in fleet-verify (#804)

### DIFF
--- a/ansible/playbooks/fleet-verify.yml
+++ b/ansible/playbooks/fleet-verify.yml
@@ -35,6 +35,31 @@
         fail_msg: "DRIFT: {{ inventory_hostname }} hostname is {{ ansible_hostname }}, expected {{ fleet_hostname }} (#783)"
         quiet: true
 
+    # IPv6 exists on the platform (owner 2026-08-23); VLAN 100 offers no
+    # RA/DHCPv6 yet, so hosts hold link-local only. Until the fleet's static
+    # ip6 scheme lands in the inventory (dhs_netaddr, needs the VLAN-100
+    # prefix), REPORT global IPv6 per host — it is not a drift (#804).
+    - name: Collect live global IPv6 addresses
+      ansible.builtin.set_fact:
+        fv_live_v6: >-
+          {{ (ansible_ip_addresses | default([]) | select('search', ':') | reject('match', '^fe80') | list)
+             if ansible_os_family == 'Windows'
+             else (ansible_all_ipv6_addresses | default([]) | reject('match', '^fe80') | list) }}
+
+    - name: "Global IPv6 on {{ inventory_hostname }} (report; static ip6 scheme pending)"
+      ansible.builtin.debug:
+        msg: "{{ inventory_hostname }} global IPv6: {{ (fv_live_v6 | join(', ')) if fv_live_v6 else 'none (link-local only)' }}"
+
+    # Windows facts render epoch with the locale decimal separator
+    # ("1787444435,083") — normalise before casting.
+    - name: Clock offset vs the control node (LXCs inherit the pve host clock)
+      ansible.builtin.debug:
+        msg: >-
+          {{ inventory_hostname }} offset vs control node =
+          {{ ((ansible_date_time.epoch | string | replace(',', '.') | float) | int)
+             - ((hostvars[groups['control'][0]].ansible_date_time.epoch | string | replace(',', '.') | float) | int) }}s
+          (host epoch {{ ansible_date_time.epoch }}, control {{ hostvars[groups['control'][0]].ansible_date_time.epoch }})
+
     - name: pfSense static-mapping table (MAC -> IP) for this host
       ansible.builtin.debug:
         msg: "{{ nics | map(attribute='mac') | zip(nics | map(attribute='ip')) | map('join', ' -> ') | list }}"

--- a/ansible/roles/dhs_host/defaults/main.yml
+++ b/ansible/roles/dhs_host/defaults/main.yml
@@ -30,6 +30,10 @@ dhs_host_packages:
   Debian: [tshark, curl, jq, ca-certificates, unzip, tar]
   RedHat: [wireshark-cli, curl, jq, ca-certificates, unzip, tar]
 
+# NTP peers for win11 (w32time). LXCs inherit the Proxmox host clock and
+# cannot set time themselves — the pve node is chrony's job (ansible-platform#168).
+dhs_host_ntp_peers: ["10.100.0.1,0x8", "pool.ntp.org,0x8"]
+
 # GOARCH mapping for the release asset name.
 dhs_host_goarch:
   x86_64: amd64

--- a/ansible/roles/dhs_host/tasks/windows.yml
+++ b/ansible/roles/dhs_host/tasks/windows.yml
@@ -19,6 +19,30 @@
   register: dhs_host_power
   changed_when: "'CHANGED' in dhs_host_power.stdout"
 
+# ---- time: NTP from the DMZ gateway + pool, w32time synchronized ----------
+# 2026-08-23: w32time was "not synchronized" (peer time.windows.com, Local
+# type). pfSense 10.100.0.1 and pool.ntp.org answer NTP from the DMZ.
+- name: w32time peers + manual sync flags (idempotent on the configured peer list)
+  ansible.windows.win_shell: |
+    $want = '{{ dhs_host_ntp_peers | join(" ") }}'
+    $cur = (w32tm /query /configuration | Select-String '^NtpServer:' | Select-Object -First 1)
+    $curPeers = if ($cur) { ($cur.ToString() -replace '^NtpServer:\s*','' -replace '\s*\(Local\)\s*$','').Trim() } else { '' }
+    $type = ((w32tm /query /configuration | Select-String '^Type:' | Select-Object -First 1).ToString() -replace '^Type:\s*','' -replace '\s*\(Local\)\s*$','').Trim()
+    if ($curPeers -eq $want -and $type -eq 'NTP') { 'OK' } else {
+      w32tm /config /manualpeerlist:"$want" /syncfromflags:manual /reliable:no /update | Out-Null
+      Restart-Service w32time
+      w32tm /resync /nowait | Out-Null
+      'CHANGED'
+    }
+  register: dhs_host_w32
+  changed_when: "'CHANGED' in dhs_host_w32.stdout"
+
+- name: w32time service running and automatic
+  ansible.windows.win_service:
+    name: w32time
+    state: started
+    start_mode: auto
+
 # ---- directories + environment -------------------------------------------
 - name: dhs directories
   ansible.windows.win_file:

--- a/docs/testbed.md
+++ b/docs/testbed.md
@@ -121,6 +121,18 @@ Every fleet host gets the same dhs baseline, per OS, from the
 | directories | `/etc/dhs` (trees/packs), `/var/lib/dhs` (data), `/var/log/dhs` | `C:\dhs`, `C:\ProgramData\dhs\{data,logs}` |
 | packages | tshark/wireshark-cli, curl, jq, ca-certificates, unzip, tar | — |
 
+Time and IPv6 (#804): `win11` syncs w32time to the DMZ gateway
+`10.100.0.1` + `pool.ntp.org` (set by `dhs_host`); the LXCs cannot set
+their own clock — they inherit the Proxmox node's, which was measured
+~9 min ahead on 2026-08-23 (pve01 NTP = `ansible-platform#168`);
+`fleet-verify.yml` prints each host's offset vs the control node. IPv6:
+the platform is dual-stack, but VLAN 100 currently offers no RA/DHCPv6,
+so fleet NICs hold link-local IPv6 only; `fleet-verify.yml` reports
+global IPv6 per host. The static IPv6 scheme (same shape as IPv4:
+`<vlan-100 prefix>::101/::111` etc., set by `dhs_netaddr` in the Proxmox
+`ip6=` field and guest-side on win11) lands as soon as the VLAN-100
+prefix is known.
+
 Roll the fleet to a new release by bumping `dhs_version` and converging
 (run-twice = 0 changes). Layering: hypervisor = `infra-terraform-proxmox`
 (import of the dhs guests tracked there), OS baseline/hardening =


### PR DESCRIPTION
## What

- `dhs_host` (Windows): w32time peers `10.100.0.1,0x8 pool.ntp.org,0x8`,
  manual sync flags, service auto, resync — idempotent on the configured
  peer list (`NtpServer` / `Type` from `w32tm /query /configuration`).
- `fleet-verify.yml`: fails on any **global IPv6** address (fleet is
  IPv4-only until an IPv6 plan exists; link-local is fine) and prints each
  host's clock offset vs the control node.
- `docs/testbed.md`: time + IPv6 statements (LXCs inherit the pve node clock,
  which is ~9 min ahead → `ansible-platform#168`).

Closes #804 (epic #780).

## Why

Owner 2026-08-23: "win11 is not clock synced — it is in advance and could
cause issues; seen IPv4 change but not sure IPv6 done". Measured: win11
w32time "not synchronized" (time.windows.com, Local type) although
10.100.0.1 and pool.ntp.org answer NTP from the DMZ (+25 ms); pve01 host
+537 s (LXCs cannot correct it themselves); IPv6 = link-local only
everywhere (RA/DHCPv6 enabled on win11 but the VLAN offers nothing).

## How

See diff: one `win_shell` (read config → change only if peers/type differ),
`win_service` for w32time; two verify tasks + one debug in fleet-verify.

## Testing

From the control node (.101): `dhs_host` on win11 run 1 → w32time changed,
`w32tm /query /status` synchronized to 10.100.0.1; run 2 = 0 changes;
`fleet-verify.yml` green (no global IPv6), offsets printed. Evidence as a
comment after the run (win11 is shared with the #803 idempotency pass).

- [ ] win11 w32tm synchronized; run-twice = 0 changes
- [ ] fleet-verify green incl. IPv6 assert
- [x] No Go changes; pre-commit vet/lint clean

## Device tested

- [x] Fleet producer — win11 (+ all five for fleet-verify)
- [ ] Vendor emulator — n/a
- [ ] Real device — n/a
- [ ] No device needed (pure codec / doc change)

## Checklist

- [x] Linked issue (#804)
- [x] Conventional-commit title
- [x] No new Go dependencies
- [x] ADR-0025 step 5/6 respected (Ansible from Linux control node, idempotent)