### PR TITLE
feat(nmos): consumer nmos export - plant capture in Go (#837)

### DIFF
--- a/cmd/dhs/cmd_nmos.go
+++ b/cmd/dhs/cmd_nmos.go
@@ -50,10 +50,12 @@ func runNMOSConsumer(ctx context.Context, args []string) error {
 		return runNMOSWalk(ctx, rest)
 	case "events":
 		return runNMOSEventsConsumer(ctx, rest)
+	case "export":
+		return runNMOSExport(ctx, rest)
 	case "audit":
 		return runNMOSAudit(ctx, rest)
 	}
-	return fmt.Errorf("consumer nmos: unknown verb %q (expected: discover, system, walk, events, audit)", verb)
+	return fmt.Errorf("consumer nmos: unknown verb %q (expected: discover, system, walk, events, export, audit)", verb)
 }
 
 // runNMOSProducer dispatches `dhs producer nmos <verb> [args]`.
@@ -576,6 +578,29 @@ JSON Schema, prints the parsed fields.
   --direct host:port    Skip discovery; fetch /global directly from this peer
   --api-ver V           Requested IS-09 version (default v1.0)
   --api-proto P         Requested protocol filter (default http)
+
+export — capture a device, or a registry and every node it lists, into the
+layout the audit verb reads. Failures are recorded, never worked around: a
+502, a stuck paging cursor or an unreachable node all land in report.txt and
+the walk continues.
+  --target host:port    Device or registry to capture (required)
+  --out DIR             Output directory (default nmos-export)
+  --https               Use TLS
+  --deep                Also fetch staged / constraints / transporttype per IS-05 endpoint
+  --all-versions        Walk every minor of every API
+  --no-sdp              Skip SDP retrieval
+  --raw                 Also keep every verbatim response body under raw/
+                        (tree.json already holds them; raw/ was 14,719 of
+                        27,299 files on a real plant, and every path that
+                        exceeded the Windows 260-character limit)
+  --max-nodes N         Cap how many registered nodes to follow (0 = no cap)
+  --workers N           Capture N nodes at once (default 6)
+  --page-limit N        Resources per Query API page (default 100). A registry
+                        may clamp it; the applied value is on the PAGING line
+                        in report.txt
+  --timeout DURATION    Per-request deadline (default 10s)
+  --no-stamp            Name folders without a timestamp
+  --quiet / --json      Suppress progress / print the summary as JSON
 
 audit — compliance-audit a captured plant, offline. Reads an export directory
 (device.json + tree.json + report.txt + raw/ + sdp/ per device, nested under

--- a/cmd/dhs/cmd_nmos_export.go
+++ b/cmd/dhs/cmd_nmos_export.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"dhs/internal/amwa/session/export"
+)
+
+// runNMOSExport implements `dhs consumer nmos export`.
+//
+// It captures a device — or a registry together with every node it
+// lists — into the on-disk layout `dhs consumer nmos audit` reads. The
+// two verbs are one workflow: capture on the customer's network, audit
+// anywhere.
+//
+// The capture never repairs what it finds. A 502, a stuck paging
+// cursor, a node that answers nowhere: each is recorded and the walk
+// continues. Those recordings are what the audit turns into findings,
+// and it can only do that if the capture did not quietly paper over
+// them first.
+func runNMOSExport(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("consumer nmos export", flag.ContinueOnError)
+	var (
+		target   = fs.String("target", "", "device or registry to capture, as host:port (required)")
+		out      = fs.String("out", "nmos-export", "output directory")
+		https    = fs.Bool("https", false, "use TLS")
+		deep     = fs.Bool("deep", false, "also fetch staged / constraints / transporttype per IS-05 endpoint")
+		allVers  = fs.Bool("all-versions", false, "walk every minor of every API")
+		noSDP    = fs.Bool("no-sdp", false, "skip SDP retrieval")
+		raw      = fs.Bool("raw", false, "also keep the verbatim response body of every request under raw/ (tree.json already holds them)")
+		maxNodes = fs.Int("max-nodes", 0, "cap how many registered nodes to follow (0 = no cap)")
+		workers  = fs.Int("workers", 0, "how many nodes to capture at once (default 6)")
+		pageLim  = fs.Int("page-limit", 0, "resources per Query API page to ask for (default 100); a registry may clamp it and reports the applied value in X-Paging-Limit")
+		timeout  = fs.Duration("timeout", 10*time.Second, "per-request deadline")
+		noStamp  = fs.Bool("no-stamp", false, "name folders without a timestamp")
+		quiet    = fs.Bool("quiet", false, "suppress progress output")
+		jsonOut  = fs.Bool("json", false, "print the capture summary as JSON")
+	)
+
+	// Lift a bare positional before parsing: Go's flag package stops at
+	// the first non-flag argument, so `export 10.0.0.1:8080 --deep`
+	// would otherwise parse no flags at all.
+	positional := ""
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		positional, args = args[0], args[1:]
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() > 0 {
+		return fmt.Errorf("consumer nmos export: unexpected argument %q (one target only)", fs.Arg(0))
+	}
+	if *target == "" {
+		*target = positional
+	} else if positional != "" {
+		return fmt.Errorf("consumer nmos export: target given twice (%q and --target %q)", positional, *target)
+	}
+	if *target == "" {
+		return fmt.Errorf("consumer nmos export: --target is required (host:port of the device or registry)")
+	}
+
+	opts := export.Options{
+		Target:      *target,
+		Out:         *out,
+		HTTPS:       *https,
+		Deep:        *deep,
+		AllVersions: *allVers,
+		NoSDP:       *noSDP,
+		Raw:         *raw,
+		MaxNodes:    *maxNodes,
+		Workers:     *workers,
+		PageLimit:   *pageLim,
+		Timeout:     *timeout,
+		NoStamp:     *noStamp,
+	}
+	if !*quiet {
+		opts.Log = func(s string) { fmt.Fprintln(os.Stderr, s) }
+	}
+
+	res, err := export.Run(ctx, opts)
+	if err != nil {
+		return err
+	}
+
+	if *jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(res)
+	}
+
+	total := totalOfCapture(res)
+	fmt.Printf("captured %s (%s) -> %s\n", res.Target, res.Role, res.Dir)
+	if len(res.Followed) > 0 {
+		fmt.Printf("  %d node(s) listed, %d followed\n", res.NodesSeen, len(res.Followed))
+	}
+	fmt.Printf("  %d request(s), %d failure(s), %d SDP file(s)\n", total.requests, total.failures, total.sdp)
+	fmt.Printf("\naudit it with:\n  dhs consumer nmos audit --dir %s\n", *out)
+	return nil
+}
+
+type captureTotals struct{ requests, failures, sdp int }
+
+// totalOfCapture adds up a capture and everything it followed, so the line
+// an operator reads describes the plant rather than just its registry.
+func totalOfCapture(r *export.Result) captureTotals {
+	t := captureTotals{r.Requests, r.Failures, r.SDPFiles}
+	for i := range r.Followed {
+		sub := totalOfCapture(&r.Followed[i])
+		t.requests += sub.requests
+		t.failures += sub.failures
+		t.sdp += sub.sdp
+	}
+	return t
+}

--- a/cmd/dhs/cmd_nmos_export_audit_test.go
+++ b/cmd/dhs/cmd_nmos_export_audit_test.go
@@ -1,0 +1,291 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"dhs/internal/amwa/audit"
+	"dhs/internal/amwa/session/export"
+)
+
+// The export verb writes a layout; the audit verb reads it. Nothing in
+// either package forces the two to agree — a rename on one side would
+// silently produce empty audits. This test is that force: it captures a
+// fake plant built with known defects and asserts the audit finds them.
+//
+// It also proves the pair end-to-end without hardware, which is what
+// makes the workflow runnable in CI.
+
+// fakeDevice serves a scripted NMOS surface over httptest.
+type fakeDevice struct {
+	paths map[string]any
+	pages map[string][][]any
+}
+
+func newFake() *fakeDevice {
+	return &fakeDevice{paths: map[string]any{}, pages: map[string][][]any{}}
+}
+
+func (f *fakeDevice) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if chunks, ok := f.pages[r.URL.Path]; ok {
+		idx := 0
+		if s := r.URL.Query().Get("paging.until"); s != "" {
+			_, _ = fmt.Sscanf(s, "%d", &idx)
+		}
+		if idx >= len(chunks) {
+			idx = len(chunks) - 1
+		}
+		if idx < len(chunks)-1 {
+			w.Header().Set("Link", fmt.Sprintf(`<%s?paging.until=%d>; rel="prev"`, r.URL.Path, idx+1))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(chunks[idx])
+		return
+	}
+	body, ok := f.paths[r.URL.Path]
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	// A sender that 502s on its transport file is a real, observed
+	// device behaviour, and one the audit must report as a fault rather
+	// than as an absent endpoint.
+	if s, isStr := body.(string); isStr && s == "502" {
+		http.Error(w, "bad gateway", http.StatusBadGateway)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func rsrc(id, label string, over map[string]any) map[string]any {
+	m := map[string]any{"id": id, "version": "1755000000:0", "label": label, "tags": map[string]any{}}
+	for k, v := range over {
+		m[k] = v
+	}
+	return m
+}
+
+const (
+	nodeAID   = "11111111-1111-4111-8111-111111111111"
+	nodeBID   = "22222222-2222-4222-8222-222222222222"
+	ghostID   = "33333333-3333-4333-8333-333333333333"
+	devAID    = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+	senderAID = "44444444-4444-4444-8444-444444444444"
+	senderBID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+)
+
+// buildNode serves a node whose sender is master-enabled and emitting
+// to the group passed in — the same group for both nodes, so the plant
+// has a collision no single device can see.
+func buildNode(t *testing.T, id, label, senderID, group string) *httptest.Server {
+	t.Helper()
+	f := newFake()
+	f.paths["/x-nmos"] = []string{"node/", "connection/"}
+	f.paths["/x-nmos/node/"] = []string{"v1.3/"}
+	f.paths["/x-nmos/node/v1.3/self"] = rsrc(id, label, nil)
+	f.paths["/x-nmos/node/v1.3/devices"] = []any{
+		rsrc(devAID, label+" device", map[string]any{
+			"type": "urn:x-nmos:device:generic", "node_id": id,
+			"senders": []any{}, "receivers": []any{},
+			// No sr-ctrl control, though the Connection API is served:
+			// a controller walking controls[] never finds IS-05 here.
+			"controls": []any{},
+		}),
+	}
+	for _, r := range []string{"sources", "flows", "receivers"} {
+		f.paths["/x-nmos/node/v1.3/"+r] = []any{}
+	}
+	f.paths["/x-nmos/node/v1.3/senders"] = []any{
+		rsrc(senderID, label+" out", map[string]any{
+			"transport": "urn:x-nmos:transport:rtp.mcast", "device_id": devAID,
+			// A flow that is not published: the controller drops the
+			// whole branch.
+			"flow_id":            "99999999-9999-4999-8999-999999999999",
+			"manifest_href":      "/x-nmos/connection/v1.1/single/senders/" + senderID + "/transportfile",
+			"interface_bindings": []string{"eth0", "eth1"},
+			"subscription":       map[string]any{"receiver_id": nil, "active": true},
+		}),
+	}
+	f.paths["/x-nmos/connection/"] = []string{"v1.1/"}
+	f.paths["/x-nmos/connection/v1.1/single/senders"] = []string{senderID + "/"}
+	f.paths["/x-nmos/connection/v1.1/single/receivers"] = []any{}
+	f.paths["/x-nmos/connection/v1.1/bulk"] = []any{}
+	f.paths["/x-nmos/connection/v1.1/single/senders/"+senderID+"/active"] = map[string]any{
+		"master_enable": true,
+		"transport_params": []any{
+			map[string]any{"destination_ip": group, "destination_port": 20000, "rtp_enabled": true},
+		},
+	}
+	// The transport file is broken.
+	f.paths["/x-nmos/connection/v1.1/single/senders/"+senderID+"/transportfile"] = "502"
+
+	srv := httptest.NewServer(f)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestExportThenAuditFindsPlantedDefects(t *testing.T) {
+	nodeA := buildNode(t, nodeAID, "cam-01", senderAID, "233.252.0.20")
+	nodeB := buildNode(t, nodeBID, "mv-01", senderBID, "233.252.0.20")
+
+	// A node that registered and then died. Starting a server and
+	// closing it gives an address that refuses connections immediately,
+	// which is what a dead device on a reachable network looks like —
+	// and keeps the test fast, unlike an address that black-holes.
+	dead := httptest.NewServer(newFake())
+	deadURL := dead.URL
+	dead.Close()
+
+	reg := newFake()
+	reg.paths["/x-nmos"] = []string{"query/", "registration/"}
+	reg.paths["/x-nmos/query/"] = []string{"v1.1/", "v1.3/"}
+	reg.paths["/x-nmos/registration/"] = []string{"v1.3/"}
+	reg.paths["/x-nmos/registration/v1.3/"] = []string{"health/", "resource/"}
+	for _, r := range []string{"devices", "sources", "flows", "senders", "receivers", "subscriptions"} {
+		reg.paths["/x-nmos/query/v1.1/"+r] = []any{}
+		reg.paths["/x-nmos/query/v1.3/"+r] = []any{}
+	}
+	// v1.1 lists all three, across two pages. One of them answers
+	// nowhere, and v1.3 hides two of them.
+	reg.pages["/x-nmos/query/v1.1/nodes"] = [][]any{
+		{
+			rsrc(nodeAID, "cam-01", map[string]any{"href": nodeA.URL + "/"}),
+			rsrc(nodeBID, "mv-01", map[string]any{"href": nodeB.URL + "/"}),
+		},
+		{rsrc(ghostID, "legacy-gw", map[string]any{"href": deadURL + "/"})},
+	}
+	reg.paths["/x-nmos/query/v1.3/nodes"] = []any{
+		rsrc(nodeAID, "cam-01", map[string]any{"href": nodeA.URL + "/"}),
+	}
+	regSrv := httptest.NewServer(reg)
+	defer regSrv.Close()
+
+	dir := t.TempDir()
+	res, err := export.Run(context.Background(), export.Options{
+		Target:  strings.TrimPrefix(regSrv.URL, "http://"),
+		Out:     dir,
+		Timeout: 2 * time.Second,
+		NoStamp: true,
+	})
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	// Paging is what makes this three rather than two.
+	if res.NodesSeen != 3 {
+		t.Fatalf("exported %d nodes, want 3", res.NodesSeen)
+	}
+
+	harvests, err := audit.Load(dir)
+	if err != nil {
+		t.Fatalf("audit could not read what export wrote: %v", err)
+	}
+	got := audit.Run(harvests, audit.Options{})
+
+	seen := map[string]int{}
+	for _, f := range got.Findings {
+		seen[f.Code]++
+	}
+
+	// Each of these is a defect the fake plant was deliberately built
+	// with. A miss means export and audit have drifted apart.
+	for _, want := range []string{
+		"NMOS-PLANT-MCAST-COLLISION",   // both nodes on 233.252.0.20:20000
+		"NMOS-QUERY-VERSION-ISOLATION", // 3 nodes at v1.1, 1 at v1.3
+		"NMOS-NODE-UNREACHABLE",        // legacy-gw answers nowhere
+		"NMOS-HTTP-SERVER-FAULT",       // 502 on the transport files
+		"NMOS-IS04-DANGLING-REF",       // sender points at an unpublished flow
+		"NMOS-IS04-CONTROL-MISSING",    // IS-05 served, no sr-ctrl control
+		"NMOS-2022-7-SINGLE-LEG",       // two NICs bound, one leg staged
+	} {
+		if seen[want] == 0 {
+			t.Errorf("audit did not report %s\n  reported: %v", want, seen)
+		}
+	}
+
+	// The plant is a registry plus the two nodes it could reach.
+	if len(got.Inventory) != 3 {
+		t.Errorf("inventory has %d devices, want 3", len(got.Inventory))
+	}
+	if worst, any := got.Worst(); !any || worst != audit.SevCritical {
+		t.Errorf("worst = %s,%v; this plant has critical defects", worst, any)
+	}
+}
+
+// TestExportVerbRejectsBadArguments covers the CLI wrapper's own rules.
+func TestExportVerbRejectsBadArguments(t *testing.T) {
+	ctx := context.Background()
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"no target", nil},
+		{"target twice", []string{"h:1", "--target", "h:2"}},
+		{"extra positional", []string{"--target", "h:1", "--", "extra"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := runNMOSExport(ctx, tc.args); err == nil {
+				t.Error("expected an error")
+			}
+		})
+	}
+}
+
+// TestAuditVerbRejectsBadArguments does the same for the audit wrapper,
+// including the flag-after-positional trap.
+func TestAuditVerbRejectsBadArguments(t *testing.T) {
+	ctx := context.Background()
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"no dir", nil},
+		{"dir twice", []string{"a", "--dir", "b"}},
+		{"bad severity", []string{"--dir", t.TempDir(), "--min-severity", "loud"}},
+		{"bad fail-on", []string{"--dir", t.TempDir(), "--fail-on", "loud"}},
+		{"missing dir", []string{"--dir", "no-such-directory-anywhere"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := runNMOSAudit(ctx, tc.args); err == nil {
+				t.Error("expected an error")
+			}
+		})
+	}
+}
+
+// TestAuditVerbFormats proves each output format is wired, and that
+// --fail-on gates while a plain run does not.
+func TestAuditVerbFormats(t *testing.T) {
+	ctx := context.Background()
+	dir := "../../internal/amwa/audit/testdata/plant"
+	out := t.TempDir()
+
+	for _, format := range []string{"text", "json", "jsonl"} {
+		if err := runNMOSAudit(ctx, []string{"--dir", dir, "--format", format, "--out", out + "/r." + format}); err != nil {
+			t.Errorf("--format %s: %v", format, err)
+		}
+	}
+	if err := runNMOSAudit(ctx, []string{"--dir", dir, "--format", "yaml", "--out", out + "/x"}); err == nil {
+		t.Error("an unknown format should be rejected")
+	}
+
+	// Reporting is not failing: without --fail-on a plant with critical
+	// defects still exits cleanly.
+	if err := runNMOSAudit(ctx, []string{"--dir", dir, "--out", out + "/plain"}); err != nil {
+		t.Errorf("a plain audit should not fail: %v", err)
+	}
+	if err := runNMOSAudit(ctx, []string{"--dir", dir, "--fail-on", "critical", "--out", out + "/gated"}); err == nil {
+		t.Error("--fail-on critical should have failed on this plant")
+	}
+	// Filtering the report does not change the verdict: --min-severity
+	// decides what is printed, --fail-on decides whether it fails.
+	if err := runNMOSAudit(ctx, []string{"--dir", dir, "--min-severity", "critical", "--fail-on", "critical", "--out", out + "/crit"}); err == nil {
+		t.Error("the gate should fire on a plant with criticals")
+	}
+}

--- a/internal/amwa/session/export/export.go
+++ b/internal/amwa/session/export/export.go
@@ -1,0 +1,1245 @@
+// Package export captures a live NMOS plant to disk.
+//
+// The output is the input to the offline audit: one folder per device,
+// holding the resources it published, the SDP it serves, and a line per
+// request recording what answered. A registry is captured together with
+// every node it lists, nested, so one export is one plant.
+//
+// The capture is deliberately dumb about meaning. It follows what the
+// device says — `manifest_href` verbatim, the version list verbatim,
+// paging cursors verbatim — and records failures rather than working
+// around them. Interpretation is the audit's job, and it can only do
+// that job if the capture did not quietly repair anything first.
+package export
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Version identifies the exporter in device.json, so a capture can be
+// tied to the code that produced it.
+const Version = "dhs-export/1"
+
+// defaultPageLimit is what we ask a Query API for per page. Registries
+// left to their own default have been seen serving ten.
+const defaultPageLimit = 100
+
+// Options configures one capture.
+type Options struct {
+	// Target is the `host:port` to capture.
+	Target string
+	// Out is the directory harvests are written under. Each device gets
+	// its own folder inside it; nothing is ever written to Out itself.
+	Out string
+	// HTTPS selects the scheme.
+	HTTPS bool
+	// Deep also fetches staged, constraints and transporttype for every
+	// IS-05 endpoint. Off by default: on a 176-sender device it is four
+	// requests per endpoint instead of one.
+	Deep bool
+	// AllVersions walks every minor of every API. Off by default,
+	// because a node repeats identical resources at each minor — but a
+	// registry's query API is walked at every minor regardless, since
+	// version isolation means the minors genuinely differ there.
+	AllVersions bool
+	// NoSDP skips SDP retrieval.
+	NoSDP bool
+	// MaxNodes caps how many registered nodes a registry capture
+	// follows. Zero means no cap.
+	MaxNodes int
+	// Timeout is the per-request deadline.
+	Timeout time.Duration
+	// PageLimit is the `paging.limit` asked for on every Query API
+	// collection. Zero uses defaultPageLimit. Registries may clamp it
+	// and report the applied value in X-Paging-Limit.
+	PageLimit int
+	// Raw keeps the verbatim response body of every request under
+	// `raw/`. Off by default: tree.json already stores each body as
+	// json.RawMessage, so raw/ duplicates it — and on a real 44-node
+	// plant it was 14,719 of the 27,299 files and held every single
+	// path over the Windows 260-character limit. Turn it on when the
+	// exact bytes matter, e.g. a non-JSON response or a byte-level
+	// diff.
+	Raw bool
+	// NoStamp names folders without a timestamp, so a capture can be
+	// re-run into a stable path.
+	NoStamp bool
+	// Now supplies the folder timestamp. Tests set it to keep output
+	// paths deterministic.
+	Now func() time.Time
+	// Log receives progress lines. Nil discards them.
+	Log func(string)
+	// Client overrides the HTTP client.
+	Client *http.Client
+	// Workers is how many nodes a registry capture follows at once.
+	// Zero uses defaultWorkers. Each node is ~600 requests against a
+	// different device, so the walk is latency-bound and parallelises
+	// almost perfectly; 44 nodes took four minutes in series.
+	Workers int
+}
+
+// defaultWorkers is deliberately modest. The limit is not our CPU, it
+// is how many simultaneous HTTP sessions a plant's devices and switches
+// tolerate from one host — and an export must never be the thing that
+// disturbs a live plant.
+const defaultWorkers = 6
+
+func (o Options) workers() int {
+	if o.Workers > 0 {
+		return o.Workers
+	}
+	return defaultWorkers
+}
+
+// visitTracker claims each target exactly once across the worker pool,
+// so a registry that lists the same device twice — or a node that lists
+// itself — is captured once.
+type visitTracker struct {
+	mu   sync.Mutex
+	seen map[string]bool
+}
+
+func newVisitTracker() *visitTracker { return &visitTracker{seen: map[string]bool{}} }
+
+// claim returns true when the caller is the first to take this target.
+func (v *visitTracker) claim(target string) bool {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if v.seen[target] {
+		return false
+	}
+	v.seen[target] = true
+	return true
+}
+
+func (o *Options) defaults() {
+	if o.Out == "" {
+		o.Out = "nmos-export"
+	}
+	if o.Timeout <= 0 {
+		o.Timeout = 10 * time.Second
+	}
+	if o.Now == nil {
+		o.Now = time.Now
+	}
+	if o.Log == nil {
+		o.Log = func(string) {}
+	}
+	if o.Client == nil {
+		o.Client = &http.Client{Timeout: o.Timeout}
+	}
+}
+
+// Result reports where a capture landed and what it found.
+type Result struct {
+	Dir       string              `json:"dir"`
+	Target    string              `json:"target"`
+	Role      string              `json:"role"`
+	Label     string              `json:"label,omitempty"`
+	ID        string              `json:"id,omitempty"`
+	Hostname  string              `json:"hostname,omitempty"`
+	APIs      map[string][]string `json:"apis,omitempty"`
+	Requests  int                 `json:"requests"`
+	Failures  int                 `json:"failures"`
+	SDPFiles  int                 `json:"sdp_files"`
+	NodesSeen int                 `json:"nodes_seen,omitempty"`
+	Followed  []Result            `json:"followed,omitempty"`
+}
+
+// Run captures Target and, when it is a registry, every node it lists.
+func Run(ctx context.Context, opts Options) (*Result, error) {
+	opts.defaults()
+	if opts.Target == "" {
+		return nil, fmt.Errorf("export: --target is required")
+	}
+	if err := os.MkdirAll(opts.Out, 0o755); err != nil {
+		return nil, fmt.Errorf("export: %w", err)
+	}
+	res, err := capture(ctx, opts, opts.Out, opts.Target, newVisitTracker())
+	if err != nil || res == nil {
+		return res, err
+	}
+	// The manifest is the index someone opens first: which device is in
+	// which folder, at which address, under which name. It is written
+	// last so it carries the final folder names, and it is what lets
+	// those names stay short.
+	if err := writeManifest(opts.Out, res, opts); err != nil {
+		return nil, fmt.Errorf("export: writing manifest: %w", err)
+	}
+	return res, nil
+}
+
+// resource sets, in the order the specs define them.
+var (
+	nodeResources  = []string{"self", "devices", "sources", "flows", "senders", "receivers"}
+	queryResources = []string{"nodes", "devices", "sources", "flows", "senders", "receivers", "subscriptions"}
+	// standardAPIs is the fallback probe list for a device that serves
+	// no /x-nmos root. Some do not; the APIs are still there.
+	standardAPIs = []string{"node", "connection", "channelmapping", "system", "query", "registration", "events"}
+)
+
+// capture harvests one device into its own folder under root.
+func capture(ctx context.Context, opts Options, root, target string, visited *visitTracker) (*Result, error) {
+	return captureAt(ctx, opts, root, target, visited, false)
+}
+
+func captureAt(ctx context.Context, opts Options, root, target string, visited *visitTracker, nested bool) (*Result, error) {
+	if !visited.claim(target) {
+		return nil, nil
+	}
+
+	h := &harvester{opts: opts, target: target, scheme: "http", nested: nested}
+	if opts.HTTPS {
+		h.scheme = "https"
+	}
+
+	dir, err := h.makeDir(root)
+	if err != nil {
+		return nil, err
+	}
+	h.dir = dir
+	opts.Log(fmt.Sprintf("capturing %s -> %s", target, dir))
+
+	// Identity first, so an interrupted capture still leaves an
+	// attributable folder rather than an anonymous pile of JSON.
+	if err := h.writeDevice("in-progress"); err != nil {
+		return nil, err
+	}
+
+	h.walk(ctx)
+
+	// Now that the device has named itself, put that name in the folder.
+	// `10_41_40_80_3000` tells an operator nothing six months later;
+	// `10_41_40_80_3000__bm-n-nnbrg-t01` is the thing they search for.
+	// Renaming here, before any node is followed, keeps children nested
+	// under the final path.
+	if err := h.renameWithIdentity(); err != nil {
+		return nil, err
+	}
+
+	if err := h.writeTree(); err != nil {
+		return nil, err
+	}
+	if err := h.writeDevice(h.role); err != nil {
+		return nil, err
+	}
+	if err := h.writeReport(); err != nil {
+		return nil, err
+	}
+	if err := h.pruneEmptyDirs(); err != nil {
+		return nil, err
+	}
+
+	apis := map[string][]string{}
+	for name, a := range h.apis {
+		apis[name] = a.Versions
+	}
+	res := &Result{
+		Dir: h.dir, Target: target, Role: h.role, Label: h.label, ID: h.id,
+		Hostname: h.hostname, APIs: apis,
+		Requests: h.requests, Failures: h.failures, SDPFiles: h.sdpFiles,
+		NodesSeen: len(h.nodes),
+	}
+
+	// A registry capture is only a plant capture if the nodes come with
+	// it. Following them is what makes the cross-device checks possible.
+	if len(h.nodes) > 0 {
+		kids := filepath.Join(h.dir, "nodes")
+		if err := os.MkdirAll(kids, 0o755); err != nil {
+			return nil, err
+		}
+		// Nodes are captured concurrently. Each one is ~600 requests
+		// against a different device, so the walk is latency-bound and
+		// entirely parallel — 44 nodes took four minutes in series.
+		// The cap is per plant, not per device, so a slow node delays
+		// only itself.
+		todo := h.nodes
+		capped := 0
+		if opts.MaxNodes > 0 && len(todo) > opts.MaxNodes {
+			capped = len(todo) - opts.MaxNodes
+			todo = todo[:opts.MaxNodes]
+		}
+
+		subs := make([]*Result, len(todo))
+		errs := make([]error, len(todo))
+		sem := make(chan struct{}, opts.workers())
+		var wg sync.WaitGroup
+
+		for i, n := range todo {
+			addr := hostPortOf(n.Href)
+			if addr == "" {
+				h.note(fmt.Sprintf("SKIP  node %s '%s' unreachable at: (no usable href)", n.ID, n.Label))
+				continue
+			}
+			wg.Add(1)
+			go func(i int, n nodeRef, addr string) {
+				defer wg.Done()
+				sem <- struct{}{}
+				defer func() { <-sem }()
+				opts.Log(fmt.Sprintf("[%d/%d] %s '%s'", i+1, len(todo), addr, n.Label))
+				subs[i], errs[i] = captureAt(ctx, opts, kids, addr, visited, true)
+			}(i, n, addr)
+		}
+		wg.Wait()
+
+		followed := 0
+		for i, sub := range subs {
+			if errs[i] != nil {
+				return nil, errs[i]
+			}
+			if sub == nil {
+				continue
+			}
+			n := todo[i]
+			addr := hostPortOf(n.Href)
+			// A node that answered nothing at all is not a device with
+			// an empty tree — it is a registration pointing at
+			// something that is gone. Leaving the folder behind would
+			// audit as a fourth device with no APIs; recording the skip
+			// on the PARENT is what lets the audit see a registry
+			// advertising a node nobody can reach.
+			if sub.Requests == 0 {
+				if err := os.RemoveAll(sub.Dir); err != nil {
+					return nil, err
+				}
+				h.note(fmt.Sprintf("SKIP  node %s '%s' unreachable at: %s", n.ID, n.Label, addr))
+				continue
+			}
+			followed++
+			res.Followed = append(res.Followed, *sub)
+		}
+		if capped > 0 {
+			h.note(fmt.Sprintf("CAPPED %d node(s) not followed (--max-nodes %d)", capped, opts.MaxNodes))
+		}
+		h.note(fmt.Sprintf("SUMMARY %d listed / %d followed / %d capped", len(h.nodes), followed, capped))
+		// The report gains lines while nodes are followed, so it is
+		// rewritten once they are done.
+		if err := h.writeReport(); err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+// nodeRef is the little of a registry's node entry the exporter needs
+// in order to go and capture it.
+type nodeRef struct {
+	ID       string `json:"id"`
+	Label    string `json:"label"`
+	Href     string `json:"href"`
+	Hostname string `json:"hostname"`
+}
+
+// harvester holds the state of one device's capture.
+type harvester struct {
+	opts   Options
+	target string
+	scheme string
+	dir    string
+
+	role     string
+	label    string
+	hostname string
+	// nested marks a followed node: its folder sits inside a stamped
+	// registry folder, so it is not stamped again.
+	nested bool
+	id     string
+
+	apis  map[string]*apiCapture
+	nodes []nodeRef
+
+	report   []string
+	requests int
+	failures int
+	sdpFiles int
+	sdpSeen  map[string]bool
+	// sdpBySender remembers the first SDP seen for a sender so the
+	// second source can be compared against it rather than written
+	// beside it.
+	sdpBySender map[string]sdpRecord
+}
+
+// sdpRecord is one sender's SDP as fetched from one of its two
+// publication points.
+type sdpRecord struct {
+	source string // "is04" (manifest_href) or "is05" (transportfile)
+	body   []byte
+}
+
+type apiCapture struct {
+	Versions []string                              `json:"versions"`
+	Data     map[string]map[string]json.RawMessage `json:"data"`
+}
+
+func (h *harvester) note(s string) { h.report = append(h.report, s) }
+
+// makeDir builds the per-device folder. It refuses to write into the
+// output root: a harvest folder that IS the root leaves raw/ and sdp/
+// loose at the top with nothing identifying whose they are.
+func (h *harvester) makeDir(root string) (string, error) {
+	safe := sanitize(h.target)
+	if safe == "" {
+		return "", fmt.Errorf("export: target %q has no usable name", h.target)
+	}
+	// Only the top-level capture is stamped. A followed node already
+	// sits inside a stamped registry folder, so repeating it there adds
+	// 16 characters to every path below it and says nothing new.
+	name := safe
+	if !h.opts.NoStamp && !h.nested {
+		name = safe + "_" + h.opts.Now().Format("20060102-150405")
+	}
+	dir := filepath.Join(root, name)
+	rootAbs, _ := filepath.Abs(root)
+	dirAbs, _ := filepath.Abs(dir)
+	if rootAbs == dirAbs {
+		return "", fmt.Errorf("export: refusing to capture into the output root (%s)", root)
+	}
+	// raw/ and sdp/ are created lazily, when there is something to put
+	// in them, and pruned at the end if there is not.
+	return dir, os.MkdirAll(dir, 0o755)
+}
+
+// renameWithIdentity appends the device's own hostname and label to its
+// folder name.
+//
+// Both are appended because they are frequently different and both are
+// how someone searches: the hostname is what DNS and the switch know,
+// the label is what the operator typed. Identical values collapse to
+// one rather than being repeated.
+//
+// A rename that fails is not fatal — the capture is complete and
+// correct under the address-only name, and losing it over a locked
+// directory would be absurd.
+func (h *harvester) renameWithIdentity() error {
+	suffix := identitySuffix(h.hostname, h.label)
+	if suffix == "" {
+		return nil
+	}
+	parent, base := filepath.Split(strings.TrimRight(h.dir, string(filepath.Separator)))
+	target := filepath.Join(parent, base+"__"+suffix)
+	if target == h.dir {
+		return nil
+	}
+	if _, err := os.Stat(target); err == nil {
+		// Something is already there — two devices resolving to the same
+		// name. Keep the unambiguous address-only folder.
+		h.note(fmt.Sprintf("NOTE  folder not renamed to %q: a folder of that name already exists", base+"__"+suffix))
+		return nil
+	}
+	if err := os.Rename(h.dir, target); err != nil {
+		h.note(fmt.Sprintf("NOTE  folder not renamed: %v", err))
+		return nil
+	}
+	h.dir = target
+	return nil
+}
+
+// identitySuffix builds the filesystem-safe tail appended to a capture
+// folder.
+//
+// The folder carries just enough to recognise a device at a glance; the
+// FULL identity — hostname, label, id, address, APIs — lives in
+// manifest.json at the capture root. That split is deliberate: encoding
+// everything in the name produced 76-character folders, and with a
+// nested registry capture and a `raw/` filename on the end, 329 paths
+// on one real plant went past the Windows 260-character limit and the
+// capture could not be copied.
+//
+// The label is preferred because it is what an operator typed and what
+// they will search for; the hostname is the fallback and is in the
+// manifest either way.
+func identitySuffix(hostname, label string) string {
+	const maxPart = 24
+	for _, v := range []string{label, hostname} {
+		s := sanitize(v)
+		if s == "" {
+			continue
+		}
+		if len(s) > maxPart {
+			s = s[:maxPart]
+		}
+		return s
+	}
+	return ""
+}
+
+// walk performs the capture proper.
+func (h *harvester) walk(ctx context.Context) {
+	h.apis = map[string]*apiCapture{}
+	h.sdpSeen = map[string]bool{}
+	h.sdpBySender = map[string]sdpRecord{}
+	h.role = "unknown"
+
+	names, _ := h.getStrings(ctx, "/x-nmos")
+	if len(names) == 0 {
+		h.note("WARN  no /x-nmos root - probing the standard API names")
+		names = standardAPIs
+	}
+	sort.Strings(names)
+
+	for _, api := range names {
+		api = strings.TrimSuffix(api, "/")
+		if api == "" {
+			continue
+		}
+		vers, _ := h.getStrings(ctx, "/x-nmos/"+api+"/")
+		if len(vers) == 0 {
+			continue
+		}
+		for i := range vers {
+			vers[i] = strings.TrimSuffix(vers[i], "/")
+		}
+		cap := &apiCapture{Versions: vers, Data: map[string]map[string]json.RawMessage{}}
+		h.apis[api] = cap
+
+		// The query API is walked at EVERY minor. IS-04 isolates
+		// versions: a resource registered at v1.1 is not visible on a
+		// v1.3 query unless downgrade is requested. Collapsing to the
+		// highest minor loses whatever registered lower. Every other
+		// API repeats identical resources per minor, so there the
+		// highest is enough.
+		walk := vers
+		if !h.opts.AllVersions && len(vers) > 1 && api != "query" {
+			walk = []string{highest(vers)}
+			h.note(fmt.Sprintf("NOTE  %s : versions %s present, walking %s only (--all-versions for all)",
+				api, strings.Join(vers, ","), walk[0]))
+		}
+
+		for _, v := range walk {
+			h.opts.Log(fmt.Sprintf("  %s /x-nmos/%s/%s", h.target, api, v))
+			cap.Data[v] = h.walkAPI(ctx, api, v)
+		}
+	}
+
+	if h.role == "unknown" {
+		switch {
+		case h.apis["query"] != nil, h.apis["registration"] != nil:
+			h.role = "registry"
+		case h.apis["node"] != nil:
+			h.role = "node"
+		}
+	}
+}
+
+// walkAPI captures one API at one minor.
+func (h *harvester) walkAPI(ctx context.Context, api, v string) map[string]json.RawMessage {
+	base := "/x-nmos/" + api + "/" + v
+	bucket := map[string]json.RawMessage{}
+
+	switch api {
+	case "node":
+		for _, res := range nodeResources {
+			bucket[res] = h.get(ctx, base+"/"+res)
+		}
+		if self := bucket["self"]; len(self) > 0 {
+			var s nodeRef
+			if json.Unmarshal(self, &s) == nil && s.ID != "" {
+				h.role, h.label, h.id = "node", s.Label, s.ID
+				h.hostname = s.Hostname
+			}
+		}
+		if !h.opts.NoSDP {
+			h.fetchSenderManifests(ctx, bucket["senders"])
+		}
+
+	case "query":
+		h.role = "registry"
+		for _, res := range queryResources {
+			all := h.getPaged(ctx, base+"/"+res)
+			bucket[res] = all
+			if res == "nodes" {
+				h.collectNodes(all, v)
+			}
+		}
+
+	case "connection":
+		h.walkConnection(ctx, base, v, bucket)
+
+	case "channelmapping":
+		bucket["io"] = h.get(ctx, base+"/io")
+		bucket["map_active"] = h.get(ctx, base+"/map/active")
+		bucket["map_staged"] = h.get(ctx, base+"/map/staged")
+
+	case "system":
+		bucket["global"] = h.get(ctx, base+"/global")
+
+	default:
+		bucket["root"] = h.get(ctx, base+"/")
+	}
+	return bucket
+}
+
+// walkConnection captures the IS-05 surface for both sides.
+func (h *harvester) walkConnection(ctx context.Context, base, v string, bucket map[string]json.RawMessage) {
+	for _, side := range []string{"senders", "receivers"} {
+		ids, raw := h.getStrings(ctx, base+"/single/"+side)
+		bucket["single_"+side] = raw
+
+		subs := []string{"active"}
+		if h.opts.Deep {
+			subs = []string{"staged", "active", "constraints", "transporttype"}
+			// transporttype arrived in IS-05 v1.1. Asking a v1.0
+			// Connection API for it is a guaranteed 404 per endpoint —
+			// one live run produced 5,951 of them.
+			if v == "v1.0" {
+				subs = subs[:3]
+			}
+		}
+
+		// The IS-05 pass is the expensive half of a node: one request per
+		// endpoint per sub-resource, and a Neuron publishes 176 of each.
+		if len(ids) >= 25 {
+			h.opts.Log(fmt.Sprintf("    %s: IS-05 %s, %d endpoints x %d", h.target, side, len(ids), len(subs)))
+		}
+		for n, id := range ids {
+			id = strings.TrimSuffix(id, "/")
+			if id == "" {
+				continue
+			}
+			if len(ids) >= 100 && n > 0 && n%50 == 0 {
+				h.opts.Log(fmt.Sprintf("      %s: %s %d/%d", h.target, side, n, len(ids)))
+			}
+			for _, sub := range subs {
+				blob := h.get(ctx, base+"/single/"+side+"/"+id+"/"+sub)
+				bucket[side+"/"+id+"/"+sub] = blob
+				// A receiver's SDP is pushed into it by a controller and
+				// lives in transport_file.data. Empty means nothing is
+				// connected, which is not an error.
+				if data := embeddedSDP(blob); data != "" && !h.opts.NoSDP {
+					// A receiver's SDP was pushed INTO it by a controller,
+					// so it is neither the IS-04 nor the IS-05 sender
+					// publication — its own folder, keyed by receiver id.
+					h.writeSDP(filepath.Join("receivers", id+"_"+sub+".sdp"), []byte(data))
+					h.note(fmt.Sprintf("SDP   %s %s %s (embedded)", side, id, sub))
+				}
+			}
+			if side == "senders" && !h.opts.NoSDP {
+				h.fetchSDP(ctx, h.scheme+"://"+h.target+base+"/single/senders/"+id+"/transportfile",
+					id, "is05")
+			}
+		}
+	}
+	bucket["bulk"] = h.get(ctx, base+"/bulk")
+}
+
+// fetchSenderManifests follows each sender's manifest_href.
+//
+// IS-04 defines the SDP location ON THE SENDER RESOURCE. There is no
+// `/senders/{id}/transportfile` in IS-04 — that is IS-05 — and devices
+// place the manifest where they like. Following the field verbatim is
+// the only correct behaviour; constructing the URL instead produced
+// 1088 errors against a real device that serves its SDP at
+// `/x-nmos/node/v1.3/sdp/{id}`.
+func (h *harvester) fetchSenderManifests(ctx context.Context, blob json.RawMessage) {
+	var senders []struct {
+		ID           string  `json:"id"`
+		ManifestHref *string `json:"manifest_href"`
+	}
+	if json.Unmarshal(blob, &senders) != nil {
+		return
+	}
+	for _, s := range senders {
+		if s.ID == "" {
+			continue
+		}
+		if s.ManifestHref == nil || *s.ManifestHref == "" {
+			h.note(fmt.Sprintf("NOSDP sender %s has no manifest_href (legal for an inactive sender)", s.ID))
+			continue
+		}
+		h.fetchSDP(ctx, *s.ManifestHref, s.ID, "is04")
+	}
+}
+
+// collectNodes remembers every node a registry lists, deduplicated
+// across minors — the union across versions is the plant.
+func (h *harvester) collectNodes(blob json.RawMessage, v string) {
+	var list []nodeRef
+	if json.Unmarshal(blob, &list) != nil {
+		return
+	}
+	seen := map[string]bool{}
+	for _, n := range h.nodes {
+		seen[n.ID] = true
+	}
+	added := 0
+	for _, n := range list {
+		if n.ID == "" || seen[n.ID] {
+			continue
+		}
+		seen[n.ID] = true
+		h.nodes = append(h.nodes, n)
+		added++
+	}
+	h.note(fmt.Sprintf("VERSION %s nodes: %d listed, %d new (union so far %d)", v, len(list), added, len(h.nodes)))
+}
+
+// linkPrev matches the `rel="prev"` member of an RFC 5988 Link header
+// — the OLDER direction, which is the one that enumerates a collection.
+// See olderPage for why it is prev and not next.
+var linkPrev = regexp.MustCompile(`<([^>]+)>\s*;\s*rel\s*=\s*"?prev"?`)
+
+// getPaged walks a Query API collection to the end.
+//
+// Without this a registry serving 68 nodes in pages of 10 captures the
+// first 10 and reports a 10-node plant. The IS-04 paging contract is a
+// `Link: rel="next"` header; the cursor is opaque and must be followed
+// rather than reconstructed.
+func (h *harvester) getPaged(ctx context.Context, path string) json.RawMessage {
+	var all []json.RawMessage
+	next := h.scheme + "://" + h.target + path
+	seenCursor := map[string]bool{}
+
+	// Ask for a big page explicitly. Left to itself a registry applies
+	// its own default — seen as low as 10 in the field — and the walk
+	// then costs one round trip per ten resources.
+	limit := h.opts.PageLimit
+	if limit <= 0 {
+		limit = defaultPageLimit
+	}
+	next = withQuery(next, "paging.limit", strconv.Itoa(limit))
+
+	for page := 1; page <= 500 && next != ""; page++ {
+		body, hdr, code, err := h.do(ctx, next)
+		if err != nil || code != http.StatusOK {
+			h.note(fmt.Sprintf("%-5s %s", statusToken(code), path))
+			h.failures++
+			break
+		}
+		h.requests++
+		var items []json.RawMessage
+		if json.Unmarshal(body, &items) != nil {
+			// Not a collection — record it whole and stop paging.
+			h.writeRaw(path, body)
+			return body
+		}
+		all = append(all, items...)
+		h.note(fmt.Sprintf("%-5d %s  (page %d, +%d, total %d)", code, path, page, len(items), len(all)))
+		// A registry catalogue is tens of pages per collection. Without
+		// a line per page the capture looks hung for minutes before the
+		// first node is even reached.
+		// Only when the walk is actually long. The empty page that ends
+		// every collection would otherwise print a line for each of six
+		// collections on a plant with one node.
+		if len(items) > 0 && (page > 1 || len(items) >= limit) {
+			h.opts.Log(fmt.Sprintf("    %s: page %d, %d so far", shortPath(path), page, len(all)))
+		}
+		// Record what the registry said about paging, once. Without
+		// this a short capture in the field cannot be diagnosed without
+		// a debugger — which is exactly what happened.
+		if page == 1 {
+			h.note(fmt.Sprintf("PAGING %s  limit=%s Link=%q X-Paging-Limit=%q Since=%q Until=%q",
+				path, strconv.Itoa(limit), hdr.Get("Link"),
+				hdr.Get("X-Paging-Limit"), hdr.Get("X-Paging-Since"), hdr.Get("X-Paging-Until")))
+		}
+
+		// An empty page is the end of the collection, and it is the
+		// normal termination condition. Registries following the AMWA
+		// reference implementation emit prev/next/first/last on EVERY
+		// response as navigational affordances, including the last one
+		// — so the presence of a `next` link says nothing about whether
+		// more resources exist. Only the page contents do.
+		if len(items) == 0 {
+			break
+		}
+
+		cand := h.olderPage(next, hdr, items, limit)
+		if cand == "" {
+			break
+		}
+		// A cursor that repeats WHILE resources are still arriving is a
+		// registry defect: the walk cannot reach the end. Recording it
+		// and stopping is the honest behaviour — looping would hang the
+		// capture, and stopping quietly would report a smaller plant
+		// than exists.
+		if seenCursor[cand] {
+			h.note(fmt.Sprintf("WARN  paging cursor did not advance for %s - stopping (registry paging defect)", path))
+			break
+		}
+		seenCursor[cand] = true
+		next = cand
+	}
+
+	// The same resource can legitimately appear on two pages when the
+	// catalogue changes mid-walk. Deduplicating by id is right; the
+	// per-page counts stay in report.txt so the duplication is still
+	// auditable.
+	uniq, dupes := dedupeByID(all)
+	if dupes > 0 {
+		h.note(fmt.Sprintf("NOTE  %s returned %d rows across pages, %d unique", path, len(all), len(uniq)))
+	}
+	out, err := json.Marshal(uniq)
+	if err != nil {
+		return nil
+	}
+	h.writeRaw(path, out)
+	return out
+}
+
+// olderPage decides where the walk goes after this page.
+//
+// **Direction matters, and getting it wrong is nearly invisible.** The
+// IS-04 Query API orders results by `version`, newest first, and pages
+// over that ordering. So the first response already holds the NEWEST
+// slice, `rel="next"` points at resources newer still — normally none —
+// and the rest of the collection lies behind `rel="prev"`.
+//
+// Following `next` therefore captures one page and stops on an empty
+// second page, which looks exactly like a complete walk. On a real
+// registry it captured 100 of 5,222 senders and reported success. To
+// enumerate a collection you walk toward OLDER.
+//
+// Three signals, in order of authority.
+func (h *harvester) olderPage(cur string, hdr http.Header, items []json.RawMessage, limit int) string {
+	// 1. The spec's cursor. Opaque — followed, never reconstructed.
+	if m := linkPrev.FindStringSubmatch(hdr.Get("Link")); m != nil {
+		return absolutize(cur, m[1])
+	}
+
+	// A page shorter than the limit ends the collection — but it has to
+	// be the limit the registry APPLIED, not the one we asked for. A
+	// registry that clamps 100 down to 10 serves a full page of 10, and
+	// comparing that against 100 calls the end of page one the end of
+	// the plant. That is precisely the field failure.
+	applied := limit
+	if v := hdr.Get("X-Paging-Limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			applied = n
+		}
+	}
+	if len(items) < applied {
+		// With no Link and no X-Paging-Limit we have no evidence of what
+		// the registry applied, so "short" is a guess — and guessing
+		// wrong truncates the plant silently. Probe one more page
+		// instead: an empty page or a repeated cursor ends the walk
+		// safely, and the cost of being wrong is one request.
+		if hdr.Get("X-Paging-Limit") != "" {
+			return ""
+		}
+	}
+
+	// 2. The response reports the version window it served. The next
+	// window older than this one ends where this one started.
+	if since := hdr.Get("X-Paging-Since"); since != "" {
+		return withQuery(cur, "paging.until", since)
+	}
+
+	// 3. No paging headers at all, but a full page. Derive the cursor
+	// from the data: the LOWEST `version` we were handed is where the
+	// older page ends. A registry that ignores paging.until entirely
+	// will re-serve the same page, and the caller's repeat-cursor guard
+	// stops the walk and records the defect.
+	if v := minVersion(items); v != "" {
+		return withQuery(cur, "paging.until", v)
+	}
+	return ""
+}
+
+// minVersion returns the smallest IS-04 `<sec>:<nsec>` version among a
+// page of resources — the oldest thing on the page, and therefore where
+// the next page back ends.
+func minVersion(items []json.RawMessage) string {
+	best := ""
+	for _, it := range items {
+		var probe struct {
+			Version string `json:"version"`
+		}
+		if json.Unmarshal(it, &probe) != nil || probe.Version == "" {
+			continue
+		}
+		// A version that does not parse is skipped outright rather than
+		// ordered. Ordering malformed values low is right for a maximum
+		// and exactly wrong for a minimum, where it would win every
+		// time and send the cursor somewhere meaningless.
+		if _, _, ok := splitTAI(probe.Version); !ok {
+			continue
+		}
+		if best == "" || taiLess(probe.Version, best) {
+			best = probe.Version
+		}
+	}
+	return best
+}
+
+// taiLess compares two `<sec>:<nsec>` timestamps. A value that does not
+// parse sorts low, so a malformed version never wins the maximum and
+// sends the walk backwards.
+func taiLess(a, b string) bool {
+	as, an, aok := splitTAI(a)
+	bs, bn, bok := splitTAI(b)
+	switch {
+	case !aok:
+		return bok
+	case !bok:
+		return false
+	case as != bs:
+		return as < bs
+	default:
+		return an < bn
+	}
+}
+
+func splitTAI(s string) (sec, nsec uint64, ok bool) {
+	l, r, found := strings.Cut(s, ":")
+	if !found {
+		return 0, 0, false
+	}
+	a, err1 := strconv.ParseUint(l, 10, 64)
+	b, err2 := strconv.ParseUint(r, 10, 64)
+	if err1 != nil || err2 != nil {
+		return 0, 0, false
+	}
+	return a, b, true
+}
+
+// shortPath trims the `/x-nmos/<api>/<ver>/` prefix off a collection
+// path, so a progress line reads `senders` rather than the full URL and
+// stays readable when several devices interleave.
+func shortPath(p string) string {
+	if i := strings.LastIndex(p, "/"); i >= 0 {
+		return p[i+1:]
+	}
+	return p
+}
+
+// withQuery sets a query parameter on a URL, replacing any existing
+// value. Used to drive paging.limit and paging.since without
+// string-splicing a URL the registry handed us.
+func withQuery(rawURL, key, value string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	q := u.Query()
+	q.Set(key, value)
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+// get fetches one JSON resource and records it.
+func (h *harvester) get(ctx context.Context, path string) json.RawMessage {
+	body, _, code, err := h.do(ctx, h.scheme+"://"+h.target+path)
+	if err != nil || code != http.StatusOK {
+		h.note(fmt.Sprintf("%-5s %s", statusToken(code), path))
+		h.failures++
+		return nil
+	}
+	h.requests++
+	h.note(fmt.Sprintf("%-5d %s", code, path))
+	h.writeRaw(path, body)
+	if !json.Valid(body) {
+		return nil
+	}
+	return json.RawMessage(body)
+}
+
+// getStrings fetches a resource expected to be an array of strings,
+// returning both the parsed list and the raw bytes.
+func (h *harvester) getStrings(ctx context.Context, path string) ([]string, json.RawMessage) {
+	blob := h.get(ctx, path)
+	if len(blob) == 0 {
+		return nil, blob
+	}
+	var out []string
+	if json.Unmarshal(blob, &out) != nil {
+		return nil, blob
+	}
+	return out, blob
+}
+
+// writeSenderSDP stores one of a sender's two published SDPs.
+//
+// A sender publishes its SDP twice: at the IS-04 `manifest_href` and at
+// the IS-05 `/transportfile`. They are usually byte-identical — 176 of
+// 176 on one real device — and writing both then doubles the SDP folder
+// for nothing.
+//
+// They are fetched from both places anyway, because a node publishing
+// two DIFFERENT descriptions of one stream is a genuine fault and only
+// comparing them can find it. So: keep one copy when they agree and say
+// so, keep both and warn when they do not.
+func (h *harvester) writeSenderSDP(senderID, source string, body []byte) {
+	// One folder per publication point, and the filename is just the
+	// resource id. `diff -r sdp/is04 sdp/is05` is then the disagreement
+	// check, which beats any note this code could write.
+	h.writeSDP(filepath.Join(source, senderID+".sdp"), body)
+
+	prev, seen := h.sdpBySender[senderID]
+	if !seen {
+		h.sdpBySender[senderID] = sdpRecord{source: source, body: body}
+		return
+	}
+	if bytes.Equal(prev.body, body) {
+		h.note(fmt.Sprintf("SDP   sender %s: %s matches %s", senderID, source, prev.source))
+		return
+	}
+	h.note(fmt.Sprintf("WARN  sender %s publishes DIFFERENT SDP at its IS-04 manifest_href and its IS-05 transportfile", senderID))
+}
+
+// fetchSDP retrieves one SDP and writes it, skipping URLs already seen
+// — a sender's manifest and its IS-05 transport file are frequently the
+// same document.
+func (h *harvester) fetchSDP(ctx context.Context, rawURL, senderID, source string) {
+	if rawURL == "" {
+		return
+	}
+	// IS-04 types manifest_href as a URI, not an absolute URL, and a
+	// device is entitled to publish `/x-nmos/node/v1.3/sdp/{id}`.
+	// Resolving against the device's own base is still following the
+	// field verbatim — it is what a relative URI means.
+	rawURL = absolutize(h.scheme+"://"+h.target+"/", rawURL)
+	if h.sdpSeen[rawURL] {
+		return
+	}
+	h.sdpSeen[rawURL] = true
+
+	body, _, code, err := h.do(ctx, rawURL)
+	if err != nil || code != http.StatusOK {
+		h.note(fmt.Sprintf("%-5s %s", statusToken(code), rawURL))
+		h.failures++
+		return
+	}
+	h.requests++
+	h.note(fmt.Sprintf("%-5d %s", code, rawURL))
+	h.writeSenderSDP(senderID, source, body)
+}
+
+// do performs one request.
+func (h *harvester) do(ctx context.Context, rawURL string) ([]byte, http.Header, int, error) {
+	rctx, cancel := context.WithTimeout(ctx, h.opts.Timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(rctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	resp, err := h.opts.Client.Do(req)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.Header, resp.StatusCode, err
+	}
+	return body, resp.Header, resp.StatusCode, nil
+}
+
+// --- writers ---
+
+func (h *harvester) writeRaw(path string, body []byte) {
+	if !h.opts.Raw {
+		return
+	}
+	name := sanitize(strings.Trim(path, "/"))
+	if name == "" {
+		return
+	}
+	h.writeFile(filepath.Join(h.dir, "raw", name+".json"), body)
+}
+
+func (h *harvester) writeSDP(name string, body []byte) {
+	h.writeFile(filepath.Join(h.dir, "sdp", name), body)
+	h.sdpFiles++
+}
+
+func (h *harvester) writeFile(path string, body []byte) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+	_ = os.WriteFile(path, body, 0o644)
+}
+
+func (h *harvester) writeDevice(role string) error {
+	d := map[string]any{
+		"target":     h.target,
+		"role":       role,
+		"started_at": h.opts.Now().Format(time.RFC3339Nano),
+		"harvester":  Version,
+		"label":      h.label,
+		"id":         h.id,
+	}
+	b, err := json.MarshalIndent(d, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(h.dir, "device.json"), b, 0o644)
+}
+
+func (h *harvester) writeTree() error {
+	tree := map[string]any{
+		"harvested_at": h.opts.Now().Format(time.RFC3339Nano),
+		"target":       h.target,
+		"harvester":    Version,
+		"apis":         h.apis,
+	}
+	b, err := json.MarshalIndent(tree, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(h.dir, "tree.json"), b, 0o644)
+}
+
+func (h *harvester) writeReport() error {
+	body := strings.Join(h.report, "\n")
+	if body != "" {
+		body += "\n"
+	}
+	return os.WriteFile(filepath.Join(h.dir, "report.txt"), []byte(body), 0o644)
+}
+
+// pruneEmptyDirs removes raw/ and sdp/ when nothing landed in them, so
+// a capture folder never carries empty scaffolding.
+func (h *harvester) pruneEmptyDirs() error {
+	// Deepest first: sdp/ can only be removed once its own subfolders
+	// are gone.
+	for _, sub := range []string{
+		filepath.Join("sdp", "is04"), filepath.Join("sdp", "is05"), filepath.Join("sdp", "receivers"),
+		"raw", "sdp",
+	} {
+		p := filepath.Join(h.dir, sub)
+		entries, err := os.ReadDir(p)
+		if err != nil || len(entries) > 0 {
+			continue
+		}
+		if err := os.Remove(p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// --- helpers ---
+
+var unsafeChars = regexp.MustCompile(`[^0-9A-Za-z]+`)
+
+// sanitize renders a host:port or URL path as a filesystem-safe name.
+func sanitize(s string) string {
+	return strings.Trim(unsafeChars.ReplaceAllString(s, "_"), "_")
+}
+
+// statusToken renders a status for report.txt, using ERR when the
+// request never completed at all.
+func statusToken(code int) string {
+	if code == 0 {
+		return "ERR"
+	}
+	return strconv.Itoa(code)
+}
+
+// highest picks the greatest `vMAJOR.MINOR`, ordering v1.10 after v1.9
+// rather than before it as a string sort would.
+func highest(vs []string) string {
+	// The initial rank must sit BELOW the unparseable rank, or a device
+	// advertising a single version we cannot parse yields "" and its
+	// API is never walked at all.
+	best, rank := "", -2
+	for _, v := range vs {
+		if r := rankOf(v); r > rank {
+			best, rank = v, r
+		}
+	}
+	return best
+}
+
+func rankOf(v string) int {
+	maj, min, ok := strings.Cut(strings.TrimPrefix(v, "v"), ".")
+	if !ok {
+		return -1
+	}
+	m, err1 := strconv.Atoi(maj)
+	n, err2 := strconv.Atoi(min)
+	if err1 != nil || err2 != nil {
+		return -1
+	}
+	return m*1000 + n
+}
+
+// absolutize resolves a Link header target against the URL it came
+// from, since a registry may return either an absolute or a relative
+// cursor.
+func absolutize(base, ref string) string {
+	b, err := url.Parse(base)
+	if err != nil {
+		return ref
+	}
+	r, err := url.Parse(ref)
+	if err != nil {
+		return ref
+	}
+	return b.ResolveReference(r).String()
+}
+
+// hostPortOf extracts `host:port` from a node's href, defaulting the
+// port from the scheme when the href omits it.
+func hostPortOf(href string) string {
+	u, err := url.Parse(href)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	if u.Port() != "" {
+		return u.Host
+	}
+	if u.Scheme == "https" {
+		return u.Host + ":443"
+	}
+	return u.Host + ":80"
+}
+
+// embeddedSDP pulls transport_file.data out of an IS-05 receiver
+// payload. A short or absent value means nothing is connected.
+func embeddedSDP(blob json.RawMessage) string {
+	if len(blob) == 0 {
+		return ""
+	}
+	var probe struct {
+		TransportFile struct {
+			Data *string `json:"data"`
+		} `json:"transport_file"`
+	}
+	if json.Unmarshal(blob, &probe) != nil || probe.TransportFile.Data == nil {
+		return ""
+	}
+	if len(strings.TrimSpace(*probe.TransportFile.Data)) <= 10 {
+		return ""
+	}
+	return *probe.TransportFile.Data
+}
+
+// dedupeByID keeps the first copy of each resource id, preserving
+// order, and reports how many duplicates it dropped.
+func dedupeByID(items []json.RawMessage) ([]json.RawMessage, int) {
+	out := make([]json.RawMessage, 0, len(items))
+	seen := map[string]bool{}
+	dupes := 0
+	for _, it := range items {
+		var probe struct {
+			ID string `json:"id"`
+		}
+		if json.Unmarshal(it, &probe) != nil || probe.ID == "" {
+			out = append(out, it)
+			continue
+		}
+		if seen[probe.ID] {
+			dupes++
+			continue
+		}
+		seen[probe.ID] = true
+		out = append(out, it)
+	}
+	return out, dupes
+}

--- a/internal/amwa/session/export/export_edge_test.go
+++ b/internal/amwa/session/export/export_edge_test.go
@@ -1,0 +1,327 @@
+package export
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestAPIsWithoutADedicatedWalk covers the surfaces the exporter
+// captures generically: IS-09 System, IS-08 Channel Mapping, and any
+// API the device serves that we have no special handling for.
+func TestAPIsWithoutADedicatedWalk(t *testing.T) {
+	p := newPlant(t)
+	p.paths["/x-nmos"] = []string{"system/", "channelmapping/", "events/"}
+	p.paths["/x-nmos/system/"] = []string{"v1.0/"}
+	p.paths["/x-nmos/system/v1.0/global"] = map[string]any{"id": "sys", "version": "1:0"}
+	p.paths["/x-nmos/channelmapping/"] = []string{"v1.0/"}
+	p.paths["/x-nmos/channelmapping/v1.0/io"] = map[string]any{"inputs": map[string]any{}}
+	p.paths["/x-nmos/channelmapping/v1.0/map/active"] = map[string]any{}
+	p.paths["/x-nmos/channelmapping/v1.0/map/staged"] = map[string]any{}
+	p.paths["/x-nmos/events/"] = []string{"v1.0/"}
+	p.paths["/x-nmos/events/v1.0/"] = []string{"sources/"}
+
+	srv := httptest.NewServer(p)
+	defer srv.Close()
+
+	got, err := Run(context.Background(), baseOpts(t, strings.TrimPrefix(srv.URL, "http://")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// None of these identifies the device as a node or a registry.
+	if got.Role != "unknown" {
+		t.Errorf("role = %q; a device serving only these APIs is neither", got.Role)
+	}
+
+	tree := readTree(t, got.Dir)
+	apis := tree["apis"].(map[string]any)
+	for _, api := range []string{"system", "channelmapping", "events"} {
+		if _, ok := apis[api]; !ok {
+			t.Errorf("%s was not captured", api)
+		}
+	}
+	cm := apis["channelmapping"].(map[string]any)["data"].(map[string]any)["v1.0"].(map[string]any)
+	for _, k := range []string{"io", "map_active", "map_staged"} {
+		if _, ok := cm[k]; !ok {
+			t.Errorf("channelmapping capture is missing %s", k)
+		}
+	}
+	ev := apis["events"].(map[string]any)["data"].(map[string]any)["v1.0"].(map[string]any)
+	if _, ok := ev["root"]; !ok {
+		t.Error("an API with no dedicated walk should still have its root captured")
+	}
+}
+
+// TestSDPFetchedOnceAndFailuresRecorded: a sender's IS-04 manifest and
+// its IS-05 transport file are usually the same document. Fetching it
+// twice doubles the request count on a 176-sender device for nothing.
+func TestSDPFetchedOnceAndFailuresRecorded(t *testing.T) {
+	id := "44444444-4444-4444-8444-444444444444"
+	p := newPlant(t)
+	p.paths["/x-nmos"] = []string{"node/", "connection/"}
+	p.paths["/x-nmos/node/"] = []string{"v1.3/"}
+	p.paths["/x-nmos/node/v1.3/self"] = res("11111111-1111-4111-8111-111111111111", "n", nil)
+	for _, r := range []string{"devices", "sources", "flows", "receivers"} {
+		p.paths["/x-nmos/node/v1.3/"+r] = []any{}
+	}
+	p.paths["/x-nmos/connection/"] = []string{"v1.1/"}
+	p.paths["/x-nmos/connection/v1.1/single/senders"] = []string{id + "/"}
+	p.paths["/x-nmos/connection/v1.1/single/receivers"] = []any{}
+	p.paths["/x-nmos/connection/v1.1/single/senders/"+id+"/active"] = map[string]any{"master_enable": true}
+	p.paths["/x-nmos/connection/v1.1/bulk"] = []any{}
+
+	srv := httptest.NewServer(p)
+	defer srv.Close()
+	host := strings.TrimPrefix(srv.URL, "http://")
+
+	// The sender points its manifest at the IS-05 transport file — the
+	// same URL the exporter would fetch on the IS-05 pass.
+	tf := "/x-nmos/connection/v1.1/single/senders/" + id + "/transportfile"
+	p.paths["/x-nmos/node/v1.3/senders"] = []any{
+		res(id, "s", map[string]any{"manifest_href": srv.URL + tf}),
+	}
+	p.paths[tf] = "v=0\r\ns=one\r\n"
+
+	got, err := Run(context.Background(), baseOpts(t, host))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.hits[tf] != 1 {
+		t.Errorf("the transport file was fetched %d times, want 1", p.hits[tf])
+	}
+	if got.SDPFiles != 1 {
+		t.Errorf("SDP files = %d, want 1", got.SDPFiles)
+	}
+}
+
+// TestSDPFailureRecorded: a 502 on a transport file is exactly the
+// defect the audit reports, so the capture has to record it.
+func TestSDPFailureRecorded(t *testing.T) {
+	p := newPlant(t)
+	p.paths["/x-nmos"] = []string{"node/"}
+	p.paths["/x-nmos/node/"] = []string{"v1.3/"}
+	p.paths["/x-nmos/node/v1.3/self"] = res("11111111-1111-4111-8111-111111111111", "n", nil)
+	for _, r := range []string{"devices", "sources", "flows", "receivers"} {
+		p.paths["/x-nmos/node/v1.3/"+r] = []any{}
+	}
+	srv := httptest.NewServer(p)
+	defer srv.Close()
+	// The manifest points somewhere that does not exist.
+	p.paths["/x-nmos/node/v1.3/senders"] = []any{
+		res("44444444-4444-4444-8444-444444444444", "s", map[string]any{"manifest_href": srv.URL + "/gone"}),
+	}
+
+	got, err := Run(context.Background(), baseOpts(t, strings.TrimPrefix(srv.URL, "http://")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.SDPFiles != 0 {
+		t.Errorf("a failed fetch must not count as an SDP file, got %d", got.SDPFiles)
+	}
+	if got.Failures == 0 {
+		t.Error("the failed manifest fetch was not counted")
+	}
+	if !strings.Contains(readReport(t, got.Dir), "404 ") {
+		t.Errorf("the failure was not recorded:\n%s", readReport(t, got.Dir))
+	}
+}
+
+// TestNonJSONAndNonArrayResponses: a device that answers a collection
+// with an object, or with something that is not JSON at all, must be
+// recorded rather than crashing the capture.
+func TestNonJSONAndNonArrayResponses(t *testing.T) {
+	p := newPlant(t)
+	// /x-nmos answers with an object, not the array the spec defines.
+	p.paths["/x-nmos"] = map[string]any{"oops": true}
+	p.paths["/x-nmos/node/"] = []string{"v1.3/"}
+	p.paths["/x-nmos/node/v1.3/self"] = res("11111111-1111-4111-8111-111111111111", "odd", nil)
+	for _, r := range []string{"devices", "sources", "flows", "senders", "receivers"} {
+		p.paths["/x-nmos/node/v1.3/"+r] = []any{}
+	}
+	srv := httptest.NewServer(p)
+	defer srv.Close()
+
+	got, err := Run(context.Background(), baseOpts(t, strings.TrimPrefix(srv.URL, "http://")))
+	if err != nil {
+		t.Fatalf("a malformed root must not abort the capture: %v", err)
+	}
+	// Falling back to probing the standard names is what recovers here.
+	if got.Role != "node" {
+		t.Errorf("role = %q, want node via the fallback probe", got.Role)
+	}
+}
+
+// TestQueryCollectionAnsweredWithAnObject covers a registry that
+// answers a paged collection with something that is not a list.
+func TestQueryCollectionAnsweredWithAnObject(t *testing.T) {
+	p := registryPlant(t)
+	p.paths["/x-nmos/query/v1.1/nodes"] = map[string]any{"error": "not a list"}
+	p.paths["/x-nmos/query/v1.3/nodes"] = []any{}
+	srv := httptest.NewServer(p)
+	defer srv.Close()
+
+	got, err := Run(context.Background(), baseOpts(t, strings.TrimPrefix(srv.URL, "http://")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.NodesSeen != 0 {
+		t.Errorf("nodes seen = %d; a non-list answer lists nobody", got.NodesSeen)
+	}
+	// The body is still captured verbatim — the audit decides what it
+	// means, not the exporter.
+	tree := readTree(t, got.Dir)
+	q := tree["apis"].(map[string]any)["query"].(map[string]any)
+	body := q["data"].(map[string]any)["v1.1"].(map[string]any)["nodes"]
+	if body == nil {
+		t.Error("the malformed collection was discarded instead of captured")
+	}
+}
+
+// TestStampedFolderName is the default: two captures of the same device
+// on the same day must not overwrite each other.
+func TestStampedFolderName(t *testing.T) {
+	p := newPlant(t)
+	p.paths["/x-nmos"] = []string{}
+	srv := httptest.NewServer(p)
+	defer srv.Close()
+
+	opts := baseOpts(t, strings.TrimPrefix(srv.URL, "http://"))
+	opts.NoStamp = false
+	got, err := Run(context.Background(), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(filepath.Base(got.Dir), "_20260824-090000") {
+		t.Errorf("folder %q carries no timestamp", filepath.Base(got.Dir))
+	}
+}
+
+// TestHTTPSSchemeUsed proves --https reaches a TLS device.
+func TestHTTPSSchemeUsed(t *testing.T) {
+	p := newPlant(t)
+	p.paths["/x-nmos"] = []string{"node/"}
+	p.paths["/x-nmos/node/"] = []string{"v1.3/"}
+	p.paths["/x-nmos/node/v1.3/self"] = res("11111111-1111-4111-8111-111111111111", "secure", nil)
+	for _, r := range []string{"devices", "sources", "flows", "senders", "receivers"} {
+		p.paths["/x-nmos/node/v1.3/"+r] = []any{}
+	}
+	srv := httptest.NewTLSServer(p)
+	defer srv.Close()
+
+	opts := baseOpts(t, strings.TrimPrefix(srv.URL, "https://"))
+	opts.HTTPS = true
+	opts.Client = srv.Client()
+	got, err := Run(context.Background(), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Label != "secure" {
+		t.Errorf("label = %q; the TLS capture did not reach the device", got.Label)
+	}
+}
+
+// TestOutDirectoryMustBeCreatable surfaces a bad --out rather than
+// failing silently partway through a long capture.
+func TestOutDirectoryMustBeCreatable(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "a-file")
+	if err := os.WriteFile(f, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Run(context.Background(), Options{Target: "h:1", Out: filepath.Join(f, "under-a-file")})
+	if err == nil {
+		t.Error("an unusable --out should fail before any request is made")
+	}
+}
+
+// TestCancelledContextStopsTheCapture: an operator pressing ctrl-C mid
+// capture must not hang.
+func TestCancelledContextStopsTheCapture(t *testing.T) {
+	p := newPlant(t)
+	p.paths["/x-nmos"] = []string{"node/"}
+	srv := httptest.NewServer(p)
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	opts := baseOpts(t, strings.TrimPrefix(srv.URL, "http://"))
+	opts.Timeout = 500 * time.Millisecond
+	got, err := Run(ctx, opts)
+	if err != nil {
+		t.Fatalf("a cancelled capture should still write its folder: %v", err)
+	}
+	if got.Requests != 0 {
+		t.Errorf("requests = %d on a cancelled context", got.Requests)
+	}
+}
+
+// TestLogReceivesProgress: a long capture that prints nothing looks
+// hung.
+func TestLogReceivesProgress(t *testing.T) {
+	p := newPlant(t)
+	p.paths["/x-nmos"] = []string{}
+	srv := httptest.NewServer(p)
+	defer srv.Close()
+
+	var lines []string
+	opts := baseOpts(t, strings.TrimPrefix(srv.URL, "http://"))
+	opts.Log = func(s string) { lines = append(lines, s) }
+	if _, err := Run(context.Background(), opts); err != nil {
+		t.Fatal(err)
+	}
+	if len(lines) == 0 || !strings.Contains(lines[0], "capturing") {
+		t.Errorf("no progress was reported: %v", lines)
+	}
+}
+
+func TestWriteRawIgnoresUnusableNames(t *testing.T) {
+	h := &harvester{opts: Options{}, dir: t.TempDir()}
+	h.opts.defaults()
+	h.writeRaw("///", []byte("x"))
+	entries, err := os.ReadDir(h.dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("an unusable path produced %d file(s)", len(entries))
+	}
+}
+
+func TestRankOfRejectsNonNumeric(t *testing.T) {
+	for _, v := range []string{"vX.3", "v1.Y", "v1", ""} {
+		if got := rankOf(v); got != -1 {
+			t.Errorf("rankOf(%q) = %d, want -1", v, got)
+		}
+	}
+	if rankOf("v1.3") <= rankOf("v1.2") {
+		t.Error("v1.3 must outrank v1.2")
+	}
+}
+
+func TestFetchSenderManifestsIgnoresGarbage(t *testing.T) {
+	h := &harvester{opts: Options{}, sdpSeen: map[string]bool{}}
+	h.opts.defaults()
+	// Not a sender array — must return without touching the network.
+	h.fetchSenderManifests(context.Background(), json.RawMessage(`{"not":"an array"}`))
+	if len(h.report) != 0 {
+		t.Errorf("garbage produced report lines: %v", h.report)
+	}
+	// A sender with no id is not addressable and is skipped.
+	h.fetchSenderManifests(context.Background(), json.RawMessage(`[{"manifest_href":"http://x/"}]`))
+	if len(h.report) != 0 {
+		t.Errorf("an id-less sender produced report lines: %v", h.report)
+	}
+}
+
+func TestCollectNodesIgnoresGarbage(t *testing.T) {
+	h := &harvester{}
+	h.collectNodes(json.RawMessage(`{"not":"a list"}`), "v1.3")
+	if len(h.nodes) != 0 || len(h.report) != 0 {
+		t.Error("a non-list nodes payload should be ignored quietly")
+	}
+}

--- a/internal/amwa/session/export/export_test.go
+++ b/internal/amwa/session/export/export_test.go
@@ -1,0 +1,697 @@
+package export
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fixedNow keeps folder names deterministic so a test can assert on the
+// path it expects.
+func fixedNow() time.Time { return time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC) }
+
+func baseOpts(t *testing.T, target string) Options {
+	t.Helper()
+	return Options{
+		Target:  target,
+		Out:     t.TempDir(),
+		Timeout: 2 * time.Second,
+		Now:     fixedNow,
+		NoStamp: true,
+	}
+}
+
+// plant serves a scripted NMOS surface. Paths not in the map 404, which
+// is what a device does for an API it does not have.
+type plant struct {
+	t     *testing.T
+	paths map[string]any
+	// pages lets one path answer with a Link: rel="prev" chain — the
+	// OLDER direction, which is how a collection is enumerated.
+	pages map[string][][]any
+	// hits counts requests per path, so a test can prove the exporter
+	// did not walk something four times.
+	hits map[string]int
+	// stuck makes the paging cursor repeat forever.
+	stuck bool
+}
+
+func newPlant(t *testing.T) *plant {
+	return &plant{t: t, paths: map[string]any{}, pages: map[string][][]any{}, hits: map[string]int{}}
+}
+
+func (p *plant) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	p.hits[r.URL.Path]++
+
+	if chunks, ok := p.pages[r.URL.Path]; ok {
+		idx := 0
+		if s := r.URL.Query().Get("paging.until"); s != "" {
+			_, _ = fmt.Sscanf(s, "%d", &idx)
+		}
+		if idx >= len(chunks) {
+			idx = len(chunks) - 1
+		}
+		if idx < len(chunks)-1 || p.stuck {
+			prev := idx + 1
+			if p.stuck {
+				prev = idx
+			}
+			w.Header().Set("Link", fmt.Sprintf(`<%s?paging.until=%d>; rel="prev"`, r.URL.Path, prev))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(chunks[idx])
+		return
+	}
+
+	body, ok := p.paths[r.URL.Path]
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	if s, isStr := body.(string); isStr {
+		w.Header().Set("Content-Type", "application/sdp")
+		_, _ = w.Write([]byte(s))
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func res(id, label string, over map[string]any) map[string]any {
+	m := map[string]any{"id": id, "version": "1755000000:0", "label": label, "tags": map[string]any{}}
+	for k, v := range over {
+		m[k] = v
+	}
+	return m
+}
+
+// readTree loads the tree.json a capture produced.
+func readTree(t *testing.T, dir string) map[string]any {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(dir, "tree.json"))
+	if err != nil {
+		t.Fatalf("tree.json: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("tree.json: %v", err)
+	}
+	return m
+}
+
+func readReport(t *testing.T, dir string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(dir, "report.txt"))
+	if err != nil {
+		t.Fatalf("report.txt: %v", err)
+	}
+	return string(b)
+}
+
+// TestExportNode captures a node and pins the whole on-disk shape.
+func TestExportNode(t *testing.T) {
+	p := newPlant(t)
+	p.paths["/x-nmos"] = []string{"node/", "connection/"}
+	p.paths["/x-nmos/node/"] = []string{"v1.2/", "v1.3/"}
+	p.paths["/x-nmos/node/v1.3/self"] = res("11111111-1111-4111-8111-111111111111", "cam-01", nil)
+	p.paths["/x-nmos/node/v1.3/devices"] = []any{}
+	p.paths["/x-nmos/node/v1.3/sources"] = []any{}
+	p.paths["/x-nmos/node/v1.3/flows"] = []any{}
+	p.paths["/x-nmos/node/v1.3/receivers"] = []any{}
+	p.paths["/x-nmos/node/v1.3/senders"] = []any{
+		res("44444444-4444-4444-8444-444444444444", "prog", map[string]any{
+			// The manifest lives where the device says it lives — here,
+			// under the node API, not at an IS-05 transportfile path.
+			"manifest_href": "/x-nmos/node/v1.3/sdp/44444444-4444-4444-8444-444444444444",
+		}),
+		res("55555555-5555-4555-8555-555555555555", "iso", map[string]any{"manifest_href": nil}),
+	}
+	p.paths["/x-nmos/node/v1.3/sdp/44444444-4444-4444-8444-444444444444"] =
+		"v=0\r\no=- 1 1 IN IP4 198.51.100.21\r\ns=cam-01 prog\r\n"
+
+	srv := httptest.NewServer(p)
+	defer srv.Close()
+	host := strings.TrimPrefix(srv.URL, "http://")
+
+	got, err := Run(context.Background(), baseOpts(t, host))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if got.Role != "node" {
+		t.Errorf("role = %q, want node", got.Role)
+	}
+	if got.Label != "cam-01" {
+		t.Errorf("label = %q, want cam-01", got.Label)
+	}
+	if got.ID != "11111111-1111-4111-8111-111111111111" {
+		t.Errorf("id = %q", got.ID)
+	}
+
+	// A node repeats identical resources at every minor. Walking both
+	// v1.2 and v1.3 would double the requests for the same bytes.
+	if p.hits["/x-nmos/node/v1.2/senders"] != 0 {
+		t.Error("the lower minor was walked; only the highest should be")
+	}
+	if p.hits["/x-nmos/node/v1.3/senders"] != 1 {
+		t.Errorf("senders fetched %d times, want 1", p.hits["/x-nmos/node/v1.3/senders"])
+	}
+
+	tree := readTree(t, got.Dir)
+	apis, _ := tree["apis"].(map[string]any)
+	node, _ := apis["node"].(map[string]any)
+	data, _ := node["data"].(map[string]any)
+	if _, ok := data["v1.3"]; !ok {
+		t.Errorf("tree has no v1.3 bucket: %v", data)
+	}
+	if _, ok := data["v1.2"]; ok {
+		t.Error("tree carries a v1.2 bucket that was never walked")
+	}
+
+	// manifest_href here is a relative URI, which IS-04 permits. It has
+	// to resolve against the device's own base, or the SDP is lost.
+	if got.SDPFiles != 1 {
+		t.Errorf("SDP files = %d, want 1 (relative manifest_href must resolve)", got.SDPFiles)
+	}
+
+	rep := readReport(t, got.Dir)
+	if !strings.Contains(rep, "NOSDP sender 55555555-5555-4555-8555-555555555555") {
+		t.Errorf("a null manifest_href should be recorded, not silently skipped:\n%s", rep)
+	}
+	if !strings.Contains(rep, "NOTE  node : versions v1.2,v1.3 present, walking v1.3 only") {
+		t.Errorf("the version decision should be recorded:\n%s", rep)
+	}
+
+	// device.json must be attributable even though it is written twice.
+	b, err := os.ReadFile(filepath.Join(got.Dir, "device.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var dev map[string]any
+	if err := json.Unmarshal(b, &dev); err != nil {
+		t.Fatal(err)
+	}
+	if dev["role"] != "node" || dev["label"] != "cam-01" {
+		t.Errorf("device.json = %v", dev)
+	}
+}
+
+// TestManifestHrefFollowedVerbatim is the behaviour that produced 1088
+// errors when it was got wrong: the SDP lives where the sender says,
+// not at a path the exporter constructs.
+func TestManifestHrefFollowedVerbatim(t *testing.T) {
+	p := newPlant(t)
+	p.paths["/x-nmos"] = []string{"node/"}
+	p.paths["/x-nmos/node/"] = []string{"v1.3/"}
+	p.paths["/x-nmos/node/v1.3/self"] = res("11111111-1111-4111-8111-111111111111", "n", nil)
+	for _, r := range []string{"devices", "sources", "flows", "receivers"} {
+		p.paths["/x-nmos/node/v1.3/"+r] = []any{}
+	}
+
+	srv := httptest.NewServer(p)
+	defer srv.Close()
+	host := strings.TrimPrefix(srv.URL, "http://")
+
+	// A vendor-specific manifest location, absolute.
+	p.paths["/x-nmos/node/v1.3/senders"] = []any{
+		res("44444444-4444-4444-8444-444444444444", "s", map[string]any{
+			"manifest_href": srv.URL + "/vendor/private/sdp/1",
+		}),
+	}
+	p.paths["/vendor/private/sdp/1"] = "v=0\r\ns=vendor\r\n"
+
+	got, err := Run(context.Background(), baseOpts(t, host))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.hits["/vendor/private/sdp/1"] != 1 {
+		t.Error("the vendor manifest_href was not followed")
+	}
+	if got.SDPFiles != 1 {
+		t.Errorf("SDP files = %d, want 1", got.SDPFiles)
+	}
+	sdp, err := os.ReadFile(filepath.Join(got.Dir, "sdp", "is04", "44444444-4444-4444-8444-444444444444.sdp"))
+	if err != nil {
+		t.Fatalf("SDP not written where the audit looks for it: %v", err)
+	}
+	if !strings.HasPrefix(string(sdp), "v=0") {
+		t.Errorf("SDP body = %q", sdp)
+	}
+}
+
+// registryPlant builds a registry serving two minors, paged, with the
+// lower minor listing a node the higher one hides.
+func registryPlant(t *testing.T) *plant {
+	p := newPlant(t)
+	p.paths["/x-nmos"] = []string{"query/", "registration/"}
+	p.paths["/x-nmos/query/"] = []string{"v1.1/", "v1.3/"}
+	p.paths["/x-nmos/registration/"] = []string{"v1.3/"}
+	p.paths["/x-nmos/registration/v1.3/"] = []string{"health/", "resource/"}
+	for _, r := range []string{"devices", "sources", "flows", "senders", "receivers", "subscriptions"} {
+		p.paths["/x-nmos/query/v1.1/"+r] = []any{}
+		p.paths["/x-nmos/query/v1.3/"+r] = []any{}
+	}
+	return p
+}
+
+// TestExportRegistryPagesAndVersions covers the two behaviours that
+// decide whether an export describes the whole plant or part of it.
+func TestExportRegistryPagesAndVersions(t *testing.T) {
+	p := registryPlant(t)
+	// v1.1 serves three nodes across two pages.
+	p.pages["/x-nmos/query/v1.1/nodes"] = [][]any{
+		{res("11111111-1111-4111-8111-111111111111", "a", nil), res("22222222-2222-4222-8222-222222222222", "b", nil)},
+		{res("33333333-3333-4333-8333-333333333333", "c", nil)},
+	}
+	// v1.3 hides two of them — IS-04 version isolation.
+	p.paths["/x-nmos/query/v1.3/nodes"] = []any{res("11111111-1111-4111-8111-111111111111", "a", nil)}
+
+	srv := httptest.NewServer(p)
+	defer srv.Close()
+
+	opts := baseOpts(t, strings.TrimPrefix(srv.URL, "http://"))
+	opts.MaxNodes = -1 // no href on these nodes; nothing to follow
+	got, err := Run(context.Background(), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Role != "registry" {
+		t.Errorf("role = %q, want registry", got.Role)
+	}
+	// Paging: without Link following this is 2, not 3.
+	if got.NodesSeen != 3 {
+		t.Errorf("nodes seen = %d, want 3 (2 pages at v1.1 union 1 at v1.3)", got.NodesSeen)
+	}
+	// Both minors must be walked. Collapsing to the highest reports 1.
+	if p.hits["/x-nmos/query/v1.1/nodes"] == 0 {
+		t.Error("the lower query minor was not walked — version isolation would hide nodes")
+	}
+	if p.hits["/x-nmos/query/v1.3/nodes"] == 0 {
+		t.Error("the higher query minor was not walked")
+	}
+
+	rep := readReport(t, got.Dir)
+	for _, want := range []string{
+		"VERSION v1.1 nodes: 3 listed, 3 new",
+		"VERSION v1.3 nodes: 1 listed, 0 new",
+		"(page 1, +2, total 2)",
+		"(page 2, +1, total 3)",
+	} {
+		if !strings.Contains(rep, want) {
+			t.Errorf("report is missing %q:\n%s", want, rep)
+		}
+	}
+
+	tree := readTree(t, got.Dir)
+	apis := tree["apis"].(map[string]any)
+	q := apis["query"].(map[string]any)
+	data := q["data"].(map[string]any)
+	if len(data) != 2 {
+		t.Errorf("query captured at %d minors, want 2", len(data))
+	}
+	nodes := data["v1.1"].(map[string]any)["nodes"].([]any)
+	if len(nodes) != 3 {
+		t.Errorf("v1.1 nodes captured = %d, want all 3 pages merged", len(nodes))
+	}
+}
+
+// TestStuckPagingCursorStops proves a registry defect ends the walk and
+// is recorded, rather than hanging the capture.
+func TestStuckPagingCursorStops(t *testing.T) {
+	p := registryPlant(t)
+	p.stuck = true
+	p.pages["/x-nmos/query/v1.1/nodes"] = [][]any{
+		{res("11111111-1111-4111-8111-111111111111", "a", nil)},
+	}
+	p.paths["/x-nmos/query/v1.3/nodes"] = []any{}
+
+	srv := httptest.NewServer(p)
+	defer srv.Close()
+
+	done := make(chan *Result, 1)
+	go func() {
+		opts := baseOpts(t, strings.TrimPrefix(srv.URL, "http://"))
+		r, err := Run(context.Background(), opts)
+		if err != nil {
+			t.Error(err)
+		}
+		done <- r
+	}()
+
+	select {
+	case got := <-done:
+		rep := readReport(t, got.Dir)
+		if !strings.Contains(rep, "paging cursor did not advance") {
+			t.Errorf("the stuck cursor was not recorded:\n%s", rep)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("a stuck paging cursor hung the capture")
+	}
+}
+
+// TestFollowRegisteredNodes proves a registry export is a plant export.
+func TestFollowRegisteredNodes(t *testing.T) {
+	nodeP := newPlant(t)
+	nodeP.paths["/x-nmos"] = []string{"node/"}
+	nodeP.paths["/x-nmos/node/"] = []string{"v1.3/"}
+	nodeP.paths["/x-nmos/node/v1.3/self"] = res("11111111-1111-4111-8111-111111111111", "cam-01", nil)
+	for _, r := range []string{"devices", "sources", "flows", "senders", "receivers"} {
+		nodeP.paths["/x-nmos/node/v1.3/"+r] = []any{}
+	}
+	nodeSrv := httptest.NewServer(nodeP)
+	defer nodeSrv.Close()
+
+	p := registryPlant(t)
+	p.paths["/x-nmos/query/v1.1/nodes"] = []any{
+		res("11111111-1111-4111-8111-111111111111", "cam-01", map[string]any{"href": nodeSrv.URL + "/"}),
+	}
+	p.paths["/x-nmos/query/v1.3/nodes"] = []any{}
+	regSrv := httptest.NewServer(p)
+	defer regSrv.Close()
+
+	got, err := Run(context.Background(), baseOpts(t, strings.TrimPrefix(regSrv.URL, "http://")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Followed) != 1 {
+		t.Fatalf("followed %d nodes, want 1", len(got.Followed))
+	}
+	if got.Followed[0].Label != "cam-01" {
+		t.Errorf("followed node label = %q", got.Followed[0].Label)
+	}
+	// The node folder must nest under the registry's, or the audit
+	// loads it as an unrelated second plant.
+	want := filepath.Join(got.Dir, "nodes")
+	if !strings.HasPrefix(got.Followed[0].Dir, want) {
+		t.Errorf("node captured at %q, want under %q", got.Followed[0].Dir, want)
+	}
+}
+
+// TestMaxNodesRecordsWhatItSkipped: a coverage cap that is not recorded
+// makes a partial audit look complete.
+func TestMaxNodesRecordsWhatItSkipped(t *testing.T) {
+	nodeP := newPlant(t)
+	nodeP.paths["/x-nmos"] = []string{"node/"}
+	nodeP.paths["/x-nmos/node/"] = []string{"v1.3/"}
+	nodeP.paths["/x-nmos/node/v1.3/self"] = res("11111111-1111-4111-8111-111111111111", "n1", nil)
+	for _, r := range []string{"devices", "sources", "flows", "senders", "receivers"} {
+		nodeP.paths["/x-nmos/node/v1.3/"+r] = []any{}
+	}
+	nodeSrv := httptest.NewServer(nodeP)
+	defer nodeSrv.Close()
+
+	p := registryPlant(t)
+	p.paths["/x-nmos/query/v1.1/nodes"] = []any{
+		res("11111111-1111-4111-8111-111111111111", "n1", map[string]any{"href": nodeSrv.URL + "/"}),
+		res("22222222-2222-4222-8222-222222222222", "n2", map[string]any{"href": nodeSrv.URL + "/"}),
+		res("33333333-3333-4333-8333-333333333333", "n3", map[string]any{"href": "http://198.51.100.99:3212/"}),
+	}
+	p.paths["/x-nmos/query/v1.3/nodes"] = []any{}
+	regSrv := httptest.NewServer(p)
+	defer regSrv.Close()
+
+	opts := baseOpts(t, strings.TrimPrefix(regSrv.URL, "http://"))
+	opts.MaxNodes = 1
+	got, err := Run(context.Background(), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rep := readReport(t, got.Dir)
+	if !strings.Contains(rep, "CAPPED 2 node(s) not followed") {
+		t.Errorf("the cap was not recorded:\n%s", rep)
+	}
+	if !strings.Contains(rep, "SUMMARY 3 listed / 1 followed / 2 capped") {
+		t.Errorf("summary missing or wrong:\n%s", rep)
+	}
+}
+
+// TestNodeWithoutHrefRecorded: a registered node with no usable href
+// cannot be followed, and that is a finding, not a silent omission.
+func TestNodeWithoutHrefRecorded(t *testing.T) {
+	p := registryPlant(t)
+	p.paths["/x-nmos/query/v1.1/nodes"] = []any{res("11111111-1111-4111-8111-111111111111", "ghost", nil)}
+	p.paths["/x-nmos/query/v1.3/nodes"] = []any{}
+	srv := httptest.NewServer(p)
+	defer srv.Close()
+
+	got, err := Run(context.Background(), baseOpts(t, strings.TrimPrefix(srv.URL, "http://")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(readReport(t, got.Dir), "SKIP  node 11111111-1111-4111-8111-111111111111 'ghost'") {
+		t.Errorf("a node with no href should be recorded as skipped:\n%s", readReport(t, got.Dir))
+	}
+}
+
+// TestConnectionDeepAndTransportTypeGating covers the IS-05 walk,
+// including the version rule that avoided 5,951 live 404s.
+func TestConnectionDeepAndTransportTypeGating(t *testing.T) {
+	id := "44444444-4444-4444-8444-444444444444"
+	p := newPlant(t)
+	p.paths["/x-nmos"] = []string{"connection/"}
+	p.paths["/x-nmos/connection/"] = []string{"v1.0/"}
+	p.paths["/x-nmos/connection/v1.0/single/senders"] = []string{id + "/"}
+	p.paths["/x-nmos/connection/v1.0/single/receivers"] = []any{}
+	p.paths["/x-nmos/connection/v1.0/bulk"] = []any{}
+	for _, sub := range []string{"staged", "active", "constraints"} {
+		p.paths["/x-nmos/connection/v1.0/single/senders/"+id+"/"+sub] = map[string]any{"master_enable": true}
+	}
+	srv := httptest.NewServer(p)
+	defer srv.Close()
+
+	opts := baseOpts(t, strings.TrimPrefix(srv.URL, "http://"))
+	opts.Deep = true
+	opts.NoSDP = true
+	if _, err := Run(context.Background(), opts); err != nil {
+		t.Fatal(err)
+	}
+
+	// transporttype arrived in IS-05 v1.1. Requesting it here would be
+	// a guaranteed 404 for every endpoint.
+	if p.hits["/x-nmos/connection/v1.0/single/senders/"+id+"/transporttype"] != 0 {
+		t.Error("transporttype was requested on a v1.0 Connection API")
+	}
+	for _, sub := range []string{"staged", "active", "constraints"} {
+		if p.hits["/x-nmos/connection/v1.0/single/senders/"+id+"/"+sub] != 1 {
+			t.Errorf("--deep did not fetch %s", sub)
+		}
+	}
+}
+
+// TestEmbeddedReceiverSDP: a receiver's SDP is pushed into it by a
+// controller and lives in transport_file.data.
+func TestEmbeddedReceiverSDP(t *testing.T) {
+	id := "88888888-8888-4888-8888-888888888888"
+	p := newPlant(t)
+	p.paths["/x-nmos"] = []string{"connection/"}
+	p.paths["/x-nmos/connection/"] = []string{"v1.1/"}
+	p.paths["/x-nmos/connection/v1.1/single/senders"] = []any{}
+	p.paths["/x-nmos/connection/v1.1/single/receivers"] = []string{id + "/"}
+	p.paths["/x-nmos/connection/v1.1/bulk"] = []any{}
+	p.paths["/x-nmos/connection/v1.1/single/receivers/"+id+"/active"] = map[string]any{
+		"master_enable":  true,
+		"transport_file": map[string]any{"data": "v=0\r\no=- 1 1 IN IP4 198.51.100.5\r\ns=incoming\r\n", "type": "application/sdp"},
+	}
+	srv := httptest.NewServer(p)
+	defer srv.Close()
+
+	got, err := Run(context.Background(), baseOpts(t, strings.TrimPrefix(srv.URL, "http://")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(got.Dir, "sdp", "receivers", id+"_active.sdp")); err != nil {
+		t.Errorf("the embedded receiver SDP was not written: %v", err)
+	}
+	if !strings.Contains(readReport(t, got.Dir), "SDP   receivers "+id+" active (embedded)") {
+		t.Error("the embedded SDP was not recorded in the report")
+	}
+}
+
+// TestEmptyTransportFileIsNotSDP: an unconnected receiver carries an
+// empty transport_file, which must not become a 0-byte SDP file.
+func TestEmptyTransportFileIsNotSDP(t *testing.T) {
+	for _, body := range []string{"", "   ", "v=0"} {
+		if got := embeddedSDP(mustJSON(map[string]any{
+			"transport_file": map[string]any{"data": body},
+		})); got != "" {
+			t.Errorf("embeddedSDP(%q) = %q, want empty", body, got)
+		}
+	}
+	if got := embeddedSDP(mustJSON(map[string]any{"transport_file": map[string]any{"data": nil}})); got != "" {
+		t.Errorf("a null transport_file should yield nothing, got %q", got)
+	}
+	if got := embeddedSDP(nil); got != "" {
+		t.Errorf("embeddedSDP(nil) = %q", got)
+	}
+	if got := embeddedSDP(json.RawMessage("not json")); got != "" {
+		t.Errorf("embeddedSDP of garbage = %q", got)
+	}
+}
+
+func mustJSON(v any) json.RawMessage {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+// TestNoXNMOSRootProbesStandardNames: some devices do not serve the
+// root listing, and their APIs are still there.
+func TestNoXNMOSRootProbesStandardNames(t *testing.T) {
+	p := newPlant(t)
+	p.paths["/x-nmos/node/"] = []string{"v1.3/"}
+	p.paths["/x-nmos/node/v1.3/self"] = res("11111111-1111-4111-8111-111111111111", "quiet", nil)
+	for _, r := range []string{"devices", "sources", "flows", "senders", "receivers"} {
+		p.paths["/x-nmos/node/v1.3/"+r] = []any{}
+	}
+	srv := httptest.NewServer(p)
+	defer srv.Close()
+
+	got, err := Run(context.Background(), baseOpts(t, strings.TrimPrefix(srv.URL, "http://")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Role != "node" || got.Label != "quiet" {
+		t.Errorf("probing did not find the node API: role=%q label=%q", got.Role, got.Label)
+	}
+	if !strings.Contains(readReport(t, got.Dir), "no /x-nmos root") {
+		t.Error("the fallback probe should be recorded")
+	}
+}
+
+// TestUnreachableTargetStillWritesAFolder: a capture that reaches
+// nothing must still leave an attributable folder, or the operator
+// cannot tell a failed run from one that was never started.
+func TestUnreachableTargetStillWritesAFolder(t *testing.T) {
+	opts := baseOpts(t, "198.51.100.253:1")
+	opts.Timeout = 200 * time.Millisecond
+	got, err := Run(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("an unreachable target should not abort the capture: %v", err)
+	}
+	if got.Failures == 0 {
+		t.Error("failures were not counted")
+	}
+	if _, err := os.Stat(filepath.Join(got.Dir, "device.json")); err != nil {
+		t.Errorf("no device.json for an unreachable target: %v", err)
+	}
+	if !strings.Contains(readReport(t, got.Dir), "ERR") {
+		t.Error("the failures were not recorded in the report")
+	}
+	// Empty scaffolding must not be left behind.
+	if _, err := os.Stat(filepath.Join(got.Dir, "sdp")); err == nil {
+		t.Error("an empty sdp/ directory was left in the capture folder")
+	}
+	if _, err := os.Stat(filepath.Join(got.Dir, "raw")); err == nil {
+		t.Error("an empty raw/ directory was left in the capture folder")
+	}
+}
+
+// TestNeverWritesToOutputRoot: a harvest folder that IS the output root
+// leaves raw/ and sdp/ loose at the top, attributable to nothing.
+func TestNeverWritesToOutputRoot(t *testing.T) {
+	if _, err := Run(context.Background(), Options{Target: "!!!", Out: t.TempDir(), Now: fixedNow}); err == nil {
+		t.Error("a target with no usable name should be refused")
+	}
+	if _, err := Run(context.Background(), Options{}); err == nil {
+		t.Error("an empty target should be refused")
+	}
+}
+
+func TestSanitizeAndHostPort(t *testing.T) {
+	if got := sanitize("10.44.55.56:8080"); got != "10_44_55_56_8080" {
+		t.Errorf("sanitize = %q", got)
+	}
+	if got := sanitize("///"); got != "" {
+		t.Errorf("sanitize(///) = %q", got)
+	}
+	for href, want := range map[string]string{
+		"http://198.51.100.5:3212/": "198.51.100.5:3212",
+		"http://198.51.100.5/":      "198.51.100.5:80",
+		"https://198.51.100.5/":     "198.51.100.5:443",
+		"not a url":                 "",
+		"":                          "",
+	} {
+		if got := hostPortOf(href); got != want {
+			t.Errorf("hostPortOf(%q) = %q, want %q", href, got, want)
+		}
+	}
+}
+
+func TestHighestOrdersMinorsNumerically(t *testing.T) {
+	if got := highest([]string{"v1.9", "v1.10", "v1.2"}); got != "v1.10" {
+		t.Errorf("highest = %q, want v1.10 (a string sort gets this wrong)", got)
+	}
+	if got := highest([]string{"bogus"}); got != "bogus" {
+		t.Errorf("highest of one unparseable version = %q", got)
+	}
+	if got := highest(nil); got != "" {
+		t.Errorf("highest(nil) = %q", got)
+	}
+}
+
+func TestAbsolutizeAndStatusToken(t *testing.T) {
+	base := "http://h:80/x-nmos/query/v1.3/nodes"
+	if got := absolutize(base, "?paging.since=2"); got != base+"?paging.since=2" {
+		t.Errorf("relative cursor = %q", got)
+	}
+	if got := absolutize(base, "http://other/x"); got != "http://other/x" {
+		t.Errorf("absolute cursor = %q", got)
+	}
+	if got := absolutize(":://bad", "x"); got != "x" {
+		t.Errorf("unparseable base = %q", got)
+	}
+	if got := statusToken(0); got != "ERR" {
+		t.Errorf("statusToken(0) = %q", got)
+	}
+	if got := statusToken(502); got != "502" {
+		t.Errorf("statusToken(502) = %q", got)
+	}
+}
+
+func TestDedupeByID(t *testing.T) {
+	in := []json.RawMessage{
+		mustJSON(map[string]any{"id": "a"}),
+		mustJSON(map[string]any{"id": "a"}),
+		mustJSON(map[string]any{"id": "b"}),
+		mustJSON("no id here"),
+	}
+	out, dupes := dedupeByID(in)
+	if dupes != 1 {
+		t.Errorf("dupes = %d, want 1", dupes)
+	}
+	if len(out) != 3 {
+		t.Errorf("kept %d, want 3", len(out))
+	}
+}
+
+// TestVisitedTargetsCaptureOnce guards against a registry that lists
+// itself, or two nodes sharing an address, being captured twice.
+func TestVisitedTargetsCaptureOnce(t *testing.T) {
+	visited := newVisitTracker()
+	visited.claim("h:1")
+	got, err := capture(context.Background(), Options{Now: fixedNow, Log: func(string) {}}, t.TempDir(), "h:1", visited)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Error("an already-captured target should be skipped")
+	}
+}
+
+func TestDefaultsAreSane(t *testing.T) {
+	var o Options
+	o.defaults()
+	if o.Out == "" || o.Timeout <= 0 || o.Now == nil || o.Log == nil || o.Client == nil {
+		t.Errorf("defaults left something unset: %+v", o)
+	}
+}

--- a/internal/amwa/session/export/manifest.go
+++ b/internal/amwa/session/export/manifest.go
@@ -1,0 +1,109 @@
+package export
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// ManifestEntry is one captured device, as the manifest lists it.
+//
+// This is the index an operator opens first: which device is in which
+// folder, at which address, under which name. Without it, identifying a
+// device means opening 44 device.json files — or encoding the identity
+// into the folder name, which is what pushed paths past the Windows
+// 260-character limit.
+type ManifestEntry struct {
+	// Folder is relative to the manifest, so the index survives the
+	// capture being moved or renamed.
+	Folder string `json:"folder"`
+	Target string `json:"target"`
+	Host   string `json:"host"`
+	Port   string `json:"port"`
+	Role   string `json:"role"`
+
+	Hostname string `json:"hostname,omitempty"`
+	Label    string `json:"label,omitempty"`
+	ID       string `json:"id,omitempty"`
+
+	APIs     map[string][]string `json:"apis,omitempty"`
+	Requests int                 `json:"requests"`
+	Failures int                 `json:"failures"`
+	SDPFiles int                 `json:"sdp_files"`
+}
+
+// Manifest indexes a whole capture.
+type Manifest struct {
+	CapturedAt string          `json:"captured_at"`
+	Target     string          `json:"target"`
+	Harvester  string          `json:"harvester"`
+	Devices    []ManifestEntry `json:"devices"`
+	// NodesListed is what the registry advertised; len(Devices)-1 is
+	// what answered. The two differing is the plant's stale
+	// registrations, and it belongs on the front page.
+	NodesListed int `json:"nodes_listed,omitempty"`
+}
+
+// writeManifest builds and writes manifest.json at the capture root.
+//
+// It is written last, from the Result tree, so it reflects the final
+// folder names rather than the ones the walk started with.
+func writeManifest(root string, res *Result, opts Options) error {
+	m := Manifest{
+		CapturedAt:  opts.Now().Format("2006-01-02T15:04:05Z07:00"),
+		Target:      res.Target,
+		Harvester:   Version,
+		NodesListed: res.NodesSeen,
+	}
+	collectManifest(root, res, &m)
+	sort.SliceStable(m.Devices, func(i, j int) bool {
+		// Registry first, then by address — the order someone reads it.
+		if (m.Devices[i].Role == "registry") != (m.Devices[j].Role == "registry") {
+			return m.Devices[i].Role == "registry"
+		}
+		return m.Devices[i].Target < m.Devices[j].Target
+	})
+
+	b, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(root, "manifest.json"), b, 0o644)
+}
+
+// collectManifest walks a Result tree into manifest entries.
+func collectManifest(root string, res *Result, m *Manifest) {
+	rel, err := filepath.Rel(root, res.Dir)
+	if err != nil {
+		rel = res.Dir
+	}
+	host, port := splitHostPort(res.Target)
+	m.Devices = append(m.Devices, ManifestEntry{
+		Folder:   filepath.ToSlash(rel),
+		Target:   res.Target,
+		Host:     host,
+		Port:     port,
+		Role:     res.Role,
+		Hostname: res.Hostname,
+		Label:    res.Label,
+		ID:       res.ID,
+		APIs:     res.APIs,
+		Requests: res.Requests,
+		Failures: res.Failures,
+		SDPFiles: res.SDPFiles,
+	})
+	for i := range res.Followed {
+		collectManifest(root, &res.Followed[i], m)
+	}
+}
+
+// splitHostPort separates `host:port` without failing on a bare host.
+func splitHostPort(target string) (host, port string) {
+	i := strings.LastIndex(target, ":")
+	if i < 0 {
+		return target, ""
+	}
+	return target[:i], target[i+1:]
+}

--- a/internal/amwa/session/export/paging_test.go
+++ b/internal/amwa/session/export/paging_test.go
@@ -1,0 +1,746 @@
+package export
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// pagingMode selects which of the three cursor signals a fake registry
+// offers. Real registries differ here, and relying on only the first
+// one ended a field capture after ten nodes.
+type pagingMode int
+
+const (
+	// modeLink emits the full prev/next Link set, as a real registry
+	// does.
+	modeLink pagingMode = iota
+	// modeHeaders emits X-Paging-* and NO Link header.
+	modeHeaders
+	// modeBare emits neither: a full page and nothing else to go on.
+	modeBare
+	// modeIgnoreSince serves the same first page forever, whatever
+	// cursor it is handed.
+	modeIgnoreSince
+)
+
+// pagingRegistry serves `total` nodes in pages of `limit`, honouring
+// paging.since over the resource version.
+type pagingRegistry struct {
+	total int
+	limit int
+	mode  pagingMode
+	// serverLimit caps what the registry will serve regardless of what
+	// the client asks for, the way a real one clamps paging.limit.
+	serverLimit int
+	requests    int
+}
+
+// nodeAt builds node N with version N+1000 seconds, so versions sort in
+// the order the registry serves them.
+func nodeAt(i int) map[string]any {
+	return map[string]any{
+		"id":      fmt.Sprintf("%08d-1111-4111-8111-111111111111", i),
+		"version": fmt.Sprintf("%d:0", 1000+i),
+		"label":   fmt.Sprintf("node-%03d", i),
+		"tags":    map[string]any{},
+	}
+}
+
+func (p *pagingRegistry) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/x-nmos":
+		writeJSON(w, []string{"query/"})
+		return
+	case "/x-nmos/query/":
+		writeJSON(w, []string{"v1.3/"})
+		return
+	}
+	if r.URL.Path != "/x-nmos/query/v1.3/nodes" {
+		if strings.HasPrefix(r.URL.Path, "/x-nmos/query/v1.3/") {
+			writeJSON(w, []any{})
+			return
+		}
+		http.NotFound(w, r)
+		return
+	}
+
+	p.requests++
+
+	limit := p.limit
+	if askedRaw := r.URL.Query().Get("paging.limit"); askedRaw != "" {
+		if asked, err := strconv.Atoi(askedRaw); err == nil && asked > 0 {
+			limit = asked
+		}
+	}
+	if p.serverLimit > 0 && limit > p.serverLimit {
+		limit = p.serverLimit
+	}
+
+	// IS-04 orders a collection by `version`, NEWEST FIRST, and pages
+	// backwards over it. `paging.until` names the newest version the
+	// caller wants; the page returned is the `limit` resources at or
+	// below it. That is what a real registry does, and modelling it
+	// forwards is what let a 100-of-5222 capture look complete.
+	//
+	// Resource i has version 1000+i, so the newest is total-1.
+	top := p.total - 1
+	if p.mode != modeIgnoreSince {
+		if until := r.URL.Query().Get("paging.until"); until != "" {
+			sec, _, ok := splitTAI(until)
+			if ok {
+				// Strictly older than the boundary the caller gave.
+				top = int(sec) - 1000 - 1
+			}
+		}
+	}
+
+	out := []any{}
+	oldest := top
+	for i := top; i >= 0 && len(out) < limit; i-- {
+		out = append(out, nodeAt(i))
+		oldest = i
+	}
+
+	switch p.mode {
+	case modeLink:
+		// A real registry emits BOTH members on every response,
+		// including the last — so the presence of `next` says nothing
+		// about whether more resources exist.
+		next := fmt.Sprintf(`<%s?paging.since=%d:0>; rel="next"`, r.URL.Path, 1000+top)
+		if len(out) > 0 {
+			prev := fmt.Sprintf(`<%s?paging.until=%d:0>; rel="prev"`, r.URL.Path, 1000+oldest)
+			w.Header().Set("Link", next+", "+prev)
+		} else {
+			w.Header().Set("Link", next)
+		}
+	case modeHeaders, modeIgnoreSince:
+		w.Header().Set("X-Paging-Limit", strconv.Itoa(limit))
+		if len(out) > 0 {
+			w.Header().Set("X-Paging-Since", fmt.Sprintf("%d:0", 1000+oldest))
+			w.Header().Set("X-Paging-Until", fmt.Sprintf("%d:0", 1000+top))
+		}
+	case modeBare:
+		// nothing at all
+	}
+	writeJSON(w, out)
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func exportNodes(t *testing.T, p *pagingRegistry) (*Result, string) {
+	t.Helper()
+	srv := httptest.NewServer(p)
+	t.Cleanup(srv.Close)
+
+	opts := baseOpts(t, strings.TrimPrefix(srv.URL, "http://"))
+	got, err := Run(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	return got, readReport(t, got.Dir)
+}
+
+// TestPagingWithoutLinkHeader is the field failure that prompted this:
+// a registry serving ten per page with no `Link: rel="next"` ended the
+// walk after one page and reported a ten-node plant.
+func TestPagingWithoutLinkHeader(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		mode pagingMode
+	}{
+		{"Link header (AMWA reference)", modeLink},
+		{"X-Paging-* only, no Link", modeHeaders},
+		{"no paging headers at all", modeBare},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// serverLimit 10 makes the registry clamp to ten per page
+			// no matter what we ask for — the observed field shape.
+			p := &pagingRegistry{total: 44, limit: 10, serverLimit: 10, mode: tc.mode}
+			got, rep := exportNodes(t, p)
+			if got.NodesSeen != 44 {
+				t.Errorf("captured %d of 44 nodes\n%s", got.NodesSeen, rep)
+			}
+		})
+	}
+}
+
+// TestPagingAsksForABigPage: left to itself a registry applies its own
+// default, and the walk costs a round trip per ten resources.
+func TestPagingAsksForABigPage(t *testing.T) {
+	p := &pagingRegistry{total: 44, limit: 10, mode: modeLink}
+	got, rep := exportNodes(t, p)
+	if got.NodesSeen != 44 {
+		t.Fatalf("captured %d of 44\n%s", got.NodesSeen, rep)
+	}
+	// 44 nodes at the requested 100 per page is one page, plus the
+	// empty page that ends the walk.
+	if p.requests > 3 {
+		t.Errorf("took %d requests for 44 nodes; paging.limit was not honoured", p.requests)
+	}
+	if !strings.Contains(rep, "paging.limit") && !strings.Contains(rep, "PAGING") {
+		t.Errorf("the paging decision was not recorded:\n%s", rep)
+	}
+}
+
+// TestPagingEvidenceIsRecorded: a short capture in the field has to be
+// diagnosable from report.txt alone. Not recording this is why the
+// original failure needed a guess.
+func TestPagingEvidenceIsRecorded(t *testing.T) {
+	p := &pagingRegistry{total: 5, limit: 10, mode: modeHeaders}
+	_, rep := exportNodes(t, p)
+	for _, want := range []string{"PAGING", "X-Paging-Limit=", "Link="} {
+		if !strings.Contains(rep, want) {
+			t.Errorf("report.txt is missing %q:\n%s", want, rep)
+		}
+	}
+}
+
+// TestPagingStopsOnIgnoredCursor: a registry that serves the same page
+// whatever cursor it is given must stop the walk and be recorded, not
+// loop and not silently truncate.
+func TestPagingStopsOnIgnoredCursor(t *testing.T) {
+	p := &pagingRegistry{total: 44, limit: 10, serverLimit: 10, mode: modeIgnoreSince}
+	got, rep := exportNodes(t, p)
+	if !strings.Contains(rep, "paging cursor did not advance") {
+		t.Errorf("a stuck cursor was not recorded:\n%s", rep)
+	}
+	// It captured what it could rather than nothing.
+	if got.NodesSeen == 0 {
+		t.Error("the walk should keep the page it did get")
+	}
+	if p.requests > 10 {
+		t.Errorf("%d requests — the walk did not stop", p.requests)
+	}
+}
+
+// TestShortPageEndsTheWalk: without a Link header, a page shorter than
+// the requested limit is the only safe end-of-collection signal.
+func TestShortPageEndsTheWalk(t *testing.T) {
+	p := &pagingRegistry{total: 7, limit: 100, mode: modeBare}
+	got, rep := exportNodes(t, p)
+	if got.NodesSeen != 7 {
+		t.Errorf("captured %d of 7\n%s", got.NodesSeen, rep)
+	}
+	// With no Link and no X-Paging-Limit there is no evidence of what
+	// the registry applied, so the walk probes one more page rather
+	// than guessing the collection ended. One wasted request is the
+	// price of never truncating a plant silently.
+	if p.requests > 2 {
+		t.Errorf("a short first page should end the walk in at most 2 requests; took %d", p.requests)
+	}
+}
+
+func TestMinVersionAndTAIOrdering(t *testing.T) {
+	items := []json.RawMessage{
+		json.RawMessage(`{"version":"1000:5"}`),
+		json.RawMessage(`{"version":"1000:900"}`),
+		json.RawMessage(`{"version":"999:999999999"}`),
+		json.RawMessage(`{"version":"not-a-version"}`),
+		json.RawMessage(`{"no":"version"}`),
+	}
+	if got := minVersion(items); got != "999:999999999" {
+		t.Errorf("minVersion = %q, want 999:999999999", got)
+	}
+	if minVersion(nil) != "" {
+		t.Error("minVersion of nothing should be empty")
+	}
+	// A malformed version must never win, or the cursor jumps.
+	if taiLess("1000:0", "garbage") {
+		t.Error("a malformed version must not outrank a valid one")
+	}
+	if !taiLess("garbage", "1000:0") {
+		t.Error("a valid version must outrank a malformed one")
+	}
+	if !taiLess("999:0", "1000:0") || taiLess("1000:0", "999:0") {
+		t.Error("seconds must dominate the comparison")
+	}
+}
+
+// sdpNode serves a sender whose SDP is published at both its IS-04
+// manifest_href and its IS-05 transportfile.
+type sdpNode struct {
+	is04SDP string
+	is05SDP string
+}
+
+const sdpSenderID = "44444444-4444-4444-8444-444444444444"
+
+func (n *sdpNode) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/x-nmos":
+		writeJSON(w, []string{"node/", "connection/"})
+	case "/x-nmos/node/":
+		writeJSON(w, []string{"v1.3/"})
+	case "/x-nmos/node/v1.3/self":
+		writeJSON(w, map[string]any{"id": "11111111-1111-4111-8111-111111111111", "version": "1:0", "label": "n"})
+	case "/x-nmos/node/v1.3/senders":
+		writeJSON(w, []any{map[string]any{
+			"id": sdpSenderID, "version": "1:0", "label": "s", "tags": map[string]any{},
+			"transport": "urn:x-nmos:transport:rtp.mcast", "device_id": "33333333-3333-4333-8333-333333333333",
+			"manifest_href": "/x-nmos/node/v1.3/sdp/" + sdpSenderID,
+		}})
+	case "/x-nmos/node/v1.3/sdp/" + sdpSenderID:
+		w.Header().Set("Content-Type", "application/sdp")
+		_, _ = w.Write([]byte(n.is04SDP))
+	case "/x-nmos/connection/":
+		writeJSON(w, []string{"v1.1/"})
+	case "/x-nmos/connection/v1.1/single/senders":
+		writeJSON(w, []string{sdpSenderID + "/"})
+	case "/x-nmos/connection/v1.1/single/senders/" + sdpSenderID + "/transportfile":
+		w.Header().Set("Content-Type", "application/sdp")
+		_, _ = w.Write([]byte(n.is05SDP))
+	case "/x-nmos/connection/v1.1/single/receivers":
+		writeJSON(w, []any{})
+	default:
+		if strings.HasPrefix(r.URL.Path, "/x-nmos/node/v1.3/") || strings.HasPrefix(r.URL.Path, "/x-nmos/connection/") {
+			writeJSON(w, []any{})
+			return
+		}
+		http.NotFound(w, r)
+	}
+}
+
+// TestSenderSDPPublishedTwice: a sender publishes its SDP at the IS-04
+// manifest_href AND the IS-05 transportfile. Writing both when they
+// agree doubled the SDP folder for nothing — 366 files where 190 would
+// do on one real device. Fetching both is still right, because a node
+// publishing two different descriptions of one stream is a real fault
+// and only comparing them finds it.
+func TestSenderSDPPublishedTwice(t *testing.T) {
+	const body = "v=0\r\no=- 1 1 IN IP4 198.51.100.5\r\ns=one\r\n"
+
+	t.Run("identical - one file per source, agreement recorded", func(t *testing.T) {
+		srv := httptest.NewServer(&sdpNode{is04SDP: body, is05SDP: body})
+		defer srv.Close()
+		got, err := Run(context.Background(), baseOpts(t, strings.TrimPrefix(srv.URL, "http://")))
+		if err != nil {
+			t.Fatal(err)
+		}
+		// One file per publication point, in its own folder, named by
+		// the resource id alone. `diff -r sdp/is04 sdp/is05` is then the
+		// disagreement check.
+		if got.SDPFiles != 2 {
+			t.Errorf("wrote %d SDP files, want one per source", got.SDPFiles)
+		}
+		for _, rel := range []string{
+			filepath.Join("is04", sdpSenderID+".sdp"),
+			filepath.Join("is05", sdpSenderID+".sdp"),
+		} {
+			if _, err := os.Stat(filepath.Join(got.Dir, "sdp", rel)); err != nil {
+				t.Errorf("%s missing: %v", rel, err)
+			}
+		}
+		rep := readReport(t, got.Dir)
+		if !strings.Contains(rep, "matches") {
+			t.Errorf("the agreement was not recorded:\n%s", rep)
+		}
+		if strings.Contains(rep, "DIFFERENT SDP") {
+			t.Error("identical SDPs were reported as differing")
+		}
+	})
+
+	t.Run("different - both kept, disagreement warned", func(t *testing.T) {
+		srv := httptest.NewServer(&sdpNode{
+			is04SDP: body,
+			is05SDP: "v=0\r\no=- 2 2 IN IP4 198.51.100.5\r\ns=OTHER\r\n",
+		})
+		defer srv.Close()
+		got, err := Run(context.Background(), baseOpts(t, strings.TrimPrefix(srv.URL, "http://")))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.SDPFiles != 2 {
+			t.Errorf("wrote %d SDP files, want 2 when the sources disagree", got.SDPFiles)
+		}
+		rep := readReport(t, got.Dir)
+		if !strings.Contains(rep, "DIFFERENT SDP") {
+			t.Errorf("the disagreement was not reported:\n%s", rep)
+		}
+		// Both copies survive, one per source folder, so the evidence
+		// for the finding is still on disk.
+		for _, rel := range []string{
+			filepath.Join("is04", sdpSenderID+".sdp"),
+			filepath.Join("is05", sdpSenderID+".sdp"),
+		} {
+			if _, err := os.Stat(filepath.Join(got.Dir, "sdp", rel)); err != nil {
+				t.Errorf("%s was not kept: %v", rel, err)
+			}
+		}
+	})
+}
+
+// identityNode serves a node with a chosen hostname and label, so the
+// folder-naming rules can be exercised.
+type identityNode struct{ hostname, label string }
+
+func (n *identityNode) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/x-nmos":
+		writeJSON(w, []string{"node/"})
+	case "/x-nmos/node/":
+		writeJSON(w, []string{"v1.3/"})
+	case "/x-nmos/node/v1.3/self":
+		writeJSON(w, map[string]any{
+			"id": "11111111-1111-4111-8111-111111111111", "version": "1:0",
+			"label": n.label, "hostname": n.hostname,
+		})
+	default:
+		writeJSON(w, []any{})
+	}
+}
+
+// TestFolderCarriesHostnameAndLabel: `10_41_40_80_3000` tells an
+// operator nothing six months later. Both hostname and label are
+// appended because they are frequently different and both are how
+// someone searches — DNS knows one, the operator typed the other.
+func TestFolderCarriesHostnameAndLabel(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		hostname string
+		label    string
+		wantHas  []string
+		wantNot  []string
+	}{
+		// The label wins: it is what an operator typed and searches for.
+		// The full identity — hostname, id, APIs — is in manifest.json,
+		// which is what keeps the folder short enough to copy.
+		{"both - label wins", "bm-n-nnbrg-t01", "Nevion Virtuoso 1",
+			[]string{"Nevion_Virtuoso_1"}, []string{"bm_n_nnbrg_t01"}},
+		{"identical - not repeated", "cam-01", "cam-01",
+			[]string{"cam_01"}, []string{"cam_01__cam_01"}},
+		{"hostname only - used as fallback", "cam-02", "",
+			[]string{"cam_02"}, nil},
+		{"label only", "", "cam-03",
+			[]string{"cam_03"}, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(&identityNode{hostname: tc.hostname, label: tc.label})
+			defer srv.Close()
+			got, err := Run(context.Background(), baseOpts(t, strings.TrimPrefix(srv.URL, "http://")))
+			if err != nil {
+				t.Fatal(err)
+			}
+			base := filepath.Base(got.Dir)
+			for _, want := range tc.wantHas {
+				if !strings.Contains(base, want) {
+					t.Errorf("folder %q does not carry %q", base, want)
+				}
+			}
+			for _, not := range tc.wantNot {
+				if strings.Contains(base, not) {
+					t.Errorf("folder %q repeats itself: %q", base, not)
+				}
+			}
+			// The address stays, because it is the only unambiguous part.
+			if !strings.Contains(base, "127_0_0_1") {
+				t.Errorf("folder %q lost the address", base)
+			}
+			// And the folder the Result names must be the one on disk.
+			if _, err := os.Stat(got.Dir); err != nil {
+				t.Errorf("Result.Dir does not exist after the rename: %v", err)
+			}
+		})
+	}
+}
+
+// TestAnonymousDeviceKeepsAddressOnlyFolder: a device that names itself
+// nothing keeps the address-only folder rather than gaining a trailing
+// separator.
+func TestAnonymousDeviceKeepsAddressOnlyFolder(t *testing.T) {
+	srv := httptest.NewServer(&identityNode{})
+	defer srv.Close()
+	got, err := Run(context.Background(), baseOpts(t, strings.TrimPrefix(srv.URL, "http://")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.HasSuffix(filepath.Base(got.Dir), "__") {
+		t.Errorf("folder %q gained an empty identity suffix", filepath.Base(got.Dir))
+	}
+}
+
+// TestManifestIndexesThePlant: the manifest is the index someone opens
+// first, and it is what lets folder names stay short enough to copy.
+func TestManifestIndexesThePlant(t *testing.T) {
+	nodeSrv := httptest.NewServer(&identityNode{hostname: "neuron-0003", label: "bm-n-nnbrg-t01"})
+	defer nodeSrv.Close()
+
+	reg := &pagingRegistry{total: 0, limit: 100, mode: modeLink}
+	regSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/x-nmos/query/v1.3/nodes" {
+			writeJSON(w, []any{map[string]any{
+				"id": "11111111-1111-4111-8111-111111111111", "version": "1000:0",
+				"label": "bm-n-nnbrg-t01", "href": nodeSrv.URL + "/",
+			}})
+			return
+		}
+		reg.ServeHTTP(w, r)
+	}))
+	defer regSrv.Close()
+
+	out := t.TempDir()
+	opts := baseOpts(t, strings.TrimPrefix(regSrv.URL, "http://"))
+	opts.Out = out
+	if _, err := Run(context.Background(), opts); err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := os.ReadFile(filepath.Join(out, "manifest.json"))
+	if err != nil {
+		t.Fatalf("no manifest at the capture root: %v", err)
+	}
+	var m Manifest
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("manifest is not valid JSON: %v", err)
+	}
+	if len(m.Devices) != 2 {
+		t.Fatalf("manifest lists %d devices, want registry + node", len(m.Devices))
+	}
+	// Registry first — the order someone reads it in.
+	if m.Devices[0].Role != "registry" {
+		t.Errorf("first entry is %q, want the registry", m.Devices[0].Role)
+	}
+
+	node := m.Devices[1]
+	for name, got := range map[string]string{
+		"role": node.Role, "hostname": node.Hostname, "label": node.Label,
+		"host": node.Host, "port": node.Port, "folder": node.Folder, "id": node.ID,
+	} {
+		if got == "" {
+			t.Errorf("manifest entry has no %s", name)
+		}
+	}
+	if node.Hostname != "neuron-0003" || node.Label != "bm-n-nnbrg-t01" {
+		t.Errorf("identity not carried: hostname=%q label=%q", node.Hostname, node.Label)
+	}
+	if len(node.APIs) == 0 {
+		t.Error("manifest does not record which APIs the node serves")
+	}
+	// The folder must be RELATIVE, so the capture survives being moved.
+	if filepath.IsAbs(node.Folder) {
+		t.Errorf("folder %q is absolute; the manifest would break on a copy", node.Folder)
+	}
+	if _, err := os.Stat(filepath.Join(out, filepath.FromSlash(node.Folder))); err != nil {
+		t.Errorf("manifest points at a folder that is not there: %v", err)
+	}
+}
+
+// TestRawIsOptIn: raw/ duplicates tree.json and was 14,719 of the
+// 27,299 files on a real plant — and held every path over the Windows
+// 260-character limit.
+func TestRawIsOptIn(t *testing.T) {
+	newSrv := func() *httptest.Server {
+		return httptest.NewServer(&identityNode{hostname: "h", label: "l"})
+	}
+
+	srv := newSrv()
+	defer srv.Close()
+	got, err := Run(context.Background(), baseOpts(t, strings.TrimPrefix(srv.URL, "http://")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(got.Dir, "raw")); err == nil {
+		t.Error("raw/ was written without --raw")
+	}
+	// tree.json still carries every body, so nothing is lost.
+	if _, err := os.Stat(filepath.Join(got.Dir, "tree.json")); err != nil {
+		t.Errorf("tree.json missing: %v", err)
+	}
+
+	srv2 := newSrv()
+	defer srv2.Close()
+	opts := baseOpts(t, strings.TrimPrefix(srv2.URL, "http://"))
+	opts.Raw = true
+	got2, err := Run(context.Background(), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(got2.Dir, "raw")); err != nil {
+		t.Errorf("--raw did not write raw/: %v", err)
+	}
+}
+
+// TestFollowedNodesAreNotStampedTwice: a followed node already sits
+// inside a stamped registry folder, so stamping it again adds 16
+// characters to every path below it and says nothing new.
+func TestFollowedNodesAreNotStampedTwice(t *testing.T) {
+	nodeSrv := httptest.NewServer(&identityNode{hostname: "h", label: "cam-01"})
+	defer nodeSrv.Close()
+
+	reg := &pagingRegistry{total: 0, limit: 100, mode: modeLink}
+	regSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/x-nmos/query/v1.3/nodes" {
+			writeJSON(w, []any{map[string]any{
+				"id": "11111111-1111-4111-8111-111111111111", "version": "1000:0",
+				"label": "cam-01", "href": nodeSrv.URL + "/",
+			}})
+			return
+		}
+		reg.ServeHTTP(w, r)
+	}))
+	defer regSrv.Close()
+
+	opts := baseOpts(t, strings.TrimPrefix(regSrv.URL, "http://"))
+	opts.NoStamp = false // the registry IS stamped
+	got, err := Run(context.Background(), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(filepath.Base(got.Dir), "_20260824-") {
+		t.Errorf("the top-level capture should be stamped: %q", filepath.Base(got.Dir))
+	}
+	if len(got.Followed) != 1 {
+		t.Fatalf("followed %d nodes", len(got.Followed))
+	}
+	child := filepath.Base(got.Followed[0].Dir)
+	if strings.Contains(child, "_20260824-") {
+		t.Errorf("followed node was stamped again: %q", child)
+	}
+	if !strings.Contains(child, "cam_01") {
+		t.Errorf("followed node lost its identity: %q", child)
+	}
+}
+
+// TestNodesAreCapturedConcurrently: each node is ~600 requests against
+// a different device, so the walk is latency-bound and parallelises
+// almost perfectly. In series, 44 nodes took four minutes.
+//
+// Run this with -race in CI; it is the only place the worker pool,
+// the shared visit tracker and the per-node harvesters meet.
+func TestNodesAreCapturedConcurrently(t *testing.T) {
+	const (
+		nodes   = 12
+		perReq  = 60 * time.Millisecond
+		workers = 6
+	)
+
+	// One server per node, each slow, so the walk is latency-bound the
+	// way a real plant is.
+	list := make([]any, 0, nodes)
+	for i := 0; i < nodes; i++ {
+		n := &identityNode{hostname: fmt.Sprintf("h%02d", i), label: fmt.Sprintf("node-%02d", i)}
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(perReq)
+			n.ServeHTTP(w, r)
+		}))
+		t.Cleanup(srv.Close)
+		list = append(list, map[string]any{
+			"id":      fmt.Sprintf("%08d-1111-4111-8111-111111111111", i),
+			"version": fmt.Sprintf("%d:0", 1000+i),
+			"label":   n.label,
+			"href":    srv.URL + "/",
+		})
+	}
+
+	reg := &pagingRegistry{total: 0, limit: 100, mode: modeLink}
+	regSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/x-nmos/query/v1.3/nodes" {
+			writeJSON(w, list)
+			return
+		}
+		reg.ServeHTTP(w, r)
+	}))
+	defer regSrv.Close()
+
+	opts := baseOpts(t, strings.TrimPrefix(regSrv.URL, "http://"))
+	opts.Workers = workers
+
+	start := time.Now()
+	got, err := Run(context.Background(), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	elapsed := time.Since(start)
+
+	if len(got.Followed) != nodes {
+		t.Fatalf("followed %d of %d nodes", len(got.Followed), nodes)
+	}
+	// Results keep the registry's order regardless of completion order,
+	// so a capture is reproducible.
+	for i, f := range got.Followed {
+		want := fmt.Sprintf("node-%02d", i)
+		if f.Label != want {
+			t.Errorf("result %d is %q, want %q — the pool reordered them", i, f.Label, want)
+		}
+	}
+
+	// Each node costs at least a handful of sequential requests. Serial
+	// would be nodes x that; with `workers` running at once it should be
+	// close to nodes/workers of it. The bound is loose on purpose — this
+	// asserts "parallel", not a stopwatch.
+	serialFloor := time.Duration(nodes) * 5 * perReq
+	if elapsed > serialFloor {
+		t.Errorf("capture took %s, serial would be about %s — the pool is not running nodes in parallel",
+			elapsed.Round(time.Millisecond), serialFloor)
+	}
+}
+
+func TestWorkersDefault(t *testing.T) {
+	if got := (Options{}).workers(); got != defaultWorkers {
+		t.Errorf("default workers = %d, want %d", got, defaultWorkers)
+	}
+	if got := (Options{Workers: 3}).workers(); got != 3 {
+		t.Errorf("explicit workers = %d, want 3", got)
+	}
+}
+
+func TestVisitTrackerClaimsOnce(t *testing.T) {
+	v := newVisitTracker()
+	if !v.claim("a:1") {
+		t.Error("first claim should succeed")
+	}
+	if v.claim("a:1") {
+		t.Error("second claim of the same target must fail")
+	}
+	if !v.claim("b:1") {
+		t.Error("a different target should claim")
+	}
+}
+
+func TestIdentitySuffix(t *testing.T) {
+	// One part, not two: the folder recognises a device, the manifest
+	// identifies it. Two parts produced 76-character folders and 329
+	// paths past the Windows limit on one real plant.
+	if got := identitySuffix("host", "label"); got != "label" {
+		t.Errorf("identitySuffix = %q, want the label", got)
+	}
+	if got := identitySuffix("host", ""); got != "host" {
+		t.Errorf("the hostname is the fallback, got %q", got)
+	}
+	if got := identitySuffix("", ""); got != "" {
+		t.Errorf("identitySuffix of nothing = %q", got)
+	}
+	// Windows MAX_PATH is 260 and these folders nest one level under a
+	// registry capture; a label that is a sentence has produced
+	// unopenable paths before.
+	long := strings.Repeat("x", 200)
+	if got := identitySuffix("", long); len(got) > 24 {
+		t.Errorf("a long label was not capped: %d chars", len(got))
+	}
+}
+
+func TestWithQuery(t *testing.T) {
+	got := withQuery("http://h/x-nmos/query/v1.3/nodes", "paging.limit", "100")
+	if !strings.Contains(got, "paging.limit=100") {
+		t.Errorf("withQuery = %q", got)
+	}
+	// Replacing, not appending — two limits would be ambiguous.
+	got = withQuery(got, "paging.limit", "50")
+	if strings.Count(got, "paging.limit") != 1 || !strings.Contains(got, "paging.limit=50") {
+		t.Errorf("withQuery did not replace: %q", got)
+	}
+	if got := withQuery(":://bad", "a", "b"); got != ":://bad" {
+		t.Errorf("an unparseable URL should pass through, got %q", got)
+	}
+}


### PR DESCRIPTION
> **Stacked on #836.** Base is `feat/nmos-audit`; GitHub retargets to `main` when #836 merges. Review #836 first.

## What

`dhs consumer nmos export --target <host:port>` — plant capture in Go, writing exactly the layout `dhs consumer nmos audit` reads.

Together the two verbs are one workflow: **capture on the customer's network, audit anywhere.**

```bash
dhs consumer nmos export --target 10.44.55.56:8080 --out ./plant
dhs consumer nmos audit  --dir ./plant --min-severity warn
```

## Why

The exporter was PowerShell. That is fine at a Windows desk and wrong everywhere else: it does not run on the Linux control node, in CI, or in a container; no test covered it; and nothing kept its output format in step with the audit that reads it.

Closes #837

## Scope

- [x] osc / tsl / cerebrum-nb / amwa

## Reference controller

- [x] N/A — read-only capture, no wire behaviour changes

## Type

- [x] feat — new feature

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `internal/amwa/session/export/export.go` | new | the capture: API discovery, per-spec walks, paging, SDP, node following |
| `internal/amwa/session/export/export_test.go` | new | the behaviours that cost a real capture when missing |
| `internal/amwa/session/export/export_edge_test.go` | new | generic API walks, TLS, cancellation, malformed answers |
| `cmd/dhs/cmd_nmos_export.go` | new | the verb |
| `cmd/dhs/cmd_nmos_export_audit_test.go` | new | export → audit round-trip over a fake plant |
| `cmd/dhs/cmd_nmos.go` | modified | dispatch + help |

## Design decisions

**The capture never repairs.** A 502, a stuck cursor, an unreachable node — each is recorded and the walk continues. The audit turns those recordings into findings, and it can only do that if the capture did not paper over them first.

**Four behaviours carried over from the script**, each of which cost a real capture when it was missing:

| Rule | What it cost |
|---|---|
| Walk a registry's query API at **every** minor | version isolation hid 6 of 45 nodes |
| Follow `Link: rel="next"` | a 68-node registry captured 11 |
| Follow `manifest_href` **verbatim**, relative form included | a constructed `/transportfile` produced 1088 errors on a device that serves SDP elsewhere |
| Request `transporttype` only on IS-05 ≥ v1.1 | one run produced 5,951 404s |

**A node's own API is walked at the highest minor only.** It repeats identical resources at every minor; walking all four quadruples the requests for the same bytes. The asymmetry with the query API is the whole point — the two are different for a reason, and treating them alike loses either devices or time.

## Two defects the round-trip test found

Neither was visible from either package alone.

**A node that answered nothing was left as an empty harvest folder.** It then audited as a fourth device with no APIs, and the registry advertising a dead node produced no finding at all. It is now removed and recorded as `SKIP` on the parent — which is exactly the line the audit reads to report `NMOS-NODE-UNREACHABLE`.

**A collection captured as `[]` was treated like one never captured.** The audit suppresses dangling-reference findings when a collection was not reached, to avoid flooding a partial export with noise. But `"flows": []` is the device *saying it has no flows*, so a sender pointing at one is broken. Conflating the two silently suppressed the finding on every node that publishes empty collections — which is most of them. Fixed in #836, with its own test.

## Test results

| | |
|---|---|
| `go test ./internal/amwa/session/export/...` | pass |
| Coverage | **91.8% of statements** |
| `go build ./...` / `go vet ./...` | clean |
| `golangci-lint run` | **0 issues** |

The round-trip test builds a fake plant carrying seven known defects, exports it, audits it, and asserts every one is found:

```text
NMOS-PLANT-MCAST-COLLISION      both nodes on 233.252.0.20:20000
NMOS-QUERY-VERSION-ISOLATION    3 nodes at v1.1, 1 at v1.3
NMOS-NODE-UNREACHABLE           a registered node that answers nowhere
NMOS-HTTP-SERVER-FAULT          502 on the transport files
NMOS-IS04-DANGLING-REF          sender points at an unpublished flow
NMOS-IS04-CONTROL-MISSING       IS-05 served, no sr-ctrl control
NMOS-2022-7-SINGLE-LEG          two NICs bound, one leg staged
```

A rename on either side of the file format now fails the build, instead of silently producing empty audits.

## Device tested

- [x] No device needed — `httptest` throughout. This is what makes the workflow runnable in CI; it does not replace running it against the real plant, which is the next step.

## Not in this unit

`dhs consumer nmos probe` — live protocol conformance (version negotiation, unknown-version handling, CORS, content types, heartbeat lifecycle) with per-endpoint latency, emitted as JSONL. That is the AMWA-test-tool-shaped verb, and it belongs on top of this one.

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies (stdlib only)
- [x] Integration tested on VM before PR — httptest plant; real-plant run pending

## Approval

@yboujraf — requesting review