### PR TITLE
refactor(transport): lift the generic HTTP server out of amwa

### DIFF
--- a/internal/amwa/session/http/server.go
+++ b/internal/amwa/session/http/server.go
@@ -1,456 +1,94 @@
 package http
 
+// The NMOS face of an HTTP server.
+//
+// The machinery — route table, TLS listener, panic barrier, CORS, the
+// trailing-slash and 404-vs-405 rules — moved to internal/transport/http,
+// where it is generic and where the package now has a server to match its
+// client. What stayed here is what is actually NMOS:
+//
+//   - the IS-04 §4.4 error envelope every API answers with;
+//   - the BCP-003-02 token gate, wired in as a transport Gate;
+//   - the CORS header set IS-04 §4.5 requires.
+//
+// Server embeds the transport one, so every existing call site keeps working:
+// Handle, HandlePrefix, HandleRaw, MuxHandler and Serve are promoted, and so
+// are the Logger and TLS fields.
+
 import (
-	"context"
-	"crypto/tls"
-	"encoding/json"
-	"errors"
-	"fmt"
 	"log/slog"
 	stdhttp "net/http"
-	"runtime/debug"
-	"strings"
-	"sync"
-	"time"
+
+	thttp "dhs/internal/transport/http"
 )
 
-// HandlerFunc is the per-route signature. Returning an error becomes
-// HTTP 500 with the spec-compatible body shape; returning a value
-// is JSON-encoded with status 200 (or status if explicitly returned).
-type HandlerFunc func(ctx context.Context, r *stdhttp.Request) (status int, body any, err error)
+// Re-exported so callers keep one import. These are the transport types;
+// aliasing rather than wrapping means a *RawBody built here is the same type
+// the server checks for.
+type (
+	// HandlerFunc is the per-route signature.
+	HandlerFunc = thttp.HandlerFunc
+	// RawBody returns a non-JSON response — IS-04 transportfile (SDP) is
+	// served as text/plain, not JSON.
+	RawBody = thttp.RawBody
+	// WithHeaders attaches extra response headers, e.g. the Location header
+	// IS-04 §6.1.1 mandates on Registration POST/PUT, or X-Paging-* on Query
+	// API list responses.
+	WithHeaders = thttp.WithHeaders
+)
 
-// Server is a thin route table over net/http.Server. Routes are
-// either exact-match `(method, path) -> HandlerFunc` or prefix-match
-// `(method, prefix*) -> HandlerFunc`. Exact matches win over prefix
-// matches; longer prefixes win over shorter prefixes.
-type Server struct {
-	Logger *slog.Logger
-
-	// Auth, when non-nil, gates every request (routes AND raw
-	// WebSocket handlers) through BCP-003-02 token validation. Set
-	// before Serve; the CORS preflight and the two always-readable
-	// base paths bypass it per the IS-10 resource-server rules.
-	Auth *AuthGate
-
-	// TLS, when non-nil, makes Serve listen with HTTPS/WSS instead of
-	// plain HTTP (BCP-003-01: a secured server SHALL NOT accept plain
-	// HTTP, so it is one or the other, never both on a listener).
-	// Responses then carry Strict-Transport-Security.
-	TLS *tls.Config
-
-	mu       sync.RWMutex
-	routes   map[routeKey]HandlerFunc
-	prefixes []prefixRoute // longer prefixes first
-	raw      map[string]stdhttp.Handler
-	mux      *stdhttp.ServeMux
-	srv      *stdhttp.Server
-}
-
-type routeKey struct {
-	method string
-	path   string
-}
-
-type prefixRoute struct {
-	method string
-	prefix string
-	fn     HandlerFunc
-}
-
-// altSlashForm returns the other spelling of a path: with a trailing
-// slash if it had none, without if it had one.
-func altSlashForm(p string) string {
-	if strings.HasSuffix(p, "/") {
-		return strings.TrimSuffix(p, "/")
-	}
-	return p + "/"
-}
-
-// ErrorBody mirrors the IS-04 §4.4 / IS-09 RAML error envelope so
-// peers see a uniform shape on 4xx / 5xx.
+// ErrorBody mirrors the IS-04 §4.4 / IS-09 RAML error envelope so peers see a
+// uniform shape on 4xx / 5xx.
 type ErrorBody struct {
 	Code  int    `json:"code"`
 	Error string `json:"error"`
 	Debug string `json:"debug,omitempty"`
 }
 
-// NewServer constructs an empty Server with a default logger if nil.
+// nmosCORS is the header set every NMOS API response carries per IS-04 §4.5
+// (and which the AMWA NMOS Testing tool requires).
+var nmosCORS = thttp.CORS{
+	AllowOrigin:  "*",
+	AllowHeaders: "Content-Type, Authorization",
+	MaxAge:       "3600",
+}
+
+// Server is a transport HTTP server pre-wired with the NMOS error shape, the
+// NMOS CORS policy, and the BCP-003-02 gate.
+type Server struct {
+	*thttp.Server
+
+	// Auth, when non-nil, gates every request (routes AND raw WebSocket
+	// handlers) through BCP-003-02 token validation. It may be set at any
+	// point before Serve — the gate reads it per request, so wiring order
+	// does not matter.
+	Auth *AuthGate
+}
+
+// NewServer constructs an empty Server.
 func NewServer(logger *slog.Logger) *Server {
-	return &Server{
-		Logger: logger,
-		routes: make(map[routeKey]HandlerFunc),
+	s := &Server{Server: thttp.NewServer(logger)}
+	s.CORS = nmosCORS
+	s.Errors = func(status int, errStr, debug string) any {
+		return ErrorBody{Code: status, Error: errStr, Debug: debug}
 	}
-}
-
-// Handle registers an exact-match (method, path) handler. Re-registering
-// the same key panics — wiring bugs should fail loudly.
-func (s *Server) Handle(method, path string, fn HandlerFunc) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	k := routeKey{method: method, path: path}
-	if _, dup := s.routes[k]; dup {
-		panic(fmt.Sprintf("nmos/http: duplicate route %s %s", method, path))
-	}
-	s.routes[k] = fn
-}
-
-// HandlePrefix registers a prefix-match (method, prefix*) handler.
-// Used by Registry endpoints under /resource/ and /health/nodes/
-// where the path tail is a parameter. Longer prefixes win over
-// shorter ones.
-func (s *Server) HandlePrefix(prefix, method string, fn HandlerFunc) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	pr := prefixRoute{method: method, prefix: prefix, fn: fn}
-	// Insert in length-descending order so dispatch picks the
-	// longest match first.
-	idx := 0
-	for idx < len(s.prefixes) && len(s.prefixes[idx].prefix) >= len(prefix) {
-		idx++
-	}
-	s.prefixes = append(s.prefixes, prefixRoute{})
-	copy(s.prefixes[idx+1:], s.prefixes[idx:])
-	s.prefixes[idx] = pr
-}
-
-// MuxHandler returns a stdhttp.Handler that runs the route-table
-// dispatcher. Used by callers (e.g. the Registry) that compose their
-// own net/http.Server (typically because they need a sibling raw
-// handler for WebSocket upgrades). The returned Handler is safe for
-// concurrent use.
-func (s *Server) MuxHandler() stdhttp.Handler {
-	return stdhttp.HandlerFunc(s.dispatch)
-}
-
-// HandleRaw registers a plain http.Handler at an exact path, bypassing
-// the (status, body, error) route table.
-//
-// Needed for WebSocket upgrades and nothing else. The normal handler
-// signature returns a value the server then serialises, which means
-// the ResponseWriter is written and closed by the framework -- but an
-// upgrade has to HIJACK that connection and keep it, so a handler that
-// only returns a body can never perform one.
-func (s *Server) HandleRaw(path string, h stdhttp.Handler) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.raw == nil {
-		s.raw = map[string]stdhttp.Handler{}
-	}
-	if _, dup := s.raw[path]; dup {
-		panic("nmos/http: duplicate raw route " + path)
-	}
-	s.raw[path] = h
-}
-
-// Serve binds to addr and serves until ctx is cancelled. Returns the
-// first non-graceful shutdown error.
-func (s *Server) Serve(ctx context.Context, addr string) error {
-	s.mu.Lock()
-	if s.mux != nil {
-		s.mu.Unlock()
-		return fmt.Errorf("nmos/http: server already started")
-	}
-	mux := stdhttp.NewServeMux()
-	mux.HandleFunc("/", s.dispatch)
-	s.mux = mux
-	s.srv = &stdhttp.Server{
-		Addr:              addr,
-		Handler:           mux,
-		ReadHeaderTimeout: 5 * time.Second,
-		TLSConfig:         s.TLS,
-	}
-	srv := s.srv
-	secure := s.TLS != nil
-	s.mu.Unlock()
-
-	errCh := make(chan error, 1)
-	go func() {
-		var err error
-		if secure {
-			// Certificates come from TLSConfig (GetCertificate hook —
-			// hot-reloadable on EST renewal), hence the empty paths.
-			err = srv.ListenAndServeTLS("", "")
-		} else {
-			err = srv.ListenAndServe()
+	// Read s.Auth per request rather than capturing it: callers set the gate
+	// after NewServer, and a snapshot taken here would be nil forever.
+	s.Gate = thttp.GateFunc(func(r *stdhttp.Request) (int, map[string]string, any, *stdhttp.Request, bool) {
+		if s.Auth == nil {
+			return 0, nil, nil, nil, true
 		}
-		if err != nil && !errors.Is(err, stdhttp.ErrServerClosed) {
-			errCh <- err
-			return
-		}
-		errCh <- nil
-	}()
-
-	select {
-	case <-ctx.Done():
-		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_ = srv.Shutdown(shutCtx)
-		return <-errCh
-	case err := <-errCh:
-		return err
-	}
-}
-
-// dispatch is the single net/http handler that walks the route table
-// and emits the response — or a spec-shaped 404 / 405 / 500.
-func (s *Server) dispatch(w stdhttp.ResponseWriter, r *stdhttp.Request) {
-	defer func() {
-		if rec := recover(); rec != nil {
-			if s.Logger != nil {
-				s.Logger.Error("nmos/http: handler panic",
-					"method", r.Method, "path", r.URL.Path, "panic", rec,
-					"stack", string(debug.Stack()))
-			}
-			writeErrorJSON(w, stdhttp.StatusInternalServerError, "Internal Server Error", "panic recovered")
-		}
-	}()
-
-	// BCP-003-01: a secured server declares it only speaks TLS
-	// (SHOULD, with the recommended 12-month max-age).
-	if r.TLS != nil {
-		w.Header().Set("Strict-Transport-Security", "max-age=31536000")
-	}
-
-	// CORS preflight: any OPTIONS request gets a 200 with the CORS
-	// allow-headers set. The AMWA NMOS Testing tool's auto_node_10
-	// expects 200 (not 204) on OPTIONS — we return an empty JSON body
-	// to keep the Content-Type consistent with every other response.
-	if r.Method == stdhttp.MethodOptions {
-		allowed := s.methodsForPath(r.URL.Path)
-		setCORSHeaders(w, allowed)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(stdhttp.StatusOK)
-		_, _ = w.Write([]byte("{}"))
-		return
-	}
-
-	// BCP-003-02 gate — after the OPTIONS preflight (credential-less
-	// by browser design) and BEFORE the raw handlers, so WebSocket
-	// upgrades are protected by the same policy as plain routes (the
-	// spec says a server SHALL NOT upgrade on an invalid token).
-	if s.Auth != nil {
 		status, hdrs, body, clientID, ok := s.Auth.Check(r)
 		if !ok {
-			for k, v := range hdrs {
-				w.Header().Set(k, v)
-			}
-			writeJSON(w, status, body)
-			return
+			return status, hdrs, body, nil, false
 		}
-		if clientID != "" {
-			// BCP-003-02: hand the authenticated client identity to the
-			// handlers so write paths can enforce per-client resource
-			// ownership (IS-04-02 test_33/test_33_1).
-			r = r.WithContext(WithClientID(r.Context(), clientID))
+		if clientID == "" {
+			return 0, nil, nil, nil, true
 		}
-	}
-
-	// Raw handlers first, and before the CORS/JSON machinery has
-	// touched the ResponseWriter -- a hijack must happen on a
-	// connection nothing has written to.
-	s.mu.RLock()
-	rawH, isRaw := s.raw[r.URL.Path]
-	if !isRaw {
-		rawH, isRaw = s.raw[altSlashForm(r.URL.Path)]
-	}
-	s.mu.RUnlock()
-	if isRaw {
-		rawH.ServeHTTP(w, r)
-		return
-	}
-
-	s.mu.RLock()
-	fn, ok := s.routes[routeKey{method: r.Method, path: r.URL.Path}]
-	if !ok {
-		// A trailing slash is not a different resource.
-		//
-		// The NMOS specs write collection paths with a trailing slash
-		// and clients send both forms freely — the AMWA testing tool
-		// asks for `single/senders/{id}/staged` while the spec text
-		// writes `.../staged/`. Answering 404 for the other form is
-		// technically defensible and practically useless: it failed 20
-		// IS-05 tests that were exercising handlers which existed and
-		// worked.
-		//
-		// Tried only after the exact match, so a route registered for
-		// one specific form still wins.
-		fn, ok = s.routes[routeKey{method: r.Method, path: altSlashForm(r.URL.Path)}]
-	}
-	if !ok {
-		// Try a prefix route — longest match first.
-		for _, pr := range s.prefixes {
-			if pr.method == r.Method && strings.HasPrefix(r.URL.Path, pr.prefix) {
-				fn = pr.fn
-				ok = true
-				break
-			}
-		}
-	}
-	if !ok {
-		// Choose 404 vs 405 based on whether ANY route matches the path.
-		methodNotAllowed := false
-		// Both spellings of the path, for the same reason the lookup
-		// above tries both: a trailing slash is not a different
-		// resource. `GET /bulk/senders` against a POST-only
-		// `/bulk/senders/` is a wrong METHOD, not a missing route, and
-		// answering 404 tells a controller the endpoint does not exist
-		// (IS-05-01 test_34/test_35).
-		alt := altSlashForm(r.URL.Path)
-		for k := range s.routes {
-			if (k.path == r.URL.Path || k.path == alt) && k.method != r.Method {
-				methodNotAllowed = true
-				break
-			}
-		}
-		if !methodNotAllowed {
-			for _, pr := range s.prefixes {
-				if pr.method != r.Method && strings.HasPrefix(r.URL.Path, pr.prefix) {
-					methodNotAllowed = true
-					break
-				}
-			}
-		}
-		s.mu.RUnlock()
-		if methodNotAllowed {
-			writeErrorJSON(w, stdhttp.StatusMethodNotAllowed, "Method Not Allowed", r.Method+" "+r.URL.Path)
-		} else {
-			writeErrorJSON(w, stdhttp.StatusNotFound, "Not Found", r.URL.Path)
-		}
-		return
-	}
-	s.mu.RUnlock()
-
-	status, body, err := fn(r.Context(), r)
-	if err != nil {
-		if s.Logger != nil {
-			s.Logger.Warn("nmos/http: handler error",
-				"method", r.Method, "path", r.URL.Path, "err", err)
-		}
-		writeErrorJSON(w, stdhttp.StatusInternalServerError, "Internal Server Error", err.Error())
-		return
-	}
-	if status == 0 {
-		status = stdhttp.StatusOK
-	}
-	writeJSON(w, status, body)
-}
-
-// RawBody lets a handler return a non-JSON response (e.g. SDP text on
-// IS-04 senders/{id}/transportfile). Set Body + ContentType; the
-// server emits them verbatim with CORS headers attached.
-type RawBody struct {
-	ContentType string
-	Body        []byte
-}
-
-// WithHeaders lets a handler attach extra response headers (e.g. the
-// `Location` header IS-04 §6.1.1 mandates on Registration POST/PUT,
-// or `X-Paging-*` on Query API list responses) without changing the
-// HandlerFunc signature. Body is JSON-encoded as usual; Headers are
-// applied verbatim before WriteHeader. Body may itself be a *RawBody
-// to combine non-JSON content with custom headers.
-type WithHeaders struct {
-	Body    any
-	Headers map[string]string
-}
-
-// writeJSON serialises body as JSON with the spec-mandated header set.
-// As a special case, *RawBody emits a non-JSON response — used for
-// IS-04 transportfile (SDP) routes that the spec requires to be
-// served as text/plain or application/sdp, NOT JSON. *WithHeaders
-// applies extra headers before delegating to the inner body.
-func writeJSON(w stdhttp.ResponseWriter, status int, body any) {
-	if wh, ok := body.(*WithHeaders); ok {
-		for k, v := range wh.Headers {
-			w.Header().Set(k, v)
-		}
-		writeJSON(w, status, wh.Body)
-		return
-	}
-	if rb, ok := body.(*RawBody); ok {
-		ct := rb.ContentType
-		if ct == "" {
-			ct = "application/octet-stream"
-		}
-		w.Header().Set("Content-Type", ct)
-		setCORSHeaders(w, "")
-		w.WriteHeader(status)
-		_, _ = w.Write(rb.Body)
-		return
-	}
-	w.Header().Set("Content-Type", "application/json")
-	setCORSHeaders(w, "")
-	w.WriteHeader(status)
-	enc := json.NewEncoder(w)
-	enc.SetEscapeHTML(false)
-	if err := enc.Encode(body); err != nil {
-		// Headers already flushed; nothing to do but log via panic
-		// recovery in the caller. We don't have a slog handle here.
-		_ = err
-	}
-}
-
-// writeErrorJSON emits the IS-04 §4.4 error envelope.
-func writeErrorJSON(w stdhttp.ResponseWriter, status int, errStr, debug string) {
-	writeJSON(w, status, ErrorBody{
-		Code:  status,
-		Error: errStr,
-		Debug: debug,
+		// BCP-003-02: hand the authenticated client identity to the handlers
+		// so write paths can enforce per-client resource ownership
+		// (IS-04-02 test_33 / test_33_1).
+		return 0, nil, nil, r.WithContext(WithClientID(r.Context(), clientID)), true
 	})
-}
-
-// setCORSHeaders adds the CORS header set every NMOS API response
-// emits per IS-04 §4.5 (and the AMWA NMOS Testing tool requires).
-// allowMethods, when non-empty, also sets Access-Control-Allow-Methods
-// + Allow — used on OPTIONS preflight responses.
-func setCORSHeaders(w stdhttp.ResponseWriter, allowMethods string) {
-	h := w.Header()
-	h.Set("Access-Control-Allow-Origin", "*")
-	h.Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
-	h.Set("Access-Control-Max-Age", "3600")
-	if allowMethods != "" {
-		h.Set("Access-Control-Allow-Methods", allowMethods)
-		h.Set("Allow", allowMethods)
-	}
-}
-
-// methodsForPath returns the comma-separated set of HTTP methods the
-// route table accepts at path. Always includes OPTIONS. Used for the
-// CORS preflight response so the peer learns which verbs are real.
-func (s *Server) methodsForPath(path string) string {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	seen := map[string]struct{}{stdhttp.MethodOptions: {}}
-	// Both slash forms, for the same reason dispatch accepts both: a
-	// preflight for `.../bulk/senders` must advertise the POST that is
-	// registered at `.../bulk/senders/`, or the browser refuses the
-	// request that would have worked.
-	alt := path
-	if strings.HasSuffix(alt, "/") {
-		alt = strings.TrimSuffix(alt, "/")
-	} else {
-		alt += "/"
-	}
-	for k := range s.routes {
-		if k.path == path || k.path == alt {
-			seen[k.method] = struct{}{}
-		}
-	}
-	for _, pr := range s.prefixes {
-		if strings.HasPrefix(path, pr.prefix) {
-			seen[pr.method] = struct{}{}
-		}
-	}
-	// Stable order: OPTIONS, GET, HEAD, POST, PUT, PATCH, DELETE.
-	order := []string{
-		stdhttp.MethodOptions, stdhttp.MethodGet, stdhttp.MethodHead,
-		stdhttp.MethodPost, stdhttp.MethodPut, stdhttp.MethodPatch, stdhttp.MethodDelete,
-	}
-	out := make([]string, 0, len(seen))
-	for _, m := range order {
-		if _, ok := seen[m]; ok {
-			out = append(out, m)
-		}
-	}
-	return strings.Join(out, ", ")
+	return s
 }

--- a/internal/transport/architecture_test.go
+++ b/internal/transport/architecture_test.go
@@ -107,7 +107,6 @@ var allowed = map[string]string{
 	// Its Serve/TLS/CORS/preflight/mux half is generic; what is NMOS is the
 	// IS-04 §4.4 error body and the BCP-003-02 gate. Extracting it also
 	// closes the conformance gap where http has a client and no server.
-	"internal/amwa/session/http/server.go":   "generic HTTP server → transport/http",
 	"internal/amwa/registry/mirror_serve.go": "TLS listener → transport once the server moves",
 
 	// DEBT — certificate handling.

--- a/internal/transport/http/server.go
+++ b/internal/transport/http/server.go
@@ -1,0 +1,472 @@
+package http
+
+// The server half of this package. It was lifted out of
+// internal/amwa/session/http, where a generic route table, TLS listener,
+// CORS policy and panic barrier had grown NMOS-shaped only in two places:
+// the error body and the auth gate. Both are now injected, so the machinery
+// is reusable and the spec-specific parts stayed with the spec.
+//
+// What is deliberately NOT here: the IS-04 §4.4 error envelope, the
+// BCP-003-02 token rules, and every NMOS route. Those live in
+// internal/amwa/session/http, which wires this server and adds them.
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	stdhttp "net/http"
+	"runtime/debug"
+	"strings"
+	"sync"
+	"time"
+)
+
+// readHeaderTimeout bounds how long a client may take to send its headers.
+// Without it a handful of idle connections holds the server open — the
+// Slowloris shape.
+const readHeaderTimeout = 5 * time.Second
+
+// shutdownGrace is how long in-flight requests get to finish on shutdown.
+const shutdownGrace = 5 * time.Second
+
+// HandlerFunc is the per-route signature. Returning an error becomes a 500
+// carrying whatever [ErrorEncoder] shapes; returning a value JSON-encodes it
+// with the given status, or 200 when status is zero.
+type HandlerFunc func(ctx context.Context, r *stdhttp.Request) (status int, body any, err error)
+
+// Gate optionally vets every request before it reaches a route — including
+// raw (WebSocket) handlers, so one policy covers both.
+//
+// It returns a REQUEST rather than a bare identity so a gate can stamp its own
+// context values without this package knowing what they mean. ok=false means
+// the caller writes status/headers/body and stops.
+type Gate interface {
+	Check(r *stdhttp.Request) (status int, headers map[string]string, body any, next *stdhttp.Request, ok bool)
+}
+
+// GateFunc adapts a function to [Gate].
+type GateFunc func(r *stdhttp.Request) (int, map[string]string, any, *stdhttp.Request, bool)
+
+// Check calls f.
+func (f GateFunc) Check(r *stdhttp.Request) (int, map[string]string, any, *stdhttp.Request, bool) {
+	return f(r)
+}
+
+// ErrorEncoder shapes the body of an error response. Protocols disagree about
+// this — IS-04 §4.4 wants {code,error,debug}, another API wants RFC 7807 —
+// so the server never invents one.
+type ErrorEncoder func(status int, err, debug string) any
+
+// defaultError is the fallback shape when no encoder is injected.
+type defaultError struct {
+	Code  int    `json:"code"`
+	Error string `json:"error"`
+	Debug string `json:"debug,omitempty"`
+}
+
+// CORS is the cross-origin policy applied to every response.
+//
+// A zero value means NO CORS headers, which is the correct default for a
+// server that is not browser-facing. Callers that need them set them; the
+// NMOS wrapper does.
+type CORS struct {
+	AllowOrigin  string
+	AllowHeaders string
+	MaxAge       string
+}
+
+// Server is a route table over net/http. Routes are exact-match
+// (method, path) or prefix-match (method, prefix*). Exact wins over prefix;
+// longer prefixes win over shorter.
+type Server struct {
+	Logger *slog.Logger
+
+	// Gate, when non-nil, vets every request (routes AND raw handlers).
+	// Set before Serve. OPTIONS preflights bypass it — they are
+	// credential-less by browser design.
+	Gate Gate
+
+	// Errors shapes error bodies. Nil uses a {code,error,debug} default.
+	Errors ErrorEncoder
+
+	// CORS is applied to every response. Zero value emits nothing.
+	CORS CORS
+
+	// TLS, when non-nil, makes Serve listen with HTTPS/WSS instead of plain
+	// HTTP — one or the other on a listener, never both. Responses then
+	// carry Strict-Transport-Security.
+	TLS *tls.Config
+
+	mu       sync.RWMutex
+	routes   map[routeKey]HandlerFunc
+	prefixes []prefixRoute // longer prefixes first
+	raw      map[string]stdhttp.Handler
+	mux      *stdhttp.ServeMux
+	srv      *stdhttp.Server
+}
+
+type routeKey struct {
+	method string
+	path   string
+}
+
+type prefixRoute struct {
+	method string
+	prefix string
+	fn     HandlerFunc
+}
+
+// altSlashForm returns the other spelling of a path: with a trailing slash if
+// it had none, without if it had one.
+func altSlashForm(p string) string {
+	if strings.HasSuffix(p, "/") {
+		return strings.TrimSuffix(p, "/")
+	}
+	return p + "/"
+}
+
+// NewServer constructs an empty Server.
+func NewServer(logger *slog.Logger) *Server {
+	return &Server{Logger: logger, routes: make(map[routeKey]HandlerFunc)}
+}
+
+// Handle registers an exact-match (method, path) handler. Re-registering the
+// same key panics — a wiring bug should fail loudly at start, not serve one
+// of two handlers at random.
+func (s *Server) Handle(method, path string, fn HandlerFunc) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	k := routeKey{method: method, path: path}
+	if _, dup := s.routes[k]; dup {
+		panic(fmt.Sprintf("transport/http: duplicate route %s %s", method, path))
+	}
+	s.routes[k] = fn
+}
+
+// HandlePrefix registers a prefix-match (method, prefix*) handler, for paths
+// whose tail is a parameter. Longer prefixes win over shorter ones.
+func (s *Server) HandlePrefix(prefix, method string, fn HandlerFunc) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	pr := prefixRoute{method: method, prefix: prefix, fn: fn}
+	idx := 0
+	for idx < len(s.prefixes) && len(s.prefixes[idx].prefix) >= len(prefix) {
+		idx++
+	}
+	s.prefixes = append(s.prefixes, prefixRoute{})
+	copy(s.prefixes[idx+1:], s.prefixes[idx:])
+	s.prefixes[idx] = pr
+}
+
+// HandleRaw registers a plain http.Handler at an exact path, bypassing the
+// (status, body, error) route table.
+//
+// Needed for WebSocket upgrades and nothing else: the normal signature returns
+// a value the server then serialises, so the framework owns the
+// ResponseWriter — but an upgrade must HIJACK the connection and keep it.
+func (s *Server) HandleRaw(path string, h stdhttp.Handler) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.raw == nil {
+		s.raw = map[string]stdhttp.Handler{}
+	}
+	if _, dup := s.raw[path]; dup {
+		panic("transport/http: duplicate raw route " + path)
+	}
+	s.raw[path] = h
+}
+
+// MuxHandler returns the route-table dispatcher as a plain handler, for
+// callers composing their own net/http.Server. Safe for concurrent use.
+func (s *Server) MuxHandler() stdhttp.Handler {
+	return stdhttp.HandlerFunc(s.dispatch)
+}
+
+// Serve binds to addr and serves until ctx is cancelled.
+func (s *Server) Serve(ctx context.Context, addr string) error {
+	s.mu.Lock()
+	if s.mux != nil {
+		s.mu.Unlock()
+		return fmt.Errorf("transport/http: server already started")
+	}
+	mux := stdhttp.NewServeMux()
+	mux.HandleFunc("/", s.dispatch)
+	s.mux = mux
+	s.srv = &stdhttp.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: readHeaderTimeout,
+		TLSConfig:         s.TLS,
+	}
+	srv := s.srv
+	secure := s.TLS != nil
+	s.mu.Unlock()
+
+	errCh := make(chan error, 1)
+	go func() {
+		var err error
+		if secure {
+			// Certificates come from TLSConfig's GetCertificate hook so they
+			// stay hot-reloadable on renewal — hence the empty paths.
+			err = srv.ListenAndServeTLS("", "")
+		} else {
+			err = srv.ListenAndServe()
+		}
+		if err != nil && !errors.Is(err, stdhttp.ErrServerClosed) {
+			errCh <- err
+			return
+		}
+		errCh <- nil
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutCtx, cancel := context.WithTimeout(context.Background(), shutdownGrace)
+		defer cancel()
+		_ = srv.Shutdown(shutCtx)
+		return <-errCh
+	case err := <-errCh:
+		return err
+	}
+}
+
+// errorBody shapes an error through the injected encoder, or the default.
+func (s *Server) errorBody(status int, errStr, debug string) any {
+	if s.Errors != nil {
+		return s.Errors(status, errStr, debug)
+	}
+	return defaultError{Code: status, Error: errStr, Debug: debug}
+}
+
+func (s *Server) writeError(w stdhttp.ResponseWriter, status int, errStr, debug string) {
+	s.writeJSON(w, status, s.errorBody(status, errStr, debug))
+}
+
+// dispatch walks the route table and emits the response — or a 404/405/500.
+func (s *Server) dispatch(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	// The panic barrier is the outermost layer on purpose: a handler that
+	// panics must still produce a response, or the client sees a dropped
+	// connection and retries into the same panic.
+	defer func() {
+		if rec := recover(); rec != nil {
+			if s.Logger != nil {
+				s.Logger.Error("transport/http: handler panic",
+					"method", r.Method, "path", r.URL.Path, "panic", rec,
+					"stack", string(debug.Stack()))
+			}
+			s.writeError(w, stdhttp.StatusInternalServerError, "Internal Server Error", "panic recovered")
+		}
+	}()
+
+	// A TLS server declares it only speaks TLS (12-month max-age).
+	if r.TLS != nil {
+		w.Header().Set("Strict-Transport-Security", "max-age=31536000")
+	}
+
+	// CORS preflight, before the gate: preflights are credential-less by
+	// browser design, so gating them makes every cross-origin call fail.
+	// 200 with an empty JSON object rather than 204, so the Content-Type
+	// stays consistent with every other response.
+	if r.Method == stdhttp.MethodOptions {
+		s.setCORS(w, s.methodsForPath(r.URL.Path))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(stdhttp.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+		return
+	}
+
+	// The gate runs BEFORE the raw handlers, so a WebSocket upgrade is held
+	// to the same policy as a plain route.
+	if s.Gate != nil {
+		status, hdrs, body, next, ok := s.Gate.Check(r)
+		if !ok {
+			for k, v := range hdrs {
+				w.Header().Set(k, v)
+			}
+			s.writeJSON(w, status, body)
+			return
+		}
+		if next != nil {
+			r = next
+		}
+	}
+
+	// Raw handlers next, before the CORS/JSON machinery has touched the
+	// ResponseWriter — a hijack must happen on a connection nothing wrote to.
+	s.mu.RLock()
+	rawH, isRaw := s.raw[r.URL.Path]
+	if !isRaw {
+		rawH, isRaw = s.raw[altSlashForm(r.URL.Path)]
+	}
+	s.mu.RUnlock()
+	if isRaw {
+		rawH.ServeHTTP(w, r)
+		return
+	}
+
+	s.mu.RLock()
+	fn, ok := s.routes[routeKey{method: r.Method, path: r.URL.Path}]
+	if !ok {
+		// A trailing slash is not a different resource. Clients send both
+		// forms freely, and answering 404 for the other spelling is
+		// technically defensible and practically useless. Tried only after
+		// the exact match, so a route registered for one form still wins.
+		fn, ok = s.routes[routeKey{method: r.Method, path: altSlashForm(r.URL.Path)}]
+	}
+	if !ok {
+		for _, pr := range s.prefixes { // longest first
+			if pr.method == r.Method && strings.HasPrefix(r.URL.Path, pr.prefix) {
+				fn, ok = pr.fn, true
+				break
+			}
+		}
+	}
+	if !ok {
+		// 404 vs 405: does ANY route match this path under another method?
+		// Answering 404 for a wrong method tells a client the endpoint does
+		// not exist. Both slash forms, for the reason above.
+		methodNotAllowed := false
+		alt := altSlashForm(r.URL.Path)
+		for k := range s.routes {
+			if (k.path == r.URL.Path || k.path == alt) && k.method != r.Method {
+				methodNotAllowed = true
+				break
+			}
+		}
+		if !methodNotAllowed {
+			for _, pr := range s.prefixes {
+				if pr.method != r.Method && strings.HasPrefix(r.URL.Path, pr.prefix) {
+					methodNotAllowed = true
+					break
+				}
+			}
+		}
+		s.mu.RUnlock()
+		if methodNotAllowed {
+			s.writeError(w, stdhttp.StatusMethodNotAllowed, "Method Not Allowed", r.Method+" "+r.URL.Path)
+		} else {
+			s.writeError(w, stdhttp.StatusNotFound, "Not Found", r.URL.Path)
+		}
+		return
+	}
+	s.mu.RUnlock()
+
+	status, body, err := fn(r.Context(), r)
+	if err != nil {
+		if s.Logger != nil {
+			s.Logger.Warn("transport/http: handler error",
+				"method", r.Method, "path", r.URL.Path, "err", err)
+		}
+		s.writeError(w, stdhttp.StatusInternalServerError, "Internal Server Error", err.Error())
+		return
+	}
+	if status == 0 {
+		status = stdhttp.StatusOK
+	}
+	s.writeJSON(w, status, body)
+}
+
+// RawBody lets a handler return a non-JSON response — SDP text, a certificate,
+// anything the spec requires not be JSON. Emitted verbatim with CORS attached.
+type RawBody struct {
+	ContentType string
+	Body        []byte
+}
+
+// WithHeaders lets a handler attach extra response headers without changing
+// the HandlerFunc signature. Body is encoded as usual and may itself be a
+// *RawBody, to combine non-JSON content with custom headers.
+type WithHeaders struct {
+	Body    any
+	Headers map[string]string
+}
+
+// writeJSON serialises body, honouring *WithHeaders and *RawBody.
+func (s *Server) writeJSON(w stdhttp.ResponseWriter, status int, body any) {
+	if wh, ok := body.(*WithHeaders); ok {
+		for k, v := range wh.Headers {
+			w.Header().Set(k, v)
+		}
+		s.writeJSON(w, status, wh.Body)
+		return
+	}
+	if rb, ok := body.(*RawBody); ok {
+		ct := rb.ContentType
+		if ct == "" {
+			ct = "application/octet-stream"
+		}
+		w.Header().Set("Content-Type", ct)
+		s.setCORS(w, "")
+		w.WriteHeader(status)
+		_, _ = w.Write(rb.Body)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	s.setCORS(w, "")
+	w.WriteHeader(status)
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(body); err != nil && s.Logger != nil {
+		// The status line is already flushed, so this cannot become a 500.
+		// Logging it is the only honest thing left: the client will see a
+		// truncated body and would otherwise have nothing to correlate.
+		s.Logger.Error("transport/http: response encode failed after headers were sent",
+			"status", status, "err", err)
+	}
+}
+
+// setCORS applies the configured policy. allowMethods, when non-empty, also
+// sets Access-Control-Allow-Methods and Allow — used on preflights.
+func (s *Server) setCORS(w stdhttp.ResponseWriter, allowMethods string) {
+	h := w.Header()
+	if s.CORS.AllowOrigin != "" {
+		h.Set("Access-Control-Allow-Origin", s.CORS.AllowOrigin)
+	}
+	if s.CORS.AllowHeaders != "" {
+		h.Set("Access-Control-Allow-Headers", s.CORS.AllowHeaders)
+	}
+	if s.CORS.MaxAge != "" {
+		h.Set("Access-Control-Max-Age", s.CORS.MaxAge)
+	}
+	if allowMethods != "" {
+		h.Set("Access-Control-Allow-Methods", allowMethods)
+		h.Set("Allow", allowMethods)
+	}
+}
+
+// methodsForPath returns the comma-separated methods the route table accepts
+// at path, always including OPTIONS, so a preflight tells the peer which verbs
+// are real.
+func (s *Server) methodsForPath(path string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	seen := map[string]struct{}{stdhttp.MethodOptions: {}}
+	// Both slash forms, for the same reason dispatch accepts both: a
+	// preflight for `.../senders` must advertise the POST registered at
+	// `.../senders/`, or the browser refuses the request that would work.
+	alt := altSlashForm(path)
+	for k := range s.routes {
+		if k.path == path || k.path == alt {
+			seen[k.method] = struct{}{}
+		}
+	}
+	for _, pr := range s.prefixes {
+		if strings.HasPrefix(path, pr.prefix) {
+			seen[pr.method] = struct{}{}
+		}
+	}
+	order := []string{
+		stdhttp.MethodOptions, stdhttp.MethodGet, stdhttp.MethodHead,
+		stdhttp.MethodPost, stdhttp.MethodPut, stdhttp.MethodPatch, stdhttp.MethodDelete,
+	}
+	out := make([]string, 0, len(seen))
+	for _, m := range order {
+		if _, ok := seen[m]; ok {
+			out = append(out, m)
+		}
+	}
+	return strings.Join(out, ", ")
+}

--- a/internal/transport/http/server_test.go
+++ b/internal/transport/http/server_test.go
@@ -1,0 +1,580 @@
+package http
+
+// Tests for the generic server. These moved here with the code they cover:
+// routing, the trailing-slash rule, 404-vs-405, CORS, the panic barrier and
+// the TLS listener are transport concerns, and their tests belong beside
+// them rather than inside a protocol package.
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// do runs one request through the dispatcher without binding a port.
+func do(s *Server, method, path string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	s.MuxHandler().ServeHTTP(w, httptest.NewRequest(method, path, nil))
+	return w
+}
+
+func okHandler(body any) HandlerFunc {
+	return func(context.Context, *stdhttp.Request) (int, any, error) { return 0, body, nil }
+}
+
+// ---- routing ---------------------------------------------------------------
+
+func TestHappyPathDefaultsTo200(t *testing.T) {
+	s := NewServer(quietLogger())
+	s.Handle(stdhttp.MethodGet, "/thing", okHandler(map[string]string{"id": "x"}))
+
+	w := do(s, stdhttp.MethodGet, "/thing")
+	if w.Code != stdhttp.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("content-type = %q", ct)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("body: %v", err)
+	}
+	if got["id"] != "x" {
+		t.Errorf("body = %v", got)
+	}
+}
+
+func TestExplicitStatusIsHonoured(t *testing.T) {
+	s := NewServer(quietLogger())
+	s.Handle(stdhttp.MethodPost, "/thing", func(context.Context, *stdhttp.Request) (int, any, error) {
+		return stdhttp.StatusCreated, map[string]string{}, nil
+	})
+	if w := do(s, stdhttp.MethodPost, "/thing"); w.Code != stdhttp.StatusCreated {
+		t.Errorf("status = %d, want 201", w.Code)
+	}
+}
+
+// A trailing slash is not a different resource: clients send both forms and
+// answering 404 for the other spelling is defensible and useless.
+func TestTrailingSlashIsTheSameResource(t *testing.T) {
+	s := NewServer(quietLogger())
+	s.Handle(stdhttp.MethodGet, "/coll/", okHandler([]string{}))
+	if w := do(s, stdhttp.MethodGet, "/coll"); w.Code != stdhttp.StatusOK {
+		t.Errorf("no-slash form: status = %d", w.Code)
+	}
+
+	s2 := NewServer(quietLogger())
+	s2.Handle(stdhttp.MethodGet, "/coll", okHandler([]string{}))
+	if w := do(s2, stdhttp.MethodGet, "/coll/"); w.Code != stdhttp.StatusOK {
+		t.Errorf("slash form: status = %d", w.Code)
+	}
+}
+
+// An exact match must beat the alternate spelling, so a route registered for
+// one specific form still wins.
+func TestExactMatchBeatsAlternateSpelling(t *testing.T) {
+	s := NewServer(quietLogger())
+	s.Handle(stdhttp.MethodGet, "/x", okHandler("no-slash"))
+	s.Handle(stdhttp.MethodGet, "/x/", okHandler("slash"))
+	w := do(s, stdhttp.MethodGet, "/x")
+	if !strings.Contains(w.Body.String(), "no-slash") {
+		t.Errorf("body = %q", w.Body.String())
+	}
+}
+
+func TestPrefixRoutesLongestFirst(t *testing.T) {
+	s := NewServer(quietLogger())
+	s.HandlePrefix("/r/", stdhttp.MethodGet, okHandler("short"))
+	s.HandlePrefix("/r/deep/", stdhttp.MethodGet, okHandler("long"))
+	// Registered short-then-long; the longer prefix must still win.
+	w := do(s, stdhttp.MethodGet, "/r/deep/thing")
+	if !strings.Contains(w.Body.String(), "long") {
+		t.Errorf("body = %q — longest prefix did not win", w.Body.String())
+	}
+	if w := do(s, stdhttp.MethodGet, "/r/other"); !strings.Contains(w.Body.String(), "short") {
+		t.Errorf("body = %q", w.Body.String())
+	}
+
+	// And the other registration order: a SHORTER prefix added after a longer
+	// one must sort behind it, not in front of it.
+	s2 := NewServer(quietLogger())
+	s2.HandlePrefix("/r/deep/", stdhttp.MethodGet, okHandler("long"))
+	s2.HandlePrefix("/r/", stdhttp.MethodGet, okHandler("short"))
+	if w := do(s2, stdhttp.MethodGet, "/r/deep/thing"); !strings.Contains(w.Body.String(), "long") {
+		t.Errorf("reverse order: body = %q — longest prefix did not win", w.Body.String())
+	}
+}
+
+func TestNotFound(t *testing.T) {
+	s := NewServer(quietLogger())
+	s.Handle(stdhttp.MethodGet, "/thing", okHandler(nil))
+	w := do(s, stdhttp.MethodGet, "/nope")
+	if w.Code != stdhttp.StatusNotFound {
+		t.Errorf("status = %d", w.Code)
+	}
+}
+
+// A wrong METHOD is 405, not 404 — answering 404 tells a client the endpoint
+// does not exist at all.
+func TestMethodNotAllowed(t *testing.T) {
+	s := NewServer(quietLogger())
+	s.Handle(stdhttp.MethodPost, "/thing", okHandler(nil))
+	if w := do(s, stdhttp.MethodGet, "/thing"); w.Code != stdhttp.StatusMethodNotAllowed {
+		t.Errorf("exact: status = %d, want 405", w.Code)
+	}
+	// Same across the other slash spelling.
+	if w := do(s, stdhttp.MethodGet, "/thing/"); w.Code != stdhttp.StatusMethodNotAllowed {
+		t.Errorf("alt spelling: status = %d, want 405", w.Code)
+	}
+}
+
+func TestMethodNotAllowedOnPrefixRoute(t *testing.T) {
+	s := NewServer(quietLogger())
+	s.HandlePrefix("/health/", stdhttp.MethodPost, okHandler(nil))
+	if w := do(s, stdhttp.MethodGet, "/health/node-1"); w.Code != stdhttp.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", w.Code)
+	}
+}
+
+func TestHandlerErrorBecomes500(t *testing.T) {
+	s := NewServer(quietLogger())
+	s.Handle(stdhttp.MethodGet, "/boom", func(context.Context, *stdhttp.Request) (int, any, error) {
+		return 0, nil, errors.New("handler exploded")
+	})
+	w := do(s, stdhttp.MethodGet, "/boom")
+	if w.Code != stdhttp.StatusInternalServerError {
+		t.Fatalf("status = %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "handler exploded") {
+		t.Errorf("the cause must reach the body: %q", w.Body.String())
+	}
+}
+
+// A panicking handler must still produce a response, or the client sees a
+// dropped connection and retries straight back into the panic.
+func TestPanicBecomes500(t *testing.T) {
+	s := NewServer(quietLogger())
+	s.Handle(stdhttp.MethodGet, "/panic", func(context.Context, *stdhttp.Request) (int, any, error) {
+		panic("boom")
+	})
+	w := do(s, stdhttp.MethodGet, "/panic")
+	if w.Code != stdhttp.StatusInternalServerError {
+		t.Errorf("status = %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "panic recovered") {
+		t.Errorf("body = %q", w.Body.String())
+	}
+}
+
+// The panic barrier must work without a logger too — a nil Logger is a
+// legitimate zero value and must not turn a recovered panic into a new one.
+func TestPanicWithNoLogger(t *testing.T) {
+	s := NewServer(nil)
+	s.Handle(stdhttp.MethodGet, "/panic", func(context.Context, *stdhttp.Request) (int, any, error) {
+		panic("boom")
+	})
+	if w := do(s, stdhttp.MethodGet, "/panic"); w.Code != stdhttp.StatusInternalServerError {
+		t.Errorf("status = %d", w.Code)
+	}
+}
+
+func TestHandlerErrorWithNoLogger(t *testing.T) {
+	s := NewServer(nil)
+	s.Handle(stdhttp.MethodGet, "/boom", func(context.Context, *stdhttp.Request) (int, any, error) {
+		return 0, nil, errors.New("nope")
+	})
+	if w := do(s, stdhttp.MethodGet, "/boom"); w.Code != stdhttp.StatusInternalServerError {
+		t.Errorf("status = %d", w.Code)
+	}
+}
+
+func TestDuplicateRoutePanics(t *testing.T) {
+	s := NewServer(quietLogger())
+	s.Handle(stdhttp.MethodGet, "/dup", okHandler(nil))
+	defer func() {
+		if recover() == nil {
+			t.Error("a duplicate route is a wiring bug and must fail loudly")
+		}
+	}()
+	s.Handle(stdhttp.MethodGet, "/dup", okHandler(nil))
+}
+
+func TestDuplicateRawRoutePanics(t *testing.T) {
+	s := NewServer(quietLogger())
+	s.HandleRaw("/ws", stdhttp.NotFoundHandler())
+	defer func() {
+		if recover() == nil {
+			t.Error("a duplicate raw route must fail loudly")
+		}
+	}()
+	s.HandleRaw("/ws", stdhttp.NotFoundHandler())
+}
+
+// ---- raw handlers ----------------------------------------------------------
+
+func TestRawHandlerBypassesTheRouteTable(t *testing.T) {
+	s := NewServer(quietLogger())
+	s.HandleRaw("/ws", stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, _ *stdhttp.Request) {
+		w.WriteHeader(stdhttp.StatusSwitchingProtocols)
+	}))
+	if w := do(s, stdhttp.MethodGet, "/ws"); w.Code != stdhttp.StatusSwitchingProtocols {
+		t.Errorf("status = %d", w.Code)
+	}
+	// Same trailing-slash tolerance as the route table.
+	if w := do(s, stdhttp.MethodGet, "/ws/"); w.Code != stdhttp.StatusSwitchingProtocols {
+		t.Errorf("alt spelling: status = %d", w.Code)
+	}
+}
+
+// ---- gate ------------------------------------------------------------------
+
+func TestGateCanDeny(t *testing.T) {
+	s := NewServer(quietLogger())
+	s.Handle(stdhttp.MethodGet, "/thing", okHandler(nil))
+	s.Gate = GateFunc(func(*stdhttp.Request) (int, map[string]string, any, *stdhttp.Request, bool) {
+		return stdhttp.StatusUnauthorized,
+			map[string]string{"WWW-Authenticate": "Bearer realm=test"},
+			map[string]string{"error": "no token"}, nil, false
+	})
+	w := do(s, stdhttp.MethodGet, "/thing")
+	if w.Code != stdhttp.StatusUnauthorized {
+		t.Fatalf("status = %d", w.Code)
+	}
+	if got := w.Header().Get("WWW-Authenticate"); got != "Bearer realm=test" {
+		t.Errorf("gate headers lost: %q", got)
+	}
+}
+
+// The gate must run before RAW handlers too, or a WebSocket upgrade escapes
+// the policy that covers every plain route.
+func TestGateCoversRawHandlers(t *testing.T) {
+	s := NewServer(quietLogger())
+	reached := false
+	s.HandleRaw("/ws", stdhttp.HandlerFunc(func(stdhttp.ResponseWriter, *stdhttp.Request) { reached = true }))
+	s.Gate = GateFunc(func(*stdhttp.Request) (int, map[string]string, any, *stdhttp.Request, bool) {
+		return stdhttp.StatusUnauthorized, nil, nil, nil, false
+	})
+	if w := do(s, stdhttp.MethodGet, "/ws"); w.Code != stdhttp.StatusUnauthorized {
+		t.Errorf("status = %d", w.Code)
+	}
+	if reached {
+		t.Error("an upgrade must not run when the gate denied the request")
+	}
+}
+
+// A gate may hand back a modified request so it can stamp context values the
+// server knows nothing about.
+func TestGateCanReplaceTheRequest(t *testing.T) {
+	type key struct{}
+	s := NewServer(quietLogger())
+	var seen any
+	s.Handle(stdhttp.MethodGet, "/thing", func(ctx context.Context, _ *stdhttp.Request) (int, any, error) {
+		seen = ctx.Value(key{})
+		return 0, nil, nil
+	})
+	s.Gate = GateFunc(func(r *stdhttp.Request) (int, map[string]string, any, *stdhttp.Request, bool) {
+		return 0, nil, nil, r.WithContext(context.WithValue(r.Context(), key{}, "client-1")), true
+	})
+	do(s, stdhttp.MethodGet, "/thing")
+	if seen != "client-1" {
+		t.Errorf("context value = %v, want the gate's", seen)
+	}
+}
+
+func TestGatePassesWithoutReplacingTheRequest(t *testing.T) {
+	s := NewServer(quietLogger())
+	s.Handle(stdhttp.MethodGet, "/thing", okHandler(nil))
+	s.Gate = GateFunc(func(*stdhttp.Request) (int, map[string]string, any, *stdhttp.Request, bool) {
+		return 0, nil, nil, nil, true
+	})
+	if w := do(s, stdhttp.MethodGet, "/thing"); w.Code != stdhttp.StatusOK {
+		t.Errorf("status = %d", w.Code)
+	}
+}
+
+// Preflights are credential-less by browser design; gating them fails every
+// cross-origin call.
+func TestPreflightBypassesTheGate(t *testing.T) {
+	s := NewServer(quietLogger())
+	s.Handle(stdhttp.MethodGet, "/thing", okHandler(nil))
+	s.Gate = GateFunc(func(*stdhttp.Request) (int, map[string]string, any, *stdhttp.Request, bool) {
+		return stdhttp.StatusUnauthorized, nil, nil, nil, false
+	})
+	if w := do(s, stdhttp.MethodOptions, "/thing"); w.Code != stdhttp.StatusOK {
+		t.Errorf("status = %d, want the preflight through", w.Code)
+	}
+}
+
+// ---- CORS + preflight ------------------------------------------------------
+
+// The zero value emits nothing: a server that is not browser-facing should
+// not be handing out cross-origin permission by default.
+func TestZeroCORSEmitsNoHeaders(t *testing.T) {
+	s := NewServer(quietLogger())
+	s.Handle(stdhttp.MethodGet, "/thing", okHandler(nil))
+	w := do(s, stdhttp.MethodGet, "/thing")
+	for _, h := range []string{"Access-Control-Allow-Origin", "Access-Control-Allow-Headers", "Access-Control-Max-Age"} {
+		if got := w.Header().Get(h); got != "" {
+			t.Errorf("%s = %q, want nothing", h, got)
+		}
+	}
+}
+
+func TestConfiguredCORSAppliesToSuccessAndError(t *testing.T) {
+	s := NewServer(quietLogger())
+	s.CORS = CORS{AllowOrigin: "*", AllowHeaders: "Content-Type", MaxAge: "3600"}
+	s.Handle(stdhttp.MethodGet, "/thing", okHandler(nil))
+	for _, path := range []string{"/thing", "/missing"} {
+		w := do(s, stdhttp.MethodGet, path)
+		if got := w.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+			t.Errorf("%s: allow-origin = %q", path, got)
+		}
+		if got := w.Header().Get("Access-Control-Max-Age"); got != "3600" {
+			t.Errorf("%s: max-age = %q", path, got)
+		}
+	}
+}
+
+func TestPreflightAdvertisesRealMethods(t *testing.T) {
+	s := NewServer(quietLogger())
+	s.CORS = CORS{AllowOrigin: "*"}
+	s.Handle(stdhttp.MethodGet, "/thing", okHandler(nil))
+	s.Handle(stdhttp.MethodPatch, "/thing", okHandler(nil))
+	// Registered on the OTHER spelling: a preflight for /coll must still
+	// advertise the POST at /coll/, or the browser refuses a request that
+	// would have worked.
+	s.Handle(stdhttp.MethodPost, "/coll/", okHandler(nil))
+	s.HandlePrefix("/thing", stdhttp.MethodDelete, okHandler(nil))
+
+	w := do(s, stdhttp.MethodOptions, "/thing")
+	if w.Code != stdhttp.StatusOK {
+		t.Fatalf("status = %d, want 200 (not 204)", w.Code)
+	}
+	if w.Body.String() != "{}" {
+		t.Errorf("body = %q, want an empty JSON object", w.Body.String())
+	}
+	got := w.Header().Get("Access-Control-Allow-Methods")
+	if got != "OPTIONS, GET, PATCH, DELETE" {
+		t.Errorf("methods = %q — want the fixed OPTIONS,GET,HEAD,POST,PUT,PATCH,DELETE order", got)
+	}
+	if w.Header().Get("Allow") != got {
+		t.Errorf("Allow must mirror Access-Control-Allow-Methods")
+	}
+
+	if m := do(s, stdhttp.MethodOptions, "/coll").Header().Get("Allow"); !strings.Contains(m, "POST") {
+		t.Errorf("alt spelling: Allow = %q, want the POST registered at /coll/", m)
+	}
+}
+
+// An unknown path still gets a preflight answer — only OPTIONS itself.
+func TestPreflightOnUnknownPath(t *testing.T) {
+	s := NewServer(quietLogger())
+	s.CORS = CORS{AllowOrigin: "*"}
+	w := do(s, stdhttp.MethodOptions, "/nowhere")
+	if w.Code != stdhttp.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	if got := w.Header().Get("Allow"); got != "OPTIONS" {
+		t.Errorf("Allow = %q, want OPTIONS alone", got)
+	}
+}
+
+// ---- bodies ----------------------------------------------------------------
+
+func TestRawBodyIsEmittedVerbatim(t *testing.T) {
+	s := NewServer(quietLogger())
+	s.Handle(stdhttp.MethodGet, "/sdp", okHandler(&RawBody{
+		ContentType: "application/sdp", Body: []byte("v=0\r\n"),
+	}))
+	w := do(s, stdhttp.MethodGet, "/sdp")
+	if ct := w.Header().Get("Content-Type"); ct != "application/sdp" {
+		t.Errorf("content-type = %q", ct)
+	}
+	if w.Body.String() != "v=0\r\n" {
+		t.Errorf("body = %q — must not be JSON-encoded", w.Body.String())
+	}
+}
+
+func TestRawBodyWithoutContentType(t *testing.T) {
+	s := NewServer(quietLogger())
+	s.Handle(stdhttp.MethodGet, "/blob", okHandler(&RawBody{Body: []byte{0x01}}))
+	if ct := do(s, stdhttp.MethodGet, "/blob").Header().Get("Content-Type"); ct != "application/octet-stream" {
+		t.Errorf("content-type = %q", ct)
+	}
+}
+
+func TestWithHeaders(t *testing.T) {
+	s := NewServer(quietLogger())
+	s.Handle(stdhttp.MethodPost, "/res", func(context.Context, *stdhttp.Request) (int, any, error) {
+		return stdhttp.StatusCreated, &WithHeaders{
+			Body:    map[string]string{"id": "n1"},
+			Headers: map[string]string{"Location": "/res/n1"},
+		}, nil
+	})
+	w := do(s, stdhttp.MethodPost, "/res")
+	if w.Header().Get("Location") != "/res/n1" {
+		t.Errorf("Location = %q", w.Header().Get("Location"))
+	}
+	if !strings.Contains(w.Body.String(), "n1") {
+		t.Errorf("body = %q", w.Body.String())
+	}
+}
+
+// WithHeaders wrapping RawBody is the combination IS-04 needs: a transportfile
+// with a custom header.
+func TestWithHeadersWrappingRawBody(t *testing.T) {
+	s := NewServer(quietLogger())
+	s.Handle(stdhttp.MethodGet, "/sdp", okHandler(&WithHeaders{
+		Body:    &RawBody{ContentType: "application/sdp", Body: []byte("v=0")},
+		Headers: map[string]string{"X-Test": "1"},
+	}))
+	w := do(s, stdhttp.MethodGet, "/sdp")
+	if w.Header().Get("X-Test") != "1" || w.Header().Get("Content-Type") != "application/sdp" {
+		t.Errorf("headers = %v", w.Header())
+	}
+	if w.Body.String() != "v=0" {
+		t.Errorf("body = %q", w.Body.String())
+	}
+}
+
+// The status line is already flushed when encoding fails, so this cannot
+// become a 500 — logging is the only honest thing left.
+func TestEncodeFailureAfterHeadersIsLogged(t *testing.T) {
+	var logged strings.Builder
+	s := NewServer(slog.New(slog.NewTextHandler(&logged, nil)))
+	s.Handle(stdhttp.MethodGet, "/bad", okHandler(make(chan int)))
+	w := do(s, stdhttp.MethodGet, "/bad")
+	if w.Code != stdhttp.StatusOK {
+		t.Errorf("status = %d — headers were already sent", w.Code)
+	}
+	if !strings.Contains(logged.String(), "encode failed") {
+		t.Errorf("the failure must be logged: %q", logged.String())
+	}
+}
+
+func TestEncodeFailureWithNoLogger(t *testing.T) {
+	s := NewServer(nil)
+	s.Handle(stdhttp.MethodGet, "/bad", okHandler(make(chan int)))
+	if w := do(s, stdhttp.MethodGet, "/bad"); w.Code != stdhttp.StatusOK {
+		t.Errorf("status = %d", w.Code)
+	}
+}
+
+// ---- error encoder ---------------------------------------------------------
+
+func TestDefaultErrorShape(t *testing.T) {
+	s := NewServer(quietLogger())
+	w := do(s, stdhttp.MethodGet, "/missing")
+	var got defaultError
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("body: %v", err)
+	}
+	if got.Code != stdhttp.StatusNotFound || got.Error != "Not Found" || got.Debug != "/missing" {
+		t.Errorf("body = %+v", got)
+	}
+}
+
+// A protocol that wants RFC 7807, or IS-04's envelope, injects its own shape
+// and the server never invents one.
+func TestInjectedErrorShape(t *testing.T) {
+	s := NewServer(quietLogger())
+	s.Errors = func(status int, errStr, debug string) any {
+		return map[string]any{"type": "about:blank", "status": status, "title": errStr, "detail": debug}
+	}
+	w := do(s, stdhttp.MethodGet, "/missing")
+	var got map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("body: %v", err)
+	}
+	if got["title"] != "Not Found" || got["type"] != "about:blank" {
+		t.Errorf("body = %v", got)
+	}
+}
+
+// ---- TLS + Serve -----------------------------------------------------------
+
+// A TLS server declares it only speaks TLS.
+func TestHSTSOnTLSRequests(t *testing.T) {
+	s := NewServer(quietLogger())
+	s.Handle(stdhttp.MethodGet, "/thing", okHandler(nil))
+	r := httptest.NewRequest(stdhttp.MethodGet, "/thing", nil)
+	r.TLS = &tls.ConnectionState{}
+	w := httptest.NewRecorder()
+	s.MuxHandler().ServeHTTP(w, r)
+	if got := w.Header().Get("Strict-Transport-Security"); got != "max-age=31536000" {
+		t.Errorf("HSTS = %q", got)
+	}
+	// And absent on a plain request.
+	if got := do(s, stdhttp.MethodGet, "/thing").Header().Get("Strict-Transport-Security"); got != "" {
+		t.Errorf("plain HTTP must not claim HSTS: %q", got)
+	}
+}
+
+func TestServeStopsOnContextCancel(t *testing.T) {
+	s := NewServer(quietLogger())
+	s.Handle(stdhttp.MethodGet, "/thing", okHandler(nil))
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- s.Serve(ctx, "127.0.0.1:0") }()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Serve = %v, want a clean shutdown", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Serve did not return after cancellation")
+	}
+}
+
+func TestServeCannotStartTwice(t *testing.T) {
+	s := NewServer(quietLogger())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = s.Serve(ctx, "127.0.0.1:0") }()
+	time.Sleep(50 * time.Millisecond)
+	if err := s.Serve(ctx, "127.0.0.1:0"); err == nil {
+		t.Error("starting twice must be an error, not a second listener")
+	}
+}
+
+func TestServeReportsListenFailure(t *testing.T) {
+	s := NewServer(quietLogger())
+	// Port 0 is chosen by the kernel; a port above the 16-bit range cannot
+	// be parsed, so ListenAndServe fails immediately.
+	if err := s.Serve(context.Background(), "127.0.0.1:99999"); err == nil {
+		t.Error("an unbindable address must be reported")
+	}
+}
+
+// The TLS branch takes a different call path (ListenAndServeTLS); an
+// unbindable address exercises it without needing a certificate.
+func TestServeTLSReportsListenFailure(t *testing.T) {
+	s := NewServer(quietLogger())
+	s.TLS = &tls.Config{MinVersion: tls.VersionTLS12}
+	if err := s.Serve(context.Background(), "127.0.0.1:99999"); err == nil {
+		t.Error("an unbindable TLS address must be reported")
+	}
+}
+
+func TestAltSlashForm(t *testing.T) {
+	if got := altSlashForm("/a"); got != "/a/" {
+		t.Errorf("got %q", got)
+	}
+	if got := altSlashForm("/a/"); got != "/a" {
+		t.Errorf("got %q", got)
+	}
+}


### PR DESCRIPTION
Allowlist step 1 of 5. The entry `internal/amwa/session/http/server.go → "generic HTTP server → transport/http"` has named this move as the plan since it was written; this does it.

`internal/transport/http` had a **client and no server**, while `amwa/session/http` carried 456 lines of server that was NMOS-shaped in exactly two places.

## What moved — because it isn't NMOS

| | |
|---|---|
| route table | exact + prefix match, longest prefix first |
| trailing-slash rule | a trailing slash is not a different resource |
| 404 vs 405 | a wrong method is not a missing endpoint |
| panic barrier | a panicking handler still answers |
| TLS listener + HSTS | |
| CORS + OPTIONS preflight | |
| `RawBody` / `WithHeaders` | |

## What stayed with the spec — now injected, not hard-coded

- **`ErrorEncoder`** — the IS-04 §4.4 envelope. Protocols disagree about error shape (one wants `{code,error,debug}`, another RFC 7807), so the server never invents one.
- **`Gate`** — the BCP-003-02 token rules. It returns a **request** rather than a client id, so a gate can stamp context values this package knows nothing about; `WithClientID` stays in amwa.
- **`CORS`** — a zero value emits **nothing**, which is right for a server that isn't browser-facing. The NMOS wrapper sets §4.5's header set.

## Call sites: all 148 unchanged

amwa's `Server` embeds the transport one. `Handle`, `HandlePrefix`, `HandleRaw`, `MuxHandler` and `Serve` are promoted, and so are the `Logger` and `TLS` fields. `HandlerFunc`, `RawBody` and `WithHeaders` are **type aliases**, not wrappers, so a `*RawBody` built in amwa is the same type the server type-switches on.

One shape worth calling out: the gate reads `s.Auth` **per request** rather than capturing it at construction. Callers set `.Auth` after `NewServer`, so a snapshot taken there would be nil forever — that's a real bug this avoids, not a style preference.

Also dropped a speculative `Addr()` accessor I'd added with no caller.

The generic **tests moved with the generic code** — routing, slash handling, 404/405, CORS, the panic barrier and the TLS listener are transport concerns; their tests belong beside them, not inside a protocol package.

## Verification

| | |
|---|---|
| `internal/transport/http` | **100%** — holds its CI floor, now with the server in it |
| architecture allowlist | 27 → 26 |
| build + vet | green |
| full suite | green |
| coverage floors | **29/29** |
| `golangci-lint` | 0 issues |

The stale-entry guard in `architecture_test.go` flagged the now-dead allowlist line on its own — the guard doing exactly its job.

Next in the drain: probel codec clients → `consumer/` (the 2 ADR-0006-forced entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
