### PR TITLE
fix(amwa): azp is the client identity when client_id is absent

### DIFF
--- a/internal/amwa/codec/is10/jwt.go
+++ b/internal/amwa/codec/is10/jwt.go
@@ -195,6 +195,16 @@ func ValidateClaimsExceptAud(c Claims, now time.Time, leeway time.Duration) erro
 	return nil
 }
 
+// EffectiveClientID is the client identity BCP-003-02 keys ownership
+// on: client_id, or azp when client_id is absent — the spec treats the
+// two the same way (IS-04-02 test_33_1 pins the equivalence).
+func (c *Claims) EffectiveClientID() string {
+	if c.ClientID != "" {
+		return c.ClientID
+	}
+	return c.Azp
+}
+
 // AudienceMatchesAny reports whether any aud entry names any of this
 // server's identities.
 func AudienceMatchesAny(aud Audience, hosts []string) bool {

--- a/internal/amwa/session/http/authgate.go
+++ b/internal/amwa/session/http/authgate.go
@@ -186,8 +186,8 @@ func (g *AuthGate) Check(r *stdhttp.Request) (status int, headers map[string]str
 		return deny(stdhttp.StatusForbidden, `Bearer error=insufficient_scope`, err.Error())
 	}
 	log.Debug("auth: authorized", "method", r.Method, "path", r.URL.Path,
-		"iss", claims.Iss, "sub", claims.Sub, "client", claims.ClientID)
-	return 0, nil, ErrorBody{}, claims.ClientID, true
+		"iss", claims.Iss, "sub", claims.Sub, "client", claims.EffectiveClientID())
+	return 0, nil, ErrorBody{}, claims.EffectiveClientID(), true
 }
 
 // clientIDKey is the context key WithClientID/ClientIDFrom share.


### PR DESCRIPTION
Refs #896. test_33_1 uses azp-only tokens; EffectiveClientID (client_id -> azp fallback) now feeds the ownership check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)