### PR TITLE
infra(fleet): move the Ansible control node to dhs-tools .104 (#820)

### DIFF
--- a/ansible/inventory/host_vars/dhs-debian.yml
+++ b/ansible/inventory/host_vars/dhs-debian.yml
@@ -1,10 +1,11 @@
 ---
 # dhs-debian — Proxmox LXC 651 "dhs.debian12", Debian 12 (bookworm).
-# Dual-NIC: eth0 10.100.0.101 (ansible_host) / eth1 10.100.0.111.
-# Roles: Ansible CONTROL NODE for the whole fleet; Docker host.
-# Never bring eth1/.111 down — it is part of the access path.
-# This host IS the control node: run local, no SSH loop-back needed.
-ansible_connection: local
+# Single management NIC: eth0 10.100.0.101 (ansible_host) — mgmt-B (.111)
+# was retired 2026-08-23 (#822).
+# Roles: dhs producer host; BINARY-TEST target, held at the same 2 vCPU as
+# .102/.103 so cross-distro binary benchmarks are comparable (#817).
+# The Ansible control node moved to dhs-tools .104 (#820) — this host is an
+# ordinary SSH target now, so NO ansible_connection: local here.
 
 pve_vmid: 651
 pve_name: dhs.debian12

--- a/ansible/inventory/host_vars/dhs-tools.yml
+++ b/ansible/inventory/host_vars/dhs-tools.yml
@@ -4,6 +4,12 @@
 # Tooling host: Docker + the AMWA NMOS Testing tool (scripts/amwa/*),
 # tshark / Wireshark dissector validation. Not a dhs producer host by
 # default (no ember_tree_src).
+#
+# ANSIBLE CONTROL NODE since 2026-08-23 (#820), moved here from dhs-debian
+# so .101 can stay a binary-test target sized like .102/.103. Runs local —
+# no SSH loop-back to itself.
+ansible_connection: local
+
 pve_vmid: 655
 pve_name: dhs.tools
 pve_cores: 6          # P1 sizing (#817): ANSIBLE CONTROL NODE - forking, templating, module assembly and SSH/TLS crypto all run here

--- a/ansible/inventory/hosts.ini
+++ b/ansible/inventory/hosts.ini
@@ -9,7 +9,7 @@
 #
 # Linux LXC are reached over SSH as root; the Windows VM over SSH as the
 # local admin-group user `by-rune` (key auth, no password file — #782).
-# Control node = dhs-debian, see docs/testbed.md "Control node".
+# Control node = dhs-tools (.104), see docs/testbed.md "Control node".
 
 [linux]
 dhs-debian  ansible_host=10.100.0.101
@@ -21,8 +21,11 @@ dhs-tools   ansible_host=10.100.0.104
 win11       ansible_host=10.100.0.105
 
 # Ansible control node (runs every play; never PowerShell drivers).
+# Moved from dhs-debian to dhs-tools 2026-08-23 (#820): .101 is a
+# binary-test target and must stay the same size as .102/.103, so the
+# controller cannot live there.
 [control]
-dhs-debian
+dhs-tools
 
 # Proxmox node hosting the fleet — node-level plays only (pve-time.yml, #810).
 [pve]

--- a/ansible/playbooks/control-node-migrate.yml
+++ b/ansible/playbooks/control-node-migrate.yml
@@ -1,0 +1,101 @@
+---
+# One-time control-node migration (#820): copy the credentials the OUTGOING
+# control node holds to the INCOMING one, so the new controller can reach the
+# fleet, the Proxmox API and win11 without re-bootstrapping anything.
+#
+# RUN IT FROM THE CURRENT CONTROL NODE, BEFORE the inventory flips:
+#
+#   cd ~/acp/ansible
+#   ansible-playbook playbooks/control-node.yml -e cn_target=dhs-tools
+#   ansible-playbook playbooks/control-node-migrate.yml -e cnm_target=dhs-tools
+#
+# Then commit the inventory flip ([control] + ansible_connection: local) and
+# run everything from the new node.
+#
+# WHY COPY RATHER THAN RE-CREATE:
+#   - The SSH key is `root@dhs`, already present in every fleet host's
+#     authorized_keys (dhs_access, #782). A fresh key would need distributing
+#     to every host first, and win11's admin key file has strict ACLs.
+#   - The PSRP client certificate is already trusted by win11 (Root +
+#     TrustedPeople) and mapped to the local account. Re-running
+#     win-winrm-bootstrap.yml would prompt for the Windows password again and
+#     create a SECOND mapping for no gain (#812).
+#
+# Idempotent: second run = 0 changes. Secrets never print (no_log).
+- name: Migrate control-node credentials to the incoming control node
+  hosts: "{{ cnm_target | default('dhs-tools') }}"
+  gather_facts: false
+  vars:
+    cnm_source: "{{ groups['control'][0] }}"
+    cnm_items:
+      - { src: /root/.ssh/id_ed25519,          dest: /root/.ssh/id_ed25519,          mode: "0600" }
+      - { src: /root/.ssh/id_ed25519.pub,      dest: /root/.ssh/id_ed25519.pub,      mode: "0644" }
+      - { src: /root/.secrets/proxmox.yml,     dest: /root/.secrets/proxmox.yml,     mode: "0600" }
+      - { src: /etc/dhs/psrp/dhs-psrp.pem,     dest: /etc/dhs/psrp/dhs-psrp.pem,     mode: "0644" }
+      - { src: /etc/dhs/psrp/dhs-psrp.key,     dest: /etc/dhs/psrp/dhs-psrp.key,     mode: "0600" }
+  tasks:
+    - name: Directories with the same modes as on {{ cnm_source }}
+      ansible.builtin.file:
+        path: "{{ item.path }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "{{ item.mode }}"
+      loop:
+        - { path: /root/.ssh, mode: "0700" }
+        - { path: /root/.secrets, mode: "0700" }
+        - { path: /etc/dhs/psrp, mode: "0700" }
+      loop_control:
+        label: "{{ item.path }}"
+
+    - name: Read each credential from {{ cnm_source }}
+      ansible.builtin.slurp:
+        src: "{{ item.src }}"
+      delegate_to: "{{ cnm_source }}"
+      loop: "{{ cnm_items }}"
+      loop_control:
+        label: "{{ item.src }}"
+      register: cnm_read
+      no_log: true
+
+    - name: Place them on {{ inventory_hostname }}
+      ansible.builtin.copy:
+        content: "{{ item.content | b64decode }}"
+        dest: "{{ item.item.dest }}"
+        owner: root
+        group: root
+        mode: "{{ item.item.mode }}"
+      loop: "{{ cnm_read.results }}"
+      loop_control:
+        label: "{{ item.item.dest }}"
+      no_log: true
+
+    # Proves the copy actually works before the inventory flips — a migration
+    # that only *looks* done is worse than one that failed loudly.
+    - name: Verify — the new node can reach every fleet host over SSH
+      ansible.builtin.command:
+        argv:
+          - ssh
+          - -i
+          - /root/.ssh/id_ed25519
+          - -o
+          - BatchMode=yes
+          - -o
+          - StrictHostKeyChecking=no
+          - "root@{{ hostvars[item].ansible_host }}"
+          - hostname
+      loop: "{{ groups['linux'] | reject('equalto', inventory_hostname) | list }}"
+      loop_control:
+        label: "{{ item }}"
+      register: cnm_ssh
+      changed_when: false
+      failed_when: cnm_ssh.rc != 0
+
+    - name: Result
+      ansible.builtin.debug:
+        msg: >-
+          {{ inventory_hostname }} holds the fleet SSH key, the Proxmox secrets
+          and the PSRP client certificate, and reached
+          {{ cnm_ssh.results | map(attribute='stdout') | join(', ') }}.
+          Next: flip [control] and ansible_connection: local in the inventory,
+          then run fleet-converge.yml from here.

--- a/ansible/playbooks/control-node.yml
+++ b/ansible/playbooks/control-node.yml
@@ -1,20 +1,40 @@
 ---
-# Control-node prerequisites (dhs-debian .103), self-applied. Run once after a
-# fresh clone and whenever requirements change:
+# Control-node prerequisites. Normally self-applied on the current control
+# node; also used to PREPARE a new one before the inventory flips to it:
 #
 #   cd ~/acp/ansible && ansible-playbook playbooks/control-node.yml
+#   ansible-playbook playbooks/control-node.yml -e cn_target=dhs-tools   # prepare .104 (#820)
+#
+# `cn_target` exists because the flip cannot be atomic: while .101 is still
+# the controller, the incoming node must be reached over SSH as an ordinary
+# host. Only after this play AND control-node-migrate.yml does the inventory
+# move `[control]` and `ansible_connection: local` to the new node.
 #
 # - git-lfs + `git lfs pull` for the LFS-tracked assets the fleet roles ship
 #   (Bonjour installer, PDFs) — without it a clone holds 132-byte pointers.
 # - the Ansible collections from requirements.yml.
 - name: Control node prerequisites
-  hosts: control
+  hosts: "{{ cn_target | default('control') }}"
   gather_facts: true
+  vars:
+    cn_repo_dir: /root/acp
+    cn_repo_url: https://github.com/by-openclaw/go-acp.git
   tasks:
     - name: git + git-lfs present
       ansible.builtin.package:
         name: [git, git-lfs]
         state: present
+
+    # The repo is PUBLIC, so no credentials are needed. `playbook_dir` is a
+    # path on the CONTROLLER, so every chdir below uses cn_repo_dir instead —
+    # otherwise preparing a remote node would run git in the wrong tree.
+    - name: Repository cloned on the target
+      ansible.builtin.git:
+        repo: "{{ cn_repo_url }}"
+        dest: "{{ cn_repo_dir }}"
+        version: main
+        update: false          # never move someone's working branch
+      register: cn_clone
 
     - name: git-lfs filters installed for root
       ansible.builtin.command: git lfs install --skip-repo
@@ -24,13 +44,13 @@
     - name: LFS objects for the amwa assets pulled
       ansible.builtin.command:
         cmd: git lfs pull --include "internal/amwa/assets/*"
-        chdir: "{{ playbook_dir }}/../.."
+        chdir: "{{ cn_repo_dir }}"
       register: cn_lfs_pull
       changed_when: "'Downloading' in cn_lfs_pull.stdout or (cn_lfs_pull.stderr is search('Downloading'))"
 
     - name: Bonjour installer is a real binary (> 1 MB)
       ansible.builtin.stat:
-        path: "{{ playbook_dir }}/../../internal/amwa/assets/BonjourPSSetup.exe"
+        path: "{{ cn_repo_dir }}/internal/amwa/assets/BonjourPSSetup.exe"
       register: cn_bonjour
       failed_when: not cn_bonjour.stat.exists or cn_bonjour.stat.size < 1000000
 
@@ -74,6 +94,6 @@
     - name: Ansible collections from requirements.yml
       ansible.builtin.command:
         cmd: ansible-galaxy collection install -r requirements.yml --upgrade
-        chdir: "{{ playbook_dir }}/.."
+        chdir: "{{ cn_repo_dir }}/ansible"
       register: cn_galaxy
       changed_when: "'Installing' in cn_galaxy.stdout"

--- a/ansible/playbooks/fleet-converge.yml
+++ b/ansible/playbooks/fleet-converge.yml
@@ -1,6 +1,6 @@
 ---
 # Converge the test fleet (epic #780). Run from the control node
-# (dhs-debian .103, repo clone ~/acp):
+# (dhs-tools .104 since #820, repo clone ~/acp):
 #
 #   cd ~/acp/ansible
 #   ansible-playbook playbooks/fleet-converge.yml          # apply

--- a/docs/testbed.md
+++ b/docs/testbed.md
@@ -12,10 +12,10 @@ in the same PR (epic #780).
 
 | Inventory name | Proxmox | Guest OS | mgmt (`ansible_host`) | Role |
 | --- | --- | --- | --- | --- |
-| `dhs-debian` | LXC 651 | Debian 12 | `10.100.0.101` | **Ansible control node** (moving to `dhs-tools`, #820); dhs producer host; binary-test target; Docker |
+| `dhs-debian` | LXC 651 | Debian 12 | `10.100.0.101` | dhs producer host; binary-test target (2 vCPU, same as .102/.103); Docker |
 | `dhs-ubuntu` | LXC 652 | Ubuntu 24.04 | `10.100.0.102` | dhs producer host; binary-test target |
 | `dhs-rocky` | LXC 653 | Rocky 9.4 | `10.100.0.103` | dhs producer host; binary-test target |
-| `dhs-tools` | LXC 655 | Ubuntu | `10.100.0.104` | tooling: Docker, AMWA NMOS Testing tool (`scripts/amwa/`), tshark |
+| `dhs-tools` | LXC 655 | Ubuntu | `10.100.0.104` | **Ansible control node** (#820, 6 vCPU); tooling: Docker, AMWA NMOS Testing tool (`scripts/amwa/`), tshark |
 | `win11` | VM 654 | Windows 11 Pro | `10.100.0.105` | Windows producer-parity row (ADR-0016); guest name `dhs-win11` |
 | `cerebrum` | VM 601 `vm-cerebrum-stg-01` | Windows 11 | `10.100.0.5` | external reference peer (EVS Cerebrum staging) — real-peer integration target, not part of the converge set |
 
@@ -76,14 +76,33 @@ Host firewalls are managed by the `dhs_firewall` role (#785): each host opens ex
 
 ## Control node
 
-`dhs-debian` (`.101`) runs every Ansible play — Linux hosts over SSH as
-`root`, the Windows VM over SSH as `by-rune` (key auth; WinRM/NTLM +
-password file is retired). It holds a clone of this (public) repo at
-`~/acp` and its own ed25519 key (`root@dhs`), which is one of the three
-fleet actor keys below. After a fresh clone run
-`ansible-playbook playbooks/control-node.yml` (git-lfs + LFS pull of the
-shipped assets, Ansible collections). Never drive the fleet from a
-Windows workstation (PowerShell) — see ADR-0025 step 5.
+`dhs-tools` (`.104`) runs every Ansible play — Linux hosts over SSH as
+`root`, the Windows VM over PSRP with certificate auth (#812). It holds a
+clone of this (public) repo at `~/acp`, ansible-core 2.17 via pipx, and the
+fleet key `root@dhs`, which is one of the actor keys below.
+
+It took over from `dhs-debian` (`.101`) on 2026-08-23 (#820), so that .101
+can stay a binary-test target sized identically to .102/.103. The move is
+two steps because it cannot be atomic — while the old node is still the
+controller, the new one must be an ordinary SSH target, and the moment
+`ansible_connection: local` moves, tasks for that host run locally:
+
+```bash
+ansible-playbook playbooks/control-node.yml -e cn_target=dhs-tools     # prepare
+ansible-playbook playbooks/control-node-migrate.yml -e cnm_target=dhs-tools
+```
+
+`control-node-migrate.yml` copies the fleet SSH key, the Proxmox secrets
+and the PSRP client certificate, then PROVES the new node can SSH to every
+fleet host before the inventory flips. Copying beats re-creating: the key is
+already in every host's `authorized_keys`, and win11 already trusts and maps
+that certificate — re-bootstrapping would prompt for the Windows password
+again and add a second mapping. Only then do `[control]` and
+`ansible_connection: local` move in the inventory.
+
+After a fresh clone run `ansible-playbook playbooks/control-node.yml`
+(git-lfs + LFS pull of the shipped assets, Ansible collections). Never drive
+the fleet from a Windows workstation (PowerShell) — see ADR-0025 step 5.
 
 Monitoring a run (#790): every play logs to `/tmp/ansible-fleet.log`
 on the control node (`tail -f` it) and prints per-task timings


### PR DESCRIPTION
## What

The Ansible control node moves from `dhs-debian` (.101) to `dhs-tools` (.104).

## Why

Owner's call, 2026-08-23: .101 must stay a binary-test target sized identically to .102 and .103, because a cross-distro benchmark is only meaningful if the guests match. The controller needs more cores for its own work and must not perturb a host under test.

Closes #820

## Scope

- [x] ci / chore

## Reference controller

- [x] N/A (no protocol behaviour change)

## Type

- [x] chore — maintenance, refactor, CI

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `ansible/playbooks/control-node.yml` | modified | optional `cn_target` to prepare a node that is not yet the controller; clones the repo; every `chdir` uses `cn_repo_dir` instead of `playbook_dir` |
| `ansible/playbooks/control-node-migrate.yml` | new | one-time credential migration, with a pre-flip reachability proof |
| `ansible/inventory/hosts.ini` | modified | `[control]` = dhs-tools |
| `ansible/inventory/host_vars/dhs-tools.yml` | modified | `ansible_connection: local` |
| `ansible/inventory/host_vars/dhs-debian.yml` | modified | ordinary SSH target again |
| `ansible/playbooks/fleet-converge.yml` | modified | stale header (`dhs-debian .103`) |
| `docs/testbed.md` | modified | control-node section + fleet table roles |

## Two design points worth keeping

**The flip cannot be atomic.** While .101 is still the controller, .104 must be an ordinary SSH target — but the moment `ansible_connection: local` moves, tasks for that host run locally instead of over SSH. Hence `cn_target` on the prepare play and a separate one-time migrate play, rather than one clever play.

**`playbook_dir` is a path on the CONTROLLER.** The old `control-node.yml` used it for `chdir`/`stat`, which would have run git in the wrong tree when preparing a remote node. Now everything uses `cn_repo_dir`.

**Copy credentials, don't re-create them.** The key `root@dhs` is already in every fleet host's `authorized_keys` (#782), and win11 already trusts and maps the PSRP client certificate (#812). Re-bootstrapping would prompt for the Windows password again and add a second mapping for no gain.

## Test results

| Check | Result |
|-------|--------|
| `.104` prepared (repo, pipx ansible-core 2.17, pypsrp, collections) | `ok=10 changed=6` |
| `control-node-migrate.yml` run 1 / run 2 | `changed=2` / **`changed=0`** |
| Pre-flip proof: .104 SSH to every fleet host with the copied key | reached dhs-debian, dhs-ubuntu, dhs-rocky |
| `fleet-converge.yml` from .104, run 1 | `changed=1` (only .101 -> 2 vCPU) — 215 s |
| `fleet-converge.yml` from .104, run 2 (ADR-0007) | **`changed=0` on all five hosts** — 202 s |
| `fleet-verify.yml` from .104 | **green on all five**, win11 `ok=11` over PSRP with the copied certificate |
| `fleet-update.yml --check` | skips **dhs-tools** from the reboot path, no longer dhs-debian |
| Live cores after | `dhs-debian 2, dhs-ubuntu 2, dhs-rocky 2, dhs-tools 6` |

## Honest performance finding — the premise did NOT hold

#817 argued a 1-vCPU control node was a fleet-wide tax. Measured, it is not, at least for converge:

| Controller | Cores | Run 1 | Run 2 |
| --- | ---: | ---: | ---: |
| dhs-debian .101 | 4 | 210 s | 186 s |
| dhs-tools .104 | 6 | 215 s | 202 s |

More controller CPU produced **no improvement** — if anything a little slower. The converge is dominated by per-task module round-trip, not controller compute. That was measurable before this PR too: the win11 pass floor is a flat 4.0–5.7 s per task regardless of what else changes.

Consequences for #817, recorded on the issue:

- **P2 (raise `forks`, `strategy: free`) is unlikely to pay** and should be measured before any code is written; the four Linux hosts already run inside the default `forks: 5`.
- **P3 (task-count consolidation, 38 -> ~12)** is the only lever with evidence behind it — the same one that took the firewall role from 111 s to 21 s.

The move still stands on its own merits: it frees .101 to be an identically-sized benchmark target, which was the actual requirement. It just should not be sold as a speed-up.

## Checklist

- [x] `go test -count=1 ./...` passes (unchanged — no Go code touched)
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [x] Integration tested on VM before PR

## Approval

@yboujraf — requesting review