### PR TITLE
refactor(probel-sw02p): the first connector that cannot open a socket

### DIFF
--- a/internal/probel-sw02p/consumer/plugin.go
+++ b/internal/probel-sw02p/consumer/plugin.go
@@ -68,11 +68,10 @@ func (f *Factory) Meta() consumer.ProtocolMeta {
 	}
 }
 
-// New constructs a fresh consumer plugin bound to the given logger.
+// New constructs a fresh consumer plugin bound to the injected dependencies.
 func (f *Factory) New(deps plugin.Deps) consumer.Protocol {
 	deps = deps.WithDefaults()
-	logger := deps.Logger
-	return &Plugin{logger: logger}
+	return &Plugin{logger: deps.Logger, net: deps.Net, metrics: deps.Metrics}
 }
 
 // MatrixConfig holds the externally-supplied matrix shape. SW-P-02
@@ -114,6 +113,15 @@ type MatrixConfig struct {
 // etc.) is added as subsequent commits land their PRs.
 type Plugin struct {
 	logger *slog.Logger
+
+	// net is the only way this plugin reaches a socket. Injected, so the
+	// process decides the transport posture (TLS, keepalive, source
+	// address) and a test substitutes a fake without a real port.
+	net transport.Net
+
+	// metrics is supplied rather than created, so the process can scrape
+	// every connector from one place.
+	metrics *metrics.Connector
 
 	mu       sync.Mutex
 	host     string
@@ -226,7 +234,14 @@ func (p *Plugin) Connect(ctx context.Context, ip string, port int) error {
 
 	addr := fmt.Sprintf("%s:%d", ip, port)
 	prof := &compliance.Profile{}
-	met := metrics.NewConnector()
+	// Normally injected by the factory. A Plugin built directly — tests, and
+	// any caller that predates Deps — still gets a working counter set rather
+	// than a nil Metrics(), which is what this used to guarantee by
+	// constructing its own.
+	met := p.metrics
+	if met == nil {
+		met = metrics.NewConnector()
+	}
 	// Register every known command byte so the metrics snapshot can
 	// pretty-print names alongside raw ids. Empty in the scaffold;
 	// per-command commits populate the catalogue.
@@ -250,7 +265,7 @@ func (p *Plugin) Connect(ctx context.Context, ip string, port int) error {
 			rec.Record("probel-sw02p", "rx", b)
 		}
 	}
-	cli, err := session.Dial(ctx, addr, p.logger, cfg)
+	cli, err := session.Dial(ctx, p.net, addr, p.logger, cfg)
 	if err != nil {
 		return &consumer.TransportError{Op: "connect", Err: err}
 	}

--- a/internal/probel-sw02p/provider/cmd_extended_test.go
+++ b/internal/probel-sw02p/provider/cmd_extended_test.go
@@ -1,6 +1,7 @@
 package probelsw02p
 
 import (
+	"dhs/internal/plugin"
 	"io"
 	"log/slog"
 	"testing"
@@ -14,7 +15,7 @@ import (
 // Used by Extended* tests that need to cross the 1023 narrow boundary.
 func newBareTestServer(t *testing.T) *server {
 	t.Helper()
-	return newServer(slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	return newServer(plugin.Deps{Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}, nil)
 }
 
 // TestExtendedInterrogateRepliesWithExtendedTally locks in the rx 65 /

--- a/internal/probel-sw02p/provider/cmd_protect_test.go
+++ b/internal/probel-sw02p/provider/cmd_protect_test.go
@@ -2,6 +2,7 @@ package probelsw02p
 
 import (
 	"context"
+	"dhs/internal/plugin"
 	"io"
 	"log/slog"
 	"net"
@@ -15,7 +16,7 @@ import (
 // the Extended PROTECT tally / connected / disconnected broadcasts
 // out to every connected session.
 func TestExtendedProtectEmitFanout(t *testing.T) {
-	srv := newServer(slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	srv := newServer(plugin.Deps{Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}, nil)
 	defer func() { _ = srv.Stop() }()
 
 	// Pre-bound listener handed straight to serveListener — the old

--- a/internal/probel-sw02p/provider/cmd_router_config_test.go
+++ b/internal/probel-sw02p/provider/cmd_router_config_test.go
@@ -1,6 +1,7 @@
 package probelsw02p
 
 import (
+	"dhs/internal/plugin"
 	"io"
 	"log/slog"
 	"testing"
@@ -33,7 +34,7 @@ func TestRouterConfigRequestDerivedFromTree(t *testing.T) {
 			},
 		},
 	}
-	srv := newServer(slog.New(slog.NewTextHandler(io.Discard, nil)), exp)
+	srv := newServer(plugin.Deps{Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}, exp)
 
 	res, err := srv.dispatch(codec.EncodeRouterConfigRequest(codec.RouterConfigRequestParams{}))
 	if err != nil {
@@ -64,7 +65,7 @@ func TestRouterConfigRequestDerivedFromTree(t *testing.T) {
 // TestRouterConfigRequestEmptyTree verifies the bare-tree case — no
 // matrices declared means bitmap=0 and no per-level entries.
 func TestRouterConfigRequestEmptyTree(t *testing.T) {
-	srv := newServer(slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	srv := newServer(plugin.Deps{Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}, nil)
 	res, err := srv.dispatch(codec.EncodeRouterConfigRequest(codec.RouterConfigRequestParams{}))
 	if err != nil {
 		t.Fatalf("dispatch rx 075: %v", err)

--- a/internal/probel-sw02p/provider/cmd_salvo_test.go
+++ b/internal/probel-sw02p/provider/cmd_salvo_test.go
@@ -1,6 +1,7 @@
 package probelsw02p
 
 import (
+	"dhs/internal/plugin"
 	"io"
 	"log/slog"
 	"testing"
@@ -33,7 +34,7 @@ func newTestServer(t *testing.T) *server {
 			},
 		},
 	}
-	return newServer(slog.New(slog.NewTextHandler(io.Discard, nil)), exp)
+	return newServer(plugin.Deps{Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}, exp)
 }
 
 // TestConnectOnGoAppendsPendingAndAcks locks in the rx 05 / tx 12

--- a/internal/probel-sw02p/provider/cmd_tally_dump_test.go
+++ b/internal/probel-sw02p/provider/cmd_tally_dump_test.go
@@ -2,6 +2,7 @@ package probelsw02p
 
 import (
 	"context"
+	"dhs/internal/plugin"
 	"io"
 	"log/slog"
 	"net"
@@ -16,7 +17,7 @@ import (
 // TallyDump through a live TCP session and confirms the wire bytes
 // arrive on the client side with the expected shape.
 func TestEmitExtendedProtectTallyDumpFanout(t *testing.T) {
-	srv := newServer(slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	srv := newServer(plugin.Deps{Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}, nil)
 	defer func() { _ = srv.Stop() }()
 
 	// Pre-bind the listener so the server picks the same address with
@@ -97,7 +98,7 @@ func TestEmitExtendedProtectTallyDumpFanout(t *testing.T) {
 // 132-byte cap is enforced: callers passing more than the per-message
 // maximum get a descriptive error and no broadcast fires.
 func TestEmitExtendedProtectTallyDumpRejectsOverflow(t *testing.T) {
-	srv := newServer(slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	srv := newServer(plugin.Deps{Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}, nil)
 	too := make([]codec.ExtendedProtectTallyDumpEntry, codec.ExtendedProtectTallyDumpMaxCount+1)
 	err := srv.EmitExtendedProtectTallyDump(codec.ExtendedProtectTallyDumpParams{Entries: too})
 	if err == nil {

--- a/internal/probel-sw02p/provider/decode_seam_test.go
+++ b/internal/probel-sw02p/provider/decode_seam_test.go
@@ -2,6 +2,7 @@ package probelsw02p
 
 import (
 	"context"
+	"dhs/internal/plugin"
 	"errors"
 	"io"
 	"log/slog"
@@ -50,7 +51,7 @@ func TestSessionRunHandlerDecodeErrorSeam(t *testing.T) {
 	defer func() { decodeErrHook = nil }()
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	srv := newServer(logger, nil)
+	srv := newServer(plugin.Deps{Logger: logger}, nil)
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -135,7 +136,7 @@ func TestNewServerTreeBuildFailureSeam(t *testing.T) {
 	defer func() { treeBuildErrHook = nil }()
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	srv := newServer(logger, &canonical.Export{Root: &canonical.Node{
+	srv := newServer(plugin.Deps{Logger: logger}, &canonical.Export{Root: &canonical.Node{
 		Header: canonical.Header{Number: 1, Identifier: "root", OID: "1"},
 	}})
 	if srv.tree == nil {

--- a/internal/probel-sw02p/provider/idle_reap_test.go
+++ b/internal/probel-sw02p/provider/idle_reap_test.go
@@ -6,6 +6,7 @@ package probelsw02p
 
 import (
 	"context"
+	"dhs/internal/plugin"
 	"io"
 	"log/slog"
 	"net"
@@ -15,7 +16,7 @@ import (
 
 func idleTestServer(t *testing.T) *server {
 	t.Helper()
-	return newServer(slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	return newServer(plugin.Deps{Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}, nil)
 }
 
 func TestServerSessionIdleTimeoutDefaultsOff(t *testing.T) {

--- a/internal/probel-sw02p/provider/plugin.go
+++ b/internal/probel-sw02p/provider/plugin.go
@@ -47,6 +47,5 @@ func (f *Factory) Meta() provider.Meta {
 // New constructs a fresh provider bound to the supplied tree.
 func (f *Factory) New(deps plugin.Deps, tree *canonical.Export) provider.Provider {
 	deps = deps.WithDefaults()
-	logger := deps.Logger
-	return newServer(logger, tree)
+	return newServer(deps, tree)
 }

--- a/internal/probel-sw02p/provider/plugin_test.go
+++ b/internal/probel-sw02p/provider/plugin_test.go
@@ -1,6 +1,7 @@
 package probelsw02p
 
 import (
+	"dhs/internal/plugin"
 	"io"
 	"log/slog"
 	"testing"
@@ -29,7 +30,7 @@ func TestFactoryMeta(t *testing.T) {
 func TestNewServerWithEmptyTree(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	exp := &canonical.Export{Root: &canonical.Node{Header: canonical.Header{Number: 1, Identifier: "root", OID: "1"}}}
-	srv := newServer(logger, exp)
+	srv := newServer(plugin.Deps{Logger: logger}, exp)
 	if srv.Metrics() == nil {
 		t.Error("Metrics() = nil; want non-nil")
 	}

--- a/internal/probel-sw02p/provider/server.go
+++ b/internal/probel-sw02p/provider/server.go
@@ -2,6 +2,7 @@ package probelsw02p
 
 import (
 	"context"
+	"dhs/internal/plugin"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -29,6 +30,10 @@ type Server = server
 type server struct {
 	logger *slog.Logger
 	tree   *tree
+
+	// net is the only way this server binds a socket. Injected, so the
+	// process owns the transport posture and a test can hand in a fake.
+	net transport.Net
 
 	mu sync.Mutex
 
@@ -88,10 +93,9 @@ func (s *server) ComplianceProfile() *compliance.Profile {
 	return s.profile
 }
 
-func newServer(logger *slog.Logger, exp *canonical.Export) *server {
-	if logger == nil {
-		logger = slog.Default()
-	}
+func newServer(deps plugin.Deps, exp *canonical.Export) *server {
+	deps = deps.WithDefaults()
+	logger := deps.Logger
 	t, err := newTree(exp)
 	if treeBuildErrHook != nil {
 		err = treeBuildErrHook()
@@ -100,12 +104,13 @@ func newServer(logger *slog.Logger, exp *canonical.Export) *server {
 		logger.Error("probel-sw02p provider: tree build failed", slog.String("err", err.Error()))
 		t = &tree{matrices: map[matrixKey]*matrixState{}}
 	}
-	met := metrics.NewConnector()
+	met := deps.Metrics
 	for _, id := range codec.CommandIDs() {
 		met.RegisterCmd(uint8(id), codec.CommandName(id))
 	}
 	return &server{
 		logger:           logger,
+		net:              deps.Net,
 		tree:             t,
 		sessions:         map[*session]struct{}{},
 		stopped:          make(chan struct{}),
@@ -118,14 +123,11 @@ func newServer(logger *slog.Logger, exp *canonical.Export) *server {
 
 // Serve binds addr and accepts client sessions until ctx is cancelled.
 func (s *server) Serve(ctx context.Context, addr string) error {
-	ln, err := transport.ListenTCP(ctx, "tcp", addr, transport.SocketOptions{})
+	ln, err := s.net.Listen(ctx, "tcp", addr)
 	if err != nil {
 		return fmt.Errorf("probel-sw02p provider: listen %q: %w", addr, err)
 	}
-	// The embedded listener, not the wrapper: serveListener's accept loop
-	// applies the socket policy itself, so a listener handed to
-	// ServeListener gets it too. Passing the wrapper would apply it twice.
-	return s.serveListener(ctx, ln.Listener)
+	return s.serveListener(ctx, ln)
 }
 
 // ServeListener accepts client sessions on a pre-bound listener until

--- a/internal/probel-sw02p/provider/server_lifecycle_test.go
+++ b/internal/probel-sw02p/provider/server_lifecycle_test.go
@@ -2,6 +2,7 @@ package probelsw02p
 
 import (
 	"context"
+	"dhs/internal/plugin"
 	"errors"
 	"io"
 	"log/slog"
@@ -236,7 +237,7 @@ func TestStopWithoutListener(t *testing.T) {
 // a nil logger is replaced with slog.Default() and the server still
 // builds.
 func TestNewServerNilLogger(t *testing.T) {
-	srv := newServer(nil, nil)
+	srv := newServer(plugin.Deps{Logger: nil}, nil)
 	if srv == nil || srv.logger == nil {
 		t.Fatal("newServer(nil,nil) produced nil server/logger")
 	}
@@ -362,7 +363,7 @@ func TestSessionCloseIdempotent(t *testing.T) {
 // session rather than aborting.
 func TestFanOutWriteFailureNotesEventAndContinues(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	srv := newServer(logger, nil)
+	srv := newServer(plugin.Deps{Logger: logger}, nil)
 
 	// A dead session: pipe with the far end already closed so Write
 	// errors deterministically.
@@ -414,7 +415,7 @@ func TestSessionRunReturnsOnCancelledContext(t *testing.T) {
 // the debug-log branch and ends the session.
 func TestSessionRunReadErrorDebugBranch(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	srv := newServer(logger, nil)
+	srv := newServer(plugin.Deps{Logger: logger}, nil)
 
 	a, b := net.Pipe()
 	defer func() { _ = b.Close() }()
@@ -465,7 +466,7 @@ func TestSessionRunPartialFrameWaitsThenCompletes(t *testing.T) {
 // a session with a debug-level logger and sending a valid frame.
 func TestSessionRunDebugLoggingPath(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	srv := newServer(logger, nil)
+	srv := newServer(plugin.Deps{Logger: logger}, nil)
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -620,7 +621,7 @@ func TestSessionWriteFailureClosesSession(t *testing.T) {
 // coverage flapped run to run.
 func TestStopClosesRegisteredSessions(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	srv := newServer(logger, nil)
+	srv := newServer(plugin.Deps{Logger: logger}, nil)
 
 	a, b := net.Pipe()
 	defer func() { _ = b.Close() }()

--- a/internal/probel-sw02p/session/client.go
+++ b/internal/probel-sw02p/session/client.go
@@ -125,7 +125,13 @@ type ClientConfig struct {
 
 // Dial opens a TCP connection to addr (host:port) and starts the reader
 // goroutine. The returned Client is ready for Send / Subscribe.
-func Dial(ctx context.Context, addr string, logger *slog.Logger, cfg ClientConfig) (*Client, error) {
+// Dial opens a session over the supplied transport.
+//
+// The Net comes from the plugin's Deps rather than being built here: this
+// package no longer decides HOW a socket is made, only what to say over it.
+// A nil Net is the plain-socket default, so a test that does not care about
+// transport still calls Dial with one argument fewer in spirit.
+func Dial(ctx context.Context, n transport.Net, addr string, logger *slog.Logger, cfg ClientConfig) (*Client, error) {
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -135,14 +141,13 @@ func Dial(ctx context.Context, addr string, logger *slog.Logger, cfg ClientConfi
 	if cfg.ReadBufferSize <= 0 {
 		cfg.ReadBufferSize = codec.DefaultReadBufferSize
 	}
-	// The shared dialler applies the same socket policy an accepted
-	// connection gets, so a dialled session and an accepted one are
-	// configured identically. A negative period disables keepalive.
-	d := transport.TCPDialer{
-		Timeout: cfg.DialTimeout,
-		Options: transport.SocketOptions{KeepalivePeriod: cfg.TCPKeepalivePeriod},
+	if n == nil {
+		n = transport.New(transport.Config{
+			Timeout:         cfg.DialTimeout,
+			KeepalivePeriod: cfg.TCPKeepalivePeriod,
+		})
 	}
-	conn, err := d.DialContext(ctx, "tcp", addr)
+	conn, err := n.Dial(ctx, "tcp", addr)
 	if err != nil {
 		return nil, fmt.Errorf("probel-sw02p dial %s: %w", addr, err)
 	}

--- a/internal/probel-sw02p/session/client_keepalive_test.go
+++ b/internal/probel-sw02p/session/client_keepalive_test.go
@@ -39,7 +39,7 @@ func TestDialAppliesTCPKeepalive(t *testing.T) {
 	cfg := ClientConfig{TCPKeepalivePeriod: 17 * time.Second}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	cli, err := Dial(ctx, addr, logger, cfg)
+	cli, err := Dial(ctx, nil, addr, logger, cfg)
 	if err != nil {
 		t.Fatalf("Dial: %v", err)
 	}

--- a/internal/probel-sw02p/session/client_paths_test.go
+++ b/internal/probel-sw02p/session/client_paths_test.go
@@ -25,7 +25,7 @@ func quietLogger() *slog.Logger {
 func TestDialError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
-	cli, err := Dial(ctx, "127.0.0.1:1", quietLogger(), ClientConfig{
+	cli, err := Dial(ctx, nil, "127.0.0.1:1", quietLogger(), ClientConfig{
 		DialTimeout: 200 * time.Millisecond,
 	})
 	if err == nil {
@@ -57,7 +57,7 @@ func TestDialDefaultsAndNilLogger(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	// nil logger + zero cfg → default timeout / buffer branches.
-	cli, err := Dial(ctx, l.Addr().String(), nil, ClientConfig{})
+	cli, err := Dial(ctx, nil, l.Addr().String(), nil, ClientConfig{})
 	if err != nil {
 		t.Fatalf("Dial: %v", err)
 	}


### PR DESCRIPTION
Step 3 of the sweep — **one connector**, proving the pattern end to end before it's repeated nine more times.

| Layer | Change |
|---|---|
| consumer | `Plugin` holds `deps.Net` and `deps.Metrics`; `session.Dial` takes the Net instead of building a `TCPDialer` |
| session | `Dial(ctx, n transport.Net, addr, logger, cfg)` — this package no longer decides *how* a socket is made, only what to say over it |
| provider | `newServer(deps, tree)`; `Serve` binds through `s.net.Listen` |

After this the package contains **no `net.Dial`, no `net.Listen`, no `ListenConfig`, no `transport.TCPDialer`**. The only remaining `net.Listener` mentions are the stdlib *type* in `ServeListener`'s signature — the seam an injected listener arrives through, not a socket being made.

`metrics.NewConnector()` is gone from both halves: the counter set is supplied, so the process can scrape every connector from one place instead of each owning a registry nobody else can reach.

## Two things worth stating rather than hiding

**A regression I introduced and caught.** `Connect` used to construct its own metrics, so a `Plugin` built directly — which several tests do — had a working `Metrics()`. Reading `deps.Metrics` unconditionally made that nil, and three consumer tests failed on it. Fixed with the same shape `WithDefaults` uses: a hand-built `Plugin` still gets a counter set. The factory path always injects one; the guard is for callers that predate `Deps`.

**`session.Dial` keeps a nil-Net fallback** that builds a default transport. That's a convenience for direct callers, not a hole in the guarantee: the plugin always injects, and the architecture test still sees no socket construction in the protocol package. Removing it would only push `transport.New` into every test.

## Verification

| | |
|---|---|
| codec / session / consumer / provider | **100% each** |
| build + vet + full suite | green |
| coverage floors | **32/32** |
| `golangci-lint` | 0 issues |

One process note: my first attempt at rewriting the provider test call sites used a regex whose `[^,]+` matched across newlines and mangled six files. Reverted and redone line-scoped — worth mentioning because the revert also undid the `server.go` change, which I had to re-apply.

**Nine connectors follow the same three steps**, and each deletes rather than moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
