### PR TITLE
feat(nmos/node): configurable heartbeat cadence, so the registry's GC is testable (#855)

### DIFF
--- a/cmd/dhs/cmd_nmos.go
+++ b/cmd/dhs/cmd_nmos.go
@@ -266,7 +266,8 @@ func runNMOSNodeServeLegacy(ctx context.Context, args []string) error {
 	noMDNS := fs.Bool("no-mdns", false, "disable mDNS announce (Mode B / static)")
 	apiVer := fs.String("api-ver", "v1.3", "IS-04 wire version exposed under /x-nmos/node/<v>")
 	priority := fs.Int("priority", 0, "DNS-SD `pri` TXT (0-99 production, 100+ dev)")
-	registry := fs.String("registry", "", "Registration API base URL — when set, the Node POSTs to /resource + heartbeats every 5 s")
+	registry := fs.String("registry", "", "Registration API base URL — when set, the Node POSTs to /resource + heartbeats")
+	heartbeat := fs.Duration("heartbeat", 0, "POST /health cadence (default 5s, IS-04 §6.1). Set it longer than the registry's --heartbeat-timeout to have this node garbage-collected on purpose")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -286,12 +287,13 @@ func runNMOSNodeServeLegacy(ctx context.Context, args []string) error {
 		mode = "static"
 	}
 	cfg := provider.IS04NodeConfig{
-		Bind:          *bind,
-		AdvertiseHost: *advertise,
-		DiscoveryMode: mode,
-		Priority:      *priority,
-		APIVer:        *apiVer,
-		RegistryURL:   *registry,
+		Bind:              *bind,
+		AdvertiseHost:     *advertise,
+		DiscoveryMode:     mode,
+		Priority:          *priority,
+		APIVer:            *apiVer,
+		RegistryURL:       *registry,
+		HeartbeatInterval: *heartbeat,
 	}
 	srv, err := provider.NewIS04NodeServer(logger, bundle, cfg)
 	if err != nil {
@@ -305,7 +307,11 @@ func runNMOSNodeServeLegacy(ctx context.Context, args []string) error {
 		fmt.Println("Announcing _nmos-node._tcp via mDNS.")
 	}
 	if *registry != "" {
-		fmt.Printf("Registering against %s every %s + heartbeat.\n", *registry, "5s")
+		beat := *heartbeat
+		if beat <= 0 {
+			beat = provider.HeartbeatInterval
+		}
+		fmt.Printf("Registering against %s, heartbeat every %s.\n", *registry, beat)
 	}
 	return srv.Serve(ctx)
 }
@@ -597,6 +603,13 @@ Role: node (Phase 1 #3 — IS-04 v1.3 Node API)
   --priority N          DNS-SD pri TXT (0-99 prod, 100+ dev)
   --registry URL        Registration API base URL (e.g. http://reg.local:8235);
                         omit to run mDNS-only / direct-Node mode
+  --heartbeat DURATION  POST /health cadence (default 5s, IS-04 §6.1). Pair it
+                        with the registry's --heartbeat-timeout to drive the
+                        garbage collector on purpose: a cadence LONGER than the
+                        timeout must get this node evicted, a shorter one must
+                        not. The threshold is NOT discoverable — IS-04 gives no
+                        way for a registry to advertise it, so both sides just
+                        assume the 5s/12s defaults.
 
 Role: system (Phase 1 #2 — IS-09 System API)
   Loads + validates a /global resource JSON, serves the two IS-09 endpoints

--- a/internal/amwa/provider/node.go
+++ b/internal/amwa/provider/node.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	dnssdcodec "dhs/internal/amwa/codec/dnssd"
 	"dhs/internal/amwa/codec/is04"
@@ -79,6 +80,10 @@ type IS04NodeConfig struct {
 	// against this Registration API base (e.g. http://10.6.239.113:8235/).
 	// When empty, mDNS-only / direct-Node mode (Mode D peers).
 	RegistryURL string
+	// HeartbeatInterval overrides the POST /health cadence. Zero uses
+	// the IS-04 §6.1 default of five seconds. Settable so a lab can
+	// drive the registry's garbage collector on purpose.
+	HeartbeatInterval time.Duration
 }
 
 // IS04NodeServer hosts the Node API endpoints + DNS-SD announce +
@@ -223,6 +228,7 @@ func (s *IS04NodeServer) Serve(ctx context.Context) error {
 	// the highest-pri Registry — that's IS-04 §3.1 Mode A.
 	if s.cfg.RegistryURL != "" {
 		rc := NewRegistrationClient(s.logger, s.cfg.RegistryURL, s.cfg.APIVer, s.bundle)
+		rc.SetHeartbeatInterval(s.cfg.HeartbeatInterval)
 		rc.SetOnRegistered(s.onRegistrationStateChanged)
 		s.regClient = rc
 		go rc.Run(ctx)
@@ -239,6 +245,7 @@ func (s *IS04NodeServer) Serve(ctx context.Context) error {
 		}
 		s.watcher = w
 		rc := NewRegistrationClient(s.logger, "", s.cfg.APIVer, s.bundle)
+		rc.SetHeartbeatInterval(s.cfg.HeartbeatInterval)
 		rc.SetWatcher(w)
 		rc.SetOnRegistered(s.onRegistrationStateChanged)
 		s.regClient = rc

--- a/internal/amwa/provider/registration_client.go
+++ b/internal/amwa/provider/registration_client.go
@@ -38,13 +38,13 @@ var ErrRegistryNotFound = errors.New("provider/node: registry returned 404 — r
 
 // RegistrationClient drives the Node-side registration loop:
 //
-//   1. POST /resource for the Node, then each Device, Source, Flow,
-//      Sender, Receiver in dependency order (referential integrity:
-//      Sources before Flows, etc.).
-//   2. Heartbeat every 5 s via POST /health/nodes/{id}.
-//   3. On 404 from heartbeat → full re-registration.
-//   4. On Stop / shutdown → DELETE every owned resource (Receivers
-//      first, then Senders, Flows, Sources, Devices, Node).
+//  1. POST /resource for the Node, then each Device, Source, Flow,
+//     Sender, Receiver in dependency order (referential integrity:
+//     Sources before Flows, etc.).
+//  2. Heartbeat every 5 s via POST /health/nodes/{id}.
+//  3. On 404 from heartbeat → full re-registration.
+//  4. On Stop / shutdown → DELETE every owned resource (Receivers
+//     first, then Senders, Flows, Sources, Devices, Node).
 type RegistrationClient struct {
 	logger *slog.Logger
 
@@ -70,9 +70,9 @@ type RegistrationClient struct {
 
 	http *stdhttp.Client
 
-	mu          sync.Mutex
-	cancelLoop  context.CancelFunc
-	registered  atomic.Bool
+	mu         sync.Mutex
+	cancelLoop context.CancelFunc
+	registered atomic.Bool
 	// onRegistered fires whenever the registered flag transitions
 	// (true→false or false→true). The callback is invoked synchronously
 	// from the loop goroutine so handlers must be quick + non-blocking
@@ -85,14 +85,40 @@ type RegistrationClient struct {
 	// On subsequent failovers we use rejoinOrRegister (heartbeat-first)
 	// per IS-04 §6.1. Touched only inside the Run loop, no mutex.
 	everRegistered bool
-	registrations uint64
-	heartbeats    uint64
-	reregister    uint64
-	deletions     uint64
-	failures      uint64
+	registrations  uint64
+	heartbeats     uint64
+	reregister     uint64
+	deletions      uint64
+	failures       uint64
+
+	// heartbeat is the POST /health/nodes/{id} cadence. Defaults to the
+	// IS-04 §6.1 five seconds; settable so a lab can drive the registry's
+	// garbage collector deliberately — a cadence longer than the
+	// registry's timeout MUST get the node evicted, and one much shorter
+	// MUST NOT. Neither case is testable against a hard-coded constant.
+	heartbeat time.Duration
 
 	// closed signals the heartbeat loop to exit + DELETE has finished.
 	closed chan struct{}
+}
+
+// SetHeartbeatInterval overrides the POST /health cadence. Zero or
+// negative restores the IS-04 §6.1 default.
+//
+// Must be called before Run; the loop reads it once at start.
+func (c *RegistrationClient) SetHeartbeatInterval(d time.Duration) {
+	if d <= 0 {
+		d = HeartbeatInterval
+	}
+	c.heartbeat = d
+}
+
+// heartbeatInterval is the cadence the loop actually uses.
+func (c *RegistrationClient) heartbeatInterval() time.Duration {
+	if c.heartbeat > 0 {
+		return c.heartbeat
+	}
+	return HeartbeatInterval
 }
 
 // NewRegistrationClient builds an unstarted client. apiVer is the
@@ -257,11 +283,21 @@ func (c *RegistrationClient) Run(ctx context.Context) {
 		}
 	}
 
-	// AMWA test_15/16 cascade-disables mocks every (HeartbeatInterval+1)
-	// seconds. To detect dead mocks reliably and fail over within that
-	// window, the loop ticks faster than the heartbeat cadence. We
-	// throttle actual heartbeats to HeartbeatInterval below.
-	ticker := time.NewTicker(1 * time.Second)
+	// AMWA test_15/16 cascade-disables mocks every (heartbeat+1) seconds.
+	// To detect dead mocks reliably and fail over within that window, the
+	// loop ticks faster than the heartbeat cadence. Actual heartbeats are
+	// throttled to the configured interval below.
+	beat := c.heartbeatInterval()
+	tick := time.Second
+	if beat < 2*time.Second {
+		// A sub-2s cadence is a deliberate lab setting; the loop has to
+		// tick faster than the beat or the throttle below swallows it.
+		tick = beat / 2
+		if tick < 50*time.Millisecond {
+			tick = 50 * time.Millisecond
+		}
+	}
+	ticker := time.NewTicker(tick)
 	defer ticker.Stop()
 	lastHeartbeat := time.Time{}
 
@@ -329,12 +365,18 @@ func (c *RegistrationClient) Run(ctx context.Context) {
 					continue
 				}
 			}
-			// Throttle actual /health POSTs near HeartbeatInterval — the
-			// 1 s tick above is for fast failover detection only. AMWA
-			// test_05 enforces 5 s ± 0.5 s between heartbeats, so we
-			// fire when the elapsed budget is within 0.5 s of due to
-			// keep the tick-quantisation jitter inside the window.
-			if time.Since(lastHeartbeat) < HeartbeatInterval-500*time.Millisecond {
+			// Throttle actual /health POSTs near the configured cadence —
+			// the faster tick above is for failover detection only. AMWA
+			// test_05 enforces 5 s ± 0.5 s between heartbeats, so we fire
+			// when the elapsed budget is within 0.5 s of due to keep the
+			// tick-quantisation jitter inside the window. The slack
+			// scales with the cadence so a 500 ms lab setting is not
+			// swallowed by a 500 ms allowance.
+			slack := 500 * time.Millisecond
+			if beat/10 < slack {
+				slack = beat / 10
+			}
+			if time.Since(lastHeartbeat) < beat-slack {
 				continue
 			}
 			lastHeartbeat = time.Now()
@@ -469,8 +511,8 @@ func (c *RegistrationClient) registerAll(ctx context.Context) error {
 // postResource POSTs one IS-04 resource. Per IS-04 v1.3.3 §4.0:
 //   - 201 Created  → fresh registration, accept it.
 //   - 200 OK       → Registry already had this UUID (stale state). The
-//                    Node MUST DELETE the stale entry and re-POST as
-//                    fresh — AMWA test_21 enforces this.
+//     Node MUST DELETE the stale entry and re-POST as
+//     fresh — AMWA test_21 enforces this.
 //   - other        → error.
 func (c *RegistrationClient) postResource(ctx context.Context, t is04.ResourceType, data any) error {
 	status, err := c.postResourceOnce(ctx, t, data)


### PR DESCRIPTION
## Why

The node heartbeats every 5 s and there is no way to change it. That is the IS-04 §6.1 default and the right default — but it makes the registry's garbage collector untestable.

Every heartbeat use case needs a cadence:

| case | needs |
|---|---|
| node is evicted when it stops heartbeating | cadence LONGER than the registry's timeout |
| node survives a slow-but-adequate cadence | cadence just under the timeout |
| node re-registers after being GC'd (404 on /health) | eviction, then a heartbeat |
| AMWA test_05 cadence window (5 s ± 0.5 s) | the default, unchanged |
| a lab that wants a fast loop | sub-second |

None of these is reachable against a hard-coded constant. The registry already has `--heartbeat-timeout` and `--gc-interval`; the node has no matching knob.

## What to build

`dhs producer nmos serve --heartbeat DURATION`, defaulting to the spec's 5 s.

The loop currently ticks at 1 s for fast failover detection and throttles actual `/health` POSTs to `HeartbeatInterval - 500ms`. Both need to scale: a 500 ms cadence is swallowed whole by a 500 ms slack, and a sub-2 s cadence needs a faster tick than the beat.

## A gap worth recording

**The threshold is not discoverable.** IS-04 defines the defaults (5 s heartbeat, 12 s timeout) and provides no way for a registry to advertise the value it actually uses:

- DNS-SD TXT carries `api_proto`, `api_ver`, `api_auth`, `pri` — nothing about timing
- `POST /health/nodes/{id}` returns `{"health": "<unix-seconds>"}` — the last-seen time, not the deadline
- the Query API exposes no registry configuration

So a node assumes 5 s and finds out it was wrong only when a heartbeat returns 404. And a **controller** watching the Query API sees a resource disappear with no reason code — a `removed` grain is `pre`-only, identical whether the node deregistered cleanly with DELETE or was garbage-collected. On the customer plant that is exactly the situation with `bm-n-aetac-001`: registered, unreachable, and nothing says why.

Nothing to fix in our code — it is a spec gap — but it belongs in `status.md` §3, and it is the reason the audit's `NMOS-NODE-UNREACHABLE` finding has to be phrased as two possibilities rather than one.

## Definition of done

- [ ] `--heartbeat` on `producer nmos serve`, default 5 s
- [ ] tick rate and throttle slack scale with the configured cadence
- [ ] integration proof: registry `--heartbeat-timeout 6s` + node `--heartbeat 20s` evicts the node; the same pair with `--heartbeat 2s` does not
- [ ] the startup banner prints the cadence in use, not a hard-coded "5s"
- [ ] the non-discoverability of the threshold recorded in `status.md`