### PR TITLE
feat(watch): recover the session for every protocol that can report death

### DIFF
--- a/cmd/dhs/cmd_watch.go
+++ b/cmd/dhs/cmd_watch.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"dhs/internal/consumer"
 	"dhs/internal/datastore"
@@ -42,6 +43,19 @@ import (
 // present slot at connect time. This caused walk-storm latency and
 // surprised operators who only wanted frame-status. New default is no
 // walks; opt in via --slot, --slots, or --auto-walk-on-plug.
+// watchCanRecover reports whether this plugin can tell us its session died,
+// which is the one thing recovery cannot be built without.
+//
+// A nil channel means "no session to lose" rather than "not implemented":
+// ACP1 over UDP is connectionless, so silence from the device carries no
+// liveness information and there is nothing to reconnect. Treating that as
+// recoverable would give the operator a watcher that reconnects a socket
+// that never broke.
+func watchCanRecover(plug consumer.Protocol) bool {
+	d, ok := plug.(consumer.SessionDoneAccessor)
+	return ok && d.SessionDone() != nil
+}
+
 func runWatch(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("watch", flag.ExitOnError)
 	fs.Usage = verbUsageFn(fs, helpWatch) // #751 G5: -h = rich help + all flags
@@ -212,27 +226,84 @@ func runWatch(ctx context.Context, args []string) error {
 		Path: *pathFilter,
 	}
 
-	// Apply Ember+ wildcard-subscribe filters (--path / --no-streams /
-	// --streams-only) BEFORE Subscribe registers the wildcard. Optional
-	// capability — plugins that don't satisfy the interface (ACP1/ACP2,
-	// Probel, …) silently ignore the flags. No protocol-name compare.
-	applyWildcardFilter(plug, *pathFilter, *noStreams, *streamsOnly)
-
 	// Subscribe. The plugin pushes decoded Event values into our channel
 	// via the callback; we print them from the main goroutine so output
 	// is serialised cleanly with Ctrl-C handling.
 	events := make(chan consumer.Event, 128)
-	if err := plug.Subscribe(req, func(ev consumer.Event) {
-		select {
-		case events <- ev:
-		default:
-			// Drop on full buffer — better than blocking the receive
-			// goroutine and missing unrelated events.
-		}
-	}); err != nil {
-		return fmt.Errorf("subscribe: %w", err)
+
+	// setup is everything that has to be re-established on a NEW session,
+	// not just the first one: the wildcard filters and the subscription
+	// itself. A subscription lives on the far side of the socket and dies
+	// with it, so a reconnect that skipped this would give you a connected
+	// watcher that shows nothing.
+	//
+	// The wildcard filters (--path / --no-streams / --streams-only) are an
+	// optional capability — plugins that don't satisfy the interface
+	// (ACP1/ACP2, Probel, …) silently ignore them. No protocol-name compare.
+	setup := func(context.Context, consumer.Protocol) error {
+		applyWildcardFilter(plug, *pathFilter, *noStreams, *streamsOnly)
+		return plug.Subscribe(req, func(ev consumer.Event) {
+			select {
+			case events <- ev:
+			default:
+				// Drop on full buffer — better than blocking the receive
+				// goroutine and missing unrelated events.
+			}
+		})
 	}
 	defer func() { _ = plug.Unsubscribe(req) }()
+
+	// supErr carries the supervisor's terminal error, or stays empty when
+	// this protocol has no recovery (see below).
+	supErr := make(chan error, 1)
+
+	if watchCanRecover(plug) {
+		// The plugin reports session death, so the watch is supervised:
+		// on loss it reconnects with backoff and re-runs setup. Both
+		// transitions are announced on stderr, because a silent gap in the
+		// table was the operator's original complaint.
+		//
+		// The supervisor owns the FIRST setup too — connectWithRetry above
+		// already established this session, so Dial hands it back untouched
+		// the first time and reconnects in place afterwards.
+		firstDial := true
+		sup := &consumer.Supervisor[consumer.Protocol]{
+			Dial: func(c context.Context) (consumer.Protocol, error) {
+				if firstDial {
+					firstDial = false
+					return plug, nil
+				}
+				if err := reconnectPlugin(c, plug, host, cf); err != nil {
+					return nil, err
+				}
+				return plug, nil
+			},
+			Setup: setup,
+			Done: func(p consumer.Protocol) <-chan struct{} {
+				return p.(consumer.SessionDoneAccessor).SessionDone()
+			},
+			// No Close: the session is torn down by reconnectPlugin on the
+			// way in, and by the outer cleanup() on the way out. Closing
+			// here as well would disconnect twice.
+			OnLost: func(err error) {
+				fmt.Fprintf(os.Stderr, "watch: connection lost (%v) — reconnecting…\n", err)
+			},
+			OnReconnected: func(attempt int, downtime time.Duration) {
+				fmt.Fprintf(os.Stderr,
+					"watch: reconnected after %s (attempt %d) — subscriptions restored\n",
+					downtime.Round(time.Second), attempt)
+			},
+		}
+		go func() { supErr <- sup.Run(ctx) }()
+	} else {
+		// No death signal from this protocol — connectionless transports
+		// (ACP1 over UDP) have no session to lose, and a plugin that has
+		// not implemented the capability yet keeps exactly today's
+		// behaviour: subscribe once, run until Ctrl-C.
+		if err := setup(ctx, plug); err != nil {
+			return fmt.Errorf("subscribe: %w", err)
+		}
+	}
 
 	fmt.Println("watching — Ctrl-C to stop")
 	fmt.Printf("%-8s  %-18s  %-30s  %-20s  %-3s  %-7s  value\n",
@@ -248,6 +319,11 @@ func runWatch(ctx context.Context, args []string) error {
 		select {
 		case <-ctx.Done():
 			return nil
+		case err := <-supErr:
+			// The supervisor gave up: the initial setup failed, or the
+			// attempt budget ran out. Either way the watch is over and the
+			// operator needs the reason, not a silent exit.
+			return err
 		case ev := <-events:
 			// Frame-status announce drives hot-plug enrichment (#254).
 			// ACP1 emits group=frame, id=0 with a SlotStatus[] payload.

--- a/cmd/dhs/common.go
+++ b/cmd/dhs/common.go
@@ -294,6 +294,42 @@ func connect(ctx context.Context, host string, cf *commonFlags) (consumer.Protoc
 	return plug, cleanup, nil
 }
 
+// reconnectPlugin re-establishes an existing plugin's session IN PLACE, for
+// a long-running verb whose link died mid-run.
+//
+// It reuses the plugin rather than building a new one through connect(),
+// which matters for three reasons. The caller's `plug` variable never
+// changes, so nothing racing the reconnect can observe a half-swapped
+// plugin. The loggers and the --capture recorder stay open, instead of a
+// reconnect silently rotating the operator's log or truncating the capture.
+// And the per-plugin configuration applied at connect time — transport kind,
+// keep-alive cadence, recorder — persists, because it lives on the plugin.
+//
+// Protocol.Connect is documented as callable more than once for exactly
+// this. Disconnect first so a half-open session is released rather than
+// leaked.
+func reconnectPlugin(ctx context.Context, plug consumer.Protocol, host string, cf *commonFlags) error {
+	port := cf.port
+	if port == 0 {
+		factory, err := consumer.Get(cf.protocol)
+		if err != nil {
+			return err
+		}
+		port = factory.Meta().DefaultPort
+	}
+	_ = plug.Disconnect()
+
+	// Same floor as connect(): a tight --timeout must not kill a reconnect
+	// that legitimately needs several round trips.
+	dialTimeout := cf.timeout
+	if dialTimeout < 5*time.Second {
+		dialTimeout = 5 * time.Second
+	}
+	dialCtx, cancel := context.WithTimeout(ctx, dialTimeout)
+	defer cancel()
+	return plug.Connect(dialCtx, host, port)
+}
+
 // connectWithRetry wraps connect() with the same exponential backoff
 // the per-plugin warm-restart watcher uses (1s → 2s → 4s → 8s → 16s →
 // 30s cap). Used by long-running verbs like `watch` so the operator can

--- a/cmd/dhs/watch_recover_test.go
+++ b/cmd/dhs/watch_recover_test.go
@@ -1,0 +1,137 @@
+package main
+
+// The two pieces the supervised watch is built on. The dial/setup/backoff
+// cycle itself is tested in internal/consumer; these cover the CLI's half:
+// deciding whether a protocol CAN recover, and re-establishing a session in
+// place when it must.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"dhs/internal/consumer"
+)
+
+// recoverablePlugin adds the death signal to the shared fakePlugin.
+type recoverablePlugin struct {
+	fakePlugin
+	done chan struct{}
+
+	connectCalls    int
+	disconnectCalls int
+	lastHost        string
+	lastPort        int
+	connectErr      error
+	deadline        time.Time
+	hadDeadline     bool
+}
+
+func (p *recoverablePlugin) SessionDone() <-chan struct{} { return p.done }
+
+func (p *recoverablePlugin) Connect(ctx context.Context, ip string, port int) error {
+	p.connectCalls++
+	p.lastHost, p.lastPort = ip, port
+	p.deadline, p.hadDeadline = ctx.Deadline()
+	return p.connectErr
+}
+
+func (p *recoverablePlugin) Disconnect() error {
+	p.disconnectCalls++
+	return nil
+}
+
+// A protocol that cannot tell us its session died cannot be supervised —
+// and neither can one whose channel is nil, which means "no session to lose"
+// (ACP1 over UDP) rather than "not implemented".
+func TestWatchCanRecover(t *testing.T) {
+	tests := []struct {
+		name string
+		plug consumer.Protocol
+		want bool
+	}{
+		{"no capability", &fakePlugin{}, false},
+		{"capability, nil channel", &recoverablePlugin{}, false},
+		{"capability, live channel", &recoverablePlugin{done: make(chan struct{})}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := watchCanRecover(tc.plug); got != tc.want {
+				t.Errorf("watchCanRecover = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// Reconnect releases the dead session before opening a new one — a
+// half-open session that is never disconnected is a leaked socket and a
+// leaked goroutine, which is the bug this whole branch exists to close.
+func TestReconnectPluginDisconnectsThenConnects(t *testing.T) {
+	p := &recoverablePlugin{done: make(chan struct{})}
+	cf := &commonFlags{protocol: "acp1", port: 2071, timeout: time.Second}
+
+	if err := reconnectPlugin(context.Background(), p, "10.6.239.113", cf); err != nil {
+		t.Fatalf("reconnectPlugin: %v", err)
+	}
+	if p.disconnectCalls != 1 {
+		t.Errorf("Disconnect called %d times, want 1", p.disconnectCalls)
+	}
+	if p.connectCalls != 1 {
+		t.Errorf("Connect called %d times, want 1", p.connectCalls)
+	}
+	if p.lastHost != "10.6.239.113" || p.lastPort != 2071 {
+		t.Errorf("reconnected to %s:%d, want 10.6.239.113:2071", p.lastHost, p.lastPort)
+	}
+}
+
+// A tight --timeout must not kill a reconnect that legitimately needs
+// several round trips: the same 5 s floor connect() applies.
+func TestReconnectPluginAppliesTheDialTimeoutFloor(t *testing.T) {
+	p := &recoverablePlugin{}
+	cf := &commonFlags{protocol: "acp1", port: 2071, timeout: 10 * time.Millisecond}
+
+	start := time.Now()
+	if err := reconnectPlugin(context.Background(), p, "10.0.0.1", cf); err != nil {
+		t.Fatalf("reconnectPlugin: %v", err)
+	}
+	if !p.hadDeadline {
+		t.Fatal("Connect got no deadline")
+	}
+	if d := p.deadline.Sub(start); d < 4*time.Second {
+		t.Errorf("dial deadline %s, want the 5s floor rather than --timeout", d)
+	}
+}
+
+// With no --port the connector's registered default is used, so a reconnect
+// does not silently land on port 0.
+func TestReconnectPluginResolvesTheDefaultPort(t *testing.T) {
+	p := &recoverablePlugin{}
+	cf := &commonFlags{protocol: "acp1", timeout: time.Second} // port left 0
+
+	if err := reconnectPlugin(context.Background(), p, "10.0.0.1", cf); err != nil {
+		t.Fatalf("reconnectPlugin: %v", err)
+	}
+	if p.lastPort == 0 {
+		t.Fatal("reconnect used port 0 instead of the connector default")
+	}
+}
+
+func TestReconnectPluginUnknownProtocol(t *testing.T) {
+	p := &recoverablePlugin{}
+	cf := &commonFlags{protocol: "not-a-protocol", timeout: time.Second}
+
+	if err := reconnectPlugin(context.Background(), p, "10.0.0.1", cf); err == nil {
+		t.Fatal("reconnectPlugin succeeded for an unknown protocol")
+	}
+}
+
+func TestReconnectPluginSurfacesConnectFailure(t *testing.T) {
+	want := errors.New("still down")
+	p := &recoverablePlugin{connectErr: want}
+	cf := &commonFlags{protocol: "acp1", port: 2071, timeout: time.Second}
+
+	if err := reconnectPlugin(context.Background(), p, "10.0.0.1", cf); !errors.Is(err, want) {
+		t.Fatalf("reconnectPlugin = %v, want %v", err, want)
+	}
+}

--- a/internal/probel-sw02p/CLAUDE.md
+++ b/internal/probel-sw02p/CLAUDE.md
@@ -226,7 +226,13 @@ Implementation:
 
 - ❌ No auto-retry on Send timeout (§3.1 has no framing ACK, so
   retry has to be app-layer / per-command).
-- ❌ No auto-reconnect on TCP drop.
+- ✅ Auto-reconnect on TCP drop: `Plugin.SessionDone()` exposes the
+  codec client's reader-exit channel, and the `watch` verb supervises
+  it — reconnect with backoff, then re-`Subscribe`, since the
+  subscription dies with the socket. The cycle itself is the shared
+  `consumer.Supervisor`, not a copy in this package. The codec client
+  itself still does NOT redial on its own; recovery is a session-layer
+  concern, deliberately.
 - ✅ Keepalive: `consumer/keepalive.go` polls rx 01 on a rotating dst
   cursor (SW-P-02 has no APP_KEEPALIVE pair, so the rx 01 / tx 03
   round-trip IS the keep-alive). Armed only when a matrix size is
@@ -241,7 +247,9 @@ Implementation:
 - ❌ Server-side idle-session cleanup / graceful-drain / per-session
   write timeout.
 
-Next-session priority: app-layer retry policy + reconnect.
+Next-session priority: app-layer retry policy. Reconnect is done (above);
+what it still needs is a live run against a severed link, the way
+cerebrum-nb's was proven with a killproxy — implemented is not verified.
 
 ## Testbed
 


### PR DESCRIPTION
The last wire of the 24/7 work.

Detection landed per connector. The shared `Supervisor` landed. `SessionDone`
landed. And `runWatch` still blocked on `ctx.Done()` and never looked at the
session — so a watcher whose link died stayed alive and silent, which is the
original complaint.

Wired **once** in `runWatch` rather than per connector, because every
protocol already goes through it. acp1 (TCP direct + AN2) and
probel-sw02p/sw08p get recovery from this commit; anything that implements
`SessionDone` later gets it for free.

## Shape

| | |
|---|---|
| `Dial` | first call hands back the session `connectWithRetry` already made; later calls reconnect in place |
| `Setup` | wildcard filters + `Subscribe` — runs on **every** session, first included, because a subscription dies with the socket |
| `Done` | `plug.SessionDone()` |

## The four hazards, closed rather than worked around

**`plug` racing the reconnect.** `reconnectPlugin` reuses the *same* plugin —
`Disconnect` then `Connect`, which `Protocol` documents as callable more than
once — so the variable never changes and nothing can observe a half-swapped
plugin. It also keeps the loggers and the `--capture` recorder open, instead
of a reconnect silently rotating the operator's log or truncating the
capture.

**Double subscription.** `Subscribe` moved *into* `Setup`, so the supervisor
owns the first one too; `Dial` returns the existing session untouched on call
one.

**Teardown.** No `Close` on the supervisor: `reconnectPlugin` releases the
dead session on the way in and `cleanup()` on the way out. Closing there as
well would disconnect twice.

**Nested backoff.** `Dial` uses `reconnectPlugin`, not `connectWithRetry`,
which carries a 1s→30s schedule of its own. The supervisor owns the schedule.

## Not every protocol, on purpose

A protocol with no death signal keeps today's behaviour exactly: subscribe
once, run until Ctrl-C. That is not a gap for **ACP1 over UDP** — the socket
is connectionless, silence carries no liveness information, and reconnecting
a socket that never broke would be worse than doing nothing.
`watchCanRecover` treats a nil channel as "no session to lose" rather than
"not implemented".

## What the operator sees

```
watch: connection lost (transport:connection-lost: ...) — reconnecting…
watch: reconnected after 1s (attempt 1) — subscriptions restored
```

Both transitions go to stderr, because a silent gap in the table was the
complaint.

## Gate

- suite 89 packages ok / 0 fail
- `cmd/dhs` green including the 188-invocation CLI surface golden — **no flag
  changed**
- `go vet` + `golangci-lint` clean
- new CLI helpers covered: `watchCanRecover` (3 cases) and `reconnectPlugin`
  (disconnect-before-connect, 5 s dial floor, default-port resolution,
  unknown protocol, connect failure)

## Two limits worth stating

**`-race` did not run locally** — this host has no C toolchain (`-race
requires cgo`). CI runs it on the OS matrix, and it matters more than usual
here because this change adds a goroutine that calls into the plugin.

**acp1 and probel recovery is not yet live-proven.** cerebrum-nb's was, with
a killproxy severing the link three times. These are unit-proven, and the
supervisor cycle is proven in `internal/consumer`, but the equivalent live
run needs fleet access. That is the next verification step, not a code step.

Stacked on #992.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
