### PR TITLE
feat(ansible): amwa-validate — per-role AMWA conformance gate

### DIFF
--- a/ansible/inventory/hosts.ini
+++ b/ansible/inventory/hosts.ini
@@ -39,6 +39,12 @@ pve01  ansible_host=10.6.224.5
 [tooling]
 dhs-tools
 
+# The AMWA plant host (dhs-nmos-registry + nodes as systemd units;
+# amwa-plant.yml deploys here, amwa-validate-*.yml delegates its
+# CuT-window tasks here).
+[plant]
+dhs-debian
+
 # dhs binary hosts: producers + consumer verbs per OS (ADR-0016 matrix).
 [dhs_clients:children]
 linux

--- a/ansible/playbooks/amwa-validate-controller.yml
+++ b/ansible/playbooks/amwa-validate-controller.yml
@@ -1,0 +1,13 @@
+---
+# Validate the CONTROLLER role. The AMWA controller suites (IS-04-04,
+# IS-05-03) need the interactive controller facade — until that unit
+# lands this play only reports them as not-automatable, so the gap
+# stays visible instead of silently absent.
+
+- name: AMWA validate — controller
+  hosts: tooling
+  gather_facts: true
+  roles:
+    - role: dhs_amwa_validate
+      vars:
+        dhs_amwa_validate_scope: controller

--- a/ansible/playbooks/amwa-validate-mirror.yml
+++ b/ansible/playbooks/amwa-validate-mirror.yml
@@ -1,0 +1,31 @@
+---
+# Validate the MIRROR registry. AMWA ships no mirror suite — the
+# checks here are ours: the mirror must hold a live Query WS
+# subscription on the upstream registry (its whole job), which is also
+# what keeps the registry's subscription surface testable
+# (IS-04-02 auto_query_18/19 need a real subscription to exist).
+#
+# Grows with the mirror unit (program slot 5): resource parity
+# upstream-vs-mirror, audit-trail assertions, and the
+# controller-in-the-middle checks.
+
+- name: AMWA validate — mirror
+  hosts: tooling
+  gather_facts: false
+  vars:
+    dhs_amwa_validate_plant_host: "10.6.250.101"
+    dhs_amwa_validate_registry_port: 8235
+  tasks:
+    - name: The upstream registry must hold at least one live subscription
+      ansible.builtin.uri:
+        url: "http://{{ dhs_amwa_validate_plant_host }}:{{ dhs_amwa_validate_registry_port }}/x-nmos/query/v1.3/subscriptions"
+        return_content: true
+      register: _subs
+
+    - name: Gate
+      ansible.builtin.assert:
+        that: _subs.json | length > 0
+        fail_msg: >-
+          no subscriptions on the upstream Query API — the mirror is
+          not connected (or was restarted and did not re-subscribe)
+        success_msg: "mirror holds {{ _subs.json | length }} subscription(s) upstream"

--- a/ansible/playbooks/amwa-validate-node.yml
+++ b/ansible/playbooks/amwa-validate-node.yml
@@ -1,0 +1,14 @@
+---
+# Validate the plant NODE against every AMWA suite it answers for.
+# Run after any node upgrade; the committed baselines are the verdict.
+#
+#   ansible-playbook -i ansible/inventory/hosts.ini ansible/playbooks/amwa-validate-node.yml
+#   # one suite: ... -e '{"dhs_amwa_validate_only":["IS-08-01"]}'
+
+- name: AMWA validate — node
+  hosts: tooling
+  gather_facts: true
+  roles:
+    - role: dhs_amwa_validate
+      vars:
+        dhs_amwa_validate_scope: node

--- a/ansible/playbooks/amwa-validate-registry.yml
+++ b/ansible/playbooks/amwa-validate-registry.yml
@@ -1,0 +1,12 @@
+---
+# Validate the plant REGISTRY (Registration + Query APIs).
+#
+#   ansible-playbook -i ansible/inventory/hosts.ini ansible/playbooks/amwa-validate-registry.yml
+
+- name: AMWA validate — registry
+  hosts: tooling
+  gather_facts: true
+  roles:
+    - role: dhs_amwa_validate
+      vars:
+        dhs_amwa_validate_scope: registry

--- a/ansible/playbooks/amwa-validate.yml
+++ b/ansible/playbooks/amwa-validate.yml
@@ -1,0 +1,11 @@
+---
+# The whole AMWA conformance gate — every role, in dependency order
+# (registry before node: node suites assume a serving plant registry;
+# mirror last: it asserts on what the earlier plays left running).
+#
+#   ansible-playbook -i ansible/inventory/hosts.ini ansible/playbooks/amwa-validate.yml
+
+- import_playbook: amwa-validate-registry.yml
+- import_playbook: amwa-validate-node.yml
+- import_playbook: amwa-validate-controller.yml
+- import_playbook: amwa-validate-mirror.yml

--- a/ansible/roles/dhs_amwa_validate/defaults/main.yml
+++ b/ansible/roles/dhs_amwa_validate/defaults/main.yml
@@ -1,0 +1,165 @@
+---
+# dhs_amwa_validate — the AMWA conformance regression gate.
+#
+# The catalog below is baselines-as-code: every suite the AMWA NMOS
+# Testing tool ships for the roles we implement, with the EXACT
+# invocation shape each one needs (per-suite endpoint rows — the part
+# that cannot be guessed and was learned run by run), the target it is
+# scored against, and the score the plant reached on 2026-08-31.
+#
+# Naming follows AMWA verbatim: suite ids are the tool's own
+# (IS-12-01, BCP-008-01-01, …) and the end report names failing tests
+# by the tool's test names (test_13, auto_query_5, test_ms05_22 …).
+#
+# Gate rules, enforced by files/parse_suite.py:
+#   - any Fail/Error row fails the play;
+#   - Pass below baseline_pass fails the play (regression);
+#   - Could-Not-Test above baseline_cnt fails the play (a lost fixture
+#     shows up as CNT before it shows up as Fail);
+#   - Pass ABOVE baseline is a warning to raise the number in git.
+
+# Tool + fleet endpoints.
+dhs_amwa_validate_tool_url: "http://localhost:5000/api"
+dhs_amwa_validate_tool_container: nmos-testing
+dhs_amwa_validate_tool_image: "nmos-testing:cachefix"
+dhs_amwa_validate_results_dir: /root/amwa-validate
+
+# The plant (all addresses live on the plant host, group [plant]).
+dhs_amwa_validate_plant_host: "10.6.250.101"
+dhs_amwa_validate_node_port: 18080
+dhs_amwa_validate_registry_port: 8235
+dhs_amwa_validate_cut_port: 18500
+dhs_amwa_validate_plant_bin: /opt/dhs-amwa-plant/dhs
+dhs_amwa_validate_plant_config: /opt/dhs-amwa-plant/amwa-test-node.json
+dhs_amwa_validate_registry_unit: dhs-nmos-registry
+dhs_amwa_validate_node_unit: dhs-nmos-test-node
+
+# Per-suite POST timeout (seconds). IS-11's stable-state loops are the
+# slowest legitimate runner.
+dhs_amwa_validate_suite_timeout: 1800
+
+# Subset filter: AMWA suite ids ("-e dhs_amwa_validate_only='[\"IS-08-01\"]'").
+# Empty = every enabled suite of the play's scope.
+dhs_amwa_validate_only: []
+
+# Safety window for CuT units: transient services self-destruct and a
+# paused registry self-restores after this many seconds even if the
+# play dies mid-suite.
+dhs_amwa_validate_window_safety_sec: 900
+
+# The isolated window (mDNS suites): a second tool instance + a fresh
+# node container on a private docker bridge on the tooling host —
+# nothing else lives there, so no LAN device can race the tool's
+# mocks.
+dhs_amwa_validate_isolated_net: dhs-validate-mdns
+dhs_amwa_validate_isolated_tool: nmos-testing-validate
+dhs_amwa_validate_isolated_tool_port: 5001
+
+# The catalog. Fields:
+#   id            AMWA suite id, verbatim
+#   scope         node | registry | controller | mirror
+#   target        node | registry | cut  (which host:port the rows use)
+#   window        absent | mdns | p2p   (CuT window around the run)
+#   rows          endpoint rows in the suite's declared order; each row
+#                 may carry ver / urlpath / selector; host+port come
+#                 from the target unless the row overrides them (null
+#                 host rows are IS-09-02's mock-System-API shape)
+#   baseline_pass / baseline_cnt   the gate
+#   enabled: false + note          suites we cannot yet drive here
+dhs_amwa_validate_suites:
+  # ---- node scope, plant node :18080 ----
+  - { id: IS-05-01, scope: node, target: node,
+      rows: [{ver: v1.2}], baseline_pass: 60, baseline_cnt: 0 }
+  # baseline 55: the tool's MP2T-SDP round (test_18) flips Pass<->Manual
+  # nondeterministically depending on which receiver it draws — 55 is
+  # the honest floor, 56 the good day.
+  - { id: IS-05-02, scope: node, target: node,
+      rows: [{ver: v1.3}, {ver: v1.2}], baseline_pass: 55, baseline_cnt: 0 }
+  - { id: IS-07-01, scope: node, target: node,
+      rows: [{ver: v1.0}], baseline_pass: 19, baseline_cnt: 0 }
+  # fresh: earlier suites in a sequential run leave staged IS-05 state
+  # (a receiver patched at a previous suite's mock URL); IS-07-02 then
+  # reads a device mid-someone-else's-test. A restart resets it.
+  - { id: IS-07-02, scope: node, target: node, fresh: true,
+      rows: [{ver: v1.3}, {ver: v1.2}, {ver: v1.0}],
+      # baseline_cnt 1 = test_06 (MQTT senders) until the MQTT unit lands.
+      baseline_pass: 52, baseline_cnt: 1 }
+  - { id: IS-08-01, scope: node, target: node,
+      rows: [{ver: v1.0}], baseline_pass: 36, baseline_cnt: 0 }
+  - { id: IS-08-02, scope: node, target: node,
+      rows: [{ver: v1.3}, {ver: v1.0}], baseline_pass: 43, baseline_cnt: 0 }
+  - { id: IS-11-01, scope: node, target: node,
+      rows: [{ver: v1.0}, {ver: v1.3}, {ver: v1.2}],
+      baseline_pass: 103, baseline_cnt: 0 }
+  - { id: IS-12-01, scope: node, target: node,
+      rows: [{ver: v1.3}, {ver: v1.0, urlpath: "x-nmos/ncp/v1.0"}, {ver: v1.0}, {ver: v1.0}],
+      # baseline_cnt 2 = tool-side auto_ms05 "Not Implemented" +
+      # test_ms05_07 (we declare no deprecated properties — by design).
+      baseline_pass: 135, baseline_cnt: 2 }
+  - { id: IS-14-01, scope: node, target: node,
+      rows: [{ver: v1.3}, {ver: v1.0}, {ver: v1.0}, {ver: v1.0}],
+      baseline_pass: 150, baseline_cnt: 1 }
+  - { id: BCP-005-01-01, scope: node, target: node,
+      rows: [{ver: v1.3}], baseline_pass: 16, baseline_cnt: 0 }
+  - { id: BCP-006-01-01, scope: node, target: node,
+      rows: [{ver: v1.3}], baseline_pass: 23, baseline_cnt: 0 }
+  - { id: BCP-006-04, scope: node, target: node,
+      rows: [{ver: v1.3}], baseline_pass: 20, baseline_cnt: 0 }
+  - { id: BCP-007-03-01, scope: node, target: node,
+      rows: [{ver: v1.3}, {ver: v1.2}], baseline_pass: 55, baseline_cnt: 0 }
+  - { id: BCP-008-01-01, scope: node, target: node,
+      rows: [{ver: v1.3}, {ver: v1.2}, {ver: v1.0, urlpath: "x-nmos/ncp/v1.0"}, {ver: v1.0}],
+      baseline_pass: 94, baseline_cnt: 0 }
+  - { id: BCP-008-02-01, scope: node, target: node,
+      rows: [{ver: v1.3}, {ver: v1.2}, {ver: v1.0, urlpath: "x-nmos/ncp/v1.0"}, {ver: v1.0}],
+      baseline_pass: 94, baseline_cnt: 0 }
+  # BCP-003-01 needs the TLS-serving window (EST/cert pair) which is
+  # not encoded here yet — historic score 7/0. Follows with the
+  # auth-mode windows.
+  - { id: BCP-003-01, scope: node, target: node, enabled: false,
+      note: "TLS window not yet encoded (historic 7/0)",
+      rows: [{ver: v1.3}], baseline_pass: 7, baseline_cnt: 0 }
+
+  # ---- node scope, CuT windows :18500 ----
+  # IS-04-01 scores a REGISTERED node against the tool's own mock
+  # registries, which it announces over mDNS: the transient node runs
+  # mDNS-discovery mode and the plant registry pauses so it cannot win
+  # the election (safety timer restores it regardless).
+  # isolated: on the LAN the real Neuron mDNS-registers with the
+  # tool's mock registries (tool-visible as "Heartbeats matched a
+  # different Node ID"), so the mDNS suites score on the private
+  # bridge. flaky_retry stays as belt-and-braces; retries are
+  # reported.
+  - { id: IS-04-01, scope: node, target: cut, window: isolated, flaky_retry: true,
+      rows: [{ver: v1.3}], baseline_pass: 57, baseline_cnt: 0 }
+  # IS-09-02 drives our node's System API CLIENT against the tool's
+  # mock System API (mDNS-announced) — same window; note the suite's
+  # own two-row shape with a null first endpoint.
+  # Two rows: the NODE row (must carry the CuT address — the tool
+  # matches observed /global requests against this IP) and the System
+  # API slot the tool itself serves (null host+port, per its docs:
+  # a null slot skips pre-validation of an API the TOOL provides).
+  - { id: IS-09-02, scope: node, target: cut, window: isolated, flaky_retry: true,
+      rows: [{ver: v1.3}, {host: null, port: null, ver: v1.0}],
+      baseline_pass: 4, baseline_cnt: 0 }
+  # IS-04-03 scores peer-to-peer mode: a registered node MUST NOT
+  # advertise _nmos-node._tcp (IS-04 §4.2.1), so P2P needs its own
+  # --no-registry transient.
+  - { id: IS-04-03, scope: node, target: cut, window: p2p,
+      rows: [{ver: v1.3}], baseline_pass: 17, baseline_cnt: 0 }
+
+  # ---- registry scope, plant registry :8235 ----
+  # baseline_cnt 2 = auto_registration_5/6: the tool substitutes ids
+  # from RAML listing GETs and the registration RAML defines none
+  # under /resource — structurally untestable for ANY implementation
+  # (nmos-cpp included).
+  - { id: IS-04-02, scope: registry, target: registry,
+      rows: [{ver: v1.3}, {ver: v1.3}], baseline_pass: 74, baseline_cnt: 2 }
+
+  # ---- controller scope: needs the controller facade (issue backlog,
+  # user-owned item #7) — listed so the report says "not automatable
+  # yet" instead of silently omitting them. ----
+  - { id: IS-04-04, scope: controller, target: node, enabled: false,
+      note: "controller facade not built yet", rows: [], baseline_pass: 0, baseline_cnt: 0 }
+  - { id: IS-05-03, scope: controller, target: node, enabled: false,
+      note: "controller facade not built yet", rows: [], baseline_pass: 0, baseline_cnt: 0 }

--- a/ansible/roles/dhs_amwa_validate/files/parse_suite.py
+++ b/ansible/roles/dhs_amwa_validate/files/parse_suite.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Gate one AMWA suite result against its baseline.
+
+Usage: parse_suite.py <result.json> <suite_id> <baseline_pass> <baseline_cnt>
+
+Prints a JSON verdict on the LAST line (the Ansible task reads it):
+  {"suite": ..., "ok": bool, "pass": N, "fail": N, "cnt": N,
+   "warnings": N, "problems": [ ... EVS-style rows ... ]}
+
+Gate rules (the baselines-as-code contract in defaults/main.yml):
+  - any Fail/Error row       -> not ok
+  - pass  < baseline_pass    -> not ok (regression)
+  - cnt   > baseline_cnt     -> not ok (a lost fixture surfaces as CNT
+                                before it surfaces as Fail)
+  - pass  > baseline_pass    -> ok, but reported so the number gets
+                                raised in git.
+
+Every non-pass row is reported with the tool's own test name, its
+state, the reason, and the AMWA spec link the tool attaches — the
+per-test view EVS asked for.
+"""
+
+import json
+import sys
+
+
+def main() -> int:
+    path, suite, base_pass, base_cnt = (
+        sys.argv[1],
+        sys.argv[2],
+        int(sys.argv[3]),
+        int(sys.argv[4]),
+    )
+    try:
+        with open(path, encoding="utf-8") as f:
+            r = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        print(json.dumps({"suite": suite, "ok": False, "error": f"unreadable result: {e}"}))
+        return 1
+    if not isinstance(r, dict):
+        print(json.dumps({"suite": suite, "ok": False, "error": f"tool error: {str(r)[:200]}"}))
+        return 1
+
+    res = r.get("results", [])
+    counts: dict[str, int] = {}
+    problems = []
+    for t in res:
+        state = t.get("state", "?")
+        counts[state] = counts.get(state, 0) + 1
+        if state not in ("Pass", "Not Applicable", "Test Disabled"):
+            problems.append(
+                {
+                    "test": t.get("name", "?"),
+                    "state": state,
+                    "reason": str(t.get("detail", ""))[:240],
+                    "amwa_link": t.get("link") or t.get("url") or "",
+                }
+            )
+
+    n_pass = counts.get("Pass", 0)
+    n_fail = counts.get("Fail", 0) + counts.get("Error", 0)
+    n_cnt = counts.get("Could Not Test", 0)
+    n_warn = counts.get("Warning", 0)
+
+    ok = n_fail == 0 and n_pass >= base_pass and n_cnt <= base_cnt
+    verdict = {
+        "suite": suite,
+        "ok": ok,
+        "pass": n_pass,
+        "fail": n_fail,
+        "cnt": n_cnt,
+        "warnings": n_warn,
+        "baseline_pass": base_pass,
+        "baseline_cnt": base_cnt,
+        "above_baseline": max(0, n_pass - base_pass),
+        "states": counts,
+        "problems": problems,
+    }
+    print(json.dumps(verdict))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ansible/roles/dhs_amwa_validate/tasks/main.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/main.yml
@@ -1,0 +1,61 @@
+---
+# dhs_amwa_validate — run on [tooling]; CuT-window tasks delegate to
+# the plant host. Invoked with dhs_amwa_validate_scope set by the
+# amwa-validate-<scope>.yml playbook.
+
+- name: Select the suites for scope {{ dhs_amwa_validate_scope }}
+  ansible.builtin.set_fact:
+    _validate_suites: >-
+      {{ dhs_amwa_validate_suites
+         | selectattr('scope', 'equalto', dhs_amwa_validate_scope)
+         | selectattr('enabled', 'undefined')
+         | list
+         + dhs_amwa_validate_suites
+         | selectattr('scope', 'equalto', dhs_amwa_validate_scope)
+         | selectattr('enabled', 'defined')
+         | selectattr('enabled')
+         | list }}
+    _skipped_suites: >-
+      {{ dhs_amwa_validate_suites
+         | selectattr('scope', 'equalto', dhs_amwa_validate_scope)
+         | selectattr('enabled', 'defined')
+         | rejectattr('enabled')
+         | list }}
+    _validate_verdicts: []
+
+- name: Apply the subset filter
+  ansible.builtin.set_fact:
+    _validate_suites: "{{ _validate_suites | selectattr('id', 'in', dhs_amwa_validate_only) | list }}"
+  when: dhs_amwa_validate_only | length > 0
+
+- name: Converge the tooling host
+  ansible.builtin.include_tasks: tooling.yml
+  when: _validate_suites | length > 0
+
+- name: Preflight the testing tool
+  ansible.builtin.include_tasks: preflight.yml
+  when: _validate_suites | length > 0
+
+- name: Create the run results directory
+  ansible.builtin.file:
+    path: "{{ dhs_amwa_validate_results_dir }}/{{ _validate_run_ts }}"
+    state: directory
+    mode: "0755"
+  when: _validate_suites | length > 0
+
+- name: Stage the suite parser
+  ansible.builtin.copy:
+    src: parse_suite.py
+    dest: "{{ dhs_amwa_validate_results_dir }}/parse_suite.py"
+    mode: "0755"
+  when: _validate_suites | length > 0
+
+- name: Run each suite
+  ansible.builtin.include_tasks: suite.yml
+  loop: "{{ _validate_suites }}"
+  loop_control:
+    loop_var: suite
+    label: "{{ suite.id }}"
+
+- name: Report
+  ansible.builtin.include_tasks: report.yml

--- a/ansible/roles/dhs_amwa_validate/tasks/preflight.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/preflight.yml
@@ -1,0 +1,47 @@
+---
+# The tool is the arbiter, so its configuration is pinned BEFORE any
+# suite runs: a drifted tool scores a different exam.
+
+- name: Read the tool container image
+  ansible.builtin.command: docker inspect --format {% raw %}"{{.Config.Image}}"{% endraw %} {{ dhs_amwa_validate_tool_container }}
+  register: _tool_image
+  changed_when: false
+
+- name: The tool image must be the pinned one
+  ansible.builtin.assert:
+    that: _tool_image.stdout.strip() == dhs_amwa_validate_tool_image
+    fail_msg: >-
+      tool container runs {{ _tool_image.stdout }} — the gate is only
+      meaningful against {{ dhs_amwa_validate_tool_image }}
+
+- name: Read the tool UserConfig
+  ansible.builtin.command: docker exec {{ dhs_amwa_validate_tool_container }} cat /config/UserConfig.py
+  register: _tool_cfg
+  changed_when: false
+
+- name: The tool knobs must match the conformance profile
+  ansible.builtin.assert:
+    that:
+      - "'PULL_REPOS = False' in _tool_cfg.stdout"
+      - "'CONFIG.GARBAGE_COLLECTION_TIMEOUT = 30' in _tool_cfg.stdout"
+      - "'ENABLE_AUTH' not in _tool_cfg.stdout"
+    fail_msg: >-
+      /config/UserConfig.py drifted — expected PULL_REPOS=False,
+      CONFIG.GARBAGE_COLLECTION_TIMEOUT=30 and auth DISARMED.
+      Got: {{ _tool_cfg.stdout }}
+
+- name: The tool API must answer
+  ansible.builtin.uri:
+    url: "{{ dhs_amwa_validate_tool_url }}"
+    method: GET
+    status_code: [200, 405]
+  register: _tool_api
+  retries: 5
+  delay: 3
+  until: _tool_api.status in [200, 405]
+
+# Stamped from a live clock read, NOT ansible_date_time — cached facts
+# hand every run the same stamp and the runs then overwrite each other.
+- name: Stamp the run
+  ansible.builtin.set_fact:
+    _validate_run_ts: "{{ lookup('pipe', 'date -u +%Y%m%dT%H%M%S') }}"

--- a/ansible/roles/dhs_amwa_validate/tasks/report.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/report.yml
@@ -1,0 +1,52 @@
+---
+# The EVS-style end report: one line per suite, then every non-pass
+# row with the tool's own test name, its state, the reason, and the
+# AMWA spec link. The play FAILS at the end (not mid-run) so a
+# regression in one suite never hides the results of the rest.
+
+- name: Suite summary
+  ansible.builtin.debug:
+    msg: >-
+      {{ '%-16s' | format(item.suite) }}
+      {{ 'OK  ' if item.ok else 'FAIL' }}
+      pass={{ item['pass'] }}/{{ item.baseline_pass }}
+      fail={{ item.fail }} cnt={{ item.cnt }}/{{ item.baseline_cnt }}
+      warn={{ item.warnings }}
+      {{ '(RETRIED — third-party interference)' if item.retried | default(false) else '' }}
+      {{ '(+%d above baseline — raise it in git)' | format(item.above_baseline) if item.above_baseline > 0 else '' }}
+  loop: "{{ _validate_verdicts }}"
+  loop_control:
+    label: "{{ item.suite }}"
+
+# Per-test detail: every non-pass row, named by the tool's own test
+# names, with the reason and the AMWA spec link.
+- name: Per-test detail rows
+  ansible.builtin.debug:
+    msg: "[{{ item.1.state }}] {{ item.1.test }}: {{ item.1.reason }}{% if item.1.amwa_link %}  ({{ item.1.amwa_link }}){% endif %}"
+  loop: "{{ _validate_verdicts | subelements('problems') }}"
+  loop_control:
+    label: "{{ item.0.suite }} {{ item.1.test }}"
+
+- name: Suites this play cannot drive yet
+  ansible.builtin.debug:
+    msg: "{{ item.id }}: {{ item.note | default('disabled') }}"
+  loop: "{{ _skipped_suites }}"
+  loop_control:
+    label: "{{ item.id }}"
+  when: _skipped_suites | length > 0
+
+- name: Results location
+  ansible.builtin.debug:
+    msg: "raw results: {{ dhs_amwa_validate_results_dir }}/{{ _validate_run_ts | default('n/a') }}/"
+  when: _validate_verdicts | length > 0
+
+- name: Gate
+  ansible.builtin.assert:
+    that: _validate_verdicts | rejectattr('ok') | list | length == 0
+    fail_msg: >-
+      {{ _validate_verdicts | rejectattr('ok') | map(attribute='suite') | join(', ') }}
+      regressed against the committed baselines
+    success_msg: >-
+      {{ _validate_verdicts | length }} suites at or above baseline,
+      0 failures
+  when: _validate_verdicts | length > 0

--- a/ansible/roles/dhs_amwa_validate/tasks/suite.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/suite.yml
@@ -1,0 +1,49 @@
+---
+# One suite: (optional fresh-node restart) -> attempt -> (optional one
+# retry for third-party-interference suites) -> collect the verdict.
+
+- name: "{{ suite.id }} — resolve the target"
+  ansible.builtin.set_fact:
+    _suite_host: "{{ dhs_amwa_validate_plant_host }}"
+    _suite_port: >-
+      {{ dhs_amwa_validate_cut_port if suite.target == 'cut'
+         else (dhs_amwa_validate_registry_port if suite.target == 'registry'
+         else dhs_amwa_validate_node_port) }}
+    _suite_verdict: !!null
+
+# fresh: true — restart the plant node first. Long sequential runs
+# leave staged IS-05 state behind (a receiver patched at a previous
+# suite's mock URL) and the next suite then reads a live device that
+# is mid-someone-else's-test.
+- name: "{{ suite.id }} — restart the plant node for a clean state"
+  ansible.builtin.systemd:
+    name: "{{ dhs_amwa_validate_node_unit }}"
+    state: restarted
+  delegate_to: "{{ groups['plant'][0] }}"
+  when: suite.fresh | default(false)
+
+- name: "{{ suite.id }} — wait for the fresh node"
+  ansible.builtin.uri:
+    url: "http://{{ _suite_host }}:{{ dhs_amwa_validate_node_port }}/x-nmos/node/v1.3/self"
+  register: _fresh_up
+  retries: 15
+  delay: 2
+  until: _fresh_up.status == 200
+  when: suite.fresh | default(false)
+
+- name: "{{ suite.id }} — first attempt"
+  ansible.builtin.include_tasks: suite_attempt.yml
+
+# flaky_retry: true — one retry with a FRESH window. Reserved for
+# suites where a third party we do not control races the tool's mocks
+# (the lab's real Neuron mDNS-registers with them, IS-04-01); the
+# retry is recorded in the verdict so it never hides silently.
+- name: "{{ suite.id }} — retry once (third-party interference)"
+  ansible.builtin.include_tasks: suite_attempt.yml
+  when:
+    - suite.flaky_retry | default(false)
+    - not (_suite_verdict.ok | default(false))
+
+- name: "{{ suite.id }} — collect the verdict"
+  ansible.builtin.set_fact:
+    _validate_verdicts: "{{ _validate_verdicts + [_suite_verdict] }}"

--- a/ansible/roles/dhs_amwa_validate/tasks/suite_attempt.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/suite_attempt.yml
@@ -1,0 +1,76 @@
+---
+# One attempt of one suite: window open -> row build -> invoke ->
+# store -> gate. The window closes in `always` so a retry reopens a
+# FRESH one — a half-registered CuT from a raced first attempt would
+# poison the second.
+
+- name: "{{ suite.id }} — attempt bookkeeping"
+  ansible.builtin.set_fact:
+    _attempt_suffix: "{{ '-retry' if _suite_verdict else '' }}"
+    _suite_host_override: !!null
+    _suite_port_override: !!null
+    _tool_url_override: !!null
+    _norm_rows: []
+
+- name: "{{ suite.id }} — attempt{{ _attempt_suffix }}"
+  block:
+    - name: "{{ suite.id }} — open the {{ suite.window | default('no') }} window"
+      ansible.builtin.include_tasks: "window_{{ suite.window }}.yml"
+      when: suite.window is defined
+
+    # Fill each row's absent members from the (possibly window-
+    # overridden) target. An EXPLICIT null in the catalog stays null —
+    # that is IS-09-02's mock-API row shape.
+    - name: "{{ suite.id }} — normalise the endpoint rows"
+      ansible.builtin.set_fact:
+        _norm_rows: >-
+          {{ _norm_rows + [ {
+               'host': row.host | default(_suite_host_override | default(_suite_host, true)),
+               'port': row.port | default((_suite_port_override | default(_suite_port, true)) | int),
+               'ver': row.ver | default(None),
+               'urlpath': row.urlpath | default(None),
+               'selector': row.selector | default(None) } ] }}
+      loop: "{{ suite.rows }}"
+      loop_control:
+        loop_var: row
+        label: "{{ row.ver | default('null') }}"
+
+    - name: "{{ suite.id }} — invoke the tool"
+      ansible.builtin.uri:
+        url: "{{ _tool_url_override | default(dhs_amwa_validate_tool_url, true) }}"
+        method: POST
+        body_format: json
+        timeout: "{{ dhs_amwa_validate_suite_timeout }}"
+        return_content: true
+        body:
+          suite: "{{ suite.id }}"
+          host: "{{ _norm_rows | map(attribute='host') | list }}"
+          port: "{{ _norm_rows | map(attribute='port') | list }}"
+          version: "{{ _norm_rows | map(attribute='ver') | list }}"
+          urlpath: "{{ _norm_rows | map(attribute='urlpath') | list }}"
+          selector: "{{ _norm_rows | map(attribute='selector') | list }}"
+          output: json
+      register: _suite_resp
+
+    - name: "{{ suite.id }} — store the raw result"
+      ansible.builtin.copy:
+        content: "{{ _suite_resp.content }}"
+        dest: "{{ dhs_amwa_validate_results_dir }}/{{ _validate_run_ts }}/{{ suite.id }}{{ _attempt_suffix }}.json"
+        mode: "0644"
+
+    - name: "{{ suite.id }} — gate against the baseline"
+      ansible.builtin.command: >-
+        python3 {{ dhs_amwa_validate_results_dir }}/parse_suite.py
+        {{ dhs_amwa_validate_results_dir }}/{{ _validate_run_ts }}/{{ suite.id }}{{ _attempt_suffix }}.json
+        {{ suite.id }} {{ suite.baseline_pass }} {{ suite.baseline_cnt }}
+      register: _suite_gate
+      changed_when: false
+      failed_when: false
+
+    - name: "{{ suite.id }} — record the verdict"
+      ansible.builtin.set_fact:
+        _suite_verdict: "{{ _suite_gate.stdout | from_json | combine({'retried': _attempt_suffix != ''}) }}"
+  always:
+    - name: "{{ suite.id }} — close the window"
+      ansible.builtin.include_tasks: window_teardown.yml
+      when: suite.window is defined

--- a/ansible/roles/dhs_amwa_validate/tasks/tooling.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/tooling.yml
@@ -1,0 +1,67 @@
+---
+# Converge the tooling host so a rebuilt dhs-tools replays to the same
+# state — nothing here may live only in someone's shell history.
+#
+#   - docker uses the cgroupfs driver: this LXC's systemd never holds
+#     its dbus name (org.freedesktop.systemd1 absent even after boot),
+#     so the default systemd cgroup driver cannot create NEW
+#     containers at all — existing ones start, new `docker run` fails
+#     with "unable to start unit docker-….scope";
+#   - the AMWA testing tool container exists, on HOST networking with
+#     the host dbus (mDNS suites need real multicast + avahi), from
+#     the pinned image;
+#   - its UserConfig carries the conformance profile.
+
+- name: Docker uses the cgroupfs driver
+  ansible.builtin.copy:
+    content: |
+      {
+        "exec-opts": ["native.cgroupdriver=cgroupfs"]
+      }
+    dest: /etc/docker/daemon.json
+    mode: "0644"
+  register: _docker_cfg
+
+- name: Restart docker on driver change
+  ansible.builtin.systemd:
+    name: docker
+    state: restarted
+  when: _docker_cfg.changed
+
+- name: The tool container exists
+  ansible.builtin.command: docker inspect -f {% raw %}"{{.State.Status}}"{% endraw %} {{ dhs_amwa_validate_tool_container }}
+  register: _tool_state
+  changed_when: false
+  failed_when: false
+
+- name: Create the tool container
+  ansible.builtin.command: >-
+    docker run -d --name {{ dhs_amwa_validate_tool_container }}
+    --network host
+    -v /run/dbus:/run/dbus
+    --restart unless-stopped
+    {{ dhs_amwa_validate_tool_image }}
+  when: _tool_state.rc != 0
+  changed_when: true
+
+- name: The tool container is running
+  ansible.builtin.command: docker start {{ dhs_amwa_validate_tool_container }}
+  when: _tool_state.rc == 0 and 'running' not in _tool_state.stdout
+  changed_when: true
+
+- name: Render the conformance UserConfig
+  ansible.builtin.copy:
+    content: |
+      PULL_REPOS = False
+      from . import Config as CONFIG
+      CONFIG.GARBAGE_COLLECTION_TIMEOUT = 30
+    dest: /opt/dhs-validate-userconfig.py
+    mode: "0644"
+  register: _userconfig
+
+- name: Pin the tool UserConfig
+  ansible.builtin.shell: >-
+    docker cp /opt/dhs-validate-userconfig.py {{ dhs_amwa_validate_tool_container }}:/config/UserConfig.py
+    && docker restart {{ dhs_amwa_validate_tool_container }}
+  when: _userconfig.changed or _tool_state.rc != 0
+  changed_when: true

--- a/ansible/roles/dhs_amwa_validate/tasks/window_isolated.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/window_isolated.yml
@@ -1,0 +1,114 @@
+---
+# Isolated CuT window (IS-04-01 / IS-09-02): a SECOND testing-tool
+# instance and a fresh node container on a private docker bridge, all
+# on the tooling host.
+#
+# Why: these suites score mDNS discovery against the tool's own mock
+# registries / System APIs, and mocks accept whoever answers first —
+# on the lab VLAN the real Neuron mDNS-registers and heartbeats into
+# them (tool-visible as "Heartbeats matched a different Node ID").
+# The bridge is the pre-plant setup that scored these suites clean:
+# nothing lives on it but the tool and the node under test.
+
+- name: Isolated bridge exists
+  ansible.builtin.command: docker network create {{ dhs_amwa_validate_isolated_net }}
+  register: _iso_net
+  changed_when: _iso_net.rc == 0
+  failed_when: _iso_net.rc != 0 and 'already exists' not in _iso_net.stderr
+
+- name: Current node binary + fixture staged on the tooling host
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: /opt/dhs-validate/
+    mode: "0755"
+  loop:
+    - "{{ dhs_amwa_validate_plant_bin }}"
+    - "{{ dhs_amwa_validate_plant_config }}"
+
+- name: Isolated tool instance is running
+  ansible.builtin.command: docker inspect -f {% raw %}"{{.State.Running}}"{% endraw %} {{ dhs_amwa_validate_isolated_tool }}
+  register: _iso_tool
+  changed_when: false
+  failed_when: false
+
+# Remove-then-run rather than start: a half-created corpse (e.g. from
+# a docker-daemon fault mid-create) holds the name but cannot run.
+- name: Clear any dead isolated tool instance
+  ansible.builtin.command: docker rm -f {{ dhs_amwa_validate_isolated_tool }}
+  when: "'true' not in _iso_tool.stdout"
+  changed_when: true
+  failed_when: false
+
+- name: Start the isolated tool instance
+  ansible.builtin.command: >-
+    docker run -d --name {{ dhs_amwa_validate_isolated_tool }}
+    --network {{ dhs_amwa_validate_isolated_net }}
+    -p 127.0.0.1:{{ dhs_amwa_validate_isolated_tool_port }}:5000
+    {{ dhs_amwa_validate_tool_image }}
+  when: "'true' not in _iso_tool.stdout"
+  changed_when: true
+
+- name: Pin the isolated tool's UserConfig
+  ansible.builtin.shell: >-
+    printf 'PULL_REPOS = False\nfrom . import Config as CONFIG\nCONFIG.GARBAGE_COLLECTION_TIMEOUT = 30\n'
+    > /tmp/validate-userconfig.py
+    && docker cp /tmp/validate-userconfig.py {{ dhs_amwa_validate_isolated_tool }}:/config/UserConfig.py
+    && docker restart {{ dhs_amwa_validate_isolated_tool }}
+  when: "'true' not in _iso_tool.stdout"
+  changed_when: true
+
+- name: The isolated tool API answers
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ dhs_amwa_validate_isolated_tool_port }}/api"
+    method: GET
+    status_code: [200, 405]
+  register: _iso_api
+  retries: 20
+  delay: 3
+  until: _iso_api.status in [200, 405]
+
+# A FRESH node per attempt, like the proven pre-plant role: a node
+# that registered in a previous attempt would skip the discovery
+# behaviour the suite exists to score.
+- name: Remove any previous CuT node container
+  ansible.builtin.command: docker rm -f dhs-validate-node
+  changed_when: true
+  failed_when: false
+
+- name: Start the CuT node on the bridge
+  ansible.builtin.command: >-
+    docker run -d --name dhs-validate-node --hostname dhs-validate-node
+    --network {{ dhs_amwa_validate_isolated_net }}
+    -v /opt/dhs-validate:/dv:ro
+    --entrypoint /dv/{{ dhs_amwa_validate_plant_bin | basename }}
+    {{ dhs_amwa_validate_tool_image }}
+    producer nmos serve
+    --bind 0.0.0.0:{{ dhs_amwa_validate_node_port }}
+    --advertise-host dhs-validate-node:{{ dhs_amwa_validate_node_port }}
+    --api-ver v1.3
+    --config /dv/{{ dhs_amwa_validate_plant_config | basename }}
+  changed_when: true
+
+- name: Resolve the CuT node's bridge address
+  ansible.builtin.command: >-
+    docker inspect -f
+    {% raw %}"{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}"{% endraw %}
+    dhs-validate-node
+  register: _iso_node_ip
+  changed_when: false
+
+- name: Let the node boot and settle
+  ansible.builtin.wait_for:
+    timeout: 5
+
+- name: The CuT node is alive
+  ansible.builtin.command: docker inspect -f {% raw %}"{{.State.Running}}"{% endraw %} dhs-validate-node
+  register: _iso_node_alive
+  changed_when: false
+  failed_when: "'true' not in _iso_node_alive.stdout"
+
+- name: Point this suite at the bridge
+  ansible.builtin.set_fact:
+    _suite_host_override: "{{ _iso_node_ip.stdout | trim }}"
+    _suite_port_override: "{{ dhs_amwa_validate_node_port }}"
+    _tool_url_override: "http://127.0.0.1:{{ dhs_amwa_validate_isolated_tool_port }}/api"

--- a/ansible/roles/dhs_amwa_validate/tasks/window_p2p.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/window_p2p.yml
@@ -1,0 +1,32 @@
+---
+# P2P CuT window (IS-04-03): a registered node MUST NOT advertise
+# _nmos-node._tcp (IS-04 §4.2.1), so peer-to-peer needs its own
+# transient with --no-registry and mDNS on. The plant stays untouched.
+
+- name: Start the transient P2P node
+  ansible.builtin.command: >-
+    systemd-run --unit dhs-nmos-validate-cut --collect
+    {{ dhs_amwa_validate_plant_bin }} producer nmos serve
+    --bind 0.0.0.0:{{ dhs_amwa_validate_cut_port }}
+    --no-registry
+    --advertise-host {{ dhs_amwa_validate_plant_host }}:{{ dhs_amwa_validate_cut_port }}
+    --api-ver v1.3
+    --config {{ dhs_amwa_validate_plant_config }}
+  delegate_to: "{{ groups['plant'][0] }}"
+  changed_when: true
+
+- name: Arm the CuT safety-stop timer
+  ansible.builtin.command: >-
+    systemd-run --unit dhs-nmos-validate-cutstop --collect
+    --on-active={{ dhs_amwa_validate_window_safety_sec }}
+    systemctl stop dhs-nmos-validate-cut
+  delegate_to: "{{ groups['plant'][0] }}"
+  changed_when: true
+
+- name: Wait for the transient node
+  ansible.builtin.uri:
+    url: "http://{{ dhs_amwa_validate_plant_host }}:{{ dhs_amwa_validate_cut_port }}/x-nmos/node/v1.3/self"
+  register: _cut_up
+  retries: 15
+  delay: 2
+  until: _cut_up.status == 200

--- a/ansible/roles/dhs_amwa_validate/tasks/window_teardown.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/window_teardown.yml
@@ -1,0 +1,45 @@
+---
+# Close whichever CuT window is open. Every unit is stopped
+# best-effort and the plant registry is (re)started unconditionally —
+# starting an already-running unit is a no-op, and a play that dies
+# between suites must still leave the plant serving.
+
+- name: Stop the transient CuT units
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    state: stopped
+  loop:
+    - dhs-nmos-validate-cut
+    - dhs-nmos-validate-cutstop.timer
+    - dhs-nmos-validate-cutkick.timer
+    - dhs-nmos-validate-restore.timer
+  delegate_to: "{{ groups['plant'][0] }}"
+  failed_when: false
+
+# The node's own log, while the container still exists — the one
+# artefact that explains a CuT failure.
+- name: What the CuT node said
+  ansible.builtin.command: docker logs --tail 80 dhs-validate-node
+  register: _cut_log
+  changed_when: false
+  failed_when: false
+
+- name: Keep the CuT log beside the results
+  ansible.builtin.copy:
+    content: |
+      {{ _cut_log.stdout | default('') }}
+      {{ _cut_log.stderr | default('') }}
+    dest: "{{ dhs_amwa_validate_results_dir }}/{{ _validate_run_ts }}/{{ suite.id }}-node.log"
+    mode: "0644"
+  when: _cut_log.rc | default(1) == 0
+
+- name: Remove the isolated CuT node container
+  ansible.builtin.command: docker rm -f dhs-validate-node
+  changed_when: false
+  failed_when: false
+
+- name: Ensure the plant registry is running
+  ansible.builtin.systemd:
+    name: "{{ dhs_amwa_validate_registry_unit }}"
+    state: started
+  delegate_to: "{{ groups['plant'][0] }}"


### PR DESCRIPTION
Closes #913.

Per-role validation plays (node / registry / controller-stub / mirror) over one role, suite catalog with AMWA names + baselines-as-code, isolated-bridge CuT windows for the mDNS suites, tooling-host convergence (cgroupfs), EVS-style per-test report with AMWA links.

Verified: full amwa-validate.yml on the fleet — 19 suites at baseline, failed=0.

Auth-mode windows follow under the same issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)