### PR TITLE
refactor(transport): bind acp1's listeners through transport

### DIFF
--- a/internal/acp1/provider/admin.go
+++ b/internal/acp1/provider/admin.go
@@ -2,6 +2,7 @@ package acp1
 
 import (
 	"context"
+	"dhs/internal/transport"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
@@ -14,6 +15,10 @@ import (
 	"sync"
 	"time"
 )
+
+// adminDialTimeout bounds a single admin request's connect. The admin socket
+// is on loopback, so this only ever fires when the producer is gone.
+const adminDialTimeout = 5 * time.Second
 
 // AdminRequest is one JSON command from a CLI client. Verbs map 1:1 to
 // the issue's `dhs producer acp1 admin <verb> ...` surface. The Args map
@@ -55,7 +60,17 @@ func (s *server) ServeAdmin(ctx context.Context, name string) error {
 	if name == "" {
 		name = "dhs-acp1"
 	}
-	listen := func() (net.Listener, error) { return net.Listen("tcp4", "127.0.0.1:0") }
+	// Loopback-only by design: the admin socket is a local control channel,
+	// never a network surface. The bind goes through transport; the shared
+	// socket policy is applied to each accepted connection below, which is
+	// also what covers a listener injected by adminListenHook.
+	listen := func() (net.Listener, error) {
+		ln, lerr := transport.ListenTCP(ctx, "tcp4", "127.0.0.1:0", transport.SocketOptions{})
+		if lerr != nil {
+			return nil, lerr
+		}
+		return ln.Listener, nil
+	}
 	if s.adminListenHook != nil {
 		listen = s.adminListenHook
 	}
@@ -193,7 +208,7 @@ func (s *server) writeAdminErr(conn net.Conn, err error) {
 type AdminClient struct {
 	addr string
 
-	// dial overrides the transport dial. Nil ⇒ net.DialTimeout. Test-only
+	// dial overrides the transport dial. Nil ⇒ transport.TCPDialer. Test-only
 	// injection seam so the request write-error and reply read-error arms of
 	// Call are deterministically reachable with a scripted net.Conn (a real
 	// loopback peer almost never fails a write synchronously).
@@ -215,7 +230,10 @@ func NewAdminClient(name string) (*AdminClient, error) {
 func (c *AdminClient) Call(ctx context.Context, req *AdminRequest) (*AdminResponse, error) {
 	dial := c.dial
 	if dial == nil {
-		dial = func() (net.Conn, error) { return net.DialTimeout("tcp4", c.addr, 5*time.Second) }
+		dial = func() (net.Conn, error) {
+			return transport.TCPDialer{Timeout: adminDialTimeout}.
+				DialContext(ctx, "tcp4", c.addr)
+		}
 	}
 	conn, err := dial()
 	if err != nil {

--- a/internal/acp1/provider/admin_cov100_test.go
+++ b/internal/acp1/provider/admin_cov100_test.go
@@ -77,8 +77,8 @@ func TestServeAdmin_AcceptWarn(t *testing.T) {
 				c   net.Conn
 				err error
 			}{
-				{nil, errAdminIO},     // transient → warn + continue
-				{nil, net.ErrClosed},  // → return nil
+				{nil, errAdminIO},    // transient → warn + continue
+				{nil, net.ErrClosed}, // → return nil
 			},
 		}, nil
 	}
@@ -357,12 +357,12 @@ func (c *scriptConn) Read(p []byte) (int, error) {
 	c.readPos += n
 	return n, nil
 }
-func (c *scriptConn) Close() error                       { return nil }
-func (c *scriptConn) LocalAddr() net.Addr                { return nil }
-func (c *scriptConn) RemoteAddr() net.Addr               { return nil }
-func (c *scriptConn) SetDeadline(time.Time) error        { return nil }
-func (c *scriptConn) SetReadDeadline(time.Time) error    { return nil }
-func (c *scriptConn) SetWriteDeadline(time.Time) error   { return nil }
+func (c *scriptConn) Close() error                     { return nil }
+func (c *scriptConn) LocalAddr() net.Addr              { return nil }
+func (c *scriptConn) RemoteAddr() net.Addr             { return nil }
+func (c *scriptConn) SetDeadline(time.Time) error      { return nil }
+func (c *scriptConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *scriptConn) SetWriteDeadline(time.Time) error { return nil }
 
 var errAdminIO = &adminIOErr{}
 

--- a/internal/acp1/provider/an2_server.go
+++ b/internal/acp1/provider/an2_server.go
@@ -31,11 +31,12 @@ const (
 // EnableProtocolEvents([1]) before receiving announces — the per-
 // session flag is honoured during fan-out.
 func (s *server) ServeAN2(ctx context.Context, addr string) error {
-	tcpAddr, err := net.ResolveTCPAddr("tcp4", addr)
-	if err != nil {
-		return fmt.Errorf("acp1 provider an2: resolve %q: %w", addr, err)
-	}
-	ln, err := net.ListenTCP("tcp4", tcpAddr)
+	// tcp4 preserved: ACP1 is IPv4-only. ListenTCPRaw rather than ListenTCP
+	// because the session, registry, writer and frame-reader signatures below
+	// all take *net.TCPConn, which only AcceptTCP provides. The socket policy
+	// is applied per accepted connection further down, where an injected
+	// listener is covered too.
+	ln, err := transport.ListenTCPRaw(ctx, "tcp4", addr)
 	if err != nil {
 		return fmt.Errorf("acp1 provider an2: listen %q: %w", addr, err)
 	}

--- a/internal/acp1/provider/an2_server_test.go
+++ b/internal/acp1/provider/an2_server_test.go
@@ -185,7 +185,7 @@ func TestServeAN2_AnnouncesGatedByEnableProtocolEvents(t *testing.T) {
 	// broadcastACP1 which honours the per-session events-enabled flag.
 	setReq := &codec.Message{
 		MTID: 2, MType: codec.MTypeRequest, MAddr: 1,
-		MCode: byte(codec.MethodSetValue),
+		MCode:    byte(codec.MethodSetValue),
 		ObjGroup: codec.GroupControl, ObjID: 0,
 		Value: []byte{0x00, 0x07}, // i16 BE = 7
 	}

--- a/internal/acp1/provider/broadcasts_gate_test.go
+++ b/internal/acp1/provider/broadcasts_gate_test.go
@@ -121,7 +121,7 @@ func TestBroadcastAnnounce_GatedSilently_WhenOff(t *testing.T) {
 
 	ann := &codec.Message{
 		MTID: 0, MType: codec.MTypeReply, MAddr: 1,
-		MCode: byte(codec.MethodSetValue),
+		MCode:    byte(codec.MethodSetValue),
 		ObjGroup: codec.GroupControl, ObjID: 0,
 		Value: []byte{0x00, 0x05},
 	}
@@ -145,7 +145,7 @@ func TestBroadcastAnnounce_FlowsThroughWhenOn(t *testing.T) {
 
 	ann := &codec.Message{
 		MTID: 0, MType: codec.MTypeReply, MAddr: 1,
-		MCode: byte(codec.MethodSetValue),
+		MCode:    byte(codec.MethodSetValue),
 		ObjGroup: codec.GroupControl, ObjID: 0,
 		Value: []byte{0x00, 0x05},
 	}

--- a/internal/acp1/provider/demo.go
+++ b/internal/acp1/provider/demo.go
@@ -2,11 +2,11 @@ package acp1
 
 import (
 	"context"
+	"dhs/internal/acp1/codec"
 	"encoding/binary"
 	"log/slog"
 	"math"
 	"time"
-	"dhs/internal/acp1/codec"
 )
 
 // RunAnnounceDemo oscillates the integer value at (slot, group, id)

--- a/internal/acp1/provider/dm_loader_test.go
+++ b/internal/acp1/provider/dm_loader_test.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	"dhs/internal/acp1/codec"
+	"dhs/internal/consumer"
 	"dhs/internal/devicemodel"
 	"dhs/internal/export"
-	"dhs/internal/consumer"
 )
 
 func TestParseCardPath(t *testing.T) {
@@ -37,9 +37,9 @@ func TestParseCardPath(t *testing.T) {
 		{in: "too/few/parts", err: true},
 		{in: "too/many/parts/here/now", err: true},
 		{in: "axon//RRS18-1601/acp1", err: true},
-		{in: "axon/synapse/RRS18/acp1", err: true},   // no rev separator
-		{in: "axon/synapse/-1601/acp1", err: true},   // empty model
-		{in: "axon/synapse/RRS18-/acp1", err: true},  // empty rev
+		{in: "axon/synapse/RRS18/acp1", err: true},  // no rev separator
+		{in: "axon/synapse/-1601/acp1", err: true},  // empty model
+		{in: "axon/synapse/RRS18-/acp1", err: true}, // empty rev
 	}
 	for _, tc := range cases {
 		t.Run(tc.in, func(t *testing.T) {
@@ -92,7 +92,7 @@ func (r *fakeDMResolver) Resolve(fp devicemodel.Fingerprint) (*devicemodel.Schem
 func (r *fakeDMResolver) LookupAlternate(fp devicemodel.Fingerprint) ([]devicemodel.Fingerprint, error) {
 	return nil, nil
 }
-func (r *fakeDMResolver) Persist(s *devicemodel.Schema) error      { return nil }
+func (r *fakeDMResolver) Persist(s *devicemodel.Schema) error            { return nil }
 func (r *fakeDMResolver) Diff(p, c *devicemodel.Schema) devicemodel.Diff { return devicemodel.Diff{} }
 
 func TestSlotLoad_NoResolverConfigured(t *testing.T) {

--- a/internal/acp1/provider/encoder.go
+++ b/internal/acp1/provider/encoder.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"strings"
 
-	"dhs/internal/export/canonical"
 	"dhs/internal/acp1/codec"
+	"dhs/internal/export/canonical"
 )
 
 // encodeObject builds the Value bytes returned by a getObject reply

--- a/internal/acp1/provider/encoder_test.go
+++ b/internal/acp1/provider/encoder_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"dhs/internal/export/canonical"
 	"dhs/internal/acp1/codec"
+	"dhs/internal/export/canonical"
 )
 
 // TestEncodeDecodeRoundTrip asserts that every object type produced by
@@ -281,49 +281,49 @@ func TestEncodeValue(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "int16 positive",
+			name:  "int16 positive",
 			entry: &entry{acpType: codec.TypeInteger, param: param("v", canonical.ParamInteger, withValue(int64(300)))},
-			want: []byte{0x01, 0x2C},
+			want:  []byte{0x01, 0x2C},
 		},
 		{
-			name: "int16 negative",
+			name:  "int16 negative",
 			entry: &entry{acpType: codec.TypeInteger, param: param("v", canonical.ParamInteger, withValue(int64(-1)))},
-			want: []byte{0xFF, 0xFF},
+			want:  []byte{0xFF, 0xFF},
 		},
 		{
-			name: "byte",
+			name:  "byte",
 			entry: &entry{acpType: codec.TypeByte, param: param("v", canonical.ParamInteger, withFormat("uint8"), withValue(int64(200)))},
-			want: []byte{0xC8},
+			want:  []byte{0xC8},
 		},
 		{
-			name: "long",
+			name:  "long",
 			entry: &entry{acpType: codec.TypeLong, param: param("v", canonical.ParamInteger, withFormat("int32"), withValue(int64(1_000_000)))},
-			want: []byte{0x00, 0x0F, 0x42, 0x40},
+			want:  []byte{0x00, 0x0F, 0x42, 0x40},
 		},
 		{
-			name: "ipaddr",
+			name:  "ipaddr",
 			entry: &entry{acpType: codec.TypeIPAddr, param: param("v", canonical.ParamString, withFormat("ipv4"), withValue("10.0.0.1"))},
-			want: []byte{0x0A, 0x00, 0x00, 0x01},
+			want:  []byte{0x0A, 0x00, 0x00, 0x01},
 		},
 		{
-			name: "enum",
+			name:  "enum",
 			entry: &entry{acpType: codec.TypeEnum, param: param("v", canonical.ParamEnum, withValue(int64(1)))},
-			want: []byte{0x01},
+			want:  []byte{0x01},
 		},
 		{
-			name: "string",
+			name:  "string",
 			entry: &entry{acpType: codec.TypeString, param: param("v", canonical.ParamString, withValue("hi"))},
-			want: []byte{'h', 'i', 0},
+			want:  []byte{'h', 'i', 0},
 		},
 		{
-			name: "alarm active",
+			name:  "alarm active",
 			entry: &entry{acpType: codec.TypeAlarm, param: param("v", canonical.ParamBoolean, withFormat("alarm"), withValue(true))},
-			want: []byte{0x01},
+			want:  []byte{0x01},
 		},
 		{
-			name: "frame",
+			name:  "frame",
 			entry: &entry{acpType: codec.TypeFrame, param: param("v", canonical.ParamOctets, withFormat("frame"), withValue([]any{int64(2), int64(0), int64(2)}))},
-			want: []byte{0x03, 0x02, 0x00, 0x02},
+			want:  []byte{0x03, 0x02, 0x00, 0x02},
 		},
 		{
 			name:    "overflow int16",
@@ -412,13 +412,13 @@ func param(ident, typ string, opts ...paramOpt) *canonical.Parameter {
 	return p
 }
 
-func withValue(v any) paramOpt       { return func(p *canonical.Parameter) { p.Value = v } }
-func withDefault(v any) paramOpt     { return func(p *canonical.Parameter) { p.Default = v } }
-func withMin(v any) paramOpt         { return func(p *canonical.Parameter) { p.Minimum = v } }
-func withMax(v any) paramOpt         { return func(p *canonical.Parameter) { p.Maximum = v } }
-func withStep(v any) paramOpt        { return func(p *canonical.Parameter) { p.Step = v } }
-func withUnit(s string) paramOpt     { return func(p *canonical.Parameter) { p.Unit = &s } }
-func withFormat(s string) paramOpt   { return func(p *canonical.Parameter) { p.Format = &s } }
+func withValue(v any) paramOpt     { return func(p *canonical.Parameter) { p.Value = v } }
+func withDefault(v any) paramOpt   { return func(p *canonical.Parameter) { p.Default = v } }
+func withMin(v any) paramOpt       { return func(p *canonical.Parameter) { p.Minimum = v } }
+func withMax(v any) paramOpt       { return func(p *canonical.Parameter) { p.Maximum = v } }
+func withStep(v any) paramOpt      { return func(p *canonical.Parameter) { p.Step = v } }
+func withUnit(s string) paramOpt   { return func(p *canonical.Parameter) { p.Unit = &s } }
+func withFormat(s string) paramOpt { return func(p *canonical.Parameter) { p.Format = &s } }
 func withDescription(s string) paramOpt {
 	return func(p *canonical.Parameter) { p.Description = &s }
 }

--- a/internal/acp1/provider/fanout_audit_test.go
+++ b/internal/acp1/provider/fanout_audit_test.go
@@ -85,7 +85,7 @@ func TestFanout_32Sessions_NoHeadOfLineBlocking(t *testing.T) {
 	for i := 0; i < triggers; i++ {
 		setReq := &codec.Message{
 			MTID: uint32(i + 1), MType: codec.MTypeRequest, MAddr: 1,
-			MCode: byte(codec.MethodSetValue),
+			MCode:    byte(codec.MethodSetValue),
 			ObjGroup: codec.GroupControl, ObjID: 0,
 			Value: []byte{0x00, byte(i % 12)},
 		}

--- a/internal/acp1/provider/fuzz.go
+++ b/internal/acp1/provider/fuzz.go
@@ -24,8 +24,8 @@ type FuzzConfig struct {
 
 // fuzzTarget is one writable object that the fuzzer can drive.
 type fuzzTarget struct {
-	key  objectKey
-	e    *entry
+	key objectKey
+	e   *entry
 }
 
 // RunFuzz drives random valid value-changes against the writable

--- a/internal/acp1/provider/fuzz_test.go
+++ b/internal/acp1/provider/fuzz_test.go
@@ -35,10 +35,10 @@ func TestRunFuzz_NoTargets(t *testing.T) {
 	defer cancel()
 
 	cfg := FuzzConfig{
-		Seed:  42,
-		Rate:  10,
-		Slot:  99, // no such slot
-		ID:    -1,
+		Seed: 42,
+		Rate: 10,
+		Slot: 99, // no such slot
+		ID:   -1,
 	}
 	err := s.RunFuzz(ctx, cfg)
 	if err == nil {
@@ -139,12 +139,12 @@ func TestRunFuzz_ReadOnlyTargetsExcluded(t *testing.T) {
 	// Identity (group=1) in the test fixture is read-only. A fuzz
 	// scoped to identity should report "no eligible targets".
 	cfg := FuzzConfig{
-		Seed:  1,
-		Rate:  10,
-		Slot:  1,
-		Group: codec.GroupIdentity,
+		Seed:     1,
+		Rate:     10,
+		Slot:     1,
+		Group:    codec.GroupIdentity,
 		GroupSet: true,
-		ID:    -1,
+		ID:       -1,
 	}
 	err := s.RunFuzz(context.Background(), cfg)
 	if err == nil {

--- a/internal/acp1/provider/helpers_cov_test.go
+++ b/internal/acp1/provider/helpers_cov_test.go
@@ -126,13 +126,13 @@ func TestValueAny_KindMismatch(t *testing.T) {
 
 func TestParsePath_Errors(t *testing.T) {
 	bad := []string{
-		"1.2.3",       // wrong component count
-		"2.1.2.0",     // first != 1
-		"1.x.2.0",     // bad slot
-		"1.0.2.0",     // slot 1-based < 1
-		"1.1.9.0",     // group > 6
-		"1.1.2.x",     // bad id
-		"1.1.2.999",   // id > 255
+		"1.2.3",     // wrong component count
+		"2.1.2.0",   // first != 1
+		"1.x.2.0",   // bad slot
+		"1.0.2.0",   // slot 1-based < 1
+		"1.1.9.0",   // group > 6
+		"1.1.2.x",   // bad id
+		"1.1.2.999", // id > 255
 	}
 	for _, p := range bad {
 		if _, err := parsePath(p); err == nil {

--- a/internal/acp1/provider/misc_cov100_test.go
+++ b/internal/acp1/provider/misc_cov100_test.go
@@ -340,8 +340,8 @@ func TestRunAnnounceDemo_IntervalDefaultAndApplyFail(t *testing.T) {
 		key: key, acpType: codec.TypeInteger,
 		access: codec.AccessRead | codec.AccessWrite,
 		param: &canonical.Parameter{
-			Header: canonical.Header{Identifier: "Bad"},
-			Value:  "not-an-int", // mutateInteger asInt16 fails every tick
+			Header:  canonical.Header{Identifier: "Bad"},
+			Value:   "not-an-int", // mutateInteger asInt16 fails every tick
 			Minimum: int64(-10), Maximum: int64(10),
 		},
 	}

--- a/internal/acp1/provider/mutate_extra_test.go
+++ b/internal/acp1/provider/mutate_extra_test.go
@@ -34,7 +34,10 @@ func TestMutate_AllMethodsAndErrors(t *testing.T) {
 			t.Fatalf("long setValue: %v", err)
 		}
 	}
-	if e := mkLong(); func() bool { _, err := s.applyMutation(e, codec.MethodSetDefValue, nil); return err == nil && e.param.Value == int64(7) }() == false {
+	if e := mkLong(); func() bool {
+		_, err := s.applyMutation(e, codec.MethodSetDefValue, nil)
+		return err == nil && e.param.Value == int64(7)
+	}() == false {
 		t.Error("long setDef should store default 7")
 	}
 	for _, m := range []codec.Method{codec.MethodSetIncValue, codec.MethodSetDecValue} {
@@ -113,7 +116,10 @@ func TestMutate_AllMethodsAndErrors(t *testing.T) {
 			Value: int64(1), Enumeration: strp("Off,On,Auto"), Default: int64(2),
 		}}
 	}
-	if e := mkEnum(); func() bool { _, err := s.applyMutation(e, codec.MethodSetDefValue, nil); return err == nil && e.param.Value == int64(2) }() == false {
+	if e := mkEnum(); func() bool {
+		_, err := s.applyMutation(e, codec.MethodSetDefValue, nil)
+		return err == nil && e.param.Value == int64(2)
+	}() == false {
 		t.Error("enum setDef should store default 2")
 	}
 	if _, err := s.applyMutation(mkEnum(), codec.MethodSetIncValue, nil); err == nil {

--- a/internal/acp1/provider/plugin.go
+++ b/internal/acp1/provider/plugin.go
@@ -20,9 +20,9 @@ package acp1
 import (
 	"log/slog"
 
+	"dhs/internal/acp1/codec"
 	"dhs/internal/export/canonical"
 	"dhs/internal/provider"
-	"dhs/internal/acp1/codec"
 )
 
 // DefaultPort is the IANA-assigned ACP port for both UDP and TCP direct.

--- a/internal/acp1/provider/server.go
+++ b/internal/acp1/provider/server.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"net"
 	"sync"
-	"syscall"
 
 	"dhs/internal/acp1/codec"
 	"dhs/internal/devicemodel"
@@ -159,24 +158,15 @@ func (s *server) Serve(ctx context.Context, addr string) error {
 	if err != nil {
 		return fmt.Errorf("acp1 provider: resolve %q: %w", addr, err)
 	}
-	lc := net.ListenConfig{
-		Control: func(network, address string, c syscall.RawConn) error {
-			var opErr error
-			// c.Control only errors on an invalid RawConn (impossible during
-			// listen setup); the real failure flows through opErr.
-			_ = c.Control(func(fd uintptr) {
-				opErr = transport.SetSocketReuseAddr(fd)
-			})
-			return opErr
-		},
-	}
-	pc, err := lc.ListenPacket(ctx, "udp4", udpAddr.String())
+	// SO_REUSEADDR is set before bind — the only window in which it takes
+	// effect — so an emulator or dev rig can share the port with a
+	// controller already listening on it. The type assertion that used to
+	// sit here now lives in transport, tested once.
+	conn, err := transport.ListenUDPAddr(ctx, "udp4", udpAddr.String(),
+		transport.UDPBindOptions{ReuseAddr: true})
 	if err != nil {
 		return fmt.Errorf("acp1 provider: listen %q: %w", addr, err)
 	}
-	// unreachable type-assert guard elided: ListenConfig.ListenPacket over
-	// "udp4" always yields a *net.UDPConn on success.
-	conn := pc.(*net.UDPConn)
 
 	// Dial a second socket to the limited broadcast address. Go stdlib
 	// auto-sets SO_BROADCAST on dialed sockets with broadcast peers,

--- a/internal/acp1/provider/session.go
+++ b/internal/acp1/provider/session.go
@@ -1,8 +1,8 @@
 package acp1
 
 import (
-	"log/slog"
 	"dhs/internal/acp1/codec"
+	"log/slog"
 )
 
 // handleRequest dispatches a decoded request to the right handler and
@@ -134,15 +134,15 @@ func (s *server) handleRoot(msg *codec.Message) *codec.Message {
 // num_control, num_status, num_alarm, num_file.
 func encodeRootObject(c *slotCounts) []byte {
 	return []byte{
-		byte(codec.TypeRoot),        // object_type
-		9,                           // num_properties
-		codec.AccessRead,            // access — Root is always read-only
-		0,                           // boot_mode
-		c.numIdentity,               // num_identity
-		c.numControl,                // num_control
-		c.numStatus,                 // num_status
-		c.numAlarm,                  // num_alarm
-		c.numFile,                   // num_file
+		byte(codec.TypeRoot), // object_type
+		9,                    // num_properties
+		codec.AccessRead,     // access — Root is always read-only
+		0,                    // boot_mode
+		c.numIdentity,        // num_identity
+		c.numControl,         // num_control
+		c.numStatus,          // num_status
+		c.numAlarm,           // num_alarm
+		c.numFile,            // num_file
 	}
 }
 
@@ -305,4 +305,3 @@ func (s *server) handleDatagram2(data []byte, srcStr string, send func([]byte) e
 		s.broadcastAnnounce(ann)
 	}
 }
-

--- a/internal/acp1/provider/session_test.go
+++ b/internal/acp1/provider/session_test.go
@@ -6,8 +6,8 @@ import (
 	"log/slog"
 	"testing"
 
-	"dhs/internal/export/canonical"
 	"dhs/internal/acp1/codec"
+	"dhs/internal/export/canonical"
 )
 
 // newTestServer builds a server with a hand-crafted tree containing two
@@ -88,8 +88,8 @@ func newTestServer(t *testing.T) *server {
 									Number: 0, Identifier: "Level", OID: "1.2.2.0",
 									Access: rw, Children: canonical.EmptyChildren(),
 								},
-								Type:  canonical.ParamInteger,
-								Value: int64(-6),
+								Type:    canonical.ParamInteger,
+								Value:   int64(-6),
 								Minimum: int64(-60), Maximum: int64(12),
 								Step: int64(1), Default: int64(0),
 							},
@@ -115,7 +115,7 @@ func TestSession_GetValue_ReadOnlyString(t *testing.T) {
 	s := newTestServer(t)
 	req := &codec.Message{
 		MTID: 42, MType: codec.MTypeRequest, MAddr: 1,
-		MCode: byte(codec.MethodGetValue),
+		MCode:    byte(codec.MethodGetValue),
 		ObjGroup: codec.GroupIdentity, ObjID: 0,
 	}
 	rep, _ := s.handleRequest(req)
@@ -139,7 +139,7 @@ func TestSession_GetObject_Integer(t *testing.T) {
 	s := newTestServer(t)
 	req := &codec.Message{
 		MTID: 7, MType: codec.MTypeRequest, MAddr: 1,
-		MCode: byte(codec.MethodGetObject),
+		MCode:    byte(codec.MethodGetObject),
 		ObjGroup: codec.GroupControl, ObjID: 0,
 	}
 	rep, _ := s.handleRequest(req)
@@ -166,7 +166,7 @@ func TestSession_Root_Synthesised(t *testing.T) {
 	// getValue on Root returns boot_mode byte (0 = normal).
 	req := &codec.Message{
 		MTID: 1, MType: codec.MTypeRequest, MAddr: 1,
-		MCode: byte(codec.MethodGetValue),
+		MCode:    byte(codec.MethodGetValue),
 		ObjGroup: codec.GroupRoot, ObjID: 0,
 	}
 	rep, _ := s.handleRequest(req)
@@ -196,7 +196,7 @@ func TestSession_UnknownObject_InstanceError(t *testing.T) {
 	// control group exists, id=99 does not.
 	req := &codec.Message{
 		MTID: 1, MType: codec.MTypeRequest, MAddr: 1,
-		MCode: byte(codec.MethodGetValue),
+		MCode:    byte(codec.MethodGetValue),
 		ObjGroup: codec.GroupControl, ObjID: 99,
 	}
 	rep, _ := s.handleRequest(req)
@@ -213,7 +213,7 @@ func TestSession_UnknownGroup_GroupError(t *testing.T) {
 	// Alarm group has no entries on slot 1.
 	req := &codec.Message{
 		MTID: 1, MType: codec.MTypeRequest, MAddr: 1,
-		MCode: byte(codec.MethodGetValue),
+		MCode:    byte(codec.MethodGetValue),
 		ObjGroup: codec.GroupAlarm, ObjID: 0,
 	}
 	rep, _ := s.handleRequest(req)

--- a/internal/acp1/provider/set.go
+++ b/internal/acp1/provider/set.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"math"
 
-	"dhs/internal/export/canonical"
 	"dhs/internal/acp1/codec"
+	"dhs/internal/export/canonical"
 )
 
 // applyMutation dispatches the four mutating methods (setValue,

--- a/internal/acp1/provider/snapshot_to_param.go
+++ b/internal/acp1/provider/snapshot_to_param.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 
 	"dhs/internal/acp1/codec"
+	"dhs/internal/consumer"
 	"dhs/internal/export"
 	"dhs/internal/export/canonical"
-	"dhs/internal/consumer"
 )
 
 // snapshotToEntries flattens a single-slot DM-library snapshot into

--- a/internal/acp1/provider/tcp_server.go
+++ b/internal/acp1/provider/tcp_server.go
@@ -54,11 +54,12 @@ const (
 // Stops cleanly when ctx is cancelled. ErrClosed is treated as a
 // successful shutdown.
 func (s *server) ServeTCP(ctx context.Context, addr string) error {
-	tcpAddr, err := net.ResolveTCPAddr("tcp4", addr)
-	if err != nil {
-		return fmt.Errorf("acp1 provider tcp: resolve %q: %w", addr, err)
-	}
-	ln, err := net.ListenTCP("tcp4", tcpAddr)
+	// tcp4 preserved: ACP1 is IPv4-only. ListenTCPRaw rather than ListenTCP
+	// because the session, registry, writer and frame-reader signatures below
+	// all take *net.TCPConn, which only AcceptTCP provides. The socket policy
+	// is applied per accepted connection further down, where an injected
+	// listener is covered too.
+	ln, err := transport.ListenTCPRaw(ctx, "tcp4", addr)
 	if err != nil {
 		return fmt.Errorf("acp1 provider tcp: listen %q: %w", addr, err)
 	}

--- a/internal/acp1/provider/tcp_server_cov100_test.go
+++ b/internal/acp1/provider/tcp_server_cov100_test.go
@@ -32,7 +32,7 @@ func TestNewTCPSessionRegistry_NilLogger(t *testing.T) {
 // TestEnqueue_DropsOnFull covers the channel-full drop arm.
 func TestEnqueue_DropsOnFull(t *testing.T) {
 	ch := make(chan []byte, 1)
-	ch <- []byte{0} // fill it
+	ch <- []byte{0}                                 // fill it
 	enqueue(ch, []byte{1}, "test", discardLogger()) // must not block; drops
 	if len(ch) != 1 {
 		t.Fatalf("channel len = %d, want 1 (second enqueue dropped)", len(ch))

--- a/internal/acp1/provider/tcp_server_test.go
+++ b/internal/acp1/provider/tcp_server_test.go
@@ -256,7 +256,7 @@ func TestServeTCP_AnnounceBroadcast_AcrossSessions(t *testing.T) {
 
 	setReq := &codec.Message{
 		MTID: 1, MType: codec.MTypeRequest, MAddr: 1,
-		MCode: byte(codec.MethodSetValue),
+		MCode:    byte(codec.MethodSetValue),
 		ObjGroup: codec.GroupControl, ObjID: 0,
 		Value: []byte{0x00, 0x05}, // i16 BE = 5
 	}

--- a/internal/transport/architecture_test.go
+++ b/internal/transport/architecture_test.go
@@ -79,10 +79,7 @@ var allowed = map[string]string{
 	// They already apply the shared socket policy via ApplySocketOptions;
 	// what remains is the bind itself moving to transport.ListenTCP, as the
 	// osc and tsl consumers have already done.
-	"internal/acp1/provider/tcp_server.go": "listener bind → transport.ListenTCP",
-	"internal/acp1/provider/an2_server.go": "listener bind → transport.ListenTCP",
-	"internal/acp1/provider/server.go":     "listener bind + UDP dial → transport",
-	"internal/acp1/provider/admin.go":      "admin listener + dial; already has an injectable dial seam",
+	"internal/acp1/provider/server.go": "broadcast dial pins a source address; transport has no model for that",
 
 	// DEBT — the HTTP server has not been extracted from amwa yet.
 	//

--- a/internal/transport/listen.go
+++ b/internal/transport/listen.go
@@ -161,3 +161,37 @@ func (l *Listener) Accept() (net.Conn, error) {
 	_ = applySocketOptions(c, l.opts)
 	return c, nil
 }
+
+// listenTCPRawAssert is the seam for the arm a real bind cannot reach: a
+// "tcp*" network always yields a *net.TCPListener.
+var listenTCPRawAssert = func(ln net.Listener) (*net.TCPListener, bool) {
+	tl, ok := ln.(*net.TCPListener)
+	return tl, ok
+}
+
+// ListenTCPRaw binds addr and returns the CONCRETE *net.TCPListener.
+//
+// For the callers that need AcceptTCP's *net.TCPConn rather than a net.Conn —
+// acp1's TCP and AN2 servers thread the concrete type through their session,
+// registry, writer and frame-reader signatures, so handing them a net.Conn
+// would mean rewriting eighteen signatures to clear one bind.
+//
+// Unlike [ListenTCP] this applies NO socket policy: a caller that wants the
+// concrete listener is accepting connections itself and applies
+// [ApplySocketOptions] there, which is also the only place an injected
+// listener would be covered. Use [ListenTCP] unless AcceptTCP is genuinely
+// needed.
+func ListenTCPRaw(ctx context.Context, network, addr string) (*net.TCPListener, error) {
+	var lc net.ListenConfig
+	ln, err := lc.Listen(ctx, network, addr)
+	if err != nil {
+		return nil, fmt.Errorf("%w: listen %s %s: %v", ErrListenFailed, network, addr, err)
+	}
+	tl, ok := listenTCPRawAssert(ln)
+	if !ok {
+		_ = ln.Close()
+		return nil, fmt.Errorf("%w: listen %s %s: unexpected listener type %T",
+			ErrListenFailed, network, addr, ln)
+	}
+	return tl, nil
+}

--- a/internal/transport/listen_test.go
+++ b/internal/transport/listen_test.go
@@ -245,3 +245,40 @@ func TestListenTCPBindError(t *testing.T) {
 		t.Errorf("err = %v, want it to wrap ErrListenFailed", err)
 	}
 }
+
+func TestListenTCPRawGivesTheConcreteListener(t *testing.T) {
+	ln, err := ListenTCPRaw(context.Background(), "tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+	// The point of this function: AcceptTCP, which net.Listener does not have.
+	if ln.Addr() == nil {
+		t.Error("bound listener has no address")
+	}
+}
+
+func TestListenTCPRawRejectsBadAddress(t *testing.T) {
+	if _, err := ListenTCPRaw(context.Background(), "tcp4", "not-an-address"); err == nil {
+		t.Error("a malformed address must be reported")
+	} else if !errors.Is(err, ErrListenFailed) {
+		t.Errorf("err = %v, want it to wrap ErrListenFailed", err)
+	}
+}
+
+// A "tcp*" network always yields a *net.TCPListener, so this arm needs the
+// seam — and it is here, once, rather than in every caller that needs the
+// concrete type.
+func TestListenTCPRawUnexpectedListenerType(t *testing.T) {
+	orig := listenTCPRawAssert
+	listenTCPRawAssert = func(net.Listener) (*net.TCPListener, bool) { return nil, false }
+	defer func() { listenTCPRawAssert = orig }()
+
+	_, err := ListenTCPRaw(context.Background(), "tcp4", "127.0.0.1:0")
+	if err == nil {
+		t.Fatal("an unexpected listener type must fail the bind")
+	}
+	if !errors.Is(err, ErrListenFailed) {
+		t.Errorf("err = %v, want it to wrap ErrListenFailed", err)
+	}
+}


### PR DESCRIPTION
Allowlist step 3, final third. **11 → 8.**

| File | Before | After |
|---|---|---|
| `tcp_server.go` | `net.ListenTCP` | `transport.ListenTCPRaw` |
| `an2_server.go` | `net.ListenTCP` | `transport.ListenTCPRaw` |
| `server.go` | `ListenConfig`+`Control` | `transport.ListenUDPAddr` |
| `admin.go` | `net.Listen` / `net.DialTimeout` | `transport.ListenTCP` / `transport.TCPDialer` |

## New: `transport.ListenTCPRaw`, returning the concrete `*net.TCPListener`

acp1's TCP and AN2 servers need `AcceptTCP`'s `*net.TCPConn`, not a `net.Conn` — the session, registry, writer, frame-reader and `sessionID` signatures all take the concrete type, and so does the `acceptTCPHook` test seam. Handing them a `net.Conn` would mean **rewriting eighteen signatures to clear one bind**, which is a bad trade for a refactor whose point is that the socket policy lives in one place. It already did here: both servers were calling `ApplySocketOptions` with `NoDelay` on every accepted connection. Only the bind was hand-rolled.

`ListenTCPRaw` applies **no** policy and documents why: a caller wanting the concrete listener runs its own accept loop, which is also the only place an injected listener is covered. Its unreachable type-assert arm is seam-tested in transport — once — instead of in every caller that needs the concrete type.

`server.go`'s UDP listen becomes `ListenUDPAddr{ReuseAddr}`, the same function osc and tsl collapsed onto in #1001. It takes the *"unreachable type-assert guard elided"* comment with it; that guard isn't elided anywhere now, it's tested in transport.

## `server.go` stays on the list, with an honest reason

Its second socket is a broadcast dial that **pins a source address** — `--bind <ip>`, so several emulators on different VIPs stay distinguishable to consumers — relying on the stdlib auto-setting `SO_BROADCAST` for a broadcast peer. `transport.DialUDP` takes a host and port and has no model for a pinned local address. Inventing one to clear a line would be the tail wagging the dog, so the entry now names the actual constraint rather than implying the whole file is debt.

Also fixed a comment in `admin.go` still promising `net.DialTimeout`.

| | |
|---|---|
| acp1 codec / consumer / provider | **100% each** |
| allowlist | **11 → 8** |
| build + vet + full suite | green |
| coverage floors | **31/31** |
| `golangci-lint` | 0 issues |

**Remaining 8**, and only 3 of them are still debt: certmgr's TLS config, the amwa mirror listener, and 2 DNS-SD sockets that need a multicast model transport doesn't have. The other 3 are permanent by design — two one-shot SYN reachability probes and a `SO_BROADCAST` discovery socket, none of which are session pipes — plus acp1's pinned-source broadcast dial above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
