### PR TITLE
fix(cli): --leg red drives single-leg senders

### DIFF
--- a/internal/amwa/consumer/resolve_test.go
+++ b/internal/amwa/consumer/resolve_test.go
@@ -32,3 +32,27 @@ func TestMatchSenderLabel(t *testing.T) {
 		t.Errorf("unknown label must list the labels present: %v", err)
 	}
 }
+
+// TestBuildSenderPatchTrimsEmptyOverflow: `--leg red` always renders
+// two slots; on a single-leg sender the trailing EMPTY slot trims
+// away, while a non-empty overflow stays a hard error.
+func TestBuildSenderPatchTrimsEmptyOverflow(t *testing.T) {
+	req := SetSenderRequest{
+		SenderID:         "s",
+		DestinationIPs:   []string{"239.60.1.1", ""},
+		DestinationPorts: []int{5010, 0},
+	}
+	patch, err := buildSenderPatch(1, "activate_immediate", req)
+	if err != nil {
+		t.Fatalf("empty overflow must trim: %v", err)
+	}
+	params := patch["transport_params"].([]map[string]any)
+	if len(params) != 1 || params[0]["destination_ip"] != "239.60.1.1" || params[0]["destination_port"] != 5010 {
+		t.Errorf("patch legs = %+v", params)
+	}
+
+	bad := SetSenderRequest{SenderID: "s", DestinationIPs: []string{"239.60.1.1", "239.62.1.1"}}
+	if _, err := buildSenderPatch(1, "activate_immediate", bad); err == nil {
+		t.Error("non-empty overflow must stay an error")
+	}
+}

--- a/internal/amwa/consumer/setsender.go
+++ b/internal/amwa/consumer/setsender.go
@@ -176,6 +176,17 @@ func buildSenderPatch(legs int, mode is05.ActivationMode, req SetSenderRequest) 
 	if legs == 0 {
 		return nil, fmt.Errorf("nmos set: sender %s reports no transport legs", req.SenderID)
 	}
+	// A trailing EMPTY slot means "leave that leg alone" — and a leg
+	// the device does not have needs no leaving-alone. Trimming lets
+	// `--leg red` (always rendered as a two-slot list) drive a
+	// single-leg sender; a NON-empty value beyond the device's legs
+	// still errors below, because that is a real addressing mistake.
+	for len(req.DestinationIPs) > legs && req.DestinationIPs[len(req.DestinationIPs)-1] == "" {
+		req.DestinationIPs = req.DestinationIPs[:len(req.DestinationIPs)-1]
+	}
+	for len(req.DestinationPorts) > legs && req.DestinationPorts[len(req.DestinationPorts)-1] == 0 {
+		req.DestinationPorts = req.DestinationPorts[:len(req.DestinationPorts)-1]
+	}
 	if n := len(req.DestinationIPs); n > 0 && n != legs {
 		return nil, fmt.Errorf("nmos set: sender %s has %d transport leg(s), you gave "+
 			"%d --destination value(s); give one per leg (ST 2022-7 legs must not "+


### PR DESCRIPTION
Finishes #922 — found by the first live retune (1-leg wide sender).

🤖 Generated with [Claude Code](https://claude.com/claude-code)