### PR TITLE
infra(fleet): Defender exclusions for the dhs + ansible-tmp folders on win11 (#815)

### DIFF
--- a/ansible/roles/dhs_host/defaults/main.yml
+++ b/ansible/roles/dhs_host/defaults/main.yml
@@ -30,6 +30,16 @@ dhs_host_packages:
   Debian: [tshark, curl, jq, ca-certificates, unzip, tar]
   RedHat: [wireshark-cli, curl, jq, ca-certificates, unzip, tar]
 
+# Defender exclusions for the automation working folders (#815). Measured on
+# win11: a bare PowerShell invocation costs ~6 s, and Defender scanning every
+# Ansible module written to the remote tmp dir is a large part of it. Scope is
+# deliberately narrow — the dhs install/data dirs and the ansible-tmp pattern
+# only; never a blanket %TEMP% or system-wide exclusion.
+dhs_host_defender_exclusions:
+  - 'C:\dhs'
+  - 'C:\ProgramData\dhs'
+  - 'C:\Users\{{ ansible_user }}\AppData\Local\Temp\ansible-tmp-*'
+
 # NTP peers for win11 (w32time). LXCs inherit the Proxmox host clock and
 # cannot set time themselves — the pve node is chrony's job (ansible-platform#168).
 dhs_host_ntp_peers: ["10.100.0.1,0x8", "pool.ntp.org,0x8"]

--- a/ansible/roles/dhs_host/tasks/windows.yml
+++ b/ansible/roles/dhs_host/tasks/windows.yml
@@ -19,6 +19,21 @@
   register: dhs_host_power
   changed_when: "'CHANGED' in dhs_host_power.stdout"
 
+# ---- Defender exclusions for the automation working folders (#815) --------
+- name: Defender exclusions for the dhs + ansible-tmp paths
+  ansible.windows.win_shell: |
+    $want = @('{{ dhs_host_defender_exclusions | join("','") }}')
+    $cur = @((Get-MpPreference).ExclusionPath)
+    $added = @()
+    foreach ($p in $want) {
+      if ($cur -notcontains $p) { Add-MpPreference -ExclusionPath $p; $added += $p }
+    }
+    if ($added.Count) { "CHANGED: $($added -join ';')" } else { 'OK' }
+  register: dhs_host_defender
+  changed_when: "'CHANGED' in dhs_host_defender.stdout"
+  failed_when: false          # Defender may be absent/managed by policy
+  when: dhs_host_defender_exclusions | length > 0
+
 # ---- time: NTP from the DMZ gateway + pool, w32time synchronized ----------
 # 2026-08-23: w32time was "not synchronized" (peer time.windows.com, Local
 # type). pfSense 10.100.0.1 and pool.ntp.org answer NTP from the DMZ.

--- a/docs/testbed.md
+++ b/docs/testbed.md
@@ -153,6 +153,36 @@ Roll the fleet to a new release by bumping `dhs_version` and converging
 un-parks — the inventory then switches port/user), dhs application layer
 = this repo's roles.
 
+### win11 Ansible latency (#790, #812, #815)
+
+A no-op `fleet-converge.yml -l win11` pass, measured 2026-08-23 from the
+control node:
+
+| Configuration | Duration |
+| --- | ---: |
+| SSH transport, one `win_firewall_rule` task per rule | 481 s |
+| PSRP over WinRM-HTTPS, client-certificate auth (#812) | 305 s |
+| + `dhs_firewall` single-pass reconcile, bulk query + in-memory join (#790) | 236 s |
+| + Defender path exclusions, VM 654 at 8 GB (#815) | 139-156 s |
+
+What each lever fixed. Over SSH every task spawns a fresh PowerShell on
+the target - connection reuse (`ControlPersist`) was already on, so the
+cost is process spawn, not connect; PSRP keeps one runspace for the
+whole play. Per-rule `Get-NetFirewallRule` + `Get-NetFirewall*Filter`
+cost ~3 s each, so ~30 rules were 111 s of the pass - one bulk query
+joined in memory removes it. Defender scanned every module written to
+`ansible-tmp-*`; the exclusions (`dhs_host_defender_exclusions`) are
+narrow by design - `C:\dhs`, `C:\ProgramData\dhs`, and the
+`ansible-tmp-*` pattern only, never a blanket `%TEMP%` or a system-wide
+exclusion, and real-time protection stays on. A memory change on the VM
+needs a hypervisor stop/start: `win_reboot` restarts the guest only, the
+QEMU process survives and keeps the old `maxmem`.
+
+The floor is now per-task, not per-role - the twelve slowest tasks are
+all 4.0-5.7 s of pure module round-trip. The next lever is task-count
+consolidation (one idempotent script per role's Windows path, as
+`dhs_firewall` already does), not transport.
+
 ## Producer launch and stop
 
 ### Linux LXC (Debian / Ubuntu / Rocky)
@@ -208,5 +238,5 @@ Second run = 0 updates / 0 changes.
 Tracked in epic #780: static addressing (#786, `dhs_netaddr`), unique
 hostnames (#783), actor-key convergence (#782), mDNS (#784, #797),
 firewall (#785), host baseline (#800), OS updates + reboot (#799),
-time sync + IPv6 (#804), win11 Ansible latency (#790). pfSense hygiene
+time sync + IPv6 (#804), win11 Ansible latency (#790, #812, #815). pfSense hygiene
 (owner, any time): exclude `10.100.0.100–120` from the DHCP pool.


### PR DESCRIPTION
## What

Ansible now manages Windows Defender antivirus **path exclusions** for the automation working folders on `win11`, in the `dhs_host` role.

## Why

Every Ansible module is written to a fresh `ansible-tmp-*` folder under the remote user's `%TEMP%` and executed there; Defender real-time protection scans each one. Measured on win11 (4 cores): a bare `raw` invocation cost ~5.8 s and `win_ping` ~9.9 s, and a 38-task no-op converge took 236 s even after the PSRP switch (#812) and the firewall bulk-query fix (#790).

Scope is deliberately narrow — the dhs install/data dirs and the `ansible-tmp-*` pattern only. **Never** a blanket `%TEMP%` or system-wide exclusion, and real-time protection stays on.

Closes #815

## Scope

- [x] ci / chore

Infrastructure only (`ansible/`); no Go code, no protocol behaviour.

## Wire evidence (protocol changes only)

N/A — no protocol change.

## Reference controller

- [x] N/A (no protocol behaviour change)

## Type

- [x] chore — maintenance, refactor, CI

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `ansible/roles/dhs_host/defaults/main.yml` | modified | `dhs_host_defender_exclusions` — the three narrow paths, with the measurement rationale in comments |
| `ansible/roles/dhs_host/tasks/windows.yml` | modified | idempotent `Add-MpPreference` task; adds only missing paths, `failed_when: false` so a policy-managed/absent Defender never breaks a converge |
| `docs/testbed.md` | modified | new "win11 Ansible latency" section — the measured table above plus what each lever fixed and what the remaining floor is |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test ./...` | untouched (no Go change) | — |
| `fleet-converge.yml -l win11` (run 1) | `ok=39 changed=1` | 0 |
| `fleet-converge.yml -l win11` (run 2, ADR-0007 idempotency) | `ok=38 changed=0` | 0 |

## Device tested

- [x] Fleet producer — win11 (10.100.0.105), driven from the control node dhs-debian (10.100.0.101) over PSRP

**Live-LXC command + observed output** (paste verbatim):

```text
$ ansible win11 -m ansible.windows.win_shell -a '(Get-MpPreference).ExclusionPath -join " | "'
win11 | CHANGED | rc=0 >>
C:\dhs | C:\ProgramData\dhs | C:\Users\by-rune\AppData\Local\Temp\ansible-tmp-*

$ ansible-playbook playbooks/fleet-converge.yml -l win11     # run 2
win11 : ok=38  changed=0  unreachable=0  failed=0  skipped=18  rescued=0  ignored=0
```

### Converge duration on win11 (no-op pass)

| Configuration | Duration |
|---|---:|
| SSH transport, per-rule firewall | 481 s |
| PSRP transport (#812) | 305 s |
| + firewall single-pass reconcile (#790) | 236 s |
| + Defender exclusions, VM at 8 GB (this PR) | **156 s** (pass 1) / **139 s** (pass 2) |

The VM was power-cycled at the hypervisor (not a guest reboot) so the 8 GB memory change took effect; both levers landed together, so 156 s covers the pair.

## Checklist

- [x] `go test -count=1 ./...` passes (unchanged — no Go code touched)
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [x] Integration tested on VM before PR

## Approval

@yboujraf — requesting review
### Remaining floor

The twelve slowest tasks are now all 4.0–5.7 s of pure module round-trip (Sleep / hibernate timeouts 5.65 s, computer name 5.47 s, Bonjour Service 5.39 s, …). At 38 tasks that *is* the pass. Transport and Defender are done as levers; the next one is task-count consolidation — one idempotent script per role's Windows path, the way `dhs_firewall` already works. Not in this PR.
