### PR TITLE
fix(amwa): MQTT sender constraints carry exactly the staged keys

### DIFF
--- a/internal/amwa/provider/connection_state.go
+++ b/internal/amwa/provider/connection_state.go
@@ -293,9 +293,19 @@ func fillEventExtParams(e *connectionEndpoint, cfg *NodeConfig, flowID *string) 
 		e.active.TransportParams[i]["ext_is_07_source_id"] = sourceID
 		e.active.TransportParams[i]["ext_is_07_rest_api_url"] = ""
 	}
-	// The constraint set has to grow the same two keys or the
-	// endpoint's own PATCH validation would reject them as unknown.
+	// The constraint set has to carry EXACTLY the staged keys — the
+	// suite compares the two sets (IS-05-01 test_09), so growing a
+	// constraint key the leg does not stage is as wrong as missing
+	// one. WS event legs stage both ext keys; MQTT legs stage only
+	// the REST URL (their constraints already carry it via
+	// constraintsForTransport).
 	for i := range e.constraints {
+		if i >= len(e.staged.TransportParams) {
+			break
+		}
+		if _, ws := e.staged.TransportParams[i]["ext_is_07_source_id"]; !ws {
+			continue
+		}
 		if _, carries := e.constraints[i]["ext_is_07_source_id"]; !carries {
 			e.constraints[i]["ext_is_07_source_id"] = map[string]any{}
 			e.constraints[i]["ext_is_07_rest_api_url"] = map[string]any{}

--- a/internal/amwa/provider/events_mqtt_test.go
+++ b/internal/amwa/provider/events_mqtt_test.go
@@ -241,6 +241,32 @@ func TestMQTTStateChangeReachesBroker(t *testing.T) {
 	})
 }
 
+// TestMQTTSenderConstraintsMatchStaged: IS-05-01 test_09 compares the
+// constraint key set to the staged key set per leg — they must be
+// identical (the WS-era constraint back-fill once grew
+// ext_is_07_source_id onto MQTT constraints that never stage it).
+func TestMQTTSenderConstraintsMatchStaged(t *testing.T) {
+	b := mqttTallyBundle("127.0.0.1", 1884)
+	st := newConnectionStore()
+	st.seedFromBundle(b)
+	e, err := st.get("senders", mqttTallySenderID)
+	if err != nil {
+		t.Fatalf("mqtt endpoint: %v", err)
+	}
+	for i := range e.staged.TransportParams {
+		for k := range e.staged.TransportParams[i] {
+			if _, ok := e.constraints[i][k]; !ok {
+				t.Errorf("leg %d: staged key %q missing from constraints", i, k)
+			}
+		}
+		for k := range e.constraints[i] {
+			if _, ok := e.staged.TransportParams[i][k]; !ok {
+				t.Errorf("leg %d: constraint key %q not staged", i, k)
+			}
+		}
+	}
+}
+
 func waitCond(t *testing.T, cond func() bool) {
 	t.Helper()
 	deadline := time.Now().Add(5 * time.Second)


### PR DESCRIPTION
Finishes #915 — the last IS-05-01 fail (test_09) after the MQTT sender landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)