### PR TITLE
infra(fleet): cut Windows-over-SSH latency - PowerShell default shell, one-pass firewall reconcile, fact cache, run log (#790)

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,11 +1,24 @@
 # Ansible config for the dhs multi-OS client matrix.
-# Run from this directory:  ansible-playbook playbooks/site.yml
+# Run from this directory:  ansible-playbook playbooks/fleet-converge.yml
 [defaults]
 inventory = inventory/hosts.ini
 roles_path = roles
 host_key_checking = False
 stdout_callback = ansible.builtin.default
 retry_files_enabled = False
+
+# Every run is observable while it runs (owner 2026-08-23: "how to monitor
+# if not crashed?"): full log + per-task timing. Tail it on the control node:
+#   tail -f /tmp/ansible-fleet.log
+log_path = /tmp/ansible-fleet.log
+callbacks_enabled = ansible.posix.profile_tasks
+
+# Facts are the single slowest Windows step (~13 s); cache them for an hour
+# and only gather when missing. Roles that need fresh facts say so.
+gathering = smart
+fact_caching = jsonfile
+fact_caching_connection = /tmp/ansible-facts
+fact_caching_timeout = 3600
 
 # YAML-shaped task results (community.general.yaml callback was removed in
 # community.general 12; this is the core replacement).

--- a/ansible/inventory/group_vars/windows.yml
+++ b/ansible/inventory/group_vars/windows.yml
@@ -10,9 +10,13 @@
 # authorized_keys) — the dhs_access role manages that file.
 ansible_connection: ssh
 ansible_user: by-rune
-# sshd DefaultShell on the VM is cmd.exe (Windows OpenSSH default); the
-# ansible.windows modules work over it as-is, so it stays cmd.
-ansible_shell_type: cmd
+# sshd DefaultShell on the VM is PowerShell (set by dhs_access, #790): every
+# module then runs in one process instead of cmd.exe spawning powershell.exe
+# — roughly halves per-task latency. BOOTSTRAP of a fresh VM (DefaultShell
+# still cmd): run playbooks/win-shell-bootstrap.yml once (play-scoped cmd
+# shell; never pass ansible_shell_type as a global -e — it also hits tasks
+# delegated to the Linux control node).
+ansible_shell_type: powershell
 ansible_become: false
 
 # Where the dhs binary is installed on the target and which local artifact to

--- a/ansible/playbooks/win-shell-bootstrap.yml
+++ b/ansible/playbooks/win-shell-bootstrap.yml
@@ -1,0 +1,28 @@
+---
+# One-time bootstrap for a fresh Windows VM whose sshd DefaultShell is still
+# cmd.exe (#790). Runs the Windows group with the cmd shell type (play-scoped,
+# so tasks delegated to the control node are untouched), sets DefaultShell =
+# PowerShell and restarts sshd. Afterwards the inventory default
+# (`ansible_shell_type: powershell`) works and this play is a no-op.
+#
+#   cd ~/acp/ansible && ansible-playbook playbooks/win-shell-bootstrap.yml
+- name: Windows — sshd DefaultShell = PowerShell (bootstrap from cmd)
+  hosts: windows
+  gather_facts: false
+  vars:
+    ansible_shell_type: cmd
+  tasks:
+    - name: sshd DefaultShell = PowerShell
+      ansible.windows.win_regedit:
+        path: HKLM:\SOFTWARE\OpenSSH
+        name: DefaultShell
+        data: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
+        type: string
+        state: present
+      register: wsb_defshell
+
+    - name: Restart sshd so the new default shell applies
+      ansible.windows.win_service:
+        name: sshd
+        state: restarted
+      when: wsb_defshell is changed

--- a/ansible/roles/dhs_access/tasks/windows.yml
+++ b/ansible/roles/dhs_access/tasks/windows.yml
@@ -39,6 +39,27 @@
   register: dhs_access_acl_prune
   changed_when: (dhs_access_acl_prune.stdout | trim | int) > 0
 
+# sshd DefaultShell = PowerShell (#790): with `ansible_shell_type: powershell`
+# every module runs directly in PowerShell instead of cmd.exe spawning it —
+# measured 8–20 s/task over the cmd path. sshd picks the new shell up only
+# after a restart (verified 2026-08-23); the restart drops the current SSH
+# session, Ansible reconnects on the next task. First-time bootstrap of a
+# fresh VM (shell still cmd): playbooks/win-shell-bootstrap.yml.
+- name: sshd DefaultShell = PowerShell
+  ansible.windows.win_regedit:
+    path: HKLM:\SOFTWARE\OpenSSH
+    name: DefaultShell
+    data: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
+    type: string
+    state: present
+  register: dhs_access_defshell
+
+- name: Restart sshd so the new default shell applies (only when it changed)
+  ansible.windows.win_service:
+    name: sshd
+    state: restarted
+  when: dhs_access_defshell is changed
+
 - name: sshd service running and automatic
   ansible.windows.win_service:
     name: sshd

--- a/ansible/roles/dhs_firewall/tasks/windows.yml
+++ b/ansible/roles/dhs_firewall/tasks/windows.yml
@@ -1,31 +1,51 @@
 ---
-# Connector rules are scoped to the dhs program (authorized app + port);
-# management rules (ssh / winrm) and mDNS are port rules. Rules are named
-# dhs-<group>-<port>-<proto>; absent groups are removed by name.
-- name: "Defender inbound rules per connector group (present/absent)"
-  community.windows.win_firewall_rule:
-    name: "{{ item.name }}"
-    localport: "{{ item.port }}"
-    protocol: "{{ item.proto }}"
-    program: "{{ dhs_firewall_windows_program if (item.program | default(false)) else omit }}"
-    direction: in
-    action: allow
-    profiles: [domain, private, public]
-    enabled: true
-    state: "{{ item.state }}"
-  loop: "{{ dhs_firewall_rules }}"
-  loop_control:
-    label: "{{ item.name }} {{ item.state }}"
-
-# Legacy rule names from the first role version (dhs-<group> without
-# port/proto, catalogue-wide) — removed so only the per-group names remain.
-- name: Remove legacy un-scoped dhs-* rules
-  community.windows.win_firewall_rule:
-    name: "{{ item.name }}"
-    state: absent
-  loop: "{{ dhs_firewall_legacy }}"
-  loop_control:
-    label: "{{ item.name }}"
+# One reconciliation pass for ALL dhs-* rules in a single PowerShell run
+# (#790): 30+ win_firewall_rule tasks at ~15 s each became one task.
+# Desired rules come from dhs_firewall_rules (state present|absent, program
+# scoping for connector rules); legacy un-scoped names are removed; the
+# task is idempotent — it reports CHANGED only when a rule was created,
+# corrected or removed.
+- name: "Defender inbound rules — reconcile all dhs-* rules in one pass"
+  ansible.windows.win_shell: |
+    $ErrorActionPreference = 'Stop'
+    $desired = @'
+    {{ dhs_firewall_rules | to_json }}
+    '@ | ConvertFrom-Json
+    $legacy = @'
+    {{ dhs_firewall_legacy | map(attribute='name') | list | to_json }}
+    '@ | ConvertFrom-Json
+    $program = '{{ dhs_firewall_windows_program }}'
+    $changed = 0
+    foreach ($r in $desired) {
+      $rule = Get-NetFirewallRule -DisplayName $r.name -ErrorAction SilentlyContinue
+      if ($r.state -eq 'absent') {
+        if ($rule) { $rule | Remove-NetFirewallRule; $changed++ }
+        continue
+      }
+      $wantProg = if ($r.program) { $program } else { 'Any' }
+      $ok = $false
+      if ($rule) {
+        $pf = $rule | Get-NetFirewallPortFilter
+        $af = $rule | Get-NetFirewallApplicationFilter
+        $ok = ($rule.Enabled -eq 'True') -and ($rule.Direction -eq 'Inbound') -and ($rule.Action -eq 'Allow') `
+              -and ($pf.Protocol -eq $r.proto.ToUpper()) -and ("$($pf.LocalPort)" -eq "$($r.port)") `
+              -and ($af.Program -eq $wantProg) -and ($rule.Profile -eq 'Domain, Private, Public' -or $rule.Profile -eq 'Any')
+      }
+      if (-not $ok) {
+        if ($rule) { $rule | Remove-NetFirewallRule }
+        $params = @{ DisplayName=$r.name; Direction='Inbound'; Action='Allow'; Enabled='True'; Profile='Domain,Private,Public'; Protocol=$r.proto.ToUpper(); LocalPort=$r.port }
+        if ($r.program) { $params.Program = $program }
+        New-NetFirewallRule @params | Out-Null
+        $changed++
+      }
+    }
+    foreach ($n in $legacy) {
+      $rule = Get-NetFirewallRule -DisplayName $n -ErrorAction SilentlyContinue
+      if ($rule) { $rule | Remove-NetFirewallRule; $changed++ }
+    }
+    "CHANGED=$changed"
+  register: dhs_firewall_win
+  changed_when: "'CHANGED=0' not in dhs_firewall_win.stdout"
 
 - name: Firewall profiles ON (enforce mode only)
   community.windows.win_firewall:

--- a/docs/testbed.md
+++ b/docs/testbed.md
@@ -77,6 +77,17 @@ fleet actor keys below. After a fresh clone run
 shipped assets, Ansible collections). Never drive the fleet from a
 Windows workstation (PowerShell) — see ADR-0025 step 5.
 
+Monitoring a run (#790): every play logs to `/tmp/ansible-fleet.log`
+on the control node (`tail -f` it) and prints per-task timings
+(`profile_tasks`); `ps -eo pid,lstart,etimes,args | grep ansible-playbook`
+shows which pass is running and for how long. Windows tasks run with
+`ansible_shell_type: powershell` against an sshd `DefaultShell` of
+PowerShell (set by `dhs_access`, sshd restarted when it changes) — a
+fresh VM needs `playbooks/win-shell-bootstrap.yml` once (play-scoped cmd
+shell; never a global `-e ansible_shell_type`, it would hit tasks delegated
+to the control node). Facts are cached for an hour (`/tmp/ansible-facts`).
+Ad-hoc `ssh by-rune@win11 '<cmd>'` now lands in PowerShell, not cmd.
+
 ## Access — actor keys, not per-host keys
 
 Exactly three ed25519 identities are authorized on every host, managed


### PR DESCRIPTION
## What

The Windows-over-SSH latency unit (#790) + run observability (owner: "how to
monitor if not crashed?"):

- `ansible.cfg`: `log_path=/tmp/ansible-fleet.log` (tail it live),
  `profile_tasks` per-task timings, fact caching (jsonfile, 1 h, `gathering=smart`).
- `group_vars/windows.yml`: `ansible_shell_type: powershell`; `dhs_access`
  sets sshd `DefaultShell` = PowerShell (registry, applies per new session) —
  no more cmd.exe→powershell.exe double spawn per task.
- `dhs_firewall` Windows: ~33 `win_firewall_rule` tasks (~15 s each) replaced
  by ONE idempotent PowerShell reconcile of all `dhs-*` rules (present/absent,
  program scoping, legacy cleanup), `CHANGED=<n>` reported.
- testbed.md: monitoring recipe + bootstrap note (`-e ansible_shell_type=cmd`
  once on a fresh VM).

Closes #790 (epic #780).

## Why

Measured with profile_tasks: 8–20 s per Windows task; a full win11 pass
~10 min, i.e. most of today's wall-clock. Owner twice: "too long for any
role on Windows" / "how to monitor if not crashed".

## Testing

From the control node: bootstrap run (`-l win11 -e ansible_shell_type=cmd`,
sets DefaultShell), then normal run ×2 with profile_tasks; before/after
per-pass seconds posted as a comment; run-twice = 0 changes; firewall rule
inventory unchanged (15 new-style rules, program-scoped).

- [ ] win11 full no-op pass < 4 min (from ~10) — numbers in comment
- [ ] run-twice = 0 changes; fleet-verify green
- [x] No Go changes; pre-commit vet/lint clean

## Device tested

- [x] Fleet producer — win11 (+ all five for fleet-verify)
- [ ] Vendor emulator — n/a
- [ ] Real device — n/a
- [ ] No device needed (pure codec / doc change)

## Checklist

- [x] Linked issue (#790)
- [x] Conventional-commit title
- [x] No new Go dependencies
- [x] ADR-0025 step 5/6 respected (Ansible from Linux control node, idempotent)