### PR TITLE
fix(amwa): batch registry Query WS grains (sync + change fan-out)

### DIFF
--- a/internal/amwa/registry/registry_http_test.go
+++ b/internal/amwa/registry/registry_http_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net"
 	stdhttp "net/http"
@@ -298,6 +299,289 @@ func TestWebSocketSubscriptionDelivers(t *testing.T) {
 	if !strings.Contains(string(payload), `"topic":"/nodes/"`) {
 		t.Fatalf("sync grain missing /nodes/ topic: %s", payload)
 	}
+}
+
+// TestWebSocketSyncBatchedIntoOneGrain asserts the initial SYNC arrives
+// as a SINGLE grain whose data array carries every matching resource —
+// not one grain per resource. This is the Cerebrum-interop + footprint
+// fix: reference controllers expect the current state batched, and one
+// grain per resource multiplies the wire footprint by the resource
+// count.
+func TestWebSocketSyncBatchedIntoOneGrain(t *testing.T) {
+	store := NewStore()
+	mgr := NewSubscriptionManager(nil, store, "127.0.0.1:0", "v1.3")
+	addr, stop := startRegistryHTTP(t, store, mgr)
+	defer stop()
+
+	ids := []string{
+		"11111111-58cc-4372-a567-0e02b2c3d479",
+		"22222222-58cc-4372-a567-0e02b2c3d479",
+		"33333333-58cc-4372-a567-0e02b2c3d479",
+	}
+	for _, id := range ids {
+		_ = store.PutNode(validNode(id))
+	}
+
+	body, _ := json.Marshal(SubscriptionRequest{ResourcePath: "/nodes"})
+	resp, err := stdhttp.Post("http://"+addr+"/x-nmos/query/v1.3/subscriptions", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST sub: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	bb, _ := io.ReadAll(resp.Body)
+	var sub SubscriptionResource
+	_ = json.Unmarshal(bb, &sub)
+	if sub.ID == "" {
+		t.Fatalf("sub create body = %s", bb)
+	}
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	wsPath := "/x-nmos/query/v1.3/subscriptions/" + sub.ID + "/ws"
+	upgrade := "GET " + wsPath + " HTTP/1.1\r\n" +
+		"Host: " + addr + "\r\n" +
+		"Upgrade: websocket\r\nConnection: Upgrade\r\n" +
+		"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+		"Sec-WebSocket-Version: 13\r\n\r\n"
+	if _, err := conn.Write([]byte(upgrade)); err != nil {
+		t.Fatalf("write upgrade: %v", err)
+	}
+
+	buf := make([]byte, 65536)
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatalf("read upgrade: %v", err)
+	}
+	respHead := string(buf[:n])
+	if !strings.Contains(respHead, "101 Switching Protocols") {
+		t.Fatalf("upgrade response = %s", respHead)
+	}
+	hdrEnd := strings.Index(respHead, "\r\n\r\n")
+	remaining := append([]byte(nil), buf[hdrEnd+4:n]...)
+
+	// Accumulate until one full frame is available.
+	deadline := time.Now().Add(1500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if _, _, err := readUnmaskedFrame(remaining); err == nil {
+			break
+		}
+		extra := make([]byte, 8192)
+		_ = conn.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+		k, rerr := conn.Read(extra)
+		if k > 0 {
+			remaining = append(remaining, extra[:k]...)
+		}
+		if rerr != nil {
+			break
+		}
+	}
+
+	opcode, payload, err := readUnmaskedFrame(remaining)
+	if err != nil {
+		t.Fatalf("frame decode: %v (have %d bytes)", err, len(remaining))
+	}
+	if opcode != 0x1 {
+		t.Fatalf("first frame opcode = 0x%x, want text", opcode)
+	}
+
+	var g wsGrainDecode
+	if err := json.Unmarshal(payload, &g); err != nil {
+		t.Fatalf("grain decode: %v (%s)", err, payload)
+	}
+	if g.Grain.Topic != "/nodes/" {
+		t.Errorf("topic = %q, want /nodes/", g.Grain.Topic)
+	}
+	// The whole point: ALL three nodes in ONE grain's data array.
+	if len(g.Grain.Data) != 3 {
+		t.Fatalf("sync grain carried %d rows, want 3 (all nodes in one grain): %s", len(g.Grain.Data), payload)
+	}
+	seen := map[string]bool{}
+	for _, row := range g.Grain.Data {
+		seen[row.Path] = true
+		// SYNC rows carry both pre and post set to the current value.
+		if row.Pre == nil || row.Post == nil {
+			t.Errorf("sync row %s missing pre/post", row.Path)
+		}
+	}
+	for _, id := range ids {
+		if !seen[id] {
+			t.Errorf("sync grain missing node %s", id)
+		}
+	}
+}
+
+// TestBuildBatchGrain checks the pure batching: many changes of one
+// topic collapse into a single grain whose data array holds every row,
+// with SYNC rows carrying pre == post.
+func TestBuildBatchGrain(t *testing.T) {
+	post := json.RawMessage(`{"id":"a","label":"n"}`)
+	changes := []Change{
+		{Kind: ChangeSync, ResourceType: is04.ResourceNode, ID: "a", Post: post},
+		{Kind: ChangeSync, ResourceType: is04.ResourceNode, ID: "b", Post: post},
+	}
+	frame, err := buildBatchGrain("src", changes, time.Unix(1, 2))
+	if err != nil {
+		t.Fatalf("buildBatchGrain: %v", err)
+	}
+	var g wsGrainDecode
+	if err := json.Unmarshal(frame, &g); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if g.Grain.Topic != "/nodes/" {
+		t.Errorf("topic = %q", g.Grain.Topic)
+	}
+	if len(g.Grain.Data) != 2 {
+		t.Fatalf("rows = %d, want 2", len(g.Grain.Data))
+	}
+	for _, r := range g.Grain.Data {
+		if r.Pre == nil || r.Post == nil {
+			t.Errorf("sync row %s missing pre/post", r.Path)
+		}
+	}
+	// Empty batch yields a grain with an empty data array (no panic).
+	if _, err := buildBatchGrain("src", nil, time.Unix(1, 2)); err != nil {
+		t.Fatalf("empty batch: %v", err)
+	}
+}
+
+// TestWebSocketChangeAggregation fires a burst of changes inside one
+// max_update_rate_ms window and asserts they are (a) all delivered and
+// (b) coalesced into fewer grains than changes — the steady-state
+// footprint win.
+func TestWebSocketChangeAggregation(t *testing.T) {
+	store := NewStore()
+	mgr := NewSubscriptionManager(nil, store, "127.0.0.1:0", "v1.3")
+	addr, stop := startRegistryHTTP(t, store, mgr)
+	defer stop()
+
+	body, _ := json.Marshal(SubscriptionRequest{ResourcePath: "/nodes", MaxUpdateRate: 300})
+	resp, err := stdhttp.Post("http://"+addr+"/x-nmos/query/v1.3/subscriptions", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST sub: %v", err)
+	}
+	bb, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	var sub SubscriptionResource
+	_ = json.Unmarshal(bb, &sub)
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+	upgrade := "GET /x-nmos/query/v1.3/subscriptions/" + sub.ID + "/ws HTTP/1.1\r\n" +
+		"Host: " + addr + "\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n" +
+		"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n"
+	if _, err := conn.Write([]byte(upgrade)); err != nil {
+		t.Fatalf("write upgrade: %v", err)
+	}
+	buf := make([]byte, 65536)
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatalf("read upgrade: %v", err)
+	}
+	head := string(buf[:n])
+	if !strings.Contains(head, "101 Switching Protocols") {
+		t.Fatalf("upgrade = %s", head)
+	}
+	// Discard anything already buffered (there are no nodes yet, so the
+	// sync is empty and nothing should be here).
+
+	// Fire a burst of distinct-node creations inside the 300ms window.
+	const burst = 8
+	for i := 0; i < burst; i++ {
+		id := fmt.Sprintf("%08d-58cc-4372-a567-0e02b2c3d479", i)
+		_ = store.PutNode(validNode(id))
+	}
+
+	// Collect grain frames for ~900ms. Count DISTINCT node ids (a node
+	// that races the initial sync snapshot can legitimately appear in
+	// both the sync grain and a change grain — a controller dedups by
+	// path, so we assert on distinct ids, not raw row count).
+	frames := 0
+	seen := map[string]bool{}
+	acc := []byte{}
+	deadline := time.Now().Add(900 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		_ = conn.SetReadDeadline(time.Now().Add(250 * time.Millisecond))
+		extra := make([]byte, 16384)
+		k, rerr := conn.Read(extra)
+		if k > 0 {
+			acc = append(acc, extra[:k]...)
+			for {
+				op, payload, consumed, ok := nextFrame(acc)
+				if !ok {
+					break
+				}
+				acc = acc[consumed:]
+				if op != 0x1 {
+					continue
+				}
+				var g wsGrainDecode
+				if json.Unmarshal(payload, &g) == nil && g.Grain.Topic == "/nodes/" {
+					frames++
+					for _, row := range g.Grain.Data {
+						seen[row.Path] = true
+					}
+				}
+			}
+		}
+		if rerr != nil && len(seen) >= burst {
+			break
+		}
+	}
+	if len(seen) != burst {
+		t.Fatalf("delivered %d distinct node ids, want %d (no loss)", len(seen), burst)
+	}
+	if frames >= burst {
+		t.Errorf("changes were not coalesced: %d frames for %d changes", frames, burst)
+	}
+}
+
+// nextFrame parses one server text frame and reports bytes consumed.
+func nextFrame(b []byte) (opcode byte, payload []byte, consumed int, ok bool) {
+	if len(b) < 2 {
+		return 0, nil, 0, false
+	}
+	opcode = b[0] & 0x0F
+	plen := int(b[1] & 0x7F)
+	off := 2
+	switch plen {
+	case 126:
+		if len(b) < 4 {
+			return 0, nil, 0, false
+		}
+		plen = int(binary.BigEndian.Uint16(b[2:4]))
+		off = 4
+	case 127:
+		if len(b) < 10 {
+			return 0, nil, 0, false
+		}
+		plen = int(binary.BigEndian.Uint64(b[2:10]))
+		off = 10
+	}
+	if len(b) < off+plen {
+		return 0, nil, 0, false
+	}
+	return opcode, b[off : off+plen], off + plen, true
+}
+
+// wsGrainDecode is a test-local slice of the grain envelope.
+type wsGrainDecode struct {
+	Grain struct {
+		Topic string `json:"topic"`
+		Data  []struct {
+			Path string           `json:"path"`
+			Pre  *json.RawMessage `json:"pre"`
+			Post *json.RawMessage `json:"post"`
+		} `json:"data"`
+	} `json:"grain"`
 }
 
 // readUnmaskedFrame parses one server-side text frame from raw bytes.

--- a/internal/amwa/registry/subscriptions.go
+++ b/internal/amwa/registry/subscriptions.go
@@ -132,6 +132,17 @@ type subscription struct {
 	ws      *httpsession.WebSocket
 	source  string // sub UUID echoed in grain.source_id
 	closeCh chan struct{}
+
+	// bufMu guards the change-aggregation buffer below. IS-04 lets a
+	// grain carry many changes, and max_update_rate_ms is the window we
+	// coalesce them over: instead of one grain per change, changes that
+	// land inside a window flush together as one grain per topic. This
+	// is the steady-state footprint win — a heartbeat re-register storm
+	// becomes one frame, not one-per-node.
+	bufMu            sync.Mutex
+	pending          []Change    // projected changes awaiting flush
+	flushTimer       *time.Timer // non-nil while a flush is scheduled
+	nextFlushAllowed time.Time   // earliest a flush may fire (rate gate)
 }
 
 // SubscriptionManager owns all in-flight subscriptions, the WS
@@ -402,7 +413,7 @@ func (m *SubscriptionManager) UpgradeHandler(base string) func(stdhttp.ResponseW
 		sub.ws = ws
 		m.mu.Unlock()
 
-		// Send sync grains for every existing resource matching the
+		// Send the SYNC snapshot for every existing resource matching the
 		// resource_path AND the subscription params filter. SYNC has
 		// pre == post (current snapshot), so a single jsonMatchesFilter
 		// against Post is sufficient. We also apply the same no-
@@ -411,7 +422,19 @@ func (m *SubscriptionManager) UpgradeHandler(base string) func(stdhttp.ResponseW
 		// resources (AMWA test_22_2). When the subscriber requested
 		// `query.downgrade=v1.X` at POST time, lower-version
 		// resources become visible per AMWA's downgrade semantics.
+		//
+		// The snapshot goes out as ONE grain per topic, not one grain
+		// per resource: IS-04 §5.2 lets a grain's `data` array carry
+		// many objects, and the reference controllers (nmos-cpp/sony)
+		// and Cerebrum expect the current state as a single batched sync
+		// grain. Emitting one grain per resource is a legal but atypical
+		// form that Cerebrum 2.8.17 does not reconcile (it keeps only the
+		// first grain's resource) and multiplies the wire footprint by
+		// the resource count. A `/senders` subscription against a real
+		// Neuron is 208 grains this way, 1 grain batched.
 		now := time.Now()
+		var order []string
+		byTopic := map[string][]Change{}
 		for _, c := range m.store.SnapshotChanges(m.apiVer) {
 			if !subscriptionMatches(sub.ResourcePath, c) {
 				continue
@@ -422,7 +445,14 @@ func (m *SubscriptionManager) UpgradeHandler(base string) func(stdhttp.ResponseW
 			if !jsonMatchesFilter(c.Post, sub.params) && len(sub.params) > 0 {
 				continue
 			}
-			frame, err := buildGrain(sub.source, c, now)
+			topic := "/" + c.ResourceType.Plural() + "/"
+			if _, seen := byTopic[topic]; !seen {
+				order = append(order, topic)
+			}
+			byTopic[topic] = append(byTopic[topic], c)
+		}
+		for _, topic := range order {
+			frame, err := buildBatchGrain(sub.source, byTopic[topic], now)
 			if err != nil {
 				m.logger.Warn("registry/subs: build sync grain", "err", err)
 				continue
@@ -482,7 +512,6 @@ func (m *SubscriptionManager) onChange(c Change) {
 		subs = append(subs, s)
 	}
 	m.mu.Unlock()
-	now := time.Now()
 	for _, s := range subs {
 		// Filter against the CANONICAL body (with all v1.3-shape
 		// fields present) so a `description=...` filter still
@@ -495,11 +524,73 @@ func (m *SubscriptionManager) onChange(c Change) {
 			continue
 		}
 		projected = reencodeChange(projected, m.apiVer)
-		frame, err := buildGrain(s.source, projected, now)
+		m.enqueue(s, projected)
+	}
+}
+
+// enqueue buffers one projected change for a subscription and ensures a
+// flush is scheduled, honoring max_update_rate_ms.
+//
+// rate <= 0 means "no rate limit": flush immediately (the historical
+// behavior), but still off the store's write lock is not possible here
+// since onChange holds it — so for the unlimited case we send inline as
+// before. rate > 0 coalesces every change inside the window into one
+// grain per topic, flushed by a timer that fires OUTSIDE the store lock.
+func (m *SubscriptionManager) enqueue(s *subscription, c Change) {
+	if s.MaxUpdateRate <= 0 {
+		now := time.Now()
+		frame, err := buildBatchGrain(s.source, []Change{c}, now)
+		if err != nil {
+			return
+		}
+		if err := s.ws.SendText(frame); err != nil {
+			m.logger.Warn("registry/subs: send grain failed", "id", s.ID, "err", err)
+		}
+		return
+	}
+	s.bufMu.Lock()
+	s.pending = append(s.pending, c)
+	if s.flushTimer == nil {
+		delay := time.Until(s.nextFlushAllowed)
+		if delay < 0 {
+			delay = 0
+		}
+		s.flushTimer = time.AfterFunc(delay, func() { m.flush(s) })
+	}
+	s.bufMu.Unlock()
+}
+
+// flush drains a subscription's pending changes and sends them as one
+// grain per topic, then re-arms the rate gate. Runs in a timer
+// goroutine, off the store's write lock.
+func (m *SubscriptionManager) flush(s *subscription) {
+	s.bufMu.Lock()
+	pending := s.pending
+	s.pending = nil
+	s.flushTimer = nil
+	s.nextFlushAllowed = time.Now().Add(time.Duration(s.MaxUpdateRate) * time.Millisecond)
+	ws := s.ws
+	s.bufMu.Unlock()
+
+	if ws == nil || len(pending) == 0 {
+		return
+	}
+	now := time.Now()
+	var order []string
+	byTopic := map[string][]Change{}
+	for _, c := range pending {
+		topic := "/" + c.ResourceType.Plural() + "/"
+		if _, seen := byTopic[topic]; !seen {
+			order = append(order, topic)
+		}
+		byTopic[topic] = append(byTopic[topic], c)
+	}
+	for _, topic := range order {
+		frame, err := buildBatchGrain(s.source, byTopic[topic], now)
 		if err != nil {
 			continue
 		}
-		if err := s.ws.SendText(frame); err != nil {
+		if err := ws.SendText(frame); err != nil {
 			m.logger.Warn("registry/subs: send grain failed", "id", s.ID, "err", err)
 		}
 	}
@@ -666,6 +757,12 @@ func jsonMatchesFilter(data json.RawMessage, q map[string][]string) bool {
 func (m *SubscriptionManager) removeSub(id string) {
 	m.mu.Lock()
 	if s, ok := m.subs[id]; ok {
+		s.bufMu.Lock()
+		if s.flushTimer != nil {
+			s.flushTimer.Stop()
+			s.flushTimer = nil
+		}
+		s.bufMu.Unlock()
 		if s.ws != nil {
 			_ = s.ws.Close()
 		}
@@ -683,7 +780,7 @@ func subscriptionMatches(resourcePath string, c Change) bool {
 	return resourcePath == "" || resourcePath == "/" || resourcePath == want
 }
 
-// buildGrain turns a Change into the IS-04 §5.2 grain wire envelope.
+// grainRow turns one Change into an IS-04 §5.2 grain data row.
 //
 // Per IS-04 v1.3.3 §5.2, the (pre, post) pair encodes the change
 // kind:
@@ -691,8 +788,7 @@ func subscriptionMatches(resourcePath string, c Change) bool {
 //   - updated  → pre present, post present (different bodies)
 //   - deleted  → pre present, post absent
 //   - sync     → pre present, post present (SAME body)
-func buildGrain(source string, c Change, now time.Time) ([]byte, error) {
-	ts := fmt.Sprintf("%d:%d", now.Unix(), now.Nanosecond())
+func grainRow(c Change) GrainDataRow {
 	row := GrainDataRow{Path: c.ID}
 	switch c.Kind {
 	case ChangeCreated:
@@ -724,6 +820,25 @@ func buildGrain(source string, c Change, now time.Time) ([]byte, error) {
 			row.Post = &p
 		}
 	}
+	return row
+}
+
+// buildBatchGrain wraps one or more Changes that share a topic into a
+// single IS-04 §5.2 grain envelope. IS-04 lets a grain's `data` array
+// carry many objects; batching all current/changed resources into one
+// grain is the form reference controllers expect and the one that keeps
+// the wire footprint flat regardless of resource count.
+//
+// All changes MUST share a resource type (topic) — callers group by
+// topic first. An empty slice yields a grain with an empty data array.
+func buildBatchGrain(source string, changes []Change, now time.Time) ([]byte, error) {
+	ts := fmt.Sprintf("%d:%d", now.Unix(), now.Nanosecond())
+	rows := make([]GrainDataRow, 0, len(changes))
+	topic := "//"
+	for _, c := range changes {
+		topic = "/" + c.ResourceType.Plural() + "/"
+		rows = append(rows, grainRow(c))
+	}
 	g := Grain{
 		GrainType:         "event",
 		SourceID:          source,
@@ -735,8 +850,8 @@ func buildGrain(source string, c Change, now time.Time) ([]byte, error) {
 		Duration:          GrainRT{Numerator: 0, Denominator: 1},
 		Grain: GrainBody{
 			Type:  "urn:x-nmos:format:data.event",
-			Topic: "/" + c.ResourceType.Plural() + "/",
-			Data:  []GrainDataRow{row},
+			Topic: topic,
+			Data:  rows,
 		},
 	}
 	return json.Marshal(g)


### PR DESCRIPTION
## Summary

Fixes DHS Registry ↔ Cerebrum 2.8.17 interop and cuts the Query-WS wire footprint.

The registry emitted the initial **SYNC** as **one grain per resource**, and fanned out changes **one grain per change**. IS-04 lets a grain''s `data` array carry many objects, and the reference controllers (nmos-cpp/sony) plus Cerebrum expect the current state as a **single batched sync grain**. One-grain-per-resource is legal but atypical:

- **Cerebrum 2.8.17** keeps only the first grain''s resource, so every node after the first showed a blank IP and read as *unavailable* — observed live: 22 nodes listed, only `dhs-test-node` (driven by a direct IS-05 poll) had an address.
- **Footprint** scaled with resource count: a `/senders` subscription against a real Neuron was **208 grains**, each repeating the full grain envelope.

Diagnosed against the live plant: all 22 nodes heartbeating 0–4 s, registry data correct, but `/subscriptions` had **0** active WS subs and the WS delivered the sync one node per frame.

## Changes

- **Initial SYNC** → one grain per topic carrying every matching resource in its `data[]`.
- **Change fan-out** → coalesced per the subscription''s `max_update_rate_ms` window into one grain per topic (the field was stored but unused). `rate<=0` keeps the historical immediate send.
- `buildGrain` split into `grainRow` + `buildBatchGrain`; flush timer torn down on `removeSub`.

## Tests

- `TestWebSocketSyncBatchedIntoOneGrain` — 3 nodes arrive as one grain with 3 rows.
- `TestBuildBatchGrain` — batching/topic/sync-pre==post + empty batch.
- `TestWebSocketChangeAggregation` — a burst inside one window is coalesced (frames < changes) with no id loss.

Spec-compliant both before and after (a grain *MAY* carry one or more objects); this aligns us with the batched form every reference controller expects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)