### PR TITLE
feat(amwa): IS-12 NCP WebSocket server over the shared MS-05 device model

### DIFF
--- a/internal/amwa/provider/configuration.go
+++ b/internal/amwa/provider/configuration.go
@@ -81,6 +81,33 @@ type IS14ConfigurationServer struct {
 	// onModelChanged reports a successful property write so the IS-04
 	// side can bump Device versions (IS-04 interactions doc).
 	onModelChanged func()
+
+	// onPropertyChanged reports a successful write with its identity —
+	// the IS-12 side turns it into PropertyChanged notifications for
+	// subscribed Controllers. Separate from onModelChanged because the
+	// IS-04 hook needs no detail and the IS-12 hook needs all of it.
+	onPropertyChanged func(ms05.NcOid, ms05.NcPropertyId, any)
+}
+
+// SetOnPropertyChanged installs the IS-12 notification hook.
+func (s *IS14ConfigurationServer) SetOnPropertyChanged(fn func(ms05.NcOid, ms05.NcPropertyId, any)) {
+	s.onPropertyChanged = fn
+}
+
+// objectByOid resolves a model object by its oid — the IS-12 address
+// form (IS-14 addresses the same objects by role path).
+func (s *IS14ConfigurationServer) objectByOid(oid int) *configObject {
+	if oid < 0 {
+		return nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, o := range s.objects {
+		if o.oid == ms05.NcOid(uint32(oid)) {
+			return o
+		}
+	}
+	return nil
 }
 
 // propKey renders a property id in the {level}p{index} URL form.
@@ -424,6 +451,9 @@ func (s *IS14ConfigurationServer) setProperty(obj *configObject, p *configProper
 	s.mu.Unlock()
 	if s.onModelChanged != nil {
 		s.onModelChanged()
+	}
+	if s.onPropertyChanged != nil {
+		s.onPropertyChanged(obj.oid, p.desc.ID, v)
 	}
 	return ms05.NcMethodStatusOk, nil
 }

--- a/internal/amwa/provider/ncp.go
+++ b/internal/amwa/provider/ncp.go
@@ -1,0 +1,509 @@
+// Layer-3 IS-12 Control Protocol provider — the NCP WebSocket.
+//
+// IS-12 is MS-05-02 over a WebSocket: a Controller opens the socket a
+// Device advertises as urn:x-nmos:control:ncp/v1.0 and drives the SAME
+// device model IS-14 serves over REST — Commands address objects by
+// oid where IS-14 addresses them by role path, but they are one model
+// with one state. Serving them from the same store is not an
+// optimisation, it is the spec's own consistency requirement: a
+// property written over IS-12 must read back changed over IS-14.
+//
+// The codec (dhs/internal/amwa/codec/is12) owns the six wire frames;
+// this file owns dispatch: which oid, which method, what result — and
+// the subscription fan-out that turns a successful Set into
+// PropertyChanged notifications for every subscribed socket.
+
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	stdhttp "net/http"
+	"sync"
+
+	"dhs/internal/amwa/codec/is04"
+	"dhs/internal/amwa/codec/is12"
+	"dhs/internal/amwa/codec/ms05"
+	httpsession "dhs/internal/amwa/session/http"
+)
+
+// ncpWireVersion is the IS-12 minor this endpoint serves.
+const ncpWireVersion = "v1.0"
+
+// NCPControlType is the device-control URN for IS-12.
+const NCPControlType = "urn:x-nmos:control:ncp/"
+
+// IS12NCPServer serves the NCP WebSocket over an IS-14 configuration
+// store.
+type IS12NCPServer struct {
+	logger *slog.Logger
+	config *IS14ConfigurationServer
+
+	mu    sync.Mutex
+	conns map[*ncpConn]struct{}
+}
+
+// ncpConn is one connected Controller with its subscription set.
+type ncpConn struct {
+	ws   *httpsession.WebSocket
+	subs map[int]struct{} // subscribed oids
+	// sendMu serialises writes: responses from the read loop and
+	// notifications from other connections' Sets share one socket.
+	sendMu sync.Mutex
+}
+
+// NewIS12NCPServer wires the NCP endpoint to the shared device model.
+func NewIS12NCPServer(logger *slog.Logger, config *IS14ConfigurationServer) *IS12NCPServer {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	s := &IS12NCPServer{logger: logger, config: config, conns: map[*ncpConn]struct{}{}}
+	config.SetOnPropertyChanged(s.notifyPropertyChanged)
+	return s
+}
+
+// Mount registers the WebSocket route. IS-12 has no REST surface —
+// the version path IS the socket.
+func (s *IS12NCPServer) Mount(srv *httpsession.Server) {
+	srv.HandleRaw("/x-nmos/ncp/"+ncpWireVersion, stdhttp.HandlerFunc(s.serveWS))
+}
+
+func (s *IS12NCPServer) serveWS(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	ws, err := httpsession.AcceptWebSocket(w, r)
+	if err != nil {
+		s.logger.Warn("provider/ncp: upgrade", "err", err)
+		return
+	}
+	c := &ncpConn{ws: ws, subs: map[int]struct{}{}}
+	s.mu.Lock()
+	s.conns[c] = struct{}{}
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		delete(s.conns, c)
+		s.mu.Unlock()
+		_ = ws.Close()
+	}()
+
+	for {
+		raw, err := ws.ReadText()
+		if err != nil {
+			return
+		}
+		msg, err := is12.Decode(raw)
+		if err != nil {
+			// IS-12 §6.4: a frame the Node cannot parse is answered
+			// with a protocol Error message, not a dropped socket — the
+			// Controller keeps its subscriptions.
+			s.send(c, is12.ErrorMessage{
+				Status:       int(ms05.NcMethodStatusBadCommandFormat),
+				ErrorMessage: err.Error(),
+			})
+			continue
+		}
+		switch m := msg.(type) {
+		case is12.CommandMessage:
+			s.send(c, s.handleCommands(m))
+		case is12.SubscriptionMessage:
+			s.send(c, s.handleSubscription(c, m))
+		default:
+			// A Node receives Commands and Subscriptions; the other
+			// four types travel Node→Controller only.
+			s.send(c, is12.ErrorMessage{
+				Status:       int(ms05.NcMethodStatusInvalidRequest),
+				ErrorMessage: fmt.Sprintf("message type %s is not valid towards a Node", msg.Kind()),
+			})
+		}
+	}
+}
+
+func (s *IS12NCPServer) send(c *ncpConn, m is12.Message) {
+	raw, err := is12.Encode(m)
+	if err != nil {
+		s.logger.Warn("provider/ncp: encode", "err", err)
+		return
+	}
+	c.sendMu.Lock()
+	defer c.sendMu.Unlock()
+	if err := c.ws.SendText(raw); err != nil {
+		s.logger.Warn("provider/ncp: send", "err", err)
+	}
+}
+
+// handleSubscription records the requested oids that name real objects
+// and answers with the accepted set (IS-12 §6.3: unknown oids are
+// simply not subscribed).
+func (s *IS12NCPServer) handleSubscription(c *ncpConn, m is12.SubscriptionMessage) is12.SubscriptionResponseMessage {
+	accepted := make([]int, 0, len(m.Subscriptions))
+	next := map[int]struct{}{}
+	for _, oid := range m.Subscriptions {
+		if s.config.objectByOid(oid) == nil {
+			continue
+		}
+		next[oid] = struct{}{}
+		accepted = append(accepted, oid)
+	}
+	// The message carries the WHOLE desired set — a subscription list
+	// replaces the previous one rather than accumulating.
+	c.subs = next
+	return is12.SubscriptionResponseMessage{Subscriptions: accepted}
+}
+
+// notifyPropertyChanged fans one successful property write out to
+// every socket subscribed to that oid.
+func (s *IS12NCPServer) notifyPropertyChanged(oid ms05.NcOid, id ms05.NcPropertyId, value any) {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return
+	}
+	n := is12.NotificationMessage{Notifications: []is12.Notification{{
+		OID:     int(oid),
+		EventID: is12.EventID{Level: 1, Index: 1}, // NcObject PropertyChanged
+		EventData: is12.PropertyChangedEventData{
+			PropertyID: is12.PropertyID{Level: int(id.Level), Index: int(id.Index)},
+			ChangeType: 0, // ValueChanged
+			Value:      raw,
+		},
+	}}}
+	s.mu.Lock()
+	targets := make([]*ncpConn, 0, len(s.conns))
+	for c := range s.conns {
+		if _, ok := c.subs[int(oid)]; ok {
+			targets = append(targets, c)
+		}
+	}
+	s.mu.Unlock()
+	for _, c := range targets {
+		s.send(c, n)
+	}
+}
+
+// handleCommands runs every command and answers each handle.
+func (s *IS12NCPServer) handleCommands(m is12.CommandMessage) is12.CommandResponseMessage {
+	out := is12.CommandResponseMessage{Responses: make([]is12.CommandResponseEntry, 0, len(m.Commands))}
+	for _, cmd := range m.Commands {
+		out.Responses = append(out.Responses, is12.CommandResponseEntry{
+			Handle: cmd.Handle,
+			Result: s.runCommand(cmd),
+		})
+	}
+	return out
+}
+
+// runCommand dispatches one command to the shared model. The result is
+// rendered to the wire MethodResult here so every arm can return the
+// typed ms05 result the schemas define.
+func (s *IS12NCPServer) runCommand(cmd is12.Command) is12.MethodResult {
+	obj := s.config.objectByOid(cmd.OID)
+	if obj == nil {
+		return ncpErr(ms05.NcMethodStatusBadOid, fmt.Sprintf("no object with oid %d", cmd.OID))
+	}
+	switch (is12.MethodID{Level: cmd.MethodID.Level, Index: cmd.MethodID.Index}) {
+	case is12.MethodID{Level: 1, Index: 1}: // NcObject.Get
+		return s.methodGet(obj, cmd.Arguments)
+	case is12.MethodID{Level: 1, Index: 2}: // NcObject.Set
+		return s.methodSet(obj, cmd.Arguments)
+	case is12.MethodID{Level: 1, Index: 3}: // GetSequenceItem
+		return s.methodSequence(obj, cmd.Arguments, "get")
+	case is12.MethodID{Level: 1, Index: 4}: // SetSequenceItem
+		return s.methodSequence(obj, cmd.Arguments, "set")
+	case is12.MethodID{Level: 1, Index: 5}: // AddSequenceItem
+		return s.methodSequence(obj, cmd.Arguments, "add")
+	case is12.MethodID{Level: 1, Index: 6}: // RemoveSequenceItem
+		return s.methodSequence(obj, cmd.Arguments, "remove")
+	case is12.MethodID{Level: 1, Index: 7}: // GetSequenceLength
+		return s.methodSequence(obj, cmd.Arguments, "length")
+	case is12.MethodID{Level: 2, Index: 1}: // NcBlock.GetMemberDescriptors
+		return s.methodMembers(obj, func(*configObject) bool { return true })
+	case is12.MethodID{Level: 2, Index: 2}: // FindMembersByPath
+		return s.methodFindByPath(obj, cmd.Arguments)
+	case is12.MethodID{Level: 2, Index: 3}: // FindMembersByRole
+		return s.methodFindByRole(obj, cmd.Arguments)
+	case is12.MethodID{Level: 2, Index: 4}: // FindMembersByClassId
+		return s.methodFindByClass(obj, cmd.Arguments)
+	case is12.MethodID{Level: 3, Index: 1}: // ClassManager.GetControlClass
+		return s.methodGetControlClass(obj, cmd.Arguments)
+	case is12.MethodID{Level: 3, Index: 2}: // ClassManager.GetDatatype
+		return s.methodGetDatatype(obj, cmd.Arguments)
+	}
+	return ncpErr(ms05.NcMethodStatusMethodNotImplemented,
+		fmt.Sprintf("method %dm%d is not implemented on oid %d", cmd.MethodID.Level, cmd.MethodID.Index, cmd.OID))
+}
+
+// classKey renders an NcClassId ([]int32 alias — not comparable) as a
+// stable map/compare key.
+func classKey(id ms05.NcClassId) string { return fmt.Sprint([]int32(id)) }
+
+// ncpErr renders an error MethodResult with the message the schemas
+// require alongside every non-2xx status.
+func ncpErr(st ms05.NcMethodStatus, msg string) is12.MethodResult {
+	raw, _ := json.Marshal(ms05.NcMethodResultError{Status: st, ErrorMessage: msg})
+	return wireResult(int(st), raw)
+}
+
+// wireResult re-packs a fully-rendered ms05 result body into the is12
+// MethodResult frame slot. The ms05 body already carries `status`;
+// is12.MethodResult mirrors it so transports can short-circuit.
+func wireResult(status int, body json.RawMessage) is12.MethodResult {
+	var peek struct {
+		Value        json.RawMessage `json:"value"`
+		ErrorMessage string          `json:"errorMessage"`
+	}
+	_ = json.Unmarshal(body, &peek)
+	return is12.MethodResult{Status: status, Value: peek.Value, ErrorMessage: peek.ErrorMessage}
+}
+
+func ncpOKValue(v any) is12.MethodResult {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return ncpErr(ms05.NcMethodStatusDeviceError, err.Error())
+	}
+	return is12.MethodResult{Status: int(ms05.NcMethodStatusOk), Value: raw}
+}
+
+func ncpOK() is12.MethodResult {
+	return is12.MethodResult{Status: int(ms05.NcMethodStatusOk)}
+}
+
+type ncpIDArg struct {
+	ID is12.PropertyID `json:"id"`
+}
+
+func (s *IS12NCPServer) methodGet(obj *configObject, args json.RawMessage) is12.MethodResult {
+	var a ncpIDArg
+	if err := json.Unmarshal(args, &a); err != nil {
+		return ncpErr(ms05.NcMethodStatusParameterError, "Get: "+err.Error())
+	}
+	p := obj.findProp(fmt.Sprintf("%dp%d", a.ID.Level, a.ID.Index))
+	if p == nil {
+		return ncpErr(ms05.NcMethodStatusPropertyNotImplemented,
+			fmt.Sprintf("no property %dp%d on oid %d", a.ID.Level, a.ID.Index, obj.oid))
+	}
+	s.config.mu.RLock()
+	v := p.value
+	s.config.mu.RUnlock()
+	return ncpOKValue(v)
+}
+
+func (s *IS12NCPServer) methodSet(obj *configObject, args json.RawMessage) is12.MethodResult {
+	var a struct {
+		ID    is12.PropertyID `json:"id"`
+		Value json.RawMessage `json:"value"`
+	}
+	if err := json.Unmarshal(args, &a); err != nil {
+		return ncpErr(ms05.NcMethodStatusParameterError, "Set: "+err.Error())
+	}
+	p := obj.findProp(fmt.Sprintf("%dp%d", a.ID.Level, a.ID.Index))
+	if p == nil {
+		return ncpErr(ms05.NcMethodStatusPropertyNotImplemented,
+			fmt.Sprintf("no property %dp%d on oid %d", a.ID.Level, a.ID.Index, obj.oid))
+	}
+	// setProperty locks the store itself and fires the model-changed +
+	// property-changed hooks on success.
+	if st, err := s.config.setProperty(obj, p, a.Value); err != nil {
+		return ncpErr(st, err.Error())
+	}
+	return ncpOK()
+}
+
+// methodSequence implements the five NcObject sequence methods over a
+// []any property value.
+func (s *IS12NCPServer) methodSequence(obj *configObject, args json.RawMessage, op string) is12.MethodResult {
+	var a struct {
+		ID    is12.PropertyID `json:"id"`
+		Index *int            `json:"index"`
+		Value json.RawMessage `json:"value"`
+	}
+	if err := json.Unmarshal(args, &a); err != nil {
+		return ncpErr(ms05.NcMethodStatusParameterError, op+": "+err.Error())
+	}
+	p := obj.findProp(fmt.Sprintf("%dp%d", a.ID.Level, a.ID.Index))
+	if p == nil {
+		return ncpErr(ms05.NcMethodStatusPropertyNotImplemented,
+			fmt.Sprintf("no property %dp%d on oid %d", a.ID.Level, a.ID.Index, obj.oid))
+	}
+	s.config.mu.Lock()
+	defer s.config.mu.Unlock()
+	seq, isSeq := p.value.([]any)
+	if !isSeq && p.value != nil {
+		return ncpErr(ms05.NcMethodStatusInvalidRequest,
+			fmt.Sprintf("property %s is not a sequence", p.desc.Name))
+	}
+	inBounds := func() bool { return a.Index != nil && *a.Index >= 0 && *a.Index < len(seq) }
+	switch op {
+	case "length":
+		return ncpOKValue(len(seq))
+	case "get":
+		if !inBounds() {
+			return ncpErr(ms05.NcMethodStatusIndexOutOfBounds, "GetSequenceItem: index out of bounds")
+		}
+		return ncpOKValue(seq[*a.Index])
+	case "set":
+		if p.desc.IsReadOnly {
+			return ncpErr(ms05.NcMethodStatusReadonly, "sequence property is readonly")
+		}
+		if !inBounds() {
+			return ncpErr(ms05.NcMethodStatusIndexOutOfBounds, "SetSequenceItem: index out of bounds")
+		}
+		var v any
+		if err := json.Unmarshal(a.Value, &v); err != nil {
+			return ncpErr(ms05.NcMethodStatusParameterError, err.Error())
+		}
+		seq[*a.Index] = v
+		p.value = seq
+		return ncpOK()
+	case "add":
+		if p.desc.IsReadOnly {
+			return ncpErr(ms05.NcMethodStatusReadonly, "sequence property is readonly")
+		}
+		var v any
+		if err := json.Unmarshal(a.Value, &v); err != nil {
+			return ncpErr(ms05.NcMethodStatusParameterError, err.Error())
+		}
+		p.value = append(seq, v)
+		return ncpOKValue(len(seq))
+	case "remove":
+		if p.desc.IsReadOnly {
+			return ncpErr(ms05.NcMethodStatusReadonly, "sequence property is readonly")
+		}
+		if !inBounds() {
+			return ncpErr(ms05.NcMethodStatusIndexOutOfBounds, "RemoveSequenceItem: index out of bounds")
+		}
+		p.value = append(seq[:*a.Index], seq[*a.Index+1:]...)
+		return ncpOK()
+	}
+	return ncpErr(ms05.NcMethodStatusMethodNotImplemented, op)
+}
+
+// methodMembers renders the member descriptors of a block. Only the
+// root block (oid 1) contains members in this flat model — matching
+// what IS-14's rolePaths listing serves.
+func (s *IS12NCPServer) methodMembers(obj *configObject, keep func(*configObject) bool) is12.MethodResult {
+	if int(obj.oid) != 1 {
+		return ncpErr(ms05.NcMethodStatusInvalidRequest,
+			fmt.Sprintf("oid %d is not a block", obj.oid))
+	}
+	s.config.mu.RLock()
+	defer s.config.mu.RUnlock()
+	out := []ms05.NcBlockMemberDescriptor{}
+	for _, key := range s.config.order {
+		o := s.config.objects[key]
+		if int(o.oid) == 1 {
+			continue // the block does not list itself
+		}
+		if keep(o) {
+			out = append(out, o.memberDescriptor())
+		}
+	}
+	return ncpOKValue(out)
+}
+
+func (s *IS12NCPServer) methodFindByPath(obj *configObject, args json.RawMessage) is12.MethodResult {
+	var a struct {
+		Path []string `json:"path"`
+	}
+	if err := json.Unmarshal(args, &a); err != nil {
+		return ncpErr(ms05.NcMethodStatusParameterError, "FindMembersByPath: "+err.Error())
+	}
+	if len(a.Path) == 0 {
+		return ncpErr(ms05.NcMethodStatusParameterError, "FindMembersByPath: empty path")
+	}
+	return s.methodMembers(obj, func(o *configObject) bool {
+		// The argument path is relative to the block: ["DeviceManager"].
+		rel := o.path
+		if len(rel) > 0 && rel[0] == "root" {
+			rel = rel[1:]
+		}
+		if len(rel) != len(a.Path) {
+			return false
+		}
+		for i := range rel {
+			if rel[i] != a.Path[i] {
+				return false
+			}
+		}
+		return true
+	})
+}
+
+func (s *IS12NCPServer) methodFindByRole(obj *configObject, args json.RawMessage) is12.MethodResult {
+	var a struct {
+		Role            string `json:"role"`
+		CaseSensitive   *bool  `json:"caseSensitive"`
+		MatchWholeString *bool `json:"matchWholeString"`
+	}
+	if err := json.Unmarshal(args, &a); err != nil {
+		return ncpErr(ms05.NcMethodStatusParameterError, "FindMembersByRole: "+err.Error())
+	}
+	if a.Role == "" {
+		return ncpErr(ms05.NcMethodStatusParameterError, "FindMembersByRole: empty role")
+	}
+	return s.methodMembers(obj, func(o *configObject) bool { return o.role == a.Role })
+}
+
+func (s *IS12NCPServer) methodFindByClass(obj *configObject, args json.RawMessage) is12.MethodResult {
+	var a struct {
+		ClassID        ms05.NcClassId `json:"classId"`
+		IncludeDerived *bool          `json:"includeDerived"`
+	}
+	if err := json.Unmarshal(args, &a); err != nil {
+		return ncpErr(ms05.NcMethodStatusParameterError, "FindMembersByClassId: "+err.Error())
+	}
+	want := classKey(a.ClassID)
+	return s.methodMembers(obj, func(o *configObject) bool { return classKey(o.classID) == want })
+}
+
+func (s *IS12NCPServer) methodGetControlClass(obj *configObject, args json.RawMessage) is12.MethodResult {
+	var a struct {
+		ClassID          ms05.NcClassId `json:"classId"`
+		IncludeInherited *bool          `json:"includeInherited"`
+	}
+	if err := json.Unmarshal(args, &a); err != nil {
+		return ncpErr(ms05.NcMethodStatusParameterError, "GetControlClass: "+err.Error())
+	}
+	class, ok := ms05.FlattenedClass(a.ClassID)
+	if !ok {
+		return ncpErr(ms05.NcMethodStatusParameterError,
+			fmt.Sprintf("no class %s", classKey(a.ClassID)))
+	}
+	return ncpOKValue(class)
+}
+
+func (s *IS12NCPServer) methodGetDatatype(obj *configObject, args json.RawMessage) is12.MethodResult {
+	var a struct {
+		Name             string `json:"name"`
+		IncludeInherited *bool  `json:"includeInherited"`
+	}
+	if err := json.Unmarshal(args, &a); err != nil {
+		return ncpErr(ms05.NcMethodStatusParameterError, "GetDatatype: "+err.Error())
+	}
+	dt, ok := ms05.FlattenedDatatype(a.Name)
+	if !ok {
+		return ncpErr(ms05.NcMethodStatusParameterError, fmt.Sprintf("no datatype %q", a.Name))
+	}
+	return ncpOKValue(dt)
+}
+
+// attachNCPAPI mounts IS-12 and advertises it on every Device. The
+// href scheme is ws — the control endpoint IS the socket.
+func (s *IS04NodeServer) attachNCPAPI(srv *httpsession.Server) {
+	if s.configuration == nil {
+		return
+	}
+	s.ncp = NewIS12NCPServer(s.logger, s.configuration)
+	s.ncp.Mount(srv)
+	host := s.controlHost()
+	wsScheme := "ws"
+	if s.scheme() == "https" {
+		wsScheme = "wss"
+	}
+	for i := range s.bundle.Devices {
+		d := &s.bundle.Devices[i]
+		upsertControl(&d.Controls, is04.DeviceControl{
+			Type:          NCPControlType + ncpWireVersion,
+			Href:          wsScheme + "://" + host + "/x-nmos/ncp/" + ncpWireVersion,
+			Authorization: s.authOn(),
+		})
+	}
+}

--- a/internal/amwa/provider/ncp_test.go
+++ b/internal/amwa/provider/ncp_test.go
@@ -1,0 +1,212 @@
+package provider
+
+// IS-12 NCP WebSocket over a live Node: the control endpoint is
+// advertised, Commands drive the SAME model IS-14 serves, a
+// Subscription turns a Set into a PropertyChanged Notification, and
+// protocol errors answer without dropping the socket.
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"dhs/internal/amwa/codec/is12"
+	httpsession "dhs/internal/amwa/session/http"
+)
+
+func serveNCPNode(t *testing.T) string {
+	t.Helper()
+	addr := freeAddr(t)
+	s, err := NewIS04NodeServer(nil, validBundle(), IS04NodeConfig{
+		Bind: addr, DiscoveryMode: "static", ConnectionAPIVer: "v1.2", APIVer: "v1.3",
+	})
+	if err != nil {
+		t.Fatalf("NewIS04NodeServer: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() { defer wg.Done(); _ = s.Serve(ctx) }()
+	t.Cleanup(func() { cancel(); _ = s.Stop(); wg.Wait() })
+	if !waitReachable(t, "http://"+addr+"/__ready__", 2*time.Second) {
+		t.Fatal("server never came up")
+	}
+	return addr
+}
+
+func ncpDial(t *testing.T, addr string) *httpsession.WebSocket {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ws, err := httpsession.DialWebSocket(ctx, "ws://"+addr+"/x-nmos/ncp/v1.0", nil)
+	if err != nil {
+		t.Fatalf("dial ncp: %v", err)
+	}
+	t.Cleanup(func() { _ = ws.Close() })
+	return ws
+}
+
+func ncpRoundTrip(t *testing.T, ws *httpsession.WebSocket, m is12.Message) is12.Message {
+	t.Helper()
+	raw, err := is12.Encode(m)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if err := ws.SendText(raw); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	_ = ws.SetReadDeadline(time.Now().Add(3 * time.Second))
+	resp, err := ws.ReadText()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	out, err := is12.Decode(resp)
+	if err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return out
+}
+
+func TestNCPControlAdvertised(t *testing.T) {
+	addr := serveNCPNode(t)
+	st, body := mxlGet(t, "http://"+addr+"/x-nmos/node/v1.3/devices")
+	if st != 200 {
+		t.Fatalf("devices GET = %d", st)
+	}
+	if !strings.Contains(string(body), NCPControlType+ncpWireVersion) {
+		t.Errorf("devices do not advertise %s: %s", NCPControlType+ncpWireVersion, body)
+	}
+	if !strings.Contains(string(body), "ws://") {
+		t.Errorf("ncp control href must be a ws:// URL: %s", body)
+	}
+}
+
+func TestNCPGetAndErrors(t *testing.T) {
+	addr := serveNCPNode(t)
+	ws := ncpDial(t, addr)
+
+	// Get root role (NcObject 1p5) on oid 1.
+	resp := ncpRoundTrip(t, ws, is12.CommandMessage{Commands: []is12.Command{{
+		Handle: 7, OID: 1, MethodID: is12.MethodID{Level: 1, Index: 1},
+		Arguments: json.RawMessage(`{"id":{"level":1,"index":5}}`),
+	}}})
+	cr, ok := resp.(is12.CommandResponseMessage)
+	if !ok {
+		t.Fatalf("response type %T", resp)
+	}
+	if len(cr.Responses) != 1 || cr.Responses[0].Handle != 7 {
+		t.Fatalf("responses = %+v", cr.Responses)
+	}
+	if cr.Responses[0].Result.Status != 200 || string(cr.Responses[0].Result.Value) != `"root"` {
+		t.Errorf("root role result = %+v", cr.Responses[0].Result)
+	}
+
+	// Unknown oid answers per-command, not with a socket error.
+	resp = ncpRoundTrip(t, ws, is12.CommandMessage{Commands: []is12.Command{{
+		Handle: 8, OID: 9999, MethodID: is12.MethodID{Level: 1, Index: 1},
+		Arguments: json.RawMessage(`{"id":{"level":1,"index":5}}`),
+	}}})
+	cr = resp.(is12.CommandResponseMessage)
+	if cr.Responses[0].Result.Status != 404 {
+		t.Errorf("bad oid status = %d, want 404", cr.Responses[0].Result.Status)
+	}
+
+	// Garbage frame answers a protocol Error and keeps the socket.
+	if err := ws.SendText([]byte(`{"messageType":`)); err != nil {
+		t.Fatalf("send garbage: %v", err)
+	}
+	_ = ws.SetReadDeadline(time.Now().Add(3 * time.Second))
+	raw, err := ws.ReadText()
+	if err != nil {
+		t.Fatalf("read after garbage: %v", err)
+	}
+	em, err := is12.Decode(raw)
+	if err != nil {
+		t.Fatalf("decode error frame: %v", err)
+	}
+	if e, ok := em.(is12.ErrorMessage); !ok || e.Status != 400 {
+		t.Errorf("garbage answer = %#v, want ErrorMessage 400", em)
+	}
+
+	// Root block members list the model.
+	resp = ncpRoundTrip(t, ws, is12.CommandMessage{Commands: []is12.Command{{
+		Handle: 9, OID: 1, MethodID: is12.MethodID{Level: 2, Index: 1},
+		Arguments: json.RawMessage(`{}`),
+	}}})
+	cr = resp.(is12.CommandResponseMessage)
+	if cr.Responses[0].Result.Status != 200 || !strings.Contains(string(cr.Responses[0].Result.Value), "DeviceManager") {
+		t.Errorf("members = %+v", cr.Responses[0].Result)
+	}
+
+	// ClassManager GetControlClass for NcObject [1].
+	resp = ncpRoundTrip(t, ws, is12.CommandMessage{Commands: []is12.Command{{
+		Handle: 10, OID: 1, MethodID: is12.MethodID{Level: 3, Index: 1},
+		Arguments: json.RawMessage(`{"classId":[1],"includeInherited":true}`),
+	}}})
+	cr = resp.(is12.CommandResponseMessage)
+	if cr.Responses[0].Result.Status != 200 || !strings.Contains(string(cr.Responses[0].Result.Value), "NcObject") {
+		t.Errorf("GetControlClass = %+v", cr.Responses[0].Result)
+	}
+}
+
+func TestNCPSubscriptionNotifiesOnSet(t *testing.T) {
+	addr := serveNCPNode(t)
+	ws := ncpDial(t, addr)
+
+	// Subscribe to root (oid 1) — unknown oids are dropped from the
+	// accepted list.
+	resp := ncpRoundTrip(t, ws, is12.SubscriptionMessage{Subscriptions: []int{1, 4242}})
+	sr, ok := resp.(is12.SubscriptionResponseMessage)
+	if !ok || len(sr.Subscriptions) != 1 || sr.Subscriptions[0] != 1 {
+		t.Fatalf("subscription response = %#v", resp)
+	}
+
+	// Set root userLabel (1p6) → CommandResponse + Notification.
+	raw, _ := is12.Encode(is12.CommandMessage{Commands: []is12.Command{{
+		Handle: 11, OID: 1, MethodID: is12.MethodID{Level: 1, Index: 2},
+		Arguments: json.RawMessage(`{"id":{"level":1,"index":6},"value":"ncp-label"}`),
+	}}})
+	if err := ws.SendText(raw); err != nil {
+		t.Fatalf("send set: %v", err)
+	}
+	gotResponse, gotNotification := false, false
+	for i := 0; i < 2; i++ {
+		_ = ws.SetReadDeadline(time.Now().Add(3 * time.Second))
+		frame, err := ws.ReadText()
+		if err != nil {
+			t.Fatalf("read %d: %v", i, err)
+		}
+		m, err := is12.Decode(frame)
+		if err != nil {
+			t.Fatalf("decode %d: %v", i, err)
+		}
+		switch v := m.(type) {
+		case is12.CommandResponseMessage:
+			gotResponse = true
+			if v.Responses[0].Result.Status != 200 {
+				t.Errorf("set result = %+v", v.Responses[0].Result)
+			}
+		case is12.NotificationMessage:
+			gotNotification = true
+			n := v.Notifications[0]
+			if n.OID != 1 || n.EventData.PropertyID != (is12.PropertyID{Level: 1, Index: 6}) {
+				t.Errorf("notification = %+v", n)
+			}
+			if string(n.EventData.Value) != `"ncp-label"` {
+				t.Errorf("notification value = %s", n.EventData.Value)
+			}
+		}
+	}
+	if !gotResponse || !gotNotification {
+		t.Errorf("gotResponse=%v gotNotification=%v", gotResponse, gotNotification)
+	}
+
+	// The write is visible over IS-14 — one model, two protocols.
+	st, body := mxlGet(t, "http://"+addr+"/x-nmos/configuration/v1.0/rolePaths/root/properties/1p6/value")
+	if st != 200 || !strings.Contains(string(body), "ncp-label") {
+		t.Errorf("IS-14 read-back = %d %s", st, body)
+	}
+}

--- a/internal/amwa/provider/node.go
+++ b/internal/amwa/provider/node.go
@@ -232,6 +232,11 @@ type IS04NodeServer struct {
 	// disables it.
 	configuration *IS14ConfigurationServer
 
+	// ncp is the IS-12 Control Protocol WebSocket, serving the SAME
+	// device model as configuration. Nil (configuration disabled)
+	// disables it.
+	ncp *IS12NCPServer
+
 	// events is the IS-07 Event & Tally API. Nil disables it.
 	events *IS07EventsServer
 
@@ -535,6 +540,7 @@ func (s *IS04NodeServer) Serve(ctx context.Context) error {
 	s.attachChannelMappingAPI(srv)
 	s.attachStreamCompatAPI(srv)
 	s.attachConfigurationAPI(srv)
+	s.attachNCPAPI(srv)
 	s.attachEventsAPI(srv)
 	s.http = srv
 


### PR DESCRIPTION
Serves the IS-12 Control Protocol WebSocket at /x-nmos/ncp/v1.0 over the SAME device model IS-14 serves (one store, two protocols). Command dispatch (NcObject/NcBlock/ClassManager), subscriptions with PropertyChanged notifications, protocol-error handling. Unblocks IS-12-01 + BCP-008 suites. Full sweep green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)