### PR TITLE
fix(amwa): jxsv SDP exactframerate from grain_rate

### DIFF
--- a/internal/amwa/provider/connection_sdp.go
+++ b/internal/amwa/provider/connection_sdp.go
@@ -166,9 +166,19 @@ func mediaLinesFor(f *is04.Flow, channels int) (media, rtpmap string, extra []st
 		if len(f.Components) > 0 && f.Components[0].BitDepth > 0 {
 			depth = f.Components[0].BitDepth
 		}
+		// exactframerate mirrors the Flow's grain_rate (ST 2110-22 /
+		// RFC 9134): integer rates render bare, fractional as num/den.
+		rate := ""
+		if f.GrainRate != nil && f.GrainRate.Numerator > 0 {
+			if f.GrainRate.Denominator <= 1 {
+				rate = fmt.Sprintf("; exactframerate=%d", f.GrainRate.Numerator)
+			} else {
+				rate = fmt.Sprintf("; exactframerate=%d/%d", f.GrainRate.Numerator, f.GrainRate.Denominator)
+			}
+		}
 		fmtp := fmt.Sprintf(
-			"fmtp:96 packetmode=0; profile=%s; level=%s; sublevel=%s; depth=%d; width=%d; height=%d; sampling=%s; colorimetry=BT709; TCS=SDR; RANGE=NARROW; SSN=ST2110-22:2019",
-			f.Profile, f.Level, f.Sublevel, depth, f.FrameWidth, f.FrameHeight, samplingFromComponents(f))
+			"fmtp:96 packetmode=0; profile=%s; level=%s; sublevel=%s; depth=%d; width=%d; height=%d; sampling=%s%s; colorimetry=BT709; TCS=SDR; RANGE=NARROW; SSN=ST2110-22:2019",
+			f.Profile, f.Level, f.Sublevel, depth, f.FrameWidth, f.FrameHeight, samplingFromComponents(f), rate)
 		return "video", "jxsv/90000", []string{fmtp}
 	case "video/MP2T":
 		// BCP-006-04 / ST 2110-22: MPEG transport stream over RTP.

--- a/internal/amwa/provider/sdp_coded_test.go
+++ b/internal/amwa/provider/sdp_coded_test.go
@@ -15,7 +15,8 @@ func TestMediaLinesForJXSV(t *testing.T) {
 	f := &is04.Flow{
 		Format: "urn:x-nmos:format:video", MediaType: "video/jxsv",
 		FrameWidth: 1920, FrameHeight: 1080,
-		Profile: "High444.12", Level: "2k-1", Sublevel: "Sublev3bpp",
+		GrainRate: &is04.GrainRate{Numerator: 50, Denominator: 1},
+		Profile:   "High444.12", Level: "2k-1", Sublevel: "Sublev3bpp",
 		Components: []is04.FlowVideoComponent{
 			{Name: "Y", Width: 1920, Height: 1080, BitDepth: 10},
 			{Name: "Cb", Width: 960, Height: 1080, BitDepth: 10},
@@ -29,7 +30,7 @@ func TestMediaLinesForJXSV(t *testing.T) {
 	if len(extra) != 1 {
 		t.Fatalf("extra=%v", extra)
 	}
-	for _, want := range []string{"profile=High444.12", "level=2k-1", "sublevel=Sublev3bpp", "width=1920", "height=1080", "packetmode=0", "SSN=ST2110-22:2019", "sampling=YCbCr-4:2:2"} {
+	for _, want := range []string{"profile=High444.12", "level=2k-1", "sublevel=Sublev3bpp", "width=1920", "height=1080", "packetmode=0", "SSN=ST2110-22:2019", "sampling=YCbCr-4:2:2", "exactframerate=50"} {
 		if !strings.Contains(extra[0], want) {
 			t.Errorf("fmtp missing %s: %s", want, extra[0])
 		}


### PR DESCRIPTION
BCP-006-01 test_05: manifest exactframerate must match flow grain_rate. Bare integer for whole rates, num/den for fractional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)