### PR TITLE
chore(ansible): catalog names every suite the tool ships (#952)

### DIFF
--- a/ansible/roles/dhs_amwa_validate/defaults/main.yml
+++ b/ansible/roles/dhs_amwa_validate/defaults/main.yml
@@ -332,3 +332,15 @@ dhs_amwa_validate_suites:
       note: "controller facade not built yet", rows: [], baseline_pass: 0, baseline_cnt: 0 }
   - { id: IS-05-03, scope: controller, target: node, enabled: false,
       note: "controller facade not built yet", rows: [], baseline_pass: 0, baseline_cnt: 0 }
+  # Found via the "a suite we cannot name IS the signal" audit (#952):
+  # two more testing-facade-driven controller exams the tool registers
+  # (its TEST_DEFINITIONS: "BCP-006-01 Controller", "BCP-007-03
+  # Controller" — testing-facade/testquestion spec rows like the two
+  # above). Named here so the catalog covers every suite the tool
+  # ships; they enable together with IS-04-04/IS-05-03 when the
+  # controller-facade decision lands. Their sibling -01 node suites
+  # are in the gate at baseline.
+  - { id: BCP-006-01-02, scope: controller, target: node, enabled: false,
+      note: "controller facade not built yet", rows: [], baseline_pass: 0, baseline_cnt: 0 }
+  - { id: BCP-007-03-02, scope: controller, target: node, enabled: false,
+      note: "controller facade not built yet", rows: [], baseline_pass: 0, baseline_cnt: 0 }


### PR DESCRIPTION
Closes #952. Details in the commit message: two invisible testing-facade controller suites (BCP-006-01-02, BCP-007-03-02) named as disabled controller-scope entries; BCP-002/004 confirmed needing no entries (no such standalone suites exist - their rules already score inside the green gate). Catalog-only change; disabled entries are inert to every play. Generated with Claude Code.