### PR TITLE
fix(amwa): registry enforces BCP-003-02 per-client resource ownership

### DIFF
--- a/internal/amwa/registry/ownership_test.go
+++ b/internal/amwa/registry/ownership_test.go
@@ -1,0 +1,76 @@
+package registry
+
+// BCP-003-02 resource ownership (IS-04-02 test_33/test_33_1): an
+// authenticated client may only update resources it registered; a
+// different client's update answers 403. azp is normalised into
+// client_id by the is10 codec, so one identity covers both tests.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	httpsession "dhs/internal/amwa/session/http"
+)
+
+// ownedPost drives the real registration route with a client identity
+// stamped the way the auth gate does it.
+func ownedPost(t *testing.T, srv *httpsession.Server, client string, body []byte) int {
+	t.Helper()
+	mux := srv.MuxHandler()
+	req := httptest.NewRequest(stdhttp.MethodPost, "/x-nmos/registration/v1.3/resource", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	if client != "" {
+		req = req.WithContext(httpsession.WithClientID(context.Background(), client))
+	}
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	_, _ = io.Copy(io.Discard, rec.Body)
+	return rec.Code
+}
+
+func TestRegistrationOwnershipRejectsMismatchedClient(t *testing.T) {
+	store := NewStore()
+	srv := httpsession.NewServer(nil)
+	installRegistrationRoutes(srv, store, "/x-nmos/registration/v1.3", "v1.3")
+
+	node := func(version string) []byte {
+		raw, _ := json.Marshal(map[string]any{
+			"type": "node",
+			"data": map[string]any{
+				"id": "0770e57e-0000-4000-8000-000000000033", "version": version,
+				"label": "own", "description": "own", "tags": map[string]any{},
+				"href": "http://h/", "hostname": "own", "caps": map[string]any{},
+				"api": map[string]any{"versions": []string{"v1.3"}, "endpoints": []any{
+					map[string]any{"host": "10.0.0.1", "port": 80, "protocol": "http"}}},
+				"services": []any{}, "clocks": []any{}, "interfaces": []any{},
+			},
+		})
+		return raw
+	}
+
+	// Client A registers.
+	if code := ownedPost(t, srv, "client-a", node("1:0")); code != 201 {
+		t.Fatalf("create by A = %d, want 201", code)
+	}
+	// Client A updates its own resource.
+	if code := ownedPost(t, srv, "client-a", node("2:0")); code != 200 {
+		t.Fatalf("update by A = %d, want 200", code)
+	}
+	// Client B must be refused.
+	if code := ownedPost(t, srv, "client-b", node("3:0")); code != 403 {
+		t.Fatalf("update by B = %d, want 403", code)
+	}
+	// Unauthenticated path (auth off) keeps historical behaviour.
+	if code := ownedPost(t, srv, "", node("4:0")); code != 200 {
+		t.Fatalf("update with auth off = %d, want 200", code)
+	}
+	if !strings.Contains(store.Owner("0770e57e-0000-4000-8000-000000000033"), "client-a") {
+		t.Errorf("owner = %q, want client-a", store.Owner("0770e57e-0000-4000-8000-000000000033"))
+	}
+}

--- a/internal/amwa/registry/registration.go
+++ b/internal/amwa/registry/registration.go
@@ -36,11 +36,27 @@ func installRegistrationRoutes(srv *httpsession.Server, store *Store, base, apiV
 		}
 		id := idFromEnvelope(env)
 		hadPrev := preExists(store, env.Type, id)
+		// BCP-003-02 resource ownership: an authenticated client may
+		// only update resources IT registered (IS-04-02 test_33 /
+		// test_33_1 — azp is normalised into client_id by the codec).
+		// A resource registered before auth was armed has no owner and
+		// is claimed by the first authenticated writer.
+		client := httpsession.ClientIDFrom(ctx)
+		if client != "" && hadPrev {
+			if owner := store.Owner(id); owner != "" && owner != client {
+				return stdhttp.StatusForbidden, httpsession.ErrorBody{
+					Code: 403, Error: "Forbidden",
+					Debug: fmt.Sprintf("resource %s is owned by another client", id)}, nil
+			}
+		}
 		if err := store.IngestRegistrationVersioned(env, apiVer); err != nil {
 			if errors.Is(err, ErrAPIVerConflict) {
 				return stdhttp.StatusConflict, httpsession.ErrorBody{Code: 409, Error: "Conflict", Debug: err.Error()}, nil
 			}
 			return stdhttp.StatusBadRequest, httpsession.ErrorBody{Code: 400, Error: "Bad Request", Debug: err.Error()}, nil
+		}
+		if client != "" {
+			store.SetOwner(id, client)
 		}
 		// Echo the data; spec says response body is the registered resource.
 		var raw any

--- a/internal/amwa/registry/registry.go
+++ b/internal/amwa/registry/registry.go
@@ -257,7 +257,7 @@ func (r *Registry) Serve(ctx context.Context, opts registryslot.ServeOptions) er
 						// the route table where srv.Auth lives, so the
 						// gate is applied here explicitly.
 						if authGate != nil {
-							if status, hdrs, body, ok := authGate.Check(req); !ok {
+							if status, hdrs, body, _, ok := authGate.Check(req); !ok {
 								for hk, hv := range hdrs {
 									w.Header().Set(hk, hv)
 								}

--- a/internal/amwa/registry/store.go
+++ b/internal/amwa/registry/store.go
@@ -72,6 +72,14 @@ type Store struct {
 	// this map every tick.
 	health map[string]time.Time
 
+	// owners maps a resource id to the IS-10 client_id that registered
+	// it (BCP-003-02: the Registration API rejects updates from a
+	// DIFFERENT client with 403 — IS-04-02 test_33/test_33_1). Entries
+	// are overwritten on every authenticated create, so a stale entry
+	// left by an evicted resource can never block a re-registration.
+	// Empty when auth is off.
+	owners map[string]string
+
 	// updateTSByType tracks the per-resource last-update TAI timestamp
 	// per IS-04 §6.1.6 — Query API pagination indexes resources by
 	// this. Keyed type → id → "<secs>:<nanos>". Maintained on every
@@ -108,6 +116,7 @@ func NewStore() *Store {
 		senders:        make(map[string]is04.Sender),
 		receivers:      make(map[string]is04.Receiver),
 		health:         make(map[string]time.Time),
+		owners:         make(map[string]string),
 		updateTSByType: make(map[is04.ResourceType]map[string]string, 6),
 		apiVerByType:   make(map[is04.ResourceType]map[string]string, 6),
 	}
@@ -543,6 +552,21 @@ func (s *Store) HealthFor(nodeID string) (time.Time, error) {
 		return time.Time{}, ErrNotFound
 	}
 	return t, nil
+}
+
+// Owner returns the client_id that registered a resource, "" when
+// unknown (auth off, or registered before auth was armed).
+func (s *Store) Owner(id string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.owners[id]
+}
+
+// SetOwner records the registering client for a resource.
+func (s *Store) SetOwner(id, client string) {
+	s.mu.Lock()
+	s.owners[id] = client
+	s.mu.Unlock()
 }
 
 // EvictStale walks the health map and DeleteNodes any whose last

--- a/internal/amwa/session/http/authgate.go
+++ b/internal/amwa/session/http/authgate.go
@@ -93,7 +93,11 @@ func bearerToken(r *stdhttp.Request) string {
 
 // Check evaluates one request. ok=true means proceed; otherwise the
 // caller writes body with the given status after applying headers.
-func (g *AuthGate) Check(r *stdhttp.Request) (status int, headers map[string]string, body ErrorBody, ok bool) {
+// clientID carries the authenticated client's identity (IS-10
+// client_id, with azp already normalised into it by the codec) so
+// handlers can enforce BCP-003-02 per-client resource ownership;
+// empty on the token-less always-readable paths.
+func (g *AuthGate) Check(r *stdhttp.Request) (status int, headers map[string]string, body ErrorBody, clientID string, ok bool) {
 	log := g.Logger
 	if log == nil {
 		log = slog.Default()
@@ -102,7 +106,7 @@ func (g *AuthGate) Check(r *stdhttp.Request) (status int, headers map[string]str
 	if leeway == 0 {
 		leeway = 30 * time.Second
 	}
-	deny := func(st int, authenticate, debug string) (int, map[string]string, ErrorBody, bool) {
+	deny := func(st int, authenticate, debug string) (int, map[string]string, ErrorBody, string, bool) {
 		reason := "Unauthorized"
 		if st == stdhttp.StatusForbidden {
 			reason = "Forbidden"
@@ -114,18 +118,18 @@ func (g *AuthGate) Check(r *stdhttp.Request) (status int, headers map[string]str
 		if st == stdhttp.StatusServiceUnavailable {
 			h["Retry-After"] = retryAfterSeconds
 		}
-		return st, h, ErrorBody{Code: st, Error: reason, Debug: debug}, false
+		return st, h, ErrorBody{Code: st, Error: reason, Debug: debug}, "", false
 	}
 
 	// CORS preflight: credential-less by browser design.
 	if r.Method == stdhttp.MethodOptions {
-		return 0, nil, ErrorBody{}, true
+		return 0, nil, ErrorBody{}, "", true
 	}
 
 	// The two always-readable base paths need no token at all.
 	p := strings.TrimSuffix(r.URL.Path, "/")
 	if (p == "" || p == "/x-nmos") && (r.Method == stdhttp.MethodGet || r.Method == stdhttp.MethodHead) {
-		return 0, nil, ErrorBody{}, true
+		return 0, nil, ErrorBody{}, "", true
 	}
 
 	tok := bearerToken(r)
@@ -183,7 +187,25 @@ func (g *AuthGate) Check(r *stdhttp.Request) (status int, headers map[string]str
 	}
 	log.Debug("auth: authorized", "method", r.Method, "path", r.URL.Path,
 		"iss", claims.Iss, "sub", claims.Sub, "client", claims.ClientID)
-	return 0, nil, ErrorBody{}, true
+	return 0, nil, ErrorBody{}, claims.ClientID, true
+}
+
+// clientIDKey is the context key WithClientID/ClientIDFrom share.
+type clientIDKey struct{}
+
+// WithClientID stamps the authenticated IS-10 client identity on a
+// request context.
+func WithClientID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, clientIDKey{}, id)
+}
+
+// ClientIDFrom reads the authenticated client identity, "" when the
+// request was not token-authenticated (auth off, or exempt path).
+func ClientIDFrom(ctx context.Context) string {
+	if v, ok := ctx.Value(clientIDKey{}).(string); ok {
+		return v
+	}
+	return ""
 }
 
 // startIssuerFetch dedupes CONCURRENT fetches per issuer only — the

--- a/internal/amwa/session/http/server.go
+++ b/internal/amwa/session/http/server.go
@@ -229,12 +229,19 @@ func (s *Server) dispatch(w stdhttp.ResponseWriter, r *stdhttp.Request) {
 	// upgrades are protected by the same policy as plain routes (the
 	// spec says a server SHALL NOT upgrade on an invalid token).
 	if s.Auth != nil {
-		if status, hdrs, body, ok := s.Auth.Check(r); !ok {
+		status, hdrs, body, clientID, ok := s.Auth.Check(r)
+		if !ok {
 			for k, v := range hdrs {
 				w.Header().Set(k, v)
 			}
 			writeJSON(w, status, body)
 			return
+		}
+		if clientID != "" {
+			// BCP-003-02: hand the authenticated client identity to the
+			// handlers so write paths can enforce per-client resource
+			// ownership (IS-04-02 test_33/test_33_1).
+			r = r.WithContext(WithClientID(r.Context(), clientID))
 		}
 	}
 


### PR DESCRIPTION
Closes #896. Gate exposes client_id via ctx; store binds resources to their registering client; mismatched-client updates answer 403 (IS-04-02 test_33/test_33_1). Ownership test + full sweep green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)