### PR TITLE
feat(acp2): provider Metrics() + restore deploy /metrics probe (#969)

### DIFF
--- a/ansible/playbooks/acp2-producer.yml
+++ b/ansible/playbooks/acp2-producer.yml
@@ -114,21 +114,23 @@
       changed_when: false
       failed_when: a2p_watch.stdout | int < 5
 
-    # NOTE: --metrics-addr is served in the unit file but the acp2
-    # provider does not implement Metrics() yet ("--metrics-addr set
-    # but provider does not expose Metrics() — skipping" in the
-    # journal) — a named #969 code sub-unit; the listener appears the
-    # moment it lands, no play change needed. Until then no /metrics
-    # probe here.
+    - name: Metrics endpoint serves the connector scrape
+      ansible.builtin.uri:
+        url: "http://127.0.0.1{{ a2p_metrics }}/metrics"
+        return_content: true
+      register: a2p_metrics_probe
+      changed_when: false
+      failed_when: >-
+        a2p_metrics_probe.status != 200
+        or 'rx_frames' not in a2p_metrics_probe.content
 
     - name: Verdict
       ansible.builtin.debug:
         msg: >-
           acp2 provider fixed-config green on {{ inventory_hostname }}:
           {{ a2p_walk.stdout | regex_search('slot 1 — [0-9]+ objects') }},
-          announce lines in 12s: {{ a2p_watch.stdout }}.
+          announce lines in 12s: {{ a2p_watch.stdout }}, metrics up at {{ a2p_metrics }}.
           Cerebrum (.5) can now add 10.6.250.101:{{ a2p_port }} as a Neuron driver.
-          (provider Metrics() pending — #969 sub-unit)
 
   handlers:
     - name: restart dhs-acp2

--- a/internal/acp2/provider/coverage100_test.go
+++ b/internal/acp2/provider/coverage100_test.go
@@ -553,3 +553,35 @@ func TestEmitFloatAnnounce_NoConstraints(t *testing.T) {
 
 // ensure binary import stays referenced.
 var _ = binary.BigEndian
+
+// TestMetricsExposed pins the Metrics() accessor (#969): it is non-nil,
+// stable across calls, and the connector actually counts a served
+// frame — so --metrics-addr has something to scrape.
+func TestMetricsExposed(t *testing.T) {
+	srv := newServer(quietLogger(), buildServeExport())
+	m := srv.Metrics()
+	if m == nil {
+		t.Fatal("Metrics() returned nil")
+	}
+	if srv.Metrics() != m {
+		t.Fatal("Metrics() must return the same connector each call")
+	}
+	before := m.Snapshot().TxFrames
+	// A served reply flows through session.write, which counts tx.
+	sess := &session{srv: srv, conn: &nopConn{}}
+	if err := sess.write(&codec.AN2Frame{
+		Proto: codec.AN2ProtoACP2, Slot: 1, Type: codec.AN2TypeData, Payload: []byte{0, 0, 0, 0},
+	}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if got := m.Snapshot().TxFrames; got != before+1 {
+		t.Fatalf("tx frames = %d, want %d (write must be counted)", got, before+1)
+	}
+}
+
+// nopConn is a net.Conn whose Write succeeds and discards — lets a
+// session.write run without a real socket.
+type nopConn struct{ net.Conn }
+
+func (*nopConn) Write(b []byte) (int, error) { return len(b), nil }
+func (*nopConn) Close() error                { return nil }

--- a/internal/acp2/provider/handlers.go
+++ b/internal/acp2/provider/handlers.go
@@ -492,5 +492,9 @@ func (s *session) write(f *codec.AN2Frame) error {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
 	_, err = s.conn.Write(raw)
+	// raw already includes the 8-byte AN2 header — count it whole. No
+	// per-handler latency axis here: replies fan out from the same
+	// synchronous dispatch, so byte/frame counters carry the signal.
+	s.srv.metrics.ObserveCmdTx(uint8(f.Type), len(raw), 0)
 	return err
 }

--- a/internal/acp2/provider/server.go
+++ b/internal/acp2/provider/server.go
@@ -10,6 +10,7 @@ import (
 
 	"dhs/internal/export/canonical"
 	"dhs/internal/acp2/codec"
+	"dhs/internal/metrics"
 )
 
 // Server is the exported alias for the concrete provider — lets
@@ -43,16 +44,30 @@ type server struct {
 	sessions map[*session]struct{}
 	closed   bool
 	stopped  chan struct{}
+
+	// metrics is the server-wide connector snapshot exposed via
+	// Metrics() so `producer acp2 serve --metrics-addr` scrapes it
+	// (#969). Frames are attributed by AN2 Type (request/reply/event/
+	// error/data) — the natural command axis for AN2. Always non-nil.
+	metrics *metrics.Connector
 }
 
 func newServer(logger *slog.Logger, exp *canonical.Export) *server {
 	if logger == nil {
 		logger = slog.Default()
 	}
+	met := metrics.NewConnector()
+	for _, t := range []codec.AN2Type{
+		codec.AN2TypeRequest, codec.AN2TypeReply, codec.AN2TypeEvent,
+		codec.AN2TypeError, codec.AN2TypeData,
+	} {
+		met.RegisterCmd(uint8(t), t.String())
+	}
 	s := &server{
 		logger:   logger,
 		sessions: map[*session]struct{}{},
 		stopped:  make(chan struct{}),
+		metrics:  met,
 	}
 	t, err := newTree(exp)
 	if err != nil {
@@ -70,6 +85,11 @@ func newServer(logger *slog.Logger, exp *canonical.Export) *server {
 	}
 	return s
 }
+
+// Metrics returns the server-wide connector metrics — satisfies the
+// cmd/dhs metricsExposer optional interface so --metrics-addr scrapes
+// the acp2 provider (#969). Always non-nil.
+func (s *server) Metrics() *metrics.Connector { return s.metrics }
 
 // Serve binds addr (e.g. "0.0.0.0:2072") and blocks until ctx is
 // cancelled or a fatal listen error occurs.

--- a/internal/acp2/provider/session.go
+++ b/internal/acp2/provider/session.go
@@ -25,6 +25,12 @@ func newSession(srv *server, conn net.Conn) *session {
 	return &session{srv: srv, conn: conn}
 }
 
+// an2HeaderBytes is the fixed AN2 frame header size (magic u16 + proto
+// + slot + mtid + type + dlen u16 — CLAUDE.md "AN2 frame header").
+// ReadAN2Frame returns Payload without it, so rx byte accounting adds
+// it back for a true on-wire count.
+const an2HeaderBytes = 8
+
 // run reads AN2 frames until the connection closes. Every frame is
 // dispatched inline through handleFrame; fatal errors close the conn.
 //
@@ -49,12 +55,16 @@ func (s *session) run() {
 				s.srv.logger.Debug("acp2 session closed", slog.String("remote", remote))
 				return
 			}
+			s.srv.metrics.ObserveDecodeError()
 			s.srv.logger.Warn("acp2 session read error",
 				slog.String("remote", remote),
 				slog.String("err", err.Error()),
 			)
 			return
 		}
+		// Attributed by AN2 frame Type; the 8-byte header is not counted
+		// in Payload, so add it back for a true on-wire byte count.
+		s.srv.metrics.ObserveCmdRx(uint8(frame.Type), len(frame.Payload)+an2HeaderBytes)
 		s.handleFrame(frame)
 	}
 }


### PR DESCRIPTION
Closes the acp2 provider `Metrics()` gap that the deploy unit (#972) flagged: `--metrics-addr` warned "provider does not expose Metrics() — skipping".

The provider now builds a `*metrics.Connector` (nil-safe, always non-nil), registers the five AN2 frame Types (request/reply/event/error/data) as the command axis, counts every rx frame in the session loop and every tx frame in `session.write` (announces included — they share that write path), and bumps the decode-error counter on a framing failure. On-wire byte counts add the 8-byte AN2 header back (`ReadAN2Frame` strips it). `Metrics()` satisfies cmd/dhs's `metricsExposer`, so `producer acp2 serve --metrics-addr :9102` now serves the Prometheus scrape and `/snapshot.json`.

Coverage held at the 100% floor (new `TestMetricsExposed` pins the accessor + a counted write). The deploy play's /metrics probe, parked in #972, is restored and asserts `dhs_connector_rx_frames_total` is served.

## Live receipts (dhs-debian, 2026-09-03)

```
--metrics-addr help present; endpoint serves dhs_connector_{rx,tx}_frames_total{proto="acp2",role="provider"}
acp2-producer.yml: 11/11 tasks green (incl. /metrics probe), slot 1 = 49,827 objects, announces 21/12s
RUN-TWICE = 0 CHANGES
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
