### PR TITLE
fix(cerebrum-nb): make DEVICE_NAME padding visible, and name it on a NACK

### DIFF
--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -878,7 +878,9 @@ func cerebrumDeviceDetails(_ context.Context, args []string) error {
 	fmt.Printf("device_type  %s\n", d.DeviceType)
 	if d.Details != nil {
 		if d.Details.Name != "" {
-			fmt.Printf("name         %s\n", d.Details.Name)
+			// This is the string --by-name has to match exactly, so it
+			// is shown with its padding, not as it happens to render.
+			fmt.Printf("name         %s\n", quoteIfPadded(d.Details.Name))
 		}
 		if d.Details.VendorType != "" {
 			fmt.Printf("vendor       %s\n", d.Details.VendorType)
@@ -968,7 +970,7 @@ func cerebrumDeviceValue(_ context.Context, args []string) error {
 	}
 	got, err := obtainSingleDeviceChange(sess, cf.timeout, dc, "VALUE")
 	if err != nil {
-		return err
+		return byNameHint(err, device, byName)
 	}
 	if got == nil || got.Device == nil {
 		fmt.Fprintln(os.Stderr, "(no DEVICE_CHANGE TYPE=VALUE response within timeout)")
@@ -1629,7 +1631,7 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 		if errors.Is(err, context.Canceled) || ctx.Err() != nil {
 			return nil // Ctrl+C during subscribe — clean exit, not an error
 		}
-		return fmt.Errorf("cerebrum-nb watch: subscribe %s: %w", dc.Type, err)
+		return fmt.Errorf("cerebrum-nb watch: subscribe %s: %w", dc.Type, byNameHint(err, device, byName))
 	}
 	fmt.Fprintf(os.Stderr, "watching DEVICE_CHANGE TYPE=%s on %s — Ctrl+C to stop\n", dc.Type, device)
 	<-ctx.Done()
@@ -1743,6 +1745,60 @@ func summarise(items []string) string {
 func displayName(s string) string {
 	if s == "" {
 		return "-"
+	}
+	return quoteIfPadded(s)
+}
+
+// byNameHint adds the one explanation a by-name NACK never carries.
+//
+// The server refuses an unknown DEVICE_NAME with the same code it uses
+// for a bad object path, so the error says "the specified obtain failed
+// to complete" whether the caller got the object wrong or the name
+// wrong by one space. When the name was padded — or when the caller
+// copied a name that WASN'T padded from output that could not show the
+// difference — that is by far the likelier cause, and it is invisible.
+//
+// The hint is appended, never substituted: the wire's own words stay
+// first, because a hint that displaces the real error is worse than no
+// hint at all.
+func byNameHint(err error, device string, byName bool) error {
+	var nack *codec.NackError
+	if err == nil || !byName || !errors.As(err, &nack) {
+		return err
+	}
+	// Only the two codes that mean "I did not recognise what you
+	// addressed". A licence failure or a not-logged-in has nothing to
+	// do with the name, and a hint there is just noise.
+	if nack.ID != codec.NackOneOrMoreObtainsInvalid && nack.ID != codec.NackOneOrMoreEventsInvalid {
+		return err
+	}
+	if device != strings.TrimSpace(device) {
+		return fmt.Errorf("%w\n  hint: --device %q is padded; DEVICE_NAME matches byte-for-byte, so try %q, or address the device by IP",
+			err, device, strings.TrimSpace(device))
+	}
+	return fmt.Errorf("%w\n  hint: DEVICE_NAME matches byte-for-byte and some Cerebrum names carry trailing whitespace that terminals cannot show — re-check the name in `device-details` (padded names are printed quoted), or address the device by IP",
+		err)
+}
+
+// quoteIfPadded renders a DEVICE_NAME so that leading or trailing
+// whitespace is VISIBLE.
+//
+// --by-name matches the name byte-for-byte, padding included, and
+// Cerebrum pads some names and not others. Printed bare, the two are
+// indistinguishable, so the operator copies what they see, the obtain
+// NACKs 10, and nothing in the error points at a space. That cost a
+// live session an hour on 2026-08-25: every by-name call against
+// "Cerebrum NMOS NOC" failed while the identical call by IP worked,
+// and the difference was one trailing character the terminal could
+// not show.
+//
+// Only padded names are quoted. Quoting every name would add noise to
+// the common case and, worse, teach the reader that the quotes are
+// decoration — the point is that a quoted name means "this string has
+// edges you cannot see".
+func quoteIfPadded(s string) string {
+	if s != strings.TrimSpace(s) {
+		return strconv.Quote(s)
 	}
 	return s
 }

--- a/cmd/dhs/cmd_cerebrum_test.go
+++ b/cmd/dhs/cmd_cerebrum_test.go
@@ -338,3 +338,81 @@ func TestRouteTargetFromFlags(t *testing.T) {
 		t.Fatalf("router IP target = %+v", byIP)
 	}
 }
+
+// TestNamePaddingIsVisible pins the fix for a live-session trap.
+//
+// --by-name matches DEVICE_NAME byte-for-byte and Cerebrum pads some
+// names and not others. Printed bare, "NOC" and "NOC " look identical,
+// so an operator copies what the terminal showed, the obtain NACKs 10,
+// and the error blames the obtain. On 2026-08-25 that cost an hour:
+// every by-name call against the NMOS NOC device failed while the same
+// call by IP succeeded, and the whole difference was one trailing
+// space.
+func TestNamePaddingIsVisible(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"trailing space is shown", "Cerebrum NMOS NOC ", `"Cerebrum NMOS NOC "`},
+		{"leading space is shown", " CONVERT", `" CONVERT"`},
+		{"tab is shown", "CONVERT\t", `"CONVERT\t"`},
+		// An unpadded name stays bare. Quoting every name would make
+		// the quotes decoration; the point is that quotes MEAN
+		// "this string has edges you cannot see".
+		{"unpadded stays bare", "Cerebrum NMOS NOC", "Cerebrum NMOS NOC"},
+		{"inner spaces are not padding", "bm-n-nncvt-001", "bm-n-nncvt-001"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := quoteIfPadded(tc.in); got != tc.want {
+				t.Errorf("quoteIfPadded(%q) = %s, want %s", tc.in, got, tc.want)
+			}
+		})
+	}
+	// displayName keeps its empty-string dash and gains the same
+	// visibility for padded values.
+	if got := displayName(""); got != "-" {
+		t.Errorf(`displayName("") = %q, want "-"`, got)
+	}
+	if got := displayName("NOC "); got != `"NOC "` {
+		t.Errorf(`displayName("NOC ") = %s, want quoted`, got)
+	}
+}
+
+// TestByNameHintNamesTheSuspect: the server refuses an unknown
+// DEVICE_NAME with the same code it uses for a bad object path, so the
+// hint is the only thing that points at whitespace.
+func TestByNameHintNamesTheSuspect(t *testing.T) {
+	nack := &codec.NackError{ID: codec.NackOneOrMoreObtainsInvalid}
+
+	// Padded name: say so, and say what to try.
+	got := byNameHint(nack, "Cerebrum NMOS NOC ", true)
+	if !strings.Contains(got.Error(), "padded") || !strings.Contains(got.Error(), `"Cerebrum NMOS NOC"`) {
+		t.Errorf("padded-name hint should name the trimmed form, got %q", got)
+	}
+	// The wire's own words must survive - a hint that displaces the
+	// real error is worse than no hint.
+	if !strings.Contains(got.Error(), "nack") {
+		t.Errorf("hint replaced the underlying error: %q", got)
+	}
+
+	// Unpadded name: still hint, because the name the operator copied
+	// may have been padded at the source.
+	got = byNameHint(nack, "Cerebrum NMOS NOC", true)
+	if !strings.Contains(got.Error(), "byte-for-byte") {
+		t.Errorf("unpadded by-name hint missing: %q", got)
+	}
+
+	// By IP: the name is not in play, so no hint.
+	if got := byNameHint(nack, "10.44.55.56", false); got != error(nack) {
+		t.Errorf("by-IP should pass the error through unchanged, got %q", got)
+	}
+	// A different NACK is not a naming problem.
+	other := &codec.NackError{ID: codec.NackNoLicenceAvailable}
+	if got := byNameHint(other, "NOC ", true); got != error(other) {
+		t.Errorf("unrelated NACK should pass through unchanged, got %q", got)
+	}
+	if byNameHint(nil, "NOC ", true) != nil {
+		t.Error("nil error must stay nil")
+	}
+}


### PR DESCRIPTION
## What

`device-details` / `list-devices` print a padded DEVICE_NAME **quoted**, and a by-name NACK 9/10 appends a hint naming whitespace as the likely cause.

## Why

`--by-name` matches DEVICE_NAME byte-for-byte and Cerebrum pads some names and not others. Printed bare, `Cerebrum NMOS NOC` and `Cerebrum NMOS NOC ` are the same three words, so an operator copies what the terminal showed and the obtain NACKs 10 — a code that also means "bad object path", with an error text mentioning only the obtain.

That cost a live session an hour on 2026-08-25. Every by-name call against the NMOS NOC device failed while the identical call by IP returned the value; we chased path spelling, group-vs-leaf granularity and sub-device resolution before the difference turned out to be one trailing character no terminal could show.

Closes #

## Scope

- [x] osc / tsl / cerebrum-nb / amwa
- [x] cli

## Wire evidence (protocol changes only)

No wire change — rendering and error text only. The wire behaviour it explains, live 2026-08-25 against 10.44.55.39:40009:

```text
# by name, padded (what device-details appeared to show):
--device "Cerebrum NMOS NOC " --by-name  ->  nack 10:ONE_OR_MORE_OBTAINS_INVALID
# by name, unpadded:
--device "Cerebrum NMOS NOC"  --by-name  ->  value="1" type=INTEGER
# by IP (always worked):
--device 10.44.55.56                     ->  value="1" type=INTEGER
```

## Reference controller

- [x] N/A (no protocol behaviour change)

## Type

- [x] fix — bug fix

## Files changed

| File | New / Modified | Description |
|------|---------------|-------------|
| `cmd/dhs/cmd_cerebrum.go` | modified | `quoteIfPadded` + `byNameHint`; wired into `device-details`, `list-devices`, `device-value`, `watch` |
| `cmd/dhs/cmd_cerebrum_test.go` | modified | padding visibility + hint scoping tests |

## Test results

| Suite | Passed | Failed |
|-------|--------|--------|
| `go test ./...` | all | 0 |
| `go vet ./...` | clean | — |
| `golangci-lint run` | clean | — |

## Device tested

- [x] Real device — Cerebrum NOC 10.44.55.39:40009 (production northbound)

**Live command + observed output** (verbatim):

```text
.\dhs.exe consumer cerebrum-nb device-value 10.44.55.39:40009 --user YOB --pass *** \
  --device "Cerebrum NMOS NOC" --by-name --sub-device 0 \
  --object "Nodes.[024e03ce-ff8b-57b4-bd69-89097483e4ef].Connected"
device      10.44.55.56 (Cerebrum NMOS NOC)
sub_device  0
object      Nodes.[024e03ce-ff8b-57b4-bd69-89097483e4ef].Connected
  Nodes.[024e03ce-ff8b-57b4-bd69-89097483e4ef].Connected available=1 value="1" type=INTEGER rw=10
```

## Checklist

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] No new external dependencies
- [x] Integration tested on real Cerebrum before PR

## Approval

@yboujraf — requesting review