### PR TITLE
feat(nmos): version-mismatch matrix + minimal reference node (#849 core)

### DIFF
--- a/internal/amwa/registry/version_matrix_test.go
+++ b/internal/amwa/registry/version_matrix_test.go
@@ -1,0 +1,55 @@
+package registry
+
+// The IS-04 version-mismatch matrix (#849), asserted as the registry's
+// own decision function. The registry translates one way only: it can
+// present a LOWER-registered resource at a HIGHER query, never a
+// higher-registered resource to a lower controller — query.downgrade
+// widens the window to [downgrade, urlVer] but cannot reach above
+// urlVer. The operational consequence the customer plant showed:
+// an old controller is permanently blind to new nodes, and the only
+// lever is the minor the NODE registers at.
+
+import "testing"
+
+func TestVersionMismatchMatrix(t *testing.T) {
+	cases := []struct {
+		name                           string
+		resourceVer, urlVer, downgrade string
+		want                           bool
+	}{
+		// Node registered LOW, controller queries at/above — visible.
+		{"v1.0 node at v1.0 query", "v1.0", "v1.0", "", true},
+		{"v1.0 node at v1.3 query, no downgrade", "v1.0", "v1.3", "", false},
+		{"v1.0 node at v1.3 query, downgrade v1.0", "v1.0", "v1.3", "v1.0", true},
+		{"v1.1 node at v1.3 query, downgrade v1.0", "v1.1", "v1.3", "v1.0", true},
+
+		// Node registered HIGH, controller queries LOW — the one-way
+		// wall. downgrade cannot help: the window is [downgrade, urlVer]
+		// and v1.3 > v1.0.
+		{"v1.3 node at v1.0 query, no downgrade", "v1.3", "v1.0", "", false},
+		{"v1.3 node at v1.0 query, downgrade v1.0", "v1.3", "v1.0", "v1.0", false},
+		{"v1.3 node at v1.3 query", "v1.3", "v1.3", "", true},
+
+		// downgrade floor excludes a resource below it.
+		{"v1.0 node at v1.3 query, downgrade v1.2", "v1.0", "v1.3", "v1.2", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := versionAllowed(tc.resourceVer, tc.urlVer, tc.downgrade); got != tc.want {
+				t.Fatalf("versionAllowed(%q,%q,%q) = %v, want %v",
+					tc.resourceVer, tc.urlVer, tc.downgrade, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestOldControllerBlindToNewNodes is the matrix's headline case as a
+// standalone assertion: no query.downgrade value a v1.0 controller can
+// send makes a v1.3-registered node visible to it.
+func TestOldControllerBlindToNewNodes(t *testing.T) {
+	for _, dg := range []string{"", "v1.0", "v1.1", "v1.2", "v1.3"} {
+		if versionAllowed("v1.3", "v1.0", dg) {
+			t.Fatalf("a v1.3 node became visible at a v1.0 query with downgrade=%q — the one-way wall is broken", dg)
+		}
+	}
+}

--- a/internal/amwa/testdata/reference-nodes/README.md
+++ b/internal/amwa/testdata/reference-nodes/README.md
@@ -1,0 +1,31 @@
+# Reference nodes (#849)
+
+Two bundles that bracket the real world, for testing controllers,
+registries, and the audit/probe verbs against known-shaped devices.
+
+## `minimal-node.json`
+The least a device can do and stay conformant: one device, one
+source/flow/sender/receiver, RTP, **empty caps, no group hints, single
+leg**. It finds every place a controller assumed more than the spec
+guarantees. Verified to load and serve (`producer nmos serve --config`),
+answering `/self` and one sender. Documentation addressing only.
+
+## Full-spec node
+The realistic exerciser is `ansible/roles/dhs_amwa_plant/files/
+amwa-test-node.json` — every published IS-04 minor, IS-05 single+bulk,
+IS-07/08/11, BCP-002 multi-role group hints, BCP-004 caps, 2022-7 SDP.
+It drives every AMWA tool suite green.
+
+Note: it is deliberately a *realistic* node, not a *clean* one — it
+carries multi-transport senders (websocket tally, MQTT) that the
+offline audit correctly flags (a master-enabled MQTT sender with no
+destination; websocket senders with no RTP transport file). A
+purpose-built zero-finding clean-full-spec bundle is tracked separately;
+the realistic node is the better exerciser for the tools themselves.
+
+## Version-mismatch matrix
+Asserted deterministically in `internal/amwa/registry/version_matrix_test.go`
+(`versionAllowed`), both directions incl. the one-way wall: a registry
+presents a lower-registered resource at a higher query, never the
+reverse — an old controller is permanently blind to new nodes, and the
+only lever is the minor the node registers at.

--- a/internal/amwa/testdata/reference-nodes/minimal-node.json
+++ b/internal/amwa/testdata/reference-nodes/minimal-node.json
@@ -1,0 +1,196 @@
+{
+  "node": {
+    "id": "2c47bf5e-1b2c-4abc-9def-deadbeef0001",
+    "version": "1777651501:0",
+    "label": "dhs-test-node",
+    "description": "dhs Phase 2 - AMWA NMOS Testing harness (full bundle)",
+    "tags": {
+      "urn:x-nmos:tag:asset:manufacturer/v1.0": [
+        "BY-SYSTEMS"
+      ],
+      "urn:x-nmos:tag:asset:product/v1.0": [
+        "dhs"
+      ],
+      "urn:x-nmos:tag:asset:instance-id/v1.0": [
+        "2c47bf5e-1b2c-4abc-9def-deadbeef0001"
+      ],
+      "urn:x-nmos:tag:asset:function/v1.0": [
+        "NMOS Node"
+      ]
+    },
+    "href": "http://127.0.0.1:18080/",
+    "caps": {},
+    "api": {
+      "versions": [
+        "v1.0",
+        "v1.1",
+        "v1.2",
+        "v1.3"
+      ],
+      "endpoints": []
+    },
+    "services": [],
+    "clocks": [
+      {
+        "name": "clk0",
+        "ref_type": "internal"
+      }
+    ],
+    "interfaces": [
+      {
+        "chassis_id": "ff-ff-ff-ff-ff-ff",
+        "port_id": "ff-ff-ff-ff-ff-ff",
+        "name": "eth0",
+        "attached_network_device": {
+          "chassis_id": "00-11-22-33-44-55",
+          "port_id": "00-11-22-33-44-66"
+        }
+      }
+    ],
+    "hostname": "dhs-test-node"
+  },
+  "devices": [
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "version": "1777651501:0",
+      "label": "dhs-test-device",
+      "description": "single device under dhs-test-node",
+      "tags": {
+        "urn:x-nmos:tag:asset:manufacturer/v1.0": [
+          "BY-SYSTEMS"
+        ],
+        "urn:x-nmos:tag:asset:product/v1.0": [
+          "dhs"
+        ],
+        "urn:x-nmos:tag:asset:instance-id/v1.0": [
+          "2c47bf5e-1b2c-4abc-9def-deadbeef0002"
+        ],
+        "urn:x-nmos:tag:asset:function/v1.0": [
+          "audio-bridge"
+        ]
+      },
+      "type": "urn:x-nmos:device:generic",
+      "node_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0001",
+      "senders": [
+        "2c47bf5e-1b2c-4abc-9def-deadbeef0102"
+      ],
+      "receivers": [
+        "2c47bf5e-1b2c-4abc-9def-deadbeef0103"
+      ],
+      "controls": []
+    }
+  ],
+  "sources": [
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef0100",
+      "version": "1777651501:0",
+      "label": "dhs-test-source-jxsv",
+      "description": "1080p50 video source feeding the JPEG XS flow",
+      "tags": {},
+      "caps": {},
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "parents": [],
+      "clock_name": "clk0",
+      "format": "urn:x-nmos:format:video",
+      "grain_rate": {
+        "numerator": 50,
+        "denominator": 1
+      }
+    }
+  ],
+  "flows": [
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef0101",
+      "version": "1777651501:0",
+      "label": "dhs-test-flow-jxsv",
+      "description": "JPEG XS 1080p50 coded video (BCP-006-01)",
+      "tags": {},
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "source_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0100",
+      "parents": [],
+      "format": "urn:x-nmos:format:video",
+      "media_type": "video/jxsv",
+      "grain_rate": {
+        "numerator": 50,
+        "denominator": 1
+      },
+      "frame_width": 1920,
+      "frame_height": 1080,
+      "interlace_mode": "progressive",
+      "colorspace": "BT709",
+      "transfer_characteristic": "SDR",
+      "profile": "High444.12",
+      "level": "2k-1",
+      "sublevel": "Sublev3bpp",
+      "bit_rate": 497664,
+      "components": [
+        {
+          "name": "Y",
+          "width": 1920,
+          "height": 1080,
+          "bit_depth": 10
+        },
+        {
+          "name": "Cb",
+          "width": 960,
+          "height": 1080,
+          "bit_depth": 10
+        },
+        {
+          "name": "Cr",
+          "width": 960,
+          "height": 1080,
+          "bit_depth": 10
+        }
+      ]
+    }
+  ],
+  "senders": [
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef0102",
+      "version": "1777651501:0",
+      "label": "dhs-test-sender-jxsv",
+      "description": "ST 2110-22 JPEG XS multicast sender (BCP-006-01)",
+      "tags": {},
+      "flow_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0101",
+      "transport": "urn:x-nmos:transport:rtp.mcast",
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "manifest_href": "http://dhs-node:18080/x-nmos/node/v1.3/senders/2c47bf5e-1b2c-4abc-9def-deadbeef0102/transportfile",
+      "interface_bindings": [
+        "eth0"
+      ],
+      "caps": {},
+      "bit_rate": 497664,
+      "packet_transmission_mode": "codestream",
+      "st2110_21_sender_type": "2110TPW",
+      "subscription": {
+        "receiver_id": null,
+        "active": false
+      }
+    }
+  ],
+  "receivers": [
+    {
+      "id": "2c47bf5e-1b2c-4abc-9def-deadbeef0103",
+      "version": "1777651501:0",
+      "label": "dhs-test-receiver-jxsv",
+      "description": "JPEG XS receiver (BCP-006-01)",
+      "tags": {},
+      "device_id": "2c47bf5e-1b2c-4abc-9def-deadbeef0002",
+      "transport": "urn:x-nmos:transport:rtp",
+      "interface_bindings": [
+        "eth0"
+      ],
+      "format": "urn:x-nmos:format:video",
+      "caps": {},
+      "subscription": {
+        "sender_id": null,
+        "active": false
+      }
+    }
+  ],
+  "connection": {
+    "senders": {},
+    "receivers": {}
+  }
+}


### PR DESCRIPTION
Addresses #849 (partial — the version-mismatch matrix + minimal node; see the honest note below on the clean-full-spec bundle).

## Version-mismatch matrix — the issue's intellectual core, deterministic

`internal/amwa/registry/version_matrix_test.go` asserts the registry's own decision (`versionAllowed`) across the whole matrix, both directions:
- node registered LOW, controller queries at/above → visible (with `query.downgrade` widening the window),
- node registered HIGH, controller queries LOW → the **one-way wall**: no `query.downgrade` value reaches above `urlVer`,
- `TestOldControllerBlindToNewNodes` pins the headline case — a v1.3 node is invisible at a v1.0 query for every downgrade value. The only lever is the minor the node registers at.

## Minimal reference node — committed + verified

`internal/amwa/testdata/reference-nodes/minimal-node.json`: one device, one RTP source/flow/sender/receiver, empty caps, no group hints, single leg — the least a conformant device can be. Derived from the valid full bundle so it loads; verified live (`producer nmos serve --config` answers `/self` = `dhs-test-node`, one sender). Documentation addressing only.

## Honest note on the full-spec node

The realistic full node (`ansible/roles/dhs_amwa_plant/files/amwa-test-node.json`) drives every AMWA **tool** suite green, but it is a *realistic* node, not a *clean* one: the offline audit correctly catches a genuine latent defect in it — an MQTT tally sender master-enabled with no destination (CRITICAL `NMOS-IS05-NO-DESTINATION`) plus websocket senders with no RTP transport file. That fixture bug is spun off separately (chip filed). A purpose-built **zero-finding** clean-full-spec bundle is therefore left as its own authoring task rather than claimed here — the realistic node stays the better exerciser for the tools themselves, and the profile of it is already FAIL 0.

`internal/amwa/registry` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
