### PR TITLE
fix(amwa): seed NcObject.enabled on BCP-008 monitors

### DIFF
--- a/internal/amwa/provider/configuration.go
+++ b/internal/amwa/provider/configuration.go
@@ -273,6 +273,10 @@ func NewIS14ConfigurationServer(logger *slog.Logger, bundle *NodeConfig, cfg IS1
 	addMonitor := func(classID ms05.NcClassId, role, resourceType, resourceID, label string, statusProps []string) {
 		seed := map[string]any{
 			"userLabel": label,
+			// NcObject.enabled is non-nullable — IS-14's bulkProperties
+			// round walks every model object and fails a null here
+			// (test_10/test_11 caught the omission on monitors).
+			"enabled": true,
 			"touchpoints": []any{map[string]any{
 				"contextNamespace": "x-nmos",
 				"resource": map[string]any{


### PR DESCRIPTION
Closes #899. Monitors seed enabled=true; clears IS-14 test_10/11/26 nulls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)