### PR TITLE
feat(logging): uniform syslog-by-default (cerebrum-nb consumer + producer) — #987 step 1–2

### DIFF
--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -90,7 +90,7 @@ func newCerebrumFlags(fs *flag.FlagSet) *cerebrumFlags {
 	fs.BoolVar(&c.tls, "tls", false, "use wss:// instead of ws://")
 	fs.BoolVar(&c.insecure, "insecure-skip-verify", false, "with --tls, skip TLS cert verification")
 	fs.BoolVar(&c.debug, "debug", false, "verbose RX/TX XML logging")
-	fs.StringVar(&c.logPath, "log", "", "write the diagnostic log (incl. RX/TX XML at full debug verbosity) to this file — clean UTF-8, no PowerShell 2> stderr wrapping; stderr stays silent. Literal \"auto\" = .cache/logs/cerebrum-nb/<host>/<verb>.log (ADR-0028)")
+	fs.StringVar(&c.logPath, "log", "auto", "local log FILE in --log-format (the terminal stays the human table). Default \"auto\" = .cache/logs/cerebrum-nb/<host>/<verb>.log (always logs locally, like the DM cache); a path overrides it; \"off\" disables the local file.")
 	fs.StringVar(&c.logFormat, "log-format", DefaultLogFormat, "log format: syslog (RFC 5424, default) | json (Loki/Promtail) | text (human) — the LOG stream only; the data tables stay human (epic #987)")
 	fs.StringVar(&c.logLevel, "log-level", "", "log level: debug | info | warn | error (default: warn, or debug with --log/--debug)")
 	fs.StringVar(&c.syslogAddr, "syslog-addr", "", "also forward logs as RFC 5424 UDP datagrams to host:port (non-blocking: a slow collector drops records; drops counted on stderr — #934)")
@@ -147,7 +147,13 @@ func (c *cerebrumFlags) newLogger() (*slog.Logger, func(), error) {
 		sinkLevel = parseLogLevel(c.logLevel)
 	}
 
-	// Local file sink (structured).
+	// Local file sink (structured). ON by default ("auto" is resolved to
+	// the ADR-0028 path by cerebrumExpandAutoPaths before this runs);
+	// "off"/"none"/"-" disable it.
+	switch c.logPath {
+	case "off", "none", "-":
+		c.logPath = ""
+	}
 	if c.logPath != "" {
 		if dir := filepath.Dir(c.logPath); dir != "." {
 			if err := os.MkdirAll(dir, 0o755); err != nil {

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -61,15 +61,25 @@ func printCerebrumJSON(v any) error {
 // cerebrumFlags is the common flag set for every dhs consumer cerebrum-nb
 // verb. host[:port] is positional; everything else is a flag.
 type cerebrumFlags struct {
-	port     int
-	user     string
-	pass     string
-	tls      bool
-	insecure bool
-	debug    bool
-	logPath  string
-	capture  string
-	timeout  time.Duration
+	port       int
+	user       string
+	pass       string
+	tls        bool
+	insecure   bool
+	debug      bool
+	logPath    string
+	logFormat  string
+	logLevel   string
+	syslogAddr string
+	capture    string
+	timeout    time.Duration
+
+	// logger + logCleanup are built once by newLogger and cached so a verb
+	// (e.g. watch) can route its own event stream through the SAME logger
+	// the plugin uses — one set of sinks (stderr/file/syslog-addr), one
+	// format. Do not set directly.
+	logger     *slog.Logger
+	logCleanup func()
 }
 
 func newCerebrumFlags(fs *flag.FlagSet) *cerebrumFlags {
@@ -81,6 +91,9 @@ func newCerebrumFlags(fs *flag.FlagSet) *cerebrumFlags {
 	fs.BoolVar(&c.insecure, "insecure-skip-verify", false, "with --tls, skip TLS cert verification")
 	fs.BoolVar(&c.debug, "debug", false, "verbose RX/TX XML logging")
 	fs.StringVar(&c.logPath, "log", "", "write the diagnostic log (incl. RX/TX XML at full debug verbosity) to this file — clean UTF-8, no PowerShell 2> stderr wrapping; stderr stays silent. Literal \"auto\" = .cache/logs/cerebrum-nb/<host>/<verb>.log (ADR-0028)")
+	fs.StringVar(&c.logFormat, "log-format", DefaultLogFormat, "log format: syslog (RFC 5424, default) | json (Loki/Promtail) | text (human) — the LOG stream only; the data tables stay human (epic #987)")
+	fs.StringVar(&c.logLevel, "log-level", "", "log level: debug | info | warn | error (default: warn, or debug with --log/--debug)")
+	fs.StringVar(&c.syslogAddr, "syslog-addr", "", "also forward logs as RFC 5424 UDP datagrams to host:port (non-blocking: a slow collector drops records; drops counted on stderr — #934)")
 	fs.StringVar(&c.capture, "capture", "", "record every TX/RX XML document (ws text payload) to this JSONL wire-trace — the same --capture contract as every other connector (WARNING: contains the LOGIN frame in cleartext, treat as secret). Literal \"auto\" = captures/cerebrum-nb/<host>/<verb>-<utcstamp>.jsonl (ADR-0028)")
 	fs.DurationVar(&c.timeout, "timeout", 5*time.Second, "per-request timeout")
 	return c
@@ -92,6 +105,34 @@ func newCerebrumFlags(fs *flag.FlagSet) *cerebrumFlags {
 // otherwise stderr at Warn (quiet success) or Debug with --debug. The
 // returned closer is a no-op for stderr.
 func (c *cerebrumFlags) newLogger() (*slog.Logger, func(), error) {
+	if c.logger != nil { // built once, shared by the plugin and the verb
+		return c.logger, c.logCleanup, nil
+	}
+	format := c.logFormat
+	if format == "" {
+		format = DefaultLogFormat
+	}
+	var closers []func()
+	cleanup := func() {
+		for i := len(closers) - 1; i >= 0; i-- {
+			closers[i]()
+		}
+	}
+
+	// Local sink + level. --log FILE writes clean UTF-8 at full debug
+	// verbosity (stderr untouched — avoids PowerShell 5.1 wrapping
+	// redirected native stderr into error records); otherwise stderr at
+	// Warn (quiet success) or Debug with --debug. A structured stream
+	// (syslog/json) carries the verb's EVENTS at Info, so it must not sit
+	// at Warn. --log-level overrides everything.
+	var w io.Writer = os.Stderr
+	level := slog.LevelWarn
+	if format != "text" {
+		level = slog.LevelInfo
+	}
+	if c.debug {
+		level = slog.LevelDebug
+	}
 	if c.logPath != "" {
 		if dir := filepath.Dir(c.logPath); dir != "." {
 			if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -102,13 +143,30 @@ func (c *cerebrumFlags) newLogger() (*slog.Logger, func(), error) {
 		if err != nil {
 			return nil, nil, fmt.Errorf("--log %s: %w", c.logPath, err)
 		}
-		return slog.New(slog.NewTextHandler(f, &slog.HandlerOptions{Level: slog.LevelDebug})), func() { _ = f.Close() }, nil
-	}
-	level := slog.LevelWarn // quiet stderr on success (PS 2> flags any stderr as error)
-	if c.debug {
+		w = f
 		level = slog.LevelDebug
+		closers = append(closers, func() { _ = f.Close() })
 	}
-	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})), func() {}, nil
+	if c.logLevel != "" {
+		level = parseLogLevel(c.logLevel)
+	}
+
+	logger := newLoggerTo(w, level, format)
+
+	// Remote server sink: forward RFC 5424 to --syslog-addr (non-blocking),
+	// teed alongside the local sink.
+	if c.syslogAddr != "" {
+		udp, err := dialSyslogUDP(c.syslogAddr)
+		if err != nil {
+			cleanup()
+			return nil, nil, fmt.Errorf("--syslog-addr %s: %w", c.syslogAddr, err)
+		}
+		closers = append(closers, func() { udp.Close() })
+		logger = slog.New(teeHandler{logger.Handler(), udp.Handler(level)})
+	}
+
+	c.logger, c.logCleanup = logger, cleanup
+	return logger, cleanup, nil
 }
 
 // cerebrumWriteFile writes an output file, creating missing parent
@@ -1646,6 +1704,15 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 		return err
 	}
 	defer func() { _ = p.Disconnect() }()
+	if cf.logCleanup != nil {
+		defer cf.logCleanup()
+	}
+	// structured = the events go to the LOG stream (syslog/json) — one
+	// record per change, to stderr/file/syslog-addr — rather than the human
+	// table. Default (syslog) is structured; --log-format text keeps the
+	// table (epic #987).
+	structured := cf.logFormat != "" && cf.logFormat != "text"
+	evLogger := cf.logger
 
 	newRow := func(obj string) *codec.DeviceChange {
 		dc := &codec.DeviceChange{}
@@ -1764,6 +1831,31 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 						ov.Value = live.Value
 						ov.Available = live.Available
 					}
+				}
+				if structured && evLogger != nil {
+					// The event IS the output — one structured record to the
+					// log stream (syslog/json → stderr/file/syslog-addr), the
+					// Loki/server path. Same fields the table shows.
+					label := ov.Label
+					if label == "" {
+						if i := strings.LastIndex(ov.Object, "."); i >= 0 {
+							label = ov.Object[i+1:]
+						} else {
+							label = ov.Object
+						}
+					}
+					evLogger.Info("cerebrum_value_change",
+						slog.String("device", device),
+						slog.String("sub_device", subDev),
+						slog.String("object", ov.Object),
+						slog.String("label", label),
+						slog.String("value", ov.Value),
+						slog.String("type", strings.ToLower(ov.DataType)),
+						slog.String("access", cerebrumAccess(ov)),
+						slog.String("units", ov.Units),
+						slog.Bool("available", ov.Available),
+					)
+					continue
 				}
 				header.Do(cerebrumDMHeader)
 				cerebrumDMRow(now, ov)

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -1899,14 +1899,9 @@ func cerebrumChildren(sess *cerebrum.Session, timeout time.Duration, device stri
 	return got.Device.ObjectValues, nil
 }
 
-// maxExpandDepth bounds "**". The deepest live NB tree seen is a node's
-// Interfaces/Devices at two levels; the cap is a guard against a cyclic
-// or pathological tree, not a real limit.
-const maxExpandDepth = 8
-
-// maxExpandObjects bounds what one expansion may subscribe.
+// maxExpandObjects bounds what one "**" expansion may subscribe.
 //
-// A deep walk probes every child, so "Nodes.**" on a live NOC is 68
+// A deep walk descends every node, so "Nodes.**" on a live NOC is 68
 // nodes x ~16 fields, then into Interfaces and Devices, then into each
 // device's Senders/Receivers/Sources — tens of thousands of obtains
 // against a production control system, from one careless command.
@@ -1929,74 +1924,52 @@ const maxExpandObjects = 2000
 // a group answers with rows for OTHER paths, a valueless leaf does
 // not. One obtain per candidate, and only for candidates.
 func cerebrumExpand(sess *cerebrum.Session, timeout time.Duration, device string, byName bool, subDev, group string, deep bool, want map[string]bool) ([]string, error) {
-	var out []string
 	seen := map[string]bool{}
-
-	var walk func(g string, depth int) error
-	walk = func(g string, depth int) error {
-		if len(out) > maxExpandObjects {
-			return fmt.Errorf("expansion exceeded %d objects at %q — narrow the path (one node rather than Nodes) or use .* instead of .**", maxExpandObjects, g)
+	var out []string
+	keep := func(object string) {
+		if object == "" || seen[object] {
+			return
 		}
-		kids, err := cerebrumChildren(sess, timeout, device, byName, subDev, g)
+		seen[object] = true
+		if wantLeaf(want, object) {
+			out = append(out, object)
+		}
+	}
+
+	if !deep {
+		// Shallow ("GROUP.*"): the group's direct children, one obtain.
+		kids, err := cerebrumChildren(sess, timeout, device, byName, subDev, group)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		for _, ov := range kids {
-			if ov.Object == "" || ov.Object == g || seen[ov.Object] {
+			if ov.Object == group {
 				continue
 			}
-			if !deep || depth >= maxExpandDepth {
-				seen[ov.Object] = true
-				out = append(out, ov.Object)
-				continue
-			}
-			// Every child is probed on a deep walk, including the ones
-			// that already carry a value.
-			//
-			// Carrying a value does NOT mean being a leaf here.
-			// Interfaces answers with "en8,en12" AND has [en8]/[en12]
-			// beneath it, each holding Chassis_ID and Port_ID; Devices
-			// does the same with its UUID list. Skipping value-carrying
-			// rows stopped the descent exactly at the two nodes worth
-			// descending into.
-			//
-			// A value-carrying group is kept as well as descended into
-			// — the summary string is real data, not a placeholder for
-			// the children.
-			if ov.Available {
-				seen[ov.Object] = true
-				out = append(out, ov.Object)
-			}
-			// Candidate group. Ask it for children; anything that
-			// answers with OTHER paths is a group and is descended
-			// into, anything else is a valueless leaf and is kept.
-			sub, err := cerebrumChildren(sess, timeout, device, byName, subDev, ov.Object)
-			if err != nil || !hasOtherPaths(sub, ov.Object) {
-				seen[ov.Object] = true
-				out = append(out, ov.Object)
-				continue
-			}
-			if err := walk(ov.Object, depth+1); err != nil {
-				return err
-			}
+			keep(ov.Object)
 		}
-		return nil
+		return out, nil
 	}
-	if err := walk(group, 0); err != nil {
+
+	// Deep ("GROUP.**"): reuse the DM walk — the SAME NB self-echo
+	// recursion extract and tree use — so a subtree watch registers exactly
+	// the LEAVES the DM holds, and only leaves (intermediate group handles
+	// deliver no change events, so subscribing them is pointless). The wire
+	// refuses wildcards, so this is client-side enumeration; a subtree too
+	// large to enumerate is refused (not truncated) so the caller narrows
+	// the path or raises the limit rather than getting a watch that
+	// silently misses objects.
+	leaves, _, truncated, err := cerebrumDeviceWalkValues(sess, timeout, device, byName, subDev, []string{group}, maxExpandObjects)
+	if err != nil {
 		return nil, err
 	}
-	return out, nil
-}
-
-// hasOtherPaths reports whether an obtain answered with rows for paths
-// other than the one asked for — the signature of a group.
-func hasOtherPaths(rows []codec.DeviceObjectValue, self string) bool {
-	for _, ov := range rows {
-		if ov.Object != "" && ov.Object != self {
-			return true
-		}
+	if truncated {
+		return nil, fmt.Errorf("%q expands past %d objects — narrow the path (a node rather than the whole subtree) or raise --max-requests", group, maxExpandObjects)
 	}
-	return false
+	for _, lv := range leaves {
+		keep(lv.Object)
+	}
+	return out, nil
 }
 
 // cerebrumSubscribeRows registers every row, batching first and
@@ -3507,12 +3480,12 @@ func cerebrumDeviceConfig(_ context.Context, args []string) error {
 // deviceConfigBodyFlags carries the flattened per-type body flags so
 // buildDeviceConfigBody can map them onto the right codec struct.
 type deviceConfigBodyFlags struct {
-	device, version, name             string
-	connType, port, timeout, poll     string
-	cpf, panelID, panelType           string
-	routerType, baud, parity          string
-	maxLevel, maxSource, maxDest      string
-	snmpPort, snmpName                string
+	device, version, name         string
+	connType, port, timeout, poll string
+	cpf, panelID, panelType       string
+	routerType, baud, parity      string
+	maxLevel, maxSource, maxDest  string
+	snmpPort, snmpName            string
 }
 
 // buildDeviceConfigBody attaches the body struct chosen by deviceType to dc

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -1674,12 +1674,22 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 
 	// Resolve the object list BEFORE subscribing, so an expansion that
 	// finds nothing fails loudly instead of quietly watching one row.
-	objects := []string{object}
+	objectRows := []codec.DeviceObjectValue{{Object: object}}
 	if subDev != "" {
-		objects, err = cerebrumWatchObjects(sess, cf.timeout, device, byName, subDev, object, only)
+		objectRows, err = cerebrumWatchObjects(sess, cf.timeout, device, byName, subDev, object, only)
 		if err != nil {
 			return err
 		}
+	}
+	// Descriptor cache. A DEVICE_CHANGE notification arrives value-only over
+	// the wire (no type/access/units), so the resolve step's descriptors are
+	// remembered here and merged into every rendered row — giving the watch
+	// the same detail (type, R/W, units, enum/range) as acp1/acp2/ember+.
+	objects := make([]string, 0, len(objectRows))
+	desc := make(map[string]codec.DeviceObjectValue, len(objectRows))
+	for _, r := range objectRows {
+		objects = append(objects, r.Object)
+		desc[r.Object] = r
 	}
 
 	// A VALUE watch is Tree/DM data, so it renders in the Tree/DM
@@ -1745,6 +1755,16 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 				if !changed(ov) {
 					continue
 				}
+				// Enrich the value-only change event with the cached
+				// descriptor so type/access/units/enum render on every row.
+				if ov.DataType == "" {
+					if d, ok := desc[ov.Object]; ok {
+						live := ov
+						ov = d
+						ov.Value = live.Value
+						ov.Available = live.Available
+					}
+				}
 				header.Do(cerebrumDMHeader)
 				cerebrumDMRow(now, ov)
 			}
@@ -1798,9 +1818,9 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 // response, not a recursive registration. Change events come from leaf
 // rows only, so watching a subtree means enumerating it first and
 // subscribing to each leaf.
-func cerebrumWatchObjects(sess *cerebrum.Session, timeout time.Duration, device string, byName bool, subDev, object, only string) ([]string, error) {
+func cerebrumWatchObjects(sess *cerebrum.Session, timeout time.Duration, device string, byName bool, subDev, object, only string) ([]codec.DeviceObjectValue, error) {
 	want := parseOnly(only)
-	var out []string
+	var out []codec.DeviceObjectValue
 	for _, part := range strings.Split(object, ";") {
 		part = strings.TrimSpace(part)
 		if part == "" {
@@ -1813,7 +1833,22 @@ func cerebrumWatchObjects(sess *cerebrum.Session, timeout time.Duration, device 
 			group, expand = strings.CutSuffix(part, ".*")
 		}
 		if !expand {
-			out = append(out, part)
+			// A literal single object: obtain it once so the watch has its
+			// descriptor (type/access/units) to render change events with —
+			// a leaf self-echoes, carrying the full descriptor. If the
+			// obtain fails or it is not a leaf, subscribe it bare.
+			row := codec.DeviceObjectValue{Object: part}
+			if sess != nil {
+				if rows, err := cerebrumChildren(sess, timeout, device, byName, subDev, part); err == nil {
+					for _, ov := range rows {
+						if ov.Object == part {
+							row = ov
+							break
+						}
+					}
+				}
+			}
+			out = append(out, row)
 			continue
 		}
 		leaves, err := cerebrumExpand(sess, timeout, device, byName, subDev, group, deep, want)
@@ -1923,16 +1958,19 @@ const maxExpandObjects = 2000
 // regardless, and for a deep expansion the available=0 rows are PROBED:
 // a group answers with rows for OTHER paths, a valueless leaf does
 // not. One obtain per candidate, and only for candidates.
-func cerebrumExpand(sess *cerebrum.Session, timeout time.Duration, device string, byName bool, subDev, group string, deep bool, want map[string]bool) ([]string, error) {
+func cerebrumExpand(sess *cerebrum.Session, timeout time.Duration, device string, byName bool, subDev, group string, deep bool, want map[string]bool) ([]codec.DeviceObjectValue, error) {
 	seen := map[string]bool{}
-	var out []string
-	keep := func(object string) {
-		if object == "" || seen[object] {
+	var out []codec.DeviceObjectValue
+	// Rows are returned WITH their descriptor (type/access/units/enum/range)
+	// so the watch can render change events — which arrive value-only over
+	// the wire — with the same detail as every other protocol's watch.
+	keep := func(ov codec.DeviceObjectValue) {
+		if ov.Object == "" || seen[ov.Object] {
 			return
 		}
-		seen[object] = true
-		if wantLeaf(want, object) {
-			out = append(out, object)
+		seen[ov.Object] = true
+		if wantLeaf(want, ov.Object) {
+			out = append(out, ov)
 		}
 	}
 
@@ -1946,7 +1984,7 @@ func cerebrumExpand(sess *cerebrum.Session, timeout time.Duration, device string
 			if ov.Object == group {
 				continue
 			}
-			keep(ov.Object)
+			keep(ov)
 		}
 		return out, nil
 	}
@@ -1967,7 +2005,7 @@ func cerebrumExpand(sess *cerebrum.Session, timeout time.Duration, device string
 		return nil, fmt.Errorf("%q expands past %d objects — narrow the path (a node rather than the whole subtree) or raise --max-requests", group, maxExpandObjects)
 	}
 	for _, lv := range leaves {
-		keep(lv.Object)
+		keep(lv)
 	}
 	return out, nil
 }

--- a/cmd/dhs/cmd_cerebrum.go
+++ b/cmd/dhs/cmd_cerebrum.go
@@ -99,11 +99,19 @@ func newCerebrumFlags(fs *flag.FlagSet) *cerebrumFlags {
 	return c
 }
 
-// newLogger builds the verb logger per flags: --log FILE writes a clean
-// debug-verbosity log to the file (stderr untouched — avoids PowerShell 5.1
-// wrapping redirected native stderr into error records, the "red flag");
-// otherwise stderr at Warn (quiet success) or Debug with --debug. The
-// returned closer is a no-op for stderr.
+// newLogger builds the verb logger under the uniform contract (epic #987,
+// Model B): the TERMINAL is always human, the SINKS are structured.
+//
+//   - stderr: human TEXT at Warn (quiet success) / Debug with --debug — the
+//     operator's operational log. Data tables print to STDOUT separately;
+//     Info-level EVENTS sit below Warn so they never clutter the terminal.
+//   - --log FILE: structured (--log-format, default syslog) at Info (or
+//     Debug with --debug) — local machine sink.
+//   - --syslog-addr host:port: structured RFC 5424 at Info — remote server.
+//
+// So `--log-format` chooses the SINK format only; the terminal stays
+// readable. Events reach file/server (Info) but not stderr (Warn). A tee
+// with per-handler levels does the routing.
 func (c *cerebrumFlags) newLogger() (*slog.Logger, func(), error) {
 	if c.logger != nil { // built once, shared by the plugin and the verb
 		return c.logger, c.logCleanup, nil
@@ -119,20 +127,27 @@ func (c *cerebrumFlags) newLogger() (*slog.Logger, func(), error) {
 		}
 	}
 
-	// Local sink + level. --log FILE writes clean UTF-8 at full debug
-	// verbosity (stderr untouched — avoids PowerShell 5.1 wrapping
-	// redirected native stderr into error records); otherwise stderr at
-	// Warn (quiet success) or Debug with --debug. A structured stream
-	// (syslog/json) carries the verb's EVENTS at Info, so it must not sit
-	// at Warn. --log-level overrides everything.
-	var w io.Writer = os.Stderr
-	level := slog.LevelWarn
-	if format != "text" {
-		level = slog.LevelInfo
-	}
+	// Terminal (human, operational). Never the structured format.
+	termLevel := slog.LevelWarn
 	if c.debug {
-		level = slog.LevelDebug
+		termLevel = slog.LevelDebug
 	}
+	if c.logLevel != "" {
+		termLevel = parseLogLevel(c.logLevel)
+	}
+	handlers := []slog.Handler{slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: termLevel})}
+
+	// Sink level: Info carries the verb's events; Debug with --debug adds
+	// the RX/TX wire detail; --log-level overrides.
+	sinkLevel := slog.LevelInfo
+	if c.debug {
+		sinkLevel = slog.LevelDebug
+	}
+	if c.logLevel != "" {
+		sinkLevel = parseLogLevel(c.logLevel)
+	}
+
+	// Local file sink (structured).
 	if c.logPath != "" {
 		if dir := filepath.Dir(c.logPath); dir != "." {
 			if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -143,30 +158,32 @@ func (c *cerebrumFlags) newLogger() (*slog.Logger, func(), error) {
 		if err != nil {
 			return nil, nil, fmt.Errorf("--log %s: %w", c.logPath, err)
 		}
-		w = f
-		level = slog.LevelDebug
+		handlers = append(handlers, newLoggerTo(f, sinkLevel, format).Handler())
 		closers = append(closers, func() { _ = f.Close() })
 	}
-	if c.logLevel != "" {
-		level = parseLogLevel(c.logLevel)
-	}
 
-	logger := newLoggerTo(w, level, format)
-
-	// Remote server sink: forward RFC 5424 to --syslog-addr (non-blocking),
-	// teed alongside the local sink.
+	// Remote server sink (structured RFC 5424, non-blocking).
 	if c.syslogAddr != "" {
 		udp, err := dialSyslogUDP(c.syslogAddr)
 		if err != nil {
 			cleanup()
 			return nil, nil, fmt.Errorf("--syslog-addr %s: %w", c.syslogAddr, err)
 		}
+		handlers = append(handlers, udp.Handler(sinkLevel))
 		closers = append(closers, func() { udp.Close() })
-		logger = slog.New(teeHandler{logger.Handler(), udp.Handler(level)})
 	}
 
+	logger := slog.New(teeHandler(handlers))
 	c.logger, c.logCleanup = logger, cleanup
 	return logger, cleanup, nil
+}
+
+// hasLogSink reports whether a structured sink (local file or remote
+// server) is configured — the terminal (stderr) is human and never carries
+// the Info-level event stream, so the verb only emits structured events
+// when there is somewhere for them to go.
+func (c *cerebrumFlags) hasLogSink() bool {
+	return c.logPath != "" || c.syslogAddr != ""
 }
 
 // cerebrumWriteFile writes an output file, creating missing parent
@@ -1707,11 +1724,11 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 	if cf.logCleanup != nil {
 		defer cf.logCleanup()
 	}
-	// structured = the events go to the LOG stream (syslog/json) — one
-	// record per change, to stderr/file/syslog-addr — rather than the human
-	// table. Default (syslog) is structured; --log-format text keeps the
-	// table (epic #987).
-	structured := cf.logFormat != "" && cf.logFormat != "text"
+	// Model B (epic #987): the terminal ALWAYS gets the human table; when a
+	// structured sink (--log file / --syslog-addr server) is configured, each
+	// change is ALSO emitted as a structured record to that sink — so you
+	// read the table live AND ship syslog/json to file/Loki at the same time.
+	logToSink := cf.hasLogSink()
 	evLogger := cf.logger
 
 	newRow := func(obj string) *codec.DeviceChange {
@@ -1832,10 +1849,12 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 						ov.Available = live.Available
 					}
 				}
-				if structured && evLogger != nil {
-					// The event IS the output — one structured record to the
-					// log stream (syslog/json → stderr/file/syslog-addr), the
-					// Loki/server path. Same fields the table shows.
+				// Terminal: the human table, always.
+				header.Do(cerebrumDMHeader)
+				cerebrumDMRow(now, ov)
+				// Sinks: the same change as a structured record (file/server),
+				// only when a sink exists (stderr is human, never the events).
+				if logToSink && evLogger != nil {
 					label := ov.Label
 					if label == "" {
 						if i := strings.LastIndex(ov.Object, "."); i >= 0 {
@@ -1855,10 +1874,7 @@ func cerebrumWatch(ctx context.Context, args []string) error {
 						slog.String("units", ov.Units),
 						slog.Bool("available", ov.Available),
 					)
-					continue
 				}
-				header.Do(cerebrumDMHeader)
-				cerebrumDMRow(now, ov)
 			}
 			return
 		}

--- a/cmd/dhs/cmd_cerebrum_extract.go
+++ b/cmd/dhs/cmd_cerebrum_extract.go
@@ -105,13 +105,29 @@ func cerebrumExtract(ctx context.Context, args []string) error {
 	if swRev == "" {
 		swRev = probe("IDENTITY.Product Version", "Identity.Software rev", "BOARD.Hardware Version", "Identity.Hardware rev")
 	}
+	// Contract (ADR-0022): the DM is keyed by Model@SwRev — but that is a
+	// key, not an operator input. A device with no identity object (the
+	// Cerebrum SERVER itself, and any node that simply does not publish one)
+	// must STILL walk and store: fall back to the device's own address/name
+	// as Model and "unknown" as SwRev, loudly. --product / --version
+	// override; they are never required.
+	identityFromTree := model != "" && swRev != ""
 	if model == "" {
-		return fmt.Errorf("cerebrum-nb extract: no Model — the device tree answered no known Card-Name spelling (Neuron or Synapse family); pass --product explicitly")
+		model = sanitizeKey(strings.TrimSpace(deviceName))
+		if model == "" {
+			model = "device"
+		}
+		fmt.Fprintf(os.Stderr, "cerebrum-nb extract: NOTE — no identity object in the tree; Model defaulted to %q (override with --product)\n", model)
 	}
 	if swRev == "" {
-		return fmt.Errorf("cerebrum-nb extract: no SwRev — the device tree answered no known version spelling (Neuron or Synapse family); pass --version explicitly")
+		swRev = "unknown"
+		fmt.Fprintf(os.Stderr, "cerebrum-nb extract: NOTE — no version object in the tree; SwRev defaulted to %q (override with --version)\n", swRev)
 	}
-	fmt.Printf("identity: %s@%s (from the device tree — same objects as the acp2 probe)\n", model, swRev)
+	if identityFromTree {
+		fmt.Printf("identity: %s@%s (from the device tree — same objects as the acp2 probe)\n", model, swRev)
+	} else {
+		fmt.Printf("identity: %s@%s (defaulted — device published no identity object)\n", model, swRev)
+	}
 
 	// ADR-0028 manifest key = the device's OWN IP (never the NB server
 	// endpoint — every device behind one Cerebrum would collide on it).

--- a/cmd/dhs/cmd_cerebrum_test.go
+++ b/cmd/dhs/cmd_cerebrum_test.go
@@ -445,7 +445,9 @@ func TestWatchObjectListGrammar(t *testing.T) {
 				t.Fatalf("got %v, want %v", got, tc.want)
 			}
 			for i := range got {
-				if got[i] != tc.want[i] {
+				// cerebrumWatchObjects now returns descriptor-bearing rows;
+				// the grammar is about which OBJECTS are resolved.
+				if got[i].Object != tc.want[i] {
 					t.Errorf("got %v, want %v", got, tc.want)
 					break
 				}

--- a/cmd/dhs/cmd_cerebrum_test.go
+++ b/cmd/dhs/cmd_cerebrum_test.go
@@ -544,36 +544,50 @@ func TestTruncatePathKeepsBothEnds(t *testing.T) {
 		t.Errorf("short path was modified: %q", got)
 	}
 }
-// TestExpandKeepsValuelessLeaves pins the bug that dropped Last_Error.
-//
-// A group obtain answers with available=0 for a child GROUP and also
-// for a leaf that has no value right now. Filtering on `available`
-// therefore silently dropped Last_Error - the one object on an NMOS
-// node that says WHY it is disconnected - and made "Nodes.*" expand to
-// nothing at all, because all 68 node children are available=0.
-//
-// So availability is never the group/leaf test: every child is kept,
-// and a deep expansion PROBES the valueless ones instead of guessing.
-func TestHasOtherPathsIsTheGroupTest(t *testing.T) {
-	self := "Nodes.[abc].Interfaces"
-	// A group answers with rows for OTHER paths.
-	group := []codec.DeviceObjectValue{
-		{Object: self + ".[eno1]"},
-		{Object: self + ".[eno2]"},
+// TestNBNodeClassification pins the NB group/leaf classifier that drives
+// the DM walk's descent. Availability is never the test (a valueless leaf
+// like Last_Error is available=0, but so is a group handle); the real
+// rules are: a scalar descriptor is always a leaf, and a non-scalar row
+// (typeless handle, or a STRING that could be a summary/list node such as
+// io.sdi="uuid,uuid,…") is worth obtaining to find out. This is exactly
+// the bug that made value-bearing summary nodes look like leaves and
+// truncated the DM.
+func TestNBNodeClassification(t *testing.T) {
+	scalarLeaf := []codec.DeviceObjectValue{
+		{Object: "a.enable", DataType: "INTEGER", Available: true, Value: "1"},
+		{Object: "a.dir", DataType: "ENUM", Available: true, Value: "Input"},
+		{Object: "a.on", DataType: "BOOL", Available: false},
+		{Object: "a.gain", DataType: "FLOAT", Available: true, Value: "0.5"},
 	}
-	if !hasOtherPaths(group, self) {
-		t.Error("rows for other paths mean a group")
+	for _, ov := range scalarLeaf {
+		if !nbScalarLeaf(ov) {
+			t.Errorf("%s (%s) must be a scalar leaf", ov.Object, ov.DataType)
+		}
+		if nbMaybeNode(ov) {
+			t.Errorf("%s (%s) is scalar; must not be probed as a node", ov.Object, ov.DataType)
+		}
 	}
-	// A valueless leaf answers with itself, or with nothing.
-	if hasOtherPaths([]codec.DeviceObjectValue{{Object: self}}, self) {
-		t.Error("a row for the path itself is not a child")
+
+	// Non-scalar rows worth obtaining (could be nodes).
+	nodes := []codec.DeviceObjectValue{
+		{Object: "io.handle", DataType: ""},                                                  // typeless handle
+		{Object: "io.sdi", DataType: "STRING", Available: true, Value: "uuid-a,uuid-b,uuid"}, // CSV summary node
+		{Object: "io.one", DataType: "STRING", Available: true, Value: "8fd150f9-883f-421c-b568-808e5fbf9712"}, // single-child list (bare UUID)
+		{Object: "io.empty", DataType: "STRING", Available: false, Value: ""},                // empty STRING handle
 	}
-	if hasOtherPaths(nil, self) {
-		t.Error("no rows is not a group")
+	for _, ov := range nodes {
+		if nbScalarLeaf(ov) {
+			t.Errorf("%s must not be scalar", ov.Object)
+		}
+		if !nbMaybeNode(ov) {
+			t.Errorf("%s (%q) must be probed as a possible node", ov.Object, ov.Value)
+		}
 	}
-	// Empty object names are noise, not children.
-	if hasOtherPaths([]codec.DeviceObjectValue{{Object: ""}}, self) {
-		t.Error("an empty object name is not a child")
+
+	// A plain STRING leaf (a real value, not a list) must NOT be probed.
+	plain := codec.DeviceObjectValue{Object: "a.name", DataType: "STRING", Available: true, Value: "SDI Input 6"}
+	if nbMaybeNode(plain) {
+		t.Errorf("plain STRING leaf %q must not be re-obtained as a node", plain.Value)
 	}
 }
 // TestConstraintsSurviveToTheWatch: the wire carries MIN/MAX/STEP and

--- a/cmd/dhs/cmd_cerebrum_tree.go
+++ b/cmd/dhs/cmd_cerebrum_tree.go
@@ -311,6 +311,7 @@ func cerebrumDeviceWalkValues(sess *cerebrum.Session, timeout time.Duration, dev
 		return got.Device.ObjectValues, nil
 	}
 
+	visited := map[string]bool{}
 	var leaves []codec.DeviceObjectValue
 	truncated := false
 	var walk func(group string) error
@@ -323,25 +324,36 @@ func cerebrumDeviceWalkValues(sess *cerebrum.Session, timeout time.Duration, dev
 		if err != nil {
 			return err
 		}
-		// A single self-echo row = this path is a real LEAF (possibly
-		// unavailable), not a group.
+		// NB self-echo semantics (the protocol's own group-vs-leaf rule):
+		// a path that answers with a single row echoing itself is a real
+		// LEAF (possibly unavailable), never a node.
 		if group != "" && len(rows) == 1 && rows[0].Object == group {
 			leaves = append(leaves, rows[0])
 			return nil
 		}
 		for _, ov := range rows {
-			if ov.Object == group {
+			if ov.Object == "" || ov.Object == group || visited[ov.Object] {
 				continue
 			}
-			// Group candidate: no value, not available, no descriptor —
-			// descend; the self-echo check above re-classifies real leaves.
-			if !ov.Available && ov.Value == "" && ov.DataType == "" {
-				if err := walk(ov.Object); err != nil {
-					return err
-				}
+			// Descent by the NB self-echo rule, not by a value shortcut.
+			// A row with a scalar descriptor (INTEGER/ENUM/BOOL/FLOAT/…) can
+			// never be a node — record it as a leaf without another obtain.
+			// Anything else is OBTAINED to find out: a typeless handle, or a
+			// STRING row that may be a *summary/list node* — on this family
+			// io.sdi / io.ip.receivers.audio answer with a CSV of child
+			// UUIDs AND have those UUIDs as real children. The old
+			// `!available && no value` shortcut wrongly classified those
+			// value-bearing summary nodes as leaves and stopped, truncating
+			// the DM; obtaining them lets the self-echo check above recurse
+			// them (or re-classify a genuine STRING leaf).
+			if nbScalarLeaf(ov) || !nbMaybeNode(ov) {
+				leaves = append(leaves, ov)
 				continue
 			}
-			leaves = append(leaves, ov)
+			visited[ov.Object] = true
+			if err := walk(ov.Object); err != nil {
+				return err
+			}
 		}
 		return nil
 	}
@@ -351,6 +363,61 @@ func cerebrumDeviceWalkValues(sess *cerebrum.Session, timeout time.Duration, dev
 		}
 	}
 	return leaves, requests, truncated, nil
+}
+
+// nbScalarLeaf reports whether an NB object row carries a scalar
+// descriptor — a type that can never be a node, so the walk records it as
+// a leaf without spending an obtain to probe it. STRING and typeless rows
+// are deliberately NOT scalar (see nbMaybeNode).
+func nbScalarLeaf(ov codec.DeviceObjectValue) bool {
+	switch strings.ToUpper(strings.TrimSpace(ov.DataType)) {
+	case "INTEGER", "INT", "UNSIGNED", "ENUM", "BOOL", "BOOLEAN",
+		"FLOAT", "DOUBLE", "REAL", "IDENTIFIER":
+		return true
+	}
+	return false
+}
+
+// nbMaybeNode reports whether a non-scalar row is worth obtaining to see
+// whether it is really a node. A typeless handle always is. A STRING row
+// is only worth probing when its value could be a list of child handles —
+// empty, comma-separated, or a bare UUID (a single-child list) — so a
+// plain STRING leaf like name="SDI Input 6" is NOT re-obtained, while a
+// summary node like io.sdi="uuid,uuid,…" is. A false positive costs one
+// extra obtain that self-echoes back to a leaf; it never loses data.
+func nbMaybeNode(ov codec.DeviceObjectValue) bool {
+	if strings.TrimSpace(ov.DataType) == "" {
+		return true
+	}
+	if !strings.EqualFold(strings.TrimSpace(ov.DataType), "STRING") {
+		return false
+	}
+	v := strings.TrimSpace(ov.Value)
+	return v == "" || strings.Contains(v, ",") || looksLikeUUID(v)
+}
+
+// looksLikeUUID reports whether s is a single canonical UUID
+// (8-4-4-4-12 hex) — a summary/list node with exactly one child answers
+// with one bare UUID, which carries no comma to key off.
+func looksLikeUUID(s string) bool {
+	s = strings.TrimSpace(s)
+	if len(s) != 36 {
+		return false
+	}
+	for i, r := range s {
+		switch i {
+		case 8, 13, 18, 23:
+			if r != '-' {
+				return false
+			}
+		default:
+			isHex := (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')
+			if !isHex {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // cerebrumMneTreeObjects renders the resource inventory PER ROUTER (owner

--- a/cmd/dhs/cmd_nmos.go
+++ b/cmd/dhs/cmd_nmos.go
@@ -39,6 +39,9 @@ import (
 
 // runNMOSConsumer dispatches `dhs consumer nmos <verb> [args]`.
 func runNMOSConsumer(ctx context.Context, args []string) error {
+	var lf *logFlags // uniform logging flags (epic #987), stripped before dispatch
+	lf, args = stripLogFlags(args)
+	ctx = withLogFlags(ctx, lf)
 	// Help IN PLACE of a verb = catalogue; after the verb it belongs to
 	// the verb's own FlagSet (#462).
 	if len(args) == 0 || isHelpToken(args[0]) {
@@ -179,7 +182,7 @@ func runNMOSDiscoverUnicast(ctx context.Context, resolver, service string, timeo
 
 func runNMOSDiscoverMDNS(ctx context.Context, service string, timeout time.Duration) error {
 	// Uniform logging (epic #987): human stderr + default local syslog file.
-	logger, logClean := consumerModelBLogger("nmos", "session", "run")
+	logger, _, logClean, _ := consumerLogger(ctx, "nmos", "session", "run")
 	defer logClean()
 	br, err := session.NewBrowser(logger)
 	if err != nil {
@@ -341,7 +344,7 @@ func runNMOSNodeServeLegacy(ctx context.Context, args []string) error {
 	}
 
 	// Uniform logging (epic #987): human stderr + default local syslog file.
-	logger, logClean := consumerModelBLogger("nmos", "session", "run")
+	logger, _, logClean, _ := consumerLogger(ctx, "nmos", "session", "run")
 	defer logClean()
 
 	bundle, err := provider.LoadNodeConfigFromFile(*configPath)
@@ -425,7 +428,7 @@ func runNMOSSystem(ctx context.Context, args []string) error {
 	}
 
 	// Uniform logging (epic #987): human stderr + default local syslog file.
-	logger, logClean := consumerModelBLogger("nmos", "session", "run")
+	logger, _, logClean, _ := consumerLogger(ctx, "nmos", "session", "run")
 	defer logClean()
 
 	// Direct override — skip discovery entirely.
@@ -561,7 +564,7 @@ func runNMOSSystemServe(ctx context.Context, args []string) error {
 	}
 
 	// Uniform logging (epic #987): human stderr + default local syslog file.
-	logger, logClean := consumerModelBLogger("nmos", "session", "run")
+	logger, _, logClean, _ := consumerLogger(ctx, "nmos", "session", "run")
 	defer logClean()
 
 	g, err := provider.LoadIS09GlobalFromFile(*configPath)
@@ -630,7 +633,7 @@ func runNMOSRegistryServe(ctx context.Context, args []string) error {
 	}
 
 	// Uniform logging (epic #987): human stderr + default local syslog file.
-	logger, logClean := consumerModelBLogger("nmos", "session", "run")
+	logger, _, logClean, _ := consumerLogger(ctx, "nmos", "session", "run")
 	defer logClean()
 
 	f, ok := registryslot.Lookup("nmos")

--- a/cmd/dhs/cmd_nmos.go
+++ b/cmd/dhs/cmd_nmos.go
@@ -178,7 +178,9 @@ func runNMOSDiscoverUnicast(ctx context.Context, resolver, service string, timeo
 }
 
 func runNMOSDiscoverMDNS(ctx context.Context, service string, timeout time.Duration) error {
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	// Uniform logging (epic #987): human stderr + default local syslog file.
+	logger, logClean := consumerModelBLogger("nmos", "session", "run")
+	defer logClean()
 	br, err := session.NewBrowser(logger)
 	if err != nil {
 		return err
@@ -338,7 +340,9 @@ func runNMOSNodeServeLegacy(ctx context.Context, args []string) error {
 		return fmt.Errorf("producer nmos serve --role node: --config FILE required (use Phase 0 #1 mDNS-only placeholder via --discover-only flag if you really mean to)")
 	}
 
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	// Uniform logging (epic #987): human stderr + default local syslog file.
+	logger, logClean := consumerModelBLogger("nmos", "session", "run")
+	defer logClean()
 
 	bundle, err := provider.LoadNodeConfigFromFile(*configPath)
 	if err != nil {
@@ -420,7 +424,9 @@ func runNMOSSystem(ctx context.Context, args []string) error {
 		return err
 	}
 
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	// Uniform logging (epic #987): human stderr + default local syslog file.
+	logger, logClean := consumerModelBLogger("nmos", "session", "run")
+	defer logClean()
 
 	// Direct override — skip discovery entirely.
 	if *direct != "" {
@@ -554,7 +560,9 @@ func runNMOSSystemServe(ctx context.Context, args []string) error {
 		return fmt.Errorf("producer nmos serve --role system: --config FILE required")
 	}
 
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	// Uniform logging (epic #987): human stderr + default local syslog file.
+	logger, logClean := consumerModelBLogger("nmos", "session", "run")
+	defer logClean()
 
 	g, err := provider.LoadIS09GlobalFromFile(*configPath)
 	if err != nil {
@@ -621,7 +629,9 @@ func runNMOSRegistryServe(ctx context.Context, args []string) error {
 		mode = "static"
 	}
 
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	// Uniform logging (epic #987): human stderr + default local syslog file.
+	logger, logClean := consumerModelBLogger("nmos", "session", "run")
+	defer logClean()
 
 	f, ok := registryslot.Lookup("nmos")
 	if !ok {

--- a/cmd/dhs/cmd_osc.go
+++ b/cmd/dhs/cmd_osc.go
@@ -37,6 +37,9 @@ import (
 
 // runOSCConsumer dispatches `dhs consumer osc-vXX <verb> [args]`.
 func runOSCConsumer(ctx context.Context, proto string, args []string) error {
+	var lf *logFlags // uniform logging flags (epic #987), stripped before dispatch
+	lf, args = stripLogFlags(args)
+	ctx = withLogFlags(ctx, lf)
 	// Help IN PLACE of a verb = catalogue; after the verb it belongs to
 	// the verb's own FlagSet (#462).
 	if len(args) == 0 || isHelpToken(args[0]) {
@@ -61,6 +64,9 @@ func runOSCConsumer(ctx context.Context, proto string, args []string) error {
 
 // runOSCProducer dispatches `dhs producer osc-vXX <verb> [args]`.
 func runOSCProducer(ctx context.Context, proto string, args []string) error {
+	var lf *logFlags // uniform logging flags (epic #987), stripped before dispatch
+	lf, args = stripLogFlags(args)
+	ctx = withLogFlags(ctx, lf)
 	if len(args) == 0 || isHelpToken(args[0]) {
 		printOSCProducerHelp(proto)
 		return nil
@@ -92,7 +98,7 @@ func runOSCWatch(ctx context.Context, proto string, args []string) error {
 		return err
 	}
 	// Uniform logging (epic #987): human stderr + default local syslog file.
-	logger, logClean := consumerModelBLogger(proto, fmt.Sprintf("%s.%d", transport, port), "watch")
+	logger, _, logClean, _ := consumerLogger(ctx, proto, fmt.Sprintf("%s.%d", transport, port), "watch")
 	defer logClean()
 	plugin := newOSCConsumer(proto, logger)
 
@@ -313,7 +319,7 @@ func runOSCServe(ctx context.Context, proto string, args []string) error {
 		return err
 	}
 	// Uniform logging (epic #987): human stderr + default local syslog file.
-	logger, logClean := consumerModelBLogger(proto, fmt.Sprintf("%s.%d", transport, port), "serve")
+	logger, _, logClean, _ := consumerLogger(ctx, proto, fmt.Sprintf("%s.%d", transport, port), "serve")
 	defer logClean()
 	plugin := newOSCConsumer(proto, logger)
 

--- a/cmd/dhs/cmd_osc.go
+++ b/cmd/dhs/cmd_osc.go
@@ -91,7 +91,9 @@ func runOSCWatch(ctx context.Context, proto string, args []string) error {
 	if err != nil {
 		return err
 	}
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	// Uniform logging (epic #987): human stderr + default local syslog file.
+	logger, logClean := consumerModelBLogger(proto, fmt.Sprintf("%s.%d", transport, port), "watch")
+	defer logClean()
 	plugin := newOSCConsumer(proto, logger)
 
 	switch transport {
@@ -310,7 +312,9 @@ func runOSCServe(ctx context.Context, proto string, args []string) error {
 	if err := requireVersion(proto, transport); err != nil {
 		return err
 	}
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	// Uniform logging (epic #987): human stderr + default local syslog file.
+	logger, logClean := consumerModelBLogger(proto, fmt.Sprintf("%s.%d", transport, port), "serve")
+	defer logClean()
 	plugin := newOSCConsumer(proto, logger)
 
 	switch transport {

--- a/cmd/dhs/cmd_probel.go
+++ b/cmd/dhs/cmd_probel.go
@@ -23,6 +23,11 @@ import (
 // shape as acp1/acp2/emberplus capture — one {ts, proto, dir, hex, len}
 // object per frame (including DLE ACK / DLE NAK control sequences).
 func runProbelsw08p(ctx context.Context, args []string) error {
+	// Uniform logging flags (epic #987): strip them here so every verb's own
+	// FlagSet is unaffected; consumerLogger reads them back from ctx.
+	var lf *logFlags
+	lf, args = stripLogFlags(args)
+	ctx = withLogFlags(ctx, lf)
 	args, rec, err := extractCaptureFlag(args)
 	if err != nil {
 		return err
@@ -188,7 +193,7 @@ func dialProbel(ctx context.Context, addr string) (*probelproto.Plugin, func(), 
 		return nil, func() {}, err
 	}
 	// Uniform logging (epic #987): human stderr + default local syslog file.
-	logger, logClean := consumerModelBLogger("probel-sw08p", host, "session")
+	logger, _, logClean, _ := consumerLogger(ctx, "probel-sw08p", host, "session")
 	f := &probelproto.Factory{}
 	p := f.New(logger).(*probelproto.Plugin)
 	if rec, ok := ctx.Value(probelRecorderKey{}).(*transport.Recorder); ok && rec != nil {

--- a/cmd/dhs/cmd_probel.go
+++ b/cmd/dhs/cmd_probel.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"log/slog"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -185,7 +183,12 @@ space-separated lowercase-hex line for debugging:
 // the probel root dispatcher) it is attached before Connect so the
 // JSONL file captures the full TX/RX stream.
 func dialProbel(ctx context.Context, addr string) (*probelproto.Plugin, func(), error) {
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	host, port, err := splitHostPort(addr, probelproto.DefaultPort)
+	if err != nil {
+		return nil, func() {}, err
+	}
+	// Uniform logging (epic #987): human stderr + default local syslog file.
+	logger, logClean := consumerModelBLogger("probel-sw08p", host, "session")
 	f := &probelproto.Factory{}
 	p := f.New(logger).(*probelproto.Plugin)
 	if rec, ok := ctx.Value(probelRecorderKey{}).(*transport.Recorder); ok && rec != nil {
@@ -194,14 +197,11 @@ func dialProbel(ctx context.Context, addr string) (*probelproto.Plugin, func(), 
 	if mc, ok := ctx.Value(probelMatrixConfigKey{}).(probelproto.MatrixConfig); ok {
 		p.SetMatrixConfig(mc)
 	}
-	host, port, err := splitHostPort(addr, probelproto.DefaultPort)
-	if err != nil {
-		return nil, func() {}, err
-	}
 	if err := p.Connect(ctx, host, port); err != nil {
+		logClean()
 		return nil, func() {}, err
 	}
-	return p, func() { _ = p.Disconnect() }, nil
+	return p, func() { _ = p.Disconnect(); logClean() }, nil
 }
 
 // probelTarget resolves the wire (matrix, level) a read verb should query.

--- a/cmd/dhs/cmd_probel02p.go
+++ b/cmd/dhs/cmd_probel02p.go
@@ -20,6 +20,10 @@ import (
 // connect, protect-*, dual-status, router-config) follow the
 // per-command file pattern from SW-P-08.
 func runProbelsw02p(ctx context.Context, args []string) error {
+	// Uniform logging flags (epic #987): strip + stash before verb dispatch.
+	var lf *logFlags
+	lf, args = stripLogFlags(args)
+	ctx = withLogFlags(ctx, lf)
 	args, rec, err := extractCaptureFlag(args)
 	if err != nil {
 		return err
@@ -355,7 +359,7 @@ func dialProbelSW02(ctx context.Context, addr string) (*probelsw02proto.Plugin, 
 		return nil, func() {}, err
 	}
 	// Uniform logging (epic #987): human stderr + default local syslog file.
-	logger, logClean := consumerModelBLogger("probel-sw02p", host, "session")
+	logger, _, logClean, _ := consumerLogger(ctx, "probel-sw02p", host, "session")
 	f := &probelsw02proto.Factory{}
 	p := f.New(logger).(*probelsw02proto.Plugin)
 	if rec, ok := ctx.Value(probelSW02RecorderKey{}).(*transport.Recorder); ok && rec != nil {

--- a/cmd/dhs/cmd_probel02p.go
+++ b/cmd/dhs/cmd_probel02p.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"log/slog"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -352,7 +350,12 @@ func probelSW02Subcommand(args []string) string {
 // dialProbelSW02 mirrors dialProbel for sw08p — connect-or-die helper
 // returning a connected plugin + a deferred-close callback.
 func dialProbelSW02(ctx context.Context, addr string) (*probelsw02proto.Plugin, func(), error) {
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	host, port, err := splitHostPort(addr, probelsw02proto.DefaultPort)
+	if err != nil {
+		return nil, func() {}, err
+	}
+	// Uniform logging (epic #987): human stderr + default local syslog file.
+	logger, logClean := consumerModelBLogger("probel-sw02p", host, "session")
 	f := &probelsw02proto.Factory{}
 	p := f.New(logger).(*probelsw02proto.Plugin)
 	if rec, ok := ctx.Value(probelSW02RecorderKey{}).(*transport.Recorder); ok && rec != nil {
@@ -361,14 +364,11 @@ func dialProbelSW02(ctx context.Context, addr string) (*probelsw02proto.Plugin, 
 	if mc, ok := ctx.Value(probelSW02MatrixConfigKey{}).(probelsw02proto.MatrixConfig); ok {
 		p.SetMatrixConfig(mc)
 	}
-	host, port, err := splitHostPort(addr, probelsw02proto.DefaultPort)
-	if err != nil {
-		return nil, func() {}, err
-	}
 	if err := p.Connect(ctx, host, port); err != nil {
+		logClean()
 		return nil, func() {}, err
 	}
-	return p, func() { _ = p.Disconnect() }, nil
+	return p, func() { _ = p.Disconnect(); logClean() }, nil
 }
 
 // runProbelsw02pWatch keeps the session open and prints every async

--- a/cmd/dhs/cmd_producer.go
+++ b/cmd/dhs/cmd_producer.go
@@ -42,33 +42,33 @@ type metricsExposer interface {
 func runProducer(ctx context.Context, protoName string, args []string) error {
 	fs := flag.NewFlagSet("producer "+protoName+" serve", flag.ContinueOnError)
 	var (
-		treePath      = fs.String("tree", "", "path to canonical tree.json (one of --tree | --manifest required)")
-		manifestPath  = fs.String("manifest", "", "path to manifest JSON (.cache/manifest/<device>.json) — assembles the tree from referenced DMs under .cache/dm/<proto>/ per ADR-0022. Mutually exclusive with --tree.")
-		cacheDir      = fs.String("cache-dir", ".cache", "root of the cache tree (`.cache/dm/<proto>/<Model@SwRev>.json` lookup base; only used with --manifest)")
-		port          = fs.Int("port", 0, "TCP listen port (0 = plugin default)")
-		host          = fs.String("host", "0.0.0.0", "TCP/UDP listen host (alias: --bind)")
-		bind          = fs.String("bind", "", "alternate spelling of --host. e.g. --bind 10.6.239.200 binds the listener AND pins the broadcast source IP to the VIP, so multi-instance emulators on the same machine appear as distinct From: addresses to consumers (#263).")
-		logLevel      = fs.String("log-level", "info", "log level: debug, info, warn, error")
-		logFormat     = fs.String("log-format", "text", "log format: text | json (Loki/Promtail) | syslog (RFC 5424 lines, severity mapped incl. critical — #751 G6)")
-		syslogAddr    = fs.String("syslog-addr", "", "also forward logs as RFC 5424 UDP datagrams to host:port (non-blocking: a slow collector drops records; drops are counted and reported on stderr — #934)")
-		announceDemo  = fs.Bool("announce-demo", false, "oscillate a target value every --announce-demo-interval and broadcast announces (acp1/acp2 only)")
-		announceSlot  = fs.Int("announce-demo-slot", 1, "slot for --announce-demo target")
-		announceGroup = fs.Int("announce-demo-group", 2, "acp1: object group for --announce-demo target (2=Control)")
-		announceID    = fs.Int("announce-demo-id", 0, "acp1: object id for --announce-demo target (must be Integer type)")
-		announceObj   = fs.Int("announce-demo-obj", 18, "acp2: obj-id for --announce-demo target (must be Number+Float)")
-		announceEvery = fs.Duration("announce-demo-interval", 2*time.Second, "--announce-demo tick interval")
-		metricsAddr   = fs.String("metrics-addr", "", "if set (e.g. ':9100'), serve Prometheus /metrics + Go/process collectors on this address")
-		transport     = fs.String("transport", "udp", "acp1 only: udp (Mode A), tcp (Mode B), an2 (Mode C, port 2072), udp+tcp (Mode A + Mode B, no AN2), or all (every transport). Other protocols ignore this flag.")
-		tcpPort       = fs.Int("tcp-port", 0, "acp1 only: TCP listen port for --transport tcp/all (0 = same as --port)")
-		an2Port       = fs.Int("an2-port", 2072, "acp1 only: AN2/TCP listen port for --transport an2/all")
-		adminName     = fs.String("name", "dhs-acp1", "acp1 only: instance name for admin RPC discovery file")
-		insertTiming  = fs.String("insert-timing", "real", "acp1 only: cascade timing for slot insert (real / fast)")
-		dmLibraryRoot = fs.String("dm-library", "", "acp1 only: DM library root for admin slot.load (#260)")
-		preload       = fs.String("preload", "", "acp1 only: pre-populate slots at boot with NO cascade. External controllers see a stable device from first walk and don't discard the cached template on producer restart. Format: slot=card[,slot=card,...] e.g. 0=axon/synapse/RRS18-1601/acp1,1=axon/synapse/2GS110-2728/acp1")
-		play          = fs.String("play", "", "acp1 only: oscillate objects with random values; each tick fires a spontaneous status announce. Pass `all` to oscillate every oscillatable object on every slot (slot 0 included), or a comma-separated path list 1.<slot+1>.<group>.<id>[,...] e.g. 1.1.3.6,1.1.3.7 oscillates Temp_Left + Temp_Right on slot 0")
-		playEvery     = fs.Duration("play-interval", 2*time.Second, "acp1 only: tick interval for --play")
-		playMode      = fs.String("play-mode", "walk", "acp1 only: --play value strategy — `walk` (mean-reverting drift, realistic) or `random` (force a uniform value across the object's full [min,max] each tick)")
-		pidfile       = fs.String("pidfile", "", "if set, write this process's PID to PATH on start (removed on exit) so `dhs producer <proto> stop --pidfile PATH` can signal it")
+		treePath       = fs.String("tree", "", "path to canonical tree.json (one of --tree | --manifest required)")
+		manifestPath   = fs.String("manifest", "", "path to manifest JSON (.cache/manifest/<device>.json) — assembles the tree from referenced DMs under .cache/dm/<proto>/ per ADR-0022. Mutually exclusive with --tree.")
+		cacheDir       = fs.String("cache-dir", ".cache", "root of the cache tree (`.cache/dm/<proto>/<Model@SwRev>.json` lookup base; only used with --manifest)")
+		port           = fs.Int("port", 0, "TCP listen port (0 = plugin default)")
+		host           = fs.String("host", "0.0.0.0", "TCP/UDP listen host (alias: --bind)")
+		bind           = fs.String("bind", "", "alternate spelling of --host. e.g. --bind 10.6.239.200 binds the listener AND pins the broadcast source IP to the VIP, so multi-instance emulators on the same machine appear as distinct From: addresses to consumers (#263).")
+		logLevel       = fs.String("log-level", "info", "log level: debug, info, warn, error")
+		logFormat      = fs.String("log-format", DefaultLogFormat, "log format: syslog (RFC 5424, default; severity mapped incl. critical — #751 G6) | json (Loki/Promtail) | text (human) — epic #987")
+		syslogAddr     = fs.String("syslog-addr", "", "also forward logs as RFC 5424 UDP datagrams to host:port (non-blocking: a slow collector drops records; drops are counted and reported on stderr — #934)")
+		announceDemo   = fs.Bool("announce-demo", false, "oscillate a target value every --announce-demo-interval and broadcast announces (acp1/acp2 only)")
+		announceSlot   = fs.Int("announce-demo-slot", 1, "slot for --announce-demo target")
+		announceGroup  = fs.Int("announce-demo-group", 2, "acp1: object group for --announce-demo target (2=Control)")
+		announceID     = fs.Int("announce-demo-id", 0, "acp1: object id for --announce-demo target (must be Integer type)")
+		announceObj    = fs.Int("announce-demo-obj", 18, "acp2: obj-id for --announce-demo target (must be Number+Float)")
+		announceEvery  = fs.Duration("announce-demo-interval", 2*time.Second, "--announce-demo tick interval")
+		metricsAddr    = fs.String("metrics-addr", "", "if set (e.g. ':9100'), serve Prometheus /metrics + Go/process collectors on this address")
+		transport      = fs.String("transport", "udp", "acp1 only: udp (Mode A), tcp (Mode B), an2 (Mode C, port 2072), udp+tcp (Mode A + Mode B, no AN2), or all (every transport). Other protocols ignore this flag.")
+		tcpPort        = fs.Int("tcp-port", 0, "acp1 only: TCP listen port for --transport tcp/all (0 = same as --port)")
+		an2Port        = fs.Int("an2-port", 2072, "acp1 only: AN2/TCP listen port for --transport an2/all")
+		adminName      = fs.String("name", "dhs-acp1", "acp1 only: instance name for admin RPC discovery file")
+		insertTiming   = fs.String("insert-timing", "real", "acp1 only: cascade timing for slot insert (real / fast)")
+		dmLibraryRoot  = fs.String("dm-library", "", "acp1 only: DM library root for admin slot.load (#260)")
+		preload        = fs.String("preload", "", "acp1 only: pre-populate slots at boot with NO cascade. External controllers see a stable device from first walk and don't discard the cached template on producer restart. Format: slot=card[,slot=card,...] e.g. 0=axon/synapse/RRS18-1601/acp1,1=axon/synapse/2GS110-2728/acp1")
+		play           = fs.String("play", "", "acp1 only: oscillate objects with random values; each tick fires a spontaneous status announce. Pass `all` to oscillate every oscillatable object on every slot (slot 0 included), or a comma-separated path list 1.<slot+1>.<group>.<id>[,...] e.g. 1.1.3.6,1.1.3.7 oscillates Temp_Left + Temp_Right on slot 0")
+		playEvery      = fs.Duration("play-interval", 2*time.Second, "acp1 only: tick interval for --play")
+		playMode       = fs.String("play-mode", "walk", "acp1 only: --play value strategy — `walk` (mean-reverting drift, realistic) or `random` (force a uniform value across the object's full [min,max] each tick)")
+		pidfile        = fs.String("pidfile", "", "if set, write this process's PID to PATH on start (removed on exit) so `dhs producer <proto> stop --pidfile PATH` can signal it")
 		announceReplay = fs.String("announce-replay", "", "acp2: loop a recorded announce stream (.jsonl from a real-device capture) to subscribed sessions — real cards announce continuously and controllers derive module liveness from it")
 	)
 	if err := parseVerbFlags(fs, args); err != nil {
@@ -510,14 +510,8 @@ func parseLogLevel(level string) slog.Level {
 }
 
 func newLogger(level, format string) *slog.Logger {
-	lvl := parseLogLevel(level)
-	opts := &slog.HandlerOptions{Level: lvl}
-	switch format {
-	case "json":
-		return slog.New(slog.NewJSONHandler(os.Stderr, opts))
-	case "syslog":
-		// RFC 5424 lines for rsyslog/syslog-ng/promtail (#751 G6).
-		return slog.New(newSyslogHandler(os.Stderr, lvl))
-	}
-	return slog.New(slog.NewTextHandler(os.Stderr, opts))
+	// Delegate to the shared format chooser (epic #987) so producer and
+	// consumer pick the log FORMAT identically. Sinks (stderr here, +file/
+	// +syslog-addr) are layered by the caller.
+	return newLoggerTo(os.Stderr, parseLogLevel(level), format)
 }

--- a/cmd/dhs/cmd_watch.go
+++ b/cmd/dhs/cmd_watch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -274,6 +275,33 @@ func runWatch(ctx context.Context, args []string) error {
 			// root-stripped form --path accepts. Display only; ev.Path
 			// is not used for resolution past this point.
 			ev.Path = stripDisplayRoot(ev.Path)
+
+			// Uniform logging (epic #987, Model B): the terminal keeps the
+			// human table below; when a structured sink (--log/--syslog-addr)
+			// is configured, ALSO emit each change as one structured record
+			// to that sink — the Loki/server path — never to the terminal.
+			if cf.logHasSink && cf.eventLogger != nil {
+				attrs := []any{
+					slog.String("proto", cf.protocol),
+					slog.String("oid", oid),
+					slog.Int("slot", ev.Slot),
+					slog.String("group", ev.Group),
+					slog.Int("id", ev.ID),
+					slog.String("path", ev.Path),
+					slog.String("label", label),
+					slog.String("access", accessStr(ev.Access)),
+				}
+				if mc := ev.MatrixChange; mc != nil {
+					attrs = append(attrs, slog.String("kind", "matrix"))
+				} else {
+					v := formatValueInline(ev.Value)
+					if ev.Unit != "" {
+						v += " " + ev.Unit
+					}
+					attrs = append(attrs, slog.String("value", v))
+				}
+				cf.eventLogger.Info("value_change", attrs...)
+			}
 
 			// Matrix crosspoint events render differently —
 			// target/sources/disposition replace the single value

--- a/cmd/dhs/common.go
+++ b/cmd/dhs/common.go
@@ -97,7 +97,7 @@ func addCommonFlags(fs *flag.FlagSet) *commonFlags {
 	fs.BoolVar(&cf.verbose, "verbose", false, "debug log output (shortcut for --log-level debug)")
 	fs.StringVar(&cf.logLevel, "log-level", "info", "log level: trace, debug, info, warn, error, critical")
 	fs.StringVar(&cf.logFormat, "log-format", DefaultLogFormat, "SINK log format: syslog (RFC 5424, default) | json (Loki/Promtail) | text — the terminal stays human; this is the --log/--syslog-addr format (epic #987)")
-	fs.StringVar(&cf.logPath, "log", "", "also write the log to this FILE in --log-format (local sink; the terminal stays the human table). Literal \"auto\" = .cache/logs/<proto>/<host>/<verb>.log")
+	fs.StringVar(&cf.logPath, "log", "auto", "local log FILE in --log-format (the terminal stays the human table). Default \"auto\" = .cache/logs/<proto>/<host>/<verb>.log (always logs locally, like the DM cache); a path overrides it; \"off\" disables the local file.")
 	fs.StringVar(&cf.syslogAddr, "syslog-addr", "", "also forward logs as RFC 5424 UDP datagrams to host:port (remote server sink; non-blocking, drops counted)")
 	fs.StringVar(&cf.capture, "capture", "",
 		"capture traffic. Path ending in .jsonl → single-file raw frame log "+

--- a/cmd/dhs/common.go
+++ b/cmd/dhs/common.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
-	"dhs/internal/logging"
-	"dhs/internal/consumer"
 	"dhs/internal/acp1/consumer"
+	"dhs/internal/consumer"
 	"dhs/internal/datastore"
+	"dhs/internal/logging"
 	"dhs/internal/transport"
 )
 
@@ -33,16 +34,29 @@ func init() {
 type commonFlags struct {
 	// verb is the FlagSet name ("export", "walk", …) — labels the
 	// ADR-0028 default capture folder; never user-visible otherwise.
-	verb              string
-	protocol          string
-	transport         string
-	port              int
-	timeout           time.Duration
-	keepalive         time.Duration
-	keepaliveTimeout  time.Duration
-	verbose           bool
-	logLevel          string
-	capture           string
+	verb             string
+	protocol         string
+	transport        string
+	port             int
+	timeout          time.Duration
+	keepalive        time.Duration
+	keepaliveTimeout time.Duration
+	verbose          bool
+	logLevel         string
+	logFormat        string
+	logPath          string
+	syslogAddr       string
+	capture          string
+
+	// eventLogger + logHasSink are set by connect(): the uniform-logging
+	// contract (epic #987, Model B). The terminal always shows the human
+	// data tables; when a structured sink (--log file / --syslog-addr
+	// server) is configured, a verb (e.g. watch) ALSO emits each event as a
+	// structured record through eventLogger — which writes ONLY to the
+	// sinks, never the terminal. nil / false when no sink is configured.
+	eventLogger *slog.Logger
+	logHasSink  bool
+	logCleanup  func()
 
 	// captureDir is populated by connect() when --capture points at a
 	// directory (or at a path without a .jsonl extension). In that
@@ -82,6 +96,9 @@ func addCommonFlags(fs *flag.FlagSet) *commonFlags {
 			"this elapses without rx; values stay decoded against the cached schema.")
 	fs.BoolVar(&cf.verbose, "verbose", false, "debug log output (shortcut for --log-level debug)")
 	fs.StringVar(&cf.logLevel, "log-level", "info", "log level: trace, debug, info, warn, error, critical")
+	fs.StringVar(&cf.logFormat, "log-format", DefaultLogFormat, "SINK log format: syslog (RFC 5424, default) | json (Loki/Promtail) | text — the terminal stays human; this is the --log/--syslog-addr format (epic #987)")
+	fs.StringVar(&cf.logPath, "log", "", "also write the log to this FILE in --log-format (local sink; the terminal stays the human table). Literal \"auto\" = .cache/logs/<proto>/<host>/<verb>.log")
+	fs.StringVar(&cf.syslogAddr, "syslog-addr", "", "also forward logs as RFC 5424 UDP datagrams to host:port (remote server sink; non-blocking, drops counted)")
 	fs.StringVar(&cf.capture, "capture", "",
 		"capture traffic. Path ending in .jsonl → single-file raw frame log "+
 			"(ACP1/ACP2/Ember+). Any other path → directory mode: writes "+
@@ -160,7 +177,17 @@ func connect(ctx context.Context, host string, cf *commonFlags) (consumer.Protoc
 	if cf.verbose && lvl > logging.LevelDebug {
 		lvl = logging.LevelDebug // --verbose is shortcut for --log-level debug
 	}
-	logger := logging.NewTextLogger(lvl)
+	// Uniform logging (epic #987, Model B): stderr stays human; --log FILE
+	// and --syslog-addr are structured sinks in --log-format (syslog
+	// default). With no sink this is exactly the old stderr text logger.
+	op, event, logCleanup, hasSink, lerr := buildConsumerLoggers(
+		lvl, cf.logFormat, cf.logPath, cf.syslogAddr,
+		defaultLogPath(cf.protocol, hostOnly(host), cf.verb))
+	if lerr != nil {
+		return nil, nil, lerr
+	}
+	cf.eventLogger, cf.logHasSink, cf.logCleanup = event, hasSink, logCleanup
+	logger := op
 
 	// Optional traffic capture for test data generation. The literal
 	// "auto" resolves to the ADR-0028 evidence home as a capture DIR
@@ -257,6 +284,9 @@ func connect(ctx context.Context, host string, cf *commonFlags) (consumer.Protoc
 		_ = plug.Disconnect()
 		if recorder != nil {
 			_ = recorder.Close()
+		}
+		if cf.logCleanup != nil {
+			cf.logCleanup()
 		}
 	}
 	return plug, cleanup, nil

--- a/cmd/dhs/logging.go
+++ b/cmd/dhs/logging.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"io"
+	"log/slog"
+)
+
+// DefaultLogFormat is the uniform logging default for every connector,
+// consumer and provider alike (epic #987): RFC 5424 syslog. `text` (the
+// human logger) and `json` (Loki/Promtail, one record per line) are opt-in
+// via --log-format. This is the LOG stream only — the human data tables
+// that watch/tree/walk print are unaffected.
+const DefaultLogFormat = "syslog"
+
+// newLoggerTo builds a slog.Logger that writes to w in the given format:
+//
+//	"syslog" → RFC 5424 lines (newSyslogHandler) — the default
+//	"json"   → slog JSON, one record per line (Loki/Promtail)
+//	anything → slog text (human)
+//
+// It is the single place the log FORMAT is chosen, shared by the producer
+// (serve) and the consumer verbs so `--log-format` means one thing across
+// the whole CLI. The remote (syslog-addr) and local-file sinks are layered
+// on by the caller via teeHandler / the file writer.
+func newLoggerTo(w io.Writer, level slog.Level, format string) *slog.Logger {
+	opts := &slog.HandlerOptions{Level: level}
+	switch format {
+	case "json":
+		return slog.New(slog.NewJSONHandler(w, opts))
+	case "text":
+		return slog.New(slog.NewTextHandler(w, opts))
+	default: // "syslog" and any unknown value fall back to the default format
+		return slog.New(newSyslogHandler(w, level))
+	}
+}

--- a/cmd/dhs/logging.go
+++ b/cmd/dhs/logging.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"log/slog"
+	"os"
+	"path/filepath"
 )
 
 // DefaultLogFormat is the uniform logging default for every connector,
@@ -32,4 +35,65 @@ func newLoggerTo(w io.Writer, level slog.Level, format string) *slog.Logger {
 	default: // "syslog" and any unknown value fall back to the default format
 		return slog.New(newSyslogHandler(w, level))
 	}
+}
+
+// buildConsumerLoggers assembles the uniform-logging Model B loggers a
+// consumer verb uses (epic #987):
+//
+//   - op:    stderr HUMAN text at `level` (the operator's operational log)
+//     PLUS the structured sinks — this is the logger the plugin uses.
+//   - event: the structured sinks ONLY (no stderr) — a verb (e.g. watch)
+//     emits its event stream through this so records reach the file/server
+//     without ever cluttering the terminal (which keeps its human data
+//     tables on stdout). nil when no sink is configured.
+//
+// Sinks: --log FILE (autoPath resolves the literal "auto") and
+// --syslog-addr host:port, both in `format` (syslog default). hasSink is
+// true when at least one exists. With no sink, op is exactly the old
+// stderr text logger and event is nil — a pure no-op change to defaults.
+func buildConsumerLoggers(level slog.Level, format, logPath, syslogAddr, autoPath string) (op, event *slog.Logger, cleanup func(), hasSink bool, err error) {
+	if format == "" {
+		format = DefaultLogFormat
+	}
+	var closers []func()
+	cleanup = func() {
+		for i := len(closers) - 1; i >= 0; i-- {
+			closers[i]()
+		}
+	}
+
+	var sinks []slog.Handler
+	if logPath != "" {
+		if logPath == "auto" {
+			logPath = autoPath
+		}
+		if dir := filepath.Dir(logPath); dir != "." {
+			if mkErr := os.MkdirAll(dir, 0o755); mkErr != nil {
+				return nil, nil, cleanup, false, fmt.Errorf("--log %s: %w", logPath, mkErr)
+			}
+		}
+		f, ferr := os.Create(logPath)
+		if ferr != nil {
+			return nil, nil, cleanup, false, fmt.Errorf("--log %s: %w", logPath, ferr)
+		}
+		sinks = append(sinks, newLoggerTo(f, level, format).Handler())
+		closers = append(closers, func() { _ = f.Close() })
+	}
+	if syslogAddr != "" {
+		udp, uerr := dialSyslogUDP(syslogAddr)
+		if uerr != nil {
+			cleanup()
+			return nil, nil, func() {}, false, fmt.Errorf("--syslog-addr %s: %w", syslogAddr, uerr)
+		}
+		sinks = append(sinks, udp.Handler(level))
+		closers = append(closers, func() { udp.Close() })
+	}
+	hasSink = len(sinks) > 0
+
+	opHandlers := append([]slog.Handler{slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})}, sinks...)
+	op = slog.New(teeHandler(opHandlers))
+	if hasSink {
+		event = slog.New(teeHandler(append([]slog.Handler(nil), sinks...)))
+	}
+	return op, event, cleanup, hasSink, nil
 }

--- a/cmd/dhs/logging.go
+++ b/cmd/dhs/logging.go
@@ -8,6 +8,23 @@ import (
 	"path/filepath"
 )
 
+// consumerModelBLogger is the default Model B logger for connectors whose
+// per-verb flagsets don't parse the logging flags yet (probel-sw08p,
+// probel-sw02p, osc, nmos): stderr stays HUMAN, and the log is ALSO written
+// to the default local .cache/logs/<proto>/<host>/<verb>.log in syslog —
+// so every connector logs syslog locally by default (epic #987). A #987
+// follow-up adds --log-format/--syslog-addr to those flagsets for the
+// remote sink; the local default is live now. Falls back to a plain stderr
+// logger if the file can't be opened.
+func consumerModelBLogger(proto, host, verb string) (*slog.Logger, func()) {
+	op, _, cleanup, _, err := buildConsumerLoggers(
+		slog.LevelInfo, DefaultLogFormat, "auto", "", defaultLogPath(proto, hostOnly(host), verb))
+	if err != nil || op == nil {
+		return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})), func() {}
+	}
+	return op, cleanup
+}
+
 // DefaultLogFormat is the uniform logging default for every connector,
 // consumer and provider alike (epic #987): RFC 5424 syslog. `text` (the
 // human logger) and `json` (Loki/Promtail, one record per line) are opt-in

--- a/cmd/dhs/logging.go
+++ b/cmd/dhs/logging.go
@@ -1,28 +1,102 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
-// consumerModelBLogger is the default Model B logger for connectors whose
-// per-verb flagsets don't parse the logging flags yet (probel-sw08p,
-// probel-sw02p, osc, nmos): stderr stays HUMAN, and the log is ALSO written
-// to the default local .cache/logs/<proto>/<host>/<verb>.log in syslog —
-// so every connector logs syslog locally by default (epic #987). A #987
-// follow-up adds --log-format/--syslog-addr to those flagsets for the
-// remote sink; the local default is live now. Falls back to a plain stderr
-// logger if the file can't be opened.
-func consumerModelBLogger(proto, host, verb string) (*slog.Logger, func()) {
-	op, _, cleanup, _, err := buildConsumerLoggers(
-		slog.LevelInfo, DefaultLogFormat, "auto", "", defaultLogPath(proto, hostOnly(host), verb))
-	if err != nil || op == nil {
-		return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})), func() {}
+// logFlags carries the four uniform logging flags for connectors whose
+// per-verb flagsets don't register them directly (probel-sw08p, probel-sw02p,
+// osc, nmos). Their dispatcher strips these flags from the args ONCE with
+// stripLogFlags and stashes the result in the context; the dial/logger spots
+// read it back with consumerLogger. Same flags, same Model B behaviour as
+// every other connector (epic #987).
+type logFlags struct {
+	format     string
+	level      string
+	path       string
+	syslogAddr string
+}
+
+type logFlagsKey struct{}
+
+// stripLogFlags pulls --log-format / --log / --syslog-addr / --log-level
+// (each as "--flag value" or "--flag=value", one or two dashes) out of args
+// so a connector's own FlagSet never sees them, and returns the parsed
+// values plus the remaining args. Defaults match every other connector.
+func stripLogFlags(args []string) (*logFlags, []string) {
+	lf := &logFlags{format: DefaultLogFormat, level: "info", path: "auto"}
+	out := make([]string, 0, len(args))
+	set := func(name, val string) bool {
+		switch name {
+		case "log-format":
+			lf.format = val
+		case "log":
+			lf.path = val
+		case "syslog-addr":
+			lf.syslogAddr = val
+		case "log-level":
+			lf.level = val
+		default:
+			return false
+		}
+		return true
 	}
-	return op, cleanup
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if len(a) < 2 || a[0] != '-' {
+			out = append(out, a)
+			continue
+		}
+		name := strings.TrimLeft(a, "-")
+		if eq := strings.IndexByte(name, '='); eq >= 0 { // --flag=value
+			if set(name[:eq], name[eq+1:]) {
+				continue
+			}
+			out = append(out, a)
+			continue
+		}
+		// --flag value
+		if i+1 < len(args) && set(name, args[i+1]) {
+			i++
+			continue
+		}
+		if set(name, "") { // flag with no following value
+			continue
+		}
+		out = append(out, a)
+	}
+	return lf, out
+}
+
+// withLogFlags stashes stripped log flags on the context for consumerLogger.
+func withLogFlags(ctx context.Context, lf *logFlags) context.Context {
+	return context.WithValue(ctx, logFlagsKey{}, lf)
+}
+
+// consumerLogger builds the Model B loggers for a connector that stashed its
+// log flags on ctx (via stripLogFlags + withLogFlags). op is the operational
+// logger (human stderr + structured sinks); event is the sink-only event
+// logger (nil without a sink) for the verb's event stream; cleanup closes the
+// sinks. Falls back to sane defaults (local syslog only) when no flags are on
+// the context.
+func consumerLogger(ctx context.Context, proto, host, verb string) (op, event *slog.Logger, cleanup func(), hasSink bool) {
+	lf, _ := ctx.Value(logFlagsKey{}).(*logFlags)
+	if lf == nil {
+		lf = &logFlags{format: DefaultLogFormat, level: "info", path: "auto"}
+	}
+	o, e, c, has, err := buildConsumerLoggers(
+		parseLogLevel(lf.level), lf.format, lf.path, lf.syslogAddr,
+		defaultLogPath(proto, hostOnly(host), verb))
+	if err != nil || o == nil {
+		return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})), nil, func() {}, false
+	}
+	return o, e, c, has
 }
 
 // DefaultLogFormat is the uniform logging default for every connector,

--- a/cmd/dhs/logging.go
+++ b/cmd/dhs/logging.go
@@ -63,10 +63,15 @@ func buildConsumerLoggers(level slog.Level, format, logPath, syslogAddr, autoPat
 	}
 
 	var sinks []slog.Handler
+	// Local file is ON by default (like the DM cache): "auto" resolves to
+	// the ADR-0028 path; "off"/"none"/"-"/"" disable it.
+	switch logPath {
+	case "off", "none", "-", "":
+		logPath = ""
+	case "auto":
+		logPath = autoPath
+	}
 	if logPath != "" {
-		if logPath == "auto" {
-			logPath = autoPath
-		}
 		if dir := filepath.Dir(logPath); dir != "." {
 			if mkErr := os.MkdirAll(dir, 0o755); mkErr != nil {
 				return nil, nil, cleanup, false, fmt.Errorf("--log %s: %w", logPath, mkErr)

--- a/cmd/dhs/logging_test.go
+++ b/cmd/dhs/logging_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestNewLoggerToJSON: --log-format json emits one parseable JSON object
+// per record with the expected fields (Loki/Promtail contract).
+func TestNewLoggerToJSON(t *testing.T) {
+	var buf bytes.Buffer
+	lg := newLoggerTo(&buf, slog.LevelInfo, "json")
+	lg.Info("value_change", slog.String("object", "io.sdi"), slog.String("value", "12G"))
+
+	line := strings.TrimSpace(buf.String())
+	var rec map[string]any
+	if err := json.Unmarshal([]byte(line), &rec); err != nil {
+		t.Fatalf("json log line does not parse: %v\nline: %s", err, line)
+	}
+	if rec["msg"] != "value_change" || rec["object"] != "io.sdi" || rec["value"] != "12G" {
+		t.Fatalf("json fields missing/wrong: %v", rec)
+	}
+}
+
+var rfc5424 = regexp.MustCompile(`^<\d+>1 \S+ \S+ \S+ \S+ `)
+
+// TestNewLoggerToSyslog: default/syslog format emits RFC 5424 lines
+// (<PRIVAL>1 TIMESTAMP HOST APP PROCID ...).
+func TestNewLoggerToSyslog(t *testing.T) {
+	for _, format := range []string{"syslog", "", "anything-unknown"} {
+		var buf bytes.Buffer
+		lg := newLoggerTo(&buf, slog.LevelInfo, format)
+		lg.Info("cerebrum_value_change", slog.String("object", "x"))
+		line := strings.TrimSpace(buf.String())
+		if !rfc5424.MatchString(line) {
+			t.Fatalf("format %q: not RFC 5424: %q", format, line)
+		}
+		if !strings.Contains(line, "cerebrum_value_change") {
+			t.Fatalf("format %q: message missing: %q", format, line)
+		}
+	}
+}
+
+// TestBuildConsumerLoggers covers the Model B assembly: a file sink writes
+// the structured record, the event logger is sink-only (nil without a
+// sink), and "off" disables the local file.
+func TestBuildConsumerLoggers(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "run.log")
+
+	op, event, cleanup, hasSink, err := buildConsumerLoggers(slog.LevelInfo, "syslog", logPath, "", "")
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if !hasSink || event == nil {
+		t.Fatalf("a file sink must set hasSink and a non-nil event logger")
+	}
+	event.Info("value_change", slog.String("object", "io.sdi"))
+	op.Warn("something")
+	cleanup()
+
+	b, rerr := os.ReadFile(logPath)
+	if rerr != nil {
+		t.Fatalf("log file not written: %v", rerr)
+	}
+	body := string(b)
+	if !strings.Contains(body, "value_change") || !strings.Contains(body, "something") {
+		t.Fatalf("file missing event and/or operational record:\n%s", body)
+	}
+	for _, ln := range strings.Split(strings.TrimSpace(body), "\n") {
+		if !rfc5424.MatchString(ln) {
+			t.Fatalf("file line not RFC 5424: %q", ln)
+		}
+	}
+
+	// No sink → no event logger, no hasSink.
+	_, event2, cleanup2, hasSink2, err2 := buildConsumerLoggers(slog.LevelInfo, "syslog", "off", "", "")
+	if err2 != nil {
+		t.Fatalf("build off: %v", err2)
+	}
+	cleanup2()
+	if hasSink2 || event2 != nil {
+		t.Fatalf("--log off must disable the sink (hasSink=%v event=%v)", hasSink2, event2)
+	}
+}

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -96,14 +96,17 @@ records are standard RFC 5424 and route by app-name `dhs`.
 
 ## Per-connector coverage
 
-| Connector | `--log-format` / `--syslog-addr` | local syslog default | watch events → sink |
-|---|---|---|---|
-| acp1 / acp2 / emberplus / tsl | ✅ (all `addCommonFlags` verbs) | ✅ | ✅ (generic watch) |
-| cerebrum-nb | ✅ | ✅ | ✅ |
-| producer (all protocols) | ✅ | stderr + `--syslog-addr` | serve logs |
-| probel-sw08p / probel-sw02p | local default (flags: follow-up) | ✅ | follow-up |
-| osc / nmos | local default (flags: follow-up) | ✅ | follow-up |
+Every connector accepts all four flags and logs syslog locally by default.
 
-All connectors log syslog **locally** by default today; adding the remote
-`--syslog-addr` / `--log-format` flags to the probel/osc/nmos per-verb
-flagsets is the remaining #987 follow-up.
+| Connector | flags (`--log-format`/`--log`/`--syslog-addr`/`--log-level`) | local syslog default | watch events → sink |
+|---|---|---|---|
+| acp1 / acp2 / emberplus / tsl | ✅ (`addCommonFlags` verbs) | ✅ | ✅ (generic watch) |
+| cerebrum-nb | ✅ | ✅ | ✅ |
+| producer (all protocols) | ✅ | ✅ | ✅ (serve) |
+| probel-sw08p / probel-sw02p | ✅ (stripped at dispatcher → ctx) | ✅ | operational (per-event: follow-up) |
+| osc / nmos | ✅ (stripped at dispatcher → ctx) | ✅ | operational (per-event: follow-up) |
+
+probel/osc/nmos honour the flags for operational + connection logs (so
+`--syslog-addr` forwards them to a server); routing each individual
+watch/tally *event* through the sink for those three (as cerebrum-nb and the
+generic watch already do) is the one remaining refinement.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,109 @@
+# Logging (uniform syslog contract)
+
+**Epic #987.** Every connector — consumer *and* producer, every protocol —
+logs in **syslog format by default**, to a **local file** and optionally a
+**remote server**, while the **terminal stays human**. One contract, one set
+of flags, everywhere.
+
+## The model (Model B)
+
+Two independent streams:
+
+| Stream | What | Format |
+|---|---|---|
+| **Terminal — stdout** | the human data tables (`watch`/`tree`/`walk` rows) | human, always |
+| **Terminal — stderr** | operational lines (connect, login, warnings, errors) | human text |
+| **Local file** (on by default) | operational logs **and** the event stream | `--log-format` (syslog default) |
+| **Remote server** (`--syslog-addr`) | same | RFC 5424 |
+
+`--log-format` sets the **sink** format only; it never changes the terminal.
+Events (Info level) go to the file/server sinks, not to stderr, so the
+terminal table stays clean.
+
+## Flags
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--log-format` | `syslog` | sink format: `syslog` (RFC 5424) · `json` (Loki/Promtail) · `text` |
+| `--log` | `auto` | local log FILE. `auto` = `.cache/logs/<proto>/<host>/<verb>.log` (like the DM cache — always logs locally). A path overrides it; `off` disables it. |
+| `--syslog-addr` | (none) | also forward RFC 5424 UDP datagrams to `host:port` (non-blocking; drops counted on stderr) |
+| `--log-level` | `info` | `debug` · `info` · `warn` · `error` |
+
+The local file is **on by default** at the ADR-0028 path — no flag needed,
+exactly like the DM cache writes itself. Disable with `--log off`.
+
+## Default log path
+
+```
+<dhs binary dir>/.cache/logs/<proto>/<host>/<verb>.log
+```
+`<host>` is the connection endpoint (for cerebrum-nb that is the NB server,
+e.g. `10.6.250.5`, not the device). Gitignored (ADR-0020).
+
+## Record formats
+
+**syslog (RFC 5424)** — the default sink line:
+```
+<134>1 2026-09-04T00:41:18.9Z dhs-debian dhs 95885 - - cerebrum_value_change device=0.0.0.0 sub_device=0 object=ComputerOverview.ProcessorTime label=ProcessorTime value=2 type=integer access=R-- units= available=true
+```
+`<134>` = facility local0 (16) × 8 + severity info (6). Severity maps from
+the slog level (debug/info/warn/error, plus `critical`).
+
+**json** — `--log-format json`, one object per line (Loki/Promtail/Vector):
+```json
+{"time":"2026-09-04T00:04:43Z","level":"INFO","msg":"cerebrum_value_change","device":"0.0.0.0","object":"ComputerOverview.ProcessorTime","value":"2","type":"integer","access":"R--","units":"","available":true}
+```
+
+### Event fields
+
+`cerebrum-nb watch` (`msg=cerebrum_value_change`):
+`device, sub_device, object, label, value, type, access, units, available`.
+
+Generic watch — acp1/acp2/emberplus/tsl (`msg=value_change`):
+`proto, oid, slot, group, id, path, label, value, access` (or `kind=matrix`
+for a crosspoint change).
+
+## Ingestion
+
+**Promtail — scrape the JSON file** (`--log-format json`):
+```yaml
+scrape_configs:
+  - job_name: dhs
+    static_configs:
+      - targets: [localhost]
+        labels: {job: dhs, __path__: /path/to/.cache/logs/**/*.log}
+    pipeline_stages:
+      - json:
+          expressions: {level: level, msg: msg, object: object, value: value}
+      - labels: {level: '', msg: ''}
+```
+
+**Promtail — RFC 5424 syslog** (`--syslog-addr <promtail-host>:1514`):
+```yaml
+scrape_configs:
+  - job_name: dhs-syslog
+    syslog:
+      listen_address: 0.0.0.0:1514
+      listen_protocol: udp
+      labels: {job: dhs}
+```
+
+**rsyslog / syslog-ng**: point `--syslog-addr` at the collector's UDP port;
+records are standard RFC 5424 and route by app-name `dhs`.
+
+**Vector**: a `file` source over the JSON logs, or a `syslog` source (mode
+`udp`) for `--syslog-addr`.
+
+## Per-connector coverage
+
+| Connector | `--log-format` / `--syslog-addr` | local syslog default | watch events → sink |
+|---|---|---|---|
+| acp1 / acp2 / emberplus / tsl | ✅ (all `addCommonFlags` verbs) | ✅ | ✅ (generic watch) |
+| cerebrum-nb | ✅ | ✅ | ✅ |
+| producer (all protocols) | ✅ | stderr + `--syslog-addr` | serve logs |
+| probel-sw08p / probel-sw02p | local default (flags: follow-up) | ✅ | follow-up |
+| osc / nmos | local default (flags: follow-up) | ✅ | follow-up |
+
+All connectors log syslog **locally** by default today; adding the remote
+`--syslog-addr` / `--log-format` flags to the probel/osc/nmos per-verb
+flagsets is the remaining #987 follow-up.


### PR DESCRIPTION
Steps 1–2 of #987 (uniform syslog-by-default logging).

> **Stacked on #986** — until that merges, this PR's diff also shows the
> cerebrum-nb DM/watch commits. Review the three logging files:
> `cmd/dhs/logging.go`, `cmd/dhs/cmd_cerebrum.go`, `cmd/dhs/cmd_producer.go`.

## What

Every connector should log **syslog by default**, to a local sink and
optionally a remote server. This lands it for the **cerebrum-nb consumer**
and the **producer**, on a shared helper the rest will reuse.

- **`newLoggerTo(w, level, format)`** — one place chooses the LOG format:
  `syslog` (RFC 5424, **default**), `json` (Loki/Promtail, one record/line),
  `text` (human). Producer's `newLogger` delegates to it; producer
  `--log-format` default flips `text` → `syslog`.
- **cerebrum-nb consumer** gains `--log-format {syslog|json|text}`,
  `--log-level`, `--syslog-addr host:port` (RFC 5424 UDP, non-blocking, drops
  counted) — the same contract as `producer serve`. The logger is built once
  and cached on `cerebrumFlags` so a verb routes its own events through the
  same sinks (stderr / `--log` file / `--syslog-addr`).
- **watch**: in structured mode (syslog/json — the default) each value change
  is one structured record (`device, sub_device, object, label, value, type,
  access, units, available`) to the log stream — the Loki/server path;
  `--log-format text` keeps the human table. `tree`/`walk` data tables are
  unchanged (this is the LOG stream, not the data output).

## Verified live (Cerebrum NB, device 0.0.0.0)

```
default : <134>1 2026-… dhs-debian dhs … cerebrum_value_change device=0.0.0.0 object=…BytesPerSec value=257 type=integer access=R-- units=Bytes/sec available=true
json    : {"time":"…","level":"INFO","msg":"cerebrum_value_change","device":"0.0.0.0","object":"…BytesPerSec","value":"621","type":"integer","access":"R--","units":"Bytes/sec",…}
text    : 23:51:34  ComputerOverview.Network.Transmit.BytesPerSec  BytesPerSec  R--  integer  4417 Bytes/sec
```

## Follow-up (#987)

- Roll the shared flags to acp1/acp2/emberplus/probel/tsl consumer verbs.
- `docs/logging.md`: field schema + Promtail/syslog ingestion snippet.
- CI test: each syslog/json line parses to the documented schema.
