### PR TITLE
feat(ansible+registry+cli): BCP-003-01 TLS window + dual-certificate serving + mirror TLS (#948)

### DIFF
--- a/ansible/playbooks/amwa-validate-node-tls.yml
+++ b/ansible/playbooks/amwa-validate-node-tls.yml
@@ -1,0 +1,18 @@
+---
+# Validate the NODE suites over BCP-003-01 TLS (issue #948): the plant
+# residents stay plain-HTTP — only the window's transient CuT serves
+# HTTPS/WSS (--tls-cert/--tls-key with the tool CA's premade
+# dhs-node.testsuite.nmos.tv identity), and the TLS tool instance
+# (ENABLE_HTTPS=True) does the scoring. Receipts carry the -tls
+# suffix, mirroring the auth twins' convention.
+#
+#   ansible-playbook -i ansible/inventory/hosts.ini ansible/playbooks/amwa-validate-node-tls.yml
+
+- name: AMWA validate — node (tls)
+  hosts: tooling
+  gather_facts: true
+  roles:
+    - role: dhs_amwa_validate
+      vars:
+        dhs_amwa_validate_scope: node
+        dhs_amwa_validate_tls_mode: true

--- a/ansible/playbooks/amwa-validate.yml
+++ b/ansible/playbooks/amwa-validate.yml
@@ -16,3 +16,7 @@
 # running, and the auth plays only add transients they tear down.
 - import_playbook: amwa-validate-registry-auth.yml
 - import_playbook: amwa-validate-node-auth.yml
+# TLS window after the auth ones (issue #948): same transient-only
+# posture — the plant residents never serve https; only the window's
+# CuT does, scored by the TLS tool instance.
+- import_playbook: amwa-validate-node-tls.yml

--- a/ansible/roles/dhs_amwa_plant/defaults/main.yml
+++ b/ansible/roles/dhs_amwa_plant/defaults/main.yml
@@ -42,6 +42,13 @@ dhs_amwa_plant_mirror_serve_advertise: "{{ dhs_amwa_plant_advertise_ip }}:8335"
 # without --serve), so the unit template nests it inside the --serve
 # block.
 dhs_amwa_plant_mirror_serve_auth: ""
+# BCP-003-01 TLS pair for the mirror's SERVED face
+# (--serve-tls-cert/--serve-tls-key, issue #948). Empty = plain HTTP,
+# the default — Cerebrum reads the served face unauthenticated over
+# plain HTTP today. Both must be set together; only meaningful inside
+# the --serve block (the CLI refuses the pair without --serve).
+dhs_amwa_plant_mirror_serve_tls_cert: ""
+dhs_amwa_plant_mirror_serve_tls_key: ""
 dhs_amwa_plant_registry_page_limit: 1000
 # Heartbeat GC window. IS-04 §6.1 defaults to 12s and makes it
 # configurable; the CONFORMANCE plant runs 30s, matched by the AMWA

--- a/ansible/roles/dhs_amwa_plant/templates/dhs-nmos-mirror.service.j2
+++ b/ansible/roles/dhs_amwa_plant/templates/dhs-nmos-mirror.service.j2
@@ -17,6 +17,10 @@ ExecStart={{ dhs_amwa_plant_bin }} registry nmos mirror \
 {% if dhs_amwa_plant_mirror_serve_auth | default('') | length > 0 %}
   --auth-url {{ dhs_amwa_plant_mirror_serve_auth }} \
 {% endif %}
+{% if dhs_amwa_plant_mirror_serve_tls_cert | default('') | length > 0 %}
+  --serve-tls-cert {{ dhs_amwa_plant_mirror_serve_tls_cert }} \
+  --serve-tls-key {{ dhs_amwa_plant_mirror_serve_tls_key }} \
+{% endif %}
 {% endif %}
   --audit-log {{ dhs_amwa_plant_mirror_audit_log }} \
   --status-addr {{ dhs_amwa_plant_mirror_status_addr }}

--- a/ansible/roles/dhs_amwa_validate/defaults/main.yml
+++ b/ansible/roles/dhs_amwa_validate/defaults/main.yml
@@ -107,8 +107,13 @@ dhs_amwa_validate_auth_mode: false
 # a hosts-pinned name that the mock certificate actually names (SAN
 # verified: DNS:mocks.testsuite.nmos.tv, DNS:nmos-mocks.local).
 dhs_amwa_validate_tls_tool_container: nmos-testing-tls
-dhs_amwa_validate_tls_port_base: 5600
-dhs_amwa_validate_tls_ws_port_base: 6600
+# 5800, not 5600: an instance's real footprint is ~PORT_BASE..+110 —
+# the per-suite mock APIs bind at PORT_BASE+100+n, so the armed
+# instance (5500) owns 5601-5606 and a 5600 base crash-loops on
+# "port may already be in use" (first fleet run of #948). Resident
+# 5000-5110, armed 5500-5610, TLS 5800-5910.
+dhs_amwa_validate_tls_port_base: 5800
+dhs_amwa_validate_tls_ws_port_base: 6800
 dhs_amwa_validate_tls_tool_host: mocks.testsuite.nmos.tv
 dhs_amwa_validate_tls_tool_url: "https://{{ dhs_amwa_validate_tls_tool_host }}:{{ dhs_amwa_validate_tls_port_base }}/api"
 # The CuT's TLS identity: the tool image ships a PREMADE pair for

--- a/ansible/roles/dhs_amwa_validate/defaults/main.yml
+++ b/ansible/roles/dhs_amwa_validate/defaults/main.yml
@@ -115,7 +115,12 @@ dhs_amwa_validate_tls_tool_container: nmos-testing-tls
 dhs_amwa_validate_tls_port_base: 5800
 dhs_amwa_validate_tls_ws_port_base: 6800
 dhs_amwa_validate_tls_tool_host: mocks.testsuite.nmos.tv
-dhs_amwa_validate_tls_tool_url: "https://{{ dhs_amwa_validate_tls_tool_host }}:{{ dhs_amwa_validate_tls_port_base }}/api"
+# http, not https: in this tool build ENABLE_HTTPS wraps only the
+# MOCK apps (PORT_BASE+100+n serve https, verified in the container
+# logs) — the core GUI/API at PORT_BASE stays plain http, and an
+# https probe dies with SSL WRONG_VERSION_NUMBER (first #948 fleet
+# rerun). TLS on the wire lives between the tool and the CuT.
+dhs_amwa_validate_tls_tool_url: "http://localhost:{{ dhs_amwa_validate_tls_port_base }}/api"
 # The CuT's TLS identity: the tool image ships a PREMADE pair for
 # dhs-node.testsuite.nmos.tv (the historic 7/0 run's identity — SAN
 # DNS:dhs-node.testsuite.nmos.tv, notAfter 2076) under

--- a/ansible/roles/dhs_amwa_validate/defaults/main.yml
+++ b/ansible/roles/dhs_amwa_validate/defaults/main.yml
@@ -94,6 +94,47 @@ dhs_amwa_validate_auth_server_url: "http://{{ dhs_amwa_validate_tooling_host }}:
 # against different tool instances and must not interleave.
 dhs_amwa_validate_auth_mode: false
 
+# TLS window (issue #948): BCP-003-01 needs an HTTPS-scoring tool and
+# an HTTPS/WSS-only CuT. FOURTH container, same created-stopped-then-
+# pin pattern as the armed one (the #942 crash-loop lesson).
+# ENABLE_HTTPS (Config.py line 92, default False) flips the tool's
+# scheme GLOBALLY — GenericTest.py derives protocol/ws_protocol from
+# it and the tool's POST /api body carries NO per-row scheme field —
+# so selecting the TLS container IS the https knob for a suite. With
+# ENABLE_HTTPS=True every flask app INCLUDING the GUI/API serves
+# https using the shipped CERTS_MOCKS defaults (mocks.testsuite.
+# nmos.tv chains — left untouched), hence the https tool URL below at
+# a hosts-pinned name that the mock certificate actually names (SAN
+# verified: DNS:mocks.testsuite.nmos.tv, DNS:nmos-mocks.local).
+dhs_amwa_validate_tls_tool_container: nmos-testing-tls
+dhs_amwa_validate_tls_port_base: 5600
+dhs_amwa_validate_tls_ws_port_base: 6600
+dhs_amwa_validate_tls_tool_host: mocks.testsuite.nmos.tv
+dhs_amwa_validate_tls_tool_url: "https://{{ dhs_amwa_validate_tls_tool_host }}:{{ dhs_amwa_validate_tls_port_base }}/api"
+# The CuT's TLS identity: the tool image ships a PREMADE pair for
+# dhs-node.testsuite.nmos.tv (the historic 7/0 run's identity — SAN
+# DNS:dhs-node.testsuite.nmos.tv, notAfter 2076) under
+# test_data/BCP00301/ca/intermediate. No cert minting per window: the
+# generate scripts live at ca/generateCerts in this image build, but
+# `openssl ca` mutates CA state (index.txt/serial) per issue and
+# refuses same-CN re-issues — copying the premade pair is
+# deterministic. The RSA chain+key are docker-cp'd out once and the
+# CuT serves them via --tls-cert/--tls-key; tooling /etc/hosts pins
+# the name at the plant IP (host-net tool containers read the host's
+# /etc/hosts).
+dhs_amwa_validate_tls_cut_fqdn: dhs-node.testsuite.nmos.tv
+# In-container CA tree (image workdir is /home/nmos-testing) and the
+# tooling-host staging dir the material is copied to; the plant-side
+# dir the window installs the CuT pair into.
+dhs_amwa_validate_tls_image_ca_dir: /home/nmos-testing/test_data/BCP00301/ca
+dhs_amwa_validate_tls_dir: /opt/dhs-validate-tls
+dhs_amwa_validate_tls_plant_dir: /opt/dhs-amwa-plant/tls
+
+# TLS-mode scope selector: set true by the amwa-validate-*-tls.yml
+# playbooks — same exclusivity rule as auth mode: a play scores
+# against exactly one tool instance (resident / armed / TLS).
+dhs_amwa_validate_tls_mode: false
+
 # The catalog. Fields:
 #   id            AMWA suite id, verbatim
 #   scope         node | registry | controller | mirror
@@ -156,12 +197,19 @@ dhs_amwa_validate_suites:
   - { id: BCP-008-02-01, scope: node, target: node,
       rows: [{ver: v1.3}, {ver: v1.2}, {ver: v1.0, urlpath: "x-nmos/ncp/v1.0"}, {ver: v1.0}],
       baseline_pass: 94, baseline_cnt: 0 }
-  # BCP-003-01 needs the TLS-serving window (EST/cert pair) which is
-  # not encoded here yet — historic score 7/0. Follows with the
-  # auth-mode windows.
-  - { id: BCP-003-01, scope: node, target: node, enabled: false,
-      note: "TLS window not yet encoded (historic 7/0)",
-      rows: [{ver: v1.3}], baseline_pass: 7, baseline_cnt: 0 }
+  # ---- TLS window (issue #948): BCP-003-01 against an HTTPS-only CuT ----
+  # tls: true selects the TLS tool instance (ENABLE_HTTPS=True — the
+  # tool's GLOBAL https/wss switch; there is no per-row scheme field
+  # on its API) and rides only the amwa-validate-*-tls.yml plays. The
+  # row addresses the CuT by the certificate's DNS identity — the
+  # premade dhs-node.testsuite.nmos.tv pair names no IP SAN, and the
+  # tool validates against its own CA — with the port defaulting to
+  # the CuT window port; tooling /etc/hosts resolves the name.
+  # baseline_pass 7 is the historic 7/0 score — first fleet rerun
+  # confirms whether the current tool version still scores 7.
+  - { id: BCP-003-01, scope: node, target: cut, window: tls, tls: true,
+      rows: [{host: dhs-node.testsuite.nmos.tv, ver: v1.3}],
+      baseline_pass: 7, baseline_cnt: 0 }
 
   # ---- node scope, CuT windows :18500 ----
   # IS-04-01 scores a REGISTERED node against the tool's own mock

--- a/ansible/roles/dhs_amwa_validate/defaults/main.yml
+++ b/ansible/roles/dhs_amwa_validate/defaults/main.yml
@@ -115,12 +115,18 @@ dhs_amwa_validate_tls_tool_container: nmos-testing-tls
 dhs_amwa_validate_tls_port_base: 5800
 dhs_amwa_validate_tls_ws_port_base: 6800
 dhs_amwa_validate_tls_tool_host: mocks.testsuite.nmos.tv
-# Which premade CuT pair the window serves. ecdsa: BCP-003-01
-# RECOMMENDS ECDSA and the tool's test_08 warns "Server is not
-# providing an ECDSA certificate" when only RSA is offered (first
-# #948 fleet score: 6 pass + that warning; the historic 7/0 implies
-# the ECDSA pair). Both algorithms ship in the image.
-dhs_amwa_validate_tls_cut_algo: ecdsa
+# The window serves BOTH premade CuT pairs — dual-certificate TLS is
+# the compliant posture, not a choice (single-algo runs proved it on
+# the fleet): RSA-only scores 6 with test_08 warning "Server is not
+# providing an ECDSA certificate"; ECDSA-only scores 6 with test_02
+# FAILING outright ("Implementation of the following TLS 1.2 ciphers
+# is required: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256" — the spec's
+# mandatory cipher is an RSA one). Serving RSA AND ECDSA together
+# lets the handshake pick per client and satisfies both tests, so the
+# former single-algo selector var is gone; the algo list below drives
+# the copy-out, the plant install, and the transient's repeated
+# --tls-cert/--tls-key pairs.
+dhs_amwa_validate_tls_cut_algos: [rsa, ecdsa]
 # http, not https: in this tool build ENABLE_HTTPS wraps only the
 # MOCK apps (PORT_BASE+100+n serve https, verified in the container
 # logs) — the core GUI/API at PORT_BASE stays plain http, and an
@@ -134,10 +140,10 @@ dhs_amwa_validate_tls_tool_url: "http://localhost:{{ dhs_amwa_validate_tls_port_
 # generate scripts live at ca/generateCerts in this image build, but
 # `openssl ca` mutates CA state (index.txt/serial) per issue and
 # refuses same-CN re-issues — copying the premade pair is
-# deterministic. The RSA chain+key are docker-cp'd out once and the
-# CuT serves them via --tls-cert/--tls-key; tooling /etc/hosts pins
-# the name at the plant IP (host-net tool containers read the host's
-# /etc/hosts).
+# deterministic. Both algorithms' chains+keys are docker-cp'd out
+# once and the CuT serves them via repeated --tls-cert/--tls-key
+# pairs; tooling /etc/hosts pins the name at the plant IP (host-net
+# tool containers read the host's /etc/hosts).
 dhs_amwa_validate_tls_cut_fqdn: dhs-node.testsuite.nmos.tv
 # In-container CA tree (image workdir is /home/nmos-testing) and the
 # tooling-host staging dir the material is copied to; the plant-side

--- a/ansible/roles/dhs_amwa_validate/defaults/main.yml
+++ b/ansible/roles/dhs_amwa_validate/defaults/main.yml
@@ -217,8 +217,11 @@ dhs_amwa_validate_suites:
   # the CuT window port; tooling /etc/hosts resolves the name.
   # baseline_pass 7 is the historic 7/0 score — first fleet rerun
   # confirms whether the current tool version still scores 7.
+  # ver v1.0 is the BCP-003-01 SPEC version (its repo has only v1.0.x
+  # branches), not an IS-04 api_ver — v1.3 made the tool die with
+  # "No branch matching ... secure v1.3 cache/bcp-003-01".
   - { id: BCP-003-01, scope: node, target: cut, window: tls, tls: true,
-      rows: [{host: dhs-node.testsuite.nmos.tv, ver: v1.3}],
+      rows: [{host: dhs-node.testsuite.nmos.tv, ver: v1.0}],
       baseline_pass: 7, baseline_cnt: 0 }
 
   # ---- node scope, CuT windows :18500 ----

--- a/ansible/roles/dhs_amwa_validate/defaults/main.yml
+++ b/ansible/roles/dhs_amwa_validate/defaults/main.yml
@@ -115,6 +115,12 @@ dhs_amwa_validate_tls_tool_container: nmos-testing-tls
 dhs_amwa_validate_tls_port_base: 5800
 dhs_amwa_validate_tls_ws_port_base: 6800
 dhs_amwa_validate_tls_tool_host: mocks.testsuite.nmos.tv
+# Which premade CuT pair the window serves. ecdsa: BCP-003-01
+# RECOMMENDS ECDSA and the tool's test_08 warns "Server is not
+# providing an ECDSA certificate" when only RSA is offered (first
+# #948 fleet score: 6 pass + that warning; the historic 7/0 implies
+# the ECDSA pair). Both algorithms ship in the image.
+dhs_amwa_validate_tls_cut_algo: ecdsa
 # http, not https: in this tool build ENABLE_HTTPS wraps only the
 # MOCK apps (PORT_BASE+100+n serve https, verified in the container
 # logs) — the core GUI/API at PORT_BASE stays plain http, and an

--- a/ansible/roles/dhs_amwa_validate/tasks/main.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/main.yml
@@ -23,34 +23,43 @@
          | list }}
     _validate_verdicts: []
 
-# Auth-mode split (issue #942): a play scores EITHER the plain
-# entries of its scope or their auth: true twins. The twins share
-# suite ids with the plain entries, so this filter must run before
-# anything keys on id alone.
-- name: Keep only this play's auth-mode side of the catalog
+# Tool-instance split (issues #942 + #948): a play scores EITHER the
+# plain entries of its scope, their auth: true twins, or their
+# tls: true entries — never a mix, because each side scores against
+# its own tool instance (resident / armed / TLS) and interleaving
+# would change the exam. Twins share suite ids with plain entries, so
+# this filter must run before anything keys on id alone.
+- name: Keep only this play's tool-instance side of the catalog
   ansible.builtin.set_fact:
     _validate_suites: >-
-      {{ _validate_suites | selectattr('auth', 'defined') | selectattr('auth') | list
+      {{ _validate_suites | selectattr('tls', 'defined') | selectattr('tls') | list
+         if dhs_amwa_validate_tls_mode else
+         _validate_suites | selectattr('auth', 'defined') | selectattr('auth') | list
          if dhs_amwa_validate_auth_mode else
-         _validate_suites | rejectattr('auth', 'defined') | list
-         + _validate_suites | selectattr('auth', 'defined') | rejectattr('auth') | list }}
+         _validate_suites | rejectattr('auth', 'defined') | rejectattr('tls', 'defined') | list
+         + _validate_suites | selectattr('auth', 'defined') | rejectattr('auth') | list
+         + _validate_suites | selectattr('tls', 'defined') | rejectattr('tls') | list }}
     _skipped_suites: >-
-      {{ _skipped_suites | selectattr('auth', 'defined') | selectattr('auth') | list
+      {{ _skipped_suites | selectattr('tls', 'defined') | selectattr('tls') | list
+         if dhs_amwa_validate_tls_mode else
+         _skipped_suites | selectattr('auth', 'defined') | selectattr('auth') | list
          if dhs_amwa_validate_auth_mode else
-         _skipped_suites | rejectattr('auth', 'defined') | list
-         + _skipped_suites | selectattr('auth', 'defined') | rejectattr('auth') | list }}
+         _skipped_suites | rejectattr('auth', 'defined') | rejectattr('tls', 'defined') | list
+         + _skipped_suites | selectattr('auth', 'defined') | rejectattr('auth') | list
+         + _skipped_suites | selectattr('tls', 'defined') | rejectattr('tls') | list }}
 
 - name: Apply the subset filter
   ansible.builtin.set_fact:
     _validate_suites: "{{ _validate_suites | selectattr('id', 'in', dhs_amwa_validate_only) | list }}"
   when: dhs_amwa_validate_only | length > 0
 
-# The armed tool instance only converges/preflights when an auth
-# window will actually use it — a plain scope run must not create or
+# The armed/TLS tool instances only converge/preflight when a window
+# will actually use them — a plain scope run must not create or
 # assert containers it never talks to.
-- name: Note whether this play needs the armed tool instance
+- name: Note whether this play needs the armed or TLS tool instances
   ansible.builtin.set_fact:
     _validate_need_auth: "{{ _validate_suites | selectattr('auth', 'defined') | selectattr('auth') | list | length > 0 }}"
+    _validate_need_tls: "{{ _validate_suites | selectattr('tls', 'defined') | selectattr('tls') | list | length > 0 }}"
 
 - name: Converge the tooling host
   ansible.builtin.include_tasks: tooling.yml

--- a/ansible/roles/dhs_amwa_validate/tasks/preflight.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/preflight.yml
@@ -105,6 +105,61 @@
   until: _auth_meta.status == 200
   when: _validate_need_auth
 
+# ---- the TLS tool instance (issue #948) ----
+# Same shape as the armed checks: a TLS play asserts ONLY its own
+# instance plus the resident (whose disarmed/plain state is part of
+# the contract, asserted above).
+- name: Read the TLS tool container image
+  ansible.builtin.command: docker inspect --format {% raw %}"{{.Config.Image}}"{% endraw %} {{ dhs_amwa_validate_tls_tool_container }}
+  register: _tls_tool_image
+  changed_when: false
+  when: _validate_need_tls
+
+- name: The TLS tool image must be the pinned one
+  ansible.builtin.assert:
+    that: _tls_tool_image.stdout.strip() == dhs_amwa_validate_tool_image
+    fail_msg: >-
+      TLS tool container runs {{ _tls_tool_image.stdout }} — the gate
+      is only meaningful against {{ dhs_amwa_validate_tool_image }}
+  when: _validate_need_tls
+
+- name: Read the TLS tool UserConfig
+  ansible.builtin.command: docker exec {{ dhs_amwa_validate_tls_tool_container }} cat /config/UserConfig.py
+  register: _tls_tool_cfg
+  changed_when: false
+  when: _validate_need_tls
+
+- name: The TLS tool knobs must match the https profile
+  ansible.builtin.assert:
+    that:
+      - "'PULL_REPOS = False' in _tls_tool_cfg.stdout"
+      - "'CONFIG.GARBAGE_COLLECTION_TIMEOUT = 30' in _tls_tool_cfg.stdout"
+      - "'CONFIG.ENABLE_HTTPS = True' in _tls_tool_cfg.stdout"
+      - "('CONFIG.PORT_BASE = ' ~ dhs_amwa_validate_tls_port_base) in _tls_tool_cfg.stdout"
+      - "'ENABLE_AUTH' not in _tls_tool_cfg.stdout"
+    fail_msg: >-
+      TLS /config/UserConfig.py drifted — expected PULL_REPOS=False,
+      CONFIG.GARBAGE_COLLECTION_TIMEOUT=30 and https ON at
+      PORT_BASE {{ dhs_amwa_validate_tls_port_base }} (auth stays off).
+      Got: {{ _tls_tool_cfg.stdout }}
+  when: _validate_need_tls
+
+# ENABLE_HTTPS makes the GUI/API itself serve https (every flask app
+# gets the ssl_context) — so the probe is https, CA-validated against
+# the image's own root at the hosts-pinned mock identity. Same long
+# first-boot window as the armed instance.
+- name: The TLS tool API must answer over https
+  ansible.builtin.uri:
+    url: "{{ dhs_amwa_validate_tls_tool_url }}"
+    method: GET
+    status_code: [200, 405]
+    ca_path: "{{ dhs_amwa_validate_tls_dir }}/ca.cert.pem"
+  register: _tls_tool_api
+  retries: 36
+  delay: 5
+  until: _tls_tool_api.status in [200, 405]
+  when: _validate_need_tls
+
 # Stamped from a live clock read, NOT ansible_date_time — cached facts
 # hand every run the same stamp and the runs then overwrite each other.
 - name: Stamp the run

--- a/ansible/roles/dhs_amwa_validate/tasks/preflight.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/preflight.yml
@@ -144,20 +144,34 @@
       Got: {{ _tls_tool_cfg.stdout }}
   when: _validate_need_tls
 
-# ENABLE_HTTPS makes the GUI/API itself serve https (every flask app
-# gets the ssl_context) — so the probe is https, CA-validated against
-# the image's own root at the hosts-pinned mock identity. Same long
-# first-boot window as the armed instance.
-- name: The TLS tool API must answer over https
+# In this tool build ENABLE_HTTPS wraps only the mock apps; the core
+# GUI/API stays plain http (see the tls_tool_url comment). The https
+# part is asserted separately below. Same long first-boot window as
+# the armed instance.
+- name: The TLS tool API must answer
   ansible.builtin.uri:
     url: "{{ dhs_amwa_validate_tls_tool_url }}"
     method: GET
     status_code: [200, 405]
-    ca_path: "{{ dhs_amwa_validate_tls_dir }}/ca.cert.pem"
   register: _tls_tool_api
   retries: 36
   delay: 5
   until: _tls_tool_api.status in [200, 405]
+  when: _validate_need_tls
+
+# The part that IS https: a mock app (PORT_BASE+101) must serve TLS
+# CA-validated at the hosts-pinned mock identity — proof the instance
+# really runs in https mode before a suite spends its window.
+- name: A TLS tool mock must serve https with the shipped chain
+  ansible.builtin.uri:
+    url: "https://{{ dhs_amwa_validate_tls_tool_host }}:{{ dhs_amwa_validate_tls_port_base + 101 }}/"
+    method: GET
+    status_code: [200, 404]
+    ca_path: "{{ dhs_amwa_validate_tls_dir }}/ca.cert.pem"
+  register: _tls_mock_api
+  retries: 5
+  delay: 3
+  until: _tls_mock_api.status in [200, 404]
   when: _validate_need_tls
 
 # Stamped from a live clock read, NOT ansible_date_time — cached facts

--- a/ansible/roles/dhs_amwa_validate/tasks/report.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/report.yml
@@ -4,12 +4,13 @@
 # AMWA spec link. The play FAILS at the end (not mid-run) so a
 # regression in one suite never hides the results of the rest.
 
-# Auth twins (issue #942) carry a " (auth)" suffix so an armed run's
-# line can never be misread as its plain sibling's.
+# Auth twins (issue #942) carry a " (auth)" suffix — and TLS entries
+# (issue #948) a " (tls)" one — so a windowed run's line can never be
+# misread as its plain sibling's.
 - name: Suite summary
   ansible.builtin.debug:
     msg: >-
-      {{ '%-16s' | format(item.suite ~ (' (auth)' if item.auth | default(false) else '')) }}
+      {{ '%-16s' | format(item.suite ~ (' (auth)' if item.auth | default(false) else (' (tls)' if item.tls | default(false) else ''))) }}
       {{ 'OK  ' if item.ok else 'FAIL' }}
       pass={{ item['pass'] }}/{{ item.baseline_pass }}
       fail={{ item.fail }} cnt={{ item.cnt }}/{{ item.baseline_cnt }}
@@ -18,7 +19,7 @@
       {{ '(+%d above baseline — raise it in git)' | format(item.above_baseline) if item.above_baseline > 0 else '' }}
   loop: "{{ _validate_verdicts }}"
   loop_control:
-    label: "{{ item.suite }}{{ ' (auth)' if item.auth | default(false) else '' }}"
+    label: "{{ item.suite }}{{ ' (auth)' if item.auth | default(false) else (' (tls)' if item.tls | default(false) else '') }}"
 
 # Per-test detail: every non-pass row, named by the tool's own test
 # names, with the reason and the AMWA spec link.
@@ -27,7 +28,7 @@
     msg: "[{{ item.1.state }}] {{ item.1.test }}: {{ item.1.reason }}{% if item.1.amwa_link %}  ({{ item.1.amwa_link }}){% endif %}"
   loop: "{{ _validate_verdicts | subelements('problems') }}"
   loop_control:
-    label: "{{ item.0.suite }}{{ ' (auth)' if item.0.auth | default(false) else '' }} {{ item.1.test }}"
+    label: "{{ item.0.suite }}{{ ' (auth)' if item.0.auth | default(false) else (' (tls)' if item.0.tls | default(false) else '') }} {{ item.1.test }}"
 
 - name: Suites this play cannot drive yet
   ansible.builtin.debug:

--- a/ansible/roles/dhs_amwa_validate/tasks/suite_attempt.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/suite_attempt.yml
@@ -40,7 +40,6 @@
     - name: "{{ suite.id }} — score with the TLS tool instance"
       ansible.builtin.set_fact:
         _tool_url_override: "{{ dhs_amwa_validate_tls_tool_url }}"
-        _tool_ca_override: "{{ dhs_amwa_validate_tls_dir }}/ca.cert.pem"
       when: suite.tls | default(false)
 
     # Fill each row's absent members from the (possibly window-

--- a/ansible/roles/dhs_amwa_validate/tasks/suite_attempt.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/suite_attempt.yml
@@ -8,12 +8,13 @@
   ansible.builtin.set_fact:
     _attempt_suffix: "{{ '-retry' if _suite_verdict else '' }}"
     # Result-file stem: auth twins keep the manual sweep's
-    # <SUITE>-auth.json convention so armed and plain receipts of the
-    # same suite id never overwrite each other.
-    _suite_file: "{{ suite.id }}{{ '-auth' if suite.auth | default(false) else '' }}"
+    # <SUITE>-auth.json convention (tls entries the -tls sibling) so
+    # receipts of the same suite id never overwrite each other.
+    _suite_file: "{{ suite.id }}{{ '-auth' if suite.auth | default(false) else ('-tls' if suite.tls | default(false) else '') }}"
     _suite_host_override: !!null
     _suite_port_override: !!null
     _tool_url_override: !!null
+    _tool_ca_override: !!null
     _norm_rows: []
 
 - name: "{{ suite.id }} — attempt{{ _attempt_suffix }}"
@@ -30,6 +31,17 @@
       ansible.builtin.set_fact:
         _tool_url_override: "{{ dhs_amwa_validate_auth_tool_url }}"
       when: suite.auth | default(false)
+
+    # TLS suites are scored by the TLS tool instance (issue #948):
+    # ENABLE_HTTPS there flips the tool's scheme globally (its API
+    # carries no per-row scheme field), and the instance's own API
+    # serves https — the invocation validates it against the image's
+    # CA copied out at tooling-converge time.
+    - name: "{{ suite.id }} — score with the TLS tool instance"
+      ansible.builtin.set_fact:
+        _tool_url_override: "{{ dhs_amwa_validate_tls_tool_url }}"
+        _tool_ca_override: "{{ dhs_amwa_validate_tls_dir }}/ca.cert.pem"
+      when: suite.tls | default(false)
 
     # Fill each row's absent members from the (possibly window-
     # overridden) target. An EXPLICIT null in the catalog stays null —
@@ -55,6 +67,7 @@
         body_format: json
         timeout: "{{ dhs_amwa_validate_suite_timeout }}"
         return_content: true
+        ca_path: "{{ _tool_ca_override | default(omit, true) }}"
         body:
           suite: "{{ suite.id }}"
           host: "{{ _norm_rows | map(attribute='host') | list }}"
@@ -85,7 +98,8 @@
         _suite_verdict: >-
           {{ _suite_gate.stdout | from_json
              | combine({'retried': _attempt_suffix != '',
-                        'auth': suite.auth | default(false)}) }}
+                        'auth': suite.auth | default(false),
+                        'tls': suite.tls | default(false)}) }}
   always:
     - name: "{{ suite.id }} — close the window"
       ansible.builtin.include_tasks: window_teardown.yml

--- a/ansible/roles/dhs_amwa_validate/tasks/tooling.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/tooling.yml
@@ -196,21 +196,26 @@
     mode: "0755"
   when: _validate_need_tls
 
-- name: Copy the CuT chain + key + CA out of the tool image
+# BOTH algorithms come out: dual-certificate serving needs the RSA
+# pair (mandatory cipher set, test_02) AND the ECDSA pair
+# (recommended posture, test_08 warns without it).
+- name: Copy the CuT chains + keys out of the tool image (both algorithms)
   ansible.builtin.command: >-
-    docker cp {{ dhs_amwa_validate_tool_container }}:{{ item.src }}
-    {{ dhs_amwa_validate_tls_dir }}/{{ item.dest }}
+    docker cp {{ dhs_amwa_validate_tool_container }}:{{ dhs_amwa_validate_tls_image_ca_dir }}/intermediate/{{ 'certs' if item.1 == 'cert.chain.pem' else 'private' }}/{{ item.0 }}.{{ dhs_amwa_validate_tls_cut_fqdn }}.{{ item.1 }}
+    {{ dhs_amwa_validate_tls_dir }}/{{ item.0 }}.{{ dhs_amwa_validate_tls_cut_fqdn }}.{{ item.1 }}
   args:
-    creates: "{{ dhs_amwa_validate_tls_dir }}/{{ item.dest }}"
-  loop:
-    - { src: "{{ dhs_amwa_validate_tls_image_ca_dir }}/intermediate/certs/{{ dhs_amwa_validate_tls_cut_algo }}.{{ dhs_amwa_validate_tls_cut_fqdn }}.cert.chain.pem",
-        dest: "{{ dhs_amwa_validate_tls_cut_algo }}.{{ dhs_amwa_validate_tls_cut_fqdn }}.cert.chain.pem" }
-    - { src: "{{ dhs_amwa_validate_tls_image_ca_dir }}/intermediate/private/{{ dhs_amwa_validate_tls_cut_algo }}.{{ dhs_amwa_validate_tls_cut_fqdn }}.key.pem",
-        dest: "{{ dhs_amwa_validate_tls_cut_algo }}.{{ dhs_amwa_validate_tls_cut_fqdn }}.key.pem" }
-    - { src: "{{ dhs_amwa_validate_tls_image_ca_dir }}/certs/ca.cert.pem",
-        dest: "ca.cert.pem" }
+    creates: "{{ dhs_amwa_validate_tls_dir }}/{{ item.0 }}.{{ dhs_amwa_validate_tls_cut_fqdn }}.{{ item.1 }}"
+  loop: "{{ dhs_amwa_validate_tls_cut_algos | product(['cert.chain.pem', 'key.pem']) | list }}"
   loop_control:
-    label: "{{ item.dest }}"
+    label: "{{ item.0 }}.{{ item.1 }}"
+  when: _validate_need_tls
+
+- name: Copy the CA out of the tool image
+  ansible.builtin.command: >-
+    docker cp {{ dhs_amwa_validate_tool_container }}:{{ dhs_amwa_validate_tls_image_ca_dir }}/certs/ca.cert.pem
+    {{ dhs_amwa_validate_tls_dir }}/ca.cert.pem
+  args:
+    creates: "{{ dhs_amwa_validate_tls_dir }}/ca.cert.pem"
   when: _validate_need_tls
 
 - name: The TLS tool container exists

--- a/ansible/roles/dhs_amwa_validate/tasks/tooling.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/tooling.yml
@@ -203,10 +203,10 @@
   args:
     creates: "{{ dhs_amwa_validate_tls_dir }}/{{ item.dest }}"
   loop:
-    - { src: "{{ dhs_amwa_validate_tls_image_ca_dir }}/intermediate/certs/rsa.{{ dhs_amwa_validate_tls_cut_fqdn }}.cert.chain.pem",
-        dest: "rsa.{{ dhs_amwa_validate_tls_cut_fqdn }}.cert.chain.pem" }
-    - { src: "{{ dhs_amwa_validate_tls_image_ca_dir }}/intermediate/private/rsa.{{ dhs_amwa_validate_tls_cut_fqdn }}.key.pem",
-        dest: "rsa.{{ dhs_amwa_validate_tls_cut_fqdn }}.key.pem" }
+    - { src: "{{ dhs_amwa_validate_tls_image_ca_dir }}/intermediate/certs/{{ dhs_amwa_validate_tls_cut_algo }}.{{ dhs_amwa_validate_tls_cut_fqdn }}.cert.chain.pem",
+        dest: "{{ dhs_amwa_validate_tls_cut_algo }}.{{ dhs_amwa_validate_tls_cut_fqdn }}.cert.chain.pem" }
+    - { src: "{{ dhs_amwa_validate_tls_image_ca_dir }}/intermediate/private/{{ dhs_amwa_validate_tls_cut_algo }}.{{ dhs_amwa_validate_tls_cut_fqdn }}.key.pem",
+        dest: "{{ dhs_amwa_validate_tls_cut_algo }}.{{ dhs_amwa_validate_tls_cut_fqdn }}.key.pem" }
     - { src: "{{ dhs_amwa_validate_tls_image_ca_dir }}/certs/ca.cert.pem",
         dest: "ca.cert.pem" }
   loop_control:

--- a/ansible/roles/dhs_amwa_validate/tasks/tooling.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/tooling.yml
@@ -162,3 +162,101 @@
   ansible.builtin.command: docker start {{ dhs_amwa_validate_auth_tool_container }}
   when: _validate_need_auth and _auth_tool_state.rc == 0 and 'running' not in _auth_tool_state.stdout
   changed_when: true
+
+# ---- the TLS tool instance (issue #948) ----
+# FOURTH container, same created-stopped-then-pin pattern (the #942
+# crash-loop lesson: config first, first start after). Host networking
+# + host dbus like the others; shifted PORT_BASE because the resident
+# owns 5000 and the armed one 5500. ENABLE_HTTPS flips the tool's
+# scheme globally, GUI/API included, using the image's shipped
+# CERTS_MOCKS (mocks.testsuite.nmos.tv) — untouched defaults.
+
+# The tool's own certificates name DNS identities only, so both TLS
+# parties get hosts pins: the CuT's FQDN at the plant IP (the tool
+# validates the CuT's cert against that name; host-net containers
+# read the host /etc/hosts) and the mock identity at loopback (so the
+# uri probes and suite POSTs can CA-validate the tool's own https).
+- name: The TLS identities resolve on the tooling host
+  ansible.builtin.lineinfile:
+    path: /etc/hosts
+    regexp: "^.*\\s{{ item.name }}\\s*$"
+    line: "{{ item.ip }} {{ item.name }}"
+  loop:
+    - { name: "{{ dhs_amwa_validate_tls_cut_fqdn }}", ip: "{{ dhs_amwa_validate_plant_host }}" }
+    - { name: "{{ dhs_amwa_validate_tls_tool_host }}", ip: "127.0.0.1" }
+  when: _validate_need_tls
+
+# The CuT pair + CA come out of the RESIDENT container (same pinned
+# image, always exists by this point) — docker cp works regardless of
+# the TLS container's create/start ordering.
+- name: Stage the TLS material directory
+  ansible.builtin.file:
+    path: "{{ dhs_amwa_validate_tls_dir }}"
+    state: directory
+    mode: "0755"
+  when: _validate_need_tls
+
+- name: Copy the CuT chain + key + CA out of the tool image
+  ansible.builtin.command: >-
+    docker cp {{ dhs_amwa_validate_tool_container }}:{{ item.src }}
+    {{ dhs_amwa_validate_tls_dir }}/{{ item.dest }}
+  args:
+    creates: "{{ dhs_amwa_validate_tls_dir }}/{{ item.dest }}"
+  loop:
+    - { src: "{{ dhs_amwa_validate_tls_image_ca_dir }}/intermediate/certs/rsa.{{ dhs_amwa_validate_tls_cut_fqdn }}.cert.chain.pem",
+        dest: "rsa.{{ dhs_amwa_validate_tls_cut_fqdn }}.cert.chain.pem" }
+    - { src: "{{ dhs_amwa_validate_tls_image_ca_dir }}/intermediate/private/rsa.{{ dhs_amwa_validate_tls_cut_fqdn }}.key.pem",
+        dest: "rsa.{{ dhs_amwa_validate_tls_cut_fqdn }}.key.pem" }
+    - { src: "{{ dhs_amwa_validate_tls_image_ca_dir }}/certs/ca.cert.pem",
+        dest: "ca.cert.pem" }
+  loop_control:
+    label: "{{ item.dest }}"
+  when: _validate_need_tls
+
+- name: The TLS tool container exists
+  ansible.builtin.command: docker inspect -f {% raw %}"{{.State.Status}}"{% endraw %} {{ dhs_amwa_validate_tls_tool_container }}
+  register: _tls_tool_state
+  changed_when: false
+  failed_when: false
+  when: _validate_need_tls
+
+- name: Create the TLS tool container (stopped)
+  ansible.builtin.command: >-
+    docker create --name {{ dhs_amwa_validate_tls_tool_container }}
+    --network host
+    -v /run/dbus:/run/dbus
+    --restart unless-stopped
+    {{ dhs_amwa_validate_tool_image }}
+  when: _validate_need_tls and _tls_tool_state.rc != 0
+  changed_when: true
+
+# Same conformance profile as the resident PLUS the https knobs —
+# ENABLE_HTTPS is the tool's global scheme switch (Config.py line 92);
+# CERTS_MOCKS / KEYS_MOCKS / CERT_TRUST_ROOT_CA stay at their shipped
+# defaults, which already point at the image's own CA material.
+- name: Render the TLS UserConfig
+  ansible.builtin.copy:
+    content: |
+      PULL_REPOS = False
+      from . import Config as CONFIG
+      CONFIG.GARBAGE_COLLECTION_TIMEOUT = 30
+      CONFIG.ENABLE_HTTPS = True
+      CONFIG.PORT_BASE = {{ dhs_amwa_validate_tls_port_base }}
+      CONFIG.WEBSOCKET_PORT_BASE = {{ dhs_amwa_validate_tls_ws_port_base }}
+    dest: /opt/dhs-validate-userconfig-tls.py
+    mode: "0644"
+  register: _tls_userconfig
+  when: _validate_need_tls
+
+- name: Pin the TLS tool UserConfig
+  ansible.builtin.shell: >-
+    docker cp /opt/dhs-validate-userconfig-tls.py {{ dhs_amwa_validate_tls_tool_container }}:/config/UserConfig.py
+    && docker restart {{ dhs_amwa_validate_tls_tool_container }}
+  when: _validate_need_tls and (_tls_userconfig.changed or _tls_tool_state.rc != 0)
+  changed_when: true
+
+# After the pin so a first start always runs the https config.
+- name: The TLS tool container is running
+  ansible.builtin.command: docker start {{ dhs_amwa_validate_tls_tool_container }}
+  when: _validate_need_tls and _tls_tool_state.rc == 0 and 'running' not in _tls_tool_state.stdout
+  changed_when: true

--- a/ansible/roles/dhs_amwa_validate/tasks/window_tls.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/window_tls.yml
@@ -1,0 +1,71 @@
+---
+# TLS CuT window (BCP-003-01, issue #948): the transient node serves
+# HTTPS/WSS ONLY — --tls-cert/--tls-key flip the whole server per
+# BCP-003-01 (a secured server SHALL NOT accept plain HTTP) — using
+# the tool CA's premade dhs-node.testsuite.nmos.tv identity, and the
+# TLS tool instance (ENABLE_HTTPS=True) scores it. Same transient
+# unit name + safety-timer + teardown as the P2P window, so
+# window_teardown.yml already covers this window.
+
+- name: The plant holds the CuT TLS material directory
+  ansible.builtin.file:
+    path: "{{ dhs_amwa_validate_tls_plant_dir }}"
+    state: directory
+    mode: "0755"
+  delegate_to: "{{ groups['plant'][0] }}"
+
+# Tooling → plant via slurp+copy: the PEMs are small and the role has
+# no controller-side staging of its own.
+- name: Read the staged CuT chain + key
+  ansible.builtin.slurp:
+    src: "{{ dhs_amwa_validate_tls_dir }}/{{ item }}"
+  register: _tls_material
+  loop:
+    - "rsa.{{ dhs_amwa_validate_tls_cut_fqdn }}.cert.chain.pem"
+    - "rsa.{{ dhs_amwa_validate_tls_cut_fqdn }}.key.pem"
+
+- name: Install the CuT chain + key on the plant
+  ansible.builtin.copy:
+    content: "{{ item.content | b64decode }}"
+    dest: "{{ dhs_amwa_validate_tls_plant_dir }}/{{ item.item }}"
+    mode: "0600"
+  loop: "{{ _tls_material.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+  delegate_to: "{{ groups['plant'][0] }}"
+
+# Advertise the certificate's DNS identity, not the IP — every URL
+# the node mints must carry the name the certificate vouches for.
+- name: Start the transient TLS node
+  ansible.builtin.command: >-
+    systemd-run --unit dhs-nmos-validate-cut --collect
+    {{ dhs_amwa_validate_plant_bin }} producer nmos serve
+    --bind 0.0.0.0:{{ dhs_amwa_validate_cut_port }}
+    --no-registry
+    --advertise-host {{ dhs_amwa_validate_tls_cut_fqdn }}:{{ dhs_amwa_validate_cut_port }}
+    --api-ver v1.3
+    --config {{ dhs_amwa_validate_plant_config }}
+    --tls-cert {{ dhs_amwa_validate_tls_plant_dir }}/rsa.{{ dhs_amwa_validate_tls_cut_fqdn }}.cert.chain.pem
+    --tls-key {{ dhs_amwa_validate_tls_plant_dir }}/rsa.{{ dhs_amwa_validate_tls_cut_fqdn }}.key.pem
+  delegate_to: "{{ groups['plant'][0] }}"
+  changed_when: true
+
+- name: Arm the CuT safety-stop timer
+  ansible.builtin.command: >-
+    systemd-run --unit dhs-nmos-validate-cutstop --collect
+    --on-active={{ dhs_amwa_validate_window_safety_sec }}
+    systemctl stop dhs-nmos-validate-cut
+  delegate_to: "{{ groups['plant'][0] }}"
+  changed_when: true
+
+# Readiness over TLS, CA-validated at the certificate's name (the
+# tooling /etc/hosts pin resolves it) — a plain-http 200 can never
+# count as ready because the handshake itself must succeed first.
+- name: Wait for the transient TLS node
+  ansible.builtin.uri:
+    url: "https://{{ dhs_amwa_validate_tls_cut_fqdn }}:{{ dhs_amwa_validate_cut_port }}/x-nmos/node/v1.3/self"
+    ca_path: "{{ dhs_amwa_validate_tls_dir }}/ca.cert.pem"
+  register: _cut_up
+  retries: 15
+  delay: 2
+  until: _cut_up.status == 200

--- a/ansible/roles/dhs_amwa_validate/tasks/window_tls.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/window_tls.yml
@@ -21,8 +21,8 @@
     src: "{{ dhs_amwa_validate_tls_dir }}/{{ item }}"
   register: _tls_material
   loop:
-    - "rsa.{{ dhs_amwa_validate_tls_cut_fqdn }}.cert.chain.pem"
-    - "rsa.{{ dhs_amwa_validate_tls_cut_fqdn }}.key.pem"
+    - "{{ dhs_amwa_validate_tls_cut_algo }}.{{ dhs_amwa_validate_tls_cut_fqdn }}.cert.chain.pem"
+    - "{{ dhs_amwa_validate_tls_cut_algo }}.{{ dhs_amwa_validate_tls_cut_fqdn }}.key.pem"
 
 - name: Install the CuT chain + key on the plant
   ansible.builtin.copy:
@@ -45,8 +45,8 @@
     --advertise-host {{ dhs_amwa_validate_tls_cut_fqdn }}:{{ dhs_amwa_validate_cut_port }}
     --api-ver v1.3
     --config {{ dhs_amwa_validate_plant_config }}
-    --tls-cert {{ dhs_amwa_validate_tls_plant_dir }}/rsa.{{ dhs_amwa_validate_tls_cut_fqdn }}.cert.chain.pem
-    --tls-key {{ dhs_amwa_validate_tls_plant_dir }}/rsa.{{ dhs_amwa_validate_tls_cut_fqdn }}.key.pem
+    --tls-cert {{ dhs_amwa_validate_tls_plant_dir }}/{{ dhs_amwa_validate_tls_cut_algo }}.{{ dhs_amwa_validate_tls_cut_fqdn }}.cert.chain.pem
+    --tls-key {{ dhs_amwa_validate_tls_plant_dir }}/{{ dhs_amwa_validate_tls_cut_algo }}.{{ dhs_amwa_validate_tls_cut_fqdn }}.key.pem
   delegate_to: "{{ groups['plant'][0] }}"
   changed_when: true
 

--- a/ansible/roles/dhs_amwa_validate/tasks/window_tls.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/window_tls.yml
@@ -15,27 +15,32 @@
   delegate_to: "{{ groups['plant'][0] }}"
 
 # Tooling → plant via slurp+copy: the PEMs are small and the role has
-# no controller-side staging of its own.
-- name: Read the staged CuT chain + key
+# no controller-side staging of its own. BOTH algorithms travel —
+# dual-certificate serving (see defaults: test_02 needs RSA for the
+# mandatory cipher, test_08 wants ECDSA alongside).
+- name: Read the staged CuT chains + keys
   ansible.builtin.slurp:
-    src: "{{ dhs_amwa_validate_tls_dir }}/{{ item }}"
+    src: "{{ dhs_amwa_validate_tls_dir }}/{{ item.0 }}.{{ dhs_amwa_validate_tls_cut_fqdn }}.{{ item.1 }}"
   register: _tls_material
-  loop:
-    - "{{ dhs_amwa_validate_tls_cut_algo }}.{{ dhs_amwa_validate_tls_cut_fqdn }}.cert.chain.pem"
-    - "{{ dhs_amwa_validate_tls_cut_algo }}.{{ dhs_amwa_validate_tls_cut_fqdn }}.key.pem"
+  loop: "{{ dhs_amwa_validate_tls_cut_algos | product(['cert.chain.pem', 'key.pem']) | list }}"
+  loop_control:
+    label: "{{ item.0 }}.{{ item.1 }}"
 
-- name: Install the CuT chain + key on the plant
+- name: Install the CuT chains + keys on the plant
   ansible.builtin.copy:
     content: "{{ item.content | b64decode }}"
-    dest: "{{ dhs_amwa_validate_tls_plant_dir }}/{{ item.item }}"
+    dest: "{{ dhs_amwa_validate_tls_plant_dir }}/{{ item.source | basename }}"
     mode: "0600"
   loop: "{{ _tls_material.results }}"
   loop_control:
-    label: "{{ item.item }}"
+    label: "{{ item.source | basename }}"
   delegate_to: "{{ groups['plant'][0] }}"
 
 # Advertise the certificate's DNS identity, not the IP — every URL
-# the node mints must carry the name the certificate vouches for.
+# the node mints must carry the name the certificates vouch for. The
+# repeated --tls-cert/--tls-key flags pair positionally: certificates
+# and keys ride in the same algorithm order, and the handshake picks
+# the pair each client can use.
 - name: Start the transient TLS node
   ansible.builtin.command: >-
     systemd-run --unit dhs-nmos-validate-cut --collect
@@ -45,8 +50,8 @@
     --advertise-host {{ dhs_amwa_validate_tls_cut_fqdn }}:{{ dhs_amwa_validate_cut_port }}
     --api-ver v1.3
     --config {{ dhs_amwa_validate_plant_config }}
-    --tls-cert {{ dhs_amwa_validate_tls_plant_dir }}/{{ dhs_amwa_validate_tls_cut_algo }}.{{ dhs_amwa_validate_tls_cut_fqdn }}.cert.chain.pem
-    --tls-key {{ dhs_amwa_validate_tls_plant_dir }}/{{ dhs_amwa_validate_tls_cut_algo }}.{{ dhs_amwa_validate_tls_cut_fqdn }}.key.pem
+    {% for algo in dhs_amwa_validate_tls_cut_algos %}--tls-cert {{ dhs_amwa_validate_tls_plant_dir }}/{{ algo }}.{{ dhs_amwa_validate_tls_cut_fqdn }}.cert.chain.pem {% endfor %}
+    {% for algo in dhs_amwa_validate_tls_cut_algos %}--tls-key {{ dhs_amwa_validate_tls_plant_dir }}/{{ algo }}.{{ dhs_amwa_validate_tls_cut_fqdn }}.key.pem {% endfor %}
   delegate_to: "{{ groups['plant'][0] }}"
   changed_when: true
 

--- a/cmd/dhs/cmd_nmos.go
+++ b/cmd/dhs/cmd_nmos.go
@@ -295,12 +295,16 @@ func runNMOSNodeServeLegacy(ctx context.Context, args []string) error {
 	authClientSecret := fs.String("auth-client-secret", "", "OAuth client secret for the client_credentials grant (with --auth-url)")
 	estHost := fs.String("est-host", "", "BCP-003-03 EST server host:port - the Node bootstraps the network Root CA + enrolls for its TLS certificate there, then serves HTTPS/WSS only")
 	estLabel := fs.String("est-label", "", "EST api_selector arbitrary label (appended to /.well-known/est)")
-	tlsCert := fs.String("tls-cert", "", "manually installed TLS certificate (PEM, leaf+chain) - alternative to EST")
-	tlsKey := fs.String("tls-key", "", "private key for --tls-cert")
+	var tlsCerts, tlsKeys stringSliceFlag
+	fs.Var(&tlsCerts, "tls-cert", "manually installed TLS certificate (PEM, leaf+chain) - alternative to EST. Repeatable: BCP-003-01 dual-certificate serving passes it once for the RSA and once for the ECDSA pair (the mandatory cipher set needs RSA, the recommended posture ECDSA) — paired with --tls-key positionally; the handshake picks per client")
+	fs.Var(&tlsKeys, "tls-key", "private key for --tls-cert (repeatable, one per certificate, same order)")
 	tlsCA := fs.String("tls-ca", "", "trust root PEM for OUTBOUND https verification (registry over https)")
 	tlsDir := fs.String("tls-dir", "", "directory for EST-provisioned material (default .cache/nmos-tls)")
 	if err := parseVerbFlags(fs, args); err != nil {
 		return err
+	}
+	if len(tlsCerts) != len(tlsKeys) {
+		return fmt.Errorf("producer nmos serve: %d --tls-cert but %d --tls-key — every certificate needs its private key, given in the same order", len(tlsCerts), len(tlsKeys))
 	}
 	if *configPath == "" {
 		return fmt.Errorf("producer nmos serve --role node: --config FILE required (use Phase 0 #1 mDNS-only placeholder via --discover-only flag if you really mean to)")
@@ -341,8 +345,8 @@ func runNMOSNodeServeLegacy(ctx context.Context, args []string) error {
 		AuthClientSecret: *authClientSecret,
 		ESTHost:          *estHost,
 		ESTLabel:         *estLabel,
-		TLSCertFile:      *tlsCert,
-		TLSKeyFile:       *tlsKey,
+		TLSCertFile:      tlsCerts.String(),
+		TLSKeyFile:       tlsKeys.String(),
 		TLSCAFile:        *tlsCA,
 		TLSDataDir:       *tlsDir,
 	}
@@ -570,11 +574,15 @@ func runNMOSRegistryServe(ctx context.Context, args []string) error {
 	regAuthURL := fs.String("auth-url", "", "BCP-003-02 Authorization Server base (scheme://host[:port]). When set, both faces validate Bearer tokens and api_auth=true is advertised")
 	regESTHost := fs.String("est-host", "", "BCP-003-03 EST server host:port - the registry enrolls for its TLS certificate there, then serves HTTPS/WSS only")
 	regESTLabel := fs.String("est-label", "", "EST api_selector arbitrary label")
-	regTLSCert := fs.String("tls-cert", "", "manually installed TLS certificate (PEM) - alternative to EST")
-	regTLSKey := fs.String("tls-key", "", "private key for --tls-cert")
+	var regTLSCerts, regTLSKeys stringSliceFlag
+	fs.Var(&regTLSCerts, "tls-cert", "manually installed TLS certificate (PEM) - alternative to EST. Repeatable: BCP-003-01 dual-certificate serving passes it once for the RSA and once for the ECDSA pair — paired with --tls-key positionally; the handshake picks per client")
+	fs.Var(&regTLSKeys, "tls-key", "private key for --tls-cert (repeatable, one per certificate, same order)")
 	regTLSDir := fs.String("tls-dir", "", "directory for EST-provisioned material (default .cache/nmos-registry-tls)")
 	if err := parseVerbFlags(fs, args); err != nil {
 		return err
+	}
+	if len(regTLSCerts) != len(regTLSKeys) {
+		return fmt.Errorf("registry nmos serve: %d --tls-cert but %d --tls-key — every certificate needs its private key, given in the same order", len(regTLSCerts), len(regTLSKeys))
 	}
 	mode := "mdns"
 	if !*mdns || *noMDNS {
@@ -602,8 +610,8 @@ func runNMOSRegistryServe(ctx context.Context, args []string) error {
 		AuthURL:          *regAuthURL,
 		ESTHost:          *regESTHost,
 		ESTLabel:         *regESTLabel,
-		TLSCertFile:      *regTLSCert,
-		TLSKeyFile:       *regTLSKey,
+		TLSCertFile:      regTLSCerts.String(),
+		TLSKeyFile:       regTLSKeys.String(),
 		TLSDataDir:       *regTLSDir,
 	}
 	verLabel := *apiVer
@@ -814,16 +822,22 @@ func runNMOSRegistryMirror(ctx context.Context, args []string) error {
 			"--serve-advertise-host). Defaults into the 100+ dev range so the "+
 			"mirror never wins a production Registry election against its own "+
 			"source registry at pri 0")
-	serveTLSCert := fs.String("serve-tls-cert", "",
+	var serveTLSCerts, serveTLSKeys stringSliceFlag
+	fs.Var(&serveTLSCerts, "serve-tls-cert",
 		"BCP-003-01 TLS certificate (PEM, leaf+chain) for the served Query "+
 			"face — with --serve-tls-key the face serves HTTPS/WSS ONLY, mints "+
 			"wss:// ws_hrefs and announces api_proto=https, the same manual "+
-			"pair path as the registry's --tls-cert. Requires --serve; the "+
-			"mirror's outbound source/target legs are untouched")
-	serveTLSKey := fs.String("serve-tls-key", "",
-		"private key for --serve-tls-cert")
+			"pair path as the registry's --tls-cert. Repeatable for "+
+			"dual-certificate serving (RSA + ECDSA), paired with "+
+			"--serve-tls-key positionally. Requires --serve; the mirror's "+
+			"outbound source/target legs are untouched")
+	fs.Var(&serveTLSKeys, "serve-tls-key",
+		"private key for --serve-tls-cert (repeatable, one per certificate, same order)")
 	if err := parseVerbFlags(fs, args); err != nil {
 		return err
+	}
+	if len(serveTLSCerts) != len(serveTLSKeys) {
+		return fmt.Errorf("nmos mirror: %d --serve-tls-cert but %d --serve-tls-key — every certificate needs its private key, given in the same order", len(serveTLSCerts), len(serveTLSKeys))
 	}
 	m, err := amwaregistry.NewMirror(amwaregistry.MirrorOptions{
 		Source:             *source,
@@ -836,8 +850,8 @@ func runNMOSRegistryMirror(ctx context.Context, args []string) error {
 		ServeAuthURL:       *serveAuthURL,
 		ServeAdvertiseHost: *serveAdvertiseHost,
 		ServePri:           *servePri,
-		ServeTLSCert:       *serveTLSCert,
-		ServeTLSKey:        *serveTLSKey,
+		ServeTLSCert:       serveTLSCerts.String(),
+		ServeTLSKey:        serveTLSKeys.String(),
 	})
 	if err != nil {
 		return fmt.Errorf("nmos mirror: %w", err)

--- a/cmd/dhs/cmd_nmos.go
+++ b/cmd/dhs/cmd_nmos.go
@@ -769,7 +769,13 @@ that identity instead of the bound address (a bare host takes the
 --serve port) and announces itself as _nmos-query._tcp via mDNS with
 --serve-pri (default 100 — dev range, so the mirror never outranks
 the production source registry). The announce's api_auth TXT tracks
---auth-url.`)
+--auth-url.
+
+With --serve-tls-cert/--serve-tls-key (requires --serve) the served
+face speaks HTTPS/WSS ONLY per BCP-003-01 — the same manual pair path
+"registry nmos serve --tls-cert" arms: ws_href becomes wss://, the
+announce carries api_proto=https, and /status.json reports
+"serve_tls". Outbound legs stay untouched.`)
 }
 
 // runNMOSRegistryMirror bridges a source Registry into a target one.
@@ -808,6 +814,14 @@ func runNMOSRegistryMirror(ctx context.Context, args []string) error {
 			"--serve-advertise-host). Defaults into the 100+ dev range so the "+
 			"mirror never wins a production Registry election against its own "+
 			"source registry at pri 0")
+	serveTLSCert := fs.String("serve-tls-cert", "",
+		"BCP-003-01 TLS certificate (PEM, leaf+chain) for the served Query "+
+			"face — with --serve-tls-key the face serves HTTPS/WSS ONLY, mints "+
+			"wss:// ws_hrefs and announces api_proto=https, the same manual "+
+			"pair path as the registry's --tls-cert. Requires --serve; the "+
+			"mirror's outbound source/target legs are untouched")
+	serveTLSKey := fs.String("serve-tls-key", "",
+		"private key for --serve-tls-cert")
 	if err := parseVerbFlags(fs, args); err != nil {
 		return err
 	}
@@ -822,6 +836,8 @@ func runNMOSRegistryMirror(ctx context.Context, args []string) error {
 		ServeAuthURL:       *serveAuthURL,
 		ServeAdvertiseHost: *serveAdvertiseHost,
 		ServePri:           *servePri,
+		ServeTLSCert:       *serveTLSCert,
+		ServeTLSKey:        *serveTLSKey,
 	})
 	if err != nil {
 		return fmt.Errorf("nmos mirror: %w", err)

--- a/cmd/dhs/cmd_nmos_tls_flags_test.go
+++ b/cmd/dhs/cmd_nmos_tls_flags_test.go
@@ -1,0 +1,47 @@
+package main
+
+// Repeatable TLS flag parsing (issue #948, dual-certificate serving):
+// --tls-cert/--tls-key (and the mirror's --serve-tls-cert/-key) may be
+// given once per pair; a cert/key count mismatch is an operator-
+// sentence error caught right after flag parsing — before any config
+// is loaded or socket bound.
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestNodeServeTLSFlagCountMismatch(t *testing.T) {
+	err := runNMOSNodeServe(context.Background(), []string{
+		"--tls-cert", "rsa.crt",
+		"--tls-cert", "ecdsa.crt",
+		"--tls-key", "rsa.key",
+	})
+	if err == nil || !strings.Contains(err.Error(), "--tls-key") {
+		t.Errorf("node serve mismatch = %v, want the cert/key count error", err)
+	}
+}
+
+func TestRegistryServeTLSFlagCountMismatch(t *testing.T) {
+	err := runNMOSRegistryServe(context.Background(), []string{
+		"--tls-cert", "rsa.crt",
+		"--tls-key", "rsa.key",
+		"--tls-key", "ecdsa.key",
+	})
+	if err == nil || !strings.Contains(err.Error(), "--tls-key") {
+		t.Errorf("registry serve mismatch = %v, want the cert/key count error", err)
+	}
+}
+
+func TestMirrorServeTLSFlagCountMismatch(t *testing.T) {
+	err := runNMOSRegistryMirror(context.Background(), []string{
+		"--source", "http://s:1", "--target", "http://t:2", "--serve", ":0",
+		"--serve-tls-cert", "rsa.crt",
+		"--serve-tls-cert", "ecdsa.crt",
+		"--serve-tls-key", "rsa.key",
+	})
+	if err == nil || !strings.Contains(err.Error(), "--serve-tls-key") {
+		t.Errorf("mirror mismatch = %v, want the cert/key count error", err)
+	}
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -338,6 +338,10 @@ Usage of mirror:
     	identity minted into the served face's ws_href and mDNS announce, as host or host:port (a bare host takes the bound --serve port). Precedence: this flag wins; empty derives from the bound address (concrete IP, else OS hostname — which off-link controllers may not resolve). Setting it also enables the _nmos-query._tcp announce of the served face
   -serve-pri int
     	DNS-SD pri TXT for the served face's announce (with --serve-advertise-host). Defaults into the 100+ dev range so the mirror never wins a production Registry election against its own source registry at pri 0 (default 100)
+  -serve-tls-cert string
+    	BCP-003-01 TLS certificate (PEM, leaf+chain) for the served Query face — with --serve-tls-key the face serves HTTPS/WSS ONLY, mints wss:// ws_hrefs and announces api_proto=https, the same manual pair path as the registry's --tls-cert. Requires --serve; the mirror's outbound source/target legs are untouched
+  -serve-tls-key string
+    	private key for --serve-tls-cert
   -source string
     	source Registry origin (http://host:port) — Query API side
   -status-addr string

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -270,12 +270,12 @@ Usage of serve:
     	IS-09 System API as host:port, skipping discovery. Empty browses for one; a Node that finds none serves normally, because IS-09 makes the System API optional
   -tls-ca string
     	trust root PEM for OUTBOUND https verification (registry over https)
-  -tls-cert string
-    	manually installed TLS certificate (PEM, leaf+chain) - alternative to EST
+  -tls-cert value
+    	manually installed TLS certificate (PEM, leaf+chain) - alternative to EST. Repeatable: BCP-003-01 dual-certificate serving passes it once for the RSA and once for the ECDSA pair (the mandatory cipher set needs RSA, the recommended posture ECDSA) — paired with --tls-key positionally; the handshake picks per client
   -tls-dir string
     	directory for EST-provisioned material (default .cache/nmos-tls)
-  -tls-key string
-    	private key for --tls-cert
+  -tls-key value
+    	private key for --tls-cert (repeatable, one per certificate, same order)
   -unicast
     	discover the Registry via unicast DNS-SD instead of mDNS (IS-04 §3.1 for multicast-blocked plants)
 ```
@@ -312,12 +312,12 @@ Usage of serve:
     	Query API page size when the client sends no paging.limit (0 = spec-parity default 100; raise for first-page-only controllers on plants larger than one page)
   -priority pri
     	DNS-SD pri TXT (0-99 production, 100+ dev)
-  -tls-cert string
-    	manually installed TLS certificate (PEM) - alternative to EST
+  -tls-cert value
+    	manually installed TLS certificate (PEM) - alternative to EST. Repeatable: BCP-003-01 dual-certificate serving passes it once for the RSA and once for the ECDSA pair — paired with --tls-key positionally; the handshake picks per client
   -tls-dir string
     	directory for EST-provisioned material (default .cache/nmos-registry-tls)
-  -tls-key string
-    	private key for --tls-cert
+  -tls-key value
+    	private key for --tls-cert (repeatable, one per certificate, same order)
 ```
 
 ## NMOS registry mirror
@@ -338,10 +338,10 @@ Usage of mirror:
     	identity minted into the served face's ws_href and mDNS announce, as host or host:port (a bare host takes the bound --serve port). Precedence: this flag wins; empty derives from the bound address (concrete IP, else OS hostname — which off-link controllers may not resolve). Setting it also enables the _nmos-query._tcp announce of the served face
   -serve-pri int
     	DNS-SD pri TXT for the served face's announce (with --serve-advertise-host). Defaults into the 100+ dev range so the mirror never wins a production Registry election against its own source registry at pri 0 (default 100)
-  -serve-tls-cert string
-    	BCP-003-01 TLS certificate (PEM, leaf+chain) for the served Query face — with --serve-tls-key the face serves HTTPS/WSS ONLY, mints wss:// ws_hrefs and announces api_proto=https, the same manual pair path as the registry's --tls-cert. Requires --serve; the mirror's outbound source/target legs are untouched
-  -serve-tls-key string
-    	private key for --serve-tls-cert
+  -serve-tls-cert value
+    	BCP-003-01 TLS certificate (PEM, leaf+chain) for the served Query face — with --serve-tls-key the face serves HTTPS/WSS ONLY, mints wss:// ws_hrefs and announces api_proto=https, the same manual pair path as the registry's --tls-cert. Repeatable for dual-certificate serving (RSA + ECDSA), paired with --serve-tls-key positionally. Requires --serve; the mirror's outbound source/target legs are untouched
+  -serve-tls-key value
+    	private key for --serve-tls-cert (repeatable, one per certificate, same order)
   -source string
     	source Registry origin (http://host:port) — Query API side
   -status-addr string

--- a/internal/amwa/registry/mirror.go
+++ b/internal/amwa/registry/mirror.go
@@ -107,10 +107,14 @@ type MirrorOptions struct {
 	ServePri int
 	// ServeTLSCert / ServeTLSKey, when both set, make the served face
 	// HTTPS/WSS-only (BCP-003-01: a secured server SHALL NOT accept
-	// plain HTTP) using this manually installed pair — the same
-	// certmgr path Registry.Serve's --tls-cert arms. ws_href is then
-	// minted wss:// and the announce carries api_proto=https. Both
-	// require ServeAddr, and each other. The mirror's OUTBOUND legs
+	// plain HTTP) using these manually installed pairs — the same
+	// certmgr path (and comma-separated list contract) Registry.Serve's
+	// --tls-cert arms. BCP-003-01 dual-certificate serving passes TWO
+	// pairs, RSA + ECDSA, matched positionally: the mandatory cipher
+	// set needs an RSA certificate and the recommended posture ECDSA;
+	// Go's handshake picks per client. ws_href is minted wss:// and
+	// the announce carries api_proto=https. Both require ServeAddr,
+	// each other, and equal entry counts. The mirror's OUTBOUND legs
 	// stay untouched.
 	ServeTLSCert string
 	ServeTLSKey  string
@@ -213,6 +217,10 @@ func NewMirror(opts MirrorOptions) (*Mirror, error) {
 	}
 	if (opts.ServeTLSCert != "") != (opts.ServeTLSKey != "") {
 		return nil, errors.New("registry/mirror: --serve-tls-cert and --serve-tls-key travel together — a certificate without its key (or the reverse) serves nothing")
+	}
+	if opts.ServeTLSCert != "" &&
+		len(strings.Split(opts.ServeTLSCert, ",")) != len(strings.Split(opts.ServeTLSKey, ",")) {
+		return nil, errors.New("registry/mirror: --serve-tls-cert and --serve-tls-key counts differ — every certificate needs its private key, given in the same order")
 	}
 	if opts.ServeTLSCert != "" && opts.ServeAddr == "" {
 		return nil, errors.New("registry/mirror: --serve-tls-cert secures the served Query face, and no face is being served — add --serve ADDR or drop the TLS pair")

--- a/internal/amwa/registry/mirror.go
+++ b/internal/amwa/registry/mirror.go
@@ -105,6 +105,15 @@ type MirrorOptions struct {
 	// range — because the plant mirror must never win a production
 	// Registry election against its own source registry (pri 0).
 	ServePri int
+	// ServeTLSCert / ServeTLSKey, when both set, make the served face
+	// HTTPS/WSS-only (BCP-003-01: a secured server SHALL NOT accept
+	// plain HTTP) using this manually installed pair — the same
+	// certmgr path Registry.Serve's --tls-cert arms. ws_href is then
+	// minted wss:// and the announce carries api_proto=https. Both
+	// require ServeAddr, and each other. The mirror's OUTBOUND legs
+	// stay untouched.
+	ServeTLSCert string
+	ServeTLSKey  string
 	// ServeAuthURL, when set, arms the served Query face with the
 	// BCP-003-02 Bearer gate: tokens are validated against the
 	// Authorization Server at this base URL, exactly the way the
@@ -201,6 +210,12 @@ func NewMirror(opts MirrorOptions) (*Mirror, error) {
 	}
 	if opts.ServeAuthURL != "" && opts.ServeAddr == "" {
 		return nil, errors.New("registry/mirror: --auth-url guards the served Query face, and no face is being served — add --serve ADDR or drop --auth-url")
+	}
+	if (opts.ServeTLSCert != "") != (opts.ServeTLSKey != "") {
+		return nil, errors.New("registry/mirror: --serve-tls-cert and --serve-tls-key travel together — a certificate without its key (or the reverse) serves nothing")
+	}
+	if opts.ServeTLSCert != "" && opts.ServeAddr == "" {
+		return nil, errors.New("registry/mirror: --serve-tls-cert secures the served Query face, and no face is being served — add --serve ADDR or drop the TLS pair")
 	}
 	if opts.APIVer == "" {
 		opts.APIVer = is04.APIVersion

--- a/internal/amwa/registry/mirror_audit.go
+++ b/internal/amwa/registry/mirror_audit.go
@@ -105,7 +105,11 @@ type mirrorStatus struct {
 	// disarmed-but-serving mirror reports an explicit false while a
 	// mirror with no served face omits the key — same presence rule
 	// as serve_addr.
-	ServeAuth   *bool        `json:"serve_auth,omitempty"`
+	ServeAuth *bool `json:"serve_auth,omitempty"`
+	// ServeTLS reports whether the served face speaks HTTPS/WSS only
+	// (--serve-tls-cert/-key, issue #948). Same pointer presence rule
+	// as serve_auth.
+	ServeTLS    *bool        `json:"serve_tls,omitempty"`
 	RecentAudit []AuditEvent `json:"recent_audit"`
 }
 
@@ -130,6 +134,8 @@ func (m *Mirror) serveStatus(ctx context.Context, addr string) {
 			st.ServeAddr = m.serve.addr
 			armed := m.opts.ServeAuthURL != ""
 			st.ServeAuth = &armed
+			secured := m.opts.ServeTLSCert != ""
+			st.ServeTLS = &secured
 		}
 		m.mu.Unlock()
 		st.RecentAudit = m.audit.recent()

--- a/internal/amwa/registry/mirror_serve.go
+++ b/internal/amwa/registry/mirror_serve.go
@@ -100,11 +100,15 @@ func (m *Mirror) startServe(ctx context.Context) error {
 		}
 	}
 	// BCP-003-01 on the SERVED face (issue #948): the same certmgr
-	// manual-pair path Registry.Serve's --tls-cert arms (LoadManual →
-	// TLSServerConfig: TLS 1.2 floor + the BCP-003-01 suite set),
-	// wrapped around the mirror's own listener. Once armed the face is
-	// HTTPS/WSS ONLY — the plain listener is replaced, never kept
-	// alongside (a secured server SHALL NOT accept plain HTTP).
+	// manual-pair path Registry.Serve's --tls-cert arms (LoadManual per
+	// pair → TLSServerConfig: TLS 1.2 floor + the BCP-003-01 suite set,
+	// every pair handed to Go's handshake for per-client selection),
+	// wrapped around the mirror's own listener. Comma-separated lists
+	// carry multiple pairs — dual-certificate serving needs an RSA AND
+	// an ECDSA pair (the spec's mandatory cipher is RSA, its
+	// recommendation ECDSA). Once armed the face is HTTPS/WSS ONLY —
+	// the plain listener is replaced, never kept alongside (a secured
+	// server SHALL NOT accept plain HTTP).
 	serveScheme := "http"
 	if m.opts.ServeTLSCert != "" {
 		tlsMgr, err := certmgr.New(certmgr.Options{DataDir: mirrorServeTLSDataDir, Logger: m.logger})
@@ -112,9 +116,13 @@ func (m *Mirror) startServe(ctx context.Context) error {
 			_ = ln.Close()
 			return fmt.Errorf("registry/mirror: serve TLS: %w", err)
 		}
-		if err := tlsMgr.LoadManual(m.opts.ServeTLSCert, m.opts.ServeTLSKey); err != nil {
-			_ = ln.Close()
-			return fmt.Errorf("registry/mirror: serve TLS: %w", err)
+		certs := strings.Split(m.opts.ServeTLSCert, ",")
+		keys := strings.Split(m.opts.ServeTLSKey, ",")
+		for i := range certs {
+			if err := tlsMgr.LoadManual(strings.TrimSpace(certs[i]), strings.TrimSpace(keys[i])); err != nil {
+				_ = ln.Close()
+				return fmt.Errorf("registry/mirror: serve TLS: %w", err)
+			}
 		}
 		ln = tls.NewListener(ln, tlsMgr.TLSServerConfig())
 		serveScheme = "https"

--- a/internal/amwa/registry/mirror_serve.go
+++ b/internal/amwa/registry/mirror_serve.go
@@ -25,6 +25,7 @@ package registry
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -41,10 +42,19 @@ import (
 	codec "dhs/internal/amwa/codec/dnssd"
 	"dhs/internal/amwa/codec/is04"
 	authsession "dhs/internal/amwa/session/auth"
+	"dhs/internal/amwa/session/certmgr"
 	session "dhs/internal/amwa/session/dnssd"
 	httpsession "dhs/internal/amwa/session/http"
 	registryslot "dhs/internal/registry"
 )
+
+// mirrorServeTLSDataDir is the certmgr working directory for the
+// served face's manual TLS pair — the mirror twin of the registry's
+// .cache/nmos-registry-tls default (manual mode touches it only to
+// exist; no EST material lands there). A var, not a const: tests
+// point it at a temp dir so `go test` leaves no .cache/ droppings in
+// the package directory (the repo ignores /.cache/ at the root only).
+var mirrorServeTLSDataDir = ".cache/nmos-mirror-serve-tls"
 
 // mirrorServe is the embedded Query face's immutable wiring — built
 // once by startServe before the watch goroutines run.
@@ -89,6 +99,26 @@ func (m *Mirror) startServe(ctx context.Context) error {
 			}
 		}
 	}
+	// BCP-003-01 on the SERVED face (issue #948): the same certmgr
+	// manual-pair path Registry.Serve's --tls-cert arms (LoadManual →
+	// TLSServerConfig: TLS 1.2 floor + the BCP-003-01 suite set),
+	// wrapped around the mirror's own listener. Once armed the face is
+	// HTTPS/WSS ONLY — the plain listener is replaced, never kept
+	// alongside (a secured server SHALL NOT accept plain HTTP).
+	serveScheme := "http"
+	if m.opts.ServeTLSCert != "" {
+		tlsMgr, err := certmgr.New(certmgr.Options{DataDir: mirrorServeTLSDataDir, Logger: m.logger})
+		if err != nil {
+			_ = ln.Close()
+			return fmt.Errorf("registry/mirror: serve TLS: %w", err)
+		}
+		if err := tlsMgr.LoadManual(m.opts.ServeTLSCert, m.opts.ServeTLSKey); err != nil {
+			_ = ln.Close()
+			return fmt.Errorf("registry/mirror: serve TLS: %w", err)
+		}
+		ln = tls.NewListener(ln, tlsMgr.TLSServerConfig())
+		serveScheme = "https"
+	}
 	store := NewStore()
 	apiVers := pickAPIVersions("")
 	srv := httpsession.NewServer(m.logger)
@@ -116,6 +146,12 @@ func (m *Mirror) startServe(ctx context.Context) error {
 	for _, apiVer := range apiVers {
 		queryBase := "/x-nmos/query/" + apiVer
 		mgr := NewSubscriptionManager(m.logger, store, advertise, apiVer)
+		if serveScheme == "https" {
+			// Same rule as Registry.Serve: a secured face mints wss://
+			// ws_hrefs — a ws:// one would point subscribers at a plain
+			// socket the server refuses to speak.
+			mgr.SetWSScheme("wss")
+		}
 		mgr.setWSLifecycleHooks(m.serveWSOpened, m.serveWSClosed)
 		installQueryRoutes(srv, store, mgr, queryBase, apiVer)
 		wsPrefix := queryBase + "/subscriptions/"
@@ -214,7 +250,7 @@ func (m *Mirror) startServe(ctx context.Context) error {
 	}
 	m.logger.Info("registry/mirror: serving mirrored Query API",
 		"addr", ln.Addr().String(), "api_vers", apiVers,
-		"auth", m.opts.ServeAuthURL != "")
+		"auth", m.opts.ServeAuthURL != "", "proto", serveScheme)
 	return nil
 }
 
@@ -242,7 +278,11 @@ func (m *Mirror) announceServe(ctx context.Context, advertise string, apiVers []
 		return
 	}
 	defer func() { _ = resp.Close() }()
-	ins := serveAnnounceInstance(host, port, apiVers, m.opts.ServePri, m.opts.ServeAuthURL != "")
+	proto := "http"
+	if m.opts.ServeTLSCert != "" {
+		proto = "https"
+	}
+	ins := serveAnnounceInstance(host, port, apiVers, m.opts.ServePri, m.opts.ServeAuthURL != "", proto)
 	if err := resp.Announce(ctx, ins); err != nil {
 		m.logger.Warn("registry/mirror: serve announce failed", "err", err)
 		return
@@ -256,14 +296,17 @@ func (m *Mirror) announceServe(ctx context.Context, advertise string, apiVers []
 // _nmos-query._tcp ONLY — the mirror's Query face is real, and there
 // is deliberately no _nmos-register._tcp twin because the mirror
 // refuses registrations. The TXT set mirrors Registry.Serve's
-// announce: api_proto (the served face speaks plain HTTP today),
-// api_ver per served minor, api_auth tracking the Bearer gate (#946),
-// and pri — CLI-defaulted to 100, the dev range, so the plant mirror
-// never wins a production Registry election against its own source
-// registry at pri 0.
-func serveAnnounceInstance(host string, port uint16, apiVers []string, pri int, auth bool) codec.Instance {
+// announce: api_proto tracking the TLS pair (#948 — https once
+// armed), api_ver per served minor, api_auth tracking the Bearer
+// gate (#946), and pri — CLI-defaulted to 100, the dev range, so the
+// plant mirror never wins a production Registry election against its
+// own source registry at pri 0.
+func serveAnnounceInstance(host string, port uint16, apiVers []string, pri int, auth bool, proto string) codec.Instance {
 	if pri < 0 {
 		pri = 0
+	}
+	if proto == "" {
+		proto = "http"
 	}
 	return codec.Instance{
 		Name:    "dhs-nmos-mirror",
@@ -273,7 +316,7 @@ func serveAnnounceInstance(host string, port uint16, apiVers []string, pri int, 
 		Port:    port,
 		IPv4:    localIPv4Candidates(host),
 		TXT: map[string]string{
-			codec.TXTKeyAPIProto: "http",
+			codec.TXTKeyAPIProto: proto,
 			codec.TXTKeyAPIVer:   strings.Join(apiVers, ","),
 			codec.TXTKeyAPIAuth:  strconv.FormatBool(auth),
 			codec.TXTKeyPriority: strconv.Itoa(pri),

--- a/internal/amwa/registry/mirror_serve_advertise_test.go
+++ b/internal/amwa/registry/mirror_serve_advertise_test.go
@@ -161,9 +161,12 @@ func TestMirrorServeAnnounce(t *testing.T) {
 // TestServeAnnounceInstanceTXT pins the pure instance builder both
 // auth ways — the mirror twin of TestPickRegistryServices.
 func TestServeAnnounceInstanceTXT(t *testing.T) {
-	armed := serveAnnounceInstance("h.test", 8335, []string{"v1.2", "v1.3"}, 100, true)
+	armed := serveAnnounceInstance("h.test", 8335, []string{"v1.2", "v1.3"}, 100, true, "https")
 	if armed.TXT[codec.TXTKeyAPIAuth] != "true" {
 		t.Errorf("armed api_auth = %q, want true", armed.TXT[codec.TXTKeyAPIAuth])
+	}
+	if armed.TXT[codec.TXTKeyAPIProto] != "https" {
+		t.Errorf("secured api_proto = %q, want https", armed.TXT[codec.TXTKeyAPIProto])
 	}
 	if armed.TXT[codec.TXTKeyAPIVer] != "v1.2,v1.3" {
 		t.Errorf("api_ver = %q, want v1.2,v1.3", armed.TXT[codec.TXTKeyAPIVer])
@@ -171,9 +174,12 @@ func TestServeAnnounceInstanceTXT(t *testing.T) {
 	if armed.Service != codec.ServiceQuery {
 		t.Errorf("service = %q, want %q", armed.Service, codec.ServiceQuery)
 	}
-	disarmed := serveAnnounceInstance("h.test", 8335, []string{"v1.3"}, -3, false)
+	disarmed := serveAnnounceInstance("h.test", 8335, []string{"v1.3"}, -3, false, "")
 	if disarmed.TXT[codec.TXTKeyAPIAuth] != "false" {
 		t.Errorf("disarmed api_auth = %q, want false", disarmed.TXT[codec.TXTKeyAPIAuth])
+	}
+	if disarmed.TXT[codec.TXTKeyAPIProto] != "http" {
+		t.Errorf("plain api_proto = %q, want http", disarmed.TXT[codec.TXTKeyAPIProto])
 	}
 	if disarmed.TXT[codec.TXTKeyPriority] != "0" {
 		t.Errorf("negative pri = %q, want clamped to 0", disarmed.TXT[codec.TXTKeyPriority])

--- a/internal/amwa/registry/mirror_serve_tls_test.go
+++ b/internal/amwa/registry/mirror_serve_tls_test.go
@@ -1,0 +1,218 @@
+package registry
+
+// Served-face TLS tests (--serve-tls-cert/--serve-tls-key, issue
+// #948): once armed the face is HTTPS/WSS ONLY — a CA-validated https
+// read works, plain http does not, ws_href is minted wss://, the
+// announce TXT carries api_proto=https, /status.json reports
+// serve_tls=true, and the option validation fails fast. The pair is
+// a self-signed in-test certificate (crypto/x509, the certmgr test
+// pattern) — no registry TLS serving test existed to borrow.
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	codec "dhs/internal/amwa/codec/dnssd"
+)
+
+// mintServeTLSPair writes a self-signed serving pair (SAN: 127.0.0.1
+// + mirror-tls.test) to a temp dir and returns the paths plus a root
+// pool trusting it.
+func mintServeTLSPair(t *testing.T) (certFile, keyFile string, pool *x509.CertPool) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "mirror-tls.test"},
+		DNSNames:              []string{"mirror-tls.test"},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	certFile = filepath.Join(dir, "serve.crt")
+	keyFile = filepath.Join(dir, "serve.key")
+	certOut, err := os.Create(certFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: der}); err != nil {
+		t.Fatal(err)
+	}
+	_ = certOut.Close()
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyOut, err := os.Create(keyFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := pem.Encode(keyOut, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}); err != nil {
+		t.Fatal(err)
+	}
+	_ = keyOut.Close()
+	parsed, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool = x509.NewCertPool()
+	pool.AddCert(parsed)
+	return certFile, keyFile, pool
+}
+
+// stubServeTLSDataDir keeps certmgr's working dir out of the package
+// tree for the duration of one test.
+func stubServeTLSDataDir(t *testing.T) {
+	t.Helper()
+	orig := mirrorServeTLSDataDir
+	mirrorServeTLSDataDir = filepath.Join(t.TempDir(), "certmgr")
+	t.Cleanup(func() { mirrorServeTLSDataDir = orig })
+}
+
+// TestMirrorServeTLS: the armed face answers CA-validated https,
+// refuses plain http, mints wss:// ws_hrefs, announces
+// api_proto=https, and reports serve_tls=true on /status.json.
+func TestMirrorServeTLS(t *testing.T) {
+	stubServeTLSDataDir(t)
+	fr := stubServeResponder(t)
+	certFile, keyFile, pool := mintServeTLSPair(t)
+
+	plant := &fakePlant{}
+	target := httptest.NewServer(plant.targetHandler())
+	t.Cleanup(target.Close)
+	push := newPushSource()
+	src := httptest.NewServer(stdhttp.NotFoundHandler())
+	src.Config.Handler = push.handler(t, func() string { return src.URL })
+	t.Cleanup(src.Close)
+
+	statusAddr := freeLoopbackAddr(t)
+	m, err := NewMirror(MirrorOptions{
+		Source: src.URL, Target: target.URL, APIVer: "v1.3",
+		ServeAddr: "127.0.0.1:0", ServeAdvertiseHost: "mirror-tls.test",
+		ServePri: 100, ServeTLSCert: certFile, ServeTLSKey: keyFile,
+		StatusAddr: statusAddr,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = m.Run(ctx) }()
+	waitFor(t, 5*time.Second, func() bool { return m.ServeAddr() != "" }, "served face to bind")
+	base := "https://" + m.ServeAddr()
+
+	client := &stdhttp.Client{Transport: &stdhttp.Transport{
+		TLSClientConfig: &tls.Config{RootCAs: pool},
+	}}
+
+	// CA-validated https read works.
+	resp, err := client.Get(base + "/x-nmos/query/v1.3/nodes")
+	if err != nil {
+		t.Fatalf("https GET: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("https GET = %d, want 200", resp.StatusCode)
+	}
+
+	// Plain http against the secured face must be refused — BCP-003-01
+	// (a secured server SHALL NOT accept plain HTTP). Go's TLS server
+	// renders the refusal as either a broken handshake or net/http's
+	// "Client sent an HTTP request to an HTTPS server" 400 — anything
+	// but a served 200.
+	plainResp, err := stdhttp.Get("http://" + m.ServeAddr() + "/x-nmos/query/v1.3/nodes")
+	if err == nil {
+		st := plainResp.StatusCode
+		_ = plainResp.Body.Close()
+		if st == 200 {
+			t.Fatal("plain http against the TLS face answered 200 — must refuse")
+		}
+	}
+
+	// ws_href on a subscription is wss://.
+	subResp, err := client.Post(base+"/x-nmos/query/v1.3/subscriptions", "application/json",
+		strings.NewReader(`{"resource_path":"/nodes","persist":false}`))
+	if err != nil {
+		t.Fatalf("https subscription POST: %v", err)
+	}
+	body, _ := io.ReadAll(subResp.Body)
+	_ = subResp.Body.Close()
+	if subResp.StatusCode != 200 && subResp.StatusCode != 201 {
+		t.Fatalf("subscription POST = %d (%s)", subResp.StatusCode, body)
+	}
+	var sub struct {
+		WSHref string `json:"ws_href"`
+	}
+	if err := json.Unmarshal(body, &sub); err != nil {
+		t.Fatalf("subscription body: %v (%s)", err, body)
+	}
+	if !strings.HasPrefix(sub.WSHref, "wss://mirror-tls.test:") {
+		t.Errorf("ws_href = %q, want wss://mirror-tls.test:…", sub.WSHref)
+	}
+
+	// The announce carries api_proto=https.
+	select {
+	case ins := <-fr.announced:
+		if got := ins.TXT[codec.TXTKeyAPIProto]; got != "https" {
+			t.Errorf("announce api_proto = %q, want https", got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("no mDNS announce for the secured served face")
+	}
+
+	// /status.json (plain http — the status endpoint is separate from
+	// the served face) says serve_tls=true.
+	waitFor(t, 5*time.Second, func() bool {
+		st, _, body := getWithToken(t, "http://"+statusAddr+"/status.json", "")
+		return st == 200 && strings.Contains(string(body), `"serve_tls":true`)
+	}, `"serve_tls":true on /status.json`)
+}
+
+// TestNewMirrorServeTLSValidation: the pair travels together and
+// requires --serve — both caught before anything runs.
+func TestNewMirrorServeTLSValidation(t *testing.T) {
+	_, err := NewMirror(MirrorOptions{
+		Source: "http://s:1", Target: "http://t:2",
+		ServeAddr: ":0", ServeTLSCert: "cert.pem",
+	})
+	if err == nil || !strings.Contains(err.Error(), "travel together") {
+		t.Errorf("cert without key = %v, want the travel-together error", err)
+	}
+	_, err = NewMirror(MirrorOptions{
+		Source: "http://s:1", Target: "http://t:2",
+		ServeTLSCert: "cert.pem", ServeTLSKey: "key.pem",
+	})
+	if err == nil || !strings.Contains(err.Error(), "--serve") {
+		t.Errorf("TLS pair without serve = %v, want the add---serve error", err)
+	}
+}

--- a/internal/amwa/registry/mirror_serve_tls_test.go
+++ b/internal/amwa/registry/mirror_serve_tls_test.go
@@ -10,9 +10,11 @@ package registry
 
 import (
 	"context"
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -32,14 +34,36 @@ import (
 	codec "dhs/internal/amwa/codec/dnssd"
 )
 
-// mintServeTLSPair writes a self-signed serving pair (SAN: 127.0.0.1
-// + mirror-tls.test) to a temp dir and returns the paths plus a root
-// pool trusting it.
-func mintServeTLSPair(t *testing.T) (certFile, keyFile string, pool *x509.CertPool) {
+// mintServeTLSPairAlgo writes a self-signed serving pair for one
+// public-key algorithm ("rsa" | "ecdsa"; SAN: 127.0.0.1 +
+// mirror-tls.test) to a temp dir — the two halves of BCP-003-01
+// dual-certificate serving.
+func mintServeTLSPairAlgo(t *testing.T, algo string) (certFile, keyFile string, parsed *x509.Certificate) {
 	t.Helper()
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		t.Fatal(err)
+	var pub any
+	var signer crypto.Signer
+	var keyBlock *pem.Block
+	switch algo {
+	case "ecdsa":
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		keyDER, err := x509.MarshalECPrivateKey(key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pub, signer = &key.PublicKey, key
+		keyBlock = &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}
+	case "rsa":
+		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pub, signer = &key.PublicKey, key
+		keyBlock = &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}
+	default:
+		t.Fatalf("unknown algo %q", algo)
 	}
 	tmpl := &x509.Certificate{
 		SerialNumber:          big.NewInt(1),
@@ -53,13 +77,13 @@ func mintServeTLSPair(t *testing.T) (certFile, keyFile string, pool *x509.CertPo
 		BasicConstraintsValid: true,
 		IsCA:                  true,
 	}
-	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, pub, signer)
 	if err != nil {
 		t.Fatal(err)
 	}
 	dir := t.TempDir()
-	certFile = filepath.Join(dir, "serve.crt")
-	keyFile = filepath.Join(dir, "serve.key")
+	certFile = filepath.Join(dir, algo+".serve.crt")
+	keyFile = filepath.Join(dir, algo+".serve.key")
 	certOut, err := os.Create(certFile)
 	if err != nil {
 		t.Fatal(err)
@@ -68,22 +92,26 @@ func mintServeTLSPair(t *testing.T) (certFile, keyFile string, pool *x509.CertPo
 		t.Fatal(err)
 	}
 	_ = certOut.Close()
-	keyDER, err := x509.MarshalECPrivateKey(key)
-	if err != nil {
-		t.Fatal(err)
-	}
 	keyOut, err := os.Create(keyFile)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := pem.Encode(keyOut, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}); err != nil {
+	if err := pem.Encode(keyOut, keyBlock); err != nil {
 		t.Fatal(err)
 	}
 	_ = keyOut.Close()
-	parsed, err := x509.ParseCertificate(der)
+	parsed, err = x509.ParseCertificate(der)
 	if err != nil {
 		t.Fatal(err)
 	}
+	return certFile, keyFile, parsed
+}
+
+// mintServeTLSPair keeps the single-pair (ECDSA) shape the earlier
+// tests use — path pair plus a root pool trusting it.
+func mintServeTLSPair(t *testing.T) (certFile, keyFile string, pool *x509.CertPool) {
+	t.Helper()
+	certFile, keyFile, parsed := mintServeTLSPairAlgo(t, "ecdsa")
 	pool = x509.NewCertPool()
 	pool.AddCert(parsed)
 	return certFile, keyFile, pool
@@ -214,5 +242,78 @@ func TestNewMirrorServeTLSValidation(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "--serve") {
 		t.Errorf("TLS pair without serve = %v, want the add---serve error", err)
+	}
+	// Dual-certificate lists pair positionally — a count mismatch is
+	// caught before any file is touched.
+	_, err = NewMirror(MirrorOptions{
+		Source: "http://s:1", Target: "http://t:2", ServeAddr: ":0",
+		ServeTLSCert: "rsa.pem,ecdsa.pem", ServeTLSKey: "rsa.key",
+	})
+	if err == nil || !strings.Contains(err.Error(), "counts differ") {
+		t.Errorf("mismatched pair counts = %v, want the counts-differ error", err)
+	}
+}
+
+// TestMirrorServeTLSDualCert: BCP-003-01 dual-certificate serving —
+// with an RSA AND an ECDSA pair installed, an RSA-only TLS 1.2 client
+// (pinned to the spec's mandatory TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256)
+// completes the handshake against the RSA certificate, and an
+// ECDSA-pinned client against the ECDSA one — Go's handshake selects
+// per ClientHello, no custom selection code (the tool's test_02/test_08
+// pair of findings, reproduced as a unit test).
+func TestMirrorServeTLSDualCert(t *testing.T) {
+	stubServeTLSDataDir(t)
+	rsaCert, rsaKey, rsaParsed := mintServeTLSPairAlgo(t, "rsa")
+	ecdsaCert, ecdsaKey, ecdsaParsed := mintServeTLSPairAlgo(t, "ecdsa")
+	pool := x509.NewCertPool()
+	pool.AddCert(rsaParsed)
+	pool.AddCert(ecdsaParsed)
+
+	plant := &fakePlant{}
+	target := httptest.NewServer(plant.targetHandler())
+	t.Cleanup(target.Close)
+	push := newPushSource()
+	src := httptest.NewServer(stdhttp.NotFoundHandler())
+	src.Config.Handler = push.handler(t, func() string { return src.URL })
+	t.Cleanup(src.Close)
+
+	m, err := NewMirror(MirrorOptions{
+		Source: src.URL, Target: target.URL, APIVer: "v1.3",
+		ServeAddr:    "127.0.0.1:0",
+		ServeTLSCert: rsaCert + "," + ecdsaCert,
+		ServeTLSKey:  rsaKey + "," + ecdsaKey,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = m.Run(ctx) }()
+	waitFor(t, 5*time.Second, func() bool { return m.ServeAddr() != "" }, "served face to bind")
+
+	// handshake pins TLS 1.2 (1.3 ignores CipherSuites) and exactly one
+	// cipher, then reports the leaf certificate the server presented.
+	handshake := func(cipher uint16) *x509.Certificate {
+		t.Helper()
+		conn, err := tls.Dial("tcp", m.ServeAddr(), &tls.Config{
+			RootCAs:      pool,
+			MinVersion:   tls.VersionTLS12,
+			MaxVersion:   tls.VersionTLS12,
+			CipherSuites: []uint16{cipher},
+		})
+		if err != nil {
+			t.Fatalf("handshake with cipher %#x: %v", cipher, err)
+		}
+		defer func() { _ = conn.Close() }()
+		return conn.ConnectionState().PeerCertificates[0]
+	}
+
+	rsaLeaf := handshake(tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256)
+	if _, ok := rsaLeaf.PublicKey.(*rsa.PublicKey); !ok {
+		t.Errorf("RSA-only client got a %T leaf — the mandatory RSA cipher needs the RSA certificate", rsaLeaf.PublicKey)
+	}
+	ecdsaLeaf := handshake(tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256)
+	if _, ok := ecdsaLeaf.PublicKey.(*ecdsa.PublicKey); !ok {
+		t.Errorf("ECDSA-pinned client got a %T leaf — want the ECDSA certificate", ecdsaLeaf.PublicKey)
 	}
 }


### PR DESCRIPTION
Closes #948 (S3b — the last approved board item).

## What

The BCP-003-01 TLS conformance window, encoded end-to-end, plus TLS on the mirror's served face — and one genuine product upgrade the window forced: **dual-certificate TLS serving**.

### The window (Ansible)

- Fourth tool instance `nmos-testing-tls` (created-stopped → pin → start, the #942 pattern) with `ENABLE_HTTPS=True` — the tool's **global** https switch (its API has no per-row scheme), so `tls: true` on a catalog entry selects the instance outright; three-way plain/auth/tls tool filter, plays never mix instances.
- The CuT serves the image's own premade `dhs-node.testsuite.nmos.tv` pairs (SAN-verified, notAfter 2076 — no per-window cert minting: `openssl ca` mutates CA state and refuses same-CN re-issues). The tool reaches the CuT by the vouched FQDN via idempotent `/etc/hosts` pins; readiness is a CA-validated https GET, so plain http can never fake ready.
- `amwa-validate-node-tls.yml` + umbrella extension; `-tls` receipt suffix; ` (tls)` report labels.

### Dual-certificate serving (Go) — what the window proved

Single-pair serving cannot be BCP-003-01 compliant: RSA-only warns test_08 ("Server is not providing an ECDSA certificate"); ECDSA-only **fails** test_02 (the spec's mandatory `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256` cipher needs an RSA certificate). `certmgr` was already multi-pair ready (its doc cites the RSA+ECDSA SHOULD; `TLSServerConfig` hands Go's handshake all pairs) — the gap was the feeding: `--tls-cert/--tls-key` (node + registry) and `--serve-tls-cert/--serve-tls-key` (mirror) are now **repeatable**, positionally paired, count-mismatch caught as an operator error before any socket binds. Handshake tests pin both selections (TLS 1.2 clients with exactly one cipher each get the matching leaf).

### Mirror served face TLS

`--serve-tls-cert/--serve-tls-key` reuse the registry's exact plumbing (certmgr manual load, TLS 1.2 floor + BCP-003-01 cipher set); ws_hrefs become `wss://`, the announce TXT carries `api_proto=https`, `serve_tls` on status.json. Plant default stays plain HTTP for Cerebrum.

## What the fleet iterations caught (each fixed in its own commit)

1. A tool instance's real port footprint is ~`PORT_BASE..+110` (per-suite mocks at `+100+n`) — TLS at 5600 sat inside the armed instance's block and crash-looped; moved to 5800/6800.
2. In this tool build `ENABLE_HTTPS` wraps only the mock apps — the core GUI/API stays plain http (https probe died with `WRONG_VERSION_NUMBER`); the API URL is http, and https-mode is asserted separately by CA-validating a mock at `+101`.
3. The suite row's `ver` is the BCP-003-01 **spec** version (v1.0 — its repo has only v1.0.x branches), not an IS-04 api_ver.
4. The single-algo attempts (above) that proved dual-cert is the only compliant posture.

## Fleet receipt (2026-09-02)

**`BCP-003-01 (tls) OK pass=7/7 fail=0 cnt=0 warn=0`** — the historic 7/0 reproduced at committed baseline, and improved: zero warnings, which single-pair serving could never achieve. Full test sweep, vet, golangci 0 issues; docs/cli.md regenerated (six flag entries now repeatable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
