### PR TITLE
fix(amwa): adapted flow rationals mirror the constraint shape

### DIFF
--- a/internal/amwa/provider/connection_mount.go
+++ b/internal/amwa/provider/connection_mount.go
@@ -202,7 +202,12 @@ func rationalEnumFirst(v any) *is04.GrainRate {
 	if !ok {
 		return nil
 	}
-	den := 1
+	// Mirror the constraint's own shape: a denominator the controller
+	// left out stays out (omitempty; the spec default is 1). The AMWA
+	// suite compares the flow's rational to its constraint value as a
+	// whole JSON object, so an added "denominator": 1 reads as a
+	// mismatch.
+	den := 0
 	if d, ok := e["denominator"].(float64); ok && d > 0 {
 		den = int(d)
 	}


### PR DESCRIPTION
Last IS-11 fail (test_02_03_05_02): the suite compares the flow rational to its constraint value as a whole JSON object, so an added denominator:1 reads as a mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)