### PR TITLE
fix(amwa): mirror recovers from target 400 with an ordered resync

### DIFF
--- a/internal/amwa/registry/mirror.go
+++ b/internal/amwa/registry/mirror.go
@@ -99,7 +99,20 @@ type Mirror struct {
 	// full re-registration after a target eviction.
 	cache map[string]map[string]json.RawMessage
 	stats MirrorStats
+	// runCtx is the context passed to Run, captured so a debounced
+	// resync fired from a timer goroutine can honour shutdown.
+	runCtx context.Context
+	// resyncTimer debounces an ordered re-registration triggered when
+	// the target rejects a child whose parent has not landed yet
+	// (Cerebrum answers 400, not 404, to a missing parent reference).
+	// Non-nil while a resync is pending. Guarded by mu.
+	resyncTimer *time.Timer
 }
+
+// mirrorResyncDebounce collapses a burst of parent-missing 400s during
+// the initial concurrent fan-out into ONE ordered resync once the burst
+// settles.
+const mirrorResyncDebounce = 750 * time.Millisecond
 
 // NewMirror validates options and builds an unstarted mirror.
 func NewMirror(opts MirrorOptions) (*Mirror, error) {
@@ -143,6 +156,9 @@ func (m *Mirror) Run(ctx context.Context) error {
 	if !ok {
 		return fmt.Errorf("registry/mirror: unknown api-ver %q", m.opts.APIVer)
 	}
+	m.mu.Lock()
+	m.runCtx = ctx
+	m.mu.Unlock()
 	qc, err := query.NewClient(m.opts.Source, codec)
 	if err != nil {
 		return fmt.Errorf("registry/mirror: source: %w", err)
@@ -164,6 +180,12 @@ func (m *Mirror) Run(ctx context.Context) error {
 	}()
 
 	wg.Wait()
+	m.mu.Lock()
+	if m.resyncTimer != nil {
+		m.resyncTimer.Stop()
+		m.resyncTimer = nil
+	}
+	m.mu.Unlock()
 	return ctx.Err()
 }
 
@@ -202,7 +224,10 @@ func (m *Mirror) forwardRow(ctx context.Context, topic string, row is04.GrainDat
 		m.mu.Lock()
 		m.cache[topic][row.Path] = row.Post
 		m.mu.Unlock()
-		m.postResource(ctx, topic, row.Post)
+		// Live path: a 400 here means a parent has not been forwarded
+		// yet (the six topics stream concurrently), so allow it to
+		// trigger an ordered resync.
+		m.postResource(ctx, topic, row.Post, true)
 	case is04.ChangeRemoved:
 		m.mu.Lock()
 		delete(m.cache[topic], row.Path)
@@ -214,7 +239,13 @@ func (m *Mirror) forwardRow(ctx context.Context, topic string, row is04.GrainDat
 }
 
 // postResource POSTs one document to the target Registration API.
-func (m *Mirror) postResource(ctx context.Context, topic string, doc json.RawMessage) {
+//
+// allowResync gates the parent-missing recovery: the live forward path
+// passes true so a 400 (target rejects a child whose parent has not
+// landed yet) schedules an ordered resync; resync itself passes false so
+// a 400 during an already-ordered pass cannot trigger another resync (no
+// runaway loop when a resource is genuinely un-postable).
+func (m *Mirror) postResource(ctx context.Context, topic string, doc json.RawMessage, allowResync bool) {
 	body, err := json.Marshal(map[string]any{
 		"type": mirrorSingular[topic],
 		"data": json.RawMessage(doc),
@@ -238,11 +269,45 @@ func (m *Mirror) postResource(ctx context.Context, topic string, doc json.RawMes
 	drainClose(resp)
 	if resp.StatusCode != stdhttp.StatusOK && resp.StatusCode != stdhttp.StatusCreated {
 		m.fail("POST", topic, fmt.Errorf("HTTP %d", resp.StatusCode))
+		// A target's registration face validates parent references and
+		// answers 400 for a child whose parent has not been forwarded
+		// yet. The six collections stream concurrently, so this is
+		// expected during the initial fill; a debounced ordered resync
+		// re-POSTs the whole cache node→device→source→flow→sender→
+		// receiver, after which every parent precedes its children.
+		if allowResync && resp.StatusCode == stdhttp.StatusBadRequest {
+			m.scheduleResync()
+		}
 		return
 	}
 	m.mu.Lock()
 	m.stats.Forwarded++
 	m.mu.Unlock()
+}
+
+// scheduleResync arms (or extends) a debounced ordered resync. Repeated
+// parent-missing 400s during the initial fan-out collapse into one pass
+// once the burst goes quiet for mirrorResyncDebounce.
+func (m *Mirror) scheduleResync() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ctx := m.runCtx
+	if ctx == nil {
+		return
+	}
+	if m.resyncTimer != nil {
+		m.resyncTimer.Reset(mirrorResyncDebounce)
+		return
+	}
+	m.resyncTimer = time.AfterFunc(mirrorResyncDebounce, func() {
+		m.mu.Lock()
+		m.resyncTimer = nil
+		rctx := m.runCtx
+		m.mu.Unlock()
+		if rctx != nil && rctx.Err() == nil {
+			m.resync(rctx)
+		}
+	})
 }
 
 // deleteResource DELETEs one document from the target.
@@ -349,7 +414,9 @@ func (m *Mirror) resync(ctx context.Context) {
 			if ctx.Err() != nil {
 				return
 			}
-			m.postResource(ctx, topic, doc)
+			// allowResync=false: this pass is already in dependency
+			// order, so a 400 here is a genuine reject, not a race.
+			m.postResource(ctx, topic, doc, false)
 		}
 	}
 }

--- a/internal/amwa/registry/mirror_test.go
+++ b/internal/amwa/registry/mirror_test.go
@@ -64,6 +64,7 @@ type fakePlant struct {
 	healths  []string // node ids
 	healthCL []string // Content-Length header per health POST
 	evict    int      // answer this many health POSTs with 404 first
+	rejectN  map[string]int // "type:id" -> answer this many POSTs with 400 first (parent-missing sim)
 }
 
 func (p *fakePlant) targetHandler() stdhttp.Handler {
@@ -80,8 +81,17 @@ func (p *fakePlant) targetHandler() stdhttp.Handler {
 				ID string `json:"id"`
 			}
 			_ = json.Unmarshal(env.Data, &doc)
+			key := env.Type + ":" + doc.ID
 			p.mu.Lock()
-			p.posts = append(p.posts, env.Type+":"+doc.ID)
+			if p.rejectN != nil && p.rejectN[key] > 0 {
+				p.rejectN[key]--
+				p.mu.Unlock()
+				// Parent-missing simulation: target rejects a child until
+				// an ordered resync re-POSTs it (Cerebrum answers 400).
+				w.WriteHeader(stdhttp.StatusBadRequest)
+				return
+			}
+			p.posts = append(p.posts, key)
 			p.mu.Unlock()
 			w.WriteHeader(stdhttp.StatusCreated)
 		case r.Method == stdhttp.MethodDelete:
@@ -217,6 +227,51 @@ func TestMirrorForwardsAndDeletes(t *testing.T) {
 	if st.Forwarded < 3 || st.Deleted < 1 {
 		t.Errorf("stats = %+v", st)
 	}
+}
+
+// TestMirrorResyncsOn400ParentMissing: the target rejects a child whose
+// parent has not landed yet with 400 (Cerebrum's behaviour, not 404).
+// The mirror must recover by re-POSTing the whole catalogue in
+// dependency order — so the flow, rejected once, lands on the resync.
+func TestMirrorResyncsOn400ParentMissing(t *testing.T) {
+	// The flow is 400'd on its first POST, forcing the ordered resync.
+	plant := &fakePlant{rejectN: map[string]int{"flow:f1": 1}}
+	target := httptest.NewServer(plant.targetHandler())
+	defer target.Close()
+
+	frames := map[string][][]byte{
+		"nodes":   {grainFrame("nodes", "n1", "", `{"id":"n1","label":"n"}`)},
+		"devices": {grainFrame("devices", "d1", "", `{"id":"d1","node_id":"n1"}`)},
+		"sources": {grainFrame("sources", "src1", "", `{"id":"src1","device_id":"d1"}`)},
+		"flows":   {grainFrame("flows", "f1", "", `{"id":"f1","source_id":"src1","device_id":"d1"}`)},
+	}
+	src := httptest.NewServer(stdhttp.NotFoundHandler())
+	src.Config.Handler = plant.sourceHandler(t, func() string { return src.URL }, frames)
+	defer src.Close()
+
+	m, err := NewMirror(MirrorOptions{Source: src.URL, Target: target.URL, APIVer: "v1.3"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = m.Run(ctx) }()
+
+	// The flow is rejected once, a resync is scheduled + fires, and the
+	// flow lands on the ordered re-POST.
+	waitFor(t, 5*time.Second, func() bool {
+		if m.Stats().Resyncs < 1 {
+			return false
+		}
+		plant.mu.Lock()
+		defer plant.mu.Unlock()
+		for _, p := range plant.posts {
+			if p == "flow:f1" {
+				return true
+			}
+		}
+		return false
+	}, "flow:f1 to land after a 400-triggered ordered resync")
 }
 
 func TestMirrorHeartbeatsWithContentLengthAndResyncsOn404(t *testing.T) {


### PR DESCRIPTION
## Summary

The registry-to-registry **mirror** now recovers from a target `400` (parent-missing) with a debounced **ordered resync** — fixes the partial fill against EVS Cerebrum 2.8.17.

### Bug
The mirror streams all six collections concurrently and POSTed each row to the target as it arrived. Dependency ordering was applied **only** in the 404-eviction resync path. Cerebrum's registration face validates parent references and answers **400 (not 404)** when a child (source/flow/sender/receiver) arrives before its parent — so those rows were counted as failures and **never retried**. A fresh mirror populated Cerebrum only partially.

Verified live: a plain mirror left **~10/22** nodes with a 400 storm on `sources`/`flows`/`receivers`; POSTing the same resources **in order** returns 200/201 for every type.

### Fix
- On a `400` POST, the **live** forward path schedules a **debounced (750 ms) ordered resync** (`node → device → source → flow → sender → receiver`); the initial-fan-out 400s collapse into one in-order re-POST after the burst settles, so every parent precedes its children.
- `resync` posts with `allowResync=false` so an already-ordered pass can't trigger another resync (no runaway loop on a genuinely un-postable resource).
- Timer torn down on shutdown.

### Tests
- `TestMirrorResyncsOn400ParentMissing` — target 400s a flow on first attempt; the flow lands on the ordered resync. Ran 6× clean.
- Existing mirror tests unchanged + green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)