### PR TITLE
fix(probel-sw08p): readLoop NAK test waits for the DLE NAK before closing - no teardown race (#806)

### DIFF
--- a/internal/probel-sw08p/codec/client_coverage_test.go
+++ b/internal/probel-sw08p/codec/client_coverage_test.go
@@ -520,17 +520,30 @@ func TestReadLoopRoutesACKNAKAndFrames(t *testing.T) {
 		t.Errorf("onRx fired %d; want >= 3", rxCount.Load())
 	}
 
+	// The malformed frame is the LAST element of the stream and its DLE NAK
+	// is emitted by the reader after the data-frame dispatch above. Wait for
+	// that terminal observable before tearing down — closing right after
+	// gotFrame raced the reader's NAK write against Close (ADR-0029: wait on
+	// the monotonic observable, never on "the frame before it").
+	sawNAK := false
+	nakDeadline := time.After(2 * time.Second)
+	for !sawNAK {
+		mu.Lock()
+		sawNAK = containsNAK(back)
+		mu.Unlock()
+		if sawNAK {
+			break
+		}
+		select {
+		case <-nakDeadline:
+			t.Fatal("reader never emitted DLE NAK for the malformed frame")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
 	_ = c.Close()
 	_ = b.Close()
 	<-readerDone
-
-	// The reader must have emitted at least one DLE NAK for the bad frame.
-	mu.Lock()
-	sawNAK := containsNAK(back)
-	mu.Unlock()
-	if !sawNAK {
-		t.Error("reader never emitted DLE NAK for the malformed frame")
-	}
 }
 
 // containsNAK reports whether buf contains a DLE NAK sequence.


### PR DESCRIPTION
## What

`TestReadLoopRoutesACKNAKAndFrames` now waits for the reader's **DLE NAK** —
the terminal observable of the injected stream — before tearing down,
instead of closing right after the data frame was dispatched.

Closes #806.

## Why

Main run 32607393578 (merge of #803, ansible/docs only) went red on
`Test (rhel9-ubi)`: `client_coverage_test.go:532: reader never emitted DLE
NAK for the malformed frame`. The test wrote `[junk, ACK, NAK, data frame,
malformed frame]` in one shot, waited for `gotFrame` (data frame dispatched)
and immediately `Close()`d client + pipe. The reader emits the NAK for the
trailing malformed frame *after* that dispatch; when Close landed first the
NAK write hit a closed pipe. Same flake class as the acp2/ember ones fixed
under ADR-0029 (transient-state wait → wait on the monotonic observable).
No production code change.

## How

After the data-frame wait, poll the collected bytes for `DLE NAK` with a
2 s deadline; only then Close. The existing ACK/NAK/desync/decode arms stay
covered.

## Testing

```text
go test -count=30 -cpu 1,2,4 -run TestReadLoopRoutesACKNAKAndFrames ./internal/probel-sw08p/codec -> ok
go test -count=3 -race ./internal/probel-sw08p/codec -> ok
```

- [x] `go test -count=1 ./...` passes (package)
- [x] `go vet ./...` / `golangci-lint` clean (pre-commit)

## Device tested

- [x] No device needed (pure codec / doc change)

## Checklist

- [x] Linked issue (#806)
- [x] Conventional-commit title
- [x] No new external dependencies