### PR TITLE
feat(registry): mirror serves the Query API - audited MITM face (#940)

### DIFF
--- a/ansible/roles/dhs_amwa_plant/defaults/main.yml
+++ b/ansible/roles/dhs_amwa_plant/defaults/main.yml
@@ -24,6 +24,10 @@ dhs_amwa_plant_mirror_source: "http://10.6.250.101:8235"
 dhs_amwa_plant_mirror_target: "http://10.6.250.5:8080"
 dhs_amwa_plant_mirror_audit_log: "{{ dhs_amwa_plant_dir }}/mirror-audit.jsonl"
 dhs_amwa_plant_mirror_status_addr: ":9101"
+# Served read-only Query API on the mirror (--serve): controllers read
+# the plant THROUGH the audited mirror. Empty string disables the
+# served face (unit then runs the plain one-way bridge).
+dhs_amwa_plant_mirror_serve: ":8335"
 dhs_amwa_plant_registry_page_limit: 1000
 # Heartbeat GC window. IS-04 §6.1 defaults to 12s and makes it
 # configurable; the CONFORMANCE plant runs 30s, matched by the AMWA

--- a/ansible/roles/dhs_amwa_plant/templates/dhs-nmos-mirror.service.j2
+++ b/ansible/roles/dhs_amwa_plant/templates/dhs-nmos-mirror.service.j2
@@ -9,6 +9,9 @@ Type=simple
 ExecStart={{ dhs_amwa_plant_bin }} registry nmos mirror \
   --source {{ dhs_amwa_plant_mirror_source }} \
   --target {{ dhs_amwa_plant_mirror_target }} \
+{% if dhs_amwa_plant_mirror_serve | default('') | length > 0 %}
+  --serve {{ dhs_amwa_plant_mirror_serve }} \
+{% endif %}
   --audit-log {{ dhs_amwa_plant_mirror_audit_log }} \
   --status-addr {{ dhs_amwa_plant_mirror_status_addr }}
 Restart=on-failure

--- a/cmd/dhs/cmd_nmos.go
+++ b/cmd/dhs/cmd_nmos.go
@@ -749,7 +749,13 @@ Bridges one Registry into another: subscribes to every collection on
 the source's Query-WS (controller role) and forwards each change to
 the target's Registration API (node role), proxying one heartbeat per
 source node. Use case: dhs Registry as the plant's source of truth
-feeding a controller vendor's own registry.`)
+feeding a controller vendor's own registry.
+
+With --serve ADDR the mirror also serves the mirrored catalogue as a
+read-only IS-04 Query API (REST + WebSocket subscriptions), so a
+controller reads the plant THROUGH the audited mirror. Served reads,
+WS subscription opens/closes, and refused registration attempts all
+land in the same --audit-log trail and /status.json counters.`)
 }
 
 // runNMOSRegistryMirror bridges a source Registry into a target one.
@@ -765,6 +771,11 @@ func runNMOSRegistryMirror(ctx context.Context, args []string) error {
 	statusAddr := fs.String("status-addr", "",
 		"serve /status.json (counters, per-collection cache sizes for parity "+
 			"checks, recent audit ring) on this address, e.g. :9101")
+	serveAddr := fs.String("serve", "",
+		"serve the mirrored catalogue as a read-only IS-04 Query API "+
+			"(REST + WS subscriptions) on this address, e.g. :8335 — "+
+			"controllers read the plant THROUGH the audited mirror; "+
+			"registration attempts are refused and audited")
 	if err := parseVerbFlags(fs, args); err != nil {
 		return err
 	}
@@ -775,11 +786,15 @@ func runNMOSRegistryMirror(ctx context.Context, args []string) error {
 		Logger:     slog.Default(),
 		AuditPath:  *auditLog,
 		StatusAddr: *statusAddr,
+		ServeAddr:  *serveAddr,
 	})
 	if err != nil {
 		return fmt.Errorf("nmos mirror: %w", err)
 	}
 	fmt.Printf("Mirroring %s -> %s. Interrupt to stop.\n", *source, *targetURL)
+	if *serveAddr != "" {
+		fmt.Printf("Serving the mirrored Query API on %s.\n", *serveAddr)
+	}
 	err = m.Run(ctx)
 	st := m.Stats()
 	fmt.Fprintf(os.Stderr, "forwarded=%d deleted=%d heartbeats=%d resyncs=%d failures=%d\n",

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -330,6 +330,8 @@ Usage of mirror:
     	IS-04 wire version used on both faces (default v1.3)
   -audit-log string
     	append one JSONL observation per external-registry behaviour (refused forwards with the target's own words, evictions, WS drops) — the evidence trail for auditing the registry on the far side
+  -serve string
+    	serve the mirrored catalogue as a read-only IS-04 Query API (REST + WS subscriptions) on this address, e.g. :8335 — controllers read the plant THROUGH the audited mirror; registration attempts are refused and audited
   -source string
     	source Registry origin (http://host:port) — Query API side
   -status-addr string

--- a/internal/amwa/registry/mirror.go
+++ b/internal/amwa/registry/mirror.go
@@ -82,6 +82,12 @@ type MirrorOptions struct {
 	// StatusAddr, when set, serves /status.json — counters, cache
 	// parity data and the recent audit ring.
 	StatusAddr string
+	// ServeAddr, when set, serves the mirrored catalogue as a
+	// read-only IS-04 Query API (REST + WS subscriptions) on this
+	// address, so a controller reads the plant THROUGH the audited
+	// mirror (mirror_serve.go). Empty disables the served face —
+	// pre-#940 behaviour unchanged.
+	ServeAddr string
 }
 
 // MirrorStats is a snapshot of forward counters. JSON names are the
@@ -92,6 +98,12 @@ type MirrorStats struct {
 	Heartbeats uint64 `json:"heartbeats"` // health POSTs accepted by the target
 	Resyncs    uint64 `json:"resyncs"`    // full re-registrations (target 404 recovery)
 	Failures   uint64 `json:"failures"`   // requests the target refused
+
+	// Served Query face counters (--serve, mirror_serve.go). Zero when
+	// serving is disabled.
+	ServedQueries uint64 `json:"served_queries"` // REST requests answered on the served Query API
+	ServedWSSubs  uint64 `json:"served_ws_subs"` // WS subscription sockets opened by consumers
+	ServedRejects uint64 `json:"served_rejects"` // write attempts refused (the mirror serves Query only)
 }
 
 // Mirror bridges one source Registry into one target Registry.
@@ -114,6 +126,16 @@ type Mirror struct {
 	// (Cerebrum answers 400, not 404, to a missing parent reference).
 	// Non-nil while a resync is pending. Guarded by mu.
 	resyncTimer *time.Timer
+
+	// serve is the embedded read-only Query face (mirror_serve.go);
+	// nil when opts.ServeAddr is empty. Assigned once in Run before the
+	// watch goroutines start, immutable after.
+	serve *mirrorServe
+	// serveReplayTimer debounces the ordered replay of the cache into
+	// the embedded store — the served-face twin of resyncTimer, fired
+	// when a grain row's parent has not landed in the store yet (the
+	// six topic streams race). Guarded by mu.
+	serveReplayTimer *time.Timer
 
 	// audit is the observation sink (mirror_audit.go); started stamps
 	// the uptime the status endpoint reports.
@@ -188,6 +210,13 @@ func (m *Mirror) Run(ctx context.Context) error {
 	if m.opts.StatusAddr != "" {
 		go m.serveStatus(ctx, m.opts.StatusAddr)
 	}
+	if m.opts.ServeAddr != "" {
+		// Started before the watch goroutines so forwardRow always sees
+		// a fully-built embedded store.
+		if err := m.startServe(ctx); err != nil {
+			return err
+		}
+	}
 
 	var wg sync.WaitGroup
 	for _, topic := range mirrorTopics {
@@ -209,6 +238,10 @@ func (m *Mirror) Run(ctx context.Context) error {
 	if m.resyncTimer != nil {
 		m.resyncTimer.Stop()
 		m.resyncTimer = nil
+	}
+	if m.serveReplayTimer != nil {
+		m.serveReplayTimer.Stop()
+		m.serveReplayTimer = nil
 	}
 	m.mu.Unlock()
 	return ctx.Err()
@@ -251,6 +284,7 @@ func (m *Mirror) forwardRow(ctx context.Context, topic string, row is04.GrainDat
 		m.mu.Lock()
 		m.cache[topic][row.Path] = row.Post
 		m.mu.Unlock()
+		m.applyServeRow(topic, row, true)
 		// Live path: a 400 here means a parent has not been forwarded
 		// yet (the six topics stream concurrently), so allow it to
 		// trigger an ordered resync.
@@ -259,6 +293,7 @@ func (m *Mirror) forwardRow(ctx context.Context, topic string, row is04.GrainDat
 		m.mu.Lock()
 		delete(m.cache[topic], row.Path)
 		m.mu.Unlock()
+		m.applyServeRow(topic, row, true)
 		m.deleteResource(ctx, topic, row.Path)
 	default:
 		m.logger.Warn("registry/mirror: grain row with neither pre nor post", "topic", topic, "id", row.Path)
@@ -448,6 +483,10 @@ func (m *Mirror) resync(ctx context.Context) {
 			m.postResource(ctx, topic, doc, false)
 		}
 	}
+	// The served face is fed from the same authoritative cache, so a
+	// full resync repopulates it too — an eviction-recovery pass must
+	// leave both downstream copies (target AND embedded store) whole.
+	m.serveReplay()
 }
 
 // nodeIDs snapshots the cached source node ids.

--- a/internal/amwa/registry/mirror_audit.go
+++ b/internal/amwa/registry/mirror_audit.go
@@ -97,7 +97,10 @@ type mirrorStatus struct {
 	UptimeSec   int64          `json:"uptime_sec"`
 	Stats       MirrorStats    `json:"stats"`
 	CacheCounts map[string]int `json:"cache_counts"`
-	RecentAudit []AuditEvent   `json:"recent_audit"`
+	// ServeAddr is the served read-only Query face's bound address
+	// (--serve, mirror_serve.go); absent when serving is disabled.
+	ServeAddr   string       `json:"serve_addr,omitempty"`
+	RecentAudit []AuditEvent `json:"recent_audit"`
 }
 
 // serveStatus runs the status endpoint until ctx ends.
@@ -116,6 +119,9 @@ func (m *Mirror) serveStatus(ctx context.Context, addr string) {
 			UptimeSec:   int64(time.Since(m.started).Seconds()),
 			Stats:       m.stats,
 			CacheCounts: counts,
+		}
+		if m.serve != nil {
+			st.ServeAddr = m.serve.addr
 		}
 		m.mu.Unlock()
 		st.RecentAudit = m.audit.recent()

--- a/internal/amwa/registry/mirror_serve.go
+++ b/internal/amwa/registry/mirror_serve.go
@@ -1,0 +1,328 @@
+package registry
+
+// The mirror's SERVED Query face (--serve, issue #940).
+//
+// A mirror without this face is a one-way pump: it audits the source
+// but a controller still has to read the plant from a registry the
+// audit does not cover. With --serve the mirror feeds an EMBEDDED
+// registry store from its source Query-WS stream and serves the full
+// IS-04 Query API (REST + WebSocket subscriptions) from that store —
+// the controller reads the plant THROUGH the audited path.
+//
+// Reuse over reimplementation: the served surface is the SAME code the
+// standalone Registry runs — Store, installQueryRoutes, and
+// SubscriptionManager. Rows are written through
+// Store.IngestRegistrationVersioned / Store.DeleteResource, exactly
+// the functions the Registration API handlers call, so mirror-driven
+// updates fan out to WS subscribers via the same Store listener →
+// SubscriptionManager.onChange → grain path registration-driven ones
+// do. Nothing here is a hand-written Query subset.
+//
+// The one face NOT mounted is the Registration API: a controller must
+// not register INTO the mirror. Any request under /x-nmos/registration
+// answers 501 with an explanation and lands a mirror_write_rejected
+// audit event.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	stdhttp "net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"dhs/internal/amwa/codec/is04"
+	httpsession "dhs/internal/amwa/session/http"
+)
+
+// mirrorServe is the embedded Query face's immutable wiring — built
+// once by startServe before the watch goroutines run.
+type mirrorServe struct {
+	store *Store
+	// addr is the actual bound address (":0" resolved), so tests and
+	// operators can find the served face.
+	addr string
+}
+
+// ServeAddr returns the served Query face's bound listen address, or
+// "" while serving is disabled or not yet started.
+func (m *Mirror) ServeAddr() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.serve == nil {
+		return ""
+	}
+	return m.serve.addr
+}
+
+// startServe binds opts.ServeAddr, mounts the Query API for every
+// registered IS-04 minor (same version fan-out as Registry.Serve) on
+// an embedded Store, and serves until ctx ends. A bind failure is the
+// operator's problem to see, not to discover later — it fails Run.
+func (m *Mirror) startServe(ctx context.Context) error {
+	ln, err := net.Listen("tcp", m.opts.ServeAddr)
+	if err != nil {
+		return fmt.Errorf("registry/mirror: serve listen %s: %w", m.opts.ServeAddr, err)
+	}
+	advertise := serveAdvertise(ln.Addr())
+	store := NewStore()
+	apiVers := pickAPIVersions("")
+	srv := httpsession.NewServer(m.logger)
+	wsPrefixes := make([]string, 0, len(apiVers))
+	upgradeHandlers := make(map[string]stdhttp.HandlerFunc, len(apiVers))
+	for _, apiVer := range apiVers {
+		queryBase := "/x-nmos/query/" + apiVer
+		mgr := NewSubscriptionManager(m.logger, store, advertise, apiVer)
+		mgr.setWSLifecycleHooks(m.serveWSOpened, m.serveWSClosed)
+		installQueryRoutes(srv, store, mgr, queryBase, apiVer)
+		wsPrefix := queryBase + "/subscriptions/"
+		wsPrefixes = append(wsPrefixes, wsPrefix)
+		upgradeHandlers[wsPrefix] = mgr.UpgradeHandler(queryBase)
+	}
+	installMirrorServeRoots(srv, apiVers)
+	routeTable := srv.MuxHandler()
+
+	// Same dispatcher shape as Registry.Serve (WS upgrades hijack the
+	// connection, so they bypass the route table), plus two mirror-only
+	// concerns: the registration block and the per-request audit.
+	dispatcher := stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, req *stdhttp.Request) {
+		if req.URL.Path == "/x-nmos/registration" || strings.HasPrefix(req.URL.Path, "/x-nmos/registration/") {
+			m.serveWriteRejected(req)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(stdhttp.StatusNotImplemented)
+			_ = json.NewEncoder(w).Encode(httpsession.ErrorBody{
+				Code: stdhttp.StatusNotImplemented, Error: "Not Implemented",
+				Debug: "read-only mirror: this Query API reflects " + m.opts.Source +
+					" — register with the source registry, not the mirror",
+			})
+			return
+		}
+		if strings.HasSuffix(req.URL.Path, "/ws") {
+			for _, prefix := range wsPrefixes {
+				if strings.HasPrefix(req.URL.Path, prefix) {
+					// Audited as serve_ws_subscribe/serve_ws_close via
+					// the lifecycle hooks, not as serve_query — and the
+					// upgrade must see the raw hijackable writer.
+					upgradeHandlers[prefix](w, req)
+					return
+				}
+			}
+		}
+		rec := &serveStatusRecorder{ResponseWriter: w, status: stdhttp.StatusOK}
+		routeTable.ServeHTTP(rec, req)
+		m.serveQueryAnswered(req, rec.status)
+	})
+
+	m.mu.Lock()
+	m.serve = &mirrorServe{store: store, addr: ln.Addr().String()}
+	m.mu.Unlock()
+
+	httpSrv := &stdhttp.Server{Handler: dispatcher, ReadHeaderTimeout: 5 * time.Second}
+	go func() {
+		<-ctx.Done()
+		shutCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = httpSrv.Shutdown(shutCtx)
+	}()
+	go func() {
+		if err := httpSrv.Serve(ln); err != nil && err != stdhttp.ErrServerClosed {
+			m.logger.Warn("registry/mirror: served query face failed", "addr", ln.Addr().String(), "err", err)
+		}
+	}()
+	m.logger.Info("registry/mirror: serving mirrored Query API",
+		"addr", ln.Addr().String(), "api_vers", apiVers)
+	return nil
+}
+
+// serveAdvertise derives the host:port minted into ws_href. A bind on
+// a concrete IP advertises that IP; an unspecified bind (":8335")
+// advertises the OS hostname — the same fallback the Registry uses.
+func serveAdvertise(addr net.Addr) string {
+	host, port, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		return addr.String()
+	}
+	if ip := net.ParseIP(host); host == "" || (ip != nil && ip.IsUnspecified()) {
+		host = osHostname()
+	}
+	return net.JoinHostPort(host, port)
+}
+
+// installMirrorServeRoots is installAPIRootRoutes minus the
+// registration face: the discovery roots list "query/" only, so a
+// walking client never learns of a registration URL the mirror would
+// refuse anyway.
+func installMirrorServeRoots(srv *httpsession.Server, apiVers []string) {
+	versionList := make([]string, 0, len(apiVers))
+	for _, v := range apiVers {
+		versionList = append(versionList, v+"/")
+	}
+	rootHandler := func(ctx context.Context, r *stdhttp.Request) (int, any, error) {
+		return 0, []string{"query/"}, nil
+	}
+	srv.Handle(stdhttp.MethodGet, "/x-nmos", rootHandler)
+	srv.Handle(stdhttp.MethodGet, "/x-nmos/", rootHandler)
+	queryHandler := func(ctx context.Context, r *stdhttp.Request) (int, any, error) {
+		return 0, versionList, nil
+	}
+	srv.Handle(stdhttp.MethodGet, "/x-nmos/query", queryHandler)
+	srv.Handle(stdhttp.MethodGet, "/x-nmos/query/", queryHandler)
+}
+
+// serveStatusRecorder captures the status code the route table wrote
+// so the audit event can report it. Plain REST responses only — WS
+// upgrades never pass through it, so no Hijacker forwarding is needed.
+type serveStatusRecorder struct {
+	stdhttp.ResponseWriter
+	status int
+}
+
+func (r *serveStatusRecorder) WriteHeader(status int) {
+	r.status = status
+	r.ResponseWriter.WriteHeader(status)
+}
+
+// serveQueryAnswered lands the per-REST-request audit event + counter.
+func (m *Mirror) serveQueryAnswered(req *stdhttp.Request, status int) {
+	m.mu.Lock()
+	m.stats.ServedQueries++
+	m.mu.Unlock()
+	m.audit.event("serve_query", map[string]any{
+		"method": req.Method, "path": req.URL.Path,
+		"remote": req.RemoteAddr, "status": status,
+	})
+}
+
+// serveWSOpened / serveWSClosed are the SubscriptionManager lifecycle
+// hooks — one audit event per subscriber socket, each direction.
+func (m *Mirror) serveWSOpened(resourcePath, remote string) {
+	m.mu.Lock()
+	m.stats.ServedWSSubs++
+	m.mu.Unlock()
+	m.audit.event("serve_ws_subscribe", map[string]any{"topic": resourcePath, "remote": remote})
+}
+
+func (m *Mirror) serveWSClosed(resourcePath, remote string) {
+	m.audit.event("serve_ws_close", map[string]any{"topic": resourcePath, "remote": remote})
+}
+
+// serveWriteRejected records a refused registration attempt against
+// the read-only face.
+func (m *Mirror) serveWriteRejected(req *stdhttp.Request) {
+	m.mu.Lock()
+	m.stats.ServedRejects++
+	m.mu.Unlock()
+	m.audit.event("mirror_write_rejected", map[string]any{
+		"method": req.Method, "path": req.URL.Path, "remote": req.RemoteAddr,
+	})
+}
+
+// applyServeRow writes one grain row through to the embedded store —
+// the same ingest/delete functions the Registration API handlers use,
+// so the store fans the change out to WS subscribers as grains.
+//
+// allowReplay gates the parent-ordering recovery: the six topic
+// streams race, so a device can reach the store before its node; a
+// debounced ordered replay of the cache repairs that. The replay pass
+// itself runs with allowReplay=false — in dependency order a failure
+// is a genuine reject, and rescheduling would loop forever.
+func (m *Mirror) applyServeRow(topic string, row is04.GrainDataRow, allowReplay bool) {
+	if m.serve == nil {
+		return
+	}
+	t, ok := singularFromPlural(topic)
+	if !ok {
+		m.logger.Warn("registry/mirror: serve: unknown topic", "topic", topic)
+		return
+	}
+	switch row.Kind() {
+	case is04.ChangeAdded, is04.ChangeModified:
+		env := &is04.RegistrationRequest{Type: t, Data: row.Post}
+		if err := m.serve.store.IngestRegistrationVersioned(env, m.opts.APIVer); err != nil {
+			m.logger.Warn("registry/mirror: serve: store ingest failed",
+				"topic", topic, "id", row.Path, "err", err)
+			if allowReplay {
+				m.scheduleServeReplay()
+			}
+		}
+	case is04.ChangeRemoved:
+		// ErrNotFound is fine: a node delete cascades in the store, so
+		// the source's follow-up child-removal rows find nothing left.
+		if err := m.serve.store.DeleteResource(t, row.Path); err != nil && !errors.Is(err, ErrNotFound) {
+			m.logger.Warn("registry/mirror: serve: store delete failed",
+				"topic", topic, "id", row.Path, "err", err)
+		}
+	}
+}
+
+// scheduleServeReplay arms (or extends) the debounced ordered replay —
+// the embedded-store twin of scheduleResync.
+func (m *Mirror) scheduleServeReplay() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.runCtx == nil {
+		return
+	}
+	if m.serveReplayTimer != nil {
+		m.serveReplayTimer.Reset(mirrorResyncDebounce)
+		return
+	}
+	m.serveReplayTimer = time.AfterFunc(mirrorResyncDebounce, func() {
+		m.mu.Lock()
+		m.serveReplayTimer = nil
+		rctx := m.runCtx
+		m.mu.Unlock()
+		if rctx != nil && rctx.Err() == nil {
+			m.serveReplay()
+		}
+	})
+}
+
+// serveReplay re-applies the whole cache to the embedded store in
+// dependency order (node → device → source → flow → sender →
+// receiver), so every parent precedes its children. Re-ingesting an
+// unchanged resource is an idempotent update; subscribers may see a
+// same-body modified grain on a replay, which is the honest rendering
+// of "the mirror re-asserted its copy".
+func (m *Mirror) serveReplay() {
+	if m.serve == nil {
+		return
+	}
+	m.mu.Lock()
+	snapshot := make(map[string][]json.RawMessage, len(mirrorTopics))
+	for _, topic := range mirrorTopics {
+		docs := make([]json.RawMessage, 0, len(m.cache[topic]))
+		for _, id := range sortedKeys(m.cache[topic]) {
+			docs = append(docs, m.cache[topic][id])
+		}
+		snapshot[topic] = docs
+	}
+	m.mu.Unlock()
+	for _, topic := range mirrorTopics {
+		t, ok := singularFromPlural(topic)
+		if !ok {
+			continue
+		}
+		for _, doc := range snapshot[topic] {
+			env := &is04.RegistrationRequest{Type: t, Data: doc}
+			if err := m.serve.store.IngestRegistrationVersioned(env, m.opts.APIVer); err != nil {
+				m.logger.Warn("registry/mirror: serve: replay ingest failed",
+					"topic", topic, "err", err)
+			}
+		}
+	}
+}
+
+// sortedKeys returns the map's keys in ascending order — deterministic
+// replay order for tests + logs, same reason resync sorts.
+func sortedKeys(docs map[string]json.RawMessage) []string {
+	ids := make([]string, 0, len(docs))
+	for id := range docs {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}

--- a/internal/amwa/registry/mirror_serve_test.go
+++ b/internal/amwa/registry/mirror_serve_test.go
@@ -1,0 +1,323 @@
+package registry
+
+// Served Query face tests (--serve, issue #940): the mirror is fed
+// grains from a fake source and must answer as a read-only Registry —
+// REST reads, WS subscription grains on later updates, refused
+// registrations — with every served interaction landing in the audit
+// ring. The consumer side is exercised through the real
+// session/query client, the same code `dhs consumer nmos watch` runs.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"dhs/internal/amwa/codec/is04"
+	amwahttp "dhs/internal/amwa/session/http"
+	"dhs/internal/amwa/session/query"
+)
+
+// pushSource is a fake source Registry whose per-topic Query-WS frames
+// are pushed on demand — the serve tests need a row to arrive AFTER a
+// subscriber connected to the mirror's served face, which the
+// send-everything-up-front sourceHandler cannot stage.
+type pushSource struct {
+	ch map[string]chan []byte
+}
+
+func newPushSource() *pushSource {
+	p := &pushSource{ch: make(map[string]chan []byte, len(mirrorTopics))}
+	for _, tp := range mirrorTopics {
+		p.ch[tp] = make(chan []byte, 16)
+	}
+	return p
+}
+
+func (p *pushSource) push(topic string, frame []byte) { p.ch[topic] <- frame }
+
+func (p *pushSource) handler(t *testing.T, srvURL func() string) stdhttp.Handler {
+	t.Helper()
+	return stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		switch {
+		case r.Method == stdhttp.MethodPost && strings.HasSuffix(r.URL.Path, "/subscriptions"):
+			var req struct {
+				ResourcePath string `json:"resource_path"`
+			}
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &req)
+			topic := strings.Trim(req.ResourcePath, "/")
+			ws := strings.Replace(srvURL(), "http://", "ws://", 1) + "/ws/" + topic
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(stdhttp.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":"sub-` + topic + `","ws_href":"` + ws + `","resource_path":"/` + topic + `"}`))
+		case strings.HasPrefix(r.URL.Path, "/ws/"):
+			topic := strings.TrimPrefix(r.URL.Path, "/ws/")
+			ws, err := amwahttp.AcceptWebSocket(w, r)
+			if err != nil {
+				t.Logf("accept ws (teardown race?): %v", err)
+				return
+			}
+			// The reader goroutine notices the mirror closing its socket
+			// (test teardown) so this handler returns and the httptest
+			// server's Close is never left waiting on it.
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				for {
+					if _, err := ws.ReadText(); err != nil {
+						return
+					}
+				}
+			}()
+			for {
+				select {
+				case f := <-p.ch[topic]:
+					if err := ws.SendText(f); err != nil {
+						return
+					}
+				case <-done:
+					return
+				}
+			}
+		default:
+			w.WriteHeader(stdhttp.StatusNotFound)
+		}
+	})
+}
+
+// startServedMirror boots a mirror with a served face against a push
+// source + recording target and waits for the serve listener to bind.
+func startServedMirror(t *testing.T) (*Mirror, *pushSource, context.CancelFunc) {
+	t.Helper()
+	plant := &fakePlant{}
+	target := httptest.NewServer(plant.targetHandler())
+	t.Cleanup(target.Close)
+	push := newPushSource()
+	src := httptest.NewServer(stdhttp.NotFoundHandler())
+	src.Config.Handler = push.handler(t, func() string { return src.URL })
+	t.Cleanup(src.Close)
+
+	m, err := NewMirror(MirrorOptions{
+		Source: src.URL, Target: target.URL, APIVer: "v1.3",
+		ServeAddr: "127.0.0.1:0",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel BEFORE the httptest servers close (t.Cleanup is LIFO) so
+	// the mirror's sockets drop first and no source handler lingers.
+	t.Cleanup(cancel)
+	go func() { _ = m.Run(ctx) }()
+	waitFor(t, 5*time.Second, func() bool { return m.ServeAddr() != "" }, "served face to bind")
+	return m, push, cancel
+}
+
+// auditKinds snapshots the kinds in the mirror's in-memory audit ring.
+func auditKinds(m *Mirror) []string {
+	m.mu.Lock()
+	a := m.audit
+	m.mu.Unlock()
+	evs := a.recent()
+	out := make([]string, 0, len(evs))
+	for _, ev := range evs {
+		out = append(out, ev.Kind)
+	}
+	return out
+}
+
+func hasKind(kinds []string, want string) bool {
+	for _, k := range kinds {
+		if k == want {
+			return true
+		}
+	}
+	return false
+}
+
+// getBody GETs url and returns (status, body).
+func getBody(t *testing.T, url string) (int, []byte) {
+	t.Helper()
+	resp, err := stdhttp.Get(url)
+	if err != nil {
+		return 0, nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, body
+}
+
+// TestMirrorServeQueryFace: mirrored rows are readable on the served
+// Query API; the device arrives BEFORE its parent node to force the
+// ordered store replay; a removed row disappears; served reads land
+// serve_query audit events + counters.
+func TestMirrorServeQueryFace(t *testing.T) {
+	m, push, _ := startServedMirror(t)
+	base := "http://" + m.ServeAddr()
+
+	const nodeID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+	const devID = "12345678-1234-4abc-9def-1234567890ab"
+	nodeDoc, _ := json.Marshal(validNode(nodeID))
+	devDoc, _ := json.Marshal(validDevice(devID, nodeID))
+
+	// Device first: its store ingest fails (parent node not landed) and
+	// must be repaired by the debounced dependency-ordered replay.
+	push.push("devices", grainFrame("devices", devID, "", string(devDoc)))
+	push.push("nodes", grainFrame("nodes", nodeID, "", string(nodeDoc)))
+
+	waitFor(t, 5*time.Second, func() bool {
+		status, body := getBody(t, base+"/x-nmos/query/v1.3/nodes")
+		return status == 200 && strings.Contains(string(body), nodeID)
+	}, "mirrored node on the served Query API")
+	waitFor(t, 5*time.Second, func() bool {
+		status, body := getBody(t, base+"/x-nmos/query/v1.3/devices")
+		return status == 200 && strings.Contains(string(body), devID)
+	}, "mirrored device (via ordered replay) on the served Query API")
+
+	// Removed row → resource gone from the served face.
+	push.push("devices", grainFrame("devices", devID, string(devDoc), ""))
+	waitFor(t, 5*time.Second, func() bool {
+		status, body := getBody(t, base+"/x-nmos/query/v1.3/devices")
+		return status == 200 && !strings.Contains(string(body), devID)
+	}, "deleted device to vanish from the served Query API")
+
+	if !hasKind(auditKinds(m), "serve_query") {
+		t.Errorf("audit ring missing serve_query: %v", auditKinds(m))
+	}
+	if st := m.Stats(); st.ServedQueries == 0 {
+		t.Errorf("stats.ServedQueries = 0, want > 0 (%+v)", st)
+	}
+}
+
+// TestMirrorServeWSSubscription: a Query-WS subscriber on the served
+// face gets the sync grain, then a live grain when a mirrored row
+// updates AFTER the subscription — proof mirror-driven store writes
+// drive the same fan-out registration-driven ones do. Open + close
+// land serve_ws_subscribe / serve_ws_close audit events.
+func TestMirrorServeWSSubscription(t *testing.T) {
+	m, push, _ := startServedMirror(t)
+	base := "http://" + m.ServeAddr()
+
+	const nodeID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+	node := validNode(nodeID)
+	nodeDoc, _ := json.Marshal(node)
+	push.push("nodes", grainFrame("nodes", nodeID, "", string(nodeDoc)))
+	waitFor(t, 5*time.Second, func() bool {
+		status, body := getBody(t, base+"/x-nmos/query/v1.3/nodes")
+		return status == 200 && strings.Contains(string(body), nodeID)
+	}, "mirrored node before subscribing")
+
+	codec, ok := is04.Get("v1.3")
+	if !ok {
+		t.Fatal("v1.3 codec not registered")
+	}
+	qc, err := query.NewClient(base, codec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sub, err := qc.Subscribe(ctx, query.SubscribeRequest{ResourcePath: "/nodes"})
+	if err != nil {
+		t.Fatalf("subscribe on served face: %v", err)
+	}
+
+	var mu sync.Mutex
+	var frames []string
+	watchCtx, watchCancel := context.WithCancel(ctx)
+	watchDone := make(chan struct{})
+	go func() {
+		defer close(watchDone)
+		_ = query.Watch(watchCtx, sub.WSHref, func(g *is04.Grain) error {
+			raw, _ := json.Marshal(g)
+			mu.Lock()
+			frames = append(frames, string(raw))
+			mu.Unlock()
+			return nil
+		}, query.WatchOptions{})
+	}()
+
+	// Sync grain first — the pre-subscription catalogue.
+	waitFor(t, 5*time.Second, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, f := range frames {
+			if strings.Contains(f, nodeID) {
+				return true
+			}
+		}
+		return false
+	}, "sync grain for the mirrored node")
+
+	// Update AFTER subscribing — must arrive as a live grain.
+	renamed := node
+	renamed.Label = "renamed-after-subscribe"
+	renamedDoc, _ := json.Marshal(renamed)
+	push.push("nodes", grainFrame("nodes", nodeID, string(nodeDoc), string(renamedDoc)))
+	waitFor(t, 5*time.Second, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, f := range frames {
+			if strings.Contains(f, "renamed-after-subscribe") {
+				return true
+			}
+		}
+		return false
+	}, "live grain for the post-subscription update")
+
+	if !hasKind(auditKinds(m), "serve_ws_subscribe") {
+		t.Errorf("audit ring missing serve_ws_subscribe: %v", auditKinds(m))
+	}
+	if st := m.Stats(); st.ServedWSSubs == 0 {
+		t.Errorf("stats.ServedWSSubs = 0, want > 0 (%+v)", st)
+	}
+
+	// Close the consumer socket — the served face must audit the close.
+	watchCancel()
+	<-watchDone
+	waitFor(t, 5*time.Second, func() bool {
+		return hasKind(auditKinds(m), "serve_ws_close")
+	}, "serve_ws_close audit event")
+}
+
+// TestMirrorServeRejectsRegistration: the served face is Query-only —
+// a registration attempt answers 501 with an operator-readable body,
+// lands mirror_write_rejected in the audit ring, and the discovery
+// root never advertises a registration face.
+func TestMirrorServeRejectsRegistration(t *testing.T) {
+	m, _, _ := startServedMirror(t)
+	base := "http://" + m.ServeAddr()
+
+	env := []byte(`{"type":"node","data":{"id":"f47ac10b-58cc-4372-a567-0e02b2c3d479"}}`)
+	resp, err := stdhttp.Post(base+"/x-nmos/registration/v1.3/resource", "application/json", bytes.NewReader(env))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != stdhttp.StatusNotImplemented {
+		t.Fatalf("registration POST status = %d, want 501 (%s)", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), "read-only mirror") {
+		t.Errorf("rejection body should say why: %s", body)
+	}
+	if !hasKind(auditKinds(m), "mirror_write_rejected") {
+		t.Errorf("audit ring missing mirror_write_rejected: %v", auditKinds(m))
+	}
+	if st := m.Stats(); st.ServedRejects == 0 {
+		t.Errorf("stats.ServedRejects = 0, want > 0 (%+v)", st)
+	}
+
+	// Discovery root lists the query face only.
+	status, rootBody := getBody(t, base+"/x-nmos")
+	if status != 200 || !strings.Contains(string(rootBody), "query/") || strings.Contains(string(rootBody), "registration/") {
+		t.Errorf("/x-nmos = %d %s, want query/ only", status, rootBody)
+	}
+}

--- a/internal/amwa/registry/subscriptions.go
+++ b/internal/amwa/registry/subscriptions.go
@@ -132,6 +132,10 @@ type subscription struct {
 	ws      *httpsession.WebSocket
 	source  string // sub UUID echoed in grain.source_id
 	closeCh chan struct{}
+	// remote is the subscriber's RemoteAddr, captured at upgrade time so
+	// the close-side lifecycle hook can name who disconnected after the
+	// socket (and its request) are gone.
+	remote string
 
 	// bufMu guards the change-aggregation buffer below. IS-04 lets a
 	// grain carry many changes, and max_update_rate_ms is the window we
@@ -160,6 +164,22 @@ type SubscriptionManager struct {
 
 	mu   sync.Mutex
 	subs map[string]*subscription
+
+	// onWSOpen / onWSClose are optional subscriber-socket lifecycle
+	// hooks. The mirror's served Query face uses them to land one audit
+	// event per WS open/close in its JSONL trail; the plain Registry
+	// leaves them nil. Installed via setWSLifecycleHooks before the
+	// manager accepts traffic, invoked outside the manager's lock.
+	onWSOpen  func(resourcePath, remote string)
+	onWSClose func(resourcePath, remote string)
+}
+
+// setWSLifecycleHooks installs the WS open/close callbacks. Must be
+// called before the manager starts accepting upgrades — the fields are
+// read without the lock on the upgrade path.
+func (m *SubscriptionManager) setWSLifecycleHooks(open, closed func(resourcePath, remote string)) {
+	m.onWSOpen = open
+	m.onWSClose = closed
 }
 
 // NewSubscriptionManager builds the manager + wires it to the store.
@@ -411,7 +431,11 @@ func (m *SubscriptionManager) UpgradeHandler(base string) func(stdhttp.ResponseW
 		}
 		m.mu.Lock()
 		sub.ws = ws
+		sub.remote = r.RemoteAddr
 		m.mu.Unlock()
+		if m.onWSOpen != nil {
+			m.onWSOpen(sub.ResourcePath, r.RemoteAddr)
+		}
 
 		// Send the SYNC snapshot for every existing resource matching the
 		// resource_path AND the subscription params filter. SYNC has
@@ -755,6 +779,11 @@ func jsonMatchesFilter(data json.RawMessage, q map[string][]string) bool {
 }
 
 func (m *SubscriptionManager) removeSub(id string) {
+	// Close-hook state captured under the lock, invoked outside it —
+	// the hook lands an audit event and must not run into the manager's
+	// mutex from a callback.
+	var closedPath, closedRemote string
+	notifyClose := false
 	m.mu.Lock()
 	if s, ok := m.subs[id]; ok {
 		s.bufMu.Lock()
@@ -765,10 +794,17 @@ func (m *SubscriptionManager) removeSub(id string) {
 		s.bufMu.Unlock()
 		if s.ws != nil {
 			_ = s.ws.Close()
+			// Only sockets that actually opened fire the close hook, so
+			// open/close audit events always pair up.
+			notifyClose = m.onWSClose != nil
+			closedPath, closedRemote = s.ResourcePath, s.remote
 		}
 		delete(m.subs, id)
 	}
 	m.mu.Unlock()
+	if notifyClose {
+		m.onWSClose(closedPath, closedRemote)
+	}
 }
 
 // subscriptionMatches reports whether c targets the given


### PR DESCRIPTION
Closes #940 (S2 of the current board).

## What

`dhs registry nmos mirror --serve :port` — the mirror becomes an audited man-in-the-middle for reads: an external controller (Cerebrum) points its registry at the mirror and reads the plant **through** it, with every access in the audit trail.

- An embedded registry `Store` is fed by the mirror stream: every forwarded row goes through `Store.IngestRegistrationVersioned` — the same entry the Registration API uses — so Query-WS subscribers of the mirror get grains from the stock `fanOut`/`SubscriptionManager` path. Zero new grain code.
- The existing conformant Query implementation (`installQueryRoutes` + `SubscriptionManager` per registered IS-04 minor, same fan-out as `Registry.Serve`) is mounted on the serve address: REST + WS subscriptions.
- The registration face answers **501** with an operator-readable body and fires `mirror_write_rejected` — controllers read through the mirror, never into it.
- Audit: `serve_query`, `serve_ws_subscribe`, `serve_ws_close` land in the same JSONL via two nil-safe lifecycle hooks on `SubscriptionManager` (plain Registry leaves them nil). `/status.json` gains `serve_addr` and `stats.served_queries` / `served_ws_subs` / `served_rejects`.
- Rows arriving before their parent replay through a debounced dependency-ordered pass; eviction-recovery resync also repopulates the store.
- Plant: `dhs-nmos-mirror` unit gains `--serve` (default `:8335`) via `dhs_amwa_plant_mirror_serve`.

## Tests

Three new deterministic tests (`mirror_serve_test.go`): query face incl. out-of-order parent replay and delete propagation; WS subscription receiving sync + live grains through the real `session/query` client; registration rejection + audit ring contents. Existing mirror tests unchanged. Full sweep green; golangci-lint 0 issues. (`-race` runs in CI — no cgo on the dev host.)

## Live receipt (plant, 2026-09-01)

Converge `amwa-plant.yml`: failed=0. Then against the live mirror:

- `GET :8335/x-nmos/query/v1.3/nodes` → **200, 22 nodes served through the mirror**
- `POST :8335/x-nmos/registration/v1.3/resource` → **501**
- `/status.json`: `serve_addr "[::]:8335"`, `stats.served_queries 1`, `served_rejects 1`, cache 22 nodes / 242 senders
- audit JSONL tail shows the `serve_query` (with remote + status) and `mirror_write_rejected` events for exactly those probes

## Left for follow-up (deliberate)

- IS-04-03 suite window against the served face in `amwa-validate-mirror.yml` (catalog addition).
- TLS/auth on the served face (mirror has no `--auth-url` today).
- The Cerebrum-side read-through needs Cerebrum's registry setting pointed at `10.6.250.101:8335` — a Cerebrum UI change on the operator's side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
