### PR TITLE
feat(amwa): MS-05 constraints enforcement + DhsGainControl worker

### DIFF
--- a/internal/amwa/codec/ms05/constraints.go
+++ b/internal/amwa/codec/ms05/constraints.go
@@ -1,0 +1,141 @@
+package ms05
+
+// Constraint VALUE checking — the enforcement half of the MS-05-02
+// constraints model (Constraints.html). Declaring a constraint in a
+// descriptor without rejecting violating writes would publish a
+// contract the device does not honour; the AMWA suite attacks exactly
+// that (IS-14-01 test_27 offers out-of-range values through
+// bulkProperties and expects error notices).
+//
+// The hierarchy (runtime overrides property overrides datatype) is
+// resolved by the CALLER — this file only answers "does this value
+// satisfy this one constraint instance".
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+)
+
+// numericStep tolerance: values arrive as JSON float64; a step check
+// on 0.5 must not reject 5.5 over representation error.
+const stepEpsilon = 1e-9
+
+// CheckConstraintValue validates one decoded JSON value against one
+// constraint instance — any of the four concrete variants (property /
+// parameter × number / string), by value or pointer. A nil value is
+// accepted (nullability is a separate descriptor rule), as is a nil
+// or base-only constraint (a bare default value constrains nothing).
+func CheckConstraintValue(v any, c any) error {
+	if v == nil || c == nil {
+		return nil
+	}
+	switch t := c.(type) {
+	case *NcParameterConstraintsNumber:
+		return checkNumber(v, t.Minimum, t.Maximum, t.Step)
+	case NcParameterConstraintsNumber:
+		return checkNumber(v, t.Minimum, t.Maximum, t.Step)
+	case *NcPropertyConstraintsNumber:
+		return checkNumber(v, t.Minimum, t.Maximum, t.Step)
+	case NcPropertyConstraintsNumber:
+		return checkNumber(v, t.Minimum, t.Maximum, t.Step)
+	case *NcParameterConstraintsString:
+		return checkString(v, t.MaxCharacters, t.Pattern)
+	case NcParameterConstraintsString:
+		return checkString(v, t.MaxCharacters, t.Pattern)
+	case *NcPropertyConstraintsString:
+		return checkString(v, t.MaxCharacters, t.Pattern)
+	case NcPropertyConstraintsString:
+		return checkString(v, t.MaxCharacters, t.Pattern)
+	}
+	return nil
+}
+
+// asFloat coerces the polymorphic min/max/step members (authored as
+// int or float literals) to float64; ok=false when absent (null).
+func asFloat(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int32:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case uint32:
+		return float64(n), true
+	case uint64:
+		return float64(n), true
+	}
+	return 0, false
+}
+
+func checkNumber(v, min, max, step any) error {
+	n, ok := asFloat(v)
+	if !ok {
+		return fmt.Errorf("value is not numeric")
+	}
+	if lo, ok := asFloat(min); ok && n < lo {
+		return fmt.Errorf("value %v is below the constraint minimum %v", n, lo)
+	}
+	if hi, ok := asFloat(max); ok && n > hi {
+		return fmt.Errorf("value %v is above the constraint maximum %v", n, hi)
+	}
+	if st, ok := asFloat(step); ok && st > 0 {
+		// Steps count from the minimum when one is declared, from
+		// zero otherwise (MS-05-02 Constraints.html).
+		base := 0.0
+		if lo, ok := asFloat(min); ok {
+			base = lo
+		}
+		ratio := (n - base) / st
+		if math.Abs(ratio-math.Round(ratio)) > stepEpsilon {
+			return fmt.Errorf("value %v does not align to the constraint step %v", n, st)
+		}
+	}
+	return nil
+}
+
+func checkString(v any, maxChars *uint32, pattern *string) error {
+	s, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("value is not a string")
+	}
+	if maxChars != nil && uint32(len([]rune(s))) > *maxChars {
+		return fmt.Errorf("value is %d characters, above the constraint maximum %d", len([]rune(s)), *maxChars)
+	}
+	if pattern != nil && *pattern != "" {
+		re, err := regexp.Compile(*pattern)
+		if err != nil {
+			return fmt.Errorf("constraint pattern %q does not compile: %v", *pattern, err)
+		}
+		if !re.MatchString(s) {
+			return fmt.Errorf("value %q does not match the constraint pattern %q", s, *pattern)
+		}
+	}
+	return nil
+}
+
+// ConstraintPropertyID extracts the propertyId member of a
+// property-level constraint instance — how callers match an entry of
+// runtimePropertyConstraints to the property being written.
+func ConstraintPropertyID(c any) (NcPropertyId, bool) {
+	switch t := c.(type) {
+	case *NcPropertyConstraintsNumber:
+		return t.PropertyId, true
+	case NcPropertyConstraintsNumber:
+		return t.PropertyId, true
+	case *NcPropertyConstraintsString:
+		return t.PropertyId, true
+	case NcPropertyConstraintsString:
+		return t.PropertyId, true
+	case *NcPropertyConstraints:
+		return t.PropertyId, true
+	case NcPropertyConstraints:
+		return t.PropertyId, true
+	}
+	return NcPropertyId{}, false
+}

--- a/internal/amwa/codec/ms05/constraints_test.go
+++ b/internal/amwa/codec/ms05/constraints_test.go
@@ -1,0 +1,126 @@
+package ms05
+
+import "testing"
+
+func u32(v uint32) *uint32 { return &v }
+func str(s string) *string { return &s }
+
+func TestCheckConstraintValueNumber(t *testing.T) {
+	c := &NcPropertyConstraintsNumber{
+		NcPropertyConstraints: NcPropertyConstraints{PropertyId: NcPropertyId{Level: 4, Index: 2}},
+		Minimum:               -60.0, Maximum: 6.0, Step: 0.5,
+	}
+	cases := []struct {
+		name string
+		v    any
+		ok   bool
+	}{
+		{"in range on step", 3.5, true},
+		{"minimum itself", -60.0, true},
+		{"maximum itself", 6.0, true},
+		{"above maximum", 6.5, false},
+		{"below minimum", -60.5, false},
+		{"off the step grid", 0.75, false},
+		{"not numeric", "x", false},
+		{"nil passes (nullability is elsewhere)", nil, true},
+	}
+	for _, tc := range cases {
+		err := CheckConstraintValue(tc.v, c)
+		if (err == nil) != tc.ok {
+			t.Errorf("%s: err=%v, want ok=%v", tc.name, err, tc.ok)
+		}
+	}
+
+	// Bounds authored as ints must coerce.
+	ci := &NcParameterConstraintsNumber{Minimum: 0, Maximum: 10, Step: 1}
+	if err := CheckConstraintValue(5.0, ci); err != nil {
+		t.Errorf("int-authored bounds: %v", err)
+	}
+	if err := CheckConstraintValue(11.0, ci); err == nil {
+		t.Error("11 above int-authored maximum accepted")
+	}
+}
+
+func TestCheckConstraintValueString(t *testing.T) {
+	c := &NcPropertyConstraintsString{
+		NcPropertyConstraints: NcPropertyConstraints{PropertyId: NcPropertyId{Level: 4, Index: 1}},
+		MaxCharacters:         u32(16),
+		Pattern:               str("^[A-Za-z0-9 _-]*$"),
+	}
+	cases := []struct {
+		name string
+		v    any
+		ok   bool
+	}{
+		{"fits", "Gain-2", true},
+		{"empty", "", true},
+		{"too long", "labels-longer-than-16", false},
+		{"pattern break", "bad*chars", false},
+		{"not a string", 3.0, false},
+	}
+	for _, tc := range cases {
+		err := CheckConstraintValue(tc.v, c)
+		if (err == nil) != tc.ok {
+			t.Errorf("%s: err=%v, want ok=%v", tc.name, err, tc.ok)
+		}
+	}
+}
+
+func TestCheckConstraintValueBaseAndNil(t *testing.T) {
+	if err := CheckConstraintValue(3.0, nil); err != nil {
+		t.Errorf("nil constraint: %v", err)
+	}
+	// Base-only constraint (default value alone) constrains nothing.
+	if err := CheckConstraintValue("anything at all, any length ->", &NcPropertyConstraints{}); err != nil {
+		t.Errorf("base constraint: %v", err)
+	}
+}
+
+func TestConstraintPropertyID(t *testing.T) {
+	id := NcPropertyId{Level: 4, Index: 2}
+	got, ok := ConstraintPropertyID(&NcPropertyConstraintsNumber{
+		NcPropertyConstraints: NcPropertyConstraints{PropertyId: id},
+	})
+	if !ok || got != id {
+		t.Errorf("ConstraintPropertyID = %v %v", got, ok)
+	}
+	if _, ok := ConstraintPropertyID(&NcParameterConstraintsNumber{}); ok {
+		t.Error("parameter constraints carry no propertyId")
+	}
+}
+
+func TestRegisterClassAndDatatype(t *testing.T) {
+	cls := NcClassDescriptor{
+		ClassID: NcClassId{1, 2, 0, 99},
+		Name:    "TestVendorClass",
+	}
+	if err := RegisterClass(cls); err != nil {
+		t.Fatalf("RegisterClass: %v", err)
+	}
+	got, ok := StandardClass(NcClassId{1, 2, 0, 99})
+	if !ok || got.Name != "TestVendorClass" {
+		t.Errorf("registered class lookup = %+v %v", got, ok)
+	}
+	// Flattening inherits through the standard prefix chain.
+	flat, ok := FlattenedClass(NcClassId{1, 2, 0, 99})
+	if !ok {
+		t.Fatal("FlattenedClass on registered class")
+	}
+	seen := false
+	for _, p := range flat.Properties {
+		if p.Name == "oid" {
+			seen = true
+		}
+	}
+	if !seen {
+		t.Error("registered class does not inherit NcObject properties")
+	}
+
+	dt := NcDatatypeDescriptor{Name: "TestVendorTypedef", Type: NcDatatypeTypeTypedef, ParentType: str("NcInt32")}
+	if err := RegisterDatatype(dt); err != nil {
+		t.Fatalf("RegisterDatatype: %v", err)
+	}
+	if _, ok := StandardDatatype("TestVendorTypedef"); !ok {
+		t.Error("registered datatype lookup failed")
+	}
+}

--- a/internal/amwa/codec/ms05/framework.go
+++ b/internal/amwa/codec/ms05/framework.go
@@ -32,10 +32,37 @@ var frameworkFS embed.FS
 
 var (
 	frameworkOnce sync.Once
+	frameworkMu   sync.RWMutex
 	classesByKey  map[string]NcClassDescriptor
 	datatypesByNm map[string]NcDatatypeDescriptor
 	frameworkErr  error
 )
+
+// RegisterClass adds a NON-STANDARD class (MS-05-02 authority-key
+// rules apply: the id must carry a 0 or negative authority key) to
+// the catalogue the ClassManager and descriptor endpoints publish.
+// Re-registering the same key replaces the entry — provider
+// construction may run more than once in one process (tests).
+func RegisterClass(d NcClassDescriptor) error {
+	if err := ensureFramework(); err != nil {
+		return err
+	}
+	frameworkMu.Lock()
+	defer frameworkMu.Unlock()
+	classesByKey[classKey(d.ClassID)] = d
+	return nil
+}
+
+// RegisterDatatype adds a non-standard datatype to the catalogue.
+func RegisterDatatype(d NcDatatypeDescriptor) error {
+	if err := ensureFramework(); err != nil {
+		return err
+	}
+	frameworkMu.Lock()
+	defer frameworkMu.Unlock()
+	datatypesByNm[d.Name] = d
+	return nil
+}
 
 // classKey renders a class id as its dotted string form ("1.3.1").
 func classKey(id NcClassId) string {
@@ -135,6 +162,8 @@ func StandardClass(id NcClassId) (NcClassDescriptor, bool) {
 	if ensureFramework() != nil {
 		return NcClassDescriptor{}, false
 	}
+	frameworkMu.RLock()
+	defer frameworkMu.RUnlock()
 	d, ok := classesByKey[classKey(id)]
 	return d, ok
 }
@@ -147,6 +176,8 @@ func FlattenedClass(id NcClassId) (NcClassDescriptor, bool) {
 	if ensureFramework() != nil {
 		return NcClassDescriptor{}, false
 	}
+	frameworkMu.RLock()
+	defer frameworkMu.RUnlock()
 	own, ok := classesByKey[classKey(id)]
 	if !ok {
 		return NcClassDescriptor{}, false
@@ -173,6 +204,8 @@ func StandardDatatype(name string) (NcDatatypeDescriptor, bool) {
 	if ensureFramework() != nil {
 		return NcDatatypeDescriptor{}, false
 	}
+	frameworkMu.RLock()
+	defer frameworkMu.RUnlock()
 	d, ok := datatypesByNm[name]
 	return d, ok
 }
@@ -187,6 +220,14 @@ func FlattenedDatatype(name string) (NcDatatypeDescriptor, bool) {
 	if ensureFramework() != nil {
 		return NcDatatypeDescriptor{}, false
 	}
+	frameworkMu.RLock()
+	defer frameworkMu.RUnlock()
+	return flattenedDatatypeLocked(name)
+}
+
+// flattenedDatatypeLocked is FlattenedDatatype's core — caller holds
+// frameworkMu (read side is enough).
+func flattenedDatatypeLocked(name string) (NcDatatypeDescriptor, bool) {
 	d, ok := datatypesByNm[name]
 	if !ok {
 		return NcDatatypeDescriptor{}, false
@@ -217,6 +258,8 @@ func FlattenedDatatypes() []NcDatatypeDescriptor {
 	if ensureFramework() != nil {
 		return nil
 	}
+	frameworkMu.RLock()
+	defer frameworkMu.RUnlock()
 	names := make([]string, 0, len(datatypesByNm))
 	for n := range datatypesByNm {
 		names = append(names, n)
@@ -224,7 +267,7 @@ func FlattenedDatatypes() []NcDatatypeDescriptor {
 	sort.Strings(names)
 	out := make([]NcDatatypeDescriptor, 0, len(names))
 	for _, n := range names {
-		d, _ := FlattenedDatatype(n)
+		d, _ := flattenedDatatypeLocked(n)
 		out = append(out, d)
 	}
 	return out
@@ -236,6 +279,8 @@ func StandardClasses() []NcClassDescriptor {
 	if ensureFramework() != nil {
 		return nil
 	}
+	frameworkMu.RLock()
+	defer frameworkMu.RUnlock()
 	keys := make([]string, 0, len(classesByKey))
 	for k := range classesByKey {
 		keys = append(keys, k)
@@ -254,6 +299,8 @@ func StandardDatatypes() []NcDatatypeDescriptor {
 	if ensureFramework() != nil {
 		return nil
 	}
+	frameworkMu.RLock()
+	defer frameworkMu.RUnlock()
 	names := make([]string, 0, len(datatypesByNm))
 	for n := range datatypesByNm {
 		names = append(names, n)

--- a/internal/amwa/codec/ms05/types_descriptor.go
+++ b/internal/amwa/codec/ms05/types_descriptor.go
@@ -23,21 +23,23 @@ type NcEnumItemDescriptor struct {
 // NcFieldDescriptor describes one field of a struct datatype.
 type NcFieldDescriptor struct {
 	NcDescriptor
-	Name        string                 `json:"name"`
-	TypeName    *string                `json:"typeName"`
-	IsNullable  bool                   `json:"isNullable"`
-	IsSequence  bool                   `json:"isSequence"`
-	Constraints *NcParameterConstraints `json:"constraints"`
+	Name        string  `json:"name"`
+	TypeName    *string `json:"typeName"`
+	IsNullable  bool    `json:"isNullable"`
+	IsSequence  bool    `json:"isSequence"`
+	// Constraints is the schema's polymorphic union — nil, or one of
+	// the NcParameterConstraints variants (Number / String / base).
+	Constraints any `json:"constraints"`
 }
 
 // NcParameterDescriptor describes one parameter of a method.
 type NcParameterDescriptor struct {
 	NcDescriptor
-	Name        string                  `json:"name"`
-	TypeName    *string                 `json:"typeName"`
-	IsNullable  bool                    `json:"isNullable"`
-	IsSequence  bool                    `json:"isSequence"`
-	Constraints *NcParameterConstraints `json:"constraints"`
+	Name        string  `json:"name"`
+	TypeName    *string `json:"typeName"`
+	IsNullable  bool    `json:"isNullable"`
+	IsSequence  bool    `json:"isSequence"`
+	Constraints any     `json:"constraints"`
 }
 
 // NcPropertyDescriptor describes one class property.
@@ -45,14 +47,14 @@ type NcParameterDescriptor struct {
 // classes/*.json `properties[]`).
 type NcPropertyDescriptor struct {
 	NcDescriptor
-	ID           NcPropertyId            `json:"id"`
-	Name         string                  `json:"name"`
-	TypeName     *string                 `json:"typeName"`
-	IsReadOnly   bool                    `json:"isReadOnly"`
-	IsNullable   bool                    `json:"isNullable"`
-	IsSequence   bool                    `json:"isSequence"`
-	IsDeprecated bool                    `json:"isDeprecated"`
-	Constraints  *NcParameterConstraints `json:"constraints"`
+	ID           NcPropertyId `json:"id"`
+	Name         string       `json:"name"`
+	TypeName     *string      `json:"typeName"`
+	IsReadOnly   bool         `json:"isReadOnly"`
+	IsNullable   bool         `json:"isNullable"`
+	IsSequence   bool         `json:"isSequence"`
+	IsDeprecated bool         `json:"isDeprecated"`
+	Constraints  any          `json:"constraints"`
 }
 
 // NcMethodDescriptor describes one class method.
@@ -114,7 +116,7 @@ type NcDatatypeDescriptor struct {
 	// the parent type.
 	IsSequence bool `json:"isSequence,omitempty"`
 
-	Constraints *NcParameterConstraints `json:"constraints,omitempty"`
+	Constraints any `json:"constraints,omitempty"`
 }
 
 // MarshalJSON emits exactly the wire shape the variant's schema

--- a/internal/amwa/provider/configuration.go
+++ b/internal/amwa/provider/configuration.go
@@ -195,6 +195,10 @@ func (o *configObject) memberDescriptor() ms05.NcBlockMemberDescriptor {
 // bundle: root block + DeviceManager + ClassManager, labelled from
 // the Node's own identity.
 func NewIS14ConfigurationServer(logger *slog.Logger, bundle *NodeConfig, cfg IS14ConfigurationConfig) *IS14ConfigurationServer {
+	// The vendor gain class + datatype must be in the ms05 catalogue
+	// before the ClassManager snapshots it or an instance is built.
+	registerVendorModels()
+
 	vers := is14.SupportedVersions()
 	if cfg.APIVer != "" {
 		vers = []string{cfg.APIVer}
@@ -321,6 +325,20 @@ func NewIS14ConfigurationServer(logger *slog.Logger, bundle *NodeConfig, cfg IS1
 				[]string{"transmissionStatus", "essenceStatus"})
 		}
 	}
+
+	// The DhsGainControl worker carries the model's constraint surface
+	// (all three MS-05 levels, declared AND enforced — vendor_gain.go).
+	gain, err5 := newConfigObject(vendorClassID, nextOid, []string{"root", vendorRole}, map[string]any{
+		"userLabel":                  "Gain control",
+		"enabled":                    true,
+		"channelLabel":               "Gain",
+		"gainDb":                     0.0,
+		"runtimePropertyConstraints": vendorRuntimeConstraints(),
+	})
+	if err5 != nil {
+		panic(fmt.Sprintf("provider/is14: gain worker model load: %v", err5))
+	}
+	objs = append(objs, gain)
 
 	if p := root.findProp("2p2"); p != nil { // NcBlock.members
 		members := make([]ms05.NcBlockMemberDescriptor, 0, len(objs)-1)
@@ -541,6 +559,12 @@ func (s *IS14ConfigurationServer) setProperty(obj *configObject, p *configProper
 		return ms05.NcMethodStatusParameterError,
 			fmt.Errorf("property %s (%s): %s", propKey(p.desc.ID), p.desc.Name, msg)
 	}
+	if c := effectiveConstraint(obj, p); c != nil {
+		if err := ms05.CheckConstraintValue(v, c); err != nil {
+			return ms05.NcMethodStatusParameterError,
+				fmt.Errorf("property %s (%s): %v", propKey(p.desc.ID), p.desc.Name, err)
+		}
+	}
 	s.mu.Lock()
 	p.value = v
 	// A userLabel write must show up in the parent block's members
@@ -566,6 +590,37 @@ func (s *IS14ConfigurationServer) setProperty(obj *configObject, p *configProper
 		s.onPropertyChanged(obj.oid, p.desc.ID, v)
 	}
 	return ms05.NcMethodStatusOk, nil
+}
+
+// effectiveConstraint resolves the constraint governing one property
+// write per the MS-05-02 hierarchy: a runtime constraint (the
+// object's runtimePropertyConstraints entry for this property id)
+// overrides the property descriptor's constraint, which overrides the
+// datatype's. Nil when no level declares one.
+func effectiveConstraint(obj *configObject, p *configProperty) any {
+	for _, rp := range obj.props {
+		if rp.desc.Name != "runtimePropertyConstraints" {
+			continue
+		}
+		list, ok := rp.value.([]any)
+		if !ok {
+			break
+		}
+		for _, c := range list {
+			if id, ok := ms05.ConstraintPropertyID(c); ok && id == p.desc.ID {
+				return c
+			}
+		}
+	}
+	if p.desc.Constraints != nil {
+		return p.desc.Constraints
+	}
+	if p.desc.TypeName != nil {
+		if dt, ok := ms05.StandardDatatype(*p.desc.TypeName); ok && dt.Constraints != nil {
+			return dt.Constraints
+		}
+	}
+	return nil
 }
 
 // typeMismatch reports (as a non-empty message) a value the
@@ -765,6 +820,24 @@ func (s *IS14ConfigurationServer) invoke(obj *configObject, md *ms05.NcMethodDes
 
 	case "GetSequenceItem", "GetSequenceLength", "SetSequenceItem", "AddSequenceItem", "RemoveSequenceItem":
 		return s.invokeSequence(obj, md.Name, args)
+
+	case "SetGainDb":
+		// DhsGainControl 4m1 — a named write of gainDb (4p2), through
+		// the same setProperty gate (constraints included).
+		var gainArgs struct {
+			GainDb json.RawMessage `json:"gainDb"`
+		}
+		if err := json.Unmarshal(rawArgs, &gainArgs); err != nil || gainArgs.GainDb == nil {
+			return ms05Err(400, ms05.NcMethodStatusParameterError, "gainDb argument required")
+		}
+		p := obj.findProp("4p2")
+		if p == nil {
+			return ms05Err(400, ms05.NcMethodStatusPropertyNotImplemented, "no gainDb property on this object")
+		}
+		if st, err := s.setProperty(obj, p, gainArgs.GainDb); err != nil {
+			return ms05Err(400, st, err.Error())
+		}
+		return 200, ms05.NcMethodResult{Status: ms05.NcMethodStatusOk}, nil
 
 	case "GetMemberDescriptors":
 		return 200, ms05.NcMethodResultBlockMemberDescriptors{
@@ -1134,6 +1207,19 @@ func (s *IS14ConfigurationServer) restore(obj *configObject, args *is14.BulkProp
 				})
 				hasError = true
 				continue
+			}
+			if c := effectiveConstraint(target, p); c != nil {
+				// The restore twin of setProperty's constraint check
+				// (IS-14 test_27 offers out-of-range values here and
+				// expects them noticed, not accepted).
+				if err := ms05.CheckConstraintValue(ph.Value, c); err != nil {
+					entry.Notices = append(entry.Notices, is14.PropertyRestoreNotice{
+						ID: ph.ID, Name: p.desc.Name, NoticeType: is14.NoticeError,
+						NoticeMessage: err.Error(),
+					})
+					hasError = true
+					continue
+				}
 			}
 			if apply {
 				raw, err := json.Marshal(ph.Value)

--- a/internal/amwa/provider/configuration_test.go
+++ b/internal/amwa/provider/configuration_test.go
@@ -93,7 +93,7 @@ func TestConfigurationTreeAndRolePaths(t *testing.T) {
 	if err := json.Unmarshal(raw, &paths); err != nil {
 		t.Fatalf("rolePaths decode: %v", err)
 	}
-	want := []string{"root/", "root.DeviceManager/", "root.ClassManager/", "root.BulkPropertiesManager/"}
+	want := []string{"root/", "root.DeviceManager/", "root.ClassManager/", "root.BulkPropertiesManager/", "root.GainControl/"}
 	if len(paths) != len(want) {
 		t.Fatalf("rolePaths = %v, want %v", paths, want)
 	}
@@ -218,9 +218,9 @@ func TestConfigurationMethods(t *testing.T) {
 		t.Fatalf("2m1 = %d %s", st, raw)
 	}
 
-	// 1m7 GetSequenceLength on members.
+	// 1m7 GetSequenceLength on members (3 managers + gain worker).
 	st, raw = doJSON(t, "PATCH", v1+"root/methods/1m7/", `{"arguments":{"id":{"level":2,"index":2}}}`)
-	if st != 200 || !bytes.Contains(raw, []byte(`"value":3`)) {
+	if st != 200 || !bytes.Contains(raw, []byte(`"value":4`)) {
 		t.Errorf("1m7 = %d %s", st, raw)
 	}
 
@@ -282,8 +282,8 @@ func TestConfigurationBulkProperties(t *testing.T) {
 	if err := json.Unmarshal(raw, &backup); err != nil {
 		t.Fatalf("backup decode: %v", err)
 	}
-	if backup.Value.ValidationFingerprint == nil || len(backup.Value.Values) != 4 {
-		t.Fatalf("backup holders = %d fp=%v, want 4 + fingerprint", len(backup.Value.Values), backup.Value.ValidationFingerprint)
+	if backup.Value.ValidationFingerprint == nil || len(backup.Value.Values) != 5 {
+		t.Fatalf("backup holders = %d fp=%v, want 5 + fingerprint", len(backup.Value.Values), backup.Value.ValidationFingerprint)
 	}
 	if backup.Value.Values[0].Values[0].Descriptor == nil {
 		t.Error("includeDescriptors default must attach descriptors")
@@ -323,8 +323,9 @@ func TestConfigurationBulkProperties(t *testing.T) {
 		t.Fatalf("backup nodesc = %d", st)
 	}
 	paths := holderPaths(raw)
-	if len(paths) != 3 || paths[0] != "root" || paths[1] != "root.DeviceManager" || paths[2] != "root.BulkPropertiesManager" {
-		t.Errorf("includeDescriptors=false holders = %v, want [root root.DeviceManager root.BulkPropertiesManager]", paths)
+	if len(paths) != 4 || paths[0] != "root" || paths[1] != "root.DeviceManager" ||
+		paths[2] != "root.BulkPropertiesManager" || paths[3] != "root.GainControl" {
+		t.Errorf("includeDescriptors=false holders = %v, want [root root.DeviceManager root.BulkPropertiesManager root.GainControl]", paths)
 	}
 
 	// recurse=false: root only.

--- a/internal/amwa/provider/ncp.go
+++ b/internal/amwa/provider/ncp.go
@@ -234,6 +234,11 @@ func (s *IS12NCPServer) runCommand(cmd is12.Command) is12.MethodResult {
 		if classDerivedFrom(obj.classID, ms05.NcClassId{1, 2, 2}) {
 			return s.methodMonitor(obj, cmd.MethodID)
 		}
+		// DhsGainControl.SetGainDb shares the 4m1 slot on a different
+		// class branch.
+		if cmd.MethodID == (is12.MethodID{Level: 4, Index: 1}) && classKey(obj.classID) == classKey(vendorClassID) {
+			return s.methodSetGainDb(obj, cmd.Arguments)
+		}
 	}
 	return ncpErr(ms05.NcMethodStatusMethodNotImplemented,
 		fmt.Sprintf("method %dm%d is not implemented on oid %d", cmd.MethodID.Level, cmd.MethodID.Index, cmd.OID))
@@ -347,6 +352,30 @@ func (s *IS12NCPServer) methodSet(obj *configObject, args json.RawMessage) is12.
 	// setProperty locks the store itself and fires the model-changed +
 	// property-changed hooks on success.
 	if st, err := s.config.setProperty(obj, p, a.Value); err != nil {
+		return ncpErr(st, err.Error())
+	}
+	return ncpOK()
+}
+
+// methodSetGainDb implements DhsGainControl.SetGainDb (4m1) — a named
+// write of gainDb (4p2) through the shared setProperty gate, so the
+// parameter constraints it declares are enforced for real.
+func (s *IS12NCPServer) methodSetGainDb(obj *configObject, args json.RawMessage) is12.MethodResult {
+	var a struct {
+		GainDb json.RawMessage `json:"gainDb"`
+	}
+	if err := json.Unmarshal(args, &a); err != nil {
+		return ncpErr(ms05.NcMethodStatusParameterError, "SetGainDb: "+err.Error())
+	}
+	if a.GainDb == nil {
+		return ncpErr(ms05.NcMethodStatusParameterError, "SetGainDb: gainDb argument required")
+	}
+	p := obj.findProp("4p2")
+	if p == nil {
+		return ncpErr(ms05.NcMethodStatusPropertyNotImplemented,
+			fmt.Sprintf("no gainDb property on oid %d", obj.oid))
+	}
+	if st, err := s.config.setProperty(obj, p, a.GainDb); err != nil {
 		return ncpErr(st, err.Error())
 	}
 	return ncpOK()

--- a/internal/amwa/provider/vendor_gain.go
+++ b/internal/amwa/provider/vendor_gain.go
@@ -1,0 +1,163 @@
+// The DhsGainControl worker — the device model's non-standard class
+// (MS-05-02 authority-key 0, experimental) and the carrier of its
+// constraints surface.
+//
+// MS-05-02 freezes the standard classes: adding a constraint to, say,
+// NcObject.userLabel would make our ClassManager catalogue disagree
+// with the published models (the AMWA suite compares them verbatim).
+// Constrained properties therefore live on a vendor worker, exactly
+// as real controlled devices declare theirs. All three constraint
+// levels are declared AND enforced (setProperty / restore), each
+// level strictly tighter than the one it overrides:
+//
+//	gainDb (4p2, DhsGainDb):  datatype −120..12 /0.5 → property −90..12 /0.5 → runtime −60..6 /0.5
+//	channelLabel (4p1):       property ≤32 chars      → runtime ≤16 chars     (same pattern)
+//
+// SetGainDb (4m1) carries the parameter-constraints declaration and
+// routes through the same setProperty enforcement.
+
+package provider
+
+import (
+	"sync"
+
+	"dhs/internal/amwa/codec/ms05"
+)
+
+const (
+	vendorClassName    = "DhsGainControl"
+	vendorRole         = "GainControl"
+	vendorDatatypeName = "DhsGainDb"
+)
+
+// vendorClassID: {1,2} = NcWorker, authority key 0 (no registered
+// OUI), class 1 under that authority.
+var vendorClassID = ms05.NcClassId{1, 2, 0, 1}
+
+var vendorGainPattern = "^[A-Za-z0-9 _-]*$"
+
+func strp(s string) *string { return &s }
+func u32p(v uint32) *uint32 { return &v }
+
+// vendorGainParamConstraints is the SetGainDb parameter constraint —
+// the property-level range, restated at the parameter (MS-05-02
+// permits either; the AMWA suite validates both declarations).
+func vendorGainParamConstraints() *ms05.NcParameterConstraintsNumber {
+	return &ms05.NcParameterConstraintsNumber{
+		NcParameterConstraints: ms05.NcParameterConstraints{DefaultValue: 0.0},
+		Minimum:                -90.0,
+		Maximum:                12.0,
+		Step:                   0.5,
+	}
+}
+
+// vendorGainClass is the DhsGainControl descriptor (own elements
+// only — inheritance stays in the catalogue via classId prefixes,
+// like every published model file).
+func vendorGainClass() ms05.NcClassDescriptor {
+	return ms05.NcClassDescriptor{
+		NcDescriptor: ms05.NcDescriptor{Description: strp("dhs example gain control (constraints reference)")},
+		ClassID:      vendorClassID,
+		Name:         vendorClassName,
+		FixedRole:    strp(vendorRole),
+		Properties: []ms05.NcPropertyDescriptor{
+			{
+				NcDescriptor: ms05.NcDescriptor{Description: strp("Channel label")},
+				ID:           ms05.NcPropertyId{Level: 4, Index: 1},
+				Name:         "channelLabel",
+				TypeName:     strp("NcString"),
+				Constraints: &ms05.NcParameterConstraintsString{
+					NcParameterConstraints: ms05.NcParameterConstraints{DefaultValue: "Gain"},
+					MaxCharacters:          u32p(32),
+					Pattern:                &vendorGainPattern,
+				},
+			},
+			{
+				NcDescriptor: ms05.NcDescriptor{Description: strp("Gain in dB")},
+				ID:           ms05.NcPropertyId{Level: 4, Index: 2},
+				Name:         "gainDb",
+				TypeName:     strp(vendorDatatypeName),
+				Constraints: &ms05.NcParameterConstraintsNumber{
+					NcParameterConstraints: ms05.NcParameterConstraints{DefaultValue: 0.0},
+					Minimum:                -90.0,
+					Maximum:                12.0,
+					Step:                   0.5,
+				},
+			},
+		},
+		Methods: []ms05.NcMethodDescriptor{
+			{
+				NcDescriptor:   ms05.NcDescriptor{Description: strp("Set the gain")},
+				ID:             ms05.NcMethodId{Level: 4, Index: 1},
+				Name:           "SetGainDb",
+				ResultDatatype: "NcMethodResult",
+				Parameters: []ms05.NcParameterDescriptor{
+					{
+						NcDescriptor: ms05.NcDescriptor{Description: strp("Gain in dB")},
+						Name:         "gainDb",
+						TypeName:     strp(vendorDatatypeName),
+						Constraints:  vendorGainParamConstraints(),
+					},
+				},
+			},
+		},
+		Events: []ms05.NcEventDescriptor{},
+	}
+}
+
+// vendorGainDatatype: DhsGainDb, a typedef of NcFloat64 carrying the
+// widest (datatype-level) range.
+func vendorGainDatatype() ms05.NcDatatypeDescriptor {
+	return ms05.NcDatatypeDescriptor{
+		NcDescriptor: ms05.NcDescriptor{Description: strp("Gain in decibels")},
+		Name:         vendorDatatypeName,
+		Type:         ms05.NcDatatypeTypeTypedef,
+		ParentType:   strp("NcFloat64"),
+		Constraints: &ms05.NcParameterConstraintsNumber{
+			NcParameterConstraints: ms05.NcParameterConstraints{DefaultValue: 0.0},
+			Minimum:                -120.0,
+			Maximum:                12.0,
+			Step:                   0.5,
+		},
+	}
+}
+
+// vendorRuntimeConstraints seeds NcObject.runtimePropertyConstraints
+// on the gain worker — the tightest level of the hierarchy.
+func vendorRuntimeConstraints() []any {
+	return []any{
+		&ms05.NcPropertyConstraintsString{
+			NcPropertyConstraints: ms05.NcPropertyConstraints{
+				PropertyId:   ms05.NcPropertyId{Level: 4, Index: 1},
+				DefaultValue: "Gain",
+			},
+			MaxCharacters: u32p(16),
+			Pattern:       &vendorGainPattern,
+		},
+		&ms05.NcPropertyConstraintsNumber{
+			NcPropertyConstraints: ms05.NcPropertyConstraints{
+				PropertyId:   ms05.NcPropertyId{Level: 4, Index: 2},
+				DefaultValue: 0.0,
+			},
+			Minimum: -60.0,
+			Maximum: 6.0,
+			Step:    0.5,
+		},
+	}
+}
+
+var vendorRegisterOnce sync.Once
+
+// registerVendorModels puts the gain class + datatype into the ms05
+// catalogue — before any ClassManager snapshot or model object is
+// built from it.
+func registerVendorModels() {
+	vendorRegisterOnce.Do(func() {
+		if err := ms05.RegisterClass(vendorGainClass()); err != nil {
+			panic("provider: vendor class registration: " + err.Error())
+		}
+		if err := ms05.RegisterDatatype(vendorGainDatatype()); err != nil {
+			panic("provider: vendor datatype registration: " + err.Error())
+		}
+	})
+}

--- a/internal/amwa/provider/vendor_gain_test.go
+++ b/internal/amwa/provider/vendor_gain_test.go
@@ -1,0 +1,181 @@
+package provider
+
+// DhsGainControl: the constraints surface is DECLARED (catalogue) and
+// ENFORCED (writes + restore) — the pair the AMWA MS-05/IS-14 suites
+// verify (test_ms05_22..26, IS-14 test_27).
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"dhs/internal/amwa/codec/is12"
+	"dhs/internal/amwa/codec/ms05"
+)
+
+func TestVendorGainCatalogue(t *testing.T) {
+	registerVendorModels()
+
+	cls, ok := ms05.StandardClass(vendorClassID)
+	if !ok {
+		t.Fatal("DhsGainControl is not in the class catalogue")
+	}
+	if cls.Name != vendorClassName || len(cls.Properties) != 2 || len(cls.Methods) != 1 {
+		t.Errorf("class descriptor = %+v", cls)
+	}
+	if _, ok := ms05.StandardDatatype(vendorDatatypeName); !ok {
+		t.Fatal("DhsGainDb is not in the datatype catalogue")
+	}
+	// The flattened descriptor must inherit NcWorker + NcObject.
+	flat, ok := ms05.FlattenedClass(vendorClassID)
+	if !ok {
+		t.Fatal("FlattenedClass(vendor)")
+	}
+	names := map[string]bool{}
+	for _, p := range flat.Properties {
+		names[p.Name] = true
+	}
+	for _, want := range []string{"channelLabel", "gainDb", "enabled", "oid", "runtimePropertyConstraints"} {
+		if !names[want] {
+			t.Errorf("flattened class is missing inherited/own property %q", want)
+		}
+	}
+}
+
+// TestVendorGainHierarchyConsistent guards the declared hierarchy the
+// AMWA suite checks (ms05_26): each level defines every bound the one
+// below defines and is at least as restrictive.
+func TestVendorGainHierarchyConsistent(t *testing.T) {
+	dt := vendorGainDatatype().Constraints.(*ms05.NcParameterConstraintsNumber)
+	var prop *ms05.NcParameterConstraintsNumber
+	for _, p := range vendorGainClass().Properties {
+		if p.Name == "gainDb" {
+			prop = p.Constraints.(*ms05.NcParameterConstraintsNumber)
+		}
+	}
+	var run *ms05.NcPropertyConstraintsNumber
+	for _, c := range vendorRuntimeConstraints() {
+		if n, ok := c.(*ms05.NcPropertyConstraintsNumber); ok {
+			run = n
+		}
+	}
+	if prop == nil || run == nil {
+		t.Fatal("gainDb constraint levels missing")
+	}
+	num := func(v any) float64 { f, _ := v.(float64); return f }
+	if num(prop.Minimum) < num(dt.Minimum) || num(prop.Maximum) > num(dt.Maximum) || num(prop.Step) < num(dt.Step) {
+		t.Errorf("property constraints (%v..%v/%v) loosen the datatype's (%v..%v/%v)",
+			prop.Minimum, prop.Maximum, prop.Step, dt.Minimum, dt.Maximum, dt.Step)
+	}
+	if num(run.Minimum) < num(prop.Minimum) || num(run.Maximum) > num(prop.Maximum) || num(run.Step) < num(prop.Step) {
+		t.Errorf("runtime constraints (%v..%v/%v) loosen the property's (%v..%v/%v)",
+			run.Minimum, run.Maximum, run.Step, prop.Minimum, prop.Maximum, prop.Step)
+	}
+}
+
+func TestVendorGainWriteEnforcement(t *testing.T) {
+	addr := serveConfigNode(t)
+	val := "http://" + addr + "/x-nmos/configuration/v1.0/rolePaths/root.GainControl/properties/4p2/value/"
+	lbl := "http://" + addr + "/x-nmos/configuration/v1.0/rolePaths/root.GainControl/properties/4p1/value/"
+
+	cases := []struct {
+		name, url, body string
+		want            int
+	}{
+		{"gain above runtime max", val, `{"value": 7.0}`, 400},
+		{"gain below runtime min", val, `{"value": -70}`, 400},
+		{"gain off the step grid", val, `{"value": 0.75}`, 400},
+		{"gain in range", val, `{"value": 5.5}`, 200},
+		{"label above runtime maxCharacters", lbl, `{"value": "labels-longer-than-16"}`, 400},
+		{"label breaking the pattern", lbl, `{"value": "bad*chars"}`, 400},
+		{"label in range", lbl, `{"value": "Gain-2"}`, 200},
+	}
+	for _, tc := range cases {
+		st, raw := doJSON(t, "PUT", tc.url, tc.body)
+		if st != tc.want {
+			t.Errorf("%s: PUT = %d %s, want %d", tc.name, st, raw, tc.want)
+		}
+	}
+
+	// The accepted values stuck; the rejected ones did not.
+	st, raw := doJSON(t, "GET", val, "")
+	if st != 200 || !strings.Contains(string(raw), "5.5") {
+		t.Errorf("gainDb after writes = %d %s, want 5.5", st, raw)
+	}
+	st, raw = doJSON(t, "GET", lbl, "")
+	if st != 200 || !strings.Contains(string(raw), "Gain-2") {
+		t.Errorf("channelLabel after writes = %d %s, want Gain-2", st, raw)
+	}
+}
+
+func TestVendorGainRestoreValidateNotices(t *testing.T) {
+	addr := serveConfigNode(t)
+	bp := "http://" + addr + "/x-nmos/configuration/v1.0/rolePaths/root.GainControl/bulkProperties/"
+
+	// PATCH = validate only: an out-of-constraint value must come back
+	// as an Error notice, and must NOT be applied.
+	dataSet := `{"arguments":{"dataSet":{"validationFingerprint":null,"values":[{"path":["root","GainControl"],"dependencyPaths":[],"allowedMembersClasses":[],"values":[{"id":{"level":4,"index":2},"descriptor":null,"value":100}]}]},"recurse":false,"restoreMode":1}}`
+	st, raw := doJSON(t, "PATCH", bp, dataSet)
+	if st != 200 {
+		t.Fatalf("validate = %d %s", st, raw)
+	}
+	body := string(raw)
+	// NoticeType Error is the numeric 400 on the wire.
+	if !strings.Contains(body, "maximum") || !strings.Contains(body, `"noticeType":400`) {
+		t.Errorf("validate response carries no constraint Error notice: %s", body)
+	}
+
+	st, raw = doJSON(t, "GET", "http://"+addr+"/x-nmos/configuration/v1.0/rolePaths/root.GainControl/properties/4p2/value/", "")
+	if st != 200 || strings.Contains(string(raw), "100") {
+		t.Errorf("validate-only round applied the value: %d %s", st, raw)
+	}
+}
+
+func TestNCPSetGainDb(t *testing.T) {
+	addr := serveNCPNode(t)
+
+	// Resolve the worker's oid (bundle-dependent) via IS-14.
+	st, raw := mxlGet(t, "http://"+addr+"/x-nmos/configuration/v1.0/rolePaths/root.GainControl/properties/1p2/value")
+	if st != 200 {
+		t.Fatalf("oid GET = %d %s", st, raw)
+	}
+	var oidResp struct {
+		Value uint32 `json:"value"`
+	}
+	if err := json.Unmarshal(raw, &oidResp); err != nil || oidResp.Value == 0 {
+		t.Fatalf("oid decode: %v (%s)", err, raw)
+	}
+
+	ws := ncpDial(t, addr)
+
+	// Violating SetGainDb answers a per-command error.
+	resp := ncpRoundTrip(t, ws, is12.CommandMessage{Commands: []is12.Command{{
+		Handle: 21, OID: int(oidResp.Value), MethodID: is12.MethodID{Level: 4, Index: 1},
+		Arguments: json.RawMessage(`{"gainDb": 100}`),
+	}}})
+	cr, ok := resp.(is12.CommandResponseMessage)
+	if !ok {
+		t.Fatalf("response type %T", resp)
+	}
+	if cr.Responses[0].Result.Status == 200 {
+		t.Errorf("violating SetGainDb succeeded: %+v", cr.Responses[0].Result)
+	}
+
+	// In-range SetGainDb applies and reads back through 4p2.
+	resp = ncpRoundTrip(t, ws, is12.CommandMessage{Commands: []is12.Command{{
+		Handle: 22, OID: int(oidResp.Value), MethodID: is12.MethodID{Level: 4, Index: 1},
+		Arguments: json.RawMessage(`{"gainDb": 3.5}`),
+	}}})
+	cr = resp.(is12.CommandResponseMessage)
+	if cr.Responses[0].Result.Status != 200 {
+		t.Fatalf("SetGainDb = %+v", cr.Responses[0].Result)
+	}
+	resp = ncpRoundTrip(t, ws, is12.CommandMessage{Commands: []is12.Command{{
+		Handle: 23, OID: int(oidResp.Value), MethodID: is12.MethodID{Level: 1, Index: 1},
+		Arguments: json.RawMessage(`{"id":{"level":4,"index":2}}`),
+	}}})
+	cr = resp.(is12.CommandResponseMessage)
+	if cr.Responses[0].Result.Status != 200 || string(cr.Responses[0].Result.Value) != "3.5" {
+		t.Errorf("gainDb after SetGainDb = %+v", cr.Responses[0].Result)
+	}
+}


### PR DESCRIPTION
Closes #903.

Implements the constraint surface end-to-end: vendor worker DhsGainControl (non-standard class, authority key 0) declares property/datatype/runtime/parameter constraints; setProperty and restore/validate enforce them, so the AMWA suites' violation attacks (IS-14 test_27, ms05_22-26) hit real rejection logic.

Verified: full amwa unit sweep green locally; suite reruns (IS-12/IS-14) follow post-merge on the plant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)