### PR TITLE
feat(nmos): AMWA parameter registers - typed catalogue + bcp00401 rewired/invoked + verbs (#851)

### DIFF
--- a/cmd/dhs/cmd_nmos.go
+++ b/cmd/dhs/cmd_nmos.go
@@ -70,8 +70,10 @@ func runNMOSConsumer(ctx context.Context, args []string) error {
 		return runNMOSAudit(ctx, rest)
 	case "probe":
 		return runNMOSProfile(ctx, rest)
+	case "registers":
+		return runNMOSRegisters(ctx, rest)
 	}
-	return fmt.Errorf("consumer nmos: unknown verb %q (expected: discover, system, walk, watch, connect, set, facade, events, export, audit, probe)", verb)
+	return fmt.Errorf("consumer nmos: unknown verb %q (expected: discover, system, walk, watch, connect, set, facade, events, export, audit, probe, registers)", verb)
 }
 
 // runNMOSProducer dispatches `dhs producer nmos <verb> [args]`.

--- a/cmd/dhs/cmd_nmos_registers.go
+++ b/cmd/dhs/cmd_nmos_registers.go
@@ -1,0 +1,101 @@
+package main
+
+// `dhs consumer nmos registers` — walk the AMWA NMOS Parameter
+// Registers the way ACP2/Ember+ expose a device tree (#851): typed,
+// enumerable, introspectable. No network; the registers are compiled
+// in from codec/registers.
+//
+//   dhs consumer nmos registers list
+//   dhs consumer nmos registers show urn:x-nmos:cap:format:component_depth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"dhs/internal/amwa/codec/registers"
+)
+
+func runNMOSRegisters(_ context.Context, args []string) error {
+	if len(args) == 0 || isHelpToken(args[0]) {
+		fmt.Println("usage: dhs consumer nmos registers <list|show> [urn] [--json]")
+		fmt.Println("  list          every parameter, URN-sorted")
+		fmt.Println("  show <urn>    one parameter's typed constraint")
+		fmt.Println("  --json        machine-readable output")
+		return nil
+	}
+	sub := args[0]
+	rest := args[1:]
+	asJSON := false
+	var urn string
+	for _, a := range rest {
+		switch {
+		case a == "--json":
+			asJSON = true
+		case urn == "":
+			urn = a
+		default:
+			return fmt.Errorf("registers %s: unexpected argument %q", sub, a)
+		}
+	}
+
+	switch sub {
+	case "list":
+		all := registers.All()
+		if asJSON {
+			return json.NewEncoder(os.Stdout).Encode(all)
+		}
+		fmt.Printf("%-52s %-10s %s\n", "URN", "KIND", "ACCEPTS")
+		for _, p := range all {
+			fmt.Printf("%-52s %-10s %s\n", p.URN, p.Kind, accepts(p))
+		}
+		fmt.Printf("\n%d parameter(s)\n", len(all))
+		return nil
+
+	case "show":
+		if urn == "" {
+			return fmt.Errorf("registers show: a parameter URN is required")
+		}
+		p, ok := registers.Lookup(urn)
+		if !ok {
+			return fmt.Errorf("registers show: %q is not in any register", urn)
+		}
+		if asJSON {
+			return json.NewEncoder(os.Stdout).Encode(p)
+		}
+		fmt.Printf("%s\n", p.URN)
+		fmt.Printf("  name     %s\n", p.Name)
+		if p.Description != "" {
+			fmt.Printf("  desc     %s\n", p.Description)
+		}
+		fmt.Printf("  kind     %s\n", p.Kind)
+		fmt.Printf("  accepts  %s\n", accepts(p))
+		fmt.Printf("  register %s %s\n", p.Register, p.RegisterVersion)
+		return nil
+	}
+	return fmt.Errorf("registers: unknown subcommand %q (want list or show)", sub)
+}
+
+// accepts renders a parameter's constraint as a one-line human answer.
+func accepts(p registers.Param) string {
+	switch p.Kind {
+	case registers.KindEnum:
+		return fmt.Sprintf("%v", p.Values)
+	case registers.KindInteger, registers.KindNumber:
+		lo, hi := "−∞", "+∞"
+		if p.Min != nil {
+			lo = fmt.Sprintf("%g", *p.Min)
+		}
+		if p.Max != nil {
+			hi = fmt.Sprintf("%g", *p.Max)
+		}
+		return lo + " .. " + hi
+	case registers.KindRational:
+		return "rational {numerator, denominator}"
+	case registers.KindBoolean:
+		return "true | false"
+	default:
+		return "any string"
+	}
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -25,6 +25,7 @@ Ansible templates render the same shape.
 - [NMOS plant export](#nmos-plant-export)
 - [NMOS plant audit](#nmos-plant-audit)
 - [NMOS live probe](#nmos-live-probe)
+- [NMOS parameter registers](#nmos-parameter-registers)
 - [consumer info](#consumer-info)
 - [consumer walk](#consumer-walk)
 - [consumer get](#consumer-get)
@@ -584,6 +585,17 @@ Usage of consumer nmos probe:
     	device to probe, as host:port (required)
   -timeout duration
     	per-request deadline (default 10s)
+```
+
+## NMOS parameter registers
+
+`dhs consumer nmos registers --help`
+
+```text
+usage: dhs consumer nmos registers <list|show> [urn] [--json]
+  list          every parameter, URN-sorted
+  show <urn>    one parameter's typed constraint
+  --json        machine-readable output
 ```
 
 ## consumer info

--- a/internal/amwa/codec/bcp/bcp00401/validator.go
+++ b/internal/amwa/codec/bcp/bcp00401/validator.go
@@ -13,9 +13,13 @@ package bcp00401
 
 import (
 	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"dhs/internal/amwa/codec/bcp"
+	"dhs/internal/amwa/codec/registers"
 	"dhs/internal/amwa/codec/spec"
 )
 
@@ -56,10 +60,37 @@ func (Validator) Validate(payload []byte) []spec.ComplianceEvent {
 	for i, set := range body.Caps.ConstraintSets {
 		if len(set) == 0 {
 			out = append(out, event("bcp_004_01_empty_constraint_set",
-				spec.SeverityWarn, "caps.constraint_sets["+itoa(i)+"]: empty"))
+				spec.SeverityWarn, fmt.Sprintf("caps.constraint_sets[%d]: empty", i)))
+			continue
+		}
+		// Every x-nmos cap parameter URN must be in the AMWA
+		// capabilities register (#851). A urn:x-nmos:cap:* not in any
+		// register is a vendor that invented a capability — a
+		// controller filtering against it silently drops the receiver.
+		// Vendor URNs outside the urn:x-nmos: namespace are permitted
+		// (BCP-004-01 §3) and not flagged.
+		for _, urn := range sortedParamURNs(set) {
+			if urn == "" || !strings.HasPrefix(urn, "urn:x-nmos:cap:") {
+				continue
+			}
+			if !registers.Known(urn) {
+				out = append(out, event("bcp_004_01_unknown_cap_urn", spec.SeverityWarn,
+					fmt.Sprintf("caps.constraint_sets[%d]: %q is not in the AMWA capabilities register", i, urn)))
+			}
 		}
 	}
 	return out
+}
+
+// sortedParamURNs returns a constraint set's parameter keys (its URNs)
+// in a stable order — meta keys and cap URNs alike; the caller filters.
+func sortedParamURNs(set map[string]any) []string {
+	keys := make([]string, 0, len(set))
+	for k := range set {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func event(code string, sev spec.Severity, detail string) spec.ComplianceEvent {
@@ -67,20 +98,6 @@ func event(code string, sev spec.Severity, detail string) spec.ComplianceEvent {
 		SpecID: SpecID, APIVer: APIVer, SpecPatch: SpecPatch,
 		Code: code, Severity: sev, Detail: detail, At: time.Now(),
 	}
-}
-
-func itoa(i int) string {
-	if i == 0 {
-		return "0"
-	}
-	var b [20]byte
-	pos := len(b)
-	for i > 0 {
-		pos--
-		b[pos] = byte('0' + i%10)
-		i /= 10
-	}
-	return string(b[pos:])
 }
 
 func init() { bcp.Register(Validator{}) }

--- a/internal/amwa/codec/bcp/bcp00401/validator_test.go
+++ b/internal/amwa/codec/bcp/bcp00401/validator_test.go
@@ -1,0 +1,54 @@
+package bcp00401
+
+// #851: the validator flags a constraint-set cap URN that is not in the
+// AMWA capabilities register — the "this vendor invented a capability"
+// case a filtering controller silently drops.
+
+import (
+	"strings"
+	"testing"
+)
+
+func codesOf(v Validator, payload string) map[string]int {
+	m := map[string]int{}
+	for _, e := range v.Validate([]byte(payload)) {
+		m[e.Code]++
+	}
+	return m
+}
+
+func TestUnknownCapURNFlagged(t *testing.T) {
+	v := New()
+
+	// A real register URN passes; an invented x-nmos cap URN is flagged;
+	// a vendor URN outside urn:x-nmos: is permitted (BCP-004-01 §3).
+	payload := `{"caps":{"constraint_sets":[
+		{"urn:x-nmos:cap:format:color_sampling":{"enum":["YCbCr-4:2:2"]},
+		 "urn:x-nmos:cap:format:teleportation":{"enum":["yes"]},
+		 "urn:x-vendor:cap:secret":{"enum":["ok"]}}
+	]}}`
+	by := codesOf(v, payload)
+	if by["bcp_004_01_unknown_cap_urn"] != 1 {
+		t.Fatalf("expected exactly one unknown-cap-urn event, got %v", by)
+	}
+}
+
+func TestKnownCapURNsClean(t *testing.T) {
+	v := New()
+	payload := `{"caps":{"constraint_sets":[
+		{"urn:x-nmos:cap:format:media_type":{"enum":["video/raw"]},
+		 "urn:x-nmos:cap:meta:preference":{"minimum":0}}
+	]}}`
+	for _, e := range v.Validate([]byte(payload)) {
+		if strings.Contains(e.Code, "unknown_cap_urn") {
+			t.Errorf("register URNs wrongly flagged: %s", e.Detail)
+		}
+	}
+}
+
+func TestEmptyConstraintSetStillFlagged(t *testing.T) {
+	v := New()
+	if codesOf(v, `{"caps":{"constraint_sets":[{}]}}`)["bcp_004_01_empty_constraint_set"] != 1 {
+		t.Error("an empty constraint set must still be flagged")
+	}
+}

--- a/internal/amwa/codec/registers/capabilities.go
+++ b/internal/amwa/codec/registers/capabilities.go
@@ -1,0 +1,75 @@
+package registers
+
+// The AMWA NMOS Capabilities register (v1.0), the cap:format:*,
+// cap:transport:* and cap:meta:* parameter constraints BCP-004-01
+// constraint sets are built from. Values are transcribed from the
+// register text at https://specs.amwa.tv/nmos-parameter-registers/
+// branches/main/capabilities/ — never from our own encoder.
+//
+// Kinds: enum values are the register's listed options; numeric
+// parameters carry the register's bound where it states one and stay
+// open otherwise; grain_rate / sample_rate style rationals are
+// KindRational.
+
+func f(v float64) *float64 { return &v }
+
+func init() {
+	register(Register{
+		Name:    "capabilities",
+		Version: "v1.0",
+		Params: []Param{
+			// ---- cap:format:* ----
+			{URN: "urn:x-nmos:cap:format:media_type", Name: "Media Type", Kind: KindEnum,
+				Description: "RTP payload media type of the Flow",
+				Values: []string{
+					"video/raw", "video/jxsv", "video/smpte291", "video/SMPTE2022-6",
+					"video/H264", "video/H265", "audio/L16", "audio/L24", "audio/L32",
+					"application/mp2t",
+				}},
+			{URN: "urn:x-nmos:cap:format:grain_rate", Name: "Grain Rate", Kind: KindRational,
+				Description: "Grain rate as an NMOS rational (numerator/denominator)"},
+			{URN: "urn:x-nmos:cap:format:frame_width", Name: "Frame Width", Kind: KindInteger,
+				Description: "Video frame width in pixels", Min: f(1)},
+			{URN: "urn:x-nmos:cap:format:frame_height", Name: "Frame Height", Kind: KindInteger,
+				Description: "Video frame height in pixels", Min: f(1)},
+			{URN: "urn:x-nmos:cap:format:interlace_mode", Name: "Interlace Mode", Kind: KindEnum,
+				Values: []string{"progressive", "interlaced_tff", "interlaced_bff", "interlaced_psf"}},
+			{URN: "urn:x-nmos:cap:format:colorspace", Name: "Colorspace", Kind: KindEnum,
+				Values: []string{"BT601", "BT709", "BT2020", "BT2100", "ST2065-1", "ST2065-3"}},
+			{URN: "urn:x-nmos:cap:format:transfer_characteristic", Name: "Transfer Characteristic", Kind: KindEnum,
+				Values: []string{"SDR", "HLG", "PQ", "ST2065-1", "unspecified"}},
+			{URN: "urn:x-nmos:cap:format:color_sampling", Name: "Color (Chroma) Sampling", Kind: KindEnum,
+				Values: []string{"YCbCr-4:4:4", "YCbCr-4:2:2", "YCbCr-4:2:0", "RGB", "RGBA", "ICtCp-4:4:4", "XYZ", "KEY"}},
+			{URN: "urn:x-nmos:cap:format:component_depth", Name: "Component Depth", Kind: KindInteger,
+				Description: "Bits per component", Min: f(8), Max: f(16)},
+			{URN: "urn:x-nmos:cap:format:channel_count", Name: "Channel Count", Kind: KindInteger,
+				Description: "Audio channel count", Min: f(1)},
+			{URN: "urn:x-nmos:cap:format:sample_rate", Name: "Sample Rate", Kind: KindRational,
+				Description: "Audio sample rate as an NMOS rational"},
+			{URN: "urn:x-nmos:cap:format:sample_depth", Name: "Sample Depth", Kind: KindInteger,
+				Description: "Audio bits per sample", Min: f(8)},
+			{URN: "urn:x-nmos:cap:format:event_type", Name: "Event Type", Kind: KindString,
+				Description: "IS-07 event type the Flow carries"},
+
+			// ---- cap:transport:* ----
+			{URN: "urn:x-nmos:cap:transport:packet_time", Name: "Packet Time", Kind: KindNumber,
+				Description: "RTP packet time in milliseconds", Min: f(0)},
+			{URN: "urn:x-nmos:cap:transport:max_packet_time", Name: "Max Packet Time", Kind: KindNumber,
+				Min: f(0)},
+			{URN: "urn:x-nmos:cap:transport:st2110_21_sender_type", Name: "ST 2110-21 Sender Type", Kind: KindEnum,
+				Values: []string{"2110TPN", "2110TPNL", "2110TPW"}},
+			{URN: "urn:x-nmos:cap:transport:bit_rate", Name: "Bit Rate", Kind: KindInteger,
+				Description: "Transport bit rate in kbit/s", Min: f(0)},
+			{URN: "urn:x-nmos:cap:transport:packet_transmission_mode", Name: "Packet Transmission Mode", Kind: KindEnum,
+				Values: []string{"codestream", "slice_sequential", "slice_out_of_order"}},
+
+			// ---- cap:meta:* ----
+			{URN: "urn:x-nmos:cap:meta:label", Name: "Constraint Set Label", Kind: KindString,
+				Description: "Human-readable label for the constraint set"},
+			{URN: "urn:x-nmos:cap:meta:preference", Name: "Constraint Set Preference", Kind: KindInteger,
+				Description: "Preference ordering; higher is preferred", Min: f(-100), Max: f(100)},
+			{URN: "urn:x-nmos:cap:meta:enabled", Name: "Constraint Set Enabled", Kind: KindBoolean,
+				Description: "Whether the constraint set is currently active"},
+		},
+	})
+}

--- a/internal/amwa/codec/registers/registers.go
+++ b/internal/amwa/codec/registers/registers.go
@@ -1,0 +1,123 @@
+// Package registers is a typed, introspectable model of the AMWA NMOS
+// Parameter Registers (#851) — stdlib-only, lift-ready (ADR-0006).
+//
+// The registers are standardised (https://specs.amwa.tv/nmos-parameter-
+// registers/), so this implements a register, not a dhs-specific
+// schema: our "valid values" must agree with every other
+// implementation's, which is the whole point of a conformance tool.
+// What we borrow from the ACP2 / Ember+ models is not their content but
+// that they are typed and walkable — you can ask a parameter what it
+// accepts and get a machine answer, not a doc link.
+//
+// Adding a parameter or a whole register is +1 entry in a data file
+// (capabilities.go, formats.go, …); nothing else changes (open/closed).
+package registers
+
+import "sort"
+
+// Kind is the typed constraint a parameter carries — the machine
+// answer to "what does this accept".
+type Kind string
+
+const (
+	// KindEnum: Values lists the legal strings.
+	KindEnum Kind = "enum"
+	// KindInteger / KindNumber: Min/Max bound a numeric (Max nil = open).
+	KindInteger Kind = "integer"
+	KindNumber  Kind = "number"
+	// KindRational: a value is {numerator, denominator} (e.g. grain_rate).
+	KindRational Kind = "rational"
+	// KindBoolean: true/false.
+	KindBoolean Kind = "boolean"
+	// KindString: a free string (a label); no value constraint.
+	KindString Kind = "string"
+)
+
+// Param is one register entry — a parameter URN and what it accepts.
+type Param struct {
+	URN         string   `json:"urn"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Kind        Kind     `json:"kind"`
+	Values      []string `json:"values,omitempty"` // KindEnum
+	Min         *float64 `json:"minimum,omitempty"`
+	Max         *float64 `json:"maximum,omitempty"`
+	// Register names the AMWA register this came from (e.g.
+	// "capabilities"); RegisterVersion the register version, so every
+	// URN carries its provenance (DoD).
+	Register        string `json:"register"`
+	RegisterVersion string `json:"register_version"`
+}
+
+// Register is a named, versioned set of parameters.
+type Register struct {
+	Name    string
+	Version string
+	Params  []Param
+}
+
+// all is the compiled-in register set, filled by each data file's
+// init(). A map keyed by URN for O(1) Lookup plus insertion-stable
+// listing via the ordered urns slice.
+var (
+	byURN = map[string]Param{}
+	urns  []string
+)
+
+// register adds one register's params to the global catalogue. Called
+// from data-file init()s. A duplicate URN panics — that is a
+// data-authoring bug, caught at process start like the codec
+// registries.
+func register(r Register) {
+	for _, p := range r.Params {
+		p.Register = r.Name
+		p.RegisterVersion = r.Version
+		if _, dup := byURN[p.URN]; dup {
+			panic("registers: duplicate URN " + p.URN)
+		}
+		byURN[p.URN] = p
+		urns = append(urns, p.URN)
+	}
+}
+
+// Lookup returns the parameter for a URN and whether it is known.
+func Lookup(urn string) (Param, bool) {
+	p, ok := byURN[urn]
+	return p, ok
+}
+
+// Known reports whether a URN exists in any register.
+func Known(urn string) bool {
+	_, ok := byURN[urn]
+	return ok
+}
+
+// All returns every parameter, URN-sorted (stable across runs so two
+// `registers list` outputs diff cleanly).
+func All() []Param {
+	out := make([]Param, 0, len(urns))
+	for _, u := range urns {
+		out = append(out, byURN[u])
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].URN < out[j].URN })
+	return out
+}
+
+// Accepts reports whether value is legal for an enum/boolean param.
+// Numeric and rational kinds return true (range/shape checks live with
+// the caller that has the parsed value); an unknown URN returns false.
+func (p Param) Accepts(value string) bool {
+	switch p.Kind {
+	case KindEnum:
+		for _, v := range p.Values {
+			if v == value {
+				return true
+			}
+		}
+		return false
+	case KindBoolean:
+		return value == "true" || value == "false"
+	default:
+		return true
+	}
+}

--- a/internal/amwa/codec/registers/registers_test.go
+++ b/internal/amwa/codec/registers/registers_test.go
@@ -1,0 +1,69 @@
+package registers
+
+// Values are transcribed from the AMWA capabilities register, never
+// from an encoder. These pin the typed model and the introspection
+// contract the CLI + bcp00401 depend on.
+
+import "testing"
+
+func TestLookupTypedConstraints(t *testing.T) {
+	// component_depth is a bounded integer 8..16.
+	p, ok := Lookup("urn:x-nmos:cap:format:component_depth")
+	if !ok {
+		t.Fatal("component_depth not in the register")
+	}
+	if p.Kind != KindInteger || p.Min == nil || *p.Min != 8 || p.Max == nil || *p.Max != 16 {
+		t.Fatalf("component_depth constraint = %+v, want integer 8..16", p)
+	}
+	if p.Register != "capabilities" || p.RegisterVersion != "v1.0" {
+		t.Errorf("provenance = %s %s, want capabilities v1.0", p.Register, p.RegisterVersion)
+	}
+
+	// color_sampling is an enum; a listed value is accepted, a bogus one not.
+	cs, _ := Lookup("urn:x-nmos:cap:format:color_sampling")
+	if cs.Kind != KindEnum {
+		t.Fatalf("color_sampling kind = %s, want enum", cs.Kind)
+	}
+	if !cs.Accepts("YCbCr-4:2:2") {
+		t.Error("color_sampling must accept YCbCr-4:2:2")
+	}
+	if cs.Accepts("YCbCr-9:9:9") {
+		t.Error("color_sampling must reject a nonsense value")
+	}
+
+	// grain_rate is rational; sample_rate too.
+	if gr, _ := Lookup("urn:x-nmos:cap:format:grain_rate"); gr.Kind != KindRational {
+		t.Errorf("grain_rate kind = %s, want rational", gr.Kind)
+	}
+
+	// meta:enabled is boolean.
+	if en, _ := Lookup("urn:x-nmos:cap:meta:enabled"); en.Kind != KindBoolean {
+		t.Errorf("meta:enabled kind = %s, want boolean", en.Kind)
+	}
+}
+
+func TestKnownAndUnknown(t *testing.T) {
+	if !Known("urn:x-nmos:cap:transport:st2110_21_sender_type") {
+		t.Error("a real transport cap URN must be Known")
+	}
+	if Known("urn:x-nmos:cap:format:teleportation") {
+		t.Error("an invented cap URN must not be Known")
+	}
+}
+
+func TestAllSortedAndProvenanced(t *testing.T) {
+	all := All()
+	if len(all) < 15 {
+		t.Fatalf("register has %d params, expected the capabilities set", len(all))
+	}
+	for i := 1; i < len(all); i++ {
+		if all[i-1].URN > all[i].URN {
+			t.Fatalf("All() not URN-sorted at %d: %s > %s", i, all[i-1].URN, all[i].URN)
+		}
+	}
+	for _, p := range all {
+		if p.Register == "" || p.RegisterVersion == "" {
+			t.Errorf("%s lacks provenance", p.URN)
+		}
+	}
+}

--- a/internal/amwa/consumer/controller.go
+++ b/internal/amwa/consumer/controller.go
@@ -2,11 +2,14 @@ package consumer
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"strings"
 	"time"
 
+	"dhs/internal/amwa/codec/bcp"
+	_ "dhs/internal/amwa/codec/bcp/bcp00401" // register the BCP-004-01 receiver-caps validator
 	"dhs/internal/amwa/codec/dnssd"
 	"dhs/internal/amwa/codec/is04"
 	"dhs/internal/amwa/codec/spec"
@@ -227,6 +230,27 @@ func (c *Controller) Walk(ctx context.Context) (*CatalogueSnapshot, []error) {
 		snap.Receivers = v
 		return err
 	})
+
+	// BCP-004-01: run the receiver-caps validators over each receiver
+	// as the controller reads it (#851) — a receiver whose caps
+	// reference a cap URN outside the AMWA register is one a filtering
+	// controller silently drops. Events flow to the same Reporter as
+	// every other walk finding.
+	for i := range snap.Receivers {
+		body, err := json.Marshal(snap.Receivers[i])
+		if err != nil {
+			continue
+		}
+		for _, v := range bcp.ForKind(bcp.KindReceiver) {
+			for _, ev := range v.Validate(body) {
+				ev.PeerHost = trimURLScheme(c.client.Base)
+				if ev.At.IsZero() {
+					ev.At = time.Now()
+				}
+				c.reporter.Report(ev)
+			}
+		}
+	}
 
 	return snap, errs
 }

--- a/tools/gencli/main.go
+++ b/tools/gencli/main.go
@@ -44,6 +44,7 @@ var matrix = []helpEntry{
 	{"NMOS plant export", []string{"consumer", "nmos", "export", "--help"}},
 	{"NMOS plant audit", []string{"consumer", "nmos", "audit", "--help"}},
 	{"NMOS live probe", []string{"consumer", "nmos", "probe", "--help"}},
+	{"NMOS parameter registers", []string{"consumer", "nmos", "registers", "--help"}},
 
 	// The generic consumer verb set (shape shared by acp1/acp2/emberplus).
 	{"consumer info", []string{"consumer", "acp1", "info", "--help"}},


### PR DESCRIPTION
Closes #851.

The AMWA NMOS Parameter Registers, modelled the way ACP2/Ember+ expose a tree: typed, enumerable, introspectable — you ask a parameter what it accepts and get a machine answer, not a doc link.

## `internal/amwa/codec/registers/`

Stdlib-only, lift-ready (verified: `go list -deps` shows only the package itself). Typed constraint `Kind` (enum / integer / number / rational / boolean / string) — not `map[string]any`. Every `Param` carries its `Register` + `RegisterVersion` provenance. The capabilities register (v1.0) is transcribed from the AMWA register text: `cap:format:*` (media_type, grain_rate, frame_width/height, interlace, colorspace, transfer, color_sampling, component_depth, channel_count, sample_rate, sample_depth, event_type), `cap:transport:*` (packet_time, st2110_21_sender_type, bit_rate, transmission_mode…), `cap:meta:*` (label, preference, enabled). Adding a register is +1 data file (open/closed).

## bcp00401 rewritten AND invoked

The 75-line shell now validates each constraint set's parameter URNs against the register: a `urn:x-nmos:cap:*` not in any register → `bcp_004_01_unknown_cap_urn` (the "vendor invented a capability" case a filtering controller silently drops); vendor URNs outside `urn:x-nmos:` are permitted per §3. Its hand-rolled `itoa` is gone.

Invoked for real, not just registered: the controller **walk** path (`Controller.Walk`) runs the receiver-caps validators over each receiver and fires events to the same `spec.Reporter` as every other walk finding. (Dependency audit green — consumer→codec/bcp is a legal layer edge.)

## Verbs

```
dhs consumer nmos registers list
dhs consumer nmos registers show urn:x-nmos:cap:format:component_depth
  → kind integer, accepts 8 .. 16, register capabilities v1.0
```
`--json` on both. Live-smoked: 21 parameters listed, `show` returns the typed constraint.

Table-driven tests (values from the register text): typed-constraint lookup, enum accept/reject, Known/unknown, sorted+provenanced All(), and the bcp00401 unknown-URN check with a fail/clean/vendor-permitted trio. cli.md regenerated with the registers section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
