### PR TITLE
feat(registry+ansible): validated, Bearer-gated mirror Query face - 7 wire fixes from the read-through gate (#946)

### DIFF
--- a/ansible/playbooks/amwa-validate-mirror.yml
+++ b/ansible/playbooks/amwa-validate-mirror.yml
@@ -8,6 +8,11 @@
 # Grows with the mirror unit (program slot 5): resource parity
 # upstream-vs-mirror, audit-trail assertions, and the
 # controller-in-the-middle checks.
+#
+# Two plays: the parity/health checks first (a broken mirror should
+# fail cheaply, not mid-suite), then the catalog's mirror-scope suites
+# (scope: mirror in dhs_amwa_validate_suites) — IS-04-02 scored
+# end-to-end THROUGH the mirror's served Query face (issue #946).
 
 - name: AMWA validate — mirror
   hosts: tooling
@@ -58,3 +63,13 @@
     - name: Recent audit observations
       ansible.builtin.debug:
         msg: "{{ _mstatus.json.recent_audit | map(attribute='kind') | list | join(', ') }}"
+
+# The mirror-scope catalog entries — same role invocation shape as
+# amwa-validate-registry.yml, selecting scope: mirror.
+- name: AMWA validate — mirror suites
+  hosts: tooling
+  gather_facts: true
+  roles:
+    - role: dhs_amwa_validate
+      vars:
+        dhs_amwa_validate_scope: mirror

--- a/ansible/playbooks/amwa-validate-mirror.yml
+++ b/ansible/playbooks/amwa-validate-mirror.yml
@@ -69,6 +69,26 @@
 - name: AMWA validate — mirror suites
   hosts: tooling
   gather_facts: true
+  pre_tasks:
+    # auto_query_18/19 page /subscriptions; the served face starts with
+    # none (the plant registry always holds the mirror's own upstream
+    # ones, the mirror's SERVED face holds only what controllers
+    # create). One persistent subscription (survives with no WS client)
+    # gives those rounds a resource — same reasoning as the armed
+    # registry window's seed in window_registry.yml.
+    - name: Seed a persistent subscription on the mirror's served face
+      ansible.builtin.uri:
+        url: "http://{{ hostvars[groups['plant'][0]].ansible_host }}:{{ dhs_amwa_validate_mirror_serve_port }}/x-nmos/query/v1.3/subscriptions"
+        method: POST
+        body_format: json
+        body:
+          max_update_rate_ms: 100
+          persist: true
+          resource_path: /nodes
+          params: {}
+        status_code: [200, 201]
+      vars:
+        dhs_amwa_validate_mirror_serve_port: 8335
   roles:
     - role: dhs_amwa_validate
       vars:

--- a/ansible/roles/dhs_amwa_plant/defaults/main.yml
+++ b/ansible/roles/dhs_amwa_plant/defaults/main.yml
@@ -28,6 +28,13 @@ dhs_amwa_plant_mirror_status_addr: ":9101"
 # the plant THROUGH the audited mirror. Empty string disables the
 # served face (unit then runs the plain one-way bridge).
 dhs_amwa_plant_mirror_serve: ":8335"
+# Advertise identity for the mirror's served face
+# (--serve-advertise-host): minted into ws_href and mDNS-announced as
+# _nmos-query._tcp (pri defaults to 100 in the CLI — dev range, never
+# outranks the source registry at pri 0). Without it the served face
+# falls back to the OS hostname, which the AMWA tool host cannot
+# resolve (IS-04-02 test_02 / test_22_2 fleet failures).
+dhs_amwa_plant_mirror_serve_advertise: "{{ dhs_amwa_plant_advertise_ip }}:8335"
 # BCP-003-02 Authorization Server base for the mirror's SERVED face
 # (--auth-url, issue #946). Empty = disarmed, the default — the plant
 # mirror serves Cerebrum unauthenticated today. Only meaningful with a

--- a/ansible/roles/dhs_amwa_plant/defaults/main.yml
+++ b/ansible/roles/dhs_amwa_plant/defaults/main.yml
@@ -28,6 +28,13 @@ dhs_amwa_plant_mirror_status_addr: ":9101"
 # the plant THROUGH the audited mirror. Empty string disables the
 # served face (unit then runs the plain one-way bridge).
 dhs_amwa_plant_mirror_serve: ":8335"
+# BCP-003-02 Authorization Server base for the mirror's SERVED face
+# (--auth-url, issue #946). Empty = disarmed, the default — the plant
+# mirror serves Cerebrum unauthenticated today. Only meaningful with a
+# non-empty dhs_amwa_plant_mirror_serve (the CLI refuses --auth-url
+# without --serve), so the unit template nests it inside the --serve
+# block.
+dhs_amwa_plant_mirror_serve_auth: ""
 dhs_amwa_plant_registry_page_limit: 1000
 # Heartbeat GC window. IS-04 §6.1 defaults to 12s and makes it
 # configurable; the CONFORMANCE plant runs 30s, matched by the AMWA

--- a/ansible/roles/dhs_amwa_plant/templates/dhs-nmos-mirror.service.j2
+++ b/ansible/roles/dhs_amwa_plant/templates/dhs-nmos-mirror.service.j2
@@ -11,6 +11,9 @@ ExecStart={{ dhs_amwa_plant_bin }} registry nmos mirror \
   --target {{ dhs_amwa_plant_mirror_target }} \
 {% if dhs_amwa_plant_mirror_serve | default('') | length > 0 %}
   --serve {{ dhs_amwa_plant_mirror_serve }} \
+{% if dhs_amwa_plant_mirror_serve_auth | default('') | length > 0 %}
+  --auth-url {{ dhs_amwa_plant_mirror_serve_auth }} \
+{% endif %}
 {% endif %}
   --audit-log {{ dhs_amwa_plant_mirror_audit_log }} \
   --status-addr {{ dhs_amwa_plant_mirror_status_addr }}

--- a/ansible/roles/dhs_amwa_plant/templates/dhs-nmos-mirror.service.j2
+++ b/ansible/roles/dhs_amwa_plant/templates/dhs-nmos-mirror.service.j2
@@ -11,6 +11,9 @@ ExecStart={{ dhs_amwa_plant_bin }} registry nmos mirror \
   --target {{ dhs_amwa_plant_mirror_target }} \
 {% if dhs_amwa_plant_mirror_serve | default('') | length > 0 %}
   --serve {{ dhs_amwa_plant_mirror_serve }} \
+{% if dhs_amwa_plant_mirror_serve_advertise | default('') | length > 0 %}
+  --serve-advertise-host {{ dhs_amwa_plant_mirror_serve_advertise }} \
+{% endif %}
 {% if dhs_amwa_plant_mirror_serve_auth | default('') | length > 0 %}
   --auth-url {{ dhs_amwa_plant_mirror_serve_auth }} \
 {% endif %}

--- a/ansible/roles/dhs_amwa_validate/defaults/main.yml
+++ b/ansible/roles/dhs_amwa_validate/defaults/main.yml
@@ -28,6 +28,10 @@ dhs_amwa_validate_results_dir: /root/amwa-validate
 dhs_amwa_validate_plant_host: "10.6.250.101"
 dhs_amwa_validate_node_port: 18080
 dhs_amwa_validate_registry_port: 8235
+# The mirror's served read-only Query face (--serve on the resident
+# mirror unit — dhs_amwa_plant_mirror_serve). Mirror-scope query rows
+# score THROUGH it via the per-row port override.
+dhs_amwa_validate_mirror_serve_port: 8335
 dhs_amwa_validate_cut_port: 18500
 # The token-bearing companion node the armed registry window registers
 # into the transient armed registry (#942 S3c).
@@ -194,6 +198,25 @@ dhs_amwa_validate_suites:
   # (nmos-cpp included).
   - { id: IS-04-02, scope: registry, target: registry,
       rows: [{ver: v1.3}, {ver: v1.3}], baseline_pass: 74, baseline_cnt: 2 }
+
+  # ---- mirror scope, plant registry :8235 + mirror served face :8335 ----
+  # IS-04-02 end-to-end THROUGH the mirror (issue #946, S2b). The
+  # suite's two rows split across the mirrored path: the registration
+  # row targets the SOURCE plant registry (:8235, the target default —
+  # the mirror's own upstream), the query row overrides the port to the
+  # mirror's served read-only Query face (:8335; suite_attempt.yml's
+  # row normalisation honours row.host/row.port). The tool registers
+  # its mock resources at the source and scores every Query read
+  # THROUGH the audited mirror. No window: the resident registry and
+  # resident mirror already run, exactly like the plant-resident
+  # entries above. The row port is a literal per this file's row style
+  # (rows never template vars — a templated port would reach the tool
+  # as a string, not an int) and must match
+  # dhs_amwa_validate_mirror_serve_port / dhs_amwa_plant_mirror_serve.
+  # baseline placeholders 0/0 — filled from the first fleet run.
+  - { id: IS-04-02, scope: mirror, target: registry,
+      rows: [{ver: v1.3}, {ver: v1.3, port: 8335}],
+      baseline_pass: 0, baseline_cnt: 0 }
 
   # ---- auth-mode windows (issue #942): the same exams WITH IS-10 ----
   # The manual sweep receipts (/root/amwa-sweep/IS-04-02-auth.json +

--- a/ansible/roles/dhs_amwa_validate/defaults/main.yml
+++ b/ansible/roles/dhs_amwa_validate/defaults/main.yml
@@ -213,10 +213,13 @@ dhs_amwa_validate_suites:
   # (rows never template vars — a templated port would reach the tool
   # as a string, not an int) and must match
   # dhs_amwa_validate_mirror_serve_port / dhs_amwa_plant_mirror_serve.
-  # baseline placeholders 0/0 — filled from the first fleet run.
+  # Baselines (2026-09-01, #946 fleet receipts after the ws_href,
+  # announce, per-minor-fidelity and identical-put fixes plus the
+  # seeded subscription): pass=73 fail=0, cnt=2 = the same structural
+  # auto_registration 5/6 pair every registry-shaped entry carries.
   - { id: IS-04-02, scope: mirror, target: registry,
       rows: [{ver: v1.3}, {ver: v1.3, port: 8335}],
-      baseline_pass: 0, baseline_cnt: 0 }
+      baseline_pass: 73, baseline_cnt: 2 }
 
   # ---- auth-mode windows (issue #942): the same exams WITH IS-10 ----
   # The manual sweep receipts (/root/amwa-sweep/IS-04-02-auth.json +

--- a/cmd/dhs/cmd_nmos.go
+++ b/cmd/dhs/cmd_nmos.go
@@ -762,7 +762,14 @@ BCP-003-02 Bearer tokens against that Authorization Server, the same
 gate "registry nmos serve --auth-url" arms: tokenless or invalid
 requests answer 401 with WWW-Authenticate, WS upgrades included.
 /status.json reports the armed state as "serve_auth". The mirror's
-outbound legs (source Query-WS, target forwards) stay untouched.`)
+outbound legs (source Query-WS, target forwards) stay untouched.
+
+With --serve-advertise-host H[:P] the served face mints ws_href from
+that identity instead of the bound address (a bare host takes the
+--serve port) and announces itself as _nmos-query._tcp via mDNS with
+--serve-pri (default 100 — dev range, so the mirror never outranks
+the production source registry). The announce's api_auth TXT tracks
+--auth-url.`)
 }
 
 // runNMOSRegistryMirror bridges a source Registry into a target one.
@@ -789,18 +796,32 @@ func runNMOSRegistryMirror(ctx context.Context, args []string) error {
 			"tokens (WS upgrades included) exactly like the registry's own "+
 			"--auth-url; the mirror's outbound source/target legs are untouched. "+
 			"Requires --serve")
+	serveAdvertiseHost := fs.String("serve-advertise-host", "",
+		"identity minted into the served face's ws_href and mDNS announce, "+
+			"as host or host:port (a bare host takes the bound --serve port). "+
+			"Precedence: this flag wins; empty derives from the bound address "+
+			"(concrete IP, else OS hostname — which off-link controllers may "+
+			"not resolve). Setting it also enables the _nmos-query._tcp "+
+			"announce of the served face")
+	servePri := fs.Int("serve-pri", 100,
+		"DNS-SD pri TXT for the served face's announce (with "+
+			"--serve-advertise-host). Defaults into the 100+ dev range so the "+
+			"mirror never wins a production Registry election against its own "+
+			"source registry at pri 0")
 	if err := parseVerbFlags(fs, args); err != nil {
 		return err
 	}
 	m, err := amwaregistry.NewMirror(amwaregistry.MirrorOptions{
-		Source:       *source,
-		Target:       *targetURL,
-		APIVer:       *apiVer,
-		Logger:       slog.Default(),
-		AuditPath:    *auditLog,
-		StatusAddr:   *statusAddr,
-		ServeAddr:    *serveAddr,
-		ServeAuthURL: *serveAuthURL,
+		Source:             *source,
+		Target:             *targetURL,
+		APIVer:             *apiVer,
+		Logger:             slog.Default(),
+		AuditPath:          *auditLog,
+		StatusAddr:         *statusAddr,
+		ServeAddr:          *serveAddr,
+		ServeAuthURL:       *serveAuthURL,
+		ServeAdvertiseHost: *serveAdvertiseHost,
+		ServePri:           *servePri,
 	})
 	if err != nil {
 		return fmt.Errorf("nmos mirror: %w", err)

--- a/cmd/dhs/cmd_nmos.go
+++ b/cmd/dhs/cmd_nmos.go
@@ -755,7 +755,14 @@ With --serve ADDR the mirror also serves the mirrored catalogue as a
 read-only IS-04 Query API (REST + WebSocket subscriptions), so a
 controller reads the plant THROUGH the audited mirror. Served reads,
 WS subscription opens/closes, and refused registration attempts all
-land in the same --audit-log trail and /status.json counters.`)
+land in the same --audit-log trail and /status.json counters.
+
+With --auth-url URL (requires --serve) the served Query face validates
+BCP-003-02 Bearer tokens against that Authorization Server, the same
+gate "registry nmos serve --auth-url" arms: tokenless or invalid
+requests answer 401 with WWW-Authenticate, WS upgrades included.
+/status.json reports the armed state as "serve_auth". The mirror's
+outbound legs (source Query-WS, target forwards) stay untouched.`)
 }
 
 // runNMOSRegistryMirror bridges a source Registry into a target one.
@@ -776,17 +783,24 @@ func runNMOSRegistryMirror(ctx context.Context, args []string) error {
 			"(REST + WS subscriptions) on this address, e.g. :8335 — "+
 			"controllers read the plant THROUGH the audited mirror; "+
 			"registration attempts are refused and audited")
+	serveAuthURL := fs.String("auth-url", "",
+		"BCP-003-02 Authorization Server base (scheme://host[:port]). "+
+			"When set with --serve, the served Query face validates Bearer "+
+			"tokens (WS upgrades included) exactly like the registry's own "+
+			"--auth-url; the mirror's outbound source/target legs are untouched. "+
+			"Requires --serve")
 	if err := parseVerbFlags(fs, args); err != nil {
 		return err
 	}
 	m, err := amwaregistry.NewMirror(amwaregistry.MirrorOptions{
-		Source:     *source,
-		Target:     *targetURL,
-		APIVer:     *apiVer,
-		Logger:     slog.Default(),
-		AuditPath:  *auditLog,
-		StatusAddr: *statusAddr,
-		ServeAddr:  *serveAddr,
+		Source:       *source,
+		Target:       *targetURL,
+		APIVer:       *apiVer,
+		Logger:       slog.Default(),
+		AuditPath:    *auditLog,
+		StatusAddr:   *statusAddr,
+		ServeAddr:    *serveAddr,
+		ServeAuthURL: *serveAuthURL,
 	})
 	if err != nil {
 		return fmt.Errorf("nmos mirror: %w", err)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -334,6 +334,10 @@ Usage of mirror:
     	BCP-003-02 Authorization Server base (scheme://host[:port]). When set with --serve, the served Query face validates Bearer tokens (WS upgrades included) exactly like the registry's own --auth-url; the mirror's outbound source/target legs are untouched. Requires --serve
   -serve string
     	serve the mirrored catalogue as a read-only IS-04 Query API (REST + WS subscriptions) on this address, e.g. :8335 — controllers read the plant THROUGH the audited mirror; registration attempts are refused and audited
+  -serve-advertise-host string
+    	identity minted into the served face's ws_href and mDNS announce, as host or host:port (a bare host takes the bound --serve port). Precedence: this flag wins; empty derives from the bound address (concrete IP, else OS hostname — which off-link controllers may not resolve). Setting it also enables the _nmos-query._tcp announce of the served face
+  -serve-pri int
+    	DNS-SD pri TXT for the served face's announce (with --serve-advertise-host). Defaults into the 100+ dev range so the mirror never wins a production Registry election against its own source registry at pri 0 (default 100)
   -source string
     	source Registry origin (http://host:port) — Query API side
   -status-addr string

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -330,6 +330,8 @@ Usage of mirror:
     	IS-04 wire version used on both faces (default v1.3)
   -audit-log string
     	append one JSONL observation per external-registry behaviour (refused forwards with the target's own words, evictions, WS drops) — the evidence trail for auditing the registry on the far side
+  -auth-url string
+    	BCP-003-02 Authorization Server base (scheme://host[:port]). When set with --serve, the served Query face validates Bearer tokens (WS upgrades included) exactly like the registry's own --auth-url; the mirror's outbound source/target legs are untouched. Requires --serve
   -serve string
     	serve the mirrored catalogue as a read-only IS-04 Query API (REST + WS subscriptions) on this address, e.g. :8335 — controllers read the plant THROUGH the audited mirror; registration attempts are refused and audited
   -source string

--- a/internal/amwa/registry/mirror.go
+++ b/internal/amwa/registry/mirror.go
@@ -88,6 +88,14 @@ type MirrorOptions struct {
 	// mirror (mirror_serve.go). Empty disables the served face —
 	// pre-#940 behaviour unchanged.
 	ServeAddr string
+	// ServeAuthURL, when set, arms the served Query face with the
+	// BCP-003-02 Bearer gate: tokens are validated against the
+	// Authorization Server at this base URL, exactly the way the
+	// standalone Registry's --auth-url arms its faces. Requires
+	// ServeAddr — a gate with no served face guards nothing. The
+	// mirror's OUTBOUND legs (source Query-WS, target forwards) are
+	// untouched. Empty keeps the served face unauthenticated.
+	ServeAuthURL string
 }
 
 // MirrorStats is a snapshot of forward counters. JSON names are the
@@ -155,6 +163,9 @@ func NewMirror(opts MirrorOptions) (*Mirror, error) {
 	}
 	if strings.TrimRight(opts.Source, "/") == strings.TrimRight(opts.Target, "/") {
 		return nil, errors.New("registry/mirror: source and target must differ")
+	}
+	if opts.ServeAuthURL != "" && opts.ServeAddr == "" {
+		return nil, errors.New("registry/mirror: --auth-url guards the served Query face, and no face is being served — add --serve ADDR or drop --auth-url")
 	}
 	if opts.APIVer == "" {
 		opts.APIVer = is04.APIVersion

--- a/internal/amwa/registry/mirror.go
+++ b/internal/amwa/registry/mirror.go
@@ -137,6 +137,12 @@ type Mirror struct {
 	logger *slog.Logger
 	http   *stdhttp.Client
 
+	// sourceClients holds one Query API client per subscribed wire
+	// minor — the WS legs dial through them, and resync re-fetches the
+	// per-minor exact-match REST views through the same set. Assigned
+	// once in Run before any goroutine starts, immutable after.
+	sourceClients map[string]*query.Client
+
 	mu sync.Mutex
 	// cache holds the latest Post document per collection/id — the
 	// mirror's authoritative copy of the source catalogue, used for
@@ -148,7 +154,13 @@ type Mirror struct {
 	// §6.1.5 downgrade semantics survive the mirrored hop (AMWA
 	// IS-04-02 test_22/test_32). Same topic/id keys as cache.
 	cacheVer map[string]map[string]string
-	stats    MirrorStats
+	// targetNodes marks node ids the TARGET has accepted (a POST
+	// landed). Heartbeats are proxied for accepted nodes only: a 404
+	// heartbeat for a node the target never held is not an eviction,
+	// and treating it as one is a full-resync-per-tick thrash loop
+	// (the fleet's resyncs=13 signature). Guarded by mu.
+	targetNodes map[string]bool
+	stats       MirrorStats
 	// runCtx is the context passed to Run, captured so a debounced
 	// resync fired from a timer goroutine can honour shutdown.
 	runCtx context.Context
@@ -203,11 +215,12 @@ func NewMirror(opts MirrorOptions) (*Mirror, error) {
 		cacheVer[tp] = map[string]string{}
 	}
 	return &Mirror{
-		opts:     opts,
-		logger:   opts.Logger,
-		http:     &stdhttp.Client{Timeout: 10 * time.Second},
-		cache:    cache,
-		cacheVer: cacheVer,
+		opts:        opts,
+		logger:      opts.Logger,
+		http:        &stdhttp.Client{Timeout: 10 * time.Second},
+		cache:       cache,
+		cacheVer:    cacheVer,
+		targetNodes: map[string]bool{},
 	}, nil
 }
 
@@ -260,6 +273,7 @@ func (m *Mirror) Run(ctx context.Context) error {
 		}
 		clients[ver] = qc
 	}
+	m.sourceClients = clients
 	if m.opts.StatusAddr != "" {
 		go m.serveStatus(ctx, m.opts.StatusAddr)
 	}
@@ -349,27 +363,52 @@ func (m *Mirror) watchTopic(ctx context.Context, qc *query.Client, topic, ver st
 
 // forwardRow applies one grain row to the cache and the target. ver is
 // the wire minor of the source subscription the row arrived on — the
-// resource's registered minor, preserved into the served store's
-// version stamp.
+// resource's registered minor.
+//
+// The minor a resource is FIRST seen at is tracked for its lifetime
+// (cacheVer) and every downstream operation — embedded-store stamp,
+// target POST/DELETE, heartbeat — addresses that one minor. A source
+// that leaves a resource unstamped exposes it on every minor's
+// subscription at once; the byte-identical dedupe below collapses
+// those duplicate deliveries (and idempotent sync-grain re-deliveries
+// after a reconnect) into nothing, so the target never sees the same
+// resource addressed under two minors.
 func (m *Mirror) forwardRow(ctx context.Context, topic, ver string, row is04.GrainDataRow) {
 	switch row.Kind() {
 	case is04.ChangeAdded, is04.ChangeModified:
 		m.mu.Lock()
+		prior, had := m.cache[topic][row.Path]
+		if had && bytes.Equal(prior, row.Post) {
+			m.mu.Unlock()
+			return // another minor's view of the same document, or a sync re-delivery
+		}
 		m.cache[topic][row.Path] = row.Post
-		m.cacheVer[topic][row.Path] = ver
+		tracked := m.cacheVer[topic][row.Path]
+		if tracked == "" {
+			tracked = ver
+			m.cacheVer[topic][row.Path] = ver
+		}
 		m.mu.Unlock()
-		m.applyServeRow(topic, ver, row, true)
+		m.applyServeRow(topic, tracked, row, true)
 		// Live path: a 400 here means a parent has not been forwarded
 		// yet (the six topics stream concurrently), so allow it to
 		// trigger an ordered resync.
-		m.postResource(ctx, topic, ver, row.Post, true)
+		m.postResource(ctx, topic, tracked, row.Path, row.Post, true)
 	case is04.ChangeRemoved:
 		m.mu.Lock()
+		_, had := m.cache[topic][row.Path]
+		tracked := m.cacheVer[topic][row.Path]
 		delete(m.cache[topic], row.Path)
 		delete(m.cacheVer[topic], row.Path)
 		m.mu.Unlock()
-		m.applyServeRow(topic, ver, row, true)
-		m.deleteResource(ctx, topic, ver, row.Path)
+		if !had {
+			return // another socket already carried this removal
+		}
+		if tracked == "" {
+			tracked = ver
+		}
+		m.applyServeRow(topic, tracked, row, true)
+		m.deleteResource(ctx, topic, tracked, row.Path)
 	default:
 		m.logger.Warn("registry/mirror: grain row with neither pre nor post", "topic", topic, "id", row.Path)
 	}
@@ -385,7 +424,18 @@ func (m *Mirror) forwardRow(ctx context.Context, topic, ver string, row is04.Gra
 // landed yet) schedules an ordered resync; resync itself passes false so
 // a 400 during an already-ordered pass cannot trigger another resync (no
 // runaway loop when a resource is genuinely un-postable).
-func (m *Mirror) postResource(ctx context.Context, topic, ver string, doc json.RawMessage, allowResync bool) {
+//
+// 409 is the IS-04 version-lock: the target holds this id registered
+// under a DIFFERENT minor (its Location header names which — nmos-cpp
+// implements exactly that). Deterministic convergence: delete the
+// target's copy at the minor IT knows, then re-POST once at ours, so
+// the target ends holding the resource at its true registered minor.
+// One recovery attempt only — a second 409 is a genuine failure.
+func (m *Mirror) postResource(ctx context.Context, topic, ver, id string, doc json.RawMessage, allowResync bool) {
+	if ver == "" {
+		m.skipNoVer("POST", topic, id)
+		return
+	}
 	body, err := json.Marshal(map[string]any{
 		"type": mirrorSingular[topic],
 		"data": doc,
@@ -395,34 +445,65 @@ func (m *Mirror) postResource(ctx context.Context, topic, ver string, doc json.R
 		return
 	}
 	url := m.registrationBase(ver) + "/resource"
-	req, err := stdhttp.NewRequestWithContext(ctx, stdhttp.MethodPost, url, bytes.NewReader(body))
-	if err != nil {
-		m.fail("build POST", topic, err)
-		return
-	}
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := m.http.Do(req)
-	if err != nil {
-		m.fail("POST", topic, err)
-		return
-	}
-	drainClose(resp)
-	if resp.StatusCode != stdhttp.StatusOK && resp.StatusCode != stdhttp.StatusCreated {
-		m.fail("POST", topic, fmt.Errorf("HTTP %d", resp.StatusCode))
+	for attempt := 0; attempt < 2; attempt++ {
+		req, err := stdhttp.NewRequestWithContext(ctx, stdhttp.MethodPost, url, bytes.NewReader(body))
+		if err != nil {
+			m.fail("build POST", topic, err)
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := m.http.Do(req)
+		if err != nil {
+			m.fail("POST", topic, err)
+			return
+		}
+		status := resp.StatusCode
+		location := resp.Header.Get("Location")
+		drainClose(resp)
+		if status == stdhttp.StatusOK || status == stdhttp.StatusCreated {
+			m.mu.Lock()
+			m.stats.Forwarded++
+			if topic == "nodes" {
+				m.targetNodes[id] = true // heartbeat this node from now on
+			}
+			m.mu.Unlock()
+			return
+		}
+		if status == stdhttp.StatusConflict && attempt == 0 {
+			held := verFromLocation(location)
+			if held == "" || held == ver {
+				// No usable Location: assume the pre-upgrade addressing —
+				// the primary minor everything used to be registered at.
+				held = m.opts.APIVer
+			}
+			if held == ver {
+				m.fail("POST", topic, fmt.Errorf("HTTP 409 at %s with no other minor to reconcile", ver))
+				return
+			}
+			m.audit.event("target_ver_conflict", map[string]any{
+				"op": "POST", "topic": topic, "id": id, "ours": ver, "target": held,
+			})
+			// A node delete cascades on the target, so a follow-up resync
+			// re-POSTs any children it swept (the resync pass itself runs
+			// with allowResync=false — no loop).
+			m.deleteResource(ctx, topic, held, id)
+			if allowResync {
+				m.scheduleResync()
+			}
+			continue
+		}
+		m.fail("POST", topic, fmt.Errorf("HTTP %d", status))
 		// A target's registration face validates parent references and
 		// answers 400 for a child whose parent has not been forwarded
 		// yet. The six collections stream concurrently, so this is
 		// expected during the initial fill; a debounced ordered resync
 		// re-POSTs the whole cache node→device→source→flow→sender→
 		// receiver, after which every parent precedes its children.
-		if allowResync && resp.StatusCode == stdhttp.StatusBadRequest {
+		if allowResync && status == stdhttp.StatusBadRequest {
 			m.scheduleResync()
 		}
 		return
 	}
-	m.mu.Lock()
-	m.stats.Forwarded++
-	m.mu.Unlock()
 }
 
 // scheduleResync arms (or extends) a debounced ordered resync. Repeated
@@ -452,41 +533,97 @@ func (m *Mirror) scheduleResync() {
 
 // deleteResource DELETEs one document from the target, at the minor
 // it was forwarded on.
+//
+// 409 is the IS-04 version-lock (the target holds the id under a
+// different minor; Location names which). Deterministic convergence:
+// retry the DELETE once at the minor the TARGET knows — the goal of a
+// delete is the resource being gone, and the target's own addressing
+// is the one that removes it. Location absent falls back to the
+// primary minor (the pre-upgrade addressing everything was registered
+// under). One recovery attempt only.
 func (m *Mirror) deleteResource(ctx context.Context, topic, ver, id string) {
-	url := m.registrationBase(ver) + "/resource/" + topic + "/" + id
-	req, err := stdhttp.NewRequestWithContext(ctx, stdhttp.MethodDelete, url, nil)
-	if err != nil {
-		m.fail("build DELETE", topic, err)
+	if ver == "" {
+		m.skipNoVer("DELETE", topic, id)
 		return
 	}
-	resp, err := m.http.Do(req)
-	if err != nil {
-		m.fail("DELETE", topic, err)
+	for attempt := 0; attempt < 2; attempt++ {
+		url := m.registrationBase(ver) + "/resource/" + topic + "/" + id
+		req, err := stdhttp.NewRequestWithContext(ctx, stdhttp.MethodDelete, url, nil)
+		if err != nil {
+			m.fail("build DELETE", topic, err)
+			return
+		}
+		resp, err := m.http.Do(req)
+		if err != nil {
+			m.fail("DELETE", topic, err)
+			return
+		}
+		status := resp.StatusCode
+		location := resp.Header.Get("Location")
+		drainClose(resp)
+		// 404 is success for a delete — the target never had it.
+		if status == stdhttp.StatusNoContent || status == stdhttp.StatusNotFound {
+			m.mu.Lock()
+			m.stats.Deleted++
+			if topic == "nodes" {
+				delete(m.targetNodes, id) // no target copy left to heartbeat
+			}
+			m.mu.Unlock()
+			return
+		}
+		if status == stdhttp.StatusConflict && attempt == 0 {
+			held := verFromLocation(location)
+			if held == "" || held == ver {
+				held = m.opts.APIVer
+			}
+			if held == ver {
+				m.fail("DELETE", topic, fmt.Errorf("HTTP 409 at %s with no other minor to reconcile", ver))
+				return
+			}
+			m.audit.event("target_ver_conflict", map[string]any{
+				"op": "DELETE", "topic": topic, "id": id, "ours": ver, "target": held,
+			})
+			ver = held
+			continue
+		}
+		m.fail("DELETE", topic, fmt.Errorf("HTTP %d", status))
 		return
 	}
-	drainClose(resp)
-	// 404 is success for a delete — the target never had it.
-	if resp.StatusCode != stdhttp.StatusNoContent && resp.StatusCode != stdhttp.StatusNotFound {
-		m.fail("DELETE", topic, fmt.Errorf("HTTP %d", resp.StatusCode))
-		return
-	}
-	m.mu.Lock()
-	m.stats.Deleted++
-	m.mu.Unlock()
 }
 
-// heartbeatLoop proxies one health POST per cached source node every
-// MirrorHeartbeatInterval. A 404 answer means the target evicted us —
-// re-register the whole cached catalogue in dependency order.
+// mirrorProbeInterval rate-limits the nothing-accepted recovery probe
+// — a resync attempt every 30 s while the target holds none of our
+// nodes, instead of a heartbeat-404 → full-resync loop every tick.
+const mirrorProbeInterval = 30 * time.Second
+
+// heartbeatLoop proxies one health POST per TARGET-ACCEPTED source
+// node every MirrorHeartbeatInterval. A 404 for an accepted node
+// means the target evicted us — re-register the catalogue in
+// dependency order. A node the target never accepted is deliberately
+// NOT heartbeated (its 404 is not an eviction); when the target holds
+// none of our nodes at all — freshly restarted, or wiped — a
+// rate-limited resync probes it back to health.
 func (m *Mirror) heartbeatLoop(ctx context.Context) {
 	ticker := time.NewTicker(MirrorHeartbeatInterval)
 	defer ticker.Stop()
+	var lastProbe time.Time
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			for _, n := range m.nodeIDs() {
+			refs, unaccepted := m.nodeIDs()
+			if len(refs) == 0 && unaccepted > 0 {
+				if time.Since(lastProbe) >= mirrorProbeInterval {
+					lastProbe = time.Now()
+					m.logger.Warn("registry/mirror: target holds none of our nodes — probing with a resync",
+						"cached_nodes", unaccepted)
+					m.audit.event("target_probe_resync", map[string]any{"cached_nodes": unaccepted})
+					m.resync(ctx)
+				}
+				continue
+			}
+			for _, n := range refs {
 				if m.sendHealth(ctx, n.id, n.ver) == errMirrorEvicted {
 					m.logger.Warn("registry/mirror: target evicted node — full resync", "node", n.id)
 					m.audit.event("target_evicted", map[string]any{"node": n.id})
@@ -500,11 +637,55 @@ func (m *Mirror) heartbeatLoop(ctx context.Context) {
 
 var errMirrorEvicted = errors.New("registry/mirror: target answered 404 to a heartbeat")
 
+// errMissingVer marks a forward skipped because the resource carries
+// no wire minor — a state forwardRow/resync cannot produce; if it is
+// ever seen, the skip is audited rather than a registration URL being
+// emitted with an empty version segment.
+var errMissingVer = errors.New("registry/mirror: resource has no wire minor")
+
+// skipNoVer audits one refused forward for a resource without a wire
+// minor. That path is designed to be impossible (the minor is tracked
+// from first sight); auditing it loudly beats emitting a malformed
+// registration URL quietly.
+func (m *Mirror) skipNoVer(op, topic, id string) {
+	m.logger.Warn("registry/mirror: forward skipped — no wire minor tracked",
+		"op", op, "topic", topic, "id", id)
+	m.audit.event("forward_missing_ver", map[string]any{"op": op, "topic": topic, "id": id})
+	m.mu.Lock()
+	m.stats.Failures++
+	m.mu.Unlock()
+}
+
+// verFromLocation extracts the wire minor from an IS-04 409 response's
+// Location header — "/x-nmos/registration/v1.3/resource/nodes/<id>"
+// (absolute URLs accepted). Registries answering the version-lock 409
+// name the held version this way (nmos-cpp does). Empty when the
+// header carries no parsable registration path.
+func verFromLocation(loc string) string {
+	const marker = "/x-nmos/registration/"
+	i := strings.Index(loc, marker)
+	if i < 0 {
+		return ""
+	}
+	rest := loc[i+len(marker):]
+	if j := strings.IndexByte(rest, '/'); j >= 0 {
+		rest = rest[:j]
+	}
+	if _, _, ok := parseAPIVer(rest); !ok {
+		return ""
+	}
+	return rest
+}
+
 // sendHealth POSTs one heartbeat. The empty (non-nil sized) body is
 // deliberate: it guarantees a Content-Length header, which some
 // registries (EVS Cerebrum) demand on POST — without it they answer
 // 411 and their GC silently sweeps the catalogue.
 func (m *Mirror) sendHealth(ctx context.Context, nodeID, ver string) error {
+	if ver == "" {
+		m.skipNoVer("health", "nodes", nodeID)
+		return errMissingVer
+	}
 	url := m.registrationBase(ver) + "/health/nodes/" + nodeID
 	req, err := stdhttp.NewRequestWithContext(ctx, stdhttp.MethodPost, url, bytes.NewReader(nil))
 	if err != nil {
@@ -532,11 +713,83 @@ func (m *Mirror) sendHealth(ctx context.Context, nodeID, ver string) error {
 	}
 }
 
-// resync re-POSTs the whole cached catalogue in dependency order,
-// each resource at its registered minor.
+// refreshCacheFromSource rebuilds cache + cacheVer from the source's
+// per-minor exact-match REST views — one paged GET per registered
+// minor per topic, the same partitioning the WS legs use, so every
+// repopulated resource carries its true registered minor. An
+// unstamped source resource shows up in every minor's view; the
+// first (lowest) minor wins, matching the WS legs' first-sight rule.
+// Any fetch failure aborts the whole refresh and keeps the existing
+// cache — a half-fetched catalogue must never replace a whole one.
+func (m *Mirror) refreshCacheFromSource(ctx context.Context) {
+	clients := m.sourceClients
+	if len(clients) == 0 {
+		return // not running through Run (unit harnesses drive rows directly)
+	}
+	newCache := make(map[string]map[string]json.RawMessage, len(mirrorTopics))
+	newVer := make(map[string]map[string]string, len(mirrorTopics))
+	for _, tp := range mirrorTopics {
+		newCache[tp] = map[string]json.RawMessage{}
+		newVer[tp] = map[string]string{}
+	}
+	for _, ver := range mirrorSourceVersions(m.opts.APIVer) {
+		qc, ok := clients[ver]
+		if !ok {
+			continue
+		}
+		for _, topic := range mirrorTopics {
+			docs, err := qc.ListRaw(ctx, topic, nil)
+			if err != nil {
+				m.logger.Warn("registry/mirror: resync refresh failed — keeping the cached catalogue",
+					"topic", topic, "ver", ver, "err", err)
+				m.audit.event("resync_refresh_failed", map[string]any{
+					"topic": topic, "ver": ver, "err": err.Error(),
+				})
+				return
+			}
+			for _, doc := range docs {
+				id := docID(doc)
+				if id == "" {
+					continue
+				}
+				if _, dup := newVer[topic][id]; dup {
+					continue // unstamped at source — first minor claimed it
+				}
+				newCache[topic][id] = doc
+				newVer[topic][id] = ver
+			}
+		}
+	}
+	m.mu.Lock()
+	m.cache = newCache
+	m.cacheVer = newVer
+	// A node gone from the source stops being heartbeated (it left the
+	// cache); drop its acceptance mark too so the map tracks reality.
+	for id := range m.targetNodes {
+		if _, ok := newCache["nodes"][id]; !ok {
+			delete(m.targetNodes, id)
+		}
+	}
+	m.mu.Unlock()
+}
+
+// docID pulls the IS-04 id out of a raw resource document.
+func docID(doc json.RawMessage) string {
+	var v struct {
+		ID string `json:"id"`
+	}
+	_ = json.Unmarshal(doc, &v)
+	return v.ID
+}
+
+// resync refreshes the cache from the source's per-minor views, then
+// re-POSTs the whole catalogue in dependency order, each resource at
+// its registered minor — the end state is target == cache.
 func (m *Mirror) resync(ctx context.Context) {
 	m.audit.event("resync", nil)
+	m.refreshCacheFromSource(ctx)
 	type verDoc struct {
+		id  string
 		ver string
 		doc json.RawMessage
 	}
@@ -551,7 +804,7 @@ func (m *Mirror) resync(ctx context.Context) {
 		sort.Strings(ids) // deterministic order for tests + logs
 		docs := make([]verDoc, 0, len(ids))
 		for _, id := range ids {
-			docs = append(docs, verDoc{ver: m.cacheVer[topic][id], doc: m.cache[topic][id]})
+			docs = append(docs, verDoc{id: id, ver: m.cacheVer[topic][id], doc: m.cache[topic][id]})
 		}
 		snapshot[topic] = docs
 	}
@@ -564,7 +817,7 @@ func (m *Mirror) resync(ctx context.Context) {
 			}
 			// allowResync=false: this pass is already in dependency
 			// order, so a 400 here is a genuine reject, not a race.
-			m.postResource(ctx, topic, vd.ver, vd.doc, false)
+			m.postResource(ctx, topic, vd.ver, vd.id, vd.doc, false)
 		}
 	}
 	// The served face is fed from the same authoritative cache, so a
@@ -580,13 +833,21 @@ type nodeRef struct {
 	ver string
 }
 
-// nodeIDs snapshots the cached source node ids with their registered
-// minors, id-sorted.
-func (m *Mirror) nodeIDs() []nodeRef {
+// nodeIDs snapshots the cached source node ids the TARGET has
+// accepted, with their registered minors, id-sorted — plus the count
+// of cached nodes the target has NOT accepted yet. Only accepted
+// nodes are heartbeated (see targetNodes); the unaccepted count lets
+// the heartbeat loop probe a target that has nothing of ours at all.
+func (m *Mirror) nodeIDs() ([]nodeRef, int) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	ids := make([]string, 0, len(m.cache["nodes"]))
+	unaccepted := 0
 	for id := range m.cache["nodes"] {
+		if !m.targetNodes[id] {
+			unaccepted++
+			continue
+		}
 		ids = append(ids, id)
 	}
 	sort.Strings(ids)
@@ -594,7 +855,7 @@ func (m *Mirror) nodeIDs() []nodeRef {
 	for _, id := range ids {
 		out = append(out, nodeRef{id: id, ver: m.cacheVer["nodes"][id]})
 	}
-	return out
+	return out, unaccepted
 }
 
 // registrationBase returns the target Registration API base URL for

--- a/internal/amwa/registry/mirror.go
+++ b/internal/amwa/registry/mirror.go
@@ -71,8 +71,11 @@ type MirrorOptions struct {
 	// Target is the origin of the Registry that receives the copy,
 	// e.g. "http://10.6.250.5:8080". Registration API side.
 	Target string
-	// APIVer is the IS-04 wire version used on BOTH faces (default
-	// v1.3). The mirror does not translate between minors.
+	// APIVer is the IS-04 wire version used toward the TARGET
+	// Registration API (default v1.3). Toward the SOURCE the mirror
+	// subscribes at every registered minor in parallel — see the
+	// version-fidelity comment on Run — and forwards each document
+	// unchanged (no minor translation of the payloads themselves).
 	APIVer string
 	// Logger receives operational events. nil = slog.Default().
 	Logger *slog.Logger
@@ -88,6 +91,20 @@ type MirrorOptions struct {
 	// mirror (mirror_serve.go). Empty disables the served face —
 	// pre-#940 behaviour unchanged.
 	ServeAddr string
+	// ServeAdvertiseHost is the identity minted into the served face's
+	// ws_href and mDNS announce, as "host" or "host:port". Precedence:
+	// when set it wins outright (a bare host takes the bound serve
+	// port); when empty the bound address decides — a concrete bind IP
+	// advertises itself, an unspecified bind falls back to the OS
+	// hostname, which peers off-link may not resolve (AMWA IS-04-02
+	// test_22_2 et al fail exactly there). Set it to the address
+	// controllers actually reach.
+	ServeAdvertiseHost string
+	// ServePri is the DNS-SD `pri` TXT for the served face's
+	// _nmos-query._tcp announce. The CLI defaults it to 100 — the dev
+	// range — because the plant mirror must never win a production
+	// Registry election against its own source registry (pri 0).
+	ServePri int
 	// ServeAuthURL, when set, arms the served Query face with the
 	// BCP-003-02 Bearer gate: tokens are validated against the
 	// Authorization Server at this base URL, exactly the way the
@@ -125,7 +142,13 @@ type Mirror struct {
 	// mirror's authoritative copy of the source catalogue, used for
 	// full re-registration after a target eviction.
 	cache map[string]map[string]json.RawMessage
-	stats MirrorStats
+	// cacheVer holds each cached resource's REGISTERED wire minor —
+	// the minor of the source subscription its row arrived on. The
+	// embedded served store re-stamps resources with it so the IS-04
+	// §6.1.5 downgrade semantics survive the mirrored hop (AMWA
+	// IS-04-02 test_22/test_32). Same topic/id keys as cache.
+	cacheVer map[string]map[string]string
+	stats    MirrorStats
 	// runCtx is the context passed to Run, captured so a debounced
 	// resync fired from a timer goroutine can honour shutdown.
 	runCtx context.Context
@@ -174,14 +197,17 @@ func NewMirror(opts MirrorOptions) (*Mirror, error) {
 		opts.Logger = slog.Default()
 	}
 	cache := make(map[string]map[string]json.RawMessage, len(mirrorTopics))
+	cacheVer := make(map[string]map[string]string, len(mirrorTopics))
 	for _, tp := range mirrorTopics {
 		cache[tp] = map[string]json.RawMessage{}
+		cacheVer[tp] = map[string]string{}
 	}
 	return &Mirror{
-		opts:   opts,
-		logger: opts.Logger,
-		http:   &stdhttp.Client{Timeout: 10 * time.Second},
-		cache:  cache,
+		opts:     opts,
+		logger:   opts.Logger,
+		http:     &stdhttp.Client{Timeout: 10 * time.Second},
+		cache:    cache,
+		cacheVer: cacheVer,
 	}, nil
 }
 
@@ -197,8 +223,7 @@ func (m *Mirror) Stats() MirrorStats {
 // registry restarting must not kill the bridge) plus the heartbeat
 // proxy loop. Returns ctx.Err() on normal shutdown.
 func (m *Mirror) Run(ctx context.Context) error {
-	codec, ok := is04.Get(m.opts.APIVer)
-	if !ok {
+	if _, ok := is04.Get(m.opts.APIVer); !ok {
 		return fmt.Errorf("registry/mirror: unknown api-ver %q", m.opts.APIVer)
 	}
 	audit, err := newAuditor(m.opts.AuditPath)
@@ -214,9 +239,26 @@ func (m *Mirror) Run(ctx context.Context) error {
 	audit.event("mirror_start", map[string]any{
 		"source": m.opts.Source, "target": m.opts.Target, "api_ver": m.opts.APIVer,
 	})
-	qc, err := query.NewClient(m.opts.Source, codec)
-	if err != nil {
-		return fmt.Errorf("registry/mirror: source: %w", err)
+	// Version fidelity (AMWA IS-04-02 test_22/test_32): the source's
+	// Query API hides a resource registered at v1.0 from a v1.3
+	// subscription (IS-04 §6.1.5 no-downgrade-by-default), and a grain
+	// row carries no version stamp — so the ONLY wire-true way to
+	// mirror the whole catalogue AND learn each resource's registered
+	// minor is one subscription per registered minor per topic. The
+	// exact-match version gate on the source then partitions the
+	// catalogue: the minor of the socket a row arrived on IS that
+	// resource's registered minor.
+	clients := make(map[string]*query.Client)
+	for _, ver := range mirrorSourceVersions(m.opts.APIVer) {
+		vcodec, ok := is04.Get(ver)
+		if !ok {
+			continue // minor without a registered codec cannot be dialled
+		}
+		qc, err := query.NewClient(m.opts.Source, vcodec)
+		if err != nil {
+			return fmt.Errorf("registry/mirror: source: %w", err)
+		}
+		clients[ver] = qc
 	}
 	if m.opts.StatusAddr != "" {
 		go m.serveStatus(ctx, m.opts.StatusAddr)
@@ -231,11 +273,13 @@ func (m *Mirror) Run(ctx context.Context) error {
 
 	var wg sync.WaitGroup
 	for _, topic := range mirrorTopics {
-		wg.Add(1)
-		go func(topic string) {
-			defer wg.Done()
-			m.watchTopic(ctx, qc, topic)
-		}(topic)
+		for ver, qc := range clients {
+			wg.Add(1)
+			go func(topic, ver string, qc *query.Client) {
+				defer wg.Done()
+				m.watchTopic(ctx, qc, topic, ver)
+			}(topic, ver, qc)
+		}
 	}
 
 	wg.Add(1)
@@ -258,67 +302,90 @@ func (m *Mirror) Run(ctx context.Context) error {
 	return ctx.Err()
 }
 
-// watchTopic subscribes to one collection and forwards its grains,
-// resubscribing with a flat 2 s backoff whenever the subscription or
-// socket fails.
-func (m *Mirror) watchTopic(ctx context.Context, qc *query.Client, topic string) {
+// mirrorSourceVersions resolves the IS-04 minors the mirror subscribes
+// at on the source — every registered codec minor (the served face's
+// own fan-out, pickAPIVersions) with the target-leg primary guaranteed
+// present. See the version-fidelity comment in Run for why one
+// subscription per minor is mandatory, not an optimisation.
+func mirrorSourceVersions(primary string) []string {
+	vers := pickAPIVersions("")
+	for _, v := range vers {
+		if v == primary {
+			return vers
+		}
+	}
+	return append(vers, primary)
+}
+
+// watchTopic subscribes to one collection at one wire minor and
+// forwards its grains, resubscribing with a flat 2 s backoff whenever
+// the subscription or socket fails.
+func (m *Mirror) watchTopic(ctx context.Context, qc *query.Client, topic, ver string) {
 	for {
 		if ctx.Err() != nil {
 			return
 		}
 		sub, err := qc.Subscribe(ctx, query.SubscribeRequest{ResourcePath: "/" + topic})
 		if err != nil {
-			m.logger.Warn("registry/mirror: subscribe failed", "topic", topic, "err", err)
-			m.audit.event("ws_subscribe_failed", map[string]any{"topic": topic, "err": err.Error()})
+			m.logger.Warn("registry/mirror: subscribe failed", "topic", topic, "ver", ver, "err", err)
+			m.audit.event("ws_subscribe_failed", map[string]any{"topic": topic, "ver": ver, "err": err.Error()})
 			m.sleep(ctx, 2*time.Second)
 			continue
 		}
 		err = query.Watch(ctx, sub.WSHref, func(g *is04.Grain) error {
 			for _, row := range g.Grain.Data {
-				m.forwardRow(ctx, topic, row)
+				m.forwardRow(ctx, topic, ver, row)
 			}
 			return nil
 		}, query.WatchOptions{})
 		if ctx.Err() != nil {
 			return
 		}
-		m.logger.Warn("registry/mirror: watch ended — resubscribing", "topic", topic, "err", err)
-		m.audit.event("ws_reconnect", map[string]any{"topic": topic, "err": fmt.Sprint(err)})
+		m.logger.Warn("registry/mirror: watch ended — resubscribing", "topic", topic, "ver", ver, "err", err)
+		m.audit.event("ws_reconnect", map[string]any{"topic": topic, "ver": ver, "err": fmt.Sprint(err)})
 		m.sleep(ctx, 2*time.Second)
 	}
 }
 
-// forwardRow applies one grain row to the cache and the target.
-func (m *Mirror) forwardRow(ctx context.Context, topic string, row is04.GrainDataRow) {
+// forwardRow applies one grain row to the cache and the target. ver is
+// the wire minor of the source subscription the row arrived on — the
+// resource's registered minor, preserved into the served store's
+// version stamp.
+func (m *Mirror) forwardRow(ctx context.Context, topic, ver string, row is04.GrainDataRow) {
 	switch row.Kind() {
 	case is04.ChangeAdded, is04.ChangeModified:
 		m.mu.Lock()
 		m.cache[topic][row.Path] = row.Post
+		m.cacheVer[topic][row.Path] = ver
 		m.mu.Unlock()
-		m.applyServeRow(topic, row, true)
+		m.applyServeRow(topic, ver, row, true)
 		// Live path: a 400 here means a parent has not been forwarded
 		// yet (the six topics stream concurrently), so allow it to
 		// trigger an ordered resync.
-		m.postResource(ctx, topic, row.Post, true)
+		m.postResource(ctx, topic, ver, row.Post, true)
 	case is04.ChangeRemoved:
 		m.mu.Lock()
 		delete(m.cache[topic], row.Path)
+		delete(m.cacheVer[topic], row.Path)
 		m.mu.Unlock()
-		m.applyServeRow(topic, row, true)
-		m.deleteResource(ctx, topic, row.Path)
+		m.applyServeRow(topic, ver, row, true)
+		m.deleteResource(ctx, topic, ver, row.Path)
 	default:
 		m.logger.Warn("registry/mirror: grain row with neither pre nor post", "topic", topic, "id", row.Path)
 	}
 }
 
-// postResource POSTs one document to the target Registration API.
+// postResource POSTs one document to the target Registration API at
+// the resource's own registered minor — a v1.0 body legitimately
+// lacks fields the v1.3 schema requires, so posting it to the v1.3
+// URL would earn a 400 from any spec-strict target.
 //
 // allowResync gates the parent-missing recovery: the live forward path
 // passes true so a 400 (target rejects a child whose parent has not
 // landed yet) schedules an ordered resync; resync itself passes false so
 // a 400 during an already-ordered pass cannot trigger another resync (no
 // runaway loop when a resource is genuinely un-postable).
-func (m *Mirror) postResource(ctx context.Context, topic string, doc json.RawMessage, allowResync bool) {
+func (m *Mirror) postResource(ctx context.Context, topic, ver string, doc json.RawMessage, allowResync bool) {
 	body, err := json.Marshal(map[string]any{
 		"type": mirrorSingular[topic],
 		"data": doc,
@@ -327,7 +394,7 @@ func (m *Mirror) postResource(ctx context.Context, topic string, doc json.RawMes
 		m.fail("encode", topic, err)
 		return
 	}
-	url := m.registrationBase() + "/resource"
+	url := m.registrationBase(ver) + "/resource"
 	req, err := stdhttp.NewRequestWithContext(ctx, stdhttp.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		m.fail("build POST", topic, err)
@@ -383,9 +450,10 @@ func (m *Mirror) scheduleResync() {
 	})
 }
 
-// deleteResource DELETEs one document from the target.
-func (m *Mirror) deleteResource(ctx context.Context, topic, id string) {
-	url := m.registrationBase() + "/resource/" + topic + "/" + id
+// deleteResource DELETEs one document from the target, at the minor
+// it was forwarded on.
+func (m *Mirror) deleteResource(ctx context.Context, topic, ver, id string) {
+	url := m.registrationBase(ver) + "/resource/" + topic + "/" + id
 	req, err := stdhttp.NewRequestWithContext(ctx, stdhttp.MethodDelete, url, nil)
 	if err != nil {
 		m.fail("build DELETE", topic, err)
@@ -418,10 +486,10 @@ func (m *Mirror) heartbeatLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			for _, id := range m.nodeIDs() {
-				if m.sendHealth(ctx, id) == errMirrorEvicted {
-					m.logger.Warn("registry/mirror: target evicted node — full resync", "node", id)
-					m.audit.event("target_evicted", map[string]any{"node": id})
+			for _, n := range m.nodeIDs() {
+				if m.sendHealth(ctx, n.id, n.ver) == errMirrorEvicted {
+					m.logger.Warn("registry/mirror: target evicted node — full resync", "node", n.id)
+					m.audit.event("target_evicted", map[string]any{"node": n.id})
 					m.resync(ctx)
 					break
 				}
@@ -436,8 +504,8 @@ var errMirrorEvicted = errors.New("registry/mirror: target answered 404 to a hea
 // deliberate: it guarantees a Content-Length header, which some
 // registries (EVS Cerebrum) demand on POST — without it they answer
 // 411 and their GC silently sweeps the catalogue.
-func (m *Mirror) sendHealth(ctx context.Context, nodeID string) error {
-	url := m.registrationBase() + "/health/nodes/" + nodeID
+func (m *Mirror) sendHealth(ctx context.Context, nodeID, ver string) error {
+	url := m.registrationBase(ver) + "/health/nodes/" + nodeID
 	req, err := stdhttp.NewRequestWithContext(ctx, stdhttp.MethodPost, url, bytes.NewReader(nil))
 	if err != nil {
 		m.fail("build health", "nodes", err)
@@ -464,34 +532,39 @@ func (m *Mirror) sendHealth(ctx context.Context, nodeID string) error {
 	}
 }
 
-// resync re-POSTs the whole cached catalogue in dependency order.
+// resync re-POSTs the whole cached catalogue in dependency order,
+// each resource at its registered minor.
 func (m *Mirror) resync(ctx context.Context) {
 	m.audit.event("resync", nil)
+	type verDoc struct {
+		ver string
+		doc json.RawMessage
+	}
 	m.mu.Lock()
 	m.stats.Resyncs++
-	snapshot := make(map[string][]json.RawMessage, len(mirrorTopics))
+	snapshot := make(map[string][]verDoc, len(mirrorTopics))
 	for _, topic := range mirrorTopics {
 		ids := make([]string, 0, len(m.cache[topic]))
 		for id := range m.cache[topic] {
 			ids = append(ids, id)
 		}
 		sort.Strings(ids) // deterministic order for tests + logs
-		docs := make([]json.RawMessage, 0, len(ids))
+		docs := make([]verDoc, 0, len(ids))
 		for _, id := range ids {
-			docs = append(docs, m.cache[topic][id])
+			docs = append(docs, verDoc{ver: m.cacheVer[topic][id], doc: m.cache[topic][id]})
 		}
 		snapshot[topic] = docs
 	}
 	m.mu.Unlock()
 
 	for _, topic := range mirrorTopics {
-		for _, doc := range snapshot[topic] {
+		for _, vd := range snapshot[topic] {
 			if ctx.Err() != nil {
 				return
 			}
 			// allowResync=false: this pass is already in dependency
 			// order, so a 400 here is a genuine reject, not a race.
-			m.postResource(ctx, topic, doc, false)
+			m.postResource(ctx, topic, vd.ver, vd.doc, false)
 		}
 	}
 	// The served face is fed from the same authoritative cache, so a
@@ -500,8 +573,16 @@ func (m *Mirror) resync(ctx context.Context) {
 	m.serveReplay()
 }
 
-// nodeIDs snapshots the cached source node ids.
-func (m *Mirror) nodeIDs() []string {
+// nodeRef is one cached source node — id plus the wire minor its
+// heartbeat is proxied at.
+type nodeRef struct {
+	id  string
+	ver string
+}
+
+// nodeIDs snapshots the cached source node ids with their registered
+// minors, id-sorted.
+func (m *Mirror) nodeIDs() []nodeRef {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	ids := make([]string, 0, len(m.cache["nodes"]))
@@ -509,14 +590,25 @@ func (m *Mirror) nodeIDs() []string {
 		ids = append(ids, id)
 	}
 	sort.Strings(ids)
-	return ids
+	out := make([]nodeRef, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, nodeRef{id: id, ver: m.cacheVer["nodes"][id]})
+	}
+	return out
 }
 
-// registrationBase returns the target Registration API base URL.
-func (m *Mirror) registrationBase() string {
+// registrationBase returns the target Registration API base URL for
+// one wire minor. A target given as a bare origin gets the minor
+// appended (empty minor falls back to the primary APIVer); a target
+// the operator pinned to an explicit /x-nmos/registration/<ver> path
+// is used verbatim for every resource — their pin outranks fidelity.
+func (m *Mirror) registrationBase(ver string) string {
 	base := strings.TrimRight(m.opts.Target, "/")
 	if !strings.Contains(base, "/x-nmos/registration/") {
-		base += "/x-nmos/registration/" + m.opts.APIVer
+		if ver == "" {
+			ver = m.opts.APIVer
+		}
+		base += "/x-nmos/registration/" + ver
 	}
 	return base
 }

--- a/internal/amwa/registry/mirror_audit.go
+++ b/internal/amwa/registry/mirror_audit.go
@@ -99,7 +99,13 @@ type mirrorStatus struct {
 	CacheCounts map[string]int `json:"cache_counts"`
 	// ServeAddr is the served read-only Query face's bound address
 	// (--serve, mirror_serve.go); absent when serving is disabled.
-	ServeAddr   string       `json:"serve_addr,omitempty"`
+	ServeAddr string `json:"serve_addr,omitempty"`
+	// ServeAuth reports whether the served face is armed with the
+	// BCP-003-02 Bearer gate (--auth-url, issue #946). A pointer so a
+	// disarmed-but-serving mirror reports an explicit false while a
+	// mirror with no served face omits the key — same presence rule
+	// as serve_addr.
+	ServeAuth   *bool        `json:"serve_auth,omitempty"`
 	RecentAudit []AuditEvent `json:"recent_audit"`
 }
 
@@ -122,6 +128,8 @@ func (m *Mirror) serveStatus(ctx context.Context, addr string) {
 		}
 		if m.serve != nil {
 			st.ServeAddr = m.serve.addr
+			armed := m.opts.ServeAuthURL != ""
+			st.ServeAuth = &armed
 		}
 		m.mu.Unlock()
 		st.RecentAudit = m.audit.recent()

--- a/internal/amwa/registry/mirror_convergence_test.go
+++ b/internal/amwa/registry/mirror_convergence_test.go
@@ -1,0 +1,463 @@
+package registry
+
+// Target-leg convergence + grain-grammar tests (fleet fixes on issue
+// #946, round 3):
+//
+//   - identical re-applies emit NO grain — the store's identical-put
+//     short-circuit, proven at store level AND on a live served-face
+//     WS subscription (AMWA IS-04-02 test_24_1: `pre` belongs to
+//     modified/removed only);
+//   - a version-locked target (409 + Location, nmos-cpp style) is
+//     reconciled deterministically for both DELETE and POST;
+//   - resync refreshes the catalogue from per-minor exact-match REST
+//     views, stamping every repopulated resource's minor;
+//   - a registration URL is never emitted with an empty minor — the
+//     forward is skipped and audited instead;
+//   - a removal delivered on several minors' sockets reaches the
+//     target exactly once, at the tracked minor.
+
+import (
+	"context"
+	"encoding/json"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"dhs/internal/amwa/codec/is04"
+	"dhs/internal/amwa/session/query"
+)
+
+// newTestMirror builds an unstarted mirror wired at a target URL with
+// a live in-memory audit ring — for driving the target-leg functions
+// directly.
+func newTestMirror(t *testing.T, target string) *Mirror {
+	t.Helper()
+	m, err := NewMirror(MirrorOptions{
+		Source: "http://source.invalid:1", Target: target, APIVer: "v1.3",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.audit, _ = newAuditor("")
+	return m
+}
+
+// recordingTarget captures every request and lets a test script the
+// responses.
+type recordingTarget struct {
+	mu      sync.Mutex
+	reqs    []string // "METHOD path"
+	respond func(method, path string, w stdhttp.ResponseWriter) bool
+}
+
+func (rt *recordingTarget) handler() stdhttp.Handler {
+	return stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		rt.mu.Lock()
+		rt.reqs = append(rt.reqs, r.Method+" "+r.URL.Path)
+		rt.mu.Unlock()
+		if rt.respond != nil && rt.respond(r.Method, r.URL.Path, w) {
+			return
+		}
+		w.WriteHeader(stdhttp.StatusNotFound)
+	})
+}
+
+func (rt *recordingTarget) requests() []string {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	return append([]string(nil), rt.reqs...)
+}
+
+// TestStoreIdenticalPutEmitsNoChange: a byte-identical re-registration
+// is a no-op at the store — no Change, no update_ts bump; a genuine
+// modification still emits.
+func TestStoreIdenticalPutEmitsNoChange(t *testing.T) {
+	store := NewStore()
+	var mu sync.Mutex
+	var changes []Change
+	store.AddListener(func(c Change) {
+		mu.Lock()
+		changes = append(changes, c)
+		mu.Unlock()
+	})
+
+	const id = "0770e57e-0000-4000-8000-000000000024"
+	node := validNode(id)
+	if err := store.PutNode(node); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutNode(node); err != nil {
+		t.Fatal(err) // identical re-put must stay a nil-error no-op
+	}
+	mu.Lock()
+	n := len(changes)
+	mu.Unlock()
+	if n != 1 {
+		t.Fatalf("changes after identical re-put = %d, want 1 (created only)", n)
+	}
+	node.Label = "renamed"
+	if err := store.PutNode(node); err != nil {
+		t.Fatal(err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(changes) != 2 || changes[1].Kind != ChangeUpdated {
+		t.Fatalf("changes after real modification = %+v, want a second, updated one", changes)
+	}
+}
+
+// TestMirrorServeReplayEmitsNoGrain: on a live served-face WS
+// subscription, the add arrives as a post-only grain, a serveReplay of
+// identical documents emits NOTHING, and a genuine modification still
+// arrives (with pre+post).
+func TestMirrorServeReplayEmitsNoGrain(t *testing.T) {
+	m, push, _ := startServedMirror(t)
+	base := "http://" + m.ServeAddr()
+
+	codec, ok := is04.Get("v1.3")
+	if !ok {
+		t.Fatal("v1.3 codec not registered")
+	}
+	qc, err := query.NewClient(base, codec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sub, err := qc.Subscribe(ctx, query.SubscribeRequest{ResourcePath: "/nodes"})
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	var mu sync.Mutex
+	var rows []is04.GrainDataRow
+	go func() {
+		_ = query.Watch(ctx, sub.WSHref, func(g *is04.Grain) error {
+			mu.Lock()
+			rows = append(rows, g.Grain.Data...)
+			mu.Unlock()
+			return nil
+		}, query.WatchOptions{})
+	}()
+	// The add must arrive LIVE (a pre-subscription add would ride the
+	// sync grain, which legitimately carries pre) — wait for the
+	// subscriber socket before pushing.
+	waitFor(t, 5*time.Second, func() bool {
+		return m.Stats().ServedWSSubs >= 1
+	}, "served WS subscriber to connect")
+
+	const nodeID = "f47ac10b-58cc-4372-a567-0e02b2c3d424"
+	node := validNode(nodeID)
+	nodeDoc, _ := json.Marshal(node)
+	push.push("nodes", grainFrame("nodes", nodeID, "", string(nodeDoc)))
+
+	// The live add must arrive post-only — no pre key on an added row.
+	waitFor(t, 5*time.Second, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, r := range rows {
+			if r.Path == nodeID {
+				return true
+			}
+		}
+		return false
+	}, "added grain on the served WS")
+	mu.Lock()
+	for _, r := range rows {
+		if r.Path == nodeID && len(r.Pre) > 0 {
+			t.Errorf("added grain carries pre: %s", r.Pre)
+		}
+	}
+	before := len(rows)
+	mu.Unlock()
+
+	// Replay of identical documents: zero grains.
+	m.serveReplay()
+	time.Sleep(900 * time.Millisecond)
+	mu.Lock()
+	after := len(rows)
+	mu.Unlock()
+	if after != before {
+		t.Fatalf("serveReplay of identical docs emitted %d grain row(s) — want none", after-before)
+	}
+
+	// A real modification still flows, as modified (pre AND post).
+	renamed := node
+	renamed.Label = "renamed-after-replay"
+	renamedDoc, _ := json.Marshal(renamed)
+	push.push("nodes", grainFrame("nodes", nodeID, string(nodeDoc), string(renamedDoc)))
+	waitFor(t, 5*time.Second, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, r := range rows[before:] {
+			if r.Path == nodeID && len(r.Pre) > 0 && len(r.Post) > 0 {
+				return true
+			}
+		}
+		return false
+	}, "modified grain after the quiet replay")
+}
+
+// TestMirrorDeleteConvergesOn409: a DELETE at the tracked minor that
+// the target 409s (version-lock, Location naming the held minor) is
+// retried once at the minor the TARGET knows and lands.
+func TestMirrorDeleteConvergesOn409(t *testing.T) {
+	const nodeID = "0770e57e-0000-4000-8000-000000000409"
+	rt := &recordingTarget{}
+	rt.respond = func(method, path string, w stdhttp.ResponseWriter) bool {
+		if method != stdhttp.MethodDelete {
+			return false
+		}
+		if strings.Contains(path, "/v1.0/") {
+			w.Header().Set("Location", "/x-nmos/registration/v1.3/resource/nodes/"+nodeID)
+			w.WriteHeader(stdhttp.StatusConflict)
+			return true
+		}
+		if strings.Contains(path, "/v1.3/") {
+			w.WriteHeader(stdhttp.StatusNoContent)
+			return true
+		}
+		return false
+	}
+	ts := httptest.NewServer(rt.handler())
+	t.Cleanup(ts.Close)
+
+	m := newTestMirror(t, ts.URL)
+	m.deleteResource(context.Background(), "nodes", "v1.0", nodeID)
+
+	want := []string{
+		"DELETE /x-nmos/registration/v1.0/resource/nodes/" + nodeID,
+		"DELETE /x-nmos/registration/v1.3/resource/nodes/" + nodeID,
+	}
+	got := rt.requests()
+	if len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("target saw %v, want %v", got, want)
+	}
+	if st := m.Stats(); st.Deleted != 1 {
+		t.Errorf("stats.Deleted = %d, want 1 (%+v)", st.Deleted, st)
+	}
+	if !hasKind(auditKinds(m), "target_ver_conflict") {
+		t.Errorf("audit ring missing target_ver_conflict: %v", auditKinds(m))
+	}
+}
+
+// TestMirrorPostConvergesOn409: a POST version-lock 409 is reconciled
+// by deleting the target's copy at the minor IT names, then
+// re-POSTing once at ours — the target ends holding the resource at
+// its true registered minor.
+func TestMirrorPostConvergesOn409(t *testing.T) {
+	const nodeID = "0770e57e-0000-4000-8000-000000000410"
+	var mu sync.Mutex
+	held := true // the target holds nodeID registered under v1.3
+	rt := &recordingTarget{}
+	rt.respond = func(method, path string, w stdhttp.ResponseWriter) bool {
+		mu.Lock()
+		defer mu.Unlock()
+		switch {
+		case method == stdhttp.MethodPost && strings.Contains(path, "/v1.0/") && strings.HasSuffix(path, "/resource"):
+			if held {
+				w.Header().Set("Location", "/x-nmos/registration/v1.3/resource/nodes/"+nodeID)
+				w.WriteHeader(stdhttp.StatusConflict)
+				return true
+			}
+			w.WriteHeader(stdhttp.StatusCreated)
+			return true
+		case method == stdhttp.MethodDelete && strings.Contains(path, "/v1.3/"):
+			held = false
+			w.WriteHeader(stdhttp.StatusNoContent)
+			return true
+		}
+		return false
+	}
+	ts := httptest.NewServer(rt.handler())
+	t.Cleanup(ts.Close)
+
+	m := newTestMirror(t, ts.URL)
+	doc := json.RawMessage(`{"id":"` + nodeID + `"}`)
+	m.postResource(context.Background(), "nodes", "v1.0", nodeID, doc, false)
+
+	want := []string{
+		"POST /x-nmos/registration/v1.0/resource",
+		"DELETE /x-nmos/registration/v1.3/resource/nodes/" + nodeID,
+		"POST /x-nmos/registration/v1.0/resource",
+	}
+	got := rt.requests()
+	if len(got) != 3 || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
+		t.Fatalf("target saw %v, want %v", got, want)
+	}
+	if st := m.Stats(); st.Forwarded != 1 {
+		t.Errorf("stats.Forwarded = %d, want 1 (%+v)", st.Forwarded, st)
+	}
+	if !hasKind(auditKinds(m), "target_ver_conflict") {
+		t.Errorf("audit ring missing target_ver_conflict: %v", auditKinds(m))
+	}
+}
+
+// TestMirrorResyncRefreshStampsMinors: resync re-fetches per-minor
+// exact-match views from the source and every repopulated resource
+// carries its true minor — into cacheVer AND into the registration
+// URL the target sees.
+func TestMirrorResyncRefreshStampsMinors(t *testing.T) {
+	const nodeID = "f47ac10b-58cc-4372-a567-0e02b2c3d425"
+	nodeDoc, _ := json.Marshal(validNode(nodeID))
+
+	src := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		if r.Method == stdhttp.MethodGet && strings.HasPrefix(r.URL.Path, "/x-nmos/query/v1.3/") {
+			w.Header().Set("Content-Type", "application/json")
+			if strings.HasSuffix(r.URL.Path, "/nodes") {
+				_, _ = w.Write([]byte("[" + string(nodeDoc) + "]"))
+				return
+			}
+			_, _ = w.Write([]byte("[]"))
+			return
+		}
+		w.WriteHeader(stdhttp.StatusNotFound)
+	}))
+	t.Cleanup(src.Close)
+
+	rt := &recordingTarget{}
+	rt.respond = func(method, path string, w stdhttp.ResponseWriter) bool {
+		if method == stdhttp.MethodPost && strings.HasSuffix(path, "/resource") {
+			w.WriteHeader(stdhttp.StatusCreated)
+			return true
+		}
+		return false
+	}
+	ts := httptest.NewServer(rt.handler())
+	t.Cleanup(ts.Close)
+
+	m := newTestMirror(t, ts.URL)
+	codec, ok := is04.Get("v1.3")
+	if !ok {
+		t.Fatal("v1.3 codec not registered")
+	}
+	qc, err := query.NewClient(src.URL, codec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.sourceClients = map[string]*query.Client{"v1.3": qc}
+
+	m.resync(context.Background())
+
+	m.mu.Lock()
+	gotVer := m.cacheVer["nodes"][nodeID]
+	_, cached := m.cache["nodes"][nodeID]
+	m.mu.Unlock()
+	if !cached || gotVer != "v1.3" {
+		t.Fatalf("refresh stamped cacheVer=%q cached=%v, want v1.3/true", gotVer, cached)
+	}
+	found := false
+	for _, r := range rt.requests() {
+		if r == "POST /x-nmos/registration/v1.3/resource" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("target requests %v missing the v1.3-addressed POST", rt.requests())
+	}
+}
+
+// TestMirrorForwardSkipsEmptyVer: a resource without a tracked minor
+// is never turned into a registration URL — the forward is skipped
+// and audited.
+func TestMirrorForwardSkipsEmptyVer(t *testing.T) {
+	rt := &recordingTarget{}
+	ts := httptest.NewServer(rt.handler())
+	t.Cleanup(ts.Close)
+
+	m := newTestMirror(t, ts.URL)
+	m.postResource(context.Background(), "nodes", "", "some-id", json.RawMessage(`{"id":"x"}`), false)
+	m.deleteResource(context.Background(), "nodes", "", "some-id")
+
+	if got := rt.requests(); len(got) != 0 {
+		t.Fatalf("target must see nothing for a minor-less forward, saw %v", got)
+	}
+	if !hasKind(auditKinds(m), "forward_missing_ver") {
+		t.Errorf("audit ring missing forward_missing_ver: %v", auditKinds(m))
+	}
+	if st := m.Stats(); st.Failures != 2 {
+		t.Errorf("stats.Failures = %d, want 2 (%+v)", st.Failures, st)
+	}
+}
+
+// TestMirrorHeartbeatsOnlyAcceptedNodes: a node the target refused is
+// not heartbeated (its 404 would masquerade as an eviction and drive
+// a full-resync-per-tick thrash loop); an accepted node is.
+func TestMirrorHeartbeatsOnlyAcceptedNodes(t *testing.T) {
+	const refusedID = "f47ac10b-58cc-4372-a567-0e02b2c3d427"
+	const acceptedID = "f47ac10b-58cc-4372-a567-0e02b2c3d428"
+	rt := &recordingTarget{}
+	var refuse bool
+	rt.respond = func(method, path string, w stdhttp.ResponseWriter) bool {
+		if method == stdhttp.MethodPost && strings.HasSuffix(path, "/resource") {
+			if refuse {
+				w.WriteHeader(stdhttp.StatusBadRequest)
+			} else {
+				w.WriteHeader(stdhttp.StatusCreated)
+			}
+			return true
+		}
+		return false
+	}
+	ts := httptest.NewServer(rt.handler())
+	t.Cleanup(ts.Close)
+
+	m := newTestMirror(t, ts.URL)
+	ctx := context.Background()
+	refusedDoc, _ := json.Marshal(validNode(refusedID))
+	acceptedDoc, _ := json.Marshal(validNode(acceptedID))
+	refuse = true
+	m.forwardRow(ctx, "nodes", "v1.3", is04.GrainDataRow{Path: refusedID, Post: refusedDoc})
+	refuse = false
+	m.forwardRow(ctx, "nodes", "v1.3", is04.GrainDataRow{Path: acceptedID, Post: acceptedDoc})
+
+	refs, unaccepted := m.nodeIDs()
+	if len(refs) != 1 || refs[0].id != acceptedID || refs[0].ver != "v1.3" {
+		t.Fatalf("heartbeat set = %+v, want only the accepted node at v1.3", refs)
+	}
+	if unaccepted != 1 {
+		t.Errorf("unaccepted = %d, want 1 (the refused node)", unaccepted)
+	}
+}
+
+// TestMirrorRemovalDedupe: a removal delivered on several minors'
+// sockets (an unstamped source broadcasts deletions) reaches the
+// target exactly once, at the tracked minor.
+func TestMirrorRemovalDedupe(t *testing.T) {
+	const nodeID = "f47ac10b-58cc-4372-a567-0e02b2c3d426"
+	nodeDoc, _ := json.Marshal(validNode(nodeID))
+
+	rt := &recordingTarget{}
+	rt.respond = func(method, path string, w stdhttp.ResponseWriter) bool {
+		switch method {
+		case stdhttp.MethodPost:
+			w.WriteHeader(stdhttp.StatusCreated)
+			return true
+		case stdhttp.MethodDelete:
+			w.WriteHeader(stdhttp.StatusNoContent)
+			return true
+		}
+		return false
+	}
+	ts := httptest.NewServer(rt.handler())
+	t.Cleanup(ts.Close)
+
+	m := newTestMirror(t, ts.URL)
+	ctx := context.Background()
+	m.forwardRow(ctx, "nodes", "v1.3", is04.GrainDataRow{Path: nodeID, Post: nodeDoc})
+	removal := is04.GrainDataRow{Path: nodeID, Pre: nodeDoc}
+	m.forwardRow(ctx, "nodes", "v1.3", removal)
+	m.forwardRow(ctx, "nodes", "v1.0", removal) // second socket's copy of the same removal
+
+	var deletes []string
+	for _, r := range rt.requests() {
+		if strings.HasPrefix(r, "DELETE ") {
+			deletes = append(deletes, r)
+		}
+	}
+	if len(deletes) != 1 || !strings.Contains(deletes[0], "/v1.3/") {
+		t.Fatalf("deletes = %v, want exactly one at the tracked v1.3 minor", deletes)
+	}
+}

--- a/internal/amwa/registry/mirror_serve.go
+++ b/internal/amwa/registry/mirror_serve.go
@@ -35,9 +35,15 @@ import (
 	"strings"
 	"time"
 
+	"log/slog"
+	"strconv"
+
+	codec "dhs/internal/amwa/codec/dnssd"
 	"dhs/internal/amwa/codec/is04"
 	authsession "dhs/internal/amwa/session/auth"
+	session "dhs/internal/amwa/session/dnssd"
 	httpsession "dhs/internal/amwa/session/http"
+	registryslot "dhs/internal/registry"
 )
 
 // mirrorServe is the embedded Query face's immutable wiring — built
@@ -69,7 +75,20 @@ func (m *Mirror) startServe(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("registry/mirror: serve listen %s: %w", m.opts.ServeAddr, err)
 	}
+	// The advertise identity minted into ws_href (and announced via
+	// mDNS below). Precedence: an explicit --serve-advertise-host wins
+	// outright — a bare host is completed with the bound serve port;
+	// otherwise the bound address decides (concrete IP advertises
+	// itself, unspecified bind falls back to the OS hostname).
 	advertise := serveAdvertise(ln.Addr())
+	if m.opts.ServeAdvertiseHost != "" {
+		advertise = m.opts.ServeAdvertiseHost
+		if _, _, err := net.SplitHostPort(advertise); err != nil {
+			if _, boundPort, perr := net.SplitHostPort(ln.Addr().String()); perr == nil {
+				advertise = net.JoinHostPort(advertise, boundPort)
+			}
+		}
+	}
 	store := NewStore()
 	apiVers := pickAPIVersions("")
 	srv := httpsession.NewServer(m.logger)
@@ -185,10 +204,81 @@ func (m *Mirror) startServe(ctx context.Context) error {
 			m.logger.Warn("registry/mirror: served query face failed", "addr", ln.Addr().String(), "err", err)
 		}
 	}()
+	// DNS-SD announce of the served Query face (AMWA IS-04-02 test_02):
+	// only with an operator-provided advertise identity — the
+	// bound-address fallbacks (loopback binds, bare OS hostnames) are
+	// exactly the identities off-link peers cannot resolve, and
+	// announcing one of those helps nobody.
+	if m.opts.ServeAdvertiseHost != "" {
+		go m.announceServe(ctx, advertise, apiVers)
+	}
 	m.logger.Info("registry/mirror: serving mirrored Query API",
 		"addr", ln.Addr().String(), "api_vers", apiVers,
 		"auth", m.opts.ServeAuthURL != "")
 	return nil
+}
+
+// newServeResponder is the mDNS seam — production uses the same
+// session/dnssd backend detection Registry.Serve does; unit tests
+// inject a recording fake (same seam pattern as osHostnameFn).
+var newServeResponder = func(logger *slog.Logger) (session.Responder, error) {
+	return session.NewResponder(logger)
+}
+
+// announceServe announces the served Query face as _nmos-query._tcp
+// via the same Responder machinery Registry.Serve uses and keeps the
+// announce alive until ctx ends. mDNS being unavailable is a warning,
+// not a mirror failure — the REST face works without it.
+func (m *Mirror) announceServe(ctx context.Context, advertise string, apiVers []string) {
+	host, port, err := pickAdvertiseHostPort(registryslot.ServeOptions{AdvertiseHost: advertise})
+	if err != nil {
+		m.logger.Warn("registry/mirror: serve announce: bad advertise host",
+			"advertise", advertise, "err", err)
+		return
+	}
+	resp, err := newServeResponder(m.logger)
+	if err != nil {
+		m.logger.Warn("registry/mirror: serve announce: mDNS unavailable", "err", err)
+		return
+	}
+	defer func() { _ = resp.Close() }()
+	ins := serveAnnounceInstance(host, port, apiVers, m.opts.ServePri, m.opts.ServeAuthURL != "")
+	if err := resp.Announce(ctx, ins); err != nil {
+		m.logger.Warn("registry/mirror: serve announce failed", "err", err)
+		return
+	}
+	m.logger.Info("registry/mirror: mDNS announce active for served Query API",
+		"host", host, "port", port, "pri", m.opts.ServePri)
+	<-ctx.Done()
+}
+
+// serveAnnounceInstance builds the served face's one DNS-SD instance:
+// _nmos-query._tcp ONLY — the mirror's Query face is real, and there
+// is deliberately no _nmos-register._tcp twin because the mirror
+// refuses registrations. The TXT set mirrors Registry.Serve's
+// announce: api_proto (the served face speaks plain HTTP today),
+// api_ver per served minor, api_auth tracking the Bearer gate (#946),
+// and pri — CLI-defaulted to 100, the dev range, so the plant mirror
+// never wins a production Registry election against its own source
+// registry at pri 0.
+func serveAnnounceInstance(host string, port uint16, apiVers []string, pri int, auth bool) codec.Instance {
+	if pri < 0 {
+		pri = 0
+	}
+	return codec.Instance{
+		Name:    "dhs-nmos-mirror",
+		Service: codec.ServiceQuery,
+		Domain:  codec.DefaultDomain,
+		Host:    host,
+		Port:    port,
+		IPv4:    localIPv4Candidates(host),
+		TXT: map[string]string{
+			codec.TXTKeyAPIProto: "http",
+			codec.TXTKeyAPIVer:   strings.Join(apiVers, ","),
+			codec.TXTKeyAPIAuth:  strconv.FormatBool(auth),
+			codec.TXTKeyPriority: strconv.Itoa(pri),
+		},
+	}
 }
 
 // serveAdvertise derives the host:port minted into ws_href. A bind on
@@ -286,14 +376,20 @@ func (m *Mirror) serveWriteRejected(req *stdhttp.Request) {
 
 // applyServeRow writes one grain row through to the embedded store —
 // the same ingest/delete functions the Registration API handlers use,
-// so the store fans the change out to WS subscribers as grains.
+// so the store fans the change out to WS subscribers as grains. ver is
+// the resource's registered wire minor (the minor of the source
+// subscription the row arrived on) — stamping it here is what keeps
+// the IS-04 §6.1.5 downgrade view intact across the mirrored hop: a
+// v1.0-registered resource must stay hidden from an un-downgraded
+// v1.3 read of the served face and appear with query.downgrade=v1.0,
+// exactly as it would on the source (AMWA IS-04-02 test_22/test_32).
 //
 // allowReplay gates the parent-ordering recovery: the six topic
 // streams race, so a device can reach the store before its node; a
 // debounced ordered replay of the cache repairs that. The replay pass
 // itself runs with allowReplay=false — in dependency order a failure
 // is a genuine reject, and rescheduling would loop forever.
-func (m *Mirror) applyServeRow(topic string, row is04.GrainDataRow, allowReplay bool) {
+func (m *Mirror) applyServeRow(topic, ver string, row is04.GrainDataRow, allowReplay bool) {
 	if m.serve == nil {
 		return
 	}
@@ -305,7 +401,7 @@ func (m *Mirror) applyServeRow(topic string, row is04.GrainDataRow, allowReplay 
 	switch row.Kind() {
 	case is04.ChangeAdded, is04.ChangeModified:
 		env := &is04.RegistrationRequest{Type: t, Data: row.Post}
-		if err := m.serve.store.IngestRegistrationVersioned(env, m.opts.APIVer); err != nil {
+		if err := m.serve.store.IngestRegistrationVersioned(env, ver); err != nil {
 			m.logger.Warn("registry/mirror: serve: store ingest failed",
 				"topic", topic, "id", row.Path, "err", err)
 			if allowReplay {
@@ -355,12 +451,20 @@ func (m *Mirror) serveReplay() {
 	if m.serve == nil {
 		return
 	}
+	type verDoc struct {
+		ver string
+		doc json.RawMessage
+	}
 	m.mu.Lock()
-	snapshot := make(map[string][]json.RawMessage, len(mirrorTopics))
+	snapshot := make(map[string][]verDoc, len(mirrorTopics))
 	for _, topic := range mirrorTopics {
-		docs := make([]json.RawMessage, 0, len(m.cache[topic]))
+		docs := make([]verDoc, 0, len(m.cache[topic]))
 		for _, id := range sortedKeys(m.cache[topic]) {
-			docs = append(docs, m.cache[topic][id])
+			ver := m.cacheVer[topic][id]
+			if ver == "" {
+				ver = m.opts.APIVer
+			}
+			docs = append(docs, verDoc{ver: ver, doc: m.cache[topic][id]})
 		}
 		snapshot[topic] = docs
 	}
@@ -370,9 +474,11 @@ func (m *Mirror) serveReplay() {
 		if !ok {
 			continue
 		}
-		for _, doc := range snapshot[topic] {
-			env := &is04.RegistrationRequest{Type: t, Data: doc}
-			if err := m.serve.store.IngestRegistrationVersioned(env, m.opts.APIVer); err != nil {
+		for _, vd := range snapshot[topic] {
+			env := &is04.RegistrationRequest{Type: t, Data: vd.doc}
+			// Re-stamp at the minor the row originally arrived on —
+			// a replay must not flatten the downgrade view.
+			if err := m.serve.store.IngestRegistrationVersioned(env, vd.ver); err != nil {
 				m.logger.Warn("registry/mirror: serve: replay ingest failed",
 					"topic", topic, "err", err)
 			}

--- a/internal/amwa/registry/mirror_serve.go
+++ b/internal/amwa/registry/mirror_serve.go
@@ -30,11 +30,13 @@ import (
 	"fmt"
 	"net"
 	stdhttp "net/http"
+	"os"
 	"sort"
 	"strings"
 	"time"
 
 	"dhs/internal/amwa/codec/is04"
+	authsession "dhs/internal/amwa/session/auth"
 	httpsession "dhs/internal/amwa/session/http"
 )
 
@@ -71,6 +73,25 @@ func (m *Mirror) startServe(ctx context.Context) error {
 	store := NewStore()
 	apiVers := pickAPIVersions("")
 	srv := httpsession.NewServer(m.logger)
+	// BCP-003-02 gate on the SERVED face only (issue #946) — the same
+	// KeyCache + AuthGate wiring Registry.Serve arms with --auth-url.
+	// The route table is covered via srv.Auth; the dispatcher branches
+	// that bypass the route table (registration block, WS upgrades) are
+	// gated explicitly below, mirroring registry.go's dispatcher.
+	var authGate *httpsession.AuthGate
+	if m.opts.ServeAuthURL != "" {
+		kc := authsession.NewKeyCache(authsession.MetadataURL(m.opts.ServeAuthURL, ""), m.logger)
+		if err := kc.Fetch(ctx); err != nil {
+			m.logger.Warn("registry/mirror: initial JWKS fetch failed; served requests will 401 until keys arrive", "err", err)
+		}
+		go kc.Run(ctx)
+		gateHosts := []string{advertiseHostOnly(advertise)}
+		if hn, err := os.Hostname(); err == nil && hn != "" {
+			gateHosts = append(gateHosts, hn, hn+".local")
+		}
+		authGate = &httpsession.AuthGate{Keys: kc, Hosts: gateHosts, Logger: m.logger}
+		srv.Auth = authGate
+	}
 	wsPrefixes := make([]string, 0, len(apiVers))
 	upgradeHandlers := make(map[string]stdhttp.HandlerFunc, len(apiVers))
 	for _, apiVer := range apiVers {
@@ -88,8 +109,33 @@ func (m *Mirror) startServe(ctx context.Context) error {
 	// Same dispatcher shape as Registry.Serve (WS upgrades hijack the
 	// connection, so they bypass the route table), plus two mirror-only
 	// concerns: the registration block and the per-request audit.
+	// denyUnauthed applies the armed gate on the dispatcher branches
+	// that bypass the route table (where srv.Auth lives). True means
+	// the denial has been written — same body shape registry.go's WS
+	// branch emits. Disarmed gate denies nothing.
+	denyUnauthed := func(w stdhttp.ResponseWriter, req *stdhttp.Request) bool {
+		if authGate == nil {
+			return false
+		}
+		status, hdrs, body, _, ok := authGate.Check(req)
+		if ok {
+			return false
+		}
+		for hk, hv := range hdrs {
+			w.Header().Set(hk, hv)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(body)
+		return true
+	}
 	dispatcher := stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, req *stdhttp.Request) {
 		if req.URL.Path == "/x-nmos/registration" || strings.HasPrefix(req.URL.Path, "/x-nmos/registration/") {
+			// The armed face answers 401 before revealing anything —
+			// even the "read-only mirror" refusal is behind the gate.
+			if denyUnauthed(w, req) {
+				return
+			}
 			m.serveWriteRejected(req)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(stdhttp.StatusNotImplemented)
@@ -103,6 +149,13 @@ func (m *Mirror) startServe(ctx context.Context) error {
 		if strings.HasSuffix(req.URL.Path, "/ws") {
 			for _, prefix := range wsPrefixes {
 				if strings.HasPrefix(req.URL.Path, prefix) {
+					// The spec says a server SHALL NOT upgrade on an
+					// invalid token, and this branch bypasses the route
+					// table where srv.Auth lives — gate it explicitly,
+					// exactly like Registry.Serve's dispatcher.
+					if denyUnauthed(w, req) {
+						return
+					}
 					// Audited as serve_ws_subscribe/serve_ws_close via
 					// the lifecycle hooks, not as serve_query — and the
 					// upgrade must see the raw hijackable writer.
@@ -133,7 +186,8 @@ func (m *Mirror) startServe(ctx context.Context) error {
 		}
 	}()
 	m.logger.Info("registry/mirror: serving mirrored Query API",
-		"addr", ln.Addr().String(), "api_vers", apiVers)
+		"addr", ln.Addr().String(), "api_vers", apiVers,
+		"auth", m.opts.ServeAuthURL != "")
 	return nil
 }
 
@@ -149,6 +203,16 @@ func serveAdvertise(addr net.Addr) string {
 		host = osHostname()
 	}
 	return net.JoinHostPort(host, port)
+}
+
+// advertiseHostOnly strips the port from a host:port advertise string —
+// the auth gate's aud matching wants host identities, not endpoints.
+func advertiseHostOnly(advertise string) string {
+	host, _, err := net.SplitHostPort(advertise)
+	if err != nil {
+		return advertise
+	}
+	return host
 }
 
 // installMirrorServeRoots is installAPIRootRoutes minus the

--- a/internal/amwa/registry/mirror_serve.go
+++ b/internal/amwa/registry/mirror_serve.go
@@ -444,9 +444,11 @@ func (m *Mirror) scheduleServeReplay() {
 // serveReplay re-applies the whole cache to the embedded store in
 // dependency order (node → device → source → flow → sender →
 // receiver), so every parent precedes its children. Re-ingesting an
-// unchanged resource is an idempotent update; subscribers may see a
-// same-body modified grain on a replay, which is the honest rendering
-// of "the mirror re-asserted its copy".
+// unchanged resource is a true no-op: the store's identical-put
+// short-circuit emits NO grain for a byte-identical document, so a
+// replay never leaks a same-body "modified" grain to subscribers
+// (IS-04 §5.2 gives `pre` to modified/removed only — AMWA IS-04-02
+// test_24_1 fails on anything else).
 func (m *Mirror) serveReplay() {
 	if m.serve == nil {
 		return

--- a/internal/amwa/registry/mirror_serve_advertise_test.go
+++ b/internal/amwa/registry/mirror_serve_advertise_test.go
@@ -1,0 +1,237 @@
+package registry
+
+// Served-face advertise + announce + version-fidelity tests (fleet
+// fixes on issue #946):
+//
+//   - ws_href must carry the operator-provided advertise identity, not
+//     an unresolvable OS-hostname fallback (AMWA IS-04-02 test_22_2 /
+//     test_23_1 / test_24_1 / test_31 "Name or service not known");
+//   - the served face announces _nmos-query._tcp with the registry's
+//     own TXT shape (test_02), api_auth tracking the Bearer gate;
+//   - a row that arrived on a vX source subscription is stamped vX in
+//     the embedded store, so the IS-04 §6.1.5 downgrade view survives
+//     the mirrored hop (test_22 / test_32).
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	codec "dhs/internal/amwa/codec/dnssd"
+	"dhs/internal/amwa/codec/is04"
+	session "dhs/internal/amwa/session/dnssd"
+)
+
+// fakeResponder records Announce calls — the mirror's twin of testing
+// the registry announce path without touching the real mDNS stack.
+type fakeResponder struct {
+	announced chan codec.Instance
+}
+
+func (f *fakeResponder) Announce(_ context.Context, ins codec.Instance) error {
+	f.announced <- ins
+	return nil
+}
+func (f *fakeResponder) Update(context.Context, codec.Instance) error { return nil }
+func (f *fakeResponder) Close() error                                 { return nil }
+
+// stubServeResponder swaps the mDNS seam for a recording fake for the
+// duration of one test.
+func stubServeResponder(t *testing.T) *fakeResponder {
+	t.Helper()
+	fr := &fakeResponder{announced: make(chan codec.Instance, 4)}
+	orig := newServeResponder
+	newServeResponder = func(*slog.Logger) (session.Responder, error) { return fr, nil }
+	t.Cleanup(func() { newServeResponder = orig })
+	return fr
+}
+
+// startAdvertisedMirror boots a served mirror with an explicit
+// advertise identity (which also arms the announce path).
+func startAdvertisedMirror(t *testing.T, advHost string) *Mirror {
+	t.Helper()
+	plant := &fakePlant{}
+	target := httptest.NewServer(plant.targetHandler())
+	t.Cleanup(target.Close)
+	push := newPushSource()
+	src := httptest.NewServer(stdhttp.NotFoundHandler())
+	src.Config.Handler = push.handler(t, func() string { return src.URL })
+	t.Cleanup(src.Close)
+
+	m, err := NewMirror(MirrorOptions{
+		Source: src.URL, Target: target.URL, APIVer: "v1.3",
+		ServeAddr: "127.0.0.1:0", ServeAdvertiseHost: advHost, ServePri: 100,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = m.Run(ctx) }()
+	waitFor(t, 5*time.Second, func() bool { return m.ServeAddr() != "" }, "served face to bind")
+	return m
+}
+
+// subscribeWSHref POSTs a subscription on the served face and returns
+// the minted ws_href.
+func subscribeWSHref(t *testing.T, base string) string {
+	t.Helper()
+	resp, err := stdhttp.Post(base+"/x-nmos/query/v1.3/subscriptions", "application/json",
+		strings.NewReader(`{"resource_path":"/nodes","persist":false}`))
+	if err != nil {
+		t.Fatalf("POST subscription: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 && resp.StatusCode != 201 {
+		t.Fatalf("subscription POST = %d (%s)", resp.StatusCode, body)
+	}
+	var sub struct {
+		WSHref string `json:"ws_href"`
+	}
+	if err := json.Unmarshal(body, &sub); err != nil {
+		t.Fatalf("subscription body: %v (%s)", err, body)
+	}
+	return sub.WSHref
+}
+
+// TestMirrorServeAdvertiseWSHref: an explicit --serve-advertise-host
+// wins over the bound-address fallback in ws_href — bare host takes
+// the bound serve port, host:port is used verbatim.
+func TestMirrorServeAdvertiseWSHref(t *testing.T) {
+	stubServeResponder(t)
+
+	t.Run("bare host takes the bound port", func(t *testing.T) {
+		m := startAdvertisedMirror(t, "mirror-adv.test")
+		_, boundPort, err := net.SplitHostPort(m.ServeAddr())
+		if err != nil {
+			t.Fatal(err)
+		}
+		href := subscribeWSHref(t, "http://"+m.ServeAddr())
+		want := "ws://mirror-adv.test:" + boundPort + "/"
+		if !strings.HasPrefix(href, want) {
+			t.Errorf("ws_href = %q, want prefix %q", href, want)
+		}
+	})
+
+	t.Run("host:port used verbatim", func(t *testing.T) {
+		m := startAdvertisedMirror(t, "mirror-adv.test:9443")
+		href := subscribeWSHref(t, "http://"+m.ServeAddr())
+		if !strings.HasPrefix(href, "ws://mirror-adv.test:9443/") {
+			t.Errorf("ws_href = %q, want ws://mirror-adv.test:9443/…", href)
+		}
+	})
+}
+
+// TestMirrorServeAnnounce: an advertise identity arms the
+// _nmos-query._tcp announce with the registry's TXT shape.
+func TestMirrorServeAnnounce(t *testing.T) {
+	fr := stubServeResponder(t)
+	startAdvertisedMirror(t, "mirror-adv.test:8335")
+
+	select {
+	case ins := <-fr.announced:
+		if ins.Service != codec.ServiceQuery {
+			t.Errorf("service = %q, want %q", ins.Service, codec.ServiceQuery)
+		}
+		if ins.Host != "mirror-adv.test" || ins.Port != 8335 {
+			t.Errorf("host:port = %s:%d, want mirror-adv.test:8335", ins.Host, ins.Port)
+		}
+		if got := ins.TXT[codec.TXTKeyPriority]; got != "100" {
+			t.Errorf("pri TXT = %q, want 100", got)
+		}
+		if got := ins.TXT[codec.TXTKeyAPIAuth]; got != "false" {
+			t.Errorf("api_auth TXT = %q, want false (disarmed)", got)
+		}
+		if got := ins.TXT[codec.TXTKeyAPIVer]; !strings.Contains(got, "v1.3") {
+			t.Errorf("api_ver TXT = %q, want it to name v1.3", got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("no mDNS announce for the served Query face")
+	}
+}
+
+// TestServeAnnounceInstanceTXT pins the pure instance builder both
+// auth ways — the mirror twin of TestPickRegistryServices.
+func TestServeAnnounceInstanceTXT(t *testing.T) {
+	armed := serveAnnounceInstance("h.test", 8335, []string{"v1.2", "v1.3"}, 100, true)
+	if armed.TXT[codec.TXTKeyAPIAuth] != "true" {
+		t.Errorf("armed api_auth = %q, want true", armed.TXT[codec.TXTKeyAPIAuth])
+	}
+	if armed.TXT[codec.TXTKeyAPIVer] != "v1.2,v1.3" {
+		t.Errorf("api_ver = %q, want v1.2,v1.3", armed.TXT[codec.TXTKeyAPIVer])
+	}
+	if armed.Service != codec.ServiceQuery {
+		t.Errorf("service = %q, want %q", armed.Service, codec.ServiceQuery)
+	}
+	disarmed := serveAnnounceInstance("h.test", 8335, []string{"v1.3"}, -3, false)
+	if disarmed.TXT[codec.TXTKeyAPIAuth] != "false" {
+		t.Errorf("disarmed api_auth = %q, want false", disarmed.TXT[codec.TXTKeyAPIAuth])
+	}
+	if disarmed.TXT[codec.TXTKeyPriority] != "0" {
+		t.Errorf("negative pri = %q, want clamped to 0", disarmed.TXT[codec.TXTKeyPriority])
+	}
+}
+
+// TestMirrorServeVersionFidelity: a row that arrived on a v1.0 source
+// subscription is stamped v1.0 in the embedded store — hidden from an
+// un-downgraded v1.3 read of the served face, visible with
+// query.downgrade=v1.0, exactly as on the source (AMWA IS-04-02
+// test_22 / test_32).
+func TestMirrorServeVersionFidelity(t *testing.T) {
+	m, _, _ := startServedMirror(t)
+	base := "http://" + m.ServeAddr()
+
+	const nodeID = "0f0e0d0c-58cc-4372-a567-0e02b2c3d422"
+	nodeDoc, _ := json.Marshal(validNode(nodeID))
+	// The row arrives on the v1.0 subscription (watchTopic threads the
+	// socket's minor through) — forwardRow is the exact live path.
+	m.forwardRow(context.Background(), "nodes", "v1.0",
+		is04.GrainDataRow{Path: nodeID, Post: nodeDoc})
+
+	if got := m.serve.store.APIVerOf(is04.ResourceNode, nodeID); got != "v1.0" {
+		t.Fatalf("embedded store stamp = %q, want v1.0", got)
+	}
+	// Un-downgraded v1.3 read: hidden (no-downgrade-by-default).
+	status, body := getBody(t, base+"/x-nmos/query/v1.3/nodes")
+	if status != 200 || strings.Contains(string(body), nodeID) {
+		t.Errorf("v1.3 read = %d %s — a v1.0 resource must stay hidden without downgrade", status, body)
+	}
+	// Downgraded read: visible.
+	status, body = getBody(t, base+"/x-nmos/query/v1.3/nodes?query.downgrade=v1.0")
+	if status != 200 || !strings.Contains(string(body), nodeID) {
+		t.Errorf("downgraded read = %d %s — want the v1.0 resource", status, body)
+	}
+	// The ordered replay must not flatten the stamp.
+	m.serveReplay()
+	if got := m.serve.store.APIVerOf(is04.ResourceNode, nodeID); got != "v1.0" {
+		t.Errorf("post-replay stamp = %q, want v1.0", got)
+	}
+}
+
+// TestMirrorSourceVersions: every registered minor is subscribed, and
+// the target-leg primary always rides along.
+func TestMirrorSourceVersions(t *testing.T) {
+	// The registry test binary registers v1.3 only (mirror_test.go).
+	got := mirrorSourceVersions("v1.3")
+	if len(got) == 0 || got[len(got)-1] != "v1.3" && got[0] != "v1.3" {
+		t.Fatalf("mirrorSourceVersions(v1.3) = %v, want v1.3 present", got)
+	}
+	withPin := mirrorSourceVersions("v9.9")
+	found := false
+	for _, v := range withPin {
+		if v == "v9.9" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("mirrorSourceVersions(v9.9) = %v, want the pinned minor appended", withPin)
+	}
+}

--- a/internal/amwa/registry/mirror_serve_auth_test.go
+++ b/internal/amwa/registry/mirror_serve_auth_test.go
@@ -1,0 +1,252 @@
+package registry
+
+// Bearer-gated served Query face tests (--auth-url with --serve,
+// issue #946). Token minting follows the session/http authgate test
+// harness — dhs never issues tokens — and the mirror is armed the
+// production way: ServeAuthURL pointing at a mock RFC 8414
+// Authorization Server whose JWKS carries the minting key, so the
+// real NewKeyCache -> AuthGate path is exercised end to end.
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"dhs/internal/amwa/codec/is10"
+)
+
+var serveAuthKey, _ = rsa.GenerateKey(rand.Reader, 2048)
+
+// mockServeAS serves the RFC 8414 metadata + JWKS the mirror's
+// KeyCache fetches — the shapes TestKeyCache pins in session/auth.
+func mockServeAS(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := stdhttp.NewServeMux()
+	var ts *httptest.Server
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w stdhttp.ResponseWriter, _ *stdhttp.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                           ts.URL,
+			"authorization_endpoint":           ts.URL + "/authorize",
+			"token_endpoint":                   ts.URL + "/token",
+			"jwks_uri":                         ts.URL + "/jwks",
+			"registration_endpoint":            ts.URL + "/register",
+			"response_types_supported":         []string{"code"},
+			"code_challenge_methods_supported": []string{"S256", "plain"},
+			"grant_types_supported":            []string{"authorization_code", "client_credentials"},
+		})
+	})
+	mux.HandleFunc("/jwks", func(w stdhttp.ResponseWriter, _ *stdhttp.Request) {
+		_ = json.NewEncoder(w).Encode(is10.JWKS{Keys: []is10.JWK{{
+			Kty: "RSA", Kid: "mirror-as-1",
+			N: base64.RawURLEncoding.EncodeToString(serveAuthKey.N.Bytes()),
+			E: base64.RawURLEncoding.EncodeToString([]byte{0x01, 0x00, 0x01}),
+		}}})
+	})
+	ts = httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// mintServeToken signs an RS512 token with the mock AS's key.
+func mintServeToken(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	enc := func(v any) string {
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		return base64.RawURLEncoding.EncodeToString(b)
+	}
+	input := enc(map[string]string{"typ": "JWT", "alg": "RS512", "kid": "mirror-as-1"}) + "." + enc(claims)
+	sum := sha512.Sum512([]byte(input))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, serveAuthKey, crypto.SHA512, sum[:])
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return input + "." + base64.RawURLEncoding.EncodeToString(sig)
+}
+
+// serveQueryClaims grants read on the whole Query API, addressed to
+// the served face's advertise host (127.0.0.1 in these tests).
+func serveQueryClaims(iss string) map[string]any {
+	return map[string]any{
+		"iss": iss, "sub": "u@test",
+		"aud":       []string{"127.0.0.1"},
+		"exp":       float64(time.Now().Add(10 * time.Minute).Unix()),
+		"client_id": "c1",
+		"scope":     "query",
+		"x-nmos-query": map[string]any{
+			"read": []string{"*"},
+		},
+	}
+}
+
+// freeLoopbackAddr reserves an ephemeral 127.0.0.1 port and returns
+// it — for the status endpoint, whose bound address is not surfaced
+// the way ServeAddr is.
+func freeLoopbackAddr(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
+	_ = ln.Close()
+	return addr
+}
+
+// startAuthedServedMirror is startServedMirror with the served face
+// armed against the mock Authorization Server, plus a status endpoint.
+func startAuthedServedMirror(t *testing.T, asURL, statusAddr string) (*Mirror, *pushSource) {
+	t.Helper()
+	plant := &fakePlant{}
+	target := httptest.NewServer(plant.targetHandler())
+	t.Cleanup(target.Close)
+	push := newPushSource()
+	src := httptest.NewServer(stdhttp.NotFoundHandler())
+	src.Config.Handler = push.handler(t, func() string { return src.URL })
+	t.Cleanup(src.Close)
+
+	m, err := NewMirror(MirrorOptions{
+		Source: src.URL, Target: target.URL, APIVer: "v1.3",
+		ServeAddr: "127.0.0.1:0", ServeAuthURL: asURL,
+		StatusAddr: statusAddr,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = m.Run(ctx) }()
+	waitFor(t, 5*time.Second, func() bool { return m.ServeAddr() != "" }, "served face to bind")
+	return m, push
+}
+
+// getWithToken GETs url with an optional Bearer token.
+func getWithToken(t *testing.T, url, token string) (int, stdhttp.Header, []byte) {
+	t.Helper()
+	req, err := stdhttp.NewRequest(stdhttp.MethodGet, url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := stdhttp.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, resp.Header, body
+}
+
+// TestMirrorServeAuthGate: an armed served face 401s tokenless and
+// garbage-token reads with WWW-Authenticate, admits a valid token,
+// keeps /x-nmos readable credential-less (IS-10 rule), gates the
+// registration block, and reports serve_auth=true on /status.json.
+func TestMirrorServeAuthGate(t *testing.T) {
+	as := mockServeAS(t)
+	statusAddr := freeLoopbackAddr(t)
+	m, push := startAuthedServedMirror(t, as.URL, statusAddr)
+	base := "http://" + m.ServeAddr()
+
+	const nodeID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+	nodeDoc, _ := json.Marshal(validNode(nodeID))
+	push.push("nodes", grainFrame("nodes", nodeID, "", string(nodeDoc)))
+
+	good := mintServeToken(t, serveQueryClaims(as.URL))
+	waitFor(t, 5*time.Second, func() bool {
+		st, _, body := getWithToken(t, base+"/x-nmos/query/v1.3/nodes", good)
+		return st == 200 && strings.Contains(string(body), nodeID)
+	}, "mirrored node behind the armed gate with a valid token")
+
+	// Tokenless: 401 + WWW-Authenticate, exactly the registry's gate.
+	st, hdr, _ := getWithToken(t, base+"/x-nmos/query/v1.3/nodes", "")
+	if st != 401 || !strings.HasPrefix(hdr.Get("WWW-Authenticate"), "Bearer ") {
+		t.Errorf("tokenless = %d %q, want 401 + WWW-Authenticate: Bearer …", st, hdr.Get("WWW-Authenticate"))
+	}
+	// Garbage token: 401 invalid_token.
+	st, hdr, _ = getWithToken(t, base+"/x-nmos/query/v1.3/nodes", "not.a.jws")
+	if st != 401 || hdr.Get("WWW-Authenticate") == "" {
+		t.Errorf("garbage token = %d %q, want 401 + WWW-Authenticate", st, hdr.Get("WWW-Authenticate"))
+	}
+	// The always-readable base path needs no token at all.
+	if st, _, _ := getWithToken(t, base+"/x-nmos", ""); st != 200 {
+		t.Errorf("/x-nmos tokenless = %d, want 200 (IS-10 always-readable)", st)
+	}
+	// The registration block sits behind the gate too: tokenless is
+	// 401, not the disarmed face's 501.
+	resp, err := stdhttp.Post(base+"/x-nmos/registration/v1.3/resource", "application/json",
+		strings.NewReader(`{"type":"node","data":{}}`))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != 401 {
+		t.Errorf("tokenless registration POST = %d, want 401", resp.StatusCode)
+	}
+
+	// /status.json says the served face is armed.
+	waitFor(t, 5*time.Second, func() bool {
+		st, _, body := getWithToken(t, "http://"+statusAddr+"/status.json", "")
+		return st == 200 && strings.Contains(string(body), `"serve_auth":true`)
+	}, `"serve_auth":true on /status.json`)
+}
+
+// TestMirrorServeDisarmedStatus: a served-but-disarmed mirror reports
+// an explicit serve_auth=false (the pre-#946 tokenless behaviour is
+// pinned by the #940 serve tests).
+func TestMirrorServeDisarmedStatus(t *testing.T) {
+	plant := &fakePlant{}
+	target := httptest.NewServer(plant.targetHandler())
+	t.Cleanup(target.Close)
+	push := newPushSource()
+	src := httptest.NewServer(stdhttp.NotFoundHandler())
+	src.Config.Handler = push.handler(t, func() string { return src.URL })
+	t.Cleanup(src.Close)
+
+	statusAddr := freeLoopbackAddr(t)
+	m, err := NewMirror(MirrorOptions{
+		Source: src.URL, Target: target.URL, APIVer: "v1.3",
+		ServeAddr: "127.0.0.1:0", StatusAddr: statusAddr,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = m.Run(ctx) }()
+	waitFor(t, 5*time.Second, func() bool { return m.ServeAddr() != "" }, "served face to bind")
+
+	waitFor(t, 5*time.Second, func() bool {
+		st, _, body := getWithToken(t, "http://"+statusAddr+"/status.json", "")
+		return st == 200 && strings.Contains(string(body), `"serve_auth":false`)
+	}, `"serve_auth":false on /status.json`)
+}
+
+// TestNewMirrorServeAuthRequiresServe: --auth-url without --serve is
+// an operator error caught before anything runs.
+func TestNewMirrorServeAuthRequiresServe(t *testing.T) {
+	_, err := NewMirror(MirrorOptions{
+		Source: "http://s:1", Target: "http://t:2",
+		ServeAuthURL: "http://as:3",
+	})
+	if err == nil {
+		t.Fatal("ServeAuthURL without ServeAddr must be rejected")
+	}
+	if !strings.Contains(err.Error(), "--serve") {
+		t.Errorf("error should point the operator at --serve: %v", err)
+	}
+}

--- a/internal/amwa/registry/store.go
+++ b/internal/amwa/registry/store.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +10,20 @@ import (
 
 	"dhs/internal/amwa/codec/is04"
 )
+
+// putUnchanged reports whether a re-registered document is
+// byte-identical to the stored copy. An identical re-registration is
+// a no-op: IS-04 §5.2 grain grammar gives `pre` to modified/removed
+// events only, and a same-body "modified" grain is a spec violation
+// on the wire (AMWA IS-04-02 test_24_1 catches it — the tool sees an
+// unexpected `pre` where it awaited `added`). Both structs decoded
+// through the same codec marshal deterministically, so byte equality
+// is semantic equality.
+func putUnchanged(prev, next any) bool {
+	a, errA := json.Marshal(prev)
+	b, errB := json.Marshal(next)
+	return errA == nil && errB == nil && bytes.Equal(a, b)
+}
 
 // ErrNotFound is returned by every getter when the resource is unknown.
 var ErrNotFound = errors.New("registry: resource not found")
@@ -241,6 +256,9 @@ func (s *Store) PutNode(n is04.Node) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	prev, hadPrev := s.nodes[n.ID]
+	if hadPrev && putUnchanged(prev, n) {
+		return nil // identical re-registration: no grain, no update_ts bump
+	}
 	s.nodes[n.ID] = n
 	s.markUpdated(is04.ResourceNode, n.ID)
 	// On insert, mark health = now so the GC doesn't immediately evict.
@@ -272,6 +290,9 @@ func (s *Store) PutDevice(d is04.Device) error {
 		return fmt.Errorf("registry: device %s.node_id %q not registered", d.ID, d.NodeID)
 	}
 	prev, hadPrev := s.devices[d.ID]
+	if hadPrev && putUnchanged(prev, d) {
+		return nil
+	}
 	s.devices[d.ID] = d
 	s.markUpdated(is04.ResourceDevice, d.ID)
 	post, _ := json.Marshal(d)
@@ -298,6 +319,9 @@ func (s *Store) PutSource(src is04.Source) error {
 		return fmt.Errorf("registry: source %s.device_id %q not registered", src.ID, src.DeviceID)
 	}
 	prev, hadPrev := s.sources[src.ID]
+	if hadPrev && putUnchanged(prev, src) {
+		return nil
+	}
 	s.sources[src.ID] = src
 	s.markUpdated(is04.ResourceSource, src.ID)
 	post, _ := json.Marshal(src)
@@ -332,6 +356,9 @@ func (s *Store) PutFlow(f is04.Flow) error {
 		return fmt.Errorf("registry: flow %s.source_id %q not registered", f.ID, f.SourceID)
 	}
 	prev, hadPrev := s.flows[f.ID]
+	if hadPrev && putUnchanged(prev, f) {
+		return nil
+	}
 	s.flows[f.ID] = f
 	s.markUpdated(is04.ResourceFlow, f.ID)
 	post, _ := json.Marshal(f)
@@ -358,6 +385,9 @@ func (s *Store) PutSender(snd is04.Sender) error {
 		return fmt.Errorf("registry: sender %s.device_id %q not registered", snd.ID, snd.DeviceID)
 	}
 	prev, hadPrev := s.senders[snd.ID]
+	if hadPrev && putUnchanged(prev, snd) {
+		return nil
+	}
 	s.senders[snd.ID] = snd
 	s.markUpdated(is04.ResourceSender, snd.ID)
 	post, _ := json.Marshal(snd)
@@ -384,6 +414,9 @@ func (s *Store) PutReceiver(r is04.Receiver) error {
 		return fmt.Errorf("registry: receiver %s.device_id %q not registered", r.ID, r.DeviceID)
 	}
 	prev, hadPrev := s.receivers[r.ID]
+	if hadPrev && putUnchanged(prev, r) {
+		return nil
+	}
 	s.receivers[r.ID] = r
 	s.markUpdated(is04.ResourceReceiver, r.ID)
 	post, _ := json.Marshal(r)
@@ -408,6 +441,19 @@ func (s *Store) DeleteNode(id string) {
 	s.deleteNodeLocked(id)
 }
 
+// deletionChangeLocked builds a stamped ChangeDeleted for (t, id).
+// MUST be called BEFORE dropUpdated clears the api_ver stamp: an
+// unstamped deletion Change fans out to EVERY minor's subscribers
+// (versionAllowed treats "" as any-version), so one source-side
+// delete would reach v1.0 through v1.3 sockets alike — a downstream
+// mirror then issues one DELETE per minor and earns 409s from a
+// version-locking target. Stamped, the removal partitions exactly
+// like the add that preceded it.
+func (s *Store) deletionChangeLocked(t is04.ResourceType, id string, pre json.RawMessage, now time.Time) Change {
+	return Change{Kind: ChangeDeleted, ResourceType: t, ID: id,
+		APIVer: s.apiVerOfLocked(t, id), Pre: pre, Timestamp: now}
+}
+
 func (s *Store) deleteNodeLocked(id string) {
 	if _, ok := s.nodes[id]; !ok {
 		return
@@ -427,47 +473,53 @@ func (s *Store) deleteNodeLocked(id string) {
 		for sid, src := range s.sources {
 			if src.DeviceID == did {
 				pre, _ := json.Marshal(src)
+				c := s.deletionChangeLocked(is04.ResourceSource, sid, pre, now)
 				delete(s.sources, sid)
 				s.dropUpdated(is04.ResourceSource, sid)
 				removedSourceIDs[sid] = struct{}{}
-				s.fanOut(Change{Kind: ChangeDeleted, ResourceType: is04.ResourceSource, ID: sid, Pre: pre, Timestamp: now})
+				s.fanOut(c)
 			}
 		}
 		for fid, f := range s.flows {
 			_, sourceGone := removedSourceIDs[f.SourceID]
 			if f.DeviceID == did || sourceGone {
 				pre, _ := json.Marshal(f)
+				c := s.deletionChangeLocked(is04.ResourceFlow, fid, pre, now)
 				delete(s.flows, fid)
 				s.dropUpdated(is04.ResourceFlow, fid)
-				s.fanOut(Change{Kind: ChangeDeleted, ResourceType: is04.ResourceFlow, ID: fid, Pre: pre, Timestamp: now})
+				s.fanOut(c)
 			}
 		}
 		for sid, snd := range s.senders {
 			if snd.DeviceID == did {
 				pre, _ := json.Marshal(snd)
+				c := s.deletionChangeLocked(is04.ResourceSender, sid, pre, now)
 				delete(s.senders, sid)
 				s.dropUpdated(is04.ResourceSender, sid)
-				s.fanOut(Change{Kind: ChangeDeleted, ResourceType: is04.ResourceSender, ID: sid, Pre: pre, Timestamp: now})
+				s.fanOut(c)
 			}
 		}
 		for rid, r := range s.receivers {
 			if r.DeviceID == did {
 				pre, _ := json.Marshal(r)
+				c := s.deletionChangeLocked(is04.ResourceReceiver, rid, pre, now)
 				delete(s.receivers, rid)
 				s.dropUpdated(is04.ResourceReceiver, rid)
-				s.fanOut(Change{Kind: ChangeDeleted, ResourceType: is04.ResourceReceiver, ID: rid, Pre: pre, Timestamp: now})
+				s.fanOut(c)
 			}
 		}
 		pre, _ := json.Marshal(d)
+		c := s.deletionChangeLocked(is04.ResourceDevice, did, pre, now)
 		delete(s.devices, did)
 		s.dropUpdated(is04.ResourceDevice, did)
-		s.fanOut(Change{Kind: ChangeDeleted, ResourceType: is04.ResourceDevice, ID: did, Pre: pre, Timestamp: now})
+		s.fanOut(c)
 	}
 	pre, _ := json.Marshal(s.nodes[id])
+	c := s.deletionChangeLocked(is04.ResourceNode, id, pre, now)
 	delete(s.nodes, id)
 	delete(s.health, id)
 	s.dropUpdated(is04.ResourceNode, id)
-	s.fanOut(Change{Kind: ChangeDeleted, ResourceType: is04.ResourceNode, ID: id, Pre: pre, Timestamp: now})
+	s.fanOut(c)
 }
 
 // DeleteResource evicts a non-Node resource. For Node, use DeleteNode.
@@ -485,45 +537,50 @@ func (s *Store) DeleteResource(t is04.ResourceType, id string) error {
 			return ErrNotFound
 		}
 		pre, _ := json.Marshal(d)
+		c := s.deletionChangeLocked(t, id, pre, now)
 		delete(s.devices, id)
 		s.dropUpdated(t, id)
-		s.fanOut(Change{Kind: ChangeDeleted, ResourceType: t, ID: id, Pre: pre, Timestamp: now})
+		s.fanOut(c)
 	case is04.ResourceSource:
 		v, ok := s.sources[id]
 		if !ok {
 			return ErrNotFound
 		}
 		pre, _ := json.Marshal(v)
+		c := s.deletionChangeLocked(t, id, pre, now)
 		delete(s.sources, id)
 		s.dropUpdated(t, id)
-		s.fanOut(Change{Kind: ChangeDeleted, ResourceType: t, ID: id, Pre: pre, Timestamp: now})
+		s.fanOut(c)
 	case is04.ResourceFlow:
 		v, ok := s.flows[id]
 		if !ok {
 			return ErrNotFound
 		}
 		pre, _ := json.Marshal(v)
+		c := s.deletionChangeLocked(t, id, pre, now)
 		delete(s.flows, id)
 		s.dropUpdated(t, id)
-		s.fanOut(Change{Kind: ChangeDeleted, ResourceType: t, ID: id, Pre: pre, Timestamp: now})
+		s.fanOut(c)
 	case is04.ResourceSender:
 		v, ok := s.senders[id]
 		if !ok {
 			return ErrNotFound
 		}
 		pre, _ := json.Marshal(v)
+		c := s.deletionChangeLocked(t, id, pre, now)
 		delete(s.senders, id)
 		s.dropUpdated(t, id)
-		s.fanOut(Change{Kind: ChangeDeleted, ResourceType: t, ID: id, Pre: pre, Timestamp: now})
+		s.fanOut(c)
 	case is04.ResourceReceiver:
 		v, ok := s.receivers[id]
 		if !ok {
 			return ErrNotFound
 		}
 		pre, _ := json.Marshal(v)
+		c := s.deletionChangeLocked(t, id, pre, now)
 		delete(s.receivers, id)
 		s.dropUpdated(t, id)
-		s.fanOut(Change{Kind: ChangeDeleted, ResourceType: t, ID: id, Pre: pre, Timestamp: now})
+		s.fanOut(c)
 	default:
 		return fmt.Errorf("registry: invalid resource type %q", t)
 	}

--- a/internal/amwa/session/query/client.go
+++ b/internal/amwa/session/query/client.go
@@ -167,6 +167,14 @@ func (c *Client) ListReceivers(ctx context.Context, filter map[string]string) ([
 	return decodeList(raw, "receiver", c.Codec.DecodeReceiver)
 }
 
+// ListRaw fetches one collection as raw JSON documents, following
+// IS-04 §6.2 pagination. For callers that must keep the WIRE bytes —
+// a registry mirror caches and re-forwards documents verbatim, and a
+// typed decode + re-marshal would silently normalise them.
+func (c *Client) ListRaw(ctx context.Context, plural string, filter map[string]string) ([]json.RawMessage, error) {
+	return c.fetchListRaw(ctx, plural, filter)
+}
+
 // fetchListRaw issues GET /x-nmos/query/<api_ver>/<plural>?<filter>
 // and returns the raw JSON array, following IS-04 §6.2 pagination.
 //


### PR DESCRIPTION
Closes #946 (S2b).

## What

The mirror's served Query face is now **validated end-to-end by the AMWA tool and Bearer-gated** — and getting there surfaced and fixed seven real wire defects the read-through gate caught.

### The gate (Ansible)

A mirror-scope IS-04-02 catalog entry with split rows: the **registration row targets the source plant registry (:8235)** and the **query row targets the mirror's served face (:8335)** via the role's per-row port override — the tool writes mock resources at the source and scores every read THROUGH the mirror. (Correction from the earlier follow-up label: IS-04-03 is the Node P2P suite; the Query API is scored inside IS-04-02.) `amwa-validate-mirror.yml` keeps its parity play and gains the role invocation plus a seeded persistent subscription (the served face starts with no controller subscriptions). Baselines from fleet receipts: **pass 73, cnt 2** — the identical structural `auto_registration_5/6` pair every registry-shaped entry carries.

### Bearer gate (Go)

`registry nmos mirror --auth-url` (with `--serve`) arms the served face with the registry's exact IS-10 resource-server constructors (`NewKeyCache` → `AuthGate`); WS upgrades and the registration-501 block are gated too; `--auth-url` without `--serve` fails fast. `status.json` gains `serve_auth`. Tests run the real KeyCache→AuthGate path against a mock RFC 8414 server minting RS512 tokens. Plant default stays disarmed (Cerebrum unauthenticated today). TLS on :8335 lands with S3b's cert-pair machinery.

### What the read-through gate caught (each fixed, none baselined away)

1. **ws_href minted from an unresolvable OS hostname** — `--serve-advertise-host` now threads into the SubscriptionManager as the registry threads its advertise host.
2. **No `_nmos-query._tcp` announce** — the served face announces via the registry's machinery at `--serve-pri` (default 100: the plant mirror must never win a production election against the pri-0 source); `api_auth` TXT tracks the gate.
3. **Version fidelity, the deep one:** a single v1.3 source subscription legitimately HIDES resources registered at other minors (IS-04 no-downgrade-by-default) — a v1.0 node never reached the mirror at all. The mirror now opens one source subscription per registered minor, stamps every resource with its true minor in cache and embedded store (downgrade semantics on the served face match a real registry), and addresses the target at each resource's own minor.
4. **Store-level: deletion Changes carried no APIVer**, broadcasting one removal to every minor's subscription (the 409 storm: the mirror issued four DELETEs, three at wrong minors). Deletions are now stamped at the store and deduped at the mirror.
5. **409 convergence on IS-04's own contract** (`Location` names the held version): DELETE retries once at the held minor; POST deletes the target's stale copy then re-POSTs at the true minor; empty-minor forwards are structurally impossible and loudly audited.
6. **Heartbeat thrash closed**: heartbeats cover accepted nodes only; an empty target recovers via a rate-limited probe resync, and resync starts with a per-minor paged REST refresh so repopulated resources carry their true minors.
7. **Query-WS grammar: identical re-registrations emitted `modified` grains carrying `pre`** (tool test_24_1) — `PutX` now short-circuits byte-identical documents: no grain, no `update_ts` bump; real modifications still carry pre+post.

## Fleet receipts (2026-09-01)

- Progression across runs: fail=6 → fail=1 → **fail=0** (pass 66 → 70 → 71 → 73 with announce+seed).
- Confirm run at committed baselines: **`IS-04-02 OK pass=73/73 fail=0 cnt=2/2`**, parity 22/22, target registry converged at 22/22 (verified with `paging.limit` — nmos-cpp pages at 10 by default), zero forward failures from plant traffic; the only audited failures are the tool's own mock registrations at minors the external target doesn't serve (3 per suite run, `forward_failed` HTTP 404, documented).
- Full test sweep, vet, golangci 0 issues; `docs/cli.md` regenerated for the three new flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
