### PR TITLE
feat(cerebrum-nb): watch reports changes, takes an object list, and renders in the Tree/DM layout

### DIFF
--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -307,7 +307,7 @@ VERBS
   extract                  ADR-0022 card data model — device walk → .cache/dm/cerebrum-nb/<Model@SwRev>.json + .cache/manifest/<device>.json. Root auto-DISCOVERED (probe ladder; no --path needed) and identity auto-probed from the device tree (acp2's objects over NB: IDENTITY.Card Name + IDENTITY.Product Version / BOARD.Hardware Version): --device NAME --by-name --sub-device N [--path "GROUP[;GROUP…]" = manual scope] [--product X] [--version V] [--max-requests N]
   validate                 OFFLINE — decode a --capture frames.jsonl through the codec (counts, NACKs, case deviations); --out-tree = observed DEVICE objects as a canonical tree  [--out-params FILE] [--stop-at NOTE]
   keepalive-probe          DIAGNOSTIC — hold WS open, observe TCP keep-alives  [--idle DUR] [--send-login]
-  watch                    SUBSCRIBE one device (§5.4): --device IP [--device-type T] = DETAILS state watch; --device NAME --by-name --sub-device S --object O = VALUE watch. --object takes ONE path, a ';'-separated LIST, "GROUP.*" = GROUP's direct children, or "GROUP.**" = every leaf beneath it (descends into child groups). A group SUBSCRIBE only lists its children — change events come from leaf rows — so ".*"/".**" are expanded client-side by obtains; the wire itself refuses wildcards. VALUE rows render in the Tree/DM columns like dhs watch; --raw keeps the per-frame wire view
+  watch                    SUBSCRIBE one device (§5.4): --device IP [--device-type T] = DETAILS state watch; --device NAME --by-name --sub-device S --object O = VALUE watch. --object takes ONE path, a ';'-separated LIST, "GROUP.*" = GROUP's direct children, or "GROUP.**" = every leaf beneath it (descends into child groups; use on ONE node, not on Nodes). --only "SubID,Connected" narrows an expansion to named leaves. A group SUBSCRIBE only lists its children — change events come from leaf rows — so ".*"/".**" are expanded client-side by obtains; the wire itself refuses wildcards. VALUE rows render in the Tree/DM columns like dhs watch; --raw keeps the per-frame wire view
 
   Write verbs (§4 ACTION — auto-LOGIN with --user/--pass; require an authenticated session)
   -----------------------  -----------------------------------------------
@@ -1598,6 +1598,13 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	// --only narrows an expansion to named leaves. Without it,
+	// "Nodes.*" on a live NOC is 68 nodes x ~16 fields and the three
+	// values anyone actually watches are lost in it.
+	only, rest, err := extractStringFlag(rest, "--only")
+	if err != nil {
+		return err
+	}
 	if device == "" {
 		return cerebrumValErr("watch", "--device IP|NAME is required")
 	}
@@ -1651,6 +1658,9 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 	if subDev != "" {
 		objects, err = cerebrumWatchObjects(sess, cf.timeout, device, byName, subDev, object)
 		if err != nil {
+			return err
+		}
+		if objects, err = keepOnly(objects, only); err != nil {
 			return err
 		}
 	}
@@ -1760,6 +1770,45 @@ func cerebrumWatchObjects(sess *cerebrum.Session, timeout time.Duration, device 
 	}
 	if len(out) == 0 {
 		return nil, cerebrumValErr("watch", "--object resolved to nothing")
+	}
+	return out, nil
+}
+
+// keepOnly narrows an expanded object list to the named LEAVES.
+//
+// An expansion answers "which objects are under here"; --only answers
+// "which of them do I care about". They compose: "Nodes.*" with
+// --only "SubID,Connected" is 68 rows of the two fields that matter
+// instead of 1,088 rows containing them.
+//
+// Matching is on the last path segment and case-insensitive, because
+// the name in the operator's head is "subid", not the exact casing of
+// a path they never typed.
+func keepOnly(objects []string, only string) ([]string, error) {
+	if strings.TrimSpace(only) == "" {
+		return objects, nil
+	}
+	want := map[string]bool{}
+	for _, w := range strings.Split(only, ",") {
+		if w = strings.TrimSpace(w); w != "" {
+			want[strings.ToLower(w)] = true
+		}
+	}
+	if len(want) == 0 {
+		return objects, nil
+	}
+	var out []string
+	for _, o := range objects {
+		leaf := o
+		if i := strings.LastIndex(o, "."); i >= 0 {
+			leaf = o[i+1:]
+		}
+		if want[strings.ToLower(leaf)] {
+			out = append(out, o)
+		}
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("cerebrum-nb watch: --only %q matched none of the %d expanded object(s)", only, len(objects))
 	}
 	return out, nil
 }

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -1659,6 +1659,13 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 	// layout — the same columns `dhs watch` gives acp1/acp2. DETAILS is
 	// connection state, a different shape, and keeps its own form.
 	dmView := subDev != "" && !rawView
+	// The header is emitted by the first row, not after subscribing:
+	// a subscription answers with the object's CURRENT value, so rows
+	// start arriving while Subscribe is still returning and a header
+	// printed afterwards lands below its own table. Deferring it to
+	// first use also means a watch that subscribes nothing prints no
+	// header for an empty table.
+	var header sync.Once
 	sess.OnEvent(codec.KindUnknown, func(f *codec.Frame) {
 		switch {
 		case f.Kind == codec.KindWildcardComplete && f.Root != nil && f.Root.Attr("mtid") == "":
@@ -1667,6 +1674,10 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 			return // transaction plumbing, not an event
 		}
 		if dmView && f.Kind == codec.KindDeviceChange && f.Device != nil {
+			if len(f.Device.ObjectValues) == 0 {
+				return
+			}
+			header.Do(cerebrumDMHeader)
 			now := time.Now()
 			for _, ov := range f.Device.ObjectValues {
 				cerebrumDMRow(now, ov)
@@ -1701,9 +1712,6 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 		what = fmt.Sprintf("%s on %d object(s)", what, okRows)
 	}
 	fmt.Fprintf(os.Stderr, "watching DEVICE_CHANGE %s on %s — Ctrl+C to stop\n", what, device)
-	if dmView {
-		cerebrumDMHeader()
-	}
 	<-ctx.Done()
 	fmt.Fprintln(os.Stderr, "watch stopped.")
 	return nil
@@ -1923,9 +1931,14 @@ func printEventLabeled(f *codec.Frame, srcNames map[string]string) {
 // acp2 against the same card over Cerebrum should be diffing values,
 // not re-learning a layout.
 func cerebrumDMHeader() {
-	fmt.Printf("%-8s  %-52s  %-16s  %-3s  %-7s  value\n",
-		"time", "path", "label", "acc", "type")
-	fmt.Println(strings.Repeat("-", 118))
+	const head = "%-8s  %-52s  %-16s  %-3s  %-7s  value\n"
+	line := fmt.Sprintf(head, "time", "path", "label", "acc", "type")
+	fmt.Print(line)
+	// The rule spans the HEADER, not an arbitrary width: a fixed 118
+	// on a 101-character header draws a line past the last column,
+	// which is exactly the kind of detail that makes output look
+	// unconsidered.
+	fmt.Println(strings.Repeat("-", len(strings.TrimRight(line, "\n"))))
 }
 
 // cerebrumDMRow renders one object value in that layout.

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -307,7 +307,7 @@ VERBS
   extract                  ADR-0022 card data model — device walk → .cache/dm/cerebrum-nb/<Model@SwRev>.json + .cache/manifest/<device>.json. Root auto-DISCOVERED (probe ladder; no --path needed) and identity auto-probed from the device tree (acp2's objects over NB: IDENTITY.Card Name + IDENTITY.Product Version / BOARD.Hardware Version): --device NAME --by-name --sub-device N [--path "GROUP[;GROUP…]" = manual scope] [--product X] [--version V] [--max-requests N]
   validate                 OFFLINE — decode a --capture frames.jsonl through the codec (counts, NACKs, case deviations); --out-tree = observed DEVICE objects as a canonical tree  [--out-params FILE] [--stop-at NOTE]
   keepalive-probe          DIAGNOSTIC — hold WS open, observe TCP keep-alives  [--idle DUR] [--send-login]
-  watch                    SUBSCRIBE one device (§5.4): --device IP [--device-type T] = DETAILS state watch; --device NAME --by-name --sub-device S --object O = VALUE watch. --object takes ONE path, a ';'-separated LIST, or "GROUP.*" = every leaf under GROUP (a group subscribe only LISTS its children; change events come from leaf rows). Paths must be known — the wire refuses wildcards, so ".*" is expanded client-side by one obtain
+  watch                    SUBSCRIBE one device (§5.4): --device IP [--device-type T] = DETAILS state watch; --device NAME --by-name --sub-device S --object O = VALUE watch. --object takes ONE path, a ';'-separated LIST, "GROUP.*" = GROUP's direct children, or "GROUP.**" = every leaf beneath it (descends into child groups). A group SUBSCRIBE only lists its children — change events come from leaf rows — so ".*"/".**" are expanded client-side by obtains; the wire itself refuses wildcards. VALUE rows render in the Tree/DM columns like dhs watch; --raw keeps the per-frame wire view
 
   Write verbs (§4 ACTION — auto-LOGIN with --user/--pass; require an authenticated session)
   -----------------------  -----------------------------------------------
@@ -1739,17 +1739,22 @@ func cerebrumWatchObjects(sess *cerebrum.Session, timeout time.Duration, device 
 		if part == "" {
 			continue
 		}
-		group, expand := strings.CutSuffix(part, ".*")
+		// Deep before shallow: "a.**" also ends in ".*".
+		group, deep := strings.CutSuffix(part, ".**")
+		expand := deep
+		if !deep {
+			group, expand = strings.CutSuffix(part, ".*")
+		}
 		if !expand {
 			out = append(out, part)
 			continue
 		}
-		leaves, err := cerebrumGroupLeaves(sess, timeout, device, byName, subDev, group)
+		leaves, err := cerebrumExpand(sess, timeout, device, byName, subDev, group, deep)
 		if err != nil {
 			return nil, fmt.Errorf("cerebrum-nb watch: expanding %q: %w", part, byNameHint(err, device, byName))
 		}
 		if len(leaves) == 0 {
-			return nil, fmt.Errorf("cerebrum-nb watch: %q expanded to no leaf objects — a group obtain lists child GROUPS as available=0; expand one level deeper, e.g. %q", part, group+".<child>.*")
+			return nil, fmt.Errorf("cerebrum-nb watch: %q expanded to nothing — check the group path against the device's Object Browser", part)
 		}
 		out = append(out, leaves...)
 	}
@@ -1759,14 +1764,8 @@ func cerebrumWatchObjects(sess *cerebrum.Session, timeout time.Duration, device 
 	return out, nil
 }
 
-// cerebrumGroupLeaves obtains one group and returns the paths of the
-// rows that carry a value.
-//
-// A §5.4.3 group obtain answers with BOTH kinds of row: child groups
-// come back available=0 with an empty value, leaves come back
-// available=1 with theirs. Only leaves can be subscribed, so the
-// available flag is the filter.
-func cerebrumGroupLeaves(sess *cerebrum.Session, timeout time.Duration, device string, byName bool, subDev, group string) ([]string, error) {
+// cerebrumChildren obtains one group and returns its child rows.
+func cerebrumChildren(sess *cerebrum.Session, timeout time.Duration, device string, byName bool, subDev, group string) ([]codec.DeviceObjectValue, error) {
 	dc := &codec.DeviceChange{Type: "VALUE", SubDevice: subDev, Object: group}
 	if group == "" {
 		dc.ExplicitEmptyObject = true
@@ -1783,13 +1782,78 @@ func cerebrumGroupLeaves(sess *cerebrum.Session, timeout time.Duration, device s
 	if got == nil || got.Device == nil {
 		return nil, fmt.Errorf("no response within timeout")
 	}
-	var leaves []string
-	for _, ov := range got.Device.ObjectValues {
-		if ov.Available {
-			leaves = append(leaves, ov.Object)
+	return got.Device.ObjectValues, nil
+}
+
+// maxExpandDepth bounds "**". The deepest live NB tree seen is a node's
+// Interfaces/Devices at two levels; the cap is a guard against a cyclic
+// or pathological tree, not a real limit.
+const maxExpandDepth = 8
+
+// cerebrumExpand turns a group into the object list to subscribe.
+//
+// Shallow ("GROUP.*") takes the group's direct children. Deep
+// ("GROUP.**") descends into the children that are themselves groups.
+//
+// The subtlety is telling a group from a leaf. `available` does NOT do
+// it: a child group comes back available=0, but so does a leaf with no
+// current value — on a live NOC node `Last_Error` is exactly that, and
+// filtering on available dropped it, which is precisely the object
+// that says WHY a node is disconnected. So every child is subscribed
+// regardless, and for a deep expansion the available=0 rows are PROBED:
+// a group answers with rows for OTHER paths, a valueless leaf does
+// not. One obtain per candidate, and only for candidates.
+func cerebrumExpand(sess *cerebrum.Session, timeout time.Duration, device string, byName bool, subDev, group string, deep bool) ([]string, error) {
+	var out []string
+	seen := map[string]bool{}
+
+	var walk func(g string, depth int) error
+	walk = func(g string, depth int) error {
+		kids, err := cerebrumChildren(sess, timeout, device, byName, subDev, g)
+		if err != nil {
+			return err
+		}
+		for _, ov := range kids {
+			if ov.Object == "" || ov.Object == g || seen[ov.Object] {
+				continue
+			}
+			// A row that already carries a value is a leaf; no probe
+			// can tell us anything more about it.
+			if !deep || ov.Available || depth >= maxExpandDepth {
+				seen[ov.Object] = true
+				out = append(out, ov.Object)
+				continue
+			}
+			// Candidate group. Ask it for children; anything that
+			// answers with OTHER paths is a group and is descended
+			// into, anything else is a valueless leaf and is kept.
+			sub, err := cerebrumChildren(sess, timeout, device, byName, subDev, ov.Object)
+			if err != nil || !hasOtherPaths(sub, ov.Object) {
+				seen[ov.Object] = true
+				out = append(out, ov.Object)
+				continue
+			}
+			if err := walk(ov.Object, depth+1); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if err := walk(group, 0); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// hasOtherPaths reports whether an obtain answered with rows for paths
+// other than the one asked for — the signature of a group.
+func hasOtherPaths(rows []codec.DeviceObjectValue, self string) bool {
+	for _, ov := range rows {
+		if ov.Object != "" && ov.Object != self {
+			return true
 		}
 	}
-	return leaves, nil
+	return false
 }
 
 // cerebrumSubscribeRows registers every row, batching first and

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -307,7 +307,7 @@ VERBS
   extract                  ADR-0022 card data model — device walk → .cache/dm/cerebrum-nb/<Model@SwRev>.json + .cache/manifest/<device>.json. Root auto-DISCOVERED (probe ladder; no --path needed) and identity auto-probed from the device tree (acp2's objects over NB: IDENTITY.Card Name + IDENTITY.Product Version / BOARD.Hardware Version): --device NAME --by-name --sub-device N [--path "GROUP[;GROUP…]" = manual scope] [--product X] [--version V] [--max-requests N]
   validate                 OFFLINE — decode a --capture frames.jsonl through the codec (counts, NACKs, case deviations); --out-tree = observed DEVICE objects as a canonical tree  [--out-params FILE] [--stop-at NOTE]
   keepalive-probe          DIAGNOSTIC — hold WS open, observe TCP keep-alives  [--idle DUR] [--send-login]
-  watch                    SUBSCRIBE one device (§5.4): --device IP [--device-type T] = DETAILS state watch; --device NAME --by-name --sub-device S --object O = VALUE watch. --object takes ONE path, a ';'-separated LIST, "GROUP.*" = GROUP's direct children, or "GROUP.**" = every leaf beneath it (descends into child groups; use on ONE node, not on Nodes). --only "SubID,Connected" narrows an expansion to named leaves. A group SUBSCRIBE only lists its children — change events come from leaf rows — so ".*"/".**" are expanded client-side by obtains; the wire itself refuses wildcards. VALUE rows render in the Tree/DM columns like dhs watch; --raw keeps the per-frame wire view
+  watch                    SUBSCRIBE one device (§5.4): --device IP [--device-type T] = DETAILS state watch; --device NAME --by-name --sub-device S --object O = VALUE watch. --object takes ONE path, a ';'-separated LIST, "GROUP.*" = GROUP's direct children, or "GROUP.**" = every leaf beneath it (descends into child groups; use on ONE node, not on Nodes). --only "SubID,Connected" narrows an expansion to named leaves. A group SUBSCRIBE only lists its children — change events come from leaf rows — so ".*"/".**" are expanded client-side by obtains; the wire itself refuses wildcards. VALUE rows render in the Tree/DM columns like dhs watch. Reports CHANGES only - a SUBSCRIBE answers with the current value and the server re-asserts unchanged ones, so both are suppressed; --initial prints the baseline, export produces a snapshot. --raw keeps the per-frame wire view
 
   Write verbs (§4 ACTION — auto-LOGIN with --user/--pass; require an authenticated session)
   -----------------------  -----------------------------------------------
@@ -1605,6 +1605,13 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	// --initial prints the value every subscription answers with.
+	// Off by default: a watch reports CHANGES. Use export for a
+	// snapshot — it walks the tree and writes a file.
+	showInitial, rest, err := extractBoolFlag(rest, "--initial")
+	if err != nil {
+		return err
+	}
 	if device == "" {
 		return cerebrumValErr("watch", "--device IP|NAME is required")
 	}
@@ -1676,6 +1683,36 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 	// first use also means a watch that subscribes nothing prints no
 	// header for an empty table.
 	var header sync.Once
+	// A watch reports CHANGES.
+	//
+	// A Cerebrum SUBSCRIBE answers with the object's CURRENT value, so
+	// every subscription emits one row before anything has happened.
+	// On a single object that reads as a useful baseline; across an
+	// expanded list it is a full state dump — subscribing 68 nodes
+	// printed 1,088 rows of unchanged data and buried the events the
+	// watch existed to show. Worse, the server RE-ASSERTS values that
+	// have not changed, so even a settled tree keeps printing.
+	//
+	// So: remember the last value per object and print only when it
+	// differs. --initial prints the baseline; export is what produces
+	// a snapshot.
+	seenValue := map[string]string{}
+	var seenMu sync.Mutex
+	changed := func(ov codec.DeviceObjectValue) bool {
+		v := ov.Value
+		if !ov.Available {
+			v = "\x00unavailable"
+		}
+		seenMu.Lock()
+		defer seenMu.Unlock()
+		prev, known := seenValue[ov.Object]
+		seenValue[ov.Object] = v
+		if !known {
+			return showInitial
+		}
+		return prev != v
+	}
+
 	sess.OnEvent(codec.KindUnknown, func(f *codec.Frame) {
 		switch {
 		case f.Kind == codec.KindWildcardComplete && f.Root != nil && f.Root.Attr("mtid") == "":
@@ -1684,12 +1721,12 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 			return // transaction plumbing, not an event
 		}
 		if dmView && f.Kind == codec.KindDeviceChange && f.Device != nil {
-			if len(f.Device.ObjectValues) == 0 {
-				return
-			}
-			header.Do(cerebrumDMHeader)
 			now := time.Now()
 			for _, ov := range f.Device.ObjectValues {
+				if !changed(ov) {
+					continue
+				}
+				header.Do(cerebrumDMHeader)
 				cerebrumDMRow(now, ov)
 			}
 			return
@@ -1839,6 +1876,17 @@ func cerebrumChildren(sess *cerebrum.Session, timeout time.Duration, device stri
 // or pathological tree, not a real limit.
 const maxExpandDepth = 8
 
+// maxExpandObjects bounds what one expansion may subscribe.
+//
+// A deep walk probes every child, so "Nodes.**" on a live NOC is 68
+// nodes x ~16 fields, then into Interfaces and Devices, then into each
+// device's Senders/Receivers/Sources — tens of thousands of obtains
+// against a production control system, from one careless command.
+//
+// The cap refuses rather than truncating: a silently-shortened watch
+// is a watch that misses the event you were waiting for.
+const maxExpandObjects = 2000
+
 // cerebrumExpand turns a group into the object list to subscribe.
 //
 // Shallow ("GROUP.*") takes the group's direct children. Deep
@@ -1858,6 +1906,9 @@ func cerebrumExpand(sess *cerebrum.Session, timeout time.Duration, device string
 
 	var walk func(g string, depth int) error
 	walk = func(g string, depth int) error {
+		if len(out) > maxExpandObjects {
+			return fmt.Errorf("expansion exceeded %d objects at %q — narrow the path (one node rather than Nodes) or use .* instead of .**", maxExpandObjects, g)
+		}
 		kids, err := cerebrumChildren(sess, timeout, device, byName, subDev, g)
 		if err != nil {
 			return err
@@ -1866,12 +1917,27 @@ func cerebrumExpand(sess *cerebrum.Session, timeout time.Duration, device string
 			if ov.Object == "" || ov.Object == g || seen[ov.Object] {
 				continue
 			}
-			// A row that already carries a value is a leaf; no probe
-			// can tell us anything more about it.
-			if !deep || ov.Available || depth >= maxExpandDepth {
+			if !deep || depth >= maxExpandDepth {
 				seen[ov.Object] = true
 				out = append(out, ov.Object)
 				continue
+			}
+			// Every child is probed on a deep walk, including the ones
+			// that already carry a value.
+			//
+			// Carrying a value does NOT mean being a leaf here.
+			// Interfaces answers with "en8,en12" AND has [en8]/[en12]
+			// beneath it, each holding Chassis_ID and Port_ID; Devices
+			// does the same with its UUID list. Skipping value-carrying
+			// rows stopped the descent exactly at the two nodes worth
+			// descending into.
+			//
+			// A value-carrying group is kept as well as descended into
+			// — the summary string is real data, not a placeholder for
+			// the children.
+			if ov.Available {
+				seen[ov.Object] = true
+				out = append(out, ov.Object)
 			}
 			// Candidate group. Ask it for children; anything that
 			// answers with OTHER paths is a group and is descended

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -307,7 +307,7 @@ VERBS
   extract                  ADR-0022 card data model — device walk → .cache/dm/cerebrum-nb/<Model@SwRev>.json + .cache/manifest/<device>.json. Root auto-DISCOVERED (probe ladder; no --path needed) and identity auto-probed from the device tree (acp2's objects over NB: IDENTITY.Card Name + IDENTITY.Product Version / BOARD.Hardware Version): --device NAME --by-name --sub-device N [--path "GROUP[;GROUP…]" = manual scope] [--product X] [--version V] [--max-requests N]
   validate                 OFFLINE — decode a --capture frames.jsonl through the codec (counts, NACKs, case deviations); --out-tree = observed DEVICE objects as a canonical tree  [--out-params FILE] [--stop-at NOTE]
   keepalive-probe          DIAGNOSTIC — hold WS open, observe TCP keep-alives  [--idle DUR] [--send-login]
-  watch                    SUBSCRIBE one device (§5.4): --device IP [--device-type T] = DETAILS state watch; --device NAME --by-name --sub-device S --object O = VALUE watch. --object takes ONE path, a ';'-separated LIST, "GROUP.*" = GROUP's direct children, or "GROUP.**" = every leaf beneath it (descends into child groups; use on ONE node, not on Nodes). --only "SubID,Connected" narrows an expansion to named leaves. A group SUBSCRIBE only lists its children — change events come from leaf rows — so ".*"/".**" are expanded client-side by obtains; the wire itself refuses wildcards. VALUE rows render in the Tree/DM columns like dhs watch. Reports CHANGES only - a SUBSCRIBE answers with the current value and the server re-asserts unchanged ones, so both are suppressed; --initial prints the baseline, export produces a snapshot. --raw keeps the per-frame wire view
+  watch                    SUBSCRIBE one device (§5.4): --device IP [--device-type T] = DETAILS state watch; --device NAME --by-name --sub-device S --object O = VALUE watch. --object takes ONE path, a ';'-separated LIST, "GROUP.*" = GROUP's direct children, or "GROUP.**" = every leaf beneath it (descends into child groups; use on ONE node, not on Nodes). --label "SubID,Connected" reports only those objects (same filter name the generic watch uses). A group SUBSCRIBE only lists its children — change events come from leaf rows — so ".*"/".**" are expanded client-side by obtains; the wire itself refuses wildcards. VALUE rows render in the Tree/DM columns like dhs watch. Reports CHANGES only - a SUBSCRIBE answers with the current value and the server re-asserts unchanged ones, so both are suppressed; --initial prints the baseline, export produces a snapshot. --raw keeps the per-frame wire view
 
   Write verbs (§4 ACTION — auto-LOGIN with --user/--pass; require an authenticated session)
   -----------------------  -----------------------------------------------
@@ -1598,10 +1598,22 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	// --only narrows an expansion to named leaves. Without it,
-	// "Nodes.*" on a live NOC is 68 nodes x ~16 fields and the three
-	// values anyone actually watches are lost in it.
-	only, rest, err := extractStringFlag(rest, "--only")
+	// --label narrows a watch to named objects. Without it, "Nodes.*"
+	// on a live NOC reports every field of all 68 nodes and the one
+	// value anyone is waiting on is lost in it.
+	//
+	// The name is not chosen here: --label is what the GENERIC watch
+	// calls this filter, next to --group / --id / --path / --slot, and
+	// that verb is shared by acp1, acp2, emberplus, probel, tsl and
+	// osc. cerebrum-nb inventing its own word for the same idea is the
+	// same class of drift as it having its own output format was.
+	//
+	// It differs in one way, deliberately: this takes a comma list
+	// where the generic one takes a single label. A list is a superset
+	// — one name still works — and the generic flag should grow the
+	// same, which is a change across every plugin's matcher rather
+	// than a rename.
+	only, rest, err := extractStringFlag(rest, "--label")
 	if err != nil {
 		return err
 	}

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -1612,6 +1612,7 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	onlyLeaves := parseOnly(only)
 	if device == "" {
 		return cerebrumValErr("watch", "--device IP|NAME is required")
 	}
@@ -1720,6 +1721,15 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 		if dmView && f.Kind == codec.KindDeviceChange && f.Device != nil {
 			now := time.Now()
 			for _, ov := range f.Device.ObjectValues {
+				// --only filters what is PRINTED as well as what is
+				// subscribed. It has to: a group subscription is
+				// indivisible — "Nodes.*" registers 68 node groups and
+				// each one reports every field of its node — so the
+				// subscription list cannot express "SubID only", and
+				// filtering the rows is the only place that can.
+				if !wantLeaf(onlyLeaves, ov.Object) {
+					continue
+				}
 				if !changed(ov) {
 					continue
 				}

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -2025,18 +2025,76 @@ func cerebrumDMRow(ts time.Time, ov codec.DeviceObjectValue) {
 		}
 	}
 	if !ov.Available {
+		// available=0 means the row carries no value. That is TWO
+		// different things and the flag does not separate them: a child
+		// GROUP, and a leaf whose value is currently absent.
+		//
+		// Live evidence for the only signal that does separate them:
+		// every collection child Cerebrum emits is BRACKETED —
+		// Interfaces.[eno1], Devices.[uuid], Nodes.[uuid] — while
+		// valueless leaves are not: Last_Error on a live node,
+		// Connected/Host/UUID/Versions on a node that never connected.
+		// Calling those "group <children>" told the operator a status
+		// field was a folder.
+		//
+		// It is a naming heuristic, so it only decides the LABEL. When
+		// it is wrong the row still reads as "no value", which is true
+		// either way.
+		kind, val := "no-value", "—"
+		if isBracketed(label) {
+			kind, val = "group", "<children>"
+		}
 		fmt.Printf("%s  %-52s  %-16s  %-3s  %-7s  %s\n",
 			ts.Format("15:04:05"), truncatePath(ov.Object, 52), truncate(label, 16),
-			"---", "group", "<children>")
+			cerebrumAccess(ov), kind, val)
 		return
 	}
 	val := ov.Value
 	if ov.Units != "" {
 		val += " " + ov.Units
 	}
+	if c := cerebrumConstraint(ov); c != "" {
+		val += "  " + c
+	}
 	fmt.Printf("%s  %-52s  %-16s  %-3s  %-7s  %s\n",
 		ts.Format("15:04:05"), truncatePath(ov.Object, 52), truncate(label, 16),
 		cerebrumAccess(ov), strings.ToLower(ov.DataType), val)
+}
+
+// cerebrumConstraint renders what a value is ALLOWED to be — the enum
+// list, or the numeric range.
+//
+// The wire carries these on the same row as the value (§5.4.3
+// MIN/MAX/STEP, ENUM_LIST) and the DM store keeps them, but the watch
+// was throwing them away. They are the difference between reading a
+// device and being able to set it: "Send SDP Always" tells you nothing
+// about what else you could write there.
+//
+// A degenerate MIN==MAX carries no information — live ENUM rows report
+// 0..0, their real constraint being the enum list — so it is dropped,
+// the same rule CanonicalDeviceObject applies when building the DM.
+func cerebrumConstraint(ov codec.DeviceObjectValue) string {
+	if len(ov.EnumList) > 0 {
+		return "{" + strings.Join(ov.EnumList, "|") + "}"
+	}
+	if ov.Min == "" && ov.Max == "" {
+		return ""
+	}
+	if ov.Min == ov.Max {
+		return ""
+	}
+	r := "[" + ov.Min + ".." + ov.Max
+	if ov.Step != "" && ov.Step != "0" {
+		r += " step " + ov.Step
+	}
+	return r + "]"
+}
+
+// isBracketed reports whether a path segment is a Cerebrum collection
+// member — "[eno1]", "[<uuid>]". Members of a collection are bracketed;
+// named fields are not.
+func isBracketed(seg string) bool {
+	return strings.HasPrefix(seg, "[") && strings.HasSuffix(seg, "]")
 }
 
 // cerebrumAccess renders the R/W bits in the same three-character shape

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -307,7 +307,7 @@ VERBS
   extract                  ADR-0022 card data model — device walk → .cache/dm/cerebrum-nb/<Model@SwRev>.json + .cache/manifest/<device>.json. Root auto-DISCOVERED (probe ladder; no --path needed) and identity auto-probed from the device tree (acp2's objects over NB: IDENTITY.Card Name + IDENTITY.Product Version / BOARD.Hardware Version): --device NAME --by-name --sub-device N [--path "GROUP[;GROUP…]" = manual scope] [--product X] [--version V] [--max-requests N]
   validate                 OFFLINE — decode a --capture frames.jsonl through the codec (counts, NACKs, case deviations); --out-tree = observed DEVICE objects as a canonical tree  [--out-params FILE] [--stop-at NOTE]
   keepalive-probe          DIAGNOSTIC — hold WS open, observe TCP keep-alives  [--idle DUR] [--send-login]
-  watch                    SUBSCRIBE one device (§5.4): --device IP [--device-type T] = DETAILS state watch; --device NAME --by-name --sub-device S --object O = VALUE watch (object path must be known — wildcards refused, live-verified)
+  watch                    SUBSCRIBE one device (§5.4): --device IP [--device-type T] = DETAILS state watch; --device NAME --by-name --sub-device S --object O = VALUE watch. --object takes ONE path, a ';'-separated LIST, or "GROUP.*" = every leaf under GROUP (a group subscribe only LISTS its children; change events come from leaf rows). Paths must be known — the wire refuses wildcards, so ".*" is expanded client-side by one obtain
 
   Write verbs (§4 ACTION — auto-LOGIN with --user/--pass; require an authenticated session)
   -----------------------  -----------------------------------------------
@@ -1596,26 +1596,39 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 	}
 	defer func() { _ = p.Disconnect() }()
 
-	dc := &codec.DeviceChange{}
-	if subDev != "" {
-		dc.Type = "VALUE"
-		dc.SubDevice = subDev
-		dc.Object = object
-		if byName {
-			dc.DeviceName = device
+	newRow := func(obj string) *codec.DeviceChange {
+		dc := &codec.DeviceChange{}
+		if subDev != "" {
+			dc.Type = "VALUE"
+			dc.SubDevice = subDev
+			dc.Object = obj
+			if byName {
+				dc.DeviceName = device
+			} else {
+				dc.IPAddress = device
+			}
 		} else {
+			// DETAILS addressing is IP-only (by-name NACKs — spec-conform).
+			dc.Type = "DETAILS"
 			dc.IPAddress = device
+			if deviceType == "" {
+				deviceType = "DEVICE"
+			}
 		}
-	} else {
-		// DETAILS addressing is IP-only (by-name NACKs — spec-conform).
-		dc.Type = "DETAILS"
-		dc.IPAddress = device
-		if deviceType == "" {
-			deviceType = "DEVICE"
+		if deviceType != "" {
+			dc.DeviceType = codec.DeviceType(strings.ToUpper(deviceType))
 		}
+		return dc
 	}
-	if deviceType != "" {
-		dc.DeviceType = codec.DeviceType(strings.ToUpper(deviceType))
+
+	// Resolve the object list BEFORE subscribing, so an expansion that
+	// finds nothing fails loudly instead of quietly watching one row.
+	objects := []string{object}
+	if subDev != "" {
+		objects, err = cerebrumWatchObjects(sess, cf.timeout, device, byName, subDev, object)
+		if err != nil {
+			return err
+		}
 	}
 
 	sess.OnEvent(codec.KindUnknown, func(f *codec.Frame) {
@@ -1627,16 +1640,150 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 		}
 		printEventLabeled(f, nil)
 	})
-	if err := sess.Subscribe(ctx, []codec.SubItem{dc}); err != nil {
-		if errors.Is(err, context.Canceled) || ctx.Err() != nil {
-			return nil // Ctrl+C during subscribe — clean exit, not an error
-		}
-		return fmt.Errorf("cerebrum-nb watch: subscribe %s: %w", dc.Type, byNameHint(err, device, byName))
+
+	// One row per object. NACK 9 is ONE_OR_MORE_EVENTS_INVALID — a
+	// batch fails WHOLESALE if any row is bad, and then names none of
+	// them. So a failed batch is retried row by row: the cost falls on
+	// the run that already has a problem, and the operator learns which
+	// path was refused instead of being told the batch was.
+	rows := make([]codec.SubItem, 0, len(objects))
+	for _, o := range objects {
+		rows = append(rows, newRow(o))
 	}
-	fmt.Fprintf(os.Stderr, "watching DEVICE_CHANGE TYPE=%s on %s — Ctrl+C to stop\n", dc.Type, device)
+	okRows, bad, err := cerebrumSubscribeRows(ctx, sess, rows, objects, device, byName)
+	if err != nil {
+		return err
+	}
+	if okRows == 0 {
+		return fmt.Errorf("cerebrum-nb watch: no object could be subscribed (%d refused)", len(bad))
+	}
+	for _, b := range bad {
+		fmt.Fprintf(os.Stderr, "cerebrum-nb watch: REFUSED %s\n", b)
+	}
+
+	what := "TYPE=" + rows[0].(*codec.DeviceChange).Type
+	if okRows > 1 {
+		what = fmt.Sprintf("%s on %d object(s)", what, okRows)
+	}
+	fmt.Fprintf(os.Stderr, "watching DEVICE_CHANGE %s on %s — Ctrl+C to stop\n", what, device)
 	<-ctx.Done()
 	fmt.Fprintln(os.Stderr, "watch stopped.")
 	return nil
+}
+
+// cerebrumWatchObjects turns the --object argument into the concrete
+// list of paths to subscribe.
+//
+//	"a"          one path, as before
+//	"a;b;c"      an explicit list — same ';' grammar --path already uses
+//	             in export/extract
+//	"GROUP.*"    every LEAF under GROUP, discovered by one obtain
+//
+// The expansion exists because a group SUBSCRIBE does not watch its
+// children. Subscribing to "Nodes" on a live NOC returns the 68 child
+// handles as available=0 rows and then delivers nothing when a child
+// changes (live-verified 2026-08-26) — the listing is the whole
+// response, not a recursive registration. Change events come from leaf
+// rows only, so watching a subtree means enumerating it first and
+// subscribing to each leaf.
+func cerebrumWatchObjects(sess *cerebrum.Session, timeout time.Duration, device string, byName bool, subDev, object string) ([]string, error) {
+	var out []string
+	for _, part := range strings.Split(object, ";") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		group, expand := strings.CutSuffix(part, ".*")
+		if !expand {
+			out = append(out, part)
+			continue
+		}
+		leaves, err := cerebrumGroupLeaves(sess, timeout, device, byName, subDev, group)
+		if err != nil {
+			return nil, fmt.Errorf("cerebrum-nb watch: expanding %q: %w", part, byNameHint(err, device, byName))
+		}
+		if len(leaves) == 0 {
+			return nil, fmt.Errorf("cerebrum-nb watch: %q expanded to no leaf objects — a group obtain lists child GROUPS as available=0; expand one level deeper, e.g. %q", part, group+".<child>.*")
+		}
+		out = append(out, leaves...)
+	}
+	if len(out) == 0 {
+		return nil, cerebrumValErr("watch", "--object resolved to nothing")
+	}
+	return out, nil
+}
+
+// cerebrumGroupLeaves obtains one group and returns the paths of the
+// rows that carry a value.
+//
+// A §5.4.3 group obtain answers with BOTH kinds of row: child groups
+// come back available=0 with an empty value, leaves come back
+// available=1 with theirs. Only leaves can be subscribed, so the
+// available flag is the filter.
+func cerebrumGroupLeaves(sess *cerebrum.Session, timeout time.Duration, device string, byName bool, subDev, group string) ([]string, error) {
+	dc := &codec.DeviceChange{Type: "VALUE", SubDevice: subDev, Object: group}
+	if group == "" {
+		dc.ExplicitEmptyObject = true
+	}
+	if byName {
+		dc.DeviceName = device
+	} else {
+		dc.IPAddress = device
+	}
+	got, err := obtainSingleDeviceChange(sess, timeout, dc, "VALUE")
+	if err != nil {
+		return nil, err
+	}
+	if got == nil || got.Device == nil {
+		return nil, fmt.Errorf("no response within timeout")
+	}
+	var leaves []string
+	for _, ov := range got.Device.ObjectValues {
+		if ov.Available {
+			leaves = append(leaves, ov.Object)
+		}
+	}
+	return leaves, nil
+}
+
+// cerebrumSubscribeRows registers every row, batching first and
+// falling back to one-at-a-time only when the batch is refused.
+//
+// Returns how many rows the server accepted and a description of each
+// one it did not.
+func cerebrumSubscribeRows(ctx context.Context, sess *cerebrum.Session, rows []codec.SubItem, labels []string, device string, byName bool) (int, []string, error) {
+	if len(rows) == 1 {
+		if err := sess.Subscribe(ctx, rows); err != nil {
+			if errors.Is(err, context.Canceled) || ctx.Err() != nil {
+				return 0, nil, nil
+			}
+			return 0, nil, fmt.Errorf("cerebrum-nb watch: subscribe: %w", byNameHint(err, device, byName))
+		}
+		return 1, nil, nil
+	}
+
+	if err := sess.Subscribe(ctx, rows); err == nil {
+		return len(rows), nil, nil
+	} else if errors.Is(err, context.Canceled) || ctx.Err() != nil {
+		return 0, nil, nil
+	}
+
+	// The batch was refused as a whole. Find out which rows the server
+	// actually objects to rather than reporting all of them as bad.
+	fmt.Fprintf(os.Stderr, "cerebrum-nb watch: batch of %d refused — retrying row by row to find the offender(s)\n", len(rows))
+	ok := 0
+	var bad []string
+	for i, row := range rows {
+		if err := sess.Subscribe(ctx, []codec.SubItem{row}); err != nil {
+			if errors.Is(err, context.Canceled) || ctx.Err() != nil {
+				return ok, bad, nil
+			}
+			bad = append(bad, fmt.Sprintf("%s: %v", labels[i], err))
+			continue
+		}
+		ok++
+	}
+	return ok, bad, nil
 }
 
 // printEventLabeled renders one dispatched frame; srcNames (optional) joins

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -1378,6 +1378,21 @@ func extractStringFlag(args []string, name string) (string, []string, error) {
 	return val, rest, nil
 }
 
+// extractBoolFlag is the presence-only sibling of extractStringFlag,
+// for verb-local switches that never take a value.
+func extractBoolFlag(args []string, name string) (bool, []string, error) {
+	rest := make([]string, 0, len(args))
+	found := false
+	for _, a := range args {
+		if a == name {
+			found = true
+			continue
+		}
+		rest = append(rest, a)
+	}
+	return found, rest, nil
+}
+
 // extractDeviceDetailsFlags splits the device-details argv into the
 // verb-specific flags (--device, --by-name) and the remainder consumed
 // by connectAndLogin. We don't extend cerebrumFlags because these
@@ -1574,6 +1589,15 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	// --raw keeps the pre-parity per-frame rendering: every wire
+	// attribute, one block per frame. The table drops frame-level
+	// attrs (name/ip/sub repeat identically on every row of a single
+	// watch), so anything diagnosing the WIRE rather than the DEVICE
+	// still needs the old view.
+	rawView, rest, err := extractBoolFlag(rest, "--raw")
+	if err != nil {
+		return err
+	}
 	if device == "" {
 		return cerebrumValErr("watch", "--device IP|NAME is required")
 	}
@@ -1631,12 +1655,23 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 		}
 	}
 
+	// A VALUE watch is Tree/DM data, so it renders in the Tree/DM
+	// layout — the same columns `dhs watch` gives acp1/acp2. DETAILS is
+	// connection state, a different shape, and keeps its own form.
+	dmView := subDev != "" && !rawView
 	sess.OnEvent(codec.KindUnknown, func(f *codec.Frame) {
 		switch {
 		case f.Kind == codec.KindWildcardComplete && f.Root != nil && f.Root.Attr("mtid") == "":
 			return // spurious §1.6 deviation
 		case f.Kind == codec.KindAck:
 			return // transaction plumbing, not an event
+		}
+		if dmView && f.Kind == codec.KindDeviceChange && f.Device != nil {
+			now := time.Now()
+			for _, ov := range f.Device.ObjectValues {
+				cerebrumDMRow(now, ov)
+			}
+			return
 		}
 		printEventLabeled(f, nil)
 	})
@@ -1666,6 +1701,9 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 		what = fmt.Sprintf("%s on %d object(s)", what, okRows)
 	}
 	fmt.Fprintf(os.Stderr, "watching DEVICE_CHANGE %s on %s — Ctrl+C to stop\n", what, device)
+	if dmView {
+		cerebrumDMHeader()
+	}
 	<-ctx.Done()
 	fmt.Fprintln(os.Stderr, "watch stopped.")
 	return nil
@@ -1874,6 +1912,87 @@ func printEventLabeled(f *codec.Frame, srcNames map[string]string) {
 	default:
 		fmt.Printf("[%s] %s\n", f.Kind, f.Root.String())
 	}
+}
+
+// cerebrumDMHeader prints the Tree/DM watch header — the SAME columns
+// `dhs watch` uses for acp1/acp2, so a device watched over NB reads
+// like the same device watched natively.
+//
+// One grammar everywhere is the whole point of the Tree/DM template
+// (docs/protocols/verbs.md §12b): an operator comparing a CONVERT over
+// acp2 against the same card over Cerebrum should be diffing values,
+// not re-learning a layout.
+func cerebrumDMHeader() {
+	fmt.Printf("%-8s  %-52s  %-16s  %-3s  %-7s  value\n",
+		"time", "path", "label", "acc", "type")
+	fmt.Println(strings.Repeat("-", 118))
+}
+
+// cerebrumDMRow renders one object value in that layout.
+//
+// `label` is the last path segment, which is what the object is called
+// — the full path already occupies its own column, and repeating it
+// is what made the previous two-line form unreadable at 15 objects.
+//
+// A row the device reports available=0 is a CHILD GROUP, not a value:
+// group listings arrive inside a VALUE response and would otherwise
+// render as an object with an empty value, which reads as "this
+// object is empty" rather than "this is a folder".
+func cerebrumDMRow(ts time.Time, ov codec.DeviceObjectValue) {
+	label := ov.Label
+	if label == "" {
+		if i := strings.LastIndex(ov.Object, "."); i >= 0 {
+			label = ov.Object[i+1:]
+		} else {
+			label = ov.Object
+		}
+	}
+	if !ov.Available {
+		fmt.Printf("%s  %-52s  %-16s  %-3s  %-7s  %s\n",
+			ts.Format("15:04:05"), truncatePath(ov.Object, 52), truncate(label, 16),
+			"---", "group", "<children>")
+		return
+	}
+	val := ov.Value
+	if ov.Units != "" {
+		val += " " + ov.Units
+	}
+	fmt.Printf("%s  %-52s  %-16s  %-3s  %-7s  %s\n",
+		ts.Format("15:04:05"), truncatePath(ov.Object, 52), truncate(label, 16),
+		cerebrumAccess(ov), strings.ToLower(ov.DataType), val)
+}
+
+// cerebrumAccess renders the R/W bits in the same three-character shape
+// `dhs watch` prints for acp1/acp2, so the column means one thing
+// across protocols.
+func cerebrumAccess(ov codec.DeviceObjectValue) string {
+	r, w := "-", "-"
+	if ov.Readable {
+		r = "R"
+	}
+	if ov.Writable {
+		w = "W"
+	}
+	return r + w + "-"
+}
+
+// truncatePath shortens from the MIDDLE, keeping both ends.
+//
+// A Cerebrum object path is front-loaded with a group and a bracketed
+// UUID, so head-truncation (what truncate does) leaves 52 characters of
+// identical prefix on every row and hides the one segment that differs.
+// The tail is the object name; the head is the group. Both matter.
+func truncatePath(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	if n < 5 {
+		return s[:n]
+	}
+	keep := n - 1 // room for the ellipsis
+	head := keep / 3
+	tail := keep - head
+	return s[:head] + "…" + s[len(s)-tail:]
 }
 
 // summarise renders the first 3 entries of a list inline; longer lists

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -1663,11 +1663,8 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 	// finds nothing fails loudly instead of quietly watching one row.
 	objects := []string{object}
 	if subDev != "" {
-		objects, err = cerebrumWatchObjects(sess, cf.timeout, device, byName, subDev, object)
+		objects, err = cerebrumWatchObjects(sess, cf.timeout, device, byName, subDev, object, only)
 		if err != nil {
-			return err
-		}
-		if objects, err = keepOnly(objects, only); err != nil {
 			return err
 		}
 	}
@@ -1779,7 +1776,8 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 // response, not a recursive registration. Change events come from leaf
 // rows only, so watching a subtree means enumerating it first and
 // subscribing to each leaf.
-func cerebrumWatchObjects(sess *cerebrum.Session, timeout time.Duration, device string, byName bool, subDev, object string) ([]string, error) {
+func cerebrumWatchObjects(sess *cerebrum.Session, timeout time.Duration, device string, byName bool, subDev, object, only string) ([]string, error) {
+	want := parseOnly(only)
 	var out []string
 	for _, part := range strings.Split(object, ";") {
 		part = strings.TrimSpace(part)
@@ -1796,7 +1794,7 @@ func cerebrumWatchObjects(sess *cerebrum.Session, timeout time.Duration, device 
 			out = append(out, part)
 			continue
 		}
-		leaves, err := cerebrumExpand(sess, timeout, device, byName, subDev, group, deep)
+		leaves, err := cerebrumExpand(sess, timeout, device, byName, subDev, group, deep, want)
 		if err != nil {
 			return nil, fmt.Errorf("cerebrum-nb watch: expanding %q: %w", part, byNameHint(err, device, byName))
 		}
@@ -1821,9 +1819,9 @@ func cerebrumWatchObjects(sess *cerebrum.Session, timeout time.Duration, device 
 // Matching is on the last path segment and case-insensitive, because
 // the name in the operator's head is "subid", not the exact casing of
 // a path they never typed.
-func keepOnly(objects []string, only string) ([]string, error) {
+func parseOnly(only string) map[string]bool {
 	if strings.TrimSpace(only) == "" {
-		return objects, nil
+		return nil
 	}
 	want := map[string]bool{}
 	for _, w := range strings.Split(only, ",") {
@@ -1832,22 +1830,30 @@ func keepOnly(objects []string, only string) ([]string, error) {
 		}
 	}
 	if len(want) == 0 {
-		return objects, nil
+		return nil
 	}
-	var out []string
-	for _, o := range objects {
-		leaf := o
-		if i := strings.LastIndex(o, "."); i >= 0 {
-			leaf = o[i+1:]
-		}
-		if want[strings.ToLower(leaf)] {
-			out = append(out, o)
-		}
+	return want
+}
+
+// wantLeaf reports whether an expanded path should be kept.
+//
+// The filter is applied DURING the walk, not after it. Applied after,
+// "Nodes.** --only SubID" builds the whole tree first and trips the
+// object cap before it ever reaches the filter — which is exactly the
+// combination needed to watch one field across a plant.
+//
+// Matching is on the last path segment and case-insensitive: the name
+// in the operator's head is "subid", not the casing of a path they
+// never typed.
+func wantLeaf(want map[string]bool, path string) bool {
+	if want == nil {
+		return true
 	}
-	if len(out) == 0 {
-		return nil, fmt.Errorf("cerebrum-nb watch: --only %q matched none of the %d expanded object(s)", only, len(objects))
+	leaf := path
+	if i := strings.LastIndex(path, "."); i >= 0 {
+		leaf = path[i+1:]
 	}
-	return out, nil
+	return want[strings.ToLower(leaf)]
 }
 
 // cerebrumChildren obtains one group and returns its child rows.
@@ -1900,7 +1906,7 @@ const maxExpandObjects = 2000
 // regardless, and for a deep expansion the available=0 rows are PROBED:
 // a group answers with rows for OTHER paths, a valueless leaf does
 // not. One obtain per candidate, and only for candidates.
-func cerebrumExpand(sess *cerebrum.Session, timeout time.Duration, device string, byName bool, subDev, group string, deep bool) ([]string, error) {
+func cerebrumExpand(sess *cerebrum.Session, timeout time.Duration, device string, byName bool, subDev, group string, deep bool, want map[string]bool) ([]string, error) {
 	var out []string
 	seen := map[string]bool{}
 

--- a/cmd/dhs/cmd_cerebrum_test.go
+++ b/cmd/dhs/cmd_cerebrum_test.go
@@ -416,3 +416,41 @@ func TestByNameHintNamesTheSuspect(t *testing.T) {
 		t.Error("nil error must stay nil")
 	}
 }
+// TestWatchObjectListGrammar: --object accepts one path, a
+// ';'-separated list (the same grammar --path already uses in
+// export/extract), or "GROUP.*" for every leaf under a group.
+//
+// Only the non-expanding forms are exercised here; ".*" needs a live
+// obtain and is covered by the consumer package's fake-WS tests.
+func TestWatchObjectListGrammar(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"single path", "Nodes.[u].SubID", []string{"Nodes.[u].SubID"}},
+		{"list", "Nodes.[u].SubID;Nodes.[u].Connected", []string{"Nodes.[u].SubID", "Nodes.[u].Connected"}},
+		{"whitespace around separators is ignored", " a ; b ", []string{"a", "b"}},
+		{"empty entries are dropped", "a;;b;", []string{"a", "b"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := cerebrumWatchObjects(nil, 0, "dev", true, "0", tc.in)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("got %v, want %v", got, tc.want)
+					break
+				}
+			}
+		})
+	}
+	// A list of nothing is a usage error, not an empty subscription.
+	if _, err := cerebrumWatchObjects(nil, 0, "dev", true, "0", " ; ; "); err == nil {
+		t.Error("an all-empty --object should be refused")
+	}
+}

--- a/cmd/dhs/cmd_cerebrum_test.go
+++ b/cmd/dhs/cmd_cerebrum_test.go
@@ -530,3 +530,35 @@ func TestTruncatePathKeepsBothEnds(t *testing.T) {
 		t.Errorf("short path was modified: %q", got)
 	}
 }
+// TestExpandKeepsValuelessLeaves pins the bug that dropped Last_Error.
+//
+// A group obtain answers with available=0 for a child GROUP and also
+// for a leaf that has no value right now. Filtering on `available`
+// therefore silently dropped Last_Error - the one object on an NMOS
+// node that says WHY it is disconnected - and made "Nodes.*" expand to
+// nothing at all, because all 68 node children are available=0.
+//
+// So availability is never the group/leaf test: every child is kept,
+// and a deep expansion PROBES the valueless ones instead of guessing.
+func TestHasOtherPathsIsTheGroupTest(t *testing.T) {
+	self := "Nodes.[abc].Interfaces"
+	// A group answers with rows for OTHER paths.
+	group := []codec.DeviceObjectValue{
+		{Object: self + ".[eno1]"},
+		{Object: self + ".[eno2]"},
+	}
+	if !hasOtherPaths(group, self) {
+		t.Error("rows for other paths mean a group")
+	}
+	// A valueless leaf answers with itself, or with nothing.
+	if hasOtherPaths([]codec.DeviceObjectValue{{Object: self}}, self) {
+		t.Error("a row for the path itself is not a child")
+	}
+	if hasOtherPaths(nil, self) {
+		t.Error("no rows is not a group")
+	}
+	// Empty object names are noise, not children.
+	if hasOtherPaths([]codec.DeviceObjectValue{{Object: ""}}, self) {
+		t.Error("an empty object name is not a child")
+	}
+}

--- a/cmd/dhs/cmd_cerebrum_test.go
+++ b/cmd/dhs/cmd_cerebrum_test.go
@@ -437,7 +437,7 @@ func TestWatchObjectListGrammar(t *testing.T) {
 		{"empty entries are dropped", "a;;b;", []string{"a", "b"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := cerebrumWatchObjects(nil, 0, "dev", true, "0", tc.in)
+			got, err := cerebrumWatchObjects(nil, 0, "dev", true, "0", tc.in, "")
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -453,7 +453,7 @@ func TestWatchObjectListGrammar(t *testing.T) {
 		})
 	}
 	// A list of nothing is a usage error, not an empty subscription.
-	if _, err := cerebrumWatchObjects(nil, 0, "dev", true, "0", " ; ; "); err == nil {
+	if _, err := cerebrumWatchObjects(nil, 0, "dev", true, "0", " ; ; ", ""); err == nil {
 		t.Error("an all-empty --object should be refused")
 	}
 }
@@ -604,37 +604,6 @@ func TestConstraintsSurviveToTheWatch(t *testing.T) {
 		t.Errorf("enum should win over range, got %q", got)
 	}
 }
-// TestKeepOnlyNarrowsAnExpansion: an expansion answers "what is under
-// here"; --only answers "which of those do I care about". Without it
-// "Nodes.*" on a live NOC is 68 nodes x ~16 fields and the values
-// anyone actually watches are lost in the flood.
-func TestKeepOnlyNarrowsAnExpansion(t *testing.T) {
-	objs := []string{
-		"Nodes.[a].SubID", "Nodes.[a].Connected", "Nodes.[a].Description",
-		"Nodes.[b].SubID", "Nodes.[b].Connected", "Nodes.[b].Description",
-	}
-	got, err := keepOnly(objs, "SubID,Connected")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(got) != 4 {
-		t.Errorf("want 4 rows, got %d: %v", len(got), got)
-	}
-	// Case-insensitive: the name in the operator's head is "subid",
-	// not the casing of a path they never typed.
-	if got, err := keepOnly(objs, " subid "); err != nil || len(got) != 2 {
-		t.Errorf("case/space-insensitive match failed: %v %v", got, err)
-	}
-	// Empty filter is a no-op, not an empty result.
-	if got, _ := keepOnly(objs, ""); len(got) != len(objs) {
-		t.Errorf("empty --only should pass everything through, got %d", len(got))
-	}
-	// A filter that matches nothing is an error, not a silent empty
-	// watch that never fires.
-	if _, err := keepOnly(objs, "Nope"); err == nil {
-		t.Error("a filter matching nothing must be refused")
-	}
-}
 // TestWatchReportsChangesNotState pins what a watch IS.
 //
 // A Cerebrum SUBSCRIBE answers with the object's CURRENT value, and
@@ -690,5 +659,29 @@ func TestWatchReportsChangesNotState(t *testing.T) {
 	f3(codec.DeviceObjectValue{Object: "x", Value: "up", Available: true})
 	if !f3(codec.DeviceObjectValue{Object: "x"}) {
 		t.Error("a value going unavailable is a change")
+	}
+}
+// TestOnlyIsAppliedDuringTheWalk: the filter has to narrow the
+// expansion as it happens, not afterwards. Applied after,
+// "Nodes.** --only SubID" builds the whole tree first and trips the
+// object cap before it reaches the filter - which is exactly the
+// combination needed to watch one field across a plant.
+func TestOnlyIsAppliedDuringTheWalk(t *testing.T) {
+	want := parseOnly("SubID,Connected")
+	if !wantLeaf(want, "Nodes.[a].SubID") {
+		t.Error("a named leaf should be kept")
+	}
+	if wantLeaf(want, "Nodes.[a].Description") {
+		t.Error("an unnamed leaf should be dropped")
+	}
+	// Case- and space-insensitive: the name in the operator's head is
+	// "subid", not the casing of a path they never typed.
+	if !wantLeaf(parseOnly(" subid "), "Nodes.[a].SubID") {
+		t.Error("match should ignore case and surrounding space")
+	}
+	// No filter keeps everything - nil means "unfiltered", never
+	// "match nothing".
+	if !wantLeaf(nil, "anything") || parseOnly("") != nil || parseOnly(" , ") != nil {
+		t.Error("an empty --only must be a no-op, not an empty result")
 	}
 }

--- a/cmd/dhs/cmd_cerebrum_test.go
+++ b/cmd/dhs/cmd_cerebrum_test.go
@@ -604,3 +604,34 @@ func TestConstraintsSurviveToTheWatch(t *testing.T) {
 		t.Errorf("enum should win over range, got %q", got)
 	}
 }
+// TestKeepOnlyNarrowsAnExpansion: an expansion answers "what is under
+// here"; --only answers "which of those do I care about". Without it
+// "Nodes.*" on a live NOC is 68 nodes x ~16 fields and the values
+// anyone actually watches are lost in the flood.
+func TestKeepOnlyNarrowsAnExpansion(t *testing.T) {
+	objs := []string{
+		"Nodes.[a].SubID", "Nodes.[a].Connected", "Nodes.[a].Description",
+		"Nodes.[b].SubID", "Nodes.[b].Connected", "Nodes.[b].Description",
+	}
+	got, err := keepOnly(objs, "SubID,Connected")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 4 {
+		t.Errorf("want 4 rows, got %d: %v", len(got), got)
+	}
+	// Case-insensitive: the name in the operator's head is "subid",
+	// not the casing of a path they never typed.
+	if got, err := keepOnly(objs, " subid "); err != nil || len(got) != 2 {
+		t.Errorf("case/space-insensitive match failed: %v %v", got, err)
+	}
+	// Empty filter is a no-op, not an empty result.
+	if got, _ := keepOnly(objs, ""); len(got) != len(objs) {
+		t.Errorf("empty --only should pass everything through, got %d", len(got))
+	}
+	// A filter that matches nothing is an error, not a silent empty
+	// watch that never fires.
+	if _, err := keepOnly(objs, "Nope"); err == nil {
+		t.Error("a filter matching nothing must be refused")
+	}
+}

--- a/cmd/dhs/cmd_cerebrum_test.go
+++ b/cmd/dhs/cmd_cerebrum_test.go
@@ -635,3 +635,60 @@ func TestKeepOnlyNarrowsAnExpansion(t *testing.T) {
 		t.Error("a filter matching nothing must be refused")
 	}
 }
+// TestWatchReportsChangesNotState pins what a watch IS.
+//
+// A Cerebrum SUBSCRIBE answers with the object's CURRENT value, and
+// the server re-asserts values that have not changed. Printing both
+// turned a 68-node watch into a 1,088-row state dump that buried the
+// events it existed to show. A snapshot is export's job.
+func TestWatchReportsChangesNotState(t *testing.T) {
+	newFilter := func(showInitial bool) func(codec.DeviceObjectValue) bool {
+		seen := map[string]string{}
+		return func(ov codec.DeviceObjectValue) bool {
+			v := ov.Value
+			if !ov.Available {
+				v = "\x00unavailable"
+			}
+			prev, known := seen[ov.Object]
+			seen[ov.Object] = v
+			if !known {
+				return showInitial
+			}
+			return prev != v
+		}
+	}
+	row := func(v string) codec.DeviceObjectValue {
+		return codec.DeviceObjectValue{Object: "Nodes.[a].SubID", Value: v, Available: true}
+	}
+
+	f := newFilter(false)
+	if f(row("0")) {
+		t.Error("the subscribe baseline must not print by default")
+	}
+	if !f(row("1000")) {
+		t.Error("a changed value must print")
+	}
+	if f(row("1000")) {
+		t.Error("a re-asserted value must not print - the server repeats them")
+	}
+	if !f(row("0")) {
+		t.Error("changing back must print")
+	}
+
+	// --initial opts the baseline back in.
+	f2 := newFilter(true)
+	if !f2(row("0")) {
+		t.Error("--initial should print the baseline")
+	}
+	if f2(row("0")) {
+		t.Error("--initial still suppresses re-asserts")
+	}
+
+	// available=0 is a distinct state, not the empty string: a value
+	// GOING absent is a change worth seeing.
+	f3 := newFilter(false)
+	f3(codec.DeviceObjectValue{Object: "x", Value: "up", Available: true})
+	if !f3(codec.DeviceObjectValue{Object: "x"}) {
+		t.Error("a value going unavailable is a change")
+	}
+}

--- a/cmd/dhs/cmd_cerebrum_test.go
+++ b/cmd/dhs/cmd_cerebrum_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"context"
+	"io"
+	"os"
+	"time"
 	"strings"
 	"testing"
 
@@ -452,5 +455,78 @@ func TestWatchObjectListGrammar(t *testing.T) {
 	// A list of nothing is a usage error, not an empty subscription.
 	if _, err := cerebrumWatchObjects(nil, 0, "dev", true, "0", " ; ; "); err == nil {
 		t.Error("an all-empty --object should be refused")
+	}
+}
+// TestCerebrumDMRowMatchesGenericWatch pins the Tree/DM layout so an
+// NB watch reads like `dhs watch` on acp1/acp2. One grammar everywhere
+// is the point of the Tree/DM template (docs/protocols/verbs.md 12b);
+// an operator comparing a CONVERT over acp2 against the same card over
+// Cerebrum should be diffing VALUES, not re-learning a layout.
+func TestCerebrumDMRowMatchesGenericWatch(t *testing.T) {
+	ts := time.Date(2026, 8, 26, 1, 2, 3, 0, time.UTC)
+	capture := func(fn func()) string {
+		old := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+		fn()
+		_ = w.Close()
+		os.Stdout = old
+		var sb strings.Builder
+		_, _ = io.Copy(&sb, r)
+		return sb.String()
+	}
+
+	// A readable value carries its access bits and type.
+	got := capture(func() {
+		cerebrumDMRow(ts, codec.DeviceObjectValue{
+			Object: "Nodes.[abc].SubID", Value: "1000",
+			Available: true, Readable: true, Writable: true, DataType: "INTEGER",
+		})
+	})
+	for _, want := range []string{"01:02:03", "SubID", "RW-", "integer", "1000"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("row missing %q:\n%s", want, got)
+		}
+	}
+
+	// available=0 is a CHILD GROUP arriving inside a VALUE response,
+	// not an object with an empty value — rendering it as the latter
+	// reads as "this object is empty" instead of "this is a folder".
+	got = capture(func() {
+		cerebrumDMRow(ts, codec.DeviceObjectValue{Object: "Nodes.[abc].Interfaces.[eno1]"})
+	})
+	if !strings.Contains(got, "group") || !strings.Contains(got, "<children>") {
+		t.Errorf("child group should render as a group row:\n%s", got)
+	}
+
+	// Units ride with the value, as in the generic watch.
+	got = capture(func() {
+		cerebrumDMRow(ts, codec.DeviceObjectValue{
+			Object: "a.Delay", Value: "5.0", Available: true, Readable: true, Units: "ms",
+		})
+	})
+	if !strings.Contains(got, "5.0 ms") {
+		t.Errorf("units should follow the value:\n%s", got)
+	}
+}
+
+// TestTruncatePathKeepsBothEnds: Cerebrum paths are front-loaded with a
+// group and a bracketed UUID, so head-truncation leaves every row with
+// an identical 52-character prefix and hides the segment that differs.
+func TestTruncatePathKeepsBothEnds(t *testing.T) {
+	long := "Nodes.[ab469b7c-0100-1000-a000-3ceceffd5b65].SDP_Resend_Mode"
+	got := truncatePath(long, 40)
+	if len([]rune(got)) != 40 {
+		t.Errorf("truncatePath returned %d runes, want 40: %q", len([]rune(got)), got)
+	}
+	if !strings.HasPrefix(got, "Nodes.") {
+		t.Errorf("head lost: %q", got)
+	}
+	if !strings.HasSuffix(got, "SDP_Resend_Mode") {
+		t.Errorf("tail lost — the tail IS the object name: %q", got)
+	}
+	// Short enough already: untouched.
+	if got := truncatePath("a.b", 40); got != "a.b" {
+		t.Errorf("short path was modified: %q", got)
 	}
 }

--- a/cmd/dhs/cmd_cerebrum_test.go
+++ b/cmd/dhs/cmd_cerebrum_test.go
@@ -496,7 +496,21 @@ func TestCerebrumDMRowMatchesGenericWatch(t *testing.T) {
 		cerebrumDMRow(ts, codec.DeviceObjectValue{Object: "Nodes.[abc].Interfaces.[eno1]"})
 	})
 	if !strings.Contains(got, "group") || !strings.Contains(got, "<children>") {
-		t.Errorf("child group should render as a group row:\n%s", got)
+		t.Errorf("a BRACKETED collection member is a group row:\n%s", got)
+	}
+
+	// ...but an UNBRACKETED valueless leaf is NOT a folder. Connected
+	// on a node that never connected, and Last_Error on a live one,
+	// both arrive available=0; calling them "group <children>" told
+	// the operator a status field was a directory.
+	got = capture(func() {
+		cerebrumDMRow(ts, codec.DeviceObjectValue{Object: "Nodes.[abc].Connected", Readable: true})
+	})
+	if strings.Contains(got, "group") {
+		t.Errorf("a valueless named field must not render as a group:\n%s", got)
+	}
+	if !strings.Contains(got, "no-value") {
+		t.Errorf("a valueless leaf should say so:\n%s", got)
 	}
 
 	// Units ride with the value, as in the generic watch.
@@ -560,5 +574,33 @@ func TestHasOtherPathsIsTheGroupTest(t *testing.T) {
 	// Empty object names are noise, not children.
 	if hasOtherPaths([]codec.DeviceObjectValue{{Object: ""}}, self) {
 		t.Error("an empty object name is not a child")
+	}
+}
+// TestConstraintsSurviveToTheWatch: the wire carries MIN/MAX/STEP and
+// ENUM_LIST on the same row as the value, and the watch was dropping
+// them. They are the difference between reading a device and being
+// able to set it.
+func TestConstraintsSurviveToTheWatch(t *testing.T) {
+	enum := codec.DeviceObjectValue{EnumList: []string{"Send SDP Always", "Send SDP Once"}}
+	if got := cerebrumConstraint(enum); got != "{Send SDP Always|Send SDP Once}" {
+		t.Errorf("enum list = %q", got)
+	}
+	rng := codec.DeviceObjectValue{Min: "0", Max: "1000", Step: "0.5"}
+	if got := cerebrumConstraint(rng); got != "[0..1000 step 0.5]" {
+		t.Errorf("range = %q", got)
+	}
+	// A degenerate MIN==MAX carries no information - live ENUM rows
+	// report 0..0 and their real constraint is the enum list. Same
+	// rule CanonicalDeviceObject applies when building the DM.
+	if got := cerebrumConstraint(codec.DeviceObjectValue{Min: "0", Max: "0"}); got != "" {
+		t.Errorf("degenerate range should be dropped, got %q", got)
+	}
+	if got := cerebrumConstraint(codec.DeviceObjectValue{}); got != "" {
+		t.Errorf("no constraint should render nothing, got %q", got)
+	}
+	// Enum wins over a range when both are present.
+	both := codec.DeviceObjectValue{EnumList: []string{"On", "Off"}, Min: "0", Max: "1"}
+	if got := cerebrumConstraint(both); got != "{On|Off}" {
+		t.Errorf("enum should win over range, got %q", got)
 	}
 }

--- a/cmd/dhs/cmd_cerebrum_test.go
+++ b/cmd/dhs/cmd_cerebrum_test.go
@@ -663,7 +663,7 @@ func TestWatchReportsChangesNotState(t *testing.T) {
 }
 // TestOnlyIsAppliedDuringTheWalk: the filter has to narrow the
 // expansion as it happens, not afterwards. Applied after,
-// "Nodes.** --only SubID" builds the whole tree first and trips the
+// "Nodes.** --label SubID" builds the whole tree first and trips the
 // object cap before it reaches the filter - which is exactly the
 // combination needed to watch one field across a plant.
 func TestOnlyIsAppliedDuringTheWalk(t *testing.T) {
@@ -682,6 +682,6 @@ func TestOnlyIsAppliedDuringTheWalk(t *testing.T) {
 	// No filter keeps everything - nil means "unfiltered", never
 	// "match nothing".
 	if !wantLeaf(nil, "anything") || parseOnly("") != nil || parseOnly(" , ") != nil {
-		t.Error("an empty --only must be a no-op, not an empty result")
+		t.Error("an empty --label must be a no-op, not an empty result")
 	}
 }


### PR DESCRIPTION
## What  `cerebrum-nb watch` becomes usable on a real device: it reports **changes** (not a state dump), takes a list / `.*` / `.**` for `--object`, filters with `--label`, and renders in the Tree/DM columns every other protocol already uses.  ## Why  `watch` took one `--object` and printed the current value of it plus everything the server re-asserted. Watching a device meant one process per object, and each one printed a two-line block repeating name/ip/sub on every frame.  Owner, on seeing a 68-node watch print 1,088 rows of unchanged data:  > watch is only expecting to get notifications for any object modified. If I need a snapshot I use export and you must walk on the tree  That is the correct division and this PR implements it. `export` walks the tree and writes a file; `watch` subscribes and tells you what moved.  Closes #  ## Scope  - [x] osc / tsl / cerebrum-nb / amwa - [x] cli  ## Wire evidence (protocol changes only)  No encoder change — `Subscribe` already took a slice of rows; the verb never built more than one. Wire facts established live on 10.44.55.39:40009 (2026-08-26) that drive the behaviour:  ```text # 1. A SUBSCRIBE answers with the object's CURRENT value, and the #    server RE-ASSERTS unchanged values: SubID available=1 value="1000" SubID available=1 value="1000"     <- re-assert, not a change SubID available=1 value="0" SubID available=1 value="0"        <- re-assert  # 2. A group subscription fires for its DIRECT children only. #    "Nodes"        -> 68-child listing, then silent on field changes #    "Nodes.[uuid]" -> fires on that node's own fields  # 3. available=0 is TWO things: a child group, and a leaf with no #    value right now (Last_Error). Collection members are bracketed; #    named fields are not — the only separator on the wire.  # 4. Interfaces / Devices carry a summary comma value AND have #    children, so "carries a value" never means "is a leaf". ```  ## Reference controller  - [x] Cerebrum still happy after this change — read-only verb, exercised against the production NOC throughout  ## Type  - [x] feat — new feature - [x] fix — bug fix  ## Files changed  | File | New / Modified | Description | |------|---------------|-------------| | `cmd/dhs/cmd_cerebrum.go` | modified | change-only reporting; `--object` list / `.*` / `.**`; `--label`; `--initial`; `--raw`; Tree/DM renderer with enum + range constraints; expansion cap | | `cmd/dhs/cmd_cerebrum_test.go` | modified | grammar, filter, change-detection, group-vs-leaf and layout tests |  ## Test results  | Suite | Passed | Failed | |-------|--------|--------| | `go test ./...` | all | 0 | | `go vet ./...` | clean | — | | `golangci-lint run` | clean | — |  ## Device tested  - [x] Real device — Cerebrum NOC 10.44.55.39:40009 (production northbound), 68 NMOS nodes  **Live command + observed output** (verbatim):  ```text .\dhs.exe consumer cerebrum-nb watch 10.44.55.39:40009 --user YOB --pass *** \   --device "Cerebrum NMOS NOC" --by-name --sub-device 0 \   --object "Nodes.*" --label "SubID" watching DEVICE_CHANGE TYPE=VALUE on 68 object(s) on Cerebrum NMOS NOC - Ctrl+C to stop time      path                                                  label             acc  type     value ----------------------------------------------------------------------------------------------------- 01:30:30  Nodes.[ab469b7c-0100-1000-a000-3ceceffd5b65].SubID    SubID             ---           1000 01:30:37  Nodes.[ab469b7c-0100-1000-a000-3ceceffd5b65].SubID    SubID             ---           0 01:30:48  Nodes.[7fc819f0-f93f-20d9-91e4-40a36ba20d90].SubID    SubID             ---           1210 01:30:54  Nodes.[7fc819f0-f93f-20d9-91e4-40a36ba20d90].SubID    SubID             ---           0 ```  Four SubID assignments across two nodes, nothing else in the stream.  ## Known follow-ups (not in this PR)  - `acc` / `type` are blank on change rows: the notification frame omits `READABLE`/`WRITABLE`/`DATA_TYPE`, which only the subscribe reply carries. Could be kept from the reply. - `dropped reply (channel full)` mtid=3 fires during the 68-subscription burst (`internal/cerebrum-nb/consumer/session.go:429`). Nothing is lost — all 68 register — but it wants a capture before being called harmless. - `--label` takes a comma list here; the generic watch takes a single label. Widening it touches every plugin's matcher, so it is its own unit — along with writing the filter vocabulary into ADR-0002, whose canonical-flag table does not mention watch filters at all.  ## Checklist  - [x] `go test -count=1 ./...` passes - [x] `go vet ./...` clean - [x] `golangci-lint run ./...` clean - [x] No new external dependencies - [x] Integration tested on real Cerebrum before PR  ## Approval  @yboujraf — requesting review