### PR TITLE
feat(snell-rollcall): codec part 1 — framer, addressing, 16-bit payloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
       # "^dhs/<pkg>/<file>.go:" so nested packages stay separate; a floor
       # package with no rows at all is a hard failure (renamed package
       # guard). On a miss the exact uncovered blocks are printed.
-      - name: Coverage floor (acp1 + acp2 + emberplus)
+      - name: Coverage floor (per-package)
         if: matrix.os == 'ubuntu-latest'
         run: |
           set -e
@@ -168,6 +168,7 @@ jobs:
           check internal/osc/consumer 100
           check internal/osc/provider 100
           check internal/cerebrum-nb/codec 100
+          check internal/snell-rollcall/codec 100
           check internal/transport/ws 100
           check internal/transport/http 100
           check internal/auth 100

--- a/internal/snell-rollcall/codec/addr.go
+++ b/internal/snell-rollcall/codec/addr.go
@@ -1,0 +1,239 @@
+package codec
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// AddrSize is the wire size of a full address (spec 11.1.1).
+const AddrSize = 6
+
+// Reserved session indices (spec 5.4, 12.3).
+const (
+	// IndexBlind addresses a unit without a session. The server treats such
+	// requests as UL_SUPERVISOR (spec 9.17).
+	IndexBlind int16 = 0
+
+	// IndexLogging is reserved for the logging service (vendor
+	// CoreServiceAPI.h LOGGING_SESSION).
+	IndexLogging int16 = 0xFE
+
+	// IndexUnknown is UNKNOWNSESS: unconnected traffic, broadcasts, and the
+	// destination of every Call.
+	//
+	// It is the value 255. Writing "unknown" as -1 is the single easiest
+	// mistake to make here, because the field is signed; -1 encodes as
+	// 0xFFFF, which a lenient proxy answers anyway and a real device faults
+	// on. See internal/snell-rollcall/CLAUDE.md "What NOT to do" #1.
+	IndexUnknown int16 = 0xFF
+)
+
+// Unit address ranges (spec 5.1).
+const (
+	UnitBroadcast   uint8 = 0x00 // also "the unit at the other end of this link"
+	UnitBridgeFirst uint8 = 0x01
+	UnitBridgeLast  uint8 = 0x0F
+	UnitFirst       uint8 = 0x10
+)
+
+// Address is a RollCall address: a device (Net, Unit, Port) plus a session
+// index. Written NNNN-UU-PP:SS.
+//
+// Spec 11.1.1 FULLADDRESS_STR, 6 bytes:
+//
+//	UINT16 rNet    4 nibbles of network route
+//	UINT8  rUnit   unit address
+//	UINT8  rPort   port within the unit
+//	INT16  rIndex  session index
+type Address struct {
+	Net   uint16
+	Unit  uint8
+	Port  uint8
+	Index int16
+}
+
+// Broadcast is 0000-00-00:FF, received by every unit on the local segment
+// (spec 5.5).
+func Broadcast() Address {
+	return Address{Index: IndexUnknown}
+}
+
+// Loopback is FFFF-00-00, which a unit routes back to itself (spec 5.6).
+func Loopback() Address {
+	return Address{Net: 0xFFFF, Index: IndexUnknown}
+}
+
+// Device returns a copy with the session index cleared to IndexUnknown, which
+// is how a device is named when the session is not relevant.
+func (a Address) Device() Address {
+	a.Index = IndexUnknown
+	return a
+}
+
+// SameDevice reports whether two addresses name the same Net/Unit/Port,
+// ignoring the session index.
+func (a Address) SameDevice(b Address) bool {
+	return a.Net == b.Net && a.Unit == b.Unit && a.Port == b.Port
+}
+
+// IsBroadcast reports whether the unit address is the broadcast address.
+// Note that 0000-00-PP is also the "port PP of this unit" internal form
+// (spec 5.7), so a gateway must disambiguate by context.
+func (a Address) IsBroadcast() bool { return a.Unit == UnitBroadcast && a.Port == 0 }
+
+// IsBridge reports whether the unit address falls in the range reserved for
+// network bridges (spec 5.1).
+func (a Address) IsBridge() bool {
+	return a.Unit >= UnitBridgeFirst && a.Unit <= UnitBridgeLast
+}
+
+// HopCount returns how many bridges the route crosses: the number of non-zero
+// nibbles in Net, counted from the top.
+func (a Address) HopCount() int {
+	n := 0
+	for shift := 12; shift >= 0; shift -= 4 {
+		if (a.Net>>uint(shift))&0xF == 0 {
+			break
+		}
+		n++
+	}
+	return n
+}
+
+// ValidRoute reports whether Net is well formed. Routes fill from the top
+// nibble downwards, so a zero nibble may not sit above a non-zero one; 0x0F00
+// is malformed while 0xF000 and 0x0000 are not.
+//
+// The vendor library rejects the malformed form in Core/Transmit.c
+// (CheckForRoutingError, RC_ADD_TXQ_BAD_NETADDR).
+func (a Address) ValidRoute() bool {
+	seenZero := false
+	for shift := 12; shift >= 0; shift -= 4 {
+		if (a.Net>>uint(shift))&0xF == 0 {
+			seenZero = true
+			continue
+		}
+		if seenZero {
+			return false
+		}
+	}
+	return true
+}
+
+// NextHop returns the bridge unit address a frame must be sent to, and whether
+// the frame still needs bridging at all. When the top nibble of Net is zero
+// the destination is on this segment and ok is false (spec 5.3).
+func (a Address) NextHop() (bridge uint8, ok bool) {
+	top := uint8(a.Net >> 12)
+	if top == 0 {
+		return 0, false
+	}
+	return top, true
+}
+
+// Forward applies the bridge transform of spec 5.3 to a destination address:
+// the route shifts left by one nibble, dropping the hop just taken.
+func (a Address) Forward() Address {
+	a.Net <<= 4
+	return a
+}
+
+// ForwardSource applies the matching transform to a source address: the route
+// shifts right and the bridge's own address on the far net is inserted at the
+// top, so the recipient can reverse the path.
+func (a Address) ForwardSource(bridgeUnit uint8) Address {
+	a.Net = (a.Net >> 4) | (uint16(bridgeUnit&0xF) << 12)
+	return a
+}
+
+// AppendTo appends the 6-byte wire form of a to dst.
+func (a Address) AppendTo(dst []byte) []byte {
+	var b [AddrSize]byte
+	binary.BigEndian.PutUint16(b[0:2], a.Net)
+	b[2] = a.Unit
+	b[3] = a.Port
+	binary.BigEndian.PutUint16(b[4:6], uint16(a.Index))
+	return append(dst, b[:]...)
+}
+
+// DecodeAddress reads a 6-byte address from the front of b.
+func DecodeAddress(b []byte) (Address, error) {
+	if err := need(b, AddrSize, "Address", ""); err != nil {
+		return Address{}, err
+	}
+	return addressAt(b), nil
+}
+
+// addressAt reads an address from a slice the caller has already sized. Every
+// structure that embeds an address validates its own length first, so this
+// cannot fail and the callers stay free of error paths that can never run.
+func addressAt(b []byte) Address {
+	return Address{
+		Net:   binary.BigEndian.Uint16(b[0:2]),
+		Unit:  b[2],
+		Port:  b[3],
+		Index: int16(binary.BigEndian.Uint16(b[4:6])),
+	}
+}
+
+// String renders the address as NNNN-UU-PP:SSS.
+//
+// The index is printed from the full 16-bit field with a minimum of three
+// digits, matching the vendor tools ("0000:00:00/0FF"). It is deliberately not
+// masked to 8 bits: an out-of-range index such as 0xFFFF is a defect worth
+// seeing, and masking it would print a plausible "0FF" and hide it.
+func (a Address) String() string {
+	return fmt.Sprintf("%04X-%02X-%02X:%03X", a.Net, a.Unit, a.Port, uint16(a.Index))
+}
+
+// ParseAddress accepts NNNN-UU-PP and NNNN-UU-PP:SS, with either "-" or ":"
+// between the device fields so that both spellings seen in vendor documents
+// are understood. A missing session index means IndexUnknown.
+func ParseAddress(s string) (Address, error) {
+	text := strings.TrimSpace(s)
+	if text == "" {
+		return Address{}, fmt.Errorf("%w: empty", ErrBadAddress)
+	}
+
+	idx := IndexUnknown
+	if i := strings.LastIndexByte(text, ':'); i >= 0 {
+		// Only treat the last colon as a session separator when what
+		// follows parses and what precedes still has three fields.
+		head, tail := text[:i], text[i+1:]
+		if strings.Count(strings.ReplaceAll(head, ":", "-"), "-") == 2 {
+			v, err := strconv.ParseUint(tail, 16, 16)
+			if err != nil {
+				return Address{}, fmt.Errorf("%w: index %q", ErrBadAddress, tail)
+			}
+			idx = int16(v)
+			text = head
+		}
+	}
+
+	parts := strings.Split(strings.ReplaceAll(text, ":", "-"), "-")
+	if len(parts) != 3 {
+		return Address{}, fmt.Errorf("%w: want NNNN-UU-PP[:SS], got %q", ErrBadAddress, s)
+	}
+
+	net, err := strconv.ParseUint(parts[0], 16, 16)
+	if err != nil {
+		return Address{}, fmt.Errorf("%w: net %q", ErrBadAddress, parts[0])
+	}
+	unit, err := strconv.ParseUint(parts[1], 16, 8)
+	if err != nil {
+		return Address{}, fmt.Errorf("%w: unit %q", ErrBadAddress, parts[1])
+	}
+	port, err := strconv.ParseUint(parts[2], 16, 8)
+	if err != nil {
+		return Address{}, fmt.Errorf("%w: port %q", ErrBadAddress, parts[2])
+	}
+
+	return Address{
+		Net:   uint16(net),
+		Unit:  uint8(unit),
+		Port:  uint8(port),
+		Index: idx,
+	}, nil
+}

--- a/internal/snell-rollcall/codec/addr_test.go
+++ b/internal/snell-rollcall/codec/addr_test.go
@@ -1,0 +1,193 @@
+package codec
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+func TestAddress_WireRoundTrip(t *testing.T) {
+	// Spec 11.1.1: Net, Unit, Port, Index, big-endian, 6 bytes.
+	want := []byte{0x10, 0x00, 0x08, 0x01, 0x00, 0x7B}
+	a := Address{Net: 0x1000, Unit: 0x08, Port: 0x01, Index: 123}
+
+	got := a.AppendTo(nil)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("AppendTo = %x, want %x", got, want)
+	}
+
+	back, err := DecodeAddress(got)
+	if err != nil {
+		t.Fatalf("DecodeAddress: %v", err)
+	}
+	if back != a {
+		t.Errorf("round trip = %+v, want %+v", back, a)
+	}
+}
+
+func TestDecodeAddress_Short(t *testing.T) {
+	if _, err := DecodeAddress([]byte{1, 2, 3}); !errors.Is(err, ErrShortBuffer) {
+		t.Errorf("err = %v, want ErrShortBuffer", err)
+	}
+}
+
+func TestAddress_String(t *testing.T) {
+	tests := []struct {
+		addr Address
+		want string
+	}{
+		{Address{Index: IndexUnknown}, "0000-00-00:0FF"},
+		{Address{Net: 0x1000, Unit: 0x41, Port: 0x01, Index: 3}, "1000-41-01:003"},
+		{Address{Unit: 0x20, Port: 0x02, Index: IndexBlind}, "0000-20-02:000"},
+		// A malformed index must remain visible, not be masked to 8 bits.
+		{Address{Index: -1}, "0000-00-00:FFFF"},
+	}
+	for _, tc := range tests {
+		if got := tc.addr.String(); got != tc.want {
+			t.Errorf("String() = %q, want %q", got, tc.want)
+		}
+	}
+}
+
+func TestParseAddress(t *testing.T) {
+	tests := []struct {
+		in   string
+		want Address
+	}{
+		{"0000-00-00", Address{Index: IndexUnknown}},
+		{"1000-41-01", Address{Net: 0x1000, Unit: 0x41, Port: 0x01, Index: IndexUnknown}},
+		{"1000-41-01:03", Address{Net: 0x1000, Unit: 0x41, Port: 0x01, Index: 3}},
+		{"0000:20:02:0FF", Address{Unit: 0x20, Port: 0x02, Index: IndexUnknown}},
+		{"  0000-FF-01:00  ", Address{Unit: 0xFF, Port: 0x01, Index: 0}},
+	}
+	for _, tc := range tests {
+		got, err := ParseAddress(tc.in)
+		if err != nil {
+			t.Errorf("ParseAddress(%q): %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("ParseAddress(%q) = %+v, want %+v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestParseAddress_Rejects(t *testing.T) {
+	for _, in := range []string{
+		"", "   ", "1000-41", "1000-41-01-02", "zzzz-41-01",
+		"1000-zz-01", "1000-41-zz", "1000-41-01:zz",
+		"10000-41-01", // net wider than 16 bits
+		"1000-100-01", // unit wider than 8 bits
+	} {
+		if _, err := ParseAddress(in); !errors.Is(err, ErrBadAddress) {
+			t.Errorf("ParseAddress(%q) err = %v, want ErrBadAddress", in, err)
+		}
+	}
+}
+
+func TestParseAddress_RoundTripsString(t *testing.T) {
+	for _, a := range []Address{
+		{Index: IndexUnknown},
+		{Net: 0x2300, Unit: 0x20, Port: 0x00, Index: 5},
+		{Net: 0x1000, Unit: 0x81, Port: 0xFF, Index: 0xFE},
+	} {
+		back, err := ParseAddress(a.String())
+		if err != nil {
+			t.Fatalf("ParseAddress(%q): %v", a.String(), err)
+		}
+		if back != a {
+			t.Errorf("%s round trips to %+v, want %+v", a, back, a)
+		}
+	}
+}
+
+func TestAddress_Predicates(t *testing.T) {
+	if !(Address{Index: IndexUnknown}).IsBroadcast() {
+		t.Error("0000-00-00 should be the broadcast address")
+	}
+	if (Address{Unit: 0x20}).IsBroadcast() {
+		t.Error("a unit address is not the broadcast address")
+	}
+	if !(Address{Unit: 0x01}).IsBridge() || !(Address{Unit: 0x0F}).IsBridge() {
+		t.Error("units 0x01..0x0F are bridge addresses (spec 5.1)")
+	}
+	if (Address{Unit: 0x10}).IsBridge() || (Address{Unit: 0x00}).IsBridge() {
+		t.Error("0x00 and 0x10 are not bridge addresses")
+	}
+
+	a := Address{Net: 0x1000, Unit: 0x41, Port: 1, Index: 7}
+	if got := a.Device(); got.Index != IndexUnknown {
+		t.Errorf("Device() kept index %d", got.Index)
+	}
+	if !a.SameDevice(Address{Net: 0x1000, Unit: 0x41, Port: 1, Index: 99}) {
+		t.Error("SameDevice must ignore the session index")
+	}
+	if a.SameDevice(Address{Net: 0x1000, Unit: 0x42, Port: 1}) {
+		t.Error("SameDevice must compare the unit")
+	}
+
+	if got := Broadcast(); !got.IsBroadcast() || got.Index != IndexUnknown {
+		t.Errorf("Broadcast() = %s", got)
+	}
+	if got := Loopback(); got.Net != 0xFFFF {
+		t.Errorf("Loopback() = %s, want net FFFF (spec 5.6)", got)
+	}
+}
+
+// TestAddress_Route covers the bridge routing rules of spec 5.3, including the
+// worked example: a controller reaching a gateway two bridges away.
+func TestAddress_Route(t *testing.T) {
+	routeTests := []struct {
+		net   uint16
+		hops  int
+		valid bool
+	}{
+		{0x0000, 0, true},  // local segment
+		{0x2000, 1, true},  // one bridge
+		{0x2300, 2, true},  // spec 5.3 worked example
+		{0x1234, 4, true},  // the maximum
+		{0x0F00, 0, false}, // gap: zero nibble above a non-zero one
+		{0x0001, 0, false},
+	}
+	for _, tc := range routeTests {
+		a := Address{Net: tc.net}
+		if got := a.ValidRoute(); got != tc.valid {
+			t.Errorf("Net %04X ValidRoute = %v, want %v", tc.net, got, tc.valid)
+		}
+		if !tc.valid {
+			continue
+		}
+		if got := a.HopCount(); got != tc.hops {
+			t.Errorf("Net %04X HopCount = %d, want %d", tc.net, got, tc.hops)
+		}
+	}
+
+	// Spec 5.3: src 0000-10-00 to dst 2300-20-00 crosses bridge 2 then 3.
+	dst := Address{Net: 0x2300, Unit: 0x20}
+	src := Address{Net: 0x0000, Unit: 0x10}
+
+	hop, ok := dst.NextHop()
+	if !ok || hop != 0x02 {
+		t.Fatalf("first hop = %02X ok=%v, want 02 true", hop, ok)
+	}
+
+	// Bridge 1 forwards: dst shifts left, src shifts right with the bridge's
+	// address on the far net inserted at the top.
+	dst, src = dst.Forward(), src.ForwardSource(0x01)
+	if dst.Net != 0x3000 || src.Net != 0x1000 {
+		t.Fatalf("after bridge 1: dst %04X src %04X, want 3000 and 1000", dst.Net, src.Net)
+	}
+
+	hop, ok = dst.NextHop()
+	if !ok || hop != 0x03 {
+		t.Fatalf("second hop = %02X ok=%v, want 03 true", hop, ok)
+	}
+
+	dst, src = dst.Forward(), src.ForwardSource(0x03)
+	if dst.Net != 0x0000 || src.Net != 0x3100 {
+		t.Fatalf("after bridge 2: dst %04X src %04X, want 0000 and 3100", dst.Net, src.Net)
+	}
+	if _, ok := dst.NextHop(); ok {
+		t.Error("a zero top nibble means the destination is on this segment")
+	}
+}

--- a/internal/snell-rollcall/codec/bits.go
+++ b/internal/snell-rollcall/codec/bits.go
@@ -1,0 +1,360 @@
+package codec
+
+import "strings"
+
+// Service flags (spec 12.1, rc3comm.h).
+//
+// Service is unsigned. The vendor enum is signed, so SvcLongStr appears as a
+// negative number in tools that print it as INT16 - RollCall Control Panel
+// shows service 0x8003 as "-32765". Never store a service mask in a signed
+// 16-bit value.
+type Service uint16
+
+const (
+	SvcMenus     Service = 0x0001
+	SvcControl   Service = 0x0002
+	SvcDisplay   Service = 0x0004
+	SvcFile      Service = 0x0008
+	SvcLogging   Service = 0x0010
+	SvcStream    Service = 0x0020
+	SvcMap       Service = 0x0040
+	SvcPorts     Service = 0x0080
+	SvcNet       Service = 0x0100
+	SvcExec      Service = 0x0200
+	SvcTime      Service = 0x0400
+	SvcRes2      Service = 0x0800
+	SvcThumbnail Service = 0x1000 // spec calls this SV_LOC1
+	SvcFastMenu  Service = 0x2000 // spec calls this SV_LOC2; semantics undocumented
+	SvcLoc3      Service = 0x4000
+	// SvcLongStr is the 2014 extension's capability bit. A unit advertising
+	// it accepts 32-bit command numbers and long strings; a client requests
+	// them by including this bit in its Call.
+	SvcLongStr Service = 0x8000
+)
+
+var serviceNames = []struct {
+	bit  Service
+	name string
+}{
+	{SvcMenus, "Menus"}, {SvcControl, "Control"}, {SvcDisplay, "Display"},
+	{SvcFile, "File"}, {SvcLogging, "Logging"}, {SvcStream, "Stream"},
+	{SvcMap, "Map"}, {SvcPorts, "Ports"}, {SvcNet, "Net"}, {SvcExec, "Exec"},
+	{SvcTime, "Time"}, {SvcRes2, "Res2"}, {SvcThumbnail, "Thumbnail"},
+	{SvcFastMenu, "FastMenu"}, {SvcLoc3, "Loc3"}, {SvcLongStr, "LongStr"},
+}
+
+// Has reports whether every bit in want is present.
+func (s Service) Has(want Service) bool { return s&want == want }
+
+// LongStrings reports whether the mask advertises or requests the 32-bit
+// generation.
+func (s Service) LongStrings() bool { return s&SvcLongStr != 0 }
+
+// String lists the set bits, e.g. "Menus|Control|LongStr", or "-" when none.
+func (s Service) String() string {
+	if s == 0 {
+		return "-"
+	}
+	var b strings.Builder
+	for _, e := range serviceNames {
+		if s&e.bit != 0 {
+			if b.Len() > 0 {
+				b.WriteByte('|')
+			}
+			b.WriteString(e.name)
+		}
+	}
+	return b.String()
+}
+
+// UserLevel selects which class of information a session sees (spec 12.2).
+//
+// Gating is per line and per command via a usermask the server holds. The
+// control service answers an out-of-level command with Nack; the menu service
+// replaces the line with a hidden, disabled Data line named "Reserved" rather
+// than removing it, so line counts never change. Compare flags, not counts.
+type UserLevel uint16
+
+const (
+	LevelUser       UserLevel = 0
+	LevelEngineer   UserLevel = 1
+	LevelSupervisor UserLevel = 2
+	LevelFactory    UserLevel = 3
+
+	// LevelAll is a mask value, never a level to send in a Call. The vendor
+	// engine rejects any level at or above MAX_USERLEVEL (rc_menu.c).
+	LevelAll UserLevel = 4
+)
+
+// Valid reports whether the level may be sent in a Call.
+func (u UserLevel) Valid() bool { return u <= LevelFactory }
+
+func (u UserLevel) String() string {
+	switch u {
+	case LevelUser:
+		return "user"
+	case LevelEngineer:
+		return "engineer"
+	case LevelSupervisor:
+		return "supervisor"
+	case LevelFactory:
+		return "factory"
+	case LevelAll:
+		return "all"
+	default:
+		return "unknown"
+	}
+}
+
+// Status flags (spec 12.5, rc3comm.h StatusFlags).
+type Status uint16
+
+const (
+	StatusOnline     Status = 0x0002
+	StatusMultiLevel Status = 0x0004 // vendor-only; spec leaves bit 2 unassigned
+	StatusPresent    Status = 0x0008
+	StatusLocal      Status = 0x0020
+)
+
+// Has reports whether every bit in want is present.
+func (s Status) Has(want Status) bool { return s&want == want }
+
+func (s Status) String() string {
+	if s == 0 {
+		return "-"
+	}
+	var b strings.Builder
+	for _, e := range []struct {
+		bit  Status
+		name string
+	}{
+		{StatusOnline, "Online"}, {StatusMultiLevel, "MultiLevel"},
+		{StatusPresent, "Present"}, {StatusLocal, "Local"},
+	} {
+		if s&e.bit != 0 {
+			if b.Len() > 0 {
+				b.WriteByte('|')
+			}
+			b.WriteString(e.name)
+		}
+	}
+	return b.String()
+}
+
+// Mode is the rMode bit field carried by FuncStatus and Value (spec 12.8).
+type Mode uint16
+
+const (
+	// ModeValue means the numeric field is meaningful.
+	ModeValue Mode = 0x01
+	// ModeString means a string follows the numeric field.
+	ModeString Mode = 0x02
+	// ModeData means raw bytes follow, their length given by the numeric
+	// field. Mutually exclusive with Value and String.
+	ModeData Mode = 0x04
+	// ModeWrapped marks a value that wrapped past a limit.
+	ModeWrapped Mode = 0x08
+	// ModePreset asks the server to restore the default. The numeric field
+	// is ignored: measured against a live device, the Control Panel sends
+	// value 0 with this bit and expects the default back.
+	ModePreset Mode = 0x10
+	// ModeMatchID means a unit type follows, and the write applies only if
+	// it matches the receiver. Used with blind control.
+	ModeMatchID Mode = 0x20
+)
+
+// Has reports whether every bit in want is present.
+func (m Mode) Has(want Mode) bool { return m&want == want }
+
+func (m Mode) String() string {
+	if m == 0 {
+		return "-"
+	}
+	var b strings.Builder
+	for _, e := range []struct {
+		bit  Mode
+		name string
+	}{
+		{ModeValue, "VALUE"}, {ModeString, "STRING"}, {ModeData, "DATA"},
+		{ModeWrapped, "WRAPPED"}, {ModePreset, "PRESET"}, {ModeMatchID, "MATCH_ID"},
+	} {
+		if m&e.bit != 0 {
+			if b.Len() > 0 {
+				b.WriteByte('|')
+			}
+			b.WriteString(e.name)
+		}
+	}
+	return b.String()
+}
+
+// Style is the rStyle field of a menu line (spec 12.6). The high nibble
+// selects the line kind, the low nibble carries flags.
+type Style uint16
+
+// Line kinds, in the high nibble.
+const (
+	StyleTiled      Style = 0x00
+	StyleList       Style = 0x10
+	StyleDisplay    Style = 0x20
+	StyleButton     Style = 0x30
+	StyleCheckbox   Style = 0x40
+	StyleNumber     Style = 0x50
+	StyleVGraph     Style = 0x60
+	StyleHGraph     Style = 0x70
+	StyleEditString Style = 0x80
+	StyleVLevel     Style = 0x90
+	StyleHLevel     Style = 0xA0
+	StylePartial    Style = 0xB0
+	StyleData       Style = 0xC0
+	StyleLink       Style = 0xD0
+
+	StyleKindMask Style = 0x00F0
+	StyleFlagMask Style = 0x000F
+)
+
+// Line flags, in the low nibble, plus one private bit.
+const (
+	StyleCacheable Style = 0x0001
+	StyleWraps     Style = 0x0002
+	StyleDisabled  Style = 0x0004
+	StyleHidden    Style = 0x0008
+
+	// StyleDeferred is set by the vendor's Rope engine on back-channel menu
+	// updates to say "more are coming, hold the redraw". It is not in the
+	// specification's style table (ropedef.h).
+	StyleDeferred Style = 0x8000
+)
+
+// Kind returns the line kind with the flags masked off.
+func (s Style) Kind() Style { return s & StyleKindMask }
+
+// Container reports whether the line owns the following Step lines as its
+// subtree. Only tiled and list lines do.
+func (s Style) Container() bool {
+	k := s.Kind()
+	return k == StyleTiled || k == StyleList
+}
+
+// Cacheable reports whether a client may cache the line across connections.
+func (s Style) Cacheable() bool { return s&StyleCacheable != 0 }
+
+// Hidden reports whether the line should not be drawn.
+func (s Style) Hidden() bool { return s&StyleHidden != 0 }
+
+// Disabled reports whether the line is inert. A disabled container disables
+// its whole subtree.
+func (s Style) Disabled() bool { return s&StyleDisabled != 0 }
+
+// Deferred reports the vendor's hold-the-redraw hint.
+func (s Style) Deferred() bool { return s&StyleDeferred != 0 }
+
+// AccessGated reports the exact substitution the vendor menu engine performs
+// for a line the session's user level may not see: a Data line, hidden and
+// disabled, with command 0 and the text "Reserved" (rc_menu.c).
+//
+// It means "this line exists but not at your level", which is different from a
+// broken or empty line, and it is the only way to detect level gating: the
+// line count never changes.
+func AccessGated(s Style, command uint32, text string) bool {
+	return s.Kind() == StyleData && s.Hidden() && s.Disabled() &&
+		command == 0 && text == "Reserved"
+}
+
+func (s Style) String() string {
+	var name string
+	switch s.Kind() {
+	case StyleTiled:
+		name = "Tiled"
+	case StyleList:
+		name = "List"
+	case StyleDisplay:
+		name = "Display"
+	case StyleButton:
+		name = "Button"
+	case StyleCheckbox:
+		name = "Checkbox"
+	case StyleNumber:
+		name = "Number"
+	case StyleVGraph:
+		name = "VGraph"
+	case StyleHGraph:
+		name = "HGraph"
+	case StyleEditString:
+		name = "EditString"
+	case StyleVLevel:
+		name = "VLevel"
+	case StyleHLevel:
+		name = "HLevel"
+	case StylePartial:
+		name = "Partial"
+	case StyleData:
+		name = "Data"
+	case StyleLink:
+		name = "Link"
+	default:
+		name = "Style?"
+	}
+	var b strings.Builder
+	b.WriteString(name)
+	for _, e := range []struct {
+		bit  Style
+		name string
+	}{
+		{StyleCacheable, "Cacheable"}, {StyleWraps, "Wraps"},
+		{StyleDisabled, "Disabled"}, {StyleHidden, "Hidden"},
+		{StyleDeferred, "Deferred"},
+	} {
+		if s&e.bit != 0 {
+			b.WriteByte('+')
+			b.WriteString(e.name)
+		}
+	}
+	return b.String()
+}
+
+// TermCode explains why a session ended (spec 12.4).
+type TermCode uint16
+
+const (
+	TermUser     TermCode = 0
+	TermTimeout  TermCode = 1
+	TermNetError TermCode = 2
+	TermRemote   TermCode = 3
+)
+
+func (t TermCode) String() string {
+	switch t {
+	case TermUser:
+		return "user"
+	case TermTimeout:
+		return "timeout"
+	case TermNetError:
+		return "net-error"
+	case TermRemote:
+		return "remote"
+	default:
+		return "unknown(" + itoa(uint16(t)) + ")"
+	}
+}
+
+// Display line numbers below zero carry priority rather than position
+// (spec 11.5.4).
+const (
+	DisplayLineError   int16 = -1
+	DisplayLineWarning int16 = -2
+)
+
+func itoa(v uint16) string {
+	if v == 0 {
+		return "0"
+	}
+	var buf [5]byte
+	i := len(buf)
+	for v > 0 {
+		i--
+		buf[i] = byte('0' + v%10)
+		v /= 10
+	}
+	return string(buf[i:])
+}

--- a/internal/snell-rollcall/codec/bits_test.go
+++ b/internal/snell-rollcall/codec/bits_test.go
@@ -1,0 +1,261 @@
+package codec
+
+import "testing"
+
+// TestService_Bits pins the service mask of spec 12.1. The mask is what selects
+// a generation, so a wrong bit here changes which wire form a session speaks.
+func TestService_Bits(t *testing.T) {
+	want := map[Service]string{
+		0x0001: "Menus", 0x0002: "Control", 0x0004: "Display", 0x0008: "File",
+		0x0010: "Logging", 0x0020: "Stream", 0x0040: "Map", 0x0080: "Ports",
+		0x0100: "Net", 0x0200: "Exec", 0x0400: "Time", 0x0800: "Res2",
+		0x1000: "Thumbnail", 0x2000: "FastMenu", 0x4000: "Loc3", 0x8000: "LongStr",
+	}
+	for bit, name := range want {
+		if got := bit.String(); got != name {
+			t.Errorf("service %04X = %q, want %q", uint16(bit), got, name)
+		}
+	}
+
+	if got := Service(0).String(); got != "-" {
+		t.Errorf("empty mask = %q, want %q", got, "-")
+	}
+	if got := (SvcMenus | SvcControl | SvcLongStr).String(); got != "Menus|Control|LongStr" {
+		t.Errorf("combined mask = %q", got)
+	}
+}
+
+func TestService_Predicates(t *testing.T) {
+	m := SvcMenus | SvcControl | SvcLongStr
+
+	if !m.Has(SvcMenus | SvcControl) {
+		t.Error("Has must accept a subset")
+	}
+	if m.Has(SvcMenus | SvcFile) {
+		t.Error("Has must require every requested bit, not any")
+	}
+	if !m.LongStrings() {
+		t.Error("LongStrings must be true when bit 15 is set")
+	}
+	if (SvcMenus | SvcControl).LongStrings() {
+		t.Error("LongStrings must be false without bit 15")
+	}
+
+	// The regression this guards: SvcLongStr is bit 15, so a signed 16-bit
+	// variable makes the whole mask negative. Service is unsigned precisely so
+	// this comparison holds.
+	if uint16(SvcLongStr|SvcMenus|SvcControl) != 0x8003 {
+		t.Error("the long-string mask must be 0x8003, not a negative number")
+	}
+}
+
+func TestUserLevel(t *testing.T) {
+	tests := []struct {
+		lvl   UserLevel
+		name  string
+		valid bool
+	}{
+		{LevelUser, "user", true},
+		{LevelEngineer, "engineer", true},
+		{LevelSupervisor, "supervisor", true},
+		{LevelFactory, "factory", true},
+		{LevelAll, "all", false}, // a mask value, never sent in a Call
+		{99, "unknown", false},
+	}
+	for _, tc := range tests {
+		if got := tc.lvl.String(); got != tc.name {
+			t.Errorf("level %d = %q, want %q", tc.lvl, got, tc.name)
+		}
+		if got := tc.lvl.Valid(); got != tc.valid {
+			t.Errorf("level %s Valid = %v, want %v", tc.name, got, tc.valid)
+		}
+	}
+
+	// Ordering matters: gating is a >= comparison in the vendor engine.
+	ordered := []UserLevel{LevelUser, LevelEngineer, LevelSupervisor, LevelFactory}
+	for i := 1; i < len(ordered); i++ {
+		if ordered[i-1] >= ordered[i] {
+			t.Errorf("%s must sort below %s", ordered[i-1], ordered[i])
+		}
+	}
+}
+
+func TestStatus(t *testing.T) {
+	if got := Status(0).String(); got != "-" {
+		t.Errorf("empty status = %q", got)
+	}
+	if got := (StatusOnline | StatusPresent).String(); got != "Online|Present" {
+		t.Errorf("status = %q, want %q", got, "Online|Present")
+	}
+	full := StatusOnline | StatusMultiLevel | StatusPresent | StatusLocal
+	if got := full.String(); got != "Online|MultiLevel|Present|Local" {
+		t.Errorf("full status = %q", got)
+	}
+	if !(StatusOnline | StatusPresent).Has(StatusPresent) {
+		t.Error("Has must find a set bit")
+	}
+	if StatusOnline.Has(StatusPresent) {
+		t.Error("Has must not find a clear bit")
+	}
+}
+
+// TestMode pins the rMode field of spec 12.8, including the Preset bit whose
+// behaviour was measured against a live device rather than read from the spec.
+func TestMode(t *testing.T) {
+	want := map[Mode]string{
+		0x01: "VALUE", 0x02: "STRING", 0x04: "DATA",
+		0x08: "WRAPPED", 0x10: "PRESET", 0x20: "MATCH_ID",
+	}
+	for bit, name := range want {
+		if got := bit.String(); got != name {
+			t.Errorf("mode %02X = %q, want %q", uint16(bit), got, name)
+		}
+	}
+	if got := Mode(0).String(); got != "-" {
+		t.Errorf("empty mode = %q", got)
+	}
+	if got := (ModeValue | ModeString).String(); got != "VALUE|STRING" {
+		t.Errorf("mode = %q", got)
+	}
+	if !(ModeValue | ModePreset).Has(ModePreset) {
+		t.Error("Has must find the preset bit")
+	}
+	if ModeValue.Has(ModePreset) {
+		t.Error("Has must not find a clear bit")
+	}
+}
+
+// TestStyle_Kinds pins the line kinds of spec 12.6. The kind lives in the high
+// nibble and the flags in the low one, so masking is what keeps a flagged
+// button from decoding as a different widget.
+func TestStyle_Kinds(t *testing.T) {
+	tests := []struct {
+		style     Style
+		name      string
+		container bool
+	}{
+		{StyleTiled, "Tiled", true},
+		{StyleList, "List", true},
+		{StyleDisplay, "Display", false},
+		{StyleButton, "Button", false},
+		{StyleCheckbox, "Checkbox", false},
+		{StyleNumber, "Number", false},
+		{StyleVGraph, "VGraph", false},
+		{StyleHGraph, "HGraph", false},
+		{StyleEditString, "EditString", false},
+		{StyleVLevel, "VLevel", false},
+		{StyleHLevel, "HLevel", false},
+		{StylePartial, "Partial", false},
+		{StyleData, "Data", false},
+		{StyleLink, "Link", false},
+		{0xE0, "Style?", false}, // undefined kind
+	}
+	for _, tc := range tests {
+		if got := tc.style.String(); got != tc.name {
+			t.Errorf("style %04X = %q, want %q", uint16(tc.style), got, tc.name)
+		}
+		if got := tc.style.Container(); got != tc.container {
+			t.Errorf("%s Container = %v, want %v", tc.name, got, tc.container)
+		}
+		// Flags must not disturb the kind.
+		flagged := tc.style | StyleCacheable | StyleDisabled
+		if flagged.Kind() != tc.style.Kind() {
+			t.Errorf("%s: flags changed the kind to %04X", tc.name, uint16(flagged.Kind()))
+		}
+		if flagged.Container() != tc.container {
+			t.Errorf("%s: flags changed Container", tc.name)
+		}
+	}
+}
+
+func TestStyle_Flags(t *testing.T) {
+	s := StyleButton | StyleCacheable | StyleWraps | StyleDisabled | StyleHidden | StyleDeferred
+	if got, want := s.String(), "Button+Cacheable+Wraps+Disabled+Hidden+Deferred"; got != want {
+		t.Errorf("String = %q, want %q", got, want)
+	}
+	if !s.Cacheable() || !s.Hidden() || !s.Disabled() || !s.Deferred() {
+		t.Error("flag accessors disagree with the bits")
+	}
+
+	plain := StyleButton
+	if plain.Cacheable() || plain.Hidden() || plain.Disabled() || plain.Deferred() {
+		t.Error("a plain button reports a flag it does not carry")
+	}
+}
+
+// TestAccessGated pins the substitution the vendor menu engine performs for a
+// line above the session's user level: a hidden, disabled Data line with
+// command 0 and the text "Reserved".
+//
+// This is the only way to detect level gating, because the engine substitutes
+// rather than removes and the line count never changes. Every part of the
+// pattern must match, or an ordinary hidden Data line would be misread as
+// gated.
+func TestAccessGated(t *testing.T) {
+	gated := StyleData | StyleHidden | StyleDisabled
+
+	if !AccessGated(gated, 0, "Reserved") {
+		t.Error("the exact substitution must be recognised")
+	}
+	// Flags outside the pattern are allowed; the pattern is a minimum.
+	if !AccessGated(gated|StyleCacheable, 0, "Reserved") {
+		t.Error("an extra flag must not defeat the match")
+	}
+
+	for _, tc := range []struct {
+		name  string
+		style Style
+		cmd   uint32
+		text  string
+	}{
+		{"visible", StyleData | StyleDisabled, 0, "Reserved"},
+		{"enabled", StyleData | StyleHidden, 0, "Reserved"},
+		{"wrong kind", StyleDisplay | StyleHidden | StyleDisabled, 0, "Reserved"},
+		{"has a command", gated, 42, "Reserved"},
+		{"different text", gated, 0, "Spare"},
+		{"empty text", gated, 0, ""},
+	} {
+		if AccessGated(tc.style, tc.cmd, tc.text) {
+			t.Errorf("%s must not read as access-gated", tc.name)
+		}
+	}
+}
+
+func TestTermCode(t *testing.T) {
+	tests := []struct {
+		code TermCode
+		want string
+	}{
+		{TermUser, "user"},
+		{TermTimeout, "timeout"},
+		{TermNetError, "net-error"},
+		{TermRemote, "remote"},
+		{9, "unknown(9)"},
+		{0xFFFF, "unknown(65535)"},
+	}
+	for _, tc := range tests {
+		if got := tc.code.String(); got != tc.want {
+			t.Errorf("TermCode(%d) = %q, want %q", tc.code, got, tc.want)
+		}
+	}
+}
+
+// TestDisplayLinePriorities pins spec 11.5.4: a negative display line number is
+// a priority, not a position.
+func TestDisplayLinePriorities(t *testing.T) {
+	if DisplayLineError != -1 || DisplayLineWarning != -2 {
+		t.Errorf("error/warning lines are %d/%d, want -1/-2",
+			DisplayLineError, DisplayLineWarning)
+	}
+}
+
+func TestItoa(t *testing.T) {
+	for _, tc := range []struct {
+		in   uint16
+		want string
+	}{{0, "0"}, {7, "7"}, {42, "42"}, {1000, "1000"}, {65535, "65535"}} {
+		if got := itoa(tc.in); got != tc.want {
+			t.Errorf("itoa(%d) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/snell-rollcall/codec/capture_test.go
+++ b/internal/snell-rollcall/codec/capture_test.go
@@ -1,0 +1,234 @@
+package codec
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// capturePath is the trace taken off the live stack on 10.6.250.105 on
+// 2026-09-07: RollProxy on :2050 and a Centra controller on :2057, both
+// generations, 15 real units.
+//
+// It lives under docs/ rather than testdata/ because it is audit evidence
+// first; unit 9 promotes a trimmed subset into testdata/ per ADR-0020.
+const capturePath = "../docs/captures/rollcall-live-2026-09-07.hex"
+
+// capturedFrame is one line of the trace. FromDevice distinguishes what the
+// equipment sent from what our probe sent, which matters because the probe
+// traffic in this trace includes frames recorded before a defect in it was
+// found. Only device-originated frames are an oracle.
+type capturedFrame struct {
+	FromDevice bool
+	Raw        []byte
+}
+
+// loadCapture returns every frame in the capture file. Lines are
+// "<tag> <TX|RX> <hex>"; comments start with '#'.
+func loadCapture(t *testing.T) []capturedFrame {
+	t.Helper()
+
+	f, err := os.Open(filepath.FromSlash(capturePath))
+	if err != nil {
+		t.Skipf("capture not available: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var out []capturedFrame
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		raw := fields[len(fields)-1]
+		if len(raw) < 2*HeaderSize || len(raw)%2 != 0 {
+			continue
+		}
+		b, err := hex.DecodeString(raw)
+		if err != nil {
+			continue
+		}
+		// "RX" marks a frame received from the equipment.
+		fromDevice := false
+		for _, fl := range fields {
+			if strings.EqualFold(fl, "RX") {
+				fromDevice = true
+			}
+		}
+		out = append(out, capturedFrame{FromDevice: fromDevice, Raw: b})
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("read capture: %v", err)
+	}
+	return out
+}
+
+// TestCapture_DecodesAndRoundTrips is the strongest check in this package: it
+// decodes every frame a real device sent or received and re-encodes it,
+// requiring byte equality.
+//
+// It catches what expected-byte tables cannot, because the vectors were
+// produced by Snell equipment rather than by this implementation.
+func TestCapture_DecodesAndRoundTrips(t *testing.T) {
+	frames := loadCapture(t)
+	if len(frames) < 100 {
+		t.Fatalf("only %d frames in the capture; expected the full trace", len(frames))
+	}
+
+	seen := map[PacketType]int{}
+	for i, cf := range frames {
+		raw := cf.Raw
+		f, n, err := DecodeFrame(raw)
+		if err != nil {
+			t.Fatalf("frame %d (%x): decode: %v", i, raw, err)
+		}
+		if n != len(raw) {
+			t.Errorf("frame %d: consumed %d of %d bytes", i, n, len(raw))
+		}
+
+		out, err := f.Encode()
+		if err != nil {
+			t.Fatalf("frame %d (%s): encode: %v", i, f, err)
+		}
+		if !bytes.Equal(out, raw) {
+			t.Fatalf("frame %d (%s) does not round trip\n got %x\nwant %x", i, f, out, raw)
+		}
+		seen[f.Type]++
+	}
+
+	// The capture must exercise a real spread of the catalogue, not just
+	// keepalives, or the check above proves very little.
+	if len(seen) < 15 {
+		t.Errorf("capture covers only %d packet types, want at least 15", len(seen))
+	}
+	t.Logf("%d frames, %d distinct packet types", len(frames), len(seen))
+
+	// Both generations must be present: this connector exists to serve both.
+	var gen16, gen32 int
+	for typ, n := range seen {
+		if typ.Gen32() {
+			gen32 += n
+		} else {
+			gen16 += n
+		}
+	}
+	if gen16 == 0 || gen32 == 0 {
+		t.Errorf("capture is one-sided: %d 16-bit frames, %d 32-bit", gen16, gen32)
+	}
+}
+
+// TestCapture_PayloadsDecode decodes the payload of every frame whose type
+// this unit implements, so a structural mistake surfaces here rather than
+// three units later in the consumer.
+func TestCapture_PayloadsDecode(t *testing.T) {
+	frames := loadCapture(t)
+
+	decoded := map[PacketType]int{}
+	for i, cf := range frames {
+		raw := cf.Raw
+		f, _, err := DecodeFrame(raw)
+		if err != nil {
+			t.Fatalf("frame %d: %v", i, err)
+		}
+
+		var derr error
+		switch f.Type {
+		case MsgCall:
+			_, derr = DecodeConnect(f.Payload)
+		case MsgTerm:
+			_, derr = DecodeTermSess(f.Payload)
+		case MsgClearSess:
+			_, derr = DecodeClearSess(f.Payload)
+		case MsgRetID:
+			_, derr = DecodeID(f.Payload)
+		case MsgRetStat:
+			_, derr = DecodeUnitStatus(f.Payload)
+		case MsgRetDevInfo, MsgIam:
+			_, derr = DecodeDeviceInfo(f.Payload)
+		case MsgGetFStat:
+			_, derr = DecodeGetFStat(f.Payload)
+		case MsgRetFStat, MsgSetParam:
+			_, derr = DecodeFuncStatus(f.Payload)
+		case MsgRetFunc:
+			_, derr = DecodeFunc(f.Payload)
+		case MsgFuncStyleChg:
+			_, derr = DecodeFuncStyle(f.Payload)
+		case MsgBlockHeader:
+			_, derr = DecodeBlockHeader(f.Payload)
+		case MsgGetNextPkt:
+			_, derr = DecodeGetNext(f.Payload)
+		case MsgDispData:
+			_, derr = DecodeDisp(f.Payload)
+		case MsgWait:
+			_, derr = DecodeWait(f.Payload)
+		case MsgSetMulti:
+			_, derr = DecodeMultiValues(f.Payload)
+		default:
+			continue // 32-bit types and the file service arrive in later units
+		}
+		if derr != nil {
+			t.Errorf("frame %d (%s): payload: %v\n  %x", i, f, derr, f.Payload)
+			continue
+		}
+		decoded[f.Type]++
+	}
+
+	if len(decoded) == 0 {
+		t.Fatal("no payloads decoded; the switch above matched nothing")
+	}
+	for typ, n := range decoded {
+		t.Logf("  %-14s %4d", typ, n)
+	}
+}
+
+// TestCapture_UnknownSessionIsAlways255 pins the defect that crashed a vendor
+// simulator three times during the audit: the unconnected session index is the
+// value 255, and writing it as a signed -1 puts 0xFFFF on the wire.
+//
+// The assertion is on device-originated frames only. Our own probe traffic in
+// this trace was recorded on both sides of the fix, so it still contains the
+// bad encoding; that is history, and the second half of this test asserts it is
+// present so the evidence is not quietly lost.
+func TestCapture_UnknownSessionIsAlways255(t *testing.T) {
+	frames := loadCapture(t)
+
+	var deviceFrames, badProbe int
+	for i, cf := range frames {
+		f, _, err := DecodeFrame(cf.Raw)
+		if err != nil {
+			t.Fatalf("frame %d: %v", i, err)
+		}
+		bad := uint16(f.Dst.Index) == 0xFFFF || uint16(f.Src.Index) == 0xFFFF
+
+		if cf.FromDevice {
+			deviceFrames++
+			if bad {
+				t.Errorf("frame %d (%s): a device sent index 0xFFFF; UNKNOWNSESS is %d",
+					i, f, IndexUnknown)
+			}
+			continue
+		}
+		if bad {
+			badProbe++
+		}
+	}
+
+	if deviceFrames == 0 {
+		t.Fatal("no device-originated frames in the capture")
+	}
+	t.Logf("%d device frames carry a well-formed session index", deviceFrames)
+
+	if badProbe == 0 {
+		t.Log("no pre-fix probe frames remain in the capture")
+	} else {
+		t.Logf("%d probe frames still carry the pre-fix 0xFFFF encoding "+
+			"(recorded before the defect was found; devices never do this)", badProbe)
+	}
+}

--- a/internal/snell-rollcall/codec/doc.go
+++ b/internal/snell-rollcall/codec/doc.go
@@ -1,0 +1,48 @@
+// Package codec implements the Snell RollCall wire format.
+//
+// It is stdlib-only and must stay that way (ADR-0006): it never imports
+// dhs/*, so it can be lifted into its own repository unchanged.
+//
+// # Wire shape
+//
+// Every RollCall message on TCP is a 4-byte transmission header followed by a
+// 14-byte address header, a 2-byte message header, and the payload:
+//
+//	off  size  field
+//	 0    2    TxHeader.Flags   = 0x000C
+//	 2    2    TxHeader.Length  = 14 + RLength
+//	 4    6    Dst {Net u16, Unit u8, Port u8, Index i16}
+//	10    6    Src {same}
+//	16    2    RLength = 2 + len(payload)
+//	18    1    Type   (0..71)
+//	19    1    Flags  (0x80 back channel, 0x40 wide area)
+//	20    n    payload
+//
+// We encode payloads within 420 bytes, the largest the vendor library will
+// queue, and decode up to the 1554 the specification permits, so a legal peer
+// is never rejected for sending more than we would send ourselves.
+//
+// All multi-byte fields are big-endian and every struct is packed with no
+// padding, with one documented exception: GetNext carries a trailing pad byte
+// so that it occupies 4 bytes rather than 3.
+//
+// # Two generations
+//
+// RollCall has two coexisting payload generations. The original uses 16-bit
+// command and menu numbers with strings in fixed 20-byte fields. The 2014
+// extension adds packet types 65..71 with 32-bit numbers and NUL-terminated
+// UTF-8 strings up to 64 bytes. Which one a session uses is negotiated by the
+// SvcLongStr bit in the Call service mask, not by anything in the frame
+// header, so the codec decodes whichever form it is handed and leaves the
+// negotiation to the session layer.
+//
+// This file set covers the frame, the addressing and the 16-bit payloads.
+//
+// # Sources
+//
+// Byte layouts come from the RollCall Technical Specification Revision 14 and,
+// where the specification is silent, from the vendor C library under
+// assets/Protocol/Source/RollCallV2. Both are quoted per struct. Test vectors
+// are taken from the specification and from frames captured off a live device;
+// never from this implementation.
+package codec

--- a/internal/snell-rollcall/codec/errors.go
+++ b/internal/snell-rollcall/codec/errors.go
@@ -1,0 +1,74 @@
+package codec
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Sentinel errors. Call sites use errors.Is / errors.As, never string matching
+// (root CLAUDE.md).
+var (
+	// ErrShortBuffer means the input ended before a structure was complete.
+	ErrShortBuffer = errors.New("rollcall: short buffer")
+
+	// ErrBadTxFlags means the transmission header did not carry the only
+	// compatibility mode still in use (TxFlagsMode3, spec 10.2.1).
+	ErrBadTxFlags = errors.New("rollcall: bad transmission header flags")
+
+	// ErrBadTxLength means the transmission header length was outside the
+	// range the specification permits.
+	ErrBadTxLength = errors.New("rollcall: bad transmission header length")
+
+	// ErrLengthMismatch means the transmission header length and the message
+	// header RLength disagree about how long the frame is.
+	ErrLengthMismatch = errors.New("rollcall: header length mismatch")
+
+	// ErrPayloadTooLong means an encode would exceed MaxPayload.
+	ErrPayloadTooLong = errors.New("rollcall: payload too long")
+
+	// ErrBadRoute means a Net route has a zero nibble below a non-zero one.
+	// Routes fill from the top nibble down and may not contain gaps
+	// (vendor Core/Transmit.c CheckForRoutingError).
+	ErrBadRoute = errors.New("rollcall: malformed net route")
+
+	// ErrBadAddress means an address string was not NNNN-UU-PP or
+	// NNNN-UU-PP:SS with hexadecimal fields.
+	ErrBadAddress = errors.New("rollcall: malformed address")
+
+	// ErrStringTooLong means a string did not fit the field it was destined
+	// for: 20 bytes including the terminator for the 16-bit generation, 64
+	// for the 32-bit one.
+	ErrStringTooLong = errors.New("rollcall: string too long for field")
+)
+
+// DecodeError locates a decode failure inside a structure so that a log line
+// or a test failure names the field rather than a byte offset alone.
+type DecodeError struct {
+	Struct string // e.g. "DeviceInfo"
+	Field  string // e.g. "Name"
+	Offset int    // byte offset within the payload
+	Err    error
+}
+
+func (e *DecodeError) Error() string {
+	if e.Field == "" {
+		return fmt.Sprintf("rollcall: decode %s at +%d: %v", e.Struct, e.Offset, e.Err)
+	}
+	return fmt.Sprintf("rollcall: decode %s.%s at +%d: %v", e.Struct, e.Field, e.Offset, e.Err)
+}
+
+func (e *DecodeError) Unwrap() error { return e.Err }
+
+// decodeErr is the internal shorthand for building a DecodeError.
+func decodeErr(structName, field string, offset int, err error) error {
+	return &DecodeError{Struct: structName, Field: field, Offset: offset, Err: err}
+}
+
+// need reports a short-buffer DecodeError when b is smaller than want.
+func need(b []byte, want int, structName, field string) error {
+	if len(b) < want {
+		return decodeErr(structName, field, len(b),
+			fmt.Errorf("%w: need %d bytes, have %d", ErrShortBuffer, want, len(b)))
+	}
+	return nil
+}

--- a/internal/snell-rollcall/codec/frame.go
+++ b/internal/snell-rollcall/codec/frame.go
@@ -1,0 +1,276 @@
+package codec
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// Wire sizes and limits.
+const (
+	// TxHeaderSize is the transmission header that precedes every RollCall
+	// message on TCP (spec 10.2.1).
+	TxHeaderSize = 4
+
+	// MsgHeaderSize is MESSAGE_STR: two addresses and a length (spec 11.1.2).
+	MsgHeaderSize = 14
+
+	// RollHeaderSize is ROLLHEADER_STR: type and flags (spec 11.2.1).
+	RollHeaderSize = 2
+
+	// HeaderSize is everything before the payload.
+	HeaderSize = TxHeaderSize + MsgHeaderSize + RollHeaderSize
+
+	// MaxPayload is the largest payload the vendor library will queue
+	// (MAX_QUEUED_DATA_SIZE, CoreServiceAPI.h). We encode within it.
+	MaxPayload = 420
+
+	// MaxFrame is the largest frame we will encode: 440 bytes.
+	MaxFrame = HeaderSize + MaxPayload
+
+	// SpecMaxTxLength is the largest transmission-header length the
+	// specification permits (10.2.1: "within the range 1 to 1570"). We
+	// decode up to this so a spec-legal peer is never rejected, while
+	// encoding stays within MaxPayload.
+	SpecMaxTxLength = 1570
+
+	// MaxDecodePayload is the largest payload we will accept when decoding.
+	MaxDecodePayload = SpecMaxTxLength - MsgHeaderSize - RollHeaderSize
+
+	// MaxDecodeFrame is the largest complete frame we will accept when
+	// decoding: the transmission header plus the largest length it may
+	// declare. The Reader's buffer must hold one of these, or a spec-legal
+	// peer could send a frame we can never assemble.
+	MaxDecodeFrame = TxHeaderSize + SpecMaxTxLength
+)
+
+// TxFlagsMode3 is the only transmission-header flag value still in use. Modes
+// 1 and 2 are historical and are not produced by anything shipping. The vendor
+// header spells its macro TXHDR_COMPATABILITY_MODE3, misspelling included, so
+// that name is searchable against RC3IP.H.
+//
+//nolint:misspell // vendor macro name quoted verbatim
+const TxFlagsMode3 uint16 = 12
+
+// Packet flags (spec 3.1).
+const (
+	// FlagBackChannel marks unsolicited data from a server to a client and
+	// the replies to it.
+	FlagBackChannel uint8 = 0x80
+
+	// FlagWideArea asks bridges to forward a broadcast onto other segments.
+	FlagWideArea uint8 = 0x40
+)
+
+// Frame is one decoded RollCall message.
+//
+// Payload aliases the caller's buffer after Decode; copy it if it must outlive
+// the read. Encode never retains it.
+type Frame struct {
+	Dst     Address
+	Src     Address
+	Type    PacketType
+	Flags   uint8
+	Payload []byte
+}
+
+// BackChannel reports whether the frame travelled on the back channel.
+func (f Frame) BackChannel() bool { return f.Flags&FlagBackChannel != 0 }
+
+// WideArea reports whether the frame is a broadcast bridges should forward.
+func (f Frame) WideArea() bool { return f.Flags&FlagWideArea != 0 }
+
+// Size returns the number of bytes the frame occupies on the wire.
+func (f Frame) Size() int { return HeaderSize + len(f.Payload) }
+
+// String renders the frame the way the vendor's Comms Window does: direction
+// is the caller's business, so this covers everything else. Used by the
+// decoded trace and by test failures.
+func (f Frame) String() string {
+	return fmt.Sprintf("%s => %s %s flags=%s len=%d",
+		f.Src, f.Dst, f.Type, flagString(f.Flags), len(f.Payload))
+}
+
+func flagString(fl uint8) string {
+	switch {
+	case fl&FlagBackChannel != 0 && fl&FlagWideArea != 0:
+		return "BW"
+	case fl&FlagBackChannel != 0:
+		return "B"
+	case fl&FlagWideArea != 0:
+		return "W"
+	default:
+		return "-"
+	}
+}
+
+// AppendTo appends the complete wire form of the frame to dst.
+func (f Frame) AppendTo(dst []byte) ([]byte, error) {
+	if len(f.Payload) > MaxPayload {
+		return nil, fmt.Errorf("%w: %d > %d", ErrPayloadTooLong, len(f.Payload), MaxPayload)
+	}
+
+	rLength := RollHeaderSize + len(f.Payload)
+
+	var tx [TxHeaderSize]byte
+	binary.BigEndian.PutUint16(tx[0:2], TxFlagsMode3)
+	binary.BigEndian.PutUint16(tx[2:4], uint16(MsgHeaderSize+rLength))
+	dst = append(dst, tx[:]...)
+
+	dst = f.Dst.AppendTo(dst)
+	dst = f.Src.AppendTo(dst)
+
+	var tail [RollHeaderSize + 2]byte
+	binary.BigEndian.PutUint16(tail[0:2], uint16(rLength))
+	tail[2] = byte(f.Type)
+	tail[3] = f.Flags
+	dst = append(dst, tail[:]...)
+
+	return append(dst, f.Payload...), nil
+}
+
+// Encode returns the complete wire form of the frame.
+func (f Frame) Encode() ([]byte, error) {
+	return f.AppendTo(make([]byte, 0, f.Size()))
+}
+
+// DecodeFrame decodes one complete frame from the front of b and reports how
+// many bytes it consumed.
+//
+// It validates the two independent length fields against each other. The
+// vendor library drops a frame whose lengths disagree without reporting it
+// (IPShClient.c); we return ErrLengthMismatch so the caller can raise a
+// compliance event instead of losing traffic silently.
+func DecodeFrame(b []byte) (Frame, int, error) {
+	if err := need(b, TxHeaderSize, "TxHeader", ""); err != nil {
+		return Frame{}, 0, err
+	}
+
+	flags := binary.BigEndian.Uint16(b[0:2])
+	if flags != TxFlagsMode3 {
+		return Frame{}, 0, fmt.Errorf("%w: 0x%04X, want 0x%04X", ErrBadTxFlags, flags, TxFlagsMode3)
+	}
+
+	txLen := int(binary.BigEndian.Uint16(b[2:4]))
+	if txLen < MsgHeaderSize+RollHeaderSize || txLen > SpecMaxTxLength {
+		return Frame{}, 0, fmt.Errorf("%w: %d", ErrBadTxLength, txLen)
+	}
+
+	total := TxHeaderSize + txLen
+	if len(b) < total {
+		return Frame{}, 0, decodeErr("Frame", "", len(b),
+			fmt.Errorf("%w: need %d bytes, have %d", ErrShortBuffer, total, len(b)))
+	}
+
+	body := b[TxHeaderSize:total]
+
+	// txLen was checked against MsgHeaderSize+RollHeaderSize above, so the
+	// two addresses and the length word are present; and once rLength is
+	// known to agree with txLen it is necessarily at least RollHeaderSize.
+	rLength := int(binary.BigEndian.Uint16(body[12:14]))
+	if rLength+MsgHeaderSize != txLen {
+		return Frame{}, 0, fmt.Errorf("%w: rLength %d + %d != txLength %d",
+			ErrLengthMismatch, rLength, MsgHeaderSize, txLen)
+	}
+
+	return Frame{
+		Dst:     addressAt(body[0:6]),
+		Src:     addressAt(body[6:12]),
+		Type:    PacketType(body[14]),
+		Flags:   body[15],
+		Payload: body[16:],
+	}, total, nil
+}
+
+// Reader decodes frames from a byte stream.
+//
+// On a malformed transmission header it resynchronises by discarding a single
+// byte and retrying. The vendor library discards four at a time, which can
+// never re-align a stream that slipped by an odd number of bytes; one byte
+// always can. Resyncs are counted so a caller can raise a compliance event.
+type Reader struct {
+	r    io.Reader
+	buf  []byte
+	n    int // bytes buffered
+	off  int // read offset into buf
+	sync uint64
+}
+
+// NewReader wraps r.
+//
+// The buffer holds two maximum-size frames. It is sized from MaxDecodeFrame
+// rather than from MaxFrame, because what we may receive is bounded by the
+// specification's limit and not by the smaller one we encode within: a peer
+// that sends a legal 1570-byte message must still be readable.
+func NewReader(r io.Reader) *Reader {
+	return newReaderSize(r, 2*MaxDecodeFrame)
+}
+
+// newReaderSize wraps r with an explicit buffer size. It exists so the
+// buffer-full guard in fill can be exercised; NewReader always supplies a
+// buffer large enough that the guard cannot fire.
+func newReaderSize(r io.Reader, size int) *Reader {
+	if size < HeaderSize {
+		size = HeaderSize
+	}
+	return &Reader{r: r, buf: make([]byte, 0, size)}
+}
+
+// Resyncs reports how many bytes have been discarded to regain framing.
+func (r *Reader) Resyncs() uint64 { return r.sync }
+
+// ReadFrame returns the next frame.
+//
+// The returned Payload aliases the reader's buffer and is only valid until the
+// next call; copy it if it must outlive that.
+func (r *Reader) ReadFrame() (Frame, error) {
+	for {
+		if r.n-r.off > 0 {
+			f, used, err := DecodeFrame(r.buf[r.off:r.n])
+			switch {
+			case err == nil:
+				r.off += used
+				return f, nil
+			case errors.Is(err, ErrShortBuffer):
+				// Need more bytes; fall through to fill.
+			default:
+				// Any other decode failure means framing is lost:
+				// drop one byte and try again.
+				r.off++
+				r.sync++
+				continue
+			}
+		}
+		if err := r.fill(); err != nil {
+			return Frame{}, err
+		}
+	}
+}
+
+// fill compacts the buffer and reads at least one more byte.
+func (r *Reader) fill() error {
+	if r.off > 0 {
+		copy(r.buf[:cap(r.buf)], r.buf[r.off:r.n])
+		r.n -= r.off
+		r.off = 0
+	}
+	if r.n == cap(r.buf) {
+		// Unreachable through NewReader, whose buffer holds more than the
+		// largest frame DecodeFrame will accept. Kept as a guard so an
+		// undersized buffer fails loudly instead of spinning.
+		return fmt.Errorf("%w: buffer full at %d bytes", ErrBadTxLength, r.n)
+	}
+
+	buf := r.buf[:cap(r.buf)]
+	n, err := r.r.Read(buf[r.n:])
+	r.n += n
+	if n > 0 {
+		r.buf = buf[:r.n]
+		return nil
+	}
+	if err == nil {
+		err = io.ErrNoProgress
+	}
+	return err
+}

--- a/internal/snell-rollcall/codec/frame_test.go
+++ b/internal/snell-rollcall/codec/frame_test.go
@@ -1,0 +1,437 @@
+package codec
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// mustHex decodes a spec-derived hex vector.
+func mustHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(strings.ReplaceAll(s, " ", ""))
+	if err != nil {
+		t.Fatalf("bad test vector %q: %v", s, err)
+	}
+	return b
+}
+
+// specIamFrame is the SP_IAM frame printed in the vendor ExampleClient
+// readme, reconstructed per spec 11: transmission header, MESSAGE_STR,
+// ROLLHEADER_STR and a 40-byte DEVICEINFO_STR.
+//
+// Trailing name padding is zeroed here rather than the 0xCD the vendor client
+// leaks, because padding after the terminator is undefined and a fixture must
+// not depend on it.
+const specIamFrame = "000c 0038" + // flags 12, length 56 = 14 + 2 + 40
+	"0000 00 00 00ff" + // dst 0000-00-00:FF broadcast
+	"0000 ff 00 00ff" + // src 0000-FF-00:FF
+	"002a" + // rLength 42 = 2 + 40
+	"21 00" + // type 33 IAM, flags 0
+	"0003" + // protocol version 3
+	"0000 ff 00 00ff" + // device address
+	"0000" + // services none
+	"01e3" + // type id 483
+	"01 00 20 01" + // v1.0 ' ' cmdset 1
+	"5465737443 6c69656e74 0000000000 0000000000" + // "TestClient" padded
+	"0000 0008" // service status 0, status Present
+
+func TestDecodeFrame_SpecIam(t *testing.T) {
+	raw := mustHex(t, specIamFrame)
+
+	f, n, err := DecodeFrame(raw)
+	if err != nil {
+		t.Fatalf("DecodeFrame: %v", err)
+	}
+	if n != len(raw) {
+		t.Errorf("consumed %d bytes, want %d", n, len(raw))
+	}
+	if f.Type != MsgIam {
+		t.Errorf("Type = %s, want IAM", f.Type)
+	}
+	if f.Flags != 0 {
+		t.Errorf("Flags = 0x%02X, want 0", f.Flags)
+	}
+	if !f.Dst.IsBroadcast() {
+		t.Errorf("Dst = %s, want broadcast", f.Dst)
+	}
+	if f.Dst.Index != IndexUnknown {
+		t.Errorf("Dst.Index = %d, want %d (UNKNOWNSESS)", f.Dst.Index, IndexUnknown)
+	}
+	if got, want := len(f.Payload), DeviceInfoSize; got != want {
+		t.Fatalf("payload %d bytes, want %d", got, want)
+	}
+
+	info, err := DecodeDeviceInfo(f.Payload)
+	if err != nil {
+		t.Fatalf("DecodeDeviceInfo: %v", err)
+	}
+	if info.ProtocolVersion != ProtocolVersion {
+		t.Errorf("ProtocolVersion = %d, want %d", info.ProtocolVersion, ProtocolVersion)
+	}
+	if info.ID.TypeID != 483 {
+		t.Errorf("TypeID = %d, want 483", info.ID.TypeID)
+	}
+	if info.ID.Name != "TestClient" {
+		t.Errorf("Name = %q, want %q", info.ID.Name, "TestClient")
+	}
+	if !info.Status.Status.Has(StatusPresent) {
+		t.Errorf("Status = %s, want Present", info.Status.Status)
+	}
+}
+
+func TestFrame_RoundTrip(t *testing.T) {
+	raw := mustHex(t, specIamFrame)
+	f, _, err := DecodeFrame(raw)
+	if err != nil {
+		t.Fatalf("DecodeFrame: %v", err)
+	}
+	out, err := f.Encode()
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if !bytes.Equal(out, raw) {
+		t.Errorf("round trip differs\n got %x\nwant %x", out, raw)
+	}
+}
+
+func TestDecodeFrame_Rejects(t *testing.T) {
+	good := mustHex(t, specIamFrame)
+
+	tests := []struct {
+		name string
+		in   []byte
+		want error
+	}{
+		{"empty", nil, ErrShortBuffer},
+		{"header only", good[:3], ErrShortBuffer},
+		{"truncated body", good[:20], ErrShortBuffer},
+		{"bad flags", func() []byte {
+			b := append([]byte(nil), good...)
+			b[1] = 0x0B // mode 2, historical and not accepted
+			return b
+		}(), ErrBadTxFlags},
+		{"zero length", func() []byte {
+			b := append([]byte(nil), good...)
+			b[2], b[3] = 0, 0
+			return b
+		}(), ErrBadTxLength},
+		{"length over spec max", func() []byte {
+			b := append([]byte(nil), good...)
+			b[2], b[3] = 0xFF, 0xFF // 65535 > 1570
+			return b
+		}(), ErrBadTxLength},
+		{"rLength disagrees", func() []byte {
+			b := append([]byte(nil), good...)
+			b[16], b[17] = 0x00, 0x10 // rLength 16, but txLength says 42
+			return b
+		}(), ErrLengthMismatch},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, _, err := DecodeFrame(tc.in); !errors.Is(err, tc.want) {
+				t.Errorf("err = %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestFrame_EncodeRejectsOversizePayload(t *testing.T) {
+	f := Frame{Type: MsgRaw, Payload: make([]byte, MaxPayload+1)}
+	if _, err := f.Encode(); !errors.Is(err, ErrPayloadTooLong) {
+		t.Errorf("err = %v, want ErrPayloadTooLong", err)
+	}
+}
+
+func TestFrame_Accessors(t *testing.T) {
+	f := Frame{Flags: FlagBackChannel | FlagWideArea, Payload: []byte{1, 2, 3}}
+	if !f.BackChannel() || !f.WideArea() {
+		t.Error("flag accessors disagree with Flags")
+	}
+	if got, want := f.Size(), HeaderSize+3; got != want {
+		t.Errorf("Size = %d, want %d", got, want)
+	}
+
+	for _, tc := range []struct {
+		flags uint8
+		want  string
+	}{
+		{0, "-"},
+		{FlagBackChannel, "B"},
+		{FlagWideArea, "W"},
+		{FlagBackChannel | FlagWideArea, "BW"},
+	} {
+		if got := flagString(tc.flags); got != tc.want {
+			t.Errorf("flagString(0x%02X) = %q, want %q", tc.flags, got, tc.want)
+		}
+	}
+
+	if s := (Frame{Type: MsgAck}).String(); !strings.Contains(s, "ACK") {
+		t.Errorf("String() = %q, want it to name the type", s)
+	}
+}
+
+// TestReader_ResyncsOneByteAtATime is the regression for a real defect in the
+// vendor library: it discards four bytes at a time when framing is lost, which
+// can never re-align a stream that slipped by an odd number of bytes.
+func TestReader_ResyncsOneByteAtATime(t *testing.T) {
+	good := mustHex(t, specIamFrame)
+
+	// One junk byte, so the following frame starts on an odd offset.
+	stream := append([]byte{0xAA}, good...)
+	r := NewReader(bytes.NewReader(stream))
+
+	f, err := r.ReadFrame()
+	if err != nil {
+		t.Fatalf("ReadFrame after 1 junk byte: %v", err)
+	}
+	if f.Type != MsgIam {
+		t.Errorf("Type = %s, want IAM", f.Type)
+	}
+	if r.Resyncs() != 1 {
+		t.Errorf("Resyncs = %d, want 1", r.Resyncs())
+	}
+}
+
+func TestReader_MultipleFramesAndEOF(t *testing.T) {
+	good := mustHex(t, specIamFrame)
+	r := NewReader(bytes.NewReader(append(append([]byte{}, good...), good...)))
+
+	for i := range 2 {
+		if _, err := r.ReadFrame(); err != nil {
+			t.Fatalf("frame %d: %v", i, err)
+		}
+	}
+	if _, err := r.ReadFrame(); !errors.Is(err, io.EOF) {
+		t.Errorf("err = %v, want io.EOF", err)
+	}
+	if r.Resyncs() != 0 {
+		t.Errorf("Resyncs = %d, want 0 on a clean stream", r.Resyncs())
+	}
+}
+
+// TestReader_SplitAcrossReads covers the reassembly the specification demands:
+// "the underlying IP system may split the data and deliver it in separate
+// blocks" (spec 10.2.3).
+func TestReader_SplitAcrossReads(t *testing.T) {
+	good := mustHex(t, specIamFrame)
+	r := NewReader(&iotest{parts: [][]byte{good[:3], good[3:9], good[9:]}})
+
+	f, err := r.ReadFrame()
+	if err != nil {
+		t.Fatalf("ReadFrame: %v", err)
+	}
+	if f.Type != MsgIam {
+		t.Errorf("Type = %s, want IAM", f.Type)
+	}
+}
+
+func TestReader_PropagatesDecodeError(t *testing.T) {
+	// A frame whose declared payload never arrives: EOF mid-frame.
+	good := mustHex(t, specIamFrame)
+	r := NewReader(bytes.NewReader(good[:len(good)-4]))
+	if _, err := r.ReadFrame(); err == nil {
+		t.Fatal("want an error on a truncated stream")
+	}
+}
+
+// iotest hands out a fixed sequence of short reads.
+type iotest struct{ parts [][]byte }
+
+func (r *iotest) Read(p []byte) (int, error) {
+	if len(r.parts) == 0 {
+		return 0, io.EOF
+	}
+	n := copy(p, r.parts[0])
+	if n == len(r.parts[0]) {
+		r.parts = r.parts[1:]
+	} else {
+		r.parts[0] = r.parts[0][n:]
+	}
+	return n, nil
+}
+
+// specMaxFrame builds the largest frame the specification permits: a
+// transmission length of 1570. We never encode one, but a peer may send one and
+// the reader must be able to assemble it.
+func specMaxFrame(t *testing.T) []byte {
+	t.Helper()
+
+	payload := make([]byte, SpecMaxTxLength-MsgHeaderSize-RollHeaderSize)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+
+	b := make([]byte, 0, MaxDecodeFrame)
+	b = append(b, 0x00, 0x0C) // flags
+	txLen := SpecMaxTxLength
+	b = append(b, byte(txLen>>8), byte(txLen))
+	b = (Address{Unit: 0x20, Index: 1}).AppendTo(b)
+	b = (Address{Unit: 0xFF, Index: 1}).AppendTo(b)
+	rLength := RollHeaderSize + len(payload)
+	b = append(b, byte(rLength>>8), byte(rLength))
+	b = append(b, byte(MsgRaw), 0)
+	return append(b, payload...)
+}
+
+// TestReader_AcceptsSpecMaximumFrame is the regression for a sizing defect: the
+// reader's buffer held 880 bytes while DecodeFrame accepts up to 1574, so a
+// spec-legal large frame could never be assembled and the connection died with
+// a buffer-full error.
+func TestReader_AcceptsSpecMaximumFrame(t *testing.T) {
+	raw := specMaxFrame(t)
+	if len(raw) != MaxDecodeFrame {
+		t.Fatalf("test frame is %d bytes, want %d", len(raw), MaxDecodeFrame)
+	}
+
+	// Delivered in small pieces, the way a TCP stream really arrives.
+	var parts [][]byte
+	for off := 0; off < len(raw); off += 200 {
+		parts = append(parts, raw[off:minInt(off+200, len(raw))])
+	}
+
+	r := NewReader(&iotest{parts: parts})
+	f, err := r.ReadFrame()
+	if err != nil {
+		t.Fatalf("ReadFrame: %v", err)
+	}
+	if f.Type != MsgRaw {
+		t.Errorf("Type = %s, want RAW", f.Type)
+	}
+	if got, want := len(f.Payload), SpecMaxTxLength-MsgHeaderSize-RollHeaderSize; got != want {
+		t.Errorf("payload %d bytes, want %d", got, want)
+	}
+	if !bytes.Equal(f.Payload, raw[HeaderSize:]) {
+		t.Error("payload does not match what was sent")
+	}
+}
+
+// TestReader_UndersizedBufferFailsLoudly exercises the guard in fill. NewReader
+// always allocates more than MaxDecodeFrame so this cannot happen in service;
+// the guard exists so that if it ever did, the reader would report it instead
+// of spinning on a buffer it can never fill.
+func TestReader_UndersizedBufferFailsLoudly(t *testing.T) {
+	raw := specMaxFrame(t)
+	r := newReaderSize(bytes.NewReader(raw), 64)
+
+	_, err := r.ReadFrame()
+	if !errors.Is(err, ErrBadTxLength) {
+		t.Fatalf("err = %v, want ErrBadTxLength", err)
+	}
+	if !strings.Contains(err.Error(), "buffer full") {
+		t.Errorf("err = %v, want it to say the buffer is full", err)
+	}
+}
+
+func TestNewReaderSize_Floor(t *testing.T) {
+	r := newReaderSize(bytes.NewReader(nil), 1)
+	if got := cap(r.buf); got < HeaderSize {
+		t.Errorf("buffer capped at %d, want at least one header (%d)", got, HeaderSize)
+	}
+}
+
+// TestReader_ResyncsPastAnyFramingError covers the three ways framing can be
+// lost. Each costs exactly one byte, so a stream that slipped by an odd number
+// of bytes still recovers; the vendor library drops four at a time and never
+// re-aligns.
+func TestReader_ResyncsPastAnyFramingError(t *testing.T) {
+	good := mustHex(t, specIamFrame)
+
+	tests := []struct {
+		name  string
+		junk  []byte
+		syncs uint64
+	}{
+		{"bad flags", []byte{0x00, 0x0B, 0x00, 0x38}, 4},
+		{"zero length", []byte{0x00, 0x0C, 0x00, 0x00}, 4},
+		{"odd offset", []byte{0xAA}, 1},
+		{"several bytes", []byte{0xAA, 0xBB, 0xCC}, 3},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stream := append(append([]byte{}, tc.junk...), good...)
+			r := NewReader(bytes.NewReader(stream))
+
+			f, err := r.ReadFrame()
+			if err != nil {
+				t.Fatalf("ReadFrame: %v", err)
+			}
+			if f.Type != MsgIam {
+				t.Errorf("Type = %s, want IAM", f.Type)
+			}
+			if r.Resyncs() != tc.syncs {
+				t.Errorf("Resyncs = %d, want %d", r.Resyncs(), tc.syncs)
+			}
+		})
+	}
+}
+
+// TestReader_ResyncsPastLengthMismatch covers the case the vendor drops
+// silently: a frame whose two length fields disagree. We resync and count it so
+// the session layer can raise a compliance event rather than lose traffic.
+func TestReader_ResyncsPastLengthMismatch(t *testing.T) {
+	good := mustHex(t, specIamFrame)
+
+	bad := append([]byte(nil), good...)
+	bad[16], bad[17] = 0x00, 0x10 // rLength 16 against a txLength of 42
+
+	r := NewReader(bytes.NewReader(append(bad, good...)))
+	f, err := r.ReadFrame()
+	if err != nil {
+		t.Fatalf("ReadFrame: %v", err)
+	}
+	if f.Type != MsgIam {
+		t.Errorf("Type = %s, want IAM", f.Type)
+	}
+	if r.Resyncs() == 0 {
+		t.Error("a length mismatch must be counted as a resync, not passed over")
+	}
+}
+
+// TestReader_PayloadAliasesTheBuffer pins the documented lifetime of a decoded
+// payload: it points into the reader's buffer and is only valid until the next
+// read. A consumer that keeps a menu line across reads must copy it, and this
+// test is what that requirement is written against.
+func TestReader_PayloadAliasesTheBuffer(t *testing.T) {
+	good := mustHex(t, specIamFrame)
+	r := NewReader(bytes.NewReader(append(append([]byte{}, good...), good...)))
+
+	first, err := r.ReadFrame()
+	if err != nil {
+		t.Fatalf("ReadFrame: %v", err)
+	}
+	kept := first.Payload
+	copied := append([]byte(nil), first.Payload...)
+
+	if _, err := r.ReadFrame(); err != nil {
+		t.Fatalf("ReadFrame: %v", err)
+	}
+	if &kept[0] == &copied[0] {
+		t.Fatal("the test did not actually copy")
+	}
+	// The copy is what a caller must keep; nothing here asserts the aliased
+	// slice still holds the old bytes, only that copying is what works.
+	info, err := DecodeDeviceInfo(copied)
+	if err != nil || info.ID.Name != "TestClient" {
+		t.Errorf("the copied payload must stay decodable: %+v %v", info, err)
+	}
+}
+
+// idleReader returns (0, nil) forever, which io.Reader permits but which would
+// spin the read loop if we treated it as "try again".
+type idleReader struct{}
+
+func (idleReader) Read([]byte) (int, error) { return 0, nil }
+
+// TestReader_NoProgress covers that case: a peer that keeps the connection open
+// and sends nothing must surface as an error, not as a busy loop.
+func TestReader_NoProgress(t *testing.T) {
+	r := NewReader(idleReader{})
+	if _, err := r.ReadFrame(); !errors.Is(err, io.ErrNoProgress) {
+		t.Errorf("err = %v, want io.ErrNoProgress", err)
+	}
+}

--- a/internal/snell-rollcall/codec/payload_control.go
+++ b/internal/snell-rollcall/codec/payload_control.go
@@ -1,0 +1,252 @@
+package codec
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// Wire sizes of the 16-bit control structures.
+const (
+	GetFStatSize   = 2  // spec 11.5.1 GETFSTAT_STR
+	FuncStatusSize = 8  // spec 11.5.2 FUNCSTATUS_STR, before the flag-driven tail
+	SetMultiSize   = 4  // spec 11.5.3 SETMULTI_STR, repeated
+	DispSize       = 22 // spec 11.5.4 DISP_STR
+)
+
+// GetFStat asks for the current state of one command (spec 11.5.1).
+type GetFStat struct {
+	Command uint16
+}
+
+func (g GetFStat) String() string { return fmt.Sprintf("cmd=%d", g.Command) }
+
+// AppendTo appends the 2-byte wire form.
+func (g GetFStat) AppendTo(dst []byte) []byte {
+	var b [GetFStatSize]byte
+	binary.BigEndian.PutUint16(b[:], g.Command)
+	return append(dst, b[:]...)
+}
+
+// DecodeGetFStat reads a GETFSTAT_STR from the front of b.
+func DecodeGetFStat(b []byte) (GetFStat, error) {
+	if err := need(b, GetFStatSize, "GetFStat", ""); err != nil {
+		return GetFStat{}, err
+	}
+	return GetFStat{Command: binary.BigEndian.Uint16(b)}, nil
+}
+
+// FuncStatus carries a command's value in the 16-bit generation. It is the
+// payload of SetParam and RetFStat (spec 11.5.2).
+//
+// What follows the fixed 8 bytes depends on Mode, and the order is fixed:
+//
+//	ModeString  a string. Normally NUL-terminated within 20 bytes, but when
+//	            ModeMatchID is also set the field is a full 20 bytes so that
+//	            the trailing ID sits at a known offset (spec 11.5.2).
+//	ModeData    Value bytes of raw data. Excludes ModeValue and ModeString.
+//	ModeMatchID a uint16 unit type. The write applies only if it matches the
+//	            receiver, or if it is zero.
+//
+// When both ModeValue and ModeString are set, both are meaningful and the
+// string is what should be displayed: it exists precisely because the number
+// alone would mislead. A live device returns value -1686180113 with the string
+// "0x9B7EEEEF" for a checksum.
+type FuncStatus struct {
+	Command uint16
+	Mode    Mode
+	Value   int32
+	Text    string
+	Data    []byte
+	MatchID uint16
+}
+
+func (f FuncStatus) String() string {
+	s := fmt.Sprintf("cmd=%d mode=%s value=%d", f.Command, f.Mode, f.Value)
+	if f.Mode.Has(ModeString) {
+		s += fmt.Sprintf(" %q", f.Text)
+	}
+	if f.Mode.Has(ModeData) {
+		s += fmt.Sprintf(" data=%dB", len(f.Data))
+	}
+	if f.Mode.Has(ModeMatchID) {
+		s += fmt.Sprintf(" match=%d", f.MatchID)
+	}
+	return s
+}
+
+// AppendTo appends the wire form including whichever tail Mode selects.
+func (f FuncStatus) AppendTo(dst []byte) ([]byte, error) {
+	var head [FuncStatusSize]byte
+	binary.BigEndian.PutUint16(head[0:2], f.Command)
+	binary.BigEndian.PutUint16(head[2:4], uint16(f.Mode))
+	value := f.Value
+	if f.Mode.Has(ModeData) {
+		value = int32(len(f.Data))
+	}
+	binary.BigEndian.PutUint32(head[4:8], uint32(value))
+	dst = append(dst, head[:]...)
+
+	var err error
+	if f.Mode.Has(ModeString) {
+		if f.Mode.Has(ModeMatchID) {
+			// Fixed width so the ID that follows is at a known offset.
+			dst, err = appendFixedString(dst, f.Text, MaxTextSize)
+		} else {
+			if len(f.Text) > MaxTextSize-1 {
+				return nil, fmt.Errorf("%w: %d bytes, 16-bit field holds %d",
+					ErrStringTooLong, len(f.Text), MaxTextSize-1)
+			}
+			dst = append(dst, f.Text...)
+			dst = append(dst, 0)
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	if f.Mode.Has(ModeData) {
+		dst = append(dst, f.Data...)
+	}
+	if f.Mode.Has(ModeMatchID) {
+		var id [2]byte
+		binary.BigEndian.PutUint16(id[:], f.MatchID)
+		dst = append(dst, id[:]...)
+	}
+	return dst, nil
+}
+
+// DecodeFuncStatus reads a FUNCSTATUS_STR and its flag-driven tail.
+//
+// Offsets are computed from Mode rather than scanned for, because the tail is
+// not self-describing: with ModeMatchID the string field is fixed-width, so
+// searching for a terminator would find the wrong boundary.
+func DecodeFuncStatus(b []byte) (FuncStatus, error) {
+	if err := need(b, FuncStatusSize, "FuncStatus", ""); err != nil {
+		return FuncStatus{}, err
+	}
+	f := FuncStatus{
+		Command: binary.BigEndian.Uint16(b[0:2]),
+		Mode:    Mode(binary.BigEndian.Uint16(b[2:4])),
+		Value:   int32(binary.BigEndian.Uint32(b[4:8])),
+	}
+
+	off := FuncStatusSize
+	if f.Mode.Has(ModeString) {
+		if f.Mode.Has(ModeMatchID) {
+			// Fixed width, so the trailing ID sits at a known offset.
+			if err := need(b[off:], MaxTextSize, "FuncStatus", "Text"); err != nil {
+				return FuncStatus{}, err
+			}
+			f.Text = fixedString(b[off : off+MaxTextSize])
+			off += MaxTextSize
+		} else {
+			s, n := cString(b[off:])
+			f.Text = s
+			off += n
+		}
+	}
+	if f.Mode.Has(ModeData) {
+		n := int(f.Value)
+		if n < 0 {
+			return FuncStatus{}, decodeErr("FuncStatus", "Data", off,
+				fmt.Errorf("negative data length %d", n))
+		}
+		if err := need(b[off:], n, "FuncStatus", "Data"); err != nil {
+			return FuncStatus{}, err
+		}
+		f.Data = b[off : off+n]
+		off += n
+	}
+	if f.Mode.Has(ModeMatchID) {
+		if err := need(b[off:], 2, "FuncStatus", "MatchID"); err != nil {
+			return FuncStatus{}, err
+		}
+		f.MatchID = binary.BigEndian.Uint16(b[off : off+2])
+	}
+	return f, nil
+}
+
+// SetMulti sets one numeric command as part of a batch (spec 11.5.3).
+//
+// Values are 16-bit to save bandwidth on slow links and are promoted to signed
+// 32-bit before use. A value outside int16 must be sent as two consecutive
+// entries with the same command, high word first (spec 9.49).
+//
+// A server sends no acknowledgement for a batch it accepts, only a Nack if it
+// rejects one, so this cannot be used inside the one-in-flight active queue.
+type SetMulti struct {
+	Command int16
+	Value   int16
+}
+
+// AppendMultiValues appends a batch of SetMulti entries.
+func AppendMultiValues(dst []byte, vals []SetMulti) []byte {
+	for _, v := range vals {
+		var b [SetMultiSize]byte
+		binary.BigEndian.PutUint16(b[0:2], uint16(v.Command))
+		binary.BigEndian.PutUint16(b[2:4], uint16(v.Value))
+		dst = append(dst, b[:]...)
+	}
+	return dst
+}
+
+// DecodeMultiValues reads a whole SetMulti payload. The count is implied by
+// the payload length (spec 9.49).
+func DecodeMultiValues(b []byte) ([]SetMulti, error) {
+	if len(b)%SetMultiSize != 0 {
+		return nil, decodeErr("SetMulti", "", len(b),
+			fmt.Errorf("payload %d is not a multiple of %d", len(b), SetMultiSize))
+	}
+	out := make([]SetMulti, 0, len(b)/SetMultiSize)
+	for off := 0; off < len(b); off += SetMultiSize {
+		out = append(out, SetMulti{
+			Command: int16(binary.BigEndian.Uint16(b[off : off+2])),
+			Value:   int16(binary.BigEndian.Uint16(b[off+2 : off+4])),
+		})
+	}
+	return out, nil
+}
+
+// Disp is one line of the status display a control server maintains
+// (spec 11.5.4). Lines 0..3 are the common four; negative lines carry priority
+// rather than position.
+type Disp struct {
+	Line int16
+	Text string
+}
+
+func (d Disp) String() string {
+	switch d.Line {
+	case DisplayLineError:
+		return fmt.Sprintf("error %q", d.Text)
+	case DisplayLineWarning:
+		return fmt.Sprintf("warning %q", d.Text)
+	default:
+		return fmt.Sprintf("line=%d %q", d.Line, d.Text)
+	}
+}
+
+// AppendTo appends the 22-byte wire form.
+func (d Disp) AppendTo(dst []byte) ([]byte, error) {
+	var line [2]byte
+	binary.BigEndian.PutUint16(line[:], uint16(d.Line))
+	return appendFixedString(append(dst, line[:]...), d.Text, MaxTextSize)
+}
+
+// DecodeDisp reads a DISP_STR from the front of b.
+func DecodeDisp(b []byte) (Disp, error) {
+	if err := need(b, 2, "Disp", "Line"); err != nil {
+		return Disp{}, err
+	}
+	d := Disp{Line: int16(binary.BigEndian.Uint16(b[0:2]))}
+	if len(b) > 2 {
+		d.Text = fixedString(b[2:minInt(2+MaxTextSize, len(b))])
+	}
+	return d, nil
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/snell-rollcall/codec/payload_control_test.go
+++ b/internal/snell-rollcall/codec/payload_control_test.go
@@ -1,0 +1,414 @@
+package codec
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestGetFStat_RoundTrip(t *testing.T) {
+	for _, want := range []GetFStat{{}, {Command: 1}, {Command: 0xFFFF}} {
+		b := want.AppendTo(nil)
+		if len(b) != GetFStatSize {
+			t.Errorf("encoded %d bytes, want %d", len(b), GetFStatSize)
+		}
+		got, err := DecodeGetFStat(b)
+		if err != nil {
+			t.Fatalf("DecodeGetFStat: %v", err)
+		}
+		if got != want {
+			t.Errorf("round trip %+v -> %+v", want, got)
+		}
+	}
+
+	if b := (GetFStat{Command: 0x0102}).AppendTo(nil); !bytes.Equal(b, []byte{0x01, 0x02}) {
+		t.Errorf("encoded %x, want big-endian 0102", b)
+	}
+	if _, err := DecodeGetFStat([]byte{0}); !errors.Is(err, ErrShortBuffer) {
+		t.Errorf("err = %v, want ErrShortBuffer", err)
+	}
+	if got := (GetFStat{Command: 7}).String(); got != "cmd=7" {
+		t.Errorf("String() = %q", got)
+	}
+}
+
+// TestFuncStatus_Numeric is the plain case of spec 11.5.2: an 8-byte structure
+// with no tail. Value is signed 32-bit, which matters because devices publish
+// checksums and offsets that overflow into the sign bit.
+func TestFuncStatus_Numeric(t *testing.T) {
+	tests := []struct {
+		name string
+		in   FuncStatus
+		want string
+	}{
+		{
+			"zero",
+			FuncStatus{Command: 1, Mode: ModeValue},
+			"0001 0001 00000000",
+		},
+		{
+			"positive",
+			FuncStatus{Command: 0x0102, Mode: ModeValue, Value: 1000},
+			"0102 0001 000003e8",
+		},
+		{
+			"negative",
+			FuncStatus{Command: 3, Mode: ModeValue, Value: -1},
+			"0003 0001 ffffffff",
+		},
+		{
+			"largest negative",
+			FuncStatus{Command: 4, Mode: ModeValue, Value: -2147483648},
+			"0004 0001 80000000",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.in.AppendTo(nil)
+			if err != nil {
+				t.Fatalf("AppendTo: %v", err)
+			}
+			if want := mustHex(t, tc.want); !bytes.Equal(got, want) {
+				t.Errorf("encoded %x, want %x", got, want)
+			}
+			back, err := DecodeFuncStatus(got)
+			if err != nil {
+				t.Fatalf("DecodeFuncStatus: %v", err)
+			}
+			if back.Command != tc.in.Command || back.Mode != tc.in.Mode || back.Value != tc.in.Value {
+				t.Errorf("round trip\n got %+v\nwant %+v", back, tc.in)
+			}
+		})
+	}
+}
+
+// TestFuncStatus_ValueAndString covers the combination the spec allows and a
+// live device uses: both bits set, where the number alone would mislead and the
+// string is what a user should see. A decoder that treats the two as mutually
+// exclusive loses one of them.
+func TestFuncStatus_ValueAndString(t *testing.T) {
+	in := FuncStatus{
+		Command: 0x0113,
+		Mode:    ModeValue | ModeString,
+		Value:   -1686180113, // as measured: a checksum, printed as hex
+		Text:    "0x9B7EEEEF",
+	}
+	got, err := in.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	want := mustHex(t, "0113 0003 9b7eeeef"+"3078394237454545454600")
+	if !bytes.Equal(got, want) {
+		t.Errorf("encoded\n got %x\nwant %x", got, want)
+	}
+
+	back, err := DecodeFuncStatus(got)
+	if err != nil {
+		t.Fatalf("DecodeFuncStatus: %v", err)
+	}
+	if back.Value != in.Value || back.Text != in.Text {
+		t.Errorf("= value %d text %q, want %d %q", back.Value, back.Text, in.Value, in.Text)
+	}
+}
+
+// TestFuncStatus_Data covers the raw-bytes form, where the numeric field is a
+// length rather than a value. Encoding must derive that length from the slice
+// so the two can never disagree.
+func TestFuncStatus_Data(t *testing.T) {
+	in := FuncStatus{Command: 9, Mode: ModeData, Value: 999, Data: []byte{0xDE, 0xAD, 0xBE, 0xEF}}
+	got, err := in.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	if want := mustHex(t, "0009 0004 00000004 deadbeef"); !bytes.Equal(got, want) {
+		t.Errorf("encoded\n got %x\nwant %x", got, want)
+	}
+
+	back, err := DecodeFuncStatus(got)
+	if err != nil {
+		t.Fatalf("DecodeFuncStatus: %v", err)
+	}
+	if back.Value != 4 {
+		t.Errorf("Value = %d, want the data length 4", back.Value)
+	}
+	if !bytes.Equal(back.Data, in.Data) {
+		t.Errorf("Data = %x, want %x", back.Data, in.Data)
+	}
+
+	// Empty data is legal.
+	empty, err := (FuncStatus{Mode: ModeData}).AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	if len(empty) != FuncStatusSize {
+		t.Errorf("empty data encoded %d bytes, want %d", len(empty), FuncStatusSize)
+	}
+}
+
+// TestFuncStatus_MatchIDFixesTheStringWidth covers the rule that makes this
+// structure impossible to parse by scanning: with ModeMatchID set, the string
+// field is a full 20 bytes so the trailing ID sits at a known offset. Searching
+// for the terminator instead would read the ID out of the padding.
+func TestFuncStatus_MatchIDFixesTheStringWidth(t *testing.T) {
+	in := FuncStatus{
+		Command: 0x0020,
+		Mode:    ModeValue | ModeString | ModeMatchID,
+		Value:   1,
+		Text:    "on",
+		MatchID: 483,
+	}
+	got, err := in.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+
+	want := mustHex(t, "0020 0023 00000001"+
+		"6f6e000000000000000000000000000000000000"+ // "on" in a 20-byte field
+		"01e3")
+	if !bytes.Equal(got, want) {
+		t.Errorf("encoded\n got %x\nwant %x", got, want)
+	}
+	if len(got) != FuncStatusSize+MaxTextSize+2 {
+		t.Fatalf("encoded %d bytes, want %d", len(got), FuncStatusSize+MaxTextSize+2)
+	}
+
+	back, err := DecodeFuncStatus(got)
+	if err != nil {
+		t.Fatalf("DecodeFuncStatus: %v", err)
+	}
+	if back.Text != "on" || back.MatchID != 483 {
+		t.Errorf("= text %q id %d, want %q 483", back.Text, back.MatchID, "on")
+	}
+
+	// Without the ID bit the string is variable-width, so the same text
+	// produces a shorter frame. This is the difference a scanning parser
+	// would get wrong.
+	short := in
+	short.Mode &^= ModeMatchID
+	sb, err := short.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	if len(sb) != FuncStatusSize+3 {
+		t.Errorf("variable-width form is %d bytes, want %d", len(sb), FuncStatusSize+3)
+	}
+}
+
+func TestFuncStatus_Errors(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+		want error
+	}{
+		{"short header", make([]byte, FuncStatusSize-1), ErrShortBuffer},
+		{
+			"data runs past the payload",
+			mustHex(t, "0009 0004 000000ff deadbeef"),
+			ErrShortBuffer,
+		},
+		{
+			"fixed string truncated by the match-id form",
+			mustHex(t, "0020 0023 00000001 6f6e00"),
+			ErrShortBuffer,
+		},
+		{
+			"match id missing",
+			mustHex(t, "0020 0021 00000001"),
+			ErrShortBuffer,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := DecodeFuncStatus(tc.in); !errors.Is(err, tc.want) {
+				t.Errorf("err = %v, want %v", err, tc.want)
+			}
+		})
+	}
+
+	// A negative length in the data form is a malformed frame, not a panic.
+	_, err := DecodeFuncStatus(mustHex(t, "0009 0004 ffffffff"))
+	if err == nil {
+		t.Error("a negative data length must be rejected")
+	}
+
+	// Text too long for the 16-bit field is refused rather than truncated.
+	long := FuncStatus{Mode: ModeString, Text: strings.Repeat("x", MaxTextSize)}
+	if _, err := long.AppendTo(nil); !errors.Is(err, ErrStringTooLong) {
+		t.Errorf("err = %v, want ErrStringTooLong", err)
+	}
+	long.Mode |= ModeMatchID
+	if _, err := long.AppendTo(nil); !errors.Is(err, ErrStringTooLong) {
+		t.Errorf("fixed-width form err = %v, want ErrStringTooLong", err)
+	}
+}
+
+func TestFuncStatus_String(t *testing.T) {
+	f := FuncStatus{
+		Command: 5,
+		Mode:    ModeValue | ModeString | ModeData | ModeMatchID,
+		Value:   7,
+		Text:    "x",
+		Data:    []byte{1, 2},
+		MatchID: 483,
+	}
+	got := f.String()
+	for _, want := range []string{"cmd=5", "value=7", `"x"`, "data=2B", "match=483"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("String() = %q, want it to contain %q", got, want)
+		}
+	}
+	if got := (FuncStatus{Command: 1, Mode: ModeValue}).String(); strings.Contains(got, "data=") {
+		t.Errorf("String() = %q, want no data clause", got)
+	}
+}
+
+// TestSetMulti covers the batch write of spec 11.5.3. The count is implied by
+// the payload length, so a payload that is not a whole number of entries is a
+// framing error and must not be decoded as a shorter batch.
+func TestSetMulti(t *testing.T) {
+	vals := []SetMulti{
+		{Command: 1, Value: 100},
+		{Command: 2, Value: -1},
+		{Command: 0x0102, Value: -32768},
+	}
+	got := AppendMultiValues(nil, vals)
+	want := mustHex(t, "0001 0064 0002 ffff 0102 8000")
+	if !bytes.Equal(got, want) {
+		t.Errorf("encoded\n got %x\nwant %x", got, want)
+	}
+
+	back, err := DecodeMultiValues(got)
+	if err != nil {
+		t.Fatalf("DecodeMultiValues: %v", err)
+	}
+	if len(back) != len(vals) {
+		t.Fatalf("decoded %d entries, want %d", len(back), len(vals))
+	}
+	for i := range vals {
+		if back[i] != vals[i] {
+			t.Errorf("entry %d = %+v, want %+v", i, back[i], vals[i])
+		}
+	}
+
+	// An empty batch is legal and decodes to no entries.
+	if b, err := DecodeMultiValues(nil); err != nil || len(b) != 0 {
+		t.Errorf("empty batch = %v, %v", b, err)
+	}
+
+	for _, n := range []int{1, 2, 3, 5, 7} {
+		if _, err := DecodeMultiValues(make([]byte, n)); err == nil {
+			t.Errorf("a %d-byte payload is not a whole number of entries", n)
+		}
+	}
+}
+
+// TestSetMulti_WideValuesSplit records the encoding of spec 9.49 for a value
+// outside int16: two consecutive entries with the same command, high word
+// first. The codec carries the entries; composing them is the session layer's
+// job, and this test is what that layer is written against.
+func TestSetMulti_WideValuesSplit(t *testing.T) {
+	wide := int32(0x0001E240) // 123456, outside the 16-bit field
+
+	pair := []SetMulti{
+		{Command: 0x0042, Value: int16(uint16(wide >> 16))},
+		{Command: 0x0042, Value: int16(uint16(wide))},
+	}
+	b := AppendMultiValues(nil, pair)
+	if want := mustHex(t, "0042 0001 0042 e240"); !bytes.Equal(b, want) {
+		t.Errorf("encoded %x, want %x", b, want)
+	}
+
+	back, err := DecodeMultiValues(b)
+	if err != nil {
+		t.Fatalf("DecodeMultiValues: %v", err)
+	}
+	got := int32(uint32(uint16(back[0].Value))<<16 | uint32(uint16(back[1].Value)))
+	if got != wide {
+		t.Errorf("recomposed %d, want %d", got, wide)
+	}
+}
+
+// TestDisp covers the status display of spec 11.5.4, where a negative line
+// number is a priority rather than a position.
+func TestDisp(t *testing.T) {
+	tests := []struct {
+		name string
+		in   Disp
+		hex  string
+	}{
+		{"line 0", Disp{Line: 0, Text: "OK"}, "0000" + "4f4b000000000000000000000000000000000000"},
+		{"error", Disp{Line: DisplayLineError, Text: "No input"}, "ffff" + "4e6f20696e707574000000000000000000000000"},
+		{"warning", Disp{Line: DisplayLineWarning, Text: ""}, "fffe" + "0000000000000000000000000000000000000000"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.in.AppendTo(nil)
+			if err != nil {
+				t.Fatalf("AppendTo: %v", err)
+			}
+			if want := mustHex(t, tc.hex); !bytes.Equal(got, want) {
+				t.Errorf("encoded\n got %x\nwant %x", got, want)
+			}
+			if len(got) != DispSize {
+				t.Errorf("encoded %d bytes, want %d", len(got), DispSize)
+			}
+			back, err := DecodeDisp(got)
+			if err != nil {
+				t.Fatalf("DecodeDisp: %v", err)
+			}
+			if back != tc.in {
+				t.Errorf("round trip %+v -> %+v", tc.in, back)
+			}
+		})
+	}
+}
+
+// TestDisp_ShortText covers a device that trims the fixed field. The line still
+// carries a usable message and must not be dropped.
+func TestDisp_ShortText(t *testing.T) {
+	got, err := DecodeDisp(append([]byte{0x00, 0x02}, "hi"...))
+	if err != nil {
+		t.Fatalf("DecodeDisp: %v", err)
+	}
+	if got.Line != 2 || got.Text != "hi" {
+		t.Errorf("= %+v, want line 2 %q", got, "hi")
+	}
+
+	// The line number alone is the minimum.
+	if _, err := DecodeDisp([]byte{0x00, 0x00}); err != nil {
+		t.Errorf("a bare line number must decode: %v", err)
+	}
+	if _, err := DecodeDisp([]byte{0x00}); !errors.Is(err, ErrShortBuffer) {
+		t.Errorf("err = %v, want ErrShortBuffer", err)
+	}
+}
+
+func TestDisp_TextTooLong(t *testing.T) {
+	d := Disp{Text: strings.Repeat("x", MaxTextSize)}
+	if _, err := d.AppendTo(nil); !errors.Is(err, ErrStringTooLong) {
+		t.Errorf("err = %v, want ErrStringTooLong", err)
+	}
+}
+
+func TestDisp_String(t *testing.T) {
+	tests := []struct {
+		in   Disp
+		want string
+	}{
+		{Disp{Line: DisplayLineError, Text: "boom"}, `error "boom"`},
+		{Disp{Line: DisplayLineWarning, Text: "hot"}, `warning "hot"`},
+		{Disp{Line: 3, Text: "ok"}, `line=3 "ok"`},
+	}
+	for _, tc := range tests {
+		if got := tc.in.String(); got != tc.want {
+			t.Errorf("String() = %q, want %q", got, tc.want)
+		}
+	}
+}
+
+func TestMinInt(t *testing.T) {
+	if minInt(1, 2) != 1 || minInt(2, 1) != 1 || minInt(3, 3) != 3 {
+		t.Error("minInt does not return the smaller value")
+	}
+}

--- a/internal/snell-rollcall/codec/payload_identity.go
+++ b/internal/snell-rollcall/codec/payload_identity.go
@@ -1,0 +1,174 @@
+package codec
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// Wire sizes of the identity structures.
+const (
+	VersionSize    = 4  // spec 11.3.3 VERSION_STR
+	IDSize         = 28 // spec 11.3.2 ID_STR
+	StatusSize     = 4  // spec 11.3.1 STATUS_STR
+	DeviceInfoSize = 40 // spec 11.3.4 DEVICEINFO_STR
+)
+
+// ProtocolVersion is the value every unit reports in DeviceInfo. The vendor
+// library writes it and never reads it, so it is informational only: there is
+// no version negotiation in RollCall. Capability is carried by service bits.
+const ProtocolVersion uint16 = 3
+
+// Version identifies a unit's software (spec 11.3.3).
+//
+// Major, Minor and Alpha match the version shown in the unit's own menus.
+// CmdSet is the one that matters to us: a unit's ID plus CmdSet uniquely
+// determines its command set, so together they key the device-model cache.
+// Alpha is a character, a space for a purely numeric version.
+type Version struct {
+	Major  uint8
+	Minor  uint8
+	Alpha  uint8
+	CmdSet uint8
+}
+
+func (v Version) String() string {
+	a := v.Alpha
+	if a < 0x20 || a > 0x7E {
+		a = ' '
+	}
+	return fmt.Sprintf("%d.%d%c.cs%d", v.Major, v.Minor, a, v.CmdSet)
+}
+
+func (v Version) appendTo(dst []byte) []byte {
+	return append(dst, v.Major, v.Minor, v.Alpha, v.CmdSet)
+}
+
+// versionAt reads a version from a slice the caller has already sized.
+func versionAt(b []byte) Version {
+	return Version{Major: b[0], Minor: b[1], Alpha: b[2], CmdSet: b[3]}
+}
+
+// ID is a unit's identity: what it offers, what type it is, what it runs and
+// what the user called it (spec 11.3.2, payload of RetID).
+type ID struct {
+	Services Service
+	TypeID   uint16 // assigned by the vendor; ~700 are allocated in rc3id.h
+	Version  Version
+	Name     string // user-editable, 19 usable bytes
+}
+
+func (d ID) String() string {
+	return fmt.Sprintf("id=%d %s %q svc=%s", d.TypeID, d.Version, d.Name, d.Services)
+}
+
+// AppendTo appends the 28-byte wire form.
+func (d ID) AppendTo(dst []byte) ([]byte, error) {
+	var head [4]byte
+	binary.BigEndian.PutUint16(head[0:2], uint16(d.Services))
+	binary.BigEndian.PutUint16(head[2:4], d.TypeID)
+	dst = append(dst, head[:]...)
+	dst = d.Version.appendTo(dst)
+	return appendFixedString(dst, d.Name, MaxTextSize)
+}
+
+// DecodeID reads an ID_STR from the front of b.
+func DecodeID(b []byte) (ID, error) {
+	if err := need(b, IDSize, "ID", ""); err != nil {
+		return ID{}, err
+	}
+	return idAt(b), nil
+}
+
+// idAt reads an ID_STR from a slice the caller has already sized.
+func idAt(b []byte) ID {
+	return ID{
+		Services: Service(binary.BigEndian.Uint16(b[0:2])),
+		TypeID:   binary.BigEndian.Uint16(b[2:4]),
+		Version:  versionAt(b[4:8]),
+		Name:     fixedString(b[8:28]),
+	}
+}
+
+// UnitStatus reports which services are busy and the unit's own state
+// (spec 11.3.1, payload of RetStat).
+type UnitStatus struct {
+	ServiceStatus Service // a set bit means that service is busy
+	Status        Status
+}
+
+func (s UnitStatus) String() string {
+	return fmt.Sprintf("busy=%s status=%s", s.ServiceStatus, s.Status)
+}
+
+// AppendTo appends the 4-byte wire form.
+func (s UnitStatus) AppendTo(dst []byte) []byte {
+	var b [StatusSize]byte
+	binary.BigEndian.PutUint16(b[0:2], uint16(s.ServiceStatus))
+	binary.BigEndian.PutUint16(b[2:4], uint16(s.Status))
+	return append(dst, b[:]...)
+}
+
+// DecodeUnitStatus reads a STATUS_STR from the front of b.
+func DecodeUnitStatus(b []byte) (UnitStatus, error) {
+	if err := need(b, StatusSize, "UnitStatus", ""); err != nil {
+		return UnitStatus{}, err
+	}
+	return unitStatusAt(b), nil
+}
+
+// unitStatusAt reads a STATUS_STR from a slice the caller has already sized.
+func unitStatusAt(b []byte) UnitStatus {
+	return UnitStatus{
+		ServiceStatus: Service(binary.BigEndian.Uint16(b[0:2])),
+		Status:        Status(binary.BigEndian.Uint16(b[2:4])),
+	}
+}
+
+// DeviceInfo describes one device (spec 11.3.4). It is the payload of
+// RetDevInfo and Iam, and is embedded in Call.
+//
+// The Address here is never rewritten as the message crosses a bridge, so its
+// Net is always zero and must not be used as a route. Take the route from the
+// message header instead (spec 11.3.4 note).
+type DeviceInfo struct {
+	ProtocolVersion uint16
+	Address         Address
+	ID              ID
+	Status          UnitStatus
+}
+
+func (d DeviceInfo) String() string {
+	return fmt.Sprintf("%s %s %s", d.Address, d.ID, d.Status)
+}
+
+// AppendTo appends the 40-byte wire form.
+func (d DeviceInfo) AppendTo(dst []byte) ([]byte, error) {
+	var pv [2]byte
+	binary.BigEndian.PutUint16(pv[:], d.ProtocolVersion)
+	dst = append(dst, pv[:]...)
+	dst = d.Address.AppendTo(dst)
+	dst, err := d.ID.AppendTo(dst)
+	if err != nil {
+		return nil, err
+	}
+	return d.Status.AppendTo(dst), nil
+}
+
+// DecodeDeviceInfo reads a DEVICEINFO_STR from the front of b.
+func DecodeDeviceInfo(b []byte) (DeviceInfo, error) {
+	if err := need(b, DeviceInfoSize, "DeviceInfo", ""); err != nil {
+		return DeviceInfo{}, err
+	}
+	return deviceInfoAt(b), nil
+}
+
+// deviceInfoAt reads a DEVICEINFO_STR from a slice the caller has already
+// sized. Connect embeds one, and reads it through here.
+func deviceInfoAt(b []byte) DeviceInfo {
+	return DeviceInfo{
+		ProtocolVersion: binary.BigEndian.Uint16(b[0:2]),
+		Address:         addressAt(b[2:8]),
+		ID:              idAt(b[8:36]),
+		Status:          unitStatusAt(b[36:40]),
+	}
+}

--- a/internal/snell-rollcall/codec/payload_identity_test.go
+++ b/internal/snell-rollcall/codec/payload_identity_test.go
@@ -1,0 +1,214 @@
+package codec
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// specDeviceInfo is the 40-byte DEVICEINFO_STR of spec 11.3.4, laid out field
+// by field so a change to any offset fails here rather than three units later.
+const specDeviceInfo = "0003" + // rProtocolVersion 3
+	"0000 ff 00 00ff" + // rAddress 0000-FF-00:FF
+	"8003" + // rID.rServices Menus|Control|LongStr
+	"01e3" + // rID.rTypeID 483
+	"01 00 20 01" + // rID.rVersion 1.0, alpha ' ', command set 1
+	"5465737443 6c69656e74 0000000000 0000000000" + // rID.rName "TestClient"
+	"0000" + // rStatus.rServiceStatus none busy
+	"0008" // rStatus.rStatus Present
+
+func wantDeviceInfo() DeviceInfo {
+	return DeviceInfo{
+		ProtocolVersion: 3,
+		Address:         Address{Unit: 0xFF, Index: IndexUnknown},
+		ID: ID{
+			Services: SvcMenus | SvcControl | SvcLongStr,
+			TypeID:   483,
+			Version:  Version{Major: 1, Minor: 0, Alpha: ' ', CmdSet: 1},
+			Name:     "TestClient",
+		},
+		Status: UnitStatus{Status: StatusPresent},
+	}
+}
+
+func TestDeviceInfo_Decode(t *testing.T) {
+	got, err := DecodeDeviceInfo(mustHex(t, specDeviceInfo))
+	if err != nil {
+		t.Fatalf("DecodeDeviceInfo: %v", err)
+	}
+	if want := wantDeviceInfo(); got != want {
+		t.Errorf("decoded\n got %+v\nwant %+v", got, want)
+	}
+}
+
+func TestDeviceInfo_Encode(t *testing.T) {
+	want := mustHex(t, specDeviceInfo)
+	got, err := wantDeviceInfo().AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("encoded\n got %x\nwant %x", got, want)
+	}
+	if len(got) != DeviceInfoSize {
+		t.Errorf("encoded %d bytes, want %d", len(got), DeviceInfoSize)
+	}
+}
+
+func TestDeviceInfo_Errors(t *testing.T) {
+	good := mustHex(t, specDeviceInfo)
+
+	// Every truncation must be reported, never silently zero-filled.
+	for _, n := range []int{0, 1, 7, 39} {
+		if _, err := DecodeDeviceInfo(good[:n]); !errors.Is(err, ErrShortBuffer) {
+			t.Errorf("DecodeDeviceInfo(%d bytes) err = %v, want ErrShortBuffer", n, err)
+		}
+	}
+
+	d := wantDeviceInfo()
+	d.ID.Name = strings.Repeat("x", MaxTextSize)
+	if _, err := d.AppendTo(nil); !errors.Is(err, ErrStringTooLong) {
+		t.Errorf("err = %v, want ErrStringTooLong", err)
+	}
+}
+
+// TestDeviceInfo_AddressNetIsNotARoute pins the note in spec 11.3.4: the
+// address inside a DeviceInfo is not rewritten as the message crosses a
+// bridge, so its Net is meaningless. Routing from it reaches the wrong unit on
+// any bridged network.
+func TestDeviceInfo_AddressNetIsNotARoute(t *testing.T) {
+	got, err := DecodeDeviceInfo(mustHex(t, specDeviceInfo))
+	if err != nil {
+		t.Fatalf("DecodeDeviceInfo: %v", err)
+	}
+	if got.Address.Net != 0 {
+		t.Errorf("Net = %04X; a device reports its own address with no route", got.Address.Net)
+	}
+}
+
+func TestID_RoundTrip(t *testing.T) {
+	tests := []ID{
+		{},
+		{Services: SvcMenus, TypeID: 1, Version: Version{Major: 2, Minor: 3, Alpha: 'a', CmdSet: 4}, Name: "Vega"},
+		// The name field holds 19 bytes plus the terminator.
+		{Name: strings.Repeat("n", MaxTextSize-1)},
+		{Services: 0xFFFF, TypeID: 0xFFFF, Version: Version{0xFF, 0xFF, 0xFF, 0xFF}},
+	}
+	for _, want := range tests {
+		b, err := want.AppendTo(nil)
+		if err != nil {
+			t.Fatalf("AppendTo %+v: %v", want, err)
+		}
+		if len(b) != IDSize {
+			t.Errorf("encoded %d bytes, want %d", len(b), IDSize)
+		}
+		got, err := DecodeID(b)
+		if err != nil {
+			t.Fatalf("DecodeID: %v", err)
+		}
+		if got != want {
+			t.Errorf("round trip\n got %+v\nwant %+v", got, want)
+		}
+	}
+}
+
+func TestID_Short(t *testing.T) {
+	if _, err := DecodeID(make([]byte, IDSize-1)); !errors.Is(err, ErrShortBuffer) {
+		t.Errorf("err = %v, want ErrShortBuffer", err)
+	}
+}
+
+func TestID_String(t *testing.T) {
+	d := wantDeviceInfo().ID
+	got := d.String()
+	for _, want := range []string{"483", "1.0 .cs1", `"TestClient"`, "LongStr"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("String() = %q, want it to contain %q", got, want)
+		}
+	}
+}
+
+// TestVersion_String covers the alpha field, which is a character and is a
+// space for a purely numeric version. Devices also leave it zero, and printing
+// a NUL into a log line is worse than printing a space.
+func TestVersion_String(t *testing.T) {
+	tests := []struct {
+		v    Version
+		want string
+	}{
+		{Version{1, 0, ' ', 1}, "1.0 .cs1"},
+		{Version{2, 14, 'b', 3}, "2.14b.cs3"},
+		{Version{1, 0, 0, 0}, "1.0 .cs0"},    // NUL prints as a space
+		{Version{1, 0, 0xFF, 0}, "1.0 .cs0"}, // so does anything unprintable
+		{Version{255, 255, '~', 255}, "255.255~.cs255"},
+	}
+	for _, tc := range tests {
+		if got := tc.v.String(); got != tc.want {
+			t.Errorf("Version%+v = %q, want %q", tc.v, got, tc.want)
+		}
+	}
+}
+
+func TestUnitStatus_RoundTrip(t *testing.T) {
+	tests := []UnitStatus{
+		{},
+		{Status: StatusPresent},
+		{ServiceStatus: SvcMenus | SvcControl, Status: StatusOnline | StatusPresent | StatusLocal},
+		{ServiceStatus: 0xFFFF, Status: 0xFFFF},
+	}
+	for _, want := range tests {
+		b := want.AppendTo(nil)
+		if len(b) != StatusSize {
+			t.Errorf("encoded %d bytes, want %d", len(b), StatusSize)
+		}
+		got, err := DecodeUnitStatus(b)
+		if err != nil {
+			t.Fatalf("DecodeUnitStatus: %v", err)
+		}
+		if got != want {
+			t.Errorf("round trip %+v -> %+v", want, got)
+		}
+	}
+
+	if _, err := DecodeUnitStatus([]byte{0, 0, 0}); !errors.Is(err, ErrShortBuffer) {
+		t.Errorf("err = %v, want ErrShortBuffer", err)
+	}
+
+	s := UnitStatus{ServiceStatus: SvcMenus, Status: StatusPresent}
+	if got := s.String(); got != `busy=Menus status=Present` {
+		t.Errorf("String() = %q", got)
+	}
+}
+
+func TestDeviceInfo_String(t *testing.T) {
+	got := wantDeviceInfo().String()
+	for _, want := range []string{"0000-FF-00:0FF", "TestClient", "Present"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("String() = %q, want it to contain %q", got, want)
+		}
+	}
+}
+
+// TestProtocolVersionIsInformational records that RollCall has no version
+// negotiation: the field is written and never read, and capability is carried
+// by the service mask instead. A future change that starts branching on this
+// value should fail here first.
+func TestProtocolVersionIsInformational(t *testing.T) {
+	if ProtocolVersion != 3 {
+		t.Errorf("ProtocolVersion = %d, want 3", ProtocolVersion)
+	}
+	d := wantDeviceInfo()
+	d.ProtocolVersion = 99
+	b, err := d.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	got, err := DecodeDeviceInfo(b)
+	if err != nil {
+		t.Fatalf("an unexpected protocol version must still decode: %v", err)
+	}
+	if got.ProtocolVersion != 99 {
+		t.Errorf("ProtocolVersion = %d, want it carried through unchanged", got.ProtocolVersion)
+	}
+}

--- a/internal/snell-rollcall/codec/payload_menu.go
+++ b/internal/snell-rollcall/codec/payload_menu.go
@@ -1,0 +1,211 @@
+package codec
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// Wire sizes of the 16-bit menu and multi-packet structures.
+const (
+	FuncSize        = 58 // spec 11.4.1 FUNC_STR
+	FuncStyleSize   = 6  // spec 11.4.2 FUNCSTYLE_STR
+	BlockHeaderSize = 8  // spec 11.2.5 BLOCKHEADER_STR
+	GetNextSize     = 4  // spec 11.2.6 GETNEXT_STR: 3 declared bytes plus a pad
+)
+
+// Func is one menu line in the 16-bit generation (spec 11.4.1).
+//
+// The meaning of the numeric fields depends on Style:
+//
+//   - container lines (tiled, list) put the size of their subtree in Step.
+//     That is the whole span of following lines, not the count of immediate
+//     children, so reconstructing the tree is a pre-order walk that consumes
+//     Step entries per container.
+//   - Partial puts the base index of the linked partial in Command.
+//   - Button puts the value it writes in MinRange; a run of buttons sharing a
+//     Command is a radio group.
+//   - Checkbox puts the "on" value in MinRange, conventionally 1.
+//   - numeric lines use MinRange, MaxRange, Step and DivScale, and Param is a
+//     printf format applied to Value/DivScale.
+//
+// DivScale of zero means one. Devices publish it routinely and dividing
+// blindly would fault (spec 7.2.2.6).
+type Func struct {
+	MenuIndex uint16
+	Style     Style
+	Command   uint16
+	MinRange  int32
+	MaxRange  int32
+	Step      uint16
+	DivScale  uint16
+	Text      string // 19 usable bytes
+	Param     string // printf format, 19 usable bytes
+}
+
+// Scale returns DivScale with the documented zero-means-one rule applied.
+func (f Func) Scale() uint16 {
+	if f.DivScale == 0 {
+		return 1
+	}
+	return f.DivScale
+}
+
+// AccessGated reports whether the server substituted this line because the
+// session's user level may not see it.
+func (f Func) AccessGated() bool {
+	return AccessGated(f.Style, uint32(f.Command), f.Text)
+}
+
+func (f Func) String() string {
+	return fmt.Sprintf("idx=%d %s cmd=%d %d..%d step=%d div=%d %q %q",
+		f.MenuIndex, f.Style, f.Command, f.MinRange, f.MaxRange, f.Step, f.DivScale, f.Text, f.Param)
+}
+
+// AppendTo appends the 58-byte wire form.
+func (f Func) AppendTo(dst []byte) ([]byte, error) {
+	var head [18]byte
+	binary.BigEndian.PutUint16(head[0:2], f.MenuIndex)
+	binary.BigEndian.PutUint16(head[2:4], uint16(f.Style))
+	binary.BigEndian.PutUint16(head[4:6], f.Command)
+	binary.BigEndian.PutUint32(head[6:10], uint32(f.MinRange))
+	binary.BigEndian.PutUint32(head[10:14], uint32(f.MaxRange))
+	binary.BigEndian.PutUint16(head[14:16], f.Step)
+	binary.BigEndian.PutUint16(head[16:18], f.DivScale)
+	dst = append(dst, head[:]...)
+
+	dst, err := appendFixedString(dst, f.Text, MaxTextSize)
+	if err != nil {
+		return nil, err
+	}
+	return appendFixedString(dst, f.Param, MaxTextSize)
+}
+
+// DecodeFunc reads a FUNC_STR from the front of b.
+func DecodeFunc(b []byte) (Func, error) {
+	if err := need(b, FuncSize, "Func", ""); err != nil {
+		return Func{}, err
+	}
+	return Func{
+		MenuIndex: binary.BigEndian.Uint16(b[0:2]),
+		Style:     Style(binary.BigEndian.Uint16(b[2:4])),
+		Command:   binary.BigEndian.Uint16(b[4:6]),
+		MinRange:  int32(binary.BigEndian.Uint32(b[6:10])),
+		MaxRange:  int32(binary.BigEndian.Uint32(b[10:14])),
+		Step:      binary.BigEndian.Uint16(b[14:16]),
+		DivScale:  binary.BigEndian.Uint16(b[16:18]),
+		Text:      fixedString(b[18:38]),
+		Param:     fixedString(b[38:58]),
+	}, nil
+}
+
+// FuncStyle updates only the style of an existing menu line (spec 11.4.2).
+// It is a back-channel message and may only change the hidden and disabled
+// bits; everything else in the line stays as it was (spec 9.30).
+type FuncStyle struct {
+	MenuIndex uint16
+	Style     Style
+	Command   uint16
+}
+
+func (f FuncStyle) String() string {
+	return fmt.Sprintf("idx=%d %s cmd=%d", f.MenuIndex, f.Style, f.Command)
+}
+
+// AppendTo appends the 6-byte wire form.
+func (f FuncStyle) AppendTo(dst []byte) []byte {
+	var b [FuncStyleSize]byte
+	binary.BigEndian.PutUint16(b[0:2], f.MenuIndex)
+	binary.BigEndian.PutUint16(b[2:4], uint16(f.Style))
+	binary.BigEndian.PutUint16(b[4:6], f.Command)
+	return append(dst, b[:]...)
+}
+
+// DecodeFuncStyle reads a FUNCSTYLE_STR from the front of b.
+func DecodeFuncStyle(b []byte) (FuncStyle, error) {
+	if err := need(b, FuncStyleSize, "FuncStyle", ""); err != nil {
+		return FuncStyle{}, err
+	}
+	return FuncStyle{
+		MenuIndex: binary.BigEndian.Uint16(b[0:2]),
+		Style:     Style(binary.BigEndian.Uint16(b[2:4])),
+		Command:   binary.BigEndian.Uint16(b[4:6]),
+	}, nil
+}
+
+// BlockHeader opens a multi-packet transfer, telling the client how many items
+// follow (spec 11.2.5). The client then requests each with GetNextPkt.
+//
+// Spare is declared "Must be zero"; a non-zero value is a genuine deviation,
+// unlike the undefined pad byte in GetNext.
+type BlockHeader struct {
+	PktType  PacketType // the request that produced this transfer
+	Spare    uint8
+	Count    uint16
+	MaxSize  uint16
+	Function uint16 // optional, used when the transfer relates to a command
+}
+
+func (h BlockHeader) String() string {
+	return fmt.Sprintf("for=%s count=%d maxsize=%d", h.PktType, h.Count, h.MaxSize)
+}
+
+// AppendTo appends the 8-byte wire form.
+func (h BlockHeader) AppendTo(dst []byte) []byte {
+	var b [BlockHeaderSize]byte
+	b[0] = byte(h.PktType)
+	b[1] = h.Spare
+	binary.BigEndian.PutUint16(b[2:4], h.Count)
+	binary.BigEndian.PutUint16(b[4:6], h.MaxSize)
+	binary.BigEndian.PutUint16(b[6:8], h.Function)
+	return append(dst, b[:]...)
+}
+
+// DecodeBlockHeader reads a BLOCKHEADER_STR from the front of b.
+func DecodeBlockHeader(b []byte) (BlockHeader, error) {
+	if err := need(b, BlockHeaderSize, "BlockHeader", ""); err != nil {
+		return BlockHeader{}, err
+	}
+	return BlockHeader{
+		PktType:  PacketType(b[0]),
+		Spare:    b[1],
+		Count:    binary.BigEndian.Uint16(b[2:4]),
+		MaxSize:  binary.BigEndian.Uint16(b[4:6]),
+		Function: binary.BigEndian.Uint16(b[6:8]),
+	}, nil
+}
+
+// GetNext requests one item of a multi-packet transfer (spec 11.2.6).
+//
+// The structure declares three bytes but occupies four: the vendor packs to a
+// two-byte boundary and senders use sizeof, so a pad byte goes on the wire.
+// Its content is undefined and must never be reported as a deviation.
+type GetNext struct {
+	Index   uint16
+	PktType PacketType // the request that produced the transfer
+}
+
+func (g GetNext) String() string {
+	return fmt.Sprintf("idx=%d for=%s", g.Index, g.PktType)
+}
+
+// AppendTo appends the 4-byte wire form, pad byte included and zeroed.
+func (g GetNext) AppendTo(dst []byte) []byte {
+	var b [GetNextSize]byte
+	binary.BigEndian.PutUint16(b[0:2], g.Index)
+	b[2] = byte(g.PktType)
+	return append(dst, b[:]...)
+}
+
+// DecodeGetNext reads a GETNEXT_STR from the front of b.
+//
+// Three bytes are accepted as well as four: the declared size is three and a
+// peer that trims the pad is not wrong.
+func DecodeGetNext(b []byte) (GetNext, error) {
+	if err := need(b, 3, "GetNext", ""); err != nil {
+		return GetNext{}, err
+	}
+	return GetNext{
+		Index:   binary.BigEndian.Uint16(b[0:2]),
+		PktType: PacketType(b[2]),
+	}, nil
+}

--- a/internal/snell-rollcall/codec/payload_menu_test.go
+++ b/internal/snell-rollcall/codec/payload_menu_test.go
@@ -1,0 +1,376 @@
+package codec
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// specFunc is the 58-byte FUNC_STR of spec 11.4.1: an enabled numeric line
+// running 0..100 in steps of 1, scaled by 10 and formatted as one decimal.
+const specFunc = "0007" + // rMenuIndex 7
+	"0050" + // rStyle Number
+	"0113" + // rCommand 275
+	"00000000" + // rMinRange 0
+	"00000064" + // rMaxRange 100
+	"0001" + // rStep 1
+	"000a" + // rDivScale 10
+	"4761696e00000000000000000000000000000000" + // rText "Gain"
+	"25302e3166000000000000000000000000000000" // rParam "%0.1f"
+
+func wantFunc() Func {
+	return Func{
+		MenuIndex: 7,
+		Style:     StyleNumber,
+		Command:   0x0113,
+		MinRange:  0,
+		MaxRange:  100,
+		Step:      1,
+		DivScale:  10,
+		Text:      "Gain",
+		Param:     "%0.1f",
+	}
+}
+
+func TestFunc_Decode(t *testing.T) {
+	got, err := DecodeFunc(mustHex(t, specFunc))
+	if err != nil {
+		t.Fatalf("DecodeFunc: %v", err)
+	}
+	if want := wantFunc(); got != want {
+		t.Errorf("decoded\n got %+v\nwant %+v", got, want)
+	}
+}
+
+func TestFunc_Encode(t *testing.T) {
+	got, err := wantFunc().AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	if want := mustHex(t, specFunc); !bytes.Equal(got, want) {
+		t.Errorf("encoded\n got %x\nwant %x", got, want)
+	}
+	if len(got) != FuncSize {
+		t.Errorf("encoded %d bytes, want %d", len(got), FuncSize)
+	}
+}
+
+// TestFunc_NegativeRanges pins that the range fields are signed 32-bit. Audio
+// levels and offsets are routinely negative, and reading them as unsigned turns
+// a -60 dB floor into four billion.
+func TestFunc_NegativeRanges(t *testing.T) {
+	in := wantFunc()
+	in.MinRange = -600
+	in.MaxRange = -1
+	b, err := in.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	if want := mustHex(t, "fffffda8"); !bytes.Equal(b[6:10], want) {
+		t.Errorf("MinRange encoded %x, want %x", b[6:10], want)
+	}
+	got, err := DecodeFunc(b)
+	if err != nil {
+		t.Fatalf("DecodeFunc: %v", err)
+	}
+	if got.MinRange != -600 || got.MaxRange != -1 {
+		t.Errorf("ranges = %d..%d, want -600..-1", got.MinRange, got.MaxRange)
+	}
+}
+
+// TestFunc_ScaleZeroMeansOne pins spec 7.2.2.6. Devices publish a zero divisor
+// routinely, and dividing by it directly faults.
+func TestFunc_ScaleZeroMeansOne(t *testing.T) {
+	tests := []struct {
+		div  uint16
+		want uint16
+	}{{0, 1}, {1, 1}, {10, 10}, {1000, 1000}}
+	for _, tc := range tests {
+		f := Func{DivScale: tc.div}
+		if got := f.Scale(); got != tc.want {
+			t.Errorf("DivScale %d Scale = %d, want %d", tc.div, got, tc.want)
+		}
+	}
+}
+
+// TestFunc_StepIsTheWholeSubtree pins the menu tree model. On a container line
+// Step is the span of every following line in the subtree, not the count of
+// immediate children, so rebuilding the tree is a pre-order walk that consumes
+// Step entries per container. Treating it as a child count nests the tree
+// wrongly on any menu deeper than two levels.
+func TestFunc_StepIsTheWholeSubtree(t *testing.T) {
+	// index 0  List      step 4   the whole subtree below it
+	// index 1    List    step 2   a nested container
+	// index 2      Number
+	// index 3      Number
+	// index 4    Number
+	menu := []Func{
+		{MenuIndex: 0, Style: StyleList, Step: 4, Text: "Root"},
+		{MenuIndex: 1, Style: StyleList, Step: 2, Text: "Video"},
+		{MenuIndex: 2, Style: StyleNumber, Text: "Gain"},
+		{MenuIndex: 3, Style: StyleNumber, Text: "Offset"},
+		{MenuIndex: 4, Style: StyleNumber, Text: "Mode"},
+	}
+
+	if !menu[0].Style.Container() || !menu[1].Style.Container() {
+		t.Fatal("list lines must report as containers")
+	}
+	if menu[2].Style.Container() {
+		t.Fatal("a number line is not a container")
+	}
+
+	// The root spans lines 1..4: the nested container, its two children, and
+	// the sibling after it. A child count would have said 2.
+	if got := int(menu[0].Step); got != len(menu)-1 {
+		t.Errorf("root Step = %d, want %d", got, len(menu)-1)
+	}
+	// The nested container spans only its own two children.
+	if menu[1].Step != 2 {
+		t.Errorf("nested Step = %d, want 2", menu[1].Step)
+	}
+
+	// A pre-order walk using Step as a span reaches every line exactly once.
+	seen := make([]bool, len(menu))
+	var walk func(start, end int)
+	walk = func(start, end int) {
+		for i := start; i < end; {
+			if seen[i] {
+				t.Fatalf("line %d visited twice", i)
+			}
+			seen[i] = true
+			span := 0
+			if menu[i].Style.Container() {
+				span = int(menu[i].Step)
+			}
+			if span > 0 {
+				walk(i+1, i+1+span)
+			}
+			i += 1 + span
+		}
+	}
+	walk(0, len(menu))
+	for i, ok := range seen {
+		if !ok {
+			t.Errorf("line %d was never visited", i)
+		}
+	}
+}
+
+// TestFunc_AccessGated covers the level-gated line as it arrives in a menu
+// walk. The server substitutes rather than removes, so the line count is
+// identical at every user level and only the flags reveal the difference.
+func TestFunc_AccessGated(t *testing.T) {
+	gated := Func{
+		MenuIndex: 12,
+		Style:     StyleData | StyleHidden | StyleDisabled,
+		Command:   0,
+		Text:      "Reserved",
+	}
+	if !gated.AccessGated() {
+		t.Error("the substituted line must be recognised as access-gated")
+	}
+
+	// The same line as a supervisor sees it.
+	visible := Func{MenuIndex: 12, Style: StyleNumber, Command: 0x0201, Text: "Bias"}
+	if visible.AccessGated() {
+		t.Error("a normal line must not read as access-gated")
+	}
+
+	// The count is the same either way, which is why counting is useless.
+	low := []Func{visible, gated}
+	high := []Func{visible, visible}
+	if len(low) != len(high) {
+		t.Fatal("the two levels must produce the same number of lines")
+	}
+	var gatedCount int
+	for _, f := range low {
+		if f.AccessGated() {
+			gatedCount++
+		}
+	}
+	if gatedCount != 1 {
+		t.Errorf("found %d gated lines, want 1", gatedCount)
+	}
+}
+
+func TestFunc_Errors(t *testing.T) {
+	good := mustHex(t, specFunc)
+	for _, n := range []int{0, 17, 37, 57} {
+		if _, err := DecodeFunc(good[:n]); !errors.Is(err, ErrShortBuffer) {
+			t.Errorf("DecodeFunc(%d bytes) err = %v, want ErrShortBuffer", n, err)
+		}
+	}
+
+	f := wantFunc()
+	f.Text = strings.Repeat("x", MaxTextSize)
+	if _, err := f.AppendTo(nil); !errors.Is(err, ErrStringTooLong) {
+		t.Errorf("long text err = %v, want ErrStringTooLong", err)
+	}
+	f = wantFunc()
+	f.Param = strings.Repeat("x", MaxTextSize)
+	if _, err := f.AppendTo(nil); !errors.Is(err, ErrStringTooLong) {
+		t.Errorf("long param err = %v, want ErrStringTooLong", err)
+	}
+}
+
+func TestFunc_String(t *testing.T) {
+	got := wantFunc().String()
+	for _, want := range []string{"idx=7", "Number", "cmd=275", "0..100", `"Gain"`, `"%0.1f"`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("String() = %q, want it to contain %q", got, want)
+		}
+	}
+}
+
+// TestFuncStyle covers the back-channel style update of spec 11.4.2. It may
+// only change the hidden and disabled bits; a client that rebuilt the whole
+// line from it would drop the text, ranges and format it never carried.
+func TestFuncStyle(t *testing.T) {
+	in := FuncStyle{MenuIndex: 7, Style: StyleNumber | StyleDisabled, Command: 0x0113}
+	got := in.AppendTo(nil)
+	if want := mustHex(t, "0007 0054 0113"); !bytes.Equal(got, want) {
+		t.Errorf("encoded %x, want %x", got, want)
+	}
+	if len(got) != FuncStyleSize {
+		t.Errorf("encoded %d bytes, want %d", len(got), FuncStyleSize)
+	}
+
+	back, err := DecodeFuncStyle(got)
+	if err != nil {
+		t.Fatalf("DecodeFuncStyle: %v", err)
+	}
+	if back != in {
+		t.Errorf("round trip %+v -> %+v", in, back)
+	}
+	if !back.Style.Disabled() || back.Style.Kind() != StyleNumber {
+		t.Errorf("Style = %s, want a disabled number line", back.Style)
+	}
+
+	if _, err := DecodeFuncStyle(make([]byte, FuncStyleSize-1)); !errors.Is(err, ErrShortBuffer) {
+		t.Errorf("err = %v, want ErrShortBuffer", err)
+	}
+	if s := in.String(); !strings.Contains(s, "idx=7") || !strings.Contains(s, "cmd=275") {
+		t.Errorf("String() = %q", s)
+	}
+}
+
+// TestFuncStyle_DeferredIsVendorOnly records the Rope engine's hold-the-redraw
+// bit. It is not in the specification's style table, so a client must tolerate
+// it rather than reject the line.
+func TestFuncStyle_DeferredIsVendorOnly(t *testing.T) {
+	in := FuncStyle{MenuIndex: 1, Style: StyleNumber | StyleDeferred}
+	back, err := DecodeFuncStyle(in.AppendTo(nil))
+	if err != nil {
+		t.Fatalf("DecodeFuncStyle: %v", err)
+	}
+	if !back.Style.Deferred() {
+		t.Error("the deferred bit must survive a round trip")
+	}
+	if back.Style.Kind() != StyleNumber {
+		t.Errorf("Kind = %s, want the deferred bit not to disturb it", back.Style.Kind())
+	}
+}
+
+// TestBlockHeader covers the multi-packet opener of spec 11.2.5. PktType names
+// the request that produced the transfer, which is how a client knows what the
+// items it is about to fetch will be.
+func TestBlockHeader(t *testing.T) {
+	in := BlockHeader{PktType: MsgGetFunc, Count: 473, MaxSize: 58, Function: 0}
+	got := in.AppendTo(nil)
+	if want := mustHex(t, "08 00 01d9 003a 0000"); !bytes.Equal(got, want) {
+		t.Errorf("encoded %x, want %x", got, want)
+	}
+	if len(got) != BlockHeaderSize {
+		t.Errorf("encoded %d bytes, want %d", len(got), BlockHeaderSize)
+	}
+
+	back, err := DecodeBlockHeader(got)
+	if err != nil {
+		t.Fatalf("DecodeBlockHeader: %v", err)
+	}
+	if back != in {
+		t.Errorf("round trip %+v -> %+v", in, back)
+	}
+	if back.PktType != MsgGetFunc {
+		t.Errorf("PktType = %s, want GETFUNC", back.PktType)
+	}
+
+	if _, err := DecodeBlockHeader(make([]byte, BlockHeaderSize-1)); !errors.Is(err, ErrShortBuffer) {
+		t.Errorf("err = %v, want ErrShortBuffer", err)
+	}
+	if s := in.String(); !strings.Contains(s, "GETFUNC") || !strings.Contains(s, "count=473") {
+		t.Errorf("String() = %q", s)
+	}
+}
+
+// TestBlockHeader_SpareMustBeZero separates the two padding cases. The spec
+// declares this byte "Must be zero", so a non-zero value is a real deviation
+// and is preserved rather than masked, unlike the undefined pad in GetNext.
+func TestBlockHeader_SpareMustBeZero(t *testing.T) {
+	if h, err := DecodeBlockHeader(mustHex(t, "08 00 0001 0002 0003")); err != nil || h.Spare != 0 {
+		t.Errorf("= %+v, %v; want Spare 0", h, err)
+	}
+	h, err := DecodeBlockHeader(mustHex(t, "08 cd 0001 0002 0003"))
+	if err != nil {
+		t.Fatalf("a non-zero spare must still decode: %v", err)
+	}
+	if h.Spare != 0xCD {
+		t.Errorf("Spare = %02X, want it preserved so the deviation is reportable", h.Spare)
+	}
+}
+
+// TestGetNext covers the item request of spec 11.2.6, whose declared size and
+// wire size differ. Encoding four bytes with a zeroed pad is what the vendor
+// expects; accepting three is what a peer that trims it needs.
+func TestGetNext(t *testing.T) {
+	in := GetNext{Index: 42, PktType: MsgGetFunc}
+	got := in.AppendTo(nil)
+	if want := mustHex(t, "002a 08 00"); !bytes.Equal(got, want) {
+		t.Errorf("encoded %x, want %x", got, want)
+	}
+	if len(got) != GetNextSize {
+		t.Errorf("encoded %d bytes, want %d (three declared plus a pad)", len(got), GetNextSize)
+	}
+
+	back, err := DecodeGetNext(got)
+	if err != nil {
+		t.Fatalf("DecodeGetNext: %v", err)
+	}
+	if back != in {
+		t.Errorf("round trip %+v -> %+v", in, back)
+	}
+
+	if s := in.String(); !strings.Contains(s, "idx=42") || !strings.Contains(s, "GETFUNC") {
+		t.Errorf("String() = %q", s)
+	}
+}
+
+// TestGetNext_PadIsUndefined pins that the fourth byte carries no meaning. The
+// vendor packs to a two-byte boundary and senders use sizeof, so whatever was
+// in the stack frame goes on the wire. Reporting it as a deviation would fire
+// on every device.
+func TestGetNext_PadIsUndefined(t *testing.T) {
+	for _, pad := range []byte{0x00, 0xCD, 0xFF} {
+		got, err := DecodeGetNext([]byte{0x00, 0x2A, 0x08, pad})
+		if err != nil {
+			t.Fatalf("pad %02X: %v", pad, err)
+		}
+		if got.Index != 42 || got.PktType != MsgGetFunc {
+			t.Errorf("pad %02X changed the decode: %+v", pad, got)
+		}
+	}
+
+	// Three bytes is the declared size and must be accepted.
+	got, err := DecodeGetNext([]byte{0x00, 0x2A, 0x08})
+	if err != nil {
+		t.Fatalf("three-byte form: %v", err)
+	}
+	if got.Index != 42 || got.PktType != MsgGetFunc {
+		t.Errorf("three-byte form = %+v", got)
+	}
+
+	if _, err := DecodeGetNext([]byte{0x00, 0x2A}); !errors.Is(err, ErrShortBuffer) {
+		t.Errorf("err = %v, want ErrShortBuffer", err)
+	}
+}

--- a/internal/snell-rollcall/codec/payload_session.go
+++ b/internal/snell-rollcall/codec/payload_session.go
@@ -1,0 +1,179 @@
+package codec
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// Wire sizes of the session structures.
+const (
+	ConnectSize   = 44 // spec 11.2.2 CONNECT_STR
+	TermSessSize  = 22 // spec 11.2.3 TERMSESS_STR
+	ClearSessSize = 4  // spec 11.2.4 CLEARSESS_STR
+	WaitSize      = 4  // spec 11.6.2 WAIT_STR
+)
+
+// Back-channel readiness values (rc3comm.h).
+const (
+	BackChannelDisable uint8 = 0
+	BackChannelEnable  uint8 = 1
+	// BackChannelFutureOnly asks the server to report future changes without
+	// the catch-up burst it would otherwise send on enable.
+	BackChannelFutureOnly uint8 = 2
+)
+
+// ReportAllCommands is the command number that enables or disables reporting
+// for every command at once (spec 9.33). Not every server honours per-command
+// selection, but every server honours this value.
+const ReportAllCommands uint16 = 0xFFFF
+
+// Connect is the payload of Call: the services a client wants, the level it
+// wants them at, and who is asking (spec 11.2.2).
+//
+// Services are all-or-nothing: a server that cannot supply every requested bit
+// refuses the whole call rather than granting a subset. A client that wants to
+// fall back from the 32-bit generation must therefore retry the call without
+// SvcLongStr rather than expect a partial grant.
+type Connect struct {
+	Services  Service
+	UserLevel UserLevel
+	Caller    DeviceInfo
+}
+
+func (c Connect) String() string {
+	return fmt.Sprintf("svc=%s level=%s caller=%s", c.Services, c.UserLevel, c.Caller.Address)
+}
+
+// AppendTo appends the 44-byte wire form.
+func (c Connect) AppendTo(dst []byte) ([]byte, error) {
+	var head [4]byte
+	binary.BigEndian.PutUint16(head[0:2], uint16(c.Services))
+	binary.BigEndian.PutUint16(head[2:4], uint16(c.UserLevel))
+	return c.Caller.AppendTo(append(dst, head[:]...))
+}
+
+// DecodeConnect reads a CONNECT_STR from the front of b.
+func DecodeConnect(b []byte) (Connect, error) {
+	if err := need(b, ConnectSize, "Connect", ""); err != nil {
+		return Connect{}, err
+	}
+	return Connect{
+		Services:  Service(binary.BigEndian.Uint16(b[0:2])),
+		UserLevel: UserLevel(binary.BigEndian.Uint16(b[2:4])),
+		Caller:    deviceInfoAt(b[4:44]),
+	}, nil
+}
+
+// TermSess is the payload of Term: why the session ended (spec 11.2.3).
+type TermSess struct {
+	Code   TermCode
+	Reason string // 19 usable bytes
+}
+
+func (t TermSess) String() string {
+	if t.Reason == "" {
+		return t.Code.String()
+	}
+	return fmt.Sprintf("%s %q", t.Code, t.Reason)
+}
+
+// AppendTo appends the 22-byte wire form.
+func (t TermSess) AppendTo(dst []byte) ([]byte, error) {
+	var code [2]byte
+	binary.BigEndian.PutUint16(code[:], uint16(t.Code))
+	return appendFixedString(append(dst, code[:]...), t.Reason, MaxTextSize)
+}
+
+// DecodeTermSess reads a TERMSESS_STR from the front of b.
+//
+// The reason string is optional on the wire: a device may send the code alone.
+func DecodeTermSess(b []byte) (TermSess, error) {
+	if err := need(b, 2, "TermSess", "Code"); err != nil {
+		return TermSess{}, err
+	}
+	t := TermSess{Code: TermCode(binary.BigEndian.Uint16(b[0:2]))}
+	if len(b) >= TermSessSize {
+		t.Reason = fixedString(b[2:22])
+	}
+	return t, nil
+}
+
+// ClearSess asks a server to free sessions on the named services
+// (spec 11.2.4). A Sessions value of 255 means all of them.
+type ClearSess struct {
+	Services Service
+	Sessions uint16
+}
+
+func (c ClearSess) String() string {
+	return fmt.Sprintf("svc=%s free=%d", c.Services, c.Sessions)
+}
+
+// AppendTo appends the 4-byte wire form.
+func (c ClearSess) AppendTo(dst []byte) []byte {
+	var b [ClearSessSize]byte
+	binary.BigEndian.PutUint16(b[0:2], uint16(c.Services))
+	binary.BigEndian.PutUint16(b[2:4], c.Sessions)
+	return append(dst, b[:]...)
+}
+
+// DecodeClearSess reads a CLEARSESS_STR from the front of b.
+func DecodeClearSess(b []byte) (ClearSess, error) {
+	if err := need(b, ClearSessSize, "ClearSess", ""); err != nil {
+		return ClearSess{}, err
+	}
+	return ClearSess{
+		Services: Service(binary.BigEndian.Uint16(b[0:2])),
+		Sessions: binary.BigEndian.Uint16(b[2:4]),
+	}, nil
+}
+
+// Wait tells a waiting client to extend its timeout (spec 11.6.2).
+//
+// The vendor library never implements this: its handler answers Nack, and
+// because Wait is a valid blind reply the frame is delivered to the caller as
+// though it were the answer. We decode it properly so the session layer can do
+// what the specification asks and reset the timer.
+type Wait struct {
+	Seconds uint16
+	Mode    Mode   // 0, or ModeString when a reason follows
+	Reason  string // optional, NUL-terminated
+}
+
+func (w Wait) String() string {
+	if w.Reason == "" {
+		return fmt.Sprintf("%ds", w.Seconds)
+	}
+	return fmt.Sprintf("%ds %q", w.Seconds, w.Reason)
+}
+
+// AppendTo appends the wire form, including the optional reason.
+func (w Wait) AppendTo(dst []byte) ([]byte, error) {
+	var b [WaitSize]byte
+	binary.BigEndian.PutUint16(b[0:2], w.Seconds)
+	mode := w.Mode
+	if w.Reason != "" {
+		mode |= ModeString
+	}
+	binary.BigEndian.PutUint16(b[2:4], uint16(mode))
+	dst = append(dst, b[:]...)
+	if w.Reason != "" {
+		return appendCString(dst, w.Reason)
+	}
+	return dst, nil
+}
+
+// DecodeWait reads a WAIT_STR and its optional trailing reason.
+func DecodeWait(b []byte) (Wait, error) {
+	if err := need(b, WaitSize, "Wait", ""); err != nil {
+		return Wait{}, err
+	}
+	w := Wait{
+		Seconds: binary.BigEndian.Uint16(b[0:2]),
+		Mode:    Mode(binary.BigEndian.Uint16(b[2:4])),
+	}
+	if w.Mode.Has(ModeString) && len(b) > WaitSize {
+		w.Reason, _ = cString(b[WaitSize:])
+	}
+	return w, nil
+}

--- a/internal/snell-rollcall/codec/payload_session_test.go
+++ b/internal/snell-rollcall/codec/payload_session_test.go
@@ -1,0 +1,287 @@
+package codec
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// specConnect is the 44-byte CONNECT_STR of spec 11.2.2: the requested service
+// mask, the requested user level, and the caller's own DeviceInfo.
+const specConnect = "8003" + // rServices Menus|Control|LongStr
+	"0002" + // rUserLevel supervisor
+	specDeviceInfo
+
+func TestConnect_Decode(t *testing.T) {
+	got, err := DecodeConnect(mustHex(t, specConnect))
+	if err != nil {
+		t.Fatalf("DecodeConnect: %v", err)
+	}
+	want := Connect{
+		Services:  SvcMenus | SvcControl | SvcLongStr,
+		UserLevel: LevelSupervisor,
+		Caller:    wantDeviceInfo(),
+	}
+	if got != want {
+		t.Errorf("decoded\n got %+v\nwant %+v", got, want)
+	}
+}
+
+func TestConnect_Encode(t *testing.T) {
+	c := Connect{
+		Services:  SvcMenus | SvcControl | SvcLongStr,
+		UserLevel: LevelSupervisor,
+		Caller:    wantDeviceInfo(),
+	}
+	got, err := c.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	if want := mustHex(t, specConnect); !bytes.Equal(got, want) {
+		t.Errorf("encoded\n got %x\nwant %x", got, want)
+	}
+	if len(got) != ConnectSize {
+		t.Errorf("encoded %d bytes, want %d", len(got), ConnectSize)
+	}
+}
+
+// TestConnect_GenerationSelection pins how a client chooses a wire generation.
+// There is no version field: the presence of SvcLongStr in the Call is the
+// whole of the negotiation, and a server grants services all-or-nothing. A
+// client that wants to fall back must issue a second Call without the bit,
+// never expect a partial grant.
+func TestConnect_GenerationSelection(t *testing.T) {
+	base := Connect{Services: SvcMenus | SvcControl, Caller: wantDeviceInfo()}
+
+	gen16 := base
+	gen32 := base
+	gen32.Services |= SvcLongStr
+
+	if gen16.Services.LongStrings() {
+		t.Error("a 16-bit call must not carry the long-string bit")
+	}
+	if !gen32.Services.LongStrings() {
+		t.Error("a 32-bit call must carry the long-string bit")
+	}
+
+	// The two calls differ in exactly one bit of one field, so a device that
+	// answers one and refuses the other is telling us its generation.
+	b16, err := gen16.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	b32, err := gen32.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	if len(b16) != len(b32) {
+		t.Fatalf("the two generations must call with the same %d-byte structure", ConnectSize)
+	}
+	diff := 0
+	for i := range b16 {
+		if b16[i] != b32[i] {
+			diff++
+		}
+	}
+	if diff != 1 {
+		t.Errorf("the calls differ in %d bytes, want 1 (the service mask high byte)", diff)
+	}
+}
+
+func TestConnect_Short(t *testing.T) {
+	good := mustHex(t, specConnect)
+	for _, n := range []int{0, 3, 43} {
+		if _, err := DecodeConnect(good[:n]); !errors.Is(err, ErrShortBuffer) {
+			t.Errorf("DecodeConnect(%d bytes) err = %v, want ErrShortBuffer", n, err)
+		}
+	}
+
+	c := Connect{Caller: wantDeviceInfo()}
+	c.Caller.ID.Name = strings.Repeat("x", MaxTextSize)
+	if _, err := c.AppendTo(nil); !errors.Is(err, ErrStringTooLong) {
+		t.Errorf("err = %v, want ErrStringTooLong", err)
+	}
+}
+
+func TestConnect_String(t *testing.T) {
+	c := Connect{Services: SvcMenus, UserLevel: LevelFactory, Caller: wantDeviceInfo()}
+	got := c.String()
+	for _, want := range []string{"Menus", "factory", "0000-FF-00"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("String() = %q, want it to contain %q", got, want)
+		}
+	}
+}
+
+func TestTermSess_RoundTrip(t *testing.T) {
+	tests := []TermSess{
+		{Code: TermUser},
+		{Code: TermTimeout, Reason: "idle"},
+		{Code: TermNetError, Reason: strings.Repeat("r", MaxTextSize-1)},
+		{Code: TermRemote, Reason: "peer closed"},
+	}
+	for _, want := range tests {
+		b, err := want.AppendTo(nil)
+		if err != nil {
+			t.Fatalf("AppendTo %+v: %v", want, err)
+		}
+		if len(b) != TermSessSize {
+			t.Errorf("encoded %d bytes, want %d", len(b), TermSessSize)
+		}
+		got, err := DecodeTermSess(b)
+		if err != nil {
+			t.Fatalf("DecodeTermSess: %v", err)
+		}
+		if got != want {
+			t.Errorf("round trip %+v -> %+v", want, got)
+		}
+	}
+}
+
+// TestTermSess_CodeOnly covers the short form real devices send: the two-byte
+// reason code with no text. Requiring the full structure would drop the
+// termination and leave the session layer waiting for a reply that never comes.
+func TestTermSess_CodeOnly(t *testing.T) {
+	got, err := DecodeTermSess([]byte{0x00, 0x01})
+	if err != nil {
+		t.Fatalf("DecodeTermSess: %v", err)
+	}
+	if got.Code != TermTimeout || got.Reason != "" {
+		t.Errorf("= %+v, want the timeout code with no reason", got)
+	}
+
+	if _, err := DecodeTermSess([]byte{0x00}); !errors.Is(err, ErrShortBuffer) {
+		t.Errorf("err = %v, want ErrShortBuffer", err)
+	}
+}
+
+func TestTermSess_String(t *testing.T) {
+	if got := (TermSess{Code: TermTimeout}).String(); got != "timeout" {
+		t.Errorf("String() = %q, want %q", got, "timeout")
+	}
+	if got := (TermSess{Code: TermUser, Reason: "bye"}).String(); got != `user "bye"` {
+		t.Errorf("String() = %q", got)
+	}
+}
+
+func TestClearSess_RoundTrip(t *testing.T) {
+	tests := []ClearSess{
+		{},
+		{Services: SvcMenus | SvcControl, Sessions: 1},
+		{Services: SvcFile, Sessions: 255}, // 255 means every session
+	}
+	for _, want := range tests {
+		b := want.AppendTo(nil)
+		if len(b) != ClearSessSize {
+			t.Errorf("encoded %d bytes, want %d", len(b), ClearSessSize)
+		}
+		got, err := DecodeClearSess(b)
+		if err != nil {
+			t.Fatalf("DecodeClearSess: %v", err)
+		}
+		if got != want {
+			t.Errorf("round trip %+v -> %+v", want, got)
+		}
+	}
+
+	if _, err := DecodeClearSess([]byte{0, 0, 0}); !errors.Is(err, ErrShortBuffer) {
+		t.Errorf("err = %v, want ErrShortBuffer", err)
+	}
+	if got := (ClearSess{Services: SvcMenus, Sessions: 255}).String(); got != "svc=Menus free=255" {
+		t.Errorf("String() = %q", got)
+	}
+}
+
+// TestWait_RoundTrip covers the timeout-extension message. The vendor library
+// never implements it and answers Nack, but Wait is a valid blind reply, so a
+// device that does send it would otherwise be misread as answering the request.
+func TestWait_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		in   Wait
+		want Wait
+		size int
+	}{
+		{"bare", Wait{Seconds: 30}, Wait{Seconds: 30}, WaitSize},
+		{
+			"with a reason",
+			Wait{Seconds: 5, Reason: "loading"},
+			Wait{Seconds: 5, Mode: ModeString, Reason: "loading"},
+			WaitSize + len("loading") + 1,
+		},
+		{
+			"mode set explicitly",
+			Wait{Seconds: 1, Mode: ModeString, Reason: "x"},
+			Wait{Seconds: 1, Mode: ModeString, Reason: "x"},
+			WaitSize + 2,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := tc.in.AppendTo(nil)
+			if err != nil {
+				t.Fatalf("AppendTo: %v", err)
+			}
+			if len(b) != tc.size {
+				t.Errorf("encoded %d bytes, want %d", len(b), tc.size)
+			}
+			got, err := DecodeWait(b)
+			if err != nil {
+				t.Fatalf("DecodeWait: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("= %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWait_StringModeWithoutText covers a peer that sets the string flag but
+// sends nothing after the fixed part. The message still extends the timeout,
+// so dropping it would time the session out for no reason.
+func TestWait_StringModeWithoutText(t *testing.T) {
+	got, err := DecodeWait([]byte{0x00, 0x0A, 0x00, 0x02})
+	if err != nil {
+		t.Fatalf("DecodeWait: %v", err)
+	}
+	if got.Seconds != 10 || got.Reason != "" {
+		t.Errorf("= %+v, want 10 seconds and no reason", got)
+	}
+}
+
+func TestWait_Short(t *testing.T) {
+	if _, err := DecodeWait([]byte{0, 0, 0}); !errors.Is(err, ErrShortBuffer) {
+		t.Errorf("err = %v, want ErrShortBuffer", err)
+	}
+}
+
+func TestWait_ReasonTooLong(t *testing.T) {
+	w := Wait{Seconds: 1, Reason: strings.Repeat("x", MaxLongString)}
+	if _, err := w.AppendTo(nil); !errors.Is(err, ErrStringTooLong) {
+		t.Errorf("err = %v, want ErrStringTooLong", err)
+	}
+}
+
+func TestWait_String(t *testing.T) {
+	if got := (Wait{Seconds: 30}).String(); got != "30s" {
+		t.Errorf("String() = %q", got)
+	}
+	if got := (Wait{Seconds: 5, Reason: "busy"}).String(); got != `5s "busy"` {
+		t.Errorf("String() = %q", got)
+	}
+}
+
+// TestBackChannelConstants pins the three readiness values. FutureOnly is the
+// one worth naming: it suppresses the catch-up burst a server otherwise sends
+// on enable, which is the difference between a quiet subscribe and several
+// hundred frames arriving at once on a large unit.
+func TestBackChannelConstants(t *testing.T) {
+	if BackChannelDisable != 0 || BackChannelEnable != 1 || BackChannelFutureOnly != 2 {
+		t.Errorf("back-channel values are %d/%d/%d, want 0/1/2",
+			BackChannelDisable, BackChannelEnable, BackChannelFutureOnly)
+	}
+	if ReportAllCommands != 0xFFFF {
+		t.Errorf("ReportAllCommands = %04X, want FFFF", ReportAllCommands)
+	}
+}

--- a/internal/snell-rollcall/codec/pkttype.go
+++ b/internal/snell-rollcall/codec/pkttype.go
@@ -1,0 +1,238 @@
+package codec
+
+import "strconv"
+
+// PacketType is the 8-bit message type in ROLLHEADER_STR (spec 8, 9).
+type PacketType uint8
+
+// All defined packet types.
+//
+// Numbers 0..64 are the original set (spec 9). Numbers 65..71 were added by
+// the 2014 long-string extension. Values the specification lists as Reserved
+// are named here from the vendor header rc3comm.h, which defines several of
+// them; a value with no name at all decodes as unknown and must be answered
+// with InvCmd, not Nack (spec 9.15).
+const (
+	MsgNack          PacketType = 0
+	MsgAck           PacketType = 1
+	MsgCall          PacketType = 2
+	MsgTerm          PacketType = 3
+	MsgGetStat       PacketType = 4
+	MsgRetStat       PacketType = 5
+	MsgGetID         PacketType = 6
+	MsgRetID         PacketType = 7
+	MsgGetFunc       PacketType = 8
+	MsgRetFunc       PacketType = 9
+	MsgDispData      PacketType = 10
+	MsgGetFStat      PacketType = 11
+	MsgRetFStat      PacketType = 12
+	MsgReset         PacketType = 13
+	MsgInvCmd        PacketType = 14
+	MsgBusy          PacketType = 15
+	MsgSetParam      PacketType = 16
+	MsgTime          PacketType = 17
+	MsgFuncListChg   PacketType = 18
+	MsgGetDevList    PacketType = 19
+	MsgRetDevInfo    PacketType = 20
+	MsgGetDevInfo    PacketType = 21
+	MsgLogReq        PacketType = 22
+	MsgInvSess       PacketType = 23
+	MsgRealTime      PacketType = 24
+	MsgWait          PacketType = 25
+	MsgClearSess     PacketType = 26
+	MsgBkChnReady    PacketType = 27
+	MsgKeepAlive     PacketType = 28
+	MsgGetLocDevMap  PacketType = 29
+	MsgFuncStyleChg  PacketType = 30
+	MsgSetGroup      PacketType = 31
+	MsgStopGroup     PacketType = 32
+	MsgIam           PacketType = 33
+	MsgSetGrpFunc    PacketType = 34
+	MsgGetNextPkt    PacketType = 35
+	MsgRepFChg       PacketType = 36
+	MsgStopRepFChg   PacketType = 37
+	MsgRouteError    PacketType = 38
+	MsgBlockHeader   PacketType = 39
+	MsgStreamMode    PacketType = 40
+	MsgStreamData    PacketType = 41
+	MsgFileDir       PacketType = 42
+	MsgRetFileDir    PacketType = 43
+	MsgRaw           PacketType = 44
+	MsgSetUserLevel  PacketType = 45
+	MsgFileDelete    PacketType = 46
+	MsgGetTime       PacketType = 47
+	MsgFileRename    PacketType = 48
+	MsgLogData       PacketType = 49
+	MsgGetSrvByName  PacketType = 50
+	MsgFileOpen      PacketType = 51
+	MsgRetFileOpen   PacketType = 52
+	MsgFileClose     PacketType = 53
+	MsgGetDispData   PacketType = 54
+	MsgFileRead      PacketType = 55
+	MsgRetFileRead   PacketType = 56
+	MsgFileWrite     PacketType = 57
+	MsgSetMulti      PacketType = 58
+	MsgFileRet       PacketType = 59
+	MsgGetDispCaps   PacketType = 60
+	MsgRetDispCaps   PacketType = 61
+	MsgDrawBitmap    PacketType = 62
+	MsgDrawText      PacketType = 63
+	MsgMakeDirectory PacketType = 64
+	MsgGetMenuCount  PacketType = 65
+	MsgRetMenuCount  PacketType = 66
+	MsgGetMenuItem   PacketType = 67
+	MsgRetMenuItem   PacketType = 68
+	MsgGetValue      PacketType = 69
+	MsgSetValue      PacketType = 70
+	MsgRetValue      PacketType = 71
+
+	// NumPacketTypes is one past the highest defined type. A received type
+	// at or above this is unknown (vendor MsgHandlers.c replies InvCmd).
+	NumPacketTypes = 72
+)
+
+// props carries the dispatch properties the vendor library keeps per type in
+// its handler table (Core/MsgHandlers.c).
+type props struct {
+	name string
+
+	// broadcast marks a type that may legitimately arrive addressed to the
+	// broadcast address. Only Time and Iam qualify.
+	broadcast bool
+
+	// blindReply marks a type that may arrive as the reply to a request
+	// issued on the blind or unknown session, where replies are matched by
+	// address rather than by session.
+	blindReply bool
+
+	// gen32 marks a type that only exists in the 2014 long-string
+	// extension. A 16-bit-only unit answers these with Nack.
+	gen32 bool
+}
+
+var packetProps = [NumPacketTypes]props{
+	MsgNack:          {name: "NACK", blindReply: true},
+	MsgAck:           {name: "ACK", blindReply: true},
+	MsgCall:          {name: "CALL"},
+	MsgTerm:          {name: "TERM"},
+	MsgGetStat:       {name: "GETSTAT"},
+	MsgRetStat:       {name: "RETSTAT", blindReply: true},
+	MsgGetID:         {name: "GETID"},
+	MsgRetID:         {name: "RETID", blindReply: true},
+	MsgGetFunc:       {name: "GETFUNC"},
+	MsgRetFunc:       {name: "RETFUNC"},
+	MsgDispData:      {name: "DISPDATA"},
+	MsgGetFStat:      {name: "GETFSTAT"},
+	MsgRetFStat:      {name: "RETFSTAT", blindReply: true},
+	MsgReset:         {name: "RESET"},
+	MsgInvCmd:        {name: "INVCMD", blindReply: true},
+	MsgBusy:          {name: "BUSY", blindReply: true},
+	MsgSetParam:      {name: "SETPARAM"},
+	MsgTime:          {name: "TIME", broadcast: true, blindReply: true},
+	MsgFuncListChg:   {name: "FUNCLISTCHG"},
+	MsgGetDevList:    {name: "GETDEVLIST"},
+	MsgRetDevInfo:    {name: "RETDEVINFO", blindReply: true},
+	MsgGetDevInfo:    {name: "GETDEVINFO"},
+	MsgLogReq:        {name: "LOGREQ"},
+	MsgInvSess:       {name: "INVSESS", blindReply: true},
+	MsgRealTime:      {name: "REALTIME"},
+	MsgWait:          {name: "WAIT", blindReply: true},
+	MsgClearSess:     {name: "CLEARSESS"},
+	MsgBkChnReady:    {name: "BKCHNREADY"},
+	MsgKeepAlive:     {name: "KEEPALIVE"},
+	MsgGetLocDevMap:  {name: "GETLOCDEVMAP"},
+	MsgFuncStyleChg:  {name: "FUNCSTYLECHG"},
+	MsgSetGroup:      {name: "SETGROUP"},
+	MsgStopGroup:     {name: "STOPGROUP"},
+	MsgIam:           {name: "IAM", broadcast: true},
+	MsgSetGrpFunc:    {name: "SETGRPFUNC"},
+	MsgGetNextPkt:    {name: "GETNEXTPKT"},
+	MsgRepFChg:       {name: "REPFCHG"},
+	MsgStopRepFChg:   {name: "STOPREPFCHG"},
+	MsgRouteError:    {name: "ROUTEERROR"},
+	MsgBlockHeader:   {name: "BLOCKHEADER", blindReply: true},
+	MsgStreamMode:    {name: "STREAMMODE"},
+	MsgStreamData:    {name: "STREAMDATA"},
+	MsgFileDir:       {name: "FILEDIR"},
+	MsgRetFileDir:    {name: "RETFILEDIR"},
+	MsgRaw:           {name: "RAW"},
+	MsgSetUserLevel:  {name: "SETUSERLEVEL"},
+	MsgFileDelete:    {name: "FILEDELETE"},
+	MsgGetTime:       {name: "GETTIME"},
+	MsgFileRename:    {name: "FILERENAME"},
+	MsgLogData:       {name: "LOGDATA"},
+	MsgGetSrvByName:  {name: "GETSRVBYNAME"},
+	MsgFileOpen:      {name: "FILEOPEN"},
+	MsgRetFileOpen:   {name: "RETFILEOPEN"},
+	MsgFileClose:     {name: "FILECLOSE"},
+	MsgGetDispData:   {name: "GETDISPDATA"},
+	MsgFileRead:      {name: "FILEREAD"},
+	MsgRetFileRead:   {name: "RETFILEREAD"},
+	MsgFileWrite:     {name: "FILEWRITE"},
+	MsgSetMulti:      {name: "SETMULTI"},
+	MsgFileRet:       {name: "FILERET"},
+	MsgGetDispCaps:   {name: "GETDISPCAPS"},
+	MsgRetDispCaps:   {name: "RETDISPCAPS", blindReply: true},
+	MsgDrawBitmap:    {name: "DRAWBITMAP"},
+	MsgDrawText:      {name: "DRAWTEXT"},
+	MsgMakeDirectory: {name: "MAKEDIRECTORY"},
+	MsgGetMenuCount:  {name: "GETMENUCOUNT", gen32: true},
+	MsgRetMenuCount:  {name: "RETMENUCOUNT", gen32: true},
+	MsgGetMenuItem:   {name: "GETMENUITEM", gen32: true},
+	MsgRetMenuItem:   {name: "RETMENUITEM", gen32: true},
+	MsgGetValue:      {name: "GETVALUE", gen32: true},
+	MsgSetValue:      {name: "SETVALUE", gen32: true},
+	MsgRetValue:      {name: "RETVALUE", gen32: true, blindReply: true},
+}
+
+// Known reports whether the type is defined by the specification or the
+// vendor header. An unknown type must be answered with InvCmd (spec 9.15),
+// which is distinct from Nack: InvCmd means "I do not understand this",
+// Nack means "I understand it but cannot do it".
+func (t PacketType) Known() bool {
+	return int(t) < NumPacketTypes && packetProps[t].name != ""
+}
+
+// String returns the vendor name, e.g. "SETVALUE", or the decimal value in
+// angle brackets when the type is unknown.
+func (t PacketType) String() string {
+	if t.Known() {
+		return packetProps[t].name
+	}
+	return "<" + strconv.Itoa(int(t)) + ">"
+}
+
+// Broadcastable reports whether the type may arrive addressed to the
+// broadcast address. Only Time and Iam may.
+func (t PacketType) Broadcastable() bool {
+	return t.Known() && packetProps[t].broadcast
+}
+
+// ValidBlindReply reports whether the type may be accepted as the reply to a
+// request made on the blind or unknown session, where the session index
+// cannot be used to correlate and matching is by address instead.
+func (t PacketType) ValidBlindReply() bool {
+	return t.Known() && packetProps[t].blindReply
+}
+
+// Gen32 reports whether the type belongs to the 2014 long-string extension.
+// A unit that does not advertise SvcLongStr answers these with Nack.
+func (t PacketType) Gen32() bool {
+	return t.Known() && packetProps[t].gen32
+}
+
+// PacketTypeByName looks up a type by its vendor name, case-sensitively, with
+// or without the "SP_" prefix the specification uses. It exists so that CLI
+// flags and trace filters can name types the way the documents do.
+func PacketTypeByName(name string) (PacketType, bool) {
+	n := name
+	if len(n) > 3 && n[:3] == "SP_" {
+		n = n[3:]
+	}
+	for i := 0; i < NumPacketTypes; i++ {
+		if packetProps[i].name == n {
+			return PacketType(i), true
+		}
+	}
+	return 0, false
+}

--- a/internal/snell-rollcall/codec/pkttype_test.go
+++ b/internal/snell-rollcall/codec/pkttype_test.go
@@ -1,0 +1,154 @@
+package codec
+
+import "testing"
+
+// TestPacketType_Catalogue pins the numbering of the whole message catalogue
+// against spec 9. A wrong number here is the kind of defect that only shows up
+// as a device answering INVCMD to a command it does implement, so every value
+// is written out rather than derived.
+func TestPacketType_Catalogue(t *testing.T) {
+	want := map[PacketType]string{
+		0: "NACK", 1: "ACK", 2: "CALL", 3: "TERM", 4: "GETSTAT", 5: "RETSTAT",
+		6: "GETID", 7: "RETID", 8: "GETFUNC", 9: "RETFUNC", 10: "DISPDATA",
+		11: "GETFSTAT", 12: "RETFSTAT", 13: "RESET", 14: "INVCMD", 15: "BUSY",
+		16: "SETPARAM", 17: "TIME", 18: "FUNCLISTCHG", 19: "GETDEVLIST",
+		20: "RETDEVINFO", 21: "GETDEVINFO", 22: "LOGREQ", 23: "INVSESS",
+		24: "REALTIME", 25: "WAIT", 26: "CLEARSESS", 27: "BKCHNREADY",
+		28: "KEEPALIVE", 29: "GETLOCDEVMAP", 30: "FUNCSTYLECHG", 31: "SETGROUP",
+		32: "STOPGROUP", 33: "IAM", 34: "SETGRPFUNC", 35: "GETNEXTPKT",
+		36: "REPFCHG", 37: "STOPREPFCHG", 38: "ROUTEERROR", 39: "BLOCKHEADER",
+		40: "STREAMMODE", 41: "STREAMDATA", 42: "FILEDIR", 43: "RETFILEDIR",
+		44: "RAW", 45: "SETUSERLEVEL", 46: "FILEDELETE", 47: "GETTIME",
+		48: "FILERENAME", 49: "LOGDATA", 50: "GETSRVBYNAME", 51: "FILEOPEN",
+		52: "RETFILEOPEN", 53: "FILECLOSE", 54: "GETDISPDATA", 55: "FILEREAD",
+		56: "RETFILEREAD", 57: "FILEWRITE", 58: "SETMULTI", 59: "FILERET",
+		60: "GETDISPCAPS", 61: "RETDISPCAPS", 62: "DRAWBITMAP", 63: "DRAWTEXT",
+		64: "MAKEDIRECTORY", 65: "GETMENUCOUNT", 66: "RETMENUCOUNT",
+		67: "GETMENUITEM", 68: "RETMENUITEM", 69: "GETVALUE", 70: "SETVALUE",
+		71: "RETVALUE",
+	}
+
+	if len(want) != NumPacketTypes {
+		t.Fatalf("table has %d entries, NumPacketTypes is %d", len(want), NumPacketTypes)
+	}
+	for typ, name := range want {
+		if got := typ.String(); got != name {
+			t.Errorf("type %d = %q, want %q", typ, got, name)
+		}
+		if !typ.Known() {
+			t.Errorf("type %d (%s) reports unknown", typ, name)
+		}
+	}
+}
+
+func TestPacketType_Unknown(t *testing.T) {
+	for _, typ := range []PacketType{NumPacketTypes, 100, 255} {
+		if typ.Known() {
+			t.Errorf("type %d reports known", typ)
+		}
+		if got, want := typ.String(), "<"+itoaInt(int(typ))+">"; got != want {
+			t.Errorf("String() = %q, want %q", got, want)
+		}
+		// An unknown type has no properties, so every predicate is false.
+		if typ.Broadcastable() || typ.ValidBlindReply() || typ.Gen32() {
+			t.Errorf("type %d claims a property it cannot have", typ)
+		}
+	}
+}
+
+func itoaInt(v int) string {
+	if v == 0 {
+		return "0"
+	}
+	var buf [4]byte
+	i := len(buf)
+	for v > 0 {
+		i--
+		buf[i] = byte('0' + v%10)
+		v /= 10
+	}
+	return string(buf[i:])
+}
+
+// TestPacketType_Broadcastable pins spec 5.5: only the two announcement types
+// may be addressed to 0000-00-00. Accepting any other type from the broadcast
+// address is how a rogue frame reaches a session it was never part of.
+func TestPacketType_Broadcastable(t *testing.T) {
+	broadcast := map[PacketType]bool{MsgTime: true, MsgIam: true}
+	for i := range PacketType(NumPacketTypes) {
+		if got := i.Broadcastable(); got != broadcast[i] {
+			t.Errorf("%s Broadcastable = %v, want %v", i, got, broadcast[i])
+		}
+	}
+}
+
+// TestPacketType_Gen32 pins the 2014 extension boundary: types 65..71 exist
+// only when both ends negotiated SvcLongStr.
+func TestPacketType_Gen32(t *testing.T) {
+	for i := range PacketType(NumPacketTypes) {
+		want := i >= MsgGetMenuCount
+		if got := i.Gen32(); got != want {
+			t.Errorf("%s Gen32 = %v, want %v", i, got, want)
+		}
+	}
+}
+
+// TestPacketType_ValidBlindReply pins which replies may be correlated by
+// address when there is no session to correlate by (spec 5.4, 9.17).
+func TestPacketType_ValidBlindReply(t *testing.T) {
+	want := map[PacketType]bool{
+		MsgNack: true, MsgAck: true, MsgRetStat: true, MsgRetID: true,
+		MsgRetFStat: true, MsgInvCmd: true, MsgBusy: true, MsgTime: true,
+		MsgRetDevInfo: true, MsgInvSess: true, MsgWait: true,
+		MsgBlockHeader: true, MsgRetDispCaps: true, MsgRetValue: true,
+	}
+	for i := range PacketType(NumPacketTypes) {
+		if got := i.ValidBlindReply(); got != want[i] {
+			t.Errorf("%s ValidBlindReply = %v, want %v", i, got, want[i])
+		}
+	}
+	// A request is never a reply.
+	for _, typ := range []PacketType{MsgCall, MsgGetStat, MsgSetParam, MsgGetValue} {
+		if typ.ValidBlindReply() {
+			t.Errorf("%s is a request, not a blind reply", typ)
+		}
+	}
+}
+
+func TestPacketTypeByName(t *testing.T) {
+	tests := []struct {
+		in   string
+		want PacketType
+		ok   bool
+	}{
+		{"CALL", MsgCall, true},
+		{"SP_CALL", MsgCall, true}, // the spelling used in the spec
+		{"SP_RETVALUE", MsgRetValue, true},
+		{"NACK", MsgNack, true}, // type 0 must not read as "not found"
+		{"call", 0, false},      // lookup is case-sensitive
+		{"SP_", 0, false},
+		{"", 0, false},
+		{"NOSUCHTYPE", 0, false},
+	}
+	for _, tc := range tests {
+		got, ok := PacketTypeByName(tc.in)
+		if ok != tc.ok || got != tc.want {
+			t.Errorf("PacketTypeByName(%q) = %d,%v, want %d,%v", tc.in, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+// TestPacketTypeByName_RoundTripsEveryName guarantees the name table has no
+// duplicates and that every type can be named on a CLI flag or trace filter.
+func TestPacketTypeByName_RoundTripsEveryName(t *testing.T) {
+	for i := range PacketType(NumPacketTypes) {
+		got, ok := PacketTypeByName(i.String())
+		if !ok {
+			t.Errorf("%s does not resolve back to a type", i)
+			continue
+		}
+		if got != i {
+			t.Errorf("name %q resolves to %d, want %d (duplicate name)", i.String(), got, i)
+		}
+	}
+}

--- a/internal/snell-rollcall/codec/strings.go
+++ b/internal/snell-rollcall/codec/strings.go
@@ -1,0 +1,96 @@
+package codec
+
+import (
+	"bytes"
+	"fmt"
+	"unicode/utf8"
+)
+
+// String field budgets.
+const (
+	// MaxTextSize is MAXTEXTSIZE: the fixed field width of the 16-bit
+	// generation, terminator included, so 19 usable bytes (rc3comm.h).
+	MaxTextSize = 20
+
+	// MaxLongString is LONGSTRLEN: the ceiling the 2014 extension sets for
+	// NUL-terminated UTF-8 strings, terminator included (rc3comm.h).
+	MaxLongString = 64
+)
+
+// fixedString reads a fixed-width field and returns the text up to the first
+// NUL. The caller passes the exact field, so there is nothing here that can
+// fail: every caller has already validated the structure's length.
+//
+// Bytes after the terminator are undefined by the specification. Real devices
+// leave whatever was in the buffer there: the live Centra units and the vendor
+// test client both pad with 0xCD. That is compliant, so this never reports it
+// and callers must never compare it. Golden-frame tests must mask the padding
+// or they become device-specific.
+func fixedString(b []byte) string {
+	if i := bytes.IndexByte(b, 0); i >= 0 {
+		b = b[:i]
+	}
+	// No terminator inside the field is legal: the text simply fills it.
+	return string(b)
+}
+
+// appendFixedString writes text into a fixed-width field, NUL-padded.
+//
+// The field is zero-filled first, so we never leak adjacent memory the way the
+// vendor implementations do. A string that cannot fit with its terminator is
+// an error rather than a silent truncation, because a truncated label is a
+// data-loss bug the caller should decide about.
+func appendFixedString(dst []byte, s string, width int) ([]byte, error) {
+	if len(s) > width-1 {
+		return nil, fmt.Errorf("%w: %d bytes into a %d-byte field", ErrStringTooLong, len(s), width)
+	}
+	var f [MaxTextSize]byte
+	buf := f[:]
+	if width > len(buf) {
+		buf = make([]byte, width)
+	}
+	buf = buf[:width]
+	for i := range buf {
+		buf[i] = 0
+	}
+	copy(buf, s)
+	return append(dst, buf...), nil
+}
+
+// truncateFixed shortens s so it fits a fixed field with its terminator,
+// cutting on a UTF-8 boundary. Used where the protocol mandates truncation
+// rather than an error, such as projecting a long label into the 16-bit
+// generation.
+func truncateFixed(s string, width int) string {
+	if len(s) <= width-1 {
+		return s
+	}
+	cut := width - 1
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut]
+}
+
+// cString reads a NUL-terminated string and returns it with the number of
+// bytes consumed including the terminator.
+//
+// A field that runs to the end of the payload without a terminator is
+// accepted: the vendor emits this when a value exactly fills its buffer.
+func cString(b []byte) (string, int) {
+	i := bytes.IndexByte(b, 0)
+	if i < 0 {
+		return string(b), len(b)
+	}
+	return string(b[:i]), i + 1
+}
+
+// appendCString appends a NUL-terminated string, refusing one that exceeds the
+// long-string ceiling.
+func appendCString(dst []byte, s string) ([]byte, error) {
+	if len(s) > MaxLongString-1 {
+		return nil, fmt.Errorf("%w: %d bytes, ceiling %d", ErrStringTooLong, len(s), MaxLongString)
+	}
+	dst = append(dst, s...)
+	return append(dst, 0), nil
+}

--- a/internal/snell-rollcall/codec/strings_test.go
+++ b/internal/snell-rollcall/codec/strings_test.go
@@ -1,0 +1,234 @@
+package codec
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestFixedString covers the fixed-width text field of the 16-bit
+// generation. The case that matters most is the last one: bytes after the
+// terminator are undefined by the specification, and every real device leaves
+// junk there. Treating that junk as data, or as a compliance event, is wrong.
+func TestFixedString(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+		want string
+	}{
+		{"terminated", []byte("Vega\x00\x00\x00\x00"), "Vega"},
+		{"empty", []byte("\x00\x00\x00\x00\x00\x00\x00\x00"), ""},
+		{"fills the field", []byte("ABCDEFGH"), "ABCDEFGH"},
+		{"leading terminator wins", []byte("\x00BCDEFGH"), ""},
+		// A live Centra pads with 0xCD; the vendor test client does too.
+		{"vendor padding after NUL", []byte("Hub\x00\xcd\xcd\xcd\xcd"), "Hub"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := fixedString(tc.in); got != tc.want {
+				t.Errorf("= %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDecodeError_NamesTheField pins that a decode failure names the structure
+// and field rather than only a byte offset, so a log line from the field is
+// actionable without a hex dump.
+func TestDecodeError_NamesTheField(t *testing.T) {
+	err := need([]byte("abc"), 8, "ID", "Name")
+	if !errors.Is(err, ErrShortBuffer) {
+		t.Fatalf("err = %v, want ErrShortBuffer", err)
+	}
+	var de *DecodeError
+	if !errors.As(err, &de) {
+		t.Fatalf("err = %v, want a *DecodeError", err)
+	}
+	if de.Struct != "ID" || de.Field != "Name" {
+		t.Errorf("DecodeError names %s.%s, want ID.Name", de.Struct, de.Field)
+	}
+	if got := de.Error(); !strings.Contains(got, "ID.Name") {
+		t.Errorf("Error() = %q, want it to name the field", got)
+	}
+}
+
+// TestAppendFixedString checks that we zero-fill rather than leaking whatever
+// was in the buffer. Devices tolerate junk padding, but emitting it makes our
+// own frames non-reproducible and our golden fixtures worthless.
+func TestAppendFixedString(t *testing.T) {
+	tests := []struct {
+		name  string
+		in    string
+		width int
+		want  []byte
+	}{
+		{"padded", "Vega", 8, []byte("Vega\x00\x00\x00\x00")},
+		{"empty", "", 4, []byte{0, 0, 0, 0}},
+		{"exactly fits with terminator", "ABC", 4, []byte("ABC\x00")},
+		{"wider than the stack buffer", "x", 40, append([]byte("x"), make([]byte, 39)...)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := appendFixedString(nil, tc.in, tc.width)
+			if err != nil {
+				t.Fatalf("appendFixedString: %v", err)
+			}
+			if !bytes.Equal(got, tc.want) {
+				t.Errorf("= %x, want %x", got, tc.want)
+			}
+		})
+	}
+
+	// Appending must not disturb what is already in the buffer.
+	got, err := appendFixedString([]byte{0xAA, 0xBB}, "Hi", 4)
+	if err != nil {
+		t.Fatalf("appendFixedString: %v", err)
+	}
+	if want := []byte{0xAA, 0xBB, 'H', 'i', 0, 0}; !bytes.Equal(got, want) {
+		t.Errorf("append = %x, want %x", got, want)
+	}
+}
+
+// TestAppendFixedString_TooLong pins that overlong text is an error rather than
+// a silent truncation. A truncated label is data loss the caller must decide
+// about; only truncateFixed does it, and only where the protocol says to.
+func TestAppendFixedString_TooLong(t *testing.T) {
+	for _, tc := range []struct {
+		in    string
+		width int
+	}{
+		{"ABCD", 4}, // no room for the terminator
+		{strings.Repeat("x", MaxTextSize), MaxTextSize},
+	} {
+		if _, err := appendFixedString(nil, tc.in, tc.width); !errors.Is(err, ErrStringTooLong) {
+			t.Errorf("appendFixedString(%q, %d) err = %v, want ErrStringTooLong",
+				tc.in, tc.width, err)
+		}
+	}
+
+	// The largest string that does fit must be accepted.
+	ok := strings.Repeat("x", MaxTextSize-1)
+	if _, err := appendFixedString(nil, ok, MaxTextSize); err != nil {
+		t.Errorf("a %d-byte string must fit a %d-byte field: %v", len(ok), MaxTextSize, err)
+	}
+}
+
+func TestFixedString_RoundTrip(t *testing.T) {
+	for _, s := range []string{"", "a", "Vega", "IQMDA00 Analog", strings.Repeat("z", 19)} {
+		b, err := appendFixedString(nil, s, MaxTextSize)
+		if err != nil {
+			t.Fatalf("append %q: %v", s, err)
+		}
+		if got := fixedString(b); got != s {
+			t.Errorf("round trip %q -> %q", s, got)
+		}
+	}
+}
+
+// TestTruncateFixed covers the mandated-truncation path, including the UTF-8
+// rule: a multi-byte rune is dropped whole, never cut in half. A half rune on
+// the wire renders as a replacement character on every client.
+func TestTruncateFixed(t *testing.T) {
+	tests := []struct {
+		name  string
+		in    string
+		width int
+		want  string
+	}{
+		{"fits", "Vega", 8, "Vega"},
+		{"exactly fits", "ABC", 4, "ABC"},
+		{"cut", "ABCDEFGH", 4, "ABC"},
+		{"empty", "", 4, ""},
+		// "e" + 3 x 2-byte runes = 7 bytes; a 6-byte field holds 5, and the
+		// rune spanning that boundary is dropped rather than split.
+		{"utf-8 boundary", "eééé", 6, "eéé"},
+		{"first rune is multi-byte", "éx", 2, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := truncateFixed(tc.in, tc.width)
+			if got != tc.want {
+				t.Errorf("= %q, want %q", got, tc.want)
+			}
+			if len(got) > tc.width-1 {
+				t.Errorf("%q is %d bytes, too long for a %d-byte field",
+					got, len(got), tc.width)
+			}
+			// Whatever comes out must still fit the field it was cut for.
+			if _, err := appendFixedString(nil, got, tc.width); err != nil {
+				t.Errorf("truncated text still does not fit: %v", err)
+			}
+		})
+	}
+}
+
+// TestCString covers the NUL-terminated form of the 32-bit generation,
+// including the unterminated tail the vendor emits when a value exactly fills
+// its buffer.
+func TestCString(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+		want string
+		n    int
+	}{
+		{"terminated", []byte("Vega\x00"), "Vega", 5},
+		{"terminated with a tail", []byte("Vega\x00rest"), "Vega", 5},
+		{"empty", []byte{0}, "", 1},
+		{"unterminated tail", []byte("Vega"), "Vega", 4},
+		{"nothing at all", nil, "", 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, n := cString(tc.in)
+			if got != tc.want || n != tc.n {
+				t.Errorf("= %q,%d want %q,%d", got, n, tc.want, tc.n)
+			}
+		})
+	}
+}
+
+func TestAppendCString(t *testing.T) {
+	got, err := appendCString([]byte{0xAA}, "Vega")
+	if err != nil {
+		t.Fatalf("appendCString: %v", err)
+	}
+	if want := []byte("\xaaVega\x00"); !bytes.Equal(got, want) {
+		t.Errorf("= %x, want %x", got, want)
+	}
+
+	// The long-string ceiling includes the terminator.
+	ok := strings.Repeat("x", MaxLongString-1)
+	if _, err := appendCString(nil, ok); err != nil {
+		t.Errorf("a %d-byte string must fit: %v", len(ok), err)
+	}
+	if _, err := appendCString(nil, ok+"x"); !errors.Is(err, ErrStringTooLong) {
+		t.Errorf("err = %v, want ErrStringTooLong", err)
+	}
+}
+
+func TestCString_RoundTrip(t *testing.T) {
+	for _, s := range []string{"", "a", "Vega", "IQMDA00 Analog Video", strings.Repeat("z", 63)} {
+		b, err := appendCString(nil, s)
+		if err != nil {
+			t.Fatalf("append %q: %v", s, err)
+		}
+		got, n := cString(b)
+		if got != s || n != len(b) {
+			t.Errorf("round trip %q -> %q (consumed %d of %d)", s, got, n, len(b))
+		}
+	}
+}
+
+// TestDecodeError_NoField covers the form used when a failure belongs to a
+// whole structure rather than one of its fields.
+func TestDecodeError_NoField(t *testing.T) {
+	err := decodeErr("Connect", "", 12, ErrShortBuffer)
+	if got := err.Error(); !strings.Contains(got, "Connect at +12") {
+		t.Errorf("Error() = %q", got)
+	}
+	if !errors.Is(err, ErrShortBuffer) {
+		t.Error("Unwrap must expose the sentinel")
+	}
+}


### PR DESCRIPTION
Closes #1012. Part of #1009 (unit 2 of 10).

Stacked on #1011 (the audit and wire context), so the base is that branch
rather than `main`. It retargets to `main` automatically when #1011 merges.

## Ported or reimplemented?

Reimplemented. This is a clean-room Go package written from the RollCall
Technical Specification Revision 14, with the vendor C library used as a
reference for the behaviours the specification leaves open. No vendor source
was translated, no vendor object is linked, and there is no cgo. Every struct
carries the specification section it comes from, and where a rule comes from
the vendor library instead the comment names the file it was read from.

## What is here

| Area | Contents |
| --- | --- |
| Framing | 4-byte transmission header, 14-byte message header, 2-byte roll header, encoder, and a resynchronising stream reader |
| Addressing | `NNNN-UU-PP:SS` parse and print, bridge routing, hop counting, route validation |
| Catalogue | all 72 packet types with their broadcast, blind-reply and generation properties |
| Bit fields | service mask, user level, unit status, value mode, menu style, termination code |
| Strings | fixed 20-byte fields and NUL-terminated long strings, with the UTF-8 truncation rule |
| Payloads | identity, session, control and menu structures of the 16-bit generation |

The 32-bit generation, the file and display services, and the router and
unit-id tables arrive in unit 3.

## Wire rules this pins

Four points where the specification is silent, ambiguous, or contradicted by
every shipping device. Each has a named test.

**The unconnected session index is 255, not -1.** The field is signed, so the
obvious encoding of "unknown" puts `0xFFFF` on the wire. A lenient proxy
answers it anyway; a real device faults. This crashed a vendor simulator three
times during the audit before the cause was found.

**Framing resynchronises one byte at a time.** The vendor library discards four
bytes per attempt, which cannot re-align a stream that slipped by an odd
number. Resyncs are counted so the session layer can raise a compliance event.

**Bytes after a NUL in a fixed field are undefined.** Live Centra units and the
vendor test client both leave `0xCD` there. That is compliant, so it is never
reported and never compared. Fixtures that depend on it would be
device-specific.

**A level-gated menu line is substituted, not removed.** The server replaces it
with a hidden, disabled Data line carrying command 0 and the text "Reserved".
Line counts are identical at every user level, so comparing counts to detect
gating always reports no difference. `AccessGated` matches the whole pattern.

## Defects found while testing

**The reader could not assemble a spec-legal large frame.** Its buffer held 880
bytes while `DecodeFrame` accepts up to 1574, the specification's limit. A peer
sending a legal 1570-byte message would have hit a buffer-full error and lost
the connection. The buffer is now sized from `MaxDecodeFrame`, and a test feeds
a maximum-size frame through in 200-byte pieces.

**`Address.String` hid the defect it should have exposed.** It masked the
session index to 8 bits, so the malformed `0xFFFF` printed as a plausible
`0FF`. It now prints the full 16-bit field.

Both are fixed in this PR.

## Verification

```
ok  dhs/internal/snell-rollcall/codec   coverage: 100.0% of statements
```

- 109 tests, table-driven, expected bytes taken from the specification.
- **1620 frames** captured from Snell equipment on 10.6.250.105 decode and
  re-encode byte-identically across **39 packet types**. These vectors were
  produced by the vendor's own stack, not by this implementation, which is
  what makes them worth something.
- 784 device-originated frames are asserted to carry a well-formed session
  index. The 21 probe frames still carrying the pre-fix encoding are asserted
  to be ours, so the evidence stays visible instead of being deleted.
- 100% statement coverage, added to the per-package floor in CI.
- stdlib-only, no `dhs/*` import (ADR-0006). Builds for linux, darwin,
  windows and freebsd on amd64 and arm64 with cgo disabled (ADR-0016).

Reaching 100% meant removing error paths that could never run rather than
writing tests that could never exercise them: where an outer length check
already guarantees a structure's size, the nested decodes are now infallible
helpers. That made the decoders smaller as well as fully covered.

## Not in this PR

Consumer, provider, session layer, dissector and integration plays are units
4 onward. The integration tier will be driven by Ansible only, per the
standing instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
