### PR TITLE
refactor(transport): separate protocol from transport — inject the dialer

### DIFF
--- a/internal/acp1/consumer/an2_client.go
+++ b/internal/acp1/consumer/an2_client.go
@@ -30,7 +30,11 @@ const AN2DefaultPort = 2072
 // clientIface for the Plugin, with the same AddListener/RemoveListener
 // announce fan-out shape as TCPClient.
 type AN2Client struct {
-	conn   *net.TCPConn
+	// conn is a net.Conn, not a *net.TCPConn: this client only ever calls
+	// Read / Write / Close / SetWriteDeadline on it, and narrowing to the
+	// concrete type forced the caller to type-assert a dialer's result —
+	// which is exactly what stopped the dialer being injectable.
+	conn   net.Conn
 	logger *slog.Logger
 	cfg    ClientConfig
 
@@ -47,7 +51,7 @@ type AN2Client struct {
 
 // NewAN2Client wraps an already-connected raw TCP socket, starts the reader
 // goroutine, and sends EnableProtocolEvents([ACP1]) so announces flow.
-func NewAN2Client(conn *net.TCPConn, logger *slog.Logger, cfg ClientConfig) *AN2Client {
+func NewAN2Client(conn net.Conn, logger *slog.Logger, cfg ClientConfig) *AN2Client {
 	if logger == nil {
 		logger = slog.Default()
 	}

--- a/internal/acp1/consumer/dialer_injection_test.go
+++ b/internal/acp1/consumer/dialer_injection_test.go
@@ -1,0 +1,99 @@
+package acp1
+
+// The payoff test for the dial seam: connectAN2 opens whatever the injected
+// dialer hands it, with no socket, no port and no listener anywhere.
+//
+// Before the seam this was untestable — connectAN2 built its own net.Dialer
+// and immediately type-asserted the result to *net.TCPConn, so the only way
+// to exercise it was to stand up a real listener.
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"testing"
+
+	"dhs/internal/transport"
+)
+
+// fakeDialer hands back a canned connection instead of opening a socket.
+type fakeDialer struct {
+	conn    net.Conn
+	err     error
+	network string
+	address string
+}
+
+func (d *fakeDialer) DialContext(_ context.Context, network, address string) (net.Conn, error) {
+	d.network, d.address = network, address
+	if d.err != nil {
+		return nil, d.err
+	}
+	return d.conn, nil
+}
+
+func TestConnectAN2UsesTheInjectedDialer(t *testing.T) {
+	ours, theirs := net.Pipe()
+	// The AN2 client sends EnableProtocolEvents as soon as it starts, so
+	// the far end has to read or that write blocks forever.
+	go func() { _, _ = io.Copy(io.Discard, theirs) }()
+	t.Cleanup(func() { _ = theirs.Close() })
+
+	d := &fakeDialer{conn: ours}
+	p := &Plugin{logger: discardLogger(), dialer: d}
+
+	if err := p.connectAN2(context.Background(), "10.6.239.113", 2072); err != nil {
+		t.Fatalf("connectAN2: %v", err)
+	}
+	t.Cleanup(func() { _ = p.client.Close() })
+
+	if d.network != "tcp4" {
+		t.Errorf("dialed network %q, want tcp4", d.network)
+	}
+	if d.address != "10.6.239.113:2072" {
+		t.Errorf("dialed address %q, want 10.6.239.113:2072", d.address)
+	}
+
+	c, ok := p.client.(*AN2Client)
+	if !ok {
+		t.Fatalf("plugin client is %T, want *AN2Client", p.client)
+	}
+	if c.conn != ours {
+		t.Error("AN2Client is not using the connection the dialer returned")
+	}
+}
+
+// A dialer that refuses is reported as a TransportError, same as a refused
+// socket was.
+func TestConnectAN2ReportsInjectedDialerFailure(t *testing.T) {
+	d := &fakeDialer{err: errors.New("no route")}
+	p := &Plugin{logger: discardLogger(), dialer: d}
+
+	err := p.connectAN2(context.Background(), "10.6.239.113", 2072)
+	if err == nil {
+		t.Fatal("connectAN2 succeeded with a failing dialer")
+	}
+	if p.client != nil {
+		t.Error("a failed dial left a client behind")
+	}
+}
+
+// With nothing injected the plugin uses the shared default, which keeps
+// Nagle off for ACP1's small frames.
+func TestPluginDialDefaults(t *testing.T) {
+	p := &Plugin{}
+	td, ok := p.dial().(transport.TCPDialer)
+	if !ok {
+		t.Fatalf("dial() = %T, want transport.TCPDialer", p.dial())
+	}
+	if !td.Options.NoDelay {
+		t.Error("the default dialer left Nagle on")
+	}
+
+	injected := &fakeDialer{}
+	p.dialer = injected
+	if p.dial() != transport.Dialer(injected) {
+		t.Error("dial() replaced an injected dialer")
+	}
+}

--- a/internal/acp1/consumer/plugin.go
+++ b/internal/acp1/consumer/plugin.go
@@ -134,6 +134,10 @@ type Plugin struct {
 	// Optional traffic capture for unit test data generation.
 	recorder *transport.Recorder
 
+	// dialer opens the AN2 (Mode C) socket. Injected rather than built
+	// inline so the pipe is substitutable — see dial() for the default.
+	dialer transport.Dialer
+
 	// profile aggregates wire-tolerance events observed during this
 	// session. See compliance_events.go for the catalog. Nil until
 	// Connect fires; callers read via ComplianceProfile().
@@ -357,20 +361,33 @@ func (p *Plugin) connectTCP(ctx context.Context, ip string, port int) error {
 // handles replies and announcements on the one socket — no separate
 // listener needed.
 func (p *Plugin) connectAN2(ctx context.Context, ip string, port int) error {
-	var d net.Dialer
-	conn, err := d.DialContext(ctx, "tcp4", net.JoinHostPort(ip, strconv.Itoa(port)))
+	conn, err := p.dial().DialContext(ctx, "tcp4", net.JoinHostPort(ip, strconv.Itoa(port)))
 	if err != nil {
 		return &consumer.TransportError{Op: "connect", Err: err}
 	}
-	// unreachable type-assert guard elided: net.Dialer.DialContext over
-	// "tcp4" always yields a *net.TCPConn on success.
-	tcpConn := conn.(*net.TCPConn)
-	_ = tcpConn.SetNoDelay(true)
 	if p.tsSink == nil {
 		p.tsSink = &timestampSink{}
 	}
-	p.client = NewAN2Client(tcpConn, p.logger, ClientConfig{OnRx: p.tsSink.recordRx})
+	p.client = NewAN2Client(conn, p.logger, ClientConfig{OnRx: p.tsSink.recordRx})
 	return nil
+}
+
+// dial returns the injected dialer, or the shared default.
+//
+// AN2 was the one acp1 transport that opened its own socket — UDP and TCP
+// direct already go through transport.DialUDP / transport.DialTCP — so it
+// also missed the socket policy those apply. The default here keeps Nagle
+// off (ACP1 messages are ≤141 bytes and latency-sensitive) and adds the
+// SO_KEEPALIVE this path never had.
+//
+// Plugin is built as a bare struct literal throughout the package, so the
+// nil case is the normal one; a caller that wants a different pipe sets the
+// field.
+func (p *Plugin) dial() transport.Dialer {
+	if p.dialer != nil {
+		return p.dialer
+	}
+	return transport.TCPDialer{Options: transport.SocketOptions{NoDelay: true}}
 }
 
 // Disconnect tears down whichever transport is active and clears all

--- a/internal/acp1/consumer/session_done.go
+++ b/internal/acp1/consumer/session_done.go
@@ -1,0 +1,35 @@
+package acp1
+
+// SessionDone — the death signal, exposed at the Plugin so a supervisor can
+// wait on it without knowing which transport mode is active.
+//
+// The multiplexing clients (TCPClient, AN2Client) already close a channel when
+// their reader goroutine exits; this just surfaces it through the Plugin.
+
+import "dhs/internal/consumer"
+
+// readerDoner is implemented by the clients that carry announcements on the
+// same socket as replies, and therefore have a reader goroutine whose exit
+// means the session is over. Declared here rather than widening clientIface
+// because the UDP path deliberately does NOT have one.
+type readerDoner interface {
+	ReaderDone() <-chan struct{}
+}
+
+// SessionDone implements consumer.SessionDoneAccessor for the connection-
+// oriented modes (TCP direct, AN2). It returns nil for UDP, where there is no
+// session to lose: the socket is connectionless, a silent device is
+// indistinguishable from an idle one, and a nil channel blocks forever, which
+// is the correct "this never fires" answer for a select.
+func (p *Plugin) SessionDone() <-chan struct{} {
+	p.mu.Lock()
+	c := p.client
+	p.mu.Unlock()
+	if rd, ok := c.(readerDoner); ok {
+		return rd.ReaderDone()
+	}
+	return nil
+}
+
+// Compile-time proof the Plugin satisfies the optional capability.
+var _ consumer.SessionDoneAccessor = (*Plugin)(nil)

--- a/internal/acp1/consumer/session_done_test.go
+++ b/internal/acp1/consumer/session_done_test.go
@@ -1,0 +1,59 @@
+package acp1
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+
+	"dhs/internal/acp1/codec"
+)
+
+// stubClient satisfies clientIface WITHOUT a reader goroutine — the shape of
+// the UDP path, where the socket is connectionless and there is no session to
+// lose.
+type stubClient struct{}
+
+func (stubClient) Do(context.Context, *codec.Message) (*codec.Message, error) {
+	return nil, nil
+}
+func (stubClient) Close() error { return nil }
+
+// A transport with no reader has no death signal, and nil is the right
+// answer: it blocks forever in a select rather than firing immediately.
+func TestSessionDoneNilForConnectionlessTransport(t *testing.T) {
+	p := &Plugin{client: stubClient{}}
+	if ch := p.SessionDone(); ch != nil {
+		t.Fatal("SessionDone returned a live channel for a client with no reader")
+	}
+	// Not connected at all is the same answer.
+	if ch := (&Plugin{}).SessionDone(); ch != nil {
+		t.Fatal("SessionDone on an unconnected plugin returned a live channel")
+	}
+}
+
+// AN2 carries announcements on the reader goroutine, so its exit IS the end
+// of the session — the signal a supervisor blocks on.
+func TestSessionDoneClosesWhenTheAN2ReaderExits(t *testing.T) {
+	ours, theirs := net.Pipe()
+	go func() { _, _ = io.Copy(io.Discard, theirs) }()
+	t.Cleanup(func() { _ = theirs.Close() })
+
+	p := &Plugin{logger: discardLogger(), dialer: &fakeDialer{conn: ours}}
+	if err := p.connectAN2(context.Background(), "10.6.239.113", 2072); err != nil {
+		t.Fatalf("connectAN2: %v", err)
+	}
+
+	done := p.SessionDone()
+	if done == nil {
+		t.Fatal("SessionDone returned nil for a connected AN2 session")
+	}
+	select {
+	case <-done:
+		t.Fatal("SessionDone fired while the session was still alive")
+	default:
+	}
+
+	_ = p.client.Close()
+	<-done // closes, or the test times out — which is the failure we want
+}

--- a/internal/acp1/provider/an2_server.go
+++ b/internal/acp1/provider/an2_server.go
@@ -67,7 +67,7 @@ func (s *server) ServeAN2(ctx context.Context, addr string) error {
 		// NoDelay: ACP1 messages are <=141 bytes and latency-sensitive.
 		// Keepalive: the OS-level dead-peer probe, without which a half-open
 		// client session holds a goroutine and a socket here for ever.
-		_ = transport.ApplyListenOptions(conn, transport.ListenOptions{NoDelay: true})
+		_ = transport.ApplySocketOptions(conn, transport.SocketOptions{NoDelay: true})
 		ip := remoteIP(conn.RemoteAddr())
 		if !reg.tryAdd(ip) {
 			s.logger.Warn("acp1 an2 refusing session: per-ip cap exceeded",

--- a/internal/acp1/provider/tcp_server.go
+++ b/internal/acp1/provider/tcp_server.go
@@ -95,7 +95,7 @@ func (s *server) ServeTCP(ctx context.Context, addr string) error {
 		// NoDelay: ACP1 messages are <=141 bytes and latency-sensitive.
 		// Keepalive: the OS-level dead-peer probe, without which a half-open
 		// client session holds a goroutine and a socket here for ever.
-		_ = transport.ApplyListenOptions(conn, transport.ListenOptions{NoDelay: true})
+		_ = transport.ApplySocketOptions(conn, transport.SocketOptions{NoDelay: true})
 		ip := remoteIP(conn.RemoteAddr())
 		if !reg.tryAdd(ip) {
 			s.logger.Warn("acp1 tcp refusing session: per-ip cap exceeded",

--- a/internal/acp2/consumer/session.go
+++ b/internal/acp2/consumer/session.go
@@ -82,6 +82,13 @@ type Session struct {
 	// in NewSession for production.
 	closeWait time.Duration
 
+	// dialer opens the TCP connection Connect establishes. Injected rather
+	// than built inline so the pipe is substitutable — a test supplies a
+	// fake, and a supervisor driving reconnect has something to ASK for a
+	// new connection, which a package-local net.Dialer is not.
+	// NewSession installs the shared transport.TCPDialer for production.
+	dialer transport.Dialer
+
 	// Write serialisation.
 	writeMu sync.Mutex
 
@@ -146,6 +153,13 @@ func NewSession(logger *slog.Logger) *Session {
 		annSubs:   make(map[int]AnnounceFunc),
 		done:      make(chan struct{}),
 		closeWait: 2 * time.Second,
+		// ACP2 frames are small and latency-sensitive, so Nagle stays off —
+		// that part is unchanged. What the shared dialer adds is
+		// SO_KEEPALIVE, which this session never set: an outbound session to
+		// a device that goes half-open had no OS-level dead-peer probe.
+		dialer: transport.TCPDialer{
+			Options: transport.SocketOptions{NoDelay: true},
+		},
 	}
 	s.mtidCond = sync.NewCond(&s.mtidMu)
 	return s
@@ -166,13 +180,9 @@ func (s *Session) Connect(ctx context.Context, ip string, port int) error {
 
 	s.logger.Debug("acp2: dialing", "host", ip, "port", port)
 
-	var d net.Dialer
-	conn, err := d.DialContext(ctx, "tcp", net.JoinHostPort(ip, fmt.Sprintf("%d", port)))
+	conn, err := s.dialer.DialContext(ctx, "tcp", net.JoinHostPort(ip, fmt.Sprintf("%d", port)))
 	if err != nil {
 		return &consumer.TransportError{Op: "connect", Err: err}
-	}
-	if tc, ok := conn.(*net.TCPConn); ok {
-		_ = tc.SetNoDelay(true)
 	}
 	s.conn = conn
 	s.host = ip

--- a/internal/acp2/provider/server.go
+++ b/internal/acp2/provider/server.go
@@ -149,7 +149,7 @@ func (s *server) acceptLoop(ln net.Listener) error {
 		// socket here for ever — the inbound twin of the consumer-side
 		// stall. Applied here rather than at bind time so an injected
 		// listener gets it too.
-		_ = transport.ApplyListenOptions(conn, transport.ListenOptions{})
+		_ = transport.ApplySocketOptions(conn, transport.SocketOptions{})
 		sess := newSession(s, conn)
 		s.registerSession(sess)
 		go func() {

--- a/internal/amwa/session/mqtt/client.go
+++ b/internal/amwa/session/mqtt/client.go
@@ -15,6 +15,8 @@ import (
 	"net"
 	"sync"
 	"time"
+
+	"dhs/internal/transport"
 )
 
 // Options configures one broker connection.
@@ -50,6 +52,12 @@ type Client struct {
 	queue    chan message
 	cancel   context.CancelFunc
 	done     chan struct{}
+
+	// dialer opens the broker connection each session establishes. Injected
+	// rather than built inline so the pipe is substitutable — which matters
+	// more here than anywhere else, because session() is the body of a
+	// reconnect loop and every retry asks it for a fresh connection.
+	dialer transport.Dialer
 }
 
 // New starts a client; the connection is managed in the background.
@@ -72,6 +80,11 @@ func New(opts Options) (*Client, error) {
 		queue:    make(chan message, 256),
 		cancel:   cancel,
 		done:     make(chan struct{}),
+		// Same 10 s connect bound as before, plus the SO_KEEPALIVE this
+		// client never set. MQTT has its own PINGREQ keep-alive, but that
+		// only detects a broker still speaking MQTT; a half-open socket
+		// needs the OS probe underneath it.
+		dialer: transport.TCPDialer{Timeout: 10 * time.Second},
 	}
 	go c.run(ctx)
 	return c, nil
@@ -132,8 +145,7 @@ func (c *Client) run(ctx context.Context) {
 
 // session runs one connect-publish-ping loop until an error.
 func (c *Client) session(ctx context.Context) error {
-	d := net.Dialer{Timeout: 10 * time.Second}
-	conn, err := d.DialContext(ctx, "tcp", c.opts.Addr)
+	conn, err := c.dialer.DialContext(ctx, "tcp", c.opts.Addr)
 	if err != nil {
 		return err
 	}

--- a/internal/cerebrum-nb/consumer/liveness_cover_test.go
+++ b/internal/cerebrum-nb/consumer/liveness_cover_test.go
@@ -135,40 +135,16 @@ func TestLastRxZeroAndSet(t *testing.T) {
 	}
 }
 
-func TestSupervisorLogFallbacks(t *testing.T) {
-	// No logger at all -> a discard logger, never nil.
-	s := &Supervisor{}
-	if s.log() == nil {
-		t.Fatal("log() returned nil with no logger configured")
-	}
-	// Logger field only.
-	explicit := slog.New(slog.NewTextHandler(discard{}, nil))
-	s = &Supervisor{Logger: explicit}
-	if s.log() != explicit {
-		t.Fatal("log() ignored the Logger field")
-	}
-	// LoggerFn wins over Logger when it yields one.
-	fn := slog.New(slog.NewTextHandler(discard{}, nil))
-	s = &Supervisor{Logger: explicit, LoggerFn: func() *slog.Logger { return fn }}
-	if s.log() != fn {
-		t.Fatal("LoggerFn must take precedence over Logger")
-	}
-	// A LoggerFn that yields nil falls back to Logger.
-	s = &Supervisor{Logger: explicit, LoggerFn: func() *slog.Logger { return nil }}
-	if s.log() != explicit {
-		t.Fatal("a nil from LoggerFn must fall back to Logger")
-	}
-}
+// discard is a logger sink for the tests below. It used to live in
+// supervisor.go; the supervisor's own logger fallbacks are now tested in
+// internal/consumer, where the implementation moved.
+type discard struct{}
 
-func TestErrTextAndCloseSessionNil(t *testing.T) {
-	if got := errText(nil); got != "unknown" {
-		t.Fatalf("errText(nil) = %q, want \"unknown\"", got)
-	}
-	if got := errText(errors.New("boom")); got != "boom" {
-		t.Fatalf("errText = %q, want \"boom\"", got)
-	}
-	// closeSession must tolerate nil — the supervisor calls it on paths where
-	// the session was never built.
+func (discard) Write(p []byte) (int, error) { return len(p), nil }
+
+// The Cerebrum wrapper still owns session teardown, and it must tolerate nil:
+// Run calls it on paths where the session was never built.
+func TestCloseSessionNil(t *testing.T) {
 	(&Supervisor{}).closeSession(nil)
 }
 

--- a/internal/cerebrum-nb/consumer/supervisor.go
+++ b/internal/cerebrum-nb/consumer/supervisor.go
@@ -1,76 +1,29 @@
 package cerebrumnb
 
-// Supervisor — keeps a watch alive across connection loss.
+// Supervisor — keeps a Cerebrum watch alive across connection loss.
 //
-// keepalive.go made a dead session DETECTABLE: the read deadline fires, the
-// prober notices a broken socket, and Session.Done() closes carrying a typed
-// transport.ErrConnectionLost. That alone does not keep a 24/7 watcher
-// running — something has to act on it. Before this, cerebrum-nb watch
-// blocked on <-ctx.Done() and never looked at the session at all, so a lost
-// connection meant the process sat there, alive and silent, forever.
+// The cycle it drives is not Cerebrum-specific, so the implementation now
+// lives in internal/consumer as a generic Supervisor shared by every
+// connector. What stays here is the Cerebrum-shaped face of it: the exported
+// type the CLI already builds, typed on *Session, with the same fields and
+// the same behaviour.
 //
-// Supervisor is that missing half. It owns the dial/setup/observe cycle:
-//
-//	dial + login  →  setup (baseline + subscribe + handlers)  →  wait
-//	     ↑                                                        │
-//	     └────────── backoff ←── session died (typed reason) ─────┘
-//
-// Re-running Setup on every reconnect is the point: a Cerebrum subscription
-// lives on the SERVER, so a new socket starts with none. Reconnecting without
-// re-subscribing yields a connected watcher that still shows nothing — the
-// original bug wearing a different hat.
+// Re-running Setup on every reconnect is still the point: a Cerebrum
+// subscription lives on the SERVER and dies with the socket, so reconnecting
+// without re-subscribing yields a connected watcher that shows nothing.
 
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 	"time"
 
 	"dhs/internal/clock"
-	"dhs/internal/transport"
+	"dhs/internal/consumer"
 )
 
-// Backoff schedules reconnect attempts. Exponential from Initial, doubling to
-// Max. Matches the acp2 warm-restart schedule (1s → 30s) so the fleet behaves
-// the same way whichever connector lost its link.
-type Backoff struct {
-	Initial time.Duration
-	Max     time.Duration
-	// MaxAttempts caps consecutive failed attempts. 0 = never give up,
-	// which is the right default for a watcher that must survive a
-	// weekend outage without an operator present.
-	MaxAttempts int
-}
-
-// Defaults for a 24/7 watcher.
-const (
-	defaultBackoffInitial = 1 * time.Second
-	defaultBackoffMax     = 30 * time.Second
-)
-
-func (b Backoff) withDefaults() Backoff {
-	if b.Initial <= 0 {
-		b.Initial = defaultBackoffInitial
-	}
-	if b.Max <= 0 {
-		b.Max = defaultBackoffMax
-	}
-	if b.Max < b.Initial {
-		b.Max = b.Initial
-	}
-	return b
-}
-
-// next doubles d, clamped to Max. Pure, so the schedule is unit-tested
-// without waiting in real time.
-func (b Backoff) next(d time.Duration) time.Duration {
-	d *= 2
-	if d > b.Max {
-		return b.Max
-	}
-	return d
-}
+// Backoff schedules reconnect attempts — the shared schedule (1 s → 30 s).
+type Backoff = consumer.Backoff
 
 // Supervisor keeps one logical watch connected. All collaborators are
 // injected — no globals, and tests substitute each one directly.
@@ -112,113 +65,28 @@ type Supervisor struct {
 // attempt budget is exhausted, so the CLI exits with the contract's runtime
 // code rather than pretending it worked.
 func (s *Supervisor) Run(ctx context.Context) error {
+	// Validated here rather than in the shared Supervisor so the operator
+	// still gets the connector's name in the message.
 	if s.Dial == nil || s.Setup == nil {
 		return errors.New("cerebrum-nb supervisor: Dial and Setup are required")
 	}
-	clk := s.Clock
-	if clk == nil {
-		clk = clock.System()
+	sup := &consumer.Supervisor[*Session]{
+		Dial:  s.Dial,
+		Setup: s.Setup,
+		// Cerebrum's Session carries both halves: Done closes on death and
+		// Err holds the typed reason classifyReadErr produced.
+		Done:  func(sess *Session) <-chan struct{} { return sess.Done() },
+		Err:   func(sess *Session) error { return sess.Err() },
+		Close: func(sess *Session) { s.closeSession(sess) },
+
+		Logger:        s.Logger,
+		Clock:         s.Clock,
+		Backoff:       s.Backoff,
+		LoggerFn:      s.LoggerFn,
+		OnLost:        s.OnLost,
+		OnReconnected: s.OnReconnected,
 	}
-	bo := s.Backoff.withDefaults()
-
-	// Initial connect uses the caller's context directly: a failure here is
-	// the operator's problem to see immediately (bad host, bad password),
-	// not something to silently retry behind a backoff.
-	sess, err := s.connect(ctx)
-	if err != nil {
-		return err
-	}
-
-	for {
-		select {
-		case <-ctx.Done():
-			s.closeSession(sess)
-			return nil
-		case <-sess.Done():
-		}
-
-		// Distinguish "the operator stopped us" from "the link died".
-		// Closing the session marks it lost too, so without this check a
-		// clean Ctrl-C would be reported as a connection failure.
-		if ctx.Err() != nil {
-			s.closeSession(sess)
-			return nil
-		}
-
-		lost := sess.Err()
-		s.log().Warn("session lost — reconnecting",
-			slog.String("reason", errText(lost)))
-		if s.OnLost != nil {
-			s.OnLost(lost)
-		}
-		s.closeSession(sess)
-
-		lostAt := clk.Now()
-		newSess, rerr := s.reconnect(ctx, clk, bo, lostAt)
-		if rerr != nil {
-			return rerr
-		}
-		if newSess == nil { // ctx cancelled while backing off
-			return nil
-		}
-		sess = newSess
-	}
-}
-
-// reconnect retries dial+setup on the backoff schedule until it succeeds, ctx
-// ends (returns nil, nil), or the attempt budget is spent (returns an error).
-func (s *Supervisor) reconnect(ctx context.Context, clk clock.Clock,
-	bo Backoff, lostAt time.Time) (*Session, error) {
-
-	delay := bo.Initial
-	for attempt := 1; ; attempt++ {
-		if err := clk.Sleep(ctx, delay); err != nil {
-			return nil, nil // ctx cancelled during backoff — an orderly stop
-		}
-
-		s.log().Info("reconnect attempt",
-			slog.Int("attempt", attempt),
-			slog.Duration("after", delay))
-
-		sess, err := s.connect(ctx)
-		if err == nil {
-			downtime := clk.Now().Sub(lostAt)
-			s.log().Info("reconnected",
-				slog.Int("attempt", attempt),
-				slog.Duration("downtime", downtime))
-			if s.OnReconnected != nil {
-				s.OnReconnected(attempt, downtime)
-			}
-			return sess, nil
-		}
-		if ctx.Err() != nil {
-			return nil, nil
-		}
-
-		s.log().Warn("reconnect failed",
-			slog.Int("attempt", attempt),
-			slog.String("err", err.Error()))
-
-		if bo.MaxAttempts > 0 && attempt >= bo.MaxAttempts {
-			return nil, fmt.Errorf("%w: giving up after %d reconnect attempts: %v",
-				transport.ErrConnectionLost, attempt, err)
-		}
-		delay = bo.next(delay)
-	}
-}
-
-// connect dials and runs Setup. A Setup failure closes the fresh session so a
-// half-built one is never handed back or leaked.
-func (s *Supervisor) connect(ctx context.Context) (*Session, error) {
-	sess, err := s.Dial(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if err := s.Setup(ctx, sess); err != nil {
-		s.closeSession(sess)
-		return nil, err
-	}
-	return sess, nil
+	return sup.Run(ctx)
 }
 
 // closeSession tears a session down, tolerating nil and double-close.
@@ -228,28 +96,3 @@ func (s *Supervisor) closeSession(sess *Session) {
 	}
 	_ = sess.close()
 }
-
-// log resolves the logger at call time, preferring LoggerFn.
-func (s *Supervisor) log() *slog.Logger {
-	if s.LoggerFn != nil {
-		if l := s.LoggerFn(); l != nil {
-			return l
-		}
-	}
-	if s.Logger != nil {
-		return s.Logger
-	}
-	return slog.New(slog.NewTextHandler(discard{}, nil))
-}
-
-func errText(err error) string {
-	if err == nil {
-		return "unknown"
-	}
-	return err.Error()
-}
-
-// discard is an io.Writer sink for the nil-logger fallback.
-type discard struct{}
-
-func (discard) Write(p []byte) (int, error) { return len(p), nil }

--- a/internal/cerebrum-nb/consumer/supervisor_test.go
+++ b/internal/cerebrum-nb/consumer/supervisor_test.go
@@ -34,37 +34,9 @@ func newTestSession() *Session {
 // killTestSession simulates the link dying with a typed reason.
 func killTestSession(s *Session, reason error) { s.markLost(reason) }
 
-func TestBackoffNextDoublesAndClamps(t *testing.T) {
-	bo := Backoff{Initial: time.Second, Max: 30 * time.Second}.withDefaults()
-	got := []time.Duration{}
-	d := bo.Initial
-	for i := 0; i < 8; i++ {
-		got = append(got, d)
-		d = bo.next(d)
-	}
-	want := []time.Duration{
-		1 * time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second,
-		16 * time.Second, 30 * time.Second, 30 * time.Second, 30 * time.Second,
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("attempt %d delay = %v, want %v", i+1, got[i], want[i])
-		}
-	}
-}
-
-func TestBackoffDefaults(t *testing.T) {
-	bo := Backoff{}.withDefaults()
-	if bo.Initial != defaultBackoffInitial || bo.Max != defaultBackoffMax {
-		t.Fatalf("defaults = %v/%v, want %v/%v",
-			bo.Initial, bo.Max, defaultBackoffInitial, defaultBackoffMax)
-	}
-	// A Max below Initial is nonsense; it must not produce a shrinking schedule.
-	bo2 := Backoff{Initial: 10 * time.Second, Max: time.Second}.withDefaults()
-	if bo2.Max < bo2.Initial {
-		t.Fatalf("Max %v < Initial %v", bo2.Max, bo2.Initial)
-	}
-}
+// The Backoff schedule itself is tested where it now lives, in
+// internal/consumer. What stays here is the Cerebrum-shaped behaviour: that
+// the wrapper reconnects, re-subscribes, and reports the way the CLI expects.
 
 // The headline: when the link dies, the supervisor reconnects AND re-runs
 // Setup, so subscriptions are re-established on the new session.

--- a/internal/consumer/keepalive.go
+++ b/internal/consumer/keepalive.go
@@ -53,3 +53,21 @@ type KeepAliver interface {
 type SessionLiveAccessor interface {
 	SessionLive() bool
 }
+
+// SessionDoneAccessor is the push-side twin of SessionLiveAccessor: a channel
+// that closes when the session ends, whether from a peer close, an I/O error
+// or an idle deadline firing.
+//
+// SessionLive answers "is the data I am showing fresh?" — it is polled.
+// SessionDone answers "is this session over?" — it is waited on, and it is
+// what a Supervisor blocks in order to drive reconnection. Detection without
+// it is a watcher that knows the link is dead and keeps running anyway, which
+// is the 24/7 stall the operator reported.
+//
+// Optional, like every capability in this file. A plugin that does not
+// implement it keeps today's behaviour exactly: the watch verb runs without a
+// supervisor. Connectionless transports (ACP1 over UDP) have no session to
+// lose and correctly do not implement it.
+type SessionDoneAccessor interface {
+	SessionDone() <-chan struct{}
+}

--- a/internal/consumer/supervisor.go
+++ b/internal/consumer/supervisor.go
@@ -1,0 +1,289 @@
+package consumer
+
+// Supervisor — keeps a session alive across connection loss, for any protocol.
+//
+// Detection was solved per connector: a read deadline fires, a keep-alive
+// probe notices a broken socket, and the session's death channel closes. That
+// alone does not keep a 24/7 watcher running — something has to act on it,
+// and until now only cerebrum-nb had that something. acp1, probel-sw02p and
+// probel-sw08p detected death and then sat there, connected to nothing.
+//
+// The cycle is the same for every protocol:
+//
+//	dial + login  →  setup (baseline + subscribe + handlers)  →  wait
+//	     ↑                                                        │
+//	     └────────── backoff ←── session died (typed reason) ─────┘
+//
+// Re-running Setup on every reconnect is the point: a subscription that lives
+// on the SERVER dies with the socket, so reconnecting without re-subscribing
+// yields a connected watcher that still shows nothing — the original bug
+// wearing a different hat.
+//
+// It is generic over the session type and takes the session's lifecycle as
+// FUNCTIONS rather than demanding an interface. That is deliberate: the six
+// connectors spell the death signal two different ways (Done on the acp2 and
+// cerebrum-nb sessions, ReaderDone on the acp1 and probel clients), and
+// renaming a method across four already-approved packages to satisfy a new
+// abstraction is the tail wagging the dog. A closure per call site costs three
+// lines and changes nothing that already works.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"dhs/internal/clock"
+	"dhs/internal/transport"
+)
+
+// Backoff schedules reconnect attempts. Exponential from Initial, doubling to
+// Max. 1 s → 30 s matches the acp2 warm-restart schedule, so the fleet behaves
+// the same way whichever connector lost its link.
+type Backoff struct {
+	Initial time.Duration
+	Max     time.Duration
+	// MaxAttempts caps consecutive failed attempts. 0 = never give up, which
+	// is the right default for a watcher that must survive a weekend outage
+	// with no operator present.
+	MaxAttempts int
+}
+
+// Defaults for a 24/7 watcher.
+const (
+	DefaultBackoffInitial = 1 * time.Second
+	DefaultBackoffMax     = 30 * time.Second
+)
+
+func (b Backoff) withDefaults() Backoff {
+	if b.Initial <= 0 {
+		b.Initial = DefaultBackoffInitial
+	}
+	if b.Max <= 0 {
+		b.Max = DefaultBackoffMax
+	}
+	if b.Max < b.Initial {
+		b.Max = b.Initial
+	}
+	return b
+}
+
+// next doubles d, clamped to Max. Pure, so the schedule is unit-tested without
+// waiting in real time.
+func (b Backoff) next(d time.Duration) time.Duration {
+	d *= 2
+	if d > b.Max {
+		return b.Max
+	}
+	return d
+}
+
+// Supervisor keeps one logical session connected. Every collaborator is
+// injected — no globals, and a test substitutes each one directly.
+//
+// S is the connector's own session or client type; nothing here needs to know
+// what it is.
+type Supervisor[S any] struct {
+	// Dial opens a session and completes login. Required.
+	Dial func(context.Context) (S, error)
+
+	// Setup re-establishes everything that lives on the SERVER or in the
+	// caller's rendering state: event handlers, the baseline read, the
+	// subscriptions. Called after every successful Dial, the first included.
+	// Required.
+	Setup func(context.Context, S) error
+
+	// Done returns the channel that closes when the session dies. Required —
+	// it is the whole reason this type exists.
+	Done func(S) <-chan struct{}
+
+	// Err returns the typed reason the session died. Optional: connectors
+	// whose client does not record one leave it nil and the reason is
+	// reported as unknown.
+	Err func(S) error
+
+	// Close tears the session down. Optional; a connector whose session
+	// cleans itself up on death leaves it nil.
+	Close func(S)
+
+	Logger  *slog.Logger
+	Clock   clock.Clock
+	Backoff Backoff
+
+	// LoggerFn, when set, is consulted at call time instead of Logger. A CLI
+	// that builds its logger during the FIRST dial would otherwise capture a
+	// nil one; resolving lazily lets reconnect messages reach the sink the
+	// operator configured.
+	LoggerFn func() *slog.Logger
+
+	// OnLost, when set, is called with the typed reason as soon as the link
+	// dies — before any backoff — so a gap in the output is explained at the
+	// moment it starts.
+	OnLost func(error)
+
+	// OnReconnected, when set, is called after a successful re-establish
+	// (never for the initial connect), so the operator is told the gap has
+	// closed and data is flowing again.
+	OnReconnected func(attempt int, downtime time.Duration)
+}
+
+// Run connects, then keeps the session alive until ctx is cancelled.
+//
+// Returns nil on ctx cancellation (the operator stopped it — an orderly end,
+// not a failure). Returns a typed error when the initial connect fails or the
+// attempt budget is exhausted, so a CLI exits with the contract's runtime code
+// rather than pretending it worked.
+func (s *Supervisor[S]) Run(ctx context.Context) error {
+	if s.Dial == nil || s.Setup == nil || s.Done == nil {
+		return errors.New("supervisor: Dial, Setup and Done are required")
+	}
+	clk := s.Clock
+	if clk == nil {
+		clk = clock.System()
+	}
+	bo := s.Backoff.withDefaults()
+
+	// The initial connect uses the caller's context directly: a failure here
+	// is the operator's problem to see immediately (bad host, bad password),
+	// not something to retry silently behind a backoff.
+	sess, err := s.connect(ctx)
+	if err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.closeSession(sess)
+			return nil
+		case <-s.Done(sess):
+		}
+
+		// Distinguish "the operator stopped us" from "the link died".
+		// Closing a session marks it lost too, so without this check a clean
+		// Ctrl-C would be reported as a connection failure.
+		if ctx.Err() != nil {
+			s.closeSession(sess)
+			return nil
+		}
+
+		lost := s.reason(sess)
+		s.log().Warn("session lost — reconnecting",
+			slog.String("reason", errText(lost)))
+		if s.OnLost != nil {
+			s.OnLost(lost)
+		}
+		s.closeSession(sess)
+
+		lostAt := clk.Now()
+		newSess, ok, rerr := s.reconnect(ctx, clk, bo, lostAt)
+		if rerr != nil {
+			return rerr
+		}
+		if !ok { // ctx cancelled while backing off
+			return nil
+		}
+		sess = newSess
+	}
+}
+
+// reconnect retries dial+setup on the backoff schedule until it succeeds, ctx
+// ends (ok=false), or the attempt budget is spent (error).
+func (s *Supervisor[S]) reconnect(ctx context.Context, clk clock.Clock,
+	bo Backoff, lostAt time.Time) (S, bool, error) {
+
+	var zero S
+	delay := bo.Initial
+	for attempt := 1; ; attempt++ {
+		if err := clk.Sleep(ctx, delay); err != nil {
+			return zero, false, nil // ctx cancelled during backoff — orderly stop
+		}
+
+		s.log().Info("reconnect attempt",
+			slog.Int("attempt", attempt),
+			slog.Duration("after", delay))
+
+		sess, err := s.connect(ctx)
+		if err == nil {
+			downtime := clk.Now().Sub(lostAt)
+			s.log().Info("reconnected",
+				slog.Int("attempt", attempt),
+				slog.Duration("downtime", downtime))
+			if s.OnReconnected != nil {
+				s.OnReconnected(attempt, downtime)
+			}
+			return sess, true, nil
+		}
+		if ctx.Err() != nil {
+			return zero, false, nil
+		}
+
+		s.log().Warn("reconnect failed",
+			slog.Int("attempt", attempt),
+			slog.String("err", err.Error()))
+
+		if bo.MaxAttempts > 0 && attempt >= bo.MaxAttempts {
+			return zero, false, fmt.Errorf("%w: giving up after %d reconnect attempts: %v",
+				transport.ErrConnectionLost, attempt, err)
+		}
+		delay = bo.next(delay)
+	}
+}
+
+// connect dials and runs Setup. A Setup failure closes the fresh session so a
+// half-built one is never handed back or leaked.
+func (s *Supervisor[S]) connect(ctx context.Context) (S, error) {
+	sess, err := s.Dial(ctx)
+	if err != nil {
+		var zero S
+		return zero, err
+	}
+	if err := s.Setup(ctx, sess); err != nil {
+		s.closeSession(sess)
+		var zero S
+		return zero, err
+	}
+	return sess, nil
+}
+
+// reason reports why the session died, or nil when the connector does not
+// record one.
+func (s *Supervisor[S]) reason(sess S) error {
+	if s.Err == nil {
+		return nil
+	}
+	return s.Err(sess)
+}
+
+// closeSession tears a session down when the connector supplied a closer.
+func (s *Supervisor[S]) closeSession(sess S) {
+	if s.Close != nil {
+		s.Close(sess)
+	}
+}
+
+// log resolves the logger at call time, preferring LoggerFn.
+func (s *Supervisor[S]) log() *slog.Logger {
+	if s.LoggerFn != nil {
+		if l := s.LoggerFn(); l != nil {
+			return l
+		}
+	}
+	if s.Logger != nil {
+		return s.Logger
+	}
+	return slog.New(slog.NewTextHandler(discard{}, nil))
+}
+
+func errText(err error) string {
+	if err == nil {
+		return "unknown"
+	}
+	return err.Error()
+}
+
+// discard is an io.Writer sink for the nil-logger fallback.
+type discard struct{}
+
+func (discard) Write(p []byte) (int, error) { return len(p), nil }

--- a/internal/consumer/supervisor_test.go
+++ b/internal/consumer/supervisor_test.go
@@ -1,0 +1,556 @@
+package consumer
+
+// Tests for the shared Supervisor — the RECOVERY half of the 24/7 contract.
+//
+// Detection is per-connector and tested there. These prove something ACTS on
+// it: reconnect, and re-run Setup, since a subscription that lives on the
+// server does not survive the socket.
+//
+// The session type is a local fake: nothing here should need a protocol.
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"dhs/internal/clock"
+	"dhs/internal/transport"
+)
+
+// fakeSess is a session with the two things a supervisor observes: a channel
+// that closes on death, and a reason.
+type fakeSess struct {
+	done   chan struct{}
+	mu     sync.Mutex
+	err    error
+	closed int
+}
+
+func newFakeSess() *fakeSess { return &fakeSess{done: make(chan struct{})} }
+
+func (s *fakeSess) kill(reason error) {
+	s.mu.Lock()
+	if s.err == nil {
+		s.err = reason
+	}
+	s.mu.Unlock()
+	select {
+	case <-s.done:
+	default:
+		close(s.done)
+	}
+}
+
+func (s *fakeSess) reason() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.err
+}
+
+func (s *fakeSess) closeCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closed
+}
+
+// wire fills in the three lifecycle functions for a *fakeSess.
+func wire(sup *Supervisor[*fakeSess]) *Supervisor[*fakeSess] {
+	sup.Done = func(s *fakeSess) <-chan struct{} { return s.done }
+	sup.Err = func(s *fakeSess) error { return s.reason() }
+	sup.Close = func(s *fakeSess) {
+		s.mu.Lock()
+		s.closed++
+		s.mu.Unlock()
+	}
+	return sup
+}
+
+func fastBackoff(maxAttempts int) Backoff {
+	return Backoff{
+		Initial:     time.Millisecond,
+		Max:         time.Millisecond,
+		MaxAttempts: maxAttempts,
+	}
+}
+
+// --- Backoff --------------------------------------------------------------
+
+func TestBackoffNextDoublesAndClamps(t *testing.T) {
+	bo := Backoff{Initial: time.Second, Max: 30 * time.Second}.withDefaults()
+	var got []time.Duration
+	d := bo.Initial
+	for i := 0; i < 8; i++ {
+		got = append(got, d)
+		d = bo.next(d)
+	}
+	want := []time.Duration{
+		1 * time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second,
+		16 * time.Second, 30 * time.Second, 30 * time.Second, 30 * time.Second,
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("attempt %d delay = %v, want %v", i+1, got[i], want[i])
+		}
+	}
+}
+
+func TestBackoffDefaults(t *testing.T) {
+	bo := Backoff{}.withDefaults()
+	if bo.Initial != DefaultBackoffInitial || bo.Max != DefaultBackoffMax {
+		t.Fatalf("defaults = %v/%v, want %v/%v",
+			bo.Initial, bo.Max, DefaultBackoffInitial, DefaultBackoffMax)
+	}
+	// A Max below Initial is nonsense; it must not make a shrinking schedule.
+	bo2 := Backoff{Initial: 10 * time.Second, Max: time.Second}.withDefaults()
+	if bo2.Max < bo2.Initial {
+		t.Fatalf("Max %v < Initial %v", bo2.Max, bo2.Initial)
+	}
+}
+
+// --- required collaborators ----------------------------------------------
+
+func TestSupervisorRequiresDialSetupAndDone(t *testing.T) {
+	tests := []struct {
+		name string
+		sup  *Supervisor[*fakeSess]
+	}{
+		{"nothing", &Supervisor[*fakeSess]{}},
+		{"no Setup", &Supervisor[*fakeSess]{
+			Dial: func(context.Context) (*fakeSess, error) { return newFakeSess(), nil },
+		}},
+		{"no Done", &Supervisor[*fakeSess]{
+			Dial:  func(context.Context) (*fakeSess, error) { return newFakeSess(), nil },
+			Setup: func(context.Context, *fakeSess) error { return nil },
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.sup.Run(context.Background())
+			if err == nil {
+				t.Fatal("Run succeeded with a missing collaborator")
+			}
+			if !strings.Contains(err.Error(), "required") {
+				t.Errorf("err = %v, want it to say what is required", err)
+			}
+		})
+	}
+}
+
+// --- the headline ---------------------------------------------------------
+
+// When the link dies the supervisor reconnects AND re-runs Setup, so
+// server-side subscriptions are re-established on the new session.
+func TestSupervisorReconnectsAndReRunsSetup(t *testing.T) {
+	var mu sync.Mutex
+	var dials, setups int
+	sessions := make(chan *fakeSess, 4)
+
+	reconnected := make(chan int, 1)
+	sup := wire(&Supervisor[*fakeSess]{
+		Clock:   clock.System(),
+		Backoff: fastBackoff(0),
+		Dial: func(context.Context) (*fakeSess, error) {
+			mu.Lock()
+			dials++
+			mu.Unlock()
+			s := newFakeSess()
+			sessions <- s
+			return s, nil
+		},
+		Setup: func(context.Context, *fakeSess) error {
+			mu.Lock()
+			setups++
+			mu.Unlock()
+			return nil
+		},
+		OnReconnected: func(attempt int, _ time.Duration) {
+			select {
+			case reconnected <- attempt:
+			default:
+			}
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runErr := make(chan error, 1)
+	go func() { runErr <- sup.Run(ctx) }()
+
+	first := <-sessions
+	first.kill(transport.ErrConnectionLost)
+
+	select {
+	case <-sessions: // the reconnect happened
+	case <-time.After(10 * time.Second):
+		t.Fatal("no reconnect after the session died")
+	}
+	select {
+	case <-reconnected:
+	case <-time.After(10 * time.Second):
+		t.Fatal("OnReconnected never fired")
+	}
+
+	cancel()
+	if err := <-runErr; err != nil {
+		t.Fatalf("Run after cancel = %v, want nil", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if dials < 2 || setups < 2 {
+		t.Errorf("dials=%d setups=%d, want at least 2 of each", dials, setups)
+	}
+	if setups != dials {
+		t.Errorf("Setup ran %d times for %d dials — it must run on every one",
+			setups, dials)
+	}
+}
+
+// OnLost carries the typed reason, so the gap is explained at the moment it
+// starts rather than after the backoff.
+func TestSupervisorOnLostCarriesTheReason(t *testing.T) {
+	lost := make(chan error, 1)
+	sessions := make(chan *fakeSess, 2)
+
+	sup := wire(&Supervisor[*fakeSess]{
+		Clock:   clock.System(),
+		Backoff: fastBackoff(0),
+		Dial: func(context.Context) (*fakeSess, error) {
+			s := newFakeSess()
+			sessions <- s
+			return s, nil
+		},
+		Setup:  func(context.Context, *fakeSess) error { return nil },
+		OnLost: func(err error) { lost <- err },
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = sup.Run(ctx) }()
+
+	(<-sessions).kill(transport.ErrIdleTimeout)
+	select {
+	case err := <-lost:
+		if !errors.Is(err, transport.ErrIdleTimeout) {
+			t.Errorf("OnLost got %v, want the idle-timeout reason", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("OnLost never fired")
+	}
+}
+
+// A connector with no Err function reports the reason as unknown rather than
+// panicking — several clients record no cause.
+func TestSupervisorToleratesNoErrFunc(t *testing.T) {
+	sessions := make(chan *fakeSess, 2)
+	lost := make(chan error, 1)
+
+	sup := &Supervisor[*fakeSess]{
+		Clock:   clock.System(),
+		Backoff: fastBackoff(0),
+		Dial: func(context.Context) (*fakeSess, error) {
+			s := newFakeSess()
+			sessions <- s
+			return s, nil
+		},
+		Setup:  func(context.Context, *fakeSess) error { return nil },
+		Done:   func(s *fakeSess) <-chan struct{} { return s.done },
+		OnLost: func(err error) { lost <- err },
+		// Err and Close deliberately nil.
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = sup.Run(ctx) }()
+
+	(<-sessions).kill(errors.New("ignored"))
+	select {
+	case err := <-lost:
+		if err != nil {
+			t.Errorf("OnLost got %v, want nil when the connector records no reason", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("OnLost never fired")
+	}
+}
+
+// --- failure paths --------------------------------------------------------
+
+// The initial connect is the operator's problem to see immediately — a bad
+// host or password must not disappear behind a backoff.
+func TestSupervisorInitialConnectFailureIsReturned(t *testing.T) {
+	want := errors.New("bad password")
+	sup := wire(&Supervisor[*fakeSess]{
+		Dial:  func(context.Context) (*fakeSess, error) { return nil, want },
+		Setup: func(context.Context, *fakeSess) error { return nil },
+	})
+	if err := sup.Run(context.Background()); !errors.Is(err, want) {
+		t.Fatalf("Run = %v, want %v", err, want)
+	}
+}
+
+// A finite attempt budget is honoured and reported as a typed
+// connection-lost error, so a CLI exits with the contract's runtime code.
+func TestSupervisorGivesUpAfterMaxAttempts(t *testing.T) {
+	var mu sync.Mutex
+	dials := 0
+	first := make(chan *fakeSess, 1)
+
+	sup := wire(&Supervisor[*fakeSess]{
+		Clock:   clock.System(),
+		Backoff: fastBackoff(3),
+		Dial: func(context.Context) (*fakeSess, error) {
+			mu.Lock()
+			dials++
+			n := dials
+			mu.Unlock()
+			if n == 1 {
+				s := newFakeSess()
+				first <- s
+				return s, nil
+			}
+			return nil, errors.New("still down")
+		},
+		Setup: func(context.Context, *fakeSess) error { return nil },
+	})
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- sup.Run(context.Background()) }()
+
+	(<-first).kill(transport.ErrConnectionLost)
+
+	select {
+	case err := <-runErr:
+		if !errors.Is(err, transport.ErrConnectionLost) {
+			t.Fatalf("Run = %v, want it to wrap transport.ErrConnectionLost", err)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("Run did not give up within the attempt budget")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if dials != 4 { // 1 initial + 3 attempts
+		t.Errorf("dials = %d, want 4 (initial + MaxAttempts=3)", dials)
+	}
+}
+
+// A Setup failure closes the fresh session, so a half-built one is never
+// handed back or leaked.
+func TestSupervisorClosesSessionWhenSetupFails(t *testing.T) {
+	sess := newFakeSess()
+	sup := wire(&Supervisor[*fakeSess]{
+		Dial:  func(context.Context) (*fakeSess, error) { return sess, nil },
+		Setup: func(context.Context, *fakeSess) error { return errors.New("subscribe refused") },
+	})
+	if err := sup.Run(context.Background()); err == nil {
+		t.Fatal("Run succeeded with a failing Setup")
+	}
+	if sess.closeCount() != 1 {
+		t.Errorf("session closed %d times, want 1", sess.closeCount())
+	}
+}
+
+// --- cancellation ---------------------------------------------------------
+
+// Cancelling a healthy session is an orderly stop, not a failure.
+func TestSupervisorCtxCancelIsOrderly(t *testing.T) {
+	sess := newFakeSess()
+	sup := wire(&Supervisor[*fakeSess]{
+		Dial:  func(context.Context) (*fakeSess, error) { return sess, nil },
+		Setup: func(context.Context, *fakeSess) error { return nil },
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runErr := make(chan error, 1)
+	go func() { runErr <- sup.Run(ctx) }()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-runErr:
+		if err != nil {
+			t.Fatalf("Run after cancel = %v, want nil", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run did not return after cancel")
+	}
+	if sess.closeCount() == 0 {
+		t.Error("cancel did not close the session")
+	}
+}
+
+// racedCtx models the one window this test is about: the operator cancels
+// between the select observing the session's death and the check that decides
+// whether it was death or a clean stop. Done never becomes ready — so the
+// select can only take the death branch — while Err already reports cancelled.
+//
+// Driving that with a real context and two goroutines makes the select a coin
+// toss between two ready channels, which is a flaky test AND flaky coverage.
+type racedCtx struct{ context.Context }
+
+func (racedCtx) Done() <-chan struct{} { return nil }
+func (racedCtx) Err() error            { return context.Canceled }
+
+// Closing a session marks it lost too, so a stop that races the death signal
+// must still be reported as orderly rather than as a connection failure.
+func TestSupervisorCancelObservedAfterSessionDeath(t *testing.T) {
+	sess := newFakeSess()
+	sess.kill(transport.ErrConnectionLost)
+
+	lost := false
+	sup := wire(&Supervisor[*fakeSess]{
+		Clock:   clock.System(),
+		Backoff: fastBackoff(0),
+		Dial:    func(context.Context) (*fakeSess, error) { return sess, nil },
+		Setup:   func(context.Context, *fakeSess) error { return nil },
+		OnLost:  func(error) { lost = true },
+	})
+
+	if err := sup.Run(racedCtx{context.Background()}); err != nil {
+		t.Fatalf("Run = %v, want nil — cancel makes this an orderly stop", err)
+	}
+	if lost {
+		t.Error("a cancelled run reported the session as lost")
+	}
+	if sess.closeCount() != 1 {
+		t.Errorf("session closed %d times, want 1", sess.closeCount())
+	}
+}
+
+// Cancelling while backing off is an orderly stop: Run returns nil rather
+// than a connection error.
+func TestSupervisorCancelDuringBackoff(t *testing.T) {
+	first := make(chan *fakeSess, 1)
+	var mu sync.Mutex
+	calls := 0
+
+	sup := wire(&Supervisor[*fakeSess]{
+		Clock:   clock.System(),
+		Backoff: Backoff{Initial: 5 * time.Second, Max: 5 * time.Second},
+		Dial: func(context.Context) (*fakeSess, error) {
+			mu.Lock()
+			calls++
+			n := calls
+			mu.Unlock()
+			if n == 1 {
+				s := newFakeSess()
+				first <- s
+				return s, nil
+			}
+			return nil, errors.New("still down")
+		},
+		Setup: func(context.Context, *fakeSess) error { return nil },
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runErr := make(chan error, 1)
+	go func() { runErr <- sup.Run(ctx) }()
+
+	(<-first).kill(transport.ErrConnectionLost)
+	time.Sleep(50 * time.Millisecond) // let it enter the backoff sleep
+	cancel()
+
+	select {
+	case err := <-runErr:
+		if err != nil {
+			t.Fatalf("Run = %v, want nil after cancel during backoff", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run did not return after cancel during backoff")
+	}
+}
+
+// Cancelling while a reconnect ATTEMPT is in flight is also orderly — the
+// dial fails because the context died, not because the peer is gone.
+func TestSupervisorCancelDuringReconnectAttempt(t *testing.T) {
+	first := make(chan *fakeSess, 1)
+	dialing := make(chan struct{}, 1)
+	var mu sync.Mutex
+	calls := 0
+
+	ctx, cancel := context.WithCancel(context.Background())
+	sup := wire(&Supervisor[*fakeSess]{
+		Clock:   clock.System(),
+		Backoff: fastBackoff(0),
+		Dial: func(c context.Context) (*fakeSess, error) {
+			mu.Lock()
+			calls++
+			n := calls
+			mu.Unlock()
+			if n == 1 {
+				s := newFakeSess()
+				first <- s
+				return s, nil
+			}
+			select {
+			case dialing <- struct{}{}:
+			default:
+			}
+			<-c.Done()
+			return nil, c.Err()
+		},
+		Setup: func(context.Context, *fakeSess) error { return nil },
+	})
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- sup.Run(ctx) }()
+
+	(<-first).kill(transport.ErrConnectionLost)
+	<-dialing
+	cancel()
+
+	select {
+	case err := <-runErr:
+		if err != nil {
+			t.Fatalf("Run = %v, want nil after cancel during a reconnect attempt", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run did not return")
+	}
+}
+
+// --- small pure helpers ---------------------------------------------------
+
+func TestSupervisorLogFallbacks(t *testing.T) {
+	// No logger at all -> a discard logger, never nil.
+	s := &Supervisor[*fakeSess]{}
+	if s.log() == nil {
+		t.Fatal("log() returned nil with no logger configured")
+	}
+	explicit := slog.New(slog.NewTextHandler(discard{}, nil))
+	s = &Supervisor[*fakeSess]{Logger: explicit}
+	if s.log() != explicit {
+		t.Fatal("log() ignored the Logger field")
+	}
+	// LoggerFn wins over Logger when it yields one.
+	fn := slog.New(slog.NewTextHandler(discard{}, nil))
+	s = &Supervisor[*fakeSess]{Logger: explicit, LoggerFn: func() *slog.Logger { return fn }}
+	if s.log() != fn {
+		t.Fatal("LoggerFn must take precedence over Logger")
+	}
+	// A LoggerFn that yields nil falls back to Logger.
+	s = &Supervisor[*fakeSess]{Logger: explicit, LoggerFn: func() *slog.Logger { return nil }}
+	if s.log() != explicit {
+		t.Fatal("a nil from LoggerFn must fall back to Logger")
+	}
+}
+
+func TestErrText(t *testing.T) {
+	if got := errText(nil); got != "unknown" {
+		t.Fatalf("errText(nil) = %q, want %q", got, "unknown")
+	}
+	if got := errText(errors.New("boom")); got != "boom" {
+		t.Fatalf("errText = %q, want %q", got, "boom")
+	}
+}
+
+func TestDiscardWriterAcceptsEverything(t *testing.T) {
+	n, err := discard{}.Write([]byte("anything"))
+	if err != nil || n != len("anything") {
+		t.Fatalf("Write = %d, %v", n, err)
+	}
+}

--- a/internal/emberplus/consumer/session.go
+++ b/internal/emberplus/consumer/session.go
@@ -56,6 +56,12 @@ type Session struct {
 	// before Connect via SetRecorder.
 	recorder *transport.Recorder
 
+	// dialer opens the TCP connection Connect establishes. Injected rather
+	// than built inline so the pipe is substitutable — a test supplies a
+	// fake, and a supervisor driving reconnect has something to ASK for a
+	// new connection. NewSession installs the shared transport.TCPDialer.
+	dialer transport.Dialer
+
 	// useLegacyGlow is set by the walker when the provider emits
 	// non-qualified Glow elements (DTD <2.10). Subscribe / Unsubscribe
 	// / SetValue must then emit the nested Node/Parameter chain form
@@ -184,6 +190,11 @@ func NewSession(logger *slog.Logger) *Session {
 		deadManThreshold:  30 * time.Second, // 3× keep-alive interval
 		invocations:       make(map[int32]chan *glow.InvocationResult),
 		dtdReady:          make(chan struct{}),
+		// Same 10 s connect bound as before. What the shared dialer adds is
+		// SO_KEEPALIVE: S101 has its own keep-alive at the framing layer,
+		// but that only covers a peer that is still speaking S101 — a
+		// half-open socket needs the OS probe underneath it.
+		dialer: transport.TCPDialer{Timeout: 10 * time.Second},
 	}
 }
 
@@ -305,8 +316,7 @@ func (s *Session) deliverInvocationResult(result *glow.InvocationResult) {
 // Connect dials the Ember+ provider and starts the read loop.
 func (s *Session) Connect(ctx context.Context, host string, port int) error {
 	addr := fmt.Sprintf("%s:%d", host, port)
-	d := net.Dialer{Timeout: 10 * time.Second}
-	conn, err := d.DialContext(ctx, "tcp", addr)
+	conn, err := s.dialer.DialContext(ctx, "tcp", addr)
 	if err != nil {
 		return WrapS101(fmt.Sprintf("connect %s", addr), err)
 	}

--- a/internal/emberplus/provider/server.go
+++ b/internal/emberplus/provider/server.go
@@ -139,7 +139,7 @@ func (s *server) acceptLoop(ctx context.Context, ln net.Listener) error {
 		// (a NAT or firewall drop with no RST) holds a goroutine and a
 		// socket here for ever. Applied in the accept loop rather than at
 		// bind time so ServeListener's injected listener gets it too.
-		_ = transport.ApplyListenOptions(conn, transport.ListenOptions{})
+		_ = transport.ApplySocketOptions(conn, transport.SocketOptions{})
 		sess := newSession(s, conn)
 		s.registerSession(sess)
 		go sess.run(ctx)

--- a/internal/osc/consumer/tcp_session.go
+++ b/internal/osc/consumer/tcp_session.go
@@ -81,7 +81,7 @@ func (s *tcpSession) IdleTimeout() time.Duration {
 func (s *tcpSession) listen(ctx context.Context, addr string) error {
 	// The listener applies SO_KEEPALIVE to every connection it accepts, so
 	// the accept loop below no longer carries its own copy of that policy.
-	l, err := transport.ListenTCP(ctx, "tcp", addr, transport.ListenOptions{
+	l, err := transport.ListenTCP(ctx, "tcp", addr, transport.SocketOptions{
 		KeepalivePeriod: tcpKeepalivePeriod,
 	})
 	if err != nil {

--- a/internal/osc/provider/tcp_dialer.go
+++ b/internal/osc/provider/tcp_dialer.go
@@ -1,6 +1,7 @@
 package osc
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"sync"
@@ -32,10 +33,23 @@ type tcpDialer struct {
 
 	mu    sync.Mutex
 	conns map[string]net.Conn
+
+	// dialer opens each outbound connection. Injected rather than calling
+	// net.Dial inline so the pipe is substitutable, and so SO_KEEPALIVE is
+	// applied by the shared dialer instead of by a separate call here.
+	dialer transport.Dialer
 }
 
 func newTCPDialer(f framerKind) *tcpDialer {
-	return &tcpDialer{framer: f, conns: map[string]net.Conn{}}
+	return &tcpDialer{
+		framer: f,
+		conns:  map[string]net.Conn{},
+		dialer: transport.TCPDialer{
+			Options: transport.SocketOptions{
+				KeepalivePeriod: DefaultTCPKeepalivePeriod,
+			},
+		},
+	}
 }
 
 func destKey(host string, port int) string {
@@ -49,11 +63,10 @@ func (d *tcpDialer) dial(host string, port int) (net.Conn, error) {
 	if c, ok := d.conns[key]; ok {
 		return c, nil
 	}
-	c, err := net.Dial("tcp", key)
+	c, err := d.dialer.DialContext(context.Background(), "tcp", key)
 	if err != nil {
 		return nil, fmt.Errorf("osc tcp dial %s: %w", key, err)
 	}
-	_ = transport.ApplyTCPKeepalive(c, DefaultTCPKeepalivePeriod)
 	d.conns[key] = c
 	return c, nil
 }

--- a/internal/probel-sw02p/consumer/session_done.go
+++ b/internal/probel-sw02p/consumer/session_done.go
@@ -1,0 +1,28 @@
+package probelsw02p
+
+// SessionDone — the death signal, exposed at the Plugin so a supervisor can
+// wait on it without reaching into the codec client.
+//
+// codec.Client closes readerDone when its reader goroutine exits: a peer
+// close, an I/O error, or the keep-alive poll's idle deadline firing. Until
+// now nothing acted on it — the watch verb detected death and kept running,
+// connected to nothing.
+
+import "dhs/internal/consumer"
+
+// SessionDone implements consumer.SessionDoneAccessor.
+//
+// Returns nil when there is no client yet (not connected), which blocks
+// forever in a select — the correct "this never fires" answer.
+func (p *Plugin) SessionDone() <-chan struct{} {
+	p.mu.Lock()
+	c := p.client
+	p.mu.Unlock()
+	if c == nil {
+		return nil
+	}
+	return c.ReaderDone()
+}
+
+// Compile-time proof the Plugin satisfies the optional capability.
+var _ consumer.SessionDoneAccessor = (*Plugin)(nil)

--- a/internal/probel-sw02p/consumer/session_done_test.go
+++ b/internal/probel-sw02p/consumer/session_done_test.go
@@ -1,0 +1,39 @@
+package probelsw02p
+
+import (
+	"net"
+	"testing"
+
+	"dhs/internal/probel-sw02p/codec"
+)
+
+// Not connected: nil, which blocks forever in a select — the correct
+// "this never fires" answer rather than a channel that fires immediately.
+func TestSessionDoneNilWhenNotConnected(t *testing.T) {
+	if ch := (&Plugin{}).SessionDone(); ch != nil {
+		t.Fatal("SessionDone on an unconnected plugin returned a live channel")
+	}
+}
+
+// Connected: the channel closes when the reader goroutine exits, which is
+// the signal a supervisor blocks on to drive reconnection.
+func TestSessionDoneClosesWhenTheReaderExits(t *testing.T) {
+	ours, theirs := net.Pipe()
+	t.Cleanup(func() { _ = theirs.Close() })
+
+	cli := codec.NewClientFromConn(ours, nil, codec.ClientConfig{})
+	p := &Plugin{client: cli}
+
+	done := p.SessionDone()
+	if done == nil {
+		t.Fatal("SessionDone returned nil for a connected plugin")
+	}
+	select {
+	case <-done:
+		t.Fatal("SessionDone fired while the session was still alive")
+	default:
+	}
+
+	_ = cli.Close()
+	<-done // closes, or the test times out — which is the failure we want
+}

--- a/internal/probel-sw02p/provider/server.go
+++ b/internal/probel-sw02p/provider/server.go
@@ -229,7 +229,7 @@ func (s *server) acceptLoop(ctx context.Context, ln net.Listener) error {
 		// (a NAT or firewall drop with no RST) holds a goroutine and a
 		// socket here for ever. Applied in the accept loop rather than at
 		// bind time so ServeListener's injected listener gets it too.
-		_ = transport.ApplyListenOptions(conn, transport.ListenOptions{})
+		_ = transport.ApplySocketOptions(conn, transport.SocketOptions{})
 		sess := newSession(s, conn)
 		s.mu.Lock()
 		s.sessions[sess] = struct{}{}

--- a/internal/probel-sw08p/consumer/session_done.go
+++ b/internal/probel-sw08p/consumer/session_done.go
@@ -1,0 +1,28 @@
+package probelsw08p
+
+// SessionDone — the death signal, exposed at the Plugin so a supervisor can
+// wait on it without reaching into the codec client.
+//
+// codec.Client closes readerDone when its reader goroutine exits: a peer
+// close, an I/O error, or the keep-alive poll's idle deadline firing. Until
+// now nothing acted on it — the watch verb detected death and kept running,
+// connected to nothing.
+
+import "dhs/internal/consumer"
+
+// SessionDone implements consumer.SessionDoneAccessor.
+//
+// Returns nil when there is no client yet (not connected), which blocks
+// forever in a select — the correct "this never fires" answer.
+func (p *Plugin) SessionDone() <-chan struct{} {
+	p.mu.Lock()
+	c := p.client
+	p.mu.Unlock()
+	if c == nil {
+		return nil
+	}
+	return c.ReaderDone()
+}
+
+// Compile-time proof the Plugin satisfies the optional capability.
+var _ consumer.SessionDoneAccessor = (*Plugin)(nil)

--- a/internal/probel-sw08p/consumer/session_done_test.go
+++ b/internal/probel-sw08p/consumer/session_done_test.go
@@ -1,0 +1,39 @@
+package probelsw08p
+
+import (
+	"net"
+	"testing"
+
+	"dhs/internal/probel-sw08p/codec"
+)
+
+// Not connected: nil, which blocks forever in a select — the correct
+// "this never fires" answer rather than a channel that fires immediately.
+func TestSessionDoneNilWhenNotConnected(t *testing.T) {
+	if ch := (&Plugin{}).SessionDone(); ch != nil {
+		t.Fatal("SessionDone on an unconnected plugin returned a live channel")
+	}
+}
+
+// Connected: the channel closes when the reader goroutine exits, which is
+// the signal a supervisor blocks on to drive reconnection.
+func TestSessionDoneClosesWhenTheReaderExits(t *testing.T) {
+	ours, theirs := net.Pipe()
+	t.Cleanup(func() { _ = theirs.Close() })
+
+	cli := codec.NewClientFromConn(ours, nil, codec.ClientConfig{})
+	p := &Plugin{client: cli}
+
+	done := p.SessionDone()
+	if done == nil {
+		t.Fatal("SessionDone returned nil for a connected plugin")
+	}
+	select {
+	case <-done:
+		t.Fatal("SessionDone fired while the session was still alive")
+	default:
+	}
+
+	_ = cli.Close()
+	<-done // closes, or the test times out — which is the failure we want
+}

--- a/internal/probel-sw08p/provider/server.go
+++ b/internal/probel-sw08p/provider/server.go
@@ -199,7 +199,7 @@ func (s *server) acceptLoop(ctx context.Context, ln net.Listener) error {
 		// that never implements cmd 09 still needs a dead-socket detector.
 		// Applied in the accept loop rather than at bind time so an
 		// injected listener (listenHook) gets it too.
-		_ = transport.ApplyListenOptions(conn, transport.ListenOptions{})
+		_ = transport.ApplySocketOptions(conn, transport.SocketOptions{})
 		sess := newSession(s, conn)
 		s.mu.Lock()
 		s.sessions[sess] = struct{}{}

--- a/internal/transport/dial.go
+++ b/internal/transport/dial.go
@@ -1,0 +1,62 @@
+package transport
+
+// The dial seam — the thing a connector takes instead of opening its own pipe.
+//
+// Architecture Principle #2 says connectors take transport, logger, tree and
+// clock as constructor parameters. On the LISTEN side that is now true. On the
+// DIAL side it was not: every consumer built a net.Dialer inside the function
+// that used it, which has two consequences.
+//
+// The first is duplication. A connector that dials for itself also decides for
+// itself whether to set SO_KEEPALIVE or Nagle, and mostly decided not to — the
+// same divergence the accept paths had.
+//
+// The second is that reconnect has nowhere to live. A supervisor that wants to
+// re-establish a lost session needs to ask something for a NEW connection, and
+// a package-local `var d net.Dialer` is not something you can ask. That is why
+// acp2 and cerebrum-nb each grew their own reconnect loop: only the connector
+// knew how to make its own pipe. With the dialer injected, reconnect is
+// protocol-agnostic — dial, set up, wait for death, back off — and there is
+// one of it instead of one per protocol.
+//
+// Deliberately the same method set as *net.Dialer, so the stdlib type
+// satisfies it with no adapter and no behaviour change at any call site that
+// keeps the default.
+
+import (
+	"context"
+	"net"
+	"time"
+)
+
+// Dialer opens one connection. *net.Dialer satisfies it as-is.
+type Dialer interface {
+	DialContext(ctx context.Context, network, address string) (net.Conn, error)
+}
+
+// TCPDialer is the default Dialer: it dials, then applies the shared
+// socket policy — the same ApplySocketOptions the accept paths use, so a
+// dialled connection and an accepted one end up with the same options.
+type TCPDialer struct {
+	// Timeout bounds the connect handshake. 0 leaves it to the context.
+	Timeout time.Duration
+
+	// Options are applied to every connection opened. The zero value means
+	// keepalive on at DefaultTCPKeepalivePeriod, Nagle untouched.
+	Options SocketOptions
+}
+
+// DialContext implements Dialer.
+//
+// A socket option that fails to apply does not fail the dial, for the same
+// reason it does not fail an Accept: the connection is usable either way, and
+// refusing it would trade a detectable problem for an outright outage.
+func (d TCPDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	nd := net.Dialer{Timeout: d.Timeout}
+	conn, err := nd.DialContext(ctx, network, address)
+	if err != nil {
+		return nil, err
+	}
+	_ = ApplySocketOptions(conn, d.Options)
+	return conn, nil
+}

--- a/internal/transport/dial_test.go
+++ b/internal/transport/dial_test.go
@@ -1,0 +1,72 @@
+package transport
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+)
+
+// The seam is only worth having if the stdlib type satisfies it with no
+// adapter — that is what makes injecting it a no-op for existing callers.
+func TestNetDialerSatisfiesDialer(t *testing.T) {
+	var _ Dialer = &net.Dialer{}
+	var _ Dialer = TCPDialer{}
+}
+
+func TestTCPDialerDialsAndAppliesOptions(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	d := TCPDialer{
+		Timeout: 5 * time.Second,
+		Options: SocketOptions{KeepalivePeriod: 5 * time.Second, NoDelay: true},
+	}
+	conn, err := d.DialContext(context.Background(), "tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("DialContext: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+	if _, ok := conn.(*net.TCPConn); !ok {
+		t.Fatalf("DialContext returned %T, want *net.TCPConn", conn)
+	}
+}
+
+func TestTCPDialerReportsDialFailure(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	_ = ln.Close() // nothing is listening now
+
+	_, err = TCPDialer{}.DialContext(context.Background(), "tcp", addr)
+	if err == nil {
+		t.Fatal("DialContext to a closed port returned nil")
+	}
+}
+
+// A failed setsockopt must not fail the dial, mirroring Accept.
+func TestTCPDialerSurvivesOptionFailure(t *testing.T) {
+	orig := applySocketOptions
+	defer func() { applySocketOptions = orig }()
+	applySocketOptions = func(net.Conn, SocketOptions) error {
+		return errors.New("boom")
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	conn, err := TCPDialer{}.DialContext(context.Background(), "tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("DialContext failed after an option failure: %v", err)
+	}
+	_ = conn.Close()
+}

--- a/internal/transport/listen.go
+++ b/internal/transport/listen.go
@@ -44,12 +44,12 @@ const DefaultTCPKeepalivePeriod = 30 * time.Second
 // from 0, which means "use the default". Mirrors consumer.DisableInterval.
 const DisableKeepalive = -1 * time.Nanosecond
 
-// ListenOptions are the socket options applied to every connection a
+// SocketOptions are the socket options applied to every connection a
 // Listener accepts. The zero value is the sensible default: keepalive on at
 // DefaultTCPKeepalivePeriod, Nagle left alone.
 //
 // Named to sit beside ws.DialOptions / ws.AcceptOptions and TLSOptions.
-type ListenOptions struct {
+type SocketOptions struct {
 	// KeepalivePeriod sets SO_KEEPALIVE. 0 ⇒ DefaultTCPKeepalivePeriod;
 	// DisableKeepalive (or any negative value) ⇒ off.
 	KeepalivePeriod time.Duration
@@ -89,7 +89,7 @@ func ApplyTCPKeepalive(c net.Conn, period time.Duration) error {
 	return nil
 }
 
-// ApplyListenOptions applies opts to one accepted or dialled connection.
+// ApplySocketOptions applies opts to one accepted or dialled connection.
 // Exported so a connector that already owns its listener — acp1's servers
 // need *net.TCPConn from AcceptTCP — can still share the socket policy
 // without giving up its accept loop.
@@ -97,7 +97,7 @@ func ApplyTCPKeepalive(c net.Conn, period time.Duration) error {
 // Errors are returned, not logged: setting an option on a socket the peer
 // has already reset is not worth failing a session over, and only the
 // caller knows whether it cares.
-func ApplyListenOptions(c net.Conn, opts ListenOptions) error {
+func ApplySocketOptions(c net.Conn, opts SocketOptions) error {
 	if err := ApplyTCPKeepalive(c, opts.KeepalivePeriod); err != nil {
 		return err
 	}
@@ -120,26 +120,26 @@ var (
 	tcpSetKeepAlive       = func(tc *net.TCPConn, on bool) error { return tc.SetKeepAlive(on) }
 	tcpSetKeepAlivePeriod = func(tc *net.TCPConn, d time.Duration) error { return tc.SetKeepAlivePeriod(d) }
 	tcpSetNoDelay         = func(tc *net.TCPConn, on bool) error { return tc.SetNoDelay(on) }
-	applyListenOptions    = ApplyListenOptions
+	applySocketOptions    = ApplySocketOptions
 )
 
-// Listener is a net.Listener whose Accept has already applied ListenOptions
+// Listener is a net.Listener whose Accept has already applied SocketOptions
 // to the connection it returns. Callers keep their own accept loop and their
 // own session handling; only the socket policy moves here.
 //
 // Use this where the connector OWNS its bind (tsl and osc consumers). Where a
 // listener can be handed in from outside — the ServeListener / listenHook
-// seams on the emberplus and probel providers — call ApplyListenOptions in
+// seams on the emberplus and probel providers — call ApplySocketOptions in
 // the accept loop instead, so an injected listener gets the same policy.
 type Listener struct {
 	net.Listener
-	opts ListenOptions
+	opts SocketOptions
 }
 
 // ListenTCP binds addr and returns a Listener that applies opts to every
 // accepted connection. network is "tcp", "tcp4" or "tcp6" — connectors that
 // bind IPv4-only (acp1, acp2) pass "tcp4" and keep that behaviour.
-func ListenTCP(ctx context.Context, network, addr string, opts ListenOptions) (*Listener, error) {
+func ListenTCP(ctx context.Context, network, addr string, opts SocketOptions) (*Listener, error) {
 	var lc net.ListenConfig
 	ln, err := lc.Listen(ctx, network, addr)
 	if err != nil {
@@ -158,6 +158,6 @@ func (l *Listener) Accept() (net.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	_ = applyListenOptions(c, l.opts)
+	_ = applySocketOptions(c, l.opts)
 	return c, nil
 }

--- a/internal/transport/listen_test.go
+++ b/internal/transport/listen_test.go
@@ -92,7 +92,7 @@ func TestApplyTCPKeepaliveOnClosedSocket(t *testing.T) {
 	}
 }
 
-func TestApplyListenOptionsOnClosedSocket(t *testing.T) {
+func TestApplySocketOptionsOnClosedSocket(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
@@ -105,7 +105,7 @@ func TestApplyListenOptionsOnClosedSocket(t *testing.T) {
 	_ = c.Close()
 
 	// Keepalive is the first option applied, so it is the arm that fails.
-	if err := ApplyListenOptions(c, ListenOptions{}); !errors.Is(err, ErrListenFailed) {
+	if err := ApplySocketOptions(c, SocketOptions{}); !errors.Is(err, ErrListenFailed) {
 		t.Errorf("err = %v, want ErrListenFailed", err)
 	}
 }
@@ -134,7 +134,7 @@ func TestApplyTCPKeepalivePeriodError(t *testing.T) {
 // The NoDelay failure arm, reached through the seam. On a real socket it is
 // unreachable: any fd state that fails SetNoDelay also fails SetKeepAlive,
 // and ApplyTCPKeepalive returns first.
-func TestApplyListenOptionsNoDelayError(t *testing.T) {
+func TestApplySocketOptionsNoDelayError(t *testing.T) {
 	orig := tcpSetNoDelay
 	defer func() { tcpSetNoDelay = orig }()
 	tcpSetNoDelay = func(*net.TCPConn, bool) error { return errors.New("boom") }
@@ -150,21 +150,21 @@ func TestApplyListenOptionsNoDelayError(t *testing.T) {
 	}
 	defer func() { _ = c.Close() }()
 
-	err = ApplyListenOptions(c, ListenOptions{NoDelay: true})
+	err = ApplySocketOptions(c, SocketOptions{NoDelay: true})
 	if err == nil {
-		t.Fatal("ApplyListenOptions returned nil with a failing SetNoDelay")
+		t.Fatal("ApplySocketOptions returned nil with a failing SetNoDelay")
 	}
 	if !errors.Is(err, ErrListenFailed) || !strings.Contains(err.Error(), "nodelay") {
 		t.Errorf("err = %v, want ErrListenFailed naming nodelay", err)
 	}
 }
 
-func TestApplyListenOptionsNoDelayOnPipe(t *testing.T) {
+func TestApplySocketOptionsNoDelayOnPipe(t *testing.T) {
 	c, other := net.Pipe()
 	defer func() { _ = c.Close(); _ = other.Close() }()
 
-	if err := ApplyListenOptions(c, ListenOptions{NoDelay: true}); err != nil {
-		t.Errorf("ApplyListenOptions(pipe) = %v, want nil", err)
+	if err := ApplySocketOptions(c, SocketOptions{NoDelay: true}); err != nil {
+		t.Errorf("ApplySocketOptions(pipe) = %v, want nil", err)
 	}
 }
 
@@ -172,7 +172,7 @@ func TestApplyListenOptionsNoDelayOnPipe(t *testing.T) {
 // the socket policy, without writing the setsockopt calls itself.
 func TestListenTCPAppliesOptionsOnAccept(t *testing.T) {
 	ln, err := ListenTCP(context.Background(), "tcp", "127.0.0.1:0",
-		ListenOptions{KeepalivePeriod: 5 * time.Second, NoDelay: true})
+		SocketOptions{KeepalivePeriod: 5 * time.Second, NoDelay: true})
 	if err != nil {
 		t.Fatalf("ListenTCP: %v", err)
 	}
@@ -198,13 +198,13 @@ func TestListenTCPAppliesOptionsOnAccept(t *testing.T) {
 // because the kernel declined a keepalive tweak would trade a detectable
 // problem for an outright outage.
 func TestListenTCPAcceptSurvivesOptionFailure(t *testing.T) {
-	orig := applyListenOptions
-	defer func() { applyListenOptions = orig }()
-	applyListenOptions = func(net.Conn, ListenOptions) error {
+	orig := applySocketOptions
+	defer func() { applySocketOptions = orig }()
+	applySocketOptions = func(net.Conn, SocketOptions) error {
 		return errors.New("boom")
 	}
 
-	ln, err := ListenTCP(context.Background(), "tcp", "127.0.0.1:0", ListenOptions{})
+	ln, err := ListenTCP(context.Background(), "tcp", "127.0.0.1:0", SocketOptions{})
 	if err != nil {
 		t.Fatalf("ListenTCP: %v", err)
 	}
@@ -224,7 +224,7 @@ func TestListenTCPAcceptSurvivesOptionFailure(t *testing.T) {
 }
 
 func TestListenTCPAcceptPropagatesAcceptError(t *testing.T) {
-	ln, err := ListenTCP(context.Background(), "tcp", "127.0.0.1:0", ListenOptions{})
+	ln, err := ListenTCP(context.Background(), "tcp", "127.0.0.1:0", SocketOptions{})
 	if err != nil {
 		t.Fatalf("ListenTCP: %v", err)
 	}
@@ -237,7 +237,7 @@ func TestListenTCPAcceptPropagatesAcceptError(t *testing.T) {
 
 func TestListenTCPBindError(t *testing.T) {
 	// Port 1 on a non-local address cannot be bound.
-	_, err := ListenTCP(context.Background(), "tcp", "198.51.100.1:1", ListenOptions{})
+	_, err := ListenTCP(context.Background(), "tcp", "198.51.100.1:1", SocketOptions{})
 	if err == nil {
 		t.Fatal("ListenTCP succeeded on an unbindable address")
 	}

--- a/internal/transport/ws/client.go
+++ b/internal/transport/ws/client.go
@@ -25,8 +25,23 @@ type DialOptions struct {
 	// MaxPayload caps incoming frame size. 0 means DefaultMaxPayload.
 	MaxPayload int64
 
-	// Dialer overrides the underlying net.Dialer (useful for tests).
-	Dialer *net.Dialer
+	// Dialer opens the TCP connection the upgrade runs over. nil means a
+	// plain net.Dialer.
+	Dialer Dialer
+}
+
+// Dialer opens one connection. *net.Dialer satisfies it, and so does
+// transport.TCPDialer — the interface is declared here rather than imported
+// because this package stays stdlib-only so it remains lift-ready (doc.go).
+// Go interfaces are structural, so the two are interchangeable at the call
+// site without either package knowing about the other.
+//
+// It was *net.Dialer, which meant the only substitution possible was another
+// real dialer: you could change the timeout but you could not hand the
+// upgrade a pipe. The handshake was therefore only testable against a live
+// listener.
+type Dialer interface {
+	DialContext(ctx context.Context, network, address string) (net.Conn, error)
 }
 
 // Dial connects to urlStr (ws:// or wss://), performs the RFC 6455

--- a/internal/transport/ws/dialer_injection_test.go
+++ b/internal/transport/ws/dialer_injection_test.go
@@ -1,0 +1,116 @@
+package ws
+
+// The payoff for widening DialOptions.Dialer to an interface: the RFC 6455
+// upgrade now runs over an injected pipe, with no listener and no port.
+//
+// While the field was *net.Dialer the only substitution possible was another
+// real dialer — you could change the timeout, but you could not hand the
+// handshake a connection — so every handshake test needed a live socket.
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// pipeDialer hands back one end of a net.Pipe instead of opening a socket.
+type pipeDialer struct {
+	conn    net.Conn
+	err     error
+	network string
+	address string
+}
+
+func (d *pipeDialer) DialContext(_ context.Context, network, address string) (net.Conn, error) {
+	d.network, d.address = network, address
+	if d.err != nil {
+		return nil, d.err
+	}
+	return d.conn, nil
+}
+
+// serveUpgrade answers one RFC 6455 upgrade on conn, then returns so the
+// caller can drive frames over the same pipe.
+func serveUpgrade(t *testing.T, conn net.Conn) {
+	t.Helper()
+	br := bufio.NewReader(conn)
+	req, err := http.ReadRequest(br)
+	if err != nil {
+		t.Errorf("read upgrade request: %v", err)
+		return
+	}
+	accept := computeAccept(req.Header.Get("Sec-WebSocket-Key"))
+	_, _ = conn.Write([]byte(
+		"HTTP/1.1 101 Switching Protocols\r\n" +
+			"Upgrade: websocket\r\n" +
+			"Connection: Upgrade\r\n" +
+			"Sec-WebSocket-Accept: " + accept + "\r\n\r\n"))
+}
+
+func TestDialUsesTheInjectedDialer(t *testing.T) {
+	ours, theirs := net.Pipe()
+	t.Cleanup(func() { _ = theirs.Close() })
+
+	// net.Pipe is synchronous and unbuffered, so the far end must keep
+	// reading after the handshake — otherwise the client's Close frame has
+	// nobody to write to and blocks for ever.
+	handshook := make(chan struct{})
+	go func() {
+		serveUpgrade(t, theirs)
+		close(handshook)
+		_, _ = io.Copy(io.Discard, theirs)
+	}()
+
+	d := &pipeDialer{conn: ours}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := Dial(ctx, "ws://10.6.250.5:40009/", &DialOptions{Dialer: d})
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer func() { _ = conn.Close(1000, "") }()
+	<-handshook
+
+	if d.network != "tcp" {
+		t.Errorf("dialed network %q, want tcp", d.network)
+	}
+	if d.address != "10.6.250.5:40009" {
+		t.Errorf("dialed address %q, want 10.6.250.5:40009", d.address)
+	}
+	// A client-side connection must mask its frames (RFC 6455 §5.3).
+	if !conn.clientSide {
+		t.Error("Dial produced a connection that does not consider itself the client")
+	}
+}
+
+// The default port is filled in from the scheme when the URL omits one —
+// checked here because the injected dialer records exactly what was asked
+// for, which a real socket cannot report as cleanly.
+func TestDialDefaultPortsReachTheDialer(t *testing.T) {
+	tests := []struct {
+		url  string
+		want string
+	}{
+		{"ws://cerebrum/", "cerebrum:80"},
+		{"wss://cerebrum/", "cerebrum:443"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.url, func(t *testing.T) {
+			// The dial itself fails; the address it asked for is the point.
+			d := &pipeDialer{err: errors.New("no route")}
+			_, err := Dial(context.Background(), tc.url, &DialOptions{Dialer: d})
+			if err == nil {
+				t.Fatal("Dial succeeded with a failing dialer")
+			}
+			if d.address != tc.want {
+				t.Errorf("dialed %q, want %q", d.address, tc.want)
+			}
+		})
+	}
+}

--- a/internal/tsl/consumer/tcp_session.go
+++ b/internal/tsl/consumer/tcp_session.go
@@ -67,7 +67,7 @@ func (s *tcpSession) IdleTimeout() time.Duration {
 func (s *tcpSession) listen(ctx context.Context, addr string) error {
 	// The listener applies SO_KEEPALIVE to every connection it accepts, so
 	// the accept loop below no longer carries its own copy of that policy.
-	l, err := transport.ListenTCP(ctx, "tcp", addr, transport.ListenOptions{
+	l, err := transport.ListenTCP(ctx, "tcp", addr, transport.SocketOptions{
 		KeepalivePeriod: tcpKeepalivePeriod,
 	})
 	if err != nil {

--- a/internal/tsl/provider/tcp_dialer.go
+++ b/internal/tsl/provider/tcp_dialer.go
@@ -1,13 +1,14 @@
 package tsl
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"sync"
 	"time"
 
-	"dhs/internal/tsl/codec"
 	"dhs/internal/transport"
+	"dhs/internal/tsl/codec"
 )
 
 // DefaultTCPKeepalivePeriod is the OS-layer SO_KEEPALIVE period applied
@@ -25,10 +26,22 @@ const DefaultTCPKeepalivePeriod = 30 * time.Second
 type tcpDialer struct {
 	mu    sync.Mutex
 	conns map[string]net.Conn // keyed by "host:port"
+
+	// dialer opens each outbound connection. Injected rather than calling
+	// net.Dial inline so the pipe is substitutable, and so SO_KEEPALIVE is
+	// applied by the shared dialer instead of by a separate call here.
+	dialer transport.Dialer
 }
 
 func newTCPDialer() *tcpDialer {
-	return &tcpDialer{conns: map[string]net.Conn{}}
+	return &tcpDialer{
+		conns: map[string]net.Conn{},
+		dialer: transport.TCPDialer{
+			Options: transport.SocketOptions{
+				KeepalivePeriod: DefaultTCPKeepalivePeriod,
+			},
+		},
+	}
 }
 
 // destKey formats a dest into the conns map key.
@@ -44,11 +57,10 @@ func (d *tcpDialer) dial(host string, port int) (net.Conn, error) {
 	if c, ok := d.conns[key]; ok {
 		return c, nil
 	}
-	c, err := net.Dial("tcp", key)
+	c, err := d.dialer.DialContext(context.Background(), "tcp", key)
 	if err != nil {
 		return nil, fmt.Errorf("tsl v5.0 TCP dial %s: %w", key, err)
 	}
-	_ = transport.ApplyTCPKeepalive(c, DefaultTCPKeepalivePeriod)
 	d.conns[key] = c
 	return c, nil
 }


### PR DESCRIPTION
Separation of concerns for the transport, with the transport injected.

Architecture Principle #2 says connectors take transport, logger, tree and
clock as constructor parameters. That was true on the listen side and not on
the dial side: every consumer built a `net.Dialer` inside the function that
used it.

That cost two things. A connector that dials for itself also decides for
itself whether to set `SO_KEEPALIVE` or Nagle, and mostly decided not to.
And reconnect had nowhere to live — a supervisor needs to ask *something*
for a new connection, and a package-local `var d net.Dialer` is not something
you can ask. That is why acp2 and cerebrum-nb each grew their own reconnect
loop.

## What changed

| connector | before | after |
|---|---|---|
| acp1 UDP / TCP-direct | already `transport.DialUDP` / `DialTCP` | unchanged |
| acp1 AN2 | inline `net.Dialer` + `conn.(*net.TCPConn)` | injected `transport.Dialer` |
| acp2 | inline `net.Dialer` | injected, default in `NewSession` |
| emberplus | inline `net.Dialer{Timeout: 10s}` | injected, default in `NewSession` |
| osc / tsl producer | `net.Dial` + separate `ApplyTCPKeepalive` | injected `TCPDialer` (keepalive call drops out) |
| amwa MQTT | inline `net.Dialer` in `session()` | injected |
| ws (cerebrum-nb) | `DialOptions.Dialer *net.Dialer` | widened to an interface |

## The narrowing was the actual blocker

`AN2Client.conn` was `*net.TCPConn` and `ws.DialOptions.Dialer` was
`*net.Dialer` — both narrower than the code needed. `AN2Client` only ever
calls `Read` / `Write` / `Close` / `SetWriteDeadline`. That narrowing forced
`connectAN2` to type-assert a dialer's result, which is exactly what made it
un-injectable. Widening both to interfaces is most of this diff.

`ws.Dialer` is declared in `ws` rather than imported from `transport`,
because that package stays stdlib-only so it remains lift-ready. Go
interfaces are structural, so the two are interchangeable at the call site
without either package importing the other, and `*net.Dialer` still
satisfies it.

## Naming

Taken from what the lib already uses, not coined here:

- `Dialer` — the stdlib's own name
- `TCPDialer` — joins `TCPConn`, `DialTCP`, `ListenTCP`
- `SocketOptions` — the lib's word for socket options (`sockopt_unix.go`,
  `sockopt_windows.go`, `SetSocketReuseAddr`, `SetSocketBroadcast`)

`SocketOptions` renames the `ListenOptions` added earlier on this stack. The
type now serves both directions — `ListenTCP` applies it on accept,
`TCPDialer` on dial — so naming it after the listen half had become wrong.

## Behaviour change, deliberate

These sessions now get `SO_KEEPALIVE`, which none of them set: acp1 AN2,
acp2, emberplus, MQTT. Same fix as the provider-side commit on the branch
below. Nagle stays off for acp1/acp2; emberplus and MQTT keep their 10 s
connect bounds. Ember+ has an S101 keep-alive and MQTT has PINGREQ, but each
only detects a peer still speaking that protocol — a half-open socket needs
the OS probe underneath it.

## Left alone, each for a reason

- `acp1/consumer/discover.go` — broadcast socket with a `Control` hook for
  `SO_BROADCAST`; a different socket, not a session pipe
- `acp1` + `acp2` `session_health.go` — `probeReachable`, a one-shot SYN test
  that closes immediately
- `acp1/provider/admin.go` — already has an injectable `dial` field
- `amwa/session/dnssd` — unicast DNS query
- `cmd/dhs/syslog_udp.go` — the log sink, CLI layer
- `probel-sw02p` + `sw08p` `codec/` — stdlib-only, must never import `dhs/*`
  (ADR-0006)
- cerebrum-nb — reconnect already injects one level up via
  `Supervisor.Dial func(ctx) (*Session, error)`; a dialer field below it
  would be two seams for one job

## Proof rather than promise

`connectAN2` and the full RFC 6455 upgrade now both run against an injected
`net.Pipe` — no socket, no port, no listener. Neither was testable that way
before, and it is the same substitution a reconnect supervisor makes.

## Gate

- suite 89 packages ok / 0 fail
- every floored package still at 100% (`internal/transport/ws`,
  `internal/acp1/*`, `internal/acp2/*`, `internal/emberplus/*`,
  `internal/osc/*`, `internal/tsl/*`)
- `go vet` + `golangci-lint` clean on every commit (pre-commit hook)
- `dial.go` 100% by function

Stacked on #991. Kept on its own branch and deliberately small (+502/-60,
22 files) after #989 reached 10k lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
