### PR TITLE
fix(ci): run CI on every PR, not only those targeting main (#843)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,12 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    # No branch filter, deliberately. A stacked PR targets its parent
+    # branch rather than main, and a filtered trigger gives those PRs no
+    # CI at all - so the unit under active review is the one running
+    # unverified, which is exactly backwards. Stacked units are how a
+    # dependent change stays reviewable on its own; they must be gated
+    # the same as any other.
     # The release-please PR touches ONLY these two bot-owned files and is
     # re-force-pushed on every merge to main; each force-push spawned a CI
     # run that parked at action_required (bot-authored PR + workflow


### PR DESCRIPTION
## What

Drop the `branches` filter from the `pull_request` trigger in `ci.yml`, so every PR runs CI regardless of base.

## Why

A stacked PR targets its parent branch, so `branches: [main]` gave it **no CI at all**:

| PR | base | checks before |
|---|---|---|
| #836 | `main` | 9, green |
| #838 | `feat/nmos-audit` | **0** |
| #842 | `feat/nmos-export` | **0** |

The unit under active review was the one running unverified.

Closes #843

## Scope

- [x] N/A — repo infrastructure

## Type

- [x] fix

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `.github/workflows/ci.yml` | modified | remove the `pull_request` branch filter |

## Unaffected

- `push: branches: [main]` — post-merge verification
- `paths-ignore` — the release-please noise guard (ADR-0029)
- `concurrency` — still one live run per ref, main never cancelled

## Cost

A three-deep stack runs the matrix three times instead of once. Cheap next to merging an unverified unit.

## Test results

Verification is the effect on #838 and #842 once this merges: both should show the full check set. Nothing else changes.

## Device tested

- [x] N/A

## Checklist

- [x] No new external dependencies
- [x] Existing triggers preserved

## Approval

@yboujraf — requesting review. This is the CI change you asked for; per ADR-0014 it is its own unit rather than folded into the NMOS work.