### PR TITLE
feat(snell-rollcall): codec part 3 — complete the spec: file, time, log, stream, display, group

### DIFF
--- a/internal/snell-rollcall/codec/payload_file.go
+++ b/internal/snell-rollcall/codec/payload_file.go
@@ -1,0 +1,325 @@
+package codec
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// Wire sizes of the file service structures (RC3FILE.H).
+const (
+	// FileSize is FILE_STR, the structure every file operation carries.
+	FileSize = 10
+
+	// FileInfoSize is FILEINFOHDR_STR, one directory entry's metadata.
+	FileInfoSize = 10
+
+	// FileNameSize is FILENAMESIZE: the fixed filename field in a directory
+	// entry. It is a DOS 8.3 name with its terminator.
+	FileNameSize = 13
+
+	// DirEntrySize is MODULE_FILEINFO_STR as it appears on the wire.
+	//
+	// The header plus the filename is 23 bytes of content, but the structure
+	// is compiled under #pragma pack(2) and so is padded to an even size, and
+	// senders use sizeof. The pad byte's content is undefined, exactly like
+	// the one in GetNext, and must never be reported as a deviation.
+	DirEntrySize = 24
+
+	// MaxFileName is the longest path the file service accepts, from
+	// RC3FILE.H MAX_FILENAME. Paths travel as NUL-terminated strings in the
+	// payload rather than in the fixed field, which is only used by directory
+	// listings.
+	MaxFileName = 131
+)
+
+// File open flags (RC3FILE.H FileOpenFlags). They mirror the C runtime's
+// open(2) flags, because that is what the vendor implementation passes them to.
+const (
+	OpenReadOnly  uint16 = 0x0000
+	OpenWriteOnly uint16 = 0x0001
+	OpenReadWrite uint16 = 0x0002
+	OpenAppend    uint16 = 0x0008
+	OpenCreate    uint16 = 0x0100
+	OpenTruncate  uint16 = 0x0200
+	OpenExclusive uint16 = 0x0400
+	OpenText      uint16 = 0x4000
+
+	// OpenBinary must be set for anything that is not line-oriented text.
+	// Without it the peer translates line endings, which corrupts a names
+	// file or a template archive silently.
+	OpenBinary uint16 = 0x8000
+)
+
+// File attribute flags (RC3FILE.H AttributeFlags).
+const (
+	AttrNormal   uint16 = 0x0000
+	AttrReadOnly uint16 = 0x0001
+	AttrHidden   uint16 = 0x0002
+	AttrSystem   uint16 = 0x0004
+	AttrVolumeID uint16 = 0x0008
+	AttrSubdir   uint16 = 0x0010
+	AttrArchive  uint16 = 0x0020
+
+	// AttrDOSFileTime says the time field is in MS-DOS date and time format
+	// rather than seconds. It is a flag about the encoding of another field,
+	// which is why it sits oddly high among the attribute bits.
+	AttrDOSFileTime uint16 = 0x1000
+	AttrRecord      uint16 = 0x2000
+	AttrWriteOnly   uint16 = 0x4000
+)
+
+// File service error values (RC3FILE.H ErrorValues). They are C errno numbers,
+// carried in the Extra field of a reply.
+const (
+	FileErrNoEntry     int16 = 2   // no such file or directory
+	FileErrAccess      int16 = 13  // mode incompatible with the request
+	FileErrExists      int16 = 17  // create-exclusive on a file that is there
+	FileErrInvalid     int16 = 22  // an invalid flag combination
+	FileErrTooManyOpen int16 = 24  // no file handles left
+	FileErrNoSpace     int16 = 28  // no space
+	FileErrBadType     int16 = 129 // bad runtime file type
+)
+
+// FileErrorName renders a file service error value.
+func FileErrorName(v int16) string {
+	switch v {
+	case 0:
+		return "ok"
+	case FileErrNoEntry:
+		return "no such file or directory"
+	case FileErrAccess:
+		return "access denied"
+	case FileErrExists:
+		return "already exists"
+	case FileErrInvalid:
+		return "invalid argument"
+	case FileErrTooManyOpen:
+		return "no file handles left"
+	case FileErrNoSpace:
+		return "no space"
+	case FileErrBadType:
+		return "bad file type"
+	default:
+		return fmt.Sprintf("error(%d)", v)
+	}
+}
+
+// Seek origins for the Extra field of a read or write.
+const (
+	SeekStart   int16 = 0
+	SeekCurrent int16 = 1
+	SeekEnd     int16 = 2
+)
+
+// File is FILE_STR, the structure every file operation carries.
+//
+// The two handles are what make the service work across a network where both
+// ends allocate independently: SrcHandle is the requester's own reference,
+// echoed back untouched so a reply can be matched, and FileHandle is the
+// server's, valid only on that server.
+//
+// Offset and Extra are overloaded by operation, which is the awkward part of
+// this structure and the reason the helpers below exist:
+//
+//	Open    Offset holds the open flags, Extra is unused
+//	Read    Offset is where to read from, Extra is the seek origin
+//	Write   Offset is where to write to, Extra is the seek origin
+//	replies Offset is the length or position reached, Extra is the error
+type File struct {
+	SrcHandle  int16
+	FileHandle int16
+	Offset     int32
+	Extra      int16
+}
+
+func (f File) String() string {
+	return fmt.Sprintf("src=%d file=%d off=%d extra=%d",
+		f.SrcHandle, f.FileHandle, f.Offset, f.Extra)
+}
+
+// Err returns the error a reply carries, or nil. A negative or zero Extra is
+// not an error: only the documented errno values are.
+func (f File) Err() error {
+	if f.Extra <= 0 {
+		return nil
+	}
+	return fmt.Errorf("rollcall file: %s", FileErrorName(f.Extra))
+}
+
+// AppendTo appends the 10-byte wire form.
+func (f File) AppendTo(dst []byte) []byte {
+	var b [FileSize]byte
+	binary.BigEndian.PutUint16(b[0:2], uint16(f.SrcHandle))
+	binary.BigEndian.PutUint16(b[2:4], uint16(f.FileHandle))
+	binary.BigEndian.PutUint32(b[4:8], uint32(f.Offset))
+	binary.BigEndian.PutUint16(b[8:10], uint16(f.Extra))
+	return append(dst, b[:]...)
+}
+
+// DecodeFile reads a FILE_STR from the front of b.
+func DecodeFile(b []byte) (File, error) {
+	if err := need(b, FileSize, "File", ""); err != nil {
+		return File{}, err
+	}
+	return File{
+		SrcHandle:  int16(binary.BigEndian.Uint16(b[0:2])),
+		FileHandle: int16(binary.BigEndian.Uint16(b[2:4])),
+		Offset:     int32(binary.BigEndian.Uint32(b[4:8])),
+		Extra:      int16(binary.BigEndian.Uint16(b[8:10])),
+	}, nil
+}
+
+// AppendFileOpen builds the payload of a file open: the structure with the
+// flags in Offset, then the path as a NUL-terminated string.
+//
+// Set OpenBinary for anything that is not line-oriented text. Without it the
+// peer translates line endings, which corrupts a names file or a template
+// archive without reporting anything.
+func AppendFileOpen(dst []byte, srcHandle int16, flags uint16, path string) ([]byte, error) {
+	if len(path) > MaxFileName-1 {
+		return nil, fmt.Errorf("%w: path %d bytes, limit %d",
+			ErrStringTooLong, len(path), MaxFileName-1)
+	}
+	dst = File{SrcHandle: srcHandle, Offset: int32(flags)}.AppendTo(dst)
+	dst = append(dst, path...)
+	return append(dst, 0), nil
+}
+
+// DecodeFileOpen reads a file open request: the structure and the path.
+func DecodeFileOpen(b []byte) (File, string, error) {
+	f, err := DecodeFile(b)
+	if err != nil {
+		return File{}, "", err
+	}
+	path, _ := CString(b[FileSize:])
+	return f, path, nil
+}
+
+// AppendFilePath builds the payload of an operation that names a path rather
+// than a handle: directory listing, delete, and make directory.
+func AppendFilePath(dst []byte, srcHandle int16, path string) ([]byte, error) {
+	if len(path) > MaxFileName-1 {
+		return nil, fmt.Errorf("%w: path %d bytes, limit %d",
+			ErrStringTooLong, len(path), MaxFileName-1)
+	}
+	dst = File{SrcHandle: srcHandle}.AppendTo(dst)
+	dst = append(dst, path...)
+	return append(dst, 0), nil
+}
+
+// AppendFileRename builds a rename: the structure, then the old and new paths
+// as two NUL-terminated strings.
+func AppendFileRename(dst []byte, srcHandle int16, from, to string) ([]byte, error) {
+	if len(from)+len(to) > MaxFileName-2 {
+		return nil, fmt.Errorf("%w: rename paths total %d bytes, limit %d",
+			ErrStringTooLong, len(from)+len(to), MaxFileName-2)
+	}
+	dst = File{SrcHandle: srcHandle}.AppendTo(dst)
+	dst = append(dst, from...)
+	dst = append(dst, 0)
+	dst = append(dst, to...)
+	return append(dst, 0), nil
+}
+
+// DecodeFileRename reads a rename request.
+func DecodeFileRename(b []byte) (f File, from, to string, err error) {
+	if f, err = DecodeFile(b); err != nil {
+		return File{}, "", "", err
+	}
+	rest := b[FileSize:]
+	from, n := CString(rest)
+	if n < len(rest) {
+		to, _ = CString(rest[n:])
+	}
+	return f, from, to, nil
+}
+
+// FileInfo is FILEINFOHDR_STR: what a directory listing says about one entry.
+type FileInfo struct {
+	// Time is the modification time. Its encoding depends on the DOS
+	// file-time attribute: with it, MS-DOS packed date and time; without it,
+	// seconds. Devices differ, so a reader must check the flag rather than
+	// assume.
+	Time   int32
+	Attrib uint16
+	Length int32
+}
+
+// IsDir reports whether the entry is a directory.
+func (f FileInfo) IsDir() bool { return f.Attrib&AttrSubdir != 0 }
+
+// ReadOnly reports whether the entry may not be written.
+func (f FileInfo) ReadOnly() bool { return f.Attrib&AttrReadOnly != 0 }
+
+// DOSTime reports whether Time is in MS-DOS packed format rather than seconds.
+func (f FileInfo) DOSTime() bool { return f.Attrib&AttrDOSFileTime != 0 }
+
+// AppendTo appends the 10-byte wire form.
+func (f FileInfo) AppendTo(dst []byte) []byte {
+	var b [FileInfoSize]byte
+	binary.BigEndian.PutUint32(b[0:4], uint32(f.Time))
+	binary.BigEndian.PutUint16(b[4:6], f.Attrib)
+	binary.BigEndian.PutUint32(b[6:10], uint32(f.Length))
+	return append(dst, b[:]...)
+}
+
+// DecodeFileInfo reads a FILEINFOHDR_STR from the front of b.
+func DecodeFileInfo(b []byte) (FileInfo, error) {
+	if err := need(b, FileInfoSize, "FileInfo", ""); err != nil {
+		return FileInfo{}, err
+	}
+	return fileInfoAt(b), nil
+}
+
+// fileInfoAt reads a FILEINFOHDR_STR from a slice the caller has already
+// sized. A directory entry embeds one and validates the whole entry first.
+func fileInfoAt(b []byte) FileInfo {
+	return FileInfo{
+		Time:   int32(binary.BigEndian.Uint32(b[0:4])),
+		Attrib: binary.BigEndian.Uint16(b[4:6]),
+		Length: int32(binary.BigEndian.Uint32(b[6:10])),
+	}
+}
+
+// DirEntry is MODULE_FILEINFO_STR: one line of a directory listing, delivered
+// as one item of a multi-packet transfer.
+type DirEntry struct {
+	Info FileInfo
+	Name string
+}
+
+func (d DirEntry) String() string {
+	kind := "file"
+	if d.Info.IsDir() {
+		kind = "dir"
+	}
+	return fmt.Sprintf("%s %q %d bytes", kind, d.Name, d.Info.Length)
+}
+
+// AppendTo appends the 24-byte wire form: the header, the fixed-width name,
+// and the pad byte the structure's packing adds.
+func (d DirEntry) AppendTo(dst []byte) ([]byte, error) {
+	dst = d.Info.AppendTo(dst)
+	dst, err := appendFixedString(dst, d.Name, FileNameSize)
+	if err != nil {
+		return nil, err
+	}
+	// The pad is zeroed rather than left as whatever was in the buffer, so
+	// our own frames stay reproducible.
+	return append(dst, 0), nil
+}
+
+// DecodeDirEntry reads a directory entry.
+//
+// Twenty-three bytes are accepted as well as twenty-four: the content is 23
+// and a peer that trims the structure's padding is not wrong.
+func DecodeDirEntry(b []byte) (DirEntry, error) {
+	const content = FileInfoSize + FileNameSize
+	if err := need(b, content, "DirEntry", ""); err != nil {
+		return DirEntry{}, err
+	}
+	return DirEntry{
+		Info: fileInfoAt(b),
+		Name: fixedString(b[FileInfoSize:content]),
+	}, nil
+}

--- a/internal/snell-rollcall/codec/payload_file_test.go
+++ b/internal/snell-rollcall/codec/payload_file_test.go
@@ -1,0 +1,349 @@
+package codec
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestFile_RoundTrip pins FILE_STR, the structure every file operation
+// carries. Field widths are from RC3FILE.H under #pragma pack(2): two 16-bit
+// handles, a signed 32-bit offset, and a signed 16-bit extra.
+func TestFile_RoundTrip(t *testing.T) {
+	in := File{SrcHandle: 0x0102, FileHandle: 0x0304, Offset: 0x05060708, Extra: -1}
+
+	got := in.AppendTo(nil)
+	if want := mustHex(t, "0102 0304 05060708 ffff"); !bytes.Equal(got, want) {
+		t.Errorf("encoded %x, want %x", got, want)
+	}
+	if len(got) != FileSize {
+		t.Errorf("encoded %d bytes, want %d", len(got), FileSize)
+	}
+
+	back, err := DecodeFile(got)
+	if err != nil {
+		t.Fatalf("DecodeFile: %v", err)
+	}
+	if back != in {
+		t.Errorf("round trip %+v -> %+v", in, back)
+	}
+
+	if _, err := DecodeFile(make([]byte, FileSize-1)); !errors.Is(err, ErrShortBuffer) {
+		t.Errorf("err = %v, want ErrShortBuffer", err)
+	}
+	if got := in.String(); !strings.Contains(got, "src=258") {
+		t.Errorf("String() = %q", got)
+	}
+}
+
+// TestFile_Err covers the error the Extra field carries on a reply. Only the
+// documented errno values are failures; zero is success and a negative value
+// is a seek origin echoed back, not an error.
+func TestFile_Err(t *testing.T) {
+	if err := (File{}).Err(); err != nil {
+		t.Errorf("a zero extra is success, got %v", err)
+	}
+	if err := (File{Extra: -1}).Err(); err != nil {
+		t.Errorf("a negative extra is not an error, got %v", err)
+	}
+
+	err := File{Extra: FileErrNoEntry}.Err()
+	if err == nil || !strings.Contains(err.Error(), "no such file") {
+		t.Errorf("err = %v, want it to name the missing file", err)
+	}
+}
+
+// TestFileErrorName pins the errno values the file service uses. They are C
+// numbers, so a wrong one turns "no space left" into "access denied" in an
+// operator's log.
+func TestFileErrorName(t *testing.T) {
+	tests := []struct {
+		code int16
+		want string
+	}{
+		{0, "ok"},
+		{2, "no such file or directory"},
+		{13, "access denied"},
+		{17, "already exists"},
+		{22, "invalid argument"},
+		{24, "no file handles left"},
+		{28, "no space"},
+		{129, "bad file type"},
+		{99, "error(99)"},
+	}
+	for _, tc := range tests {
+		if got := FileErrorName(tc.code); got != tc.want {
+			t.Errorf("FileErrorName(%d) = %q, want %q", tc.code, got, tc.want)
+		}
+	}
+}
+
+// TestFileOpen covers the open request, whose path travels after the structure
+// as a NUL-terminated string rather than in a fixed field.
+func TestFileOpen(t *testing.T) {
+	const path = "TEMPLATE.ZIP"
+
+	got, err := AppendFileOpen(nil, 7, OpenReadOnly|OpenBinary, path)
+	if err != nil {
+		t.Fatalf("AppendFileOpen: %v", err)
+	}
+	want := mustHex(t, "0007 0000 00008000 0000"+"54454d504c4154452e5a495000")
+	if !bytes.Equal(got, want) {
+		t.Errorf("encoded\n got %x\nwant %x", got, want)
+	}
+
+	f, back, err := DecodeFileOpen(got)
+	if err != nil {
+		t.Fatalf("DecodeFileOpen: %v", err)
+	}
+	if back != path {
+		t.Errorf("path = %q, want %q", back, path)
+	}
+	if f.SrcHandle != 7 {
+		t.Errorf("source handle = %d, want 7", f.SrcHandle)
+	}
+	// The flags travel in the offset field, which is the awkward part of this
+	// structure and the reason there is a helper.
+	if uint16(f.Offset) != OpenReadOnly|OpenBinary {
+		t.Errorf("flags = %04X, want %04X", uint16(f.Offset), OpenReadOnly|OpenBinary)
+	}
+
+	if _, _, err := DecodeFileOpen(make([]byte, 4)); !errors.Is(err, ErrShortBuffer) {
+		t.Errorf("err = %v, want ErrShortBuffer", err)
+	}
+}
+
+// TestFileOpen_BinaryMatters records why the binary flag is not optional. A
+// peer that opens in text mode translates line endings, which silently
+// corrupts a names file or a template archive.
+func TestFileOpen_BinaryMatters(t *testing.T) {
+	if OpenBinary != 0x8000 {
+		t.Errorf("OpenBinary = %04X, want 8000", OpenBinary)
+	}
+	if OpenText != 0x4000 {
+		t.Errorf("OpenText = %04X, want 4000", OpenText)
+	}
+	if OpenBinary&OpenText != 0 {
+		t.Error("binary and text must be distinct bits")
+	}
+
+	// The flags are the C runtime's, because that is what the vendor passes
+	// them to.
+	tests := map[uint16]string{
+		0x0000: "read only", 0x0001: "write only", 0x0002: "read write",
+		0x0008: "append", 0x0100: "create", 0x0200: "truncate", 0x0400: "exclusive",
+	}
+	got := map[uint16]string{
+		OpenReadOnly: "read only", OpenWriteOnly: "write only", OpenReadWrite: "read write",
+		OpenAppend: "append", OpenCreate: "create", OpenTruncate: "truncate",
+		OpenExclusive: "exclusive",
+	}
+	for v, name := range tests {
+		if got[v] != name {
+			t.Errorf("flag %04X is %q, want %q", v, got[v], name)
+		}
+	}
+}
+
+func TestFilePath(t *testing.T) {
+	got, err := AppendFilePath(nil, 3, "/RC_Files")
+	if err != nil {
+		t.Fatalf("AppendFilePath: %v", err)
+	}
+	if want := mustHex(t, "0003 0000 00000000 0000"+"2f52435f46696c657300"); !bytes.Equal(got, want) {
+		t.Errorf("encoded\n got %x\nwant %x", got, want)
+	}
+
+	_, path, err := DecodeFileOpen(got)
+	if err != nil {
+		t.Fatalf("DecodeFileOpen: %v", err)
+	}
+	if path != "/RC_Files" {
+		t.Errorf("path = %q", path)
+	}
+}
+
+func TestFileRename(t *testing.T) {
+	got, err := AppendFileRename(nil, 1, "OLD.TXT", "NEW.TXT")
+	if err != nil {
+		t.Fatalf("AppendFileRename: %v", err)
+	}
+
+	f, from, to, err := DecodeFileRename(got)
+	if err != nil {
+		t.Fatalf("DecodeFileRename: %v", err)
+	}
+	if f.SrcHandle != 1 || from != "OLD.TXT" || to != "NEW.TXT" {
+		t.Errorf("= %+v %q %q", f, from, to)
+	}
+
+	// A rename with only one path is malformed but must not panic: the
+	// second name simply comes back empty.
+	short, err := AppendFilePath(nil, 1, "OLD.TXT")
+	if err != nil {
+		t.Fatalf("AppendFilePath: %v", err)
+	}
+	_, from, to, err = DecodeFileRename(short)
+	if err != nil {
+		t.Fatalf("DecodeFileRename: %v", err)
+	}
+	if from != "OLD.TXT" || to != "" {
+		t.Errorf("= %q %q, want the second name empty", from, to)
+	}
+
+	if _, _, _, err := DecodeFileRename(make([]byte, 4)); !errors.Is(err, ErrShortBuffer) {
+		t.Errorf("err = %v, want ErrShortBuffer", err)
+	}
+}
+
+func TestFilePaths_TooLong(t *testing.T) {
+	long := strings.Repeat("x", MaxFileName)
+
+	if _, err := AppendFileOpen(nil, 1, 0, long); !errors.Is(err, ErrStringTooLong) {
+		t.Errorf("open err = %v, want ErrStringTooLong", err)
+	}
+	if _, err := AppendFilePath(nil, 1, long); !errors.Is(err, ErrStringTooLong) {
+		t.Errorf("path err = %v, want ErrStringTooLong", err)
+	}
+	if _, err := AppendFileRename(nil, 1, long, long); !errors.Is(err, ErrStringTooLong) {
+		t.Errorf("rename err = %v, want ErrStringTooLong", err)
+	}
+
+	// The longest acceptable path is one short of the limit, leaving room for
+	// the terminator.
+	ok := strings.Repeat("x", MaxFileName-1)
+	if _, err := AppendFileOpen(nil, 1, 0, ok); err != nil {
+		t.Errorf("a %d-byte path must fit: %v", len(ok), err)
+	}
+}
+
+// TestFileInfo covers a directory entry's metadata, including the flag that
+// says how to read the time field. A reader that assumes one encoding gets
+// dates decades out on the devices that use the other.
+func TestFileInfo(t *testing.T) {
+	in := FileInfo{Time: 0x11223344, Attrib: AttrReadOnly | AttrArchive, Length: 1024}
+
+	got := in.AppendTo(nil)
+	if want := mustHex(t, "11223344 0021 00000400"); !bytes.Equal(got, want) {
+		t.Errorf("encoded %x, want %x", got, want)
+	}
+	if len(got) != FileInfoSize {
+		t.Errorf("encoded %d bytes, want %d", len(got), FileInfoSize)
+	}
+
+	back, err := DecodeFileInfo(got)
+	if err != nil {
+		t.Fatalf("DecodeFileInfo: %v", err)
+	}
+	if back != in {
+		t.Errorf("round trip %+v -> %+v", in, back)
+	}
+
+	if !back.ReadOnly() {
+		t.Error("the read-only attribute was lost")
+	}
+	if back.IsDir() {
+		t.Error("a file is not a directory")
+	}
+	if back.DOSTime() {
+		t.Error("the DOS time flag was not set")
+	}
+
+	dir := FileInfo{Attrib: AttrSubdir | AttrDOSFileTime}
+	if !dir.IsDir() || !dir.DOSTime() {
+		t.Errorf("= %+v, want a directory with a DOS time", dir)
+	}
+
+	if _, err := DecodeFileInfo(make([]byte, FileInfoSize-1)); !errors.Is(err, ErrShortBuffer) {
+		t.Errorf("err = %v, want ErrShortBuffer", err)
+	}
+}
+
+// TestDirEntry_PaddedToTwentyFour pins the size question this structure
+// raises. Its content is a 10-byte header and a 13-byte name, which is 23,
+// but under #pragma pack(2) it is padded to an even size and senders use
+// sizeof. Twenty-four bytes go on the wire.
+func TestDirEntry_PaddedToTwentyFour(t *testing.T) {
+	in := DirEntry{
+		Info: FileInfo{Attrib: AttrNormal, Length: 4096},
+		Name: "TEMPLATE.ZIP",
+	}
+
+	got, err := in.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	if len(got) != DirEntrySize {
+		t.Fatalf("encoded %d bytes, want %d", len(got), DirEntrySize)
+	}
+	if DirEntrySize != FileInfoSize+FileNameSize+1 {
+		t.Errorf("the size is not the content plus one pad byte")
+	}
+	// The pad is zeroed rather than left as whatever was in the buffer.
+	if got[DirEntrySize-1] != 0 {
+		t.Errorf("pad byte = %02X, want it zeroed", got[DirEntrySize-1])
+	}
+
+	back, err := DecodeDirEntry(got)
+	if err != nil {
+		t.Fatalf("DecodeDirEntry: %v", err)
+	}
+	if back.Name != in.Name || back.Info != in.Info {
+		t.Errorf("round trip %+v -> %+v", in, back)
+	}
+}
+
+// TestDirEntry_AcceptsTheTrimmedForm covers a peer that sends the 23 bytes of
+// content without the structure's padding. It is not wrong, and the entry must
+// still decode.
+func TestDirEntry_AcceptsTheTrimmedForm(t *testing.T) {
+	full, err := DirEntry{Name: "A.TXT"}.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+
+	trimmed := full[:FileInfoSize+FileNameSize]
+	got, err := DecodeDirEntry(trimmed)
+	if err != nil {
+		t.Fatalf("DecodeDirEntry on the trimmed form: %v", err)
+	}
+	if got.Name != "A.TXT" {
+		t.Errorf("name = %q", got.Name)
+	}
+
+	if _, err := DecodeDirEntry(trimmed[:len(trimmed)-1]); !errors.Is(err, ErrShortBuffer) {
+		t.Errorf("err = %v, want ErrShortBuffer", err)
+	}
+}
+
+func TestDirEntry_Errors(t *testing.T) {
+	long := DirEntry{Name: strings.Repeat("n", FileNameSize)}
+	if _, err := long.AppendTo(nil); !errors.Is(err, ErrStringTooLong) {
+		t.Errorf("err = %v, want ErrStringTooLong", err)
+	}
+	// A DOS 8.3 name with its terminator is the longest that fits.
+	ok := DirEntry{Name: "FILENAME.EXT"}
+	if _, err := ok.AppendTo(nil); err != nil {
+		t.Errorf("a %d-byte name must fit a %d-byte field: %v",
+			len(ok.Name), FileNameSize, err)
+	}
+}
+
+func TestDirEntry_String(t *testing.T) {
+	file := DirEntry{Info: FileInfo{Length: 100}, Name: "A.TXT"}
+	if got := file.String(); !strings.Contains(got, "file") || !strings.Contains(got, "100") {
+		t.Errorf("String() = %q", got)
+	}
+	dir := DirEntry{Info: FileInfo{Attrib: AttrSubdir}, Name: "SUB"}
+	if got := dir.String(); !strings.Contains(got, "dir") {
+		t.Errorf("String() = %q", got)
+	}
+}
+
+// TestSeekOrigins pins the values the Extra field carries on a read or write.
+func TestSeekOrigins(t *testing.T) {
+	if SeekStart != 0 || SeekCurrent != 1 || SeekEnd != 2 {
+		t.Errorf("seek origins are %d/%d/%d, want 0/1/2", SeekStart, SeekCurrent, SeekEnd)
+	}
+}

--- a/internal/snell-rollcall/codec/payload_services.go
+++ b/internal/snell-rollcall/codec/payload_services.go
@@ -1,0 +1,378 @@
+package codec
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// Wire sizes of the remaining service structures.
+const (
+	LogPacketSize   = 38 // LOGPACKET_STR, before the message text
+	StreamModeSize  = 4  // STREAMMODE_STR
+	StreamHdrSize   = 8  // STREAMHDR_STR, before the data
+	DisplayCapsSize = 12 // DISPLAYCAPS_STR
+	DrawBitmapSize  = 2  // DRAWBITMAP_STR, before the bitmap
+	DrawTextSize    = 2  // DRAWTEXT_STR, before the text
+	SetGroupSize    = 2  // SETGROUP_STR
+	GroupParamSize  = 2  // GROUPPARAM_STR
+	DownloadSize    = 2  // DOWNLOAD_STR
+
+	// RouteErrorSize is zero because ROUTEERROR_STR has no definition.
+	//
+	// Packet type 38 refers to it in rc3comm.h and no shipped header declares
+	// it, so its layout is unknown. The frame is delivered with its payload
+	// intact and a caller may inspect it; inventing a structure would be a
+	// guess presented as fact. See docs/spec-coverage.md §4.
+	RouteErrorSize = 0
+)
+
+// LogPacket is LOGPACKET_STR: one line of a unit's log, pushed to a subscriber.
+//
+// It names its source by both type id and user-given name, which matters
+// because a log server collects from many units and the frame's source address
+// only says which gateway forwarded it.
+type LogPacket struct {
+	Time   SysTime
+	Format uint16
+	ID     uint16
+	Name   string // the source unit's user-given name, 19 usable bytes
+
+	// Text is the log message itself, which follows the structure.
+	Text string
+}
+
+func (l LogPacket) String() string {
+	return fmt.Sprintf("%s [%s] %s", l.Time, l.Name, l.Text)
+}
+
+// AppendTo appends the wire form: the structure, then the message text.
+func (l LogPacket) AppendTo(dst []byte) ([]byte, error) {
+	dst = l.Time.AppendTo(dst)
+
+	var head [4]byte
+	binary.BigEndian.PutUint16(head[0:2], l.Format)
+	binary.BigEndian.PutUint16(head[2:4], l.ID)
+	dst = append(dst, head[:]...)
+
+	dst, err := appendFixedString(dst, l.Name, MaxTextSize)
+	if err != nil {
+		return nil, err
+	}
+	if l.Text == "" {
+		return dst, nil
+	}
+	return appendCString(dst, l.Text)
+}
+
+// DecodeLogPacket reads a LOGPACKET_STR and its trailing message.
+func DecodeLogPacket(b []byte) (LogPacket, error) {
+	if err := need(b, LogPacketSize, "LogPacket", ""); err != nil {
+		return LogPacket{}, err
+	}
+	l := LogPacket{
+		Time:   sysTimeAt(b[0:TimeSize]),
+		Format: binary.BigEndian.Uint16(b[14:16]),
+		ID:     binary.BigEndian.Uint16(b[16:18]),
+		Name:   fixedString(b[18:38]),
+	}
+	if len(b) > LogPacketSize {
+		l.Text, _ = CString(b[LogPacketSize:])
+	}
+	return l, nil
+}
+
+// Stream mode flags (RC3STRM.H StreamModeFlags).
+const (
+	// StreamBinary opens the stream without line-ending translation.
+	StreamBinary uint8 = 1
+)
+
+// StreamMode is STREAMMODE_STR: opening or reconfiguring a logical stream.
+type StreamMode struct {
+	Stream  uint8
+	Mode    uint8
+	MaxSize uint16
+}
+
+func (s StreamMode) String() string {
+	return fmt.Sprintf("stream=%d mode=%02X max=%d", s.Stream, s.Mode, s.MaxSize)
+}
+
+// Binary reports whether the stream carries untranslated bytes.
+func (s StreamMode) Binary() bool { return s.Mode&StreamBinary != 0 }
+
+// AppendTo appends the 4-byte wire form.
+func (s StreamMode) AppendTo(dst []byte) []byte {
+	var b [StreamModeSize]byte
+	b[0] = s.Stream
+	b[1] = s.Mode
+	binary.BigEndian.PutUint16(b[2:4], s.MaxSize)
+	return append(dst, b[:]...)
+}
+
+// DecodeStreamMode reads a STREAMMODE_STR from the front of b.
+func DecodeStreamMode(b []byte) (StreamMode, error) {
+	if err := need(b, StreamModeSize, "StreamMode", ""); err != nil {
+		return StreamMode{}, err
+	}
+	return StreamMode{
+		Stream:  b[0],
+		Mode:    b[1],
+		MaxSize: binary.BigEndian.Uint16(b[2:4]),
+	}, nil
+}
+
+// StreamHeader is STREAMHDR_STR: one block of stream data.
+//
+// Like the file service it carries a handle from each end, so a reply can be
+// matched without either side having to agree on numbering.
+type StreamHeader struct {
+	ClientHandle int16
+	ServerHandle int16
+	Command      uint16
+	Data         []byte
+}
+
+func (s StreamHeader) String() string {
+	return fmt.Sprintf("client=%d server=%d cmd=%d %dB",
+		s.ClientHandle, s.ServerHandle, s.Command, len(s.Data))
+}
+
+// AppendTo appends the header and its data. The length is taken from the
+// slice, so the two can never disagree.
+func (s StreamHeader) AppendTo(dst []byte) ([]byte, error) {
+	if len(s.Data) > MaxPayload {
+		return nil, fmt.Errorf("%w: %d bytes of stream data", ErrPayloadTooLong, len(s.Data))
+	}
+	var b [StreamHdrSize]byte
+	binary.BigEndian.PutUint16(b[0:2], uint16(s.ClientHandle))
+	binary.BigEndian.PutUint16(b[2:4], uint16(s.ServerHandle))
+	binary.BigEndian.PutUint16(b[4:6], s.Command)
+	binary.BigEndian.PutUint16(b[6:8], uint16(int16(len(s.Data))))
+	return append(append(dst, b[:]...), s.Data...), nil
+}
+
+// DecodeStreamHeader reads a STREAMHDR_STR and its data.
+func DecodeStreamHeader(b []byte) (StreamHeader, error) {
+	if err := need(b, StreamHdrSize, "StreamHeader", ""); err != nil {
+		return StreamHeader{}, err
+	}
+	s := StreamHeader{
+		ClientHandle: int16(binary.BigEndian.Uint16(b[0:2])),
+		ServerHandle: int16(binary.BigEndian.Uint16(b[2:4])),
+		Command:      binary.BigEndian.Uint16(b[4:6]),
+	}
+	n := int(int16(binary.BigEndian.Uint16(b[6:8])))
+	if n < 0 {
+		return StreamHeader{}, decodeErr("StreamHeader", "Bytes", 6,
+			fmt.Errorf("negative data length %d", n))
+	}
+	if err := need(b[StreamHdrSize:], n, "StreamHeader", "Data"); err != nil {
+		return StreamHeader{}, err
+	}
+	s.Data = b[StreamHdrSize : StreamHdrSize+n]
+	return s, nil
+}
+
+// Display colour formats (rc3comm.h CF_ constants): bits per pixel.
+const (
+	ColourFormat2Bit  int16 = 1
+	ColourFormat4Bit  int16 = 4
+	ColourFormat8Bit  int16 = 8
+	ColourFormat15Bit int16 = 15
+	ColourFormat16Bit int16 = 16
+	ColourFormat24Bit int16 = 24
+)
+
+// DisplayCaps is DISPLAYCAPS_STR: what a unit's display can show.
+//
+// A unit answers with one of these per display it has, which is what tells a
+// client whether it is driving a four-line character panel or a bitmap screen.
+type DisplayCaps struct {
+	Display uint8
+	Type    uint8
+	Chars   int16 // characters per line
+	Lines   int16
+	XPixels int16
+	YPixels int16
+	Format  int16 // bits per pixel
+}
+
+// IsCharacter reports whether the display is character-based, which is true
+// when it has no pixel resolution to speak of.
+func (d DisplayCaps) IsCharacter() bool { return d.XPixels == 0 && d.YPixels == 0 }
+
+func (d DisplayCaps) String() string {
+	if d.IsCharacter() {
+		return fmt.Sprintf("display=%d %dx%d chars", d.Display, d.Chars, d.Lines)
+	}
+	return fmt.Sprintf("display=%d %dx%d px %d-bit", d.Display, d.XPixels, d.YPixels, d.Format)
+}
+
+// AppendTo appends the 12-byte wire form.
+func (d DisplayCaps) AppendTo(dst []byte) []byte {
+	var b [DisplayCapsSize]byte
+	b[0] = d.Display
+	b[1] = d.Type
+	binary.BigEndian.PutUint16(b[2:4], uint16(d.Chars))
+	binary.BigEndian.PutUint16(b[4:6], uint16(d.Lines))
+	binary.BigEndian.PutUint16(b[6:8], uint16(d.XPixels))
+	binary.BigEndian.PutUint16(b[8:10], uint16(d.YPixels))
+	binary.BigEndian.PutUint16(b[10:12], uint16(d.Format))
+	return append(dst, b[:]...)
+}
+
+// DecodeDisplayCaps reads a DISPLAYCAPS_STR from the front of b.
+func DecodeDisplayCaps(b []byte) (DisplayCaps, error) {
+	if err := need(b, DisplayCapsSize, "DisplayCaps", ""); err != nil {
+		return DisplayCaps{}, err
+	}
+	return DisplayCaps{
+		Display: b[0],
+		Type:    b[1],
+		Chars:   int16(binary.BigEndian.Uint16(b[2:4])),
+		Lines:   int16(binary.BigEndian.Uint16(b[4:6])),
+		XPixels: int16(binary.BigEndian.Uint16(b[6:8])),
+		YPixels: int16(binary.BigEndian.Uint16(b[8:10])),
+		Format:  int16(binary.BigEndian.Uint16(b[10:12])),
+	}, nil
+}
+
+// DrawBitmap is DRAWBITMAP_STR and the bitmap that follows it.
+//
+// The header is two bytes: which display, and a pad the header documents as
+// "must be zero". Everything about the bitmap's own layout comes from the
+// display's capabilities rather than from this structure.
+type DrawBitmap struct {
+	Display uint8
+	Bitmap  []byte
+}
+
+func (d DrawBitmap) String() string {
+	return fmt.Sprintf("display=%d bitmap=%dB", d.Display, len(d.Bitmap))
+}
+
+// AppendTo appends the header and the bitmap.
+func (d DrawBitmap) AppendTo(dst []byte) []byte {
+	return append(append(dst, d.Display, 0), d.Bitmap...)
+}
+
+// DecodeDrawBitmap reads a DRAWBITMAP_STR and its bitmap.
+func DecodeDrawBitmap(b []byte) (DrawBitmap, error) {
+	if err := need(b, DrawBitmapSize, "DrawBitmap", ""); err != nil {
+		return DrawBitmap{}, err
+	}
+	return DrawBitmap{Display: b[0], Bitmap: b[DrawBitmapSize:]}, nil
+}
+
+// DrawText is DRAWTEXT_STR and the text that follows it.
+type DrawText struct {
+	Display uint8
+	Mode    uint8
+	Text    string
+}
+
+func (d DrawText) String() string {
+	return fmt.Sprintf("display=%d mode=%d %q", d.Display, d.Mode, d.Text)
+}
+
+// AppendTo appends the header and the text.
+func (d DrawText) AppendTo(dst []byte) ([]byte, error) {
+	dst = append(dst, d.Display, d.Mode)
+	return appendCString(dst, d.Text)
+}
+
+// DecodeDrawText reads a DRAWTEXT_STR and its text.
+func DecodeDrawText(b []byte) (DrawText, error) {
+	if err := need(b, DrawTextSize, "DrawText", ""); err != nil {
+		return DrawText{}, err
+	}
+	d := DrawText{Display: b[0], Mode: b[1]}
+	if len(b) > DrawTextSize {
+		d.Text, _ = CString(b[DrawTextSize:])
+	}
+	return d, nil
+}
+
+// SetGroup is SETGROUP_STR: putting a unit into a control group.
+//
+// A group lets one write reach several units at once. The master flag marks
+// the unit whose values the others follow, which is how a group is kept
+// consistent without the client writing to each in turn.
+type SetGroup struct {
+	Group  uint8
+	Master bool
+}
+
+func (s SetGroup) String() string {
+	if s.Master {
+		return fmt.Sprintf("group=%d master", s.Group)
+	}
+	return fmt.Sprintf("group=%d", s.Group)
+}
+
+// AppendTo appends the 2-byte wire form.
+func (s SetGroup) AppendTo(dst []byte) []byte {
+	var m byte
+	if s.Master {
+		m = 1
+	}
+	return append(dst, s.Group, m)
+}
+
+// DecodeSetGroup reads a SETGROUP_STR from the front of b.
+func DecodeSetGroup(b []byte) (SetGroup, error) {
+	if err := need(b, SetGroupSize, "SetGroup", ""); err != nil {
+		return SetGroup{}, err
+	}
+	return SetGroup{Group: b[0], Master: b[1] != 0}, nil
+}
+
+// GroupParam is GROUPPARAM_STR: which group a group write applies to.
+//
+// It precedes a FuncStatus in a group set, so the payload is this structure
+// followed by the value.
+type GroupParam struct {
+	Group uint8
+}
+
+func (g GroupParam) String() string { return fmt.Sprintf("group=%d", g.Group) }
+
+// AppendTo appends the 2-byte wire form, pad included and zeroed.
+func (g GroupParam) AppendTo(dst []byte) []byte {
+	return append(dst, g.Group, 0)
+}
+
+// DecodeGroupParam reads a GROUPPARAM_STR from the front of b.
+func DecodeGroupParam(b []byte) (GroupParam, error) {
+	if err := need(b, GroupParamSize, "GroupParam", ""); err != nil {
+		return GroupParam{}, err
+	}
+	return GroupParam{Group: b[0]}, nil
+}
+
+// Download is DOWNLOAD_STR: a configuration download request.
+//
+// The vendor header labels its only field "No idea - DRAGONS" and nothing else
+// in the sources explains it, so it is carried through unchanged rather than
+// interpreted.
+type Download struct {
+	List uint16
+}
+
+func (d Download) String() string { return fmt.Sprintf("list=%d", d.List) }
+
+// AppendTo appends the 2-byte wire form.
+func (d Download) AppendTo(dst []byte) []byte {
+	var b [DownloadSize]byte
+	binary.BigEndian.PutUint16(b[:], d.List)
+	return append(dst, b[:]...)
+}
+
+// DecodeDownload reads a DOWNLOAD_STR from the front of b.
+func DecodeDownload(b []byte) (Download, error) {
+	if err := need(b, DownloadSize, "Download", ""); err != nil {
+		return Download{}, err
+	}
+	return Download{List: binary.BigEndian.Uint16(b)}, nil
+}

--- a/internal/snell-rollcall/codec/payload_services_test.go
+++ b/internal/snell-rollcall/codec/payload_services_test.go
@@ -1,0 +1,423 @@
+package codec
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestLogPacket pins LOGPACKET_STR: a time structure, a format word, the
+// source unit's type id, its name in a fixed field, and then the message.
+//
+// The source is named twice over because a log server collects from many units
+// and the frame's own source address says only which gateway forwarded it.
+func TestLogPacket(t *testing.T) {
+	in := LogPacket{
+		Time:   NewSysTime(time.Date(2026, 9, 7, 3, 7, 55, 0, time.UTC)),
+		Format: 0x0102,
+		ID:     636,
+		Name:   "Router Matrix",
+		Text:   "level 3 destination 40 protected",
+	}
+
+	got, err := in.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	if len(got) < LogPacketSize {
+		t.Fatalf("encoded %d bytes, want at least %d", len(got), LogPacketSize)
+	}
+	// The fixed part is the time, the two words and the twenty-byte name.
+	if want := TimeSize + 4 + MaxTextSize; want != LogPacketSize {
+		t.Fatalf("the fixed part is %d bytes, not %d", want, LogPacketSize)
+	}
+
+	back, err := DecodeLogPacket(got)
+	if err != nil {
+		t.Fatalf("DecodeLogPacket: %v", err)
+	}
+	if back.Format != in.Format || back.ID != in.ID || back.Name != in.Name || back.Text != in.Text {
+		t.Errorf("round trip\n got %+v\nwant %+v", back, in)
+	}
+	when, ok := back.Time.Time()
+	if !ok || when.Hour() != 3 {
+		t.Errorf("time = %s,%v", when, ok)
+	}
+
+	// The type id names the product, which is what makes a log line legible
+	// without the operator knowing the number.
+	if got := UnitTypeName(back.ID); got != "Router Matrix" {
+		t.Errorf("id %d is %q", back.ID, got)
+	}
+}
+
+// TestLogPacket_NoText covers a log entry that is just an event with no
+// message, which is how a unit reports a state change.
+func TestLogPacket_NoText(t *testing.T) {
+	in := LogPacket{Name: "Vega"}
+
+	got, err := in.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	if len(got) != LogPacketSize {
+		t.Errorf("encoded %d bytes, want exactly the fixed part %d", len(got), LogPacketSize)
+	}
+
+	back, err := DecodeLogPacket(got)
+	if err != nil {
+		t.Fatalf("DecodeLogPacket: %v", err)
+	}
+	if back.Text != "" || back.Name != "Vega" {
+		t.Errorf("= %+v", back)
+	}
+}
+
+func TestLogPacket_Errors(t *testing.T) {
+	if _, err := DecodeLogPacket(make([]byte, LogPacketSize-1)); !errors.Is(err, ErrShortBuffer) {
+		t.Errorf("err = %v, want ErrShortBuffer", err)
+	}
+
+	long := LogPacket{Name: strings.Repeat("n", MaxTextSize)}
+	if _, err := long.AppendTo(nil); !errors.Is(err, ErrStringTooLong) {
+		t.Errorf("err = %v, want ErrStringTooLong", err)
+	}
+
+	overText := LogPacket{Text: strings.Repeat("t", MaxLongString)}
+	if _, err := overText.AppendTo(nil); !errors.Is(err, ErrStringTooLong) {
+		t.Errorf("err = %v, want ErrStringTooLong", err)
+	}
+}
+
+func TestLogPacket_String(t *testing.T) {
+	l := LogPacket{
+		Time: NewSysTime(time.Date(2026, 9, 7, 3, 7, 55, 0, time.UTC)),
+		Name: "Vega",
+		Text: "input lost",
+	}
+	got := l.String()
+	for _, want := range []string{"2026-09-07", "Vega", "input lost"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("String() = %q, want it to contain %q", got, want)
+		}
+	}
+}
+
+func TestStreamMode(t *testing.T) {
+	in := StreamMode{Stream: 3, Mode: StreamBinary, MaxSize: 420}
+
+	got := in.AppendTo(nil)
+	if want := mustHex(t, "03 01 01a4"); !bytes.Equal(got, want) {
+		t.Errorf("encoded %x, want %x", got, want)
+	}
+	if len(got) != StreamModeSize {
+		t.Errorf("encoded %d bytes, want %d", len(got), StreamModeSize)
+	}
+
+	back, err := DecodeStreamMode(got)
+	if err != nil {
+		t.Fatalf("DecodeStreamMode: %v", err)
+	}
+	if back != in {
+		t.Errorf("round trip %+v -> %+v", in, back)
+	}
+	if !back.Binary() {
+		t.Error("the binary flag was lost")
+	}
+	if (StreamMode{}).Binary() {
+		t.Error("a zero mode is not binary")
+	}
+
+	if _, err := DecodeStreamMode(make([]byte, StreamModeSize-1)); !errors.Is(err, ErrShortBuffer) {
+		t.Errorf("err = %v, want ErrShortBuffer", err)
+	}
+	if got := in.String(); !strings.Contains(got, "stream=3") {
+		t.Errorf("String() = %q", got)
+	}
+}
+
+// TestStreamHeader covers a block of stream data. Like the file service it
+// carries a handle from each end, so neither has to agree with the other on
+// numbering.
+func TestStreamHeader(t *testing.T) {
+	in := StreamHeader{ClientHandle: 1, ServerHandle: 2, Command: 3, Data: []byte{0xDE, 0xAD}}
+
+	got, err := in.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	if want := mustHex(t, "0001 0002 0003 0002 dead"); !bytes.Equal(got, want) {
+		t.Errorf("encoded\n got %x\nwant %x", got, want)
+	}
+
+	back, err := DecodeStreamHeader(got)
+	if err != nil {
+		t.Fatalf("DecodeStreamHeader: %v", err)
+	}
+	if back.ClientHandle != 1 || back.ServerHandle != 2 || back.Command != 3 {
+		t.Errorf("= %+v", back)
+	}
+	if !bytes.Equal(back.Data, in.Data) {
+		t.Errorf("data = %x, want %x", back.Data, in.Data)
+	}
+
+	// An empty block is legal: it is how a stream is closed.
+	empty, err := (StreamHeader{ClientHandle: 1}).AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	if len(empty) != StreamHdrSize {
+		t.Errorf("an empty block is %d bytes, want %d", len(empty), StreamHdrSize)
+	}
+}
+
+func TestStreamHeader_Errors(t *testing.T) {
+	if _, err := DecodeStreamHeader(make([]byte, StreamHdrSize-1)); !errors.Is(err, ErrShortBuffer) {
+		t.Errorf("err = %v, want ErrShortBuffer", err)
+	}
+	// A length longer than the block.
+	if _, err := DecodeStreamHeader(mustHex(t, "0001 0002 0003 00ff dead")); !errors.Is(err, ErrShortBuffer) {
+		t.Errorf("err = %v, want ErrShortBuffer", err)
+	}
+	// The length is signed, so a negative one is malformed rather than huge.
+	if _, err := DecodeStreamHeader(mustHex(t, "0001 0002 0003 ffff")); err == nil {
+		t.Error("a negative length must be rejected")
+	}
+	// More data than a frame can carry.
+	big := StreamHeader{Data: make([]byte, MaxPayload+1)}
+	if _, err := big.AppendTo(nil); !errors.Is(err, ErrPayloadTooLong) {
+		t.Errorf("err = %v, want ErrPayloadTooLong", err)
+	}
+	if got := (StreamHeader{Data: []byte{1}}).String(); !strings.Contains(got, "1B") {
+		t.Errorf("String() = %q", got)
+	}
+}
+
+// TestDisplayCaps covers what a unit says about its display, which is what
+// tells a client whether it is driving a character panel or a bitmap screen.
+func TestDisplayCaps(t *testing.T) {
+	panel := DisplayCaps{Display: 0, Type: 1, Chars: 20, Lines: 4}
+
+	got := panel.AppendTo(nil)
+	if want := mustHex(t, "00 01 0014 0004 0000 0000 0000"); !bytes.Equal(got, want) {
+		t.Errorf("encoded\n got %x\nwant %x", got, want)
+	}
+	if len(got) != DisplayCapsSize {
+		t.Errorf("encoded %d bytes, want %d", len(got), DisplayCapsSize)
+	}
+
+	back, err := DecodeDisplayCaps(got)
+	if err != nil {
+		t.Fatalf("DecodeDisplayCaps: %v", err)
+	}
+	if back != panel {
+		t.Errorf("round trip %+v -> %+v", panel, back)
+	}
+	if !back.IsCharacter() {
+		t.Error("a display with no pixels is a character display")
+	}
+	if got := back.String(); !strings.Contains(got, "20x4 chars") {
+		t.Errorf("String() = %q", got)
+	}
+
+	screen := DisplayCaps{Display: 1, XPixels: 320, YPixels: 240, Format: ColourFormat16Bit}
+	if screen.IsCharacter() {
+		t.Error("a display with pixels is not a character display")
+	}
+	if got := screen.String(); !strings.Contains(got, "320x240 px") || !strings.Contains(got, "16-bit") {
+		t.Errorf("String() = %q", got)
+	}
+
+	if _, err := DecodeDisplayCaps(make([]byte, DisplayCapsSize-1)); !errors.Is(err, ErrShortBuffer) {
+		t.Errorf("err = %v, want ErrShortBuffer", err)
+	}
+}
+
+// TestColourFormats pins the bits-per-pixel values, which are the numbers
+// themselves rather than an enumeration, except the two-bit case.
+func TestColourFormats(t *testing.T) {
+	tests := map[int16]int16{
+		ColourFormat2Bit: 1, ColourFormat4Bit: 4, ColourFormat8Bit: 8,
+		ColourFormat15Bit: 15, ColourFormat16Bit: 16, ColourFormat24Bit: 24,
+	}
+	for got, want := range tests {
+		if got != want {
+			t.Errorf("colour format = %d, want %d", got, want)
+		}
+	}
+}
+
+func TestDrawBitmap(t *testing.T) {
+	in := DrawBitmap{Display: 1, Bitmap: []byte{0xAA, 0xBB, 0xCC}}
+
+	got := in.AppendTo(nil)
+	if want := mustHex(t, "01 00 aabbcc"); !bytes.Equal(got, want) {
+		t.Errorf("encoded %x, want %x", got, want)
+	}
+	// The second byte is the header's documented "must be zero" pad.
+	if got[1] != 0 {
+		t.Errorf("pad = %02X, want zero", got[1])
+	}
+
+	back, err := DecodeDrawBitmap(got)
+	if err != nil {
+		t.Fatalf("DecodeDrawBitmap: %v", err)
+	}
+	if back.Display != 1 || !bytes.Equal(back.Bitmap, in.Bitmap) {
+		t.Errorf("= %+v", back)
+	}
+
+	// A header with no bitmap is legal: it clears the display.
+	bare, err := DecodeDrawBitmap(mustHex(t, "0100"))
+	if err != nil {
+		t.Fatalf("DecodeDrawBitmap: %v", err)
+	}
+	if len(bare.Bitmap) != 0 {
+		t.Errorf("bitmap = %x, want none", bare.Bitmap)
+	}
+
+	if _, err := DecodeDrawBitmap([]byte{1}); !errors.Is(err, ErrShortBuffer) {
+		t.Errorf("err = %v, want ErrShortBuffer", err)
+	}
+	if got := in.String(); !strings.Contains(got, "3B") {
+		t.Errorf("String() = %q", got)
+	}
+}
+
+func TestDrawText(t *testing.T) {
+	in := DrawText{Display: 1, Mode: 2, Text: "OK"}
+
+	got, err := in.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	if want := mustHex(t, "01 02 4f4b00"); !bytes.Equal(got, want) {
+		t.Errorf("encoded %x, want %x", got, want)
+	}
+
+	back, err := DecodeDrawText(got)
+	if err != nil {
+		t.Fatalf("DecodeDrawText: %v", err)
+	}
+	if back != in {
+		t.Errorf("round trip %+v -> %+v", in, back)
+	}
+
+	bare, err := DecodeDrawText(mustHex(t, "0102"))
+	if err != nil {
+		t.Fatalf("DecodeDrawText: %v", err)
+	}
+	if bare.Text != "" {
+		t.Errorf("text = %q, want none", bare.Text)
+	}
+
+	if _, err := DecodeDrawText([]byte{1}); !errors.Is(err, ErrShortBuffer) {
+		t.Errorf("err = %v, want ErrShortBuffer", err)
+	}
+	long := DrawText{Text: strings.Repeat("x", MaxLongString)}
+	if _, err := long.AppendTo(nil); !errors.Is(err, ErrStringTooLong) {
+		t.Errorf("err = %v, want ErrStringTooLong", err)
+	}
+	if got := in.String(); !strings.Contains(got, `"OK"`) {
+		t.Errorf("String() = %q", got)
+	}
+}
+
+// TestSetGroup covers putting a unit into a control group, which is how one
+// write reaches several units at once.
+func TestSetGroup(t *testing.T) {
+	master := SetGroup{Group: 3, Master: true}
+
+	got := master.AppendTo(nil)
+	if want := mustHex(t, "0301"); !bytes.Equal(got, want) {
+		t.Errorf("encoded %x, want %x", got, want)
+	}
+
+	back, err := DecodeSetGroup(got)
+	if err != nil {
+		t.Fatalf("DecodeSetGroup: %v", err)
+	}
+	if back != master {
+		t.Errorf("round trip %+v -> %+v", master, back)
+	}
+
+	follower := SetGroup{Group: 3}
+	if got := follower.AppendTo(nil); !bytes.Equal(got, mustHex(t, "0300")) {
+		t.Errorf("encoded %x", got)
+	}
+	// Any non-zero byte means master, not only one.
+	odd, err := DecodeSetGroup(mustHex(t, "03ff"))
+	if err != nil {
+		t.Fatalf("DecodeSetGroup: %v", err)
+	}
+	if !odd.Master {
+		t.Error("a non-zero master byte must read as master")
+	}
+
+	if _, err := DecodeSetGroup([]byte{1}); !errors.Is(err, ErrShortBuffer) {
+		t.Errorf("err = %v, want ErrShortBuffer", err)
+	}
+	if got := master.String(); got != "group=3 master" {
+		t.Errorf("String() = %q", got)
+	}
+	if got := follower.String(); got != "group=3" {
+		t.Errorf("String() = %q", got)
+	}
+}
+
+func TestGroupParam(t *testing.T) {
+	in := GroupParam{Group: 7}
+
+	got := in.AppendTo(nil)
+	if want := mustHex(t, "0700"); !bytes.Equal(got, want) {
+		t.Errorf("encoded %x, want %x", got, want)
+	}
+	// The second byte is the header's "must be zero" alignment field.
+	if got[1] != 0 {
+		t.Errorf("pad = %02X, want zero", got[1])
+	}
+
+	back, err := DecodeGroupParam(got)
+	if err != nil {
+		t.Fatalf("DecodeGroupParam: %v", err)
+	}
+	if back != in {
+		t.Errorf("round trip %+v -> %+v", in, back)
+	}
+
+	if _, err := DecodeGroupParam([]byte{1}); !errors.Is(err, ErrShortBuffer) {
+		t.Errorf("err = %v, want ErrShortBuffer", err)
+	}
+	if got := in.String(); got != "group=7" {
+		t.Errorf("String() = %q", got)
+	}
+}
+
+// TestDownload covers the one structure whose meaning the vendor header does
+// not know either: its field is labelled "No idea - DRAGONS". It is carried
+// through unchanged rather than interpreted.
+func TestDownload(t *testing.T) {
+	in := Download{List: 0x0102}
+
+	got := in.AppendTo(nil)
+	if want := mustHex(t, "0102"); !bytes.Equal(got, want) {
+		t.Errorf("encoded %x, want %x", got, want)
+	}
+
+	back, err := DecodeDownload(got)
+	if err != nil {
+		t.Fatalf("DecodeDownload: %v", err)
+	}
+	if back != in {
+		t.Errorf("round trip %+v -> %+v", in, back)
+	}
+
+	if _, err := DecodeDownload([]byte{1}); !errors.Is(err, ErrShortBuffer) {
+		t.Errorf("err = %v, want ErrShortBuffer", err)
+	}
+	if got := in.String(); got != "list=258" {
+		t.Errorf("String() = %q", got)
+	}
+}

--- a/internal/snell-rollcall/codec/payload_time.go
+++ b/internal/snell-rollcall/codec/payload_time.go
@@ -1,0 +1,207 @@
+package codec
+
+import (
+	"encoding/binary"
+	"fmt"
+	"time"
+)
+
+// Wire sizes of the time structures.
+const (
+	TimeSize     = 14 // TIME_STR
+	TimecodeSize = 6  // TIMECODE_STR
+)
+
+// Time mode flags (rc3comm.h TimeModeFlags). They say which parts of the
+// structure a sender filled in, and a reader that ignores them will read
+// zeroes as a real date.
+const (
+	// TimeModeSystem means the time is absolute wall-clock time.
+	TimeModeSystem uint8 = 1
+	// TimeModeUptime means it is time since the unit powered on.
+	TimeModeUptime uint8 = 2
+	// TimeModeElapsed means the Elapsed field is meaningful.
+	TimeModeElapsed uint8 = 4
+	// TimeModeReal means the broken-down fields are meaningful.
+	TimeModeReal uint8 = 8
+)
+
+// Timecode flags (rc3comm.h TimeCodeFlags).
+const (
+	TimecodeEvenField uint8 = 1
+	Timecode30Hz      uint8 = 2
+)
+
+// SysTime is TIME_STR: a unit's idea of the time, in two forms at once.
+//
+// Elapsed is a single number and the broken-down fields are the same instant
+// spelled out. Which of them is meaningful is stated by Mode, not implied, so
+// a reader must check the flags: a unit with no real-time clock sends uptime
+// with the broken-down fields left at zero, and treating that as a date puts
+// 1900 in a log.
+//
+// Month is zero-based and weekday is zero-based from Sunday, both following C,
+// which is the classic off-by-one in this structure.
+type SysTime struct {
+	// Elapsed is the vendor's "MS-DOS format time", meaningful when
+	// TimeModeElapsed is set. In practice devices send seconds here.
+	Elapsed int32
+	Mode    uint8
+
+	Sec, Min, Hour uint8
+	Mday, Mon      uint8 // Mon is 0..11, following C
+	Year           uint8 // years since 1900, following C
+	Wday           uint8 // 0..6 from Sunday, following C
+	Yday           int16 // 0..365
+}
+
+// Has reports whether every flag in want is set.
+func (t SysTime) Has(want uint8) bool { return t.Mode&want == want }
+
+// AppendTo appends the 14-byte wire form.
+func (t SysTime) AppendTo(dst []byte) []byte {
+	var b [TimeSize]byte
+	binary.BigEndian.PutUint32(b[0:4], uint32(t.Elapsed))
+	b[4] = t.Mode
+	b[5] = t.Sec
+	b[6] = t.Min
+	b[7] = t.Hour
+	b[8] = t.Mday
+	b[9] = t.Mon
+	b[10] = t.Year
+	b[11] = t.Wday
+	binary.BigEndian.PutUint16(b[12:14], uint16(t.Yday))
+	return append(dst, b[:]...)
+}
+
+// DecodeSysTime reads a TIME_STR from the front of b.
+func DecodeSysTime(b []byte) (SysTime, error) {
+	if err := need(b, TimeSize, "SysTime", ""); err != nil {
+		return SysTime{}, err
+	}
+	return sysTimeAt(b), nil
+}
+
+// sysTimeAt reads a TIME_STR from a slice the caller has already sized.
+func sysTimeAt(b []byte) SysTime {
+	return SysTime{
+		Elapsed: int32(binary.BigEndian.Uint32(b[0:4])),
+		Mode:    b[4],
+		Sec:     b[5],
+		Min:     b[6],
+		Hour:    b[7],
+		Mday:    b[8],
+		Mon:     b[9],
+		Year:    b[10],
+		Wday:    b[11],
+		Yday:    int16(binary.BigEndian.Uint16(b[12:14])),
+	}
+}
+
+// Time converts the broken-down fields to a time.Time in UTC, and reports
+// whether they were meaningful.
+//
+// It returns false unless the real-time flag is set, because a unit without a
+// clock leaves these fields at zero and the alternative is silently reporting
+// the first of January 1900.
+func (t SysTime) Time() (time.Time, bool) {
+	if !t.Has(TimeModeReal) {
+		return time.Time{}, false
+	}
+	return time.Date(
+		1900+int(t.Year),
+		time.Month(t.Mon)+1, // the wire is zero-based, time.Month is not
+		int(t.Mday),
+		int(t.Hour), int(t.Min), int(t.Sec), 0,
+		time.UTC,
+	), true
+}
+
+// Uptime returns how long the unit has been running, and whether it said.
+func (t SysTime) Uptime() (time.Duration, bool) {
+	if !t.Has(TimeModeUptime | TimeModeElapsed) {
+		return 0, false
+	}
+	return time.Duration(t.Elapsed) * time.Second, true
+}
+
+// NewSysTime builds a TIME_STR for an absolute instant, filling in both forms
+// and flagging both as meaningful.
+func NewSysTime(at time.Time) SysTime {
+	at = at.UTC()
+	return SysTime{
+		Elapsed: int32(at.Unix()),
+		Mode:    TimeModeSystem | TimeModeReal | TimeModeElapsed,
+		Sec:     uint8(at.Second()),
+		Min:     uint8(at.Minute()),
+		Hour:    uint8(at.Hour()),
+		Mday:    uint8(at.Day()),
+		Mon:     uint8(at.Month() - 1),
+		Year:    uint8(at.Year() - 1900),
+		Wday:    uint8(at.Weekday()),
+		Yday:    int16(at.YearDay() - 1),
+	}
+}
+
+func (t SysTime) String() string {
+	if when, ok := t.Time(); ok {
+		return when.Format("2006-01-02 15:04:05")
+	}
+	if up, ok := t.Uptime(); ok {
+		return "up " + up.String()
+	}
+	return fmt.Sprintf("mode=%d elapsed=%d", t.Mode, t.Elapsed)
+}
+
+// Timecode is TIMECODE_STR: a decoded video timecode.
+type Timecode struct {
+	Flags   uint8
+	Frames  uint8
+	Seconds uint8
+	Minutes uint8
+	Hours   uint16
+}
+
+// EvenField reports whether the field is even.
+func (t Timecode) EvenField() bool { return t.Flags&TimecodeEvenField != 0 }
+
+// Is30Hz reports whether the frame rate is 30 Hz rather than 25.
+func (t Timecode) Is30Hz() bool { return t.Flags&Timecode30Hz != 0 }
+
+// FrameRate returns the frame rate the flags imply.
+func (t Timecode) FrameRate() int {
+	if t.Is30Hz() {
+		return 30
+	}
+	return 25
+}
+
+// AppendTo appends the 6-byte wire form.
+func (t Timecode) AppendTo(dst []byte) []byte {
+	var b [TimecodeSize]byte
+	b[0] = t.Flags
+	b[1] = t.Frames
+	b[2] = t.Seconds
+	b[3] = t.Minutes
+	binary.BigEndian.PutUint16(b[4:6], t.Hours)
+	return append(dst, b[:]...)
+}
+
+// DecodeTimecode reads a TIMECODE_STR from the front of b.
+func DecodeTimecode(b []byte) (Timecode, error) {
+	if err := need(b, TimecodeSize, "Timecode", ""); err != nil {
+		return Timecode{}, err
+	}
+	return Timecode{
+		Flags:   b[0],
+		Frames:  b[1],
+		Seconds: b[2],
+		Minutes: b[3],
+		Hours:   binary.BigEndian.Uint16(b[4:6]),
+	}, nil
+}
+
+func (t Timecode) String() string {
+	return fmt.Sprintf("%02d:%02d:%02d:%02d@%d",
+		t.Hours, t.Minutes, t.Seconds, t.Frames, t.FrameRate())
+}

--- a/internal/snell-rollcall/codec/payload_time_test.go
+++ b/internal/snell-rollcall/codec/payload_time_test.go
@@ -1,0 +1,229 @@
+package codec
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestSysTime_Layout pins TIME_STR. Its fields are laid out under
+// #pragma pack(2): a 32-bit elapsed time, then eight single bytes, then a
+// 16-bit day of year which lands on an even offset without padding.
+func TestSysTime_Layout(t *testing.T) {
+	in := SysTime{
+		Elapsed: 0x11223344,
+		Mode:    TimeModeSystem | TimeModeReal,
+		Sec:     59, Min: 58, Hour: 23,
+		Mday: 31, Mon: 11, Year: 126,
+		Wday: 3, Yday: 364,
+	}
+
+	got := in.AppendTo(nil)
+	want := mustHex(t, "11223344"+"09"+"3b"+"3a"+"17"+"1f"+"0b"+"7e"+"03"+"016c")
+	if !bytes.Equal(got, want) {
+		t.Errorf("encoded\n got %x\nwant %x", got, want)
+	}
+	if len(got) != TimeSize {
+		t.Fatalf("encoded %d bytes, want %d", len(got), TimeSize)
+	}
+	// The day of year sits at offset 12, immediately after the single bytes.
+	if !bytes.Equal(got[12:14], mustHex(t, "016c")) {
+		t.Errorf("day of year is not at offset 12: %x", got[12:14])
+	}
+
+	back, err := DecodeSysTime(got)
+	if err != nil {
+		t.Fatalf("DecodeSysTime: %v", err)
+	}
+	if back != in {
+		t.Errorf("round trip\n got %+v\nwant %+v", back, in)
+	}
+
+	if _, err := DecodeSysTime(make([]byte, TimeSize-1)); !errors.Is(err, ErrShortBuffer) {
+		t.Errorf("err = %v, want ErrShortBuffer", err)
+	}
+}
+
+// TestSysTime_ModeGatesTheFields pins the rule that stops a unit with no clock
+// being read as the first of January 1900. Which parts of the structure are
+// meaningful is stated by the mode flags, never implied by the values.
+func TestSysTime_ModeGatesTheFields(t *testing.T) {
+	// A unit with no real-time clock: uptime only, date fields at zero.
+	noClock := SysTime{Elapsed: 3600, Mode: TimeModeUptime | TimeModeElapsed}
+
+	if _, ok := noClock.Time(); ok {
+		t.Error("a unit without a clock must not report a date")
+	}
+	up, ok := noClock.Uptime()
+	if !ok || up != time.Hour {
+		t.Errorf("uptime = %s,%v want 1h,true", up, ok)
+	}
+
+	// A unit with a clock.
+	withClock := NewSysTime(time.Date(2026, 9, 7, 12, 30, 45, 0, time.UTC))
+	when, ok := withClock.Time()
+	if !ok {
+		t.Fatal("a unit with a clock must report a date")
+	}
+	if !when.Equal(time.Date(2026, 9, 7, 12, 30, 45, 0, time.UTC)) {
+		t.Errorf("= %s, want 2026-09-07 12:30:45", when)
+	}
+
+	// A unit reporting neither.
+	silent := SysTime{}
+	if _, ok := silent.Time(); ok {
+		t.Error("an empty structure must not report a date")
+	}
+	if _, ok := silent.Uptime(); ok {
+		t.Error("an empty structure must not report an uptime")
+	}
+}
+
+// TestSysTime_CConventions pins the two off-by-one traps. Month is zero-based
+// and the year counts from 1900, both following C, so a naive reader is a
+// month and a century out.
+func TestSysTime_CConventions(t *testing.T) {
+	at := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	st := NewSysTime(at)
+
+	if st.Mon != 0 {
+		t.Errorf("January encoded as %d, want the zero-based 0", st.Mon)
+	}
+	if st.Year != 126 {
+		t.Errorf("2026 encoded as %d, want 126 years since 1900", st.Year)
+	}
+	if st.Yday != 0 {
+		t.Errorf("the first of January is day %d, want the zero-based 0", st.Yday)
+	}
+	if st.Wday != uint8(time.Thursday) {
+		t.Errorf("weekday = %d, want %d", st.Wday, time.Thursday)
+	}
+
+	back, ok := st.Time()
+	if !ok {
+		t.Fatal("the time should be readable")
+	}
+	if !back.Equal(at) {
+		t.Errorf("round trip %s -> %s", at, back)
+	}
+
+	// December is the other end of the same trap.
+	dec := NewSysTime(time.Date(2026, time.December, 31, 0, 0, 0, 0, time.UTC))
+	if dec.Mon != 11 {
+		t.Errorf("December encoded as %d, want 11", dec.Mon)
+	}
+	if got, _ := dec.Time(); got.Month() != time.December {
+		t.Errorf("December decoded as %s", got.Month())
+	}
+}
+
+func TestSysTime_RoundTripsThroughWire(t *testing.T) {
+	for _, at := range []time.Time{
+		time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2000, 2, 29, 12, 0, 0, 0, time.UTC),
+		time.Date(2026, 9, 7, 3, 7, 55, 0, time.UTC),
+		time.Date(2155, 12, 31, 23, 59, 59, 0, time.UTC),
+	} {
+		st := NewSysTime(at)
+		back, err := DecodeSysTime(st.AppendTo(nil))
+		if err != nil {
+			t.Fatalf("%s: DecodeSysTime: %v", at, err)
+		}
+		got, ok := back.Time()
+		if !ok {
+			t.Fatalf("%s: the decoded time was not marked real", at)
+		}
+		if !got.Equal(at) {
+			t.Errorf("%s round trips to %s", at, got)
+		}
+	}
+}
+
+func TestSysTime_String(t *testing.T) {
+	withClock := NewSysTime(time.Date(2026, 9, 7, 12, 30, 45, 0, time.UTC))
+	if got := withClock.String(); got != "2026-09-07 12:30:45" {
+		t.Errorf("String() = %q", got)
+	}
+
+	uptime := SysTime{Elapsed: 90, Mode: TimeModeUptime | TimeModeElapsed}
+	if got := uptime.String(); got != "up 1m30s" {
+		t.Errorf("String() = %q", got)
+	}
+
+	bare := SysTime{Elapsed: 5}
+	if got := bare.String(); got != "mode=0 elapsed=5" {
+		t.Errorf("String() = %q", got)
+	}
+}
+
+func TestSysTime_Has(t *testing.T) {
+	st := SysTime{Mode: TimeModeSystem | TimeModeReal}
+
+	if !st.Has(TimeModeSystem) || !st.Has(TimeModeSystem|TimeModeReal) {
+		t.Error("Has must accept a subset")
+	}
+	if st.Has(TimeModeUptime) {
+		t.Error("Has must not find a clear flag")
+	}
+	if st.Has(TimeModeSystem | TimeModeUptime) {
+		t.Error("Has must require every requested flag, not any")
+	}
+
+	if TimeModeSystem != 1 || TimeModeUptime != 2 || TimeModeElapsed != 4 || TimeModeReal != 8 {
+		t.Error("the time mode flags do not match the header")
+	}
+}
+
+// TestTimecode pins TIMECODE_STR, whose hour field is the only 16-bit one
+// because a timecode may run past twenty-four hours.
+func TestTimecode(t *testing.T) {
+	in := Timecode{Flags: Timecode30Hz, Frames: 29, Seconds: 59, Minutes: 59, Hours: 100}
+
+	got := in.AppendTo(nil)
+	if want := mustHex(t, "02 1d 3b 3b 0064"); !bytes.Equal(got, want) {
+		t.Errorf("encoded %x, want %x", got, want)
+	}
+	if len(got) != TimecodeSize {
+		t.Errorf("encoded %d bytes, want %d", len(got), TimecodeSize)
+	}
+
+	back, err := DecodeTimecode(got)
+	if err != nil {
+		t.Fatalf("DecodeTimecode: %v", err)
+	}
+	if back != in {
+		t.Errorf("round trip %+v -> %+v", in, back)
+	}
+
+	if _, err := DecodeTimecode(make([]byte, TimecodeSize-1)); !errors.Is(err, ErrShortBuffer) {
+		t.Errorf("err = %v, want ErrShortBuffer", err)
+	}
+}
+
+// TestTimecode_Flags pins the frame rate, which is a flag rather than a field:
+// a timecode read at the wrong rate drifts against the video it names.
+func TestTimecode_Flags(t *testing.T) {
+	pal := Timecode{Frames: 24, Seconds: 1}
+	if pal.Is30Hz() || pal.FrameRate() != 25 {
+		t.Errorf("without the flag the rate is %d, want 25", pal.FrameRate())
+	}
+	if pal.EvenField() {
+		t.Error("the even-field flag was not set")
+	}
+
+	ntsc := Timecode{Flags: Timecode30Hz | TimecodeEvenField, Frames: 29}
+	if !ntsc.Is30Hz() || ntsc.FrameRate() != 30 {
+		t.Errorf("with the flag the rate is %d, want 30", ntsc.FrameRate())
+	}
+	if !ntsc.EvenField() {
+		t.Error("the even-field flag was lost")
+	}
+
+	if got := ntsc.String(); got != "00:00:00:29@30" {
+		t.Errorf("String() = %q", got)
+	}
+	if got := pal.String(); got != "00:00:01:24@25" {
+		t.Errorf("String() = %q", got)
+	}
+}

--- a/internal/snell-rollcall/codec/speccoverage_test.go
+++ b/internal/snell-rollcall/codec/speccoverage_test.go
@@ -1,0 +1,236 @@
+package codec
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The coverage document is a claim about this package. These tests make it a
+// checkable one: if a packet type loses its handling, or a structure is
+// removed, or the document stops naming something the code has, CI says so
+// instead of the document quietly going stale.
+
+const coverageDoc = "../docs/spec-coverage.md"
+
+// TestSpecCoverage_EveryPacketTypeIsNamed checks that all 72 types are known
+// to the table. An unknown type must be answered with InvCmd rather than Nack
+// (spec 9.15), and a type missing from the table would take that path by
+// accident rather than by decision.
+func TestSpecCoverage_EveryPacketTypeIsNamed(t *testing.T) {
+	for i := range PacketType(NumPacketTypes) {
+		if !i.Known() {
+			t.Errorf("packet type %d has no name", i)
+		}
+	}
+	if got := PacketType(NumPacketTypes); got.Known() {
+		t.Errorf("type %d is past the catalogue and must read as unknown", got)
+	}
+}
+
+// TestSpecCoverage_DocumentListsEveryType reads the coverage document and
+// requires a row for every packet type. It is the check that stops the
+// document drifting from the code.
+func TestSpecCoverage_DocumentListsEveryType(t *testing.T) {
+	doc := readCoverageDoc(t)
+
+	for i := range PacketType(NumPacketTypes) {
+		name := i.String()
+		if !strings.Contains(doc, "| "+name+" |") {
+			t.Errorf("packet type %d (%s) has no row in %s", i, name, coverageDoc)
+		}
+	}
+}
+
+// TestSpecCoverage_DocumentListsEveryStructure requires a row for each vendor
+// structure, naming the Go type that implements it.
+func TestSpecCoverage_DocumentListsEveryStructure(t *testing.T) {
+	doc := readCoverageDoc(t)
+
+	// Every structure the vendor headers declare, with the Go type that
+	// implements it. A structure added to the codec without a row here is a
+	// gap in the document; one listed here and removed from the code will
+	// fail to compile.
+	structures := map[string]string{
+		"MESSAGE_STR":         "Frame",
+		"FULLADDRESS_STR":     "Address",
+		"VERSION_STR":         "Version",
+		"ID_STR":              "ID",
+		"STATUS_STR":          "UnitStatus",
+		"DEVICEINFO_STR":      "DeviceInfo",
+		"CONNECT_STR":         "Connect",
+		"TERMSESS_STR":        "TermSess",
+		"CLEARSESS_STR":       "ClearSess",
+		"WAIT_STR":            "Wait",
+		"BLOCKHEADER_STR":     "BlockHeader",
+		"GETNEXT_STR":         "GetNext",
+		"FUNC_STR":            "Func",
+		"FUNCSTYLE_STR":       "FuncStyle",
+		"GETFSTAT_STR":        "GetFStat",
+		"FUNCSTATUS_STR":      "FuncStatus",
+		"SETMULTI_STR":        "SetMulti",
+		"DISP_STR":            "Disp",
+		"MENUREQ_STR":         "MenuReq",
+		"MENUSIZE_STR":        "MenuSize",
+		"MENUITEM_STR":        "MenuItem",
+		"GETVALUE_STR":        "GetValue",
+		"VALUE_STR":           "Value",
+		"FILE_STR":            "File",
+		"FILEINFOHDR_STR":     "FileInfo",
+		"MODULE_FILEINFO_STR": "DirEntry",
+		"TIME_STR":            "SysTime",
+		"TIMECODE_STR":        "Timecode",
+		"LOGPACKET_STR":       "LogPacket",
+		"STREAMMODE_STR":      "StreamMode",
+		"STREAMHDR_STR":       "StreamHeader",
+		"DISPLAYCAPS_STR":     "DisplayCaps",
+		"DRAWBITMAP_STR":      "DrawBitmap",
+		"DRAWTEXT_STR":        "DrawText",
+		"SETGROUP_STR":        "SetGroup",
+		"GROUPPARAM_STR":      "GroupParam",
+		"DOWNLOAD_STR":        "Download",
+	}
+
+	for vendor, goType := range structures {
+		if !strings.Contains(doc, vendor) {
+			t.Errorf("%s has no row in %s", vendor, coverageDoc)
+		}
+		if !strings.Contains(doc, "`"+goType+"`") {
+			t.Errorf("%s implements %s but is not named in %s", goType, vendor, coverageDoc)
+		}
+	}
+}
+
+// TestSpecCoverage_EveryStructureEncodesAndDecodes exercises one round trip of
+// every structure through its zero value. It is deliberately shallow: the
+// per-structure tests check the field layouts, and this one checks that none
+// of them has been left half-wired, with an encoder and no decoder or the
+// reverse.
+func TestSpecCoverage_EveryStructureEncodesAndDecodes(t *testing.T) {
+	type roundTrip struct {
+		name   string
+		encode func() ([]byte, error)
+		decode func([]byte) error
+	}
+
+	cases := []roundTrip{
+		{"Address", func() ([]byte, error) { return Address{}.AppendTo(nil), nil },
+			func(b []byte) error { _, err := DecodeAddress(b); return err }},
+		{"ID", func() ([]byte, error) { return ID{}.AppendTo(nil) },
+			func(b []byte) error { _, err := DecodeID(b); return err }},
+		{"UnitStatus", func() ([]byte, error) { return UnitStatus{}.AppendTo(nil), nil },
+			func(b []byte) error { _, err := DecodeUnitStatus(b); return err }},
+		{"DeviceInfo", func() ([]byte, error) { return DeviceInfo{}.AppendTo(nil) },
+			func(b []byte) error { _, err := DecodeDeviceInfo(b); return err }},
+		{"Connect", func() ([]byte, error) { return Connect{}.AppendTo(nil) },
+			func(b []byte) error { _, err := DecodeConnect(b); return err }},
+		{"TermSess", func() ([]byte, error) { return TermSess{}.AppendTo(nil) },
+			func(b []byte) error { _, err := DecodeTermSess(b); return err }},
+		{"ClearSess", func() ([]byte, error) { return ClearSess{}.AppendTo(nil), nil },
+			func(b []byte) error { _, err := DecodeClearSess(b); return err }},
+		{"Wait", func() ([]byte, error) { return Wait{}.AppendTo(nil) },
+			func(b []byte) error { _, err := DecodeWait(b); return err }},
+		{"BlockHeader", func() ([]byte, error) { return BlockHeader{}.AppendTo(nil), nil },
+			func(b []byte) error { _, err := DecodeBlockHeader(b); return err }},
+		{"GetNext", func() ([]byte, error) { return GetNext{}.AppendTo(nil), nil },
+			func(b []byte) error { _, err := DecodeGetNext(b); return err }},
+		{"Func", func() ([]byte, error) { return Func{}.AppendTo(nil) },
+			func(b []byte) error { _, err := DecodeFunc(b); return err }},
+		{"FuncStyle", func() ([]byte, error) { return FuncStyle{}.AppendTo(nil), nil },
+			func(b []byte) error { _, err := DecodeFuncStyle(b); return err }},
+		{"GetFStat", func() ([]byte, error) { return GetFStat{}.AppendTo(nil), nil },
+			func(b []byte) error { _, err := DecodeGetFStat(b); return err }},
+		{"FuncStatus", func() ([]byte, error) { return FuncStatus{}.AppendTo(nil) },
+			func(b []byte) error { _, err := DecodeFuncStatus(b); return err }},
+		{"Disp", func() ([]byte, error) { return Disp{}.AppendTo(nil) },
+			func(b []byte) error { _, err := DecodeDisp(b); return err }},
+		{"MenuReq", func() ([]byte, error) { return MenuReq{}.AppendTo(nil), nil },
+			func(b []byte) error { _, err := DecodeMenuReq(b); return err }},
+		{"MenuSize", func() ([]byte, error) { return MenuSize{}.AppendTo(nil), nil },
+			func(b []byte) error { _, err := DecodeMenuSize(b); return err }},
+		{"MenuItem", func() ([]byte, error) { return MenuItem{}.AppendTo(nil) },
+			func(b []byte) error { _, err := DecodeMenuItem(b); return err }},
+		{"GetValue", func() ([]byte, error) { return GetValue{}.AppendTo(nil), nil },
+			func(b []byte) error { _, err := DecodeGetValue(b); return err }},
+		{"Value", func() ([]byte, error) { return Value{}.AppendTo(nil) },
+			func(b []byte) error { _, err := DecodeValue(b); return err }},
+		{"File", func() ([]byte, error) { return File{}.AppendTo(nil), nil },
+			func(b []byte) error { _, err := DecodeFile(b); return err }},
+		{"FileInfo", func() ([]byte, error) { return FileInfo{}.AppendTo(nil), nil },
+			func(b []byte) error { _, err := DecodeFileInfo(b); return err }},
+		{"DirEntry", func() ([]byte, error) { return DirEntry{}.AppendTo(nil) },
+			func(b []byte) error { _, err := DecodeDirEntry(b); return err }},
+		{"SysTime", func() ([]byte, error) { return SysTime{}.AppendTo(nil), nil },
+			func(b []byte) error { _, err := DecodeSysTime(b); return err }},
+		{"Timecode", func() ([]byte, error) { return Timecode{}.AppendTo(nil), nil },
+			func(b []byte) error { _, err := DecodeTimecode(b); return err }},
+		{"LogPacket", func() ([]byte, error) { return LogPacket{}.AppendTo(nil) },
+			func(b []byte) error { _, err := DecodeLogPacket(b); return err }},
+		{"StreamMode", func() ([]byte, error) { return StreamMode{}.AppendTo(nil), nil },
+			func(b []byte) error { _, err := DecodeStreamMode(b); return err }},
+		{"StreamHeader", func() ([]byte, error) { return StreamHeader{}.AppendTo(nil) },
+			func(b []byte) error { _, err := DecodeStreamHeader(b); return err }},
+		{"DisplayCaps", func() ([]byte, error) { return DisplayCaps{}.AppendTo(nil), nil },
+			func(b []byte) error { _, err := DecodeDisplayCaps(b); return err }},
+		{"DrawBitmap", func() ([]byte, error) { return DrawBitmap{}.AppendTo(nil), nil },
+			func(b []byte) error { _, err := DecodeDrawBitmap(b); return err }},
+		{"DrawText", func() ([]byte, error) { return DrawText{}.AppendTo(nil) },
+			func(b []byte) error { _, err := DecodeDrawText(b); return err }},
+		{"SetGroup", func() ([]byte, error) { return SetGroup{}.AppendTo(nil), nil },
+			func(b []byte) error { _, err := DecodeSetGroup(b); return err }},
+		{"GroupParam", func() ([]byte, error) { return GroupParam{}.AppendTo(nil), nil },
+			func(b []byte) error { _, err := DecodeGroupParam(b); return err }},
+		{"Download", func() ([]byte, error) { return Download{}.AppendTo(nil), nil },
+			func(b []byte) error { _, err := DecodeDownload(b); return err }},
+	}
+
+	if len(cases) != 34 {
+		t.Fatalf("the round-trip list holds %d structures; keep it in step with the document", len(cases))
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := tc.encode()
+			if err != nil {
+				t.Fatalf("encode: %v", err)
+			}
+			if err := tc.decode(b); err != nil {
+				t.Fatalf("decode what we encoded: %v", err)
+			}
+		})
+	}
+}
+
+// TestSpecCoverage_GapsAreRecorded requires the document to keep naming the
+// two places the specification does not settle. Deleting the section would
+// make the coverage claim read as complete when it is not.
+func TestSpecCoverage_GapsAreRecorded(t *testing.T) {
+	doc := readCoverageDoc(t)
+
+	for _, want := range []string{
+		"ROUTEERROR_STR",   // referenced by the type table, never defined
+		"router sub-table", // offsets read from the document's ordering
+		"CENTRA_SIMULATED_ROUTER",
+	} {
+		if !strings.Contains(doc, want) {
+			t.Errorf("%s no longer records %q as an open question", coverageDoc, want)
+		}
+	}
+
+	// The route-error type is decoded as an opaque payload, which is what the
+	// document says. If a structure is ever written for it, this fails and
+	// the document has to be updated with it.
+	if RouteErrorSize != 0 {
+		t.Error("a structure now exists for ROUTEERROR_STR; update the coverage document")
+	}
+}
+
+func readCoverageDoc(t *testing.T) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.FromSlash(coverageDoc))
+	if err != nil {
+		t.Fatalf("read %s: %v", coverageDoc, err)
+	}
+	return string(b)
+}

--- a/internal/snell-rollcall/docs/spec-coverage.md
+++ b/internal/snell-rollcall/docs/spec-coverage.md
@@ -1,0 +1,261 @@
+# RollCall specification coverage
+
+What the Go codec implements, checked against the RollCall Technical
+Specification Revision 14, the 2014 long-string extension, the Full Control
+Command Set, and the vendor headers `rc3comm.h`, `RC3FILE.H`, `RC3LOG.H`,
+`RC3STRM.H` and `RC3TYPES.H`.
+
+This file answers one question: is the wire format covered, or only the part we
+happened to need? It is checked by `TestSpecCoverage` in the codec package,
+which fails if a packet type loses its handling or a structure disappears, so
+the table cannot drift away from the code without CI noticing.
+
+Last verified 2026-09-07 against `internal/snell-rollcall/codec` at 100%
+statement coverage.
+
+---
+
+## 1. Message types
+
+All 72 defined types are named, and every one carries the dispatch properties
+the vendor keeps per type: whether it may be addressed to the broadcast
+address, whether it may answer a request made outside a session, and whether it
+belongs to the 32-bit generation.
+
+"Payload" means a decoded structure exists. A type with no payload carries
+none on the wire, or carries a single scalar the caller reads directly.
+
+### Session and link (spec §4, §9)
+
+| # | Type | Payload | Status |
+| ---: | --- | --- | --- |
+| 0 | NACK | optional text | done |
+| 1 | ACK | optional text | done |
+| 2 | CALL | `Connect` | done |
+| 3 | TERM | `TermSess` | done |
+| 13 | RESET | none | done |
+| 14 | INVCMD | none | done |
+| 15 | BUSY | optional `ID` | done |
+| 23 | INVSESS | none | done |
+| 25 | WAIT | `Wait` | done |
+| 26 | CLEARSESS | `ClearSess` | done |
+| 27 | BKCHNREADY | one byte | done |
+| 28 | KEEPALIVE | none | done |
+| 38 | ROUTEERROR | opaque | **see §4** |
+| 39 | BLOCKHEADER | `BlockHeader` | done |
+| 35 | GETNEXTPKT | `GetNext` | done |
+| 44 | RAW | opaque by definition | done |
+| 45 | SETUSERLEVEL | one word | done |
+
+### Identity, map and ports (spec §7.6, §7.7)
+
+| # | Type | Payload | Status |
+| ---: | --- | --- | --- |
+| 4 | GETSTAT | none | done |
+| 5 | RETSTAT | `UnitStatus` | done |
+| 6 | GETID | none | done |
+| 7 | RETID | `ID` | done |
+| 19 | GETDEVLIST | none | done |
+| 20 | RETDEVINFO | `DeviceInfo` | done |
+| 21 | GETDEVINFO | none | done |
+| 29 | GETLOCDEVMAP | none | done |
+| 33 | IAM | `DeviceInfo` | done |
+| 50 | GETSRVBYNAME | name string | done |
+
+### Menu service, 16-bit (spec §7.2)
+
+| # | Type | Payload | Status |
+| ---: | --- | --- | --- |
+| 8 | GETFUNC | base index | done |
+| 9 | RETFUNC | `Func` | done |
+| 18 | FUNCLISTCHG | none | done |
+| 30 | FUNCSTYLECHG | `FuncStyle` | done |
+
+### Control service, 16-bit (spec §7.1)
+
+| # | Type | Payload | Status |
+| ---: | --- | --- | --- |
+| 11 | GETFSTAT | `GetFStat` | done |
+| 12 | RETFSTAT | `FuncStatus` | done |
+| 16 | SETPARAM | `FuncStatus` | done |
+| 36 | REPFCHG | command number | done |
+| 37 | STOPREPFCHG | command number | done |
+| 58 | SETMULTI | `[]SetMulti` | done |
+
+### 32-bit generation (2014 extension)
+
+| # | Type | Payload | Status |
+| ---: | --- | --- | --- |
+| 65 | GETMENUCOUNT | `MenuReq` | done |
+| 66 | RETMENUCOUNT | `MenuSize` | done |
+| 67 | GETMENUITEM | `MenuReq` | done |
+| 68 | RETMENUITEM | `MenuItem` | done |
+| 69 | GETVALUE | `GetValue` | done |
+| 70 | SETVALUE | `Value` | done |
+| 71 | RETVALUE | `Value` | done |
+
+### Display service (spec §7.3)
+
+| # | Type | Payload | Status |
+| ---: | --- | --- | --- |
+| 10 | DISPDATA | `Disp` | done |
+| 54 | GETDISPDATA | line number | done |
+| 60 | GETDISPCAPS | none | done |
+| 61 | RETDISPCAPS | `DisplayCaps` | done |
+| 62 | DRAWBITMAP | `DrawBitmap` | done |
+| 63 | DRAWTEXT | `DrawText` | done |
+
+### File service (spec §7.4, `RC3FILE.H`)
+
+| # | Type | Payload | Status |
+| ---: | --- | --- | --- |
+| 42 | FILEDIR | `File` + path | done |
+| 43 | RETFILEDIR | `DirEntry` | done |
+| 46 | FILEDELETE | `File` + path | done |
+| 48 | FILERENAME | `File` + two paths | done |
+| 51 | FILEOPEN | `File` + path | done |
+| 52 | RETFILEOPEN | `File` | done |
+| 53 | FILECLOSE | `File` | done |
+| 55 | FILEREAD | `File` | done |
+| 56 | RETFILEREAD | `File` + data | done |
+| 57 | FILEWRITE | `File` + data | done |
+| 59 | FILERET | `File` | done |
+| 64 | MAKEDIRECTORY | `File` + path | done |
+
+### Logging service (spec §7.8, `RC3LOG.H`)
+
+| # | Type | Payload | Status |
+| ---: | --- | --- | --- |
+| 22 | LOGREQ | format word | done |
+| 49 | LOGDATA | `LogPacket` | done |
+
+### Stream service (`RC3STRM.H`)
+
+| # | Type | Payload | Status |
+| ---: | --- | --- | --- |
+| 40 | STREAMMODE | `StreamMode` | done |
+| 41 | STREAMDATA | `StreamHeader` | done |
+
+### Time service
+
+| # | Type | Payload | Status |
+| ---: | --- | --- | --- |
+| 17 | TIME | `SysTime` | done |
+| 24 | REALTIME | `Timecode` | done |
+| 47 | GETTIME | none | done |
+
+### Group control (spec §7.1.3)
+
+| # | Type | Payload | Status |
+| ---: | --- | --- | --- |
+| 31 | SETGROUP | `SetGroup` | done |
+| 32 | STOPGROUP | none | done |
+| 34 | SETGRPFUNC | `GroupParam` + `FuncStatus` | done |
+
+---
+
+## 2. Structures
+
+Every structure declared in the vendor headers, with its wire size.
+
+| Structure | Bytes | Go type |
+| --- | ---: | --- |
+| `MESSAGE_STR` + `ROLLHEADER_STR` | 16 | `Frame` |
+| `FULLADDRESS_STR` | 6 | `Address` |
+| `VERSION_STR` | 4 | `Version` |
+| `ID_STR` | 28 | `ID` |
+| `STATUS_STR` | 4 | `UnitStatus` |
+| `DEVICEINFO_STR` | 40 | `DeviceInfo` |
+| `CONNECT_STR` | 44 | `Connect` |
+| `TERMSESS_STR` | 22 | `TermSess` |
+| `CLEARSESS_STR` | 4 | `ClearSess` |
+| `WAIT_STR` | 4 + text | `Wait` |
+| `BLOCKHEADER_STR` | 8 | `BlockHeader` |
+| `GETNEXT_STR` | 4 | `GetNext` |
+| `FUNC_STR` | 58 | `Func` |
+| `FUNCSTYLE_STR` | 6 | `FuncStyle` |
+| `GETFSTAT_STR` | 2 | `GetFStat` |
+| `FUNCSTATUS_STR` | 8 + tail | `FuncStatus` |
+| `SETMULTI_STR` | 4 each | `SetMulti` |
+| `DISP_STR` | 22 | `Disp` |
+| `MENUREQ_STR` | 4 | `MenuReq` |
+| `MENUSIZE_STR` | 8 | `MenuSize` |
+| `MENUITEM_STR` | 22 + 2 strings | `MenuItem` |
+| `GETVALUE_STR` | 4 | `GetValue` |
+| `VALUE_STR` | 12 + tail | `Value` |
+| `FILE_STR` | 10 | `File` |
+| `FILEINFOHDR_STR` | 10 | `FileInfo` |
+| `MODULE_FILEINFO_STR` | 24 | `DirEntry` |
+| `TIME_STR` | 14 | `SysTime` |
+| `TIMECODE_STR` | 6 | `Timecode` |
+| `LOGPACKET_STR` | 38 + text | `LogPacket` |
+| `STREAMMODE_STR` | 4 | `StreamMode` |
+| `STREAMHDR_STR` | 8 + data | `StreamHeader` |
+| `DISPLAYCAPS_STR` | 12 | `DisplayCaps` |
+| `DRAWBITMAP_STR` | 2 + bitmap | `DrawBitmap` |
+| `DRAWTEXT_STR` | 2 + text | `DrawText` |
+| `SETGROUP_STR` | 2 | `SetGroup` |
+| `GROUPPARAM_STR` | 2 | `GroupParam` |
+| `DOWNLOAD_STR` | 2 | `Download` |
+
+Every structure the vendor headers declare now has a Go equivalent.
+
+---
+
+## 3. Flag and value tables
+
+| Table | Header | Go |
+| --- | --- | --- |
+| `ServiceFlags` | `rc3comm.h` | `Service` |
+| `UserLevels` | `rc3comm.h` | `UserLevel` |
+| `StatusFlags` | `rc3comm.h` | `Status` |
+| `FuncModes` | `rc3comm.h` | `Mode` |
+| `StyleFlags` | `rc3comm.h` | `Style` |
+| `TermTypes` | `rc3comm.h` | `TermCode` |
+| `BCStateTypes` | `rc3comm.h` | back-channel constants |
+| `TimeModeFlags` | `rc3comm.h` | time mode constants |
+| `TimeCodeFlags` | `rc3comm.h` | timecode constants |
+| `AttributeFlags` | `RC3FILE.H` | attribute constants |
+| `FileOpenFlags` | `RC3FILE.H` | open constants |
+| `ErrorValues` | `RC3FILE.H` | file error constants |
+| `StreamModeFlags` | `RC3STRM.H` | `StreamBinary` |
+| colour formats | `rc3comm.h` | colour format constants |
+| `UnitIDs` | `rc3id.h` | 770-entry generated table |
+| routing interface | Full Control Command Set | `codec/router` |
+| Data Transfer Params | Full Control Command Set | `codec/dtp` |
+
+---
+
+## 4. Known gaps
+
+Two, both recorded rather than guessed at.
+
+**`ROUTEERROR_STR` is never defined.** Packet type 38 refers to it in
+`rc3comm.h`, and no shipped header declares it. Nothing in the vendor sources
+or the specification gives its layout. The type is decoded as an opaque payload
+and the frame is delivered intact, so a caller can inspect it; inventing a
+structure for it would be a guess presented as fact.
+
+**The router sub-table offsets are inferred.** The Full Control Command Set
+numbers only its root table, stating that `CMD_INTERFACE_VERSION` is command
+100 and the rest follow. The per-matrix, per-level, per-source and
+per-destination tables are described as "defined in a similar fashion" with
+their commands listed in order but never numbered, so the offsets are read from
+that ordering.
+
+This has not been checked against a router controller. The audit oracle answers
+NACK to command 100 and so exposes no routing interface at all. Closing it
+needs either a real router controller, or the simulator reconfigured with
+`CENTRA_SIMULATED_ROUTER`, and belongs to the integration unit.
+
+---
+
+## 5. Out of scope, deliberately
+
+| Not implemented | Why |
+| --- | --- |
+| RollNet, ArcNet, serial, I2C transports | The connector is TCP only, per the epic's scope. The wire structures above are transport-independent and would carry over unchanged. |
+| `SV_NET` bridging | We are an endpoint, never a bridge. The addressing rules for bridging are implemented and tested, so a frame that crosses one is understood; we do not forward. |
+| `SV_EXEC` beyond `DOWNLOAD_STR` | The executive service has no documented protocol beyond the one structure, which is itself labelled "No idea - DRAGONS" in the vendor header. |
+| `SV_THUMBNAIL`, `SV_LOC3` | No specification and no observed traffic. The service bits are named so a peer advertising them is reported accurately. |
+| `SV_FASTMENU` | The bit is named. The specification says nothing about the mechanism beyond "file-based fast menu upload", and the file service it would use is implemented. |


### PR DESCRIPTION
Closes #1020. Part of #1009. Inserted before the consumer, stacked on #1019.

## Why this exists

You asked to make sure the whole specification is supported. I checked the
codec against the vendor headers before starting the consumer, and it was not:
**fifteen wire structures were unimplemented**. Building consumer and producer
verbs on that would have produced a connector that looked complete and quietly
could not speak half the protocol.

## What was missing

| Service | Structures |
| --- | --- |
| File | `FILE_STR`, `FILEINFOHDR_STR`, `MODULE_FILEINFO_STR` |
| Time | `TIME_STR`, `TIMECODE_STR` |
| Logging | `LOGPACKET_STR` |
| Stream | `STREAMMODE_STR`, `STREAMHDR_STR` |
| Display | `DISPLAYCAPS_STR`, `DRAWBITMAP_STR`, `DRAWTEXT_STR` |
| Group | `SETGROUP_STR`, `GROUPPARAM_STR` |
| Exec | `DOWNLOAD_STR` |

All fifteen are now implemented, with the flag sets that go with them: file
attributes, open flags, errno values, seek origins, time and timecode modes,
stream modes, and the display colour formats.

## The file service is the one that unblocks real work

Two things from the audit depend on it and neither could be built without it.

The Control Panel **will not render a producer** without `TEMPLATE.ZIP` served
over `SV_FILE`. That was established against the live Control Panel 4.12.48;
the menu service alone is not enough.

And every router source and destination name is fetched from a file, named by
a `{filename, crc}` pair. The layouts and the checksum landed in #1017. This is
the transport for them.

## Three details worth calling out

**`MODULE_FILEINFO_STR` is 24 bytes, not 23.** Its content is a 10-byte header
plus a 13-byte name, but under `#pragma pack(2)` the structure is padded to an
even size and senders use `sizeof`. Same shape as the pad already documented on
`GETNEXT_STR`: encode 24, accept either.

**`TIME_STR` follows C.** Month is zero-based and the year counts from 1900. A
reader that misses this is a month and a century out, and the values look
plausible either way.

**Which parts of `TIME_STR` are meaningful is stated, not implied.** A unit
with no real-time clock sends uptime and leaves the date fields at zero.
Reading those as a date puts 1 January 1900 in an operator's log, so `Time()`
returns false unless the real-time flag is set.

## The coverage question now has a checkable answer

New: `internal/snell-rollcall/docs/spec-coverage.md`. Every packet type and
every structure against its implementation, the flag tables, the known gaps,
and what is deliberately out of scope with the reason.

It is **verified by tests rather than asserted**. `TestSpecCoverage` requires a
row for every one of the 72 packet types, a row naming the Go type for every
vendor structure, and a round trip through all 34 encoders and decoders. The
document cannot drift from the code without CI saying so.

## Two gaps, recorded rather than guessed

**`ROUTEERROR_STR` has no definition.** Packet type 38 refers to it in
`rc3comm.h` and no shipped header declares it. Type 38 is carried as an opaque
payload with the frame delivered intact, so a caller can inspect it. Inventing
a structure would be a guess presented as fact.

**The router sub-table offsets are inferred.** The Full Control document
numbers only its root table and describes the rest as "defined in a similar
fashion", so the offsets are read from that ordering. Unvalidated, because the
audit oracle answers NACK to command 100 and exposes no routing interface. A
test fails if the document stops saying so.

## Verification

```
ok  dhs/internal/snell-rollcall/codec          coverage: 100.0% of statements
ok  dhs/internal/snell-rollcall/codec/dtp      coverage: 100.0% of statements
ok  dhs/internal/snell-rollcall/codec/router   coverage: 100.0% of statements
ok  dhs/internal/snell-rollcall/session        coverage: 100.0% of statements
```

186 tests in the codec package. Every structure the vendor headers declare now
has a Go equivalent. Still stdlib-only with no `dhs/*` import, and building for
five OS/arch pairs with cgo disabled.

## Next

Unit 5, the consumer, on a codec that now covers the whole wire format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
