### PR TITLE
chore: repo-root hygiene - ignore coverage profiles + session scratch (#930)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,12 @@ tests/integration/nmos/amwa/dhs
 *.test
 *.out
 *.prof
+*.cov
 coverage.html
+
+# Local session scratch (audit notes, commit-message drafts, handoffs).
+# Working files only — anything durable graduates into docs/ or a memory.
+/.audit/
 
 # IDE
 .idea/


### PR DESCRIPTION
Closes #930.

## What

Repo-root hygiene unit from the approved post-spec-100% roadmap. The tracked change is `.gitignore` only:

- `*.cov` — Go coverage profiles (the root held 3 of these plus 9 extensionless `mode: set` profiles from ad-hoc runs).
- `/.audit/` — the local session-scratch directory (commit-message drafts, PR bodies, audit notes).

Local cleanup done alongside (nothing tracked, all reproducible or archived):

- Deleted 12 coverage profiles, the 24 MB `dhs-linux` cross-build, and `ember-int.tar` — verified first that all 9 tar members are committed under `internal/emberplus/testdata/integration-test/` (the tar was only the git-bundle-era transport copy).
- Archived the stale 2026-06-07 `AUDIT-PUNCHLIST.md` and `CLAUDE.local.md` handoff into `.audit/` — the durable rules they carried (PowerShell-only host, oracle-per-tier testing) already live in `CLAUDE.md` / `docs/user.md`, and their remaining content (VPN-era access claims, pre-program approval discipline) is superseded.

`git status` at root is now clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
