### PR TITLE
feat(nmos): SDP conformance in audit + probe via codec/sdp (#850)

### DIFF
--- a/internal/amwa/audit/audit.go
+++ b/internal/amwa/audit/audit.go
@@ -69,6 +69,7 @@ var deviceChecks = []checkFn{
 	checkIS05TransportParams,
 	checkTransportReport,
 	checkQueryVersionIsolation,
+	checkSDPConformance,
 }
 
 // Run audits every harvest and returns the merged result.

--- a/internal/amwa/audit/checks_sdp.go
+++ b/internal/amwa/audit/checks_sdp.go
@@ -1,0 +1,109 @@
+package audit
+
+import (
+	"fmt"
+	"path"
+	"sort"
+
+	"dhs/internal/amwa/codec/sdp"
+)
+
+// checkSDPConformance parses every captured SDP transport file and
+// reports the deviations the sdp codec finds (#850). A sender can
+// publish a non-conformant SDP that the controller relays verbatim
+// (correctly — a controller must never author stream parameters it
+// does not own), the receiver then cannot decode, and IS-04/IS-05 both
+// report the route "up". The deviation is the only signal, and until
+// now nothing consumed codec/sdp's []Deviation.
+//
+// Each SDP is keyed by its capture-relative path (e.g.
+// "is05/<id>.sdp"); the id is the resource the finding names.
+func checkSDPConformance(h *Harvest) []Finding {
+	if len(h.SDP) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(h.SDP))
+	for k := range h.SDP {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var out []Finding
+	for _, key := range keys {
+		id := sdpResourceID(key)
+		sess, devs, err := sdp.Parse(string(h.SDP[key]))
+		if err != nil {
+			out = append(out, Finding{
+				Code:     "NMOS-SDP-UNPARSEABLE",
+				Severity: SevError,
+				Target:   h.Target,
+				Device:   h.Label,
+				Resource: "sender/" + id,
+				Detail:   "SDP transport file is structurally invalid: " + err.Error(),
+				Spec:     "SMPTE ST 2110 / RFC 4566 SDP; BCP-004-01 transport file",
+				Hint:     "the receiver cannot decode this stream even though IS-04/IS-05 report the route up",
+			})
+			continue
+		}
+		for _, d := range devs {
+			out = append(out, Finding{
+				Code:     "NMOS-SDP-DEVIATION",
+				Severity: SevWarn,
+				Target:   h.Target,
+				Device:   h.Label,
+				Resource: "sender/" + id,
+				Detail:   sdpDeviationDetail(key, d),
+				Spec:     "SMPTE ST 2110 / RFC 4566 SDP",
+				Hint:     "a non-conformant SDP a controller relays verbatim; the receiver may fail to decode",
+			})
+		}
+		// A well-formed but leg-incoherent SDP is its own failure: a
+		// 2022-7 sender advertising a=group:DUP whose tags do not both
+		// resolve to media sections joins one path only.
+		if f := checkDupLegs(h, id, sess); f != nil {
+			out = append(out, *f)
+		}
+	}
+	return out
+}
+
+// checkDupLegs flags an a=group:DUP whose tags do not both resolve to
+// a media section — a ST 2022-7 sender that will come up single-path.
+func checkDupLegs(h *Harvest, id string, sess *sdp.Session) *Finding {
+	hasDUP := false
+	for _, g := range sess.Groups {
+		if g.Semantics == "DUP" {
+			hasDUP = true
+		}
+	}
+	if !hasDUP {
+		return nil
+	}
+	legs := sess.Legs()
+	if len(legs) >= 2 {
+		return nil
+	}
+	return &Finding{
+		Code:     "NMOS-SDP-DUP-INCOMPLETE",
+		Severity: SevWarn,
+		Target:   h.Target,
+		Device:   h.Label,
+		Resource: "sender/" + id,
+		Detail:   "SDP declares a=group:DUP but only one leg resolves — the sender advertises ST 2022-7 redundancy it does not carry",
+		Spec:     "SMPTE ST 2022-7; SDP a=group:DUP",
+		Hint:     "check that both a=mid tags name present m= sections with distinct c= addresses",
+	}
+}
+
+// sdpResourceID recovers the resource id from a capture key like
+// "is05/<uuid>.sdp" or "<uuid>.sdp".
+func sdpResourceID(key string) string {
+	base := path.Base(key)
+	return base[:len(base)-len(path.Ext(base))]
+}
+
+// sdpDeviationDetail renders one deviation with its capture location
+// and line number.
+func sdpDeviationDetail(key string, d sdp.Deviation) string {
+	return fmt.Sprintf("%s line %d: %s (%s)", key, d.Line, d.Reason, d.Text)
+}

--- a/internal/amwa/audit/checks_sdp_test.go
+++ b/internal/amwa/audit/checks_sdp_test.go
@@ -1,0 +1,98 @@
+package audit
+
+// #850: the audit consumes codec/sdp deviations. A conformant SDP is
+// silent; a malformed line is a WARN naming the file+line; a
+// structurally broken file is an ERROR; a DUP group with one leg is
+// its own WARN. Expectations written from the SDP text, not the
+// checker's output.
+
+import (
+	"strings"
+	"testing"
+)
+
+const cleanDupSDP = `v=0
+o=- 1 1 IN IP4 198.51.100.10
+s=clean
+t=0 0
+a=group:DUP primary secondary
+m=video 5004 RTP/AVP 96
+c=IN IP4 233.252.0.10/64
+a=rtpmap:96 raw/90000
+a=mid:primary
+m=video 5004 RTP/AVP 96
+c=IN IP4 233.252.0.138/64
+a=rtpmap:96 raw/90000
+a=mid:secondary
+`
+
+// one m= section, one a=rtpmap malformed (no clock), plus a DUP group
+// that only names one resolvable leg.
+const deviantSDP = `v=0
+o=- 1 1 IN IP4 198.51.100.10
+s=deviant
+t=0 0
+a=group:DUP primary secondary
+m=video 5004 RTP/AVP 96
+c=IN IP4 233.252.0.10/64
+a=rtpmap:96 raw
+a=mid:primary
+`
+
+func findingsByCode(fs []Finding) map[string]int {
+	m := map[string]int{}
+	for _, f := range fs {
+		m[f.Code]++
+	}
+	return m
+}
+
+func TestCheckSDPConformance(t *testing.T) {
+	h := &Harvest{
+		Target: "198.51.100.99:3212", Label: "unit",
+		SDP: map[string][]byte{
+			"is05/aaaa.sdp": []byte(cleanDupSDP),
+			"is05/bbbb.sdp": []byte(deviantSDP),
+			"is05/cccc.sdp": []byte("not an sdp at all\n"),
+		},
+	}
+	fs := checkSDPConformance(h)
+	by := findingsByCode(fs)
+
+	if by["NMOS-SDP-DEVIATION"] < 1 {
+		t.Errorf("deviant SDP (rtpmap without clock) produced no NMOS-SDP-DEVIATION: %+v", fs)
+	}
+	if by["NMOS-SDP-DUP-INCOMPLETE"] != 1 {
+		t.Errorf("DUP with one resolvable leg = %d NMOS-SDP-DUP-INCOMPLETE, want 1", by["NMOS-SDP-DUP-INCOMPLETE"])
+	}
+	if by["NMOS-SDP-UNPARSEABLE"] != 1 {
+		t.Errorf("the non-SDP file = %d NMOS-SDP-UNPARSEABLE, want 1", by["NMOS-SDP-UNPARSEABLE"])
+	}
+
+	// The clean two-leg DUP SDP must contribute nothing.
+	for _, f := range fs {
+		if f.Resource == "sender/aaaa" {
+			t.Errorf("clean SDP produced a finding: %+v", f)
+		}
+	}
+
+	// Findings name the file + line and the resource id from the key.
+	var dev Finding
+	for _, f := range fs {
+		if f.Code == "NMOS-SDP-DEVIATION" {
+			dev = f
+		}
+	}
+	if dev.Resource != "sender/bbbb" {
+		t.Errorf("deviation resource = %q, want sender/bbbb", dev.Resource)
+	}
+	if !strings.Contains(dev.Detail, "is05/bbbb.sdp line ") {
+		t.Errorf("deviation detail lacks file+line: %q", dev.Detail)
+	}
+}
+
+func TestCheckSDPConformanceEmpty(t *testing.T) {
+	if fs := checkSDPConformance(&Harvest{}); fs != nil {
+		t.Errorf("no SDPs must yield no findings, got %+v", fs)
+	}
+}

--- a/internal/amwa/audit/harvest.go
+++ b/internal/amwa/audit/harvest.go
@@ -225,17 +225,24 @@ func loadOne(dir string) (*Harvest, error) {
 		h.Report = splitLines(string(b))
 	}
 
+	// SDPs are exported under sdp/{is04,is05,receivers}/<id>.sdp — a
+	// flat ReadDir misses them all (it skips directories). Walk the
+	// subtree; key each file by its relative path so is04 and is05
+	// captures of the same sender id stay distinct.
 	sdpDir := filepath.Join(dir, "sdp")
-	if entries, err := os.ReadDir(sdpDir); err == nil {
-		for _, e := range entries {
-			if e.IsDir() || !strings.EqualFold(filepath.Ext(e.Name()), ".sdp") {
-				continue
-			}
-			if b, err := os.ReadFile(filepath.Join(sdpDir, e.Name())); err == nil {
-				h.SDP[e.Name()] = b
-			}
+	_ = filepath.WalkDir(sdpDir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.EqualFold(filepath.Ext(d.Name()), ".sdp") {
+			return nil //nolint:nilerr // a missing sdp dir is not an error
 		}
-	}
+		if b, rerr := os.ReadFile(p); rerr == nil {
+			rel, relErr := filepath.Rel(sdpDir, p)
+			if relErr != nil {
+				rel = d.Name()
+			}
+			h.SDP[filepath.ToSlash(rel)] = b
+		}
+		return nil
+	})
 
 	// Followed nodes. Each is a full harvest in its own right.
 	kidsDir := filepath.Join(dir, "nodes")

--- a/internal/amwa/profile/checks.go
+++ b/internal/amwa/profile/checks.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+
+	"dhs/internal/amwa/codec/sdp"
 )
 
 // checkRoot fetches /x-nmos and records which APIs the device serves.
@@ -554,6 +556,80 @@ func checkTransportFileContentType(ctx context.Context, s *Session) []Result {
 		}
 	}
 	return out
+}
+
+// checkSenderSDPConformance fetches a live sender's transport file and
+// parses it with codec/sdp (#850). A non-conformant SDP a controller
+// relays verbatim is the invisible cause of a route that "comes up"
+// and decodes nothing — this is the live counterpart to the offline
+// audit's SDP checks. Deviations are WARN (permitted-but-risky), an
+// unparseable body is FAIL. A 404 (inactive sender) is a SKIP: there
+// is no SDP to judge.
+func checkSenderSDPConformance(ctx context.Context, s *Session) []Result {
+	const (
+		id   = "PROFILE-SDP-001"
+		name = "served SDP transport files are ST 2110 conformant"
+		spec = "SMPTE ST 2110 / RFC 4566 SDP"
+	)
+	vs, has := s.APIs["connection"]
+	if !has || len(vs) == 0 {
+		return []Result{s.skip(id, name, spec, "device serves no connection API")}
+	}
+	ver := highestVersion(vs)
+
+	list := s.get(ctx, "/x-nmos/connection/"+ver+"/single/senders")
+	ids, ok := jsonArray(list.Body)
+	if list.Status != http.StatusOK || !ok || len(ids) == 0 {
+		return []Result{s.skip(id, name, spec, "the device publishes no IS-05 senders")}
+	}
+	if !s.opts.Deep {
+		ids = ids[:1]
+	}
+
+	var out []Result
+	for _, sid := range ids {
+		sid = strings.TrimSuffix(sid, "/")
+		path := "/x-nmos/connection/" + ver + "/single/senders/" + sid + "/transportfile"
+		r := s.get(ctx, path)
+		switch {
+		case r.Status == http.StatusNotFound:
+			out = append(out, s.result(id, name, spec, StatusSkip, r,
+				fmt.Sprintf("sender %s has no transport file (inactive) — no SDP to check", sid)))
+			continue
+		case r.Err != nil || r.Status != http.StatusOK:
+			out = append(out, s.result(id, name, spec, StatusSkip, r,
+				fmt.Sprintf("sender %s transport file not retrievable (status %d) — covered by PROFILE-IS05-001", sid, r.Status)))
+			continue
+		}
+		sess, devs, err := sdp.Parse(string(r.Body))
+		switch {
+		case err != nil:
+			out = append(out, s.result(id, name, spec, StatusFail, r,
+				fmt.Sprintf("sender %s SDP is structurally invalid: %v", sid, err)))
+		case len(devs) > 0:
+			out = append(out, s.result(id, name, spec, StatusWarn, r,
+				fmt.Sprintf("sender %s SDP has %d deviation(s), first: line %d %s", sid, len(devs), devs[0].Line, devs[0].Reason)))
+		case dupUnderfilled(sess):
+			out = append(out, s.result(id, name, spec, StatusWarn, r,
+				fmt.Sprintf("sender %s SDP declares a=group:DUP but only one leg resolves (ST 2022-7 redundancy not carried)", sid)))
+		default:
+			out = append(out, s.result(id, name, spec, StatusPass, r,
+				fmt.Sprintf("sender %s SDP is conformant (%d media section(s))", sid, len(sess.Media))))
+		}
+	}
+	return out
+}
+
+// dupUnderfilled reports an a=group:DUP that resolves to fewer than two
+// legs — the same rule the offline audit applies.
+func dupUnderfilled(sess *sdp.Session) bool {
+	hasDUP := false
+	for _, g := range sess.Groups {
+		if g.Semantics == "DUP" {
+			hasDUP = true
+		}
+	}
+	return hasDUP && len(sess.Legs()) < 2
 }
 
 func sortedKeys(m map[string][]string) []string {

--- a/internal/amwa/profile/profile.go
+++ b/internal/amwa/profile/profile.go
@@ -147,6 +147,7 @@ var checks = []checkFn{
 	checkQueryDowngrade,
 	checkHeartbeatUnknownNode,
 	checkTransportFileContentType,
+	checkSenderSDPConformance,
 }
 
 // Run probes the target and returns the report.

--- a/internal/amwa/profile/profile_test.go
+++ b/internal/amwa/profile/profile_test.go
@@ -724,3 +724,29 @@ func TestHTTPSOption(t *testing.T) {
 	}
 	want(t, rep, "PROFILE-ROOT-001", StatusPass)
 }
+
+// #850: the live probe parses a sender's transport file with codec/sdp.
+// Default mock SDP is minimal-but-valid → PASS; a malformed rtpmap →
+// WARN (deviation); a non-SDP body → FAIL; an inactive sender (404) →
+// SKIP.
+func TestSenderSDPConformance(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		set  func(*device)
+		want Status
+	}{
+		{"conformant", func(d *device) {}, StatusPass},
+		{"deviation", func(d *device) {
+			d.transportFile = "v=0\r\no=- 1 1 IN IP4 198.51.100.5\r\ns=x\r\nt=0 0\r\nm=video 5004 RTP/AVP 96\r\na=rtpmap:96 raw\r\n"
+		}, StatusWarn},
+		{"unparseable", func(d *device) { d.transportFile = "not an sdp\r\n" }, StatusFail},
+		{"inactive 404", func(d *device) { d.transportCode = http.StatusNotFound }, StatusSkip},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newDevice()
+			d.apis["connection"] = []string{"v1.1"}
+			tc.set(d)
+			want(t, profileIt(t, d), "PROFILE-SDP-001", tc.want)
+		})
+	}
+}


### PR DESCRIPTION
Closes #850.

Wires the `codec/sdp` parser (#827) into both consumers — until now nothing consumed its `[]Deviation`, so a sender publishing a non-conformant SDP that the controller relays verbatim was the invisible cause of a route that "comes up" and decodes nothing.

## Offline — `dhs consumer nmos audit`

New `checkSDPConformance`: parses every captured `sdp/**/*.sdp`, emitting
- `NMOS-SDP-DEVIATION` (WARN) per codec deviation, naming file + line,
- `NMOS-SDP-UNPARSEABLE` (ERROR) for a structurally broken file,
- `NMOS-SDP-DUP-INCOMPLETE` (WARN) for an `a=group:DUP` that resolves to fewer than two legs (ST 2022-7 redundancy advertised but not carried).

Bug fixed in passing: the harvest SDP loader did a flat `ReadDir` and skipped directories, so it loaded **zero** of the real captures — they live under `sdp/is04/`, `sdp/is05/`. Now a recursive walk keyed by capture-relative path.

## Live — `dhs consumer nmos probe`

New `checkSenderSDPConformance` (`PROFILE-SDP-001`): fetches a live sender's transport file and parses it — PASS conformant, WARN on deviations / underfilled DUP, FAIL unparseable, SKIP on a 404 (inactive sender, no SDP to judge). `--deep` asserts every sender.

Both sides table-tested (conformant / deviation / unparseable / DUP-incomplete / inactive). Full `internal/amwa/...` + `cmd/dhs` sweep clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
