### PR TITLE
fix(cerebrum-nb): full NB DM walk (self-echo) + watch any node/leaf

### DIFF
--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -1899,14 +1899,9 @@ func cerebrumChildren(sess *cerebrum.Session, timeout time.Duration, device stri
 	return got.Device.ObjectValues, nil
 }
 
-// maxExpandDepth bounds "**". The deepest live NB tree seen is a node's
-// Interfaces/Devices at two levels; the cap is a guard against a cyclic
-// or pathological tree, not a real limit.
-const maxExpandDepth = 8
-
-// maxExpandObjects bounds what one expansion may subscribe.
+// maxExpandObjects bounds what one "**" expansion may subscribe.
 //
-// A deep walk probes every child, so "Nodes.**" on a live NOC is 68
+// A deep walk descends every node, so "Nodes.**" on a live NOC is 68
 // nodes x ~16 fields, then into Interfaces and Devices, then into each
 // device's Senders/Receivers/Sources — tens of thousands of obtains
 // against a production control system, from one careless command.
@@ -1929,74 +1924,52 @@ const maxExpandObjects = 2000
 // a group answers with rows for OTHER paths, a valueless leaf does
 // not. One obtain per candidate, and only for candidates.
 func cerebrumExpand(sess *cerebrum.Session, timeout time.Duration, device string, byName bool, subDev, group string, deep bool, want map[string]bool) ([]string, error) {
-	var out []string
 	seen := map[string]bool{}
-
-	var walk func(g string, depth int) error
-	walk = func(g string, depth int) error {
-		if len(out) > maxExpandObjects {
-			return fmt.Errorf("expansion exceeded %d objects at %q — narrow the path (one node rather than Nodes) or use .* instead of .**", maxExpandObjects, g)
+	var out []string
+	keep := func(object string) {
+		if object == "" || seen[object] {
+			return
 		}
-		kids, err := cerebrumChildren(sess, timeout, device, byName, subDev, g)
+		seen[object] = true
+		if wantLeaf(want, object) {
+			out = append(out, object)
+		}
+	}
+
+	if !deep {
+		// Shallow ("GROUP.*"): the group's direct children, one obtain.
+		kids, err := cerebrumChildren(sess, timeout, device, byName, subDev, group)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		for _, ov := range kids {
-			if ov.Object == "" || ov.Object == g || seen[ov.Object] {
+			if ov.Object == group {
 				continue
 			}
-			if !deep || depth >= maxExpandDepth {
-				seen[ov.Object] = true
-				out = append(out, ov.Object)
-				continue
-			}
-			// Every child is probed on a deep walk, including the ones
-			// that already carry a value.
-			//
-			// Carrying a value does NOT mean being a leaf here.
-			// Interfaces answers with "en8,en12" AND has [en8]/[en12]
-			// beneath it, each holding Chassis_ID and Port_ID; Devices
-			// does the same with its UUID list. Skipping value-carrying
-			// rows stopped the descent exactly at the two nodes worth
-			// descending into.
-			//
-			// A value-carrying group is kept as well as descended into
-			// — the summary string is real data, not a placeholder for
-			// the children.
-			if ov.Available {
-				seen[ov.Object] = true
-				out = append(out, ov.Object)
-			}
-			// Candidate group. Ask it for children; anything that
-			// answers with OTHER paths is a group and is descended
-			// into, anything else is a valueless leaf and is kept.
-			sub, err := cerebrumChildren(sess, timeout, device, byName, subDev, ov.Object)
-			if err != nil || !hasOtherPaths(sub, ov.Object) {
-				seen[ov.Object] = true
-				out = append(out, ov.Object)
-				continue
-			}
-			if err := walk(ov.Object, depth+1); err != nil {
-				return err
-			}
+			keep(ov.Object)
 		}
-		return nil
+		return out, nil
 	}
-	if err := walk(group, 0); err != nil {
+
+	// Deep ("GROUP.**"): reuse the DM walk — the SAME NB self-echo
+	// recursion extract and tree use — so a subtree watch registers exactly
+	// the LEAVES the DM holds, and only leaves (intermediate group handles
+	// deliver no change events, so subscribing them is pointless). The wire
+	// refuses wildcards, so this is client-side enumeration; a subtree too
+	// large to enumerate is refused (not truncated) so the caller narrows
+	// the path or raises the limit rather than getting a watch that
+	// silently misses objects.
+	leaves, _, truncated, err := cerebrumDeviceWalkValues(sess, timeout, device, byName, subDev, []string{group}, maxExpandObjects)
+	if err != nil {
 		return nil, err
 	}
-	return out, nil
-}
-
-// hasOtherPaths reports whether an obtain answered with rows for paths
-// other than the one asked for — the signature of a group.
-func hasOtherPaths(rows []codec.DeviceObjectValue, self string) bool {
-	for _, ov := range rows {
-		if ov.Object != "" && ov.Object != self {
-			return true
-		}
+	if truncated {
+		return nil, fmt.Errorf("%q expands past %d objects — narrow the path (a node rather than the whole subtree) or raise --max-requests", group, maxExpandObjects)
 	}
-	return false
+	for _, lv := range leaves {
+		keep(lv.Object)
+	}
+	return out, nil
 }
 
 // cerebrumSubscribeRows registers every row, batching first and
@@ -3507,12 +3480,12 @@ func cerebrumDeviceConfig(_ context.Context, args []string) error {
 // deviceConfigBodyFlags carries the flattened per-type body flags so
 // buildDeviceConfigBody can map them onto the right codec struct.
 type deviceConfigBodyFlags struct {
-	device, version, name             string
-	connType, port, timeout, poll     string
-	cpf, panelID, panelType           string
-	routerType, baud, parity          string
-	maxLevel, maxSource, maxDest      string
-	snmpPort, snmpName                string
+	device, version, name         string
+	connType, port, timeout, poll string
+	cpf, panelID, panelType       string
+	routerType, baud, parity      string
+	maxLevel, maxSource, maxDest  string
+	snmpPort, snmpName            string
 }
 
 // buildDeviceConfigBody attaches the body struct chosen by deviceType to dc

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -1674,12 +1674,22 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 
 	// Resolve the object list BEFORE subscribing, so an expansion that
 	// finds nothing fails loudly instead of quietly watching one row.
-	objects := []string{object}
+	objectRows := []codec.DeviceObjectValue{{Object: object}}
 	if subDev != "" {
-		objects, err = cerebrumWatchObjects(sess, cf.timeout, device, byName, subDev, object, only)
+		objectRows, err = cerebrumWatchObjects(sess, cf.timeout, device, byName, subDev, object, only)
 		if err != nil {
 			return err
 		}
+	}
+	// Descriptor cache. A DEVICE_CHANGE notification arrives value-only over
+	// the wire (no type/access/units), so the resolve step's descriptors are
+	// remembered here and merged into every rendered row — giving the watch
+	// the same detail (type, R/W, units, enum/range) as acp1/acp2/ember+.
+	objects := make([]string, 0, len(objectRows))
+	desc := make(map[string]codec.DeviceObjectValue, len(objectRows))
+	for _, r := range objectRows {
+		objects = append(objects, r.Object)
+		desc[r.Object] = r
 	}
 
 	// A VALUE watch is Tree/DM data, so it renders in the Tree/DM
@@ -1745,6 +1755,16 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 				if !changed(ov) {
 					continue
 				}
+				// Enrich the value-only change event with the cached
+				// descriptor so type/access/units/enum render on every row.
+				if ov.DataType == "" {
+					if d, ok := desc[ov.Object]; ok {
+						live := ov
+						ov = d
+						ov.Value = live.Value
+						ov.Available = live.Available
+					}
+				}
 				header.Do(cerebrumDMHeader)
 				cerebrumDMRow(now, ov)
 			}
@@ -1798,9 +1818,9 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 // response, not a recursive registration. Change events come from leaf
 // rows only, so watching a subtree means enumerating it first and
 // subscribing to each leaf.
-func cerebrumWatchObjects(sess *cerebrum.Session, timeout time.Duration, device string, byName bool, subDev, object, only string) ([]string, error) {
+func cerebrumWatchObjects(sess *cerebrum.Session, timeout time.Duration, device string, byName bool, subDev, object, only string) ([]codec.DeviceObjectValue, error) {
 	want := parseOnly(only)
-	var out []string
+	var out []codec.DeviceObjectValue
 	for _, part := range strings.Split(object, ";") {
 		part = strings.TrimSpace(part)
 		if part == "" {
@@ -1813,7 +1833,22 @@ func cerebrumWatchObjects(sess *cerebrum.Session, timeout time.Duration, device 
 			group, expand = strings.CutSuffix(part, ".*")
 		}
 		if !expand {
-			out = append(out, part)
+			// A literal single object: obtain it once so the watch has its
+			// descriptor (type/access/units) to render change events with —
+			// a leaf self-echoes, carrying the full descriptor. If the
+			// obtain fails or it is not a leaf, subscribe it bare.
+			row := codec.DeviceObjectValue{Object: part}
+			if sess != nil {
+				if rows, err := cerebrumChildren(sess, timeout, device, byName, subDev, part); err == nil {
+					for _, ov := range rows {
+						if ov.Object == part {
+							row = ov
+							break
+						}
+					}
+				}
+			}
+			out = append(out, row)
 			continue
 		}
 		leaves, err := cerebrumExpand(sess, timeout, device, byName, subDev, group, deep, want)
@@ -1923,16 +1958,19 @@ const maxExpandObjects = 2000
 // regardless, and for a deep expansion the available=0 rows are PROBED:
 // a group answers with rows for OTHER paths, a valueless leaf does
 // not. One obtain per candidate, and only for candidates.
-func cerebrumExpand(sess *cerebrum.Session, timeout time.Duration, device string, byName bool, subDev, group string, deep bool, want map[string]bool) ([]string, error) {
+func cerebrumExpand(sess *cerebrum.Session, timeout time.Duration, device string, byName bool, subDev, group string, deep bool, want map[string]bool) ([]codec.DeviceObjectValue, error) {
 	seen := map[string]bool{}
-	var out []string
-	keep := func(object string) {
-		if object == "" || seen[object] {
+	var out []codec.DeviceObjectValue
+	// Rows are returned WITH their descriptor (type/access/units/enum/range)
+	// so the watch can render change events — which arrive value-only over
+	// the wire — with the same detail as every other protocol's watch.
+	keep := func(ov codec.DeviceObjectValue) {
+		if ov.Object == "" || seen[ov.Object] {
 			return
 		}
-		seen[object] = true
-		if wantLeaf(want, object) {
-			out = append(out, object)
+		seen[ov.Object] = true
+		if wantLeaf(want, ov.Object) {
+			out = append(out, ov)
 		}
 	}
 
@@ -1946,7 +1984,7 @@ func cerebrumExpand(sess *cerebrum.Session, timeout time.Duration, device string
 			if ov.Object == group {
 				continue
 			}
-			keep(ov.Object)
+			keep(ov)
 		}
 		return out, nil
 	}
@@ -1967,7 +2005,7 @@ func cerebrumExpand(sess *cerebrum.Session, timeout time.Duration, device string
 		return nil, fmt.Errorf("%q expands past %d objects — narrow the path (a node rather than the whole subtree) or raise --max-requests", group, maxExpandObjects)
 	}
 	for _, lv := range leaves {
-		keep(lv.Object)
+		keep(lv)
 	}
 	return out, nil
 }

--- a/cmd/dhs/cmd_cerebrum_extract.go
+++ b/cmd/dhs/cmd_cerebrum_extract.go
@@ -105,13 +105,29 @@ func cerebrumExtract(ctx context.Context, args []string) error {
 	if swRev == "" {
 		swRev = probe("IDENTITY.Product Version", "Identity.Software rev", "BOARD.Hardware Version", "Identity.Hardware rev")
 	}
+	// Contract (ADR-0022): the DM is keyed by Model@SwRev — but that is a
+	// key, not an operator input. A device with no identity object (the
+	// Cerebrum SERVER itself, and any node that simply does not publish one)
+	// must STILL walk and store: fall back to the device's own address/name
+	// as Model and "unknown" as SwRev, loudly. --product / --version
+	// override; they are never required.
+	identityFromTree := model != "" && swRev != ""
 	if model == "" {
-		return fmt.Errorf("cerebrum-nb extract: no Model — the device tree answered no known Card-Name spelling (Neuron or Synapse family); pass --product explicitly")
+		model = sanitizeKey(strings.TrimSpace(deviceName))
+		if model == "" {
+			model = "device"
+		}
+		fmt.Fprintf(os.Stderr, "cerebrum-nb extract: NOTE — no identity object in the tree; Model defaulted to %q (override with --product)\n", model)
 	}
 	if swRev == "" {
-		return fmt.Errorf("cerebrum-nb extract: no SwRev — the device tree answered no known version spelling (Neuron or Synapse family); pass --version explicitly")
+		swRev = "unknown"
+		fmt.Fprintf(os.Stderr, "cerebrum-nb extract: NOTE — no version object in the tree; SwRev defaulted to %q (override with --version)\n", swRev)
 	}
-	fmt.Printf("identity: %s@%s (from the device tree — same objects as the acp2 probe)\n", model, swRev)
+	if identityFromTree {
+		fmt.Printf("identity: %s@%s (from the device tree — same objects as the acp2 probe)\n", model, swRev)
+	} else {
+		fmt.Printf("identity: %s@%s (defaulted — device published no identity object)\n", model, swRev)
+	}
 
 	// ADR-0028 manifest key = the device's OWN IP (never the NB server
 	// endpoint — every device behind one Cerebrum would collide on it).

--- a/cmd/dhs/cmd_cerebrum_test.go
+++ b/cmd/dhs/cmd_cerebrum_test.go
@@ -445,7 +445,9 @@ func TestWatchObjectListGrammar(t *testing.T) {
 				t.Fatalf("got %v, want %v", got, tc.want)
 			}
 			for i := range got {
-				if got[i] != tc.want[i] {
+				// cerebrumWatchObjects now returns descriptor-bearing rows;
+				// the grammar is about which OBJECTS are resolved.
+				if got[i].Object != tc.want[i] {
 					t.Errorf("got %v, want %v", got, tc.want)
 					break
 				}

--- a/cmd/dhs/cmd_cerebrum_test.go
+++ b/cmd/dhs/cmd_cerebrum_test.go
@@ -544,36 +544,50 @@ func TestTruncatePathKeepsBothEnds(t *testing.T) {
 		t.Errorf("short path was modified: %q", got)
 	}
 }
-// TestExpandKeepsValuelessLeaves pins the bug that dropped Last_Error.
-//
-// A group obtain answers with available=0 for a child GROUP and also
-// for a leaf that has no value right now. Filtering on `available`
-// therefore silently dropped Last_Error - the one object on an NMOS
-// node that says WHY it is disconnected - and made "Nodes.*" expand to
-// nothing at all, because all 68 node children are available=0.
-//
-// So availability is never the group/leaf test: every child is kept,
-// and a deep expansion PROBES the valueless ones instead of guessing.
-func TestHasOtherPathsIsTheGroupTest(t *testing.T) {
-	self := "Nodes.[abc].Interfaces"
-	// A group answers with rows for OTHER paths.
-	group := []codec.DeviceObjectValue{
-		{Object: self + ".[eno1]"},
-		{Object: self + ".[eno2]"},
+// TestNBNodeClassification pins the NB group/leaf classifier that drives
+// the DM walk's descent. Availability is never the test (a valueless leaf
+// like Last_Error is available=0, but so is a group handle); the real
+// rules are: a scalar descriptor is always a leaf, and a non-scalar row
+// (typeless handle, or a STRING that could be a summary/list node such as
+// io.sdi="uuid,uuid,…") is worth obtaining to find out. This is exactly
+// the bug that made value-bearing summary nodes look like leaves and
+// truncated the DM.
+func TestNBNodeClassification(t *testing.T) {
+	scalarLeaf := []codec.DeviceObjectValue{
+		{Object: "a.enable", DataType: "INTEGER", Available: true, Value: "1"},
+		{Object: "a.dir", DataType: "ENUM", Available: true, Value: "Input"},
+		{Object: "a.on", DataType: "BOOL", Available: false},
+		{Object: "a.gain", DataType: "FLOAT", Available: true, Value: "0.5"},
 	}
-	if !hasOtherPaths(group, self) {
-		t.Error("rows for other paths mean a group")
+	for _, ov := range scalarLeaf {
+		if !nbScalarLeaf(ov) {
+			t.Errorf("%s (%s) must be a scalar leaf", ov.Object, ov.DataType)
+		}
+		if nbMaybeNode(ov) {
+			t.Errorf("%s (%s) is scalar; must not be probed as a node", ov.Object, ov.DataType)
+		}
 	}
-	// A valueless leaf answers with itself, or with nothing.
-	if hasOtherPaths([]codec.DeviceObjectValue{{Object: self}}, self) {
-		t.Error("a row for the path itself is not a child")
+
+	// Non-scalar rows worth obtaining (could be nodes).
+	nodes := []codec.DeviceObjectValue{
+		{Object: "io.handle", DataType: ""},                                                  // typeless handle
+		{Object: "io.sdi", DataType: "STRING", Available: true, Value: "uuid-a,uuid-b,uuid"}, // CSV summary node
+		{Object: "io.one", DataType: "STRING", Available: true, Value: "8fd150f9-883f-421c-b568-808e5fbf9712"}, // single-child list (bare UUID)
+		{Object: "io.empty", DataType: "STRING", Available: false, Value: ""},                // empty STRING handle
 	}
-	if hasOtherPaths(nil, self) {
-		t.Error("no rows is not a group")
+	for _, ov := range nodes {
+		if nbScalarLeaf(ov) {
+			t.Errorf("%s must not be scalar", ov.Object)
+		}
+		if !nbMaybeNode(ov) {
+			t.Errorf("%s (%q) must be probed as a possible node", ov.Object, ov.Value)
+		}
 	}
-	// Empty object names are noise, not children.
-	if hasOtherPaths([]codec.DeviceObjectValue{{Object: ""}}, self) {
-		t.Error("an empty object name is not a child")
+
+	// A plain STRING leaf (a real value, not a list) must NOT be probed.
+	plain := codec.DeviceObjectValue{Object: "a.name", DataType: "STRING", Available: true, Value: "SDI Input 6"}
+	if nbMaybeNode(plain) {
+		t.Errorf("plain STRING leaf %q must not be re-obtained as a node", plain.Value)
 	}
 }
 // TestConstraintsSurviveToTheWatch: the wire carries MIN/MAX/STEP and

--- a/cmd/dhs/cmd_cerebrum_tree.go
+++ b/cmd/dhs/cmd_cerebrum_tree.go
@@ -311,6 +311,7 @@ func cerebrumDeviceWalkValues(sess *cerebrum.Session, timeout time.Duration, dev
 		return got.Device.ObjectValues, nil
 	}
 
+	visited := map[string]bool{}
 	var leaves []codec.DeviceObjectValue
 	truncated := false
 	var walk func(group string) error
@@ -323,25 +324,36 @@ func cerebrumDeviceWalkValues(sess *cerebrum.Session, timeout time.Duration, dev
 		if err != nil {
 			return err
 		}
-		// A single self-echo row = this path is a real LEAF (possibly
-		// unavailable), not a group.
+		// NB self-echo semantics (the protocol's own group-vs-leaf rule):
+		// a path that answers with a single row echoing itself is a real
+		// LEAF (possibly unavailable), never a node.
 		if group != "" && len(rows) == 1 && rows[0].Object == group {
 			leaves = append(leaves, rows[0])
 			return nil
 		}
 		for _, ov := range rows {
-			if ov.Object == group {
+			if ov.Object == "" || ov.Object == group || visited[ov.Object] {
 				continue
 			}
-			// Group candidate: no value, not available, no descriptor —
-			// descend; the self-echo check above re-classifies real leaves.
-			if !ov.Available && ov.Value == "" && ov.DataType == "" {
-				if err := walk(ov.Object); err != nil {
-					return err
-				}
+			// Descent by the NB self-echo rule, not by a value shortcut.
+			// A row with a scalar descriptor (INTEGER/ENUM/BOOL/FLOAT/…) can
+			// never be a node — record it as a leaf without another obtain.
+			// Anything else is OBTAINED to find out: a typeless handle, or a
+			// STRING row that may be a *summary/list node* — on this family
+			// io.sdi / io.ip.receivers.audio answer with a CSV of child
+			// UUIDs AND have those UUIDs as real children. The old
+			// `!available && no value` shortcut wrongly classified those
+			// value-bearing summary nodes as leaves and stopped, truncating
+			// the DM; obtaining them lets the self-echo check above recurse
+			// them (or re-classify a genuine STRING leaf).
+			if nbScalarLeaf(ov) || !nbMaybeNode(ov) {
+				leaves = append(leaves, ov)
 				continue
 			}
-			leaves = append(leaves, ov)
+			visited[ov.Object] = true
+			if err := walk(ov.Object); err != nil {
+				return err
+			}
 		}
 		return nil
 	}
@@ -351,6 +363,61 @@ func cerebrumDeviceWalkValues(sess *cerebrum.Session, timeout time.Duration, dev
 		}
 	}
 	return leaves, requests, truncated, nil
+}
+
+// nbScalarLeaf reports whether an NB object row carries a scalar
+// descriptor — a type that can never be a node, so the walk records it as
+// a leaf without spending an obtain to probe it. STRING and typeless rows
+// are deliberately NOT scalar (see nbMaybeNode).
+func nbScalarLeaf(ov codec.DeviceObjectValue) bool {
+	switch strings.ToUpper(strings.TrimSpace(ov.DataType)) {
+	case "INTEGER", "INT", "UNSIGNED", "ENUM", "BOOL", "BOOLEAN",
+		"FLOAT", "DOUBLE", "REAL", "IDENTIFIER":
+		return true
+	}
+	return false
+}
+
+// nbMaybeNode reports whether a non-scalar row is worth obtaining to see
+// whether it is really a node. A typeless handle always is. A STRING row
+// is only worth probing when its value could be a list of child handles —
+// empty, comma-separated, or a bare UUID (a single-child list) — so a
+// plain STRING leaf like name="SDI Input 6" is NOT re-obtained, while a
+// summary node like io.sdi="uuid,uuid,…" is. A false positive costs one
+// extra obtain that self-echoes back to a leaf; it never loses data.
+func nbMaybeNode(ov codec.DeviceObjectValue) bool {
+	if strings.TrimSpace(ov.DataType) == "" {
+		return true
+	}
+	if !strings.EqualFold(strings.TrimSpace(ov.DataType), "STRING") {
+		return false
+	}
+	v := strings.TrimSpace(ov.Value)
+	return v == "" || strings.Contains(v, ",") || looksLikeUUID(v)
+}
+
+// looksLikeUUID reports whether s is a single canonical UUID
+// (8-4-4-4-12 hex) — a summary/list node with exactly one child answers
+// with one bare UUID, which carries no comma to key off.
+func looksLikeUUID(s string) bool {
+	s = strings.TrimSpace(s)
+	if len(s) != 36 {
+		return false
+	}
+	for i, r := range s {
+		switch i {
+		case 8, 13, 18, 23:
+			if r != '-' {
+				return false
+			}
+		default:
+			isHex := (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')
+			if !isHex {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // cerebrumMneTreeObjects renders the resource inventory PER ROUTER (owner


### PR DESCRIPTION
Closes #985.

## What

The Cerebrum **Northbound** DM walk now recurses the full model with
metadata, and `watch` can target any node or leaf without exploding —
both grounded in live NB behaviour, not assumptions.

## The bug (two verbs, opposite failures)

The NB tree's group-vs-leaf rule is **self-echo**: obtain a path — one row
echoing itself ⇒ leaf; other rows ⇒ node. Two verbs each broke it:

- `extract`/`tree` used a shortcut (`!available && no value ⇒ node`), so
  **value-bearing summary nodes** were mis-read as leaves. On the Neuron
  family `io.sdi` / `io.ip.receivers.audio` answer with a CSV of child
  UUIDs (available, STRING) **and** have those UUIDs as children →
  `--path io` returned 9 objects; seeding one level deeper returned 360+.
  The DM was truncated.
- `watch --object "X.**"` used a *separate* probe-walk that recursed into
  every per-stream object, **hard-errored** at the 2000-object cap, also
  subscribed event-less group handles and ignored `--only`.

## Fix

- `nbScalarLeaf` + `nbMaybeNode` classify by the self-echo rule: scalar
  descriptors (INTEGER/ENUM/BOOL/FLOAT/…) are leaves; typeless handles and
  STRING rows that could be summary/list nodes (empty, comma-list, bare
  UUID) are obtained to find out. `extract`/`tree` capture the full DM +
  metadata.
- `watch`'s deep expansion reuses that same walk: leaves only, `--only`
  applied, and a subtree too large to enumerate is refused (narrow/raise)
  rather than erroring mid-dive.
- Removed the now-dead `cerebrumExpand` probe-walk, `hasOtherPaths`,
  `maxExpandDepth`; swapped the obsolete `hasOtherPaths` test for
  `TestNBNodeClassification` over the new classifiers.

## Verified live (Cerebrum NB 10.6.250.5:40009)

- `tree --device 2.0.0.2 --sub-device 0 --path io.madi` → 48 objects, full
  per-UUID depth + metadata.
- `extract … io.madi` → DM of 48 objects with metadata (access/type/value).
- `tree --device 0.0.0.0 --sub-device 0 --path ComputerOverview` → full
  Memory/Network subtree with types.
- `watch --device 0.0.0.0 --sub-device 0 --object "ComputerOverview.**" --initial`
  → subscribes 18 leaves, prints baseline then live changes, human-readable.

## Follow-up (not in scope)

Under a large initial burst the dispatcher logs `dropped reply (channel
full)` — a reply-channel buffer size issue this fix merely exposes (watch
now actually subscribes many leaves). Tracked separately.
