### PR TITLE
feat(amwa): IS-08 boot_map seed — boot-routed device with real activation record

### DIFF
--- a/ansible/roles/dhs_amwa_plant/files/amwa-test-node.json
+++ b/ansible/roles/dhs_amwa_plant/files/amwa-test-node.json
@@ -1057,6 +1057,26 @@
           null
         ]
       }
+    },
+    "boot_map": {
+      "2c47bf5e-1b2c-4abc-9def-deadbeef0032": {
+        "0": {
+          "input": "2c47bf5e-1b2c-4abc-9def-deadbeef0031",
+          "channel_index": 0
+        },
+        "1": {
+          "input": "2c47bf5e-1b2c-4abc-9def-deadbeef0031",
+          "channel_index": 1
+        },
+        "2": {
+          "input": "2c47bf5e-1b2c-4abc-9def-deadbeef0031",
+          "channel_index": 0
+        },
+        "3": {
+          "input": "2c47bf5e-1b2c-4abc-9def-deadbeef0031",
+          "channel_index": 1
+        }
+      }
     }
   },
   "event_types": {

--- a/internal/amwa/provider/channelmapping.go
+++ b/internal/amwa/provider/channelmapping.go
@@ -128,6 +128,33 @@ func NewIS08ChannelMappingServer(logger *slog.Logger, bundle *NodeConfig, cfg IS
 		Activation: is08.ActivationResponse{},
 		Map:        unroutedMap(s.io),
 	}
+
+	// The boot map routes the device before any controller arrives,
+	// through the SAME apply + record path an immediate activation
+	// takes — so map/active AND map/activations/{id} reflect a real
+	// event, not fabricated history. Already validated at config load;
+	// re-checked here because tests build bundles in code.
+	if bundle != nil && bundle.ChannelMapping != nil && len(bundle.ChannelMapping.BootMap) > 0 {
+		action := is08.MapEntries(bundle.ChannelMapping.BootMap)
+		if err := validateAction(s.io, action); err != nil {
+			log := logger
+			if log == nil {
+				log = slog.Default()
+			}
+			log.Error("provider/channelmapping: boot_map rejected", "err", err)
+		} else {
+			s.applyLocked(action)
+			mode := is08.ActivationModeImmediate
+			stamp := is05.FormatTAINow(s.now())
+			s.nextID++
+			resp := is08.MapActivationResponse{
+				Activation: is08.ActivationResponse{Mode: &mode, ActivationTime: &stamp},
+				Action:     action,
+			}
+			s.activations[strconv.Itoa(s.nextID)] = resp
+			s.active.Activation = resp.Activation
+		}
+	}
 	return s
 }
 
@@ -660,8 +687,15 @@ func (s *IS08ChannelMappingServer) lockedByLocked(action is08.MapEntries) (bool,
 
 // validateActionLocked checks one action against the IO view.
 func (s *IS08ChannelMappingServer) validateActionLocked(action is08.MapEntries) error {
+	return validateAction(s.io, action)
+}
+
+// validateAction checks one action against an IO view — shared by the
+// live activation path and the boot_map seed validation, so a boot
+// map the running device would 400 fails at config load instead.
+func validateAction(view is08.IO, action is08.MapEntries) error {
 	for outID, chans := range action {
-		out, found := s.io.Outputs[outID]
+		out, found := view.Outputs[outID]
 		if !found {
 			return fmt.Errorf("unknown output %q", outID)
 		}
@@ -677,7 +711,7 @@ func (s *IS08ChannelMappingServer) validateActionLocked(action is08.MapEntries) 
 			if entry.Input == nil || entry.ChannelIndex == nil {
 				return fmt.Errorf("output %q channel %s: input and channel_index must both be set or both null", outID, idx)
 			}
-			in, found := s.io.Inputs[*entry.Input]
+			in, found := view.Inputs[*entry.Input]
 			if !found {
 				return fmt.Errorf("unknown input %q", *entry.Input)
 			}
@@ -685,7 +719,7 @@ func (s *IS08ChannelMappingServer) validateActionLocked(action is08.MapEntries) 
 				return fmt.Errorf("input %q has no channel %d", *entry.Input, *entry.ChannelIndex)
 			}
 		}
-		if err := validateOutputCapsLocked(out, chans, s.io.Inputs); err != nil {
+		if err := validateOutputCapsLocked(out, chans, view.Inputs); err != nil {
 			return fmt.Errorf("output %q: %w", outID, err)
 		}
 	}

--- a/internal/amwa/provider/channelmapping_constraints_test.go
+++ b/internal/amwa/provider/channelmapping_constraints_test.go
@@ -170,3 +170,59 @@ func TestChannelMappingConstraintEnforcement(t *testing.T) {
 }
 
 func itoa(n int) string { return strconv.Itoa(n) }
+
+// TestChannelMappingBootMap: a seeded boot map routes the device at
+// startup through the real activation path — map/active shows the
+// routes and map/activations carries a genuine record.
+func TestChannelMappingBootMap(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	b := constrainedBundle()
+	in := blockInID
+	ch := func(n int) is08.MapEntry { return is08.MapEntry{Input: &in, ChannelIndex: &n} }
+	b.ChannelMapping.BootMap = map[string]map[string]is08.MapEntry{
+		wideOutID: {"0": ch(0), "1": ch(1), "2": ch(0), "3": ch(1)},
+	}
+	if err := validateBundle(b); err != nil {
+		t.Fatalf("bundle with boot_map does not validate: %v", err)
+	}
+	cm := NewIS08ChannelMappingServer(logger, b, IS08ChannelMappingConfig{APIVer: "v1.0"})
+	srv := httpsession.NewServer(logger)
+	cm.Mount(srv)
+	ts := httptest.NewServer(srv.MuxHandler())
+	t.Cleanup(ts.Close)
+
+	var active is08.MapActive
+	if st := cmGet(t, ts, "/x-nmos/channelmapping/v1.0/map/active/", &active); st != 200 {
+		t.Fatalf("map/active = %d", st)
+	}
+	e := active.Map[wideOutID]["2"]
+	if e.Input == nil || *e.Input != blockInID || e.ChannelIndex == nil || *e.ChannelIndex != 0 {
+		t.Errorf("boot map not applied: channel 2 = %+v", e)
+	}
+	if active.Activation.ActivationTime == nil || active.Activation.Mode == nil {
+		t.Errorf("boot activation must stamp map/active: %+v", active.Activation)
+	}
+
+	var acts map[string]is08.MapActivationResponse
+	if st := cmGet(t, ts, "/x-nmos/channelmapping/v1.0/map/activations/", &acts); st != 200 {
+		t.Fatalf("activations = %d", st)
+	}
+	if len(acts) != 1 {
+		t.Fatalf("boot activation record missing: %d entries", len(acts))
+	}
+	for id := range acts {
+		var one is08.MapActivationResponse
+		if st := cmGet(t, ts, "/x-nmos/channelmapping/v1.0/map/activations/"+id+"/", &one); st != 200 {
+			t.Errorf("activations/%s = %d, want 200", id, st)
+		}
+	}
+
+	// A boot map violating the declared caps is rejected at load.
+	bad := constrainedBundle()
+	bad.ChannelMapping.BootMap = map[string]map[string]is08.MapEntry{
+		wideOutID: {"0": ch(0), "1": ch(0)},
+	}
+	if err := validateBundle(bad); err == nil {
+		t.Error("boot_map violating block constraints validated")
+	}
+}

--- a/internal/amwa/provider/node_config.go
+++ b/internal/amwa/provider/node_config.go
@@ -14,6 +14,7 @@ import (
 
 	"dhs/internal/amwa/codec/is04"
 	"dhs/internal/amwa/codec/is05"
+	"dhs/internal/amwa/codec/is08"
 )
 
 // NodeConfig is the on-disk Node bundle. Fields parallel the Node API
@@ -72,6 +73,15 @@ type NodeConfig struct {
 type ChannelMappingSeed struct {
 	Inputs  map[string]*ChannelMappingInputSeed  `json:"inputs,omitempty"`
 	Outputs map[string]*ChannelMappingOutputSeed `json:"outputs,omitempty"`
+
+	// BootMap is a channel map applied at startup through the normal
+	// immediate-activation path, so the device boots with its channels
+	// routed AND an activation record a controller can read — the
+	// map/active twin of the IS-05 connection seed. Shape is exactly
+	// an IS-08 action: output id → channel index → {input,
+	// channel_index}. It is validated against the declared caps at
+	// load; a boot map the device itself would 400 is a config error.
+	BootMap map[string]map[string]is08.MapEntry `json:"boot_map,omitempty"`
 }
 
 // ChannelMappingInputSeed declares one input's routing constraints.
@@ -118,6 +128,11 @@ func validateChannelMappingSeed(cfg *NodeConfig) error {
 			if _, ok := io.Inputs[*in]; !ok {
 				return fmt.Errorf("channel_mapping.outputs[%q].routable_inputs[%d] %q: not an input of this bundle", id, i, *in)
 			}
+		}
+	}
+	if len(cfg.ChannelMapping.BootMap) > 0 {
+		if err := validateAction(io, is08.MapEntries(cfg.ChannelMapping.BootMap)); err != nil {
+			return fmt.Errorf("channel_mapping.boot_map: %w", err)
 		}
 	}
 	return nil

--- a/internal/amwa/provider/plant_fixture_test.go
+++ b/internal/amwa/provider/plant_fixture_test.go
@@ -35,4 +35,7 @@ func TestPlantFixtureValidates(t *testing.T) {
 	if !ok || out.Caps == nil || len(out.Caps.RoutableInputs) != 2 || len(out.Channels) < 4 {
 		t.Errorf("wide output = caps %+v (channels %d), want restricted routable_inputs and >=4 channels", out.Caps, len(out.Channels))
 	}
+	if len(cfg.ChannelMapping.BootMap) == 0 {
+		t.Error("plant fixture lost its boot_map (the boot activation record the AMWA auto rows read)")
+	}
 }


### PR DESCRIPTION
Closes #907.

🤖 Generated with [Claude Code](https://claude.com/claude-code)