### PR TITLE
docs(amwa): fix 44 doc-drift findings against shipped code (#927)

### DIFF
--- a/internal/amwa/CLAUDE.md
+++ b/internal/amwa/CLAUDE.md
@@ -42,19 +42,26 @@ implementing all three roles correctly; it is not a separate feature.
 > NMOS and another dhs protocol. Cross-protocol architecture lives
 > elsewhere; the NMOS plugin only ever speaks NMOS.
 
-CLI surface mapping (planned):
+CLI surface mapping (shipped — dispatch in `cmd/dhs/cmd_nmos.go`):
 
 ```
 dhs producer nmos serve                       # Node side (the device — default)
+dhs producer nmos events                      # Node side — IS-07 event emitter
 dhs registry nmos serve                       # Registry side (dual-face middleware)
                                               #   - serves Registration API (consumes from Nodes)
                                               #   - serves Query API + WS subs (provides to Controllers)
-dhs consumer nmos walk     <reg-host>         # Controller — walk a Registry
-dhs consumer nmos watch    <reg-host>         # Controller — subscribe via Query WS
-dhs consumer nmos connect  <node-host> ...    # Controller — drive IS-05 on a Node
+dhs registry nmos mirror                      # Registry side — bridge one Registry into another
+dhs consumer nmos discover                    # Controller — DNS-SD discovery
+dhs consumer nmos system                      # Controller — read an IS-09 System API
+dhs consumer nmos walk                        # Controller — walk a Registry (or --node direct)
+dhs consumer nmos watch                       # Controller — subscribe via Query WS
+dhs consumer nmos connect                     # Controller — drive IS-05 on a Node
+dhs consumer nmos set                         # Controller — stage a Sender's IS-05 transport
+dhs consumer nmos facade                      # Controller — AMWA-tool facade (drives the Controller)
+dhs consumer nmos events                      # Controller — IS-07 WS/MQTT subscriber
 ```
 
-The new `dhs registry` top-level verb is needed because the Registry's
+The `dhs registry` top-level verb exists because the Registry's
 dual-face nature does not fit `producer` (which historically means
 "serves a canonical tree of my own state") nor `consumer` (which
 historically means "talks outbound to a remote device").
@@ -69,7 +76,7 @@ historically means "talks outbound to a remote device").
 | **Bootstrap config** | HTTP/JSON, single `/global` resource | IS-09 |
 | **Resource graph** | HTTP/JSON REST (`/x-nmos/<api>/<ver>/...`) + WebSocket subscription on Query API | IS-04 |
 | **Connection control** | HTTP/JSON REST, stage-then-activate pattern, SDP payload for RTP | IS-05, IS-08 |
-| **Event & tally** | WebSocket OR MQTT, JSON envelope (`message_type` ∈ {state, health, reboot, shutdown}) | IS-07 |
+| **Event & tally** | WebSocket OR MQTT, JSON envelope (`message_type` ∈ {state, health, reboot, shutdown, connection_status (MQTT-only)}) | IS-07 |
 | **Device model + control** | WebSocket, JSON envelope (`messageType` ∈ {Command, CommandResponse, Subscription, SubscriptionResponse, Notification, Error}) | IS-12 (wire), MS-05-01 (architecture), MS-05-02 (class library) |
 | **Annotation** | HTTP/JSON PATCH (sibling of Node API) | IS-13 (WIP) |
 | **Profiles** | JSON-Schema rules layered onto IS-04 / IS-05 | BCP-002, BCP-004, BCP-006, BCP-007 |
@@ -224,6 +231,9 @@ provider (`internal/amwa/provider/`), which is a different question.
 | IS-05 Connection | `/x-nmos/connection/{ver}/` + SDP + activation scheduler | `connection*.go` |
 | IS-07 Event & Tally | `/x-nmos/events/{ver}/` REST + the WebSocket at `…/ws` | `events.go` |
 | IS-08 Channel Mapping | `/x-nmos/channelmapping/{ver}/` incl. `inputs`/`outputs` | `channelmapping.go` |
+| IS-11 Stream Compatibility | `/x-nmos/streamcompatibility/{ver}/` incl. `inputs`/`outputs` + EDID | `streamcompat.go` |
+| IS-12 / MS-05 Control | the WebSocket at `/x-nmos/ncp/v1.0` | `ncp.go` |
+| IS-14 Device Configuration | `/x-nmos/configuration/{ver}/` (rolePaths view of the MS-05 model) | `configuration.go` + `configuration_mount.go` |
 | IS-09 System | **client**, not server — the Node reads a System API | `system_client.go` |
 
 IS-09 is the odd one and worth stating: every other row is something
@@ -272,7 +282,9 @@ These layer into the IS-04 / IS-05 encoders — no separate plugin slots.
    combinations:
    - **Mode A — Full mDNS + Registry** (greenfield / spec-compliant peers).
    - **Mode B — Unicast Registry** (`--no-mdns --registry <ip>:<port>`).
-   - **Mode C — Direct-Node** (`--no-mdns --no-registry --peer-list peers.csv`).
+   - **Mode C — Direct-Node** (producer: `--no-mdns --no-registry`;
+     consumer: `--peer-list peers.csv` on `discover`/`system`,
+     `--node <url>` on `walk`).
    - **Mode D — mDNS direct-Node** (`--mdns --no-registry`) — Cerebrum P2P.
    Default to mDNS but never assume it works. See
    [`docs/matrix-compliance.md`](docs/matrix-compliance.md) and
@@ -322,9 +334,10 @@ These layer into the IS-04 / IS-05 encoders — no separate plugin slots.
     v1.3.3 mandates single-target selection: *"The Node selects a
     Registration API to use based on the priority"*. HA is
     client-driven failover via `pri` ranking + 5xx fallback, NOT
-    multi-Registry replication. dhs supports active/passive priority
-    pair + ST 2022-7 dual-network out of the box; active/active
-    shared-store is out of scope for v1. See
+    multi-Registry replication. dhs supports the active/passive
+    priority pair out of the box (`--bind` is a single address; an
+    ST 2022-7 dual-network plant runs one process per network);
+    active/active shared-store is out of scope for v1. See
     [`docs/ha.md`](docs/ha.md). Heartbeat 5 s, GC 12 s — failover
     must complete inside GC window.
 14. **`pri` 0–99 are production; 100+ are dev.** Spec carves the
@@ -361,7 +374,7 @@ flow**:
 
 ```
 LAYER 4  cmd/dhs/cmd_nmos.go                    (CLI)
-LAYER 3  internal/amwa/{consumer,provider,registry}  (PLUGIN)
+LAYER 3  internal/amwa/{consumer,provider,registry,facade}  (PLUGIN)
 LAYER 2  internal/amwa/session/*                (SESSION)
 LAYER 1  internal/amwa/codec/*                  (CODEC — stdlib only)
 ```
@@ -398,7 +411,8 @@ internal/amwa/codec/
   spec/                          # NMOS-wide base (Versioned interface, generic Registry[T],
                                  # SelectHighestMutual, ComplianceEvent + Reporter)
   is04/  is05/  is07/  is08/     # one folder per spec — canonical structs + Codec interface
-  is09/  is12/  ms0501/  ms0502/
+  is09/  is10/  is11/  is12/
+  is14/  ms05/                   # (ms05 = MS-05-02 control framework, single package)
     codec.go                     # extends spec.Versioned with the spec's resource methods
     {node,device,...}.go         # canonical union structs (every minor's fields, omitempty)
     patterns.go enums.go         # shared regex / URN tables
@@ -408,9 +422,12 @@ internal/amwa/codec/
     v10/  v11/  v12/  v13/       # per-minor Strategy impls — SELF-CONTAINED
       codec.go                   # this minor's identity + its own drop table + its strip
 
+  edid/                          # BCP-005-01 EDID parsing (base block + CTA-861)
+  est/                           # BCP-003-03 EST client bytes (enrollment + PKCS#7)
+
   bcp/                           # JSON-shape validators (no own wire — layer onto host spec)
     bcp00201/  bcp00202/         # BCP-002-01 / 002-02
-    bcp00401/  bcp00402/         # BCP-004-01 / 002-02
+    bcp00401/  bcp00402/         # BCP-004-01 / 004-02
     bcp00601/  bcp00604/         # BCP-006-01 / 006-04
     bcp00801/  bcp00802/         # BCP-008-01 / 008-02
 ```
@@ -443,7 +460,9 @@ validates against them.
 (ADR-0006) covering exactly the keywords a scan of the four schema sets
 reports. **An unimplemented keyword is REPORTED, never skipped** — a
 silent skip means a document went unchecked and nobody notices;
-`TestNoUnimplementedKeyword` fails the build if AMWA ships one.
+`TestNoUnimplementedKeyword` (in
+`codec/is04/schemas/schemas_test.go`) fails the build if AMWA ships
+one.
 
 ### Each minor is self-contained
 

--- a/internal/amwa/docs/amwa-reality-check-2026-08-23.md
+++ b/internal/amwa/docs/amwa-reality-check-2026-08-23.md
@@ -65,3 +65,21 @@ spec repo when epic #146 planning resumes).
    certification target set — "full certified" per the owner's
    2026-08-23 statement implies yes for anything with a published
    suite.
+
+## Addendum 2026-09-01
+
+The historical findings above are kept as written; the deltas have
+since been closed in code:
+
+- **IS-10 / BCP-003-02** authorization: implemented (`codec/is10`,
+  `session/auth`; `--auth-url` on node + registry). CLAUDE.md's
+  "out of scope for v1" wording is gone — its version table now
+  tracks it as shipped.
+- **IS-11, IS-14, BCP-003-01, BCP-003-03, BCP-005-01, BCP-007-03
+  MXL**: implemented (`codec/is11` + `provider/streamcompat.go`,
+  `codec/is14` + `provider/configuration.go`, TLS serving,
+  `codec/est` + `session/certmgr`, `codec/edid`,
+  `urn:x-nmos:transport:mxl` in the IS-04 + IS-05 codecs).
+- **BCP-008-01 / BCP-008-02**: ship (ms05 monitor classes over
+  IS-12).
+- **IS-06** remains the only genuinely absent spec.

--- a/internal/amwa/docs/architecture.md
+++ b/internal/amwa/docs/architecture.md
@@ -183,12 +183,14 @@ attaches to in-process state; Consumer is pure subscriber.
                                                    └────────────────────┘
 ```
 
-Event types (data formats): `boolean`, `number`, `string`, `enum`.
+Event types (data formats): `boolean`, `number`, `string`, `enum`, `object`.
 Source `format = urn:x-nmos:format:data`.
 Sender `transport ∈ urn:x-nmos:transport:websocket | urn:x-nmos:transport:mqtt`.
 
-The dhs slice ships **WebSocket only first**; MQTT layered on top once
-WS is wire-validated.
+dhs ships **both transports** — WebSocket (`session/events`) and MQTT
+(`session/mqtt` + `provider/events_mqtt.go`) — with per-sender
+transport selection; the broker is configured via the bundle's
+`events.mqtt_broker` key.
 
 ---
 
@@ -251,6 +253,72 @@ NcManager family (DeviceManager, ClassManager, SubscriptionManager),
 NcTouchpoint linking model OIDs back to IS-04 UUIDs.
 
 Surfaced via IS-04 Device `controls` URN `urn:x-nmos:control:ncp/v1.0`.
+
+---
+
+## IS-14 — Device Configuration
+
+REST view of the same MS-05-02 device model IS-12 serves over WS —
+rolePaths addressing instead of OIDs.
+
+```
+   ┌─────────────────────┐                     ┌─────────────────────────┐
+   │   [C] Controller    │  GET /rolePaths/    │   [N] Device            │
+   │                     │ ──────────────────> │  /x-nmos/configuration/ │
+   │                     │  GET .../root/...   │   {ver}/                │
+   │                     │      properties     │                         │
+   │                     │ <────────────────── │  same MS-05-02 model as │
+   │                     │                     │  the IS-12 WS (ncp)     │
+   └─────────────────────┘                     └─────────────────────────┘
+```
+
+Served by `provider/configuration.go` + `configuration_mount.go`.
+
+---
+
+## IS-11 — Stream Compatibility Management
+
+REST sibling of IS-05: active constraints on Senders, media-profile
+status on Senders/Receivers, Inputs/Outputs with EDID properties
+(BCP-005-01 via `codec/edid`).
+
+```
+   ┌─────────────────────┐                     ┌──────────────────────────┐
+   │   [C] Controller    │  GET /senders/{id}/ │   [N] Node               │
+   │                     │      status         │  /x-nmos/                │
+   │                     │ ──────────────────> │   streamcompatibility/   │
+   │  PUT /senders/{id}/ │                     │   {ver}/                 │
+   │   constraints/active│ ──────────────────> │  senders / receivers /   │
+   │                     │ <────────────────── │  inputs / outputs        │
+   └─────────────────────┘                     └──────────────────────────┘
+```
+
+Served by `provider/streamcompat.go`.
+
+---
+
+## IS-10 / BCP-003-02 — Authorization
+
+OAuth 2.0 client_credentials + JWT Bearer validation layered onto
+every served API (WS included). Armed by `--auth-url` on node and
+registry; flips `api_auth=true` in DNS-SD TXT.
+
+```
+   ┌──────────────────┐  POST /token          ┌───────────────────────┐
+   │  dhs client      │ ────────────────────> │  Authorization Server  │
+   │  ([N] reg client │ <──────────────────── │  (external, IS-10)     │
+   │   or [C])        │  access_token (JWT)   └───────────────────────┘
+   │                  │
+   │                  │  Authorization: Bearer <JWT>
+   │                  │ ────────────────────> ┌───────────────────────┐
+   │                  │ <──────────────────── │  [N]/[R] dhs resource  │
+   │                  │  200 / 401            │  server — validates    │
+   └──────────────────┘                       │  token per IS-10       │
+                                              └───────────────────────┘
+```
+
+Client + resource-server codec in `codec/is10`; session glue in
+`session/auth` + the auth gate in `session/http`.
 
 ---
 
@@ -372,7 +440,7 @@ Hardened deployments. mDNS firewalled but a Registry still exists.
                 └─────────────────────┘
 ```
 
-### Mode C — direct-Node, no Registry  (`--no-mdns --no-registry --peer-list FILE`)
+### Mode C — direct-Node, no Registry  (producer: `--no-mdns --no-registry`; consumer: `--node URL` per Node)
 
 Lawo VSM use-case (no Registration API support — see
 [`matrix-compliance.md`](matrix-compliance.md)). End-user networks
@@ -382,15 +450,15 @@ where mDNS AND Registry are blocked.
    ┌────────┐                              ┌──────────────────────┐
    │ [N]    │                              │ [C]      Controller   │
    │ Node   │  ◄── direct REST per Node ── │                       │
-   │        │      (host list comes from   │  --peer-list peers.csv│
-   │        │       --peer-list FILE)      │                       │
-   └────────┘                              │  reads:                │
-   ┌────────┐                              │   nodeA.lan,2080      │
-   │ [N]    │  ◄────────────────────────── │   nodeB.lan,2080      │
-   │ Node   │                              │   192.0.2.5,8000      │
-   └────────┘                              └──────────────────────┘
-   ┌────────┐
-   │ [N]    │  ◄──────────────────────────
+   │        │      (each Node named via    │  walk --node          │
+   │        │       its own --node URL)    │    http://nodeA:2080  │
+   └────────┘                              │  walk --node          │
+   ┌────────┐                              │    http://nodeB:2080  │
+   │ [N]    │  ◄────────────────────────── │                       │
+   │ Node   │                              │  (discover / system   │
+   └────────┘                              │   also take a CSV via │
+   ┌────────┐                              │   --peer-list)        │
+   │ [N]    │  ◄────────────────────────── └──────────────────────┘
    │ Node   │
    └────────┘
 ```

--- a/internal/amwa/docs/cerebrum-interop.md
+++ b/internal/amwa/docs/cerebrum-interop.md
@@ -68,15 +68,16 @@ Mode 3 — Cerebrum hosts the Registry
 ## 3. Mapping to dhs deployment modes
 
 [`matrix-compliance.md`](matrix-compliance.md) "Deployment modes"
-defines three today: **A** (full mDNS + Registry), **B** (unicast
-Registry), **C** (direct-Node, no mDNS, no Registry). Cerebrum's mode 2
-("peer-to-peer with mDNS but no Registry") doesn't fit any of them —
-mDNS is mandatory but Registry is absent. We need a new **Mode D**.
+defines five rows: **A** (full mDNS + Registry), **B** (unicast
+Registry), **C** (direct-Node, no mDNS, no Registry), **D** (mDNS
+direct-Node, no Registry) and CSV bootstrap. Cerebrum's mode 2
+("peer-to-peer with mDNS but no Registry") is exactly **Mode D**,
+which was added for it.
 
 | Cerebrum mode | dhs equivalent | Notes |
 |---|---|---|
 | 1. External Registry | **A** (`--mdns`) or **B** (`--no-mdns --registry`) — we're a Node and/or Controller; Cerebrum is too | Both peers register against a third-party Registry |
-| 2. Peer-to-peer | **D** (NEW) — `mDNS direct-Node`, no Registry | Required for Cerebrum P2P; not yet wired in CLI |
+| 2. Peer-to-peer | **D** — `mDNS direct-Node`, no Registry | Required for Cerebrum P2P; wired: `producer nmos serve --mdns --no-registry`, consumer discovers `_nmos-node._tcp` + walks `--node` |
 | 3. Hosted Registry | **A** or **B** — we're a Node and/or Controller; Cerebrum is the Registry | dhs `producer nmos serve` + `consumer nmos walk` against Cerebrum:8080 |
 
 **Mode D — new deployment mode:**
@@ -87,7 +88,7 @@ mDNS is mandatory but Registry is absent. We need a new **Mode D**.
 | Registry | none — direct-Node walking only |
 | Heartbeats | N/A (no Registry to heartbeat against) |
 | Producer flags | `dhs producer nmos serve --mdns --no-registry` |
-| Consumer flags | `dhs consumer nmos walk-nodes --mdns --no-registry` |
+| Consumer flags | `dhs consumer nmos discover --mdns --service _nmos-node._tcp`, then `dhs consumer nmos walk --node http://<host>:<port>` per Node |
 | Fallback | once mDNS resolves a peer set, the rest of the flow degrades into direct-Node walking |
 
 **Principle:** dhs supports **every** deployment topology a peer might
@@ -136,16 +137,18 @@ Each of these matches the "absorb-and-fire" pattern from
 
 | Deviation | Cerebrum behaviour | dhs response | Compliance event |
 |---|---|---|---|
-| Query API absent | Vendor PDF: *"external third party control systems cannot interrogate the registry directly"*. Only Registration API endpoints served. | If we're the Controller, fall back to direct-Node walking against Cerebrum's known Nodes. | `nmos_query_api_missing` (existing) |
-| IS-05 activation always-immediate | Single PATCH; activation always coerced to `now`. | Detect rejection of `activate_scheduled_*`; retry as `activate_immediate`. | `nmos_scheduled_activation_unsupported` (existing — applies to Cerebrum too) |
-| IS-05 single-PATCH expectation | Cerebrum waits for HTTP 200 OK before next PATCH on same device. | Don't pipeline IS-05 PATCHes when peer is Cerebrum; serialise per-device. | `nmos_is05_serial_patch_required` (NEW) |
-| SDP legs truncated | Cerebrum reads only the first 2 leg/stream definitions in `m=` blocks (vendor PDF: *"Cerebrum currently only use the first two definitions of legs/streams"*). | dhs encoder/decoder supports unlimited legs. When our Sender has >2 legs and peer is Cerebrum, fire event so operator knows extra legs were silently dropped peer-side. | `nmos_sdp_legs_truncated_peer` (NEW) |
-| Sender identity tuple uniqueness | Cerebrum requires (m/c addr, origin addr, port) globally unique across senders; duplicates are highlighted red in their UI but not rejected. | Detect duplicates ourselves before announcing — Cerebrum will mis-route otherwise. | `nmos_sender_identity_collision` (NEW) |
+| Query API absent | Vendor PDF: *"external third party control systems cannot interrogate the registry directly"*. Only Registration API endpoints served. | If we're the Controller, fall back to direct-Node walking against Cerebrum's known Nodes. | none today — the fallback is behavioural (per-collection walk failures fire `nmos_query_collection_failed`) |
+| IS-05 activation always-immediate | Single PATCH; activation always coerced to `now`. | Detect rejection of `activate_scheduled_*`; retry as `activate_immediate`. | none today — detection code not yet landed |
+| IS-05 single-PATCH expectation | Cerebrum waits for HTTP 200 OK before next PATCH on same device. | Don't pipeline IS-05 PATCHes when peer is Cerebrum; serialise per-device. | none today — handled operationally (serialise per-device) |
+| SDP legs truncated | Cerebrum reads only the first 2 leg/stream definitions in `m=` blocks (vendor PDF: *"Cerebrum currently only use the first two definitions of legs/streams"*). | dhs encoder/decoder supports unlimited legs. When our Sender has >2 legs and peer is Cerebrum, extra legs are silently dropped peer-side — operator guidance only. | none today — detection code not yet landed |
+| Sender identity tuple uniqueness | Cerebrum requires (m/c addr, origin addr, port) globally unique across senders; duplicates are highlighted red in their UI but not rejected. | Detect duplicates ourselves before announcing — Cerebrum will mis-route otherwise. | none today — check during integration testing |
 | `a=group:DUP primary secondary` expected for redundant flows | Cerebrum expects this exact spelling; if absent, the second leg is treated as a separate flow. | dhs encoder emits the canonical form already; integration tests must verify the line is preserved end-to-end. | n/a (we already comply — no event) |
 
-Naming convention: `nmos_` prefix; new events land in the NMOS
-compliance catalogue when the codec-side compliance package is wired
-(see `internal/amwa/CLAUDE.md` "Strict-dependency architecture").
+Naming convention: `nmos_` prefix. The codec-side compliance package
+is wired (`codec/spec/compliance.go`, reported via `spec.Reporter` /
+`spec.SliceReporter`); each event above lands in the catalogue in
+[`matrix-compliance.md`](matrix-compliance.md) when its detection
+code lands.
 
 ---
 
@@ -514,9 +517,10 @@ Their registration face also validates parent references (sender
 without known device → 400), so fill order is mandatory, and a full
 node re-fill is required after any eviction.
 
-Productization of this bridge (the `dhs registry nmos mirror` verb:
-Query-WS-driven forwarding, deletion propagation, per-node heartbeat
-proxying) is designed and awaits approval post-merge.
+The bridge is productized as `dhs registry nmos mirror --source URL
+--target URL [--api-ver v1.3] [--audit-log FILE] [--status-addr :PORT]`
+(Query-WS-driven forwarding, deletion propagation, per-node heartbeat
+proxying) — see [`use-cases.md`](use-cases.md).
 
 ### Cerebrum device-panel knobs that affect interop (per
 "Modify Device" UI screenshot 2026-05-01)

--- a/internal/amwa/docs/dependencies.md
+++ b/internal/amwa/docs/dependencies.md
@@ -36,15 +36,15 @@ introduces a back-arrow.
 │  internal/amwa/consumer/  (Controller)                                     │
 │  internal/amwa/provider/  (Node)                                           │
 │  internal/amwa/registry/  (Registry — dual-face middleware)                │
+│  internal/amwa/facade/    (AMWA-tool facade — drives the consumer)         │
 │                                                                            │
 │  Allowed:  dhs/internal/amwa/session/*                                      │
 │            dhs/internal/amwa/codec/*                                        │
 │            dhs/internal/consumer           (interface only)                 │
 │            dhs/internal/provider           (interface only)                 │
-│            dhs/internal/registry           (interface only — NEW slot)      │
+│            dhs/internal/registry           (interface only)                 │
 │            dhs/internal/consumer/compliance                                │
 │            dhs/internal/datastore            (portable data dir)              │
-│            dhs/internal/metrics            (connector + Prom)               │
 │  Forbidden: any other internal/<proto>/*                                    │
 │             cmd/*                                                          │
 │             cross-imports between consumer / provider / registry            │
@@ -52,20 +52,19 @@ introduces a back-arrow.
                                    │
 ┌──────────────────────────────────▼─────────────────────────────────────────┐
 │  LAYER 2 — SESSION                                                         │
-│  internal/amwa/session/dnssd/                                              │
-│  internal/amwa/session/registration/   (Node-side registration client)     │
-│  internal/amwa/session/registry_core/  (Registry catalogue + GC + WS subs) │
-│  internal/amwa/session/query/          (Controller-side Query API client)  │
-│  internal/amwa/session/connection/     (IS-05 stage/activate orchestration)│
-│  internal/amwa/session/events/         (IS-07 WS publisher + subscriber)   │
-│  internal/amwa/session/control/        (IS-12 + MS-05-02 model server +    │
-│                                          client)                           │
-│  internal/amwa/session/bootstrap/      (IS-09 fetch on Node boot)          │
+│  internal/amwa/session/dnssd/       (mDNS + unicast browse + peer list)    │
+│  internal/amwa/session/auth/        (IS-10 token client + validation)      │
+│  internal/amwa/session/certmgr/     (BCP-003-03 EST certificate manager)   │
+│  internal/amwa/session/connection/  (IS-05 stage/activate orchestration)   │
+│  internal/amwa/session/events/      (IS-07 WS publisher + subscriber)      │
+│  internal/amwa/session/http/        (shared HTTP server + auth gate)       │
+│  internal/amwa/session/mqtt/        (IS-07 MQTT client)                    │
+│  internal/amwa/session/query/       (Controller-side Query API client)     │
+│  internal/amwa/session/system/      (IS-09 fetch on Node boot)             │
 │                                                                            │
 │  Allowed:  dhs/internal/amwa/codec/*                                        │
 │            dhs/internal/transport       (HTTP/WS capture)                   │
 │            dhs/internal/consumer/compliance                                │
-│            dhs/internal/metrics                                            │
 │  Forbidden: dhs/internal/amwa/{consumer,provider,registry}                  │
 │             cmd/*                                                          │
 │             any other internal/<proto>/*                                    │
@@ -73,17 +72,22 @@ introduces a back-arrow.
                                    │
 ┌──────────────────────────────────▼─────────────────────────────────────────┐
 │  LAYER 1 — CODEC                                                            │
+│  internal/amwa/codec/spec/         (NMOS-wide base: Versioned, Registry[T]) │
 │  internal/amwa/codec/dnssd/        (mDNS + unicast SRV/TXT)                 │
-│  internal/amwa/codec/jsonschema/   (Schema compiler — BCP-002/004/006/007)  │
-│  internal/amwa/codec/rql/          (Query API filter syntax)                │
-│  internal/amwa/codec/sdp/          (RFC 4566 SDP encode + decode)           │
+│  internal/amwa/codec/jsonschema/   (draft-04 schema compiler)               │
 │  internal/amwa/codec/is04/         (Node/Device/Source/Flow/Sender/Receiver)│
 │  internal/amwa/codec/is05/         (staged/active/transportfile envelopes)  │
 │  internal/amwa/codec/is07/         (state/health/reboot/shutdown envelopes) │
 │  internal/amwa/codec/is08/         (channel mapping schemas)                │
 │  internal/amwa/codec/is09/         (Global config schema)                   │
-│  internal/amwa/codec/ms05/         (NcObject root + class + datatype reg)   │
+│  internal/amwa/codec/is10/         (authorization: JWT + access rules)      │
+│  internal/amwa/codec/is11/         (stream compatibility types)             │
 │  internal/amwa/codec/is12/         (JSON envelope: messageType + handle)    │
+│  internal/amwa/codec/is14/         (device configuration types)             │
+│  internal/amwa/codec/ms05/         (NcObject root + class + datatype reg)   │
+│  internal/amwa/codec/edid/         (BCP-005-01 EDID parsing)                │
+│  internal/amwa/codec/est/          (BCP-003-03 EST + PKCS#7 bytes)          │
+│  internal/amwa/codec/bcp/          (BCP JSON-shape validator packages)      │
 │                                                                            │
 │  Allowed:  Go stdlib                                                       │
 │            sibling internal/amwa/codec/* (per the inter-codec graph below) │
@@ -148,13 +152,7 @@ The graph has THREE tiers within Layer 1:
           ▼                 ▼                ▼
    ┌──────────┐       ┌──────────┐     ┌──────────┐
    │   is05   │       │   is07   │     │   is08   │
-   └─────┬────┘       └──────────┘     └──────────┘
-         │
-         │ (transportfile body)
-         ▼
-   ┌──────────┐
-   │   sdp    │
-   └──────────┘
+   └──────────┘       └──────────┘     └──────────┘
 
    ┌──────────────┐
    │     ms05     │  ◄── BCP-008-01 + BCP-008-02 register feature-set classes here
@@ -172,10 +170,15 @@ The graph has THREE tiers within Layer 1:
    │     is09     │  ◄── independent (only used at Node bootstrap)
    └──────────────┘
 
-   ┌──────────────┐
-   │     rql      │  ◄── used by is04 Query API only; no reverse import
-   └──────────────┘
+   ┌──────────────────────────────────┐
+   │  is10 · is11 · is14 · edid · est │  ◄── independent — import spec/ only
+   └──────────────────────────────────┘
 ```
+
+RQL filter parsing lives in `internal/amwa/registry/query.go`
+(Layer 3) and SDP encode/decode in
+`internal/amwa/provider/connection_sdp*.go` (Layer 3) — neither is a
+codec package.
 
 ### Forbidden edges
 
@@ -185,10 +188,7 @@ The graph has THREE tiers within Layer 1:
 - `ms05` MUST NOT import `is12` (wire is the marshaller; model is the
   domain).
 - `dnssd` and `jsonschema` MUST NOT import any sibling codec package.
-- `sdp` MUST NOT import `is04` / `is05` (it's pure RFC 4566).
 - `is09` MUST NOT import `is04` (System config is bootstrap-only).
-- `rql` MUST NOT import `is04` (it's pure filter-syntax; resource
-  type-checking happens in the IS-04 layer).
 - `spec/` (the NMOS-wide codec base) MUST NOT import any sibling
   codec package. It is the leaf — every spec depends on it; it
   depends on no spec.
@@ -214,14 +214,13 @@ NMOS Registry doesn't fit `internal/consumer/` (consumer plugins) nor
 left face consumes registrations, right face provides catalogue. Same
 process, two faces.
 
-A **new Tier-1 plugin slot** lands in this branch:
+The **Tier-1 plugin slot**:
 
 ```
 internal/registry/
 ├── registry.go           neutral interface every Registry plugin implements
-├── factory.go            Factory + Register() + Lookup() — same shape as
-│                         internal/consumer/ + internal/provider/
-└── compliance/           OPTIONAL — registry-side compliance events
+└── factory.go            Factory + Register() + Lookup() — same shape as
+                          internal/consumer/ + internal/provider/
 ```
 
 ```go
@@ -234,12 +233,18 @@ type Registry interface {
     Stats() Stats
 }
 
-type Factory interface {
-    Name() string
-    DefaultPort() int
-    NewRegistry() Registry
+type Meta struct {
+    Name        string // e.g. "nmos"
+    Description string
+    DefaultPort int
 }
 
+type Factory interface {
+    Meta() Meta
+    New(logger *slog.Logger) Registry
+}
+
+// internal/registry/factory.go — keyed on f.Meta().Name
 func Register(f Factory) { ... }
 func Lookup(name string) (Factory, bool) { ... }
 ```
@@ -251,11 +256,11 @@ blank-imports it just like consumer + provider plugins today.
 CLI dispatch (Layer 4):
 
 ```go
-// cmd/dhs/cmd_registry.go
-case "registry":
-    f, ok := registry.Lookup(args[1])  // "nmos"
-    if !ok { ... }
-    f.NewRegistry().Serve(ctx, opts)
+// cmd/dhs/cmd_nmos.go — runNMOSRegistry / runNMOSRegistryServe
+f, ok := registryslot.Lookup("nmos")
+if !ok { ... }
+r := f.New(logger)
+r.Serve(ctx, opts)
 ```
 
 The slot is introduced for NMOS. Whether other protocols will use it
@@ -265,52 +270,60 @@ is undecided and out of scope for this PR.
 
 ## Enforcement
 
-Three independent gates land in the Phase 1 PR (step #1) — all CI-fail
-on violation:
+Three independent gates — all CI-fail on violation:
 
 ### 1. `depguard` golangci-lint rule
 
-`.golangci.yml` adds:
+`.golangci.yml` (version `"2"` layout — rules live under
+`linters.settings.depguard.rules`) carries three rules:
 
 ```yaml
 linters:
   enable:
     - depguard
+  settings:
+    depguard:
+      rules:
+        # Layer 1 — codec stays stdlib-only.
+        nmos-codec-stdlib-only:
+          list-mode: lax
+          files:
+            - "**/internal/amwa/codec/**"
+          deny:
+            - pkg: github.com          # third-party
+            - pkg: dhs/cmd
+            - pkg: dhs/internal/amwa/session
+            - pkg: dhs/internal/amwa/consumer
+            - pkg: dhs/internal/amwa/provider
+            - pkg: dhs/internal/amwa/registry
 
-linters-settings:
-  depguard:
-    rules:
-      nmos-codec-stdlib-only:
-        list-mode: lax
-        files:
-          - "**/internal/amwa/codec/**"
-        deny:
-          - pkg: "dhs/"
-            desc: "codec layer must be stdlib-only (lift-to-own-repo ready)"
-          - pkg: "github.com/"
-            desc: "codec layer must be stdlib-only"
+        # Layer 2 — session never reaches back into plugins or cmd/.
+        nmos-session-no-plugin-imports:
+          list-mode: lax
+          files:
+            - "**/internal/amwa/session/**"
+          deny:
+            - pkg: dhs/internal/amwa/consumer
+            - pkg: dhs/internal/amwa/provider
+            - pkg: dhs/internal/amwa/registry
+            - pkg: dhs/cmd
 
-      nmos-session-no-plugin-imports:
-        list-mode: lax
-        files:
-          - "**/internal/amwa/session/**"
-        deny:
-          - pkg: "dhs/internal/amwa/consumer"
-            desc: "session must not import plugin layer (back-arrow)"
-          - pkg: "dhs/internal/amwa/provider"
-          - pkg: "dhs/internal/amwa/registry"
-          - pkg: "dhs/cmd/"
-
-      nmos-plugin-no-cross-plugin:
-        list-mode: lax
-        files:
-          - "**/internal/amwa/consumer/**"
-        deny:
-          - pkg: "dhs/internal/amwa/provider"
-            desc: "consumer must not import provider (cross-plugin leak)"
-          - pkg: "dhs/internal/amwa/registry"
-      # ... mirror rules for provider/ and registry/
+        # Layer 3 — one files-glob covers all three plugins, so this
+        # rule can only deny cmd/ (denying a sibling plugin here would
+        # also deny the plugin's own package).
+        nmos-plugin-no-cross-plugin:
+          list-mode: lax
+          files:
+            - "**/internal/amwa/consumer/**"
+            - "**/internal/amwa/provider/**"
+            - "**/internal/amwa/registry/**"
+          deny:
+            - pkg: dhs/cmd
 ```
+
+Cross-plugin isolation (consumer ↛ provider ↛ registry) is therefore
+enforced by the Go test (`TestNoCrossPluginImports` in
+`internal/amwa/dependencies_test.go`), not by depguard.
 
 ### 2. `go list -deps` import audit test
 
@@ -332,7 +345,7 @@ func TestCodecHasNoAcpImports(t *testing.T) {
     // (excluding sibling dhs/internal/amwa/codec/*)
 }
 
-func TestSessionHasNoPluginImports(t *testing.T) {
+func TestSessionDoesNotImportPlugins(t *testing.T) {
     // walk every session package, fail if it imports
     // dhs/internal/amwa/{consumer,provider,registry}
 }
@@ -367,7 +380,6 @@ without breaking the layering:
 | Package | Purpose | Layers allowed |
 |---|---|---|
 | `dhs/internal/datastore` | Portable data dir + atomic file writes | 2, 3 |
-| `dhs/internal/metrics` | Connector counters + Prom registry | 2, 3 |
 | `dhs/internal/transport` | HTTP/WS capture (`--capture` flag) | 2 only |
 | `dhs/internal/consumer/compliance` | Compliance.Profile + event types | 2, 3 |
 | `dhs/internal/consumer` | Consumer interface + registry | 3, 4 |

--- a/internal/amwa/docs/dns-sd-unbound.md
+++ b/internal/amwa/docs/dns-sd-unbound.md
@@ -25,9 +25,9 @@ one TXT** record per face (Registration / Query). The four IS-04
 
 | Key | Spec | Example |
 |---|---|---|
-| `api_proto` | IS-04 §3.1.1.1 | `http` (or `https` once IS-10 lands) |
+| `api_proto` | IS-04 §3.1.1.1 | `http`; `https` when TLS is armed (`--est-host` / `--tls-cert`, BCP-003-01) |
 | `api_ver` | IS-04 §3.1.1.1 | comma-list — `v1.3` or `v1.1,v1.2,v1.3` |
-| `api_auth` | IS-04 §3.1.1.1 | `false` (until IS-10 deployed) |
+| `api_auth` | IS-04 §3.1.1.1 | `false`; `true` when `--auth-url` arms IS-10 authorization |
 | `pri` | IS-04 §3.1.1.1 | `0`–`99` production, `100`+ dev/staging |
 
 Multiple instances of the same service type all PTR back to the bare
@@ -193,12 +193,12 @@ For an IS-09 System server, use `_nmos-system._tcp` instead — and
 **omit `api_auth`** from its TXT record (IS-09 v1.0 predates IS-10).
 For Node P2P (Mode D), use `_nmos-node._tcp`.
 
-Compliance events fired by `dhs consumer nmos discover` when a peer's
-records deviate (priority collisions, missing keys, malformed `pri`)
-are catalogued in
-[`../codec/dnssd/types.go`](../codec/dnssd/types.go) and surface via
-the `compliance.Event` channel — see
-[`internal/consumer/compliance/`](../../consumer/compliance/).
+Deviations in a peer's records (missing TXT keys, malformed `pri`)
+are absorbed by discovery and surface only in the log — there are no
+per-record DNS-SD compliance events today. The emitted NMOS event set
+is catalogued in
+[`matrix-compliance.md`](matrix-compliance.md) "Compliance event
+catalogue".
 
 ---
 

--- a/internal/amwa/docs/firewall-recipes.md
+++ b/internal/amwa/docs/firewall-recipes.md
@@ -18,14 +18,14 @@ host's local firewall.
 
 | Role | Binary invocation | Inbound TCP | Inbound UDP | Notes |
 |---|---|---|---|---|
-| **Node** | `dhs producer nmos serve` | **8080** (Node API HTTP — Phase 1 step #3) | 5353 (Mode A only) | Default port; override with `--bind`. |
-| **Registry** | `dhs registry nmos serve` | **8235** (Registration + Query HTTP — Phase 1 step #4) | 5353 (Mode A only) | Default port; override with `--bind`. |
+| **Node** | `dhs producer nmos serve` | **8080** (Node API HTTP) | 5353 (Mode A only) | Default port; override with `--bind`. |
+| **Registry** | `dhs registry nmos serve` | **8235** (Registration + Query HTTP) | 5353 (Mode A only) | Default port; override with `--bind`. |
 | **Controller** | `dhs consumer nmos discover` / `walk` | none — outbound only | 5353 (Mode A only — to receive mDNS responses) | No HTTP listener. |
 | **Cerebrum host** (peer Registry) | EVS Cerebrum app | 8080 | 5353 (Mode A only) | Per [`cerebrum-interop.md`](cerebrum-interop.md) §4. |
 
-Phase 1 step #1 (PR #149) ships discovery only — no HTTP REST yet. The
-TCP rules below take effect once Phase 1 #3/#4 land; add them now so the
-firewall doesn't become a surprise blocker later.
+Both HTTP servers ship (`dhs producer nmos serve --bind :8080`,
+`dhs registry nmos serve --bind :8235`); the TCP rules below are live
+requirements, not future-proofing.
 
 ---
 
@@ -149,7 +149,7 @@ pass in proto udp from any           to any port 5353 keep state
 |---|---|
 | TCP listener bound | `netstat -an \| grep 8235` (Win/Linux) / `lsof -nP -iTCP:8235 -sTCP:LISTEN` (Linux/macOS) |
 | Reachable from peer | `Test-NetConnection -ComputerName <host> -Port 8235` (Win) / `nc -zv <host> 8235` (Linux/macOS) |
-| HTTP response | `curl http://<host>:8235/x-nmos/registration/` once Phase 1 #4 lands |
+| HTTP response | `curl http://<host>:8235/x-nmos/registration/` |
 | mDNS observable | `dns-sd -B _nmos-register._tcp` (mDNSResponder, Win/macOS) / `avahi-browse -r _nmos-register._tcp` (Linux) |
 
 Equivalent dhs end-to-end:

--- a/internal/amwa/docs/ha.md
+++ b/internal/amwa/docs/ha.md
@@ -175,10 +175,15 @@ dhs registry nmos serve --bind 10.0.0.1:8000  --advertise-host 10.0.0.1:8000
 # BLU Registry on blue network
 dhs registry nmos serve --bind 10.0.1.1:8000  --advertise-host 10.0.1.1:8000
 
-# Node side - same dhs producer, but bound on both NICs
-dhs producer nmos serve --bind 10.0.0.50:2080,10.0.1.50:2080 \
-                        --advertise-host 10.0.0.50:2080,10.0.1.50:2080
+# Node side — `--bind` takes ONE address, so run one dhs producer per
+# network (one process per NIC)
+dhs producer nmos serve --bind 10.0.0.50:2080 --advertise-host 10.0.0.50:2080   # RED
+dhs producer nmos serve --bind 10.0.1.50:2080 --advertise-host 10.0.1.50:2080   # BLU
 ```
+
+The single-process HA mechanism dhs ships out of the box is the
+active/passive `pri` pair (Topology 2); ST 2022-7 dual-network today
+means one process per network as above.
 
 ### Topology 4 — active/active shared-store (OUT OF SPEC + OUT OF SCOPE FOR v1)
 
@@ -258,20 +263,22 @@ re-register branch.
 
 ---
 
-## Compliance events (HA-specific)
+## Failover observability
 
-Each fires once per (session, Registry) tuple:
+The Node-side failover machinery is implemented in
+`internal/amwa/provider/registration_client.go`. It fires no dedicated
+compliance events; the observable surface is the structured log:
 
 ```
-nmos_registry_failover           Primary 5xx; switching to secondary from list.
-nmos_registry_re_registered     Lost during failover; re-POSTed full resource graph.
-nmos_registry_all_failed         Every discoverable Registry returned 5xx; entering exponential backoff.
-nmos_registry_pri_collision      Two Registries advertised with same pri AND same api_ver — picking randomly.
-nmos_registry_dev_pri            Saw pri >= 100 in production deployment (dev Registry leaked into live).
+provider/node: better registry available — switching   a higher-pri Registry appeared; client re-targets it
+provider/node: heartbeat 404 — re-registering          new Registry does not know us; full re-register
+provider/node: heartbeat failed                        current Registry disqualified; next cycle tries next-best
+provider/node: re-register attempt failed              registration retry against the picked Registry failed
 ```
 
-Surfaced via the standard dhs metrics counter
-(`dhs_connector_compliance_events_total{proto="nmos",event="..."}`).
+On failover the client follows IS-04 v1.3.3 §6.1: heartbeat-first
+against the new Registry, full `POST /resource` only on a 404 (AMWA
+test_16 fails a Node that re-POSTs on every failover).
 
 ---
 

--- a/internal/amwa/docs/matrix-compliance.md
+++ b/internal/amwa/docs/matrix-compliance.md
@@ -64,9 +64,9 @@ deployment topology. Each mode maps to a CLI flag set:
 |---|---|---|
 | **Full mDNS + Registry** | Greenfield / lab / spec-compliant peers (nmos-cpp). | `dhs registry nmos serve --mdns`<br>`dhs producer nmos serve` (Node auto-discovers Registry)<br>`dhs consumer nmos walk` (Controller auto-discovers Registry) |
 | **Unicast Registry** (mDNS off, static Registry hint) | Hardened deployments where mDNS is firewalled but a Registry still exists. | `dhs registry nmos serve --no-mdns --advertise-host <ip>:<port>`<br>`dhs producer nmos serve --no-mdns --registry <ip>:<port>`<br>`dhs consumer nmos walk <registry-ip>:<port>` |
-| **Direct-Node** (no Registry at all) | Lawo VSM, vendor environments without IS-04 registration support, end-user environments where mDNS is blocked. | `dhs producer nmos serve --no-mdns --no-registry`<br>`dhs consumer nmos walk-nodes --peer-list peers.csv`<br>`dhs consumer nmos walk-node <node-ip>:<port>` |
-| **mDNS direct-Node** (mDNS on, no Registry) | EVS Cerebrum peer-to-peer mode and any deployment where mDNS works but no Registry is provisioned. Nodes are mDNS-discovered on `_nmos-node._tcp` (peer service type) and addressed directly. See [`cerebrum-interop.md`](cerebrum-interop.md). | `dhs producer nmos serve --mdns --no-registry`<br>`dhs consumer nmos walk-nodes --mdns --no-registry` |
-| **CSV bootstrap** | Operations team gives dhs a static list of Node URLs (Lawo VSM convention). | `--peer-list peers.csv` (one Node URL per line) |
+| **Direct-Node** (no Registry at all) | Lawo VSM, vendor environments without IS-04 registration support, end-user environments where mDNS is blocked. | `dhs producer nmos serve --no-mdns --no-registry`<br>`dhs consumer nmos walk --node http://<node-ip>:<port>` (one call per Node) |
+| **mDNS direct-Node** (mDNS on, no Registry) | EVS Cerebrum peer-to-peer mode and any deployment where mDNS works but no Registry is provisioned. Nodes are mDNS-discovered on `_nmos-node._tcp` (peer service type) and addressed directly. See [`cerebrum-interop.md`](cerebrum-interop.md). | `dhs producer nmos serve --mdns --no-registry`<br>`dhs consumer nmos discover --mdns --service _nmos-node._tcp`, then `walk --node http://<host>:<port>` |
+| **CSV bootstrap** | Operations team gives dhs a static list of Node addresses (Lawo VSM convention). | `--peer-list peers.csv` on `discover` / `system` (CSV: `host,port[,api_ver]` per line) |
 
 Default mode: **Full mDNS + Registry**. Deviations fire a startup-log
 banner naming the chosen mode so debugging is unambiguous.
@@ -75,41 +75,36 @@ banner naming the chosen mode so debugging is unambiguous.
 
 ## Compliance event catalogue (NMOS)
 
-Each event is fired at most once per (session, peer, deviation) tuple
-to avoid log spam. All names use snake_case prefixed with `nmos_`.
+The events the code emits today (every emission site lives under
+`internal/amwa/`). All names use snake_case prefixed with `nmos_`.
+Events fire on each occurrence — there is no per-(session, peer,
+deviation) deduplication in the reporter today.
 
 ```
 # IS-04 deviations
-nmos_registry_not_supported          peer rejects POST /resource → fall back to direct-Node mode
-nmos_query_api_missing               peer has no /x-nmos/query/* → can't browse, must walk per-Node
-nmos_node_api_version_downgrade      peer offers only v1.0/v1.1, we wanted v1.3
-nmos_p2p_only                        no Registry discovered, falling back to peer-to-peer
+nmos_is04_schema_deviation           decoded resource does not match the AMWA schema at that minor; absorbed at Warn
+nmos_is04_unknown_field              peer sent a field the modelled resource does not carry; absorbed + recorded
 
 # IS-05 deviations
-nmos_scheduled_activation_unsupported peer rejected activate_scheduled_*; retried as activate_immediate
-nmos_constraints_endpoint_missing    GET /constraints returned 404
-nmos_bulk_unsupported                POST /bulk/* returned 404 or 405
-nmos_master_enable_ignored           PATCH set master_enable=true, GET /active still shows false
+nmos_is05_no_transport_file          sender served no transport file; receiver still targeted by sender id
+nmos_is05_empty_transport_file       sender served an empty transport file
+nmos_is05_active_unreadable          receiver's /active state unreadable during a dry-run read-back
+nmos_is05_master_enable_ignored      stage accepted but device reports master_enable=false; no signal will flow
+nmos_is05_destination_ignored        device kept destination_ip empty / 0.0.0.0 after a stage that set it
 
-# IS-07 / IS-12 / MS-05 deviations
-nmos_is07_unsupported                Source advertises events but no WS/MQTT endpoint
-nmos_is12_unsupported                Device controls array has no urn:x-nmos:control:ncp/*
-nmos_ms05_class_missing              ClassManager doesn't expose class we expected (per BCP-008)
+# IS-09 deviations
+nmos_is09_global_deviation           /global fails the IS-09 schema; absorbed and used anyway
 
-# Discovery deviations
-nmos_mdns_disabled                   user passed --no-mdns
-nmos_mdns_no_response                mDNS browser ran for full timeout, found nothing
-nmos_csv_peer_unreachable            entry in --peer-list refused TCP connect
+# Version negotiation
+nmos_no_common_api_ver               no common IS-04 api_ver between us and the peer's advertised set
 
-# Wire deviations
-nmos_resource_schema_violation       resource JSON failed BCP-004 / IS-04 schema validation but parsed
-nmos_subscription_dropped            WS subscription closed unexpectedly; reconnect attempted
-nmos_heartbeat_late                  Node missed POST /health by > 1× ttl interval (warn before purge)
+# Query API
+nmos_query_collection_failed         one catalogue collection failed during a walk; snapshot is partial
 ```
 
-Every event is also surfaced via the standard dhs metrics counter
-(`dhs_connector_compliance_events_total{proto="nmos",event="..."}`)
-once Phase 4+ wires NMOS into `internal/metrics/`.
+Events surface through `spec.Reporter` (`codec/spec/compliance.go`):
+production wires a logger-backed reporter in `cmd/dhs/cmd_nmos.go`;
+tests assert against `spec.SliceReporter`.
 
 ---
 

--- a/internal/amwa/docs/runbook-multi-os.md
+++ b/internal/amwa/docs/runbook-multi-os.md
@@ -6,7 +6,8 @@ test rig (#197) gating the Avahi/Bonjour DNS-SD backends (#194/#195/#196).
 
 > **Service-per-device rule.** Every dhs connector runs as one managed
 > service per one physical device — never multiplexed. See
-> `internal/amwa/docs/ha.md` for the lease/handover protocol.
+> `internal/amwa/docs/ha.md` for the multi-Registry HA rules
+> (client-driven `pri` priority failover).
 
 ## Per-OS package matrix
 
@@ -139,7 +140,7 @@ server (Unbound on pfSense in this fleet — see `dns-sd-unbound.md`).
 | Doc | What |
 |---|---|
 | [architecture.md](architecture.md) | Top-level NMOS Node + Registry layout |
-| [ha.md](ha.md) | One-service-per-device rule + lease/handover |
+| [ha.md](ha.md) | Multi-Registry HA — client-driven `pri` priority failover |
 | [dns-sd-unbound.md](dns-sd-unbound.md) | Unicast DNS-SD records for pfSense Unbound |
 | [cerebrum-interop.md](cerebrum-interop.md) | Cerebrum v1.1/v1.2/v1.3 advertising shape (matches what we observe live on `10.100.0.5`) |
 

--- a/internal/amwa/reference.md
+++ b/internal/amwa/reference.md
@@ -36,7 +36,7 @@ Roles to support: **proxy gateway** + **consumer** + **provider**.
 
 | ID | Name | Spec status | Release(s) |
 |---|---|---|---|
-| IS-04 | Discovery & Registration | AMWA Specification (Stable) | v1.3.3 / v1.2.2 / v1.1.3 |
+| IS-04 | Discovery & Registration | AMWA Specification (Stable) | v1.3.3 / v1.2.2 / v1.1.3 / v1.0.3 |
 | IS-09 | System Parameters | AMWA Specification | v1.0.0 |
 | IS-13 | Annotation | Work In Progress | — |
 | BCP-002-01 | Natural Grouping | AMWA Specification | v1.0.0 |
@@ -54,15 +54,18 @@ Roles to support: **proxy gateway** + **consumer** + **provider**.
 
 | ID | Name | Spec status | Release(s) |
 |---|---|---|---|
-| IS-05 | Device Connection Management | AMWA Specification (Stable) | v1.1.2 / v1.0.2 |
+| IS-05 | Device Connection Management | AMWA Specification (Stable) | v1.2.0 / v1.1.2 / v1.0.2 |
 | IS-08 | Audio Channel Mapping | AMWA Specification (Stable) | v1.0.1 |
+| IS-11 | Stream Compatibility Management | AMWA Specification | v1.0.0 |
 | BCP-004-01 | Receiver Capabilities | AMWA Specification | v1.0.0 |
 | BCP-004-02 | Sender Capabilities | AMWA Specification | v1.0.0 |
+| BCP-005-01 | EDID to Receiver Capabilities Mapping | AMWA Specification | v1.0.0 |
 | BCP-006-01 | NMOS With JPEG XS | AMWA Specification | v1.0.0 |
 | BCP-006-02 | NMOS With H.264 | Work In Progress | — |
 | BCP-006-03 | NMOS With H.265 | Work In Progress | — |
 | BCP-006-04 | NMOS Support for MPEG Transport Streams | AMWA Specification | v1.0.0 |
 | BCP-007-01 | NMOS With NDI | Work In Progress | — |
+| BCP-007-03 | NMOS With MXL | AMWA Specification | v1.0.0 |
 | INFO-003 | Sink Metadata Processing Architecture | Work In Progress | — |
 | INFO-005 | Implementation Guide for NMOS Controllers | AMWA Specification | — |
 
@@ -78,8 +81,24 @@ Roles to support: **proxy gateway** + **consumer** + **provider**.
 |---|---|---|---|
 | IS-07 | Event & Tally | AMWA Specification | v1.0.1 |
 | IS-12 | Control Protocol | AMWA Specification | v1.0.1 |
+| IS-14 | Device Configuration | AMWA Specification | v1.0.0 |
 | MS-05-01 | NMOS Control Architecture | AMWA Specification | v1.0.0 |
 | MS-05-02 | NMOS Control Framework | AMWA Specification | v1.0.0 |
 | BCP-008-01 | NMOS Receiver Status Monitoring | AMWA Specification | v1.0.0 |
 | BCP-008-02 | NMOS Sender Status Monitoring | AMWA Specification | v1.0.0 |
 | INFO-006 | Implementation Guide for NMOS Device Control & Monitoring | AMWA Specification | — |
+
+---
+
+## 4. Security
+
+Spec index: https://specs.amwa.tv/nmos/#security
+
+Roles to support: **proxy gateway** + **consumer** + **provider**.
+
+| ID | Name | Spec status | Release(s) |
+|---|---|---|---|
+| IS-10 | Authorization | AMWA Specification | v1.0.0 |
+| BCP-003-01 | Secure Communication in NMOS Systems | AMWA Specification | v1.0.1 |
+| BCP-003-02 | Authorization in NMOS Systems | AMWA Specification | v1.0.0 |
+| BCP-003-03 | Certificate Provisioning in NMOS Systems | AMWA Specification | v1.0.0 |


### PR DESCRIPTION
Closes #927 (part 2 of 2 - part 1 was #928, the Go style guide + lint hardening).

## What

A code-verified audit of the 15 in-scope amwa docs found 44 drift findings across 11 files (4 files were clean). Every fix moves the doc to what the code does today - nothing aspirational added:

- **CLAUDE.md**: CLI surface "(planned)" -> shipped 12-verb set; IS-07 gains `connection_status`; NODE table gains IS-11/IS-12(ncp)/IS-14 surfaces; Mode C flags per role; dual-network HA claim trimmed to the real single-`--bind` priority-pair failover; layer/codec trees corrected.
- **reference.md**: adds implemented IS-04 v1.0.3 + IS-05 v1.2.0 and rows for IS-10, IS-11, IS-14, BCP-003-01/-02/-03, BCP-005-01, BCP-007-03 MXL.
- **dependencies.md**: real session/codec package lists (phantom `session/registration|registry_core|control|bootstrap`, `codec/rql`, `codec/sdp` removed), real `internal/registry` factory API, real depguard v2 config + Go-test enforcement split, correct audit-test name.
- **matrix-compliance.md**: compliance-event catalogue replaced - of 20 documented codes 19 never existed; now lists the 10 genuinely emitted `nmos_*` codes (the audit's own 11th, `nmos_query_api_missing`, is only a doc-comment example - dropped too). Undocumented dedup claim removed.
- **ha.md / cerebrum-interop.md / firewall-recipes.md / dns-sd-unbound.md / architecture.md / runbook-multi-os.md**: phantom events, nonexistent metric, stale "Phase 1" / "not yet wired" / "awaits approval" gating replaced with shipped reality (mirror verb, MQTT, IS-10 auth/TLS); architecture gains IS-10/IS-11/IS-14 diagrams.
- **amwa-reality-check-2026-08-23.md**: historical body untouched; dated addendum records what has shipped since.

Docs-only: no `.go`, no config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
