### PR TITLE
refactor(transport): bind the four TCP providers through transport.ListenTCP

### DIFF
--- a/internal/acp2/provider/coverage100_test.go
+++ b/internal/acp2/provider/coverage100_test.go
@@ -460,9 +460,11 @@ func TestServe_AcceptHardError(t *testing.T) {
 // non-net.ErrClosed error, driving acceptLoop's hard-error return arm.
 type hardErrListener struct{}
 
-func (*hardErrListener) Accept() (net.Conn, error) { return nil, errors.New("synthetic accept failure") }
-func (*hardErrListener) Close() error              { return nil }
-func (*hardErrListener) Addr() net.Addr            { return dummyAddr{} }
+func (*hardErrListener) Accept() (net.Conn, error) {
+	return nil, errors.New("synthetic accept failure")
+}
+func (*hardErrListener) Close() error   { return nil }
+func (*hardErrListener) Addr() net.Addr { return dummyAddr{} }
 
 type dummyAddr struct{}
 

--- a/internal/acp2/provider/demo.go
+++ b/internal/acp2/provider/demo.go
@@ -2,10 +2,10 @@ package acp2
 
 import (
 	"context"
+	"dhs/internal/acp2/codec"
 	"log/slog"
 	"math"
 	"time"
-	"dhs/internal/acp2/codec"
 )
 
 // RunAnnounceDemo mutates slot=1 / obj=18 (GainFloat) every `interval`

--- a/internal/acp2/provider/encoder.go
+++ b/internal/acp2/provider/encoder.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	"dhs/internal/export/canonical"
 	"dhs/internal/acp2/codec"
+	"dhs/internal/export/canonical"
 )
 
 // buildProperties assembles the ACP2 property list a get_object reply

--- a/internal/acp2/provider/encoder_test.go
+++ b/internal/acp2/provider/encoder_test.go
@@ -4,8 +4,8 @@ import (
 	"encoding/binary"
 	"testing"
 
-	"dhs/internal/export/canonical"
 	"dhs/internal/acp2/codec"
+	"dhs/internal/export/canonical"
 )
 
 // helper â€” round-trips a tree through buildProperties + EncodeProperties
@@ -52,7 +52,7 @@ func TestBuildProperties_Node(t *testing.T) {
 		codec.PIDObjectType: true, codec.PIDLabel: true, codec.PIDChildren: true,
 	}
 	notWant := map[uint8]bool{
-		codec.PIDAccess:        true, // pid 3 â€” Node row blank
+		codec.PIDAccess:     true, // pid 3 â€” Node row blank
 		codec.PIDEventDelay: true, // pid 4 â€” Node row blank
 	}
 	for _, p := range got {
@@ -83,7 +83,7 @@ func TestBuildProperties_NumberS32(t *testing.T) {
 		Header: canonical.Header{
 			Number: 5, Identifier: "Level", Access: canonical.AccessReadWrite,
 		},
-		Type: canonical.ParamInteger,
+		Type:  canonical.ParamInteger,
 		Value: int64(-6), Minimum: int64(-60), Maximum: int64(12),
 		Step: int64(1), Default: int64(0),
 		Unit: &unit,

--- a/internal/acp2/provider/handlers.go
+++ b/internal/acp2/provider/handlers.go
@@ -1,9 +1,9 @@
 package acp2
 
 import (
+	"dhs/internal/acp2/codec"
 	"fmt"
 	"log/slog"
-	"dhs/internal/acp2/codec"
 )
 
 // Version constants advertised by this provider.
@@ -55,10 +55,10 @@ func (s *session) dispatch(f *codec.AN2Frame) {
 // handleAN2Internal implements the proto=0 handshake a consumer runs
 // before sending any ACP2 traffic. Reply byte layouts per spec:
 //
-//	1. GetVersion           §3.3.1 -> [0, ver_hi, ver_lo]      ver=u16BE
-//	2. GetDeviceInfo        §3.3.2 -> [1, slot_count]          dlen=2
-//	3. GetSlotInfo(slot)    §3.3.3 -> [2, status, num, protos] dlen=3+num
-//	4. EnableProtocolEvents §3.3.4 -> [3]                      dlen=1
+//  1. GetVersion           §3.3.1 -> [0, ver_hi, ver_lo]      ver=u16BE
+//  2. GetDeviceInfo        §3.3.2 -> [1, slot_count]          dlen=2
+//  3. GetSlotInfo(slot)    §3.3.3 -> [2, status, num, protos] dlen=3+num
+//  4. EnableProtocolEvents §3.3.4 -> [3]                      dlen=1
 //
 // All replies mirror the request's AN2 mtid + slot per spec §3.3 so
 // the consumer's waiter table correlates them cleanly.

--- a/internal/acp2/provider/handlers_test.go
+++ b/internal/acp2/provider/handlers_test.go
@@ -1,13 +1,13 @@
 package acp2
 
 import (
+	"dhs/internal/acp2/codec"
 	"io"
 	"log/slog"
 	"net"
 	"sync"
 	"testing"
 	"time"
-	"dhs/internal/acp2/codec"
 )
 
 // newTestSession builds a session bound to a net.Pipe so handshake
@@ -275,10 +275,10 @@ func TestAN2Handshake_EnableProtocolEvents(t *testing.T) {
 	defer func() { _ = peer.Close() }()
 
 	req := &codec.AN2Frame{
-		Proto:   codec.AN2ProtoInternal,
-		Slot:    0,
-		MTID:    6,
-		Type:    codec.AN2TypeRequest,
+		Proto: codec.AN2ProtoInternal,
+		Slot:  0,
+		MTID:  6,
+		Type:  codec.AN2TypeRequest,
 		// count=1, proto=ACP2
 		Payload: []byte{codec.AN2FuncEnableProtocolEvents, 1, uint8(codec.AN2ProtoACP2)},
 	}

--- a/internal/acp2/provider/server.go
+++ b/internal/acp2/provider/server.go
@@ -100,10 +100,17 @@ func (s *server) Metrics() *metrics.Connector { return s.metrics }
 // Serve binds addr (e.g. "0.0.0.0:2072") and blocks until ctx is
 // cancelled or a fatal listen error occurs.
 func (s *server) Serve(ctx context.Context, addr string) error {
-	ln, err := net.Listen("tcp4", addr)
+	// tcp4 preserved: acp2 binds IPv4-only.
+	//
+	// The bind goes through transport; the socket policy is applied by the
+	// accept loop below, which is why the embedded listener is used rather
+	// than the wrapper — the wrapper would apply it a second time, and the
+	// accept loop is the arm that also covers a listener injected by a test.
+	tln, err := transport.ListenTCP(ctx, "tcp4", addr, transport.SocketOptions{})
 	if err != nil {
 		return fmt.Errorf("acp2 provider: listen %q: %w", addr, err)
 	}
+	ln := tln.Listener
 
 	s.mu.Lock()
 	s.listener = ln

--- a/internal/acp2/provider/tree.go
+++ b/internal/acp2/provider/tree.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"sync"
 
-	"dhs/internal/export/canonical"
 	"dhs/internal/acp2/codec"
+	"dhs/internal/export/canonical"
 )
 
 // entry is one object in the served tree. Holds the canonical source
@@ -17,13 +17,13 @@ import (
 type entry struct {
 	objID    uint32
 	slot     uint8
-	parent   uint32             // 0 for the slot root (ROOT_NODE_V2)
+	parent   uint32 // 0 for the slot root (ROOT_NODE_V2)
 	label    string
-	access   uint8              // bit 0 read, bit 1 write (spec pid=3)
-	objType  codec.ACP2ObjType  // node / number / enum / ipv4 / string / preset
-	numType  codec.NumberType   // meaningful for codec.ObjTypeNumber, codec.ObjTypeEnum (u32 index)
-	children []uint32           // pid=14 u32[] — direct child obj-ids
-	node     *canonical.Node    // set when objType=node
+	access   uint8                // bit 0 read, bit 1 write (spec pid=3)
+	objType  codec.ACP2ObjType    // node / number / enum / ipv4 / string / preset
+	numType  codec.NumberType     // meaningful for codec.ObjTypeNumber, codec.ObjTypeEnum (u32 index)
+	children []uint32             // pid=14 u32[] — direct child obj-ids
+	node     *canonical.Node      // set when objType=node
 	param    *canonical.Parameter // set for leaf types
 	// presetDepth is the N of a preset child's idx list (pid 7). Zero
 	// means "not a preset" — every other object type leaves this at 0.
@@ -202,14 +202,14 @@ func flatten(slot uint8, parent uint32, el canonical.Element, index map[uint32]*
 			return fmt.Errorf("obj %d (%q): %w", id, x.Identifier, err)
 		}
 		e := &entry{
-			objID:       id,
-			slot:        slot,
-			parent:      parent,
-			label:       wireLabel(x.Identifier),
-			access:      deriveAccess(x.Access),
-			objType:     objType,
-			numType:     numType,
-			param:       x,
+			objID:         id,
+			slot:          slot,
+			parent:        parent,
+			label:         wireLabel(x.Identifier),
+			access:        deriveAccess(x.Access),
+			objType:       objType,
+			numType:       numType,
+			param:         x,
 			presetDepth:   presetDepthHint(x),
 			presetIdxList: presetIdxHint(x),
 		}

--- a/internal/acp2/provider/tree_test.go
+++ b/internal/acp2/provider/tree_test.go
@@ -3,8 +3,8 @@ package acp2
 import (
 	"testing"
 
-	"dhs/internal/export/canonical"
 	"dhs/internal/acp2/codec"
+	"dhs/internal/export/canonical"
 )
 
 func TestTree_FlattensAndIndexesBySlot(t *testing.T) {
@@ -23,28 +23,28 @@ func TestTree_FlattensAndIndexesBySlot(t *testing.T) {
 	board := &canonical.Node{
 		Header: canonical.Header{
 			Number: 2, Identifier: "BOARD", OID: "1.1.2",
-			Access: canonical.AccessRead,
+			Access:   canonical.AccessRead,
 			Children: []canonical.Element{label},
 		},
 	}
 	root := &canonical.Node{
 		Header: canonical.Header{
 			Number: 1, Identifier: "ROOT_NODE_V2", OID: "1.1.1",
-			Access: canonical.AccessRead,
+			Access:   canonical.AccessRead,
 			Children: []canonical.Element{board},
 		},
 	}
 	slot1 := &canonical.Node{
 		Header: canonical.Header{
 			Number: 1, Identifier: "slot-1", OID: "1.1",
-			Access: canonical.AccessRead,
+			Access:   canonical.AccessRead,
 			Children: []canonical.Element{root},
 		},
 	}
 	exp := &canonical.Export{Root: &canonical.Node{
 		Header: canonical.Header{
 			Number: 1, Identifier: "device", OID: "1",
-			Access: canonical.AccessRead,
+			Access:   canonical.AccessRead,
 			Children: []canonical.Element{slot1},
 		},
 	}}

--- a/internal/emberplus/provider/coverage2_test.go
+++ b/internal/emberplus/provider/coverage2_test.go
@@ -707,7 +707,7 @@ func TestWritePump_WriteError(t *testing.T) {
 // encodeTemplateElement (the "kind not supported" guards).
 type customElement struct{ hdr canonical.Header }
 
-func (c *customElement) Kind() string             { return "custom" }
+func (c *customElement) Kind() string              { return "custom" }
 func (c *customElement) Common() *canonical.Header { return &c.hdr }
 
 // TestEncoders_UnsupportedKind covers the default error arms of

--- a/internal/emberplus/provider/coverage_netfail_test.go
+++ b/internal/emberplus/provider/coverage_netfail_test.go
@@ -45,11 +45,11 @@ func (c *failConn) Close() error {
 	return nil
 }
 
-func (c *failConn) LocalAddr() net.Addr                { return fakeAddr{} }
-func (c *failConn) RemoteAddr() net.Addr               { return fakeAddr{} }
-func (c *failConn) SetDeadline(time.Time) error        { return nil }
-func (c *failConn) SetReadDeadline(time.Time) error    { return nil }
-func (c *failConn) SetWriteDeadline(time.Time) error   { return nil }
+func (c *failConn) LocalAddr() net.Addr              { return fakeAddr{} }
+func (c *failConn) RemoteAddr() net.Addr             { return fakeAddr{} }
+func (c *failConn) SetDeadline(time.Time) error      { return nil }
+func (c *failConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *failConn) SetWriteDeadline(time.Time) error { return nil }
 
 type fakeAddr struct{}
 
@@ -184,7 +184,7 @@ func TestFindCommandInElements_MatrixChildren(t *testing.T) {
 	cmd := &glow.Command{Number: glow.CmdGetDirectory}
 	els := []glow.Element{{
 		Matrix: &glow.Matrix{
-			Path: []int32{1, 2},
+			Path:     []int32{1, 2},
 			Children: []glow.Element{{Command: cmd}},
 		},
 	}}

--- a/internal/emberplus/provider/coverage_test.go
+++ b/internal/emberplus/provider/coverage_test.go
@@ -183,16 +183,16 @@ func TestProvider_Loopback(t *testing.T) {
 	}
 
 	reqs := [][]byte{
-		glow.EncodeGetDirectory(),                       // bare root GetDirectory
-		glow.EncodeGetDirectoryFor([]int32{1}),          // GetDirectory on root node
-		glow.EncodeGetDirectoryFor([]int32{1, 7}),       // GetDirectory on matrix (implicit subscribe)
-		glow.EncodeSubscribe([]int32{1, 5}),             // subscribe stream param
-		glow.EncodeUnsubscribe([]int32{1, 5}),           // unsubscribe
-		glow.EncodeSetValue([]int32{1, 1}, int64(42)),   // set int param
+		glow.EncodeGetDirectory(),                                                  // bare root GetDirectory
+		glow.EncodeGetDirectoryFor([]int32{1}),                                     // GetDirectory on root node
+		glow.EncodeGetDirectoryFor([]int32{1, 7}),                                  // GetDirectory on matrix (implicit subscribe)
+		glow.EncodeSubscribe([]int32{1, 5}),                                        // subscribe stream param
+		glow.EncodeUnsubscribe([]int32{1, 5}),                                      // unsubscribe
+		glow.EncodeSetValue([]int32{1, 1}, int64(42)),                              // set int param
 		glow.EncodeMatrixConnect([]int32{1, 7}, 1, []int32{1}, glow.ConnOpConnect), // matrix connect
 		glow.EncodeInvoke([]int32{1, 8}, 99, []any{int64(3), int64(4)}),            // invoke sum
-		glow.EncodeGetDirectoryFor([]int32{4, 2}),       // unknown path → replyGetDirectory error
-		glow.EncodeSetValue([]int32{9, 9, 9}, int64(1)), // set on missing oid → error path
+		glow.EncodeGetDirectoryFor([]int32{4, 2}),                                  // unknown path → replyGetDirectory error
+		glow.EncodeSetValue([]int32{9, 9, 9}, int64(1)),                            // set on missing oid → error path
 	}
 	drive(t, srv, reqs)
 
@@ -380,8 +380,8 @@ func TestEncodeValue_AllTypes(t *testing.T) {
 		{canonical.ParamBoolean, 1, false},
 		{canonical.ParamOctets, []byte{1}, true},
 		{canonical.ParamOctets, "nope", false},
-		{canonical.ParamTrigger, nil, false},  // nil short-circuit
-		{"unknown-type", int64(1), false},     // unmapped type
+		{canonical.ParamTrigger, nil, false}, // nil short-circuit
+		{"unknown-type", int64(1), false},    // unmapped type
 	}
 	for _, c := range cases {
 		if _, ok := encodeValue(c.typ, c.v); ok != c.want {

--- a/internal/emberplus/provider/encoder.go
+++ b/internal/emberplus/provider/encoder.go
@@ -3,9 +3,9 @@ package emberplus
 import (
 	"fmt"
 
-	"dhs/internal/export/canonical"
 	"dhs/internal/emberplus/codec/ber"
 	"dhs/internal/emberplus/codec/glow"
+	"dhs/internal/export/canonical"
 )
 
 // encodeGetDirReply walks the tree entry e and produces the BER payload

--- a/internal/emberplus/provider/encoder_test.go
+++ b/internal/emberplus/provider/encoder_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"dhs/internal/export/canonical"
 	"dhs/internal/emberplus/codec/glow"
+	"dhs/internal/export/canonical"
 )
 
 // TestRoundTrip_NodeWithParameter asserts the provider encoder and the

--- a/internal/emberplus/provider/function.go
+++ b/internal/emberplus/provider/function.go
@@ -1,9 +1,9 @@
 package emberplus
 
 import (
-	"dhs/internal/export/canonical"
 	"dhs/internal/emberplus/codec/ber"
 	"dhs/internal/emberplus/codec/glow"
+	"dhs/internal/export/canonical"
 )
 
 // encodeQualifiedFunction emits a [APPLICATION 20] QualifiedFunction. Only

--- a/internal/emberplus/provider/function_test.go
+++ b/internal/emberplus/provider/function_test.go
@@ -3,8 +3,8 @@ package emberplus
 import (
 	"testing"
 
-	"dhs/internal/export/canonical"
 	"dhs/internal/emberplus/codec/glow"
+	"dhs/internal/export/canonical"
 )
 
 // TestRoundTrip_Function checks a Function with 2 integer args → 1 result

--- a/internal/emberplus/provider/invoke.go
+++ b/internal/emberplus/provider/invoke.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"sync"
 
-	"dhs/internal/export/canonical"
 	"dhs/internal/emberplus/codec/ber"
 	"dhs/internal/emberplus/codec/glow"
+	"dhs/internal/export/canonical"
 )
 
 // FunctionImpl is a provider-side callback bound to a canonical Function.
@@ -17,7 +17,7 @@ type FunctionImpl func(args []any) ([]any, error)
 
 // functionRegistry maps function OID -> callback. Accessed under s.mu.
 type functionRegistry struct {
-	mu  sync.RWMutex
+	mu    sync.RWMutex
 	byOID map[string]FunctionImpl
 }
 

--- a/internal/emberplus/provider/matrix.go
+++ b/internal/emberplus/provider/matrix.go
@@ -3,9 +3,9 @@ package emberplus
 import (
 	"fmt"
 
-	"dhs/internal/export/canonical"
 	"dhs/internal/emberplus/codec/ber"
 	"dhs/internal/emberplus/codec/glow"
+	"dhs/internal/export/canonical"
 )
 
 // encodeQualifiedMatrix emits a [APPLICATION 17] QualifiedMatrix. Contents

--- a/internal/emberplus/provider/matrix_test.go
+++ b/internal/emberplus/provider/matrix_test.go
@@ -3,8 +3,8 @@ package emberplus
 import (
 	"testing"
 
-	"dhs/internal/export/canonical"
 	"dhs/internal/emberplus/codec/glow"
+	"dhs/internal/export/canonical"
 )
 
 // buildMatrixTree constructs a minimal tree: router(Node 1) → mat(Matrix 1.1)

--- a/internal/emberplus/provider/server.go
+++ b/internal/emberplus/provider/server.go
@@ -62,12 +62,14 @@ func (s *server) Serve(ctx context.Context, addr string) error {
 	if s.tree == nil {
 		return fmt.Errorf("emberplus-provider: tree not loaded")
 	}
-	lc := net.ListenConfig{}
-	ln, err := lc.Listen(ctx, "tcp", addr)
+	ln, err := transport.ListenTCP(ctx, "tcp", addr, transport.SocketOptions{})
 	if err != nil {
 		return fmt.Errorf("listen %s: %w", addr, err)
 	}
-	return s.serveListener(ctx, ln)
+	// The embedded listener, not the wrapper: serveListener's accept loop
+	// applies the socket policy itself, so an injected listener from
+	// ServeListener gets it too. Passing the wrapper would apply it twice.
+	return s.serveListener(ctx, ln.Listener)
 }
 
 // ServeListener serves on a pre-bound listener. Exported on the concrete

--- a/internal/emberplus/provider/session.go
+++ b/internal/emberplus/provider/session.go
@@ -12,9 +12,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"dhs/internal/export/canonical"
 	"dhs/internal/emberplus/codec/glow"
 	"dhs/internal/emberplus/codec/s101"
+	"dhs/internal/export/canonical"
 )
 
 // session is one live consumer connection. Single read loop; a send

--- a/internal/emberplus/provider/streamer.go
+++ b/internal/emberplus/provider/streamer.go
@@ -7,20 +7,20 @@ import (
 	"math/rand"
 	"time"
 
-	"dhs/internal/export/canonical"
 	"dhs/internal/emberplus/codec/ber"
 	"dhs/internal/emberplus/codec/glow"
+	"dhs/internal/export/canonical"
 )
 
 // streamEntry holds the per-parameter state needed to emit StreamEntry
 // values each tick. Type is captured at tree-load time so the streamer
 // doesn't have to re-look-up the Parameter on every tick.
 type streamEntry struct {
-	id      int64  // stream identifier (wire-visible to consumers)
-	oid     string // source parameter OID, for debug
-	kind    string // canonical parameter type (real / integer / boolean)
-	min     float64
-	max     float64
+	id   int64  // stream identifier (wire-visible to consumers)
+	oid  string // source parameter OID, for debug
+	kind string // canonical parameter type (real / integer / boolean)
+	min  float64
+	max  float64
 }
 
 // collectStreams walks the loaded tree for Parameters with a non-nil
@@ -166,4 +166,3 @@ func (s *server) fanoutStreams(entries []streamEntry) {
 		}
 	}
 }
-

--- a/internal/probel-sw02p/provider/server.go
+++ b/internal/probel-sw02p/provider/server.go
@@ -118,12 +118,14 @@ func newServer(logger *slog.Logger, exp *canonical.Export) *server {
 
 // Serve binds addr and accepts client sessions until ctx is cancelled.
 func (s *server) Serve(ctx context.Context, addr string) error {
-	lc := &net.ListenConfig{}
-	ln, err := lc.Listen(ctx, "tcp", addr)
+	ln, err := transport.ListenTCP(ctx, "tcp", addr, transport.SocketOptions{})
 	if err != nil {
 		return fmt.Errorf("probel-sw02p provider: listen %q: %w", addr, err)
 	}
-	return s.serveListener(ctx, ln)
+	// The embedded listener, not the wrapper: serveListener's accept loop
+	// applies the socket policy itself, so a listener handed to
+	// ServeListener gets it too. Passing the wrapper would apply it twice.
+	return s.serveListener(ctx, ln.Listener)
 }
 
 // ServeListener accepts client sessions on a pre-bound listener until

--- a/internal/probel-sw08p/provider/server.go
+++ b/internal/probel-sw08p/provider/server.go
@@ -100,8 +100,13 @@ var listenHook func(ctx context.Context, addr string) (net.Listener, error)
 // Serve binds addr and accepts client sessions until ctx is cancelled.
 func (s *server) Serve(ctx context.Context, addr string) error {
 	listen := func(ctx context.Context, addr string) (net.Listener, error) {
-		lc := &net.ListenConfig{}
-		return lc.Listen(ctx, "tcp", addr)
+		// The embedded listener, not the wrapper: acceptLoop applies the
+		// socket policy itself, so a listener from listenHook gets it too.
+		ln, err := transport.ListenTCP(ctx, "tcp", addr, transport.SocketOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return ln.Listener, nil
 	}
 	if listenHook != nil {
 		listen = listenHook

--- a/internal/transport/architecture_test.go
+++ b/internal/transport/architecture_test.go
@@ -79,18 +79,14 @@ var allowed = map[string]string{
 	// They already apply the shared socket policy via ApplySocketOptions;
 	// what remains is the bind itself moving to transport.ListenTCP, as the
 	// osc and tsl consumers have already done.
-	"internal/acp1/provider/tcp_server.go":     "listener bind → transport.ListenTCP",
-	"internal/acp1/provider/an2_server.go":     "listener bind → transport.ListenTCP",
-	"internal/acp1/provider/server.go":         "listener bind + UDP dial → transport",
-	"internal/acp1/provider/admin.go":          "admin listener + dial; already has an injectable dial seam",
-	"internal/acp2/provider/server.go":         "listener bind → transport.ListenTCP",
-	"internal/emberplus/provider/server.go":    "listener bind → transport.ListenTCP",
-	"internal/probel-sw02p/provider/server.go": "listener bind → transport.ListenTCP",
-	"internal/probel-sw08p/provider/server.go": "listener bind → transport.ListenTCP",
-	"internal/osc/consumer/session.go":         "UDP listener bind → transport.ListenUDP",
-	"internal/osc/provider/sender.go":          "UDP sender socket → transport",
-	"internal/tsl/consumer/session.go":         "UDP listener bind → transport.ListenUDP",
-	"internal/tsl/provider/sender.go":          "UDP sender socket → transport",
+	"internal/acp1/provider/tcp_server.go": "listener bind → transport.ListenTCP",
+	"internal/acp1/provider/an2_server.go": "listener bind → transport.ListenTCP",
+	"internal/acp1/provider/server.go":     "listener bind + UDP dial → transport",
+	"internal/acp1/provider/admin.go":      "admin listener + dial; already has an injectable dial seam",
+	"internal/osc/consumer/session.go":     "UDP listener bind → transport.ListenUDP",
+	"internal/osc/provider/sender.go":      "UDP sender socket → transport",
+	"internal/tsl/consumer/session.go":     "UDP listener bind → transport.ListenUDP",
+	"internal/tsl/provider/sender.go":      "UDP sender socket → transport",
 
 	// DEBT — the HTTP server has not been extracted from amwa yet.
 	//

--- a/internal/transport/capture.go
+++ b/internal/transport/capture.go
@@ -114,7 +114,7 @@ func (r *Recorder) Close() error {
 // RecordingTransport wraps an ACP1 Transport and records every Send/Receive.
 // It satisfies the acp1.Transport interface (Send, Receive, Close).
 type RecordingTransport struct {
-	inner    interface {
+	inner interface {
 		Send(ctx context.Context, payload []byte) error
 		Receive(ctx context.Context, maxSize int) ([]byte, error)
 		Close() error

--- a/internal/transport/ws/loopback_test.go
+++ b/internal/transport/ws/loopback_test.go
@@ -773,7 +773,10 @@ func bufioReader(b []byte) *bufio.Reader { return bufio.NewReader(bytes.NewReade
 
 type writeCollector struct{ buf []byte }
 
-func (w *writeCollector) Write(p []byte) (int, error) { w.buf = append(w.buf, p...); return len(p), nil }
+func (w *writeCollector) Write(p []byte) (int, error) {
+	w.buf = append(w.buf, p...)
+	return len(p), nil
+}
 
 func bufioWriterBytes(fn func(*writeCollector)) []byte {
 	w := &writeCollector{}

--- a/internal/transport/ws/unit_test.go
+++ b/internal/transport/ws/unit_test.go
@@ -137,10 +137,10 @@ func TestIsControl(t *testing.T) {
 // fakeAddr / closedConn drive Conn.Close's underlying-close error arm.
 type closedConn struct{ net.Conn }
 
-func (closedConn) Write(b []byte) (int, error) { return len(b), nil }
-func (closedConn) Close() error                { return errors.New("close boom") }
-func (closedConn) LocalAddr() net.Addr         { return nil }
-func (closedConn) RemoteAddr() net.Addr        { return nil }
+func (closedConn) Write(b []byte) (int, error)      { return len(b), nil }
+func (closedConn) Close() error                     { return errors.New("close boom") }
+func (closedConn) LocalAddr() net.Addr              { return nil }
+func (closedConn) RemoteAddr() net.Addr             { return nil }
 func (closedConn) SetWriteDeadline(time.Time) error { return nil }
 func (closedConn) SetReadDeadline(time.Time) error  { return nil }
 func (closedConn) SetDeadline(time.Time) error      { return nil }


### PR DESCRIPTION
Allowlist step 3, first half. **19 → 15.**

These four already applied the shared socket policy in their accept loops — the allowlist entry said as much — but each still opened its own listener. That bind was the half keeping them on the list.

| Provider | Before | After |
|---|---|---|
| acp2 | `net.Listen("tcp4", …)` | `transport.ListenTCP(ctx, "tcp4", …)` |
| emberplus | `lc.Listen(ctx, "tcp", …)` | `transport.ListenTCP(ctx, "tcp", …)` |
| probel-sw02p | `lc.Listen(ctx, "tcp", …)` | `transport.ListenTCP(ctx, "tcp", …)` |
| probel-sw08p | `lc.Listen` inside `listenHook` | same, hook seam untouched |

acp2 keeps `tcp4` — it binds IPv4-only by design, and that's behaviour, not boilerplate.

## Why all four pass the embedded listener, not the wrapper

This is deliberate and it's what the `transport.Listener` doc comment prescribes. The wrapper applies socket options in its own `Accept`; these servers already apply them in their accept loops. Passing the wrapper would apply them twice — but more to the point, **the accept loop is the arm that also covers a listener injected from outside**, which the wrapper never sees:

- emberplus and probel-sw02p take one via `ServeListener`
- probel-sw08p via `listenHook`
- acp2's tests drive `acceptLoop` directly

Applying the policy where every path converges is why an injected listener isn't a hole.

## No behaviour change

Same networks, same addresses, same options, same error text. The bind simply goes through the one function that owns it now.

| | |
|---|---|
| allowlist | **19 → 15** |
| build + vet + full suite | green |
| coverage floors | **31/31** |
| `golangci-lint` | 0 issues |

## What is deliberately not here

The four UDP entries — osc/tsl consumer binds and provider senders. `transport.ListenUDP` takes a *port* and binds `udp4` on every interface; those four bind a specific `host:port` on `"udp"` and need the raw conn for their own read loops. They need a transport function that doesn't exist yet, plus the migration of two elaborate `bind_seam.go` files whose tests exist purely to drive unreachable setsockopt arms to the 100% floor. That's its own unit, not a squeeze into this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
