### PR TITLE
feat(snell-rollcall): session layer — link, sessions, back channel, keepalive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,7 @@ jobs:
           check internal/snell-rollcall/codec 100
           check internal/snell-rollcall/codec/dtp 100
           check internal/snell-rollcall/codec/router 100
+          check internal/snell-rollcall/session 100
           check internal/transport/ws 100
           check internal/transport/http 100
           check internal/auth 100

--- a/internal/snell-rollcall/codec/payload_control.go
+++ b/internal/snell-rollcall/codec/payload_control.go
@@ -139,7 +139,7 @@ func DecodeFuncStatus(b []byte) (FuncStatus, error) {
 			f.Text = fixedString(b[off : off+MaxTextSize])
 			off += MaxTextSize
 		} else {
-			s, n := cString(b[off:])
+			s, n := CString(b[off:])
 			f.Text = s
 			off += n
 		}

--- a/internal/snell-rollcall/codec/payload_control32.go
+++ b/internal/snell-rollcall/codec/payload_control32.go
@@ -109,7 +109,7 @@ func DecodeValue(b []byte) (Value, error) {
 
 	off := ValueSize
 	if v.Mode.Has(ModeString) {
-		s, n := cString(b[off:])
+		s, n := CString(b[off:])
 		v.Text = s
 		off += n
 	}
@@ -142,7 +142,7 @@ func (v Value) ToFuncStatus() (FuncStatus, error) {
 		Command: uint16(v.Command),
 		Mode:    v.Mode,
 		Value:   v.Val,
-		Text:    truncateFixed(v.Text, MaxTextSize),
+		Text:    TruncateFixed(v.Text, MaxTextSize),
 		Data:    v.Data,
 		MatchID: v.MatchID,
 	}, nil

--- a/internal/snell-rollcall/codec/payload_menu32.go
+++ b/internal/snell-rollcall/codec/payload_menu32.go
@@ -168,12 +168,12 @@ func DecodeMenuItem(b []byte) (MenuItem, error) {
 
 	rest := b[MenuItemSize:]
 	if len(rest) > 0 {
-		s, n := cString(rest)
+		s, n := CString(rest)
 		m.Text = s
 		rest = rest[n:]
 	}
 	if len(rest) > 0 {
-		m.Param, _ = cString(rest)
+		m.Param, _ = CString(rest)
 	}
 	return m, nil
 }
@@ -207,8 +207,8 @@ func (m MenuItem) ToFunc() (Func, error) {
 		MaxRange:  m.MaxRange,
 		Step:      uint16(m.Step),
 		DivScale:  m.DivScale,
-		Text:      truncateFixed(m.Text, MaxTextSize),
-		Param:     truncateFixed(m.Param, MaxTextSize),
+		Text:      TruncateFixed(m.Text, MaxTextSize),
+		Param:     TruncateFixed(m.Param, MaxTextSize),
 	}, nil
 }
 

--- a/internal/snell-rollcall/codec/payload_session.go
+++ b/internal/snell-rollcall/codec/payload_session.go
@@ -173,7 +173,7 @@ func DecodeWait(b []byte) (Wait, error) {
 		Mode:    Mode(binary.BigEndian.Uint16(b[2:4])),
 	}
 	if w.Mode.Has(ModeString) && len(b) > WaitSize {
-		w.Reason, _ = cString(b[WaitSize:])
+		w.Reason, _ = CString(b[WaitSize:])
 	}
 	return w, nil
 }

--- a/internal/snell-rollcall/codec/strings.go
+++ b/internal/snell-rollcall/codec/strings.go
@@ -57,11 +57,16 @@ func appendFixedString(dst []byte, s string, width int) ([]byte, error) {
 	return append(dst, buf...), nil
 }
 
-// truncateFixed shortens s so it fits a fixed field with its terminator,
+// TruncateFixed shortens s so it fits a fixed field with its terminator,
 // cutting on a UTF-8 boundary. Used where the protocol mandates truncation
 // rather than an error, such as projecting a long label into the 16-bit
-// generation.
-func truncateFixed(s string, width int) string {
+// generation, or naming ourselves in an identity a peer will display.
+//
+// It is exported because the session layer builds identities from
+// caller-supplied names, and a name too long for the field must be shortened
+// rather than refused: a client that cannot connect because its own name is
+// long is a worse outcome than one that appears under a shortened name.
+func TruncateFixed(s string, width int) string {
 	if len(s) <= width-1 {
 		return s
 	}
@@ -72,12 +77,16 @@ func truncateFixed(s string, width int) string {
 	return s[:cut]
 }
 
-// cString reads a NUL-terminated string and returns it with the number of
+// CString reads a NUL-terminated string and returns it with the number of
 // bytes consumed including the terminator.
+//
+// It is exported because several messages end with an optional string that is
+// not part of any structure: the text a Nack may carry, the reason on a Wait.
+// The session layer reads those directly.
 //
 // A field that runs to the end of the payload without a terminator is
 // accepted: the vendor emits this when a value exactly fills its buffer.
-func cString(b []byte) (string, int) {
+func CString(b []byte) (string, int) {
 	i := bytes.IndexByte(b, 0)
 	if i < 0 {
 		return string(b), len(b)

--- a/internal/snell-rollcall/codec/strings_test.go
+++ b/internal/snell-rollcall/codec/strings_test.go
@@ -92,7 +92,7 @@ func TestAppendFixedString(t *testing.T) {
 
 // TestAppendFixedString_TooLong pins that overlong text is an error rather than
 // a silent truncation. A truncated label is data loss the caller must decide
-// about; only truncateFixed does it, and only where the protocol says to.
+// about; only TruncateFixed does it, and only where the protocol says to.
 func TestAppendFixedString_TooLong(t *testing.T) {
 	for _, tc := range []struct {
 		in    string
@@ -147,7 +147,7 @@ func TestTruncateFixed(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := truncateFixed(tc.in, tc.width)
+			got := TruncateFixed(tc.in, tc.width)
 			if got != tc.want {
 				t.Errorf("= %q, want %q", got, tc.want)
 			}
@@ -181,7 +181,7 @@ func TestCString(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, n := cString(tc.in)
+			got, n := CString(tc.in)
 			if got != tc.want || n != tc.n {
 				t.Errorf("= %q,%d want %q,%d", got, n, tc.want, tc.n)
 			}
@@ -214,7 +214,7 @@ func TestCString_RoundTrip(t *testing.T) {
 		if err != nil {
 			t.Fatalf("append %q: %v", s, err)
 		}
-		got, n := cString(b)
+		got, n := CString(b)
 		if got != s || n != len(b) {
 			t.Errorf("round trip %q -> %q (consumed %d of %d)", s, got, n, len(b))
 		}

--- a/internal/snell-rollcall/session/backchannel_test.go
+++ b/internal/snell-rollcall/session/backchannel_test.go
@@ -1,0 +1,322 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"dhs/internal/snell-rollcall/codec"
+)
+
+// TestEnableBackChannel_NeedsBothMessages pins the step that is easy to miss.
+// BkChnReady opens the channel, and control-value pushes additionally require
+// ReportChange. With only the first, a session looks subscribed and never
+// receives a value.
+func TestEnableBackChannel_NeedsBothMessages(t *testing.T) {
+	h := newHarness(t, Config{})
+	s := h.callSession(t, codec.SvcMenus|codec.SvcControl)
+
+	done := make(chan error, 1)
+	go func() { done <- s.EnableBackChannel(context.Background(), true) }()
+
+	ready := h.peer.recvType(codec.MsgBkChnReady)
+	if len(ready.Payload) != 1 || ready.Payload[0] != codec.BackChannelEnable {
+		t.Errorf("payload = %x, want the enable byte %02x", ready.Payload, codec.BackChannelEnable)
+	}
+	h.peer.send(ready, codec.MsgAck, nil)
+
+	report := h.peer.recvType(codec.MsgRepFChg)
+	if got := uint16(report.Payload[0])<<8 | uint16(report.Payload[1]); got != codec.ReportAllCommands {
+		t.Errorf("command = %04X, want the wildcard %04X", got, codec.ReportAllCommands)
+	}
+	h.peer.send(report, codec.MsgAck, nil)
+
+	if err := <-done; err != nil {
+		t.Fatalf("EnableBackChannel: %v", err)
+	}
+}
+
+// TestEnableBackChannel_MenusOnly covers a menu-only subscription, which does
+// not need value reporting and must not send a message the peer may Nack.
+func TestEnableBackChannel_MenusOnly(t *testing.T) {
+	h := newHarness(t, Config{})
+	s := h.callSession(t, codec.SvcMenus)
+
+	done := make(chan error, 1)
+	go func() { done <- s.EnableBackChannel(context.Background(), false) }()
+
+	ready := h.peer.recvType(codec.MsgBkChnReady)
+	h.peer.send(ready, codec.MsgAck, nil)
+
+	if err := <-done; err != nil {
+		t.Fatalf("EnableBackChannel: %v", err)
+	}
+	h.peer.quiet()
+}
+
+func TestEnableBackChannel_Refused(t *testing.T) {
+	h := newHarness(t, Config{})
+	s := h.callSession(t, codec.SvcControl)
+
+	done := make(chan error, 1)
+	go func() { done <- s.EnableBackChannel(context.Background(), true) }()
+
+	ready := h.peer.recvType(codec.MsgBkChnReady)
+	h.peer.send(ready, codec.MsgNack, nil)
+
+	if err := <-done; !errors.Is(err, ErrRefused) {
+		t.Fatalf("err = %v, want ErrRefused", err)
+	}
+
+	// A peer that opens the channel but refuses value reporting is also a
+	// failure: the caller asked for values and will not get them.
+	done2 := make(chan error, 1)
+	go func() { done2 <- s.EnableBackChannel(context.Background(), true) }()
+	ready = h.peer.recvType(codec.MsgBkChnReady)
+	h.peer.send(ready, codec.MsgAck, nil)
+	report := h.peer.recvType(codec.MsgRepFChg)
+	h.peer.send(report, codec.MsgNack, nil)
+
+	if err := <-done2; !errors.Is(err, ErrRefused) {
+		t.Fatalf("err = %v, want ErrRefused", err)
+	}
+}
+
+func TestDisableBackChannel(t *testing.T) {
+	h := newHarness(t, Config{})
+	s := h.callSession(t, codec.SvcControl)
+
+	done := make(chan error, 1)
+	go func() { done <- s.DisableBackChannel(context.Background()) }()
+
+	f := h.peer.recvType(codec.MsgBkChnReady)
+	if len(f.Payload) != 1 || f.Payload[0] != codec.BackChannelDisable {
+		t.Errorf("payload = %x, want the disable byte", f.Payload)
+	}
+	h.peer.send(f, codec.MsgAck, nil)
+
+	if err := <-done; err != nil {
+		t.Fatalf("DisableBackChannel: %v", err)
+	}
+}
+
+// TestPushIsAcknowledgedByTheApplication pins the flow control the protocol
+// provides. Each push is a request, and its acknowledgement is what asks for
+// the next one. Acknowledging before the application has taken the message
+// throws that away and lets a fast device outrun a slow reader.
+func TestPushIsAcknowledgedByTheApplication(t *testing.T) {
+	h := newHarness(t, Config{})
+	s := h.callSession(t, codec.SvcControl)
+
+	value, err := codec.FuncStatus{Command: 0x0113, Mode: codec.ModeValue, Value: -60}.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	h.peer.push(s, codec.MsgRetFStat, value)
+
+	var got Push
+	select {
+	case got = <-s.Pushes():
+	case <-time.After(2 * time.Second):
+		t.Fatal("the push was never delivered")
+	}
+
+	if got.Frame.Type != codec.MsgRetFStat {
+		t.Errorf("push type = %s, want RETFSTAT", got.Frame.Type)
+	}
+	if !got.Frame.BackChannel() {
+		t.Error("a push must carry the back-channel flag")
+	}
+	fs, err := codec.DecodeFuncStatus(got.Frame.Payload)
+	if err != nil {
+		t.Fatalf("DecodeFuncStatus: %v", err)
+	}
+	if fs.Command != 0x0113 || fs.Value != -60 {
+		t.Errorf("= %+v, want command 275 at -60", fs)
+	}
+
+	// Nothing is sent until the application acknowledges.
+	h.peer.quiet()
+
+	if err := got.Ack(); err != nil {
+		t.Fatalf("Ack: %v", err)
+	}
+	ack := h.peer.recvType(codec.MsgAck)
+	if !ack.BackChannel() {
+		t.Error("the acknowledgement must go back on the back channel")
+	}
+	if ack.Dst.Index != s.RemoteIndex() {
+		t.Errorf("ack destination index = %d, want the peer's %d", ack.Dst.Index, s.RemoteIndex())
+	}
+}
+
+// TestPushAddressing pins the addressing a push must carry, which is the third
+// of the three index mistakes found during the audit. A push is addressed to
+// the client's own index, not the server's, and one addressed wrongly is
+// dropped without a word.
+func TestPushAddressing(t *testing.T) {
+	h := newHarness(t, Config{})
+	s := h.callSession(t, codec.SvcControl)
+
+	// Addressed correctly: to our index.
+	h.peer.push(s, codec.MsgDispData, nil)
+	select {
+	case <-s.Pushes():
+	case <-time.After(2 * time.Second):
+		t.Fatal("a correctly addressed push was not delivered")
+	}
+
+	// Addressed to the peer's own index instead. It belongs to no session
+	// here and must not be delivered to ours.
+	h.peer.write(codec.Frame{
+		Dst:   addrWithIndex(peerAddr, s.RemoteIndex()+50),
+		Src:   addrWithIndex(peerAddr, s.RemoteIndex()),
+		Type:  codec.MsgDispData,
+		Flags: codec.FlagBackChannel,
+	})
+
+	select {
+	case p := <-s.Pushes():
+		t.Fatalf("a push for another session was delivered: %s", p.Frame)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// TestPushQueueBackPressure covers a reader that stops taking pushes. The queue
+// fills and the withheld acknowledgements stall the peer, which is what the
+// protocol intends; the alternative is dropping values silently.
+func TestPushQueueBackPressure(t *testing.T) {
+	h := newHarness(t, Config{PushQueue: 2})
+	s := h.callSession(t, codec.SvcControl)
+
+	for range 5 {
+		h.peer.push(s, codec.MsgDispData, nil)
+	}
+
+	// A front-channel frame behind the pushes is the barrier. The read loop
+	// is sequential, so once this has been dispatched every push before it
+	// has been too, and the queue can be counted without racing the reader.
+	h.peer.write(codec.Frame{
+		Dst:  addrWithIndex(peerAddr, s.LocalIndex()),
+		Src:  addrWithIndex(peerAddr, s.RemoteIndex()),
+		Type: codec.MsgTime,
+	})
+	select {
+	case <-h.link.Unsolicited():
+	case <-time.After(2 * time.Second):
+		t.Fatal("the barrier frame never arrived")
+	}
+
+	// Exactly the queue depth is held; the rest were refused rather than
+	// buffered without bound.
+	held := 0
+	for {
+		select {
+		case <-s.Pushes():
+			held++
+			continue
+		default:
+		}
+		break
+	}
+	if held != 2 {
+		t.Errorf("queue held %d pushes, want the configured depth of 2", held)
+	}
+
+	// Nothing was acknowledged, because nothing acknowledges on the
+	// application's behalf.
+	h.peer.quiet()
+}
+
+// TestProviderPushIsAnActiveMessage covers the provider side. A push is a
+// request: the next may not be sent until this one is acknowledged, which is
+// why a burst of changes queues instead of being written to the socket.
+func TestProviderPushIsAnActiveMessage(t *testing.T) {
+	h := newHarness(t, Config{})
+	s := h.callSession(t, codec.SvcControl)
+
+	first := make(chan error, 1)
+	go func() { first <- s.Push(context.Background(), codec.MsgRetFStat, make([]byte, 8)) }()
+	sent := h.peer.recvType(codec.MsgRetFStat)
+	if !sent.BackChannel() {
+		t.Error("a push must carry the back-channel flag")
+	}
+
+	second := make(chan error, 1)
+	go func() { second <- s.Push(context.Background(), codec.MsgDispData, nil) }()
+	h.peer.quiet()
+
+	select {
+	case <-second:
+		t.Fatal("a second push went out before the first was acknowledged")
+	default:
+	}
+
+	h.peer.sendFlags(sent, codec.MsgAck, codec.FlagBackChannel, nil)
+	if err := <-first; err != nil {
+		t.Fatalf("first push: %v", err)
+	}
+
+	next := h.peer.recvType(codec.MsgDispData)
+	h.peer.sendFlags(next, codec.MsgAck, codec.FlagBackChannel, nil)
+	if err := <-second; err != nil {
+		t.Fatalf("second push: %v", err)
+	}
+}
+
+// TestPushTimeout covers a client that stops acknowledging. A provider must
+// not wait forever on it, or one dead panel stalls every update it subscribed
+// to.
+func TestPushTimeout(t *testing.T) {
+	h := newHarness(t, Config{ReplyTimeout: 3 * time.Second})
+	s := h.callSession(t, codec.SvcControl)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- s.Push(context.Background(), codec.MsgDispData, nil) }()
+	h.peer.recvType(codec.MsgDispData)
+
+	h.fire(t, 1, 3*time.Second)
+
+	if err := <-errCh; !errors.Is(err, ErrTimeout) {
+		t.Fatalf("err = %v, want ErrTimeout", err)
+	}
+}
+
+// TestReplyOnTheBackChannel covers a provider answering a push the other way,
+// which is what a consumer's acknowledgement is underneath.
+func TestReplyOnTheBackChannel(t *testing.T) {
+	h := newHarness(t, Config{})
+	s := h.callSession(t, codec.SvcControl)
+
+	if err := s.Reply(codec.MsgAck, nil); err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+	f := h.peer.recvType(codec.MsgAck)
+	if !f.BackChannel() {
+		t.Error("Reply must set the back-channel flag")
+	}
+}
+
+// TestFrontChannelChatterIsSurfaced covers a peer sending on the front channel
+// with nothing outstanding. Some units send display updates that way, so the
+// frame is surfaced rather than dropped.
+func TestFrontChannelChatterIsSurfaced(t *testing.T) {
+	h := newHarness(t, Config{})
+	s := h.callSession(t, codec.SvcDisplay)
+
+	h.peer.write(codec.Frame{
+		Dst:  addrWithIndex(peerAddr, s.LocalIndex()),
+		Src:  addrWithIndex(peerAddr, s.RemoteIndex()),
+		Type: codec.MsgDispData,
+	})
+
+	select {
+	case f := <-h.link.Unsolicited():
+		if f.Type != codec.MsgDispData {
+			t.Errorf("= %s, want DISPDATA", f.Type)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("front-channel chatter was dropped instead of surfaced")
+	}
+}

--- a/internal/snell-rollcall/session/channel.go
+++ b/internal/snell-rollcall/session/channel.go
@@ -1,0 +1,221 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"dhs/internal/clock"
+	"dhs/internal/snell-rollcall/codec"
+)
+
+// channel is one direction of one session, and it enforces the rule the whole
+// protocol is built on: one message in flight at a time, and nothing else sent
+// until it is answered (spec 4).
+//
+// Every operation that touches the free token or a pending entry's frame
+// buffer happens under the mutex. All of them are non-blocking — the token
+// channel holds one slot and the frame buffer is bounded with a default case —
+// so holding the lock costs nothing and removes the race between a shutdown
+// closing those channels and a delivery writing to them. Waiting for a reply
+// happens on the caller's own goroutine with the lock released.
+type channel struct {
+	name string // "front" or "back", for errors and traces
+
+	mu         sync.Mutex
+	inFlight   *pending
+	closed     bool
+	err        error // why it closed, returned to later callers
+	strikes    int
+	maxStrikes int
+
+	// free is a one-token semaphore. Holding the token is the right to send;
+	// it is returned when the reply arrives or the attempt fails.
+	//
+	// It is never closed. Shutting down puts the token back instead, and each
+	// waiter that takes it finds the channel closed, returns the reason and
+	// passes the token on. Closing it would work too, but it would leave two
+	// ways to learn the channel is finished and a window in which a waiter
+	// takes a real token from a channel that is closing.
+	free chan struct{}
+
+	clk     clock.Clock
+	timeout time.Duration
+}
+
+// pending is the message occupying the slot.
+type pending struct {
+	// req is what was sent, kept so a timeout can name it.
+	req codec.PacketType
+
+	// frames carries everything the link matched to this request. It is
+	// buffered because a Wait arrives before the real reply and both have to
+	// be delivered without the link's read loop blocking on us.
+	frames chan codec.Frame
+}
+
+func newChannel(name string, clk clock.Clock, timeout time.Duration, maxStrikes int) *channel {
+	c := &channel{
+		name:       name,
+		free:       make(chan struct{}, 1),
+		clk:        clk,
+		timeout:    timeout,
+		maxStrikes: maxStrikes,
+	}
+	c.free <- struct{}{}
+	return c
+}
+
+// acquire waits for the slot and installs a pending entry for req.
+//
+// It is the only way to send on a channel, which is what makes the
+// one-in-flight rule structural rather than a convention every call site has
+// to remember.
+func (c *channel) acquire(ctx context.Context, req codec.PacketType) (*pending, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-c.free:
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		// Pass the token on so the next waiter also wakes and learns why.
+		c.free <- struct{}{}
+		return nil, c.err
+	}
+	p := &pending{req: req, frames: make(chan codec.Frame, 4)}
+	c.inFlight = p
+	return p, nil
+}
+
+// release clears the slot and hands the token back, unless the failure count
+// has reached the point where the session is dead.
+func (c *channel) release(ok bool) {
+	c.mu.Lock()
+	c.inFlight = nil
+	if ok {
+		c.strikes = 0
+	} else {
+		c.strikes++
+	}
+	dead := !c.closed && c.strikes >= c.maxStrikes
+	if !c.closed && !dead {
+		c.free <- struct{}{} // capacity 1, we hold the only token
+	}
+	c.mu.Unlock()
+
+	if dead {
+		c.closeWith(fmt.Errorf("%w: %s channel", ErrSessionDead, c.name))
+	}
+}
+
+// await blocks for the reply to p, honouring the peer's request for more time.
+//
+// Wait is the reason this is a loop rather than a single select. A server that
+// needs longer than the deadline says so, and the deadline restarts. The
+// vendor library answers Nack to Wait and never implements the extension,
+// which abandons the operation and leaves the peer's session behind.
+func (c *channel) await(ctx context.Context, p *pending) (codec.Frame, error) {
+	// A stoppable timer rather than After, because a Wait replaces the
+	// deadline and an abandoned After keeps its timer armed until it fires.
+	// One per extension on a busy link is a leak that grows with traffic.
+	timer := c.clk.NewTicker(c.timeout)
+	defer func() { timer.Stop() }()
+
+	for {
+		select {
+		case <-ctx.Done():
+			c.release(false)
+			return codec.Frame{}, ctx.Err()
+
+		case <-timer.C():
+			c.release(false)
+			return codec.Frame{}, fmt.Errorf("%w: %s after %s", ErrTimeout, p.req, c.timeout)
+
+		case f, ok := <-p.frames:
+			if !ok {
+				c.release(false)
+				return codec.Frame{}, c.closedErr()
+			}
+			if f.Type == codec.MsgWait {
+				timer.Stop()
+				timer = c.clk.NewTicker(waitDuration(f, c.timeout))
+				continue
+			}
+			c.release(true)
+			return f, nil
+		}
+	}
+}
+
+// waitDuration reads how much longer the peer asked for.
+//
+// A Wait carrying no time, or one whose payload will not decode, still means
+// "I am working on it", so the deadline restarts at the normal timeout rather
+// than the message being discarded.
+func waitDuration(f codec.Frame, fallback time.Duration) time.Duration {
+	if w, err := codec.DecodeWait(f.Payload); err == nil && w.Seconds > 0 {
+		return time.Duration(w.Seconds) * time.Second
+	}
+	return fallback
+}
+
+// deliver hands a frame to whatever is in flight, and reports whether anything
+// was waiting for it.
+//
+// It never blocks. A full buffer means the peer sent more replies than it was
+// asked for, which is the peer's fault and must not stall the link's read
+// loop.
+func (c *channel) deliver(f codec.Frame) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.closed || c.inFlight == nil {
+		return false
+	}
+	select {
+	case c.inFlight.frames <- f:
+		return true
+	default:
+		return false
+	}
+}
+
+// busy reports whether a message is in flight.
+func (c *channel) busy() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.inFlight != nil
+}
+
+// closeWith shuts the channel down, waking anything waiting on it.
+//
+// err says why, and must not be nil: it is what every later caller is given,
+// and "closed for no reason" is not something a caller can act on.
+func (c *channel) closeWith(err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.closed {
+		return
+	}
+	c.closed = true
+	c.err = err
+	if c.inFlight != nil {
+		close(c.inFlight.frames)
+	}
+	// Wake one waiter, which will wake the next in turn.
+	select {
+	case c.free <- struct{}{}:
+	default:
+	}
+}
+
+func (c *channel) closedErr() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.err
+}

--- a/internal/snell-rollcall/session/channel_test.go
+++ b/internal/snell-rollcall/session/channel_test.go
@@ -1,0 +1,485 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"dhs/internal/clock"
+	"dhs/internal/snell-rollcall/codec"
+)
+
+// TestOneMessageInFlight is the rule the whole protocol rests on: a request
+// occupies the channel until it is answered, and nothing else may be sent
+// meanwhile (spec 4).
+//
+// A peer matches replies head-of-queue, so two requests on the wire at once do
+// not merely arrive out of order, they are answered to the wrong caller.
+func TestOneMessageInFlight(t *testing.T) {
+	h := newHarness(t, Config{})
+	s := h.callSession(t, codec.SvcControl)
+
+	firstDone := make(chan codec.Frame, 1)
+	go func() {
+		f, err := s.Do(context.Background(), codec.MsgGetFStat, []byte{0, 1})
+		if err != nil {
+			t.Errorf("first request: %v", err)
+		}
+		firstDone <- f
+	}()
+	first := h.peer.recvType(codec.MsgGetFStat)
+
+	// A second request must not reach the wire while the first is unanswered.
+	secondDone := make(chan codec.Frame, 1)
+	go func() {
+		f, err := s.Do(context.Background(), codec.MsgGetID, nil)
+		if err != nil {
+			t.Errorf("second request: %v", err)
+		}
+		secondDone <- f
+	}()
+	h.peer.quiet()
+
+	select {
+	case <-secondDone:
+		t.Fatal("the second request completed while the first was in flight")
+	default:
+	}
+
+	// Answering the first releases the slot, and only then does the second go
+	// out.
+	h.peer.send(first, codec.MsgRetFStat, nil)
+	if f := <-firstDone; f.Type != codec.MsgRetFStat {
+		t.Errorf("first reply = %s", f.Type)
+	}
+
+	second := h.peer.recvType(codec.MsgGetID)
+	h.peer.send(second, codec.MsgRetID, nil)
+	if f := <-secondDone; f.Type != codec.MsgRetID {
+		t.Errorf("second reply = %s", f.Type)
+	}
+}
+
+// TestReplyTimeout covers the three-second active-message deadline, driven by
+// advancing the clock rather than by waiting.
+func TestReplyTimeout(t *testing.T) {
+	h := newHarness(t, Config{ReplyTimeout: 3 * time.Second})
+	s := h.callSession(t, codec.SvcControl)
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := s.Do(context.Background(), codec.MsgGetStat, nil)
+		errCh <- err
+	}()
+	h.peer.recvType(codec.MsgGetStat) // deliberately unanswered
+
+	h.fire(t, 1, 3*time.Second)
+
+	err := <-errCh
+	if !errors.Is(err, ErrTimeout) {
+		t.Fatalf("err = %v, want ErrTimeout", err)
+	}
+	// The message that timed out is named, because "timeout" alone in a log
+	// says nothing about what was lost.
+	if got := err.Error(); !contains(got, "GETSTAT") {
+		t.Errorf("err = %q, want it to name the request", got)
+	}
+
+	// The slot is released, so the session is still usable.
+	go func() { _, _ = s.Do(context.Background(), codec.MsgGetID, nil) }()
+	h.peer.recvType(codec.MsgGetID)
+}
+
+// TestWaitExtendsTheDeadline covers the message the vendor library never
+// implements. A server that needs longer says so, and the deadline restarts.
+// Answering Wait with a Nack, as the vendor does, abandons the operation and
+// leaves the peer's session behind.
+func TestWaitExtendsTheDeadline(t *testing.T) {
+	h := newHarness(t, Config{ReplyTimeout: 3 * time.Second})
+	s := h.callSession(t, codec.SvcControl)
+
+	type result struct {
+		f   codec.Frame
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		f, err := s.Do(context.Background(), codec.MsgGetFunc, nil)
+		done <- result{f, err}
+	}()
+	req := h.peer.recvType(codec.MsgGetFunc)
+
+	// Two seconds in, the peer asks for thirty more.
+	h.fire(t, 1, 2*time.Second)
+
+	wait, err := codec.Wait{Seconds: 30}.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	h.peer.send(req, codec.MsgWait, wait)
+	h.barrier(t)
+
+	// The original deadline would have expired here. The extension means it
+	// does not.
+	h.fire(t, 1, 5*time.Second)
+
+	select {
+	case r := <-done:
+		t.Fatalf("the request ended early: %+v", r)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	h.peer.send(req, codec.MsgRetFunc, nil)
+	r := <-done
+	if r.err != nil {
+		t.Fatalf("Do: %v", r.err)
+	}
+	if r.f.Type != codec.MsgRetFunc {
+		t.Errorf("reply = %s, want RETFUNC", r.f.Type)
+	}
+}
+
+// TestWaitWithoutATimeRestartsTheDefault covers a peer that sends Wait with no
+// duration, or one whose payload will not decode. It still means "I am working
+// on it", so the deadline restarts rather than the message being discarded.
+func TestWaitWithoutATimeRestartsTheDefault(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload []byte
+	}{
+		{"zero seconds", mustWait(t, 0)},
+		{"truncated payload", []byte{0x00}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHarness(t, Config{ReplyTimeout: 3 * time.Second})
+			s := h.callSession(t, codec.SvcControl)
+
+			errCh := make(chan error, 1)
+			go func() {
+				_, err := s.Do(context.Background(), codec.MsgGetStat, nil)
+				errCh <- err
+			}()
+			req := h.peer.recvType(codec.MsgGetStat)
+
+			h.fire(t, 1, 2*time.Second)
+			h.peer.send(req, codec.MsgWait, tc.payload)
+			h.barrier(t)
+
+			// The deadline restarted, so two more seconds is not enough.
+			h.fire(t, 1, 2*time.Second)
+			select {
+			case err := <-errCh:
+				t.Fatalf("the deadline did not restart: %v", err)
+			case <-time.After(50 * time.Millisecond):
+			}
+
+			// A further three seconds does expire it.
+			h.fire(t, 1, 3*time.Second)
+			if err := <-errCh; !errors.Is(err, ErrTimeout) {
+				t.Errorf("err = %v, want ErrTimeout", err)
+			}
+		})
+	}
+}
+
+func mustWait(t *testing.T, secs uint16) []byte {
+	t.Helper()
+	b, err := codec.Wait{Seconds: secs}.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	return b
+}
+
+// TestStrikesEndTheSession pins the five-failure rule. The vendor then drops
+// the session without sending Term, which is how units run out of sessions;
+// this reports it so the caller can reconnect deliberately.
+func TestStrikesEndTheSession(t *testing.T) {
+	h := newHarness(t, Config{ReplyTimeout: time.Second, MaxStrikes: 3})
+	s := h.callSession(t, codec.SvcControl)
+
+	for i := range 3 {
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := s.Do(context.Background(), codec.MsgGetStat, nil)
+			errCh <- err
+		}()
+		h.peer.recvType(codec.MsgGetStat)
+		h.fire(t, 1, time.Second)
+
+		err := <-errCh
+		if !errors.Is(err, ErrTimeout) {
+			t.Fatalf("attempt %d: err = %v, want ErrTimeout", i+1, err)
+		}
+	}
+
+	// The third failure reached the limit, so the channel is finished.
+	_, err := s.Do(context.Background(), codec.MsgGetStat, nil)
+	if !errors.Is(err, ErrSessionDead) {
+		t.Fatalf("err = %v, want ErrSessionDead", err)
+	}
+	h.peer.quiet()
+}
+
+// TestStrikesResetOnSuccess covers the "consecutive" in consecutive failures.
+// A session that fails once an hour and works in between is healthy, and
+// counting failures without resetting would kill it after five hours.
+func TestStrikesResetOnSuccess(t *testing.T) {
+	h := newHarness(t, Config{ReplyTimeout: time.Second, MaxStrikes: 2})
+	s := h.callSession(t, codec.SvcControl)
+
+	// One failure.
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := s.Do(context.Background(), codec.MsgGetStat, nil)
+		errCh <- err
+	}()
+	h.peer.recvType(codec.MsgGetStat)
+	h.fire(t, 1, time.Second)
+	if err := <-errCh; !errors.Is(err, ErrTimeout) {
+		t.Fatalf("err = %v", err)
+	}
+
+	// Then a success, which clears the count.
+	go func() { _, _ = s.Do(context.Background(), codec.MsgGetID, nil) }()
+	req := h.peer.recvType(codec.MsgGetID)
+	h.peer.send(req, codec.MsgRetID, nil)
+
+	// One more failure must not be the second strike.
+	go func() {
+		_, err := s.Do(context.Background(), codec.MsgGetStat, nil)
+		errCh <- err
+	}()
+	h.peer.recvType(codec.MsgGetStat)
+	h.fire(t, 1, time.Second)
+	if err := <-errCh; !errors.Is(err, ErrTimeout) {
+		t.Fatalf("err = %v", err)
+	}
+
+	// Still alive.
+	go func() { _, _ = s.Do(context.Background(), codec.MsgGetID, nil) }()
+	h.peer.recvType(codec.MsgGetID)
+}
+
+// TestCancellationReleasesTheSlot covers a caller giving up. The slot has to
+// come back, or the session is wedged for every later request.
+func TestCancellationReleasesTheSlot(t *testing.T) {
+	h := newHarness(t, Config{})
+	s := h.callSession(t, codec.SvcControl)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := s.Do(ctx, codec.MsgGetStat, nil)
+		errCh <- err
+	}()
+	h.peer.recvType(codec.MsgGetStat)
+
+	cancel()
+	if err := <-errCh; !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+
+	go func() { _, _ = s.Do(context.Background(), codec.MsgGetID, nil) }()
+	h.peer.recvType(codec.MsgGetID)
+}
+
+// TestCancellationWhileQueued covers a caller giving up before it ever reaches
+// the wire, which is the common case when a burst is cancelled.
+func TestCancellationWhileQueued(t *testing.T) {
+	h := newHarness(t, Config{})
+	s := h.callSession(t, codec.SvcControl)
+
+	go func() { _, _ = s.Do(context.Background(), codec.MsgGetFStat, []byte{0, 1}) }()
+	h.peer.recvType(codec.MsgGetFStat)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := s.Do(ctx, codec.MsgGetID, nil)
+		errCh <- err
+	}()
+
+	// It is queued behind the first request, so nothing is on the wire.
+	h.peer.quiet()
+	cancel()
+
+	if err := <-errCh; !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	h.peer.quiet()
+}
+
+// TestUnexpectedRepliesDoNotStall covers a peer sending more replies than it
+// was asked for. They must not block the read loop, because that would stop
+// every other session on the link.
+func TestUnexpectedRepliesDoNotStall(t *testing.T) {
+	h := newHarness(t, Config{})
+	s := h.callSession(t, codec.SvcControl)
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = s.Do(context.Background(), codec.MsgGetStat, nil)
+		close(done)
+	}()
+	req := h.peer.recvType(codec.MsgGetStat)
+
+	// Ten replies to one request. The first completes it; the rest have
+	// nowhere to go and must be dropped rather than block anything.
+	for range 10 {
+		h.peer.send(req, codec.MsgRetStat, make([]byte, 4))
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the request never completed")
+	}
+
+	// The link is still working.
+	go func() { _, _ = s.Do(context.Background(), codec.MsgGetID, nil) }()
+	h.peer.recvType(codec.MsgGetID)
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+// TestChannel_Closed covers the shutdown handshake directly, because the
+// interesting part is what happens to callers already waiting for the slot.
+//
+// The token is passed on rather than the channel closed, so each waiter in
+// turn wakes, learns the reason, and hands the token to the next. Nobody is
+// left blocked and nobody sees a different error from anybody else.
+func TestChannel_Closed(t *testing.T) {
+	clk := clock.NewFake(time.Time{})
+	c := newChannel("test", clk, time.Second, 5)
+
+	// One caller holds the slot.
+	held, err := c.acquire(context.Background(), codec.MsgGetStat)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	if !c.busy() {
+		t.Error("the channel should report itself busy")
+	}
+
+	// Two more queue behind it.
+	waiting := make(chan error, 2)
+	for range 2 {
+		go func() {
+			_, err := c.acquire(context.Background(), codec.MsgGetID)
+			waiting <- err
+		}()
+	}
+
+	boom := errors.New("link went away")
+	c.closeWith(boom)
+
+	for i := range 2 {
+		select {
+		case err := <-waiting:
+			if !errors.Is(err, boom) {
+				t.Errorf("waiter %d got %v, want the close reason", i, err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("waiter %d was left blocked after the channel closed", i)
+		}
+	}
+
+	// The caller that held the slot is woken through its frame buffer.
+	if _, err := c.await(context.Background(), held); !errors.Is(err, boom) {
+		t.Errorf("the holder got %v, want the close reason", err)
+	}
+
+	// A caller arriving afterwards gets the same answer rather than blocking.
+	if _, err := c.acquire(context.Background(), codec.MsgGetID); !errors.Is(err, boom) {
+		t.Errorf("a late caller got %v, want the close reason", err)
+	}
+
+	// Closing twice keeps the first reason: it is the one that explains what
+	// happened, and the second is a consequence of it.
+	c.closeWith(errors.New("something else"))
+	if !errors.Is(c.closedErr(), boom) {
+		t.Errorf("the reason changed to %v", c.closedErr())
+	}
+}
+
+// TestChannel_DeliverRefusesAFullBuffer covers a peer sending more than it was
+// asked for. The buffer is bounded, and a full one must be refused rather than
+// block: the caller is the link's read loop, and stalling it would stop every
+// session on the link.
+func TestChannel_DeliverRefusesAFullBuffer(t *testing.T) {
+	clk := clock.NewFake(time.Time{})
+	c := newChannel("test", clk, time.Second, 5)
+
+	if c.deliver(codec.Frame{Type: codec.MsgAck}) {
+		t.Error("an idle channel has nothing to deliver to")
+	}
+
+	if _, err := c.acquire(context.Background(), codec.MsgGetStat); err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+
+	// Nothing is reading, so the buffer fills.
+	n := 0
+	for c.deliver(codec.Frame{Type: codec.MsgWait}) {
+		n++
+		if n > 100 {
+			t.Fatal("the buffer is unbounded")
+		}
+	}
+	if n == 0 {
+		t.Fatal("nothing could be delivered at all")
+	}
+	t.Logf("buffered %d frames before refusing", n)
+
+	// And a closed channel accepts nothing.
+	c.closeWith(errors.New("done"))
+	if c.deliver(codec.Frame{Type: codec.MsgAck}) {
+		t.Error("a closed channel accepted a delivery")
+	}
+}
+
+// TestWaitDuration covers the extension the peer asks for, and the two ways it
+// can decline to say: a zero time, and a payload that will not decode. Both
+// still mean "I am working on it".
+func TestWaitDuration(t *testing.T) {
+	const fallback = 3 * time.Second
+
+	thirty, err := codec.Wait{Seconds: 30}.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	one, err := codec.Wait{Seconds: 1}.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		in   []byte
+		want time.Duration
+	}{
+		{"thirty seconds", thirty, 30 * time.Second},
+		{"one second", one, time.Second},
+		{"zero seconds", mustWait(t, 0), fallback},
+		{"truncated", []byte{0x00}, fallback},
+		{"empty", nil, fallback},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := waitDuration(codec.Frame{Type: codec.MsgWait, Payload: tc.in}, fallback)
+			if got != tc.want {
+				t.Errorf("= %s, want %s", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/snell-rollcall/session/config.go
+++ b/internal/snell-rollcall/session/config.go
@@ -1,0 +1,122 @@
+package session
+
+import "time"
+
+// Protocol timers.
+//
+// The values come from the vendor library and were checked against the live
+// stack during the audit; the reasoning for each is in
+// internal/snell-rollcall/docs/audit-2026-09-07.md §3.5.
+const (
+	// DefaultReplyTimeout bounds one active message. The specification sets
+	// three seconds, and a server that needs longer says so with Wait rather
+	// than staying silent.
+	DefaultReplyTimeout = 3 * time.Second
+
+	// DefaultMaxStrikes is how many consecutive failures end a session. The
+	// vendor uses five and then drops the session without sending Term,
+	// which is how units run out of sessions; we send it.
+	DefaultMaxStrikes = 5
+
+	// DefaultKeepaliveInterval is how long a link may sit idle before it is
+	// probed. Fifteen seconds matches RollProxy's own KeepAliveInterval and
+	// stays well inside the sixty-second map expiry, so we are never aged
+	// out of a peer's device map while still connected.
+	DefaultKeepaliveInterval = 15 * time.Second
+
+	// DefaultMaxKeepaliveMisses is how many probes may go unanswered before
+	// the link is considered dead.
+	DefaultMaxKeepaliveMisses = 3
+
+	// DefaultIamInterval is the announcement period. The specification asks
+	// for 12.5 to 17.5 seconds, and the vendor spreads units within that
+	// window by adding twenty milliseconds per unit address so a large frame
+	// does not announce every module in the same instant.
+	DefaultIamInterval = 12500 * time.Millisecond
+
+	// IamSpreadPerUnit is that per-unit offset.
+	IamSpreadPerUnit = 20 * time.Millisecond
+
+	// DefaultPushQueue is how many back-channel pushes may be held for a
+	// slow reader before the link stops acknowledging them. Acknowledgement
+	// is what asks for the next push, so holding it is the flow control the
+	// protocol gives us.
+	DefaultPushQueue = 64
+)
+
+// Config tunes a Link. The zero value is usable: every field falls back to
+// the constant above it.
+type Config struct {
+	// ReplyTimeout bounds one active message.
+	ReplyTimeout time.Duration
+
+	// MaxStrikes is how many consecutive failures end a session.
+	MaxStrikes int
+
+	// KeepaliveInterval is how long the link may be idle before it is
+	// probed. Negative disables probing, which is only appropriate for a
+	// link whose peer is known to push continuously.
+	KeepaliveInterval time.Duration
+
+	// MaxKeepaliveMisses is how many unanswered probes end the link.
+	MaxKeepaliveMisses int
+
+	// PushQueue is the depth of the back-channel delivery queue.
+	PushQueue int
+
+	// Local is our own address on this link.
+	//
+	// A TCP client leaves the net, unit and port zero and lets the gateway
+	// stamp them, which is what the vendor's IPShare client does; the
+	// address it assigns is learned from the first reply and filled in here.
+	// A provider sets its own address, because it is the one doing the
+	// stamping.
+	Local Address
+}
+
+// Address mirrors codec.Address without importing it into a configuration
+// struct a caller has to fill in by hand.
+type Address struct {
+	Net  uint16
+	Unit uint8
+	Port uint8
+}
+
+func (c Config) replyTimeout() time.Duration {
+	if c.ReplyTimeout > 0 {
+		return c.ReplyTimeout
+	}
+	return DefaultReplyTimeout
+}
+
+func (c Config) maxStrikes() int {
+	if c.MaxStrikes > 0 {
+		return c.MaxStrikes
+	}
+	return DefaultMaxStrikes
+}
+
+func (c Config) keepaliveInterval() time.Duration {
+	switch {
+	case c.KeepaliveInterval > 0:
+		return c.KeepaliveInterval
+	case c.KeepaliveInterval < 0:
+		return 0 // explicitly disabled
+	default:
+		return DefaultKeepaliveInterval
+	}
+}
+
+func (c Config) maxKeepaliveMisses() int {
+	if c.MaxKeepaliveMisses > 0 {
+		return c.MaxKeepaliveMisses
+	}
+	return DefaultMaxKeepaliveMisses
+}
+
+func (c Config) pushQueue() int {
+	if c.PushQueue > 0 {
+		return c.PushQueue
+	}
+	return DefaultPushQueue
+}

--- a/internal/snell-rollcall/session/doc.go
+++ b/internal/snell-rollcall/session/doc.go
@@ -1,0 +1,46 @@
+// Package session is the RollCall protocol state machine.
+//
+// It sits below consumer and provider because it is the same machine on both
+// sides with the roles exchanged: a link carrying frames, sessions multiplexed
+// over it by index, one message in flight per channel, and a back channel
+// whose pushes are themselves requests. The vendor's own Core/ directory is
+// organised the same way for the same reason.
+//
+// It is transport-agnostic. A Link is handed a net.Conn and never opens one,
+// so a test drives it over net.Pipe with no socket, no port and no listener.
+// Time comes from an injected clock, so every timeout, probe and backoff in
+// here is exercised by advancing a fake rather than by sleeping.
+//
+// # The active-message rule
+//
+// The rule that shapes everything else: one message may be in flight per
+// channel per session, and the next may not be sent until the current one is
+// answered (spec 4). Every request therefore queues, including the keepalive
+// probe. Sending a probe beside a pending request is not a shortcut, it is a
+// correctness bug — replies are matched head-of-queue, so the probe's ACK
+// would be handed to whatever was waiting.
+//
+// A reply is expected within three seconds. A server that needs longer sends
+// Wait, which extends the deadline. The vendor library never implements that
+// and answers Nack instead, so a server asking for more time is abandoned
+// mid-operation and its session leaks; we honour it.
+//
+// After five consecutive failures a session is dead. The vendor then drops it
+// without sending Term, which is how units run out of sessions and why the
+// library's own comments warn about it. This package always sends Term: on
+// close, on error and on context cancellation.
+//
+// # Address rewriting
+//
+// A client on TCP does not know its own RollCall address, and says so by
+// sending a zeroed source. The gateway stamps its own unit and a port drawn
+// from its connection slots, and reverses that on the way back. This is
+// library behaviour rather than anything in the specification, and a peer that
+// skips it is rejected by real gateways and by the Control Panel.
+//
+// # What is not here
+//
+// The verbs. This package will hand you a session you can send a request on
+// and receive a push from; deciding which requests to send is the consumer's
+// job, and answering them is the provider's.
+package session

--- a/internal/snell-rollcall/session/errors.go
+++ b/internal/snell-rollcall/session/errors.go
@@ -1,0 +1,124 @@
+package session
+
+import (
+	"errors"
+	"fmt"
+
+	"dhs/internal/snell-rollcall/codec"
+)
+
+// Sentinel errors. Call sites use errors.Is and errors.As, never string
+// matching (root CLAUDE.md).
+var (
+	// ErrLinkClosed means the link is no longer usable. It is returned to
+	// everything still waiting when a link shuts down, so a caller blocked on
+	// a request learns immediately rather than at its own timeout.
+	ErrLinkClosed = errors.New("rollcall: link closed")
+
+	// ErrSessionClosed means the session was terminated. The link may still
+	// be fine and other sessions on it unaffected.
+	ErrSessionClosed = errors.New("rollcall: session closed")
+
+	// ErrTimeout means a reply did not arrive within the active-message
+	// deadline, including any extension the peer asked for with Wait.
+	ErrTimeout = errors.New("rollcall: reply timeout")
+
+	// ErrSessionDead means the session exceeded its strike count. Nothing
+	// further may be sent on it; the caller reconnects.
+	ErrSessionDead = errors.New("rollcall: session failed too many times")
+
+	// ErrLinkDead means the link's keepalive went unanswered often enough
+	// that the peer is assumed gone.
+	ErrLinkDead = errors.New("rollcall: link is not answering")
+
+	// ErrBusy means the peer refused a Call because it has no session left.
+	// It is worth retrying; a Nack is not.
+	ErrBusy = errors.New("rollcall: peer is busy")
+
+	// ErrRefused means the peer refused a Call outright. Services are
+	// all-or-nothing, so the usual cause is asking for a service bit the
+	// peer does not provide.
+	ErrRefused = errors.New("rollcall: call refused")
+
+	// ErrInvalidSession means the peer did not recognise the session index we
+	// used. During the audit this was produced by sending our own index where
+	// the peer's belonged, which silently lost every push.
+	ErrInvalidSession = errors.New("rollcall: peer rejected the session index")
+
+	// ErrNotUnderstood means the peer does not implement the message type,
+	// which is different from refusing to act on it.
+	ErrNotUnderstood = errors.New("rollcall: peer does not implement this message")
+
+	// ErrUnexpectedReply means a reply arrived whose type cannot answer the
+	// request that was in flight.
+	ErrUnexpectedReply = errors.New("rollcall: unexpected reply type")
+)
+
+// ProtocolError is a refusal the peer sent us, carrying the frame it came in
+// so a caller can inspect the payload rather than guess.
+type ProtocolError struct {
+	// Op names what was being attempted, e.g. "call" or "get".
+	Op string
+
+	// Type is the message the peer answered with.
+	Type codec.PacketType
+
+	// Detail is any text the peer supplied. Nack and Busy may carry one.
+	Detail string
+
+	// Err is the sentinel this maps to.
+	Err error
+}
+
+func (e *ProtocolError) Error() string {
+	s := fmt.Sprintf("rollcall: %s: %s", e.Op, e.Type)
+	if e.Detail != "" {
+		s += fmt.Sprintf(" (%s)", e.Detail)
+	}
+	return s
+}
+
+func (e *ProtocolError) Unwrap() error { return e.Err }
+
+// protocolError maps a refusal message to its sentinel.
+//
+// The distinction that matters is between Nack and InvCmd: Nack means the peer
+// understood and will not, InvCmd means it did not understand at all
+// (spec 9.15). A client that treats them alike either retries something that
+// can never work, or gives up on a peer that simply wanted a different
+// message.
+func protocolError(op string, f codec.Frame) error {
+	e := &ProtocolError{Op: op, Type: f.Type}
+	switch f.Type {
+	case codec.MsgBusy:
+		e.Err = ErrBusy
+	case codec.MsgNack:
+		e.Err = ErrRefused
+	case codec.MsgInvCmd:
+		e.Err = ErrNotUnderstood
+	case codec.MsgInvSess:
+		e.Err = ErrInvalidSession
+	default:
+		e.Err = ErrUnexpectedReply
+	}
+	e.Detail = refusalText(f)
+	return e
+}
+
+// refusalText reads the optional text a refusal may carry. Nack and Ack may
+// carry a string, and Busy may carry an ID_STR naming who holds the session;
+// none is required, and the frame is well formed without one.
+func refusalText(f codec.Frame) string {
+	switch f.Type {
+	case codec.MsgBusy:
+		if id, err := codec.DecodeID(f.Payload); err == nil {
+			return id.Name
+		}
+	case codec.MsgNack, codec.MsgAck:
+		if len(f.Payload) > 0 {
+			s, _ := codec.CString(f.Payload)
+			return s
+		}
+	}
+	return ""
+}

--- a/internal/snell-rollcall/session/errors_test.go
+++ b/internal/snell-rollcall/session/errors_test.go
@@ -1,0 +1,314 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"dhs/internal/snell-rollcall/codec"
+)
+
+// TestProtocolError_Message covers both forms. A refusal that names a reason
+// must show it, because "call refused" alone gives an operator nothing to act
+// on; one that carries no text must not print an empty pair of brackets.
+func TestProtocolError_Message(t *testing.T) {
+	tests := []struct {
+		name string
+		err  *ProtocolError
+		want string
+	}{
+		{
+			"with a reason",
+			&ProtocolError{Op: "call", Type: codec.MsgNack, Detail: "no long strings", Err: ErrRefused},
+			"rollcall: call: NACK (no long strings)",
+		},
+		{
+			"without one",
+			&ProtocolError{Op: "GETSTAT", Type: codec.MsgInvSess, Err: ErrInvalidSession},
+			"rollcall: GETSTAT: INVSESS",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.err.Error(); got != tc.want {
+				t.Errorf("Error() = %q, want %q", got, tc.want)
+			}
+			if !errors.Is(tc.err, tc.err.Err) {
+				t.Error("Unwrap must expose the sentinel")
+			}
+		})
+	}
+}
+
+// TestProtocolError_Mapping pins which refusal means what. Nack and InvCmd are
+// the pair that matters: one means the peer understood and will not, the other
+// that it did not understand at all, and a client that conflates them either
+// retries something impossible or abandons a peer that wanted a different
+// message.
+func TestProtocolError_Mapping(t *testing.T) {
+	tests := []struct {
+		reply codec.PacketType
+		want  error
+	}{
+		{codec.MsgNack, ErrRefused},
+		{codec.MsgBusy, ErrBusy},
+		{codec.MsgInvCmd, ErrNotUnderstood},
+		{codec.MsgInvSess, ErrInvalidSession},
+		{codec.MsgRetStat, ErrUnexpectedReply},
+	}
+	for _, tc := range tests {
+		err := protocolError("op", codec.Frame{Type: tc.reply})
+		if !errors.Is(err, tc.want) {
+			t.Errorf("%s mapped to %v, want %v", tc.reply, err, tc.want)
+		}
+	}
+}
+
+// TestRefusalText covers the optional text a refusal may carry. None of it is
+// required, and a frame is well formed without it, so a missing or malformed
+// payload must not turn a refusal into a decode failure.
+func TestRefusalText(t *testing.T) {
+	id, err := codec.ID{Name: "Control Panel"}.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		in   codec.Frame
+		want string
+	}{
+		{"busy names the holder", codec.Frame{Type: codec.MsgBusy, Payload: id}, "Control Panel"},
+		{"busy with no payload", codec.Frame{Type: codec.MsgBusy}, ""},
+		{"busy with a short payload", codec.Frame{Type: codec.MsgBusy, Payload: []byte{1, 2}}, ""},
+		{"nack with a reason", codec.Frame{Type: codec.MsgNack, Payload: []byte("bad\x00")}, "bad"},
+		{"nack with none", codec.Frame{Type: codec.MsgNack}, ""},
+		{"ack with a note", codec.Frame{Type: codec.MsgAck, Payload: []byte("ok\x00")}, "ok"},
+		{"a type that carries no text", codec.Frame{Type: codec.MsgInvCmd, Payload: []byte("x\x00")}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := refusalText(tc.in); got != tc.want {
+				t.Errorf("= %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCall_UnencodableIdentity covers a caller whose own identity will not fit
+// the wire. It fails before anything is sent and before a session index is
+// taken, so a bad configuration does not consume a slot on the peer.
+func TestCall_UnencodableIdentity(t *testing.T) {
+	h := newHarness(t, Config{})
+
+	bad := ClientIdentity("x", codec.SvcMenus)
+	bad.ID.Name = strings.Repeat("n", codec.MaxTextSize)
+
+	_, err := Call(context.Background(), h.link, peerAddr, codec.SvcMenus, codec.LevelUser, bad)
+	if !errors.Is(err, codec.ErrStringTooLong) {
+		t.Fatalf("err = %v, want ErrStringTooLong", err)
+	}
+	h.peer.quiet()
+	if n := h.link.SessionCount(); n != 0 {
+		t.Errorf("%d sessions registered after a failed call", n)
+	}
+}
+
+// TestLink_IndexExhaustion covers a link asked for more sessions than the
+// index space holds. Indices are a single byte with three values reserved, so
+// this is reachable on a busy gateway and must be reported rather than
+// returning a duplicate.
+func TestLink_IndexExhaustion(t *testing.T) {
+	h := newHarness(t, Config{})
+
+	var held []*Session
+	for {
+		s := bareSession(h.link)
+		if err := h.link.register(s); err != nil {
+			if !strings.Contains(err.Error(), "no free session index") {
+				t.Fatalf("err = %v, want the exhaustion message", err)
+			}
+			break
+		}
+		held = append(held, s)
+		if len(held) > 300 {
+			t.Fatal("the index space should have run out by now")
+		}
+	}
+
+	// The space is one byte with zero, 0xFE and 0xFF reserved.
+	if len(held) != 0xFD {
+		t.Errorf("held %d sessions before exhaustion, want %d", len(held), 0xFD)
+	}
+
+	// Freeing one makes room again.
+	h.link.removeSession(held[0].localIndex)
+	if err := h.link.register(bareSession(h.link)); err != nil {
+		t.Errorf("register after freeing an index: %v", err)
+	}
+}
+
+// TestExchange_SendFailureReleasesTheSlot covers the socket dying between
+// taking the one-in-flight slot and writing. The slot has to come back, or
+// every later request on that channel blocks for ever behind a message that
+// was never sent.
+func TestExchange_SendFailureReleasesTheSlot(t *testing.T) {
+	h := newHarness(t, Config{})
+	s := h.callSession(t, codec.SvcControl)
+
+	h.peer.close()
+
+	// Give the link a moment to notice, then confirm the failure surfaces
+	// rather than hanging on the reply deadline.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		_, err := s.Do(context.Background(), codec.MsgGetStat, nil)
+		if err != nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("a request on a dead link should fail")
+		}
+	}
+
+	// The channel is not wedged: a second attempt fails the same way rather
+	// than blocking.
+	done := make(chan error, 1)
+	go func() {
+		_, err := s.Do(context.Background(), codec.MsgGetID, nil)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("the second request should have failed too")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the slot was never released, so the channel is wedged")
+	}
+}
+
+// TestHandshake_GatewayThatDoesNotStamp covers a peer that leaves our address
+// alone, which is what a direct connection to a unit does. There is nothing to
+// learn, and nothing must be invented.
+func TestHandshake_GatewayThatDoesNotStamp(t *testing.T) {
+	h := newHarness(t, Config{})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := h.link.Handshake(context.Background())
+		done <- err
+	}()
+	h.peer.recvType(codec.MsgGetDevInfo)
+
+	info, err := codec.DeviceInfo{Address: peerAddr}.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	// The reply comes back addressed to the zeros we sent.
+	h.peer.write(codec.Frame{
+		Dst:     codec.Address{Index: codec.IndexUnknown},
+		Src:     peerAddr,
+		Type:    codec.MsgRetDevInfo,
+		Payload: info,
+	})
+
+	if err := <-done; err != nil {
+		t.Fatalf("Handshake: %v", err)
+	}
+	if got := h.link.LocalAddress(); got.Unit != 0 || got.Port != 0 {
+		t.Errorf("local address = %s, want it left as zeros", got)
+	}
+	if got := h.link.RemoteAddress(); got.Unit != peerAddr.Unit {
+		t.Errorf("remote address = %s, want the peer's", got)
+	}
+}
+
+// TestCall_GatewayStampsOnTheAcknowledgement covers learning our address from
+// the Call rather than the handshake, which is what happens when a caller
+// opens a session without probing first.
+func TestCall_GatewayStampsOnTheAcknowledgement(t *testing.T) {
+	h := newHarness(t, Config{})
+
+	type result struct {
+		s   *Session
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		s, err := Call(context.Background(), h.link, peerAddr, codec.SvcMenus,
+			codec.LevelUser, ClientIdentity("dhs", codec.SvcMenus))
+		done <- result{s, err}
+	}()
+
+	req := h.peer.recvType(codec.MsgCall)
+	if req.Src.Unit != 0 {
+		t.Errorf("the call's source unit = %02X, want zero for a client", req.Src.Unit)
+	}
+
+	h.peer.write(codec.Frame{
+		Dst:  codec.Address{Unit: 0x08, Port: 0xE1, Index: req.Src.Index},
+		Src:  addrWithIndex(peerAddr, 0x31),
+		Type: codec.MsgAck,
+	})
+
+	r := <-done
+	if r.err != nil {
+		t.Fatalf("Call: %v", r.err)
+	}
+	if got := h.link.LocalAddress(); got.Unit != 0x08 || got.Port != 0xE1 {
+		t.Errorf("local address = %s, want the stamped 0000-08-E1", got)
+	}
+
+	// A second session must not overwrite the address we already learned.
+	h.callSession(t, codec.SvcControl)
+	if got := h.link.LocalAddress(); got.Port != 0xE1 {
+		t.Errorf("local address changed to %s on a second call", got)
+	}
+}
+
+// TestHandshake_Timeout covers a peer that accepts the connection and then
+// says nothing, which is what a wrong port looks like: the socket opens, and
+// nothing on the other side speaks RollCall.
+func TestHandshake_Timeout(t *testing.T) {
+	h := newHarness(t, Config{ReplyTimeout: 3 * time.Second})
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := h.link.Handshake(context.Background())
+		errCh <- err
+	}()
+	h.peer.recvType(codec.MsgGetDevInfo)
+
+	h.fire(t, 1, 3*time.Second)
+
+	if err := <-errCh; !errors.Is(err, ErrTimeout) {
+		t.Fatalf("err = %v, want ErrTimeout", err)
+	}
+}
+
+// TestCall_Timeout covers the same for opening a session, and checks the
+// index is given back. A call that times out must not leak a session slot,
+// because the peer never opened one.
+func TestCall_Timeout(t *testing.T) {
+	h := newHarness(t, Config{ReplyTimeout: 3 * time.Second})
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := Call(context.Background(), h.link, peerAddr, codec.SvcMenus,
+			codec.LevelUser, ClientIdentity("dhs", codec.SvcMenus))
+		errCh <- err
+	}()
+	h.peer.recvType(codec.MsgCall)
+
+	h.fire(t, 1, 3*time.Second)
+
+	if err := <-errCh; !errors.Is(err, ErrTimeout) {
+		t.Fatalf("err = %v, want ErrTimeout", err)
+	}
+	if n := h.link.SessionCount(); n != 0 {
+		t.Errorf("%d sessions left registered after a timed-out call", n)
+	}
+}

--- a/internal/snell-rollcall/session/harness_test.go
+++ b/internal/snell-rollcall/session/harness_test.go
@@ -1,0 +1,307 @@
+package session
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"dhs/internal/clock"
+	"dhs/internal/metrics"
+	"dhs/internal/plugin"
+	"dhs/internal/snell-rollcall/codec"
+)
+
+// Every test in this package runs over net.Pipe against a fake peer, with time
+// supplied by a fake clock. There is no socket, no port and no sleep anywhere:
+// a timeout is tested by advancing the clock, which makes the result the same
+// on a loaded Windows runner as on an idle laptop.
+
+// peerAddr is the device the fake peer presents as.
+var peerAddr = codec.Address{Unit: 0x20, Port: 0x00, Index: codec.IndexUnknown}
+
+// peer is the other end of the pipe: it reads frames into a channel and writes
+// whatever a test tells it to.
+type peer struct {
+	t    *testing.T
+	conn net.Conn
+
+	frames chan codec.Frame
+	done   chan struct{}
+	once   sync.Once
+}
+
+func newPeer(t *testing.T, conn net.Conn) *peer {
+	t.Helper()
+	p := &peer{
+		t:      t,
+		conn:   conn,
+		frames: make(chan codec.Frame, 64),
+		done:   make(chan struct{}),
+	}
+	go p.read()
+	return p
+}
+
+func (p *peer) read() {
+	r := codec.NewReader(p.conn)
+	for {
+		f, err := r.ReadFrame()
+		if err != nil {
+			close(p.frames)
+			return
+		}
+		// The payload aliases the reader's buffer, so it must be copied
+		// before being handed across a channel.
+		f.Payload = append([]byte(nil), f.Payload...)
+		select {
+		case p.frames <- f:
+		case <-p.done:
+			return
+		}
+	}
+}
+
+// recv returns the next frame the peer received, failing the test if none
+// arrives. The wait is a real one because it is bounded by the pipe rather
+// than by protocol time; nothing under test is waiting on it.
+func (p *peer) recv() codec.Frame {
+	p.t.Helper()
+	select {
+	case f, ok := <-p.frames:
+		if !ok {
+			p.t.Fatal("peer: connection closed while waiting for a frame")
+		}
+		return f
+	case <-time.After(2 * time.Second):
+		p.t.Fatal("peer: no frame arrived")
+		return codec.Frame{}
+	}
+}
+
+// recvType waits for a frame and requires it to be of the given type.
+func (p *peer) recvType(want codec.PacketType) codec.Frame {
+	p.t.Helper()
+	f := p.recv()
+	if f.Type != want {
+		p.t.Fatalf("peer received %s, want %s", f.Type, want)
+	}
+	return f
+}
+
+// quiet requires that nothing further arrived. Used to prove the
+// one-in-flight rule: a second request must not be on the wire while the
+// first is unanswered.
+func (p *peer) quiet() {
+	p.t.Helper()
+	select {
+	case f, ok := <-p.frames:
+		if ok {
+			p.t.Fatalf("peer received %s, but nothing should have been sent", f)
+		}
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+// send writes a frame back, addressed as a reply to req.
+func (p *peer) send(req codec.Frame, typ codec.PacketType, payload []byte) {
+	p.t.Helper()
+	p.sendFlags(req, typ, 0, payload)
+}
+
+func (p *peer) sendFlags(req codec.Frame, typ codec.PacketType, flags uint8, payload []byte) {
+	p.t.Helper()
+
+	// A reply swaps the addresses: what was our source becomes its
+	// destination, index included. That index is ours, which is how the link
+	// finds the session again.
+	f := codec.Frame{
+		Dst:     req.Src,
+		Src:     req.Dst,
+		Type:    typ,
+		Flags:   flags,
+		Payload: payload,
+	}
+	if f.Src.Unit == 0 {
+		f.Src = addrWithIndex(peerAddr, req.Dst.Index)
+	}
+	p.write(f)
+}
+
+// push sends an unsolicited back-channel message on a session.
+func (p *peer) push(s *Session, typ codec.PacketType, payload []byte) {
+	p.t.Helper()
+	p.write(codec.Frame{
+		Dst:     addrWithIndex(peerAddr, s.LocalIndex()),
+		Src:     addrWithIndex(peerAddr, s.RemoteIndex()),
+		Type:    typ,
+		Flags:   codec.FlagBackChannel,
+		Payload: payload,
+	})
+}
+
+func (p *peer) write(f codec.Frame) {
+	p.t.Helper()
+	b, err := f.Encode()
+	if err != nil {
+		p.t.Fatalf("peer: encode %s: %v", f.Type, err)
+	}
+	if _, err := p.conn.Write(b); err != nil && err != io.ErrClosedPipe {
+		p.t.Fatalf("peer: write: %v", err)
+	}
+}
+
+func (p *peer) close() {
+	p.once.Do(func() {
+		close(p.done)
+		_ = p.conn.Close()
+	})
+}
+
+// harness is a Link with a fake peer and a fake clock.
+type harness struct {
+	link *Link
+	peer *peer
+	clk  *clock.Fake
+	met  *metrics.Connector
+}
+
+func newHarness(t *testing.T, cfg Config) *harness {
+	t.Helper()
+
+	ours, theirs := net.Pipe()
+	clk := clock.NewFake(time.Time{})
+	met := metrics.NewConnector()
+
+	h := &harness{
+		peer: newPeer(t, theirs),
+		clk:  clk,
+		met:  met,
+	}
+	h.link = NewLink(ours, cfg, plugin.Deps{
+		Logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Clock:   clk,
+		Metrics: met,
+	})
+
+	t.Cleanup(func() {
+		_ = h.link.Close()
+		h.peer.close()
+	})
+	return h
+}
+
+// fire advances the fake clock once n timers are armed.
+//
+// Waiting for the timer to be armed is what makes this deterministic: the code
+// under test registers its deadline on its own goroutine, and advancing before
+// it does would fire nothing and the test would hang rather than fail.
+//
+// The count is exact rather than a minimum, which is only possible because
+// nothing in this package leaves a timer armed after it is finished with. That
+// is worth asserting: a leaked timer is the usual cost of using After in a
+// retry loop.
+func (h *harness) fire(t *testing.T, n int, d time.Duration) {
+	t.Helper()
+	h.armed(t, n)
+	h.clk.Advance(d)
+}
+
+// armed waits until exactly n timers are armed.
+func (h *harness) armed(t *testing.T, n int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for h.clk.Waiters() != n {
+		if time.Now().After(deadline) {
+			t.Fatalf("%d timers armed, want %d", h.clk.Waiters(), n)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// peerSessionIndex is the index the fake peer assigns to the next session it
+// accepts. It deliberately does not match the client's, because the two are
+// independent and a harness that made them equal would hide the mistake this
+// package exists to prevent.
+var peerSessionIndex int16 = 0x30
+
+// callSession opens a session against the fake peer, answering the Call.
+func (h *harness) callSession(t *testing.T, services codec.Service) *Session {
+	t.Helper()
+
+	type result struct {
+		s   *Session
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		s, err := Call(context.Background(), h.link, peerAddr, services,
+			codec.LevelSupervisor, ClientIdentity("test", services))
+		done <- result{s, err}
+	}()
+
+	req := h.peer.recvType(codec.MsgCall)
+
+	// A real device answers from its own session index, which is what the
+	// client must then address every later message to.
+	peerSessionIndex++
+	h.peer.write(codec.Frame{
+		Dst:  req.Src,
+		Src:  addrWithIndex(peerAddr, peerSessionIndex),
+		Type: codec.MsgAck,
+	})
+
+	r := <-done
+	if r.err != nil {
+		t.Fatalf("Call: %v", r.err)
+	}
+	return r.s
+}
+
+// barrier waits until everything the peer has written so far has been
+// dispatched.
+//
+// The link's read loop is sequential, so a frame that reaches the unsolicited
+// channel proves every frame written before it has already been handled. It is
+// addressed to no session and is a request rather than a reply, so it can
+// never be mistaken for the answer to something in flight.
+func (h *harness) barrier(t *testing.T) {
+	t.Helper()
+	h.peer.write(codec.Frame{
+		Dst:  codec.Address{Index: codec.IndexUnknown},
+		Src:  peerAddr,
+		Type: codec.MsgGetStat,
+	})
+	select {
+	case <-h.link.Unsolicited():
+	case <-time.After(2 * time.Second):
+		t.Fatal("the barrier frame was never dispatched")
+	}
+}
+
+// bareSession builds a session with its channels in place but no Call behind
+// it, for tests of the link's own bookkeeping. Registering a half-built
+// Session would crash the link's shutdown, which only ever sees sessions that
+// Call constructed.
+func bareSession(l *Link) *Session {
+	s := &Session{
+		link:        l,
+		remoteIndex: codec.IndexUnknown,
+		pushes:      make(chan Push, 1),
+	}
+	s.front = newChannel("front", l.clk, l.cfg.replyTimeout(), l.cfg.maxStrikes())
+	s.back = newChannel("back", l.clk, l.cfg.replyTimeout(), l.cfg.maxStrikes())
+	return s
+}
+
+// deps builds the standard dependency set with a fake clock.
+func testDeps(clk clock.Clock) plugin.Deps {
+	return plugin.Deps{
+		Logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Clock:   clk,
+		Metrics: metrics.NewConnector(),
+	}
+}

--- a/internal/snell-rollcall/session/identity.go
+++ b/internal/snell-rollcall/session/identity.go
@@ -1,0 +1,114 @@
+package session
+
+import (
+	"context"
+	"time"
+
+	"dhs/internal/snell-rollcall/codec"
+)
+
+// Identity is who we say we are on a link.
+//
+// A provider announces it so that clients and RollMap can find us; a consumer
+// carries it in every Call so the peer knows who connected. The type id is
+// what a vendor tool uses to pick an icon and a manual, so reporting one the
+// database knows makes us legible to tools we did not write.
+type Identity struct {
+	Info codec.DeviceInfo
+
+	// Interval overrides the announcement period. Zero uses the default.
+	Interval time.Duration
+}
+
+// Announcer sends Iam on a schedule.
+//
+// Announcements are never answered: Iam is one of the two message types that
+// may be addressed to the broadcast address, and a peer that replied to one
+// would be talking to everybody. So this does not go through the active-message
+// queue, and it is the only sender in the package that does not.
+//
+// The period is spread by unit address. A frame announcing sixteen modules at
+// the same instant produces a burst the specification's 12.5-to-17.5-second
+// window exists to avoid, so the vendor adds twenty milliseconds per unit and
+// so do we.
+type Announcer struct {
+	link *Link
+	id   Identity
+	sent uint64
+}
+
+// NewAnnouncer starts announcing until ctx ends or the link closes.
+func NewAnnouncer(ctx context.Context, l *Link, id Identity) *Announcer {
+	a := &Announcer{link: l, id: id}
+
+	l.wg.Add(1)
+	go func() {
+		defer l.wg.Done()
+		a.loop(ctx)
+	}()
+	return a
+}
+
+// Interval returns the announcement period this announcer uses.
+func (a *Announcer) Interval() time.Duration {
+	if a.id.Interval > 0 {
+		return a.id.Interval
+	}
+	return DefaultIamInterval + time.Duration(a.id.Info.Address.Unit)*IamSpreadPerUnit
+}
+
+// Sent reports how many announcements have gone out.
+func (a *Announcer) Sent() uint64 { return a.sent }
+
+func (a *Announcer) loop(ctx context.Context) {
+	t := a.link.clk.NewTicker(a.Interval())
+	defer t.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-a.link.done:
+			return
+		case <-t.C():
+			// A failed announcement is not worth ending anything over: the
+			// next one is a few seconds away, and if the link is really gone
+			// the read loop will say so.
+			_ = a.Announce()
+		}
+	}
+}
+
+// Announce sends one Iam immediately.
+func (a *Announcer) Announce() error {
+	payload, err := a.id.Info.AppendTo(nil)
+	if err != nil {
+		return err
+	}
+	a.sent++
+	return a.link.send(codec.Frame{
+		Dst:     codec.Broadcast(),
+		Src:     addrWithIndex(a.id.Info.Address, codec.IndexUnknown),
+		Type:    codec.MsgIam,
+		Payload: payload,
+	})
+}
+
+// ClientIdentity builds the DeviceInfo a consumer presents.
+//
+// It reports the vendor's own routing-client type id, so tools that read the
+// id show us as something they recognise rather than as an unknown number. The
+// services are what we are prepared to receive, not what we provide.
+func ClientIdentity(name string, services codec.Service) codec.DeviceInfo {
+	return codec.DeviceInfo{
+		ProtocolVersion: codec.ProtocolVersion,
+		Address:         codec.Address{Index: codec.IndexUnknown},
+		ID: codec.ID{
+			Services: services,
+			TypeID:   codec.TypeIDRoutingIPShareClient,
+			Version:  codec.Version{Major: 1, Minor: 0, Alpha: ' ', CmdSet: 1},
+			Name:     codec.TruncateFixed(name, codec.MaxTextSize),
+		},
+		Status: codec.UnitStatus{Status: codec.StatusPresent | codec.StatusOnline},
+	}
+}

--- a/internal/snell-rollcall/session/identity_test.go
+++ b/internal/snell-rollcall/session/identity_test.go
@@ -1,0 +1,200 @@
+package session
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"dhs/internal/snell-rollcall/codec"
+)
+
+// TestAnnouncer_IsNeverAnswered pins what makes announcements different from
+// everything else in this package. Iam is one of only two types that may be
+// addressed to the broadcast address, and a peer that replied to one would be
+// answering everybody, so it does not go through the active-message queue.
+func TestAnnouncer_IsNeverAnswered(t *testing.T) {
+	h := newHarness(t, Config{})
+
+	id := Identity{
+		Info:     ClientIdentity("dhs", codec.SvcMenus|codec.SvcControl),
+		Interval: 12500 * time.Millisecond,
+	}
+	id.Info.Address = codec.Address{Unit: 0x41, Port: 0x00, Index: codec.IndexUnknown}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	a := NewAnnouncer(ctx, h.link, id)
+
+	h.fire(t, 1, 12500*time.Millisecond)
+
+	f := h.peer.recvType(codec.MsgIam)
+	if !f.Dst.IsBroadcast() {
+		t.Errorf("announced to %s, want the broadcast address", f.Dst)
+	}
+	if f.Dst.Index != codec.IndexUnknown {
+		t.Errorf("index = %d, want %d", f.Dst.Index, codec.IndexUnknown)
+	}
+	if !codec.MsgIam.Broadcastable() {
+		t.Error("IAM must be one of the types allowed on the broadcast address")
+	}
+
+	info, err := codec.DecodeDeviceInfo(f.Payload)
+	if err != nil {
+		t.Fatalf("DecodeDeviceInfo: %v", err)
+	}
+	if info.ID.Name != "dhs" {
+		t.Errorf("name = %q, want dhs", info.ID.Name)
+	}
+
+	// The next announcement goes out without anything having answered the
+	// first, which is the whole point.
+	h.fire(t, 1, 12500*time.Millisecond)
+	h.peer.recvType(codec.MsgIam)
+
+	if a.Sent() < 2 {
+		t.Errorf("Sent = %d, want at least 2", a.Sent())
+	}
+}
+
+// TestAnnouncer_SpreadsByUnit covers the per-unit offset. A frame announcing
+// sixteen modules at the same instant produces exactly the burst the
+// specification's 12.5-to-17.5-second window exists to avoid.
+func TestAnnouncer_SpreadsByUnit(t *testing.T) {
+	h := newHarness(t, Config{})
+
+	var last time.Duration
+	for _, unit := range []uint8{0x10, 0x11, 0x20, 0x41} {
+		id := Identity{Info: ClientIdentity("x", codec.SvcMenus)}
+		id.Info.Address = codec.Address{Unit: unit, Index: codec.IndexUnknown}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		a := NewAnnouncer(ctx, h.link, id)
+		got := a.Interval()
+		cancel()
+
+		want := DefaultIamInterval + time.Duration(unit)*IamSpreadPerUnit
+		if got != want {
+			t.Errorf("unit %02X interval = %s, want %s", unit, got, want)
+		}
+		if got <= last {
+			t.Errorf("unit %02X did not spread past the previous unit", unit)
+		}
+		last = got
+
+		// Every spread interval must stay inside the window the
+		// specification allows.
+		if got < 12500*time.Millisecond || got > 17500*time.Millisecond {
+			t.Errorf("unit %02X interval %s falls outside the 12.5-17.5s window", unit, got)
+		}
+	}
+}
+
+func TestAnnouncer_ExplicitInterval(t *testing.T) {
+	h := newHarness(t, Config{})
+
+	id := Identity{Info: ClientIdentity("x", codec.SvcMenus), Interval: 5 * time.Second}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if got := NewAnnouncer(ctx, h.link, id).Interval(); got != 5*time.Second {
+		t.Errorf("Interval = %s, want the explicit 5s", got)
+	}
+}
+
+// TestAnnouncer_SurvivesAFailedSend covers a transient write failure. The next
+// announcement is seconds away, and if the link is really gone the read loop
+// reports it, so one lost announcement must not end anything.
+func TestAnnouncer_SurvivesAFailedSend(t *testing.T) {
+	h := newHarness(t, Config{})
+
+	// A name too long for the field cannot be encoded, so the announcement
+	// fails every time.
+	id := Identity{Info: ClientIdentity("x", codec.SvcMenus), Interval: time.Second}
+	id.Info.ID.Name = strings.Repeat("n", codec.MaxTextSize)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	a := NewAnnouncer(ctx, h.link, id)
+
+	if err := a.Announce(); err == nil {
+		t.Fatal("an unencodable identity should fail to announce")
+	}
+
+	h.fire(t, 1, time.Second)
+	select {
+	case <-h.link.Done():
+		t.Fatal("a failed announcement must not close the link")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestAnnouncer_StopsWithTheContext(t *testing.T) {
+	h := newHarness(t, Config{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	NewAnnouncer(ctx, h.link, Identity{Info: ClientIdentity("x", codec.SvcMenus)})
+	h.armed(t, 1)
+
+	cancel()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for h.clk.Waiters() != 0 {
+		if time.Now().After(deadline) {
+			t.Fatalf("%d timers still armed after cancellation", h.clk.Waiters())
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestAnnouncer_StopsWithTheLink(t *testing.T) {
+	h := newHarness(t, Config{})
+
+	NewAnnouncer(context.Background(), h.link, Identity{Info: ClientIdentity("x", codec.SvcMenus)})
+	h.armed(t, 1)
+
+	_ = h.link.Close()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for h.clk.Waiters() != 0 {
+		if time.Now().After(deadline) {
+			t.Fatalf("%d timers still armed after the link closed", h.clk.Waiters())
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// TestClientIdentity covers what we present to a peer. The type id is the one
+// the vendor database assigns to a routing client, so tools that read the id
+// show us as something they recognise rather than as an unknown number.
+func TestClientIdentity(t *testing.T) {
+	id := ClientIdentity("dhs consumer", codec.SvcMenus|codec.SvcControl|codec.SvcLongStr)
+
+	if id.ID.TypeID != codec.TypeIDRoutingIPShareClient {
+		t.Errorf("type id = %d, want the routing client %d",
+			id.ID.TypeID, codec.TypeIDRoutingIPShareClient)
+	}
+	if _, ok := codec.LookupUnitType(id.ID.TypeID); !ok {
+		t.Error("the type id we present must exist in the vendor database")
+	}
+	if id.ProtocolVersion != codec.ProtocolVersion {
+		t.Errorf("protocol version = %d", id.ProtocolVersion)
+	}
+	if id.Address.Index != codec.IndexUnknown {
+		t.Errorf("index = %d, want %d before any session", id.Address.Index, codec.IndexUnknown)
+	}
+	if !id.Status.Status.Has(codec.StatusPresent) {
+		t.Errorf("status = %s, want it to say we are present", id.Status.Status)
+	}
+
+	// Whatever we are called, the identity must encode: a client that cannot
+	// connect because its own name is long is a worse outcome than one that
+	// appears under a shortened name.
+	long := ClientIdentity(strings.Repeat("n", 100), codec.SvcMenus)
+	if _, err := long.AppendTo(nil); err != nil {
+		t.Errorf("a long name must be truncated rather than refused: %v", err)
+	}
+	if len(long.ID.Name) != codec.MaxTextSize-1 {
+		t.Errorf("name is %d bytes, want %d", len(long.ID.Name), codec.MaxTextSize-1)
+	}
+}

--- a/internal/snell-rollcall/session/keepalive.go
+++ b/internal/snell-rollcall/session/keepalive.go
@@ -1,0 +1,113 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"dhs/internal/snell-rollcall/codec"
+)
+
+// Keepalive probes an idle link and closes it when the peer stops answering.
+//
+// It has to probe, because silence carries no information. Measured against
+// the live stack during the audit: an idle connection receives exactly zero
+// unsolicited frames over ninety seconds, and the session survives that
+// silence intact. So a quiet link is indistinguishable from a dead one until
+// something is sent.
+//
+// KeepAlive is answered with Ack by both a real device and the proxy, on both
+// an unconnected and a connected session, in four milliseconds. It is the
+// specification's own link probe and costs an empty payload, where GetDevInfo
+// costs a forty-byte reply; GetDevInfo remains the fallback for a peer that
+// ignores the type.
+type Keepalive struct {
+	link    *Link
+	session *Session
+	misses  atomic.Int64
+	probes  atomic.Uint64
+}
+
+// NewKeepalive starts probing a link.
+//
+// When s is non-nil the probe is sent on that session, which proves the
+// session still exists as well as the socket. On the unconnected index a
+// successful probe proves only that the peer's stack is alive, and the session
+// is what actually breaks.
+func NewKeepalive(ctx context.Context, l *Link, s *Session) *Keepalive {
+	k := &Keepalive{link: l, session: s}
+
+	interval := l.cfg.keepaliveInterval()
+	if interval <= 0 {
+		return k // explicitly disabled
+	}
+
+	l.wg.Add(1)
+	go func() {
+		defer l.wg.Done()
+		k.loop(ctx, interval)
+	}()
+	return k
+}
+
+// Misses reports how many consecutive probes went unanswered.
+func (k *Keepalive) Misses() int { return int(k.misses.Load()) }
+
+// Probes reports how many probes have been sent.
+func (k *Keepalive) Probes() uint64 { return k.probes.Load() }
+
+func (k *Keepalive) loop(ctx context.Context, interval time.Duration) {
+	t := k.link.clk.NewTicker(interval)
+	defer t.Stop()
+
+	max := k.link.cfg.maxKeepaliveMisses()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-k.link.done:
+			return
+		case <-t.C():
+			if err := k.probe(ctx); err != nil {
+				if k.misses.Add(1) >= int64(max) {
+					k.link.closeWith(fmt.Errorf("%w: %d probes unanswered", ErrLinkDead, max))
+					return
+				}
+				continue
+			}
+			k.misses.Store(0)
+		}
+	}
+}
+
+// Probe sends one keepalive and waits for the answer.
+//
+// It goes through the ordinary send queue because it is an active message like
+// any other. Injecting it beside a pending request would have it matched
+// head-of-queue against that request's reply, which is a correctness bug
+// rather than a shortcut.
+func (k *Keepalive) Probe(ctx context.Context) error { return k.probe(ctx) }
+
+func (k *Keepalive) probe(ctx context.Context) error {
+	k.probes.Add(1)
+
+	if k.session != nil {
+		_, err := k.session.Do(ctx, codec.MsgKeepAlive, nil)
+		return err
+	}
+
+	req := codec.Frame{
+		Dst:  addrWithIndex(k.link.RemoteAddress(), codec.IndexUnknown),
+		Src:  addrWithIndex(k.link.LocalAddress(), codec.IndexUnknown),
+		Type: codec.MsgKeepAlive,
+	}
+	reply, err := k.link.exchange(ctx, k.link.blind, req)
+	if err != nil {
+		return err
+	}
+	if reply.Type != codec.MsgAck {
+		return protocolError("keepalive", reply)
+	}
+	return nil
+}

--- a/internal/snell-rollcall/session/keepalive_test.go
+++ b/internal/snell-rollcall/session/keepalive_test.go
@@ -1,0 +1,277 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"dhs/internal/snell-rollcall/codec"
+)
+
+// TestKeepalive_ProbesAnIdleLink covers why the probe exists at all.
+//
+// Measured against the live stack during the audit: an idle connection
+// receives exactly zero unsolicited frames over ninety seconds, and the
+// session survives that silence intact. So silence carries no information, and
+// a quiet link is indistinguishable from a dead one until something is sent.
+func TestKeepalive_ProbesAnIdleLink(t *testing.T) {
+	h := newHarness(t, Config{KeepaliveInterval: 15 * time.Second})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	k := NewKeepalive(ctx, h.link, nil)
+
+	// Nothing is sent until the interval elapses.
+	h.peer.quiet()
+
+	h.fire(t, 1, 15*time.Second)
+
+	probe := h.peer.recvType(codec.MsgKeepAlive)
+	if len(probe.Payload) != 0 {
+		t.Errorf("payload = %x, want none; the probe is cheap by design", probe.Payload)
+	}
+	if probe.Dst.Index != codec.IndexUnknown {
+		t.Errorf("index = %d, want %d before a session exists",
+			probe.Dst.Index, codec.IndexUnknown)
+	}
+
+	h.peer.send(probe, codec.MsgAck, nil)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for k.Misses() != 0 || k.Probes() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatalf("after an answered probe: %d probes, %d misses", k.Probes(), k.Misses())
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// TestKeepalive_ProbesTheSession covers the difference the audit calls out. A
+// probe on the unconnected index proves the peer's stack is alive; one on a
+// session also proves the session still exists, and the session is what
+// actually breaks.
+func TestKeepalive_ProbesTheSession(t *testing.T) {
+	h := newHarness(t, Config{KeepaliveInterval: 15 * time.Second})
+	s := h.callSession(t, codec.SvcControl)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	NewKeepalive(ctx, h.link, s)
+
+	h.fire(t, 1, 15*time.Second)
+
+	probe := h.peer.recvType(codec.MsgKeepAlive)
+	if probe.Dst.Index != s.RemoteIndex() {
+		t.Errorf("probe index = %d, want the session's %d", probe.Dst.Index, s.RemoteIndex())
+	}
+	if probe.Src.Index != s.LocalIndex() {
+		t.Errorf("probe source index = %d, want ours %d", probe.Src.Index, s.LocalIndex())
+	}
+	h.peer.send(probe, codec.MsgAck, nil)
+}
+
+// TestKeepalive_ThreeMissesEndTheLink covers a peer that stops answering.
+func TestKeepalive_ThreeMissesEndTheLink(t *testing.T) {
+	h := newHarness(t, Config{
+		KeepaliveInterval:  15 * time.Second,
+		ReplyTimeout:       3 * time.Second,
+		MaxKeepaliveMisses: 3,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	NewKeepalive(ctx, h.link, nil)
+
+	for i := range 3 {
+		// The ticker fires, a probe goes out, and its own deadline is the
+		// second armed timer.
+		h.fire(t, 1, 15*time.Second)
+		h.peer.recvType(codec.MsgKeepAlive)
+		h.fire(t, 2, 3*time.Second)
+
+		if i < 2 {
+			select {
+			case <-h.link.Done():
+				t.Fatalf("the link died after %d misses, want 3", i+1)
+			case <-time.After(50 * time.Millisecond):
+			}
+		}
+	}
+
+	select {
+	case <-h.link.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("three unanswered probes should have ended the link")
+	}
+	if !errors.Is(h.link.Err(), ErrLinkDead) {
+		t.Errorf("link error = %v, want ErrLinkDead", h.link.Err())
+	}
+}
+
+// TestKeepalive_MissesResetOnAnAnswer covers a link that drops one probe and
+// recovers. Counting misses without resetting would kill a healthy link after
+// three lost packets spread over an hour.
+func TestKeepalive_MissesResetOnAnAnswer(t *testing.T) {
+	h := newHarness(t, Config{
+		KeepaliveInterval:  15 * time.Second,
+		ReplyTimeout:       3 * time.Second,
+		MaxKeepaliveMisses: 2,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	k := NewKeepalive(ctx, h.link, nil)
+
+	// One missed probe.
+	h.fire(t, 1, 15*time.Second)
+	h.peer.recvType(codec.MsgKeepAlive)
+	h.fire(t, 2, 3*time.Second)
+
+	// One answered.
+	h.fire(t, 1, 15*time.Second)
+	probe := h.peer.recvType(codec.MsgKeepAlive)
+	h.peer.send(probe, codec.MsgAck, nil)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for k.Misses() != 0 {
+		if time.Now().After(deadline) {
+			t.Fatalf("misses = %d after an answered probe, want 0", k.Misses())
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	select {
+	case <-h.link.Done():
+		t.Fatal("the link died despite recovering")
+	default:
+	}
+}
+
+// TestKeepalive_IsAnActiveMessage pins the rule that makes the probe safe. It
+// occupies the one-in-flight slot like any other request. Injecting it beside
+// a pending request would have it matched head-of-queue against that request's
+// reply, which is a correctness bug rather than a shortcut.
+func TestKeepalive_IsAnActiveMessage(t *testing.T) {
+	// The reply timeout is set well above the probe interval so the pending
+	// request is still outstanding when the probe comes due. With the
+	// production values the request would have timed out first, which would
+	// test nothing.
+	h := newHarness(t, Config{KeepaliveInterval: time.Second, ReplyTimeout: time.Minute})
+	s := h.callSession(t, codec.SvcControl)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	NewKeepalive(ctx, h.link, s)
+
+	// A request is in flight.
+	go func() { _, _ = s.Do(context.Background(), codec.MsgGetFStat, []byte{0, 1}) }()
+	req := h.peer.recvType(codec.MsgGetFStat)
+
+	// The probe comes due, and must wait rather than jump the queue.
+	h.fire(t, 2, time.Second)
+	h.peer.quiet()
+
+	// Answering the request lets the probe out.
+	h.peer.send(req, codec.MsgRetFStat, nil)
+	probe := h.peer.recvType(codec.MsgKeepAlive)
+	h.peer.send(probe, codec.MsgAck, nil)
+}
+
+// TestKeepalive_RefusalCountsAsAMiss covers a peer that answers the probe with
+// something other than an acknowledgement. It is alive, but not agreeing, and
+// treating that as success would hide a session the peer has already dropped.
+func TestKeepalive_RefusalCountsAsAMiss(t *testing.T) {
+	h := newHarness(t, Config{KeepaliveInterval: time.Second})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	k := NewKeepalive(ctx, h.link, nil)
+
+	h.fire(t, 1, time.Second)
+	probe := h.peer.recvType(codec.MsgKeepAlive)
+	h.peer.send(probe, codec.MsgInvSess, nil)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for k.Misses() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("a refused probe was counted as a success")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// TestKeepalive_Disabled covers a link whose peer pushes continuously, where
+// probing is wasted traffic.
+func TestKeepalive_Disabled(t *testing.T) {
+	h := newHarness(t, Config{KeepaliveInterval: -1})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	k := NewKeepalive(ctx, h.link, nil)
+
+	if h.clk.Waiters() != 0 {
+		t.Errorf("%d timers armed, want none when probing is disabled", h.clk.Waiters())
+	}
+	if k.Probes() != 0 {
+		t.Errorf("%d probes sent, want none", k.Probes())
+	}
+}
+
+// TestKeepalive_StopsWithTheContext covers shutdown. A leaked ticker keeps a
+// link alive in the runtime after the caller has finished with it.
+func TestKeepalive_StopsWithTheContext(t *testing.T) {
+	h := newHarness(t, Config{KeepaliveInterval: 15 * time.Second})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	NewKeepalive(ctx, h.link, nil)
+	h.armed(t, 1)
+
+	cancel()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for h.clk.Waiters() != 0 {
+		if time.Now().After(deadline) {
+			t.Fatalf("%d timers still armed after cancellation", h.clk.Waiters())
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// TestKeepalive_StopsWithTheLink covers the other way it ends.
+func TestKeepalive_StopsWithTheLink(t *testing.T) {
+	h := newHarness(t, Config{KeepaliveInterval: 15 * time.Second})
+
+	NewKeepalive(context.Background(), h.link, nil)
+	h.armed(t, 1)
+
+	_ = h.link.Close()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for h.clk.Waiters() != 0 {
+		if time.Now().After(deadline) {
+			t.Fatalf("%d timers still armed after the link closed", h.clk.Waiters())
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// TestKeepalive_ProbeDirectly covers the exported single probe, which a caller
+// uses to check a link on demand rather than on a schedule.
+func TestKeepalive_ProbeDirectly(t *testing.T) {
+	h := newHarness(t, Config{KeepaliveInterval: -1})
+	k := NewKeepalive(context.Background(), h.link, nil)
+
+	done := make(chan error, 1)
+	go func() { done <- k.Probe(context.Background()) }()
+
+	probe := h.peer.recvType(codec.MsgKeepAlive)
+	h.peer.send(probe, codec.MsgAck, nil)
+
+	if err := <-done; err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	if k.Probes() != 1 {
+		t.Errorf("Probes = %d, want 1", k.Probes())
+	}
+}

--- a/internal/snell-rollcall/session/link.go
+++ b/internal/snell-rollcall/session/link.go
@@ -1,0 +1,368 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+	"sync/atomic"
+
+	"dhs/internal/clock"
+	"dhs/internal/metrics"
+	"dhs/internal/plugin"
+	"dhs/internal/snell-rollcall/codec"
+)
+
+// Link is one RollCall connection: a byte stream with frames on it, and the
+// sessions multiplexed over it by index.
+//
+// It never opens a socket. A caller dials through the injected transport and
+// hands the net.Conn over, which is what lets every test in this package run
+// over net.Pipe with no port, no listener and no timing.
+type Link struct {
+	conn net.Conn
+	cfg  Config
+	log  *slog.Logger
+	clk  clock.Clock
+	met  *metrics.Connector
+
+	// writeMu serialises writes. Frames are small and written whole, so a
+	// mutex is cheaper and clearer than a writer goroutine with a queue.
+	writeMu sync.Mutex
+
+	mu       sync.RWMutex
+	local    codec.Address // our address, learned from the gateway if stamped
+	remote   codec.Address // the peer at the other end, learned by Handshake
+	sessions map[int16]*Session
+	nextIdx  int16
+	closed   bool
+	closeErr error
+
+	// blind carries replies to traffic sent outside any session: the first
+	// GETDEVINFO, keepalives before a session exists, blind control on index
+	// zero. It is a channel like any other, so those requests obey the same
+	// one-in-flight rule.
+	blind *channel
+
+	// unsolicited receives frames addressed to no session and answering no
+	// request, such as an Iam announcement from a peer.
+	unsolicited chan codec.Frame
+
+	done     chan struct{}
+	doneOnce sync.Once
+	wg       sync.WaitGroup
+
+	rxFrames atomic.Uint64
+	txFrames atomic.Uint64
+	resyncs  atomic.Uint64
+}
+
+// NewLink wraps an established connection.
+//
+// The caller owns the dial and keeps ownership of nothing else: Close shuts
+// the connection down. Deps supplies the logger, clock and metrics, so a Link
+// cannot read the wall clock or invent a counter set of its own.
+func NewLink(conn net.Conn, cfg Config, deps plugin.Deps) *Link {
+	deps = deps.WithDefaults()
+
+	l := &Link{
+		conn:        conn,
+		cfg:         cfg,
+		log:         deps.Logger,
+		clk:         deps.Clock,
+		met:         deps.Metrics,
+		sessions:    make(map[int16]*Session),
+		nextIdx:     1,
+		unsolicited: make(chan codec.Frame, 16),
+		done:        make(chan struct{}),
+		local: codec.Address{
+			Net:   cfg.Local.Net,
+			Unit:  cfg.Local.Unit,
+			Port:  cfg.Local.Port,
+			Index: codec.IndexUnknown,
+		},
+		// Until the handshake names the peer, the only address we can reach
+		// it on is the broadcast one, which every unit on the segment
+		// answers to.
+		remote: codec.Broadcast(),
+	}
+	l.blind = newChannel("blind", l.clk, cfg.replyTimeout(), cfg.maxStrikes())
+
+	l.wg.Add(1)
+	go l.readLoop()
+	return l
+}
+
+// LocalAddress returns our address on this link.
+//
+// A TCP client starts with zeros and learns its real address from the first
+// reply a gateway stamps, so this changes once early in a link's life and then
+// stays put.
+func (l *Link) LocalAddress() codec.Address {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.local
+}
+
+// SetLocalAddress records the address a gateway assigned us.
+func (l *Link) SetLocalAddress(a codec.Address) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.local.Net, l.local.Unit, l.local.Port = a.Net, a.Unit, a.Port
+}
+
+// RemoteAddress returns the peer at the other end of the link, which is the
+// broadcast address until Handshake learns the real one.
+func (l *Link) RemoteAddress() codec.Address {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.remote
+}
+
+// SetRemoteAddress records the peer's address.
+func (l *Link) SetRemoteAddress(a codec.Address) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.remote = a.Device()
+}
+
+// Handshake is the first thing a client sends on a new connection: GetDevInfo
+// for port zero, addressed to the unconnected broadcast address.
+//
+// It exists because a TCP client knows neither address. Its own is assigned by
+// the gateway, which stamps a port drawn from its connection slots over the
+// zeroed source we send; and the gateway's own address is whatever the reply
+// comes from. Both are learned here, and both are needed before any session
+// can be opened.
+//
+// The reply also carries the peer's service mask, which is what decides
+// whether a 32-bit session can be asked for at all.
+func (l *Link) Handshake(ctx context.Context) (codec.DeviceInfo, error) {
+	req := codec.Frame{
+		Dst:  codec.Broadcast(),
+		Src:  addrWithIndex(l.LocalAddress(), codec.IndexUnknown),
+		Type: codec.MsgGetDevInfo,
+	}
+
+	reply, err := l.exchange(ctx, l.blind, req)
+	if err != nil {
+		return codec.DeviceInfo{}, err
+	}
+	if reply.Type != codec.MsgRetDevInfo {
+		return codec.DeviceInfo{}, protocolError("handshake", reply)
+	}
+
+	info, err := codec.DecodeDeviceInfo(reply.Payload)
+	if err != nil {
+		return codec.DeviceInfo{}, err
+	}
+
+	// Take the addresses from the frame header, not from the payload. The
+	// address inside a DeviceInfo is never rewritten as a message crosses a
+	// bridge, so its route is meaningless (spec 11.3.4).
+	l.SetRemoteAddress(reply.Src)
+	if reply.Dst.Unit != 0 {
+		l.SetLocalAddress(reply.Dst)
+	}
+	return info, nil
+}
+
+// Unsolicited returns frames that answered no request and belonged to no
+// session: announcements, mostly. It is buffered and lossy by design — a
+// caller that is not draining it is not interested, and an announcement is
+// repeated every few seconds anyway.
+func (l *Link) Unsolicited() <-chan codec.Frame { return l.unsolicited }
+
+// Done is closed when the link stops. Err says why.
+func (l *Link) Done() <-chan struct{} { return l.done }
+
+// Err returns why the link closed, or nil while it is running.
+func (l *Link) Err() error {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.closeErr
+}
+
+// Stats reports frame counts and how many bytes were discarded to regain
+// framing. A non-zero resync count is worth a compliance event: it means the
+// peer sent something that was not a frame.
+func (l *Link) Stats() (rx, tx, resyncs uint64) {
+	return l.rxFrames.Load(), l.txFrames.Load(), l.resyncs.Load()
+}
+
+// Close shuts the link down and every session on it.
+func (l *Link) Close() error {
+	l.closeWith(ErrLinkClosed)
+	l.wg.Wait()
+	return nil
+}
+
+// closeWith stops the link once, recording the first reason given.
+func (l *Link) closeWith(err error) {
+	l.doneOnce.Do(func() {
+		l.mu.Lock()
+		l.closed = true
+		l.closeErr = err
+		sessions := make([]*Session, 0, len(l.sessions))
+		for _, s := range l.sessions {
+			sessions = append(sessions, s)
+		}
+		l.mu.Unlock()
+
+		// Waking every waiter matters more than the order it happens in: a
+		// caller blocked on a request should learn now, not at its own
+		// timeout.
+		l.blind.closeWith(err)
+		for _, s := range sessions {
+			s.linkClosed(err)
+		}
+
+		close(l.done)
+		_ = l.conn.Close()
+	})
+}
+
+// send writes one frame.
+func (l *Link) send(f codec.Frame) error {
+	buf, err := f.Encode()
+	if err != nil {
+		return err
+	}
+
+	l.writeMu.Lock()
+	_, err = l.conn.Write(buf)
+	l.writeMu.Unlock()
+
+	if err != nil {
+		l.closeWith(fmt.Errorf("rollcall: write: %w", err))
+		return err
+	}
+	l.txFrames.Add(1)
+	l.met.ObserveTx(len(buf), 0)
+	return nil
+}
+
+// exchange sends a request on a channel and waits for its reply, holding the
+// one-in-flight slot for the whole round trip.
+func (l *Link) exchange(ctx context.Context, ch *channel, f codec.Frame) (codec.Frame, error) {
+	p, err := ch.acquire(ctx, f.Type)
+	if err != nil {
+		return codec.Frame{}, err
+	}
+	if err := l.send(f); err != nil {
+		ch.release(false)
+		return codec.Frame{}, err
+	}
+	return ch.await(ctx, p)
+}
+
+// readLoop decodes frames until the connection ends.
+func (l *Link) readLoop() {
+	defer l.wg.Done()
+
+	r := codec.NewReader(l.conn)
+	for {
+		f, err := r.ReadFrame()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				l.closeWith(ErrLinkClosed)
+			} else {
+				l.met.ObserveDecodeError()
+				l.closeWith(fmt.Errorf("rollcall: read: %w", err))
+			}
+			return
+		}
+
+		l.rxFrames.Add(1)
+		l.resyncs.Store(r.Resyncs())
+		l.met.ObserveRx(f.Size())
+		l.dispatch(f)
+	}
+}
+
+// dispatch routes one received frame.
+//
+// The destination session index is what identifies the session, and it is our
+// index rather than the peer's: we chose it, we put it in the source of
+// everything we send, and the peer echoes it back here. Matching on the peer's
+// index instead is the mistake that produced SP_INVSESS during the audit and
+// lost every push.
+func (l *Link) dispatch(f codec.Frame) {
+	if s := l.session(f.Dst.Index); s != nil {
+		s.receive(f)
+		return
+	}
+
+	// Not for a session. A reply to something sent outside one is matched
+	// head-of-queue on the blind channel, because there is no index to
+	// correlate by and the protocol only ever has one such request in flight.
+	if f.Type.ValidBlindReply() && l.blind.deliver(f) {
+		return
+	}
+	l.deliverUnsolicited(f)
+}
+
+func (l *Link) deliverUnsolicited(f codec.Frame) {
+	select {
+	case l.unsolicited <- f:
+	default:
+		// Nobody is listening. Announcements repeat, so dropping one costs
+		// nothing; stalling the read loop would cost everything.
+		l.log.Debug("rollcall: dropped unsolicited frame",
+			"type", f.Type.String(), "src", f.Src.String())
+	}
+}
+
+func (l *Link) session(idx int16) *Session {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.sessions[idx]
+}
+
+// register allocates the session index we publish as our own and makes the
+// session findable under it.
+//
+// Both happen under one lock. Allocating an index and registering separately
+// leaves a window in which the peer's acknowledgement, which is addressed to
+// that index, arrives before anything is listening on it.
+//
+// Zero, 0xFE and 0xFF are reserved for blind, logging and unconnected traffic
+// respectively, so allocation starts at one and skips them.
+func (l *Link) register(s *Session) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.closed {
+		return l.closeErr
+	}
+	for range 0xFD {
+		idx := l.nextIdx
+		l.nextIdx++
+		if l.nextIdx >= codec.IndexLogging {
+			l.nextIdx = 1
+		}
+		if _, taken := l.sessions[idx]; !taken {
+			s.localIndex = idx
+			l.sessions[idx] = s
+			return nil
+		}
+	}
+	return errors.New("rollcall: no free session index on this link")
+}
+
+func (l *Link) removeSession(idx int16) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	delete(l.sessions, idx)
+}
+
+// SessionCount reports how many sessions are open, which is what a provider
+// checks before answering a Call with Busy.
+func (l *Link) SessionCount() int {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return len(l.sessions)
+}

--- a/internal/snell-rollcall/session/link_test.go
+++ b/internal/snell-rollcall/session/link_test.go
@@ -1,0 +1,440 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"dhs/internal/clock"
+	deps "dhs/internal/plugin"
+	"dhs/internal/snell-rollcall/codec"
+)
+
+// TestHandshake_LearnsBothAddresses covers the first thing a client sends.
+//
+// A TCP client knows neither address. Its own is assigned by the gateway,
+// which stamps a port drawn from its connection slots over the zeroed source
+// we send; the gateway's own is wherever the reply comes from. A peer that
+// skips this is rejected by real gateways and by the Control Panel.
+func TestHandshake_LearnsBothAddresses(t *testing.T) {
+	h := newHarness(t, Config{})
+
+	// Before the handshake we have no address and can only reach the peer on
+	// the broadcast one.
+	if got := h.link.LocalAddress(); got.Unit != 0 || got.Port != 0 {
+		t.Errorf("local address starts as %s, want zeros", got)
+	}
+	if !h.link.RemoteAddress().IsBroadcast() {
+		t.Errorf("remote address starts as %s, want the broadcast address",
+			h.link.RemoteAddress())
+	}
+
+	type result struct {
+		info codec.DeviceInfo
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		info, err := h.link.Handshake(context.Background())
+		done <- result{info, err}
+	}()
+
+	req := h.peer.recvType(codec.MsgGetDevInfo)
+	if !req.Dst.IsBroadcast() {
+		t.Errorf("handshake sent to %s, want the broadcast address", req.Dst)
+	}
+	if req.Dst.Index != codec.IndexUnknown {
+		t.Errorf("handshake index = %d, want %d", req.Dst.Index, codec.IndexUnknown)
+	}
+
+	// The gateway answers from its real address, and stamps ours into the
+	// destination.
+	gateway := codec.Address{Unit: 0x08, Port: 0x00, Index: codec.IndexUnknown}
+	assigned := codec.Address{Unit: 0x08, Port: 0xE3, Index: codec.IndexUnknown}
+
+	info := codec.DeviceInfo{
+		ProtocolVersion: codec.ProtocolVersion,
+		Address:         gateway,
+		ID: codec.ID{
+			Services: codec.SvcMenus | codec.SvcControl | codec.SvcLongStr,
+			TypeID:   636,
+			Name:     "Centra",
+		},
+		Status: codec.UnitStatus{Status: codec.StatusPresent},
+	}
+	payload, err := info.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	h.peer.write(codec.Frame{
+		Dst:     assigned,
+		Src:     gateway,
+		Type:    codec.MsgRetDevInfo,
+		Payload: payload,
+	})
+
+	r := <-done
+	if r.err != nil {
+		t.Fatalf("Handshake: %v", r.err)
+	}
+
+	if got := h.link.LocalAddress(); got.Unit != 0x08 || got.Port != 0xE3 {
+		t.Errorf("local address = %s, want the stamped 0000-08-E3", got)
+	}
+	if got := h.link.RemoteAddress(); got.Unit != 0x08 || got.Port != 0x00 {
+		t.Errorf("remote address = %s, want the gateway 0000-08-00", got)
+	}
+
+	// The reply also says which generation the peer can speak, which is what
+	// decides whether a 32-bit session may be asked for.
+	if !r.info.ID.Services.LongStrings() {
+		t.Error("the peer's service mask should advertise long strings")
+	}
+	if r.info.ID.Name != "Centra" {
+		t.Errorf("name = %q", r.info.ID.Name)
+	}
+}
+
+// TestHandshake_AddressInThePayloadIsNotARoute pins the note in spec 11.3.4.
+// The address inside a DeviceInfo is never rewritten as a message crosses a
+// bridge, so the route in it is meaningless and the header is what must be
+// believed.
+func TestHandshake_AddressInThePayloadIsNotARoute(t *testing.T) {
+	h := newHarness(t, Config{})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := h.link.Handshake(context.Background())
+		done <- err
+	}()
+	h.peer.recvType(codec.MsgGetDevInfo)
+
+	// The payload claims no route; the header says the peer is two bridges
+	// away. The header wins.
+	info := codec.DeviceInfo{Address: codec.Address{Unit: 0x20, Index: codec.IndexUnknown}}
+	payload, err := info.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	h.peer.write(codec.Frame{
+		Dst:     codec.Address{Unit: 0x08, Port: 0xE0, Index: codec.IndexUnknown},
+		Src:     codec.Address{Net: 0x2300, Unit: 0x20, Index: codec.IndexUnknown},
+		Type:    codec.MsgRetDevInfo,
+		Payload: payload,
+	})
+
+	if err := <-done; err != nil {
+		t.Fatalf("Handshake: %v", err)
+	}
+	if got := h.link.RemoteAddress(); got.Net != 0x2300 {
+		t.Errorf("remote route = %04X, want the header's 2300", got.Net)
+	}
+}
+
+func TestHandshake_Refused(t *testing.T) {
+	h := newHarness(t, Config{})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := h.link.Handshake(context.Background())
+		done <- err
+	}()
+	req := h.peer.recvType(codec.MsgGetDevInfo)
+	h.peer.send(req, codec.MsgNack, nil)
+
+	if err := <-done; !errors.Is(err, ErrRefused) {
+		t.Fatalf("err = %v, want ErrRefused", err)
+	}
+}
+
+func TestHandshake_MalformedReply(t *testing.T) {
+	h := newHarness(t, Config{})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := h.link.Handshake(context.Background())
+		done <- err
+	}()
+	req := h.peer.recvType(codec.MsgGetDevInfo)
+	h.peer.send(req, codec.MsgRetDevInfo, []byte{1, 2, 3}) // too short
+
+	if err := <-done; !errors.Is(err, codec.ErrShortBuffer) {
+		t.Fatalf("err = %v, want ErrShortBuffer", err)
+	}
+}
+
+// TestLink_SessionIndexAllocation pins which indices may be used. Zero, 0xFE
+// and 0xFF are reserved for blind, logging and unconnected traffic, so a
+// session must never be handed one of them.
+func TestLink_SessionIndexAllocation(t *testing.T) {
+	h := newHarness(t, Config{})
+
+	seen := map[int16]bool{}
+	for range 20 {
+		s := bareSession(h.link)
+		if err := h.link.register(s); err != nil {
+			t.Fatalf("register: %v", err)
+		}
+		idx := s.localIndex
+		if idx == codec.IndexBlind || idx == codec.IndexLogging || idx == codec.IndexUnknown {
+			t.Fatalf("allocated the reserved index %d", idx)
+		}
+		if seen[idx] {
+			t.Fatalf("index %d allocated twice", idx)
+		}
+		seen[idx] = true
+	}
+}
+
+// TestLink_IndexReuse covers a long-lived link opening and closing many
+// sessions. Indices wrap, and one still in use must be skipped rather than
+// handed out twice.
+func TestLink_IndexReuse(t *testing.T) {
+	h := newHarness(t, Config{})
+
+	held := h.callSession(t, codec.SvcMenus)
+	taken := held.LocalIndex()
+
+	for range 300 {
+		s := bareSession(h.link)
+		if err := h.link.register(s); err != nil {
+			t.Fatalf("register: %v", err)
+		}
+		if s.localIndex == taken {
+			t.Fatalf("allocated index %d, which is already in use", s.localIndex)
+		}
+		h.link.removeSession(s.localIndex)
+	}
+}
+
+func TestLink_ClosedRefusesWork(t *testing.T) {
+	h := newHarness(t, Config{})
+	_ = h.link.Close()
+
+	if err := h.link.register(bareSession(h.link)); !errors.Is(err, ErrLinkClosed) {
+		t.Errorf("register err = %v, want ErrLinkClosed", err)
+	}
+	if _, err := Call(context.Background(), h.link, peerAddr, codec.SvcMenus,
+		codec.LevelUser, ClientIdentity("x", codec.SvcMenus)); !errors.Is(err, ErrLinkClosed) {
+		t.Errorf("Call err = %v, want ErrLinkClosed", err)
+	}
+	// Closing twice is harmless.
+	if err := h.link.Close(); err != nil {
+		t.Errorf("second Close: %v", err)
+	}
+}
+
+// TestLink_PeerDisconnect covers the far end going away, which is the ordinary
+// way a link ends.
+func TestLink_PeerDisconnect(t *testing.T) {
+	h := newHarness(t, Config{})
+	s := h.callSession(t, codec.SvcMenus)
+
+	h.peer.close()
+
+	select {
+	case <-h.link.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("the link did not notice the peer disconnecting")
+	}
+	if _, err := s.Do(context.Background(), codec.MsgGetStat, nil); err == nil {
+		t.Error("a session on a dead link should refuse work")
+	}
+}
+
+// TestLink_WriteFailureClosesTheLink covers the socket dying under a send.
+// There is no point keeping a link whose writes fail.
+func TestLink_WriteFailureClosesTheLink(t *testing.T) {
+	ours, theirs := net.Pipe()
+	clk := clock.NewFake(time.Time{})
+	l := NewLink(ours, Config{}, testDeps(clk))
+	t.Cleanup(func() { _ = l.Close() })
+
+	_ = theirs.Close()
+
+	err := l.send(codec.Frame{Type: codec.MsgKeepAlive})
+	if err == nil {
+		t.Fatal("a write to a closed pipe should fail")
+	}
+	select {
+	case <-l.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("a failed write should close the link")
+	}
+}
+
+// TestLink_OversizePayloadIsRefusedBeforeSending covers a caller building a
+// frame too big for the wire. It fails locally rather than being truncated
+// into a frame the peer will misparse.
+func TestLink_OversizePayloadIsRefusedBeforeSending(t *testing.T) {
+	h := newHarness(t, Config{})
+
+	err := h.link.send(codec.Frame{Type: codec.MsgRaw, Payload: make([]byte, codec.MaxPayload+1)})
+	if !errors.Is(err, codec.ErrPayloadTooLong) {
+		t.Fatalf("err = %v, want ErrPayloadTooLong", err)
+	}
+	h.peer.quiet()
+	select {
+	case <-h.link.Done():
+		t.Error("a rejected frame must not close the link")
+	default:
+	}
+}
+
+// TestLink_Stats covers the counters, including the resync count. A non-zero
+// resync means the peer sent something that was not a frame, which is worth a
+// compliance event rather than silence.
+func TestLink_Stats(t *testing.T) {
+	h := newHarness(t, Config{})
+
+	rx, tx, resyncs := h.link.Stats()
+	if rx != 0 || tx != 0 || resyncs != 0 {
+		t.Errorf("a new link reports %d/%d/%d", rx, tx, resyncs)
+	}
+
+	s := h.callSession(t, codec.SvcMenus)
+	_ = s
+
+	rx, tx, _ = h.link.Stats()
+	if tx == 0 {
+		t.Error("no frames counted as sent")
+	}
+	if rx == 0 {
+		t.Error("no frames counted as received")
+	}
+}
+
+// TestLink_ResyncIsCounted covers junk on the stream. One byte of it puts
+// every following frame on an odd offset, and the reader recovers a byte at a
+// time; the count is what tells an operator it happened.
+func TestLink_ResyncIsCounted(t *testing.T) {
+	h := newHarness(t, Config{})
+
+	if _, err := h.peer.conn.Write([]byte{0xAA}); err != nil {
+		t.Fatalf("write junk: %v", err)
+	}
+	h.peer.write(codec.Frame{
+		Dst:  codec.Broadcast(),
+		Src:  peerAddr,
+		Type: codec.MsgIam,
+	})
+
+	select {
+	case f := <-h.link.Unsolicited():
+		if f.Type != codec.MsgIam {
+			t.Errorf("= %s, want IAM after the resync", f.Type)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the reader did not recover from one junk byte")
+	}
+
+	if _, _, resyncs := h.link.Stats(); resyncs != 1 {
+		t.Errorf("resyncs = %d, want 1", resyncs)
+	}
+}
+
+// TestLink_UnsolicitedIsLossy covers a caller that never reads announcements.
+// They repeat every few seconds, so dropping one costs nothing; stalling the
+// read loop would stop every session on the link.
+func TestLink_UnsolicitedIsLossy(t *testing.T) {
+	h := newHarness(t, Config{})
+
+	for range 100 {
+		h.peer.write(codec.Frame{Dst: codec.Broadcast(), Src: peerAddr, Type: codec.MsgIam})
+	}
+
+	// The link is still working: a session opens normally.
+	s := h.callSession(t, codec.SvcMenus)
+	if s == nil {
+		t.Fatal("the link stalled on undrained announcements")
+	}
+}
+
+// TestLink_BlindReplyMatching covers traffic sent outside any session. There is
+// no index to correlate by, so replies are matched head-of-queue, which is
+// safe precisely because the one-in-flight rule allows only one such request
+// at a time.
+func TestLink_BlindReplyMatching(t *testing.T) {
+	h := newHarness(t, Config{})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := h.link.Handshake(context.Background())
+		done <- err
+	}()
+	req := h.peer.recvType(codec.MsgGetDevInfo)
+
+	// A frame that is not a valid blind reply must not be matched to it.
+	h.peer.send(req, codec.MsgGetStat, nil)
+	select {
+	case err := <-done:
+		t.Fatalf("a request type was matched as a reply: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	info, err := codec.DeviceInfo{Address: peerAddr}.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	h.peer.send(req, codec.MsgRetDevInfo, info)
+	if err := <-done; err != nil {
+		t.Fatalf("Handshake: %v", err)
+	}
+}
+
+func TestNewLink_DefaultsAreUsable(t *testing.T) {
+	ours, theirs := net.Pipe()
+	t.Cleanup(func() { _ = theirs.Close() })
+
+	// An empty dependency set is filled in rather than panicking, so a caller
+	// that only cares about one dependency still gets a working link.
+	l := NewLink(ours, Config{}, deps.Deps{})
+	t.Cleanup(func() { _ = l.Close() })
+
+	if l.cfg.replyTimeout() != DefaultReplyTimeout {
+		t.Errorf("reply timeout = %s, want the default", l.cfg.replyTimeout())
+	}
+	if l.cfg.maxStrikes() != DefaultMaxStrikes {
+		t.Errorf("max strikes = %d, want the default", l.cfg.maxStrikes())
+	}
+	if l.cfg.pushQueue() != DefaultPushQueue {
+		t.Errorf("push queue = %d, want the default", l.cfg.pushQueue())
+	}
+	if l.cfg.keepaliveInterval() != DefaultKeepaliveInterval {
+		t.Errorf("keepalive interval = %s, want the default", l.cfg.keepaliveInterval())
+	}
+	if l.cfg.maxKeepaliveMisses() != DefaultMaxKeepaliveMisses {
+		t.Errorf("max misses = %d, want the default", l.cfg.maxKeepaliveMisses())
+	}
+}
+
+// TestConfig_KeepaliveCanBeDisabled covers the difference between "unset" and
+// "off". Zero takes the default; negative turns probing off, which is only
+// right for a link whose peer pushes continuously.
+func TestConfig_KeepaliveCanBeDisabled(t *testing.T) {
+	if got := (Config{}).keepaliveInterval(); got != DefaultKeepaliveInterval {
+		t.Errorf("unset = %s, want the default", got)
+	}
+	if got := (Config{KeepaliveInterval: -1}).keepaliveInterval(); got != 0 {
+		t.Errorf("negative = %s, want probing disabled", got)
+	}
+	if got := (Config{KeepaliveInterval: time.Second}).keepaliveInterval(); got != time.Second {
+		t.Errorf("explicit = %s, want one second", got)
+	}
+}
+
+// TestConfig_LocalAddress covers a provider that knows its own address, as
+// opposed to a client that is assigned one.
+func TestConfig_LocalAddress(t *testing.T) {
+	h := newHarness(t, Config{Local: Address{Net: 0x1000, Unit: 0x41, Port: 0x02}})
+
+	got := h.link.LocalAddress()
+	if got.Net != 0x1000 || got.Unit != 0x41 || got.Port != 0x02 {
+		t.Errorf("local address = %s, want 1000-41-02", got)
+	}
+	if got.Index != codec.IndexUnknown {
+		t.Errorf("index = %d, want %d before any session", got.Index, codec.IndexUnknown)
+	}
+}

--- a/internal/snell-rollcall/session/listsvc.go
+++ b/internal/snell-rollcall/session/listsvc.go
@@ -1,0 +1,100 @@
+package session
+
+import (
+	"context"
+	"fmt"
+
+	"dhs/internal/snell-rollcall/codec"
+)
+
+// WalkFunc receives one item of a multi-packet transfer. Returning an error
+// stops the walk and is returned to the caller.
+type WalkFunc func(index int, f codec.Frame) error
+
+// Walk performs a multi-packet transfer in the 16-bit generation.
+//
+// The shape is: a request, a BlockHeader saying how many items follow, then one
+// GetNextPkt per item. It carries menus, device lists, port lists and file
+// directories, which is why it lives here rather than in any one of them.
+//
+// The index in a GetNextPkt is an offset from the base of the request that
+// opened the transfer, and the server holds that base as state. So a walk owns
+// the session for its duration and cannot be interleaved with another, which
+// the one-in-flight rule already guarantees.
+//
+// A server that answers the opening request with something other than a
+// BlockHeader is not refusing: some answer a single-item transfer with the item
+// itself. That is handled rather than treated as an error.
+func Walk(ctx context.Context, s *Session, req codec.PacketType, payload []byte, fn WalkFunc) error {
+	first, err := s.Do(ctx, req, payload)
+	if err != nil {
+		return err
+	}
+
+	if first.Type != codec.MsgBlockHeader {
+		// A one-item answer with no block around it.
+		return fn(0, first)
+	}
+
+	hdr, err := codec.DecodeBlockHeader(first.Payload)
+	if err != nil {
+		return fmt.Errorf("rollcall: walk %s: %w", req, err)
+	}
+
+	for i := range int(hdr.Count) {
+		item, err := s.Do(ctx, codec.MsgGetNextPkt,
+			codec.GetNext{Index: uint16(i), PktType: req}.AppendTo(nil))
+		if err != nil {
+			return fmt.Errorf("rollcall: walk %s item %d of %d: %w", req, i+1, hdr.Count, err)
+		}
+		if err := fn(i, item); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// WalkMenu32 performs a menu walk in the 32-bit generation.
+//
+// It is a different shape, and simpler. GetMenuCount returns a count, and each
+// item is fetched by absolute index. Nothing is held as state on the server,
+// so items may be fetched in any order — this walks in order because a menu is
+// a tree written depth-first and reading it that way is what makes the spans
+// meaningful.
+func WalkMenu32(ctx context.Context, s *Session, base uint32, fn func(codec.MenuItem) error) error {
+	reply, err := s.Do(ctx, codec.MsgGetMenuCount, codec.MenuReq{MenuIndex: base}.AppendTo(nil))
+	if err != nil {
+		return err
+	}
+	if reply.Type != codec.MsgRetMenuCount {
+		return protocolError("menu count", reply)
+	}
+
+	size, err := codec.DecodeMenuSize(reply.Payload)
+	if err != nil {
+		return fmt.Errorf("rollcall: menu count: %w", err)
+	}
+
+	for i := range size.MenuCount {
+		item, err := GetMenuItem(ctx, s, base+i)
+		if err != nil {
+			return fmt.Errorf("rollcall: menu item %d of %d: %w", i+1, size.MenuCount, err)
+		}
+		if err := fn(item); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetMenuItem fetches one menu line by absolute index.
+func GetMenuItem(ctx context.Context, s *Session, index uint32) (codec.MenuItem, error) {
+	reply, err := s.Do(ctx, codec.MsgGetMenuItem, codec.MenuReq{MenuIndex: index}.AppendTo(nil))
+	if err != nil {
+		return codec.MenuItem{}, err
+	}
+	if reply.Type != codec.MsgRetMenuItem {
+		return codec.MenuItem{}, protocolError("menu item", reply)
+	}
+	return codec.DecodeMenuItem(reply.Payload)
+}

--- a/internal/snell-rollcall/session/listsvc_test.go
+++ b/internal/snell-rollcall/session/listsvc_test.go
@@ -1,0 +1,448 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"dhs/internal/snell-rollcall/codec"
+)
+
+// TestWalk_BlockHeaderThenItems covers the 16-bit multi-packet shape: a
+// request, a header saying how many items follow, then one fetch per item.
+//
+// The index in each fetch is an offset from the base of the request that
+// opened the transfer, and the server holds that base as state. So a walk owns
+// the session for its duration, which the one-in-flight rule already
+// guarantees.
+func TestWalk_BlockHeaderThenItems(t *testing.T) {
+	h := newHarness(t, Config{})
+	s := h.callSession(t, codec.SvcMenus)
+
+	const count = 3
+	type collected struct {
+		index int
+		frame codec.Frame
+	}
+	got := make([]collected, 0, count)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- Walk(context.Background(), s, codec.MsgGetFunc, []byte{0, 0},
+			func(i int, f codec.Frame) error {
+				got = append(got, collected{i, f})
+				return nil
+			})
+	}()
+
+	open := h.peer.recvType(codec.MsgGetFunc)
+	hdr := codec.BlockHeader{PktType: codec.MsgGetFunc, Count: count, MaxSize: codec.FuncSize}
+	h.peer.send(open, codec.MsgBlockHeader, hdr.AppendTo(nil))
+
+	for i := range count {
+		req := h.peer.recvType(codec.MsgGetNextPkt)
+
+		next, err := codec.DecodeGetNext(req.Payload)
+		if err != nil {
+			t.Fatalf("DecodeGetNext: %v", err)
+		}
+		if int(next.Index) != i {
+			t.Errorf("fetch %d asked for index %d", i, next.Index)
+		}
+		// The type names the request that opened the transfer, which is how
+		// the server knows which base the offset applies to.
+		if next.PktType != codec.MsgGetFunc {
+			t.Errorf("fetch %d named %s, want GETFUNC", i, next.PktType)
+		}
+
+		line, err := codec.Func{MenuIndex: uint16(i), Style: codec.StyleNumber, Text: "line"}.AppendTo(nil)
+		if err != nil {
+			t.Fatalf("AppendTo: %v", err)
+		}
+		h.peer.send(req, codec.MsgRetFunc, line)
+	}
+
+	if err := <-done; err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if len(got) != count {
+		t.Fatalf("collected %d items, want %d", len(got), count)
+	}
+	for i, c := range got {
+		if c.index != i {
+			t.Errorf("item %d reported index %d", i, c.index)
+		}
+		if c.frame.Type != codec.MsgRetFunc {
+			t.Errorf("item %d = %s, want RETFUNC", i, c.frame.Type)
+		}
+	}
+}
+
+// TestWalk_SingleItemWithoutABlock covers a server that answers a one-item
+// transfer with the item itself. It is not refusing, and treating it as an
+// error would lose the answer.
+func TestWalk_SingleItemWithoutABlock(t *testing.T) {
+	h := newHarness(t, Config{})
+	s := h.callSession(t, codec.SvcMenus)
+
+	var seen int
+	done := make(chan error, 1)
+	go func() {
+		done <- Walk(context.Background(), s, codec.MsgGetDevList, nil,
+			func(int, codec.Frame) error { seen++; return nil })
+	}()
+
+	req := h.peer.recvType(codec.MsgGetDevList)
+	info, err := codec.DeviceInfo{Address: peerAddr}.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	h.peer.send(req, codec.MsgRetDevInfo, info)
+
+	if err := <-done; err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if seen != 1 {
+		t.Errorf("collected %d items, want 1", seen)
+	}
+}
+
+// TestWalk_EmptyBlock covers a device with nothing to list, which is ordinary
+// on an empty slot rather than an error.
+func TestWalk_EmptyBlock(t *testing.T) {
+	h := newHarness(t, Config{})
+	s := h.callSession(t, codec.SvcMenus)
+
+	var seen int
+	done := make(chan error, 1)
+	go func() {
+		done <- Walk(context.Background(), s, codec.MsgGetFunc, []byte{0, 0},
+			func(int, codec.Frame) error { seen++; return nil })
+	}()
+
+	req := h.peer.recvType(codec.MsgGetFunc)
+	h.peer.send(req, codec.MsgBlockHeader, codec.BlockHeader{PktType: codec.MsgGetFunc}.AppendTo(nil))
+
+	if err := <-done; err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if seen != 0 {
+		t.Errorf("collected %d items from an empty block", seen)
+	}
+	h.peer.quiet()
+}
+
+// TestWalk_CallerStops covers a caller that has seen enough. The walk stops
+// where it is rather than fetching every remaining item.
+func TestWalk_CallerStops(t *testing.T) {
+	h := newHarness(t, Config{})
+	s := h.callSession(t, codec.SvcMenus)
+
+	stop := errors.New("enough")
+	done := make(chan error, 1)
+	go func() {
+		done <- Walk(context.Background(), s, codec.MsgGetFunc, []byte{0, 0},
+			func(int, codec.Frame) error { return stop })
+	}()
+
+	open := h.peer.recvType(codec.MsgGetFunc)
+	h.peer.send(open, codec.MsgBlockHeader,
+		codec.BlockHeader{PktType: codec.MsgGetFunc, Count: 500}.AppendTo(nil))
+
+	req := h.peer.recvType(codec.MsgGetNextPkt)
+	h.peer.send(req, codec.MsgRetFunc, make([]byte, codec.FuncSize))
+
+	if err := <-done; !errors.Is(err, stop) {
+		t.Fatalf("err = %v, want the caller's own error", err)
+	}
+	h.peer.quiet()
+}
+
+func TestWalk_Errors(t *testing.T) {
+	t.Run("request refused", func(t *testing.T) {
+		h := newHarness(t, Config{})
+		s := h.callSession(t, codec.SvcMenus)
+
+		done := make(chan error, 1)
+		go func() {
+			done <- Walk(context.Background(), s, codec.MsgGetFunc, nil,
+				func(int, codec.Frame) error { return nil })
+		}()
+		req := h.peer.recvType(codec.MsgGetFunc)
+		h.peer.send(req, codec.MsgNack, nil)
+
+		if err := <-done; !errors.Is(err, ErrRefused) {
+			t.Errorf("err = %v, want ErrRefused", err)
+		}
+	})
+
+	t.Run("malformed header", func(t *testing.T) {
+		h := newHarness(t, Config{})
+		s := h.callSession(t, codec.SvcMenus)
+
+		done := make(chan error, 1)
+		go func() {
+			done <- Walk(context.Background(), s, codec.MsgGetFunc, nil,
+				func(int, codec.Frame) error { return nil })
+		}()
+		req := h.peer.recvType(codec.MsgGetFunc)
+		h.peer.send(req, codec.MsgBlockHeader, []byte{1, 2})
+
+		if err := <-done; !errors.Is(err, codec.ErrShortBuffer) {
+			t.Errorf("err = %v, want ErrShortBuffer", err)
+		}
+	})
+
+	t.Run("item refused", func(t *testing.T) {
+		h := newHarness(t, Config{})
+		s := h.callSession(t, codec.SvcMenus)
+
+		done := make(chan error, 1)
+		go func() {
+			done <- Walk(context.Background(), s, codec.MsgGetFunc, nil,
+				func(int, codec.Frame) error { return nil })
+		}()
+		open := h.peer.recvType(codec.MsgGetFunc)
+		h.peer.send(open, codec.MsgBlockHeader,
+			codec.BlockHeader{PktType: codec.MsgGetFunc, Count: 2}.AppendTo(nil))
+
+		req := h.peer.recvType(codec.MsgGetNextPkt)
+		h.peer.send(req, codec.MsgNack, nil)
+
+		err := <-done
+		if !errors.Is(err, ErrRefused) {
+			t.Errorf("err = %v, want ErrRefused", err)
+		}
+		// The failure names which item of how many, because "walk failed"
+		// alone does not say whether a menu is half read.
+		if !contains(err.Error(), "item 1 of 2") {
+			t.Errorf("err = %q, want it to say which item failed", err)
+		}
+	})
+}
+
+// TestWalkMenu32 covers the 32-bit menu shape, which is a different one: a
+// count, then each item by absolute index, with no state held on the server.
+func TestWalkMenu32(t *testing.T) {
+	h := newHarness(t, Config{})
+	s := h.callSession(t, codec.SvcMenus|codec.SvcLongStr)
+
+	const base = 0x0100
+	const count = 3
+
+	var got []codec.MenuItem
+	done := make(chan error, 1)
+	go func() {
+		done <- WalkMenu32(context.Background(), s, base, func(m codec.MenuItem) error {
+			got = append(got, m)
+			return nil
+		})
+	}()
+
+	req := h.peer.recvType(codec.MsgGetMenuCount)
+	askedFor, err := codec.DecodeMenuReq(req.Payload)
+	if err != nil {
+		t.Fatalf("DecodeMenuReq: %v", err)
+	}
+	if askedFor.MenuIndex != base {
+		t.Errorf("asked for base %d, want %d", askedFor.MenuIndex, base)
+	}
+	h.peer.send(req, codec.MsgRetMenuCount,
+		codec.MenuSize{MenuIndex: base, MenuCount: count}.AppendTo(nil))
+
+	for i := range count {
+		item := h.peer.recvType(codec.MsgGetMenuItem)
+		r, err := codec.DecodeMenuReq(item.Payload)
+		if err != nil {
+			t.Fatalf("DecodeMenuReq: %v", err)
+		}
+		// Absolute, not an offset. That is what makes the request stateless.
+		if r.MenuIndex != base+uint32(i) {
+			t.Errorf("item %d asked for index %d, want the absolute %d",
+				i, r.MenuIndex, base+uint32(i))
+		}
+
+		payload, err := codec.MenuItem{
+			MenuIndex: r.MenuIndex,
+			Style:     codec.StyleNumber,
+			Command:   0x0001_0000 + r.MenuIndex,
+			Text:      "Level",
+		}.AppendTo(nil)
+		if err != nil {
+			t.Fatalf("AppendTo: %v", err)
+		}
+		h.peer.send(item, codec.MsgRetMenuItem, payload)
+	}
+
+	if err := <-done; err != nil {
+		t.Fatalf("WalkMenu32: %v", err)
+	}
+	if len(got) != count {
+		t.Fatalf("collected %d items, want %d", len(got), count)
+	}
+	for i, m := range got {
+		if m.MenuIndex != base+uint32(i) {
+			t.Errorf("item %d has index %d", i, m.MenuIndex)
+		}
+		if m.Text != "Level" {
+			t.Errorf("item %d text = %q", i, m.Text)
+		}
+	}
+}
+
+func TestWalkMenu32_Errors(t *testing.T) {
+	t.Run("wrong reply to the count", func(t *testing.T) {
+		h := newHarness(t, Config{})
+		s := h.callSession(t, codec.SvcMenus|codec.SvcLongStr)
+
+		done := make(chan error, 1)
+		go func() {
+			done <- WalkMenu32(context.Background(), s, 0, func(codec.MenuItem) error { return nil })
+		}()
+		req := h.peer.recvType(codec.MsgGetMenuCount)
+		// An acknowledgement is not a count, and treating it as one would
+		// walk a menu of whatever the empty payload decoded to.
+		h.peer.send(req, codec.MsgAck, nil)
+
+		if err := <-done; !errors.Is(err, ErrUnexpectedReply) {
+			t.Errorf("err = %v, want ErrUnexpectedReply", err)
+		}
+	})
+
+	t.Run("malformed count", func(t *testing.T) {
+		h := newHarness(t, Config{})
+		s := h.callSession(t, codec.SvcMenus|codec.SvcLongStr)
+
+		done := make(chan error, 1)
+		go func() {
+			done <- WalkMenu32(context.Background(), s, 0, func(codec.MenuItem) error { return nil })
+		}()
+		req := h.peer.recvType(codec.MsgGetMenuCount)
+		h.peer.send(req, codec.MsgRetMenuCount, []byte{1, 2})
+
+		if err := <-done; !errors.Is(err, codec.ErrShortBuffer) {
+			t.Errorf("err = %v, want ErrShortBuffer", err)
+		}
+	})
+
+	t.Run("count refused", func(t *testing.T) {
+		h := newHarness(t, Config{})
+		s := h.callSession(t, codec.SvcMenus|codec.SvcLongStr)
+
+		done := make(chan error, 1)
+		go func() {
+			done <- WalkMenu32(context.Background(), s, 0, func(codec.MenuItem) error { return nil })
+		}()
+		req := h.peer.recvType(codec.MsgGetMenuCount)
+		h.peer.send(req, codec.MsgNack, nil)
+
+		if err := <-done; !errors.Is(err, ErrRefused) {
+			t.Errorf("err = %v, want ErrRefused", err)
+		}
+	})
+
+	t.Run("item refused", func(t *testing.T) {
+		h := newHarness(t, Config{})
+		s := h.callSession(t, codec.SvcMenus|codec.SvcLongStr)
+
+		done := make(chan error, 1)
+		go func() {
+			done <- WalkMenu32(context.Background(), s, 0, func(codec.MenuItem) error { return nil })
+		}()
+		req := h.peer.recvType(codec.MsgGetMenuCount)
+		h.peer.send(req, codec.MsgRetMenuCount, codec.MenuSize{MenuCount: 4}.AppendTo(nil))
+
+		item := h.peer.recvType(codec.MsgGetMenuItem)
+		h.peer.send(item, codec.MsgNack, nil)
+
+		err := <-done
+		if !errors.Is(err, ErrRefused) {
+			t.Errorf("err = %v, want ErrRefused", err)
+		}
+		if !contains(err.Error(), "item 1 of 4") {
+			t.Errorf("err = %q, want it to say which item failed", err)
+		}
+	})
+
+	t.Run("caller stops", func(t *testing.T) {
+		h := newHarness(t, Config{})
+		s := h.callSession(t, codec.SvcMenus|codec.SvcLongStr)
+
+		stop := errors.New("enough")
+		done := make(chan error, 1)
+		go func() {
+			done <- WalkMenu32(context.Background(), s, 0, func(codec.MenuItem) error { return stop })
+		}()
+		req := h.peer.recvType(codec.MsgGetMenuCount)
+		h.peer.send(req, codec.MsgRetMenuCount, codec.MenuSize{MenuCount: 500}.AppendTo(nil))
+
+		item := h.peer.recvType(codec.MsgGetMenuItem)
+		h.peer.send(item, codec.MsgRetMenuItem, make([]byte, codec.MenuItemSize))
+
+		if err := <-done; !errors.Is(err, stop) {
+			t.Errorf("err = %v, want the caller's own error", err)
+		}
+		h.peer.quiet()
+	})
+}
+
+// TestGetMenuItem covers fetching one line on its own, which is what a
+// back-channel update prompts: the peer says a line changed, and only that
+// line is re-read.
+func TestGetMenuItem(t *testing.T) {
+	h := newHarness(t, Config{})
+	s := h.callSession(t, codec.SvcMenus|codec.SvcLongStr)
+
+	type result struct {
+		item codec.MenuItem
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		m, err := GetMenuItem(context.Background(), s, 42)
+		done <- result{m, err}
+	}()
+
+	req := h.peer.recvType(codec.MsgGetMenuItem)
+	payload, err := codec.MenuItem{MenuIndex: 42, Text: "Gain"}.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	h.peer.send(req, codec.MsgRetMenuItem, payload)
+
+	r := <-done
+	if r.err != nil {
+		t.Fatalf("GetMenuItem: %v", r.err)
+	}
+	if r.item.MenuIndex != 42 || r.item.Text != "Gain" {
+		t.Errorf("= %+v", r.item)
+	}
+}
+
+func TestGetMenuItem_Errors(t *testing.T) {
+	h := newHarness(t, Config{})
+	s := h.callSession(t, codec.SvcMenus|codec.SvcLongStr)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := GetMenuItem(context.Background(), s, 1)
+		done <- err
+	}()
+	req := h.peer.recvType(codec.MsgGetMenuItem)
+	h.peer.send(req, codec.MsgAck, nil)
+
+	if err := <-done; !errors.Is(err, ErrUnexpectedReply) {
+		t.Errorf("err = %v, want ErrUnexpectedReply", err)
+	}
+
+	go func() {
+		_, err := GetMenuItem(context.Background(), s, 1)
+		done <- err
+	}()
+	req = h.peer.recvType(codec.MsgGetMenuItem)
+	h.peer.send(req, codec.MsgRetMenuItem, []byte{1, 2})
+
+	if err := <-done; !errors.Is(err, codec.ErrShortBuffer) {
+		t.Errorf("err = %v, want ErrShortBuffer", err)
+	}
+}

--- a/internal/snell-rollcall/session/session.go
+++ b/internal/snell-rollcall/session/session.go
@@ -1,0 +1,348 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"dhs/internal/snell-rollcall/codec"
+)
+
+// Session is one negotiated conversation with a peer: a set of services at a
+// user level, with a front channel we drive and a back channel the peer does.
+//
+// Two indices matter and confusing them is the defect this type exists to
+// prevent. localIndex is ours: we chose it, it goes in the source of every
+// message we send, and the peer must put it in the destination of every push.
+// remoteIndex is the peer's, learned from its acknowledgement, and it goes in
+// the destination of every message we send. Sending our own index where the
+// peer's belongs produces SP_INVSESS and, on the back channel, silently loses
+// every push.
+type Session struct {
+	link *Link
+
+	// peer is the device this session is with, without an index.
+	peer codec.Address
+
+	localIndex  int16
+	remoteIndex int16
+
+	services  codec.Service
+	userLevel codec.UserLevel
+
+	front *channel
+	back  *channel
+
+	// pushes carries back-channel messages to the application. Each one is a
+	// request the peer expects acknowledged, and the acknowledgement is what
+	// asks for the next, so a full queue is back pressure rather than an
+	// error.
+	pushes chan Push
+
+	mu     sync.Mutex
+	closed bool
+
+	closeOnce sync.Once
+}
+
+// Push is one back-channel message and the means to acknowledge it.
+type Push struct {
+	Frame codec.Frame
+
+	// ack acknowledges the push. It is called by the delivery loop once the
+	// application has taken the message, not by the application itself.
+	ack func() error
+}
+
+// Services returns the service mask this session negotiated.
+func (s *Session) Services() codec.Service { return s.services }
+
+// UserLevel returns the level this session was opened at. Menus and commands
+// above it are hidden rather than absent, so the level is part of what
+// identifies a cached device model.
+func (s *Session) UserLevel() codec.UserLevel { return s.userLevel }
+
+// LocalIndex is the session index we publish as our own.
+func (s *Session) LocalIndex() int16 { return s.localIndex }
+
+// RemoteIndex is the session index the peer assigned, which every message we
+// send must carry as its destination.
+func (s *Session) RemoteIndex() int16 { return s.remoteIndex }
+
+// Peer returns the address of the device on the other end, carrying the peer's
+// session index.
+func (s *Session) Peer() codec.Address {
+	a := s.peer
+	a.Index = s.remoteIndex
+	return a
+}
+
+// Pushes returns the back-channel stream. It is empty until the back channel
+// is enabled.
+func (s *Session) Pushes() <-chan Push { return s.pushes }
+
+// Uses32Bit reports whether this session negotiated the long-string
+// generation. It decides which message types every later request uses, and it
+// is a property of the session rather than of the device: the same unit serves
+// both, one session each.
+func (s *Session) Uses32Bit() bool { return s.services.LongStrings() }
+
+// Call opens a session with a peer.
+//
+// Services are all-or-nothing: a peer that cannot supply every requested bit
+// refuses the whole call rather than granting a subset. A client that wants to
+// fall back from the 32-bit generation therefore issues a second Call without
+// the long-string bit; it must not expect a partial grant.
+func Call(ctx context.Context, l *Link, peer codec.Address, services codec.Service,
+	level codec.UserLevel, caller codec.DeviceInfo) (*Session, error) {
+
+	if !level.Valid() {
+		return nil, fmt.Errorf("rollcall: call: user level %d is not one a client may request", level)
+	}
+
+	payload, err := codec.Connect{
+		Services:  services,
+		UserLevel: level,
+		Caller:    caller,
+	}.AppendTo(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &Session{
+		link:        l,
+		peer:        peer.Device(),
+		remoteIndex: codec.IndexUnknown,
+		services:    services,
+		userLevel:   level,
+		pushes:      make(chan Push, l.cfg.pushQueue()),
+	}
+	s.front = newChannel("front", l.clk, l.cfg.replyTimeout(), l.cfg.maxStrikes())
+	s.back = newChannel("back", l.clk, l.cfg.replyTimeout(), l.cfg.maxStrikes())
+
+	// Registered before the Call goes out: the acknowledgement is addressed
+	// to our index, so the session has to be findable when it arrives.
+	if err := l.register(s); err != nil {
+		return nil, err
+	}
+	idx := s.localIndex
+
+	// The destination index is the unconnected one: there is no session yet,
+	// and 255 is what says so. Writing "unknown" as -1 puts 0xFFFF on the
+	// wire, which a proxy answers and a real device faults on.
+	req := codec.Frame{
+		Dst:     addrWithIndex(peer, codec.IndexUnknown),
+		Src:     addrWithIndex(l.LocalAddress(), idx),
+		Type:    codec.MsgCall,
+		Payload: payload,
+	}
+
+	reply, err := l.exchange(ctx, s.front, req)
+	if err != nil {
+		l.removeSession(idx)
+		return nil, err
+	}
+	if reply.Type != codec.MsgAck {
+		l.removeSession(idx)
+		return nil, protocolError("call", reply)
+	}
+
+	// The peer's index arrives as the source of its acknowledgement. It is
+	// sticky for the life of the session.
+	s.remoteIndex = reply.Src.Index
+	s.peer = reply.Src.Device()
+
+	// A gateway rewrites our zeroed source into the address it assigned us.
+	// Learning it here is what lets every later frame carry a real source.
+	if l.LocalAddress().Unit == 0 && reply.Dst.Unit != 0 {
+		l.SetLocalAddress(reply.Dst)
+	}
+	return s, nil
+}
+
+// Do sends a request on the front channel and returns the reply.
+//
+// It fills in the addressing, so a caller supplies only the type and payload
+// and cannot get the indices the wrong way round.
+func (s *Session) Do(ctx context.Context, typ codec.PacketType, payload []byte) (codec.Frame, error) {
+	return s.do(ctx, s.front, 0, typ, payload)
+}
+
+// Reply answers a back-channel push. Providers use it; a consumer's pushes are
+// acknowledged for it by the delivery loop.
+func (s *Session) Reply(typ codec.PacketType, payload []byte) error {
+	return s.link.send(s.frame(codec.FlagBackChannel, typ, payload))
+}
+
+// Push sends an unsolicited message on the back channel and waits for the
+// peer to acknowledge it.
+//
+// Every push is an active message: the next may not be sent until this one is
+// answered. That is why this blocks, and why a provider with a burst of
+// changes queues them rather than writing them all to the socket.
+func (s *Session) Push(ctx context.Context, typ codec.PacketType, payload []byte) error {
+	_, err := s.do(ctx, s.back, codec.FlagBackChannel, typ, payload)
+	return err
+}
+
+func (s *Session) do(ctx context.Context, ch *channel, flags uint8,
+	typ codec.PacketType, payload []byte) (codec.Frame, error) {
+
+	if s.isClosed() {
+		return codec.Frame{}, ErrSessionClosed
+	}
+
+	reply, err := s.link.exchange(ctx, ch, s.frame(flags, typ, payload))
+	if err != nil {
+		return codec.Frame{}, err
+	}
+	switch reply.Type {
+	case codec.MsgNack, codec.MsgInvCmd, codec.MsgInvSess, codec.MsgBusy:
+		return reply, protocolError(typ.String(), reply)
+	default:
+		return reply, nil
+	}
+}
+
+// frame builds an outbound frame with this session's addressing.
+func (s *Session) frame(flags uint8, typ codec.PacketType, payload []byte) codec.Frame {
+	return codec.Frame{
+		Dst:     addrWithIndex(s.peer, s.remoteIndex),
+		Src:     addrWithIndex(s.link.LocalAddress(), s.localIndex),
+		Type:    typ,
+		Flags:   flags,
+		Payload: payload,
+	}
+}
+
+// receive routes a frame the link matched to this session.
+func (s *Session) receive(f codec.Frame) {
+	if f.BackChannel() {
+		// A back-channel frame is either the peer's answer to something we
+		// pushed, or a push of its own.
+		if s.back.busy() && s.back.deliver(f) {
+			return
+		}
+		s.receivePush(f)
+		return
+	}
+	if s.front.deliver(f) {
+		return
+	}
+	// A front-channel frame answering nothing is the peer talking out of
+	// turn. Announcements and display updates arrive this way from some
+	// units, so it is surfaced rather than dropped.
+	s.link.deliverUnsolicited(f)
+}
+
+// receivePush queues a back-channel push for the application.
+//
+// The acknowledgement is deliberately not sent here. It is what asks the peer
+// for the next push, so sending it before the application has taken this one
+// throws away the flow control the protocol provides. If the queue is full the
+// push is dropped and not acknowledged, which stalls the peer rather than
+// letting it run ahead of a reader that cannot keep up.
+func (s *Session) receivePush(f codec.Frame) {
+	p := Push{Frame: f, ack: func() error { return s.Reply(codec.MsgAck, nil) }}
+	select {
+	case s.pushes <- p:
+	default:
+		s.link.log.Warn("rollcall: back-channel queue full, push withheld",
+			"type", f.Type.String(), "peer", s.peer.String())
+	}
+}
+
+// Ack acknowledges a push. A consumer calls it once it has taken the message;
+// until it does, the peer will not send another.
+func (p Push) Ack() error { return p.ack() }
+
+// EnableBackChannel turns the back channel on.
+//
+// Two messages are needed, and the second is easy to forget: BkChnReady opens
+// the channel, and control-value pushes additionally require ReportChange.
+// With only the first, a session looks subscribed and never receives a value.
+//
+// On enable the peer flushes every changed value, so a burst follows
+// immediately; that is the specification's behaviour, not a fault.
+func (s *Session) EnableBackChannel(ctx context.Context, reportValues bool) error {
+	if _, err := s.Do(ctx, codec.MsgBkChnReady, []byte{codec.BackChannelEnable}); err != nil {
+		return err
+	}
+	if !reportValues {
+		return nil
+	}
+	return s.reportChange(ctx, codec.ReportAllCommands)
+}
+
+// DisableBackChannel closes the back channel again.
+func (s *Session) DisableBackChannel(ctx context.Context) error {
+	_, err := s.Do(ctx, codec.MsgBkChnReady, []byte{codec.BackChannelDisable})
+	return err
+}
+
+// reportChange asks for value pushes. The wildcard command asks for all of
+// them, which every server honours; per-command selection is optional and not
+// every server implements it.
+func (s *Session) reportChange(ctx context.Context, command uint16) error {
+	_, err := s.Do(ctx, codec.MsgRepFChg, []byte{byte(command >> 8), byte(command)})
+	return err
+}
+
+// Term ends the session.
+//
+// It is always sent, on close, on error and on cancellation. Servers do not
+// time idle sessions out — the vendor's own comments warn that units "don't
+// time them out very well (at all), and then run out of available sessions" —
+// so a session we abandon is leaked until the unit reboots.
+func (s *Session) Term(ctx context.Context, code codec.TermCode, reason string) error {
+	var err error
+	s.closeOnce.Do(func() {
+		payload, perr := codec.TermSess{Code: code, Reason: reason}.AppendTo(nil)
+		if perr != nil {
+			// A reason too long for the field must not stop the session
+			// being closed; the code alone is what the peer acts on.
+			payload, _ = codec.TermSess{Code: code}.AppendTo(nil)
+		}
+
+		// Term is sent directly rather than through the channel. The slot may
+		// be held by a request that will never be answered, and waiting for
+		// it is how a session ends up abandoned instead of closed.
+		err = s.link.send(s.frame(0, codec.MsgTerm, payload))
+		s.shutdown(ErrSessionClosed)
+	})
+	return err
+}
+
+// Close terminates the session with the ordinary user code.
+func (s *Session) Close() error {
+	return s.Term(context.Background(), codec.TermUser, "")
+}
+
+// linkClosed shuts the session down because the link underneath it went away.
+// No Term is sent: there is nothing left to send it on.
+func (s *Session) linkClosed(err error) {
+	s.closeOnce.Do(func() { s.shutdown(err) })
+}
+
+func (s *Session) shutdown(err error) {
+	s.mu.Lock()
+	s.closed = true
+	s.mu.Unlock()
+
+	s.front.closeWith(err)
+	s.back.closeWith(err)
+	s.link.removeSession(s.localIndex)
+	close(s.pushes)
+}
+
+func (s *Session) isClosed() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closed
+}
+
+// addrWithIndex returns a copy of a carrying the given session index.
+func addrWithIndex(a codec.Address, idx int16) codec.Address {
+	a.Index = idx
+	return a
+}

--- a/internal/snell-rollcall/session/session_test.go
+++ b/internal/snell-rollcall/session/session_test.go
@@ -1,0 +1,396 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"dhs/internal/snell-rollcall/codec"
+)
+
+// TestCall_StickyIndices is the defect this package was shaped to prevent.
+//
+// Two session indices exist and they are not interchangeable. Ours goes in the
+// source of everything we send and in the destination of everything the peer
+// pushes. The peer's, learned from its acknowledgement, goes in the
+// destination of everything we send. Swapping them produced SP_INVSESS during
+// the audit and silently lost every back-channel push.
+func TestCall_StickyIndices(t *testing.T) {
+	h := newHarness(t, Config{})
+
+	type result struct {
+		s   *Session
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		s, err := Call(context.Background(), h.link, peerAddr,
+			codec.SvcMenus|codec.SvcControl, codec.LevelSupervisor,
+			ClientIdentity("dhs", codec.SvcMenus))
+		done <- result{s, err}
+	}()
+
+	req := h.peer.recvType(codec.MsgCall)
+
+	// The call goes to the unconnected index, because there is no session
+	// yet, and carries our chosen index as its source.
+	if req.Dst.Index != codec.IndexUnknown {
+		t.Errorf("Call destination index = %d, want %d (UNKNOWNSESS)",
+			req.Dst.Index, codec.IndexUnknown)
+	}
+	ourIndex := req.Src.Index
+	if ourIndex == codec.IndexUnknown || ourIndex == codec.IndexBlind {
+		t.Fatalf("Call source index = %d, want a real allocated index", ourIndex)
+	}
+
+	// The peer answers from its own index, which is deliberately different.
+	const peerIndex int16 = 0x2A
+	h.peer.write(codec.Frame{
+		Dst:  addrWithIndex(req.Src, ourIndex),
+		Src:  addrWithIndex(peerAddr, peerIndex),
+		Type: codec.MsgAck,
+	})
+
+	r := <-done
+	if r.err != nil {
+		t.Fatalf("Call: %v", r.err)
+	}
+	s := r.s
+
+	if s.LocalIndex() != ourIndex {
+		t.Errorf("LocalIndex = %d, want %d", s.LocalIndex(), ourIndex)
+	}
+	if s.RemoteIndex() != peerIndex {
+		t.Errorf("RemoteIndex = %d, want %d", s.RemoteIndex(), peerIndex)
+	}
+
+	// Every later message must carry the peer's index as its destination and
+	// ours as its source.
+	go func() { _, _ = s.Do(context.Background(), codec.MsgGetStat, nil) }()
+	next := h.peer.recvType(codec.MsgGetStat)
+
+	if next.Dst.Index != peerIndex {
+		t.Errorf("destination index = %d, want the peer's %d", next.Dst.Index, peerIndex)
+	}
+	if next.Src.Index != ourIndex {
+		t.Errorf("source index = %d, want ours %d", next.Src.Index, ourIndex)
+	}
+}
+
+// TestCall_ServicesAreAllOrNothing pins the negotiation rule. A peer that
+// cannot supply every requested bit refuses the whole call, so a client
+// wanting to fall back from the 32-bit generation must issue a second call
+// without the long-string bit rather than expect a partial grant.
+func TestCall_ServicesAreAllOrNothing(t *testing.T) {
+	h := newHarness(t, Config{})
+
+	want := codec.SvcMenus | codec.SvcControl | codec.SvcLongStr
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := Call(context.Background(), h.link, peerAddr, want,
+			codec.LevelSupervisor, ClientIdentity("dhs", want))
+		errCh <- err
+	}()
+
+	req := h.peer.recvType(codec.MsgCall)
+	conn, err := codec.DecodeConnect(req.Payload)
+	if err != nil {
+		t.Fatalf("DecodeConnect: %v", err)
+	}
+	if conn.Services != want {
+		t.Errorf("requested %s, want %s", conn.Services, want)
+	}
+	if conn.UserLevel != codec.LevelSupervisor {
+		t.Errorf("user level = %s, want supervisor", conn.UserLevel)
+	}
+
+	// A peer without long strings refuses the whole thing.
+	h.peer.send(req, codec.MsgNack, []byte("no long strings\x00"))
+
+	err = <-errCh
+	if !errors.Is(err, ErrRefused) {
+		t.Fatalf("err = %v, want ErrRefused", err)
+	}
+	var pe *ProtocolError
+	if !errors.As(err, &pe) || pe.Detail != "no long strings" {
+		t.Errorf("err = %v, want the peer's text carried through", err)
+	}
+
+	// The refused session must not be left registered on the link.
+	if n := h.link.SessionCount(); n != 0 {
+		t.Errorf("link holds %d sessions after a refused call", n)
+	}
+
+	// The second call, without the bit, is what a client does next.
+	s := h.callSession(t, codec.SvcMenus|codec.SvcControl)
+	if s.Uses32Bit() {
+		t.Error("the fallback session must not claim the 32-bit generation")
+	}
+}
+
+func TestCall_Busy(t *testing.T) {
+	h := newHarness(t, Config{})
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := Call(context.Background(), h.link, peerAddr, codec.SvcMenus,
+			codec.LevelUser, ClientIdentity("dhs", codec.SvcMenus))
+		errCh <- err
+	}()
+
+	req := h.peer.recvType(codec.MsgCall)
+
+	// Busy may name who holds the session, as an ID_STR.
+	id, err := codec.ID{Name: "Control Panel"}.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	h.peer.send(req, codec.MsgBusy, id)
+
+	err = <-errCh
+	if !errors.Is(err, ErrBusy) {
+		t.Fatalf("err = %v, want ErrBusy", err)
+	}
+	var pe *ProtocolError
+	if !errors.As(err, &pe) || pe.Detail != "Control Panel" {
+		t.Errorf("err = %v, want it to name who holds the session", err)
+	}
+	// Busy is worth retrying, unlike a refusal.
+	if errors.Is(err, ErrRefused) {
+		t.Error("busy must not read as a refusal")
+	}
+}
+
+func TestCall_RejectsAnImpossibleLevel(t *testing.T) {
+	h := newHarness(t, Config{})
+
+	// LevelAll is a mask value the vendor engine rejects outright, so sending
+	// it wastes a round trip and a session slot.
+	_, err := Call(context.Background(), h.link, peerAddr, codec.SvcMenus,
+		codec.LevelAll, ClientIdentity("dhs", codec.SvcMenus))
+	if err == nil {
+		t.Fatal("a level above factory must be refused before it is sent")
+	}
+	h.peer.quiet()
+}
+
+// TestSession_Generations covers the property that decides which message types
+// every later request uses. It belongs to the session, not the device: the
+// same unit serves both, one session each.
+func TestSession_Generations(t *testing.T) {
+	h := newHarness(t, Config{})
+
+	gen16 := h.callSession(t, codec.SvcMenus|codec.SvcControl)
+	if gen16.Uses32Bit() {
+		t.Error("a session without the long-string bit is the 16-bit generation")
+	}
+
+	gen32 := h.callSession(t, codec.SvcMenus|codec.SvcControl|codec.SvcLongStr)
+	if !gen32.Uses32Bit() {
+		t.Error("a session with the long-string bit is the 32-bit generation")
+	}
+
+	// Both live on one link, with distinct indices.
+	if gen16.LocalIndex() == gen32.LocalIndex() {
+		t.Error("two sessions on one link share an index")
+	}
+	if n := h.link.SessionCount(); n != 2 {
+		t.Errorf("link holds %d sessions, want 2", n)
+	}
+}
+
+// TestSession_Do covers an ordinary request and the refusals that are not
+// errors of ours. Nack and InvCmd are different failures: one means the peer
+// will not, the other that it cannot understand, and a client that treats them
+// alike either retries forever or gives up too early.
+func TestSession_Do(t *testing.T) {
+	h := newHarness(t, Config{})
+	s := h.callSession(t, codec.SvcControl)
+
+	tests := []struct {
+		name  string
+		reply codec.PacketType
+		want  error
+	}{
+		{"answered", codec.MsgRetFStat, nil},
+		{"refused", codec.MsgNack, ErrRefused},
+		{"not implemented", codec.MsgInvCmd, ErrNotUnderstood},
+		{"bad session", codec.MsgInvSess, ErrInvalidSession},
+		{"busy", codec.MsgBusy, ErrBusy},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			type result struct {
+				f   codec.Frame
+				err error
+			}
+			done := make(chan result, 1)
+			go func() {
+				f, err := s.Do(context.Background(), codec.MsgGetFStat, []byte{0, 1})
+				done <- result{f, err}
+			}()
+
+			req := h.peer.recvType(codec.MsgGetFStat)
+			h.peer.send(req, tc.reply, nil)
+
+			r := <-done
+			if tc.want == nil {
+				if r.err != nil {
+					t.Fatalf("Do: %v", r.err)
+				}
+				if r.f.Type != tc.reply {
+					t.Errorf("reply = %s, want %s", r.f.Type, tc.reply)
+				}
+				return
+			}
+			if !errors.Is(r.err, tc.want) {
+				t.Errorf("err = %v, want %v", r.err, tc.want)
+			}
+			// The frame comes back even on a refusal, so a caller can read
+			// whatever the peer put in it.
+			if r.f.Type != tc.reply {
+				t.Errorf("reply frame = %s, want %s", r.f.Type, tc.reply)
+			}
+		})
+	}
+}
+
+// TestSession_TermIsAlwaysSent pins the rule that keeps units usable. Servers
+// do not time idle sessions out, so a session we abandon is leaked until the
+// unit reboots.
+func TestSession_TermIsAlwaysSent(t *testing.T) {
+	h := newHarness(t, Config{})
+	s := h.callSession(t, codec.SvcMenus)
+
+	if err := s.Term(context.Background(), codec.TermUser, "done"); err != nil {
+		t.Fatalf("Term: %v", err)
+	}
+
+	f := h.peer.recvType(codec.MsgTerm)
+	ts, err := codec.DecodeTermSess(f.Payload)
+	if err != nil {
+		t.Fatalf("DecodeTermSess: %v", err)
+	}
+	if ts.Code != codec.TermUser || ts.Reason != "done" {
+		t.Errorf("= %+v, want the user code and reason", ts)
+	}
+	if f.Dst.Index != s.RemoteIndex() {
+		t.Errorf("Term destination index = %d, want the peer's %d", f.Dst.Index, s.RemoteIndex())
+	}
+
+	// The session is gone from the link and refuses further work.
+	if n := h.link.SessionCount(); n != 0 {
+		t.Errorf("link still holds %d sessions", n)
+	}
+	if _, err := s.Do(context.Background(), codec.MsgGetStat, nil); !errors.Is(err, ErrSessionClosed) {
+		t.Errorf("err = %v, want ErrSessionClosed", err)
+	}
+
+	// Terminating twice sends one Term. A second would be answered with
+	// InvSess by a peer that already freed the session.
+	if err := s.Close(); err != nil {
+		t.Errorf("Close after Term: %v", err)
+	}
+	h.peer.quiet()
+}
+
+// TestSession_TermSurvivesAnOverlongReason covers a caller passing a reason too
+// long for the twenty-byte field. The code is what the peer acts on, so the
+// session must still be closed rather than left behind over a label.
+func TestSession_TermSurvivesAnOverlongReason(t *testing.T) {
+	h := newHarness(t, Config{})
+	s := h.callSession(t, codec.SvcMenus)
+
+	long := "a reason far longer than the field can carry"
+	if err := s.Term(context.Background(), codec.TermNetError, long); err != nil {
+		t.Fatalf("Term: %v", err)
+	}
+
+	f := h.peer.recvType(codec.MsgTerm)
+	ts, err := codec.DecodeTermSess(f.Payload)
+	if err != nil {
+		t.Fatalf("DecodeTermSess: %v", err)
+	}
+	if ts.Code != codec.TermNetError {
+		t.Errorf("code = %s, want net-error", ts.Code)
+	}
+	if ts.Reason != "" {
+		t.Errorf("reason = %q, want it dropped rather than the Term abandoned", ts.Reason)
+	}
+}
+
+// TestSession_TermWhileARequestIsPending covers the case the vendor gets
+// wrong. A request that will never be answered holds the one-in-flight slot;
+// waiting for it is how a session ends up abandoned instead of closed, so Term
+// is sent directly.
+func TestSession_TermWhileARequestIsPending(t *testing.T) {
+	h := newHarness(t, Config{})
+	s := h.callSession(t, codec.SvcControl)
+
+	go func() { _, _ = s.Do(context.Background(), codec.MsgGetStat, nil) }()
+	h.peer.recvType(codec.MsgGetStat) // never answered
+
+	if err := s.Term(context.Background(), codec.TermUser, ""); err != nil {
+		t.Fatalf("Term with a request pending: %v", err)
+	}
+	h.peer.recvType(codec.MsgTerm)
+}
+
+func TestSession_Peer(t *testing.T) {
+	h := newHarness(t, Config{})
+	s := h.callSession(t, codec.SvcMenus)
+
+	p := s.Peer()
+	if p.Unit != peerAddr.Unit {
+		t.Errorf("Peer unit = %02X, want %02X", p.Unit, peerAddr.Unit)
+	}
+	if p.Index != s.RemoteIndex() {
+		t.Errorf("Peer index = %d, want the peer's session index %d", p.Index, s.RemoteIndex())
+	}
+	if s.Services() != codec.SvcMenus {
+		t.Errorf("Services = %s", s.Services())
+	}
+	if s.UserLevel() != codec.LevelSupervisor {
+		t.Errorf("UserLevel = %s, want supervisor", s.UserLevel())
+	}
+}
+
+// TestSession_LinkClosedWakesEveryone covers a link dying under its sessions.
+// A caller blocked on a request must learn immediately rather than wait out
+// its own timeout, and no Term is attempted because there is nothing to send
+// it on.
+func TestSession_LinkClosedWakesEveryone(t *testing.T) {
+	h := newHarness(t, Config{})
+	s := h.callSession(t, codec.SvcControl)
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := s.Do(context.Background(), codec.MsgGetStat, nil)
+		errCh <- err
+	}()
+	h.peer.recvType(codec.MsgGetStat)
+
+	_ = h.link.Close()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("the pending request should have failed")
+		}
+		if !errors.Is(err, ErrLinkClosed) {
+			t.Errorf("err = %v, want ErrLinkClosed", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("a pending request was not woken when the link closed")
+	}
+
+	if !errors.Is(h.link.Err(), ErrLinkClosed) {
+		t.Errorf("link error = %v, want ErrLinkClosed", h.link.Err())
+	}
+	select {
+	case <-h.link.Done():
+	default:
+		t.Error("Done was not closed")
+	}
+}


### PR DESCRIPTION
Closes #1018. Part of #1009 (unit 4 of 10).

Stacked on #1017. It retargets automatically as the one below it merges.

## What this is

The protocol state machine. It sits below `consumer/` and `provider/` because
it is the same machine on both sides with the roles exchanged: a link carrying
frames, sessions multiplexed over it by index, one message in flight per
channel, and a back channel whose pushes are themselves requests. The vendor's
own `Core/` is organised the same way for the same reason.

It is handed a `net.Conn` and never opens one. Every test runs over `net.Pipe`
with no socket, no port and no listener, and time comes from the injected
clock, so a three-second timeout is tested by advancing a fake rather than by
waiting three seconds. There is no `time.Sleep` in the package's logic, and
none in its tests except the poll that waits for a timer to be armed.

## The rule everything else follows

One message in flight per channel per session. A peer matches replies
head-of-queue, so two requests on the wire at once are not merely reordered,
they are answered to the wrong caller. Acquiring the slot is the only way to
send, which makes the rule structural rather than a convention every call site
has to remember.

The keepalive probe obeys it too. Injecting a probe beside a pending request
is not a shortcut, it is the same bug.

## Five behaviours the vendor gets wrong or leaves out

**Wait extends the deadline.** The vendor library answers Nack to it and never
implements the extension, so a server that asks for more time is abandoned
mid-operation and its session is left behind.

**Term is always sent** — on close, on error, on cancellation. And directly,
not through a queue slot that a request which will never be answered may still
be holding: waiting for that slot is exactly how a session ends up abandoned
instead of closed. Servers do not time idle sessions out, which the vendor's
own source comments warn about, so a session we walk away from is leaked until
the unit reboots.

**Five consecutive failures end a session and say so.** The vendor drops it
without sending Term, which is how units run out of sessions.

**A push is acknowledged by the application, not on its behalf.** The
acknowledgement is what asks for the next push, so sending it before the
application has taken this one throws away the only flow control the protocol
offers. A full queue withholds acknowledgements and stalls the peer, which is
what the protocol intends.

**The two session indices are not interchangeable.** Ours goes in the source
of what we send and the destination of what is pushed to us. The peer's, from
its acknowledgement, goes in the destination of what we send. Swapping them
produced SP_INVSESS during the audit and silently lost every back-channel push.
There is a test for each of the three ways it went wrong.

## Address rewriting

A TCP client knows neither address. Its own is assigned by the gateway, which
stamps a port drawn from its connection slots over the zeroed source we send;
the gateway's own is wherever the reply comes from. `Handshake` learns both,
and a peer that skips this is rejected by real gateways and by the Control
Panel.

Both are read from the frame header, never from the DeviceInfo payload: the
address inside one is not rewritten as a message crosses a bridge, so its
route is meaningless. There is a test with a payload and a header that
disagree.

## Keepalive, measured rather than inferred

From the audit against the live stack:

| Probe | Direct to the device | Via the proxy |
| --- | --- | --- |
| KeepAlive on the unconnected index | Ack, 4 ms | Ack, 4 ms |
| KeepAlive on a connected session | Ack, 4 ms | Ack, 4 ms |
| Unsolicited frames during 90 s idle | 0 | 0 |
| Session alive after 90 s of silence | yes | yes |

Zero unsolicited traffic means silence carries no information, so liveness has
to be probed. The probe goes on the session when there is one, because that
proves the session still exists and the session is what actually breaks.
Defaults: every 15 s, 3 s per probe, three misses ends the link.

## Two defects fixed while building it

**The reply deadline leaked a timer per Wait.** It used `After` in a retry
loop, so every extension left an armed timer behind until it fired. It is now
a stoppable timer. That also let the tests assert an exact armed-timer count
rather than a minimum, which is what makes them deterministic.

**Allocating an index and registering the session were two steps.** Between
them was a window in which the peer's acknowledgement, which is addressed to
that index, could arrive with nothing listening on it. They are now one
operation under one lock.

## Verification

```
ok  dhs/internal/snell-rollcall/session   coverage: 100.0% of statements
```

- 87 tests, 100% statement coverage, added to the CI floor.
- Ten consecutive runs, no flake.
- Imports `context`, `net`, `sync`, `time` and four dhs packages: codec, clock,
  metrics and the dependency set. It cannot reach `consumer/` or `provider/`,
  and they cannot reach each other.
- Builds for five OS/arch pairs with cgo disabled.

## Also in this PR

Two codec helpers are exported because the session layer needs them:
`CString`, for the optional text a Nack or a Wait may carry, and
`TruncateFixed`, for naming ourselves in an identity a peer will display. A
client that cannot connect because its own name is long is a worse outcome
than one that appears under a shortened name.

## Not in this PR

The verbs. This package hands you a session you can send a request on and
receive a push from; deciding which requests to send is the consumer's job,
and answering them is the provider's. Those are units 5 and 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
