### PR TITLE
feat(amwa): BCP-005-03 NMOS Support for IPMX/PEP

### DIFF
--- a/internal/amwa/CLAUDE.md
+++ b/internal/amwa/CLAUDE.md
@@ -171,7 +171,7 @@ a MISSING implementation by the rule below, never a scope decision.
 | BCP-004-01 / -02 Receiver/Sender Caps | **v1.0.0** | — | ✅ |
 | BCP-005-01 EDID Mapping | **v1.0.0** | — | ✅ codec/edid (unit-verified; tool ships no suite) |
 | BCP-005-02 IPMX HKEP | **v1.0.0** | — | ✅ hkep attr + cap + SDP + consistency |
-| BCP-005-03 IPMX PEP | **v1.0.0** | — | ❌ **MISSING** |
+| BCP-005-03 IPMX PEP | **v1.0.0** | — | ✅ privacy attr + cap + IS-05 ext_privacy_* params + SDP + consistency |
 | BCP-006-01 JPEG XS / -04 MPEG TS | **v1.0.0** | — | ✅ |
 | BCP-007-03 MXL | **v1.0.0** | v1.3/v1.2 | ✅ urn:x-nmos:transport:mxl (IS-04 + IS-05 binding) |
 | BCP-008-01 / -02 Status Monitoring | **v1.0.0** | — | ✅ |
@@ -206,8 +206,8 @@ and none appeared here, so nothing flagged them as missing. Re-verify
 against specs.amwa.tv whenever the AMWA testing tool gains a suite we
 have no row for: the tool ships suites for exactly the published set,
 so a suite we cannot name IS the signal. Suites present on the tool
-today with no implementation behind them:
-BCP-007-03.
+today with no implementation behind them: **none** — every published
+minor in the table above is implemented.
 
 ---
 

--- a/internal/amwa/codec/is04/hkep.go
+++ b/internal/amwa/codec/is04/hkep.go
@@ -10,25 +10,7 @@ import "fmt"
 // capability from a caps map (as it appears in caps.constraint_sets[]
 // or a sender's caps). Returns nil when the capability is absent.
 func HKEPCapValues(caps map[string]any) []bool {
-	cap, ok := caps[HKEPCapabilityURN]
-	if !ok {
-		return nil
-	}
-	m, ok := cap.(map[string]any)
-	if !ok {
-		return nil
-	}
-	rawEnum, ok := m["enum"].([]any)
-	if !ok {
-		return nil
-	}
-	out := make([]bool, 0, len(rawEnum))
-	for _, v := range rawEnum {
-		if b, ok := v.(bool); ok {
-			out = append(out, b)
-		}
-	}
-	return out
+	return boolCapValues(caps, HKEPCapabilityURN)
 }
 
 // capAllows reports whether a boolean enum permits value v.

--- a/internal/amwa/codec/is04/privacy.go
+++ b/internal/amwa/codec/is04/privacy.go
@@ -1,0 +1,84 @@
+package is04
+
+import "fmt"
+
+// BCP-005-03 (NMOS Support for IPMX/PEP) consistency rules between a
+// Sender's `privacy` attribute, its SDP, and the
+// urn:x-nmos:cap:transport:privacy capability.
+//
+// The privacy attribute is the NMOS-layer statement of whether a Sender
+// is emitting PEP-encrypted media; the capability declares what a
+// Receiver (or a Sender's own advertisement) will accept. The keys and
+// cipher live in the IS-05 ext_privacy_* parameters + the SDP transport
+// file; those are device media-plane and modeled in codec/is05.
+
+// PrivacyCapValues extracts the boolean enum of the privacy transport
+// capability from a caps map (as it appears in caps.constraint_sets[]
+// or a sender's caps). Returns nil when the capability is absent.
+//
+// BCP-005-03 says the capability is a SINGULAR boolean — the enum holds
+// exactly one of true/false, never both — but the extractor returns
+// whatever the enum lists so ValidatePrivacyConsistency can report a
+// two-valued enum rather than silently accepting it.
+func PrivacyCapValues(caps map[string]any) []bool {
+	return boolCapValues(caps, PrivacyCapabilityURN)
+}
+
+// boolCapValues pulls the boolean enum of one capability URN out of a
+// caps map. Shared by the HKEP and PEP extractors.
+func boolCapValues(caps map[string]any, urn string) []bool {
+	cap, ok := caps[urn]
+	if !ok {
+		return nil
+	}
+	m, ok := cap.(map[string]any)
+	if !ok {
+		return nil
+	}
+	rawEnum, ok := m["enum"].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]bool, 0, len(rawEnum))
+	for _, v := range rawEnum {
+		if b, ok := v.(bool); ok {
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+// ValidatePrivacyConsistency enforces the BCP-005-03 "Consistency" rules
+// for a Sender: the privacy attribute must agree with a declared
+// urn:x-nmos:cap:transport:privacy capability.
+//
+//   - cap allows only true  ⇒ privacy MUST be true (and, per spec, the
+//     SDP MUST carry a privacy attribute + IS-05 params other than NULL —
+//     enforced on the params side by is05.ValidatePrivacyParams)
+//   - cap allows only false ⇒ privacy MUST be false
+//   - cap is two-valued     ⇒ rejected: the capability is singular
+//   - cap absent            ⇒ no constraint
+//
+// privacy==nil means the Sender does not implement BCP-005-03; that is
+// only a conflict when the capability restricts to a single value.
+func ValidatePrivacyConsistency(privacy *bool, capValues []bool) error {
+	if len(capValues) == 0 {
+		return nil
+	}
+	allowsTrue := capAllows(capValues, true)
+	allowsFalse := capAllows(capValues, false)
+
+	switch {
+	case allowsTrue && allowsFalse:
+		return fmt.Errorf("is04: %s must be a singular boolean but its enum allows both true and false", PrivacyCapabilityURN)
+	case allowsTrue: // only true
+		if privacy == nil || !*privacy {
+			return fmt.Errorf("is04: privacy capability allows only true but the sender's privacy attribute is %s", boolPtrStr(privacy))
+		}
+	case allowsFalse: // only false
+		if privacy != nil && *privacy {
+			return fmt.Errorf("is04: privacy capability allows only false but the sender's privacy attribute is true")
+		}
+	}
+	return nil
+}

--- a/internal/amwa/codec/is04/privacy_test.go
+++ b/internal/amwa/codec/is04/privacy_test.go
@@ -1,0 +1,95 @@
+package is04_test
+
+// BCP-005-03 (IPMX/PEP) tests: the privacy Sender attribute round-trips,
+// and the capability↔attribute consistency rules match the spec's
+// "Consistency" section. The capability is a SINGULAR boolean, so a
+// two-valued enum is itself an error. Helpers boolp/contains live in
+// hkep_test.go (same package).
+
+import (
+	"encoding/json"
+	"testing"
+
+	"dhs/internal/amwa/codec/is04"
+)
+
+func TestSenderPrivacyRoundTrip(t *testing.T) {
+	raw := []byte(`{
+		"id":"cccccccc-3333-4333-8333-333333333333","version":"1:0",
+		"label":"s","description":"d","tags":{},
+		"flow_id":"dddddddd-4444-4444-8444-444444444444",
+		"transport":"urn:x-nmos:transport:rtp.mcast",
+		"device_id":"eeeeeeee-5555-4555-8555-555555555555",
+		"manifest_href":"http://h/tf","interface_bindings":["eth0"],
+		"subscription":{"receiver_id":null,"active":true},
+		"privacy":true,
+		"caps":{"constraint_sets":[{"urn:x-nmos:cap:transport:privacy":{"enum":[true]}}]}
+	}`)
+	s, err := is04.DecodeSender(raw)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if s.Privacy == nil || !*s.Privacy {
+		t.Fatalf("privacy attribute lost: %v", s.Privacy)
+	}
+	out, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !contains(out, `"privacy":true`) {
+		t.Errorf("re-encoded sender dropped privacy: %s", out)
+	}
+
+	// A sender without privacy keeps the attribute ABSENT (not false).
+	noPriv := []byte(`{"id":"cccccccc-3333-4333-8333-333333333333","version":"1:0","label":"s","description":"d","tags":{},"flow_id":null,"transport":"urn:x-nmos:transport:rtp","device_id":"eeeeeeee-5555-4555-8555-555555555555","manifest_href":null,"interface_bindings":[],"subscription":{"receiver_id":null,"active":false}}`)
+	s2, err := is04.DecodeSender(noPriv)
+	if err != nil {
+		t.Fatalf("decode no-privacy: %v", err)
+	}
+	if s2.Privacy != nil {
+		t.Errorf("absent privacy must stay nil, got %v", *s2.Privacy)
+	}
+	out2, _ := json.Marshal(s2)
+	if contains(out2, `"privacy"`) {
+		t.Errorf("absent privacy must not serialise: %s", out2)
+	}
+}
+
+func TestPrivacyCapValues(t *testing.T) {
+	caps := map[string]any{
+		"urn:x-nmos:cap:transport:privacy": map[string]any{"enum": []any{true}},
+	}
+	if v := is04.PrivacyCapValues(caps); len(v) != 1 || !v[0] {
+		t.Errorf("cap values = %v, want [true]", v)
+	}
+	if v := is04.PrivacyCapValues(map[string]any{}); v != nil {
+		t.Errorf("absent cap = %v, want nil", v)
+	}
+}
+
+func TestPrivacyConsistency(t *testing.T) {
+	cases := []struct {
+		name    string
+		privacy *bool
+		cap     []bool
+		wantErr bool
+	}{
+		{"no cap, no attr", nil, nil, false},
+		{"no cap, privacy true", boolp(true), nil, false},
+		{"cap true-only + privacy true", boolp(true), []bool{true}, false},
+		{"cap true-only + privacy false", boolp(false), []bool{true}, true},
+		{"cap true-only + privacy absent", nil, []bool{true}, true},
+		{"cap false-only + privacy false", boolp(false), []bool{false}, false},
+		{"cap false-only + privacy true", boolp(true), []bool{false}, true},
+		{"cap false-only + privacy absent", nil, []bool{false}, false},
+		// The capability is SINGULAR: a two-valued enum is itself invalid.
+		{"cap two-valued (illegal) + privacy true", boolp(true), []bool{true, false}, true},
+		{"cap two-valued (illegal) + privacy absent", nil, []bool{true, false}, true},
+	}
+	for _, tc := range cases {
+		err := is04.ValidatePrivacyConsistency(tc.privacy, tc.cap)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("%s: err=%v, wantErr=%v", tc.name, err, tc.wantErr)
+		}
+	}
+}

--- a/internal/amwa/codec/is04/sender.go
+++ b/internal/amwa/codec/is04/sender.go
@@ -33,11 +33,24 @@ type Sender struct {
 	// Sender does not implement BCP-005-02) stays distinct from an
 	// explicit false.
 	Hkep *bool `json:"hkep,omitempty"`
+
+	// Privacy is the BCP-005-03 Sender attribute: MUST be true when the
+	// Sender's SDP transport file carries a `privacy` attribute (IPMX
+	// media-plane encryption via the Privacy Encryption Protocol), and
+	// false when no `privacy` attribute is present. A pointer so ABSENT
+	// (the Sender does not implement BCP-005-03) stays distinct from an
+	// explicit false.
+	Privacy *bool `json:"privacy,omitempty"`
 }
 
 // HKEPCapabilityURN is the BCP-004-01 capability a Sender/Receiver
 // uses to declare HDCP/HKEP support (BCP-005-02).
 const HKEPCapabilityURN = "urn:x-nmos:cap:transport:hkep"
+
+// PrivacyCapabilityURN is the BCP-004-01 capability a Sender/Receiver
+// uses to declare IPMX/PEP support (BCP-005-03). Singular boolean:
+// the constraint enum holds true OR false, never both.
+const PrivacyCapabilityURN = "urn:x-nmos:cap:transport:privacy"
 
 // SenderSubscription mirrors sender.json `subscription`. Per IS-04
 // v1.3 sender.json the field is REQUIRED with type ["string","null"]

--- a/internal/amwa/codec/is05/privacy.go
+++ b/internal/amwa/codec/is05/privacy.go
@@ -1,0 +1,154 @@
+package is05
+
+import "fmt"
+
+// BCP-005-03 (NMOS With IPMX/PEP) IS-05 extended transport parameters.
+//
+// PEP (the IPMX Privacy Encryption Protocol) negotiates media-plane
+// encryption. The KEYS and the cipher itself are device media-plane and
+// out of scope for a reference node; what IS-05 models — and what a
+// Controller reads to wire two peers together — is the SET of extended
+// transport parameters below, plus the rule that a Sender advertising no
+// privacy pins protocol and mode to the "NULL" sentinel.
+//
+// The spec names the parameters with the `ext_` prefix IS-05 reserves
+// for information a transport needs that IS-05 itself knows nothing
+// about (§ transport parameters), so they layer onto ANY RTP leg
+// without a new transport URN.
+const (
+	// Core parameters — every PEP-capable device carries these.
+	ParamPrivacyProtocol     = "ext_privacy_protocol"
+	ParamPrivacyMode         = "ext_privacy_mode"
+	ParamPrivacyIV           = "ext_privacy_iv"
+	ParamPrivacyKeyGenerator = "ext_privacy_key_generator"
+	ParamPrivacyKeyVersion   = "ext_privacy_key_version"
+	ParamPrivacyKeyID        = "ext_privacy_key_id"
+
+	// ECDH parameters — only devices doing an ECDH key exchange carry
+	// these. A device using a pre-shared key omits the whole trio.
+	ParamPrivacyECDHSenderPubKey   = "ext_privacy_ecdh_sender_public_key"
+	ParamPrivacyECDHReceiverPubKey = "ext_privacy_ecdh_receiver_public_key"
+	ParamPrivacyECDHCurve          = "ext_privacy_ecdh_curve"
+)
+
+// PrivacyNull is the sentinel a PEP parameter carries when the feature
+// is not engaged. It is a real value, not absence: a PEP-capable device
+// advertises the parameters at all times and sets them to "NULL" when
+// privacy is off, so a Controller can tell "encryption disabled" apart
+// from "device does not implement PEP" (the latter omits the parameters
+// entirely).
+const PrivacyNull = "NULL"
+
+// PrivacyProtocols is the closed set of ext_privacy_protocol values.
+var PrivacyProtocols = []string{"RTP", "RTP_KV", "USB", "USB_KV", PrivacyNull}
+
+// PrivacyECDHCurves is the closed set of ext_privacy_ecdh_curve values.
+var PrivacyECDHCurves = []string{"secp256r1", "secp521r1", "25519", "448", PrivacyNull}
+
+// IsValidPrivacyProtocol reports whether v is a spec ext_privacy_protocol.
+func IsValidPrivacyProtocol(v string) bool { return inSet(PrivacyProtocols, v) }
+
+// IsValidPrivacyECDHCurve reports whether v is a spec ext_privacy_ecdh_curve.
+func IsValidPrivacyECDHCurve(v string) bool { return inSet(PrivacyECDHCurves, v) }
+
+func inSet(set []string, v string) bool {
+	for _, x := range set {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
+// PrivacyLegParams builds the unset-but-present PEP parameter set for one
+// leg — every value at the "NULL" sentinel, which is the state of a
+// PEP-capable device with encryption disabled. Pass ecdh=true to include
+// the ECDH trio (a device doing an ECDH key exchange); false for a
+// pre-shared-key device, which omits it.
+//
+// The keys returned here MUST also be added to the leg's constraints
+// object with the same names, or the endpoint's own PATCH validation
+// rejects them as unknown (constraints and transport_params carry
+// exactly the same key set).
+func PrivacyLegParams(ecdh bool) TransportParams {
+	p := TransportParams{
+		ParamPrivacyProtocol:     PrivacyNull,
+		ParamPrivacyMode:         PrivacyNull,
+		ParamPrivacyIV:           PrivacyNull,
+		ParamPrivacyKeyGenerator: PrivacyNull,
+		ParamPrivacyKeyVersion:   PrivacyNull,
+		ParamPrivacyKeyID:        PrivacyNull,
+	}
+	if ecdh {
+		p[ParamPrivacyECDHSenderPubKey] = PrivacyNull
+		p[ParamPrivacyECDHReceiverPubKey] = PrivacyNull
+		p[ParamPrivacyECDHCurve] = PrivacyNull
+	}
+	return p
+}
+
+// PrivacyParamKeys lists the PEP parameter names present in a leg. Used
+// to grow the constraints object alongside transport_params.
+func PrivacyParamKeys(p TransportParams) []string {
+	all := []string{
+		ParamPrivacyProtocol, ParamPrivacyMode, ParamPrivacyIV,
+		ParamPrivacyKeyGenerator, ParamPrivacyKeyVersion, ParamPrivacyKeyID,
+		ParamPrivacyECDHSenderPubKey, ParamPrivacyECDHReceiverPubKey, ParamPrivacyECDHCurve,
+	}
+	out := []string{}
+	for _, k := range all {
+		if _, ok := p[k]; ok {
+			out = append(out, k)
+		}
+	}
+	return out
+}
+
+// ValidatePrivacyParams enforces the BCP-005-03 rules that bind the IS-05
+// PEP parameters to the Sender's `privacy` attribute:
+//
+//   - ext_privacy_protocol, when present, MUST be a known protocol; the
+//     same for ext_privacy_ecdh_curve.
+//   - When the Sender's privacy attribute is false (encryption off),
+//     ext_privacy_protocol AND ext_privacy_mode MUST be "NULL".
+//   - When the Sender's privacy attribute is true, ext_privacy_protocol
+//     MUST NOT be "NULL" — an enabled Sender that named no protocol is
+//     self-contradictory.
+//
+// privacy==nil means the Sender does not implement BCP-005-03; the
+// parameters are then only checked for enum validity, not for the
+// on/off coupling.
+func ValidatePrivacyParams(p TransportParams, privacy *bool) error {
+	if p == nil {
+		return nil
+	}
+	proto, hasProto := stringParam(p, ParamPrivacyProtocol)
+	if hasProto && !IsValidPrivacyProtocol(proto) {
+		return fmt.Errorf("is05: %s %q not one of %v", ParamPrivacyProtocol, proto, PrivacyProtocols)
+	}
+	if curve, ok := stringParam(p, ParamPrivacyECDHCurve); ok && !IsValidPrivacyECDHCurve(curve) {
+		return fmt.Errorf("is05: %s %q not one of %v", ParamPrivacyECDHCurve, curve, PrivacyECDHCurves)
+	}
+	mode, hasMode := stringParam(p, ParamPrivacyMode)
+	if privacy != nil && !*privacy {
+		if hasProto && proto != PrivacyNull {
+			return fmt.Errorf("is05: privacy attribute is false but %s is %q (must be %q)", ParamPrivacyProtocol, proto, PrivacyNull)
+		}
+		if hasMode && mode != PrivacyNull {
+			return fmt.Errorf("is05: privacy attribute is false but %s is %q (must be %q)", ParamPrivacyMode, mode, PrivacyNull)
+		}
+	}
+	if privacy != nil && *privacy && hasProto && proto == PrivacyNull {
+		return fmt.Errorf("is05: privacy attribute is true but %s is %q", ParamPrivacyProtocol, PrivacyNull)
+	}
+	return nil
+}
+
+func stringParam(p TransportParams, key string) (string, bool) {
+	v, ok := p[key]
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	return s, ok
+}

--- a/internal/amwa/codec/is05/privacy_test.go
+++ b/internal/amwa/codec/is05/privacy_test.go
@@ -1,0 +1,121 @@
+package is05_test
+
+// BCP-005-03 (IPMX/PEP) IS-05 extended transport parameter tests.
+// Oracle = the spec's parameter list, value sets, and the
+// privacy-attribute/parameter coupling rules.
+
+import (
+	"testing"
+
+	"dhs/internal/amwa/codec/is05"
+)
+
+func boolp(b bool) *bool { return &b }
+
+func TestPrivacyLegParamsCore(t *testing.T) {
+	p := is05.PrivacyLegParams(false)
+	// Six core params, all at the NULL sentinel, no ECDH trio.
+	want := []string{
+		is05.ParamPrivacyProtocol, is05.ParamPrivacyMode, is05.ParamPrivacyIV,
+		is05.ParamPrivacyKeyGenerator, is05.ParamPrivacyKeyVersion, is05.ParamPrivacyKeyID,
+	}
+	for _, k := range want {
+		if v, ok := p[k]; !ok || v != is05.PrivacyNull {
+			t.Errorf("core param %s = %v (ok=%v), want %q", k, v, ok, is05.PrivacyNull)
+		}
+	}
+	if _, ok := p[is05.ParamPrivacyECDHCurve]; ok {
+		t.Errorf("core-only leg must omit the ECDH trio, found %s", is05.ParamPrivacyECDHCurve)
+	}
+	if len(p) != 6 {
+		t.Errorf("core leg has %d params, want 6", len(p))
+	}
+}
+
+func TestPrivacyLegParamsECDH(t *testing.T) {
+	p := is05.PrivacyLegParams(true)
+	for _, k := range []string{
+		is05.ParamPrivacyECDHSenderPubKey, is05.ParamPrivacyECDHReceiverPubKey, is05.ParamPrivacyECDHCurve,
+	} {
+		if v, ok := p[k]; !ok || v != is05.PrivacyNull {
+			t.Errorf("ecdh param %s = %v (ok=%v), want %q", k, v, ok, is05.PrivacyNull)
+		}
+	}
+	if len(p) != 9 {
+		t.Errorf("ecdh leg has %d params, want 9", len(p))
+	}
+	if got := len(is05.PrivacyParamKeys(p)); got != 9 {
+		t.Errorf("PrivacyParamKeys = %d, want 9", got)
+	}
+}
+
+func TestPrivacyEnums(t *testing.T) {
+	for _, v := range []string{"RTP", "RTP_KV", "USB", "USB_KV", "NULL"} {
+		if !is05.IsValidPrivacyProtocol(v) {
+			t.Errorf("protocol %q should be valid", v)
+		}
+	}
+	if is05.IsValidPrivacyProtocol("AES") {
+		t.Errorf("protocol AES should be invalid")
+	}
+	for _, v := range []string{"secp256r1", "secp521r1", "25519", "448", "NULL"} {
+		if !is05.IsValidPrivacyECDHCurve(v) {
+			t.Errorf("curve %q should be valid", v)
+		}
+	}
+	if is05.IsValidPrivacyECDHCurve("p256") {
+		t.Errorf("curve p256 should be invalid")
+	}
+}
+
+func TestValidatePrivacyParams(t *testing.T) {
+	cases := []struct {
+		name    string
+		p       is05.TransportParams
+		privacy *bool
+		wantErr bool
+	}{
+		{"nil params", nil, boolp(true), false},
+		{"off + all NULL", is05.PrivacyLegParams(false), boolp(false), false},
+		{
+			"off + non-NULL protocol",
+			is05.TransportParams{is05.ParamPrivacyProtocol: "RTP", is05.ParamPrivacyMode: "NULL"},
+			boolp(false), true,
+		},
+		{
+			"off + non-NULL mode",
+			is05.TransportParams{is05.ParamPrivacyProtocol: "NULL", is05.ParamPrivacyMode: "AES-CTR"},
+			boolp(false), true,
+		},
+		{
+			"on + protocol NULL",
+			is05.TransportParams{is05.ParamPrivacyProtocol: "NULL"},
+			boolp(true), true,
+		},
+		{
+			"on + protocol RTP",
+			is05.TransportParams{is05.ParamPrivacyProtocol: "RTP", is05.ParamPrivacyMode: "AES-CTR"},
+			boolp(true), false,
+		},
+		{
+			"bad protocol enum",
+			is05.TransportParams{is05.ParamPrivacyProtocol: "TWOFISH"},
+			nil, true,
+		},
+		{
+			"bad curve enum",
+			is05.TransportParams{is05.ParamPrivacyECDHCurve: "p256"},
+			nil, true,
+		},
+		{
+			"absent attr + all NULL",
+			is05.PrivacyLegParams(true), nil, false,
+		},
+	}
+	for _, tc := range cases {
+		err := is05.ValidatePrivacyParams(tc.p, tc.privacy)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("%s: err=%v, wantErr=%v", tc.name, err, tc.wantErr)
+		}
+	}
+}

--- a/internal/amwa/provider/connection_sdp.go
+++ b/internal/amwa/provider/connection_sdp.go
@@ -76,6 +76,17 @@ func (s *IS05ConnectionServer) sdpForSender(id string, active is05.StagedSender)
 		fmt.Fprintf(&b, "a=hkep\r\n")
 	}
 
+	// BCP-005-03: a `privacy` attribute in the SDP transport file marks
+	// the stream as PEP-encrypted. The Sender's `privacy` IS-04 attribute
+	// MUST be true iff this line is present. Its presence is the semantic
+	// the spec's consistency + Controller checks rely on; the PEP key
+	// material + RTP extension-header detail is device-plane and out of
+	// scope for a reference node, so a bare session-level marker is
+	// emitted here.
+	if snd.Privacy != nil && *snd.Privacy {
+		fmt.Fprintf(&b, "a=privacy\r\n")
+	}
+
 	// The channel count is on the SOURCE, not the Flow — a Flow
 	// describes the encoding, a Source describes what was encoded.
 	flow := s.flowByID(snd.FlowID)

--- a/internal/amwa/provider/connection_state.go
+++ b/internal/amwa/provider/connection_state.go
@@ -188,6 +188,14 @@ func (s *connectionStore) seedFromBundle(cfg *NodeConfig) {
 		e := newEndpointForTransport(snd.Transport, true)
 		e.id = snd.ID
 		fillEventExtParams(e, cfg, snd.FlowID)
+		// BCP-005-03: a Sender that implements PEP (privacy attribute
+		// present) publishes the ext_privacy_* IS-05 parameters so a
+		// Controller can wire encryption. Gated on the attribute so a
+		// non-PEP Sender is byte-for-byte unchanged. Injected before the
+		// seed so a Connection seed can override the NULL defaults.
+		if snd.Privacy != nil && isRTP(snd.Transport) {
+			injectPrivacyParams(e)
+		}
 		if cfg.Connection != nil {
 			applySeed(e, cfg.Connection.Senders[snd.ID], snd.Transport)
 		}
@@ -270,6 +278,31 @@ func fillEventExtParams(e *connectionEndpoint, cfg *NodeConfig, flowID *string) 
 		if _, carries := e.constraints[i]["ext_is_07_source_id"]; !carries {
 			e.constraints[i]["ext_is_07_source_id"] = map[string]any{}
 			e.constraints[i]["ext_is_07_rest_api_url"] = map[string]any{}
+		}
+	}
+}
+
+// injectPrivacyParams adds the BCP-005-03 ext_privacy_* parameters to
+// every leg of a PEP-capable Sender endpoint, defaulting to the "NULL"
+// sentinel (a PEP-capable device with encryption not currently engaged
+// — the honest state for a reference node, which runs no cipher). The
+// same keys are mirrored into the constraints object, or the endpoint's
+// own PATCH validation would reject them as unknown.
+//
+// The ECDH trio is omitted: a reference node advertises pre-shared-key
+// capability only. A device doing an ECDH exchange re-declares the leg
+// with is05.PrivacyLegParams(true).
+func injectPrivacyParams(e *connectionEndpoint) {
+	for i := range e.staged.TransportParams {
+		pp := is05.PrivacyLegParams(false)
+		for k, v := range pp {
+			e.staged.TransportParams[i][k] = v
+			e.active.TransportParams[i][k] = v
+		}
+		if i < len(e.constraints) {
+			for _, k := range is05.PrivacyParamKeys(pp) {
+				e.constraints[i][k] = map[string]any{}
+			}
 		}
 	}
 }

--- a/internal/amwa/provider/pep_test.go
+++ b/internal/amwa/provider/pep_test.go
@@ -1,0 +1,112 @@
+package provider
+
+// BCP-005-03 (NMOS With IPMX/PEP) provider rules: a Sender that declares
+// the `privacy` attribute emits an `a=privacy` marker in its SDP and
+// publishes the ext_privacy_* IS-05 transport parameters (staged +
+// constraints); a Sender without the attribute is byte-for-byte
+// unchanged.
+
+import (
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"dhs/internal/amwa/codec/is05"
+)
+
+func pepServer(t *testing.T, privacy *bool) *IS05ConnectionServer {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	b := audioBundle()
+	b.Senders[0].Privacy = privacy
+	cs := NewIS05ConnectionServer(logger, b, IS05ConnectionConfig{APIVer: "v1.2"})
+	cs.Store().setNodeIP("10.0.0.7")
+	cs.Store().reresolveActive()
+	return cs
+}
+
+func TestPEPSDPMarkerPresentWhenPrivacyTrue(t *testing.T) {
+	on := true
+	cs := pepServer(t, &on)
+	id := cs.bundle.Senders[0].ID
+	e, _ := cs.Store().get("senders", id)
+	sdp := cs.sdpForSender(id, e.active)
+	if !strings.Contains(sdp, "a=privacy\r\n") {
+		t.Errorf("privacy=true sender must emit a=privacy:\n%s", sdp)
+	}
+}
+
+func TestPEPSDPMarkerAbsentOtherwise(t *testing.T) {
+	off := false
+	for _, tc := range []struct {
+		name string
+		priv *bool
+	}{
+		{"attr false", &off},
+		{"attr absent", nil},
+	} {
+		cs := pepServer(t, tc.priv)
+		id := cs.bundle.Senders[0].ID
+		e, _ := cs.Store().get("senders", id)
+		sdp := cs.sdpForSender(id, e.active)
+		if strings.Contains(sdp, "a=privacy") {
+			t.Errorf("%s: must NOT emit a=privacy:\n%s", tc.name, sdp)
+		}
+	}
+}
+
+func TestPEPParamsInjectedForPrivacySender(t *testing.T) {
+	off := false
+	cs := pepServer(t, &off) // attribute present ⇒ PEP-capable ⇒ params published
+	id := cs.bundle.Senders[0].ID
+	e, _ := cs.Store().get("senders", id)
+
+	coreKeys := []string{
+		is05.ParamPrivacyProtocol, is05.ParamPrivacyMode, is05.ParamPrivacyIV,
+		is05.ParamPrivacyKeyGenerator, is05.ParamPrivacyKeyVersion, is05.ParamPrivacyKeyID,
+	}
+	for _, leg := range e.staged.TransportParams {
+		for _, k := range coreKeys {
+			v, ok := leg[k]
+			if !ok {
+				t.Errorf("staged leg missing %s", k)
+				continue
+			}
+			// Disabled PEP sender ⇒ every param at the NULL sentinel.
+			if v != is05.PrivacyNull {
+				t.Errorf("%s = %v, want %q", k, v, is05.PrivacyNull)
+			}
+		}
+	}
+	// Constraints must carry the same keys (empty objects, no auto).
+	for i, c := range e.constraints {
+		for _, k := range coreKeys {
+			cv, ok := c[k]
+			if !ok {
+				t.Errorf("constraints[%d] missing %s", i, k)
+				continue
+			}
+			if m, ok := cv.(map[string]any); !ok || len(m) != 0 {
+				t.Errorf("constraints[%d][%s] = %v, want empty object", i, k, cv)
+			}
+		}
+	}
+	// The disabled PEP params validate against the attribute.
+	for _, leg := range e.staged.TransportParams {
+		if err := is05.ValidatePrivacyParams(leg, &off); err != nil {
+			t.Errorf("ValidatePrivacyParams: %v", err)
+		}
+	}
+}
+
+func TestPEPParamsAbsentForNonPEPSender(t *testing.T) {
+	cs := pepServer(t, nil) // no privacy attribute ⇒ no PEP params
+	id := cs.bundle.Senders[0].ID
+	e, _ := cs.Store().get("senders", id)
+	for _, leg := range e.staged.TransportParams {
+		if _, ok := leg[is05.ParamPrivacyProtocol]; ok {
+			t.Errorf("non-PEP sender must not carry %s: %v", is05.ParamPrivacyProtocol, leg)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

BCP-005-03 "NMOS With IPMX/PEP" (seq 15 — final unit in the AMWA program). Models the **NMOS-layer** Privacy Encryption Protocol contract — the keys and cipher are device media-plane, out of scope for a reference node.

- **is04 Sender** gains the `privacy` attribute (bool pointer: absent = does not implement BCP-005-03, distinct from explicit false) + `urn:x-nmos:cap:transport:privacy` (a **singular** boolean) + `ValidatePrivacyConsistency` (attribute↔capability rules; a two-valued enum is itself rejected)
- **is05** models the `ext_privacy_*` extended transport parameters: six core params + the optional ECDH trio, their value sets (`RTP`/`RTP_KV`/`USB`/`USB_KV`/`NULL`; `secp256r1`/`secp521r1`/`25519`/`448`/`NULL`), the `NULL` sentinel, and `ValidatePrivacyParams` (privacy-off pins protocol+mode to `NULL`; privacy-on forbids a `NULL` protocol)
- **provider** publishes the `ext_privacy_*` params (staged + constraints) on a Sender that declares the attribute, and emits an `a=privacy` SDP marker when `privacy` is true; a non-PEP Sender is **byte-for-byte unchanged** (injection gated strictly on the attribute)

## Verification

Oracle = the spec doc value sets + Consistency section; the AMWA tool ships no standalone PEP suite.

- [x] `privacy` attribute round-trip (present true / absent stays nil, never serialises false)
- [x] consistency rules incl. the singular-boolean rejection
- [x] IS-05 param model: core/ECDH sets, enums, off⇒NULL / on⇒non-NULL coupling
- [x] provider: `a=privacy` present iff privacy true; params injected only for PEP senders; non-PEP senders untouched
- [x] full `./internal/amwa/... ./cmd/...` sweep green

Applies to IS-04 v1.3+ / IS-05 v1.1+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)