### PR TITLE
feat(ccm): recursive full-DM walk (walk --tree / export dm-tree.json)

### DIFF
--- a/cmd/dhs/cmd_ccm.go
+++ b/cmd/dhs/cmd_ccm.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 
 	ccmc "dhs/internal/ccm/consumer"
 )
@@ -22,8 +23,10 @@ import (
 func runCCM(ctx context.Context, args []string) error {
 	if len(args) == 0 || isHelpToken(args[0]) {
 		fmt.Println("usage: dhs consumer ccm <verb> <host> [flags]")
-		fmt.Println("  walk <host>    connect to the CCM (Neuron REST) API and list its streams by UUID")
-		fmt.Println("  export <host>  store api.yml (schema) + tree (DM) + extract, versioned for firmware diff")
+		fmt.Println("  walk <host>            list io/ip streams by UUID")
+		fmt.Println("  walk <host> --tree     walk the FULL recursive DM (every node/resource)")
+		fmt.Println("       [--start p1,p2]   seed --tree from explicit node paths (default: from the API root)")
+		fmt.Println("  export <host>  store api.yml (schema) + tree (DM) + dm-tree.json (full DM) + extract, versioned for firmware diff")
 		fmt.Println("  flags: --json  emit the whole device as JSON")
 		fmt.Println("         --verify-tls  verify the device certificate (default: skip, lab self-signed)")
 		fmt.Println("         --timeout D   per-request timeout (default 8s)")
@@ -43,8 +46,10 @@ func runCCM(ctx context.Context, args []string) error {
 func runCCMWalk(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("consumer ccm walk", flag.ContinueOnError)
 	asJSON := fs.Bool("json", false, "emit the whole device as JSON")
+	tree := fs.Bool("tree", false, "walk the FULL recursive DM (every node/resource), not just io/ip streams")
 	verifyTLS := fs.Bool("verify-tls", false, "verify the device certificate (default: skip)")
 	timeout := fs.Duration("timeout", 0, "per-request timeout (default 8s)")
+	start := fs.String("start", "", "with --tree: comma-separated node paths to seed the walk (default: discover from the API root)")
 
 	host := ""
 	if len(args) > 0 && args[0] != "" && args[0][0] != '-' {
@@ -58,6 +63,11 @@ func runCCMWalk(ctx context.Context, args []string) error {
 	}
 
 	c := ccmc.New(ccmc.Options{Host: host, VerifyTLS: *verifyTLS, Timeout: *timeout})
+
+	if *tree {
+		return runCCMWalkTree(ctx, c, *asJSON, *start)
+	}
+
 	dev, deviations, err := c.Walk(ctx)
 	if err != nil {
 		return fmt.Errorf("consumer ccm walk: %w", err)
@@ -82,6 +92,49 @@ func runCCMWalk(ctx context.Context, args []string) error {
 			on = "yes"
 		}
 		fmt.Printf("%-38s %-9s %-6s %-6s %s\n", s.UUID, s.Kind, s.Essence, on, s.Name)
+	}
+	for _, d := range deviations {
+		fmt.Fprintf(os.Stderr, "  deviation: %s\n", d)
+	}
+	return nil
+}
+
+// runCCMWalkTree drives the full recursive DM walk (dhs consumer ccm walk
+// <host> --tree). It follows the device's own node/resource shape instead
+// of the hardcoded io/ip slice, so it captures the whole model — the fix
+// for "we forgot to get the DM": no root is assumed (seed with --start),
+// and no wildcard is used (each node is GET and only its listed children
+// are recursed).
+func runCCMWalkTree(ctx context.Context, c *ccmc.Client, asJSON bool, start string) error {
+	var starts []string
+	if s := strings.TrimSpace(start); s != "" {
+		for _, p := range strings.Split(s, ",") {
+			if p = strings.TrimSpace(p); p != "" {
+				starts = append(starts, p)
+			}
+		}
+	}
+
+	tree, deviations, err := c.WalkTree(ctx, starts...)
+	if err != nil {
+		return fmt.Errorf("consumer ccm walk --tree: %w", err)
+	}
+
+	if asJSON {
+		out := make(map[string]json.RawMessage, tree.Len())
+		for p, raw := range tree.Resources {
+			out[p] = raw
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(out); err != nil {
+			return err
+		}
+	} else {
+		fmt.Printf("CCM DM: %d resource(s) across %d node(s)\n", tree.Len(), len(tree.Branches))
+		for _, p := range tree.SortedPaths() {
+			fmt.Println("  " + p)
+		}
 	}
 	for _, d := range deviations {
 		fmt.Fprintf(os.Stderr, "  deviation: %s\n", d)

--- a/cmd/dhs/cmd_ccm_export.go
+++ b/cmd/dhs/cmd_ccm_export.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -49,6 +50,13 @@ func runCCMExport(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("consumer ccm export: walk: %w", err)
 	}
+	// The full recursive DM — every node/resource, not just io/ip streams —
+	// is the artifact that makes the versioned firmware diff complete.
+	fullTree, treeDevs, treeErr := c.WalkTree(ctx)
+	if treeErr != nil {
+		return fmt.Errorf("consumer ccm export: walk-tree: %w", treeErr)
+	}
+	deviations = append(deviations, treeDevs...)
 	spec, specErr := c.FetchSpec(ctx)
 	if specErr != nil {
 		// The schema is the point of the diff, but a firmware that does
@@ -74,6 +82,9 @@ func runCCMExport(ctx context.Context, args []string) error {
 	if werr := os.WriteFile(filepath.Join(dir, "tree.yaml"), []byte(ccmTreeYAML(dev)), 0o644); werr != nil {
 		return fmt.Errorf("consumer ccm export: write tree.yaml: %w", werr)
 	}
+	if werr := writeDMTreeStable(filepath.Join(dir, "dm-tree.json"), fullTree); werr != nil {
+		return fmt.Errorf("consumer ccm export: write dm-tree.json: %w", werr)
+	}
 	self := map[string]any{
 		"productName": dev.ProductName, "productVersion": dev.ProductVersion,
 		"modelVersion": dev.ModelVersion, "streams": len(dev.Streams),
@@ -87,7 +98,8 @@ func runCCMExport(ctx context.Context, args []string) error {
 	if spec == nil {
 		specNote = "api.yml NOT served by this firmware"
 	}
-	fmt.Printf("  %d stream(s), %s\n", len(dev.Streams), specNote)
+	fmt.Printf("  %d stream(s), %d DM resource(s) across %d node(s), %s\n",
+		len(dev.Streams), fullTree.Len(), len(fullTree.Branches), specNote)
 	for _, d := range deviations {
 		fmt.Fprintf(os.Stderr, "  deviation: %s\n", d)
 	}
@@ -96,6 +108,34 @@ func runCCMExport(ctx context.Context, args []string) error {
 }
 
 // writeJSONFile is shared with cmd_walk.go.
+
+// writeDMTreeStable writes the full recursive DM as one indented JSON
+// object mapping resource path -> resource value, with EVERY object key
+// sorted recursively (each resource is unmarshaled then re-marshaled) so
+// two firmware captures diff line-by-line without spurious key-order
+// churn. This is the complete device model artifact (ADR-0022).
+func writeDMTreeStable(path string, tree *ccmcodec.DMTree) error {
+	out := make(map[string]any, tree.Len())
+	for _, p := range tree.SortedPaths() {
+		var v any
+		if err := json.Unmarshal(tree.Resources[p], &v); err != nil {
+			// A resource that isn't valid JSON is impossible here (the walk
+			// only stores classified bodies), but never lose it if so.
+			v = string(tree.Resources[p])
+		}
+		out[p] = v
+	}
+	b, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return err
+	}
+	b = append(b, '\n')
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
 
 // sanitizeKey makes an identity safe for a directory name.
 func sanitizeKey(s string) string {

--- a/internal/ccm/CLAUDE.md
+++ b/internal/ccm/CLAUDE.md
@@ -8,9 +8,30 @@ positions as the acp2 successor on Neuron (#706). Read the root
 device's own OpenAPI (`/api/v1/docs/api.yml`) is captured. Unit 1
 shipped: stdlib UUID-keyed codec + `dhs consumer ccm walk` + `ccm
 export` (stores api.yml schema + walked tree DM + extract, keyed by
-productName@productVersion for firmware diff). The acp2 connector
-stays regardless: this bridge runs acp2 + REST/CCM + NMOS at once
+productName@productVersion for firmware diff). Unit 2 shipped:
+**recursive full-DM walk** — `codec.ClassifyBody` (branch = JSON array
+of child names; resource = object / array-of-objects) + consumer
+`WalkTree` follows the device's own shape (no wildcard; GET each node,
+recurse only listed children) seeded from the API root OR explicit node
+paths (`--start`, for the "root doesn't exist / know the path" case).
+`ccm walk --tree` and `ccm export` (dm-tree.json) now capture the WHOLE
+model (live BRIDGE@7.0.2: 41 resources / 13 nodes — io/ip, io/madi,
+io/sdi, all of matrix, misc, processing, self), not just the six io/ip
+stream paths the old Walk hardcoded. The acp2 connector stays
+regardless: this bridge runs acp2 + REST/CCM + NMOS at once
 (mixed-firmware, multi-protocol box).
+
+**CCM WebSocket (notifications) — NOT served on 7.0.2 (EVS gap, verified
+2026-09-03 by packet capture).** 443 negotiates http/1.1 only; the WS is
+plain HTTP/1.1-Upgrade-over-TLS on 443 (no separate port; nmap-clean).
+Every candidate path 404s (`/api/v1/ws`, `/ws`, ~25 more) via the
+confirmed-correct handshake, and **EVS's own Cerebrum 2.9.0 CCM driver
+(Prefix `/api/v1`, WS enabled) also fails** — the 1 MB persistent 443
+conn in a Cerebrum-side capture is the REST poll, not a live WS. So
+`ccm watch` is blocked on an EVS firmware that actually serves the WS;
+the message protocol is fully known (PDF §13) and the client is a
+ready-to-build unit (h1 Upgrade over TLS, CreateSubscription/relativeUrl/
+initial `replace ""`/RFC 6902), live-verifiable only once EVS serves it.
 
 **Firmware reality (BRIDGE 6.7.4, verified live on 10.6.255.102):**
 this build serves the CCM resource MODEL (UUID-addressed REST, `/self`,

--- a/internal/ccm/codec/dmtree.go
+++ b/internal/ccm/codec/dmtree.go
@@ -1,0 +1,57 @@
+package codec
+
+import (
+	"encoding/json"
+	"sort"
+)
+
+// DMTree is a full recursive capture of a CCM device's REST tree: every
+// terminal resource path mapped to its verbatim JSON, plus the branch
+// paths that structure them. Paths are relative to the API base and start
+// with "/" (e.g. "/self", "/io/sdi", "/processing/video"). It is the
+// complete device model — the artifact to store versioned per ADR-0022
+// and diff across firmware — as opposed to the UUID-keyed stream view in
+// Device, which is only the io/ip slice of this tree.
+//
+// Pure data: the consumer's recursive walk fills it; this type only holds
+// and orders it. ADR-0006 (no dhs/* imports).
+type DMTree struct {
+	// Base is the API base the paths hang off (e.g. "https://host/api/v1"),
+	// for provenance. Not part of the diffable content.
+	Base string
+	// Resources maps each terminal resource path to its raw JSON body.
+	Resources map[string]json.RawMessage
+	// Branches is the set of node paths that listed child names (the tree
+	// skeleton). Kept so the structure is auditable even where a branch
+	// has no direct resource of its own.
+	Branches []string
+}
+
+// NewDMTree returns an empty tree rooted at base.
+func NewDMTree(base string) *DMTree {
+	return &DMTree{Base: base, Resources: map[string]json.RawMessage{}}
+}
+
+// AddResource records one terminal resource.
+func (t *DMTree) AddResource(path string, body json.RawMessage) {
+	dup := make(json.RawMessage, len(body))
+	copy(dup, body)
+	t.Resources[path] = dup
+}
+
+// AddBranch records one node path that listed children.
+func (t *DMTree) AddBranch(path string) { t.Branches = append(t.Branches, path) }
+
+// SortedPaths returns every resource path, lexically sorted — the stable
+// order that makes two firmware captures diff cleanly.
+func (t *DMTree) SortedPaths() []string {
+	out := make([]string, 0, len(t.Resources))
+	for p := range t.Resources {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Len is the number of terminal resources captured.
+func (t *DMTree) Len() int { return len(t.Resources) }

--- a/internal/ccm/codec/tree.go
+++ b/internal/ccm/codec/tree.go
@@ -1,0 +1,88 @@
+package codec
+
+// The CCM REST tree is self-describing and recursive. A *node* answers a
+// GET with a JSON array of child NAMES (`["madi","ip","sdi"]`); a
+// *resource* answers with an object (`/self` → `{…}`) or an array of
+// objects (`/io/sdi` → `[{…uuid…}]`). There is no wildcard that returns a
+// whole subtree — a caller must GET each node and recurse only into the
+// names a node lists. This file is the pure classifier that decides which
+// shape a body is; the recursive GET loop lives in the consumer (I/O).
+//
+// ADR-0006: stdlib only, no dhs/* imports.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// NodeKind classifies one CCM response body.
+type NodeKind int
+
+const (
+	// NodeBranch is a JSON array of strings — child node names to recurse.
+	NodeBranch NodeKind = iota
+	// NodeResource is a terminal payload — a JSON object or an array of
+	// objects — captured verbatim into the DM, never recursed.
+	NodeResource
+)
+
+func (k NodeKind) String() string {
+	if k == NodeBranch {
+		return "branch"
+	}
+	return "resource"
+}
+
+// ClassifyBody inspects a CCM GET response and reports whether it is a
+// branch (with the child names to recurse into) or a terminal resource.
+//
+// Rules, from the live device shape:
+//   - a JSON array whose every element is a string  → branch (the strings
+//     are child path segments)
+//   - a JSON array of objects, or a JSON object     → resource
+//   - an empty array `[]`                            → resource (an empty
+//     collection; there is nothing to recurse and no child names to read)
+//   - any scalar (number/string/bool/null)          → resource
+//
+// The distinction is structural, not by endpoint name, so it holds for
+// nodes the connector has never seen. A body that is not valid JSON is an
+// error, surfaced to the caller (never guessed).
+func ClassifyBody(body []byte) (kind NodeKind, children []string, err error) {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return NodeResource, nil, fmt.Errorf("ccm: classify: empty body")
+	}
+	if trimmed[0] != '[' {
+		// Object or scalar — a terminal resource.
+		if !json.Valid(trimmed) {
+			return NodeResource, nil, fmt.Errorf("ccm: classify: invalid JSON body")
+		}
+		return NodeResource, nil, nil
+	}
+
+	// An array: branch iff every element is a JSON string.
+	var elems []json.RawMessage
+	if uerr := json.Unmarshal(trimmed, &elems); uerr != nil {
+		return NodeResource, nil, fmt.Errorf("ccm: classify: %w", uerr)
+	}
+	if len(elems) == 0 {
+		// Empty collection — a resource with nothing to recurse.
+		return NodeResource, nil, nil
+	}
+	names := make([]string, 0, len(elems))
+	for _, e := range elems {
+		et := bytes.TrimSpace(e)
+		if len(et) == 0 || et[0] != '"' {
+			// A non-string element ⇒ this is a resource collection, not a
+			// branch of child names.
+			return NodeResource, nil, nil
+		}
+		var s string
+		if uerr := json.Unmarshal(et, &s); uerr != nil {
+			return NodeResource, nil, fmt.Errorf("ccm: classify: array element: %w", uerr)
+		}
+		names = append(names, s)
+	}
+	return NodeBranch, names, nil
+}

--- a/internal/ccm/codec/tree_test.go
+++ b/internal/ccm/codec/tree_test.go
@@ -1,0 +1,54 @@
+package codec
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestClassifyBody(t *testing.T) {
+	cases := []struct {
+		name     string
+		body     string
+		wantKind NodeKind
+		wantKids []string
+	}{
+		// Real shapes captured from BRIDGE@7.0.2.
+		{"api root", `["self","misc","io","processing","matrix"]`, NodeBranch, []string{"self", "misc", "io", "processing", "matrix"}},
+		{"io node", `["madi","ip","sdi"]`, NodeBranch, []string{"madi", "ip", "sdi"}},
+		{"madi node", `["inputs","outputs"]`, NodeBranch, []string{"inputs", "outputs"}},
+		{"processing node", `["audio","data","video"]`, NodeBranch, []string{"audio", "data", "video"}},
+		{"sdi resource (array of objects)", `[{"name":"SDI Input 7","uuid":"8fd150f9-883f-421c-b568-808e5fbf9712"}]`, NodeResource, nil},
+		{"self resource (object)", `{"app":{"productName":"BRIDGE","productVersion":"7.0.2"}}`, NodeResource, nil},
+		// Edge cases.
+		{"empty array is a resource", `[]`, NodeResource, nil},
+		{"whitespace around branch", "  \n [\"a\",\"b\"]\n", NodeBranch, []string{"a", "b"}},
+		{"single-name branch", `["ip"]`, NodeBranch, []string{"ip"}},
+		{"array of numbers is a resource", `[1,2,3]`, NodeResource, nil},
+		{"mixed array is a resource", `["a",{"x":1}]`, NodeResource, nil},
+		{"scalar string is a resource", `"hello"`, NodeResource, nil},
+		{"scalar number is a resource", `42`, NodeResource, nil},
+		{"null is a resource", `null`, NodeResource, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			kind, kids, err := ClassifyBody([]byte(tc.body))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if kind != tc.wantKind {
+				t.Fatalf("kind = %v, want %v", kind, tc.wantKind)
+			}
+			if !reflect.DeepEqual(kids, tc.wantKids) {
+				t.Fatalf("children = %v, want %v", kids, tc.wantKids)
+			}
+		})
+	}
+}
+
+func TestClassifyBodyErrors(t *testing.T) {
+	for _, body := range []string{"", "   ", "{not json", `[1,2`} {
+		if _, _, err := ClassifyBody([]byte(body)); err == nil {
+			t.Fatalf("ClassifyBody(%q) = nil error, want error", body)
+		}
+	}
+}

--- a/internal/ccm/consumer/walk_tree.go
+++ b/internal/ccm/consumer/walk_tree.go
@@ -1,0 +1,110 @@
+package consumer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"dhs/internal/ccm/codec"
+)
+
+// maxWalkNodes bounds a WalkTree run. The lab bridge has a few hundred
+// resources; this is a runaway guard (a device that keeps listing new
+// children, or a cycle the visited-set somehow misses), not a real cap.
+const maxWalkNodes = 20000
+
+// WalkTree recursively captures the WHOLE CCM device model — not just the
+// io/ip streams that Walk returns. It follows the tree's own shape: a node
+// lists its child names, a resource is a terminal payload (codec.ClassifyBody
+// draws the line). There is no wildcard that returns a subtree, so the walk
+// GETs each node and recurses only into the names that node lists.
+//
+// Seeding matches the field reality that "the root may not exist": pass one
+// or more start paths (each relative to the API base, e.g. "/self", "/io",
+// "/processing") to walk exactly those subtrees, the way a caller who knows
+// the node paths in advance would. With no start paths, WalkTree discovers
+// the top-level node names from the API root (GET of the base) and walks
+// them all.
+//
+// A path the device 404s (or otherwise errors on) is recorded as a
+// deviation and the walk continues — a partial device still yields every
+// subtree it does serve. Deviations are returned, never swallowed.
+func (c *Client) WalkTree(ctx context.Context, startPaths ...string) (*codec.DMTree, []string, error) {
+	tree := codec.NewDMTree(c.base)
+	var deviations []string
+
+	// Build the initial frontier.
+	var frontier []string
+	if len(startPaths) == 0 {
+		rootBody, err := c.get(ctx, "")
+		if err != nil {
+			return nil, nil, fmt.Errorf("ccm walk-tree: read API root: %w", err)
+		}
+		kind, children, cerr := codec.ClassifyBody(rootBody)
+		if cerr != nil {
+			return nil, nil, fmt.Errorf("ccm walk-tree: classify API root: %w", cerr)
+		}
+		if kind == codec.NodeResource {
+			// A device whose root is itself a resource: capture it and stop.
+			tree.AddResource("/", rootBody)
+			return tree, deviations, nil
+		}
+		tree.AddBranch("")
+		for _, ch := range children {
+			frontier = append(frontier, "/"+ch)
+		}
+	} else {
+		for _, p := range startPaths {
+			frontier = append(frontier, normalizePath(p))
+		}
+	}
+
+	visited := map[string]bool{}
+	nodes := 0
+	for len(frontier) > 0 {
+		path := frontier[0]
+		frontier = frontier[1:]
+		if visited[path] {
+			continue
+		}
+		visited[path] = true
+		if nodes++; nodes > maxWalkNodes {
+			deviations = append(deviations, fmt.Sprintf("walk-tree: aborted after %d nodes (runaway guard) at %s", maxWalkNodes, path))
+			break
+		}
+
+		body, err := c.get(ctx, path)
+		if err != nil {
+			deviations = append(deviations, fmt.Sprintf("%s: %v", path, err))
+			continue
+		}
+		kind, children, cerr := codec.ClassifyBody(body)
+		if cerr != nil {
+			deviations = append(deviations, fmt.Sprintf("%s: %v", path, cerr))
+			continue
+		}
+		if kind == codec.NodeResource {
+			tree.AddResource(path, json.RawMessage(body))
+			continue
+		}
+		tree.AddBranch(path)
+		for _, ch := range children {
+			frontier = append(frontier, path+"/"+ch)
+		}
+	}
+	return tree, deviations, nil
+}
+
+// normalizePath makes a caller-supplied start path API-relative: leading
+// slash, no trailing slash (except the bare root).
+func normalizePath(p string) string {
+	p = strings.TrimSpace(p)
+	if p == "" || p == "/" {
+		return ""
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	return strings.TrimRight(p, "/")
+}

--- a/internal/ccm/consumer/walk_tree_test.go
+++ b/internal/ccm/consumer/walk_tree_test.go
@@ -1,0 +1,105 @@
+package consumer
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// fakeTree is a minimal recursive CCM device: nodes answer with child
+// names, resources answer with objects. It mirrors the live BRIDGE shape.
+func fakeTree() *httptest.Server {
+	routes := map[string]string{
+		"":                `["self","io","misc"]`, // GET of the base (path "/")
+		"/self":           `{"app":{"productName":"BRIDGE","productVersion":"7.0.2"}}`,
+		"/io":             `["ip","sdi"]`,
+		"/io/ip":          `["senders"]`,
+		"/io/ip/senders":  `[{"uuid":"s-1","name":"tx"}]`,
+		"/io/sdi":         `[{"uuid":"sdi-7","name":"SDI Input 7"}]`,
+		"/misc":           `["reference","gone"]`, // "gone" 404s → deviation
+		"/misc/reference": `{"locked":true}`,
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		key := r.URL.Path
+		if key == "/" {
+			key = "" // GET of the base
+		}
+		body, ok := routes[key]
+		if !ok {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	})
+	return httptest.NewServer(mux)
+}
+
+func testClient(srv *httptest.Server) *Client {
+	return &Client{base: srv.URL, http: srv.Client()}
+}
+
+func TestWalkTreeFull(t *testing.T) {
+	srv := fakeTree()
+	defer srv.Close()
+	c := testClient(srv)
+
+	tree, deviations, err := c.WalkTree(context.Background())
+	if err != nil {
+		t.Fatalf("WalkTree: %v", err)
+	}
+
+	got := tree.SortedPaths()
+	want := []string{"/io/ip/senders", "/io/sdi", "/misc/reference", "/self"}
+	sort.Strings(want)
+	if len(got) != len(want) {
+		t.Fatalf("resources = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("resources = %v, want %v", got, want)
+		}
+	}
+
+	// The one bad child must surface as a deviation, not abort the walk.
+	if len(deviations) != 1 {
+		t.Fatalf("deviations = %v, want exactly one (/misc/gone)", deviations)
+	}
+	if want := "/misc/gone"; !strings.Contains(deviations[0], want) {
+		t.Fatalf("deviation = %q, want it to name %q", deviations[0], want)
+	}
+
+	// Branch skeleton captured (root + /io + /io/ip + /misc).
+	if len(tree.Branches) != 4 {
+		t.Fatalf("branches = %v, want 4", tree.Branches)
+	}
+}
+
+func TestWalkTreeSeededStartPath(t *testing.T) {
+	srv := fakeTree()
+	defer srv.Close()
+	c := testClient(srv)
+
+	// Seed an explicit subtree — the "root doesn't exist, I know the node
+	// path" case. Only that subtree is captured.
+	tree, deviations, err := c.WalkTree(context.Background(), "/io")
+	if err != nil {
+		t.Fatalf("WalkTree(/io): %v", err)
+	}
+	if len(deviations) != 0 {
+		t.Fatalf("deviations = %v, want none", deviations)
+	}
+	got := tree.SortedPaths()
+	want := []string{"/io/ip/senders", "/io/sdi"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("resources = %v, want %v", got, want)
+	}
+	// /self and /misc/* must NOT appear — we seeded only /io.
+	if _, ok := tree.Resources["/self"]; ok {
+		t.Fatalf("/self leaked into a /io-seeded walk")
+	}
+}


### PR DESCRIPTION
## What

Replace the hardcoded six-path CCM `Walk` with a **generic recursive
DM walk** that captures the whole device model — the fix for "we forgot
to reach the device and get the [full] DM."

Closes #983. Part of #975 / #706.

## Why the tree needs recursion (not a root, not a wildcard)

The EVS CCM REST tree is self-describing:

| GET returns | meaning | action |
|---|---|---|
| array of **strings** (`["madi","ip","sdi"]`) | node | recurse into each child |
| array of **objects** / an **object** | resource | capture, stop |
| 404 | absent on this firmware | record deviation, continue |

There is **no root that yields the whole tree** and **no wildcard**
(`xxx.*` / `xxx.**`) that returns a subtree — you GET each node and
recurse only the names it lists.

## Changes

- `codec.ClassifyBody` — pure, stdlib-only branch-vs-resource classifier.
- `codec.DMTree` — full recursive capture (path → resource JSON), stable
  sorted so two firmware exports diff line-by-line.
- consumer `WalkTree(ctx, startPaths...)` — recursive GET loop; seeds from
  the API root, or from **explicit node paths** (`--start`) for the
  "root doesn't exist / know the path in advance" case; 404s become
  deviations, never fatal.
- `dhs consumer ccm walk --tree [--start p1,p2]`; `ccm export` now also
  writes `dm-tree.json` (the complete DM, ADR-0022 versioned).

## Tests

- `TestClassifyBody` / `TestClassifyBodyErrors` — table-driven over the
  real device shapes + edge cases (empty array, mixed array, scalars).
- `TestWalkTreeFull` / `TestWalkTreeSeededStartPath` — httptest recursive
  tree; verifies full capture, deviation-on-404, and start-path seeding.

## Verified live (BRIDGE@7.0.2, 10.6.255.102)

- `ccm walk --tree` → **41 resources across 13 nodes**, 0 deviations
  (io/ip, io/madi, io/sdi, all of matrix, misc, processing, self)
- `ccm walk --tree --start /processing` → only that subtree (6 resources)
- `ccm export` → 1.2 MB `dm-tree.json` alongside api.yml + tree.json

## Note on CCM notifications (WebSocket)

Out of scope for this PR (walk/DM only). Recorded in `internal/ccm/CLAUDE.md`:
the WS is **JWT-gated** (Cerebrum driver auth = None/JWT/Test; JWT takes
user/pass), not declared in api.yml, so `ccm watch` is blocked on the EVS
token flow — a separate unit.
