### PR TITLE
docs: Go house style guide + lint hardening (#927)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,11 @@ linters:
   default: standard
   enable:
     - depguard
+    # docs/go-style.md "Linting": enabled only because the whole tree
+    # already passes them — the config describes the code.
+    - misspell
+    - unconvert
+    - wastedassign
   settings:
     depguard:
       rules:

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -1134,7 +1134,7 @@ func cerebrumCategoryDetails(_ context.Context, args []string) error {
 			out.Available = &av
 			out.Description = c.Details.Description
 			for _, it := range c.Details.Items {
-				out.Items = append(out.Items, item{it.Index, string(it.Type), it.Value})
+				out.Items = append(out.Items, item{it.Index, it.Type, it.Value})
 			}
 		}
 		return printCerebrumJSON(out)

--- a/cmd/dhs/cmd_probel_csv.go
+++ b/cmd/dhs/cmd_probel_csv.go
@@ -588,7 +588,7 @@ func applyProbelNameCSV(ctx context.Context, p *probelproto.Plugin, path, typ st
 	// Apply changed labels, batched into contiguous same-(matrix,level) id runs
 	// sized to the SW-P-08 DATA cap. Skipped entirely on --check.
 	if !check {
-		perFrame := 120 / int(width.Bytes())
+		perFrame := 120 / width.Bytes()
 		if perFrame < 1 {
 			perFrame = 1
 		}

--- a/docs/go-style.md
+++ b/docs/go-style.md
@@ -1,0 +1,91 @@
+# Go house style
+
+The writing-level standard for this repository — what `gofmt`, the
+linters and the ADRs do **not** already enforce. Read it once, then
+let `.golangci.yml` hold the machine-checkable half.
+
+Scope note (ADR-0015): build rules live elsewhere and are only
+referenced here — layering and dependency policy in
+[`docs/dependencies.md`](../internal/amwa/docs/dependencies.md) and
+ADR-0005/0006, naming and testing baselines in the root
+[`CLAUDE.md`](../CLAUDE.md) "Coding conventions". This page is about
+how the code and its commentary are *written*.
+
+## Comments carry the WHY, and only the why
+
+The house comment is a **rationale**, not a narration. It states the
+constraint the code cannot show: the spec clause being satisfied, the
+failure that taught us, the reason the obvious alternative is wrong.
+
+```go
+// The null entry is not padding: it is how IS-08 spells "this
+// output may be left unrouted". Without it a controller must treat
+// unrouting as forbidden.
+out = append(out, nil)
+```
+
+Rules of thumb:
+
+- **Never narrate.** `// increment the counter` is deleted on sight.
+- **Cite the authority.** A behaviour pinned by a spec names the spec
+  and section (`IS-05 §4.2`, `MQTT 3.1.1 §2.2.3`, `ADR-0013`); one
+  pinned by a tool names the test (`IS-14-01 test_27`); one pinned by
+  a real device names the device ("a real EVS Neuron ships…").
+- **Record the scar.** When code exists because something broke, the
+  comment says what broke and how it looked from the outside — that
+  is what stops the next reader from "simplifying" it back.
+- **Package headers are doctrine.** Every non-trivial package opens
+  with a comment that says what the package IS, the shape of its
+  surface, and the one or two invariants that make it correct.
+
+## Errors are operator sentences
+
+An error is read by someone at 2 a.m. with no source open.
+
+- Lower-case, no trailing punctuation, prefixed with the failing
+  subsystem the way the package does it (`nmos set:`, `registry/mirror:`,
+  `settings:`).
+- Say what was expected AND what to do:
+  `--format: unknown value %q (want table|json|md)`.
+- When a collection was searched, say what WAS there — the resolver
+  that rejects a label lists the labels present.
+- Wrap with `%w` when the caller may branch on it; `errors.Is/As` at
+  call sites, never string matching (root CLAUDE.md).
+- The device's own answer is the truth: report what the peer said
+  (status code, body words), not what we hoped.
+
+## The honesty doctrine
+
+- **No silent fallbacks.** A skipped feature, an unresolvable value,
+  an absorbed deviation — each is logged, counted, or fired as a
+  compliance event. "It happens to work" is not a state this codebase
+  recognises.
+- **Warnings name consequences.** Not "leg 0 unset" but "this leg
+  emits nothing".
+- **Tests assert from the authority**, never from the code under
+  test: wire bytes from the spec document, scores from the AMWA tool,
+  behaviour from the real device. A test that would still pass after
+  the bug is reintroduced is not a test.
+
+## Shape
+
+- One primary type per file; the file name says which (root CLAUDE.md
+  naming).
+- Constructors validate and return `(*T, error)`; half-built values
+  do not escape.
+- Hooks and cross-layer callbacks are explicit struct fields with a
+  comment stating WHO wires them and what must not happen inside
+  (blocking under a lock is the classic).
+- Goroutines started by a type are owned by it: a `Close`/`Stop` that
+  provably ends them (`done` channels, contexts), never "it will exit
+  eventually".
+- Table-driven tests name every case; the name states the behaviour,
+  not the input (`"both refuses one destination"`, not `"case 4"`).
+
+## Linting
+
+`.golangci.yml` enforces the machine-checkable half: the standard
+linter set plus `depguard` (layering) — and the pre-commit hook runs
+`staticcheck`, so style debates end at the hook, not in review.
+A linter is only enabled when the whole tree already passes it:
+the config describes the code, not an aspiration.

--- a/internal/acp2/codec/codec_error_test.go
+++ b/internal/acp2/codec/codec_error_test.go
@@ -150,7 +150,7 @@ func TestDecodeACP2Message_GetVersionReply(t *testing.T) {
 // embedded property headers.
 func TestDecodeACP2Message_AnnounceWithProperties(t *testing.T) {
 	// header
-	data := []byte{byte(ACP2TypeAnnounce), 0, byte(PIDValue), PIDValue}
+	data := []byte{byte(ACP2TypeAnnounce), 0, PIDValue, PIDValue}
 	// obj-id + idx
 	objIdx := make([]byte, 8)
 	binary.BigEndian.PutUint32(objIdx[0:4], 0x01020304)

--- a/internal/acp2/consumer/plugin.go
+++ b/internal/acp2/consumer/plugin.go
@@ -471,7 +471,7 @@ func (p *Plugin) GetValue(ctx context.Context, req consumer.ValueRequest) (consu
 
 	// req.PID overrides pid=8 (value); req.Idx overrides idx=0 (active).
 	// Zero defaults preserve historical behaviour.
-	targetPID := uint8(codec.PIDValue)
+	targetPID := codec.PIDValue
 	if req.PID > 0 {
 		targetPID = uint8(req.PID)
 	}

--- a/internal/acp2/consumer/walker.go
+++ b/internal/acp2/consumer/walker.go
@@ -264,7 +264,7 @@ func (w *Walker) parseObjectProperties(props []codec.Property, slot int, objID u
 
 		case codec.PIDAccess:
 			if len(p.Data) >= 4 {
-				obj.Access = uint8(p.Data[3])
+				obj.Access = p.Data[3]
 			} else {
 				obj.Access = p.VType
 			}
@@ -318,7 +318,7 @@ func (w *Walker) parseObjectProperties(props []codec.Property, slot int, objID u
 
 		case codec.PIDEventPrio:
 			if len(p.Data) >= 4 {
-				obj.AlarmPriority = uint8(p.Data[3])
+				obj.AlarmPriority = p.Data[3]
 			}
 
 		case codec.PIDEventMessages:

--- a/internal/acp2/provider/encoder.go
+++ b/internal/acp2/provider/encoder.go
@@ -444,7 +444,7 @@ func stringMaxLen(p *canonical.Parameter) uint16 {
 		return 256
 	}
 	if ml := maxLenHint(p); ml > 0 {
-		return uint16(ml)
+		return ml
 	}
 	if p.Maximum != nil {
 		if u, err := asUint32(p.Maximum, "max"); err == nil && u > 0 && u <= 0xFFFF {

--- a/internal/amwa/codec/jsonschema/jsonschema.go
+++ b/internal/amwa/codec/jsonschema/jsonschema.go
@@ -241,7 +241,7 @@ func (v *validator) applyObject(s map[string]any, inst any, path string) {
 func (v *validator) applyRef(ref string, inst any, path string) {
 	file, frag, _ := strings.Cut(ref, "#")
 	base := v.base
-	root := any(nil)
+	var root any
 
 	if file == "" {
 		var err error

--- a/internal/amwa/provider/channelmapping.go
+++ b/internal/amwa/provider/channelmapping.go
@@ -135,7 +135,7 @@ func NewIS08ChannelMappingServer(logger *slog.Logger, bundle *NodeConfig, cfg IS
 	// event, not fabricated history. Already validated at config load;
 	// re-checked here because tests build bundles in code.
 	if bundle != nil && bundle.ChannelMapping != nil && len(bundle.ChannelMapping.BootMap) > 0 {
-		action := is08.MapEntries(bundle.ChannelMapping.BootMap)
+		action := bundle.ChannelMapping.BootMap
 		if err := validateAction(s.io, action); err != nil {
 			log := logger
 			if log == nil {

--- a/internal/amwa/provider/configuration.go
+++ b/internal/amwa/provider/configuration.go
@@ -107,7 +107,7 @@ func (s *IS14ConfigurationServer) objectByOid(oid int) *configObject {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	for _, o := range s.objects {
-		if o.oid == ms05.NcOid(uint32(oid)) {
+		if o.oid == ms05.NcOid(oid) {
 			return o
 		}
 	}

--- a/internal/amwa/provider/ncp.go
+++ b/internal/amwa/provider/ncp.go
@@ -246,7 +246,7 @@ func (s *IS12NCPServer) runCommand(cmd is12.Command) is12.MethodResult {
 
 // classKey renders an NcClassId ([]int32 alias — not comparable) as a
 // stable map/compare key.
-func classKey(id ms05.NcClassId) string { return fmt.Sprint([]int32(id)) }
+func classKey(id ms05.NcClassId) string { return fmt.Sprint(id) }
 
 // classDerivedFrom reports whether id equals or descends from base —
 // MS-05 class ids inherit by prefix ([1,3,1] derives from [1] and

--- a/internal/amwa/provider/node_config.go
+++ b/internal/amwa/provider/node_config.go
@@ -145,7 +145,7 @@ func validateChannelMappingSeed(cfg *NodeConfig) error {
 		}
 	}
 	if len(cfg.ChannelMapping.BootMap) > 0 {
-		if err := validateAction(io, is08.MapEntries(cfg.ChannelMapping.BootMap)); err != nil {
+		if err := validateAction(io, cfg.ChannelMapping.BootMap); err != nil {
 			return fmt.Errorf("channel_mapping.boot_map: %w", err)
 		}
 	}

--- a/internal/amwa/registry/mirror.go
+++ b/internal/amwa/registry/mirror.go
@@ -275,7 +275,7 @@ func (m *Mirror) forwardRow(ctx context.Context, topic string, row is04.GrainDat
 func (m *Mirror) postResource(ctx context.Context, topic string, doc json.RawMessage, allowResync bool) {
 	body, err := json.Marshal(map[string]any{
 		"type": mirrorSingular[topic],
-		"data": json.RawMessage(doc),
+		"data": doc,
 	})
 	if err != nil {
 		m.fail("encode", topic, err)

--- a/internal/cerebrum-nb/codec/ws/client.go
+++ b/internal/cerebrum-nb/codec/ws/client.go
@@ -61,7 +61,7 @@ func Dial(ctx context.Context, urlStr string, opts *DialOptions) (*Conn, error) 
 		return nil, fmt.Errorf("ws: tcp dial: %w", err)
 	}
 
-	nc := net.Conn(rawConn)
+	nc := rawConn
 	if u.Scheme == "wss" {
 		cfg := opts.TLSConfig
 		if cfg == nil {

--- a/internal/cerebrum-nb/consumer/session.go
+++ b/internal/cerebrum-nb/consumer/session.go
@@ -486,7 +486,7 @@ func splitURLHostPort(urlStr string) (string, int) {
 		return "", 0
 	}
 	host := u.Hostname()
-	port := 0
+	var port int
 	if p := u.Port(); p != "" {
 		port, _ = strconv.Atoi(p)
 	} else if u.Scheme == "wss" {

--- a/internal/emberplus/consumer/canonicalize.go
+++ b/internal/emberplus/consumer/canonicalize.go
@@ -232,7 +232,7 @@ func (p *Plugin) buildElement(e *treeEntry) (canonical.Element, error) {
 // threads them from the relevant Glow struct.
 func buildHeader(e *treeEntry, identifier, description string, isOnline bool, access int64) canonical.Header {
 	return canonical.Header{
-		Number:      int(e.obj.ID),
+		Number:      e.obj.ID,
 		Identifier:  identifier,
 		Path:        strings.Join(e.obj.Path, "."),
 		OID:         e.obj.OID,

--- a/internal/emberplus/consumer/resolver.go
+++ b/internal/emberplus/consumer/resolver.go
@@ -79,7 +79,7 @@ func (p *Plugin) resolveMatrixLabels(m *canonical.Matrix, elements map[string]ca
 	absorb := make([]string, 0, len(m.Labels))
 
 	for _, lbl := range m.Labels {
-		key := ""
+		var key string
 		if lbl.Description != nil && *lbl.Description != "" {
 			key = *lbl.Description
 		} else {

--- a/internal/export/read_yaml.go
+++ b/internal/export/read_yaml.go
@@ -171,7 +171,6 @@ func ReadYAML(r io.Reader) (*Snapshot, error) {
 			} else {
 				// New node or leaf name — flush previous object.
 				flushObj(&curSlot.Objects, curObj)
-				curObj = nil
 
 				// Trim path stack to current depth.
 				if depth <= len(pathStack) {

--- a/internal/osc/codec/per_tag_test.go
+++ b/internal/osc/codec/per_tag_test.go
@@ -88,10 +88,10 @@ func TestPerTag_Blob_VariousSizes(t *testing.T) {
 
 func TestPerTag_Char_RoundTrip(t *testing.T) {
 	for _, c := range []rune{'A', 'z', '0', ' ', '!', 0x7f} {
-		m := Message{Address: "/c", Args: []Arg{Char(int32(c))}}
+		m := Message{Address: "/c", Args: []Arg{Char(c)}}
 		got := encodeDecode(t, m)
-		if rune(got.Args[0].Int32) != c {
-			t.Errorf("char: got %q, want %q", rune(got.Args[0].Int32), c)
+		if got.Args[0].Int32 != c {
+			t.Errorf("char: got %q, want %q", got.Args[0].Int32, c)
 		}
 	}
 }

--- a/internal/probel-sw02p/codec/cmd_router_config_test.go
+++ b/internal/probel-sw02p/codec/cmd_router_config_test.go
@@ -185,7 +185,7 @@ func TestDecodeRouterConfigResponse2IgnoresReservedGarbage(t *testing.T) {
 	for _, b := range wire[1 : 1+1+payloadLen] {
 		sum += b
 	}
-	wire[1+1+payloadLen] = byte(-sum) & 0x7F
+	wire[1+1+payloadLen] = -sum & 0x7F
 	parsed, _, err := Unpack(wire)
 	if err != nil {
 		t.Fatalf("Unpack: %v", err)

--- a/internal/probel-sw02p/codec/framer.go
+++ b/internal/probel-sw02p/codec/framer.go
@@ -39,7 +39,7 @@ func checksum7(b []byte) byte {
 	for _, x := range b {
 		s += x
 	}
-	return byte(-s) & 0x7F
+	return -s & 0x7F
 }
 
 // EncodeFrame wraps command + payload into one SW-P-02 frame per §3.1:


### PR DESCRIPTION
Closes #927 (part 1 of 2 — part 2 is the amwa docs drift fix).

## What

- **docs/go-style.md** — the Go house style for this repo: rationale-only comments citing spec/tool/device, operator-sentence errors, honesty doctrine (no silent fallbacks; tests assert from the authority), shape rules, and the linting policy: a linter is only enabled when the whole tree already passes it.
- **.golangci.yml** — enables `misspell`, `unconvert`, `wastedassign` per that policy.
- **23 mechanical fixes** so the tree passes the new linters: 19 redundant type conversions removed, 4 wasted assignments dropped. No behavior change; full test sweep green (79 packages, 0 FAIL).

## Verification

- `go vet ./...` clean
- `go test ./...` — 79 package results, zero FAIL
- pre-commit golangci-lint: 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)