### PR TITLE
feat(amwa+ansible): phase 2 - BCP-008 health engine, fault drills, WS ancestry (#956)

### DIFF
--- a/ansible/playbooks/amwa-verify-manual.yml
+++ b/ansible/playbooks/amwa-verify-manual.yml
@@ -20,10 +20,8 @@
 #                         |   per-topic id-set snapshot (stronger:
 #                         |   exact set equality across 6 topics).
 #   IS-04-02 test_25_1    | dhs equivalent HERE (REST ancestry — the
-#                         |   engine the WS face would use; the WS
-#                         |   subscription path currently STRIPS
-#                         |   query.ancestry_* params, a reported
-#                         |   product gap, phase 2).
+#                         |   same set logic the WS face applies
+#                         |   since #956).
 #   IS-08-01 test_09/10   | dhs equivalent HERE (authored, non-
 #                         |   placeholder properties — "human-readable"
 #                         |   approximated by "equal to the values a
@@ -44,15 +42,25 @@
 #                         |   a product gap — /global was recorded,
 #                         |   never applied; the registration client
 #                         |   now reads the interval live.)
-#   PHASE 2               | WS ancestry: the Query API's WebSocket
-#                         |   subscription path strips every query.*
-#                         |   param except query.rql
-#                         |   (subscriptions.go:242-250), so ancestry
-#                         |   params on a subscription silently select
-#                         |   nothing — implement-or-501 is the
-#                         |   phase-2 product decision.
-#   BCP-008 rows,         | OUT OF SCOPE phase 1 (per #950).
-#   BCP-007-03 test_15    |
+#   (WS ancestry)         | PRODUCT-FIXED phase 2 (#956): the WS
+#                         |   subscription path now validates and
+#                         |   applies query.ancestry_* like REST;
+#                         |   pinned by Go unit tests
+#                         |   (subscriptions_ancestry_test.go).
+#   BCP-008 test_04/11,   | dhs equivalents HERE (phase 2, #956): a
+#   008-01 test_15/16,    |   transient node window drives the
+#   008-02 test_15        |   DhsFaultControl worker over IS-14 REST —
+#                         |   injected faults, delayed recovery, sync
+#                         |   source change, packet counters + reset.
+#                         |   (test_03/05/06/07 are TOOL-SCORED now:
+#                         |   the health engine degrades honestly
+#                         |   after statusReportingDelay.)
+#   BCP-007-03 test_15    | dhs equivalent HERE (phase 2): MXL
+#                         |   read/write starts/stops on activation,
+#                         |   observed as the MXL legs' monitors
+#                         |   tracking IS-05 master_enable — the only
+#                         |   observable "read/write" a reference node
+#                         |   has (tool: unconditional MANUAL).
 #
 #   ansible-playbook -i ansible/inventory/hosts.ini ansible/playbooks/amwa-verify-manual.yml
 
@@ -82,14 +90,28 @@
     vm_cut_port: "{{ dhs_amwa_validate_cut_port }}"
     vm_sys_port: 10641
     vm_is05_receiver: "{{ vm_is08_input }}"
+    # The BCP-008 / BCP-007-03 drill window (phase 2, #956): its own
+    # transient direct-mode node so activations never touch the
+    # registered resident fleet. Monitor roles follow fixture order.
+    vm_b8_port: 10643
+    vm_b8_node: "http://{{ dhs_amwa_validate_plant_host }}:{{ vm_b8_port }}"
+    vm_b8_cfg: "{{ vm_b8_node }}/x-nmos/configuration/v1.0/rolePaths"
+    vm_b8_conn: "{{ vm_b8_node }}/x-nmos/connection/v1.2/single"
+    vm_b8_rx: "{{ vm_is08_input }}"                          # dhs-test-receiver-audio
+    vm_b8_rm: "root.ReceiverMonitor-03"
+    vm_b8_tx: "2c47bf5e-1b2c-4abc-9def-deadbeef0005"         # dhs-test-sender-rtp
+    vm_b8_sm: "root.SenderMonitor-03"
+    vm_mxl_rx: "2c47bf5e-1b2c-4abc-9def-deadbeef0303"        # dhs-test-receiver-mxl
+    vm_mxl_rm: "root.ReceiverMonitor-02"
+    vm_mxl_tx: "2c47bf5e-1b2c-4abc-9def-deadbeef0302"        # dhs-test-sender-mxl
+    vm_mxl_sm: "root.SenderMonitor-02"
   tasks:
     # ---- IS-04-02 test_25_1: "Query API WebSockets implement ancestry
-    # queries". The ancestry ENGINE (ancestry.go — the one the WS face
-    # would consult) is driven over the REST Query API in both
-    # directions against the authored family. The WS-side param
-    # plumbing is a reported phase-2 product gap (subscriptions.go
-    # strips query.* except query.rql), so this check deliberately
-    # claims the engine, not the socket.
+    # queries". The ancestry ENGINE (ancestry.go — the same set logic
+    # the WS face consults since #956) is driven over the REST Query
+    # API in both directions against the authored family; the WS-side
+    # param plumbing and grain clipping are pinned by Go unit tests
+    # (subscriptions_ancestry_test.go).
     - name: "IS-04-02 test_25_1 — ancestry children: block-in's descendants"
       ansible.builtin.uri:
         url: "{{ vm_registry }}/sources?query.ancestry_id={{ vm_ancestry_parent }}&query.ancestry_type=children"
@@ -294,6 +316,334 @@
           delegate_to: "{{ groups['plant'][0] }}"
           failed_when: false
 
+    # ---- BCP-008 fault drills + BCP-007-03 MXL activation (phase 2,
+    # #956). The tool's unconditional-Manual rows say "check by
+    # manually forcing an error condition"; the DhsFaultControl worker
+    # is that force, over IS-14's rolePaths methods PATCH, and every
+    # injected transition runs the same health engine the tool-scored
+    # rows exercise. statusReportingDelay is dropped to 1 s (3p3 is
+    # writable by class definition) so the drills stay fast.
+    - name: "BCP-008 / BCP-007-03 — transient drill window"
+      block:
+        - name: "Start the transient drill node (direct mode)"
+          ansible.builtin.command: >-
+            systemd-run --unit dhs-nmos-verify-b8 --collect
+            {{ dhs_amwa_validate_plant_bin }} producer nmos serve
+            --bind 0.0.0.0:{{ vm_b8_port }}
+            --no-registry --no-mdns
+            --api-ver v1.3
+            --config {{ dhs_amwa_validate_plant_config }}
+          delegate_to: "{{ groups['plant'][0] }}"
+          changed_when: true
+
+        - name: "Arm the drill-window safety-stop timer"
+          ansible.builtin.command: >-
+            systemd-run --unit dhs-nmos-verify-b8-stop --collect
+            --on-active={{ dhs_amwa_validate_window_safety_sec }}
+            systemctl stop dhs-nmos-verify-b8
+          delegate_to: "{{ groups['plant'][0] }}"
+          changed_when: true
+
+        - name: "Wait for the drill node"
+          ansible.builtin.uri:
+            url: "{{ vm_b8_node }}/x-nmos/node/v1.3/self"
+          register: vm_b8_up
+          retries: 15
+          delay: 2
+          until: vm_b8_up.status == 200
+
+        - name: "Shorten statusReportingDelay to 1 s on the drill monitors"
+          ansible.builtin.uri:
+            url: "{{ vm_b8_cfg }}/{{ item }}/properties/3p3/value"
+            method: PUT
+            body_format: json
+            body: { value: 1 }
+            status_code: [200]
+          loop: ["{{ vm_b8_rm }}", "{{ vm_b8_sm }}"]
+
+        - name: "Activate the drill receiver over IS-05"
+          ansible.builtin.uri:
+            url: "{{ vm_b8_conn }}/receivers/{{ vm_b8_rx }}/staged"
+            method: PATCH
+            body_format: json
+            body: { master_enable: true, activation: { mode: activate_immediate } }
+            status_code: [200]
+
+        - name: "BCP-008-01 test_02-equiv — monitor Healthy on activation"
+          ansible.builtin.uri:
+            url: "{{ vm_b8_cfg }}/{{ vm_b8_rm }}/properties/3p1/value"
+            return_content: true
+          register: vm_b8_overall
+          retries: 10
+          delay: 1
+          until: vm_b8_overall.json.value | int == 1
+
+        - name: "BCP-008-01 test_03-equiv — honest no-stream degradation after the delay"
+          ansible.builtin.uri:
+            url: "{{ vm_b8_cfg }}/{{ vm_b8_rm }}/properties/4p4/value"
+            return_content: true
+          register: vm_b8_conn_status
+          retries: 10
+          delay: 1
+          until: vm_b8_conn_status.json.value | int == 3
+
+        - name: "BCP-008 test_04 — inject a link fault (counted, immediate past the window)"
+          ansible.builtin.uri:
+            url: "{{ vm_b8_cfg }}/root.FaultControl/methods/4m1/"
+            method: PATCH
+            body_format: json
+            body:
+              arguments:
+                monitorRole: ReceiverMonitor-03
+                domain: linkStatus
+                status: 2
+                message: "drill: one path down"
+            status_code: [200]
+
+        - name: "BCP-008 test_04 — linkStatus degraded and its transition counted"
+          ansible.builtin.uri:
+            url: "{{ vm_b8_cfg }}/{{ vm_b8_rm }}/properties/{{ item.prop }}/value"
+            return_content: true
+          register: vm_b8_link
+          failed_when: vm_b8_link.json.value | int != item.want
+          loop:
+            - { prop: "4p1", want: 2 }   # linkStatus SomeDown
+            - { prop: "4p3", want: 1 }   # linkStatusTransitionCounter
+          loop_control:
+            label: "{{ item.prop }}={{ item.want }}"
+
+        - name: "BCP-008 test_04 — clear the fault"
+          ansible.builtin.uri:
+            url: "{{ vm_b8_cfg }}/root.FaultControl/methods/4m2/"
+            method: PATCH
+            body_format: json
+            body: { arguments: { monitorRole: ReceiverMonitor-03, domain: linkStatus } }
+            status_code: [200]
+
+        - name: "BCP-008 test_04 — recovery is DELAYED: still degraded right after the clear"
+          ansible.builtin.uri:
+            url: "{{ vm_b8_cfg }}/{{ vm_b8_rm }}/properties/4p1/value"
+            return_content: true
+          register: vm_b8_link_hold
+          failed_when: vm_b8_link_hold.json.value | int != 2
+
+        - name: "BCP-008 test_04 — recovery lands after statusReportingDelay"
+          ansible.builtin.uri:
+            url: "{{ vm_b8_cfg }}/{{ vm_b8_rm }}/properties/4p1/value"
+            return_content: true
+          register: vm_b8_link_rec
+          retries: 8
+          delay: 1
+          until: vm_b8_link_rec.json.value | int == 1
+
+        - name: "BCP-008 test_11 — synchronization source change"
+          ansible.builtin.uri:
+            url: "{{ vm_b8_cfg }}/root.FaultControl/methods/4m3/"
+            method: PATCH
+            body_format: json
+            body: { arguments: { monitorRole: ReceiverMonitor-03, sourceId: "ptp-drill-gm" } }
+            status_code: [200]
+
+        - name: "BCP-008 test_11 — PartiallyHealthy dip + published source id"
+          ansible.builtin.uri:
+            url: "{{ vm_b8_cfg }}/{{ vm_b8_rm }}/properties/{{ item.prop }}/value"
+            return_content: true
+          register: vm_b8_sync
+          failed_when: vm_b8_sync.json.value != item.want
+          loop:
+            - { prop: "4p7", want: 2 }               # externalSynchronizationStatus
+            - { prop: "4p10", want: "ptp-drill-gm" } # synchronizationSourceId
+          loop_control:
+            label: "{{ item.prop }}"
+
+        - name: "BCP-008 test_11 — temporary: back to Healthy after the delay"
+          ansible.builtin.uri:
+            url: "{{ vm_b8_cfg }}/{{ vm_b8_rm }}/properties/4p7/value"
+            return_content: true
+          register: vm_b8_sync_rec
+          retries: 8
+          delay: 1
+          until: vm_b8_sync_rec.json.value | int == 1
+
+        - name: "BCP-008-01 test_15 — inject late-packet counters"
+          ansible.builtin.uri:
+            url: "{{ vm_b8_cfg }}/root.FaultControl/methods/4m4/"
+            method: PATCH
+            body_format: json
+            body:
+              arguments:
+                monitorRole: ReceiverMonitor-03
+                counter: late
+                name: drill-session
+                increment: 5
+            status_code: [200]
+
+        - name: "BCP-008-01 test_15 — GetLatePacketCounters answers the injected entry"
+          ansible.builtin.uri:
+            url: "{{ vm_b8_cfg }}/{{ vm_b8_rm }}/methods/4m2/"
+            method: PATCH
+            body_format: json
+            body: { arguments: {} }
+            return_content: true
+          register: vm_b8_late
+          failed_when: >-
+            vm_b8_late.status != 200
+            or vm_b8_late.json.value | length != 1
+            or vm_b8_late.json.value[0].name != 'drill-session'
+            or vm_b8_late.json.value[0].value | int != 5
+
+        - name: "BCP-008-01 test_16 — ResetCountersAndMessages"
+          ansible.builtin.uri:
+            url: "{{ vm_b8_cfg }}/{{ vm_b8_rm }}/methods/4m3/"
+            method: PATCH
+            body_format: json
+            body: { arguments: {} }
+            status_code: [200]
+
+        - name: "BCP-008-01 test_16 — packet AND transition counters read zero after reset"
+          ansible.builtin.uri:
+            url: "{{ vm_b8_cfg }}/{{ vm_b8_rm }}/{{ item.tail }}"
+            method: "{{ item.method }}"
+            body_format: json
+            body: "{{ item.body | default(omit) }}"
+            return_content: true
+          register: vm_b8_reset
+          failed_when: >-
+            vm_b8_reset.status != 200
+            or (item.empty and vm_b8_reset.json.value | length != 0)
+            or (not item.empty and vm_b8_reset.json.value | int != 0)
+          loop:
+            - { tail: "methods/4m2/", method: "PATCH", body: { arguments: {} }, empty: true }
+            - { tail: "properties/4p3/value", method: "GET", empty: false }
+            - { tail: "properties/4p6/value", method: "GET", empty: false }
+          loop_control:
+            label: "{{ item.tail }}"
+
+        # Sender side (BCP-008-02): the same engine on the
+        # transmission domain, plus its own counter getter + reset.
+        - name: "Activate the drill sender over IS-05"
+          ansible.builtin.uri:
+            url: "{{ vm_b8_conn }}/senders/{{ vm_b8_tx }}/staged"
+            method: PATCH
+            body_format: json
+            body: { master_enable: true, activation: { mode: activate_immediate } }
+            status_code: [200]
+
+        - name: "BCP-008-02 — transmissionStatus degrades honestly after the delay"
+          ansible.builtin.uri:
+            url: "{{ vm_b8_cfg }}/{{ vm_b8_sm }}/properties/4p4/value"
+            return_content: true
+          register: vm_b8_tx_status
+          retries: 10
+          delay: 1
+          until: vm_b8_tx_status.json.value | int == 3
+
+        - name: "BCP-008-02 test_15 — inject + read transmission error counters"
+          ansible.builtin.uri:
+            url: "{{ vm_b8_cfg }}/root.FaultControl/methods/4m4/"
+            method: PATCH
+            body_format: json
+            body:
+              arguments:
+                monitorRole: SenderMonitor-03
+                counter: transmission
+                name: drill-errors
+                increment: 3
+            status_code: [200]
+
+        - name: "BCP-008-02 test_15 — GetTransmissionErrorCounters answers the injected entry"
+          ansible.builtin.uri:
+            url: "{{ vm_b8_cfg }}/{{ vm_b8_sm }}/methods/4m1/"
+            method: PATCH
+            body_format: json
+            body: { arguments: {} }
+            return_content: true
+          register: vm_b8_tx_cnt
+          failed_when: >-
+            vm_b8_tx_cnt.status != 200
+            or vm_b8_tx_cnt.json.value | length != 1
+            or vm_b8_tx_cnt.json.value[0].name != 'drill-errors'
+            or vm_b8_tx_cnt.json.value[0].value | int != 3
+
+        - name: "BCP-008-02 test_15 — invoke the sender reset"
+          ansible.builtin.uri:
+            url: "{{ vm_b8_cfg }}/{{ vm_b8_sm }}/methods/4m2/"
+            method: PATCH
+            body_format: json
+            body: { arguments: {} }
+            status_code: [200]
+
+        - name: "BCP-008-02 test_15 — getter empty after reset"
+          ansible.builtin.uri:
+            url: "{{ vm_b8_cfg }}/{{ vm_b8_sm }}/methods/4m1/"
+            method: PATCH
+            body_format: json
+            body: { arguments: {} }
+            return_content: true
+          register: vm_b8_tx_after
+          failed_when: vm_b8_tx_after.status != 200 or vm_b8_tx_after.json.value | length != 0
+
+        # BCP-007-03-01 test_15 — "MXL read/write starts or stops on
+        # activation". The only observable read/write a reference node
+        # has is its monitors: both MXL legs' monitors must track
+        # IS-05 master_enable, and the receiver PATCH carries no
+        # transport_file (an MXL sender MUST NOT provide one).
+        - name: "BCP-007-03 test_15 — activate both MXL legs"
+          ansible.builtin.uri:
+            url: "{{ vm_b8_conn }}/{{ item.kind }}/{{ item.id }}/staged"
+            method: PATCH
+            body_format: json
+            body: { master_enable: true, activation: { mode: activate_immediate } }
+            status_code: [200]
+          loop:
+            - { kind: "receivers", id: "{{ vm_mxl_rx }}" }
+            - { kind: "senders", id: "{{ vm_mxl_tx }}" }
+          loop_control:
+            label: "{{ item.kind }}"
+
+        - name: "BCP-007-03 test_15 — MXL read/write STARTED (monitors Healthy)"
+          ansible.builtin.uri:
+            url: "{{ vm_b8_cfg }}/{{ item }}/properties/3p1/value"
+            return_content: true
+          register: vm_b8_mxl_on
+          retries: 10
+          delay: 1
+          until: vm_b8_mxl_on.json.value | int == 1
+          loop: ["{{ vm_mxl_rm }}", "{{ vm_mxl_sm }}"]
+
+        - name: "BCP-007-03 test_15 — deactivate both MXL legs"
+          ansible.builtin.uri:
+            url: "{{ vm_b8_conn }}/{{ item.kind }}/{{ item.id }}/staged"
+            method: PATCH
+            body_format: json
+            body: { master_enable: false, activation: { mode: activate_immediate } }
+            status_code: [200]
+          loop:
+            - { kind: "receivers", id: "{{ vm_mxl_rx }}" }
+            - { kind: "senders", id: "{{ vm_mxl_tx }}" }
+          loop_control:
+            label: "{{ item.kind }}"
+
+        - name: "BCP-007-03 test_15 — MXL read/write STOPPED (monitors Inactive)"
+          ansible.builtin.uri:
+            url: "{{ vm_b8_cfg }}/{{ item }}/properties/3p1/value"
+            return_content: true
+          register: vm_b8_mxl_off
+          retries: 10
+          delay: 1
+          until: vm_b8_mxl_off.json.value | int == 0
+          loop: ["{{ vm_mxl_rm }}", "{{ vm_mxl_sm }}"]
+      always:
+        - name: "Close the drill window"
+          ansible.builtin.systemd:
+            name: "{{ item }}"
+            state: stopped
+          loop:
+            - dhs-nmos-verify-b8
+            - dhs-nmos-verify-b8-stop.timer
+          delegate_to: "{{ groups['plant'][0] }}"
+          failed_when: false
+
     # ---- EVS-style summary: one line per manual row this phase
     # touches — checks that ran, conversions that moved rows to the
     # tool, and the gaps deliberately left visible.
@@ -309,7 +659,13 @@
         - { row: "IS-08-01 test_10", check: "output properties authored", state: "PASS" }
         - { row: "IS-04-03 test_02", check: "ver_rcv TXT +1 on IS-05 activation", state: "PASS" }
         - { row: "IS-09-02 test_05", check: "heartbeat_interval applied (INFO log)", state: "PASS" }
-        - { row: "(WS ancestry)", check: "subscription query.* params", state: "PHASE 2 (subscriptions.go:242-250 strips them)" }
+        - { row: "(WS ancestry)", check: "subscription query.ancestry_* params", state: "PRODUCT-FIXED #956 (Go unit tests)" }
+        - { row: "BCP-008 test_03/05/06/07", check: "honest no-stream degradation", state: "TOOL-SCORED (see BCP-008 receipts)" }
+        - { row: "BCP-008 test_04", check: "fault clear held by reporting delay", state: "PASS" }
+        - { row: "BCP-008 test_11", check: "sync change dips PartiallyHealthy", state: "PASS" }
+        - { row: "BCP-008-01 test_15/16", check: "late counters inject/get/reset", state: "PASS" }
+        - { row: "BCP-008-02 test_15", check: "tx error counters inject/get/reset", state: "PASS" }
+        - { row: "BCP-007-03 test_15", check: "MXL monitors track master_enable", state: "PASS" }
       loop_control:
         label: "{{ item.row }}"
 

--- a/ansible/playbooks/amwa-verify-manual.yml
+++ b/ansible/playbooks/amwa-verify-manual.yml
@@ -675,6 +675,9 @@
       ansible.builtin.debug:
         msg: >-
           manual-row equivalents green: ancestry engine, IS-08
-          properties, ver_* bump on activation, and applied IS-09
-          heartbeat_interval all verified live; 2 rows tool-scored via
-          the fixture; WS ancestry remains the one phase-2 item.
+          properties, ver_* bump on activation, applied IS-09
+          heartbeat_interval, BCP-008 fault drills (delayed recovery,
+          sync-source dip, packet counters + resets) and BCP-007-03
+          MXL activation tracking all verified live; 2 rows
+          tool-scored via the fixture; WS ancestry product-fixed
+          (#956, Go unit tests).

--- a/ansible/roles/dhs_amwa_validate/defaults/main.yml
+++ b/ansible/roles/dhs_amwa_validate/defaults/main.yml
@@ -246,10 +246,10 @@ dhs_amwa_validate_suites:
       rows: [{ver: v1.3}, {ver: v1.2}], baseline_pass: 55, baseline_cnt: 0 }
   - { id: BCP-008-01-01, scope: node, target: node,
       rows: [{ver: v1.3}, {ver: v1.2}, {ver: v1.0, urlpath: "x-nmos/ncp/v1.0"}, {ver: v1.0}],
-      baseline_pass: 94, baseline_cnt: 0 }
+      baseline_pass: 98, baseline_cnt: 0 }
   - { id: BCP-008-02-01, scope: node, target: node,
       rows: [{ver: v1.3}, {ver: v1.2}, {ver: v1.0, urlpath: "x-nmos/ncp/v1.0"}, {ver: v1.0}],
-      baseline_pass: 94, baseline_cnt: 0 }
+      baseline_pass: 98, baseline_cnt: 0 }
   # ---- TLS window (issue #948): BCP-003-01 against an HTTPS-only CuT ----
   # tls: true selects the TLS tool instance (ENABLE_HTTPS=True — the
   # tool's GLOBAL https/wss switch; there is no per-row scheme field
@@ -281,7 +281,7 @@ dhs_amwa_validate_suites:
   # RTP receiver with a templatable media_types[0] (#950 phase 1) —
   # expect 58 (confirm from the fleet before raising).
   - { id: IS-04-01, scope: node, target: cut, window: isolated, flaky_retry: true,
-      rows: [{ver: v1.3}], baseline_pass: 58, baseline_cnt: 0 }
+      rows: [{ver: v1.3}], baseline_pass: 59, baseline_cnt: 0 }
   # IS-09-02 drives our node's System API CLIENT against the tool's
   # mock System API (mDNS-announced) — same window; note the suite's
   # own two-row shape with a null first endpoint.

--- a/internal/amwa/provider/configuration.go
+++ b/internal/amwa/provider/configuration.go
@@ -91,6 +91,10 @@ type IS14ConfigurationServer struct {
 	// monitorByResource maps an IS-04 sender/receiver id to its status
 	// monitor's role-path key (BCP-008 touchpoint, inverted).
 	monitorByResource map[string]string
+
+	// monHealth is the per-monitor runtime state of the BCP-008 health
+	// engine (monitor_health.go), keyed like objects.
+	monHealth map[string]*monitorHealth
 }
 
 // SetOnPropertyChanged installs the IS-12 notification hook.
@@ -339,6 +343,18 @@ func NewIS14ConfigurationServer(logger *slog.Logger, bundle *NodeConfig, cfg IS1
 		panic(fmt.Sprintf("provider/is14: gain worker model load: %v", err5))
 	}
 	objs = append(objs, gain)
+	nextOid++
+
+	// The DhsFaultControl worker: the operator/Ansible seam into the
+	// BCP-008 health engine (vendor_fault.go).
+	fault, err6 := newConfigObject(faultClassID, nextOid, []string{"root", faultRole}, map[string]any{
+		"userLabel": "Fault injection control",
+		"enabled":   true,
+	})
+	if err6 != nil {
+		panic(fmt.Sprintf("provider/is14: fault worker model load: %v", err6))
+	}
+	objs = append(objs, fault)
 
 	if p := root.findProp("2p2"); p != nil { // NcBlock.members
 		members := make([]ms05.NcBlockMemberDescriptor, 0, len(objs)-1)
@@ -356,48 +372,8 @@ func NewIS14ConfigurationServer(logger *slog.Logger, bundle *NodeConfig, cfg IS1
 	return s
 }
 
-// SetMonitorActive flips the status monitor tied to an IS-04 sender or
-// receiver between Inactive and Healthy on IS-05 activation — BCP-008
-// "monitor transitions to Healthy state on activation" and its
-// deactivation mirror. Every changed property fires the IS-12
-// notification hook.
-func (s *IS14ConfigurationServer) SetMonitorActive(resourceID string, active bool) {
-	key, ok := s.monitorByResource[resourceID]
-	if !ok {
-		return
-	}
-	s.mu.Lock()
-	obj := s.objects[key]
-	if obj == nil {
-		s.mu.Unlock()
-		return
-	}
-	status := 0 // Inactive
-	if active {
-		status = 1 // Healthy
-	}
-	type change struct {
-		id ms05.NcPropertyId
-		v  any
-	}
-	var fired []change
-	for _, name := range []string{"overallStatus", "connectionStatus", "streamStatus", "transmissionStatus", "essenceStatus"} {
-		for _, p := range obj.props {
-			if p.desc.Name == name {
-				if p.value != status {
-					p.value = status
-					fired = append(fired, change{p.desc.ID, status})
-				}
-			}
-		}
-	}
-	s.mu.Unlock()
-	if s.onPropertyChanged != nil {
-		for _, c := range fired {
-			s.onPropertyChanged(obj.oid, c.id, c.v)
-		}
-	}
-}
+// SetMonitorActive lives in monitor_health.go — the BCP-008 health
+// engine drives every monitor status from IS-05 activation state.
 
 // Versions lists the mounted IS-14 minors.
 func (s *IS14ConfigurationServer) Versions() []string { return s.vers }
@@ -836,6 +812,15 @@ func (s *IS14ConfigurationServer) invoke(obj *configObject, md *ms05.NcMethodDes
 		}
 		if st, err := s.setProperty(obj, p, gainArgs.GainDb); err != nil {
 			return ms05Err(400, st, err.Error())
+		}
+		return 200, ms05.NcMethodResult{Status: ms05.NcMethodStatusOk}, nil
+
+	case "InjectMonitorFault", "ClearMonitorFault", "SetMonitorSyncSource", "AddMonitorPacketCounters":
+		// DhsFaultControl — the BCP-008 fault-injection seam, invocable
+		// over IS-14 REST so the Ansible verify plays reach it with
+		// plain HTTP.
+		if err := s.invokeFaultMethod(md.Name, rawArgs); err != nil {
+			return ms05Err(400, ms05.NcMethodStatusParameterError, err.Error())
 		}
 		return 200, ms05.NcMethodResult{Status: ms05.NcMethodStatusOk}, nil
 

--- a/internal/amwa/provider/configuration.go
+++ b/internal/amwa/provider/configuration.go
@@ -824,6 +824,32 @@ func (s *IS14ConfigurationServer) invoke(obj *configObject, md *ms05.NcMethodDes
 		}
 		return 200, ms05.NcMethodResult{Status: ms05.NcMethodStatusOk}, nil
 
+	case "ResetCountersAndMessages":
+		// BCP-008 monitor reset over the IS-14 face — same body as the
+		// IS-12 method (transition counters, messages AND injected
+		// packet counters clear together).
+		s.mu.Lock()
+		changes := s.resetCountersLocked(strings.Join(obj.path, "."), obj)
+		s.mu.Unlock()
+		s.fire(changes)
+		return 200, ms05.NcMethodResult{Status: ms05.NcMethodStatusOk}, nil
+
+	case "GetLostPacketCounters", "GetLatePacketCounters", "GetTransmissionErrorCounters":
+		kind := map[string]string{
+			"GetLostPacketCounters":        "lost",
+			"GetLatePacketCounters":        "late",
+			"GetTransmissionErrorCounters": "transmission",
+		}[md.Name]
+		counters := s.MonitorPacketCounters(obj.oid, kind)
+		if counters == nil {
+			counters = []ncCounter{}
+		}
+		raw, err := json.Marshal(counters)
+		if err != nil {
+			return ms05Err(500, ms05.NcMethodStatusDeviceError, err.Error())
+		}
+		return 200, ms05.NcMethodResultPropertyValue{Status: ms05.NcMethodStatusOk, Value: raw}, nil
+
 	case "GetMemberDescriptors":
 		return 200, ms05.NcMethodResultBlockMemberDescriptors{
 			Status: ms05.NcMethodStatusOk, Value: s.membersOf(obj, args.Recurse != nil && *args.Recurse),

--- a/internal/amwa/provider/configuration_test.go
+++ b/internal/amwa/provider/configuration_test.go
@@ -93,7 +93,7 @@ func TestConfigurationTreeAndRolePaths(t *testing.T) {
 	if err := json.Unmarshal(raw, &paths); err != nil {
 		t.Fatalf("rolePaths decode: %v", err)
 	}
-	want := []string{"root/", "root.DeviceManager/", "root.ClassManager/", "root.BulkPropertiesManager/", "root.GainControl/"}
+	want := []string{"root/", "root.DeviceManager/", "root.ClassManager/", "root.BulkPropertiesManager/", "root.GainControl/", "root.FaultControl/"}
 	if len(paths) != len(want) {
 		t.Fatalf("rolePaths = %v, want %v", paths, want)
 	}
@@ -218,9 +218,9 @@ func TestConfigurationMethods(t *testing.T) {
 		t.Fatalf("2m1 = %d %s", st, raw)
 	}
 
-	// 1m7 GetSequenceLength on members (3 managers + gain worker).
+	// 1m7 GetSequenceLength on members (3 managers + gain + fault workers).
 	st, raw = doJSON(t, "PATCH", v1+"root/methods/1m7/", `{"arguments":{"id":{"level":2,"index":2}}}`)
-	if st != 200 || !bytes.Contains(raw, []byte(`"value":4`)) {
+	if st != 200 || !bytes.Contains(raw, []byte(`"value":5`)) {
 		t.Errorf("1m7 = %d %s", st, raw)
 	}
 
@@ -282,8 +282,8 @@ func TestConfigurationBulkProperties(t *testing.T) {
 	if err := json.Unmarshal(raw, &backup); err != nil {
 		t.Fatalf("backup decode: %v", err)
 	}
-	if backup.Value.ValidationFingerprint == nil || len(backup.Value.Values) != 5 {
-		t.Fatalf("backup holders = %d fp=%v, want 5 + fingerprint", len(backup.Value.Values), backup.Value.ValidationFingerprint)
+	if backup.Value.ValidationFingerprint == nil || len(backup.Value.Values) != 6 {
+		t.Fatalf("backup holders = %d fp=%v, want 6 + fingerprint", len(backup.Value.Values), backup.Value.ValidationFingerprint)
 	}
 	if backup.Value.Values[0].Values[0].Descriptor == nil {
 		t.Error("includeDescriptors default must attach descriptors")
@@ -323,9 +323,10 @@ func TestConfigurationBulkProperties(t *testing.T) {
 		t.Fatalf("backup nodesc = %d", st)
 	}
 	paths := holderPaths(raw)
-	if len(paths) != 4 || paths[0] != "root" || paths[1] != "root.DeviceManager" ||
-		paths[2] != "root.BulkPropertiesManager" || paths[3] != "root.GainControl" {
-		t.Errorf("includeDescriptors=false holders = %v, want [root root.DeviceManager root.BulkPropertiesManager root.GainControl]", paths)
+	if len(paths) != 5 || paths[0] != "root" || paths[1] != "root.DeviceManager" ||
+		paths[2] != "root.BulkPropertiesManager" || paths[3] != "root.GainControl" ||
+		paths[4] != "root.FaultControl" {
+		t.Errorf("includeDescriptors=false holders = %v, want [root root.DeviceManager root.BulkPropertiesManager root.GainControl root.FaultControl]", paths)
 	}
 
 	// recurse=false: root only.

--- a/internal/amwa/provider/monitor_health.go
+++ b/internal/amwa/provider/monitor_health.go
@@ -1,0 +1,557 @@
+// BCP-008 monitor health engine — the runtime behind the
+// NcReceiverMonitor / NcSenderMonitor objects in the IS-14/IS-12
+// device model.
+//
+// The AMWA BCP-008 suites activate a monitored resource with a
+// synthetic SDP and expect the monitor to tell the truth about it:
+// transition to Healthy immediately on activation, hold that for
+// statusReportingDelay (3p3), then — since a reference node has no
+// media plane and no stream ever arrives — transition the stream
+// domain (connectionStatus on receivers, transmissionStatus on
+// senders) to Unhealthy, incrementing its transition counter and
+// publishing a status message. Deactivation goes straight to Inactive
+// with no intermediate unhealthy states and no delay. overallStatus is
+// never written directly: it is Inactive while the stream domains are
+// Inactive and otherwise the least healthy (max) of all domain
+// statuses — the exact mapping the suites' check_overall_status
+// enforces.
+//
+// Injected faults (the DhsFaultControl worker, vendor_fault.go) ride
+// the same engine: a less-healthy report lands immediately once the
+// post-activation delay window has passed (held to the window's end
+// inside it), and a recovery to a more-healthy state is delayed by
+// statusReportingDelay — the two timing rules BCP-008 states for
+// status reporting.
+package provider
+
+import (
+	"fmt"
+	"time"
+
+	"dhs/internal/amwa/codec/ms05"
+)
+
+// BCP-008 status enum values shared by NcOverallStatus,
+// NcConnectionStatus, NcStreamStatus, NcTransmissionStatus,
+// NcEssenceStatus (and, positionally, NcLinkStatus /
+// NcSynchronizationStatus: higher is less healthy in every one).
+const (
+	monStatusInactive         = 0 // NotUsed for externalSynchronizationStatus
+	monStatusHealthy          = 1 // AllUp for linkStatus
+	monStatusPartiallyHealthy = 2
+	monStatusUnhealthy        = 3
+)
+
+// monNoStreamMessage is the truthful stream-domain fault of a
+// reference node: nothing is ever received or transmitted.
+const monNoStreamMessage = "no stream on the synthetic media plane (reference node)"
+
+// monitorFault is one injected domain override.
+type monitorFault struct {
+	status  int
+	message string
+}
+
+// ncCounter is the monitoring feature set's NcCounter datatype (name /
+// value / nullable description) in the wire shape the 4m1/4m2 counter
+// getters return.
+type ncCounter struct {
+	Name        string  `json:"name"`
+	Value       uint64  `json:"value"`
+	Description *string `json:"description"`
+}
+
+// monitorHealth is the per-monitor runtime state, guarded by the
+// configuration server's mutex.
+type monitorHealth struct {
+	active      bool
+	graceEnd    time.Time   // end of the post-activation delay window
+	graceTimer  *time.Timer // fires monitorGraceExpired; nil once fired
+	clearTimers map[string]*time.Timer
+
+	// faults are the injected domain overrides (domain property name →
+	// fault). The no-stream fault is not stored here — it is the
+	// baseline of the stream domain while active.
+	faults map[string]monitorFault
+
+	// syncSource mirrors synchronizationSourceId once a sync source
+	// change was injected: from then on the monitor is "using external
+	// synchronization" and its baseline extSync status is Healthy.
+	syncSource string
+
+	// packetCounters back the 4m1/4m2 counter getters, keyed by kind
+	// ("late" / "lost" for receivers, "transmission" for senders).
+	packetCounters map[string][]ncCounter
+}
+
+// streamDomainFor names the domain property BCP-008 calls the "stream
+// status" of the class — the one that must go Unhealthy when no
+// stream exists.
+func streamDomainFor(classID ms05.NcClassId) string {
+	if classDerivedFrom(classID, ms05.NcClassId{1, 2, 2, 1}) {
+		return "connectionStatus"
+	}
+	return "transmissionStatus"
+}
+
+// inactiveableDomainsFor lists the domain properties with an Inactive
+// option — the ones deactivation must zero (the suites'
+// get_inactiveable_status_property_ids, minus overallStatus which the
+// recompute owns).
+func inactiveableDomainsFor(classID ms05.NcClassId) []string {
+	if classDerivedFrom(classID, ms05.NcClassId{1, 2, 2, 1}) {
+		return []string{"connectionStatus", "streamStatus"}
+	}
+	return []string{"transmissionStatus", "essenceStatus"}
+}
+
+// domainStatusNames lists every domain status feeding overallStatus.
+func domainStatusNames(classID ms05.NcClassId) []string {
+	return append([]string{"linkStatus", "externalSynchronizationStatus"},
+		inactiveableDomainsFor(classID)...)
+}
+
+// propChange is one fired notification, collected under the lock and
+// delivered outside it.
+type propChange struct {
+	oid ms05.NcOid
+	id  ms05.NcPropertyId
+	v   any
+}
+
+// health returns (allocating if needed) the runtime state for a
+// monitor object key. Callers hold s.mu.
+func (s *IS14ConfigurationServer) healthLocked(key string) *monitorHealth {
+	if s.monHealth == nil {
+		s.monHealth = map[string]*monitorHealth{}
+	}
+	h, ok := s.monHealth[key]
+	if !ok {
+		h = &monitorHealth{
+			faults:         map[string]monitorFault{},
+			clearTimers:    map[string]*time.Timer{},
+			packetCounters: map[string][]ncCounter{},
+		}
+		s.monHealth[key] = h
+	}
+	return h
+}
+
+// findPropByName locates a property slot by descriptor name.
+func findPropByName(o *configObject, name string) *configProperty {
+	for _, p := range o.props {
+		if p.desc.Name == name {
+			return p
+		}
+	}
+	return nil
+}
+
+// asInt reads a status value regardless of how it was stored (seeded
+// int, JSON-decoded float64, or typed uint).
+func asInt(v any) int {
+	switch n := v.(type) {
+	case int:
+		return n
+	case int64:
+		return int(n)
+	case uint32:
+		return int(n)
+	case uint64:
+		return int(n)
+	case float64:
+		return int(n)
+	}
+	return 0
+}
+
+// monitorDelayLocked reads statusReportingDelay (3p3) as a duration.
+func monitorDelayLocked(obj *configObject) time.Duration {
+	if p := obj.findProp("3p3"); p != nil {
+		if d := asInt(p.value); d > 0 {
+			return time.Duration(d) * time.Second
+		}
+	}
+	return 3 * time.Second
+}
+
+// setDomainLocked writes one domain status (with its message and, on
+// a transition to a strictly less healthy non-neutral state, its
+// transition counter), collecting notifications. No overallStatus
+// recompute here — callers batch that once per event.
+func (s *IS14ConfigurationServer) setDomainLocked(obj *configObject, domain string, status int, message string) []propChange {
+	p := findPropByName(obj, domain)
+	if p == nil {
+		return nil
+	}
+	old := asInt(p.value)
+	if old == status {
+		return nil
+	}
+	var out []propChange
+	p.value = status
+	out = append(out, propChange{obj.oid, p.desc.ID, status})
+
+	// Status messages accompany degraded states and clear otherwise.
+	if mp := findPropByName(obj, domain+"Message"); mp != nil {
+		var mv any
+		if status >= monStatusPartiallyHealthy && message != "" {
+			mv = message
+		}
+		if mp.value != mv {
+			mp.value = mv
+			out = append(out, propChange{obj.oid, mp.desc.ID, mv})
+		}
+	}
+
+	// "Transitions to less healthy states are counted" — any move to a
+	// strictly higher, degraded value (NotUsed→PartiallyHealthy on the
+	// sync domain counts too: the domain became degraded).
+	if status > old && status >= monStatusPartiallyHealthy {
+		if cp := findPropByName(obj, domain+"TransitionCounter"); cp != nil {
+			n := uint64(asInt(cp.value)) + 1
+			cp.value = n
+			out = append(out, propChange{obj.oid, cp.desc.ID, n})
+		}
+	}
+	return out
+}
+
+// recomputeOverallLocked derives overallStatus from the domains per
+// the BCP-008 mapping rule.
+func (s *IS14ConfigurationServer) recomputeOverallLocked(obj *configObject) []propChange {
+	inactiveable := inactiveableDomainsFor(obj.classID)
+	overall := monStatusInactive
+	inactive := false
+	for _, d := range inactiveable {
+		if p := findPropByName(obj, d); p != nil && asInt(p.value) == monStatusInactive {
+			inactive = true
+		}
+	}
+	if !inactive {
+		for _, d := range domainStatusNames(obj.classID) {
+			if p := findPropByName(obj, d); p != nil {
+				if v := asInt(p.value); v > overall {
+					overall = v
+				}
+			}
+		}
+	}
+	p := findPropByName(obj, "overallStatus")
+	if p == nil || asInt(p.value) == overall {
+		return nil
+	}
+	p.value = overall
+	return []propChange{{obj.oid, p.desc.ID, overall}}
+}
+
+// fire delivers collected notifications outside the lock.
+func (s *IS14ConfigurationServer) fire(changes []propChange) {
+	if s.onPropertyChanged == nil {
+		return
+	}
+	for _, c := range changes {
+		s.onPropertyChanged(c.oid, c.id, c.v)
+	}
+}
+
+// resetCountersLocked zeroes every transition counter, clears every
+// nullable status message, and drops the injected packet counters —
+// the shared body of ResetCountersAndMessages and autoResetCounters.
+func (s *IS14ConfigurationServer) resetCountersLocked(key string, obj *configObject) []propChange {
+	var out []propChange
+	for _, p := range obj.props {
+		if hasSuffix(p.desc.Name, "TransitionCounter") && asInt(p.value) != 0 {
+			p.value = uint64(0)
+			out = append(out, propChange{obj.oid, p.desc.ID, uint64(0)})
+		}
+		if hasSuffix(p.desc.Name, "Message") && p.desc.IsNullable && p.value != nil {
+			p.value = nil
+			out = append(out, propChange{obj.oid, p.desc.ID, nil})
+		}
+	}
+	s.healthLocked(key).packetCounters = map[string][]ncCounter{}
+	return out
+}
+
+func hasSuffix(s, suf string) bool {
+	return len(s) >= len(suf) && s[len(s)-len(suf):] == suf
+}
+
+// SetMonitorActive drives the monitor tied to an IS-04 sender or
+// receiver through IS-05 activation state — the engine's primary
+// input, wired from the connection server at construction.
+func (s *IS14ConfigurationServer) SetMonitorActive(resourceID string, active bool) {
+	key, ok := s.monitorByResource[resourceID]
+	if !ok {
+		return
+	}
+	s.mu.Lock()
+	obj := s.objects[key]
+	if obj == nil {
+		s.mu.Unlock()
+		return
+	}
+	h := s.healthLocked(key)
+	// Any state change invalidates pending transitions.
+	if h.graceTimer != nil {
+		h.graceTimer.Stop()
+		h.graceTimer = nil
+	}
+	for d, t := range h.clearTimers {
+		t.Stop()
+		delete(h.clearTimers, d)
+	}
+	var changes []propChange
+	if active {
+		h.active = true
+		h.faults = map[string]monitorFault{}
+		// autoResetCountersAndMessages: reset on activation when armed.
+		if p := findPropByName(obj, "autoResetCountersAndMessages"); p != nil {
+			if b, ok := p.value.(bool); ok && b {
+				changes = append(changes, s.resetCountersLocked(key, obj)...)
+			}
+		}
+		// Domains with an Inactive option MUST transition immediately
+		// to Healthy on activation.
+		for _, d := range inactiveableDomainsFor(obj.classID) {
+			changes = append(changes, s.setDomainLocked(obj, d, monStatusHealthy, "")...)
+		}
+		delay := monitorDelayLocked(obj)
+		h.graceEnd = time.Now().Add(delay)
+		h.graceTimer = time.AfterFunc(delay, func() { s.monitorGraceExpired(key) })
+	} else {
+		h.active = false
+		h.faults = map[string]monitorFault{}
+		// Clean disconnect: straight to Inactive, no intermediate
+		// unhealthy states, no reporting delay.
+		for _, d := range inactiveableDomainsFor(obj.classID) {
+			changes = append(changes, s.setDomainLocked(obj, d, monStatusInactive, "")...)
+		}
+	}
+	changes = append(changes, s.recomputeOverallLocked(obj)...)
+	s.mu.Unlock()
+	s.fire(changes)
+}
+
+// monitorGraceExpired ends the post-activation delay window: the
+// stream domain reports the truth — no stream exists on a reference
+// node — and any less-healthy faults injected during the window land.
+func (s *IS14ConfigurationServer) monitorGraceExpired(key string) {
+	s.mu.Lock()
+	obj := s.objects[key]
+	h := s.monHealth[key]
+	if obj == nil || h == nil || !h.active {
+		s.mu.Unlock()
+		return
+	}
+	h.graceTimer = nil
+	var changes []propChange
+	stream := streamDomainFor(obj.classID)
+	if f, ok := h.faults[stream]; ok {
+		changes = append(changes, s.setDomainLocked(obj, stream, f.status, f.message)...)
+	} else {
+		changes = append(changes, s.setDomainLocked(obj, stream, monStatusUnhealthy, monNoStreamMessage)...)
+	}
+	for d, f := range h.faults {
+		if d == stream {
+			continue
+		}
+		if p := findPropByName(obj, d); p != nil && f.status > asInt(p.value) {
+			changes = append(changes, s.setDomainLocked(obj, d, f.status, f.message)...)
+		}
+	}
+	changes = append(changes, s.recomputeOverallLocked(obj)...)
+	s.mu.Unlock()
+	s.fire(changes)
+}
+
+// monitorObjLocked resolves "root.<Role>" (or a bare role) to the
+// monitor object + its health state. Callers hold s.mu.
+func (s *IS14ConfigurationServer) monitorObjLocked(role string) (*configObject, *monitorHealth, string, error) {
+	key := role
+	if _, ok := s.objects[key]; !ok {
+		key = "root." + role
+	}
+	obj, ok := s.objects[key]
+	if !ok {
+		return nil, nil, "", fmt.Errorf("no model object at role %q", role)
+	}
+	if !classDerivedFrom(obj.classID, ms05.NcClassId{1, 2, 2}) {
+		return nil, nil, "", fmt.Errorf("%q is not a status monitor", role)
+	}
+	return obj, s.healthLocked(key), key, nil
+}
+
+// SetMonitorFault injects (or, with status <= Healthy, clears) one
+// domain fault — the DhsFaultControl entry point. Timing follows the
+// BCP-008 reporting rules: degradations land immediately once the
+// activation window has passed and are held to its end inside it;
+// recoveries are delayed by statusReportingDelay.
+func (s *IS14ConfigurationServer) SetMonitorFault(role, domain string, status int, message string) error {
+	s.mu.Lock()
+	obj, h, key, err := s.monitorObjLocked(role)
+	if err != nil {
+		s.mu.Unlock()
+		return err
+	}
+	if !h.active {
+		s.mu.Unlock()
+		return fmt.Errorf("monitor %q is inactive; activate its IS-05 resource first", role)
+	}
+	p := findPropByName(obj, domain)
+	if p == nil || findPropByName(obj, domain+"TransitionCounter") == nil {
+		s.mu.Unlock()
+		return fmt.Errorf("monitor %q has no status domain %q", role, domain)
+	}
+	if t, ok := h.clearTimers[domain]; ok {
+		t.Stop()
+		delete(h.clearTimers, domain)
+	}
+	var changes []propChange
+	cur := asInt(p.value)
+	switch {
+	case status >= monStatusPartiallyHealthy && status > cur:
+		if h.graceTimer != nil {
+			// Inside the activation window: record; the window's end
+			// applies it.
+			h.faults[domain] = monitorFault{status: status, message: message}
+		} else {
+			h.faults[domain] = monitorFault{status: status, message: message}
+			changes = append(changes, s.setDomainLocked(obj, domain, status, message)...)
+			changes = append(changes, s.recomputeOverallLocked(obj)...)
+		}
+	default:
+		// Recovery (or a no-op level): forget the fault and restore
+		// the baseline after the reporting delay.
+		delete(h.faults, domain)
+		delay := monitorDelayLocked(obj)
+		h.clearTimers[domain] = time.AfterFunc(delay, func() { s.monitorFaultCleared(key, domain) })
+	}
+	s.mu.Unlock()
+	s.fire(changes)
+	return nil
+}
+
+// monitorFaultCleared restores a domain's baseline after the
+// reporting-delay hold on recoveries.
+func (s *IS14ConfigurationServer) monitorFaultCleared(key, domain string) {
+	s.mu.Lock()
+	obj := s.objects[key]
+	h := s.monHealth[key]
+	if obj == nil || h == nil || !h.active {
+		s.mu.Unlock()
+		return
+	}
+	delete(h.clearTimers, domain)
+	if _, refaulted := h.faults[domain]; refaulted {
+		s.mu.Unlock()
+		return
+	}
+	status, msg := s.baselineDomainLocked(obj, h, domain)
+	var changes []propChange
+	changes = append(changes, s.setDomainLocked(obj, domain, status, msg)...)
+	changes = append(changes, s.recomputeOverallLocked(obj)...)
+	s.mu.Unlock()
+	s.fire(changes)
+}
+
+// baselineDomainLocked is a domain's truthful un-faulted state.
+func (s *IS14ConfigurationServer) baselineDomainLocked(obj *configObject, h *monitorHealth, domain string) (int, string) {
+	switch domain {
+	case "linkStatus":
+		return monStatusHealthy, "" // AllUp
+	case "externalSynchronizationStatus":
+		if h.syncSource != "" {
+			return monStatusHealthy, ""
+		}
+		return monStatusInactive, "" // NotUsed
+	case streamDomainFor(obj.classID):
+		if h.active && h.graceTimer == nil {
+			return monStatusUnhealthy, monNoStreamMessage
+		}
+	}
+	if h.active {
+		return monStatusHealthy, ""
+	}
+	return monStatusInactive, ""
+}
+
+// SetMonitorSyncSource injects a synchronization source change:
+// synchronizationSourceId updates, the sync domain dips to
+// PartiallyHealthy (counted), and recovers to Healthy after the
+// reporting delay — the transition BCP-008 test_11 describes.
+func (s *IS14ConfigurationServer) SetMonitorSyncSource(role, sourceID string) error {
+	s.mu.Lock()
+	obj, h, key, err := s.monitorObjLocked(role)
+	if err != nil {
+		s.mu.Unlock()
+		return err
+	}
+	if !h.active {
+		s.mu.Unlock()
+		return fmt.Errorf("monitor %q is inactive; activate its IS-05 resource first", role)
+	}
+	h.syncSource = sourceID
+	var changes []propChange
+	if p := findPropByName(obj, "synchronizationSourceId"); p != nil {
+		var v any
+		if sourceID != "" {
+			v = sourceID
+		}
+		if p.value != v {
+			p.value = v
+			changes = append(changes, propChange{obj.oid, p.desc.ID, v})
+		}
+	}
+	const domain = "externalSynchronizationStatus"
+	if t, ok := h.clearTimers[domain]; ok {
+		t.Stop()
+	}
+	changes = append(changes, s.setDomainLocked(obj, domain, monStatusPartiallyHealthy,
+		"synchronization source changed to "+sourceID)...)
+	changes = append(changes, s.recomputeOverallLocked(obj)...)
+	delay := monitorDelayLocked(obj)
+	h.clearTimers[domain] = time.AfterFunc(delay, func() { s.monitorFaultCleared(key, domain) })
+	s.mu.Unlock()
+	s.fire(changes)
+	return nil
+}
+
+// AddMonitorPacketCounters accumulates one named counter of the given
+// kind ("late" / "lost" on receivers, "transmission" on senders) so
+// the 4m1/4m2 getters answer real NcCounter data.
+func (s *IS14ConfigurationServer) AddMonitorPacketCounters(role, kind, name string, value uint64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, h, _, err := s.monitorObjLocked(role)
+	if err != nil {
+		return err
+	}
+	for i := range h.packetCounters[kind] {
+		if h.packetCounters[kind][i].Name == name {
+			h.packetCounters[kind][i].Value += value
+			return nil
+		}
+	}
+	desc := kind + " packet counter (injected by DhsFaultControl)"
+	h.packetCounters[kind] = append(h.packetCounters[kind],
+		ncCounter{Name: name, Value: value, Description: &desc})
+	return nil
+}
+
+// MonitorPacketCounters answers a monitor's injected counters for the
+// IS-12 getter methods. The empty list is the truthful default.
+func (s *IS14ConfigurationServer) MonitorPacketCounters(oid ms05.NcOid, kind string) []ncCounter {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for key, o := range s.objects {
+		if o.oid == oid {
+			if h := s.monHealth[key]; h != nil {
+				return append([]ncCounter(nil), h.packetCounters[kind]...)
+			}
+			return nil
+		}
+	}
+	return nil
+}

--- a/internal/amwa/provider/monitor_health.go
+++ b/internal/amwa/provider/monitor_health.go
@@ -46,6 +46,21 @@ const (
 // reference node: nothing is ever received or transmitted.
 const monNoStreamMessage = "no stream on the synthetic media plane (reference node)"
 
+// monGraceMargin pads the post-activation hold past statusReportingDelay.
+// The delay is a MINIMUM ("delay the reporting ... for the duration,
+// and then transition"), and an observer clocks the window from its
+// RECEIPT of the Healthy notification — later than the activation
+// instant the timer runs from. Firing at exactly the delay makes the
+// degradation notification race the observer's window cutoff: the
+// AMWA suites' check_overall_status aggregates mid-window
+// notifications with no tolerance, so connectionStatus=Unhealthy
+// could land inside the window while the overallStatus that follows
+// lands outside it — scored as an overall-status mapping error
+// (BCP-008 test_08, seen live on the first fleet run). Half a second
+// clears the cutoff deterministically and stays well inside the
+// suites' post-window observation sleep (delay + 2 s).
+const monGraceMargin = 500 * time.Millisecond
+
 // monitorFault is one injected domain override.
 type monitorFault struct {
 	status  int
@@ -317,9 +332,9 @@ func (s *IS14ConfigurationServer) SetMonitorActive(resourceID string, active boo
 		for _, d := range inactiveableDomainsFor(obj.classID) {
 			changes = append(changes, s.setDomainLocked(obj, d, monStatusHealthy, "")...)
 		}
-		delay := monitorDelayLocked(obj)
-		h.graceEnd = time.Now().Add(delay)
-		h.graceTimer = time.AfterFunc(delay, func() { s.monitorGraceExpired(key) })
+		hold := monitorDelayLocked(obj) + monGraceMargin
+		h.graceEnd = time.Now().Add(hold)
+		h.graceTimer = time.AfterFunc(hold, func() { s.monitorGraceExpired(key) })
 	} else {
 		h.active = false
 		h.faults = map[string]monitorFault{}

--- a/internal/amwa/provider/monitor_health_test.go
+++ b/internal/amwa/provider/monitor_health_test.go
@@ -1,0 +1,256 @@
+// The BCP-008 health engine, pinned at the exact behaviors the AMWA
+// suites score (BCP008Test._check_monitor_status_changes and friends):
+// Healthy immediately on activation, honest no-stream degradation only
+// after statusReportingDelay, counted less-healthy transitions, clean
+// immediate deactivation, delayed recovery, and the overallStatus
+// mapping rule.
+package provider
+
+import (
+	"testing"
+	"time"
+)
+
+// engineFixture builds a configuration server over the audio bundle
+// with a 1-second reporting delay on the first receiver monitor so
+// timing tests stay fast.
+func engineFixture(t *testing.T) (*IS14ConfigurationServer, string, string) {
+	t.Helper()
+	bundle := audioBundle()
+	s := NewIS14ConfigurationServer(nil, bundle, IS14ConfigurationConfig{})
+	rid := bundle.Receivers[0].ID
+	key := s.monitorByResource[rid]
+	s.mu.Lock()
+	if p := s.objects[key].findProp("3p3"); p != nil {
+		p.value = uint32(1)
+	}
+	s.mu.Unlock()
+	return s, rid, key
+}
+
+func (s *IS14ConfigurationServer) propVal(t *testing.T, key, name string) any {
+	t.Helper()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	p := findPropByName(s.objects[key], name)
+	if p == nil {
+		t.Fatalf("no property %q on %s", name, key)
+	}
+	return p.value
+}
+
+func waitStatus(t *testing.T, s *IS14ConfigurationServer, key, name string, want int, within time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for {
+		if asInt(s.propVal(t, key, name)) == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("%s.%s = %v, want %d within %v", key, name, s.propVal(t, key, name), want, within)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestMonitorHealthActivationTimeline(t *testing.T) {
+	s, rid, key := engineFixture(t)
+
+	// Activation: Healthy immediately, overall included.
+	s.SetMonitorActive(rid, true)
+	for _, name := range []string{"connectionStatus", "streamStatus", "overallStatus"} {
+		if got := asInt(s.propVal(t, key, name)); got != monStatusHealthy {
+			t.Errorf("%s right after activation = %d, want Healthy", name, got)
+		}
+	}
+	if got := asInt(s.propVal(t, key, "connectionStatusTransitionCounter")); got != 0 {
+		t.Errorf("counter after Inactive->Healthy = %d, want 0 (not a less-healthy transition)", got)
+	}
+
+	// Reporting delay passes: the stream domain tells the truth.
+	waitStatus(t, s, key, "connectionStatus", monStatusUnhealthy, 3*time.Second)
+	if got := asInt(s.propVal(t, key, "overallStatus")); got != monStatusUnhealthy {
+		t.Errorf("overallStatus after no-stream degradation = %d, want Unhealthy (max rule)", got)
+	}
+	if got := asInt(s.propVal(t, key, "connectionStatusTransitionCounter")); got != 1 {
+		t.Errorf("counter after Healthy->Unhealthy = %d, want 1", got)
+	}
+	if msg := s.propVal(t, key, "connectionStatusMessage"); msg != monNoStreamMessage {
+		t.Errorf("connectionStatusMessage = %v, want the no-stream message", msg)
+	}
+
+	// Deactivation: straight to Inactive, no delay.
+	s.SetMonitorActive(rid, false)
+	for _, name := range []string{"connectionStatus", "streamStatus", "overallStatus"} {
+		if got := asInt(s.propVal(t, key, name)); got != monStatusInactive {
+			t.Errorf("%s after deactivation = %d, want Inactive", name, got)
+		}
+	}
+}
+
+func TestMonitorHealthDeactivateInsideGraceStaysClean(t *testing.T) {
+	s, rid, key := engineFixture(t)
+	s.SetMonitorActive(rid, true)
+	s.SetMonitorActive(rid, false)
+
+	// The grace timer must be cancelled: no unhealthy transition may
+	// arrive after a clean deactivation.
+	time.Sleep(1500 * time.Millisecond)
+	if got := asInt(s.propVal(t, key, "connectionStatus")); got != monStatusInactive {
+		t.Fatalf("connectionStatus after deactivate-inside-grace = %d, want Inactive", got)
+	}
+	if got := asInt(s.propVal(t, key, "connectionStatusTransitionCounter")); got != 0 {
+		t.Fatalf("counter after clean deactivation = %d, want 0", got)
+	}
+}
+
+func TestMonitorHealthAutoResetOnActivation(t *testing.T) {
+	s, rid, key := engineFixture(t)
+	s.SetMonitorActive(rid, true)
+	waitStatus(t, s, key, "connectionStatus", monStatusUnhealthy, 3*time.Second)
+	s.SetMonitorActive(rid, false)
+
+	// autoResetCountersAndMessages seeds true: re-activation clears the
+	// counter and the message from the previous session.
+	s.SetMonitorActive(rid, true)
+	if got := asInt(s.propVal(t, key, "connectionStatusTransitionCounter")); got != 0 {
+		t.Errorf("counter after auto-reset activation = %d, want 0", got)
+	}
+	if msg := s.propVal(t, key, "connectionStatusMessage"); msg != nil {
+		t.Errorf("message after auto-reset activation = %v, want null", msg)
+	}
+}
+
+func TestMonitorHealthFaultInjectAndDelayedRecovery(t *testing.T) {
+	s, rid, key := engineFixture(t)
+	role := "ReceiverMonitor-00"
+	s.SetMonitorActive(rid, true)
+	waitStatus(t, s, key, "connectionStatus", monStatusUnhealthy, 3*time.Second)
+
+	// Past the window: a link fault lands immediately and is counted.
+	if err := s.SetMonitorFault(role, "linkStatus", monStatusPartiallyHealthy, "one path down"); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+	if got := asInt(s.propVal(t, key, "linkStatus")); got != monStatusPartiallyHealthy {
+		t.Fatalf("linkStatus after inject = %d, want PartiallyHealthy", got)
+	}
+	if got := asInt(s.propVal(t, key, "linkStatusTransitionCounter")); got != 1 {
+		t.Errorf("link counter after inject = %d, want 1", got)
+	}
+
+	// Recovery is delayed by statusReportingDelay — still degraded
+	// right after the clear, back to AllUp only once the delay passed.
+	if err := s.SetMonitorFault(role, "linkStatus", monStatusHealthy, ""); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	if got := asInt(s.propVal(t, key, "linkStatus")); got != monStatusPartiallyHealthy {
+		t.Fatalf("linkStatus immediately after clear = %d, want still PartiallyHealthy", got)
+	}
+	waitStatus(t, s, key, "linkStatus", monStatusHealthy, 3*time.Second)
+	if msg := s.propVal(t, key, "linkStatusMessage"); msg != nil {
+		t.Errorf("linkStatusMessage after recovery = %v, want null", msg)
+	}
+
+	// Inactive monitors refuse injection.
+	s.SetMonitorActive(rid, false)
+	if err := s.SetMonitorFault(role, "linkStatus", monStatusUnhealthy, "x"); err == nil {
+		t.Error("inject on an inactive monitor must fail")
+	}
+}
+
+func TestMonitorHealthFaultDuringGraceHeldToWindowEnd(t *testing.T) {
+	s, rid, key := engineFixture(t)
+	role := "ReceiverMonitor-00"
+	s.SetMonitorActive(rid, true)
+
+	// Inside the window: the degradation must NOT report yet.
+	if err := s.SetMonitorFault(role, "linkStatus", monStatusUnhealthy, "cable pulled"); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+	if got := asInt(s.propVal(t, key, "linkStatus")); got != monStatusHealthy {
+		t.Fatalf("linkStatus inside grace = %d, want still AllUp", got)
+	}
+	// At window end both the no-stream truth and the held fault land.
+	waitStatus(t, s, key, "linkStatus", monStatusUnhealthy, 3*time.Second)
+	waitStatus(t, s, key, "connectionStatus", monStatusUnhealthy, time.Second)
+}
+
+func TestMonitorHealthSyncSourceChange(t *testing.T) {
+	s, rid, key := engineFixture(t)
+	role := "ReceiverMonitor-00"
+	s.SetMonitorActive(rid, true)
+
+	if err := s.SetMonitorSyncSource(role, "ptp-gm-1"); err != nil {
+		t.Fatalf("sync source: %v", err)
+	}
+	if got := s.propVal(t, key, "synchronizationSourceId"); got != "ptp-gm-1" {
+		t.Errorf("synchronizationSourceId = %v", got)
+	}
+	if got := asInt(s.propVal(t, key, "externalSynchronizationStatus")); got != monStatusPartiallyHealthy {
+		t.Fatalf("extSync right after change = %d, want PartiallyHealthy", got)
+	}
+	if got := asInt(s.propVal(t, key, "externalSynchronizationStatusTransitionCounter")); got != 1 {
+		t.Errorf("extSync counter = %d, want 1", got)
+	}
+	// Recovery lands Healthy (a sync source is in use now, not
+	// NotUsed) after the reporting delay.
+	waitStatus(t, s, key, "externalSynchronizationStatus", monStatusHealthy, 3*time.Second)
+}
+
+func TestMonitorHealthPacketCountersAndReset(t *testing.T) {
+	s, rid, key := engineFixture(t)
+	role := "ReceiverMonitor-00"
+	s.SetMonitorActive(rid, true)
+
+	if err := s.AddMonitorPacketCounters(role, "late", "session", 7); err != nil {
+		t.Fatalf("add counters: %v", err)
+	}
+	if err := s.AddMonitorPacketCounters(role, "late", "session", 3); err != nil {
+		t.Fatalf("add counters: %v", err)
+	}
+	s.mu.RLock()
+	oid := s.objects[key].oid
+	s.mu.RUnlock()
+	got := s.MonitorPacketCounters(oid, "late")
+	if len(got) != 1 || got[0].Name != "session" || got[0].Value != 10 {
+		t.Fatalf("late counters = %+v, want one 'session' entry at 10", got)
+	}
+
+	// Reset clears injected packet counters with everything else.
+	s.mu.Lock()
+	changes := s.resetCountersLocked(key, s.objects[key])
+	s.mu.Unlock()
+	_ = changes
+	if got := s.MonitorPacketCounters(oid, "late"); len(got) != 0 {
+		t.Fatalf("late counters after reset = %+v, want empty", got)
+	}
+}
+
+func TestFaultMethodArgValidation(t *testing.T) {
+	s, rid, _ := engineFixture(t)
+	s.SetMonitorActive(rid, true)
+
+	cases := []struct {
+		name string
+		args string
+	}{
+		{"InjectMonitorFault", `{}`},
+		{"InjectMonitorFault", `{"monitorRole":"ReceiverMonitor-00","domain":"linkStatus","status":7}`},
+		{"InjectMonitorFault", `{"monitorRole":"nope","domain":"linkStatus","status":3}`},
+		{"InjectMonitorFault", `{"monitorRole":"ReceiverMonitor-00","domain":"gainDb","status":3}`},
+		{"ClearMonitorFault", `{"monitorRole":"ReceiverMonitor-00"}`},
+		{"SetMonitorSyncSource", `{"monitorRole":"ReceiverMonitor-00"}`},
+		{"AddMonitorPacketCounters", `{"monitorRole":"ReceiverMonitor-00","counter":"weird","name":"x"}`},
+		{"NoSuchMethod", `{"monitorRole":"ReceiverMonitor-00"}`},
+	}
+	for _, tc := range cases {
+		if err := s.invokeFaultMethod(tc.name, []byte(tc.args)); err == nil {
+			t.Errorf("%s(%s) accepted, want error", tc.name, tc.args)
+		}
+	}
+
+	if err := s.invokeFaultMethod("InjectMonitorFault",
+		[]byte(`{"monitorRole":"ReceiverMonitor-00","domain":"linkStatus","status":3,"message":"drill"}`)); err != nil {
+		t.Errorf("valid inject rejected: %v", err)
+	}
+}

--- a/internal/amwa/provider/ncp.go
+++ b/internal/amwa/provider/ncp.go
@@ -228,16 +228,29 @@ func (s *IS12NCPServer) runCommand(cmd is12.Command) is12.MethodResult {
 		return s.methodGetControlClass(obj, cmd.Arguments)
 	case is12.MethodID{Level: 3, Index: 2}: // ClassManager.GetDatatype
 		return s.methodGetDatatype(obj, cmd.Arguments)
-	case is12.MethodID{Level: 4, Index: 1}, is12.MethodID{Level: 4, Index: 2}, is12.MethodID{Level: 4, Index: 3}:
+	case is12.MethodID{Level: 4, Index: 1}, is12.MethodID{Level: 4, Index: 2},
+		is12.MethodID{Level: 4, Index: 3}, is12.MethodID{Level: 4, Index: 4}:
 		// BCP-008 monitor methods (NcReceiverMonitor 4m1/4m2 counter
 		// getters + 4m3 reset; NcSenderMonitor 4m1 getter + 4m2 reset).
-		if classDerivedFrom(obj.classID, ms05.NcClassId{1, 2, 2}) {
+		if classDerivedFrom(obj.classID, ms05.NcClassId{1, 2, 2}) && cmd.MethodID.Index <= 3 {
 			return s.methodMonitor(obj, cmd.MethodID)
 		}
 		// DhsGainControl.SetGainDb shares the 4m1 slot on a different
 		// class branch.
 		if cmd.MethodID == (is12.MethodID{Level: 4, Index: 1}) && classKey(obj.classID) == classKey(vendorClassID) {
 			return s.methodSetGainDb(obj, cmd.Arguments)
+		}
+		// DhsFaultControl 4m1-4m4: dispatch by declared method name so
+		// IS-12 and IS-14 REST invoke share one implementation.
+		if classKey(obj.classID) == classKey(faultClassID) {
+			for _, md := range obj.class.Methods {
+				if int(md.ID.Level) == cmd.MethodID.Level && int(md.ID.Index) == cmd.MethodID.Index && isFaultMethod(md.Name) {
+					if err := s.config.invokeFaultMethod(md.Name, cmd.Arguments); err != nil {
+						return ncpErr(ms05.NcMethodStatusParameterError, err.Error())
+					}
+					return ncpOK()
+				}
+			}
 		}
 	}
 	return ncpErr(ms05.NcMethodStatusMethodNotImplemented,
@@ -592,10 +605,11 @@ func (s *IS12NCPServer) methodGetDatatype(obj *configObject, args json.RawMessag
 	return ncpOKValue(dt)
 }
 
-// methodMonitor implements the BCP-008 monitor methods. A reference
-// node carries no media plane, so the packet/error counter getters
-// truthfully answer an empty counter list; reset clears the transition
-// counters and messages the model does carry.
+// methodMonitor implements the BCP-008 monitor methods. Reset routes
+// through the health engine (transition counters, status messages AND
+// the injected packet counters all clear together); the counter
+// getters answer whatever DhsFaultControl injected — the empty list
+// is the truthful default for a node with no media plane.
 func (s *IS12NCPServer) methodMonitor(obj *configObject, id is12.MethodID) is12.MethodResult {
 	isReceiver := classDerivedFrom(obj.classID, ms05.NcClassId{1, 2, 2, 1})
 	resetIdx := 2 // NcSenderMonitor.ResetCountersAndMessages = 4m2
@@ -604,19 +618,27 @@ func (s *IS12NCPServer) methodMonitor(obj *configObject, id is12.MethodID) is12.
 	}
 	if id.Index == resetIdx {
 		s.config.mu.Lock()
-		for _, p := range obj.props {
-			if strings.HasSuffix(p.desc.Name, "TransitionCounter") {
-				p.value = uint64(0)
-			}
-			if strings.HasSuffix(p.desc.Name, "Message") && p.desc.IsNullable {
-				p.value = nil
-			}
-		}
+		key := strings.Join(obj.path, ".")
+		changes := s.config.resetCountersLocked(key, obj)
 		s.config.mu.Unlock()
+		s.config.fire(changes)
 		return ncpOK()
 	}
-	// Remaining indices are counter getters.
-	return ncpOKValue([]any{})
+	// Remaining indices are counter getters: receivers 4m1 lost / 4m2
+	// late, senders 4m1 transmission errors.
+	kind := "transmission"
+	if isReceiver {
+		kind = "lost"
+		if id.Index == 2 {
+			kind = "late"
+		}
+	}
+	counters := s.config.MonitorPacketCounters(obj.oid, kind)
+	out := make([]any, 0, len(counters))
+	for _, c := range counters {
+		out = append(out, c)
+	}
+	return ncpOKValue(out)
 }
 
 // attachNCPAPI mounts IS-12 and advertises it on every Device. The

--- a/internal/amwa/provider/vendor_fault.go
+++ b/internal/amwa/provider/vendor_fault.go
@@ -1,0 +1,177 @@
+// The DhsFaultControl worker — the vendor-class seam that lets an
+// operator (or the Ansible verify plays) drive the BCP-008 monitor
+// health engine over the standard wire.
+//
+// Every monitor status property is read-only by class definition, so
+// neither the AMWA tool nor a controller can induce a fault through
+// NcObject.Set — which is exactly why the tool marks its
+// fault-transition tests Manual. This worker turns "manually force an
+// error condition" into four spec-legal method invocations (MS-05-02
+// authority-key 0, the DhsGainControl pattern), reachable over IS-12
+// AND over IS-14's rolePaths/{path}/methods/{id} REST invoke:
+//
+//	4m1 InjectMonitorFault(monitorRole, domain, status, message)
+//	4m2 ClearMonitorFault(monitorRole, domain)
+//	4m3 SetMonitorSyncSource(monitorRole, sourceId)
+//	4m4 AddMonitorPacketCounters(monitorRole, counter, name, increment)
+//
+// The methods only ever feed the health engine (monitor_health.go),
+// so injected transitions get the same debounce, transition counters,
+// status messages, and overallStatus mapping as organic ones.
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"dhs/internal/amwa/codec/ms05"
+)
+
+const (
+	faultClassName = "DhsFaultControl"
+	faultRole      = "FaultControl"
+)
+
+// faultClassID: NcWorker branch, authority key 0, class 2 (class 1 is
+// DhsGainControl).
+var faultClassID = ms05.NcClassId{1, 2, 0, 2}
+
+// vendorFaultClass is the DhsFaultControl descriptor (own elements
+// only, like every published model file).
+func vendorFaultClass() ms05.NcClassDescriptor {
+	str := func(name, desc string) ms05.NcParameterDescriptor {
+		return ms05.NcParameterDescriptor{
+			NcDescriptor: ms05.NcDescriptor{Description: strp(desc)},
+			Name:         name,
+			TypeName:     strp("NcString"),
+		}
+	}
+	return ms05.NcClassDescriptor{
+		NcDescriptor: ms05.NcDescriptor{Description: strp("dhs fault injection for BCP-008 status monitors")},
+		ClassID:      faultClassID,
+		Name:         faultClassName,
+		FixedRole:    strp(faultRole),
+		Properties:   []ms05.NcPropertyDescriptor{},
+		Methods: []ms05.NcMethodDescriptor{
+			{
+				NcDescriptor:   ms05.NcDescriptor{Description: strp("Force a domain status on a monitor")},
+				ID:             ms05.NcMethodId{Level: 4, Index: 1},
+				Name:           "InjectMonitorFault",
+				ResultDatatype: "NcMethodResult",
+				Parameters: []ms05.NcParameterDescriptor{
+					str("monitorRole", "Monitor role, e.g. ReceiverMonitor-00"),
+					str("domain", "Status property name, e.g. linkStatus"),
+					{
+						NcDescriptor: ms05.NcDescriptor{Description: strp("Status enum value (2 PartiallyHealthy, 3 Unhealthy)")},
+						Name:         "status",
+						TypeName:     strp("NcUint64"),
+					},
+					str("message", "Status message accompanying the fault"),
+				},
+			},
+			{
+				NcDescriptor:   ms05.NcDescriptor{Description: strp("Clear an injected fault (recovery is delayed by statusReportingDelay)")},
+				ID:             ms05.NcMethodId{Level: 4, Index: 2},
+				Name:           "ClearMonitorFault",
+				ResultDatatype: "NcMethodResult",
+				Parameters: []ms05.NcParameterDescriptor{
+					str("monitorRole", "Monitor role"),
+					str("domain", "Status property name"),
+				},
+			},
+			{
+				NcDescriptor:   ms05.NcDescriptor{Description: strp("Change the synchronization source (dips to PartiallyHealthy)")},
+				ID:             ms05.NcMethodId{Level: 4, Index: 3},
+				Name:           "SetMonitorSyncSource",
+				ResultDatatype: "NcMethodResult",
+				Parameters: []ms05.NcParameterDescriptor{
+					str("monitorRole", "Monitor role"),
+					str("sourceId", "New synchronization source id"),
+				},
+			},
+			{
+				NcDescriptor:   ms05.NcDescriptor{Description: strp("Accumulate a late/lost/transmission packet counter")},
+				ID:             ms05.NcMethodId{Level: 4, Index: 4},
+				Name:           "AddMonitorPacketCounters",
+				ResultDatatype: "NcMethodResult",
+				Parameters: []ms05.NcParameterDescriptor{
+					str("monitorRole", "Monitor role"),
+					str("counter", "Counter kind: late, lost or transmission"),
+					str("name", "Counter entry name"),
+					{
+						NcDescriptor: ms05.NcDescriptor{Description: strp("Amount to add")},
+						Name:         "increment",
+						TypeName:     strp("NcUint64"),
+					},
+				},
+			},
+		},
+		Events: []ms05.NcEventDescriptor{},
+	}
+}
+
+// faultArgs is the union argument shape of all four methods.
+type faultArgs struct {
+	MonitorRole string `json:"monitorRole"`
+	Domain      string `json:"domain"`
+	Status      *int   `json:"status"`
+	Message     string `json:"message"`
+	SourceID    string `json:"sourceId"`
+	Counter     string `json:"counter"`
+	Name        string `json:"name"`
+	Increment   uint64 `json:"increment"`
+}
+
+// invokeFaultMethod runs one DhsFaultControl method by name against
+// the health engine. Shared by the IS-12 and IS-14 dispatchers.
+func (s *IS14ConfigurationServer) invokeFaultMethod(name string, rawArgs json.RawMessage) error {
+	var a faultArgs
+	if len(rawArgs) > 0 {
+		if err := json.Unmarshal(rawArgs, &a); err != nil {
+			return fmt.Errorf("%s: %w", name, err)
+		}
+	}
+	if a.MonitorRole == "" {
+		return fmt.Errorf("%s: monitorRole argument required", name)
+	}
+	switch name {
+	case "InjectMonitorFault":
+		if a.Domain == "" || a.Status == nil {
+			return fmt.Errorf("InjectMonitorFault: domain and status arguments required")
+		}
+		if *a.Status < monStatusPartiallyHealthy || *a.Status > monStatusUnhealthy {
+			return fmt.Errorf("InjectMonitorFault: status must be 2 (PartiallyHealthy) or 3 (Unhealthy), got %d", *a.Status)
+		}
+		return s.SetMonitorFault(a.MonitorRole, a.Domain, *a.Status, a.Message)
+	case "ClearMonitorFault":
+		if a.Domain == "" {
+			return fmt.Errorf("ClearMonitorFault: domain argument required")
+		}
+		return s.SetMonitorFault(a.MonitorRole, a.Domain, monStatusHealthy, "")
+	case "SetMonitorSyncSource":
+		if a.SourceID == "" {
+			return fmt.Errorf("SetMonitorSyncSource: sourceId argument required")
+		}
+		return s.SetMonitorSyncSource(a.MonitorRole, a.SourceID)
+	case "AddMonitorPacketCounters":
+		switch a.Counter {
+		case "late", "lost", "transmission":
+		default:
+			return fmt.Errorf("AddMonitorPacketCounters: counter must be late, lost or transmission, got %q", a.Counter)
+		}
+		if a.Name == "" {
+			return fmt.Errorf("AddMonitorPacketCounters: name argument required")
+		}
+		return s.AddMonitorPacketCounters(a.MonitorRole, a.Counter, a.Name, a.Increment)
+	}
+	return fmt.Errorf("no DhsFaultControl method %q", name)
+}
+
+// faultMethodNames gates the by-name dispatch.
+func isFaultMethod(name string) bool {
+	switch name {
+	case "InjectMonitorFault", "ClearMonitorFault", "SetMonitorSyncSource", "AddMonitorPacketCounters":
+		return true
+	}
+	return false
+}

--- a/internal/amwa/provider/vendor_gain.go
+++ b/internal/amwa/provider/vendor_gain.go
@@ -159,5 +159,8 @@ func registerVendorModels() {
 		if err := ms05.RegisterDatatype(vendorGainDatatype()); err != nil {
 			panic("provider: vendor datatype registration: " + err.Error())
 		}
+		if err := ms05.RegisterClass(vendorFaultClass()); err != nil {
+			panic("provider: fault class registration: " + err.Error())
+		}
 	})
 }

--- a/internal/amwa/registry/subscriptions.go
+++ b/internal/amwa/registry/subscriptions.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -129,6 +130,26 @@ type subscription struct {
 	// to its own api_ver.
 	downgrade string
 
+	// ancestry* mirror the IS-04 §6.1.5 `query.ancestry_*` control
+	// params on the Query WS, validated at POST time with the same
+	// rules as the REST path (parseAncestry). ancestryType empty means
+	// no ancestry filter.
+	//
+	// Store listeners run under the store's lock, so membership can't
+	// be answered by calling Store.ParentsIndex from the fan-out path.
+	// Instead the subscription keeps its own id→parents index (ancMu),
+	// seeded from the sync snapshot at WS-upgrade time and maintained
+	// incrementally from the change stream. Membership is evaluated
+	// for the CHANGED resource only: a change that silently re-shapes
+	// another resource's ancestry emits no synthetic grain for that
+	// other resource — the same point-in-time semantics a REST poll
+	// has between two GETs.
+	ancestryID   string
+	ancestryType string
+	ancestryGens int
+	ancMu        sync.Mutex
+	ancIndex     map[string][]string
+
 	ws      *httpsession.WebSocket
 	source  string // sub UUID echoed in grain.source_id
 	closeCh chan struct{}
@@ -235,6 +256,43 @@ func (m *SubscriptionManager) HandlePost(base string) httpsession.HandlerFunc {
 			downgrade = vs[0]
 			delete(params, "query.downgrade")
 		}
+		// Ancestry control params get the same POST-time validation the
+		// Query API GET path applies (parseAncestry) — reject early with
+		// the same status codes rather than silently dropping the filter
+		// in the strip loop below.
+		ancID, ancType, ancGens := "", "", 0
+		if hasAncestryFilter(params) {
+			if _, ok := ancestryTypeForPath(req.ResourcePath); !ok {
+				return stdhttp.StatusNotImplemented, httpsession.ErrorBody{
+					Code: 501, Error: "Not Implemented",
+					Debug: "ancestry queries apply to sources and flows; this registry does not define them for " + req.ResourcePath,
+				}, nil
+			}
+			ancID = first(params["query.ancestry_id"])
+			ancType = first(params["query.ancestry_type"])
+			if ancID == "" || ancType == "" {
+				return stdhttp.StatusBadRequest, httpsession.ErrorBody{
+					Code: 400, Error: "Bad Request",
+					Debug: "query.ancestry_id and query.ancestry_type must be supplied together",
+				}, nil
+			}
+			if ancType != ancestryChildren && ancType != ancestryParents {
+				return stdhttp.StatusBadRequest, httpsession.ErrorBody{
+					Code: 400, Error: "Bad Request",
+					Debug: "query.ancestry_type must be \"children\" or \"parents\", got " + ancType,
+				}, nil
+			}
+			if g := first(params["query.ancestry_generations"]); g != "" {
+				n, err := strconv.Atoi(g)
+				if err != nil || n < 1 {
+					return stdhttp.StatusBadRequest, httpsession.ErrorBody{
+						Code: 400, Error: "Bad Request",
+						Debug: "query.ancestry_generations must be a positive integer, got " + g,
+					}, nil
+				}
+				ancGens = n
+			}
+		}
 		// Strip pagination + non-rql control params — they're not
 		// equality filters. Keep `query.rql` (the RQL predicate) so
 		// jsonMatchesFilter can honor it. Same handling as the Query
@@ -261,6 +319,9 @@ func (m *SubscriptionManager) HandlePost(base string) httpsession.HandlerFunc {
 			MaxUpdateRate: req.MaxUpdateRate,
 			params:        params,
 			downgrade:     downgrade,
+			ancestryID:    ancID,
+			ancestryType:  ancType,
+			ancestryGens:  ancGens,
 			source:        id,
 			closeCh:       make(chan struct{}),
 		}
@@ -459,7 +520,9 @@ func (m *SubscriptionManager) UpgradeHandler(base string) func(stdhttp.ResponseW
 		now := time.Now()
 		var order []string
 		byTopic := map[string][]Change{}
-		for _, c := range m.store.SnapshotChanges(m.apiVer) {
+		snapshot := m.store.SnapshotChanges(m.apiVer)
+		sub.seedAncestry(snapshot)
+		for _, c := range snapshot {
 			if !subscriptionMatches(sub.ResourcePath, c) {
 				continue
 			}
@@ -467,6 +530,9 @@ func (m *SubscriptionManager) UpgradeHandler(base string) func(stdhttp.ResponseW
 				continue
 			}
 			if !jsonMatchesFilter(c.Post, sub.params) && len(sub.params) > 0 {
+				continue
+			}
+			if !sub.ancestryMember(c.ID) {
 				continue
 			}
 			topic := "/" + c.ResourceType.Plural() + "/"
@@ -543,7 +609,11 @@ func (m *SubscriptionManager) onChange(c Change) {
 		// the wire. After projection, re-encode the surviving
 		// pre/post bodies via the wire codec so the subscriber
 		// only sees fields that exist in their wire minor.
-		projected, ok := projectChange(c, s.params)
+		projected, ok := s.ancestryProject(c)
+		if !ok {
+			continue
+		}
+		projected, ok = projectChange(projected, s.params)
 		if !ok {
 			continue
 		}
@@ -721,6 +791,109 @@ func projectChange(c Change, params map[string][]string) (Change, bool) {
 		} else {
 			out.Kind = ChangeUpdated
 		}
+	case len(out.Pre) > 0:
+		out.Kind = ChangeDeleted
+	case len(out.Post) > 0:
+		out.Kind = ChangeCreated
+	}
+	return out, true
+}
+
+// ancestryTypeForPath maps a subscription resource_path to the IS-04
+// kind ancestry is defined for. Only Sources and Flows carry
+// `parents` — every other path answers (zero, false), which the POST
+// handler turns into the same 501 the REST path uses.
+func ancestryTypeForPath(resourcePath string) (is04.ResourceType, bool) {
+	switch strings.Trim(resourcePath, "/") {
+	case "sources":
+		return is04.ResourceSource, true
+	case "flows":
+		return is04.ResourceFlow, true
+	}
+	return "", false
+}
+
+// parentsFromBody pulls the `parents` array out of a Source/Flow JSON
+// body. A missing or malformed field reads as no parents.
+func parentsFromBody(data json.RawMessage) []string {
+	if len(data) == 0 {
+		return nil
+	}
+	var v struct {
+		Parents []string `json:"parents"`
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return nil
+	}
+	return v.Parents
+}
+
+// seedAncestry (re)builds the subscription's local parents index from
+// the sync snapshot rows of the subscribed kind. Runs at WS-upgrade
+// time, before the snapshot is filtered, so the sync grains and the
+// index agree on one point in time.
+func (s *subscription) seedAncestry(snapshot []Change) {
+	if s.ancestryType == "" {
+		return
+	}
+	idx := make(map[string][]string, len(snapshot))
+	for _, c := range snapshot {
+		if !subscriptionMatches(s.ResourcePath, c) || len(c.Post) == 0 {
+			continue
+		}
+		idx[c.ID] = parentsFromBody(c.Post)
+	}
+	s.ancMu.Lock()
+	s.ancIndex = idx
+	s.ancMu.Unlock()
+}
+
+// ancestryMember answers whether id is currently selected by the
+// subscription's ancestry filter. Callers without a filter always get
+// true.
+func (s *subscription) ancestryMember(id string) bool {
+	if s.ancestryType == "" {
+		return true
+	}
+	s.ancMu.Lock()
+	defer s.ancMu.Unlock()
+	return ancestrySet(s.ancIndex, s.ancestryID, s.ancestryType, s.ancestryGens)[id]
+}
+
+// ancestryProject applies the ancestry filter to one live change:
+// updates the local index with the change, then clips the grain to the
+// changed resource's membership transition — entering the set drops
+// pre, leaving it drops post, outside on both sides emits nothing.
+// Mirrors projectChange's filter-set semantics.
+func (s *subscription) ancestryProject(c Change) (Change, bool) {
+	if s.ancestryType == "" {
+		return c, true
+	}
+	s.ancMu.Lock()
+	if s.ancIndex == nil {
+		s.ancIndex = map[string][]string{}
+	}
+	before := ancestrySet(s.ancIndex, s.ancestryID, s.ancestryType, s.ancestryGens)[c.ID]
+	if len(c.Post) > 0 {
+		s.ancIndex[c.ID] = parentsFromBody(c.Post)
+	} else {
+		delete(s.ancIndex, c.ID)
+	}
+	after := ancestrySet(s.ancIndex, s.ancestryID, s.ancestryType, s.ancestryGens)[c.ID]
+	s.ancMu.Unlock()
+	if !before && !after {
+		return c, false
+	}
+	out := c
+	if !before {
+		out.Pre = nil
+	}
+	if !after {
+		out.Post = nil
+	}
+	switch {
+	case len(out.Pre) > 0 && len(out.Post) > 0:
+		out.Kind = ChangeUpdated
 	case len(out.Pre) > 0:
 		out.Kind = ChangeDeleted
 	case len(out.Post) > 0:

--- a/internal/amwa/registry/subscriptions_ancestry_test.go
+++ b/internal/amwa/registry/subscriptions_ancestry_test.go
@@ -1,0 +1,179 @@
+package registry
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	stdhttp "net/http"
+	"testing"
+
+	"dhs/internal/amwa/codec/is04"
+)
+
+// postSubscription POSTs a raw SubscriptionRequest and returns the
+// status code + decoded body.
+func postSubscription(t *testing.T, base string, req SubscriptionRequest) (int, []byte) {
+	t.Helper()
+	body, _ := json.Marshal(req)
+	resp, err := stdhttp.Post(base+"/x-nmos/query/v1.3/subscriptions",
+		"application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /subscriptions: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, raw
+}
+
+// TestSubscriptionAncestryPostValidation: the Query WS accepts the
+// same query.ancestry_* control params as the REST listing, with the
+// same rejection codes — 501 off sources/flows, 400 when malformed.
+// Before this landed the params were silently stripped with the rest
+// of query.*, so a subscriber got an unfiltered firehose while its
+// subscription echoed the ancestry params back as if honored.
+func TestSubscriptionAncestryPostValidation(t *testing.T) {
+	store := NewStore()
+	mgr := NewSubscriptionManager(nil, store, "127.0.0.1:0", "v1.3")
+	base, stop := startRegistryHTTP(t, store, mgr)
+	defer stop()
+	a, _, _ := seedAncestryChain(t, store)
+
+	cases := []struct {
+		name   string
+		path   string
+		params map[string]string
+		want   int
+	}{
+		{"valid children filter on /sources", "/sources",
+			map[string]string{"query.ancestry_id": a, "query.ancestry_type": "children"}, 201},
+		{"ancestry undefined for /senders", "/senders",
+			map[string]string{"query.ancestry_id": a, "query.ancestry_type": "children"}, 501},
+		{"id without type", "/sources",
+			map[string]string{"query.ancestry_id": a}, 400},
+		{"bad type", "/sources",
+			map[string]string{"query.ancestry_id": a, "query.ancestry_type": "cousins"}, 400},
+		{"bad generations", "/sources",
+			map[string]string{"query.ancestry_id": a, "query.ancestry_type": "children",
+				"query.ancestry_generations": "zero"}, 400},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			params := map[string]any{}
+			for k, v := range tc.params {
+				params[k] = v
+			}
+			code, body := postSubscription(t, "http://"+base, SubscriptionRequest{
+				ResourcePath: tc.path, Params: params,
+			})
+			if code != tc.want {
+				t.Fatalf("HTTP %d, want %d: %s", code, tc.want, body)
+			}
+		})
+	}
+}
+
+// subForAncestry builds a bare subscription with an ancestry filter
+// seeded from the store's snapshot — the exact state a WS-upgraded
+// subscriber holds after the sync grains went out.
+func subForAncestry(store *Store, rootID, typ string, gens int) *subscription {
+	s := &subscription{
+		ResourcePath: "/sources",
+		ancestryID:   rootID,
+		ancestryType: typ,
+		ancestryGens: gens,
+	}
+	s.seedAncestry(store.SnapshotChanges("v1.3"))
+	return s
+}
+
+func TestSubscriptionAncestrySyncMembership(t *testing.T) {
+	store := NewStore()
+	a, b, c := seedAncestryChain(t, store)
+	sub := subForAncestry(store, a, ancestryChildren, 0)
+
+	for id, want := range map[string]bool{a: false, b: true, c: true} {
+		if got := sub.ancestryMember(id); got != want {
+			t.Errorf("member(%s) = %v, want %v", id, got, want)
+		}
+	}
+
+	// One generation only: C drops out.
+	sub1 := subForAncestry(store, a, ancestryChildren, 1)
+	if !sub1.ancestryMember(b) || sub1.ancestryMember(c) {
+		t.Errorf("1-generation filter: member(B)=%v member(C)=%v, want true/false",
+			sub1.ancestryMember(b), sub1.ancestryMember(c))
+	}
+}
+
+// TestSubscriptionAncestryLiveProjection: live changes are clipped to
+// the changed resource's membership transition, mirroring
+// projectChange's enter/leave semantics.
+func TestSubscriptionAncestryLiveProjection(t *testing.T) {
+	store := NewStore()
+	a, b, _ := seedAncestryChain(t, store)
+	sub := subForAncestry(store, a, ancestryChildren, 0)
+
+	body := func(id string, parents ...string) json.RawMessage {
+		if parents == nil {
+			parents = []string{}
+		}
+		raw, _ := json.Marshal(map[string]any{"id": id, "parents": parents})
+		return raw
+	}
+
+	d := "9c000000-0000-4000-8000-00000000000d"
+
+	t.Run("new descendant enters the set", func(t *testing.T) {
+		got, ok := sub.ancestryProject(Change{
+			Kind: ChangeCreated, ResourceType: is04.ResourceSource,
+			ID: d, Post: body(d, b),
+		})
+		if !ok || got.Kind != ChangeCreated || len(got.Post) == 0 {
+			t.Fatalf("ok=%v kind=%v post=%d bytes — want a created grain", ok, got.Kind, len(got.Post))
+		}
+	})
+
+	t.Run("reparent away leaves the set as a delete", func(t *testing.T) {
+		got, ok := sub.ancestryProject(Change{
+			Kind: ChangeUpdated, ResourceType: is04.ResourceSource,
+			ID: d, Pre: body(d, b), Post: body(d),
+		})
+		if !ok || got.Kind != ChangeDeleted || got.Post != nil {
+			t.Fatalf("ok=%v kind=%v — want a pre-only deleted grain", ok, got.Kind)
+		}
+	})
+
+	t.Run("outside on both sides emits nothing", func(t *testing.T) {
+		e := "9c000000-0000-4000-8000-00000000000e"
+		if _, ok := sub.ancestryProject(Change{
+			Kind: ChangeCreated, ResourceType: is04.ResourceSource,
+			ID: e, Post: body(e),
+		}); ok {
+			t.Fatal("orphan source must not pass a children-of-A filter")
+		}
+	})
+
+	t.Run("root is not its own child", func(t *testing.T) {
+		if _, ok := sub.ancestryProject(Change{
+			Kind: ChangeUpdated, ResourceType: is04.ResourceSource,
+			ID: a, Pre: body(a), Post: body(a),
+		}); ok {
+			t.Fatal("the ancestry root must not match its own filter")
+		}
+	})
+}
+
+// TestSubscriptionWithoutAncestryUnchanged pins the no-filter fast
+// path: every change passes through untouched.
+func TestSubscriptionWithoutAncestryUnchanged(t *testing.T) {
+	sub := &subscription{ResourcePath: "/sources"}
+	in := Change{Kind: ChangeUpdated, ResourceType: is04.ResourceSource,
+		ID: "x", Pre: json.RawMessage(`{"id":"x"}`), Post: json.RawMessage(`{"id":"x"}`)}
+	got, ok := sub.ancestryProject(in)
+	if !ok || got.Kind != ChangeUpdated || len(got.Pre) == 0 || len(got.Post) == 0 {
+		t.Fatalf("no-filter path altered the change: ok=%v kind=%v", ok, got.Kind)
+	}
+	if !sub.ancestryMember("anything") {
+		t.Fatal("no-filter membership must be universal")
+	}
+}


### PR DESCRIPTION
Closes #956.

Phase 2 of the AMWA validation program: the BCP-008 fault-transition Manual rows and BCP-007-03 test_15 are machine-verified, and IS-04 ancestry works on the Query WS. Design grounded in the tool's own suite code (pulled from the nmos-testing container — `BCP008Test.py` and derivatives), per the standing no-speculation rule.

## Fleet receipts

Targeted rerun after the one live-caught fix, then the full umbrella confirm at the committed baselines:

```
BCP-008-01-01    OK   pass=98/98 fail=0 cnt=0/0 warn=0
BCP-008-02-01    OK   pass=98/98 fail=0 cnt=0/0 warn=0
```

`amwa-verify-manual.yml` drill window, all first-run green:

```
BCP-008 test_04        fault clear held by reporting delay  PASS
BCP-008 test_11        sync change dips PartiallyHealthy    PASS
BCP-008-01 test_15/16  late counters inject/get/reset       PASS
BCP-008-02 test_15     tx error counters inject/get/reset   PASS
BCP-007-03 test_15     MXL monitors track master_enable     PASS
```

Full umbrella confirm at the committed baselines — every scope, `rc=0`:

```
node       18 suites at or above baseline, 0 failures   (BCP-008-01/02 98/98, IS-04-01 59/59)
controller  4 suites at or above baseline, 0 failures   (4/4, 4/4, 5/5, 4/4)
mirror      IS-04-02 73/73 cnt 2/2
auth        IS-04-02 88/88 cnt 2/2, IS-05-01 67/67
tls         BCP-003-01 7/7 warn 0
```

## 1. BCP-008 honest monitor health engine (`monitor_health.go`)

The monitors were scaffolding: `SetMonitorActive` wrote Healthy/Inactive once and nothing else ever moved. The tool's conditional-Manual rows (test_03/05/06/07) score PASS exactly when the device does what the suites' own comment says: *"there is no actual stream so we expect connection to transition to a less healthy state after the status reporting delay"*. The engine now delivers: Healthy immediately on activation (autoResetCounters honored), the stream domain degrades to Unhealthy with a message once `statusReportingDelay` expires — the truth of a reference node with no media plane — transition counters increment on every move to a strictly-less-healthy value, `overallStatus` is derived (Inactive rule + max mapping, the suites' exact check), recoveries are delayed by the reporting delay, and deactivation goes straight to Inactive with timers cancelled. **+4 passes per suite** (3 Manual conversions + test_08's mapping check now exercised and green).

## 2. `DhsFaultControl` vendor worker (`vendor_fault.go`)

The unconditional-Manual rows (`return test.MANUAL(...)` — test_04, test_11, the packet-counter tests, BCP-007-03 test_15) can never be tool-scored, and every monitor status property is read-only by class definition. The worker (vendor NcWorker, authority key 0, the DhsGainControl pattern) exposes InjectMonitorFault / ClearMonitorFault / SetMonitorSyncSource / AddMonitorPacketCounters over IS-12 **and** IS-14's `rolePaths/{path}/methods/{id}` PATCH — so the Ansible drills drive it with plain `uri`. Everything feeds the same engine: injected transitions get identical debounce, counters, messages, and mapping. Monitor reset + counter getters are now also invocable over IS-14 by name.

## 3. Ansible drill window (`amwa-verify-manual.yml`)

A transient direct-mode node (activations never touch the registered resident fleet) drives all six formerly-Manual rows: delayed recovery after fault clear, the PartiallyHealthy sync-source dip with published source id, packet-counter inject/get/reset on both monitor classes, and BCP-007-03 test_15 as both MXL legs' monitors tracking IS-05 `master_enable` (receiver PATCH carries no transport_file, per the MUST NOT).

## 4. IS-04 ancestry on the Query WS (`subscriptions.go`)

The WS path stripped every `query.*` control param but `query.rql`, so ancestry params were echoed back while delivering the unfiltered firehose. POST now validates the trio with the exact REST rules (501 off sources/flows, 400 malformed); membership rides a per-subscription parents index (store listeners run under the store's lock, so `ParentsIndex` can't be called from fan-out), seeded from the sync snapshot and maintained from the change stream; live grains are clipped to the changed resource's membership transition, mirroring `projectChange`.

## Live-caught fix

First umbrella run: BCP-008 test_08 failed — `connectionStatus=Unhealthy` landed inside the tool's no-tolerance mid-window aggregation cutoff while the following `overallStatus` landed outside, because the grace timer fired at exactly `delay` from the activation instant while the tool clocks the window from its *receipt* of the Healthy notification. The delay is a spec minimum, so the hold now pads 500 ms past it (`monGraceMargin`), clearing the cutoff deterministically — well inside the suites' delay+2 s observation sleep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
