### PR TITLE
fix(ci): Release Please uses the svc-rune service token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,7 +364,14 @@ jobs:
         id: release
         with:
           release-type: go
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # The svc-rune service token (org convention, same as
+          # ansible-platform) — NOT anyone's personal PAT. GITHUB_TOKEN
+          # began 403ing on create-a-release on 2026-09-02 despite
+          # logged contents:write (org/platform-side tightening; repos
+          # on the rune token were untouched). Falls back to
+          # GITHUB_TOKEN so PR bookkeeping still works if the secret
+          # is ever absent.
+          token: ${{ secrets.RUNE_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
 
   build-release:
     name: Build release binaries


### PR DESCRIPTION
GITHUB_TOKEN began failing create-a-release with 403 Resource-not-accessible on 2026-09-02 (~15:00-19:45 UTC window) despite job logs proving Contents:write in the failing runs - same config that cut v0.19.0 that morning; zero rulesets; action SHA identical between working and failing runs. Root cause surfaced by comparing with ansible-platform, whose release flow kept working: it never uses GITHUB_TOKEN - its Release Please authenticates with the svc-rune service token (RUNE_GITHUB_TOKEN). This aligns go-acp with that org convention (service identity, NOT a personal PAT), with GITHUB_TOKEN as fallback so PR bookkeeping degrades gracefully if the secret is absent. Requires the RUNE_GITHUB_TOKEN secret on this repo (or as an org secret). v0.20.0 was cut manually during the outage; next cut proves this path.