### PR TITLE
feat(ansible): token-bearing companion node populates the armed registry window (#944)

### DIFF
--- a/ansible/roles/dhs_amwa_validate/defaults/main.yml
+++ b/ansible/roles/dhs_amwa_validate/defaults/main.yml
@@ -29,6 +29,9 @@ dhs_amwa_validate_plant_host: "10.6.250.101"
 dhs_amwa_validate_node_port: 18080
 dhs_amwa_validate_registry_port: 8235
 dhs_amwa_validate_cut_port: 18500
+# The token-bearing companion node the armed registry window registers
+# into the transient armed registry (#942 S3c).
+dhs_amwa_validate_cutnode_port: 18510
 dhs_amwa_validate_plant_bin: /opt/dhs-amwa-plant/dhs
 dhs_amwa_validate_plant_config: /opt/dhs-amwa-plant/amwa-test-node.json
 dhs_amwa_validate_registry_unit: dhs-nmos-registry

--- a/ansible/roles/dhs_amwa_validate/defaults/main.yml
+++ b/ansible/roles/dhs_amwa_validate/defaults/main.yml
@@ -211,16 +211,14 @@ dhs_amwa_validate_suites:
   # connection suite passes against the Bearer-gated node, no CNTs.
   - { id: IS-05-01, scope: node, target: cut, window: p2p, auth: true,
       rows: [{ver: v1.2}], baseline_pass: 67, baseline_cnt: 0 }
-  # Armed baselines from the 2026-09-01 first fleet run: pass=79
-  # fail=0. cnt 11 = the non-auth twin's structural pair
-  # (auto_registration 5/6, RAML id substitution) PLUS nine
-  # "No resources found" rows: the transient armed registry is EMPTY
-  # by design — it announces at dev pri 100 and plant nodes hold no
-  # tokens, so nothing registers into it. Registering a token-bearing
-  # transient node into the armed window (shrinking these CNTs) is
-  # the named follow-up in #942.
+  # Armed baselines (2026-09-01, #944): the token-bearing companion
+  # node + seeded persistent subscription give every Query round a
+  # resource, so the armed window sits the SAME exam shape as the
+  # disarmed twin — cnt 2 is the identical structural
+  # auto_registration 5/6 pair (RAML id substitution, untestable for
+  # any implementation).
   - { id: IS-04-02, scope: registry, target: registry, window: registry, auth: true,
-      rows: [{ver: v1.3}, {ver: v1.3}], baseline_pass: 79, baseline_cnt: 11 }
+      rows: [{ver: v1.3}, {ver: v1.3}], baseline_pass: 88, baseline_cnt: 2 }
 
   # ---- controller scope: needs the controller facade (issue backlog,
   # user-owned item #7) — listed so the report says "not automatable

--- a/ansible/roles/dhs_amwa_validate/tasks/window_registry.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/window_registry.yml
@@ -52,6 +52,94 @@
   delay: 2
   until: _cut_up.status == (401 if suite.auth | default(false) else 200)
 
+# ---- token-bearing companion node (#942 follow-up S3c) --------------
+# An empty armed registry leaves nine Query rounds "No resources
+# found" (the first armed baseline). The companion node registers a
+# real resource graph INTO the armed registry so those rounds score.
+# Credentials come from the mock Authorization Server's own RFC 7591
+# registration endpoint — read from its RFC 8414 metadata, never
+# hardcoded — and the node arms with them via --auth-client-id/secret
+# (the same client_credentials flow a production node would use).
+- name: Read the Authorization Server metadata
+  ansible.builtin.uri:
+    url: "{{ dhs_amwa_validate_auth_server_url }}/.well-known/oauth-authorization-server"
+    return_content: true
+  register: _auth_meta
+  when: suite.auth | default(false)
+
+- name: Register the companion node as an OAuth client
+  ansible.builtin.uri:
+    url: "{{ _auth_meta.json.registration_endpoint }}"
+    method: POST
+    body_format: json
+    body:
+      client_name: dhs-nmos-validate-cutnode
+      grant_types: [client_credentials]
+      token_endpoint_auth_method: client_secret_basic
+      scope: "registration query"
+    status_code: [200, 201]
+  register: _dcr
+  no_log: true
+  when: suite.auth | default(false)
+
+- name: Start the token-bearing companion node
+  ansible.builtin.command: >-
+    systemd-run --unit dhs-nmos-validate-cutnode --collect
+    {{ dhs_amwa_validate_plant_bin }} producer nmos serve
+    --bind 0.0.0.0:{{ dhs_amwa_validate_cutnode_port }}
+    --no-mdns
+    --registry http://{{ dhs_amwa_validate_plant_host }}:{{ dhs_amwa_validate_cut_port }}
+    --advertise-host {{ dhs_amwa_validate_plant_host }}:{{ dhs_amwa_validate_cutnode_port }}
+    --api-ver {{ suite.rows[0].ver }}
+    --config {{ dhs_amwa_validate_plant_config }}
+    --auth-url {{ dhs_amwa_validate_auth_server_url }}
+    --auth-client-id {{ _dcr.json.client_id }}
+    --auth-client-secret {{ _dcr.json.client_secret }}
+  delegate_to: "{{ groups['plant'][0] }}"
+  no_log: true
+  changed_when: true
+  when: suite.auth | default(false)
+
+- name: Arm the companion-node safety-stop timer
+  ansible.builtin.command: >-
+    systemd-run --unit dhs-nmos-validate-cutnodestop --collect
+    --on-active={{ dhs_amwa_validate_window_safety_sec }}
+    systemctl stop dhs-nmos-validate-cutnode
+  delegate_to: "{{ groups['plant'][0] }}"
+  changed_when: true
+  when: suite.auth | default(false)
+
+# Proof of registration, not just liveness: fetch our own token (the
+# registered client carries the query scope too) and poll the armed
+# Query API until the companion's node document is in it.
+- name: Fetch a verification token
+  ansible.builtin.uri:
+    url: "{{ _auth_meta.json.token_endpoint }}"
+    method: POST
+    body_format: form-urlencoded
+    body:
+      grant_type: client_credentials
+      scope: query
+    url_username: "{{ _dcr.json.client_id }}"
+    url_password: "{{ _dcr.json.client_secret }}"
+    force_basic_auth: true
+  register: _verify_tok
+  no_log: true
+  when: suite.auth | default(false)
+
+- name: The companion node is registered in the armed registry
+  ansible.builtin.uri:
+    url: "http://{{ dhs_amwa_validate_plant_host }}:{{ dhs_amwa_validate_cut_port }}/x-nmos/query/v1.3/nodes"
+    headers:
+      Authorization: "Bearer {{ _verify_tok.json.access_token }}"
+    return_content: true
+  register: _cut_reg
+  retries: 20
+  delay: 3
+  until: _cut_reg.status == 200 and (_cut_reg.json | length) >= 1
+  no_log: true
+  when: suite.auth | default(false)
+
 # The catalog rows carry the registry target; point them at the
 # transient instead of the plant resident.
 - name: Point this suite at the transient registry

--- a/ansible/roles/dhs_amwa_validate/tasks/window_registry.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/window_registry.yml
@@ -140,6 +140,26 @@
   no_log: true
   when: suite.auth | default(false)
 
+# auto_query_18/19 page the /subscriptions collection; the plant
+# resident always holds live ones (the mirror's), the fresh transient
+# holds none. A persistent subscription (survives with no WS client
+# attached) gives those rounds a resource to score.
+- name: Seed a persistent subscription so the subscription rounds score
+  ansible.builtin.uri:
+    url: "http://{{ dhs_amwa_validate_plant_host }}:{{ dhs_amwa_validate_cut_port }}/x-nmos/query/v1.3/subscriptions"
+    method: POST
+    body_format: json
+    body:
+      max_update_rate_ms: 100
+      persist: true
+      resource_path: /nodes
+      params: {}
+    headers:
+      Authorization: "Bearer {{ _verify_tok.json.access_token }}"
+    status_code: [200, 201]
+  no_log: true
+  when: suite.auth | default(false)
+
 # The catalog rows carry the registry target; point them at the
 # transient instead of the plant resident.
 - name: Point this suite at the transient registry

--- a/ansible/roles/dhs_amwa_validate/tasks/window_teardown.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/window_teardown.yml
@@ -10,6 +10,8 @@
     state: stopped
   loop:
     - dhs-nmos-validate-cut
+    - dhs-nmos-validate-cutnode
+    - dhs-nmos-validate-cutnodestop.timer
     - dhs-nmos-validate-cutstop.timer
     - dhs-nmos-validate-cutkick.timer
     - dhs-nmos-validate-restore.timer


### PR DESCRIPTION
Closes #944 (S3c). The armed IS-04-02 window scored against an empty transient registry, leaving nine Query rounds Could-Not-Test. The window now: (1) performs RFC 7591 dynamic client registration against the mock Authorization Server - endpoint read from its RFC 8414 metadata, never hardcoded (verified live: 201 with client_credentials credentials); (2) starts a transient companion node armed with the issued credentials via the existing --auth-client-id/secret flags, registering the committed fixture graph INTO the armed registry - the same client_credentials flow a production node uses; (3) proves registration, not liveness, by fetching its own token and polling the armed Query API for the node document; (4) seeds one persistent subscription so the /subscriptions paging rounds score (the plant resident always has the mirror's live ones). Teardown covers the new transient pair. Zero product code - the window exercises the shipped IS-10 client path end to end. Fleet receipts: first run pass=86 cnt=4, subscription seed run pass=88 cnt=2, confirm run at committed baselines IS-04-02 (auth) OK pass=88/88 fail=0 cnt=2/2 - the armed window now sits the SAME exam shape as the disarmed twin; only the structural auto_registration pair remains. Generated with Claude Code.