### PR TITLE
feat(amwa+ansible): controller scope validated - facade window, 4 suites green (#954)

### DIFF
--- a/ansible/playbooks/amwa-validate-controller.yml
+++ b/ansible/playbooks/amwa-validate-controller.yml
@@ -1,8 +1,12 @@
 ---
-# Validate the CONTROLLER role. The AMWA controller suites (IS-04-04,
-# IS-05-03) need the interactive controller facade — until that unit
-# lands this play only reports them as not-automatable, so the gap
-# stays visible instead of silently absent.
+# Validate the CONTROLLER role (issue #954): the four testing-facade
+# exams — IS-04-04, IS-05-03, BCP-006-01-02, BCP-007-03-02 — scored by
+# the RESIDENT tool instance against OUR shipped facade
+# (`dhs consumer nmos facade`, window_facade.yml), which answers the
+# tool's questions by driving the consumer Controller against the
+# tool's own mock registry.
+#
+#   ansible-playbook -i ansible/inventory/hosts.ini ansible/playbooks/amwa-validate-controller.yml
 
 - name: AMWA validate — controller
   hosts: tooling

--- a/ansible/roles/dhs_amwa_validate/defaults/main.yml
+++ b/ansible/roles/dhs_amwa_validate/defaults/main.yml
@@ -373,19 +373,19 @@ dhs_amwa_validate_suites:
   - { id: IS-04-04, scope: controller, target: node, window: facade,
       rows: [{host: 127.0.0.1, port: 5320, ver: v1.0},
              {host: null, port: null, ver: v1.3}],
-      baseline_pass: 0, baseline_cnt: 0 }
+      baseline_pass: 4, baseline_cnt: 0 }
   - { id: IS-05-03, scope: controller, target: node, window: facade,
       rows: [{host: 127.0.0.1, port: 5320, ver: v1.0},
              {host: null, port: null, ver: v1.3},
              {host: null, port: null, ver: v1.1}],
-      baseline_pass: 0, baseline_cnt: 0 }
+      baseline_pass: 4, baseline_cnt: 0 }
   - { id: BCP-006-01-02, scope: controller, target: node, window: facade,
       rows: [{host: 127.0.0.1, port: 5320, ver: v1.0},
              {host: null, port: null, ver: v1.3},
              {host: null, port: null, ver: v1.1}],
-      baseline_pass: 0, baseline_cnt: 0 }
+      baseline_pass: 5, baseline_cnt: 0 }
   - { id: BCP-007-03-02, scope: controller, target: node, window: facade,
       rows: [{host: 127.0.0.1, port: 5320, ver: v1.0},
              {host: null, port: null, ver: v1.3},
              {host: null, port: null, ver: v1.1}],
-      baseline_pass: 0, baseline_cnt: 0 }
+      baseline_pass: 4, baseline_cnt: 0 }

--- a/ansible/roles/dhs_amwa_validate/defaults/main.yml
+++ b/ansible/roles/dhs_amwa_validate/defaults/main.yml
@@ -157,12 +157,40 @@ dhs_amwa_validate_tls_plant_dir: /opt/dhs-amwa-plant/tls
 # against exactly one tool instance (resident / armed / TLS).
 dhs_amwa_validate_tls_mode: false
 
+# Controller scope (issue #954): the CuT is OUR testing facade
+# (`dhs consumer nmos facade`) answering the tool's testquestion
+# POSTs by driving the consumer Controller against the tool's own
+# mock registry. The RESIDENT tool instance scores these suites: the
+# controller path does no zeroconf at all (ControllerTest.py — the
+# mock registries are named by URL, never announced, and IS-04-04
+# test_01, the one DNS-SD round, self-DISABLEs unless
+# DNS_SD_MODE=unicast), so the LAN-pollution concern that sends
+# IS-04-01 to the isolated instance does not apply; neither auth nor
+# tls is in play either. The facade runs as a CONTAINER on the
+# tooling host (window_facade.yml, host networking) — tooling-host
+# transients follow the window_isolated container pattern because
+# this LXC's systemd never holds its dbus name (tooling.yml's
+# cgroupfs note); systemd-run windows stay a plant-host thing.
+dhs_amwa_validate_facade_container: dhs-validate-facade
+# 5320 sits in the gap between the resident instance's real footprint
+# (5000..5110 — per-suite mock APIs bind PORT_BASE+100+n) and the
+# armed one (5500..5610). The facade verb's own default :5001 would
+# collide with the isolated tool's published port.
+dhs_amwa_validate_facade_port: 5320
+# The tool's PRIMARY mock registry: mocks/Registry.py binds instance
+# i at PORT_BASE+100+(i+1) and ControllerTest picks registries[1] —
+# resident PORT_BASE 5000 + 102. The facade is pointed straight at
+# it: in multicast mode nothing announces it and the tool's own
+# pre-test question hands a human this URL — the URL IS the
+# discovery contract, so --registry is the honest automated twin.
+dhs_amwa_validate_mock_registry_port: 5102
+
 # The catalog. Fields:
 #   id            AMWA suite id, verbatim
 #   scope         node | registry | controller | mirror
 #   target        node | registry | cut  (which host:port the rows use)
-#   window        absent | isolated | p2p | registry  (CuT window
-#                 around the run — window_<name>.yml)
+#   window        absent | isolated | p2p | registry | tls | facade
+#                 (CuT window around the run — window_<name>.yml)
 #   auth          true = IS-10 window (issue #942): the window's CuT
 #                 is armed with --auth-url and the ARMED tool instance
 #                 scores it; plant resident units are never armed
@@ -325,22 +353,39 @@ dhs_amwa_validate_suites:
   - { id: IS-04-02, scope: registry, target: registry, window: registry, auth: true,
       rows: [{ver: v1.3}, {ver: v1.3}], baseline_pass: 88, baseline_cnt: 2 }
 
-  # ---- controller scope: needs the controller facade (issue backlog,
-  # user-owned item #7) — listed so the report says "not automatable
-  # yet" instead of silently omitting them. ----
-  - { id: IS-04-04, scope: controller, target: node, enabled: false,
-      note: "controller facade not built yet", rows: [], baseline_pass: 0, baseline_cnt: 0 }
-  - { id: IS-05-03, scope: controller, target: node, enabled: false,
-      note: "controller facade not built yet", rows: [], baseline_pass: 0, baseline_cnt: 0 }
-  # Found via the "a suite we cannot name IS the signal" audit (#952):
-  # two more testing-facade-driven controller exams the tool registers
-  # (its TEST_DEFINITIONS: "BCP-006-01 Controller", "BCP-007-03
-  # Controller" — testing-facade/testquestion spec rows like the two
-  # above). Named here so the catalog covers every suite the tool
-  # ships; they enable together with IS-04-04/IS-05-03 when the
-  # controller-facade decision lands. Their sibling -01 node suites
-  # are in the gate at baseline.
-  - { id: BCP-006-01-02, scope: controller, target: node, enabled: false,
-      note: "controller facade not built yet", rows: [], baseline_pass: 0, baseline_cnt: 0 }
-  - { id: BCP-007-03-02, scope: controller, target: node, enabled: false,
-      note: "controller facade not built yet", rows: [], baseline_pass: 0, baseline_cnt: 0 }
+  # ---- controller scope (issue #954): the four testing-facade exams,
+  # driven by our shipped facade (window_facade.yml). Row shapes are
+  # the tool's own TEST_DEFINITIONS, verified from NMOSTesting.py:
+  # row 1 is the testing-facade/testquestion slot — the ONLY row that
+  # names the CuT (our facade on the tooling host; host:port literals
+  # per this file's row style, matching dhs_amwa_validate_facade_port);
+  # the is-04/query and is-05/connection rows carry
+  # disable_fields host+port — the TOOL fills its own mocks — spelled
+  # as the explicit-null row shape IS-09-02 already uses. Row versions
+  # are the tool's spec defaults (testquestion v1.0, query v1.3,
+  # connection v1.1). IS-04-04 has NO connection row (2-row suite).
+  # baseline 0/0 placeholders — the fleet fills them. Expected first
+  # run: IS-04-04 test_01 reports DISABLED (multicast mode);
+  # BCP-006-01-02 test_03/test_04 FAIL — a named facade coverage gap
+  # (TR-08 compatibility with the counterpart identified only in
+  # prose; the facade answers the question's own "unable to
+  # identify" branch) — keep-or-disable is the post-fleet decision.
+  - { id: IS-04-04, scope: controller, target: node, window: facade,
+      rows: [{host: 127.0.0.1, port: 5320, ver: v1.0},
+             {host: null, port: null, ver: v1.3}],
+      baseline_pass: 0, baseline_cnt: 0 }
+  - { id: IS-05-03, scope: controller, target: node, window: facade,
+      rows: [{host: 127.0.0.1, port: 5320, ver: v1.0},
+             {host: null, port: null, ver: v1.3},
+             {host: null, port: null, ver: v1.1}],
+      baseline_pass: 0, baseline_cnt: 0 }
+  - { id: BCP-006-01-02, scope: controller, target: node, window: facade,
+      rows: [{host: 127.0.0.1, port: 5320, ver: v1.0},
+             {host: null, port: null, ver: v1.3},
+             {host: null, port: null, ver: v1.1}],
+      baseline_pass: 0, baseline_cnt: 0 }
+  - { id: BCP-007-03-02, scope: controller, target: node, window: facade,
+      rows: [{host: 127.0.0.1, port: 5320, ver: v1.0},
+             {host: null, port: null, ver: v1.3},
+             {host: null, port: null, ver: v1.1}],
+      baseline_pass: 0, baseline_cnt: 0 }

--- a/ansible/roles/dhs_amwa_validate/tasks/window_facade.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/window_facade.yml
@@ -1,0 +1,75 @@
+---
+# Controller CuT window (IS-04-04 / IS-05-03 / BCP-006-01-02 /
+# BCP-007-03-02, issue #954): the CuT is OUR testing facade
+# (`dhs consumer nmos facade`) — the tool POSTs its testquestion
+# rounds to it and it answers by driving the consumer Controller
+# against the tool's own PRIMARY mock registry (deterministic port,
+# see dhs_amwa_validate_mock_registry_port; nothing is mDNS-announced
+# on the controller path, and the one DNS-SD round self-disables in
+# multicast mode).
+#
+# A container, not systemd-run: tooling-host transients follow the
+# window_isolated pattern because this LXC's systemd never holds its
+# dbus name (tooling.yml's cgroupfs note). Fresh per attempt, removed
+# in window_teardown.yml — no plant-side safety timer applies, and a
+# leaked facade container serves nothing but an idle listener the
+# next window's remove-then-run clears.
+
+- name: Facade staging directory exists on the tooling host
+  ansible.builtin.file:
+    path: /opt/dhs-validate
+    state: directory
+    mode: "0755"
+
+# The binary lives on the PLANT host — explicit plant -> controller ->
+# tooling hop, same as window_isolated (the secondary runner is not
+# the plant).
+- name: Current dhs binary pulled from the plant
+  ansible.builtin.fetch:
+    src: "{{ dhs_amwa_validate_plant_bin }}"
+    dest: /tmp/dhs-validate-stage/
+    flat: true
+  delegate_to: "{{ groups['plant'][0] }}"
+
+- name: Current dhs binary staged on the tooling host
+  ansible.builtin.copy:
+    src: "/tmp/dhs-validate-stage/{{ dhs_amwa_validate_plant_bin | basename }}"
+    dest: /opt/dhs-validate/
+    mode: "0755"
+
+# A FRESH facade per attempt — remove-then-run clears any half-created
+# corpse holding the name.
+- name: Remove any previous facade container
+  ansible.builtin.command: docker rm -f {{ dhs_amwa_validate_facade_container }}
+  changed_when: true
+  failed_when: false
+
+# Host networking, both directions: the tool (also host-net) POSTs
+# questions to 127.0.0.1:{{ dhs_amwa_validate_facade_port }} (the
+# testquestion row) and answers land on its answer_uri; the facade's
+# outbound legs reach the mock registry + mock node on the same
+# loopback. --api-ver pins the Query walk to the suites' v1.3 query
+# row (IS-04-04 test_02 asserts the requested version).
+- name: Start the facade CuT
+  ansible.builtin.command: >-
+    docker run -d --name {{ dhs_amwa_validate_facade_container }}
+    --network host
+    -v /opt/dhs-validate:/dv:ro
+    --entrypoint /dv/{{ dhs_amwa_validate_plant_bin | basename }}
+    {{ dhs_amwa_validate_tool_image }}
+    consumer nmos facade
+    --bind 0.0.0.0:{{ dhs_amwa_validate_facade_port }}
+    --registry http://127.0.0.1:{{ dhs_amwa_validate_mock_registry_port }}
+    --api-ver v1.3
+  changed_when: true
+
+# The facade's only route is the question POST — a GET answering 405
+# IS the readiness signal (listening, wrong method).
+- name: Wait for the facade
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ dhs_amwa_validate_facade_port }}/"
+    status_code: [405]
+  register: _facade_up
+  retries: 10
+  delay: 2
+  until: _facade_up.status == 405

--- a/ansible/roles/dhs_amwa_validate/tasks/window_teardown.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/window_teardown.yml
@@ -40,6 +40,29 @@
   changed_when: false
   failed_when: false
 
+# The facade window's CuT (issue #954) — its log is the question /
+# answer decision trail, the one artefact that explains a controller
+# suite verdict.
+- name: What the facade CuT said
+  ansible.builtin.command: docker logs --tail 120 {{ dhs_amwa_validate_facade_container }}
+  register: _facade_log
+  changed_when: false
+  failed_when: false
+
+- name: Keep the facade log beside the results
+  ansible.builtin.copy:
+    content: |
+      {{ _facade_log.stdout | default('') }}
+      {{ _facade_log.stderr | default('') }}
+    dest: "{{ dhs_amwa_validate_results_dir }}/{{ _validate_run_ts }}/{{ _suite_file | default(suite.id) }}-facade.log"
+    mode: "0644"
+  when: _facade_log.rc | default(1) == 0
+
+- name: Remove the facade container
+  ansible.builtin.command: docker rm -f {{ dhs_amwa_validate_facade_container }}
+  changed_when: false
+  failed_when: false
+
 - name: Ensure the plant registry is running
   ansible.builtin.systemd:
     name: "{{ dhs_amwa_validate_registry_unit }}"

--- a/internal/amwa/consumer/connect.go
+++ b/internal/amwa/consumer/connect.go
@@ -70,7 +70,8 @@ type ConnectResult struct {
 // fetch the Sender's transport file, stage it on the Receiver together
 // with sender_id and master_enable, and activate. Staging without
 // master_enable=true is the classic silent failure — everything reports
-// success and no signal moves.
+// success and no signal moves. MXL legs are the one exception: no
+// transport file is fetched or staged (see mxlLeg).
 func (c *Controller) Connect(ctx context.Context, req ConnectRequest) (*ConnectResult, error) {
 	if req.ReceiverID == "" {
 		return nil, fmt.Errorf("nmos connect: receiver id is required")
@@ -111,6 +112,14 @@ func (c *Controller) Connect(ctx context.Context, req ConnectRequest) (*ConnectR
 		// Disconnect. sender_id must be explicitly null — omitting it
 		// would leave the existing one in place, because PATCH merges.
 		patch["sender_id"] = nil
+	} else if mxlLeg(snap, req.SenderID, req.ReceiverID) {
+		// BCP-007-03: an MXL connection carries NO transport file —
+		// the receiver locates the flow through the MXL runtime, not
+		// an SDP, and the spec's Controller suite (BCP-007-03-02
+		// test_03) scores a PATCH that attaches one as non-conformant.
+		// Deliberately not even requesting /transportfile: an MXL
+		// sender has none to serve.
+		patch["sender_id"] = req.SenderID
 	} else {
 		patch["sender_id"] = req.SenderID
 		sdp, err := cl.TransportFile(ctx, req.SenderID)
@@ -239,6 +248,27 @@ func pickConnectionControl(controls []is04.DeviceControl) string {
 		}
 	}
 	return best
+}
+
+// mxlLeg reports whether either end of the requested connection rides
+// urn:x-nmos:transport:mxl (or a dotted subclassification), looked up
+// in the snapshot already fetched for control-href resolution. BCP-007-03
+// forbids a transport file on MXL connections, so Connect branches on it.
+func mxlLeg(snap *CatalogueSnapshot, senderID, receiverID string) bool {
+	isMXL := func(t string) bool {
+		return t == is04.TransportMXL || strings.HasPrefix(t, is04.TransportMXL+".")
+	}
+	for _, r := range snap.Receivers {
+		if r.ID == receiverID && isMXL(r.Transport) {
+			return true
+		}
+	}
+	for _, s := range snap.Senders {
+		if s.ID == senderID && isMXL(s.Transport) {
+			return true
+		}
+	}
+	return false
 }
 
 // activationBody builds the IS-05 activation object. Only the scheduled

--- a/internal/amwa/consumer/connect_mxl_test.go
+++ b/internal/amwa/consumer/connect_mxl_test.go
@@ -1,0 +1,41 @@
+package consumer
+
+// BCP-007-03: an MXL connection carries NO transport file. mxlLeg is
+// the branch Connect takes to skip the /transportfile fetch entirely
+// (BCP-007-03-02 test_03 scores a PATCH that attaches one as
+// non-conformant).
+
+import (
+	"testing"
+
+	"dhs/internal/amwa/codec/is04"
+)
+
+func TestMXLLeg(t *testing.T) {
+	snap := &CatalogueSnapshot{
+		Senders: []is04.Sender{
+			{ResourceCore: is04.ResourceCore{ID: "snd-mxl"}, Transport: is04.TransportMXL},
+			{ResourceCore: is04.ResourceCore{ID: "snd-rtp"}, Transport: "urn:x-nmos:transport:rtp.mcast"},
+		},
+		Receivers: []is04.Receiver{
+			{ResourceCore: is04.ResourceCore{ID: "rcv-mxl"}, Transport: is04.TransportMXL},
+			{ResourceCore: is04.ResourceCore{ID: "rcv-rtp"}, Transport: "urn:x-nmos:transport:rtp"},
+		},
+	}
+	cases := []struct {
+		name         string
+		sender, recv string
+		want         bool
+	}{
+		{"both MXL", "snd-mxl", "rcv-mxl", true},
+		{"receiver MXL only", "snd-rtp", "rcv-mxl", true},
+		{"sender MXL only", "snd-mxl", "rcv-rtp", true},
+		{"neither", "snd-rtp", "rcv-rtp", false},
+		{"unknown ids", "nope", "nada", false},
+	}
+	for _, tc := range cases {
+		if got := mxlLeg(snap, tc.sender, tc.recv); got != tc.want {
+			t.Errorf("%s: mxlLeg = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/internal/amwa/facade/decide.go
+++ b/internal/amwa/facade/decide.go
@@ -3,6 +3,8 @@ package facade
 import (
 	"context"
 	"fmt"
+	"io"
+	stdhttp "net/http"
 	"regexp"
 	"sort"
 	"strconv"
@@ -66,17 +68,15 @@ func (s *Server) chooseMulti(ctx context.Context, q Question) ([]string, error) 
 		// "label (description, <uuid>)" (ControllerTest.py
 		// _format_device_metadata), so the counterpart's id — the one
 		// stable identifier NMOS has — is extracted with a UUID
-		// pattern, never by label matching. Compatibility then reads
-		// from the registry: TR-08's capability set ⇔ JPEG XS profile
-		// and conformance level ⇔ level, both registered on the Flow,
-		// and the tool builds each mock receiver's BCP-004-01
-		// constraint sets from exactly its compatible interop points —
-		// so "some constraint set admits the flow's profile+level" IS
-		// the tool's own capability_set/conformance_level rule seen
-		// through registry data.
-		keep = tr08CompatibleFromProse(snap, q.Question)
+		// pattern, never by label matching. Compatibility is judged
+		// the way a real BCP-006-01 controller judges it: fetch the
+		// sender's transport file and match the receiver's BCP-004-01
+		// constraint sets against the SDP's parameters (see
+		// tr08CompatibleFromProse for why the registry alone cannot
+		// express the rule).
+		keep = tr08CompatibleFromProse(ctx, snap, q.Question)
 		if keep == nil {
-			s.logger.Warn("nmos/facade: compatibility question names no resolvable counterpart UUID — answering 'unable to identify'",
+			s.logger.Warn("nmos/facade: compatibility question names no resolvable counterpart (or its SDP is unreadable) — answering 'unable to identify'",
 				"question_id", q.QuestionID)
 			keep = map[string]bool{}
 		}
@@ -539,32 +539,52 @@ var uuidRE = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0
 // UUID; whichever side it resolves to in the registry decides the
 // direction — a sender selects compatible receivers (test_03), a
 // receiver selects compatible senders (test_04). Returns nil when no
-// embedded UUID resolves, so the caller can log and take the
-// question's own "unable to identify" branch.
-func tr08CompatibleFromProse(snap *consumer.CatalogueSnapshot, questionText string) map[string]bool {
+// embedded UUID resolves (or the named sender's SDP is unreadable),
+// so the caller can log and take the question's own "unable to
+// identify" branch.
+//
+// Why the SENDER'S SDP, not its registered Flow: TR-08 capability
+// sets differ by color sampling and depth, and IS-04 registers
+// neither — the tool's own fixture book has Set A/B and Set C interop
+// points that are byte-identical in every registered flow field
+// (same geometry, framerate, profile High444.12, level, colorimetry,
+// TCS, even the same derived bit_rate) and differ ONLY in the SDP's
+// sampling=YCbCr-4:2:2 vs 4:4:4. The first #954 receipts are that
+// ambiguity scored ("Receivers incorrectly identified as compatible").
+// So the facade does what BCP-006-01 says a controller does: fetch
+// the transport file from the sender's manifest_href and match the
+// receiver's BCP-004-01 constraint sets against SDP-derived
+// parameters. That reproduces the tool's capability_set /
+// conformance_level table exactly, because each mock receiver's
+// constraint sets enumerate precisely its compatible interop points —
+// sampling and depth included.
+func tr08CompatibleFromProse(ctx context.Context, snap *consumer.CatalogueSnapshot, questionText string) map[string]bool {
 	for _, id := range uuidRE.FindAllString(questionText, -1) {
-		for _, snd := range snap.Senders {
-			if snd.ID != id {
+		for i := range snap.Senders {
+			if snap.Senders[i].ID != id {
 				continue
 			}
-			flow := flowForSender(snap, &snd)
+			params := senderSDPParams(ctx, &snap.Senders[i])
+			if params == nil {
+				return nil
+			}
 			out := map[string]bool{}
 			for _, r := range snap.Receivers {
-				if tr08Match(flow, r.Caps) {
+				if tr08SDPMatch(params, r.Caps) {
 					out[r.ID] = true
 				}
 			}
 			return out
 		}
-		for _, r := range snap.Receivers {
-			if r.ID != id {
+		for i := range snap.Receivers {
+			if snap.Receivers[i].ID != id {
 				continue
 			}
-			caps := r.Caps
+			caps := snap.Receivers[i].Caps
 			out := map[string]bool{}
-			for _, snd := range snap.Senders {
-				if tr08Match(flowForSender(snap, &snd), caps) {
-					out[snd.ID] = true
+			for j := range snap.Senders {
+				if params := senderSDPParams(ctx, &snap.Senders[j]); params != nil && tr08SDPMatch(params, caps) {
+					out[snap.Senders[j].ID] = true
 				}
 			}
 			return out
@@ -573,57 +593,192 @@ func tr08CompatibleFromProse(snap *consumer.CatalogueSnapshot, questionText stri
 	return nil
 }
 
-// flowForSender resolves a Sender's Flow in the snapshot, nil when the
-// sender carries no flow_id or the flow is not registered.
-func flowForSender(snap *consumer.CatalogueSnapshot, snd *is04.Sender) *is04.Flow {
-	if snd.FlowID == nil {
+// sdpClient fetches sender transport files (manifest_href) — the
+// BCP-006-01 controller's evidence source for capability matching.
+var sdpClient = &stdhttp.Client{Timeout: 5 * time.Second}
+
+// senderSDPParams fetches and parses one sender's transport file into
+// BCP-004-01 parameter values. nil when the sender advertises no
+// manifest, the fetch fails, or the SDP yields nothing usable — a
+// sender whose capabilities cannot be read is never claimed
+// compatible.
+func senderSDPParams(ctx context.Context, snd *is04.Sender) map[string]any {
+	if snd.ManifestHref == nil || *snd.ManifestHref == "" {
 		return nil
 	}
-	for i := range snap.Flows {
-		if snap.Flows[i].ID == *snd.FlowID {
-			return &snap.Flows[i]
-		}
+	req, err := stdhttp.NewRequestWithContext(ctx, stdhttp.MethodGet, *snd.ManifestHref, nil)
+	if err != nil {
+		return nil
 	}
-	return nil
+	resp, err := sdpClient.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != stdhttp.StatusOK {
+		return nil
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil
+	}
+	params := sdpCapParams(string(body))
+	if len(params) == 0 {
+		return nil
+	}
+	return params
 }
 
-// tr08Match is the TR-08 compatibility predicate over registered data:
-// the flow's media type is a member of the receiver's caps.media_types
-// and some BCP-004-01 constraint set admits the flow's JPEG XS
-// profile AND level. Profile encodes the TR-08 capability set and
-// level the conformance level, so this reproduces the tool's
-// capability_set/conformance_level rule exactly; the sets' other
-// members (frame geometry, depth, sampling) are deliberately NOT
-// evaluated here — the tool registers its mock flows without depth or
-// sampling, so judging them would compare template noise, not
-// authored data. A flow without profile+level (video/raw) matches no
-// TR-08 set; a receiver without constraint sets declares no JPEG XS
-// capability and matches nothing.
-func tr08Match(f *is04.Flow, caps is04.ReceiverCaps) bool {
-	if f == nil || f.Profile == "" || f.Level == "" {
+// sdpCapParams maps an SDP's media description onto BCP-004-01
+// parameter-constraint values, keyed by cap URN. Field names follow
+// the ST 2110 / RFC 9134 fmtp grammar the AMWA tool's own SDP
+// templates emit (sampling, depth, width, height, exactframerate,
+// interlace, colorimetry, TCS, RANGE, profile, level, sublevel,
+// packetmode, TP) plus b=AS for bit_rate. Numbers land as float64 so
+// they compare cleanly with JSON-decoded constraint values.
+func sdpCapParams(sdp string) map[string]any {
+	out := map[string]any{}
+	kind := ""
+	for _, line := range strings.Split(sdp, "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(line, "m="):
+			if f := strings.Fields(strings.TrimPrefix(line, "m=")); len(f) > 0 {
+				kind = f[0]
+			}
+		case strings.HasPrefix(line, "b=AS:"):
+			if n, err := strconv.ParseFloat(strings.TrimPrefix(line, "b=AS:"), 64); err == nil {
+				out["urn:x-nmos:cap:format:bit_rate"] = n
+			}
+		case strings.HasPrefix(line, "a=rtpmap:"):
+			// a=rtpmap:<pt> <subtype>/<clock> — with the m= kind this
+			// is the media type.
+			if f := strings.Fields(line); len(f) >= 2 && kind != "" {
+				if sub, _, ok := strings.Cut(f[1], "/"); ok {
+					out["urn:x-nmos:cap:format:media_type"] = kind + "/" + sub
+				}
+			}
+		case strings.HasPrefix(line, "a=fmtp:"):
+			rest := strings.TrimPrefix(line, "a=fmtp:")
+			if i := strings.IndexByte(rest, ' '); i >= 0 {
+				rest = rest[i+1:]
+			}
+			interlaced := false
+			for _, kv := range strings.Split(rest, ";") {
+				kv = strings.TrimSpace(kv)
+				if kv == "" {
+					continue
+				}
+				k, v, has := strings.Cut(kv, "=")
+				if !has {
+					if strings.TrimSpace(k) == "interlace" {
+						interlaced = true
+					}
+					continue
+				}
+				k, v = strings.TrimSpace(k), strings.TrimSpace(v)
+				switch k {
+				case "profile":
+					out["urn:x-nmos:cap:format:profile"] = v
+				case "level":
+					out["urn:x-nmos:cap:format:level"] = v
+				case "sublevel":
+					out["urn:x-nmos:cap:format:sublevel"] = v
+				case "sampling":
+					out["urn:x-nmos:cap:format:color_sampling"] = v
+				case "colorimetry":
+					out["urn:x-nmos:cap:format:colorspace"] = v
+				case "TCS":
+					out["urn:x-nmos:cap:format:transfer_characteristic"] = v
+				case "TP":
+					out["urn:x-nmos:cap:transport:st2110_21_sender_type"] = v
+				case "packetmode":
+					if v == "0" {
+						out["urn:x-nmos:cap:transport:packet_transmission_mode"] = "codestream"
+					}
+				case "depth":
+					if n, err := strconv.ParseFloat(v, 64); err == nil {
+						out["urn:x-nmos:cap:format:component_depth"] = n
+					}
+				case "width":
+					if n, err := strconv.ParseFloat(v, 64); err == nil {
+						out["urn:x-nmos:cap:format:frame_width"] = n
+					}
+				case "height":
+					if n, err := strconv.ParseFloat(v, 64); err == nil {
+						out["urn:x-nmos:cap:format:frame_height"] = n
+					}
+				case "exactframerate":
+					num, den, ok := strings.Cut(v, "/")
+					d := 1
+					if ok {
+						if n, err := strconv.Atoi(den); err == nil {
+							d = n
+						}
+					}
+					if n, err := strconv.Atoi(num); err == nil {
+						out["urn:x-nmos:cap:format:grain_rate"] = is04.GrainRate{Numerator: n, Denominator: d}
+					}
+				}
+			}
+			if interlaced {
+				out["urn:x-nmos:cap:format:interlace_mode"] = "interlaced_tff"
+			} else {
+				out["urn:x-nmos:cap:format:interlace_mode"] = "progressive"
+			}
+		}
+	}
+	return out
+}
+
+// tr08SDPMatch — the sender's SDP parameters against one receiver's
+// declared capabilities: media type membership, then at least one
+// BCP-004-01 constraint set every one of whose parameter constraints
+// is satisfied by the SDP value (constraints for parameters the SDP
+// does not carry are skipped, the tool's own leniency; a receiver
+// with no constraint sets declares no coded-format capability and
+// matches nothing).
+func tr08SDPMatch(params map[string]any, caps is04.ReceiverCaps) bool {
+	mt, _ := params["urn:x-nmos:cap:format:media_type"].(string)
+	if mt == "" {
 		return false
 	}
-	mtOK := false
-	for _, mt := range caps.MediaTypes {
-		if mt == f.MediaType {
-			mtOK = true
+	member := false
+	for _, m := range caps.MediaTypes {
+		if m == mt {
+			member = true
 			break
 		}
 	}
-	if !mtOK {
+	if !member || len(caps.ConstraintSets) == 0 {
 		return false
 	}
 	for _, cs := range caps.ConstraintSets {
-		p, pok := cs["urn:x-nmos:cap:format:profile"].(map[string]any)
-		l, lok := cs["urn:x-nmos:cap:format:level"].(map[string]any)
-		if !pok || !lok {
-			continue
-		}
-		if constraintSatisfied(f.Profile, p) && constraintSatisfied(f.Level, l) {
+		if sdpMatchesConstraintSet(params, cs) {
 			return true
 		}
 	}
 	return false
+}
+
+// sdpMatchesConstraintSet applies one constraint set to SDP-derived
+// values — meta keys and parameters without an SDP-derived value are
+// skipped.
+func sdpMatchesConstraintSet(params map[string]any, cs map[string]any) bool {
+	for capURI, raw := range cs {
+		constraint, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		v, known := params[capURI]
+		if !known {
+			continue
+		}
+		if !constraintSatisfied(v, constraint) {
+			return false
+		}
+	}
+	return true
 }
 
 // compatibleReceiversForSender — BCP-007-03-02's compatibility rule,

--- a/internal/amwa/facade/decide.go
+++ b/internal/amwa/facade/decide.go
@@ -3,6 +3,7 @@ package facade
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -59,18 +60,26 @@ func (s *Server) chooseMulti(ctx context.Context, q Question) ([]string, error) 
 		// BCP-004-01 constraint set satisfied by the flow's fields).
 		keep = compatibleReceiversForSender(snap, q.Metadata.Sender.ID)
 	case strings.Contains(question, "compatible"):
-		// BCP-006-01-02 test_03/test_04: TR-08 capability-set /
-		// conformance-level compatibility with a counterpart named
-		// ONLY in prose (no metadata) — display strings are mutable
-		// label+description, and this facade matches by UUID alone by
-		// design. Unanswerable without guessing, so take the
-		// question's own "If unable to identify ..., press 'Submit'
-		// without making a selection" branch. COVERAGE GAP, reported:
-		// closing it needs the tool to carry the counterpart's id in
-		// metadata, or a TR-08 matcher plus prose-label resolution.
-		s.logger.Warn("nmos/facade: TR-08 compatibility question without metadata — answering 'unable to identify' (coverage gap)",
-			"question_id", q.QuestionID)
-		keep = map[string]bool{}
+		// BCP-006-01-02 test_03/test_04: TR-08 compatibility with a
+		// counterpart carried in prose, not metadata. The prose IS
+		// machine-usable by UUID: the tool's display_answer format is
+		// "label (description, <uuid>)" (ControllerTest.py
+		// _format_device_metadata), so the counterpart's id — the one
+		// stable identifier NMOS has — is extracted with a UUID
+		// pattern, never by label matching. Compatibility then reads
+		// from the registry: TR-08's capability set ⇔ JPEG XS profile
+		// and conformance level ⇔ level, both registered on the Flow,
+		// and the tool builds each mock receiver's BCP-004-01
+		// constraint sets from exactly its compatible interop points —
+		// so "some constraint set admits the flow's profile+level" IS
+		// the tool's own capability_set/conformance_level rule seen
+		// through registry data.
+		keep = tr08CompatibleFromProse(snap, q.Question)
+		if keep == nil {
+			s.logger.Warn("nmos/facade: compatibility question names no resolvable counterpart UUID — answering 'unable to identify'",
+				"question_id", q.QuestionID)
+			keep = map[string]bool{}
+		}
 	case mentionsConnectionAPI(q.Question):
 		// IS-05-03 test_01: only receivers whose Device advertises an
 		// IS-05 control are correct — the registry lists more, and a
@@ -519,6 +528,102 @@ func mxlReceivers(snap *consumer.CatalogueSnapshot) map[string]bool {
 		}
 	}
 	return out
+}
+
+// uuidRE matches an RFC 4122 UUID — the id embedded in the tool's
+// display_answer prose ("label (description, <uuid>)").
+var uuidRE = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
+
+// tr08CompatibleFromProse answers the BCP-006-01-02 TR-08
+// compatibility questions. The question embeds the counterpart's
+// UUID; whichever side it resolves to in the registry decides the
+// direction — a sender selects compatible receivers (test_03), a
+// receiver selects compatible senders (test_04). Returns nil when no
+// embedded UUID resolves, so the caller can log and take the
+// question's own "unable to identify" branch.
+func tr08CompatibleFromProse(snap *consumer.CatalogueSnapshot, questionText string) map[string]bool {
+	for _, id := range uuidRE.FindAllString(questionText, -1) {
+		for _, snd := range snap.Senders {
+			if snd.ID != id {
+				continue
+			}
+			flow := flowForSender(snap, &snd)
+			out := map[string]bool{}
+			for _, r := range snap.Receivers {
+				if tr08Match(flow, r.Caps) {
+					out[r.ID] = true
+				}
+			}
+			return out
+		}
+		for _, r := range snap.Receivers {
+			if r.ID != id {
+				continue
+			}
+			caps := r.Caps
+			out := map[string]bool{}
+			for _, snd := range snap.Senders {
+				if tr08Match(flowForSender(snap, &snd), caps) {
+					out[snd.ID] = true
+				}
+			}
+			return out
+		}
+	}
+	return nil
+}
+
+// flowForSender resolves a Sender's Flow in the snapshot, nil when the
+// sender carries no flow_id or the flow is not registered.
+func flowForSender(snap *consumer.CatalogueSnapshot, snd *is04.Sender) *is04.Flow {
+	if snd.FlowID == nil {
+		return nil
+	}
+	for i := range snap.Flows {
+		if snap.Flows[i].ID == *snd.FlowID {
+			return &snap.Flows[i]
+		}
+	}
+	return nil
+}
+
+// tr08Match is the TR-08 compatibility predicate over registered data:
+// the flow's media type is a member of the receiver's caps.media_types
+// and some BCP-004-01 constraint set admits the flow's JPEG XS
+// profile AND level. Profile encodes the TR-08 capability set and
+// level the conformance level, so this reproduces the tool's
+// capability_set/conformance_level rule exactly; the sets' other
+// members (frame geometry, depth, sampling) are deliberately NOT
+// evaluated here — the tool registers its mock flows without depth or
+// sampling, so judging them would compare template noise, not
+// authored data. A flow without profile+level (video/raw) matches no
+// TR-08 set; a receiver without constraint sets declares no JPEG XS
+// capability and matches nothing.
+func tr08Match(f *is04.Flow, caps is04.ReceiverCaps) bool {
+	if f == nil || f.Profile == "" || f.Level == "" {
+		return false
+	}
+	mtOK := false
+	for _, mt := range caps.MediaTypes {
+		if mt == f.MediaType {
+			mtOK = true
+			break
+		}
+	}
+	if !mtOK {
+		return false
+	}
+	for _, cs := range caps.ConstraintSets {
+		p, pok := cs["urn:x-nmos:cap:format:profile"].(map[string]any)
+		l, lok := cs["urn:x-nmos:cap:format:level"].(map[string]any)
+		if !pok || !lok {
+			continue
+		}
+		if constraintSatisfied(f.Profile, p) && constraintSatisfied(f.Level, l) {
+			return true
+		}
+	}
+	return false
 }
 
 // compatibleReceiversForSender — BCP-007-03-02's compatibility rule,

--- a/internal/amwa/facade/decide.go
+++ b/internal/amwa/facade/decide.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"dhs/internal/amwa/codec/is04"
 	"dhs/internal/amwa/consumer"
 )
 
@@ -43,18 +44,54 @@ func (s *Server) chooseMulti(ctx context.Context, q Question) ([]string, error) 
 	if err != nil {
 		return nil, err
 	}
+	question := strings.ToLower(q.Question)
 	var keep map[string]bool
 	switch {
 	case mentionsOffline(q.Question):
 		// "select the ones which have been put offline" — the right
 		// answers are the offered resources the registry NO LONGER has.
 		keep = complementOf(snapshotIDs(snap), q.Answers)
+	case q.Metadata != nil && q.Metadata.Sender != nil:
+		// BCP-007-03-02 test_04: "select the Receivers that are
+		// compatible with the following MXL Sender" — the sender rides
+		// in metadata, and compatibility is the suite's published rule
+		// (both ends MXL, flow media_type in caps.media_types, any
+		// BCP-004-01 constraint set satisfied by the flow's fields).
+		keep = compatibleReceiversForSender(snap, q.Metadata.Sender.ID)
+	case strings.Contains(question, "compatible"):
+		// BCP-006-01-02 test_03/test_04: TR-08 capability-set /
+		// conformance-level compatibility with a counterpart named
+		// ONLY in prose (no metadata) — display strings are mutable
+		// label+description, and this facade matches by UUID alone by
+		// design. Unanswerable without guessing, so take the
+		// question's own "If unable to identify ..., press 'Submit'
+		// without making a selection" branch. COVERAGE GAP, reported:
+		// closing it needs the tool to carry the counterpart's id in
+		// metadata, or a TR-08 matcher plus prose-label resolution.
+		s.logger.Warn("nmos/facade: TR-08 compatibility question without metadata — answering 'unable to identify' (coverage gap)",
+			"question_id", q.QuestionID)
+		keep = map[string]bool{}
 	case mentionsConnectionAPI(q.Question):
 		// IS-05-03 test_01: only receivers whose Device advertises an
 		// IS-05 control are correct — the registry lists more, and a
 		// controller that offers to route what it cannot route is
 		// worse than one that hides it.
 		keep = connectableReceivers(snap)
+	case strings.Contains(question, "jpeg xs") && strings.Contains(question, "senders"):
+		// BCP-006-01-02 test_01: a Sender is JPEG XS capable when the
+		// Flow it transmits carries media_type video/jxsv (BCP-006-01
+		// puts the coding on the Flow, not the Sender).
+		keep = jxsvCapableSenders(snap)
+	case strings.Contains(question, "jpeg xs") && strings.Contains(question, "receivers"):
+		// BCP-006-01-02 test_02: a Receiver is JPEG XS capable when
+		// video/jxsv is a member of caps.media_types.
+		keep = jxsvCapableReceivers(snap)
+	case strings.Contains(question, "mxl senders"):
+		// BCP-007-03-02 test_01: transport urn:x-nmos:transport:mxl.
+		keep = mxlSenders(snap)
+	case strings.Contains(question, "mxl receivers"):
+		// BCP-007-03-02 test_02.
+		keep = mxlReceivers(snap)
 	default:
 		keep = snapshotIDs(snap)
 	}
@@ -419,6 +456,238 @@ func connectableReceivers(snap *consumer.CatalogueSnapshot) map[string]bool {
 		}
 	}
 	return out
+}
+
+// ---- BCP-006-01-02 / BCP-007-03-02 capability selection -----------------
+//
+// The four helpers below mirror the published rules the two Controller
+// suites score, driven from the registry snapshot alone.
+
+// jxsvCapableSenders — a Sender is JPEG XS capable when the Flow it
+// transmits carries media_type video/jxsv.
+func jxsvCapableSenders(snap *consumer.CatalogueSnapshot) map[string]bool {
+	flowMediaType := map[string]string{}
+	for _, f := range snap.Flows {
+		flowMediaType[f.ID] = f.MediaType
+	}
+	out := map[string]bool{}
+	for _, s := range snap.Senders {
+		if s.FlowID != nil && flowMediaType[*s.FlowID] == "video/jxsv" {
+			out[s.ID] = true
+		}
+	}
+	return out
+}
+
+// jxsvCapableReceivers — video/jxsv is a member of caps.media_types.
+func jxsvCapableReceivers(snap *consumer.CatalogueSnapshot) map[string]bool {
+	out := map[string]bool{}
+	for _, r := range snap.Receivers {
+		for _, mt := range r.Caps.MediaTypes {
+			if mt == "video/jxsv" {
+				out[r.ID] = true
+				break
+			}
+		}
+	}
+	return out
+}
+
+// isMXLTransport matches urn:x-nmos:transport:mxl (and any dotted
+// subclassification, the way RTP variants subclass their base URN).
+func isMXLTransport(t string) bool {
+	return t == is04.TransportMXL || strings.HasPrefix(t, is04.TransportMXL+".")
+}
+
+// mxlSenders / mxlReceivers — BCP-007-03 discovery: transport is the
+// MXL URN.
+func mxlSenders(snap *consumer.CatalogueSnapshot) map[string]bool {
+	out := map[string]bool{}
+	for _, s := range snap.Senders {
+		if isMXLTransport(s.Transport) {
+			out[s.ID] = true
+		}
+	}
+	return out
+}
+
+func mxlReceivers(snap *consumer.CatalogueSnapshot) map[string]bool {
+	out := map[string]bool{}
+	for _, r := range snap.Receivers {
+		if isMXLTransport(r.Transport) {
+			out[r.ID] = true
+		}
+	}
+	return out
+}
+
+// compatibleReceiversForSender — BCP-007-03-02's compatibility rule,
+// exactly as the suite scores it: both ends on the MXL transport, the
+// sender's Flow media_type a member of the receiver's caps.media_types,
+// and at least one BCP-004-01 constraint set satisfied by the Flow's
+// fields (a receiver with NO constraint_sets is not compatible — the
+// suite requires the capability declaration, not just the media type).
+// A sender that is missing or not MXL selects nothing: the only
+// metadata-carrying multi_choice the tool ships today is the MXL one,
+// and an empty selection is the question's own "unable to identify".
+func compatibleReceiversForSender(snap *consumer.CatalogueSnapshot, senderID string) map[string]bool {
+	out := map[string]bool{}
+	var flow *is04.Flow
+	for _, s := range snap.Senders {
+		if s.ID != senderID || !isMXLTransport(s.Transport) || s.FlowID == nil {
+			continue
+		}
+		for i := range snap.Flows {
+			if snap.Flows[i].ID == *s.FlowID {
+				flow = &snap.Flows[i]
+				break
+			}
+		}
+		break
+	}
+	if flow == nil {
+		return out
+	}
+	for _, r := range snap.Receivers {
+		if !isMXLTransport(r.Transport) {
+			continue
+		}
+		mtOK := false
+		for _, mt := range r.Caps.MediaTypes {
+			if mt == flow.MediaType {
+				mtOK = true
+				break
+			}
+		}
+		if !mtOK || len(r.Caps.ConstraintSets) == 0 {
+			continue
+		}
+		for _, cs := range r.Caps.ConstraintSets {
+			if flowMatchesConstraintSet(flow, cs) {
+				out[r.ID] = true
+				break
+			}
+		}
+	}
+	return out
+}
+
+// flowMatchesConstraintSet applies one BCP-004-01 constraint set to a
+// Flow. Only the parameter constraints the MXL suite scores are
+// evaluated (the CAP_URI table below); meta keys and unknown cap URNs
+// are skipped, matching the suite's own leniency.
+func flowMatchesConstraintSet(f *is04.Flow, cs map[string]any) bool {
+	for capURI, raw := range cs {
+		constraint, ok := raw.(map[string]any)
+		if !ok {
+			continue // meta:label / meta:enabled and friends
+		}
+		v, known := flowCapValue(f, capURI)
+		if !known {
+			continue
+		}
+		if !constraintSatisfied(v, constraint) {
+			return false
+		}
+	}
+	return true
+}
+
+// flowCapValue resolves one urn:x-nmos:cap:format:* parameter to the
+// Flow's value. Numbers come back as float64 so they compare cleanly
+// with JSON-decoded constraint values.
+func flowCapValue(f *is04.Flow, capURI string) (any, bool) {
+	switch capURI {
+	case "urn:x-nmos:cap:format:media_type":
+		return f.MediaType, true
+	case "urn:x-nmos:cap:format:frame_width":
+		return float64(f.FrameWidth), true
+	case "urn:x-nmos:cap:format:frame_height":
+		return float64(f.FrameHeight), true
+	case "urn:x-nmos:cap:format:grain_rate":
+		if f.GrainRate == nil {
+			return nil, false
+		}
+		return *f.GrainRate, true
+	case "urn:x-nmos:cap:format:interlace_mode":
+		return f.Interlace, true
+	case "urn:x-nmos:cap:format:colorspace":
+		return f.ColorSpace, true
+	case "urn:x-nmos:cap:format:transfer_characteristic":
+		return f.TransferChar, true
+	case "urn:x-nmos:cap:format:component_depth":
+		depth := 0
+		for _, c := range f.Components {
+			if c.BitDepth > depth {
+				depth = c.BitDepth
+			}
+		}
+		if depth == 0 {
+			return nil, false
+		}
+		return float64(depth), true
+	}
+	return nil, false
+}
+
+// constraintSatisfied applies the BCP-004-01 enum / minimum / maximum
+// keywords to one value.
+func constraintSatisfied(v any, constraint map[string]any) bool {
+	if enum, ok := constraint["enum"].([]any); ok {
+		found := false
+		for _, e := range enum {
+			if capValueEqual(v, e) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	if minRaw, ok := constraint["minimum"].(float64); ok {
+		n, isNum := v.(float64)
+		if !isNum || n < minRaw {
+			return false
+		}
+	}
+	if maxRaw, ok := constraint["maximum"].(float64); ok {
+		n, isNum := v.(float64)
+		if !isNum || n > maxRaw {
+			return false
+		}
+	}
+	return true
+}
+
+// capValueEqual compares a Flow value with one JSON-decoded enum entry.
+// Rational entries (grain_rate) compare numerator/denominator with the
+// spec's implicit denominator of 1.
+func capValueEqual(v any, entry any) bool {
+	switch fv := v.(type) {
+	case string:
+		s, ok := entry.(string)
+		return ok && s == fv
+	case float64:
+		n, ok := entry.(float64)
+		return ok && n == fv
+	case is04.GrainRate:
+		m, ok := entry.(map[string]any)
+		if !ok {
+			return false
+		}
+		num, _ := m["numerator"].(float64)
+		den := 1.0
+		if d, ok := m["denominator"].(float64); ok {
+			den = d
+		}
+		fDen := fv.Denominator
+		if fDen == 0 {
+			fDen = 1
+		}
+		return int(num) == fv.Numerator && int(den) == fDen
+	}
+	return false
 }
 
 func mentionsOffline(q string) bool {

--- a/internal/amwa/facade/decide_helpers_test.go
+++ b/internal/amwa/facade/decide_helpers_test.go
@@ -1,0 +1,135 @@
+package facade
+
+// Capability-selection helpers for the BCP-006-01-02 / BCP-007-03-02
+// Controller suites (issue #954): JPEG XS capability is the Flow's
+// media_type (senders) / caps.media_types membership (receivers); MXL
+// discovery is the transport URN; MXL compatibility is the suite's
+// published rule — both ends MXL, media_type membership, and at least
+// one BCP-004-01 constraint set satisfied by the Flow's fields.
+
+import (
+	"testing"
+
+	"dhs/internal/amwa/codec/is04"
+	"dhs/internal/amwa/consumer"
+)
+
+func strPtr(s string) *string { return &s }
+
+// mxlSnap builds a registry snapshot shaped like the MXL suite's mock
+// plant: one 1080p25 v210 MXL sender, one RTP sender, and receivers of
+// varying compatibility.
+func mxlSnap() *consumer.CatalogueSnapshot {
+	v210caps := func(sets []map[string]any) is04.ReceiverCaps {
+		return is04.ReceiverCaps{MediaTypes: []string{"video/v210"}, ConstraintSets: sets, Version: "0:1"}
+	}
+	matching := []map[string]any{{
+		"urn:x-nmos:cap:meta:label":                      "1080p25",
+		"urn:x-nmos:cap:format:media_type":               map[string]any{"enum": []any{"video/v210"}},
+		"urn:x-nmos:cap:format:frame_width":              map[string]any{"maximum": float64(1920)},
+		"urn:x-nmos:cap:format:frame_height":             map[string]any{"minimum": float64(720), "maximum": float64(1080)},
+		"urn:x-nmos:cap:format:grain_rate":               map[string]any{"enum": []any{map[string]any{"numerator": float64(25), "denominator": float64(1)}}},
+		"urn:x-nmos:cap:format:interlace_mode":           map[string]any{"enum": []any{"progressive"}},
+		"urn:x-nmos:cap:format:component_depth":          map[string]any{"maximum": float64(10)},
+		"urn:x-nmos:cap:format:transfer_characteristic":  map[string]any{"enum": []any{"SDR"}},
+		"urn:x-nmos:cap:format:colorspace":               map[string]any{"enum": []any{"BT709"}},
+		"urn:x-nmos:cap:format:some_unknown_cap_is_fine": map[string]any{"enum": []any{"ignored"}},
+	}}
+	tooNarrow := []map[string]any{{
+		"urn:x-nmos:cap:format:frame_width": map[string]any{"maximum": float64(1280)},
+	}}
+	return &consumer.CatalogueSnapshot{
+		Flows: []is04.Flow{
+			{ResourceCore: is04.ResourceCore{ID: "flow-jxsv"}, MediaType: "video/jxsv"},
+			{ResourceCore: is04.ResourceCore{ID: "flow-mxl"}, MediaType: "video/v210",
+				FrameWidth: 1920, FrameHeight: 1080,
+				GrainRate: &is04.GrainRate{Numerator: 25, Denominator: 1},
+				Interlace: "progressive", ColorSpace: "BT709", TransferChar: "SDR",
+				Components: []is04.FlowVideoComponent{{Name: "Y", BitDepth: 10}, {Name: "Cb", BitDepth: 10}}},
+		},
+		Senders: []is04.Sender{
+			{ResourceCore: is04.ResourceCore{ID: "snd-jxsv"}, FlowID: strPtr("flow-jxsv"),
+				Transport: "urn:x-nmos:transport:rtp.mcast"},
+			{ResourceCore: is04.ResourceCore{ID: "snd-mxl"}, FlowID: strPtr("flow-mxl"),
+				Transport: is04.TransportMXL},
+		},
+		Receivers: []is04.Receiver{
+			{ResourceCore: is04.ResourceCore{ID: "rcv-jxsv"}, Transport: "urn:x-nmos:transport:rtp",
+				Caps: is04.ReceiverCaps{MediaTypes: []string{"video/jxsv", "video/raw"}}},
+			{ResourceCore: is04.ResourceCore{ID: "rcv-raw"}, Transport: "urn:x-nmos:transport:rtp",
+				Caps: is04.ReceiverCaps{MediaTypes: []string{"video/raw"}}},
+			{ResourceCore: is04.ResourceCore{ID: "rcv-mxl-ok"}, Transport: is04.TransportMXL,
+				Caps: v210caps(matching)},
+			{ResourceCore: is04.ResourceCore{ID: "rcv-mxl-narrow"}, Transport: is04.TransportMXL,
+				Caps: v210caps(tooNarrow)},
+			{ResourceCore: is04.ResourceCore{ID: "rcv-mxl-nosets"}, Transport: is04.TransportMXL,
+				Caps: is04.ReceiverCaps{MediaTypes: []string{"video/v210"}}},
+		},
+	}
+}
+
+func TestJPEGXSCapabilitySelection(t *testing.T) {
+	snap := mxlSnap()
+	if got := jxsvCapableSenders(snap); !got["snd-jxsv"] || got["snd-mxl"] || len(got) != 1 {
+		t.Errorf("jxsvCapableSenders = %v, want exactly snd-jxsv", got)
+	}
+	if got := jxsvCapableReceivers(snap); !got["rcv-jxsv"] || got["rcv-raw"] || len(got) != 1 {
+		t.Errorf("jxsvCapableReceivers = %v, want exactly rcv-jxsv", got)
+	}
+}
+
+func TestMXLDiscoverySelection(t *testing.T) {
+	snap := mxlSnap()
+	if got := mxlSenders(snap); !got["snd-mxl"] || got["snd-jxsv"] || len(got) != 1 {
+		t.Errorf("mxlSenders = %v, want exactly snd-mxl", got)
+	}
+	got := mxlReceivers(snap)
+	if len(got) != 3 || !got["rcv-mxl-ok"] || !got["rcv-mxl-narrow"] || !got["rcv-mxl-nosets"] {
+		t.Errorf("mxlReceivers = %v, want the three MXL-transport receivers", got)
+	}
+}
+
+// TestMXLCompatibility pins the suite's rule: the fully matching
+// constraint set is compatible; a narrower frame_width maximum is not;
+// NO constraint sets at all is not (the capability declaration is
+// required); a non-MXL sender selects nothing.
+func TestMXLCompatibility(t *testing.T) {
+	snap := mxlSnap()
+	got := compatibleReceiversForSender(snap, "snd-mxl")
+	if len(got) != 1 || !got["rcv-mxl-ok"] {
+		t.Errorf("compatibleReceiversForSender(snd-mxl) = %v, want exactly rcv-mxl-ok", got)
+	}
+	if got := compatibleReceiversForSender(snap, "snd-jxsv"); len(got) != 0 {
+		t.Errorf("non-MXL sender must select nothing, got %v", got)
+	}
+	if got := compatibleReceiversForSender(snap, "missing"); len(got) != 0 {
+		t.Errorf("unknown sender must select nothing, got %v", got)
+	}
+}
+
+// TestConstraintSatisfied covers the three BCP-004-01 keywords over the
+// value shapes the MXL profiles use.
+func TestConstraintSatisfied(t *testing.T) {
+	gr := is04.GrainRate{Numerator: 50} // denominator omitted = 1
+	cases := []struct {
+		name string
+		v    any
+		c    map[string]any
+		want bool
+	}{
+		{"enum string hit", "BT709", map[string]any{"enum": []any{"BT709", "BT2020"}}, true},
+		{"enum string miss", "BT601", map[string]any{"enum": []any{"BT709"}}, false},
+		{"min/max inside", float64(1080), map[string]any{"minimum": float64(720), "maximum": float64(2160)}, true},
+		{"below minimum", float64(576), map[string]any{"minimum": float64(720)}, false},
+		{"above maximum", float64(4320), map[string]any{"maximum": float64(2160)}, false},
+		{"grain rate default denominator", gr,
+			map[string]any{"enum": []any{map[string]any{"numerator": float64(50), "denominator": float64(1)}}}, true},
+		{"grain rate mismatch", gr,
+			map[string]any{"enum": []any{map[string]any{"numerator": float64(25)}}}, false},
+	}
+	for _, tc := range cases {
+		if got := constraintSatisfied(tc.v, tc.c); got != tc.want {
+			t.Errorf("%s: constraintSatisfied = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/internal/amwa/facade/decide_helpers_test.go
+++ b/internal/amwa/facade/decide_helpers_test.go
@@ -107,6 +107,92 @@ func TestMXLCompatibility(t *testing.T) {
 	}
 }
 
+// tr08Snap models the BCP-006-01-02 mock plant: JPEG XS senders whose
+// flows carry the TR-08 discriminators (profile ⇔ capability set,
+// level ⇔ conformance level — the tool registers them via
+// flow_params), a video/raw sender, and receivers whose BCP-004-01
+// constraint sets enumerate exactly their compatible interop points'
+// profile/level pairs (how ControllerTest builds mock caps).
+func tr08Snap() *consumer.CatalogueSnapshot {
+	profLevel := func(profile, level string) map[string]any {
+		return map[string]any{
+			"urn:x-nmos:cap:meta:label":         profile + " " + level,
+			"urn:x-nmos:cap:format:media_type":  map[string]any{"enum": []any{"video/jxsv"}},
+			"urn:x-nmos:cap:format:profile":     map[string]any{"enum": []any{profile}},
+			"urn:x-nmos:cap:format:level":       map[string]any{"enum": []any{level}},
+			"urn:x-nmos:cap:format:frame_width": map[string]any{"enum": []any{float64(1920)}},
+		}
+	}
+	return &consumer.CatalogueSnapshot{
+		Flows: []is04.Flow{
+			{ResourceCore: is04.ResourceCore{ID: "flow-ab"}, MediaType: "video/jxsv",
+				Profile: "Main422.10", Level: "2k-1", FrameWidth: 1920},
+			{ResourceCore: is04.ResourceCore{ID: "flow-c"}, MediaType: "video/jxsv",
+				Profile: "High444.12", Level: "2k-1", FrameWidth: 1920},
+			{ResourceCore: is04.ResourceCore{ID: "flow-raw"}, MediaType: "video/raw",
+				FrameWidth: 1920},
+		},
+		Senders: []is04.Sender{
+			{ResourceCore: is04.ResourceCore{ID: "b0b00000-0000-4000-8000-00000000ab01"},
+				FlowID: strPtr("flow-ab"), Transport: "urn:x-nmos:transport:rtp.mcast"},
+			{ResourceCore: is04.ResourceCore{ID: "b0b00000-0000-4000-8000-00000000c001"},
+				FlowID: strPtr("flow-c"), Transport: "urn:x-nmos:transport:rtp.mcast"},
+			{ResourceCore: is04.ResourceCore{ID: "b0b00000-0000-4000-8000-0000000faw01"},
+				FlowID: strPtr("flow-raw"), Transport: "urn:x-nmos:transport:rtp.mcast"},
+		},
+		Receivers: []is04.Receiver{
+			// Set A/B receiver: compatible with A/B senders only.
+			{ResourceCore: is04.ResourceCore{ID: "rcv-ab"}, Transport: "urn:x-nmos:transport:rtp",
+				Caps: is04.ReceiverCaps{MediaTypes: []string{"video/jxsv"}, Version: "0:1",
+					ConstraintSets: []map[string]any{profLevel("Main422.10", "2k-1")}}},
+			// Set D receiver: compatible with A/B AND C senders (its
+			// constraint sets enumerate both points).
+			{ResourceCore: is04.ResourceCore{ID: "rcv-d"}, Transport: "urn:x-nmos:transport:rtp",
+				Caps: is04.ReceiverCaps{MediaTypes: []string{"video/jxsv"}, Version: "0:1",
+					ConstraintSets: []map[string]any{
+						profLevel("Main422.10", "2k-1"), profLevel("High444.12", "2k-1")}}},
+			// Raw receiver: no constraint sets, no JPEG XS capability.
+			{ResourceCore: is04.ResourceCore{ID: "rcv-raw"}, Transport: "urn:x-nmos:transport:rtp",
+				Caps: is04.ReceiverCaps{MediaTypes: []string{"video/raw"}}},
+		},
+	}
+}
+
+// TestTR08CompatibleFromProse: the counterpart UUID embedded in the
+// question prose (the tool's display_answer format) drives both
+// directions — a sender selects its compatible receivers (test_03), a
+// receiver its compatible senders (test_04); no resolvable UUID means
+// nil (the caller's "unable to identify" branch).
+func TestTR08CompatibleFromProse(t *testing.T) {
+	snap := tr08Snap()
+
+	// test_03 shape: given the A/B sender, both jxsv receivers admit
+	// its profile/level; the raw receiver never does.
+	q := "select the Receivers compatible with:\n\ns0/rush (Mock Sender 0, b0b00000-0000-4000-8000-00000000ab01)\n"
+	got := tr08CompatibleFromProse(snap, q)
+	if len(got) != 2 || !got["rcv-ab"] || !got["rcv-d"] {
+		t.Errorf("A/B sender receivers = %v, want rcv-ab + rcv-d", got)
+	}
+	// Given the C sender, only the D receiver's sets admit it.
+	q = "compatible with (x, b0b00000-0000-4000-8000-00000000c001)"
+	got = tr08CompatibleFromProse(snap, q)
+	if len(got) != 1 || !got["rcv-d"] {
+		t.Errorf("C sender receivers = %v, want exactly rcv-d", got)
+	}
+	// test_04 shape: given the D receiver, both jxsv senders match,
+	// the raw sender (no profile/level) never.
+	q = "select the Senders compatible with (x, rcv-d)" // not a UUID — resolve failure first
+	if got = tr08CompatibleFromProse(snap, q); got != nil {
+		t.Errorf("non-UUID prose must resolve to nil, got %v", got)
+	}
+	snap.Receivers[1].ID = "d0d00000-0000-4000-8000-000000000d01"
+	q = "select the Senders compatible with (x, d0d00000-0000-4000-8000-000000000d01)"
+	got = tr08CompatibleFromProse(snap, q)
+	if len(got) != 2 || !got["b0b00000-0000-4000-8000-00000000ab01"] || !got["b0b00000-0000-4000-8000-00000000c001"] {
+		t.Errorf("D receiver senders = %v, want the two jxsv senders", got)
+	}
+}
+
 // TestConstraintSatisfied covers the three BCP-004-01 keywords over the
 // value shapes the MXL profiles use.
 func TestConstraintSatisfied(t *testing.T) {

--- a/internal/amwa/facade/decide_helpers_test.go
+++ b/internal/amwa/facade/decide_helpers_test.go
@@ -8,6 +8,10 @@ package facade
 // one BCP-004-01 constraint set satisfied by the Flow's fields.
 
 import (
+	"context"
+	"fmt"
+	stdhttp "net/http"
+	"net/http/httptest"
 	"testing"
 
 	"dhs/internal/amwa/codec/is04"
@@ -107,89 +111,194 @@ func TestMXLCompatibility(t *testing.T) {
 	}
 }
 
-// tr08Snap models the BCP-006-01-02 mock plant: JPEG XS senders whose
-// flows carry the TR-08 discriminators (profile ⇔ capability set,
-// level ⇔ conformance level — the tool registers them via
-// flow_params), a video/raw sender, and receivers whose BCP-004-01
-// constraint sets enumerate exactly their compatible interop points'
-// profile/level pairs (how ControllerTest builds mock caps).
-func tr08Snap() *consumer.CatalogueSnapshot {
-	profLevel := func(profile, level string) map[string]any {
-		return map[string]any{
-			"urn:x-nmos:cap:meta:label":         profile + " " + level,
-			"urn:x-nmos:cap:format:media_type":  map[string]any{"enum": []any{"video/jxsv"}},
-			"urn:x-nmos:cap:format:profile":     map[string]any{"enum": []any{profile}},
-			"urn:x-nmos:cap:format:level":       map[string]any{"enum": []any{level}},
-			"urn:x-nmos:cap:format:frame_width": map[string]any{"enum": []any{float64(1920)}},
-		}
+// ---- TR-08 (BCP-006-01-02 test_03/test_04) fixtures --------------------
+//
+// Modeled verbatim on the tool's fixture book, INCLUDING its trap: the
+// Set A/B UHD1 base point (IP 7b) and the Set C UHD1 base point (IP 3c)
+// are byte-identical in every REGISTERED flow field — same 3840x2160,
+// 60000/1001, profile High444.12, level 4k-2, BT2100, PQ, even the same
+// derived bit rate — and differ ONLY in the SDP's sampling
+// (YCbCr-4:2:2 vs 4:4:4). That twin is what the second fleet run's
+// over-selection receipts scored, and why the matcher reads the SDP.
+
+// jxsvSDP renders an SDP the way the tool's video-jxsv.sdp template
+// does.
+func jxsvSDP(width, height int, framerate, sampling, colorimetry, tcs, profile, level string, bitrate int) string {
+	return fmt.Sprintf(`v=0
+o=- 1 1 IN IP4 10.0.0.1
+s=Test
+t=0 0
+m=video 5004 RTP/AVP 97
+c=IN IP4 239.1.1.1/32
+b=AS:%d
+a=rtpmap:97 jxsv/90000
+a=fmtp:97 packetmode=0; profile=%s; level=%s; sublevel=Sublev3bpp; depth=10; width=%d; height=%d; exactframerate=%s; sampling=%s; colorimetry=%s; TCS=%s; SSN=ST2110-22:2022; TP=2110TPW
+a=mediaclk:direct=0
+`, bitrate, profile, level, width, height, framerate, sampling, colorimetry, tcs)
+}
+
+// tr08ConstraintSet builds one per-interop-point constraint set the
+// way ControllerTest._generate_constraint_set does.
+func tr08ConstraintSet(sampling string, w, h float64, grNum, grDen float64, colorimetry, tcs, profile, level string, minBR, maxBR float64) map[string]any {
+	return map[string]any{
+		"urn:x-nmos:cap:format:color_sampling":              map[string]any{"enum": []any{sampling}},
+		"urn:x-nmos:cap:format:frame_width":                 map[string]any{"enum": []any{w}},
+		"urn:x-nmos:cap:format:frame_height":                map[string]any{"enum": []any{h}},
+		"urn:x-nmos:cap:format:grain_rate":                  map[string]any{"enum": []any{map[string]any{"numerator": grNum, "denominator": grDen}}},
+		"urn:x-nmos:cap:format:interlace_mode":              map[string]any{"enum": []any{"progressive"}},
+		"urn:x-nmos:cap:format:component_depth":             map[string]any{"enum": []any{float64(10)}},
+		"urn:x-nmos:cap:format:colorspace":                  map[string]any{"enum": []any{colorimetry}},
+		"urn:x-nmos:cap:format:transfer_characteristic":     map[string]any{"enum": []any{tcs}},
+		"urn:x-nmos:cap:format:profile":                     map[string]any{"enum": []any{profile}},
+		"urn:x-nmos:cap:format:level":                       map[string]any{"enum": []any{level}},
+		"urn:x-nmos:cap:format:sublevel":                    map[string]any{"enum": []any{"Sublev3bpp", "Sublev4bpp"}},
+		"urn:x-nmos:cap:transport:packet_transmission_mode": map[string]any{"enum": []any{"codestream"}},
+		"urn:x-nmos:cap:format:bit_rate":                    map[string]any{"minimum": minBR, "maximum": maxBR},
+		"urn:x-nmos:cap:transport:st2110_21_sender_type":    map[string]any{"enum": []any{"2110TN", "2110TNL", "2110TPW"}},
 	}
+}
+
+const (
+	tr08S30ID = "4db45e3b-0000-4000-8000-000000000030" // s30/collapse — Set C, UHD2, IP 4c
+	tr08R1ID  = "89bab259-0000-4000-8000-000000000001" // r1/tb2 — Set A/B, UHD1
+)
+
+// tr08Snap builds the snapshot + SDP server. The registered fields are
+// deliberately IDENTICAL for the UHD1 A/B and C senders — only their
+// SDPs differ.
+func tr08Snap(t *testing.T) *consumer.CatalogueSnapshot {
+	t.Helper()
+	sdps := map[string]string{
+		// Set A/B UHD1, IP 7b (PQ) — sampling 4:2:2.
+		"/ab-uhd1.sdp": jxsvSDP(3840, 2160, "60000/1001", "YCbCr-4:2:2", "BT2100", "PQ", "High444.12", "4k-2", 995000),
+		// Set C UHD1, IP 3c (PQ) — the registered-twin: ONLY sampling differs.
+		"/c-uhd1.sdp": jxsvSDP(3840, 2160, "60000/1001", "YCbCr-4:4:4", "BT2100", "PQ", "High444.12", "4k-2", 995000),
+		// Set A/B UHD2, IP 9c (HLG) — sampling 4:2:2.
+		"/ab-uhd2.sdp": jxsvSDP(7680, 4320, "60000/1001", "YCbCr-4:2:2", "BT2100", "HLG", "High444.12", "8k-2", 3977000),
+		// Set C UHD2, IP 4c (HLG) — the receipts' s30/collapse.
+		"/s30.sdp": jxsvSDP(7680, 4320, "60000/1001", "YCbCr-4:4:4", "BT2100", "HLG", "High444.12", "8k-2", 3981000),
+	}
+	srv := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		sdp, ok := sdps[r.URL.Path]
+		if !ok {
+			w.WriteHeader(404)
+			return
+		}
+		w.Header().Set("Content-Type", "application/sdp")
+		_, _ = w.Write([]byte(sdp))
+	}))
+	t.Cleanup(srv.Close)
+	href := func(p string) *string { u := srv.URL + p; return &u }
+
+	// Per-point constraint sets (the tool builds each mock receiver's
+	// caps from exactly its compatible interop points).
+	set7b := tr08ConstraintSet("YCbCr-4:2:2", 3840, 2160, 60000, 1001, "BT2100", "PQ", "High444.12", "4k-2", 746000, 1989000)
+	set3c := tr08ConstraintSet("YCbCr-4:4:4", 3840, 2160, 60000, 1001, "BT2100", "PQ", "High444.12", "4k-2", 746000, 1991000)
+	set9c := tr08ConstraintSet("YCbCr-4:2:2", 7680, 4320, 60000, 1001, "BT2100", "HLG", "High444.12", "8k-2", 2983000, 7955000)
+	set4c := tr08ConstraintSet("YCbCr-4:4:4", 7680, 4320, 60000, 1001, "BT2100", "HLG", "High444.12", "8k-2", 2986000, 7963000)
+
 	return &consumer.CatalogueSnapshot{
-		Flows: []is04.Flow{
-			{ResourceCore: is04.ResourceCore{ID: "flow-ab"}, MediaType: "video/jxsv",
-				Profile: "Main422.10", Level: "2k-1", FrameWidth: 1920},
-			{ResourceCore: is04.ResourceCore{ID: "flow-c"}, MediaType: "video/jxsv",
-				Profile: "High444.12", Level: "2k-1", FrameWidth: 1920},
-			{ResourceCore: is04.ResourceCore{ID: "flow-raw"}, MediaType: "video/raw",
-				FrameWidth: 1920},
-		},
 		Senders: []is04.Sender{
-			{ResourceCore: is04.ResourceCore{ID: "b0b00000-0000-4000-8000-00000000ab01"},
-				FlowID: strPtr("flow-ab"), Transport: "urn:x-nmos:transport:rtp.mcast"},
-			{ResourceCore: is04.ResourceCore{ID: "b0b00000-0000-4000-8000-00000000c001"},
-				FlowID: strPtr("flow-c"), Transport: "urn:x-nmos:transport:rtp.mcast"},
-			{ResourceCore: is04.ResourceCore{ID: "b0b00000-0000-4000-8000-0000000faw01"},
-				FlowID: strPtr("flow-raw"), Transport: "urn:x-nmos:transport:rtp.mcast"},
+			{ResourceCore: is04.ResourceCore{ID: "ab0d0000-0000-4000-8000-00000000ud01"},
+				Transport: "urn:x-nmos:transport:rtp.mcast", ManifestHref: href("/ab-uhd1.sdp")},
+			{ResourceCore: is04.ResourceCore{ID: "c0000000-0000-4000-8000-00000000ud01"},
+				Transport: "urn:x-nmos:transport:rtp.mcast", ManifestHref: href("/c-uhd1.sdp")},
+			{ResourceCore: is04.ResourceCore{ID: "ab0d0000-0000-4000-8000-00000000ud02"},
+				Transport: "urn:x-nmos:transport:rtp.mcast", ManifestHref: href("/ab-uhd2.sdp")},
+			{ResourceCore: is04.ResourceCore{ID: tr08S30ID},
+				Transport: "urn:x-nmos:transport:rtp.mcast", ManifestHref: href("/s30.sdp")},
+			// A sender advertising no manifest can never be judged compatible.
+			{ResourceCore: is04.ResourceCore{ID: "0000dead-0000-4000-8000-000000000000"},
+				Transport: "urn:x-nmos:transport:rtp.mcast"},
 		},
 		Receivers: []is04.Receiver{
-			// Set A/B receiver: compatible with A/B senders only.
-			{ResourceCore: is04.ResourceCore{ID: "rcv-ab"}, Transport: "urn:x-nmos:transport:rtp",
+			// r1/tb2 — Set A/B, UHD1: A/B-UHD1 point sets only.
+			{ResourceCore: is04.ResourceCore{ID: tr08R1ID}, Transport: "urn:x-nmos:transport:rtp",
 				Caps: is04.ReceiverCaps{MediaTypes: []string{"video/jxsv"}, Version: "0:1",
-					ConstraintSets: []map[string]any{profLevel("Main422.10", "2k-1")}}},
-			// Set D receiver: compatible with A/B AND C senders (its
-			// constraint sets enumerate both points).
-			{ResourceCore: is04.ResourceCore{ID: "rcv-d"}, Transport: "urn:x-nmos:transport:rtp",
+					ConstraintSets: []map[string]any{set7b}}},
+			// Set C, UHD2 receiver: A/B-UHD2 + C-UHD2 point sets.
+			{ResourceCore: is04.ResourceCore{ID: "c0000000-0000-4000-8000-00000000ud02"}, Transport: "urn:x-nmos:transport:rtp",
 				Caps: is04.ReceiverCaps{MediaTypes: []string{"video/jxsv"}, Version: "0:1",
-					ConstraintSets: []map[string]any{
-						profLevel("Main422.10", "2k-1"), profLevel("High444.12", "2k-1")}}},
-			// Raw receiver: no constraint sets, no JPEG XS capability.
-			{ResourceCore: is04.ResourceCore{ID: "rcv-raw"}, Transport: "urn:x-nmos:transport:rtp",
+					ConstraintSets: []map[string]any{set9c, set4c}}},
+			// Set A/B, UHD2 receiver: A/B-UHD2 point sets only.
+			{ResourceCore: is04.ResourceCore{ID: "ab0d0000-0000-4000-8000-00000000rc02"}, Transport: "urn:x-nmos:transport:rtp",
+				Caps: is04.ReceiverCaps{MediaTypes: []string{"video/jxsv"}, Version: "0:1",
+					ConstraintSets: []map[string]any{set9c}}},
+			// Set C, UHD1 receiver: A/B-UHD1 + C-UHD1 point sets.
+			{ResourceCore: is04.ResourceCore{ID: "c0000000-0000-4000-8000-00000000rc01"}, Transport: "urn:x-nmos:transport:rtp",
+				Caps: is04.ReceiverCaps{MediaTypes: []string{"video/jxsv"}, Version: "0:1",
+					ConstraintSets: []map[string]any{set7b, set3c}}},
+			// Raw receiver: no coded-format capability declared.
+			{ResourceCore: is04.ResourceCore{ID: "0000fa00-0000-4000-8000-000000000000"}, Transport: "urn:x-nmos:transport:rtp",
 				Caps: is04.ReceiverCaps{MediaTypes: []string{"video/raw"}}},
 		},
 	}
 }
 
-// TestTR08CompatibleFromProse: the counterpart UUID embedded in the
-// question prose (the tool's display_answer format) drives both
-// directions — a sender selects its compatible receivers (test_03), a
-// receiver its compatible senders (test_04); no resolvable UUID means
-// nil (the caller's "unable to identify" branch).
+// TestTR08CompatibleFromProse pins the two receipt shapes exactly:
+//
+//	test_03 — "… compatible for Sender s30/collapse …: Capability Set
+//	C, Conformance Level UHD2, IP 4c": expected receivers are the C
+//	and D families at UHD2 (here: the C-UHD2 receiver), and the A/B
+//	UHD2 receiver must be rejected — its only discriminator against
+//	s30 is the SDP's sampling.
+//	test_04 — "… compatible for Receiver r1/tb2 …: Capability Set
+//	A/B, Conformance Level UHD1": expected senders are A/B-UHD1 only;
+//	the C-UHD1 sender is the registered-twin and must be rejected on
+//	its SDP sampling alone.
 func TestTR08CompatibleFromProse(t *testing.T) {
-	snap := tr08Snap()
+	snap := tr08Snap(t)
+	ctx := context.Background()
 
-	// test_03 shape: given the A/B sender, both jxsv receivers admit
-	// its profile/level; the raw receiver never does.
-	q := "select the Receivers compatible with:\n\ns0/rush (Mock Sender 0, b0b00000-0000-4000-8000-00000000ab01)\n"
-	got := tr08CompatibleFromProse(snap, q)
-	if len(got) != 2 || !got["rcv-ab"] || !got["rcv-d"] {
-		t.Errorf("A/B sender receivers = %v, want rcv-ab + rcv-d", got)
+	// test_03 direction (sender named in prose).
+	q := "select the Receivers that are compatible with the following Sender:\n\ns30/collapse (Mock Sender 30, " + tr08S30ID + ")\n"
+	got := tr08CompatibleFromProse(ctx, snap, q)
+	if len(got) != 1 || !got["c0000000-0000-4000-8000-00000000ud02"] {
+		t.Errorf("s30 receivers = %v, want exactly the C-UHD2 receiver (A/B-UHD2 must fall to sampling)", got)
 	}
-	// Given the C sender, only the D receiver's sets admit it.
-	q = "compatible with (x, b0b00000-0000-4000-8000-00000000c001)"
-	got = tr08CompatibleFromProse(snap, q)
-	if len(got) != 1 || !got["rcv-d"] {
-		t.Errorf("C sender receivers = %v, want exactly rcv-d", got)
+
+	// test_04 direction (receiver named in prose).
+	q = "select the Senders that are compatible with the following Receiver:\n\nr1/tb2 (Mock Receiver 1, " + tr08R1ID + ")\n"
+	got = tr08CompatibleFromProse(ctx, snap, q)
+	if len(got) != 1 || !got["ab0d0000-0000-4000-8000-00000000ud01"] {
+		t.Errorf("r1 senders = %v, want exactly the A/B-UHD1 sender (the C-UHD1 registered-twin must fall to sampling)", got)
 	}
-	// test_04 shape: given the D receiver, both jxsv senders match,
-	// the raw sender (no profile/level) never.
-	q = "select the Senders compatible with (x, rcv-d)" // not a UUID — resolve failure first
-	if got = tr08CompatibleFromProse(snap, q); got != nil {
+
+	// No resolvable UUID → nil (the caller's "unable to identify").
+	if got = tr08CompatibleFromProse(ctx, snap, "compatible with (x, not-a-uuid)"); got != nil {
 		t.Errorf("non-UUID prose must resolve to nil, got %v", got)
 	}
-	snap.Receivers[1].ID = "d0d00000-0000-4000-8000-000000000d01"
-	q = "select the Senders compatible with (x, d0d00000-0000-4000-8000-000000000d01)"
-	got = tr08CompatibleFromProse(snap, q)
-	if len(got) != 2 || !got["b0b00000-0000-4000-8000-00000000ab01"] || !got["b0b00000-0000-4000-8000-00000000c001"] {
-		t.Errorf("D receiver senders = %v, want the two jxsv senders", got)
+	// A named sender whose SDP cannot be read → nil.
+	if got = tr08CompatibleFromProse(ctx, snap, "compatible with (x, 0000dead-0000-4000-8000-000000000000)"); got != nil {
+		t.Errorf("manifest-less sender must resolve to nil, got %v", got)
+	}
+}
+
+// TestSDPCapParams pins the fmtp → BCP-004-01 parameter mapping on the
+// tool's own template shape.
+func TestSDPCapParams(t *testing.T) {
+	params := sdpCapParams(jxsvSDP(7680, 4320, "60000/1001", "YCbCr-4:4:4", "BT2100", "HLG", "High444.12", "8k-2", 3981000))
+	want := map[string]any{
+		"urn:x-nmos:cap:format:media_type":                  "video/jxsv",
+		"urn:x-nmos:cap:format:profile":                     "High444.12",
+		"urn:x-nmos:cap:format:level":                       "8k-2",
+		"urn:x-nmos:cap:format:sublevel":                    "Sublev3bpp",
+		"urn:x-nmos:cap:format:color_sampling":              "YCbCr-4:4:4",
+		"urn:x-nmos:cap:format:colorspace":                  "BT2100",
+		"urn:x-nmos:cap:format:transfer_characteristic":     "HLG",
+		"urn:x-nmos:cap:transport:st2110_21_sender_type":    "2110TPW",
+		"urn:x-nmos:cap:transport:packet_transmission_mode": "codestream",
+		"urn:x-nmos:cap:format:component_depth":             float64(10),
+		"urn:x-nmos:cap:format:frame_width":                 float64(7680),
+		"urn:x-nmos:cap:format:frame_height":                float64(4320),
+		"urn:x-nmos:cap:format:interlace_mode":              "progressive",
+		"urn:x-nmos:cap:format:bit_rate":                    float64(3981000),
+		"urn:x-nmos:cap:format:grain_rate":                  is04.GrainRate{Numerator: 60000, Denominator: 1001},
+	}
+	for k, v := range want {
+		if params[k] != v {
+			t.Errorf("params[%s] = %v, want %v", k, params[k], v)
+		}
 	}
 }
 

--- a/internal/amwa/session/query/client.go
+++ b/internal/amwa/session/query/client.go
@@ -194,46 +194,88 @@ func (c *Client) fetchListRaw(ctx context.Context, plural string, filter map[str
 		}
 		u += "?" + q.Encode()
 	}
-	// Whole-collection walk direction, per the AMWA-pinned IS-04
-	// §6.1.6 orientation: collections are newest-first and the Link
-	// cursors move through TIME — rel="next" is NEWER data, rel="prev"
-	// OLDER. The unanchored first response is the HEAD page, so the
-	// rest of the collection lies behind rel="prev"; following next
-	// from the head asks for the future and legally returns nothing —
-	// which is exactly how a live walk of a 211-sender plant returned
-	// 100 (2026-08-29). Some servers instead treat next as an
-	// ascending index cursor and emit no prev; the first page picks
-	// the chain: prev when offered, next otherwise. Either chain ends
-	// at an empty page, a missing link, or a URL already visited.
+	// Whole-collection walk, BOTH directions. IS-04 §6.1.6 pins the
+	// cursor semantics (rel="next" = newer data, rel="prev" = older)
+	// but NOT which window an unanchored GET returns: our registry
+	// serves the newest page (the rest lies behind prev), while the
+	// AMWA tool's own mock registry serves the OLDEST page with both
+	// links present (the rest lies ahead of next). IS-04-04 test_03
+	// drops the mock's page size to 2 exactly to catch controllers
+	// that guess one direction — and this walker's earlier
+	// prev-when-offered guess walked into the void there and
+	// truncated the catalogue at one page (first #954 fleet run). So:
+	// take the anchor page, exhaust the prev chain, then exhaust the
+	// next chain from the same anchor, deduplicating by resource id —
+	// whichever direction is the empty one costs one fetch and
+	// nothing else. Every chain ends at an empty page, a missing
+	// link, or a URL already visited.
 	var out []json.RawMessage
-	seen := map[string]bool{}
-	followPrev := false
-	// 10k pages caps a runaway server that links to itself forever; a
-	// real catalogue at limit=2 never gets near it.
-	for i := 0; u != "" && i < 10000; i++ {
-		if seen[u] {
-			break // servers that Link back to an earlier page
+	seenURL := map[string]bool{u: true}
+	seenID := map[string]bool{}
+	appendPage := func(page []json.RawMessage) {
+		for _, r := range page {
+			if id := rawResourceID(r); id != "" {
+				if seenID[id] {
+					continue
+				}
+				seenID[id] = true
+			}
+			out = append(out, r)
 		}
-		seen[u] = true
-		var page []json.RawMessage
-		next, prev, err := c.HTTP.GetJSONPageLinks(ctx, u, &page)
-		if err != nil {
-			return nil, fmt.Errorf("nmos/query: list %s: %w", plural, err)
-		}
-		out = append(out, page...)
-		if len(page) == 0 {
-			break
-		}
-		if i == 0 {
-			followPrev = prev != ""
-		}
-		if followPrev {
-			u = prev
-		} else {
-			u = next
+	}
+	var first []json.RawMessage
+	firstNext, firstPrev, err := c.HTTP.GetJSONPageLinks(ctx, u, &first)
+	if err != nil {
+		return nil, fmt.Errorf("nmos/query: list %s: %w", plural, err)
+	}
+	appendPage(first)
+	if len(first) == 0 {
+		return out, nil
+	}
+	chains := []struct {
+		start   string
+		usePrev bool
+	}{
+		{start: firstPrev, usePrev: true},
+		{start: firstNext, usePrev: false},
+	}
+	for _, chain := range chains {
+		u := chain.start
+		// 10k pages caps a runaway server that links to itself
+		// forever; a real catalogue at limit=2 never gets near it.
+		for i := 0; u != "" && i < 10000; i++ {
+			if seenURL[u] {
+				break // servers that Link back to an earlier page
+			}
+			seenURL[u] = true
+			var page []json.RawMessage
+			next, prev, err := c.HTTP.GetJSONPageLinks(ctx, u, &page)
+			if err != nil {
+				return nil, fmt.Errorf("nmos/query: list %s: %w", plural, err)
+			}
+			appendPage(page)
+			if len(page) == 0 {
+				break
+			}
+			if chain.usePrev {
+				u = prev
+			} else {
+				u = next
+			}
 		}
 	}
 	return out, nil
+}
+
+// rawResourceID pulls the IS-04 id out of one raw listing element —
+// the dedupe key for the two-direction page walk (windows should
+// never overlap, but a server bug must not double resources).
+func rawResourceID(r json.RawMessage) string {
+	var v struct {
+		ID string `json:"id"`
+	}
+	_ = json.Unmarshal(r, &v)
+	return v.ID
 }
 
 // decodeList runs each raw element through the per-resource codec

--- a/internal/amwa/session/query/pagination_test.go
+++ b/internal/amwa/session/query/pagination_test.go
@@ -154,6 +154,78 @@ func TestFetchListSinglePageRegistry(t *testing.T) {
 	}
 }
 
+// TestFetchListToolMockRegistry models the AMWA testing tool's OWN
+// mock registry (nmos-testing mocks/Registry.py): collections sorted
+// version-ASCENDING, an unanchored GET returns the OLDEST window, and
+// BOTH rel="prev" and rel="next" are always present — prev pointing
+// before the window (empty from the anchor), next at the rest of the
+// collection. The first #954 fleet run proved that guessing
+// prev-when-offered walks into the void here and truncates the
+// catalogue at one page (IS-04-04 test_03 drops the page size to 2
+// exactly to catch that); the two-direction walk must yield every
+// item exactly once.
+func TestFetchListToolMockRegistry(t *testing.T) {
+	const total, pageSize = 5, 2
+	var srv *httptest.Server
+	srv = httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		// Window: [since, since+pageSize) ascending; paging.until
+		// without since anchors a window ENDING at until (exclusive).
+		var start, end int
+		switch {
+		case r.URL.Query().Get("paging.since") != "":
+			start, _ = strconv.Atoi(r.URL.Query().Get("paging.since"))
+			end = start + pageSize
+		case r.URL.Query().Get("paging.until") != "":
+			end, _ = strconv.Atoi(r.URL.Query().Get("paging.until"))
+			start = end - pageSize
+		default:
+			start, end = 0, pageSize
+		}
+		if start < 0 {
+			start = 0
+		}
+		if end > total {
+			end = total
+		}
+		var page []map[string]any
+		for i := start; i < end; i++ { // ascending body, like the mock
+			page = append(page, map[string]any{"id": fmt.Sprintf("00000000-0000-4000-8000-%012d", i)})
+		}
+		// Both links, always — the mock's shape.
+		w.Header().Set("Link", fmt.Sprintf(
+			`<%s/x-nmos/query/v1.3/senders/?paging.since=%d&paging.limit=%d>; rel="next",`+
+				`<%s/x-nmos/query/v1.3/senders/?paging.until=%d&paging.limit=%d>; rel="prev"`,
+			srv.URL, end, pageSize, srv.URL, start, pageSize))
+		w.Header().Set("X-Paging-Limit", strconv.Itoa(pageSize))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(page)
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(srv.URL, v13.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := c.fetchListRaw(context.Background(), "senders", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(raw) != total {
+		t.Fatalf("got %d senders, want %d — the walk must exhaust the NEXT chain when the anchor is the oldest page", len(raw), total)
+	}
+	seen := map[string]bool{}
+	for _, rb := range raw {
+		var v struct {
+			ID string `json:"id"`
+		}
+		_ = json.Unmarshal(rb, &v)
+		if seen[v.ID] {
+			t.Fatalf("duplicate %s in walk", v.ID)
+		}
+		seen[v.ID] = true
+	}
+}
+
 // TestFetchListStopsOnLinkLoop: a server whose chain link points back
 // at an earlier page must not hang the client.
 func TestFetchListStopsOnLinkLoop(t *testing.T) {


### PR DESCRIPTION
Closes #954.

Enables the last unvalidated role: the controller scope, scored by the AMWA tool's four testing-facade suites against a transient `dhs consumer nmos facade` (new `window_facade.yml`, container on the tooling host, pointed at the tool's deterministic mock registry).

## Fleet receipts (dhs-tools, confirm run at committed baselines)

```
IS-04-04         OK   pass=4/4 fail=0 cnt=0/0 warn=0
IS-05-03         OK   pass=4/4 fail=0 cnt=0/0 warn=0
BCP-006-01-02    OK   pass=5/5 fail=0 cnt=0/0 warn=0
BCP-007-03-02    OK   pass=4/4 fail=0 cnt=0/0 warn=0
4 suites at or above baseline, 0 failures
```

With this, every implementable tool suite in the catalog is machine-validated across all four roles (node, registry, controller, and the mirror's Query serve).

## What it took (three root-causes, no rerun-and-hope)

1. **Stale-binary trap (run 1).** `window_facade.yml` stages the *deployed* plant binary; the first run scored code that predated the branch. Operational rule now documented in the window: **converge before validate**.
2. **Pagination dialect (real bug).** The tool's mock registry sorts version-*ascending* and an unanchored GET returns the *oldest* window with both `prev` and `next` links always present. Our prev-when-offered heuristic (correct against our newest-first registry) walked `prev` into the void and read one page. `fetchListRaw` now exhausts the prev chain then the next chain from the same anchor, deduplicating by id — pinned by `TestFetchListToolMockRegistry` plus the five prior dialect tests unchanged.
3. **TR-08 compatibility (BCP-006-01-02 test_03/04).** The counterpart UUID is machine-extractable from the question's `display_answer` prose. But the fixture book registers Set-A/B and Set-C sender twins with byte-identical registry flows — the discriminators (sampling, depth) exist only in each sender's rendered SDP. `decide.go` now fetches the candidate's SDP via `manifest_href`, parses it to BCP-004-01 cap-URNs, and requires a receiver constraint set that admits every SDP-derived param (SDP-absent params skipped; unreadable SDP never compatible). Unit tests pin the byte-identical-twin trap.

## Spec fix that fell out

`consumer.Connect` no longer fetches `/transportfile` when either leg is MXL — BCP-007-03 says an MXL sender MUST NOT provide one (`connect_mxl_test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
