### PR TITLE
feat(nmos): consumer nmos profile - live conformance + latency, as JSONL (#839)

### DIFF
--- a/cmd/dhs/cmd_nmos.go
+++ b/cmd/dhs/cmd_nmos.go
@@ -54,8 +54,10 @@ func runNMOSConsumer(ctx context.Context, args []string) error {
 		return runNMOSExport(ctx, rest)
 	case "audit":
 		return runNMOSAudit(ctx, rest)
+	case "profile":
+		return runNMOSProfile(ctx, rest)
 	}
-	return fmt.Errorf("consumer nmos: unknown verb %q (expected: discover, system, walk, events, export, audit)", verb)
+	return fmt.Errorf("consumer nmos: unknown verb %q (expected: discover, system, walk, events, export, audit, profile)", verb)
 }
 
 // runNMOSProducer dispatches `dhs producer nmos <verb> [args]`.
@@ -611,7 +613,20 @@ same bytes always produce the same report.
   --format FORMAT       text (default) | json | jsonl
   --min-severity SEV    info (default) | warn | error | critical
   --out FILE            Write the report to FILE instead of stdout
-  --fail-on SEV         Exit non-zero when a finding at or above SEV is present`)
+  --fail-on SEV         Exit non-zero when a finding at or above SEV is present
+
+profile — live protocol conformance against one device, plus per-endpoint latency.
+Answers what a capture cannot: whether an unknown API version is rejected,
+whether CORS is present, whether a paging limit is honoured and reported back,
+whether health for an unregistered node 404s. Strictly read-only — it never
+PATCHes, activates, or registers, so it is safe against a plant that is on air.
+  --target host:port    Device to profile (required)
+  --https               Use TLS
+  --deep                Assert every IS-05 endpoint, not just the first
+  --format FORMAT       text (default) | json | jsonl
+  --out FILE            Write the report to FILE instead of stdout
+  --fail-on STATUS      Exit non-zero at or above this status: warn | fail
+  --timeout DURATION    Per-request deadline (default 10s)`)
 }
 
 func printNMOSProducerHelp() {

--- a/cmd/dhs/cmd_nmos_profile.go
+++ b/cmd/dhs/cmd_nmos_profile.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"dhs/internal/amwa/profile"
+)
+
+// runNMOSProfile implements `dhs consumer nmos profile`.
+//
+// Where `export` + `audit` answer "what does this plant look like",
+// probe answers "does this device behave". The difference is the live
+// exchange: whether an unknown version is rejected, whether CORS is
+// present, whether a paging limit is honoured and reported back. None
+// of that survives into a capture, because a capture records answers
+// rather than the conversation.
+//
+// The verb is read-only by construction. It never PATCHes, never
+// activates, never registers — a conformance tool that stages a
+// connection is one that can take a live source off air, and this one
+// is meant to be safe to point at a plant that is on.
+func runNMOSProfile(ctx context.Context, args []string) (err error) {
+	fs := flag.NewFlagSet("consumer nmos profile", flag.ContinueOnError)
+	var (
+		target  = fs.String("target", "", "device to probe, as host:port (required)")
+		https   = fs.Bool("https", false, "use TLS")
+		deep    = fs.Bool("deep", false, "assert every IS-05 endpoint, not just the first")
+		format  = fs.String("format", "text", "output format: text | json | jsonl")
+		outPath = fs.String("out", "", "write the report to this file instead of stdout")
+		failOn  = fs.String("fail-on", "", "exit non-zero when a result at or above this status is present: warn | fail")
+		timeout = fs.Duration("timeout", 10*time.Second, "per-request deadline")
+	)
+
+	// Lift a bare positional before parsing — Go's flag package stops
+	// at the first non-flag argument.
+	positional := ""
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		positional, args = args[0], args[1:]
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() > 0 {
+		return fmt.Errorf("consumer nmos profile: unexpected argument %q (one target only)", fs.Arg(0))
+	}
+	if *target == "" {
+		*target = positional
+	} else if positional != "" {
+		return fmt.Errorf("consumer nmos profile: target given twice (%q and --target %q)", positional, *target)
+	}
+	if *target == "" {
+		return fmt.Errorf("consumer nmos profile: --target is required (host:port of the device to probe)")
+	}
+
+	var gate profile.Status
+	switch strings.ToLower(*failOn) {
+	case "":
+	case "warn":
+		gate = profile.StatusWarn
+	case "fail":
+		gate = profile.StatusFail
+	default:
+		return fmt.Errorf("consumer nmos profile: unknown --fail-on %q (want warn or fail)", *failOn)
+	}
+
+	rep, err := profile.Run(ctx, profile.Options{
+		Target:  *target,
+		HTTPS:   *https,
+		Deep:    *deep,
+		Timeout: *timeout,
+	})
+	if err != nil {
+		return err
+	}
+
+	var w io.Writer = os.Stdout
+	if *outPath != "" {
+		f, ferr := os.Create(*outPath)
+		if ferr != nil {
+			return fmt.Errorf("consumer nmos profile: %w", ferr)
+		}
+		// A truncated report reads as a healthier device than the probe
+		// actually found, so a failed Close is surfaced.
+		defer func() {
+			if cerr := f.Close(); cerr != nil && err == nil {
+				err = fmt.Errorf("consumer nmos profile: writing %s: %w", *outPath, cerr)
+			}
+		}()
+		w = f
+	}
+
+	switch *format {
+	case "text":
+		err = profile.RenderText(w, rep)
+	case "json":
+		err = profile.RenderJSON(w, rep)
+	case "jsonl":
+		err = profile.RenderJSONL(w, rep)
+	default:
+		return fmt.Errorf("consumer nmos profile: unknown --format %q (want text, json or jsonl)", *format)
+	}
+	if err != nil {
+		return err
+	}
+
+	// Opt-in, like the audit's gate. Reporting is not failing, and each
+	// CI job picks its own threshold.
+	if gate == "" {
+		return nil
+	}
+	rank := map[profile.Status]int{profile.StatusPass: 0, profile.StatusSkip: 1, profile.StatusWarn: 2, profile.StatusFail: 3}
+	if worst, any := rep.Worst(); any && rank[worst] >= rank[gate] {
+		return fmt.Errorf("consumer nmos profile: worst result %s (--fail-on %s)", worst, gate)
+	}
+	return nil
+}

--- a/internal/amwa/profile/checks.go
+++ b/internal/amwa/profile/checks.go
@@ -1,0 +1,571 @@
+package profile
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// checkRoot fetches /x-nmos and records which APIs the device serves.
+// Every later check depends on this, so it also populates the session.
+func checkRoot(ctx context.Context, s *Session) []Result {
+	const (
+		id   = "PROFILE-ROOT-001"
+		name = "/x-nmos lists the APIs served"
+		spec = "IS-04 v1.3 §4 API paths"
+	)
+	r := s.get(ctx, "/x-nmos")
+	switch {
+	case r.Err != nil:
+		return []Result{s.result(id, name, spec, StatusFail, r,
+			fmt.Sprintf("GET /x-nmos did not complete: %v", r.Err))}
+	case r.Status != http.StatusOK:
+		return []Result{s.result(id, name, spec, StatusFail, r,
+			fmt.Sprintf("GET /x-nmos returned %d, want 200", r.Status))}
+	}
+
+	names, ok := jsonArray(r.Body)
+	if !ok {
+		return []Result{s.result(id, name, spec, StatusFail, r,
+			"GET /x-nmos did not return a JSON array of API names")}
+	}
+
+	out := []Result{s.result(id, name, spec, StatusPass, r,
+		fmt.Sprintf("GET /x-nmos returned %d API(s): %s", len(names), strings.Join(names, " ")))}
+
+	// Discover the version list for each, so the later checks know what
+	// to ask for. Failures here are reported by checkVersionLists.
+	for _, api := range names {
+		api = strings.TrimSuffix(api, "/")
+		if api == "" {
+			continue
+		}
+		vr := s.get(ctx, "/x-nmos/"+api+"/")
+		if vr.Status != http.StatusOK {
+			s.APIs[api] = nil
+			continue
+		}
+		vs, ok := jsonArray(vr.Body)
+		if !ok {
+			s.APIs[api] = nil
+			continue
+		}
+		for i := range vs {
+			vs[i] = strings.TrimSuffix(vs[i], "/")
+		}
+		s.APIs[api] = vs
+	}
+	return out
+}
+
+// checkVersionLists asserts every advertised version is well-formed.
+//
+// A version string a controller cannot parse is a version it cannot
+// select, and version selection is the first thing every NMOS peer
+// does.
+func checkVersionLists(_ context.Context, s *Session) []Result {
+	const (
+		id   = "PROFILE-VER-001"
+		name = "each API advertises parseable versions"
+		spec = "IS-04 v1.3 §6.1 API versioning"
+	)
+	if len(s.APIs) == 0 {
+		return []Result{s.skip(id, name, spec, "no APIs were discovered")}
+	}
+
+	var out []Result
+	for _, api := range sortedKeys(s.APIs) {
+		vs := s.APIs[api]
+		res := Result{ID: id, Name: name, Spec: spec, Target: s.opts.Target}
+		switch {
+		case len(vs) == 0:
+			res.Status = StatusFail
+			res.Detail = fmt.Sprintf("GET /x-nmos/%s/ returned no usable version list", api)
+		default:
+			bad := []string{}
+			for _, v := range vs {
+				if !versionPattern.MatchString(v) {
+					bad = append(bad, v)
+				}
+			}
+			if len(bad) > 0 {
+				res.Status = StatusFail
+				res.Detail = fmt.Sprintf("/x-nmos/%s/ advertises %v, which is not vMAJOR.MINOR", api, bad)
+			} else {
+				res.Status = StatusPass
+				res.Detail = fmt.Sprintf("/x-nmos/%s/ advertises %s", api, strings.Join(vs, ","))
+			}
+		}
+		out = append(out, res)
+	}
+	return out
+}
+
+// checkUnknownVersionRejected asks for a version the device does not
+// serve.
+//
+// A device that answers 200 to /x-nmos/query/v9.9/nodes is telling a
+// controller it speaks a version it does not, and the controller will
+// then send v9.9 requests it cannot handle. The failure surfaces later,
+// somewhere else, as malformed data.
+func checkUnknownVersionRejected(ctx context.Context, s *Session) []Result {
+	const (
+		id   = "PROFILE-VER-002"
+		name = "an unknown API version is rejected"
+		spec = "IS-04 v1.3 §6.1 API versioning"
+	)
+	api, _, ok := s.queryOrNode()
+	if !ok {
+		return []Result{s.skip(id, name, spec, "device serves neither a query nor a node API")}
+	}
+
+	path := "/x-nmos/" + api + "/v9.9/"
+	r := s.get(ctx, path)
+	switch {
+	case r.Err != nil:
+		return []Result{s.result(id, name, spec, StatusFail, r,
+			fmt.Sprintf("GET %s did not complete: %v", path, r.Err))}
+	case r.Status == http.StatusNotFound:
+		return []Result{s.result(id, name, spec, StatusPass, r,
+			fmt.Sprintf("GET %s returned 404", path))}
+	case r.Status >= 500:
+		return []Result{s.result(id, name, spec, StatusFail, r,
+			fmt.Sprintf("GET %s returned %d — an unsupported version must 404, not fault", path, r.Status))}
+	case r.Status < 400:
+		return []Result{s.result(id, name, spec, StatusFail, r,
+			fmt.Sprintf("GET %s returned %d — the device claims to serve a version it does not advertise", path, r.Status))}
+	default:
+		return []Result{s.result(id, name, spec, StatusWarn, r,
+			fmt.Sprintf("GET %s returned %d; 404 is the spec's answer", path, r.Status))}
+	}
+}
+
+// checkCORS asserts the headers a browser-based controller needs.
+//
+// IS-04 requires CORS on every API. Without it every web controller
+// fails at the first request, with an error that names the browser
+// rather than the device — which is why this is worth asserting
+// explicitly rather than discovering during an integration.
+func checkCORS(ctx context.Context, s *Session) []Result {
+	const spec = "IS-04 v1.3 §5 Cross-Origin Resource Sharing"
+
+	get := s.get(ctx, "/x-nmos")
+	origin := get.Header.Get("Access-Control-Allow-Origin")
+
+	out := []Result{}
+	switch {
+	case get.Err != nil || get.Status != http.StatusOK:
+		out = append(out, s.skip("PROFILE-CORS-001", "GET carries Access-Control-Allow-Origin", spec,
+			"/x-nmos did not answer"))
+	case origin == "":
+		out = append(out, s.result("PROFILE-CORS-001", "GET carries Access-Control-Allow-Origin", spec,
+			StatusFail, get, "GET /x-nmos returned no Access-Control-Allow-Origin header — no browser-based controller can read this API"))
+	default:
+		out = append(out, s.result("PROFILE-CORS-001", "GET carries Access-Control-Allow-Origin", spec,
+			StatusPass, get, "Access-Control-Allow-Origin: "+origin))
+	}
+
+	// The preflight matters separately: a browser sends OPTIONS before
+	// any request carrying a custom header, and a device that answers
+	// GET correctly can still refuse the preflight.
+	pre := s.request(ctx, http.MethodOptions, "/x-nmos", http.Header{
+		"Origin":                        []string{"http://profile.invalid"},
+		"Access-Control-Request-Method": []string{"GET"},
+	})
+	const (
+		preID   = "PROFILE-CORS-002"
+		preName = "OPTIONS preflight is answered"
+	)
+	switch {
+	case pre.Err != nil:
+		out = append(out, s.result(preID, preName, spec, StatusFail, pre,
+			fmt.Sprintf("OPTIONS /x-nmos did not complete: %v", pre.Err)))
+	case pre.Status >= 400:
+		out = append(out, s.result(preID, preName, spec, StatusFail, pre,
+			fmt.Sprintf("OPTIONS /x-nmos returned %d — browsers will not proceed past the preflight", pre.Status)))
+	case pre.Header.Get("Access-Control-Allow-Methods") == "":
+		out = append(out, s.result(preID, preName, spec, StatusWarn, pre,
+			fmt.Sprintf("OPTIONS /x-nmos returned %d but named no Access-Control-Allow-Methods", pre.Status)))
+	default:
+		out = append(out, s.result(preID, preName, spec, StatusPass, pre,
+			"Access-Control-Allow-Methods: "+pre.Header.Get("Access-Control-Allow-Methods")))
+	}
+	return out
+}
+
+// checkContentType asserts JSON endpoints say they serve JSON.
+func checkContentType(ctx context.Context, s *Session) []Result {
+	const (
+		id   = "PROFILE-CT-001"
+		name = "JSON endpoints declare application/json"
+		spec = "IS-04 v1.3 §4 — all APIs use application/json"
+	)
+	r := s.get(ctx, "/x-nmos")
+	if r.Err != nil || r.Status != http.StatusOK {
+		return []Result{s.skip(id, name, spec, "/x-nmos did not answer")}
+	}
+	ct := r.Header.Get("Content-Type")
+	switch {
+	case ct == "":
+		return []Result{s.result(id, name, spec, StatusFail, r, "GET /x-nmos returned no Content-Type")}
+	case strings.HasPrefix(strings.ToLower(ct), "application/json"):
+		return []Result{s.result(id, name, spec, StatusPass, r, "Content-Type: "+ct)}
+	default:
+		return []Result{s.result(id, name, spec, StatusFail, r,
+			fmt.Sprintf("GET /x-nmos returned Content-Type %q, want application/json", ct))}
+	}
+}
+
+// checkUnknownResource asks for a resource that does not exist.
+//
+// The distinction that matters is 404 versus 500. A controller retries
+// a 500 — it reads as "the device is unwell" — and gives up on a 404,
+// which reads as "that thing is gone". A device that 500s on a missing
+// resource turns every stale reference into a retry storm.
+func checkUnknownResource(ctx context.Context, s *Session) []Result {
+	const (
+		id   = "PROFILE-404-001"
+		name = "a missing resource returns 404, not a fault"
+		spec = "IS-04 v1.3 §4 error response"
+	)
+	api, ver, ok := s.queryOrNode()
+	if !ok {
+		return []Result{s.skip(id, name, spec, "device serves neither a query nor a node API")}
+	}
+	if api == "node" {
+		return []Result{s.skip(id, name, spec, "node API has no per-id resource path to check safely")}
+	}
+
+	const absent = "00000000-0000-4000-8000-000000000000"
+	path := "/x-nmos/" + api + "/" + ver + "/nodes/" + absent
+	r := s.get(ctx, path)
+
+	out := []Result{}
+	switch {
+	case r.Err != nil:
+		out = append(out, s.result(id, name, spec, StatusFail, r,
+			fmt.Sprintf("GET %s did not complete: %v", path, r.Err)))
+		return out
+	case r.Status == http.StatusNotFound:
+		out = append(out, s.result(id, name, spec, StatusPass, r,
+			fmt.Sprintf("GET %s returned 404", path)))
+	case r.Status >= 500:
+		out = append(out, s.result(id, name, spec, StatusFail, r,
+			fmt.Sprintf("GET %s returned %d — controllers retry a fault and abandon a 404", path, r.Status)))
+		return out
+	default:
+		out = append(out, s.result(id, name, spec, StatusFail, r,
+			fmt.Sprintf("GET %s returned %d for a resource that does not exist", path, r.Status)))
+		return out
+	}
+
+	// IS-04 defines the error body shape. A controller that wants to
+	// tell the operator WHY has nothing to show without it.
+	const (
+		bodyID   = "PROFILE-404-002"
+		bodyName = "the 404 body carries the IS-04 error object"
+	)
+	var e struct {
+		Code  *int    `json:"code"`
+		Error *string `json:"error"`
+		Debug any     `json:"debug"`
+	}
+	switch {
+	case json.Unmarshal(r.Body, &e) != nil:
+		out = append(out, s.result(bodyID, bodyName, spec, StatusWarn, r,
+			"the 404 body is not a JSON object"))
+	case e.Code == nil || e.Error == nil:
+		out = append(out, s.result(bodyID, bodyName, spec, StatusWarn, r,
+			"the 404 body omits code and/or error"))
+	default:
+		out = append(out, s.result(bodyID, bodyName, spec, StatusPass, r,
+			fmt.Sprintf("404 body: code=%d error=%q", *e.Code, *e.Error)))
+	}
+	return out
+}
+
+// checkTrailingSlash asserts a version root answers with or without its
+// trailing slash.
+//
+// Controllers build these URLs by concatenation and disagree about the
+// slash. A device that serves one and 404s the other works with half
+// the controllers on the market.
+func checkTrailingSlash(ctx context.Context, s *Session) []Result {
+	const (
+		id   = "PROFILE-PATH-001"
+		name = "a version root answers with and without a trailing slash"
+		spec = "IS-04 v1.3 §4 API paths"
+	)
+	api, ver, ok := s.queryOrNode()
+	if !ok {
+		return []Result{s.skip(id, name, spec, "device serves neither a query nor a node API")}
+	}
+
+	base := "/x-nmos/" + api + "/" + ver
+	with := s.get(ctx, base+"/")
+	without := s.get(ctx, base)
+
+	okStatus := func(c int) bool { return c == http.StatusOK || (c >= 300 && c < 400) }
+	switch {
+	case with.Err != nil || without.Err != nil:
+		return []Result{s.result(id, name, spec, StatusFail, with, "one of the two requests did not complete")}
+	case okStatus(with.Status) && okStatus(without.Status):
+		return []Result{s.result(id, name, spec, StatusPass, with,
+			fmt.Sprintf("%s/ → %d, %s → %d", base, with.Status, base, without.Status))}
+	default:
+		return []Result{s.result(id, name, spec, StatusWarn, with,
+			fmt.Sprintf("%s/ → %d but %s → %d; controllers build these URLs both ways",
+				base, with.Status, base, without.Status))}
+	}
+}
+
+// checkQueryPaging asserts the Query API's paging contract.
+//
+// This is the defect that produced an 11-node capture of a 68-node
+// registry, and it is invisible unless you ask for a limit and count
+// what comes back.
+func checkQueryPaging(ctx context.Context, s *Session) []Result {
+	const spec = "IS-04 v1.3 §7 Query API paging"
+	vs, has := s.APIs["query"]
+	if !has || len(vs) == 0 {
+		return []Result{s.skip("PROFILE-PAGE-001", "paging.limit is honoured", spec, "device serves no query API")}
+	}
+	ver := highestVersion(vs)
+	path := "/x-nmos/query/" + ver + "/nodes?paging.limit=1"
+	r := s.get(ctx, path)
+
+	if r.Err != nil || r.Status != http.StatusOK {
+		return []Result{s.skip("PROFILE-PAGE-001", "paging.limit is honoured", spec,
+			fmt.Sprintf("GET %s returned %d", path, r.Status))}
+	}
+
+	var items []json.RawMessage
+	if json.Unmarshal(r.Body, &items) != nil {
+		return []Result{s.result("PROFILE-PAGE-001", "paging.limit is honoured", spec, StatusFail, r,
+			fmt.Sprintf("GET %s did not return a JSON array", path))}
+	}
+
+	out := []Result{}
+	if len(items) > 1 {
+		out = append(out, s.result("PROFILE-PAGE-001", "paging.limit is honoured", spec, StatusFail, r,
+			fmt.Sprintf("GET %s returned %d resources", path, len(items))))
+	} else {
+		out = append(out, s.result("PROFILE-PAGE-001", "paging.limit is honoured", spec, StatusPass, r,
+			fmt.Sprintf("GET %s returned %d resource(s)", path, len(items))))
+	}
+
+	// The paging headers are how a client knows where it is. Without
+	// them it cannot resume, and cannot tell a short page from the end.
+	const (
+		hdrID   = "PROFILE-PAGE-002"
+		hdrName = "paging headers are returned"
+	)
+	missing := []string{}
+	for _, h := range []string{"X-Paging-Limit", "X-Paging-Since", "X-Paging-Until"} {
+		if r.Header.Get(h) == "" {
+			missing = append(missing, h)
+		}
+	}
+	if len(missing) > 0 {
+		out = append(out, s.result(hdrID, hdrName, spec, StatusWarn, r,
+			fmt.Sprintf("GET %s omitted %s", path, strings.Join(missing, ", "))))
+	} else {
+		out = append(out, s.result(hdrID, hdrName, spec, StatusPass, r,
+			fmt.Sprintf("X-Paging-Limit=%s Since=%s Until=%s",
+				r.Header.Get("X-Paging-Limit"), r.Header.Get("X-Paging-Since"), r.Header.Get("X-Paging-Until"))))
+	}
+
+	// A Link: rel="next" is what a walker follows. Its absence on a
+	// full page means the catalogue cannot be walked to the end.
+	const (
+		linkID   = "PROFILE-PAGE-003"
+		linkName = "a truncated page carries Link rel=next"
+	)
+	hasNext := strings.Contains(r.Header.Get("Link"), `rel="next"`) || strings.Contains(r.Header.Get("Link"), "rel=next")
+	switch {
+	case len(items) == 0:
+		out = append(out, s.skip(linkID, linkName, spec, "the registry listed no nodes, so there is no next page to offer"))
+	case hasNext:
+		out = append(out, s.result(linkID, linkName, spec, StatusPass, r, "Link: "+r.Header.Get("Link")))
+	default:
+		out = append(out, s.result(linkID, linkName, spec, StatusWarn, r,
+			"a limited page carried no Link rel=next; either the catalogue holds exactly one node, or it cannot be paged to the end"))
+	}
+	return out
+}
+
+// checkQueryDowngrade asserts the escape hatch from version isolation.
+//
+// A registry serving v1.1 and v1.3 hides v1.1-registered resources from
+// a v1.3 query. `query.downgrade` is the spec's answer, and a registry
+// that does not implement it makes the highest minor the wrong one to
+// ask on — which is the opposite of what every controller does by
+// default.
+func checkQueryDowngrade(ctx context.Context, s *Session) []Result {
+	const (
+		id   = "PROFILE-VER-003"
+		name = "query.downgrade is supported"
+		spec = "IS-04 v1.3 §6.1 query.downgrade"
+	)
+	vs, has := s.APIs["query"]
+	if !has || len(vs) < 2 {
+		return []Result{s.skip(id, name, spec, "registry serves fewer than two query minors, so isolation cannot arise")}
+	}
+
+	top := highestVersion(vs)
+	lowest := top
+	for _, v := range vs {
+		if v != top {
+			lowest = v
+			break
+		}
+	}
+
+	plain := s.get(ctx, "/x-nmos/query/"+top+"/nodes")
+	down := s.get(ctx, "/x-nmos/query/"+top+"/nodes?query.downgrade="+lowest)
+	if plain.Status != http.StatusOK || down.Status != http.StatusOK {
+		if down.Status >= 400 {
+			return []Result{s.result(id, name, spec, StatusFail, down,
+				fmt.Sprintf("GET /x-nmos/query/%s/nodes?query.downgrade=%s returned %d", top, lowest, down.Status))}
+		}
+		return []Result{s.skip(id, name, spec, "the query could not be compared")}
+	}
+
+	var a, b []json.RawMessage
+	if json.Unmarshal(plain.Body, &a) != nil || json.Unmarshal(down.Body, &b) != nil {
+		return []Result{s.result(id, name, spec, StatusFail, down, "one of the two responses was not a JSON array")}
+	}
+
+	switch {
+	case len(b) > len(a):
+		return []Result{s.result(id, name, spec, StatusPass, down,
+			fmt.Sprintf("%s lists %d nodes, downgraded to %s lists %d — isolation is escapable", top, len(a), lowest, len(b)))}
+	case len(b) == len(a):
+		return []Result{s.result(id, name, spec, StatusPass, down,
+			fmt.Sprintf("downgrade accepted; both list %d nodes (nothing is registered at a lower minor)", len(a)))}
+	default:
+		return []Result{s.result(id, name, spec, StatusFail, down,
+			fmt.Sprintf("downgrading to %s returned FEWER nodes (%d) than %s (%d)", lowest, len(b), top, len(a)))}
+	}
+}
+
+// checkHeartbeatUnknownNode probes the Registration API's answer for a
+// node it does not know.
+//
+// This is read-only: a GET, never a POST. The registry must answer 404,
+// because that is the signal a node uses to know it has been garbage
+// collected and must re-register. A registry that 200s or 500s here
+// leaves a dropped node believing it is still registered.
+func checkHeartbeatUnknownNode(ctx context.Context, s *Session) []Result {
+	const (
+		id   = "PROFILE-REG-001"
+		name = "health for an unregistered node returns 404"
+		spec = "IS-04 v1.3 §4.2 Registration API health"
+	)
+	vs, has := s.APIs["registration"]
+	if !has || len(vs) == 0 {
+		return []Result{s.skip(id, name, spec, "device serves no registration API")}
+	}
+
+	const absent = "00000000-0000-4000-8000-000000000000"
+	path := "/x-nmos/registration/" + highestVersion(vs) + "/health/nodes/" + absent
+	r := s.get(ctx, path)
+
+	switch {
+	case r.Err != nil:
+		return []Result{s.result(id, name, spec, StatusFail, r,
+			fmt.Sprintf("GET %s did not complete: %v", path, r.Err))}
+	case r.Status == http.StatusNotFound:
+		return []Result{s.result(id, name, spec, StatusPass, r,
+			fmt.Sprintf("GET %s returned 404", path))}
+	case r.Status == http.StatusMethodNotAllowed:
+		return []Result{s.result(id, name, spec, StatusWarn, r,
+			fmt.Sprintf("GET %s returned 405; the health endpoint is POST-only here, so the read-only profile cannot assert it", path))}
+	case r.Status >= 500:
+		return []Result{s.result(id, name, spec, StatusFail, r,
+			fmt.Sprintf("GET %s returned %d — a node cannot tell it was garbage collected", path, r.Status))}
+	default:
+		return []Result{s.result(id, name, spec, StatusFail, r,
+			fmt.Sprintf("GET %s returned %d for a node that is not registered", path, r.Status))}
+	}
+}
+
+// checkTransportFileContentType asserts an IS-05 transport file is
+// served as SDP.
+//
+// A receiver handed `text/html` will not parse it, and the failure
+// appears as a route that silently does not come up.
+func checkTransportFileContentType(ctx context.Context, s *Session) []Result {
+	const (
+		id   = "PROFILE-IS05-001"
+		name = "a transport file is served as application/sdp"
+		spec = "IS-05 v1.1 §4.2 transportfile"
+	)
+	vs, has := s.APIs["connection"]
+	if !has || len(vs) == 0 {
+		return []Result{s.skip(id, name, spec, "device serves no connection API")}
+	}
+	ver := highestVersion(vs)
+
+	list := s.get(ctx, "/x-nmos/connection/"+ver+"/single/senders")
+	ids, ok := jsonArray(list.Body)
+	if list.Status != http.StatusOK || !ok || len(ids) == 0 {
+		return []Result{s.skip(id, name, spec, "the device publishes no IS-05 senders")}
+	}
+
+	// One sender by default. --deep asserts every one, which is what
+	// catches a device that is broken on some of them — the shape a
+	// 502-on-every-transportfile device has.
+	if !s.opts.Deep {
+		ids = ids[:1]
+	}
+
+	var out []Result
+	for _, sid := range ids {
+		sid = strings.TrimSuffix(sid, "/")
+		path := "/x-nmos/connection/" + ver + "/single/senders/" + sid + "/transportfile"
+		r := s.get(ctx, path)
+		ct := r.Header.Get("Content-Type")
+		switch {
+		case r.Err != nil:
+			out = append(out, s.result(id, name, spec, StatusFail, r,
+				fmt.Sprintf("GET %s did not complete: %v", path, r.Err)))
+		case r.Status >= 500:
+			out = append(out, s.result(id, name, spec, StatusFail, r,
+				fmt.Sprintf("GET %s returned %d — the endpoint exists and is broken", path, r.Status)))
+		case r.Status == http.StatusNotFound:
+			// Legal for a sender that is not transmitting.
+			out = append(out, s.result(id, name, spec, StatusWarn, r,
+				fmt.Sprintf("GET %s returned 404 (legal only while the sender is inactive)", path)))
+		case r.Status != http.StatusOK:
+			out = append(out, s.result(id, name, spec, StatusFail, r,
+				fmt.Sprintf("GET %s returned %d", path, r.Status)))
+		case !strings.HasPrefix(strings.ToLower(ct), "application/sdp"):
+			out = append(out, s.result(id, name, spec, StatusFail, r,
+				fmt.Sprintf("GET %s returned Content-Type %q, want application/sdp", path, ct)))
+		case !strings.HasPrefix(strings.TrimSpace(string(r.Body)), "v="):
+			out = append(out, s.result(id, name, spec, StatusFail, r,
+				fmt.Sprintf("GET %s returned a body that does not start with `v=` — not an SDP", path)))
+		default:
+			out = append(out, s.result(id, name, spec, StatusPass, r,
+				fmt.Sprintf("GET %s returned %d bytes of application/sdp", path, len(r.Body))))
+		}
+	}
+	return out
+}
+
+func sortedKeys(m map[string][]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	// A stable order keeps two runs diffable.
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j] < out[j-1]; j-- {
+			out[j], out[j-1] = out[j-1], out[j]
+		}
+	}
+	return out
+}

--- a/internal/amwa/profile/profile.go
+++ b/internal/amwa/profile/profile.go
@@ -1,0 +1,355 @@
+// Package profile runs live protocol-conformance assertions against an
+// NMOS device and times every request.
+//
+// It answers what an offline audit cannot. An export records answers;
+// a profile records the conversation. Whether an unknown API version is
+// rejected, whether CORS is present, whether a paging limit is honoured
+// and reported back, whether a heartbeat for an unregistered node
+// 404s — none of that survives into a capture, and every one of them
+// decides whether a real controller can drive the device.
+//
+// The profile is strictly read-only. It never PATCHes, never activates,
+// never registers. A conformance tool that stages a connection is a
+// tool that can take a live source off air, and this one is meant to be
+// safe to point at a plant that is on.
+package profile
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Status is the outcome of one assertion.
+type Status string
+
+const (
+	// StatusPass means the device behaved as the spec requires.
+	StatusPass Status = "PASS"
+	// StatusWarn means the behaviour is permitted but will cause
+	// trouble with a stricter peer.
+	StatusWarn Status = "WARN"
+	// StatusFail means the device contradicts a spec requirement.
+	StatusFail Status = "FAIL"
+	// StatusSkip means the check did not apply — the device does not
+	// serve the API the check is about. A skip is never a pass, and is
+	// reported so a green run cannot hide an untested surface.
+	StatusSkip Status = "SKIP"
+)
+
+// Result is one assertion's outcome. The shape is deliberately flat:
+// one JSON object per line, appendable across runs, diffable between
+// two firmware versions without a reading exercise.
+type Result struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Spec   string `json:"spec,omitempty"`
+	Target string `json:"target"`
+	Status Status `json:"status"`
+	// Detail states what was observed, always including the request
+	// that produced it, so a FAIL can be reproduced by hand.
+	Detail string `json:"detail"`
+	// DurationMS is the wall time of the request this result rests on.
+	DurationMS float64 `json:"duration_ms,omitempty"`
+}
+
+// Options configures a profile run.
+type Options struct {
+	Target  string
+	HTTPS   bool
+	Timeout time.Duration
+	Client  *http.Client
+	// Deep runs the checks that make many requests — per-endpoint
+	// IS-05 assertions across every sender a device publishes.
+	Deep bool
+}
+
+func (o *Options) defaults() {
+	if o.Timeout <= 0 {
+		o.Timeout = 10 * time.Second
+	}
+	if o.Client == nil {
+		o.Client = &http.Client{Timeout: o.Timeout}
+	}
+}
+
+// Report is a complete profile run: the assertions, and how fast the
+// device answered.
+type Report struct {
+	Target  string         `json:"target"`
+	Results []Result       `json:"results"`
+	Counts  map[string]int `json:"counts"`
+	Latency []EndpointStat `json:"latency"`
+}
+
+// EndpointStat is the timing profile of one endpoint class.
+//
+// Percentiles rather than a mean: a registry that answers in 8 ms and
+// occasionally in 4 seconds has a fine mean and is unusable, and the
+// mean is exactly what hides that.
+type EndpointStat struct {
+	Endpoint string  `json:"endpoint"`
+	Requests int     `json:"requests"`
+	P50MS    float64 `json:"p50_ms"`
+	P95MS    float64 `json:"p95_ms"`
+	P99MS    float64 `json:"p99_ms"`
+	MaxMS    float64 `json:"max_ms"`
+	Errors   int     `json:"errors"`
+}
+
+// Session carries what the checks share: the transport, what the device
+// said it serves, and the latency record.
+type Session struct {
+	opts   Options
+	scheme string
+
+	// APIs maps an API name to the versions the device advertised.
+	APIs map[string][]string
+
+	samples map[string][]float64
+	errors  map[string]int
+}
+
+// response is one observed exchange.
+type response struct {
+	Status  int
+	Header  http.Header
+	Body    []byte
+	Elapsed time.Duration
+	Err     error
+}
+
+// ms renders the elapsed time for a Result.
+func (r response) ms() float64 { return float64(r.Elapsed.Microseconds()) / 1000 }
+
+// checkFn is one assertion group. Each returns every Result it
+// produced, so a check that iterates endpoints reports per endpoint.
+type checkFn func(ctx context.Context, s *Session) []Result
+
+// checks is the ordered assertion set. Adding one is adding a function
+// here — that is the whole extension mechanism.
+var checks = []checkFn{
+	checkRoot,
+	checkVersionLists,
+	checkUnknownVersionRejected,
+	checkCORS,
+	checkContentType,
+	checkUnknownResource,
+	checkTrailingSlash,
+	checkQueryPaging,
+	checkQueryDowngrade,
+	checkHeartbeatUnknownNode,
+	checkTransportFileContentType,
+}
+
+// Run probes the target and returns the report.
+func Run(ctx context.Context, opts Options) (*Report, error) {
+	opts.defaults()
+	if opts.Target == "" {
+		return nil, fmt.Errorf("profile: --target is required")
+	}
+
+	s := &Session{
+		opts:    opts,
+		scheme:  "http",
+		APIs:    map[string][]string{},
+		samples: map[string][]float64{},
+		errors:  map[string]int{},
+	}
+	if opts.HTTPS {
+		s.scheme = "https"
+	}
+
+	rep := &Report{Target: opts.Target, Counts: map[string]int{}}
+	for _, c := range checks {
+		rep.Results = append(rep.Results, c(ctx, s)...)
+	}
+	for _, r := range rep.Results {
+		rep.Counts[string(r.Status)]++
+	}
+	rep.Latency = s.latency()
+	return rep, nil
+}
+
+// Worst reports the most severe status present, ranked FAIL > WARN >
+// SKIP > PASS, and whether anything was reported at all.
+func (r *Report) Worst() (Status, bool) {
+	rank := map[Status]int{StatusPass: 0, StatusSkip: 1, StatusWarn: 2, StatusFail: 3}
+	worst, any := StatusPass, false
+	for _, res := range r.Results {
+		if !any || rank[res.Status] > rank[worst] {
+			worst, any = res.Status, true
+		}
+	}
+	return worst, any
+}
+
+// --- transport ---
+
+// get performs one request and records its timing.
+func (s *Session) get(ctx context.Context, path string) response {
+	return s.request(ctx, http.MethodGet, path, nil)
+}
+
+func (s *Session) request(ctx context.Context, method, path string, hdr http.Header) response {
+	rctx, cancel := context.WithTimeout(ctx, s.opts.Timeout)
+	defer cancel()
+
+	url := path
+	if strings.HasPrefix(path, "/") {
+		url = s.scheme + "://" + s.opts.Target + path
+	}
+
+	start := time.Now()
+	req, err := http.NewRequestWithContext(rctx, method, url, nil)
+	if err != nil {
+		return response{Err: err, Elapsed: time.Since(start)}
+	}
+	for k, vs := range hdr {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
+	}
+
+	resp, err := s.opts.Client.Do(req)
+	if err != nil {
+		el := time.Since(start)
+		s.record(path, el, true)
+		return response{Err: err, Elapsed: el}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, readErr := io.ReadAll(resp.Body)
+	el := time.Since(start)
+	s.record(path, el, readErr != nil || resp.StatusCode >= 500)
+	return response{Status: resp.StatusCode, Header: resp.Header, Body: body, Elapsed: el, Err: readErr}
+}
+
+// uuidInPath collapses per-resource URLs into one endpoint class, so a
+// 176-sender device produces one latency row rather than 176.
+var uuidInPath = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
+
+func endpointClass(path string) string {
+	if i := strings.Index(path, "/x-nmos/"); i >= 0 {
+		path = path[i:]
+	}
+	if i := strings.Index(path, "?"); i >= 0 {
+		path = path[:i]
+	}
+	return uuidInPath.ReplaceAllString(path, "{id}")
+}
+
+func (s *Session) record(path string, d time.Duration, failed bool) {
+	class := endpointClass(path)
+	s.samples[class] = append(s.samples[class], float64(d.Microseconds())/1000)
+	if failed {
+		s.errors[class]++
+	}
+}
+
+// latency renders the timing record, slowest p99 first — the row an
+// operator needs to see is the one at the top.
+func (s *Session) latency() []EndpointStat {
+	out := make([]EndpointStat, 0, len(s.samples))
+	for ep, xs := range s.samples {
+		sorted := append([]float64(nil), xs...)
+		sort.Float64s(sorted)
+		out = append(out, EndpointStat{
+			Endpoint: ep,
+			Requests: len(sorted),
+			P50MS:    percentile(sorted, 50),
+			P95MS:    percentile(sorted, 95),
+			P99MS:    percentile(sorted, 99),
+			MaxMS:    sorted[len(sorted)-1],
+			Errors:   s.errors[ep],
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].P99MS != out[j].P99MS {
+			return out[i].P99MS > out[j].P99MS
+		}
+		return out[i].Endpoint < out[j].Endpoint
+	})
+	return out
+}
+
+// percentile uses nearest-rank on a sorted slice. With the handful of
+// samples a profile run collects, interpolation would invent precision the
+// data does not have.
+func percentile(sorted []float64, p int) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	idx := (p*len(sorted) + 99) / 100 // ceil(p/100 * n)
+	if idx < 1 {
+		idx = 1
+	}
+	if idx > len(sorted) {
+		idx = len(sorted)
+	}
+	return sorted[idx-1]
+}
+
+// --- result helpers ---
+
+func (s *Session) result(id, name, spec string, st Status, r response, detail string) Result {
+	return Result{
+		ID: id, Name: name, Spec: spec, Target: s.opts.Target,
+		Status: st, Detail: detail, DurationMS: r.ms(),
+	}
+}
+
+func (s *Session) skip(id, name, spec, why string) Result {
+	return Result{ID: id, Name: name, Spec: spec, Target: s.opts.Target, Status: StatusSkip, Detail: why}
+}
+
+// jsonArray decodes a body as an array of strings, the shape every
+// NMOS index endpoint uses.
+func jsonArray(b []byte) ([]string, bool) {
+	var out []string
+	if json.Unmarshal(b, &out) != nil {
+		return nil, false
+	}
+	return out, true
+}
+
+// versionPattern is the `vMAJOR.MINOR` form every API version takes.
+var versionPattern = regexp.MustCompile(`^v\d+\.\d+$`)
+
+// firstAPIWithResources names an API the device serves that has
+// walkable collections, preferring the registry's catalogue.
+func (s *Session) queryOrNode() (api, ver string, ok bool) {
+	for _, name := range []string{"query", "node"} {
+		if vs, has := s.APIs[name]; has && len(vs) > 0 {
+			return name, highestVersion(vs), true
+		}
+	}
+	return "", "", false
+}
+
+// highestVersion orders v1.10 after v1.9, which a string sort gets
+// wrong.
+func highestVersion(vs []string) string {
+	best, rank := "", -2
+	for _, v := range vs {
+		r := -1
+		if maj, min, cut := strings.Cut(strings.TrimPrefix(v, "v"), "."); cut {
+			m, e1 := strconv.Atoi(maj)
+			n, e2 := strconv.Atoi(min)
+			if e1 == nil && e2 == nil {
+				r = m*1000 + n
+			}
+		}
+		if r > rank {
+			best, rank = v, r
+		}
+	}
+	return best
+}

--- a/internal/amwa/profile/profile_test.go
+++ b/internal/amwa/profile/profile_test.go
@@ -1,0 +1,726 @@
+package profile
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// device is a scriptable NMOS surface. Its defaults are spec-correct,
+// and each test breaks exactly one thing — so a failing assertion names
+// the rule that was broken rather than a pile of unrelated noise.
+type device struct {
+	apis map[string][]string
+	// nodes is what the query API lists.
+	nodes []any
+
+	// the knobs each test turns
+	noCORS          bool
+	refusePreflight bool
+	contentType     string
+	unknownVerOK    bool
+	faultOnMissing  bool
+	plainErrorBody  bool
+	noTrailingSlash bool
+	ignorePaging    bool
+	noPagingHeaders bool
+	noLinkNext      bool
+	downgradeFails  bool
+	healthOnUnknown int
+	transportFile   string
+	transportCT     string
+	transportCode   int
+}
+
+func newDevice() *device {
+	return &device{
+		apis:            map[string][]string{"query": {"v1.1", "v1.3"}, "registration": {"v1.3"}},
+		contentType:     "application/json",
+		healthOnUnknown: http.StatusNotFound,
+		transportCT:     "application/sdp",
+		transportCode:   http.StatusOK,
+		transportFile:   "v=0\r\no=- 1 1 IN IP4 198.51.100.5\r\ns=probe\r\n",
+	}
+}
+
+func (d *device) writeJSON(w http.ResponseWriter, v any) {
+	if !d.noCORS {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+	}
+	if d.contentType != "" {
+		w.Header().Set("Content-Type", d.contentType)
+	}
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func (d *device) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	p := r.URL.Path
+
+	if r.Method == http.MethodOptions {
+		if d.refusePreflight {
+			http.Error(w, "no", http.StatusForbidden)
+			return
+		}
+		if !d.noCORS {
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+		}
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	switch {
+	case p == "/x-nmos":
+		names := make([]string, 0, len(d.apis))
+		for k := range d.apis {
+			names = append(names, k+"/")
+		}
+		d.writeJSON(w, names)
+		return
+
+	case strings.HasPrefix(p, "/x-nmos/") && strings.Count(strings.Trim(p, "/"), "/") == 1:
+		api := strings.TrimSuffix(strings.TrimPrefix(p, "/x-nmos/"), "/")
+		vs, ok := d.apis[api]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		out := make([]string, 0, len(vs))
+		for _, v := range vs {
+			out = append(out, v+"/")
+		}
+		d.writeJSON(w, out)
+		return
+	}
+
+	// Anything at an unadvertised version.
+	if strings.Contains(p, "/v9.9/") {
+		if d.unknownVerOK {
+			d.writeJSON(w, []any{})
+			return
+		}
+		http.NotFound(w, r)
+		return
+	}
+
+	// The version root, with and without a trailing slash.
+	if p == "/x-nmos/query/v1.3" || p == "/x-nmos/query/v1.3/" {
+		if d.noTrailingSlash && p == "/x-nmos/query/v1.3" {
+			http.NotFound(w, r)
+			return
+		}
+		d.writeJSON(w, []string{"nodes/", "devices/"})
+		return
+	}
+
+	// A single node by id — the check only ever asks for one that is
+	// not there.
+	if strings.HasPrefix(p, "/x-nmos/query/v1.3/nodes/") {
+		if d.faultOnMissing {
+			http.Error(w, "boom", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		if d.plainErrorBody {
+			_, _ = w.Write([]byte("not found"))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"code": 404, "error": "resource not found", "debug": nil,
+		})
+		return
+	}
+
+	if p == "/x-nmos/query/v1.1/nodes" || p == "/x-nmos/query/v1.3/nodes" {
+		items := d.nodes
+		limit := r.URL.Query().Get("paging.limit")
+
+		// Version isolation: v1.3 hides the LAST node — whatever was
+		// registered at the lower minor — unless the caller asks to
+		// downgrade. Hiding all but one instead would leave the page
+		// always at length 1, and the paging assertions below would
+		// have nothing to bite on.
+		if p == "/x-nmos/query/v1.3/nodes" {
+			down := r.URL.Query().Get("query.downgrade")
+			if down != "" && d.downgradeFails {
+				http.Error(w, "unsupported", http.StatusBadRequest)
+				return
+			}
+			if down == "" && len(items) > 1 {
+				items = items[:len(items)-1]
+			}
+		}
+
+		if limit != "" && !d.ignorePaging && len(items) > 1 {
+			items = items[:1]
+		}
+		if !d.noPagingHeaders {
+			w.Header().Set("X-Paging-Limit", "10")
+			w.Header().Set("X-Paging-Since", "0:0")
+			w.Header().Set("X-Paging-Until", "0:0")
+		}
+		if limit != "" && !d.noLinkNext && len(d.nodes) > len(items) {
+			w.Header().Set("Link", fmt.Sprintf(`<%s?paging.since=1>; rel="next"`, p))
+		}
+		d.writeJSON(w, items)
+		return
+	}
+
+	if strings.HasPrefix(p, "/x-nmos/registration/v1.3/health/nodes/") {
+		w.WriteHeader(d.healthOnUnknown)
+		return
+	}
+
+	if p == "/x-nmos/connection/v1.1/single/senders" {
+		d.writeJSON(w, []string{"44444444-4444-4444-8444-444444444444/"})
+		return
+	}
+	if strings.HasSuffix(p, "/transportfile") {
+		if d.transportCode != http.StatusOK {
+			w.WriteHeader(d.transportCode)
+			return
+		}
+		w.Header().Set("Content-Type", d.transportCT)
+		_, _ = w.Write([]byte(d.transportFile))
+		return
+	}
+
+	http.NotFound(w, r)
+}
+
+func node(id, label string) map[string]any {
+	return map[string]any{"id": id, "version": "1755000000:0", "label": label, "tags": map[string]any{}}
+}
+
+func profileIt(t *testing.T, d *device) *Report {
+	t.Helper()
+	srv := httptest.NewServer(d)
+	t.Cleanup(srv.Close)
+	rep, err := Run(context.Background(), Options{
+		Target:  strings.TrimPrefix(srv.URL, "http://"),
+		Timeout: 2 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	return rep
+}
+
+// statusOf returns the status of the first result with the given id.
+func statusOf(t *testing.T, r *Report, id string) Status {
+	t.Helper()
+	for _, res := range r.Results {
+		if res.ID == id {
+			return res.Status
+		}
+	}
+	t.Fatalf("no result with id %s; got %v", id, idsOf(r))
+	return ""
+}
+
+func idsOf(r *Report) []string {
+	out := make([]string, 0, len(r.Results))
+	for _, res := range r.Results {
+		out = append(out, res.ID+"="+string(res.Status))
+	}
+	return out
+}
+
+func want(t *testing.T, r *Report, id string, st Status) {
+	t.Helper()
+	if got := statusOf(t, r, id); got != st {
+		for _, res := range r.Results {
+			if res.ID == id {
+				t.Errorf("%s = %s, want %s\n  detail: %s", id, got, st, res.Detail)
+				return
+			}
+		}
+	}
+}
+
+// TestCompliantDeviceHasNoFailures is the baseline. Everything after it
+// breaks exactly one rule, so a failure elsewhere is unambiguous.
+func TestCompliantDeviceHasNoFailures(t *testing.T) {
+	d := newDevice()
+	d.nodes = []any{
+		node("11111111-1111-4111-8111-111111111111", "a"),
+		node("22222222-2222-4222-8222-222222222222", "b"),
+	}
+	rep := profileIt(t, d)
+
+	for _, res := range rep.Results {
+		if res.Status == StatusFail {
+			t.Errorf("a compliant device produced %s: %s\n  %s", res.ID, res.Status, res.Detail)
+		}
+	}
+	if rep.Counts[string(StatusPass)] == 0 {
+		t.Error("no assertion passed against a compliant device")
+	}
+	if worst, any := rep.Worst(); !any || worst == StatusFail {
+		t.Errorf("Worst() = %s,%v on a compliant device", worst, any)
+	}
+}
+
+func TestUnknownVersionServed(t *testing.T) {
+	d := newDevice()
+	d.unknownVerOK = true
+	want(t, profileIt(t, d), "PROFILE-VER-002", StatusFail)
+}
+
+func TestMissingCORS(t *testing.T) {
+	d := newDevice()
+	d.noCORS = true
+	rep := profileIt(t, d)
+	want(t, rep, "PROFILE-CORS-001", StatusFail)
+	// The preflight still answers; it just names no methods.
+	want(t, rep, "PROFILE-CORS-002", StatusWarn)
+}
+
+func TestRefusedPreflight(t *testing.T) {
+	d := newDevice()
+	d.refusePreflight = true
+	want(t, profileIt(t, d), "PROFILE-CORS-002", StatusFail)
+}
+
+func TestWrongContentType(t *testing.T) {
+	d := newDevice()
+	d.contentType = "text/html"
+	want(t, profileIt(t, d), "PROFILE-CT-001", StatusFail)
+
+	d2 := newDevice()
+	d2.contentType = ""
+	want(t, profileIt(t, d2), "PROFILE-CT-001", StatusFail)
+}
+
+// TestFaultOnMissingResource is the distinction that turns a stale
+// reference into a retry storm.
+func TestFaultOnMissingResource(t *testing.T) {
+	d := newDevice()
+	d.faultOnMissing = true
+	want(t, profileIt(t, d), "PROFILE-404-001", StatusFail)
+}
+
+func TestErrorBodyShape(t *testing.T) {
+	d := newDevice()
+	d.plainErrorBody = true
+	rep := profileIt(t, d)
+	want(t, rep, "PROFILE-404-001", StatusPass) // the status is still right
+	want(t, rep, "PROFILE-404-002", StatusWarn) // the body is not
+}
+
+func TestTrailingSlashInconsistency(t *testing.T) {
+	d := newDevice()
+	d.noTrailingSlash = true
+	want(t, profileIt(t, d), "PROFILE-PATH-001", StatusWarn)
+}
+
+// TestPagingLimitIgnored is the defect that captured 11 nodes of a
+// 68-node registry.
+func TestPagingLimitIgnored(t *testing.T) {
+	d := newDevice()
+	d.ignorePaging = true
+	// Three nodes so that v1.3 still lists two after version isolation
+	// hides the one registered lower — a limit of 1 then has something
+	// to fail to honour.
+	d.nodes = []any{
+		node("11111111-1111-4111-8111-111111111111", "a"),
+		node("22222222-2222-4222-8222-222222222222", "b"),
+		node("33333333-3333-4333-8333-333333333333", "c"),
+	}
+	want(t, profileIt(t, d), "PROFILE-PAGE-001", StatusFail)
+}
+
+func TestPagingHeadersAndLink(t *testing.T) {
+	d := newDevice()
+	d.noPagingHeaders = true
+	d.noLinkNext = true
+	d.nodes = []any{
+		node("11111111-1111-4111-8111-111111111111", "a"),
+		node("22222222-2222-4222-8222-222222222222", "b"),
+	}
+	rep := profileIt(t, d)
+	want(t, rep, "PROFILE-PAGE-002", StatusWarn)
+	want(t, rep, "PROFILE-PAGE-003", StatusWarn)
+}
+
+// TestPagingSkippedOnEmptyRegistry: an empty catalogue cannot prove or
+// disprove paging, and must not be reported as either.
+func TestPagingSkippedOnEmptyRegistry(t *testing.T) {
+	d := newDevice()
+	d.nodes = nil
+	rep := profileIt(t, d)
+	want(t, rep, "PROFILE-PAGE-003", StatusSkip)
+}
+
+// TestDowngradeEscapesVersionIsolation: the fake registry hides its
+// second node at v1.3, exactly as a real one does.
+func TestDowngradeEscapesVersionIsolation(t *testing.T) {
+	d := newDevice()
+	d.nodes = []any{
+		node("11111111-1111-4111-8111-111111111111", "a"),
+		node("22222222-2222-4222-8222-222222222222", "b"),
+	}
+	rep := profileIt(t, d)
+	want(t, rep, "PROFILE-VER-003", StatusPass)
+	for _, res := range rep.Results {
+		if res.ID == "PROFILE-VER-003" && !strings.Contains(res.Detail, "isolation is escapable") {
+			t.Errorf("the downgrade result should say what it proved: %q", res.Detail)
+		}
+	}
+}
+
+func TestDowngradeRejected(t *testing.T) {
+	d := newDevice()
+	d.downgradeFails = true
+	d.nodes = []any{
+		node("11111111-1111-4111-8111-111111111111", "a"),
+		node("22222222-2222-4222-8222-222222222222", "b"),
+	}
+	want(t, profileIt(t, d), "PROFILE-VER-003", StatusFail)
+}
+
+func TestDowngradeSkippedOnSingleMinor(t *testing.T) {
+	d := newDevice()
+	d.apis["query"] = []string{"v1.3"}
+	want(t, profileIt(t, d), "PROFILE-VER-003", StatusSkip)
+}
+
+func TestHeartbeatForUnknownNode(t *testing.T) {
+	for _, tc := range []struct {
+		code int
+		want Status
+	}{
+		{http.StatusNotFound, StatusPass},
+		{http.StatusOK, StatusFail},
+		{http.StatusInternalServerError, StatusFail},
+		{http.StatusMethodNotAllowed, StatusWarn},
+	} {
+		t.Run(fmt.Sprint(tc.code), func(t *testing.T) {
+			d := newDevice()
+			d.healthOnUnknown = tc.code
+			want(t, profileIt(t, d), "PROFILE-REG-001", tc.want)
+		})
+	}
+}
+
+func TestNoRegistrationAPISkipsHeartbeat(t *testing.T) {
+	d := newDevice()
+	delete(d.apis, "registration")
+	want(t, profileIt(t, d), "PROFILE-REG-001", StatusSkip)
+}
+
+// TestTransportFile covers each way a transport file can be wrong. The
+// 502 case is a real device behaviour, observed live.
+func TestTransportFile(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		set  func(*device)
+		want Status
+	}{
+		{"served correctly", func(d *device) {}, StatusPass},
+		{"502", func(d *device) { d.transportCode = http.StatusBadGateway }, StatusFail},
+		{"404 while inactive", func(d *device) { d.transportCode = http.StatusNotFound }, StatusWarn},
+		{"403", func(d *device) { d.transportCode = http.StatusForbidden }, StatusFail},
+		{"wrong content type", func(d *device) { d.transportCT = "text/plain" }, StatusFail},
+		{"not an SDP", func(d *device) { d.transportFile = "<html>nope</html>" }, StatusFail},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newDevice()
+			d.apis["connection"] = []string{"v1.1"}
+			tc.set(d)
+			want(t, profileIt(t, d), "PROFILE-IS05-001", tc.want)
+		})
+	}
+}
+
+func TestNoConnectionAPISkipsTransportFile(t *testing.T) {
+	want(t, profileIt(t, newDevice()), "PROFILE-IS05-001", StatusSkip)
+}
+
+// TestDeepProbesEverySender proves --deep is what catches a device that
+// is broken on some endpoints and not others.
+func TestDeepProbesEverySender(t *testing.T) {
+	ids := []string{
+		"44444444-4444-4444-8444-444444444444/",
+		"55555555-5555-4555-8555-555555555555/",
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/x-nmos":
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			_ = json.NewEncoder(w).Encode([]string{"connection/"})
+		case r.URL.Path == "/x-nmos/connection/":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]string{"v1.1/"})
+		case r.URL.Path == "/x-nmos/connection/v1.1/single/senders":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(ids)
+		case strings.HasSuffix(r.URL.Path, "/transportfile"):
+			// The second sender is broken; the first is fine.
+			if strings.Contains(r.URL.Path, "5555") {
+				http.Error(w, "bad gateway", http.StatusBadGateway)
+				return
+			}
+			w.Header().Set("Content-Type", "application/sdp")
+			_, _ = w.Write([]byte("v=0\r\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	target := strings.TrimPrefix(srv.URL, "http://")
+
+	shallow, err := Run(context.Background(), Options{Target: target, Timeout: 2 * time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	deep, err := Run(context.Background(), Options{Target: target, Timeout: 2 * time.Second, Deep: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	countIS05 := func(r *Report, st Status) int {
+		n := 0
+		for _, res := range r.Results {
+			if res.ID == "PROFILE-IS05-001" && res.Status == st {
+				n++
+			}
+		}
+		return n
+	}
+	if countIS05(shallow, StatusFail) != 0 {
+		t.Error("the shallow probe should have checked only the first, working sender")
+	}
+	if countIS05(deep, StatusFail) != 1 {
+		t.Errorf("--deep found %d broken senders, want 1", countIS05(deep, StatusFail))
+	}
+	if countIS05(deep, StatusPass) != 1 {
+		t.Errorf("--deep found %d working senders, want 1", countIS05(deep, StatusPass))
+	}
+}
+
+// TestUnreachableTargetFailsCleanly: pointing the probe at nothing must
+// report, not panic.
+func TestUnreachableTargetFailsCleanly(t *testing.T) {
+	srv := httptest.NewServer(newDevice())
+	target := strings.TrimPrefix(srv.URL, "http://")
+	srv.Close()
+
+	rep, err := Run(context.Background(), Options{Target: target, Timeout: 500 * time.Millisecond})
+	if err != nil {
+		t.Fatalf("an unreachable target should report, not error: %v", err)
+	}
+	want(t, rep, "PROFILE-ROOT-001", StatusFail)
+	if worst, any := rep.Worst(); !any || worst != StatusFail {
+		t.Errorf("Worst() = %s,%v", worst, any)
+	}
+}
+
+func TestRootNotAnArray(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"not":"an array"}`))
+	}))
+	defer srv.Close()
+	rep, err := Run(context.Background(), Options{Target: strings.TrimPrefix(srv.URL, "http://"), Timeout: time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want(t, rep, "PROFILE-ROOT-001", StatusFail)
+	// With no APIs discovered, the version check has nothing to assert
+	// and must skip rather than pass.
+	want(t, rep, "PROFILE-VER-001", StatusSkip)
+}
+
+func TestMalformedVersionList(t *testing.T) {
+	d := newDevice()
+	d.apis["query"] = []string{"1.3", "latest"}
+	want(t, profileIt(t, d), "PROFILE-VER-001", StatusFail)
+}
+
+func TestTargetRequired(t *testing.T) {
+	if _, err := Run(context.Background(), Options{}); err == nil {
+		t.Error("an empty target should be refused")
+	}
+}
+
+// TestLatencyIsRecorded: the timing is half the point of the verb.
+func TestLatencyIsRecorded(t *testing.T) {
+	rep := profileIt(t, newDevice())
+	if len(rep.Latency) == 0 {
+		t.Fatal("no latency was recorded")
+	}
+	for _, s := range rep.Latency {
+		if s.Requests == 0 {
+			t.Errorf("%s recorded 0 requests", s.Endpoint)
+		}
+		if s.P50MS > s.P99MS || s.P99MS > s.MaxMS {
+			t.Errorf("%s percentiles are not ordered: p50=%.2f p99=%.2f max=%.2f",
+				s.Endpoint, s.P50MS, s.P99MS, s.MaxMS)
+		}
+	}
+	// Per-resource URLs must collapse into one endpoint class, or a
+	// 176-sender device produces 176 unreadable rows.
+	for _, s := range rep.Latency {
+		if strings.Contains(s.Endpoint, "0000-4000-8000") {
+			t.Errorf("a UUID survived into an endpoint class: %s", s.Endpoint)
+		}
+	}
+}
+
+func TestPercentileNearestRank(t *testing.T) {
+	xs := []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	for _, tc := range []struct {
+		p    int
+		want float64
+	}{
+		{50, 5}, {95, 10}, {99, 10}, {1, 1},
+	} {
+		if got := percentile(xs, tc.p); got != tc.want {
+			t.Errorf("percentile(%d) = %v, want %v", tc.p, got, tc.want)
+		}
+	}
+	if got := percentile(nil, 50); got != 0 {
+		t.Errorf("percentile of nothing = %v", got)
+	}
+	if got := percentile([]float64{42}, 99); got != 42 {
+		t.Errorf("percentile of one sample = %v", got)
+	}
+}
+
+func TestHighestVersionOrdersNumerically(t *testing.T) {
+	if got := highestVersion([]string{"v1.9", "v1.10"}); got != "v1.10" {
+		t.Errorf("highestVersion = %q, want v1.10", got)
+	}
+	if got := highestVersion([]string{"junk"}); got != "junk" {
+		t.Errorf("highestVersion of one unparseable = %q", got)
+	}
+}
+
+func TestEndpointClass(t *testing.T) {
+	got := endpointClass("http://h:80/x-nmos/connection/v1.1/single/senders/44444444-4444-4444-8444-444444444444/active?x=1")
+	if got != "/x-nmos/connection/v1.1/single/senders/{id}/active" {
+		t.Errorf("endpointClass = %q", got)
+	}
+	if got := endpointClass("/other/path"); got != "/other/path" {
+		t.Errorf("endpointClass of a non-nmos path = %q", got)
+	}
+}
+
+// TestRenderers pins each output shape.
+func TestRenderers(t *testing.T) {
+	d := newDevice()
+	d.noCORS = true
+	d.nodes = []any{node("11111111-1111-4111-8111-111111111111", "a")}
+	rep := profileIt(t, d)
+
+	var text bytes.Buffer
+	if err := RenderText(&text, rep); err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range []string{"NMOS LIVE PROBE", "FAIL", "LATENCY (ms)", "SUMMARY", "PROFILE-CORS-001"} {
+		if !strings.Contains(text.String(), s) {
+			t.Errorf("text report missing %q", s)
+		}
+	}
+	// Failures first: an operator runs a probe because something is
+	// suspected.
+	if strings.Index(text.String(), "FAIL") > strings.Index(text.String(), "PASS —") {
+		t.Error("failures should be reported before passes")
+	}
+
+	var jb bytes.Buffer
+	if err := RenderJSON(&jb, rep); err != nil {
+		t.Fatal(err)
+	}
+	var back Report
+	if err := json.Unmarshal(jb.Bytes(), &back); err != nil {
+		t.Fatalf("the report does not round-trip: %v", err)
+	}
+	if len(back.Results) != len(rep.Results) {
+		t.Error("the round trip lost results")
+	}
+
+	var lb bytes.Buffer
+	if err := RenderJSONL(&lb, rep); err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimRight(lb.String(), "\n"), "\n")
+	if len(lines) != len(rep.Results)+len(rep.Latency) {
+		t.Errorf("JSONL wrote %d lines for %d results + %d latency rows",
+			len(lines), len(rep.Results), len(rep.Latency))
+	}
+	// Latency rows must be distinguishable from results, or a consumer
+	// reading the file cannot tell them apart.
+	latencyRows := 0
+	for _, ln := range lines {
+		var row struct {
+			Kind string `json:"kind"`
+			ID   string `json:"id"`
+		}
+		if err := json.Unmarshal([]byte(ln), &row); err != nil {
+			t.Fatalf("a JSONL line is not an object: %v", err)
+		}
+		if row.Kind == "latency" {
+			latencyRows++
+		} else if row.ID == "" {
+			t.Error("a non-latency line carries no id")
+		}
+	}
+	if latencyRows != len(rep.Latency) {
+		t.Errorf("%d latency rows tagged, want %d", latencyRows, len(rep.Latency))
+	}
+}
+
+type failWriter struct{ n int }
+
+func (f *failWriter) Write(p []byte) (int, error) {
+	if f.n <= 0 {
+		return 0, fmt.Errorf("closed")
+	}
+	f.n--
+	return len(p), nil
+}
+
+func TestRenderersPropagateWriteErrors(t *testing.T) {
+	rep := profileIt(t, newDevice())
+	if err := RenderText(&failWriter{n: 1}, rep); err == nil {
+		t.Error("RenderText should surface the write error")
+	}
+	if err := RenderJSONL(&failWriter{n: 0}, rep); err == nil {
+		t.Error("RenderJSONL should surface the write error")
+	}
+	// The latency rows come after the results, so a writer that dies
+	// partway must still report.
+	if err := RenderJSONL(&failWriter{n: len(rep.Results)}, rep); err == nil {
+		t.Error("RenderJSONL should surface a write error on the latency rows")
+	}
+}
+
+func TestWorstOnEmptyReport(t *testing.T) {
+	if _, any := (&Report{}).Worst(); any {
+		t.Error("an empty report should report nothing")
+	}
+}
+
+func TestHTTPSOption(t *testing.T) {
+	d := newDevice()
+	srv := httptest.NewTLSServer(d)
+	defer srv.Close()
+	rep, err := Run(context.Background(), Options{
+		Target: strings.TrimPrefix(srv.URL, "https://"), HTTPS: true,
+		Client: srv.Client(), Timeout: 2 * time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want(t, rep, "PROFILE-ROOT-001", StatusPass)
+}

--- a/internal/amwa/profile/render.go
+++ b/internal/amwa/profile/render.go
@@ -1,0 +1,114 @@
+package profile
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// RenderText writes the human report: the assertions grouped by
+// outcome, then the timing.
+//
+// Failures come first. A probe is usually run because something is
+// suspected, and the answer should not need scrolling to.
+func RenderText(w io.Writer, r *Report) error {
+	bw := &errWriter{w: w}
+
+	bw.printf("NMOS LIVE PROBE — %s\n", r.Target)
+	bw.printf("%s\n\n", strings.Repeat("=", 78))
+
+	for _, st := range []Status{StatusFail, StatusWarn, StatusSkip, StatusPass} {
+		group := filterByStatus(r.Results, st)
+		if len(group) == 0 {
+			continue
+		}
+		bw.printf("%s — %d\n%s\n", st, len(group), strings.Repeat("-", 40))
+		for _, res := range group {
+			bw.printf("  %-18s %s\n", res.ID, res.Name)
+			bw.printf("  %-18s   %s\n", "", res.Detail)
+			if res.Spec != "" {
+				bw.printf("  %-18s   spec %s\n", "", res.Spec)
+			}
+		}
+		bw.printf("\n")
+	}
+
+	bw.printf("LATENCY (ms)\n\n")
+	bw.printf("%-46s %5s %8s %8s %8s %6s\n", "ENDPOINT", "REQS", "P50", "P95", "P99", "ERRS")
+	bw.printf("%s\n", strings.Repeat("-", 78))
+	for _, s := range r.Latency {
+		bw.printf("%-46s %5d %8.1f %8.1f %8.1f %6d\n",
+			truncLeft(s.Endpoint, 46), s.Requests, s.P50MS, s.P95MS, s.P99MS, s.Errors)
+	}
+
+	bw.printf("\nSUMMARY\n\n")
+	for _, st := range []Status{StatusFail, StatusWarn, StatusSkip, StatusPass} {
+		bw.printf("  %-6s %d\n", st, r.Counts[string(st)])
+	}
+	return bw.err
+}
+
+// RenderJSON writes the whole report as one object.
+func RenderJSON(w io.Writer, r *Report) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(r)
+}
+
+// RenderJSONL writes one result per line.
+//
+// This is the form that appends across runs and diffs as plain lines,
+// so "did this device get better or worse since the firmware update" is
+// a diff rather than a reading exercise. The latency rows follow the
+// results, tagged so a reader can tell them apart.
+func RenderJSONL(w io.Writer, r *Report) error {
+	enc := json.NewEncoder(w)
+	for _, res := range r.Results {
+		if err := enc.Encode(res); err != nil {
+			return err
+		}
+	}
+	for _, s := range r.Latency {
+		row := struct {
+			Kind   string `json:"kind"`
+			Target string `json:"target"`
+			EndpointStat
+		}{Kind: "latency", Target: r.Target, EndpointStat: s}
+		if err := enc.Encode(row); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func filterByStatus(rs []Result, st Status) []Result {
+	var out []Result
+	for _, r := range rs {
+		if r.Status == st {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (e *errWriter) printf(format string, args ...any) {
+	if e.err != nil {
+		return
+	}
+	_, e.err = fmt.Fprintf(e.w, format, args...)
+}
+
+// truncLeft clips from the left, keeping the tail of a path — the part
+// that distinguishes two endpoints is at the end, not the start.
+func truncLeft(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return "…" + s[len(s)-n+1:]
+}


### PR DESCRIPTION
> **Stacked on #838**, which is stacked on #836. Base is `feat/nmos-export`; GitHub retargets as each merges. Review order: #836 → #838 → this.

## What

`dhs consumer nmos probe --target <host:port>` — live protocol conformance against one device, with per-endpoint latency, emitted as JSONL.

```bash
dhs consumer nmos probe --target 10.44.55.56:8080 --format jsonl --out results.jsonl
```

## Why

The audit reads bytes. A probe reads the conversation. Neither substitutes for the other:

| Question | Answered by |
|---|---|
| what does this plant look like, and where does it deviate | `audit` |
| does an unknown API version 404, or does the device serve it anyway | **probe** |
| is CORS present — without it no browser-based controller works at all | **probe** |
| is `paging.limit` honoured, clamped, and reported back | **probe** |
| does `query.downgrade` actually escape version isolation | **probe** |
| does health for an unregistered node 404, so the node knows to re-register | **probe** |
| how slow is it | **probe** |

Closes #839

## It found defects in us before it found any elsewhere

Run against our own registry and node:

| Finding | Filed |
|---|---|
| version root 404s without a trailing slash | #840 |
| our Node serves no Connection API — discoverable, unroutable | #841 |

## Scope

- [x] osc / tsl / cerebrum-nb / amwa

## Reference controller

- [x] N/A — read-only client

## Type

- [x] feat — new feature

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `internal/amwa/probe/probe.go` | new | session, transport, latency recording |
| `internal/amwa/probe/checks.go` | new | the thirteen assertions |
| `internal/amwa/probe/render.go` | new | text / json / jsonl |
| `internal/amwa/probe/probe_test.go` | new | a compliant device, then one broken rule at a time |
| `cmd/dhs/cmd_nmos_probe.go` | new | the verb |
| `cmd/dhs/cmd_nmos.go` | modified | dispatch + help |

## Design decisions

**Read-only by construction.** It never PATCHes, activates, or registers. A conformance tool that stages a connection is one that can take a live source off air, and this is meant to be safe to point at a plant that is on. Write-path conformance needs a lab device and its own opt-in verb.

**SKIP is reported, never folded into PASS.** A device with no Connection API skips the IS-05 assertions; that is not the same as passing them, and a green run must not hide an untested surface.

**Percentiles, not a mean.** A registry that answers in 8 ms and occasionally in 4 seconds has a fine mean and is unusable. Per-resource URLs collapse into one endpoint class, so a 176-sender device produces one row rather than 176.

**JSONL because it diffs.** One object per line, appendable across runs. "Did this device get better or worse since the firmware update" becomes a line diff. Latency rows are tagged `"kind":"latency"` so a consumer can tell them from results.

**This is not the AMWA Testing tool, and does not pretend to be.** That suite is the reference and stays the reference (#173/#183). This is what runs in one binary, no Docker, against a production plant, inside a commissioning window. Both emit the same JSONL shape, so one report can carry both.

## Test results

| | |
|---|---|
| `go test ./internal/amwa/probe/...` | pass |
| Coverage | **91.7% of statements** |
| `go build ./...` / `go vet ./...` | clean |
| `golangci-lint run` | **0 issues** |

Every assertion is tested twice: against a device that gets it right, and one that breaks exactly that rule. The compliant baseline asserts *zero* failures, so a new check that misfires fails the build.

Against our own live registry:

```text
SUMMARY

  FAIL   0
  WARN   1     <- the trailing-slash defect, now #840
  SKIP   2
  PASS  13

LATENCY (ms)
ENDPOINT                                        REQS      P50      P95      P99   ERRS
/x-nmos                                            4      0.0      3.3      3.3      0
/x-nmos/query/v1.3/nodes                           3      0.5      1.1      1.1      0
```

## Device tested

- [x] Tested against a live `dhs registry nmos serve` + `dhs producer nmos serve` pair on this host, plus `httptest` devices for every failure mode. Not yet run against third-party hardware — that is the next step and needs the fleet.

## Not in this unit

- **IS-07 / IS-08 / IS-12 assertions.** The framework takes them as one function each; the specs land first.
- **Write-path conformance.** Deliberately excluded, see above.

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies (stdlib only)
- [x] Integration tested before PR — against our own live registry and node

## Approval

@yboujraf — requesting review