### PR TITLE
fix(amwa): seed externalSynchronizationStatus NotUsed on monitors

### DIFF
--- a/internal/amwa/provider/configuration.go
+++ b/internal/amwa/provider/configuration.go
@@ -285,6 +285,10 @@ func NewIS14ConfigurationServer(logger *slog.Logger, bundle *NodeConfig, cfg IS1
 			"overallStatus":                0, // Inactive
 			"linkStatus":                   1, // AllUp
 			"linkStatusTransitionCounter":  uint64(0),
+			// A reference node has no external sync source: NotUsed —
+			// and a concrete value ALWAYS. The AMWA BCP-008 checker
+			// feeds every status into max(); a null crashes it.
+			"externalSynchronizationStatus":                  0, // NotUsed
 			"externalSynchronizationStatusTransitionCounter": uint64(0),
 		}
 		for _, p := range statusProps {


### PR DESCRIPTION
Closes #892. Seeds NcSynchronizationStatus NotUsed(0) so no monitor status reads null; unblocks the 9 checker-crash fails in BCP-008-01/-02.

🤖 Generated with [Claude Code](https://claude.com/claude-code)