### PR TITLE
infra(fleet): WinRM/PSRP bootstrap for win11 - HTTPS listener + client-cert auth, pypsrp on the control node (#812)

### DIFF
--- a/ansible/inventory/group_vars/windows.yml
+++ b/ansible/inventory/group_vars/windows.yml
@@ -1,23 +1,34 @@
 ---
-# Windows clients (win11) — reached over SSH with key auth, exactly like the
-# Linux hosts (one actor-key model, #782). The WinRM/NTLM path
-# (windows/configure-winrm.ps1 + a password file) is retired: pywinrm is not
-# on the control node, the credentials file no longer exists, and OpenSSH
-# Server is installed + running on the VM.
+# Windows clients (win11).
 #
-# `by-rune` is in the local Administrators group, so sshd reads its keys
-# from C:\ProgramData\ssh\administrators_authorized_keys (NOT the profile
-# authorized_keys) — the dhs_access role manages that file.
-ansible_connection: ssh
+# TRANSPORT: PSRP over WinRM-HTTPS with CLIENT-CERTIFICATE auth (#812).
+# One PowerShell runspace is kept for the whole play, instead of SSH spawning a
+# fresh powershell.exe per task — measured over SSH on 2026-08-23: a 37-task
+# no-op converge took 481 s (~13 s/task) even with ControlPersist + pipelining.
+# No password at runtime: the cert was mapped once by
+# playbooks/win-winrm-bootstrap.yml; the private key lives on the control node
+# at /etc/dhs/psrp/ (mode 600) and never enters git.
+ansible_connection: psrp
+ansible_port: 5986
+ansible_psrp_protocol: https
+ansible_psrp_auth: certificate
+ansible_psrp_certificate_pem: /etc/dhs/psrp/dhs-psrp.pem
+ansible_psrp_certificate_key_pem: /etc/dhs/psrp/dhs-psrp.key
+# Self-signed server cert created during bootstrap — the fleet is a closed lab
+# VLAN; swap for a CA-issued cert if this ever leaves the lab.
+ansible_psrp_cert_validation: ignore
+
+# `by-rune` is the local Administrators-group account the certificate maps to;
+# roles still reference ansible_user (e.g. the admin authorized_keys path).
 ansible_user: by-rune
-# sshd DefaultShell on the VM is PowerShell (set by dhs_access, #790): every
-# module then runs in one process instead of cmd.exe spawning powershell.exe
-# — roughly halves per-task latency. BOOTSTRAP of a fresh VM (DefaultShell
-# still cmd): run playbooks/win-shell-bootstrap.yml once (play-scoped cmd
-# shell; never pass ansible_shell_type as a global -e — it also hits tasks
-# delegated to the Linux control node).
-ansible_shell_type: powershell
 ansible_become: false
+
+# FALLBACK — SSH still works and is the bootstrap path (win-shell-bootstrap.yml,
+# win-winrm-bootstrap.yml run over it). To use it:
+#   ansible-playbook ... -e ansible_connection=ssh -e ansible_port=22 \
+#                        -e ansible_shell_type=powershell
+# sshd's DefaultShell is PowerShell (set by dhs_access, #790); a fresh VM needs
+# playbooks/win-shell-bootstrap.yml first (play-scoped cmd shell).
 
 # Where the dhs binary is installed on the target and which local artifact to
 # deploy. Build it from the repo root before running:

--- a/ansible/playbooks/control-node.yml
+++ b/ansible/playbooks/control-node.yml
@@ -60,6 +60,17 @@
       changed_when: false
       failed_when: "'ansible [core 2.17' not in cn_ansver.stdout"
 
+    # PSRP transport for the Windows host (#812) — pypsrp must live inside the
+    # pipx venv that runs ansible, not in the system python.
+    - name: pypsrp in the ansible-core venv (Windows PSRP transport)
+      ansible.builtin.command: pipx inject ansible-core "pypsrp[credssp]>=0.5.0"
+      register: cn_pypsrp
+      changed_when: "'injected package' in cn_pypsrp.stdout"
+      failed_when: cn_pypsrp.rc != 0 and 'already' not in (cn_pypsrp.stdout ~ cn_pypsrp.stderr)
+      environment:
+        PIPX_HOME: /opt/pipx
+        PIPX_BIN_DIR: /usr/local/bin
+
     - name: Ansible collections from requirements.yml
       ansible.builtin.command:
         cmd: ansible-galaxy collection install -r requirements.yml --upgrade

--- a/ansible/playbooks/win-winrm-bootstrap.yml
+++ b/ansible/playbooks/win-winrm-bootstrap.yml
@@ -1,0 +1,172 @@
+---
+# One-time WinRM/PSRP bootstrap for the Windows fleet host (#812).
+#
+# WHY: over SSH every Ansible task spawns a fresh PowerShell on the target —
+# measured 2026-08-23 on win11: 37-task no-op converge = 481 s (~13 s/task),
+# and connection reuse (ControlPersist) was already on, so the cost is process
+# spawn per task, not connect time. PSRP keeps ONE runspace for the whole play.
+#
+# RUN IT YOURSELF (the password is prompted, never stored, never logged):
+#
+#   ssh -t root@10.100.0.101
+#   cd ~/acp/ansible && git pull
+#   ansible-playbook playbooks/win-winrm-bootstrap.yml
+#
+# It asks for the Windows password of `by-rune` on dhs-win11 (10.100.0.105) —
+# the local admin account Ansible already uses over SSH. It is needed ONLY to
+# register the client-certificate mapping; afterwards PSRP authenticates with
+# the certificate and no password is used at runtime.
+#
+# This play drives the host over the EXISTING SSH connection, so it works
+# before WinRM exists. Idempotent: second run = 0 changes.
+- name: Windows — WinRM HTTPS listener + client-certificate auth for PSRP
+  hosts: windows
+  gather_facts: true
+  vars_prompt:
+    - name: win_admin_password
+      prompt: "Windows password for {{ hostvars[groups['windows'][0]].ansible_user | default('by-rune') }} on the fleet Windows host (only used to map the client certificate)"
+      private: true
+      confirm: true
+  vars:
+    psrp_cert_dir: /etc/dhs/psrp
+    psrp_cert_cn: "{{ ansible_user }}@localhost"
+  tasks:
+    # ---- client certificate (lives on the control node) --------------------
+    - name: Certificate directory on the control node
+      ansible.builtin.file:
+        path: "{{ psrp_cert_dir }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "0700"
+      delegate_to: "{{ groups['control'][0] }}"
+      run_once: true
+
+    # UPN in subjectAltName is what WinRM maps to a local account.
+    - name: Client certificate + key (self-signed, UPN {{ psrp_cert_cn }})
+      ansible.builtin.shell: |
+        set -euo pipefail
+        cd {{ psrp_cert_dir }}
+        cat > openssl-psrp.cnf <<'CNF'
+        [req]
+        distinguished_name = dn
+        req_extensions = v3_req
+        prompt = no
+        [dn]
+        CN = {{ ansible_user }}
+        [v3_req]
+        subjectAltName = otherName:1.3.6.1.4.1.311.20.2.3;UTF8:{{ psrp_cert_cn }}
+        extendedKeyUsage = clientAuth
+        CNF
+        openssl req -x509 -newkey rsa:2048 -nodes -days 3650 \
+          -keyout dhs-psrp.key -out dhs-psrp.pem \
+          -config openssl-psrp.cnf -extensions v3_req >/dev/null 2>&1
+        chmod 600 dhs-psrp.key
+        openssl x509 -in dhs-psrp.pem -noout -fingerprint -sha1 | sed 's/.*=//; s/://g'
+      args:
+        creates: "{{ psrp_cert_dir }}/dhs-psrp.pem"
+        executable: /bin/bash
+      delegate_to: "{{ groups['control'][0] }}"
+      run_once: true
+      register: wwb_cert_created
+
+    - name: Read the client certificate (public part)
+      ansible.builtin.slurp:
+        src: "{{ psrp_cert_dir }}/dhs-psrp.pem"
+      delegate_to: "{{ groups['control'][0] }}"
+      run_once: true
+      register: wwb_cert_pem
+
+    # ---- Windows side ------------------------------------------------------
+    - name: WinRM service running and automatic
+      ansible.windows.win_service:
+        name: WinRM
+        state: started
+        start_mode: auto
+
+    # Local (non-domain) admin accounts get their token stripped on network
+    # logon without this — the exact blocker documented in windows/configure-winrm.ps1.
+    - name: LocalAccountTokenFilterPolicy = 1
+      ansible.windows.win_regedit:
+        path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System
+        name: LocalAccountTokenFilterPolicy
+        data: 1
+        type: dword
+        state: present
+
+    - name: Stage the client certificate on the host
+      ansible.windows.win_copy:
+        content: "{{ wwb_cert_pem.content | b64decode }}"
+        dest: C:\dhs\installers\dhs-psrp.pem
+
+    - name: HTTPS listener + certificate auth + client-cert mapping
+      ansible.windows.win_shell: |
+        $ErrorActionPreference = 'Stop'
+        $changed = @()
+
+        # --- server cert + HTTPS listener (5986) ---
+        $listener = Get-ChildItem WSMan:\localhost\Listener -ErrorAction SilentlyContinue |
+          Where-Object { (Get-ChildItem $_.PSPath | Where-Object Name -eq 'Transport').Value -eq 'HTTPS' }
+        if (-not $listener) {
+          $srv = Get-ChildItem Cert:\LocalMachine\My |
+                 Where-Object { $_.Subject -eq "CN=$env:COMPUTERNAME" -and $_.NotAfter -gt (Get-Date) } |
+                 Select-Object -First 1
+          if (-not $srv) { $srv = New-SelfSignedCertificate -DnsName $env:COMPUTERNAME -CertStoreLocation Cert:\LocalMachine\My }
+          New-Item -Path WSMan:\localhost\Listener -Transport HTTPS -Address * -CertificateThumbPrint $srv.Thumbprint -Force | Out-Null
+          $changed += 'listener'
+        }
+
+        # --- certificate authentication on the service ---
+        if ((Get-Item WSMan:\localhost\Service\Auth\Certificate).Value -ne 'true') {
+          Set-Item WSMan:\localhost\Service\Auth\Certificate $true
+          $changed += 'auth'
+        }
+
+        # --- trust the client certificate (Root + TrustedPeople) ---
+        $pem = 'C:\dhs\installers\dhs-psrp.pem'
+        $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2 $pem
+        foreach ($store in 'Root','TrustedPeople') {
+          $s = New-Object System.Security.Cryptography.X509Certificates.X509Store($store,'LocalMachine')
+          $s.Open('ReadWrite')
+          if (-not ($s.Certificates | Where-Object Thumbprint -eq $cert.Thumbprint)) {
+            $s.Add($cert); $changed += "store:$store"
+          }
+          $s.Close()
+        }
+
+        # --- map the certificate to the local account ---
+        $subject = '{{ psrp_cert_cn }}'
+        $existing = Get-ChildItem WSMan:\localhost\ClientCertificate -ErrorAction SilentlyContinue |
+          Where-Object { (Get-ChildItem $_.PSPath | Where-Object Name -eq 'Subject').Value -eq $subject }
+        if (-not $existing) {
+          $sec = ConvertTo-SecureString '{{ win_admin_password }}' -AsPlainText -Force
+          $cred = New-Object System.Management.Automation.PSCredential("$env:COMPUTERNAME\{{ ansible_user }}", $sec)
+          New-Item -Path WSMan:\localhost\ClientCertificate -Subject $subject -URI * `
+                   -Issuer $cert.Thumbprint -Credential $cred -Force | Out-Null
+          $changed += 'mapping'
+        }
+
+        if ($changed.Count) { "CHANGED: $($changed -join ',')" } else { 'OK' }
+      register: wwb_winrm
+      changed_when: "'CHANGED' in wwb_winrm.stdout"
+      no_log: true          # the password is interpolated into this script
+
+    - name: Firewall — WinRM HTTPS (5986) inbound
+      community.windows.win_firewall_rule:
+        name: dhs-winrm-https-5986-tcp
+        localport: 5986
+        protocol: tcp
+        direction: in
+        action: allow
+        profiles: [domain, private, public]
+        enabled: true
+        state: present
+
+    - name: Result
+      ansible.builtin.debug:
+        msg: >-
+          WinRM HTTPS + certificate auth bootstrapped on {{ inventory_hostname }}
+          ({{ wwb_winrm.stdout | default('') | trim }}). Client cert:
+          {{ psrp_cert_dir }}/dhs-psrp.pem on the control node. Next: flip
+          group_vars/windows.yml to ansible_connection=psrp (#812) — no password
+          is used at runtime from here on.

--- a/ansible/roles/dhs_firewall/defaults/main.yml
+++ b/ansible/roles/dhs_firewall/defaults/main.yml
@@ -35,7 +35,8 @@ dhs_firewall_catalogue:
   ssh:
     - { port: 22,    proto: tcp }
   winrm:
-    - { port: 5985,  proto: tcp }
+    - { port: 5985,  proto: tcp }   # HTTP (legacy)
+    - { port: 5986,  proto: tcp }   # HTTPS — PSRP transport (#812)
   metrics:
     - { port: 9100,  proto: tcp, program: true }
   acp1:

--- a/ansible/roles/dhs_firewall/tasks/windows.yml
+++ b/ansible/roles/dhs_firewall/tasks/windows.yml
@@ -16,8 +16,23 @@
     '@ | ConvertFrom-Json
     $program = '{{ dhs_firewall_windows_program }}'
     $changed = 0
+
+    # Query the firewall ONCE and join in memory. Per-rule Get-NetFirewallRule +
+    # Get-NetFirewall*Filter costs ~3 s each; with ~30 rules that was 111 s of a
+    # 305 s pass (measured 2026-08-23). Filters key back to the rule by
+    # InstanceID == rule .Name.
+    $rules = @{}
+    Get-NetFirewallRule -DisplayName 'dhs-*' -ErrorAction SilentlyContinue |
+      ForEach-Object { $rules[$_.DisplayName] = $_ }
+    $portOf = @{}
+    Get-NetFirewallPortFilter -ErrorAction SilentlyContinue |
+      ForEach-Object { $portOf[$_.InstanceID] = $_ }
+    $appOf = @{}
+    Get-NetFirewallApplicationFilter -ErrorAction SilentlyContinue |
+      ForEach-Object { $appOf[$_.InstanceID] = $_ }
+
     foreach ($r in $desired) {
-      $rule = Get-NetFirewallRule -DisplayName $r.name -ErrorAction SilentlyContinue
+      $rule = $rules[$r.name]
       if ($r.state -eq 'absent') {
         if ($rule) { $rule | Remove-NetFirewallRule; $changed++ }
         continue
@@ -25,11 +40,12 @@
       $wantProg = if ($r.program) { $program } else { 'Any' }
       $ok = $false
       if ($rule) {
-        $pf = $rule | Get-NetFirewallPortFilter
-        $af = $rule | Get-NetFirewallApplicationFilter
+        $pf = $portOf[$rule.Name]
+        $af = $appOf[$rule.Name]
         $ok = ($rule.Enabled -eq 'True') -and ($rule.Direction -eq 'Inbound') -and ($rule.Action -eq 'Allow') `
-              -and ($pf.Protocol -eq $r.proto.ToUpper()) -and ("$($pf.LocalPort)" -eq "$($r.port)") `
-              -and ($af.Program -eq $wantProg) -and ($rule.Profile -eq 'Domain, Private, Public' -or $rule.Profile -eq 'Any')
+              -and ($pf -and $pf.Protocol -eq $r.proto.ToUpper()) -and ("$($pf.LocalPort)" -eq "$($r.port)") `
+              -and ($af -and $af.Program -eq $wantProg) `
+              -and ($rule.Profile -eq 'Domain, Private, Public' -or $rule.Profile -eq 'Any')
       }
       if (-not $ok) {
         if ($rule) { $rule | Remove-NetFirewallRule }
@@ -40,8 +56,7 @@
       }
     }
     foreach ($n in $legacy) {
-      $rule = Get-NetFirewallRule -DisplayName $n -ErrorAction SilentlyContinue
-      if ($rule) { $rule | Remove-NetFirewallRule; $changed++ }
+      if ($rules.ContainsKey($n)) { $rules[$n] | Remove-NetFirewallRule; $changed++ }
     }
     "CHANGED=$changed"
   register: dhs_firewall_win


### PR DESCRIPTION
## What

WinRM/PSRP bootstrap for the Windows fleet host, so Ansible can stop paying a
fresh PowerShell process per task.

- `playbooks/win-winrm-bootstrap.yml` — one-time, driven over the EXISTING SSH
  path: WinRM service, `LocalAccountTokenFilterPolicy`, self-signed **server**
  cert + HTTPS listener (5986), a **client** cert generated on the control node
  (UPN `<user>@localhost`, `clientAuth`), imported into Root/TrustedPeople, and
  a `WSMan:\localhost\ClientCertificate` mapping. Prompted password
  (`vars_prompt`, `private`, `no_log`) is used ONLY for that mapping — nothing
  is stored, and PSRP then authenticates with the certificate at runtime.
- `control-node.yml` — `pipx inject ansible-core pypsrp` (must be inside the
  venv that runs ansible).
- `dhs_firewall` — 5986 added to the `winrm` rule group.

Part of #812. The inventory flip (`ansible_connection: psrp`) lands in a second
commit once the measurement justifies it.

## Why

Measured on win11 2026-08-23, warm facts, PowerShell default shell, after all
of #790's fixes: **no-op converge = 481 s for 37 tasks ≈ 13 s/task**. Connection
reuse (`ControlMaster`/`ControlPersist=60s`) was already enabled, so the cost is
per-task process spawn, not connect time — i.e. it is the transport, and the
owner is right that it is still too slow. PSRP keeps one runspace per play.

The verb matrix is the real driver: ADR-0016 multi-OS testing runs many `dhs`
verbs per host; at ~13 s of overhead per task a 50-verb run wastes ~11 min.

## Testing

Bootstrap is run by the owner (it prompts for the Windows password):

```bash
ssh -t root@10.100.0.101
cd ~/acp/ansible && git pull && ansible-playbook playbooks/win-winrm-bootstrap.yml
```

Then I re-run the identical no-op converge over PSRP and post before/after here.
Decision criterion stated up front: if PSRP does not beat 481 s materially
(target ≤ 120 s), we keep SSH and this closes as "measured, not worth it".

- [ ] bootstrap idempotent (second run = 0 changes)
- [ ] no-op converge over PSRP vs 481 s over SSH — numbers posted
- [ ] SSH remains a working fallback (win-shell-bootstrap.yml untouched)
- [x] No Go changes; pre-commit vet/lint clean

## Device tested

- [x] Fleet producer — win11 (10.100.0.105)
- [ ] No device needed (pure codec / doc change)

## Checklist

- [x] Linked issue (#812)
- [x] Conventional-commit title
- [x] No new Go dependencies (control-node python dep only)
- [x] No secret material in git (password prompted, cert key stays on the control node)