### PR TITLE
feat(cli): non-blocking RFC 5424 syslog forwarding via --syslog-addr (#934)

### DIFF
--- a/cmd/dhs/cmd_producer.go
+++ b/cmd/dhs/cmd_producer.go
@@ -50,6 +50,7 @@ func runProducer(ctx context.Context, protoName string, args []string) error {
 		bind          = fs.String("bind", "", "alternate spelling of --host. e.g. --bind 10.6.239.200 binds the listener AND pins the broadcast source IP to the VIP, so multi-instance emulators on the same machine appear as distinct From: addresses to consumers (#263).")
 		logLevel      = fs.String("log-level", "info", "log level: debug, info, warn, error")
 		logFormat     = fs.String("log-format", "text", "log format: text | json (Loki/Promtail) | syslog (RFC 5424 lines, severity mapped incl. critical — #751 G6)")
+		syslogAddr    = fs.String("syslog-addr", "", "also forward logs as RFC 5424 UDP datagrams to host:port (non-blocking: a slow collector drops records; drops are counted and reported on stderr — #934)")
 		announceDemo  = fs.Bool("announce-demo", false, "oscillate a target value every --announce-demo-interval and broadcast announces (acp1/acp2 only)")
 		announceSlot  = fs.Int("announce-demo-slot", 1, "slot for --announce-demo target")
 		announceGroup = fs.Int("announce-demo-group", 2, "acp1: object group for --announce-demo target (2=Control)")
@@ -95,6 +96,14 @@ func runProducer(ctx context.Context, protoName string, args []string) error {
 	}
 
 	logger := newLogger(*logLevel, *logFormat)
+	if *syslogAddr != "" {
+		udp, err := dialSyslogUDP(*syslogAddr)
+		if err != nil {
+			return err
+		}
+		defer udp.Close()
+		logger = slog.New(teeHandler{logger.Handler(), udp.Handler(parseLogLevel(*logLevel))})
+	}
 
 	factory, ok := provider.Lookup(protoName)
 	if !ok {
@@ -485,20 +494,23 @@ func loadTree(path string) (*canonical.Export, error) {
 	return &exp, nil
 }
 
-func newLogger(level, format string) *slog.Logger {
-	var lvl slog.Level
+func parseLogLevel(level string) slog.Level {
 	switch level {
 	case "debug":
-		lvl = slog.LevelDebug
+		return slog.LevelDebug
 	case "warn":
-		lvl = slog.LevelWarn
+		return slog.LevelWarn
 	case "error":
-		lvl = slog.LevelError
+		return slog.LevelError
 	case "critical":
-		lvl = LevelCritical
+		return LevelCritical
 	default:
-		lvl = slog.LevelInfo
+		return slog.LevelInfo
 	}
+}
+
+func newLogger(level, format string) *slog.Logger {
+	lvl := parseLogLevel(level)
 	opts := &slog.HandlerOptions{Level: lvl}
 	switch format {
 	case "json":

--- a/cmd/dhs/syslog_handler.go
+++ b/cmd/dhs/syslog_handler.go
@@ -95,7 +95,11 @@ func syslogVal(v slog.Value) string {
 	return s
 }
 
-func (h *syslogHandler) Handle(_ context.Context, r slog.Record) error {
+// formatRecord renders one record as an RFC 5424 line WITHOUT a
+// trailing newline — the stderr path appends '\n' per line, while the
+// UDP forwarder sends the bare line as one datagram (RFC 5426 §3.1:
+// one message per datagram, no line terminator).
+func (h *syslogHandler) formatRecord(r slog.Record) string {
 	var b strings.Builder
 	pri := syslogFacility*8 + syslogSeverity(r.Level)
 	ts := "-"
@@ -114,9 +118,13 @@ func (h *syslogHandler) Handle(_ context.Context, r slog.Record) error {
 		fmt.Fprintf(&b, " %s%s=%s", prefix, a.Key, syslogVal(a.Value))
 		return true
 	})
-	b.WriteByte('\n')
+	return b.String()
+}
+
+func (h *syslogHandler) Handle(_ context.Context, r slog.Record) error {
+	line := h.formatRecord(r) + "\n"
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	_, err := io.WriteString(h.w, b.String())
+	_, err := io.WriteString(h.w, line)
 	return err
 }

--- a/cmd/dhs/syslog_udp.go
+++ b/cmd/dhs/syslog_udp.go
@@ -1,0 +1,162 @@
+package main
+
+// Non-blocking RFC 5424 forwarding over UDP (#934). `--syslog-addr
+// host:port` tees producer logs to a collector as one datagram per
+// record (RFC 5426 §3.1). The contract is that logging NEVER stalls a
+// frame path: Handle() enqueues into a bounded channel and returns; a
+// single writer goroutine drains to the socket. When the collector
+// cannot keep up the queue fills, the record is dropped, and the drop
+// is counted — the first drop and the close-time total are reported on
+// stderr, so lost records are audited rather than silent.
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"sync"
+	"sync/atomic"
+)
+
+// syslogQueueDepth bounds how many formatted records may wait for the
+// socket before new records are dropped. 1024 lines rides out collector
+// hiccups of a few hundred ms at debug-level chatter without letting an
+// unreachable collector grow the heap unbounded.
+const syslogQueueDepth = 1024
+
+// syslogUDP owns the socket, the bounded queue, and the writer
+// goroutine. One instance is shared by every derived handler
+// (WithAttrs/WithGroup copies), so the drop accounting is per-target.
+type syslogUDP struct {
+	addr      string
+	conn      net.Conn
+	ch        chan string
+	dropped   atomic.Uint64
+	writeErrs atomic.Uint64
+	wg        sync.WaitGroup
+	closeOnce sync.Once
+}
+
+// dialSyslogUDP resolves the collector address and starts the writer
+// goroutine. UDP "dialing" only fails on resolution — an unreachable
+// collector is invisible at this layer, which is exactly why drops and
+// write errors are counted instead of assumed impossible.
+func dialSyslogUDP(addr string) (*syslogUDP, error) {
+	conn, err := net.Dial("udp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("syslog dial %s: %w", addr, err)
+	}
+	q := &syslogUDP{addr: addr, conn: conn, ch: make(chan string, syslogQueueDepth)}
+	q.wg.Add(1)
+	go func() {
+		defer q.wg.Done()
+		for line := range q.ch {
+			if _, err := q.conn.Write([]byte(line)); err != nil {
+				q.writeErrs.Add(1)
+			}
+		}
+	}()
+	return q, nil
+}
+
+// enqueue hands one formatted line to the writer without blocking.
+func (q *syslogUDP) enqueue(line string) {
+	select {
+	case q.ch <- line:
+	default:
+		if q.dropped.Add(1) == 1 {
+			fmt.Fprintf(os.Stderr, "syslog: collector %s not keeping up; dropping records (totals reported at shutdown)\n", q.addr)
+		}
+	}
+}
+
+// Close drains the queue, closes the socket, and reports totals. Safe
+// to call more than once.
+func (q *syslogUDP) Close() {
+	q.closeOnce.Do(func() {
+		close(q.ch)
+		q.wg.Wait()
+		_ = q.conn.Close()
+		if d := q.dropped.Load(); d > 0 {
+			fmt.Fprintf(os.Stderr, "syslog: dropped %d record(s) for %s (queue full)\n", d, q.addr)
+		}
+		if e := q.writeErrs.Load(); e > 0 {
+			fmt.Fprintf(os.Stderr, "syslog: %d send error(s) to %s\n", e, q.addr)
+		}
+	})
+}
+
+// Handler returns a slog.Handler forwarding to this queue at min level.
+func (q *syslogUDP) Handler(min slog.Level) slog.Handler {
+	// io.Discard: the formatting state never writes — Handle goes
+	// through formatRecord + enqueue, not syslogHandler.Handle.
+	return &syslogUDPHandler{fmtH: newSyslogHandler(io.Discard, min), q: q}
+}
+
+// syslogUDPHandler pairs the shared queue with per-handler formatting
+// state. Formatting reuses syslogHandler so the wire line is
+// byte-identical to the `--log-format syslog` stderr line.
+type syslogUDPHandler struct {
+	fmtH *syslogHandler
+	q    *syslogUDP
+}
+
+func (h *syslogUDPHandler) Enabled(ctx context.Context, l slog.Level) bool {
+	return h.fmtH.Enabled(ctx, l)
+}
+
+func (h *syslogUDPHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &syslogUDPHandler{fmtH: h.fmtH.WithAttrs(attrs).(*syslogHandler), q: h.q}
+}
+
+func (h *syslogUDPHandler) WithGroup(name string) slog.Handler {
+	return &syslogUDPHandler{fmtH: h.fmtH.WithGroup(name).(*syslogHandler), q: h.q}
+}
+
+func (h *syslogUDPHandler) Handle(_ context.Context, r slog.Record) error {
+	h.q.enqueue(h.fmtH.formatRecord(r))
+	return nil
+}
+
+// teeHandler fans one record out to every underlying handler. Used to
+// keep the operator's stderr format while also forwarding to syslog.
+type teeHandler []slog.Handler
+
+func (t teeHandler) Enabled(ctx context.Context, l slog.Level) bool {
+	for _, h := range t {
+		if h.Enabled(ctx, l) {
+			return true
+		}
+	}
+	return false
+}
+
+func (t teeHandler) Handle(ctx context.Context, r slog.Record) error {
+	var first error
+	for _, h := range t {
+		if h.Enabled(ctx, r.Level) {
+			if err := h.Handle(ctx, r.Clone()); err != nil && first == nil {
+				first = err
+			}
+		}
+	}
+	return first
+}
+
+func (t teeHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	out := make(teeHandler, len(t))
+	for i, h := range t {
+		out[i] = h.WithAttrs(attrs)
+	}
+	return out
+}
+
+func (t teeHandler) WithGroup(name string) slog.Handler {
+	out := make(teeHandler, len(t))
+	for i, h := range t {
+		out[i] = h.WithGroup(name)
+	}
+	return out
+}

--- a/cmd/dhs/syslog_udp_test.go
+++ b/cmd/dhs/syslog_udp_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSyslogUDPDeliversRFC5424 asserts that one log record arrives at
+// the collector as one RFC 5424 datagram, byte-compatible with the
+// `--log-format syslog` stderr line minus the trailing newline
+// (RFC 5426 §3.1: no line terminator in the datagram).
+func TestSyslogUDPDeliversRFC5424(t *testing.T) {
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = pc.Close() }()
+
+	q, err := dialSyslogUDP(pc.LocalAddr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	logger := slog.New(q.Handler(slog.LevelInfo))
+	logger.Info("route set", "dst", 7, "src", "cam 1")
+	q.Close()
+
+	_ = pc.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 2048)
+	n, _, err := pc.ReadFrom(buf)
+	if err != nil {
+		t.Fatalf("read datagram: %v", err)
+	}
+	got := string(buf[:n])
+
+	// <134> = facility local0(16)*8 + severity info(6), per the stderr
+	// handler's mapping (#751 G6).
+	if !strings.HasPrefix(got, "<134>1 ") {
+		t.Fatalf("datagram PRI/version = %q, want prefix %q", got, "<134>1 ")
+	}
+	if !strings.Contains(got, " dhs ") {
+		t.Fatalf("datagram missing APP-NAME 'dhs': %q", got)
+	}
+	if !strings.Contains(got, "route set dst=7 src=\"cam 1\"") {
+		t.Fatalf("datagram MSG = %q, want message + key=val attrs", got)
+	}
+	if strings.HasSuffix(got, "\n") {
+		t.Fatalf("datagram must not carry a trailing newline: %q", got)
+	}
+}
+
+// TestSyslogUDPNeverBlocks pins the non-blocking contract: with no
+// writer draining the queue, enqueues past the depth return immediately
+// and are counted as drops instead of stalling the caller.
+func TestSyslogUDPNeverBlocks(t *testing.T) {
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = pc.Close() }()
+	conn, err := net.Dial("udp", pc.LocalAddr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	// Hand-built queue with capacity 2 and NO writer goroutine, so the
+	// third enqueue must take the drop path, not block.
+	q := &syslogUDP{addr: "test", conn: conn, ch: make(chan string, 2)}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h := q.Handler(slog.LevelInfo)
+		r := slog.NewRecord(time.Now(), slog.LevelInfo, "m", 0)
+		for i := 0; i < 5; i++ {
+			_ = h.Handle(context.Background(), r)
+		}
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Handle blocked on a full queue")
+	}
+	if got := q.dropped.Load(); got != 3 {
+		t.Fatalf("dropped = %d, want 3 (5 enqueues into cap-2 queue)", got)
+	}
+	_ = conn.Close()
+}
+
+// TestTeeHandlerFansOut asserts both underlying handlers see the
+// record and that per-handler Enabled gating holds.
+func TestTeeHandlerFansOut(t *testing.T) {
+	var a, b strings.Builder
+	tee := teeHandler{
+		newSyslogHandler(&a, slog.LevelInfo),
+		newSyslogHandler(&b, slog.LevelError),
+	}
+	logger := slog.New(tee)
+	logger.Info("only-a")
+	logger.Error("both")
+
+	if !strings.Contains(a.String(), "only-a") || !strings.Contains(a.String(), "both") {
+		t.Fatalf("handler a saw %q, want both records", a.String())
+	}
+	if strings.Contains(b.String(), "only-a") {
+		t.Fatalf("handler b (error-gated) must not see info records: %q", b.String())
+	}
+	if !strings.Contains(b.String(), "both") {
+		t.Fatalf("handler b missing error record: %q", b.String())
+	}
+}

--- a/internal/probel-sw02p/provider/server_lifecycle_test.go
+++ b/internal/probel-sw02p/provider/server_lifecycle_test.go
@@ -612,3 +612,40 @@ func TestSessionWriteFailureClosesSession(t *testing.T) {
 		t.Fatal("session.run did not exit after write failure")
 	}
 }
+
+// TestStopClosesRegisteredSessions covers Stop's session-drain loops
+// deterministically (server.go Stop: copy-under-lock + close-outside-
+// lock). Whether the accept-loop tests leave a session registered at
+// Stop time is a teardown race, so without this test the two loops'
+// coverage flapped run to run.
+func TestStopClosesRegisteredSessions(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	srv := newServer(logger, nil)
+
+	a, b := net.Pipe()
+	defer func() { _ = b.Close() }()
+	sess := newSession(srv, a)
+	srv.mu.Lock()
+	srv.sessions[sess] = struct{}{}
+	srv.mu.Unlock()
+
+	if err := srv.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	// sess.close() must have closed the socket: the far end of the pipe
+	// unblocks with an error instead of hanging.
+	done := make(chan error, 1)
+	go func() {
+		buf := make([]byte, 1)
+		_, err := b.Read(buf)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("read succeeded; session socket still open after Stop")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("session socket not closed by Stop")
+	}
+}


### PR DESCRIPTION
Closes #934 — the final unit of the approved post-spec-100% roadmap.

## What

`dhs producer <proto> serve --syslog-addr host:port` forwards logs to a syslog collector as RFC 5424 UDP datagrams (one record = one datagram, RFC 5426), teed alongside the operator's chosen `--log-format` on stderr.

**The non-blocking contract** (the point of the unit): `Handle()` formats and enqueues into a bounded 1024-line channel and returns; a single writer goroutine owns the socket. A slow or unreachable collector fills the queue, and further records are **dropped and counted** — the first drop logs a one-time stderr notice, and shutdown reports total drops and send errors. Logging can never stall a frame path, and lost records are audited rather than silent.

## How

- `syslog_handler.go`: `Handle` split into `formatRecord` (no trailing newline) + write — stderr output stays byte-identical, pinned by the existing `TestSyslogHandler_LineShape`.
- `syslog_udp.go` (new): `syslogUDP` queue + writer, `syslogUDPHandler` reusing the stderr formatter, and a small `teeHandler` fan-out with per-handler level gating.
- `cmd_producer.go`: the flag, the tee at logger construction, `defer udp.Close()` for drain + totals; `parseLogLevel` extracted from `newLogger` (no behavior change).
- `docs/cli.md` unchanged — verified by regenerating: gencli's output does not include per-verb flag dumps.

## Verification

- `go test ./cmd/dhs/`: all 5 syslog/tee tests pass (datagram PRI/APP-NAME/attrs shape, no trailing newline, never-blocks with exact drop count, tee gating); full package green.
- `-race` runs in CI (this Windows box has no cgo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
