### PR TITLE
feat(ansible): auth-mode validate windows - both modes gate every upgrade (#942)

### DIFF
--- a/ansible/playbooks/amwa-validate-node-auth.yml
+++ b/ansible/playbooks/amwa-validate-node-auth.yml
@@ -1,0 +1,17 @@
+---
+# Validate the NODE suites WITH IS-10/BCP-003-02 authorization armed
+# (issue #942): the plant residents stay disarmed — only the window's
+# transient CuT gets --auth-url, and the armed tool instance
+# (ENABLE_AUTH=True) does the scoring. Receipts follow the manual
+# sweep's <SUITE>-auth.json convention.
+#
+#   ansible-playbook -i ansible/inventory/hosts.ini ansible/playbooks/amwa-validate-node-auth.yml
+
+- name: AMWA validate — node (auth)
+  hosts: tooling
+  gather_facts: true
+  roles:
+    - role: dhs_amwa_validate
+      vars:
+        dhs_amwa_validate_scope: node
+        dhs_amwa_validate_auth_mode: true

--- a/ansible/playbooks/amwa-validate-registry-auth.yml
+++ b/ansible/playbooks/amwa-validate-registry-auth.yml
@@ -1,0 +1,18 @@
+---
+# Validate the REGISTRY (Registration + Query APIs) WITH IS-10/
+# BCP-003-02 authorization armed (issue #942): the plant registry
+# stays running and disarmed — a transient registry CuT gets
+# --auth-url, and the armed tool instance (ENABLE_AUTH=True) does the
+# scoring. Receipts follow the manual sweep's <SUITE>-auth.json
+# convention.
+#
+#   ansible-playbook -i ansible/inventory/hosts.ini ansible/playbooks/amwa-validate-registry-auth.yml
+
+- name: AMWA validate — registry (auth)
+  hosts: tooling
+  gather_facts: true
+  roles:
+    - role: dhs_amwa_validate
+      vars:
+        dhs_amwa_validate_scope: registry
+        dhs_amwa_validate_auth_mode: true

--- a/ansible/playbooks/amwa-validate.yml
+++ b/ansible/playbooks/amwa-validate.yml
@@ -1,7 +1,8 @@
 ---
 # The whole AMWA conformance gate — every role, in dependency order
 # (registry before node: node suites assume a serving plant registry;
-# mirror last: it asserts on what the earlier plays left running).
+# mirror after the resident scopes: it asserts on what those plays
+# left running; the IS-10 auth twins close the gate).
 #
 #   ansible-playbook -i ansible/inventory/hosts.ini ansible/playbooks/amwa-validate.yml
 
@@ -9,3 +10,9 @@
 - import_playbook: amwa-validate-node.yml
 - import_playbook: amwa-validate-controller.yml
 - import_playbook: amwa-validate-mirror.yml
+# Auth windows LAST (issue #942): prove the plain gate first, then the
+# armed one — every upgrade passes both WITHOUT and WITH IS-10. Mirror
+# stays before them: it asserts on what the resident plays leave
+# running, and the auth plays only add transients they tear down.
+- import_playbook: amwa-validate-registry-auth.yml
+- import_playbook: amwa-validate-node-auth.yml

--- a/ansible/roles/dhs_amwa_validate/defaults/main.yml
+++ b/ansible/roles/dhs_amwa_validate/defaults/main.yml
@@ -206,12 +206,16 @@ dhs_amwa_validate_suites:
   # here in git).
   - { id: IS-05-01, scope: node, target: cut, window: p2p, auth: true,
       rows: [{ver: v1.2}], baseline_pass: 0, baseline_cnt: 0 }
-  # baseline_cnt 2 inherited from the non-auth twin: auto_registration
-  # 5/6 are structurally untestable for ANY implementation (RAML id
-  # substitution — see the registry-scope entry above), and arming
-  # auth does not change that.
+  # Armed baselines from the 2026-09-01 first fleet run: pass=79
+  # fail=0. cnt 11 = the non-auth twin's structural pair
+  # (auto_registration 5/6, RAML id substitution) PLUS nine
+  # "No resources found" rows: the transient armed registry is EMPTY
+  # by design — it announces at dev pri 100 and plant nodes hold no
+  # tokens, so nothing registers into it. Registering a token-bearing
+  # transient node into the armed window (shrinking these CNTs) is
+  # the named follow-up in #942.
   - { id: IS-04-02, scope: registry, target: registry, window: registry, auth: true,
-      rows: [{ver: v1.3}, {ver: v1.3}], baseline_pass: 0, baseline_cnt: 2 }
+      rows: [{ver: v1.3}, {ver: v1.3}], baseline_pass: 79, baseline_cnt: 11 }
 
   # ---- controller scope: needs the controller facade (issue backlog,
   # user-owned item #7) — listed so the report says "not automatable

--- a/ansible/roles/dhs_amwa_validate/defaults/main.yml
+++ b/ansible/roles/dhs_amwa_validate/defaults/main.yml
@@ -55,11 +55,47 @@ dhs_amwa_validate_isolated_net: dhs-validate-mdns
 dhs_amwa_validate_isolated_tool: nmos-testing-validate
 dhs_amwa_validate_isolated_tool_port: 5001
 
+# Auth-mode windows (issue #942): every upgrade is proven WITHOUT and
+# WITH IS-10/BCP-003-02 authorization. A THIRD tool instance carries
+# the armed profile — the resident tool stays auth-DISARMED (preflight
+# asserts it), because flipping ENABLE_AUTH on the shared arbiter
+# mid-gate would change the exam for the suites around it.
+#
+# The armed instance runs on HOST networking like the resident: the
+# tool's mock Authorization Server builds its issuer / token_endpoint
+# / jwks_uri from the machine's own default IP (nmos-testing
+# mocks/Auth.py make_issuer -> get_default_ip), so on a docker bridge
+# the RFC 8414 metadata would name a 172.x address the plant-side CuT
+# can never reach. Host networking in turn forces a shifted PORT_BASE
+# — the resident already owns 5000 — so the mock auth server lands on
+# PORT_BASE+10 = 5510. (The manual sweep receipts show :5010 only
+# because that sweep's tool was the sole instance at PORT_BASE 5000.)
+dhs_amwa_validate_tooling_host: "10.6.250.104"
+dhs_amwa_validate_auth_tool_container: nmos-testing-auth
+dhs_amwa_validate_auth_port_base: 5500
+# WS mocks shift with the instance too, so an auth suite can never
+# race the resident tool for the 6000+ websocket mock range.
+dhs_amwa_validate_auth_ws_port_base: 6500
+dhs_amwa_validate_auth_tool_url: "http://localhost:{{ dhs_amwa_validate_auth_port_base }}/api"
+# What the transient CuT is armed with (--auth-url): the armed tool's
+# mock Authorization Server, reachable from the plant host.
+dhs_amwa_validate_auth_server_url: "http://{{ dhs_amwa_validate_tooling_host }}:{{ dhs_amwa_validate_auth_port_base + 10 }}"
+
+# Auth-mode scope selector: set true by the amwa-validate-*-auth.yml
+# playbooks. A play runs EITHER a scope's plain entries or its
+# auth: true twins, never a mix — armed and disarmed windows score
+# against different tool instances and must not interleave.
+dhs_amwa_validate_auth_mode: false
+
 # The catalog. Fields:
 #   id            AMWA suite id, verbatim
 #   scope         node | registry | controller | mirror
 #   target        node | registry | cut  (which host:port the rows use)
-#   window        absent | mdns | p2p   (CuT window around the run)
+#   window        absent | isolated | p2p | registry  (CuT window
+#                 around the run — window_<name>.yml)
+#   auth          true = IS-10 window (issue #942): the window's CuT
+#                 is armed with --auth-url and the ARMED tool instance
+#                 scores it; plant resident units are never armed
 #   rows          endpoint rows in the suite's declared order; each row
 #                 may carry ver / urlpath / selector; host+port come
 #                 from the target unless the row overrides them (null
@@ -155,6 +191,27 @@ dhs_amwa_validate_suites:
   # (nmos-cpp included).
   - { id: IS-04-02, scope: registry, target: registry,
       rows: [{ver: v1.3}, {ver: v1.3}], baseline_pass: 74, baseline_cnt: 2 }
+
+  # ---- auth-mode windows (issue #942): the same exams WITH IS-10 ----
+  # The manual sweep receipts (/root/amwa-sweep/IS-04-02-auth.json +
+  # IS-05-01-auth.json on dhs-tools) proved the recipe: tool
+  # ENABLE_AUTH=True, transient CuT armed via --auth-url at the tool's
+  # mock Authorization Server, every request tokened. Auth activates
+  # the per-endpoint 401/403/WWW-Authenticate auto rounds, so pass
+  # counts sit ABOVE the non-auth twins once baselined.
+  # baseline_pass 0 = baseline set from first fleet run: the gate
+  # still fails on any Fail/Error and on cnt above baseline (the
+  # parse_suite.py rules are unchanged — pass >= 0 is trivially true,
+  # so the pass-regression arm only bites once the real number lands
+  # here in git).
+  - { id: IS-05-01, scope: node, target: cut, window: p2p, auth: true,
+      rows: [{ver: v1.2}], baseline_pass: 0, baseline_cnt: 0 }
+  # baseline_cnt 2 inherited from the non-auth twin: auto_registration
+  # 5/6 are structurally untestable for ANY implementation (RAML id
+  # substitution — see the registry-scope entry above), and arming
+  # auth does not change that.
+  - { id: IS-04-02, scope: registry, target: registry, window: registry, auth: true,
+      rows: [{ver: v1.3}, {ver: v1.3}], baseline_pass: 0, baseline_cnt: 2 }
 
   # ---- controller scope: needs the controller facade (issue backlog,
   # user-owned item #7) — listed so the report says "not automatable

--- a/ansible/roles/dhs_amwa_validate/defaults/main.yml
+++ b/ansible/roles/dhs_amwa_validate/defaults/main.yml
@@ -204,8 +204,10 @@ dhs_amwa_validate_suites:
   # parse_suite.py rules are unchanged — pass >= 0 is trivially true,
   # so the pass-regression arm only bites once the real number lands
   # here in git).
+  # Armed baseline from the 2026-09-01 first fleet run: the full
+  # connection suite passes against the Bearer-gated node, no CNTs.
   - { id: IS-05-01, scope: node, target: cut, window: p2p, auth: true,
-      rows: [{ver: v1.2}], baseline_pass: 0, baseline_cnt: 0 }
+      rows: [{ver: v1.2}], baseline_pass: 67, baseline_cnt: 0 }
   # Armed baselines from the 2026-09-01 first fleet run: pass=79
   # fail=0. cnt 11 = the non-auth twin's structural pair
   # (auto_registration 5/6, RAML id substitution) PLUS nine

--- a/ansible/roles/dhs_amwa_validate/tasks/main.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/main.yml
@@ -23,10 +23,34 @@
          | list }}
     _validate_verdicts: []
 
+# Auth-mode split (issue #942): a play scores EITHER the plain
+# entries of its scope or their auth: true twins. The twins share
+# suite ids with the plain entries, so this filter must run before
+# anything keys on id alone.
+- name: Keep only this play's auth-mode side of the catalog
+  ansible.builtin.set_fact:
+    _validate_suites: >-
+      {{ _validate_suites | selectattr('auth', 'defined') | selectattr('auth') | list
+         if dhs_amwa_validate_auth_mode else
+         _validate_suites | rejectattr('auth', 'defined') | list
+         + _validate_suites | selectattr('auth', 'defined') | rejectattr('auth') | list }}
+    _skipped_suites: >-
+      {{ _skipped_suites | selectattr('auth', 'defined') | selectattr('auth') | list
+         if dhs_amwa_validate_auth_mode else
+         _skipped_suites | rejectattr('auth', 'defined') | list
+         + _skipped_suites | selectattr('auth', 'defined') | rejectattr('auth') | list }}
+
 - name: Apply the subset filter
   ansible.builtin.set_fact:
     _validate_suites: "{{ _validate_suites | selectattr('id', 'in', dhs_amwa_validate_only) | list }}"
   when: dhs_amwa_validate_only | length > 0
+
+# The armed tool instance only converges/preflights when an auth
+# window will actually use it — a plain scope run must not create or
+# assert containers it never talks to.
+- name: Note whether this play needs the armed tool instance
+  ansible.builtin.set_fact:
+    _validate_need_auth: "{{ _validate_suites | selectattr('auth', 'defined') | selectattr('auth') | list | length > 0 }}"
 
 - name: Converge the tooling host
   ansible.builtin.include_tasks: tooling.yml

--- a/ansible/roles/dhs_amwa_validate/tasks/preflight.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/preflight.yml
@@ -78,14 +78,17 @@
       Got: {{ _auth_tool_cfg.stdout }}
   when: _validate_need_auth
 
+# First boot after (re)create loads every suite before the GUI binds —
+# ~1-2 min on this LXC; 5x3s only covered the already-running case and
+# failed the first fleet run of #942.
 - name: The auth tool API must answer
   ansible.builtin.uri:
     url: "{{ dhs_amwa_validate_auth_tool_url }}"
     method: GET
     status_code: [200, 405]
   register: _auth_tool_api
-  retries: 5
-  delay: 3
+  retries: 36
+  delay: 5
   until: _auth_tool_api.status in [200, 405]
   when: _validate_need_auth
 

--- a/ansible/roles/dhs_amwa_validate/tasks/preflight.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/preflight.yml
@@ -40,6 +40,68 @@
   delay: 3
   until: _tool_api.status in [200, 405]
 
+# ---- the auth-ARMED tool instance (issue #942) ----
+# The resident checks above still ran: an auth play arms ONLY its own
+# instance, and the resident staying disarmed is part of the contract
+# being asserted.
+- name: Read the auth tool container image
+  ansible.builtin.command: docker inspect --format {% raw %}"{{.Config.Image}}"{% endraw %} {{ dhs_amwa_validate_auth_tool_container }}
+  register: _auth_tool_image
+  changed_when: false
+  when: _validate_need_auth
+
+- name: The auth tool image must be the pinned one
+  ansible.builtin.assert:
+    that: _auth_tool_image.stdout.strip() == dhs_amwa_validate_tool_image
+    fail_msg: >-
+      auth tool container runs {{ _auth_tool_image.stdout }} — the gate
+      is only meaningful against {{ dhs_amwa_validate_tool_image }}
+  when: _validate_need_auth
+
+- name: Read the auth tool UserConfig
+  ansible.builtin.command: docker exec {{ dhs_amwa_validate_auth_tool_container }} cat /config/UserConfig.py
+  register: _auth_tool_cfg
+  changed_when: false
+  when: _validate_need_auth
+
+- name: The auth tool knobs must match the armed profile
+  ansible.builtin.assert:
+    that:
+      - "'PULL_REPOS = False' in _auth_tool_cfg.stdout"
+      - "'CONFIG.GARBAGE_COLLECTION_TIMEOUT = 30' in _auth_tool_cfg.stdout"
+      - "'CONFIG.ENABLE_AUTH = True' in _auth_tool_cfg.stdout"
+      - "('CONFIG.PORT_BASE = ' ~ dhs_amwa_validate_auth_port_base) in _auth_tool_cfg.stdout"
+    fail_msg: >-
+      auth /config/UserConfig.py drifted — expected PULL_REPOS=False,
+      CONFIG.GARBAGE_COLLECTION_TIMEOUT=30 and auth ARMED at
+      PORT_BASE {{ dhs_amwa_validate_auth_port_base }}.
+      Got: {{ _auth_tool_cfg.stdout }}
+  when: _validate_need_auth
+
+- name: The auth tool API must answer
+  ansible.builtin.uri:
+    url: "{{ dhs_amwa_validate_auth_tool_url }}"
+    method: GET
+    status_code: [200, 405]
+  register: _auth_tool_api
+  retries: 5
+  delay: 3
+  until: _auth_tool_api.status in [200, 405]
+  when: _validate_need_auth
+
+# The exact URL the CuT will be armed with must serve the RFC 8414
+# metadata — this catches the bridged-networking failure mode (issuer
+# baked to an unreachable IP) before a 30-minute suite does.
+- name: The mock Authorization Server must answer where the CuT will look
+  ansible.builtin.uri:
+    url: "{{ dhs_amwa_validate_auth_server_url }}/.well-known/oauth-authorization-server"
+    method: GET
+  register: _auth_meta
+  retries: 5
+  delay: 3
+  until: _auth_meta.status == 200
+  when: _validate_need_auth
+
 # Stamped from a live clock read, NOT ansible_date_time — cached facts
 # hand every run the same stamp and the runs then overwrite each other.
 - name: Stamp the run

--- a/ansible/roles/dhs_amwa_validate/tasks/report.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/report.yml
@@ -4,10 +4,12 @@
 # AMWA spec link. The play FAILS at the end (not mid-run) so a
 # regression in one suite never hides the results of the rest.
 
+# Auth twins (issue #942) carry a " (auth)" suffix so an armed run's
+# line can never be misread as its plain sibling's.
 - name: Suite summary
   ansible.builtin.debug:
     msg: >-
-      {{ '%-16s' | format(item.suite) }}
+      {{ '%-16s' | format(item.suite ~ (' (auth)' if item.auth | default(false) else '')) }}
       {{ 'OK  ' if item.ok else 'FAIL' }}
       pass={{ item['pass'] }}/{{ item.baseline_pass }}
       fail={{ item.fail }} cnt={{ item.cnt }}/{{ item.baseline_cnt }}
@@ -16,7 +18,7 @@
       {{ '(+%d above baseline — raise it in git)' | format(item.above_baseline) if item.above_baseline > 0 else '' }}
   loop: "{{ _validate_verdicts }}"
   loop_control:
-    label: "{{ item.suite }}"
+    label: "{{ item.suite }}{{ ' (auth)' if item.auth | default(false) else '' }}"
 
 # Per-test detail: every non-pass row, named by the tool's own test
 # names, with the reason and the AMWA spec link.
@@ -25,7 +27,7 @@
     msg: "[{{ item.1.state }}] {{ item.1.test }}: {{ item.1.reason }}{% if item.1.amwa_link %}  ({{ item.1.amwa_link }}){% endif %}"
   loop: "{{ _validate_verdicts | subelements('problems') }}"
   loop_control:
-    label: "{{ item.0.suite }} {{ item.1.test }}"
+    label: "{{ item.0.suite }}{{ ' (auth)' if item.0.auth | default(false) else '' }} {{ item.1.test }}"
 
 - name: Suites this play cannot drive yet
   ansible.builtin.debug:

--- a/ansible/roles/dhs_amwa_validate/tasks/suite_attempt.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/suite_attempt.yml
@@ -7,6 +7,10 @@
 - name: "{{ suite.id }} — attempt bookkeeping"
   ansible.builtin.set_fact:
     _attempt_suffix: "{{ '-retry' if _suite_verdict else '' }}"
+    # Result-file stem: auth twins keep the manual sweep's
+    # <SUITE>-auth.json convention so armed and plain receipts of the
+    # same suite id never overwrite each other.
+    _suite_file: "{{ suite.id }}{{ '-auth' if suite.auth | default(false) else '' }}"
     _suite_host_override: !!null
     _suite_port_override: !!null
     _tool_url_override: !!null
@@ -17,6 +21,15 @@
     - name: "{{ suite.id }} — open the {{ suite.window | default('no') }} window"
       ansible.builtin.include_tasks: "window_{{ suite.window }}.yml"
       when: suite.window is defined
+
+    # Auth suites are scored by the ARMED tool instance (issue #942).
+    # After the window include on purpose: no auth suite runs in the
+    # isolated window today, but if one ever does, the armed URL must
+    # win over the isolated instance's override.
+    - name: "{{ suite.id }} — score with the armed tool instance"
+      ansible.builtin.set_fact:
+        _tool_url_override: "{{ dhs_amwa_validate_auth_tool_url }}"
+      when: suite.auth | default(false)
 
     # Fill each row's absent members from the (possibly window-
     # overridden) target. An EXPLICIT null in the catalog stays null —
@@ -55,13 +68,13 @@
     - name: "{{ suite.id }} — store the raw result"
       ansible.builtin.copy:
         content: "{{ _suite_resp.content }}"
-        dest: "{{ dhs_amwa_validate_results_dir }}/{{ _validate_run_ts }}/{{ suite.id }}{{ _attempt_suffix }}.json"
+        dest: "{{ dhs_amwa_validate_results_dir }}/{{ _validate_run_ts }}/{{ _suite_file }}{{ _attempt_suffix }}.json"
         mode: "0644"
 
     - name: "{{ suite.id }} — gate against the baseline"
       ansible.builtin.command: >-
         python3 {{ dhs_amwa_validate_results_dir }}/parse_suite.py
-        {{ dhs_amwa_validate_results_dir }}/{{ _validate_run_ts }}/{{ suite.id }}{{ _attempt_suffix }}.json
+        {{ dhs_amwa_validate_results_dir }}/{{ _validate_run_ts }}/{{ _suite_file }}{{ _attempt_suffix }}.json
         {{ suite.id }} {{ suite.baseline_pass }} {{ suite.baseline_cnt }}
       register: _suite_gate
       changed_when: false
@@ -69,7 +82,10 @@
 
     - name: "{{ suite.id }} — record the verdict"
       ansible.builtin.set_fact:
-        _suite_verdict: "{{ _suite_gate.stdout | from_json | combine({'retried': _attempt_suffix != ''}) }}"
+        _suite_verdict: >-
+          {{ _suite_gate.stdout | from_json
+             | combine({'retried': _attempt_suffix != '',
+                        'auth': suite.auth | default(false)}) }}
   always:
     - name: "{{ suite.id }} — close the window"
       ansible.builtin.include_tasks: window_teardown.yml

--- a/ansible/roles/dhs_amwa_validate/tasks/tooling.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/tooling.yml
@@ -101,3 +101,57 @@
     && docker restart {{ dhs_amwa_validate_tool_container }}
   when: _userconfig.changed or _tool_state.rc != 0
   changed_when: true
+
+# ---- the auth-ARMED tool instance (issue #942) ----
+# Third container, same pinned image, HOST networking + host dbus like
+# the resident (its mock Authorization Server derives issuer/jwks_uri
+# from the machine's default IP — a bridge would bake in an
+# unreachable 172.x; IS-04-02's DNS-SD rounds also need real
+# multicast). Shifted PORT_BASE because the resident owns 5000; the
+# mock auth server follows at PORT_BASE+10.
+- name: The auth tool container exists
+  ansible.builtin.command: docker inspect -f {% raw %}"{{.State.Status}}"{% endraw %} {{ dhs_amwa_validate_auth_tool_container }}
+  register: _auth_tool_state
+  changed_when: false
+  failed_when: false
+  when: _validate_need_auth
+
+- name: Create the auth tool container
+  ansible.builtin.command: >-
+    docker run -d --name {{ dhs_amwa_validate_auth_tool_container }}
+    --network host
+    -v /run/dbus:/run/dbus
+    --restart unless-stopped
+    {{ dhs_amwa_validate_tool_image }}
+  when: _validate_need_auth and _auth_tool_state.rc != 0
+  changed_when: true
+
+- name: The auth tool container is running
+  ansible.builtin.command: docker start {{ dhs_amwa_validate_auth_tool_container }}
+  when: _validate_need_auth and _auth_tool_state.rc == 0 and 'running' not in _auth_tool_state.stdout
+  changed_when: true
+
+# Same conformance profile as the resident PLUS the armed knobs —
+# ENABLE_AUTH is the tool's own switch (its receipts CONFIG dump names
+# it), PORT_BASE moves the GUI/API + every PORT_BASE-relative mock,
+# WEBSOCKET_PORT_BASE moves the WS mocks off the resident's range.
+- name: Render the armed UserConfig
+  ansible.builtin.copy:
+    content: |
+      PULL_REPOS = False
+      from . import Config as CONFIG
+      CONFIG.GARBAGE_COLLECTION_TIMEOUT = 30
+      CONFIG.ENABLE_AUTH = True
+      CONFIG.PORT_BASE = {{ dhs_amwa_validate_auth_port_base }}
+      CONFIG.WEBSOCKET_PORT_BASE = {{ dhs_amwa_validate_auth_ws_port_base }}
+    dest: /opt/dhs-validate-userconfig-auth.py
+    mode: "0644"
+  register: _auth_userconfig
+  when: _validate_need_auth
+
+- name: Pin the auth tool UserConfig
+  ansible.builtin.shell: >-
+    docker cp /opt/dhs-validate-userconfig-auth.py {{ dhs_amwa_validate_auth_tool_container }}:/config/UserConfig.py
+    && docker restart {{ dhs_amwa_validate_auth_tool_container }}
+  when: _validate_need_auth and (_auth_userconfig.changed or _auth_tool_state.rc != 0)
+  changed_when: true

--- a/ansible/roles/dhs_amwa_validate/tasks/tooling.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/tooling.yml
@@ -116,19 +116,20 @@
   failed_when: false
   when: _validate_need_auth
 
-- name: Create the auth tool container
+# docker CREATE, not run: the tool must never execute with default
+# config. With defaults PULL_REPOS=True kicks off git operations at
+# startup, and the config pin's restart then lands mid `git reset`,
+# leaving a stale cache .git/HEAD.lock that crash-loops the container
+# forever (first fleet run of #942 hit exactly this). Config first,
+# first start after.
+- name: Create the auth tool container (stopped)
   ansible.builtin.command: >-
-    docker run -d --name {{ dhs_amwa_validate_auth_tool_container }}
+    docker create --name {{ dhs_amwa_validate_auth_tool_container }}
     --network host
     -v /run/dbus:/run/dbus
     --restart unless-stopped
     {{ dhs_amwa_validate_tool_image }}
   when: _validate_need_auth and _auth_tool_state.rc != 0
-  changed_when: true
-
-- name: The auth tool container is running
-  ansible.builtin.command: docker start {{ dhs_amwa_validate_auth_tool_container }}
-  when: _validate_need_auth and _auth_tool_state.rc == 0 and 'running' not in _auth_tool_state.stdout
   changed_when: true
 
 # Same conformance profile as the resident PLUS the armed knobs —
@@ -154,4 +155,10 @@
     docker cp /opt/dhs-validate-userconfig-auth.py {{ dhs_amwa_validate_auth_tool_container }}:/config/UserConfig.py
     && docker restart {{ dhs_amwa_validate_auth_tool_container }}
   when: _validate_need_auth and (_auth_userconfig.changed or _auth_tool_state.rc != 0)
+  changed_when: true
+
+# After the pin so a first start always runs the armed config.
+- name: The auth tool container is running
+  ansible.builtin.command: docker start {{ dhs_amwa_validate_auth_tool_container }}
+  when: _validate_need_auth and _auth_tool_state.rc == 0 and 'running' not in _auth_tool_state.stdout
   changed_when: true

--- a/ansible/roles/dhs_amwa_validate/tasks/window_p2p.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/window_p2p.yml
@@ -2,6 +2,12 @@
 # P2P CuT window (IS-04-03): a registered node MUST NOT advertise
 # _nmos-node._tcp (IS-04 §4.2.1), so peer-to-peer needs its own
 # transient with --no-registry and mDNS on. The plant stays untouched.
+#
+# auth: true suites (issue #942) reuse this window with the ONE
+# difference the manual sweep proved: the transient is armed with
+# --auth-url at the tool's mock Authorization Server, which flips
+# api_auth=true and Bearer-gates every served API. Plant resident
+# units are never armed.
 
 - name: Start the transient P2P node
   ansible.builtin.command: >-
@@ -12,6 +18,7 @@
     --advertise-host {{ dhs_amwa_validate_plant_host }}:{{ dhs_amwa_validate_cut_port }}
     --api-ver v1.3
     --config {{ dhs_amwa_validate_plant_config }}
+    {{ ('--auth-url ' ~ dhs_amwa_validate_auth_server_url) if suite.auth | default(false) else '' }}
   delegate_to: "{{ groups['plant'][0] }}"
   changed_when: true
 
@@ -23,10 +30,14 @@
   delegate_to: "{{ groups['plant'][0] }}"
   changed_when: true
 
+# An armed CuT answers a tokenless probe with 401 — that IS the
+# readiness proof (the Bearer gate is up before the tool knocks);
+# 200 is the disarmed shape.
 - name: Wait for the transient node
   ansible.builtin.uri:
     url: "http://{{ dhs_amwa_validate_plant_host }}:{{ dhs_amwa_validate_cut_port }}/x-nmos/node/v1.3/self"
+    status_code: [200, 401]
   register: _cut_up
   retries: 15
   delay: 2
-  until: _cut_up.status == 200
+  until: _cut_up.status == (401 if suite.auth | default(false) else 200)

--- a/ansible/roles/dhs_amwa_validate/tasks/window_registry.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/window_registry.yml
@@ -1,0 +1,60 @@
+---
+# Registry CuT window (IS-04-02 auth, issue #942): a transient
+# registry on the plant host, armed with --auth-url so BOTH faces
+# (Registration + Query) Bearer-gate and api_auth=true is advertised.
+# The plant registry stays running and DISARMED — resident units are
+# never armed — and keeps its pri-0 announce; the transient announces
+# at dev priority 100 under its own instance name so no plant node
+# re-elects onto an armed registry it holds no token for (pri 0-99
+# production, 100+ dev — IS-04 §3).
+#
+# The transient mirrors the plant registry's exam-shaping flags
+# (dhs_amwa_plant's dhs-nmos-registry.service.j2): the tool's pinned
+# GARBAGE_COLLECTION_TIMEOUT=30 profile assumes the 30 s heartbeat
+# window, and the paging default changes which Query paging rounds
+# the tool can score — a drifted transient sits a different exam than
+# the committed non-auth baseline did.
+#
+# Same transient unit name as the p2p window so window_teardown.yml
+# closes either window identically.
+
+- name: Start the transient registry CuT
+  ansible.builtin.command: >-
+    systemd-run --unit dhs-nmos-validate-cut --collect
+    {{ dhs_amwa_validate_plant_bin }} registry nmos serve
+    --bind 0.0.0.0:{{ dhs_amwa_validate_cut_port }}
+    --advertise-host {{ dhs_amwa_validate_plant_host }}:{{ dhs_amwa_validate_cut_port }}
+    --priority 100
+    --instance-name dhs-nmos-validate-auth
+    --page-limit-default 1000
+    --heartbeat-timeout 30s
+    {{ ('--auth-url ' ~ dhs_amwa_validate_auth_server_url) if suite.auth | default(false) else '' }}
+  delegate_to: "{{ groups['plant'][0] }}"
+  changed_when: true
+
+- name: Arm the CuT safety-stop timer
+  ansible.builtin.command: >-
+    systemd-run --unit dhs-nmos-validate-cutstop --collect
+    --on-active={{ dhs_amwa_validate_window_safety_sec }}
+    systemctl stop dhs-nmos-validate-cut
+  delegate_to: "{{ groups['plant'][0] }}"
+  changed_when: true
+
+# An armed registry answers a tokenless probe with 401 — that IS the
+# readiness proof (the Bearer gate is up before the tool knocks);
+# 200 is the disarmed shape.
+- name: Wait for the transient registry
+  ansible.builtin.uri:
+    url: "http://{{ dhs_amwa_validate_plant_host }}:{{ dhs_amwa_validate_cut_port }}/x-nmos/query/v1.3/nodes"
+    status_code: [200, 401]
+  register: _cut_up
+  retries: 15
+  delay: 2
+  until: _cut_up.status == (401 if suite.auth | default(false) else 200)
+
+# The catalog rows carry the registry target; point them at the
+# transient instead of the plant resident.
+- name: Point this suite at the transient registry
+  ansible.builtin.set_fact:
+    _suite_host_override: "{{ dhs_amwa_validate_plant_host }}"
+    _suite_port_override: "{{ dhs_amwa_validate_cut_port }}"

--- a/ansible/roles/dhs_amwa_validate/tasks/window_teardown.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/window_teardown.yml
@@ -29,7 +29,7 @@
     content: |
       {{ _cut_log.stdout | default('') }}
       {{ _cut_log.stderr | default('') }}
-    dest: "{{ dhs_amwa_validate_results_dir }}/{{ _validate_run_ts }}/{{ suite.id }}-node.log"
+    dest: "{{ dhs_amwa_validate_results_dir }}/{{ _validate_run_ts }}/{{ _suite_file | default(suite.id) }}-node.log"
     mode: "0644"
   when: _cut_log.rc | default(1) == 0
 


### PR DESCRIPTION
Closes #942 (S3 — "must use both non or with auth").

## What

The conformance gate now proves every upgrade **without and with IS-10 auth**. `amwa-validate.yml` runs the four resident (disarmed) scopes, then the auth plays.

- **Catalog auth twins** with their own baselines-as-code: `IS-05-01 {auth}` (node, p2p window) and `IS-04-02 {auth}` (registry, new `registry` window). Results follow the manual-sweep `<suite>-auth.json` convention; the EVS-style report suffixes ` (auth)`.
- **Armed tool instance**: a third, host-networked `nmos-testing-auth` container at `PORT_BASE 5500` (mock Authorization Server at `:5510`). Host networking is load-bearing: upstream `mocks/Auth.py` builds the RFC 8414 issuer/jwks URLs from the machine's default IP, so a bridge container would hand the CuT unreachable 172.x endpoints. Preflight GETs the `.well-known/oauth-authorization-server` metadata **at the exact URL the CuT gets armed with** before any suite runs.
- **Armed windows**: the transient CuTs get `--auth-url`; the new `window_registry.yml` runs a transient armed registry on `:18500` at dev priority 100 with its own instance name, so no plant node re-elects onto a registry it holds no token for. Tokenless readiness probes must answer **401 when armed** — the Bearer gate being up is the readiness signal. Plant residents stay disarmed.
- Same teardown/safety-timer machinery as every other window; playbooks `amwa-validate-node-auth.yml` / `amwa-validate-registry-auth.yml`.

## What the fleet runs caught (fixed in their own commits)

1. `docker run` started the armed tool with default config (`PULL_REPOS=True` → git ops), and the config pin's restart landed mid-`git reset`, crash-looping on its own stale `HEAD.lock` → the container is now **created stopped**, configured, then started: it never executes unconfigured.
2. The tool's first boot loads every suite before binding (~1–2 min); the 5×3 s preflight budget only covered the warm case → 36×5 s.

## Live receipts (fleet, 2026-09-01, confirm run at committed baselines)

- `IS-05-01 (auth)  OK  pass=67/67 fail=0 cnt=0/0` — the full connection suite passes against the Bearer-gated node.
- `IS-04-02 (auth)  OK  pass=79/79 fail=0 cnt=11/11` — full registry suite, zero failures armed. The cnt 11 = the structural `auto_registration_5/6` pair plus nine "No resources found" rows because the transient armed registry is empty by design (documented in the catalog).
- Both plays exit 0; the warnings are our deliberate dev-range `pri 100`.

## Named follow-ups

- Register a token-bearing transient node into the armed registry window to shrink the nine empty-registry CNTs.
- BCP-003-01 TLS window (EST/cert pair) — S3b, separate machinery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
