### PR TITLE
fix(ansible): lab MQTT broker on 1884

### DIFF
--- a/ansible/roles/dhs_amwa_plant/files/amwa-test-node.json
+++ b/ansible/roles/dhs_amwa_plant/files/amwa-test-node.json
@@ -1149,7 +1149,7 @@
     }
   },
   "events": {
-    "mqtt_broker": "10.6.250.104:1883"
+    "mqtt_broker": "10.6.250.104:1884"
   },
   "event_types": {
     "2c47bf5e-1b2c-4abc-9def-deadbeef0051": {
@@ -1232,7 +1232,7 @@
         "transport_params": [
           {
             "destination_host": "10.6.250.104",
-            "destination_port": 1883
+            "destination_port": 1884
           }
         ]
       },

--- a/ansible/roles/dhs_amwa_validate/tasks/tooling.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/tooling.yml
@@ -30,10 +30,13 @@
     update_cache: true
     cache_valid_time: 86400
 
+# Port 1884, not the MQTT default: the nmos-cpp reference stack's
+# registry container publishes ITS bundled mosquitto on 1883 of this
+# same host.
 - name: Mosquitto listens for the lab (open, LAN-only)
   ansible.builtin.copy:
     content: |
-      listener 1883 0.0.0.0
+      listener 1884 0.0.0.0
       allow_anonymous true
     dest: /etc/mosquitto/conf.d/dhs-lab.conf
     mode: "0644"


### PR DESCRIPTION
Finishes #915 — 1883 belongs to the nmos-cpp reference stack's bundled broker on the same host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)