### PR TITLE
consumer.Base — inherit the four cross-cutting concerns

### DIFF
--- a/internal/acp1/consumer/consumer_cov_test.go
+++ b/internal/acp1/consumer/consumer_cov_test.go
@@ -70,8 +70,11 @@ func TestTransportKind_String(t *testing.T) {
 
 func TestPlugin_Accessors(t *testing.T) {
 	p := &Plugin{}
-	if p.ComplianceProfile() != nil {
-		t.Error("ComplianceProfile before connect should be nil")
+	// Never nil: the profile is connector-scoped and exists from the start,
+	// so a deviation cannot be dropped for want of a Connect, and callers
+	// like cmd/dhs/cmd_profile.go need no nil check.
+	if p.ComplianceProfile() == nil {
+		t.Error("ComplianceProfile must never be nil")
 	}
 	p.SetRecorder(nil) // exercises the setter
 	p.SetTransport(TransportTCPDirect)

--- a/internal/acp1/consumer/identity.go
+++ b/internal/acp1/consumer/identity.go
@@ -108,8 +108,8 @@ func (p *Plugin) IdentityProbe(ctx context.Context, slot int) (string, error) {
 func (p *Plugin) GetIdentity(ctx context.Context, slot int) (consumer.CardIdentity, error) {
 	p.mu.Lock()
 	c := p.client
-	profile := p.profile
 	p.mu.Unlock()
+	profile := p.ComplianceProfile()
 	if c == nil {
 		return consumer.CardIdentity{}, consumer.ErrNotConnected
 	}

--- a/internal/acp1/consumer/identity_test.go
+++ b/internal/acp1/consumer/identity_test.go
@@ -9,7 +9,6 @@ import (
 
 	"dhs/internal/acp1/codec"
 	"dhs/internal/consumer"
-	"dhs/internal/consumer/compliance"
 )
 
 // stringObject builds the wire bytes for a String identity object
@@ -61,11 +60,8 @@ func newPluginWithClient(t *testing.T) (*Plugin, *fakeTransport, uint32) {
 		ReceiveTimeout: 50 * time.Millisecond,
 	})
 	c.nextMTID = 1000
-	p := &Plugin{
-		logger:  slog.Default(),
-		client:  c,
-		profile: &compliance.Profile{},
-	}
+	// Base gives every connector a profile without a constructor call.
+	p := &Plugin{logger: slog.Default(), client: c}
 	return p, ft, 1000
 }
 
@@ -95,7 +91,7 @@ func TestGetIdentity_HappyPath(t *testing.T) {
 	if id.HwRev != "100" {
 		t.Fatalf("HwRev = %q, want 100", id.HwRev)
 	}
-	if got := p.profile.Snapshot()[IdentityNAK]; got != 0 {
+	if got := p.ComplianceProfile().Snapshot()[IdentityNAK]; got != 0 {
 		t.Fatalf("IdentityNAK fired %d times, want 0", got)
 	}
 }
@@ -113,7 +109,7 @@ func TestGetIdentity_CardLabelNAK_FiresComplianceEvent(t *testing.T) {
 	if !errors.Is(err, consumer.ErrIdentityUnresolved) {
 		t.Fatalf("err = %v, want ErrIdentityUnresolved", err)
 	}
-	if got := p.profile.Snapshot()[IdentityNAK]; got != 1 {
+	if got := p.ComplianceProfile().Snapshot()[IdentityNAK]; got != 1 {
 		t.Fatalf("IdentityNAK fired %d times, want 1", got)
 	}
 }
@@ -140,7 +136,7 @@ func TestGetIdentity_PartialIdentity_OnSwRevNAK(t *testing.T) {
 		t.Fatalf("partial identity wrong: %+v", id)
 	}
 	// Soft-NAK must NOT trip the IdentityNAK compliance event.
-	if got := p.profile.Snapshot()[IdentityNAK]; got != 0 {
+	if got := p.ComplianceProfile().Snapshot()[IdentityNAK]; got != 0 {
 		t.Fatalf("IdentityNAK fired %d times, want 0", got)
 	}
 }

--- a/internal/acp1/consumer/metrics_test.go
+++ b/internal/acp1/consumer/metrics_test.go
@@ -26,13 +26,13 @@ func TestPluginExposesMetrics(t *testing.T) {
 // timestamp identically; whichever one a session resolves to, the counters
 // mean the same thing.
 func TestClientHooksCountAndTimestampBothWays(t *testing.T) {
-	p := &Plugin{tsSink: &timestampSink{}, met: metrics.NewConnector()}
+	p := &Plugin{tsSink: &timestampSink{}}
 	cfg := p.clientHooks()
 
 	cfg.OnRx(41)
 	cfg.OnTx(7)
 
-	snap := p.met.Snapshot()
+	snap := p.Metrics().Snapshot()
 	if snap.RxFrames != 1 || snap.RxBytes != 41 {
 		t.Errorf("rx = %d frames / %d bytes, want 1 / 41", snap.RxFrames, snap.RxBytes)
 	}

--- a/internal/acp1/consumer/plugin.go
+++ b/internal/acp1/consumer/plugin.go
@@ -12,8 +12,6 @@ import (
 
 	"dhs/internal/acp1/codec"
 	"dhs/internal/consumer"
-	"dhs/internal/consumer/compliance"
-	"dhs/internal/metrics"
 	"dhs/internal/transport"
 )
 
@@ -37,8 +35,8 @@ func (f *Factory) Meta() consumer.ProtocolMeta {
 
 func (f *Factory) New(deps plugin.Deps) consumer.Protocol {
 	deps = deps.WithDefaults()
-	p := &Plugin{logger: deps.Logger, met: deps.Metrics}
-	p.Configure(deps.Net, acp1StaleAfter)
+	p := &Plugin{logger: deps.Logger}
+	p.Init(deps, acp1StaleAfter)
 	return p
 }
 
@@ -108,13 +106,9 @@ type Plugin struct {
 	// ACP1 contributes only the stale window, the time source and —
 	// the part that used to be wrong — which network it is actually
 	// talking over.
-	consumer.Health
+	consumer.Base
 
 	logger *slog.Logger
-
-	// met counts every frame in and out. Supplied rather than created, so
-	// the process scrapes every connector from one place. Always non-nil.
-	met *metrics.Connector
 
 	mu        sync.Mutex
 	transport TransportKind
@@ -146,17 +140,9 @@ type Plugin struct {
 
 	subHandles map[subKey]SubHandle
 
-	// Optional traffic capture for unit test data generation.
-	recorder *transport.Recorder
-
 	// dialer opens the AN2 (Mode C) socket. Injected rather than built
 	// inline so the pipe is substitutable — see dial() for the default.
 	dialer transport.Dialer
-
-	// profile aggregates wire-tolerance events observed during this
-	// session. See compliance_events.go for the catalog. Nil until
-	// Connect fires; callers read via ComplianceProfile().
-	profile *compliance.Profile
 
 	// tsSink tracks the most-recent rx/tx wire timestamps so
 	// SessionHealth() can compute Live without blocking. Nil until
@@ -175,23 +161,6 @@ type Plugin struct {
 	// failure on the connected port can't be forced cross-platform with
 	// SO_REUSEADDR enabled).
 	newListener func(logger *slog.Logger, port int) (*Listener, error)
-}
-
-// ComplianceProfile returns the session-scoped compliance profile.
-// Returns nil if Connect hasn't been called yet. Safe to call from
-// any goroutine.
-func (p *Plugin) ComplianceProfile() *compliance.Profile {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.profile
-}
-
-// SetRecorder attaches a traffic recorder to this plugin.
-// Call before Connect. All sent and received frames are recorded.
-func (p *Plugin) SetRecorder(rec *transport.Recorder) {
-	p.mu.Lock()
-	p.recorder = rec
-	p.mu.Unlock()
 }
 
 // SetTransport selects UDP or TCP for subsequent Connect calls. Must be
@@ -282,12 +251,11 @@ func (p *Plugin) Connect(ctx context.Context, ip string, port int) error {
 	cfg := defaultCacheConfig()
 	p.trees = newSlotTreeCache(cfg.MaxSize, cfg.TTL)
 	p.subHandles = map[subKey]SubHandle{}
-	p.profile = &compliance.Profile{}
 	// p.tsSink is guaranteed non-nil here: every transport path
 	// (connectUDP/connectTCP/connectAN2 above) allocates it before
 	// returning, so the former `if p.tsSink == nil` guard was unreachable.
 	p.walker = NewWalker(p.client)
-	p.walker.SetProfile(p.profile)
+	p.walker.SetProfile(p.ComplianceProfile())
 	p.logger.Info("acp1 connected",
 		"host", ip, "port", port, "transport", p.transport)
 
@@ -309,15 +277,6 @@ func (p *Plugin) Connect(ctx context.Context, ip string, port int) error {
 	return nil
 }
 
-// Metrics returns the connector's counter set — frames and bytes in and
-// out, plus errors and latency. Satisfies the optional interface the CLI
-// type-asserts for --metrics-addr. Always non-nil.
-func (p *Plugin) Metrics() *metrics.Connector {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.met
-}
-
 // clientHooks is the one place the rx/tx taps are built, so all three
 // transports (UDP, TCP direct, AN2) count and timestamp identically.
 //
@@ -325,7 +284,7 @@ func (p *Plugin) Metrics() *metrics.Connector {
 // count, not a decoded message, and ACP1's command axis (MCODE) is inside
 // the frame. Frames and bytes are what the scrape was missing entirely.
 func (p *Plugin) clientHooks() ClientConfig {
-	sink, met := p.tsSink, p.met
+	sink, met := p.tsSink, p.Metrics()
 	return ClientConfig{
 		OnRx: func(n int) {
 			if sink != nil {
@@ -356,15 +315,15 @@ func (p *Plugin) connectUDP(ctx context.Context, ip string, port int) error {
 	}
 	p.udpConn = conn
 	var tr Transport = conn
-	if p.recorder != nil {
-		tr = p.recorder.WrapTransport(conn, "acp1")
+	if rec := p.Recorder(); rec != nil {
+		tr = rec.WrapTransport(conn, "acp1")
 	}
 	// Wrap with timestamp tap so SessionHealth (#266) sees rx/tx
 	// activity without each call needing to probe the wire.
 	if p.tsSink == nil {
 		p.tsSink = &timestampSink{}
 	}
-	tr = &timestampingTransport{inner: tr, sink: p.tsSink, met: p.met}
+	tr = &timestampingTransport{inner: tr, sink: p.tsSink, met: p.Metrics()}
 	p.client = NewClient(tr, p.logger, ClientConfig{})
 
 	mkListener := p.newListener
@@ -470,9 +429,7 @@ func (p *Plugin) Disconnect() error {
 	// One-line session summary, the same shape probel has emitted since the
 	// metrics work landed. Most consumer verbs are one-shot, so this is
 	// where the counters become visible at all.
-	if p.met != nil {
-		p.logger.Info("acp1 session metrics", slog.String("summary", p.met.Summary()))
-	}
+	p.logger.Info("acp1 session metrics", slog.String("summary", p.Metrics().Summary()))
 	p.walker = nil
 	p.trees = nil
 	p.subHandles = nil

--- a/internal/acp2/consumer/io_coverage_test.go
+++ b/internal/acp2/consumer/io_coverage_test.go
@@ -370,9 +370,14 @@ func TestAccessors_RecorderProfileWalkProgress(t *testing.T) {
 		Interval: consumer.DisableInterval,
 		Timeout:  consumer.DisableTimeout,
 	})
-	// Before Connect: no profile.
-	if p.ComplianceProfile() != nil {
-		t.Error("ComplianceProfile non-nil before Connect")
+	// The profile exists from the start and survives reconnects. It used to
+	// be nil until Connect and replaced on every Connect, which threw away
+	// every deviation seen before a link blip — and made every caller carry
+	// a nil check, including cmd/dhs, which type-asserts and calls this
+	// straight.
+	before := p.ComplianceProfile()
+	if before == nil {
+		t.Error("ComplianceProfile must never be nil")
 	}
 	rec, err := transport.NewRecorder(t.TempDir() + "/cap.jsonl")
 	if err != nil {
@@ -390,9 +395,10 @@ func TestAccessors_RecorderProfileWalkProgress(t *testing.T) {
 	}
 	defer func() { _ = p.Disconnect() }()
 
-	// After Connect: profile exists.
-	if p.ComplianceProfile() == nil {
-		t.Error("ComplianceProfile nil after Connect")
+	// Connect attaches that same profile to the session rather than
+	// installing a fresh one.
+	if got := p.ComplianceProfile(); got != before {
+		t.Error("Connect replaced the profile instead of reusing it")
 	}
 	_ = progressCount
 }

--- a/internal/acp2/consumer/plugin.go
+++ b/internal/acp2/consumer/plugin.go
@@ -2,7 +2,6 @@ package acp2
 
 import (
 	"context"
-	"dhs/internal/metrics"
 	"dhs/internal/plugin"
 	"encoding/binary"
 	"fmt"
@@ -14,7 +13,6 @@ import (
 
 	"dhs/internal/acp2/codec"
 	"dhs/internal/consumer"
-	"dhs/internal/consumer/compliance"
 	"dhs/internal/transport"
 )
 
@@ -38,8 +36,8 @@ func (f *Factory) Meta() consumer.ProtocolMeta {
 
 func (f *Factory) New(deps plugin.Deps) consumer.Protocol {
 	deps = deps.WithDefaults()
-	p := &Plugin{logger: deps.Logger, net: deps.Net, metrics: deps.Metrics}
-	p.Configure(deps.Net, acp2StaleAfter)
+	p := &Plugin{logger: deps.Logger, net: deps.Net}
+	p.Init(deps, acp2StaleAfter)
 	return p
 }
 
@@ -47,18 +45,16 @@ func (f *Factory) New(deps plugin.Deps) consumer.Protocol {
 // device. Internally it holds an AN2 Session for transport, a Walker for
 // tree traversal, and per-slot caches of walked trees.
 type Plugin struct {
-	// Health supplies SessionHealth. Inherited, not reimplemented:
-	// what is ACP2-specific is only the stale window and the time
-	// source, which Connect hands over.
-	consumer.Health
+	// Base supplies health, metrics, the compliance profile and the
+	// capture recorder — the four concerns that are not ACP2's. What is
+	// ACP2-specific is only the stale window and the time source, which
+	// Connect hands over.
+	consumer.Base
 
 	logger *slog.Logger
 
 	// net is the only way this plugin reaches a socket. Injected.
 	net transport.Net
-
-	// metrics is supplied rather than created.
-	metrics *metrics.Connector
 
 	mu      sync.Mutex
 	session *Session
@@ -83,16 +79,8 @@ type Plugin struct {
 	// and after Disconnect; non-nil between.
 	rc *reconnectState
 
-	// Optional traffic capture.
-	recorder *transport.Recorder
-
 	// Optional walk progress callback.
 	walkProgress WalkProgressFunc
-
-	// profile aggregates wire-tolerance events observed during this
-	// session. See compliance_events.go for the catalog. Nil until
-	// Connect fires; callers read via ComplianceProfile().
-	profile *compliance.Profile
 
 	// kaCfg captures the operator's --keepalive / --keepalive-timeout
 	// choice (set via SetKeepAlive). Zero values mean "use plugin
@@ -215,15 +203,6 @@ func decodeStringlyOptionsMap(v any) map[uint32]string {
 	return nil
 }
 
-// ComplianceProfile returns the session-scoped compliance profile.
-// Returns nil if Connect hasn't been called yet. Safe to call from
-// any goroutine.
-func (p *Plugin) ComplianceProfile() *compliance.Profile {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.profile
-}
-
 // subKey canonicalises a ValueRequest for map lookup.
 type subKey struct {
 	slot  int
@@ -245,13 +224,6 @@ type activeSubscription struct {
 	sessionID int
 }
 
-// SetRecorder attaches a traffic recorder. Call before Connect.
-func (p *Plugin) SetRecorder(rec *transport.Recorder) {
-	p.mu.Lock()
-	p.recorder = rec
-	p.mu.Unlock()
-}
-
 // SetWalkProgress sets a callback invoked for each object during Walk.
 // Allows the CLI to print objects as they're discovered (streaming output).
 func (p *Plugin) SetWalkProgress(fn WalkProgressFunc) {
@@ -261,16 +233,6 @@ func (p *Plugin) SetWalkProgress(fn WalkProgressFunc) {
 	}
 	p.walkProgress = fn
 	p.mu.Unlock()
-}
-
-// Metrics returns the connector's counter set — frames and bytes in and out
-// attributed by AN2 Type, plus errors and latency. Satisfies the optional
-// interface the CLI type-asserts for --metrics-addr. Always non-nil, because
-// plugin.Deps.WithDefaults fills it.
-func (p *Plugin) Metrics() *metrics.Connector {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.metrics
 }
 
 // Connect establishes the AN2/TCP connection and runs the full handshake:
@@ -284,9 +246,9 @@ func (p *Plugin) Connect(ctx context.Context, ip string, port int) error {
 	}
 
 	s := NewSession(p.net, p.logger)
-	s.SetMetrics(p.metrics)
-	if p.recorder != nil {
-		s.SetRecorder(p.recorder)
+	s.SetMetrics(p.Metrics())
+	if rec := p.Recorder(); rec != nil {
+		s.SetRecorder(rec)
 	}
 	if err := s.Connect(ctx, ip, port); err != nil {
 		return err
@@ -310,8 +272,11 @@ func (p *Plugin) Connect(ctx context.Context, ip string, port int) error {
 	if p.activeSubs == nil {
 		p.activeSubs = make(map[subKey]*activeSubscription)
 	}
-	p.profile = &compliance.Profile{}
-	s.SetProfile(p.profile)
+	// The profile is connector-scoped, not per-session: it used to be
+	// replaced on every Connect, which threw away every deviation observed
+	// before a reconnect. probel already kept its own across Disconnect for
+	// exactly that reason.
+	s.SetProfile(p.ComplianceProfile())
 	// Start the keep-alive prober + watchdog (mirrors ACP1).
 	// context.Background() is intentional: the keepalive lives for the
 	// life of the session, not the caller's Connect ctx — we cancel
@@ -343,9 +308,7 @@ func (p *Plugin) Disconnect() error {
 	// One-line session summary, the same shape probel has emitted since the
 	// metrics work landed. Most consumer verbs are one-shot, so this is
 	// where the counters become visible at all.
-	if p.metrics != nil {
-		p.logger.Info("acp2 session metrics", slog.String("summary", p.metrics.Summary()))
-	}
+	p.logger.Info("acp2 session metrics", slog.String("summary", p.Metrics().Summary()))
 	if p.trees != nil {
 		p.trees.Clear()
 	}

--- a/internal/cerebrum-nb/consumer/plugin.go
+++ b/internal/cerebrum-nb/consumer/plugin.go
@@ -15,7 +15,6 @@ import (
 
 	"dhs/internal/cerebrum-nb/codec"
 	"dhs/internal/consumer"
-	"dhs/internal/metrics"
 	"dhs/internal/transport"
 )
 
@@ -41,10 +40,7 @@ func (f *Factory) Meta() consumer.ProtocolMeta {
 func (f *Factory) New(deps plugin.Deps) consumer.Protocol {
 	deps = deps.WithDefaults()
 	p := NewPlugin(deps.Logger)
-	if deps.Metrics != nil {
-		p.met = deps.Metrics
-	}
-	p.Configure(deps.Net, defaultKeepAliveTimeout)
+	p.Init(deps, defaultKeepAliveTimeout)
 	return p
 }
 
@@ -55,13 +51,9 @@ type Plugin struct {
 	// Health supplies SessionHealth. Inherited, not reimplemented: what is
 	// Cerebrum's is the stale window — the keep-alive timeout it already
 	// judges a dead link by — and the Session as the time source.
-	consumer.Health
+	consumer.Base
 
 	logger *slog.Logger
-
-	// met counts every XML document in and out. Supplied rather than
-	// created, so the process scrapes every connector from one place.
-	met *metrics.Connector
 
 	// Username / Password come from CLI flags or the
 	// DHS_CEREBRUM_USER / DHS_CEREBRUM_PASS env vars. Optional —
@@ -105,14 +97,11 @@ func NewPlugin(logger *slog.Logger) *Plugin {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	// The connector is created here rather than only in the factory: the
-	// CLI builds this plugin directly with NewPlugin, so a nil default
-	// would leave every command-line session uncounted. Deps.Metrics
-	// overrides it in Factory.New when there is one to share.
-	return &Plugin{
-		logger: logger.With(slog.String("plugin", "cerebrum-nb")),
-		met:    metrics.NewConnector(),
-	}
+	// No connector to create here any more: Base supplies one on demand,
+	// which is what NewPlugin needed. The CLI builds this plugin directly
+	// rather than through the factory, so a field that only the factory
+	// filled left every command-line session uncounted.
+	return &Plugin{logger: logger.With(slog.String("plugin", "cerebrum-nb"))}
 }
 
 // Connect dials the Cerebrum WebSocket endpoint. Cerebrum has no path
@@ -159,7 +148,7 @@ func (p *Plugin) Connect(ctx context.Context, host string, port int) error {
 	sess, err := newSession(ctx, p.logger, url, transport.TLSOptions{
 		Enable:   p.UseTLS,
 		Insecure: p.InsecureSkipVerify,
-	}, rec, p.met)
+	}, rec, p.Metrics())
 	if err != nil {
 		_ = rec.Close() // nil-safe; don't leak the file on dial failure
 		return err
@@ -201,9 +190,7 @@ func (p *Plugin) Disconnect() error {
 	sess := p.session
 	p.session = nil
 	p.Closed()
-	if p.met != nil {
-		p.logger.Info("cerebrum-nb session metrics", slog.String("summary", p.met.Summary()))
-	}
+	p.logger.Info("cerebrum-nb session metrics", slog.String("summary", p.Metrics().Summary()))
 	p.mu.Unlock()
 	if sess == nil {
 		return nil
@@ -304,15 +291,6 @@ func (p *Plugin) SetValue(ctx context.Context, req consumer.ValueRequest, val co
 // canonical DEVICE.SUB.OBJECT… paths onto §5.4 VALUE subscriptions.
 // Routing/category/salvo subscriptions keep their precise §5 addressing
 // through Session.Subscribe<X> (the Matrix-template half).
-
-// Metrics returns the connector's counter set — XML documents and bytes in
-// and out, plus errors. Satisfies the optional interface the CLI
-// type-asserts for --metrics-addr.
-func (p *Plugin) Metrics() *metrics.Connector {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.met
-}
 
 // sessionTimes adapts a Session to consumer.RxTxTimes.
 //

--- a/internal/consumer/base.go
+++ b/internal/consumer/base.go
@@ -1,0 +1,102 @@
+package consumer
+
+import (
+	"sync"
+	"time"
+
+	"dhs/internal/consumer/compliance"
+	"dhs/internal/metrics"
+	"dhs/internal/plugin"
+	"dhs/internal/transport"
+)
+
+// Base is the half of a connector that is not about its protocol.
+//
+// Four concerns cut across every connector in this repo and none of them is
+// protocol-specific: liveness, counters, spec-deviation events, and traffic
+// capture. Each was nevertheless written per connector, so the same field
+// and the same accessor existed five to eight times over — SetRecorder was
+// byte-for-byte identical in five packages, ComplianceProfile in five,
+// Metrics in eight. Duplication at that scale does not stay identical: it
+// drifts, one copy at a time, and the drift is invisible because each copy
+// looks correct on its own. That is exactly how the transport work started,
+// with six of eight accept paths missing SO_KEEPALIVE.
+//
+// A connector embeds Base and gets all four. What stays its own is the
+// codec and the session — the parts that genuinely differ.
+//
+// Embedded BY VALUE, and its zero value works. An embedded pointer would be
+// nil in every test that builds a connector as a bare struct literal, and
+// this repo has well over a hundred of those; the panic would surface at
+// the first accessor rather than at the missing assignment.
+type Base struct {
+	// Health supplies SessionHealth, Opened/Closed and the rx/tx stamps.
+	Health
+
+	// mu guards the three below. It is deliberately NOT the connector's own
+	// mutex: these are independent of whatever protocol state that lock
+	// protects, and sharing one lock across both would mean a metrics read
+	// waits behind a walk.
+	mu       sync.Mutex
+	profile  *compliance.Profile
+	metrics  *metrics.Connector
+	recorder *transport.Recorder
+}
+
+// Init wires the cross-cutting concerns from the injected dependency set.
+// Called once at the top of a connector's factory, in place of the four
+// assignments it replaces.
+//
+// stale is the protocol's own silence threshold, which is the one part of
+// this that a connector genuinely decides (ACP1/ACP2 90s, Ember+ 30s,
+// TSL 5s). Pass 0 to take consumer.DefaultStaleAfter.
+func (b *Base) Init(deps plugin.Deps, stale time.Duration) {
+	deps = deps.WithDefaults()
+	b.Configure(deps.Net, stale)
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.metrics = deps.Metrics
+	if b.profile == nil {
+		b.profile = &compliance.Profile{}
+	}
+}
+
+// ComplianceProfile returns the connector's spec-deviation profile. Never
+// nil after Init; a connector built without it gets one on first use, so a
+// deviation is never dropped for want of a constructor call.
+func (b *Base) ComplianceProfile() *compliance.Profile {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.profile == nil {
+		b.profile = &compliance.Profile{}
+	}
+	return b.profile
+}
+
+// Metrics returns the connector's counter set, satisfying the optional
+// interface the CLI type-asserts for --metrics-addr. Never nil.
+func (b *Base) Metrics() *metrics.Connector {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.metrics == nil {
+		b.metrics = metrics.NewConnector()
+	}
+	return b.metrics
+}
+
+// SetRecorder attaches a traffic recorder, or clears it with nil. Safe at
+// any time; a session reads it through Recorder when it writes a frame.
+func (b *Base) SetRecorder(rec *transport.Recorder) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.recorder = rec
+}
+
+// Recorder returns the attached recorder, or nil. transport.Recorder's
+// methods are nil-safe, so a caller does not have to check.
+func (b *Base) Recorder() *transport.Recorder {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.recorder
+}

--- a/internal/consumer/base_test.go
+++ b/internal/consumer/base_test.go
@@ -1,0 +1,157 @@
+package consumer
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"dhs/internal/metrics"
+	"dhs/internal/plugin"
+	"dhs/internal/transport"
+)
+
+// The zero value has to work. This repo builds connectors as bare struct
+// literals in well over a hundred tests, and an embedded type that needed a
+// constructor would be a nil field in every one of them — surfacing as a
+// panic at the first accessor rather than at the missing assignment.
+func TestZeroBaseIsUsable(t *testing.T) {
+	var b Base
+
+	if b.ComplianceProfile() == nil {
+		t.Error("ComplianceProfile must never be nil")
+	}
+	if b.Metrics() == nil {
+		t.Error("Metrics must never be nil")
+	}
+	if b.Recorder() != nil {
+		t.Error("Recorder starts absent")
+	}
+	if got := b.SessionHealth(context.Background()); got.Connected || got.Live {
+		t.Errorf("nothing is open on a zero Base, got %+v", got)
+	}
+}
+
+// Init is the one call a factory makes in place of the four assignments it
+// replaces, and the stale window is the only part a connector really decides.
+func TestInitWiresTheDependencySet(t *testing.T) {
+	met := metrics.NewConnector()
+	var b Base
+	b.Init(plugin.Deps{Metrics: met}, 5*time.Second)
+
+	if b.Metrics() != met {
+		t.Error("Init must keep the supplied Connector, not replace it")
+	}
+	if got := b.SessionHealth(context.Background()); got.StaleAfter != 5*time.Second {
+		t.Errorf("StaleAfter = %v, want the protocol's own 5s", got.StaleAfter)
+	}
+}
+
+// A connector that names no window takes the shared default rather than
+// zero, which would make every session instantly stale.
+func TestInitWithoutAWindowTakesTheDefault(t *testing.T) {
+	var b Base
+	b.Init(plugin.Deps{}, 0)
+
+	if got := b.SessionHealth(context.Background()); got.StaleAfter != DefaultStaleAfter {
+		t.Errorf("StaleAfter = %v, want %v", got.StaleAfter, DefaultStaleAfter)
+	}
+	if b.Metrics() == nil {
+		t.Error("WithDefaults must have filled the Connector")
+	}
+}
+
+// Init is called from a factory, and a factory may run twice in a process.
+// The profile is the one thing that must survive, because a deviation
+// already recorded is evidence.
+func TestInitKeepsAnExistingProfile(t *testing.T) {
+	var b Base
+	first := b.ComplianceProfile()
+	b.Init(plugin.Deps{}, time.Second)
+
+	if b.ComplianceProfile() != first {
+		t.Error("Init replaced a profile that already existed")
+	}
+}
+
+func TestSetRecorderRoundTrips(t *testing.T) {
+	var b Base
+	rec := &transport.Recorder{}
+
+	b.SetRecorder(rec)
+	if b.Recorder() != rec {
+		t.Error("Recorder did not return what SetRecorder was given")
+	}
+
+	// Clearing it is how a capture is stopped.
+	b.SetRecorder(nil)
+	if b.Recorder() != nil {
+		t.Error("SetRecorder(nil) must clear the recorder")
+	}
+}
+
+// Base embeds Health, so a connector embedding Base satisfies HealthChecker
+// without naming it. That promotion is the whole point of the composition.
+func TestBaseSatisfiesHealthCheckerThroughEmbedding(t *testing.T) {
+	type connector struct{ Base }
+	var _ HealthChecker = (*connector)(nil)
+
+	c := &connector{}
+	c.Init(plugin.Deps{}, time.Minute)
+	c.Opened("tcp", "10.0.0.1", 2072, nil)
+	c.RecordRx()
+
+	got := c.SessionHealth(context.Background())
+	if !got.Connected || !got.Live {
+		t.Errorf("the embedded Health must work through Base, got %+v", got)
+	}
+	if c.Metrics() == nil || c.ComplianceProfile() == nil {
+		t.Error("the other three concerns must be promoted too")
+	}
+}
+
+// The accessors are reached from a read loop, a CLI verb and a metrics
+// scrape at the same time; none of them may race.
+func TestBaseIsConcurrencySafe(t *testing.T) {
+	var b Base
+	b.Init(plugin.Deps{}, time.Minute)
+	rec := &transport.Recorder{}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(4)
+		go func() { defer wg.Done(); _ = b.Metrics() }()
+		go func() { defer wg.Done(); _ = b.ComplianceProfile() }()
+		go func() { defer wg.Done(); b.SetRecorder(rec) }()
+		go func() { defer wg.Done(); _ = b.Recorder() }()
+	}
+	wg.Wait()
+}
+
+// Base's lock is deliberately not the connector's own: a metrics scrape must
+// not wait behind whatever protocol state that mutex guards. Reading through
+// Base while the connector's lock is held proves they are independent.
+func TestBaseLockIsIndependentOfTheConnectorLock(t *testing.T) {
+	type connector struct {
+		Base
+		mu sync.Mutex
+	}
+	c := &connector{}
+	c.Init(plugin.Deps{}, time.Minute)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = c.Metrics()
+		_ = c.ComplianceProfile()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Base blocked on the connector's mutex — the locks are not independent")
+	}
+}

--- a/internal/emberplus/consumer/canonicalize.go
+++ b/internal/emberplus/consumer/canonicalize.go
@@ -329,15 +329,11 @@ func (p *Plugin) enumMapToCanonical(glowMap map[int64]string, enumeration string
 			}
 			if isMasked(lbl) {
 				entry.Masked = true
-				if p.profile != nil {
-					p.profile.Note(EnumMaskedItem)
-				}
+				p.ComplianceProfile().Note(EnumMaskedItem)
 			}
 			entries = append(entries, entry)
 		}
-		if p.profile != nil {
-			p.profile.Note(EnumMapDerived)
-		}
+		p.ComplianceProfile().Note(EnumMapDerived)
 		return entries
 	}
 
@@ -350,9 +346,7 @@ func (p *Plugin) enumMapToCanonical(glowMap map[int64]string, enumeration string
 		}
 		if isMasked(k) {
 			entry.Masked = true
-			if p.profile != nil {
-				p.profile.Note(EnumMaskedItem)
-			}
+			p.ComplianceProfile().Note(EnumMaskedItem)
 		}
 		entries = append(entries, entry)
 	}
@@ -362,10 +356,10 @@ func (p *Plugin) enumMapToCanonical(glowMap map[int64]string, enumeration string
 	// Both forms present — fires only when they disagree on count,
 	// which we check via a quick length compare against the legacy
 	// enumeration split.
-	if enumeration != "" && p.profile != nil {
+	if enumeration != "" {
 		legacy := strings.Split(enumeration, "\n")
 		if len(legacy) != len(entries) {
-			p.profile.Note(EnumDoubleSource)
+			p.ComplianceProfile().Note(EnumDoubleSource)
 		}
 	}
 	return entries
@@ -388,14 +382,10 @@ func (p *Plugin) buildParameter(e *treeEntry) *canonical.Parameter {
 	if typeName == "" || typeName == "null" {
 		if inferred := inferParamType(pr.Value); inferred != "" {
 			typeName = inferred
-			if p.profile != nil {
-				p.profile.Note(FieldInferred)
-			}
+			p.ComplianceProfile().Note(FieldInferred)
 		} else {
 			typeName = canonical.ParamString
-			if p.profile != nil {
-				p.profile.Note(FieldInferred)
-			}
+			p.ComplianceProfile().Note(FieldInferred)
 		}
 	}
 

--- a/internal/emberplus/consumer/coverage_final_arms_test.go
+++ b/internal/emberplus/consumer/coverage_final_arms_test.go
@@ -425,10 +425,10 @@ func TestProcessParameter_StreamIDReannounceSamePath(t *testing.T) {
 			Type: glow.ParamTypeInteger, HasStreamIdentifier: true, StreamIdentifier: 5}}
 	}
 	p.handleElements([]glow.Element{mk()})
-	before := p.profile.Snapshot()[StreamIDCollisionNoDescriptor]
+	before := p.ComplianceProfile().Snapshot()[StreamIDCollisionNoDescriptor]
 	// Re-announce the SAME parameter (key "1") → isNewPath false → no Note.
 	p.handleElements([]glow.Element{mk()})
-	after := p.profile.Snapshot()[StreamIDCollisionNoDescriptor]
+	after := p.ComplianceProfile().Snapshot()[StreamIDCollisionNoDescriptor]
 	if after != before {
 		t.Errorf("re-announce of same stream path must not re-fire collision: %d → %d", before, after)
 	}

--- a/internal/emberplus/consumer/coverage_pipeline_arms_test.go
+++ b/internal/emberplus/consumer/coverage_pipeline_arms_test.go
@@ -108,7 +108,7 @@ func TestProcessParameter_StreamIDCollision(t *testing.T) {
 		{Parameter: &glow.Parameter{Number: 2, Identifier: "b", Type: glow.ParamTypeInteger,
 			HasStreamIdentifier: true, StreamIdentifier: 5}},
 	})
-	if p.profile.Snapshot()[StreamIDCollisionNoDescriptor] == 0 {
+	if p.ComplianceProfile().Snapshot()[StreamIDCollisionNoDescriptor] == 0 {
 		t.Error("expected StreamIDCollisionNoDescriptor compliance event")
 	}
 }

--- a/internal/emberplus/consumer/coverage_pipeline_test.go
+++ b/internal/emberplus/consumer/coverage_pipeline_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"dhs/internal/consumer"
-	"dhs/internal/consumer/compliance"
 	"dhs/internal/emberplus/codec/ber"
 	"dhs/internal/emberplus/codec/glow"
 	"dhs/internal/emberplus/codec/s101"
@@ -28,7 +27,6 @@ func newTreePlugin() *Plugin {
 	p.streamIndex = make(map[int64][]string)
 	p.templates = make(map[string]*glow.Template)
 	p.pendingSets = newPendingSetRegistry()
-	p.profile = &compliance.Profile{}
 	p.unknownCTX = newUnknownCTXAudit()
 	return p
 }
@@ -255,7 +253,7 @@ func TestProcessParameter_NonQualified(t *testing.T) {
 	if _, ok := p.numIndex["1.2"]; !ok {
 		t.Errorf("non-qualified child not indexed at 1.2; index=%v", keys(p.numIndex))
 	}
-	if p.profile.Snapshot()[NonQualifiedElement] == 0 {
+	if p.ComplianceProfile().Snapshot()[NonQualifiedElement] == 0 {
 		t.Error("NonQualifiedElement compliance event not fired")
 	}
 }

--- a/internal/emberplus/consumer/coverage_purehelpers_test.go
+++ b/internal/emberplus/consumer/coverage_purehelpers_test.go
@@ -311,7 +311,7 @@ func TestSplitFormatUnit(t *testing.T) {
 // masked item), the legacy-enumeration-derived path, and the empty
 // (nil) path.
 func TestEnumMapToCanonical(t *testing.T) {
-	p := &Plugin{profile: &compliance.Profile{}}
+	p := &Plugin{}
 
 	if got := p.enumMapToCanonical(nil, ""); got != nil {
 		t.Errorf("empty = %v, want nil", got)
@@ -332,14 +332,14 @@ func TestEnumMapToCanonical(t *testing.T) {
 	if len(legacy) != 3 || legacy[1].Key != "b" || !legacy[1].Masked {
 		t.Errorf("legacy = %+v", legacy)
 	}
-	if got := p.profile.Snapshot()[EnumMapDerived]; got != 1 {
+	if got := p.ComplianceProfile().Snapshot()[EnumMapDerived]; got != 1 {
 		t.Errorf("enum_map_derived = %d, want 1", got)
 	}
 
 	// Both present + count mismatch → EnumDoubleSource.
-	p2 := &Plugin{profile: &compliance.Profile{}}
+	p2 := &Plugin{}
 	p2.enumMapToCanonical(map[int64]string{0: "x"}, "x\ny")
-	if got := p2.profile.Snapshot()[EnumDoubleSource]; got != 1 {
+	if got := p2.ComplianceProfile().Snapshot()[EnumDoubleSource]; got != 1 {
 		t.Errorf("enum_double_source = %d, want 1", got)
 	}
 }

--- a/internal/emberplus/consumer/coverage_resolver2_test.go
+++ b/internal/emberplus/consumer/coverage_resolver2_test.go
@@ -3,13 +3,12 @@ package emberplus
 import (
 	"testing"
 
-	"dhs/internal/consumer/compliance"
 	"dhs/internal/export/canonical"
 )
 
 // TestResolve_NilElements covers resolve's nil-map early return.
 func TestResolve_NilElements(t *testing.T) {
-	p := &Plugin{profile: &compliance.Profile{}}
+	p := &Plugin{}
 	p.resolve(nil, nil, CanonicalOptions{Labels: "inline"})
 }
 
@@ -21,9 +20,9 @@ func TestResolveMatrixLabels_BasepathNotNode(t *testing.T) {
 	elements := map[string]canonical.Element{
 		"1.2": &canonical.Parameter{Header: canonical.Header{OID: "1.2"}}, // not a Node
 	}
-	p := &Plugin{profile: &compliance.Profile{}}
+	p := &Plugin{}
 	p.resolveMatrixLabels(m, elements, modeInline)
-	if got := p.profile.Snapshot()[MatrixLabelBasepathUnresolved]; got != 1 {
+	if got := p.ComplianceProfile().Snapshot()[MatrixLabelBasepathUnresolved]; got != 1 {
 		t.Errorf("basepath-not-node should fire unresolved: got %d", got)
 	}
 }
@@ -51,9 +50,9 @@ func TestResolveMatrixLabels_LevelMismatch(t *testing.T) {
 		"1.2": mkLevel("1.2", 2),
 		"1.3": mkLevel("1.3", 3), // different count → mismatch
 	}
-	p := &Plugin{profile: &compliance.Profile{}}
+	p := &Plugin{}
 	p.resolveMatrixLabels(m, elements, modeBoth)
-	if got := p.profile.Snapshot()[MatrixLabelLevelMismatch]; got != 1 {
+	if got := p.ComplianceProfile().Snapshot()[MatrixLabelLevelMismatch]; got != 1 {
 		t.Errorf("level mismatch should fire: got %d", got)
 	}
 }

--- a/internal/emberplus/consumer/coverage_resolver_test.go
+++ b/internal/emberplus/consumer/coverage_resolver_test.go
@@ -3,7 +3,6 @@ package emberplus
 import (
 	"testing"
 
-	"dhs/internal/consumer/compliance"
 	"dhs/internal/export/canonical"
 )
 
@@ -61,7 +60,7 @@ func TestResolveMatrixGain(t *testing.T) {
 	elements := map[string]canonical.Element{"1.2.1": m, "1.2.2": base}
 	walk(base, func(el canonical.Element) { elements[el.Common().OID] = el })
 
-	p := &Plugin{profile: &compliance.Profile{}}
+	p := &Plugin{}
 	p.resolveMatrixGain(m, elements, modeInline)
 
 	if got := m.TargetParams["0"]["gain"]; got != int64(3) {
@@ -77,7 +76,7 @@ func TestResolveMatrixGain(t *testing.T) {
 	if _, still := elements["1.2.2"]; still {
 		t.Error("inline mode must absorb parametersLocation base node")
 	}
-	if got := p.profile.Snapshot()[GainAbsorbed]; got != 1 {
+	if got := p.ComplianceProfile().Snapshot()[GainAbsorbed]; got != 1 {
 		t.Errorf("gain_absorbed = %d, want 1", got)
 	}
 }
@@ -87,7 +86,7 @@ func TestResolveMatrixGain(t *testing.T) {
 func TestResolveMatrixGain_EdgeCases(t *testing.T) {
 	// pointer mode: no-op.
 	m := &canonical.Matrix{ParametersLocation: sp("1.2.2")}
-	p := &Plugin{profile: &compliance.Profile{}}
+	p := &Plugin{}
 	p.resolveMatrixGain(m, map[string]canonical.Element{}, modePointer)
 	if m.TargetParams != nil {
 		t.Error("pointer mode must not populate")
@@ -100,7 +99,7 @@ func TestResolveMatrixGain_EdgeCases(t *testing.T) {
 	// unresolved pointer (not in map): warn event.
 	m3 := &canonical.Matrix{ParametersLocation: sp("9.9.9")}
 	p.resolveMatrixGain(m3, map[string]canonical.Element{}, modeInline)
-	if got := p.profile.Snapshot()[MatrixParametersLocationUnresolved]; got != 1 {
+	if got := p.ComplianceProfile().Snapshot()[MatrixParametersLocationUnresolved]; got != 1 {
 		t.Errorf("unresolved (missing) = %d, want 1", got)
 	}
 
@@ -108,7 +107,7 @@ func TestResolveMatrixGain_EdgeCases(t *testing.T) {
 	bad := &canonical.Parameter{Header: canonical.Header{OID: "1.2.2"}}
 	m4 := &canonical.Matrix{ParametersLocation: sp("1.2.2")}
 	p.resolveMatrixGain(m4, map[string]canonical.Element{"1.2.2": bad}, modeInline)
-	if got := p.profile.Snapshot()[MatrixParametersLocationUnresolved]; got != 2 {
+	if got := p.ComplianceProfile().Snapshot()[MatrixParametersLocationUnresolved]; got != 2 {
 		t.Errorf("unresolved (wrong type) = %d, want 2", got)
 	}
 }
@@ -184,7 +183,7 @@ func TestResolveTemplates(t *testing.T) {
 		{Number: 3, OID: "", Identifier: "no-oid", Template: paramTpl},
 	}
 
-	p := &Plugin{profile: &compliance.Profile{}}
+	p := &Plugin{}
 	p.resolveTemplates(elements, templates, modeInline)
 
 	if referrerParam.Type != canonical.ParamInteger || referrerParam.Unit == nil || *referrerParam.Unit != "dB" {
@@ -197,7 +196,7 @@ func TestResolveTemplates(t *testing.T) {
 		t.Errorf("node inflate failed: children=%d desc=%v", len(referrerNode.Children), referrerNode.Description)
 	}
 
-	snap := p.profile.Snapshot()
+	snap := p.ComplianceProfile().Snapshot()
 	if got := snap[TemplateAbsorbed]; got != 2 {
 		t.Errorf("template_absorbed = %d, want 2", got)
 	}
@@ -207,7 +206,7 @@ func TestResolveTemplates(t *testing.T) {
 	}
 
 	// pointer mode is a no-op.
-	p2 := &Plugin{profile: &compliance.Profile{}}
+	p2 := &Plugin{}
 	pn := &canonical.Parameter{Header: canonical.Header{OID: "1.1"}, TemplateReference: sp("10.1")}
 	els := map[string]canonical.Element{"1.1": pn}
 	p2.resolveTemplates(els, templates, modePointer)

--- a/internal/emberplus/consumer/coverage_stream_test.go
+++ b/internal/emberplus/consumer/coverage_stream_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"dhs/internal/consumer"
-	"dhs/internal/consumer/compliance"
 	"dhs/internal/emberplus/codec/glow"
 )
 
@@ -24,7 +23,6 @@ func newStreamTestPlugin(t *testing.T, streamID int64, desc *glow.StreamDescript
 		subs:        map[string]consumer.EventFunc{},
 		streamSubs:  map[string][]int32{},
 		streamIndex: map[int64][]string{},
-		profile:     &compliance.Profile{},
 	}
 	gp := &glow.Parameter{
 		Number:              1,

--- a/internal/emberplus/consumer/coverage_verb_arms_test.go
+++ b/internal/emberplus/consumer/coverage_verb_arms_test.go
@@ -171,7 +171,7 @@ func TestMatrixConnect_SourceStealAccepted(t *testing.T) {
 	if err := p.MatrixConnect(context.Background(), "mtx", 2, []int32{3}, glow.ConnOpAbsolute); err != nil {
 		t.Errorf("oneToOne source-steal connect should succeed: %v", err)
 	}
-	if p.profile.Snapshot()[OneToOneSourceStealAccepted] == 0 {
+	if p.ComplianceProfile().Snapshot()[OneToOneSourceStealAccepted] == 0 {
 		t.Error("expected OneToOneSourceStealAccepted compliance event")
 	}
 }

--- a/internal/emberplus/consumer/coverage_verbs_test.go
+++ b/internal/emberplus/consumer/coverage_verbs_test.go
@@ -27,7 +27,6 @@ func freshPlugin() *Plugin {
 		streamSubs:   map[string][]int32{},
 		streamIndex:  map[int64][]string{},
 		templates:    map[string]*glow.Template{},
-		profile:      &compliance.Profile{},
 		pendingSets:  newPendingSetRegistry(),
 	}
 }

--- a/internal/emberplus/consumer/plugin.go
+++ b/internal/emberplus/consumer/plugin.go
@@ -27,11 +27,8 @@ import (
 	"time"
 
 	"dhs/internal/consumer"
-	"dhs/internal/consumer/compliance"
 	"dhs/internal/emberplus/codec/glow"
 	"dhs/internal/emberplus/codec/matrix"
-	"dhs/internal/metrics"
-	"dhs/internal/transport"
 )
 
 func init() {
@@ -55,8 +52,8 @@ func (f *Factory) Meta() consumer.ProtocolMeta {
 // separate Plugin so cached tree state cannot cross devices.
 func (f *Factory) New(deps plugin.Deps) consumer.Protocol {
 	deps = deps.WithDefaults()
-	p := &Plugin{logger: deps.Logger, met: deps.Metrics}
-	p.Configure(deps.Net, emberStaleAfter)
+	p := &Plugin{logger: deps.Logger}
+	p.Init(deps, emberStaleAfter)
 	return p
 }
 
@@ -88,11 +85,7 @@ const (
 type Plugin struct {
 	// Health supplies SessionHealth. Inherited, not reimplemented: Ember+
 	// contributes the dead-man window and the Session as the time source.
-	consumer.Health
-
-	// met counts every frame in and out. Supplied rather than created, so
-	// the process scrapes every connector from one place. Always non-nil.
-	met *metrics.Connector
+	consumer.Base
 
 	logger  *slog.Logger
 	session *Session
@@ -152,17 +145,6 @@ type Plugin struct {
 	// Spec p.54–58 (Ember+ 1.4 Templates).
 	templates   map[string]*glow.Template
 	templatesMu sync.RWMutex
-
-	// profile tracks tolerance events (spec deviations absorbed
-	// during this session). Exposed via ComplianceProfile(); a
-	// summary line is logged on Disconnect. See compliance/profile.go
-	// and internal/emberplus/docs/consumer.md §A9.
-	profile *compliance.Profile
-
-	// recorder captures raw S101 frames (tx + rx) to a JSONL file
-	// when the CLI passed --capture. Shared with the Session so the
-	// reader/writer taps fire on every frame.
-	recorder *transport.Recorder
 
 	// connIP / connPort are captured at Connect time for log context.
 	connIP   string
@@ -280,24 +262,6 @@ func (p *Plugin) wildcardMatches(entry *treeEntry) bool {
 	return false
 }
 
-// ComplianceProfile returns the live compliance profile for this
-// connection. Callers use it to classify the peer provider (strict
-// vs partial) and to drive a compatibility matrix.
-func (p *Plugin) ComplianceProfile() *compliance.Profile {
-	return p.profile
-}
-
-// SetRecorder attaches a raw-traffic recorder to this plugin. When set,
-// every S101 frame (both TX and RX) is written to the recorder with
-// proto="emberplus" and the raw bytes include BOF/EOF/CRC, so the
-// capture file is sufficient input for replay-based unit tests.
-// Call before Connect.
-func (p *Plugin) SetRecorder(r *transport.Recorder) {
-	p.mu.Lock()
-	p.recorder = r
-	p.mu.Unlock()
-}
-
 // treeEntry is the in-RAM record per decoded element. It keeps both the
 // protocol-agnostic Object (consumed by CLI/format code) and the raw Glow
 // struct (consumed by matrix / invoke operations that need the numeric
@@ -346,7 +310,7 @@ type treeEntry struct {
 // keep-alive reply is received first.
 func (p *Plugin) Connect(ctx context.Context, ip string, port int) error {
 	s := NewSession(p.logger)
-	s.SetMetrics(p.met)
+	s.SetMetrics(p.Metrics())
 	p.mu.Lock()
 	p.session = s
 	p.Opened("tcp", ip, port, sessionTimes{s})
@@ -361,17 +325,16 @@ func (p *Plugin) Connect(ctx context.Context, ip string, port int) error {
 	p.streamIndex = make(map[int64][]string)
 	p.templates = make(map[string]*glow.Template)
 	p.pendingSets = newPendingSetRegistry()
-	p.profile = &compliance.Profile{}
 	p.connIP = ip
 	p.connPort = port
 	p.unknownCTX = newUnknownCTXAudit()
 	p.mu.Unlock()
 
 	s.SetOnElement(p.handleElements)
-	s.SetProfile(p.profile)
+	s.SetProfile(p.ComplianceProfile())
 	s.SetOnStateChange(p.onSessionStateChange)
-	if p.recorder != nil {
-		s.SetRecorder(p.recorder)
+	if rec := p.Recorder(); rec != nil {
+		s.SetRecorder(rec)
 	}
 	return s.Connect(ctx, ip, port)
 }
@@ -508,28 +471,24 @@ func (p *Plugin) Disconnect() error {
 
 	p.unsubscribeAll()
 
-	if p.profile != nil {
-		summary := p.profile.SummaryLine()
-		class := p.profile.Classification()
-		if summary == "" {
-			p.logger.Info("emberplus: compliance profile",
-				"host", p.connIP, "port", p.connPort,
-				"classification", class)
-		} else {
-			p.logger.Info("emberplus: compliance profile",
-				"host", p.connIP, "port", p.connPort,
-				"classification", class,
-				"deviations", summary)
-		}
+	summary := p.ComplianceProfile().SummaryLine()
+	class := p.ComplianceProfile().Classification()
+	if summary == "" {
+		p.logger.Info("emberplus: compliance profile",
+			"host", p.connIP, "port", p.connPort,
+			"classification", class)
+	} else {
+		p.logger.Info("emberplus: compliance profile",
+			"host", p.connIP, "port", p.connPort,
+			"classification", class,
+			"deviations", summary)
 	}
 
 	p.mu.Lock()
 	s := p.session
 	p.session = nil
 	p.Closed()
-	if p.met != nil {
-		p.logger.Info("emberplus session metrics", slog.String("summary", p.met.Summary()))
-	}
+	p.logger.Info("emberplus session metrics", slog.String("summary", p.Metrics().Summary()))
 	p.mu.Unlock()
 	if s != nil {
 		return s.Disconnect()
@@ -1134,7 +1093,7 @@ func (p *Plugin) MatrixConnect(ctx context.Context, matrixPath string, target in
 		// profile`. Refs #465.
 		if stolen := entry.matrixState.DetectOneToOneSourceSteal(target, sources); len(stolen) > 0 {
 			for _, pair := range stolen {
-				p.profile.Note(OneToOneSourceStealAccepted)
+				p.ComplianceProfile().Note(OneToOneSourceStealAccepted)
 				p.logger.Debug("emberplus: oneToOne source-steal accepted",
 					"matrix_path", matrixPath,
 					"target", target,
@@ -1297,7 +1256,7 @@ func (p *Plugin) resolveNumPath(explicit []int32, parent []int32, number int32) 
 	if len(explicit) > 0 {
 		return cloneInt32Slice(explicit)
 	}
-	p.profile.Note(NonQualifiedElement)
+	p.ComplianceProfile().Note(NonQualifiedElement)
 	// Provider speaks legacy non-qualified Glow (DTD <2.10). Pin the
 	// session so subscribe / unsubscribe / setvalue use the nested
 	// Node/Parameter chain wire form the provider's path index
@@ -2041,7 +2000,7 @@ func (p *Plugin) processParameter(param *glow.Parameter, parentPath []string, pa
 		// new registrant's side; duplicate-detection-on-existing would
 		// require re-reading numIndex entries here, which we avoid on
 		// the hot path.
-		if len(existing) > 0 && param.StreamDescriptor == nil && p.profile != nil {
+		if len(existing) > 0 && param.StreamDescriptor == nil {
 			isNewPath := true
 			for _, k := range existing {
 				if k == key {
@@ -2050,7 +2009,7 @@ func (p *Plugin) processParameter(param *glow.Parameter, parentPath []string, pa
 				}
 			}
 			if isNewPath {
-				p.profile.Note(StreamIDCollisionNoDescriptor)
+				p.ComplianceProfile().Note(StreamIDCollisionNoDescriptor)
 			}
 		}
 		p.streamIndex[param.StreamIdentifier] = appendUnique(existing, key)
@@ -2674,16 +2633,6 @@ func valueToGlow(val consumer.Value) any {
 		return val.Str
 	}
 	return val.Int
-}
-
-// Metrics returns the connector's counter set — S101 frames and bytes in
-// and out attributed by command byte, plus errors and latency. Satisfies the
-// optional interface the CLI type-asserts for --metrics-addr. Always
-// non-nil.
-func (p *Plugin) Metrics() *metrics.Connector {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.met
 }
 
 // sessionTimes adapts a Session to consumer.RxTxTimes. The session stamps rx

--- a/internal/emberplus/consumer/reconnect.go
+++ b/internal/emberplus/consumer/reconnect.go
@@ -135,10 +135,10 @@ func (p *Plugin) reconnectLoop(ctx context.Context) {
 		// dead and will be garbage-collected once nothing holds it.
 		s := NewSession(p.logger)
 		s.SetOnElement(p.handleElements)
-		s.SetProfile(p.profile)
+		s.SetProfile(p.ComplianceProfile())
 		s.SetOnStateChange(p.onSessionStateChange)
-		if p.recorder != nil {
-			s.SetRecorder(p.recorder)
+		if rec := p.Recorder(); rec != nil {
+			s.SetRecorder(rec)
 		}
 
 		dialCtx, cancel := context.WithTimeout(ctx, 10*time.Second)

--- a/internal/emberplus/consumer/resolver.go
+++ b/internal/emberplus/consumer/resolver.go
@@ -68,9 +68,7 @@ func (p *Plugin) resolveMatrixLabels(m *canonical.Matrix, elements map[string]ca
 	}
 
 	if len(m.Labels) == 0 {
-		if p.profile != nil {
-			p.profile.Note(MatrixLabelNone)
-		}
+		p.ComplianceProfile().Note(MatrixLabelNone)
 		return
 	}
 
@@ -84,23 +82,17 @@ func (p *Plugin) resolveMatrixLabels(m *canonical.Matrix, elements map[string]ca
 			key = *lbl.Description
 		} else {
 			key = lbl.BasePath
-			if p.profile != nil {
-				p.profile.Note(MatrixLabelDescriptionEmpty)
-			}
+			p.ComplianceProfile().Note(MatrixLabelDescriptionEmpty)
 		}
 
 		base, ok := elements[lbl.BasePath]
 		if !ok {
-			if p.profile != nil {
-				p.profile.Note(MatrixLabelBasepathUnresolved)
-			}
+			p.ComplianceProfile().Note(MatrixLabelBasepathUnresolved)
 			continue
 		}
 		baseNode, ok := base.(*canonical.Node)
 		if !ok {
-			if p.profile != nil {
-				p.profile.Note(MatrixLabelBasepathUnresolved)
-			}
+			p.ComplianceProfile().Note(MatrixLabelBasepathUnresolved)
 			continue
 		}
 
@@ -122,9 +114,7 @@ func (p *Plugin) resolveMatrixLabels(m *canonical.Matrix, elements map[string]ca
 	}
 
 	if mismatched(targetLabels) || mismatched(sourceLabels) {
-		if p.profile != nil {
-			p.profile.Note(MatrixLabelLevelMismatch)
-		}
+		p.ComplianceProfile().Note(MatrixLabelLevelMismatch)
 	}
 
 	if len(targetLabels) > 0 {
@@ -136,9 +126,7 @@ func (p *Plugin) resolveMatrixLabels(m *canonical.Matrix, elements map[string]ca
 
 	if mode == modeInline && len(absorb) > 0 {
 		removeFromTree(elements, absorb)
-		if p.profile != nil {
-			p.profile.Note(LabelsAbsorbed)
-		}
+		p.ComplianceProfile().Note(LabelsAbsorbed)
 	}
 }
 
@@ -161,16 +149,12 @@ func (p *Plugin) resolveMatrixGain(m *canonical.Matrix, elements map[string]cano
 
 	base, ok := elements[*m.ParametersLocation]
 	if !ok {
-		if p.profile != nil {
-			p.profile.Note(MatrixParametersLocationUnresolved)
-		}
+		p.ComplianceProfile().Note(MatrixParametersLocationUnresolved)
 		return
 	}
 	baseNode, ok := base.(*canonical.Node)
 	if !ok {
-		if p.profile != nil {
-			p.profile.Note(MatrixParametersLocationUnresolved)
-		}
+		p.ComplianceProfile().Note(MatrixParametersLocationUnresolved)
 		return
 	}
 
@@ -193,9 +177,7 @@ func (p *Plugin) resolveMatrixGain(m *canonical.Matrix, elements map[string]cano
 
 	if mode == modeInline {
 		removeFromTree(elements, []string{*m.ParametersLocation})
-		if p.profile != nil {
-			p.profile.Note(GainAbsorbed)
-		}
+		p.ComplianceProfile().Note(GainAbsorbed)
 	}
 }
 
@@ -238,20 +220,14 @@ func (p *Plugin) resolveTemplates(elements map[string]canonical.Element, templat
 		}
 		t, ok := index[*ref]
 		if !ok || t == nil || t.Template == nil {
-			if p.profile != nil {
-				p.profile.Note(TemplateReferenceUnresolved)
-			}
+			p.ComplianceProfile().Note(TemplateReferenceUnresolved)
 			continue
 		}
 		if !inflateTemplate(el, t.Template) {
-			if p.profile != nil {
-				p.profile.Note(TemplateReferenceUnresolved)
-			}
+			p.ComplianceProfile().Note(TemplateReferenceUnresolved)
 			continue
 		}
-		if p.profile != nil {
-			p.profile.Note(TemplateAbsorbed)
-		}
+		p.ComplianceProfile().Note(TemplateAbsorbed)
 	}
 }
 

--- a/internal/emberplus/consumer/resolver_test.go
+++ b/internal/emberplus/consumer/resolver_test.go
@@ -3,7 +3,6 @@ package emberplus
 import (
 	"testing"
 
-	"dhs/internal/consumer/compliance"
 	"dhs/internal/export/canonical"
 )
 
@@ -20,7 +19,7 @@ import (
 //   - labels_absorbed fires once (per matrix, not per level)
 func TestResolveMatrixLabels_MultiLevel(t *testing.T) {
 	m, elements := buildMultiLevelMatrixTree()
-	p := &Plugin{profile: &compliance.Profile{}}
+	p := &Plugin{}
 
 	p.resolveMatrixLabels(m, elements, modeInline)
 
@@ -53,7 +52,7 @@ func TestResolveMatrixLabels_MultiLevel(t *testing.T) {
 	}
 
 	// Compliance event should fire exactly once per matrix.
-	snap := p.profile.Snapshot()
+	snap := p.ComplianceProfile().Snapshot()
 	if got := snap[LabelsAbsorbed]; got != 1 {
 		t.Errorf("labels_absorbed count = %d, want 1", got)
 	}
@@ -65,7 +64,7 @@ func TestResolveMatrixLabels_MultiLevel(t *testing.T) {
 func TestResolveMatrixLabels_Pointer(t *testing.T) {
 	m, elements := buildMultiLevelMatrixTree()
 	beforeCount := len(elements)
-	p := &Plugin{profile: &compliance.Profile{}}
+	p := &Plugin{}
 
 	p.resolveMatrixLabels(m, elements, modePointer)
 
@@ -78,7 +77,7 @@ func TestResolveMatrixLabels_Pointer(t *testing.T) {
 	if len(elements) != beforeCount {
 		t.Errorf("pointer mode must not mutate elements; before=%d after=%d", beforeCount, len(elements))
 	}
-	if got := p.profile.Snapshot()[LabelsAbsorbed]; got != 0 {
+	if got := p.ComplianceProfile().Snapshot()[LabelsAbsorbed]; got != 0 {
 		t.Errorf("pointer mode must not fire labels_absorbed; got %d", got)
 	}
 }
@@ -89,7 +88,7 @@ func TestResolveMatrixLabels_Pointer(t *testing.T) {
 func TestResolveMatrixLabels_Both(t *testing.T) {
 	m, elements := buildMultiLevelMatrixTree()
 	beforeCount := len(elements)
-	p := &Plugin{profile: &compliance.Profile{}}
+	p := &Plugin{}
 
 	p.resolveMatrixLabels(m, elements, modeBoth)
 
@@ -99,7 +98,7 @@ func TestResolveMatrixLabels_Both(t *testing.T) {
 	if len(elements) != beforeCount {
 		t.Errorf("both mode must keep source subtrees; before=%d after=%d", beforeCount, len(elements))
 	}
-	if got := p.profile.Snapshot()[LabelsAbsorbed]; got != 0 {
+	if got := p.ComplianceProfile().Snapshot()[LabelsAbsorbed]; got != 0 {
 		t.Errorf("both mode must not fire labels_absorbed; got %d", got)
 	}
 }
@@ -116,7 +115,7 @@ func TestResolveMatrixLabels_BasepathUnresolved(t *testing.T) {
 		BasePath:    "9.9.9",
 		Description: &brokenDesc,
 	})
-	p := &Plugin{profile: &compliance.Profile{}}
+	p := &Plugin{}
 
 	p.resolveMatrixLabels(m, elements, modeInline)
 
@@ -126,7 +125,7 @@ func TestResolveMatrixLabels_BasepathUnresolved(t *testing.T) {
 	if len(m.TargetLabels) != 2 {
 		t.Errorf("other two levels must still resolve; got %d", len(m.TargetLabels))
 	}
-	if got := p.profile.Snapshot()[MatrixLabelBasepathUnresolved]; got != 1 {
+	if got := p.ComplianceProfile().Snapshot()[MatrixLabelBasepathUnresolved]; got != 1 {
 		t.Errorf("matrix_label_basepath_unresolved = %d, want 1", got)
 	}
 }
@@ -138,7 +137,7 @@ func TestResolveMatrixLabels_DescriptionEmpty(t *testing.T) {
 	m, elements := buildMultiLevelMatrixTree()
 	// Clear the Primary level's description — simulate a wire defect.
 	m.Labels[0].Description = nil
-	p := &Plugin{profile: &compliance.Profile{}}
+	p := &Plugin{}
 
 	p.resolveMatrixLabels(m, elements, modeInline)
 
@@ -147,7 +146,7 @@ func TestResolveMatrixLabels_DescriptionEmpty(t *testing.T) {
 	if _, ok := m.TargetLabels["1.2"]; !ok {
 		t.Errorf("empty-description level must key by basePath; got keys %v", keysOf(m.TargetLabels))
 	}
-	if got := p.profile.Snapshot()[MatrixLabelDescriptionEmpty]; got != 1 {
+	if got := p.ComplianceProfile().Snapshot()[MatrixLabelDescriptionEmpty]; got != 1 {
 		t.Errorf("matrix_label_description_empty = %d, want 1", got)
 	}
 }

--- a/internal/osc/consumer/plugin.go
+++ b/internal/osc/consumer/plugin.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"dhs/internal/consumer"
-	"dhs/internal/metrics"
 )
 
 func init() {
@@ -80,8 +79,8 @@ func (f *Factory) Meta() consumer.ProtocolMeta {
 
 func (f *Factory) New(deps plugin.Deps) consumer.Protocol {
 	deps = deps.WithDefaults()
-	p := &Plugin{version: f.version, logger: deps.Logger, met: deps.Metrics}
-	p.Configure(deps.Net, oscStaleAfter)
+	p := &Plugin{version: f.version, logger: deps.Logger}
+	p.Init(deps, oscStaleAfter)
 	return p
 }
 
@@ -114,11 +113,7 @@ type Plugin struct {
 	// there is no remote to probe, and probing our own bound port would
 	// report a reachability that means nothing. Liveness comes from packets
 	// actually arriving, stamped through RecordRx.
-	consumer.Health
-
-	// met counts every packet received. Supplied rather than created, so
-	// the process scrapes every connector from one place.
-	met *metrics.Connector
+	consumer.Base
 
 	version Version
 	logger  *slog.Logger
@@ -255,15 +250,7 @@ func (p *Plugin) Unsubscribe(req consumer.ValueRequest) error {
 // metrics connector. One function so UDP and TCP report identically.
 func (p *Plugin) noteRx(n int) {
 	p.RecordRx()
-	if p.met != nil {
-		p.met.ObserveRx(n)
+	if p.Metrics() != nil {
+		p.Metrics().ObserveRx(n)
 	}
 }
-
-// Metrics returns the connector's counter set. Satisfies the optional
-// interface the CLI type-asserts for --metrics-addr.
-//
-// Only rx is counted: this connector LISTENS, and the consumer side never
-// writes to the wire. A tx series would be a permanent zero pretending to
-// mean something.
-func (p *Plugin) Metrics() *metrics.Connector { return p.met }

--- a/internal/probel-sw02p/consumer/plugin.go
+++ b/internal/probel-sw02p/consumer/plugin.go
@@ -25,8 +25,6 @@ import (
 	"time"
 
 	"dhs/internal/consumer"
-	"dhs/internal/consumer/compliance"
-	"dhs/internal/metrics"
 	"dhs/internal/probel-sw02p/codec"
 	session "dhs/internal/probel-sw02p/session"
 	"dhs/internal/transport"
@@ -71,8 +69,8 @@ func (f *Factory) Meta() consumer.ProtocolMeta {
 // New constructs a fresh consumer plugin bound to the injected dependencies.
 func (f *Factory) New(deps plugin.Deps) consumer.Protocol {
 	deps = deps.WithDefaults()
-	p := &Plugin{logger: deps.Logger, net: deps.Net, metrics: deps.Metrics}
-	p.Configure(deps.Net, DefaultOnlineStaleAfter)
+	p := &Plugin{logger: deps.Logger, net: deps.Net}
+	p.Init(deps, DefaultOnlineStaleAfter)
 	return p
 }
 
@@ -117,7 +115,7 @@ type Plugin struct {
 	// Health supplies SessionHealth. Inherited, not reimplemented: the
 	// only protocol-specific parts are the stale window and the metrics
 	// Connector this consumer already counts every frame through.
-	consumer.Health
+	consumer.Base
 
 	logger *slog.Logger
 
@@ -126,15 +124,10 @@ type Plugin struct {
 	// address) and a test substitutes a fake without a real port.
 	net transport.Net
 
-	// metrics is supplied rather than created, so the process can scrape
-	// every connector from one place.
-	metrics *metrics.Connector
-
-	mu       sync.Mutex
-	host     string
-	port     int
-	client   *session.Client
-	recorder *transport.Recorder
+	mu     sync.Mutex
+	host   string
+	port   int
+	client *session.Client
 
 	// matrixCfg holds caller-supplied matrix shape + bootstrap/keep-
 	// alive knobs. Set via SetMatrixConfig before Connect; defaults
@@ -144,16 +137,6 @@ type Plugin struct {
 	// keepaliveCancel stops the per-session bootstrap + keep-alive
 	// goroutine. Nil unless one is running.
 	keepaliveCancel context.CancelFunc
-
-	// profile aggregates wire-tolerance events observed during this
-	// session. See compliance_events.go for the catalog. Nil until
-	// Connect fires; callers read via ComplianceProfile().
-	profile *compliance.Profile
-
-	// metricsConn carries rx/tx counters + error counters. Nil until
-	// Connect fires; callers read via Metrics(). Preserved after
-	// Disconnect so post-mortem summaries are still available.
-	metricsConn *metrics.Connector
 }
 
 // SetMatrixConfig records the caller-supplied matrix shape + poll
@@ -173,15 +156,6 @@ func (p *Plugin) MatrixConfig() MatrixConfig {
 	return p.matrixCfg
 }
 
-// Metrics returns the session-scoped connector metrics. Nil before
-// Connect, non-nil after (preserved across Disconnect). Safe from any
-// goroutine — metrics.Connector is internally synchronised.
-func (p *Plugin) Metrics() *metrics.Connector {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.metricsConn
-}
-
 // IsOnline reports whether the plugin considers the matrix alive —
 // true if we have seen any rx frame within DefaultOnlineStaleAfter.
 // Mirrors the canonical.Header.IsOnline flag surfaced by the Ember+
@@ -194,33 +168,11 @@ func (p *Plugin) IsOnline() bool {
 
 // IsOnlineWithin is IsOnline with an explicit staleness threshold.
 func (p *Plugin) IsOnlineWithin(stale time.Duration) bool {
-	p.mu.Lock()
-	met := p.metricsConn
-	p.mu.Unlock()
-	if met == nil {
-		return false
-	}
-	snap := met.Snapshot()
+	snap := p.Metrics().Snapshot()
 	if snap.LastRxAt.IsZero() {
 		return false
 	}
 	return time.Since(snap.LastRxAt) < stale
-}
-
-// ComplianceProfile returns the session-scoped compliance profile.
-// Nil before Connect, non-nil after.
-func (p *Plugin) ComplianceProfile() *compliance.Profile {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.profile
-}
-
-// SetRecorder attaches a JSONL traffic recorder to this plugin. Call
-// before Connect.
-func (p *Plugin) SetRecorder(rec *transport.Recorder) {
-	p.mu.Lock()
-	p.recorder = rec
-	p.mu.Unlock()
 }
 
 // Connect opens a TCP session to the matrix. Idempotent when called
@@ -240,15 +192,7 @@ func (p *Plugin) Connect(ctx context.Context, ip string, port int) error {
 	}
 
 	addr := fmt.Sprintf("%s:%d", ip, port)
-	prof := &compliance.Profile{}
-	// Normally injected by the factory. A Plugin built directly — tests, and
-	// any caller that predates Deps — still gets a working counter set rather
-	// than a nil Metrics(), which is what this used to guarantee by
-	// constructing its own.
-	met := p.metrics
-	if met == nil {
-		met = metrics.NewConnector()
-	}
+	met := p.Metrics()
 	// Register every known command byte so the metrics snapshot can
 	// pretty-print names alongside raw ids. Empty in the scaffold;
 	// per-command commits populate the catalogue.
@@ -259,8 +203,7 @@ func (p *Plugin) Connect(ctx context.Context, ip string, port int) error {
 		OnTx: func(b []byte) { observeTxBytes(met, b) },
 		OnRx: func(b []byte) { observeRxBytes(met, b) },
 	}
-	if p.recorder != nil {
-		rec := p.recorder
+	if rec := p.Recorder(); rec != nil {
 		wrappedTx := cfg.OnTx
 		wrappedRx := cfg.OnRx
 		cfg.OnTx = func(b []byte) {
@@ -279,8 +222,6 @@ func (p *Plugin) Connect(ctx context.Context, ip string, port int) error {
 	p.client = cli
 	p.host = ip
 	p.port = port
-	p.profile = prof
-	p.metricsConn = met
 	p.Opened("tcp", ip, port, consumer.MetricsTimes{C: met})
 	p.logger.Info("probel-sw02p connected",
 		slog.String("host", ip),
@@ -301,7 +242,7 @@ func (p *Plugin) Connect(ctx context.Context, ip string, port int) error {
 func (p *Plugin) Disconnect() error {
 	p.mu.Lock()
 	cli := p.client
-	met := p.metricsConn
+	met := p.Metrics()
 	cancel := p.keepaliveCancel
 	p.client = nil
 	p.host = ""

--- a/internal/probel-sw02p/consumer/plugin_test.go
+++ b/internal/probel-sw02p/consumer/plugin_test.go
@@ -57,22 +57,24 @@ func TestDisconnectBeforeConnect(t *testing.T) {
 	}
 }
 
-// TestMetricsNilBeforeConnect pins the contract: Metrics() is nil
-// until Connect fires. Wired via Connect, preserved across Disconnect.
-func TestMetricsNilBeforeConnect(t *testing.T) {
+// TestMetricsExistsBeforeConnect pins the contract: Metrics() is never nil.
+// It used to be, until Connect installed a copy of the injected connector,
+// which meant --metrics-addr on a plugin that had not connected scraped
+// nothing and every caller carried a nil check.
+func TestMetricsExistsBeforeConnect(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	p := &Plugin{logger: logger}
-	if m := p.Metrics(); m != nil {
-		t.Errorf("Metrics() = %v before Connect; want nil", m)
+	if p.Metrics() == nil {
+		t.Error("Metrics() = nil; it must never be")
 	}
 }
 
-// TestComplianceProfileNilBeforeConnect: accessing ComplianceProfile
-// on a fresh plugin returns nil (the session profile is installed at
-// Connect time).
-func TestComplianceProfileNilBeforeConnect(t *testing.T) {
+// TestComplianceProfileExistsBeforeConnect: the profile is connector-scoped
+// and available immediately, so a deviation is never dropped for want of a
+// Connect.
+func TestComplianceProfileExistsBeforeConnect(t *testing.T) {
 	p := &Plugin{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
-	if p.ComplianceProfile() != nil {
-		t.Error("ComplianceProfile() = non-nil; want nil before Connect")
+	if p.ComplianceProfile() == nil {
+		t.Error("ComplianceProfile() = nil; it must never be")
 	}
 }

--- a/internal/probel-sw08p/consumer/collect_done_test.go
+++ b/internal/probel-sw08p/consumer/collect_done_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"dhs/internal/metrics"
 	"dhs/internal/probel-sw08p/codec"
 )
 
@@ -12,8 +11,9 @@ import (
 // connector exists but no rx frame has been observed yet: a freshly-dialed
 // session whose LastRxAt is still zero must report offline.
 func TestIsOnlineWithin_MetricsButNoRx(t *testing.T) {
+	// Base always supplies a connector, so this is now simply a plugin
+	// that has never received a frame.
 	p := freshPlugin()
-	p.metricsConn = metrics.NewConnector() // connected, but never received a frame
 	if p.IsOnlineWithin(1 * time.Second) {
 		t.Error("IsOnlineWithin true with zero LastRxAt; want false")
 	}

--- a/internal/probel-sw08p/consumer/compliance_test.go
+++ b/internal/probel-sw08p/consumer/compliance_test.go
@@ -12,13 +12,13 @@ import (
 	"dhs/internal/probel-sw08p/codec"
 )
 
-// TestComplianceProfileNilBeforeConnect: accessing ComplianceProfile on a
-// fresh plugin returns nil (the session profile is installed at Connect
-// time).
-func TestComplianceProfileNilBeforeConnect(t *testing.T) {
+// TestComplianceProfileExistsBeforeConnect: the profile is connector-scoped
+// and available immediately, so a deviation can never be dropped for want of
+// a Connect, and callers need no nil check.
+func TestComplianceProfileExistsBeforeConnect(t *testing.T) {
 	p := &Plugin{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
-	if p.ComplianceProfile() != nil {
-		t.Error("ComplianceProfile() = non-nil; want nil before Connect")
+	if p.ComplianceProfile() == nil {
+		t.Error("ComplianceProfile() = nil; it must never be")
 	}
 }
 

--- a/internal/probel-sw08p/consumer/plugin.go
+++ b/internal/probel-sw08p/consumer/plugin.go
@@ -26,8 +26,6 @@ import (
 
 	"dhs/internal/clock"
 	"dhs/internal/consumer"
-	"dhs/internal/consumer/compliance"
-	"dhs/internal/metrics"
 	"dhs/internal/probel-sw08p/codec"
 	sw08session "dhs/internal/probel-sw08p/session"
 	"dhs/internal/transport"
@@ -60,8 +58,8 @@ func (f *Factory) Meta() consumer.ProtocolMeta {
 // New constructs a fresh consumer plugin bound to the given logger.
 func (f *Factory) New(deps plugin.Deps) consumer.Protocol {
 	deps = deps.WithDefaults()
-	p := &Plugin{logger: deps.Logger, net: deps.Net, metrics: deps.Metrics}
-	p.Configure(deps.Net, DefaultOnlineStaleAfter)
+	p := &Plugin{logger: deps.Logger, net: deps.Net}
+	p.Init(deps, DefaultOnlineStaleAfter)
 	return p
 }
 
@@ -93,7 +91,7 @@ type Plugin struct {
 	// Health supplies SessionHealth. Inherited, not reimplemented: the
 	// only protocol-specific parts are the stale window and the metrics
 	// Connector this consumer already counts every frame through.
-	consumer.Health
+	consumer.Base
 
 	logger *slog.Logger
 
@@ -101,15 +99,10 @@ type Plugin struct {
 	// process owns the transport posture and a test substitutes a fake.
 	net transport.Net
 
-	// metrics is supplied rather than created, so one place can scrape
-	// every connector.
-	metrics *metrics.Connector
-
-	mu       sync.Mutex
-	host     string
-	port     int
-	client   *sw08session.Client
-	recorder *transport.Recorder
+	mu     sync.Mutex
+	host   string
+	port   int
+	client *sw08session.Client
 
 	// kaPoll owns the spec-sanctioned cmd 08 keep-alive prober (§5
 	// "Supporting dual controllers over IP" — poll "to keep the connections
@@ -123,16 +116,6 @@ type Plugin struct {
 	// matrixCfg holds caller-supplied matrix shape. Set via
 	// SetMatrixConfig before Connect; defaults applied at use sites.
 	matrixCfg MatrixConfig
-
-	// profile aggregates wire-tolerance events observed during this
-	// session. See compliance_events.go for the catalog. Nil until
-	// Connect fires; callers read via ComplianceProfile().
-	profile *compliance.Profile
-
-	// metricsConn carries rx/tx counters + error counters. Nil until
-	// Connect fires; callers read via Metrics(). Preserved after
-	// Disconnect so post-mortem summaries are still available.
-	metricsConn *metrics.Connector
 }
 
 // SetMatrixConfig records the caller-supplied matrix shape. Call
@@ -152,15 +135,6 @@ func (p *Plugin) MatrixConfig() MatrixConfig {
 	return p.matrixCfg
 }
 
-// Metrics returns the session-scoped connector metrics. Nil before
-// Connect, non-nil after (preserved across Disconnect). Safe from any
-// goroutine — metrics.Connector is internally synchronised.
-func (p *Plugin) Metrics() *metrics.Connector {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.metricsConn
-}
-
 // IsOnline reports whether the plugin considers the matrix alive — true
 // if we have seen any rx frame (application or DLE ACK / NAK) within
 // DefaultOnlineStaleAfter. Mirrors the canonical.Header.IsOnline flag
@@ -175,13 +149,7 @@ func (p *Plugin) IsOnline() bool {
 // when the caller knows the peer's keepalive cadence (e.g. an Ember+
 // mirror polling at 5 s can pass stale=15 s).
 func (p *Plugin) IsOnlineWithin(stale time.Duration) bool {
-	p.mu.Lock()
-	met := p.metricsConn
-	p.mu.Unlock()
-	if met == nil {
-		return false
-	}
-	snap := met.Snapshot()
+	snap := p.Metrics().Snapshot()
 	if snap.LastRxAt.IsZero() {
 		return false
 	}
@@ -189,25 +157,6 @@ func (p *Plugin) IsOnlineWithin(stale time.Duration) bool {
 }
 
 // ComplianceProfile returns the session-scoped compliance profile.
-// Nil before Connect, non-nil after. Safe to call from any goroutine —
-// compliance.Profile is internally synchronized.
-func (p *Plugin) ComplianceProfile() *compliance.Profile {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.profile
-}
-
-// SetRecorder attaches a JSONL traffic recorder to this plugin. Call
-// before Connect — the recorder is wired into the sw08session.Client at
-// Dial time and captures every TX and RX frame (including DLE ACK /
-// DLE NAK control sequences) in the same format the ACP1/ACP2/Ember+
-// plugins produce.
-func (p *Plugin) SetRecorder(rec *transport.Recorder) {
-	p.mu.Lock()
-	p.recorder = rec
-	p.mu.Unlock()
-}
-
 // Connect opens a TCP session to the matrix. Idempotent when called
 // twice with the same endpoint. Port 0 resolves to DefaultPort.
 func (p *Plugin) Connect(ctx context.Context, ip string, port int) error {
@@ -225,14 +174,8 @@ func (p *Plugin) Connect(ctx context.Context, ip string, port int) error {
 	}
 
 	addr := fmt.Sprintf("%s:%d", ip, port)
-	prof := &compliance.Profile{}
-	// Normally injected. A Plugin built directly still gets a counter set
-	// rather than a nil Metrics(), which is what this used to guarantee by
-	// constructing its own.
-	met := p.metrics
-	if met == nil {
-		met = metrics.NewConnector()
-	}
+	prof := p.ComplianceProfile()
+	met := p.Metrics()
 	// Register every known command byte so the metrics snapshot can
 	// pretty-print names alongside raw ids.
 	for _, id := range codec.CommandIDs() {
@@ -260,8 +203,7 @@ func (p *Plugin) Connect(ctx context.Context, ip string, port int) error {
 		},
 		OnEvent: p.keepaliveAutoResponder(),
 	}
-	if p.recorder != nil {
-		rec := p.recorder
+	if rec := p.Recorder(); rec != nil {
 		wrappedTx := cfg.OnTx
 		wrappedRx := cfg.OnRx
 		cfg.OnTx = func(b []byte) {
@@ -280,8 +222,6 @@ func (p *Plugin) Connect(ctx context.Context, ip string, port int) error {
 	p.client = cli
 	p.host = ip
 	p.port = port
-	p.profile = prof
-	p.metricsConn = met
 	p.Opened("tcp", ip, port, consumer.MetricsTimes{C: met})
 	// Start the spec-sanctioned cmd 08 poll (§5 "…to keep the connections
 	// open") and arm the reader's dead-man deadline alongside it. Our own
@@ -323,7 +263,6 @@ func (p *Plugin) Disconnect() error {
 	// race the close and log a spurious write failure.
 	p.stopKeepalivePoll()
 	cli := p.client
-	met := p.metricsConn
 	p.client = nil
 	p.host = ""
 	p.port = 0
@@ -332,7 +271,7 @@ func (p *Plugin) Disconnect() error {
 	if cli == nil {
 		return nil
 	}
-	if met != nil {
+	if met := p.Metrics(); met != nil {
 		p.logger.Info("probel session metrics",
 			slog.String("summary", met.Summary()),
 		)

--- a/internal/probel-sw08p/consumer/plugin_test.go
+++ b/internal/probel-sw08p/consumer/plugin_test.go
@@ -57,12 +57,14 @@ func TestDisconnectBeforeConnect(t *testing.T) {
 	}
 }
 
-// TestMetricsNilBeforeConnect pins the contract: Metrics() is nil
-// until Connect fires. Wired via Connect, preserved across Disconnect.
-func TestMetricsNilBeforeConnect(t *testing.T) {
+// TestMetricsExistsBeforeConnect pins the contract: Metrics() is never nil.
+// It used to be, until Connect installed a copy of the injected connector —
+// which meant `--metrics-addr` on a plugin that had not connected yet
+// scraped nothing, and every caller carried a nil check.
+func TestMetricsExistsBeforeConnect(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	p := &Plugin{logger: logger}
-	if m := p.Metrics(); m != nil {
-		t.Errorf("Metrics() = %v before Connect; want nil", m)
+	if p.Metrics() == nil {
+		t.Error("Metrics() = nil; it must never be")
 	}
 }

--- a/internal/tsl/consumer/plugin.go
+++ b/internal/tsl/consumer/plugin.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"dhs/internal/consumer"
-	"dhs/internal/metrics"
 )
 
 func init() {
@@ -91,8 +90,8 @@ func (f *Factory) Meta() consumer.ProtocolMeta {
 // New instantiates a Plugin for this version.
 func (f *Factory) New(deps plugin.Deps) consumer.Protocol {
 	deps = deps.WithDefaults()
-	p := &Plugin{version: f.version, logger: deps.Logger, met: deps.Metrics}
-	p.Configure(deps.Net, tslStaleAfter)
+	p := &Plugin{version: f.version, logger: deps.Logger}
+	p.Init(deps, tslStaleAfter)
 	return p
 }
 
@@ -131,11 +130,7 @@ type Plugin struct {
 	// there is no remote to probe, and probing our own bound port would
 	// report a reachability that means nothing. Liveness comes from packets
 	// actually arriving, stamped through RecordRx.
-	consumer.Health
-
-	// met counts every packet received. Supplied rather than created, so
-	// the process scrapes every connector from one place.
-	met *metrics.Connector
+	consumer.Base
 
 	version Version
 	logger  *slog.Logger
@@ -334,15 +329,7 @@ func (p *Plugin) Unsubscribe(req consumer.ValueRequest) error {
 // metrics connector. One function so UDP and TCP report identically.
 func (p *Plugin) noteRx(n int) {
 	p.RecordRx()
-	if p.met != nil {
-		p.met.ObserveRx(n)
+	if p.Metrics() != nil {
+		p.Metrics().ObserveRx(n)
 	}
 }
-
-// Metrics returns the connector's counter set. Satisfies the optional
-// interface the CLI type-asserts for --metrics-addr.
-//
-// Only rx is counted: TSL is one-way by spec (§1.0, "for one way
-// communication only"), so a consumer never writes to the wire and a tx
-// series would be a permanent zero pretending to mean something.
-func (p *Plugin) Metrics() *metrics.Connector { return p.met }


### PR DESCRIPTION
## What

Four concerns cut across every connector and none is protocol-specific: **liveness, counters, spec-deviation events, traffic capture**. Each was written per connector anyway:

| | written N times | identical? |
| --- | --- | --- |
| `SetRecorder` | 5 | byte-for-byte |
| `ComplianceProfile` | 5 | 4 identical, the 5th unlocked |
| `Metrics` | 8 | identical |
| `Health` | 11 | unified earlier |

`consumer.Base` holds all four. A connector embeds it and keeps its **codec and session** — the parts that genuinely differ. All **8 consumers** are converted, one commit each.

## Contract changes, deliberate

- **The compliance profile is never nil, and connector-scoped.** It used to be nil until Connect and *replaced* on every Connect, so a reconnect discarded every deviation observed before it — and ACP1 reconnects by design. probel already kept its own across Disconnect for exactly that reason. `cmd/dhs/cmd_profile.go` type-asserts and calls it with no nil check; it was one un-Connected plugin away from a nil dereference.
- **`Metrics()` is never nil.** probel carried *two* connector fields — `metrics` from the factory and a `metricsConn` copy set at Connect — whose only effect was making `Metrics()` nil beforehand. `--metrics-addr` against a not-yet-connected plugin scraped nothing. `metricsConn` is gone.

## Dead code removed

emberplus guarded the profile **18 times** (`if p.profile != nil { p.profile.Note(...) }`) plus two compound conditions. All unreachable once the profile is guaranteed. cerebrum-nb loses a hand-rolled Connector in `NewPlugin` that existed only because the CLI bypasses the factory.

## Verification

`go test ./...` green; every touched package still at its 100% floor. `go test -race ./internal/...` clean on Linux (this Windows host can't run `-race`).

## Note for the reviewer

Renaming `p.met` → `p.Metrics()` across a file that *defines* `Metrics()` yields `func (p *Plugin) Metrics() ... { return p.Metrics() }` — legal, and it recurses until the stack goes. It bit twice: emberplus (caught by the compiler) and osc/tsl (caught only as a test that never finished). Both fixed; worth knowing before a similar rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)