### PR TITLE
feat(amwa+ansible): IS-09-01 System API server suite - the catalog is complete (#958)

### DIFF
--- a/ansible/roles/dhs_amwa_validate/defaults/main.yml
+++ b/ansible/roles/dhs_amwa_validate/defaults/main.yml
@@ -297,7 +297,7 @@ dhs_amwa_validate_suites:
   # pure GenericTest (auto RAML/schema rows only); the window serves a
   # transient `--role system` with an authored /global on the CuT port.
   - { id: IS-09-01, scope: node, target: cut, window: system,
-      rows: [{ver: v1.0}], baseline_pass: 0, baseline_cnt: 0 }
+      rows: [{ver: v1.0}], baseline_pass: 5, baseline_cnt: 0 }
   # IS-04-03 scores peer-to-peer mode: a registered node MUST NOT
   # advertise _nmos-node._tcp (IS-04 §4.2.1), so P2P needs its own
   # --no-registry transient.

--- a/ansible/roles/dhs_amwa_validate/defaults/main.yml
+++ b/ansible/roles/dhs_amwa_validate/defaults/main.yml
@@ -292,6 +292,12 @@ dhs_amwa_validate_suites:
   - { id: IS-09-02, scope: node, target: cut, window: isolated, flaky_retry: true,
       rows: [{ver: v1.3}, {host: null, port: null, ver: v1.0}],
       baseline_pass: 4, baseline_cnt: 0 }
+  # IS-09-01 scores our System API SERVER (issue #958) — the one
+  # registered tool suite that had no row and no receipt anywhere. A
+  # pure GenericTest (auto RAML/schema rows only); the window serves a
+  # transient `--role system` with an authored /global on the CuT port.
+  - { id: IS-09-01, scope: node, target: cut, window: system,
+      rows: [{ver: v1.0}], baseline_pass: 0, baseline_cnt: 0 }
   # IS-04-03 scores peer-to-peer mode: a registered node MUST NOT
   # advertise _nmos-node._tcp (IS-04 §4.2.1), so P2P needs its own
   # --no-registry transient.

--- a/ansible/roles/dhs_amwa_validate/tasks/window_system.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/window_system.yml
@@ -1,0 +1,49 @@
+---
+# System API server window (IS-09-01, issue #958): a transient
+# `--role system` unit on the CuT port serving an authored /global.
+# The suite is a pure GenericTest — auto-generated RAML/schema rows
+# against the System API tree — so the window only has to put a
+# spec-shaped server where the row points. The plant residents stay
+# untouched (no resident serves a System API; Nodes CONSUME one).
+
+- name: Author the transient System API global
+  ansible.builtin.copy:
+    content: |
+      {
+        "id": "0d0a0f0e-0000-4000-8000-000000000958",
+        "version": "1:0",
+        "label": "dhs-validate-system-global",
+        "description": "transient /global for the IS-09-01 window (issue #958)",
+        "tags": {},
+        "is04": { "heartbeat_interval": 5 },
+        "ptp": { "announce_receipt_timeout": 3, "domain_number": 0 }
+      }
+    dest: /opt/dhs-amwa-plant/validate-global.json
+    mode: "0644"
+  delegate_to: "{{ groups['plant'][0] }}"
+
+- name: Start the transient System API
+  ansible.builtin.command: >-
+    systemd-run --unit dhs-nmos-validate-sys --collect
+    {{ dhs_amwa_validate_plant_bin }} producer nmos serve --role system
+    --config /opt/dhs-amwa-plant/validate-global.json
+    --bind 0.0.0.0:{{ dhs_amwa_validate_cut_port }}
+    --no-mdns
+  delegate_to: "{{ groups['plant'][0] }}"
+  changed_when: true
+
+- name: Arm the window safety-stop timer
+  ansible.builtin.command: >-
+    systemd-run --unit dhs-nmos-validate-sysstop --collect
+    --on-active={{ dhs_amwa_validate_window_safety_sec }}
+    systemctl stop dhs-nmos-validate-sys
+  delegate_to: "{{ groups['plant'][0] }}"
+  changed_when: true
+
+- name: Wait for the transient System API
+  ansible.builtin.uri:
+    url: "http://{{ dhs_amwa_validate_plant_host }}:{{ dhs_amwa_validate_cut_port }}/x-nmos/system/v1.0/global"
+  register: _sys_up
+  retries: 15
+  delay: 2
+  until: _sys_up.status == 200

--- a/ansible/roles/dhs_amwa_validate/tasks/window_teardown.yml
+++ b/ansible/roles/dhs_amwa_validate/tasks/window_teardown.yml
@@ -15,6 +15,8 @@
     - dhs-nmos-validate-cutstop.timer
     - dhs-nmos-validate-cutkick.timer
     - dhs-nmos-validate-restore.timer
+    - dhs-nmos-validate-sys
+    - dhs-nmos-validate-sysstop.timer
   delegate_to: "{{ groups['plant'][0] }}"
   failed_when: false
 

--- a/internal/amwa/provider/system.go
+++ b/internal/amwa/provider/system.go
@@ -113,6 +113,21 @@ func (s *IS09Server) Serve(ctx context.Context) error {
 	indexPath := "/x-nmos/system/" + s.cfg.APIVer + "/"
 	globalPath := "/x-nmos/system/" + s.cfg.APIVer + "/global"
 
+	// The base-path indexes above the versioned tree are part of the
+	// RAML surface (the AMWA suite's auto_system_1/2 GET /x-nmos/ and
+	// /x-nmos/system/ — 404s until the IS-09-01 window first scored
+	// this server, issue #958). Same shape the Node server serves.
+	for _, p := range []string{"/x-nmos", "/x-nmos/"} {
+		srv.Handle(stdhttp.MethodGet, p, func(ctx context.Context, r *stdhttp.Request) (int, any, error) {
+			return 0, []string{"system/"}, nil
+		})
+	}
+	for _, p := range []string{"/x-nmos/system", "/x-nmos/system/"} {
+		srv.Handle(stdhttp.MethodGet, p, func(ctx context.Context, r *stdhttp.Request) (int, any, error) {
+			return 0, []string{s.cfg.APIVer + "/"}, nil
+		})
+	}
+
 	srv.Handle(stdhttp.MethodGet, indexPath, func(ctx context.Context, r *stdhttp.Request) (int, any, error) {
 		atomic.AddUint64(&s.indexHits, 1)
 		return 0, is09.IndexBody(), nil

--- a/internal/amwa/provider/system_test.go
+++ b/internal/amwa/provider/system_test.go
@@ -110,6 +110,25 @@ func TestServeEndToEnd(t *testing.T) {
 		t.Fatal("server never came up")
 	}
 
+	// The base-path indexes above the versioned tree (the AMWA
+	// IS-09-01 auto_system_1/2 rows — 404 until #958).
+	for path, want := range map[string]string{
+		"/x-nmos/":        "system/",
+		"/x-nmos/system/": "v1.0/",
+	} {
+		br, err := stdhttp.Get("http://" + addr + path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		bb, _ := io.ReadAll(br.Body)
+		_ = br.Body.Close()
+		var listing []string
+		_ = json.Unmarshal(bb, &listing)
+		if br.StatusCode != 200 || len(listing) != 1 || listing[0] != want {
+			t.Fatalf("GET %s = %d %s, want [%q]", path, br.StatusCode, bb, want)
+		}
+	}
+
 	// GET / index
 	resp, err := stdhttp.Get("http://" + addr + "/x-nmos/system/v1.0/")
 	if err != nil {


### PR DESCRIPTION
Closes #958.

Completes the suite universe: diffing the tool's live `TEST_DEFINITIONS` (26 registered suites) against the validate catalog found exactly one registered suite for an implemented role with no row and no receipt anywhere — IS-09-01, the System API **server** exam. Every registered suite now has a row and a green receipt (IS-06-01 excepted: parked per S5 until a controllable fabric is in scope).

## Fleet receipts

First run (found a real gap), then the fix, then the confirm at the committed baseline:

```
run 1     IS-09-01    FAIL pass=3 fail=2   auto_system_1/2: Incorrect response code: 404
fix                   system.go: serve the /x-nmos and /x-nmos/system base-path indexes
rerun     IS-09-01    OK   pass=5/0
confirm   IS-09-01    OK   pass=5/5, 0 failures
```

## What it is

- **`window_system.yml`**: a transient `dhs producer nmos serve --role system` on the CuT port with an authored `/global` (the amwa-verify-manual pattern) — no resident serves a System API (Nodes *consume* one), so the window puts a spec-shaped server where the row points. Safety timer + teardown wired.
- **Catalog row** `{id: IS-09-01, target: cut, window: system, rows: [{ver: v1.0}], baseline_pass: 5}` — the suite is a pure `GenericTest` (auto RAML/schema rows only, auth autos disabled tool-side).
- **Spec fix the suite immediately earned**: the `--role system` server mounted only the versioned tree; `GET /x-nmos/` and `GET /x-nmos/system/` 404'd. It now serves the base-path listings (`["system/"]`, `["v1.0/"]`) exactly like the Node server does — pinned in `TestServeEndToEnd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
