### PR TITLE
IRD reconnaissance, the MIB library, and a MIB checker

### DIFF
--- a/docs/testbed.md
+++ b/docs/testbed.md
@@ -39,7 +39,8 @@ ADR-0025 requires — a connector is not DONE against our own provider.
 | **EVS Neuron** | `10.6.255.102` | acp2 `:2072` · Probel SW-P-08 `:7800` · NMOS · REST API (OASIS 3.1) | `acp2`, `probel-sw08p`, `amwa`, `ccm` (REST, later) |
 | **Riedel Fusion 6** | (being commissioned) | NMOS · REST API | `amwa` |
 | ACP1 frame (controller + cards) | (to confirm) | ACP1 | `acp1` |
-| IRD satellite receiver | (being addressed) | SNMP + MIB · HTTP management page | none yet — `internal/snmp` is unwritten |
+| **Tandberg TT1260** (IRD) | `10.6.255.110` | SNMP v1 `:161` · HTTP `:80` | none yet — `internal/snmp` is unwritten |
+| **Tandberg RX1290** (IRD) | `10.6.255.111` | SNMP v1 `:161` · HTTP `:80` | none yet — `internal/snmp` is unwritten |
 | **EVS Cerebrum** | `10.6.250.5` | Cerebrum NB `:40009` · SNMP agent `:1161` · SNMP manager `:161` + trap receiver `:162` · syslog | `cerebrum-nb`, and the SNMP peer for `internal/snmp` when it is written |
 
 Only `ACP2_TEST_HOST` among these has an integration gate today. Probel SW-P-08,
@@ -49,8 +50,45 @@ services this one Neuron offers cannot yet be driven at a real device — see
 
 ### IRD satellite receivers — SNMP only
 
-Installed 2026-09-07; the codeowner is assigning fabric addresses so they are
-reachable, and sourcing the MIBs (they belong in `internal/snmp/assets/mibs/`).
+Installed and addressed 2026-09-07. Both answer on the management fabric;
+the MIBs belong in `internal/snmp/assets/mibs/`.
+
+| | TT1260 | RX1290 |
+| --- | --- | --- |
+| Address | `10.6.255.110` | `10.6.255.111` |
+| `sysDescr` | "Tandberg TV TT1260 Professional MPEG Receiver" | "Tandberg Television RX1290 Professional AVC Receiver" |
+| `sysObjectID` | `1.3.6.1.4.1.1773.1.3.200` | `1.3.6.1.4.1.1773.1.3.200` |
+| Objects under 1773 | 577 | 842 |
+
+**The MIB to find is Tandberg Television, IANA enterprise 1773.** Both units
+report the SAME sysObjectID, so one product-family MIB covers both — which
+matches their identical web UI and their shared alarm-ID namespace
+(1 = Signal Lock lost, 2 = BER too high, 4 = Video stopped, 5/6 = Audio
+stopped, 8 = CN margin too low, 9 = PreBER too high). Ericsson acquired
+Tandberg Television in 2007, so vendor material may be filed under either
+name.
+
+Verified live with `snmpget`/`snmpwalk` from `dhs-tools`:
+
+- **SNMPv1 ONLY.** v2c gets no response at all, on either unit, for either
+  community. Community `public` reads. This happens to match Cerebrum's own
+  manager default (v1, `public`), so Cerebrum can poll them as they stand.
+- Tree shape: `1773.1.1.x` is the common chassis branch (network config at
+  `.1.1.1.1-4`, trap destinations at `.1.1.2.1`, a card/module table at
+  `.1.1.3.1` carrying per-slot type, firmware and card names), and
+  `1773.1.3.200.x` is the product branch — 299 of the TT1260's objects.
+
+Two things to fix on the devices before trap work starts:
+
+1. **The trap destination is stale.** `.1.1.2.1.2.1` still reads
+   `192.168.0.229`, an address from a previous network, so traps currently
+   go nowhere. Point it at Cerebrum (`10.6.250.5`, receiver Active on 162)
+   for an independent confirmation the devices emit at all.
+2. **The clock is unset** — both report `0000-00-00 00:00:00`, and every
+   alarm row carries that timestamp. Trap and alarm times are meaningless
+   until NTP is configured.
+
+Scope, per the codeowner:
 
 Scope, per the codeowner:
 

--- a/internal/snmp/CLAUDE.md
+++ b/internal/snmp/CLAUDE.md
@@ -33,16 +33,42 @@ SNMP is **ASN.1 BER over UDP**, and this repo already owns a BER codec at
 ADR-0006 like every other codec, and there is no argument for a dependency to
 put bytes on the wire.
 
+## Where the MIBs live
+
+**`github.com/by-protocol/mib`** — its own repository, not this tree. Per
+device under `ird/` (TT1260, RX1290, RX8200), plus `standard/` carrying the
+six IETF base modules every vendor MIB imports and no vendor ships.
+
+The vendor is **Ericsson Television Limited** (formerly Tandberg Television),
+IANA enterprise **1773**. `ETV-Base-MIB` defines
+`mibEricssonTelevision ::= { enterprises 1773 }` and
+`elementManagementMIB ::= { mibEricssonTelevision 1 }`, which is exactly the
+branch the testbed devices answer on.
+
+The import graph is shallow and shared:
+
+    ird/<device>/*.mib
+      ├── ETV-Base-MIB   (Base.mib)    enterprises 1773
+      ├── ETV-Types-TC   (Types.mib)   Uint8 / Uint16 / Uint32 / PIDNumber
+      └── standard/      RFC1155-SMI · RFC-1212 · RFC-1215
+                         SNMPv2-SMI · SNMPv2-TC · RFC1213-MIB
+
+Note the SMIv1/SMIv2 mix: the product MIBs import RFC1155-SMI and RFC-1212
+(SMIv1) while the trap MIB imports SNMPv2-SMI and SNMPv2-TC (SMIv2). A
+compiler that only handles one of the two dialects will not get through this
+set.
+
 ## MIB parsing happens OFFLINE, never in the binary
 
 This is the load-bearing decision. Parsing MIB source is a compiler problem —
 lexer, grammar, IMPORTS resolution across files — and dragging that into the
 shipped binary is how a connector acquires a dependency tail.
 
-Instead: a tool under `tools/` compiles the MIBs in `assets/mibs/` into
-committed Go OID tables, and the connector reads the generated tables. The
-compile is a development step whose output is reviewed in a PR; the runtime
-knows only numbers and types.
+Instead: a tool under `tools/` compiles the MIBs from a checkout of
+`by-protocol/mib` into committed Go OID tables, and the connector reads the
+generated tables. The compile is a development step whose output is reviewed
+in a PR; the runtime knows only numbers and types, and this repo never
+vendors the MIB source.
 
 Measured for the fork set the codeowner already made under
 `github.com/by-protocol` (per ADR-0005's build-graph rule — what enters OUR

--- a/internal/snmp/assets/mibs/README.md
+++ b/internal/snmp/assets/mibs/README.md
@@ -1,3 +1,22 @@
-Drop vendor MIB source files here (.mib / .txt / .my), INCLUDING every MIB
-they IMPORT — a MIB that references a definition we do not have cannot be
-compiled. Keep the vendor filenames.
+# mibs/
+
+**The MIB library lives in its own repository: `github.com/by-protocol/mib`.**
+
+Do not copy MIBs in here. That repo is the single source (ADR-0015), it is
+shared across projects, and duplicating 500 KB of vendor source into this
+tree would only create a second copy to drift.
+
+It holds, per device under `ird/`:
+
+    ird/TT1260/    ird/RX1290/    ird/RX8200/
+
+plus `standard/` — the six IETF base modules every vendor MIB imports and no
+vendor ships (`RFC1155-SMI`, `RFC-1212`, `RFC-1215`, `SNMPv2-SMI`,
+`SNMPv2-TC`, `RFC1213-MIB`). Without those, nothing under `ird/` compiles.
+
+The offline MIB compiler (see `../../CLAUDE.md`) takes a path to a checkout
+of that repo and emits committed Go OID tables into this tree. The MIB source
+stays there; the generated tables are what ships.
+
+This folder remains only as the place to put a MIB that is genuinely specific
+to this project and belongs nowhere else. That has not happened yet.

--- a/tools/mibcheck/main.go
+++ b/tools/mibcheck/main.go
@@ -1,0 +1,417 @@
+// Command mibcheck validates a directory of SNMP MIB source before anything
+// is generated from it.
+//
+//	go run ./tools/mibcheck <dir>...
+//
+// A MIB is a contract we decode devices against, and a defect in one is
+// silent: the compiler accepts it, the generated tables look plausible, and
+// a value decodes to the wrong label — or to two labels — for as long as
+// nobody looks. Vendor MIBs do contain such defects. The Ericsson Television
+// set ships with an enumeration where one wire value carries two names and
+// a second name is duplicated:
+//
+//	inS2StatusModulationType ::= INTEGER {
+//	    modBpsk(1), modQpsk(2), mod8psk(3), mod16qam(4),
+//	    modAuto(5), mod16sqam(5), modAuto(7) }
+//
+// so decoding a 5 is ambiguous and 6 is unreachable, against a DESCRIPTION
+// that lists seven distinct modulations.
+//
+// The checks are deliberately the ones that need no grammar — this is a
+// linter, not a compiler, and it must be able to run over a set that does
+// not yet compile:
+//
+//	duplicate-value  two members of one enumeration share a wire value
+//	duplicate-name   one name appears twice in one enumeration
+//	missing-import   a module is IMPORTed that nothing in the set DEFINES
+//
+// Exits non-zero when anything is found, so it can gate a commit.
+//
+// With -fetch it also RESOLVES the missing imports, downloading each absent
+// module into -out and re-checking the enlarged set:
+//
+//	go run ./tools/mibcheck -fetch -out standard ird
+//
+// Every download is validated before it is written: it must declare the
+// module it was asked for and contain no markup. That is not paranoia.
+// mibs.observium.org serves a rendered HTML page at the URL that looks like
+// a raw download, so an unchecked fetch produces a 47 KB web page named
+// SNMPv2-SMI instead of the 9 KB module, and the defect surfaces much later
+// as a parse error in something apparently unrelated.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// defaultMIBSource is where -fetch looks. mibbrowser.online publishes raw
+// module source at a predictable path; the other well-known browsers render
+// HTML instead, which is why this is the default and why every download is
+// validated regardless of where it came from.
+const defaultMIBSource = "https://mibbrowser.online/mibs/"
+
+// fetchTimeout bounds one download. A linter must not hang on a slow mirror.
+const fetchTimeout = 30 * time.Second
+
+func main() {
+	quiet := flag.Bool("q", false, "print only findings, no summary")
+	fetch := flag.Bool("fetch", false, "download modules that are imported but missing")
+	out := flag.String("out", "", "directory to write fetched modules into (required with -fetch)")
+	source := flag.String("source", defaultMIBSource, "base URL to fetch missing modules from")
+	flag.Parse()
+
+	dirs := flag.Args()
+	if len(dirs) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: mibcheck [-q] [-fetch -out DIR] <dir>...")
+		os.Exit(2)
+	}
+	if *fetch && *out == "" {
+		fmt.Fprintln(os.Stderr, "mibcheck: -fetch needs -out <dir>")
+		os.Exit(2)
+	}
+
+	set, err := scan(dirs)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "mibcheck:", err)
+		os.Exit(2)
+	}
+
+	if *fetch {
+		if n := fetchMissing(*source, *out, set.missing()); n > 0 {
+			// Re-scan from disk rather than trusting what was just written:
+			// what matters is what the next compile will see.
+			fmt.Fprintf(os.Stderr, "mibcheck: fetched %d module(s) into %s; re-checking\n", n, *out)
+			if set, err = scan(append(dirs, *out)); err != nil {
+				fmt.Fprintln(os.Stderr, "mibcheck:", err)
+				os.Exit(2)
+			}
+		}
+	}
+
+	findings := set.findings()
+	for _, f := range findings {
+		fmt.Println(f)
+	}
+	if !*quiet {
+		fmt.Fprintf(os.Stderr, "\nmibcheck: %d file(s), %d module(s) defined, %d finding(s)\n",
+			set.files, len(set.defined), len(findings))
+	}
+	if len(findings) > 0 {
+		os.Exit(1)
+	}
+}
+
+// Finding is one defect, formatted like a compiler diagnostic so an editor
+// can jump to it.
+type Finding struct {
+	File string
+	Line int
+	Rule string
+	Msg  string
+}
+
+func (f Finding) String() string {
+	if f.Line > 0 {
+		return fmt.Sprintf("%s:%d: %s: %s", f.File, f.Line, f.Rule, f.Msg)
+	}
+	return fmt.Sprintf("%s: %s: %s", f.File, f.Rule, f.Msg)
+}
+
+// Set is one scan of a MIB collection: what it defines, what it imports, and
+// the per-file defects found along the way.
+type Set struct {
+	files    int
+	defined  map[string]string   // module -> file that defines it
+	imported map[string][]string // module -> files that import it
+	enums    []Finding
+}
+
+// scan reads every MIB under dirs once.
+func scan(dirs []string) (*Set, error) {
+	paths, err := collect(dirs)
+	if err != nil {
+		return nil, err
+	}
+	s := &Set{
+		defined:  map[string]string{},
+		imported: map[string][]string{},
+	}
+	for _, p := range paths {
+		src, err := os.ReadFile(p)
+		if err != nil {
+			return nil, err
+		}
+		s.files++
+		text := stripComments(string(src))
+		s.enums = append(s.enums, checkEnums(p, text)...)
+		for _, m := range definedModules(text) {
+			s.defined[m] = p
+		}
+		for _, m := range importedModules(text) {
+			s.imported[m] = append(s.imported[m], p)
+		}
+	}
+	return s, nil
+}
+
+// missing lists modules the set imports but never defines. This is what
+// makes a set incomplete rather than wrong: the compile fails on a machine
+// without them and succeeds on one that happens to have them installed,
+// which is the worst of both.
+func (s *Set) missing() []string {
+	var out []string
+	for m := range s.imported {
+		if _, ok := s.defined[m]; !ok {
+			out = append(out, m)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (s *Set) findings() []Finding {
+	out := append([]Finding(nil), s.enums...)
+	for _, m := range s.missing() {
+		files := append([]string(nil), s.imported[m]...)
+		sort.Strings(files)
+		where := ""
+		if len(files) > 0 {
+			where = files[0]
+		}
+		out = append(out, Finding{where, 0, "missing-import",
+			fmt.Sprintf("module %q is imported by %d file(s) but defined nowhere in the set",
+				m, len(files))})
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].File != out[j].File {
+			return out[i].File < out[j].File
+		}
+		return out[i].Line < out[j].Line
+	})
+	return out
+}
+
+// mibExt reports whether a filename looks like MIB source. Extensionless
+// files are included: the IETF modules ship with no extension at all.
+func mibExt(name string) bool {
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".mib", ".my", ".txt", "":
+		return true
+	}
+	return false
+}
+
+func collect(dirs []string) ([]string, error) {
+	seen := map[string]bool{}
+	var out []string
+	for _, d := range dirs {
+		err := filepath.Walk(d, func(p string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() || !mibExt(info.Name()) {
+				return nil
+			}
+			// A README sitting beside the modules is not one of them.
+			if strings.EqualFold(info.Name(), "README.md") {
+				return nil
+			}
+			slash := filepath.ToSlash(p)
+			// -fetch appends the output dir to the scan list, which may
+			// already be inside one of them; count each file once.
+			if !seen[slash] {
+				seen[slash] = true
+				out = append(out, slash)
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// stripComments removes ASN.1 comments (-- to end of line) while preserving
+// line numbering, so a reported line still matches the source. Without this
+// a commented-out example enumeration would be linted as if it were real.
+func stripComments(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, ln := range lines {
+		if j := strings.Index(ln, "--"); j >= 0 {
+			lines[i] = ln[:j]
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+var (
+	enumRe   = regexp.MustCompile(`(?s)\b(?:INTEGER|Integer32|BITS)\s*\{(.*?)\}`)
+	pairRe   = regexp.MustCompile(`([A-Za-z][\w-]*)\s*\(\s*(-?\d+)\s*\)`)
+	defineRe = regexp.MustCompile(`(?m)^\s*([A-Za-z][\w-]*)\s+DEFINITIONS\s*::=`)
+	fromRe   = regexp.MustCompile(`\bFROM\s+([A-Za-z][\w-]*)`)
+	importRe = regexp.MustCompile(`(?s)\bIMPORTS\b(.*?);`)
+)
+
+// checkEnums reports duplicate values and duplicate names inside a single
+// enumeration. Both are defects regardless of intent: a repeated value makes
+// decoding ambiguous, and a repeated name makes encoding ambiguous.
+func checkEnums(file, text string) []Finding {
+	var out []Finding
+	for _, loc := range enumRe.FindAllStringSubmatchIndex(text, -1) {
+		body := text[loc[2]:loc[3]]
+		pairs := pairRe.FindAllStringSubmatch(body, -1)
+		if len(pairs) < 2 {
+			continue
+		}
+		line := 1 + strings.Count(text[:loc[0]], "\n")
+
+		byValue := map[int][]string{}
+		byName := map[string][]int{}
+		var valueOrder []int
+		var nameOrder []string
+		for _, p := range pairs {
+			name := p[1]
+			v, err := strconv.Atoi(p[2])
+			if err != nil {
+				continue
+			}
+			if _, seen := byValue[v]; !seen {
+				valueOrder = append(valueOrder, v)
+			}
+			if _, seen := byName[name]; !seen {
+				nameOrder = append(nameOrder, name)
+			}
+			byValue[v] = append(byValue[v], name)
+			byName[name] = append(byName[name], v)
+		}
+
+		for _, v := range valueOrder {
+			if names := byValue[v]; len(names) > 1 {
+				out = append(out, Finding{file, line, "duplicate-value",
+					fmt.Sprintf("value %d is used by %s — decoding it is ambiguous",
+						v, strings.Join(names, " and "))})
+			}
+		}
+		for _, n := range nameOrder {
+			if vs := byName[n]; len(vs) > 1 {
+				strs := make([]string, len(vs))
+				for i, v := range vs {
+					strs[i] = strconv.Itoa(v)
+				}
+				out = append(out, Finding{file, line, "duplicate-name",
+					fmt.Sprintf("name %q is used for values %s — encoding it is ambiguous",
+						n, strings.Join(strs, " and "))})
+			}
+		}
+	}
+	return out
+}
+
+func definedModules(text string) []string {
+	var out []string
+	for _, m := range defineRe.FindAllStringSubmatch(text, -1) {
+		out = append(out, m[1])
+	}
+	return out
+}
+
+// importedModules reads the names after FROM inside IMPORTS blocks only, so
+// the word "FROM" in a DESCRIPTION cannot invent a dependency.
+func importedModules(text string) []string {
+	var out []string
+	for _, blk := range importRe.FindAllStringSubmatch(text, -1) {
+		for _, m := range fromRe.FindAllStringSubmatch(blk[1], -1) {
+			out = append(out, m[1])
+		}
+	}
+	return out
+}
+
+// fetchMissing downloads each missing module into dir and returns how many
+// were written. A module that cannot be fetched, or that fails validation,
+// is reported and skipped rather than written — a bad file on disk is worse
+// than an absent one, because the next run stops reporting it as missing.
+func fetchMissing(source, dir string, missing []string) int {
+	if len(missing) == 0 {
+		return 0
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "mibcheck: %v\n", err)
+		return 0
+	}
+	n := 0
+	for _, m := range missing {
+		body, err := download(source, m)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "mibcheck: fetch %s: %v\n", m, err)
+			continue
+		}
+		if err := validate(m, body); err != nil {
+			fmt.Fprintf(os.Stderr, "mibcheck: fetch %s: %v (not written)\n", m, err)
+			continue
+		}
+		path := filepath.Join(dir, m)
+		if err := os.WriteFile(path, body, 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "mibcheck: write %s: %v\n", path, err)
+			continue
+		}
+		fmt.Fprintf(os.Stderr, "mibcheck: fetched %s (%d bytes) -> %s\n", m, len(body), path)
+		n++
+	}
+	return n
+}
+
+func download(source, module string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), fetchTimeout)
+	defer cancel()
+	url := strings.TrimSuffix(source, "/") + "/" + module + ".mib"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s: HTTP %d", url, resp.StatusCode)
+	}
+	// Cap the read: a MIB is tens of kilobytes, and an unbounded read from
+	// a mirror that decided to serve something else is not worth the risk.
+	return io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+}
+
+// validate rejects anything that is not the module it was asked for. Both
+// checks matter: the markup test catches a rendered browser page, and the
+// DEFINITIONS test catches a mirror that served a different module.
+func validate(module string, body []byte) error {
+	text := string(body)
+	lower := strings.ToLower(text)
+	if strings.Contains(lower, "<html") || strings.Contains(lower, "<!doctype") {
+		return fmt.Errorf("looks like a web page, not MIB source")
+	}
+	got := definedModules(stripComments(text))
+	for _, g := range got {
+		if g == module {
+			return nil
+		}
+	}
+	if len(got) == 0 {
+		return fmt.Errorf("declares no module at all")
+	}
+	return fmt.Errorf("declares %s, not %s", strings.Join(got, ", "), module)
+}

--- a/tools/mibcheck/main_test.go
+++ b/tools/mibcheck/main_test.go
@@ -1,0 +1,238 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The defect this tool was written for, reduced to its essentials: one wire
+// value carrying two names, and one name carrying two values.
+func TestCheckEnumsFindsTheEricssonDefect(t *testing.T) {
+	src := `
+inS2StatusModulationType OBJECT-TYPE
+    SYNTAX    INTEGER { modBpsk(1), modQpsk(2), mod8psk(3), mod16qam(4), modAuto(5), mod16sqam(5), modAuto(7) }
+    ACCESS    read-only
+`
+	got := checkEnums("TT1260-MIB.mib", stripComments(src))
+	if len(got) != 2 {
+		t.Fatalf("got %d findings, want 2:\n%v", len(got), got)
+	}
+
+	var sawValue, sawName bool
+	for _, f := range got {
+		if f.Line != 3 {
+			t.Errorf("finding on line %d, want the SYNTAX line 3: %v", f.Line, f)
+		}
+		switch f.Rule {
+		case "duplicate-value":
+			sawValue = true
+			if !strings.Contains(f.Msg, "modAuto") || !strings.Contains(f.Msg, "mod16sqam") {
+				t.Errorf("duplicate-value must name both members: %q", f.Msg)
+			}
+		case "duplicate-name":
+			sawName = true
+			if !strings.Contains(f.Msg, "5") || !strings.Contains(f.Msg, "7") {
+				t.Errorf("duplicate-name must name both values: %q", f.Msg)
+			}
+		}
+	}
+	if !sawValue || !sawName {
+		t.Errorf("both rules must fire on this enum, got %v", got)
+	}
+}
+
+// The RX8200 case: the VALUE is right and the LABEL is wrong, so only the
+// name rule fires. A checker that only looked for duplicate values would
+// miss it entirely.
+func TestCheckEnumsFindsADuplicateLabelAlone(t *testing.T) {
+	src := `
+    mpegAlert OBJECT-TYPE
+        SYNTAX Integer32 {
+            NO_MPEG_ALERTS_ACTIVE(0),
+            SYNC_LOSS(1),
+            OUT_OF_REGULATION(2),
+            SYNC_LOSS-OUT_OF_REGULATION(3),
+            RS_THRESHOLD(4),
+            SYNC_LOSS-RS_THRESHOLD(5),
+            SYNC_LOSS-OUT_OF_REGULATION(6) }
+`
+	got := checkEnums("x.mib", stripComments(src))
+	if len(got) != 1 || got[0].Rule != "duplicate-name" {
+		t.Fatalf("want exactly one duplicate-name finding, got %v", got)
+	}
+}
+
+// A well-formed enumeration produces nothing. Without this the tool could
+// "pass" by reporting everything.
+func TestCheckEnumsAcceptsAWellFormedEnum(t *testing.T) {
+	src := `SYNTAX INTEGER { off(0), on(1), auto(2) }`
+	if got := checkEnums("x.mib", stripComments(src)); len(got) != 0 {
+		t.Errorf("a clean enum must produce no findings, got %v", got)
+	}
+}
+
+// A commented-out enumeration is not source. Linting one would report
+// defects nobody can fix, in text the compiler never sees.
+func TestCommentedEnumIsNotLinted(t *testing.T) {
+	src := `-- SYNTAX INTEGER { a(1), b(1) }
+SYNTAX INTEGER { off(0), on(1) }`
+	if got := checkEnums("x.mib", stripComments(src)); len(got) != 0 {
+		t.Errorf("commented text must be ignored, got %v", got)
+	}
+}
+
+// stripComments must not move any line, or every reported line number after
+// the first comment would be wrong.
+func TestStripCommentsPreservesLineNumbering(t *testing.T) {
+	src := "a -- one\nb\n-- two\nc"
+	got := stripComments(src)
+	if strings.Count(got, "\n") != strings.Count(src, "\n") {
+		t.Fatalf("line count changed: %q", got)
+	}
+	if lines := strings.Split(got, "\n"); lines[3] != "c" {
+		t.Errorf("line 4 = %q, want %q", lines[3], "c")
+	}
+}
+
+// "FROM" appears in prose too. Reading it outside an IMPORTS block would
+// invent dependencies and make every set look incomplete.
+func TestImportedModulesReadsOnlyTheImportsBlock(t *testing.T) {
+	src := `
+FOO-MIB DEFINITIONS ::= BEGIN
+IMPORTS
+    OBJECT-TYPE FROM SNMPv2-SMI
+    Uint8       FROM ETV-Types-TC;
+
+bar OBJECT-TYPE
+    DESCRIPTION "the value read FROM RFC1213-MIB is not an import"
+END`
+	got := importedModules(src)
+	if len(got) != 2 {
+		t.Fatalf("got %v, want exactly the two real imports", got)
+	}
+	for _, g := range got {
+		if g == "RFC1213-MIB" {
+			t.Error("a FROM inside a DESCRIPTION was treated as an import")
+		}
+	}
+	if defs := definedModules(src); len(defs) != 1 || defs[0] != "FOO-MIB" {
+		t.Errorf("definedModules = %v, want [FOO-MIB]", defs)
+	}
+}
+
+// The whole point of the import rule: a set that compiles here because the
+// module happens to be installed, and fails on a colleague's machine.
+func TestMissingReportsImportedButUndefined(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "a.mib", `A-MIB DEFINITIONS ::= BEGIN
+IMPORTS OBJECT-TYPE FROM SNMPv2-SMI; END`)
+	write(t, dir, "b.mib", `B-MIB DEFINITIONS ::= BEGIN
+IMPORTS Uint8 FROM A-MIB; END`)
+
+	set, err := scan([]string{dir})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	missing := set.missing()
+	if len(missing) != 1 || missing[0] != "SNMPv2-SMI" {
+		t.Fatalf("missing = %v, want [SNMPv2-SMI] — A-MIB is defined here", missing)
+	}
+	if set.files != 2 {
+		t.Errorf("scanned %d files, want 2", set.files)
+	}
+}
+
+// -fetch appends its output directory to the scan list, and that directory
+// may sit inside one already listed. Counting a file twice would report
+// every one of its enums twice.
+func TestScanCountsEachFileOnce(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "standard")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write(t, sub, "S.mib", `S-MIB DEFINITIONS ::= BEGIN END`)
+
+	set, err := scan([]string{dir, sub})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if set.files != 1 {
+		t.Errorf("scanned %d files, want 1 — the overlap must not double-count", set.files)
+	}
+}
+
+// The lesson from observium: a URL that looks like a download can return a
+// rendered web page, and writing it would be worse than fetching nothing,
+// because the next run stops reporting the module as missing.
+func TestValidateRejectsAWebPage(t *testing.T) {
+	page := []byte("<!DOCTYPE html>\n<html lang=\"en\"><title>SNMPv2-SMI</title></html>")
+	err := validate("SNMPv2-SMI", page)
+	if err == nil {
+		t.Fatal("a web page must be rejected")
+	}
+	if !strings.Contains(err.Error(), "web page") {
+		t.Errorf("error should say what it is: %v", err)
+	}
+}
+
+func TestValidateRejectsTheWrongModule(t *testing.T) {
+	body := []byte("SNMPv2-TC DEFINITIONS ::= BEGIN\nEND")
+	err := validate("SNMPv2-SMI", body)
+	if err == nil {
+		t.Fatal("a different module must be rejected")
+	}
+	if !strings.Contains(err.Error(), "SNMPv2-TC") {
+		t.Errorf("error should name what arrived: %v", err)
+	}
+}
+
+func TestValidateRejectsSomethingWithNoModule(t *testing.T) {
+	if err := validate("SNMPv2-SMI", []byte("not a mib at all")); err == nil {
+		t.Fatal("content declaring no module must be rejected")
+	}
+}
+
+func TestValidateAcceptsTheRealThing(t *testing.T) {
+	body := []byte("-- a comment\nSNMPv2-SMI DEFINITIONS ::= BEGIN\nEND")
+	if err := validate("SNMPv2-SMI", body); err != nil {
+		t.Errorf("valid source rejected: %v", err)
+	}
+}
+
+// The IETF modules ship with no extension at all, so an extension allow-list
+// that forgot that case would silently skip exactly the files the import
+// rule needs.
+func TestMibExtAcceptsExtensionlessModules(t *testing.T) {
+	for _, name := range []string{"SNMPv2-SMI", "Base.mib", "RFC-1212.my", "IF-MIB.txt"} {
+		if !mibExt(name) {
+			t.Errorf("%s should be treated as MIB source", name)
+		}
+	}
+	for _, name := range []string{"notes.pdf", "logo.png"} {
+		if mibExt(name) {
+			t.Errorf("%s should not be treated as MIB source", name)
+		}
+	}
+}
+
+func TestFindingFormat(t *testing.T) {
+	withLine := Finding{"a.mib", 12, "duplicate-value", "boom"}
+	if got := withLine.String(); got != "a.mib:12: duplicate-value: boom" {
+		t.Errorf("got %q", got)
+	}
+	// A missing import belongs to a set, not to a line.
+	noLine := Finding{"a.mib", 0, "missing-import", "boom"}
+	if got := noLine.String(); got != "a.mib: missing-import: boom" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func write(t *testing.T, dir, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## What

Groundwork from getting the two IRD receivers onto the fabric. No connector code — `internal/snmp` stays parked.

### The devices answer, and they say what MIB they need

```
sysObjectID = 1.3.6.1.4.1.1773.1.3.200   (both units)
sysDescr    = "Tandberg TV TT1260 Professional MPEG Receiver"
              "Tandberg Television RX1290 Professional AVC Receiver"
```

IANA enterprise **1773** is Ericsson Television Limited (formerly Tandberg Television). Both report the same sysObjectID, so one product-family MIB covers both.

**SNMPv1 only** — v2c draws no response from either unit on either community. That happens to match Cerebrum's own manager default (v1, `public`), so Cerebrum can poll them as they stand. 577 objects readable on the TT1260, 842 on the RX1290.

Two device-side things recorded because they will silently spoil trap work: the trap destination is still `192.168.0.229` from a previous network, and the clock is unset on both, which is why every alarm row reads `0000-00-00 00:00:00`.

### The MIBs live in their own repo

`internal/snmp/assets/mibs/` becomes a pointer to `github.com/by-protocol/mib` rather than a second copy of 500 KB of vendor source. Recorded there: the import graph is shallow and shared, and it **mixes SMIv1 and SMIv2** — the product MIBs import `RFC1155-SMI`/`RFC-1212`, the trap MIB imports `SNMPv2-SMI`/`SNMPv2-TC`. A compiler handling only one dialect will not get through the set.

### `tools/mibcheck`

Because one of those MIBs is wrong:

```
TT1260-MIB.mib:3298: duplicate-value: value 5 is used by modAuto and mod16sqam
TT1260-MIB.mib:3298: duplicate-name:  name "modAuto" is used for values 5 and 7
```

The DESCRIPTION lists seven distinct modulations, so `mod16sqam` should be 6 and the second `modAuto` needs its own name. As shipped, decoding a 5 is ambiguous and 6 is unreachable.

Three rules that need no grammar, so the tool runs over a set that does not yet compile: `duplicate-value`, `duplicate-name`, `missing-import`. `-fetch` resolves the missing ones, validating every download declares the module it was asked for and contains no markup — `mibs.observium.org` serves a rendered HTML page at the URL that looks like a raw download.

## Verification

`go test ./...` green. `mibcheck` over the library reports the 5 real enum defects and no missing imports, once `SNMPv2-CONF` is added ([by-protocol/mib#1](https://github.com/by-protocol/mib/pull/1)) — which `mibcheck` itself found, after a by-eye pass missed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)