### PR TITLE
feat(nmos): BCP-002 group pivot + live probe verb + stuck-cursor fix (#845 #839)

### DIFF
--- a/cmd/dhs/cmd_nmos.go
+++ b/cmd/dhs/cmd_nmos.go
@@ -68,8 +68,10 @@ func runNMOSConsumer(ctx context.Context, args []string) error {
 		return runNMOSExport(ctx, rest)
 	case "audit":
 		return runNMOSAudit(ctx, rest)
+	case "profile":
+		return runNMOSProfile(ctx, rest)
 	}
-	return fmt.Errorf("consumer nmos: unknown verb %q (expected: discover, system, walk, watch, connect, set, facade, events, export, audit)", verb)
+	return fmt.Errorf("consumer nmos: unknown verb %q (expected: discover, system, walk, watch, connect, set, facade, events, export, audit, profile)", verb)
 }
 
 // runNMOSProducer dispatches `dhs producer nmos <verb> [args]`.
@@ -758,7 +760,20 @@ same bytes always produce the same report.
   --format FORMAT       text (default) | json | jsonl
   --min-severity SEV    info (default) | warn | error | critical
   --out FILE            Write the report to FILE instead of stdout
-  --fail-on SEV         Exit non-zero when a finding at or above SEV is present`)
+  --fail-on SEV         Exit non-zero when a finding at or above SEV is present
+
+profile — live protocol conformance against one device, plus per-endpoint latency.
+Answers what a capture cannot: whether an unknown API version is rejected,
+whether CORS is present, whether a paging limit is honoured and reported back,
+whether health for an unregistered node 404s. Strictly read-only — it never
+PATCHes, activates, or registers, so it is safe against a plant that is on air.
+  --target host:port    Device to profile (required)
+  --https               Use TLS
+  --deep                Assert every IS-05 endpoint, not just the first
+  --format FORMAT       text (default) | json | jsonl
+  --out FILE            Write the report to FILE instead of stdout
+  --fail-on STATUS      Exit non-zero at or above this status: warn | fail
+  --timeout DURATION    Per-request deadline (default 10s)`)
 }
 
 func printNMOSProducerHelp() {

--- a/cmd/dhs/cmd_nmos.go
+++ b/cmd/dhs/cmd_nmos.go
@@ -68,10 +68,10 @@ func runNMOSConsumer(ctx context.Context, args []string) error {
 		return runNMOSExport(ctx, rest)
 	case "audit":
 		return runNMOSAudit(ctx, rest)
-	case "profile":
+	case "probe":
 		return runNMOSProfile(ctx, rest)
 	}
-	return fmt.Errorf("consumer nmos: unknown verb %q (expected: discover, system, walk, watch, connect, set, facade, events, export, audit, profile)", verb)
+	return fmt.Errorf("consumer nmos: unknown verb %q (expected: discover, system, walk, watch, connect, set, facade, events, export, audit, probe)", verb)
 }
 
 // runNMOSProducer dispatches `dhs producer nmos <verb> [args]`.
@@ -762,12 +762,12 @@ same bytes always produce the same report.
   --out FILE            Write the report to FILE instead of stdout
   --fail-on SEV         Exit non-zero when a finding at or above SEV is present
 
-profile — live protocol conformance against one device, plus per-endpoint latency.
+probe — live protocol conformance against one device, plus per-endpoint latency.
 Answers what a capture cannot: whether an unknown API version is rejected,
 whether CORS is present, whether a paging limit is honoured and reported back,
 whether health for an unregistered node 404s. Strictly read-only — it never
 PATCHes, activates, or registers, so it is safe against a plant that is on air.
-  --target host:port    Device to profile (required)
+  --target host:port    Device to probe (required)
   --https               Use TLS
   --deep                Assert every IS-05 endpoint, not just the first
   --format FORMAT       text (default) | json | jsonl

--- a/cmd/dhs/cmd_nmos_profile.go
+++ b/cmd/dhs/cmd_nmos_profile.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"dhs/internal/amwa/profile"
+)
+
+// runNMOSProfile implements `dhs consumer nmos profile`.
+//
+// Where `export` + `audit` answer "what does this plant look like",
+// probe answers "does this device behave". The difference is the live
+// exchange: whether an unknown version is rejected, whether CORS is
+// present, whether a paging limit is honoured and reported back. None
+// of that survives into a capture, because a capture records answers
+// rather than the conversation.
+//
+// The verb is read-only by construction. It never PATCHes, never
+// activates, never registers — a conformance tool that stages a
+// connection is one that can take a live source off air, and this one
+// is meant to be safe to point at a plant that is on.
+func runNMOSProfile(ctx context.Context, args []string) (err error) {
+	fs := flag.NewFlagSet("consumer nmos profile", flag.ContinueOnError)
+	var (
+		target  = fs.String("target", "", "device to probe, as host:port (required)")
+		https   = fs.Bool("https", false, "use TLS")
+		deep    = fs.Bool("deep", false, "assert every IS-05 endpoint, not just the first")
+		format  = fs.String("format", "text", "output format: text | json | jsonl")
+		outPath = fs.String("out", "", "write the report to this file instead of stdout")
+		failOn  = fs.String("fail-on", "", "exit non-zero when a result at or above this status is present: warn | fail")
+		timeout = fs.Duration("timeout", 10*time.Second, "per-request deadline")
+	)
+
+	// Lift a bare positional before parsing — Go's flag package stops
+	// at the first non-flag argument.
+	positional := ""
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		positional, args = args[0], args[1:]
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() > 0 {
+		return fmt.Errorf("consumer nmos profile: unexpected argument %q (one target only)", fs.Arg(0))
+	}
+	if *target == "" {
+		*target = positional
+	} else if positional != "" {
+		return fmt.Errorf("consumer nmos profile: target given twice (%q and --target %q)", positional, *target)
+	}
+	if *target == "" {
+		return fmt.Errorf("consumer nmos profile: --target is required (host:port of the device to probe)")
+	}
+
+	var gate profile.Status
+	switch strings.ToLower(*failOn) {
+	case "":
+	case "warn":
+		gate = profile.StatusWarn
+	case "fail":
+		gate = profile.StatusFail
+	default:
+		return fmt.Errorf("consumer nmos profile: unknown --fail-on %q (want warn or fail)", *failOn)
+	}
+
+	rep, err := profile.Run(ctx, profile.Options{
+		Target:  *target,
+		HTTPS:   *https,
+		Deep:    *deep,
+		Timeout: *timeout,
+	})
+	if err != nil {
+		return err
+	}
+
+	var w io.Writer = os.Stdout
+	if *outPath != "" {
+		f, ferr := os.Create(*outPath)
+		if ferr != nil {
+			return fmt.Errorf("consumer nmos profile: %w", ferr)
+		}
+		// A truncated report reads as a healthier device than the probe
+		// actually found, so a failed Close is surfaced.
+		defer func() {
+			if cerr := f.Close(); cerr != nil && err == nil {
+				err = fmt.Errorf("consumer nmos profile: writing %s: %w", *outPath, cerr)
+			}
+		}()
+		w = f
+	}
+
+	switch *format {
+	case "text":
+		err = profile.RenderText(w, rep)
+	case "json":
+		err = profile.RenderJSON(w, rep)
+	case "jsonl":
+		err = profile.RenderJSONL(w, rep)
+	default:
+		return fmt.Errorf("consumer nmos profile: unknown --format %q (want text, json or jsonl)", *format)
+	}
+	if err != nil {
+		return err
+	}
+
+	// Opt-in, like the audit's gate. Reporting is not failing, and each
+	// CI job picks its own threshold.
+	if gate == "" {
+		return nil
+	}
+	rank := map[profile.Status]int{profile.StatusPass: 0, profile.StatusSkip: 1, profile.StatusWarn: 2, profile.StatusFail: 3}
+	if worst, any := rep.Worst(); any && rank[worst] >= rank[gate] {
+		return fmt.Errorf("consumer nmos profile: worst result %s (--fail-on %s)", worst, gate)
+	}
+	return nil
+}

--- a/cmd/dhs/cmd_nmos_profile.go
+++ b/cmd/dhs/cmd_nmos_profile.go
@@ -12,7 +12,8 @@ import (
 	"dhs/internal/amwa/profile"
 )
 
-// runNMOSProfile implements `dhs consumer nmos profile`.
+// runNMOSProfile implements `dhs consumer nmos probe` (issue #839;
+// the internal package keeps its original name, profile).
 //
 // Where `export` + `audit` answer "what does this plant look like",
 // probe answers "does this device behave". The difference is the live
@@ -26,7 +27,7 @@ import (
 // connection is one that can take a live source off air, and this one
 // is meant to be safe to point at a plant that is on.
 func runNMOSProfile(ctx context.Context, args []string) (err error) {
-	fs := flag.NewFlagSet("consumer nmos profile", flag.ContinueOnError)
+	fs := flag.NewFlagSet("consumer nmos probe", flag.ContinueOnError)
 	var (
 		target  = fs.String("target", "", "device to probe, as host:port (required)")
 		https   = fs.Bool("https", false, "use TLS")
@@ -47,15 +48,15 @@ func runNMOSProfile(ctx context.Context, args []string) (err error) {
 		return err
 	}
 	if fs.NArg() > 0 {
-		return fmt.Errorf("consumer nmos profile: unexpected argument %q (one target only)", fs.Arg(0))
+		return fmt.Errorf("consumer nmos probe: unexpected argument %q (one target only)", fs.Arg(0))
 	}
 	if *target == "" {
 		*target = positional
 	} else if positional != "" {
-		return fmt.Errorf("consumer nmos profile: target given twice (%q and --target %q)", positional, *target)
+		return fmt.Errorf("consumer nmos probe: target given twice (%q and --target %q)", positional, *target)
 	}
 	if *target == "" {
-		return fmt.Errorf("consumer nmos profile: --target is required (host:port of the device to probe)")
+		return fmt.Errorf("consumer nmos probe: --target is required (host:port of the device to probe)")
 	}
 
 	var gate profile.Status
@@ -66,7 +67,7 @@ func runNMOSProfile(ctx context.Context, args []string) (err error) {
 	case "fail":
 		gate = profile.StatusFail
 	default:
-		return fmt.Errorf("consumer nmos profile: unknown --fail-on %q (want warn or fail)", *failOn)
+		return fmt.Errorf("consumer nmos probe: unknown --fail-on %q (want warn or fail)", *failOn)
 	}
 
 	rep, err := profile.Run(ctx, profile.Options{
@@ -83,13 +84,13 @@ func runNMOSProfile(ctx context.Context, args []string) (err error) {
 	if *outPath != "" {
 		f, ferr := os.Create(*outPath)
 		if ferr != nil {
-			return fmt.Errorf("consumer nmos profile: %w", ferr)
+			return fmt.Errorf("consumer nmos probe: %w", ferr)
 		}
 		// A truncated report reads as a healthier device than the probe
 		// actually found, so a failed Close is surfaced.
 		defer func() {
 			if cerr := f.Close(); cerr != nil && err == nil {
-				err = fmt.Errorf("consumer nmos profile: writing %s: %w", *outPath, cerr)
+				err = fmt.Errorf("consumer nmos probe: writing %s: %w", *outPath, cerr)
 			}
 		}()
 		w = f
@@ -103,7 +104,7 @@ func runNMOSProfile(ctx context.Context, args []string) (err error) {
 	case "jsonl":
 		err = profile.RenderJSONL(w, rep)
 	default:
-		return fmt.Errorf("consumer nmos profile: unknown --format %q (want text, json or jsonl)", *format)
+		return fmt.Errorf("consumer nmos probe: unknown --format %q (want text, json or jsonl)", *format)
 	}
 	if err != nil {
 		return err
@@ -116,7 +117,7 @@ func runNMOSProfile(ctx context.Context, args []string) (err error) {
 	}
 	rank := map[profile.Status]int{profile.StatusPass: 0, profile.StatusSkip: 1, profile.StatusWarn: 2, profile.StatusFail: 3}
 	if worst, any := rep.Worst(); any && rank[worst] >= rank[gate] {
-		return fmt.Errorf("consumer nmos profile: worst result %s (--fail-on %s)", worst, gate)
+		return fmt.Errorf("consumer nmos probe: worst result %s (--fail-on %s)", worst, gate)
 	}
 	return nil
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,6 +24,7 @@ Ansible templates render the same shape.
 - [NMOS controller: events (IS-07)](#nmos-controller-events-is-07)
 - [NMOS plant export](#nmos-plant-export)
 - [NMOS plant audit](#nmos-plant-audit)
+- [NMOS live probe](#nmos-live-probe)
 - [consumer info](#consumer-info)
 - [consumer walk](#consumer-walk)
 - [consumer get](#consumer-get)
@@ -559,6 +560,28 @@ Usage of consumer nmos audit:
     	drop findings below this severity: info | warn | error | critical (default "info")
   -out string
     	write the report to this file instead of stdout
+```
+
+## NMOS live probe
+
+`dhs consumer nmos probe --help`
+
+```text
+Usage of consumer nmos probe:
+  -deep
+    	assert every IS-05 endpoint, not just the first
+  -fail-on string
+    	exit non-zero when a result at or above this status is present: warn | fail
+  -format string
+    	output format: text | json | jsonl (default "text")
+  -https
+    	use TLS
+  -out string
+    	write the report to this file instead of stdout
+  -target string
+    	device to probe, as host:port (required)
+  -timeout duration
+    	per-request deadline (default 10s)
 ```
 
 ## consumer info

--- a/internal/amwa/audit/audit.go
+++ b/internal/amwa/audit/audit.go
@@ -29,12 +29,23 @@ type Inventory struct {
 	Senders   int `json:"senders,omitempty"`
 	Receivers int `json:"receivers,omitempty"`
 	SDPFiles  int `json:"sdp_files,omitempty"`
+
+	// HintedSenders / HintedReceivers / Groups measure BCP-002-01
+	// grouping on this device: how many resources carry a group hint,
+	// and how many distinct groups they name. This is the answer to
+	// "which nodes actually express which essences belong together".
+	HintedSenders   int `json:"hinted_senders,omitempty"`
+	HintedReceivers int `json:"hinted_receivers,omitempty"`
+	Groups          int `json:"groups,omitempty"`
 }
 
 // Result is a complete audit: what was found, and what is wrong with it.
 type Result struct {
 	Inventory []Inventory `json:"inventory"`
-	Findings  []Finding   `json:"findings"`
+	// Groups is the plant pivoted by BCP-002-01 group hint: what a
+	// controller would be able to offer as one signal.
+	Groups   []GroupRow `json:"groups,omitempty"`
+	Findings []Finding  `json:"findings"`
 	// Counts is the per-severity tally of Findings, after filtering.
 	Counts map[string]int `json:"counts"`
 }
@@ -80,6 +91,10 @@ func Run(harvests []*Harvest, opts Options) Result {
 	}
 	res.Findings = append(res.Findings, checkPlantMulticast(all)...)
 	res.Findings = append(res.Findings, checkPlantRegistration(harvests)...)
+
+	groups, groupFindings := checkPlantGroups(all)
+	res.Groups = groups
+	res.Findings = append(res.Findings, groupFindings...)
 
 	kept := res.Findings[:0]
 	for _, f := range res.Findings {
@@ -127,6 +142,7 @@ func inventoryOf(h *Harvest) Inventory {
 		inv.APIs[name] = vs
 	}
 	inv.SDPFiles = len(h.SDP)
+	inv.HintedSenders, inv.HintedReceivers, inv.Groups = hintCounts(h)
 
 	// A Registry's catalogue lives under `query`; a Node's own
 	// resources under `node`. Counting both keeps one field set

--- a/internal/amwa/audit/checks_is04.go
+++ b/internal/amwa/audit/checks_is04.go
@@ -276,13 +276,13 @@ func checkIS04Graph(h *Harvest) []Finding {
 		// edge dangles — absence of the collection is not absence of
 		// the target. A collection that WAS captured and came back
 		// empty is different: the device has said it has none.
-		if !have[toKind] || maybeShort[toKind] {
+		if !have[toKind] || maybeShort[toKind] != "" {
 			return
 		}
 		out = append(out, h.find(
 			"NMOS-IS04-DANGLING-REF", SevError,
 			strings.TrimSuffix(kind, "s")+"/"+from,
-			fmt.Sprintf("%s %s points at %s %s, which is not in the capture", field, to, strings.TrimSuffix(toKind, "s"), to),
+			fmt.Sprintf("%s points at %s %s, which is not in the capture", field, strings.TrimSuffix(toKind, "s"), to),
 			"IS-04 "+strings.TrimSuffix(kind, "s")+".json "+field,
 			"a controller drops the whole branch when a link cannot be resolved"))
 	}

--- a/internal/amwa/audit/checks_report.go
+++ b/internal/amwa/audit/checks_report.go
@@ -95,18 +95,30 @@ func checkTransportReport(h *Harvest) []Finding {
 	// Suppressing findings against a possibly-short collection is only
 	// honest if the suppression itself is reported. Otherwise a
 	// truncated capture reads as a clean plant.
+	// One finding per REASON, not one per kind: a registry that breaks
+	// the same way on six collections is one defect, but a registry
+	// whose flows cursor sticks while its senders merely end on an
+	// empty page has told us two different things, and collapsing
+	// those into one sentence loses the stronger of the two.
 	if short := truncatedKinds(h.Report); len(short) > 0 {
-		kinds := make([]string, 0, len(short))
-		for k := range short {
-			kinds = append(kinds, k)
+		byReason := map[string][]string{}
+		for kind, reason := range short {
+			byReason[reason] = append(byReason[reason], kind)
 		}
-		sort.Strings(kinds)
-		out = append(out, h.find(
-			"NMOS-AUDIT-COLLECTION-MAYBE-SHORT", SevWarn, "query",
-			fmt.Sprintf("the walk of %s ended on an empty page directly after a full one",
-				strings.Join(kinds, ", ")),
-			"IS-04 v1.3 §7 Query API paging",
-			"either the registry holds exactly one page, or its cursor stopped advancing; checks that reason from a missing resource were suppressed for these"))
+		reasons := make([]string, 0, len(byReason))
+		for r := range byReason {
+			reasons = append(reasons, r)
+		}
+		sort.Strings(reasons)
+		for _, reason := range reasons {
+			kinds := byReason[reason]
+			sort.Strings(kinds)
+			out = append(out, h.find(
+				"NMOS-AUDIT-COLLECTION-MAYBE-SHORT", SevWarn, "query",
+				fmt.Sprintf("the walk of %s %s", strings.Join(kinds, ", "), reason),
+				"IS-04 v1.3 §7 Query API paging",
+				"the capture does not prove these collections are complete, so checks that reason from a missing resource were suppressed for them"))
+		}
 	}
 
 	if len(stuck) > 0 {
@@ -222,52 +234,91 @@ func checkQueryVersionIsolation(h *Harvest) []Finding {
 	return out
 }
 
+// Reasons a collection's walk cannot be trusted to have reached the
+// end. Ordered weakest to strongest, so a kind seen under several
+// paths keeps the most definite one.
+const (
+	shortEmptyPage = "ended on an empty page directly after a full one"
+	shortDupedRows = "re-served rows it had already handed out, so page boundaries are not stable"
+	shortStuckCurs = "was abandoned when the registry's paging cursor stopped advancing"
+)
+
+// shortRank orders the reasons by how definite they are, so a kind seen
+// under several paths keeps the strongest evidence. An empty page is
+// ambiguous — it also describes a registry with exactly one page. A
+// repeated cursor is not ambiguous at all.
+func shortRank(reason string) int {
+	switch reason {
+	case shortStuckCurs:
+		return 3
+	case shortDupedRows:
+		return 2
+	default:
+		return 1
+	}
+}
+
 // truncatedKinds reads the exporter's per-page record and names the
-// resource kinds whose walk may have stopped short.
+// resource kinds whose walk may have stopped short, against the reason
+// it stopped.
 //
-// The signature is a walk that ended on an empty page immediately after
-// a FULL one. A registry holding exactly one page of resources produces
-// the same trace as a registry whose paging cursor stops advancing, and
-// nothing in the capture distinguishes them. What the two share is that
-// neither proves the collection is complete — so anything that reasons
+// Three signatures, all meaning the same thing to a check: the capture
+// does not prove this collection is complete, so anything reasoning
 // from the ABSENCE of a resource has to stand down.
 //
-// Ignoring this cost 97 dangling-reference findings on one real 44-node
-// capture: the registry served exactly 100 senders and 100 flows, and
-// every sender past the boundary appeared to point at a flow that did
-// not exist.
-func truncatedKinds(report []string) map[string]bool {
-	type walk struct {
-		increments []int
-	}
-	walks := map[string]*walk{}
-	for _, line := range report {
-		m := pageLine.FindStringSubmatch(line)
-		if m == nil {
-			continue
+//  1. A walk that ended on an empty page immediately after a FULL one.
+//     A registry holding exactly one page produces the same trace as a
+//     registry whose cursor stops advancing, and nothing in the capture
+//     separates them.
+//  2. A walk the exporter abandoned because the cursor repeated. This
+//     one is not ambiguous — the catalogue was still arriving.
+//  3. A walk that came back with more rows than unique resources. A
+//     cursor that re-serves rows can also skip them.
+//
+// Ignoring (1) cost 97 dangling-reference findings on one real 44-node
+// capture. Ignoring (2) and (3) cost 8,802 on the full plant behind it:
+// the registry's flows cursor re-served page one forever, so every one
+// of 5,168 senders appeared to point at a flow that did not exist.
+func truncatedKinds(report []string) map[string]string {
+	out := map[string]string{}
+	mark := func(path, reason string) {
+		kind := kindOfPath(path)
+		if prev, ok := out[kind]; ok && shortRank(prev) >= shortRank(reason) {
+			return
 		}
-		path, inc := m[1], m[3]
-		n, err := strconv.Atoi(inc)
-		if err != nil {
-			continue
-		}
-		w, ok := walks[path]
-		if !ok {
-			w = &walk{}
-			walks[path] = w
-		}
-		w.increments = append(w.increments, n)
+		out[kind] = reason
 	}
 
-	out := map[string]bool{}
-	for path, w := range walks {
-		if len(w.increments) < 2 {
+	increments := map[string][]int{}
+	for _, line := range report {
+		switch {
+		case pageLine.MatchString(line):
+			m := pageLine.FindStringSubmatch(line)
+			n, err := strconv.Atoi(m[3])
+			if err != nil {
+				continue
+			}
+			increments[m[1]] = append(increments[m[1]], n)
+
+		case strings.HasPrefix(line, "WARN  paging cursor did not advance"):
+			mark(pathOfStuckLine(line), shortStuckCurs)
+
+		case pagingDupe.MatchString(line):
+			m := pagingDupe.FindStringSubmatch(line)
+			rows, _ := strconv.Atoi(m[2])
+			uniq, _ := strconv.Atoi(m[3])
+			if rows > uniq {
+				mark(m[1], shortDupedRows)
+			}
+		}
+	}
+
+	for path, inc := range increments {
+		if len(inc) < 2 {
 			continue
 		}
-		last := w.increments[len(w.increments)-1]
-		prev := w.increments[len(w.increments)-2]
-		if last == 0 && prev > 0 {
-			out[kindOfPath(path)] = true
+		if inc[len(inc)-1] == 0 && inc[len(inc)-2] > 0 {
+			mark(path, shortEmptyPage)
 		}
 	}
 	return out

--- a/internal/amwa/audit/checks_test.go
+++ b/internal/amwa/audit/checks_test.go
@@ -593,6 +593,73 @@ func TestTruncatedCollectionSuppressesDanglingRefs(t *testing.T) {
 	}
 }
 
+// TestStuckCursorSuppressesDanglingRefs pins the second signature of an
+// incomplete walk. Where TestTruncatedCollectionSuppressesDanglingRefs
+// covers a walk that ended on an empty page, this covers one the
+// exporter ABANDONED because the registry re-served the same cursor —
+// the page record then ends on a FULL page, so the empty-page signature
+// never fires and every reference into the collection looks dangling.
+//
+// Measured on a real 45-node plant: the registry answered
+// /x-nmos/query/v1.3/flows with `X-Paging-Since: ""` and a rel="prev"
+// cursor carrying an empty `paging.until`, so the walk stopped at 100
+// flows. That produced 5,128 dangling-reference errors — one for every
+// sender in the plant — for one registry defect.
+func TestStuckCursorSuppressesDanglingRefs(t *testing.T) {
+	h := mk("registry", map[string]map[string]map[string]any{
+		"query": {"v1.3": {
+			"flows":   []any{},
+			"devices": []any{},
+			"senders": []any{sender(sID, map[string]any{
+				"flow_id": "99999999-9999-4999-8999-999999999999",
+			})},
+		}},
+	})
+	// Note the walk ends on a FULL page — the empty-page signature
+	// cannot fire here.
+	h.Report = []string{
+		"200   /x-nmos/query/v1.3/flows  (page 1, +100, total 100)",
+		"200   /x-nmos/query/v1.3/flows  (page 2, +100, total 200)",
+		"WARN  paging cursor did not advance for /x-nmos/query/v1.3/flows - stopping (registry paging defect)",
+		"NOTE  /x-nmos/query/v1.3/flows returned 200 rows across pages, 100 unique",
+	}
+
+	for _, f := range checkIS04Graph(h) {
+		if f.Code == "NMOS-IS04-DANGLING-REF" && strings.Contains(f.Detail, "flow_id") {
+			t.Errorf("a reference into a stuck-cursor collection was reported: %q", f.Detail)
+		}
+	}
+	// Suppression stays per collection: devices walked cleanly, so a
+	// dangling device_id is still a finding.
+	if !strings.Contains(has(t, checkIS04Graph(h), "NMOS-IS04-DANGLING-REF").Detail, "device_id") {
+		t.Error("references into a complete collection must still be reported")
+	}
+
+	// The registry defect itself must still be reported — suppressing
+	// the symptom while hiding the cause would read as a clean plant.
+	found := checkTransportReport(h)
+	has(t, found, "NMOS-QUERY-PAGING-STUCK")
+	has(t, found, "NMOS-QUERY-PAGING-DUPES")
+	f := has(t, found, "NMOS-AUDIT-COLLECTION-MAYBE-SHORT")
+	if !strings.Contains(f.Detail, "flows") || !strings.Contains(f.Detail, "cursor stopped advancing") {
+		t.Errorf("the finding must name the collection AND the reason: %q", f.Detail)
+	}
+}
+
+// TestShortReasonKeepsStrongestEvidence: a kind seen under several
+// paths reports the most definite reason, not the last one parsed. An
+// empty page is ambiguous; a repeated cursor is not.
+func TestShortReasonKeepsStrongestEvidence(t *testing.T) {
+	got := truncatedKinds([]string{
+		"200   /x-nmos/query/v1.1/flows  (page 1, +100, total 100)",
+		"200   /x-nmos/query/v1.1/flows  (page 2, +0, total 100)",
+		"WARN  paging cursor did not advance for /x-nmos/query/v1.3/flows - stopping (registry paging defect)",
+	})
+	if got["flows"] != shortStuckCurs {
+		t.Errorf("want the stuck-cursor reason to win, got %q", got["flows"])
+	}
+}
+
 func TestTruncatedKinds(t *testing.T) {
 	// A walk that ended on a non-empty page is complete.
 	if got := truncatedKinds([]string{
@@ -600,6 +667,12 @@ func TestTruncatedKinds(t *testing.T) {
 		"200   /x-nmos/query/v1.3/nodes  (page 2, +7, total 107)",
 	}); len(got) != 0 {
 		t.Errorf("a walk ending on a partial page is complete, got %v", got)
+	}
+	// Rows equal to unique is a clean walk, not a truncated one.
+	if got := truncatedKinds([]string{
+		"NOTE  /x-nmos/query/v1.3/nodes returned 40 rows across pages, 40 unique",
+	}); len(got) != 0 {
+		t.Errorf("a walk with no duplicates is complete, got %v", got)
 	}
 	// A single page is complete.
 	if got := truncatedKinds([]string{

--- a/internal/amwa/audit/groups.go
+++ b/internal/amwa/audit/groups.go
@@ -1,0 +1,320 @@
+package audit
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// GroupRow is one BCP-002-01 group as it appears across the plant.
+//
+// NMOS has no level concept. What a router calls a level, NMOS models as
+// a separate Sender/Receiver pair per essence — 2110-20 video, 2110-30
+// audio per channel group, 2110-40 ANC — so breakaway is the default and
+// routing one level is native. The hard part is the inverse: knowing
+// which essences are one signal. A group hint is the only thing in NMOS
+// that says so, and this row is what it adds up to.
+type GroupRow struct {
+	// Name is the group-hint group name, the part before the colon.
+	Name string `json:"name"`
+	// Roles are the levels present in the group, in the order a router
+	// would list them where they are recognisable.
+	Roles []string `json:"roles"`
+	// Senders and Receivers count the resources carrying this group.
+	Senders   int `json:"senders"`
+	Receivers int `json:"receivers"`
+	// Devices are the targets contributing to the group. More than one
+	// means no controller can bind the group from NMOS alone.
+	Devices []string `json:"devices"`
+}
+
+// groupAccumulator collects hints across every captured device.
+type groupAccumulator struct {
+	roles     map[string]map[string]bool
+	senders   map[string]int
+	receivers map[string]int
+	devices   map[string]map[string]bool
+}
+
+func newGroupAccumulator() *groupAccumulator {
+	return &groupAccumulator{
+		roles:     map[string]map[string]bool{},
+		senders:   map[string]int{},
+		receivers: map[string]int{},
+		devices:   map[string]map[string]bool{},
+	}
+}
+
+// add records one hint. BCP-002-01 §3 spells a hint `<group>:<role>`;
+// a role may itself contain spaces ("audio 1"), and a group name may
+// contain colons, so the split is on the LAST colon — splitting on the
+// first would make "RACK:1:video" a group called "RACK".
+func (g *groupAccumulator) add(hint, target, kind string) {
+	name, role, ok := cutLast(hint, ":")
+	if !ok {
+		return
+	}
+	name, role = strings.TrimSpace(name), strings.TrimSpace(role)
+	if name == "" {
+		return
+	}
+	if g.roles[name] == nil {
+		g.roles[name] = map[string]bool{}
+		g.devices[name] = map[string]bool{}
+	}
+	if role != "" {
+		g.roles[name][role] = true
+	}
+	g.devices[name][target] = true
+	if kind == "senders" {
+		g.senders[name]++
+	} else {
+		g.receivers[name]++
+	}
+}
+
+// cutLast splits on the last occurrence of sep.
+func cutLast(s, sep string) (before, after string, found bool) {
+	i := strings.LastIndex(s, sep)
+	if i < 0 {
+		return s, "", false
+	}
+	return s[:i], s[i+len(sep):], true
+}
+
+// rows renders the accumulator, group name order.
+func (g *groupAccumulator) rows() []GroupRow {
+	names := make([]string, 0, len(g.roles))
+	for n := range g.roles {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	out := make([]GroupRow, 0, len(names))
+	for _, n := range names {
+		out = append(out, GroupRow{
+			Name:      n,
+			Roles:     sortedRoles(g.roles[n]),
+			Senders:   g.senders[n],
+			Receivers: g.receivers[n],
+			Devices:   sortedSet(g.devices[n]),
+		})
+	}
+	return out
+}
+
+// roleOrder puts the levels an operator thinks in first, so a group
+// reads video → audio → ANC rather than alphabetically. Anything
+// unrecognised keeps its own order after them.
+var roleOrder = []string{"video", "audio", "anc", "data", "mux"}
+
+func roleRank(role string) int {
+	low := strings.ToLower(role)
+	for i, known := range roleOrder {
+		if strings.HasPrefix(low, known) {
+			return i
+		}
+	}
+	return len(roleOrder)
+}
+
+func sortedRoles(set map[string]bool) []string {
+	out := sortedSet(set)
+	sort.SliceStable(out, func(i, j int) bool {
+		ri, rj := roleRank(out[i]), roleRank(out[j])
+		if ri != rj {
+			return ri < rj
+		}
+		return out[i] < out[j]
+	})
+	return out
+}
+
+func sortedSet(set map[string]bool) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// hintProbe decodes only the tags a grouping pass needs.
+type hintProbe struct {
+	ID   string              `json:"id"`
+	Tags map[string][]string `json:"tags"`
+}
+
+// hintCounts reports how many senders and receivers on one device carry
+// a group hint, and how many distinct groups they name. This is the
+// "does this node publish BCP-002 at all" measurement.
+func hintCounts(h *Harvest) (senders, receivers, groups int) {
+	api := "node"
+	if _, ok := h.APIs["query"]; ok {
+		api = "query"
+	}
+	names := map[string]bool{}
+	for _, kind := range []string{"senders", "receivers"} {
+		items, _ := h.collect(api, kind)
+		for _, blob := range items {
+			var p hintProbe
+			if json.Unmarshal(blob, &p) != nil {
+				continue
+			}
+			hints := p.Tags[groupHintTag]
+			if len(hints) == 0 {
+				continue
+			}
+			if kind == "senders" {
+				senders++
+			} else {
+				receivers++
+			}
+			for _, hint := range hints {
+				if name, _, ok := cutLast(hint, ":"); ok && strings.TrimSpace(name) != "" {
+					names[strings.TrimSpace(name)] = true
+				}
+			}
+		}
+	}
+	return senders, receivers, len(names)
+}
+
+// checkPlantGroups pivots every captured device by group hint and
+// reports the two shapes that leave a group unusable.
+//
+// This runs plant-wide because the second shape only exists there: a
+// group whose essences live on different devices cannot be seen as one
+// from inside either of them.
+func checkPlantGroups(all []*Harvest) ([]GroupRow, []Finding) {
+	acc := newGroupAccumulator()
+	// firstSeen keeps a device per group so a finding can name where to
+	// go and look.
+	firstSeen := map[string]*Harvest{}
+
+	// A registry's catalogue is a VIEW of the nodes, not a device of its
+	// own: the same sender appears in the registry's query API and in
+	// the node's own API. Counting both makes every grouped resource
+	// look like it spans two devices and doubles its count — on one real
+	// plant that turned 4-receiver services into 7-receiver ones and
+	// invented 170 cross-device groups. Nodes are walked first and their
+	// resource ids remembered, so a registry only ever contributes
+	// resources no node capture covered.
+	ordered := make([]*Harvest, 0, len(all))
+	for _, h := range all {
+		if h.Role != "registry" {
+			ordered = append(ordered, h)
+		}
+	}
+	for _, h := range all {
+		if h.Role == "registry" {
+			ordered = append(ordered, h)
+		}
+	}
+
+	seenResource := map[string]bool{}
+	for _, h := range ordered {
+		api := "node"
+		if _, ok := h.APIs["query"]; ok {
+			api = "query"
+		}
+		for _, kind := range []string{"senders", "receivers"} {
+			items, _ := h.collect(api, kind)
+			for _, blob := range items {
+				var p hintProbe
+				if json.Unmarshal(blob, &p) != nil {
+					continue
+				}
+				if p.ID != "" {
+					if seenResource[p.ID] {
+						continue
+					}
+					seenResource[p.ID] = true
+				}
+				for _, hint := range p.Tags[groupHintTag] {
+					acc.add(hint, h.Name(), kind)
+					if name, _, ok := cutLast(hint, ":"); ok {
+						name = strings.TrimSpace(name)
+						if _, seen := firstSeen[name]; !seen && name != "" {
+							firstSeen[name] = h
+						}
+					}
+				}
+			}
+		}
+	}
+
+	rows := acc.rows()
+	var out []Finding
+
+	// Collapse the single-role case into one finding per device. A
+	// Neuron publishes one group per essence, so per-group findings
+	// would be 176 lines saying the same thing.
+	singleByDevice := map[string][]string{}
+
+	for _, r := range rows {
+		if len(r.Roles) <= 1 && len(r.Devices) == 1 {
+			singleByDevice[r.Devices[0]] = append(singleByDevice[r.Devices[0]], r.Name)
+		}
+		if len(r.Devices) > 1 {
+			h := firstSeen[r.Name]
+			if h == nil {
+				continue
+			}
+			// Two very different situations produce this, and a capture
+			// cannot tell them apart: one signal genuinely spanning
+			// devices, or a group name that is simply not unique across
+			// the plant. Both need saying, because the second is worse
+			// — a controller merging by name fuses unrelated devices
+			// into one bogus signal.
+			out = append(out, h.find(
+				"NMOS-BCP002-GROUP-CROSS-DEVICE", SevWarn, "group/"+r.Name,
+				fmt.Sprintf("group %q appears on %d devices: %s", r.Name, len(r.Devices), strings.Join(r.Devices, ", ")),
+				"BCP-002-01 v1.0 §3 grouphint",
+				"either one signal spans them — which IS-04 cannot express, so a controller needs its own signal database — or the name is not unique across the plant, and a controller grouping by name would fuse unrelated devices"))
+		}
+	}
+
+	for _, dev := range sortedSet(toSet(keysOfStrings(singleByDevice))) {
+		names := singleByDevice[dev]
+		sort.Strings(names)
+		h := firstSeen[names[0]]
+		if h == nil {
+			continue
+		}
+		out = append(out, h.find(
+			"NMOS-BCP002-GROUP-SINGLE-ROLE", SevWarn, "groups",
+			fmt.Sprintf("%d group(s) on %s hold exactly one role, so they express no association between essences: %s",
+				len(names), dev, examplesOf(names)),
+			"BCP-002-01 v1.0 §3 grouphint",
+			"a controller cannot offer \"route all levels\" or a breakaway when each essence is its own group"))
+	}
+
+	return rows, out
+}
+
+func keysOfStrings(m map[string][]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func toSet(ss []string) map[string]bool {
+	out := make(map[string]bool, len(ss))
+	for _, s := range ss {
+		out[s] = true
+	}
+	return out
+}
+
+// examplesOf names up to three groups, so a finding is actionable
+// without printing 176 UUID-shaped names.
+func examplesOf(names []string) string {
+	if len(names) <= 3 {
+		return strings.Join(names, ", ")
+	}
+	return strings.Join(names[:3], ", ") + fmt.Sprintf(" (+%d more)", len(names)-3)
+}

--- a/internal/amwa/audit/groups_test.go
+++ b/internal/amwa/audit/groups_test.go
@@ -1,0 +1,309 @@
+package audit
+
+import (
+	"strings"
+	"testing"
+)
+
+// hinted builds a sender or receiver carrying group hints.
+func hinted(id string, hints ...string) map[string]any {
+	return sender(id, map[string]any{
+		"tags": map[string]any{groupHintTag: hints},
+	})
+}
+
+// TestGroupPivotBuildsLevels is the shape a controller needs: one group
+// holding several roles, which is what makes "route all levels" and a
+// breakaway possible.
+func TestGroupPivotBuildsLevels(t *testing.T) {
+	h := mk("node", map[string]map[string]map[string]any{
+		"node": {"v1.3": {
+			"senders": []any{
+				hinted("44444444-4444-4444-8444-444444444444", "CAM-01:Video 1"),
+				hinted("55555555-5555-4555-8555-555555555555", "CAM-01:Audio 1"),
+				hinted("66666666-6666-4666-8666-666666666666", "CAM-01:Anc 1"),
+			},
+			"receivers": []any{},
+		}},
+	})
+
+	rows, findings := checkPlantGroups([]*Harvest{h})
+	if len(rows) != 1 {
+		t.Fatalf("want 1 group, got %d: %v", len(rows), rows)
+	}
+	g := rows[0]
+	if g.Name != "CAM-01" {
+		t.Errorf("group name = %q", g.Name)
+	}
+	if g.Senders != 3 || g.Receivers != 0 {
+		t.Errorf("counts = %d/%d, want 3/0", g.Senders, g.Receivers)
+	}
+	// Roles read video → audio → anc, the order an operator thinks in,
+	// not alphabetically.
+	if got := strings.Join(g.Roles, ","); got != "Video 1,Audio 1,Anc 1" {
+		t.Errorf("roles = %q, want video then audio then anc", got)
+	}
+	// A properly grouped signal is not a finding.
+	for _, f := range findings {
+		if strings.HasPrefix(f.Code, "NMOS-BCP002-GROUP") {
+			t.Errorf("a well-formed group produced %s: %s", f.Code, f.Detail)
+		}
+	}
+}
+
+// TestSingleRoleGroupsReported is the real EVS Neuron pathology: every
+// hint present, syntactically valid, and grouping nothing — each
+// essence is its own group named after itself.
+func TestSingleRoleGroupsReported(t *testing.T) {
+	h := mk("node", map[string]map[string]map[string]any{
+		"node": {"v1.3": {
+			"senders": []any{
+				hinted("44444444-4444-4444-8444-444444444444", "ARX-01:s2110-30"),
+				hinted("55555555-5555-4555-8555-555555555555", "ARX-02:s2110-30"),
+				hinted("66666666-6666-4666-8666-666666666666", "ARX-03:s2110-30"),
+			},
+			"receivers": []any{},
+		}},
+	})
+
+	rows, findings := checkPlantGroups([]*Harvest{h})
+	if len(rows) != 3 {
+		t.Fatalf("want 3 single-role groups, got %d", len(rows))
+	}
+
+	// One finding per device, not one per group: a 176-sender node would
+	// otherwise emit 176 lines saying the same thing.
+	var got []Finding
+	for _, f := range findings {
+		if f.Code == "NMOS-BCP002-GROUP-SINGLE-ROLE" {
+			got = append(got, f)
+		}
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 grouped finding, got %d", len(got))
+	}
+	if !strings.Contains(got[0].Detail, "3 group(s)") {
+		t.Errorf("the finding should name the count: %q", got[0].Detail)
+	}
+	if !strings.Contains(got[0].Hint, "breakaway") {
+		t.Errorf("the hint should say what it costs the operator: %q", got[0].Hint)
+	}
+}
+
+// TestCrossDeviceGroupReported covers both readings of the same
+// observation, because a capture cannot tell them apart.
+func TestCrossDeviceGroupReported(t *testing.T) {
+	a := mk("node", map[string]map[string]map[string]any{
+		"node": {"v1.3": {
+			"senders":   []any{hinted("44444444-4444-4444-8444-444444444444", "device_1:source_1")},
+			"receivers": []any{},
+		}},
+	})
+	a.Label = "node-a"
+	b := mk("node", map[string]map[string]map[string]any{
+		"node": {"v1.3": {
+			"senders":   []any{hinted("55555555-5555-4555-8555-555555555555", "device_1:source_2")},
+			"receivers": []any{},
+		}},
+	})
+	b.Label = "node-b"
+
+	rows, findings := checkPlantGroups([]*Harvest{a, b})
+	if len(rows) != 1 || len(rows[0].Devices) != 2 {
+		t.Fatalf("want one group across two devices, got %v", rows)
+	}
+	f := has(t, findings, "NMOS-BCP002-GROUP-CROSS-DEVICE")
+	for _, want := range []string{"node-a", "node-b", "device_1"} {
+		if !strings.Contains(f.Detail, want) {
+			t.Errorf("detail %q missing %q", f.Detail, want)
+		}
+	}
+	// Both readings must be offered — the name-collision one is the
+	// dangerous half.
+	if !strings.Contains(f.Hint, "not unique") {
+		t.Errorf("the hint must offer the name-collision reading: %q", f.Hint)
+	}
+}
+
+// TestRegistryViewDoesNotDoubleCount is the bug this check shipped with
+// and had to have fixed: a registry's catalogue is a VIEW of its nodes,
+// so counting both turned 4-receiver services into 7-receiver ones and
+// invented 170 cross-device groups on one real plant.
+func TestRegistryViewDoesNotDoubleCount(t *testing.T) {
+	const sid = "44444444-4444-4444-8444-444444444444"
+
+	node := mk("node", map[string]map[string]map[string]any{
+		"node": {"v1.3": {
+			"senders":   []any{hinted(sid, "Service 01:Video 1")},
+			"receivers": []any{},
+		}},
+	})
+	node.Label = "the-node"
+
+	reg := mk("registry", map[string]map[string]map[string]any{
+		"query": {"v1.3": {
+			"senders":   []any{hinted(sid, "Service 01:Video 1")},
+			"receivers": []any{},
+		}},
+	})
+	reg.Label = "the-registry"
+
+	// Registry first in the slice, to prove the ordering is enforced by
+	// the check and not by luck.
+	rows, findings := checkPlantGroups([]*Harvest{reg, node})
+	if len(rows) != 1 {
+		t.Fatalf("want 1 group, got %d", len(rows))
+	}
+	if rows[0].Senders != 1 {
+		t.Errorf("sender count = %d, want 1 — the registry view was counted again", rows[0].Senders)
+	}
+	if len(rows[0].Devices) != 1 || rows[0].Devices[0] != "the-node" {
+		t.Errorf("devices = %v, want just the node that owns the resource", rows[0].Devices)
+	}
+	for _, f := range findings {
+		if f.Code == "NMOS-BCP002-GROUP-CROSS-DEVICE" {
+			t.Errorf("a registry view produced a phantom cross-device finding: %s", f.Detail)
+		}
+	}
+}
+
+// TestRegistryOnlyCaptureStillGroups: when nothing but a registry was
+// captured, its catalogue is all there is and must still be used.
+func TestRegistryOnlyCaptureStillGroups(t *testing.T) {
+	reg := mk("registry", map[string]map[string]map[string]any{
+		"query": {"v1.3": {
+			"senders": []any{
+				hinted("44444444-4444-4444-8444-444444444444", "CAM-01:Video 1"),
+				hinted("55555555-5555-4555-8555-555555555555", "CAM-01:Audio 1"),
+			},
+			"receivers": []any{},
+		}},
+	})
+	rows, _ := checkPlantGroups([]*Harvest{reg})
+	if len(rows) != 1 || rows[0].Senders != 2 {
+		t.Fatalf("a registry-only capture must still group: %v", rows)
+	}
+}
+
+// TestHintCountsMeasureCoverage is the "which nodes expose BCP-002"
+// inventory column.
+func TestHintCountsMeasureCoverage(t *testing.T) {
+	h := mk("node", map[string]map[string]map[string]any{
+		"node": {"v1.3": {
+			"senders": []any{
+				hinted("44444444-4444-4444-8444-444444444444", "CAM-01:Video 1"),
+				sender("55555555-5555-4555-8555-555555555555", nil), // no hint
+			},
+			"receivers": []any{hinted("88888888-8888-4888-8888-888888888888", "CAM-01:Audio 1")},
+		}},
+	})
+	s, r, groups := hintCounts(h)
+	if s != 1 || r != 1 || groups != 1 {
+		t.Errorf("hintCounts = %d,%d,%d; want 1,1,1", s, r, groups)
+	}
+
+	// A device with no hints at all reports zeroes rather than being
+	// omitted — "publishes none" is a finding, not an absence.
+	bare := mk("node", map[string]map[string]map[string]any{
+		"node": {"v1.3": {"senders": []any{sender(sID, nil)}, "receivers": []any{}}},
+	})
+	if s, r, g := hintCounts(bare); s != 0 || r != 0 || g != 0 {
+		t.Errorf("hintCounts on an unhinted device = %d,%d,%d", s, r, g)
+	}
+}
+
+// TestHintSplitsOnLastColon: a role may contain spaces and a group name
+// may contain colons, so splitting on the FIRST colon would turn
+// "RACK:1:video" into a group called "RACK".
+func TestHintSplitsOnLastColon(t *testing.T) {
+	acc := newGroupAccumulator()
+	acc.add("RACK:1:Video 1", "dev", "senders")
+	rows := acc.rows()
+	if len(rows) != 1 {
+		t.Fatalf("want 1 group, got %v", rows)
+	}
+	if rows[0].Name != "RACK:1" {
+		t.Errorf("group name = %q, want RACK:1", rows[0].Name)
+	}
+	if len(rows[0].Roles) != 1 || rows[0].Roles[0] != "Video 1" {
+		t.Errorf("roles = %v, want [Video 1]", rows[0].Roles)
+	}
+}
+
+// TestMalformedHintsIgnored: a hint with no colon groups nothing, and
+// must not create a group keyed on the whole string.
+func TestMalformedHintsIgnored(t *testing.T) {
+	acc := newGroupAccumulator()
+	acc.add("no-colon-here", "dev", "senders")
+	acc.add(":only-a-role", "dev", "senders")
+	acc.add("", "dev", "senders")
+	if rows := acc.rows(); len(rows) != 0 {
+		t.Errorf("malformed hints produced groups: %v", rows)
+	}
+}
+
+// TestGroupsAppearInEveryRenderer proves the pivot reaches the operator
+// in each output form.
+func TestGroupsAppearInEveryRenderer(t *testing.T) {
+	res := loadPlant(t)
+	// The fixture plant has one hinted sender: cam-01 iso, "cam-01:video".
+	if len(res.Groups) == 0 {
+		t.Fatal("the fixture plant has a group hint; the pivot found none")
+	}
+
+	var b strings.Builder
+	if err := RenderText(&b, res); err != nil {
+		t.Fatal(err)
+	}
+	s := b.String()
+	for _, want := range []string{"GROUPING (BCP-002-01)", "ROLES (levels)", "cam-01"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("text report missing %q", want)
+		}
+	}
+	// Grouping is printed before the findings, because it changes how
+	// they read.
+	if strings.Index(s, "GROUPING") > strings.Index(s, "FINDINGS") {
+		t.Error("grouping must come before the findings")
+	}
+}
+
+// TestNoHintsAnywhereSaysSo: a plant with no grouping at all is the
+// worst case for a controller, and the report must state it rather than
+// print an empty table.
+func TestNoHintsAnywhereSaysSo(t *testing.T) {
+	var b strings.Builder
+	res := Result{
+		Counts:    map[string]int{},
+		Inventory: []Inventory{{Target: "h:1", Senders: 4}},
+	}
+	if err := RenderText(&b, res); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(b.String(), "no group hints anywhere") {
+		t.Errorf("an ungrouped plant should say so explicitly:\n%s", b.String())
+	}
+	// The coverage column reads 0/4, not blank.
+	if !strings.Contains(b.String(), "0/4") {
+		t.Error("the inventory should show 0/4 rather than an empty cell")
+	}
+}
+
+func TestOfTotal(t *testing.T) {
+	if got := ofTotal(0, 0); got != "-" {
+		t.Errorf("nothing to cover should read %q, got %q", "-", got)
+	}
+	if got := ofTotal(3, 176); got != "3/176" {
+		t.Errorf("ofTotal = %q", got)
+	}
+}
+
+func TestRoleOrdering(t *testing.T) {
+	got := sortedRoles(map[string]bool{"Anc 1": true, "Audio 2": true, "Video 1": true, "zzz": true, "Audio 1": true})
+	want := []string{"Video 1", "Audio 1", "Audio 2", "Anc 1", "zzz"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("sortedRoles = %v, want %v", got, want)
+		}
+	}
+}

--- a/internal/amwa/audit/render.go
+++ b/internal/amwa/audit/render.go
@@ -45,6 +45,43 @@ func RenderText(w io.Writer, r Result) error {
 		bw.printf("%-24s %s\n", trunc(inv.Target, 24), strings.Join(parts, " "))
 	}
 
+	// Grouping comes before the findings because it changes how they
+	// read. "13 hints absent" means one thing on a plant with 40 healthy
+	// groups and another on a plant with none.
+	bw.printf("\nGROUPING (BCP-002-01) — which devices say what belongs together\n\n")
+	bw.printf("%-24s %-28s %6s %6s %7s\n", "TARGET", "LABEL", "SND+", "RCV+", "GROUPS")
+	bw.printf("%s\n", strings.Repeat("-", 78))
+	for _, inv := range r.Inventory {
+		if inv.Senders == 0 && inv.Receivers == 0 {
+			continue
+		}
+		bw.printf("%-24s %-28s %6s %6s %7d\n",
+			trunc(inv.Target, 24), trunc(inv.Label, 28),
+			ofTotal(inv.HintedSenders, inv.Senders),
+			ofTotal(inv.HintedReceivers, inv.Receivers),
+			inv.Groups)
+	}
+	if len(r.Groups) == 0 {
+		bw.printf("\n  no group hints anywhere in this plant — a controller sees a flat\n")
+		bw.printf("  list of essences and cannot offer a grouped route or a breakaway\n")
+	} else {
+		bw.printf("\n%-28s %-34s %5s %5s %s\n", "GROUP", "ROLES (levels)", "SND", "RCV", "DEVICES")
+		bw.printf("%s\n", strings.Repeat("-", 78))
+		shown := r.Groups
+		const maxGroups = 40
+		if len(shown) > maxGroups {
+			shown = shown[:maxGroups]
+		}
+		for _, g := range shown {
+			bw.printf("%-28s %-34s %5d %5d %s\n",
+				trunc(g.Name, 28), trunc(strings.Join(g.Roles, ", "), 34),
+				g.Senders, g.Receivers, trunc(strings.Join(g.Devices, ", "), 20))
+		}
+		if len(r.Groups) > maxGroups {
+			bw.printf("  … %d more group(s); use --format json for the full pivot\n", len(r.Groups)-maxGroups)
+		}
+	}
+
 	bw.printf("\nFINDINGS — %d\n\n", len(r.Findings))
 	if len(r.Findings) == 0 {
 		bw.printf("  none at or above the requested severity\n")
@@ -116,6 +153,16 @@ func (e *errWriter) printf(format string, args ...any) {
 		return
 	}
 	_, e.err = fmt.Fprintf(e.w, format, args...)
+}
+
+// ofTotal renders "3/176", or a bare dash when the device publishes
+// nothing of that kind — an empty cell reads as zero coverage, which is
+// a different statement from having nothing to cover.
+func ofTotal(n, total int) string {
+	if total == 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%d/%d", n, total)
 }
 
 // trunc clips a column value, marking that it was clipped.

--- a/internal/amwa/profile/checks.go
+++ b/internal/amwa/profile/checks.go
@@ -1,0 +1,571 @@
+package profile
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// checkRoot fetches /x-nmos and records which APIs the device serves.
+// Every later check depends on this, so it also populates the session.
+func checkRoot(ctx context.Context, s *Session) []Result {
+	const (
+		id   = "PROFILE-ROOT-001"
+		name = "/x-nmos lists the APIs served"
+		spec = "IS-04 v1.3 §4 API paths"
+	)
+	r := s.get(ctx, "/x-nmos")
+	switch {
+	case r.Err != nil:
+		return []Result{s.result(id, name, spec, StatusFail, r,
+			fmt.Sprintf("GET /x-nmos did not complete: %v", r.Err))}
+	case r.Status != http.StatusOK:
+		return []Result{s.result(id, name, spec, StatusFail, r,
+			fmt.Sprintf("GET /x-nmos returned %d, want 200", r.Status))}
+	}
+
+	names, ok := jsonArray(r.Body)
+	if !ok {
+		return []Result{s.result(id, name, spec, StatusFail, r,
+			"GET /x-nmos did not return a JSON array of API names")}
+	}
+
+	out := []Result{s.result(id, name, spec, StatusPass, r,
+		fmt.Sprintf("GET /x-nmos returned %d API(s): %s", len(names), strings.Join(names, " ")))}
+
+	// Discover the version list for each, so the later checks know what
+	// to ask for. Failures here are reported by checkVersionLists.
+	for _, api := range names {
+		api = strings.TrimSuffix(api, "/")
+		if api == "" {
+			continue
+		}
+		vr := s.get(ctx, "/x-nmos/"+api+"/")
+		if vr.Status != http.StatusOK {
+			s.APIs[api] = nil
+			continue
+		}
+		vs, ok := jsonArray(vr.Body)
+		if !ok {
+			s.APIs[api] = nil
+			continue
+		}
+		for i := range vs {
+			vs[i] = strings.TrimSuffix(vs[i], "/")
+		}
+		s.APIs[api] = vs
+	}
+	return out
+}
+
+// checkVersionLists asserts every advertised version is well-formed.
+//
+// A version string a controller cannot parse is a version it cannot
+// select, and version selection is the first thing every NMOS peer
+// does.
+func checkVersionLists(_ context.Context, s *Session) []Result {
+	const (
+		id   = "PROFILE-VER-001"
+		name = "each API advertises parseable versions"
+		spec = "IS-04 v1.3 §6.1 API versioning"
+	)
+	if len(s.APIs) == 0 {
+		return []Result{s.skip(id, name, spec, "no APIs were discovered")}
+	}
+
+	var out []Result
+	for _, api := range sortedKeys(s.APIs) {
+		vs := s.APIs[api]
+		res := Result{ID: id, Name: name, Spec: spec, Target: s.opts.Target}
+		switch {
+		case len(vs) == 0:
+			res.Status = StatusFail
+			res.Detail = fmt.Sprintf("GET /x-nmos/%s/ returned no usable version list", api)
+		default:
+			bad := []string{}
+			for _, v := range vs {
+				if !versionPattern.MatchString(v) {
+					bad = append(bad, v)
+				}
+			}
+			if len(bad) > 0 {
+				res.Status = StatusFail
+				res.Detail = fmt.Sprintf("/x-nmos/%s/ advertises %v, which is not vMAJOR.MINOR", api, bad)
+			} else {
+				res.Status = StatusPass
+				res.Detail = fmt.Sprintf("/x-nmos/%s/ advertises %s", api, strings.Join(vs, ","))
+			}
+		}
+		out = append(out, res)
+	}
+	return out
+}
+
+// checkUnknownVersionRejected asks for a version the device does not
+// serve.
+//
+// A device that answers 200 to /x-nmos/query/v9.9/nodes is telling a
+// controller it speaks a version it does not, and the controller will
+// then send v9.9 requests it cannot handle. The failure surfaces later,
+// somewhere else, as malformed data.
+func checkUnknownVersionRejected(ctx context.Context, s *Session) []Result {
+	const (
+		id   = "PROFILE-VER-002"
+		name = "an unknown API version is rejected"
+		spec = "IS-04 v1.3 §6.1 API versioning"
+	)
+	api, _, ok := s.queryOrNode()
+	if !ok {
+		return []Result{s.skip(id, name, spec, "device serves neither a query nor a node API")}
+	}
+
+	path := "/x-nmos/" + api + "/v9.9/"
+	r := s.get(ctx, path)
+	switch {
+	case r.Err != nil:
+		return []Result{s.result(id, name, spec, StatusFail, r,
+			fmt.Sprintf("GET %s did not complete: %v", path, r.Err))}
+	case r.Status == http.StatusNotFound:
+		return []Result{s.result(id, name, spec, StatusPass, r,
+			fmt.Sprintf("GET %s returned 404", path))}
+	case r.Status >= 500:
+		return []Result{s.result(id, name, spec, StatusFail, r,
+			fmt.Sprintf("GET %s returned %d — an unsupported version must 404, not fault", path, r.Status))}
+	case r.Status < 400:
+		return []Result{s.result(id, name, spec, StatusFail, r,
+			fmt.Sprintf("GET %s returned %d — the device claims to serve a version it does not advertise", path, r.Status))}
+	default:
+		return []Result{s.result(id, name, spec, StatusWarn, r,
+			fmt.Sprintf("GET %s returned %d; 404 is the spec's answer", path, r.Status))}
+	}
+}
+
+// checkCORS asserts the headers a browser-based controller needs.
+//
+// IS-04 requires CORS on every API. Without it every web controller
+// fails at the first request, with an error that names the browser
+// rather than the device — which is why this is worth asserting
+// explicitly rather than discovering during an integration.
+func checkCORS(ctx context.Context, s *Session) []Result {
+	const spec = "IS-04 v1.3 §5 Cross-Origin Resource Sharing"
+
+	get := s.get(ctx, "/x-nmos")
+	origin := get.Header.Get("Access-Control-Allow-Origin")
+
+	out := []Result{}
+	switch {
+	case get.Err != nil || get.Status != http.StatusOK:
+		out = append(out, s.skip("PROFILE-CORS-001", "GET carries Access-Control-Allow-Origin", spec,
+			"/x-nmos did not answer"))
+	case origin == "":
+		out = append(out, s.result("PROFILE-CORS-001", "GET carries Access-Control-Allow-Origin", spec,
+			StatusFail, get, "GET /x-nmos returned no Access-Control-Allow-Origin header — no browser-based controller can read this API"))
+	default:
+		out = append(out, s.result("PROFILE-CORS-001", "GET carries Access-Control-Allow-Origin", spec,
+			StatusPass, get, "Access-Control-Allow-Origin: "+origin))
+	}
+
+	// The preflight matters separately: a browser sends OPTIONS before
+	// any request carrying a custom header, and a device that answers
+	// GET correctly can still refuse the preflight.
+	pre := s.request(ctx, http.MethodOptions, "/x-nmos", http.Header{
+		"Origin":                        []string{"http://profile.invalid"},
+		"Access-Control-Request-Method": []string{"GET"},
+	})
+	const (
+		preID   = "PROFILE-CORS-002"
+		preName = "OPTIONS preflight is answered"
+	)
+	switch {
+	case pre.Err != nil:
+		out = append(out, s.result(preID, preName, spec, StatusFail, pre,
+			fmt.Sprintf("OPTIONS /x-nmos did not complete: %v", pre.Err)))
+	case pre.Status >= 400:
+		out = append(out, s.result(preID, preName, spec, StatusFail, pre,
+			fmt.Sprintf("OPTIONS /x-nmos returned %d — browsers will not proceed past the preflight", pre.Status)))
+	case pre.Header.Get("Access-Control-Allow-Methods") == "":
+		out = append(out, s.result(preID, preName, spec, StatusWarn, pre,
+			fmt.Sprintf("OPTIONS /x-nmos returned %d but named no Access-Control-Allow-Methods", pre.Status)))
+	default:
+		out = append(out, s.result(preID, preName, spec, StatusPass, pre,
+			"Access-Control-Allow-Methods: "+pre.Header.Get("Access-Control-Allow-Methods")))
+	}
+	return out
+}
+
+// checkContentType asserts JSON endpoints say they serve JSON.
+func checkContentType(ctx context.Context, s *Session) []Result {
+	const (
+		id   = "PROFILE-CT-001"
+		name = "JSON endpoints declare application/json"
+		spec = "IS-04 v1.3 §4 — all APIs use application/json"
+	)
+	r := s.get(ctx, "/x-nmos")
+	if r.Err != nil || r.Status != http.StatusOK {
+		return []Result{s.skip(id, name, spec, "/x-nmos did not answer")}
+	}
+	ct := r.Header.Get("Content-Type")
+	switch {
+	case ct == "":
+		return []Result{s.result(id, name, spec, StatusFail, r, "GET /x-nmos returned no Content-Type")}
+	case strings.HasPrefix(strings.ToLower(ct), "application/json"):
+		return []Result{s.result(id, name, spec, StatusPass, r, "Content-Type: "+ct)}
+	default:
+		return []Result{s.result(id, name, spec, StatusFail, r,
+			fmt.Sprintf("GET /x-nmos returned Content-Type %q, want application/json", ct))}
+	}
+}
+
+// checkUnknownResource asks for a resource that does not exist.
+//
+// The distinction that matters is 404 versus 500. A controller retries
+// a 500 — it reads as "the device is unwell" — and gives up on a 404,
+// which reads as "that thing is gone". A device that 500s on a missing
+// resource turns every stale reference into a retry storm.
+func checkUnknownResource(ctx context.Context, s *Session) []Result {
+	const (
+		id   = "PROFILE-404-001"
+		name = "a missing resource returns 404, not a fault"
+		spec = "IS-04 v1.3 §4 error response"
+	)
+	api, ver, ok := s.queryOrNode()
+	if !ok {
+		return []Result{s.skip(id, name, spec, "device serves neither a query nor a node API")}
+	}
+	if api == "node" {
+		return []Result{s.skip(id, name, spec, "node API has no per-id resource path to check safely")}
+	}
+
+	const absent = "00000000-0000-4000-8000-000000000000"
+	path := "/x-nmos/" + api + "/" + ver + "/nodes/" + absent
+	r := s.get(ctx, path)
+
+	out := []Result{}
+	switch {
+	case r.Err != nil:
+		out = append(out, s.result(id, name, spec, StatusFail, r,
+			fmt.Sprintf("GET %s did not complete: %v", path, r.Err)))
+		return out
+	case r.Status == http.StatusNotFound:
+		out = append(out, s.result(id, name, spec, StatusPass, r,
+			fmt.Sprintf("GET %s returned 404", path)))
+	case r.Status >= 500:
+		out = append(out, s.result(id, name, spec, StatusFail, r,
+			fmt.Sprintf("GET %s returned %d — controllers retry a fault and abandon a 404", path, r.Status)))
+		return out
+	default:
+		out = append(out, s.result(id, name, spec, StatusFail, r,
+			fmt.Sprintf("GET %s returned %d for a resource that does not exist", path, r.Status)))
+		return out
+	}
+
+	// IS-04 defines the error body shape. A controller that wants to
+	// tell the operator WHY has nothing to show without it.
+	const (
+		bodyID   = "PROFILE-404-002"
+		bodyName = "the 404 body carries the IS-04 error object"
+	)
+	var e struct {
+		Code  *int    `json:"code"`
+		Error *string `json:"error"`
+		Debug any     `json:"debug"`
+	}
+	switch {
+	case json.Unmarshal(r.Body, &e) != nil:
+		out = append(out, s.result(bodyID, bodyName, spec, StatusWarn, r,
+			"the 404 body is not a JSON object"))
+	case e.Code == nil || e.Error == nil:
+		out = append(out, s.result(bodyID, bodyName, spec, StatusWarn, r,
+			"the 404 body omits code and/or error"))
+	default:
+		out = append(out, s.result(bodyID, bodyName, spec, StatusPass, r,
+			fmt.Sprintf("404 body: code=%d error=%q", *e.Code, *e.Error)))
+	}
+	return out
+}
+
+// checkTrailingSlash asserts a version root answers with or without its
+// trailing slash.
+//
+// Controllers build these URLs by concatenation and disagree about the
+// slash. A device that serves one and 404s the other works with half
+// the controllers on the market.
+func checkTrailingSlash(ctx context.Context, s *Session) []Result {
+	const (
+		id   = "PROFILE-PATH-001"
+		name = "a version root answers with and without a trailing slash"
+		spec = "IS-04 v1.3 §4 API paths"
+	)
+	api, ver, ok := s.queryOrNode()
+	if !ok {
+		return []Result{s.skip(id, name, spec, "device serves neither a query nor a node API")}
+	}
+
+	base := "/x-nmos/" + api + "/" + ver
+	with := s.get(ctx, base+"/")
+	without := s.get(ctx, base)
+
+	okStatus := func(c int) bool { return c == http.StatusOK || (c >= 300 && c < 400) }
+	switch {
+	case with.Err != nil || without.Err != nil:
+		return []Result{s.result(id, name, spec, StatusFail, with, "one of the two requests did not complete")}
+	case okStatus(with.Status) && okStatus(without.Status):
+		return []Result{s.result(id, name, spec, StatusPass, with,
+			fmt.Sprintf("%s/ → %d, %s → %d", base, with.Status, base, without.Status))}
+	default:
+		return []Result{s.result(id, name, spec, StatusWarn, with,
+			fmt.Sprintf("%s/ → %d but %s → %d; controllers build these URLs both ways",
+				base, with.Status, base, without.Status))}
+	}
+}
+
+// checkQueryPaging asserts the Query API's paging contract.
+//
+// This is the defect that produced an 11-node capture of a 68-node
+// registry, and it is invisible unless you ask for a limit and count
+// what comes back.
+func checkQueryPaging(ctx context.Context, s *Session) []Result {
+	const spec = "IS-04 v1.3 §7 Query API paging"
+	vs, has := s.APIs["query"]
+	if !has || len(vs) == 0 {
+		return []Result{s.skip("PROFILE-PAGE-001", "paging.limit is honoured", spec, "device serves no query API")}
+	}
+	ver := highestVersion(vs)
+	path := "/x-nmos/query/" + ver + "/nodes?paging.limit=1"
+	r := s.get(ctx, path)
+
+	if r.Err != nil || r.Status != http.StatusOK {
+		return []Result{s.skip("PROFILE-PAGE-001", "paging.limit is honoured", spec,
+			fmt.Sprintf("GET %s returned %d", path, r.Status))}
+	}
+
+	var items []json.RawMessage
+	if json.Unmarshal(r.Body, &items) != nil {
+		return []Result{s.result("PROFILE-PAGE-001", "paging.limit is honoured", spec, StatusFail, r,
+			fmt.Sprintf("GET %s did not return a JSON array", path))}
+	}
+
+	out := []Result{}
+	if len(items) > 1 {
+		out = append(out, s.result("PROFILE-PAGE-001", "paging.limit is honoured", spec, StatusFail, r,
+			fmt.Sprintf("GET %s returned %d resources", path, len(items))))
+	} else {
+		out = append(out, s.result("PROFILE-PAGE-001", "paging.limit is honoured", spec, StatusPass, r,
+			fmt.Sprintf("GET %s returned %d resource(s)", path, len(items))))
+	}
+
+	// The paging headers are how a client knows where it is. Without
+	// them it cannot resume, and cannot tell a short page from the end.
+	const (
+		hdrID   = "PROFILE-PAGE-002"
+		hdrName = "paging headers are returned"
+	)
+	missing := []string{}
+	for _, h := range []string{"X-Paging-Limit", "X-Paging-Since", "X-Paging-Until"} {
+		if r.Header.Get(h) == "" {
+			missing = append(missing, h)
+		}
+	}
+	if len(missing) > 0 {
+		out = append(out, s.result(hdrID, hdrName, spec, StatusWarn, r,
+			fmt.Sprintf("GET %s omitted %s", path, strings.Join(missing, ", "))))
+	} else {
+		out = append(out, s.result(hdrID, hdrName, spec, StatusPass, r,
+			fmt.Sprintf("X-Paging-Limit=%s Since=%s Until=%s",
+				r.Header.Get("X-Paging-Limit"), r.Header.Get("X-Paging-Since"), r.Header.Get("X-Paging-Until"))))
+	}
+
+	// A Link: rel="next" is what a walker follows. Its absence on a
+	// full page means the catalogue cannot be walked to the end.
+	const (
+		linkID   = "PROFILE-PAGE-003"
+		linkName = "a truncated page carries Link rel=next"
+	)
+	hasNext := strings.Contains(r.Header.Get("Link"), `rel="next"`) || strings.Contains(r.Header.Get("Link"), "rel=next")
+	switch {
+	case len(items) == 0:
+		out = append(out, s.skip(linkID, linkName, spec, "the registry listed no nodes, so there is no next page to offer"))
+	case hasNext:
+		out = append(out, s.result(linkID, linkName, spec, StatusPass, r, "Link: "+r.Header.Get("Link")))
+	default:
+		out = append(out, s.result(linkID, linkName, spec, StatusWarn, r,
+			"a limited page carried no Link rel=next; either the catalogue holds exactly one node, or it cannot be paged to the end"))
+	}
+	return out
+}
+
+// checkQueryDowngrade asserts the escape hatch from version isolation.
+//
+// A registry serving v1.1 and v1.3 hides v1.1-registered resources from
+// a v1.3 query. `query.downgrade` is the spec's answer, and a registry
+// that does not implement it makes the highest minor the wrong one to
+// ask on — which is the opposite of what every controller does by
+// default.
+func checkQueryDowngrade(ctx context.Context, s *Session) []Result {
+	const (
+		id   = "PROFILE-VER-003"
+		name = "query.downgrade is supported"
+		spec = "IS-04 v1.3 §6.1 query.downgrade"
+	)
+	vs, has := s.APIs["query"]
+	if !has || len(vs) < 2 {
+		return []Result{s.skip(id, name, spec, "registry serves fewer than two query minors, so isolation cannot arise")}
+	}
+
+	top := highestVersion(vs)
+	lowest := top
+	for _, v := range vs {
+		if v != top {
+			lowest = v
+			break
+		}
+	}
+
+	plain := s.get(ctx, "/x-nmos/query/"+top+"/nodes")
+	down := s.get(ctx, "/x-nmos/query/"+top+"/nodes?query.downgrade="+lowest)
+	if plain.Status != http.StatusOK || down.Status != http.StatusOK {
+		if down.Status >= 400 {
+			return []Result{s.result(id, name, spec, StatusFail, down,
+				fmt.Sprintf("GET /x-nmos/query/%s/nodes?query.downgrade=%s returned %d", top, lowest, down.Status))}
+		}
+		return []Result{s.skip(id, name, spec, "the query could not be compared")}
+	}
+
+	var a, b []json.RawMessage
+	if json.Unmarshal(plain.Body, &a) != nil || json.Unmarshal(down.Body, &b) != nil {
+		return []Result{s.result(id, name, spec, StatusFail, down, "one of the two responses was not a JSON array")}
+	}
+
+	switch {
+	case len(b) > len(a):
+		return []Result{s.result(id, name, spec, StatusPass, down,
+			fmt.Sprintf("%s lists %d nodes, downgraded to %s lists %d — isolation is escapable", top, len(a), lowest, len(b)))}
+	case len(b) == len(a):
+		return []Result{s.result(id, name, spec, StatusPass, down,
+			fmt.Sprintf("downgrade accepted; both list %d nodes (nothing is registered at a lower minor)", len(a)))}
+	default:
+		return []Result{s.result(id, name, spec, StatusFail, down,
+			fmt.Sprintf("downgrading to %s returned FEWER nodes (%d) than %s (%d)", lowest, len(b), top, len(a)))}
+	}
+}
+
+// checkHeartbeatUnknownNode probes the Registration API's answer for a
+// node it does not know.
+//
+// This is read-only: a GET, never a POST. The registry must answer 404,
+// because that is the signal a node uses to know it has been garbage
+// collected and must re-register. A registry that 200s or 500s here
+// leaves a dropped node believing it is still registered.
+func checkHeartbeatUnknownNode(ctx context.Context, s *Session) []Result {
+	const (
+		id   = "PROFILE-REG-001"
+		name = "health for an unregistered node returns 404"
+		spec = "IS-04 v1.3 §4.2 Registration API health"
+	)
+	vs, has := s.APIs["registration"]
+	if !has || len(vs) == 0 {
+		return []Result{s.skip(id, name, spec, "device serves no registration API")}
+	}
+
+	const absent = "00000000-0000-4000-8000-000000000000"
+	path := "/x-nmos/registration/" + highestVersion(vs) + "/health/nodes/" + absent
+	r := s.get(ctx, path)
+
+	switch {
+	case r.Err != nil:
+		return []Result{s.result(id, name, spec, StatusFail, r,
+			fmt.Sprintf("GET %s did not complete: %v", path, r.Err))}
+	case r.Status == http.StatusNotFound:
+		return []Result{s.result(id, name, spec, StatusPass, r,
+			fmt.Sprintf("GET %s returned 404", path))}
+	case r.Status == http.StatusMethodNotAllowed:
+		return []Result{s.result(id, name, spec, StatusWarn, r,
+			fmt.Sprintf("GET %s returned 405; the health endpoint is POST-only here, so the read-only profile cannot assert it", path))}
+	case r.Status >= 500:
+		return []Result{s.result(id, name, spec, StatusFail, r,
+			fmt.Sprintf("GET %s returned %d — a node cannot tell it was garbage collected", path, r.Status))}
+	default:
+		return []Result{s.result(id, name, spec, StatusFail, r,
+			fmt.Sprintf("GET %s returned %d for a node that is not registered", path, r.Status))}
+	}
+}
+
+// checkTransportFileContentType asserts an IS-05 transport file is
+// served as SDP.
+//
+// A receiver handed `text/html` will not parse it, and the failure
+// appears as a route that silently does not come up.
+func checkTransportFileContentType(ctx context.Context, s *Session) []Result {
+	const (
+		id   = "PROFILE-IS05-001"
+		name = "a transport file is served as application/sdp"
+		spec = "IS-05 v1.1 §4.2 transportfile"
+	)
+	vs, has := s.APIs["connection"]
+	if !has || len(vs) == 0 {
+		return []Result{s.skip(id, name, spec, "device serves no connection API")}
+	}
+	ver := highestVersion(vs)
+
+	list := s.get(ctx, "/x-nmos/connection/"+ver+"/single/senders")
+	ids, ok := jsonArray(list.Body)
+	if list.Status != http.StatusOK || !ok || len(ids) == 0 {
+		return []Result{s.skip(id, name, spec, "the device publishes no IS-05 senders")}
+	}
+
+	// One sender by default. --deep asserts every one, which is what
+	// catches a device that is broken on some of them — the shape a
+	// 502-on-every-transportfile device has.
+	if !s.opts.Deep {
+		ids = ids[:1]
+	}
+
+	var out []Result
+	for _, sid := range ids {
+		sid = strings.TrimSuffix(sid, "/")
+		path := "/x-nmos/connection/" + ver + "/single/senders/" + sid + "/transportfile"
+		r := s.get(ctx, path)
+		ct := r.Header.Get("Content-Type")
+		switch {
+		case r.Err != nil:
+			out = append(out, s.result(id, name, spec, StatusFail, r,
+				fmt.Sprintf("GET %s did not complete: %v", path, r.Err)))
+		case r.Status >= 500:
+			out = append(out, s.result(id, name, spec, StatusFail, r,
+				fmt.Sprintf("GET %s returned %d — the endpoint exists and is broken", path, r.Status)))
+		case r.Status == http.StatusNotFound:
+			// Legal for a sender that is not transmitting.
+			out = append(out, s.result(id, name, spec, StatusWarn, r,
+				fmt.Sprintf("GET %s returned 404 (legal only while the sender is inactive)", path)))
+		case r.Status != http.StatusOK:
+			out = append(out, s.result(id, name, spec, StatusFail, r,
+				fmt.Sprintf("GET %s returned %d", path, r.Status)))
+		case !strings.HasPrefix(strings.ToLower(ct), "application/sdp"):
+			out = append(out, s.result(id, name, spec, StatusFail, r,
+				fmt.Sprintf("GET %s returned Content-Type %q, want application/sdp", path, ct)))
+		case !strings.HasPrefix(strings.TrimSpace(string(r.Body)), "v="):
+			out = append(out, s.result(id, name, spec, StatusFail, r,
+				fmt.Sprintf("GET %s returned a body that does not start with `v=` — not an SDP", path)))
+		default:
+			out = append(out, s.result(id, name, spec, StatusPass, r,
+				fmt.Sprintf("GET %s returned %d bytes of application/sdp", path, len(r.Body))))
+		}
+	}
+	return out
+}
+
+func sortedKeys(m map[string][]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	// A stable order keeps two runs diffable.
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j] < out[j-1]; j-- {
+			out[j], out[j-1] = out[j-1], out[j]
+		}
+	}
+	return out
+}

--- a/internal/amwa/profile/profile.go
+++ b/internal/amwa/profile/profile.go
@@ -1,0 +1,355 @@
+// Package profile runs live protocol-conformance assertions against an
+// NMOS device and times every request.
+//
+// It answers what an offline audit cannot. An export records answers;
+// a profile records the conversation. Whether an unknown API version is
+// rejected, whether CORS is present, whether a paging limit is honoured
+// and reported back, whether a heartbeat for an unregistered node
+// 404s — none of that survives into a capture, and every one of them
+// decides whether a real controller can drive the device.
+//
+// The profile is strictly read-only. It never PATCHes, never activates,
+// never registers. A conformance tool that stages a connection is a
+// tool that can take a live source off air, and this one is meant to be
+// safe to point at a plant that is on.
+package profile
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Status is the outcome of one assertion.
+type Status string
+
+const (
+	// StatusPass means the device behaved as the spec requires.
+	StatusPass Status = "PASS"
+	// StatusWarn means the behaviour is permitted but will cause
+	// trouble with a stricter peer.
+	StatusWarn Status = "WARN"
+	// StatusFail means the device contradicts a spec requirement.
+	StatusFail Status = "FAIL"
+	// StatusSkip means the check did not apply — the device does not
+	// serve the API the check is about. A skip is never a pass, and is
+	// reported so a green run cannot hide an untested surface.
+	StatusSkip Status = "SKIP"
+)
+
+// Result is one assertion's outcome. The shape is deliberately flat:
+// one JSON object per line, appendable across runs, diffable between
+// two firmware versions without a reading exercise.
+type Result struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Spec   string `json:"spec,omitempty"`
+	Target string `json:"target"`
+	Status Status `json:"status"`
+	// Detail states what was observed, always including the request
+	// that produced it, so a FAIL can be reproduced by hand.
+	Detail string `json:"detail"`
+	// DurationMS is the wall time of the request this result rests on.
+	DurationMS float64 `json:"duration_ms,omitempty"`
+}
+
+// Options configures a profile run.
+type Options struct {
+	Target  string
+	HTTPS   bool
+	Timeout time.Duration
+	Client  *http.Client
+	// Deep runs the checks that make many requests — per-endpoint
+	// IS-05 assertions across every sender a device publishes.
+	Deep bool
+}
+
+func (o *Options) defaults() {
+	if o.Timeout <= 0 {
+		o.Timeout = 10 * time.Second
+	}
+	if o.Client == nil {
+		o.Client = &http.Client{Timeout: o.Timeout}
+	}
+}
+
+// Report is a complete profile run: the assertions, and how fast the
+// device answered.
+type Report struct {
+	Target  string         `json:"target"`
+	Results []Result       `json:"results"`
+	Counts  map[string]int `json:"counts"`
+	Latency []EndpointStat `json:"latency"`
+}
+
+// EndpointStat is the timing profile of one endpoint class.
+//
+// Percentiles rather than a mean: a registry that answers in 8 ms and
+// occasionally in 4 seconds has a fine mean and is unusable, and the
+// mean is exactly what hides that.
+type EndpointStat struct {
+	Endpoint string  `json:"endpoint"`
+	Requests int     `json:"requests"`
+	P50MS    float64 `json:"p50_ms"`
+	P95MS    float64 `json:"p95_ms"`
+	P99MS    float64 `json:"p99_ms"`
+	MaxMS    float64 `json:"max_ms"`
+	Errors   int     `json:"errors"`
+}
+
+// Session carries what the checks share: the transport, what the device
+// said it serves, and the latency record.
+type Session struct {
+	opts   Options
+	scheme string
+
+	// APIs maps an API name to the versions the device advertised.
+	APIs map[string][]string
+
+	samples map[string][]float64
+	errors  map[string]int
+}
+
+// response is one observed exchange.
+type response struct {
+	Status  int
+	Header  http.Header
+	Body    []byte
+	Elapsed time.Duration
+	Err     error
+}
+
+// ms renders the elapsed time for a Result.
+func (r response) ms() float64 { return float64(r.Elapsed.Microseconds()) / 1000 }
+
+// checkFn is one assertion group. Each returns every Result it
+// produced, so a check that iterates endpoints reports per endpoint.
+type checkFn func(ctx context.Context, s *Session) []Result
+
+// checks is the ordered assertion set. Adding one is adding a function
+// here — that is the whole extension mechanism.
+var checks = []checkFn{
+	checkRoot,
+	checkVersionLists,
+	checkUnknownVersionRejected,
+	checkCORS,
+	checkContentType,
+	checkUnknownResource,
+	checkTrailingSlash,
+	checkQueryPaging,
+	checkQueryDowngrade,
+	checkHeartbeatUnknownNode,
+	checkTransportFileContentType,
+}
+
+// Run probes the target and returns the report.
+func Run(ctx context.Context, opts Options) (*Report, error) {
+	opts.defaults()
+	if opts.Target == "" {
+		return nil, fmt.Errorf("profile: --target is required")
+	}
+
+	s := &Session{
+		opts:    opts,
+		scheme:  "http",
+		APIs:    map[string][]string{},
+		samples: map[string][]float64{},
+		errors:  map[string]int{},
+	}
+	if opts.HTTPS {
+		s.scheme = "https"
+	}
+
+	rep := &Report{Target: opts.Target, Counts: map[string]int{}}
+	for _, c := range checks {
+		rep.Results = append(rep.Results, c(ctx, s)...)
+	}
+	for _, r := range rep.Results {
+		rep.Counts[string(r.Status)]++
+	}
+	rep.Latency = s.latency()
+	return rep, nil
+}
+
+// Worst reports the most severe status present, ranked FAIL > WARN >
+// SKIP > PASS, and whether anything was reported at all.
+func (r *Report) Worst() (Status, bool) {
+	rank := map[Status]int{StatusPass: 0, StatusSkip: 1, StatusWarn: 2, StatusFail: 3}
+	worst, any := StatusPass, false
+	for _, res := range r.Results {
+		if !any || rank[res.Status] > rank[worst] {
+			worst, any = res.Status, true
+		}
+	}
+	return worst, any
+}
+
+// --- transport ---
+
+// get performs one request and records its timing.
+func (s *Session) get(ctx context.Context, path string) response {
+	return s.request(ctx, http.MethodGet, path, nil)
+}
+
+func (s *Session) request(ctx context.Context, method, path string, hdr http.Header) response {
+	rctx, cancel := context.WithTimeout(ctx, s.opts.Timeout)
+	defer cancel()
+
+	url := path
+	if strings.HasPrefix(path, "/") {
+		url = s.scheme + "://" + s.opts.Target + path
+	}
+
+	start := time.Now()
+	req, err := http.NewRequestWithContext(rctx, method, url, nil)
+	if err != nil {
+		return response{Err: err, Elapsed: time.Since(start)}
+	}
+	for k, vs := range hdr {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
+	}
+
+	resp, err := s.opts.Client.Do(req)
+	if err != nil {
+		el := time.Since(start)
+		s.record(path, el, true)
+		return response{Err: err, Elapsed: el}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, readErr := io.ReadAll(resp.Body)
+	el := time.Since(start)
+	s.record(path, el, readErr != nil || resp.StatusCode >= 500)
+	return response{Status: resp.StatusCode, Header: resp.Header, Body: body, Elapsed: el, Err: readErr}
+}
+
+// uuidInPath collapses per-resource URLs into one endpoint class, so a
+// 176-sender device produces one latency row rather than 176.
+var uuidInPath = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
+
+func endpointClass(path string) string {
+	if i := strings.Index(path, "/x-nmos/"); i >= 0 {
+		path = path[i:]
+	}
+	if i := strings.Index(path, "?"); i >= 0 {
+		path = path[:i]
+	}
+	return uuidInPath.ReplaceAllString(path, "{id}")
+}
+
+func (s *Session) record(path string, d time.Duration, failed bool) {
+	class := endpointClass(path)
+	s.samples[class] = append(s.samples[class], float64(d.Microseconds())/1000)
+	if failed {
+		s.errors[class]++
+	}
+}
+
+// latency renders the timing record, slowest p99 first — the row an
+// operator needs to see is the one at the top.
+func (s *Session) latency() []EndpointStat {
+	out := make([]EndpointStat, 0, len(s.samples))
+	for ep, xs := range s.samples {
+		sorted := append([]float64(nil), xs...)
+		sort.Float64s(sorted)
+		out = append(out, EndpointStat{
+			Endpoint: ep,
+			Requests: len(sorted),
+			P50MS:    percentile(sorted, 50),
+			P95MS:    percentile(sorted, 95),
+			P99MS:    percentile(sorted, 99),
+			MaxMS:    sorted[len(sorted)-1],
+			Errors:   s.errors[ep],
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].P99MS != out[j].P99MS {
+			return out[i].P99MS > out[j].P99MS
+		}
+		return out[i].Endpoint < out[j].Endpoint
+	})
+	return out
+}
+
+// percentile uses nearest-rank on a sorted slice. With the handful of
+// samples a profile run collects, interpolation would invent precision the
+// data does not have.
+func percentile(sorted []float64, p int) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	idx := (p*len(sorted) + 99) / 100 // ceil(p/100 * n)
+	if idx < 1 {
+		idx = 1
+	}
+	if idx > len(sorted) {
+		idx = len(sorted)
+	}
+	return sorted[idx-1]
+}
+
+// --- result helpers ---
+
+func (s *Session) result(id, name, spec string, st Status, r response, detail string) Result {
+	return Result{
+		ID: id, Name: name, Spec: spec, Target: s.opts.Target,
+		Status: st, Detail: detail, DurationMS: r.ms(),
+	}
+}
+
+func (s *Session) skip(id, name, spec, why string) Result {
+	return Result{ID: id, Name: name, Spec: spec, Target: s.opts.Target, Status: StatusSkip, Detail: why}
+}
+
+// jsonArray decodes a body as an array of strings, the shape every
+// NMOS index endpoint uses.
+func jsonArray(b []byte) ([]string, bool) {
+	var out []string
+	if json.Unmarshal(b, &out) != nil {
+		return nil, false
+	}
+	return out, true
+}
+
+// versionPattern is the `vMAJOR.MINOR` form every API version takes.
+var versionPattern = regexp.MustCompile(`^v\d+\.\d+$`)
+
+// firstAPIWithResources names an API the device serves that has
+// walkable collections, preferring the registry's catalogue.
+func (s *Session) queryOrNode() (api, ver string, ok bool) {
+	for _, name := range []string{"query", "node"} {
+		if vs, has := s.APIs[name]; has && len(vs) > 0 {
+			return name, highestVersion(vs), true
+		}
+	}
+	return "", "", false
+}
+
+// highestVersion orders v1.10 after v1.9, which a string sort gets
+// wrong.
+func highestVersion(vs []string) string {
+	best, rank := "", -2
+	for _, v := range vs {
+		r := -1
+		if maj, min, cut := strings.Cut(strings.TrimPrefix(v, "v"), "."); cut {
+			m, e1 := strconv.Atoi(maj)
+			n, e2 := strconv.Atoi(min)
+			if e1 == nil && e2 == nil {
+				r = m*1000 + n
+			}
+		}
+		if r > rank {
+			best, rank = v, r
+		}
+	}
+	return best
+}

--- a/internal/amwa/profile/profile_test.go
+++ b/internal/amwa/profile/profile_test.go
@@ -1,0 +1,726 @@
+package profile
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// device is a scriptable NMOS surface. Its defaults are spec-correct,
+// and each test breaks exactly one thing — so a failing assertion names
+// the rule that was broken rather than a pile of unrelated noise.
+type device struct {
+	apis map[string][]string
+	// nodes is what the query API lists.
+	nodes []any
+
+	// the knobs each test turns
+	noCORS          bool
+	refusePreflight bool
+	contentType     string
+	unknownVerOK    bool
+	faultOnMissing  bool
+	plainErrorBody  bool
+	noTrailingSlash bool
+	ignorePaging    bool
+	noPagingHeaders bool
+	noLinkNext      bool
+	downgradeFails  bool
+	healthOnUnknown int
+	transportFile   string
+	transportCT     string
+	transportCode   int
+}
+
+func newDevice() *device {
+	return &device{
+		apis:            map[string][]string{"query": {"v1.1", "v1.3"}, "registration": {"v1.3"}},
+		contentType:     "application/json",
+		healthOnUnknown: http.StatusNotFound,
+		transportCT:     "application/sdp",
+		transportCode:   http.StatusOK,
+		transportFile:   "v=0\r\no=- 1 1 IN IP4 198.51.100.5\r\ns=probe\r\n",
+	}
+}
+
+func (d *device) writeJSON(w http.ResponseWriter, v any) {
+	if !d.noCORS {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+	}
+	if d.contentType != "" {
+		w.Header().Set("Content-Type", d.contentType)
+	}
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func (d *device) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	p := r.URL.Path
+
+	if r.Method == http.MethodOptions {
+		if d.refusePreflight {
+			http.Error(w, "no", http.StatusForbidden)
+			return
+		}
+		if !d.noCORS {
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+		}
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	switch {
+	case p == "/x-nmos":
+		names := make([]string, 0, len(d.apis))
+		for k := range d.apis {
+			names = append(names, k+"/")
+		}
+		d.writeJSON(w, names)
+		return
+
+	case strings.HasPrefix(p, "/x-nmos/") && strings.Count(strings.Trim(p, "/"), "/") == 1:
+		api := strings.TrimSuffix(strings.TrimPrefix(p, "/x-nmos/"), "/")
+		vs, ok := d.apis[api]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		out := make([]string, 0, len(vs))
+		for _, v := range vs {
+			out = append(out, v+"/")
+		}
+		d.writeJSON(w, out)
+		return
+	}
+
+	// Anything at an unadvertised version.
+	if strings.Contains(p, "/v9.9/") {
+		if d.unknownVerOK {
+			d.writeJSON(w, []any{})
+			return
+		}
+		http.NotFound(w, r)
+		return
+	}
+
+	// The version root, with and without a trailing slash.
+	if p == "/x-nmos/query/v1.3" || p == "/x-nmos/query/v1.3/" {
+		if d.noTrailingSlash && p == "/x-nmos/query/v1.3" {
+			http.NotFound(w, r)
+			return
+		}
+		d.writeJSON(w, []string{"nodes/", "devices/"})
+		return
+	}
+
+	// A single node by id — the check only ever asks for one that is
+	// not there.
+	if strings.HasPrefix(p, "/x-nmos/query/v1.3/nodes/") {
+		if d.faultOnMissing {
+			http.Error(w, "boom", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		if d.plainErrorBody {
+			_, _ = w.Write([]byte("not found"))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"code": 404, "error": "resource not found", "debug": nil,
+		})
+		return
+	}
+
+	if p == "/x-nmos/query/v1.1/nodes" || p == "/x-nmos/query/v1.3/nodes" {
+		items := d.nodes
+		limit := r.URL.Query().Get("paging.limit")
+
+		// Version isolation: v1.3 hides the LAST node — whatever was
+		// registered at the lower minor — unless the caller asks to
+		// downgrade. Hiding all but one instead would leave the page
+		// always at length 1, and the paging assertions below would
+		// have nothing to bite on.
+		if p == "/x-nmos/query/v1.3/nodes" {
+			down := r.URL.Query().Get("query.downgrade")
+			if down != "" && d.downgradeFails {
+				http.Error(w, "unsupported", http.StatusBadRequest)
+				return
+			}
+			if down == "" && len(items) > 1 {
+				items = items[:len(items)-1]
+			}
+		}
+
+		if limit != "" && !d.ignorePaging && len(items) > 1 {
+			items = items[:1]
+		}
+		if !d.noPagingHeaders {
+			w.Header().Set("X-Paging-Limit", "10")
+			w.Header().Set("X-Paging-Since", "0:0")
+			w.Header().Set("X-Paging-Until", "0:0")
+		}
+		if limit != "" && !d.noLinkNext && len(d.nodes) > len(items) {
+			w.Header().Set("Link", fmt.Sprintf(`<%s?paging.since=1>; rel="next"`, p))
+		}
+		d.writeJSON(w, items)
+		return
+	}
+
+	if strings.HasPrefix(p, "/x-nmos/registration/v1.3/health/nodes/") {
+		w.WriteHeader(d.healthOnUnknown)
+		return
+	}
+
+	if p == "/x-nmos/connection/v1.1/single/senders" {
+		d.writeJSON(w, []string{"44444444-4444-4444-8444-444444444444/"})
+		return
+	}
+	if strings.HasSuffix(p, "/transportfile") {
+		if d.transportCode != http.StatusOK {
+			w.WriteHeader(d.transportCode)
+			return
+		}
+		w.Header().Set("Content-Type", d.transportCT)
+		_, _ = w.Write([]byte(d.transportFile))
+		return
+	}
+
+	http.NotFound(w, r)
+}
+
+func node(id, label string) map[string]any {
+	return map[string]any{"id": id, "version": "1755000000:0", "label": label, "tags": map[string]any{}}
+}
+
+func profileIt(t *testing.T, d *device) *Report {
+	t.Helper()
+	srv := httptest.NewServer(d)
+	t.Cleanup(srv.Close)
+	rep, err := Run(context.Background(), Options{
+		Target:  strings.TrimPrefix(srv.URL, "http://"),
+		Timeout: 2 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	return rep
+}
+
+// statusOf returns the status of the first result with the given id.
+func statusOf(t *testing.T, r *Report, id string) Status {
+	t.Helper()
+	for _, res := range r.Results {
+		if res.ID == id {
+			return res.Status
+		}
+	}
+	t.Fatalf("no result with id %s; got %v", id, idsOf(r))
+	return ""
+}
+
+func idsOf(r *Report) []string {
+	out := make([]string, 0, len(r.Results))
+	for _, res := range r.Results {
+		out = append(out, res.ID+"="+string(res.Status))
+	}
+	return out
+}
+
+func want(t *testing.T, r *Report, id string, st Status) {
+	t.Helper()
+	if got := statusOf(t, r, id); got != st {
+		for _, res := range r.Results {
+			if res.ID == id {
+				t.Errorf("%s = %s, want %s\n  detail: %s", id, got, st, res.Detail)
+				return
+			}
+		}
+	}
+}
+
+// TestCompliantDeviceHasNoFailures is the baseline. Everything after it
+// breaks exactly one rule, so a failure elsewhere is unambiguous.
+func TestCompliantDeviceHasNoFailures(t *testing.T) {
+	d := newDevice()
+	d.nodes = []any{
+		node("11111111-1111-4111-8111-111111111111", "a"),
+		node("22222222-2222-4222-8222-222222222222", "b"),
+	}
+	rep := profileIt(t, d)
+
+	for _, res := range rep.Results {
+		if res.Status == StatusFail {
+			t.Errorf("a compliant device produced %s: %s\n  %s", res.ID, res.Status, res.Detail)
+		}
+	}
+	if rep.Counts[string(StatusPass)] == 0 {
+		t.Error("no assertion passed against a compliant device")
+	}
+	if worst, any := rep.Worst(); !any || worst == StatusFail {
+		t.Errorf("Worst() = %s,%v on a compliant device", worst, any)
+	}
+}
+
+func TestUnknownVersionServed(t *testing.T) {
+	d := newDevice()
+	d.unknownVerOK = true
+	want(t, profileIt(t, d), "PROFILE-VER-002", StatusFail)
+}
+
+func TestMissingCORS(t *testing.T) {
+	d := newDevice()
+	d.noCORS = true
+	rep := profileIt(t, d)
+	want(t, rep, "PROFILE-CORS-001", StatusFail)
+	// The preflight still answers; it just names no methods.
+	want(t, rep, "PROFILE-CORS-002", StatusWarn)
+}
+
+func TestRefusedPreflight(t *testing.T) {
+	d := newDevice()
+	d.refusePreflight = true
+	want(t, profileIt(t, d), "PROFILE-CORS-002", StatusFail)
+}
+
+func TestWrongContentType(t *testing.T) {
+	d := newDevice()
+	d.contentType = "text/html"
+	want(t, profileIt(t, d), "PROFILE-CT-001", StatusFail)
+
+	d2 := newDevice()
+	d2.contentType = ""
+	want(t, profileIt(t, d2), "PROFILE-CT-001", StatusFail)
+}
+
+// TestFaultOnMissingResource is the distinction that turns a stale
+// reference into a retry storm.
+func TestFaultOnMissingResource(t *testing.T) {
+	d := newDevice()
+	d.faultOnMissing = true
+	want(t, profileIt(t, d), "PROFILE-404-001", StatusFail)
+}
+
+func TestErrorBodyShape(t *testing.T) {
+	d := newDevice()
+	d.plainErrorBody = true
+	rep := profileIt(t, d)
+	want(t, rep, "PROFILE-404-001", StatusPass) // the status is still right
+	want(t, rep, "PROFILE-404-002", StatusWarn) // the body is not
+}
+
+func TestTrailingSlashInconsistency(t *testing.T) {
+	d := newDevice()
+	d.noTrailingSlash = true
+	want(t, profileIt(t, d), "PROFILE-PATH-001", StatusWarn)
+}
+
+// TestPagingLimitIgnored is the defect that captured 11 nodes of a
+// 68-node registry.
+func TestPagingLimitIgnored(t *testing.T) {
+	d := newDevice()
+	d.ignorePaging = true
+	// Three nodes so that v1.3 still lists two after version isolation
+	// hides the one registered lower — a limit of 1 then has something
+	// to fail to honour.
+	d.nodes = []any{
+		node("11111111-1111-4111-8111-111111111111", "a"),
+		node("22222222-2222-4222-8222-222222222222", "b"),
+		node("33333333-3333-4333-8333-333333333333", "c"),
+	}
+	want(t, profileIt(t, d), "PROFILE-PAGE-001", StatusFail)
+}
+
+func TestPagingHeadersAndLink(t *testing.T) {
+	d := newDevice()
+	d.noPagingHeaders = true
+	d.noLinkNext = true
+	d.nodes = []any{
+		node("11111111-1111-4111-8111-111111111111", "a"),
+		node("22222222-2222-4222-8222-222222222222", "b"),
+	}
+	rep := profileIt(t, d)
+	want(t, rep, "PROFILE-PAGE-002", StatusWarn)
+	want(t, rep, "PROFILE-PAGE-003", StatusWarn)
+}
+
+// TestPagingSkippedOnEmptyRegistry: an empty catalogue cannot prove or
+// disprove paging, and must not be reported as either.
+func TestPagingSkippedOnEmptyRegistry(t *testing.T) {
+	d := newDevice()
+	d.nodes = nil
+	rep := profileIt(t, d)
+	want(t, rep, "PROFILE-PAGE-003", StatusSkip)
+}
+
+// TestDowngradeEscapesVersionIsolation: the fake registry hides its
+// second node at v1.3, exactly as a real one does.
+func TestDowngradeEscapesVersionIsolation(t *testing.T) {
+	d := newDevice()
+	d.nodes = []any{
+		node("11111111-1111-4111-8111-111111111111", "a"),
+		node("22222222-2222-4222-8222-222222222222", "b"),
+	}
+	rep := profileIt(t, d)
+	want(t, rep, "PROFILE-VER-003", StatusPass)
+	for _, res := range rep.Results {
+		if res.ID == "PROFILE-VER-003" && !strings.Contains(res.Detail, "isolation is escapable") {
+			t.Errorf("the downgrade result should say what it proved: %q", res.Detail)
+		}
+	}
+}
+
+func TestDowngradeRejected(t *testing.T) {
+	d := newDevice()
+	d.downgradeFails = true
+	d.nodes = []any{
+		node("11111111-1111-4111-8111-111111111111", "a"),
+		node("22222222-2222-4222-8222-222222222222", "b"),
+	}
+	want(t, profileIt(t, d), "PROFILE-VER-003", StatusFail)
+}
+
+func TestDowngradeSkippedOnSingleMinor(t *testing.T) {
+	d := newDevice()
+	d.apis["query"] = []string{"v1.3"}
+	want(t, profileIt(t, d), "PROFILE-VER-003", StatusSkip)
+}
+
+func TestHeartbeatForUnknownNode(t *testing.T) {
+	for _, tc := range []struct {
+		code int
+		want Status
+	}{
+		{http.StatusNotFound, StatusPass},
+		{http.StatusOK, StatusFail},
+		{http.StatusInternalServerError, StatusFail},
+		{http.StatusMethodNotAllowed, StatusWarn},
+	} {
+		t.Run(fmt.Sprint(tc.code), func(t *testing.T) {
+			d := newDevice()
+			d.healthOnUnknown = tc.code
+			want(t, profileIt(t, d), "PROFILE-REG-001", tc.want)
+		})
+	}
+}
+
+func TestNoRegistrationAPISkipsHeartbeat(t *testing.T) {
+	d := newDevice()
+	delete(d.apis, "registration")
+	want(t, profileIt(t, d), "PROFILE-REG-001", StatusSkip)
+}
+
+// TestTransportFile covers each way a transport file can be wrong. The
+// 502 case is a real device behaviour, observed live.
+func TestTransportFile(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		set  func(*device)
+		want Status
+	}{
+		{"served correctly", func(d *device) {}, StatusPass},
+		{"502", func(d *device) { d.transportCode = http.StatusBadGateway }, StatusFail},
+		{"404 while inactive", func(d *device) { d.transportCode = http.StatusNotFound }, StatusWarn},
+		{"403", func(d *device) { d.transportCode = http.StatusForbidden }, StatusFail},
+		{"wrong content type", func(d *device) { d.transportCT = "text/plain" }, StatusFail},
+		{"not an SDP", func(d *device) { d.transportFile = "<html>nope</html>" }, StatusFail},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newDevice()
+			d.apis["connection"] = []string{"v1.1"}
+			tc.set(d)
+			want(t, profileIt(t, d), "PROFILE-IS05-001", tc.want)
+		})
+	}
+}
+
+func TestNoConnectionAPISkipsTransportFile(t *testing.T) {
+	want(t, profileIt(t, newDevice()), "PROFILE-IS05-001", StatusSkip)
+}
+
+// TestDeepProbesEverySender proves --deep is what catches a device that
+// is broken on some endpoints and not others.
+func TestDeepProbesEverySender(t *testing.T) {
+	ids := []string{
+		"44444444-4444-4444-8444-444444444444/",
+		"55555555-5555-4555-8555-555555555555/",
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/x-nmos":
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			_ = json.NewEncoder(w).Encode([]string{"connection/"})
+		case r.URL.Path == "/x-nmos/connection/":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]string{"v1.1/"})
+		case r.URL.Path == "/x-nmos/connection/v1.1/single/senders":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(ids)
+		case strings.HasSuffix(r.URL.Path, "/transportfile"):
+			// The second sender is broken; the first is fine.
+			if strings.Contains(r.URL.Path, "5555") {
+				http.Error(w, "bad gateway", http.StatusBadGateway)
+				return
+			}
+			w.Header().Set("Content-Type", "application/sdp")
+			_, _ = w.Write([]byte("v=0\r\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	target := strings.TrimPrefix(srv.URL, "http://")
+
+	shallow, err := Run(context.Background(), Options{Target: target, Timeout: 2 * time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	deep, err := Run(context.Background(), Options{Target: target, Timeout: 2 * time.Second, Deep: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	countIS05 := func(r *Report, st Status) int {
+		n := 0
+		for _, res := range r.Results {
+			if res.ID == "PROFILE-IS05-001" && res.Status == st {
+				n++
+			}
+		}
+		return n
+	}
+	if countIS05(shallow, StatusFail) != 0 {
+		t.Error("the shallow probe should have checked only the first, working sender")
+	}
+	if countIS05(deep, StatusFail) != 1 {
+		t.Errorf("--deep found %d broken senders, want 1", countIS05(deep, StatusFail))
+	}
+	if countIS05(deep, StatusPass) != 1 {
+		t.Errorf("--deep found %d working senders, want 1", countIS05(deep, StatusPass))
+	}
+}
+
+// TestUnreachableTargetFailsCleanly: pointing the probe at nothing must
+// report, not panic.
+func TestUnreachableTargetFailsCleanly(t *testing.T) {
+	srv := httptest.NewServer(newDevice())
+	target := strings.TrimPrefix(srv.URL, "http://")
+	srv.Close()
+
+	rep, err := Run(context.Background(), Options{Target: target, Timeout: 500 * time.Millisecond})
+	if err != nil {
+		t.Fatalf("an unreachable target should report, not error: %v", err)
+	}
+	want(t, rep, "PROFILE-ROOT-001", StatusFail)
+	if worst, any := rep.Worst(); !any || worst != StatusFail {
+		t.Errorf("Worst() = %s,%v", worst, any)
+	}
+}
+
+func TestRootNotAnArray(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"not":"an array"}`))
+	}))
+	defer srv.Close()
+	rep, err := Run(context.Background(), Options{Target: strings.TrimPrefix(srv.URL, "http://"), Timeout: time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want(t, rep, "PROFILE-ROOT-001", StatusFail)
+	// With no APIs discovered, the version check has nothing to assert
+	// and must skip rather than pass.
+	want(t, rep, "PROFILE-VER-001", StatusSkip)
+}
+
+func TestMalformedVersionList(t *testing.T) {
+	d := newDevice()
+	d.apis["query"] = []string{"1.3", "latest"}
+	want(t, profileIt(t, d), "PROFILE-VER-001", StatusFail)
+}
+
+func TestTargetRequired(t *testing.T) {
+	if _, err := Run(context.Background(), Options{}); err == nil {
+		t.Error("an empty target should be refused")
+	}
+}
+
+// TestLatencyIsRecorded: the timing is half the point of the verb.
+func TestLatencyIsRecorded(t *testing.T) {
+	rep := profileIt(t, newDevice())
+	if len(rep.Latency) == 0 {
+		t.Fatal("no latency was recorded")
+	}
+	for _, s := range rep.Latency {
+		if s.Requests == 0 {
+			t.Errorf("%s recorded 0 requests", s.Endpoint)
+		}
+		if s.P50MS > s.P99MS || s.P99MS > s.MaxMS {
+			t.Errorf("%s percentiles are not ordered: p50=%.2f p99=%.2f max=%.2f",
+				s.Endpoint, s.P50MS, s.P99MS, s.MaxMS)
+		}
+	}
+	// Per-resource URLs must collapse into one endpoint class, or a
+	// 176-sender device produces 176 unreadable rows.
+	for _, s := range rep.Latency {
+		if strings.Contains(s.Endpoint, "0000-4000-8000") {
+			t.Errorf("a UUID survived into an endpoint class: %s", s.Endpoint)
+		}
+	}
+}
+
+func TestPercentileNearestRank(t *testing.T) {
+	xs := []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	for _, tc := range []struct {
+		p    int
+		want float64
+	}{
+		{50, 5}, {95, 10}, {99, 10}, {1, 1},
+	} {
+		if got := percentile(xs, tc.p); got != tc.want {
+			t.Errorf("percentile(%d) = %v, want %v", tc.p, got, tc.want)
+		}
+	}
+	if got := percentile(nil, 50); got != 0 {
+		t.Errorf("percentile of nothing = %v", got)
+	}
+	if got := percentile([]float64{42}, 99); got != 42 {
+		t.Errorf("percentile of one sample = %v", got)
+	}
+}
+
+func TestHighestVersionOrdersNumerically(t *testing.T) {
+	if got := highestVersion([]string{"v1.9", "v1.10"}); got != "v1.10" {
+		t.Errorf("highestVersion = %q, want v1.10", got)
+	}
+	if got := highestVersion([]string{"junk"}); got != "junk" {
+		t.Errorf("highestVersion of one unparseable = %q", got)
+	}
+}
+
+func TestEndpointClass(t *testing.T) {
+	got := endpointClass("http://h:80/x-nmos/connection/v1.1/single/senders/44444444-4444-4444-8444-444444444444/active?x=1")
+	if got != "/x-nmos/connection/v1.1/single/senders/{id}/active" {
+		t.Errorf("endpointClass = %q", got)
+	}
+	if got := endpointClass("/other/path"); got != "/other/path" {
+		t.Errorf("endpointClass of a non-nmos path = %q", got)
+	}
+}
+
+// TestRenderers pins each output shape.
+func TestRenderers(t *testing.T) {
+	d := newDevice()
+	d.noCORS = true
+	d.nodes = []any{node("11111111-1111-4111-8111-111111111111", "a")}
+	rep := profileIt(t, d)
+
+	var text bytes.Buffer
+	if err := RenderText(&text, rep); err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range []string{"NMOS LIVE PROBE", "FAIL", "LATENCY (ms)", "SUMMARY", "PROFILE-CORS-001"} {
+		if !strings.Contains(text.String(), s) {
+			t.Errorf("text report missing %q", s)
+		}
+	}
+	// Failures first: an operator runs a probe because something is
+	// suspected.
+	if strings.Index(text.String(), "FAIL") > strings.Index(text.String(), "PASS —") {
+		t.Error("failures should be reported before passes")
+	}
+
+	var jb bytes.Buffer
+	if err := RenderJSON(&jb, rep); err != nil {
+		t.Fatal(err)
+	}
+	var back Report
+	if err := json.Unmarshal(jb.Bytes(), &back); err != nil {
+		t.Fatalf("the report does not round-trip: %v", err)
+	}
+	if len(back.Results) != len(rep.Results) {
+		t.Error("the round trip lost results")
+	}
+
+	var lb bytes.Buffer
+	if err := RenderJSONL(&lb, rep); err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimRight(lb.String(), "\n"), "\n")
+	if len(lines) != len(rep.Results)+len(rep.Latency) {
+		t.Errorf("JSONL wrote %d lines for %d results + %d latency rows",
+			len(lines), len(rep.Results), len(rep.Latency))
+	}
+	// Latency rows must be distinguishable from results, or a consumer
+	// reading the file cannot tell them apart.
+	latencyRows := 0
+	for _, ln := range lines {
+		var row struct {
+			Kind string `json:"kind"`
+			ID   string `json:"id"`
+		}
+		if err := json.Unmarshal([]byte(ln), &row); err != nil {
+			t.Fatalf("a JSONL line is not an object: %v", err)
+		}
+		if row.Kind == "latency" {
+			latencyRows++
+		} else if row.ID == "" {
+			t.Error("a non-latency line carries no id")
+		}
+	}
+	if latencyRows != len(rep.Latency) {
+		t.Errorf("%d latency rows tagged, want %d", latencyRows, len(rep.Latency))
+	}
+}
+
+type failWriter struct{ n int }
+
+func (f *failWriter) Write(p []byte) (int, error) {
+	if f.n <= 0 {
+		return 0, fmt.Errorf("closed")
+	}
+	f.n--
+	return len(p), nil
+}
+
+func TestRenderersPropagateWriteErrors(t *testing.T) {
+	rep := profileIt(t, newDevice())
+	if err := RenderText(&failWriter{n: 1}, rep); err == nil {
+		t.Error("RenderText should surface the write error")
+	}
+	if err := RenderJSONL(&failWriter{n: 0}, rep); err == nil {
+		t.Error("RenderJSONL should surface the write error")
+	}
+	// The latency rows come after the results, so a writer that dies
+	// partway must still report.
+	if err := RenderJSONL(&failWriter{n: len(rep.Results)}, rep); err == nil {
+		t.Error("RenderJSONL should surface a write error on the latency rows")
+	}
+}
+
+func TestWorstOnEmptyReport(t *testing.T) {
+	if _, any := (&Report{}).Worst(); any {
+		t.Error("an empty report should report nothing")
+	}
+}
+
+func TestHTTPSOption(t *testing.T) {
+	d := newDevice()
+	srv := httptest.NewTLSServer(d)
+	defer srv.Close()
+	rep, err := Run(context.Background(), Options{
+		Target: strings.TrimPrefix(srv.URL, "https://"), HTTPS: true,
+		Client: srv.Client(), Timeout: 2 * time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want(t, rep, "PROFILE-ROOT-001", StatusPass)
+}

--- a/internal/amwa/profile/render.go
+++ b/internal/amwa/profile/render.go
@@ -1,0 +1,114 @@
+package profile
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// RenderText writes the human report: the assertions grouped by
+// outcome, then the timing.
+//
+// Failures come first. A probe is usually run because something is
+// suspected, and the answer should not need scrolling to.
+func RenderText(w io.Writer, r *Report) error {
+	bw := &errWriter{w: w}
+
+	bw.printf("NMOS LIVE PROBE — %s\n", r.Target)
+	bw.printf("%s\n\n", strings.Repeat("=", 78))
+
+	for _, st := range []Status{StatusFail, StatusWarn, StatusSkip, StatusPass} {
+		group := filterByStatus(r.Results, st)
+		if len(group) == 0 {
+			continue
+		}
+		bw.printf("%s — %d\n%s\n", st, len(group), strings.Repeat("-", 40))
+		for _, res := range group {
+			bw.printf("  %-18s %s\n", res.ID, res.Name)
+			bw.printf("  %-18s   %s\n", "", res.Detail)
+			if res.Spec != "" {
+				bw.printf("  %-18s   spec %s\n", "", res.Spec)
+			}
+		}
+		bw.printf("\n")
+	}
+
+	bw.printf("LATENCY (ms)\n\n")
+	bw.printf("%-46s %5s %8s %8s %8s %6s\n", "ENDPOINT", "REQS", "P50", "P95", "P99", "ERRS")
+	bw.printf("%s\n", strings.Repeat("-", 78))
+	for _, s := range r.Latency {
+		bw.printf("%-46s %5d %8.1f %8.1f %8.1f %6d\n",
+			truncLeft(s.Endpoint, 46), s.Requests, s.P50MS, s.P95MS, s.P99MS, s.Errors)
+	}
+
+	bw.printf("\nSUMMARY\n\n")
+	for _, st := range []Status{StatusFail, StatusWarn, StatusSkip, StatusPass} {
+		bw.printf("  %-6s %d\n", st, r.Counts[string(st)])
+	}
+	return bw.err
+}
+
+// RenderJSON writes the whole report as one object.
+func RenderJSON(w io.Writer, r *Report) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(r)
+}
+
+// RenderJSONL writes one result per line.
+//
+// This is the form that appends across runs and diffs as plain lines,
+// so "did this device get better or worse since the firmware update" is
+// a diff rather than a reading exercise. The latency rows follow the
+// results, tagged so a reader can tell them apart.
+func RenderJSONL(w io.Writer, r *Report) error {
+	enc := json.NewEncoder(w)
+	for _, res := range r.Results {
+		if err := enc.Encode(res); err != nil {
+			return err
+		}
+	}
+	for _, s := range r.Latency {
+		row := struct {
+			Kind   string `json:"kind"`
+			Target string `json:"target"`
+			EndpointStat
+		}{Kind: "latency", Target: r.Target, EndpointStat: s}
+		if err := enc.Encode(row); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func filterByStatus(rs []Result, st Status) []Result {
+	var out []Result
+	for _, r := range rs {
+		if r.Status == st {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (e *errWriter) printf(format string, args ...any) {
+	if e.err != nil {
+		return
+	}
+	_, e.err = fmt.Fprintf(e.w, format, args...)
+}
+
+// truncLeft clips from the left, keeping the tail of a path — the part
+// that distinguishes two endpoints is at the end, not the start.
+func truncLeft(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return "…" + s[len(s)-n+1:]
+}

--- a/tools/gencli/main.go
+++ b/tools/gencli/main.go
@@ -43,6 +43,7 @@ var matrix = []helpEntry{
 	{"NMOS controller: events (IS-07)", []string{"consumer", "nmos", "events", "--help"}},
 	{"NMOS plant export", []string{"consumer", "nmos", "export", "--help"}},
 	{"NMOS plant audit", []string{"consumer", "nmos", "audit", "--help"}},
+	{"NMOS live probe", []string{"consumer", "nmos", "probe", "--help"}},
 
 	// The generic consumer verb set (shape shared by acp1/acp2/emberplus).
 	{"consumer info", []string{"consumer", "acp1", "info", "--help"}},


### PR DESCRIPTION
Closes #845. Closes #839. Second salvage tranche onto current main: (1) the BCP-002 group/level pivot - GROUPING section before FINDINGS, per-device SND+/RCV+/GROUPS table, plant-wide group pivot, essence-ordered roles, registry-as-view fix (170 spurious cross-device groups down to 8 real), codes NMOS-BCP002-GROUP-CROSS-DEVICE / -SINGLE-ROLE; (2) `dhs consumer nmos probe` (issue #839's verb name; internal package keeps its salvage name profile) - live conformance the offline audit is blind to: unknown-version 404s, CORS, Content-Type, paging honour/clamp/report-back, query.downgrade, unregistered-heartbeat 404, per-endpoint latency percentiles; text/json/jsonl + --fail-on gating; (3) the stuck-cursor audit fix - truncatedKinds now classifies shortEmptyPage/shortDupedRows/shortStuckCurs and stands down dangling-ref checks behind a stuck cursor (9,150 findings down to the 2 naming the real registry defect on a 45-node plant). docs/cli.md regenerated with the probe section.