### PR TITLE
feat(amwa): IS-08 routing constraints declared + enforced

### DIFF
--- a/ansible/roles/dhs_amwa_plant/files/amwa-test-node.json
+++ b/ansible/roles/dhs_amwa_plant/files/amwa-test-node.json
@@ -81,6 +81,7 @@
         "2c47bf5e-1b2c-4abc-9def-deadcfff000e",
         "2c47bf5e-1b2c-4abc-9def-deadbeef0023",
         "2c47bf5e-1b2c-4abc-9def-deadbeef0025",
+        "2c47bf5e-1b2c-4abc-9def-deadbeef0034",
         "2c47bf5e-1b2c-4abc-9def-deadbeef0102",
         "2c47bf5e-1b2c-4abc-9def-deadbeef0202",
         "2c47bf5e-1b2c-4abc-9def-deadbeef0302"
@@ -278,6 +279,66 @@
           "symbol": "R"
         }
       ]
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef0031",
+      "version": "1777651501:0",
+      "label": "dhs-source-block-in",
+      "description": "4-channel internally-generated input routed in hardware blocks of 2 without re-ordering (IS-08 constraint surface)",
+      "tags": {},
+      "caps": {},
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "parents": [],
+      "clock_name": "clk0",
+      "format": "urn:x-nmos:format:audio",
+      "channels": [
+        {
+          "label": "Block A Left",
+          "symbol": "L"
+        },
+        {
+          "label": "Block A Right",
+          "symbol": "R"
+        },
+        {
+          "label": "Block B Left",
+          "symbol": "Lt"
+        },
+        {
+          "label": "Block B Right",
+          "symbol": "Rt"
+        }
+      ]
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef0032",
+      "version": "1777651501:0",
+      "label": "dhs-source-wide-out",
+      "description": "4-channel audio source backing the constrained wide sender (IS-08 constraint surface)",
+      "tags": {},
+      "caps": {},
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "parents": [],
+      "clock_name": "clk0",
+      "format": "urn:x-nmos:format:audio",
+      "channels": [
+        {
+          "label": "Out 1",
+          "symbol": "L"
+        },
+        {
+          "label": "Out 2",
+          "symbol": "R"
+        },
+        {
+          "label": "Out 3",
+          "symbol": "Lt"
+        },
+        {
+          "label": "Out 4",
+          "symbol": "Rt"
+        }
+      ]
     }
   ],
   "flows": [
@@ -464,6 +525,23 @@
       "tags": {},
       "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
       "source_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0027",
+      "parents": [],
+      "format": "urn:x-nmos:format:audio",
+      "media_type": "audio/L24",
+      "sample_rate": {
+        "numerator": 48000,
+        "denominator": 1
+      },
+      "bit_depth": 24
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef0033",
+      "version": "1777651501:0",
+      "label": "dhs-flow-wide",
+      "description": "4-channel audio flow backing the constrained wide sender",
+      "tags": {},
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "source_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0032",
       "parents": [],
       "format": "urn:x-nmos:format:audio",
       "media_type": "audio/L24",
@@ -692,6 +770,24 @@
       "subscription": {
         "receiver_id": null,
         "active": true
+      }
+    },
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef0034",
+      "version": "1777651501:0",
+      "label": "dhs-sender-wide",
+      "description": "4-channel sender fed by the constrained wide output (IS-08 constraint surface)",
+      "tags": {},
+      "flow_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0033",
+      "transport": "urn:x-nmos:transport:rtp.mcast",
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "manifest_href": "http://dhs-node:18080/x-nmos/node/v1.3/senders/2c47bf5e-1b2c-4abc-9def-deadbeef0034/transportfile",
+      "interface_bindings": [
+        "eth0"
+      ],
+      "subscription": {
+        "receiver_id": null,
+        "active": false
       }
     }
   ],
@@ -947,6 +1043,22 @@
       }
     }
   ],
+  "channel_mapping": {
+    "inputs": {
+      "2c47bf5e-1b2c-4abc-9def-deadbeef0031": {
+        "reordering": false,
+        "block_size": 2
+      }
+    },
+    "outputs": {
+      "2c47bf5e-1b2c-4abc-9def-deadbeef0032": {
+        "routable_inputs": [
+          "2c47bf5e-1b2c-4abc-9def-deadbeef0031",
+          null
+        ]
+      }
+    }
+  },
   "event_types": {
     "2c47bf5e-1b2c-4abc-9def-deadbeef0007": {
       "type": "boolean"

--- a/internal/amwa/provider/channelmapping.go
+++ b/internal/amwa/provider/channelmapping.go
@@ -43,6 +43,7 @@ import (
 	stdhttp "net/http"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -226,6 +227,33 @@ func deriveIO(bundle *NodeConfig) is08.IO {
 	for id, o := range out.Outputs {
 		if o.Caps != nil {
 			o.Caps.RoutableInputs = routableInputs(out.Inputs)
+			out.Outputs[id] = o
+		}
+	}
+
+	// Declared caps override the permissive defaults — the bundle's
+	// channel_mapping seed is how a device says "this input routes in
+	// hardware blocks" or "this output only takes these inputs".
+	if bundle.ChannelMapping != nil {
+		for id, seed := range bundle.ChannelMapping.Inputs {
+			in, ok := out.Inputs[id]
+			if !ok || seed == nil || in.Caps == nil {
+				continue
+			}
+			if seed.Reordering != nil {
+				in.Caps.Reordering = *seed.Reordering
+			}
+			if seed.BlockSize != nil {
+				in.Caps.BlockSize = *seed.BlockSize
+			}
+			out.Inputs[id] = in
+		}
+		for id, seed := range bundle.ChannelMapping.Outputs {
+			o, ok := out.Outputs[id]
+			if !ok || seed == nil || o.Caps == nil || seed.RoutableInputs == nil {
+				continue
+			}
+			o.Caps.RoutableInputs = seed.RoutableInputs
 			out.Outputs[id] = o
 		}
 	}
@@ -656,6 +684,112 @@ func (s *IS08ChannelMappingServer) validateActionLocked(action is08.MapEntries) 
 			if *entry.ChannelIndex < 0 || *entry.ChannelIndex >= len(in.Channels) {
 				return fmt.Errorf("input %q has no channel %d", *entry.Input, *entry.ChannelIndex)
 			}
+		}
+		if err := validateOutputCapsLocked(out, chans, s.io.Inputs); err != nil {
+			return fmt.Errorf("output %q: %w", outID, err)
+		}
+	}
+	return nil
+}
+
+// validateOutputCapsLocked enforces the declared IS-08 caps on one
+// output's slice of an action. The rules mirror what the AMWA suite's
+// own route builder produces as LEGAL (is08/active.py
+// getRouteBlockActionsForInputOutput) and what its constraint tests
+// attack (IS-08-01 test_13/14/15):
+//
+//   - routable_inputs is authoritative: an input absent from the list
+//     cannot be routed, and a null entry is what permits unrouting;
+//   - block_size B > 1 routes whole blocks: every touched output
+//     block must be fully specified from ONE aligned input block
+//     (base % B == 0), one input channel per output channel;
+//   - reordering=false means the device is a block selector: the
+//     whole action routes ONE aligned input block, order preserved
+//     (input offset == output offset within the block). With
+//     reordering=true the block may be permuted and different output
+//     blocks may take different input blocks.
+func validateOutputCapsLocked(out is08.Output, chans map[string]is08.MapEntry, inputs map[string]is08.Input) error {
+	if out.Caps == nil {
+		return nil
+	}
+	routable := map[string]bool{}
+	nullOK := false
+	for _, r := range out.Caps.RoutableInputs {
+		if r == nil {
+			nullOK = true
+			continue
+		}
+		routable[*r] = true
+	}
+
+	// Group the routed entries by output block per the routed input's
+	// block size, tracking the one input block a no-reordering input
+	// is allowed.
+	type blockEntry struct {
+		outOffset int
+		inCh      int
+	}
+	blocks := map[string][]blockEntry{} // key = inputID/blockStart
+	noReorderBase := map[string]int{}   // inputID -> required aligned base
+
+	for idx, entry := range chans {
+		n, _ := strconv.Atoi(idx)
+		if entry.Input == nil && entry.ChannelIndex == nil {
+			if !nullOK && len(out.Caps.RoutableInputs) > 0 {
+				return fmt.Errorf("channel %s: unrouting is not permitted (no null entry in routable_inputs)", idx)
+			}
+			continue
+		}
+		if len(out.Caps.RoutableInputs) > 0 && !routable[*entry.Input] {
+			return fmt.Errorf("channel %s: input %q is not in routable_inputs", idx, *entry.Input)
+		}
+		in, ok := inputs[*entry.Input]
+		if !ok || in.Caps == nil {
+			continue
+		}
+		b := in.Caps.BlockSize
+		if b < 1 {
+			b = 1
+		}
+		c := *entry.ChannelIndex
+		if b > 1 {
+			blockStart := (n / b) * b
+			key := *entry.Input + "/" + strconv.Itoa(blockStart)
+			blocks[key] = append(blocks[key], blockEntry{outOffset: n - blockStart, inCh: c})
+		}
+		if !in.Caps.Reordering {
+			base := c - (n % b)
+			if base%b != 0 {
+				return fmt.Errorf("channel %s: input %q routes without re-ordering — input channel %d does not align to a block of %d", idx, *entry.Input, c, b)
+			}
+			if prev, seen := noReorderBase[*entry.Input]; seen && prev != base {
+				return fmt.Errorf("input %q does not support re-ordering: all channels must route from one input block (%d vs %d)", *entry.Input, prev, base)
+			}
+			noReorderBase[*entry.Input] = base
+		}
+	}
+
+	// Block completeness + one aligned input block per output block.
+	for key, entries := range blocks {
+		inID := key[:strings.LastIndexByte(key, '/')]
+		b := inputs[inID].Caps.BlockSize
+		if len(entries) != b {
+			return fmt.Errorf("input %q routes in blocks of %d: touched output block is only %d/%d specified", inID, b, len(entries), b)
+		}
+		seen := map[int]bool{}
+		base := -1
+		for _, e := range entries {
+			bs := (e.inCh / b) * b
+			if base == -1 {
+				base = bs
+			} else if base != bs {
+				return fmt.Errorf("input %q routes in blocks of %d: output block mixes input blocks %d and %d", inID, b, base, bs)
+			}
+			off := e.inCh - bs
+			if seen[off] {
+				return fmt.Errorf("input %q routes in blocks of %d: input channel %d routed twice into one block", inID, b, e.inCh)
+			}
+			seen[off] = true
 		}
 	}
 	return nil

--- a/internal/amwa/provider/channelmapping_constraints_test.go
+++ b/internal/amwa/provider/channelmapping_constraints_test.go
@@ -1,0 +1,172 @@
+package provider
+
+// IS-08 routing constraints: declared caps (channel_mapping seed) are
+// ENFORCED on activations — the attacks IS-08-01 test_13/14/15 run,
+// plus the tool's own legal route shapes which must keep working.
+
+import (
+	"io"
+	"log/slog"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"dhs/internal/amwa/codec/is04"
+	"dhs/internal/amwa/codec/is08"
+	httpsession "dhs/internal/amwa/session/http"
+)
+
+// constrainedBundle extends audioBundle with a 4-channel block input
+// (reordering=false, block_size=2) and a 4-channel output restricted
+// to that input.
+func constrainedBundle() *NodeConfig {
+	b := audioBundle()
+	dev := b.Devices[0].ID
+	fourCh := []is04.SourceAudioChannel{
+		{Label: "Ch1"}, {Label: "Ch2"}, {Label: "Ch3"}, {Label: "Ch4"},
+	}
+	blockIn := is04.Source{
+		ResourceCore: is04.ResourceCore{
+			ID: "eeeeeeee-5555-4555-8555-555555555555", Version: "0:0",
+			Label: "src-block-in", Description: "block input", Tags: map[string][]string{},
+		},
+		Caps: map[string]any{}, DeviceID: dev, Parents: []string{},
+		Format: is04.FormatAudio, Channels: fourCh,
+	}
+	wideSrc := is04.Source{
+		ResourceCore: is04.ResourceCore{
+			ID: "ffffffff-6666-4666-8666-666666666666", Version: "0:0",
+			Label: "src-wide-out", Description: "wide output", Tags: map[string][]string{},
+		},
+		Caps: map[string]any{}, DeviceID: dev, Parents: []string{},
+		Format: is04.FormatAudio, Channels: fourCh,
+	}
+	wideFlow := is04.Flow{
+		ResourceCore: is04.ResourceCore{
+			ID: "abababab-7777-4777-8777-777777777777", Version: "0:0",
+			Label: "flow-wide", Description: "L24", Tags: map[string][]string{},
+		},
+		SourceID: wideSrc.ID, DeviceID: dev, Parents: []string{},
+		Format: is04.FormatAudio, MediaType: "audio/L24",
+		SampleRate: &is04.GrainRate{Numerator: 48000}, BitDepth: 24,
+	}
+	wfid := wideFlow.ID
+	wideSnd := is04.Sender{
+		ResourceCore: is04.ResourceCore{
+			ID: "cdcdcdcd-8888-4888-8888-888888888888", Version: "0:0",
+			Label: "snd-wide", Description: "wide sender", Tags: map[string][]string{},
+		},
+		FlowID: &wfid, Transport: is04.TransportRTP, DeviceID: dev,
+		InterfaceBindings: []string{"eth0"},
+	}
+	b.Sources = append(b.Sources, blockIn, wideSrc)
+	b.Flows = append(b.Flows, wideFlow)
+	b.Senders = append(b.Senders, wideSnd)
+	b.Devices[0].Senders = append(b.Devices[0].Senders, wideSnd.ID)
+
+	f, bs := false, 2
+	blockInID := blockIn.ID
+	b.ChannelMapping = &ChannelMappingSeed{
+		Inputs: map[string]*ChannelMappingInputSeed{
+			blockIn.ID: {Reordering: &f, BlockSize: &bs},
+		},
+		Outputs: map[string]*ChannelMappingOutputSeed{
+			wideSrc.ID: {RoutableInputs: []*string{&blockInID, nil}},
+		},
+	}
+	return b
+}
+
+const (
+	blockInID  = "eeeeeeee-5555-4555-8555-555555555555"
+	wideOutID  = "ffffffff-6666-4666-8666-666666666666"
+	stereoInID = "bbbbbbbb-2222-4222-8222-222222222222" // audioBundle receiver
+)
+
+func cmConstrainedServer(t *testing.T) (*IS08ChannelMappingServer, *httptest.Server) {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	b := constrainedBundle()
+	if err := validateBundle(b); err != nil {
+		t.Fatalf("constrained bundle does not validate: %v", err)
+	}
+	cm := NewIS08ChannelMappingServer(logger, b, IS08ChannelMappingConfig{APIVer: "v1.0"})
+	srv := httpsession.NewServer(logger)
+	cm.Mount(srv)
+	ts := httptest.NewServer(srv.MuxHandler())
+	t.Cleanup(ts.Close)
+	return cm, ts
+}
+
+func postActivation(t *testing.T, ts *httptest.Server, body string) (int, string) {
+	t.Helper()
+	resp, err := ts.Client().Post(ts.URL+"/x-nmos/channelmapping/v1.0/map/activations/",
+		"application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST activation: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(raw)
+}
+
+func TestChannelMappingSeededCaps(t *testing.T) {
+	_, ts := cmConstrainedServer(t)
+
+	var caps is08.InputCaps
+	if st := cmGet(t, ts, "/x-nmos/channelmapping/v1.0/inputs/"+blockInID+"/caps/", &caps); st != 200 {
+		t.Fatalf("input caps = %d", st)
+	}
+	if caps.Reordering || caps.BlockSize != 2 {
+		t.Errorf("seeded input caps = %+v, want reordering=false block_size=2", caps)
+	}
+	var ocaps is08.OutputCaps
+	if st := cmGet(t, ts, "/x-nmos/channelmapping/v1.0/outputs/"+wideOutID+"/caps/", &ocaps); st != 200 {
+		t.Fatalf("output caps = %d", st)
+	}
+	if len(ocaps.RoutableInputs) != 2 || ocaps.RoutableInputs[0] == nil || *ocaps.RoutableInputs[0] != blockInID || ocaps.RoutableInputs[1] != nil {
+		t.Errorf("seeded routable_inputs = %v, want [block-in, null]", ocaps.RoutableInputs)
+	}
+}
+
+func TestChannelMappingConstraintEnforcement(t *testing.T) {
+	act := func(entries string) string {
+		return `{"activation":{"mode":"activate_immediate"},"action":{"` + wideOutID + `":{` + entries + `}}}`
+	}
+	route := func(out int, in string, ch int) string {
+		return `"` + itoa(out) + `":{"input":"` + in + `","channel_index":` + itoa(ch) + `}`
+	}
+
+	cases := []struct {
+		name string
+		body string
+		want int
+	}{
+		{"forbidden input (test_13)", act(route(0, stereoInID, 0)), 400},
+		{"cross-block swap, order kept (test_14)",
+			act(route(0, blockInID, 2) + "," + route(1, blockInID, 3) + "," +
+				route(2, blockInID, 0) + "," + route(3, blockInID, 1)), 400},
+		{"out-of-block duplicate (test_15)",
+			act(route(0, blockInID, 0) + "," + route(1, blockInID, 0)), 400},
+		{"partial block", act(route(0, blockInID, 0)), 400},
+		{"legal: block 0 repeated (tool route builder shape)",
+			act(route(0, blockInID, 0) + "," + route(1, blockInID, 1) + "," +
+				route(2, blockInID, 0) + "," + route(3, blockInID, 1)), 200},
+		{"legal: block 1 repeated",
+			act(route(0, blockInID, 2) + "," + route(1, blockInID, 3) + "," +
+				route(2, blockInID, 2) + "," + route(3, blockInID, 3)), 200},
+		{"legal: unroute all",
+			act(`"0":{"input":null,"channel_index":null},"1":{"input":null,"channel_index":null},"2":{"input":null,"channel_index":null},"3":{"input":null,"channel_index":null}`), 200},
+	}
+	for _, tc := range cases {
+		// Fresh server per case: immediate activations mutate the map.
+		_, ts := cmConstrainedServer(t)
+		st, body := postActivation(t, ts, tc.body)
+		if st != tc.want {
+			t.Errorf("%s: POST = %d %s, want %d", tc.name, st, body, tc.want)
+		}
+	}
+}
+
+func itoa(n int) string { return strconv.Itoa(n) }

--- a/internal/amwa/provider/node_config.go
+++ b/internal/amwa/provider/node_config.go
@@ -47,6 +47,13 @@ type NodeConfig struct {
 	// without it serves an empty (but valid) IS-11 tree.
 	StreamCompatibility *StreamCompatSeed `json:"stream_compatibility,omitempty"`
 
+	// ChannelMapping seeds the IS-08 caps per input/output id. Not
+	// derivable from IS-04: whether a device can re-order channels or
+	// routes them in hardware blocks is channel-mapping vocabulary
+	// only. Optional — inputs default to {reordering:true, block_size:1}
+	// and outputs to the unrestricted routable list.
+	ChannelMapping *ChannelMappingSeed `json:"channel_mapping,omitempty"`
+
 	// Connection seeds the IS-05 boot state per endpoint id.
 	//
 	// Without it every endpoint boots master_enable=false with one leg
@@ -58,6 +65,62 @@ type NodeConfig struct {
 	// keyed by resource id rather than extra keys smuggled into the
 	// IS-04 resources (those are schema-checked on the wire).
 	Connection *ConnectionSeed `json:"connection,omitempty"`
+}
+
+// ChannelMappingSeed maps IS-08 io ids (the IS-04 resource ids the io
+// view derives from) to declared caps.
+type ChannelMappingSeed struct {
+	Inputs  map[string]*ChannelMappingInputSeed  `json:"inputs,omitempty"`
+	Outputs map[string]*ChannelMappingOutputSeed `json:"outputs,omitempty"`
+}
+
+// ChannelMappingInputSeed declares one input's routing constraints.
+type ChannelMappingInputSeed struct {
+	Reordering *bool `json:"reordering,omitempty"`
+	BlockSize  *int  `json:"block_size,omitempty"`
+}
+
+// ChannelMappingOutputSeed restricts which inputs an output accepts.
+// A null entry in the list keeps unrouting legal (IS-08 spells
+// "may be left unrouted" exactly that way).
+type ChannelMappingOutputSeed struct {
+	RoutableInputs []*string `json:"routable_inputs,omitempty"`
+}
+
+// validateChannelMappingSeed rejects seeds naming unknown io ids or
+// declaring impossible caps. The io ids are checked against the SAME
+// derivation deriveIO uses, so a typo fails at load rather than
+// surfacing as an AMWA CouldNotTest four suites later.
+func validateChannelMappingSeed(cfg *NodeConfig) error {
+	if cfg.ChannelMapping == nil {
+		return nil
+	}
+	io := deriveIO(cfg)
+	for id, seed := range cfg.ChannelMapping.Inputs {
+		if _, ok := io.Inputs[id]; !ok {
+			return fmt.Errorf("channel_mapping.inputs[%q]: no such channel-mapping input derives from the bundle", id)
+		}
+		if seed != nil && seed.BlockSize != nil && *seed.BlockSize < 1 {
+			return fmt.Errorf("channel_mapping.inputs[%q].block_size %d: must be >= 1", id, *seed.BlockSize)
+		}
+	}
+	for id, seed := range cfg.ChannelMapping.Outputs {
+		if _, ok := io.Outputs[id]; !ok {
+			return fmt.Errorf("channel_mapping.outputs[%q]: no such channel-mapping output derives from the bundle", id)
+		}
+		if seed == nil {
+			continue
+		}
+		for i, in := range seed.RoutableInputs {
+			if in == nil {
+				continue
+			}
+			if _, ok := io.Inputs[*in]; !ok {
+				return fmt.Errorf("channel_mapping.outputs[%q].routable_inputs[%d] %q: not an input of this bundle", id, i, *in)
+			}
+		}
+	}
+	return nil
 }
 
 // ConnectionSeed maps IS-04 resource ids to their boot connection
@@ -197,5 +260,8 @@ func validateBundle(cfg *NodeConfig) error {
 			return fmt.Errorf("receivers[%d].device_id %q: not declared under devices[]", i, r.DeviceID)
 		}
 	}
-	return validateConnectionSeed(cfg)
+	if err := validateConnectionSeed(cfg); err != nil {
+		return err
+	}
+	return validateChannelMappingSeed(cfg)
 }

--- a/internal/amwa/provider/plant_fixture_test.go
+++ b/internal/amwa/provider/plant_fixture_test.go
@@ -1,0 +1,38 @@
+package provider
+
+// The Ansible plant fixture is a real NodeConfig consumed by the lab
+// deployment — a bundle edit that fails validation would otherwise
+// surface as a dead plant node after the next converge, three hops
+// from the typo.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPlantFixtureValidates(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "ansible", "roles", "dhs_amwa_plant", "files", "amwa-test-node.json")
+	if _, err := os.Stat(path); err != nil {
+		t.Skipf("plant fixture not present: %v", err)
+	}
+	cfg, err := LoadNodeConfigFromFile(path)
+	if err != nil {
+		t.Fatalf("plant fixture does not validate: %v", err)
+	}
+
+	// The IS-08 constraint surface the AMWA suite exercises must stay
+	// declared: a block-routing input and a restricted output.
+	if cfg.ChannelMapping == nil {
+		t.Fatal("plant fixture lost its channel_mapping seed")
+	}
+	io := deriveIO(cfg)
+	in, ok := io.Inputs["2c47bf5e-1b2c-4abc-9def-deadbeef0031"]
+	if !ok || in.Caps == nil || in.Caps.Reordering || in.Caps.BlockSize != 2 || len(in.Channels) < 4 {
+		t.Errorf("block input caps = %+v (channels %d), want reordering=false block_size=2 with >=4 channels", in.Caps, len(in.Channels))
+	}
+	out, ok := io.Outputs["2c47bf5e-1b2c-4abc-9def-deadbeef0032"]
+	if !ok || out.Caps == nil || len(out.Caps.RoutableInputs) != 2 || len(out.Channels) < 4 {
+		t.Errorf("wide output = caps %+v (channels %d), want restricted routable_inputs and >=4 channels", out.Caps, len(out.Channels))
+	}
+}


### PR DESCRIPTION
Closes #905.

channel_mapping seed (reordering/block_size per input, routable_inputs per output) + activation-time enforcement matching the AMWA suite's semantics: test_13/14/15 attacks answer 400 while the suite's own legal route shapes (is08/active.py builder) stay accepted. Plant fixture gains the constrained 4-channel chain; a fixture-validation test guards the bundle in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)