### PR TITLE
feat(nmos/audit): BCP-002 group/level pivot (#845)

### DIFF
--- a/internal/amwa/audit/audit.go
+++ b/internal/amwa/audit/audit.go
@@ -29,12 +29,23 @@ type Inventory struct {
 	Senders   int `json:"senders,omitempty"`
 	Receivers int `json:"receivers,omitempty"`
 	SDPFiles  int `json:"sdp_files,omitempty"`
+
+	// HintedSenders / HintedReceivers / Groups measure BCP-002-01
+	// grouping on this device: how many resources carry a group hint,
+	// and how many distinct groups they name. This is the answer to
+	// "which nodes actually express which essences belong together".
+	HintedSenders   int `json:"hinted_senders,omitempty"`
+	HintedReceivers int `json:"hinted_receivers,omitempty"`
+	Groups          int `json:"groups,omitempty"`
 }
 
 // Result is a complete audit: what was found, and what is wrong with it.
 type Result struct {
 	Inventory []Inventory `json:"inventory"`
-	Findings  []Finding   `json:"findings"`
+	// Groups is the plant pivoted by BCP-002-01 group hint: what a
+	// controller would be able to offer as one signal.
+	Groups   []GroupRow `json:"groups,omitempty"`
+	Findings []Finding  `json:"findings"`
 	// Counts is the per-severity tally of Findings, after filtering.
 	Counts map[string]int `json:"counts"`
 }
@@ -80,6 +91,10 @@ func Run(harvests []*Harvest, opts Options) Result {
 	}
 	res.Findings = append(res.Findings, checkPlantMulticast(all)...)
 	res.Findings = append(res.Findings, checkPlantRegistration(harvests)...)
+
+	groups, groupFindings := checkPlantGroups(all)
+	res.Groups = groups
+	res.Findings = append(res.Findings, groupFindings...)
 
 	kept := res.Findings[:0]
 	for _, f := range res.Findings {
@@ -127,6 +142,7 @@ func inventoryOf(h *Harvest) Inventory {
 		inv.APIs[name] = vs
 	}
 	inv.SDPFiles = len(h.SDP)
+	inv.HintedSenders, inv.HintedReceivers, inv.Groups = hintCounts(h)
 
 	// A Registry's catalogue lives under `query`; a Node's own
 	// resources under `node`. Counting both keeps one field set

--- a/internal/amwa/audit/groups.go
+++ b/internal/amwa/audit/groups.go
@@ -1,0 +1,320 @@
+package audit
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// GroupRow is one BCP-002-01 group as it appears across the plant.
+//
+// NMOS has no level concept. What a router calls a level, NMOS models as
+// a separate Sender/Receiver pair per essence — 2110-20 video, 2110-30
+// audio per channel group, 2110-40 ANC — so breakaway is the default and
+// routing one level is native. The hard part is the inverse: knowing
+// which essences are one signal. A group hint is the only thing in NMOS
+// that says so, and this row is what it adds up to.
+type GroupRow struct {
+	// Name is the group-hint group name, the part before the colon.
+	Name string `json:"name"`
+	// Roles are the levels present in the group, in the order a router
+	// would list them where they are recognisable.
+	Roles []string `json:"roles"`
+	// Senders and Receivers count the resources carrying this group.
+	Senders   int `json:"senders"`
+	Receivers int `json:"receivers"`
+	// Devices are the targets contributing to the group. More than one
+	// means no controller can bind the group from NMOS alone.
+	Devices []string `json:"devices"`
+}
+
+// groupAccumulator collects hints across every captured device.
+type groupAccumulator struct {
+	roles     map[string]map[string]bool
+	senders   map[string]int
+	receivers map[string]int
+	devices   map[string]map[string]bool
+}
+
+func newGroupAccumulator() *groupAccumulator {
+	return &groupAccumulator{
+		roles:     map[string]map[string]bool{},
+		senders:   map[string]int{},
+		receivers: map[string]int{},
+		devices:   map[string]map[string]bool{},
+	}
+}
+
+// add records one hint. BCP-002-01 §3 spells a hint `<group>:<role>`;
+// a role may itself contain spaces ("audio 1"), and a group name may
+// contain colons, so the split is on the LAST colon — splitting on the
+// first would make "RACK:1:video" a group called "RACK".
+func (g *groupAccumulator) add(hint, target, kind string) {
+	name, role, ok := cutLast(hint, ":")
+	if !ok {
+		return
+	}
+	name, role = strings.TrimSpace(name), strings.TrimSpace(role)
+	if name == "" {
+		return
+	}
+	if g.roles[name] == nil {
+		g.roles[name] = map[string]bool{}
+		g.devices[name] = map[string]bool{}
+	}
+	if role != "" {
+		g.roles[name][role] = true
+	}
+	g.devices[name][target] = true
+	if kind == "senders" {
+		g.senders[name]++
+	} else {
+		g.receivers[name]++
+	}
+}
+
+// cutLast splits on the last occurrence of sep.
+func cutLast(s, sep string) (before, after string, found bool) {
+	i := strings.LastIndex(s, sep)
+	if i < 0 {
+		return s, "", false
+	}
+	return s[:i], s[i+len(sep):], true
+}
+
+// rows renders the accumulator, group name order.
+func (g *groupAccumulator) rows() []GroupRow {
+	names := make([]string, 0, len(g.roles))
+	for n := range g.roles {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	out := make([]GroupRow, 0, len(names))
+	for _, n := range names {
+		out = append(out, GroupRow{
+			Name:      n,
+			Roles:     sortedRoles(g.roles[n]),
+			Senders:   g.senders[n],
+			Receivers: g.receivers[n],
+			Devices:   sortedSet(g.devices[n]),
+		})
+	}
+	return out
+}
+
+// roleOrder puts the levels an operator thinks in first, so a group
+// reads video → audio → ANC rather than alphabetically. Anything
+// unrecognised keeps its own order after them.
+var roleOrder = []string{"video", "audio", "anc", "data", "mux"}
+
+func roleRank(role string) int {
+	low := strings.ToLower(role)
+	for i, known := range roleOrder {
+		if strings.HasPrefix(low, known) {
+			return i
+		}
+	}
+	return len(roleOrder)
+}
+
+func sortedRoles(set map[string]bool) []string {
+	out := sortedSet(set)
+	sort.SliceStable(out, func(i, j int) bool {
+		ri, rj := roleRank(out[i]), roleRank(out[j])
+		if ri != rj {
+			return ri < rj
+		}
+		return out[i] < out[j]
+	})
+	return out
+}
+
+func sortedSet(set map[string]bool) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// hintProbe decodes only the tags a grouping pass needs.
+type hintProbe struct {
+	ID   string              `json:"id"`
+	Tags map[string][]string `json:"tags"`
+}
+
+// hintCounts reports how many senders and receivers on one device carry
+// a group hint, and how many distinct groups they name. This is the
+// "does this node publish BCP-002 at all" measurement.
+func hintCounts(h *Harvest) (senders, receivers, groups int) {
+	api := "node"
+	if _, ok := h.APIs["query"]; ok {
+		api = "query"
+	}
+	names := map[string]bool{}
+	for _, kind := range []string{"senders", "receivers"} {
+		items, _ := h.collect(api, kind)
+		for _, blob := range items {
+			var p hintProbe
+			if json.Unmarshal(blob, &p) != nil {
+				continue
+			}
+			hints := p.Tags[groupHintTag]
+			if len(hints) == 0 {
+				continue
+			}
+			if kind == "senders" {
+				senders++
+			} else {
+				receivers++
+			}
+			for _, hint := range hints {
+				if name, _, ok := cutLast(hint, ":"); ok && strings.TrimSpace(name) != "" {
+					names[strings.TrimSpace(name)] = true
+				}
+			}
+		}
+	}
+	return senders, receivers, len(names)
+}
+
+// checkPlantGroups pivots every captured device by group hint and
+// reports the two shapes that leave a group unusable.
+//
+// This runs plant-wide because the second shape only exists there: a
+// group whose essences live on different devices cannot be seen as one
+// from inside either of them.
+func checkPlantGroups(all []*Harvest) ([]GroupRow, []Finding) {
+	acc := newGroupAccumulator()
+	// firstSeen keeps a device per group so a finding can name where to
+	// go and look.
+	firstSeen := map[string]*Harvest{}
+
+	// A registry's catalogue is a VIEW of the nodes, not a device of its
+	// own: the same sender appears in the registry's query API and in
+	// the node's own API. Counting both makes every grouped resource
+	// look like it spans two devices and doubles its count — on one real
+	// plant that turned 4-receiver services into 7-receiver ones and
+	// invented 170 cross-device groups. Nodes are walked first and their
+	// resource ids remembered, so a registry only ever contributes
+	// resources no node capture covered.
+	ordered := make([]*Harvest, 0, len(all))
+	for _, h := range all {
+		if h.Role != "registry" {
+			ordered = append(ordered, h)
+		}
+	}
+	for _, h := range all {
+		if h.Role == "registry" {
+			ordered = append(ordered, h)
+		}
+	}
+
+	seenResource := map[string]bool{}
+	for _, h := range ordered {
+		api := "node"
+		if _, ok := h.APIs["query"]; ok {
+			api = "query"
+		}
+		for _, kind := range []string{"senders", "receivers"} {
+			items, _ := h.collect(api, kind)
+			for _, blob := range items {
+				var p hintProbe
+				if json.Unmarshal(blob, &p) != nil {
+					continue
+				}
+				if p.ID != "" {
+					if seenResource[p.ID] {
+						continue
+					}
+					seenResource[p.ID] = true
+				}
+				for _, hint := range p.Tags[groupHintTag] {
+					acc.add(hint, h.Name(), kind)
+					if name, _, ok := cutLast(hint, ":"); ok {
+						name = strings.TrimSpace(name)
+						if _, seen := firstSeen[name]; !seen && name != "" {
+							firstSeen[name] = h
+						}
+					}
+				}
+			}
+		}
+	}
+
+	rows := acc.rows()
+	var out []Finding
+
+	// Collapse the single-role case into one finding per device. A
+	// Neuron publishes one group per essence, so per-group findings
+	// would be 176 lines saying the same thing.
+	singleByDevice := map[string][]string{}
+
+	for _, r := range rows {
+		if len(r.Roles) <= 1 && len(r.Devices) == 1 {
+			singleByDevice[r.Devices[0]] = append(singleByDevice[r.Devices[0]], r.Name)
+		}
+		if len(r.Devices) > 1 {
+			h := firstSeen[r.Name]
+			if h == nil {
+				continue
+			}
+			// Two very different situations produce this, and a capture
+			// cannot tell them apart: one signal genuinely spanning
+			// devices, or a group name that is simply not unique across
+			// the plant. Both need saying, because the second is worse
+			// — a controller merging by name fuses unrelated devices
+			// into one bogus signal.
+			out = append(out, h.find(
+				"NMOS-BCP002-GROUP-CROSS-DEVICE", SevWarn, "group/"+r.Name,
+				fmt.Sprintf("group %q appears on %d devices: %s", r.Name, len(r.Devices), strings.Join(r.Devices, ", ")),
+				"BCP-002-01 v1.0 §3 grouphint",
+				"either one signal spans them — which IS-04 cannot express, so a controller needs its own signal database — or the name is not unique across the plant, and a controller grouping by name would fuse unrelated devices"))
+		}
+	}
+
+	for _, dev := range sortedSet(toSet(keysOfStrings(singleByDevice))) {
+		names := singleByDevice[dev]
+		sort.Strings(names)
+		h := firstSeen[names[0]]
+		if h == nil {
+			continue
+		}
+		out = append(out, h.find(
+			"NMOS-BCP002-GROUP-SINGLE-ROLE", SevWarn, "groups",
+			fmt.Sprintf("%d group(s) on %s hold exactly one role, so they express no association between essences: %s",
+				len(names), dev, examplesOf(names)),
+			"BCP-002-01 v1.0 §3 grouphint",
+			"a controller cannot offer \"route all levels\" or a breakaway when each essence is its own group"))
+	}
+
+	return rows, out
+}
+
+func keysOfStrings(m map[string][]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func toSet(ss []string) map[string]bool {
+	out := make(map[string]bool, len(ss))
+	for _, s := range ss {
+		out[s] = true
+	}
+	return out
+}
+
+// examplesOf names up to three groups, so a finding is actionable
+// without printing 176 UUID-shaped names.
+func examplesOf(names []string) string {
+	if len(names) <= 3 {
+		return strings.Join(names, ", ")
+	}
+	return strings.Join(names[:3], ", ") + fmt.Sprintf(" (+%d more)", len(names)-3)
+}

--- a/internal/amwa/audit/groups_test.go
+++ b/internal/amwa/audit/groups_test.go
@@ -1,0 +1,309 @@
+package audit
+
+import (
+	"strings"
+	"testing"
+)
+
+// hinted builds a sender or receiver carrying group hints.
+func hinted(id string, hints ...string) map[string]any {
+	return sender(id, map[string]any{
+		"tags": map[string]any{groupHintTag: hints},
+	})
+}
+
+// TestGroupPivotBuildsLevels is the shape a controller needs: one group
+// holding several roles, which is what makes "route all levels" and a
+// breakaway possible.
+func TestGroupPivotBuildsLevels(t *testing.T) {
+	h := mk("node", map[string]map[string]map[string]any{
+		"node": {"v1.3": {
+			"senders": []any{
+				hinted("44444444-4444-4444-8444-444444444444", "CAM-01:Video 1"),
+				hinted("55555555-5555-4555-8555-555555555555", "CAM-01:Audio 1"),
+				hinted("66666666-6666-4666-8666-666666666666", "CAM-01:Anc 1"),
+			},
+			"receivers": []any{},
+		}},
+	})
+
+	rows, findings := checkPlantGroups([]*Harvest{h})
+	if len(rows) != 1 {
+		t.Fatalf("want 1 group, got %d: %v", len(rows), rows)
+	}
+	g := rows[0]
+	if g.Name != "CAM-01" {
+		t.Errorf("group name = %q", g.Name)
+	}
+	if g.Senders != 3 || g.Receivers != 0 {
+		t.Errorf("counts = %d/%d, want 3/0", g.Senders, g.Receivers)
+	}
+	// Roles read video → audio → anc, the order an operator thinks in,
+	// not alphabetically.
+	if got := strings.Join(g.Roles, ","); got != "Video 1,Audio 1,Anc 1" {
+		t.Errorf("roles = %q, want video then audio then anc", got)
+	}
+	// A properly grouped signal is not a finding.
+	for _, f := range findings {
+		if strings.HasPrefix(f.Code, "NMOS-BCP002-GROUP") {
+			t.Errorf("a well-formed group produced %s: %s", f.Code, f.Detail)
+		}
+	}
+}
+
+// TestSingleRoleGroupsReported is the real EVS Neuron pathology: every
+// hint present, syntactically valid, and grouping nothing — each
+// essence is its own group named after itself.
+func TestSingleRoleGroupsReported(t *testing.T) {
+	h := mk("node", map[string]map[string]map[string]any{
+		"node": {"v1.3": {
+			"senders": []any{
+				hinted("44444444-4444-4444-8444-444444444444", "ARX-01:s2110-30"),
+				hinted("55555555-5555-4555-8555-555555555555", "ARX-02:s2110-30"),
+				hinted("66666666-6666-4666-8666-666666666666", "ARX-03:s2110-30"),
+			},
+			"receivers": []any{},
+		}},
+	})
+
+	rows, findings := checkPlantGroups([]*Harvest{h})
+	if len(rows) != 3 {
+		t.Fatalf("want 3 single-role groups, got %d", len(rows))
+	}
+
+	// One finding per device, not one per group: a 176-sender node would
+	// otherwise emit 176 lines saying the same thing.
+	var got []Finding
+	for _, f := range findings {
+		if f.Code == "NMOS-BCP002-GROUP-SINGLE-ROLE" {
+			got = append(got, f)
+		}
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 grouped finding, got %d", len(got))
+	}
+	if !strings.Contains(got[0].Detail, "3 group(s)") {
+		t.Errorf("the finding should name the count: %q", got[0].Detail)
+	}
+	if !strings.Contains(got[0].Hint, "breakaway") {
+		t.Errorf("the hint should say what it costs the operator: %q", got[0].Hint)
+	}
+}
+
+// TestCrossDeviceGroupReported covers both readings of the same
+// observation, because a capture cannot tell them apart.
+func TestCrossDeviceGroupReported(t *testing.T) {
+	a := mk("node", map[string]map[string]map[string]any{
+		"node": {"v1.3": {
+			"senders":   []any{hinted("44444444-4444-4444-8444-444444444444", "device_1:source_1")},
+			"receivers": []any{},
+		}},
+	})
+	a.Label = "node-a"
+	b := mk("node", map[string]map[string]map[string]any{
+		"node": {"v1.3": {
+			"senders":   []any{hinted("55555555-5555-4555-8555-555555555555", "device_1:source_2")},
+			"receivers": []any{},
+		}},
+	})
+	b.Label = "node-b"
+
+	rows, findings := checkPlantGroups([]*Harvest{a, b})
+	if len(rows) != 1 || len(rows[0].Devices) != 2 {
+		t.Fatalf("want one group across two devices, got %v", rows)
+	}
+	f := has(t, findings, "NMOS-BCP002-GROUP-CROSS-DEVICE")
+	for _, want := range []string{"node-a", "node-b", "device_1"} {
+		if !strings.Contains(f.Detail, want) {
+			t.Errorf("detail %q missing %q", f.Detail, want)
+		}
+	}
+	// Both readings must be offered — the name-collision one is the
+	// dangerous half.
+	if !strings.Contains(f.Hint, "not unique") {
+		t.Errorf("the hint must offer the name-collision reading: %q", f.Hint)
+	}
+}
+
+// TestRegistryViewDoesNotDoubleCount is the bug this check shipped with
+// and had to have fixed: a registry's catalogue is a VIEW of its nodes,
+// so counting both turned 4-receiver services into 7-receiver ones and
+// invented 170 cross-device groups on one real plant.
+func TestRegistryViewDoesNotDoubleCount(t *testing.T) {
+	const sid = "44444444-4444-4444-8444-444444444444"
+
+	node := mk("node", map[string]map[string]map[string]any{
+		"node": {"v1.3": {
+			"senders":   []any{hinted(sid, "Service 01:Video 1")},
+			"receivers": []any{},
+		}},
+	})
+	node.Label = "the-node"
+
+	reg := mk("registry", map[string]map[string]map[string]any{
+		"query": {"v1.3": {
+			"senders":   []any{hinted(sid, "Service 01:Video 1")},
+			"receivers": []any{},
+		}},
+	})
+	reg.Label = "the-registry"
+
+	// Registry first in the slice, to prove the ordering is enforced by
+	// the check and not by luck.
+	rows, findings := checkPlantGroups([]*Harvest{reg, node})
+	if len(rows) != 1 {
+		t.Fatalf("want 1 group, got %d", len(rows))
+	}
+	if rows[0].Senders != 1 {
+		t.Errorf("sender count = %d, want 1 — the registry view was counted again", rows[0].Senders)
+	}
+	if len(rows[0].Devices) != 1 || rows[0].Devices[0] != "the-node" {
+		t.Errorf("devices = %v, want just the node that owns the resource", rows[0].Devices)
+	}
+	for _, f := range findings {
+		if f.Code == "NMOS-BCP002-GROUP-CROSS-DEVICE" {
+			t.Errorf("a registry view produced a phantom cross-device finding: %s", f.Detail)
+		}
+	}
+}
+
+// TestRegistryOnlyCaptureStillGroups: when nothing but a registry was
+// captured, its catalogue is all there is and must still be used.
+func TestRegistryOnlyCaptureStillGroups(t *testing.T) {
+	reg := mk("registry", map[string]map[string]map[string]any{
+		"query": {"v1.3": {
+			"senders": []any{
+				hinted("44444444-4444-4444-8444-444444444444", "CAM-01:Video 1"),
+				hinted("55555555-5555-4555-8555-555555555555", "CAM-01:Audio 1"),
+			},
+			"receivers": []any{},
+		}},
+	})
+	rows, _ := checkPlantGroups([]*Harvest{reg})
+	if len(rows) != 1 || rows[0].Senders != 2 {
+		t.Fatalf("a registry-only capture must still group: %v", rows)
+	}
+}
+
+// TestHintCountsMeasureCoverage is the "which nodes expose BCP-002"
+// inventory column.
+func TestHintCountsMeasureCoverage(t *testing.T) {
+	h := mk("node", map[string]map[string]map[string]any{
+		"node": {"v1.3": {
+			"senders": []any{
+				hinted("44444444-4444-4444-8444-444444444444", "CAM-01:Video 1"),
+				sender("55555555-5555-4555-8555-555555555555", nil), // no hint
+			},
+			"receivers": []any{hinted("88888888-8888-4888-8888-888888888888", "CAM-01:Audio 1")},
+		}},
+	})
+	s, r, groups := hintCounts(h)
+	if s != 1 || r != 1 || groups != 1 {
+		t.Errorf("hintCounts = %d,%d,%d; want 1,1,1", s, r, groups)
+	}
+
+	// A device with no hints at all reports zeroes rather than being
+	// omitted — "publishes none" is a finding, not an absence.
+	bare := mk("node", map[string]map[string]map[string]any{
+		"node": {"v1.3": {"senders": []any{sender(sID, nil)}, "receivers": []any{}}},
+	})
+	if s, r, g := hintCounts(bare); s != 0 || r != 0 || g != 0 {
+		t.Errorf("hintCounts on an unhinted device = %d,%d,%d", s, r, g)
+	}
+}
+
+// TestHintSplitsOnLastColon: a role may contain spaces and a group name
+// may contain colons, so splitting on the FIRST colon would turn
+// "RACK:1:video" into a group called "RACK".
+func TestHintSplitsOnLastColon(t *testing.T) {
+	acc := newGroupAccumulator()
+	acc.add("RACK:1:Video 1", "dev", "senders")
+	rows := acc.rows()
+	if len(rows) != 1 {
+		t.Fatalf("want 1 group, got %v", rows)
+	}
+	if rows[0].Name != "RACK:1" {
+		t.Errorf("group name = %q, want RACK:1", rows[0].Name)
+	}
+	if len(rows[0].Roles) != 1 || rows[0].Roles[0] != "Video 1" {
+		t.Errorf("roles = %v, want [Video 1]", rows[0].Roles)
+	}
+}
+
+// TestMalformedHintsIgnored: a hint with no colon groups nothing, and
+// must not create a group keyed on the whole string.
+func TestMalformedHintsIgnored(t *testing.T) {
+	acc := newGroupAccumulator()
+	acc.add("no-colon-here", "dev", "senders")
+	acc.add(":only-a-role", "dev", "senders")
+	acc.add("", "dev", "senders")
+	if rows := acc.rows(); len(rows) != 0 {
+		t.Errorf("malformed hints produced groups: %v", rows)
+	}
+}
+
+// TestGroupsAppearInEveryRenderer proves the pivot reaches the operator
+// in each output form.
+func TestGroupsAppearInEveryRenderer(t *testing.T) {
+	res := loadPlant(t)
+	// The fixture plant has one hinted sender: cam-01 iso, "cam-01:video".
+	if len(res.Groups) == 0 {
+		t.Fatal("the fixture plant has a group hint; the pivot found none")
+	}
+
+	var b strings.Builder
+	if err := RenderText(&b, res); err != nil {
+		t.Fatal(err)
+	}
+	s := b.String()
+	for _, want := range []string{"GROUPING (BCP-002-01)", "ROLES (levels)", "cam-01"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("text report missing %q", want)
+		}
+	}
+	// Grouping is printed before the findings, because it changes how
+	// they read.
+	if strings.Index(s, "GROUPING") > strings.Index(s, "FINDINGS") {
+		t.Error("grouping must come before the findings")
+	}
+}
+
+// TestNoHintsAnywhereSaysSo: a plant with no grouping at all is the
+// worst case for a controller, and the report must state it rather than
+// print an empty table.
+func TestNoHintsAnywhereSaysSo(t *testing.T) {
+	var b strings.Builder
+	res := Result{
+		Counts:    map[string]int{},
+		Inventory: []Inventory{{Target: "h:1", Senders: 4}},
+	}
+	if err := RenderText(&b, res); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(b.String(), "no group hints anywhere") {
+		t.Errorf("an ungrouped plant should say so explicitly:\n%s", b.String())
+	}
+	// The coverage column reads 0/4, not blank.
+	if !strings.Contains(b.String(), "0/4") {
+		t.Error("the inventory should show 0/4 rather than an empty cell")
+	}
+}
+
+func TestOfTotal(t *testing.T) {
+	if got := ofTotal(0, 0); got != "-" {
+		t.Errorf("nothing to cover should read %q, got %q", "-", got)
+	}
+	if got := ofTotal(3, 176); got != "3/176" {
+		t.Errorf("ofTotal = %q", got)
+	}
+}
+
+func TestRoleOrdering(t *testing.T) {
+	got := sortedRoles(map[string]bool{"Anc 1": true, "Audio 2": true, "Video 1": true, "zzz": true, "Audio 1": true})
+	want := []string{"Video 1", "Audio 1", "Audio 2", "Anc 1", "zzz"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("sortedRoles = %v, want %v", got, want)
+		}
+	}
+}

--- a/internal/amwa/audit/render.go
+++ b/internal/amwa/audit/render.go
@@ -45,6 +45,43 @@ func RenderText(w io.Writer, r Result) error {
 		bw.printf("%-24s %s\n", trunc(inv.Target, 24), strings.Join(parts, " "))
 	}
 
+	// Grouping comes before the findings because it changes how they
+	// read. "13 hints absent" means one thing on a plant with 40 healthy
+	// groups and another on a plant with none.
+	bw.printf("\nGROUPING (BCP-002-01) — which devices say what belongs together\n\n")
+	bw.printf("%-24s %-28s %6s %6s %7s\n", "TARGET", "LABEL", "SND+", "RCV+", "GROUPS")
+	bw.printf("%s\n", strings.Repeat("-", 78))
+	for _, inv := range r.Inventory {
+		if inv.Senders == 0 && inv.Receivers == 0 {
+			continue
+		}
+		bw.printf("%-24s %-28s %6s %6s %7d\n",
+			trunc(inv.Target, 24), trunc(inv.Label, 28),
+			ofTotal(inv.HintedSenders, inv.Senders),
+			ofTotal(inv.HintedReceivers, inv.Receivers),
+			inv.Groups)
+	}
+	if len(r.Groups) == 0 {
+		bw.printf("\n  no group hints anywhere in this plant — a controller sees a flat\n")
+		bw.printf("  list of essences and cannot offer a grouped route or a breakaway\n")
+	} else {
+		bw.printf("\n%-28s %-34s %5s %5s %s\n", "GROUP", "ROLES (levels)", "SND", "RCV", "DEVICES")
+		bw.printf("%s\n", strings.Repeat("-", 78))
+		shown := r.Groups
+		const maxGroups = 40
+		if len(shown) > maxGroups {
+			shown = shown[:maxGroups]
+		}
+		for _, g := range shown {
+			bw.printf("%-28s %-34s %5d %5d %s\n",
+				trunc(g.Name, 28), trunc(strings.Join(g.Roles, ", "), 34),
+				g.Senders, g.Receivers, trunc(strings.Join(g.Devices, ", "), 20))
+		}
+		if len(r.Groups) > maxGroups {
+			bw.printf("  … %d more group(s); use --format json for the full pivot\n", len(r.Groups)-maxGroups)
+		}
+	}
+
 	bw.printf("\nFINDINGS — %d\n\n", len(r.Findings))
 	if len(r.Findings) == 0 {
 		bw.printf("  none at or above the requested severity\n")
@@ -116,6 +153,16 @@ func (e *errWriter) printf(format string, args ...any) {
 		return
 	}
 	_, e.err = fmt.Fprintf(e.w, format, args...)
+}
+
+// ofTotal renders "3/176", or a bare dash when the device publishes
+// nothing of that kind — an empty cell reads as zero coverage, which is
+// a different statement from having nothing to cover.
+func ofTotal(n, total int) string {
+	if total == 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%d/%d", n, total)
 }
 
 // trunc clips a column value, marking that it was clipped.


### PR DESCRIPTION
> **Stacked on #842 → #838 → #836.** GitHub retargets as the stack merges.

## What

A BCP-002-01 group/level pivot in `dhs consumer nmos audit` — which devices say what belongs together, and which groups are unusable.

Closes #845

## Why

NMOS has **no level concept**. A router level is, in NMOS, a separate Sender/Receiver pair per essence — so breakaway is the default and routing one level is native. The hard part is the inverse: **knowing which essences are one signal**. Group hints are the only thing in NMOS that says so, and the audit previously reported them as a bare count:

```
NMOS-BCP002-HINT-ABSENT   1 of 2 senders carry no grouphint tag
```

That answers none of the questions an operator has.

## Scope

- [x] osc / tsl / cerebrum-nb / amwa

## Reference controller

- [x] N/A — offline analysis

## Type

- [x] feat

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `internal/amwa/audit/groups.go` | new | the pivot, role ordering, both findings |
| `internal/amwa/audit/groups_test.go` | new | tests incl. the registry-double-count regression |
| `internal/amwa/audit/audit.go` | modified | `Result.Groups`, inventory hint columns |
| `internal/amwa/audit/render.go` | modified | GROUPING section |

## What it found on the 44-node plant

**9,831 groups.** The picture the customer needs:

```
TARGET                   LABEL                          SND+   RCV+  GROUPS
10.41.40.80:3000         bm-n-nnbrg-t01               176/176 176/176     352
10.44.59.3:8989          AES67 M60 C1 ID61              0/68   0/68        0
10.44.72.12:80           bm-n-titan-001 (Server A)      0/44   0/10        0
```

- The **Nevion** nodes hint 176/176 senders and 176/176 receivers — and form **352 groups**, one per resource, each named after itself: `ARX-01:s2110-30`. Every hint present, every hint valid, **grouping nothing**. This is the EVS Neuron pathology at plant scale, and it is *invisible* in a hints-absent count because the hints ARE present.
- **337 groups do hold real levels**: `Service 01 → Video 1 + Audio 1 + Audio 2 + Anc 1`, `SPG9000 → Video1-6 + Audio1-6 + Data1-6`.
- The **AES67** and **Titan** nodes publish none at all.

## Design decisions

**Single-role groups report once per device**, not once per group — a 176-sender node would otherwise emit 176 identical lines.

**Cross-device groups offer both readings**, because a capture cannot tell them apart:

> either one signal spans them — which IS-04 cannot express, so a controller needs its own signal database — or the name is not unique across the plant, and a controller grouping by name would fuse unrelated devices

The 8 real ones on this plant are the second kind: five `bm-n-rfus6-*` nodes each using `device_1` and `channel_5`.

**Roles sort video → audio → anc**, the order an operator thinks in. **Hints split on the LAST colon** — a role may contain spaces (`Audio 1`) and a group name may contain colons, so splitting on the first turns `RACK:1:video` into a group called `RACK`.

## A bug found while validating

A registry's catalogue is a **view** of its nodes, not a device of its own. Counting both turned 4-receiver services into 7-receiver ones and invented **170** cross-device groups. Nodes are now walked first and their resource ids remembered, so a registry only contributes what no node capture covered. **170 → 8**, and the 8 are real. Regression test included.

## Test results

| | |
|---|---|
| `go test ./internal/amwa/audit/...` | pass |
| Coverage | **95.7%** |
| `go build` / `go vet` / `golangci-lint` | clean |

## Device tested

- [x] Verified against the 44-node customer capture; every number above checked against the raw JSON.

## Not in scope

**Fixing the hints.** There is no stable NMOS write path for tags — IS-05 writes only `transport_params`, `master_enable`, `activation`, `transport_file`; annotation is IS-13, still WIP at AMWA. Setting a group hint today is a vendor operation. The audit reports; it does not annotate.

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies

## Approval

@yboujraf — requesting review