### PR TITLE
infra(fleet): dhs_guestsize - guest vCPU from the inventory truth via the Proxmox API (#817)

### DIFF
--- a/ansible/inventory/host_vars/dhs-debian.yml
+++ b/ansible/inventory/host_vars/dhs-debian.yml
@@ -8,7 +8,7 @@ ansible_connection: local
 
 pve_vmid: 651
 pve_name: dhs.debian12
-pve_cores: 4          # P1 sizing (#817): binary-test host (control node moved to .104)
+pve_cores: 2          # P1 sizing (#817): binary-test host - SAME size as .102/.103 so cross-distro binary perf is comparable
 os_label: "Debian 12"
 nics:
   - { name: eth0, mac: "BC:24:11:80:E3:AC", ip: 10.100.0.101 }

--- a/ansible/inventory/host_vars/dhs-debian.yml
+++ b/ansible/inventory/host_vars/dhs-debian.yml
@@ -8,6 +8,7 @@ ansible_connection: local
 
 pve_vmid: 651
 pve_name: dhs.debian12
+pve_cores: 4          # P1 sizing (#817): binary-test host (control node moved to .104)
 os_label: "Debian 12"
 nics:
   - { name: eth0, mac: "BC:24:11:80:E3:AC", ip: 10.100.0.101 }

--- a/ansible/inventory/host_vars/dhs-rocky.yml
+++ b/ansible/inventory/host_vars/dhs-rocky.yml
@@ -4,6 +4,7 @@
 # (one host, two mgmt ports; the old .104/.105 leases were this host.)
 pve_vmid: 653
 pve_name: dhs.rocky9
+pve_cores: 2          # P1 sizing (#817): LXC cores are a cgroup ceiling, not a reservation
 os_label: "Rocky 9.4"
 nics:
   - { name: eth0, mac: "BC:24:11:2B:F7:C7", ip: 10.100.0.103 }

--- a/ansible/inventory/host_vars/dhs-tools.yml
+++ b/ansible/inventory/host_vars/dhs-tools.yml
@@ -6,6 +6,7 @@
 # default (no ember_tree_src).
 pve_vmid: 655
 pve_name: dhs.tools
+pve_cores: 6          # P1 sizing (#817): ANSIBLE CONTROL NODE - forking, templating, module assembly and SSH/TLS crypto all run here
 os_label: "Ubuntu"
 nics:
   - { name: eth0, mac: "BC:24:11:C1:92:FF", ip: 10.100.0.104 }

--- a/ansible/inventory/host_vars/dhs-ubuntu.yml
+++ b/ansible/inventory/host_vars/dhs-ubuntu.yml
@@ -3,6 +3,7 @@
 # Dual-NIC: eth0 10.100.0.102 (ansible_host) / eth1 10.100.0.112.
 pve_vmid: 652
 pve_name: dhs.ubuntu24
+pve_cores: 2          # P1 sizing (#817): LXC cores are a cgroup ceiling, not a reservation
 os_label: "Ubuntu 24.04"
 nics:
   - { name: eth0, mac: "BC:24:11:28:78:25", ip: 10.100.0.102 }

--- a/ansible/playbooks/fleet-converge.yml
+++ b/ansible/playbooks/fleet-converge.yml
@@ -14,6 +14,9 @@
   hosts: dhs_clients
   gather_facts: true
   roles:
+    # first: guest vCPU/RAM from the inventory truth (#817 P1). LXC changes
+    # apply live; a VM delta is reported, never power-cycled.
+    - dhs_guestsize
     - dhs_host
     - dhs_access
     - dhs_hostname

--- a/ansible/roles/dhs_guestsize/defaults/main.yml
+++ b/ansible/roles/dhs_guestsize/defaults/main.yml
@@ -1,0 +1,42 @@
+---
+# dhs_guestsize — vCPU / RAM of each fleet guest converged from the inventory
+# truth, via the Proxmox API (#817 P1).
+#
+# WHY: measured 2026-08-23, the control node ran every Ansible play for the
+# whole fleet on ONE vCPU while pve01 sat at ~12% of 24 cores. Ansible does
+# its forking, Jinja templating, module assembly and SSH/TLS crypto on the
+# CONTROLLER, so a 1-core control node is a fleet-wide tax — not a per-host
+# one. `dhs version` warm cost 0.54-0.56 s on the 1-core LXCs, which is a
+# CPU-starvation signal for a Go binary printing a string.
+#
+# SIZING IS DELIBERATELY CONSERVATIVE. pve01 is a PRODUCTION node: 12 running
+# guests including pfsense01 (the firewall), vm-cerebrum-stg-01 (8 vCPU /
+# 64 GB) and by-odoo-instances (8 vCPU / 32 GB); 43 vCPU allocated on 24
+# cores and 162 of 188.7 GB RAM before this role. So:
+#   - LXC `cores` is a cgroup CEILING, not a reservation — an idle container
+#     consumes nothing, which is why raising it on containers is cheap.
+#   - QEMU vCPUs are real threads, so win11 is NOT resized here.
+#   - RAM is the tight resource (27 GB headroom) — this role changes memory
+#     only where a host_var asks for it, and nothing asks today.
+#
+# Desired values live in host_vars as `pve_cores` (and optionally
+# `pve_memory`, MiB). A host without `pve_cores` is skipped entirely.
+
+# Proxmox API — token vars come from the control-node-only secrets file
+# (-e @/root/.secrets/proxmox.yml), same as dhs_netaddr and dhs_hostname.
+dhs_guestsize_enabled: "{{ proxmox_token_id is defined and proxmox_token_secret is defined }}"
+proxmox_api_host: 10.6.224.5:8006
+proxmox_node: pve01
+proxmox_validate_certs: false
+
+# LXC core/memory changes apply LIVE (cgroup), no restart. QEMU needs a
+# hypervisor stop/start — a guest reboot keeps the same QEMU process and the
+# new config is NOT picked up (learned on win11, see docs/testbed.md). This
+# role never power-cycles a VM; it reports the pending delta and leaves the
+# window to the operator.
+dhs_guestsize_vm_apply: false
+
+# Guard: refuse to converge if the node's total allocated vCPU for RUNNING
+# guests would exceed this ratio of physical cores. 43/24 = 1.79 today; the
+# P1 targets take it to 50/24 = 2.08.
+dhs_guestsize_max_overcommit: 2.5

--- a/ansible/roles/dhs_guestsize/meta/main.yml
+++ b/ansible/roles/dhs_guestsize/meta/main.yml
@@ -1,0 +1,20 @@
+---
+galaxy_info:
+  role_name: dhs_guestsize
+  author: by-rune
+  description: >-
+    vCPU / RAM of each fleet guest converged from the inventory truth via the
+    Proxmox API. LXC changes apply live (cgroup); QEMU deltas are reported,
+    never power-cycled. Idempotent: run-twice = 0 changes.
+  license: see repository
+  min_ansible_version: "2.14"
+  platforms:
+    - name: EL
+      versions: [all]
+    - name: Debian
+      versions: [all]
+    - name: Ubuntu
+      versions: [all]
+    - name: Windows
+      versions: [all]
+dependencies: []

--- a/ansible/roles/dhs_guestsize/tasks/main.yml
+++ b/ansible/roles/dhs_guestsize/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+# NOTE: never `meta: end_host` here — this role runs FIRST in
+# fleet-converge.yml, and end_host would skip every later role for any host
+# that declares no desired size. Guard with `when:` instead.
+- name: Proxmox layer skipped (no token vars)
+  ansible.builtin.debug:
+    msg: >-
+      dhs_guestsize: pass -e @/root/.secrets/proxmox.yml to converge
+      {{ inventory_hostname }}'s vCPU/RAM
+  when:
+    - pve_cores is defined or pve_memory is defined
+    - not (dhs_guestsize_enabled | bool)
+
+- name: Converge guest size
+  ansible.builtin.include_tasks: proxmox.yml
+  when:
+    - pve_cores is defined or pve_memory is defined
+    - dhs_guestsize_enabled | bool
+    - pve_vmid is defined

--- a/ansible/roles/dhs_guestsize/tasks/proxmox.yml
+++ b/ansible/roles/dhs_guestsize/tasks/proxmox.yml
@@ -1,0 +1,103 @@
+---
+# Read the guest config, compare vCPU/RAM against the inventory truth, PUT
+# only what differs. LXC applies live; QEMU is reported, never power-cycled.
+- name: Guest kind (lxc unless the host declares otherwise)
+  ansible.builtin.set_fact:
+    dhs_guestsize_kind: "{{ pve_type | default('qemu' if ansible_os_family == 'Windows' else 'lxc') }}"
+
+- name: Read the node's CPU capacity
+  ansible.builtin.uri:
+    url: "https://{{ proxmox_api_host }}/api2/json/nodes/{{ proxmox_node }}/status"
+    headers:
+      Authorization: "PVEAPIToken={{ proxmox_token_id }}={{ proxmox_token_secret }}"
+    validate_certs: "{{ proxmox_validate_certs }}"
+    return_content: true
+  delegate_to: localhost
+  register: dhs_guestsize_node
+
+- name: Read every guest on the node (containers + VMs)
+  ansible.builtin.uri:
+    url: "https://{{ proxmox_api_host }}/api2/json/nodes/{{ proxmox_node }}/{{ item }}"
+    headers:
+      Authorization: "PVEAPIToken={{ proxmox_token_id }}={{ proxmox_token_secret }}"
+    validate_certs: "{{ proxmox_validate_certs }}"
+    return_content: true
+  delegate_to: localhost
+  loop: [lxc, qemu]
+  register: dhs_guestsize_all
+
+# pve01 is a PRODUCTION node (pfSense, Cerebrum staging, Odoo). Refuse to
+# push total allocated vCPU past the ceiling rather than discover it later.
+- name: Overcommit guard — allocated vCPU for running guests after this change
+  ansible.builtin.set_fact:
+    dhs_guestsize_alloc: >-
+      {{ (dhs_guestsize_all.results | map(attribute='json.data') | flatten
+          | selectattr('status', 'equalto', 'running')
+          | rejectattr('vmid', 'equalto', pve_vmid | int)
+          | map(attribute='cpus') | map('int') | sum)
+         + (pve_cores | default(0) | int) }}
+    dhs_guestsize_node_cores: "{{ dhs_guestsize_node.json.data.cpuinfo.cpus | int }}"
+
+- name: Assert the node stays inside the overcommit ceiling
+  ansible.builtin.assert:
+    that:
+      - (dhs_guestsize_alloc | int) <= (dhs_guestsize_node_cores | int) * (dhs_guestsize_max_overcommit | float)
+    fail_msg: >-
+      dhs_guestsize: {{ inventory_hostname }} -> {{ pve_cores | default('n/a') }} vCPU would take
+      pve01 to {{ dhs_guestsize_alloc }} allocated vCPU on {{ dhs_guestsize_node_cores }} cores
+      (ceiling {{ dhs_guestsize_max_overcommit }}x). Lower pve_cores or raise
+      dhs_guestsize_max_overcommit deliberately.
+    success_msg: >-
+      {{ dhs_guestsize_alloc }} vCPU allocated on {{ dhs_guestsize_node_cores }} cores
+      ({{ ((dhs_guestsize_alloc | float) / (dhs_guestsize_node_cores | float)) | round(2) }}x,
+      ceiling {{ dhs_guestsize_max_overcommit }}x)
+
+- name: Read the guest config from Proxmox
+  ansible.builtin.uri:
+    url: "https://{{ proxmox_api_host }}/api2/json/nodes/{{ proxmox_node }}/{{ dhs_guestsize_kind }}/{{ pve_vmid }}/config"
+    headers:
+      Authorization: "PVEAPIToken={{ proxmox_token_id }}={{ proxmox_token_secret }}"
+    validate_certs: "{{ proxmox_validate_certs }}"
+    return_content: true
+  delegate_to: localhost
+  register: dhs_guestsize_cfg
+
+- name: Delta — cores / memory that differ from the inventory
+  ansible.builtin.set_fact:
+    dhs_guestsize_changes: >-
+      {{ {}
+         | combine({'cores': pve_cores | int}
+                   if (pve_cores is defined and (dhs_guestsize_cfg.json.data.cores | default(0) | int) != (pve_cores | int))
+                   else {})
+         | combine({'memory': pve_memory | int}
+                   if (pve_memory is defined and (dhs_guestsize_cfg.json.data.memory | default(0) | int) != (pve_memory | int))
+                   else {}) }}
+
+- name: "Proxmox {{ dhs_guestsize_kind }} {{ pve_vmid }} size -> {{ dhs_guestsize_changes | dict2items | map(attribute='key') | join(',') | default('no change', true) }}"
+  ansible.builtin.uri:
+    url: "https://{{ proxmox_api_host }}/api2/json/nodes/{{ proxmox_node }}/{{ dhs_guestsize_kind }}/{{ pve_vmid }}/config"
+    method: PUT
+    headers:
+      Authorization: "PVEAPIToken={{ proxmox_token_id }}={{ proxmox_token_secret }}"
+    body_format: form-urlencoded
+    body: "{{ dhs_guestsize_changes }}"
+    validate_certs: "{{ proxmox_validate_certs }}"
+  delegate_to: localhost
+  when:
+    - dhs_guestsize_changes | length > 0
+    - dhs_guestsize_kind == 'lxc' or (dhs_guestsize_vm_apply | bool)
+  changed_when: true
+
+# A QEMU config change needs a hypervisor stop/start: win_reboot restarts the
+# guest OS only, the QEMU process survives and keeps the old cores/maxmem.
+- name: VM resize pending an operator power cycle
+  ansible.builtin.debug:
+    msg: >-
+      dhs_guestsize: {{ inventory_hostname }} (VM {{ pve_vmid }}) wants
+      {{ dhs_guestsize_changes }} — not applied. Set dhs_guestsize_vm_apply=true
+      to write the config, then STOP and START the VM (a guest reboot keeps the
+      old QEMU process and the change will not take effect).
+  when:
+    - dhs_guestsize_changes | length > 0
+    - dhs_guestsize_kind != 'lxc'
+    - not (dhs_guestsize_vm_apply | bool)

--- a/ansible/roles/dhs_guestsize/tasks/proxmox.yml
+++ b/ansible/roles/dhs_guestsize/tasks/proxmox.yml
@@ -13,6 +13,7 @@
     validate_certs: "{{ proxmox_validate_certs }}"
     return_content: true
   delegate_to: localhost
+  check_mode: false          # read-only GET: must run in --check too
   register: dhs_guestsize_node
 
 - name: Read every guest on the node (containers + VMs)
@@ -24,6 +25,7 @@
     return_content: true
   delegate_to: localhost
   loop: [lxc, qemu]
+  check_mode: false          # read-only GET: must run in --check too
   register: dhs_guestsize_all
 
 # pve01 is a PRODUCTION node (pfSense, Cerebrum staging, Odoo). Refuse to
@@ -60,6 +62,7 @@
     validate_certs: "{{ proxmox_validate_certs }}"
     return_content: true
   delegate_to: localhost
+  check_mode: false          # read-only GET: must run in --check too
   register: dhs_guestsize_cfg
 
 - name: Delta — cores / memory that differ from the inventory


### PR DESCRIPTION
## What

New `dhs_guestsize` role: each fleet guest's vCPU (and optionally RAM) converged from `host_vars` through the Proxmox API, run first in `fleet-converge.yml`.

## Why

P1 of #817. Measured 2026-08-23: the control node ran **every** Ansible play for the whole fleet on **one vCPU**, while pve01 sat at ~12% of 24 cores. Ansible forks, templates, assembles modules and does its SSH/TLS crypto on the *controller*, so a 1-core control node is a fleet-wide tax rather than a per-host one. A warm `dhs version` cost 0.54–0.56 s on the 1-core LXCs — CPU starvation for a Go binary printing a string.

**Part of #817** — this is P1 of five phases (P2 controller tuning, P3 Windows task consolidation, P4 OS/service trim, P5 `fleet-bench.yml`). Deliberately NOT a closing keyword: the issue stays open until the remaining phases land.

Sizing is deliberately conservative, because pve01 turned out to be a **production** node: 12 running guests including `pfsense01`, `vm-cerebrum-stg-01` (8 vCPU / 64 GB) and `by-odoo-instances` (8 vCPU / 32 GB), 43 vCPU allocated on 24 cores and 162 of 188.7 GB RAM. So the role:

- changes **no memory** (27 GB headroom is the tight resource; nothing asks for it today);
- refuses to write if the node would pass a **2.5× vCPU overcommit ceiling**, asserted against live allocation before every change;
- **never power-cycles a VM** — a QEMU delta is reported, because `win_reboot` restarts the guest OS while the QEMU process survives and keeps the old `cores`/`maxmem` (learned on win11, recorded in `docs/testbed.md`).

LXC `cores` is a cgroup ceiling, not a reservation, so raising it on idle containers costs nothing.

## Scope

- [x] ci / chore

Infrastructure only (`ansible/`); no Go code, no protocol behaviour.

## Reference controller

- [x] N/A (no protocol behaviour change)

## Type

- [x] chore — maintenance, refactor, CI

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `ansible/roles/dhs_guestsize/defaults/main.yml` | new | API vars, `dhs_guestsize_vm_apply` (default false), `dhs_guestsize_max_overcommit` (2.5), with the measurement rationale |
| `ansible/roles/dhs_guestsize/tasks/main.yml` | new | guards; deliberately no `meta: end_host` (it would skip every later role for a host with no desired size, e.g. win11) |
| `ansible/roles/dhs_guestsize/tasks/proxmox.yml` | new | node capacity + allocation read, overcommit assert, config delta, PUT only what differs |
| `ansible/roles/dhs_guestsize/meta/main.yml` | new | role metadata |
| `ansible/inventory/host_vars/dhs-{debian,ubuntu,rocky,tools}.yml` | modified | `pve_cores` |
| `ansible/playbooks/fleet-converge.yml` | modified | role runs first |

## Test results

| Suite | Result |
|-------|--------|
| `--syntax-check` | clean |
| `fleet-converge.yml --check` | delta detected, overcommit guard passes |
| `fleet-converge.yml` run 1 | `changed=1` per LXC (the sizing PUT) — 210 s |
| `fleet-converge.yml` run 2 (ADR-0007) | **`changed=0` on all five hosts**, task reports `size -> no change` — 186 s |

Live result — `nproc` per host after the run:

```text
dhs-debian -> 4        (inventory now says 2; see sequencing below)
dhs-rocky  -> 2
dhs-ubuntu -> 2
dhs-tools  -> 6
```

## Device tested

- [x] Fleet producer — all four LXCs plus win11, driven from the control node

## Sizing rationale

| Host | Before | After | Why |
| --- | ---: | ---: | --- |
| dhs-tools .104 | 2 | **6** | incoming Ansible control node (#820) |
| dhs-debian .101 | 1 | **2** | binary-test target |
| dhs-ubuntu .102 | 1 | **2** | binary-test target |
| dhs-rocky .103 | 1 | **2** | binary-test target |
| win11 .105 | 4 | 4 | unchanged; a VM resize needs an operator power cycle |

The three test LXCs are held **identical at 2 vCPU** on purpose (owner's call): they are the cross-distro binary benchmark targets (Debian 12 / Ubuntu 24.04 / Rocky 9), and a comparison is only meaningful if the guests are the same size.

### Sequencing note

`dhs-debian` is live at 4 vCPU while the inventory says 2. That is intentional: .101 is still the active control node, and converging it down before #820 moves control to .104 would deliberately slow the host running every play. The next converge after the move lands it at 2 — which also exercises the role converging **downward**.

## Known issue found, not fixed here

`fleet-converge.yml --check` fails on the Linux `dhs_host` install path: in check mode `get_url` does not download, so the later unarchive reports `Source '/tmp/dhs_linux_amd64-v0.18.0.tar.gz' does not exist`. Pre-existing, unrelated to this role (rocky passes because it already has the pinned version). Filed separately rather than widened into this PR.

## Checklist

- [x] `go test -count=1 ./...` passes (unchanged — no Go code touched)
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [x] Integration tested on VM before PR

## Approval

@yboujraf — requesting review