### PR TITLE
feat(amwa/sdp): stdlib-only SDP parser for ST 2110 transport files (#827)

### DIFF
--- a/internal/amwa/codec/sdp/parse.go
+++ b/internal/amwa/codec/sdp/parse.go
@@ -1,0 +1,259 @@
+package sdp
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Parse reads one SDP document. Recoverable defects come back as
+// Deviations; only a structurally impossible document (empty, or not
+// starting with v=) is an error. The returned Session preserves every
+// line: modelled fields are extracted, everything else lands verbatim
+// in Attributes / Extra.
+func Parse(text string) (*Session, []Deviation, error) {
+	lines := strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n")
+	// Drop one trailing empty line from the final newline; keep inner
+	// blanks visible as deviations below.
+	if n := len(lines); n > 0 && lines[n-1] == "" {
+		lines = lines[:n-1]
+	}
+	if len(lines) == 0 {
+		return nil, nil, fmt.Errorf("sdp: empty document")
+	}
+	if !strings.HasPrefix(lines[0], "v=") {
+		return nil, nil, fmt.Errorf("sdp: document must start with v=, got %q", lines[0])
+	}
+
+	s := &Session{}
+	var devs []Deviation
+	dev := func(n int, line, reason string) {
+		devs = append(devs, Deviation{Line: n + 1, Text: line, Reason: reason})
+	}
+	var cur *Media // nil while in the session part
+
+	for i, line := range lines {
+		if line == "" {
+			dev(i, line, "blank line inside the document")
+			continue
+		}
+		if len(line) < 2 || line[1] != '=' {
+			dev(i, line, "not a <type>=<value> line")
+			continue
+		}
+		typ, val := line[0], line[2:]
+
+		switch typ {
+		case 'v':
+			n, err := strconv.Atoi(strings.TrimSpace(val))
+			if err != nil {
+				dev(i, line, "non-numeric version")
+				continue
+			}
+			s.Version = n
+
+		case 'o':
+			f := strings.Fields(val)
+			if len(f) != 6 {
+				dev(i, line, "o= wants 6 fields")
+				continue
+			}
+			s.Origin = Origin{Username: f[0], SessID: f[1], SessVersion: f[2],
+				NetType: f[3], AddrType: f[4], Addr: f[5]}
+
+		case 's':
+			s.Name = val
+
+		case 't':
+			f := strings.Fields(val)
+			if len(f) != 2 {
+				dev(i, line, "t= wants 2 fields")
+				continue
+			}
+			s.Timing = append(s.Timing, Timing{Start: f[0], Stop: f[1]})
+
+		case 'c':
+			c, err := parseConnection(val)
+			if err != nil {
+				dev(i, line, err.Error())
+				continue
+			}
+			if cur != nil {
+				cur.Connection = c
+			} else {
+				s.Connection = c
+			}
+
+		case 'm':
+			m, err := parseMediaHeader(val)
+			if err != nil {
+				dev(i, line, err.Error())
+				// Still open a section so following lines have a home
+				// and nothing is silently dropped.
+				m = &Media{Type: val}
+			}
+			s.Media = append(s.Media, *m)
+			cur = &s.Media[len(s.Media)-1]
+
+		case 'a':
+			name, value := val, ""
+			if idx := strings.Index(val, ":"); idx >= 0 {
+				name, value = val[:idx], val[idx+1:]
+			}
+			if cur == nil {
+				if name == "group" {
+					f := strings.Fields(value)
+					if len(f) < 1 {
+						dev(i, line, "a=group without semantics")
+						continue
+					}
+					s.Groups = append(s.Groups, Group{Semantics: f[0], Tags: f[1:]})
+				} else {
+					s.Attributes = append(s.Attributes, Attribute{Name: name, Value: value})
+				}
+				continue
+			}
+			if reason := applyMediaAttr(cur, name, value); reason != "" {
+				dev(i, line, reason)
+			}
+
+		default:
+			// b=, i=, u=, e=, p=, z=, r=, k=, … — preserved verbatim.
+			if cur != nil {
+				cur.Extra = append(cur.Extra, line)
+			} else {
+				s.Extra = append(s.Extra, line)
+			}
+		}
+	}
+	return s, devs, nil
+}
+
+func parseConnection(val string) (*Connection, error) {
+	f := strings.Fields(val)
+	if len(f) != 3 {
+		return nil, fmt.Errorf("c= wants 3 fields")
+	}
+	addr, ttl := f[2], ""
+	if idx := strings.Index(addr, "/"); idx >= 0 {
+		addr, ttl = addr[:idx], f[2][idx+1:]
+	}
+	return &Connection{NetType: f[0], AddrType: f[1], Addr: addr, TTL: ttl}, nil
+}
+
+func parseMediaHeader(val string) (*Media, error) {
+	f := strings.Fields(val)
+	if len(f) < 4 {
+		return nil, fmt.Errorf("m= wants at least 4 fields")
+	}
+	port, err := strconv.Atoi(f[1])
+	if err != nil {
+		return nil, fmt.Errorf("m= port is not a number")
+	}
+	return &Media{Type: f[0], Port: port, Proto: f[2], Formats: f[3:]}, nil
+}
+
+// applyMediaAttr routes one media-level a= line into its modelled
+// slot, or preserves it verbatim. A non-empty return is a Deviation
+// reason — the raw line is preserved in Attributes regardless, so a
+// malformed modelled attribute is reported AND kept.
+func applyMediaAttr(m *Media, name, value string) string {
+	switch name {
+	case "mid":
+		m.Mid = value
+		return ""
+
+	case "rtpmap":
+		f := strings.Fields(value)
+		if len(f) != 2 {
+			m.Attributes = append(m.Attributes, Attribute{Name: name, Value: value})
+			return "a=rtpmap wants '<payload> <encoding>/<clock>[/<params>]'"
+		}
+		enc := strings.SplitN(f[1], "/", 3)
+		if len(enc) < 2 {
+			m.Attributes = append(m.Attributes, Attribute{Name: name, Value: value})
+			return "a=rtpmap encoding wants '<name>/<clock>'"
+		}
+		clock, err := strconv.Atoi(enc[1])
+		if err != nil {
+			m.Attributes = append(m.Attributes, Attribute{Name: name, Value: value})
+			return "a=rtpmap clock rate is not a number"
+		}
+		r := RTPMap{Encoding: enc[0], ClockRate: clock, Raw: value}
+		if len(enc) == 3 {
+			r.Params = enc[2]
+		}
+		if m.RTPMap == nil {
+			m.RTPMap = map[string]RTPMap{}
+		}
+		m.RTPMap[f[0]] = r
+		return ""
+
+	case "fmtp":
+		payload, rest, ok := strings.Cut(value, " ")
+		if !ok {
+			m.Attributes = append(m.Attributes, Attribute{Name: name, Value: value})
+			return "a=fmtp wants '<payload> <params>'"
+		}
+		fm := FMTP{Raw: rest}
+		for _, part := range strings.Split(rest, ";") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			k, v, _ := strings.Cut(part, "=")
+			fm.Params = append(fm.Params, FMTPParam{Key: k, Value: v})
+		}
+		if m.FMTP == nil {
+			m.FMTP = map[string]FMTP{}
+		}
+		m.FMTP[payload] = fm
+		return ""
+
+	case "ts-refclk":
+		if !strings.HasPrefix(value, "ptp=") {
+			// localmac= and friends: preserved, not modelled.
+			m.Attributes = append(m.Attributes, Attribute{Name: name, Value: value})
+			return ""
+		}
+		parts := strings.Split(strings.TrimPrefix(value, "ptp="), ":")
+		t := &TSRefClk{Raw: value, Domain: -1}
+		switch len(parts) {
+		case 2: // IEEE1588-2008:traceable
+			t.Version, t.GMID = parts[0], parts[1]
+		case 3: // IEEE1588-2008:<gmid>:<domain>
+			t.Version, t.GMID = parts[0], parts[1]
+			d, err := strconv.Atoi(parts[2])
+			if err != nil {
+				m.Attributes = append(m.Attributes, Attribute{Name: name, Value: value})
+				return "a=ts-refclk ptp domain is not a number"
+			}
+			t.Domain = d
+		default:
+			m.Attributes = append(m.Attributes, Attribute{Name: name, Value: value})
+			return "a=ts-refclk ptp= wants '<version>:<gmid>[:<domain>]'"
+		}
+		m.TSRefClk = t
+		return ""
+
+	case "mediaclk":
+		m.MediaClk = value
+		return ""
+
+	case "ptime":
+		m.PTime = value
+		return ""
+
+	case "source-filter":
+		f := strings.Fields(value)
+		if len(f) < 5 {
+			m.Attributes = append(m.Attributes, Attribute{Name: name, Value: value})
+			return "a=source-filter wants '<mode> <net> <addr-type> <dest> <src>...'"
+		}
+		m.SourceFilt = &SourceFilter{Mode: f[0], NetType: f[1], AddrType: f[2],
+			Dest: f[3], Srcs: f[4:]}
+		return ""
+	}
+	m.Attributes = append(m.Attributes, Attribute{Name: name, Value: value})
+	return ""
+}

--- a/internal/amwa/codec/sdp/sdp.go
+++ b/internal/amwa/codec/sdp/sdp.go
@@ -1,0 +1,195 @@
+// Package sdp is a stdlib-only parser for the SDP transport files
+// ST 2110 senders publish over IS-05 (issue #827).
+//
+// SDP is where the wire truth lives: the multicast address per 2022-7
+// leg, the PTP grandmaster and domain, the essence parameters
+// (rtpmap/fmtp), the source filter. The parser's posture mirrors the
+// connector compliance model: PRESERVE, NEVER INVENT — unknown
+// attributes and lines are kept verbatim in order, absent fields stay
+// zero and are never defaulted, and a malformed-but-recoverable line
+// becomes a Deviation while only a structurally impossible document
+// is an error.
+//
+// ADR-0006: this package imports the standard library only and is
+// lift-to-own-repo ready. It never imports dhs/*.
+package sdp
+
+// Session is one parsed SDP document.
+type Session struct {
+	Version    int         // v=
+	Origin     Origin      // o=
+	Name       string      // s=
+	Timing     []Timing    // t=
+	Connection *Connection // session-level c=, if present
+	Groups     []Group     // a=group:<semantics> <tags...>
+	Attributes []Attribute // every other session-level a=, in order
+	Extra      []string    // non-modelled session-level lines (b=, i=, u=, …), verbatim
+	Media      []Media     // m= sections in order
+}
+
+// Origin is the o= line.
+type Origin struct {
+	Username    string
+	SessID      string
+	SessVersion string
+	NetType     string
+	AddrType    string
+	Addr        string
+}
+
+// Timing is one t= line.
+type Timing struct {
+	Start string
+	Stop  string
+}
+
+// Connection is a c= line.
+type Connection struct {
+	NetType  string
+	AddrType string
+	Addr     string // address with any /ttl or /count suffix stripped
+	TTL      string // multicast TTL suffix when present, verbatim
+}
+
+// Group is a session-level a=group line — ST 2022-7 uses
+// "a=group:DUP primary secondary".
+type Group struct {
+	Semantics string
+	Tags      []string
+}
+
+// Attribute is one a= line kept verbatim: Name is the token before
+// the first ':', Value everything after it ("" for flag attributes).
+type Attribute struct {
+	Name  string
+	Value string
+}
+
+// Media is one m= section.
+type Media struct {
+	Type       string   // audio | video | application
+	Port       int
+	Proto      string   // e.g. RTP/AVP
+	Formats    []string // payload types
+	Connection *Connection
+	Mid        string            // a=mid → "primary" / "secondary"
+	RTPMap     map[string]RTPMap // by payload type
+	FMTP       map[string]FMTP   // by payload type
+	TSRefClk   *TSRefClk
+	MediaClk   string // a=mediaclk value
+	SourceFilt *SourceFilter
+	PTime      string      // a=ptime value
+	Attributes []Attribute // everything else, raw, in order
+	Extra      []string    // non-modelled lines in this section (b=, …), verbatim
+}
+
+// RTPMap is one a=rtpmap entry: "<payload> <encoding>/<clock>[/<params>]".
+type RTPMap struct {
+	Encoding  string
+	ClockRate int
+	Params    string // e.g. audio channel count ("8")
+	Raw       string
+}
+
+// FMTPParam is one key=value (or bare flag) inside a=fmtp, in source
+// order — ST 2110 parameter order is meaningful to some receivers.
+type FMTPParam struct {
+	Key   string
+	Value string
+}
+
+// FMTP is one a=fmtp entry.
+type FMTP struct {
+	Params []FMTPParam
+	Raw    string
+}
+
+// Get returns the first value for key ("" when absent) plus presence.
+func (f FMTP) Get(key string) (string, bool) {
+	for _, p := range f.Params {
+		if p.Key == key {
+			return p.Value, true
+		}
+	}
+	return "", false
+}
+
+// TSRefClk is a=ts-refclk with the ptp= form:
+// "ptp=IEEE1588-2008:<gmid>:<domain>" or "ptp=IEEE1588-2008:traceable".
+type TSRefClk struct {
+	Version string // e.g. IEEE1588-2008
+	GMID    string // grandmaster id, or "traceable"
+	Domain  int    // -1 when absent (traceable form)
+	Raw     string // the full attribute value, always
+}
+
+// SourceFilter is a=source-filter (RFC 4570):
+// "incl IN IP4 <dest> <src>...".
+type SourceFilter struct {
+	Mode     string // incl | excl
+	NetType  string
+	AddrType string
+	Dest     string
+	Srcs     []string
+}
+
+// Deviation is one recoverable defect found while parsing — reported,
+// never swallowed (compliance posture).
+type Deviation struct {
+	Line   int    // 1-based line number in the document
+	Text   string // the offending line, verbatim
+	Reason string
+}
+
+// Leg is one ST 2022-7 leg: a group:DUP tag paired with its media
+// section by a=mid.
+type Leg struct {
+	Mid   string
+	Media *Media
+	Dest  string // media c= address, falling back to the session c=
+	Src   string // first source-filter source, "" when absent
+	Port  int
+}
+
+// Legs pairs the a=group:DUP tags with their m= sections in group
+// order. Sessions without a DUP group return every media section as
+// one leg each (single-path senders), preserving order.
+func (s *Session) Legs() []Leg {
+	byMid := map[string]*Media{}
+	for i := range s.Media {
+		if s.Media[i].Mid != "" {
+			byMid[s.Media[i].Mid] = &s.Media[i]
+		}
+	}
+	mkLeg := func(mid string, m *Media) Leg {
+		l := Leg{Mid: mid, Media: m, Port: m.Port}
+		if m.Connection != nil {
+			l.Dest = m.Connection.Addr
+		} else if s.Connection != nil {
+			l.Dest = s.Connection.Addr
+		}
+		if m.SourceFilt != nil && len(m.SourceFilt.Srcs) > 0 {
+			l.Src = m.SourceFilt.Srcs[0]
+		}
+		return l
+	}
+	for _, g := range s.Groups {
+		if g.Semantics != "DUP" {
+			continue
+		}
+		out := make([]Leg, 0, len(g.Tags))
+		for _, tag := range g.Tags {
+			if m, ok := byMid[tag]; ok {
+				out = append(out, mkLeg(tag, m))
+			}
+		}
+		if len(out) > 0 {
+			return out
+		}
+	}
+	out := make([]Leg, 0, len(s.Media))
+	for i := range s.Media {
+		out = append(out, mkLeg(s.Media[i].Mid, &s.Media[i]))
+	}
+	return out
+}

--- a/internal/amwa/codec/sdp/sdp_test.go
+++ b/internal/amwa/codec/sdp/sdp_test.go
@@ -1,0 +1,218 @@
+package sdp
+
+// Expected values are written from the SDP text in testdata/, never
+// from the parser's own output (repo testing rule). Fixtures use
+// documentation multicast (233.252.0.0/24, RFC 5771) and a synthetic
+// grandmaster — no customer addressing.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func load(t *testing.T, name string) string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	return string(raw)
+}
+
+func TestParseVideoRawDup(t *testing.T) {
+	s, devs, err := Parse(load(t, "video-raw-dup.sdp"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(devs) != 0 {
+		t.Fatalf("clean fixture produced deviations: %+v", devs)
+	}
+	if s.Version != 0 || s.Name != "dhs-video-raw ST 2110-20" {
+		t.Errorf("session header: v=%d s=%q", s.Version, s.Name)
+	}
+	if s.Origin.Addr != "198.51.100.10" || s.Origin.SessID != "1443716955" {
+		t.Errorf("origin = %+v", s.Origin)
+	}
+	if len(s.Groups) != 1 || s.Groups[0].Semantics != "DUP" ||
+		len(s.Groups[0].Tags) != 2 || s.Groups[0].Tags[0] != "primary" || s.Groups[0].Tags[1] != "secondary" {
+		t.Fatalf("groups = %+v", s.Groups)
+	}
+	if len(s.Media) != 2 {
+		t.Fatalf("media sections = %d, want 2", len(s.Media))
+	}
+
+	m := s.Media[0]
+	if m.Type != "video" || m.Port != 5004 || m.Proto != "RTP/AVP" ||
+		len(m.Formats) != 1 || m.Formats[0] != "96" {
+		t.Errorf("m[0] header = %+v", m)
+	}
+	if m.Connection == nil || m.Connection.Addr != "233.252.0.10" || m.Connection.TTL != "64" {
+		t.Errorf("m[0] c= %+v", m.Connection)
+	}
+	r, ok := m.RTPMap["96"]
+	if !ok || r.Encoding != "raw" || r.ClockRate != 90000 || r.Params != "" {
+		t.Errorf("m[0] rtpmap = %+v", m.RTPMap)
+	}
+	f, ok := m.FMTP["96"]
+	if !ok {
+		t.Fatal("m[0] fmtp missing")
+	}
+	// Parameter ORDER is preserved: sampling is first, TP last.
+	if f.Params[0].Key != "sampling" || f.Params[0].Value != "YCbCr-4:2:2" ||
+		f.Params[len(f.Params)-1].Key != "TP" || f.Params[len(f.Params)-1].Value != "2110TPN" {
+		t.Errorf("m[0] fmtp order = %+v", f.Params)
+	}
+	for _, want := range [][2]string{
+		{"width", "1920"}, {"height", "1080"}, {"exactframerate", "50"},
+		{"depth", "10"}, {"colorimetry", "BT709"}, {"SSN", "ST2110-20:2017"},
+	} {
+		if got, ok := f.Get(want[0]); !ok || got != want[1] {
+			t.Errorf("fmtp %s = %q (present=%v), want %q", want[0], got, ok, want[1])
+		}
+	}
+	if m.TSRefClk == nil || m.TSRefClk.Version != "IEEE1588-2008" ||
+		m.TSRefClk.GMID != "AA-BB-CC-FF-FE-00-00-01" || m.TSRefClk.Domain != 127 {
+		t.Errorf("m[0] ts-refclk = %+v", m.TSRefClk)
+	}
+	if m.MediaClk != "direct=0" || m.Mid != "primary" {
+		t.Errorf("m[0] mediaclk=%q mid=%q", m.MediaClk, m.Mid)
+	}
+	if m.SourceFilt == nil || m.SourceFilt.Mode != "incl" ||
+		m.SourceFilt.Dest != "233.252.0.10" ||
+		len(m.SourceFilt.Srcs) != 1 || m.SourceFilt.Srcs[0] != "198.51.100.10" {
+		t.Errorf("m[0] source-filter = %+v", m.SourceFilt)
+	}
+
+	// The 2022-7 helper pairs group tags with sections, group order.
+	legs := s.Legs()
+	if len(legs) != 2 {
+		t.Fatalf("legs = %d, want 2", len(legs))
+	}
+	if legs[0].Mid != "primary" || legs[0].Dest != "233.252.0.10" ||
+		legs[0].Src != "198.51.100.10" || legs[0].Port != 5004 {
+		t.Errorf("leg[0] = %+v", legs[0])
+	}
+	if legs[1].Mid != "secondary" || legs[1].Dest != "233.252.0.138" ||
+		legs[1].Src != "198.51.100.138" {
+		t.Errorf("leg[1] = %+v", legs[1])
+	}
+}
+
+func TestParseAudioL24(t *testing.T) {
+	s, devs, err := Parse(load(t, "audio-l24.sdp"))
+	if err != nil || len(devs) != 0 {
+		t.Fatalf("Parse: err=%v devs=%+v", err, devs)
+	}
+	m := s.Media[0]
+	r := m.RTPMap["97"]
+	if r.Encoding != "L24" || r.ClockRate != 48000 || r.Params != "8" {
+		t.Errorf("audio rtpmap = %+v", r)
+	}
+	if m.PTime != "0.125" {
+		t.Errorf("ptime = %q", m.PTime)
+	}
+	// The channel-order value carries dots and parentheses — it must
+	// survive verbatim.
+	if got, ok := m.FMTP["97"].Get("channel-order"); !ok || got != "SMPTE2110.(U08)" {
+		t.Errorf("channel-order = %q", got)
+	}
+	if len(s.Legs()) != 2 {
+		t.Errorf("audio legs = %d, want 2", len(s.Legs()))
+	}
+}
+
+func TestParseAncSmpte291(t *testing.T) {
+	s, devs, err := Parse(load(t, "anc-smpte291.sdp"))
+	if err != nil || len(devs) != 0 {
+		t.Fatalf("Parse: err=%v devs=%+v", err, devs)
+	}
+	m := s.Media[0]
+	if m.RTPMap["100"].Encoding != "smpte291" {
+		t.Errorf("anc rtpmap = %+v", m.RTPMap)
+	}
+	// The DID_SDID value carries braces and a comma inside one param.
+	if got, ok := m.FMTP["100"].Get("DID_SDID"); !ok || got != "{0x61,0x02}" {
+		t.Errorf("DID_SDID = %q", got)
+	}
+	// traceable form: GMID "traceable", domain absent = -1.
+	if m.TSRefClk == nil || m.TSRefClk.GMID != "traceable" || m.TSRefClk.Domain != -1 {
+		t.Errorf("ts-refclk = %+v", m.TSRefClk)
+	}
+	// b=AS:100 is not modelled — preserved verbatim, never dropped.
+	found := false
+	for _, x := range m.Extra {
+		if x == "b=AS:100" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("b= line not preserved: %+v", m.Extra)
+	}
+	// No DUP group: one leg per media section.
+	legs := s.Legs()
+	if len(legs) != 1 || legs[0].Dest != "233.252.0.30" {
+		t.Errorf("single-path legs = %+v", legs)
+	}
+}
+
+func TestParseMalformedReportsDeviations(t *testing.T) {
+	s, devs, err := Parse(load(t, "malformed.sdp"))
+	if err != nil {
+		t.Fatalf("recoverable defects must not error: %v", err)
+	}
+	// Three malformed modelled attributes + one non-SDP line.
+	wantReasons := map[string]bool{}
+	for _, d := range devs {
+		wantReasons[d.Text] = true
+		if d.Line < 1 {
+			t.Errorf("deviation without line number: %+v", d)
+		}
+	}
+	for _, text := range []string{
+		"a=rtpmap:96 raw",
+		"a=ts-refclk:ptp=IEEE1588-2008",
+		"a=source-filter: incl IN",
+		"x-not-an-sdp-line",
+	} {
+		if !wantReasons[text] {
+			t.Errorf("expected a deviation for %q, got %+v", text, devs)
+		}
+	}
+	// The malformed attributes are preserved raw, never dropped.
+	m := s.Media[0]
+	raw := map[string]bool{}
+	for _, a := range m.Attributes {
+		raw[a.Name] = true
+	}
+	for _, name := range []string{"rtpmap", "ts-refclk", "source-filter", "custom-flag"} {
+		if !raw[name] {
+			t.Errorf("malformed/unknown attribute %q not preserved: %+v", name, m.Attributes)
+		}
+	}
+	// The flag attribute is a plain preserve, not a deviation.
+	for _, d := range devs {
+		if d.Text == "a=custom-flag" {
+			t.Errorf("unknown flag attribute wrongly flagged as deviation")
+		}
+	}
+}
+
+func TestParseStructurallyImpossible(t *testing.T) {
+	if _, _, err := Parse(""); err == nil {
+		t.Error("empty document must error")
+	}
+	if _, _, err := Parse("s=no-version\n"); err == nil {
+		t.Error("document not starting with v= must error")
+	}
+}
+
+func TestParseCRLF(t *testing.T) {
+	s, devs, err := Parse("v=0\r\no=- 1 1 IN IP4 198.51.100.10\r\ns=crlf\r\nt=0 0\r\n")
+	if err != nil || len(devs) != 0 {
+		t.Fatalf("CRLF document: err=%v devs=%+v", err, devs)
+	}
+	if s.Name != "crlf" {
+		t.Errorf("s= %q", s.Name)
+	}
+}

--- a/internal/amwa/codec/sdp/testdata/anc-smpte291.sdp
+++ b/internal/amwa/codec/sdp/testdata/anc-smpte291.sdp
@@ -1,0 +1,11 @@
+v=0
+o=- 1443716955 1443716955 IN IP4 198.51.100.10
+s=dhs-anc ST 2110-40
+t=0 0
+m=video 5004 RTP/AVP 100
+c=IN IP4 233.252.0.30/64
+b=AS:100
+a=rtpmap:100 smpte291/90000
+a=fmtp:100 DID_SDID={0x61,0x02}; VPID_Code=133
+a=ts-refclk:ptp=IEEE1588-2008:traceable
+a=mediaclk:direct=0

--- a/internal/amwa/codec/sdp/testdata/audio-l24.sdp
+++ b/internal/amwa/codec/sdp/testdata/audio-l24.sdp
@@ -1,0 +1,23 @@
+v=0
+o=- 1443716955 1443716955 IN IP4 198.51.100.10
+s=dhs-audio ST 2110-30
+t=0 0
+a=group:DUP primary secondary
+m=audio 5004 RTP/AVP 97
+c=IN IP4 233.252.0.20/64
+a=source-filter: incl IN IP4 233.252.0.20 198.51.100.10
+a=rtpmap:97 L24/48000/8
+a=ptime:0.125
+a=fmtp:97 channel-order=SMPTE2110.(U08)
+a=ts-refclk:ptp=IEEE1588-2008:AA-BB-CC-FF-FE-00-00-01:127
+a=mediaclk:direct=0
+a=mid:primary
+m=audio 5004 RTP/AVP 97
+c=IN IP4 233.252.0.148/64
+a=source-filter: incl IN IP4 233.252.0.148 198.51.100.138
+a=rtpmap:97 L24/48000/8
+a=ptime:0.125
+a=fmtp:97 channel-order=SMPTE2110.(U08)
+a=ts-refclk:ptp=IEEE1588-2008:AA-BB-CC-FF-FE-00-00-01:127
+a=mediaclk:direct=0
+a=mid:secondary

--- a/internal/amwa/codec/sdp/testdata/malformed.sdp
+++ b/internal/amwa/codec/sdp/testdata/malformed.sdp
@@ -1,0 +1,10 @@
+v=0
+o=- 1 1 IN IP4 198.51.100.10
+s=dhs-broken
+t=0 0
+m=video 5004 RTP/AVP 96
+a=rtpmap:96 raw
+a=ts-refclk:ptp=IEEE1588-2008
+a=source-filter: incl IN
+a=custom-flag
+x-not-an-sdp-line

--- a/internal/amwa/codec/sdp/testdata/video-raw-dup.sdp
+++ b/internal/amwa/codec/sdp/testdata/video-raw-dup.sdp
@@ -1,0 +1,21 @@
+v=0
+o=- 1443716955 1443716955 IN IP4 198.51.100.10
+s=dhs-video-raw ST 2110-20
+t=0 0
+a=group:DUP primary secondary
+m=video 5004 RTP/AVP 96
+c=IN IP4 233.252.0.10/64
+a=source-filter: incl IN IP4 233.252.0.10 198.51.100.10
+a=rtpmap:96 raw/90000
+a=fmtp:96 sampling=YCbCr-4:2:2; width=1920; height=1080; exactframerate=50; depth=10; TCS=SDR; colorimetry=BT709; PM=2110GPM; SSN=ST2110-20:2017; TP=2110TPN
+a=ts-refclk:ptp=IEEE1588-2008:AA-BB-CC-FF-FE-00-00-01:127
+a=mediaclk:direct=0
+a=mid:primary
+m=video 5004 RTP/AVP 96
+c=IN IP4 233.252.0.138/64
+a=source-filter: incl IN IP4 233.252.0.138 198.51.100.138
+a=rtpmap:96 raw/90000
+a=fmtp:96 sampling=YCbCr-4:2:2; width=1920; height=1080; exactframerate=50; depth=10; TCS=SDR; colorimetry=BT709; PM=2110GPM; SSN=ST2110-20:2017; TP=2110TPN
+a=ts-refclk:ptp=IEEE1588-2008:AA-BB-CC-FF-FE-00-00-01:127
+a=mediaclk:direct=0
+a=mid:secondary


### PR DESCRIPTION
Closes #827. Implements the issue's design verbatim: internal/amwa/codec/sdp (stdlib-only, lift-ready per ADR-0006) with the typed Session/Media model, preserve-never-invent parsing (unknown attributes and non-modelled lines kept verbatim in order; malformed modelled attributes become Deviations AND stay preserved raw; only structurally impossible documents error), and the Legs() 2022-7 helper pairing group:DUP tags with m= sections. DoD receipts: all three real essence shapes parsed (video/raw dual-leg with ordered fmtp, audio/L24 with ptime + channel-order SMPTE2110.(U08) surviving dots/parens, video/smpte291 with DID_SDID braces + ts-refclk traceable form); per-leg c=/source-filter/port extraction; CRLF tolerated; fixtures on documentation multicast 233.252.0.0/24 with a synthetic grandmaster; table-driven expectations written from the SDP text. First unit of the point-25/26 closure program - the audit, conformance, and network-plane units consume this model.