### PR TITLE
feat(amwa): BCP-008 status monitors on the device model

### DIFF
--- a/internal/amwa/codec/ms05/framework.go
+++ b/internal/amwa/codec/ms05/framework.go
@@ -23,7 +23,11 @@ import (
 // and datatypes part of every conforming device's catalogue, and the
 // AMWA suite checks for them by name.
 //
-//go:embed testdata/schemas/v1.0.0/classes/*.json testdata/schemas/v1.0.0/datatypes/*.json testdata/schemas/v1.0.0/featuresets/device-configuration/classes/*.json testdata/schemas/v1.0.0/featuresets/device-configuration/datatypes/*.json
+// The monitoring feature set rides along the same way: BCP-008-01/-02
+// put NcReceiverMonitor / NcSenderMonitor (1.2.2.x) and their status
+// datatypes in the catalogue of every device that monitors streams.
+//
+//go:embed testdata/schemas/v1.0.0/classes/*.json testdata/schemas/v1.0.0/datatypes/*.json testdata/schemas/v1.0.0/featuresets/device-configuration/classes/*.json testdata/schemas/v1.0.0/featuresets/device-configuration/datatypes/*.json testdata/schemas/v1.0.0/featuresets/monitoring/classes/*.json testdata/schemas/v1.0.0/featuresets/monitoring/datatypes/*.json
 var frameworkFS embed.FS
 
 var (
@@ -92,6 +96,7 @@ func loadFramework() {
 	for _, dir := range []string{
 		"testdata/schemas/v1.0.0/classes",
 		"testdata/schemas/v1.0.0/featuresets/device-configuration/classes",
+		"testdata/schemas/v1.0.0/featuresets/monitoring/classes",
 	} {
 		if err := load(dir, loadClasses); err != nil {
 			frameworkErr = err
@@ -101,6 +106,7 @@ func loadFramework() {
 	for _, dir := range []string{
 		"testdata/schemas/v1.0.0/datatypes",
 		"testdata/schemas/v1.0.0/featuresets/device-configuration/datatypes",
+		"testdata/schemas/v1.0.0/featuresets/monitoring/datatypes",
 	} {
 		if err := load(dir, loadDatatypes); err != nil {
 			frameworkErr = err

--- a/internal/amwa/codec/ms05/testdata/schemas/v1.0.0/featuresets/monitoring/classes/1.2.2.1.json
+++ b/internal/amwa/codec/ms05/testdata/schemas/v1.0.0/featuresets/monitoring/classes/1.2.2.1.json
@@ -1,0 +1,245 @@
+{
+  "description": "Receiver monitor class descriptor",
+  "classId": [
+    1,
+    2,
+    2,
+    1
+  ],
+  "name": "NcReceiverMonitor",
+  "fixedRole": null,
+  "properties": [
+    {
+      "description": "Link status property",
+      "id": {
+        "level": 4,
+        "index": 1
+      },
+      "name": "linkStatus",
+      "typeName": "NcLinkStatus",
+      "isReadOnly": true,
+      "isNullable": false,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    },
+    {
+      "description": "Link status message property",
+      "id": {
+        "level": 4,
+        "index": 2
+      },
+      "name": "linkStatusMessage",
+      "typeName": "NcString",
+      "isReadOnly": true,
+      "isNullable": true,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    },
+    {
+      "description": "Link status transition counter property",
+      "id": {
+        "level": 4,
+        "index": 3
+      },
+      "name": "linkStatusTransitionCounter",
+      "typeName": "NcUint64",
+      "isReadOnly": true,
+      "isNullable": false,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    },
+    {
+      "description": "Connection status property",
+      "id": {
+        "level": 4,
+        "index": 4
+      },
+      "name": "connectionStatus",
+      "typeName": "NcConnectionStatus",
+      "isReadOnly": true,
+      "isNullable": false,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    },
+    {
+      "description": "Connection status message property",
+      "id": {
+        "level": 4,
+        "index": 5
+      },
+      "name": "connectionStatusMessage",
+      "typeName": "NcString",
+      "isReadOnly": true,
+      "isNullable": true,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    },
+    {
+      "description": "Connection status transition counter property",
+      "id": {
+        "level": 4,
+        "index": 6
+      },
+      "name": "connectionStatusTransitionCounter",
+      "typeName": "NcUint64",
+      "isReadOnly": true,
+      "isNullable": false,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    },
+    {
+      "description": "External synchronization status property",
+      "id": {
+        "level": 4,
+        "index": 7
+      },
+      "name": "externalSynchronizationStatus",
+      "typeName": "NcSynchronizationStatus",
+      "isReadOnly": true,
+      "isNullable": false,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    },
+    {
+      "description": "External synchronization status message property",
+      "id": {
+        "level": 4,
+        "index": 8
+      },
+      "name": "externalSynchronizationStatusMessage",
+      "typeName": "NcString",
+      "isReadOnly": true,
+      "isNullable": true,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    },
+    {
+      "description": "External synchronization status transition counter property",
+      "id": {
+        "level": 4,
+        "index": 9
+      },
+      "name": "externalSynchronizationStatusTransitionCounter",
+      "typeName": "NcUint64",
+      "isReadOnly": true,
+      "isNullable": false,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    },
+    {
+      "description": "Synchronization source id property",
+      "id": {
+        "level": 4,
+        "index": 10
+      },
+      "name": "synchronizationSourceId",
+      "typeName": "NcString",
+      "isReadOnly": true,
+      "isNullable": true,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    },
+    {
+      "description": "Stream status property",
+      "id": {
+        "level": 4,
+        "index": 11
+      },
+      "name": "streamStatus",
+      "typeName": "NcStreamStatus",
+      "isReadOnly": true,
+      "isNullable": false,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    },
+    {
+      "description": "Stream status message property",
+      "id": {
+        "level": 4,
+        "index": 12
+      },
+      "name": "streamStatusMessage",
+      "typeName": "NcString",
+      "isReadOnly": true,
+      "isNullable": true,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    },
+    {
+      "description": "Stream status transition counter property",
+      "id": {
+        "level": 4,
+        "index": 13
+      },
+      "name": "streamStatusTransitionCounter",
+      "typeName": "NcUint64",
+      "isReadOnly": true,
+      "isNullable": false,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    },
+    {
+      "description": "Automatic reset counters and status messages property (default: true)",
+      "id": {
+        "level": 4,
+        "index": 14
+      },
+      "name": "autoResetCountersAndMessages",
+      "typeName": "NcBoolean",
+      "isReadOnly": false,
+      "isNullable": false,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    }
+  ],
+  "methods": [
+    {
+      "description": "Gets the lost packet counters",
+      "id": {
+        "level": 4,
+        "index": 1
+      },
+      "name": "GetLostPacketCounters",
+      "resultDatatype": "NcMethodResultCounters",
+      "parameters": [],
+      "isDeprecated": false
+    },
+    {
+      "description": "Gets the late packet counters",
+      "id": {
+        "level": 4,
+        "index": 2
+      },
+      "name": "GetLatePacketCounters",
+      "resultDatatype": "NcMethodResultCounters",
+      "parameters": [],
+      "isDeprecated": false
+    },
+    {
+      "description": "Resets ALL counters and status messages",
+      "id": {
+        "level": 4,
+        "index": 3
+      },
+      "name": "ResetCountersAndMessages",
+      "resultDatatype": "NcMethodResult",
+      "parameters": [],
+      "isDeprecated": false
+    }
+  ],
+  "events": []
+}

--- a/internal/amwa/codec/ms05/testdata/schemas/v1.0.0/featuresets/monitoring/classes/1.2.2.2.json
+++ b/internal/amwa/codec/ms05/testdata/schemas/v1.0.0/featuresets/monitoring/classes/1.2.2.2.json
@@ -1,0 +1,234 @@
+{
+  "description": "Sender monitor class descriptor",
+  "classId": [
+    1,
+    2,
+    2,
+    2
+  ],
+  "name": "NcSenderMonitor",
+  "fixedRole": null,
+  "properties": [
+    {
+      "description": "Link status property",
+      "id": {
+        "level": 4,
+        "index": 1
+      },
+      "name": "linkStatus",
+      "typeName": "NcLinkStatus",
+      "isReadOnly": true,
+      "isNullable": false,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    },
+    {
+      "description": "Link status message property",
+      "id": {
+        "level": 4,
+        "index": 2
+      },
+      "name": "linkStatusMessage",
+      "typeName": "NcString",
+      "isReadOnly": true,
+      "isNullable": true,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    },
+    {
+      "description": "Link status transition counter property",
+      "id": {
+        "level": 4,
+        "index": 3
+      },
+      "name": "linkStatusTransitionCounter",
+      "typeName": "NcUint64",
+      "isReadOnly": true,
+      "isNullable": false,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    },
+    {
+      "description": "Transmission status property",
+      "id": {
+        "level": 4,
+        "index": 4
+      },
+      "name": "transmissionStatus",
+      "typeName": "NcTransmissionStatus",
+      "isReadOnly": true,
+      "isNullable": false,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    },
+    {
+      "description": "Transmission status message property",
+      "id": {
+        "level": 4,
+        "index": 5
+      },
+      "name": "transmissionStatusMessage",
+      "typeName": "NcString",
+      "isReadOnly": true,
+      "isNullable": true,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    },
+    {
+      "description": "Transmission status transition counter property",
+      "id": {
+        "level": 4,
+        "index": 6
+      },
+      "name": "transmissionStatusTransitionCounter",
+      "typeName": "NcUint64",
+      "isReadOnly": true,
+      "isNullable": false,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    },
+    {
+      "description": "External synchronization status property",
+      "id": {
+        "level": 4,
+        "index": 7
+      },
+      "name": "externalSynchronizationStatus",
+      "typeName": "NcSynchronizationStatus",
+      "isReadOnly": true,
+      "isNullable": false,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    },
+    {
+      "description": "External synchronization status message property",
+      "id": {
+        "level": 4,
+        "index": 8
+      },
+      "name": "externalSynchronizationStatusMessage",
+      "typeName": "NcString",
+      "isReadOnly": true,
+      "isNullable": true,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    },
+    {
+      "description": "External synchronization status transition counter property",
+      "id": {
+        "level": 4,
+        "index": 9
+      },
+      "name": "externalSynchronizationStatusTransitionCounter",
+      "typeName": "NcUint64",
+      "isReadOnly": true,
+      "isNullable": false,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    },
+    {
+      "description": "Synchronization source id property",
+      "id": {
+        "level": 4,
+        "index": 10
+      },
+      "name": "synchronizationSourceId",
+      "typeName": "NcString",
+      "isReadOnly": true,
+      "isNullable": true,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    },
+    {
+      "description": "Essence status property",
+      "id": {
+        "level": 4,
+        "index": 11
+      },
+      "name": "essenceStatus",
+      "typeName": "NcEssenceStatus",
+      "isReadOnly": true,
+      "isNullable": false,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    },
+    {
+      "description": "Essence status message property",
+      "id": {
+        "level": 4,
+        "index": 12
+      },
+      "name": "essenceStatusMessage",
+      "typeName": "NcString",
+      "isReadOnly": true,
+      "isNullable": true,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    },
+    {
+      "description": "Essence status transition counter property",
+      "id": {
+        "level": 4,
+        "index": 13
+      },
+      "name": "essenceStatusTransitionCounter",
+      "typeName": "NcUint64",
+      "isReadOnly": true,
+      "isNullable": false,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    },
+    {
+      "description": "Automatic reset counters and status messages property (default: true)",
+      "id": {
+        "level": 4,
+        "index": 14
+      },
+      "name": "autoResetCountersAndMessages",
+      "typeName": "NcBoolean",
+      "isReadOnly": false,
+      "isNullable": false,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    }
+  ],
+  "methods": [
+    {
+      "description": "Gets the transmission error counters",
+      "id": {
+        "level": 4,
+        "index": 1
+      },
+      "name": "GetTransmissionErrorCounters",
+      "resultDatatype": "NcMethodResultCounters",
+      "parameters": [],
+      "isDeprecated": false
+    },
+    {
+      "description": "Resets ALL counters and status messages",
+      "id": {
+        "level": 4,
+        "index": 2
+      },
+      "name": "ResetCountersAndMessages",
+      "resultDatatype": "NcMethodResult",
+      "parameters": [],
+      "isDeprecated": false
+    }
+  ],
+  "events": []
+}

--- a/internal/amwa/codec/ms05/testdata/schemas/v1.0.0/featuresets/monitoring/classes/1.2.2.json
+++ b/internal/amwa/codec/ms05/testdata/schemas/v1.0.0/featuresets/monitoring/classes/1.2.2.json
@@ -1,0 +1,56 @@
+{
+  "description": "Baseline status monitoring class",
+  "classId": [
+    1,
+    2,
+    2
+  ],
+  "name": "NcStatusMonitor",
+  "fixedRole": null,
+  "properties": [
+    {
+      "description": "Overall status property",
+      "id": {
+        "level": 3,
+        "index": 1
+      },
+      "name": "overallStatus",
+      "typeName": "NcOverallStatus",
+      "isReadOnly": true,
+      "isNullable": false,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    },
+    {
+      "description": "Overall status message property",
+      "id": {
+        "level": 3,
+        "index": 2
+      },
+      "name": "overallStatusMessage",
+      "typeName": "NcString",
+      "isReadOnly": true,
+      "isNullable": true,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    },
+    {
+      "description": "Status reporting delay property (in seconds, default is 3s and 0 means no delay)",
+      "id": {
+        "level": 3,
+        "index": 3
+      },
+      "name": "statusReportingDelay",
+      "typeName": "NcUint32",
+      "isReadOnly": false,
+      "isNullable": false,
+      "isSequence": false,
+      "isDeprecated": false,
+      "constraints": null
+    }
+  ],
+  "methods": [],
+  "events": []
+}

--- a/internal/amwa/codec/ms05/testdata/schemas/v1.0.0/featuresets/monitoring/datatypes/NcConnectionStatus.json
+++ b/internal/amwa/codec/ms05/testdata/schemas/v1.0.0/featuresets/monitoring/datatypes/NcConnectionStatus.json
@@ -1,0 +1,28 @@
+{
+    "description": "Connection status enum data type",
+    "name": "NcConnectionStatus",
+    "type": 3,
+    "items": [
+        {
+            "description": "Inactive",
+            "name": "Inactive",
+            "value": 0
+        },
+        {
+            "description": "Active and healthy",
+            "name": "Healthy",
+            "value": 1
+        },
+        {
+            "description": "Active and partially healthy",
+            "name": "PartiallyHealthy",
+            "value": 2
+        },
+        {
+            "description": "Active and unhealthy",
+            "name": "Unhealthy",
+            "value": 3
+        }
+    ],
+    "constraints": null
+}

--- a/internal/amwa/codec/ms05/testdata/schemas/v1.0.0/featuresets/monitoring/datatypes/NcCounter.json
+++ b/internal/amwa/codec/ms05/testdata/schemas/v1.0.0/featuresets/monitoring/datatypes/NcCounter.json
@@ -1,0 +1,33 @@
+{
+    "description": "Counter data type",
+    "name": "NcCounter",
+    "type": 2,
+    "fields": [
+        {
+            "description": "Counter name",
+            "name": "name",
+            "typeName": "NcString",
+            "isNullable": false,
+            "isSequence": false,
+            "constraints": null
+        },
+        {
+            "description": "Counter value",
+            "name": "value",
+            "typeName": "NcUint64",
+            "isNullable": false,
+            "isSequence": false,
+            "constraints": null
+        },
+        {
+            "description": "Optional counter description",
+            "name": "description",
+            "typeName": "NcString",
+            "isNullable": true,
+            "isSequence": false,
+            "constraints": null
+        }
+    ],
+    "parentType": null,
+    "constraints": null
+}

--- a/internal/amwa/codec/ms05/testdata/schemas/v1.0.0/featuresets/monitoring/datatypes/NcEssenceStatus.json
+++ b/internal/amwa/codec/ms05/testdata/schemas/v1.0.0/featuresets/monitoring/datatypes/NcEssenceStatus.json
@@ -1,0 +1,28 @@
+{
+    "description": "Essence status enum data type",
+    "name": "NcEssenceStatus",
+    "type": 3,
+    "items": [
+        {
+            "description": "Inactive",
+            "name": "Inactive",
+            "value": 0
+        },
+        {
+            "description": "Active and healthy",
+            "name": "Healthy",
+            "value": 1
+        },
+        {
+            "description": "Active and partially healthy",
+            "name": "PartiallyHealthy",
+            "value": 2
+        },
+        {
+            "description": "Active and unhealthy",
+            "name": "Unhealthy",
+            "value": 3
+        }
+    ],
+    "constraints": null
+}

--- a/internal/amwa/codec/ms05/testdata/schemas/v1.0.0/featuresets/monitoring/datatypes/NcLinkStatus.json
+++ b/internal/amwa/codec/ms05/testdata/schemas/v1.0.0/featuresets/monitoring/datatypes/NcLinkStatus.json
@@ -1,0 +1,23 @@
+{
+    "description": "Link status enum data type",
+    "name": "NcLinkStatus",
+    "type": 3,
+    "items": [
+        {
+            "description": "All the associated network interfaces are up",
+            "name": "AllUp",
+            "value": 1
+        },
+        {
+            "description": "Some of the associated network interfaces are down",
+            "name": "SomeDown",
+            "value": 2
+        },
+        {
+            "description": "All the associated network interfaces are down",
+            "name": "AllDown",
+            "value": 3
+        }
+    ],
+    "constraints": null
+}

--- a/internal/amwa/codec/ms05/testdata/schemas/v1.0.0/featuresets/monitoring/datatypes/NcMethodResultCounters.json
+++ b/internal/amwa/codec/ms05/testdata/schemas/v1.0.0/featuresets/monitoring/datatypes/NcMethodResultCounters.json
@@ -1,0 +1,17 @@
+{
+  "description": "Counters method result",
+  "name": "NcMethodResultCounters",
+  "type": 2,
+  "fields": [
+    {
+      "description": "Counters",
+      "name": "value",
+      "typeName": "NcCounter",
+      "isNullable": false,
+      "isSequence": true,
+      "constraints": null
+    }
+  ],
+  "parentType": "NcMethodResult",
+  "constraints": null
+}

--- a/internal/amwa/codec/ms05/testdata/schemas/v1.0.0/featuresets/monitoring/datatypes/NcOverallStatus.json
+++ b/internal/amwa/codec/ms05/testdata/schemas/v1.0.0/featuresets/monitoring/datatypes/NcOverallStatus.json
@@ -1,0 +1,28 @@
+{
+    "description": "Overall status enum data type",
+    "name": "NcOverallStatus",
+    "type": 3,
+    "items": [
+        {
+            "description": "Inactive",
+            "name": "Inactive",
+            "value": 0
+        },
+        {
+            "description": "The overall status is healthy",
+            "name": "Healthy",
+            "value": 1
+        },
+        {
+            "description": "The overall status is partially healthy",
+            "name": "PartiallyHealthy",
+            "value": 2
+        },
+        {
+            "description": "The overall status is unhealthy",
+            "name": "Unhealthy",
+            "value": 3
+        }
+    ],
+    "constraints": null
+}

--- a/internal/amwa/codec/ms05/testdata/schemas/v1.0.0/featuresets/monitoring/datatypes/NcStreamStatus.json
+++ b/internal/amwa/codec/ms05/testdata/schemas/v1.0.0/featuresets/monitoring/datatypes/NcStreamStatus.json
@@ -1,0 +1,28 @@
+{
+    "description": "Stream status enum data type",
+    "name": "NcStreamStatus",
+    "type": 3,
+    "items": [
+        {
+            "description": "Inactive",
+            "name": "Inactive",
+            "value": 0
+        },
+        {
+            "description": "Active and healthy",
+            "name": "Healthy",
+            "value": 1
+        },
+        {
+            "description": "Active and partially healthy",
+            "name": "PartiallyHealthy",
+            "value": 2
+        },
+        {
+            "description": "Active and unhealthy",
+            "name": "Unhealthy",
+            "value": 3
+        }
+    ],
+    "constraints": null
+}

--- a/internal/amwa/codec/ms05/testdata/schemas/v1.0.0/featuresets/monitoring/datatypes/NcSynchronizationStatus.json
+++ b/internal/amwa/codec/ms05/testdata/schemas/v1.0.0/featuresets/monitoring/datatypes/NcSynchronizationStatus.json
@@ -1,0 +1,28 @@
+{
+    "description": "Synchronization status enum data type",
+    "name": "NcSynchronizationStatus",
+    "type": 3,
+    "items": [
+        {
+            "description": "Feature not in use",
+            "name": "NotUsed",
+            "value": 0
+        },
+        {
+            "description": "Locked to a synchronization source",
+            "name": "Healthy",
+            "value": 1
+        },
+        {
+            "description": "Partially locked to a synchronization source",
+            "name": "PartiallyHealthy",
+            "value": 2
+        },
+        {
+            "description": "Not locked to a synchronization source",
+            "name": "Unhealthy",
+            "value": 3
+        }
+    ],
+    "constraints": null
+}

--- a/internal/amwa/codec/ms05/testdata/schemas/v1.0.0/featuresets/monitoring/datatypes/NcTransmissionStatus.json
+++ b/internal/amwa/codec/ms05/testdata/schemas/v1.0.0/featuresets/monitoring/datatypes/NcTransmissionStatus.json
@@ -1,0 +1,28 @@
+{
+    "description": "Transmission status enum data type",
+    "name": "NcTransmissionStatus",
+    "type": 3,
+    "items": [
+        {
+            "description": "Inactive",
+            "name": "Inactive",
+            "value": 0
+        },
+        {
+            "description": "Active and healthy",
+            "name": "Healthy",
+            "value": 1
+        },
+        {
+            "description": "Active and partially healthy",
+            "name": "PartiallyHealthy",
+            "value": 2
+        },
+        {
+            "description": "Active and unhealthy",
+            "name": "Unhealthy",
+            "value": 3
+        }
+    ],
+    "constraints": null
+}

--- a/internal/amwa/provider/configuration.go
+++ b/internal/amwa/provider/configuration.go
@@ -87,6 +87,10 @@ type IS14ConfigurationServer struct {
 	// subscribed Controllers. Separate from onModelChanged because the
 	// IS-04 hook needs no detail and the IS-12 hook needs all of it.
 	onPropertyChanged func(ms05.NcOid, ms05.NcPropertyId, any)
+
+	// monitorByResource maps an IS-04 sender/receiver id to its status
+	// monitor's role-path key (BCP-008 touchpoint, inverted).
+	monitorByResource map[string]string
 }
 
 // SetOnPropertyChanged installs the IS-12 notification hook.
@@ -259,16 +263,114 @@ func NewIS14ConfigurationServer(logger *slog.Logger, bundle *NodeConfig, cfg IS1
 		// a build defect, not a runtime condition.
 		panic(fmt.Sprintf("provider/is14: framework model load: %v %v %v %v", err, err2, err3, err4))
 	}
-	if p := root.findProp("2p2"); p != nil { // NcBlock.members
-		p.value = []ms05.NcBlockMemberDescriptor{dm.memberDescriptor(), cm.memberDescriptor(), bpm.memberDescriptor()}
+	// BCP-008-01/-02: one status monitor per stream endpoint, tied to
+	// its IS-04 resource through a touchpoint. Statuses boot Inactive —
+	// nothing transmits until IS-05 activates — and flip on activation
+	// via SetMonitorActive.
+	objs := []*configObject{root, dm, cm, bpm}
+	s.monitorByResource = map[string]string{}
+	nextOid := ms05.NcOid(5)
+	addMonitor := func(classID ms05.NcClassId, role, resourceType, resourceID, label string, statusProps []string) {
+		seed := map[string]any{
+			"userLabel": label,
+			"touchpoints": []any{map[string]any{
+				"contextNamespace": "x-nmos",
+				"resource": map[string]any{
+					"resourceType": resourceType,
+					"id":           resourceID,
+				},
+			}},
+			"statusReportingDelay":         uint32(3),
+			"autoResetCountersAndMessages": true,
+			"overallStatus":                0, // Inactive
+			"linkStatus":                   1, // AllUp
+			"linkStatusTransitionCounter":  uint64(0),
+			"externalSynchronizationStatusTransitionCounter": uint64(0),
+		}
+		for _, p := range statusProps {
+			seed[p] = 0
+			seed[p+"TransitionCounter"] = uint64(0)
+		}
+		mon, err := newConfigObject(classID, nextOid, []string{"root", role}, seed)
+		if err != nil {
+			panic(fmt.Sprintf("provider/is14: monitor model load: %v", err))
+		}
+		nextOid++
+		objs = append(objs, mon)
+		s.monitorByResource[resourceID] = strings.Join(mon.path, ".")
+	}
+	if bundle != nil {
+		for i := range bundle.Receivers {
+			r := &bundle.Receivers[i]
+			addMonitor(ms05.NcClassId{1, 2, 2, 1}, fmt.Sprintf("ReceiverMonitor-%02d", i),
+				"receiver", r.ID, "Receiver monitor "+r.Label,
+				[]string{"connectionStatus", "streamStatus"})
+		}
+		for i := range bundle.Senders {
+			snd := &bundle.Senders[i]
+			addMonitor(ms05.NcClassId{1, 2, 2, 2}, fmt.Sprintf("SenderMonitor-%02d", i),
+				"sender", snd.ID, "Sender monitor "+snd.Label,
+				[]string{"transmissionStatus", "essenceStatus"})
+		}
 	}
 
-	for _, o := range []*configObject{root, dm, cm, bpm} {
+	if p := root.findProp("2p2"); p != nil { // NcBlock.members
+		members := make([]ms05.NcBlockMemberDescriptor, 0, len(objs)-1)
+		for _, o := range objs[1:] {
+			members = append(members, o.memberDescriptor())
+		}
+		p.value = members
+	}
+
+	for _, o := range objs {
 		key := strings.Join(o.path, ".")
 		s.objects[key] = o
 		s.order = append(s.order, key)
 	}
 	return s
+}
+
+// SetMonitorActive flips the status monitor tied to an IS-04 sender or
+// receiver between Inactive and Healthy on IS-05 activation — BCP-008
+// "monitor transitions to Healthy state on activation" and its
+// deactivation mirror. Every changed property fires the IS-12
+// notification hook.
+func (s *IS14ConfigurationServer) SetMonitorActive(resourceID string, active bool) {
+	key, ok := s.monitorByResource[resourceID]
+	if !ok {
+		return
+	}
+	s.mu.Lock()
+	obj := s.objects[key]
+	if obj == nil {
+		s.mu.Unlock()
+		return
+	}
+	status := 0 // Inactive
+	if active {
+		status = 1 // Healthy
+	}
+	type change struct {
+		id ms05.NcPropertyId
+		v  any
+	}
+	var fired []change
+	for _, name := range []string{"overallStatus", "connectionStatus", "streamStatus", "transmissionStatus", "essenceStatus"} {
+		for _, p := range obj.props {
+			if p.desc.Name == name {
+				if p.value != status {
+					p.value = status
+					fired = append(fired, change{p.desc.ID, status})
+				}
+			}
+		}
+	}
+	s.mu.Unlock()
+	if s.onPropertyChanged != nil {
+		for _, c := range fired {
+			s.onPropertyChanged(obj.oid, c.id, c.v)
+		}
+	}
 }
 
 // Versions lists the mounted IS-14 minors.

--- a/internal/amwa/provider/connection.go
+++ b/internal/amwa/provider/connection.go
@@ -56,6 +56,10 @@ type IS05ConnectionServer struct {
 	// `subscription.active` both read from here.
 	bundle *NodeConfig
 
+	// onMonitorState reports an activation to the BCP-008 status
+	// monitor tied to the endpoint (nil = no monitors served).
+	onMonitorState func(resourceID string, active bool)
+
 	// onResourceChanged fires after an activation has rewritten an
 	// IS-04 resource, so the Node can re-POST it to its Registry.
 	//
@@ -104,6 +108,13 @@ func NewIS05ConnectionServer(logger *slog.Logger, bundle *NodeConfig, cfg IS05Co
 // Runs under the store lock, so it must not call back into the store.
 func (s *IS05ConnectionServer) afterActivation(kind, id string, active is05.StagedSender) string {
 	s.updateIS04Subscription(kind, id, active)
+	if s.onMonitorState != nil {
+		// BCP-008: the status monitor tied to this endpoint follows the
+		// activation. In a goroutine because it fans out to IS-12
+		// WebSocket subscribers — socket writes must not run under the
+		// connection store's lock.
+		go s.onMonitorState(id, active.MasterEnable)
+	}
 	if kind == "senders" {
 		return s.sdpForSender(id, active)
 	}

--- a/internal/amwa/provider/ncp.go
+++ b/internal/amwa/provider/ncp.go
@@ -228,6 +228,12 @@ func (s *IS12NCPServer) runCommand(cmd is12.Command) is12.MethodResult {
 		return s.methodGetControlClass(obj, cmd.Arguments)
 	case is12.MethodID{Level: 3, Index: 2}: // ClassManager.GetDatatype
 		return s.methodGetDatatype(obj, cmd.Arguments)
+	case is12.MethodID{Level: 4, Index: 1}, is12.MethodID{Level: 4, Index: 2}, is12.MethodID{Level: 4, Index: 3}:
+		// BCP-008 monitor methods (NcReceiverMonitor 4m1/4m2 counter
+		// getters + 4m3 reset; NcSenderMonitor 4m1 getter + 4m2 reset).
+		if classDerivedFrom(obj.classID, ms05.NcClassId{1, 2, 2}) {
+			return s.methodMonitor(obj, cmd.MethodID)
+		}
 	}
 	return ncpErr(ms05.NcMethodStatusMethodNotImplemented,
 		fmt.Sprintf("method %dm%d is not implemented on oid %d", cmd.MethodID.Level, cmd.MethodID.Index, cmd.OID))
@@ -555,6 +561,33 @@ func (s *IS12NCPServer) methodGetDatatype(obj *configObject, args json.RawMessag
 		return ncpErr(ms05.NcMethodStatusParameterError, fmt.Sprintf("no datatype %q", a.Name))
 	}
 	return ncpOKValue(dt)
+}
+
+// methodMonitor implements the BCP-008 monitor methods. A reference
+// node carries no media plane, so the packet/error counter getters
+// truthfully answer an empty counter list; reset clears the transition
+// counters and messages the model does carry.
+func (s *IS12NCPServer) methodMonitor(obj *configObject, id is12.MethodID) is12.MethodResult {
+	isReceiver := classDerivedFrom(obj.classID, ms05.NcClassId{1, 2, 2, 1})
+	resetIdx := 2 // NcSenderMonitor.ResetCountersAndMessages = 4m2
+	if isReceiver {
+		resetIdx = 3 // NcReceiverMonitor.ResetCountersAndMessages = 4m3
+	}
+	if id.Index == resetIdx {
+		s.config.mu.Lock()
+		for _, p := range obj.props {
+			if strings.HasSuffix(p.desc.Name, "TransitionCounter") {
+				p.value = uint64(0)
+			}
+			if strings.HasSuffix(p.desc.Name, "Message") && p.desc.IsNullable {
+				p.value = nil
+			}
+		}
+		s.config.mu.Unlock()
+		return ncpOK()
+	}
+	// Remaining indices are counter getters.
+	return ncpOKValue([]any{})
 }
 
 // attachNCPAPI mounts IS-12 and advertises it on every Device. The

--- a/internal/amwa/provider/ncp_test.go
+++ b/internal/amwa/provider/ncp_test.go
@@ -8,6 +8,7 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	stdhttp "net/http"
 	"strings"
 	"sync"
 	"testing"
@@ -18,9 +19,13 @@ import (
 )
 
 func serveNCPNode(t *testing.T) string {
+	return serveNCPBundleNode(t, validBundle())
+}
+
+func serveNCPBundleNode(t *testing.T, bundle *NodeConfig) string {
 	t.Helper()
 	addr := freeAddr(t)
-	s, err := NewIS04NodeServer(nil, validBundle(), IS04NodeConfig{
+	s, err := NewIS04NodeServer(nil, bundle, IS04NodeConfig{
 		Bind: addr, DiscoveryMode: "static", ConnectionAPIVer: "v1.2", APIVer: "v1.3",
 	})
 	if err != nil {
@@ -149,6 +154,66 @@ func TestNCPGetAndErrors(t *testing.T) {
 	cr = resp.(is12.CommandResponseMessage)
 	if cr.Responses[0].Result.Status != 200 || !strings.Contains(string(cr.Responses[0].Result.Value), "NcObject") {
 		t.Errorf("GetControlClass = %+v", cr.Responses[0].Result)
+	}
+}
+
+// TestBCP008MonitorFollowsActivation: every sender/receiver carries a
+// status monitor whose statuses boot Inactive and flip to Healthy when
+// IS-05 activates the endpoint (BCP-008 test_02 behaviour), and the
+// monitor methods answer over NCP.
+func TestBCP008MonitorFollowsActivation(t *testing.T) {
+	addr := serveNCPBundleNode(t, audioBundle())
+
+	// The monitor exists and boots Inactive.
+	st, body := mxlGet(t, "http://"+addr+"/x-nmos/configuration/v1.0/rolePaths/root.ReceiverMonitor-00/properties/3p1/value")
+	if st != 200 || !strings.Contains(string(body), `"value": 0`) && !strings.Contains(string(body), `"value":0`) {
+		t.Fatalf("monitor overallStatus before activation = %d %s", st, body)
+	}
+
+	// Activate the receiver over IS-05.
+	rid := ""
+	for _, r := range audioBundle().Receivers {
+		rid = r.ID
+		break
+	}
+	patch := `{"master_enable":true,"activation":{"mode":"activate_immediate","requested_time":null,"activation_time":null}}`
+	req, _ := stdhttp.NewRequest(stdhttp.MethodPatch,
+		"http://"+addr+"/x-nmos/connection/v1.2/single/receivers/"+rid+"/staged",
+		strings.NewReader(patch))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := stdhttp.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("activate receiver: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		t.Fatalf("activate receiver: status=%d", resp.StatusCode)
+	}
+
+	// The flip happens via a goroutine — poll briefly.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		_, body = mxlGet(t, "http://"+addr+"/x-nmos/configuration/v1.0/rolePaths/root.ReceiverMonitor-00/properties/3p1/value")
+		if strings.Contains(string(body), `"value": 1`) || strings.Contains(string(body), `"value":1`) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("monitor never went Healthy: %s", body)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	// Monitor methods over NCP: counters getter + reset answer OK.
+	ws := ncpDial(t, addr)
+	resp2 := ncpRoundTrip(t, ws, is12.CommandMessage{Commands: []is12.Command{
+		{Handle: 20, OID: 5, MethodID: is12.MethodID{Level: 4, Index: 1}, Arguments: json.RawMessage(`{}`)},
+		{Handle: 21, OID: 5, MethodID: is12.MethodID{Level: 4, Index: 3}, Arguments: json.RawMessage(`{}`)},
+	}})
+	cr := resp2.(is12.CommandResponseMessage)
+	for _, r := range cr.Responses {
+		if r.Result.Status != 200 {
+			t.Errorf("monitor method handle %d = %+v", r.Handle, r.Result)
+		}
 	}
 }
 

--- a/internal/amwa/provider/node.go
+++ b/internal/amwa/provider/node.go
@@ -373,6 +373,11 @@ func NewIS04NodeServer(logger *slog.Logger, bundle *NodeConfig, cfg IS04NodeConf
 			APIVer: cfg.ConfigurationAPIVer,
 		})
 	}
+	// BCP-008: an IS-05 activation flips the endpoint's status monitor
+	// between Inactive and Healthy. Wired only when both sides exist.
+	if s.connection != nil && s.configuration != nil {
+		s.connection.onMonitorState = s.configuration.SetMonitorActive
+	}
 	if !cfg.NoEventsAPI {
 		s.events = NewIS07EventsServer(logger, fullBundle, IS07EventsConfig{
 			APIVer: cfg.EventsAPIVer,


### PR DESCRIPTION
Vendors the AMWA monitoring feature set into the MS-05 framework; one NcReceiverMonitor/NcSenderMonitor per IS-04 endpoint with x-nmos touchpoints; IS-05 activation flips Inactive<->Healthy with IS-12 notifications; monitor methods over NCP. Closes the last build item on the conformance board (unblocks BCP-008-01/-02 + IS-12 could-not-tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)