### PR TITLE
feat(amwa): BCP-005-02 NMOS Support for IPMX/HKEP

### DIFF
--- a/internal/amwa/CLAUDE.md
+++ b/internal/amwa/CLAUDE.md
@@ -170,7 +170,8 @@ a MISSING implementation by the rule below, never a scope decision.
 | BCP-003-03 Certificate Provisioning | **v1.0.0** | — | ✅ EST client (codec/est + certmgr) |
 | BCP-004-01 / -02 Receiver/Sender Caps | **v1.0.0** | — | ✅ |
 | BCP-005-01 EDID Mapping | **v1.0.0** | — | ✅ codec/edid (unit-verified; tool ships no suite) |
-| BCP-005-02 / -03 IPMX HKEP, PEP | **v1.0.0** | — | ❌ **MISSING** |
+| BCP-005-02 IPMX HKEP | **v1.0.0** | — | ✅ hkep attr + cap + SDP + consistency |
+| BCP-005-03 IPMX PEP | **v1.0.0** | — | ❌ **MISSING** |
 | BCP-006-01 JPEG XS / -04 MPEG TS | **v1.0.0** | — | ✅ |
 | BCP-007-03 MXL | **v1.0.0** | v1.3/v1.2 | ✅ urn:x-nmos:transport:mxl (IS-04 + IS-05 binding) |
 | BCP-008-01 / -02 Status Monitoring | **v1.0.0** | — | ✅ |

--- a/internal/amwa/codec/is04/hkep.go
+++ b/internal/amwa/codec/is04/hkep.go
@@ -1,0 +1,85 @@
+package is04
+
+import "fmt"
+
+// BCP-005-02 (NMOS Support for IPMX/HKEP) consistency rules between a
+// Sender's `hkep` attribute, its SDP, and the
+// urn:x-nmos:cap:transport:hkep capability.
+
+// HKEPCapValues extracts the boolean enum of the hkep transport
+// capability from a caps map (as it appears in caps.constraint_sets[]
+// or a sender's caps). Returns nil when the capability is absent.
+func HKEPCapValues(caps map[string]any) []bool {
+	cap, ok := caps[HKEPCapabilityURN]
+	if !ok {
+		return nil
+	}
+	m, ok := cap.(map[string]any)
+	if !ok {
+		return nil
+	}
+	rawEnum, ok := m["enum"].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]bool, 0, len(rawEnum))
+	for _, v := range rawEnum {
+		if b, ok := v.(bool); ok {
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+// capAllows reports whether a boolean enum permits value v.
+func capAllows(values []bool, v bool) bool {
+	for _, x := range values {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidateHKEPConsistency enforces the BCP-005-02 "Consistency" rules
+// for a Sender: the hkep attribute (present ⇒ matches the SDP) must
+// agree with a declared urn:x-nmos:cap:transport:hkep capability.
+//
+//   - cap allows only true  ⇒ hkep MUST be true
+//   - cap allows only false ⇒ hkep MUST be false
+//   - cap allows both       ⇒ either is valid
+//   - cap absent            ⇒ no constraint
+//
+// hkep==nil means the Sender does not implement BCP-005-02; that is
+// only a conflict when a capability restricts to a single value.
+func ValidateHKEPConsistency(hkep *bool, capValues []bool) error {
+	if len(capValues) == 0 {
+		return nil
+	}
+	allowsTrue := capAllows(capValues, true)
+	allowsFalse := capAllows(capValues, false)
+
+	switch {
+	case allowsTrue && allowsFalse:
+		return nil // both permitted
+	case allowsTrue: // only true
+		if hkep == nil || !*hkep {
+			return fmt.Errorf("is04: hkep capability allows only true but the sender's hkep attribute is %s", boolPtrStr(hkep))
+		}
+	case allowsFalse: // only false
+		if hkep != nil && *hkep {
+			return fmt.Errorf("is04: hkep capability allows only false but the sender's hkep attribute is true")
+		}
+	}
+	return nil
+}
+
+func boolPtrStr(b *bool) string {
+	if b == nil {
+		return "absent"
+	}
+	if *b {
+		return "true"
+	}
+	return "false"
+}

--- a/internal/amwa/codec/is04/hkep_test.go
+++ b/internal/amwa/codec/is04/hkep_test.go
@@ -1,0 +1,112 @@
+package is04_test
+
+// BCP-005-02 (IPMX/HKEP) tests: the hkep Sender attribute round-trips,
+// and the capability↔attribute consistency rules match the spec's
+// "Consistency" section. Oracle = the spec doc + its sender.json
+// example (hkep:true alongside urn:x-nmos:cap:transport:hkep enum
+// [true]).
+
+import (
+	"encoding/json"
+	"testing"
+
+	"dhs/internal/amwa/codec/is04"
+)
+
+func boolp(b bool) *bool { return &b }
+
+func TestSenderHKEPRoundTrip(t *testing.T) {
+	// The spec sender.json example: hkep true.
+	raw := []byte(`{
+		"id":"cccccccc-3333-4333-8333-333333333333","version":"1:0",
+		"label":"s","description":"d","tags":{},
+		"flow_id":"dddddddd-4444-4444-8444-444444444444",
+		"transport":"urn:x-nmos:transport:rtp.mcast",
+		"device_id":"eeeeeeee-5555-4555-8555-555555555555",
+		"manifest_href":"http://h/tf","interface_bindings":["eth0"],
+		"subscription":{"receiver_id":null,"active":true},
+		"hkep":true,
+		"caps":{"constraint_sets":[{"urn:x-nmos:cap:transport:hkep":{"enum":[true]}}]}
+	}`)
+	s, err := is04.DecodeSender(raw)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if s.Hkep == nil || !*s.Hkep {
+		t.Fatalf("hkep attribute lost: %v", s.Hkep)
+	}
+	// Re-encode keeps hkep.
+	out, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !contains(out, `"hkep":true`) {
+		t.Errorf("re-encoded sender dropped hkep: %s", out)
+	}
+
+	// A sender without hkep keeps the attribute ABSENT (not false).
+	noHkep := []byte(`{"id":"cccccccc-3333-4333-8333-333333333333","version":"1:0","label":"s","description":"d","tags":{},"flow_id":null,"transport":"urn:x-nmos:transport:rtp","device_id":"eeeeeeee-5555-4555-8555-555555555555","manifest_href":null,"interface_bindings":[],"subscription":{"receiver_id":null,"active":false}}`)
+	s2, err := is04.DecodeSender(noHkep)
+	if err != nil {
+		t.Fatalf("decode no-hkep: %v", err)
+	}
+	if s2.Hkep != nil {
+		t.Errorf("absent hkep must stay nil, got %v", *s2.Hkep)
+	}
+	out2, _ := json.Marshal(s2)
+	if contains(out2, `"hkep"`) {
+		t.Errorf("absent hkep must not serialise: %s", out2)
+	}
+}
+
+func TestHKEPCapValues(t *testing.T) {
+	caps := map[string]any{
+		"urn:x-nmos:cap:transport:hkep": map[string]any{"enum": []any{true}},
+	}
+	if v := is04.HKEPCapValues(caps); len(v) != 1 || !v[0] {
+		t.Errorf("cap values = %v, want [true]", v)
+	}
+	if v := is04.HKEPCapValues(map[string]any{}); v != nil {
+		t.Errorf("absent cap = %v, want nil", v)
+	}
+}
+
+func TestHKEPConsistency(t *testing.T) {
+	cases := []struct {
+		name    string
+		hkep    *bool
+		cap     []bool
+		wantErr bool
+	}{
+		{"no cap, no attr", nil, nil, false},
+		{"no cap, hkep true", boolp(true), nil, false},
+		{"cap true-only + hkep true", boolp(true), []bool{true}, false},
+		{"cap true-only + hkep false", boolp(false), []bool{true}, true},
+		{"cap true-only + hkep absent", nil, []bool{true}, true},
+		{"cap false-only + hkep false", boolp(false), []bool{false}, false},
+		{"cap false-only + hkep true", boolp(true), []bool{false}, true},
+		{"cap false-only + hkep absent", nil, []bool{false}, false},
+		{"cap both + hkep true", boolp(true), []bool{true, false}, false},
+		{"cap both + hkep false", boolp(false), []bool{true, false}, false},
+		{"cap both + hkep absent", nil, []bool{true, false}, false},
+	}
+	for _, tc := range cases {
+		err := is04.ValidateHKEPConsistency(tc.hkep, tc.cap)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("%s: err=%v, wantErr=%v", tc.name, err, tc.wantErr)
+		}
+	}
+}
+
+func contains(b []byte, s string) bool {
+	return len(b) >= len(s) && indexOf(string(b), s) >= 0
+}
+
+func indexOf(h, n string) int {
+	for i := 0; i+len(n) <= len(h); i++ {
+		if h[i:i+len(n)] == n {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/amwa/codec/is04/sender.go
+++ b/internal/amwa/codec/is04/sender.go
@@ -26,7 +26,18 @@ type Sender struct {
 	// infidelity a controller diff will eventually trip over.
 	Caps         *map[string]any    `json:"caps,omitempty"`
 	Subscription SenderSubscription `json:"subscription"`
+
+	// Hkep is the BCP-005-02 Sender attribute: true when the Sender's
+	// SDP carries an `hkep` attribute (HDCP encryption via the IPMX
+	// HKEP protocol), false when it does not. A pointer so ABSENT (the
+	// Sender does not implement BCP-005-02) stays distinct from an
+	// explicit false.
+	Hkep *bool `json:"hkep,omitempty"`
 }
+
+// HKEPCapabilityURN is the BCP-004-01 capability a Sender/Receiver
+// uses to declare HDCP/HKEP support (BCP-005-02).
+const HKEPCapabilityURN = "urn:x-nmos:cap:transport:hkep"
 
 // SenderSubscription mirrors sender.json `subscription`. Per IS-04
 // v1.3 sender.json the field is REQUIRED with type ["string","null"]

--- a/internal/amwa/provider/connection_sdp.go
+++ b/internal/amwa/provider/connection_sdp.go
@@ -67,6 +67,15 @@ func (s *IS05ConnectionServer) sdpForSender(id string, active is05.StagedSender)
 		fmt.Fprintf(&b, "a=group:DUP %s\r\n", strings.Join(mids[:len(active.TransportParams)], " "))
 	}
 
+	// BCP-005-02: the presence of an `hkep` attribute (TR-10-5) marks
+	// the stream as HDCP-protected. Its presence is the semantic the
+	// spec's consistency + Controller checks rely on; the full TR-10-5
+	// key parameters are device-plane and out of scope for a reference
+	// node, so a bare session-level marker is emitted here.
+	if snd.Hkep != nil && *snd.Hkep {
+		fmt.Fprintf(&b, "a=hkep\r\n")
+	}
+
 	// The channel count is on the SOURCE, not the Flow — a Flow
 	// describes the encoding, a Source describes what was encoded.
 	flow := s.flowByID(snd.FlowID)


### PR DESCRIPTION
## Summary

BCP-005-02 "NMOS Support for IPMX/HKEP" (seq 14, #861). Models the **NMOS-layer** HKEP contract — the HDCP key exchange itself is device media-plane, not the control model a reference node implements.

- **is04 Sender** gains the `hkep` attribute (bool pointer: absent = does not implement BCP-005-02, distinct from explicit false)
- **`ValidateHKEPConsistency`** enforces the spec's Consistency rules between the `hkep` attribute and the `urn:x-nmos:cap:transport:hkep` capability (true-only ⇒ hkep true; false-only ⇒ hkep false; both ⇒ either) + `HKEPCapValues` extractor
- **provider SDP** emits a session-level `hkep` marker when the sender is HDCP-protected (presence is the semantic the spec's checks rely on; full TR-10-5 key parameters are device-plane, out of scope)

## Verification

Oracle = the spec doc + its `sender.json` example (`hkep:true` with `urn:x-nmos:cap:transport:hkep` enum `[true]`); the AMWA tool has no standalone HKEP suite.

- [x] hkep attribute round-trip (present true / absent stays nil, never serialises false)
- [x] consistency rules — all 11 cap×attr combinations
- [x] SDP marker on an HDCP-protected sender
- [x] full `./internal/amwa/... ./cmd/...` sweep green

🤖 Generated with [Claude Code](https://claude.com/claude-code)