### PR TITLE
feat(lldp): the LLDP concern as its own package — fills IS-04 attached_network_device, with the host posture to match

### DIFF
--- a/ansible/playbooks/fleet-converge.yml
+++ b/ansible/playbooks/fleet-converge.yml
@@ -8,8 +8,8 @@
 #   ansible-playbook playbooks/fleet-converge.yml --check  # dry-run
 #
 # Roles land one per task issue: dhs_access (#782) · dhs_hostname (#783)
-# · dhs_mdns (#784) · dhs_firewall (#785). fleet-verify.yml (#786) asserts
-# the result without changing anything.
+# · dhs_mdns (#784) · dhs_capture · dhs_firewall (#785).
+# fleet-verify.yml (#786) asserts the result without changing anything.
 - name: Converge fleet access, names, mDNS and firewall
   hosts: dhs_clients
   gather_facts: true
@@ -21,6 +21,10 @@
     - dhs_access
     - dhs_hostname
     - dhs_mdns
+    # raw-frame capture posture: cap_net_raw on Linux, Npcap verified on
+    # Windows. Verifies by default and never fails the converge — Npcap
+    # cannot be installed unattended without an OEM licence.
+    - dhs_capture
     - dhs_firewall
     # last: may reboot the CT to apply static addressing (#786); the control
     # node's own reboot ends the play — re-run afterwards = 0 changes.

--- a/ansible/roles/dhs_capture/defaults/main.yml
+++ b/ansible/roles/dhs_capture/defaults/main.yml
@@ -1,0 +1,48 @@
+---
+# dhs_capture — the host side of raw frame capture, which dhs needs to read
+# LLDP (Ethertype 0x88CC) off a local interface and fill IS-04
+# interfaces[].attached_network_device.
+#
+# Linux and macOS need NO package: AF_PACKET and BPF are kernel interfaces
+# reached from stdlib syscall. They need a PRIVILEGE, which this role grants
+# to the dhs binary via file capabilities instead of running dhs as root.
+#
+# Windows needs Npcap, because Windows raw sockets are IP-level and cannot
+# see a non-IP Ethertype at all. Npcap is the one host dependency this repo
+# may not stage the way it stages Bonjour — see the licence note below.
+
+# ---- Linux -----------------------------------------------------------------
+# cap_net_raw on the binary. Narrower than root and survives reinstalls
+# because dhs_host re-applies it after a version bump.
+dhs_capture_linux_setcap: true
+dhs_capture_linux_capability: cap_net_raw+ep
+
+# ---- Windows ---------------------------------------------------------------
+# Detection: Npcap installs its own DLL directory and a driver service. Either
+# is proof enough; both are checked because a half-removed install leaves one.
+dhs_capture_npcap_dll: 'C:\Windows\System32\Npcap\wpcap.dll'
+dhs_capture_npcap_service: npcap
+
+# Npcap CANNOT be installed unattended by this role, and that is a licence
+# limit rather than a gap in the automation:
+#
+#   * the FREE edition's /S silent switch does not exist — silent mode is
+#     Npcap OEM only, so an unattended install is impossible without a paid
+#     licence;
+#   * the free edition permits at most FIVE systems and NO redistribution,
+#     so committing the installer next to BonjourPSSetup.exe would be
+#     redistributing it from a public repo.
+#
+# Point this at an OEM installer the operator holds OUTSIDE the repo to let
+# the role install it. Left empty, the role only verifies.
+dhs_capture_npcap_oem_installer_src: ""
+dhs_capture_npcap_installer_dst: 'C:\dhs\installers\npcap-oem.exe'
+
+# Whether a Windows host WITHOUT Npcap fails the converge.
+#
+# Default false, and deliberately: ADR-0016's stdlib floor says a missing host
+# dependency degrades a capability, never breaks the connector. Without Npcap
+# everything runs; only LOCAL LLDP capture is unavailable, and the usual
+# source of LLDP is the device's own API anyway. Set true on hosts whose job
+# actually is local capture.
+dhs_capture_npcap_required: false

--- a/ansible/roles/dhs_capture/meta/main.yml
+++ b/ansible/roles/dhs_capture/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  role_name: dhs_capture
+  author: by-rune
+  description: >-
+    Ensure a fleet host can capture raw LLDP frames — cap_net_raw on the dhs
+    binary on Linux (AF_PACKET needs no package), Npcap on Windows (verified,
+    and installed only from an operator-supplied OEM installer, because the
+    free edition permits neither redistribution nor silent install).
+    Idempotent: run-twice = 0 changes.
+  license: see repository
+  min_ansible_version: "2.14"
+  platforms:
+    - name: EL
+      versions: [all]
+    - name: Debian
+      versions: [all]
+    - name: Ubuntu
+      versions: [all]
+    - name: Windows
+      versions: [all]
+dependencies: []

--- a/ansible/roles/dhs_capture/tasks/linux.yml
+++ b/ansible/roles/dhs_capture/tasks/linux.yml
@@ -1,0 +1,40 @@
+---
+# AF_PACKET needs CAP_NET_RAW. Granting it to the binary keeps dhs off root:
+# a producer that runs as root to read one Ethertype is a much larger blast
+# radius than the capability it actually needs.
+- name: libcap tooling present (provides setcap/getcap)
+  ansible.builtin.package:
+    name: "{{ 'libcap2-bin' if ansible_os_family == 'Debian' else 'libcap' }}"
+    state: present
+  when: dhs_capture_linux_setcap | bool
+
+- name: dhs binary present before granting a capability
+  ansible.builtin.stat:
+    path: "{{ dhs_bin }}"
+  register: dhs_capture_bin
+
+# Read first, write only on a mismatch — setcap is not itself idempotent in
+# its exit status, so the check is what makes run-twice = 0 changes.
+- name: Current file capabilities on the dhs binary
+  ansible.builtin.command:
+    argv: [getcap, "{{ dhs_bin }}"]
+  register: dhs_capture_getcap
+  changed_when: false
+  failed_when: false
+  when: dhs_capture_linux_setcap | bool and dhs_capture_bin.stat.exists
+
+- name: Grant cap_net_raw to the dhs binary
+  ansible.builtin.command:
+    argv: [setcap, "{{ dhs_capture_linux_capability }}", "{{ dhs_bin }}"]
+  when:
+    - dhs_capture_linux_setcap | bool
+    - dhs_capture_bin.stat.exists
+    - dhs_capture_linux_capability.split('+')[0] not in (dhs_capture_getcap.stdout | default(''))
+  changed_when: true
+
+- name: Report the capture posture
+  ansible.builtin.debug:
+    msg: >-
+      LLDP capture {{ 'ENABLED' if dhs_capture_bin.stat.exists and dhs_capture_linux_setcap | bool
+      else 'not configured' }} on {{ inventory_hostname }} —
+      AF_PACKET via stdlib syscall, no package required.

--- a/ansible/roles/dhs_capture/tasks/main.yml
+++ b/ansible/roles/dhs_capture/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Converge (Linux — cap_net_raw on the dhs binary)
+  ansible.builtin.include_tasks: linux.yml
+  when: ansible_os_family != "Windows"
+
+- name: Converge (Windows — Npcap)
+  ansible.builtin.include_tasks: windows.yml
+  when: ansible_os_family == "Windows"

--- a/ansible/roles/dhs_capture/tasks/windows.yml
+++ b/ansible/roles/dhs_capture/tasks/windows.yml
@@ -1,0 +1,96 @@
+---
+# Unlike Bonjour, Npcap is NOT staged from internal/amwa/assets/. Its free
+# licence forbids redistribution, so committing the installer to this repo
+# would breach it. The role therefore VERIFIES by default and only installs
+# when the operator points it at an OEM installer they hold themselves.
+
+- name: Npcap DLL present?
+  ansible.windows.win_stat:
+    path: "{{ dhs_capture_npcap_dll }}"
+  register: dhs_capture_npcap_dll_stat
+
+- name: Npcap driver service present?
+  ansible.windows.win_service_info:
+    name: "{{ dhs_capture_npcap_service }}"
+  register: dhs_capture_npcap_svc
+  failed_when: false
+
+- name: Resolve whether Npcap is installed
+  ansible.builtin.set_fact:
+    dhs_capture_npcap_present: >-
+      {{ dhs_capture_npcap_dll_stat.stat.exists
+         or (dhs_capture_npcap_svc.services | default([]) | length > 0) }}
+
+# ---- optional install, OEM only --------------------------------------------
+# /S exists in Npcap OEM and nowhere else; the free installer has no silent
+# mode, so there is no unattended path for it and none is attempted here.
+- name: Install Npcap from the operator-supplied OEM installer
+  when:
+    - not (dhs_capture_npcap_present | bool)
+    - dhs_capture_npcap_oem_installer_src | length > 0
+  block:
+    - name: Installer drop directory
+      ansible.windows.win_file:
+        path: "{{ dhs_capture_npcap_installer_dst | win_dirname }}"
+        state: directory
+
+    - name: Stage the OEM installer
+      ansible.windows.win_copy:
+        src: "{{ dhs_capture_npcap_oem_installer_src }}"
+        dest: "{{ dhs_capture_npcap_installer_dst }}"
+
+    # The installer backgrounds itself even in silent mode, so it must be
+    # waited on or the exit code read back is the launcher's, not the
+    # install's.
+    - name: Install Npcap silently (OEM /S)
+      ansible.windows.win_shell: |
+        $ErrorActionPreference = 'Stop'
+        $p = Start-Process -FilePath '{{ dhs_capture_npcap_installer_dst }}' `
+                           -ArgumentList '/S' -Wait -PassThru
+        if ($p.ExitCode -ne 0) { throw "npcap installer exit $($p.ExitCode)" }
+        'CHANGED'
+      register: dhs_capture_npcap_install
+      changed_when: "'CHANGED' in dhs_capture_npcap_install.stdout"
+
+    - name: Re-check the DLL after install
+      ansible.windows.win_stat:
+        path: "{{ dhs_capture_npcap_dll }}"
+      register: dhs_capture_npcap_dll_stat
+
+    - name: Refresh the resolved state
+      ansible.builtin.set_fact:
+        dhs_capture_npcap_present: "{{ dhs_capture_npcap_dll_stat.stat.exists }}"
+
+# ---- verdict ---------------------------------------------------------------
+# Failing is opt-in. ADR-0016's stdlib floor: a missing host dependency
+# degrades one capability, it does not break the connector.
+- name: Npcap is required on this host but absent
+  ansible.builtin.fail:
+    msg: >-
+      Npcap is not installed on {{ inventory_hostname }} and
+      dhs_capture_npcap_required is true.
+      Windows cannot capture LLDP without it — raw sockets there are
+      IP-level and never see Ethertype 0x88CC.
+      There is no unattended install for the FREE edition (/S is Npcap OEM
+      only), and its licence caps free use at five systems with no
+      redistribution, so this repo cannot stage it the way it stages Bonjour.
+      Three lawful routes, cheapest first:
+        1. install Wireshark on this host — it bundles Npcap under the
+           exception that makes the bundle unlimited, and the fleet already
+           wants tshark for the dissectors;
+        2. install Npcap by hand from https://npcap.com/ (within the
+           five-system cap);
+        3. buy an OEM licence and set dhs_capture_npcap_oem_installer_src
+           to the installer, which this role will then install silently.
+      Or take LLDP from the device's own API instead of capturing locally,
+      which needs none of the above.
+  when:
+    - not (dhs_capture_npcap_present | bool)
+    - dhs_capture_npcap_required | bool
+
+- name: Report the capture posture
+  ansible.builtin.debug:
+    msg: >-
+      LLDP capture {{ 'ENABLED (Npcap present)' if dhs_capture_npcap_present | bool
+      else 'UNAVAILABLE (no Npcap) — device-reported LLDP still works' }}
+      on {{ inventory_hostname }}.

--- a/docs/adr/0005-deps.json
+++ b/docs/adr/0005-deps.json
@@ -1,11 +1,13 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "policy": {
     "default": "stdlib-only",
     "exception_process_adr": "0014",
     "codec_layer_rule_adr": "0006",
     "multi_os_rule_adr": "0016",
-    "ci_gate": "tools/check-deps.sh"
+    "ci_gate": "tools/check-deps.sh",
+    "host_dep_rule_adr": "0016",
+    "host_dep_note": "host_deps are NOT Go modules and never enter go.mod. They are software the OPERATOR installs on the host to upgrade a capability. Every one of them is optional by ADR-0016's stdlib-floor rule: without it the connector runs degraded, never broken. tools/check-deps.sh does not gate them — it matches on \"module\", which host entries deliberately do not carry."
   },
   "deps": [
     {
@@ -31,10 +33,20 @@
       "transitive_deps": null,
       "cve_last_check": null,
       "cve_status": null,
-      "tooling": ["govulncheck", "osv-scanner", "go-licenses"],
-      "scope": ["linux", "darwin", "windows"],
+      "tooling": [
+        "govulncheck",
+        "osv-scanner",
+        "go-licenses"
+      ],
+      "scope": [
+        "linux",
+        "darwin",
+        "windows"
+      ],
       "reason": "no stdlib WebSocket; ws+wss native via stdlib TLS",
-      "adr_refs": ["0003"],
+      "adr_refs": [
+        "0003"
+      ],
       "approved_at": "2026-05-03",
       "approved_by": "yboujraf"
     },
@@ -61,10 +73,19 @@
       "transitive_deps": null,
       "cve_last_check": null,
       "cve_status": null,
-      "tooling": ["govulncheck", "osv-scanner", "go-licenses"],
-      "scope": ["linux"],
+      "tooling": [
+        "govulncheck",
+        "osv-scanner",
+        "go-licenses"
+      ],
+      "scope": [
+        "linux"
+      ],
       "reason": "Linux Avahi via DBus; no stdlib DBus",
-      "adr_refs": ["0012", "0016"],
+      "adr_refs": [
+        "0012",
+        "0016"
+      ],
       "approved_at": "2026-05-03",
       "approved_by": "yboujraf"
     },
@@ -91,10 +112,22 @@
       "transitive_deps": null,
       "cve_last_check": null,
       "cve_status": null,
-      "tooling": ["govulncheck", "osv-scanner", "go-licenses"],
-      "scope": ["linux", "darwin", "windows"],
+      "tooling": [
+        "govulncheck",
+        "osv-scanner",
+        "go-licenses"
+      ],
+      "scope": [
+        "linux",
+        "darwin",
+        "windows"
+      ],
       "reason": "secrets manager client SDK; signs licenses via Transit engine (ADR-0003), reads runtime secrets via KV",
-      "adr_refs": ["0003", "0010", "0011"],
+      "adr_refs": [
+        "0003",
+        "0010",
+        "0011"
+      ],
       "approved_at": "2026-05-03",
       "approved_by": "yboujraf"
     },
@@ -121,10 +154,20 @@
       "transitive_deps": null,
       "cve_last_check": null,
       "cve_status": null,
-      "tooling": ["govulncheck", "osv-scanner", "go-licenses"],
-      "scope": ["linux", "darwin", "windows"],
+      "tooling": [
+        "govulncheck",
+        "osv-scanner",
+        "go-licenses"
+      ],
+      "scope": [
+        "linux",
+        "darwin",
+        "windows"
+      ],
       "reason": "plugin hot un-register supervisor (ADR-0009)",
-      "adr_refs": ["0009"],
+      "adr_refs": [
+        "0009"
+      ],
       "approved_at": "2026-05-03",
       "approved_by": "yboujraf"
     },
@@ -151,12 +194,194 @@
       "transitive_deps": null,
       "cve_last_check": null,
       "cve_status": null,
-      "tooling": ["govulncheck", "osv-scanner", "go-licenses"],
-      "scope": ["linux", "darwin", "windows"],
+      "tooling": [
+        "govulncheck",
+        "osv-scanner",
+        "go-licenses"
+      ],
+      "scope": [
+        "linux",
+        "darwin",
+        "windows"
+      ],
       "reason": "license format JWT-EdDSA (ADR-0003); native Ed25519 support per RFC 8037",
-      "adr_refs": ["0003"],
+      "adr_refs": [
+        "0003"
+      ],
       "approved_at": "2026-05-03",
       "approved_by": "yboujraf"
+    }
+  ],
+  "host_deps": [
+    {
+      "id": "avahi-daemon",
+      "name": "Avahi mDNS/DNS-SD daemon",
+      "os": [
+        "linux"
+      ],
+      "version": null,
+      "url": "https://avahi.org/",
+      "license": {
+        "spdx": "LGPL-2.1-or-later",
+        "file_url": "https://github.com/avahi/avahi/blob/master/LICENSE"
+      },
+      "redistributable_by_us": false,
+      "redistribution_note": "System package. Installed by the operator's package manager; dhs never ships it.",
+      "capability": "DNS-SD browse + advertise delegated to the system daemon",
+      "needed_for": [
+        "internal/amwa/session/dnssd"
+      ],
+      "talks_via": "github.com/godbus/dbus/v5 on the system bus (pure Go, no CGo)",
+      "cgo": false,
+      "fallback": "internal/amwa/session/dnssd stdlib mDNS on 224.0.0.251:5353",
+      "without_it": "Works, degraded: 500ms read-deadline jitter makes AMWA cascade-timing tests (test_05/15/16) unreliable.",
+      "install": {
+        "debian": "apt-get install -y avahi-daemon libnss-mdns",
+        "rhel": "dnf install -y avahi avahi-tools"
+      },
+      "cve_last_check": null,
+      "cve_status": null,
+      "adr_refs": [
+        "0016"
+      ],
+      "status": "shipped"
+    },
+    {
+      "id": "bonjour-windows",
+      "name": "Bonjour Service for Windows (dnssd.dll)",
+      "os": [
+        "windows"
+      ],
+      "version": null,
+      "url": "https://developer.apple.com/bonjour/",
+      "license": {
+        "spdx": "Apache-2.0",
+        "file_url": "https://github.com/apple-oss-distributions/mDNSResponder",
+        "note": "mDNSResponder SOURCE is Apache-2.0. Apple's Windows SDK/installer is a separate distribution; bundling it in a product needs an agreement with Apple. Operator-installed here, so we redistribute nothing."
+      },
+      "redistributable_by_us": false,
+      "redistribution_note": "Operator downloads from Apple (registration required). Matches how Cerebrum and nmos-cpp behave on Windows.",
+      "capability": "DNS-SD browse + advertise delegated to the Bonjour service",
+      "needed_for": [
+        "internal/amwa/session/dnssd"
+      ],
+      "talks_via": "dnssd.dll",
+      "cgo": true,
+      "fallback": "internal/amwa/session/dnssd stdlib mDNS on 224.0.0.251:5353",
+      "without_it": "Works, degraded: same cascade-timing jitter as a Linux host with no Avahi.",
+      "install": {
+        "windows": "Install \"Bonjour Print Services for Windows\" or the Bonjour SDK for Windows from Apple (manual download)."
+      },
+      "cve_last_check": null,
+      "cve_status": null,
+      "adr_refs": [
+        "0016"
+      ],
+      "status": "planned",
+      "tracking": "#195",
+      "blocked_on": "ADR-0016 CGo wrapper conflict (Path A vs Path B) is unresolved; CGo also breaks CGO_ENABLED=0 cross-compile."
+    },
+    {
+      "id": "bonjour-macos",
+      "name": "Bonjour (built into macOS)",
+      "os": [
+        "darwin"
+      ],
+      "version": null,
+      "url": "https://developer.apple.com/bonjour/",
+      "license": {
+        "spdx": "Apache-2.0",
+        "note": "Part of the OS. Nothing to install, nothing to redistribute."
+      },
+      "redistributable_by_us": false,
+      "redistribution_note": "Present on every macOS host; no install step.",
+      "capability": "DNS-SD browse + advertise delegated to the system daemon",
+      "needed_for": [
+        "internal/amwa/session/dnssd"
+      ],
+      "talks_via": "libSystem / CoreServices",
+      "cgo": true,
+      "fallback": "internal/amwa/session/dnssd stdlib mDNS on 224.0.0.251:5353",
+      "without_it": "N/A — the daemon is always present; only our CGo binding is unwritten.",
+      "install": {
+        "darwin": "none — shipped with the OS"
+      },
+      "cve_last_check": null,
+      "cve_status": null,
+      "adr_refs": [
+        "0016"
+      ],
+      "status": "planned",
+      "tracking": "#196",
+      "blocked_on": "Same CGo wrapper conflict as bonjour-windows."
+    },
+    {
+      "id": "npcap",
+      "name": "Npcap packet capture driver",
+      "os": [
+        "windows"
+      ],
+      "version": null,
+      "url": "https://npcap.com/",
+      "license": {
+        "spdx": "LicenseRef-Npcap",
+        "file_url": "https://npcap.com/oem/",
+        "note": "NOT open source and NOT unrestricted. Free edition: use on at most 5 systems and NO external redistribution. Unlimited only when deployed exclusively alongside Wireshark, Nmap or Microsoft Defender for Identity. Any other fleet-wide or bundled use needs a paid OEM licence from Nmap Software LLC."
+      },
+      "redistributable_by_us": false,
+      "redistribution_note": "Hard blocker for bundling. We never ship it; the operator installs it, and on any host that already has Wireshark it is present under the unlimited exception.",
+      "capability": "Capture raw LLDP frames (Ethertype 0x88CC) on a local interface",
+      "needed_for": [
+        "internal/lldp (planned)"
+      ],
+      "talks_via": "Npcap driver + wpcap.dll",
+      "cgo": true,
+      "fallback": "Device-reported LLDP over the device's own API; no local capture.",
+      "without_it": "Windows cannot capture LLDP locally at all: Windows raw sockets are IP-level and cannot see non-IP Ethertypes. IS-04 attached_network_device stays unset unless another source supplies it.",
+      "install": {
+        "windows": "Install Npcap from https://npcap.com/ (manual), or note that Wireshark already bundles it."
+      },
+      "cve_last_check": null,
+      "cve_status": null,
+      "adr_refs": [
+        "0016"
+      ],
+      "status": "not-adopted",
+      "decision_pending": "Licence terms conflict with fleet-wide deployment. Preferred answer is to avoid it entirely: take LLDP from the device's own API rather than capturing on the host."
+    },
+    {
+      "id": "raw-capture-privilege",
+      "name": "Raw-capture privilege (no package)",
+      "os": [
+        "linux",
+        "darwin"
+      ],
+      "version": null,
+      "url": null,
+      "license": {
+        "spdx": null,
+        "note": "Kernel interface, not a library. Nothing to install or licence."
+      },
+      "redistributable_by_us": null,
+      "redistribution_note": "N/A.",
+      "capability": "Capture raw LLDP frames (Ethertype 0x88CC) via AF_PACKET (Linux) or BPF (macOS)",
+      "needed_for": [
+        "internal/lldp (planned)"
+      ],
+      "talks_via": "syscall (stdlib) — AF_PACKET socket on Linux, /dev/bpf* on macOS",
+      "cgo": false,
+      "fallback": "Device-reported LLDP; no local capture.",
+      "without_it": "Capture returns a typed permission error; everything else runs.",
+      "install": {
+        "linux": "setcap cap_net_raw+ep /usr/local/bin/dhs   (or run as root)",
+        "darwin": "run as root, or grant access to /dev/bpf*"
+      },
+      "cve_last_check": null,
+      "cve_status": null,
+      "adr_refs": [
+        "0016"
+      ],
+      "status": "planned"
     }
   ]
 }

--- a/docs/adr/0016-multi-os-support.md
+++ b/docs/adr/0016-multi-os-support.md
@@ -58,6 +58,33 @@ Every per-OS dep entry in `0005-deps.json` (per ADR-0005) carries:
 - CVE history + transitive dep count
 - Per-OS install command
 
+These live in that manifest's `host_deps` array — separate from `deps`,
+which is Go modules only. A host dep is software the OPERATOR installs;
+it never enters `go.mod`, and `tools/check-deps.sh` does not gate it
+(the script matches on `module`, which host entries do not carry).
+
+Every host dep is OPTIONAL by the stdlib-floor rule above: without it
+the connector runs degraded, never broken. The array records what each
+one buys, what happens without it, and — because two of them are not
+freely redistributable — whether we may ship it. We may not ship any of
+them, so all of them are operator-installed:
+
+| Host dep | OS | Buys | Without it |
+|---|---|---|---|
+| `avahi-daemon` | Linux | DNS-SD via system daemon | stdlib mDNS, cascade-timing jitter |
+| `bonjour-windows` | Windows | DNS-SD via `dnssd.dll` | stdlib mDNS, same jitter |
+| `bonjour-macos` | macOS | DNS-SD via libSystem | stdlib mDNS, same jitter |
+| `npcap` | Windows | local LLDP frame capture | no local capture at all |
+| `raw-capture-privilege` | Linux/macOS | local LLDP frame capture | typed permission error |
+
+**Npcap is the one to read before planning around it.** Its free edition
+allows at most five systems and NO redistribution; unlimited use applies
+only when it is deployed exclusively alongside Wireshark, Nmap or
+Microsoft Defender for Identity. Anything fleet-wide needs a paid OEM
+licence. That is why the preferred source of LLDP is the device's own
+API rather than capturing on the host — see the entry's
+`decision_pending`.
+
 ### Per-connector deliverables
 
 | File | Required content |

--- a/internal/amwa/dependencies_test.go
+++ b/internal/amwa/dependencies_test.go
@@ -190,6 +190,7 @@ func isCrossProtocol(importPath string) bool {
 		"metrics",
 		"transport",
 		"auth",
+		"lldp",
 		"export",
 		"scenario",
 		"amwa",

--- a/internal/amwa/provider/configuration.go
+++ b/internal/amwa/provider/configuration.go
@@ -61,12 +61,12 @@ type configProperty struct {
 
 // configObject is one Device Model object, addressed by role path.
 type configObject struct {
-	classID  ms05.NcClassId
-	oid      ms05.NcOid
-	role     string
-	path     []string // role path as array, ["root", ...]
-	class    ms05.NcClassDescriptor
-	props    []*configProperty // flattened-descriptor order (own first)
+	classID ms05.NcClassId
+	oid     ms05.NcOid
+	role    string
+	path    []string // role path as array, ["root", ...]
+	class   ms05.NcClassDescriptor
+	props   []*configProperty // flattened-descriptor order (own first)
 }
 
 // IS14ConfigurationServer serves the Configuration API for one Node.

--- a/internal/amwa/provider/connection_state.go
+++ b/internal/amwa/provider/connection_state.go
@@ -579,6 +579,7 @@ func splitBroker(addr string) (string, int) {
 	}
 	return host, port
 }
+
 const (
 	transportWebSocketURN = "urn:x-nmos:transport:websocket"
 	transportMQTTURN      = "urn:x-nmos:transport:mqtt"

--- a/internal/amwa/provider/mxl_test.go
+++ b/internal/amwa/provider/mxl_test.go
@@ -109,9 +109,9 @@ func TestMXLSenderIS04Rules(t *testing.T) {
 		t.Fatalf("sender GET = %d", st)
 	}
 	var snd struct {
-		Transport         string          `json:"transport"`
-		ManifestHref      *string         `json:"manifest_href"`
-		InterfaceBindings []string        `json:"interface_bindings"`
+		Transport         string   `json:"transport"`
+		ManifestHref      *string  `json:"manifest_href"`
+		InterfaceBindings []string `json:"interface_bindings"`
 	}
 	if err := json.Unmarshal(body, &snd); err != nil {
 		t.Fatalf("decode sender: %v", err)

--- a/internal/amwa/provider/node.go
+++ b/internal/amwa/provider/node.go
@@ -23,6 +23,7 @@ import (
 	"dhs/internal/amwa/session/certmgr"
 	dnssdsession "dhs/internal/amwa/session/dnssd"
 	httpsession "dhs/internal/amwa/session/http"
+	"dhs/internal/lldp"
 
 	"dhs/internal/amwa/codec/est"
 )
@@ -99,6 +100,18 @@ type IS04NodeConfig struct {
 	// per IS-04 §3.1 for plants that block multicast.
 	UnicastResolver string
 	UnicastDomain   string
+
+	// LLDP supplies interfaces[].attached_network_device. Nil leaves the
+	// field unset, which is its correct value when the Node does not know
+	// what it is patched into — IS-04 v1.3 defines it as what this Node
+	// "received in LLDP", so it can only come from outside.
+	//
+	// Injected, not constructed: lldp.Capture reads local frames where the
+	// platform allows it, a device that reports its own LLDP over an API
+	// satisfies the same interface with no privileges, and on Windows the
+	// latter is the only option. Wrap in lldp.NewCache to bound how often
+	// a slow source is consulted.
+	LLDP lldp.Source
 
 	// RegistryURL — when non-empty the producer also registers itself
 	// against this Registration API base (e.g. http://10.6.239.113:8235/).
@@ -440,6 +453,11 @@ func (s *IS04NodeServer) Serve(ctx context.Context) error {
 	s.secure = s.cfg.ESTHost != "" || s.cfg.TLSCertFile != ""
 
 	expandNodeEndpoints(&s.bundle.Node, s.cfg.AdvertiseHost, s.cfg.Bind, s.authOn())
+
+	// attached_network_device before anything publishes the Node: the mDNS
+	// announce, the served /node resource and the registration POST all read
+	// this same bundle, so filling it here covers all three.
+	s.applyLLDPLocked(ctx)
 
 	// The Node's own href follows the same authority: it is the Node
 	// API base a controller will fetch, and a bundle-file leftover

--- a/internal/amwa/provider/node_lldp.go
+++ b/internal/amwa/provider/node_lldp.go
@@ -1,0 +1,110 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"dhs/internal/amwa/codec/is04"
+	"dhs/internal/lldp"
+)
+
+// lldpResolveTimeout bounds the neighbour lookup during Serve.
+//
+// Serve must not stall on it: a capture Source waits for frames that arrive
+// on the SENDER's schedule (30s by default), and a Node that refused to start
+// until a switch spoke would be down for half a minute after every restart.
+// An unanswered lookup leaves attached_network_device unset, which is what
+// the field means when the Node does not know.
+const lldpResolveTimeout = 3 * time.Second
+
+// applyLLDPLocked fills interfaces[].attached_network_device from the injected
+// LLDP source.
+//
+// IS-04 v1.3 defines that object as "the Chassis ID … as signalled in LLDP
+// received by this Node", so it can only come from outside — the Node cannot
+// know which switch port it is patched into by looking at itself. The source
+// is injected rather than constructed here: a device that reports its own LLDP
+// over an API is as valid as a local capture, and on Windows it is the only
+// option there is.
+//
+// Never fatal. ADR-0016's stdlib floor says a missing host capability degrades
+// a field, it does not stop the Node — a plant where LLDP is switched off must
+// still get a registered, routable Node.
+//
+// Caller holds s.mu.
+func (s *IS04NodeServer) applyLLDPLocked(ctx context.Context) {
+	if s.cfg.LLDP == nil || len(s.bundle.Node.Interfaces) == 0 {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, lldpResolveTimeout)
+	defer cancel()
+
+	seen, err := s.cfg.LLDP.Neighbors(ctx)
+	if err != nil {
+		// Not being able to capture is a property of the platform, not a
+		// fault: logging it at Warn on every Windows start would train
+		// operators to ignore the level that matters.
+		if errors.Is(err, lldp.ErrCaptureUnsupported) {
+			s.logger.Debug("provider/node: no local LLDP capture on this platform; "+
+				"attached_network_device unset unless another source supplies it",
+				"err", err)
+		} else {
+			s.logger.Warn("provider/node: LLDP lookup failed; "+
+				"attached_network_device left unset", "err", err)
+		}
+		// A partial result is still worth using: a Cache serves its stale
+		// view alongside the error rather than nothing.
+		if len(seen) == 0 {
+			return
+		}
+	}
+
+	filled := 0
+	for i := range s.bundle.Node.Interfaces {
+		iface := &s.bundle.Node.Interfaces[i]
+		n, ok := seen[iface.Name]
+		if !ok {
+			continue
+		}
+		// Both members are REQUIRED by the schema once the object exists,
+		// so a neighbour missing either is skipped entirely. Emitting a
+		// half-filled object would fail validation for every reader.
+		if n.ChassisID == "" || n.PortID == "" {
+			s.logger.Debug("provider/node: LLDP neighbour lacks a required id; skipping",
+				"interface", iface.Name, "chassis_id", n.ChassisID, "port_id", n.PortID)
+			continue
+		}
+		iface.AttachedNetworkDevice = &is04.AttachedNetworkDevice{
+			ChassisID: n.ChassisID,
+			PortID:    n.PortID,
+		}
+		filled++
+		s.logger.Info("provider/node: attached network device from LLDP",
+			"interface", iface.Name, "chassis_id", n.ChassisID, "port_id", n.PortID,
+			"switch", n.SysName, "port", n.PortDesc)
+	}
+	if filled == 0 && len(seen) > 0 {
+		// The source saw neighbours but on interface names this Node does
+		// not list — almost always a bundle whose interface names do not
+		// match the host's. Silence here would look like "no LLDP".
+		s.logger.Warn("provider/node: LLDP reported neighbours on interfaces this Node does not declare",
+			"lldp_interfaces", keysOf(seen), "node_interfaces", ifaceNames(s.bundle.Node.Interfaces))
+	}
+}
+
+func keysOf(m map[string]lldp.Neighbor) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func ifaceNames(ifs []is04.NodeIface) []string {
+	out := make([]string, 0, len(ifs))
+	for _, i := range ifs {
+		out = append(out, i.Name)
+	}
+	return out
+}

--- a/internal/amwa/provider/node_lldp_test.go
+++ b/internal/amwa/provider/node_lldp_test.go
@@ -1,0 +1,131 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"dhs/internal/amwa/codec/is04"
+	"dhs/internal/lldp"
+)
+
+// nodeWithIfaces builds the minimum server state applyLLDPLocked reads, so
+// the test does not need a whole served Node.
+func nodeWithIfaces(src lldp.Source, names ...string) *IS04NodeServer {
+	ifs := make([]is04.NodeIface, 0, len(names))
+	for _, n := range names {
+		ifs = append(ifs, is04.NodeIface{Name: n, PortID: "00-00-00-00-00-01"})
+	}
+	return &IS04NodeServer{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		cfg:    IS04NodeConfig{LLDP: src},
+		bundle: &NodeConfig{Node: is04.Node{Interfaces: ifs}},
+	}
+}
+
+func TestAttachedNetworkDeviceFromLLDP(t *testing.T) {
+	s := nodeWithIfaces(lldp.StaticSource{
+		"eth0": {ChassisID: "00-11-22-33-44-55", PortID: "aa-bb-cc-dd-ee-ff", SysName: "core-sw-1"},
+	}, "eth0", "eth1")
+	s.applyLLDPLocked(context.Background())
+
+	got := s.bundle.Node.Interfaces[0].AttachedNetworkDevice
+	if got == nil {
+		t.Fatal("eth0 had a neighbour and must carry attached_network_device")
+	}
+	if got.ChassisID != "00-11-22-33-44-55" || got.PortID != "aa-bb-cc-dd-ee-ff" {
+		t.Errorf("got %+v", got)
+	}
+	// eth1 had no neighbour: absent is the correct value, not an empty object.
+	if s.bundle.Node.Interfaces[1].AttachedNetworkDevice != nil {
+		t.Error("an interface with no neighbour must leave the field unset")
+	}
+}
+
+// Both members are required once the object exists, so a neighbour missing
+// either must produce no object at all rather than one that fails validation
+// for every reader.
+func TestHalfFilledNeighbourIsSkipped(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		n    lldp.Neighbor
+	}{
+		{"no chassis", lldp.Neighbor{PortID: "aa-bb-cc-dd-ee-ff"}},
+		{"no port", lldp.Neighbor{ChassisID: "00-11-22-33-44-55"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := nodeWithIfaces(lldp.StaticSource{"eth0": tc.n}, "eth0")
+			s.applyLLDPLocked(context.Background())
+			if s.bundle.Node.Interfaces[0].AttachedNetworkDevice != nil {
+				t.Error("a half-filled neighbour must not become a half-filled object")
+			}
+		})
+	}
+}
+
+// A plant with LLDP switched off, or a Windows host with no capture, must
+// still produce a usable Node.
+func TestLLDPFailureIsNeverFatal(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"capture unsupported", lldp.ErrCaptureUnsupported},
+		{"source broken", errors.New("switch unreachable")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := nodeWithIfaces(lldp.SourceFunc(func(context.Context) (map[string]lldp.Neighbor, error) {
+				return nil, tc.err
+			}), "eth0")
+			s.applyLLDPLocked(context.Background())
+			if s.bundle.Node.Interfaces[0].AttachedNetworkDevice != nil {
+				t.Error("a failed lookup must leave the field unset, not invent one")
+			}
+		})
+	}
+}
+
+// A Cache serves its stale view alongside the error. That partial result is
+// still worth using — dropping it would blank a field that was correct a
+// moment ago because one refresh failed.
+func TestPartialResultWithErrorIsStillUsed(t *testing.T) {
+	s := nodeWithIfaces(lldp.SourceFunc(func(context.Context) (map[string]lldp.Neighbor, error) {
+		return map[string]lldp.Neighbor{
+			"eth0": {ChassisID: "00-11-22-33-44-55", PortID: "aa-bb-cc-dd-ee-ff"},
+		}, errors.New("refresh failed, serving stale")
+	}), "eth0")
+	s.applyLLDPLocked(context.Background())
+	if s.bundle.Node.Interfaces[0].AttachedNetworkDevice == nil {
+		t.Error("a stale-but-present neighbour must still fill the field")
+	}
+}
+
+func TestNoSourceIsANoOp(t *testing.T) {
+	s := nodeWithIfaces(nil, "eth0")
+	s.applyLLDPLocked(context.Background())
+	if s.bundle.Node.Interfaces[0].AttachedNetworkDevice != nil {
+		t.Error("no source means the Node does not know; the field stays unset")
+	}
+}
+
+func TestNoInterfacesIsANoOp(t *testing.T) {
+	s := nodeWithIfaces(lldp.StaticSource{"eth0": {ChassisID: "a", PortID: "b"}})
+	s.applyLLDPLocked(context.Background())
+	if len(s.bundle.Node.Interfaces) != 0 {
+		t.Error("interfaces must not be invented from LLDP")
+	}
+}
+
+// Neighbours on names the Node does not declare is the classic
+// bundle-vs-host mismatch, and must not pass silently as "no LLDP".
+func TestNeighboursOnUndeclaredInterfaces(t *testing.T) {
+	s := nodeWithIfaces(lldp.StaticSource{
+		"ens192": {ChassisID: "00-11-22-33-44-55", PortID: "aa-bb-cc-dd-ee-ff"},
+	}, "eth0")
+	s.applyLLDPLocked(context.Background())
+	if s.bundle.Node.Interfaces[0].AttachedNetworkDevice != nil {
+		t.Error("a neighbour on another interface must not be applied to eth0")
+	}
+}

--- a/internal/amwa/provider/registration_client.go
+++ b/internal/amwa/provider/registration_client.go
@@ -633,6 +633,7 @@ func (c *RegistrationClient) registerAll(ctx context.Context) error {
 //     Node MUST DELETE the stale entry and re-POST as
 //     fresh — AMWA test_21 enforces this.
 //   - other        → error.
+//
 // SetTokenSource installs the access-token supplier (BCP-003-02).
 func (c *RegistrationClient) SetTokenSource(fn func(context.Context) (string, error)) {
 	c.tokenSource = fn

--- a/internal/amwa/provider/sdp_coded_test.go
+++ b/internal/amwa/provider/sdp_coded_test.go
@@ -95,4 +95,3 @@ func TestSDPCarriesBandwidthForCodedFlow(t *testing.T) {
 		t.Errorf("SDP missing jxsv rtpmap:\n%s", sdp)
 	}
 }
-

--- a/internal/lldp/capture_linux.go
+++ b/internal/lldp/capture_linux.go
@@ -1,0 +1,154 @@
+//go:build linux
+
+package lldp
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"net"
+	"syscall"
+	"time"
+)
+
+// Capture listens for LLDP frames and answers [Source] from what it has heard.
+//
+// Linux path: an AF_PACKET socket bound to Ethertype 0x88CC. Stdlib syscall
+// only — no libpcap, no cgo. It needs CAP_NET_RAW, which the dhs_capture
+// Ansible role grants to the binary rather than running dhs as root.
+type Capture struct {
+	// Iface limits capture to one interface. Empty means every interface.
+	Iface string
+	// Window is how long Neighbors waits for frames. LLDP is announced on
+	// the sender's schedule (30 s by default), so a short window on a quiet
+	// link legitimately returns nothing; the neighbour is not gone, it just
+	// has not spoken yet. Zero means 2s.
+	Window time.Duration
+}
+
+const (
+	defaultWindow = 2 * time.Second
+	// readTick bounds one blocking read so ctx cancellation lands within a
+	// tick rather than at the end of the whole window.
+	readTick = 250 * time.Millisecond
+)
+
+// htons puts an Ethertype in network byte order for AF_PACKET's protocol
+// field, which is a host-order uint16 holding a big-endian value.
+func htons(v uint16) uint16 {
+	var b [2]byte
+	binary.BigEndian.PutUint16(b[:], v)
+	return binary.NativeEndian.Uint16(b[:])
+}
+
+// Neighbors opens the socket, listens for Window, and decodes what arrives.
+//
+// Frames that fail to decode are SKIPPED, not fatal: a malformed LLDPDU from
+// one misbehaving switch must not hide the four that are fine.
+func (c Capture) Neighbors(ctx context.Context) (map[string]Neighbor, error) {
+	byIndex, wantIdx, err := interfaceIndex(c.Iface)
+	if err != nil {
+		return nil, err
+	}
+
+	// SOCK_DGRAM, not SOCK_RAW: the kernel strips the Ethernet header and
+	// hands over the LLDPDU, which is exactly what Decode wants.
+	fd, err := syscall.Socket(syscall.AF_PACKET, syscall.SOCK_DGRAM, int(htons(EtherType)))
+	if err != nil {
+		if errors.Is(err, syscall.EPERM) || errors.Is(err, syscall.EACCES) {
+			return nil, fmt.Errorf("lldp: AF_PACKET socket needs CAP_NET_RAW "+
+				"(setcap cap_net_raw+ep on this binary, or run as root): %w", err)
+		}
+		return nil, fmt.Errorf("lldp: AF_PACKET socket: %w", err)
+	}
+	defer func() { _ = syscall.Close(fd) }()
+
+	if c.Iface != "" {
+		if err := syscall.Bind(fd, &syscall.SockaddrLinklayer{
+			Protocol: htons(EtherType),
+			Ifindex:  wantIdx,
+		}); err != nil {
+			return nil, fmt.Errorf("lldp: bind %s: %w", c.Iface, err)
+		}
+	}
+
+	window := c.Window
+	if window <= 0 {
+		window = defaultWindow
+	}
+	deadline := time.Now().Add(window)
+	if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
+		deadline = d
+	}
+
+	out := map[string]Neighbor{}
+	buf := make([]byte, 1500)
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return out, nil
+		}
+		if err := ctx.Err(); err != nil {
+			return out, err
+		}
+		tv := syscall.NsecToTimeval(int64(min(remaining, readTick)))
+		if err := syscall.SetsockoptTimeval(fd, syscall.SOL_SOCKET, syscall.SO_RCVTIMEO, &tv); err != nil {
+			return out, fmt.Errorf("lldp: set read timeout: %w", err)
+		}
+		n, from, err := syscall.Recvfrom(fd, buf, 0)
+		if err != nil {
+			if errors.Is(err, syscall.EAGAIN) || errors.Is(err, syscall.EINTR) {
+				continue
+			}
+			return out, fmt.Errorf("lldp: recv: %w", err)
+		}
+		ll, ok := from.(*syscall.SockaddrLinklayer)
+		if !ok {
+			continue
+		}
+		name := byIndex[ll.Ifindex]
+		if name == "" || (c.Iface != "" && name != c.Iface) {
+			continue
+		}
+		nb, derr := Decode(buf[:n])
+		if derr != nil {
+			continue
+		}
+		// A shutdown LLDPDU means the neighbour is leaving; recording it
+		// would publish a switch port that is no longer attached.
+		if nb.Shutdown() {
+			delete(out, name)
+			continue
+		}
+		out[name] = nb
+	}
+}
+
+// interfaceIndex maps ifindex to name and resolves the requested interface.
+//
+// A name that does not exist is an ERROR rather than an empty result: a typo
+// would otherwise present as "no neighbours", which looks identical to an
+// unplugged cable and sends the operator to the wrong end of the link.
+func interfaceIndex(want string) (map[int]string, int, error) {
+	ifs, err := net.Interfaces()
+	if err != nil {
+		return nil, 0, fmt.Errorf("lldp: list interfaces: %w", err)
+	}
+	out := make(map[int]string, len(ifs))
+	idx := -1
+	for _, i := range ifs {
+		out[i.Index] = i.Name
+		if i.Name == want {
+			idx = i.Index
+		}
+	}
+	if want != "" && idx < 0 {
+		return nil, 0, fmt.Errorf("lldp: no interface named %q on this host", want)
+	}
+	return out, idx, nil
+}
+
+// Supported reports whether this build can capture LLDP locally. True on
+// Linux, though the socket may still be refused for want of CAP_NET_RAW.
+func Supported() bool { return true }

--- a/internal/lldp/capture_linux_test.go
+++ b/internal/lldp/capture_linux_test.go
@@ -1,0 +1,81 @@
+//go:build linux
+
+package lldp
+
+import (
+	"context"
+	"encoding/binary"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSupportedIsTrueOnLinux(t *testing.T) {
+	if !Supported() {
+		t.Error("linux captures via AF_PACKET")
+	}
+}
+
+func TestHtonsIsBigEndianRegardlessOfHost(t *testing.T) {
+	var b [2]byte
+	binary.NativeEndian.PutUint16(b[:], htons(EtherType))
+	if binary.BigEndian.Uint16(b[:]) != EtherType {
+		t.Errorf("htons(0x%04X) did not land big-endian in memory", EtherType)
+	}
+}
+
+// A name that does not exist must be an ERROR, not an empty result: a typo
+// otherwise looks exactly like an unplugged cable and sends the operator to
+// the wrong end of the link. This runs before any socket is opened, so it
+// needs no privileges.
+func TestUnknownInterfaceIsAnError(t *testing.T) {
+	_, _, err := interfaceIndex("definitely-not-an-interface-0")
+	if err == nil {
+		t.Fatal("an unknown interface name must be rejected")
+	}
+	if !strings.Contains(err.Error(), "definitely-not-an-interface-0") {
+		t.Errorf("error must name the interface: %v", err)
+	}
+
+	// Neighbors resolves the interface first, so it fails the same way
+	// without needing CAP_NET_RAW.
+	if _, err := (Capture{Iface: "definitely-not-an-interface-0"}).Neighbors(context.Background()); err == nil {
+		t.Error("Neighbors must reject an unknown interface")
+	}
+}
+
+func TestInterfaceIndexResolvesARealInterface(t *testing.T) {
+	ifs, err := net.Interfaces()
+	if err != nil || len(ifs) == 0 {
+		t.Skip("no interfaces to test against")
+	}
+	want := ifs[0]
+	byIndex, idx, err := interfaceIndex(want.Name)
+	if err != nil {
+		t.Fatalf("interfaceIndex(%q): %v", want.Name, err)
+	}
+	if idx != want.Index {
+		t.Errorf("index = %d, want %d", idx, want.Index)
+	}
+	if byIndex[want.Index] != want.Name {
+		t.Errorf("byIndex[%d] = %q, want %q", want.Index, byIndex[want.Index], want.Name)
+	}
+
+	// Empty name means "every interface" and resolves to no specific index.
+	if _, idx, err := interfaceIndex(""); err != nil || idx != -1 {
+		t.Errorf("empty name: idx=%d err=%v, want -1 and no error", idx, err)
+	}
+}
+
+// Unprivileged, AF_PACKET is refused. The error must say what to do about it
+// rather than surfacing a bare EPERM.
+func TestCaptureWithoutCapabilityExplainsItself(t *testing.T) {
+	_, err := Capture{Window: time.Millisecond}.Neighbors(context.Background())
+	if err == nil {
+		t.Skip("this host can open AF_PACKET (running privileged); nothing to assert")
+	}
+	if !strings.Contains(err.Error(), "cap_net_raw") {
+		t.Errorf("a permission failure must name the capability: %v", err)
+	}
+}

--- a/internal/lldp/capture_other.go
+++ b/internal/lldp/capture_other.go
@@ -1,0 +1,40 @@
+//go:build !linux
+
+package lldp
+
+import (
+	"context"
+	"time"
+)
+
+// Capture is the no-capture build of the capture Source.
+//
+// It exists with the same shape on every OS so callers wire it identically
+// and branch on the ERROR, not on runtime.GOOS. A build-tag check scattered
+// through calling code is how platform divergence becomes invisible.
+//
+// macOS could capture through /dev/bpf* and is a legitimate future build tag.
+// Windows cannot from stdlib at all: its raw sockets are IP-level and never
+// see a non-IP Ethertype, so it needs the Npcap driver — recorded in
+// docs/adr/0005-deps.json under host_deps, and not adopted, because Npcap's
+// free licence permits five systems with no redistribution and its silent
+// installer is OEM-only.
+type Capture struct {
+	// Iface limits capture to one interface. Empty means every interface.
+	Iface string
+	// Window is how long Neighbors waits for frames. Zero means 2s.
+	Window time.Duration
+}
+
+// Neighbors always fails with [ErrCaptureUnsupported].
+//
+// It returns the typed error rather than an empty map on purpose: silently
+// reporting "no neighbours" on a host that is structurally incapable of
+// hearing any would tell an operator their switch is misconfigured when the
+// truth is that this platform never looked.
+func (Capture) Neighbors(context.Context) (map[string]Neighbor, error) {
+	return nil, ErrCaptureUnsupported
+}
+
+// Supported reports whether this build can capture LLDP locally.
+func Supported() bool { return false }

--- a/internal/lldp/capture_other_test.go
+++ b/internal/lldp/capture_other_test.go
@@ -1,0 +1,28 @@
+//go:build !linux
+
+package lldp
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// On a platform that cannot capture, the answer must be the typed error and
+// not an empty result. "No neighbours" would tell an operator their switch is
+// misconfigured when the truth is that this host never looked.
+func TestCaptureUnsupportedIsTyped(t *testing.T) {
+	got, err := Capture{Iface: "eth0"}.Neighbors(context.Background())
+	if !errors.Is(err, ErrCaptureUnsupported) {
+		t.Errorf("err = %v, want ErrCaptureUnsupported", err)
+	}
+	if got != nil {
+		t.Errorf("got %v, want no map alongside the error", got)
+	}
+}
+
+func TestSupportedIsFalseHere(t *testing.T) {
+	if Supported() {
+		t.Error("this build has no capture path and must not claim one")
+	}
+}

--- a/internal/lldp/doc.go
+++ b/internal/lldp/doc.go
@@ -1,0 +1,49 @@
+// Package lldp is the Link Layer Discovery Protocol concern: IEEE 802.1AB
+// frames, decoded into the neighbour a host sees on one interface.
+//
+// It exists because two unrelated questions in this repo need the same
+// answer shape, and neither is a protocol connector's business:
+//
+//   - an AMWA NMOS Node must publish interfaces[].attached_network_device,
+//     which IS-04 v1.3 defines as "the Chassis ID … as signalled in LLDP
+//     received by this Node";
+//   - an operator asking which switch port a device is on wants the same
+//     four fields, whoever supplies them.
+//
+// So this package is neutral infrastructure, a sibling of transport and
+// auth. It is not owned by any protocol, and no protocol package reaches
+// through it into another — internal/amwa/dependencies_test.go fails the
+// build on that.
+//
+// # The split that matters
+//
+// Decoding LLDP is pure bytes: stdlib, no I/O, every OS, no privileges.
+// OBTAINING the bytes is where the platforms diverge sharply, so the two
+// are separate. [Source] is the seam:
+//
+//	Decode      always available, everywhere
+//	Source      who supplies neighbours — injected, never assumed
+//	Capture     one Source: raw frames off a local interface
+//
+// A device that reports its own LLDP over an API is as valid a Source as a
+// capture, needs no privileges, and is the common case in a plant. Local
+// capture is the special case, not the default.
+//
+// # Why local capture is not portable
+//
+// Reading Ethertype 0x88CC means a raw link-layer socket:
+//
+//	Linux    AF_PACKET, stdlib syscall, needs CAP_NET_RAW
+//	macOS    /dev/bpf*, stdlib syscall, needs root
+//	Windows  impossible from stdlib — Windows raw sockets are IP-level and
+//	         never see a non-IP Ethertype. It needs the Npcap driver, whose
+//	         free licence permits five systems and no redistribution, and
+//	         whose silent installer is OEM-only.
+//
+// Windows therefore returns [ErrCaptureUnsupported] rather than pretending.
+// Nothing here adds a dependency on any OS: the two platforms that can
+// capture do it from syscall, and the one that cannot says so in a typed
+// error the caller can branch on. The host-side posture is recorded in
+// docs/adr/0005-deps.json under host_deps and applied by the dhs_capture
+// Ansible role.
+package lldp

--- a/internal/lldp/lldp_test.go
+++ b/internal/lldp/lldp_test.go
@@ -1,0 +1,509 @@
+package lldp
+
+// Expected behaviour comes from IEEE 802.1AB (TLV framing, the mandatory
+// TLVs and their order, the shutdown LLDPDU) and from IS-04 v1.3's
+// attached_network_device schema for the MAC rendering — not from working
+// code.
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"net"
+	"testing"
+	"time"
+)
+
+// frame assembles an LLDPDU from TLVs. Kept separate from EncodeTLVs in the
+// cases that matter so the decoder is not merely tested against its own
+// encoder.
+func frame(t *testing.T, tlvs ...TLV) []byte {
+	t.Helper()
+	b, err := EncodeTLVs(tlvs)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	return b
+}
+
+func chassisMAC(mac ...byte) TLV {
+	return TLV{Type: TypeChassisID, Value: append([]byte{ChassisSubtypeMAC}, mac...)}
+}
+
+func portMAC(mac ...byte) TLV {
+	return TLV{Type: TypePortID, Value: append([]byte{PortSubtypeMAC}, mac...)}
+}
+
+func ttl(sec uint16) TLV {
+	var b [2]byte
+	binary.BigEndian.PutUint16(b[:], sec)
+	return TLV{Type: TypeTTL, Value: b[:]}
+}
+
+func mandatory(t *testing.T) []TLV {
+	t.Helper()
+	return []TLV{
+		chassisMAC(0x00, 0x11, 0x22, 0x33, 0x44, 0x55),
+		portMAC(0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff),
+		ttl(120),
+	}
+}
+
+// ---- TLV framing -----------------------------------------------------------
+
+func TestTLVRoundTrip(t *testing.T) {
+	in := []TLV{
+		{Type: TypeChassisID, Value: []byte{ChassisSubtypeIfName, 'e', 't', 'h', '0'}},
+		{Type: TypeSysName, Value: []byte("switch-1")},
+	}
+	b, err := EncodeTLVs(in)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	out, err := DecodeTLVs(b)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out) != len(in) {
+		t.Fatalf("got %d TLVs, want %d", len(out), len(in))
+	}
+	for i := range in {
+		if out[i].Type != in[i].Type || string(out[i].Value) != string(in[i].Value) {
+			t.Errorf("TLV %d: got %+v, want %+v", i, out[i], in[i])
+		}
+	}
+}
+
+// An Ethernet frame is padded to 60 bytes. Those zeros follow the End TLV and
+// must not be read as another TLV, or nearly every real frame fails.
+func TestEndTLVStopsAtPadding(t *testing.T) {
+	b := frame(t, TLV{Type: TypeSysName, Value: []byte("sw")})
+	padded := append(b, make([]byte, 20)...)
+	out, err := DecodeTLVs(padded)
+	if err != nil {
+		t.Fatalf("padded frame must decode: %v", err)
+	}
+	if len(out) != 1 {
+		t.Errorf("got %d TLVs, want 1 — padding was read as a TLV", len(out))
+	}
+}
+
+func TestTruncatedTLVIsAnError(t *testing.T) {
+	// Header claims 10 bytes, 2 supplied.
+	b := []byte{TypeSysName << 1, 10, 'a', 'b'}
+	if _, err := DecodeTLVs(b); err == nil {
+		t.Error("a TLV claiming more bytes than remain must be an error")
+	}
+}
+
+// Missing End TLV returns the TLVs read SO FAR alongside the error, so a
+// caller that only needs the mandatory ones can still proceed.
+func TestMissingEndTLVReturnsPartial(t *testing.T) {
+	var b []byte
+	for _, tlv := range mandatory(t) {
+		var h [2]byte
+		binary.BigEndian.PutUint16(h[:], uint16(tlv.Type)<<9|uint16(len(tlv.Value)))
+		b = append(b, h[:]...)
+		b = append(b, tlv.Value...)
+	}
+	out, err := DecodeTLVs(b)
+	if !errors.Is(err, ErrNoEndTLV) {
+		t.Fatalf("err = %v, want ErrNoEndTLV", err)
+	}
+	if len(out) != 3 {
+		t.Errorf("got %d TLVs, want the 3 read before the end", len(out))
+	}
+}
+
+func TestEncodeRejectsOversizeFields(t *testing.T) {
+	if _, err := EncodeTLVs([]TLV{{Type: 128}}); err == nil {
+		t.Error("a type above the 7-bit field must be rejected")
+	}
+	if _, err := EncodeTLVs([]TLV{{Type: TypeSysName, Value: make([]byte, maxTLVLength+1)}}); err == nil {
+		t.Error("a value above the 9-bit length must be rejected")
+	}
+}
+
+// ---- Neighbor decode -------------------------------------------------------
+
+func TestDecodeFullFrame(t *testing.T) {
+	tlvs := append(mandatory(t),
+		TLV{Type: TypePortDesc, Value: []byte("GigabitEthernet1/0/7")},
+		TLV{Type: TypeSysName, Value: []byte("core-sw-1")},
+		TLV{Type: TypeSysDesc, Value: []byte("Vendor OS 1.2")},
+		// Management address: len=5 (subtype + 4), IPv4, 10.0.0.9,
+		// then interface subtype/number/OID which are not read.
+		TLV{Type: TypeMgmtAddr, Value: []byte{5, 1, 10, 0, 0, 9, 2, 0, 0, 0, 1, 0}},
+		// A vendor TLV every real switch sends; must be skipped, not fatal.
+		TLV{Type: TypeOrgSpecific, Value: []byte{0x00, 0x12, 0x0f, 0x01, 0x03}},
+	)
+	n, err := Decode(frame(t, tlvs...))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if n.ChassisID != "00-11-22-33-44-55" {
+		t.Errorf("chassis = %q, want the IS-04 hyphenated MAC form", n.ChassisID)
+	}
+	if n.PortID != "aa-bb-cc-dd-ee-ff" {
+		t.Errorf("port = %q", n.PortID)
+	}
+	if n.TTL != 120*time.Second {
+		t.Errorf("ttl = %v", n.TTL)
+	}
+	if n.SysName != "core-sw-1" || n.PortDesc != "GigabitEthernet1/0/7" || n.SysDesc != "Vendor OS 1.2" {
+		t.Errorf("strings lost: %+v", n)
+	}
+	if !n.MgmtAddr.Equal(net.IPv4(10, 0, 0, 9)) {
+		t.Errorf("mgmt addr = %v", n.MgmtAddr)
+	}
+	if n.Shutdown() {
+		t.Error("TTL 120 is not a shutdown")
+	}
+	if n.ChassisSubtype != ChassisSubtypeMAC || n.PortSubtype != PortSubtypeMAC {
+		t.Errorf("subtypes lost: %d %d", n.ChassisSubtype, n.PortSubtype)
+	}
+}
+
+// The chassis and port subtype numbering differ — MAC is 4 for a chassis and
+// 3 for a port. A shared table would render one of them as a freeform string.
+func TestSubtypeNumberingIsNotShared(t *testing.T) {
+	// Port subtype 4 is NETWORK ADDRESS, not MAC: must not be hyphenated.
+	n, err := Decode(frame(t,
+		chassisMAC(0x00, 0x11, 0x22, 0x33, 0x44, 0x55),
+		TLV{Type: TypePortID, Value: []byte{PortSubtypeNetAddr, 1, 10, 0, 0, 1}},
+		ttl(30),
+	))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if n.PortID == "01-0a-00-00-01" {
+		t.Error("port subtype 4 is a network address, not a MAC — chassis numbering was applied")
+	}
+}
+
+func TestNonMACIdentifiersStayFreeform(t *testing.T) {
+	n, err := Decode(frame(t,
+		TLV{Type: TypeChassisID, Value: append([]byte{ChassisSubtypeLocal}, []byte("chassis-7")...)},
+		TLV{Type: TypePortID, Value: append([]byte{PortSubtypeIfName}, []byte("Gi1/0/7")...)},
+		ttl(30),
+	))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if n.ChassisID != "chassis-7" || n.PortID != "Gi1/0/7" {
+		t.Errorf("freeform ids mangled: %q %q", n.ChassisID, n.PortID)
+	}
+}
+
+// A MAC subtype whose value is not six bytes is malformed. Rendering it as a
+// hyphenated MAC anyway would emit a string IS-04's schema rejects.
+func TestMACSubtypeWithWrongLengthFallsBack(t *testing.T) {
+	n, err := Decode(frame(t,
+		TLV{Type: TypeChassisID, Value: []byte{ChassisSubtypeMAC, 0x00, 0x11}},
+		portMAC(0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff),
+		ttl(30),
+	))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if n.ChassisID == "00-11" {
+		t.Error("a 2-byte MAC must not be rendered as a hyphenated MAC")
+	}
+}
+
+func TestShutdownLLDPDU(t *testing.T) {
+	n, err := Decode(frame(t,
+		chassisMAC(0x00, 0x11, 0x22, 0x33, 0x44, 0x55),
+		portMAC(0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff),
+		ttl(0),
+	))
+	if err != nil {
+		t.Fatalf("a shutdown LLDPDU is well-formed: %v", err)
+	}
+	if !n.Shutdown() {
+		t.Error("TTL 0 is the shutdown announcement")
+	}
+}
+
+func TestMandatoryTLVsRequired(t *testing.T) {
+	full := mandatory(t)
+	for _, tc := range []struct {
+		name string
+		drop int
+	}{
+		{"no chassis id", 0},
+		{"no port id", 1},
+		{"no ttl", 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var kept []TLV
+			for i, v := range full {
+				if i != tc.drop {
+					kept = append(kept, v)
+				}
+			}
+			_, err := Decode(frame(t, kept...))
+			if !errors.Is(err, ErrIncomplete) {
+				t.Errorf("err = %v, want ErrIncomplete", err)
+			}
+		})
+	}
+}
+
+func TestMalformedMandatoryTLVs(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		tlvs []TLV
+	}{
+		{"chassis with subtype only", []TLV{
+			{Type: TypeChassisID, Value: []byte{ChassisSubtypeMAC}},
+			portMAC(1, 2, 3, 4, 5, 6), ttl(30)}},
+		{"port with subtype only", []TLV{
+			chassisMAC(1, 2, 3, 4, 5, 6),
+			{Type: TypePortID, Value: []byte{PortSubtypeMAC}}, ttl(30)}},
+		{"ttl not two bytes", []TLV{
+			chassisMAC(1, 2, 3, 4, 5, 6), portMAC(1, 2, 3, 4, 5, 6),
+			{Type: TypeTTL, Value: []byte{0x01}}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := Decode(frame(t, tc.tlvs...)); err == nil {
+				t.Error("must be rejected")
+			}
+		})
+	}
+}
+
+// A truncated frame that nonetheless carried every mandatory TLV is usable —
+// they come first by requirement, so the useful half survived.
+func TestTruncatedButCompleteDecodes(t *testing.T) {
+	var b []byte
+	for _, tlv := range mandatory(t) {
+		var h [2]byte
+		binary.BigEndian.PutUint16(h[:], uint16(tlv.Type)<<9|uint16(len(tlv.Value)))
+		b = append(b, h[:]...)
+		b = append(b, tlv.Value...)
+	}
+	n, err := Decode(b)
+	if err != nil {
+		t.Fatalf("a truncated frame with all mandatory TLVs must decode: %v", err)
+	}
+	if n.ChassisID != "00-11-22-33-44-55" {
+		t.Errorf("chassis = %q", n.ChassisID)
+	}
+}
+
+func TestTruncatedAndIncompleteReportsBoth(t *testing.T) {
+	// Chassis only, no End TLV.
+	c := chassisMAC(0x00, 0x11, 0x22, 0x33, 0x44, 0x55)
+	var h [2]byte
+	binary.BigEndian.PutUint16(h[:], uint16(c.Type)<<9|uint16(len(c.Value)))
+	b := append(h[:], c.Value...)
+	_, err := Decode(b)
+	if !errors.Is(err, ErrIncomplete) || !errors.Is(err, ErrNoEndTLV) {
+		t.Errorf("err = %v, want both ErrIncomplete and ErrNoEndTLV", err)
+	}
+}
+
+func TestDecodePropagatesFramingError(t *testing.T) {
+	if _, err := Decode([]byte{TypeSysName << 1, 10, 'a'}); err == nil {
+		t.Error("a truncated TLV must fail the whole decode")
+	}
+}
+
+func TestStringHygiene(t *testing.T) {
+	n, err := Decode(frame(t, append(mandatory(t),
+		// NUL-padded fixed-width field, and an invalid UTF-8 byte.
+		TLV{Type: TypeSysName, Value: []byte("sw-1\x00\x00\x00")},
+		TLV{Type: TypeSysDesc, Value: []byte{'a', 0xff, 'b'}},
+	)...))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if n.SysName != "sw-1" {
+		t.Errorf("sysName = %q — NUL padding not trimmed", n.SysName)
+	}
+	if n.SysDesc == "a\xffb" {
+		t.Error("invalid UTF-8 must not be passed through to JSON")
+	}
+}
+
+func TestManagementAddress(t *testing.T) {
+	v6 := []byte{17, 2}
+	v6 = append(v6, net.ParseIP("2001:db8::1").To16()...)
+	for _, tc := range []struct {
+		name  string
+		value []byte
+		want  net.IP
+	}{
+		{"ipv4", []byte{5, 1, 192, 168, 1, 1}, net.IPv4(192, 168, 1, 1)},
+		{"ipv6", v6, net.ParseIP("2001:db8::1")},
+		{"unknown family", []byte{5, 99, 1, 2, 3, 4}, nil},
+		{"too short", []byte{1}, nil},
+		{"length overruns", []byte{200, 1, 10, 0, 0, 1}, nil},
+		{"zero length", []byte{0, 1}, nil},
+		{"ipv4 wrong size", []byte{3, 1, 10, 0}, nil},
+		{"ipv6 wrong size", []byte{3, 2, 10, 0}, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			n, err := Decode(frame(t, append(mandatory(t),
+				TLV{Type: TypeMgmtAddr, Value: tc.value})...))
+			if err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			switch {
+			case tc.want == nil && n.MgmtAddr != nil:
+				t.Errorf("got %v, want none", n.MgmtAddr)
+			case tc.want != nil && !n.MgmtAddr.Equal(tc.want):
+				t.Errorf("got %v, want %v", n.MgmtAddr, tc.want)
+			}
+		})
+	}
+}
+
+// Only the FIRST management address is kept; a switch may advertise several.
+func TestFirstManagementAddressWins(t *testing.T) {
+	n, err := Decode(frame(t, append(mandatory(t),
+		TLV{Type: TypeMgmtAddr, Value: []byte{5, 1, 10, 0, 0, 1}},
+		TLV{Type: TypeMgmtAddr, Value: []byte{5, 1, 10, 0, 0, 2}},
+	)...))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !n.MgmtAddr.Equal(net.IPv4(10, 0, 0, 1)) {
+		t.Errorf("got %v, want the first advertised address", n.MgmtAddr)
+	}
+}
+
+// ---- Source ----------------------------------------------------------------
+
+func TestSourceFunc(t *testing.T) {
+	want := map[string]Neighbor{"eth0": {SysName: "sw"}}
+	var s Source = SourceFunc(func(context.Context) (map[string]Neighbor, error) {
+		return want, nil
+	})
+	got, err := s.Neighbors(context.Background())
+	if err != nil || got["eth0"].SysName != "sw" {
+		t.Errorf("got %v, %v", got, err)
+	}
+}
+
+// A caller must not be able to mutate the source's own map through the
+// returned one.
+func TestStaticSourceReturnsCopy(t *testing.T) {
+	s := StaticSource{"eth0": {SysName: "sw"}}
+	got, err := s.Neighbors(context.Background())
+	if err != nil {
+		t.Fatalf("neighbors: %v", err)
+	}
+	got["eth0"] = Neighbor{SysName: "tampered"}
+	delete(got, "eth0")
+	if s["eth0"].SysName != "sw" {
+		t.Error("the source's own map was mutated through the returned one")
+	}
+}
+
+func TestCacheServesWithinTTL(t *testing.T) {
+	var calls int
+	now := time.Unix(1000, 0)
+	c := NewCache(SourceFunc(func(context.Context) (map[string]Neighbor, error) {
+		calls++
+		return map[string]Neighbor{"eth0": {SysName: "sw"}}, nil
+	}), time.Minute)
+	c.now = func() time.Time { return now }
+
+	for i := 0; i < 3; i++ {
+		if _, err := c.Neighbors(context.Background()); err != nil {
+			t.Fatalf("neighbors: %v", err)
+		}
+	}
+	if calls != 1 {
+		t.Errorf("source called %d times within the TTL, want 1", calls)
+	}
+	now = now.Add(2 * time.Minute)
+	if _, err := c.Neighbors(context.Background()); err != nil {
+		t.Fatalf("neighbors: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("source called %d times after expiry, want 2", calls)
+	}
+}
+
+func TestCacheZeroTTLAlwaysFetches(t *testing.T) {
+	var calls int
+	c := NewCache(SourceFunc(func(context.Context) (map[string]Neighbor, error) {
+		calls++
+		return map[string]Neighbor{}, nil
+	}), 0)
+	for i := 0; i < 3; i++ {
+		if _, err := c.Neighbors(context.Background()); err != nil {
+			t.Fatalf("neighbors: %v", err)
+		}
+	}
+	if calls != 3 {
+		t.Errorf("source called %d times with no TTL, want 3", calls)
+	}
+}
+
+// A momentarily unreachable source must not look like a device that
+// unplugged itself: the stale view is served WITH the error.
+func TestCacheServesStaleOnError(t *testing.T) {
+	fail := false
+	boom := errors.New("switch unreachable")
+	now := time.Unix(1000, 0)
+	c := NewCache(SourceFunc(func(context.Context) (map[string]Neighbor, error) {
+		if fail {
+			return nil, boom
+		}
+		return map[string]Neighbor{"eth0": {SysName: "sw"}}, nil
+	}), time.Minute)
+	c.now = func() time.Time { return now }
+
+	if _, err := c.Neighbors(context.Background()); err != nil {
+		t.Fatalf("warm: %v", err)
+	}
+	fail = true
+	now = now.Add(2 * time.Minute)
+	got, err := c.Neighbors(context.Background())
+	if !errors.Is(err, boom) {
+		t.Errorf("err = %v, want the source error", err)
+	}
+	if got["eth0"].SysName != "sw" {
+		t.Error("stale neighbours must survive a failed refresh")
+	}
+	// The error is remembered and reported again while the stale entry is
+	// still being served from cache.
+	now = now.Add(time.Second)
+	if _, err := c.Neighbors(context.Background()); !errors.Is(err, boom) {
+		t.Errorf("cached err = %v, want the source error", err)
+	}
+}
+
+func TestCacheColdFailureReturnsNothing(t *testing.T) {
+	boom := errors.New("no source")
+	c := NewCache(SourceFunc(func(context.Context) (map[string]Neighbor, error) {
+		return nil, boom
+	}), time.Minute)
+	got, err := c.Neighbors(context.Background())
+	if !errors.Is(err, boom) {
+		t.Errorf("err = %v", err)
+	}
+	if got != nil {
+		t.Errorf("got %v, want nothing — there is no stale view to serve", got)
+	}
+}
+
+func TestCacheReturnsCopy(t *testing.T) {
+	c := NewCache(StaticSource{"eth0": {SysName: "sw"}}, time.Minute)
+	got, err := c.Neighbors(context.Background())
+	if err != nil {
+		t.Fatalf("neighbors: %v", err)
+	}
+	delete(got, "eth0")
+	again, err := c.Neighbors(context.Background())
+	if err != nil {
+		t.Fatalf("neighbors: %v", err)
+	}
+	if again["eth0"].SysName != "sw" {
+		t.Error("the cached map was mutated through a returned copy")
+	}
+}

--- a/internal/lldp/neighbor.go
+++ b/internal/lldp/neighbor.go
@@ -1,0 +1,179 @@
+package lldp
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+// ErrNoEndTLV reports an LLDPDU that ran out of bytes before its End TLV.
+var ErrNoEndTLV = errors.New("lldp: LLDPDU ended without an End TLV")
+
+// ErrIncomplete reports an LLDPDU missing one of the three TLVs 802.1AB
+// makes mandatory (chassis ID, port ID, TTL).
+var ErrIncomplete = errors.New("lldp: LLDPDU is missing a mandatory TLV")
+
+// Neighbor is what one LLDP frame says about the device at the other end of
+// a link.
+//
+// ChassisID and PortID are formatted for direct use: a MAC-subtype value
+// becomes the lowercase hyphenated form ("00-11-22-33-44-55"), which is both
+// the IEEE display convention and exactly the pattern IS-04's
+// attached_network_device schema requires. Every other subtype stays the
+// freeform string the sender chose, which that schema also permits.
+type Neighbor struct {
+	ChassisID string
+	PortID    string
+
+	// Subtypes are kept because they are the only way to know whether an ID
+	// is a MAC, an interface name or something locally invented. Two switches
+	// can send the same string with different meanings.
+	ChassisSubtype uint8
+	PortSubtype    uint8
+
+	PortDesc string
+	SysName  string
+	SysDesc  string
+
+	// MgmtAddr is the first management address advertised, or nil.
+	MgmtAddr net.IP
+
+	// TTL is how long this neighbour stays valid. Zero is meaningful: it is
+	// the shutdown LLDPDU, the sender saying it is going away.
+	TTL time.Duration
+}
+
+// Shutdown reports whether this frame was a shutdown announcement (TTL 0),
+// which IEEE 802.1AB §8.4 requires a sender to emit when it stops. Callers
+// must drop the neighbour rather than record it with a zero lifetime.
+func (n Neighbor) Shutdown() bool { return n.TTL == 0 }
+
+// Decode parses one LLDPDU — the Ethernet PAYLOAD, with no Ethernet header —
+// into a Neighbor.
+//
+// Unknown and organisationally-specific TLVs are skipped rather than
+// rejected: every real switch sends vendor TLVs, and a decoder that failed on
+// them would report nothing on most networks.
+func Decode(pdu []byte) (Neighbor, error) {
+	tlvs, err := DecodeTLVs(pdu)
+	// A truncated LLDPDU may still carry every mandatory TLV, since those
+	// come first by requirement. Keep going and let the completeness check
+	// below decide; only report the truncation if something is actually
+	// missing.
+	if err != nil && !errors.Is(err, ErrNoEndTLV) {
+		return Neighbor{}, err
+	}
+	truncated := errors.Is(err, ErrNoEndTLV)
+
+	var (
+		n                              Neighbor
+		haveChassis, havePort, haveTTL bool
+	)
+	for _, t := range tlvs {
+		switch t.Type {
+		case TypeChassisID:
+			if len(t.Value) < 2 {
+				return Neighbor{}, fmt.Errorf("lldp: chassis ID TLV is %d bytes, need subtype + value", len(t.Value))
+			}
+			n.ChassisSubtype = t.Value[0]
+			n.ChassisID = formatID(t.Value[0] == ChassisSubtypeMAC, t.Value[1:])
+			haveChassis = true
+		case TypePortID:
+			if len(t.Value) < 2 {
+				return Neighbor{}, fmt.Errorf("lldp: port ID TLV is %d bytes, need subtype + value", len(t.Value))
+			}
+			n.PortSubtype = t.Value[0]
+			n.PortID = formatID(t.Value[0] == PortSubtypeMAC, t.Value[1:])
+			havePort = true
+		case TypeTTL:
+			if len(t.Value) != 2 {
+				return Neighbor{}, fmt.Errorf("lldp: TTL TLV is %d bytes, want 2", len(t.Value))
+			}
+			n.TTL = time.Duration(binary.BigEndian.Uint16(t.Value)) * time.Second
+			haveTTL = true
+		case TypePortDesc:
+			n.PortDesc = cleanString(t.Value)
+		case TypeSysName:
+			n.SysName = cleanString(t.Value)
+		case TypeSysDesc:
+			n.SysDesc = cleanString(t.Value)
+		case TypeMgmtAddr:
+			if ip := decodeMgmtAddr(t.Value); ip != nil && n.MgmtAddr == nil {
+				n.MgmtAddr = ip
+			}
+		}
+	}
+	if !haveChassis || !havePort || !haveTTL {
+		if truncated {
+			return Neighbor{}, fmt.Errorf("%w: %w", ErrIncomplete, ErrNoEndTLV)
+		}
+		return Neighbor{}, fmt.Errorf("%w (chassis=%t port=%t ttl=%t)",
+			ErrIncomplete, haveChassis, havePort, haveTTL)
+	}
+	return n, nil
+}
+
+// formatID renders an ID value: MACs in the lowercase hyphenated form IS-04
+// requires, everything else as the sender's own string.
+func formatID(isMAC bool, v []byte) string {
+	if isMAC && len(v) == 6 {
+		const hex = "0123456789abcdef"
+		b := make([]byte, 0, 17)
+		for i, c := range v {
+			if i > 0 {
+				b = append(b, '-')
+			}
+			b = append(b, hex[c>>4], hex[c&0x0f])
+		}
+		return string(b)
+	}
+	return cleanString(v)
+}
+
+// cleanString trims the trailing NULs switches pad fixed-width fields with,
+// and refuses to hand back invalid UTF-8.
+//
+// The UTF-8 check is not fussiness: these strings end up in JSON, and
+// encoding/json silently replaces invalid bytes with U+FFFD. A sysName that
+// arrived as Latin-1 would then be published as mojibake with no trace of
+// where it happened, so it is replaced here where the reason is visible.
+func cleanString(v []byte) string {
+	s := strings.TrimRight(string(v), "\x00")
+	s = strings.TrimSpace(s)
+	if !utf8.ValidString(s) {
+		return strings.ToValidUTF8(s, "�")
+	}
+	return s
+}
+
+// decodeMgmtAddr reads the address out of a Management Address TLV
+// (IEEE 802.1AB §8.5.9). Layout: length byte covering subtype+address, then
+// an IANA address-family subtype, then the address.
+//
+// Returns nil for anything that is not IPv4 or IPv6 — the TLV can carry any
+// IANA family, and guessing at one we cannot render is worse than omitting it.
+func decodeMgmtAddr(v []byte) net.IP {
+	if len(v) < 2 {
+		return nil
+	}
+	n := int(v[0]) // subtype + address
+	if n < 1 || 1+n > len(v) {
+		return nil
+	}
+	subtype, addr := v[1], v[2:1+n]
+	switch subtype {
+	case 1: // IANA: IPv4
+		if len(addr) == net.IPv4len {
+			return net.IP(append([]byte(nil), addr...))
+		}
+	case 2: // IANA: IPv6
+		if len(addr) == net.IPv6len {
+			return net.IP(append([]byte(nil), addr...))
+		}
+	}
+	return nil
+}

--- a/internal/lldp/source.go
+++ b/internal/lldp/source.go
@@ -1,0 +1,105 @@
+package lldp
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// ErrCaptureUnsupported reports that this OS cannot capture LLDP frames from
+// stdlib. Windows returns it always: its raw sockets are IP-level and never
+// see a non-IP Ethertype, so capture needs the Npcap driver.
+//
+// Typed so a caller can tell "this host cannot" from "this host may not"
+// (a permission error) and from "nothing arrived" (no error, no neighbour).
+// Those three deserve different operator messages.
+var ErrCaptureUnsupported = errors.New("lldp: local frame capture is not supported on this platform")
+
+// Source supplies the LLDP neighbours seen on a host's interfaces.
+//
+// This is the dependency-injection seam, and the reason the package is useful
+// beyond capture: a device that reports its own LLDP over an API satisfies
+// this interface with no privileges and no platform constraint, and is the
+// ordinary case in a plant. Capture is one implementation, not the contract.
+//
+// Neighbors returns the current view keyed by local interface name. It does
+// not block waiting for frames — LLDP is announced on the sender's own
+// schedule (30 s by default), so a caller that blocked would stall for half a
+// minute on a link that is working perfectly.
+type Source interface {
+	Neighbors(ctx context.Context) (map[string]Neighbor, error)
+}
+
+// SourceFunc adapts a function to [Source].
+type SourceFunc func(ctx context.Context) (map[string]Neighbor, error)
+
+// Neighbors calls f.
+func (f SourceFunc) Neighbors(ctx context.Context) (map[string]Neighbor, error) { return f(ctx) }
+
+// StaticSource is a fixed set of neighbours: tests, and deployments where the
+// operator knows the wiring and would rather state it than discover it.
+type StaticSource map[string]Neighbor
+
+// Neighbors returns a copy, so a caller cannot mutate the source's map.
+func (s StaticSource) Neighbors(context.Context) (map[string]Neighbor, error) {
+	out := make(map[string]Neighbor, len(s))
+	for k, v := range s {
+		out[k] = v
+	}
+	return out, nil
+}
+
+// Cache wraps a Source with an expiry, so a slow or rate-limited underlying
+// source is not consulted per request.
+//
+// The zero value is not usable; build one with [NewCache].
+type Cache struct {
+	src Source
+	ttl time.Duration
+	now func() time.Time
+
+	mu      sync.Mutex
+	at      time.Time
+	cached  map[string]Neighbor
+	lastErr error
+}
+
+// NewCache wraps src, refreshing no more often than ttl. A zero or negative
+// ttl means every call reaches src.
+func NewCache(src Source, ttl time.Duration) *Cache {
+	return &Cache{src: src, ttl: ttl, now: time.Now}
+}
+
+// Neighbors returns the cached view, refreshing when it has expired.
+//
+// On a refresh failure the STALE view is served alongside the error, rather
+// than an empty map. A momentarily unreachable source must not look like a
+// device that unplugged itself — the same reasoning that keeps JWKS keys
+// through an outage. A caller that cannot tolerate stale data checks the
+// error; one that only wants the best available ignores it.
+func (c *Cache) Neighbors(ctx context.Context) (map[string]Neighbor, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.cached != nil && c.ttl > 0 && c.now().Sub(c.at) < c.ttl {
+		return copyNeighbors(c.cached), c.lastErr
+	}
+	fresh, err := c.src.Neighbors(ctx)
+	if err != nil {
+		c.lastErr = err
+		if c.cached != nil {
+			return copyNeighbors(c.cached), err
+		}
+		return nil, err
+	}
+	c.cached, c.at, c.lastErr = fresh, c.now(), nil
+	return copyNeighbors(fresh), nil
+}
+
+func copyNeighbors(m map[string]Neighbor) map[string]Neighbor {
+	out := make(map[string]Neighbor, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/lldp/tlv.go
+++ b/internal/lldp/tlv.go
@@ -1,0 +1,116 @@
+package lldp
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// EtherType is the LLDP Ethertype (IEEE 802.1AB §8.1).
+const EtherType = 0x88CC
+
+// TLV types (IEEE 802.1AB Table 8-1). Only the ones this package reads are
+// named; anything else decodes as a TLV with its number intact, because an
+// unknown TLV is normal on the wire and must not fail a frame.
+const (
+	TypeEnd         uint8 = 0
+	TypeChassisID   uint8 = 1
+	TypePortID      uint8 = 2
+	TypeTTL         uint8 = 3
+	TypePortDesc    uint8 = 4
+	TypeSysName     uint8 = 5
+	TypeSysDesc     uint8 = 6
+	TypeSysCaps     uint8 = 7
+	TypeMgmtAddr    uint8 = 8
+	TypeOrgSpecific uint8 = 127
+)
+
+// Chassis ID subtypes (IEEE 802.1AB Table 8-2).
+const (
+	ChassisSubtypeComponent uint8 = 1
+	ChassisSubtypeIfAlias   uint8 = 2
+	ChassisSubtypePortComp  uint8 = 3
+	ChassisSubtypeMAC       uint8 = 4
+	ChassisSubtypeNetAddr   uint8 = 5
+	ChassisSubtypeIfName    uint8 = 6
+	ChassisSubtypeLocal     uint8 = 7
+)
+
+// Port ID subtypes (IEEE 802.1AB Table 8-3). Note the numbering differs from
+// chassis subtypes — MAC is 4 for a chassis and 3 for a port. Getting that
+// backwards silently turns a MAC into a freeform string, so they are separate
+// constant blocks rather than one shared set.
+const (
+	PortSubtypeIfAlias  uint8 = 1
+	PortSubtypePortComp uint8 = 2
+	PortSubtypeMAC      uint8 = 3
+	PortSubtypeNetAddr  uint8 = 4
+	PortSubtypeIfName   uint8 = 5
+	PortSubtypeCircuit  uint8 = 6
+	PortSubtypeLocal    uint8 = 7
+)
+
+// maxTLVLength is the 9-bit ceiling the header can express.
+const maxTLVLength = 511
+
+// TLV is one Type-Length-Value unit of an LLDPDU.
+type TLV struct {
+	Type  uint8
+	Value []byte
+}
+
+// DecodeTLVs splits an LLDPDU into its TLVs.
+//
+// It stops at the End TLV and ignores whatever follows, because an Ethernet
+// frame is padded to 60 bytes and those zero bytes are not a malformed TLV —
+// treating them as one would reject almost every real frame from a switch
+// that sends a short LLDPDU.
+//
+// A truncated TLV IS an error: it means the frame was cut, and continuing
+// would report a neighbour assembled from bytes that were never received.
+func DecodeTLVs(b []byte) ([]TLV, error) {
+	var out []TLV
+	for i := 0; i+2 <= len(b); {
+		h := binary.BigEndian.Uint16(b[i:])
+		typ := uint8(h >> 9)
+		n := int(h & 0x01FF)
+		i += 2
+		if typ == TypeEnd {
+			return out, nil
+		}
+		if i+n > len(b) {
+			return nil, fmt.Errorf("lldp: TLV type %d claims %d bytes, %d remain", typ, n, len(b)-i)
+		}
+		v := make([]byte, n)
+		copy(v, b[i:i+n])
+		out = append(out, TLV{Type: typ, Value: v})
+		i += n
+	}
+	// Running out of bytes without an End TLV. Real senders emit it; a frame
+	// without one was truncated somewhere, and the TLVs already read may be
+	// complete — so they are returned WITH the error, letting a caller that
+	// only wants chassis/port decide for itself.
+	return out, ErrNoEndTLV
+}
+
+// EncodeTLVs builds an LLDPDU, appending the End TLV.
+//
+// Present so the decoder can be tested against bytes this package did not
+// itself produce in the same function, and so a future LLDP agent has the
+// encoder it will need. dhs does not transmit LLDP today.
+func EncodeTLVs(tlvs []TLV) ([]byte, error) {
+	var out []byte
+	for _, t := range tlvs {
+		if t.Type > 127 {
+			return nil, fmt.Errorf("lldp: TLV type %d exceeds the 7-bit field", t.Type)
+		}
+		if len(t.Value) > maxTLVLength {
+			return nil, fmt.Errorf("lldp: TLV type %d value is %d bytes, max %d",
+				t.Type, len(t.Value), maxTLVLength)
+		}
+		var h [2]byte
+		binary.BigEndian.PutUint16(h[:], uint16(t.Type)<<9|uint16(len(t.Value)))
+		out = append(out, h[:]...)
+		out = append(out, t.Value...)
+	}
+	return append(out, 0x00, 0x00), nil
+}


### PR DESCRIPTION
Three commits, one thread: **LLDP as a concern**, the host software it needs, and the IS-04 field it finally fills.

## 1. `internal/lldp` — the concern

`codec/is04` has carried `AttachedNetworkDevice{ChassisID, PortID}` since it was written and **nothing ever populated it**. The v1.3.3 schema says where it comes from: *"the Chassis ID of the attached network device, as signalled in LLDP received by this Node."* Without it a controller can't tell which switch port a Node is patched into.

Neutral infrastructure, sibling of `transport` and `auth` — not owned by any protocol. sony/nmos-cpp made the same call with `Development/lldp`.

```
tlv.go · neighbor.go   IEEE 802.1AB decode — pure bytes, stdlib, every OS, no privileges
source.go              Source: who SUPPLIES neighbours. The DI seam.
capture_linux.go       one Source: AF_PACKET via stdlib syscall, needs CAP_NET_RAW
capture_other.go       typed ErrCaptureUnsupported
```

Decoding is portable; **obtaining** the bytes is where platforms diverge, so they're separate. A device reporting its own LLDP over an API satisfies `Source` with no privileges and is the ordinary case in a plant — local capture is the special case, not the default. Windows returns the typed error rather than an empty map: "no neighbours" would tell an operator their switch is misconfigured when the truth is the host never looked.

Decoder decisions that are easy to get wrong:

- Ethernet pads frames to 60 bytes — decode **stops at the End TLV** and ignores the padding. Reading it as a TLV rejects almost every real frame.
- A frame truncated before its End TLV **still decodes** if the three mandatory TLVs arrived; they come first by requirement. Only when something is missing do both errors surface together.
- **Chassis and port subtype numbering differ** — MAC is 4 for a chassis, 3 for a port. Separate constant blocks, because one shared table silently renders a MAC as a freeform string that IS-04's schema then rejects.
- MAC ids render lowercase-hyphenated (IEEE convention *and* exactly IS-04's pattern). A MAC subtype whose value isn't six bytes falls back to a string rather than emitting an invalid one.
- **TTL 0 is the shutdown LLDPDU**, not a zero lifetime — the neighbour is dropped, never recorded.

## 2. Provider wiring — injected, never constructed

`IS04NodeConfig.LLDP`, applied in `Serve` before the mDNS announce, the served `/node` and the registration POST — all three read the same bundle, so one call covers them. **Never fatal** per ADR-0016's stdlib floor: a plant with LLDP switched off still gets a registered, routable Node. A neighbour missing either id is skipped whole, since both are required once the object exists. The v1.2 strip is unaffected — that happens in the codec at encode time, not in the bundle.

`internal/lldp` joins the neutral-infrastructure list in `dependencies_test.go` alongside `transport` and `auth`, so no protocol can reach another through it.

## 3. The host posture

**Bonjour was already handled** — `dhs_mdns` stages `BonjourPSSetup.exe`, carves the embedded CAB and installs `Bonjour64.msi`. **Npcap was handled nowhere**, and Windows had no base-package step at all while Linux gets `tshark`.

New role `dhs_capture` in the `dhs_mdns` idiom, added to `fleet-converge.yml`:

| OS | Does | Package |
|---|---|---|
| Linux | `setcap cap_net_raw+ep` on the dhs binary | **none** — AF_PACKET is a kernel interface |
| Windows | verify Npcap; install only from an operator-supplied OEM installer | Npcap |

Npcap deliberately does **not** get the Bonjour treatment, and it's licence rather than laziness — both verified:

1. **The free edition has no `/S`.** Silent install is [Npcap OEM only](https://nmap.org/nmap-silent-install), so unattended install is impossible without a paid licence.
2. **Free use is capped at five systems with no redistribution**, so committing the installer beside `BonjourPSSetup.exe` would be redistributing it from a public repo.

So the role verifies by default; failing is opt-in via `dhs_capture_npcap_required`. Its failure message names the three lawful routes, cheapest first: install Wireshark (bundles Npcap under the exception that lifts the cap, and the fleet wants tshark anyway); install by hand inside the five-system limit; or buy an OEM licence.

Also fills `0005-deps.json`'s `host_deps`, which ADR-0016 has always pointed at and which held five Go modules and zero host entries.

## Verification

- Build **and** vet green on **linux, darwin and windows**.
- Full suite green; `internal/lldp` **100%** on this platform (the Linux capture loop needs CAP_NET_RAW and won't be covered in CI — no floor claimed for it).
- `golangci-lint` 0 issues.
- `check-deps.sh` output unchanged from before (the pre-existing `prometheus/client_golang` error and four pre-approval notices — neither introduced nor fixed here).
- **Not run against the fleet.** Ansible runs from the control node, not this workstation, and there's no `ansible-lint` in CI or here — the role is syntax-checked only. A converge + re-converge on a Windows host is the real proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
