### PR TITLE
feat(nmos/node): configurable heartbeat cadence - the registry's GC is testable (#855)

### DIFF
--- a/cmd/dhs/cmd_nmos.go
+++ b/cmd/dhs/cmd_nmos.go
@@ -304,7 +304,8 @@ func runNMOSNodeServeLegacy(ctx context.Context, args []string) error {
 	domain := fs.String("domain", "", "search domain the registration SRV records live under (with --unicast)")
 	apiVer := fs.String("api-ver", "v1.3", "IS-04 wire version exposed under /x-nmos/node/<v>")
 	priority := fs.Int("priority", 0, "DNS-SD `pri` TXT (0-99 production, 100+ dev)")
-	registry := fs.String("registry", "", "Registration API base URL — when set, the Node POSTs to /resource + heartbeats every 5 s")
+	registry := fs.String("registry", "", "Registration API base URL — when set, the Node POSTs to /resource + heartbeats at the --heartbeat cadence")
+	heartbeat := fs.Duration("heartbeat", 5*time.Second, "heartbeat cadence for POST /health (IS-04 §6.1 default 5s). An IS-09 System API's heartbeat_interval outranks it when one is found. Sub-second cadences work — the loop's tick and early-fire slack scale down with the value")
 	noConnection := fs.Bool("no-connection-api", false, "do not serve IS-05. The Node stays discoverable and becomes unroutable — useful only to reproduce a discovery-only device")
 	connectionAPIVer := fs.String("connection-api-ver", "", "pin IS-05 to one wire minor (v1.0/v1.1/v1.2). Empty serves every registered minor in parallel, which is what a real product does")
 	systemURL := fs.String("system", "", "IS-09 System API as `host:port`, skipping discovery. Empty browses for one; a Node that finds none serves normally, because IS-09 makes the System API optional")
@@ -347,27 +348,28 @@ func runNMOSNodeServeLegacy(ctx context.Context, args []string) error {
 		mode = "unicast"
 	}
 	cfg := provider.IS04NodeConfig{
-		Bind:             *bind,
-		AdvertiseHost:    *advertise,
-		DiscoveryMode:    mode,
-		Priority:         *priority,
-		APIVer:           *apiVer,
-		RegistryURL:      *registry,
-		UnicastResolver:  *resolver,
-		UnicastDomain:    *domain,
-		NoConnectionAPI:  *noConnection,
-		ConnectionAPIVer: *connectionAPIVer,
-		SystemURL:        *systemURL,
-		NoRegistry:       *noRegistry,
-		AuthURL:          *authURL,
-		AuthClientID:     *authClientID,
-		AuthClientSecret: *authClientSecret,
-		ESTHost:          *estHost,
-		ESTLabel:         *estLabel,
-		TLSCertFile:      tlsCerts.String(),
-		TLSKeyFile:       tlsKeys.String(),
-		TLSCAFile:        *tlsCA,
-		TLSDataDir:       *tlsDir,
+		Bind:              *bind,
+		AdvertiseHost:     *advertise,
+		DiscoveryMode:     mode,
+		Priority:          *priority,
+		APIVer:            *apiVer,
+		RegistryURL:       *registry,
+		UnicastResolver:   *resolver,
+		UnicastDomain:     *domain,
+		NoConnectionAPI:   *noConnection,
+		ConnectionAPIVer:  *connectionAPIVer,
+		SystemURL:         *systemURL,
+		NoRegistry:        *noRegistry,
+		HeartbeatInterval: *heartbeat,
+		AuthURL:           *authURL,
+		AuthClientID:      *authClientID,
+		AuthClientSecret:  *authClientSecret,
+		ESTHost:           *estHost,
+		ESTLabel:          *estLabel,
+		TLSCertFile:       tlsCerts.String(),
+		TLSKeyFile:        tlsKeys.String(),
+		TLSCAFile:         *tlsCA,
+		TLSDataDir:        *tlsDir,
 	}
 	srv, err := provider.NewIS04NodeServer(logger, bundle, cfg)
 	if err != nil {
@@ -384,7 +386,10 @@ func runNMOSNodeServeLegacy(ctx context.Context, args []string) error {
 		fmt.Println("Announcing _nmos-node._tcp via mDNS.")
 	}
 	if *registry != "" {
-		fmt.Printf("Registering against %s every %s + heartbeat.\n", *registry, "5s")
+		// The banner prints the cadence actually configured, not a
+		// hard-coded default (#855); a discovered IS-09 System API can
+		// still override it live.
+		fmt.Printf("Registering against %s + heartbeat every %s (IS-09 may override).\n", *registry, *heartbeat)
 	}
 	return srv.Serve(ctx)
 }

--- a/cmd/dhs/cmd_nmos_heartbeat_evict_test.go
+++ b/cmd/dhs/cmd_nmos_heartbeat_evict_test.go
@@ -1,0 +1,147 @@
+package main
+
+// The #855 definition-of-done eviction pair, end to end and
+// in-process: a real dhs Registry (GC armed) + a real registration
+// client. A cadence LONGER than the registry's heartbeat timeout gets
+// the node evicted; a cadence comfortably inside it keeps the node
+// registered across several GC windows. cmd/dhs is Layer 4 — the one
+// package allowed to import both sides.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	stdhttp "net/http"
+	"os"
+	"testing"
+	"time"
+
+	"dhs/internal/amwa/provider"
+	registryslot "dhs/internal/registry"
+
+	_ "dhs/internal/amwa/registry" // registry plugin registration
+)
+
+// freeTCPPort asks the OS for a free port and releases it for reuse.
+func freeTCPPort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	_ = l.Close()
+	return port
+}
+
+// queryNodeCount reads the Query API's /nodes listing.
+func queryNodeCount(t *testing.T, base string) (int, error) {
+	t.Helper()
+	resp, err := stdhttp.Get(base + "/x-nmos/query/v1.3/nodes?paging.limit=100")
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		return 0, fmt.Errorf("HTTP %d: %s", resp.StatusCode, body)
+	}
+	var list []json.RawMessage
+	if err := json.Unmarshal(body, &list); err != nil {
+		return 0, err
+	}
+	return len(list), nil
+}
+
+func TestHeartbeatCadenceVsRegistryGC(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	bundle, err := provider.LoadNodeConfigFromFile("../../tests/integration/nmos/amwa/amwa-test-node.json")
+	if err != nil {
+		t.Fatalf("load fixture: %v", err)
+	}
+
+	run := func(t *testing.T, cadence time.Duration, wantEvicted bool) {
+		t.Helper()
+		port := freeTCPPort(t)
+		base := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+		f, ok := registryslot.Lookup("nmos")
+		if !ok {
+			t.Fatal("nmos registry plugin not registered")
+		}
+		regCtx, regCancel := context.WithCancel(context.Background())
+		defer regCancel()
+		go func() {
+			_ = f.New(logger).Serve(regCtx, registryslot.ServeOptions{
+				BindAddrs:        []string{fmt.Sprintf("127.0.0.1:%d", port)},
+				DiscoveryMode:    "static",
+				GCInterval:       100 * time.Millisecond,
+				HeartbeatTimeout: 1 * time.Second,
+			})
+		}()
+		deadline := time.Now().Add(5 * time.Second)
+		for {
+			if _, err := queryNodeCount(t, base); err == nil {
+				break
+			}
+			if time.Now().After(deadline) {
+				t.Fatal("registry never came up")
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+
+		rc := provider.NewRegistrationClient(logger, base, "v1.3", bundle)
+		rc.SetDefaultHeartbeatInterval(cadence)
+		nodeCtx, nodeCancel := context.WithCancel(context.Background())
+		defer nodeCancel()
+		go rc.Run(nodeCtx)
+
+		// Wait for the initial registration to land.
+		deadline = time.Now().Add(5 * time.Second)
+		for {
+			if n, err := queryNodeCount(t, base); err == nil && n == 1 {
+				break
+			}
+			if time.Now().After(deadline) {
+				t.Fatal("node never registered")
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+
+		if wantEvicted {
+			// Cadence 3 s vs timeout 1 s: the GC must purge the node
+			// well before the second heartbeat is even due.
+			deadline = time.Now().Add(2500 * time.Millisecond)
+			for {
+				n, err := queryNodeCount(t, base)
+				if err == nil && n == 0 {
+					return // evicted, as the spec demands
+				}
+				if time.Now().After(deadline) {
+					t.Fatalf("node with cadence %v never evicted by a 1s-timeout registry (nodes=%d)", cadence, n)
+				}
+				time.Sleep(100 * time.Millisecond)
+			}
+		}
+		// Cadence 300 ms vs timeout 1 s: the node must survive several
+		// GC windows. (The client re-registers on a heartbeat 404, so
+		// an eviction would also show as a count flap — check steadily.)
+		for end := time.Now().Add(2500 * time.Millisecond); time.Now().Before(end); {
+			n, err := queryNodeCount(t, base)
+			if err != nil || n != 1 {
+				t.Fatalf("node with cadence %v dropped out of a 1s-timeout registry (nodes=%d, err=%v)", cadence, n, err)
+			}
+			time.Sleep(200 * time.Millisecond)
+		}
+	}
+
+	t.Run("cadence beyond the timeout is evicted", func(t *testing.T) {
+		run(t, 3*time.Second, true)
+	})
+	t.Run("cadence inside the timeout survives", func(t *testing.T) {
+		run(t, 300*time.Millisecond, false)
+	})
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -250,6 +250,8 @@ Usage of serve:
     	BCP-003-03 EST server host:port - the Node bootstraps the network Root CA + enrolls for its TLS certificate there, then serves HTTPS/WSS only
   -est-label string
     	EST api_selector arbitrary label (appended to /.well-known/est)
+  -heartbeat duration
+    	heartbeat cadence for POST /health (IS-04 §6.1 default 5s). An IS-09 System API's heartbeat_interval outranks it when one is found. Sub-second cadences work — the loop's tick and early-fire slack scale down with the value (default 5s)
   -mdns
     	advertise via mDNS (default true)
   -no-connection-api
@@ -261,7 +263,7 @@ Usage of serve:
   -priority pri
     	DNS-SD pri TXT (0-99 production, 100+ dev)
   -registry string
-    	Registration API base URL — when set, the Node POSTs to /resource + heartbeats every 5 s
+    	Registration API base URL — when set, the Node POSTs to /resource + heartbeats at the --heartbeat cadence
   -resolver IP[:port]
     	DNS server IP[:port] holding the _nmos-register._tcp records (with --unicast)
   -role string

--- a/internal/amwa/docs/ha.md
+++ b/internal/amwa/docs/ha.md
@@ -65,6 +65,23 @@ Controllers do the failover work; Registries are independent.
 > "It is RECOMMENDED that heartbeat and garbage collection intervals
 > are user-configurable to non-default values"
 
+Both knobs exist in dhs: the registry's `--heartbeat-timeout` /
+`--gc-interval` and the node's `--heartbeat` (#855; an IS-09 System
+API's `heartbeat_interval` outranks the flag — the System API is the
+plant-wide operator config).
+
+**Spec gap — the threshold is not discoverable.** IS-04 defines the
+defaults and no way for a Registry to advertise the values it actually
+uses: DNS-SD TXT carries `api_proto` / `api_ver` / `api_auth` / `pri`,
+nothing about timing; `POST /health/nodes/{id}` answers the last-seen
+time, never the deadline; the Query API exposes no registry
+configuration. A node configured off the registry's real timeout finds
+out only when a heartbeat 404s. A controller watching the Query API
+cannot tell eviction from clean deregistration either — a `removed`
+grain is `pre`-only in both cases — so "node disappeared" findings
+must always be phrased as two possibilities (clean DELETE vs GC).
+Nothing to fix in our code; recorded so nobody re-derives it.
+
 ### Multi-network exception (closest to "HA" in the spec)
 
 > "Registered discovery MAY use either a single registry, or an

--- a/internal/amwa/provider/heartbeat_cadence_test.go
+++ b/internal/amwa/provider/heartbeat_cadence_test.go
@@ -1,0 +1,124 @@
+package provider
+
+// The --heartbeat operator knob (issue #855): the cadence fallback
+// chain (IS-09 live value > --heartbeat default > IS-04 §6.1 5 s),
+// the tick/slack scaling that makes sub-second cadences beat on time,
+// and the loop proof against a counting fake Registration API — the
+// node-side half of "the registry's GC is testable" (the registry's
+// eviction half is pinned by its own store tests).
+
+import (
+	"context"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"dhs/internal/amwa/codec/is09"
+)
+
+func TestHeartbeatDefaultIntervalPrecedence(t *testing.T) {
+	s := newTestNodeServer(t)
+	rc := NewRegistrationClient(nil, "http://reg.invalid:8235", "v1.3", validBundle())
+	rc.SetHeartbeatIntervalFn(s.systemHeartbeatInterval)
+
+	// No IS-09 global, no flag: the spec default.
+	if got := rc.heartbeatInterval(); got != HeartbeatInterval {
+		t.Fatalf("bare: interval = %v, want %v", got, HeartbeatInterval)
+	}
+
+	// The --heartbeat default replaces the 5 s fallback.
+	rc.SetDefaultHeartbeatInterval(2 * time.Second)
+	if got := rc.heartbeatInterval(); got != 2*time.Second {
+		t.Fatalf("with --heartbeat 2s: interval = %v, want 2s", got)
+	}
+
+	// An IS-09 global still outranks the flag — the System API is the
+	// plant-wide operator config.
+	s.applySystemGlobal(&is09.Global{
+		ID: "0d0a0f0e-0000-4000-8000-000000000855", Version: "1:0",
+		IS04: is09.IS04Config{HeartbeatInterval: 7},
+	}, "http://sys.test/x-nmos/system/v1.0/global")
+	if got := rc.heartbeatInterval(); got != 7*time.Second {
+		t.Fatalf("IS-09 over flag: interval = %v, want 7s", got)
+	}
+
+	// Non-positive flag values keep the spec default in force.
+	rc2 := NewRegistrationClient(nil, "http://reg.invalid:8235", "v1.3", validBundle())
+	rc2.SetDefaultHeartbeatInterval(0)
+	if got := rc2.heartbeatInterval(); got != HeartbeatInterval {
+		t.Fatalf("zero flag: interval = %v, want %v", got, HeartbeatInterval)
+	}
+}
+
+func TestHeartbeatTickAndSlackScale(t *testing.T) {
+	cases := []struct {
+		cadence, tick, slack time.Duration
+	}{
+		// The 5 s default keeps the historic loop numbers exactly.
+		{5 * time.Second, time.Second, 500 * time.Millisecond},
+		{2 * time.Second, time.Second, 500 * time.Millisecond},
+		// Sub-2 s: both scale so the slack can't swallow the beat.
+		{time.Second, 500 * time.Millisecond, 250 * time.Millisecond},
+		{500 * time.Millisecond, 250 * time.Millisecond, 125 * time.Millisecond},
+		// Floors: a pathological cadence cannot spin the loop.
+		{20 * time.Millisecond, 50 * time.Millisecond, 10 * time.Millisecond},
+	}
+	for _, tc := range cases {
+		if got := heartbeatTick(tc.cadence); got != tc.tick {
+			t.Errorf("tick(%v) = %v, want %v", tc.cadence, got, tc.tick)
+		}
+		if got := heartbeatSlack(tc.cadence); got != tc.slack {
+			t.Errorf("slack(%v) = %v, want %v", tc.cadence, got, tc.slack)
+		}
+	}
+}
+
+// countingRegistry is a minimal Registration API accepting resource
+// POSTs and counting /health POSTs.
+func countingRegistry(t *testing.T) (*httptest.Server, *atomic.Uint64) {
+	t.Helper()
+	var heartbeats atomic.Uint64
+	srv := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/health/nodes/"):
+			heartbeats.Add(1)
+			w.WriteHeader(stdhttp.StatusOK)
+			_, _ = w.Write([]byte(`{"health":"1"}`))
+		case strings.HasSuffix(r.URL.Path, "/resource"):
+			w.WriteHeader(stdhttp.StatusCreated)
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			stdhttp.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &heartbeats
+}
+
+// TestHeartbeatCadenceHonored drives the real Run loop against the
+// counting fake: a 200 ms cadence must land several beats inside a
+// window where the 5 s default lands at most the post-registration
+// one — the tick and slack provably scaled down.
+func TestHeartbeatCadenceHonored(t *testing.T) {
+	run := func(cadence time.Duration) uint64 {
+		srv, beats := countingRegistry(t)
+		rc := NewRegistrationClient(nil, srv.URL, "v1.3", validBundle())
+		if cadence > 0 {
+			rc.SetDefaultHeartbeatInterval(cadence)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 1100*time.Millisecond)
+		defer cancel()
+		rc.Run(ctx)
+		return beats.Load()
+	}
+
+	if fast := run(200 * time.Millisecond); fast < 4 {
+		t.Errorf("cadence 200ms: %d heartbeats in ~1.1s, want >= 4", fast)
+	}
+	if slow := run(0); slow > 2 {
+		t.Errorf("default cadence: %d heartbeats in ~1.1s, want <= 2", slow)
+	}
+}

--- a/internal/amwa/provider/node.go
+++ b/internal/amwa/provider/node.go
@@ -8,12 +8,13 @@ import (
 	"io"
 	"log/slog"
 	"net"
-	"os"
 	stdhttp "net/http"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	dnssdcodec "dhs/internal/amwa/codec/dnssd"
 	"dhs/internal/amwa/codec/is04"
@@ -166,6 +167,13 @@ type IS04NodeConfig struct {
 	// _nmos-node._tcp, so a Node allowed to find a Registry cannot
 	// also be a peer-to-peer Node.
 	NoRegistry bool
+
+	// HeartbeatInterval, when positive, replaces the IS-04 §6.1 5 s
+	// default heartbeat cadence (`--heartbeat`, issue #855) — the knob
+	// that makes a registry's GC drills testable. An IS-09 System
+	// API's heartbeat_interval still outranks it: the System API is
+	// the plant-wide operator config, this is a local default.
+	HeartbeatInterval time.Duration
 
 	// AuthURL, when non-empty, turns on BCP-003-02: every API this
 	// Node serves validates Bearer tokens against the named
@@ -624,6 +632,7 @@ func (s *IS04NodeServer) Serve(ctx context.Context) error {
 		s.attachTLSTrust(rc)
 		rc.SetOnRegistered(s.onRegistrationStateChanged)
 		rc.SetHeartbeatIntervalFn(s.systemHeartbeatInterval)
+		rc.SetDefaultHeartbeatInterval(s.cfg.HeartbeatInterval)
 		s.regClient = rc
 		s.wireResourceChanged(rc)
 		go rc.Run(ctx)
@@ -641,6 +650,7 @@ func (s *IS04NodeServer) Serve(ctx context.Context) error {
 		rc.SetWatcher(uw)
 		rc.SetOnRegistered(s.onRegistrationStateChanged)
 		rc.SetHeartbeatIntervalFn(s.systemHeartbeatInterval)
+		rc.SetDefaultHeartbeatInterval(s.cfg.HeartbeatInterval)
 		s.regClient = rc
 		s.wireResourceChanged(rc)
 		go rc.Run(ctx)
@@ -662,6 +672,7 @@ func (s *IS04NodeServer) Serve(ctx context.Context) error {
 		rc.SetWatcher(w)
 		rc.SetOnRegistered(s.onRegistrationStateChanged)
 		rc.SetHeartbeatIntervalFn(s.systemHeartbeatInterval)
+		rc.SetDefaultHeartbeatInterval(s.cfg.HeartbeatInterval)
 		s.regClient = rc
 		s.wireResourceChanged(rc)
 		go rc.Run(ctx)

--- a/internal/amwa/provider/registration_client.go
+++ b/internal/amwa/provider/registration_client.go
@@ -88,6 +88,12 @@ type RegistrationClient struct {
 	// default of HeartbeatInterval (5 s).
 	heartbeatIntervalFn atomic.Pointer[func() time.Duration]
 
+	// defaultInterval, when positive, replaces the IS-04 §6.1 5 s
+	// fallback above — the `--heartbeat` operator knob (#855). The
+	// IS-09 value still outranks it: the System API is the
+	// plant-wide config, the flag is a local default.
+	defaultInterval time.Duration
+
 	mu         sync.Mutex
 	cancelLoop context.CancelFunc
 	registered atomic.Bool
@@ -307,16 +313,59 @@ func (c *RegistrationClient) SetHeartbeatIntervalFn(fn func() time.Duration) {
 	c.heartbeatIntervalFn.Store(&fn)
 }
 
-// heartbeatInterval returns the cadence in force right now: the
-// System-API-supplied value when one is recorded and positive, else
-// the IS-04 §6.1 default (HeartbeatInterval, 5 s).
+// SetDefaultHeartbeatInterval replaces the fallback cadence used when
+// no System API supplies one — the `--heartbeat` operator knob
+// (issue #855). Non-positive keeps the IS-04 §6.1 default. Safe to
+// call before Run only.
+func (c *RegistrationClient) SetDefaultHeartbeatInterval(d time.Duration) {
+	c.defaultInterval = d
+}
+
+// heartbeatInterval returns the cadence in force right now:
+// the System-API-supplied value when one is recorded and positive
+// (IS-09 is the plant-wide operator config and outranks a local
+// flag), else the operator's --heartbeat default, else the IS-04
+// §6.1 default (HeartbeatInterval, 5 s).
 func (c *RegistrationClient) heartbeatInterval() time.Duration {
 	if p := c.heartbeatIntervalFn.Load(); p != nil {
 		if d := (*p)(); d > 0 {
 			return d
 		}
 	}
+	if c.defaultInterval > 0 {
+		return c.defaultInterval
+	}
 	return HeartbeatInterval
+}
+
+// heartbeatTick is the loop's poll rate for a given cadence: fast
+// enough for failover detection AND for sub-second cadences (half the
+// beat), never slower than the historic 1 s, floored so a pathological
+// cadence cannot spin the loop.
+func heartbeatTick(cadence time.Duration) time.Duration {
+	t := cadence / 2
+	if t > time.Second {
+		t = time.Second
+	}
+	if t < 50*time.Millisecond {
+		t = 50 * time.Millisecond
+	}
+	return t
+}
+
+// heartbeatSlack is the early-fire allowance that keeps the
+// tick-quantisation jitter inside an observer's ±window (AMWA test_05
+// uses ±0.5 s at the 5 s default). It must scale down with the
+// cadence — a 500 ms slack swallows a 500 ms beat whole.
+func heartbeatSlack(cadence time.Duration) time.Duration {
+	s := cadence / 4
+	if s > 500*time.Millisecond {
+		s = 500 * time.Millisecond
+	}
+	if s < 10*time.Millisecond {
+		s = 10 * time.Millisecond
+	}
+	return s
 }
 
 // Run drives the registration + heartbeat loop until ctx is
@@ -346,8 +395,13 @@ func (c *RegistrationClient) Run(ctx context.Context) {
 	// AMWA test_15/16 cascade-disables mocks every (HeartbeatInterval+1)
 	// seconds. To detect dead mocks reliably and fail over within that
 	// window, the loop ticks faster than the heartbeat cadence. We
-	// throttle actual heartbeats to HeartbeatInterval below.
-	ticker := time.NewTicker(1 * time.Second)
+	// throttle actual heartbeats to the live cadence below. The tick
+	// scales with the cadence (heartbeatTick) so a sub-second
+	// --heartbeat / IS-09 value still beats on time — at the 5 s
+	// default this is the historic 1 s tick — and is Reset when a
+	// live IS-09 change moves the cadence.
+	curTick := heartbeatTick(c.heartbeatInterval())
+	ticker := time.NewTicker(curTick)
 	defer ticker.Stop()
 	lastHeartbeat := time.Time{}
 
@@ -429,13 +483,19 @@ func (c *RegistrationClient) Run(ctx context.Context) {
 				}
 			}
 			// Throttle actual /health POSTs near the live cadence — the
-			// 1 s tick above is for fast failover detection only. AMWA
+			// fast tick above is for failover detection only. AMWA
 			// test_05 enforces the interval ± 0.5 s between heartbeats,
-			// so we fire when the elapsed budget is within 0.5 s of due
-			// to keep the tick-quantisation jitter inside the window.
-			// The cadence is the IS-09 System API's heartbeat_interval
-			// when one has been read, else the IS-04 §6.1 default.
-			if time.Since(lastHeartbeat) < c.heartbeatInterval()-500*time.Millisecond {
+			// so we fire when the elapsed budget is within the scaled
+			// slack of due, keeping tick-quantisation jitter inside the
+			// window at every cadence. The cadence is the IS-09 System
+			// API's heartbeat_interval when one has been read, else the
+			// --heartbeat default, else IS-04 §6.1's 5 s.
+			cadence := c.heartbeatInterval()
+			if nt := heartbeatTick(cadence); nt != curTick {
+				curTick = nt
+				ticker.Reset(nt)
+			}
+			if time.Since(lastHeartbeat) < cadence-heartbeatSlack(cadence) {
 				continue
 			}
 			lastHeartbeat = time.Now()


### PR DESCRIPTION
feat(nmos/node): configurable heartbeat cadence - the registry's GC is testable (#855)

Rebuilt fresh on current main (stale PR #856 closed as
superseded-in-part: #951 already made the cadence live-readable from
IS-09, which rewrote the plumbing that branch touched).

--heartbeat DURATION on `producer nmos serve` (default the IS-04 §6.1
5 s) installs the fallback cadence; a discovered IS-09 System API's
heartbeat_interval still outranks it - the System API is the
plant-wide operator config, the flag a local default. The loop's tick
and early-fire slack now scale with the live cadence (tick
min(1s, cadence/2), slack min(500ms, cadence/4), both floored), so a
sub-second cadence beats on time instead of being swallowed whole by
the fixed 500 ms slack; at the 5 s default both values are unchanged
to the millisecond, keeping AMWA test_05's +/-0.5 s window exactly as
before. The startup banner prints the configured cadence instead of a
hard-coded "5s".

Proofs: precedence chain (IS-09 > flag > spec default), tick/slack
table, a counting fake Registration API showing a 200 ms cadence
lands >=4 beats where the default lands <=2 - and the #855
definition-of-done eviction pair end-to-end in-process at cmd level
(the one package allowed to import both sides): a real dhs registry
with a 1 s heartbeat timeout evicts a 3 s-cadence node and keeps a
300 ms one across several GC windows.

The IS-04 spec gap (a registry cannot advertise the timeout it
enforces; eviction and clean DELETE are indistinguishable on the
Query WS) is recorded in internal/amwa/docs/ha.md next to the spec's
own timing text.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
