### PR TITLE
feat(amwa/sdp): stdlib-only SDP parser for ST 2110 transport files (#827)

### DIFF
--- a/internal/amwa/codec/sdp/edge_test.go
+++ b/internal/amwa/codec/sdp/edge_test.go
@@ -1,0 +1,229 @@
+package sdp_test
+
+import (
+	"strings"
+	"testing"
+
+	"dhs/internal/amwa/codec/sdp"
+)
+
+const head = "v=0\no=- 1 1 IN IP4 192.0.2.1\ns=x\nt=0 0\n"
+
+func parseOK(t *testing.T, in string) (*sdp.Session, []sdp.Deviation) {
+	t.Helper()
+	s, devs, err := sdp.Parse([]byte(in))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return s, devs
+}
+
+func TestDeviationString(t *testing.T) {
+	d := sdp.Deviation{Line: 7, Text: "garbage", Msg: "not a <type>=<value> line"}
+	got := d.String()
+	for _, want := range []string{"line 7", "not a <type>=<value> line", `"garbage"`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("String() = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestSessionLevelConnectionUsedWhenMediaHasNone(t *testing.T) {
+	s, devs := parseOK(t, head+"c=IN IP4 233.252.0.9/32\nm=video 5004 RTP/AVP 96\n")
+	if len(devs) != 0 {
+		t.Fatalf("deviations: %v", devs)
+	}
+	if s.Connection == nil || s.Connection.Address != "233.252.0.9" {
+		t.Fatalf("session connection = %+v", s.Connection)
+	}
+	if s.Media[0].Connection != nil {
+		t.Errorf("media connection should be nil, got %+v", s.Media[0].Connection)
+	}
+	// Legs must fall back to the session-level c= rather than reporting no dest.
+	legs := s.Legs()
+	if len(legs) != 1 || legs[0].Dest != "233.252.0.9" {
+		t.Errorf("legs = %+v, want dest 233.252.0.9 from the session-level c=", legs)
+	}
+}
+
+func TestPropertyAttributeHasNoValue(t *testing.T) {
+	s, _ := parseOK(t, head+"m=video 5004 RTP/AVP 96\na=recvonly\n")
+	var found bool
+	for _, a := range s.Media[0].Attributes {
+		if a.Name == "recvonly" {
+			found = true
+			if a.Value != "" {
+				t.Errorf("property attribute got value %q, want empty", a.Value)
+			}
+		}
+	}
+	if !found {
+		t.Error("a=recvonly was dropped")
+	}
+}
+
+func TestOtherLineTypesPreserved(t *testing.T) {
+	s, devs := parseOK(t, head+"u=http://example.invalid\nb=AS:1000\nm=video 5004 RTP/AVP 96\nb=TIAS:900000\n")
+	if len(devs) != 0 {
+		t.Fatalf("b=/u= must not be deviations, got %v", devs)
+	}
+	var sessionB, mediaB bool
+	for _, a := range s.Attributes {
+		if a.Name == "b" && strings.Contains(a.Raw, "AS:1000") {
+			sessionB = true
+		}
+	}
+	for _, a := range s.Media[0].Attributes {
+		if a.Name == "b" && strings.Contains(a.Raw, "TIAS:900000") {
+			mediaB = true
+		}
+	}
+	if !sessionB || !mediaB {
+		t.Errorf("b= lines lost: session=%v media=%v", sessionB, mediaB)
+	}
+}
+
+func TestTSRefClkNonPTPFormKept(t *testing.T) {
+	s, devs := parseOK(t, head+"m=video 5004 RTP/AVP 96\na=ts-refclk:localmac=00-11-22-33-44-55\n")
+	if len(devs) != 0 {
+		t.Fatalf("a non-PTP ts-refclk is legal, got deviations: %v", devs)
+	}
+	tc := s.Media[0].TSRefClk
+	if tc == nil {
+		t.Fatal("ts-refclk missing")
+	}
+	if tc.GMID != "" || tc.Version != "" {
+		t.Errorf("non-PTP form should leave PTP fields empty, got %+v", tc)
+	}
+	if tc.Domain != -1 {
+		t.Errorf("domain = %d, want -1 (absent)", tc.Domain)
+	}
+	if !strings.Contains(tc.Raw, "localmac") {
+		t.Errorf("raw not preserved: %q", tc.Raw)
+	}
+}
+
+func TestPTPWithoutDomain(t *testing.T) {
+	s, devs := parseOK(t, head+"m=video 5004 RTP/AVP 96\na=ts-refclk:ptp=IEEE1588-2008:00-11-22-FF-FE-33-44-55\n")
+	if len(devs) != 0 {
+		t.Fatalf("deviations: %v", devs)
+	}
+	tc := s.Media[0].TSRefClk
+	if tc.GMID != "00-11-22-FF-FE-33-44-55" {
+		t.Errorf("gmid = %q", tc.GMID)
+	}
+	if tc.Domain != -1 {
+		t.Errorf("domain = %d, want -1 when the device omits it", tc.Domain)
+	}
+}
+
+func TestFMTPBareFlagAndMissingKey(t *testing.T) {
+	s, _ := parseOK(t, head+"m=video 5004 RTP/AVP 96\na=fmtp:96 interlace; width=1920;\n")
+	f := s.Media[0].FMTP["96"]
+	if v, ok := f.Get("interlace"); !ok || v != "" {
+		t.Errorf("bare flag: value=%q present=%v, want empty/true", v, ok)
+	}
+	if v, ok := f.Get("WIDTH"); !ok || v != "1920" {
+		t.Errorf("Get must be case-insensitive: %q %v", v, ok)
+	}
+	if _, ok := f.Get("nope"); ok {
+		t.Error("Get returned true for an absent key")
+	}
+	// a trailing ';' must not produce an empty parameter
+	for _, p := range f.Params {
+		if p.Key == "" {
+			t.Errorf("empty parameter parsed from trailing semicolon: %+v", f.Params)
+		}
+	}
+}
+
+func TestMalformedShortLines(t *testing.T) {
+	tests := []struct {
+		name, in, want string
+	}{
+		{"media too short", head + "m=video\n", "m= expects <media> <port> <proto> [fmt...]"},
+		{"group without semantics", head + "a=group:\nm=video 1 RTP/AVP 96\n", "group has no semantics"},
+		{"fmtp without params", head + "m=video 1 RTP/AVP 96\na=fmtp:96\n", "fmtp expects <pt> <params>"},
+		{"rtpmap without encoding", head + "m=video 1 RTP/AVP 96\na=rtpmap:96\n", "rtpmap expects <pt> <encoding>/<clock>[/<channels>]"},
+		{"source-filter too short", head + "m=video 1 RTP/AVP 96\na=source-filter: incl IN IP4\n", "source-filter expects <mode> <nettype> <addrtype> <dest> <src>..."},
+		{"ptp without gmid", head + "m=video 1 RTP/AVP 96\na=ts-refclk:ptp=IEEE1588-2008\n", "ptp expects <version>:<gmid>[:<domain>]"},
+		{"timing wrong arity", head + "t=0\n", "t= expects <start> <stop>"},
+		{"version not a number", "v=x\no=- 1 1 IN IP4 192.0.2.1\ns=x\nt=0 0\n", "v= is not a number"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, devs := parseOK(t, tc.in)
+			for _, d := range devs {
+				if d.Msg == tc.want {
+					return
+				}
+			}
+			t.Errorf("deviations = %v, want one with %q", devs, tc.want)
+		})
+	}
+}
+
+func TestMediaPortCount(t *testing.T) {
+	s, devs := parseOK(t, head+"m=video 5004/2 RTP/AVP 96\n")
+	if len(devs) != 0 {
+		t.Fatalf("deviations: %v", devs)
+	}
+	if s.Media[0].Port != 5004 || s.Media[0].PortCount != 2 {
+		t.Errorf("port/count = %d/%d, want 5004/2", s.Media[0].Port, s.Media[0].PortCount)
+	}
+}
+
+func TestLegsIgnoreNonDupGroups(t *testing.T) {
+	// FID grouping is not redundancy; Legs must not treat it as a DUP pair.
+	in := head + "a=group:FID 1 2\nm=video 1 RTP/AVP 96\na=mid:1\nm=video 2 RTP/AVP 96\na=mid:2\n"
+	s, _ := parseOK(t, in)
+	legs := s.Legs()
+	if len(legs) != 2 {
+		t.Fatalf("legs = %d, want 2 (fallback: one per media section)", len(legs))
+	}
+	if legs[0].MediaIdx != 0 || legs[1].MediaIdx != 1 {
+		t.Errorf("fallback legs should follow document order, got %+v", legs)
+	}
+}
+
+func TestFormatsCaptured(t *testing.T) {
+	s, _ := parseOK(t, head+"m=video 5004 RTP/AVP 96 97 98\n")
+	got := s.Media[0].Formats
+	if len(got) != 3 || got[0] != "96" || got[2] != "98" {
+		t.Errorf("formats = %v, want [96 97 98]", got)
+	}
+}
+
+func TestSessionInfoLine(t *testing.T) {
+	s, devs := parseOK(t, "v=0\no=- 1 1 IN IP4 192.0.2.1\ns=x\ni=a description\nt=0 0\n")
+	if len(devs) != 0 {
+		t.Fatalf("deviations: %v", devs)
+	}
+	if s.Info != "a description" {
+		t.Errorf("info = %q, want %q", s.Info, "a description")
+	}
+}
+
+func TestLegsSkipDanglingGroupTag(t *testing.T) {
+	// The group names two tags but only one m= carries a=mid. The dangling tag
+	// is reported as a Deviation at parse time; Legs returns the leg that does
+	// exist rather than an empty set or a phantom entry.
+	in := head + "a=group:DUP primary secondary\nm=video 1 RTP/AVP 96\nc=IN IP4 233.252.0.1/32\na=mid:primary\n"
+	s, devs := parseOK(t, in)
+	var reported bool
+	for _, d := range devs {
+		if strings.Contains(d.Msg, "has no matching a=mid") {
+			reported = true
+		}
+	}
+	if !reported {
+		t.Errorf("dangling group tag was not reported: %v", devs)
+	}
+	legs := s.Legs()
+	if len(legs) != 1 {
+		t.Fatalf("legs = %d, want 1", len(legs))
+	}
+	if legs[0].Mid != "primary" || legs[0].Dest != "233.252.0.1" {
+		t.Errorf("leg = %+v, want primary / 233.252.0.1", legs[0])
+	}
+}

--- a/internal/amwa/codec/sdp/parse.go
+++ b/internal/amwa/codec/sdp/parse.go
@@ -1,0 +1,344 @@
+package sdp
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Deviation is a recoverable defect in the document: the parser keeps going
+// and reports it, rather than silently normalising the device's output. Same
+// posture as the connector compliance model — absorb and surface, never patch.
+type Deviation struct {
+	Line int    // 1-based line number in the source
+	Text string // the offending line, trimmed
+	Msg  string
+}
+
+func (d Deviation) String() string { return fmt.Sprintf("line %d: %s (%q)", d.Line, d.Msg, d.Text) }
+
+// ErrEmpty is returned when there is nothing to parse.
+var ErrEmpty = errors.New("sdp: empty document")
+
+// ErrNoVersion is returned when the document does not start with `v=`.
+var ErrNoVersion = errors.New("sdp: missing v= line")
+
+// Parse decodes an SDP document.
+//
+// It returns the session, any recoverable deviations, and an error only when
+// the document is not an SDP document at all. A caller that wants strictness
+// treats a non-empty deviation slice as failure.
+func Parse(b []byte) (*Session, []Deviation, error) {
+	text := strings.ReplaceAll(string(b), "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+	if strings.TrimSpace(text) == "" {
+		return nil, nil, ErrEmpty
+	}
+
+	var (
+		s    Session
+		devs []Deviation
+		cur  *Media // nil until the first m=
+	)
+
+	for i, raw := range strings.Split(text, "\n") {
+		lineNo := i + 1
+		line := strings.TrimRight(raw, " \t")
+		if line == "" {
+			continue
+		}
+		if len(line) < 2 || line[1] != '=' {
+			devs = append(devs, Deviation{lineNo, strings.TrimSpace(line), "not a <type>=<value> line"})
+			continue
+		}
+		typ, val := line[0], line[2:]
+
+		switch typ {
+		case 'v':
+			n, err := strconv.Atoi(strings.TrimSpace(val))
+			if err != nil {
+				devs = append(devs, Deviation{lineNo, line, "v= is not a number"})
+				continue
+			}
+			s.Version = n
+		case 'o':
+			o, d := parseOrigin(val, lineNo)
+			if d != nil {
+				devs = append(devs, *d)
+			}
+			s.Origin = o
+		case 's':
+			s.Name = val
+		case 'i':
+			s.Info = val
+		case 't':
+			f := strings.Fields(val)
+			if len(f) != 2 {
+				devs = append(devs, Deviation{lineNo, line, "t= expects <start> <stop>"})
+				continue
+			}
+			s.Timing = append(s.Timing, Timing{Start: f[0], Stop: f[1]})
+		case 'c':
+			c, d := parseConnection(val, lineNo)
+			if d != nil {
+				devs = append(devs, *d)
+			}
+			if cur != nil {
+				cur.Connection = c
+			} else {
+				s.Connection = c
+			}
+		case 'm':
+			m, d := parseMedia(val, lineNo)
+			if d != nil {
+				devs = append(devs, *d)
+			}
+			s.Media = append(s.Media, m)
+			cur = &s.Media[len(s.Media)-1]
+		case 'a':
+			attr := splitAttribute(val)
+			if cur != nil {
+				cur.Attributes = append(cur.Attributes, attr)
+				if d := applyMediaAttribute(cur, attr, lineNo); d != nil {
+					devs = append(devs, *d)
+				}
+				continue
+			}
+			s.Attributes = append(s.Attributes, attr)
+			if strings.EqualFold(attr.Name, "group") {
+				g, d := parseGroup(attr.Value, lineNo)
+				if d != nil {
+					devs = append(devs, *d)
+				}
+				s.Groups = append(s.Groups, g)
+			}
+		default:
+			// b=, u=, e=, p=, r=, z=, k= and anything else: not modelled here,
+			// but kept so nothing is lost.
+			if cur != nil {
+				cur.Attributes = append(cur.Attributes, Attribute{Name: string(typ), Raw: line})
+			} else {
+				s.Attributes = append(s.Attributes, Attribute{Name: string(typ), Raw: line})
+			}
+		}
+	}
+
+	if s.Version == 0 && !strings.HasPrefix(strings.TrimSpace(text), "v=") {
+		return nil, devs, ErrNoVersion
+	}
+
+	// A DUP tag that names no m= section is a real defect: a controller would
+	// look for a leg that is not described.
+	for _, g := range s.Groups {
+		for _, tag := range g.Tags {
+			found := false
+			for _, m := range s.Media {
+				if m.Mid == tag {
+					found = true
+					break
+				}
+			}
+			if !found {
+				devs = append(devs, Deviation{0, "a=group:" + g.Semantics, "group tag " + tag + " has no matching a=mid"})
+			}
+		}
+	}
+
+	return &s, devs, nil
+}
+
+func parseOrigin(val string, lineNo int) (Origin, *Deviation) {
+	f := strings.Fields(val)
+	if len(f) != 6 {
+		return Origin{}, &Deviation{lineNo, "o=" + val, "o= expects 6 fields"}
+	}
+	return Origin{f[0], f[1], f[2], f[3], f[4], f[5]}, nil
+}
+
+func parseConnection(val string, lineNo int) (*Connection, *Deviation) {
+	f := strings.Fields(val)
+	if len(f) != 3 {
+		return nil, &Deviation{lineNo, "c=" + val, "c= expects <nettype> <addrtype> <address>"}
+	}
+	c := Connection{NetType: f[0], AddrType: f[1], Raw: val}
+	parts := strings.Split(f[2], "/")
+	c.Address = parts[0]
+	if len(parts) > 1 {
+		if n, err := strconv.Atoi(parts[1]); err == nil {
+			c.TTL = n
+		}
+	}
+	if len(parts) > 2 {
+		if n, err := strconv.Atoi(parts[2]); err == nil {
+			c.Count = n
+		}
+	}
+	return &c, nil
+}
+
+func parseMedia(val string, lineNo int) (Media, *Deviation) {
+	f := strings.Fields(val)
+	if len(f) < 3 {
+		return Media{}, &Deviation{lineNo, "m=" + val, "m= expects <media> <port> <proto> [fmt...]"}
+	}
+	m := Media{
+		Type:    f[0],
+		Proto:   f[2],
+		Formats: append([]string(nil), f[3:]...),
+		RTPMap:  map[string]RTPMap{},
+		FMTP:    map[string]FMTP{},
+	}
+	port := f[1]
+	if i := strings.IndexByte(port, '/'); i >= 0 {
+		if n, err := strconv.Atoi(port[i+1:]); err == nil {
+			m.PortCount = n
+		}
+		port = port[:i]
+	}
+	if n, err := strconv.Atoi(port); err == nil {
+		m.Port = n
+	} else {
+		return m, &Deviation{lineNo, "m=" + val, "m= port is not a number"}
+	}
+	return m, nil
+}
+
+func splitAttribute(val string) Attribute {
+	a := Attribute{Raw: val}
+	if i := strings.IndexByte(val, ':'); i >= 0 {
+		a.Name = val[:i]
+		a.Value = val[i+1:]
+	} else {
+		a.Name = val
+	}
+	return a
+}
+
+func parseGroup(val string, lineNo int) (Group, *Deviation) {
+	f := strings.Fields(val)
+	if len(f) == 0 {
+		return Group{}, &Deviation{lineNo, "a=group:" + val, "group has no semantics"}
+	}
+	return Group{Semantics: f[0], Tags: append([]string(nil), f[1:]...)}, nil
+}
+
+func applyMediaAttribute(m *Media, a Attribute, lineNo int) *Deviation {
+	switch strings.ToLower(a.Name) {
+	case "mid":
+		m.Mid = strings.TrimSpace(a.Value)
+	case "ptime":
+		m.PTime = strings.TrimSpace(a.Value)
+	case "mediaclk":
+		m.MediaClk = strings.TrimSpace(a.Value)
+	case "rtpmap":
+		r, d := parseRTPMap(a.Value, lineNo)
+		if d != nil {
+			return d
+		}
+		m.RTPMap[r.PayloadType] = r
+	case "fmtp":
+		f, d := parseFMTP(a.Value, lineNo)
+		if d != nil {
+			return d
+		}
+		m.FMTP[f.PayloadType] = f
+	case "ts-refclk":
+		t, d := parseTSRefClk(a.Value, lineNo)
+		if d != nil {
+			return d
+		}
+		m.TSRefClk = t
+	case "source-filter":
+		sf, d := parseSourceFilter(a.Value, lineNo)
+		if d != nil {
+			return d
+		}
+		m.SourceFilt = sf
+	}
+	return nil
+}
+
+func parseRTPMap(val string, lineNo int) (RTPMap, *Deviation) {
+	f := strings.Fields(val)
+	if len(f) < 2 {
+		return RTPMap{}, &Deviation{lineNo, "a=rtpmap:" + val, "rtpmap expects <pt> <encoding>/<clock>[/<channels>]"}
+	}
+	r := RTPMap{PayloadType: f[0]}
+	parts := strings.Split(f[1], "/")
+	r.Encoding = parts[0]
+	if len(parts) > 1 {
+		n, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return r, &Deviation{lineNo, "a=rtpmap:" + val, "clock rate is not a number"}
+		}
+		r.ClockRate = n
+	}
+	if len(parts) > 2 {
+		if n, err := strconv.Atoi(parts[2]); err == nil {
+			r.Channels = n
+		}
+	}
+	return r, nil
+}
+
+func parseFMTP(val string, lineNo int) (FMTP, *Deviation) {
+	i := strings.IndexAny(val, " \t")
+	if i < 0 {
+		return FMTP{}, &Deviation{lineNo, "a=fmtp:" + val, "fmtp expects <pt> <params>"}
+	}
+	f := FMTP{PayloadType: strings.TrimSpace(val[:i]), Raw: val}
+	for _, kv := range strings.Split(val[i+1:], ";") {
+		kv = strings.TrimSpace(kv)
+		if kv == "" {
+			continue
+		}
+		if j := strings.IndexByte(kv, '='); j >= 0 {
+			f.Params = append(f.Params, Param{Key: strings.TrimSpace(kv[:j]), Value: strings.TrimSpace(kv[j+1:])})
+			continue
+		}
+		f.Params = append(f.Params, Param{Key: kv})
+	}
+	return f, nil
+}
+
+// parseTSRefClk handles the PTP form. Other forms (localmac, ntp) are kept as
+// Raw with no parsed fields rather than being reported as defects.
+func parseTSRefClk(val string, lineNo int) (*TSRefClk, *Deviation) {
+	t := &TSRefClk{Raw: val, Domain: -1}
+	v := strings.TrimSpace(val)
+	if !strings.HasPrefix(strings.ToLower(v), "ptp=") {
+		return t, nil
+	}
+	parts := strings.Split(v[len("ptp="):], ":")
+	if len(parts) < 2 {
+		return t, &Deviation{lineNo, "a=ts-refclk:" + val, "ptp expects <version>:<gmid>[:<domain>]"}
+	}
+	t.Version = parts[0]
+	t.GMID = parts[1]
+	if len(parts) > 2 {
+		n, err := strconv.Atoi(parts[2])
+		if err != nil {
+			return t, &Deviation{lineNo, "a=ts-refclk:" + val, "ptp domain is not a number"}
+		}
+		t.Domain = n
+	}
+	return t, nil
+}
+
+func parseSourceFilter(val string, lineNo int) (*SourceFilter, *Deviation) {
+	// Devices commonly emit "a=source-filter: incl IN IP4 <dst> <src>" with a
+	// space after the colon; Fields handles both forms.
+	f := strings.Fields(val)
+	if len(f) < 5 {
+		return nil, &Deviation{lineNo, "a=source-filter:" + val, "source-filter expects <mode> <nettype> <addrtype> <dest> <src>..."}
+	}
+	return &SourceFilter{
+		Mode:     f[0],
+		NetType:  f[1],
+		AddrType: f[2],
+		Dest:     f[3],
+		Sources:  append([]string(nil), f[4:]...),
+		Raw:      val,
+	}, nil
+}

--- a/internal/amwa/codec/sdp/sdp.go
+++ b/internal/amwa/codec/sdp/sdp.go
@@ -1,0 +1,199 @@
+// Package sdp decodes SDP transport files (RFC 4566) as used by AMWA NMOS
+// IS-04 (sender manifest_href) and IS-05 (transport_file).
+//
+// Scope is the ST 2110 profile a broadcast node actually publishes: the
+// multicast address per SMPTE 2022-7 leg, the PTP reference clock, the RTP
+// payload mapping and the essence parameters. Everything the parser does not
+// model is preserved verbatim rather than discarded, so a caller can always
+// see what the device really sent.
+//
+// Stdlib only (ADR-0006): this package never imports dhs/*.
+package sdp
+
+import "strings"
+
+// Attribute is one `a=` line. Value is empty for a property attribute
+// (`a=recvonly`); for `a=<name>:<value>` Value holds everything after the
+// first colon, untrimmed on the right so nothing is silently altered.
+type Attribute struct {
+	Name  string
+	Value string
+	Raw   string // the line as received, without the leading "a="
+}
+
+// Origin is the `o=` line.
+type Origin struct {
+	Username       string
+	SessionID      string
+	SessionVersion string
+	NetType        string
+	AddrType       string
+	Address        string
+}
+
+// Connection is a `c=` line. For IPv4 multicast the address carries a TTL
+// (`239.0.0.1/32`) and optionally an address count (`239.0.0.1/32/2`).
+type Connection struct {
+	NetType  string
+	AddrType string
+	Address  string // address only, TTL and count stripped
+	TTL      int    // 0 when absent
+	Count    int    // 0 when absent
+	Raw      string
+}
+
+// Timing is a `t=` line.
+type Timing struct {
+	Start string
+	Stop  string
+}
+
+// Group is an `a=group:<semantics> <tag>...` line. ST 2022-7 redundancy uses
+// `a=group:DUP primary secondary`, whose tags refer to `a=mid` values.
+type Group struct {
+	Semantics string
+	Tags      []string
+}
+
+// RTPMap is an `a=rtpmap:<pt> <encoding>/<clock>[/<channels>]` line.
+type RTPMap struct {
+	PayloadType string
+	Encoding    string // raw, L24, smpte291, ...
+	ClockRate   int
+	Channels    int // 0 when absent (video)
+}
+
+// FMTP is an `a=fmtp:<pt> <k=v>; <k=v>; ...` line. Params keeps source order
+// because the order carries meaning when comparing two devices' output.
+type FMTP struct {
+	PayloadType string
+	Params      []Param
+	Raw         string
+}
+
+// Param is one `key=value` from an fmtp line. A bare flag has an empty Value.
+type Param struct {
+	Key   string
+	Value string
+}
+
+// Get returns the first value for key and whether it was present.
+func (f FMTP) Get(key string) (string, bool) {
+	for _, p := range f.Params {
+		if strings.EqualFold(p.Key, key) {
+			return p.Value, true
+		}
+	}
+	return "", false
+}
+
+// TSRefClk is an `a=ts-refclk:ptp=<version>:<gmid>:<domain>` line — the check
+// that tells you whether a sender is locked to the fabric grandmaster or is
+// quoting its own clock identity.
+type TSRefClk struct {
+	Version string // IEEE1588-2008
+	GMID    string // grandmaster clock identity, e.g. 00-90-56-FF-FE-08-6D-42
+	Domain  int    // -1 when absent
+	Raw     string
+}
+
+// SourceFilter is an `a=source-filter: <incl|excl> <nettype> <addrtype>
+// <dest> <src>...` line (RFC 4570), i.e. source-specific multicast.
+type SourceFilter struct {
+	Mode     string // incl | excl
+	NetType  string
+	AddrType string
+	Dest     string
+	Sources  []string
+	Raw      string
+}
+
+// Media is one `m=` section.
+type Media struct {
+	Type       string // audio | video | application
+	Port       int
+	PortCount  int // from `m=video 5004/2`, 0 when absent
+	Proto      string
+	Formats    []string
+	Connection *Connection
+	Mid        string // a=mid — the tag a group refers to
+	PTime      string // a=ptime
+	MediaClk   string // a=mediaclk
+	RTPMap     map[string]RTPMap
+	FMTP       map[string]FMTP
+	TSRefClk   *TSRefClk
+	SourceFilt *SourceFilter
+	Attributes []Attribute // every a= line in this section, in order
+}
+
+// Session is a parsed SDP document.
+type Session struct {
+	Version    int
+	Origin     Origin
+	Name       string
+	Info       string
+	Timing     []Timing
+	Connection *Connection // session-level c=, if any
+	Groups     []Group
+	Attributes []Attribute // session-level a= lines, in order
+	Media      []Media
+}
+
+// Leg is one side of an SMPTE 2022-7 pair, resolved from a=group + a=mid.
+type Leg struct {
+	Mid      string // primary | secondary (whatever the device used)
+	Index    int    // position of the m= section in the document
+	Dest     string // multicast destination from the section's c=
+	Port     int
+	Sources  []string // from a=source-filter, when present
+	MediaIdx int      // index into Session.Media
+}
+
+// Legs pairs the tags of the first `a=group:DUP` with their `m=` sections.
+// A document with no DUP group yields one Leg per media section, so callers
+// do not need a special case for an unprotected stream.
+func (s *Session) Legs() []Leg {
+	byMid := make(map[string]int, len(s.Media))
+	for i, m := range s.Media {
+		if m.Mid != "" {
+			byMid[m.Mid] = i
+		}
+	}
+
+	leg := func(idx, pos int) Leg {
+		m := s.Media[idx]
+		l := Leg{Mid: m.Mid, Index: pos, Port: m.Port, MediaIdx: idx}
+		if m.Connection != nil {
+			l.Dest = m.Connection.Address
+		} else if s.Connection != nil {
+			l.Dest = s.Connection.Address
+		}
+		if m.SourceFilt != nil {
+			l.Sources = m.SourceFilt.Sources
+		}
+		return l
+	}
+
+	for _, g := range s.Groups {
+		if !strings.EqualFold(g.Semantics, "DUP") {
+			continue
+		}
+		out := make([]Leg, 0, len(g.Tags))
+		for pos, tag := range g.Tags {
+			idx, ok := byMid[tag]
+			if !ok {
+				continue // a tag with no matching m= is reported as a Deviation at parse time
+			}
+			out = append(out, leg(idx, pos))
+		}
+		if len(out) > 0 {
+			return out
+		}
+	}
+
+	out := make([]Leg, 0, len(s.Media))
+	for i := range s.Media {
+		out = append(out, leg(i, i))
+	}
+	return out
+}

--- a/internal/amwa/codec/sdp/sdp_test.go
+++ b/internal/amwa/codec/sdp/sdp_test.go
@@ -1,0 +1,290 @@
+package sdp_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"dhs/internal/amwa/codec/sdp"
+)
+
+func load(t *testing.T, name string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return b
+}
+
+func parseClean(t *testing.T, name string) *sdp.Session {
+	t.Helper()
+	s, devs, err := sdp.Parse(load(t, name))
+	if err != nil {
+		t.Fatalf("%s: unexpected error: %v", name, err)
+	}
+	if len(devs) != 0 {
+		t.Fatalf("%s: unexpected deviations: %v", name, devs)
+	}
+	return s
+}
+
+// Expected values below are read from the fixture TEXT, never from the
+// parser's own output (ADR: expected bytes come from the spec, not from
+// working code).
+
+func TestVideoRawDualLeg(t *testing.T) {
+	s := parseClean(t, "video_2022-7.sdp")
+
+	if s.Version != 0 {
+		t.Errorf("version = %d, want 0", s.Version)
+	}
+	if s.Name != "VTX-01" {
+		t.Errorf("name = %q, want VTX-01", s.Name)
+	}
+	if s.Origin.Address != "192.0.2.42" {
+		t.Errorf("origin address = %q, want 192.0.2.42", s.Origin.Address)
+	}
+	if len(s.Media) != 2 {
+		t.Fatalf("media sections = %d, want 2", len(s.Media))
+	}
+
+	m := s.Media[0]
+	if m.Type != "video" || m.Port != 20000 || m.Proto != "RTP/AVP" {
+		t.Errorf("m= parsed as %s/%d/%s, want video/20000/RTP/AVP", m.Type, m.Port, m.Proto)
+	}
+	if m.Connection == nil || m.Connection.Address != "233.252.0.27" || m.Connection.TTL != 32 {
+		t.Errorf("leg 1 connection = %+v, want 233.252.0.27 ttl 32", m.Connection)
+	}
+	if m.Mid != "primary" {
+		t.Errorf("leg 1 mid = %q, want primary", m.Mid)
+	}
+
+	r, ok := m.RTPMap["96"]
+	if !ok {
+		t.Fatal("rtpmap 96 missing")
+	}
+	if r.Encoding != "raw" || r.ClockRate != 90000 || r.Channels != 0 {
+		t.Errorf("rtpmap = %+v, want raw/90000 with no channels", r)
+	}
+
+	f, ok := m.FMTP["96"]
+	if !ok {
+		t.Fatal("fmtp 96 missing")
+	}
+	for _, tc := range []struct{ key, want string }{
+		{"width", "1920"},
+		{"height", "1080"},
+		{"exactframerate", "50"},
+		{"sampling", "YCbCr-4:2:2"},
+		{"depth", "10"},
+		{"colorimetry", "BT709"},
+		{"TCS", "SDR"},
+		{"PM", "2110GPM"},
+		{"SSN", "ST2110-20:2017"},
+		{"TP", "2110TPN"},
+	} {
+		got, ok := f.Get(tc.key)
+		if !ok {
+			t.Errorf("fmtp %s missing", tc.key)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("fmtp %s = %q, want %q", tc.key, got, tc.want)
+		}
+	}
+	// sampling contains a colon; splitting on the first '=' must keep it whole.
+	if v, _ := f.Get("sampling"); v != "YCbCr-4:2:2" {
+		t.Errorf("sampling lost its colons: %q", v)
+	}
+
+	if m.TSRefClk == nil {
+		t.Fatal("ts-refclk missing")
+	}
+	if m.TSRefClk.Version != "IEEE1588-2008" ||
+		m.TSRefClk.GMID != "00-11-22-FF-FE-33-44-55" ||
+		m.TSRefClk.Domain != 127 {
+		t.Errorf("ts-refclk = %+v, want IEEE1588-2008 / 00-11-22-FF-FE-33-44-55 / 127", m.TSRefClk)
+	}
+
+	if m.SourceFilt == nil {
+		t.Fatal("source-filter missing")
+	}
+	if m.SourceFilt.Mode != "incl" || m.SourceFilt.Dest != "233.252.0.27" ||
+		len(m.SourceFilt.Sources) != 1 || m.SourceFilt.Sources[0] != "192.0.2.42" {
+		t.Errorf("source-filter = %+v", m.SourceFilt)
+	}
+
+	if s.Media[1].Connection.Address != "233.252.1.27" || s.Media[1].Mid != "secondary" {
+		t.Errorf("leg 2 = %s / %s, want 233.252.1.27 / secondary",
+			s.Media[1].Connection.Address, s.Media[1].Mid)
+	}
+}
+
+func TestLegsResolveDupGroup(t *testing.T) {
+	s := parseClean(t, "video_2022-7.sdp")
+	legs := s.Legs()
+	if len(legs) != 2 {
+		t.Fatalf("legs = %d, want 2", len(legs))
+	}
+	want := []struct {
+		mid, dest, src string
+		port           int
+	}{
+		{"primary", "233.252.0.27", "192.0.2.42", 20000},
+		{"secondary", "233.252.1.27", "198.51.100.42", 20000},
+	}
+	for i, w := range want {
+		if legs[i].Mid != w.mid || legs[i].Dest != w.dest || legs[i].Port != w.port {
+			t.Errorf("leg %d = %+v, want %s %s :%d", i, legs[i], w.mid, w.dest, w.port)
+		}
+		if len(legs[i].Sources) != 1 || legs[i].Sources[0] != w.src {
+			t.Errorf("leg %d sources = %v, want [%s]", i, legs[i].Sources, w.src)
+		}
+	}
+}
+
+func TestAudioL24Channels(t *testing.T) {
+	s := parseClean(t, "audio_l24.sdp")
+	m := s.Media[0]
+	if m.Type != "audio" || m.Port != 30000 {
+		t.Errorf("m= = %s/%d, want audio/30000", m.Type, m.Port)
+	}
+	r := m.RTPMap["97"]
+	if r.Encoding != "L24" || r.ClockRate != 48000 || r.Channels != 8 {
+		t.Errorf("rtpmap = %+v, want L24/48000/8", r)
+	}
+	if m.PTime != "0.125" {
+		t.Errorf("ptime = %q, want 0.125", m.PTime)
+	}
+	if v, ok := m.FMTP["97"].Get("channel-order"); !ok || v != "SMPTE2110.(U08)" {
+		t.Errorf("channel-order = %q (present=%v), want SMPTE2110.(U08)", v, ok)
+	}
+	if m.MediaClk != "direct=0" {
+		t.Errorf("mediaclk = %q, want direct=0", m.MediaClk)
+	}
+	if m.TSRefClk.Domain != 100 {
+		t.Errorf("ptp domain = %d, want 100", m.TSRefClk.Domain)
+	}
+}
+
+func TestAncillarySMPTE291(t *testing.T) {
+	s := parseClean(t, "anc_smpte291.sdp")
+	m := s.Media[0]
+	// ANC is carried in an m=video section — the media type alone does not
+	// identify the essence; the rtpmap encoding does.
+	if m.Type != "video" {
+		t.Errorf("media type = %q, want video", m.Type)
+	}
+	if got := m.RTPMap["100"].Encoding; got != "smpte291" {
+		t.Errorf("encoding = %q, want smpte291", got)
+	}
+	if m.SourceFilt != nil {
+		t.Errorf("source-filter should be absent, got %+v", m.SourceFilt)
+	}
+	if len(s.Legs()) != 2 {
+		t.Errorf("legs = %d, want 2", len(s.Legs()))
+	}
+}
+
+func TestSingleLegWithoutGroup(t *testing.T) {
+	s := parseClean(t, "single_leg.sdp")
+	if len(s.Groups) != 0 {
+		t.Fatalf("groups = %d, want 0", len(s.Groups))
+	}
+	legs := s.Legs()
+	if len(legs) != 1 {
+		t.Fatalf("legs = %d, want 1 (a stream with no DUP group is still one leg)", len(legs))
+	}
+	if legs[0].Dest != "233.252.0.5" || legs[0].Port != 5004 {
+		t.Errorf("leg = %+v, want 233.252.0.5:5004", legs[0])
+	}
+	c := s.Media[0].Connection
+	if c.TTL != 64 || c.Count != 2 {
+		t.Errorf("connection ttl/count = %d/%d, want 64/2", c.TTL, c.Count)
+	}
+}
+
+func TestCRLFAccepted(t *testing.T) {
+	s := parseClean(t, "crlf.sdp")
+	if s.Name != "crlf" {
+		t.Errorf("name = %q, want crlf (CR must not survive into values)", s.Name)
+	}
+	if s.Media[0].RTPMap["97"].Channels != 2 {
+		t.Errorf("channels = %d, want 2", s.Media[0].RTPMap["97"].Channels)
+	}
+}
+
+func TestUnknownAttributesPreserved(t *testing.T) {
+	in := []byte("v=0\no=- 1 1 IN IP4 192.0.2.1\ns=x\nt=0 0\na=x-vendor:whatever\nm=video 1 RTP/AVP 96\na=x-media-thing:42\n")
+	s, devs, err := sdp.Parse(in)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(devs) != 0 {
+		t.Fatalf("unexpected deviations: %v", devs)
+	}
+	var found bool
+	for _, a := range s.Attributes {
+		if a.Name == "x-vendor" && a.Value == "whatever" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("session-level unknown attribute was dropped")
+	}
+	found = false
+	for _, a := range s.Media[0].Attributes {
+		if a.Name == "x-media-thing" && a.Value == "42" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("media-level unknown attribute was dropped")
+	}
+}
+
+func TestDeviations(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"not a type=value line", "v=0\no=- 1 1 IN IP4 192.0.2.1\ns=x\nt=0 0\ngarbage\n", "not a <type>=<value> line"},
+		{"short origin", "v=0\no=- 1 1 IN IP4\ns=x\nt=0 0\n", "o= expects 6 fields"},
+		{"bad connection", "v=0\no=- 1 1 IN IP4 192.0.2.1\ns=x\nt=0 0\nc=IN IP4\n", "c= expects <nettype> <addrtype> <address>"},
+		{"bad media port", "v=0\no=- 1 1 IN IP4 192.0.2.1\ns=x\nt=0 0\nm=video xyz RTP/AVP 96\n", "m= port is not a number"},
+		{"bad rtpmap clock", "v=0\no=- 1 1 IN IP4 192.0.2.1\ns=x\nt=0 0\nm=video 1 RTP/AVP 96\na=rtpmap:96 raw/abc\n", "clock rate is not a number"},
+		{"bad ptp domain", "v=0\no=- 1 1 IN IP4 192.0.2.1\ns=x\nt=0 0\nm=video 1 RTP/AVP 96\na=ts-refclk:ptp=IEEE1588-2008:00-11:xyz\n", "ptp domain is not a number"},
+		{"dangling group tag", "v=0\no=- 1 1 IN IP4 192.0.2.1\ns=x\nt=0 0\na=group:DUP primary secondary\nm=video 1 RTP/AVP 96\na=mid:primary\n", "group tag secondary has no matching a=mid"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, devs, err := sdp.Parse([]byte(tc.in))
+			if err != nil {
+				t.Fatalf("parse returned error %v; a recoverable defect must be a Deviation", err)
+			}
+			var got bool
+			for _, d := range devs {
+				if d.Msg == tc.want {
+					got = true
+				}
+			}
+			if !got {
+				t.Errorf("deviations = %v, want one with %q", devs, tc.want)
+			}
+		})
+	}
+}
+
+func TestEmptyAndNonSDP(t *testing.T) {
+	if _, _, err := sdp.Parse(nil); err != sdp.ErrEmpty {
+		t.Errorf("nil input: err = %v, want ErrEmpty", err)
+	}
+	if _, _, err := sdp.Parse([]byte("   \n\n")); err != sdp.ErrEmpty {
+		t.Errorf("blank input: err = %v, want ErrEmpty", err)
+	}
+	if _, _, err := sdp.Parse([]byte("s=no version here\n")); err != sdp.ErrNoVersion {
+		t.Errorf("missing v=: err = %v, want ErrNoVersion", err)
+	}
+}

--- a/internal/amwa/codec/sdp/testdata/anc_smpte291.sdp
+++ b/internal/amwa/codec/sdp/testdata/anc_smpte291.sdp
@@ -1,0 +1,17 @@
+v=0
+o=- 1712345678 3200964341 IN IP4 192.0.2.42
+s=DTX-03
+t=0 0
+a=group:DUP primary secondary
+m=video 40000 RTP/AVP 100
+c=IN IP4 233.252.0.99/32
+a=ts-refclk:ptp=IEEE1588-2008:00-11-22-FF-FE-33-44-55:127
+a=mediaclk:direct=0
+a=rtpmap:100 smpte291/90000
+a=mid:primary
+m=video 40000 RTP/AVP 100
+c=IN IP4 233.252.1.99/32
+a=ts-refclk:ptp=IEEE1588-2008:00-11-22-FF-FE-33-44-55:127
+a=mediaclk:direct=0
+a=rtpmap:100 smpte291/90000
+a=mid:secondary

--- a/internal/amwa/codec/sdp/testdata/audio_l24.sdp
+++ b/internal/amwa/codec/sdp/testdata/audio_l24.sdp
@@ -1,0 +1,23 @@
+v=0
+o=- 1992998563 3996293031 IN IP4 192.0.2.34
+s=ATX-01
+t=0 0
+a=group:DUP primary secondary
+m=audio 30000 RTP/AVP 97
+c=IN IP4 233.252.0.10/32
+a=ts-refclk:ptp=IEEE1588-2008:00-11-22-FF-FE-33-44-55:100
+a=mediaclk:direct=0
+a=source-filter: incl IN IP4 233.252.0.10 192.0.2.34
+a=rtpmap:97 L24/48000/8
+a=ptime:0.125
+a=fmtp:97 channel-order=SMPTE2110.(U08)
+a=mid:primary
+m=audio 30000 RTP/AVP 97
+c=IN IP4 233.252.1.10/32
+a=ts-refclk:ptp=IEEE1588-2008:00-11-22-FF-FE-33-44-55:100
+a=mediaclk:direct=0
+a=source-filter: incl IN IP4 233.252.1.10 198.51.100.34
+a=rtpmap:97 L24/48000/8
+a=ptime:0.125
+a=fmtp:97 channel-order=SMPTE2110.(U08)
+a=mid:secondary

--- a/internal/amwa/codec/sdp/testdata/crlf.sdp
+++ b/internal/amwa/codec/sdp/testdata/crlf.sdp
@@ -1,0 +1,7 @@
+v=0
+o=- 1 1 IN IP4 192.0.2.7
+s=crlf
+t=0 0
+m=audio 5004 RTP/AVP 97
+c=IN IP4 233.252.0.6/32
+a=rtpmap:97 L24/48000/2

--- a/internal/amwa/codec/sdp/testdata/single_leg.sdp
+++ b/internal/amwa/codec/sdp/testdata/single_leg.sdp
@@ -1,0 +1,7 @@
+v=0
+o=- 1 1 IN IP4 192.0.2.7
+s=unprotected
+t=0 0
+m=video 5004 RTP/AVP 96
+c=IN IP4 233.252.0.5/64/2
+a=rtpmap:96 raw/90000

--- a/internal/amwa/codec/sdp/testdata/video_2022-7.sdp
+++ b/internal/amwa/codec/sdp/testdata/video_2022-7.sdp
@@ -1,0 +1,21 @@
+v=0
+o=- 1892839283 3200968197 IN IP4 192.0.2.42
+s=VTX-01
+t=0 0
+a=group:DUP primary secondary
+m=video 20000 RTP/AVP 96
+c=IN IP4 233.252.0.27/32
+a=ts-refclk:ptp=IEEE1588-2008:00-11-22-FF-FE-33-44-55:127
+a=mediaclk:direct=0
+a=source-filter: incl IN IP4 233.252.0.27 192.0.2.42
+a=rtpmap:96 raw/90000
+a=fmtp:96 width=1920; height=1080; exactframerate=50; sampling=YCbCr-4:2:2; depth=10; colorimetry=BT709; TCS=SDR; PM=2110GPM; SSN=ST2110-20:2017; TP=2110TPN;
+a=mid:primary
+m=video 20000 RTP/AVP 96
+c=IN IP4 233.252.1.27/32
+a=ts-refclk:ptp=IEEE1588-2008:00-11-22-FF-FE-33-44-55:127
+a=mediaclk:direct=0
+a=source-filter: incl IN IP4 233.252.1.27 198.51.100.42
+a=rtpmap:96 raw/90000
+a=fmtp:96 width=1920; height=1080; exactframerate=50; sampling=YCbCr-4:2:2; depth=10; colorimetry=BT709; TCS=SDR; PM=2110GPM; SSN=ST2110-20:2017; TP=2110TPN;
+a=mid:secondary


### PR DESCRIPTION
## What

New stdlib-only package `internal/amwa/codec/sdp` — a parser for the SDP transport files NMOS carries (IS-04 `manifest_href`, IS-05 `transport_file`).

## Why

The repo could not read an SDP at all. The only SDP code was `sdpFor()` in `internal/amwa/provider/node_endpoints.go:54`, which *emits* a fixed minimal audio body. Everything the wire actually carries was unreachable in code:

- the multicast address **per SMPTE 2022-7 leg** (`c=` inside each `m=`, resolved through `a=group:DUP` + `a=mid`);
- the PTP grandmaster and domain (`a=ts-refclk`) — the check that catches a sender quoting its own clock identity instead of the fabric grandmaster;
- the essence parameters (`a=rtpmap`, `a=fmtp`, `a=ptime`) and the source address (`a=source-filter`).

Closes #827

## Scope

- [x] osc / tsl / cerebrum-nb / amwa

## Reference controller

- [x] N/A (no protocol behaviour change — read-only codec, not wired to any surface yet)

## Type

- [x] feat — new feature

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `internal/amwa/codec/sdp/sdp.go` | new | model: Session, Media, Connection, RTPMap, FMTP, TSRefClk, SourceFilter, Group, Leg |
| `internal/amwa/codec/sdp/parse.go` | new | RFC 4566 line parser + ST 2110 attribute decoding + Deviation reporting |
| `internal/amwa/codec/sdp/sdp_test.go` | new | the three real essence shapes, legs, deviations, empty/non-SDP |
| `internal/amwa/codec/sdp/edge_test.go` | new | edge cases: session-level `c=`, property attributes, non-PTP ts-refclk, bare fmtp flags, malformed lines |
| `internal/amwa/codec/sdp/testdata/*.sdp` | new | 5 fixtures |

## Design decisions

**`Parse` returns `(*Session, []Deviation, error)`.** A recoverable defect becomes a Deviation and parsing continues — the connector compliance posture, absorb and surface rather than patch. Only a document that is not SDP at all is an error (`ErrEmpty`, `ErrNoVersion`). A caller wanting strictness treats a non-empty deviation slice as failure.

**Nothing is discarded.** Unknown attributes and unmodelled line types (`b=`, `u=`, …) are preserved verbatim; `m=` section order and `fmtp` parameter order are kept, because leg identity and cross-device comparison depend on both.

**`Legs()` handles the unprotected case.** With no `a=group:DUP` it returns one leg per `m=` section, so callers need no special case. A DUP tag naming no `a=mid` is reported as a Deviation and skipped rather than producing a phantom leg.

**Absent is not zero.** `TSRefClk.Domain` is `-1` when the device omits it, so "domain 0" and "no domain" are distinguishable.

## Test results

| Suite | Result |
|-------|--------|
| `go test ./internal/amwa/codec/sdp/...` | pass |
| Coverage | **100.0% of statements** |
| `go vet ./...` | clean |
| `golangci-lint run ./internal/amwa/codec/sdp/...` | **0 issues** |
| `gofmt -l` | clean |
| `internal/amwa` architecture tests | pass — `TestCodecHasNoAcpImports` confirms stdlib-only |
| `go test ./...` | no failures |

`-race` could not run on this host (`-race requires cgo`); CI covers it.

## Fixtures

Three real ST 2110 shapes observed on an EVS Neuron, plus two edge cases:

| Fixture | Shape |
|---|---|
| `video_2022-7.sdp` | `video/raw`, 1920x1080 @50, YCbCr-4:2:2, 10-bit, BT709, SDR, PM=2110GPM, SSN=ST2110-20:2017, TP=2110TPN, dual leg |
| `audio_l24.sdp` | `L24/48000/8`, `ptime 0.125`, `channel-order=SMPTE2110.(U08)`, dual leg |
| `anc_smpte291.sdp` | `smpte291/90000` in an `m=video` section, dual leg, no source-filter |
| `single_leg.sdp` | no DUP group; `c=` with TTL and address count |
| `crlf.sdp` | CRLF line endings |

Addresses are documentation-range (`233.252.0.0/24`, `192.0.2.0/24`, `198.51.100.0/24`) with a synthetic grandmaster — **no customer addressing in a public repo**.

## Scope boundaries

Out of scope, each its own unit: emitting SDP (the provider's `sdpFor` is untouched), the IS-05 client/server, and CLI wiring. This unit only reads.

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies (stdlib only)
- [x] Integration tested on VM before PR — N/A, pure codec; fixtures are captured device output

## Approval

@yboujraf — requesting review