### PR TITLE
infra(fleet): single management NIC - drop mgmt-B (.110+), IPv4 only (#822)

### DIFF
--- a/ansible/inventory/host_vars/dhs-debian.yml
+++ b/ansible/inventory/host_vars/dhs-debian.yml
@@ -11,7 +11,6 @@ pve_name: dhs.debian12
 os_label: "Debian 12"
 nics:
   - { name: eth0, mac: "BC:24:11:80:E3:AC", ip: 10.100.0.101 }
-  - { name: eth1, mac: "BC:24:11:91:97:7C", ip: 10.100.0.111 }
 fleet_hostname: dhs-debian
 
 # Ember+ producer: our integration DM — the synthetic tree that carries the

--- a/ansible/inventory/host_vars/dhs-rocky.yml
+++ b/ansible/inventory/host_vars/dhs-rocky.yml
@@ -7,7 +7,6 @@ pve_name: dhs.rocky9
 os_label: "Rocky 9.4"
 nics:
   - { name: eth0, mac: "BC:24:11:2B:F7:C7", ip: 10.100.0.103 }
-  - { name: eth1, mac: "BC:24:11:33:74:4A", ip: 10.100.0.113 }
 fleet_hostname: dhs-rocky
 
 # Ember+ producer: the Lawo PowerCore tree (1024-target matrix), rebuilt from

--- a/ansible/inventory/host_vars/dhs-ubuntu.yml
+++ b/ansible/inventory/host_vars/dhs-ubuntu.yml
@@ -6,7 +6,6 @@ pve_name: dhs.ubuntu24
 os_label: "Ubuntu 24.04"
 nics:
   - { name: eth0, mac: "BC:24:11:28:78:25", ip: 10.100.0.102 }
-  - { name: eth1, mac: "BC:24:11:B2:50:A5", ip: 10.100.0.112 }
 fleet_hostname: dhs-ubuntu
 
 # Ember+ producer: the DHD audio console tree, rebuilt from the committed

--- a/ansible/roles/dhs_netaddr/tasks/proxmox.yml
+++ b/ansible/roles/dhs_netaddr/tasks/proxmox.yml
@@ -49,6 +49,26 @@
          | combine({'nameserver': dhs_netaddr_dns | join(' ')} if (dhs_netaddr_ct.json.data.nameserver | default('')) != (dhs_netaddr_dns | join(' ')) else {})
          | combine({'searchdomain': dhs_netaddr_searchdomain} if (dhs_netaddr_ct.json.data.searchdomain | default('')) != dhs_netaddr_searchdomain else {}) }}
 
+# The inventory is the SOURCE OF TRUTH, not an overlay: a netX that exists on
+# the CT but is not declared in `nics:` is removed. Without this, dropping a
+# NIC from host_vars silently leaves it configured and live — which is how
+# mgmt-B (.110+) kept answering mDNS for <host>.local after it was retired
+# (#822). Proxmox takes a comma-separated `delete` list.
+- name: Delta — netX on the CT that the inventory does not declare
+  ansible.builtin.set_fact:
+    dhs_netaddr_prune: >-
+      {{ dhs_netaddr_ct.json.data | dict2items | map(attribute='key')
+         | select('match', '^net[0-9]+$')
+         | reject('in', (dhs_netaddr_desired | default({})).keys() | list)
+         | list }}
+
+- name: Add the prune list to the pending changes
+  ansible.builtin.set_fact:
+    dhs_netaddr_changes: >-
+      {{ dhs_netaddr_changes | default({})
+         | combine({'delete': dhs_netaddr_prune | join(',')}) }}
+  when: dhs_netaddr_prune | length > 0
+
 - name: "Proxmox CT {{ pve_vmid }} network config -> static ({{ dhs_netaddr_changes | default({}) | dict2items | map(attribute='key') | join(',') }})"
   ansible.builtin.uri:
     url: "https://{{ proxmox_api_host }}/api2/json/nodes/{{ proxmox_node }}/lxc/{{ pve_vmid }}/config"

--- a/docs/testbed.md
+++ b/docs/testbed.md
@@ -10,26 +10,34 @@ in the same PR (epic #780).
 
 ## Fleet
 
-| Inventory name | Proxmox | Guest OS | eth0 mgmt-A (`ansible_host`) | eth1 mgmt-B | Role |
-| --- | --- | --- | --- | --- | --- |
-| `dhs-debian` | LXC 651 | Debian 12 | `10.100.0.101` | `10.100.0.111` | **Ansible control node**; dhs producer host; Docker |
-| `dhs-ubuntu` | LXC 652 | Ubuntu 24.04 | `10.100.0.102` | `10.100.0.112` | dhs producer host |
-| `dhs-rocky` | LXC 653 | Rocky 9.4 | `10.100.0.103` | `10.100.0.113` | dhs producer host |
-| `dhs-tools` | LXC 655 | Ubuntu | `10.100.0.104` | — | tooling: Docker, AMWA NMOS Testing tool (`scripts/amwa/`), tshark |
-| `win11` | VM 654 | Windows 11 Pro | `10.100.0.105` | — | Windows producer-parity row (ADR-0016); guest name `dhs-win11` |
-| `cerebrum` | VM 601 `vm-cerebrum-stg-01` | Windows 11 | `10.100.0.5` | — | external reference peer (EVS Cerebrum staging) — real-peer integration target, not part of the converge set |
+| Inventory name | Proxmox | Guest OS | mgmt (`ansible_host`) | Role |
+| --- | --- | --- | --- | --- |
+| `dhs-debian` | LXC 651 | Debian 12 | `10.100.0.101` | **Ansible control node** (moving to `dhs-tools`, #820); dhs producer host; binary-test target; Docker |
+| `dhs-ubuntu` | LXC 652 | Ubuntu 24.04 | `10.100.0.102` | dhs producer host; binary-test target |
+| `dhs-rocky` | LXC 653 | Rocky 9.4 | `10.100.0.103` | dhs producer host; binary-test target |
+| `dhs-tools` | LXC 655 | Ubuntu | `10.100.0.104` | tooling: Docker, AMWA NMOS Testing tool (`scripts/amwa/`), tshark |
+| `win11` | VM 654 | Windows 11 Pro | `10.100.0.105` | Windows producer-parity row (ADR-0016); guest name `dhs-win11` |
+| `cerebrum` | VM 601 `vm-cerebrum-stg-01` | Windows 11 | `10.100.0.5` | external reference peer (EVS Cerebrum staging) — real-peer integration target, not part of the converge set |
 
 All LXCs are unprivileged with `nesting=1`. MAC addresses per NIC live
 in `ansible/inventory/host_vars/<name>.yml` (`nics:`).
 
 Addressing is **static, from the inventory** (`dhs_netaddr` role, #786):
-one scheme across the fleet — eth0 = mgmt-A (`ansible_host`, default
-gateway `10.100.0.1`), eth1 = eth0 + 10 = mgmt-B (no default route);
-`.101–.105` / `.111–.113`, no overlaps, Cerebrum staging stays `.5`.
+one management NIC per host — `eth0` = `ansible_host`, default gateway
+`10.100.0.1`; `.101`–`.105`, no overlaps, Cerebrum staging stays `.5`.
 LXCs get it in the Proxmox CT config (`netX: …,ip=<addr>/24[,gw=…]`,
 `nameserver`, `searchdomain`, written via the API, applied by a CT
 reboot); the Windows VM gets it guest-side. No DHCP dependency (pfSense
-only needs `.100–.120` excluded from its pool as hygiene).
+only needs `.100–.120` excluded from its pool as hygiene). The inventory
+is the source of truth, not an overlay: a `netX` on the CT that `nics:`
+does not declare is REMOVED (`delete=netN`).
+
+A second management NIC (`eth1` = eth0 + 10, `.111`–`.113`, no default
+route) existed until 2026-08-23 and is **parked, not deleted** — re-adding
+it is a `host_vars` edit. It was retired because both NICs sat on the same
+L2, so `<host>.local` resolved to whichever answered first: `dhs-debian.local`
+returned `.111` instead of `.101` (#822). IPv6 is **out of scope for this
+fleet** — dual stack lives on the new Proxmox node.
 `ansible/playbooks/fleet-verify.yml` asserts live IP == inventory IP per
 NIC and fails loudly on drift. Before 2026-08-23 the fleet ran on DHCP
 leases (`.101–.108`, win11 drifted `.106`→`.107`) — never reuse those
@@ -132,19 +140,19 @@ Every fleet host gets the same dhs baseline, per OS, from the
 | directories | `/etc/dhs` (trees/packs), `/var/lib/dhs` (data), `/var/log/dhs` | `C:\dhs`, `C:\ProgramData\dhs\{data,logs}` |
 | packages | tshark/wireshark-cli, curl, jq, ca-certificates, unzip, tar | — |
 
-Time and IPv6 (#804): `win11` syncs w32time to the DMZ gateway
+Time (#804): `win11` syncs w32time to the DMZ gateway
 `10.100.0.1` + `pool.ntp.org` (set by `dhs_host`); the LXCs cannot set
 their own clock — they inherit the Proxmox node's, which was measured
 ~9 min ahead on 2026-08-23 → `ansible/playbooks/pve-time.yml` (#810,
 group `pve` = pve01 over SSH as root; chrony + `makestep`; platform twin
 `ansible-platform#168`);
-`fleet-verify.yml` prints each host's offset vs the control node. IPv6:
-the platform is dual-stack, but VLAN 100 currently offers no RA/DHCPv6,
-so fleet NICs hold link-local IPv6 only; `fleet-verify.yml` reports
-global IPv6 per host. The static IPv6 scheme (same shape as IPv4:
-`<vlan-100 prefix>::101/::111` etc., set by `dhs_netaddr` in the Proxmox
-`ip6=` field and guest-side on win11) lands as soon as the VLAN-100
-prefix is known.
+`fleet-verify.yml` prints each host's offset vs the control node.
+
+IPv6: this fleet is **IPv4-only** (owner, 2026-08-23). VLAN 100 offers no
+RA/DHCPv6 — a 20 s capture for `icmpv6.type==134` saw nothing — so NICs
+hold link-local IPv6 only and nothing autoconfigures. Dual stack belongs
+to the NEW Proxmox node, not here; do not reintroduce an IPv6 scheme for
+this fleet without the owner asking.
 
 Roll the fleet to a new release by bumping `dhs_version` and converging
 (run-twice = 0 changes). Layering: hypervisor = `infra-terraform-proxmox`


### PR DESCRIPTION
## What

The three dual-NIC LXCs go back to one management interface, and `dhs_netaddr` learns to prune interfaces the inventory does not declare.

## Why

Owner correction, 2026-08-23: dual stack exists only on the NEW Proxmox node — this fleet stays IPv4-only — and the second management NIC (.110+) is disabled for now to keep things simple.

It also fixes a real discovery defect. Both NICs sat on the same L2, so `<host>.local` resolved to whichever answered first: `dhs-debian.local` returned **10.100.0.111 (eth1)** instead of **.101 (eth0)**. Anything trusting mDNS — NMOS discovery included — could get an address it did not expect. Removing mgmt-B fixes it with no Avahi interface-scoping needed.

Closes #822

## Scope

- [x] ci / chore

Infrastructure only (`ansible/`, `docs/`); no Go code, no protocol behaviour.

## Reference controller

- [x] N/A (no protocol behaviour change)

## Type

- [x] chore — maintenance, refactor, CI

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `ansible/inventory/host_vars/dhs-{debian,ubuntu,rocky}.yml` | modified | `eth1` dropped from `nics:` |
| `ansible/roles/dhs_netaddr/tasks/proxmox.yml` | modified | prune: a `netX` on the CT that `nics:` does not declare is removed (`delete=netN`) |
| `docs/testbed.md` | modified | single-mgmt fleet table; IPv4-only stated explicitly; mgmt-B recorded as parked, not deleted |

## Why the prune matters

Without it the inventory is an *overlay*, not a source of truth: dropping a NIC from `host_vars` leaves it configured and live on the CT. That is precisely how .111 kept answering mDNS after mgmt-B was retired.

## Test results

| Check | Result |
|-------|--------|
| CT net interfaces after apply | **1 each** — 651, 652, 653, 655 |
| Control node live IPv4 | `eth0=10.100.0.101/24` only |
| `dhs-debian.local` | **10.100.0.101** (was `.111`) |
| `dhs-ubuntu/rocky/tools.local`, `dhs-win11.local` | `.102` / `.103` / `.104` / `.105` |
| Full `fleet-converge.yml` run 2 (ADR-0007) | **`changed=0` on all five hosts** |

```text
=== mDNS after ===
dhs-debian.local -> 10.100.0.101
dhs-ubuntu.local -> 10.100.0.102
dhs-rocky.local  -> 10.100.0.103
dhs-tools.local  -> 10.100.0.104
dhs-win11.local  -> 10.100.0.105

=== converge run 2 ===
dhs-debian : ok=37 changed=0    dhs-rocky : ok=37 changed=0
dhs-ubuntu : ok=37 changed=0    dhs-tools : ok=38 changed=0
win11      : ok=39 changed=0
```

## Device tested

- [x] Fleet producer — all four LXCs plus win11, driven from the control node

## Rollout note

The control node's own CT (651) reboots to apply, which ends the play — documented behaviour of `dhs_netaddr`. It came back on `.101` and the follow-up run was clean. Access never depended on a removed NIC: all Ansible reaches hosts on mgmt-A.

## IPv6

Explicitly out of scope for this fleet. VLAN 100 advertises no RA (20 s capture for `icmpv6.type==134` saw nothing), so nothing autoconfigures here; `docs/testbed.md` now says so, to stop the assumption returning.

## Checklist

- [x] `go test -count=1 ./...` passes (unchanged — no Go code touched)
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [x] Integration tested on VM before PR

## Approval

@yboujraf — requesting review