### PR TITLE
feat(nmos): registry mirror verb - bridge one Registry into another

### DIFF
--- a/cmd/dhs/cmd_nmos.go
+++ b/cmd/dhs/cmd_nmos.go
@@ -31,6 +31,7 @@ import (
 	"dhs/internal/amwa/codec/spec"
 	"dhs/internal/amwa/consumer"
 	"dhs/internal/amwa/provider"
+	amwaregistry "dhs/internal/amwa/registry"
 	session "dhs/internal/amwa/session/dnssd"
 	"dhs/internal/amwa/session/query"
 	registryslot "dhs/internal/registry"
@@ -95,8 +96,10 @@ func runNMOSRegistry(ctx context.Context, args []string) error {
 	switch verb {
 	case "serve":
 		return runNMOSRegistryServe(ctx, rest)
+	case "mirror":
+		return runNMOSRegistryMirror(ctx, rest)
 	}
-	return fmt.Errorf("registry nmos: unknown verb %q (expected: serve)", verb)
+	return fmt.Errorf("registry nmos: unknown verb %q (expected: serve, mirror)", verb)
 }
 
 // ---- discover ---------------------------------------------------------------
@@ -708,7 +711,44 @@ announce of _nmos-register._tcp + _nmos-query._tcp.
   --priority N             DNS-SD pri TXT (0-99 prod, 100+ dev)
   --gc-interval D          Heartbeat watchdog tick rate (default 1s)
   --heartbeat-timeout D    Evict Nodes that miss heartbeats this long
-                           (default 12s, IS-04 §6.1)`)
+                           (default 12s, IS-04 §6.1)
+
+  dhs registry nmos mirror --source URL --target URL [--api-ver v1.3]
+
+Bridges one Registry into another: subscribes to every collection on
+the source's Query-WS (controller role) and forwards each change to
+the target's Registration API (node role), proxying one heartbeat per
+source node. Use case: dhs Registry as the plant's source of truth
+feeding a controller vendor's own registry.`)
+}
+
+// runNMOSRegistryMirror bridges a source Registry into a target one.
+func runNMOSRegistryMirror(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("mirror", flag.ContinueOnError)
+	source := fs.String("source", "", "source Registry origin (http://host:port) — Query API side")
+	targetURL := fs.String("target", "", "target Registry origin (http://host:port) — Registration API side")
+	apiVer := fs.String("api-ver", "", "IS-04 wire version used on both faces (default v1.3)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	m, err := amwaregistry.NewMirror(amwaregistry.MirrorOptions{
+		Source: *source,
+		Target: *targetURL,
+		APIVer: *apiVer,
+		Logger: slog.Default(),
+	})
+	if err != nil {
+		return fmt.Errorf("nmos mirror: %w", err)
+	}
+	fmt.Printf("Mirroring %s -> %s. Interrupt to stop.\n", *source, *targetURL)
+	err = m.Run(ctx)
+	st := m.Stats()
+	fmt.Fprintf(os.Stderr, "forwarded=%d deleted=%d heartbeats=%d resyncs=%d failures=%d\n",
+		st.Forwarded, st.Deleted, st.Heartbeats, st.Resyncs, st.Failures)
+	if err != nil && !errors.Is(err, context.Canceled) {
+		return fmt.Errorf("nmos mirror: %w", err)
+	}
+	return nil
 }
 
 // ---- consumer walk (IS-04 Controller) ---------------------------------------

--- a/internal/amwa/docs/use-cases.md
+++ b/internal/amwa/docs/use-cases.md
@@ -1,0 +1,49 @@
+# NMOS use cases — proven configurations
+
+Each row was run live on the VLAN600 plant (registry `10.6.250.101:8235`,
+EVS Neuron, EVS Cerebrum 2.8.17) with wire receipts; dates 2026-08-28/29.
+Details live in [`vlan600-migration.md`](vlan600-migration.md),
+[`cerebrum-interop.md`](cerebrum-interop.md),
+[`neuron-interop-matrix.md`](neuron-interop-matrix.md).
+
+## Discovery of the registry (node side)
+
+| mode | how | proof |
+|---|---|---|
+| **Manual** | device/UI pins `http://<registry>:8235` (Neuron Addr Override; dhs `--registry URL`) | Neuron + dhs node heartbeats on tape |
+| **mDNS** (Mode A) | registry announces `_nmos-register/_nmos-query._tcp`; nodes browse | Cerebrum harvest; Neuron fallback registration; announce-off purge |
+| **sd-DNS** (RFC 6763 §10) | zone on dnsmasq @ `.101` (`by-systems.arpa`); node `--unicast --resolver 10.6.250.101` | `registry discovered (unicast DNS-SD)` + registration |
+
+`--no-mdns` on the registry gives a fully deterministic manual-only
+plant (proven: both nodes re-registered after a registry restart with
+no announces at all).
+
+## Mirror registration (registry → registry)
+
+```
+dhs Node ↔ dhs Registry ↔ [ vendor Registry ↔ vendor controller ]
+           (source of truth)      (their native catalogue)
+```
+
+`dhs registry nmos mirror --source http://10.6.250.101:8235 --target
+http://<vendor>:8080` — toward the source the mirror is a standard
+Controller (Query-WS grains); toward the target a standard Node
+(Registration API + per-node heartbeats). Proven against Cerebrum's
+hosted registry: 856/856 resources, full SDP + details rendered by the
+Cerebrum controller from its own catalogue. Traps encoded in the
+implementation: explicit `Content-Length: 0` heartbeats (their 411),
+dependency-ordered POSTs (their parent validation), full resync on a
+404 heartbeat.
+
+## IS-05 driving (controller side)
+
+- `consumer nmos connect --registry … --receiver R --sender S` —
+  route through the catalogue (proven on the Neuron: VTX-03 → VRX-04,
+  device-verified ACTIVE).
+- `consumer nmos set --registry … --sender S --destination ip1,ip2
+  --port p1,p2 --enable` — retune multicast + port per leg; SDP
+  regenerates (proven: 239.30/32.1.1:5010, receiver re-fed).
+- `consumer nmos watch --registry … --resource /senders` — live
+  change stream (proven: 211-grain sync + the change grain from a
+  `set`).
+- Every mutating verb has `--dry-run` printing the exact PATCH first.

--- a/internal/amwa/registry/mirror.go
+++ b/internal/amwa/registry/mirror.go
@@ -1,0 +1,398 @@
+package registry
+
+// Mirror — registry-to-registry bridge (the productized form of the
+// VLAN600 lab bridge, see internal/amwa/docs/cerebrum-interop.md
+// "Registry-to-registry bridge").
+//
+// Topology:
+//
+//	source Registry ──Query-WS grains──► Mirror ──Registration API──► target Registry
+//	   (controller role toward source)          (node role toward target)
+//
+// The mirror subscribes to all six resource collections on the source
+// Query API and forwards every change to the target Registration API:
+// added/modified rows become POST /resource, removed rows become
+// DELETE. One heartbeat per source node is proxied every
+// HeartbeatInterval while that node exists in the source. No new wire
+// behaviour is invented anywhere — toward the source the mirror is a
+// standard Controller, toward the target a standard Node.
+//
+// Field-taught details baked in (measured against EVS Cerebrum
+// 2.8.17, 2026-08-29):
+//   - health POSTs carry an explicit empty body so Content-Length: 0
+//     is always present — Cerebrum's registry answers 411 to bodyless
+//     POSTs and then silently GCs everything;
+//   - a 404 heartbeat triggers a full re-registration of the cached
+//     catalogue in dependency order — their registration face
+//     validates parent references, so order is mandatory.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	stdhttp "net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"dhs/internal/amwa/codec/is04"
+	"dhs/internal/amwa/session/query"
+)
+
+// MirrorHeartbeatInterval is the IS-04 §6.1 heartbeat cadence the
+// mirror proxies per source node.
+const MirrorHeartbeatInterval = 5 * time.Second
+
+// mirrorTopics is every Query API collection, in registration
+// dependency order (IS-04 referential integrity: sources before
+// flows, flows before senders, …). Re-registration walks this order.
+var mirrorTopics = []string{"nodes", "devices", "sources", "flows", "senders", "receivers"}
+
+// mirrorSingular maps a collection to the Registration API type key.
+var mirrorSingular = map[string]string{
+	"nodes":     "node",
+	"devices":   "device",
+	"sources":   "source",
+	"flows":     "flow",
+	"senders":   "sender",
+	"receivers": "receiver",
+}
+
+// MirrorOptions configures Run.
+type MirrorOptions struct {
+	// Source is the origin of the Registry whose catalogue is mirrored,
+	// e.g. "http://10.6.250.101:8235". Query API side.
+	Source string
+	// Target is the origin of the Registry that receives the copy,
+	// e.g. "http://10.6.250.5:8080". Registration API side.
+	Target string
+	// APIVer is the IS-04 wire version used on BOTH faces (default
+	// v1.3). The mirror does not translate between minors.
+	APIVer string
+	// Logger receives operational events. nil = slog.Default().
+	Logger *slog.Logger
+}
+
+// MirrorStats is a snapshot of forward counters.
+type MirrorStats struct {
+	Forwarded  uint64 // POSTs accepted by the target
+	Deleted    uint64 // DELETEs accepted by the target
+	Heartbeats uint64 // health POSTs accepted by the target
+	Resyncs    uint64 // full re-registrations (target 404 recovery)
+	Failures   uint64 // requests the target refused
+}
+
+// Mirror bridges one source Registry into one target Registry.
+type Mirror struct {
+	opts   MirrorOptions
+	logger *slog.Logger
+	http   *stdhttp.Client
+
+	mu sync.Mutex
+	// cache holds the latest Post document per collection/id — the
+	// mirror's authoritative copy of the source catalogue, used for
+	// full re-registration after a target eviction.
+	cache map[string]map[string]json.RawMessage
+	stats MirrorStats
+}
+
+// NewMirror validates options and builds an unstarted mirror.
+func NewMirror(opts MirrorOptions) (*Mirror, error) {
+	if opts.Source == "" || opts.Target == "" {
+		return nil, errors.New("registry/mirror: source and target are required")
+	}
+	if strings.TrimRight(opts.Source, "/") == strings.TrimRight(opts.Target, "/") {
+		return nil, errors.New("registry/mirror: source and target must differ")
+	}
+	if opts.APIVer == "" {
+		opts.APIVer = is04.APIVersion
+	}
+	if opts.Logger == nil {
+		opts.Logger = slog.Default()
+	}
+	cache := make(map[string]map[string]json.RawMessage, len(mirrorTopics))
+	for _, tp := range mirrorTopics {
+		cache[tp] = map[string]json.RawMessage{}
+	}
+	return &Mirror{
+		opts:   opts,
+		logger: opts.Logger,
+		http:   &stdhttp.Client{Timeout: 10 * time.Second},
+		cache:  cache,
+	}, nil
+}
+
+// Stats returns a snapshot of the forward counters.
+func (m *Mirror) Stats() MirrorStats {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.stats
+}
+
+// Run drives the mirror until ctx ends: one watch goroutine per
+// collection (resubscribing with backoff on socket loss — the source
+// registry restarting must not kill the bridge) plus the heartbeat
+// proxy loop. Returns ctx.Err() on normal shutdown.
+func (m *Mirror) Run(ctx context.Context) error {
+	codec, ok := is04.Get(m.opts.APIVer)
+	if !ok {
+		return fmt.Errorf("registry/mirror: unknown api-ver %q", m.opts.APIVer)
+	}
+	qc, err := query.NewClient(m.opts.Source, codec)
+	if err != nil {
+		return fmt.Errorf("registry/mirror: source: %w", err)
+	}
+
+	var wg sync.WaitGroup
+	for _, topic := range mirrorTopics {
+		wg.Add(1)
+		go func(topic string) {
+			defer wg.Done()
+			m.watchTopic(ctx, qc, topic)
+		}(topic)
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		m.heartbeatLoop(ctx)
+	}()
+
+	wg.Wait()
+	return ctx.Err()
+}
+
+// watchTopic subscribes to one collection and forwards its grains,
+// resubscribing with a flat 2 s backoff whenever the subscription or
+// socket fails.
+func (m *Mirror) watchTopic(ctx context.Context, qc *query.Client, topic string) {
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		sub, err := qc.Subscribe(ctx, query.SubscribeRequest{ResourcePath: "/" + topic})
+		if err != nil {
+			m.logger.Warn("registry/mirror: subscribe failed", "topic", topic, "err", err)
+			m.sleep(ctx, 2*time.Second)
+			continue
+		}
+		err = query.Watch(ctx, sub.WSHref, func(g *is04.Grain) error {
+			for _, row := range g.Grain.Data {
+				m.forwardRow(ctx, topic, row)
+			}
+			return nil
+		}, query.WatchOptions{})
+		if ctx.Err() != nil {
+			return
+		}
+		m.logger.Warn("registry/mirror: watch ended — resubscribing", "topic", topic, "err", err)
+		m.sleep(ctx, 2*time.Second)
+	}
+}
+
+// forwardRow applies one grain row to the cache and the target.
+func (m *Mirror) forwardRow(ctx context.Context, topic string, row is04.GrainDataRow) {
+	switch row.Kind() {
+	case is04.ChangeAdded, is04.ChangeModified:
+		m.mu.Lock()
+		m.cache[topic][row.Path] = row.Post
+		m.mu.Unlock()
+		m.postResource(ctx, topic, row.Post)
+	case is04.ChangeRemoved:
+		m.mu.Lock()
+		delete(m.cache[topic], row.Path)
+		m.mu.Unlock()
+		m.deleteResource(ctx, topic, row.Path)
+	default:
+		m.logger.Warn("registry/mirror: grain row with neither pre nor post", "topic", topic, "id", row.Path)
+	}
+}
+
+// postResource POSTs one document to the target Registration API.
+func (m *Mirror) postResource(ctx context.Context, topic string, doc json.RawMessage) {
+	body, err := json.Marshal(map[string]any{
+		"type": mirrorSingular[topic],
+		"data": json.RawMessage(doc),
+	})
+	if err != nil {
+		m.fail("encode", topic, err)
+		return
+	}
+	url := m.registrationBase() + "/resource"
+	req, err := stdhttp.NewRequestWithContext(ctx, stdhttp.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		m.fail("build POST", topic, err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := m.http.Do(req)
+	if err != nil {
+		m.fail("POST", topic, err)
+		return
+	}
+	drainClose(resp)
+	if resp.StatusCode != stdhttp.StatusOK && resp.StatusCode != stdhttp.StatusCreated {
+		m.fail("POST", topic, fmt.Errorf("HTTP %d", resp.StatusCode))
+		return
+	}
+	m.mu.Lock()
+	m.stats.Forwarded++
+	m.mu.Unlock()
+}
+
+// deleteResource DELETEs one document from the target.
+func (m *Mirror) deleteResource(ctx context.Context, topic, id string) {
+	url := m.registrationBase() + "/resource/" + topic + "/" + id
+	req, err := stdhttp.NewRequestWithContext(ctx, stdhttp.MethodDelete, url, nil)
+	if err != nil {
+		m.fail("build DELETE", topic, err)
+		return
+	}
+	resp, err := m.http.Do(req)
+	if err != nil {
+		m.fail("DELETE", topic, err)
+		return
+	}
+	drainClose(resp)
+	// 404 is success for a delete — the target never had it.
+	if resp.StatusCode != stdhttp.StatusNoContent && resp.StatusCode != stdhttp.StatusNotFound {
+		m.fail("DELETE", topic, fmt.Errorf("HTTP %d", resp.StatusCode))
+		return
+	}
+	m.mu.Lock()
+	m.stats.Deleted++
+	m.mu.Unlock()
+}
+
+// heartbeatLoop proxies one health POST per cached source node every
+// MirrorHeartbeatInterval. A 404 answer means the target evicted us —
+// re-register the whole cached catalogue in dependency order.
+func (m *Mirror) heartbeatLoop(ctx context.Context) {
+	ticker := time.NewTicker(MirrorHeartbeatInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			for _, id := range m.nodeIDs() {
+				if m.sendHealth(ctx, id) == errMirrorEvicted {
+					m.logger.Warn("registry/mirror: target evicted node — full resync", "node", id)
+					m.resync(ctx)
+					break
+				}
+			}
+		}
+	}
+}
+
+var errMirrorEvicted = errors.New("registry/mirror: target answered 404 to a heartbeat")
+
+// sendHealth POSTs one heartbeat. The empty (non-nil sized) body is
+// deliberate: it guarantees a Content-Length header, which some
+// registries (EVS Cerebrum) demand on POST — without it they answer
+// 411 and their GC silently sweeps the catalogue.
+func (m *Mirror) sendHealth(ctx context.Context, nodeID string) error {
+	url := m.registrationBase() + "/health/nodes/" + nodeID
+	req, err := stdhttp.NewRequestWithContext(ctx, stdhttp.MethodPost, url, bytes.NewReader(nil))
+	if err != nil {
+		m.fail("build health", "nodes", err)
+		return err
+	}
+	resp, err := m.http.Do(req)
+	if err != nil {
+		m.fail("health", "nodes", err)
+		return err
+	}
+	drainClose(resp)
+	switch resp.StatusCode {
+	case stdhttp.StatusOK:
+		m.mu.Lock()
+		m.stats.Heartbeats++
+		m.mu.Unlock()
+		return nil
+	case stdhttp.StatusNotFound:
+		return errMirrorEvicted
+	default:
+		err := fmt.Errorf("HTTP %d", resp.StatusCode)
+		m.fail("health", "nodes", err)
+		return err
+	}
+}
+
+// resync re-POSTs the whole cached catalogue in dependency order.
+func (m *Mirror) resync(ctx context.Context) {
+	m.mu.Lock()
+	m.stats.Resyncs++
+	snapshot := make(map[string][]json.RawMessage, len(mirrorTopics))
+	for _, topic := range mirrorTopics {
+		ids := make([]string, 0, len(m.cache[topic]))
+		for id := range m.cache[topic] {
+			ids = append(ids, id)
+		}
+		sort.Strings(ids) // deterministic order for tests + logs
+		docs := make([]json.RawMessage, 0, len(ids))
+		for _, id := range ids {
+			docs = append(docs, m.cache[topic][id])
+		}
+		snapshot[topic] = docs
+	}
+	m.mu.Unlock()
+
+	for _, topic := range mirrorTopics {
+		for _, doc := range snapshot[topic] {
+			if ctx.Err() != nil {
+				return
+			}
+			m.postResource(ctx, topic, doc)
+		}
+	}
+}
+
+// nodeIDs snapshots the cached source node ids.
+func (m *Mirror) nodeIDs() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ids := make([]string, 0, len(m.cache["nodes"]))
+	for id := range m.cache["nodes"] {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// registrationBase returns the target Registration API base URL.
+func (m *Mirror) registrationBase() string {
+	base := strings.TrimRight(m.opts.Target, "/")
+	if !strings.Contains(base, "/x-nmos/registration/") {
+		base += "/x-nmos/registration/" + m.opts.APIVer
+	}
+	return base
+}
+
+func (m *Mirror) fail(op, topic string, err error) {
+	m.logger.Warn("registry/mirror: "+op+" failed", "topic", topic, "err", err)
+	m.mu.Lock()
+	m.stats.Failures++
+	m.mu.Unlock()
+}
+
+// sleep waits d or until ctx ends, whichever is first.
+func (m *Mirror) sleep(ctx context.Context, d time.Duration) {
+	select {
+	case <-ctx.Done():
+	case <-time.After(d):
+	}
+}
+
+// drainClose fully consumes and closes a response body so the
+// transport can reuse the connection.
+func drainClose(resp *stdhttp.Response) {
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+	_ = resp.Body.Close()
+}

--- a/internal/amwa/registry/mirror_test.go
+++ b/internal/amwa/registry/mirror_test.go
@@ -1,0 +1,266 @@
+package registry
+
+// Mirror tests: a fake source Registry (subscriptions + Query-WS
+// grains) and a fake target Registration API, wired through the real
+// Mirror. The Cerebrum-taught details are pinned here: explicit
+// Content-Length on health POSTs, and full dependency-ordered resync
+// after a 404 heartbeat.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	_ "dhs/internal/amwa/codec/is04/v13" // register the v1.3 codec
+	amwahttp "dhs/internal/amwa/session/http"
+)
+
+func TestNewMirrorValidates(t *testing.T) {
+	if _, err := NewMirror(MirrorOptions{}); err == nil {
+		t.Error("empty options must be rejected")
+	}
+	if _, err := NewMirror(MirrorOptions{Source: "http://a:1", Target: "http://a:1"}); err == nil {
+		t.Error("source == target must be rejected")
+	}
+	if m, err := NewMirror(MirrorOptions{Source: "http://a:1", Target: "http://b:1"}); err != nil || m == nil {
+		t.Errorf("valid options rejected: %v", err)
+	}
+}
+
+// grainFrame builds one Query-WS grain frame for topic with one row.
+func grainFrame(topic, id, pre, post string) []byte {
+	row := map[string]any{"path": id}
+	if pre != "" {
+		row["pre"] = json.RawMessage(pre)
+	}
+	if post != "" {
+		row["post"] = json.RawMessage(post)
+	}
+	g := map[string]any{
+		"grain_type": "event",
+		"grain": map[string]any{
+			"type":  "urn:x-nmos:format:data.event",
+			"topic": "/" + topic + "/",
+			"data":  []any{row},
+		},
+	}
+	raw, _ := json.Marshal(g)
+	return raw
+}
+
+// fakePlant is a source Registry (subscriptions + ws) and a target
+// Registration API sharing one recorder.
+type fakePlant struct {
+	mu       sync.Mutex
+	posts    []string // "topic:id" in arrival order at the TARGET
+	deletes  []string // "topic/id"
+	healths  []string // node ids
+	healthCL []string // Content-Length header per health POST
+	evict    int      // answer this many health POSTs with 404 first
+}
+
+func (p *fakePlant) targetHandler() stdhttp.Handler {
+	return stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		switch {
+		case r.Method == stdhttp.MethodPost && strings.HasSuffix(r.URL.Path, "/resource"):
+			body, _ := io.ReadAll(r.Body)
+			var env struct {
+				Type string          `json:"type"`
+				Data json.RawMessage `json:"data"`
+			}
+			_ = json.Unmarshal(body, &env)
+			var doc struct {
+				ID string `json:"id"`
+			}
+			_ = json.Unmarshal(env.Data, &doc)
+			p.mu.Lock()
+			p.posts = append(p.posts, env.Type+":"+doc.ID)
+			p.mu.Unlock()
+			w.WriteHeader(stdhttp.StatusCreated)
+		case r.Method == stdhttp.MethodDelete:
+			parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/x-nmos/registration/v1.3/resource/"), "/")
+			p.mu.Lock()
+			p.deletes = append(p.deletes, strings.Join(parts, "/"))
+			p.mu.Unlock()
+			w.WriteHeader(stdhttp.StatusNoContent)
+		case r.Method == stdhttp.MethodPost && strings.Contains(r.URL.Path, "/health/nodes/"):
+			id := r.URL.Path[strings.LastIndexByte(r.URL.Path, '/')+1:]
+			p.mu.Lock()
+			p.healths = append(p.healths, id)
+			p.healthCL = append(p.healthCL, r.Header.Get("Content-Length"))
+			evict := p.evict > 0
+			if evict {
+				p.evict--
+			}
+			p.mu.Unlock()
+			if evict {
+				w.WriteHeader(stdhttp.StatusNotFound)
+				return
+			}
+			w.WriteHeader(stdhttp.StatusOK)
+		default:
+			w.WriteHeader(stdhttp.StatusNotFound)
+		}
+	})
+}
+
+// sourceHandler serves POST /subscriptions and the ws endpoint. Each
+// topic's socket first sends the frames in frames[topic], then holds
+// open until the server closes.
+func (p *fakePlant) sourceHandler(t *testing.T, srvURL func() string, frames map[string][][]byte) stdhttp.Handler {
+	t.Helper()
+	return stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		switch {
+		case r.Method == stdhttp.MethodPost && strings.HasSuffix(r.URL.Path, "/subscriptions"):
+			var req struct {
+				ResourcePath string `json:"resource_path"`
+			}
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &req)
+			topic := strings.Trim(req.ResourcePath, "/")
+			ws := strings.Replace(srvURL(), "http://", "ws://", 1) + "/ws/" + topic
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(stdhttp.StatusCreated)
+			_, _ = fmt.Fprintf(w, `{"id":"sub-%s","ws_href":"%s","resource_path":"/%s"}`, topic, ws, topic)
+		case strings.HasPrefix(r.URL.Path, "/ws/"):
+			topic := strings.TrimPrefix(r.URL.Path, "/ws/")
+			ws, err := amwahttp.AcceptWebSocket(w, r)
+			if err != nil {
+				t.Errorf("accept ws: %v", err)
+				return
+			}
+			for _, f := range frames[topic] {
+				if err := ws.SendText(f); err != nil {
+					return
+				}
+			}
+			// Hold open; read until the client closes.
+			for {
+				if _, err := ws.ReadText(); err != nil {
+					return
+				}
+			}
+		default:
+			w.WriteHeader(stdhttp.StatusNotFound)
+		}
+	})
+}
+
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool, what string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("timeout waiting for %s", what)
+}
+
+func TestMirrorForwardsAndDeletes(t *testing.T) {
+	plant := &fakePlant{}
+	target := httptest.NewServer(plant.targetHandler())
+	defer target.Close()
+
+	frames := map[string][][]byte{
+		"nodes":   {grainFrame("nodes", "n1", "", `{"id":"n1","label":"src-node"}`)},
+		"devices": {grainFrame("devices", "d1", "", `{"id":"d1"}`)},
+		"senders": {
+			grainFrame("senders", "s1", "", `{"id":"s1","label":"S1"}`),
+			grainFrame("senders", "s1", `{"id":"s1"}`, ""), // removed
+		},
+	}
+	var src *httptest.Server
+	src = httptest.NewServer((&fakePlant{}).sourceHandler(t, func() string { return src.URL }, frames))
+	defer src.Close()
+	// The source handler needs plant-independent frames only; reuse.
+	src.Config.Handler = plant.sourceHandler(t, func() string { return src.URL }, frames)
+
+	m, err := NewMirror(MirrorOptions{Source: src.URL, Target: target.URL, APIVer: "v1.3"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = m.Run(ctx) }()
+
+	waitFor(t, 5*time.Second, func() bool {
+		plant.mu.Lock()
+		defer plant.mu.Unlock()
+		hasNode, hasDel := false, len(plant.deletes) > 0
+		for _, p := range plant.posts {
+			if p == "node:n1" {
+				hasNode = true
+			}
+		}
+		return hasNode && hasDel
+	}, "node POST + sender DELETE at target")
+
+	plant.mu.Lock()
+	defer plant.mu.Unlock()
+	joined := strings.Join(plant.posts, ",")
+	if !strings.Contains(joined, "device:d1") || !strings.Contains(joined, "sender:s1") {
+		t.Errorf("posts = %v", plant.posts)
+	}
+	if plant.deletes[0] != "senders/s1" {
+		t.Errorf("deletes = %v", plant.deletes)
+	}
+	st := m.Stats()
+	if st.Forwarded < 3 || st.Deleted < 1 {
+		t.Errorf("stats = %+v", st)
+	}
+}
+
+func TestMirrorHeartbeatsWithContentLengthAndResyncsOn404(t *testing.T) {
+	plant := &fakePlant{evict: 1} // first heartbeat answered 404
+	target := httptest.NewServer(plant.targetHandler())
+	defer target.Close()
+
+	frames := map[string][][]byte{
+		"nodes":   {grainFrame("nodes", "n1", "", `{"id":"n1"}`)},
+		"sources": {grainFrame("sources", "src1", "", `{"id":"src1"}`)},
+	}
+	src := httptest.NewServer(stdhttp.NotFoundHandler())
+	src.Config.Handler = plant.sourceHandler(t, func() string { return src.URL }, frames)
+	defer src.Close()
+
+	m, err := NewMirror(MirrorOptions{Source: src.URL, Target: target.URL, APIVer: "v1.3"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = m.Run(ctx) }()
+
+	// One heartbeat interval must elapse; the first health POST is
+	// 404'd which must trigger a resync (node + source re-POSTed).
+	waitFor(t, 3*MirrorHeartbeatInterval, func() bool {
+		return m.Stats().Resyncs >= 1 && m.Stats().Heartbeats >= 1
+	}, "a 404-triggered resync followed by a healthy heartbeat")
+
+	plant.mu.Lock()
+	defer plant.mu.Unlock()
+	for i, cl := range plant.healthCL {
+		if cl != "0" {
+			t.Errorf("health POST %d: Content-Length = %q, want \"0\" (411 trap)", i, cl)
+		}
+	}
+	// Resync re-POSTs in dependency order: the node must be re-posted
+	// before the source in the post-404 tail.
+	joined := strings.Join(plant.posts, ",")
+	if strings.Count(joined, "node:n1") < 2 || strings.Count(joined, "source:src1") < 2 {
+		t.Errorf("expected resync re-POSTs, posts = %v", plant.posts)
+	}
+	last := plant.posts[len(plant.posts)-2:]
+	if last[0] != "node:n1" || last[1] != "source:src1" {
+		t.Errorf("resync order wrong, tail = %v", last)
+	}
+}


### PR DESCRIPTION
## Scope

`dhs registry nmos mirror --source URL --target URL` — registry-to-registry bridge, the productized form of the VLAN600 lab bridge. Source face: standard Controller (Query-WS subscriptions on all six collections). Target face: standard Node (Registration API POST/DELETE + one proxied heartbeat per source node). Full dependency-ordered resync on a 404 heartbeat. No new wire behaviour on either face.

Also adds `internal/amwa/docs/use-cases.md` — the proven discovery-mode matrix (manual / mDNS / sd-DNS) + mirror + IS-05 driving receipts.

## Verification

- Unit: forward/delete propagation, heartbeat Content-Length: 0 (the Cerebrum 411 trap), 404-triggered dependency-ordered resync — against fake source (real WS server) + fake target
- Live plant: verb replaced the lab bridge script mid-flight; an IS-05 `set` on the source registry propagated into Cerebrum's hosted registry via the mirror within seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)