### PR TITLE
infra(amwa): ansible-manage the lab plant - converge + 0-change idempotence

### DIFF
--- a/ansible/playbooks/amwa-plant.yml
+++ b/ansible/playbooks/amwa-plant.yml
@@ -1,0 +1,19 @@
+---
+# Stand up (or converge) the AMWA lab plant — registry + node fleet —
+# on the control host, entirely via Ansible. Replaces the ad-hoc
+# /tmp/*.sh launch scripts (issue #871).
+#
+#   cd ~/acp/ansible
+#   ansible-playbook playbooks/amwa-plant.yml            # converge
+#   ansible-playbook playbooks/amwa-plant.yml            # again -> 0 changes
+#   ansible-playbook playbooks/amwa-plant.yml -e dhs_amwa_plant_scale_count=0
+#
+# The binary is built from COMMITTED source on the Go-capable build
+# host (dhs-tools) and deployed to the plant host; a redeploy after a
+# merge is one idempotent run, and every score/render names a commit.
+
+- name: AMWA lab plant — registry + node fleet
+  hosts: dhs-debian
+  gather_facts: true
+  roles:
+    - role: dhs_amwa_plant

--- a/ansible/roles/dhs_amwa_plant/defaults/main.yml
+++ b/ansible/roles/dhs_amwa_plant/defaults/main.yml
@@ -1,0 +1,46 @@
+---
+# dhs_amwa_plant — the standing AMWA lab plant on the control host:
+# one NMOS registry plus a fleet of dhs nodes, all managed as systemd
+# units. Replaces the hand-launched /tmp/*.sh scripts (issue #871):
+# provisioning + run is Ansible only, per the project rule.
+
+# Where the binary and node bundles live on the plant host.
+dhs_amwa_plant_dir: /opt/dhs-amwa-plant
+dhs_amwa_plant_bin: "{{ dhs_amwa_plant_dir }}/dhs"
+
+# The plant host has no Go toolchain, so the binary is built on a
+# Go-capable host and copied over. Both are inventory hostnames.
+dhs_amwa_plant_build_host: dhs-tools
+dhs_amwa_plant_go: /usr/local/go/bin/go
+
+# The registry the whole plant registers into.
+dhs_amwa_plant_registry_bind: ":8235"
+dhs_amwa_plant_registry_port: 8235
+dhs_amwa_plant_registry_page_limit: 1000
+
+# The registry + node advertise address is the plant host's own
+# VLAN600 IP (resolved at run time from the inventory ansible_host).
+dhs_amwa_plant_advertise_ip: "{{ ansible_host }}"
+
+# Resident nodes served from committed fixtures. Each entry:
+#   name   -> systemd instance + advertise label
+#   port   -> HTTP bind/advertise port
+#   config -> bundle filename under files/ (rendered into the plant dir)
+dhs_amwa_plant_nodes:
+  - name: test-node
+    port: 18080
+    config: amwa-test-node.json
+  - name: is11-node
+    port: 18400
+    config: amwa-test-node.json
+
+# Generated scale nodes: count + base port. node<i> serves on
+# base_port + i, advertise host:port, registers into the registry.
+dhs_amwa_plant_scale_count: 20
+dhs_amwa_plant_scale_base_port: 18200
+
+# IS-04 wire version every node + the registry serve on the fleet.
+dhs_amwa_plant_api_ver: v1.3
+
+# Seconds to let the plant settle before the registration check.
+dhs_amwa_plant_settle: 15

--- a/ansible/roles/dhs_amwa_plant/files/amwa-test-node.json
+++ b/ansible/roles/dhs_amwa_plant/files/amwa-test-node.json
@@ -1,0 +1,867 @@
+{
+  "node": {
+    "id": "2c47bf5e-1b2c-4abc-9def-deadbeef0001",
+    "version": "1777651501:0",
+    "label": "dhs-test-node",
+    "description": "dhs Phase 2 - AMWA NMOS Testing harness (full bundle)",
+    "tags": {
+      "urn:x-nmos:tag:asset:manufacturer/v1.0": [
+        "BY-SYSTEMS"
+      ],
+      "urn:x-nmos:tag:asset:product/v1.0": [
+        "dhs"
+      ],
+      "urn:x-nmos:tag:asset:instance-id/v1.0": [
+        "2c47bf5e-1b2c-4abc-9def-deadbeef0001"
+      ],
+      "urn:x-nmos:tag:asset:function/v1.0": [
+        "NMOS Node"
+      ]
+    },
+    "href": "http://127.0.0.1:18080/",
+    "caps": {},
+    "api": {
+      "versions": [
+        "v1.0",
+        "v1.1",
+        "v1.2",
+        "v1.3"
+      ],
+      "endpoints": []
+    },
+    "services": [],
+    "clocks": [
+      {
+        "name": "clk0",
+        "ref_type": "internal"
+      }
+    ],
+    "interfaces": [
+      {
+        "chassis_id": "ff-ff-ff-ff-ff-ff",
+        "port_id": "ff-ff-ff-ff-ff-ff",
+        "name": "eth0",
+        "attached_network_device": {
+          "chassis_id": "00-11-22-33-44-55",
+          "port_id": "00-11-22-33-44-66"
+        }
+      }
+    ],
+    "hostname": "dhs-test-node"
+  },
+  "devices": [
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "version": "1777651501:0",
+      "label": "dhs-test-device",
+      "description": "single device under dhs-test-node",
+      "tags": {
+        "urn:x-nmos:tag:asset:manufacturer/v1.0": [
+          "BY-SYSTEMS"
+        ],
+        "urn:x-nmos:tag:asset:product/v1.0": [
+          "dhs"
+        ],
+        "urn:x-nmos:tag:asset:instance-id/v1.0": [
+          "2c47bf5e-1b2c-4abc-9def-deadbeef0002"
+        ],
+        "urn:x-nmos:tag:asset:function/v1.0": [
+          "audio-bridge"
+        ]
+      },
+      "type": "urn:x-nmos:device:generic",
+      "node_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0001",
+      "senders": [
+        "2c47bf5e-1b2c-4abc-9def-deadbeef0005",
+        "2c47bf5e-1b2c-4abc-9def-deadbeef0009",
+        "2c47bf5e-1b2c-4abc-9def-deadcfff000a",
+        "2c47bf5e-1b2c-4abc-9def-deadcfff000b",
+        "2c47bf5e-1b2c-4abc-9def-deadcfff000c",
+        "2c47bf5e-1b2c-4abc-9def-deadcfff000d",
+        "2c47bf5e-1b2c-4abc-9def-deadcfff000e",
+        "2c47bf5e-1b2c-4abc-9def-deadbeef0023",
+        "2c47bf5e-1b2c-4abc-9def-deadbeef0025"
+      ],
+      "receivers": [
+        "2c47bf5e-1b2c-4abc-9def-deadbeef0006",
+        "2c47bf5e-1b2c-4abc-9def-deadbeef0024",
+        "2c47bf5e-1b2c-4abc-9def-deadbeef0028"
+      ],
+      "controls": []
+    }
+  ],
+  "sources": [
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef0003",
+      "version": "1777651501:0",
+      "label": "dhs-test-source-audio",
+      "description": "stereo audio source",
+      "tags": {},
+      "caps": {},
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "parents": [],
+      "clock_name": "clk0",
+      "format": "urn:x-nmos:format:audio",
+      "channels": [
+        {
+          "label": "Left",
+          "symbol": "L"
+        },
+        {
+          "label": "Right",
+          "symbol": "R"
+        }
+      ]
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef0007",
+      "version": "1777651501:0",
+      "label": "dhs-test-source-tally",
+      "description": "camera 1 tally",
+      "tags": {},
+      "caps": {},
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "parents": [],
+      "clock_name": "clk0",
+      "format": "urn:x-nmos:format:data",
+      "event_type": "boolean"
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef000a",
+      "version": "1777651501:0",
+      "label": "dhs-test-source-fader",
+      "description": "fader position",
+      "tags": {},
+      "caps": {},
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "parents": [],
+      "clock_name": "clk0",
+      "format": "urn:x-nmos:format:data",
+      "event_type": "number"
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef000b",
+      "version": "1777651501:0",
+      "label": "dhs-test-source-label",
+      "description": "camera label",
+      "tags": {},
+      "caps": {},
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "parents": [],
+      "clock_name": "clk0",
+      "format": "urn:x-nmos:format:data",
+      "event_type": "string"
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef000c",
+      "version": "1777651501:0",
+      "label": "dhs-test-source-tally-enum",
+      "description": "tally with named states",
+      "tags": {},
+      "caps": {},
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "parents": [],
+      "clock_name": "clk0",
+      "format": "urn:x-nmos:format:data",
+      "event_type": "boolean"
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef000d",
+      "version": "1777651501:0",
+      "label": "dhs-test-source-preset-enum",
+      "description": "preset-enum",
+      "tags": {},
+      "caps": {},
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "parents": [],
+      "clock_name": "clk0",
+      "format": "urn:x-nmos:format:data",
+      "event_type": "number"
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef000e",
+      "version": "1777651501:0",
+      "label": "dhs-test-source-camera-enum",
+      "description": "camera-enum",
+      "tags": {},
+      "caps": {},
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "parents": [],
+      "clock_name": "clk0",
+      "format": "urn:x-nmos:format:data",
+      "event_type": "string"
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef0021",
+      "version": "1777651501:0",
+      "label": "dhs-source-min",
+      "description": "Required-fields-only audio source backing the min sender",
+      "tags": {},
+      "caps": {},
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "parents": [],
+      "clock_name": "clk0",
+      "format": "urn:x-nmos:format:audio",
+      "channels": [
+        {
+          "label": "Left",
+          "symbol": "L"
+        },
+        {
+          "label": "Right",
+          "symbol": "R"
+        }
+      ]
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef0027",
+      "version": "1777651501:0",
+      "label": "dhs-source-full",
+      "description": "Fully-populated audio source backing the full sender",
+      "tags": {},
+      "caps": {},
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "parents": [],
+      "clock_name": "clk0",
+      "format": "urn:x-nmos:format:audio",
+      "channels": [
+        {
+          "label": "Left",
+          "symbol": "L"
+        },
+        {
+          "label": "Right",
+          "symbol": "R"
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef0004",
+      "version": "1777651501:0",
+      "label": "dhs-test-flow-audio-l24",
+      "description": "audio L24 48kHz stereo",
+      "tags": {},
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "source_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0003",
+      "parents": [],
+      "format": "urn:x-nmos:format:audio",
+      "media_type": "audio/L24",
+      "sample_rate": {
+        "numerator": 48000,
+        "denominator": 1
+      },
+      "bit_depth": 24
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef0008",
+      "version": "1777651501:0",
+      "label": "dhs-test-flow-tally",
+      "description": "tally events",
+      "tags": {},
+      "source_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0007",
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "parents": [],
+      "format": "urn:x-nmos:format:data",
+      "media_type": "application/json",
+      "event_type": "boolean"
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbfff000a",
+      "version": "1777651501:0",
+      "label": "dhs-test-source-fader-flow",
+      "description": "fader position",
+      "tags": {},
+      "source_id": "2c47bf5e-1b2c-4abc-9def-deadbeef000a",
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "parents": [],
+      "format": "urn:x-nmos:format:data",
+      "media_type": "application/json",
+      "event_type": "number"
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbfff000b",
+      "version": "1777651501:0",
+      "label": "dhs-test-source-label-flow",
+      "description": "camera label",
+      "tags": {},
+      "source_id": "2c47bf5e-1b2c-4abc-9def-deadbeef000b",
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "parents": [],
+      "format": "urn:x-nmos:format:data",
+      "media_type": "application/json",
+      "event_type": "string"
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbfff000c",
+      "version": "1777651501:0",
+      "label": "dhs-test-source-tally-enum-flow",
+      "description": "tally with named states",
+      "tags": {},
+      "source_id": "2c47bf5e-1b2c-4abc-9def-deadbeef000c",
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "parents": [],
+      "format": "urn:x-nmos:format:data",
+      "media_type": "application/json",
+      "event_type": "boolean"
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbfff000d",
+      "version": "1777651501:0",
+      "label": "dhs-test-flow-preset-enum",
+      "description": "preset-enum",
+      "tags": {},
+      "source_id": "2c47bf5e-1b2c-4abc-9def-deadbeef000d",
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "parents": [],
+      "format": "urn:x-nmos:format:data",
+      "media_type": "application/json",
+      "event_type": "number"
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbfff000e",
+      "version": "1777651501:0",
+      "label": "dhs-test-flow-camera-enum",
+      "description": "camera-enum",
+      "tags": {},
+      "source_id": "2c47bf5e-1b2c-4abc-9def-deadbeef000e",
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "parents": [],
+      "format": "urn:x-nmos:format:data",
+      "media_type": "application/json",
+      "event_type": "string"
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef0022",
+      "version": "1777651501:0",
+      "label": "dhs-flow-min",
+      "description": "Required-fields-only audio flow backing the min sender",
+      "tags": {},
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "source_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0021",
+      "parents": [],
+      "format": "urn:x-nmos:format:audio",
+      "media_type": "audio/L24",
+      "sample_rate": {
+        "numerator": 48000,
+        "denominator": 1
+      },
+      "bit_depth": 24
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef0026",
+      "version": "1777651501:0",
+      "label": "dhs-flow-full",
+      "description": "Fully-populated audio flow backing the full sender",
+      "tags": {},
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "source_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0027",
+      "parents": [],
+      "format": "urn:x-nmos:format:audio",
+      "media_type": "audio/L24",
+      "sample_rate": {
+        "numerator": 48000,
+        "denominator": 1
+      },
+      "bit_depth": 24
+    }
+  ],
+  "senders": [
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef0005",
+      "version": "1777651501:0",
+      "label": "dhs-test-sender-rtp",
+      "description": "RTP unicast sender carrying the audio L24 flow",
+      "tags": {
+        "urn:x-nmos:tag:grouphint/v1.0": [
+          "dhs-test-group:sender-1"
+        ]
+      },
+      "flow_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0004",
+      "transport": "urn:x-nmos:transport:rtp.ucast",
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "manifest_href": "http://dhs-node:18080/x-nmos/node/v1.3/senders/2c47bf5e-1b2c-4abc-9def-deadbeef0005/transportfile",
+      "interface_bindings": [
+        "eth0"
+      ],
+      "caps": {},
+      "subscription": {
+        "receiver_id": null,
+        "active": false
+      }
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef0009",
+      "version": "1777651501:0",
+      "label": "dhs-test-sender-tally",
+      "description": "tally over websocket",
+      "tags": {},
+      "flow_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0008",
+      "transport": "urn:x-nmos:transport:websocket",
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "manifest_href": null,
+      "interface_bindings": [
+        "eth0"
+      ],
+      "subscription": {
+        "receiver_id": null,
+        "active": false
+      }
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadcfff000a",
+      "version": "1777651501:0",
+      "label": "dhs-test-source-fader-sender",
+      "description": "fader position over websocket",
+      "tags": {},
+      "flow_id": "2c47bf5e-1b2c-4abc-9def-deadbfff000a",
+      "transport": "urn:x-nmos:transport:websocket",
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "manifest_href": null,
+      "interface_bindings": [
+        "eth0"
+      ],
+      "subscription": {
+        "receiver_id": null,
+        "active": false
+      }
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadcfff000b",
+      "version": "1777651501:0",
+      "label": "dhs-test-source-label-sender",
+      "description": "camera label over websocket",
+      "tags": {},
+      "flow_id": "2c47bf5e-1b2c-4abc-9def-deadbfff000b",
+      "transport": "urn:x-nmos:transport:websocket",
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "manifest_href": null,
+      "interface_bindings": [
+        "eth0"
+      ],
+      "subscription": {
+        "receiver_id": null,
+        "active": false
+      }
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadcfff000c",
+      "version": "1777651501:0",
+      "label": "dhs-test-source-tally-enum-sender",
+      "description": "tally with named states over websocket",
+      "tags": {},
+      "flow_id": "2c47bf5e-1b2c-4abc-9def-deadbfff000c",
+      "transport": "urn:x-nmos:transport:websocket",
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "manifest_href": null,
+      "interface_bindings": [
+        "eth0"
+      ],
+      "subscription": {
+        "receiver_id": null,
+        "active": false
+      }
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadcfff000d",
+      "version": "1777651501:0",
+      "label": "dhs-test-sender-preset-enum",
+      "description": "preset-enum over websocket",
+      "tags": {},
+      "flow_id": "2c47bf5e-1b2c-4abc-9def-deadbfff000d",
+      "transport": "urn:x-nmos:transport:websocket",
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "manifest_href": null,
+      "interface_bindings": [
+        "eth0"
+      ],
+      "subscription": {
+        "receiver_id": null,
+        "active": false
+      }
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadcfff000e",
+      "version": "1777651501:0",
+      "label": "dhs-test-sender-camera-enum",
+      "description": "camera-enum over websocket",
+      "tags": {},
+      "flow_id": "2c47bf5e-1b2c-4abc-9def-deadbfff000e",
+      "transport": "urn:x-nmos:transport:websocket",
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "manifest_href": null,
+      "interface_bindings": [
+        "eth0"
+      ],
+      "subscription": {
+        "receiver_id": null,
+        "active": false
+      }
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef0023",
+      "version": "1777651501:0",
+      "label": "dhs-sender-min",
+      "description": "MIN archetype: only the fields sender.json requires, no caps, no tags, IS-05 factory-fresh (master_enable=false, params unset)",
+      "tags": {},
+      "flow_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0022",
+      "transport": "urn:x-nmos:transport:rtp.mcast",
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "manifest_href": "http://dhs-node:18080/x-nmos/node/v1.3/senders/2c47bf5e-1b2c-4abc-9def-deadbeef0023/transportfile",
+      "interface_bindings": [
+        "eth0"
+      ],
+      "subscription": {
+        "receiver_id": null,
+        "active": false
+      }
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef0025",
+      "version": "1777651501:0",
+      "label": "dhs-sender-full",
+      "description": "FULL archetype: every optional field, grouphint, caps, boot-ACTIVE ST 2022-7 pair on 239.20.1.1/239.22.1.1:5004 with SDP",
+      "tags": {
+        "urn:x-nmos:tag:grouphint/v1.0": [
+          "dhs-full-group:sender-full"
+        ]
+      },
+      "flow_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0026",
+      "transport": "urn:x-nmos:transport:rtp.mcast",
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "manifest_href": "http://dhs-node:18080/x-nmos/node/v1.3/senders/2c47bf5e-1b2c-4abc-9def-deadbeef0025/transportfile",
+      "interface_bindings": [
+        "eth0",
+        "eth0"
+      ],
+      "caps": {},
+      "subscription": {
+        "receiver_id": null,
+        "active": true
+      }
+    }
+  ],
+  "receivers": [
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef0006",
+      "version": "1777651501:0",
+      "label": "dhs-test-receiver-audio",
+      "description": "RTP audio receiver",
+      "tags": {
+        "urn:x-nmos:tag:grouphint/v1.0": [
+          "dhs-test-group:receiver-1"
+        ]
+      },
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "transport": "urn:x-nmos:transport:rtp",
+      "interface_bindings": [
+        "eth0"
+      ],
+      "format": "urn:x-nmos:format:audio",
+      "caps": {
+        "media_types": [
+          "audio/L24",
+          "audio/L16"
+        ],
+        "version": "1777651501:0",
+        "constraint_sets": [
+          {
+            "urn:x-nmos:cap:meta:label": "L24 / L16 audio @ 48 kHz, stereo",
+            "urn:x-nmos:cap:meta:preference": 100,
+            "urn:x-nmos:cap:meta:enabled": true,
+            "urn:x-nmos:cap:format:media_type": {
+              "enum": [
+                "audio/L24",
+                "audio/L16"
+              ]
+            },
+            "urn:x-nmos:cap:format:sample_rate": {
+              "enum": [
+                {
+                  "numerator": 48000,
+                  "denominator": 1
+                }
+              ]
+            },
+            "urn:x-nmos:cap:format:channel_count": {
+              "minimum": 2,
+              "maximum": 2
+            }
+          },
+          {
+            "urn:x-nmos:cap:meta:label": "44.1 kHz L16 (disabled)",
+            "urn:x-nmos:cap:meta:preference": 0,
+            "urn:x-nmos:cap:meta:enabled": false,
+            "urn:x-nmos:cap:format:media_type": {
+              "enum": [
+                "audio/L16"
+              ]
+            },
+            "urn:x-nmos:cap:format:sample_rate": {
+              "enum": [
+                {
+                  "numerator": 44100,
+                  "denominator": 1
+                }
+              ]
+            },
+            "urn:x-nmos:cap:format:channel_count": {
+              "minimum": 2,
+              "maximum": 2
+            }
+          }
+        ]
+      },
+      "subscription": {
+        "sender_id": null,
+        "active": false
+      }
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef0024",
+      "version": "1777651501:0",
+      "label": "dhs-receiver-min",
+      "description": "MIN archetype: only required fields, caps limited to media_types, IS-05 factory-fresh",
+      "tags": {},
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "transport": "urn:x-nmos:transport:rtp",
+      "interface_bindings": [
+        "eth0"
+      ],
+      "format": "urn:x-nmos:format:audio",
+      "caps": {
+        "media_types": [
+          "audio/L24",
+          "audio/L16"
+        ]
+      },
+      "subscription": {
+        "sender_id": null,
+        "active": false
+      }
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef0028",
+      "version": "1777651501:0",
+      "label": "dhs-receiver-full",
+      "description": "FULL archetype: BCP-004-01 constraint_sets, grouphint, boot-ACTIVE join of 239.20.1.1:5004",
+      "tags": {
+        "urn:x-nmos:tag:grouphint/v1.0": [
+          "dhs-full-group:receiver-full"
+        ]
+      },
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "transport": "urn:x-nmos:transport:rtp",
+      "interface_bindings": [
+        "eth0"
+      ],
+      "format": "urn:x-nmos:format:audio",
+      "caps": {
+        "media_types": [
+          "audio/L24",
+          "audio/L16"
+        ],
+        "version": "1777651501:0",
+        "constraint_sets": [
+          {
+            "urn:x-nmos:cap:meta:label": "L24 / L16 audio @ 48 kHz, stereo",
+            "urn:x-nmos:cap:meta:preference": 100,
+            "urn:x-nmos:cap:meta:enabled": true,
+            "urn:x-nmos:cap:format:media_type": {
+              "enum": [
+                "audio/L24",
+                "audio/L16"
+              ]
+            },
+            "urn:x-nmos:cap:format:sample_rate": {
+              "enum": [
+                {
+                  "numerator": 48000,
+                  "denominator": 1
+                }
+              ]
+            },
+            "urn:x-nmos:cap:format:channel_count": {
+              "minimum": 2,
+              "maximum": 2
+            }
+          },
+          {
+            "urn:x-nmos:cap:meta:label": "44.1 kHz L16 (disabled)",
+            "urn:x-nmos:cap:meta:preference": 0,
+            "urn:x-nmos:cap:meta:enabled": false,
+            "urn:x-nmos:cap:format:media_type": {
+              "enum": [
+                "audio/L16"
+              ]
+            },
+            "urn:x-nmos:cap:format:sample_rate": {
+              "enum": [
+                {
+                  "numerator": 44100,
+                  "denominator": 1
+                }
+              ]
+            },
+            "urn:x-nmos:cap:format:channel_count": {
+              "minimum": 2,
+              "maximum": 2
+            }
+          }
+        ]
+      },
+      "subscription": {
+        "sender_id": null,
+        "active": true
+      }
+    }
+  ],
+  "event_types": {
+    "2c47bf5e-1b2c-4abc-9def-deadbeef0007": {
+      "type": "boolean"
+    },
+    "2c47bf5e-1b2c-4abc-9def-deadbeef000a": {
+      "type": "number",
+      "min": {
+        "value": -60,
+        "scale": 1
+      },
+      "max": {
+        "value": 10,
+        "scale": 1
+      },
+      "step": {
+        "value": 1,
+        "scale": 1
+      },
+      "unit": "dB"
+    },
+    "2c47bf5e-1b2c-4abc-9def-deadbeef000b": {
+      "type": "string",
+      "min_length": 0,
+      "max_length": 16
+    },
+    "2c47bf5e-1b2c-4abc-9def-deadbeef000c": {
+      "type": "boolean",
+      "values": [
+        {
+          "value": true,
+          "label": "Program",
+          "description": "camera is on air"
+        },
+        {
+          "value": false,
+          "label": "Off",
+          "description": "camera is not on air"
+        }
+      ]
+    },
+    "2c47bf5e-1b2c-4abc-9def-deadbeef000d": {
+      "type": "number",
+      "values": [
+        {
+          "value": 1,
+          "label": "Wide",
+          "description": "wide shot preset"
+        },
+        {
+          "value": 2,
+          "label": "Tight",
+          "description": "tight shot preset"
+        }
+      ]
+    },
+    "2c47bf5e-1b2c-4abc-9def-deadbeef000e": {
+      "type": "string",
+      "values": [
+        {
+          "value": "CAM1",
+          "label": "Camera 1",
+          "description": "studio camera 1"
+        },
+        {
+          "value": "CAM2",
+          "label": "Camera 2",
+          "description": "studio camera 2"
+        }
+      ]
+    }
+  },
+  "connection": {
+    "senders": {
+      "2c47bf5e-1b2c-4abc-9def-deadbeef0025": {
+        "master_enable": true,
+        "transport_params": [
+          {
+            "rtp_enabled": true,
+            "destination_ip": "239.20.1.1",
+            "destination_port": 5004
+          },
+          {
+            "rtp_enabled": true,
+            "destination_ip": "239.22.1.1",
+            "destination_port": 5004
+          }
+        ]
+      }
+    },
+    "receivers": {
+      "2c47bf5e-1b2c-4abc-9def-deadbeef0028": {
+        "master_enable": true,
+        "transport_params": [
+          {
+            "rtp_enabled": true,
+            "multicast_ip": "239.20.1.1",
+            "destination_port": 5004,
+            "interface_ip": "auto"
+          }
+        ]
+      }
+    }
+  },
+  "stream_compatibility": {
+    "inputs": [
+      {
+        "id": "aaaa1111-0000-4000-8000-000000000001",
+        "version": "1:0",
+        "label": "dhs-input-sdi-1",
+        "description": "reference SDI input for IS-11",
+        "tags": {},
+        "base_edid_support": true,
+        "connected": true,
+        "edid_support": true,
+        "adjust_to_caps": false,
+        "status": {
+          "state": "signal_present"
+        },
+        "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002"
+      }
+    ],
+    "outputs": [
+      {
+        "id": "bbbb2222-0000-4000-8000-000000000001",
+        "version": "1:0",
+        "label": "dhs-output-hdmi-1",
+        "description": "reference HDMI output for IS-11",
+        "tags": {},
+        "connected": true,
+        "edid_support": false,
+        "status": {
+          "state": "no_signal"
+        },
+        "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002"
+      }
+    ],
+    "sender_inputs": {
+      "2c47bf5e-1b2c-4abc-9def-deadbeef0025": [
+        "aaaa1111-0000-4000-8000-000000000001"
+      ]
+    },
+    "receiver_outputs": {
+      "2c47bf5e-1b2c-4abc-9def-deadbeef0024": [
+        "bbbb2222-0000-4000-8000-000000000001"
+      ]
+    }
+  }
+}

--- a/ansible/roles/dhs_amwa_plant/meta/main.yml
+++ b/ansible/roles/dhs_amwa_plant/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  role_name: dhs_amwa_plant
+  author: by-rune
+  description: >-
+    The standing AMWA lab plant: one dhs NMOS registry plus a fleet of
+    dhs nodes (resident fixtures + generated scale instances), all run
+    as systemd units on the control host. Builds the binary from
+    committed source on a Go-capable host, deploys it, templates the
+    units, and verifies every node registered. Idempotent — replaces
+    the hand-launched /tmp/*.sh plant scripts (issue #871).
+  license: see repository
+  min_ansible_version: "2.14"
+  platforms:
+    - name: Debian
+      versions: [all]
+    - name: Ubuntu
+      versions: [all]
+dependencies: []

--- a/ansible/roles/dhs_amwa_plant/tasks/main.yml
+++ b/ansible/roles/dhs_amwa_plant/tasks/main.yml
@@ -1,0 +1,207 @@
+---
+# Converge the AMWA lab plant: build the binary on a Go host, deploy
+# it + the node bundles to the plant host, and run the registry and
+# every node as systemd units. Idempotent — run-twice = 0 changes.
+
+# ---- 1. Build the binary on the Go-capable host from COMMITTED source
+
+- name: Archive the tracked source (assets/testdata/docs dropped — none compiles)
+  ansible.builtin.shell:
+    cmd: >-
+      git ls-files -z
+      | grep -zZv -e '^internal/[^/]*/assets/' -e 'testdata/' -e '^docs/' -e '^captures/' -e '^tests/integration/nmos/amwa/results/'
+      | tar --null -T - -czf /tmp/dhs-plant-src.tgz
+    chdir: "{{ playbook_dir }}/../.."
+  delegate_to: localhost
+  run_once: true
+  changed_when: true
+
+- name: Record the commit being deployed
+  ansible.builtin.command:
+    cmd: git rev-parse HEAD
+    chdir: "{{ playbook_dir }}/../.."
+  register: dhs_amwa_plant_commit
+  delegate_to: localhost
+  run_once: true
+  changed_when: false
+
+- name: Stage the build directory on the build host (wiped first)
+  ansible.builtin.file:
+    path: /opt/dhs-plant-build
+    state: "{{ item }}"
+    mode: "0755"
+  loop: [absent, directory]
+  delegate_to: "{{ dhs_amwa_plant_build_host }}"
+  run_once: true
+
+- name: Ship + unpack the source on the build host
+  ansible.builtin.unarchive:
+    src: /tmp/dhs-plant-src.tgz
+    dest: /opt/dhs-plant-build
+  delegate_to: "{{ dhs_amwa_plant_build_host }}"
+  run_once: true
+
+- name: Build the linux binary on the build host
+  ansible.builtin.command:
+    cmd: "{{ dhs_amwa_plant_go }} build -trimpath -o /opt/dhs-plant-build/dhs ./cmd/dhs"
+    chdir: /opt/dhs-plant-build
+  environment:
+    CGO_ENABLED: "0"
+    GOOS: linux
+  delegate_to: "{{ dhs_amwa_plant_build_host }}"
+  run_once: true
+  changed_when: true
+
+- name: Fetch the built binary to the controller
+  ansible.builtin.fetch:
+    src: /opt/dhs-plant-build/dhs
+    dest: /tmp/dhs-plant-bin
+    flat: true
+  delegate_to: "{{ dhs_amwa_plant_build_host }}"
+  run_once: true
+
+# ---- 2. Deploy binary + node bundles to the plant host
+
+- name: Create the plant directory
+  ansible.builtin.file:
+    path: "{{ dhs_amwa_plant_dir }}/scale"
+    state: directory
+    mode: "0755"
+
+- name: Install the dhs binary
+  ansible.builtin.copy:
+    src: /tmp/dhs-plant-bin
+    dest: "{{ dhs_amwa_plant_bin }}"
+    mode: "0755"
+  register: dhs_amwa_plant_bincopy
+
+- name: Install the resident node bundles
+  ansible.builtin.copy:
+    src: "{{ item.config }}"
+    dest: "{{ dhs_amwa_plant_dir }}/{{ item.config }}"
+    mode: "0644"
+  loop: "{{ dhs_amwa_plant_nodes }}"
+  loop_control:
+    label: "{{ item.name }}"
+  register: dhs_amwa_plant_bundles
+
+- name: Generate the scale node bundles
+  ansible.builtin.template:
+    src: scale-node.json.j2
+    dest: "{{ dhs_amwa_plant_dir }}/scale/node{{ item }}.json"
+    mode: "0644"
+  loop: "{{ range(0, dhs_amwa_plant_scale_count) | list }}"
+  loop_control:
+    label: "node{{ item }}"
+  register: dhs_amwa_plant_scalecfgs
+
+# ---- 3. systemd units — registry, resident nodes, scale nodes
+
+- name: Install the registry unit
+  ansible.builtin.template:
+    src: dhs-nmos-registry.service.j2
+    dest: /etc/systemd/system/dhs-nmos-registry.service
+    mode: "0644"
+  register: dhs_amwa_plant_regunit
+
+- name: Install the resident node units
+  ansible.builtin.template:
+    src: dhs-nmos-node.service.j2
+    dest: "/etc/systemd/system/dhs-nmos-{{ item.name }}.service"
+    mode: "0644"
+  vars:
+    node_name: "{{ item.name }}"
+    node_port: "{{ item.port }}"
+    node_config: "{{ dhs_amwa_plant_dir }}/{{ item.config }}"
+  loop: "{{ dhs_amwa_plant_nodes }}"
+  loop_control:
+    label: "{{ item.name }}"
+  register: dhs_amwa_plant_nodeunits
+
+- name: Install the scale node units
+  ansible.builtin.template:
+    src: dhs-nmos-node.service.j2
+    dest: "/etc/systemd/system/dhs-nmos-scale{{ item }}.service"
+    mode: "0644"
+  vars:
+    node_name: "scale{{ item }}"
+    node_port: "{{ dhs_amwa_plant_scale_base_port + item }}"
+    node_config: "{{ dhs_amwa_plant_dir }}/scale/node{{ item }}.json"
+  loop: "{{ range(0, dhs_amwa_plant_scale_count) | list }}"
+  loop_control:
+    label: "scale{{ item }}"
+  register: dhs_amwa_plant_scaleunits
+
+- name: Reload systemd when any unit changed
+  ansible.builtin.systemd:
+    daemon_reload: true
+  when: >-
+    dhs_amwa_plant_regunit is changed
+    or dhs_amwa_plant_nodeunits is changed
+    or dhs_amwa_plant_scaleunits is changed
+
+# One-time migration: the plant used to run as hand-launched
+# /tmp/dhs-main processes (the pre-Ansible era, issue #871). They bind
+# the same ports as the units about to start, so stop any that survive.
+# Not a driver script — a convergence guard: rc 0 = something was
+# killed (changed), rc 1 = nothing to kill (ok).
+- name: Stop any legacy hand-launched plant processes
+  ansible.builtin.command: pkill -f '^/tmp/dhs-main'
+  register: dhs_amwa_plant_legacy
+  changed_when: dhs_amwa_plant_legacy.rc == 0
+  failed_when: dhs_amwa_plant_legacy.rc not in [0, 1]
+
+# The registry starts first and is RESTARTED (not just started) when
+# the binary or its unit changed, so a new build actually takes over.
+- name: Enable + start the registry
+  ansible.builtin.systemd:
+    name: dhs-nmos-registry.service
+    enabled: true
+    state: "{{ 'restarted' if (dhs_amwa_plant_bincopy is changed or dhs_amwa_plant_regunit is changed) else 'started' }}"
+
+- name: Give the registry a moment before the nodes register
+  ansible.builtin.wait_for:
+    port: "{{ dhs_amwa_plant_registry_port }}"
+    host: 127.0.0.1
+    timeout: 30
+
+- name: Enable + start every node (restart on binary/unit/config change)
+  ansible.builtin.systemd:
+    name: "dhs-nmos-{{ item }}.service"
+    enabled: true
+    state: "{{ 'restarted' if dhs_amwa_plant_restart else 'started' }}"
+  vars:
+    dhs_amwa_plant_restart: >-
+      {{ dhs_amwa_plant_bincopy is changed
+         or dhs_amwa_plant_nodeunits is changed
+         or dhs_amwa_plant_scaleunits is changed
+         or dhs_amwa_plant_bundles is changed
+         or dhs_amwa_plant_scalecfgs is changed }}
+  loop: "{{ (dhs_amwa_plant_nodes | map(attribute='name') | list)
+            + (range(0, dhs_amwa_plant_scale_count) | map('regex_replace', '^', 'scale') | list) }}"
+
+# ---- 4. Verify the plant converged
+
+- name: Let the fleet register
+  ansible.builtin.wait_for:
+    timeout: "{{ dhs_amwa_plant_settle }}"
+
+- name: Count registered nodes
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ dhs_amwa_plant_registry_port }}/x-nmos/query/{{ dhs_amwa_plant_api_ver }}/nodes?paging.limit=300"
+    return_content: true
+  register: dhs_amwa_plant_nodes_seen
+  until: >-
+    (dhs_amwa_plant_nodes_seen.json | default([]) | length)
+    >= (dhs_amwa_plant_nodes | length + dhs_amwa_plant_scale_count)
+  retries: 6
+  delay: 5
+
+- name: Report the plant state
+  ansible.builtin.debug:
+    msg: >-
+      AMWA plant on {{ ansible_host }} @ {{ dhs_amwa_plant_commit.stdout[:8] }}:
+      registry :{{ dhs_amwa_plant_registry_port }},
+      {{ dhs_amwa_plant_nodes_seen.json | length }} nodes registered
+      ({{ dhs_amwa_plant_nodes | length }} resident +
+      {{ dhs_amwa_plant_scale_count }} scale).

--- a/ansible/roles/dhs_amwa_plant/tasks/main.yml
+++ b/ansible/roles/dhs_amwa_plant/tasks/main.yml
@@ -4,22 +4,12 @@
 # every node as systemd units. Idempotent — run-twice = 0 changes.
 
 # ---- 1. Build the binary on the Go-capable host from COMMITTED source
-
-# testdata is dropped as a rule, but ms05/framework.go go:embeds the
-# MS-05-02 framework models under ms05/testdata/ — so that one tree
-# rides along or the build fails "no matching files found" (same
-# exception as the .dockerignore + the conformance role).
-- name: Archive the tracked source (assets/testdata/docs dropped — none compiles)
-  ansible.builtin.shell:
-    cmd: >-
-      { git ls-files -z
-      | grep -zZv -e '^internal/[^/]*/assets/' -e 'testdata/' -e '^docs/' -e '^captures/' -e '^tests/integration/nmos/amwa/results/' ;
-      git ls-files -z internal/amwa/codec/ms05/testdata/ ; }
-      | tar --null -T - -czf /tmp/dhs-plant-src.tgz
-    chdir: "{{ playbook_dir }}/../.."
-  delegate_to: localhost
-  run_once: true
-  changed_when: true
+#
+# The whole build+deploy is gated on the deployed commit: a converge
+# that finds the plant already on the current HEAD does no build, no
+# copy, no restart — that is what makes run-twice = 0 changes
+# (ADR-0025 #6). A new merge changes HEAD, the gate opens, and the
+# binary is rebuilt and rolled out.
 
 - name: Record the commit being deployed
   ansible.builtin.command:
@@ -30,40 +20,73 @@
   run_once: true
   changed_when: false
 
-- name: Stage the build directory on the build host (wiped first)
-  ansible.builtin.file:
-    path: /opt/dhs-plant-build
-    state: "{{ item }}"
-    mode: "0755"
-  loop: [absent, directory]
-  delegate_to: "{{ dhs_amwa_plant_build_host }}"
-  run_once: true
+- name: Read the commit currently deployed on the plant host
+  ansible.builtin.slurp:
+    src: "{{ dhs_amwa_plant_dir }}/.commit"
+  register: dhs_amwa_plant_deployed
+  failed_when: false
+  changed_when: false
 
-- name: Ship + unpack the source on the build host
-  ansible.builtin.unarchive:
-    src: /tmp/dhs-plant-src.tgz
-    dest: /opt/dhs-plant-build
-  delegate_to: "{{ dhs_amwa_plant_build_host }}"
-  run_once: true
+- name: Decide whether a (re)build is needed
+  ansible.builtin.set_fact:
+    dhs_amwa_plant_needs_build: >-
+      {{ (dhs_amwa_plant_deployed.content is not defined)
+         or ((dhs_amwa_plant_deployed.content | b64decode | trim)
+             != dhs_amwa_plant_commit.stdout) }}
 
-- name: Build the linux binary on the build host
-  ansible.builtin.command:
-    cmd: "{{ dhs_amwa_plant_go }} build -trimpath -o /opt/dhs-plant-build/dhs ./cmd/dhs"
-    chdir: /opt/dhs-plant-build
-  environment:
-    CGO_ENABLED: "0"
-    GOOS: linux
-  delegate_to: "{{ dhs_amwa_plant_build_host }}"
-  run_once: true
-  changed_when: true
+- name: Build + fetch the binary (only when the commit changed)
+  when: dhs_amwa_plant_needs_build
+  block:
+    # testdata is dropped as a rule, but ms05/framework.go go:embeds
+    # the MS-05-02 framework models under ms05/testdata/ — that one
+    # tree rides along or the build fails "no matching files found"
+    # (same exception as the .dockerignore + the conformance role).
+    - name: Archive the tracked source (assets/testdata/docs dropped — none compiles)
+      ansible.builtin.shell:
+        cmd: >-
+          { git ls-files -z
+          | grep -zZv -e '^internal/[^/]*/assets/' -e 'testdata/' -e '^docs/' -e '^captures/' -e '^tests/integration/nmos/amwa/results/' ;
+          git ls-files -z internal/amwa/codec/ms05/testdata/ ; }
+          | tar --null -T - -czf /tmp/dhs-plant-src.tgz
+        chdir: "{{ playbook_dir }}/../.."
+      delegate_to: localhost
+      run_once: true
+      changed_when: true
 
-- name: Fetch the built binary to the controller
-  ansible.builtin.fetch:
-    src: /opt/dhs-plant-build/dhs
-    dest: /tmp/dhs-plant-bin
-    flat: true
-  delegate_to: "{{ dhs_amwa_plant_build_host }}"
-  run_once: true
+    - name: Stage the build directory on the build host (wiped first)
+      ansible.builtin.file:
+        path: /opt/dhs-plant-build
+        state: "{{ item }}"
+        mode: "0755"
+      loop: [absent, directory]
+      delegate_to: "{{ dhs_amwa_plant_build_host }}"
+      run_once: true
+
+    - name: Ship + unpack the source on the build host
+      ansible.builtin.unarchive:
+        src: /tmp/dhs-plant-src.tgz
+        dest: /opt/dhs-plant-build
+      delegate_to: "{{ dhs_amwa_plant_build_host }}"
+      run_once: true
+
+    - name: Build the linux binary on the build host
+      ansible.builtin.command:
+        cmd: "{{ dhs_amwa_plant_go }} build -trimpath -o /opt/dhs-plant-build/dhs ./cmd/dhs"
+        chdir: /opt/dhs-plant-build
+      environment:
+        CGO_ENABLED: "0"
+        GOOS: linux
+      delegate_to: "{{ dhs_amwa_plant_build_host }}"
+      run_once: true
+      changed_when: true
+
+    - name: Fetch the built binary to the controller
+      ansible.builtin.fetch:
+        src: /opt/dhs-plant-build/dhs
+        dest: /tmp/dhs-plant-bin
+        flat: true
+      delegate_to: "{{ dhs_amwa_plant_build_host }}"
+      run_once: true
 
 # ---- 2. Deploy binary + node bundles to the plant host
 
@@ -73,12 +96,13 @@
     state: directory
     mode: "0755"
 
-- name: Install the dhs binary
+- name: Install the dhs binary (only when rebuilt)
   ansible.builtin.copy:
     src: /tmp/dhs-plant-bin
     dest: "{{ dhs_amwa_plant_bin }}"
     mode: "0755"
   register: dhs_amwa_plant_bincopy
+  when: dhs_amwa_plant_needs_build
 
 - name: Install the resident node bundles
   ansible.builtin.copy:
@@ -184,6 +208,15 @@
          or dhs_amwa_plant_scalecfgs is changed }}
   loop: "{{ (dhs_amwa_plant_nodes | map(attribute='name') | list)
             + (range(0, dhs_amwa_plant_scale_count) | map('regex_replace', '^', 'scale') | list) }}"
+
+# Stamp the deployed commit AFTER the fleet is (re)started, so a run
+# that failed part-way does not claim success and skip the retry.
+- name: Record the deployed commit
+  ansible.builtin.copy:
+    content: "{{ dhs_amwa_plant_commit.stdout }}\n"
+    dest: "{{ dhs_amwa_plant_dir }}/.commit"
+    mode: "0644"
+  when: dhs_amwa_plant_needs_build
 
 # ---- 4. Verify the plant converged
 

--- a/ansible/roles/dhs_amwa_plant/tasks/main.yml
+++ b/ansible/roles/dhs_amwa_plant/tasks/main.yml
@@ -5,11 +5,16 @@
 
 # ---- 1. Build the binary on the Go-capable host from COMMITTED source
 
+# testdata is dropped as a rule, but ms05/framework.go go:embeds the
+# MS-05-02 framework models under ms05/testdata/ — so that one tree
+# rides along or the build fails "no matching files found" (same
+# exception as the .dockerignore + the conformance role).
 - name: Archive the tracked source (assets/testdata/docs dropped — none compiles)
   ansible.builtin.shell:
     cmd: >-
-      git ls-files -z
-      | grep -zZv -e '^internal/[^/]*/assets/' -e 'testdata/' -e '^docs/' -e '^captures/' -e '^tests/integration/nmos/amwa/results/'
+      { git ls-files -z
+      | grep -zZv -e '^internal/[^/]*/assets/' -e 'testdata/' -e '^docs/' -e '^captures/' -e '^tests/integration/nmos/amwa/results/' ;
+      git ls-files -z internal/amwa/codec/ms05/testdata/ ; }
       | tar --null -T - -czf /tmp/dhs-plant-src.tgz
     chdir: "{{ playbook_dir }}/../.."
   delegate_to: localhost

--- a/ansible/roles/dhs_amwa_plant/templates/dhs-nmos-node.service.j2
+++ b/ansible/roles/dhs_amwa_plant/templates/dhs-nmos-node.service.j2
@@ -1,0 +1,20 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=dhs AMWA NMOS node {{ node_name }} (lab plant)
+After=dhs-nmos-registry.service
+Wants=dhs-nmos-registry.service
+
+[Service]
+Type=simple
+ExecStart={{ dhs_amwa_plant_bin }} producer nmos serve \
+  --bind 0.0.0.0:{{ node_port }} \
+  --no-mdns \
+  --registry http://{{ dhs_amwa_plant_advertise_ip }}:{{ dhs_amwa_plant_registry_port }} \
+  --advertise-host {{ dhs_amwa_plant_advertise_ip }}:{{ node_port }} \
+  --api-ver {{ dhs_amwa_plant_api_ver }} \
+  --config {{ node_config }}
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/dhs_amwa_plant/templates/dhs-nmos-registry.service.j2
+++ b/ansible/roles/dhs_amwa_plant/templates/dhs-nmos-registry.service.j2
@@ -1,0 +1,18 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=dhs AMWA NMOS registry (lab plant)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart={{ dhs_amwa_plant_bin }} registry nmos serve \
+  --bind {{ dhs_amwa_plant_registry_bind }} \
+  --advertise-host {{ dhs_amwa_plant_advertise_ip }}:{{ dhs_amwa_plant_registry_port }} \
+  --priority 0 \
+  --page-limit-default {{ dhs_amwa_plant_registry_page_limit }}
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/dhs_amwa_plant/templates/scale-node.json.j2
+++ b/ansible/roles/dhs_amwa_plant/templates/scale-node.json.j2
@@ -1,0 +1,87 @@
+{# One lean-but-valid IS-04 bundle per scale node. UUIDs are derived
+   from the loop index (unique per resource type + index); the
+   provider overwrites href / manifest_href from --advertise-host at
+   serve time, so the placeholders below only need to be well-formed. #}
+{%- set i = '%02d' % item -%}
+{
+  "node": {
+    "id": "aa000000-0000-4000-8000-0000000000{{ i }}",
+    "version": "1777651501:0",
+    "label": "dhs-scale-{{ i }}",
+    "description": "scale test instance {{ item }}",
+    "tags": {},
+    "href": "http://{{ dhs_amwa_plant_advertise_ip }}:{{ dhs_amwa_plant_scale_base_port + item }}/",
+    "caps": {},
+    "api": {"versions": ["{{ dhs_amwa_plant_api_ver }}"], "endpoints": []},
+    "services": [],
+    "clocks": [{"name": "clk0", "ref_type": "internal"}],
+    "interfaces": [{"chassis_id": "ff-ff-ff-ff-ff-ff", "port_id": "ff-ff-ff-ff-ff-ff", "name": "eth0"}],
+    "hostname": "dhs-scale-{{ i }}"
+  },
+  "devices": [{
+    "id": "bb000000-0000-4000-8000-0000000000{{ i }}",
+    "version": "1777651501:0",
+    "label": "dhs-scale-{{ i }}-dev",
+    "description": "single device",
+    "tags": {},
+    "type": "urn:x-nmos:device:generic",
+    "node_id": "aa000000-0000-4000-8000-0000000000{{ i }}",
+    "senders": ["ee000000-0000-4000-8000-0000000000{{ i }}"],
+    "receivers": ["ff000000-0000-4000-8000-0000000000{{ i }}"],
+    "controls": []
+  }],
+  "sources": [{
+    "id": "cc000000-0000-4000-8000-0000000000{{ i }}",
+    "version": "1777651501:0",
+    "label": "dhs-scale-{{ i }}-src",
+    "description": "stereo audio source",
+    "tags": {},
+    "caps": {},
+    "device_id": "bb000000-0000-4000-8000-0000000000{{ i }}",
+    "parents": [],
+    "clock_name": "clk0",
+    "format": "urn:x-nmos:format:audio",
+    "channels": [{"label": "Left", "symbol": "L"}, {"label": "Right", "symbol": "R"}]
+  }],
+  "flows": [{
+    "id": "dd000000-0000-4000-8000-0000000000{{ i }}",
+    "version": "1777651501:0",
+    "label": "dhs-scale-{{ i }}-flow",
+    "description": "audio L24 48kHz stereo",
+    "tags": {},
+    "device_id": "bb000000-0000-4000-8000-0000000000{{ i }}",
+    "source_id": "cc000000-0000-4000-8000-0000000000{{ i }}",
+    "parents": [],
+    "format": "urn:x-nmos:format:audio",
+    "media_type": "audio/L24",
+    "sample_rate": {"numerator": 48000, "denominator": 1},
+    "bit_depth": 24
+  }],
+  "senders": [{
+    "id": "ee000000-0000-4000-8000-0000000000{{ i }}",
+    "version": "1777651501:0",
+    "label": "dhs-scale-{{ i }}-sender",
+    "description": "RTP unicast sender",
+    "tags": {},
+    "flow_id": "dd000000-0000-4000-8000-0000000000{{ i }}",
+    "transport": "urn:x-nmos:transport:rtp.ucast",
+    "device_id": "bb000000-0000-4000-8000-0000000000{{ i }}",
+    "manifest_href": "http://{{ dhs_amwa_plant_advertise_ip }}:{{ dhs_amwa_plant_scale_base_port + item }}/x-nmos/node/{{ dhs_amwa_plant_api_ver }}/senders/ee000000-0000-4000-8000-0000000000{{ i }}/transportfile",
+    "interface_bindings": ["eth0"],
+    "caps": {},
+    "subscription": {"receiver_id": null, "active": false}
+  }],
+  "receivers": [{
+    "id": "ff000000-0000-4000-8000-0000000000{{ i }}",
+    "version": "1777651501:0",
+    "label": "dhs-scale-{{ i }}-receiver",
+    "description": "RTP audio receiver",
+    "tags": {},
+    "device_id": "bb000000-0000-4000-8000-0000000000{{ i }}",
+    "transport": "urn:x-nmos:transport:rtp",
+    "interface_bindings": ["eth0"],
+    "format": "urn:x-nmos:format:audio",
+    "caps": {"media_types": ["audio/L24", "audio/L16"]},
+    "subscription": {"sender_id": null, "active": false}
+  }]
+}


### PR DESCRIPTION
## Summary

Ansible-manage the standing AMWA lab plant — closes #871. Replaces the hand-launched `/tmp/*.sh` plant scripts with a role + playbook, per the Ansible-only rule.

- **dhs_amwa_plant role**: builds the dhs binary from COMMITTED source on the Go-capable build host (dhs-tools), deploys it to the plant host (dhs-debian), templates systemd units for the registry + resident nodes (test-node, is11-node) + N generated scale nodes, and verifies every node registered
- **commit-gated**: the deployed commit is stamped in `.commit`; a converge already on HEAD skips build/deploy/restart entirely → run-twice = 0 changes (ADR-0025 #6)
- **one-time migration**: stops the legacy `/tmp/dhs-main` processes so the units take their ports
- `amwa-plant.yml`: `ansible-playbook playbooks/amwa-plant.yml`

## Test plan (live, control node .101)

- [x] converge from clean: registry + 22 nodes up as systemd units, all `active`, **22 registered**, `failed=0`
- [x] **idempotence: second run `changed=0`** (skipped=8 — the whole build/deploy chain gated off the unchanged commit)
- [x] ms05/testdata embed exception carried into the build archive (first converge caught + fixed the `no matching files` build break)

Follow-up left as-is: `dhs_netaddr` VLAN 600 host_vars rework (the other half of #871) — separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)