### PR TITLE
feat(nmos): IS-04 Query WebSocket watcher + consumer nmos watch (#830)

### DIFF
--- a/cmd/dhs/cmd_nmos.go
+++ b/cmd/dhs/cmd_nmos.go
@@ -15,6 +15,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -25,11 +26,13 @@ import (
 	"time"
 
 	codec "dhs/internal/amwa/codec/dnssd"
+	"dhs/internal/amwa/codec/is04"
 	"dhs/internal/amwa/codec/is09"
 	"dhs/internal/amwa/codec/spec"
 	"dhs/internal/amwa/consumer"
 	"dhs/internal/amwa/provider"
 	session "dhs/internal/amwa/session/dnssd"
+	"dhs/internal/amwa/session/query"
 	registryslot "dhs/internal/registry"
 )
 
@@ -50,6 +53,8 @@ func runNMOSConsumer(ctx context.Context, args []string) error {
 		return runNMOSSystem(ctx, rest)
 	case "walk":
 		return runNMOSWalk(ctx, rest)
+	case "watch":
+		return runNMOSWatch(ctx, rest)
 	case "connect":
 		return runNMOSConnect(ctx, rest)
 	case "set":
@@ -59,7 +64,7 @@ func runNMOSConsumer(ctx context.Context, args []string) error {
 	case "events":
 		return runNMOSEventsConsumer(ctx, rest)
 	}
-	return fmt.Errorf("consumer nmos: unknown verb %q (expected: discover, system, walk, connect, set, facade, events)", verb)
+	return fmt.Errorf("consumer nmos: unknown verb %q (expected: discover, system, walk, watch, connect, set, facade, events)", verb)
 }
 
 // runNMOSProducer dispatches `dhs producer nmos <verb> [args]`.
@@ -707,6 +712,127 @@ announce of _nmos-register._tcp + _nmos-query._tcp.
 }
 
 // ---- consumer walk (IS-04 Controller) ---------------------------------------
+
+// runNMOSWatch streams live resource changes from a Registry's Query API
+// WebSocket subscription (IS-04 §5.2).
+//
+// This is the ONLY push surface IS-04 defines. A Node publishes no resource
+// changes of its own, so "watch what is happening in the plant" means
+// subscribing to a Registry — not polling a Node.
+func runNMOSWatch(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("watch", flag.ContinueOnError)
+	registry := fs.String("registry", "", "Registry origin (Mode B unicast — http://host:port). When empty, --mdns or --unicast triggers DNS-SD discovery.")
+	mdns := fs.Bool("mdns", true, "discover the Registry via mDNS (Mode A); ignored if --registry is set")
+	unicast := fs.Bool("unicast", false, "discover via unicast DNS-SD (Mode B); requires --resolver")
+	resolver := fs.String("resolver", "", "unicast DNS resolver IP")
+	domain := fs.String("domain", "by-systems.arpa", "unicast DNS-SD discovery domain")
+	apiVer := fs.String("api-ver", "", "force a specific IS-04 wire minor (v1.1 / v1.2 / v1.3); empty = highest mutual")
+	discTimeout := fs.Duration("timeout", 5*time.Second, "DNS-SD discovery timeout")
+	resource := fs.String("resource", "/nodes", "resource path to subscribe to: /nodes /devices /sources /flows /senders /receivers (IS-04 spells these without a trailing slash)")
+	params := fs.String("params", "", "subscription filter as k=v[,k=v...] (e.g. label=CAM1)")
+	persist := fs.Bool("persist", false, "ask the Registry to keep the subscription after the socket closes")
+	rate := fs.Int("rate", 0, "max_update_rate_ms; 0 lets the Registry choose")
+	duration := fs.Duration("duration", 0, "stop after this long; 0 = until interrupted")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *registry == "" && !*mdns && !*unicast {
+		return fmt.Errorf("nmos watch: pick exactly one of --registry / --mdns / --unicast")
+	}
+
+	mode := ""
+	switch {
+	case *unicast:
+		if *resolver == "" {
+			return fmt.Errorf("nmos watch --unicast: --resolver is required")
+		}
+		mode = "unicast"
+	case *mdns:
+		mode = "mdns"
+	}
+
+	rep := &spec.SliceReporter{}
+	c, err := consumer.NewController(ctx, consumer.ControllerOptions{
+		Logger:           slog.Default(),
+		Reporter:         rep,
+		RegistryURL:      *registry,
+		DiscoveryMode:    mode,
+		DiscoveryTimeout: *discTimeout,
+		UnicastResolver:  *resolver,
+		UnicastDomain:    *domain,
+		APIVer:           *apiVer,
+	})
+	if err != nil {
+		return fmt.Errorf("nmos watch: %w", err)
+	}
+
+	qc, err := query.NewClient(c.BaseURL(), c.Codec())
+	if err != nil {
+		return fmt.Errorf("nmos watch: %w", err)
+	}
+
+	filter := map[string]string{}
+	for _, kv := range strings.Split(*params, ",") {
+		kv = strings.TrimSpace(kv)
+		if kv == "" {
+			continue
+		}
+		i := strings.IndexByte(kv, '=')
+		if i < 0 {
+			return fmt.Errorf("nmos watch: --params entry %q is not k=v", kv)
+		}
+		filter[strings.TrimSpace(kv[:i])] = strings.TrimSpace(kv[i+1:])
+	}
+
+	sub, err := qc.Subscribe(ctx, query.SubscribeRequest{
+		ResourcePath:  *resource,
+		Params:        filter,
+		Persist:       *persist,
+		MaxUpdateRate: *rate,
+	})
+	if err != nil {
+		return fmt.Errorf("nmos watch: subscribe: %w", err)
+	}
+
+	fmt.Printf("Registry %s (api_ver=%s, spec=%s)\n", c.BaseURL(), c.Codec().APIVer(), c.Codec().SpecPatch())
+	fmt.Printf("Subscribed %s -> %s (id=%s, persist=%v, max_update_rate_ms=%d)\n",
+		sub.ResourcePath, sub.WSHref, sub.ID, sub.Persist, sub.MaxUpdateRate)
+	fmt.Println("Watching. The first grain is the current state; later grains are changes.")
+
+	if *duration > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, *duration)
+		defer cancel()
+	}
+
+	var grains, changes int
+	err = query.Watch(ctx, sub.WSHref, func(g *is04.Grain) error {
+		grains++
+		for _, row := range g.Grain.Data {
+			changes++
+			label := row.Label()
+			if label != "" {
+				label = " " + label
+			}
+			fmt.Printf("%-8s %-12s %s%s\n",
+				row.Kind(), strings.Trim(g.Grain.Topic, "/"), row.Path, label)
+		}
+		return nil
+	}, query.WatchOptions{})
+
+	fmt.Fprintf(os.Stderr, "\n%d grain(s), %d change row(s)\n", grains, changes)
+	if events := rep.Snapshot(); len(events) > 0 {
+		fmt.Fprintf(os.Stderr, "%d compliance event(s) fired:\n", len(events))
+		for _, ev := range events {
+			fmt.Fprintf(os.Stderr, "  [%s] %s/%s %s: %s\n", ev.Severity, ev.SpecID, ev.APIVer, ev.Code, ev.Detail)
+		}
+	}
+	// A deadline or interrupt is how a watch normally ends, not a failure.
+	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("nmos watch: %w", err)
+	}
+	return nil
+}
 
 func runNMOSWalk(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("walk", flag.ContinueOnError)

--- a/internal/amwa/codec/is04/grain.go
+++ b/internal/amwa/codec/is04/grain.go
@@ -1,0 +1,106 @@
+package is04
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// Grain is the IS-04 §5.2 WebSocket envelope a Query API subscription ships on
+// every frame. It is the only push surface IS-04 defines: a Node publishes no
+// resource changes of its own, so watching a plant means watching a Registry's
+// Query API subscription.
+type Grain struct {
+	GrainType         string    `json:"grain_type"`
+	SourceID          string    `json:"source_id"`
+	FlowID            string    `json:"flow_id"`
+	OriginTimestamp   string    `json:"origin_timestamp"`
+	SyncTimestamp     string    `json:"sync_timestamp"`
+	CreationTimestamp string    `json:"creation_timestamp"`
+	// Reuses the Source/Flow GrainRate — the same numerator/denominator pair.
+	Rate     GrainRate `json:"rate"`
+	Duration GrainRate `json:"duration"`
+	Grain    GrainBody `json:"grain"`
+}
+
+// GrainBody carries the change set. Topic is the resource path the
+// subscription was opened on, e.g. "/senders/".
+type GrainBody struct {
+	Type  string         `json:"type"`
+	Topic string         `json:"topic"`
+	Data  []GrainDataRow `json:"data"`
+}
+
+// GrainDataRow is one change. Path is the resource id; Pre and Post are the
+// before and after states.
+//
+// The three cases are distinguished by which side is present, NOT by a type
+// field — that is how IS-04 encodes them:
+//
+//	Pre == nil, Post != nil  -> ADDED
+//	Pre != nil, Post != nil  -> MODIFIED (or SYNC on the initial burst)
+//	Pre != nil, Post == nil  -> REMOVED
+type GrainDataRow struct {
+	Path string          `json:"path"`
+	Pre  json.RawMessage `json:"pre,omitempty"`
+	Post json.RawMessage `json:"post,omitempty"`
+}
+
+// ChangeKind classifies a GrainDataRow.
+type ChangeKind string
+
+// Change kinds carried by a Query API subscription grain.
+const (
+	ChangeAdded    ChangeKind = "added"
+	ChangeModified ChangeKind = "modified"
+	ChangeRemoved  ChangeKind = "removed"
+	ChangeUnknown  ChangeKind = "unknown"
+)
+
+// Kind reports what happened to the resource. A row with neither side is not
+// something IS-04 defines; it is reported as unknown rather than guessed at.
+func (r GrainDataRow) Kind() ChangeKind {
+	hasPre, hasPost := len(r.Pre) > 0, len(r.Post) > 0
+	switch {
+	case !hasPre && hasPost:
+		return ChangeAdded
+	case hasPre && hasPost:
+		return ChangeModified
+	case hasPre && !hasPost:
+		return ChangeRemoved
+	default:
+		return ChangeUnknown
+	}
+}
+
+// Label pulls the human-readable label out of whichever side is present, for
+// log lines. Empty when the payload carries none.
+func (r GrainDataRow) Label() string {
+	for _, raw := range []json.RawMessage{r.Post, r.Pre} {
+		if len(raw) == 0 {
+			continue
+		}
+		var v struct {
+			Label string `json:"label"`
+		}
+		if err := json.Unmarshal(raw, &v); err == nil && v.Label != "" {
+			return v.Label
+		}
+	}
+	return ""
+}
+
+// ErrNotGrain is returned when a frame is well-formed JSON but not a grain.
+var ErrNotGrain = errors.New("is04: frame is not a grain envelope")
+
+// DecodeGrain decodes one WebSocket frame.
+func DecodeGrain(raw []byte) (*Grain, error) {
+	var g Grain
+	if err := json.Unmarshal(raw, &g); err != nil {
+		return nil, fmt.Errorf("is04: decode grain: %w", err)
+	}
+	if g.GrainType == "" && g.Grain.Topic == "" && len(g.Grain.Data) == 0 {
+		return nil, ErrNotGrain
+	}
+	return &g, nil
+}

--- a/internal/amwa/codec/is04/grain_test.go
+++ b/internal/amwa/codec/is04/grain_test.go
@@ -1,0 +1,122 @@
+package is04_test
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"dhs/internal/amwa/codec/is04"
+)
+
+// IS-04 §5.2 encodes what happened by WHICH SIDE IS PRESENT, not by a type
+// field. Getting this wrong means a controller reports a removal as a change.
+func TestGrainDataRowKind(t *testing.T) {
+	tests := []struct {
+		name string
+		row  is04.GrainDataRow
+		want is04.ChangeKind
+	}{
+		{"added: post only", is04.GrainDataRow{Path: "a", Post: json.RawMessage(`{"id":"a"}`)}, is04.ChangeAdded},
+		{"modified: both", is04.GrainDataRow{Path: "a", Pre: json.RawMessage(`{"id":"a"}`), Post: json.RawMessage(`{"id":"a"}`)}, is04.ChangeModified},
+		{"removed: pre only", is04.GrainDataRow{Path: "a", Pre: json.RawMessage(`{"id":"a"}`)}, is04.ChangeRemoved},
+		{"neither side", is04.GrainDataRow{Path: "a"}, is04.ChangeUnknown},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.row.Kind(); got != tc.want {
+				t.Errorf("Kind() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGrainDataRowLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		row  is04.GrainDataRow
+		want string
+	}{
+		{
+			"prefers post",
+			is04.GrainDataRow{Pre: json.RawMessage(`{"label":"old"}`), Post: json.RawMessage(`{"label":"new"}`)},
+			"new",
+		},
+		{
+			"falls back to pre on removal",
+			is04.GrainDataRow{Pre: json.RawMessage(`{"label":"gone"}`)},
+			"gone",
+		},
+		{"absent label", is04.GrainDataRow{Post: json.RawMessage(`{"id":"x"}`)}, ""},
+		{"no payload", is04.GrainDataRow{}, ""},
+		{"unparseable payload", is04.GrainDataRow{Post: json.RawMessage(`not json`)}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.row.Label(); got != tc.want {
+				t.Errorf("Label() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDecodeGrain(t *testing.T) {
+	// Shape taken from IS-04 §5.2: the envelope wraps a change set whose topic
+	// is the subscribed resource path.
+	raw := []byte(`{
+	  "grain_type": "event",
+	  "source_id": "6c1b2b3c-0000-4000-8000-000000000001",
+	  "flow_id": "6c1b2b3c-0000-4000-8000-000000000002",
+	  "origin_timestamp": "1787500000:0",
+	  "sync_timestamp": "1787500000:0",
+	  "creation_timestamp": "1787500000:0",
+	  "rate": {"numerator": 0, "denominator": 1},
+	  "duration": {"numerator": 0, "denominator": 1},
+	  "grain": {
+	    "type": "urn:x-nmos:format:data.event",
+	    "topic": "/senders/",
+	    "data": [
+	      {"path": "id-1", "post": {"id": "id-1", "label": "VTX-01"}},
+	      {"path": "id-2", "pre": {"id": "id-2", "label": "VTX-02"}}
+	    ]
+	  }
+	}`)
+
+	g, err := is04.DecodeGrain(raw)
+	if err != nil {
+		t.Fatalf("DecodeGrain: %v", err)
+	}
+	if g.GrainType != "event" {
+		t.Errorf("grain_type = %q, want event", g.GrainType)
+	}
+	if g.Grain.Topic != "/senders/" {
+		t.Errorf("topic = %q, want /senders/", g.Grain.Topic)
+	}
+	if g.Rate.Denominator != 1 {
+		t.Errorf("rate denominator = %d, want 1", g.Rate.Denominator)
+	}
+	if len(g.Grain.Data) != 2 {
+		t.Fatalf("data rows = %d, want 2", len(g.Grain.Data))
+	}
+	if k := g.Grain.Data[0].Kind(); k != is04.ChangeAdded {
+		t.Errorf("row 0 kind = %q, want added", k)
+	}
+	if k := g.Grain.Data[1].Kind(); k != is04.ChangeRemoved {
+		t.Errorf("row 1 kind = %q, want removed", k)
+	}
+	if l := g.Grain.Data[0].Label(); l != "VTX-01" {
+		t.Errorf("row 0 label = %q, want VTX-01", l)
+	}
+}
+
+func TestDecodeGrainRejects(t *testing.T) {
+	if _, err := is04.DecodeGrain([]byte(`{`)); err == nil {
+		t.Error("malformed JSON should be an error")
+	}
+	// Well-formed JSON that is not a grain: a peer sending something else on
+	// the subscription socket must be distinguishable from a decode failure,
+	// so the caller can skip it and keep watching.
+	_, err := is04.DecodeGrain([]byte(`{"hello":"world"}`))
+	if !errors.Is(err, is04.ErrNotGrain) {
+		t.Errorf("err = %v, want ErrNotGrain", err)
+	}
+}

--- a/internal/amwa/session/query/watch.go
+++ b/internal/amwa/session/query/watch.go
@@ -1,0 +1,178 @@
+package query
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"dhs/internal/amwa/codec/is04"
+	amwahttp "dhs/internal/amwa/session/http"
+)
+
+// Subscription is the resource a Registry returns from POST /subscriptions.
+// WSHref is the WebSocket endpoint to dial for the change stream.
+type Subscription struct {
+	ID            string         `json:"id"`
+	WSHref        string         `json:"ws_href"`
+	ResourcePath  string         `json:"resource_path"`
+	Params        map[string]any `json:"params"`
+	Persist       bool           `json:"persist"`
+	MaxUpdateRate int            `json:"max_update_rate_ms"`
+	Secure        bool           `json:"secure,omitempty"`
+}
+
+// SubscribeRequest asks a Registry to open a subscription.
+//
+// ResourcePath is the collection to watch, with leading and trailing slashes
+// as the spec writes them: "/nodes/", "/senders/", "/receivers/", …
+type SubscribeRequest struct {
+	ResourcePath  string
+	Params        map[string]string
+	Persist       bool
+	MaxUpdateRate int // milliseconds; 0 lets the Registry choose
+}
+
+// ErrNoWSHref is returned when a Registry answers a subscription without the
+// endpoint to dial — the response is then useless to a Controller, so it is a
+// failure rather than something to work around.
+var ErrNoWSHref = errors.New("query: subscription response has no ws_href")
+
+// Subscribe opens (or re-uses) a Query API subscription.
+//
+// A Registry may answer 200 with an existing subscription instead of 201 when
+// the same request has been made before; both are success, per IS-04.
+func (c *Client) Subscribe(ctx context.Context, req SubscribeRequest) (*Subscription, error) {
+	// IS-04's subscription schema enumerates resource_path WITHOUT a trailing
+	// slash ("/nodes", "/senders", ...). Accept either spelling from callers
+	// and always put the spec form on the wire — a Registry that matches on
+	// the exact string silently returns nothing for "/nodes/".
+	path := strings.TrimSpace(req.ResourcePath)
+	if path == "" {
+		return nil, errors.New("query: resource_path is required")
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	if len(path) > 1 {
+		path = strings.TrimSuffix(path, "/")
+	}
+
+	body := map[string]any{
+		"max_update_rate_ms": req.MaxUpdateRate,
+		"resource_path":      path,
+		"params":             map[string]string{},
+		"persist":            req.Persist,
+	}
+	if len(req.Params) > 0 {
+		body["params"] = req.Params
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("query: encode subscription: %w", err)
+	}
+
+	url := c.urlFor("subscriptions")
+	hreq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(raw))
+	if err != nil {
+		return nil, fmt.Errorf("query: build subscription request: %w", err)
+	}
+	hreq.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(hreq)
+	if err != nil {
+		return nil, fmt.Errorf("query: POST %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("query: POST %s: unexpected status %d", url, resp.StatusCode)
+	}
+
+	var sub Subscription
+	if err := json.NewDecoder(resp.Body).Decode(&sub); err != nil {
+		return nil, fmt.Errorf("query: decode subscription: %w", err)
+	}
+	if sub.WSHref == "" {
+		return nil, ErrNoWSHref
+	}
+	return &sub, nil
+}
+
+// GrainFunc is called once per received grain. Returning an error stops the
+// watch and Watch returns that error.
+type GrainFunc func(*is04.Grain) error
+
+// WatchOptions tunes a Watch call.
+type WatchOptions struct {
+	// ReadTimeout bounds a single frame read. Zero means wait indefinitely,
+	// which is what a low-traffic plant needs — an idle subscription is
+	// normal, not a fault.
+	ReadTimeout time.Duration
+}
+
+// Watch dials a subscription's WebSocket and streams grains to fn until the
+// context is cancelled, the peer closes, or fn returns an error.
+//
+// The first frame a Registry sends after connect is a SYNC burst carrying the
+// current state of the collection; subsequent frames are changes. Callers that
+// only want changes can skip rows whose Pre and Post are equal.
+func Watch(ctx context.Context, wsHref string, fn GrainFunc, opts WatchOptions) error {
+	if wsHref == "" {
+		return ErrNoWSHref
+	}
+	if fn == nil {
+		return errors.New("query: Watch needs a GrainFunc")
+	}
+
+	ws, err := amwahttp.DialWebSocket(ctx, wsHref, nil)
+	if err != nil {
+		return fmt.Errorf("query: dial %s: %w", wsHref, err)
+	}
+	defer func() { _ = ws.Close() }()
+
+	// Close the socket when the context ends so a blocked ReadText returns.
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = ws.Close()
+		case <-done:
+		}
+	}()
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if opts.ReadTimeout > 0 {
+			if err := ws.SetReadDeadline(time.Now().Add(opts.ReadTimeout)); err != nil {
+				return fmt.Errorf("query: set read deadline: %w", err)
+			}
+		}
+		frame, err := ws.ReadText()
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return fmt.Errorf("query: read frame: %w", err)
+		}
+		g, err := is04.DecodeGrain(frame)
+		if err != nil {
+			// A non-grain frame is a peer deviation, not a reason to drop the
+			// stream: keep watching and let the caller see the rest.
+			if errors.Is(err, is04.ErrNotGrain) {
+				continue
+			}
+			return err
+		}
+		if err := fn(g); err != nil {
+			return err
+		}
+	}
+}

--- a/internal/amwa/session/query/watch_test.go
+++ b/internal/amwa/session/query/watch_test.go
@@ -1,0 +1,184 @@
+package query_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"dhs/internal/amwa/codec/is04"
+	_ "dhs/internal/amwa/codec/is04/v13" // register the v1.3 codec
+	"dhs/internal/amwa/session/query"
+)
+
+func v13(t *testing.T) is04.Codec {
+	t.Helper()
+	c, ok := is04.Get("v1.3")
+	if !ok {
+		t.Fatal("is04 v1.3 codec not registered")
+	}
+	return c
+}
+
+func TestSubscribePostsSpecShape(t *testing.T) {
+	var gotPath, gotMethod, gotCT string
+	var gotBody map[string]any
+
+	srv := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		gotPath, gotMethod, gotCT = r.URL.Path, r.Method, r.Header.Get("Content-Type")
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(stdhttp.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"sub-1","ws_href":"ws://example.invalid/x-nmos/query/v1.3/subscriptions/sub-1/ws",
+		  "resource_path":"/senders/","params":{},"persist":true,"max_update_rate_ms":100,"secure":false}`))
+	}))
+	defer srv.Close()
+
+	c, err := query.NewClient(srv.URL, v13(t))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	sub, err := c.Subscribe(context.Background(), query.SubscribeRequest{
+		ResourcePath:  "/senders/",
+		Params:        map[string]string{"label": "VTX-01"},
+		Persist:       true,
+		MaxUpdateRate: 100,
+	})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	if gotMethod != stdhttp.MethodPost {
+		t.Errorf("method = %s, want POST", gotMethod)
+	}
+	if want := "/x-nmos/query/v1.3/subscriptions"; gotPath != want {
+		t.Errorf("path = %s, want %s", gotPath, want)
+	}
+	if gotCT != "application/json" {
+		t.Errorf("content-type = %q, want application/json", gotCT)
+	}
+	// The four keys IS-04 requires on a subscription request.
+	for _, k := range []string{"max_update_rate_ms", "resource_path", "params", "persist"} {
+		if _, ok := gotBody[k]; !ok {
+			t.Errorf("request body missing %q: %v", k, gotBody)
+		}
+	}
+	if got := gotBody["resource_path"]; got != "/senders" {
+		t.Errorf("resource_path = %v, want /senders (spec form, no trailing slash)", got)
+	}
+	if sub.ID != "sub-1" || !strings.HasSuffix(sub.WSHref, "/ws") {
+		t.Errorf("subscription = %+v", sub)
+	}
+}
+
+func TestSubscribeAddsLeadingSlash(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		var body map[string]any
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &body)
+		got, _ = body["resource_path"].(string)
+		w.WriteHeader(stdhttp.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"s","ws_href":"ws://x/ws"}`))
+	}))
+	defer srv.Close()
+
+	c, _ := query.NewClient(srv.URL, v13(t))
+	if _, err := c.Subscribe(context.Background(), query.SubscribeRequest{ResourcePath: "senders/"}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	if got != "/senders" {
+		t.Errorf("resource_path = %q, want /senders (leading slash added, trailing removed)", got)
+	}
+}
+
+func TestSubscribeAcceptsExistingSubscription(t *testing.T) {
+	// A Registry may answer 200 with an existing subscription rather than 201.
+	srv := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, _ *stdhttp.Request) {
+		w.WriteHeader(stdhttp.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"existing","ws_href":"ws://x/ws"}`))
+	}))
+	defer srv.Close()
+
+	c, _ := query.NewClient(srv.URL, v13(t))
+	sub, err := c.Subscribe(context.Background(), query.SubscribeRequest{ResourcePath: "/nodes/"})
+	if err != nil {
+		t.Fatalf("200 must be accepted: %v", err)
+	}
+	if sub.ID != "existing" {
+		t.Errorf("id = %q, want existing", sub.ID)
+	}
+}
+
+func TestSubscribeRejects(t *testing.T) {
+	t.Run("no resource path", func(t *testing.T) {
+		c, _ := query.NewClient("http://example.invalid", v13(t))
+		if _, err := c.Subscribe(context.Background(), query.SubscribeRequest{}); err == nil {
+			t.Error("empty resource_path must be rejected")
+		}
+	})
+
+	t.Run("no ws_href", func(t *testing.T) {
+		srv := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, _ *stdhttp.Request) {
+			w.WriteHeader(stdhttp.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":"s","resource_path":"/nodes/"}`))
+		}))
+		defer srv.Close()
+		c, _ := query.NewClient(srv.URL, v13(t))
+		_, err := c.Subscribe(context.Background(), query.SubscribeRequest{ResourcePath: "/nodes/"})
+		if !errors.Is(err, query.ErrNoWSHref) {
+			t.Errorf("err = %v, want ErrNoWSHref — a subscription with no endpoint is useless", err)
+		}
+	})
+
+	t.Run("server error", func(t *testing.T) {
+		srv := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, _ *stdhttp.Request) {
+			w.WriteHeader(stdhttp.StatusInternalServerError)
+		}))
+		defer srv.Close()
+		c, _ := query.NewClient(srv.URL, v13(t))
+		if _, err := c.Subscribe(context.Background(), query.SubscribeRequest{ResourcePath: "/nodes/"}); err == nil {
+			t.Error("500 must be an error")
+		}
+	})
+
+	t.Run("malformed body", func(t *testing.T) {
+		srv := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, _ *stdhttp.Request) {
+			w.WriteHeader(stdhttp.StatusCreated)
+			_, _ = w.Write([]byte(`{`))
+		}))
+		defer srv.Close()
+		c, _ := query.NewClient(srv.URL, v13(t))
+		if _, err := c.Subscribe(context.Background(), query.SubscribeRequest{ResourcePath: "/nodes/"}); err == nil {
+			t.Error("undecodable body must be an error")
+		}
+	})
+}
+
+func TestWatchRejectsBadInput(t *testing.T) {
+	if err := query.Watch(context.Background(), "", func(*is04.Grain) error { return nil }, query.WatchOptions{}); !errors.Is(err, query.ErrNoWSHref) {
+		t.Errorf("empty ws_href: err = %v, want ErrNoWSHref", err)
+	}
+	if err := query.Watch(context.Background(), "ws://example.invalid/ws", nil, query.WatchOptions{}); err == nil {
+		t.Error("nil GrainFunc must be rejected")
+	}
+}
+
+func TestWatchDialFailureIsReported(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err := query.Watch(ctx, "ws://127.0.0.1:1/ws", func(*is04.Grain) error { return nil }, query.WatchOptions{})
+	if err == nil {
+		t.Fatal("dialling a closed port must fail")
+	}
+	if !strings.Contains(err.Error(), "dial") {
+		t.Errorf("err = %v, want it to name the dial failure", err)
+	}
+}


### PR DESCRIPTION
## What

IS-04 Query API WebSocket subscription client, and the `dhs consumer nmos watch` verb that uses it.

## Why

**IS-04 defines exactly one push surface: the Query API WebSocket subscription.** A Node publishes no resource changes of its own, so "monitor what is happening in the plant" means subscribing to a Registry. Our registry has served subscriptions all along — nothing could consume them.

Closes #830

## Scope

- [x] osc / tsl / cerebrum-nb / amwa

## Reference controller

- [x] N/A (client-side addition; no change to what we serve)

## Type

- [x] feat — new feature

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `internal/amwa/codec/is04/grain.go` | new | IS-04 §5.2 grain envelope; `Kind()`, `Label()`, `DecodeGrain` |
| `internal/amwa/codec/is04/grain_test.go` | new | change-kind table, label fallback, decode + `ErrNotGrain` |
| `internal/amwa/session/query/watch.go` | new | `Subscribe()` + `Watch()` |
| `internal/amwa/session/query/watch_test.go` | new | request shape, 200-vs-201, missing `ws_href`, dial failure |
| `cmd/dhs/cmd_nmos.go` | modified | `consumer nmos watch` |

## Design decisions

**Change kind comes from which side is present, not from a type field** — that is how IS-04 encodes it: `post` only = added, both = modified, `pre` only = removed. A row with neither is reported `unknown` rather than guessed at.

**A non-grain frame is skipped, not fatal.** A peer sending something else on the subscription socket is a deviation; dropping the whole stream over it would lose everything that follows.

**Either `resource_path` spelling is accepted, the spec form is sent** — see the defect below.

## Defect found while building this

IS-04 spells `resource_path` **without** a trailing slash (`/nodes`). Our registry matches the exact string, so subscribing to `/nodes/` succeeds and then delivers **nothing, forever**. Caught only by running against the live registry — the unit tests were happy.

Our registry **accepts** the invalid form instead of rejecting it, which is a second, separate defect. Filed rather than fixed here to keep this unit reviewable.

## Test results

| Suite | Result |
|-------|--------|
| `go test ./internal/amwa/... ./cmd/...` | pass |
| `go vet ./...` | clean |
| `golangci-lint` | clean |
| `gofmt -l` | clean |

## Device tested

- [x] Fleet producer — registry on `dhs-rocky`, node on `dhs-ubuntu`, controller on `dhs-tools`

**Live output** — the node was stopped mid-watch, GC-evicted after the 12 s heartbeat timeout, then restarted:

```text
Registry http://10.100.0.103:8235 (api_ver=v1.3, spec=v1.3.3)
Subscribed /nodes -> ws://10.100.0.103:8235/x-nmos/query/v1.3/subscriptions/27a69f25-.../ws
modified nodes  2c47bf5e-1b2c-4abc-9def-deadbeef0001 dhs-test-node
removed  nodes  2c47bf5e-1b2c-4abc-9def-deadbeef0001 dhs-test-node
added    nodes  2c47bf5e-1b2c-4abc-9def-deadbeef0001 dhs-test-node
3 grain(s), 3 change row(s)
```

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [x] Integration tested on VM before PR

## Approval

@yboujraf — requesting review