### PR TITLE
fix(amwa): IS-11 flows adapt to constraints; base EDID served verbatim

### DIFF
--- a/internal/amwa/provider/connection_mount.go
+++ b/internal/amwa/provider/connection_mount.go
@@ -20,6 +20,7 @@ import (
 
 	"dhs/internal/amwa/codec/is04"
 	"dhs/internal/amwa/codec/is05"
+	"dhs/internal/amwa/codec/is11"
 	httpsession "dhs/internal/amwa/session/http"
 )
 
@@ -94,6 +95,7 @@ func (s *IS04NodeServer) attachStreamCompatAPI(srv *httpsession.Server) {
 	}
 	s.streamCompat.onSenderConstraintsChanged = s.bumpSenderVersion
 	s.streamCompat.onDeviceChanged = func(string) { s.bumpDeviceVersions() }
+	s.streamCompat.onFlowConstraintsApplied = s.adaptFlowToConstraints
 	s.streamCompat.Mount(srv)
 	host := s.controlHost()
 	for i := range s.bundle.Devices {
@@ -107,6 +109,104 @@ func (s *IS04NodeServer) attachStreamCompatAPI(srv *httpsession.Server) {
 			upsertControl(&d.Controls, ctrl)
 		}
 	}
+}
+
+// flowEssence remembers a Flow's bundle-authored media parameters so
+// removing Active Constraints restores them.
+type flowEssence struct {
+	grainRate  *is04.GrainRate
+	sampleRate *is04.GrainRate
+}
+
+// adaptFlowToConstraints re-configures the Sender's Flow so its
+// essence satisfies the Active Constraints — IS-11's model of a
+// device re-negotiating what it emits (Behaviour.md; the AMWA suite
+// reads the flow's grain_rate/sample_rate back and expects the
+// constrained value, test_02_03_05_*). The empty shape restores the
+// bundle's original parameters.
+func (s *IS04NodeServer) adaptFlowToConstraints(senderID string, a is11.ActiveConstraints) {
+	if s.bundle == nil {
+		return
+	}
+	var fl *is04.Flow
+	for i := range s.bundle.Senders {
+		if s.bundle.Senders[i].ID != senderID || s.bundle.Senders[i].FlowID == nil {
+			continue
+		}
+		for j := range s.bundle.Flows {
+			if s.bundle.Flows[j].ID == *s.bundle.Senders[i].FlowID {
+				fl = &s.bundle.Flows[j]
+			}
+		}
+	}
+	if fl == nil {
+		return
+	}
+	if s.flowOriginals == nil {
+		s.flowOriginals = map[string]flowEssence{}
+	}
+	if _, ok := s.flowOriginals[fl.ID]; !ok {
+		s.flowOriginals[fl.ID] = flowEssence{grainRate: fl.GrainRate, sampleRate: fl.SampleRate}
+	}
+
+	var gr, sr *is04.GrainRate
+	for _, cs := range a.ConstraintSets {
+		if en, ok := cs["urn:x-nmos:cap:meta:enabled"].(bool); ok && !en {
+			continue
+		}
+		if gr == nil {
+			gr = rationalEnumFirst(cs["urn:x-nmos:cap:format:grain_rate"])
+		}
+		if sr == nil {
+			sr = rationalEnumFirst(cs["urn:x-nmos:cap:format:sample_rate"])
+		}
+	}
+	orig := s.flowOriginals[fl.ID]
+	if fl.GrainRate != nil || gr != nil {
+		if gr != nil {
+			fl.GrainRate = gr
+		} else {
+			fl.GrainRate = orig.grainRate
+		}
+	}
+	if fl.SampleRate != nil || sr != nil {
+		if sr != nil {
+			fl.SampleRate = sr
+		} else {
+			fl.SampleRate = orig.sampleRate
+		}
+	}
+	fl.Version = is05.FormatTAINow(time.Now())
+	if s.connection != nil {
+		snap := *fl
+		s.connection.notifyChanged(is04.ResourceFlow, &snap)
+	}
+}
+
+// rationalEnumFirst pulls the first rational out of a parameter
+// constraint's enum member ({"enum":[{"numerator":..,"denominator":..}]}).
+func rationalEnumFirst(v any) *is04.GrainRate {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil
+	}
+	enum, ok := m["enum"].([]any)
+	if !ok || len(enum) == 0 {
+		return nil
+	}
+	e, ok := enum[0].(map[string]any)
+	if !ok {
+		return nil
+	}
+	num, ok := e["numerator"].(float64)
+	if !ok {
+		return nil
+	}
+	den := 1
+	if d, ok := e["denominator"].(float64); ok && d > 0 {
+		den = int(d)
+	}
+	return &is04.GrainRate{Numerator: int(num), Denominator: den}
 }
 
 // bumpSenderVersion stamps a fresh IS-04 version on one Sender and

--- a/internal/amwa/provider/node.go
+++ b/internal/amwa/provider/node.go
@@ -228,6 +228,11 @@ type IS04NodeServer struct {
 	// Nil disables it.
 	streamCompat *IS11StreamCompatServer
 
+	// flowOriginals remembers each Flow's bundle-authored media
+	// parameters so removing Active Constraints restores them
+	// (adaptFlowToConstraints).
+	flowOriginals map[string]flowEssence
+
 	// configuration is the IS-14 Device Configuration API. Nil
 	// disables it.
 	configuration *IS14ConfigurationServer

--- a/internal/amwa/provider/streamcompat.go
+++ b/internal/amwa/provider/streamcompat.go
@@ -171,6 +171,12 @@ type IS11StreamCompatServer struct {
 	// onDeviceChanged does the same for the Device owning a changed
 	// Input/Output.
 	onDeviceChanged func(deviceID string)
+	// onFlowConstraintsApplied lets the IS-04 side re-configure the
+	// Sender's Flow to satisfy the Active Constraints — IS-11's
+	// essence adaptation (test_02_03_05_* reads the flow's
+	// grain_rate/sample_rate back and expects the constrained value).
+	// Called with the empty shape on DELETE so originals restore.
+	onFlowConstraintsApplied func(senderID string, a is11.ActiveConstraints)
 }
 
 // NewIS11StreamCompatServer builds the surface from the bundle seed.
@@ -416,6 +422,9 @@ func (s *IS11StreamCompatServer) putActive(id string, r *stdhttp.Request) (int, 
 	if s.onSenderConstraintsChanged != nil {
 		s.onSenderConstraintsChanged(id)
 	}
+	if s.onFlowConstraintsApplied != nil {
+		s.onFlowConstraintsApplied(id, a)
+	}
 	s.bumpConstrainedInputs(id)
 	return 200, a, nil
 }
@@ -434,6 +443,9 @@ func (s *IS11StreamCompatServer) deleteActive(id string) (int, any, error) {
 	s.mu.Unlock()
 	if s.onSenderConstraintsChanged != nil {
 		s.onSenderConstraintsChanged(id)
+	}
+	if s.onFlowConstraintsApplied != nil {
+		s.onFlowConstraintsApplied(id, is11.ActiveConstraints{})
 	}
 	s.bumpConstrainedInputs(id)
 	return 200, is11.ActiveConstraints{ConstraintSets: []is11.ConstraintSet{}}, nil
@@ -497,12 +509,14 @@ func (s *IS11StreamCompatServer) mountInput(srv *httpsession.Server, p, id strin
 		// suite fails test_01_01/01_02/01_06 on it. Serving a distinct
 		// default also makes "Effective changes when Base changes"
 		// observable.
-		blob, has := s.baseEDID[id]
-		if !has {
-			blob = defaultEDID()
+		if blob, has := s.baseEDID[id]; has {
+			// An explicitly-set Base EDID is served back VERBATIM —
+			// test_01_02 compares the bytes. The re-negotiation
+			// variant applies only to the device's own default.
+			return 200, &httpsession.RawBody{ContentType: "application/octet-stream", Body: blob}, nil
 		}
 		return 200, &httpsession.RawBody{ContentType: "application/octet-stream",
-			Body: edidVariant(blob, s.edidEpoch[id])}, nil
+			Body: edidVariant(defaultEDID(), s.edidEpoch[id])}, nil
 	})
 }
 

--- a/internal/amwa/provider/streamcompat_constraints_test.go
+++ b/internal/amwa/provider/streamcompat_constraints_test.go
@@ -6,13 +6,20 @@ package provider
 // observes.
 
 import (
+	"encoding/json"
 	"io"
 	stdhttp "net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"dhs/internal/amwa/codec/is11"
+	// The node mounts IS-11 for the registered minors only — the test
+	// binary needs the v1.0 codec registered like cmd/dhs does.
+	_ "dhs/internal/amwa/codec/is11/v10"
 )
+
+func ioReader(s string) io.Reader { return strings.NewReader(s) }
 
 func scReadEffective(t *testing.T, ts *httptest.Server, id string) []byte {
 	t.Helper()
@@ -72,5 +79,78 @@ func TestIS11ConstraintsMoveInputs(t *testing.T) {
 	edidReset := scReadEffective(t, ts, scInput)
 	if string(edidReset) == string(edidAfter) {
 		t.Error("effective EDID did not move on constraints DELETE")
+	}
+}
+
+// TestIS11ConstraintsAdaptFlow: applying Active Constraints
+// re-configures the sender's Flow (IS-11 essence adaptation), and
+// removing them restores the bundle's original parameters.
+func TestIS11ConstraintsAdaptFlow(t *testing.T) {
+	b := audioBundle()
+	sndID := "aaaaaaaa-1111-4111-8111-111111111111"
+	flowID := "dddddddd-4444-4444-8444-444444444444"
+	inID := "33333333-3333-4333-8333-333333333333" // IS-11 input entity (its own id space)
+	adjust := false
+	b.StreamCompatibility = &StreamCompatSeed{
+		Inputs: []is11.Input{{
+			ResourceCore: is11.ResourceCore{ID: inID, Version: "1:0", Label: "IN",
+				Description: "x", Tags: map[string][]string{}},
+			AdjustToCaps:    &adjust,
+			BaseEDIDSupport: true,
+			Connected:       true,
+			EDIDSupport:     true,
+			Status:          is11.Status{State: is11.InputSignalPresent},
+			DeviceID:        b.Devices[0].ID,
+		}},
+		SenderInputs: map[string][]string{sndID: {inID}},
+	}
+	addr := serveNCPBundleNode(t, b)
+
+	put := func(body string) int {
+		req, _ := stdhttp.NewRequest("PUT",
+			"http://"+addr+"/x-nmos/streamcompatibility/v1.0/senders/"+sndID+"/constraints/active/",
+			ioReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := stdhttp.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("PUT constraints: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		return resp.StatusCode
+	}
+	flowRate := func() string {
+		st, raw := mxlGet(t, "http://"+addr+"/x-nmos/node/v1.3/flows/"+flowID)
+		if st != 200 {
+			t.Fatalf("flow GET = %d", st)
+		}
+		var f struct {
+			SampleRate struct {
+				Numerator int `json:"numerator"`
+			} `json:"sample_rate"`
+		}
+		if err := json.Unmarshal(raw, &f); err != nil {
+			t.Fatalf("flow decode: %v", err)
+		}
+		return itoa(f.SampleRate.Numerator)
+	}
+
+	if got := flowRate(); got != "48000" {
+		t.Fatalf("boot sample_rate = %s, want 48000", got)
+	}
+	if st := put(`{"constraint_sets":[{"urn:x-nmos:cap:format:sample_rate":{"enum":[{"numerator":44100,"denominator":1}]}}]}`); st != 200 {
+		t.Fatalf("PUT constraints = %d", st)
+	}
+	if got := flowRate(); got != "44100" {
+		t.Errorf("constrained sample_rate = %s, want 44100 (flow must adapt)", got)
+	}
+	req, _ := stdhttp.NewRequest("DELETE",
+		"http://"+addr+"/x-nmos/streamcompatibility/v1.0/senders/"+sndID+"/constraints/active/", nil)
+	resp, err := stdhttp.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE constraints: %v", err)
+	}
+	_ = resp.Body.Close()
+	if got := flowRate(); got != "48000" {
+		t.Errorf("sample_rate after DELETE = %s, want restored 48000", got)
 	}
 }


### PR DESCRIPTION
Finishes #909 — the three fails from the first rerun (test_01_02, test_02_03_05_01/02).

🤖 Generated with [Claude Code](https://claude.com/claude-code)