### PR TITLE
fix(cli): validate output in English - frames not trames (#969 nit)

### DIFF
--- a/cmd/dhs/cmd_validate.go
+++ b/cmd/dhs/cmd_validate.go
@@ -68,7 +68,7 @@ func runValidate(ctx context.Context, args []string) error {
 		return fmt.Errorf("validate: %w", err)
 	}
 
-	fmt.Printf("validate: %d trames decoded\n", report.TramesProcessed)
+	fmt.Printf("validate: %d frames decoded\n", report.TramesProcessed)
 	dirs := make([]string, 0, len(report.PerDirection))
 	for d := range report.PerDirection {
 		dirs = append(dirs, string(d))
@@ -83,7 +83,7 @@ func runValidate(ctx context.Context, args []string) error {
 	if len(report.Errors) > 0 {
 		fmt.Fprintf(os.Stderr, "errors: %d\n", len(report.Errors))
 		for _, e := range report.Errors {
-			fmt.Fprintf(os.Stderr, "  trame %d (%s): %s\n", e.TrameIndex, e.Direction, e.Err)
+			fmt.Fprintf(os.Stderr, "  frame %d (%s): %s\n", e.TrameIndex, e.Direction, e.Err)
 		}
 	}
 	if len(report.Invariants) > 0 {
@@ -114,10 +114,10 @@ with existing capture tooling.
 Flags:
   --out-tree <path>     also write a canonical tree.json
   --out-params <path>   also write a canonical params dump (csv/json by ext)
-  --stop-at <note>      halt at the first trame whose .note matches
+  --stop-at <note>      halt at the first frame whose .note matches
 
 IN   dhs consumer acp1 validate captures/acp1/slot0_walk/frames.jsonl
-OUT  validate: 642 trames decoded
+OUT  validate: 642 frames decoded
        rx: 321
        tx: 321
 

--- a/internal/acp1/consumer/validate.go
+++ b/internal/acp1/consumer/validate.go
@@ -95,13 +95,13 @@ func (p *Plugin) Validate(ctx context.Context, trames []wiretrace.Trame, opts co
 		case codec.MTypeRequest:
 			if msg.MTID == 0 {
 				report.Invariants = append(report.Invariants,
-					fmt.Sprintf("trame %d: request with MTID=0 (spec: must be non-zero)", i))
+					fmt.Sprintf("frame %d: request with MTID=0 (spec: must be non-zero)", i))
 			}
 			lastReqMTID = msg.MTID
 		case codec.MTypeReply:
 			if msg.MTID != lastReqMTID {
 				report.Invariants = append(report.Invariants,
-					fmt.Sprintf("trame %d: reply MTID=%d does not match last request MTID=%d", i, msg.MTID, lastReqMTID))
+					fmt.Sprintf("frame %d: reply MTID=%d does not match last request MTID=%d", i, msg.MTID, lastReqMTID))
 			}
 			// Capture getObject replies into the per-slot tree map
 			// when --out-tree is requested. We can decode every reply

--- a/internal/acp2/consumer/validate.go
+++ b/internal/acp2/consumer/validate.go
@@ -65,12 +65,12 @@ func (p *Plugin) Validate(ctx context.Context, trames []wiretrace.Trame, opts co
 		case codec.AN2ProtoInternal:
 			if frame.Type != codec.AN2TypeData && frame.MTID == 0 {
 				report.Invariants = append(report.Invariants,
-					fmt.Sprintf("trame %d: an2 internal req/reply with mtid=0 (must be 1-255)", i))
+					fmt.Sprintf("frame %d: an2 internal req/reply with mtid=0 (must be 1-255)", i))
 			}
 		case codec.AN2ProtoACP2:
 			if frame.Type != codec.AN2TypeData {
 				report.Invariants = append(report.Invariants,
-					fmt.Sprintf("trame %d: ACP2 frame must use AN2TypeData (4), got %d", i, frame.Type))
+					fmt.Sprintf("frame %d: ACP2 frame must use AN2TypeData (4), got %d", i, frame.Type))
 				continue
 			}
 			msg, err := codec.DecodeACP2Message(frame.Payload)
@@ -87,28 +87,28 @@ func (p *Plugin) Validate(ctx context.Context, trames []wiretrace.Trame, opts co
 			case codec.ACP2TypeRequest:
 				if msg.MTID == 0 {
 					report.Invariants = append(report.Invariants,
-						fmt.Sprintf("trame %d: ACP2 request with mtid=0 (spec: 1-255)", i))
+						fmt.Sprintf("frame %d: ACP2 request with mtid=0 (spec: 1-255)", i))
 				}
 				lastReqMTID = msg.MTID
 			case codec.ACP2TypeReply:
 				if msg.MTID != lastReqMTID {
 					report.Invariants = append(report.Invariants,
-						fmt.Sprintf("trame %d: ACP2 reply mtid=%d does not match last request mtid=%d", i, msg.MTID, lastReqMTID))
+						fmt.Sprintf("frame %d: ACP2 reply mtid=%d does not match last request mtid=%d", i, msg.MTID, lastReqMTID))
 				}
 			case codec.ACP2TypeAnnounce:
 				if msg.MTID != 0 {
 					report.Invariants = append(report.Invariants,
-						fmt.Sprintf("trame %d: ACP2 announce with mtid=%d (spec: must be 0)", i, msg.MTID))
+						fmt.Sprintf("frame %d: ACP2 announce with mtid=%d (spec: must be 0)", i, msg.MTID))
 				}
 			case codec.ACP2TypeError:
 				stat := codec.ACP2ErrStatus(msg.Func)
 				if stat > codec.ErrInvalidValue {
 					report.Invariants = append(report.Invariants,
-						fmt.Sprintf("trame %d: ACP2 error stat=%d outside spec range [0..5]", i, stat))
+						fmt.Sprintf("frame %d: ACP2 error stat=%d outside spec range [0..5]", i, stat))
 				}
 			default:
 				report.Invariants = append(report.Invariants,
-					fmt.Sprintf("trame %d: ACP2 unknown msg type %d (spec: 0..3)", i, msg.Type))
+					fmt.Sprintf("frame %d: ACP2 unknown msg type %d (spec: 0..3)", i, msg.Type))
 			}
 		}
 


### PR DESCRIPTION
The validate verb printed French "trames" in user-facing output — spotted in the acp2 oracle receipts (`validate: 99884 trames decoded`). This anglicises the operator-visible text only: the verb summary line, the per-frame error prefix, the `--stop-at` help, the doc example, and the acp1/acp2 validation messages (`frame %d: ...`). Internal Go identifiers (`Trame` type, `TramesProcessed`, `TrameIndex`, `wiretrace.ReadTrames`) are untouched — a wider rename for another day. cli.md regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
