### PR TITLE
chore(ci): workflow_dispatch trigger - recover dropped push events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,12 @@ name: CI
 on:
   push:
     branches: [main]
+  # Manual trigger for dropped push events: GitHub occasionally fails to
+  # dispatch a workflow for a push (seen live 2026-09-02 — the v0.20.0
+  # release merge c12f9ec7 got zero runs; API total_count 0, status page
+  # all-operational). On main this re-runs the full verification AND the
+  # Release Please job, which recovers a missed release cut.
+  workflow_dispatch:
   pull_request:
     branches: [main]
     # The release-please PR touches ONLY these two bot-owned files and is


### PR DESCRIPTION
GitHub never dispatched a CI run for the v0.20.0 release merge c12f9ec7 (API shows zero runs for the sha 20+ minutes after the push; status page all-operational; the identical v0.19.0 merge this morning triggered normally). With no workflow_dispatch trigger there is no clean way to re-run CI + Release Please on main without pushing a commit. This adds the trigger; merging this PR also generates the fresh push event whose Release Please job cuts the missed v0.20.0.