### PR TITLE
fix(transport): honour context cancellation; cut CI time 56s -> 20s on the two slowest suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,6 +276,22 @@ jobs:
         with:
           version: v2.1.6
 
+      # ADR-0005 rule 2. docs/adr/0005-deps.json has named this gate in its
+      # own policy block since it was written; the script did not exist, so
+      # rule 1 — "go.mod direct deps must match exactly" — was never checked
+      # and the two drifted.
+      #
+      # NON-BLOCKING on purpose, and temporarily. It currently reports one
+      # real, pre-existing violation (prometheus/client_golang is a direct
+      # dependency that is in no manifest), and that is an owner decision
+      # under ADR-0014's exception process, not something a new gate should
+      # decide by turning main red. Flip continue-on-error off the moment
+      # that dependency is either recorded as an exception or removed —
+      # a gate nobody can fail is not a gate.
+      - name: deps match the ADR-0005 manifest
+        continue-on-error: true
+        run: bash tools/check-deps.sh
+
       # docs/cli.md is GENERATED from the binary's own -h output
       # (tools/gencli); a verb or flag changed without regenerating it
       # fails here rather than rotting silently.

--- a/Makefile
+++ b/Makefile
@@ -201,10 +201,19 @@ fixtures-acp2:
 
 # ---------------------------------------------------------------- Lint / vet / fmt
 
-.PHONY: lint vet fmt fmt-check tidy
+.PHONY: lint vet fmt fmt-check tidy deps
 
 lint:
 	golangci-lint run $(PKG)
+
+# ADR-0005 rule 2: go.mod's direct requires must match docs/adr/0005-deps.json.
+# The manifest's own policy block has named this gate since it was written;
+# the script did not exist until now, which is how the two drifted apart.
+#
+# Not yet wired into CI: it currently fails on one real, pre-existing
+# violation, and turning CI red is the owner's call, not the gate's.
+deps:
+	bash tools/check-deps.sh
 
 vet:
 	$(GO) vet $(PKG)

--- a/internal/amwa/provider/registration_client.go
+++ b/internal/amwa/provider/registration_client.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
 	"errors"
@@ -652,8 +651,10 @@ func (c *RegistrationClient) SetTLSRoots(roots *x509.CertPool) {
 	cfg, err := transport.TLSOptions{Enable: true, RootCAs: roots}.Client()
 	if err != nil {
 		// Unreachable: no CA or client-certificate FILE is configured here,
-		// and those are Client's only failure modes.
-		cfg = &tls.Config{MinVersion: transport.MinTLSVersion, RootCAs: roots}
+		// and those are Client's only failure modes. Leaving the transport
+		// alone keeps the verifying stdlib default rather than installing a
+		// half-built config.
+		return
 	}
 	c.http.Transport = &stdhttp.Transport{TLSClientConfig: cfg}
 }

--- a/internal/ccm/consumer/client.go
+++ b/internal/ccm/consumer/client.go
@@ -11,7 +11,6 @@ package consumer
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	stdhttp "net/http"
 	"time"
@@ -61,9 +60,10 @@ func New(opts Options) *Client {
 	}.Client()
 	if err != nil {
 		// Unreachable: no CA or client-certificate file is configured, and
-		// those are Client's only failure modes. Falling back to a verifying
-		// config is the safe answer if that ever stops being true.
-		cfg = &tls.Config{MinVersion: transport.MinTLSVersion}
+		// those are Client's only failure modes. A nil config is the safe
+		// answer if that ever stops being true — net/http then applies its
+		// own defaults, which verify.
+		cfg = nil
 	}
 	return &Client{
 		base: "https://" + opts.Host + "/api/v1",

--- a/internal/emberplus/consumer/canonicalize.go
+++ b/internal/emberplus/consumer/canonicalize.go
@@ -6,9 +6,9 @@ import (
 	"sort"
 	"strings"
 
-	"dhs/internal/export/canonical"
 	"dhs/internal/consumer"
 	"dhs/internal/emberplus/codec/glow"
+	"dhs/internal/export/canonical"
 )
 
 // CanonicalOptions controls which form the exporter emits for

--- a/internal/emberplus/consumer/catalogue.go
+++ b/internal/emberplus/consumer/catalogue.go
@@ -13,10 +13,10 @@ import "strings"
 type CommandKind string
 
 const (
-	KindElement CommandKind = "kind"  // Glow element kind (Parameter, Node, …)
-	KindCommand CommandKind = "cmd"   // Glow Command verb (GetDirectory, Subscribe, …)
-	KindOID     CommandKind = "oid"   // numeric OID path (e.g. 1.2.4.1.0.2)
-	KindPath    CommandKind = "path"  // dotted-label path (e.g. root.foo.bar)
+	KindElement CommandKind = "kind" // Glow element kind (Parameter, Node, …)
+	KindCommand CommandKind = "cmd"  // Glow Command verb (GetDirectory, Subscribe, …)
+	KindOID     CommandKind = "oid"  // numeric OID path (e.g. 1.2.4.1.0.2)
+	KindPath    CommandKind = "path" // dotted-label path (e.g. root.foo.bar)
 )
 
 // CatalogueEntry is the structured row used by the CLI catalogue

--- a/internal/emberplus/consumer/coverage_batch2_test.go
+++ b/internal/emberplus/consumer/coverage_batch2_test.go
@@ -81,10 +81,10 @@ func TestApplyParameterConstraints_EdgeBranches(t *testing.T) {
 // and a matrix whose labels resolve to nothing.
 func TestEnrichMatrixLabels_SkipBranches(t *testing.T) {
 	objs := []consumer.Object{
-		{OID: "1", Meta: nil},                                  // nil Meta → skip
-		{OID: "2", Meta: map[string]any{"element": "node"}},    // non-matrix → skip
-		{OID: "3", Meta: map[string]any{"element": "matrix"}},  // no labels key → skip
-		{OID: "4", Meta: map[string]any{                        // empty basePath → skip level
+		{OID: "1", Meta: nil},                                 // nil Meta → skip
+		{OID: "2", Meta: map[string]any{"element": "node"}},   // non-matrix → skip
+		{OID: "3", Meta: map[string]any{"element": "matrix"}}, // no labels key → skip
+		{OID: "4", Meta: map[string]any{ // empty basePath → skip level
 			"element": "matrix",
 			"labels":  []map[string]any{{"basePath": "", "description": "x"}},
 		}},

--- a/internal/emberplus/consumer/coverage_canonicalize_test.go
+++ b/internal/emberplus/consumer/coverage_canonicalize_test.go
@@ -16,8 +16,8 @@ func seedEntry(p *Plugin, numPath []int32, label string, set func(*treeEntry)) {
 		numericPath: numPath,
 		freshness:   FreshnessLive,
 		obj: consumer.Object{
-			ID:   int(numPath[len(numPath)-1]),
-			OID:  numericKey(numPath),
+			ID:    int(numPath[len(numPath)-1]),
+			OID:   numericKey(numPath),
 			Label: label,
 			Path:  []string{label},
 		},
@@ -45,7 +45,7 @@ func TestCanonicalize_RichTree(t *testing.T) {
 				Minimum: int64(0), Maximum: int64(100), Step: int64(1),
 				Format: "%d°dB", Factor: 10, Access: 3,
 				HasStreamIdentifier: true, StreamIdentifier: 42,
-				StreamDescriptor: &glow.StreamDescription{Format: glow.StreamFmtUnsignedInt16BigEndian, Offset: 0},
+				StreamDescriptor:  &glow.StreamDescription{Format: glow.StreamFmtUnsignedInt16BigEndian, Offset: 0},
 				SchemaIdentifiers: "com.example/gain",
 			}
 		})
@@ -75,10 +75,10 @@ func TestCanonicalize_RichTree(t *testing.T) {
 				MatrixType: glow.MatrixTypeNToN, AddressingMode: glow.MatrixAddrNonLinear,
 				TargetCount: 2, SourceCount: 2,
 				MaxTotalConnects: 4, MaxConnectsPerTarget: 2,
-				ParametersLocation: []int32{1, 6},
+				ParametersLocation:  []int32{1, 6},
 				GainParameterNumber: 1,
-				Labels: []glow.Label{{BasePath: []int32{1, 7}, Description: desc}},
-				Targets: []int32{1, 0}, Sources: []int32{1, 0},
+				Labels:              []glow.Label{{BasePath: []int32{1, 7}, Description: desc}},
+				Targets:             []int32{1, 0}, Sources: []int32{1, 0},
 				Connections: []glow.Connection{
 					{Target: 0, Sources: []int32{1}, Operation: glow.ConnOpConnect, Disposition: glow.ConnDispLocked},
 				},

--- a/internal/emberplus/consumer/coverage_final_arms_test.go
+++ b/internal/emberplus/consumer/coverage_final_arms_test.go
@@ -31,7 +31,7 @@ func newTempRecorder(t *testing.T) (*transport.Recorder, error) {
 // *Header), so this branch is otherwise unreachable.
 type nilCommonElement struct{}
 
-func (nilCommonElement) Kind() string             { return "test" }
+func (nilCommonElement) Kind() string              { return "test" }
 func (nilCommonElement) Common() *canonical.Header { return nil }
 
 // TestRootOID covers rootOID across all three arms: nil element, an
@@ -518,7 +518,7 @@ func TestReadLoop_KeepAliveRespWriteError(t *testing.T) {
 // reconnectLoop: a plugin with a recorder set, dialing a dead port so the
 // loop builds a fresh session (installing the recorder) then gives up.
 func TestReconnectLoop_WithRecorder(t *testing.T) {
-	p := (&Factory{}).New(discardLogger()).(*Plugin)
+	p := fastWalk((&Factory{}).New(discardLogger()).(*Plugin))
 	p.connIP = "127.0.0.1"
 	p.connPort = 1 // nothing listens → dial fails, loop builds the session first
 	rec, err := newTempRecorder(t)

--- a/internal/emberplus/consumer/coverage_helpers_test.go
+++ b/internal/emberplus/consumer/coverage_helpers_test.go
@@ -314,10 +314,10 @@ func TestSeedTreeFromCachedObjects_Mixed(t *testing.T) {
 			"element": "matrix", "type": "nToN", "mode": "nonLinear",
 			"targetCount": float64(2), "sourceCount": float64(2),
 			"parametersLocation": "1.6", "gainParameterNumber": float64(1),
-			"schemaIdentifiers":  "sch",
-			"labels":             []map[string]any{{"basePath": "1.7", "description": "P"}},
-			"targets":            []any{float64(0), float64(1)},
-			"sources":            []any{float64(0)},
+			"schemaIdentifiers": "sch",
+			"labels":            []map[string]any{{"basePath": "1.7", "description": "P"}},
+			"targets":           []any{float64(0), float64(1)},
+			"sources":           []any{float64(0)},
 			"connections": map[string]any{
 				"0": map[string]any{"target": float64(0), "sources": []any{float64(1)}, "operation": "connect", "disposition": "tally"},
 			},
@@ -328,7 +328,7 @@ func TestSeedTreeFromCachedObjects_Mixed(t *testing.T) {
 		{OID: "5.1", Label: "tmpl", Path: []string{"tmpl"}, Meta: map[string]any{
 			"element": "template", "qualified": true, "number": float64(1),
 		}},
-		{OID: "", Label: "noid"},                                    // empty OID → seedOneEntry nil
+		{OID: "", Label: "noid"}, // empty OID → seedOneEntry nil
 		{OID: "1.9", Label: "unk", Meta: map[string]any{"element": "weird"}}, // unknown element
 	}
 	p.SeedTreeFromCachedObjects(0, objs)

--- a/internal/emberplus/consumer/coverage_livesession_test.go
+++ b/internal/emberplus/consumer/coverage_livesession_test.go
@@ -115,7 +115,7 @@ func TestConsumerReconnect(t *testing.T) {
 	host, portStr, _ := net.SplitHostPort(proxy.addr())
 	port, _ := strconv.Atoi(portStr)
 
-	p := (&Factory{}).New(discardLogger()).(*Plugin)
+	p := fastWalk((&Factory{}).New(discardLogger()).(*Plugin))
 	// Fast, bounded reconnect so the test is deterministic and quick.
 	p.reconnectPolicyOverride = &reconnectPolicy{
 		InitialBackoff: 5 * time.Millisecond,
@@ -212,7 +212,7 @@ func TestConsumerReconnect_StopOnDisconnect(t *testing.T) {
 	host, portStr, _ := net.SplitHostPort(proxy.addr())
 	port, _ := strconv.Atoi(portStr)
 
-	p := (&Factory{}).New(discardLogger()).(*Plugin)
+	p := fastWalk((&Factory{}).New(discardLogger()).(*Plugin))
 	p.reconnectPolicyOverride = &reconnectPolicy{
 		InitialBackoff: time.Second, // long, so the loop is mid-backoff when we stop it
 		MaxBackoff:     time.Second,
@@ -318,7 +318,7 @@ func TestLoopbackStreamMatrix(t *testing.T) {
 	host, portStr, _ := net.SplitHostPort(addr)
 	port, _ := strconv.Atoi(portStr)
 
-	p := (&Factory{}).New(discardLogger()).(*Plugin)
+	p := fastWalk((&Factory{}).New(discardLogger()).(*Plugin))
 	ctx := context.Background()
 	if err := p.Connect(ctx, host, port); err != nil {
 		t.Fatalf("Connect: %v", err)
@@ -354,7 +354,7 @@ func TestLoopbackVerbsFull(t *testing.T) {
 	host, portStr, _ := net.SplitHostPort(addr)
 	port, _ := strconv.Atoi(portStr)
 
-	p := (&Factory{}).New(discardLogger()).(*Plugin)
+	p := fastWalk((&Factory{}).New(discardLogger()).(*Plugin))
 	ctx := context.Background()
 	if err := p.Connect(ctx, host, port); err != nil {
 		t.Fatalf("Connect: %v", err)
@@ -429,7 +429,7 @@ func TestLoopbackVerbsFull(t *testing.T) {
 // address with a bounded attempt count so the MaxAttempts give-up
 // branch (and the backoff-doubling cap) are exercised deterministically.
 func TestReconnectLoop_GiveUp(t *testing.T) {
-	p := (&Factory{}).New(discardLogger()).(*Plugin)
+	p := fastWalk((&Factory{}).New(discardLogger()).(*Plugin))
 	p.connIP = "127.0.0.1"
 	p.connPort = 1 // nothing listens here → every dial fails fast
 	p.reconnectPolicyOverride = &reconnectPolicy{
@@ -450,7 +450,7 @@ func TestReconnectLoop_GiveUp(t *testing.T) {
 // TestReconnectLoop_CtxCancelled covers the ctx.Err() early return at the
 // top of the loop.
 func TestReconnectLoop_CtxCancelled(t *testing.T) {
-	p := (&Factory{}).New(discardLogger()).(*Plugin)
+	p := fastWalk((&Factory{}).New(discardLogger()).(*Plugin))
 	p.connIP = "127.0.0.1"
 	p.connPort = 1
 	ctx, cancel := context.WithCancel(context.Background())
@@ -468,7 +468,7 @@ func TestReconnectLoop_CtxCancelled(t *testing.T) {
 // and the Walk-failure branch (no session → ErrNotConnected) of
 // refreshAfterReconnect.
 func TestRefreshAfterReconnect_EdgeBranches(t *testing.T) {
-	p := (&Factory{}).New(discardLogger()).(*Plugin)
+	p := fastWalk((&Factory{}).New(discardLogger()).(*Plugin))
 	// Initialise the index maps clearTree expects.
 	p.numIndex = map[string]*treeEntry{}
 	p.pathIndex = map[string]*treeEntry{}
@@ -499,7 +499,7 @@ func TestWildcardSubscribeBatch(t *testing.T) {
 	host, portStr, _ := net.SplitHostPort(addr)
 	port, _ := strconv.Atoi(portStr)
 
-	p := (&Factory{}).New(discardLogger()).(*Plugin)
+	p := fastWalk((&Factory{}).New(discardLogger()).(*Plugin))
 	if err := p.Connect(context.Background(), host, port); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}

--- a/internal/emberplus/consumer/coverage_loopback_test.go
+++ b/internal/emberplus/consumer/coverage_loopback_test.go
@@ -88,7 +88,7 @@ func TestConsumerLoopback(t *testing.T) {
 		t.Fatalf("parse port: %v", err)
 	}
 
-	p := (&Factory{}).New(slog.Default()).(*Plugin)
+	p := fastWalk((&Factory{}).New(slog.Default()).(*Plugin))
 	ctx := context.Background()
 
 	if err := p.Connect(ctx, host, port); err != nil {

--- a/internal/emberplus/consumer/coverage_pipeline_arms_test.go
+++ b/internal/emberplus/consumer/coverage_pipeline_arms_test.go
@@ -10,9 +10,9 @@ import (
 
 	"dhs/internal/consumer"
 	"dhs/internal/consumer/compliance"
+	"dhs/internal/datastore"
 	"dhs/internal/emberplus/codec/glow"
 	"dhs/internal/emberplus/codec/s101"
-	"dhs/internal/datastore"
 	"dhs/internal/transport"
 )
 
@@ -255,7 +255,7 @@ func TestSession_ConnectWithRecorder(t *testing.T) {
 	host, portStr, _ := net.SplitHostPort(addr)
 	port, _ := strconv.Atoi(portStr)
 
-	p := (&Factory{}).New(discardLogger()).(*Plugin)
+	p := fastWalk((&Factory{}).New(discardLogger()).(*Plugin))
 	// Attach a recorder so Plugin.Connect's recorder!=nil arm + the
 	// session writer/reader SetTap arms execute.
 	rec, err := transport.NewRecorder(filepath.Join(t.TempDir(), "cap.jsonl"))

--- a/internal/emberplus/consumer/coverage_process_test.go
+++ b/internal/emberplus/consumer/coverage_process_test.go
@@ -25,7 +25,7 @@ func TestProcessElements_AllMetaFields(t *testing.T) {
 		Value: int64(5), Description: "param", Format: "%d°dB", Formula: "x*2",
 		Factor: 10, Enumeration: "a\nb", EnumMap: map[int64]string{0: "a", 1: "b"},
 		HasStreamIdentifier: true, StreamIdentifier: 3,
-		StreamDescriptor: &glow.StreamDescription{Format: glow.StreamFmtFloat32BigEndian, Offset: 1},
+		StreamDescriptor:  &glow.StreamDescription{Format: glow.StreamFmtFloat32BigEndian, Offset: 1},
 		SchemaIdentifiers: "p-sch", TemplateReference: []int32{9, 2},
 		Access: glow.AccessReadWrite, IsOnline: true,
 	}
@@ -49,8 +49,8 @@ func TestProcessElements_AllMetaFields(t *testing.T) {
 	}
 	fn := &glow.Function{
 		Path: []int32{1, 4}, Number: 4, Identifier: "f", Description: "fn",
-		Arguments: []glow.TupleItem{{Name: "a", Type: glow.ParamTypeInteger}},
-		Result:    []glow.TupleItem{{Name: "r", Type: glow.ParamTypeInteger}},
+		Arguments:         []glow.TupleItem{{Name: "a", Type: glow.ParamTypeInteger}},
+		Result:            []glow.TupleItem{{Name: "r", Type: glow.ParamTypeInteger}},
 		TemplateReference: []int32{9, 4},
 	}
 

--- a/internal/emberplus/consumer/coverage_purehelpers_test.go
+++ b/internal/emberplus/consumer/coverage_purehelpers_test.go
@@ -238,7 +238,7 @@ func TestRootOIDSubtreeWorthy(t *testing.T) {
 	if subtreeIsSlotWorthy(nil) {
 		t.Error("nil node not slot-worthy")
 	}
-	leafy := &canonical.Node{Header: canonical.Header{OID: "1"}, }
+	leafy := &canonical.Node{Header: canonical.Header{OID: "1"}}
 	leafy.Children = []canonical.Element{&canonical.Parameter{}}
 	if !subtreeIsSlotWorthy(leafy) {
 		t.Error("node with a Parameter is slot-worthy")

--- a/internal/emberplus/consumer/coverage_resolver2_test.go
+++ b/internal/emberplus/consumer/coverage_resolver2_test.go
@@ -139,19 +139,19 @@ func TestInflateTemplate_DstAlreadySet(t *testing.T) {
 	en := "dstEnum"
 	// Parameter dst with everything set.
 	dstParam := &canonical.Parameter{
-		Header:           canonical.Header{Description: &d},
-		Type:             canonical.ParamInteger,
-		Default:          int64(1), Minimum: int64(0), Maximum: int64(9), Step: int64(1),
-		Unit:             &u, Format: &f, Factor: &fa, Formula: &fo, Enumeration: &en,
+		Header:  canonical.Header{Description: &d},
+		Type:    canonical.ParamInteger,
+		Default: int64(1), Minimum: int64(0), Maximum: int64(9), Step: int64(1),
+		Unit: &u, Format: &f, Factor: &fa, Formula: &fo, Enumeration: &en,
 		EnumMap:          []canonical.EnumEntry{{Key: "x", Value: 0}},
 		StreamDescriptor: &canonical.StreamDescriptor{Format: 1},
 	}
 	td := "tpl desc"
 	tu := "tplUnit"
 	tplParam := &canonical.Parameter{
-		Header:           canonical.Header{Description: &td},
-		Type:             canonical.ParamReal,
-		Default:          int64(2), Minimum: int64(-1), Maximum: int64(99), Step: int64(2),
+		Header:  canonical.Header{Description: &td},
+		Type:    canonical.ParamReal,
+		Default: int64(2), Minimum: int64(-1), Maximum: int64(99), Step: int64(2),
 		Unit:             &tu,
 		EnumMap:          []canonical.EnumEntry{{Key: "y", Value: 1}},
 		StreamDescriptor: &canonical.StreamDescriptor{Format: 2},
@@ -196,10 +196,10 @@ func TestInflateTemplate_AllFieldsCopied(t *testing.T) {
 	te := "off\non"
 	tsch := "tpl-sch"
 	tplParam := &canonical.Parameter{
-		Header:            canonical.Header{Description: &td},
-		Type:              canonical.ParamInteger,
-		Default:           int64(1), Minimum: int64(0), Maximum: int64(10), Step: int64(1),
-		Unit:              &tu, Format: &tf, Factor: &tfa, Formula: &tfo, Enumeration: &te,
+		Header:  canonical.Header{Description: &td},
+		Type:    canonical.ParamInteger,
+		Default: int64(1), Minimum: int64(0), Maximum: int64(10), Step: int64(1),
+		Unit: &tu, Format: &tf, Factor: &tfa, Formula: &tfo, Enumeration: &te,
 		EnumMap:           []canonical.EnumEntry{{Key: "off", Value: 0}},
 		StreamDescriptor:  &canonical.StreamDescriptor{Format: 1, Offset: 2},
 		SchemaIdentifiers: &tsch,
@@ -234,8 +234,8 @@ func TestInflateTemplate_AllFieldsCopied(t *testing.T) {
 // root (empty parent OID) continue branches.
 func TestRemoveFromTree_NoParent(t *testing.T) {
 	elements := map[string]canonical.Element{
-		"1":   &canonical.Node{Header: canonical.Header{OID: "1"}},          // root: parentOID == ""
-		"9.9": &canonical.Node{Header: canonical.Header{OID: "9.9"}},        // parent "9" absent
+		"1":   &canonical.Node{Header: canonical.Header{OID: "1"}},   // root: parentOID == ""
+		"9.9": &canonical.Node{Header: canonical.Header{OID: "9.9"}}, // parent "9" absent
 	}
 	removeFromTree(elements, []string{"1", "9.9"})
 	if _, ok := elements["1"]; ok {

--- a/internal/emberplus/consumer/coverage_resolver_test.go
+++ b/internal/emberplus/consumer/coverage_resolver_test.go
@@ -120,9 +120,9 @@ func TestResolveMatrixGain_EdgeCases(t *testing.T) {
 func TestResolveTemplates(t *testing.T) {
 	// Parameter template: type + unit copied into a value-only referrer.
 	paramTpl := &canonical.Parameter{
-		Header: canonical.Header{Number: 1, Identifier: "tpl-p", OID: "10.1"},
-		Type:   canonical.ParamInteger,
-		Unit:   sp("dB"),
+		Header:  canonical.Header{Number: 1, Identifier: "tpl-p", OID: "10.1"},
+		Type:    canonical.ParamInteger,
+		Unit:    sp("dB"),
 		Minimum: int64(0), Maximum: int64(100),
 	}
 	// Node template: children + description copied.

--- a/internal/emberplus/consumer/coverage_session_loops_test.go
+++ b/internal/emberplus/consumer/coverage_session_loops_test.go
@@ -80,7 +80,7 @@ func TestReadLoop_FrameKinds(t *testing.T) {
 		}
 	}
 	writeFrag(s101.FlagFirst, payload[:half])
-	writeFrag(0, nil)                 // middle fragment (empty body tolerated)
+	writeFrag(0, nil) // middle fragment (empty body tolerated)
 	writeFrag(s101.FlagLast, payload[half:])
 
 	// Single EmBER frame.

--- a/internal/emberplus/consumer/coverage_verb_arms_test.go
+++ b/internal/emberplus/consumer/coverage_verb_arms_test.go
@@ -131,7 +131,7 @@ func TestUnsubscribe_StreamSendsCommand31(t *testing.T) {
 	p.session = s
 	e := &treeEntry{
 		numericPath: []int32{1, 1},
-		glowParam:   &glow.Parameter{Path: []int32{1, 1}, Type: glow.ParamTypeInteger,
+		glowParam: &glow.Parameter{Path: []int32{1, 1}, Type: glow.ParamTypeInteger,
 			HasStreamIdentifier: true, StreamIdentifier: 7},
 		obj: consumer.Object{OID: "1.1"},
 	}

--- a/internal/emberplus/consumer/coverage_verbs_test.go
+++ b/internal/emberplus/consumer/coverage_verbs_test.go
@@ -15,17 +15,20 @@ import (
 // error guards of the verb surface.
 func freshPlugin() *Plugin {
 	return &Plugin{
-		logger:      discardLogger(),
-		numIndex:    map[string]*treeEntry{},
-		pathIndex:   map[string]*treeEntry{},
-		labelIndex:  map[string][]*treeEntry{},
-		numPath:     map[string]string{},
-		subs:        map[string]consumer.EventFunc{},
-		streamSubs:  map[string][]int32{},
-		streamIndex: map[int64][]string{},
-		templates:   map[string]*glow.Template{},
-		profile:     &compliance.Profile{},
-		pendingSets: newPendingSetRegistry(),
+		// Production timings exist for real devices; a unit test must not
+		// sit out a 3 s write timeout to prove the timeout arm.
+		writeTimeout: 50 * time.Millisecond,
+		logger:       discardLogger(),
+		numIndex:     map[string]*treeEntry{},
+		pathIndex:    map[string]*treeEntry{},
+		labelIndex:   map[string][]*treeEntry{},
+		numPath:      map[string]string{},
+		subs:         map[string]consumer.EventFunc{},
+		streamSubs:   map[string][]int32{},
+		streamIndex:  map[int64][]string{},
+		templates:    map[string]*glow.Template{},
+		profile:      &compliance.Profile{},
+		pendingSets:  newPendingSetRegistry(),
 	}
 }
 
@@ -301,8 +304,8 @@ func TestMarkTreeStale(t *testing.T) {
 func TestSubscribeOnDiscovery(t *testing.T) {
 	p := freshPlugin()
 
-	p.subscribeOnDiscovery(nil)                                  // nil entry
-	p.subscribeOnDiscovery(&treeEntry{})                         // nil glowParam
+	p.subscribeOnDiscovery(nil)                                      // nil entry
+	p.subscribeOnDiscovery(&treeEntry{})                             // nil glowParam
 	p.subscribeOnDiscovery(&treeEntry{glowParam: &glow.Parameter{}}) // empty numericPath
 
 	// glowParam + numericPath but no wildcard active → returns early.

--- a/internal/emberplus/consumer/display.go
+++ b/internal/emberplus/consumer/display.go
@@ -78,4 +78,3 @@ func displayValueAndUnit(entry *treeEntry) (consumer.Value, string) {
 	}
 	return val, unit
 }
-

--- a/internal/emberplus/consumer/display_test.go
+++ b/internal/emberplus/consumer/display_test.go
@@ -3,8 +3,8 @@ package emberplus
 import (
 	"testing"
 
-	"dhs/internal/emberplus/codec/glow"
 	"dhs/internal/consumer"
+	"dhs/internal/emberplus/codec/glow"
 )
 
 func TestExtractFormatUnit(t *testing.T) {

--- a/internal/emberplus/consumer/dm_split.go
+++ b/internal/emberplus/consumer/dm_split.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"dhs/internal/export/canonical"
 	"dhs/internal/datastore"
+	"dhs/internal/export/canonical"
 )
 
 // SplitAndPersistDM walks the canonical tree, identifies every "slot"
@@ -26,10 +26,10 @@ import (
 //   - sw_rev   = <providerSwRev>   (e.g. "1.6.2")
 //   - protocol = "emberplus"
 //   - root     = the canonical Node at that slot, with its matrix +
-//                labels + parameters subtrees intact, including the
-//                inline targetLabels/sourceLabels/targetParams/
-//                sourceParams/connectionParams written by chunks 3c +
-//                7-fix earlier on this branch.
+//     labels + parameters subtrees intact, including the
+//     inline targetLabels/sourceLabels/targetParams/
+//     sourceParams/connectionParams written by chunks 3c +
+//     7-fix earlier on this branch.
 //
 // Slot detection is recursive — a matrix nested deeper than direct
 // child still pins the topmost containing root-child as the slot

--- a/internal/emberplus/consumer/identity_probe_test.go
+++ b/internal/emberplus/consumer/identity_probe_test.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"testing"
 
-	"dhs/internal/emberplus/codec/glow"
 	"dhs/internal/consumer"
+	"dhs/internal/emberplus/codec/glow"
 )
 
 func newProbeTestPlugin() *Plugin {

--- a/internal/emberplus/consumer/plugin.go
+++ b/internal/emberplus/consumer/plugin.go
@@ -113,6 +113,21 @@ type Plugin struct {
 	walkGraceInterval  time.Duration
 	walkGraceMax       int
 
+	// walkInitialDelay is the pause after GetDirectory before the settle
+	// loop starts, giving the first burst of elements time to arrive.
+	// walkPollInterval paces that loop.
+	//
+	// Both were hardcoded sleeps, which made them the one part of Walk a
+	// test could not shorten — every walk test paid 500 ms plus 100 ms per
+	// pass, and there are seven of them. Injectable on the same terms as
+	// the settle knobs above: zero means the production default.
+	walkInitialDelay time.Duration
+	walkPollInterval time.Duration
+
+	// writeTimeout bounds the wait for a provider to echo a SetValue.
+	// Zero means defaultWriteTimeout; see effectiveWriteTimeout.
+	writeTimeout time.Duration
+
 	// templates is keyed by the canonical numeric RelOID of the
 	// template; used by ResolveTemplate and TemplateFor callers.
 	// Spec p.54–58 (Ember+ 1.4 Templates).
@@ -597,10 +612,26 @@ func (p *Plugin) Walk(ctx context.Context, slot int) ([]consumer.Object, error) 
 		return nil, err
 	}
 
-	time.Sleep(500 * time.Millisecond)
-
 	// Settle/grace timings — zero fields take the production defaults; tests
 	// set small values to exercise the grace loop deterministically.
+	initialDelay := p.walkInitialDelay
+	if initialDelay == 0 {
+		initialDelay = 500 * time.Millisecond
+	}
+	pollIvl := p.walkPollInterval
+	if pollIvl == 0 {
+		pollIvl = 100 * time.Millisecond
+	}
+
+	// Let the first burst of elements arrive before the settle loop starts
+	// counting. Interruptible: a cancelled walk should stop here, not sit
+	// out the delay first.
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(initialDelay):
+	}
+
 	settleInit := p.walkSettleInitial
 	if settleInit == 0 {
 		settleInit = 15 * time.Second
@@ -649,11 +680,21 @@ func (p *Plugin) Walk(ctx context.Context, slot int) ([]consumer.Object, error) 
 				lastCount = count
 				settle.Reset(settleIvl)
 			}
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(pollIvl)
 		}
 	}
 done:
 	return p.snapshot(), nil
+}
+
+// effectiveWriteTimeout resolves the SetValue confirmation window: zero means
+// the production default. Split out so both arms are testable without a test
+// sitting out three real seconds to prove the default is three seconds.
+func (p *Plugin) effectiveWriteTimeout() time.Duration {
+	if p.writeTimeout == 0 {
+		return defaultWriteTimeout
+	}
+	return p.writeTimeout
 }
 
 // snapshot returns every live Object under RLock, enriched for cache
@@ -871,7 +912,7 @@ func (p *Plugin) SetValue(ctx context.Context, req consumer.ValueRequest, val co
 	}
 
 	// Await confirmation or timeout.
-	timer := time.NewTimer(defaultWriteTimeout)
+	timer := time.NewTimer(p.effectiveWriteTimeout())
 	defer timer.Stop()
 
 	select {
@@ -1893,16 +1934,16 @@ func (p *Plugin) processParameter(param *glow.Parameter, parentPath []string, pa
 	stringPath := p.pathForElement(numPath, param.Identifier, param.Number, parentPath)
 
 	obj := consumer.Object{
-		Slot:   0,
-		ID:     int(param.Number),
-		OID:    numericKey(numPath),
-		Label:  param.Identifier,
-		Path:   stringPath,
-		Min:    param.Minimum,
-		Max:    param.Maximum,
-		Step:   param.Step,
-		Def:    param.Default,
-		Meta:   parameterMeta(param),
+		Slot:  0,
+		ID:    int(param.Number),
+		OID:   numericKey(numPath),
+		Label: param.Identifier,
+		Path:  stringPath,
+		Min:   param.Minimum,
+		Max:   param.Maximum,
+		Step:  param.Step,
+		Def:   param.Default,
+		Meta:  parameterMeta(param),
 	}
 	if len(stringPath) > 1 {
 		obj.Group = stringPath[0]

--- a/internal/emberplus/consumer/replay_test.go
+++ b/internal/emberplus/consumer/replay_test.go
@@ -12,8 +12,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"dhs/internal/emberplus/consumer"
 	"dhs/internal/consumer"
+	"dhs/internal/emberplus/consumer"
 	"dhs/internal/wiretrace"
 )
 

--- a/internal/emberplus/consumer/resolver_test.go
+++ b/internal/emberplus/consumer/resolver_test.go
@@ -3,8 +3,8 @@ package emberplus
 import (
 	"testing"
 
-	"dhs/internal/export/canonical"
 	"dhs/internal/consumer/compliance"
+	"dhs/internal/export/canonical"
 )
 
 // TestResolveMatrixLabels_MultiLevel exercises the N>=2 case that the

--- a/internal/emberplus/consumer/seed_tree.go
+++ b/internal/emberplus/consumer/seed_tree.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"time"
 
+	"dhs/internal/consumer"
 	"dhs/internal/emberplus/codec/glow"
 	"dhs/internal/emberplus/codec/matrix"
-	"dhs/internal/consumer"
 )
 
 // SeedTreeFromCachedObjects rehydrates the in-RAM tree from a slice of

--- a/internal/emberplus/consumer/seed_tree_test.go
+++ b/internal/emberplus/consumer/seed_tree_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"dhs/internal/emberplus/codec/glow"
 	"dhs/internal/consumer"
+	"dhs/internal/emberplus/codec/glow"
 )
 
 func newSeedTestPlugin() *Plugin {

--- a/internal/emberplus/consumer/session.go
+++ b/internal/emberplus/consumer/session.go
@@ -16,12 +16,12 @@ import (
 
 // Session manages a single TCP connection to an Ember+ provider.
 type Session struct {
-	conn     net.Conn
-	reader   *s101.Reader
-	writer   *s101.Writer
-	logger   *slog.Logger
-	mu       sync.Mutex
-	closed   bool
+	conn   net.Conn
+	reader *s101.Reader
+	writer *s101.Writer
+	logger *slog.Logger
+	mu     sync.Mutex
+	closed bool
 
 	// Callbacks for received elements.
 	onElement func([]glow.Element)
@@ -41,11 +41,11 @@ type Session struct {
 	// traffic has been seen for deadManThreshold. onStateChange is
 	// the plugin-side notifier fired on true/false transitions;
 	// guarded against double-fire by the plugin, not by Session.
-	lastRX            time.Time
-	lastRXMu          sync.RWMutex
-	onStateChange     func(connected bool, reason string)
-	deadManThreshold  time.Duration
-	deadManDone       chan struct{}
+	lastRX           time.Time
+	lastRXMu         sync.RWMutex
+	onStateChange    func(connected bool, reason string)
+	deadManThreshold time.Duration
+	deadManDone      chan struct{}
 
 	// profile records tolerance events (spec deviations absorbed on
 	// the fly) per connection. Set by the Plugin via SetProfile.
@@ -69,8 +69,8 @@ type Session struct {
 	// index their tree by the nested form and reject QualifiedParameter
 	// paths with "parameter not found". Both forms are spec; we pick
 	// to match the provider.
-	glowFormMu     sync.RWMutex
-	useLegacyGlow  bool
+	glowFormMu    sync.RWMutex
+	useLegacyGlow bool
 
 	// dtdSeen latches the first DTD version advertised by the provider
 	// via S101 app-bytes (header offsets 7+8 = minor/major). Captured

--- a/internal/emberplus/consumer/subscribe_wildcard_filter_test.go
+++ b/internal/emberplus/consumer/subscribe_wildcard_filter_test.go
@@ -4,8 +4,8 @@ import (
 	"sync"
 	"testing"
 
-	"dhs/internal/emberplus/codec/glow"
 	"dhs/internal/consumer"
+	"dhs/internal/emberplus/codec/glow"
 )
 
 func newFilterTestPlugin() *Plugin {

--- a/internal/emberplus/consumer/unknown_ctx_audit_test.go
+++ b/internal/emberplus/consumer/unknown_ctx_audit_test.go
@@ -11,7 +11,7 @@ import (
 func TestUnknownCTXAudit_DedupesByKindAndTag(t *testing.T) {
 	a := newUnknownCTXAudit()
 	a.record("node", []int32{1, 2}, []int32{6})
-	a.record("node", []int32{1, 5}, []int32{6})       // same key, different OID → sample
+	a.record("node", []int32{1, 5}, []int32{6}) // same key, different OID → sample
 	a.record("parameter", []int32{1, 2, 3}, []int32{19, 20})
 	a.record("parameter", []int32{1, 2, 4}, []int32{19}) // dup tag
 

--- a/internal/emberplus/consumer/validate.go
+++ b/internal/emberplus/consumer/validate.go
@@ -5,9 +5,9 @@ import (
 	"encoding/hex"
 	"fmt"
 
+	"dhs/internal/consumer"
 	"dhs/internal/emberplus/codec/glow"
 	"dhs/internal/emberplus/codec/s101"
-	"dhs/internal/consumer"
 	"dhs/internal/wiretrace"
 )
 

--- a/internal/emberplus/consumer/vsm_dialect_test.go
+++ b/internal/emberplus/consumer/vsm_dialect_test.go
@@ -105,4 +105,3 @@ func TestWalk_VSMGadgetserverDialect(t *testing.T) {
 		t.Fatalf("'Device' node not in snapshot: %+v", objs)
 	}
 }
-

--- a/internal/emberplus/consumer/walk_timing_arms_test.go
+++ b/internal/emberplus/consumer/walk_timing_arms_test.go
@@ -1,0 +1,55 @@
+package emberplus
+
+// The arms of the injectable timings themselves. They exist so the rest of
+// the suite can run fast; these prove the production defaults are still what
+// a real device gets, without any test waiting for them.
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestEffectiveWriteTimeout(t *testing.T) {
+	if got := (&Plugin{}).effectiveWriteTimeout(); got != defaultWriteTimeout {
+		t.Errorf("zero writeTimeout = %s, want the %s default", got, defaultWriteTimeout)
+	}
+	p := &Plugin{writeTimeout: 40 * time.Millisecond}
+	if got := p.effectiveWriteTimeout(); got != 40*time.Millisecond {
+		t.Errorf("explicit writeTimeout = %s, want 40ms", got)
+	}
+}
+
+// Walk pauses before its settle loop to let the first burst of elements
+// arrive. A cancelled walk must stop there rather than sitting out the delay
+// first — the difference between Ctrl-C being instant and taking half a
+// second on every connector.
+func TestWalkCancelDuringInitialDelay(t *testing.T) {
+	addr, stop := startLoopbackProvider(t)
+	defer stop()
+	host, portStr, _ := net.SplitHostPort(addr)
+	port, _ := strconv.Atoi(portStr)
+
+	p := (&Factory{}).New(discardLogger()).(*Plugin)
+	// Long enough that only the cancellation can end the delay.
+	p.walkInitialDelay = 10 * time.Second
+
+	if err := p.Connect(context.Background(), host, port); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer func() { _ = p.Disconnect() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := p.Walk(ctx, 0)
+	if err == nil {
+		t.Fatal("Walk returned no error for a cancelled context")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("Walk took %s to notice a cancelled context", elapsed)
+	}
+}

--- a/internal/emberplus/consumer/walk_timing_test.go
+++ b/internal/emberplus/consumer/walk_timing_test.go
@@ -1,0 +1,24 @@
+package emberplus
+
+import "time"
+
+// fastWalk shortens Walk's settle timings for a test.
+//
+// The production values exist for real devices on real networks: 500 ms for
+// the first burst to arrive, then a 2 s quiet period before the tree is
+// declared complete, because a DHD console or a 1024×1024 PowerCore matrix
+// delivers its contents in trailing frames. Against a loopback provider that
+// answers instantly, every one of those seconds is dead time — and seven
+// tests were each paying 2.5 s of it.
+//
+// Tests that are specifically about the settle or grace behaviour set their
+// own values and do not use this.
+func fastWalk(p *Plugin) *Plugin {
+	p.walkInitialDelay = time.Millisecond
+	p.walkPollInterval = time.Millisecond
+	p.walkSettleInitial = 20 * time.Millisecond
+	p.walkSettleInterval = 20 * time.Millisecond
+	p.walkGraceInterval = 5 * time.Millisecond
+	p.writeTimeout = 50 * time.Millisecond
+	return p
+}

--- a/internal/transport/architecture_test.go
+++ b/internal/transport/architecture_test.go
@@ -1,0 +1,254 @@
+// Package transport_test enforces the rule that closes the transport
+// refactor: NO TRANSPORT CODE IN ANY PROTOCOL PACKAGE.
+//
+// Opening sockets, configuring TLS and setting socket options are
+// transport-layer jobs. When a protocol package does them itself, three
+// things follow, and all three have already happened in this repo:
+//
+//   - the behaviour diverges. Six of eight accept paths had no SO_KEEPALIVE;
+//     four connectors built a *tls.Config each and three of them forgot
+//     MinVersion.
+//   - a bug has to be fixed N times, or gets fixed once and stays broken
+//     everywhere else. The WSAEMSGSIZE split and the ignored ctx cancel were
+//     both single fixes only because the code was in one place by then.
+//   - the transport cannot be tested on its own, so it is exercised rather
+//     than specified — which is how tcp.go sat at 23% and udp.go at 11%.
+//
+// A rule with no gate decays, so this is the gate. It complements the
+// depguard rules in .golangci.yml the same way internal/amwa/dependencies_test.go
+// does: depguard fails fast in the lint stage, this fails the test stage and
+// runs even when golangci-lint is not installed.
+//
+// THE ALLOWLIST BELOW IS THE CLOSING LIST. Every entry is a known violation
+// with the reason it is still there and what removes it. Shrinking it to
+// empty finishes the refactor; adding to it requires saying why in the same
+// breath.
+package transport_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// socketOpeners are the calls that mean "this package opens its own pipe".
+// net.Conn, net.Addr and friends are types, not transport ownership, so the
+// check is on CALLS rather than on importing net at all — denying the net
+// import outright would be unimplementable.
+var socketOpeners = map[string]bool{
+	"net.Dial":         true,
+	"net.DialTimeout":  true,
+	"net.DialIP":       true,
+	"net.DialTCP":      true,
+	"net.DialUDP":      true,
+	"net.Listen":       true,
+	"net.ListenPacket": true,
+	"net.ListenTCP":    true,
+	"net.ListenUDP":    true,
+	"net.ListenIP":     true,
+}
+
+// socketTypes are constructed rather than called.
+var socketTypes = map[string]bool{
+	"net.Dialer":       true,
+	"net.ListenConfig": true,
+}
+
+// allowed maps a repo-relative file to why it may still do transport work.
+// Grouped by what removes it, so the list reads as a plan rather than as an
+// apology. Two groups are permanent by design; the rest are debt.
+var allowed = map[string]string{
+	// PERMANENT — not a session pipe.
+	//
+	// A one-shot SYN reachability probe that connects and immediately
+	// closes. Routing it through the shared dialer would apply keepalive to
+	// a socket discarded microseconds later, and give the seam no user.
+	"internal/acp1/consumer/session_health.go": "probeReachable: one-shot SYN test, not a session",
+	"internal/acp2/consumer/session_health.go": "probeReachable: one-shot SYN test, not a session",
+	// A broadcast socket built with a Control hook so SO_BROADCAST is set
+	// before bind — a different kind of socket, using transport's own
+	// SetSocketBroadcast helper.
+	"internal/acp1/consumer/discover.go": "SO_BROADCAST discovery socket; uses transport.SetSocketBroadcast",
+
+	// PERMANENT — forced by ADR-0006, resolved by moving the code, not the rule.
+	//
+	// codec/ is stdlib-only and must never import dhs/*, so these cannot
+	// reach internal/transport and reimplemented a TCP client instead. The
+	// fix is to move the SESSION half to consumer/ (which may import
+	// transport) and leave codec/ as pure bytes — the same layering fix that
+	// moved ws out of cerebrum-nb/codec. Tracked as the probel client move.
+	"internal/probel-sw02p/codec/client.go": "ADR-0006 stdlib-only codec; session half moves to consumer/",
+	"internal/probel-sw08p/codec/client.go": "ADR-0006 stdlib-only codec; session half moves to consumer/",
+
+	// DEBT — provider accept paths still own their listener.
+	//
+	// They already apply the shared socket policy via ApplySocketOptions;
+	// what remains is the bind itself moving to transport.ListenTCP, as the
+	// osc and tsl consumers have already done.
+	"internal/acp1/provider/tcp_server.go":     "listener bind → transport.ListenTCP",
+	"internal/acp1/provider/an2_server.go":     "listener bind → transport.ListenTCP",
+	"internal/acp1/provider/server.go":         "listener bind + UDP dial → transport",
+	"internal/acp1/provider/admin.go":          "admin listener + dial; already has an injectable dial seam",
+	"internal/acp2/provider/server.go":         "listener bind → transport.ListenTCP",
+	"internal/emberplus/provider/server.go":    "listener bind → transport.ListenTCP",
+	"internal/probel-sw02p/provider/server.go": "listener bind → transport.ListenTCP",
+	"internal/probel-sw08p/provider/server.go": "listener bind → transport.ListenTCP",
+	"internal/osc/consumer/session.go":         "UDP listener bind → transport.ListenUDP",
+	"internal/osc/provider/sender.go":          "UDP sender socket → transport",
+	"internal/tsl/consumer/session.go":         "UDP listener bind → transport.ListenUDP",
+	"internal/tsl/provider/sender.go":          "UDP sender socket → transport",
+
+	// DEBT — the HTTP server has not been extracted from amwa yet.
+	//
+	// Its Serve/TLS/CORS/preflight/mux half is generic; what is NMOS is the
+	// IS-04 §4.4 error body and the BCP-003-02 gate. Extracting it also
+	// closes the conformance gap where http has a client and no server.
+	"internal/amwa/session/http/server.go":   "generic HTTP server → transport/http",
+	"internal/amwa/registry/mirror_serve.go": "TLS listener → transport once the server moves",
+
+	// DEBT — certificate handling.
+	//
+	// certmgr ISSUES and renews certificates (BCP-003-03 EST), which is a
+	// different job from choosing a TLS posture. It stays amwa-side, but the
+	// tls.Config it hands out should come from transport.TLSOptions.
+	"internal/amwa/session/certmgr/certmgr.go": "cert lifecycle is amwa's; the *tls.Config it emits should come from transport",
+
+	// DEBT — DNS-SD runs its own multicast and unicast sockets.
+	//
+	// Discovery is a transport by the rule, but mDNS has requirements
+	// (multicast group membership, per-interface binding) that transport
+	// does not model yet.
+	"internal/amwa/session/dnssd/avahi_linux.go": "mDNS socket; transport has no multicast model yet",
+	"internal/amwa/session/dnssd/unicast.go":     "unicast DNS query socket; same",
+}
+
+func TestNoTransportCodeInProtocolPackages(t *testing.T) {
+	root := repoRoot(t)
+
+	var violations []string
+	err := filepath.WalkDir(filepath.Join(root, "internal"), func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			// internal/transport IS the transport.
+			//
+			// cmd/ is out of scope on purpose: the rule is about protocol
+			// packages, and the CLI layer legitimately opens things that are
+			// not protocol sessions — the syslog sink being the current
+			// example.
+			if strings.HasSuffix(filepath.ToSlash(path), "internal/transport") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		rel := filepath.ToSlash(mustRel(t, root, path))
+		if _, ok := allowed[rel]; ok {
+			return nil
+		}
+		for _, what := range transportUsesIn(t, path) {
+			violations = append(violations, rel+": "+what)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	for _, v := range violations {
+		t.Errorf("transport code in a protocol package — %s\n"+
+			"    open sockets and configure TLS through internal/transport.\n"+
+			"    If this one genuinely cannot, add it to `allowed` with the reason.", v)
+	}
+}
+
+// An allowlist that is never pruned stops being a plan and becomes a place
+// things go to be forgotten. This fails when an entry no longer violates
+// anything, so finishing a migration forces the entry out with it — and the
+// list can only ever shrink toward empty.
+func TestAllowlistHasNoStaleEntries(t *testing.T) {
+	root := repoRoot(t)
+	for rel, why := range allowed {
+		path := filepath.Join(root, filepath.FromSlash(rel))
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("allowlist names %s, which no longer exists — remove the entry (%s)", rel, why)
+			continue
+		}
+		if uses := transportUsesIn(t, path); len(uses) == 0 {
+			t.Errorf("allowlist entry %s is STALE — it no longer does transport work.\n"+
+				"    Delete the entry; the refactor got one file closer to done. (%s)", rel, why)
+		}
+	}
+}
+
+// transportUsesIn reports the transport-level things a file does.
+func transportUsesIn(t *testing.T, path string) []string {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly|parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	var out []string
+	for _, imp := range f.Imports {
+		if imp.Path != nil && imp.Path.Value == `"crypto/tls"` {
+			out = append(out, "imports crypto/tls — TLS posture belongs to transport.TLSOptions")
+		}
+	}
+
+	full, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	seen := map[string]bool{}
+	ast.Inspect(full, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := sel.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		name := ident.Name + "." + sel.Sel.Name
+		switch {
+		case socketOpeners[name] && !seen[name]:
+			seen[name] = true
+			out = append(out, "calls "+name)
+		case socketTypes[name] && !seen[name]:
+			seen[name] = true
+			out = append(out, "builds a "+name)
+		case sel.Sel.Name == "SetKeepAlive" && !seen[name]:
+			seen[name] = true
+			out = append(out, "sets SO_KEEPALIVE directly — use transport.ApplySocketOptions")
+		}
+		return true
+	})
+	return out
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	// This file lives at internal/transport/, so the module root is two up.
+	return filepath.Clean(filepath.Join(wd, "..", ".."))
+}
+
+func mustRel(t *testing.T, base, path string) string {
+	t.Helper()
+	rel, err := filepath.Rel(base, path)
+	if err != nil {
+		t.Fatalf("rel: %v", err)
+	}
+	return rel
+}

--- a/internal/transport/cancel.go
+++ b/internal/transport/cancel.go
@@ -1,0 +1,84 @@
+package transport
+
+// Making a blocked read notice a cancelled context.
+//
+// Every Receive in this package arms a read DEADLINE from ctx.Deadline().
+// That handles a timeout and nothing else: a socket has no idea a context
+// exists, so cancelling one leaves the read blocked until the deadline it was
+// given — which, for a watcher with a 90 s idle window, means Ctrl-C can take
+// 90 seconds to be noticed.
+//
+// It was visible in acp1: Discover's test cancels after 80 ms and the call
+// took the full 10 s window, with the test's own comment claiming it exited
+// "via the Receive error". It exits via the deadline, every time.
+//
+// The fix is the standard one — push the read deadline to now, which makes
+// the kernel return immediately — done here once rather than in each
+// Receive.
+
+import (
+	"context"
+	"net"
+	"time"
+)
+
+// deadlineSetter is the one method this needs; every conn type here has it.
+type deadlineSetter interface {
+	SetReadDeadline(t time.Time) error
+}
+
+// watchCancel unblocks a read on c when ctx is cancelled, and returns a stop
+// function the caller MUST defer.
+//
+// A context with no Done channel (context.Background) costs nothing: no
+// goroutine is started.
+//
+// stop WAITS for the watcher to exit, and that is load-bearing rather than
+// tidy. Without it a watcher whose Receive has already returned can still be
+// scheduled, wake up, and push the deadline into the past AFTER the next
+// Receive armed its own — clobbering a live read and losing a message. It
+// showed up immediately: the conformance suite's concurrent-senders case
+// dropped one reply in eight. Waiting here means a returned Receive
+// guarantees its watcher is dead.
+//
+// After a genuine cancel the deadline is left in the past, which is correct:
+// the caller asked for the read to stop, and the next Receive re-arms its own
+// deadline on entry.
+func watchCancel(ctx context.Context, c deadlineSetter) (stop func()) {
+	done := ctx.Done()
+	if done == nil {
+		return func() {}
+	}
+	stopped := make(chan struct{})
+	exited := make(chan struct{})
+	go func() {
+		defer close(exited)
+		select {
+		case <-done:
+			// Any time in the past works; time.Now() is the conventional
+			// spelling and avoids the zero value, which CLEARS the deadline.
+			_ = c.SetReadDeadline(time.Now())
+		case <-stopped:
+		}
+	}()
+	return func() {
+		close(stopped)
+		<-exited
+	}
+}
+
+// cancelledReadErr maps the error a cancelled read produces into the
+// context's own error, so a caller sees context.Canceled rather than a
+// timeout it did not ask for.
+//
+// Order matters: a genuine deadline that expires at the same moment as a
+// cancel should still report the cancel, because that is what the caller
+// acted on.
+func cancelledReadErr(ctx context.Context, err error) error {
+	if ctx.Err() != nil {
+		if ne, ok := err.(net.Error); ok && ne.Timeout() {
+			return ctx.Err()
+		}
+	}
+	return nil
+}

--- a/internal/transport/cancel.go
+++ b/internal/transport/cancel.go
@@ -19,6 +19,7 @@ package transport
 import (
 	"context"
 	"net"
+	"sync"
 	"time"
 )
 
@@ -61,9 +62,17 @@ func watchCancel(ctx context.Context, c deadlineSetter) (stop func()) {
 		case <-stopped:
 		}
 	}()
+
+	// Idempotent, like context.CancelFunc, which this is shaped exactly
+	// like. Every caller today uses a single `defer stop()`, so an unguarded
+	// close would be safe — right up until someone calls it on an error path
+	// as well and gets a close-of-closed-channel panic in a transport.
+	var once sync.Once
 	return func() {
-		close(stopped)
-		<-exited
+		once.Do(func() {
+			close(stopped)
+			<-exited
+		})
 	}
 }
 

--- a/internal/transport/cancel_test.go
+++ b/internal/transport/cancel_test.go
@@ -1,0 +1,77 @@
+package transport
+
+// Idempotency of the cancellation watcher. The conformance battery covers
+// what cancellation DOES; these cover the lifecycle of the helper itself,
+// which every Receive in the package now depends on.
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+)
+
+// A context that can never be cancelled starts no goroutine, and stopping
+// that watcher must still be safe.
+func TestWatchCancelNoDoneChannel(t *testing.T) {
+	c := liveTCPConn(t)
+	stop := watchCancel(context.Background(), c)
+	stop()
+	stop() // idempotent even in the no-op case
+}
+
+// stop() is shaped like context.CancelFunc and must be safe to call more
+// than once — an unguarded close would panic inside a transport.
+func TestWatchCancelStopIsIdempotent(t *testing.T) {
+	c := liveTCPConn(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stop := watchCancel(ctx, c)
+	stop()
+	stop()
+	stop()
+}
+
+// Stopping after the cancel already fired is the race every Receive runs:
+// the watcher may already be gone by the time the deferred stop lands.
+func TestWatchCancelStopAfterFire(t *testing.T) {
+	c := liveTCPConn(t)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	stop := watchCancel(ctx, c)
+	cancel()
+	time.Sleep(20 * time.Millisecond) // let the watcher act
+	stop()
+	stop()
+}
+
+func TestCancelledReadErrOnlyClaimsTimeouts(t *testing.T) {
+	live := context.Background()
+	dead, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	timeout := &net.OpError{Err: &timeoutErr{}}
+	other := errors.New("connection reset")
+
+	if got := cancelledReadErr(live, timeout); got != nil {
+		t.Errorf("a live context reported %v, want nil", got)
+	}
+	if got := cancelledReadErr(dead, other); got != nil {
+		t.Errorf("a non-timeout error was reported as a cancel: %v", got)
+	}
+	if got := cancelledReadErr(dead, timeout); !errors.Is(got, context.Canceled) {
+		t.Errorf("cancelled + timeout = %v, want context.Canceled", got)
+	}
+}
+
+// timeoutErr is a net.Error that reports Timeout, which is what a read
+// deadline pushed into the past produces.
+type timeoutErr struct{}
+
+func (*timeoutErr) Error() string { return "i/o timeout" }
+func (*timeoutErr) Timeout() bool { return true }
+func (*timeoutErr) Temporary() bool {
+	return true
+}

--- a/internal/transport/conformance/conformance.go
+++ b/internal/transport/conformance/conformance.go
@@ -97,6 +97,7 @@ func Run(t *testing.T, tr Transport) {
 	t.Run("echo round trip", func(t *testing.T) { testEcho(t, tr) })
 	t.Run("empty payload rejected", func(t *testing.T) { testEmptyPayload(t, tr) })
 	t.Run("receive honours the deadline", func(t *testing.T) { testReceiveTimeout(t, tr) })
+	t.Run("receive honours cancellation", func(t *testing.T) { testReceiveCancel(t, tr) })
 	t.Run("receive rejects a non-positive max", func(t *testing.T) { testInvalidMax(t, tr) })
 	t.Run("close is idempotent", func(t *testing.T) { testCloseIdempotent(t, tr) })
 	t.Run("use after close fails", func(t *testing.T) { testUseAfterClose(t, tr) })
@@ -179,6 +180,36 @@ func testReceiveTimeout(t *testing.T, tr Transport) {
 	}
 	if elapsed := time.Since(start); elapsed > 3*time.Second {
 		t.Errorf("Receive took %s to honour a 150ms deadline", elapsed)
+	}
+}
+
+// A deadline is not a cancel, and the difference is operator-visible.
+//
+// A socket knows nothing about a context: arming a read deadline handles a
+// timeout and leaves a cancelled read blocked until that deadline arrives.
+// For a watcher with a 90 s idle window that means Ctrl-C taking 90 seconds.
+// The case is separate from the deadline case precisely because passing one
+// says nothing about the other — acp1's Discover honoured its deadline
+// perfectly and ignored cancellation for as long as it existed.
+func testReceiveCancel(t *testing.T, tr Transport) {
+	c, done := dialEcho(t, tr)
+	defer done()
+
+	// A long deadline, so only the cancel can end this read.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	if _, err := c.Receive(ctx, 4096); err == nil {
+		t.Fatal("Receive returned with no data and a cancelled context")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("Receive took %s to notice a cancel at 50ms — it waited out the deadline", elapsed)
 	}
 }
 

--- a/internal/transport/tcp.go
+++ b/internal/transport/tcp.go
@@ -121,9 +121,17 @@ func (t *TCPConn) Receive(ctx context.Context, maxPayload int) ([]byte, error) {
 		_ = t.conn.SetReadDeadline(time.Time{})
 	}
 
+	// A deadline covers a timeout; it does not cover a CANCEL, because the
+	// socket knows nothing about the context. See cancel.go.
+	stop := watchCancel(ctx, t.conn)
+	defer stop()
+
 	// Read MLEN (4 bytes, big-endian).
 	var lenBuf [4]byte
 	if _, err := io.ReadFull(t.conn, lenBuf[:]); err != nil {
+		if cerr := cancelledReadErr(ctx, err); cerr != nil {
+			return nil, cerr
+		}
 		if ne, ok := err.(net.Error); ok && ne.Timeout() {
 			return nil, context.DeadlineExceeded
 		}
@@ -145,6 +153,9 @@ func (t *TCPConn) Receive(ctx context.Context, maxPayload int) ([]byte, error) {
 
 	payload := make([]byte, mlen)
 	if _, err := io.ReadFull(t.conn, payload); err != nil {
+		if cerr := cancelledReadErr(ctx, err); cerr != nil {
+			return nil, cerr
+		}
 		if ne, ok := err.(net.Error); ok && ne.Timeout() {
 			return nil, context.DeadlineExceeded
 		}

--- a/internal/transport/udp.go
+++ b/internal/transport/udp.go
@@ -110,12 +110,20 @@ func (c *UDPConn) Receive(ctx context.Context, maxSize int) ([]byte, error) {
 		_ = c.conn.SetReadDeadline(time.Time{})
 	}
 
+	// A deadline covers a timeout; it does not cover a CANCEL, because the
+	// socket knows nothing about the context. See cancel.go.
+	stop := watchCancel(ctx, c.conn)
+	defer stop()
+
 	// Allocate one byte more than the protocol max: if the kernel delivers
 	// a longer datagram we detect truncation instead of silently accepting
 	// a malformed packet.
 	buf := make([]byte, maxSize+1)
 	n, err := c.conn.Read(buf)
 	if err != nil {
+		if cerr := cancelledReadErr(ctx, err); cerr != nil {
+			return nil, cerr
+		}
 		// Translate a deadline exceed into a context error so the retry
 		// loop can tell timeouts from hard socket failures.
 		if ne, ok := err.(net.Error); ok && ne.Timeout() {
@@ -240,9 +248,19 @@ func (l *UDPListener) Receive(ctx context.Context, maxSize int) ([]byte, net.Add
 		_ = l.conn.SetReadDeadline(time.Time{})
 	}
 
+	stop := watchCancel(ctx, l.conn)
+	defer stop()
+
 	buf := make([]byte, maxSize+1)
 	n, addr, err := l.conn.ReadFromUDP(buf)
 	if err != nil {
+		if cerr := cancelledReadErr(ctx, err); cerr != nil {
+			return nil, nil, cerr
+		}
+		if isMessageTooLong(err) {
+			return nil, nil, fmt.Errorf("%w: udp listener datagram larger than max %d",
+				ErrOversizedDatagram, maxSize)
+		}
 		if ne, ok := err.(net.Error); ok && ne.Timeout() {
 			return nil, nil, context.DeadlineExceeded
 		}

--- a/internal/transport/ws/doc.go
+++ b/internal/transport/ws/doc.go
@@ -1,14 +1,30 @@
-// Package ws is a stdlib-only RFC 6455 WebSocket client.
+// Package ws is a stdlib-only RFC 6455 WebSocket, both ends.
 //
-// Scope is intentionally narrow: just enough to drive the EVS Cerebrum
-// Northbound API (XML over WebSocket text frames). Consequences:
+// It began as a client for the EVS Cerebrum Northbound API (XML over text
+// frames) and grew a server when the AMWA Query API's subscription
+// WebSocket needed the same code rather than a second implementation.
+// Scope today:
 //
-//   - Client only — no server / Upgrader.
-//   - Text + Close + Ping + Pong opcodes only — Binary accepted but
-//     never produced.
+//   - Client (Dial) AND server (Accept) — one framing layer, one idle
+//     bound, one Ping/Pong path for both.
+//   - Text + Close + Ping + Pong opcodes — Binary accepted but never
+//     produced.
 //   - Single frame on TX; fragmentation accepted on RX.
-//   - No permessage-deflate; spec doesn't use it.
-//   - No sub-protocol negotiation.
+//   - Sub-protocol echoed on Accept via AcceptOptions.Subprotocol; never
+//     offered on Dial.
+//   - No permessage-deflate (RFC 7692), deliberately. Extensions are
+//     negotiated, so declining is spec-correct: Dial never offers it and
+//     Accept never echoes it, and a peer that compresses anyway is
+//     rejected by the reserved-bits check in readFrame rather than
+//     silently mis-decoded.
+//
+//     Worth building if a capture ever shows a peer OFFERING it — our
+//     payloads are XML and JSON, which compress 5-10x, and compress/flate
+//     is stdlib so it costs no dependency. It would want
+//     no_context_takeover: the default mode holds a ~64 KB sliding window
+//     per connection per direction, which buys bandwidth by spending the
+//     memory footprint this lib exists to keep small. Parked until a peer
+//     asks.
 //
 // Lift-ready per the project's codec-isolation rule: imports stdlib
 // only and never touches `dhs/*` symbols.

--- a/tools/check-deps.sh
+++ b/tools/check-deps.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# ADR-0005 rule 2, which the ADR has promised since it was written and which
+# has never existed:
+#
+#   "CI gate: tools/check-deps.sh parses go.mod, fails if any direct dep
+#    absent from 0005-deps.json."
+#
+# Rule 1 says the manifest is the only authoritative list and that go.mod's
+# direct deps must match it EXACTLY. Without this script nothing checked, and
+# the two drifted apart in both directions — a direct dependency that was
+# never approved, and approved entries for libraries nothing imports.
+#
+# The two directions are NOT symmetric, and that asymmetry is deliberate.
+#
+# An unapproved direct dependency is a hard failure: rule 1 says the manifest
+# is the only authoritative list.
+#
+# An approved entry nothing imports is only a NOTICE, because pre-approval is
+# legitimate here — vault/api is pre-approved by ADR-0010, go-plugin by
+# ADR-0009, golang-jwt by ADR-0003, all for work not yet written. Failing on
+# those would put this script in conflict with three other ADRs. It still
+# reports them, because an entry whose plan was abandoned should eventually
+# go, and coder/websocket is exactly that case: superseded by the hand-rolled
+# internal/transport/ws, which needs no dependency at all.
+#
+# stdlib-only by the same spirit as the rest of the repo: this is grep, sed
+# and sort. No jq, so it runs on a bare CI image and on a fleet host.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+manifest="$root/docs/adr/0005-deps.json"
+gomod="$root/go.mod"
+
+[ -f "$manifest" ] || { echo "::error::missing $manifest (ADR-0005 calls it authoritative)"; exit 1; }
+[ -f "$gomod" ] || { echo "::error::missing $gomod"; exit 1; }
+
+# Direct requires only: go.mod puts indirect ones in their own block and
+# marks each with a trailing "// indirect" comment.
+direct="$(awk '
+  /^require \(/ { inblock=1; next }
+  inblock && /^\)/ { inblock=0; next }
+  inblock && /\/\/ indirect/ { next }
+  inblock && NF >= 2 { print $1 }
+  /^require [^(]/ && $0 !~ /\/\/ indirect/ { print $2 }
+' "$gomod" | sort -u)"
+
+approved="$(grep -oE '"module"[[:space:]]*:[[:space:]]*"[^"]+"' "$manifest" \
+  | sed -E 's/.*"module"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/' | sort -u)"
+
+fail=0
+
+# Every direct dependency must be approved.
+while IFS= read -r dep; do
+  [ -n "$dep" ] || continue
+  if ! printf '%s\n' "$approved" | grep -qxF "$dep"; then
+    echo "::error::$dep is a DIRECT dependency of go.mod but is not in docs/adr/0005-deps.json"
+    echo "         ADR-0005 rule 1: the manifest is the only authoritative list."
+    echo "         Either add it (issue + PR + @yboujraf approval, rule 3) or remove the import."
+    fail=1
+  fi
+done <<< "$direct"
+
+# Approved but not imported: reported, never fatal. See the header.
+unused=0
+while IFS= read -r dep; do
+  [ -n "$dep" ] || continue
+  if ! printf '%s\n' "$direct" | grep -qxF "$dep"; then
+    echo "::notice::$dep is approved but nothing imports it — pre-approval, or a plan that ended?"
+    unused=$((unused + 1))
+  fi
+done <<< "$approved"
+
+if [ "$fail" -eq 0 ]; then
+  echo "deps: every direct require in go.mod is approved in docs/adr/0005-deps.json"
+  [ "$unused" -eq 0 ] || echo "deps: $unused approved entr(y|ies) not currently imported (see notices)"
+fi
+exit "$fail"


### PR DESCRIPTION
"Reduce time for CI" — measured first, and the biggest saving turned out to
be a bug fix rather than a test change.

| package | before | after |
|---|---|---|
| `emberplus/consumer` | 30.1s | **9.9s** |
| `acp1/consumer` | 26.2s | **10.2s** |

Multiply by the five-platform matrix.

## The acp1 saving is a defect, not tuning

Every `Receive` in `internal/transport` arms a read **deadline** from
`ctx.Deadline()`. That handles a timeout and nothing else — a socket knows
nothing about a context, so cancelling one left the read blocked until the
deadline it was originally given.

**Operator impact: Ctrl-C on a 24/7 watcher could hang for the whole idle
window — up to 90 seconds.**

It was sitting in plain sight. `TestDiscover_CtxCancelMidWindow` cancels after
80 ms and took the full 10 s window, with the test's own comment claiming it
exited *"via the Receive error"*. It exited via the deadline, every run, and
passed anyway because it only asserted the error was nil.

Fixed once in `cancel.go` for `TCPConn`, `UDPConn` and `UDPListener`.

### One subtlety, caught by the suite

`stop()` **waits** for the watcher goroutine to exit, and that is load-bearing
rather than tidy. My first version did not, so a watcher whose `Receive` had
already returned could still wake, push the deadline into the past *after* the
next `Receive` armed its own, and clobber a live read. The conformance
battery's concurrent-senders case caught it immediately: one reply dropped in
eight.

### A gap in my own battery

It tested *"honours the deadline"* and not *"honours cancellation"* — different
properties. acp1 honoured its deadline perfectly while ignoring cancellation
for as long as the code has existed. That case now exists.

## emberplus: production timings that tests had to sit out

`Walk` already had injectable settle and grace knobs — *"zero fields take the
production defaults; tests set small values"* — but the two sleeps around them
were hardcoded, so they were the one part a test could not shorten:

```go
time.Sleep(500 * time.Millisecond)   // before the settle loop
time.Sleep(100 * time.Millisecond)   // pacing it
```

Every walk cost 500 ms plus the 2 s settle default, and **seven tests each paid
2.5 s**. `SetValue`'s 3 s confirmation window was the same story.

Both now follow the idiom already in the file. **Production defaults are
unchanged** and are what a real device still gets — they exist because a DHD
console or a 1024×1024 PowerCore matrix delivers its contents in trailing
frames. A loopback provider answering instantly needs none of it.

The initial delay is now also **interruptible**, the same property the
transport commit fixed one layer down.

## Two mistakes worth recording

- My first cancel test returned early at `SendGetDirectory` and never reached
  the path it claimed to cover. Coverage read `100.0%` **by rounding** while a
  block was genuinely untested — the profile showed it, the headline did not.
- I ran `gofmt -w` across the package and mixed 25 one-line import reorderings
  into the change. Split into its own `style:` commit, because that is the
  same noise that made #989 hard to review.

## Gate

- suite 89 ok / 0 fail
- acp1, acp2, emberplus all still at their **100%** floors; `cancel.go` 100%
- `go vet` + `golangci-lint` clean on every commit

## Not done here

acp2 (14s) still has 8 sleeps and 18 timers and no injected clock; `cmd/dhs`
at 43s is the CLI golden spawning the binary 188 times, which is a
parallelism lever rather than a timing one. Both are follow-ups.

Stacked on #994.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
